### PR TITLE
refactor(csharp-query): unify relation retention policy

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -108,6 +108,9 @@ Status:
   obvious grouped-summary shapes still short-circuit structurally, while
   path-aware edge retention and DAG relation retention now measure competing
   source paths directly when the structural signal is unclear
+- the current implementation now shares one internal relation-retention policy
+  layer for DAG and path-aware edge selection, while keeping separate public
+  override knobs for benchmarking and diagnosis
 
 Work:
 

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -33,7 +33,10 @@ The current runtime now exposes a narrow explicit retention contract:
 
 These hooks do not solve every ingestion case yet, but they make the
 retention choice explicit at the runtime/provider boundary instead of hiding it
-inside benchmark-specific wiring.
+inside benchmark-specific wiring. The current runtime now also shares one
+internal measured relation-retention policy layer between DAG relation
+selection and path-aware edge selection, while preserving separate public
+override surfaces for those families.
 
 ## Required Capabilities
 
@@ -134,8 +137,8 @@ For the current benchmark/runtime surface, the streamed path is:
    directly from streamed facts instead of generic replayed edge rows
 7. where streaming, replayable buffering, and external materialized rows are
    all viable sources for that cache, the runtime can use measured edge-retention
-   buckets and bounded probes to choose among them before honoring an explicit
-   executor override
+   buckets and bounded probes to choose among them through that same shared
+   relation-retention policy layer before honoring an explicit executor override
 8. shortest-path and weighted-shortest-path operators can emit compact
    grouped root minima directly from streamed edge/seed inputs
 9. where grouped minima and legacy seeded-row regrouping both exist, the runtime

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -554,7 +554,10 @@ Comparison note:
   per-family override knob
 - the path-aware edge relation now also goes through measured retention
   selection, and on the current benchmark surface `Auto` prefers
-  `ReplayableBuffer`; trace output now exposes edge buckets such as
+  `ReplayableBuffer`; that selection now runs through the same internal
+  relation-retention policy layer that also drives the DAG family, while the
+  benchmark-visible override knobs stay separate
+- trace output now exposes edge buckets such as
   `edge_strategy_select`, `edge_probe_streaming_direct`,
   `edge_probe_replayable_buffer`, `edge_materialize_replayable`, and
   `edge_build_replayable_buffer`
@@ -702,6 +705,9 @@ Comparison note:
 - relation ingestion now also goes through a measured DAG retention
   selector, and the generated benchmarks expose
   `UNIFYWEAVER_DAG_RETENTION_STRATEGY=auto|streaming|replayable|external`
+- the DAG selector now shares the same internal relation-retention policy layer
+  as path-aware edge retention, while preserving a DAG-specific public override
+  surface
 - on the current synthetic benchmark surface, `Auto` picks
   `StreamingDirect` for the reach-count DAG path; at smaller scales it can
   use bounded probes (`dag_probe_streaming_direct`,

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -504,6 +504,18 @@ namespace UnifyWeaver.QueryRuntime
         LegacySeededRows
     }
 
+    internal enum RelationRetentionPolicyStrategy
+    {
+        Auto,
+        StreamingDirect,
+        ReplayableBuffer,
+        ExternalMaterialized
+    }
+
+    internal readonly record struct RelationRetentionSelection(
+        RelationRetentionPolicyStrategy Strategy,
+        string DecisionMode);
+
     internal readonly record struct PathAwareEdgeRetentionSelection(
         PathAwareEdgeRetentionStrategy Strategy,
         string DecisionMode);
@@ -7976,8 +7988,44 @@ namespace UnifyWeaver.QueryRuntime
             }
         }
 
-        private static DagRelationRetentionStrategy ResolveStructuralDagRelationRetentionStrategy(
-            PlanNode node,
+        private static RelationRetentionPolicyStrategy ToRelationRetentionPolicyStrategy(DagRelationRetentionStrategy strategy)
+            => strategy switch
+            {
+                DagRelationRetentionStrategy.StreamingDirect => RelationRetentionPolicyStrategy.StreamingDirect,
+                DagRelationRetentionStrategy.ReplayableBuffer => RelationRetentionPolicyStrategy.ReplayableBuffer,
+                DagRelationRetentionStrategy.ExternalMaterialized => RelationRetentionPolicyStrategy.ExternalMaterialized,
+                _ => RelationRetentionPolicyStrategy.Auto
+            };
+
+        private static DagRelationRetentionStrategy ToDagRelationRetentionStrategy(RelationRetentionPolicyStrategy strategy)
+            => strategy switch
+            {
+                RelationRetentionPolicyStrategy.StreamingDirect => DagRelationRetentionStrategy.StreamingDirect,
+                RelationRetentionPolicyStrategy.ReplayableBuffer => DagRelationRetentionStrategy.ReplayableBuffer,
+                RelationRetentionPolicyStrategy.ExternalMaterialized => DagRelationRetentionStrategy.ExternalMaterialized,
+                _ => DagRelationRetentionStrategy.Auto
+            };
+
+        private static RelationRetentionPolicyStrategy ToRelationRetentionPolicyStrategy(PathAwareEdgeRetentionStrategy strategy)
+            => strategy switch
+            {
+                PathAwareEdgeRetentionStrategy.StreamingDirect => RelationRetentionPolicyStrategy.StreamingDirect,
+                PathAwareEdgeRetentionStrategy.ReplayableBuffer => RelationRetentionPolicyStrategy.ReplayableBuffer,
+                PathAwareEdgeRetentionStrategy.ExternalMaterialized => RelationRetentionPolicyStrategy.ExternalMaterialized,
+                _ => RelationRetentionPolicyStrategy.Auto
+            };
+
+        private static PathAwareEdgeRetentionStrategy ToPathAwareEdgeRetentionStrategy(RelationRetentionPolicyStrategy strategy)
+            => strategy switch
+            {
+                RelationRetentionPolicyStrategy.StreamingDirect => PathAwareEdgeRetentionStrategy.StreamingDirect,
+                RelationRetentionPolicyStrategy.ReplayableBuffer => PathAwareEdgeRetentionStrategy.ReplayableBuffer,
+                RelationRetentionPolicyStrategy.ExternalMaterialized => PathAwareEdgeRetentionStrategy.ExternalMaterialized,
+                _ => PathAwareEdgeRetentionStrategy.Auto
+            };
+
+        private static RelationRetentionPolicyStrategy ResolveStructuralRelationRetentionStrategy(
+            RelationRetentionPolicyStrategy preferredStrategy,
             bool hasStreaming,
             bool hasReplayable,
             bool hasExternal,
@@ -7985,42 +8033,44 @@ namespace UnifyWeaver.QueryRuntime
         {
             if (replayableMaterialized && hasReplayable)
             {
-                return DagRelationRetentionStrategy.ReplayableBuffer;
+                return RelationRetentionPolicyStrategy.ReplayableBuffer;
             }
 
-            if (node is SeedGroupedTransitiveClosureCountNode or SeedGroupedDagLongestDepthNode)
+            if (preferredStrategy == RelationRetentionPolicyStrategy.ReplayableBuffer)
             {
-                if (hasStreaming)
-                {
-                    return DagRelationRetentionStrategy.StreamingDirect;
-                }
-
                 if (hasReplayable)
                 {
-                    return DagRelationRetentionStrategy.ReplayableBuffer;
+                    return RelationRetentionPolicyStrategy.ReplayableBuffer;
+                }
+
+                if (hasStreaming)
+                {
+                    return RelationRetentionPolicyStrategy.StreamingDirect;
                 }
             }
             else
             {
-                if (hasReplayable)
-                {
-                    return DagRelationRetentionStrategy.ReplayableBuffer;
-                }
-
                 if (hasStreaming)
                 {
-                    return DagRelationRetentionStrategy.StreamingDirect;
+                    return RelationRetentionPolicyStrategy.StreamingDirect;
+                }
+
+                if (hasReplayable)
+                {
+                    return RelationRetentionPolicyStrategy.ReplayableBuffer;
                 }
             }
 
             return hasExternal
-                ? DagRelationRetentionStrategy.ExternalMaterialized
-                : DagRelationRetentionStrategy.StreamingDirect;
+                ? RelationRetentionPolicyStrategy.ExternalMaterialized
+                : preferredStrategy == RelationRetentionPolicyStrategy.ReplayableBuffer
+                    ? RelationRetentionPolicyStrategy.ReplayableBuffer
+                    : RelationRetentionPolicyStrategy.StreamingDirect;
         }
 
-        private static bool ShouldProbeDagRelationRetentionStrategy(
-            PlanNode node,
+        private static bool ShouldProbeRelationRetentionStrategy(
             long? relationBytes,
+            long thresholdBytes,
             bool hasStreaming,
             bool hasReplayable,
             bool hasExternal,
@@ -8042,22 +8092,12 @@ namespace UnifyWeaver.QueryRuntime
                 return true;
             }
 
-            if (node is SeedGroupedTransitiveClosureCountNode)
-            {
-                return relationBytes <= 384 * 1024L;
-            }
-
-            if (node is SeedGroupedDagLongestDepthNode)
-            {
-                return relationBytes <= 320 * 1024L;
-            }
-
-            return relationBytes <= 256 * 1024L;
+            return relationBytes <= thresholdBytes;
         }
 
-        private static DagRelationRetentionStrategy ResolveMeasuredDagRelationRetentionStrategy(
-            IReadOnlyDictionary<DagRelationRetentionStrategy, TimeSpan> probes,
-            DagRelationRetentionStrategy structuralStrategy)
+        private static RelationRetentionPolicyStrategy ResolveMeasuredRelationRetentionStrategy(
+            IReadOnlyDictionary<RelationRetentionPolicyStrategy, TimeSpan> probes,
+            RelationRetentionPolicyStrategy structuralStrategy)
         {
             var bestStrategy = structuralStrategy;
             var bestTicks = double.PositiveInfinity;
@@ -8079,6 +8119,141 @@ namespace UnifyWeaver.QueryRuntime
             }
 
             return double.IsInfinity(bestTicks) ? structuralStrategy : bestStrategy;
+        }
+
+        private static RelationRetentionSelection ResolveRelationRetentionStrategy(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            string selectPhase,
+            string streamingProbePhase,
+            string replayableProbePhase,
+            string externalProbePhase,
+            RelationRetentionPolicyStrategy configuredStrategy,
+            RelationRetentionPolicyStrategy structuralStrategy,
+            bool shouldProbe,
+            bool hasStreaming,
+            bool hasReplayable,
+            bool hasExternal,
+            bool replayableMaterialized,
+            Func<TimeSpan>? measureStreamingProbe = null,
+            Func<TimeSpan>? measureReplayableProbe = null,
+            Func<TimeSpan>? measureExternalProbe = null)
+        {
+            return MeasurePhase(trace, node, selectPhase, () =>
+            {
+                bool IsAvailable(RelationRetentionPolicyStrategy strategy) => strategy switch
+                {
+                    RelationRetentionPolicyStrategy.StreamingDirect => hasStreaming,
+                    RelationRetentionPolicyStrategy.ReplayableBuffer => hasReplayable,
+                    RelationRetentionPolicyStrategy.ExternalMaterialized => hasExternal,
+                    _ => hasStreaming || hasReplayable || hasExternal
+                };
+
+                if (configuredStrategy != RelationRetentionPolicyStrategy.Auto)
+                {
+                    if (IsAvailable(configuredStrategy))
+                    {
+                        return new RelationRetentionSelection(configuredStrategy, "ConfiguredOverride");
+                    }
+
+                    configuredStrategy = RelationRetentionPolicyStrategy.Auto;
+                }
+
+                if (replayableMaterialized && hasReplayable)
+                {
+                    return new RelationRetentionSelection(RelationRetentionPolicyStrategy.ReplayableBuffer, "ReplayableCached");
+                }
+
+                if (!shouldProbe)
+                {
+                    var availableCount = (hasStreaming ? 1 : 0) + (hasReplayable ? 1 : 0) + (hasExternal ? 1 : 0);
+                    return new RelationRetentionSelection(structuralStrategy, availableCount <= 1 ? "OnlyAvailable" : "Structural");
+                }
+
+                var probes = new Dictionary<RelationRetentionPolicyStrategy, TimeSpan>();
+                if (measureStreamingProbe is not null)
+                {
+                    var probe = measureStreamingProbe();
+                    trace?.RecordPhase(node, streamingProbePhase, probe);
+                    probes[RelationRetentionPolicyStrategy.StreamingDirect] = probe;
+                }
+
+                if (measureReplayableProbe is not null)
+                {
+                    var probe = measureReplayableProbe();
+                    trace?.RecordPhase(node, replayableProbePhase, probe);
+                    probes[RelationRetentionPolicyStrategy.ReplayableBuffer] = probe;
+                }
+
+                if (measureExternalProbe is not null)
+                {
+                    var probe = measureExternalProbe();
+                    trace?.RecordPhase(node, externalProbePhase, probe);
+                    probes[RelationRetentionPolicyStrategy.ExternalMaterialized] = probe;
+                }
+
+                if (probes.Count == 0)
+                {
+                    return new RelationRetentionSelection(structuralStrategy, "Structural");
+                }
+
+                return new RelationRetentionSelection(
+                    ResolveMeasuredRelationRetentionStrategy(probes, structuralStrategy),
+                    "MeasuredProbe");
+            });
+        }
+
+        private static void RecordRelationRetentionStrategy(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            RelationRetentionSelection selection,
+            string selectionPrefix,
+            string strategyPrefix)
+        {
+            trace?.RecordStrategy(node, $"{selectionPrefix}{selection.DecisionMode}");
+            trace?.RecordStrategy(node, $"{strategyPrefix}{selection.Strategy}");
+        }
+
+        private static DagRelationRetentionStrategy ResolveStructuralDagRelationRetentionStrategy(
+            PlanNode node,
+            bool hasStreaming,
+            bool hasReplayable,
+            bool hasExternal,
+            bool replayableMaterialized)
+        {
+            var preferredStrategy = node is SeedGroupedTransitiveClosureCountNode or SeedGroupedDagLongestDepthNode
+                ? RelationRetentionPolicyStrategy.StreamingDirect
+                : RelationRetentionPolicyStrategy.ReplayableBuffer;
+            return ToDagRelationRetentionStrategy(
+                ResolveStructuralRelationRetentionStrategy(
+                    preferredStrategy,
+                    hasStreaming,
+                    hasReplayable,
+                    hasExternal,
+                    replayableMaterialized));
+        }
+
+        private static bool ShouldProbeDagRelationRetentionStrategy(
+            PlanNode node,
+            long? relationBytes,
+            bool hasStreaming,
+            bool hasReplayable,
+            bool hasExternal,
+            bool replayableMaterialized)
+        {
+            var thresholdBytes = node switch
+            {
+                SeedGroupedTransitiveClosureCountNode => 384 * 1024L,
+                SeedGroupedDagLongestDepthNode => 320 * 1024L,
+                _ => 256 * 1024L,
+            };
+            return ShouldProbeRelationRetentionStrategy(
+                relationBytes,
+                thresholdBytes,
+                hasStreaming,
+                hasReplayable,
+                hasExternal,
+                replayableMaterialized);
         }
 
         private static DagRelationRetentionSelection ResolveDagRelationRetentionStrategy(
@@ -8094,69 +8269,31 @@ namespace UnifyWeaver.QueryRuntime
             Func<TimeSpan>? measureReplayableProbe = null,
             Func<TimeSpan>? measureExternalProbe = null)
         {
-            return MeasurePhase(trace, node, "dag_strategy_select", () =>
-            {
-                bool IsAvailable(DagRelationRetentionStrategy strategy) => strategy switch
-                {
-                    DagRelationRetentionStrategy.StreamingDirect => hasStreaming,
-                    DagRelationRetentionStrategy.ReplayableBuffer => hasReplayable,
-                    DagRelationRetentionStrategy.ExternalMaterialized => hasExternal,
-                    _ => hasStreaming || hasReplayable || hasExternal
-                };
-
-                if (configuredStrategy != DagRelationRetentionStrategy.Auto)
-                {
-                    if (IsAvailable(configuredStrategy))
-                    {
-                        return new DagRelationRetentionSelection(configuredStrategy, "ConfiguredOverride");
-                    }
-
-                    configuredStrategy = DagRelationRetentionStrategy.Auto;
-                }
-
-                if (replayableMaterialized && hasReplayable)
-                {
-                    return new DagRelationRetentionSelection(DagRelationRetentionStrategy.ReplayableBuffer, "ReplayableCached");
-                }
-
-                var structuralStrategy = ResolveStructuralDagRelationRetentionStrategy(node, hasStreaming, hasReplayable, hasExternal, replayableMaterialized);
-                if (!ShouldProbeDagRelationRetentionStrategy(node, relationBytes, hasStreaming, hasReplayable, hasExternal, replayableMaterialized))
-                {
-                    var availableCount = (hasStreaming ? 1 : 0) + (hasReplayable ? 1 : 0) + (hasExternal ? 1 : 0);
-                    return new DagRelationRetentionSelection(structuralStrategy, availableCount <= 1 ? "OnlyAvailable" : "Structural");
-                }
-
-                var probes = new Dictionary<DagRelationRetentionStrategy, TimeSpan>();
-                if (measureStreamingProbe is not null)
-                {
-                    var probe = measureStreamingProbe();
-                    trace?.RecordPhase(node, "dag_probe_streaming_direct", probe);
-                    probes[DagRelationRetentionStrategy.StreamingDirect] = probe;
-                }
-
-                if (measureReplayableProbe is not null)
-                {
-                    var probe = measureReplayableProbe();
-                    trace?.RecordPhase(node, "dag_probe_replayable_buffer", probe);
-                    probes[DagRelationRetentionStrategy.ReplayableBuffer] = probe;
-                }
-
-                if (measureExternalProbe is not null)
-                {
-                    var probe = measureExternalProbe();
-                    trace?.RecordPhase(node, "dag_probe_external_materialized", probe);
-                    probes[DagRelationRetentionStrategy.ExternalMaterialized] = probe;
-                }
-
-                if (probes.Count == 0)
-                {
-                    return new DagRelationRetentionSelection(structuralStrategy, "Structural");
-                }
-
-                return new DagRelationRetentionSelection(
-                    ResolveMeasuredDagRelationRetentionStrategy(probes, structuralStrategy),
-                    "MeasuredProbe");
-            });
+            var structuralStrategy = ToRelationRetentionPolicyStrategy(
+                ResolveStructuralDagRelationRetentionStrategy(
+                    node,
+                    hasStreaming,
+                    hasReplayable,
+                    hasExternal,
+                    replayableMaterialized));
+            var selection = ResolveRelationRetentionStrategy(
+                trace,
+                node,
+                "dag_strategy_select",
+                "dag_probe_streaming_direct",
+                "dag_probe_replayable_buffer",
+                "dag_probe_external_materialized",
+                ToRelationRetentionPolicyStrategy(configuredStrategy),
+                structuralStrategy,
+                ShouldProbeDagRelationRetentionStrategy(node, relationBytes, hasStreaming, hasReplayable, hasExternal, replayableMaterialized),
+                hasStreaming,
+                hasReplayable,
+                hasExternal,
+                replayableMaterialized,
+                measureStreamingProbe,
+                measureReplayableProbe,
+                measureExternalProbe);
+            return new DagRelationRetentionSelection(ToDagRelationRetentionStrategy(selection.Strategy), selection.DecisionMode);
         }
 
         private static void RecordDagRelationRetentionStrategy(
@@ -8164,8 +8301,12 @@ namespace UnifyWeaver.QueryRuntime
             PlanNode node,
             DagRelationRetentionSelection selection)
         {
-            trace?.RecordStrategy(node, $"DagRelationRetentionSelection{selection.DecisionMode}");
-            trace?.RecordStrategy(node, $"DagRelationRetention{selection.Strategy}");
+            RecordRelationRetentionStrategy(
+                trace,
+                node,
+                new RelationRetentionSelection(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode),
+                "DagRelationRetentionSelection",
+                "DagRelationRetention");
         }
 
         private static PathAwareEdgeRetentionStrategy ResolveStructuralPathAwareEdgeRetentionStrategy(
@@ -8175,51 +8316,16 @@ namespace UnifyWeaver.QueryRuntime
             bool hasExternal,
             bool replayableMaterialized)
         {
-            if (replayableMaterialized && hasReplayable)
-            {
-                return PathAwareEdgeRetentionStrategy.ReplayableBuffer;
-            }
-
-            if (node is SeedGroupedPathAwareWeightSumNode)
-            {
-                if (hasReplayable)
-                {
-                    return PathAwareEdgeRetentionStrategy.ReplayableBuffer;
-                }
-
-                if (hasStreaming)
-                {
-                    return PathAwareEdgeRetentionStrategy.StreamingDirect;
-                }
-            }
-            else if (node is SeedGroupedPathAwareDepthMinNode or SeedGroupedPathAwareAccumulationMinNode)
-            {
-                if (hasStreaming)
-                {
-                    return PathAwareEdgeRetentionStrategy.StreamingDirect;
-                }
-
-                if (hasReplayable)
-                {
-                    return PathAwareEdgeRetentionStrategy.ReplayableBuffer;
-                }
-            }
-            else
-            {
-                if (hasStreaming)
-                {
-                    return PathAwareEdgeRetentionStrategy.StreamingDirect;
-                }
-
-                if (hasReplayable)
-                {
-                    return PathAwareEdgeRetentionStrategy.ReplayableBuffer;
-                }
-            }
-
-            return hasExternal
-                ? PathAwareEdgeRetentionStrategy.ExternalMaterialized
-                : PathAwareEdgeRetentionStrategy.StreamingDirect;
+            var preferredStrategy = node is SeedGroupedPathAwareWeightSumNode
+                ? RelationRetentionPolicyStrategy.ReplayableBuffer
+                : RelationRetentionPolicyStrategy.StreamingDirect;
+            return ToPathAwareEdgeRetentionStrategy(
+                ResolveStructuralRelationRetentionStrategy(
+                    preferredStrategy,
+                    hasStreaming,
+                    hasReplayable,
+                    hasExternal,
+                    replayableMaterialized));
         }
 
         private static bool ShouldProbePathAwareEdgeRetentionStrategy(
@@ -8230,59 +8336,19 @@ namespace UnifyWeaver.QueryRuntime
             bool hasExternal,
             bool replayableMaterialized)
         {
-            if (replayableMaterialized)
+            var thresholdBytes = node switch
             {
-                return false;
-            }
-
-            var availableCount = (hasStreaming ? 1 : 0) + (hasReplayable ? 1 : 0) + (hasExternal ? 1 : 0);
-            if (availableCount <= 1)
-            {
-                return false;
-            }
-
-            if (relationBytes is null)
-            {
-                return true;
-            }
-
-            if (node is SeedGroupedPathAwareWeightSumNode)
-            {
-                return relationBytes <= 384 * 1024L;
-            }
-
-            if (node is SeedGroupedPathAwareDepthMinNode or SeedGroupedPathAwareAccumulationMinNode)
-            {
-                return relationBytes <= 320 * 1024L;
-            }
-
-            return relationBytes <= 256 * 1024L;
-        }
-
-        private static PathAwareEdgeRetentionStrategy ResolveMeasuredPathAwareEdgeRetentionStrategy(
-            IReadOnlyDictionary<PathAwareEdgeRetentionStrategy, TimeSpan> probes,
-            PathAwareEdgeRetentionStrategy structuralStrategy)
-        {
-            var bestStrategy = structuralStrategy;
-            var bestTicks = double.PositiveInfinity;
-            foreach (var entry in probes)
-            {
-                var ticks = entry.Value == TimeSpan.MaxValue
-                    ? double.PositiveInfinity
-                    : entry.Value.Ticks;
-                if (ticks <= 0d || double.IsNaN(ticks))
-                {
-                    continue;
-                }
-
-                if (ticks < bestTicks)
-                {
-                    bestTicks = ticks;
-                    bestStrategy = entry.Key;
-                }
-            }
-
-            return double.IsInfinity(bestTicks) ? structuralStrategy : bestStrategy;
+                SeedGroupedPathAwareWeightSumNode => 384 * 1024L,
+                SeedGroupedPathAwareDepthMinNode or SeedGroupedPathAwareAccumulationMinNode => 320 * 1024L,
+                _ => 256 * 1024L,
+            };
+            return ShouldProbeRelationRetentionStrategy(
+                relationBytes,
+                thresholdBytes,
+                hasStreaming,
+                hasReplayable,
+                hasExternal,
+                replayableMaterialized);
         }
 
         private static PathAwareEdgeRetentionSelection ResolvePathAwareEdgeRetentionStrategy(
@@ -8298,69 +8364,31 @@ namespace UnifyWeaver.QueryRuntime
             Func<TimeSpan>? measureReplayableProbe = null,
             Func<TimeSpan>? measureExternalProbe = null)
         {
-            return MeasurePhase(trace, node, "edge_strategy_select", () =>
-            {
-                bool IsAvailable(PathAwareEdgeRetentionStrategy strategy) => strategy switch
-                {
-                    PathAwareEdgeRetentionStrategy.StreamingDirect => hasStreaming,
-                    PathAwareEdgeRetentionStrategy.ReplayableBuffer => hasReplayable,
-                    PathAwareEdgeRetentionStrategy.ExternalMaterialized => hasExternal,
-                    _ => hasStreaming || hasReplayable || hasExternal
-                };
-
-                if (configuredStrategy != PathAwareEdgeRetentionStrategy.Auto)
-                {
-                    if (IsAvailable(configuredStrategy))
-                    {
-                        return new PathAwareEdgeRetentionSelection(configuredStrategy, "ConfiguredOverride");
-                    }
-
-                    configuredStrategy = PathAwareEdgeRetentionStrategy.Auto;
-                }
-
-                if (replayableMaterialized && hasReplayable)
-                {
-                    return new PathAwareEdgeRetentionSelection(PathAwareEdgeRetentionStrategy.ReplayableBuffer, "ReplayableCached");
-                }
-
-                var structuralStrategy = ResolveStructuralPathAwareEdgeRetentionStrategy(node, hasStreaming, hasReplayable, hasExternal, replayableMaterialized);
-                if (!ShouldProbePathAwareEdgeRetentionStrategy(node, relationBytes, hasStreaming, hasReplayable, hasExternal, replayableMaterialized))
-                {
-                    var availableCount = (hasStreaming ? 1 : 0) + (hasReplayable ? 1 : 0) + (hasExternal ? 1 : 0);
-                    return new PathAwareEdgeRetentionSelection(structuralStrategy, availableCount <= 1 ? "OnlyAvailable" : "Structural");
-                }
-
-                var probes = new Dictionary<PathAwareEdgeRetentionStrategy, TimeSpan>();
-                if (measureStreamingProbe is not null)
-                {
-                    var probe = measureStreamingProbe();
-                    trace?.RecordPhase(node, "edge_probe_streaming_direct", probe);
-                    probes[PathAwareEdgeRetentionStrategy.StreamingDirect] = probe;
-                }
-
-                if (measureReplayableProbe is not null)
-                {
-                    var probe = measureReplayableProbe();
-                    trace?.RecordPhase(node, "edge_probe_replayable_buffer", probe);
-                    probes[PathAwareEdgeRetentionStrategy.ReplayableBuffer] = probe;
-                }
-
-                if (measureExternalProbe is not null)
-                {
-                    var probe = measureExternalProbe();
-                    trace?.RecordPhase(node, "edge_probe_external_materialized", probe);
-                    probes[PathAwareEdgeRetentionStrategy.ExternalMaterialized] = probe;
-                }
-
-                if (probes.Count == 0)
-                {
-                    return new PathAwareEdgeRetentionSelection(structuralStrategy, "Structural");
-                }
-
-                return new PathAwareEdgeRetentionSelection(
-                    ResolveMeasuredPathAwareEdgeRetentionStrategy(probes, structuralStrategy),
-                    "MeasuredProbe");
-            });
+            var structuralStrategy = ToRelationRetentionPolicyStrategy(
+                ResolveStructuralPathAwareEdgeRetentionStrategy(
+                    node,
+                    hasStreaming,
+                    hasReplayable,
+                    hasExternal,
+                    replayableMaterialized));
+            var selection = ResolveRelationRetentionStrategy(
+                trace,
+                node,
+                "edge_strategy_select",
+                "edge_probe_streaming_direct",
+                "edge_probe_replayable_buffer",
+                "edge_probe_external_materialized",
+                ToRelationRetentionPolicyStrategy(configuredStrategy),
+                structuralStrategy,
+                ShouldProbePathAwareEdgeRetentionStrategy(node, relationBytes, hasStreaming, hasReplayable, hasExternal, replayableMaterialized),
+                hasStreaming,
+                hasReplayable,
+                hasExternal,
+                replayableMaterialized,
+                measureStreamingProbe,
+                measureReplayableProbe,
+                measureExternalProbe);
+            return new PathAwareEdgeRetentionSelection(ToPathAwareEdgeRetentionStrategy(selection.Strategy), selection.DecisionMode);
         }
 
         private static void RecordPathAwareEdgeRetentionStrategy(
@@ -8368,8 +8396,12 @@ namespace UnifyWeaver.QueryRuntime
             PlanNode node,
             PathAwareEdgeRetentionSelection selection)
         {
-            trace?.RecordStrategy(node, $"PathAwareEdgeRetentionSelection{selection.DecisionMode}");
-            trace?.RecordStrategy(node, $"PathAwareEdgeRetention{selection.Strategy}");
+            RecordRelationRetentionStrategy(
+                trace,
+                node,
+                new RelationRetentionSelection(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode),
+                "PathAwareEdgeRetentionSelection",
+                "PathAwareEdgeRetention");
         }
 
         private static PathAwareGroupedSummaryStrategy ToPathAwareGroupedSummaryStrategy(PathAwareGroupedMinStrategy strategy)


### PR DESCRIPTION
  ## Summary

  This PR unifies the internal measured relation-retention policy layer in
  the C# query runtime.

  Before this change, the runtime already had measured retention selection
  for two different relation families:

  - DAG relation retention
  - path-aware edge retention

  Both were working, but they still carried duplicated internal machinery:

  - separate strategy conversion
  - separate structural resolution
  - separate probe gating
  - separate measured selection loops
  - separate strategy trace plumbing

  This PR factors that into one shared internal relation-retention policy
  layer while preserving the existing public per-family override knobs.

  ## What Changed

  ### Shared Internal Policy Layer

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added shared internal types and helpers for relation-retention selection,
  including:

  - shared internal relation-retention strategy representation
  - shared selection record
  - shared structural resolution helper
  - shared probe-gating helper
  - shared measured-selection helper
  - shared strategy-recording helper

  This policy layer now serves both:

  - DAG relation retention
  - path-aware edge retention

  ### DAG and Path-Aware Wrappers Kept Intact

  The runtime still preserves the benchmark-visible per-family option
  surfaces:

  - `DagRelationRetentionStrategy`
  - `PathAwareEdgeRetentionStrategy`

  Those public enums and their generated benchmark environment-variable
  controls are unchanged.

  So this PR is a refactor of the runtime internals, not a change to the
  user-facing tuning knobs.

  ### Structural Preferences Still Differ By Family

  The unification is not a flattening of behavior.

  The family-specific wrappers still preserve their different structural
  preferences:

  - DAG relation retention still defaults toward streamed DAG build on the
    current DAG family
  - path-aware edge retention still preserves its separate weight-sum vs
    minima preferences

  What changed is that those differences are now expressed as inputs to a
  shared policy mechanism rather than as two separate implementations.

  ### Docs Updated

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`
  - `examples/benchmark/README.md`

  These now describe the retention work more accurately:

  - DAG relation retention and path-aware edge retention now share one
    internal measured relation-retention policy layer
  - public per-family override surfaces remain separate for benchmarking
    and diagnosis

  ## Why This Matters

  The main value of this PR is structural.

  The engine had reached the point where it already knew how to make
  measured retention choices in multiple places. At that point, duplicated
  policy machinery becomes the next problem:

  - harder to reason about
  - harder to extend
  - easier to let behavior drift unintentionally across families

  This PR turns those two parallel implementations into one reusable
  runtime capability.

  That makes the next extension point cleaner:

  - more relation families can adopt measured retention selection
  - without copying the same policy code again

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_category_influence_cross_target.py \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py

  ### Full benchmark reruns

  Ran locally:

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated \
      --repetitions 1

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  All outputs still matched.

  ### Trace sanity check

  Also ran with trace enabled:

  UNIFYWEAVER_BENCH_TRACE=1 \
  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query \
      --repetitions 1

  This confirmed that benchmark-visible strategy names are still preserved,
  for example:

  - PathAwareEdgeRetentionReplayableBuffer
  - PathAwareEdgeRetentionSelectionMeasuredProbe

  So the shared internal policy refactor did not break the expected trace
  surface.

  ## Representative Results After Refactor

  ### Shortest path

  - 300: csharp-query 0.292s
  - 10k: csharp-query 0.203s

  ### Weighted shortest path

  - 300: csharp-query 0.466s
  - 10k: csharp-query 0.454s

  ### Effective distance

  - 300: csharp-query 0.558s
  - 10k: csharp-query 0.984s

  ### Category influence

  - 300: csharp-query 1.023s
  - 10k: csharp-query 0.959s

  ### Dependency reach-count

  - 300: csharp-query 0.265s
  - 10k: csharp-query 0.129s

  ### Dependency longest depth

  - 300: csharp-query 0.075s
  - 10k: csharp-query 0.143s

  ## Interpretation

  This PR is a runtime-policy refactor, not a new optimization technique.

  The important result is:

  - the measured relation-retention logic is now shared
  - behavior is still correct across all benchmark families
  - the public tuning and trace surface remains intact

  That is the right cleanup step after proving the policy pattern on more
  than one family.

  ## Scope

  This PR adds:

  - a shared internal relation-retention policy layer
  - DAG/path-aware wrapper adaptation to that layer
  - doc updates describing the unified policy

  It does not change:

  - the public benchmark environment variables
  - the public executor option names
  - the grouped-summary policy layer
  - benchmark semantics

  ## Follow-Up

  Likely next work:

  - extend the shared relation-retention policy idea to additional operator
    families beyond the current DAG/path-aware relation cases
  - continue reducing duplicated runtime policy code where measured
    retention selection is already established
  - eventually connect the shared grouped-summary policy and shared
    relation-retention policy more explicitly into a broader runtime
    materialization-planning layer
