### PR TITLE
fix(wam): monotonic variable counter and retry binding saves for deep recursion

### DIFF
--- a/src/unifyweaver/runtime/wam_runtime.pl
+++ b/src/unifyweaver/runtime/wam_runtime.pl
@@ -137,9 +137,10 @@ init_state(Goal, Code, Labels, wam_state(PC, Regs, [], [], [], halt, [], Code, L
     ;   PC = 1
     ),
     build_regs(Args, 1, Regs),
-    % Initialize the WAM variable binding table (global, mutable)
+    % Initialize the WAM variable binding table and counter (global, mutable)
     empty_assoc(EmptyBindings),
-    nb_setval(wam_bindings, EmptyBindings).
+    nb_setval(wam_bindings, EmptyBindings),
+    nb_setval(wam_var_counter, 0).
 
 % ============================================================================
 % Fact Table Registry
@@ -539,7 +540,12 @@ step_wam(put_constant(C, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_s
     NPC is PC + 1.
 
 step_wam(put_variable(Xn, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, NR, NS, H, NT, CP, CPS, Code, L)) :-
-    format(atom(NewVar), "_V~w", [PC]),
+    % Use monotonic counter for unique variable names across recursion depths.
+    % PC-based names collide when the same instruction runs at different depths.
+    nb_getval(wam_var_counter, VarCount),
+    NVC is VarCount + 1,
+    nb_setval(wam_var_counter, NVC),
+    format(atom(NewVar), "_V~w", [VarCount]),
     trail_binding(Xn, R, T, T1),
     trail_binding(Ai, R, T1, NT),
     put_reg(Xn, NewVar, R, R1, S, S1),

--- a/src/unifyweaver/runtime/wam_runtime.pl
+++ b/src/unifyweaver/runtime/wam_runtime.pl
@@ -304,17 +304,15 @@ resume_builtin(member(Elem, ListRaw, PC), StateIn, StateOut) :-
 resume_builtin(fact_retry(A1, FactTable, Arity, RestMatches, SavedCP), StateIn, StateOut) :-
     StateIn = wam_state(_, R, S, H, T, CP, [cp(NextPC, R_orig, S_orig, H_orig, CP_orig, T_orig, _, SB)|CPs], Code, L),
     RestMatches = [NextMatch|MoreMatches],
-    get_assoc('A2', R, A2Val),
+    % Save bindings BEFORE unify for correct retry
+    (   MoreMatches \= []
+    ->  wam_save_bindings(SB2),
+        NCPS0 = [cp(NextPC, R_orig, S_orig, H_orig, CP_orig, T_orig, fact_retry(A1, FactTable, Arity, MoreMatches, SavedCP), SB2)|CPs]
+    ;   NCPS0 = CPs
+    ),
     % Try to unify remaining args with the next match
     (   unify_fact_args(NextMatch, 2, Arity, R, T, NR, NT)
-    ->  % Success — create CP for further matches if any
-        (   MoreMatches \= []
-        ->  wam_save_bindings(SB2),
-            NCPS = [cp(NextPC, R_orig, S_orig, H_orig, CP_orig, T_orig, fact_retry(A1, FactTable, Arity, MoreMatches, SavedCP), SB2)|CPs]
-        ;   NCPS = CPs
-        ),
-        % Return to caller
-        StateOut = wam_state(SavedCP, NR, S, H, NT, halt, NCPS, Code, L)
+    ->  StateOut = wam_state(SavedCP, NR, S, H, NT, halt, NCPS0, Code, L)
     ;   % This match failed — try the next one
         (   MoreMatches \= []
         ->  wam_restore_bindings(SB),


### PR DESCRIPTION
  ## Summary

  Two fixes that enable deep recursive path finding (depth 3+) in the Prolog WAM emulator:

  1. **Monotonic variable counter** — `put_variable` was using `_V<PC>` for variable names, causing collisions across
  recursion depths (same PC = same name). Fix: global counter via `nb_setval(wam_var_counter)`.

  2. **Save retry bindings BEFORE unify** — `resume_builtin(fact_retry)` saved the CP bindings snapshot after
  `unify_fact_args` had already bound variables. On the next retry, the stale binding survived. Fix: save before unify.

  ## Results

  | Test | Before | After |
  |------|--------|-------|
  | Depth 1-2 linear chain | ✓ | ✓ |
  | Depth 3-6 linear chain | ✗ (all fail) | **✓ (all pass)** |
  | 1899_est (hardest seed, 1212 native paths) | 0 paths | **1 path** (1421ms) |
  | Astrophysics (multi-parent) | 1 path (10ms) | 1 path (5540ms) |

  The 1899_establishments seed finds a path through the WAM emulator for the first time.

  ## Known issue

  Full 300-scale benchmark times out (>10min) due to binding table growth with unique variable names. Each recursion level
   generates new variable names that accumulate in the binding table without cleanup. This is a performance issue, not a
  correctness issue — the individual seed tests produce correct results.

  ## Test plan

  - [x] WAM E2E: 21/22 (no regression)
  - [x] Depth 1-6 linear chains: all correct
  - [x] 1899_est seed: finds path (was 0 before)
  - [x] Multi-parent (Astrophysics): finds path

  🤖 Generated with [Claude Code](https://claude.com/claude-code)