### PR TITLE
feat(wam): binding table, builtins, cut barrier, and O(log n) dispatch in Prolog WAM runtime

### DIFF
--- a/src/unifyweaver/runtime/wam_runtime.pl
+++ b/src/unifyweaver/runtime/wam_runtime.pl
@@ -34,7 +34,46 @@ prepare_code(Raw, Instructions, Labels) :-
     ;   atomic_list_concat(Lines, '\n', Raw)
     ),
     empty_assoc(L0),
-    parse_lines(Lines, 1, Instructions, L0, Labels).
+    parse_lines(Lines, 1, RawInstructions, L0, Labels),
+    % Post-process: convert switch_on_constant to indexed form for O(log n) dispatch
+    maplist(index_switch_instr, RawInstructions, IndexedInstructions),
+    % Convert list to assoc for O(log n) instruction fetch
+    list_to_code_assoc(IndexedInstructions, 1, Instructions).
+
+%% list_to_code_assoc(+InstrList, +StartPC, -CodeAssoc)
+%  Converts instruction list to a PC → Instruction assoc for O(log n) fetch.
+list_to_code_assoc(InstrList, StartPC, CodeAssoc) :-
+    empty_assoc(A0),
+    foldl(add_instr_to_assoc, InstrList, StartPC-A0, _-CodeAssoc).
+
+add_instr_to_assoc(Instr, PC-AIn, NPC-AOut) :-
+    put_assoc(PC, AIn, Instr, AOut),
+    NPC is PC + 1.
+
+%% index_switch_instr(+RawInstr, -IndexedInstr)
+%  Converts switch_on_constant(K1:L1, K2:L2, ...) to switch_on_constant_index(Assoc).
+index_switch_instr(Instr, Indexed) :-
+    (   Instr =.. [Op|Args],
+        (Op == switch_on_constant ; Op == switch_on_constant_a2),
+        (Args = [Entries], is_list(Entries) -> true ; Entries = Args),
+        Entries \= []
+    ->  entries_to_assoc(Entries, Assoc),
+        Indexed = switch_on_constant_index(Assoc)
+    ;   Indexed = Instr
+    ).
+
+entries_to_assoc(Entries, Assoc) :-
+    empty_assoc(A0),
+    foldl(add_entry, Entries, A0, Assoc).
+
+add_entry(Entry, AIn, AOut) :-
+    (   once(sub_atom(Entry, Before, 1, After, ':'))
+    ->  sub_atom(Entry, 0, Before, _, KeyStr),
+        sub_atom(Entry, _, After, 0, LabelStr),
+        (atom_number(KeyStr, Key) -> true ; Key = KeyStr),
+        put_assoc(Key, AIn, LabelStr, AOut)
+    ;   AOut = AIn
+    ).
 
 parse_lines([], _, [], L, L).
 parse_lines([Line|Rest], PC, Instrs, LIn, LOut) :-
@@ -124,7 +163,7 @@ run_loop(S, Sf) :-
     ).
 
 fetch_instr(wam_state(PC, _, _, _, _, _, _, Code, _), Instr) :-
-    integer(PC), nth1(PC, Code, Instr).
+    integer(PC), get_assoc(PC, Code, Instr).
 
 %% backtrack(+StateIn, -StateOut)
 backtrack(wam_state(_, _, _, _, Trail, _, [cp(NextPC, R, S, H, CP, SavedTrail, BuiltinState, SavedB)|CPs], Code, L),
@@ -449,12 +488,26 @@ step_wam(retry_me_else(NextL), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_
     ),
     NPC is PC + 1.
 
-%% Indexing instructions — handle both list and variadic forms
+%% Indexing instructions — O(log n) dispatch via assoc lookup.
+%  switch_on_constant entries are pre-parsed into assoc during prepare_code.
+%  Format: switch_on_constant_index(Assoc) where Assoc maps Key → Label.
+step_wam(switch_on_constant_index(IndexAssoc), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, S, H, T, CP, CPS, Code, L)) :-
+    get_assoc('A1', R, Val0),
+    wam_deref(Val0, Val),
+    (   \+ is_unbound_var(Val),
+        get_assoc(Val, IndexAssoc, LabelStr),
+        LabelStr \== default,
+        get_assoc(LabelStr, L, TargetPC)
+    ->  NPC = TargetPC
+    ;   NPC is PC + 1
+    ).
+
+%% Legacy switch_on_constant with flat list (fallback for unprocessed code)
 step_wam(Instr, wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, S, H, T, CP, CPS, Code, L)) :-
     Instr =.. [Op|Args],
     (Op == switch_on_constant ; Op == switch_on_structure ; Op == switch_on_constant_a2),
     (Args = [Entries], is_list(Entries) -> true ; Entries = Args),
-    (get_assoc('A1', R, Val), \+ is_unbound_var(Val), lookup_index(Val, Entries, L, TargetPC) -> NPC = TargetPC ; NPC is PC + 1).
+    (get_assoc('A1', R, Val0), wam_deref(Val0, Val), \+ is_unbound_var(Val), lookup_index(Val, Entries, L, TargetPC) -> NPC = TargetPC ; NPC is PC + 1).
 
 lookup_index(Val, [Entry|Rest], Labels, TargetPC) :-
     (once(sub_atom(Entry, Before, 1, After, ':')) ->

--- a/src/unifyweaver/runtime/wam_runtime.pl
+++ b/src/unifyweaver/runtime/wam_runtime.pl
@@ -423,10 +423,12 @@ step_wam(execute(P), wam_state(_, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, 
 
 step_wam(proceed, wam_state(_, R, S, H, T, CP, CPS, Code, L), wam_state(CP, R, S, H, T, halt, CPS, Code, L)).
 
-step_wam(allocate, wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, [env(CP, YRegs)|S], H, T, CP, CPS, Code, L)) :-
-    empty_assoc(YRegs), NPC is PC + 1.
+step_wam(allocate, wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, [env(CP, YRegs, CutBarrier)|S], H, T, CP, CPS, Code, L)) :-
+    empty_assoc(YRegs),
+    length(CPS, CutBarrier),  % save CP stack depth as cut barrier
+    NPC is PC + 1.
 
-step_wam(deallocate, wam_state(PC, R, [env(OldCP, _)|S], H, T, _, CPS, Code, L), wam_state(NPC, R, S, H, T, OldCP, CPS, Code, L)) :-
+step_wam(deallocate, wam_state(PC, R, [env(OldCP, _, _)|S], H, T, _, CPS, Code, L), wam_state(NPC, R, S, H, T, OldCP, CPS, Code, L)) :-
     NPC is PC + 1.
 
 step_wam(try_me_else(NextL), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, S, H, T, CP, [cp(NextPC, R, S, H, CP, T, _, SavedB)|CPS], Code, L)) :-
@@ -461,11 +463,19 @@ lookup_index(Val, [Entry|Rest], Labels, TargetPC) :-
         (Key == Val -> (LabelStr == 'default' -> fail ; get_assoc(LabelStr, Labels, TargetPC)) ; lookup_index(Val, Rest, Labels, TargetPC))
     ; fail).
 
-%% !/0 — cut: clear all choice points.
-%  TODO: proper cut barrier (only remove CPs above the barrier).
-step_wam(builtin_call('!/0', 0), wam_state(PC, R, S, H, T, CP, _CPS, Code, L),
-         wam_state(NPC, R, S, H, T, CP, [], Code, L)) :-
-    NPC is PC + 1.
+%% !/0 — cut: truncate choice points to the cut barrier.
+%  The cut barrier is saved at Allocate time in the env frame.
+step_wam(builtin_call('!/0', 0), wam_state(PC, R, S, H, T, CP, CPS, Code, L),
+         wam_state(NPC, R, S, H, T, CP, NCPS, Code, L)) :-
+    NPC is PC + 1,
+    % Find the cut barrier from the topmost env frame
+    (   member(env(_, _, CutBarrier), S)
+    ->  length(CPS, CPLen),
+        KeepN is min(CutBarrier, CPLen),
+        length(NCPS, KeepN),
+        append(NCPS, _, CPS)
+    ;   NCPS = []  % no env frame — clear all (fallback)
+    ).
 
 %% length/2 — measure list length, bind to A2.
 step_wam(builtin_call('length/2', 2), wam_state(PC, R, S, H, T, CP, CPS, Code, L),
@@ -716,14 +726,14 @@ get_reg_val(Reg, R, S, Val) :-
 
 get_reg(Reg, _R, Stack, Val) :-
     is_y_reg(Reg), !,
-    member(env(_, YRegs), Stack), !,
+    member(env(_, YRegs, _), Stack), !,
     get_assoc(Reg, YRegs, Val).
 get_reg(Reg, R, _, Val) :-
     get_assoc(Reg, R, Val).
 
 put_reg(Reg, Val, R, R, Stack, NewStack) :- is_y_reg(Reg), !, update_top_env(Stack, Reg, Val, NewStack).
 put_reg(Reg, Val, R, NR, Stack, Stack) :- put_assoc(Reg, R, Val, NR).
-update_top_env([env(CP, YRegs)|Rest], Reg, Val, [env(CP, NewYRegs)|Rest]) :- put_assoc(Reg, YRegs, Val, NewYRegs).
+update_top_env([env(CP, YRegs, CB)|Rest], Reg, Val, [env(CP, NewYRegs, CB)|Rest]) :- put_assoc(Reg, YRegs, Val, NewYRegs).
 
 get_arity(FN, Arity) :-
     (   once(sub_atom(FN, _, 1, After, '/'))


### PR DESCRIPTION
  ## Summary

  - Add binding table to Prolog WAM runtime for cross-register variable propagation
  - Implement \+/1 (negation-as-failure), length/2, !/0 builtins
  - Proper cut barrier using env frame depth (not clear-all)
  - O(log n) instruction fetch (assoc) and switch_on_constant dispatch (pre-indexed assoc)

  ## Motivation

  The shared Prolog WAM runtime (`wam_runtime.pl`) had three fundamental gaps:
  1. No binding propagation — `put_variable Y2, A1` shared a variable name between registers, but `get_constant` binding
  A1 didn't propagate to Y2
  2. Missing builtins — `\+/1` threw `not_supported(negation_as_failure)`, `length/2` and `!/0` were absent
  3. O(n) data structures — instruction fetch via `nth1` on a list, switch_on_constant via linear string scanning

  These gaps affected ALL WAM targets (Rust, Haskell, Elixir, etc.) since they all use `wam_target.pl` for WAM
  compilation.

  ## Changes

  ### Binding table (`nb_setval/nb_getval`)
  - `wam_bind(VarName, Value)`: record binding in global table
  - `wam_deref(Val, Derefed)`: follow binding chains
  - `wam_save_bindings/wam_restore_bindings`: snapshot for choice points
  - `get_reg_val` dereferences through bindings
  - `get_constant`, `is/2`, `length/2` call `wam_bind` when binding unbound vars
  - `extract_bindings` checks binding table first (before register value)
  - `deref_wam` checks binding table before register lookup
  - Choice points save/restore bindings (8th field of `cp/8`)

  ### Builtins
  - `\+/1`: fast path for `member/2` (direct list scan), general path via goal reconstruction from heap structures
  - `length/2`: measure list, bind result
  - `!/0`: truncate CPs to cut barrier (env frame depth, not clear-all)

  ### Performance
  - `prepare_code` converts instruction list to PC → Instruction assoc (O(log n) fetch)
  - `switch_on_constant` entries pre-parsed into assoc (O(log n) dispatch)

  ### Architecture note
  The Prolog WAM emulator is an interpreter-on-interpreter (~100x overhead per step). It's useful for correctness testing
  on small datasets but not for benchmarking. The target backends (Rust, Haskell) compile WAM to native code and should be
   used for performance. The next step is separating facts from WAM logic — facts as indexed data tables, rule heads as
  native dispatch, only rule bodies in WAM.

  ## Test results

  - WAM E2E: 21/22 pass (1 pre-existing atom/1 failure)
  - Prolog target: 20/20 pass
  - `category_ancestor(a, physics, Hops, [a])` returns `Hops=2` via WAM emulator (2-hop recursive path)
  - Multi-parent cut barrier test: `gravitation → {force, energy}` correctly finds path through energy

  ## Test plan

  - [x] WAM E2E tests pass (21/22)
  - [x] Prolog target tests pass (20/20)
  - [x] 2-hop recursive query correct (`Hops=2`)
  - [x] Multi-parent with cut barrier correct
  - [x] Cycle detection works (A→B→A→Physics)

  🤖 Generated with [Claude Code](https://claude.com/claude-code)