### PR TITLE
feat(csharp-query): measure grouped summary retention costs

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -89,7 +89,10 @@ Status:
 - `QueryExecutorOptions.PathAwareWeightSumStrategy` can force `Auto`,
   `CompactGrouped`, or `LegacySeededRows` for grouped weight-sum benchmarking
 - the current implementation shares one grouped-summary heuristic/resolution
-  path internally while keeping per-family override knobs for benchmarking
+  path internally, now records measured cost buckets at the retention
+  decision points, and keeps per-family override knobs for benchmarking
+- the current selector only runs bounded measured probes in ambiguous cases;
+  obvious shapes still short-circuit structurally
 
 Work:
 

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -67,14 +67,14 @@ Examples:
   `(group, root, min_value)` summaries instead of retaining full seeded path rows
 - where both grouped minima and legacy seeded-row regrouping are available, the
   runtime can choose between them through a shared grouped-summary policy
-  layer and still expose an explicit override via
-  `QueryExecutorOptions.PathAwareGroupedMinStrategy`
+  layer, record measured cost buckets for that choice, and still expose an
+  explicit override via `QueryExecutorOptions.PathAwareGroupedMinStrategy`
 - effective-distance and category-influence operators can build compact
   `(group, root, weight_sum)` summaries instead of retaining full path rows
 - where grouped weight sums and legacy seeded-row regrouping both exist, the
   runtime can choose between them through that same grouped-summary policy
-  layer and still expose an explicit override via
-  `QueryExecutorOptions.PathAwareWeightSumStrategy`
+  layer, record measured cost buckets for that choice, and still expose an
+  explicit override via `QueryExecutorOptions.PathAwareWeightSumStrategy`
 - other operators may request replay buffers or indexes when needed
 
 ### 3. External materialization fallback
@@ -123,13 +123,15 @@ For the current benchmark/runtime surface, the streamed path is:
 6. shortest-path and weighted-shortest-path operators can emit compact
    grouped root minima directly from streamed edge/seed inputs
 7. where grouped minima and legacy seeded-row regrouping both exist, the runtime
-   can select between them through a shared grouped-summary policy layer or
-   via an explicit executor option
+   can select between them through a shared grouped-summary policy layer,
+   record measured cost buckets for that decision, and use bounded probes in
+   ambiguous cases before falling back to an explicit executor option
 8. effective-distance and category-influence operators can emit compact
    grouped root-weight summaries directly from streamed edge/seed inputs
 9. where grouped weight sums and legacy seeded-row regrouping both exist, the
    runtime can select between them through that same grouped-summary policy
-   layer or via an explicit executor option
+   layer, record measured cost buckets for that decision, and use bounded
+   probes in ambiguous cases before falling back to an explicit executor option
 10. the operator builds only the retained state it actually needs
 11. benchmark code avoids preloading raw facts into in-memory relations first
 

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -30,7 +30,10 @@ pipelines across the full benchmark range while preserving the same
 all-path semantics. It also now supports cost-guided selection between
 compact grouped weight sums and the legacy seeded-row regrouping path,
 using the same grouped-summary policy layer that now also drives the
-shortest-path minima family.
+shortest-path minima family. That policy now records measured cost buckets
+like `load_roots`, `load_seeds`, `strategy_select`, `build_*`, and
+`group_reduce`, while only running bounded probes when the structural signal
+is ambiguous.
 
 | Target | 300 art | 1K art | 5K art | 10K art |
 |--------|---------|--------|--------|---------|
@@ -537,7 +540,9 @@ Comparison note:
 - the new `Auto` selector currently chooses the compact grouped minima
   path at every tested scale; this now flows through the same grouped-summary
   policy layer used by grouped weight sums, while still preserving the
-  per-family override knob. Forcing legacy seeded-row regrouping is
+  per-family override knob. Trace output now exposes measured buckets such as
+  `load_roots`, `load_seeds`, `strategy_select`, `build_compact_grouped`, and
+  `group_reduce`. Forcing legacy seeded-row regrouping is
   materially worse (`300`: `0.160s` vs `0.083s`, `10k`: `0.419s` vs
   `0.161s`)
 - seeded Prolog `min` remains competitive, but the C# query engine is
@@ -591,7 +596,8 @@ Comparison note:
   also collapses to the final article result count
 - the new `Auto` selector also chooses the compact grouped minima path
   here; this now uses the same grouped-summary policy layer as shortest
-  path while keeping a separate benchmark override
+  path while keeping a separate benchmark override, and the same measured
+  buckets are available under trace for this family too
 - forcing legacy seeded-row regrouping regresses both ends of the
   benchmark (`300`: `0.202s` vs `0.151s`, `10k`: `0.430s` vs `0.320s`)
 - seeded Prolog `min` still wins narrowly at `300` and `1k`, but the C#
@@ -778,7 +784,9 @@ Comparison note:
 - the remaining benchmark-side work is only the final per-root sum over those
   compact article/root summaries
 - the new `Auto` selector also chooses the compact grouped weight-sum path
-  here; forcing legacy seeded-row regrouping regresses badly (`300`: `0.711s`
+  here; trace output now exposes measured buckets such as `load_roots`,
+  `load_seeds`, `strategy_select`, `build_compact_grouped`, and
+  `group_reduce`. Forcing legacy seeded-row regrouping regresses badly (`300`: `0.711s`
   vs `0.237s`, `10k`: `2.998s` vs `0.829s`)
 - Rust and Go remain generated DFS/pipeline binaries
 - so this runner is still intentionally a mixed execution-model comparison:

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -2500,6 +2500,21 @@ class Program
         }}
     }}
 
+    static void PrintWeightSumPhases(QueryExecutionTrace? trace)
+    {{
+        if (trace is null)
+        {{
+            return;
+        }}
+
+        foreach (var phase in trace.SnapshotPhases()
+            .Where(p => p.NodeType == nameof(SeedGroupedPathAwareWeightSumNode))
+            .OrderBy(p => p.Phase, StringComparer.Ordinal))
+        {{
+            Console.Error.WriteLine($"phase_{{phase.Phase}}_ms={{phase.Elapsed.TotalMilliseconds.ToString(\"F3\", CultureInfo.InvariantCulture)}}");
+        }}
+    }}
+
     static void Main(string[] args)
     {{
         if (args.Length < 2)
@@ -2564,10 +2579,10 @@ class Program
         swAgg.Stop();
         swTotal.Stop();
 
-        Console.WriteLine("root_category	influence_score");
+        Console.WriteLine("root_category\tinfluence_score");
         foreach (var item in results)
         {{
-            Console.WriteLine($"{{item.Root}}	{{item.Score.ToString("F12", CultureInfo.InvariantCulture)}}");
+            Console.WriteLine($"{{item.Root}}\t{{item.Score.ToString(\"F12\", CultureInfo.InvariantCulture)}}");
         }}
 
         Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
@@ -2579,6 +2594,7 @@ class Program
         Console.Error.WriteLine($"root_count={{results.Count}}");
         Console.Error.WriteLine($"weight_sum_strategy_setting={{weightSumStrategy}}");
         PrintWeightSumStrategies(trace);
+        PrintWeightSumPhases(trace);
     }}
 }}
 '''
@@ -2624,6 +2640,21 @@ class Program
             .OrderBy(s => s.Strategy, StringComparer.Ordinal))
         {{
             Console.Error.WriteLine($"strategy_{{strategy.Strategy}}={{strategy.Count}}");
+        }}
+    }}
+
+    static void PrintWeightSumPhases(QueryExecutionTrace? trace)
+    {{
+        if (trace is null)
+        {{
+            return;
+        }}
+
+        foreach (var phase in trace.SnapshotPhases()
+            .Where(p => p.NodeType == nameof(SeedGroupedPathAwareWeightSumNode))
+            .OrderBy(p => p.Phase, StringComparer.Ordinal))
+        {{
+            Console.Error.WriteLine($"phase_{{phase.Phase}}_ms={{phase.Elapsed.TotalMilliseconds.ToString(\"F3\", CultureInfo.InvariantCulture)}}");
         }}
     }}
 
@@ -2681,10 +2712,10 @@ class Program
         swAgg.Stop();
         swTotal.Stop();
 
-        Console.WriteLine("article	root_category	effective_distance");
+        Console.WriteLine("article\troot_category\teffective_distance");
         foreach (var (deff, article) in results)
         {{
-            Console.WriteLine($"{{article}}	{{ROOT_CATEGORY}}	{{deff.ToString("F6", CultureInfo.InvariantCulture)}}");
+            Console.WriteLine($"{{article}}\t{{ROOT_CATEGORY}}\t{{deff.ToString(\"F6\", CultureInfo.InvariantCulture)}}");
         }}
 
         Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
@@ -2695,6 +2726,7 @@ class Program
         Console.Error.WriteLine($"article_count={{results.Count}}");
         Console.Error.WriteLine($"weight_sum_strategy_setting={{weightSumStrategy}}");
         PrintWeightSumStrategies(trace);
+        PrintWeightSumPhases(trace);
     }}
 
     static double ComputeDeff(double weightSum)
@@ -2743,6 +2775,21 @@ class Program
             .OrderBy(s => s.Strategy, StringComparer.Ordinal))
         {{
             Console.Error.WriteLine($"strategy_{{strategy.Strategy}}={{strategy.Count}}");
+        }}
+    }}
+
+    static void PrintPathMinPhases(QueryExecutionTrace? trace)
+    {{
+        if (trace is null)
+        {{
+            return;
+        }}
+
+        foreach (var phase in trace.SnapshotPhases()
+            .Where(p => p.NodeType == nameof(SeedGroupedPathAwareDepthMinNode))
+            .OrderBy(p => p.Phase, StringComparer.Ordinal))
+        {{
+            Console.Error.WriteLine($"phase_{{phase.Phase}}_ms={{phase.Elapsed.TotalMilliseconds.ToString(\"F3\", CultureInfo.InvariantCulture)}}");
         }}
     }}
 
@@ -2799,10 +2846,10 @@ class Program
         swAgg.Stop();
         swTotal.Stop();
 
-        Console.WriteLine("article	root_category	shortest_path");
+        Console.WriteLine("article\troot_category\tshortest_path");
         foreach (var item in results)
         {{
-            Console.WriteLine($"{{item.Article}}	{{ROOT_CATEGORY}}	{{item.Distance}}");
+            Console.WriteLine($"{{item.Article}}\t{{ROOT_CATEGORY}}\t{{item.Distance}}");
         }}
 
         Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
@@ -2813,10 +2860,10 @@ class Program
         Console.Error.WriteLine($"article_count={{results.Count}}");
         Console.Error.WriteLine($"path_min_strategy_setting={{pathMinStrategy}}");
         PrintPathMinStrategies(trace);
+        PrintPathMinPhases(trace);
     }}
 }}
 '''
-
 
 
 def generate_csharp_query_weighted_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
@@ -2862,6 +2909,21 @@ class Program
         }}
     }}
 
+    static void PrintPathMinPhases(QueryExecutionTrace? trace)
+    {{
+        if (trace is null)
+        {{
+            return;
+        }}
+
+        foreach (var phase in trace.SnapshotPhases()
+            .Where(p => p.NodeType == nameof(SeedGroupedPathAwareAccumulationMinNode))
+            .OrderBy(p => p.Phase, StringComparer.Ordinal))
+        {{
+            Console.Error.WriteLine($"phase_{{phase.Phase}}_ms={{phase.Elapsed.TotalMilliseconds.ToString(\"F3\", CultureInfo.InvariantCulture)}}");
+        }}
+    }}
+
     static void Main(string[] args)
     {{
         if (args.Length < 2)
@@ -2891,7 +2953,7 @@ class Program
                 continue;
             }}
 
-            var parts = line.Split('	', 2);
+            var parts = line.Split('\t', 2);
             if (parts.Length != 2)
             {{
                 continue;
@@ -2955,10 +3017,10 @@ class Program
         swAgg.Stop();
         swTotal.Stop();
 
-        Console.WriteLine("article	root_category	weighted_shortest_path");
+        Console.WriteLine("article\troot_category\tweighted_shortest_path");
         foreach (var item in results)
         {{
-            Console.WriteLine($"{{item.Article}}	{{ROOT_CATEGORY}}	{{item.Distance.ToString("F12", CultureInfo.InvariantCulture)}}");
+            Console.WriteLine($"{{item.Article}}\t{{ROOT_CATEGORY}}\t{{item.Distance.ToString(\"F12\", CultureInfo.InvariantCulture)}}");
         }}
 
         Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
@@ -2969,9 +3031,11 @@ class Program
         Console.Error.WriteLine($"article_count={{results.Count}}");
         Console.Error.WriteLine($"path_min_strategy_setting={{pathMinStrategy}}");
         PrintPathMinStrategies(trace);
+        PrintPathMinPhases(trace);
     }}
 }}
 '''
+
 
 def generate_csharp_weighted_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
     root = list(root_cats)[0] if root_cats else "Physics"

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -488,6 +488,10 @@ namespace UnifyWeaver.QueryRuntime
         LegacySeededRows
     }
 
+    internal readonly record struct PathAwareGroupedSummarySelection(
+        PathAwareGroupedSummaryStrategy Strategy,
+        string DecisionMode);
+
     public sealed record QueryExecutorOptions(
         bool ReuseCaches = false,
         PathAwareGroupedMinStrategy PathAwareGroupedMinStrategy = PathAwareGroupedMinStrategy.Auto,
@@ -7629,36 +7633,153 @@ namespace UnifyWeaver.QueryRuntime
                 _ => PathAwareGroupedSummaryStrategy.Auto
             };
 
-        private static PathAwareGroupedSummaryStrategy ResolvePathAwareGroupedSummaryStrategy(
-            PathAwareGroupedSummaryStrategy configuredStrategy,
-            int groupCount,
-            int uniqueSeedCount,
-            int rootCount,
-            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex)
+        private static TimeSpan MeasureElapsed(Action action)
         {
-            if (configuredStrategy != PathAwareGroupedSummaryStrategy.Auto)
-            {
-                return configuredStrategy;
-            }
+            var stopwatch = Stopwatch.StartNew();
+            action();
+            stopwatch.Stop();
+            return stopwatch.Elapsed;
+        }
 
-            var effectiveGroups = Math.Max(1, groupCount);
-            var effectiveSeeds = Math.Max(1, uniqueSeedCount);
-            var effectiveRoots = Math.Max(1, rootCount);
-            var nodeCount = Math.Max(1, EstimatePathAwareNodeCount(succIndex));
-            var estimatedGroupedRows = (long)effectiveGroups * effectiveRoots;
-            var estimatedLegacyRows = (long)effectiveSeeds * nodeCount;
-            return estimatedLegacyRows <= Math.Max(64L, estimatedGroupedRows * 4L)
+        private static T MeasurePhase<T>(QueryExecutionTrace? trace, PlanNode node, string phase, Func<T> action)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var result = action();
+            stopwatch.Stop();
+            trace?.RecordPhase(node, phase, stopwatch.Elapsed);
+            return result;
+        }
+
+        private static void MeasurePhase(QueryExecutionTrace? trace, PlanNode node, string phase, Action action)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            action();
+            stopwatch.Stop();
+            trace?.RecordPhase(node, phase, stopwatch.Elapsed);
+        }
+
+        private static PathAwareGroupedSummaryStrategy ResolveStructuralPathAwareGroupedSummaryStrategy(
+            long estimatedGroupedRows,
+            long estimatedLegacyRows) =>
+            estimatedLegacyRows <= Math.Max(64L, estimatedGroupedRows * 4L)
                 ? PathAwareGroupedSummaryStrategy.LegacySeededRows
                 : PathAwareGroupedSummaryStrategy.CompactGrouped;
+
+        private static bool ShouldProbePathAwareGroupedSummaryStrategy(
+            long estimatedGroupedRows,
+            long estimatedLegacyRows,
+            int uniqueSeedCount)
+        {
+            if (uniqueSeedCount < 2)
+            {
+                return false;
+            }
+
+            var lowerBound = Math.Max(64L, estimatedGroupedRows * 2L);
+            var upperBound = Math.Max(256L, estimatedGroupedRows * 8L);
+            return estimatedLegacyRows > lowerBound && estimatedLegacyRows < upperBound;
+        }
+
+        private static PathAwareGroupedSummaryStrategy ResolveMeasuredPathAwareGroupedSummaryStrategy(
+            int totalSeedCount,
+            int sampleSeedCount,
+            TimeSpan compactProbe,
+            TimeSpan legacyProbe,
+            long estimatedGroupedRows,
+            long estimatedLegacyRows)
+        {
+            var structuralStrategy = ResolveStructuralPathAwareGroupedSummaryStrategy(estimatedGroupedRows, estimatedLegacyRows);
+            if (sampleSeedCount <= 0 || totalSeedCount <= 0)
+            {
+                return structuralStrategy;
+            }
+
+            var compactTicks = compactProbe == TimeSpan.MaxValue
+                ? double.PositiveInfinity
+                : compactProbe.Ticks * (double)totalSeedCount / sampleSeedCount;
+            var legacyTicks = legacyProbe == TimeSpan.MaxValue
+                ? double.PositiveInfinity
+                : legacyProbe.Ticks * (double)totalSeedCount / sampleSeedCount;
+
+            if (double.IsInfinity(compactTicks) && !double.IsInfinity(legacyTicks))
+            {
+                return PathAwareGroupedSummaryStrategy.LegacySeededRows;
+            }
+
+            if (double.IsInfinity(legacyTicks) && !double.IsInfinity(compactTicks))
+            {
+                return PathAwareGroupedSummaryStrategy.CompactGrouped;
+            }
+
+            if (compactTicks <= 0d || legacyTicks <= 0d || (double.IsInfinity(compactTicks) && double.IsInfinity(legacyTicks)))
+            {
+                return structuralStrategy;
+            }
+
+            return legacyTicks <= compactTicks
+                ? PathAwareGroupedSummaryStrategy.LegacySeededRows
+                : PathAwareGroupedSummaryStrategy.CompactGrouped;
+        }
+
+        private static PathAwareGroupedSummarySelection ResolvePathAwareGroupedSummaryStrategy(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            PathAwareGroupedSummaryStrategy configuredStrategy,
+            int groupCount,
+            IReadOnlyList<object?> orderedUniqueSeeds,
+            int rootCount,
+            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
+            Func<IReadOnlyList<object?>, TimeSpan>? measureCompactProbe = null,
+            Func<IReadOnlyList<object?>, TimeSpan>? measureLegacyProbe = null)
+        {
+            return MeasurePhase(trace, node, "strategy_select", () =>
+            {
+                if (configuredStrategy != PathAwareGroupedSummaryStrategy.Auto)
+                {
+                    return new PathAwareGroupedSummarySelection(configuredStrategy, "ConfiguredOverride");
+                }
+
+                var uniqueSeedCount = orderedUniqueSeeds.Count;
+                var effectiveGroups = Math.Max(1, groupCount);
+                var effectiveSeeds = Math.Max(1, uniqueSeedCount);
+                var effectiveRoots = Math.Max(1, rootCount);
+                var nodeCount = Math.Max(1, EstimatePathAwareNodeCount(succIndex));
+                var estimatedGroupedRows = (long)effectiveGroups * effectiveRoots;
+                var estimatedLegacyRows = (long)effectiveSeeds * nodeCount;
+                var structuralStrategy = ResolveStructuralPathAwareGroupedSummaryStrategy(estimatedGroupedRows, estimatedLegacyRows);
+
+                if (measureCompactProbe is null || measureLegacyProbe is null ||
+                    !ShouldProbePathAwareGroupedSummaryStrategy(estimatedGroupedRows, estimatedLegacyRows, uniqueSeedCount))
+                {
+                    return new PathAwareGroupedSummarySelection(structuralStrategy, "Structural");
+                }
+
+                var sampleSeedCount = Math.Min(uniqueSeedCount, 4);
+                var sampleSeeds = orderedUniqueSeeds.Take(sampleSeedCount).ToList();
+                var compactProbe = measureCompactProbe(sampleSeeds);
+                trace?.RecordPhase(node, "strategy_probe_compact_grouped", compactProbe);
+                var legacyProbe = measureLegacyProbe(sampleSeeds);
+                trace?.RecordPhase(node, "strategy_probe_legacy_seeded_rows", legacyProbe);
+
+                var measuredStrategy = ResolveMeasuredPathAwareGroupedSummaryStrategy(
+                    uniqueSeedCount,
+                    sampleSeedCount,
+                    compactProbe,
+                    legacyProbe,
+                    estimatedGroupedRows,
+                    estimatedLegacyRows);
+                return new PathAwareGroupedSummarySelection(measuredStrategy, "MeasuredProbe");
+            });
         }
 
         private static void RecordPathAwareGroupedSummaryStrategy(
             QueryExecutionTrace? trace,
             PlanNode node,
             string nodeStrategyPrefix,
-            PathAwareGroupedSummaryStrategy strategy)
+            PathAwareGroupedSummarySelection selection)
         {
-            trace?.RecordStrategy(node, strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows
+            trace?.RecordStrategy(node, $"{nodeStrategyPrefix}Selection{selection.DecisionMode}");
+            trace?.RecordStrategy(node, selection.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows
                 ? $"{nodeStrategyPrefix}LegacySeededRows"
                 : $"{nodeStrategyPrefix}CompactGrouped");
         }
@@ -7773,20 +7894,23 @@ namespace UnifyWeaver.QueryRuntime
 
                 var rootKeys = new HashSet<object>();
                 var rootValues = new Dictionary<object, object?>();
-                foreach (var row in GetFactStream(closure.RootRelation, context))
+                MeasurePhase(trace, closure, "load_roots", () =>
                 {
-                    if (row is null || row.Length == 0)
+                    foreach (var row in GetFactStream(closure.RootRelation, context))
                     {
-                        continue;
-                    }
+                        if (row is null || row.Length == 0)
+                        {
+                            continue;
+                        }
 
-                    var root = row[0];
-                    var rootKey = root ?? NullFactIndexKey;
-                    if (rootKeys.Add(rootKey))
-                    {
-                        rootValues[rootKey] = root;
+                        var root = row[0];
+                        var rootKey = root ?? NullFactIndexKey;
+                        if (rootKeys.Add(rootKey))
+                        {
+                            rootValues[rootKey] = root;
+                        }
                     }
-                }
+                });
 
                 if (rootKeys.Count == 0)
                 {
@@ -7799,30 +7923,32 @@ namespace UnifyWeaver.QueryRuntime
                 var groupValues = new List<object?>();
                 var uniqueSeeds = new HashSet<object?>();
                 var orderedUniqueSeeds = new List<object?>();
-
-                foreach (var row in GetFactStream(closure.SeedRelation, context))
+                MeasurePhase(trace, closure, "load_seeds", () =>
                 {
-                    if (row is null || row.Length < 2)
+                    foreach (var row in GetFactStream(closure.SeedRelation, context))
                     {
-                        continue;
-                    }
+                        if (row is null || row.Length < 2)
+                        {
+                            continue;
+                        }
 
-                    var group = row[0];
-                    var seed = row[1];
-                    var groupKey = group ?? NullFactIndexKey;
-                    if (!groupedSeeds.TryGetValue(groupKey, out var bucket))
-                    {
-                        bucket = new List<object?>();
-                        groupedSeeds[groupKey] = bucket;
-                        groupValues.Add(group);
-                    }
+                        var group = row[0];
+                        var seed = row[1];
+                        var groupKey = group ?? NullFactIndexKey;
+                        if (!groupedSeeds.TryGetValue(groupKey, out var bucket))
+                        {
+                            bucket = new List<object?>();
+                            groupedSeeds[groupKey] = bucket;
+                            groupValues.Add(group);
+                        }
 
-                    bucket.Add(seed);
-                    if (uniqueSeeds.Add(seed))
-                    {
-                        orderedUniqueSeeds.Add(seed);
+                        bucket.Add(seed);
+                        if (uniqueSeeds.Add(seed))
+                        {
+                            orderedUniqueSeeds.Add(seed);
+                        }
                     }
-                }
+                });
 
                 if (groupValues.Count == 0)
                 {
@@ -7833,20 +7959,8 @@ namespace UnifyWeaver.QueryRuntime
 
                 orderedUniqueSeeds.Sort(CompareCacheSeedValues);
                 groupValues.Sort(CompareCacheSeedValues);
-                var selectedStrategy = ResolvePathAwareGroupedSummaryStrategy(
-                    _pathAwareWeightSumStrategy,
-                    groupValues.Count,
-                    orderedUniqueSeeds.Count,
-                    rootKeys.Count,
-                    succIndex);
-                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareWeightSum", selectedStrategy);
 
-                IReadOnlyDictionary<object, Dictionary<object, double>> seedWeightSums;
-                if (selectedStrategy == PathAwareGroupedSummaryStrategy.LegacySeededRows)
-                {
-                    seedWeightSums = ExecuteSeedGroupedPathAwareWeightSumFallback(closure, orderedUniqueSeeds, rootKeys, context);
-                }
-                else
+                Dictionary<object, Dictionary<object, double>> BuildCompactSeedWeightSums(IReadOnlyList<object?> seeds)
                 {
                     var distanceWeightCache = new Dictionary<int, double>();
                     var nodeIds = new Dictionary<object, int>();
@@ -7878,7 +7992,7 @@ namespace UnifyWeaver.QueryRuntime
                     }
 
                     var directSeedWeightSums = new Dictionary<object, Dictionary<object, double>>();
-                    foreach (var seed in orderedUniqueSeeds)
+                    foreach (var seed in seeds)
                     {
                         var weightSums = ComputePathAwareRootWeightSumsForSeed(seed, succIndex, rootKeys, closure.MaxDepth, GetNodeId, GetDistanceWeight);
                         if (weightSums.Count > 0)
@@ -7887,45 +8001,74 @@ namespace UnifyWeaver.QueryRuntime
                         }
                     }
 
-                    seedWeightSums = directSeedWeightSums;
+                    return directSeedWeightSums;
                 }
 
-                var rows = new List<object[]>();
-                foreach (var group in groupValues)
-                {
-                    var groupKey = group ?? NullFactIndexKey;
-                    if (!groupedSeeds.TryGetValue(groupKey, out var seedsForGroup))
-                    {
-                        continue;
-                    }
+                TimeSpan MeasureCompactProbe(IReadOnlyList<object?> sampleSeeds) =>
+                    MeasureElapsed(() => _ = BuildCompactSeedWeightSums(sampleSeeds));
 
-                    Dictionary<object, double>? groupSums = null;
-                    foreach (var seed in seedsForGroup)
+                TimeSpan MeasureLegacyProbe(IReadOnlyList<object?> sampleSeeds) =>
+                    MeasureElapsed(() => _ = ExecuteSeedGroupedPathAwareWeightSumFallback(closure, sampleSeeds, rootKeys, context));
+
+                var selection = ResolvePathAwareGroupedSummaryStrategy(
+                    trace,
+                    closure,
+                    _pathAwareWeightSumStrategy,
+                    groupValues.Count,
+                    orderedUniqueSeeds,
+                    rootKeys.Count,
+                    succIndex,
+                    MeasureCompactProbe,
+                    MeasureLegacyProbe);
+                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareWeightSum", selection);
+
+                IReadOnlyDictionary<object, Dictionary<object, double>> seedWeightSums = selection.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows
+                    ? MeasurePhase(trace, closure, "build_legacy_seeded_rows", () =>
+                        (IReadOnlyDictionary<object, Dictionary<object, double>>)ExecuteSeedGroupedPathAwareWeightSumFallback(closure, orderedUniqueSeeds, rootKeys, context))
+                    : MeasurePhase(trace, closure, "build_compact_grouped", () =>
+                        (IReadOnlyDictionary<object, Dictionary<object, double>>)BuildCompactSeedWeightSums(orderedUniqueSeeds));
+
+                var rows = MeasurePhase(trace, closure, "group_reduce", () =>
+                {
+                    var builtRows = new List<object[]>();
+                    foreach (var group in groupValues)
                     {
-                        if (!seedWeightSums.TryGetValue(seed ?? NullFactIndexKey, out var rootSums))
+                        var groupKey = group ?? NullFactIndexKey;
+                        if (!groupedSeeds.TryGetValue(groupKey, out var seedsForGroup))
                         {
                             continue;
                         }
 
-                        groupSums ??= new Dictionary<object, double>();
-                        foreach (var entry in rootSums)
+                        Dictionary<object, double>? groupSums = null;
+                        foreach (var seed in seedsForGroup)
                         {
-                            groupSums[entry.Key] = groupSums.TryGetValue(entry.Key, out var current) ? current + entry.Value : entry.Value;
+                            if (!seedWeightSums.TryGetValue(seed ?? NullFactIndexKey, out var rootSums))
+                            {
+                                continue;
+                            }
+
+                            groupSums ??= new Dictionary<object, double>();
+                            foreach (var entry in rootSums)
+                            {
+                                groupSums[entry.Key] = groupSums.TryGetValue(entry.Key, out var current) ? current + entry.Value : entry.Value;
+                            }
+                        }
+
+                        if (groupSums is null)
+                        {
+                            continue;
+                        }
+
+                        var orderedRoots = groupSums.Keys.ToList();
+                        orderedRoots.Sort((left, right) => CompareCacheSeedValues(rootValues[left], rootValues[right]));
+                        foreach (var rootKey in orderedRoots)
+                        {
+                            builtRows.Add(new object[] { group!, rootValues[rootKey]!, groupSums[rootKey] });
                         }
                     }
 
-                    if (groupSums is null)
-                    {
-                        continue;
-                    }
-
-                    var orderedRoots = groupSums.Keys.ToList();
-                    orderedRoots.Sort((left, right) => CompareCacheSeedValues(rootValues[left], rootValues[right]));
-                    foreach (var rootKey in orderedRoots)
-                    {
-                        rows.Add(new object[] { group!, rootValues[rootKey]!, groupSums[rootKey] });
-                    }
-                }
+                    return builtRows;
+                });
 
                 context.SeedGroupedPathAwareWeightSumResults[cacheKey] = rows;
                 return rows;
@@ -8112,20 +8255,23 @@ namespace UnifyWeaver.QueryRuntime
                 var succIndex = edgeState.Successors;
                 var rootKeys = new HashSet<object>();
                 var rootValues = new Dictionary<object, object?>();
-                foreach (var row in GetFactStream(closure.RootRelation, context))
+                MeasurePhase(trace, closure, "load_roots", () =>
                 {
-                    if (row is null || row.Length == 0)
+                    foreach (var row in GetFactStream(closure.RootRelation, context))
                     {
-                        continue;
-                    }
+                        if (row is null || row.Length == 0)
+                        {
+                            continue;
+                        }
 
-                    var root = row[0];
-                    var rootKey = root ?? NullFactIndexKey;
-                    if (rootKeys.Add(rootKey))
-                    {
-                        rootValues[rootKey] = root;
+                        var root = row[0];
+                        var rootKey = root ?? NullFactIndexKey;
+                        if (rootKeys.Add(rootKey))
+                        {
+                            rootValues[rootKey] = root;
+                        }
                     }
-                }
+                });
 
                 if (rootKeys.Count == 0)
                 {
@@ -8138,29 +8284,32 @@ namespace UnifyWeaver.QueryRuntime
                 var groupValues = new List<object?>();
                 var uniqueSeeds = new HashSet<object?>();
                 var orderedUniqueSeeds = new List<object?>();
-                foreach (var row in GetFactStream(closure.SeedRelation, context))
+                MeasurePhase(trace, closure, "load_seeds", () =>
                 {
-                    if (row is null || row.Length < 2)
+                    foreach (var row in GetFactStream(closure.SeedRelation, context))
                     {
-                        continue;
-                    }
+                        if (row is null || row.Length < 2)
+                        {
+                            continue;
+                        }
 
-                    var group = row[0];
-                    var seed = row[1];
-                    var groupKey = group ?? NullFactIndexKey;
-                    if (!groupedSeeds.TryGetValue(groupKey, out var bucket))
-                    {
-                        bucket = new List<object?>();
-                        groupedSeeds[groupKey] = bucket;
-                        groupValues.Add(group);
-                    }
+                        var group = row[0];
+                        var seed = row[1];
+                        var groupKey = group ?? NullFactIndexKey;
+                        if (!groupedSeeds.TryGetValue(groupKey, out var bucket))
+                        {
+                            bucket = new List<object?>();
+                            groupedSeeds[groupKey] = bucket;
+                            groupValues.Add(group);
+                        }
 
-                    bucket.Add(seed);
-                    if (uniqueSeeds.Add(seed))
-                    {
-                        orderedUniqueSeeds.Add(seed);
+                        bucket.Add(seed);
+                        if (uniqueSeeds.Add(seed))
+                        {
+                            orderedUniqueSeeds.Add(seed);
+                        }
                     }
-                }
+                });
 
                 if (groupValues.Count == 0)
                 {
@@ -8171,23 +8320,11 @@ namespace UnifyWeaver.QueryRuntime
 
                 orderedUniqueSeeds.Sort(CompareCacheSeedValues);
                 groupValues.Sort(CompareCacheSeedValues);
-                var selectedStrategy = ResolvePathAwareGroupedSummaryStrategy(
-                    _pathAwareGroupedMinStrategy,
-                    groupValues.Count,
-                    orderedUniqueSeeds.Count,
-                    rootKeys.Count,
-                    succIndex);
-                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareDepthMin", selectedStrategy);
 
-                IReadOnlyDictionary<object, Dictionary<object, int>> seedDepthMins;
-                if (selectedStrategy == PathAwareGroupedSummaryStrategy.LegacySeededRows)
-                {
-                    seedDepthMins = ExecuteSeedGroupedPathAwareDepthMinFallback(closure, orderedUniqueSeeds, rootKeys, context);
-                }
-                else
+                Dictionary<object, Dictionary<object, int>> BuildCompactSeedDepthMins(IReadOnlyList<object?> seeds)
                 {
                     var directSeedMins = new Dictionary<object, Dictionary<object, int>>();
-                    foreach (var seed in orderedUniqueSeeds)
+                    foreach (var seed in seeds)
                     {
                         var mins = ComputePathAwareRootDepthMinsForSeed(seed, succIndex, rootKeys, closure.DirectSeedDepth, closure.MaxDepth);
                         if (mins.Count > 0)
@@ -8196,48 +8333,77 @@ namespace UnifyWeaver.QueryRuntime
                         }
                     }
 
-                    seedDepthMins = directSeedMins;
+                    return directSeedMins;
                 }
 
-                var rows = new List<object[]>();
-                foreach (var group in groupValues)
-                {
-                    var groupKey = group ?? NullFactIndexKey;
-                    if (!groupedSeeds.TryGetValue(groupKey, out var seedsForGroup))
-                    {
-                        continue;
-                    }
+                TimeSpan MeasureCompactProbe(IReadOnlyList<object?> sampleSeeds) =>
+                    MeasureElapsed(() => _ = BuildCompactSeedDepthMins(sampleSeeds));
 
-                    Dictionary<object, int>? groupMins = null;
-                    foreach (var seed in seedsForGroup)
+                TimeSpan MeasureLegacyProbe(IReadOnlyList<object?> sampleSeeds) =>
+                    MeasureElapsed(() => _ = ExecuteSeedGroupedPathAwareDepthMinFallback(closure, sampleSeeds, rootKeys, context));
+
+                var selection = ResolvePathAwareGroupedSummaryStrategy(
+                    trace,
+                    closure,
+                    _pathAwareGroupedMinStrategy,
+                    groupValues.Count,
+                    orderedUniqueSeeds,
+                    rootKeys.Count,
+                    succIndex,
+                    MeasureCompactProbe,
+                    MeasureLegacyProbe);
+                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareDepthMin", selection);
+
+                IReadOnlyDictionary<object, Dictionary<object, int>> seedDepthMins = selection.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows
+                    ? MeasurePhase(trace, closure, "build_legacy_seeded_rows", () =>
+                        (IReadOnlyDictionary<object, Dictionary<object, int>>)ExecuteSeedGroupedPathAwareDepthMinFallback(closure, orderedUniqueSeeds, rootKeys, context))
+                    : MeasurePhase(trace, closure, "build_compact_grouped", () =>
+                        (IReadOnlyDictionary<object, Dictionary<object, int>>)BuildCompactSeedDepthMins(orderedUniqueSeeds));
+
+                var rows = MeasurePhase(trace, closure, "group_reduce", () =>
+                {
+                    var builtRows = new List<object[]>();
+                    foreach (var group in groupValues)
                     {
-                        if (!seedDepthMins.TryGetValue(seed ?? NullFactIndexKey, out var rootMins))
+                        var groupKey = group ?? NullFactIndexKey;
+                        if (!groupedSeeds.TryGetValue(groupKey, out var seedsForGroup))
                         {
                             continue;
                         }
 
-                        groupMins ??= new Dictionary<object, int>();
-                        foreach (var entry in rootMins)
+                        Dictionary<object, int>? groupMins = null;
+                        foreach (var seed in seedsForGroup)
                         {
-                            if (!groupMins.TryGetValue(entry.Key, out var current) || entry.Value < current)
+                            if (!seedDepthMins.TryGetValue(seed ?? NullFactIndexKey, out var rootMins))
                             {
-                                groupMins[entry.Key] = entry.Value;
+                                continue;
                             }
+
+                            groupMins ??= new Dictionary<object, int>();
+                            foreach (var entry in rootMins)
+                            {
+                                if (!groupMins.TryGetValue(entry.Key, out var current) || entry.Value < current)
+                                {
+                                    groupMins[entry.Key] = entry.Value;
+                                }
+                            }
+                        }
+
+                        if (groupMins is null)
+                        {
+                            continue;
+                        }
+
+                        var orderedRoots = groupMins.Keys.ToList();
+                        orderedRoots.Sort((left, right) => CompareCacheSeedValues(rootValues[left], rootValues[right]));
+                        foreach (var rootKey in orderedRoots)
+                        {
+                            builtRows.Add(new object[] { group!, rootValues[rootKey]!, groupMins[rootKey] });
                         }
                     }
 
-                    if (groupMins is null)
-                    {
-                        continue;
-                    }
-
-                    var orderedRoots = groupMins.Keys.ToList();
-                    orderedRoots.Sort((left, right) => CompareCacheSeedValues(rootValues[left], rootValues[right]));
-                    foreach (var rootKey in orderedRoots)
-                    {
-                        rows.Add(new object[] { group!, rootValues[rootKey]!, groupMins[rootKey] });
-                    }
-                }
+                    return builtRows;
+                });
 
                 context.SeedGroupedPathAwareDepthMinResults[closure] = rows;
                 return rows;
@@ -8341,20 +8507,23 @@ namespace UnifyWeaver.QueryRuntime
                 var succIndex = edgeState.Successors;
                 var rootKeys = new HashSet<object>();
                 var rootValues = new Dictionary<object, object?>();
-                foreach (var row in GetFactStream(closure.RootRelation, context))
+                MeasurePhase(trace, closure, "load_roots", () =>
                 {
-                    if (row is null || row.Length == 0)
+                    foreach (var row in GetFactStream(closure.RootRelation, context))
                     {
-                        continue;
-                    }
+                        if (row is null || row.Length == 0)
+                        {
+                            continue;
+                        }
 
-                    var root = row[0];
-                    var rootKey = root ?? NullFactIndexKey;
-                    if (rootKeys.Add(rootKey))
-                    {
-                        rootValues[rootKey] = root;
+                        var root = row[0];
+                        var rootKey = root ?? NullFactIndexKey;
+                        if (rootKeys.Add(rootKey))
+                        {
+                            rootValues[rootKey] = root;
+                        }
                     }
-                }
+                });
 
                 if (rootKeys.Count == 0)
                 {
@@ -8367,29 +8536,32 @@ namespace UnifyWeaver.QueryRuntime
                 var groupValues = new List<object?>();
                 var uniqueSeeds = new HashSet<object?>();
                 var orderedUniqueSeeds = new List<object?>();
-                foreach (var row in GetFactStream(closure.SeedRelation, context))
+                MeasurePhase(trace, closure, "load_seeds", () =>
                 {
-                    if (row is null || row.Length < 2)
+                    foreach (var row in GetFactStream(closure.SeedRelation, context))
                     {
-                        continue;
-                    }
+                        if (row is null || row.Length < 2)
+                        {
+                            continue;
+                        }
 
-                    var group = row[0];
-                    var seed = row[1];
-                    var groupKey = group ?? NullFactIndexKey;
-                    if (!groupedSeeds.TryGetValue(groupKey, out var bucket))
-                    {
-                        bucket = new List<object?>();
-                        groupedSeeds[groupKey] = bucket;
-                        groupValues.Add(group);
-                    }
+                        var group = row[0];
+                        var seed = row[1];
+                        var groupKey = group ?? NullFactIndexKey;
+                        if (!groupedSeeds.TryGetValue(groupKey, out var bucket))
+                        {
+                            bucket = new List<object?>();
+                            groupedSeeds[groupKey] = bucket;
+                            groupValues.Add(group);
+                        }
 
-                    bucket.Add(seed);
-                    if (uniqueSeeds.Add(seed))
-                    {
-                        orderedUniqueSeeds.Add(seed);
+                        bucket.Add(seed);
+                        if (uniqueSeeds.Add(seed))
+                        {
+                            orderedUniqueSeeds.Add(seed);
+                        }
                     }
-                }
+                });
 
                 if (groupValues.Count == 0)
                 {
@@ -8400,88 +8572,141 @@ namespace UnifyWeaver.QueryRuntime
 
                 orderedUniqueSeeds.Sort(CompareCacheSeedValues);
                 groupValues.Sort(CompareCacheSeedValues);
-                var selectedStrategy = ResolvePathAwareGroupedSummaryStrategy(
+
+                Dictionary<object, List<object[]>>? auxIndex = null;
+                PositiveStepEvaluator? stepEvaluator = null;
+                var directSeedValue = Convert.ToDouble(closure.DirectSeedValue, CultureInfo.InvariantCulture);
+                var positiveFastPathPrepared = false;
+                var usePositiveMinFastPath = false;
+
+                void EnsurePositiveMinFastPathPrepared()
+                {
+                    if (positiveFastPathPrepared)
+                    {
+                        return;
+                    }
+
+                    positiveFastPathPrepared = true;
+                    var auxRows = MeasurePhase(trace, closure, "load_auxiliary", () => GetFactsList(closure.AuxiliaryRelation, context));
+                    auxIndex = MeasurePhase(trace, closure, "build_auxiliary_index", () => GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context));
+                    usePositiveMinFastPath = closure.MaxDepth > 0 &&
+                        TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, closure.PositiveStepProven, out stepEvaluator);
+                }
+
+                Dictionary<object, Dictionary<object, object>> BuildCompactSeedMinima(IReadOnlyList<object?> seeds)
+                {
+                    EnsurePositiveMinFastPathPrepared();
+                    if (!usePositiveMinFastPath || auxIndex is null || stepEvaluator is null)
+                    {
+                        return new Dictionary<object, Dictionary<object, object>>();
+                    }
+
+                    var fastSeedMinima = new Dictionary<object, Dictionary<object, object>>();
+                    foreach (var seed in seeds)
+                    {
+                        var mins = ComputePositiveMinRootAccumulationsForSeed(seed, succIndex, auxIndex, rootKeys, stepEvaluator, directSeedValue, closure.MaxDepth);
+                        if (mins.Count > 0)
+                        {
+                            fastSeedMinima[seed ?? NullFactIndexKey] = mins.ToDictionary(kvp => kvp.Key, kvp => (object)kvp.Value);
+                        }
+                    }
+
+                    return fastSeedMinima;
+                }
+
+                TimeSpan MeasureCompactProbe(IReadOnlyList<object?> sampleSeeds) =>
+                    MeasureElapsed(() =>
+                    {
+                        EnsurePositiveMinFastPathPrepared();
+                        if (!usePositiveMinFastPath || auxIndex is null || stepEvaluator is null)
+                        {
+                            return;
+                        }
+
+                        _ = BuildCompactSeedMinima(sampleSeeds);
+                    });
+
+                TimeSpan MeasureLegacyProbe(IReadOnlyList<object?> sampleSeeds) =>
+                    MeasureElapsed(() => _ = ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, sampleSeeds, rootKeys, context));
+
+                var selection = ResolvePathAwareGroupedSummaryStrategy(
+                    trace,
+                    closure,
                     _pathAwareGroupedMinStrategy,
                     groupValues.Count,
-                    orderedUniqueSeeds.Count,
+                    orderedUniqueSeeds,
                     rootKeys.Count,
-                    succIndex);
-                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareAccumulationMin", selectedStrategy);
+                    succIndex,
+                    MeasureCompactProbe,
+                    MeasureLegacyProbe);
+                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareAccumulationMin", selection);
 
                 IReadOnlyDictionary<object, Dictionary<object, object>> seedMinima;
-                if (selectedStrategy == PathAwareGroupedSummaryStrategy.LegacySeededRows)
+                if (selection.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows)
                 {
-                    seedMinima = ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, orderedUniqueSeeds, rootKeys, context);
+                    seedMinima = MeasurePhase(trace, closure, "build_legacy_seeded_rows", () =>
+                        (IReadOnlyDictionary<object, Dictionary<object, object>>)ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, orderedUniqueSeeds, rootKeys, context));
                 }
                 else
                 {
-                    var auxRows = GetFactsList(closure.AuxiliaryRelation, context);
-                    var auxIndex = GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context);
-                    PositiveStepEvaluator? stepEvaluator = null;
-                    var usePositiveMinFastPath = closure.MaxDepth > 0 &&
-                        TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, closure.PositiveStepProven, out stepEvaluator);
-
-                    if (usePositiveMinFastPath)
+                    EnsurePositiveMinFastPathPrepared();
+                    if (usePositiveMinFastPath && auxIndex is not null && stepEvaluator is not null)
                     {
-                        var directSeedValue = Convert.ToDouble(closure.DirectSeedValue, CultureInfo.InvariantCulture);
-                        var fastSeedMinima = new Dictionary<object, Dictionary<object, object>>();
-                        foreach (var seed in orderedUniqueSeeds)
-                        {
-                            var mins = ComputePositiveMinRootAccumulationsForSeed(seed, succIndex, auxIndex, rootKeys, stepEvaluator!, directSeedValue, closure.MaxDepth);
-                            if (mins.Count > 0)
-                            {
-                                fastSeedMinima[seed ?? NullFactIndexKey] = mins.ToDictionary(kvp => kvp.Key, kvp => (object)kvp.Value);
-                            }
-                        }
-
-                        seedMinima = fastSeedMinima;
+                        seedMinima = MeasurePhase(trace, closure, "build_compact_grouped", () =>
+                            (IReadOnlyDictionary<object, Dictionary<object, object>>)BuildCompactSeedMinima(orderedUniqueSeeds));
                     }
                     else
                     {
                         trace?.RecordStrategy(closure, "SeedGroupedPathAwareAccumulationMinLegacySeededRowsNoPositiveFastPath");
-                        seedMinima = ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, orderedUniqueSeeds, rootKeys, context);
+                        seedMinima = MeasurePhase(trace, closure, "build_legacy_seeded_rows", () =>
+                            (IReadOnlyDictionary<object, Dictionary<object, object>>)ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, orderedUniqueSeeds, rootKeys, context));
                     }
                 }
 
-                var rows = new List<object[]>();
-                foreach (var group in groupValues)
+                var rows = MeasurePhase(trace, closure, "group_reduce", () =>
                 {
-                    var groupKey = group ?? NullFactIndexKey;
-                    if (!groupedSeeds.TryGetValue(groupKey, out var seedsForGroup))
+                    var builtRows = new List<object[]>();
+                    foreach (var group in groupValues)
                     {
-                        continue;
-                    }
-
-                    Dictionary<object, object>? groupMins = null;
-                    foreach (var seed in seedsForGroup)
-                    {
-                        if (!seedMinima.TryGetValue(seed ?? NullFactIndexKey, out var rootMins))
+                        var groupKey = group ?? NullFactIndexKey;
+                        if (!groupedSeeds.TryGetValue(groupKey, out var seedsForGroup))
                         {
                             continue;
                         }
 
-                        groupMins ??= new Dictionary<object, object>();
-                        foreach (var entry in rootMins)
+                        Dictionary<object, object>? groupMins = null;
+                        foreach (var seed in seedsForGroup)
                         {
-                            if (!groupMins.TryGetValue(entry.Key, out var current) || CompareValues(entry.Value, current) < 0)
+                            if (!seedMinima.TryGetValue(seed ?? NullFactIndexKey, out var rootMins))
                             {
-                                groupMins[entry.Key] = entry.Value;
+                                continue;
                             }
+
+                            groupMins ??= new Dictionary<object, object>();
+                            foreach (var entry in rootMins)
+                            {
+                                if (!groupMins.TryGetValue(entry.Key, out var current) || CompareValues(entry.Value, current) < 0)
+                                {
+                                    groupMins[entry.Key] = entry.Value;
+                                }
+                            }
+                        }
+
+                        if (groupMins is null)
+                        {
+                            continue;
+                        }
+
+                        var orderedRoots = groupMins.Keys.ToList();
+                        orderedRoots.Sort((left, right) => CompareCacheSeedValues(rootValues[left], rootValues[right]));
+                        foreach (var rootKey in orderedRoots)
+                        {
+                            builtRows.Add(new object[] { group!, rootValues[rootKey]!, groupMins[rootKey] });
                         }
                     }
 
-                    if (groupMins is null)
-                    {
-                        continue;
-                    }
-
-                    var orderedRoots = groupMins.Keys.ToList();
-                    orderedRoots.Sort((left, right) => CompareCacheSeedValues(rootValues[left], rootValues[right]));
-                    foreach (var rootKey in orderedRoots)
-                    {
-                        rows.Add(new object[] { group!, rootValues[rootKey]!, groupMins[rootKey] });
-                    }
-                }
+                    return builtRows;
+                });
 
                 context.SeedGroupedPathAwareAccumulationMinResults[closure] = rows;
                 return rows;


### PR DESCRIPTION
  ## Summary

  This PR extends the C# query runtime’s grouped-summary retention policy
  from structural heuristics to measured cost buckets.

  Previously, `Auto` selection for grouped summaries was driven mainly by
  shape estimates such as:

  - group count
  - seed count
  - root count
  - estimated path-aware graph size

  That was useful, but still indirect.

  This PR adds measured cost instrumentation at the grouped-summary
  retention decision points, exposes those measurements through benchmark
  trace output, and keeps the existing compact grouped vs legacy seeded-row
  fallback structure intact.

  ## What Changed

  ### Runtime: measured grouped-summary selection

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  The shared grouped-summary policy now:

  - records measured phase buckets around retention decisions
  - supports bounded probe timing in ambiguous cases
  - still honors explicit per-family overrides

  Added/measured buckets include phases such as:

  - `load_roots`
  - `load_seeds`
  - `strategy_select`
  - `strategy_probe_compact_grouped`
  - `strategy_probe_legacy_seeded_rows`
  - `build_compact_grouped`
  - `build_legacy_seeded_rows`
  - `group_reduce`

  The implementation keeps the public override knobs unchanged:

  - `QueryExecutorOptions.PathAwareGroupedMinStrategy`
  - `QueryExecutorOptions.PathAwareWeightSumStrategy`

  ### Runtime: selection metadata

  The grouped-summary selector now records not just the selected retained
  form, but also how it was selected:

  - `ConfiguredOverride`
  - `Structural`
  - `MeasuredProbe`

  This makes the retention-policy decision easier to inspect in traces.

  ### Generator: trace output for measured buckets

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The generated C# query benchmark programs for:

  - `shortest_path_to_root`
  - `weighted_shortest_path`
  - `effective_distance`
  - `category_influence`

  now print grouped-summary phase timings when:

  - `UNIFYWEAVER_BENCH_TRACE=1`

  They already exposed selected strategies; now they also expose the
  measured cost buckets behind those decisions.

  ### Docs

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`
  - `examples/benchmark/README.md`

  These docs now reflect that Stage 4 is no longer just structural
  heuristics. The grouped-summary policy now records measured cost buckets
  and only runs bounded probes when the structural signal is ambiguous.

  ## Why This Matters

  This PR is the next step after:

  - adding compact grouped retained forms
  - adding cost-guided selection
  - unifying grouped-summary policy internally

  The remaining gap was that `Auto` was still largely estimating cost
  instead of observing it.

  This change makes the retention policy more evidence-based without
  jumping all the way to a full planner.

  It also keeps the benchmark story cleaner:

  - retained-form selection is explicit
  - the chosen strategy is visible
  - the measured buckets behind that choice are visible too

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_category_influence_cross_target.py
  ```
  Full benchmark reruns passed for:
  ```
  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,rust-dfs,go-dfs \
      --repetitions 1
  ```
  All outputs matched.

  ## Representative Results

  ### Shortest path

  - 300: csharp-query 0.103s
  - 10k: csharp-query 0.191s

  ### Weighted shortest path

  - 300: csharp-query 0.151s
  - 10k: csharp-query 0.303s

  ### Effective distance

  - 300: csharp-query 0.218s
  - 10k: csharp-query 0.868s

  ### Category influence

  - 300: csharp-query 0.410s
  - 10k: csharp-query 0.762s

  ## Interpretation

  On the current benchmark surface, Auto still usually selects the
  compact grouped path structurally, which is a good sign: the retained
  form is clearly correct for these workloads.

  But now the runtime can also:

  - expose measured retention buckets
  - run bounded probes in closer cases
  - evolve the heuristic using observed cost instead of structure alone

  So this PR is mainly about making retention selection measurable and
  refinable, not about changing benchmark semantics.

  ## Scope

  This PR adds:

  - measured grouped-summary cost buckets
  - bounded probe-based selection support
  - trace visibility into retention decisions
  - doc updates describing the stronger Stage 4 policy

  It does not yet add:

  - a universal cost-based planner across all operator families
  - measured-selection logic for every retention strategy in the runtime

  ## Follow-Up

  Likely next work:

  - use the new measured buckets to refine Auto beyond the current
    structural thresholds
  - extend measured retention selection beyond grouped summaries
  - keep making retention-policy choices explicit, traceable, and grounded
    in observed cost