### PR TITLE
fix(wam): comma functor parsing, aggregate_all analysis

### DIFF
--- a/src/unifyweaver/runtime/wam_runtime.pl
+++ b/src/unifyweaver/runtime/wam_runtime.pl
@@ -117,11 +117,26 @@ parse_instr(Str, Term) :-
         sub_string(Str, 0, Before, _, OpStr),
         sub_string(Str, _, After, 0, ArgsStr),
         atom_string(Op, OpStr),
-        split_string(ArgsStr, ",", " \t", ArgList),
+        split_string(ArgsStr, ",", " \t", ArgList0),
+        fix_comma_functor(ArgList0, ArgList),
         maplist(parse_arg, ArgList, ArgAtoms),
         Term =.. [Op|ArgAtoms]
     ;   atom_string(Term, Str)
     ).
+
+%% fix_comma_functor(+ArgList, -Fixed)
+%  When splitting on commas, a functor like ,/2 produces ["", "/2", ...].
+%  Merge the empty string and /N back into ",/N".
+fix_comma_functor([], []).
+fix_comma_functor([""|Rest], Fixed) :-
+    Rest = [SlashN|More],
+    sub_string(SlashN, 0, 1, _, "/"),
+    !,
+    string_concat(",", SlashN, Merged),
+    fix_comma_functor(More, MoreFixed),
+    Fixed = [Merged|MoreFixed].
+fix_comma_functor([H|T], [H|Fixed]) :-
+    fix_comma_functor(T, Fixed).
 
 parse_arg(Str, Val) :-
     (   number_string(Num, Str)


### PR DESCRIPTION
  ## Summary

  - Fix comma functor parsing in WAM text parser — `,/2` was split into 3 args
  - Analyze aggregate_all/3 execution model — native delegation causes infinite recursion

  ## Comma parser fix

  `put_structure ,/2, A2` was parsed as `put_structure('', '/2', 'A2')` (3 args)
  instead of `put_structure(',/2', 'A2')` (2 args). The comma in the functor name
  was treated as a delimiter. Fix: `fix_comma_functor` merges empty-string + `/N`
  tokens back into the correct `,/N` functor.

  This unblocks the `category_ancestor$power_sum_bound/3` WAM execution which was
  failing at the conjunction structure construction step.

  ## aggregate_all analysis

  Delegating to native Prolog's `aggregate_all` creates infinite recursion because
  the Goal calls `category_ancestor` which exists in user space. Native Prolog
  executes it directly (not through the WAM), but the WAM intercepts the `call`
  instruction and re-enters `aggregate_all`.

  The fix: implement findall-like solution collection within the WAM execution loop.
  This means running the Goal sub-execution through the WAM's own step/backtrack
  mechanism and collecting results, not delegating to native Prolog.

  ## Test plan
  - [x] WAM E2E: 21/22 (no regression)
  - [x] Comma functor: `put_structure(,/2, A2)` now parses correctly

  🤖 Generated with [Claude Code](https://claude.com/claude-code)