### PR TITLE
Normalize Rust WAM foreign results around tuple layouts and direct wrappers

### DIFF
--- a/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
+++ b/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
@@ -301,15 +301,16 @@ compiler now prefers the foreign path over earlier generic native clause
 lowering. That keeps recognized recursive kernels on the tested runtime path
 instead of silently taking a less structured lowering tier first.
 
-The runtime now also uses a small foreign-result layout layer:
+The runtime now also uses a tuple-shaped foreign-result layout layer:
 
-- `single` for one output register
-- `pair` for two-output payloads packed into one foreign result item
-- `triple` for three-output payloads packed into one foreign result item
+- `tuple:1` for one output register
+- `tuple:2` for two-output payloads packed into one foreign result item
+- `tuple:3` for three-output payloads packed into one foreign result item
 
 That replaces the older kernel-specific resume branching for result shape and
-makes additional kernels cheaper to add as long as they fit an existing result
-layout. `tc_parent_distance/4` is the first kernel using the `triple` path.
+makes additional kernels cheaper to add without adding another arity-specific
+resume path. `tc_parent_distance/4` is the first kernel using the `tuple:3`
+path.
 
 The reverse transitive-closure path required an additional correctness fix:
 reverse schemas must register fact pairs in `child -> parent` orientation, and

--- a/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
+++ b/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
@@ -283,6 +283,7 @@ The current test coverage now includes:
 - compiler-selection tests for:
   - `category_ancestor/4`
   - `tail_suffix/2`
+  - `tail_suffixes/2`
   - `tri_sum/2`
   - `tc_ancestor/2`
   - `tc_descendant/2`
@@ -290,6 +291,7 @@ The current test coverage now includes:
   - `tc_parent_distance/4`
 - end-to-end generated Rust runtime validation for:
   - `tail_suffix/2`
+  - `tail_suffixes/2`
   - `tri_sum/2`
   - `tc_ancestor/2`
   - `tc_descendant/2`
@@ -301,7 +303,9 @@ compiler now prefers the foreign path over earlier generic native clause
 lowering. That keeps recognized recursive kernels on the tested runtime path
 instead of silently taking a less structured lowering tier first.
 
-The runtime now also uses a tuple-shaped foreign-result layout layer:
+The runtime now separates result shape from result-delivery mode.
+
+The tuple-shaped foreign-result layout layer is:
 
 - `tuple:1` for one output register
 - `tuple:2` for two-output payloads packed into one foreign result item
@@ -311,6 +315,15 @@ That replaces the older kernel-specific resume branching for result shape and
 makes additional kernels cheaper to add without adding another arity-specific
 resume path. `tc_parent_distance/4` is the first kernel using the `tuple:3`
 path.
+
+Foreign result delivery now also distinguishes:
+
+- `stream` for predicates that yield one tuple per solution through backtracking
+- `deterministic` for single-result predicates like `tri_sum/2`
+- `deterministic_collection` for predicates that return one collection payload
+  without leaving residual backtracking state
+
+`tail_suffixes/2` is the first deterministic collection kernel on this path.
 
 The reverse transitive-closure path required an additional correctness fix:
 reverse schemas must register fact pairs in `child -> parent` orientation, and

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3720,6 +3720,7 @@ rust_recursive_kernel(Pred, Arity, Clauses, Kernel) :-
 rust_recursive_kernel_detector(category_ancestor, rust_recursive_kernel_category_ancestor).
 rust_recursive_kernel_detector(countdown_sum2, rust_recursive_kernel_countdown_sum).
 rust_recursive_kernel_detector(list_suffix2, rust_recursive_kernel_list_suffix).
+rust_recursive_kernel_detector(list_suffixes2, rust_recursive_kernel_list_suffixes).
 rust_recursive_kernel_detector(transitive_closure2, rust_recursive_kernel_transitive_closure).
 rust_recursive_kernel_detector(transitive_distance3, rust_recursive_kernel_transitive_distance).
 rust_recursive_kernel_detector(transitive_parent_distance4, rust_recursive_kernel_transitive_parent_distance).
@@ -3732,15 +3733,18 @@ rust_recursive_kernel_spec(
 
 rust_recursive_kernel_setup_ops(KernelKind, PredIndicator, KernelConfig,
         [ register_foreign_native_kind(PredIndicator, NativeKind),
-          register_foreign_result_layout(PredIndicator, ResultLayout)
+          register_foreign_result_layout(PredIndicator, ResultLayout),
+          register_foreign_result_mode(PredIndicator, ResultMode)
         |ConfigOps]) :-
     rust_recursive_kernel_native_kind(KernelKind, NativeKind),
     rust_recursive_kernel_result_layout(KernelKind, ResultLayout),
+    rust_recursive_kernel_result_mode(KernelKind, ResultMode),
     rust_recursive_kernel_config_ops(KernelKind, PredIndicator, KernelConfig, ConfigOps).
 
 rust_recursive_kernel_native_kind(category_ancestor, category_ancestor).
 rust_recursive_kernel_native_kind(countdown_sum2, countdown_sum2).
 rust_recursive_kernel_native_kind(list_suffix2, list_suffix2).
+rust_recursive_kernel_native_kind(list_suffixes2, list_suffixes2).
 rust_recursive_kernel_native_kind(transitive_closure2, transitive_closure2).
 rust_recursive_kernel_native_kind(transitive_distance3, transitive_distance3).
 rust_recursive_kernel_native_kind(transitive_parent_distance4, transitive_parent_distance4).
@@ -3748,15 +3752,25 @@ rust_recursive_kernel_native_kind(transitive_parent_distance4, transitive_parent
 rust_recursive_kernel_result_layout(category_ancestor, tuple(1)).
 rust_recursive_kernel_result_layout(countdown_sum2, tuple(1)).
 rust_recursive_kernel_result_layout(list_suffix2, tuple(1)).
+rust_recursive_kernel_result_layout(list_suffixes2, tuple(1)).
 rust_recursive_kernel_result_layout(transitive_closure2, tuple(1)).
 rust_recursive_kernel_result_layout(transitive_distance3, tuple(2)).
 rust_recursive_kernel_result_layout(transitive_parent_distance4, tuple(3)).
+
+rust_recursive_kernel_result_mode(category_ancestor, stream).
+rust_recursive_kernel_result_mode(countdown_sum2, deterministic).
+rust_recursive_kernel_result_mode(list_suffix2, stream).
+rust_recursive_kernel_result_mode(list_suffixes2, deterministic_collection).
+rust_recursive_kernel_result_mode(transitive_closure2, stream).
+rust_recursive_kernel_result_mode(transitive_distance3, stream).
+rust_recursive_kernel_result_mode(transitive_parent_distance4, stream).
 
 rust_recursive_kernel_config_ops(category_ancestor, category_ancestor/4,
         [max_depth(MaxDepth)],
         [register_foreign_usize_config(category_ancestor/4, max_depth, MaxDepth)]).
 rust_recursive_kernel_config_ops(countdown_sum2, _PredIndicator, [], []).
 rust_recursive_kernel_config_ops(list_suffix2, _PredIndicator, [], []).
+rust_recursive_kernel_config_ops(list_suffixes2, _PredIndicator, [], []).
 rust_recursive_kernel_config_ops(transitive_closure2, PredIndicator,
         KernelConfig, ConfigOps) :-
     rust_recursive_kernel_binary_edge_config_ops(PredIndicator, KernelConfig, ConfigOps).
@@ -3786,6 +3800,10 @@ rust_recursive_kernel_countdown_sum(Pred, Arity, Clauses,
 rust_recursive_kernel_list_suffix(Pred, Arity, Clauses,
         recursive_kernel(list_suffix2, Pred/Arity, [])) :-
     rust_foreign_lowerable_list_suffix(Pred, Arity, Clauses).
+
+rust_recursive_kernel_list_suffixes(Pred, Arity, Clauses,
+        recursive_kernel(list_suffixes2, Pred/Arity, [])) :-
+    rust_foreign_lowerable_list_suffixes(Pred, Arity, Clauses).
 
 rust_recursive_kernel_transitive_closure(Pred, Arity, Clauses,
         recursive_kernel(transitive_closure2, Pred/Arity,
@@ -3838,6 +3856,13 @@ rust_foreign_lowerable_list_suffix(Pred, 2, Clauses) :-
     RecHead =.. [Pred, InputList, Suffix],
     InputList = [_|Tail],
     RecBody =.. [Pred, Tail, Suffix].
+
+rust_foreign_lowerable_list_suffixes(Pred, 2, Clauses) :-
+    member(BaseHead-true, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseHead =.. [Pred, [], [[]]],
+    RecHead =.. [Pred, [Head|Tail], [[Head|Tail]|Rest]],
+    RecBody =.. [Pred, Tail, Rest].
 
 rust_foreign_lowerable_transitive_closure(Pred, 2, Clauses, EdgePred/2, FactPairs) :-
     member(BaseHead-BaseBody, Clauses),

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3745,12 +3745,12 @@ rust_recursive_kernel_native_kind(transitive_closure2, transitive_closure2).
 rust_recursive_kernel_native_kind(transitive_distance3, transitive_distance3).
 rust_recursive_kernel_native_kind(transitive_parent_distance4, transitive_parent_distance4).
 
-rust_recursive_kernel_result_layout(category_ancestor, single).
-rust_recursive_kernel_result_layout(countdown_sum2, single).
-rust_recursive_kernel_result_layout(list_suffix2, single).
-rust_recursive_kernel_result_layout(transitive_closure2, single).
-rust_recursive_kernel_result_layout(transitive_distance3, pair).
-rust_recursive_kernel_result_layout(transitive_parent_distance4, triple).
+rust_recursive_kernel_result_layout(category_ancestor, tuple(1)).
+rust_recursive_kernel_result_layout(countdown_sum2, tuple(1)).
+rust_recursive_kernel_result_layout(list_suffix2, tuple(1)).
+rust_recursive_kernel_result_layout(transitive_closure2, tuple(1)).
+rust_recursive_kernel_result_layout(transitive_distance3, tuple(2)).
+rust_recursive_kernel_result_layout(transitive_parent_distance4, tuple(3)).
 
 rust_recursive_kernel_config_ops(category_ancestor, category_ancestor/4,
         [max_depth(MaxDepth)],

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -785,6 +785,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
     compile_execute_foreign_predicate_to_rust(ForeignCode),
     compile_resume_builtin_to_rust(ResumeCode),
     compile_foreign_result_helpers_to_rust(ForeignResultHelpersCode),
+    compile_parse_foreign_tuple_layout_to_rust(ForeignTupleLayoutCode),
     compile_collect_native_category_ancestor_to_rust(NativeAncestorCode),
     compile_compute_native_countdown_sum_to_rust(NativeCountdownSumCode),
     compile_collect_native_list_suffixes_to_rust(NativeListSuffixCode),
@@ -805,6 +806,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
         ForeignCode, '\n\n',
         ResumeCode, '\n\n',
         ForeignResultHelpersCode, '\n\n',
+        ForeignTupleLayoutCode, '\n\n',
         NativeAncestorCode, '\n\n',
         NativeCountdownSumCode, '\n\n',
         NativeListSuffixCode, '\n\n',
@@ -1091,7 +1093,9 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                 if hops.is_empty() {
                     return false;
                 }
-                let results: Vec<Value> = hops.into_iter().map(Value::Integer).collect();
+                let results: Vec<Value> = hops.into_iter().map(|hop| {
+                    Value::Str("__tuple__".to_string(), vec![Value::Integer(hop)])
+                }).collect();
                 self.finish_foreign_results(&pred_key, vec![hops_reg], results)
             }
             "countdown_sum2" => {
@@ -1107,7 +1111,9 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                     Some(sum) => sum,
                     None => return false,
                 };
-                self.finish_foreign_results(&pred_key, vec![sum_reg], vec![Value::Integer(sum)])
+                self.finish_foreign_results(&pred_key, vec![sum_reg], vec![
+                    Value::Str("__tuple__".to_string(), vec![Value::Integer(sum)])
+                ])
             }
             "list_suffix2" => {
                 let items = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
@@ -1131,7 +1137,10 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                 if suffixes.is_empty() {
                     return false;
                 }
-                self.finish_foreign_results(&pred_key, vec![suffix_reg], suffixes)
+                let results: Vec<Value> = suffixes.into_iter().map(|suffix| {
+                    Value::Str("__tuple__".to_string(), vec![suffix])
+                }).collect();
+                self.finish_foreign_results(&pred_key, vec![suffix_reg], results)
             }
             "transitive_closure2" => {
                 let start = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
@@ -1159,7 +1168,9 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                 if nodes.is_empty() {
                     return false;
                 }
-                let results: Vec<Value> = nodes.into_iter().map(Value::Atom).collect();
+                let results: Vec<Value> = nodes.into_iter().map(|node| {
+                    Value::Str("__tuple__".to_string(), vec![Value::Atom(node)])
+                }).collect();
                 self.finish_foreign_results(&pred_key, vec![target_reg], results)
             }
             "transitive_distance3" => {
@@ -1193,7 +1204,7 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                     return false;
                 }
                 let packed_results: Vec<Value> = results.into_iter().map(|(node, dist)| {
-                    Value::Str("__pair__".to_string(), vec![
+                    Value::Str("__tuple__".to_string(), vec![
                         Value::Atom(node),
                         Value::Integer(dist),
                     ])
@@ -1235,7 +1246,7 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                     return false;
                 }
                 let packed_results: Vec<Value> = results.into_iter().map(|(node, parent, dist)| {
-                    Value::Str("__triple__".to_string(), vec![
+                    Value::Str("__tuple__".to_string(), vec![
                         Value::Atom(node),
                         Value::Atom(parent),
                         Value::Integer(dist),
@@ -1287,43 +1298,30 @@ compile_foreign_result_helpers_to_rust(Code) :-
         result_regs: &[Value],
         result: &Value,
     ) -> bool {
-        let layout = match self.foreign_result_layout(pred_key) {
-            Some(layout) => layout,
+        let tuple_arity = match self.foreign_result_layout(pred_key)
+            .and_then(Self::parse_foreign_tuple_layout) {
+            Some(arity) => arity,
             None => return false,
         };
-        match layout {
-            "single" => {
-                if result_regs.len() != 1 {
-                    return false;
-                }
-                self.unify(&result_regs[0], result)
-            }
-            "pair" => {
-                if result_regs.len() != 2 {
-                    return false;
-                }
-                match result {
-                    Value::Str(functor, args) if functor == "__pair__" && args.len() == 2 => {
-                        self.unify(&result_regs[0], &args[0]) && self.unify(&result_regs[1], &args[1])
+        if result_regs.len() != tuple_arity {
+            return false;
+        }
+        match result {
+            Value::Str(functor, args) if functor == "__tuple__" && args.len() == tuple_arity => {
+                for (reg, arg) in result_regs.iter().zip(args.iter()) {
+                    if !self.unify(reg, arg) {
+                        return false;
                     }
-                    _ => false,
                 }
-            }
-            "triple" => {
-                if result_regs.len() != 3 {
-                    return false;
-                }
-                match result {
-                    Value::Str(functor, args) if functor == "__triple__" && args.len() == 3 => {
-                        self.unify(&result_regs[0], &args[0])
-                            && self.unify(&result_regs[1], &args[1])
-                            && self.unify(&result_regs[2], &args[2])
-                    }
-                    _ => false,
-                }
+                true
             }
             _ => false,
         }
+    }'.
+
+compile_parse_foreign_tuple_layout_to_rust(Code) :-
+    Code = '    fn parse_foreign_tuple_layout(layout: &str) -> Option<usize> {
+        layout.strip_prefix("tuple:")?.parse::<usize>().ok()
     }'.
 
 compile_collect_native_category_ancestor_to_rust(Code) :-
@@ -1893,8 +1891,9 @@ rust_foreign_setup_line(register_foreign_native_kind(Pred/Arity, Kind), Line) :-
     format(string(Line),
         '    vm.register_foreign_native_kind("~w/~w", "~w");', [Pred, Arity, Kind]).
 rust_foreign_setup_line(register_foreign_result_layout(Pred/Arity, Layout), Line) :-
+    rust_foreign_result_layout_literal(Layout, LayoutLiteral),
     format(string(Line),
-        '    vm.register_foreign_result_layout("~w/~w", "~w");', [Pred, Arity, Layout]).
+        '    vm.register_foreign_result_layout("~w/~w", "~w");', [Pred, Arity, LayoutLiteral]).
 rust_foreign_setup_line(register_foreign_string_config(Pred/Arity, Key, ValuePred/ValueArity), Line) :-
     format(string(Line),
         '    vm.register_foreign_string_config("~w/~w", "~w", "~w/~w");',
@@ -1921,6 +1920,10 @@ rust_fact_pair_literal(Left-Right, Literal) :-
     escape_rust_string(Left, ELeft),
     escape_rust_string(Right, ERight),
     format(string(Literal), '("~w", "~w")', [ELeft, ERight]).
+
+rust_foreign_result_layout_literal(tuple(Arity), Literal) :-
+    format(string(Literal), 'tuple:~w', [Arity]).
+rust_foreign_result_layout_literal(Layout, Layout).
 
 %% wam_code_to_rust_instructions(+WamCodeStr, +PredIndicator, +Options, -InstrLiterals, -LabelLiterals)
 %  Parses a WAM code string and generates Rust vec![] entries and label map inserts.

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1142,6 +1142,20 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                 }).collect();
                 self.finish_foreign_results(&pred_key, vec![suffix_reg], results)
             }
+            "list_suffixes2" => {
+                let items = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
+                    Some(Value::List(items)) => items,
+                    _ => return false,
+                };
+                let suffixes_reg = match self.regs.get("A2").cloned() {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let mut suffixes: Vec<Value> = Vec::new();
+                self.collect_native_list_suffixes(&items, &mut suffixes);
+                let result = Value::Str("__tuple__".to_string(), vec![Value::List(suffixes)]);
+                self.finish_foreign_results(&pred_key, vec![suffixes_reg], vec![result])
+            }
             "transitive_closure2" => {
                 let start = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
                     Some(Value::Atom(start)) => start,
@@ -1265,31 +1279,46 @@ compile_foreign_result_helpers_to_rust(Code) :-
         result_regs: Vec<Value>,
         results: Vec<Value>,
     ) -> bool {
+        let result_mode = match self.foreign_result_mode(pred_key) {
+            Some(mode) => mode,
+            None => "stream",
+        };
         if results.is_empty() {
             return false;
         }
-        if results.len() > 1 {
-            self.choice_points.push(ChoicePoint {
-                next_pc: self.pc,
-                saved_args: self.save_regs(),
-                stack: self.stack.clone(),
-                cp: self.cp,
-                trail_len: self.trail.len(),
-                heap_len: self.heap.len(),
-                builtin_state: Some(BuiltinState {
-                    name: "foreign_results".to_string(),
-                    args: {
-                        let mut args = Vec::with_capacity(result_regs.len() + 1);
-                        args.push(Value::Atom(pred_key.to_string()));
-                        args.extend(result_regs.iter().cloned());
-                        args
-                    },
-                    data: results[1..].to_vec(),
-                }),
-                cut_barrier: self.cut_barrier,
-            });
+        match result_mode {
+            "stream" => {
+                if results.len() > 1 {
+                    self.choice_points.push(ChoicePoint {
+                        next_pc: self.pc,
+                        saved_args: self.save_regs(),
+                        stack: self.stack.clone(),
+                        cp: self.cp,
+                        trail_len: self.trail.len(),
+                        heap_len: self.heap.len(),
+                        builtin_state: Some(BuiltinState {
+                            name: "foreign_results".to_string(),
+                            args: {
+                                let mut args = Vec::with_capacity(result_regs.len() + 1);
+                                args.push(Value::Atom(pred_key.to_string()));
+                                args.extend(result_regs.iter().cloned());
+                                args
+                            },
+                            data: results[1..].to_vec(),
+                        }),
+                        cut_barrier: self.cut_barrier,
+                    });
+                }
+                self.apply_foreign_result(pred_key, &result_regs, &results[0])
+            }
+            "deterministic" | "deterministic_collection" => {
+                if results.len() != 1 {
+                    return false;
+                }
+                self.apply_foreign_result(pred_key, &result_regs, &results[0])
+            }
+            _ => false,
         }
-        self.apply_foreign_result(pred_key, &result_regs, &results[0])
     }
 
     fn apply_foreign_result(
@@ -1894,6 +1923,9 @@ rust_foreign_setup_line(register_foreign_result_layout(Pred/Arity, Layout), Line
     rust_foreign_result_layout_literal(Layout, LayoutLiteral),
     format(string(Line),
         '    vm.register_foreign_result_layout("~w/~w", "~w");', [Pred, Arity, LayoutLiteral]).
+rust_foreign_setup_line(register_foreign_result_mode(Pred/Arity, Mode), Line) :-
+    format(string(Line),
+        '    vm.register_foreign_result_mode("~w/~w", "~w");', [Pred, Arity, Mode]).
 rust_foreign_setup_line(register_foreign_string_config(Pred/Arity, Key, ValuePred/ValueArity), Line) :-
     format(string(Line),
         '    vm.register_foreign_string_config("~w/~w", "~w", "~w/~w");',
@@ -1950,7 +1982,10 @@ wam_lines_to_rust([Line|Rest], PC, PredIndicator, Options, Instrs, Labels) :-
             wam_lines_to_rust(Rest, PC, PredIndicator, Options, Instrs, RestLabels)
         ;   % Instruction line
             wam_line_to_rust_instr(CleanParts, PredIndicator, Options, RustInstr),
-            format(string(InstrEntry), '        ~w,', [RustInstr]),
+            (   sub_string(RustInstr, 0, _, _, "/*")
+            ->  format(string(InstrEntry), '        ~w', [RustInstr])
+            ;   format(string(InstrEntry), '        ~w,', [RustInstr])
+            ),
             NPC is PC + 1,
             Instrs = [InstrEntry|RestInstrs],
             wam_lines_to_rust(Rest, NPC, PredIndicator, Options, RestInstrs, Labels)

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1873,34 +1873,38 @@ compile_wam_predicate_to_rust(Pred/Arity, WamCode, Options, RustCode) :-
     atom_string(Pred, PredStr),
     build_rust_wam_arg_list(Arity, ArgList),
     build_rust_wam_arg_setup(Arity, ArgSetup),
-    % Convert WAM instruction string to Rust Instruction enum literals
-    wam_code_to_rust_instructions(WamCode, Pred/Arity, Options, InstrLiterals, LabelLiterals),
-    foreign_wrapper_setup(Pred/Arity, Options, ForeignSetup, RunExpr),
+    foreign_wrapper_setup(Pred/Arity, WamCode, Options, InstrSetup, ForeignSetup, RunExpr),
     format(string(RustCode),
 '/// WAM-compiled predicate: ~w/~w
 /// Compiled via WAM for predicates that resist native lowering.
 pub fn ~w(~w) -> bool {
     use std::collections::HashMap;
-    let code: Vec<Instruction> = vec![
+~w
+~w
+~w
+    ~w
+}', [PredStr, Arity, PredStr, ArgList, InstrSetup, ForeignSetup, ArgSetup, RunExpr]).
+
+foreign_wrapper_setup(Pred/Arity, WamCode, Options, InstrSetup, Setup, RunExpr) :-
+    (   option(foreign_lowering(ForeignSpec), Options),
+        rust_foreign_spec(Pred/Arity, ForeignSpec, SetupOps, EntryPred/EntryArity)
+    ->  InstrSetup = '    vm.code = Vec::new();
+    vm.labels = HashMap::new();
+    vm.pc = 1;',
+        rust_foreign_setup_code(SetupOps, Setup),
+        format(string(RunExpr),
+            'vm.execute_foreign_predicate("~w", ~w)', [EntryPred, EntryArity])
+    ;   wam_code_to_rust_instructions(WamCode, Pred/Arity, Options, InstrLiterals, LabelLiterals),
+        format(string(InstrSetup),
+'    let code: Vec<Instruction> = vec![
 ~w
     ];
     let mut labels: HashMap<String, usize> = HashMap::new();
 ~w
     vm.code = code;
     vm.labels = labels;
-    vm.pc = 1;
-~w
-~w
-    ~w
-}', [PredStr, Arity, PredStr, ArgList, InstrLiterals, LabelLiterals, ForeignSetup, ArgSetup, RunExpr]).
-
-foreign_wrapper_setup(Pred/Arity, Options, Setup, RunExpr) :-
-    (   option(foreign_lowering(ForeignSpec), Options),
-        rust_foreign_spec(Pred/Arity, ForeignSpec, SetupOps, EntryPred/EntryArity)
-    ->  rust_foreign_setup_code(SetupOps, Setup),
-        format(string(RunExpr),
-            'vm.execute_foreign_predicate("~w", ~w)', [EntryPred, EntryArity])
-    ;   Setup = "",
+    vm.pc = 1;', [InstrLiterals, LabelLiterals]),
+        Setup = "",
         RunExpr = 'vm.run()'
     ).
 

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -87,6 +87,7 @@ pub struct WamState {
     /// Foreign predicate usize configs keyed by "name/arity#config".
     pub foreign_usize_configs: HashMap<String, usize>,
     /// Foreign predicate result layouts keyed by "name/arity".
+    /// Layouts are encoded as "tuple:N".
     pub foreign_result_layouts: HashMap<String, String>,
     /// Variable binding table: maps Unbound variable names to their bound values.
     /// This simulates the WAM heap's shared binding semantics when PutVariable
@@ -206,12 +207,12 @@ impl WamState {
             .copied()
     }
 
-    /// Register a result layout for a foreign predicate.
+    /// Register a tuple layout for a foreign predicate.
     pub fn register_foreign_result_layout(&mut self, pred: &str, layout: &str) {
         self.foreign_result_layouts.insert(pred.to_string(), layout.to_string());
     }
 
-    /// Fetch the result layout for a foreign predicate.
+    /// Fetch the tuple layout for a foreign predicate.
     pub fn foreign_result_layout(&self, pred: &str) -> Option<&str> {
         self.foreign_result_layouts.get(pred).map(|layout| layout.as_str())
     }

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -89,6 +89,8 @@ pub struct WamState {
     /// Foreign predicate result layouts keyed by "name/arity".
     /// Layouts are encoded as "tuple:N".
     pub foreign_result_layouts: HashMap<String, String>,
+    /// Foreign predicate result-delivery modes keyed by "name/arity".
+    pub foreign_result_modes: HashMap<String, String>,
     /// Variable binding table: maps Unbound variable names to their bound values.
     /// This simulates the WAM heap's shared binding semantics when PutVariable
     /// creates a variable that's stored in both a Y-register and an A-register.
@@ -129,6 +131,7 @@ impl WamState {
             foreign_string_configs: HashMap::new(),
             foreign_usize_configs: HashMap::new(),
             foreign_result_layouts: HashMap::new(),
+            foreign_result_modes: HashMap::new(),
             bindings: HashMap::new(),
             var_counter: 0,
             cut_barrier: 0,
@@ -215,6 +218,16 @@ impl WamState {
     /// Fetch the tuple layout for a foreign predicate.
     pub fn foreign_result_layout(&self, pred: &str) -> Option<&str> {
         self.foreign_result_layouts.get(pred).map(|layout| layout.as_str())
+    }
+
+    /// Register a result-delivery mode for a foreign predicate.
+    pub fn register_foreign_result_mode(&mut self, pred: &str, mode: &str) {
+        self.foreign_result_modes.insert(pred.to_string(), mode.to_string());
+    }
+
+    /// Fetch the result-delivery mode for a foreign predicate.
+    pub fn foreign_result_mode(&self, pred: &str) -> Option<&str> {
+        self.foreign_result_modes.get(pred).map(|mode| mode.as_str())
     }
 
     /// Dereference an Unbound variable through the binding table.

--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -64,6 +64,10 @@ tri_sum(N, Sum) :-
 tail_suffix(S, S).
 tail_suffix([_|T], S) :- tail_suffix(T, S).
 
+:- dynamic tail_suffixes/2.
+tail_suffixes([], [[]]).
+tail_suffixes([H|T], [[H|T]|Rest]) :- tail_suffixes(T, Rest).
+
 %% Integration test
 test_runtime_execution :-
     Test = 'WAM-Rust Runtime: end-to-end execution',
@@ -74,7 +78,7 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tri_sum/2, user:tail_suffix/2],
+        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2],
             [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
@@ -89,6 +93,7 @@ use runtime_test::tc_distance;
 use runtime_test::tc_parent_distance;
 use runtime_test::tri_sum;
 use runtime_test::tail_suffix;
+use runtime_test::tail_suffixes;
 
 #[test]
 fn test_generated_predicates() {
@@ -347,6 +352,34 @@ fn test_generated_predicates() {
         list_abc,
         Value::List(vec![Value::Atom("d".to_string())]));
     assert!(!ok15, "tail_suffix([a,b,c], [d]) should fail");
+
+    // Test tail_suffixes/2 deterministic collection foreign lowering end-to-end
+    let mut vm_suffixes = WamState::new(vec![], std::collections::HashMap::new());
+    let ok16 = tail_suffixes(&mut vm_suffixes,
+        Value::List(vec![
+            Value::Atom("a".to_string()),
+            Value::Atom("b".to_string()),
+            Value::Atom("c".to_string()),
+        ]),
+        Value::Unbound("Suffixes".to_string()));
+    assert!(ok16, "tail_suffixes([a,b,c], Suffixes) should succeed");
+    match vm_suffixes.bindings.get("Suffixes").cloned() {
+        Some(Value::List(items)) => assert_eq!(items, vec![
+            Value::List(vec![
+                Value::Atom("a".to_string()),
+                Value::Atom("b".to_string()),
+                Value::Atom("c".to_string()),
+            ]),
+            Value::List(vec![
+                Value::Atom("b".to_string()),
+                Value::Atom("c".to_string()),
+            ]),
+            Value::List(vec![Value::Atom("c".to_string())]),
+            Value::List(vec![]),
+        ]),
+        other => panic!("expected deterministic suffix collection in Suffixes, got {:?}", other),
+    }
+    assert!(!vm_suffixes.backtrack(), "tail_suffixes/2 should not leave backtracking results behind");
 }
 ',
         setup_call_cleanup(open(TestPath, write, S), format(S, "~w", [TestContent]), close(S)),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -270,7 +270,7 @@ test_foreign_spec_wrapper_generation :-
         sub_string(S, _, _, _, 'register_foreign_result_mode("category_ancestor/4", "stream")'),
         sub_string(S, _, _, _, 'register_foreign_usize_config("category_ancestor/4", "max_depth", 10)'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("category_ancestor", 4)'),
-        sub_string(S, _, _, _, 'Instruction::CallForeign("category_ancestor".to_string(), 4)')
+        sub_string(S, _, _, _, 'vm.code = Vec::new();')
     ->  pass(Test)
     ;   fail_test(Test, 'Generic foreign spec did not drive wrapper generation')
     ).
@@ -447,9 +447,10 @@ test_foreign_lowering_category_ancestor :-
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("category_ancestor/4", "category_ancestor")'),
         sub_string(S, _, _, _, 'register_foreign_result_layout("category_ancestor/4", "tuple:1")'),
+        sub_string(S, _, _, _, 'register_foreign_result_mode("category_ancestor/4", "stream")'),
         sub_string(S, _, _, _, 'register_foreign_usize_config("category_ancestor/4", "max_depth", 10)'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("category_ancestor", 4)'),
-        sub_string(S, _, _, _, 'Instruction::CallForeign("category_ancestor".to_string(), 4)')
+        sub_string(S, _, _, _, 'vm.code = Vec::new();')
     ->  pass(Test)
     ;   fail_test(Test, 'Foreign lowering was not selected for category_ancestor/4')
     ).
@@ -461,10 +462,11 @@ test_foreign_lowering_transitive_closure :-
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tc_ancestor/2", "transitive_closure2")'),
         sub_string(S, _, _, _, 'register_foreign_result_layout("tc_ancestor/2", "tuple:1")'),
+        sub_string(S, _, _, _, 'register_foreign_result_mode("tc_ancestor/2", "stream")'),
         sub_string(S, _, _, _, 'register_foreign_string_config("tc_ancestor/2", "edge_pred", "tc_parent/2")'),
         sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("tc_parent/2", &[("tom", "bob"), ("tom", "liz"), ("bob", "ann"), ("bob", "pat"), ("pat", "jim")])'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tc_ancestor", 2)'),
-        sub_string(S, _, _, _, 'Instruction::CallForeign("tc_ancestor".to_string(), 2)')
+        sub_string(S, _, _, _, 'vm.code = Vec::new();')
     ->  pass(Test)
     ;   fail_test(Test, 'Foreign lowering was not selected for tc_ancestor/2')
     ).
@@ -476,8 +478,9 @@ test_foreign_lowering_countdown_sum :-
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tri_sum/2", "countdown_sum2")'),
         sub_string(S, _, _, _, 'register_foreign_result_layout("tri_sum/2", "tuple:1")'),
+        sub_string(S, _, _, _, 'register_foreign_result_mode("tri_sum/2", "deterministic")'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tri_sum", 2)'),
-        sub_string(S, _, _, _, 'Instruction::CallForeign("tri_sum".to_string(), 2)')
+        sub_string(S, _, _, _, 'vm.code = Vec::new();')
     ->  pass(Test)
     ;   fail_test(Test, 'Foreign lowering was not selected for tri_sum/2')
     ).
@@ -489,8 +492,9 @@ test_foreign_lowering_list_suffix :-
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tail_suffix/2", "list_suffix2")'),
         sub_string(S, _, _, _, 'register_foreign_result_layout("tail_suffix/2", "tuple:1")'),
+        sub_string(S, _, _, _, 'register_foreign_result_mode("tail_suffix/2", "stream")'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tail_suffix", 2)'),
-        sub_string(S, _, _, _, 'Instruction::CallForeign("tail_suffix".to_string(), 2)')
+        sub_string(S, _, _, _, 'vm.code = Vec::new();')
     ->  pass(Test)
     ;   fail_test(Test, 'Foreign lowering was not selected for tail_suffix/2')
     ).
@@ -504,7 +508,7 @@ test_foreign_lowering_list_suffixes :-
         sub_string(S, _, _, _, 'register_foreign_result_layout("tail_suffixes/2", "tuple:1")'),
         sub_string(S, _, _, _, 'register_foreign_result_mode("tail_suffixes/2", "deterministic_collection")'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tail_suffixes", 2)'),
-        sub_string(S, _, _, _, 'Instruction::CallForeign("tail_suffixes".to_string(), 2)')
+        sub_string(S, _, _, _, 'vm.code = Vec::new();')
     ->  pass(Test)
     ;   fail_test(Test, 'Foreign lowering was not selected for tail_suffixes/2')
     ).
@@ -516,10 +520,11 @@ test_foreign_lowering_reverse_transitive_closure :-
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tc_descendant/2", "transitive_closure2")'),
         sub_string(S, _, _, _, 'register_foreign_result_layout("tc_descendant/2", "tuple:1")'),
+        sub_string(S, _, _, _, 'register_foreign_result_mode("tc_descendant/2", "stream")'),
         sub_string(S, _, _, _, 'register_foreign_string_config("tc_descendant/2", "edge_pred", "tc_parent/2")'),
         sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("tc_parent/2", &[("bob", "tom"), ("liz", "tom"), ("ann", "bob"), ("pat", "bob"), ("jim", "pat")])'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tc_descendant", 2)'),
-        sub_string(S, _, _, _, 'Instruction::CallForeign("tc_descendant".to_string(), 2)')
+        sub_string(S, _, _, _, 'vm.code = Vec::new();')
     ->  pass(Test)
     ;   fail_test(Test, 'Foreign lowering was not selected for tc_descendant/2')
     ).
@@ -531,10 +536,11 @@ test_foreign_lowering_transitive_distance :-
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tc_distance/3", "transitive_distance3")'),
         sub_string(S, _, _, _, 'register_foreign_result_layout("tc_distance/3", "tuple:2")'),
+        sub_string(S, _, _, _, 'register_foreign_result_mode("tc_distance/3", "stream")'),
         sub_string(S, _, _, _, 'register_foreign_string_config("tc_distance/3", "edge_pred", "tc_parent/2")'),
         sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("tc_parent/2", &[("tom", "bob"), ("tom", "liz"), ("bob", "ann"), ("bob", "pat"), ("pat", "jim")])'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tc_distance", 3)'),
-        sub_string(S, _, _, _, 'Instruction::CallForeign("tc_distance".to_string(), 3)')
+        sub_string(S, _, _, _, 'vm.code = Vec::new();')
     ->  pass(Test)
     ;   fail_test(Test, 'Foreign lowering was not selected for tc_distance/3')
     ).
@@ -546,9 +552,10 @@ test_foreign_lowering_transitive_parent_distance :-
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tc_parent_distance/4", "transitive_parent_distance4")'),
         sub_string(S, _, _, _, 'register_foreign_result_layout("tc_parent_distance/4", "tuple:3")'),
+        sub_string(S, _, _, _, 'register_foreign_result_mode("tc_parent_distance/4", "stream")'),
         sub_string(S, _, _, _, 'register_foreign_string_config("tc_parent_distance/4", "edge_pred", "tc_parent/2")'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tc_parent_distance", 4)'),
-        sub_string(S, _, _, _, 'Instruction::CallForeign("tc_parent_distance".to_string(), 4)')
+        sub_string(S, _, _, _, 'vm.code = Vec::new();')
     ->  pass(Test)
     ;   fail_test(Test, 'Foreign lowering was not selected for tc_parent_distance/4')
     ).

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -251,7 +251,7 @@ test_foreign_spec_wrapper_generation :-
     ForeignSpec = foreign_predicate(
         category_ancestor/4,
         [ register_foreign_native_kind(category_ancestor/4, category_ancestor),
-          register_foreign_result_layout(category_ancestor/4, single),
+          register_foreign_result_layout(category_ancestor/4, tuple(1)),
           register_foreign_usize_config(category_ancestor/4, max_depth, 10)
         ],
         [category_ancestor/4]
@@ -261,7 +261,7 @@ test_foreign_spec_wrapper_generation :-
             [foreign_lowering(ForeignSpec)], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("category_ancestor/4", "category_ancestor")'),
-        sub_string(S, _, _, _, 'register_foreign_result_layout("category_ancestor/4", "single")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("category_ancestor/4", "tuple:1")'),
         sub_string(S, _, _, _, 'register_foreign_usize_config("category_ancestor/4", "max_depth", 10)'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("category_ancestor", 4)'),
         sub_string(S, _, _, _, 'Instruction::CallForeign("category_ancestor".to_string(), 4)')
@@ -340,7 +340,7 @@ test_recursive_kernel_spec_generation :-
         ForeignSpec = foreign_predicate(
             tc_parent_distance/4,
             [ register_foreign_native_kind(tc_parent_distance/4, transitive_parent_distance4),
-              register_foreign_result_layout(tc_parent_distance/4, triple),
+              register_foreign_result_layout(tc_parent_distance/4, tuple(3)),
               register_foreign_string_config(tc_parent_distance/4, edge_pred, tc_parent/2),
               register_indexed_atom_fact2(tc_parent/2, ['tom'-'bob', 'bob'-'ann'])
             ],
@@ -433,7 +433,7 @@ test_foreign_lowering_category_ancestor :-
             [include_main(false), foreign_lowering(true)], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("category_ancestor/4", "category_ancestor")'),
-        sub_string(S, _, _, _, 'register_foreign_result_layout("category_ancestor/4", "single")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("category_ancestor/4", "tuple:1")'),
         sub_string(S, _, _, _, 'register_foreign_usize_config("category_ancestor/4", "max_depth", 10)'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("category_ancestor", 4)'),
         sub_string(S, _, _, _, 'Instruction::CallForeign("category_ancestor".to_string(), 4)')
@@ -447,7 +447,7 @@ test_foreign_lowering_transitive_closure :-
             [include_main(false), foreign_lowering(true)], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tc_ancestor/2", "transitive_closure2")'),
-        sub_string(S, _, _, _, 'register_foreign_result_layout("tc_ancestor/2", "single")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("tc_ancestor/2", "tuple:1")'),
         sub_string(S, _, _, _, 'register_foreign_string_config("tc_ancestor/2", "edge_pred", "tc_parent/2")'),
         sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("tc_parent/2", &[("tom", "bob"), ("tom", "liz"), ("bob", "ann"), ("bob", "pat"), ("pat", "jim")])'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tc_ancestor", 2)'),
@@ -462,7 +462,7 @@ test_foreign_lowering_countdown_sum :-
             [include_main(false), foreign_lowering(true)], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tri_sum/2", "countdown_sum2")'),
-        sub_string(S, _, _, _, 'register_foreign_result_layout("tri_sum/2", "single")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("tri_sum/2", "tuple:1")'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tri_sum", 2)'),
         sub_string(S, _, _, _, 'Instruction::CallForeign("tri_sum".to_string(), 2)')
     ->  pass(Test)
@@ -475,7 +475,7 @@ test_foreign_lowering_list_suffix :-
             [include_main(false), foreign_lowering(true)], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tail_suffix/2", "list_suffix2")'),
-        sub_string(S, _, _, _, 'register_foreign_result_layout("tail_suffix/2", "single")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("tail_suffix/2", "tuple:1")'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tail_suffix", 2)'),
         sub_string(S, _, _, _, 'Instruction::CallForeign("tail_suffix".to_string(), 2)')
     ->  pass(Test)
@@ -488,7 +488,7 @@ test_foreign_lowering_reverse_transitive_closure :-
             [include_main(false), foreign_lowering(true)], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tc_descendant/2", "transitive_closure2")'),
-        sub_string(S, _, _, _, 'register_foreign_result_layout("tc_descendant/2", "single")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("tc_descendant/2", "tuple:1")'),
         sub_string(S, _, _, _, 'register_foreign_string_config("tc_descendant/2", "edge_pred", "tc_parent/2")'),
         sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("tc_parent/2", &[("bob", "tom"), ("liz", "tom"), ("ann", "bob"), ("pat", "bob"), ("jim", "pat")])'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tc_descendant", 2)'),
@@ -503,7 +503,7 @@ test_foreign_lowering_transitive_distance :-
             [include_main(false), foreign_lowering(true)], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tc_distance/3", "transitive_distance3")'),
-        sub_string(S, _, _, _, 'register_foreign_result_layout("tc_distance/3", "pair")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("tc_distance/3", "tuple:2")'),
         sub_string(S, _, _, _, 'register_foreign_string_config("tc_distance/3", "edge_pred", "tc_parent/2")'),
         sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("tc_parent/2", &[("tom", "bob"), ("tom", "liz"), ("bob", "ann"), ("bob", "pat"), ("pat", "jim")])'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tc_distance", 3)'),
@@ -518,7 +518,7 @@ test_foreign_lowering_transitive_parent_distance :-
             [include_main(false), foreign_lowering(true)], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("tc_parent_distance/4", "transitive_parent_distance4")'),
-        sub_string(S, _, _, _, 'register_foreign_result_layout("tc_parent_distance/4", "triple")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("tc_parent_distance/4", "tuple:3")'),
         sub_string(S, _, _, _, 'register_foreign_string_config("tc_parent_distance/4", "edge_pred", "tc_parent/2")'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("tc_parent_distance", 4)'),
         sub_string(S, _, _, _, 'Instruction::CallForeign("tc_parent_distance".to_string(), 4)')
@@ -549,8 +549,9 @@ test_compile_wam_runtime_output :-
         sub_string(S, _, _, _, 'foreign_usize_config(&pred_key, "max_depth")'),
         sub_string(S, _, _, _, 'fn finish_foreign_results'),
         sub_string(S, _, _, _, 'fn apply_foreign_result'),
-        sub_string(S, _, _, _, '"triple"'),
-        sub_string(S, _, _, _, '__triple__'),
+        sub_string(S, _, _, _, 'fn parse_foreign_tuple_layout'),
+        sub_string(S, _, _, _, 'tuple:'),
+        sub_string(S, _, _, _, '__tuple__'),
         sub_string(S, _, _, _, 'name: "foreign_results".to_string()'),
         sub_string(S, _, _, _, 'transitive_closure2'),
         sub_string(S, _, _, _, 'collect_native_transitive_closure_nodes'),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -513,6 +513,21 @@ test_foreign_lowering_list_suffixes :-
     ;   fail_test(Test, 'Foreign lowering was not selected for tail_suffixes/2')
     ).
 
+test_foreign_only_wrapper_omits_dead_wam_code :-
+    Test = 'WAM-Rust: foreign-only wrappers omit dead WAM instruction setup',
+    (   rust_target:compile_predicate_to_rust(user:tail_suffixes/2,
+            [include_main(false), foreign_lowering(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'vm.code = Vec::new();'),
+        sub_string(S, _, _, _, 'vm.labels = HashMap::new();'),
+        \+ sub_string(S, _, _, _, 'let code: Vec<Instruction> = vec!['),
+        \+ sub_string(S, _, _, _, 'labels.insert('),
+        \+ sub_string(S, _, _, _, 'switch_on_term'),
+        \+ sub_string(S, _, _, _, 'unknown:')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Foreign-only wrapper still emitted dead WAM setup')
+    ).
+
 test_foreign_lowering_reverse_transitive_closure :-
     Test = 'WAM-Rust: compiler can choose foreign lowering for tc_descendant/2',
     (   rust_target:compile_predicate_to_rust(user:tc_descendant/2,

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -29,6 +29,7 @@ test_simple_fact(foo, bar).
 :- dynamic category_ancestor/4.
 :- dynamic category_parent/2.
 :- dynamic tail_suffix/2.
+:- dynamic tail_suffixes/2.
 :- dynamic tc_ancestor/2.
 :- dynamic tri_sum/2.
 :- dynamic tc_descendant/2.
@@ -45,6 +46,9 @@ category_parent(beta, physics).
 
 tail_suffix(S, S).
 tail_suffix([_|T], S) :- tail_suffix(T, S).
+
+tail_suffixes([], [[]]).
+tail_suffixes([H|T], [[H|T]|Rest]) :- tail_suffixes(T, Rest).
 
 category_ancestor(Cat, Target, 1, Visited) :-
     category_parent(Cat, Target),
@@ -252,6 +256,7 @@ test_foreign_spec_wrapper_generation :-
         category_ancestor/4,
         [ register_foreign_native_kind(category_ancestor/4, category_ancestor),
           register_foreign_result_layout(category_ancestor/4, tuple(1)),
+          register_foreign_result_mode(category_ancestor/4, stream),
           register_foreign_usize_config(category_ancestor/4, max_depth, 10)
         ],
         [category_ancestor/4]
@@ -262,6 +267,7 @@ test_foreign_spec_wrapper_generation :-
         atom_string(Code, S),
         sub_string(S, _, _, _, 'register_foreign_native_kind("category_ancestor/4", "category_ancestor")'),
         sub_string(S, _, _, _, 'register_foreign_result_layout("category_ancestor/4", "tuple:1")'),
+        sub_string(S, _, _, _, 'register_foreign_result_mode("category_ancestor/4", "stream")'),
         sub_string(S, _, _, _, 'register_foreign_usize_config("category_ancestor/4", "max_depth", 10)'),
         sub_string(S, _, _, _, 'execute_foreign_predicate("category_ancestor", 4)'),
         sub_string(S, _, _, _, 'Instruction::CallForeign("category_ancestor".to_string(), 4)')
@@ -297,6 +303,10 @@ test_recursive_kernel_ir_selection :-
         tail_suffix(S1, S1)-true,
         tail_suffix([_|T2], S2)-tail_suffix(T2, S2)
     ],
+    SuffixesClauses = [
+        tail_suffixes([], [[]])-true,
+        tail_suffixes([H3|T3], [[H3|T3]|Rest3])-tail_suffixes(T3, Rest3)
+    ],
     DistClauses = [
         tc_distance(S1, T1, 1)-tc_parent(S1, T1),
         tc_distance(S2, T2, D2)-(tc_parent(S2, M2), (tc_distance(M2, T2, D1), D2 is D1 + 1))
@@ -312,6 +322,8 @@ test_recursive_kernel_ir_selection :-
             recursive_kernel(countdown_sum2, tri_sum/2, [])),
         rust_target:rust_recursive_kernel(tail_suffix, 2, SuffixClauses,
             recursive_kernel(list_suffix2, tail_suffix/2, [])),
+        rust_target:rust_recursive_kernel(tail_suffixes, 2, SuffixesClauses,
+            recursive_kernel(list_suffixes2, tail_suffixes/2, [])),
         rust_target:rust_recursive_kernel(tc_parent_distance, 4, ParentDistClauses,
             recursive_kernel(transitive_parent_distance4, tc_parent_distance/4,
                 [edge_pred(tc_parent/2), fact_pairs(ParentDistancePairs)])),
@@ -341,6 +353,7 @@ test_recursive_kernel_spec_generation :-
             tc_parent_distance/4,
             [ register_foreign_native_kind(tc_parent_distance/4, transitive_parent_distance4),
               register_foreign_result_layout(tc_parent_distance/4, tuple(3)),
+              register_foreign_result_mode(tc_parent_distance/4, stream),
               register_foreign_string_config(tc_parent_distance/4, edge_pred, tc_parent/2),
               register_indexed_atom_fact2(tc_parent/2, ['tom'-'bob', 'bob'-'ann'])
             ],
@@ -354,7 +367,7 @@ test_recursive_kernel_registry :-
     Test = 'WAM-Rust: recursive kernel registry enumerates supported kernels',
     findall(Kind, rust_target:rust_recursive_kernel_detector(Kind, _), Kinds0),
     sort(Kinds0, Kinds),
-    (   Kinds == [category_ancestor, countdown_sum2, list_suffix2, transitive_closure2, transitive_distance3, transitive_parent_distance4]
+    (   Kinds == [category_ancestor, countdown_sum2, list_suffix2, list_suffixes2, transitive_closure2, transitive_distance3, transitive_parent_distance4]
     ->  pass(Test)
     ;   fail_test(Test, 'Recursive kernel registry did not match expected supported kernels')
     ).
@@ -482,6 +495,20 @@ test_foreign_lowering_list_suffix :-
     ;   fail_test(Test, 'Foreign lowering was not selected for tail_suffix/2')
     ).
 
+test_foreign_lowering_list_suffixes :-
+    Test = 'WAM-Rust: compiler can choose foreign lowering for tail_suffixes/2',
+    (   rust_target:compile_predicate_to_rust(user:tail_suffixes/2,
+            [include_main(false), foreign_lowering(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("tail_suffixes/2", "list_suffixes2")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("tail_suffixes/2", "tuple:1")'),
+        sub_string(S, _, _, _, 'register_foreign_result_mode("tail_suffixes/2", "deterministic_collection")'),
+        sub_string(S, _, _, _, 'execute_foreign_predicate("tail_suffixes", 2)'),
+        sub_string(S, _, _, _, 'Instruction::CallForeign("tail_suffixes".to_string(), 2)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Foreign lowering was not selected for tail_suffixes/2')
+    ).
+
 test_foreign_lowering_reverse_transitive_closure :-
     Test = 'WAM-Rust: compiler can choose foreign lowering for tc_descendant/2',
     (   rust_target:compile_predicate_to_rust(user:tc_descendant/2,
@@ -545,6 +572,7 @@ test_compile_wam_runtime_output :-
         sub_string(S, _, _, _, 'TryMeElse'),
         sub_string(S, _, _, _, 'foreign_native_kind(&pred_key)'),
         sub_string(S, _, _, _, 'foreign_result_layout(pred_key)'),
+        sub_string(S, _, _, _, 'foreign_result_mode(pred_key)'),
         sub_string(S, _, _, _, 'foreign_string_config(&pred_key, "edge_pred")'),
         sub_string(S, _, _, _, 'foreign_usize_config(&pred_key, "max_depth")'),
         sub_string(S, _, _, _, 'fn finish_foreign_results'),
@@ -552,6 +580,7 @@ test_compile_wam_runtime_output :-
         sub_string(S, _, _, _, 'fn parse_foreign_tuple_layout'),
         sub_string(S, _, _, _, 'tuple:'),
         sub_string(S, _, _, _, '__tuple__'),
+        sub_string(S, _, _, _, 'deterministic_collection'),
         sub_string(S, _, _, _, 'name: "foreign_results".to_string()'),
         sub_string(S, _, _, _, 'transitive_closure2'),
         sub_string(S, _, _, _, 'collect_native_transitive_closure_nodes'),


### PR DESCRIPTION
## Summary

This PR cleans up the Rust WAM foreign-lowering path in three connected areas:

- normalizes foreign result shapes around tuple-style layouts instead of fixed `single` / `pair` / `triple` cases
- separates result delivery mode from result shape, so streamed solutions and deterministic collection-style results use the same binding path cleanly
- removes dead WAM instruction setup from foreign-only wrappers, so foreign-lowered predicates call native handlers directly

## What Changed

- Replaced arity-specific foreign result layouts with tuple layouts:
  - `tuple:1`
  - `tuple:2`
  - `tuple:3`
- Updated the Rust WAM runtime to bind foreign results through a single `__tuple__` payload path.
- Added explicit foreign result delivery modes:
  - `stream`
  - `deterministic`
  - `deterministic_collection`
- Added `tail_suffixes/2` as the first deterministic collection kernel, using native kind `list_suffixes2`.
- Changed foreign-only wrappers so they no longer emit unused WAM instruction vectors or label maps.
- Added generator-level regression coverage to ensure foreign-only wrappers do not leak dead WAM code or placeholder comments.

## Why

Before this change, the foreign runtime still had two architectural rough edges:

- result handling was drifting toward more arity-specific cases
- foreign-lowered wrappers still carried around compiled WAM setup they never executed

This PR fixes both at the right abstraction level. The result path is now easier to extend for future kernels, and foreign-only wrappers now reflect the real execution model instead of depending on dead code generation.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`

Both passed locally.

## Scope

This PR is intentionally limited to the Rust WAM foreign-lowering path. It does not try to expand general WAM instruction coverage; instead it makes the existing foreign path cleaner, more explicit, and easier to extend.
