### PR TITLE
feat(csharp-query): measure relation retention costs

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -81,6 +81,9 @@ Status:
 
 - started for shortest-path and weighted-shortest-path grouped minima
 - started for effective-distance and category-influence grouped weight sums
+- started for path-aware edge-relation retention, where the runtime can now
+  choose between direct streamed edge-state build, replayable buffering, and
+  external materialized fallback before building operator-owned edge state
 - the runtime can now choose between compact grouped summaries and legacy
   seeded-row regrouping for both operator families through a shared
   grouped-summary policy layer
@@ -91,8 +94,12 @@ Status:
 - the current implementation shares one grouped-summary heuristic/resolution
   path internally, now records measured cost buckets at the retention
   decision points, and keeps per-family override knobs for benchmarking
+- `QueryExecutorOptions.PathAwareEdgeRetentionStrategy` can force `Auto`,
+  `StreamingDirect`, `ReplayableBuffer`, or `ExternalMaterialized` for
+  path-aware edge-retention benchmarking
 - the current selector only runs bounded measured probes in ambiguous cases;
-  obvious shapes still short-circuit structurally
+  obvious grouped-summary shapes still short-circuit structurally, while
+  path-aware edge retention now measures competing source paths directly
 
 Work:
 

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -63,6 +63,10 @@ Examples:
 - DAG longest depth builds adjacency and scalar suffix-depth state
 - path-aware shortest-path operators can build compact source->targets edge state
   instead of retaining generic edge tuples
+- where direct streaming, replayable buffering, and external materialized rows
+  are all viable sources for that edge state, the runtime can choose among
+  them through a measured retention selector and still expose an explicit
+  override via `QueryExecutorOptions.PathAwareEdgeRetentionStrategy`
 - shortest-path and weighted-shortest-path operators can emit compact
   `(group, root, min_value)` summaries instead of retaining full seeded path rows
 - where both grouped minima and legacy seeded-row regrouping are available, the
@@ -120,20 +124,24 @@ For the current benchmark/runtime surface, the streamed path is:
 4. DAG, scan, and path-aware operators read rows through that retention boundary
 5. path-aware shortest-path operators can build a compact edge-state cache
    directly from streamed facts instead of generic replayed edge rows
-6. shortest-path and weighted-shortest-path operators can emit compact
+6. where streaming, replayable buffering, and external materialized rows are
+   all viable sources for that cache, the runtime can use measured edge-retention
+   buckets and bounded probes to choose among them before honoring an explicit
+   executor override
+7. shortest-path and weighted-shortest-path operators can emit compact
    grouped root minima directly from streamed edge/seed inputs
-7. where grouped minima and legacy seeded-row regrouping both exist, the runtime
+8. where grouped minima and legacy seeded-row regrouping both exist, the runtime
    can select between them through a shared grouped-summary policy layer,
    record measured cost buckets for that decision, and use bounded probes in
    ambiguous cases before falling back to an explicit executor option
-8. effective-distance and category-influence operators can emit compact
+9. effective-distance and category-influence operators can emit compact
    grouped root-weight summaries directly from streamed edge/seed inputs
-9. where grouped weight sums and legacy seeded-row regrouping both exist, the
+10. where grouped weight sums and legacy seeded-row regrouping both exist, the
    runtime can select between them through that same grouped-summary policy
    layer, record measured cost buckets for that decision, and use bounded
    probes in ambiguous cases before falling back to an explicit executor option
-10. the operator builds only the retained state it actually needs
-11. benchmark code avoids preloading raw facts into in-memory relations first
+11. the operator builds only the retained state it actually needs
+12. benchmark code avoids preloading raw facts into in-memory relations first
 
 This is still a first step, not the full endpoint, but it is now broader than
 just the original DAG-only fast paths.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -32,25 +32,26 @@ compact grouped weight sums and the legacy seeded-row regrouping path,
 using the same grouped-summary policy layer that now also drives the
 shortest-path minima family. That policy now records measured cost buckets
 like `load_roots`, `load_seeds`, `strategy_select`, `build_*`, and
-`group_reduce`, while only running bounded probes when the structural signal
-is ambiguous.
+`group_reduce`, while the earlier path-aware edge-retention boundary now also
+records buckets like `edge_strategy_select`, `edge_probe_*`,
+`edge_materialize_replayable`, and `edge_build_*`.
 
 | Target | 300 art | 1K art | 5K art | 10K art |
 |--------|---------|--------|--------|---------|
-| **C# Query Engine** | **0.224s** | **0.182s** | **0.406s** | **0.695s** |
-| Prolog accumulated | 0.349s | 0.236s | 0.856s | 1.942s |
-| C# DFS pipeline | 0.437s | 1.313s | 5.634s | 10.196s |
-| Rust DFS pipeline | 0.365s | 1.638s | 7.164s | 13.782s |
-| Go DFS pipeline | 0.469s | 1.971s | 11.302s | 19.074s |
+| **C# Query Engine** | **0.279s** | **0.229s** | **0.453s** | **0.902s** |
+| Prolog accumulated | 0.488s | 0.333s | 1.040s | 2.283s |
+| C# DFS pipeline | 0.509s | 1.465s | 6.494s | 11.863s |
+| Rust DFS pipeline | 0.413s | 1.718s | 9.761s | 16.344s |
+| Go DFS pipeline | 0.580s | 2.496s | 15.875s | 24.587s |
 
 **Speedups of the current C# query engine:**
 
 | Scale | vs Prolog accumulated | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------------------:|----------:|------------:|----------:|
-| 300 art | 1.56x | 1.95x | 1.63x | 2.09x |
-| 1K art | 1.30x | 7.21x | 9.00x | 10.83x |
-| 5K art | 2.11x | 13.88x | 17.65x | 27.84x |
-| 10K art | 2.79x | 14.67x | 19.83x | 27.46x |
+| 300 art | 1.75x | 1.83x | 1.48x | 2.08x |
+| 1K art | 1.45x | 6.40x | 7.50x | 10.90x |
+| 5K art | 2.30x | 14.34x | 21.55x | 35.04x |
+| 10K art | 2.53x | 13.15x | 18.12x | 27.26x |
 
 Semantic note:
 
@@ -110,13 +111,13 @@ For historical context, the original DFS-only pipeline comparison:
 
 ### Key Findings
 
-1. **The C# query engine is now the fastest effective-distance path on
-   this benchmark surface** — it beats accumulated Prolog by `1.56x` at
-   `300`, `1.30x` at `1k`, `2.11x` at `5k`, and `2.79x` at `10k`.
+1. **The C# query engine is still the fastest effective-distance path on
+   this benchmark surface** — it beats accumulated Prolog by `1.75x` at
+   `300`, `1.45x` at `1k`, `2.30x` at `5k`, and `2.53x` at `10k`.
 
-2. **The C# query engine now beats the DFS baselines by a wide margin** —
-   at `10k` it is `14.67x` faster than C# DFS, `19.83x` faster than Rust
-   DFS, and `27.46x` faster than Go DFS.
+2. **The C# query engine still beats the DFS baselines by a wide margin** —
+   at `10k` it is `13.15x` faster than C# DFS, `18.12x` faster than Rust
+   DFS, and `27.26x` faster than Go DFS.
 
 3. **Retained-state strategy matters more than branch pruning on this
    workload** — seeded reuse is the first big win, and moving per-article
@@ -516,28 +517,28 @@ Latest local results:
 
 | Scale | C# Query | Prolog Min | C# DFS | Rust DFS | Go DFS | Outputs |
 |-------|---------:|-----------:|--------:|---------:|-------:|---------|
-| 300 | 0.095s | 0.131s | 0.500s | 0.437s | 0.478s | match |
-| 1k | 0.090s | 0.131s | 1.262s | 1.765s | 2.148s | match |
-| 5k | 0.121s | 0.254s | 5.822s | 8.109s | 12.126s | match |
-| 10k | 0.184s | 0.459s | 11.182s | 15.130s | 20.374s | match |
+| 300 | 0.117s | 0.136s | 0.537s | 0.418s | 0.600s | match |
+| 1k | 0.107s | 0.112s | 1.465s | 1.718s | 2.531s | match |
+| 5k | 0.148s | 0.278s | 6.434s | 8.819s | 15.760s | match |
+| 10k | 0.212s | 0.510s | 12.139s | 16.450s | 25.110s | match |
 
 Direct C# query vs Prolog seeded `min`:
 
 | Scale | Faster target | Speedup |
 |-------|---------------|--------:|
-| 300 | C# Query | 1.38x |
-| 1k | C# Query | 1.45x |
-| 5k | C# Query | 2.11x |
-| 10k | C# Query | 2.49x |
+| 300 | C# Query | 1.15x |
+| 1k | C# Query | 1.05x |
+| 5k | C# Query | 1.87x |
+| 10k | C# Query | 2.40x |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 5.26x | 4.59x | 5.04x |
-| 1k | 14.03x | 19.62x | 23.88x |
-| 5k | 48.29x | 67.26x | 100.57x |
-| 10k | 60.64x | 82.06x | 110.49x |
+| 300 | 4.57x | 3.56x | 5.11x |
+| 1k | 13.73x | 16.10x | 23.72x |
+| 5k | 43.34x | 59.41x | 106.16x |
+| 10k | 57.21x | 77.53x | 118.35x |
 
 Comparison note:
 
@@ -547,12 +548,17 @@ Comparison note:
 - on the current one-root benchmark shape, the retained row count now
   collapses to the final article result count, which is why the C# query
   path improves so sharply at every tested scale
-- the new `Auto` selector currently chooses the compact grouped minima
+- the new `Auto` selector still chooses the compact grouped minima
   path at every tested scale; this now flows through the same grouped-summary
   policy layer used by grouped weight sums, while still preserving the
-  per-family override knob. Trace output now exposes measured buckets such as
-  `load_roots`, `load_seeds`, `strategy_select`, `build_compact_grouped`, and
-  `group_reduce`. Forcing legacy seeded-row regrouping is
+  per-family override knob
+- the path-aware edge relation now also goes through measured retention
+  selection, and on the current benchmark surface `Auto` prefers
+  `ReplayableBuffer`; trace output now exposes edge buckets such as
+  `edge_strategy_select`, `edge_probe_streaming_direct`,
+  `edge_probe_replayable_buffer`, `edge_materialize_replayable`, and
+  `edge_build_replayable_buffer`
+- forcing legacy seeded-row regrouping is
   materially worse (`300`: `0.160s` vs `0.083s`, `10k`: `0.419s` vs
   `0.161s`)
 - seeded Prolog `min` remains competitive, but the C# query engine is
@@ -574,28 +580,28 @@ Latest local results:
 
 | Scale | C# Query | Prolog Min | C# DFS | Rust DFS | Go DFS | Outputs |
 |-------|---------:|-----------:|--------:|---------:|-------:|---------|
-| 300 | 0.162s | 0.128s | 0.523s | 0.427s | 0.497s | match |
-| 1k | 0.147s | 0.125s | 1.402s | 1.762s | 2.186s | match |
-| 5k | 0.222s | 0.295s | 6.116s | 8.414s | 11.994s | match |
-| 10k | 0.347s | 0.514s | 11.450s | 16.019s | 20.289s | match |
+| 300 | 0.190s | 0.134s | 0.528s | 0.386s | 0.628s | match |
+| 1k | 0.175s | 0.155s | 1.450s | 1.730s | 2.622s | match |
+| 5k | 0.246s | 0.305s | 6.742s | 9.137s | 15.661s | match |
+| 10k | 0.414s | 0.636s | 12.798s | 17.239s | 24.495s | match |
 
 Direct C# query vs Prolog seeded `min`:
 
 | Scale | Faster target | Speedup |
 |-------|---------------|--------:|
-| 300 | Prolog Min | 1.26x |
-| 1k | Prolog Min | 1.17x |
-| 5k | C# Query | 1.33x |
-| 10k | C# Query | 1.48x |
+| 300 | Prolog Min | 1.42x |
+| 1k | Prolog Min | 1.13x |
+| 5k | C# Query | 1.24x |
+| 10k | C# Query | 1.54x |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 3.24x | 2.64x | 3.07x |
-| 1k | 9.55x | 12.00x | 14.89x |
-| 5k | 27.60x | 37.97x | 54.12x |
-| 10k | 32.99x | 46.16x | 58.46x |
+| 300 | 2.78x | 2.03x | 3.31x |
+| 1k | 8.30x | 9.90x | 15.01x |
+| 5k | 27.39x | 37.12x | 63.62x |
+| 10k | 30.93x | 41.66x | 59.20x |
 
 Comparison note:
 
@@ -606,8 +612,10 @@ Comparison note:
   also collapses to the final article result count
 - the new `Auto` selector also chooses the compact grouped minima path
   here; this now uses the same grouped-summary policy layer as shortest
-  path while keeping a separate benchmark override, and the same measured
-  buckets are available under trace for this family too
+  path while keeping a separate benchmark override
+- the path-aware edge relation also now goes through measured retention
+  selection, and the same edge buckets are available under trace for this
+  family too
 - forcing legacy seeded-row regrouping regresses both ends of the
   benchmark (`300`: `0.202s` vs `0.151s`, `10k`: `0.430s` vs `0.320s`)
 - seeded Prolog `min` still wins narrowly at `300` and `1k`, but the C#
@@ -772,19 +780,19 @@ Latest local results:
 
 | Scale | C# Query | Rust DFS | Go DFS | Outputs |
 |-------|---------:|---------:|-------:|---------|
-| 300 | 0.207s | 0.484s | 0.495s | match |
-| 1k | 0.170s | 1.608s | 2.096s | match |
-| 5k | 0.382s | 8.125s | 11.640s | match |
-| 10k | 0.718s | 14.767s | 19.544s | match |
+| 300 | 0.320s | 0.469s | 1.516s | match |
+| 1k | 0.340s | 2.861s | 2.636s | match |
+| 5k | 0.455s | 9.366s | 14.989s | match |
+| 10k | 0.882s | 16.925s | 25.592s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs Rust DFS | vs Go DFS |
 |-------|------------:|----------:|
-| 300 | 2.33x | 2.39x |
-| 1k | 9.48x | 12.35x |
-| 5k | 21.26x | 30.45x |
-| 10k | 20.55x | 27.20x |
+| 300 | 1.47x | 4.74x |
+| 1k | 8.42x | 7.75x |
+| 5k | 20.57x | 32.92x |
+| 10k | 19.19x | 29.01x |
 
 Comparison note:
 
@@ -794,9 +802,14 @@ Comparison note:
 - the remaining benchmark-side work is only the final per-root sum over those
   compact article/root summaries
 - the new `Auto` selector also chooses the compact grouped weight-sum path
-  here; trace output now exposes measured buckets such as `load_roots`,
-  `load_seeds`, `strategy_select`, `build_compact_grouped`, and
-  `group_reduce`. Forcing legacy seeded-row regrouping regresses badly (`300`: `0.711s`
+  here
+- the path-aware edge relation now also goes through measured retention
+  selection, and trace output exposes both grouped-summary buckets such as
+  `load_roots`, `load_seeds`, `strategy_select`, `build_compact_grouped`, and
+  `group_reduce`, plus edge buckets such as `edge_strategy_select`,
+  `edge_probe_streaming_direct`, `edge_probe_replayable_buffer`,
+  `edge_materialize_replayable`, and `edge_build_replayable_buffer`
+- forcing legacy seeded-row regrouping regresses badly (`300`: `0.711s`
   vs `0.237s`, `10k`: `2.998s` vs `0.829s`)
 - Rust and Go remain generated DFS/pipeline binaries
 - so this runner is still intentionally a mixed execution-model comparison:

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -2485,6 +2485,18 @@ class Program
         }};
     }}
 
+    static PathAwareEdgeRetentionStrategy ReadEdgeRetentionStrategy()
+    {{
+        var value = Environment.GetEnvironmentVariable("UNIFYWEAVER_EDGE_RETENTION_STRATEGY");
+        return value?.ToLowerInvariant() switch
+        {{
+            "streaming" => PathAwareEdgeRetentionStrategy.StreamingDirect,
+            "replayable" => PathAwareEdgeRetentionStrategy.ReplayableBuffer,
+            "external" => PathAwareEdgeRetentionStrategy.ExternalMaterialized,
+            _ => PathAwareEdgeRetentionStrategy.Auto
+        }};
+    }}
+
     static void PrintWeightSumStrategies(QueryExecutionTrace? trace)
     {{
         if (trace is null)
@@ -2549,12 +2561,14 @@ class Program
         );
 
         var weightSumStrategy = ReadWeightSumStrategy();
+        var edgeRetentionStrategy = ReadEdgeRetentionStrategy();
         var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
         QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
 
         var swQuery = Stopwatch.StartNew();
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(
             ReuseCaches: false,
+            PathAwareEdgeRetentionStrategy: edgeRetentionStrategy,
             PathAwareWeightSumStrategy: weightSumStrategy));
         var rows = executor.Execute(plan, trace: trace).ToList();
         swQuery.Stop();
@@ -2593,6 +2607,7 @@ class Program
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"root_count={{results.Count}}");
         Console.Error.WriteLine($"weight_sum_strategy_setting={{weightSumStrategy}}");
+        Console.Error.WriteLine($"edge_retention_strategy_setting={{edgeRetentionStrategy}}");
         PrintWeightSumStrategies(trace);
         PrintWeightSumPhases(trace);
     }}
@@ -2625,6 +2640,18 @@ class Program
             "legacy" => PathAwareWeightSumStrategy.LegacySeededRows,
             "grouped" => PathAwareWeightSumStrategy.CompactGrouped,
             _ => PathAwareWeightSumStrategy.Auto
+        }};
+    }}
+
+    static PathAwareEdgeRetentionStrategy ReadEdgeRetentionStrategy()
+    {{
+        var value = Environment.GetEnvironmentVariable("UNIFYWEAVER_EDGE_RETENTION_STRATEGY");
+        return value?.ToLowerInvariant() switch
+        {{
+            "streaming" => PathAwareEdgeRetentionStrategy.StreamingDirect,
+            "replayable" => PathAwareEdgeRetentionStrategy.ReplayableBuffer,
+            "external" => PathAwareEdgeRetentionStrategy.ExternalMaterialized,
+            _ => PathAwareEdgeRetentionStrategy.Auto
         }};
     }}
 
@@ -2688,12 +2715,14 @@ class Program
         );
 
         var weightSumStrategy = ReadWeightSumStrategy();
+        var edgeRetentionStrategy = ReadEdgeRetentionStrategy();
         var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
         QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
 
         var swExec = Stopwatch.StartNew();
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(
             ReuseCaches: false,
+            PathAwareEdgeRetentionStrategy: edgeRetentionStrategy,
             PathAwareWeightSumStrategy: weightSumStrategy));
         var rows = executor.Execute(plan, trace: trace).ToList();
         swExec.Stop();
@@ -2725,6 +2754,7 @@ class Program
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"article_count={{results.Count}}");
         Console.Error.WriteLine($"weight_sum_strategy_setting={{weightSumStrategy}}");
+        Console.Error.WriteLine($"edge_retention_strategy_setting={{edgeRetentionStrategy}}");
         PrintWeightSumStrategies(trace);
         PrintWeightSumPhases(trace);
     }}
@@ -2760,6 +2790,18 @@ class Program
             "legacy" => PathAwareGroupedMinStrategy.LegacySeededRows,
             "grouped" => PathAwareGroupedMinStrategy.CompactGrouped,
             _ => PathAwareGroupedMinStrategy.Auto
+        }};
+    }}
+
+    static PathAwareEdgeRetentionStrategy ReadEdgeRetentionStrategy()
+    {{
+        var value = Environment.GetEnvironmentVariable("UNIFYWEAVER_EDGE_RETENTION_STRATEGY");
+        return value?.ToLowerInvariant() switch
+        {{
+            "streaming" => PathAwareEdgeRetentionStrategy.StreamingDirect,
+            "replayable" => PathAwareEdgeRetentionStrategy.ReplayableBuffer,
+            "external" => PathAwareEdgeRetentionStrategy.ExternalMaterialized,
+            _ => PathAwareEdgeRetentionStrategy.Auto
         }};
     }}
 
@@ -2823,12 +2865,14 @@ class Program
         );
 
         var pathMinStrategy = ReadPathMinStrategy();
+        var edgeRetentionStrategy = ReadEdgeRetentionStrategy();
         var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
         QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
 
         var swQuery = Stopwatch.StartNew();
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(
             ReuseCaches: false,
+            PathAwareEdgeRetentionStrategy: edgeRetentionStrategy,
             PathAwareGroupedMinStrategy: pathMinStrategy));
         var rows = executor.Execute(plan, trace: trace).ToList();
         swQuery.Stop();
@@ -2859,6 +2903,7 @@ class Program
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"article_count={{results.Count}}");
         Console.Error.WriteLine($"path_min_strategy_setting={{pathMinStrategy}}");
+        Console.Error.WriteLine($"edge_retention_strategy_setting={{edgeRetentionStrategy}}");
         PrintPathMinStrategies(trace);
         PrintPathMinPhases(trace);
     }}
@@ -2891,6 +2936,18 @@ class Program
             "legacy" => PathAwareGroupedMinStrategy.LegacySeededRows,
             "grouped" => PathAwareGroupedMinStrategy.CompactGrouped,
             _ => PathAwareGroupedMinStrategy.Auto
+        }};
+    }}
+
+    static PathAwareEdgeRetentionStrategy ReadEdgeRetentionStrategy()
+    {{
+        var value = Environment.GetEnvironmentVariable("UNIFYWEAVER_EDGE_RETENTION_STRATEGY");
+        return value?.ToLowerInvariant() switch
+        {{
+            "streaming" => PathAwareEdgeRetentionStrategy.StreamingDirect,
+            "replayable" => PathAwareEdgeRetentionStrategy.ReplayableBuffer,
+            "external" => PathAwareEdgeRetentionStrategy.ExternalMaterialized,
+            _ => PathAwareEdgeRetentionStrategy.Auto
         }};
     }}
 
@@ -2994,12 +3051,14 @@ class Program
         );
 
         var pathMinStrategy = ReadPathMinStrategy();
+        var edgeRetentionStrategy = ReadEdgeRetentionStrategy();
         var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
         QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
 
         var swQuery = Stopwatch.StartNew();
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(
             ReuseCaches: false,
+            PathAwareEdgeRetentionStrategy: edgeRetentionStrategy,
             PathAwareGroupedMinStrategy: pathMinStrategy));
         var rows = executor.Execute(plan, trace: trace).ToList();
         swQuery.Stop();
@@ -3030,6 +3089,7 @@ class Program
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"article_count={{results.Count}}");
         Console.Error.WriteLine($"path_min_strategy_setting={{pathMinStrategy}}");
+        Console.Error.WriteLine($"edge_retention_strategy_setting={{edgeRetentionStrategy}}");
         PrintPathMinStrategies(trace);
         PrintPathMinPhases(trace);
     }}

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -43,6 +43,14 @@ namespace UnifyWeaver.QueryRuntime
         ExternalMaterialized
     }
 
+    public enum PathAwareEdgeRetentionStrategy
+    {
+        Auto,
+        StreamingDirect,
+        ReplayableBuffer,
+        ExternalMaterialized
+    }
+
     public readonly record struct DelimitedRelationSource(
         string InputPath,
         char Delimiter = '	',
@@ -488,12 +496,17 @@ namespace UnifyWeaver.QueryRuntime
         LegacySeededRows
     }
 
+    internal readonly record struct PathAwareEdgeRetentionSelection(
+        PathAwareEdgeRetentionStrategy Strategy,
+        string DecisionMode);
+
     internal readonly record struct PathAwareGroupedSummarySelection(
         PathAwareGroupedSummaryStrategy Strategy,
         string DecisionMode);
 
     public sealed record QueryExecutorOptions(
         bool ReuseCaches = false,
+        PathAwareEdgeRetentionStrategy PathAwareEdgeRetentionStrategy = PathAwareEdgeRetentionStrategy.Auto,
         PathAwareGroupedMinStrategy PathAwareGroupedMinStrategy = PathAwareGroupedMinStrategy.Auto,
         PathAwareWeightSumStrategy PathAwareWeightSumStrategy = PathAwareWeightSumStrategy.Auto,
         int PairProbeCacheMaxEntries = 4096,
@@ -1278,6 +1291,8 @@ namespace UnifyWeaver.QueryRuntime
             _factory = factory ?? throw new ArgumentNullException(nameof(factory));
         }
 
+        public bool IsMaterialized => _buffer is not null;
+
         public IEnumerable<object[]> Stream() => Materialize();
 
         public List<object[]> Materialize()
@@ -1292,6 +1307,16 @@ namespace UnifyWeaver.QueryRuntime
                 _buffer ??= _factory().ToList();
                 return _buffer;
             }
+        }
+
+        public List<object[]> ProbeMaterialize(int maxRows)
+        {
+            if (_buffer is not null)
+            {
+                return _buffer.Take(Math.Max(0, maxRows)).ToList();
+            }
+
+            return _factory().Take(Math.Max(0, maxRows)).ToList();
         }
     }
 
@@ -1430,6 +1455,7 @@ namespace UnifyWeaver.QueryRuntime
         private readonly int _seededCacheAdmissionMinRows;
         private readonly double _seededCacheAdmissionMinRowsPerSeed;
         private readonly int _maxFixpointIterations;
+        private readonly PathAwareEdgeRetentionStrategy _pathAwareEdgeRetentionStrategy;
         private readonly PathAwareGroupedSummaryStrategy _pathAwareGroupedMinStrategy;
         private readonly PathAwareGroupedSummaryStrategy _pathAwareWeightSumStrategy;
 
@@ -1445,6 +1471,7 @@ namespace UnifyWeaver.QueryRuntime
             _seededCacheAdmissionMinRows = Math.Max(0, options.SeededCacheAdmissionMinRows);
             _seededCacheAdmissionMinRowsPerSeed = Math.Max(0d, options.SeededCacheAdmissionMinRowsPerSeed);
             _maxFixpointIterations = Math.Max(0, options.MaxFixpointIterations);
+            _pathAwareEdgeRetentionStrategy = options.PathAwareEdgeRetentionStrategy;
             _pathAwareGroupedMinStrategy = ToPathAwareGroupedSummaryStrategy(options.PathAwareGroupedMinStrategy);
             _pathAwareWeightSumStrategy = ToPathAwareGroupedSummaryStrategy(options.PathAwareWeightSumStrategy);
         }
@@ -5828,6 +5855,156 @@ namespace UnifyWeaver.QueryRuntime
             return false;
         }
 
+        private bool TryGetExternalFacts(PredicateId predicate, out IEnumerable<object[]> facts)
+        {
+            if (TryBindRelation(predicate, RelationRetentionMode.ExternalMaterialized, out var binding) &&
+                binding.Mode == RelationRetentionMode.ExternalMaterialized)
+            {
+                facts = _provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>();
+                return true;
+            }
+
+            facts = default!;
+            return false;
+        }
+
+        private static void AddPathAwareEdge(
+            Dictionary<object, PathAwareSuccessorBucket> successors,
+            List<object?> seeds,
+            HashSet<object?> seenSeeds,
+            object? source,
+            object? target)
+        {
+            var lookupKey = source ?? NullFactIndexKey;
+            if (!successors.TryGetValue(lookupKey, out var bucket))
+            {
+                bucket = new PathAwareSuccessorBucket(source);
+                successors[lookupKey] = bucket;
+            }
+
+            bucket.Targets.Add(target);
+            if (seenSeeds.Add(source))
+            {
+                seeds.Add(source);
+            }
+        }
+
+        private static PathAwareEdgeState FinalizePathAwareEdgeState(
+            Dictionary<object, PathAwareSuccessorBucket> successors,
+            List<object?> seeds)
+        {
+            seeds.Sort(CompareCacheSeedValues);
+            return new PathAwareEdgeState(successors, seeds);
+        }
+
+        private static PathAwareEdgeState BuildPathAwareEdgeStateFromRows(IEnumerable<object[]> edges)
+        {
+            var successors = new Dictionary<object, PathAwareSuccessorBucket>();
+            var seeds = new List<object?>();
+            var seenSeeds = new HashSet<object?>();
+
+            foreach (var edge in edges)
+            {
+                if (edge is null || edge.Length < 2)
+                {
+                    continue;
+                }
+
+                AddPathAwareEdge(successors, seeds, seenSeeds, edge[0], edge[1]);
+            }
+
+            return FinalizePathAwareEdgeState(successors, seeds);
+        }
+
+        private static PathAwareEdgeState BuildPathAwareEdgeStateFromDelimited(DelimitedRelationSource delimitedSource)
+        {
+            var successors = new Dictionary<object, PathAwareSuccessorBucket>();
+            var seeds = new List<object?>();
+            var seenSeeds = new HashSet<object?>();
+
+            using var reader = DelimitedRelationReader.OpenSequentialReader(delimitedSource.InputPath);
+            for (var i = 0; i < delimitedSource.SkipRows; i++)
+            {
+                if (reader.ReadLine() is null)
+                {
+                    break;
+                }
+            }
+
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                if (!DelimitedRelationReader.TrySplitTwoColumnLine(line, delimitedSource.Delimiter, out var left, out var right))
+                {
+                    continue;
+                }
+
+                AddPathAwareEdge(successors, seeds, seenSeeds, left, right);
+            }
+
+            return FinalizePathAwareEdgeState(successors, seeds);
+        }
+
+        private static void ProbePathAwareEdgeRows(IEnumerable<object[]> edges, int maxRows)
+        {
+            var successors = new Dictionary<object, PathAwareSuccessorBucket>();
+            var seeds = new List<object?>();
+            var seenSeeds = new HashSet<object?>();
+            var consumed = 0;
+
+            foreach (var edge in edges)
+            {
+                if (edge is null || edge.Length < 2)
+                {
+                    continue;
+                }
+
+                AddPathAwareEdge(successors, seeds, seenSeeds, edge[0], edge[1]);
+                consumed++;
+                if (consumed >= maxRows)
+                {
+                    break;
+                }
+            }
+
+            seeds.Sort(CompareCacheSeedValues);
+        }
+
+        private static void ProbePathAwareEdgeDelimited(DelimitedRelationSource delimitedSource, int maxRows)
+        {
+            var successors = new Dictionary<object, PathAwareSuccessorBucket>();
+            var seeds = new List<object?>();
+            var seenSeeds = new HashSet<object?>();
+            var consumed = 0;
+
+            using var reader = DelimitedRelationReader.OpenSequentialReader(delimitedSource.InputPath);
+            for (var i = 0; i < delimitedSource.SkipRows; i++)
+            {
+                if (reader.ReadLine() is null)
+                {
+                    break;
+                }
+            }
+
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                if (!DelimitedRelationReader.TrySplitTwoColumnLine(line, delimitedSource.Delimiter, out var left, out var right))
+                {
+                    continue;
+                }
+
+                AddPathAwareEdge(successors, seeds, seenSeeds, left, right);
+                consumed++;
+                if (consumed >= maxRows)
+                {
+                    break;
+                }
+            }
+
+            seeds.Sort(CompareCacheSeedValues);
+        }
+
         private IEnumerable<object[]> GetFactStream(PredicateId predicate, EvaluationContext? context = null)
         {
             if (context is not null && TryGetReplayableSource(predicate, context, out var replayableSource))
@@ -5859,7 +6036,7 @@ namespace UnifyWeaver.QueryRuntime
             return factsSource as List<object[]> ?? factsSource.ToList();
         }
 
-        private PathAwareEdgeState GetPathAwareEdgeState(PredicateId predicate, EvaluationContext context)
+        private PathAwareEdgeState GetPathAwareEdgeState(PredicateId predicate, EvaluationContext context, PlanNode traceNode)
         {
             if (context.PathAwareEdgeStates.TryGetValue(predicate, out var cached))
             {
@@ -5869,63 +6046,94 @@ namespace UnifyWeaver.QueryRuntime
 
             context.Trace?.RecordCacheLookup("PathAwareEdgeState", $"{predicate.Name}/{predicate.Arity}", hit: false, built: true);
 
-            var successors = new Dictionary<object, PathAwareSuccessorBucket>();
-            var seeds = new List<object?>();
-            var seenSeeds = new HashSet<object?>();
+            var hasStreaming = TryGetDelimitedSource(predicate, RelationRetentionMode.Streaming, out var delimitedSource);
+            var hasReplayable = TryGetReplayableSource(predicate, context, out var replayableSource);
+            var hasExternal = TryGetExternalFacts(predicate, out var externalFacts);
+            var concreteReplayable = replayableSource as ReplayableRelationSource;
+            var relationBytes = hasStreaming && !string.IsNullOrEmpty(delimitedSource.InputPath) && File.Exists(delimitedSource.InputPath)
+                ? new FileInfo(delimitedSource.InputPath).Length
+                : (long?)null;
+            const int edgeProbeRowLimit = 256;
 
-            void AddEdge(object? source, object? target)
+            Func<TimeSpan>? measureStreamingProbe = hasStreaming
+                ? () => MeasureElapsed(() => ProbePathAwareEdgeDelimited(delimitedSource, edgeProbeRowLimit))
+                : null;
+            Func<TimeSpan>? measureReplayableProbe = hasReplayable
+                ? () => MeasureElapsed(() =>
+                {
+                    var probeRows = concreteReplayable is not null
+                        ? concreteReplayable.ProbeMaterialize(edgeProbeRowLimit)
+                        : replayableSource.Stream().Take(edgeProbeRowLimit).ToList();
+                    ProbePathAwareEdgeRows(probeRows, edgeProbeRowLimit);
+                })
+                : null;
+            Func<TimeSpan>? measureExternalProbe = hasExternal
+                ? () => MeasureElapsed(() => ProbePathAwareEdgeRows(externalFacts, edgeProbeRowLimit))
+                : null;
+
+            var selection = ResolvePathAwareEdgeRetentionStrategy(
+                context.Trace,
+                traceNode,
+                _pathAwareEdgeRetentionStrategy,
+                relationBytes,
+                hasStreaming,
+                hasReplayable,
+                hasExternal,
+                concreteReplayable?.IsMaterialized == true,
+                measureStreamingProbe,
+                measureReplayableProbe,
+                measureExternalProbe);
+            RecordPathAwareEdgeRetentionStrategy(context.Trace, traceNode, selection);
+
+            PathAwareEdgeState state;
+            switch (selection.Strategy)
             {
-                var lookupKey = source ?? NullFactIndexKey;
-                if (!successors.TryGetValue(lookupKey, out var bucket))
-                {
-                    bucket = new PathAwareSuccessorBucket(source);
-                    successors[lookupKey] = bucket;
-                }
-
-                bucket.Targets.Add(target);
-                if (seenSeeds.Add(source))
-                {
-                    seeds.Add(source);
-                }
-            }
-
-            if (TryGetDelimitedSource(predicate, RelationRetentionMode.Streaming, out var delimitedSource))
-            {
-                using var reader = DelimitedRelationReader.OpenSequentialReader(delimitedSource.InputPath);
-                for (var i = 0; i < delimitedSource.SkipRows; i++)
-                {
-                    if (reader.ReadLine() is null)
+                case PathAwareEdgeRetentionStrategy.StreamingDirect when hasStreaming:
+                    state = MeasurePhase(context.Trace, traceNode, "edge_build_streaming_direct", () => BuildPathAwareEdgeStateFromDelimited(delimitedSource));
+                    break;
+                case PathAwareEdgeRetentionStrategy.ReplayableBuffer when hasReplayable:
+                    var replayableRows = MeasurePhase(context.Trace, traceNode, "edge_materialize_replayable", () => replayableSource.Materialize());
+                    state = MeasurePhase(context.Trace, traceNode, "edge_build_replayable_buffer", () => BuildPathAwareEdgeStateFromRows(replayableRows));
+                    break;
+                case PathAwareEdgeRetentionStrategy.ExternalMaterialized when hasExternal:
+                    state = MeasurePhase(context.Trace, traceNode, "edge_build_external_materialized", () => BuildPathAwareEdgeStateFromRows(externalFacts));
+                    break;
+                case PathAwareEdgeRetentionStrategy.StreamingDirect:
+                    if (hasReplayable)
                     {
+                        var fallbackReplayableRows = MeasurePhase(context.Trace, traceNode, "edge_materialize_replayable", () => replayableSource.Materialize());
+                        state = MeasurePhase(context.Trace, traceNode, "edge_build_replayable_buffer", () => BuildPathAwareEdgeStateFromRows(fallbackReplayableRows));
                         break;
                     }
-                }
 
-                string? line;
-                while ((line = reader.ReadLine()) is not null)
-                {
-                    if (!DelimitedRelationReader.TrySplitTwoColumnLine(line, delimitedSource.Delimiter, out var left, out var right))
+                    state = MeasurePhase(context.Trace, traceNode, "edge_build_external_materialized", () => BuildPathAwareEdgeStateFromRows(_provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>()));
+                    break;
+                case PathAwareEdgeRetentionStrategy.ReplayableBuffer:
+                    if (hasStreaming)
                     {
-                        continue;
+                        state = MeasurePhase(context.Trace, traceNode, "edge_build_streaming_direct", () => BuildPathAwareEdgeStateFromDelimited(delimitedSource));
+                        break;
                     }
 
-                    AddEdge(left, right);
-                }
-            }
-            else
-            {
-                foreach (var edge in GetFactStream(predicate, context))
-                {
-                    if (edge is null || edge.Length < 2)
+                    state = MeasurePhase(context.Trace, traceNode, "edge_build_external_materialized", () => BuildPathAwareEdgeStateFromRows(_provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>()));
+                    break;
+                default:
+                    if (hasStreaming)
                     {
-                        continue;
+                        state = MeasurePhase(context.Trace, traceNode, "edge_build_streaming_direct", () => BuildPathAwareEdgeStateFromDelimited(delimitedSource));
                     }
-
-                    AddEdge(edge[0], edge[1]);
-                }
+                    else if (hasReplayable)
+                    {
+                        var fallbackReplayableRows = MeasurePhase(context.Trace, traceNode, "edge_materialize_replayable", () => replayableSource.Materialize());
+                        state = MeasurePhase(context.Trace, traceNode, "edge_build_replayable_buffer", () => BuildPathAwareEdgeStateFromRows(fallbackReplayableRows));
+                    }
+                    else
+                    {
+                        state = MeasurePhase(context.Trace, traceNode, "edge_build_external_materialized", () => BuildPathAwareEdgeStateFromRows(_provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>()));
+                    }
+                    break;
             }
 
-            seeds.Sort(CompareCacheSeedValues);
-            var state = new PathAwareEdgeState(successors, seeds);
             context.PathAwareEdgeStates[predicate] = state;
             return state;
         }
@@ -7617,6 +7825,210 @@ namespace UnifyWeaver.QueryRuntime
             }
         }
 
+        private static PathAwareEdgeRetentionStrategy ResolveStructuralPathAwareEdgeRetentionStrategy(
+            PlanNode node,
+            bool hasStreaming,
+            bool hasReplayable,
+            bool hasExternal,
+            bool replayableMaterialized)
+        {
+            if (replayableMaterialized && hasReplayable)
+            {
+                return PathAwareEdgeRetentionStrategy.ReplayableBuffer;
+            }
+
+            if (node is SeedGroupedPathAwareWeightSumNode)
+            {
+                if (hasReplayable)
+                {
+                    return PathAwareEdgeRetentionStrategy.ReplayableBuffer;
+                }
+
+                if (hasStreaming)
+                {
+                    return PathAwareEdgeRetentionStrategy.StreamingDirect;
+                }
+            }
+            else if (node is SeedGroupedPathAwareDepthMinNode or SeedGroupedPathAwareAccumulationMinNode)
+            {
+                if (hasStreaming)
+                {
+                    return PathAwareEdgeRetentionStrategy.StreamingDirect;
+                }
+
+                if (hasReplayable)
+                {
+                    return PathAwareEdgeRetentionStrategy.ReplayableBuffer;
+                }
+            }
+            else
+            {
+                if (hasStreaming)
+                {
+                    return PathAwareEdgeRetentionStrategy.StreamingDirect;
+                }
+
+                if (hasReplayable)
+                {
+                    return PathAwareEdgeRetentionStrategy.ReplayableBuffer;
+                }
+            }
+
+            return hasExternal
+                ? PathAwareEdgeRetentionStrategy.ExternalMaterialized
+                : PathAwareEdgeRetentionStrategy.StreamingDirect;
+        }
+
+        private static bool ShouldProbePathAwareEdgeRetentionStrategy(
+            PlanNode node,
+            long? relationBytes,
+            bool hasStreaming,
+            bool hasReplayable,
+            bool hasExternal,
+            bool replayableMaterialized)
+        {
+            if (replayableMaterialized)
+            {
+                return false;
+            }
+
+            var availableCount = (hasStreaming ? 1 : 0) + (hasReplayable ? 1 : 0) + (hasExternal ? 1 : 0);
+            if (availableCount <= 1)
+            {
+                return false;
+            }
+
+            if (relationBytes is null)
+            {
+                return true;
+            }
+
+            if (node is SeedGroupedPathAwareWeightSumNode)
+            {
+                return relationBytes <= 384 * 1024L;
+            }
+
+            if (node is SeedGroupedPathAwareDepthMinNode or SeedGroupedPathAwareAccumulationMinNode)
+            {
+                return relationBytes <= 320 * 1024L;
+            }
+
+            return relationBytes <= 256 * 1024L;
+        }
+
+        private static PathAwareEdgeRetentionStrategy ResolveMeasuredPathAwareEdgeRetentionStrategy(
+            IReadOnlyDictionary<PathAwareEdgeRetentionStrategy, TimeSpan> probes,
+            PathAwareEdgeRetentionStrategy structuralStrategy)
+        {
+            var bestStrategy = structuralStrategy;
+            var bestTicks = double.PositiveInfinity;
+            foreach (var entry in probes)
+            {
+                var ticks = entry.Value == TimeSpan.MaxValue
+                    ? double.PositiveInfinity
+                    : entry.Value.Ticks;
+                if (ticks <= 0d || double.IsNaN(ticks))
+                {
+                    continue;
+                }
+
+                if (ticks < bestTicks)
+                {
+                    bestTicks = ticks;
+                    bestStrategy = entry.Key;
+                }
+            }
+
+            return double.IsInfinity(bestTicks) ? structuralStrategy : bestStrategy;
+        }
+
+        private static PathAwareEdgeRetentionSelection ResolvePathAwareEdgeRetentionStrategy(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            PathAwareEdgeRetentionStrategy configuredStrategy,
+            long? relationBytes,
+            bool hasStreaming,
+            bool hasReplayable,
+            bool hasExternal,
+            bool replayableMaterialized,
+            Func<TimeSpan>? measureStreamingProbe = null,
+            Func<TimeSpan>? measureReplayableProbe = null,
+            Func<TimeSpan>? measureExternalProbe = null)
+        {
+            return MeasurePhase(trace, node, "edge_strategy_select", () =>
+            {
+                bool IsAvailable(PathAwareEdgeRetentionStrategy strategy) => strategy switch
+                {
+                    PathAwareEdgeRetentionStrategy.StreamingDirect => hasStreaming,
+                    PathAwareEdgeRetentionStrategy.ReplayableBuffer => hasReplayable,
+                    PathAwareEdgeRetentionStrategy.ExternalMaterialized => hasExternal,
+                    _ => hasStreaming || hasReplayable || hasExternal
+                };
+
+                if (configuredStrategy != PathAwareEdgeRetentionStrategy.Auto)
+                {
+                    if (IsAvailable(configuredStrategy))
+                    {
+                        return new PathAwareEdgeRetentionSelection(configuredStrategy, "ConfiguredOverride");
+                    }
+
+                    configuredStrategy = PathAwareEdgeRetentionStrategy.Auto;
+                }
+
+                if (replayableMaterialized && hasReplayable)
+                {
+                    return new PathAwareEdgeRetentionSelection(PathAwareEdgeRetentionStrategy.ReplayableBuffer, "ReplayableCached");
+                }
+
+                var structuralStrategy = ResolveStructuralPathAwareEdgeRetentionStrategy(node, hasStreaming, hasReplayable, hasExternal, replayableMaterialized);
+                if (!ShouldProbePathAwareEdgeRetentionStrategy(node, relationBytes, hasStreaming, hasReplayable, hasExternal, replayableMaterialized))
+                {
+                    var availableCount = (hasStreaming ? 1 : 0) + (hasReplayable ? 1 : 0) + (hasExternal ? 1 : 0);
+                    return new PathAwareEdgeRetentionSelection(structuralStrategy, availableCount <= 1 ? "OnlyAvailable" : "Structural");
+                }
+
+                var probes = new Dictionary<PathAwareEdgeRetentionStrategy, TimeSpan>();
+                if (measureStreamingProbe is not null)
+                {
+                    var probe = measureStreamingProbe();
+                    trace?.RecordPhase(node, "edge_probe_streaming_direct", probe);
+                    probes[PathAwareEdgeRetentionStrategy.StreamingDirect] = probe;
+                }
+
+                if (measureReplayableProbe is not null)
+                {
+                    var probe = measureReplayableProbe();
+                    trace?.RecordPhase(node, "edge_probe_replayable_buffer", probe);
+                    probes[PathAwareEdgeRetentionStrategy.ReplayableBuffer] = probe;
+                }
+
+                if (measureExternalProbe is not null)
+                {
+                    var probe = measureExternalProbe();
+                    trace?.RecordPhase(node, "edge_probe_external_materialized", probe);
+                    probes[PathAwareEdgeRetentionStrategy.ExternalMaterialized] = probe;
+                }
+
+                if (probes.Count == 0)
+                {
+                    return new PathAwareEdgeRetentionSelection(structuralStrategy, "Structural");
+                }
+
+                return new PathAwareEdgeRetentionSelection(
+                    ResolveMeasuredPathAwareEdgeRetentionStrategy(probes, structuralStrategy),
+                    "MeasuredProbe");
+            });
+        }
+
+        private static void RecordPathAwareEdgeRetentionStrategy(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            PathAwareEdgeRetentionSelection selection)
+        {
+            trace?.RecordStrategy(node, $"PathAwareEdgeRetentionSelection{selection.DecisionMode}");
+            trace?.RecordStrategy(node, $"PathAwareEdgeRetention{selection.Strategy}");
+        }
+
         private static PathAwareGroupedSummaryStrategy ToPathAwareGroupedSummaryStrategy(PathAwareGroupedMinStrategy strategy)
             => strategy switch
             {
@@ -7889,7 +8301,7 @@ namespace UnifyWeaver.QueryRuntime
 
                 trace?.RecordCacheLookup("SeedGroupedPathAwareWeightSum", traceKey, hit: false, built: true);
 
-                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context);
+                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context, closure);
                 var succIndex = edgeState.Successors;
 
                 var rootKeys = new HashSet<object>();
@@ -8251,7 +8663,7 @@ namespace UnifyWeaver.QueryRuntime
 
                 trace?.RecordCacheLookup("SeedGroupedPathAwareDepthMin", $"{closure.Predicate.Name}/{closure.Predicate.Arity}", hit: false, built: true);
 
-                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context);
+                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context, closure);
                 var succIndex = edgeState.Successors;
                 var rootKeys = new HashSet<object>();
                 var rootValues = new Dictionary<object, object?>();
@@ -8503,7 +8915,7 @@ namespace UnifyWeaver.QueryRuntime
 
                 trace?.RecordCacheLookup("SeedGroupedPathAwareAccumulationMin", $"{closure.Predicate.Name}/{closure.Predicate.Arity}", hit: false, built: true);
 
-                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context);
+                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context, closure);
                 var succIndex = edgeState.Successors;
                 var rootKeys = new HashSet<object>();
                 var rootValues = new Dictionary<object, object?>();
@@ -8876,7 +9288,7 @@ namespace UnifyWeaver.QueryRuntime
                 var trace = context.Trace;
                 trace?.RecordStrategy(closure, "PathAwareTransitiveClosure");
 
-                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context);
+                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context, closure);
                 var totalRows = new List<object[]>();
                 foreach (var seed in edgeState.Seeds)
                 {
@@ -8908,7 +9320,7 @@ namespace UnifyWeaver.QueryRuntime
                 var trace = context.Trace;
                 trace?.RecordStrategy(closure, "PathAwareTransitiveClosureSeeded");
 
-                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context);
+                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context, closure);
                 var seeds = new List<object?>();
                 var seenSeeds = new HashSet<object?>();
 
@@ -9042,7 +9454,7 @@ namespace UnifyWeaver.QueryRuntime
                 var trace = context.Trace;
                 trace?.RecordStrategy(closure, "PathAwareAccumulation");
 
-                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context);
+                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context, closure);
                 var succIndex = edgeState.Successors;
                 var auxRows = GetFactsList(closure.AuxiliaryRelation, context);
                 var auxIndex = GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context);
@@ -9088,7 +9500,7 @@ namespace UnifyWeaver.QueryRuntime
                 var trace = context.Trace;
                 trace?.RecordStrategy(closure, "PathAwareAccumulationSeeded");
 
-                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context);
+                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context, closure);
                 var succIndex = edgeState.Successors;
                 var auxRows = GetFactsList(closure.AuxiliaryRelation, context);
                 var auxIndex = GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context);


### PR DESCRIPTION
  ## Summary

  This PR extends the C# query runtime’s retention policy down to the
  relation-retention boundary for path-aware edge relations.

  Previously, Stage 4 cost guidance existed mainly at the grouped-summary
  layer:

  - grouped minima
  - grouped weight sums

  That meant the runtime could choose between compact grouped summaries and
  legacy seeded-row regrouping, but the lower-level edge relation still had
  a weaker policy boundary.

  This PR adds measured selection for the path-aware edge relation itself,
  so the runtime can choose among:

  - direct streamed edge-state build
  - replayable buffered edge-state build
  - external materialized fallback

  and expose that choice through benchmark trace output.

  ## What Changed

  ### New Runtime Strategy Option

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `PathAwareEdgeRetentionStrategy`
    - `Auto`
    - `StreamingDirect`
    - `ReplayableBuffer`
    - `ExternalMaterialized`

  Extended:

  - `QueryExecutorOptions`
    - `PathAwareEdgeRetentionStrategy`

  This makes edge-relation retention an explicit runtime choice rather than
  an implicit implementation detail.

  ### Replayable Source Probing Support

  Updated:

  - `ReplayableRelationSource`

  Added:

  - `IsMaterialized`
  - `ProbeMaterialize(int maxRows)`

  This lets the runtime inspect replayable cost in bounded form without
  fully committing to the path prematurely.

  ### Measured Edge-Retention Selection

  Updated path-aware edge-state construction in:

  - `GetPathAwareEdgeState(...)`

  Added shared helpers for:

  - streamed edge-state build
  - replayable edge-state build
  - external-materialized edge-state build
  - bounded streaming probes
  - bounded replayable probes
  - structural and measured selection

  The runtime now records and uses measured buckets such as:

  - `edge_strategy_select`
  - `edge_probe_streaming_direct`
  - `edge_probe_replayable_buffer`
  - `edge_materialize_replayable`
  - `edge_build_streaming_direct`
  - `edge_build_replayable_buffer`
  - `edge_build_external_materialized`

  ### Generator Support

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The generated `csharp_query` programs for:

  - `shortest_path_to_root`
  - `weighted_shortest_path`
  - `effective_distance`
  - `category_influence`

  now support:

  - `UNIFYWEAVER_EDGE_RETENTION_STRATEGY=auto|streaming|replayable|external`

  and print:

  - `edge_retention_strategy_setting=...`

  Trace mode continues to work via:

  - `UNIFYWEAVER_BENCH_TRACE=1`

  so benchmark runs can now show both:

  - grouped-summary strategy selection
  - edge-relation retention selection

  ### Docs

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`
  - `examples/benchmark/README.md`

  These now reflect that measured retention selection has moved below the
  grouped-summary layer and into the relation-retention boundary for
  path-aware edge state.

  ## Why This Matters

  This PR is the next logical step in the materialization work.

  The runtime already knew how to choose among different grouped-summary
  forms. Now it also has a more explicit and measurable answer to an
  earlier question:

  - should the edge relation be streamed directly?
  - should it be buffered replayably first?
  - should externally materialized facts be used as fallback?

  That matters because grouped-summary selection alone is not enough if the
  runtime still commits to the wrong lower-level retained form.

  This PR makes that decision explicit, traceable, and grounded in observed
  cost.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_category_influence_cross_target.py

  ### Full benchmark reruns

  Ran locally:

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated \
      --repetitions 1

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,rust-dfs,go-dfs \
      --repetitions 1

  All outputs matched.

  ### Trace validation

  With:

  UNIFYWEAVER_BENCH_TRACE=1

  the runtime now exposes edge-retention strategy traces such as:

  - strategy_PathAwareEdgeRetentionReplayableBuffer=1
  - strategy_PathAwareEdgeRetentionStreamingDirect=1
  - strategy_PathAwareEdgeRetentionSelectionMeasuredProbe=1
  - strategy_PathAwareEdgeRetentionSelectionStructural=1

  This confirmed that Auto is now using measured probes in small/ambiguous
  cases and structural short-circuiting in clearer larger cases.

  ## Representative Results

  ### Shortest path

  | Scale | C# Query | Prolog Min | C# DFS | Rust DFS | Go DFS | Outputs |
  |---|---:|---:|---:|---:|---:|---|
  | 300 | 0.117s | 0.136s | 0.537s | 0.418s | 0.600s | match |
  | 1k | 0.107s | 0.112s | 1.465s | 1.718s | 2.531s | match |
  | 5k | 0.148s | 0.278s | 6.434s | 8.819s | 15.760s | match |
  | 10k | 0.212s | 0.510s | 12.139s | 16.450s | 25.110s | match |

  ### Weighted shortest path

  | Scale | C# Query | Prolog Min | C# DFS | Rust DFS | Go DFS | Outputs |
  |---|---:|---:|---:|---:|---:|---|
  | 300 | 0.190s | 0.134s | 0.528s | 0.386s | 0.628s | match |
  | 1k | 0.175s | 0.155s | 1.450s | 1.730s | 2.622s | match |
  | 5k | 0.246s | 0.305s | 6.742s | 9.137s | 15.661s | match |
  | 10k | 0.414s | 0.636s | 12.798s | 17.239s | 24.495s | match |

  ### Effective distance

  | Scale | C# Query | Prolog Accumulated | C# DFS | Rust DFS | Go DFS | Outputs |
  |---|---:|---:|---:|---:|---:|---|
  | 300 | 0.279s | 0.488s | 0.509s | 0.413s | 0.580s | match |
  | 1k | 0.229s | 0.333s | 1.465s | 1.718s | 2.496s | match |
  | 5k | 0.453s | 1.040s | 6.494s | 9.761s | 15.875s | match |
  | 10k | 0.902s | 2.283s | 11.863s | 16.344s | 24.587s | match |

  ### Category influence

  | Scale | C# Query | Rust DFS | Go DFS | Outputs |
  |---|---:|---:|---:|---|
  | 300 | 0.320s | 0.469s | 1.516s | match |
  | 1k | 0.340s | 2.861s | 2.636s | match |
  | 5k | 0.455s | 9.366s | 14.989s | match |
  | 10k | 0.882s | 16.925s | 25.592s | match |

  ## Interpretation

  This PR does not introduce a new retained summary node.

  Its value is that it makes the lower-level relation-retention decision
  more intelligent and observable.

  The current benchmark surface suggests:

  - shortest-path minima family:
      - replayable buffering can win at small scale
      - direct streaming can win at larger scale
  - grouped weight-sum family:
      - replayable buffering remains the better default

  That is exactly the kind of decision that belongs in the runtime rather
  than in the benchmark harness or parser.

  ## Scope

  This PR adds:

  - explicit edge-retention strategy selection
  - measured edge-retention buckets and bounded probes
  - benchmark override/trace support
  - doc updates reflecting the broader Stage 4 policy

  It does not yet add:

  - universal measured retention selection for every relation/operator type
  - a full global planner across all retention strategies

  ## Follow-Up

  Likely next work:

  - extend measured relation-retention selection beyond path-aware edge
    relations
  - reuse the same measured policy ideas for other operator-owned indexed
    states
  - continue moving retention decisions inward:
      - parser streams tuples
      - runtime chooses relation retention
      - operator chooses retained summary form