### PR TITLE
feat(wam-rust): Add a triple result layout to Rust WAM foreign lowering

### DIFF
--- a/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
+++ b/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
@@ -231,6 +231,7 @@ recursive schemas:
 - binary transitive closure such as `tc_ancestor/2`
 - reversed binary closure such as `tc_descendant/2`
 - recursive distance search such as `tc_distance/3`
+- recursive parent+distance search such as `tc_parent_distance/4`
 
 The shape is:
 
@@ -273,6 +274,7 @@ The currently registered recursive kernel families are:
 - `list_suffix2`
 - `transitive_closure2`
 - `transitive_distance3`
+- `transitive_parent_distance4`
 
 ### What Is Verified
 
@@ -285,12 +287,14 @@ The current test coverage now includes:
   - `tc_ancestor/2`
   - `tc_descendant/2`
   - `tc_distance/3`
+  - `tc_parent_distance/4`
 - end-to-end generated Rust runtime validation for:
   - `tail_suffix/2`
   - `tri_sum/2`
   - `tc_ancestor/2`
   - `tc_descendant/2`
   - `tc_distance/3`
+  - `tc_parent_distance/4`
 
 When `foreign_lowering(true)` is enabled and a registered kernel matches, the
 compiler now prefers the foreign path over earlier generic native clause
@@ -301,10 +305,11 @@ The runtime now also uses a small foreign-result layout layer:
 
 - `single` for one output register
 - `pair` for two-output payloads packed into one foreign result item
+- `triple` for three-output payloads packed into one foreign result item
 
 That replaces the older kernel-specific resume branching for result shape and
 makes additional kernels cheaper to add as long as they fit an existing result
-layout.
+layout. `tc_parent_distance/4` is the first kernel using the `triple` path.
 
 The reverse transitive-closure path required an additional correctness fix:
 reverse schemas must register fact pairs in `child -> parent` orientation, and

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3722,6 +3722,7 @@ rust_recursive_kernel_detector(countdown_sum2, rust_recursive_kernel_countdown_s
 rust_recursive_kernel_detector(list_suffix2, rust_recursive_kernel_list_suffix).
 rust_recursive_kernel_detector(transitive_closure2, rust_recursive_kernel_transitive_closure).
 rust_recursive_kernel_detector(transitive_distance3, rust_recursive_kernel_transitive_distance).
+rust_recursive_kernel_detector(transitive_parent_distance4, rust_recursive_kernel_transitive_parent_distance).
 
 rust_recursive_kernel_spec(
         recursive_kernel(KernelKind, PredIndicator, KernelConfig),
@@ -3742,12 +3743,14 @@ rust_recursive_kernel_native_kind(countdown_sum2, countdown_sum2).
 rust_recursive_kernel_native_kind(list_suffix2, list_suffix2).
 rust_recursive_kernel_native_kind(transitive_closure2, transitive_closure2).
 rust_recursive_kernel_native_kind(transitive_distance3, transitive_distance3).
+rust_recursive_kernel_native_kind(transitive_parent_distance4, transitive_parent_distance4).
 
 rust_recursive_kernel_result_layout(category_ancestor, single).
 rust_recursive_kernel_result_layout(countdown_sum2, single).
 rust_recursive_kernel_result_layout(list_suffix2, single).
 rust_recursive_kernel_result_layout(transitive_closure2, single).
 rust_recursive_kernel_result_layout(transitive_distance3, pair).
+rust_recursive_kernel_result_layout(transitive_parent_distance4, triple).
 
 rust_recursive_kernel_config_ops(category_ancestor, category_ancestor/4,
         [max_depth(MaxDepth)],
@@ -3758,6 +3761,9 @@ rust_recursive_kernel_config_ops(transitive_closure2, PredIndicator,
         KernelConfig, ConfigOps) :-
     rust_recursive_kernel_binary_edge_config_ops(PredIndicator, KernelConfig, ConfigOps).
 rust_recursive_kernel_config_ops(transitive_distance3, PredIndicator,
+        KernelConfig, ConfigOps) :-
+    rust_recursive_kernel_binary_edge_config_ops(PredIndicator, KernelConfig, ConfigOps).
+rust_recursive_kernel_config_ops(transitive_parent_distance4, PredIndicator,
         KernelConfig, ConfigOps) :-
     rust_recursive_kernel_binary_edge_config_ops(PredIndicator, KernelConfig, ConfigOps).
 
@@ -3790,6 +3796,11 @@ rust_recursive_kernel_transitive_distance(Pred, Arity, Clauses,
         recursive_kernel(transitive_distance3, Pred/Arity,
             [edge_pred(EdgePred/2), fact_pairs(FactPairs)])) :-
     rust_foreign_lowerable_transitive_distance(Pred, Arity, Clauses, EdgePred/2, FactPairs).
+
+rust_recursive_kernel_transitive_parent_distance(Pred, Arity, Clauses,
+        recursive_kernel(transitive_parent_distance4, Pred/Arity,
+            [edge_pred(EdgePred/2), fact_pairs(FactPairs)])) :-
+    rust_foreign_lowerable_transitive_parent_distance(Pred, Arity, Clauses, EdgePred/2, FactPairs).
 
 rust_foreign_lowerable_category_ancestor(category_ancestor, 4, Clauses, MaxDepth) :-
     member(_-BaseBody, Clauses),
@@ -3869,6 +3880,27 @@ rust_foreign_lowerable_transitive_distance(Pred, 3, Clauses, EdgePred/2, FactPai
     RecBody = (EdgeGoal, (RecGoal, IsGoal)),
     EdgeGoal =.. [EdgePred, RecStart, RecMid],
     RecGoal =.. [Pred, RecMid, RecTarget, PrevDepth],
+    IsGoal =.. [is, RecDepth, Expr],
+    Expr =.. [+, PrevDepth, 1],
+    findall(Left-Right,
+        ( functor(EdgeHead, EdgePred, 2),
+          user:clause(EdgeHead, true),
+          EdgeHead =.. [EdgePred, Left, Right],
+          atom(Left),
+          atom(Right)
+        ),
+        FactPairs),
+    FactPairs \= [].
+
+rust_foreign_lowerable_transitive_parent_distance(Pred, 4, Clauses, EdgePred/2, FactPairs) :-
+    member(BaseHead-BaseBody, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseHead =.. [Pred, BaseStart, BaseTarget, BaseStart, 1],
+    RecHead =.. [Pred, RecStart, RecTarget, RecParent, RecDepth],
+    BaseBody =.. [EdgePred, BaseStart, BaseTarget],
+    RecBody = (EdgeGoal, (RecGoal, IsGoal)),
+    EdgeGoal =.. [EdgePred, RecStart, RecMid],
+    RecGoal =.. [Pred, RecMid, RecTarget, RecParent, PrevDepth],
     IsGoal =.. [is, RecDepth, Expr],
     Expr =.. [+, PrevDepth, 1],
     findall(Left-Right,

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -790,6 +790,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
     compile_collect_native_list_suffixes_to_rust(NativeListSuffixCode),
     compile_collect_native_transitive_closure_to_rust(NativeClosureCode),
     compile_collect_native_transitive_distance_to_rust(NativeDistanceCode),
+    compile_collect_native_transitive_parent_distance_to_rust(NativeParentDistanceCode),
     compile_eval_arith_to_rust(ArithCode),
     atomic_list_concat([
         RunLoopCode, '\n\n',
@@ -809,6 +810,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
         NativeListSuffixCode, '\n\n',
         NativeClosureCode, '\n\n',
         NativeDistanceCode, '\n\n',
+        NativeParentDistanceCode, '\n\n',
         ArithCode
     ], RustCode).
 
@@ -1198,6 +1200,49 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                 }).collect();
                 self.finish_foreign_results(&pred_key, vec![target_reg, dist_reg], packed_results)
             }
+            "transitive_parent_distance4" => {
+                let start = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
+                    Some(Value::Atom(start)) => start,
+                    _ => return false,
+                };
+                let target_reg = match self.regs.get("A2").cloned() {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let parent_reg = match self.regs.get("A3").cloned() {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let dist_reg = match self.regs.get("A4").cloned() {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let target_filter = match self.deref_var(&target_reg) {
+                    Value::Atom(target) => Some(target),
+                    Value::Unbound(_) => None,
+                    _ => return false,
+                };
+                let edge_pred = match self.foreign_string_config(&pred_key, "edge_pred") {
+                    Some(pred) => pred.to_string(),
+                    None => return false,
+                };
+                let mut results: Vec<(String, String, i64)> = Vec::new();
+                self.collect_native_transitive_parent_distance_results(&start, &edge_pred, &mut results);
+                if let Some(target) = target_filter {
+                    results.retain(|(node, _, _)| *node == target);
+                }
+                if results.is_empty() {
+                    return false;
+                }
+                let packed_results: Vec<Value> = results.into_iter().map(|(node, parent, dist)| {
+                    Value::Str("__triple__".to_string(), vec![
+                        Value::Atom(node),
+                        Value::Atom(parent),
+                        Value::Integer(dist),
+                    ])
+                }).collect();
+                self.finish_foreign_results(&pred_key, vec![target_reg, parent_reg, dist_reg], packed_results)
+            }
             _ => false,
         }
     }'.
@@ -1260,6 +1305,19 @@ compile_foreign_result_helpers_to_rust(Code) :-
                 match result {
                     Value::Str(functor, args) if functor == "__pair__" && args.len() == 2 => {
                         self.unify(&result_regs[0], &args[0]) && self.unify(&result_regs[1], &args[1])
+                    }
+                    _ => false,
+                }
+            }
+            "triple" => {
+                if result_regs.len() != 3 {
+                    return false;
+                }
+                match result {
+                    Value::Str(functor, args) if functor == "__triple__" && args.len() == 3 => {
+                        self.unify(&result_regs[0], &args[0])
+                            && self.unify(&result_regs[1], &args[1])
+                            && self.unify(&result_regs[2], &args[2])
                     }
                     _ => false,
                 }
@@ -1379,6 +1437,25 @@ compile_collect_native_transitive_distance_to_rust(Code) :-
                     let mut next_path = path.clone();
                     next_path.push(next.clone());
                     stack.push((next.clone(), next_depth, next_path));
+                }
+            }
+        }
+    }'.
+
+compile_collect_native_transitive_parent_distance_to_rust(Code) :-
+    Code = '    pub fn collect_native_transitive_parent_distance_results(
+        &self,
+        start: &str,
+        edge_pred: &str,
+        out: &mut Vec<(String, String, i64)>,
+    ) {
+        let mut stack: Vec<(String, i64)> = vec![(start.to_string(), 0)];
+        while let Some((node, depth)) = stack.pop() {
+            if let Some(next_nodes) = self.indexed_atom_fact2.get(edge_pred).and_then(|table| table.get(&node)) {
+                for next in next_nodes.iter().rev() {
+                    let next_depth = depth + 1;
+                    out.push((next.clone(), node.clone(), next_depth));
+                    stack.push((next.clone(), next_depth));
                 }
             }
         }

--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -45,6 +45,13 @@ tc_descendant(X, Y) :- tc_parent(Z, X), tc_descendant(Z, Y).
 tc_distance(X, Y, 1) :- tc_parent(X, Y).
 tc_distance(X, Y, D) :- tc_parent(X, Z), tc_distance(Z, Y, D1), D is D1 + 1.
 
+:- dynamic tc_parent_distance/4.
+tc_parent_distance(X, Y, X, 1) :- tc_parent(X, Y).
+tc_parent_distance(X, Y, Parent, D) :-
+    tc_parent(X, Z),
+    tc_parent_distance(Z, Y, Parent, D1),
+    D is D1 + 1.
+
 :- dynamic tri_sum/2.
 tri_sum(0, 0).
 tri_sum(N, Sum) :-
@@ -67,7 +74,7 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tri_sum/2, user:tail_suffix/2],
+        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tri_sum/2, user:tail_suffix/2],
             [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
@@ -79,6 +86,7 @@ use runtime_test::state::WamState;
 use runtime_test::tc_ancestor;
 use runtime_test::tc_descendant;
 use runtime_test::tc_distance;
+use runtime_test::tc_parent_distance;
 use runtime_test::tri_sum;
 use runtime_test::tail_suffix;
 
@@ -215,6 +223,61 @@ fn test_generated_predicates() {
         Value::Atom("jim".to_string()),
         Value::Unbound("D".to_string()));
     assert!(!ok9, "tc_distance(liz, jim, D) should fail");
+
+    // Test tc_parent_distance/4 foreign lowering end-to-end
+    let mut vm_parent_dist = WamState::new(vec![], std::collections::HashMap::new());
+    let ok_pd1 = tc_parent_distance(&mut vm_parent_dist,
+        Value::Atom("tom".to_string()),
+        Value::Unbound("Target2".to_string()),
+        Value::Unbound("Parent2".to_string()),
+        Value::Unbound("Dist2".to_string()));
+    assert!(ok_pd1, "tc_parent_distance(tom, Target, Parent, Dist) first solution should succeed");
+
+    let mut parent_distances: Vec<String> = Vec::new();
+    if let (Some(Value::Atom(target)), Some(Value::Atom(parent)), Some(Value::Integer(dist))) =
+        (vm_parent_dist.bindings.get("Target2").cloned(),
+         vm_parent_dist.bindings.get("Parent2").cloned(),
+         vm_parent_dist.bindings.get("Dist2").cloned()) {
+        parent_distances.push(format!("{}:{}:{}", target, parent, dist));
+    } else {
+        panic!("expected first tc_parent_distance result in Target2/Parent2/Dist2");
+    }
+
+    while vm_parent_dist.backtrack() {
+        if let (Some(Value::Atom(target)), Some(Value::Atom(parent)), Some(Value::Integer(dist))) =
+            (vm_parent_dist.bindings.get("Target2").cloned(),
+             vm_parent_dist.bindings.get("Parent2").cloned(),
+             vm_parent_dist.bindings.get("Dist2").cloned()) {
+            parent_distances.push(format!("{}:{}:{}", target, parent, dist));
+        } else {
+            panic!("expected backtracked tc_parent_distance result in Target2/Parent2/Dist2");
+        }
+    }
+
+    parent_distances.sort();
+    assert_eq!(parent_distances, vec![
+        "ann:bob:2".to_string(),
+        "bob:tom:1".to_string(),
+        "jim:pat:3".to_string(),
+        "liz:tom:1".to_string(),
+        "pat:bob:2".to_string(),
+    ]);
+
+    let mut vm_parent_dist_check = WamState::new(vec![], std::collections::HashMap::new());
+    let ok_pd2 = tc_parent_distance(&mut vm_parent_dist_check,
+        Value::Atom("tom".to_string()),
+        Value::Atom("jim".to_string()),
+        Value::Atom("pat".to_string()),
+        Value::Integer(3));
+    assert!(ok_pd2, "tc_parent_distance(tom, jim, pat, 3) should succeed");
+
+    let mut vm_parent_dist_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok_pd3 = tc_parent_distance(&mut vm_parent_dist_fail,
+        Value::Atom("liz".to_string()),
+        Value::Atom("jim".to_string()),
+        Value::Unbound("Parent3".to_string()),
+        Value::Unbound("Dist3".to_string()));
+    assert!(!ok_pd3, "tc_parent_distance(liz, jim, Parent, Dist) should fail");
 
     // Test tri_sum/2 foreign lowering end-to-end
     let mut vm_sum = WamState::new(vec![], std::collections::HashMap::new());

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -33,6 +33,7 @@ test_simple_fact(foo, bar).
 :- dynamic tri_sum/2.
 :- dynamic tc_descendant/2.
 :- dynamic tc_distance/3.
+:- dynamic tc_parent_distance/4.
 :- dynamic tc_parent/2.
 :- dynamic max_depth/1.
 
@@ -79,6 +80,11 @@ tri_sum(N, Sum) :-
 
 tc_distance(X, Y, 1) :- tc_parent(X, Y).
 tc_distance(X, Y, D) :- tc_parent(X, Z), tc_distance(Z, Y, D1), D is D1 + 1.
+tc_parent_distance(X, Y, X, 1) :- tc_parent(X, Y).
+tc_parent_distance(X, Y, Parent, D) :-
+    tc_parent(X, Z),
+    tc_parent_distance(Z, Y, Parent, D1),
+    D is D1 + 1.
 
 pass(Test) :-
     format('[PASS] ~w~n', [Test]).
@@ -295,12 +301,20 @@ test_recursive_kernel_ir_selection :-
         tc_distance(S1, T1, 1)-tc_parent(S1, T1),
         tc_distance(S2, T2, D2)-(tc_parent(S2, M2), (tc_distance(M2, T2, D1), D2 is D1 + 1))
     ],
+    ParentDistClauses = [
+        tc_parent_distance(SP1, TP1, SP1, 1)-tc_parent(SP1, TP1),
+        tc_parent_distance(SP2, TP2, PP2, DP2)-
+            (tc_parent(SP2, MP2), (tc_parent_distance(MP2, TP2, PP2, DPrev2), DP2 is DPrev2 + 1))
+    ],
     (   rust_target:rust_recursive_kernel(category_ancestor, 4, CategoryClauses,
             recursive_kernel(category_ancestor, category_ancestor/4, [max_depth(10)])),
         rust_target:rust_recursive_kernel(tri_sum, 2, SumClauses,
             recursive_kernel(countdown_sum2, tri_sum/2, [])),
         rust_target:rust_recursive_kernel(tail_suffix, 2, SuffixClauses,
             recursive_kernel(list_suffix2, tail_suffix/2, [])),
+        rust_target:rust_recursive_kernel(tc_parent_distance, 4, ParentDistClauses,
+            recursive_kernel(transitive_parent_distance4, tc_parent_distance/4,
+                [edge_pred(tc_parent/2), fact_pairs(ParentDistancePairs)])),
         rust_target:rust_recursive_kernel(tc_descendant, 2, DescClauses,
             recursive_kernel(transitive_closure2, tc_descendant/2,
                 [edge_pred(tc_parent/2), fact_pairs(FactPairs)])),
@@ -309,6 +323,7 @@ test_recursive_kernel_ir_selection :-
                 [edge_pred(tc_parent/2), fact_pairs(DistancePairs)])),
         FactPairs == ['bob'-'tom', 'liz'-'tom', 'ann'-'bob', 'pat'-'bob', 'jim'-'pat']
         , DistancePairs == ['tom'-'bob', 'tom'-'liz', 'bob'-'ann', 'bob'-'pat', 'pat'-'jim']
+        , ParentDistancePairs == ['tom'-'bob', 'tom'-'liz', 'bob'-'ann', 'bob'-'pat', 'pat'-'jim']
     ->  pass(Test)
     ;   fail_test(Test, 'Recursive kernel IR did not normalize expected schemas')
     ).
@@ -316,16 +331,20 @@ test_recursive_kernel_ir_selection :-
 test_recursive_kernel_spec_generation :-
     Test = 'WAM-Rust: recursive kernel IR generates foreign specs declaratively',
     Kernel = recursive_kernel(
-        list_suffix2,
-        tail_suffix/2,
-        []),
+        transitive_parent_distance4,
+        tc_parent_distance/4,
+        [ edge_pred(tc_parent/2),
+          fact_pairs(['tom'-'bob', 'bob'-'ann'])
+        ]),
     (   rust_target:rust_recursive_kernel_spec(Kernel, ForeignSpec),
         ForeignSpec = foreign_predicate(
-            tail_suffix/2,
-            [ register_foreign_native_kind(tail_suffix/2, list_suffix2),
-              register_foreign_result_layout(tail_suffix/2, single)
+            tc_parent_distance/4,
+            [ register_foreign_native_kind(tc_parent_distance/4, transitive_parent_distance4),
+              register_foreign_result_layout(tc_parent_distance/4, triple),
+              register_foreign_string_config(tc_parent_distance/4, edge_pred, tc_parent/2),
+              register_indexed_atom_fact2(tc_parent/2, ['tom'-'bob', 'bob'-'ann'])
             ],
-            [tail_suffix/2]
+            [tc_parent_distance/4]
         )
     ->  pass(Test)
     ;   fail_test(Test, 'Recursive kernel spec generation did not match expected foreign spec')
@@ -335,7 +354,7 @@ test_recursive_kernel_registry :-
     Test = 'WAM-Rust: recursive kernel registry enumerates supported kernels',
     findall(Kind, rust_target:rust_recursive_kernel_detector(Kind, _), Kinds0),
     sort(Kinds0, Kinds),
-    (   Kinds == [category_ancestor, countdown_sum2, list_suffix2, transitive_closure2, transitive_distance3]
+    (   Kinds == [category_ancestor, countdown_sum2, list_suffix2, transitive_closure2, transitive_distance3, transitive_parent_distance4]
     ->  pass(Test)
     ;   fail_test(Test, 'Recursive kernel registry did not match expected supported kernels')
     ).
@@ -493,6 +512,20 @@ test_foreign_lowering_transitive_distance :-
     ;   fail_test(Test, 'Foreign lowering was not selected for tc_distance/3')
     ).
 
+test_foreign_lowering_transitive_parent_distance :-
+    Test = 'WAM-Rust: compiler can choose foreign lowering for tc_parent_distance/4',
+    (   rust_target:compile_predicate_to_rust(user:tc_parent_distance/4,
+            [include_main(false), foreign_lowering(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("tc_parent_distance/4", "transitive_parent_distance4")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("tc_parent_distance/4", "triple")'),
+        sub_string(S, _, _, _, 'register_foreign_string_config("tc_parent_distance/4", "edge_pred", "tc_parent/2")'),
+        sub_string(S, _, _, _, 'execute_foreign_predicate("tc_parent_distance", 4)'),
+        sub_string(S, _, _, _, 'Instruction::CallForeign("tc_parent_distance".to_string(), 4)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Foreign lowering was not selected for tc_parent_distance/4')
+    ).
+
 test_compile_wam_runtime_output :-
     Test = 'WAM-Rust E2E: full runtime generates valid impl block',
     (   compile_wam_runtime_to_rust([], Code),
@@ -516,9 +549,12 @@ test_compile_wam_runtime_output :-
         sub_string(S, _, _, _, 'foreign_usize_config(&pred_key, "max_depth")'),
         sub_string(S, _, _, _, 'fn finish_foreign_results'),
         sub_string(S, _, _, _, 'fn apply_foreign_result'),
+        sub_string(S, _, _, _, '"triple"'),
+        sub_string(S, _, _, _, '__triple__'),
         sub_string(S, _, _, _, 'name: "foreign_results".to_string()'),
         sub_string(S, _, _, _, 'transitive_closure2'),
-        sub_string(S, _, _, _, 'collect_native_transitive_closure_nodes')
+        sub_string(S, _, _, _, 'collect_native_transitive_closure_nodes'),
+        sub_string(S, _, _, _, 'collect_native_transitive_parent_distance_results')
     ->  pass(Test)
     ;   fail_test(Test, 'Runtime impl block incomplete')
     ).
@@ -794,6 +830,7 @@ run_tests :-
     test_foreign_lowering_list_suffix,
     test_foreign_lowering_reverse_transitive_closure,
     test_foreign_lowering_transitive_distance,
+    test_foreign_lowering_transitive_parent_distance,
     test_compile_wam_runtime_output,
     test_write_wam_rust_project,
     test_project_cargo_content,


### PR DESCRIPTION
## Summary

This PR extends Rust WAM foreign result handling with a third structured result
layout, `triple`, and adds the first kernel that uses it:
`transitive_parent_distance4`, exercised through `tc_parent_distance/4`.

The runtime previously supported:

- `single`
- `pair`

This change proves that the foreign-result-layout abstraction scales to richer
multi-output kernels without reintroducing kernel-specific resume logic.

## What Changed

- added `triple` result-layout metadata in recursive-kernel foreign specs
- extended the generic foreign result binder to unpack triple payloads
- added `transitive_parent_distance4` as the first kernel using `triple`
- added codegen coverage for `tc_parent_distance/4`
- added end-to-end generated Rust runtime validation for `tc_parent_distance/4`
- updated the design notes to document the new layout and kernel family

## Why

After normalizing foreign result layouts, the next missing proof was whether
the abstraction still holds once outputs exceed the existing `single` and
`pair` cases.

`tc_parent_distance/4` is a good first `triple` kernel because it reuses the
existing fact-indexed graph traversal path while forcing the runtime to bind
three outputs from one backtracked foreign result item:

- target
- parent
- distance

That keeps the change focused on result-shape support rather than mixing in a
separate runtime problem.

## Validation

Ran locally:

- `swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`

Covered in tests:

- compiler-selected foreign lowering for `tc_parent_distance/4`
- recursive-kernel registry now includes `transitive_parent_distance4`
- generated Rust runtime execution for `tc_parent_distance/4`
- generic `triple` result binding in the Rust WAM runtime
- existing foreign-lowered kernels continue to pass:
  - `category_ancestor/4`
  - `tri_sum/2`
  - `tail_suffix/2`
  - `tc_ancestor/2`
  - `tc_descendant/2`
  - `tc_distance/3`

## Scope

This PR adds one new result layout and one kernel that uses it. It does not
attempt to introduce arbitrary tuple arities or a fully generic structured
payload schema beyond the current `single` / `pair` / `triple` progression.
