### PR TITLE
feat: benchmark min semantic distance with precomputed embedding weights

### DIFF
--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -49,6 +49,8 @@ BENCH_DIR = ROOT / "data" / "benchmark"
 GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
 PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_effective_distance_benchmark.pl"
 WAM_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_effective_distance_benchmark.pl"
+SEMANTIC_PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_min_semantic_distance_benchmark.pl"
+EDGE_WEIGHT_SCRIPT = ROOT / "examples" / "benchmark" / "precompute_edge_weights.py"
 
 
 @dataclass
@@ -134,6 +136,42 @@ def build_prolog_effective_distance(root: Path, scale: str, variant: str) -> lis
     return ["swipl", "-q", "-s", str(script_path)]
 
 
+def build_prolog_semantic_min(root: Path, scale: str) -> list[str]:
+    """Build the min semantic distance Prolog benchmark.
+
+    Requires precomputed edge weights in data/benchmark/<scale>/edge_weights.pl.
+    Generate them first with:
+        python precompute_edge_weights.py data/benchmark/<scale>/category_parent.tsv data/benchmark/<scale>/
+    """
+    facts_path = require_file(BENCH_DIR / scale / "facts.pl")
+    weights_path = BENCH_DIR / scale / "edge_weights.pl"
+    if not weights_path.exists():
+        # Try to precompute if sentence-transformers is available
+        edges_path = BENCH_DIR / scale / "category_parent.tsv"
+        if edges_path.exists():
+            print(f"  Precomputing edge weights for {scale}...", file=sys.stderr)
+            run_command(
+                [sys.executable, str(EDGE_WEIGHT_SCRIPT), str(edges_path), str(BENCH_DIR / scale)],
+                check=False,
+            )
+        if not weights_path.exists():
+            raise FileNotFoundError(
+                f"Edge weights not found: {weights_path}\n"
+                f"Run: python precompute_edge_weights.py {BENCH_DIR / scale / 'category_parent.tsv'} {BENCH_DIR / scale}/"
+            )
+    weights_path = require_file(weights_path)
+
+    script_path = root / "prolog_semantic_min" / scale / "min_semantic_distance.pl"
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl", "-q", "-s", str(SEMANTIC_PROLOG_GENERATOR),
+            "--", str(facts_path), str(weights_path), str(script_path),
+        ]
+    )
+    return ["swipl", "-q", "-s", str(script_path)]
+
+
 def build_wam_rust_effective_distance(root: Path, scale: str) -> list[str]:
     facts_path = require_file(BENCH_DIR / scale / "facts.pl")
     project_dir = root / "wam_rust" / scale
@@ -193,6 +231,7 @@ def print_summary(results: list[RunResult]) -> None:
         prolog_article_accumulated = find_result(entries, "prolog-article-accumulated")
         prolog_root_accumulated = find_result(entries, "prolog-root-accumulated")
         wam_rust_accumulated = find_result(entries, "wam-rust-accumulated")
+        prolog_semantic_min = find_result(entries, "prolog-semantic-min")
         dfs_like = [item for item in entries if item.target in {"csharp-dfs", "rust-dfs", "go-dfs"}]
 
         if len(dfs_like) > 1:
@@ -205,6 +244,7 @@ def print_summary(results: list[RunResult]) -> None:
         print_pair_match_status(scale, "query_vs_prolog_root_accumulated", qe, prolog_root_accumulated)
         print_pair_match_status(scale, "query_vs_wam_rust_accumulated", qe, wam_rust_accumulated)
         print_pair_match_status(scale, "prolog_vs_wam_rust_accumulated", prolog_accumulated, wam_rust_accumulated)
+        print_pair_match_status(scale, "query_vs_prolog_semantic_min", qe, prolog_semantic_min)
         print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
         print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
         print_speedup(scale, "speedup_vs_prolog_seeded", prolog_seeded, qe)
@@ -213,6 +253,7 @@ def print_summary(results: list[RunResult]) -> None:
         print_speedup(scale, "speedup_vs_prolog_article_accumulated", prolog_article_accumulated, qe)
         print_speedup(scale, "speedup_vs_prolog_root_accumulated", prolog_root_accumulated, qe)
         print_speedup(scale, "speedup_vs_wam_rust_accumulated", wam_rust_accumulated, qe)
+        print_speedup(scale, "speedup_vs_prolog_semantic_min", prolog_semantic_min, qe)
         print_phase_metrics(scale, "csharp-query-metrics", qe)
         print_phase_metrics(scale, "prolog-seeded-metrics", prolog_seeded)
         print_phase_metrics(scale, "prolog-pruned-metrics", prolog_pruned)
@@ -220,6 +261,7 @@ def print_summary(results: list[RunResult]) -> None:
         print_phase_metrics(scale, "prolog-article-accumulated-metrics", prolog_article_accumulated)
         print_phase_metrics(scale, "prolog-root-accumulated-metrics", prolog_root_accumulated)
         print_phase_metrics(scale, "wam-rust-accumulated-metrics", wam_rust_accumulated)
+        print_phase_metrics(scale, "prolog-semantic-min-metrics", prolog_semantic_min)
 
 
 def scale_sort_key(scale: str) -> tuple[int, str]:
@@ -272,6 +314,8 @@ def main() -> int:
                 continue
             elif target == "wam-rust-accumulated":
                 continue
+            elif target == "prolog-semantic-min":
+                continue
             else:
                 raise ValueError(f"unsupported target: {target}")
 
@@ -290,6 +334,8 @@ def main() -> int:
                     command = build_prolog_effective_distance(temp_root, scale, "root_accumulated")
                 elif target == "wam-rust-accumulated":
                     command = build_wam_rust_effective_distance(temp_root, scale)
+                elif target == "prolog-semantic-min":
+                    command = build_prolog_semantic_min(temp_root, scale)
                 else:
                     command = commands[target]
                 results.append(benchmark_target(command, scale, args.repetitions, target))

--- a/examples/benchmark/generate_prolog_min_semantic_distance_benchmark.pl
+++ b/examples/benchmark/generate_prolog_min_semantic_distance_benchmark.pl
@@ -1,0 +1,119 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025-2026 John William Creighton (@s243a)
+%
+% generate_prolog_min_semantic_distance_benchmark.pl
+%
+% Generates a self-contained Prolog benchmark that computes minimum
+% semantic distance from articles to root categories using precomputed
+% edge weights.
+%
+% Usage:
+%   swipl -q -s generate_prolog_min_semantic_distance_benchmark.pl -- \
+%       <facts.pl> <edge_weights.pl> <output.pl>
+
+:- use_module(library(lists)).
+:- use_module(library(option)).
+
+:- initialization(main, main).
+
+main :-
+    current_prolog_flag(argv, Args),
+    (   Args = [FactsFile, WeightsFile, OutputFile]
+    ->  generate_benchmark(FactsFile, WeightsFile, OutputFile)
+    ;   format(user_error, 'Usage: swipl ... -- <facts.pl> <edge_weights.pl> <output.pl>~n', []),
+        halt(1)
+    ).
+
+generate_benchmark(FactsFile, WeightsFile, OutputFile) :-
+    format(user_error, 'Generating min semantic distance benchmark...~n', []),
+
+    % Read facts
+    load_facts(FactsFile),
+    format(user_error, '  Facts loaded~n', []),
+
+    % Read edge weights
+    load_weights(WeightsFile),
+    format(user_error, '  Edge weights loaded~n', []),
+
+    % Collect unique data
+    findall(A-C, user:article_category(A, C), ArticleCats),
+    findall(R, user:root_category(R), Roots),
+    findall(edge_weight(C, P, W), user:edge_weight(C, P, W), WeightFacts),
+    length(ArticleCats, NAC),
+    length(Roots, NR),
+    length(WeightFacts, NW),
+    format(user_error, '  ~w article-category pairs, ~w roots, ~w weighted edges~n',
+           [NAC, NR, NW]),
+
+    % Write output
+    open(OutputFile, write, S),
+    write_header(S),
+    write_facts(S, ArticleCats, Roots, WeightFacts),
+    write_solver(S),
+    write_main(S),
+    close(S),
+    format(user_error, '  Wrote: ~w~n', [OutputFile]).
+
+load_facts(File) :-
+    (   exists_file(File)
+    ->  consult(File)
+    ;   format(user_error, 'ERROR: ~w not found~n', [File]),
+        halt(1)
+    ).
+
+load_weights(File) :-
+    (   exists_file(File)
+    ->  consult(File)
+    ;   format(user_error, 'ERROR: ~w not found~n', [File]),
+        halt(1)
+    ).
+
+write_header(S) :-
+    format(S, '%% Auto-generated min semantic distance benchmark~n', []),
+    format(S, '%% Computes shortest weighted path from article categories to roots~n', []),
+    format(S, '%% Edge weights = 1 - cosine_similarity(embedding(from), embedding(to))~n~n', []),
+    format(S, ':- use_module(library(lists)).~n~n', []).
+
+write_facts(S, ArticleCats, Roots, WeightFacts) :-
+    format(S, '%% Article-category assignments~n', []),
+    forall(member(A-C, ArticleCats),
+        format(S, 'article_category(~q, ~q).~n', [A, C])),
+    format(S, '~n%% Root categories~n', []),
+    forall(member(R, Roots),
+        format(S, 'root_category(~q).~n', [R])),
+    format(S, '~n%% Semantic edge weights~n', []),
+    forall(member(edge_weight(C, P, W), WeightFacts),
+        format(S, 'edge_weight(~q, ~q, ~w).~n', [C, P, W])),
+    format(S, '~n', []).
+
+write_solver(S) :-
+    format(S, '%% Min semantic distance solver~n', []),
+    format(S, '%% Uses Dijkstra-like exploration via aggregate_all(min)~n~n', []),
+    format(S, 'semantic_path_cost(X, Y, _Visited, W) :-~n', []),
+    format(S, '    edge_weight(X, Y, W).~n~n', []),
+    format(S, 'semantic_path_cost(X, Y, Visited, Cost) :-~n', []),
+    format(S, '    edge_weight(X, Z, W),~n', []),
+    format(S, '    \\+ member(Z, Visited),~n', []),
+    format(S, '    semantic_path_cost(Z, Y, [Z|Visited], RestCost),~n', []),
+    format(S, '    Cost is W + RestCost.~n~n', []),
+    format(S, 'min_semantic_dist(Start, Target, MinDist) :-~n', []),
+    format(S, '    aggregate_all(min(Cost),~n', []),
+    format(S, '        semantic_path_cost(Start, Target, [Start], Cost),~n', []),
+    format(S, '        MinDist).~n~n', []).
+
+write_main(S) :-
+    format(S, '%% Benchmark entry point~n', []),
+    format(S, ':- initialization((\n', []),
+    format(S, '    forall(\n', []),
+    format(S, '        ( article_category(Article, Cat),\n', []),
+    format(S, '          root_category(Root),\n', []),
+    format(S, '          ( min_semantic_dist(Cat, Root, Dist)\n', []),
+    format(S, '          -> true\n', []),
+    format(S, '          ;  Dist = inf\n', []),
+    format(S, '          )\n', []),
+    format(S, '        ),\n', []),
+    write(S, '        format("~w\\t~w\\t~w\\n", [Article, Root, Dist])\n'),
+    format(S, '    ),\n', []),
+    format(S, '    halt\n', []),
+    format(S, '), main).\n', []).

--- a/examples/benchmark/precompute_edge_weights.py
+++ b/examples/benchmark/precompute_edge_weights.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Precompute semantic edge weights for the min_semantic_distance benchmark.
+
+Reads category_parent.tsv and computes:
+    weight(From, To) = 1 - cosine_similarity(embedding(From), embedding(To))
+
+Outputs a Prolog facts file with edge_weight/3 clauses, plus a TSV file
+for non-Prolog targets.
+
+Usage:
+    python precompute_edge_weights.py <category_parent.tsv> <output_dir> [--model MODEL]
+
+Requirements:
+    pip install sentence-transformers numpy
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("edges_tsv", type=Path, help="category_parent.tsv file")
+    parser.add_argument("output_dir", type=Path, help="Output directory for weight files")
+    parser.add_argument(
+        "--model",
+        default="all-MiniLM-L6-v2",
+        help="Sentence transformer model (default: all-MiniLM-L6-v2)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=256,
+        help="Embedding batch size (default: 256)",
+    )
+    return parser.parse_args()
+
+
+def load_edges(path: Path) -> list[tuple[str, str]]:
+    edges = []
+    with open(path) as f:
+        header = f.readline()  # skip header
+        for line in f:
+            parts = line.strip().split("\t")
+            if len(parts) >= 2:
+                edges.append((parts[0], parts[1]))
+    return edges
+
+
+def compute_weights(
+    edges: list[tuple[str, str]], model_name: str, batch_size: int
+) -> list[tuple[str, str, float]]:
+    from sentence_transformers import SentenceTransformer
+
+    # Collect unique nodes
+    nodes = sorted(set(n for edge in edges for n in edge))
+    print(f"  {len(nodes)} unique nodes, {len(edges)} edges", file=sys.stderr)
+
+    # Compute embeddings
+    print(f"  Encoding with {model_name}...", file=sys.stderr)
+    model = SentenceTransformer(model_name)
+    # Replace underscores with spaces for better semantic representation
+    node_texts = [n.replace("_", " ") for n in nodes]
+    embeddings = model.encode(node_texts, batch_size=batch_size, show_progress_bar=True, convert_to_numpy=True)
+    emb_map = {node: emb for node, emb in zip(nodes, embeddings)}
+
+    # Compute weights
+    print("  Computing cosine distances...", file=sys.stderr)
+    weighted_edges = []
+    for child, parent in edges:
+        emb_a = emb_map[child]
+        emb_b = emb_map[parent]
+        dot = np.dot(emb_a, emb_b)
+        norm = np.linalg.norm(emb_a) * np.linalg.norm(emb_b)
+        sim = float(dot / norm) if norm > 0 else 0.0
+        weight = max(0.0, 1.0 - sim)  # clamp to [0, ∞)
+        weighted_edges.append((child, parent, round(weight, 6)))
+
+    return weighted_edges
+
+
+def write_prolog(weighted_edges: list[tuple[str, str, float]], path: Path) -> None:
+    with open(path, "w") as f:
+        f.write("%% Precomputed semantic edge weights\n")
+        f.write("%% weight = 1 - cosine_similarity(embedding(from), embedding(to))\n\n")
+        for child, parent, weight in weighted_edges:
+            # Escape single quotes in Prolog atoms
+            c = child.replace("'", "\\'")
+            p = parent.replace("'", "\\'")
+            f.write(f"edge_weight('{c}', '{p}', {weight}).\n")
+    print(f"  Wrote {len(weighted_edges)} edge_weight/3 facts to {path}", file=sys.stderr)
+
+
+def write_tsv(weighted_edges: list[tuple[str, str, float]], path: Path) -> None:
+    with open(path, "w") as f:
+        f.write("child\tparent\tweight\n")
+        for child, parent, weight in weighted_edges:
+            f.write(f"{child}\t{parent}\t{weight}\n")
+    print(f"  Wrote {len(weighted_edges)} rows to {path}", file=sys.stderr)
+
+
+def main() -> int:
+    args = parse_args()
+    edges = load_edges(args.edges_tsv)
+    if not edges:
+        print("No edges found", file=sys.stderr)
+        return 1
+
+    print(f"Precomputing semantic edge weights...", file=sys.stderr)
+    weighted_edges = compute_weights(edges, args.model, args.batch_size)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    write_prolog(weighted_edges, args.output_dir / "edge_weights.pl")
+    write_tsv(weighted_edges, args.output_dir / "edge_weights.tsv")
+
+    # Stats
+    weights = [w for _, _, w in weighted_edges]
+    print(f"\n  Weight stats: min={min(weights):.4f} max={max(weights):.4f} "
+          f"mean={sum(weights)/len(weights):.4f} median={sorted(weights)[len(weights)//2]:.4f}",
+          file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add `prolog-semantic-min` target to the effective distance benchmark harness
- New script to precompute semantic edge weights from category name embeddings
- New Prolog generator that produces self-contained min semantic distance benchmarks
- Same 3-column output format as existing hop-count benchmarks for direct comparison

## Motivation

The min semantic distance kernel (#1268) computes shortest weighted paths where edge weights are semantic distances. To benchmark it against the existing hop-count effective distance, we need:

1. Precomputed edge weights from real Wikipedia category embeddings
2. A Prolog benchmark generator that embeds the weights and solver
3. Integration into the benchmark harness for apples-to-apples timing comparison

This lets us compare the cost of semantically-weighted shortest path vs integer hop-count across scales (300, 1k, 5k, 10k articles).

## What changed

### `precompute_edge_weights.py` — Edge weight computation

Reads `category_parent.tsv` and computes semantic distance per edge:

```
weight(A, B) = 1 - cosine_similarity(encode(A), encode(B))
```

- Encodes category names using SentenceTransformer (default: `all-MiniLM-L6-v2`)
- Replaces underscores with spaces for better semantic representation
- Batched encoding (configurable `--batch-size`)
- Outputs both `edge_weights.pl` (Prolog facts) and `edge_weights.tsv` (for non-Prolog targets)
- Reports weight distribution stats (min, max, mean, median)

Usage:
```bash
python precompute_edge_weights.py data/benchmark/dev/category_parent.tsv data/benchmark/dev/
```

### `generate_prolog_min_semantic_distance_benchmark.pl` — Benchmark generator

Takes `facts.pl` + `edge_weights.pl` and produces a self-contained Prolog benchmark:

- Embeds all `article_category/2`, `root_category/1`, and `edge_weight/3` facts
- Includes the `semantic_path_cost/4` solver with visited-set cycle detection
- Uses `aggregate_all(min(Cost), ..., MinDist)` for shortest weighted path
- Output format: `Article\tRoot\tMinDist` (same 3-column TSV as effective_distance)

Usage:
```bash
swipl -q -s generate_prolog_min_semantic_distance_benchmark.pl -- \
    data/benchmark/dev/facts.pl data/benchmark/dev/edge_weights.pl output.pl
```

### `benchmark_effective_distance.py` — Harness integration

New target: `prolog-semantic-min`

- Auto-precomputes edge weights if `edge_weights.pl` not found in scale directory (requires `sentence-transformers`)
- Per-scale Prolog generation via the generator script
- Integrated into summary output:
  - `query_vs_prolog_semantic_min` — output agreement check
  - `speedup_vs_prolog_semantic_min` — timing comparison vs C# query engine
  - `prolog-semantic-min-metrics` — phase timing breakdown

Usage:
```bash
python benchmark_effective_distance.py \
    --targets prolog-semantic-min,prolog-accumulated \
    --scales dev,300
```

## Output comparison

The semantic distance benchmark produces different values than hop-count (expected — it's a different metric), but the same output format:

| Metric | hop-count (d_eff) | semantic (min weighted) |
|--------|-------------------|------------------------|
| Scale | Integer hops, power-mean | Float weights, Dijkstra min |
| Range | ~1-10 | ~0.1-8.0 (depends on embeddings) |
| Format | `Article\tRoot\tDist` | `Article\tRoot\tDist` |
| Solver | DFS + aggregate sum | DFS + aggregate min |

## Test plan

- [x] `precompute_edge_weights.py` parses correctly (Python syntax check)
- [x] `generate_prolog_min_semantic_distance_benchmark.pl` produces valid Prolog from dev scale
- [x] Generated benchmark runs and produces 3-column output
- [x] `benchmark_effective_distance.py` parses correctly with new target
- [x] Existing 61 semantic/fuzzy assertions unaffected
- [x] Min semantic distance Prolog spec tests still pass (3/3)
