### PR TITLE
feat(prolog): add bound-root effective-distance fast path

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -199,7 +199,7 @@ Tables:
 | `generate_pipeline.py` | Generate self-contained pipeline per target |
 | `benchmark_common.py` | Shared build/run utilities for cross-target benchmark runners |
 | `compute_effective_distance.py` | Post-processing aggregation (validation tool) |
-| `benchmark_effective_distance.py` | Rebuild and time effective distance across the C# query engine, accumulated Prolog, optional direct article/root Prolog, and C#/Rust/Go DFS binaries |
+| `benchmark_effective_distance.py` | Rebuild and time effective distance across the C# query engine, accumulated Prolog, optional direct article/root and root-bound Prolog variants, and C#/Rust/Go DFS binaries |
 | `benchmark_shortest_path_cross_target.py` | Compare shortest-path-to-root across C# query, seeded Prolog `min`, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_depth_cross_target.py` | Compare synthetic dependency reach-count across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_longest_depth_cross_target.py` | Compare true DAG longest dependency-chain depth across C# query, C# DFS, Rust DFS, and Go DFS |
@@ -210,7 +210,7 @@ Tables:
 | `generate_prolog_shortest_path_benchmark.pl` | Generate standalone SWI-Prolog shortest-path benchmark scripts with `branch_pruning(auto|false)` |
 | `benchmark_prolog_branch_pruning.py` | Compare handwritten Prolog shortest-path source against generated pruned and unpruned Prolog scripts |
 | `generate_prolog_effective_distance_benchmark.pl` | Generate standalone SWI-Prolog effective-distance scripts for seeded closure reuse, generated accumulation helpers, optional direct article/root helpers, and optional branch pruning |
-| `benchmark_prolog_effective_distance.py` | Compare seeded, pruned, accumulated, and optional direct article/root Prolog effective-distance scripts and report phase/work metrics |
+| `benchmark_prolog_effective_distance.py` | Compare seeded, pruned, accumulated, and optional direct article/root and root-bound Prolog effective-distance scripts and report phase/work metrics |
 | `generate_prolog_category_influence_benchmark.pl` | Generate standalone SWI-Prolog category-influence scripts using the PPV `category_ancestor/4` closure with optional seeded accumulation helpers |
 | `benchmark_prolog_category_influence.py` | Compare seeded and accumulated Prolog category-influence scripts and report phase/work metrics |
 | `generate_prolog_shortest_path_seeded_benchmark.pl` | Generate standalone SWI-Prolog shortest-path scripts for seeded `all` vs mode-directed `min` closure, loading `facts.pl` at runtime |
@@ -416,6 +416,16 @@ Current interpretation:
   - `300`: `0.457s` vs `0.393s`
   - `1k`: `0.493s` vs `0.274s`
   - `5k`: `6.275s` vs `0.973s`
+- the new `root_accumulated` profiling path uses the generated
+  `category_ancestor$effective_distance_article_sum_by_root/3` and
+  `category_ancestor$effective_distance_article_sum_pairs_by_root/2`
+  helpers to benchmark the bound-root path directly
+- that root-bound path is competitive at smaller scales but not the best
+  default retained-state plan overall:
+  - `300`: `0.360s` vs accumulated `0.354s`
+  - `1k`: `0.236s` vs accumulated `0.288s`
+  - `5k`: `0.934s` vs accumulated `0.797s`
+  - `10k`: `2.629s` vs accumulated `1.943s`
 - pre-aggregating per-seed weight sums materially reduces retained state:
   - `1k`: tuple count `10976 -> 48`
   - `5k`: tuple count `41132 -> 151`

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """
 Benchmark the effective-distance workload for the C# query engine, seeded
-Prolog, optional direct article/root Prolog, and the compiled DFS pipelines.
+Prolog, optional direct article/root and bound-root Prolog variants, and
+the compiled DFS pipelines.
 
 Default targets:
   - csharp-query  : current C# query runtime using PathAwareTransitiveClosureNode
@@ -73,7 +74,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--targets",
         default="csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated",
-        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded,prolog-pruned,prolog-accumulated,prolog-article-accumulated",
+        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded,prolog-pruned,prolog-accumulated,prolog-article-accumulated,prolog-root-accumulated",
     )
     parser.add_argument(
         "--repetitions",
@@ -167,6 +168,7 @@ def print_summary(results: list[RunResult]) -> None:
         prolog_pruned = find_result(entries, "prolog-pruned")
         prolog_accumulated = find_result(entries, "prolog-accumulated")
         prolog_article_accumulated = find_result(entries, "prolog-article-accumulated")
+        prolog_root_accumulated = find_result(entries, "prolog-root-accumulated")
         dfs_like = [item for item in entries if item.target in {"csharp-dfs", "rust-dfs", "go-dfs"}]
 
         if len(dfs_like) > 1:
@@ -176,17 +178,20 @@ def print_summary(results: list[RunResult]) -> None:
         print_pair_match_status(scale, "query_vs_prolog_pruned", qe, prolog_pruned)
         print_pair_match_status(scale, "query_vs_prolog_accumulated", qe, prolog_accumulated)
         print_pair_match_status(scale, "query_vs_prolog_article_accumulated", qe, prolog_article_accumulated)
+        print_pair_match_status(scale, "query_vs_prolog_root_accumulated", qe, prolog_root_accumulated)
         print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
         print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
         print_speedup(scale, "speedup_vs_prolog_seeded", prolog_seeded, qe)
         print_speedup(scale, "speedup_vs_prolog_pruned", prolog_pruned, qe)
         print_speedup(scale, "speedup_vs_prolog_accumulated", prolog_accumulated, qe)
         print_speedup(scale, "speedup_vs_prolog_article_accumulated", prolog_article_accumulated, qe)
+        print_speedup(scale, "speedup_vs_prolog_root_accumulated", prolog_root_accumulated, qe)
         print_phase_metrics(scale, "csharp-query-metrics", qe)
         print_phase_metrics(scale, "prolog-seeded-metrics", prolog_seeded)
         print_phase_metrics(scale, "prolog-pruned-metrics", prolog_pruned)
         print_phase_metrics(scale, "prolog-accumulated-metrics", prolog_accumulated)
         print_phase_metrics(scale, "prolog-article-accumulated-metrics", prolog_article_accumulated)
+        print_phase_metrics(scale, "prolog-root-accumulated-metrics", prolog_root_accumulated)
 
 
 def scale_sort_key(scale: str) -> tuple[int, str]:
@@ -235,6 +240,8 @@ def main() -> int:
                 continue
             elif target == "prolog-article-accumulated":
                 continue
+            elif target == "prolog-root-accumulated":
+                continue
             else:
                 raise ValueError(f"unsupported target: {target}")
 
@@ -249,6 +256,8 @@ def main() -> int:
                     command = build_prolog_effective_distance(temp_root, scale, "accumulated")
                 elif target == "prolog-article-accumulated":
                     command = build_prolog_effective_distance(temp_root, scale, "article_accumulated")
+                elif target == "prolog-root-accumulated":
+                    command = build_prolog_effective_distance(temp_root, scale, "root_accumulated")
                 else:
                     command = commands[target]
                 results.append(benchmark_target(command, scale, args.repetitions, target))

--- a/examples/benchmark/benchmark_prolog_effective_distance.py
+++ b/examples/benchmark/benchmark_prolog_effective_distance.py
@@ -8,6 +8,8 @@ Targets:
   - prolog-accumulated : generated Prolog using seeded pre-aggregated weight sums
   - prolog-article-accumulated : generated Prolog using the experimental
     direct article/root weight-sum helper
+  - prolog-root-accumulated : generated Prolog using the bound-root
+    profiling/fast-path helper
 """
 
 from __future__ import annotations
@@ -60,7 +62,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--targets",
         default="prolog-seeded,prolog-pruned,prolog-accumulated",
-        help="Comma-separated targets: prolog-seeded,prolog-pruned,prolog-accumulated,prolog-article-accumulated",
+        help="Comma-separated targets: prolog-seeded,prolog-pruned,prolog-accumulated,prolog-article-accumulated,prolog-root-accumulated",
     )
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--keep-temp", action="store_true")
@@ -71,7 +73,7 @@ def available_targets(requested: list[str]) -> list[str]:
     if shutil.which("swipl") is None:
         print("skip prolog effective-distance benchmark: swipl not found", file=sys.stderr)
         return []
-    supported = {"prolog-seeded", "prolog-pruned", "prolog-accumulated", "prolog-article-accumulated"}
+    supported = {"prolog-seeded", "prolog-pruned", "prolog-accumulated", "prolog-article-accumulated", "prolog-root-accumulated"}
     targets: list[str] = []
     for target in requested:
         if target not in supported:
@@ -128,18 +130,22 @@ def print_summary(results: list[RunResult]) -> None:
         pruned = find_result(entries, "prolog-pruned")
         accumulated = find_result(entries, "prolog-accumulated")
         article_accumulated = find_result(entries, "prolog-article-accumulated")
+        root_accumulated = find_result(entries, "prolog-root-accumulated")
         print_pair_match_status(scale, "seeded_vs_pruned", seeded, pruned)
         print_pair_match_status(scale, "seeded_vs_accumulated", seeded, accumulated)
         print_pair_match_status(scale, "pruned_vs_accumulated", pruned, accumulated)
         print_pair_match_status(scale, "seeded_vs_article_accumulated", seeded, article_accumulated)
+        print_pair_match_status(scale, "seeded_vs_root_accumulated", seeded, root_accumulated)
         print_speedup(scale, "speedup_pruned_vs_seeded", seeded, pruned)
         print_speedup(scale, "speedup_accumulated_vs_seeded", seeded, accumulated)
         print_speedup(scale, "speedup_accumulated_vs_pruned", pruned, accumulated)
         print_speedup(scale, "speedup_article_accumulated_vs_seeded", seeded, article_accumulated)
+        print_speedup(scale, "speedup_root_accumulated_vs_seeded", seeded, root_accumulated)
         print_phase_metrics(scale, "seeded_metrics", seeded)
         print_phase_metrics(scale, "pruned_metrics", pruned)
         print_phase_metrics(scale, "accumulated_metrics", accumulated)
         print_phase_metrics(scale, "article_accumulated_metrics", article_accumulated)
+        print_phase_metrics(scale, "root_accumulated_metrics", root_accumulated)
 
 
 def main() -> int:
@@ -177,6 +183,10 @@ def main() -> int:
                 elif target == "prolog-article-accumulated":
                     commands[target] = build_generated_script(
                         temp_root, scale, "article_accumulated", "effective_distance_article_accumulated.pl"
+                    )
+                elif target == "prolog-root-accumulated":
+                    commands[target] = build_generated_script(
+                        temp_root, scale, "root_accumulated", "effective_distance_root_accumulated.pl"
                     )
                 else:
                     raise ValueError(f"unsupported target: {target}")

--- a/examples/benchmark/generate_prolog_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_prolog_effective_distance_benchmark.pl
@@ -12,7 +12,7 @@ main :-
     (   Argv = [FactsPath, OutputPath, VariantAtom]
     ->  true
     ;   format(user_error,
-            'Usage: swipl -q -s generate_prolog_effective_distance_benchmark.pl -- <facts.pl> <output-script> <seeded|pruned|accumulated|article_accumulated>~n',
+            'Usage: swipl -q -s generate_prolog_effective_distance_benchmark.pl -- <facts.pl> <output-script> <seeded|pruned|accumulated|article_accumulated|root_accumulated>~n',
             []),
         halt(1)
     ),
@@ -62,9 +62,17 @@ parse_variant('article_accumulated', article_accumulated, [
         seeded_accumulation(auto)
     ]) :-
     !.
+parse_variant('root_accumulated', root_accumulated, [
+        dialect(swi),
+        entry_point(run_benchmark),
+        branch_pruning(false),
+        min_closure(false),
+        seeded_accumulation(auto)
+    ]) :-
+    !.
 parse_variant(Atom, _, _) :-
     format(user_error,
-        'Unsupported effective-distance benchmark variant: ~w (expected seeded, pruned, accumulated, or article_accumulated)~n',
+        'Unsupported effective-distance benchmark variant: ~w (expected seeded, pruned, accumulated, article_accumulated, or root_accumulated)~n',
         [Atom]),
     halt(1).
 
@@ -74,6 +82,7 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
     benchmark_results_line(Variant, ResultsLine),
     benchmark_weight_sum_query_line(Variant, WeightSumQueryLine),
     benchmark_article_weight_sum_query_line(Variant, ArticleWeightSumQueryLine),
+    benchmark_article_weight_sum_by_root_query_line(Variant, ArticleWeightSumByRootQueryLine),
     benchmark_mode_line(Variant, ModeLine),
     Lines = [
         ':- use_module(library(aggregate)).',
@@ -140,6 +149,17 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '    ),',
         '    aggregate_all(count, bench_article_weight_sum(_, _, _), TupleCount).',
         '',
+        'build_root_article_weight_sum_index(Root, SeedCount, TupleCount) :-',
+        '    clear_seed_indexes,',
+        '    collect_seed_categories(Seeds),',
+        '    length(Seeds, SeedCount),',
+        '    article_weight_sum_by_root_query(Root, ArticlePairs),',
+        '    forall(',
+        '        member(Article-WeightSum, ArticlePairs),',
+        '        assertz(bench_article_weight_sum(Article, Root, WeightSum))',
+        '    ),',
+        '    aggregate_all(count, bench_article_weight_sum(_, _, _), TupleCount).',
+        '',
         'seeded_article_root_hops(Article, Root, 1) :-',
         '    article_category(Article, Root).',
         'seeded_article_root_hops(Article, Root, Hops) :-',
@@ -160,6 +180,15 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '',
         'article_weight_sum_query(Article, Root, WeightSum) :-',
         ArticleWeightSumQueryLine,
+        '',
+        'article_weight_sum_by_root_query(Root, ArticlePairs) :-',
+        ArticleWeightSumByRootQueryLine,
+        '',
+        'root_accumulated_prepare(Root, SeedCount, TupleCount, ArticlePairs) :-',
+        '    collect_seed_categories(Seeds),',
+        '    length(Seeds, SeedCount),',
+        '    article_weight_sum_by_root_query(Root, ArticlePairs),',
+        '    length(ArticlePairs, TupleCount).',
         '',
         'compute_effective_distance_results_from_hops(Root, Results) :-',
         '    collect_articles(Articles),',
@@ -199,6 +228,17 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '    InvN is -1 / N,',
         '    findall(Deff-Article,',
         '        (   bench_article_weight_sum(Article, Root, WeightSum),',
+        '            WeightSum > 0,',
+        '            Deff is WeightSum ** InvN',
+        '        ),',
+        '        Pairs),',
+        '    sort(Pairs, Results).',
+        '',
+        'compute_effective_distance_results_from_root_pairs(ArticlePairs, Results) :-',
+        '    dimension_n(N),',
+        '    InvN is -1 / N,',
+        '    findall(Deff-Article,',
+        '        (   member(Article-WeightSum, ArticlePairs),',
         '            WeightSum > 0,',
         '            Deff is WeightSum ** InvN',
         '        ),',
@@ -246,23 +286,35 @@ benchmark_index_build_line(seeded, '    build_seed_hops_index(Root, SeedCount, T
 benchmark_index_build_line(pruned, '    build_seed_hops_index(Root, SeedCount, TupleCount),').
 benchmark_index_build_line(accumulated, '    build_seed_weight_sum_index(Root, SeedCount, TupleCount),').
 benchmark_index_build_line(article_accumulated, '    build_article_weight_sum_index(Root, SeedCount, TupleCount),').
+benchmark_index_build_line(root_accumulated, '    root_accumulated_prepare(Root, SeedCount, TupleCount, RootArticlePairs),').
 
 benchmark_results_line(seeded, '    compute_effective_distance_results_from_hops(Root, Results),').
 benchmark_results_line(pruned, '    compute_effective_distance_results_from_hops(Root, Results),').
 benchmark_results_line(accumulated, '    compute_effective_distance_results_from_weight_sums(Root, Results),').
 benchmark_results_line(article_accumulated, '    compute_effective_distance_results_from_article_sums(Root, Results),').
+benchmark_results_line(root_accumulated, '    compute_effective_distance_results_from_root_pairs(RootArticlePairs, Results),').
 
 benchmark_weight_sum_query_line(seeded, '    fail.').
 benchmark_weight_sum_query_line(pruned, '    fail.').
 benchmark_weight_sum_query_line(accumulated, '    ''category_ancestor$effective_distance_sum_selected''(Cat, Root, WeightSum).').
 benchmark_weight_sum_query_line(article_accumulated, '    ''category_ancestor$effective_distance_sum_selected''(Cat, Root, WeightSum).').
+benchmark_weight_sum_query_line(root_accumulated, '    ''category_ancestor$effective_distance_sum_selected''(Cat, Root, WeightSum).').
 
 benchmark_article_weight_sum_query_line(seeded, '    fail.').
 benchmark_article_weight_sum_query_line(pruned, '    fail.').
 benchmark_article_weight_sum_query_line(accumulated, '    fail.').
 benchmark_article_weight_sum_query_line(article_accumulated, '    ''category_ancestor$effective_distance_article_sum''(Article, Root, WeightSum).').
+benchmark_article_weight_sum_query_line(root_accumulated, '    fail.').
+
+benchmark_article_weight_sum_by_root_query_line(seeded, '    fail.').
+benchmark_article_weight_sum_by_root_query_line(pruned, '    fail.').
+benchmark_article_weight_sum_by_root_query_line(accumulated, '    fail.').
+benchmark_article_weight_sum_by_root_query_line(article_accumulated, '    fail.').
+benchmark_article_weight_sum_by_root_query_line(root_accumulated,
+    '    ''category_ancestor$effective_distance_article_sum_pairs_by_root''(Root, ArticlePairs).').
 
 benchmark_mode_line(seeded, '    format(user_error, ''mode=seeded~n'', []),').
 benchmark_mode_line(pruned, '    format(user_error, ''mode=pruned~n'', []),').
 benchmark_mode_line(accumulated, '    format(user_error, ''mode=accumulated~n'', []),').
 benchmark_mode_line(article_accumulated, '    format(user_error, ''mode=article_accumulated~n'', []),').
+benchmark_mode_line(root_accumulated, '    format(user_error, ''mode=root_accumulated~n'', []),').

--- a/src/unifyweaver/targets/prolog_target.pl
+++ b/src/unifyweaver/targets/prolog_target.pl
@@ -886,13 +886,17 @@ build_effective_distance_consumer_code(Pred/_Arity,
     build_grouped_alias_suffixes([EffectiveSuffix], [EffectiveGroupedSuffix]),
     helper_name_for_suffix(Pred, EffectiveGroupedSuffix, EffectiveGroupedHelperName),
     helper_name_for_suffix(Pred, effective_distance_article_sum, ArticleSumHelperName),
+    helper_name_for_suffix(Pred, effective_distance_article_sum_by_root, ArticleSumByRootHelperName),
+    helper_name_for_suffix(Pred, effective_distance_article_sum_pairs_by_root,
+        ArticleSumPairsByRootHelperName),
     helper_name_for_suffix(Pred, effective_distance_article_sum_root_grouped, RootGroupedName),
     helper_name_for_suffix(Pred, effective_distance_article_sum_article_grouped, ArticleGroupedName),
     atom_concat(ArticleSumHelperName, '$sum_pairs', SumPairsName),
     atom_concat(ArticleSumHelperName, '$take_same_key', TakeSameKeyName),
-    build_effective_distance_consumer_clauses(ArticleSumHelperName, RootGroupedName,
-        ArticleGroupedName, EffectiveBoundHelperName, EffectiveGroupedHelperName,
-        SumPairsName, TakeSameKeyName, Clauses, TableDeclCode),
+    build_effective_distance_consumer_clauses(ArticleSumHelperName, ArticleSumByRootHelperName,
+        ArticleSumPairsByRootHelperName, RootGroupedName, ArticleGroupedName,
+        EffectiveBoundHelperName, EffectiveGroupedHelperName, SumPairsName, TakeSameKeyName,
+        Clauses, TableDeclCode),
     clauses_to_code(Clauses, ClauseCode),
     atomic_list_concat([
         '% Effective-distance grouped consumer helper for compact (article, root, weight_sum) rows.',
@@ -906,10 +910,12 @@ effective_distance_suffix_from_formula(
     member(EffectiveSuffix, [PrimarySuffix|AliasSuffixes]),
     EffectiveSuffix == effective_distance_sum.
 
-build_effective_distance_consumer_clauses(ArticleSumHelperName, RootGroupedName,
-        ArticleGroupedName, EffectiveBoundHelperName, EffectiveGroupedHelperName,
-        SumPairsName, TakeSameKeyName, Clauses, TableDeclCode) :-
-    build_effective_distance_consumer_entry_clauses(ArticleSumHelperName, RootGroupedName,
+build_effective_distance_consumer_clauses(ArticleSumHelperName, ArticleSumByRootHelperName,
+        ArticleSumPairsByRootHelperName, RootGroupedName, ArticleGroupedName,
+        EffectiveBoundHelperName, EffectiveGroupedHelperName, SumPairsName, TakeSameKeyName,
+        Clauses, TableDeclCode) :-
+    build_effective_distance_consumer_entry_clauses(ArticleSumHelperName,
+        ArticleSumByRootHelperName, ArticleSumPairsByRootHelperName, RootGroupedName,
         ArticleGroupedName, EntryClauses),
     build_effective_distance_consumer_root_grouped_clause(RootGroupedName,
         EffectiveBoundHelperName, SumPairsName, RootGroupedClause),
@@ -923,15 +929,29 @@ build_effective_distance_consumer_clauses(ArticleSumHelperName, RootGroupedName,
     format(atom(TableDeclCode), ':- table ~q.~n:- table ~q.',
         [RootTableSpec, ArticleTableSpec]).
 
-build_effective_distance_consumer_entry_clauses(ArticleSumHelperName, RootGroupedName,
-        ArticleGroupedName, Clauses) :-
+build_effective_distance_consumer_entry_clauses(ArticleSumHelperName, ArticleSumByRootHelperName,
+        ArticleSumPairsByRootHelperName, RootGroupedName, ArticleGroupedName, Clauses) :-
+    RootPairsHead =.. [ArticleSumPairsByRootHelperName, Root, ArticlePairs],
+    RootPairsCall =.. [RootGroupedName, Root, ArticlePairs],
+    RootPairsBody = (
+        nonvar(Root),
+        RootPairsCall
+    ),
+    clause_term(RootPairsHead, RootPairsBody, RootPairsClause),
+    ByRootHead =.. [ArticleSumByRootHelperName, Root, Article, WeightSum],
+    ByRootPairsCall =.. [ArticleSumPairsByRootHelperName, Root, ArticlePairs],
+    ByRootBody = (
+        nonvar(Root),
+        ByRootPairsCall,
+        member(Article-WeightSum, ArticlePairs)
+    ),
+    clause_term(ByRootHead, ByRootBody, ByRootClause),
     RootHead =.. [ArticleSumHelperName, Article, Root, WeightSum],
-    RootGroupedCall =.. [RootGroupedName, Root, ArticlePairs],
+    RootByArticleCall =.. [ArticleSumByRootHelperName, Root, Article, WeightSum],
     RootBody = (
         nonvar(Root),
         !,
-        RootGroupedCall,
-        member(Article-WeightSum, ArticlePairs)
+        RootByArticleCall
     ),
     clause_term(RootHead, RootBody, RootClause),
     ArticleHead =.. [ArticleSumHelperName, Article, Root, WeightSum],
@@ -954,7 +974,7 @@ build_effective_distance_consumer_entry_clauses(ArticleSumHelperName, RootGroupe
         member(Root-WeightSum, RootPairs)
     ),
     clause_term(EnumerateHead, EnumerateBody, EnumerateClause),
-    Clauses = [RootClause, ArticleClause, EnumerateClause].
+    Clauses = [RootPairsClause, ByRootClause, RootClause, ArticleClause, EnumerateClause].
 
 build_effective_distance_consumer_root_grouped_clause(RootGroupedName,
         EffectiveBoundHelperName, SumPairsName, ClauseTerm) :-

--- a/tests/core/test_prolog_target.pl
+++ b/tests/core/test_prolog_target.pl
@@ -412,6 +412,36 @@ collect_generated_effective_distance_article_sums(Options, PredicateCode, Articl
         cleanup_temp_module_source(Path)
     ).
 
+collect_generated_effective_distance_root_article_sums(Options, PredicateCode, ArticleSums) :-
+    once(prolog_target:generate_predicate_code(test_effective_ppv_reach/4, Options, PredicateCode)),
+    gensym(test_effective_root_runtime_, ModuleName),
+    build_effective_distance_runtime_source(ModuleName, PredicateCode, Source),
+    write_temp_module_source(Source, Path),
+    setup_call_cleanup(
+        load_files(Path, []),
+        (
+            Goal =.. ['test_effective_ppv_reach$effective_distance_article_sum_by_root', c, Article, Sum],
+            findall(Article-Sum, ModuleName:Goal, ArticleSums0),
+            sort(ArticleSums0, ArticleSums)
+        ),
+        cleanup_temp_module_source(Path)
+    ).
+
+collect_generated_effective_distance_root_pairs(Options, PredicateCode, ArticlePairs) :-
+    once(prolog_target:generate_predicate_code(test_effective_ppv_reach/4, Options, PredicateCode)),
+    gensym(test_effective_root_pairs_runtime_, ModuleName),
+    build_effective_distance_runtime_source(ModuleName, PredicateCode, Source),
+    write_temp_module_source(Source, Path),
+    setup_call_cleanup(
+        load_files(Path, []),
+        (
+            Goal =.. ['test_effective_ppv_reach$effective_distance_article_sum_pairs_by_root', c, Pairs],
+            once(ModuleName:Goal),
+            sort(Pairs, ArticlePairs)
+        ),
+        cleanup_temp_module_source(Path)
+    ).
+
 build_category_influence_runtime_source(ModuleName, PredicateCode, Source) :-
     atomic_list_concat([
         'test_influence_edge(a, b).',
@@ -592,6 +622,8 @@ test(emits_effective_distance_accumulation_helper_for_counted_ppv,
     once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_sum_bound')),
     once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_sum_selected')),
     once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_article_sum')),
+    once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_article_sum_by_root')),
+    once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_article_sum_pairs_by_root')),
     Expected is (3 ** -5) + (4 ** -5),
     Delta is abs(Actual - Expected),
     Delta < 1.0e-12.
@@ -615,6 +647,33 @@ test(emits_effective_distance_article_sum_helper_for_bound_root_queries,
     DeltaTwo is abs(Two - ExpectedTwo),
     DeltaOne < 1.0e-12,
     DeltaTwo < 1.0e-12.
+
+test(emits_effective_distance_root_bound_helper_for_profiling_and_fast_paths,
+        [setup(setup_effective_distance_accumulation_fixture),
+         cleanup(cleanup_effective_distance_accumulation_fixture)]) :-
+    Options = [
+        dialect(swi),
+        min_closure(false),
+        branch_pruning(false),
+        effective_distance_accumulation(auto),
+        predicates([dimension_n/1, max_depth/1, test_effective_ppv_reach/4])
+    ],
+    collect_generated_effective_distance_root_article_sums(Options, PredicateCode, ActualPairs),
+    collect_generated_effective_distance_root_pairs(Options, _PairsCode, PairList),
+    once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_article_sum_by_root')),
+    once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_article_sum_pairs_by_root')),
+    ExpectedOne is (3 ** -5) + (3 ** -5) + (4 ** -5),
+    ExpectedTwo is 2 ** -5,
+    ActualPairs = [article_one-One, article_three-1.0, article_two-Two],
+    PairList = [article_one-OnePair, article_three-1.0, article_two-TwoPair],
+    DeltaOne is abs(One - ExpectedOne),
+    DeltaTwo is abs(Two - ExpectedTwo),
+    DeltaOnePair is abs(OnePair - ExpectedOne),
+    DeltaTwoPair is abs(TwoPair - ExpectedTwo),
+    DeltaOne < 1.0e-12,
+    DeltaTwo < 1.0e-12,
+    DeltaOnePair < 1.0e-12,
+    DeltaTwoPair < 1.0e-12.
 
 test(skips_effective_distance_accumulation_helper_when_disabled_explicitly,
         [setup(setup_effective_distance_accumulation_fixture),


### PR DESCRIPTION
  ## Summary

  This adds a generated bound-root effective-distance fast path to the
  Prolog target.

  The goal is narrower than the earlier experimental direct
  `(article, root, weight_sum)` helper:

  - target the actual benchmark shape where `Root` is already bound
  - expose a public helper surface that can be benchmarked and profiled directly
  - keep the existing seed-accumulated path as the stable default unless the
    new root-bound path is actually better

  That helper surface is now:

  - `category_ancestor$effective_distance_article_sum_by_root/3`
  - `category_ancestor$effective_distance_article_sum_pairs_by_root/2`

  ## What Changed

  - extended `src/unifyweaver/targets/prolog_target.pl`
    - added generated bound-root effective-distance helpers for the
      canonical counted PPV shape
    - `effective_distance_article_sum_by_root/3` enumerates
      `(Root, Article, WeightSum)` through the bound-root path
    - `effective_distance_article_sum_pairs_by_root/2` exposes the compact
      article/weight pair list directly for profiling and benchmark use
    - kept the existing seed-accumulated helper and selected-helper
      machinery intact
  - extended `tests/core/test_prolog_target.pl`
    - added execution-level tests for the new root-bound helper surface
    - verified both:
      - row-by-row helper output
      - pair-list profiling output
  - updated `examples/benchmark/generate_prolog_effective_distance_benchmark.pl`
    - added a new benchmark variant: `root_accumulated`
    - this variant uses the generated root-bound helper directly instead of
      going through the generic per-article helper
  - updated `examples/benchmark/benchmark_prolog_effective_distance.py`
    - added `prolog-root-accumulated`
  - updated `examples/benchmark/benchmark_effective_distance.py`
    - added optional cross-target support for `prolog-root-accumulated`
  - updated `examples/benchmark/README.md`
    - documented the new helper and benchmark path
    - recorded the current performance result and interpretation

  ## Why

  The previous direct article/root helper proved correctness, but it still
  was not the fast path that this workload actually wants.

  The effective-distance benchmark binds a single root and then asks for
  all article summaries under that root. So the next sensible optimization
  was not “more general article/root retained state,” but a narrower
  specialization for that exact bound-root consumer shape.

  This PR adds that missing path and gives us a direct predicate to profile
  when tuning this workload further.

  ## Result

  ### Semantic result

  The new `root_accumulated` path matches the existing effective-distance
  outputs.

  The new helper is now usable both as:

  - a benchmark execution path
  - a direct profiling surface for one bound root

  ### Performance result

  `root_accumulated` is a meaningful improvement over the earlier
  per-article direct helper, but it is still not the universal default
  winner.

  Latest local standalone Prolog comparison:

  | Scale | Accumulated | Article Accumulated | Root Accumulated |
  |-------|------------:|--------------------:|-----------------:|
  | 300 | 0.354s | 0.385s | 0.360s |
  | 1k | 0.288s | 0.388s | 0.236s |
  | 5k | 0.797s | 5.720s | 0.934s |
  | 10k | 1.943s | — | 2.629s |

  Interpretation:

  - `root_accumulated` is the right public fast-path/profiling helper
  - it improves the direct article/root idea substantially
  - but it still loses to the stable seed-accumulated path at larger scales
  - therefore `prolog-accumulated` remains the default effective-distance
    comparison path

  ### Cross-target spot check

  Latest local `csharp-query` vs Prolog run:

  | Scale | C# Query | Prolog Accumulated | Prolog Root Accumulated |
  |-------|---------:|-------------------:|------------------------:|
  | 300 | 0.202s | 0.347s | 0.339s |
  | 1k | 0.154s | 0.230s | 0.239s |
  | 5k | 0.338s | 0.783s | 0.888s |
  | 10k | 0.687s | 2.000s | 2.226s |

  Outputs match across all compared targets.

  So the root-bound path narrows the small-scale gap slightly, but it does
  not replace the seed-accumulated path as the better end-to-end Prolog
  strategy today.

  ## Verification

  - `swipl -q -t halt -s src/unifyweaver/targets/prolog_target.pl`
  - `swipl -q -g "use_module('tests/core/test_prolog_target.pl'), test_prolog_target:run_prolog_target_tests" -t halt`
  - `python -m py_compile examples/benchmark/benchmark_prolog_effective_distance.py examples/benchmark/
  benchmark_effective_distance.py`
  - `python examples/benchmark/benchmark_prolog_effective_distance.py --scales 300,1k,5k --targets prolog-
  accumulated,prolog-article-accumulated,prolog-root-accumulated --repetitions 1`
  - `python examples/benchmark/benchmark_prolog_effective_distance.py --scales 10k --targets prolog-accumulated,prolog-
  root-accumulated --repetitions 1`
  - `python examples/benchmark/benchmark_effective_distance.py --scales 300,1k,5k --targets csharp-query,prolog-
  accumulated,prolog-root-accumulated --repetitions 1`
  - `python examples/benchmark/benchmark_effective_distance.py --scales 10k --targets csharp-query,prolog-
  accumulated,prolog-root-accumulated --repetitions 1`

  ## Notes

  - this PR is worth merging because it adds a real, generated,
    benchmarkable fast path for the bound-root effective-distance query
  - it also gives us explicit predicates for profiling and optimization
    work, which was previously missing
  - the result still supports the broader conclusion:
    the remaining gap is mostly execution strategy, not missing helper
    shapes