### PR TITLE
test(wam-rust): Validate weighted shortest-path foreign lowering end to end

### DIFF
--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -75,6 +75,21 @@ tail_suffix([_|T], S) :- tail_suffix(T, S).
 tail_suffixes([], [[]]).
 tail_suffixes([H|T], [[H|T]|Rest]) :- tail_suffixes(T, Rest).
 
+:- dynamic weighted_edge/3.
+weighted_edge(s, a, 1.0).
+weighted_edge(s, b, 4.0).
+weighted_edge(a, b, 2.0).
+weighted_edge(a, c, 5.0).
+weighted_edge(b, c, 1.0).
+weighted_edge(c, d, 3.0).
+
+:- dynamic weighted_path/3.
+weighted_path(X, Y, W) :- weighted_edge(X, Y, W).
+weighted_path(X, Y, Cost) :-
+    weighted_edge(X, Z, W),
+    weighted_path(Z, Y, RestCost),
+    Cost is W + RestCost.
+
 %% Integration test
 test_runtime_execution :-
     Test = 'WAM-Rust Runtime: end-to-end execution',
@@ -85,7 +100,7 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2],
+        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3],
             [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
@@ -102,9 +117,14 @@ use runtime_test::tc_step_parent_distance;
 use runtime_test::tri_sum;
 use runtime_test::tail_suffix;
 use runtime_test::tail_suffixes;
+use runtime_test::weighted_path;
 
 #[test]
 fn test_generated_predicates() {
+    fn assert_close(actual: f64, expected: f64) {
+        assert!((actual - expected).abs() < 1e-9, "expected {}, got {}", expected, actual);
+    }
+
     // Test tc_ancestor/2 foreign lowering end-to-end
     let mut vm_tc = WamState::new(vec![], std::collections::HashMap::new());
     let ok1 = tc_ancestor(&mut vm_tc,
@@ -448,6 +468,67 @@ fn test_generated_predicates() {
         other => panic!("expected deterministic suffix collection in Suffixes, got {:?}", other),
     }
     assert!(!vm_suffixes.backtrack(), "tail_suffixes/2 should not leave backtracking results behind");
+
+    // Test weighted_path/3 foreign lowering end-to-end
+    let mut vm_weighted = WamState::new(vec![], std::collections::HashMap::new());
+    let ok17 = weighted_path(&mut vm_weighted,
+        Value::Atom("s".to_string()),
+        Value::Unbound("TargetW".to_string()),
+        Value::Unbound("CostW".to_string()));
+    assert!(ok17, "weighted_path(s, Target, Cost) first solution should succeed");
+
+    let mut weighted_results: Vec<(String, f64)> = Vec::new();
+    if let (Some(Value::Atom(target)), Some(Value::Float(cost))) =
+        (vm_weighted.bindings.get("TargetW").cloned(), vm_weighted.bindings.get("CostW").cloned()) {
+        weighted_results.push((target, cost));
+    } else {
+        panic!("expected first weighted_path result in TargetW/CostW");
+    }
+
+    while vm_weighted.backtrack() {
+        if let (Some(Value::Atom(target)), Some(Value::Float(cost))) =
+            (vm_weighted.bindings.get("TargetW").cloned(), vm_weighted.bindings.get("CostW").cloned()) {
+            weighted_results.push((target, cost));
+        } else {
+            panic!("expected backtracked weighted_path result in TargetW/CostW");
+        }
+    }
+
+    weighted_results.sort_by(|a, b| a.0.cmp(&b.0));
+    assert_eq!(weighted_results.len(), 4);
+    assert_eq!(weighted_results[0].0, "a".to_string());
+    assert_eq!(weighted_results[1].0, "b".to_string());
+    assert_eq!(weighted_results[2].0, "c".to_string());
+    assert_eq!(weighted_results[3].0, "d".to_string());
+    assert_close(weighted_results[0].1, 1.0);
+    assert_close(weighted_results[1].1, 3.0);
+    assert_close(weighted_results[2].1, 4.0);
+    assert_close(weighted_results[3].1, 7.0);
+
+    let mut vm_weighted_check = WamState::new(vec![], std::collections::HashMap::new());
+    let ok18 = weighted_path(&mut vm_weighted_check,
+        Value::Atom("s".to_string()),
+        Value::Atom("d".to_string()),
+        Value::Unbound("CostD".to_string()));
+    assert!(ok18, "weighted_path(s, d, Cost) should succeed");
+    match vm_weighted_check.bindings.get("CostD").cloned() {
+        Some(Value::Float(cost)) => assert_close(cost, 7.0),
+        other => panic!("expected weighted_path(s, d, CostD) to bind float cost, got {:?}", other),
+    }
+
+    let mut vm_weighted_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok19 = weighted_path(&mut vm_weighted_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("c".to_string()),
+        Value::Float(4.0));
+    assert!(ok19, "weighted_path(s, c, 4.0) should succeed");
+
+    let mut vm_weighted_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok20 = weighted_path(&mut vm_weighted_fail,
+        Value::Atom("d".to_string()),
+        Value::Atom("s".to_string()),
+        Value::Unbound("CostFail".to_string()));
+    assert!(!ok20, "weighted_path(d, s, Cost) should fail");
 }
 ',
         setup_call_cleanup(open(TestPath, write, S), format(S, "~w", [TestContent]), close(S)),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -36,6 +36,8 @@ test_simple_fact(foo, bar).
 :- dynamic tc_distance/3.
 :- dynamic tc_parent_distance/4.
 :- dynamic tc_step_parent_distance/5.
+:- dynamic weighted_path/3.
+:- dynamic weighted_edge/3.
 :- dynamic tc_parent/2.
 :- dynamic max_depth/1.
 
@@ -95,6 +97,19 @@ tc_step_parent_distance(X, Y, Step, Parent, D) :-
     tc_parent(X, Step),
     tc_step_parent_distance(Step, Y, _Inner, Parent, D1),
     D is D1 + 1.
+
+weighted_edge(s, a, 1.0).
+weighted_edge(s, b, 4.0).
+weighted_edge(a, b, 2.0).
+weighted_edge(a, c, 5.0).
+weighted_edge(b, c, 1.0).
+weighted_edge(c, d, 3.0).
+
+weighted_path(X, Y, W) :- weighted_edge(X, Y, W).
+weighted_path(X, Y, Cost) :-
+    weighted_edge(X, Z, W),
+    weighted_path(Z, Y, RestCost),
+    Cost is W + RestCost.
 
 pass(Test) :-
     format('[PASS] ~w~n', [Test]).
@@ -628,6 +643,22 @@ test_foreign_lowering_transitive_step_parent_distance :-
     ;   fail_test(Test, 'Foreign lowering was not selected for tc_step_parent_distance/5')
     ).
 
+test_foreign_lowering_weighted_shortest_path :-
+    Test = 'WAM-Rust: compiler can choose foreign lowering for weighted_path/3',
+    (   rust_target:compile_predicate_to_rust(user:weighted_path/3,
+            [include_main(false), foreign_lowering(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("weighted_path/3", "weighted_shortest_path3")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("weighted_path/3", "tuple:2")'),
+        sub_string(S, _, _, _, 'register_foreign_result_mode("weighted_path/3", "stream")'),
+        sub_string(S, _, _, _, 'register_foreign_string_config("weighted_path/3", "weight_pred", "weighted_edge/3")'),
+        sub_string(S, _, _, _, 'register_indexed_weighted_edge_triples("weighted_edge/3", &[("s", "a", 1.0), ("s", "b", 4.0), ("a", "b", 2.0), ("a", "c", 5.0), ("b", "c", 1.0), ("c", "d", 3.0)])'),
+        sub_string(S, _, _, _, 'execute_foreign_predicate("weighted_path", 3)'),
+        sub_string(S, _, _, _, 'vm.code = Vec::new();')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Foreign lowering was not selected for weighted_path/3')
+    ).
+
 test_compile_wam_runtime_output :-
     Test = 'WAM-Rust E2E: full runtime generates valid impl block',
     (   compile_wam_runtime_to_rust([], Code),
@@ -660,7 +691,8 @@ test_compile_wam_runtime_output :-
         sub_string(S, _, _, _, 'transitive_closure2'),
         sub_string(S, _, _, _, 'collect_native_transitive_closure_nodes'),
         sub_string(S, _, _, _, 'collect_native_transitive_parent_distance_results'),
-        sub_string(S, _, _, _, 'collect_native_transitive_step_parent_distance_results')
+        sub_string(S, _, _, _, 'collect_native_transitive_step_parent_distance_results'),
+        sub_string(S, _, _, _, 'collect_native_weighted_shortest_path_results')
     ->  pass(Test)
     ;   fail_test(Test, 'Runtime impl block incomplete')
     ).
@@ -937,6 +969,8 @@ run_tests :-
     test_foreign_lowering_reverse_transitive_closure,
     test_foreign_lowering_transitive_distance,
     test_foreign_lowering_transitive_parent_distance,
+    test_foreign_lowering_transitive_step_parent_distance,
+    test_foreign_lowering_weighted_shortest_path,
     test_compile_wam_runtime_output,
     test_write_wam_rust_project,
     test_project_cargo_content,


### PR DESCRIPTION
## Summary

This PR adds missing coverage for the Rust WAM `weighted_shortest_path3` foreign-lowered kernel.

The kernel was already present in the detector/IR/spec pipeline and already had Rust runtime support, but it was not yet exercised end to end through a generated Rust project. This patch closes that gap.

## What Changed

- Added target-suite coverage for `weighted_path/3` foreign lowering in `tests/test_wam_rust_target.pl`
- Added generated Rust runtime integration coverage for `weighted_path/3` in `tests/test_wam_rust_runtime.pl`
- Added a small weighted graph fixture to validate:
  - streamed `(Target, Cost)` results
  - shortest-path costs for reachable nodes
  - target-filtered queries
  - failure for unreachable targets

## Why

`feat: benchmark min semantic distance with precomputed embedding weights` merged the benchmark-side weighted path work, and the Rust foreign kernel was already wired up locally. The remaining gap was proof that the generated Rust runtime executes that kernel correctly, not just that the compiler can register it.

This PR makes the weighted shortest-path path consistent with the rest of the Rust WAM foreign-lowering coverage:

- compiler selection is tested
- generated runtime execution is tested

## Validation

Ran locally:

```sh
swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl
swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl
```

Both passed.

## Scope

This PR is intentionally test-focused. It does not change the weighted shortest-path implementation itself; it validates the existing implementation end to end.
