### PR TITLE
feat: Rust/C# fuzzy dispatch and Go batch fuzzy operations

### DIFF
--- a/docs/design/SEMANTIC_INTERFACE_IMPLEMENTATION_PLAN.md
+++ b/docs/design/SEMANTIC_INTERFACE_IMPLEMENTATION_PLAN.md
@@ -19,12 +19,17 @@
 - [x] Implement Go fuzzy dispatch: f_and, f_or, f_dist_or, f_union, f_not, blend_scores, top_k.
 - [x] Tests for fuzzy recognition, Go codegen, Python dispatch.
 
+## Phase 2c: Full Fuzzy Target Coverage (Completed)
+- [x] Implement Rust fuzzy dispatch: f_and, f_or, f_dist_or, f_union, f_not, blend_scores, top_k.
+- [x] Implement C# fuzzy dispatch: all core ops + LINQ-based blend_scores and top_k.
+- [x] Go batch fuzzy operations: f_and_batch, f_or_batch, f_dist_or_batch, f_union_batch.
+- [x] Tests for Rust (AND/OR/NOT), C# (AND/OR/NOT), Go batch (AND/OR).
+
 ## Phase 3: Runtime Integration & Data Sources
 - [ ] Extend `input_source.pl` to handle vector index files for different targets.
 - [ ] Add support for `semantic_search/4` (options including threshold, custom model).
 - [ ] Integrate with `cross_runtime_pipeline.pl` to allow multi-language semantic stages.
-- [ ] Implement Rust and C# fuzzy dispatch (core operations).
-- [ ] Go fuzzy batch operations (slice-based vectorization).
+- [ ] Rust and C# batch fuzzy operations.
 
 ## Phase 4: Extended Target Coverage & Polish
 - [ ] Implement `semantic_dispatch` for Elixir (via Bumblebee/NX).

--- a/docs/design/SEMANTIC_INTERFACE_SPECIFICATION.md
+++ b/docs/design/SEMANTIC_INTERFACE_SPECIFICATION.md
@@ -82,7 +82,9 @@ The `semantic_compiler` also provides a `fuzzy_dispatch/3` multifile hook for co
 | Target | Core ops | Batch ops | Utility ops |
 |--------|----------|-----------|-------------|
 | **Python** | f\_and, f\_or, f\_dist\_or, f\_union, f\_not | f\_and\_batch, f\_or\_batch, f\_dist\_or\_batch | blend, top\_k, filter, boost |
-| **Go** | f\_and, f\_or, f\_dist\_or, f\_union, f\_not | — | blend, top\_k |
+| **Go** | f\_and, f\_or, f\_dist\_or, f\_union, f\_not | f\_and\_batch, f\_or\_batch, f\_dist\_or\_batch, f\_union\_batch | blend, top\_k |
+| **Rust** | f\_and, f\_or, f\_dist\_or, f\_union, f\_not | — | blend, top\_k |
+| **C#** | f\_and, f\_or, f\_dist\_or, f\_union, f\_not | — | blend (LINQ Zip), top\_k (LINQ OrderByDescending) |
 
 ### 4.5 Usage Example
 

--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -83,6 +83,107 @@ semantic_compiler:semantic_dispatch(csharp, Goal, Provider, VarMap, Code) :-
     var results = searcher.Search("~w", ~w);
 ', [Model, DeviceInit, Model, QueryExpr, TopKExpr]).
 
+% ============================================================================
+% FUZZY LOGIC DISPATCH (C# target)
+% ============================================================================
+%
+% Generates inline C# code for fuzzy operations using LINQ where appropriate.
+% Assumes `termScores` (Dictionary<string, double>) is in scope.
+
+:- multifile semantic_compiler:fuzzy_dispatch/3.
+
+%% f_and: Fuzzy AND (product t-norm)
+semantic_compiler:fuzzy_dispatch(csharp, f_and(Terms, _Result), Code) :-
+    generate_csharp_product_terms(Terms, TermCode),
+    format(string(Code),
+'    // Fuzzy AND (product t-norm)
+    double result = 1.0;
+~w', [TermCode]).
+
+%% f_or: Fuzzy OR (probabilistic sum)
+semantic_compiler:fuzzy_dispatch(csharp, f_or(Terms, _Result), Code) :-
+    generate_csharp_complement_terms(Terms, TermCode),
+    format(string(Code),
+'    // Fuzzy OR (probabilistic sum)
+    double complement = 1.0;
+~w    double result = 1.0 - complement;
+', [TermCode]).
+
+%% f_dist_or: Distributed OR
+semantic_compiler:fuzzy_dispatch(csharp, f_dist_or(BaseScore, Terms, _Result), Code) :-
+    (number(BaseScore) -> format(string(BaseExpr), "~w", [BaseScore]) ; BaseExpr = BaseScore),
+    generate_csharp_dist_complement_terms(BaseExpr, Terms, TermCode),
+    format(string(Code),
+'    // Fuzzy distributed OR
+    double complement = 1.0;
+~w    double result = 1.0 - complement;
+', [TermCode]).
+
+%% f_union: Non-distributed OR (base * OR result)
+semantic_compiler:fuzzy_dispatch(csharp, f_union(BaseScore, Terms, _Result), Code) :-
+    (number(BaseScore) -> format(string(BaseExpr), "~w", [BaseScore]) ; BaseExpr = BaseScore),
+    generate_csharp_complement_terms(Terms, TermCode),
+    format(string(Code),
+'    // Fuzzy union (base * OR)
+    double complement = 1.0;
+~w    double result = ~w * (1.0 - complement);
+', [TermCode, BaseExpr]).
+
+%% f_not: Fuzzy NOT (complement)
+semantic_compiler:fuzzy_dispatch(csharp, f_not(Score, _Result), Code) :-
+    (number(Score) -> format(string(ScoreExpr), "~w", [Score]) ; format(string(ScoreExpr), "~w", [Score])),
+    format(string(Code), '    double result = 1.0 - ~w;\n', [ScoreExpr]).
+
+%% blend_scores: Weighted interpolation using LINQ Zip
+semantic_compiler:fuzzy_dispatch(csharp, blend_scores(Alpha, Scores1, Scores2, _Result), Code) :-
+    (number(Alpha) -> format(string(AExpr), "~w", [Alpha]) ; AExpr = Alpha),
+    format(string(Code),
+'    // Blend scores: alpha*s1 + (1-alpha)*s2
+    var result = ~w.Zip(~w, (s1, s2) => ~w * s1 + (1.0 - ~w) * s2).ToArray();
+', [Scores1, Scores2, AExpr, AExpr]).
+
+%% top_k: Get top K items by score using LINQ
+semantic_compiler:fuzzy_dispatch(csharp, top_k(Items, K, _Result), Code) :-
+    format(string(Code),
+'    // Top-K selection
+    var result = ~w.OrderByDescending(x => x.Score).Take(~w).ToList();
+', [Items, K]).
+
+% ---- Helpers for generating per-term C# code ----
+
+generate_csharp_product_terms([], '').
+generate_csharp_product_terms([w(Term, Weight)|Rest], Code) :-
+    generate_csharp_product_terms(Rest, RestCode),
+    format(string(Line), '    result *= ~w * (termScores.TryGetValue("~w", out var s_~w) ? s_~w : 0.5);\n', [Weight, Term, Term, Term]),
+    string_concat(Line, RestCode, Code).
+generate_csharp_product_terms([Term|Rest], Code) :-
+    atom(Term),
+    generate_csharp_product_terms(Rest, RestCode),
+    format(string(Line), '    result *= termScores.TryGetValue("~w", out var s_~w) ? s_~w : 0.5;\n', [Term, Term, Term]),
+    string_concat(Line, RestCode, Code).
+
+generate_csharp_complement_terms([], '').
+generate_csharp_complement_terms([w(Term, Weight)|Rest], Code) :-
+    generate_csharp_complement_terms(Rest, RestCode),
+    format(string(Line), '    complement *= 1.0 - ~w * (termScores.TryGetValue("~w", out var s_~w) ? s_~w : 0.5);\n', [Weight, Term, Term, Term]),
+    string_concat(Line, RestCode, Code).
+generate_csharp_complement_terms([Term|Rest], Code) :-
+    atom(Term),
+    generate_csharp_complement_terms(Rest, RestCode),
+    format(string(Line), '    complement *= 1.0 - (termScores.TryGetValue("~w", out var s_~w) ? s_~w : 0.5);\n', [Term, Term, Term]),
+    string_concat(Line, RestCode, Code).
+
+generate_csharp_dist_complement_terms(_, [], '').
+generate_csharp_dist_complement_terms(BaseExpr, [w(Term, Weight)|Rest], Code) :-
+    generate_csharp_dist_complement_terms(BaseExpr, Rest, RestCode),
+    format(string(Line), '    complement *= 1.0 - ~w * ~w * (termScores.TryGetValue("~w", out var s_~w) ? s_~w : 0.5);\n', [BaseExpr, Weight, Term, Term, Term]),
+    string_concat(Line, RestCode, Code).
+generate_csharp_dist_complement_terms(BaseExpr, [Term|Rest], Code) :-
+    atom(Term),
+    generate_csharp_dist_complement_terms(BaseExpr, Rest, RestCode),
+    format(string(Line), '    complement *= 1.0 - ~w * (termScores.TryGetValue("~w", out var s_~w) ? s_~w : 0.5);\n', [BaseExpr, Term, Term, Term]),
+    string_concat(Line, RestCode, Code).
+
 :- dynamic query_materialized_relation/1.
 :- discontiguous emit_plan_expression/2.
 

--- a/src/unifyweaver/targets/go_target.pl
+++ b/src/unifyweaver/targets/go_target.pl
@@ -8418,6 +8418,122 @@ generate_go_dist_complement_terms(BaseExpr, [Term|Rest], Code) :-
     format(string(Line), '\tcomplement *= (1 - ~w * termScores["~w"])\n', [BaseExpr, Term]),
     string_concat(Line, RestCode, Code).
 
+% ============================================================================
+% FUZZY BATCH OPERATIONS (Go target)
+% ============================================================================
+%
+% Slice-based batch fuzzy operations. Operates on []float64 score slices,
+% one score per item. Assumes termScoresBatch (map[string][]float64) is in scope.
+
+%% f_and_batch: Batch product t-norm over slices
+semantic_compiler:fuzzy_dispatch(go, f_and_batch(Terms, _ScoresBatch, _Result), Code) :-
+    generate_go_batch_product_terms(Terms, TermCode),
+    format(string(Code),
+'\t// Batch fuzzy AND (product t-norm)
+\tn := batchLen(termScoresBatch)
+\tresult := make([]float64, n)
+\tfor i := range result { result[i] = 1.0 }
+~w', [TermCode]).
+
+%% f_or_batch: Batch probabilistic sum over slices
+semantic_compiler:fuzzy_dispatch(go, f_or_batch(Terms, _ScoresBatch, _Result), Code) :-
+    generate_go_batch_complement_terms(Terms, TermCode),
+    format(string(Code),
+'\t// Batch fuzzy OR (probabilistic sum)
+\tn := batchLen(termScoresBatch)
+\tcomplement := make([]float64, n)
+\tfor i := range complement { complement[i] = 1.0 }
+~w\tresult := make([]float64, n)
+\tfor i := range result { result[i] = 1 - complement[i] }
+', [TermCode]).
+
+%% f_dist_or_batch: Batch distributed OR
+semantic_compiler:fuzzy_dispatch(go, f_dist_or_batch(BaseScores, Terms, _ScoresBatch, _Result), Code) :-
+    generate_go_batch_dist_complement_terms(Terms, TermCode),
+    format(string(Code),
+'\t// Batch fuzzy distributed OR
+\tn := len(~w)
+\tcomplement := make([]float64, n)
+\tfor i := range complement { complement[i] = 1.0 }
+~w\tresult := make([]float64, n)
+\tfor i := range result { result[i] = 1 - complement[i] }
+', [BaseScores, TermCode]).
+
+%% f_union_batch: Batch non-distributed OR
+semantic_compiler:fuzzy_dispatch(go, f_union_batch(BaseScores, Terms, _ScoresBatch, _Result), Code) :-
+    generate_go_batch_complement_terms(Terms, TermCode),
+    format(string(Code),
+'\t// Batch fuzzy union (base * OR)
+\tn := len(~w)
+\tcomplement := make([]float64, n)
+\tfor i := range complement { complement[i] = 1.0 }
+~w\tresult := make([]float64, n)
+\tfor i := range result { result[i] = ~w[i] * (1 - complement[i]) }
+', [BaseScores, TermCode, BaseScores]).
+
+% ---- Batch helper generators ----
+
+%% generate_go_batch_product_terms(+Terms, -Code)
+%  Generate: for i := range result { result[i] *= weight * scores[i] }
+generate_go_batch_product_terms([], '').
+generate_go_batch_product_terms([w(Term, Weight)|Rest], Code) :-
+    generate_go_batch_product_terms(Rest, RestCode),
+    format(string(Line),
+'\tif scores, ok := termScoresBatch["~w"]; ok {
+\t\tfor i := range result { result[i] *= ~w * scores[i] }
+\t}
+', [Term, Weight]),
+    string_concat(Line, RestCode, Code).
+generate_go_batch_product_terms([Term|Rest], Code) :-
+    atom(Term),
+    generate_go_batch_product_terms(Rest, RestCode),
+    format(string(Line),
+'\tif scores, ok := termScoresBatch["~w"]; ok {
+\t\tfor i := range result { result[i] *= scores[i] }
+\t}
+', [Term]),
+    string_concat(Line, RestCode, Code).
+
+%% generate_go_batch_complement_terms(+Terms, -Code)
+generate_go_batch_complement_terms([], '').
+generate_go_batch_complement_terms([w(Term, Weight)|Rest], Code) :-
+    generate_go_batch_complement_terms(Rest, RestCode),
+    format(string(Line),
+'\tif scores, ok := termScoresBatch["~w"]; ok {
+\t\tfor i := range complement { complement[i] *= (1 - ~w * scores[i]) }
+\t}
+', [Term, Weight]),
+    string_concat(Line, RestCode, Code).
+generate_go_batch_complement_terms([Term|Rest], Code) :-
+    atom(Term),
+    generate_go_batch_complement_terms(Rest, RestCode),
+    format(string(Line),
+'\tif scores, ok := termScoresBatch["~w"]; ok {
+\t\tfor i := range complement { complement[i] *= (1 - scores[i]) }
+\t}
+', [Term]),
+    string_concat(Line, RestCode, Code).
+
+%% generate_go_batch_dist_complement_terms(+Terms, -Code)
+generate_go_batch_dist_complement_terms([], '').
+generate_go_batch_dist_complement_terms([w(Term, Weight)|Rest], Code) :-
+    generate_go_batch_dist_complement_terms(Rest, RestCode),
+    format(string(Line),
+'\tif scores, ok := termScoresBatch["~w"]; ok {
+\t\tfor i := range complement { complement[i] *= (1 - baseScores[i] * ~w * scores[i]) }
+\t}
+', [Term, Weight]),
+    string_concat(Line, RestCode, Code).
+generate_go_batch_dist_complement_terms([Term|Rest], Code) :-
+    atom(Term),
+    generate_go_batch_dist_complement_terms(Rest, RestCode),
+    format(string(Line),
+'\tif scores, ok := termScoresBatch["~w"]; ok {
+\t\tfor i := range complement { complement[i] *= (1 - baseScores[i] * scores[i]) }
+\t}
+', [Term]),
+    string_concat(Line, RestCode, Code).
+
 %% compile_semantic_rule_go(+PredStr, +HeadArgs, +Goal, -GoCode)
 compile_semantic_rule_go(PredStr, HeadArgs, Goal, GoCode) :-
     build_var_map(HeadArgs, VarMap),

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -138,6 +138,111 @@ semantic_compiler:semantic_dispatch(rust, Goal, Provider, VarMap, Code) :-
     let results = searcher.text_search("~w", ~w)?;
 ', [Model, DeviceInit, Model, QueryExpr, TopKExpr]).
 
+% ============================================================================
+% FUZZY LOGIC DISPATCH (Rust target)
+% ============================================================================
+%
+% Generates inline Rust code for fuzzy operations. Assumes `term_scores`
+% (HashMap<String, f64>) is in scope from the surrounding search context.
+
+:- multifile semantic_compiler:fuzzy_dispatch/3.
+
+%% f_and: Fuzzy AND (product t-norm)
+semantic_compiler:fuzzy_dispatch(rust, f_and(Terms, _Result), Code) :-
+    generate_rust_product_terms(Terms, TermCode),
+    format(string(Code),
+'    // Fuzzy AND (product t-norm)
+    let mut result: f64 = 1.0;
+~w', [TermCode]).
+
+%% f_or: Fuzzy OR (probabilistic sum)
+semantic_compiler:fuzzy_dispatch(rust, f_or(Terms, _Result), Code) :-
+    generate_rust_complement_terms(Terms, TermCode),
+    format(string(Code),
+'    // Fuzzy OR (probabilistic sum)
+    let mut complement: f64 = 1.0;
+~w    let result = 1.0 - complement;
+', [TermCode]).
+
+%% f_dist_or: Distributed OR
+semantic_compiler:fuzzy_dispatch(rust, f_dist_or(BaseScore, Terms, _Result), Code) :-
+    (number(BaseScore) -> format(string(BaseExpr), "~w", [BaseScore]) ; BaseExpr = BaseScore),
+    generate_rust_dist_complement_terms(BaseExpr, Terms, TermCode),
+    format(string(Code),
+'    // Fuzzy distributed OR
+    let mut complement: f64 = 1.0;
+~w    let result = 1.0 - complement;
+', [TermCode]).
+
+%% f_union: Non-distributed OR (base * OR result)
+semantic_compiler:fuzzy_dispatch(rust, f_union(BaseScore, Terms, _Result), Code) :-
+    (number(BaseScore) -> format(string(BaseExpr), "~w", [BaseScore]) ; BaseExpr = BaseScore),
+    generate_rust_complement_terms(Terms, TermCode),
+    format(string(Code),
+'    // Fuzzy union (base * OR)
+    let mut complement: f64 = 1.0;
+~w    let result = ~w * (1.0 - complement);
+', [TermCode, BaseExpr]).
+
+%% f_not: Fuzzy NOT (complement)
+semantic_compiler:fuzzy_dispatch(rust, f_not(Score, _Result), Code) :-
+    (number(Score) -> format(string(ScoreExpr), "~w", [Score]) ; format(string(ScoreExpr), "~w", [Score])),
+    format(string(Code), '    let result = 1.0 - ~w;\n', [ScoreExpr]).
+
+%% blend_scores: Weighted interpolation using iterators
+semantic_compiler:fuzzy_dispatch(rust, blend_scores(Alpha, Scores1, Scores2, _Result), Code) :-
+    (number(Alpha) -> format(string(AExpr), "~w_f64", [Alpha]) ; AExpr = Alpha),
+    format(string(Code),
+'    // Blend scores: alpha*s1 + (1-alpha)*s2
+    let result: Vec<f64> = ~w.iter().zip(~w.iter())
+        .map(|(s1, s2)| ~w * s1 + (1.0 - ~w) * s2)
+        .collect();
+', [Scores1, Scores2, AExpr, AExpr]).
+
+%% top_k: Get top K items by score
+semantic_compiler:fuzzy_dispatch(rust, top_k(Items, K, _Result), Code) :-
+    format(string(Code),
+'    // Top-K selection
+    let mut scored: Vec<_> = ~w.clone();
+    scored.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    let result = scored.into_iter().take(~w).collect::<Vec<_>>();
+', [Items, K]).
+
+% ---- Helpers for generating per-term Rust code ----
+
+generate_rust_product_terms([], '').
+generate_rust_product_terms([w(Term, Weight)|Rest], Code) :-
+    generate_rust_product_terms(Rest, RestCode),
+    format(string(Line), '    result *= ~w * term_scores.get("~w").copied().unwrap_or(0.5);\n', [Weight, Term]),
+    string_concat(Line, RestCode, Code).
+generate_rust_product_terms([Term|Rest], Code) :-
+    atom(Term),
+    generate_rust_product_terms(Rest, RestCode),
+    format(string(Line), '    result *= term_scores.get("~w").copied().unwrap_or(0.5);\n', [Term]),
+    string_concat(Line, RestCode, Code).
+
+generate_rust_complement_terms([], '').
+generate_rust_complement_terms([w(Term, Weight)|Rest], Code) :-
+    generate_rust_complement_terms(Rest, RestCode),
+    format(string(Line), '    complement *= 1.0 - ~w * term_scores.get("~w").copied().unwrap_or(0.5);\n', [Weight, Term]),
+    string_concat(Line, RestCode, Code).
+generate_rust_complement_terms([Term|Rest], Code) :-
+    atom(Term),
+    generate_rust_complement_terms(Rest, RestCode),
+    format(string(Line), '    complement *= 1.0 - term_scores.get("~w").copied().unwrap_or(0.5);\n', [Term]),
+    string_concat(Line, RestCode, Code).
+
+generate_rust_dist_complement_terms(_, [], '').
+generate_rust_dist_complement_terms(BaseExpr, [w(Term, Weight)|Rest], Code) :-
+    generate_rust_dist_complement_terms(BaseExpr, Rest, RestCode),
+    format(string(Line), '    complement *= 1.0 - ~w * ~w * term_scores.get("~w").copied().unwrap_or(0.5);\n', [BaseExpr, Weight, Term]),
+    string_concat(Line, RestCode, Code).
+generate_rust_dist_complement_terms(BaseExpr, [Term|Rest], Code) :-
+    atom(Term),
+    generate_rust_dist_complement_terms(BaseExpr, Rest, RestCode),
+    format(string(Line), '    complement *= 1.0 - ~w * term_scores.get("~w").copied().unwrap_or(0.5);\n', [BaseExpr, Term]),
+    string_concat(Line, RestCode, Code).
+
 % Per-path visited pattern detection
 :- use_module('../core/advanced/pattern_matchers', [
     is_per_path_visited_pattern/4,

--- a/tests/core/test_semantic_dispatch.pl
+++ b/tests/core/test_semantic_dispatch.pl
@@ -148,6 +148,39 @@ semantic_compiler:fuzzy_dispatch(python, f_or(Terms, _Result), Code) :-
     py_weighted_terms(Terms, PyTerms),
     format(string(Code), '    result = f_or(~w, _term_scores)\n', [PyTerms]).
 
+% Minimal Rust fuzzy dispatch (mirrors rust_target.pl)
+semantic_compiler:fuzzy_dispatch(rust, f_and(Terms, _Result), Code) :-
+    rust_product_terms(Terms, TermCode),
+    format(string(Code), '    let mut result: f64 = 1.0;\n~w', [TermCode]).
+
+semantic_compiler:fuzzy_dispatch(rust, f_or(Terms, _Result), Code) :-
+    rust_complement_terms(Terms, TermCode),
+    format(string(Code), '    let mut complement: f64 = 1.0;\n~w    let result = 1.0 - complement;\n', [TermCode]).
+
+semantic_compiler:fuzzy_dispatch(rust, f_not(Score, _Result), Code) :-
+    format(string(Code), '    let result = 1.0 - ~w;\n', [Score]).
+
+% Minimal C# fuzzy dispatch (mirrors csharp_target.pl)
+semantic_compiler:fuzzy_dispatch(csharp, f_and(Terms, _Result), Code) :-
+    csharp_product_terms(Terms, TermCode),
+    format(string(Code), '    double result = 1.0;\n~w', [TermCode]).
+
+semantic_compiler:fuzzy_dispatch(csharp, f_or(Terms, _Result), Code) :-
+    csharp_complement_terms(Terms, TermCode),
+    format(string(Code), '    double complement = 1.0;\n~w    double result = 1.0 - complement;\n', [TermCode]).
+
+semantic_compiler:fuzzy_dispatch(csharp, f_not(Score, _Result), Code) :-
+    format(string(Code), '    double result = 1.0 - ~w;\n', [Score]).
+
+% Minimal Go batch fuzzy dispatch (mirrors go_target.pl batch ops)
+semantic_compiler:fuzzy_dispatch(go, f_and_batch(Terms, _ScoresBatch, _Result), Code) :-
+    go_batch_product_terms(Terms, TermCode),
+    format(string(Code), '\tn := batchLen(termScoresBatch)\n\tresult := make([]float64, n)\n\tfor i := range result { result[i] = 1.0 }\n~w', [TermCode]).
+
+semantic_compiler:fuzzy_dispatch(go, f_or_batch(Terms, _ScoresBatch, _Result), Code) :-
+    go_batch_complement_terms(Terms, TermCode),
+    format(string(Code), '\tn := batchLen(termScoresBatch)\n\tcomplement := make([]float64, n)\n\tfor i := range complement { complement[i] = 1.0 }\n~w\tresult := make([]float64, n)\n\tfor i := range result { result[i] = 1 - complement[i] }\n', [TermCode]).
+
 % ---- Inline test helpers ----
 
 go_product_terms([], '').
@@ -160,6 +193,42 @@ go_complement_terms([], '').
 go_complement_terms([w(Term, Weight)|Rest], Code) :-
     go_complement_terms(Rest, RestCode),
     format(string(Line), '\tcomplement *= (1 - ~w * termScores["~w"])\n', [Weight, Term]),
+    string_concat(Line, RestCode, Code).
+
+rust_product_terms([], '').
+rust_product_terms([w(Term, Weight)|Rest], Code) :-
+    rust_product_terms(Rest, RestCode),
+    format(string(Line), '    result *= ~w * term_scores.get("~w").copied().unwrap_or(0.5);\n', [Weight, Term]),
+    string_concat(Line, RestCode, Code).
+
+rust_complement_terms([], '').
+rust_complement_terms([w(Term, Weight)|Rest], Code) :-
+    rust_complement_terms(Rest, RestCode),
+    format(string(Line), '    complement *= 1.0 - ~w * term_scores.get("~w").copied().unwrap_or(0.5);\n', [Weight, Term]),
+    string_concat(Line, RestCode, Code).
+
+csharp_product_terms([], '').
+csharp_product_terms([w(Term, Weight)|Rest], Code) :-
+    csharp_product_terms(Rest, RestCode),
+    format(string(Line), '    result *= ~w * (termScores.TryGetValue("~w", out var s_~w) ? s_~w : 0.5);\n', [Weight, Term, Term, Term]),
+    string_concat(Line, RestCode, Code).
+
+csharp_complement_terms([], '').
+csharp_complement_terms([w(Term, Weight)|Rest], Code) :-
+    csharp_complement_terms(Rest, RestCode),
+    format(string(Line), '    complement *= 1.0 - ~w * (termScores.TryGetValue("~w", out var s_~w) ? s_~w : 0.5);\n', [Weight, Term, Term, Term]),
+    string_concat(Line, RestCode, Code).
+
+go_batch_product_terms([], '').
+go_batch_product_terms([w(Term, Weight)|Rest], Code) :-
+    go_batch_product_terms(Rest, RestCode),
+    format(string(Line), '\tif scores, ok := termScoresBatch["~w"]; ok {\n\t\tfor i := range result { result[i] *= ~w * scores[i] }\n\t}\n', [Term, Weight]),
+    string_concat(Line, RestCode, Code).
+
+go_batch_complement_terms([], '').
+go_batch_complement_terms([w(Term, Weight)|Rest], Code) :-
+    go_batch_complement_terms(Rest, RestCode),
+    format(string(Line), '\tif scores, ok := termScoresBatch["~w"]; ok {\n\t\tfor i := range complement { complement[i] *= (1 - ~w * scores[i]) }\n\t}\n', [Term, Weight]),
     string_concat(Line, RestCode, Code).
 
 py_weighted_terms(Terms, PyTerms) :-
@@ -214,6 +283,55 @@ test_python_fuzzy_or :-
     compile_fuzzy_call(python, f_or([w(bash, 0.9)], _), Code),
     assert_contains(Code, "f_or(", "f_or call").
 
+test_rust_fuzzy_and :-
+    format('--- Rust Fuzzy AND ---~n'),
+    compile_fuzzy_call(rust, f_and([w(bash, 0.9), w(shell, 0.5)], _), Code),
+    assert_contains(Code, "let mut result: f64 = 1.0", "product identity"),
+    assert_contains(Code, "term_scores.get(\"bash\")", "HashMap lookup"),
+    assert_contains(Code, "unwrap_or(0.5)", "default score fallback").
+
+test_rust_fuzzy_or :-
+    format('--- Rust Fuzzy OR ---~n'),
+    compile_fuzzy_call(rust, f_or([w(bash, 0.9)], _), Code),
+    assert_contains(Code, "let mut complement: f64 = 1.0", "complement identity"),
+    assert_contains(Code, "1.0 - complement", "probabilistic sum").
+
+test_rust_fuzzy_not :-
+    format('--- Rust Fuzzy NOT ---~n'),
+    compile_fuzzy_call(rust, f_not(0.3, _), Code),
+    assert_contains(Code, "1.0 - 0.3", "complement").
+
+test_csharp_fuzzy_and :-
+    format('--- C# Fuzzy AND ---~n'),
+    compile_fuzzy_call(csharp, f_and([w(bash, 0.9), w(shell, 0.5)], _), Code),
+    assert_contains(Code, "double result = 1.0", "product identity"),
+    assert_contains(Code, "TryGetValue(\"bash\"", "Dictionary lookup"),
+    assert_contains(Code, "0.5)", "default score fallback").
+
+test_csharp_fuzzy_or :-
+    format('--- C# Fuzzy OR ---~n'),
+    compile_fuzzy_call(csharp, f_or([w(bash, 0.9)], _), Code),
+    assert_contains(Code, "double complement = 1.0", "complement identity"),
+    assert_contains(Code, "1.0 - complement", "probabilistic sum").
+
+test_csharp_fuzzy_not :-
+    format('--- C# Fuzzy NOT ---~n'),
+    compile_fuzzy_call(csharp, f_not(0.3, _), Code),
+    assert_contains(Code, "1.0 - 0.3", "complement").
+
+test_go_batch_and :-
+    format('--- Go Batch AND ---~n'),
+    compile_fuzzy_call(go, f_and_batch([w(bash, 0.9)], scores, _), Code),
+    assert_contains(Code, "batchLen(termScoresBatch)", "batch length"),
+    assert_contains(Code, "make([]float64, n)", "slice allocation"),
+    assert_contains(Code, "termScoresBatch[\"bash\"]", "batch lookup").
+
+test_go_batch_or :-
+    format('--- Go Batch OR ---~n'),
+    compile_fuzzy_call(go, f_or_batch([w(bash, 0.9)], scores, _), Code),
+    assert_contains(Code, "complement[i] = 1.0", "complement init"),
+    assert_contains(Code, "1 - complement[i]", "element-wise sum").
+
 % ---- Helpers ----
 
 assert_contains(String, Substring, Label) :-
@@ -235,6 +353,14 @@ test_all :-
     test_go_fuzzy_or,
     test_go_fuzzy_not,
     test_python_fuzzy_and,
-    test_python_fuzzy_or.
+    test_python_fuzzy_or,
+    test_rust_fuzzy_and,
+    test_rust_fuzzy_or,
+    test_rust_fuzzy_not,
+    test_csharp_fuzzy_and,
+    test_csharp_fuzzy_or,
+    test_csharp_fuzzy_not,
+    test_go_batch_and,
+    test_go_batch_or.
 
 :- initialization(test_all, main).


### PR DESCRIPTION
## Summary

- Implement fuzzy logic dispatch for Rust and C# targets (all 5 core ops + blend_scores + top_k)
- Add Go batch fuzzy operations for slice-based vectorized processing
- 8 new tests, 35 total assertions passing

## Motivation

The previous PR (#1250) added `fuzzy_dispatch/3` to the generic semantic interface with Go and Python support. This completes the coverage: Rust and C# get the same core operations, and Go gets batch variants matching Python's NumPy-backed batch ops.

## What changed

### `rust_target.pl` — Rust fuzzy dispatch

7 operations generating idiomatic Rust code:

| Operation | Rust pattern |
|-----------|-------------|
| `f_and` | `result *= weight * term_scores.get("term").copied().unwrap_or(0.5)` |
| `f_or` | `complement *= 1.0 - weight * term_scores.get(...)` then `1.0 - complement` |
| `f_dist_or` | Same with base score factor |
| `f_union` | `base * (1.0 - complement)` |
| `f_not` | `1.0 - score` |
| `blend_scores` | `.iter().zip().map(\|(s1, s2)\| alpha * s1 + (1.0 - alpha) * s2).collect()` |
| `top_k` | `sort_by` with `partial_cmp` + `.take(k).collect()` |

Assumes `term_scores: HashMap<String, f64>` in scope. Uses `unwrap_or(0.5)` for missing term defaults.

### `csharp_target.pl` — C# fuzzy dispatch

Same 7 operations using C# idioms:

| Operation | C# pattern |
|-----------|-----------|
| `f_and` | `result *= weight * (termScores.TryGetValue("term", out var s) ? s : 0.5)` |
| `f_or` | Same complement accumulation pattern |
| `f_dist_or` | With base score factor |
| `f_union` | `base * (1.0 - complement)` |
| `f_not` | `1.0 - score` |
| `blend_scores` | `scores1.Zip(scores2, (s1, s2) => alpha * s1 + (1.0 - alpha) * s2).ToArray()` |
| `top_k` | `items.OrderByDescending(x => x.Score).Take(k).ToList()` |

Assumes `termScores: Dictionary<string, double>` in scope. Uses `TryGetValue` with 0.5 default.

### `go_target.pl` — Go batch operations

4 batch operations for processing score slices (`[]float64`) across multiple items simultaneously:

| Operation | Description |
|-----------|-------------|
| `f_and_batch` | Element-wise product across `map[string][]float64` |
| `f_or_batch` | Element-wise probabilistic sum |
| `f_dist_or_batch` | Distributed OR with per-element base scores |
| `f_union_batch` | Per-element base * OR result |

Each generates a loop over the batch with `termScoresBatch` map lookup and slice allocation via `make([]float64, n)`.

### Tests

8 new test predicates with inline dispatch clauses:

| Test | Assertions |
|------|-----------|
| Rust f_and | product identity, HashMap lookup, unwrap_or default |
| Rust f_or | complement identity, probabilistic sum |
| Rust f_not | complement |
| C# f_and | product identity, Dictionary lookup, TryGetValue default |
| C# f_or | complement identity, probabilistic sum |
| C# f_not | complement |
| Go batch f_and | batch length, slice allocation, batch lookup |
| Go batch f_or | complement init, element-wise sum |

### Documentation

- `SEMANTIC_INTERFACE_SPECIFICATION.md`: updated target support table with Rust, C#, and Go batch columns
- `SEMANTIC_INTERFACE_IMPLEMENTATION_PLAN.md`: added Phase 2c (completed), updated Phase 3 remaining items

## Test plan

- [x] `swipl tests/core/test_semantic_dispatch.pl` — 20 tests, 35 assertions, all passing
- [x] `swipl -g "use_module('src/unifyweaver/targets/rust_target'), halt."` — loads cleanly
- [x] `swipl -g "use_module('src/unifyweaver/targets/csharp_target'), halt."` — loads cleanly
- [x] Existing semantic dispatch and fuzzy tests unaffected
