### PR TITLE
feat: cross-target consistency validation for WAM hybrid backends

### DIFF
--- a/tests/test_wam_cross_target_consistency.pl
+++ b/tests/test_wam_cross_target_consistency.pl
@@ -1,0 +1,282 @@
+:- encoding(utf8).
+% test_wam_cross_target_consistency.pl
+%
+% Validates that all hybrid WAM targets share consistent instruction sets,
+% register ABIs, and builtin op ID mappings. Catches drift between targets.
+
+:- use_module(library(plunit)).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../src/unifyweaver/targets/wam_ilasm_target').
+:- use_module('../src/unifyweaver/bindings/llvm_wam_bindings').
+:- use_module('../src/unifyweaver/bindings/cil_wam_bindings').
+
+:- begin_tests(wam_cross_target_consistency).
+
+% ============================================================================
+% Register ABI: A1→0, X1→16 must match across LLVM and ILAsm
+% ============================================================================
+
+test(register_abi_a1_consistent) :-
+    reg_name_to_index('A1', LLVMIdx),
+    cil_reg_name_to_index('A1', CILIdx),
+    assertion(LLVMIdx == CILIdx),
+    assertion(LLVMIdx == 0).
+
+test(register_abi_a16_consistent) :-
+    reg_name_to_index('A16', LLVMIdx),
+    cil_reg_name_to_index('A16', CILIdx),
+    assertion(LLVMIdx == CILIdx),
+    assertion(LLVMIdx == 15).
+
+test(register_abi_x1_consistent) :-
+    reg_name_to_index('X1', LLVMIdx),
+    cil_reg_name_to_index('X1', CILIdx),
+    assertion(LLVMIdx == CILIdx),
+    assertion(LLVMIdx == 16).
+
+test(register_abi_x16_consistent) :-
+    reg_name_to_index('X16', LLVMIdx),
+    cil_reg_name_to_index('X16', CILIdx),
+    assertion(LLVMIdx == CILIdx),
+    assertion(LLVMIdx == 31).
+
+test(register_abi_full_range) :-
+    % Verify all 32 register slots are consistent
+    numlist(1, 16, AIndices),
+    forall(member(I, AIndices), (
+        atom_concat('A', I, RegName),
+        reg_name_to_index(RegName, LIdx),
+        cil_reg_name_to_index(RegName, CIdx),
+        assertion(LIdx == CIdx)
+    )),
+    numlist(1, 16, XIndices),
+    forall(member(I, XIndices), (
+        atom_concat('X', I, RegName),
+        reg_name_to_index(RegName, LIdx),
+        cil_reg_name_to_index(RegName, CIdx),
+        assertion(LIdx == CIdx)
+    )).
+
+% ============================================================================
+% Builtin op IDs: must match between LLVM and ILAsm
+% ============================================================================
+
+test(builtin_op_ids_consistent) :-
+    % All builtin ops that have IDs in both targets
+    Builtins = [
+        'is/2', '>/2', '</2', '>=/2', '=</2', '=:=/2', '=\\=/2',
+        '==/2', 'true/0', 'fail/0', '!/0'
+    ],
+    forall(member(Op, Builtins), (
+        builtin_op_to_id(Op, LLVMId),
+        builtin_op_to_cil_id(Op, CILId),
+        assertion(LLVMId == CILId)
+    )).
+
+test(builtin_op_is_id_zero) :-
+    builtin_op_to_id('is/2', LLVMId),
+    builtin_op_to_cil_id('is/2', CILId),
+    assertion(LLVMId == 0),
+    assertion(CILId == 0).
+
+test(builtin_op_cut_id_ten) :-
+    builtin_op_to_id('!/0', LLVMId),
+    builtin_op_to_cil_id('!/0', CILId),
+    assertion(LLVMId == 10),
+    assertion(CILId == 10).
+
+test(builtin_op_unknown_consistent) :-
+    builtin_op_to_id('nonexistent/7', LLVMId),
+    builtin_op_to_cil_id('nonexistent/7', CILId),
+    assertion(LLVMId == 99),
+    assertion(CILId == 99).
+
+% ============================================================================
+% Instruction set: all targets must have the same 25 instruction cases
+% ============================================================================
+
+% The canonical instruction set (by name, alphabetical order)
+canonical_instruction_set(InstrSet) :-
+    InstrSet = [
+        allocate, builtin_call, call, deallocate, execute,
+        get_constant, get_list, get_structure, get_value, get_variable,
+        proceed, put_constant, put_list, put_structure, put_value, put_variable,
+        retry_me_else, set_constant, set_value, set_variable,
+        trust_me, try_me_else,
+        unify_constant, unify_value, unify_variable
+    ].
+
+test(llvm_step_has_all_instructions) :-
+    compile_step_wam_to_llvm([], StepCode),
+    canonical_instruction_set(Instrs),
+    forall(member(Instr, Instrs), (
+        atom_string(Instr, InstrStr),
+        (   sub_atom(StepCode, _, _, _, InstrStr)
+        ->  true
+        ;   format(user_error, 'LLVM missing instruction: ~w~n', [Instr]),
+            fail
+        )
+    )).
+
+test(ilasm_step_has_all_instructions) :-
+    compile_step_wam_to_cil([], StepCode),
+    canonical_instruction_set(Instrs),
+    forall(member(Instr, Instrs), (
+        atom_string(Instr, InstrStr),
+        % ILAsm uses L_ prefix for labels
+        format(atom(Label), 'L_~w', [InstrStr]),
+        (   sub_atom(StepCode, _, _, _, Label)
+        ->  true
+        ;   format(user_error, 'ILAsm missing instruction: ~w~n', [Instr]),
+            fail
+        )
+    )).
+
+% ============================================================================
+% Instruction tag numbering: LLVM and ILAsm must use same tags
+% ============================================================================
+
+% Canonical tag mapping
+canonical_instruction_tag(get_constant, 0).
+canonical_instruction_tag(get_variable, 1).
+canonical_instruction_tag(get_value, 2).
+canonical_instruction_tag(get_structure, 3).
+canonical_instruction_tag(get_list, 4).
+canonical_instruction_tag(unify_variable, 5).
+canonical_instruction_tag(unify_value, 6).
+canonical_instruction_tag(unify_constant, 7).
+canonical_instruction_tag(put_constant, 8).
+canonical_instruction_tag(put_variable, 9).
+canonical_instruction_tag(put_value, 10).
+canonical_instruction_tag(put_structure, 11).
+canonical_instruction_tag(put_list, 12).
+canonical_instruction_tag(set_variable, 13).
+canonical_instruction_tag(set_value, 14).
+canonical_instruction_tag(set_constant, 15).
+canonical_instruction_tag(allocate, 16).
+canonical_instruction_tag(deallocate, 17).
+canonical_instruction_tag(call, 18).
+canonical_instruction_tag(execute, 19).
+canonical_instruction_tag(proceed, 20).
+canonical_instruction_tag(builtin_call, 21).
+canonical_instruction_tag(try_me_else, 22).
+canonical_instruction_tag(retry_me_else, 23).
+canonical_instruction_tag(trust_me, 24).
+
+test(llvm_instruction_tags_in_switch) :-
+    compile_step_wam_to_llvm([], StepCode),
+    % Verify key tags appear in the switch statement
+    forall(canonical_instruction_tag(_, Tag), (
+        format(atom(TagStr), 'i32 ~w, label', [Tag]),
+        (   sub_atom(StepCode, _, _, _, TagStr)
+        ->  true
+        ;   format(user_error, 'LLVM missing tag: ~w~n', [Tag]),
+            fail
+        )
+    )).
+
+test(ilasm_instruction_tags_in_switch) :-
+    compile_step_wam_to_cil([], StepCode),
+    % ILAsm switch lists labels in order — the switch itself covers tags 0-24
+    assertion(sub_atom(StepCode, _, _, _, 'switch (')),
+    assertion(sub_atom(StepCode, _, _, _, 'L_get_constant')),
+    assertion(sub_atom(StepCode, _, _, _, 'L_trust_me')).
+
+% ============================================================================
+% Instruction lowering: LLVM and ILAsm produce consistent literals
+% ============================================================================
+
+test(allocate_literal_consistent) :-
+    wam_instruction_to_llvm_literal(allocate, LLVMLit),
+    wam_instruction_to_cil_literal(allocate, CILLit),
+    % Both should encode tag 16
+    assertion(sub_atom(LLVMLit, _, _, _, '16')),
+    assertion(sub_atom(CILLit, _, _, _, '16')).
+
+test(proceed_literal_consistent) :-
+    wam_instruction_to_llvm_literal(proceed, LLVMLit),
+    wam_instruction_to_cil_literal(proceed, CILLit),
+    assertion(sub_atom(LLVMLit, _, _, _, '20')),
+    assertion(sub_atom(CILLit, _, _, _, '20')).
+
+test(get_variable_literal_tag_consistent) :-
+    wam_instruction_to_llvm_literal(get_variable('X1', 'A1'), LLVMLit),
+    wam_instruction_to_cil_literal(get_variable('X1', 'A1'), CILLit),
+    % Both should have tag 1, X1=16, A1=0
+    assertion(sub_atom(LLVMLit, _, _, _, '1')),
+    assertion(sub_atom(LLVMLit, _, _, _, '16')),
+    assertion(sub_atom(CILLit, _, _, _, '1')),
+    assertion(sub_atom(CILLit, _, _, _, '16')).
+
+% ============================================================================
+% Type mappings: both targets map the same Prolog types
+% ============================================================================
+
+test(type_map_keys_consistent) :-
+    CoreTypes = [value, integer, float, bool, atom, string, list, assoc],
+    forall(member(T, CoreTypes), (
+        (   llvm_wam_type_map(T, _)
+        ->  true
+        ;   format(user_error, 'LLVM missing type map for: ~w~n', [T]), fail
+        ),
+        (   cil_wam_type_map(T, _)
+        ->  true
+        ;   format(user_error, 'CIL missing type map for: ~w~n', [T]), fail
+        )
+    )).
+
+% ============================================================================
+% Binding coverage: both targets have bindings for core operations
+% ============================================================================
+
+test(core_bindings_exist_in_both) :-
+    CoreOps = [
+        get_assoc/3, put_assoc/4, atom/1, integer/1, var/1,
+        '+'/3, '-'/3, '*'/3, '=='/2
+    ],
+    forall(member(Op, CoreOps), (
+        (   llvm_wam_binding(Op, _, _, _, _)
+        ->  true
+        ;   format(user_error, 'LLVM missing binding: ~w~n', [Op]), fail
+        ),
+        (   cil_wam_binding(Op, _, _, _, _)
+        ->  true
+        ;   format(user_error, 'CIL missing binding: ~w~n', [Op]), fail
+        )
+    )).
+
+% ============================================================================
+% Step function structure: both targets have read/write mode dispatch
+% ============================================================================
+
+test(llvm_has_read_write_mode) :-
+    compile_step_wam_to_llvm([], Code),
+    assertion(sub_atom(Code, _, _, _, 'wam_peek_stack_type')),
+    assertion(sub_atom(Code, _, _, _, 'wam_unify_ctx_next')),
+    assertion(sub_atom(Code, _, _, _, 'wam_write_ctx_dec')).
+
+test(ilasm_has_read_write_mode) :-
+    compile_step_wam_to_cil([], Code),
+    assertion(sub_atom(Code, _, _, _, 'PeekStackType')),
+    assertion(sub_atom(Code, _, _, _, 'UnifyCtxNext')),
+    assertion(sub_atom(Code, _, _, _, 'WriteCtxDec')).
+
+% ============================================================================
+% Helper functions: both targets have the same set
+% ============================================================================
+
+test(llvm_has_all_helpers) :-
+    compile_wam_helpers_to_llvm([], Code),
+    assertion(sub_atom(Code, _, _, _, 'backtrack')),
+    assertion(sub_atom(Code, _, _, _, 'unwind_trail')),
+    assertion(sub_atom(Code, _, _, _, 'execute_builtin')),
+    assertion(sub_atom(Code, _, _, _, 'eval_arith')).
+
+test(ilasm_has_all_helpers) :-
+    compile_wam_helpers_to_cil([], Code),
+    assertion(sub_atom(Code, _, _, _, 'backtrack')),
+    assertion(sub_atom(Code, _, _, _, 'unwind_trail')),
+    assertion(sub_atom(Code, _, _, _, 'execute_builtin')),
+    assertion(sub_atom(Code, _, _, _, 'eval_arith')).
+
+:- end_tests(wam_cross_target_consistency).

--- a/tests/test_wam_cross_target_consistency.pl
+++ b/tests/test_wam_cross_target_consistency.pl
@@ -44,14 +44,14 @@ test(register_abi_full_range) :-
     % Verify all 32 register slots are consistent
     numlist(1, 16, AIndices),
     forall(member(I, AIndices), (
-        atom_concat('A', I, RegName),
+        format(atom(RegName), 'A~w', [I]),
         reg_name_to_index(RegName, LIdx),
         cil_reg_name_to_index(RegName, CIdx),
         assertion(LIdx == CIdx)
     )),
     numlist(1, 16, XIndices),
     forall(member(I, XIndices), (
-        atom_concat('X', I, RegName),
+        format(atom(RegName), 'X~w', [I]),
         reg_name_to_index(RegName, LIdx),
         cil_reg_name_to_index(RegName, CIdx),
         assertion(LIdx == CIdx)
@@ -165,22 +165,31 @@ canonical_instruction_tag(trust_me, 24).
 
 test(llvm_instruction_tags_in_switch) :-
     compile_step_wam_to_llvm([], StepCode),
-    % Verify key tags appear in the switch statement
-    forall(canonical_instruction_tag(_, Tag), (
-        format(atom(TagStr), 'i32 ~w, label', [Tag]),
+    % Verify all 25 tags appear in the switch with anchored pattern "i32 N, label %name"
+    forall(canonical_instruction_tag(Instr, Tag), (
+        format(atom(TagStr), 'i32 ~w, label %', [Tag]),
         (   sub_atom(StepCode, _, _, _, TagStr)
         ->  true
-        ;   format(user_error, 'LLVM missing tag: ~w~n', [Tag]),
+        ;   format(user_error, 'LLVM missing tag ~w for ~w~n', [Tag, Instr]),
             fail
         )
     )).
 
 test(ilasm_instruction_tags_in_switch) :-
     compile_step_wam_to_cil([], StepCode),
-    % ILAsm switch lists labels in order — the switch itself covers tags 0-24
+    % Verify all 25 instructions have labeled cases in the switch
+    % ILAsm switch lists labels positionally (index = tag), so we verify
+    % each instruction's L_ label AND the switch keyword
     assertion(sub_atom(StepCode, _, _, _, 'switch (')),
-    assertion(sub_atom(StepCode, _, _, _, 'L_get_constant')),
-    assertion(sub_atom(StepCode, _, _, _, 'L_trust_me')).
+    forall(canonical_instruction_tag(Instr, _), (
+        atom_string(Instr, InstrStr),
+        format(atom(Label), 'L_~w:', [InstrStr]),
+        (   sub_atom(StepCode, _, _, _, Label)
+        ->  true
+        ;   format(user_error, 'ILAsm missing label for ~w~n', [Instr]),
+            fail
+        )
+    )).
 
 % ============================================================================
 % Instruction lowering: LLVM and ILAsm produce consistent literals
@@ -189,24 +198,22 @@ test(ilasm_instruction_tags_in_switch) :-
 test(allocate_literal_consistent) :-
     wam_instruction_to_llvm_literal(allocate, LLVMLit),
     wam_instruction_to_cil_literal(allocate, CILLit),
-    % Both should encode tag 16
-    assertion(sub_atom(LLVMLit, _, _, _, '16')),
-    assertion(sub_atom(CILLit, _, _, _, '16')).
+    % Both should encode tag 16 exactly
+    assertion(LLVMLit == '{ i32 16, i64 0, i64 0 }'),
+    assertion(CILLit == 'new Instruction(16, 0L, 0L)').
 
 test(proceed_literal_consistent) :-
     wam_instruction_to_llvm_literal(proceed, LLVMLit),
     wam_instruction_to_cil_literal(proceed, CILLit),
-    assertion(sub_atom(LLVMLit, _, _, _, '20')),
-    assertion(sub_atom(CILLit, _, _, _, '20')).
+    assertion(LLVMLit == '{ i32 20, i64 0, i64 0 }'),
+    assertion(CILLit == 'new Instruction(20, 0L, 0L)').
 
 test(get_variable_literal_tag_consistent) :-
     wam_instruction_to_llvm_literal(get_variable('X1', 'A1'), LLVMLit),
     wam_instruction_to_cil_literal(get_variable('X1', 'A1'), CILLit),
-    % Both should have tag 1, X1=16, A1=0
-    assertion(sub_atom(LLVMLit, _, _, _, '1')),
-    assertion(sub_atom(LLVMLit, _, _, _, '16')),
-    assertion(sub_atom(CILLit, _, _, _, '1')),
-    assertion(sub_atom(CILLit, _, _, _, '16')).
+    % Both should have tag=1, op1=16 (X1), op2=0 (A1)
+    assertion(LLVMLit == '{ i32 1, i64 16, i64 0 }'),
+    assertion(CILLit == 'new Instruction(1, 16L, 0L)').
 
 % ============================================================================
 % Type mappings: both targets map the same Prolog types


### PR DESCRIPTION
## Summary

- Adds a 22-test harness verifying that the LLVM and ILAsm hybrid WAM targets share identical instruction sets, register ABIs, builtin op IDs, type mappings, and structural patterns
- Catches drift between backends as they evolve in parallel
- Also confirmed JVM and Elixir targets have full compound term support with read/write mode (no code changes needed)

## What's tested (22 tests across 8 categories)

| Category | Tests | What's verified |
|----------|-------|-----------------|
| Register ABI | 5 | A1→0, A16→15, X1→16, X16→31 identical; full 32-slot sweep |
| Builtin op IDs | 4 | All 11 core builtins have equal IDs; is/2=0, !/0=10, unknown=99 |
| Instruction set | 2 | All 25 canonical instructions present in both step functions |
| Instruction tags | 2 | Tags 0-24 in LLVM switch (anchored `i32 N, label %`); all `L_<instr>:` labels in ILAsm |
| Instruction lowering | 3 | Exact literal assertions for allocate(16), proceed(20), get_variable(1, X1=16, A1=0) |
| Type mappings | 1 | 8 core types mapped in both targets |
| Binding coverage | 1 | 9 core operations have bindings in both targets |
| Step/helper structure | 4 | Read/write mode dispatch + backtrack/unwind_trail/execute_builtin/eval_arith in both |

## Canonical reference

The test file includes a `canonical_instruction_tag/2` fact table (25 entries) that serves as the authoritative tag mapping document for all backends using integer dispatch:

```
get_constant=0, get_variable=1, ..., trust_me=24
```

## Changes (1 file, +289 lines)

| File | Change |
|------|--------|
| `tests/test_wam_cross_target_consistency.pl` | **New** — 22 cross-target consistency tests |

## Review history

Two rounds of review, all critical items resolved:

1. **Fragile sub_atom tag checks** → anchored patterns (`i32 N, label %`) and exact literal assertions
2. **Loose get_variable check** → full literal string comparison instead of substring
3. **ILAsm tag test weaker than LLVM** → now uses `forall` over all 25 instructions
4. **atom_concat portability** → `format(atom(...))` for cross-Prolog compatibility

## JVM/Elixir compound term parity (item 2 from roadmap)

Confirmed via exploration — no code changes needed:
- **JVM**: All 10 compound instructions implemented with Java method-based dispatch
- **Elixir**: All 10 compound instructions with explicit `{:unify_ctx, args}` / `{:write_ctx, n}` stack-tagged read/write mode
- Both existing test suites pass

## Test plan

- [x] 22 cross-target consistency tests pass
- [x] 60 LLVM unit tests pass
- [x] 45 ILAsm unit tests pass
- [x] JVM tests pass
- [x] Elixir tests pass
