### PR TITLE
Refactor Rust WAM foreign lowering around a recursive-kernel IR

### DIFF
--- a/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
+++ b/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
@@ -242,6 +242,24 @@ This is a better fit than adding many custom opcodes for high-level recursive
 search. It preserves the WAM runtime for general predicates while letting the
 hottest recursive kernels execute natively.
 
+The current compiler structure is now split into three layers instead of one
+ad hoc selection block:
+
+1. **Detector registry**
+   - A small registry maps kernel kinds to detector predicates.
+   - Adding a new recursive family no longer requires editing the central
+     dispatcher directly.
+2. **Recursive-kernel IR**
+   - Supported predicates normalize into `recursive_kernel(...)` terms.
+   - This is the compiler's internal representation of "foreign-lowerable
+     recursive work."
+3. **Metadata-driven foreign spec generation**
+   - Foreign setup ops and rewrite targets are derived from kernel metadata,
+     rather than one bespoke spec-construction clause per supported family.
+
+That split makes the foreign-lowering path easier to extend without letting
+`rust_target.pl` grow another layer of special cases.
+
 ### What Is Verified
 
 The current test coverage now includes:

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3501,9 +3501,12 @@ rust_foreign_lowering_spec(Pred, Arity, Clauses, ForeignSpec) :-
     rust_recursive_kernel_spec(Kernel, ForeignSpec).
 
 rust_recursive_kernel(Pred, Arity, Clauses, Kernel) :-
-    rust_recursive_kernel_category_ancestor(Pred, Arity, Clauses, Kernel).
-rust_recursive_kernel(Pred, Arity, Clauses, Kernel) :-
-    rust_recursive_kernel_transitive_closure(Pred, Arity, Clauses, Kernel).
+    rust_recursive_kernel_detector(KernelKind, Detector),
+    call(Detector, Pred, Arity, Clauses, Kernel),
+    Kernel = recursive_kernel(KernelKind, _, _).
+
+rust_recursive_kernel_detector(category_ancestor, rust_recursive_kernel_category_ancestor).
+rust_recursive_kernel_detector(transitive_closure2, rust_recursive_kernel_transitive_closure).
 
 rust_recursive_kernel_spec(
         recursive_kernel(KernelKind, PredIndicator, KernelConfig),

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3497,16 +3497,16 @@ compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
     ).
 
 rust_foreign_lowering_spec(Pred, Arity, Clauses, ForeignSpec) :-
-    rust_foreign_lowering_schema(Pred, Arity, Clauses, Schema),
-    rust_foreign_schema_spec(Schema, ForeignSpec).
+    rust_recursive_kernel(Pred, Arity, Clauses, Kernel),
+    rust_recursive_kernel_spec(Kernel, ForeignSpec).
 
-rust_foreign_lowering_schema(Pred, Arity, Clauses, Schema) :-
-    rust_foreign_schema_category_ancestor(Pred, Arity, Clauses, Schema).
-rust_foreign_lowering_schema(Pred, Arity, Clauses, Schema) :-
-    rust_foreign_schema_transitive_closure(Pred, Arity, Clauses, Schema).
+rust_recursive_kernel(Pred, Arity, Clauses, Kernel) :-
+    rust_recursive_kernel_category_ancestor(Pred, Arity, Clauses, Kernel).
+rust_recursive_kernel(Pred, Arity, Clauses, Kernel) :-
+    rust_recursive_kernel_transitive_closure(Pred, Arity, Clauses, Kernel).
 
-rust_foreign_schema_spec(
-        foreign_schema(
+rust_recursive_kernel_spec(
+        recursive_kernel(
             category_ancestor,
             category_ancestor/4,
             [max_depth(MaxDepth)]
@@ -3518,8 +3518,8 @@ rust_foreign_schema_spec(
             ],
             [category_ancestor/4]
         )).
-rust_foreign_schema_spec(
-        foreign_schema(
+rust_recursive_kernel_spec(
+        recursive_kernel(
             transitive_closure2,
             Pred/Arity,
             [edge_pred(EdgePred/2), fact_pairs(FactPairs)]
@@ -3533,12 +3533,12 @@ rust_foreign_schema_spec(
             [Pred/Arity]
         )).
 
-rust_foreign_schema_category_ancestor(Pred, Arity, Clauses,
-        foreign_schema(category_ancestor, category_ancestor/4, [max_depth(MaxDepth)])) :-
+rust_recursive_kernel_category_ancestor(Pred, Arity, Clauses,
+        recursive_kernel(category_ancestor, category_ancestor/4, [max_depth(MaxDepth)])) :-
     rust_foreign_lowerable_category_ancestor(Pred, Arity, Clauses, MaxDepth).
 
-rust_foreign_schema_transitive_closure(Pred, Arity, Clauses,
-        foreign_schema(transitive_closure2, Pred/Arity,
+rust_recursive_kernel_transitive_closure(Pred, Arity, Clauses,
+        recursive_kernel(transitive_closure2, Pred/Arity,
             [edge_pred(EdgePred/2), fact_pairs(FactPairs)])) :-
     rust_foreign_lowerable_transitive_closure(Pred, Arity, Clauses, EdgePred/2, FactPairs).
 

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3506,32 +3506,29 @@ rust_recursive_kernel(Pred, Arity, Clauses, Kernel) :-
     rust_recursive_kernel_transitive_closure(Pred, Arity, Clauses, Kernel).
 
 rust_recursive_kernel_spec(
-        recursive_kernel(
-            category_ancestor,
-            category_ancestor/4,
-            [max_depth(MaxDepth)]
-        ),
-        foreign_predicate(
-            category_ancestor/4,
-            [ register_foreign_native_kind(category_ancestor/4, category_ancestor),
-              register_foreign_usize_config(category_ancestor/4, max_depth, MaxDepth)
-            ],
-            [category_ancestor/4]
-        )).
-rust_recursive_kernel_spec(
-        recursive_kernel(
-            transitive_closure2,
-            Pred/Arity,
-            [edge_pred(EdgePred/2), fact_pairs(FactPairs)]
-        ),
-        foreign_predicate(
-            Pred/Arity,
-            [ register_foreign_native_kind(Pred/Arity, transitive_closure2),
-              register_foreign_string_config(Pred/Arity, edge_pred, EdgePred/2),
-              register_indexed_atom_fact2(EdgePred/2, FactPairs)
-            ],
-            [Pred/Arity]
-        )).
+        recursive_kernel(KernelKind, PredIndicator, KernelConfig),
+        foreign_predicate(PredIndicator, SetupOps, RewriteTargets)) :-
+    rust_recursive_kernel_setup_ops(KernelKind, PredIndicator, KernelConfig, SetupOps),
+    rust_recursive_kernel_rewrite_targets(KernelKind, PredIndicator, KernelConfig, RewriteTargets).
+
+rust_recursive_kernel_setup_ops(KernelKind, PredIndicator, KernelConfig,
+        [register_foreign_native_kind(PredIndicator, NativeKind)|ConfigOps]) :-
+    rust_recursive_kernel_native_kind(KernelKind, NativeKind),
+    rust_recursive_kernel_config_ops(KernelKind, PredIndicator, KernelConfig, ConfigOps).
+
+rust_recursive_kernel_native_kind(category_ancestor, category_ancestor).
+rust_recursive_kernel_native_kind(transitive_closure2, transitive_closure2).
+
+rust_recursive_kernel_config_ops(category_ancestor, category_ancestor/4,
+        [max_depth(MaxDepth)],
+        [register_foreign_usize_config(category_ancestor/4, max_depth, MaxDepth)]).
+rust_recursive_kernel_config_ops(transitive_closure2, PredIndicator,
+        [edge_pred(EdgePred/2), fact_pairs(FactPairs)],
+        [ register_foreign_string_config(PredIndicator, edge_pred, EdgePred/2),
+          register_indexed_atom_fact2(EdgePred/2, FactPairs)
+        ]).
+
+rust_recursive_kernel_rewrite_targets(_KernelKind, PredIndicator, _KernelConfig, [PredIndicator]).
 
 rust_recursive_kernel_category_ancestor(Pred, Arity, Clauses,
         recursive_kernel(category_ancestor, category_ancestor/4, [max_depth(MaxDepth)])) :-

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -245,6 +245,36 @@ test_foreign_spec_wrapper_generation :-
     ;   fail_test(Test, 'Generic foreign spec did not drive wrapper generation')
     ).
 
+test_recursive_kernel_ir_selection :-
+    Test = 'WAM-Rust: recursive kernel IR normalizes supported schemas',
+    CategoryClauses = [
+        category_ancestor(Cat1, Target1, 1, Visited1)-
+            (category_parent(Cat1, Target1), \+ member(Target1, Visited1)),
+        category_ancestor(Cat2, Target2, Hops2, Visited2)-
+            ( max_depth(MaxDepth2),
+              length(Visited2, Depth2),
+              Depth2 < MaxDepth2,
+              !,
+              category_parent(Cat2, Mid2),
+              \+ member(Mid2, Visited2),
+              category_ancestor(Mid2, Target2, H12, [Mid2|Visited2]),
+              Hops2 is H12 + 1
+            )
+    ],
+    DescClauses = [
+        tc_descendant(X1, Y1)-tc_parent(Y1, X1),
+        tc_descendant(X2, Y2)-(tc_parent(Z2, X2), tc_descendant(Z2, Y2))
+    ],
+    (   rust_target:rust_recursive_kernel(category_ancestor, 4, CategoryClauses,
+            recursive_kernel(category_ancestor, category_ancestor/4, [max_depth(10)])),
+        rust_target:rust_recursive_kernel(tc_descendant, 2, DescClauses,
+            recursive_kernel(transitive_closure2, tc_descendant/2,
+                [edge_pred(tc_parent/2), fact_pairs(FactPairs)])),
+        FactPairs == ['bob'-'tom', 'liz'-'tom', 'ann'-'bob', 'pat'-'bob', 'jim'-'pat']
+    ->  pass(Test)
+    ;   fail_test(Test, 'Recursive kernel IR did not normalize expected schemas')
+    ).
+
 %% Phase 4: WAM fallback integration tests
 
 test_wam_fallback_enabled :-
@@ -638,6 +668,7 @@ run_tests :-
     test_builtin_dispatch,
     test_predicate_wrapper,
     test_foreign_spec_wrapper_generation,
+    test_recursive_kernel_ir_selection,
     test_wam_fallback_enabled,
     test_wam_fallback_disabled,
     test_native_still_preferred,

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -275,6 +275,27 @@ test_recursive_kernel_ir_selection :-
     ;   fail_test(Test, 'Recursive kernel IR did not normalize expected schemas')
     ).
 
+test_recursive_kernel_spec_generation :-
+    Test = 'WAM-Rust: recursive kernel IR generates foreign specs declaratively',
+    Kernel = recursive_kernel(
+        transitive_closure2,
+        tc_descendant/2,
+        [ edge_pred(tc_parent/2),
+          fact_pairs(['bob'-'tom', 'liz'-'tom'])
+        ]),
+    (   rust_target:rust_recursive_kernel_spec(Kernel, ForeignSpec),
+        ForeignSpec = foreign_predicate(
+            tc_descendant/2,
+            [ register_foreign_native_kind(tc_descendant/2, transitive_closure2),
+              register_foreign_string_config(tc_descendant/2, edge_pred, tc_parent/2),
+              register_indexed_atom_fact2(tc_parent/2, ['bob'-'tom', 'liz'-'tom'])
+            ],
+            [tc_descendant/2]
+        )
+    ->  pass(Test)
+    ;   fail_test(Test, 'Recursive kernel spec generation did not match expected foreign spec')
+    ).
+
 %% Phase 4: WAM fallback integration tests
 
 test_wam_fallback_enabled :-
@@ -669,6 +690,7 @@ run_tests :-
     test_predicate_wrapper,
     test_foreign_spec_wrapper_generation,
     test_recursive_kernel_ir_selection,
+    test_recursive_kernel_spec_generation,
     test_wam_fallback_enabled,
     test_wam_fallback_disabled,
     test_native_still_preferred,

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -296,6 +296,15 @@ test_recursive_kernel_spec_generation :-
     ;   fail_test(Test, 'Recursive kernel spec generation did not match expected foreign spec')
     ).
 
+test_recursive_kernel_registry :-
+    Test = 'WAM-Rust: recursive kernel registry enumerates supported kernels',
+    findall(Kind, rust_target:rust_recursive_kernel_detector(Kind, _), Kinds0),
+    sort(Kinds0, Kinds),
+    (   Kinds == [category_ancestor, transitive_closure2]
+    ->  pass(Test)
+    ;   fail_test(Test, 'Recursive kernel registry did not match expected supported kernels')
+    ).
+
 %% Phase 4: WAM fallback integration tests
 
 test_wam_fallback_enabled :-
@@ -691,6 +700,7 @@ run_tests :-
     test_foreign_spec_wrapper_generation,
     test_recursive_kernel_ir_selection,
     test_recursive_kernel_spec_generation,
+    test_recursive_kernel_registry,
     test_wam_fallback_enabled,
     test_wam_fallback_disabled,
     test_native_still_preferred,


### PR DESCRIPTION
## Summary

This PR refactors Rust WAM foreign lowering into a cleaner internal architecture for recursive predicates.

Instead of keeping foreign-lowering selection and spec generation in a growing set of ad hoc clauses, the compiler now uses:

- a recursive-kernel IR
- metadata-driven foreign spec generation
- a registry for kernel detectors

Behavior is unchanged for the currently supported foreign-lowered recursive families:

- `category_ancestor/4`
- forward transitive closure such as `tc_ancestor/2`
- reverse transitive closure such as `tc_descendant/2`

## What Changed

### Compiler Structure

In [rust_target.pl](/data/data/com.termux/files/home/UnifyWeaver/context/claude/UnifyWeaver/src/unifyweaver/targets/rust_target.pl):

- introduced `recursive_kernel(...)` as the internal normalized representation for foreign-lowerable recursive work
- refactored foreign spec generation so setup ops and rewrite targets are derived from kernel metadata rather than bespoke per-family spec clauses
- added a detector registry (`rust_recursive_kernel_detector/2`) so supported kernel families are registered explicitly instead of hardcoded in the central dispatcher

### Tests

In [test_wam_rust_target.pl](/data/data/com.termux/files/home/UnifyWeaver/context/claude/UnifyWeaver/tests/test_wam_rust_target.pl):

- added direct coverage for recursive-kernel IR normalization
- added direct coverage for metadata-driven foreign spec generation
- added direct coverage for the registered kernel set

Existing codegen and runtime validation for:

- `category_ancestor/4`
- `tc_ancestor/2`
- `tc_descendant/2`

remain in place and continue to pass.

### Documentation

Updated [WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md](/data/data/com.termux/files/home/UnifyWeaver/context/claude/UnifyWeaver/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md) to describe the current three-layer structure:

1. detector registry
2. recursive-kernel IR
3. metadata-driven foreign spec generation

## Why

The previous foreign-lowering work proved the architecture was viable, but the compiler-side implementation was still too specialized. Adding another recursive family would have required editing multiple central predicates.

This refactor makes the extension path clearer:

- register a detector
- produce a `recursive_kernel(...)`
- map kernel metadata to foreign setup ops

That lowers the cost of adding future recursive families without changing current behavior.

## Validation

Ran locally:

- `swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`

Both passed locally.

## Scope

This PR is an internal architecture refactor. It does not add a new foreign-lowered recursive family yet; it prepares the compiler structure so the next one can be added with less churn and clearer tests.
