### PR TITLE
fix(rust): Fix weighted aggregate wrapper lowering in Rust

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -4058,6 +4058,11 @@ rust_foreign_edge_pair(reverse, Left, Right, Right-Left).
 compile_aggregate_rule_to_rust(Pred, _Arity, _Head, AggInfo, IncludeMain, RustCode) :-
     get_dict(goal, AggInfo, Goal),
     get_dict(goal_info, AggInfo, GoalInfo),
+    compile_rust_weighted_min_aggregate_wrapper(Pred, Goal, GoalInfo, AggInfo, IncludeMain, RustCode),
+    !.
+compile_aggregate_rule_to_rust(Pred, _Arity, _Head, AggInfo, IncludeMain, RustCode) :-
+    get_dict(goal, AggInfo, Goal),
+    get_dict(goal_info, AggInfo, GoalInfo),
     get_dict(relations, GoalInfo, [RelGoal|_]),
     RelGoal =.. [InnerPred|GoalArgs],
     length(GoalArgs, InnerArity),
@@ -4084,6 +4089,83 @@ compile_aggregate_rule_to_rust(Pred, _Arity, _Head, AggInfo, IncludeMain, RustCo
     ->  compile_rust_grouped_recursive_aggregate(Pred, Goal, InnerPred, InnerArity, GoalArgs, GroupTerm, Op, ValueIndex, IncludeMain, RustCode)
     ;   fail
     ).
+
+compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _IncludeMain, RustCode) :-
+    get_dict(type, AggInfo, all),
+    get_dict(op, AggInfo, min),
+    get_dict(expr, AggInfo, Expr),
+    get_dict(relations, GoalInfo, [RelGoal|_]),
+    RelGoal =.. [InnerPred, _StartArg, TargetArg, CostArg],
+    Expr == CostArg,
+    var(TargetArg),
+    functor(InnerHead, InnerPred, 3),
+    findall(InnerHead-InnerBody, user:clause(InnerHead, InnerBody), Clauses),
+    Clauses \= [],
+    rust_foreign_lowerable_weighted_shortest_path(InnerPred, 3, Clauses, WeightPred/3, FactTriples),
+    atom_string(Pred, PredStr),
+    atom_string(InnerPred, InnerPredStr),
+    format(string(WeightPredKey), '~w/3', [WeightPred]),
+    rust_weighted_fact_triples_literal(FactTriples, TriplesLiteral),
+    format(string(RustCode),
+'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool {
+    vm.reset_query();
+    vm.code = Vec::new();
+    vm.labels = HashMap::new();
+    vm.pc = 1;
+    vm.register_foreign_native_kind("~w/3", "weighted_shortest_path3");
+    vm.register_foreign_result_layout("~w/3", "tuple:2");
+    vm.register_foreign_result_mode("~w/3", "stream");
+    vm.register_foreign_string_config("~w/3", "weight_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+
+    let temp_target = "__agg_target".to_string();
+    let temp_cost = "__agg_cost".to_string();
+    let target_arg = match &a2 {
+        Value::Unbound(_) => Value::Unbound(temp_target.clone()),
+        _ => a2.clone(),
+    };
+
+    vm.set_reg("A1", a1.clone());
+    vm.set_reg("A2", target_arg);
+    vm.set_reg("A3", Value::Unbound(temp_cost.clone()));
+
+    if !vm.execute_foreign_predicate("~w", 3) {
+        vm.bindings.remove(&temp_target);
+        vm.bindings.remove(&temp_cost);
+        return false;
+    }
+
+    let mut best = match vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+        Some(Value::Float(cost)) => Some(cost),
+        _ => None,
+    };
+    while vm.backtrack() {
+        if let Some(Value::Float(cost)) = vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+            best = Some(match best {
+                Some(current) => current.min(cost),
+                None => cost,
+            });
+        }
+    }
+
+    vm.bindings.remove(&temp_target);
+    vm.bindings.remove(&temp_cost);
+
+    match best {
+        Some(cost) => vm.unify(&a3, &Value::Float(cost)),
+        None => false,
+    }
+}', [PredStr, InnerPredStr, InnerPredStr, InnerPredStr, InnerPredStr, WeightPredKey, WeightPredKey, TriplesLiteral, InnerPredStr]).
+
+rust_weighted_fact_triples_literal(Triples, Literal) :-
+    maplist(rust_weighted_fact_triple_literal, Triples, TripleLiterals),
+    atomic_list_concat(TripleLiterals, ', ', Joined),
+    format(string(Literal), '[~w]', [Joined]).
+
+rust_weighted_fact_triple_literal(Left-Right-Weight, Literal) :-
+    rust_literal(Left, LeftLiteral),
+    rust_literal(Right, RightLiteral),
+    format(string(Literal), '(~w, ~w, ~w)', [LeftLiteral, RightLiteral, Weight]).
 
 rust_filter_fact_rows(_GoalArgs, GoalInfo, FactRows, FilteredRows) :-
     include(rust_fact_row_matches(GoalInfo), FactRows, FilteredRows).

--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -90,6 +90,10 @@ weighted_path(X, Y, Cost) :-
     weighted_path(Z, Y, RestCost),
     Cost is W + RestCost.
 
+:- dynamic min_semantic_dist/3.
+min_semantic_dist(Start, Target, MinDist) :-
+    aggregate_all(min(Cost), weighted_path(Start, Target, Cost), MinDist).
+
 %% Integration test
 test_runtime_execution :-
     Test = 'WAM-Rust Runtime: end-to-end execution',
@@ -100,7 +104,7 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3],
+        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:min_semantic_dist/3],
             [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
@@ -118,6 +122,7 @@ use runtime_test::tri_sum;
 use runtime_test::tail_suffix;
 use runtime_test::tail_suffixes;
 use runtime_test::weighted_path;
+use runtime_test::min_semantic_dist;
 
 #[test]
 fn test_generated_predicates() {
@@ -529,6 +534,44 @@ fn test_generated_predicates() {
         Value::Atom("s".to_string()),
         Value::Unbound("CostFail".to_string()));
     assert!(!ok20, "weighted_path(d, s, Cost) should fail");
+
+    // Test min_semantic_dist/3 aggregate wrapper over weighted_path/3
+    let mut vm_min = WamState::new(vec![], std::collections::HashMap::new());
+    let ok21 = min_semantic_dist(&mut vm_min,
+        Value::Atom("s".to_string()),
+        Value::Atom("d".to_string()),
+        Value::Unbound("MinCost".to_string()));
+    assert!(ok21, "min_semantic_dist(s, d, MinCost) should succeed");
+    match vm_min.bindings.get("MinCost").cloned() {
+        Some(Value::Float(cost)) => assert_close(cost, 7.0),
+        other => panic!("expected min_semantic_dist(s, d, MinCost) to bind float cost, got {:?}", other),
+    }
+
+    let mut vm_min_any = WamState::new(vec![], std::collections::HashMap::new());
+    let ok22 = min_semantic_dist(&mut vm_min_any,
+        Value::Atom("s".to_string()),
+        Value::Unbound("AnyTarget".to_string()),
+        Value::Unbound("GlobalMin".to_string()));
+    assert!(ok22, "min_semantic_dist(s, Target, GlobalMin) should succeed");
+    assert!(vm_min_any.bindings.get("AnyTarget").is_none(), "aggregate wrapper should not bind existential Target");
+    match vm_min_any.bindings.get("GlobalMin").cloned() {
+        Some(Value::Float(cost)) => assert_close(cost, 1.0),
+        other => panic!("expected min_semantic_dist(s, Target, GlobalMin) to bind float cost, got {:?}", other),
+    }
+
+    let mut vm_min_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok23 = min_semantic_dist(&mut vm_min_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("c".to_string()),
+        Value::Float(4.0));
+    assert!(ok23, "min_semantic_dist(s, c, 4.0) should succeed");
+
+    let mut vm_min_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok24 = min_semantic_dist(&mut vm_min_fail,
+        Value::Atom("d".to_string()),
+        Value::Atom("s".to_string()),
+        Value::Unbound("NoPath".to_string()));
+    assert!(!ok24, "min_semantic_dist(d, s, NoPath) should fail");
 }
 ',
         setup_call_cleanup(open(TestPath, write, S), format(S, "~w", [TestContent]), close(S)),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -38,6 +38,7 @@ test_simple_fact(foo, bar).
 :- dynamic tc_step_parent_distance/5.
 :- dynamic weighted_path/3.
 :- dynamic weighted_edge/3.
+:- dynamic min_semantic_dist/3.
 :- dynamic tc_parent/2.
 :- dynamic max_depth/1.
 
@@ -110,6 +111,9 @@ weighted_path(X, Y, Cost) :-
     weighted_edge(X, Z, W),
     weighted_path(Z, Y, RestCost),
     Cost is W + RestCost.
+
+min_semantic_dist(Start, Target, MinDist) :-
+    aggregate_all(min(Cost), weighted_path(Start, Target, Cost), MinDist).
 
 pass(Test) :-
     format('[PASS] ~w~n', [Test]).
@@ -659,6 +663,20 @@ test_foreign_lowering_weighted_shortest_path :-
     ;   fail_test(Test, 'Foreign lowering was not selected for weighted_path/3')
     ).
 
+test_weighted_min_aggregate_wrapper :-
+    Test = 'WAM-Rust: aggregate min wrapper delegates to weighted_path/3',
+    (   rust_target:compile_predicate_to_rust(user:min_semantic_dist/3,
+            [include_main(false), foreign_lowering(true), wam_fallback(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'pub fn min_semantic_dist(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool'),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("weighted_path/3", "weighted_shortest_path3")'),
+        sub_string(S, _, _, _, 'register_indexed_weighted_edge_triples("weighted_edge/3", &[("s", "a", 1.0), ("s", "b", 4.0), ("a", "b", 2.0), ("a", "c", 5.0), ("b", "c", 1.0), ("c", "d", 3.0)])'),
+        sub_string(S, _, _, _, 'if !vm.execute_foreign_predicate("weighted_path", 3) {'),
+        sub_string(S, _, _, _, 'vm.unify(&a3, &Value::Float(cost))')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Weighted aggregate wrapper did not delegate correctly')
+    ).
+
 test_compile_wam_runtime_output :-
     Test = 'WAM-Rust E2E: full runtime generates valid impl block',
     (   compile_wam_runtime_to_rust([], Code),
@@ -971,6 +989,7 @@ run_tests :-
     test_foreign_lowering_transitive_parent_distance,
     test_foreign_lowering_transitive_step_parent_distance,
     test_foreign_lowering_weighted_shortest_path,
+    test_weighted_min_aggregate_wrapper,
     test_compile_wam_runtime_output,
     test_write_wam_rust_project,
     test_project_cargo_content,


### PR DESCRIPTION
## Summary

This PR fixes Rust lowering for aggregate wrappers over the weighted shortest-path kernel, and adds end-to-end validation for that path.

Before this change, a predicate like `min_semantic_dist/3`:

```prolog
min_semantic_dist(Start, Target, MinDist) :-
    aggregate_all(min(Cost), weighted_path(Start, Target, Cost), MinDist).
```

was being captured by the generic recursive aggregate lowering path. That path produced the wrong shape for this case: it ignored the weighted edge facts and did not generate a proper predicate wrapper around the existing weighted foreign kernel.

## What Changed

- Added a dedicated aggregate-wrapper lowering path for `aggregate_all(min(...))` over `weighted_path/3`
- Lowered that wrapper to a real exported Rust predicate that:
  - delegates to the existing `weighted_shortest_path3` foreign runtime
  - computes the minimum from streamed weighted results
  - binds the aggregate output correctly
  - does not bind the existential target variable when it is unbound in the query
- Added target-suite coverage for the generated wrapper shape
- Added generated Rust runtime coverage for `min_semantic_dist/3`

## Why

`weighted_path/3` itself was already covered and correct after the previous weighted shortest-path runtime validation work.

The remaining gap was the aggregate wrapper above it. In practice, that matters for the min semantic distance workflow because the benchmark-facing predicate is the aggregate form, not just the raw weighted path enumerator.

This PR fixes the lowering bug rather than only adding a failing test around it.

## Validation

Ran locally:

```sh
swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl
swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl
```

Both passed.

The runtime validation now checks:

- `min_semantic_dist(s, d, MinCost)` binds `MinCost = 7.0`
- `min_semantic_dist(s, Target, GlobalMin)` binds `GlobalMin = 1.0`
- unbound `Target` remains existential and is not leaked as a binding
- unreachable targets fail as expected

## Scope

This PR is intentionally narrow:

- it fixes weighted aggregate-wrapper lowering
- it does not attempt to generalize every aggregate wrapper shape yet

That broader aggregate-wrapper coverage is still a separate follow-up.
