### PR TITLE
refactor(wam-rust): normalize foreign result layouts in Rust WAM

### DIFF
--- a/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
+++ b/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
@@ -259,6 +259,9 @@ ad hoc selection block:
 3. **Metadata-driven foreign spec generation**
    - Foreign setup ops and rewrite targets are derived from kernel metadata,
      rather than one bespoke spec-construction clause per supported family.
+   - Result layouts are also registered from kernel metadata, so result
+     resumption no longer needs to branch on specific kernel names just to
+     distinguish single-result versus pair-result payloads.
 
 That split makes the foreign-lowering path easier to extend without letting
 `rust_target.pl` grow another layer of special cases.
@@ -293,6 +296,15 @@ When `foreign_lowering(true)` is enabled and a registered kernel matches, the
 compiler now prefers the foreign path over earlier generic native clause
 lowering. That keeps recognized recursive kernels on the tested runtime path
 instead of silently taking a less structured lowering tier first.
+
+The runtime now also uses a small foreign-result layout layer:
+
+- `single` for one output register
+- `pair` for two-output payloads packed into one foreign result item
+
+That replaces the older kernel-specific resume branching for result shape and
+makes additional kernels cheaper to add as long as they fit an existing result
+layout.
 
 The reverse transitive-closure path required an additional correctness fix:
 reverse schemas must register fact pairs in `child -> parent` orientation, and

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3730,8 +3730,11 @@ rust_recursive_kernel_spec(
     rust_recursive_kernel_rewrite_targets(KernelKind, PredIndicator, KernelConfig, RewriteTargets).
 
 rust_recursive_kernel_setup_ops(KernelKind, PredIndicator, KernelConfig,
-        [register_foreign_native_kind(PredIndicator, NativeKind)|ConfigOps]) :-
+        [ register_foreign_native_kind(PredIndicator, NativeKind),
+          register_foreign_result_layout(PredIndicator, ResultLayout)
+        |ConfigOps]) :-
     rust_recursive_kernel_native_kind(KernelKind, NativeKind),
+    rust_recursive_kernel_result_layout(KernelKind, ResultLayout),
     rust_recursive_kernel_config_ops(KernelKind, PredIndicator, KernelConfig, ConfigOps).
 
 rust_recursive_kernel_native_kind(category_ancestor, category_ancestor).
@@ -3739,6 +3742,12 @@ rust_recursive_kernel_native_kind(countdown_sum2, countdown_sum2).
 rust_recursive_kernel_native_kind(list_suffix2, list_suffix2).
 rust_recursive_kernel_native_kind(transitive_closure2, transitive_closure2).
 rust_recursive_kernel_native_kind(transitive_distance3, transitive_distance3).
+
+rust_recursive_kernel_result_layout(category_ancestor, single).
+rust_recursive_kernel_result_layout(countdown_sum2, single).
+rust_recursive_kernel_result_layout(list_suffix2, single).
+rust_recursive_kernel_result_layout(transitive_closure2, single).
+rust_recursive_kernel_result_layout(transitive_distance3, pair).
 
 rust_recursive_kernel_config_ops(category_ancestor, category_ancestor/4,
         [max_depth(MaxDepth)],

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -784,6 +784,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
     compile_execute_meta_builtin_to_rust(MetaBuiltinCode),
     compile_execute_foreign_predicate_to_rust(ForeignCode),
     compile_resume_builtin_to_rust(ResumeCode),
+    compile_foreign_result_helpers_to_rust(ForeignResultHelpersCode),
     compile_collect_native_category_ancestor_to_rust(NativeAncestorCode),
     compile_compute_native_countdown_sum_to_rust(NativeCountdownSumCode),
     compile_collect_native_list_suffixes_to_rust(NativeListSuffixCode),
@@ -802,6 +803,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
         MetaBuiltinCode, '\n\n',
         ForeignCode, '\n\n',
         ResumeCode, '\n\n',
+        ForeignResultHelpersCode, '\n\n',
         NativeAncestorCode, '\n\n',
         NativeCountdownSumCode, '\n\n',
         NativeListSuffixCode, '\n\n',
@@ -1087,25 +1089,8 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                 if hops.is_empty() {
                     return false;
                 }
-                if hops.len() > 1 {
-                    self.choice_points.push(ChoicePoint {
-                        next_pc: self.pc,
-                        saved_args: self.save_regs(),
-                        stack: self.stack.clone(),
-                        cp: self.cp,
-                        trail_len: self.trail.len(),
-                        heap_len: self.heap.len(),
-                        builtin_state: Some(BuiltinState {
-                            name: "foreign_results".to_string(),
-                            args: vec![Value::Atom(pred_key.clone()), hops_reg.clone()],
-                            data: hops[1..].iter().map(|hop| Value::Integer(*hop)).collect(),
-                        }),
-                        cut_barrier: self.cut_barrier,
-                    });
-                }
-                if self.unify(&hops_reg, &Value::Integer(hops[0])) {
-                    self.pc += 1; true
-                } else { false }
+                let results: Vec<Value> = hops.into_iter().map(Value::Integer).collect();
+                self.finish_foreign_results(&pred_key, vec![hops_reg], results)
             }
             "countdown_sum2" => {
                 let n = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
@@ -1120,9 +1105,7 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                     Some(sum) => sum,
                     None => return false,
                 };
-                if self.unify(&sum_reg, &Value::Integer(sum)) {
-                    self.pc += 1; true
-                } else { false }
+                self.finish_foreign_results(&pred_key, vec![sum_reg], vec![Value::Integer(sum)])
             }
             "list_suffix2" => {
                 let items = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
@@ -1146,25 +1129,7 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                 if suffixes.is_empty() {
                     return false;
                 }
-                if suffixes.len() > 1 {
-                    self.choice_points.push(ChoicePoint {
-                        next_pc: self.pc,
-                        saved_args: self.save_regs(),
-                        stack: self.stack.clone(),
-                        cp: self.cp,
-                        trail_len: self.trail.len(),
-                        heap_len: self.heap.len(),
-                        builtin_state: Some(BuiltinState {
-                            name: "foreign_results".to_string(),
-                            args: vec![Value::Atom(pred_key.clone()), suffix_reg.clone()],
-                            data: suffixes[1..].to_vec(),
-                        }),
-                        cut_barrier: self.cut_barrier,
-                    });
-                }
-                if self.unify(&suffix_reg, &suffixes[0]) {
-                    self.pc += 1; true
-                } else { false }
+                self.finish_foreign_results(&pred_key, vec![suffix_reg], suffixes)
             }
             "transitive_closure2" => {
                 let start = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
@@ -1192,25 +1157,8 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                 if nodes.is_empty() {
                     return false;
                 }
-                if nodes.len() > 1 {
-                    self.choice_points.push(ChoicePoint {
-                        next_pc: self.pc,
-                        saved_args: self.save_regs(),
-                        stack: self.stack.clone(),
-                        cp: self.cp,
-                        trail_len: self.trail.len(),
-                        heap_len: self.heap.len(),
-                        builtin_state: Some(BuiltinState {
-                            name: "foreign_results".to_string(),
-                            args: vec![Value::Atom(pred_key.clone()), target_reg.clone()],
-                            data: nodes[1..].iter().map(|node| Value::Atom(node.clone())).collect(),
-                        }),
-                        cut_barrier: self.cut_barrier,
-                    });
-                }
-                if self.unify(&target_reg, &Value::Atom(nodes[0].clone())) {
-                    self.pc += 1; true
-                } else { false }
+                let results: Vec<Value> = nodes.into_iter().map(Value::Atom).collect();
+                self.finish_foreign_results(&pred_key, vec![target_reg], results)
             }
             "transitive_distance3" => {
                 let start = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
@@ -1242,31 +1190,79 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                 if results.is_empty() {
                     return false;
                 }
-                if results.len() > 1 {
-                    self.choice_points.push(ChoicePoint {
-                        next_pc: self.pc,
-                        saved_args: self.save_regs(),
-                        stack: self.stack.clone(),
-                        cp: self.cp,
-                        trail_len: self.trail.len(),
-                        heap_len: self.heap.len(),
-                        builtin_state: Some(BuiltinState {
-                            name: "foreign_results".to_string(),
-                            args: vec![Value::Atom(pred_key.clone()), target_reg.clone(), dist_reg.clone()],
-                            data: results[1..].iter().map(|(node, dist)| {
-                                Value::Str("__pair__".to_string(), vec![
-                                    Value::Atom(node.clone()),
-                                    Value::Integer(*dist),
-                                ])
-                            }).collect(),
-                        }),
-                        cut_barrier: self.cut_barrier,
-                    });
+                let packed_results: Vec<Value> = results.into_iter().map(|(node, dist)| {
+                    Value::Str("__pair__".to_string(), vec![
+                        Value::Atom(node),
+                        Value::Integer(dist),
+                    ])
+                }).collect();
+                self.finish_foreign_results(&pred_key, vec![target_reg, dist_reg], packed_results)
+            }
+            _ => false,
+        }
+    }'.
+
+compile_foreign_result_helpers_to_rust(Code) :-
+    Code = '    fn finish_foreign_results(
+        &mut self,
+        pred_key: &str,
+        result_regs: Vec<Value>,
+        results: Vec<Value>,
+    ) -> bool {
+        if results.is_empty() {
+            return false;
+        }
+        if results.len() > 1 {
+            self.choice_points.push(ChoicePoint {
+                next_pc: self.pc,
+                saved_args: self.save_regs(),
+                stack: self.stack.clone(),
+                cp: self.cp,
+                trail_len: self.trail.len(),
+                heap_len: self.heap.len(),
+                builtin_state: Some(BuiltinState {
+                    name: "foreign_results".to_string(),
+                    args: {
+                        let mut args = Vec::with_capacity(result_regs.len() + 1);
+                        args.push(Value::Atom(pred_key.to_string()));
+                        args.extend(result_regs.iter().cloned());
+                        args
+                    },
+                    data: results[1..].to_vec(),
+                }),
+                cut_barrier: self.cut_barrier,
+            });
+        }
+        self.apply_foreign_result(pred_key, &result_regs, &results[0])
+    }
+
+    fn apply_foreign_result(
+        &mut self,
+        pred_key: &str,
+        result_regs: &[Value],
+        result: &Value,
+    ) -> bool {
+        let layout = match self.foreign_result_layout(pred_key) {
+            Some(layout) => layout,
+            None => return false,
+        };
+        match layout {
+            "single" => {
+                if result_regs.len() != 1 {
+                    return false;
                 }
-                if self.unify(&target_reg, &Value::Atom(results[0].0.clone()))
-                    && self.unify(&dist_reg, &Value::Integer(results[0].1)) {
-                    self.pc += 1; true
-                } else { false }
+                self.unify(&result_regs[0], result)
+            }
+            "pair" => {
+                if result_regs.len() != 2 {
+                    return false;
+                }
+                match result {
+                    Value::Str(functor, args) if functor == "__pair__" && args.len() == 2 => {
+                        self.unify(&result_regs[0], &args[0]) && self.unify(&result_regs[1], &args[1])
+                    }
+                    _ => false,
+                }
             }
             _ => false,
         }
@@ -1584,40 +1580,9 @@ compile_resume_builtin_to_rust(Code) :-
                         cut_barrier: self.cut_barrier,
                     });
                 }
-                let native_kind = match self.foreign_native_kind(&pred_key) {
-                    Some(kind) => kind,
-                    None => return false,
-                };
-                match native_kind {
-                    "category_ancestor" | "list_suffix2" | "transitive_closure2" => {
-                        let result_reg = match state.args.get(1) {
-                            Some(val) => val.clone(),
-                            None => return false,
-                        };
-                        if self.unify(&result_reg, &result) {
-                            self.pc += 1; true
-                        } else { false }
-                    }
-                    "transitive_distance3" => {
-                        let target_reg = match state.args.get(1) {
-                            Some(val) => val.clone(),
-                            None => return false,
-                        };
-                        let dist_reg = match state.args.get(2) {
-                            Some(val) => val.clone(),
-                            None => return false,
-                        };
-                        match result {
-                            Value::Str(functor, args) if functor == "__pair__" && args.len() == 2 => {
-                                if self.unify(&target_reg, &args[0]) && self.unify(&dist_reg, &args[1]) {
-                                    self.pc += 1; true
-                                } else { false }
-                            }
-                            _ => false,
-                        }
-                    }
-                    _ => false,
-                }
+                if self.apply_foreign_result(&pred_key, &state.args[1..], &result) {
+                    self.pc += 1; true
+                } else { false }
             }
             _ => false,
         }
@@ -1850,6 +1815,9 @@ rust_foreign_setup_code(Ops, Setup) :-
 rust_foreign_setup_line(register_foreign_native_kind(Pred/Arity, Kind), Line) :-
     format(string(Line),
         '    vm.register_foreign_native_kind("~w/~w", "~w");', [Pred, Arity, Kind]).
+rust_foreign_setup_line(register_foreign_result_layout(Pred/Arity, Layout), Line) :-
+    format(string(Line),
+        '    vm.register_foreign_result_layout("~w/~w", "~w");', [Pred, Arity, Layout]).
 rust_foreign_setup_line(register_foreign_string_config(Pred/Arity, Key, ValuePred/ValueArity), Line) :-
     format(string(Line),
         '    vm.register_foreign_string_config("~w/~w", "~w", "~w/~w");',

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -86,6 +86,8 @@ pub struct WamState {
     pub foreign_string_configs: HashMap<String, String>,
     /// Foreign predicate usize configs keyed by "name/arity#config".
     pub foreign_usize_configs: HashMap<String, usize>,
+    /// Foreign predicate result layouts keyed by "name/arity".
+    pub foreign_result_layouts: HashMap<String, String>,
     /// Variable binding table: maps Unbound variable names to their bound values.
     /// This simulates the WAM heap's shared binding semantics when PutVariable
     /// creates a variable that's stored in both a Y-register and an A-register.
@@ -125,6 +127,7 @@ impl WamState {
             foreign_native_kinds: HashMap::new(),
             foreign_string_configs: HashMap::new(),
             foreign_usize_configs: HashMap::new(),
+            foreign_result_layouts: HashMap::new(),
             bindings: HashMap::new(),
             var_counter: 0,
             cut_barrier: 0,
@@ -201,6 +204,16 @@ impl WamState {
         self.foreign_usize_configs
             .get(&format!("{}#{}", pred, key))
             .copied()
+    }
+
+    /// Register a result layout for a foreign predicate.
+    pub fn register_foreign_result_layout(&mut self, pred: &str, layout: &str) {
+        self.foreign_result_layouts.insert(pred.to_string(), layout.to_string());
+    }
+
+    /// Fetch the result layout for a foreign predicate.
+    pub fn foreign_result_layout(&self, pred: &str) -> Option<&str> {
+        self.foreign_result_layouts.get(pred).map(|layout| layout.as_str())
     }
 
     /// Dereference an Unbound variable through the binding table.

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -245,6 +245,7 @@ test_foreign_spec_wrapper_generation :-
     ForeignSpec = foreign_predicate(
         category_ancestor/4,
         [ register_foreign_native_kind(category_ancestor/4, category_ancestor),
+          register_foreign_result_layout(category_ancestor/4, single),
           register_foreign_usize_config(category_ancestor/4, max_depth, 10)
         ],
         [category_ancestor/4]
@@ -254,6 +255,7 @@ test_foreign_spec_wrapper_generation :-
             [foreign_lowering(ForeignSpec)], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("category_ancestor/4", "category_ancestor")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("category_ancestor/4", "single")'),
         sub_string(S, _, _, _, 'register_foreign_usize_config("category_ancestor/4", "max_depth", 10)'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("category_ancestor", 4)'),
         sub_string(S, _, _, _, 'Instruction::CallForeign("category_ancestor".to_string(), 4)')
@@ -320,7 +322,9 @@ test_recursive_kernel_spec_generation :-
     (   rust_target:rust_recursive_kernel_spec(Kernel, ForeignSpec),
         ForeignSpec = foreign_predicate(
             tail_suffix/2,
-            [register_foreign_native_kind(tail_suffix/2, list_suffix2)],
+            [ register_foreign_native_kind(tail_suffix/2, list_suffix2),
+              register_foreign_result_layout(tail_suffix/2, single)
+            ],
             [tail_suffix/2]
         )
     ->  pass(Test)
@@ -410,6 +414,7 @@ test_foreign_lowering_category_ancestor :-
             [include_main(false), foreign_lowering(true)], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("category_ancestor/4", "category_ancestor")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("category_ancestor/4", "single")'),
         sub_string(S, _, _, _, 'register_foreign_usize_config("category_ancestor/4", "max_depth", 10)'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("category_ancestor", 4)'),
         sub_string(S, _, _, _, 'Instruction::CallForeign("category_ancestor".to_string(), 4)')
@@ -423,6 +428,7 @@ test_foreign_lowering_transitive_closure :-
             [include_main(false), foreign_lowering(true)], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tc_ancestor/2", "transitive_closure2")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("tc_ancestor/2", "single")'),
         sub_string(S, _, _, _, 'register_foreign_string_config("tc_ancestor/2", "edge_pred", "tc_parent/2")'),
         sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("tc_parent/2", &[("tom", "bob"), ("tom", "liz"), ("bob", "ann"), ("bob", "pat"), ("pat", "jim")])'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tc_ancestor", 2)'),
@@ -437,6 +443,7 @@ test_foreign_lowering_countdown_sum :-
             [include_main(false), foreign_lowering(true)], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tri_sum/2", "countdown_sum2")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("tri_sum/2", "single")'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tri_sum", 2)'),
         sub_string(S, _, _, _, 'Instruction::CallForeign("tri_sum".to_string(), 2)')
     ->  pass(Test)
@@ -449,6 +456,7 @@ test_foreign_lowering_list_suffix :-
             [include_main(false), foreign_lowering(true)], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tail_suffix/2", "list_suffix2")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("tail_suffix/2", "single")'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tail_suffix", 2)'),
         sub_string(S, _, _, _, 'Instruction::CallForeign("tail_suffix".to_string(), 2)')
     ->  pass(Test)
@@ -461,6 +469,7 @@ test_foreign_lowering_reverse_transitive_closure :-
             [include_main(false), foreign_lowering(true)], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tc_descendant/2", "transitive_closure2")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("tc_descendant/2", "single")'),
         sub_string(S, _, _, _, 'register_foreign_string_config("tc_descendant/2", "edge_pred", "tc_parent/2")'),
         sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("tc_parent/2", &[("bob", "tom"), ("liz", "tom"), ("ann", "bob"), ("pat", "bob"), ("jim", "pat")])'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tc_descendant", 2)'),
@@ -475,6 +484,7 @@ test_foreign_lowering_transitive_distance :-
             [include_main(false), foreign_lowering(true)], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tc_distance/3", "transitive_distance3")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("tc_distance/3", "pair")'),
         sub_string(S, _, _, _, 'register_foreign_string_config("tc_distance/3", "edge_pred", "tc_parent/2")'),
         sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("tc_parent/2", &[("tom", "bob"), ("tom", "liz"), ("bob", "ann"), ("bob", "pat"), ("pat", "jim")])'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tc_distance", 3)'),
@@ -501,8 +511,11 @@ test_compile_wam_runtime_output :-
         sub_string(S, _, _, _, 'Proceed'),
         sub_string(S, _, _, _, 'TryMeElse'),
         sub_string(S, _, _, _, 'foreign_native_kind(&pred_key)'),
+        sub_string(S, _, _, _, 'foreign_result_layout(pred_key)'),
         sub_string(S, _, _, _, 'foreign_string_config(&pred_key, "edge_pred")'),
         sub_string(S, _, _, _, 'foreign_usize_config(&pred_key, "max_depth")'),
+        sub_string(S, _, _, _, 'fn finish_foreign_results'),
+        sub_string(S, _, _, _, 'fn apply_foreign_result'),
         sub_string(S, _, _, _, 'name: "foreign_results".to_string()'),
         sub_string(S, _, _, _, 'transitive_closure2'),
         sub_string(S, _, _, _, 'collect_native_transitive_closure_nodes')


### PR DESCRIPTION
 ## Summary

This PR refactors Rust WAM foreign result handling so result resumption is
driven by registered result layouts rather than branching on specific kernel
names.

The compiler now emits result-layout metadata alongside native handler
registration, and the runtime uses generic helpers to:

- queue remaining foreign results
- resume them through backtracking
- bind outputs according to the registered result shape

## What Changed

- added result-layout metadata to recursive-kernel foreign specs
- registered result layouts in the generated Rust WAM state
- added runtime support for foreign result layouts in `WamState`
- replaced kernel-specific `foreign_results` resume branching with generic:
  - `finish_foreign_results`
  - `apply_foreign_result`
- updated generated-code assertions to cover result-layout registration and use
- updated design notes to document the new runtime layer

## Why

Before this change, foreign result resumption still depended partly on
kernel-specific logic:

- single-result kernels shared one path
- pair-valued kernels used a separate path

That meant adding a new kernel could require touching resume logic even when
the new kernel’s outputs fit an already-supported result shape.

This PR moves that distinction into metadata. The runtime now cares about
result layout rather than kernel identity for result binding.

## Current Result Layouts

- `single`
  - one output register bound directly from one foreign result value
- `pair`
  - two output registers bound from a packed pair payload

This keeps the current behavior intact while making future kernels cheaper to
add if they fit an existing layout.

## Validation

Ran locally:

- `swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`

These cover the existing foreign-lowered kernels:

- `category_ancestor/4`
- `tri_sum/2`
- `tail_suffix/2`
- `tc_ancestor/2`
- `tc_descendant/2`
- `tc_distance/3`

## Scope

This PR does not introduce new kernel families or new result layouts. It
refactors the runtime and generated metadata so current kernels use a more
general result-binding path, which is the right foundation for future foreign
lowering work.
