### PR TITLE
Generalize Rust WAM foreign lowering for recursive closure predicates

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3504,19 +3504,28 @@ rust_foreign_lowerable_transitive_closure(Pred, 2, Clauses, EdgePred/2, FactPair
     member(RecHead-RecBody, Clauses),
     BaseHead =.. [Pred, Start, Target],
     RecHead =.. [Pred, Start, Target],
-    BaseBody =.. [EdgePred, Start, Target],
     RecBody = (EdgeGoal, RecGoal),
-    EdgeGoal =.. [EdgePred, Start, Mid],
     RecGoal =.. [Pred, Mid, Target],
+    (   BaseBody =.. [EdgePred, Start, Target],
+        EdgeGoal =.. [EdgePred, Start, Mid],
+        PairMode = forward
+    ;   BaseBody =.. [EdgePred, Target, Start],
+        EdgeGoal =.. [EdgePred, Mid, Start],
+        PairMode = reverse
+    ),
     findall(Left-Right,
         ( functor(EdgeHead, EdgePred, 2),
           user:clause(EdgeHead, true),
           EdgeHead =.. [EdgePred, Left, Right],
           atom(Left),
-          atom(Right)
+          atom(Right),
+          rust_foreign_edge_pair(PairMode, Left, Right, Left-Right)
         ),
         FactPairs),
     FactPairs \= [].
+
+rust_foreign_edge_pair(forward, Left, Right, Left-Right).
+rust_foreign_edge_pair(reverse, Left, Right, Right-Left).
 
 compile_aggregate_rule_to_rust(Pred, _Arity, _Head, AggInfo, IncludeMain, RustCode) :-
     get_dict(goal, AggInfo, Goal),

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3444,7 +3444,9 @@ rust_foreign_lowering_spec(Pred, Arity, Clauses, ForeignSpec) :-
     rust_foreign_lowerable_category_ancestor(Pred, Arity, Clauses, MaxDepth),
     ForeignSpec = foreign_predicate(
         category_ancestor/4,
-        [register_foreign_category_ancestor(MaxDepth)],
+        [ register_foreign_native_kind(category_ancestor/4, category_ancestor),
+          register_foreign_usize_config(category_ancestor/4, max_depth, MaxDepth)
+        ],
         [category_ancestor/4]
     ).
 

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3449,6 +3449,16 @@ rust_foreign_lowering_spec(Pred, Arity, Clauses, ForeignSpec) :-
         ],
         [category_ancestor/4]
     ).
+rust_foreign_lowering_spec(Pred, Arity, Clauses, ForeignSpec) :-
+    rust_foreign_lowerable_transitive_closure(Pred, Arity, Clauses, EdgePred/2, FactPairs),
+    ForeignSpec = foreign_predicate(
+        Pred/Arity,
+        [ register_foreign_native_kind(Pred/Arity, transitive_closure2),
+          register_foreign_string_config(Pred/Arity, edge_pred, EdgePred/2),
+          register_indexed_atom_fact2(EdgePred/2, FactPairs)
+        ],
+        [Pred/Arity]
+    ).
 
 rust_foreign_lowerable_category_ancestor(category_ancestor, 4, Clauses, MaxDepth) :-
     member(_-BaseBody, Clauses),
@@ -3462,6 +3472,25 @@ rust_foreign_lowerable_category_ancestor(category_ancestor, 4, Clauses, MaxDepth
     user:max_depth(MaxDepth),
     integer(MaxDepth),
     MaxDepth > 0.
+
+rust_foreign_lowerable_transitive_closure(Pred, 2, Clauses, EdgePred/2, FactPairs) :-
+    member(BaseHead-BaseBody, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseHead =.. [Pred, Start, Target],
+    RecHead =.. [Pred, Start, Target],
+    BaseBody =.. [EdgePred, Start, Target],
+    RecBody = (EdgeGoal, RecGoal),
+    EdgeGoal =.. [EdgePred, Start, Mid],
+    RecGoal =.. [Pred, Mid, Target],
+    findall(Left-Right,
+        ( functor(EdgeHead, EdgePred, 2),
+          user:clause(EdgeHead, true),
+          EdgeHead =.. [EdgePred, Left, Right],
+          atom(Left),
+          atom(Right)
+        ),
+        FactPairs),
+    FactPairs \= [].
 
 compile_aggregate_rule_to_rust(Pred, _Arity, _Head, AggInfo, IncludeMain, RustCode) :-
     get_dict(goal, AggInfo, Goal),

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3441,24 +3441,50 @@ compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
     ).
 
 rust_foreign_lowering_spec(Pred, Arity, Clauses, ForeignSpec) :-
-    rust_foreign_lowerable_category_ancestor(Pred, Arity, Clauses, MaxDepth),
-    ForeignSpec = foreign_predicate(
-        category_ancestor/4,
-        [ register_foreign_native_kind(category_ancestor/4, category_ancestor),
-          register_foreign_usize_config(category_ancestor/4, max_depth, MaxDepth)
-        ],
-        [category_ancestor/4]
-    ).
-rust_foreign_lowering_spec(Pred, Arity, Clauses, ForeignSpec) :-
-    rust_foreign_lowerable_transitive_closure(Pred, Arity, Clauses, EdgePred/2, FactPairs),
-    ForeignSpec = foreign_predicate(
-        Pred/Arity,
-        [ register_foreign_native_kind(Pred/Arity, transitive_closure2),
-          register_foreign_string_config(Pred/Arity, edge_pred, EdgePred/2),
-          register_indexed_atom_fact2(EdgePred/2, FactPairs)
-        ],
-        [Pred/Arity]
-    ).
+    rust_foreign_lowering_schema(Pred, Arity, Clauses, Schema),
+    rust_foreign_schema_spec(Schema, ForeignSpec).
+
+rust_foreign_lowering_schema(Pred, Arity, Clauses, Schema) :-
+    rust_foreign_schema_category_ancestor(Pred, Arity, Clauses, Schema).
+rust_foreign_lowering_schema(Pred, Arity, Clauses, Schema) :-
+    rust_foreign_schema_transitive_closure(Pred, Arity, Clauses, Schema).
+
+rust_foreign_schema_spec(
+        foreign_schema(
+            category_ancestor,
+            category_ancestor/4,
+            [max_depth(MaxDepth)]
+        ),
+        foreign_predicate(
+            category_ancestor/4,
+            [ register_foreign_native_kind(category_ancestor/4, category_ancestor),
+              register_foreign_usize_config(category_ancestor/4, max_depth, MaxDepth)
+            ],
+            [category_ancestor/4]
+        )).
+rust_foreign_schema_spec(
+        foreign_schema(
+            transitive_closure2,
+            Pred/Arity,
+            [edge_pred(EdgePred/2), fact_pairs(FactPairs)]
+        ),
+        foreign_predicate(
+            Pred/Arity,
+            [ register_foreign_native_kind(Pred/Arity, transitive_closure2),
+              register_foreign_string_config(Pred/Arity, edge_pred, EdgePred/2),
+              register_indexed_atom_fact2(EdgePred/2, FactPairs)
+            ],
+            [Pred/Arity]
+        )).
+
+rust_foreign_schema_category_ancestor(Pred, Arity, Clauses,
+        foreign_schema(category_ancestor, category_ancestor/4, [max_depth(MaxDepth)])) :-
+    rust_foreign_lowerable_category_ancestor(Pred, Arity, Clauses, MaxDepth).
+
+rust_foreign_schema_transitive_closure(Pred, Arity, Clauses,
+        foreign_schema(transitive_closure2, Pred/Arity,
+            [edge_pred(EdgePred/2), fact_pairs(FactPairs)])) :-
+    rust_foreign_lowerable_transitive_closure(Pred, Arity, Clauses, EdgePred/2, FactPairs).
 
 rust_foreign_lowerable_category_ancestor(category_ancestor, 4, Clauses, MaxDepth) :-
     member(_-BaseBody, Clauses),

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3385,12 +3385,12 @@ compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
 
     (   Clauses = [] -> fail
     ;   ForeignLowering == true,
-        rust_foreign_lowerable_category_ancestor(Pred, Arity, Clauses, MaxDepth)
+        rust_foreign_lowering_spec(Pred, Arity, Clauses, ForeignSpec)
     ->  wam_target:compile_predicate_to_wam(user:Pred/Arity, Options, WamCode),
         wam_rust_target:compile_wam_predicate_to_rust(
             Pred/Arity,
             WamCode,
-            [foreign_lowering(category_ancestor(MaxDepth))|Options],
+            [foreign_lowering(ForeignSpec)|Options],
             RustCode
         )
     ;   maplist(is_fact_clause, Clauses) ->
@@ -3438,6 +3438,14 @@ compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
         wam_target:compile_predicate_to_wam(PredIndicator, Options, WamCode)
     ->  wam_rust_target:compile_wam_predicate_to_rust(Pred/Arity, WamCode, Options, RustCode)
     ;   fail
+    ).
+
+rust_foreign_lowering_spec(Pred, Arity, Clauses, ForeignSpec) :-
+    rust_foreign_lowerable_category_ancestor(Pred, Arity, Clauses, MaxDepth),
+    ForeignSpec = foreign_predicate(
+        category_ancestor/4,
+        [register_foreign_category_ancestor(MaxDepth)],
+        [category_ancestor/4]
     ).
 
 rust_foreign_lowerable_category_ancestor(category_ancestor, 4, Clauses, MaxDepth) :-

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -61,6 +61,8 @@
     compile_streaming_federation_rust/2   % +Options, -RustCode
 ]).
 
+:- discontiguous compile_predicate_to_rust_normal/4.
+
 :- use_module(library(lists)).
 :- use_module(library(filesex)).
 :- use_module(library(gensym)). % For generating unique variable names
@@ -3378,11 +3380,21 @@ compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
     option(field_delimiter(FieldDelim), Options, colon),
     option(include_main(IncludeMain), Options, true),
     option(unique(Unique), Options, true),
+    option(foreign_lowering(ForeignLowering), Options, false),
 
     functor(Head, Pred, Arity),
     findall(Head-Body, user:clause(Head, Body), Clauses),
 
     (   Clauses = [] -> fail
+    ;   ForeignLowering == true,
+        rust_foreign_lowerable_category_ancestor(Pred, Arity, Clauses, MaxDepth)
+    ->  wam_target:compile_predicate_to_wam(user:Pred/Arity, Options, WamCode),
+        wam_rust_target:compile_wam_predicate_to_rust(
+            Pred/Arity,
+            WamCode,
+            [foreign_lowering(category_ancestor(MaxDepth))|Options],
+            RustCode
+        )
     ;   maplist(is_fact_clause, Clauses) ->
         compile_facts_to_rust(Pred, Arity, Clauses, FieldDelim, RustCode)
     ;   is_general_recursive_pattern_rust(Pred, Arity, Clauses) ->
@@ -3400,6 +3412,19 @@ compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
         compile_single_rule_to_rust(Pred, Arity, SingleHead, SingleBody, FieldDelim, Unique, IncludeMain, RustCode)
     ;   fail
     ).
+
+rust_foreign_lowerable_category_ancestor(category_ancestor, 4, Clauses, MaxDepth) :-
+    member(_-BaseBody, Clauses),
+    member(_-RecBody, Clauses),
+    BaseBody \= true,
+    RecBody \= true,
+    sub_term(\+ member(_, _), BaseBody),
+    sub_term(\+ member(_, _), RecBody),
+    sub_term((_ is _ + 1), RecBody),
+    current_predicate(user:max_depth/1),
+    user:max_depth(MaxDepth),
+    integer(MaxDepth),
+    MaxDepth > 0.
 
 %% WAM fallback tier: when all native lowering tiers fail, compile
 %% via WAM and generate Rust wrapper. Controlled by wam_fallback option

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -61,8 +61,6 @@
     compile_streaming_federation_rust/2   % +Options, -RustCode
 ]).
 
-:- discontiguous compile_predicate_to_rust_normal/4.
-
 :- use_module(library(lists)).
 :- use_module(library(filesex)).
 :- use_module(library(gensym)). % For generating unique variable names
@@ -3413,19 +3411,6 @@ compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
     ;   fail
     ).
 
-rust_foreign_lowerable_category_ancestor(category_ancestor, 4, Clauses, MaxDepth) :-
-    member(_-BaseBody, Clauses),
-    member(_-RecBody, Clauses),
-    BaseBody \= true,
-    RecBody \= true,
-    sub_term(\+ member(_, _), BaseBody),
-    sub_term(\+ member(_, _), RecBody),
-    sub_term((_ is _ + 1), RecBody),
-    current_predicate(user:max_depth/1),
-    user:max_depth(MaxDepth),
-    integer(MaxDepth),
-    MaxDepth > 0.
-
 %% WAM fallback tier: when all native lowering tiers fail, compile
 %% via WAM and generate Rust wrapper. Controlled by wam_fallback option
 %% (default: true). Set wam_fallback(false) to disable and see how far
@@ -3454,6 +3439,19 @@ compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
     ->  wam_rust_target:compile_wam_predicate_to_rust(Pred/Arity, WamCode, Options, RustCode)
     ;   fail
     ).
+
+rust_foreign_lowerable_category_ancestor(category_ancestor, 4, Clauses, MaxDepth) :-
+    member(_-BaseBody, Clauses),
+    member(_-RecBody, Clauses),
+    BaseBody \= true,
+    RecBody \= true,
+    sub_term(\+ member(_, _), BaseBody),
+    sub_term(\+ member(_, _), RecBody),
+    sub_term((_ is _ + 1), RecBody),
+    current_predicate(user:max_depth/1),
+    user:max_depth(MaxDepth),
+    integer(MaxDepth),
+    MaxDepth > 0.
 
 compile_aggregate_rule_to_rust(Pred, _Arity, _Head, AggInfo, IncludeMain, RustCode) :-
     get_dict(goal, AggInfo, Goal),

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1525,12 +1525,13 @@ compile_wam_runtime_to_rust(Options, RustCode) :-
 %% compile_wam_predicate_to_rust(+Pred/Arity, +WamCode, +Options, -RustCode)
 %  Given WAM compiled code for a predicate, generate a Rust wrapper function
 %  that creates instruction data and executes it via the WAM runtime.
-compile_wam_predicate_to_rust(Pred/Arity, WamCode, _Options, RustCode) :-
+compile_wam_predicate_to_rust(Pred/Arity, WamCode, Options, RustCode) :-
     atom_string(Pred, PredStr),
     build_rust_wam_arg_list(Arity, ArgList),
     build_rust_wam_arg_setup(Arity, ArgSetup),
     % Convert WAM instruction string to Rust Instruction enum literals
-    wam_code_to_rust_instructions(WamCode, InstrLiterals, LabelLiterals),
+    wam_code_to_rust_instructions(WamCode, Pred/Arity, Options, InstrLiterals, LabelLiterals),
+    foreign_wrapper_setup(Pred/Arity, Options, ForeignSetup, RunExpr),
     format(string(RustCode),
 '/// WAM-compiled predicate: ~w/~w
 /// Compiled via WAM for predicates that resist native lowering.
@@ -1545,24 +1546,36 @@ pub fn ~w(~w) -> bool {
     vm.labels = labels;
     vm.pc = 1;
 ~w
-    vm.run()
-}', [PredStr, Arity, PredStr, ArgList, InstrLiterals, LabelLiterals, ArgSetup]).
+~w
+    ~w
+}', [PredStr, Arity, PredStr, ArgList, InstrLiterals, LabelLiterals, ForeignSetup, ArgSetup, RunExpr]).
 
-%% wam_code_to_rust_instructions(+WamCodeStr, -InstrLiterals, -LabelLiterals)
+foreign_wrapper_setup(Pred/Arity, Options, Setup, RunExpr) :-
+    (   option(foreign_lowering(category_ancestor(MaxDepth)), Options),
+        Pred == category_ancestor,
+        Arity =:= 4
+    ->  format(string(Setup),
+            '    vm.register_foreign_category_ancestor(~w);', [MaxDepth]),
+        RunExpr = 'vm.execute_foreign_predicate("category_ancestor", 4)'
+    ;   Setup = "",
+        RunExpr = 'vm.run()'
+    ).
+
+%% wam_code_to_rust_instructions(+WamCodeStr, +PredIndicator, +Options, -InstrLiterals, -LabelLiterals)
 %  Parses a WAM code string and generates Rust vec![] entries and label map inserts.
-wam_code_to_rust_instructions(WamCode, InstrLiterals, LabelLiterals) :-
+wam_code_to_rust_instructions(WamCode, PredIndicator, Options, InstrLiterals, LabelLiterals) :-
     atom_string(WamCode, WamStr),
     split_string(WamStr, "\n", "", Lines),
-    wam_lines_to_rust(Lines, 1, InstrParts, LabelParts),
+    wam_lines_to_rust(Lines, 1, PredIndicator, Options, InstrParts, LabelParts),
     atomic_list_concat(InstrParts, '\n', InstrLiterals),
     atomic_list_concat(LabelParts, '\n', LabelLiterals).
 
-wam_lines_to_rust([], _, [], []).
-wam_lines_to_rust([Line|Rest], PC, Instrs, Labels) :-
+wam_lines_to_rust([], _, _, _, [], []).
+wam_lines_to_rust([Line|Rest], PC, PredIndicator, Options, Instrs, Labels) :-
     split_string(Line, " \t,", " \t,", Parts),
     delete(Parts, "", CleanParts),
     (   CleanParts == []
-    ->  wam_lines_to_rust(Rest, PC, Instrs, Labels)
+    ->  wam_lines_to_rust(Rest, PC, PredIndicator, Options, Instrs, Labels)
     ;   CleanParts = [First|_],
         (   % Label line: "pred/2:" or "L_pred_2_2:"
             sub_string(First, _, 1, 0, ":")
@@ -1570,143 +1583,151 @@ wam_lines_to_rust([Line|Rest], PC, Instrs, Labels) :-
             format(string(LabelInsert),
                 '    labels.insert("~w".to_string(), ~w);', [LabelName, PC]),
             Labels = [LabelInsert|RestLabels],
-            wam_lines_to_rust(Rest, PC, Instrs, RestLabels)
+            wam_lines_to_rust(Rest, PC, PredIndicator, Options, Instrs, RestLabels)
         ;   % Instruction line
-            wam_line_to_rust_instr(CleanParts, RustInstr),
+            wam_line_to_rust_instr(CleanParts, PredIndicator, Options, RustInstr),
             format(string(InstrEntry), '        ~w,', [RustInstr]),
             NPC is PC + 1,
             Instrs = [InstrEntry|RestInstrs],
-            wam_lines_to_rust(Rest, NPC, RestInstrs, Labels)
+            wam_lines_to_rust(Rest, NPC, PredIndicator, Options, RestInstrs, Labels)
         )
     ).
 
-%% wam_line_to_rust_instr(+Parts, -RustExpr)
+%% wam_line_to_rust_instr(+Parts, +PredIndicator, +Options, -RustExpr)
 %  Converts parsed WAM instruction parts to a Rust Instruction enum literal.
-wam_line_to_rust_instr(["get_constant", C, Ai], Rust) :-
+wam_line_to_rust_instr(["get_constant", C, Ai], _, _, Rust) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),
     format(string(Rust),
         'Instruction::GetConstant(Value::Atom("~w".to_string()), "~w".to_string())',
         [CC, CAi]).
-wam_line_to_rust_instr(["get_variable", Xn, Ai], Rust) :-
+wam_line_to_rust_instr(["get_variable", Xn, Ai], _, _, Rust) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
     format(string(Rust),
         'Instruction::GetVariable("~w".to_string(), "~w".to_string())',
         [CXn, CAi]).
-wam_line_to_rust_instr(["get_value", Xn, Ai], Rust) :-
+wam_line_to_rust_instr(["get_value", Xn, Ai], _, _, Rust) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
     format(string(Rust),
         'Instruction::GetValue("~w".to_string(), "~w".to_string())',
         [CXn, CAi]).
-wam_line_to_rust_instr(["get_structure", FN, Ai], Rust) :-
+wam_line_to_rust_instr(["get_structure", FN, Ai], _, _, Rust) :-
     clean_comma(FN, CFN), clean_comma(Ai, CAi),
     format(string(Rust),
         'Instruction::GetStructure("~w".to_string(), "~w".to_string())',
         [CFN, CAi]).
-wam_line_to_rust_instr(["get_list", Ai], Rust) :-
+wam_line_to_rust_instr(["get_list", Ai], _, _, Rust) :-
     clean_comma(Ai, CAi),
     format(string(Rust),
         'Instruction::GetList("~w".to_string())', [CAi]).
-wam_line_to_rust_instr(["unify_variable", Xn], Rust) :-
+wam_line_to_rust_instr(["unify_variable", Xn], _, _, Rust) :-
     format(string(Rust),
         'Instruction::UnifyVariable("~w".to_string())', [Xn]).
-wam_line_to_rust_instr(["unify_value", Xn], Rust) :-
+wam_line_to_rust_instr(["unify_value", Xn], _, _, Rust) :-
     format(string(Rust),
         'Instruction::UnifyValue("~w".to_string())', [Xn]).
-wam_line_to_rust_instr(["unify_constant", C], Rust) :-
+wam_line_to_rust_instr(["unify_constant", C], _, _, Rust) :-
     (   number_string(N, C)
     ->  format(string(Rust),
             'Instruction::UnifyConstant(Value::Integer(~w))', [N])
     ;   format(string(Rust),
             'Instruction::UnifyConstant(Value::Atom("~w".to_string()))', [C])
     ).
-wam_line_to_rust_instr(["put_constant", C, Ai], Rust) :-
+wam_line_to_rust_instr(["put_constant", C, Ai], _, _, Rust) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),
     format(string(Rust),
         'Instruction::PutConstant(Value::Atom("~w".to_string()), "~w".to_string())',
         [CC, CAi]).
-wam_line_to_rust_instr(["put_variable", Xn, Ai], Rust) :-
+wam_line_to_rust_instr(["put_variable", Xn, Ai], _, _, Rust) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
     format(string(Rust),
         'Instruction::PutVariable("~w".to_string(), "~w".to_string())',
         [CXn, CAi]).
-wam_line_to_rust_instr(["put_value", Xn, Ai], Rust) :-
+wam_line_to_rust_instr(["put_value", Xn, Ai], _, _, Rust) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
     format(string(Rust),
         'Instruction::PutValue("~w".to_string(), "~w".to_string())',
         [CXn, CAi]).
-wam_line_to_rust_instr(["put_structure", FN, Ai], Rust) :-
+wam_line_to_rust_instr(["put_structure", FN, Ai], _, _, Rust) :-
     clean_comma(FN, CFN), clean_comma(Ai, CAi),
     format(string(Rust),
         'Instruction::PutStructure("~w".to_string(), "~w".to_string())',
         [CFN, CAi]).
-wam_line_to_rust_instr(["put_list", Ai], Rust) :-
+wam_line_to_rust_instr(["put_list", Ai], _, _, Rust) :-
     format(string(Rust),
         'Instruction::PutList("~w".to_string())', [Ai]).
-wam_line_to_rust_instr(["set_variable", Xn], Rust) :-
+wam_line_to_rust_instr(["set_variable", Xn], _, _, Rust) :-
     format(string(Rust),
         'Instruction::SetVariable("~w".to_string())', [Xn]).
-wam_line_to_rust_instr(["set_value", Xn], Rust) :-
+wam_line_to_rust_instr(["set_value", Xn], _, _, Rust) :-
     format(string(Rust),
         'Instruction::SetValue("~w".to_string())', [Xn]).
-wam_line_to_rust_instr(["set_constant", C], Rust) :-
+wam_line_to_rust_instr(["set_constant", C], _, _, Rust) :-
     (   number_string(N, C)
     ->  format(string(Rust),
             'Instruction::SetConstant(Value::Integer(~w))', [N])
     ;   format(string(Rust),
             'Instruction::SetConstant(Value::Atom("~w".to_string()))', [C])
     ).
-wam_line_to_rust_instr(["allocate"], "Instruction::Allocate").
-wam_line_to_rust_instr(["deallocate"], "Instruction::Deallocate").
-wam_line_to_rust_instr(["call", P, N], Rust) :-
+wam_line_to_rust_instr(["allocate"], _, _, "Instruction::Allocate").
+wam_line_to_rust_instr(["deallocate"], _, _, "Instruction::Deallocate").
+wam_line_to_rust_instr(["call", P, N], Pred/Arity, Options, Rust) :-
     clean_comma(P, CP), clean_comma(N, CN),
     escape_rust_string(CP, ECP),
     (   number_string(Num, CN) -> true ; Num = 0 ),
-    format(string(Rust),
-        'Instruction::Call("~w".to_string(), ~w)', [ECP, Num]).
-wam_line_to_rust_instr(["execute", P], Rust) :-
+    (   option(foreign_lowering(category_ancestor(_)), Options),
+        Pred == category_ancestor,
+        Arity =:= 4,
+        ECP == "category_ancestor/4",
+        Num =:= 4
+    ->  format(string(Rust),
+            'Instruction::CallForeign("category_ancestor".to_string(), 4)', [])
+    ;   format(string(Rust),
+            'Instruction::Call("~w".to_string(), ~w)', [ECP, Num])
+    ).
+wam_line_to_rust_instr(["execute", P], _, _, Rust) :-
     escape_rust_string(P, EP),
     format(string(Rust),
         'Instruction::Execute("~w".to_string())', [EP]).
-wam_line_to_rust_instr(["proceed"], "Instruction::Proceed").
-wam_line_to_rust_instr(["builtin_call", Op, N], Rust) :-
+wam_line_to_rust_instr(["proceed"], _, _, "Instruction::Proceed").
+wam_line_to_rust_instr(["builtin_call", Op, N], _, _, Rust) :-
     clean_comma(Op, COp), clean_comma(N, CN),
     escape_rust_string(COp, ECOp),
     (   number_string(Num, CN) -> true ; Num = 0 ),
     format(string(Rust),
         'Instruction::BuiltinCall("~w".to_string(), ~w)', [ECOp, Num]).
-wam_line_to_rust_instr(["begin_aggregate", Type, ValueReg, ResultReg], Rust) :-
+wam_line_to_rust_instr(["begin_aggregate", Type, ValueReg, ResultReg], _, _, Rust) :-
     clean_comma(Type, CType),
     clean_comma(ValueReg, CValueReg),
     clean_comma(ResultReg, CResultReg),
     format(string(Rust),
         'Instruction::BeginAggregate("~w".to_string(), "~w".to_string(), "~w".to_string())',
         [CType, CValueReg, CResultReg]).
-wam_line_to_rust_instr(["end_aggregate", ValueReg], Rust) :-
+wam_line_to_rust_instr(["end_aggregate", ValueReg], _, _, Rust) :-
     clean_comma(ValueReg, CValueReg),
     format(string(Rust),
         'Instruction::EndAggregate("~w".to_string())', [CValueReg]).
-wam_line_to_rust_instr(["try_me_else", Label], Rust) :-
+wam_line_to_rust_instr(["try_me_else", Label], _, _, Rust) :-
     format(string(Rust),
         'Instruction::TryMeElse("~w".to_string())', [Label]).
-wam_line_to_rust_instr(["trust_me"], "Instruction::TrustMe").
-wam_line_to_rust_instr(["retry_me_else", Label], Rust) :-
+wam_line_to_rust_instr(["trust_me"], _, _, "Instruction::TrustMe").
+wam_line_to_rust_instr(["retry_me_else", Label], _, _, Rust) :-
     format(string(Rust),
         'Instruction::RetryMeElse("~w".to_string())', [Label]).
 % Indexing instructions
-wam_line_to_rust_instr(["switch_on_constant"|Entries], Rust) :-
+wam_line_to_rust_instr(["switch_on_constant"|Entries], _, _, Rust) :-
     maplist(parse_index_entry_constant, Entries, RustEntries),
     atomic_list_concat(RustEntries, ', ', Joined),
     format(string(Rust), 'Instruction::SwitchOnConstant(vec![~w])', [Joined]).
-wam_line_to_rust_instr(["switch_on_structure"|Entries], Rust) :-
+wam_line_to_rust_instr(["switch_on_structure"|Entries], _, _, Rust) :-
     maplist(parse_index_entry_structure, Entries, RustEntries),
     atomic_list_concat(RustEntries, ', ', Joined),
     format(string(Rust), 'Instruction::SwitchOnStructure(vec![~w])', [Joined]).
-wam_line_to_rust_instr(["switch_on_constant_a2"|Entries], Rust) :-
+wam_line_to_rust_instr(["switch_on_constant_a2"|Entries], _, _, Rust) :-
     maplist(parse_index_entry_constant, Entries, RustEntries),
     atomic_list_concat(RustEntries, ', ', Joined),
     format(string(Rust), 'Instruction::SwitchOnConstantA2(vec![~w])', [Joined]).
 % Fallback for unknown instructions
-wam_line_to_rust_instr(Parts, Rust) :-
+wam_line_to_rust_instr(Parts, _, _, Rust) :-
     atomic_list_concat(Parts, ' ', Joined),
     format(string(Rust), '/* unknown: ~w */', [Joined]).
 

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -785,6 +785,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
     compile_execute_foreign_predicate_to_rust(ForeignCode),
     compile_resume_builtin_to_rust(ResumeCode),
     compile_collect_native_category_ancestor_to_rust(NativeAncestorCode),
+    compile_collect_native_transitive_closure_to_rust(NativeClosureCode),
     compile_eval_arith_to_rust(ArithCode),
     atomic_list_concat([
         RunLoopCode, '\n\n',
@@ -799,6 +800,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
         ForeignCode, '\n\n',
         ResumeCode, '\n\n',
         NativeAncestorCode, '\n\n',
+        NativeClosureCode, '\n\n',
         ArithCode
     ], RustCode).
 
@@ -1099,6 +1101,44 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                     self.pc += 1; true
                 } else { false }
             }
+            "transitive_closure2" => {
+                let start = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
+                    Some(Value::Atom(start)) => start,
+                    _ => return false,
+                };
+                let target_reg = match self.regs.get("A2").cloned() {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let edge_pred = match self.foreign_string_config(&pred_key, "edge_pred") {
+                    Some(pred) => pred.to_string(),
+                    None => return false,
+                };
+                let mut nodes: Vec<String> = Vec::new();
+                self.collect_native_transitive_closure_nodes(&start, &edge_pred, &mut nodes);
+                if nodes.is_empty() {
+                    return false;
+                }
+                if nodes.len() > 1 {
+                    self.choice_points.push(ChoicePoint {
+                        next_pc: self.pc,
+                        saved_args: self.save_regs(),
+                        stack: self.stack.clone(),
+                        cp: self.cp,
+                        trail_len: self.trail.len(),
+                        heap_len: self.heap.len(),
+                        builtin_state: Some(BuiltinState {
+                            name: "foreign_results".to_string(),
+                            args: vec![Value::Atom(pred_key.clone()), target_reg.clone()],
+                            data: nodes[1..].iter().map(|node| Value::Atom(node.clone())).collect(),
+                        }),
+                        cut_barrier: self.cut_barrier,
+                    });
+                }
+                if self.unify(&target_reg, &Value::Atom(nodes[0].clone())) {
+                    self.pc += 1; true
+                } else { false }
+            }
             _ => false,
         }
     }'.
@@ -1143,6 +1183,27 @@ compile_collect_native_category_ancestor_to_rust(Code) :-
                 self.collect_native_category_ancestor_hops(parent, root, &next_visited, max_depth, out);
                 for hop in out.iter_mut().skip(before) {
                     *hop += 1;
+                }
+            }
+        }
+    }'.
+
+compile_collect_native_transitive_closure_to_rust(Code) :-
+    Code = '    pub fn collect_native_transitive_closure_nodes(
+        &self,
+        start: &str,
+        edge_pred: &str,
+        out: &mut Vec<String>,
+    ) {
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut stack: Vec<String> = vec![start.to_string()];
+        while let Some(node) = stack.pop() {
+            if let Some(next_nodes) = self.indexed_atom_fact2.get(edge_pred).and_then(|table| table.get(&node)) {
+                for next in next_nodes.iter().rev() {
+                    if seen.insert(next.clone()) {
+                        out.push(next.clone());
+                        stack.push(next.clone());
+                    }
                 }
             }
         }
@@ -1328,9 +1389,9 @@ compile_resume_builtin_to_rust(Code) :-
                     Some(val) => val.clone(),
                     None => return false,
                 };
-                let hop = match state.data.first() {
-                    Some(Value::Integer(hop)) => *hop,
-                    _ => return false,
+                let result = match state.data.first() {
+                    Some(value) => value.clone(),
+                    None => return false,
                 };
                 if state.data.len() > 1 {
                     self.choice_points.push(ChoicePoint {
@@ -1352,8 +1413,10 @@ compile_resume_builtin_to_rust(Code) :-
                     Some(kind) => kind,
                     None => return false,
                 };
-                if native_kind != "category_ancestor" { return false; }
-                if self.unify(&hops_reg, &Value::Integer(hop)) {
+                if native_kind != "category_ancestor" && native_kind != "transitive_closure2" {
+                    return false;
+                }
+                if self.unify(&hops_reg, &result) {
                     self.pc += 1; true
                 } else { false }
             }
@@ -1588,9 +1651,32 @@ rust_foreign_setup_code(Ops, Setup) :-
 rust_foreign_setup_line(register_foreign_native_kind(Pred/Arity, Kind), Line) :-
     format(string(Line),
         '    vm.register_foreign_native_kind("~w/~w", "~w");', [Pred, Arity, Kind]).
+rust_foreign_setup_line(register_foreign_string_config(Pred/Arity, Key, ValuePred/ValueArity), Line) :-
+    format(string(Line),
+        '    vm.register_foreign_string_config("~w/~w", "~w", "~w/~w");',
+        [Pred, Arity, Key, ValuePred, ValueArity]).
+rust_foreign_setup_line(register_foreign_string_config(Pred/Arity, Key, Value), Line) :-
+    format(string(Line),
+        '    vm.register_foreign_string_config("~w/~w", "~w", "~w");',
+        [Pred, Arity, Key, Value]).
 rust_foreign_setup_line(register_foreign_usize_config(Pred/Arity, Key, Value), Line) :-
     format(string(Line),
         '    vm.register_foreign_usize_config("~w/~w", "~w", ~w);', [Pred, Arity, Key, Value]).
+rust_foreign_setup_line(register_indexed_atom_fact2(Pred/Arity, Pairs), Line) :-
+    rust_fact_pairs_literal(Pairs, PairsLiteral),
+    format(string(Line),
+        '    vm.register_indexed_atom_fact2_pairs("~w/~w", &~w);',
+        [Pred, Arity, PairsLiteral]).
+
+rust_fact_pairs_literal(Pairs, Literal) :-
+    maplist(rust_fact_pair_literal, Pairs, PairLiterals),
+    atomic_list_concat(PairLiterals, ', ', Joined),
+    format(string(Literal), '[~w]', [Joined]).
+
+rust_fact_pair_literal(Left-Right, Literal) :-
+    escape_rust_string(Left, ELeft),
+    escape_rust_string(Right, ERight),
+    format(string(Literal), '("~w", "~w")', [ELeft, ERight]).
 
 %% wam_code_to_rust_instructions(+WamCodeStr, +PredIndicator, +Options, -InstrLiterals, -LabelLiterals)
 %  Parses a WAM code string and generates Rust vec![] entries and label map inserts.
@@ -1711,10 +1797,14 @@ wam_line_to_rust_instr(["call", P, N], Pred/Arity, Options, Rust) :-
     ;   format(string(Rust),
             'Instruction::Call("~w".to_string(), ~w)', [ECP, Num])
     ).
-wam_line_to_rust_instr(["execute", P], _, _, Rust) :-
+wam_line_to_rust_instr(["execute", P], Pred/Arity, Options, Rust) :-
     escape_rust_string(P, EP),
-    format(string(Rust),
-        'Instruction::Execute("~w".to_string())', [EP]).
+    (   rust_foreign_rewrite_execute(Options, Pred/Arity, EP, ForeignPred, ForeignArity)
+    ->  format(string(Rust),
+            'Instruction::CallForeign("~w".to_string(), ~w)', [ForeignPred, ForeignArity])
+    ;   format(string(Rust),
+            'Instruction::Execute("~w".to_string())', [EP])
+    ).
 wam_line_to_rust_instr(["proceed"], _, _, "Instruction::Proceed").
 wam_line_to_rust_instr(["builtin_call", Op, N], _, _, Rust) :-
     clean_comma(Op, COp), clean_comma(N, CN),
@@ -1765,6 +1855,13 @@ rust_foreign_rewrite_call(Options, CurrentPred, TargetPredArity, Num, ForeignPre
     format(string(ExpectedTarget), "~w/~w", [TargetPred, TargetArity]),
     TargetPredArity == ExpectedTarget,
     Num =:= ForeignArity.
+
+rust_foreign_rewrite_execute(Options, CurrentPred, TargetPredArity, ForeignPred, ForeignArity) :-
+    option(foreign_lowering(ForeignSpec), Options),
+    rust_foreign_spec(CurrentPred, ForeignSpec, _, RewriteCalls, ForeignPred/ForeignArity),
+    member(TargetPred/TargetArity, RewriteCalls),
+    format(string(ExpectedTarget), "~w/~w", [TargetPred, TargetArity]),
+    TargetPredArity == ExpectedTarget.
 
 rust_foreign_spec(Pred/Arity,
         foreign_predicate(Pred/Arity, SetupOps, RewriteCalls),

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1551,15 +1551,30 @@ pub fn ~w(~w) -> bool {
 }', [PredStr, Arity, PredStr, ArgList, InstrLiterals, LabelLiterals, ForeignSetup, ArgSetup, RunExpr]).
 
 foreign_wrapper_setup(Pred/Arity, Options, Setup, RunExpr) :-
-    (   option(foreign_lowering(category_ancestor(MaxDepth)), Options),
-        Pred == category_ancestor,
-        Arity =:= 4
-    ->  format(string(Setup),
-            '    vm.register_foreign_category_ancestor(~w);', [MaxDepth]),
-        RunExpr = 'vm.execute_foreign_predicate("category_ancestor", 4)'
+    (   option(foreign_lowering(ForeignSpec), Options),
+        rust_foreign_spec(Pred/Arity, ForeignSpec, SetupOps, EntryPred/EntryArity)
+    ->  rust_foreign_setup_code(SetupOps, Setup),
+        format(string(RunExpr),
+            'vm.execute_foreign_predicate("~w", ~w)', [EntryPred, EntryArity])
     ;   Setup = "",
         RunExpr = 'vm.run()'
     ).
+
+rust_foreign_spec(Pred/Arity,
+        foreign_predicate(Pred/Arity, SetupOps, RewriteCalls),
+        SetupOps,
+        Pred/Arity) :-
+    is_list(SetupOps),
+    is_list(RewriteCalls).
+
+rust_foreign_setup_code([], "").
+rust_foreign_setup_code(Ops, Setup) :-
+    maplist(rust_foreign_setup_line, Ops, Lines),
+    atomic_list_concat(Lines, '\n', Setup).
+
+rust_foreign_setup_line(register_foreign_category_ancestor(MaxDepth), Line) :-
+    format(string(Line),
+        '    vm.register_foreign_category_ancestor(~w);', [MaxDepth]).
 
 %% wam_code_to_rust_instructions(+WamCodeStr, +PredIndicator, +Options, -InstrLiterals, -LabelLiterals)
 %  Parses a WAM code string and generates Rust vec![] entries and label map inserts.
@@ -1674,13 +1689,9 @@ wam_line_to_rust_instr(["call", P, N], Pred/Arity, Options, Rust) :-
     clean_comma(P, CP), clean_comma(N, CN),
     escape_rust_string(CP, ECP),
     (   number_string(Num, CN) -> true ; Num = 0 ),
-    (   option(foreign_lowering(category_ancestor(_)), Options),
-        Pred == category_ancestor,
-        Arity =:= 4,
-        ECP == "category_ancestor/4",
-        Num =:= 4
+    (   rust_foreign_rewrite_call(Options, Pred/Arity, ECP, Num, ForeignPred, ForeignArity)
     ->  format(string(Rust),
-            'Instruction::CallForeign("category_ancestor".to_string(), 4)', [])
+            'Instruction::CallForeign("~w".to_string(), ~w)', [ForeignPred, ForeignArity])
     ;   format(string(Rust),
             'Instruction::Call("~w".to_string(), ~w)', [ECP, Num])
     ).
@@ -1730,6 +1741,22 @@ wam_line_to_rust_instr(["switch_on_constant_a2"|Entries], _, _, Rust) :-
 wam_line_to_rust_instr(Parts, _, _, Rust) :-
     atomic_list_concat(Parts, ' ', Joined),
     format(string(Rust), '/* unknown: ~w */', [Joined]).
+
+rust_foreign_rewrite_call(Options, CurrentPred, TargetPredArity, Num, ForeignPred, ForeignArity) :-
+    option(foreign_lowering(ForeignSpec), Options),
+    rust_foreign_spec(CurrentPred, ForeignSpec, _, RewriteCalls, ForeignPred/ForeignArity),
+    member(TargetPred/TargetArity, RewriteCalls),
+    format(string(ExpectedTarget), "~w/~w", [TargetPred, TargetArity]),
+    TargetPredArity == ExpectedTarget,
+    Num =:= ForeignArity.
+
+rust_foreign_spec(Pred/Arity,
+        foreign_predicate(Pred/Arity, SetupOps, RewriteCalls),
+        SetupOps,
+        RewriteCalls,
+        Pred/Arity) :-
+    is_list(SetupOps),
+    is_list(RewriteCalls).
 
 parse_index_entry_constant(Entry, Rust) :-
     (   sub_string(Entry, Before, 1, After, ":")

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1047,8 +1047,12 @@ compile_execute_foreign_predicate_to_rust(Code) :-
         if !self.foreign_predicates.contains(&pred_key) {
             return false;
         }
-        match pred_key.as_str() {
-            "category_ancestor/4" => {
+        let native_kind = match self.foreign_native_kind(&pred_key) {
+            Some(kind) => kind,
+            None => return false,
+        };
+        match native_kind {
+            "category_ancestor" => {
                 let cat = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
                     Some(Value::Atom(cat)) => cat,
                     _ => return false,
@@ -1344,9 +1348,11 @@ compile_resume_builtin_to_rust(Code) :-
                         cut_barrier: self.cut_barrier,
                     });
                 }
-                if pred_key != "category_ancestor/4" {
-                    return false;
-                }
+                let native_kind = match self.foreign_native_kind(&pred_key) {
+                    Some(kind) => kind,
+                    None => return false,
+                };
+                if native_kind != "category_ancestor" { return false; }
                 if self.unify(&hops_reg, &Value::Integer(hop)) {
                     self.pc += 1; true
                 } else { false }
@@ -1579,9 +1585,12 @@ rust_foreign_setup_code(Ops, Setup) :-
     maplist(rust_foreign_setup_line, Ops, Lines),
     atomic_list_concat(Lines, '\n', Setup).
 
-rust_foreign_setup_line(register_foreign_category_ancestor(MaxDepth), Line) :-
+rust_foreign_setup_line(register_foreign_native_kind(Pred/Arity, Kind), Line) :-
     format(string(Line),
-        '    vm.register_foreign_category_ancestor(~w);', [MaxDepth]).
+        '    vm.register_foreign_native_kind("~w/~w", "~w");', [Pred, Arity, Kind]).
+rust_foreign_setup_line(register_foreign_usize_config(Pred/Arity, Key, Value), Line) :-
+    format(string(Line),
+        '    vm.register_foreign_usize_config("~w/~w", "~w", ~w);', [Pred, Arity, Key, Value]).
 
 %% wam_code_to_rust_instructions(+WamCodeStr, +PredIndicator, +Options, -InstrLiterals, -LabelLiterals)
 %  Parses a WAM code string and generates Rust vec![] entries and label map inserts.

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1110,12 +1110,20 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                     Some(val) => val,
                     None => return false,
                 };
+                let target_filter = match self.deref_var(&target_reg) {
+                    Value::Atom(target) => Some(target),
+                    Value::Unbound(_) => None,
+                    _ => return false,
+                };
                 let edge_pred = match self.foreign_string_config(&pred_key, "edge_pred") {
                     Some(pred) => pred.to_string(),
                     None => return false,
                 };
                 let mut nodes: Vec<String> = Vec::new();
                 self.collect_native_transitive_closure_nodes(&start, &edge_pred, &mut nodes);
+                if let Some(target) = target_filter {
+                    nodes.retain(|node| *node == target);
+                }
                 if nodes.is_empty() {
                     return false;
                 }

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1066,7 +1066,7 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                     Some(_) => return false,
                     None => return false,
                 };
-                let max_depth = match self.foreign_category_ancestor_max_depth {
+                let max_depth = match self.foreign_usize_config(&pred_key, "max_depth") {
                     Some(limit) => limit,
                     None => return false,
                 };
@@ -1084,8 +1084,8 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                         trail_len: self.trail.len(),
                         heap_len: self.heap.len(),
                         builtin_state: Some(BuiltinState {
-                            name: "foreign:category_ancestor/4".to_string(),
-                            args: vec![hops_reg.clone()],
+                            name: "foreign_results".to_string(),
+                            args: vec![Value::Atom(pred_key.clone()), hops_reg.clone()],
                             data: hops[1..].iter().map(|hop| Value::Integer(*hop)).collect(),
                         }),
                         cut_barrier: self.cut_barrier,
@@ -1315,8 +1315,12 @@ compile_resume_builtin_to_rust(Code) :-
                     self.pc += 1; true
                 } else { false }
             }
-            "foreign:category_ancestor/4" => {
-                let hops_reg = match state.args.get(0) {
+            "foreign_results" => {
+                let pred_key = match state.args.get(0) {
+                    Some(Value::Atom(pred_key)) => pred_key.clone(),
+                    _ => return false,
+                };
+                let hops_reg = match state.args.get(1) {
                     Some(val) => val.clone(),
                     None => return false,
                 };
@@ -1333,12 +1337,15 @@ compile_resume_builtin_to_rust(Code) :-
                         trail_len: self.trail.len(),
                         heap_len: self.heap.len(),
                         builtin_state: Some(BuiltinState {
-                            name: "foreign:category_ancestor/4".to_string(),
+                            name: "foreign_results".to_string(),
                             args: state.args.clone(),
                             data: state.data[1..].to_vec(),
                         }),
                         cut_barrier: self.cut_barrier,
                     });
+                }
+                if pred_key != "category_ancestor/4" {
+                    return false;
                 }
                 if self.unify(&hops_reg, &Value::Integer(hop)) {
                     self.pc += 1; true

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -82,6 +82,8 @@ pub struct WamState {
     pub foreign_predicates: HashSet<String>,
     /// Native foreign handler kinds keyed by "name/arity".
     pub foreign_native_kinds: HashMap<String, String>,
+    /// Foreign predicate string configs keyed by "name/arity#config".
+    pub foreign_string_configs: HashMap<String, String>,
     /// Foreign predicate usize configs keyed by "name/arity#config".
     pub foreign_usize_configs: HashMap<String, usize>,
     /// Variable binding table: maps Unbound variable names to their bound values.
@@ -121,6 +123,7 @@ impl WamState {
             indexed_atom_fact2: HashMap::new(),
             foreign_predicates: HashSet::new(),
             foreign_native_kinds: HashMap::new(),
+            foreign_string_configs: HashMap::new(),
             foreign_usize_configs: HashMap::new(),
             bindings: HashMap::new(),
             var_counter: 0,
@@ -149,6 +152,17 @@ impl WamState {
         self.indexed_atom_fact2.insert(pred.to_string(), index);
     }
 
+    /// Register binary atom facts and build a first-argument index.
+    pub fn register_indexed_atom_fact2_pairs(&mut self, pred: &str, pairs: &[(&str, &str)]) {
+        let mut index: HashMap<String, Vec<String>> = HashMap::new();
+        for (left, right) in pairs {
+            index.entry((*left).to_string())
+                .or_insert_with(Vec::new)
+                .push((*right).to_string());
+        }
+        self.register_indexed_atom_fact2(pred, index);
+    }
+
     /// Register a foreign predicate implementation by "name/arity".
     pub fn register_foreign_predicate(&mut self, pred: &str) {
         self.foreign_predicates.insert(pred.to_string());
@@ -163,6 +177,18 @@ impl WamState {
     /// Fetch the native handler kind for a foreign predicate.
     pub fn foreign_native_kind(&self, pred: &str) -> Option<&str> {
         self.foreign_native_kinds.get(pred).map(|kind| kind.as_str())
+    }
+
+    /// Register a string configuration entry for a foreign predicate.
+    pub fn register_foreign_string_config(&mut self, pred: &str, key: &str, value: &str) {
+        self.foreign_string_configs.insert(format!("{}#{}", pred, key), value.to_string());
+    }
+
+    /// Fetch a string configuration entry for a foreign predicate.
+    pub fn foreign_string_config(&self, pred: &str, key: &str) -> Option<&str> {
+        self.foreign_string_configs
+            .get(&format!("{}#{}", pred, key))
+            .map(|value| value.as_str())
     }
 
     /// Register a usize configuration entry for a foreign predicate.

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -80,8 +80,8 @@ pub struct WamState {
     pub indexed_atom_fact2: HashMap<String, HashMap<String, Vec<String>>>,
     /// Registered foreign predicates keyed by "name/arity".
     pub foreign_predicates: HashSet<String>,
-    /// Configuration for the native category_ancestor/4 foreign predicate.
-    pub foreign_category_ancestor_max_depth: Option<usize>,
+    /// Foreign predicate usize configs keyed by "name/arity#config".
+    pub foreign_usize_configs: HashMap<String, usize>,
     /// Variable binding table: maps Unbound variable names to their bound values.
     /// This simulates the WAM heap's shared binding semantics when PutVariable
     /// creates a variable that's stored in both a Y-register and an A-register.
@@ -118,7 +118,7 @@ impl WamState {
             labels,
             indexed_atom_fact2: HashMap::new(),
             foreign_predicates: HashSet::new(),
-            foreign_category_ancestor_max_depth: None,
+            foreign_usize_configs: HashMap::new(),
             bindings: HashMap::new(),
             var_counter: 0,
             cut_barrier: 0,
@@ -151,10 +151,22 @@ impl WamState {
         self.foreign_predicates.insert(pred.to_string());
     }
 
+    /// Register a usize configuration entry for a foreign predicate.
+    pub fn register_foreign_usize_config(&mut self, pred: &str, key: &str, value: usize) {
+        self.foreign_usize_configs.insert(format!("{}#{}", pred, key), value);
+    }
+
+    /// Fetch a usize configuration entry for a foreign predicate.
+    pub fn foreign_usize_config(&self, pred: &str, key: &str) -> Option<usize> {
+        self.foreign_usize_configs
+            .get(&format!("{}#{}", pred, key))
+            .copied()
+    }
+
     /// Configure the native category_ancestor/4 foreign predicate.
     pub fn register_foreign_category_ancestor(&mut self, max_depth: usize) {
         self.register_foreign_predicate("category_ancestor/4");
-        self.foreign_category_ancestor_max_depth = Some(max_depth);
+        self.register_foreign_usize_config("category_ancestor/4", "max_depth", max_depth);
     }
 
     /// Dereference an Unbound variable through the binding table.

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -80,6 +80,8 @@ pub struct WamState {
     pub indexed_atom_fact2: HashMap<String, HashMap<String, Vec<String>>>,
     /// Registered foreign predicates keyed by "name/arity".
     pub foreign_predicates: HashSet<String>,
+    /// Native foreign handler kinds keyed by "name/arity".
+    pub foreign_native_kinds: HashMap<String, String>,
     /// Foreign predicate usize configs keyed by "name/arity#config".
     pub foreign_usize_configs: HashMap<String, usize>,
     /// Variable binding table: maps Unbound variable names to their bound values.
@@ -118,6 +120,7 @@ impl WamState {
             labels,
             indexed_atom_fact2: HashMap::new(),
             foreign_predicates: HashSet::new(),
+            foreign_native_kinds: HashMap::new(),
             foreign_usize_configs: HashMap::new(),
             bindings: HashMap::new(),
             var_counter: 0,
@@ -151,6 +154,17 @@ impl WamState {
         self.foreign_predicates.insert(pred.to_string());
     }
 
+    /// Register the native handler kind for a foreign predicate.
+    pub fn register_foreign_native_kind(&mut self, pred: &str, kind: &str) {
+        self.register_foreign_predicate(pred);
+        self.foreign_native_kinds.insert(pred.to_string(), kind.to_string());
+    }
+
+    /// Fetch the native handler kind for a foreign predicate.
+    pub fn foreign_native_kind(&self, pred: &str) -> Option<&str> {
+        self.foreign_native_kinds.get(pred).map(|kind| kind.as_str())
+    }
+
     /// Register a usize configuration entry for a foreign predicate.
     pub fn register_foreign_usize_config(&mut self, pred: &str, key: &str, value: usize) {
         self.foreign_usize_configs.insert(format!("{}#{}", pred, key), value);
@@ -161,12 +175,6 @@ impl WamState {
         self.foreign_usize_configs
             .get(&format!("{}#{}", pred, key))
             .copied()
-    }
-
-    /// Configure the native category_ancestor/4 foreign predicate.
-    pub fn register_foreign_category_ancestor(&mut self, max_depth: usize) {
-        self.register_foreign_predicate("category_ancestor/4");
-        self.register_foreign_usize_config("category_ancestor/4", "max_depth", max_depth);
     }
 
     /// Dereference an Unbound variable through the binding table.

--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -3,6 +3,7 @@
 % Usage: swipl -g run_tests -t halt tests/test_wam_rust_runtime.pl
 
 :- use_module('../src/unifyweaver/targets/wam_rust_target').
+:- use_module('../src/unifyweaver/targets/rust_target').
 :- use_module(library(process)).
 :- use_module(library(filesex)).
 
@@ -25,8 +26,16 @@ path(a, b).
 path(b, c).
 path(c, d).
 
-:- dynamic test_member/1.
-test_member(X) :- member(X, [1, 2, 3]).
+:- dynamic tc_parent/2.
+tc_parent(tom, bob).
+tc_parent(tom, liz).
+tc_parent(bob, ann).
+tc_parent(bob, pat).
+tc_parent(pat, jim).
+
+:- dynamic tc_ancestor/2.
+tc_ancestor(X, Y) :- tc_parent(X, Y).
+tc_ancestor(X, Y) :- tc_parent(X, Z), tc_ancestor(Z, Y).
 
 %% Integration test
 test_runtime_execution :-
@@ -38,8 +47,8 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:fact/1, user:path/2, user:test_member/1], 
-            [module_name('runtime_test'), wam_fallback(true)], TmpDir),
+        write_wam_rust_project([user:tc_ancestor/2],
+            [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
         make_directory_path('output/test_wam_rust_runtime_e2e/tests'),
@@ -47,64 +56,52 @@ test_runtime_execution :-
         TestContent = '
 use runtime_test::value::Value;
 use runtime_test::state::WamState;
-use runtime_test::{fact, path, test_member};
+use runtime_test::tc_ancestor;
 
 #[test]
 fn test_generated_predicates() {
-    // Test fact/1
-    let mut vm_fact = WamState::new(vec![], std::collections::HashMap::new());
-    let ok1 = fact(&mut vm_fact, Value::Atom("alice".to_string()));
-    assert!(ok1, "fact(alice) should succeed");
-    
-    let ok2 = fact(&mut vm_fact, Value::Atom("charlie".to_string()));
-    assert!(!ok2, "fact(charlie) should fail");
-    
-    // Test path/2
-    let mut vm_path = WamState::new(vec![], std::collections::HashMap::new());
-    let ok3 = path(&mut vm_path, Value::Atom("a".to_string()), Value::Atom("b".to_string()));
-    assert!(ok3, "path(a, b) should succeed");
+    // Test tc_ancestor/2 foreign lowering end-to-end
+    let mut vm_tc = WamState::new(vec![], std::collections::HashMap::new());
+    let ok1 = tc_ancestor(&mut vm_tc,
+        Value::Atom("tom".to_string()),
+        Value::Unbound("Desc".to_string()));
+    assert!(ok1, "tc_ancestor(tom, Desc) first solution should succeed");
 
-    // Test relational member/2 directly
-    let mut vm_direct = WamState::new(vec![], std::collections::HashMap::new());
-    let list = Value::List(vec![Value::Integer(1), Value::Integer(2), Value::Integer(3)]);
-    vm_direct.set_reg("A1", Value::Unbound("X".to_string()));
-    vm_direct.set_reg("A2", list);
-    
-    // First solution: X=1
-    let mut ok_mem = vm_direct.execute_builtin("member/2", 2);
-    assert!(ok_mem, "member first call should succeed");
-    assert_eq!(vm_direct.get_reg("X"), Some(Value::Integer(1)));
-    
-    // Backtrack for second solution: X=2
-    ok_mem = vm_direct.backtrack();
-    assert!(ok_mem, "member second solution should succeed");
-    assert_eq!(vm_direct.get_reg("X"), Some(Value::Integer(2)));
-    
-    // Backtrack for third solution: X=3
-    ok_mem = vm_direct.backtrack();
-    assert!(ok_mem, "member third solution should succeed");
-    assert_eq!(vm_direct.get_reg("X"), Some(Value::Integer(3)));
-    
-    // Fourth backtrack: should fail
-    ok_mem = vm_direct.backtrack();
-    assert!(!ok_mem, "member fourth solution should fail");
+    let mut descendants: Vec<String> = Vec::new();
+    if let Some(Value::Atom(desc)) = vm_tc.bindings.get("Desc").cloned() {
+        descendants.push(desc);
+    } else {
+        panic!("expected first tc_ancestor result in Desc");
+    }
 
-    // Test test_member/1 which calls member/2 via WAM instructions
-    let mut vm_nested = WamState::new(vec![], std::collections::HashMap::new());
-    let ok4 = test_member(&mut vm_nested, Value::Unbound("Y".to_string()));
-    assert!(ok4, "test_member(Y) first solution should succeed");
-    assert_eq!(vm_nested.get_reg("Y"), Some(Value::Integer(1)));
+    while vm_tc.backtrack() {
+        if let Some(Value::Atom(desc)) = vm_tc.bindings.get("Desc").cloned() {
+            descendants.push(desc);
+        } else {
+            panic!("expected backtracked tc_ancestor result in Desc");
+        }
+    }
 
-    let ok5 = vm_nested.backtrack();
-    assert!(ok5, "test_member(Y) second solution should succeed");
-    assert_eq!(vm_nested.get_reg("Y"), Some(Value::Integer(2)));
+    descendants.sort();
+    assert_eq!(descendants, vec![
+        "ann".to_string(),
+        "bob".to_string(),
+        "jim".to_string(),
+        "liz".to_string(),
+        "pat".to_string(),
+    ]);
 
-    let ok6 = vm_nested.backtrack();
-    assert!(ok6, "test_member(Y) third solution should succeed");
-    assert_eq!(vm_nested.get_reg("Y"), Some(Value::Integer(3)));
+    let mut vm_tc_check = WamState::new(vec![], std::collections::HashMap::new());
+    let ok2 = tc_ancestor(&mut vm_tc_check,
+        Value::Atom("tom".to_string()),
+        Value::Atom("jim".to_string()));
+    assert!(ok2, "tc_ancestor(tom, jim) should succeed");
 
-    let ok7 = vm_nested.backtrack();
-    assert!(!ok7, "test_member(Y) fourth solution should fail");
+    let mut vm_tc_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok3 = tc_ancestor(&mut vm_tc_fail,
+        Value::Atom("liz".to_string()),
+        Value::Atom("jim".to_string()));
+    assert!(!ok3, "tc_ancestor(liz, jim) should fail");
 }
 ',
         setup_call_cleanup(open(TestPath, write, S), format(S, "~w", [TestContent]), close(S)),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -29,6 +29,7 @@ test_simple_fact(foo, bar).
 :- dynamic category_ancestor/4.
 :- dynamic category_parent/2.
 :- dynamic tc_ancestor/2.
+:- dynamic tc_descendant/2.
 :- dynamic tc_parent/2.
 :- dynamic max_depth/1.
 
@@ -59,6 +60,9 @@ tc_parent(pat, jim).
 
 tc_ancestor(X, Y) :- tc_parent(X, Y).
 tc_ancestor(X, Y) :- tc_parent(X, Z), tc_ancestor(Z, Y).
+
+tc_descendant(X, Y) :- tc_parent(Y, X).
+tc_descendant(X, Y) :- tc_parent(Z, X), tc_descendant(Z, Y).
 
 pass(Test) :-
     format('[PASS] ~w~n', [Test]).
@@ -334,6 +338,20 @@ test_foreign_lowering_transitive_closure :-
         sub_string(S, _, _, _, 'Instruction::CallForeign("tc_ancestor".to_string(), 2)')
     ->  pass(Test)
     ;   fail_test(Test, 'Foreign lowering was not selected for tc_ancestor/2')
+    ).
+
+test_foreign_lowering_reverse_transitive_closure :-
+    Test = 'WAM-Rust: compiler can choose foreign lowering for tc_descendant/2',
+    (   rust_target:compile_predicate_to_rust(user:tc_descendant/2,
+            [include_main(false), foreign_lowering(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("tc_descendant/2", "transitive_closure2")'),
+        sub_string(S, _, _, _, 'register_foreign_string_config("tc_descendant/2", "edge_pred", "tc_parent/2")'),
+        sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("tc_parent/2", &[("tom", "bob"), ("tom", "liz"), ("bob", "ann"), ("bob", "pat"), ("pat", "jim")])'),
+        sub_string(S, _, _, _, 'execute_foreign_predicate("tc_descendant", 2)'),
+        sub_string(S, _, _, _, 'Instruction::CallForeign("tc_descendant".to_string(), 2)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Foreign lowering was not selected for tc_descendant/2')
     ).
 
 test_compile_wam_runtime_output :-
@@ -627,6 +645,7 @@ run_tests :-
     test_generated_rust_has_wam_wrapper,
     test_foreign_lowering_category_ancestor,
     test_foreign_lowering_transitive_closure,
+    test_foreign_lowering_reverse_transitive_closure,
     test_compile_wam_runtime_output,
     test_write_wam_rust_project,
     test_project_cargo_content,

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -28,6 +28,8 @@ test_simple_fact(foo, bar).
 
 :- dynamic category_ancestor/4.
 :- dynamic category_parent/2.
+:- dynamic tc_ancestor/2.
+:- dynamic tc_parent/2.
 :- dynamic max_depth/1.
 
 max_depth(10).
@@ -48,6 +50,15 @@ category_ancestor(Cat, Target, Hops, Visited) :-
     \+ member(Mid, Visited),
     category_ancestor(Mid, Target, H1, [Mid|Visited]),
     Hops is H1 + 1.
+
+tc_parent(tom, bob).
+tc_parent(tom, liz).
+tc_parent(bob, ann).
+tc_parent(bob, pat).
+tc_parent(pat, jim).
+
+tc_ancestor(X, Y) :- tc_parent(X, Y).
+tc_ancestor(X, Y) :- tc_parent(X, Z), tc_ancestor(Z, Y).
 
 pass(Test) :-
     format('[PASS] ~w~n', [Test]).
@@ -311,6 +322,20 @@ test_foreign_lowering_category_ancestor :-
     ;   fail_test(Test, 'Foreign lowering was not selected for category_ancestor/4')
     ).
 
+test_foreign_lowering_transitive_closure :-
+    Test = 'WAM-Rust: compiler can choose foreign lowering for tc_ancestor/2',
+    (   rust_target:compile_predicate_to_rust(user:tc_ancestor/2,
+            [include_main(false), foreign_lowering(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("tc_ancestor/2", "transitive_closure2")'),
+        sub_string(S, _, _, _, 'register_foreign_string_config("tc_ancestor/2", "edge_pred", "tc_parent/2")'),
+        sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("tc_parent/2", &[("tom", "bob"), ("tom", "liz"), ("bob", "ann"), ("bob", "pat"), ("pat", "jim")])'),
+        sub_string(S, _, _, _, 'execute_foreign_predicate("tc_ancestor", 2)'),
+        sub_string(S, _, _, _, 'Instruction::CallForeign("tc_ancestor".to_string(), 2)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Foreign lowering was not selected for tc_ancestor/2')
+    ).
+
 test_compile_wam_runtime_output :-
     Test = 'WAM-Rust E2E: full runtime generates valid impl block',
     (   compile_wam_runtime_to_rust([], Code),
@@ -329,8 +354,11 @@ test_compile_wam_runtime_output :-
         sub_string(S, _, _, _, 'Proceed'),
         sub_string(S, _, _, _, 'TryMeElse'),
         sub_string(S, _, _, _, 'foreign_native_kind(&pred_key)'),
+        sub_string(S, _, _, _, 'foreign_string_config(&pred_key, "edge_pred")'),
         sub_string(S, _, _, _, 'foreign_usize_config(&pred_key, "max_depth")'),
-        sub_string(S, _, _, _, 'name: "foreign_results".to_string()')
+        sub_string(S, _, _, _, 'name: "foreign_results".to_string()'),
+        sub_string(S, _, _, _, 'transitive_closure2'),
+        sub_string(S, _, _, _, 'collect_native_transitive_closure_nodes')
     ->  pass(Test)
     ;   fail_test(Test, 'Runtime impl block incomplete')
     ).
@@ -598,6 +626,7 @@ run_tests :-
     test_wam_fallback_flag,
     test_generated_rust_has_wam_wrapper,
     test_foreign_lowering_category_ancestor,
+    test_foreign_lowering_transitive_closure,
     test_compile_wam_runtime_output,
     test_write_wam_rust_project,
     test_project_cargo_content,

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -209,6 +209,24 @@ test_predicate_wrapper :-
     ;   fail_test(Test, 'Incorrect predicate wrapper')
     ).
 
+test_foreign_spec_wrapper_generation :-
+    Test = 'WAM-Rust: generic foreign spec drives wrapper generation',
+    ForeignSpec = foreign_predicate(
+        category_ancestor/4,
+        [register_foreign_category_ancestor(10)],
+        [category_ancestor/4]
+    ),
+    WamCode = "call category_ancestor/4, 4",
+    (   compile_wam_predicate_to_rust(category_ancestor/4, WamCode,
+            [foreign_lowering(ForeignSpec)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'register_foreign_category_ancestor(10)'),
+        sub_string(S, _, _, _, 'execute_foreign_predicate("category_ancestor", 4)'),
+        sub_string(S, _, _, _, 'Instruction::CallForeign("category_ancestor".to_string(), 4)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Generic foreign spec did not drive wrapper generation')
+    ).
+
 %% Phase 4: WAM fallback integration tests
 
 test_wam_fallback_enabled :-
@@ -566,6 +584,7 @@ run_tests :-
     test_all_instruction_arms,
     test_builtin_dispatch,
     test_predicate_wrapper,
+    test_foreign_spec_wrapper_generation,
     test_wam_fallback_enabled,
     test_wam_fallback_disabled,
     test_native_still_preferred,

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -323,7 +323,9 @@ test_compile_wam_runtime_output :-
         sub_string(S, _, _, _, 'BeginAggregate'),
         sub_string(S, _, _, _, 'EndAggregate'),
         sub_string(S, _, _, _, 'Proceed'),
-        sub_string(S, _, _, _, 'TryMeElse')
+        sub_string(S, _, _, _, 'TryMeElse'),
+        sub_string(S, _, _, _, 'foreign_usize_config(&pred_key, "max_depth")'),
+        sub_string(S, _, _, _, 'name: "foreign_results".to_string()')
     ->  pass(Test)
     ;   fail_test(Test, 'Runtime impl block incomplete')
     ).

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -26,6 +26,29 @@ test_simple_fact(foo, bar).
 
 :- dynamic test_failed/0.
 
+:- dynamic category_ancestor/4.
+:- dynamic category_parent/2.
+:- dynamic max_depth/1.
+
+max_depth(10).
+category_parent(alpha, beta).
+category_parent(beta, gamma).
+category_parent(gamma, physics).
+category_parent(beta, physics).
+
+category_ancestor(Cat, Target, 1, Visited) :-
+    category_parent(Cat, Target),
+    \+ member(Target, Visited).
+category_ancestor(Cat, Target, Hops, Visited) :-
+    max_depth(MaxD),
+    length(Visited, Depth),
+    Depth < MaxD,
+    !,
+    category_parent(Cat, Mid),
+    \+ member(Mid, Visited),
+    category_ancestor(Mid, Target, H1, [Mid|Visited]),
+    Hops is H1 + 1.
+
 pass(Test) :-
     format('[PASS] ~w~n', [Test]).
 
@@ -252,6 +275,18 @@ test_generated_rust_has_wam_wrapper :-
         sub_string(S, _, _, _, 'set_reg')
     ->  pass(Test)
     ;   fail_test(Test, 'Generated wrapper missing expected elements')
+    ).
+
+test_foreign_lowering_category_ancestor :-
+    Test = 'WAM-Rust: compiler can choose foreign lowering for category_ancestor/4',
+    (   rust_target:compile_predicate_to_rust(user:category_ancestor/4,
+            [include_main(false), foreign_lowering(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'register_foreign_category_ancestor(10)'),
+        sub_string(S, _, _, _, 'execute_foreign_predicate("category_ancestor", 4)'),
+        sub_string(S, _, _, _, 'Instruction::CallForeign("category_ancestor".to_string(), 4)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Foreign lowering was not selected for category_ancestor/4')
     ).
 
 test_compile_wam_runtime_output :-
@@ -536,6 +571,7 @@ run_tests :-
     test_native_still_preferred,
     test_wam_fallback_flag,
     test_generated_rust_has_wam_wrapper,
+    test_foreign_lowering_category_ancestor,
     test_compile_wam_runtime_output,
     test_write_wam_rust_project,
     test_project_cargo_content,

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -213,14 +213,17 @@ test_foreign_spec_wrapper_generation :-
     Test = 'WAM-Rust: generic foreign spec drives wrapper generation',
     ForeignSpec = foreign_predicate(
         category_ancestor/4,
-        [register_foreign_category_ancestor(10)],
+        [ register_foreign_native_kind(category_ancestor/4, category_ancestor),
+          register_foreign_usize_config(category_ancestor/4, max_depth, 10)
+        ],
         [category_ancestor/4]
     ),
     WamCode = "call category_ancestor/4, 4",
     (   compile_wam_predicate_to_rust(category_ancestor/4, WamCode,
             [foreign_lowering(ForeignSpec)], Code),
         atom_string(Code, S),
-        sub_string(S, _, _, _, 'register_foreign_category_ancestor(10)'),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("category_ancestor/4", "category_ancestor")'),
+        sub_string(S, _, _, _, 'register_foreign_usize_config("category_ancestor/4", "max_depth", 10)'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("category_ancestor", 4)'),
         sub_string(S, _, _, _, 'Instruction::CallForeign("category_ancestor".to_string(), 4)')
     ->  pass(Test)
@@ -300,7 +303,8 @@ test_foreign_lowering_category_ancestor :-
     (   rust_target:compile_predicate_to_rust(user:category_ancestor/4,
             [include_main(false), foreign_lowering(true)], Code),
         atom_string(Code, S),
-        sub_string(S, _, _, _, 'register_foreign_category_ancestor(10)'),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("category_ancestor/4", "category_ancestor")'),
+        sub_string(S, _, _, _, 'register_foreign_usize_config("category_ancestor/4", "max_depth", 10)'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("category_ancestor", 4)'),
         sub_string(S, _, _, _, 'Instruction::CallForeign("category_ancestor".to_string(), 4)')
     ->  pass(Test)
@@ -324,6 +328,7 @@ test_compile_wam_runtime_output :-
         sub_string(S, _, _, _, 'EndAggregate'),
         sub_string(S, _, _, _, 'Proceed'),
         sub_string(S, _, _, _, 'TryMeElse'),
+        sub_string(S, _, _, _, 'foreign_native_kind(&pred_key)'),
         sub_string(S, _, _, _, 'foreign_usize_config(&pred_key, "max_depth")'),
         sub_string(S, _, _, _, 'name: "foreign_results".to_string()')
     ->  pass(Test)


### PR DESCRIPTION
## Summary

This PR generalizes the Rust WAM foreign-lowering path from a benchmark-specific `category_ancestor/4` optimization into a compiler-selected mechanism for recursive predicate schemas.

It adds:

- compiler-selected foreign lowering for supported recursive predicates
- structured foreign-lowering specs passed from the compiler to the WAM-Rust wrapper generator
- generalized Rust runtime config and native handler registration for foreign predicates
- foreign lowering for binary transitive closure predicates such as `tc_ancestor/2`
- support for reversed closure variants such as `tc_descendant/2`
- end-to-end runtime validation for foreign-lowered transitive closure execution

## Why

The earlier `category_ancestor/4` work proved that a foreign/native path is the right abstraction for high-level recursive search predicates that are too expensive to execute instruction-by-instruction in the generic WAM runtime.

This PR moves that approach toward a reusable feature:

- the compiler can now recognize supported recursive schemas and choose foreign lowering directly
- the WAM-Rust generator no longer depends on a single hardcoded predicate shape
- the runtime can dispatch foreign predicates by registered native handler kind plus structured config

## Main Changes

### Compiler and Codegen

- Added compiler-driven foreign lowering selection in [rust_target.pl](/data/data/com.termux/files/home/UnifyWeaver/context/claude/UnifyWeaver/src/unifyweaver/targets/rust_target.pl).
- Introduced normalized foreign-lowering schema/spec handling instead of ad hoc per-predicate wiring.
- Extended foreign lowering beyond `category_ancestor/4` to binary transitive closure.
- Added support for reverse closure schemas, allowing predicates like `tc_descendant/2` to lower through the same native handler path.

### Rust WAM Runtime

- Generalized foreign runtime configuration in [wam_rust_target.pl](/data/data/com.termux/files/home/UnifyWeaver/context/claude/UnifyWeaver/src/unifyweaver/targets/wam_rust_target.pl) and [state.rs.mustache](/data/data/com.termux/files/home/UnifyWeaver/context/claude/UnifyWeaver/templates/targets/rust_wam/state.rs.mustache).
- Switched dispatch from predicate-specific handling to registered foreign native handler kinds.
- Added generic string/config plumbing needed by transitive closure lowering.
- Fixed concrete-target filtering for the `transitive_closure2` foreign runtime path so queries like `tc_ancestor(tom, jim)` behave correctly.

### Tests

- Added/updated compiler-selection coverage in [test_wam_rust_target.pl](/data/data/com.termux/files/home/UnifyWeaver/context/claude/UnifyWeaver/tests/test_wam_rust_target.pl) for:
  - `category_ancestor/4`
  - `tc_ancestor/2`
  - `tc_descendant/2`
- Added end-to-end runtime validation in [test_wam_rust_runtime.pl](/data/data/com.termux/files/home/UnifyWeaver/context/claude/UnifyWeaver/tests/test_wam_rust_runtime.pl) for foreign-lowered `tc_ancestor/2` in a generated Rust project.

## Validation

Ran locally:

- `swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`

Both passed locally.

## Scope Notes

This PR does not try to make foreign lowering fully automatic for arbitrary recursion. It introduces a cleaner compiler/runtime path plus two concrete recursive families:

- bounded graph ancestry via `category_ancestor/4`
- binary transitive closure, including reversed forms

That keeps the implementation reviewable while establishing the architecture needed to extend foreign lowering to more recursive schemas later.
