### PR TITLE
feat(wam-rust): Add a quad-result foreign kernel to Rust WAM lowering

### DIFF
--- a/PR_WAM_RUST_QUAD_RESULT_KERNEL.md
+++ b/PR_WAM_RUST_QUAD_RESULT_KERNEL.md
@@ -1,0 +1,57 @@
+## PR Title
+
+Add a quad-result foreign kernel to Rust WAM lowering
+
+## Summary
+
+This PR extends the Rust WAM foreign-lowering path with a higher-arity tuple case by adding a new `tuple:4` kernel and validating it end to end.
+
+The new kernel, `tc_step_parent_distance/5`, proves that the current foreign result model scales beyond `tuple:3` without another runtime refactor.
+
+## What Changed
+
+- Added a new recursive kernel family:
+  - `transitive_step_parent_distance5`
+- Added compiler detection and foreign spec generation for:
+  - `tc_step_parent_distance/5`
+- Registered the new kernel with:
+  - result layout `tuple:4`
+  - result mode `stream`
+- Added Rust runtime support to emit quadruple result tuples:
+  - `(target, first_step, terminal_parent, distance)`
+- Added target tests covering:
+  - kernel detection
+  - declarative spec generation
+  - registry enumeration
+  - compiler-selected foreign lowering
+- Added runtime integration coverage for:
+  - enumerating all results
+  - exact success case matching
+  - failure case matching
+- Updated the design retrospective to document the new `tuple:4` path.
+
+## Why
+
+The previous branch established:
+
+- tuple-shaped foreign result layouts
+- explicit result delivery modes
+- deterministic collection support
+- direct foreign-only wrappers
+
+The next useful proof was to show that `tuple:N` is not just a renamed `single/pair/triple` ladder. Adding a real `tuple:4` kernel demonstrates that the current result-shape and delivery-mode split scales to higher arities without reopening the runtime design.
+
+## Validation
+
+- `swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`
+
+Both passed locally.
+
+## Scope
+
+This PR is intentionally narrow:
+
+- it adds one higher-arity kernel to prove the current architecture
+- it does not introduce a new result encoding model
+- it does not broaden general WAM instruction coverage

--- a/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
+++ b/docs/design/WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md
@@ -275,6 +275,7 @@ The currently registered recursive kernel families are:
 - `transitive_closure2`
 - `transitive_distance3`
 - `transitive_parent_distance4`
+- `transitive_step_parent_distance5`
 
 ### What Is Verified
 
@@ -289,6 +290,7 @@ The current test coverage now includes:
   - `tc_descendant/2`
   - `tc_distance/3`
   - `tc_parent_distance/4`
+  - `tc_step_parent_distance/5`
 - end-to-end generated Rust runtime validation for:
   - `tail_suffix/2`
   - `tail_suffixes/2`
@@ -297,6 +299,7 @@ The current test coverage now includes:
   - `tc_descendant/2`
   - `tc_distance/3`
   - `tc_parent_distance/4`
+  - `tc_step_parent_distance/5`
 
 When `foreign_lowering(true)` is enabled and a registered kernel matches, the
 compiler now prefers the foreign path over earlier generic native clause
@@ -310,11 +313,12 @@ The tuple-shaped foreign-result layout layer is:
 - `tuple:1` for one output register
 - `tuple:2` for two-output payloads packed into one foreign result item
 - `tuple:3` for three-output payloads packed into one foreign result item
+- `tuple:4` for four-output payloads packed into one foreign result item
 
 That replaces the older kernel-specific resume branching for result shape and
 makes additional kernels cheaper to add without adding another arity-specific
 resume path. `tc_parent_distance/4` is the first kernel using the `tuple:3`
-path.
+path. `tc_step_parent_distance/5` is the first kernel using `tuple:4`.
 
 Foreign result delivery now also distinguishes:
 

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3724,6 +3724,7 @@ rust_recursive_kernel_detector(list_suffixes2, rust_recursive_kernel_list_suffix
 rust_recursive_kernel_detector(transitive_closure2, rust_recursive_kernel_transitive_closure).
 rust_recursive_kernel_detector(transitive_distance3, rust_recursive_kernel_transitive_distance).
 rust_recursive_kernel_detector(transitive_parent_distance4, rust_recursive_kernel_transitive_parent_distance).
+rust_recursive_kernel_detector(transitive_step_parent_distance5, rust_recursive_kernel_transitive_step_parent_distance).
 
 rust_recursive_kernel_spec(
         recursive_kernel(KernelKind, PredIndicator, KernelConfig),
@@ -3748,6 +3749,7 @@ rust_recursive_kernel_native_kind(list_suffixes2, list_suffixes2).
 rust_recursive_kernel_native_kind(transitive_closure2, transitive_closure2).
 rust_recursive_kernel_native_kind(transitive_distance3, transitive_distance3).
 rust_recursive_kernel_native_kind(transitive_parent_distance4, transitive_parent_distance4).
+rust_recursive_kernel_native_kind(transitive_step_parent_distance5, transitive_step_parent_distance5).
 
 rust_recursive_kernel_result_layout(category_ancestor, tuple(1)).
 rust_recursive_kernel_result_layout(countdown_sum2, tuple(1)).
@@ -3756,6 +3758,7 @@ rust_recursive_kernel_result_layout(list_suffixes2, tuple(1)).
 rust_recursive_kernel_result_layout(transitive_closure2, tuple(1)).
 rust_recursive_kernel_result_layout(transitive_distance3, tuple(2)).
 rust_recursive_kernel_result_layout(transitive_parent_distance4, tuple(3)).
+rust_recursive_kernel_result_layout(transitive_step_parent_distance5, tuple(4)).
 
 rust_recursive_kernel_result_mode(category_ancestor, stream).
 rust_recursive_kernel_result_mode(countdown_sum2, deterministic).
@@ -3764,6 +3767,7 @@ rust_recursive_kernel_result_mode(list_suffixes2, deterministic_collection).
 rust_recursive_kernel_result_mode(transitive_closure2, stream).
 rust_recursive_kernel_result_mode(transitive_distance3, stream).
 rust_recursive_kernel_result_mode(transitive_parent_distance4, stream).
+rust_recursive_kernel_result_mode(transitive_step_parent_distance5, stream).
 
 rust_recursive_kernel_config_ops(category_ancestor, category_ancestor/4,
         [max_depth(MaxDepth)],
@@ -3778,6 +3782,9 @@ rust_recursive_kernel_config_ops(transitive_distance3, PredIndicator,
         KernelConfig, ConfigOps) :-
     rust_recursive_kernel_binary_edge_config_ops(PredIndicator, KernelConfig, ConfigOps).
 rust_recursive_kernel_config_ops(transitive_parent_distance4, PredIndicator,
+        KernelConfig, ConfigOps) :-
+    rust_recursive_kernel_binary_edge_config_ops(PredIndicator, KernelConfig, ConfigOps).
+rust_recursive_kernel_config_ops(transitive_step_parent_distance5, PredIndicator,
         KernelConfig, ConfigOps) :-
     rust_recursive_kernel_binary_edge_config_ops(PredIndicator, KernelConfig, ConfigOps).
 
@@ -3819,6 +3826,11 @@ rust_recursive_kernel_transitive_parent_distance(Pred, Arity, Clauses,
         recursive_kernel(transitive_parent_distance4, Pred/Arity,
             [edge_pred(EdgePred/2), fact_pairs(FactPairs)])) :-
     rust_foreign_lowerable_transitive_parent_distance(Pred, Arity, Clauses, EdgePred/2, FactPairs).
+
+rust_recursive_kernel_transitive_step_parent_distance(Pred, Arity, Clauses,
+        recursive_kernel(transitive_step_parent_distance5, Pred/Arity,
+            [edge_pred(EdgePred/2), fact_pairs(FactPairs)])) :-
+    rust_foreign_lowerable_transitive_step_parent_distance(Pred, Arity, Clauses, EdgePred/2, FactPairs).
 
 rust_foreign_lowerable_category_ancestor(category_ancestor, 4, Clauses, MaxDepth) :-
     member(_-BaseBody, Clauses),
@@ -3926,6 +3938,28 @@ rust_foreign_lowerable_transitive_parent_distance(Pred, 4, Clauses, EdgePred/2, 
     RecBody = (EdgeGoal, (RecGoal, IsGoal)),
     EdgeGoal =.. [EdgePred, RecStart, RecMid],
     RecGoal =.. [Pred, RecMid, RecTarget, RecParent, PrevDepth],
+    IsGoal =.. [is, RecDepth, Expr],
+    Expr =.. [+, PrevDepth, 1],
+    findall(Left-Right,
+        ( functor(EdgeHead, EdgePred, 2),
+          user:clause(EdgeHead, true),
+          EdgeHead =.. [EdgePred, Left, Right],
+          atom(Left),
+          atom(Right)
+        ),
+        FactPairs),
+    FactPairs \= [].
+
+rust_foreign_lowerable_transitive_step_parent_distance(Pred, 5, Clauses, EdgePred/2, FactPairs) :-
+    member(BaseHead-BaseBody, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseHead =.. [Pred, BaseStart, BaseTarget, BaseTarget, BaseStart, 1],
+    RecHead =.. [Pred, RecStart, RecTarget, RecStep, RecParent, RecDepth],
+    BaseBody =.. [EdgePred, BaseStart, BaseTarget],
+    RecBody = (EdgeGoal, (RecGoal, IsGoal)),
+    EdgeGoal =.. [EdgePred, RecStart, RecMid],
+    RecStep == RecMid,
+    RecGoal =.. [Pred, RecMid, RecTarget, _InnerStep, RecParent, PrevDepth],
     IsGoal =.. [is, RecDepth, Expr],
     Expr =.. [+, PrevDepth, 1],
     findall(Left-Right,

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -792,6 +792,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
     compile_collect_native_transitive_closure_to_rust(NativeClosureCode),
     compile_collect_native_transitive_distance_to_rust(NativeDistanceCode),
     compile_collect_native_transitive_parent_distance_to_rust(NativeParentDistanceCode),
+    compile_collect_native_transitive_step_parent_distance_to_rust(NativeStepParentDistanceCode),
     compile_eval_arith_to_rust(ArithCode),
     atomic_list_concat([
         RunLoopCode, '\n\n',
@@ -813,6 +814,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
         NativeClosureCode, '\n\n',
         NativeDistanceCode, '\n\n',
         NativeParentDistanceCode, '\n\n',
+        NativeStepParentDistanceCode, '\n\n',
         ArithCode
     ], RustCode).
 
@@ -1268,6 +1270,54 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                 }).collect();
                 self.finish_foreign_results(&pred_key, vec![target_reg, parent_reg, dist_reg], packed_results)
             }
+            "transitive_step_parent_distance5" => {
+                let start = match self.regs.get("A1").cloned().map(|v| self.deref_var(&v)) {
+                    Some(Value::Atom(start)) => start,
+                    _ => return false,
+                };
+                let target_reg = match self.regs.get("A2").cloned() {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let step_reg = match self.regs.get("A3").cloned() {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let parent_reg = match self.regs.get("A4").cloned() {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let dist_reg = match self.regs.get("A5").cloned() {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let target_filter = match self.deref_var(&target_reg) {
+                    Value::Atom(target) => Some(target),
+                    Value::Unbound(_) => None,
+                    _ => return false,
+                };
+                let edge_pred = match self.foreign_string_config(&pred_key, "edge_pred") {
+                    Some(pred) => pred.to_string(),
+                    None => return false,
+                };
+                let mut results: Vec<(String, String, String, i64)> = Vec::new();
+                self.collect_native_transitive_step_parent_distance_results(&start, &edge_pred, &mut results);
+                if let Some(target) = target_filter {
+                    results.retain(|(node, _, _, _)| *node == target);
+                }
+                if results.is_empty() {
+                    return false;
+                }
+                let packed_results: Vec<Value> = results.into_iter().map(|(node, step, parent, dist)| {
+                    Value::Str("__tuple__".to_string(), vec![
+                        Value::Atom(node),
+                        Value::Atom(step),
+                        Value::Atom(parent),
+                        Value::Integer(dist),
+                    ])
+                }).collect();
+                self.finish_foreign_results(&pred_key, vec![target_reg, step_reg, parent_reg, dist_reg], packed_results)
+            }
             _ => false,
         }
     }'.
@@ -1483,6 +1533,25 @@ compile_collect_native_transitive_parent_distance_to_rust(Code) :-
                     let next_depth = depth + 1;
                     out.push((next.clone(), node.clone(), next_depth));
                     stack.push((next.clone(), next_depth));
+                }
+            }
+        }
+    }'.
+
+compile_collect_native_transitive_step_parent_distance_to_rust(Code) :-
+    Code = '    pub fn collect_native_transitive_step_parent_distance_results(
+        &self,
+        start: &str,
+        edge_pred: &str,
+        out: &mut Vec<(String, String, String, i64)>,
+    ) {
+        if let Some(next_nodes) = self.indexed_atom_fact2.get(edge_pred).and_then(|table| table.get(start)) {
+            for next in next_nodes {
+                out.push((next.clone(), next.clone(), start.to_string(), 1));
+                let mut nested: Vec<(String, String, i64)> = Vec::new();
+                self.collect_native_transitive_parent_distance_results(next, edge_pred, &mut nested);
+                for (target, parent, dist) in nested {
+                    out.push((target, next.clone(), parent, dist + 1));
                 }
             }
         }

--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -52,6 +52,13 @@ tc_parent_distance(X, Y, Parent, D) :-
     tc_parent_distance(Z, Y, Parent, D1),
     D is D1 + 1.
 
+:- dynamic tc_step_parent_distance/5.
+tc_step_parent_distance(X, Y, Y, X, 1) :- tc_parent(X, Y).
+tc_step_parent_distance(X, Y, Step, Parent, D) :-
+    tc_parent(X, Step),
+    tc_step_parent_distance(Step, Y, _Inner, Parent, D1),
+    D is D1 + 1.
+
 :- dynamic tri_sum/2.
 tri_sum(0, 0).
 tri_sum(N, Sum) :-
@@ -78,7 +85,7 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2],
+        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2],
             [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
@@ -91,6 +98,7 @@ use runtime_test::tc_ancestor;
 use runtime_test::tc_descendant;
 use runtime_test::tc_distance;
 use runtime_test::tc_parent_distance;
+use runtime_test::tc_step_parent_distance;
 use runtime_test::tri_sum;
 use runtime_test::tail_suffix;
 use runtime_test::tail_suffixes;
@@ -283,6 +291,66 @@ fn test_generated_predicates() {
         Value::Unbound("Parent3".to_string()),
         Value::Unbound("Dist3".to_string()));
     assert!(!ok_pd3, "tc_parent_distance(liz, jim, Parent, Dist) should fail");
+
+    // Test tc_step_parent_distance/5 foreign lowering end-to-end
+    let mut vm_step_parent = WamState::new(vec![], std::collections::HashMap::new());
+    let ok_sp1 = tc_step_parent_distance(&mut vm_step_parent,
+        Value::Atom("tom".to_string()),
+        Value::Unbound("Target4".to_string()),
+        Value::Unbound("Step4".to_string()),
+        Value::Unbound("Parent4".to_string()),
+        Value::Unbound("Dist4".to_string()));
+    assert!(ok_sp1, "tc_step_parent_distance(tom, Target, Step, Parent, Dist) first solution should succeed");
+
+    let mut step_parent_distances: Vec<String> = Vec::new();
+    if let (Some(Value::Atom(target)), Some(Value::Atom(step)), Some(Value::Atom(parent)), Some(Value::Integer(dist))) =
+        (vm_step_parent.bindings.get("Target4").cloned(),
+         vm_step_parent.bindings.get("Step4").cloned(),
+         vm_step_parent.bindings.get("Parent4").cloned(),
+         vm_step_parent.bindings.get("Dist4").cloned()) {
+        step_parent_distances.push(format!("{}:{}:{}:{}", target, step, parent, dist));
+    } else {
+        panic!("expected first tc_step_parent_distance result in Target4/Step4/Parent4/Dist4");
+    }
+
+    while vm_step_parent.backtrack() {
+        if let (Some(Value::Atom(target)), Some(Value::Atom(step)), Some(Value::Atom(parent)), Some(Value::Integer(dist))) =
+            (vm_step_parent.bindings.get("Target4").cloned(),
+             vm_step_parent.bindings.get("Step4").cloned(),
+             vm_step_parent.bindings.get("Parent4").cloned(),
+             vm_step_parent.bindings.get("Dist4").cloned()) {
+            step_parent_distances.push(format!("{}:{}:{}:{}", target, step, parent, dist));
+        } else {
+            panic!("expected backtracked tc_step_parent_distance result in Target4/Step4/Parent4/Dist4");
+        }
+    }
+
+    step_parent_distances.sort();
+    assert_eq!(step_parent_distances, vec![
+        "ann:bob:bob:2".to_string(),
+        "bob:bob:tom:1".to_string(),
+        "jim:bob:pat:3".to_string(),
+        "liz:liz:tom:1".to_string(),
+        "pat:bob:bob:2".to_string(),
+    ]);
+
+    let mut vm_step_parent_check = WamState::new(vec![], std::collections::HashMap::new());
+    let ok_sp2 = tc_step_parent_distance(&mut vm_step_parent_check,
+        Value::Atom("tom".to_string()),
+        Value::Atom("jim".to_string()),
+        Value::Atom("bob".to_string()),
+        Value::Atom("pat".to_string()),
+        Value::Integer(3));
+    assert!(ok_sp2, "tc_step_parent_distance(tom, jim, bob, pat, 3) should succeed");
+
+    let mut vm_step_parent_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok_sp3 = tc_step_parent_distance(&mut vm_step_parent_fail,
+        Value::Atom("liz".to_string()),
+        Value::Atom("jim".to_string()),
+        Value::Unbound("Step".to_string()),
+        Value::Unbound("Parent".to_string()),
+        Value::Unbound("Dist".to_string()));
+    assert!(!ok_sp3, "tc_step_parent_distance(liz, jim, Step, Parent, Dist) should fail");
 
     // Test tri_sum/2 foreign lowering end-to-end
     let mut vm_sum = WamState::new(vec![], std::collections::HashMap::new());

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -35,6 +35,7 @@ test_simple_fact(foo, bar).
 :- dynamic tc_descendant/2.
 :- dynamic tc_distance/3.
 :- dynamic tc_parent_distance/4.
+:- dynamic tc_step_parent_distance/5.
 :- dynamic tc_parent/2.
 :- dynamic max_depth/1.
 
@@ -88,6 +89,11 @@ tc_parent_distance(X, Y, X, 1) :- tc_parent(X, Y).
 tc_parent_distance(X, Y, Parent, D) :-
     tc_parent(X, Z),
     tc_parent_distance(Z, Y, Parent, D1),
+    D is D1 + 1.
+tc_step_parent_distance(X, Y, Y, X, 1) :- tc_parent(X, Y).
+tc_step_parent_distance(X, Y, Step, Parent, D) :-
+    tc_parent(X, Step),
+    tc_step_parent_distance(Step, Y, _Inner, Parent, D1),
     D is D1 + 1.
 
 pass(Test) :-
@@ -316,6 +322,11 @@ test_recursive_kernel_ir_selection :-
         tc_parent_distance(SP2, TP2, PP2, DP2)-
             (tc_parent(SP2, MP2), (tc_parent_distance(MP2, TP2, PP2, DPrev2), DP2 is DPrev2 + 1))
     ],
+    StepParentDistClauses = [
+        tc_step_parent_distance(SS1, ST1, ST1, SS1, 1)-tc_parent(SS1, ST1),
+        tc_step_parent_distance(SS2, ST2, SSP2, SPP2, SDP2)-
+            (tc_parent(SS2, SSP2), (tc_step_parent_distance(SSP2, ST2, _Inner2, SPP2, SDPrev2), SDP2 is SDPrev2 + 1))
+    ],
     (   rust_target:rust_recursive_kernel(category_ancestor, 4, CategoryClauses,
             recursive_kernel(category_ancestor, category_ancestor/4, [max_depth(10)])),
         rust_target:rust_recursive_kernel(tri_sum, 2, SumClauses,
@@ -327,6 +338,9 @@ test_recursive_kernel_ir_selection :-
         rust_target:rust_recursive_kernel(tc_parent_distance, 4, ParentDistClauses,
             recursive_kernel(transitive_parent_distance4, tc_parent_distance/4,
                 [edge_pred(tc_parent/2), fact_pairs(ParentDistancePairs)])),
+        rust_target:rust_recursive_kernel(tc_step_parent_distance, 5, StepParentDistClauses,
+            recursive_kernel(transitive_step_parent_distance5, tc_step_parent_distance/5,
+                [edge_pred(tc_parent/2), fact_pairs(StepParentDistancePairs)])),
         rust_target:rust_recursive_kernel(tc_descendant, 2, DescClauses,
             recursive_kernel(transitive_closure2, tc_descendant/2,
                 [edge_pred(tc_parent/2), fact_pairs(FactPairs)])),
@@ -336,6 +350,7 @@ test_recursive_kernel_ir_selection :-
         FactPairs == ['bob'-'tom', 'liz'-'tom', 'ann'-'bob', 'pat'-'bob', 'jim'-'pat']
         , DistancePairs == ['tom'-'bob', 'tom'-'liz', 'bob'-'ann', 'bob'-'pat', 'pat'-'jim']
         , ParentDistancePairs == ['tom'-'bob', 'tom'-'liz', 'bob'-'ann', 'bob'-'pat', 'pat'-'jim']
+        , StepParentDistancePairs == ['tom'-'bob', 'tom'-'liz', 'bob'-'ann', 'bob'-'pat', 'pat'-'jim']
     ->  pass(Test)
     ;   fail_test(Test, 'Recursive kernel IR did not normalize expected schemas')
     ).
@@ -363,11 +378,34 @@ test_recursive_kernel_spec_generation :-
     ;   fail_test(Test, 'Recursive kernel spec generation did not match expected foreign spec')
     ).
 
+test_recursive_kernel_spec_generation_quad :-
+    Test = 'WAM-Rust: quad tuple kernel spec generation is declarative',
+    Kernel = recursive_kernel(
+        transitive_step_parent_distance5,
+        tc_step_parent_distance/5,
+        [ edge_pred(tc_parent/2),
+          fact_pairs(['tom'-'bob', 'bob'-'ann'])
+        ]),
+    (   rust_target:rust_recursive_kernel_spec(Kernel, ForeignSpec),
+        ForeignSpec = foreign_predicate(
+            tc_step_parent_distance/5,
+            [ register_foreign_native_kind(tc_step_parent_distance/5, transitive_step_parent_distance5),
+              register_foreign_result_layout(tc_step_parent_distance/5, tuple(4)),
+              register_foreign_result_mode(tc_step_parent_distance/5, stream),
+              register_foreign_string_config(tc_step_parent_distance/5, edge_pred, tc_parent/2),
+              register_indexed_atom_fact2(tc_parent/2, ['tom'-'bob', 'bob'-'ann'])
+            ],
+            [tc_step_parent_distance/5]
+        )
+    ->  pass(Test)
+    ;   fail_test(Test, 'Quad tuple kernel spec generation did not match expected foreign spec')
+    ).
+
 test_recursive_kernel_registry :-
     Test = 'WAM-Rust: recursive kernel registry enumerates supported kernels',
     findall(Kind, rust_target:rust_recursive_kernel_detector(Kind, _), Kinds0),
     sort(Kinds0, Kinds),
-    (   Kinds == [category_ancestor, countdown_sum2, list_suffix2, list_suffixes2, transitive_closure2, transitive_distance3, transitive_parent_distance4]
+    (   Kinds == [category_ancestor, countdown_sum2, list_suffix2, list_suffixes2, transitive_closure2, transitive_distance3, transitive_parent_distance4, transitive_step_parent_distance5]
     ->  pass(Test)
     ;   fail_test(Test, 'Recursive kernel registry did not match expected supported kernels')
     ).
@@ -575,6 +613,21 @@ test_foreign_lowering_transitive_parent_distance :-
     ;   fail_test(Test, 'Foreign lowering was not selected for tc_parent_distance/4')
     ).
 
+test_foreign_lowering_transitive_step_parent_distance :-
+    Test = 'WAM-Rust: compiler can choose foreign lowering for tc_step_parent_distance/5',
+    (   rust_target:compile_predicate_to_rust(user:tc_step_parent_distance/5,
+            [include_main(false), foreign_lowering(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("tc_step_parent_distance/5", "transitive_step_parent_distance5")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("tc_step_parent_distance/5", "tuple:4")'),
+        sub_string(S, _, _, _, 'register_foreign_result_mode("tc_step_parent_distance/5", "stream")'),
+        sub_string(S, _, _, _, 'register_foreign_string_config("tc_step_parent_distance/5", "edge_pred", "tc_parent/2")'),
+        sub_string(S, _, _, _, 'execute_foreign_predicate("tc_step_parent_distance", 5)'),
+        sub_string(S, _, _, _, 'vm.code = Vec::new();')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Foreign lowering was not selected for tc_step_parent_distance/5')
+    ).
+
 test_compile_wam_runtime_output :-
     Test = 'WAM-Rust E2E: full runtime generates valid impl block',
     (   compile_wam_runtime_to_rust([], Code),
@@ -606,7 +659,8 @@ test_compile_wam_runtime_output :-
         sub_string(S, _, _, _, 'name: "foreign_results".to_string()'),
         sub_string(S, _, _, _, 'transitive_closure2'),
         sub_string(S, _, _, _, 'collect_native_transitive_closure_nodes'),
-        sub_string(S, _, _, _, 'collect_native_transitive_parent_distance_results')
+        sub_string(S, _, _, _, 'collect_native_transitive_parent_distance_results'),
+        sub_string(S, _, _, _, 'collect_native_transitive_step_parent_distance_results')
     ->  pass(Test)
     ;   fail_test(Test, 'Runtime impl block incomplete')
     ).


### PR DESCRIPTION
## Summary

This PR extends the Rust WAM foreign-lowering path with a higher-arity tuple case by adding a new `tuple:4` kernel and validating it end to end.

The new kernel, `tc_step_parent_distance/5`, proves that the current foreign result model scales beyond `tuple:3` without another runtime refactor.

## What Changed

- Added a new recursive kernel family:
  - `transitive_step_parent_distance5`
- Added compiler detection and foreign spec generation for:
  - `tc_step_parent_distance/5`
- Registered the new kernel with:
  - result layout `tuple:4`
  - result mode `stream`
- Added Rust runtime support to emit quadruple result tuples:
  - `(target, first_step, terminal_parent, distance)`
- Added target tests covering:
  - kernel detection
  - declarative spec generation
  - registry enumeration
  - compiler-selected foreign lowering
- Added runtime integration coverage for:
  - enumerating all results
  - exact success case matching
  - failure case matching
- Updated the design retrospective to document the new `tuple:4` path.

## Why

The previous branch established:

- tuple-shaped foreign result layouts
- explicit result delivery modes
- deterministic collection support
- direct foreign-only wrappers

The next useful proof was to show that `tuple:N` is not just a renamed `single/pair/triple` ladder. Adding a real `tuple:4` kernel demonstrates that the current result-shape and delivery-mode split scales to higher arities without reopening the runtime design.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`

Both passed locally.

## Scope

This PR is intentionally narrow:

- it adds one higher-arity kernel to prove the current architecture
- it does not introduce a new result encoding model
- it does not broaden general WAM instruction coverage
