### PR TITLE
feat(wam-rust): Add a list-suffix kernel to Rust WAM foreign lowering

### DIFF
--- a/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
+++ b/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
@@ -227,6 +227,7 @@ recursive schemas:
 
 - `category_ancestor/4`-style bounded recursive search
 - countdown-style numeric recursion such as `tri_sum/2`
+- list-suffix recursion such as `tail_suffix/2`
 - binary transitive closure such as `tc_ancestor/2`
 - reversed binary closure such as `tc_descendant/2`
 - recursive distance search such as `tc_distance/3`
@@ -266,6 +267,7 @@ The currently registered recursive kernel families are:
 
 - `category_ancestor`
 - `countdown_sum2`
+- `list_suffix2`
 - `transitive_closure2`
 - `transitive_distance3`
 
@@ -275,11 +277,13 @@ The current test coverage now includes:
 
 - compiler-selection tests for:
   - `category_ancestor/4`
+  - `tail_suffix/2`
   - `tri_sum/2`
   - `tc_ancestor/2`
   - `tc_descendant/2`
   - `tc_distance/3`
 - end-to-end generated Rust runtime validation for:
+  - `tail_suffix/2`
   - `tri_sum/2`
   - `tc_ancestor/2`
   - `tc_descendant/2`

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3719,6 +3719,7 @@ rust_recursive_kernel(Pred, Arity, Clauses, Kernel) :-
 
 rust_recursive_kernel_detector(category_ancestor, rust_recursive_kernel_category_ancestor).
 rust_recursive_kernel_detector(countdown_sum2, rust_recursive_kernel_countdown_sum).
+rust_recursive_kernel_detector(list_suffix2, rust_recursive_kernel_list_suffix).
 rust_recursive_kernel_detector(transitive_closure2, rust_recursive_kernel_transitive_closure).
 rust_recursive_kernel_detector(transitive_distance3, rust_recursive_kernel_transitive_distance).
 
@@ -3735,6 +3736,7 @@ rust_recursive_kernel_setup_ops(KernelKind, PredIndicator, KernelConfig,
 
 rust_recursive_kernel_native_kind(category_ancestor, category_ancestor).
 rust_recursive_kernel_native_kind(countdown_sum2, countdown_sum2).
+rust_recursive_kernel_native_kind(list_suffix2, list_suffix2).
 rust_recursive_kernel_native_kind(transitive_closure2, transitive_closure2).
 rust_recursive_kernel_native_kind(transitive_distance3, transitive_distance3).
 
@@ -3742,6 +3744,7 @@ rust_recursive_kernel_config_ops(category_ancestor, category_ancestor/4,
         [max_depth(MaxDepth)],
         [register_foreign_usize_config(category_ancestor/4, max_depth, MaxDepth)]).
 rust_recursive_kernel_config_ops(countdown_sum2, _PredIndicator, [], []).
+rust_recursive_kernel_config_ops(list_suffix2, _PredIndicator, [], []).
 rust_recursive_kernel_config_ops(transitive_closure2, PredIndicator,
         KernelConfig, ConfigOps) :-
     rust_recursive_kernel_binary_edge_config_ops(PredIndicator, KernelConfig, ConfigOps).
@@ -3764,6 +3767,10 @@ rust_recursive_kernel_category_ancestor(Pred, Arity, Clauses,
 rust_recursive_kernel_countdown_sum(Pred, Arity, Clauses,
         recursive_kernel(countdown_sum2, Pred/Arity, [])) :-
     rust_foreign_lowerable_countdown_sum(Pred, Arity, Clauses).
+
+rust_recursive_kernel_list_suffix(Pred, Arity, Clauses,
+        recursive_kernel(list_suffix2, Pred/Arity, [])) :-
+    rust_foreign_lowerable_list_suffix(Pred, Arity, Clauses).
 
 rust_recursive_kernel_transitive_closure(Pred, Arity, Clauses,
         recursive_kernel(transitive_closure2, Pred/Arity,
@@ -3802,6 +3809,15 @@ rust_foreign_lowerable_countdown_sum(Pred, 2, Clauses) :-
     RecGoal =.. [Pred, PrevN, PrevSum],
     SumGoal =.. [is, Sum, SumExpr],
     SumExpr =.. [+, PrevSum, N].
+
+rust_foreign_lowerable_list_suffix(Pred, 2, Clauses) :-
+    member(BaseHead-true, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseHead =.. [Pred, BaseList, BaseList],
+    var(BaseList),
+    RecHead =.. [Pred, InputList, Suffix],
+    InputList = [_|Tail],
+    RecBody =.. [Pred, Tail, Suffix].
 
 rust_foreign_lowerable_transitive_closure(Pred, 2, Clauses, EdgePred/2, FactPairs) :-
     member(BaseHead-BaseBody, Clauses),

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -786,6 +786,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
     compile_resume_builtin_to_rust(ResumeCode),
     compile_collect_native_category_ancestor_to_rust(NativeAncestorCode),
     compile_compute_native_countdown_sum_to_rust(NativeCountdownSumCode),
+    compile_collect_native_list_suffixes_to_rust(NativeListSuffixCode),
     compile_collect_native_transitive_closure_to_rust(NativeClosureCode),
     compile_collect_native_transitive_distance_to_rust(NativeDistanceCode),
     compile_eval_arith_to_rust(ArithCode),
@@ -803,6 +804,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
         ResumeCode, '\n\n',
         NativeAncestorCode, '\n\n',
         NativeCountdownSumCode, '\n\n',
+        NativeListSuffixCode, '\n\n',
         NativeClosureCode, '\n\n',
         NativeDistanceCode, '\n\n',
         ArithCode
@@ -1122,6 +1124,48 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                     self.pc += 1; true
                 } else { false }
             }
+            "list_suffix2" => {
+                let items = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
+                    Some(Value::List(items)) => items,
+                    _ => return false,
+                };
+                let suffix_reg = match self.regs.get("A2").cloned() {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let suffix_filter = match self.deref_var(&suffix_reg) {
+                    Value::List(items) => Some(items),
+                    Value::Unbound(_) => None,
+                    _ => return false,
+                };
+                let mut suffixes: Vec<Value> = Vec::new();
+                self.collect_native_list_suffixes(&items, &mut suffixes);
+                if let Some(filter) = suffix_filter {
+                    suffixes.retain(|suffix| matches!(suffix, Value::List(items) if *items == filter));
+                }
+                if suffixes.is_empty() {
+                    return false;
+                }
+                if suffixes.len() > 1 {
+                    self.choice_points.push(ChoicePoint {
+                        next_pc: self.pc,
+                        saved_args: self.save_regs(),
+                        stack: self.stack.clone(),
+                        cp: self.cp,
+                        trail_len: self.trail.len(),
+                        heap_len: self.heap.len(),
+                        builtin_state: Some(BuiltinState {
+                            name: "foreign_results".to_string(),
+                            args: vec![Value::Atom(pred_key.clone()), suffix_reg.clone()],
+                            data: suffixes[1..].to_vec(),
+                        }),
+                        cut_barrier: self.cut_barrier,
+                    });
+                }
+                if self.unify(&suffix_reg, &suffixes[0]) {
+                    self.pc += 1; true
+                } else { false }
+            }
             "transitive_closure2" => {
                 let start = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
                     Some(Value::Atom(start)) => start,
@@ -1285,6 +1329,17 @@ compile_compute_native_countdown_sum_to_rust(Code) :-
             current -= 1;
         }
         Some(total)
+    }'.
+
+compile_collect_native_list_suffixes_to_rust(Code) :-
+    Code = '    pub fn collect_native_list_suffixes(
+        &self,
+        items: &[Value],
+        out: &mut Vec<Value>,
+    ) {
+        for idx in 0..=items.len() {
+            out.push(Value::List(items[idx..].to_vec()));
+        }
     }'.
 
 compile_collect_native_transitive_closure_to_rust(Code) :-
@@ -1534,7 +1589,7 @@ compile_resume_builtin_to_rust(Code) :-
                     None => return false,
                 };
                 match native_kind {
-                    "category_ancestor" | "transitive_closure2" => {
+                    "category_ancestor" | "list_suffix2" | "transitive_closure2" => {
                         let result_reg = match state.args.get(1) {
                             Some(val) => val.clone(),
                             None => return false,

--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -53,6 +53,10 @@ tri_sum(N, Sum) :-
     tri_sum(N1, Prev),
     Sum is Prev + N.
 
+:- dynamic tail_suffix/2.
+tail_suffix(S, S).
+tail_suffix([_|T], S) :- tail_suffix(T, S).
+
 %% Integration test
 test_runtime_execution :-
     Test = 'WAM-Rust Runtime: end-to-end execution',
@@ -63,7 +67,7 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tri_sum/2],
+        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tri_sum/2, user:tail_suffix/2],
             [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
@@ -76,6 +80,7 @@ use runtime_test::tc_ancestor;
 use runtime_test::tc_descendant;
 use runtime_test::tc_distance;
 use runtime_test::tri_sum;
+use runtime_test::tail_suffix;
 
 #[test]
 fn test_generated_predicates() {
@@ -230,6 +235,55 @@ fn test_generated_predicates() {
         Value::Integer(4),
         Value::Integer(11));
     assert!(!ok12, "tri_sum(4, 11) should fail");
+
+    // Test tail_suffix/2 foreign lowering end-to-end
+    let list_abc = Value::List(vec![
+        Value::Atom("a".to_string()),
+        Value::Atom("b".to_string()),
+        Value::Atom("c".to_string()),
+    ]);
+    let mut vm_suffix = WamState::new(vec![], std::collections::HashMap::new());
+    let ok13 = tail_suffix(&mut vm_suffix,
+        list_abc.clone(),
+        Value::Unbound("Suffix".to_string()));
+    assert!(ok13, "tail_suffix([a,b,c], Suffix) first solution should succeed");
+
+    let mut suffixes: Vec<String> = Vec::new();
+    if let Some(value) = vm_suffix.bindings.get("Suffix").cloned() {
+        suffixes.push(format!("{}", value));
+    } else {
+        panic!("expected first tail_suffix result in Suffix");
+    }
+
+    while vm_suffix.backtrack() {
+        if let Some(value) = vm_suffix.bindings.get("Suffix").cloned() {
+            suffixes.push(format!("{}", value));
+        } else {
+            panic!("expected backtracked tail_suffix result in Suffix");
+        }
+    }
+
+    assert_eq!(suffixes, vec![
+        "[a, b, c]".to_string(),
+        "[b, c]".to_string(),
+        "[c]".to_string(),
+        "[]".to_string(),
+    ]);
+
+    let mut vm_suffix_check = WamState::new(vec![], std::collections::HashMap::new());
+    let ok14 = tail_suffix(&mut vm_suffix_check,
+        list_abc.clone(),
+        Value::List(vec![
+            Value::Atom("b".to_string()),
+            Value::Atom("c".to_string()),
+        ]));
+    assert!(ok14, "tail_suffix([a,b,c], [b,c]) should succeed");
+
+    let mut vm_suffix_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok15 = tail_suffix(&mut vm_suffix_fail,
+        list_abc,
+        Value::List(vec![Value::Atom("d".to_string())]));
+    assert!(!ok15, "tail_suffix([a,b,c], [d]) should fail");
 }
 ',
         setup_call_cleanup(open(TestPath, write, S), format(S, "~w", [TestContent]), close(S)),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -28,6 +28,7 @@ test_simple_fact(foo, bar).
 
 :- dynamic category_ancestor/4.
 :- dynamic category_parent/2.
+:- dynamic tail_suffix/2.
 :- dynamic tc_ancestor/2.
 :- dynamic tri_sum/2.
 :- dynamic tc_descendant/2.
@@ -40,6 +41,9 @@ category_parent(alpha, beta).
 category_parent(beta, gamma).
 category_parent(gamma, physics).
 category_parent(beta, physics).
+
+tail_suffix(S, S).
+tail_suffix([_|T], S) :- tail_suffix(T, S).
 
 category_ancestor(Cat, Target, 1, Visited) :-
     category_parent(Cat, Target),
@@ -281,6 +285,10 @@ test_recursive_kernel_ir_selection :-
         tri_sum(0, 0)-true,
         tri_sum(N2, Sum2)-((N2 > 0), ((N12 is N2 - 1), (tri_sum(N12, Prev2), Sum2 is Prev2 + N2)))
     ],
+    SuffixClauses = [
+        tail_suffix(S1, S1)-true,
+        tail_suffix([_|T2], S2)-tail_suffix(T2, S2)
+    ],
     DistClauses = [
         tc_distance(S1, T1, 1)-tc_parent(S1, T1),
         tc_distance(S2, T2, D2)-(tc_parent(S2, M2), (tc_distance(M2, T2, D1), D2 is D1 + 1))
@@ -289,6 +297,8 @@ test_recursive_kernel_ir_selection :-
             recursive_kernel(category_ancestor, category_ancestor/4, [max_depth(10)])),
         rust_target:rust_recursive_kernel(tri_sum, 2, SumClauses,
             recursive_kernel(countdown_sum2, tri_sum/2, [])),
+        rust_target:rust_recursive_kernel(tail_suffix, 2, SuffixClauses,
+            recursive_kernel(list_suffix2, tail_suffix/2, [])),
         rust_target:rust_recursive_kernel(tc_descendant, 2, DescClauses,
             recursive_kernel(transitive_closure2, tc_descendant/2,
                 [edge_pred(tc_parent/2), fact_pairs(FactPairs)])),
@@ -304,14 +314,14 @@ test_recursive_kernel_ir_selection :-
 test_recursive_kernel_spec_generation :-
     Test = 'WAM-Rust: recursive kernel IR generates foreign specs declaratively',
     Kernel = recursive_kernel(
-        countdown_sum2,
-        tri_sum/2,
+        list_suffix2,
+        tail_suffix/2,
         []),
     (   rust_target:rust_recursive_kernel_spec(Kernel, ForeignSpec),
         ForeignSpec = foreign_predicate(
-            tri_sum/2,
-            [register_foreign_native_kind(tri_sum/2, countdown_sum2)],
-            [tri_sum/2]
+            tail_suffix/2,
+            [register_foreign_native_kind(tail_suffix/2, list_suffix2)],
+            [tail_suffix/2]
         )
     ->  pass(Test)
     ;   fail_test(Test, 'Recursive kernel spec generation did not match expected foreign spec')
@@ -321,7 +331,7 @@ test_recursive_kernel_registry :-
     Test = 'WAM-Rust: recursive kernel registry enumerates supported kernels',
     findall(Kind, rust_target:rust_recursive_kernel_detector(Kind, _), Kinds0),
     sort(Kinds0, Kinds),
-    (   Kinds == [category_ancestor, countdown_sum2, transitive_closure2, transitive_distance3]
+    (   Kinds == [category_ancestor, countdown_sum2, list_suffix2, transitive_closure2, transitive_distance3]
     ->  pass(Test)
     ;   fail_test(Test, 'Recursive kernel registry did not match expected supported kernels')
     ).
@@ -431,6 +441,18 @@ test_foreign_lowering_countdown_sum :-
         sub_string(S, _, _, _, 'Instruction::CallForeign("tri_sum".to_string(), 2)')
     ->  pass(Test)
     ;   fail_test(Test, 'Foreign lowering was not selected for tri_sum/2')
+    ).
+
+test_foreign_lowering_list_suffix :-
+    Test = 'WAM-Rust: compiler can choose foreign lowering for tail_suffix/2',
+    (   rust_target:compile_predicate_to_rust(user:tail_suffix/2,
+            [include_main(false), foreign_lowering(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("tail_suffix/2", "list_suffix2")'),
+        sub_string(S, _, _, _, 'execute_foreign_predicate("tail_suffix", 2)'),
+        sub_string(S, _, _, _, 'Instruction::CallForeign("tail_suffix".to_string(), 2)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Foreign lowering was not selected for tail_suffix/2')
     ).
 
 test_foreign_lowering_reverse_transitive_closure :-
@@ -756,6 +778,7 @@ run_tests :-
     test_foreign_lowering_category_ancestor,
     test_foreign_lowering_transitive_closure,
     test_foreign_lowering_countdown_sum,
+    test_foreign_lowering_list_suffix,
     test_foreign_lowering_reverse_transitive_closure,
     test_foreign_lowering_transitive_distance,
     test_compile_wam_runtime_output,


### PR DESCRIPTION
## Summary

This PR adds a new recursive kernel family to the Rust WAM foreign-lowering
path: `list_suffix2`, exercised through `tail_suffix/2`.

This is the first nondeterministic non-graph kernel in the current foreign
lowering architecture. It extends the existing detector/IR/spec/runtime path to
cover list-structured recursion with multiple list-valued results returned
through normal backtracking.

## What Changed

- added `list_suffix2` kernel detection and normalization in `rust_target.pl`
- added metadata-driven foreign spec generation for `tail_suffix/2`
- added Rust-side foreign runtime support for list-valued nondeterministic
  suffix enumeration
- reused the existing `foreign_results` resume path for list-valued results
- added target-level and end-to-end runtime coverage for `tail_suffix/2`
- updated the Rust WAM design notes to document the new kernel family

## Why

Before this change, the foreign-kernel path had already been proven for:

- graph recursion
- deterministic numeric recursion

The missing case was a structurally different recursive family that is both:

- nondeterministic
- non-graph

`tail_suffix/2` is a good next kernel because it is simple but exercises an
important missing shape:

- recursive over list structure rather than graph facts
- multiple solutions via backtracking
- list-valued outputs rather than only atoms or integers

That makes it a better proof of extensibility than adding another graph variant
or another deterministic kernel.

## Validation

Ran locally:

- `swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`

Covered in tests:

- compiler-selected foreign lowering for `tail_suffix/2`
- recursive-kernel registry now includes `list_suffix2`
- generated Rust runtime execution for `tail_suffix/2`
- backtracking over list-valued suffix results
- existing foreign-lowered kernels continue to pass:
  - `category_ancestor/4`
  - `tri_sum/2`
  - `tc_ancestor/2`
  - `tc_descendant/2`
  - `tc_distance/3`

## Scope

This PR does not attempt to fully generalize foreign result payload handling
across every possible result shape. It adds one concrete nondeterministic
list-recursive kernel to prove that the current Rust WAM foreign-lowering path
works beyond graph traversal and deterministic numeric recursion.
