### PR TITLE
feat(csharp-query): add path-aware materialization planner

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -111,6 +111,10 @@ Status:
 - the current implementation now shares one internal relation-retention policy
   layer for DAG and path-aware edge selection, while keeping separate public
   override knobs for benchmarking and diagnosis
+- the path-aware grouped-summary family now coordinates that relation-retention
+  choice with grouped-summary selection through a small internal
+  materialization-planner layer, while preserving the current per-family
+  override knobs and trace surface
 
 Work:
 
@@ -119,6 +123,8 @@ Work:
   - replayable buffering
   - indexed retained state
   - fallback external materialization
+- coordinate relation-retention and grouped-summary choices when both policy
+  layers exist for the same operator family
 - keep this heuristic-driven at first, then refine as profiling improves
 
 Success criteria:

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -36,7 +36,10 @@ retention choice explicit at the runtime/provider boundary instead of hiding it
 inside benchmark-specific wiring. The current runtime now also shares one
 internal measured relation-retention policy layer between DAG relation
 selection and path-aware edge selection, while preserving separate public
-override surfaces for those families.
+override surfaces for those families. For the path-aware grouped-summary
+family, the runtime now coordinates that relation-retention choice with the
+grouped-summary selector through a small internal materialization planner
+layer.
 
 ## Required Capabilities
 
@@ -86,6 +89,10 @@ Examples:
   runtime can choose between them through that same grouped-summary policy
   layer, record measured cost buckets for that choice, and still expose an
   explicit override via `QueryExecutorOptions.PathAwareWeightSumStrategy`
+- when a path-aware operator family has both relation-retention and
+  grouped-summary policy layers available, the runtime can coordinate them
+  through a materialization planner layer instead of treating them as
+  unrelated decisions
 - other operators may request replay buffers or indexes when needed
 
 ### 3. External materialization fallback
@@ -151,8 +158,11 @@ For the current benchmark/runtime surface, the streamed path is:
    runtime can select between them through that same grouped-summary policy
    layer, record measured cost buckets for that decision, and use bounded
    probes in ambiguous cases before falling back to an explicit executor option
-12. the operator builds only the retained state it actually needs
-13. benchmark code avoids preloading raw facts into in-memory relations first
+12. for the current path-aware grouped-summary family, a materialization
+   planner layer now coordinates the earlier edge-retention choice with the
+   later grouped-summary choice and records the combined plan in trace output
+13. the operator builds only the retained state it actually needs
+14. benchmark code avoids preloading raw facts into in-memory relations first
 
 This is still a first step, not the full endpoint, but it is now broader than
 just the original DAG-only fast paths.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -30,10 +30,12 @@ pipelines across the full benchmark range while preserving the same
 all-path semantics. It also now supports cost-guided selection between
 compact grouped weight sums and the legacy seeded-row regrouping path,
 using the same grouped-summary policy layer that now also drives the
-shortest-path minima family. That policy now records measured cost buckets
-like `load_roots`, `load_seeds`, `strategy_select`, `build_*`, and
-`group_reduce`, while the earlier path-aware edge-retention boundary now also
-records buckets like `edge_strategy_select`, `edge_probe_*`,
+shortest-path minima family. The path-aware family now also coordinates that
+grouped-summary selector with the earlier edge-retention selector through a
+small internal materialization planner layer. That policy now records measured
+cost buckets like `load_roots`, `load_seeds`, `strategy_select`, `build_*`,
+and `group_reduce`, while the earlier path-aware edge-retention boundary now
+also records buckets like `edge_strategy_select`, `edge_probe_*`,
 `edge_materialize_replayable`, and `edge_build_*`.
 
 | Target | 300 art | 1K art | 5K art | 10K art |

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -524,6 +524,11 @@ namespace UnifyWeaver.QueryRuntime
         PathAwareGroupedSummaryStrategy Strategy,
         string DecisionMode);
 
+    internal readonly record struct PathAwareMaterializationPlanSelection(
+        PathAwareEdgeRetentionSelection EdgeRetention,
+        PathAwareGroupedSummarySelection GroupedSummary,
+        string DecisionMode);
+
     internal readonly record struct DagRelationRetentionSelection(
         DagRelationRetentionStrategy Strategy,
         string DecisionMode);
@@ -1759,6 +1764,7 @@ namespace UnifyWeaver.QueryRuntime
             _cacheContext.FactSources.Clear();
             _cacheContext.ReplayableFactSources.Clear();
             _cacheContext.PathAwareEdgeStates.Clear();
+            _cacheContext.PathAwareEdgeRetentionSelections.Clear();
             _cacheContext.FactSets.Clear();
             _cacheContext.FactIndices.Clear();
             _cacheContext.JoinIndices.Clear();
@@ -6297,8 +6303,16 @@ namespace UnifyWeaver.QueryRuntime
                     break;
             }
 
+            context.PathAwareEdgeRetentionSelections[predicate] = selection;
             context.PathAwareEdgeStates[predicate] = state;
             return state;
+        }
+
+        private static PathAwareEdgeRetentionSelection GetCachedPathAwareEdgeRetentionSelection(PredicateId predicate, EvaluationContext context)
+        {
+            return context.PathAwareEdgeRetentionSelections.TryGetValue(predicate, out var selection)
+                ? selection
+                : new PathAwareEdgeRetentionSelection(PathAwareEdgeRetentionStrategy.Auto, "Unavailable");
         }
 
         private List<object[]> GetFactsList(PredicateId predicate, EvaluationContext? context)
@@ -8445,26 +8459,55 @@ namespace UnifyWeaver.QueryRuntime
             trace?.RecordPhase(node, phase, stopwatch.Elapsed);
         }
 
+        private static long AdjustEstimatedLegacyRowsForPathAwareEdgeRetention(
+            long estimatedGroupedRows,
+            long estimatedLegacyRows,
+            PathAwareEdgeRetentionStrategy edgeRetentionStrategy)
+        {
+            var factor = edgeRetentionStrategy switch
+            {
+                PathAwareEdgeRetentionStrategy.StreamingDirect => 1.50d,
+                PathAwareEdgeRetentionStrategy.ReplayableBuffer => 0.75d,
+                PathAwareEdgeRetentionStrategy.ExternalMaterialized => 0.90d,
+                _ => 1.0d,
+            };
+
+            var adjusted = (long)Math.Ceiling(Math.Min(long.MaxValue, estimatedLegacyRows * factor));
+            return Math.Max(estimatedGroupedRows, adjusted);
+        }
+
         private static PathAwareGroupedSummaryStrategy ResolveStructuralPathAwareGroupedSummaryStrategy(
             long estimatedGroupedRows,
-            long estimatedLegacyRows) =>
-            estimatedLegacyRows <= Math.Max(64L, estimatedGroupedRows * 4L)
+            long estimatedLegacyRows,
+            PathAwareEdgeRetentionStrategy edgeRetentionStrategy)
+        {
+            var adjustedLegacyRows = AdjustEstimatedLegacyRowsForPathAwareEdgeRetention(
+                estimatedGroupedRows,
+                estimatedLegacyRows,
+                edgeRetentionStrategy);
+            return adjustedLegacyRows <= Math.Max(64L, estimatedGroupedRows * 4L)
                 ? PathAwareGroupedSummaryStrategy.LegacySeededRows
                 : PathAwareGroupedSummaryStrategy.CompactGrouped;
+        }
 
         private static bool ShouldProbePathAwareGroupedSummaryStrategy(
             long estimatedGroupedRows,
             long estimatedLegacyRows,
-            int uniqueSeedCount)
+            int uniqueSeedCount,
+            PathAwareEdgeRetentionStrategy edgeRetentionStrategy)
         {
             if (uniqueSeedCount < 2)
             {
                 return false;
             }
 
+            var adjustedLegacyRows = AdjustEstimatedLegacyRowsForPathAwareEdgeRetention(
+                estimatedGroupedRows,
+                estimatedLegacyRows,
+                edgeRetentionStrategy);
             var lowerBound = Math.Max(64L, estimatedGroupedRows * 2L);
             var upperBound = Math.Max(256L, estimatedGroupedRows * 8L);
-            return estimatedLegacyRows > lowerBound && estimatedLegacyRows < upperBound;
+            return adjustedLegacyRows > lowerBound && adjustedLegacyRows < upperBound;
         }
 
         private static PathAwareGroupedSummaryStrategy ResolveMeasuredPathAwareGroupedSummaryStrategy(
@@ -8473,9 +8516,13 @@ namespace UnifyWeaver.QueryRuntime
             TimeSpan compactProbe,
             TimeSpan legacyProbe,
             long estimatedGroupedRows,
-            long estimatedLegacyRows)
+            long estimatedLegacyRows,
+            PathAwareEdgeRetentionStrategy edgeRetentionStrategy)
         {
-            var structuralStrategy = ResolveStructuralPathAwareGroupedSummaryStrategy(estimatedGroupedRows, estimatedLegacyRows);
+            var structuralStrategy = ResolveStructuralPathAwareGroupedSummaryStrategy(
+                estimatedGroupedRows,
+                estimatedLegacyRows,
+                edgeRetentionStrategy);
             if (sampleSeedCount <= 0 || totalSeedCount <= 0)
             {
                 return structuralStrategy;
@@ -8516,6 +8563,7 @@ namespace UnifyWeaver.QueryRuntime
             IReadOnlyList<object?> orderedUniqueSeeds,
             int rootCount,
             IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
+            PathAwareEdgeRetentionStrategy edgeRetentionStrategy,
             Func<IReadOnlyList<object?>, TimeSpan>? measureCompactProbe = null,
             Func<IReadOnlyList<object?>, TimeSpan>? measureLegacyProbe = null)
         {
@@ -8533,10 +8581,13 @@ namespace UnifyWeaver.QueryRuntime
                 var nodeCount = Math.Max(1, EstimatePathAwareNodeCount(succIndex));
                 var estimatedGroupedRows = (long)effectiveGroups * effectiveRoots;
                 var estimatedLegacyRows = (long)effectiveSeeds * nodeCount;
-                var structuralStrategy = ResolveStructuralPathAwareGroupedSummaryStrategy(estimatedGroupedRows, estimatedLegacyRows);
+                var structuralStrategy = ResolveStructuralPathAwareGroupedSummaryStrategy(
+                    estimatedGroupedRows,
+                    estimatedLegacyRows,
+                    edgeRetentionStrategy);
 
                 if (measureCompactProbe is null || measureLegacyProbe is null ||
-                    !ShouldProbePathAwareGroupedSummaryStrategy(estimatedGroupedRows, estimatedLegacyRows, uniqueSeedCount))
+                    !ShouldProbePathAwareGroupedSummaryStrategy(estimatedGroupedRows, estimatedLegacyRows, uniqueSeedCount, edgeRetentionStrategy))
                 {
                     return new PathAwareGroupedSummarySelection(structuralStrategy, "Structural");
                 }
@@ -8554,7 +8605,8 @@ namespace UnifyWeaver.QueryRuntime
                     compactProbe,
                     legacyProbe,
                     estimatedGroupedRows,
-                    estimatedLegacyRows);
+                    estimatedLegacyRows,
+                    edgeRetentionStrategy);
                 return new PathAwareGroupedSummarySelection(measuredStrategy, "MeasuredProbe");
             });
         }
@@ -8569,6 +8621,61 @@ namespace UnifyWeaver.QueryRuntime
             trace?.RecordStrategy(node, selection.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows
                 ? $"{nodeStrategyPrefix}LegacySeededRows"
                 : $"{nodeStrategyPrefix}CompactGrouped");
+        }
+
+        private static PathAwareMaterializationPlanSelection ResolvePathAwareMaterializationPlan(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            PathAwareEdgeRetentionSelection edgeRetentionSelection,
+            PathAwareGroupedSummaryStrategy configuredSummaryStrategy,
+            int groupCount,
+            IReadOnlyList<object?> orderedUniqueSeeds,
+            int rootCount,
+            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
+            Func<IReadOnlyList<object?>, TimeSpan>? measureCompactProbe = null,
+            Func<IReadOnlyList<object?>, TimeSpan>? measureLegacyProbe = null)
+        {
+            return MeasurePhase(trace, node, "materialization_plan_select", () =>
+            {
+                var groupedSummarySelection = ResolvePathAwareGroupedSummaryStrategy(
+                    trace,
+                    node,
+                    configuredSummaryStrategy,
+                    groupCount,
+                    orderedUniqueSeeds,
+                    rootCount,
+                    succIndex,
+                    edgeRetentionSelection.Strategy,
+                    measureCompactProbe,
+                    measureLegacyProbe);
+
+                var decisionMode = groupedSummarySelection.DecisionMode switch
+                {
+                    "ConfiguredOverride" => "ConfiguredSummary",
+                    "MeasuredProbe" when edgeRetentionSelection.DecisionMode == "MeasuredProbe" => "MeasuredRelationAndSummary",
+                    "MeasuredProbe" => "MeasuredSummary",
+                    _ when edgeRetentionSelection.DecisionMode == "MeasuredProbe" => "MeasuredRelation",
+                    _ when edgeRetentionSelection.DecisionMode == "ConfiguredOverride" => "ConfiguredRelation",
+                    _ when edgeRetentionSelection.DecisionMode == "ReplayableCached" => "ReplayableCached",
+                    _ => "Structural"
+                };
+
+                return new PathAwareMaterializationPlanSelection(
+                    edgeRetentionSelection,
+                    groupedSummarySelection,
+                    decisionMode);
+            });
+        }
+
+        private static void RecordPathAwareMaterializationPlanStrategy(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            string nodeStrategyPrefix,
+            PathAwareMaterializationPlanSelection selection)
+        {
+            trace?.RecordStrategy(node, $"{nodeStrategyPrefix}MaterializationPlanSelection{selection.DecisionMode}");
+            trace?.RecordStrategy(node,
+                $"{nodeStrategyPrefix}MaterializationPlanEdge{selection.EdgeRetention.Strategy}Summary{selection.GroupedSummary.Strategy}");
         }
 
         private IReadOnlyDictionary<object, Dictionary<object, double>> ExecuteSeedGroupedPathAwareWeightSumFallback(
@@ -8677,6 +8784,7 @@ namespace UnifyWeaver.QueryRuntime
                 trace?.RecordCacheLookup("SeedGroupedPathAwareWeightSum", traceKey, hit: false, built: true);
 
                 var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context, closure);
+                var edgeRetentionSelection = GetCachedPathAwareEdgeRetentionSelection(closure.EdgeRelation, context);
                 var succIndex = edgeState.Successors;
 
                 var rootKeys = new HashSet<object>();
@@ -8797,9 +8905,10 @@ namespace UnifyWeaver.QueryRuntime
                 TimeSpan MeasureLegacyProbe(IReadOnlyList<object?> sampleSeeds) =>
                     MeasureElapsed(() => _ = ExecuteSeedGroupedPathAwareWeightSumFallback(closure, sampleSeeds, rootKeys, context));
 
-                var selection = ResolvePathAwareGroupedSummaryStrategy(
+                var materializationPlan = ResolvePathAwareMaterializationPlan(
                     trace,
                     closure,
+                    edgeRetentionSelection,
                     _pathAwareWeightSumStrategy,
                     groupValues.Count,
                     orderedUniqueSeeds,
@@ -8807,9 +8916,10 @@ namespace UnifyWeaver.QueryRuntime
                     succIndex,
                     MeasureCompactProbe,
                     MeasureLegacyProbe);
-                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareWeightSum", selection);
+                RecordPathAwareMaterializationPlanStrategy(trace, closure, "SeedGroupedPathAwareWeightSum", materializationPlan);
+                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareWeightSum", materializationPlan.GroupedSummary);
 
-                IReadOnlyDictionary<object, Dictionary<object, double>> seedWeightSums = selection.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows
+                IReadOnlyDictionary<object, Dictionary<object, double>> seedWeightSums = materializationPlan.GroupedSummary.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows
                     ? MeasurePhase(trace, closure, "build_legacy_seeded_rows", () =>
                         (IReadOnlyDictionary<object, Dictionary<object, double>>)ExecuteSeedGroupedPathAwareWeightSumFallback(closure, orderedUniqueSeeds, rootKeys, context))
                     : MeasurePhase(trace, closure, "build_compact_grouped", () =>
@@ -9039,6 +9149,7 @@ namespace UnifyWeaver.QueryRuntime
                 trace?.RecordCacheLookup("SeedGroupedPathAwareDepthMin", $"{closure.Predicate.Name}/{closure.Predicate.Arity}", hit: false, built: true);
 
                 var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context, closure);
+                var edgeRetentionSelection = GetCachedPathAwareEdgeRetentionSelection(closure.EdgeRelation, context);
                 var succIndex = edgeState.Successors;
                 var rootKeys = new HashSet<object>();
                 var rootValues = new Dictionary<object, object?>();
@@ -9129,9 +9240,10 @@ namespace UnifyWeaver.QueryRuntime
                 TimeSpan MeasureLegacyProbe(IReadOnlyList<object?> sampleSeeds) =>
                     MeasureElapsed(() => _ = ExecuteSeedGroupedPathAwareDepthMinFallback(closure, sampleSeeds, rootKeys, context));
 
-                var selection = ResolvePathAwareGroupedSummaryStrategy(
+                var materializationPlan = ResolvePathAwareMaterializationPlan(
                     trace,
                     closure,
+                    edgeRetentionSelection,
                     _pathAwareGroupedMinStrategy,
                     groupValues.Count,
                     orderedUniqueSeeds,
@@ -9139,9 +9251,10 @@ namespace UnifyWeaver.QueryRuntime
                     succIndex,
                     MeasureCompactProbe,
                     MeasureLegacyProbe);
-                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareDepthMin", selection);
+                RecordPathAwareMaterializationPlanStrategy(trace, closure, "SeedGroupedPathAwareDepthMin", materializationPlan);
+                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareDepthMin", materializationPlan.GroupedSummary);
 
-                IReadOnlyDictionary<object, Dictionary<object, int>> seedDepthMins = selection.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows
+                IReadOnlyDictionary<object, Dictionary<object, int>> seedDepthMins = materializationPlan.GroupedSummary.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows
                     ? MeasurePhase(trace, closure, "build_legacy_seeded_rows", () =>
                         (IReadOnlyDictionary<object, Dictionary<object, int>>)ExecuteSeedGroupedPathAwareDepthMinFallback(closure, orderedUniqueSeeds, rootKeys, context))
                     : MeasurePhase(trace, closure, "build_compact_grouped", () =>
@@ -9291,6 +9404,7 @@ namespace UnifyWeaver.QueryRuntime
                 trace?.RecordCacheLookup("SeedGroupedPathAwareAccumulationMin", $"{closure.Predicate.Name}/{closure.Predicate.Arity}", hit: false, built: true);
 
                 var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context, closure);
+                var edgeRetentionSelection = GetCachedPathAwareEdgeRetentionSelection(closure.EdgeRelation, context);
                 var succIndex = edgeState.Successors;
                 var rootKeys = new HashSet<object>();
                 var rootValues = new Dictionary<object, object?>();
@@ -9416,9 +9530,10 @@ namespace UnifyWeaver.QueryRuntime
                 TimeSpan MeasureLegacyProbe(IReadOnlyList<object?> sampleSeeds) =>
                     MeasureElapsed(() => _ = ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, sampleSeeds, rootKeys, context));
 
-                var selection = ResolvePathAwareGroupedSummaryStrategy(
+                var materializationPlan = ResolvePathAwareMaterializationPlan(
                     trace,
                     closure,
+                    edgeRetentionSelection,
                     _pathAwareGroupedMinStrategy,
                     groupValues.Count,
                     orderedUniqueSeeds,
@@ -9426,10 +9541,11 @@ namespace UnifyWeaver.QueryRuntime
                     succIndex,
                     MeasureCompactProbe,
                     MeasureLegacyProbe);
-                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareAccumulationMin", selection);
+                RecordPathAwareMaterializationPlanStrategy(trace, closure, "SeedGroupedPathAwareAccumulationMin", materializationPlan);
+                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareAccumulationMin", materializationPlan.GroupedSummary);
 
                 IReadOnlyDictionary<object, Dictionary<object, object>> seedMinima;
-                if (selection.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows)
+                if (materializationPlan.GroupedSummary.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows)
                 {
                     seedMinima = MeasurePhase(trace, closure, "build_legacy_seeded_rows", () =>
                         (IReadOnlyDictionary<object, Dictionary<object, object>>)ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, orderedUniqueSeeds, rootKeys, context));
@@ -9445,6 +9561,7 @@ namespace UnifyWeaver.QueryRuntime
                     else
                     {
                         trace?.RecordStrategy(closure, "SeedGroupedPathAwareAccumulationMinLegacySeededRowsNoPositiveFastPath");
+                        trace?.RecordStrategy(closure, "SeedGroupedPathAwareAccumulationMinMaterializationPlanFallbackLegacyNoPositiveFastPath");
                         seedMinima = MeasurePhase(trace, closure, "build_legacy_seeded_rows", () =>
                             (IReadOnlyDictionary<object, Dictionary<object, object>>)ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, orderedUniqueSeeds, rootKeys, context));
                     }
@@ -17100,6 +17217,7 @@ namespace UnifyWeaver.QueryRuntime
                 FactSources = parent?.FactSources ?? new Dictionary<PredicateId, PlanNode>();
                 ReplayableFactSources = parent?.ReplayableFactSources ?? new Dictionary<PredicateId, IReplayableRelationSource>();
                 PathAwareEdgeStates = parent?.PathAwareEdgeStates ?? new Dictionary<PredicateId, PathAwareEdgeState>();
+                PathAwareEdgeRetentionSelections = parent?.PathAwareEdgeRetentionSelections ?? new Dictionary<PredicateId, PathAwareEdgeRetentionSelection>();
                 FactSets = parent?.FactSets ?? new Dictionary<PredicateId, HashSet<object[]>>();
                 FactIndices = parent?.FactIndices ?? new Dictionary<(PredicateId Predicate, int ColumnIndex), Dictionary<object, List<object[]>>>();
                 JoinIndices = parent?.JoinIndices ?? new Dictionary<(PredicateId Predicate, string KeySignature), Dictionary<RowWrapper, List<object[]>>>();
@@ -17165,6 +17283,8 @@ namespace UnifyWeaver.QueryRuntime
             public Dictionary<PredicateId, IReplayableRelationSource> ReplayableFactSources { get; }
 
             public Dictionary<PredicateId, PathAwareEdgeState> PathAwareEdgeStates { get; }
+
+            public Dictionary<PredicateId, PathAwareEdgeRetentionSelection> PathAwareEdgeRetentionSelections { get; }
 
             public Dictionary<PredicateId, HashSet<object[]>> FactSets { get; }
 


### PR DESCRIPTION
  ## Summary

  This PR adds a small internal materialization-planner layer for the
  path-aware family in the C# query runtime.

  Previously, the runtime already had two separate policy decisions for
  these workloads:

  - relation retention for path-aware edges
  - grouped-summary selection for minima / weight sums

  Both worked, but they were still resolved mostly independently.

  This PR connects them.

  The runtime can now treat the path-aware materialization choice as one
  coordinated plan, while keeping the existing public override knobs and
  benchmark trace surface intact.

  ## What Changed

  ### Runtime: Path-Aware Materialization Planner

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `PathAwareMaterializationPlanSelection`

  The new planner coordinates:

  - `PathAwareEdgeRetentionSelection`
  - `PathAwareGroupedSummarySelection`

  for the path-aware grouped-summary family.

  This currently applies to:

  - `SeedGroupedPathAwareWeightSumNode`
  - `SeedGroupedPathAwareDepthMinNode`
  - `SeedGroupedPathAwareAccumulationMinNode`

  ### Runtime: Cached Edge-Retention Selection

  The evaluation context now keeps the chosen path-aware edge-retention
  selection alongside the cached edge state.

  That lets later grouped-summary planning use the earlier retention choice
  explicitly instead of only benefiting from it indirectly through cached
  state.

  ### Runtime: Combined Trace Output

  The planner now records combined strategy traces such as:

  - `SeedGroupedPathAwareDepthMinMaterializationPlanSelection...`
  - `SeedGroupedPathAwareWeightSumMaterializationPlanEdge...Summary...`

  So trace output now shows the combined plan, not just the individual
  sub-decisions.

  ### Heuristic Coordination

  The grouped-summary selector now considers the earlier edge-retention
  choice when estimating whether compact grouped summaries or legacy
  seeded-row regrouping are more appropriate.

  This is still heuristic and lightweight, but it is now expressed as a
  real planner layer rather than two unrelated selector passes.

  ### Docs

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`
  - `examples/benchmark/README.md`

  These docs now describe the path-aware family as using a coordinated
  materialization planner on top of the existing relation-retention and
  grouped-summary policy layers.

  ## Why This Matters

  This PR does not add a new retained summary form.

  Its value is architectural:

  - relation retention and grouped-summary choice are now coordinated
  - the runtime has a clearer path from separate policy components toward a
    broader materialization planner
  - the existing public knobs remain available for benchmarking and
    diagnosis

  That makes Stage 4 of the materialization work more coherent.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_category_influence_cross_target.py \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py

  Full reruns passed for:

  - benchmark_shortest_path_cross_target.py
  - benchmark_weighted_shortest_path_cross_target.py
  - benchmark_effective_distance.py
  - benchmark_category_influence_cross_target.py
  - benchmark_dependency_depth_cross_target.py
  - benchmark_dependency_longest_depth_cross_target.py

  All outputs still matched across targets.

  ### Representative Results

  - shortest path 10k: csharp-query 0.237s
  - weighted shortest path 10k: csharp-query 0.421s
  - effective distance 10k: csharp-query 0.894s
  - category influence 10k: csharp-query 0.976s
  - dependency reach-count 10k: csharp-query 0.110s
  - dependency longest depth 10k: csharp-query 0.125s

  ### Trace Sanity Check

  With:

  UNIFYWEAVER_BENCH_TRACE=1

  the path-aware family now emits combined planner traces in addition to
  the existing edge-retention and grouped-summary traces.

  ## Interpretation

  This PR is a planner-layer step, not a new operator optimization.

  The main result is that the path-aware family now has:

  - one coordinated internal materialization plan
  - explicit trace visibility for that plan
  - preserved benchmark override surfaces

  That is the right next step before trying to generalize a broader runtime
  materialization planner across more operator families.