### PR TITLE
Add a non-graph countdown kernel to Rust WAM foreign lowering

### DIFF
--- a/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
+++ b/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
@@ -226,6 +226,7 @@ Instead, the compiler now supports a **foreign-lowering** path for selected
 recursive schemas:
 
 - `category_ancestor/4`-style bounded recursive search
+- countdown-style numeric recursion such as `tri_sum/2`
 - binary transitive closure such as `tc_ancestor/2`
 - reversed binary closure such as `tc_descendant/2`
 - recursive distance search such as `tc_distance/3`
@@ -264,6 +265,7 @@ That split makes the foreign-lowering path easier to extend without letting
 The currently registered recursive kernel families are:
 
 - `category_ancestor`
+- `countdown_sum2`
 - `transitive_closure2`
 - `transitive_distance3`
 
@@ -273,13 +275,20 @@ The current test coverage now includes:
 
 - compiler-selection tests for:
   - `category_ancestor/4`
+  - `tri_sum/2`
   - `tc_ancestor/2`
   - `tc_descendant/2`
   - `tc_distance/3`
 - end-to-end generated Rust runtime validation for:
+  - `tri_sum/2`
   - `tc_ancestor/2`
   - `tc_descendant/2`
   - `tc_distance/3`
+
+When `foreign_lowering(true)` is enabled and a registered kernel matches, the
+compiler now prefers the foreign path over earlier generic native clause
+lowering. That keeps recognized recursive kernels on the tested runtime path
+instead of silently taking a less structured lowering tier first.
 
 The reverse transitive-closure path required an additional correctness fix:
 reverse schemas must register fact pairs in `child -> parent` orientation, and

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3499,6 +3499,21 @@ sub_term(Sub, Term) :-
 :- endif.
 % Try native clause body lowering first
 compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
+    option(foreign_lowering(ForeignLowering), Options, false),
+    ForeignLowering == true,
+    functor(Head, Pred, Arity),
+    findall(Head-Body, user:clause(Head, Body), Clauses),
+    Clauses \= [],
+    rust_foreign_lowering_spec(Pred, Arity, Clauses, ForeignSpec),
+    !,
+    wam_target:compile_predicate_to_wam(user:Pred/Arity, Options, WamCode),
+    wam_rust_target:compile_wam_predicate_to_rust(
+        Pred/Arity,
+        WamCode,
+        [foreign_lowering(ForeignSpec)|Options],
+        RustCode
+    ).
+compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
     option(include_main(IncludeMain), Options, true),
     functor(Head, Pred, Arity),
     findall(Head-Body, user:clause(Head, Body), Clauses),
@@ -3539,21 +3554,11 @@ compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
     option(field_delimiter(FieldDelim), Options, colon),
     option(include_main(IncludeMain), Options, true),
     option(unique(Unique), Options, true),
-    option(foreign_lowering(ForeignLowering), Options, false),
 
     functor(Head, Pred, Arity),
     findall(Head-Body, user:clause(Head, Body), Clauses),
 
     (   Clauses = [] -> fail
-    ;   ForeignLowering == true,
-        rust_foreign_lowering_spec(Pred, Arity, Clauses, ForeignSpec)
-    ->  wam_target:compile_predicate_to_wam(user:Pred/Arity, Options, WamCode),
-        wam_rust_target:compile_wam_predicate_to_rust(
-            Pred/Arity,
-            WamCode,
-            [foreign_lowering(ForeignSpec)|Options],
-            RustCode
-        )
     ;   maplist(is_fact_clause, Clauses) ->
         compile_facts_to_rust(Pred, Arity, Clauses, FieldDelim, RustCode)
     ;   is_general_recursive_pattern_rust(Pred, Arity, Clauses) ->
@@ -3611,6 +3616,7 @@ rust_recursive_kernel(Pred, Arity, Clauses, Kernel) :-
     Kernel = recursive_kernel(KernelKind, _, _).
 
 rust_recursive_kernel_detector(category_ancestor, rust_recursive_kernel_category_ancestor).
+rust_recursive_kernel_detector(countdown_sum2, rust_recursive_kernel_countdown_sum).
 rust_recursive_kernel_detector(transitive_closure2, rust_recursive_kernel_transitive_closure).
 rust_recursive_kernel_detector(transitive_distance3, rust_recursive_kernel_transitive_distance).
 
@@ -3626,12 +3632,14 @@ rust_recursive_kernel_setup_ops(KernelKind, PredIndicator, KernelConfig,
     rust_recursive_kernel_config_ops(KernelKind, PredIndicator, KernelConfig, ConfigOps).
 
 rust_recursive_kernel_native_kind(category_ancestor, category_ancestor).
+rust_recursive_kernel_native_kind(countdown_sum2, countdown_sum2).
 rust_recursive_kernel_native_kind(transitive_closure2, transitive_closure2).
 rust_recursive_kernel_native_kind(transitive_distance3, transitive_distance3).
 
 rust_recursive_kernel_config_ops(category_ancestor, category_ancestor/4,
         [max_depth(MaxDepth)],
         [register_foreign_usize_config(category_ancestor/4, max_depth, MaxDepth)]).
+rust_recursive_kernel_config_ops(countdown_sum2, _PredIndicator, [], []).
 rust_recursive_kernel_config_ops(transitive_closure2, PredIndicator,
         KernelConfig, ConfigOps) :-
     rust_recursive_kernel_binary_edge_config_ops(PredIndicator, KernelConfig, ConfigOps).
@@ -3650,6 +3658,10 @@ rust_recursive_kernel_rewrite_targets(_KernelKind, PredIndicator, _KernelConfig,
 rust_recursive_kernel_category_ancestor(Pred, Arity, Clauses,
         recursive_kernel(category_ancestor, category_ancestor/4, [max_depth(MaxDepth)])) :-
     rust_foreign_lowerable_category_ancestor(Pred, Arity, Clauses, MaxDepth).
+
+rust_recursive_kernel_countdown_sum(Pred, Arity, Clauses,
+        recursive_kernel(countdown_sum2, Pred/Arity, [])) :-
+    rust_foreign_lowerable_countdown_sum(Pred, Arity, Clauses).
 
 rust_recursive_kernel_transitive_closure(Pred, Arity, Clauses,
         recursive_kernel(transitive_closure2, Pred/Arity,
@@ -3673,6 +3685,21 @@ rust_foreign_lowerable_category_ancestor(category_ancestor, 4, Clauses, MaxDepth
     user:max_depth(MaxDepth),
     integer(MaxDepth),
     MaxDepth > 0.
+
+rust_foreign_lowerable_countdown_sum(Pred, 2, Clauses) :-
+    member(BaseHead-true, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseHead =.. [Pred, 0, 0],
+    RecHead =.. [Pred, N, Sum],
+    RecBody = (GtGoal, (StepGoal, (RecGoal, SumGoal))),
+    GtGoal =.. [>, N, 0],
+    StepGoal =.. [is, PrevN, StepExpr],
+    (   StepExpr =.. [-, N, 1]
+    ;   StepExpr =.. [+, N, -1]
+    ),
+    RecGoal =.. [Pred, PrevN, PrevSum],
+    SumGoal =.. [is, Sum, SumExpr],
+    SumExpr =.. [+, PrevSum, N].
 
 rust_foreign_lowerable_transitive_closure(Pred, 2, Clauses, EdgePred/2, FactPairs) :-
     member(BaseHead-BaseBody, Clauses),

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -785,6 +785,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
     compile_execute_foreign_predicate_to_rust(ForeignCode),
     compile_resume_builtin_to_rust(ResumeCode),
     compile_collect_native_category_ancestor_to_rust(NativeAncestorCode),
+    compile_compute_native_countdown_sum_to_rust(NativeCountdownSumCode),
     compile_collect_native_transitive_closure_to_rust(NativeClosureCode),
     compile_collect_native_transitive_distance_to_rust(NativeDistanceCode),
     compile_eval_arith_to_rust(ArithCode),
@@ -801,6 +802,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
         ForeignCode, '\n\n',
         ResumeCode, '\n\n',
         NativeAncestorCode, '\n\n',
+        NativeCountdownSumCode, '\n\n',
         NativeClosureCode, '\n\n',
         NativeDistanceCode, '\n\n',
         ArithCode
@@ -1103,6 +1105,23 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                     self.pc += 1; true
                 } else { false }
             }
+            "countdown_sum2" => {
+                let n = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
+                    Some(Value::Integer(n)) => n,
+                    _ => return false,
+                };
+                let sum_reg = match self.regs.get("A2").cloned() {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let sum = match self.compute_native_countdown_sum(n) {
+                    Some(sum) => sum,
+                    None => return false,
+                };
+                if self.unify(&sum_reg, &Value::Integer(sum)) {
+                    self.pc += 1; true
+                } else { false }
+            }
             "transitive_closure2" => {
                 let start = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
                     Some(Value::Atom(start)) => start,
@@ -1252,6 +1271,20 @@ compile_collect_native_category_ancestor_to_rust(Code) :-
                 }
             }
         }
+    }'.
+
+compile_compute_native_countdown_sum_to_rust(Code) :-
+    Code = '    pub fn compute_native_countdown_sum(&self, n: i64) -> Option<i64> {
+        if n < 0 {
+            return None;
+        }
+        let mut total = 0;
+        let mut current = n;
+        while current > 0 {
+            total += current;
+            current -= 1;
+        }
+        Some(total)
     }'.
 
 compile_collect_native_transitive_closure_to_rust(Code) :-

--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -45,6 +45,14 @@ tc_descendant(X, Y) :- tc_parent(Z, X), tc_descendant(Z, Y).
 tc_distance(X, Y, 1) :- tc_parent(X, Y).
 tc_distance(X, Y, D) :- tc_parent(X, Z), tc_distance(Z, Y, D1), D is D1 + 1.
 
+:- dynamic tri_sum/2.
+tri_sum(0, 0).
+tri_sum(N, Sum) :-
+    N > 0,
+    N1 is N - 1,
+    tri_sum(N1, Prev),
+    Sum is Prev + N.
+
 %% Integration test
 test_runtime_execution :-
     Test = 'WAM-Rust Runtime: end-to-end execution',
@@ -55,7 +63,7 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3],
+        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tri_sum/2],
             [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
@@ -67,6 +75,7 @@ use runtime_test::state::WamState;
 use runtime_test::tc_ancestor;
 use runtime_test::tc_descendant;
 use runtime_test::tc_distance;
+use runtime_test::tri_sum;
 
 #[test]
 fn test_generated_predicates() {
@@ -201,6 +210,26 @@ fn test_generated_predicates() {
         Value::Atom("jim".to_string()),
         Value::Unbound("D".to_string()));
     assert!(!ok9, "tc_distance(liz, jim, D) should fail");
+
+    // Test tri_sum/2 foreign lowering end-to-end
+    let mut vm_sum = WamState::new(vec![], std::collections::HashMap::new());
+    let ok10 = tri_sum(&mut vm_sum,
+        Value::Integer(4),
+        Value::Unbound("Sum".to_string()));
+    assert!(ok10, "tri_sum(4, Sum) should succeed");
+    assert_eq!(vm_sum.bindings.get("Sum").cloned(), Some(Value::Integer(10)));
+
+    let mut vm_sum_check = WamState::new(vec![], std::collections::HashMap::new());
+    let ok11 = tri_sum(&mut vm_sum_check,
+        Value::Integer(4),
+        Value::Integer(10));
+    assert!(ok11, "tri_sum(4, 10) should succeed");
+
+    let mut vm_sum_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok12 = tri_sum(&mut vm_sum_fail,
+        Value::Integer(4),
+        Value::Integer(11));
+    assert!(!ok12, "tri_sum(4, 11) should fail");
 }
 ',
         setup_call_cleanup(open(TestPath, write, S), format(S, "~w", [TestContent]), close(S)),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -29,6 +29,7 @@ test_simple_fact(foo, bar).
 :- dynamic category_ancestor/4.
 :- dynamic category_parent/2.
 :- dynamic tc_ancestor/2.
+:- dynamic tri_sum/2.
 :- dynamic tc_descendant/2.
 :- dynamic tc_distance/3.
 :- dynamic tc_parent/2.
@@ -64,6 +65,13 @@ tc_ancestor(X, Y) :- tc_parent(X, Z), tc_ancestor(Z, Y).
 
 tc_descendant(X, Y) :- tc_parent(Y, X).
 tc_descendant(X, Y) :- tc_parent(Z, X), tc_descendant(Z, Y).
+
+tri_sum(0, 0).
+tri_sum(N, Sum) :-
+    N > 0,
+    N1 is N - 1,
+    tri_sum(N1, Prev),
+    Sum is Prev + N.
 
 tc_distance(X, Y, 1) :- tc_parent(X, Y).
 tc_distance(X, Y, D) :- tc_parent(X, Z), tc_distance(Z, Y, D1), D is D1 + 1.
@@ -269,12 +277,18 @@ test_recursive_kernel_ir_selection :-
         tc_descendant(X1, Y1)-tc_parent(Y1, X1),
         tc_descendant(X2, Y2)-(tc_parent(Z2, X2), tc_descendant(Z2, Y2))
     ],
+    SumClauses = [
+        tri_sum(0, 0)-true,
+        tri_sum(N2, Sum2)-((N2 > 0), ((N12 is N2 - 1), (tri_sum(N12, Prev2), Sum2 is Prev2 + N2)))
+    ],
     DistClauses = [
         tc_distance(S1, T1, 1)-tc_parent(S1, T1),
         tc_distance(S2, T2, D2)-(tc_parent(S2, M2), (tc_distance(M2, T2, D1), D2 is D1 + 1))
     ],
     (   rust_target:rust_recursive_kernel(category_ancestor, 4, CategoryClauses,
             recursive_kernel(category_ancestor, category_ancestor/4, [max_depth(10)])),
+        rust_target:rust_recursive_kernel(tri_sum, 2, SumClauses,
+            recursive_kernel(countdown_sum2, tri_sum/2, [])),
         rust_target:rust_recursive_kernel(tc_descendant, 2, DescClauses,
             recursive_kernel(transitive_closure2, tc_descendant/2,
                 [edge_pred(tc_parent/2), fact_pairs(FactPairs)])),
@@ -290,19 +304,14 @@ test_recursive_kernel_ir_selection :-
 test_recursive_kernel_spec_generation :-
     Test = 'WAM-Rust: recursive kernel IR generates foreign specs declaratively',
     Kernel = recursive_kernel(
-        transitive_distance3,
-        tc_distance/3,
-        [ edge_pred(tc_parent/2),
-          fact_pairs(['tom'-'bob', 'bob'-'ann'])
-        ]),
+        countdown_sum2,
+        tri_sum/2,
+        []),
     (   rust_target:rust_recursive_kernel_spec(Kernel, ForeignSpec),
         ForeignSpec = foreign_predicate(
-            tc_distance/3,
-            [ register_foreign_native_kind(tc_distance/3, transitive_distance3),
-              register_foreign_string_config(tc_distance/3, edge_pred, tc_parent/2),
-              register_indexed_atom_fact2(tc_parent/2, ['tom'-'bob', 'bob'-'ann'])
-            ],
-            [tc_distance/3]
+            tri_sum/2,
+            [register_foreign_native_kind(tri_sum/2, countdown_sum2)],
+            [tri_sum/2]
         )
     ->  pass(Test)
     ;   fail_test(Test, 'Recursive kernel spec generation did not match expected foreign spec')
@@ -312,7 +321,7 @@ test_recursive_kernel_registry :-
     Test = 'WAM-Rust: recursive kernel registry enumerates supported kernels',
     findall(Kind, rust_target:rust_recursive_kernel_detector(Kind, _), Kinds0),
     sort(Kinds0, Kinds),
-    (   Kinds == [category_ancestor, transitive_closure2, transitive_distance3]
+    (   Kinds == [category_ancestor, countdown_sum2, transitive_closure2, transitive_distance3]
     ->  pass(Test)
     ;   fail_test(Test, 'Recursive kernel registry did not match expected supported kernels')
     ).
@@ -410,6 +419,18 @@ test_foreign_lowering_transitive_closure :-
         sub_string(S, _, _, _, 'Instruction::CallForeign("tc_ancestor".to_string(), 2)')
     ->  pass(Test)
     ;   fail_test(Test, 'Foreign lowering was not selected for tc_ancestor/2')
+    ).
+
+test_foreign_lowering_countdown_sum :-
+    Test = 'WAM-Rust: compiler can choose foreign lowering for tri_sum/2',
+    (   rust_target:compile_predicate_to_rust(user:tri_sum/2,
+            [include_main(false), foreign_lowering(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("tri_sum/2", "countdown_sum2")'),
+        sub_string(S, _, _, _, 'execute_foreign_predicate("tri_sum", 2)'),
+        sub_string(S, _, _, _, 'Instruction::CallForeign("tri_sum".to_string(), 2)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Foreign lowering was not selected for tri_sum/2')
     ).
 
 test_foreign_lowering_reverse_transitive_closure :-
@@ -734,6 +755,7 @@ run_tests :-
     test_generated_rust_has_wam_wrapper,
     test_foreign_lowering_category_ancestor,
     test_foreign_lowering_transitive_closure,
+    test_foreign_lowering_countdown_sum,
     test_foreign_lowering_reverse_transitive_closure,
     test_foreign_lowering_transitive_distance,
     test_compile_wam_runtime_output,


### PR DESCRIPTION
## Summary

This PR adds a fourth recursive kernel family to the Rust WAM foreign-lowering
path: `countdown_sum2`, exercised through `tri_sum/2`.

Up to this point, the recursive-kernel registry had only been validated on
graph-shaped recursion:

- `category_ancestor/4`
- `tc_ancestor/2`
- `tc_descendant/2`
- `tc_distance/3`

This change extends the same detector/IR/spec/runtime pipeline to a structurally
different recursive family, showing that the architecture is not limited to
graph traversal.

## What Changed

- added `countdown_sum2` kernel detection and normalization in `rust_target.pl`
- added metadata-driven foreign spec generation for the new kernel
- added Rust-side foreign runtime support for deterministic countdown summation
- changed foreign-lowering selection so that when `foreign_lowering(true)` is
  enabled and a registered kernel matches, the compiler prefers the foreign
  path over earlier generic native clause lowering
- added target-level and end-to-end runtime coverage for `tri_sum/2`
- updated the Rust WAM design notes to document the new kernel family and the
  foreign-lowering selection rule

## Why

The recursive-kernel IR and detector registry were already in place, but they
had only been proven on closely related graph recursion patterns. Adding a
non-graph recursive kernel is the more meaningful validation of the design.

`tri_sum/2` is intentionally simple:

- it is recursive
- it is not graph-shaped
- it is deterministic
- it exercises a different foreign handler shape without needing another large
  runtime abstraction jump

That makes it a good next kernel for proving extensibility.

## Validation

Ran locally:

- `swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`

Covered in tests:

- compiler-selected foreign lowering for `tri_sum/2`
- recursive-kernel registry now includes `countdown_sum2`
- generated Rust runtime execution for `tri_sum/2`
- existing foreign-lowered kernels continue to pass:
  - `category_ancestor/4`
  - `tc_ancestor/2`
  - `tc_descendant/2`
  - `tc_distance/3`

## Scope

This PR does not attempt to generalize all arithmetic recursion into a broader
numeric kernel framework. It adds one concrete non-graph recursive family to
prove the current registry/IR/spec path scales beyond graph traversal.
