### PR TITLE
test(wam-rust): Validate Rust WAM A* foreign lowering end to end

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1402,7 +1402,7 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                     return false;
                 }
                 let packed_results: Vec<Value> = results.into_iter().map(|(node, dist)| {
-                    Value::Str("__tuple2__".to_string(), vec![
+                    Value::Str("__tuple__".to_string(), vec![
                         Value::Atom(node),
                         Value::Float(dist),
                     ])

--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -83,11 +83,31 @@ weighted_edge(a, c, 5.0).
 weighted_edge(b, c, 1.0).
 weighted_edge(c, d, 3.0).
 
+:- dynamic direct_semantic_dist/3.
+direct_semantic_dist(s, a, 1.0).
+direct_semantic_dist(s, b, 3.0).
+direct_semantic_dist(s, c, 4.0).
+direct_semantic_dist(s, d, 7.0).
+direct_semantic_dist(a, b, 2.0).
+direct_semantic_dist(a, c, 3.0).
+direct_semantic_dist(a, d, 6.0).
+direct_semantic_dist(b, c, 1.0).
+direct_semantic_dist(b, d, 4.0).
+direct_semantic_dist(c, d, 3.0).
+
 :- dynamic weighted_path/3.
 weighted_path(X, Y, W) :- weighted_edge(X, Y, W).
 weighted_path(X, Y, Cost) :-
     weighted_edge(X, Z, W),
     weighted_path(Z, Y, RestCost),
+    Cost is W + RestCost.
+
+:- dynamic astar_weighted_path/4.
+astar_weighted_path(X, Y, _Dim, W) :- weighted_edge(X, Y, W).
+astar_weighted_path(X, Y, Dim, Cost) :-
+    weighted_edge(X, Z, W),
+    direct_semantic_dist(Z, Y, _Heuristic),
+    astar_weighted_path(Z, Y, Dim, RestCost),
     Cost is W + RestCost.
 
 :- dynamic min_semantic_dist/3.
@@ -104,7 +124,7 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:min_semantic_dist/3],
+        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:astar_weighted_path/4, user:min_semantic_dist/3],
             [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
@@ -122,6 +142,7 @@ use runtime_test::tri_sum;
 use runtime_test::tail_suffix;
 use runtime_test::tail_suffixes;
 use runtime_test::weighted_path;
+use runtime_test::astar_weighted_path;
 use runtime_test::min_semantic_dist;
 
 #[test]
@@ -534,6 +555,71 @@ fn test_generated_predicates() {
         Value::Atom("s".to_string()),
         Value::Unbound("CostFail".to_string()));
     assert!(!ok20, "weighted_path(d, s, Cost) should fail");
+
+    // Test astar_weighted_path/4 foreign lowering end-to-end
+    let mut vm_astar = WamState::new(vec![], std::collections::HashMap::new());
+    let ok_astar1 = astar_weighted_path(&mut vm_astar,
+        Value::Atom("s".to_string()),
+        Value::Unbound("ATarget".to_string()),
+        Value::Integer(5),
+        Value::Unbound("ACost".to_string()));
+    assert!(ok_astar1, "astar_weighted_path(s, Target, 5, Cost) first solution should succeed");
+
+    let mut astar_results: Vec<(String, f64)> = Vec::new();
+    if let (Some(Value::Atom(target)), Some(Value::Float(cost))) =
+        (vm_astar.bindings.get("ATarget").cloned(), vm_astar.bindings.get("ACost").cloned()) {
+        astar_results.push((target, cost));
+    } else {
+        panic!("expected first astar_weighted_path result in ATarget/ACost");
+    }
+
+    while vm_astar.backtrack() {
+        if let (Some(Value::Atom(target)), Some(Value::Float(cost))) =
+            (vm_astar.bindings.get("ATarget").cloned(), vm_astar.bindings.get("ACost").cloned()) {
+            astar_results.push((target, cost));
+        } else {
+            panic!("expected backtracked astar_weighted_path result in ATarget/ACost");
+        }
+    }
+
+    astar_results.sort_by(|a, b| a.0.cmp(&b.0));
+    assert_eq!(astar_results.len(), 4);
+    assert_eq!(astar_results[0].0, "a".to_string());
+    assert_eq!(astar_results[1].0, "b".to_string());
+    assert_eq!(astar_results[2].0, "c".to_string());
+    assert_eq!(astar_results[3].0, "d".to_string());
+    assert_close(astar_results[0].1, 1.0);
+    assert_close(astar_results[1].1, 3.0);
+    assert_close(astar_results[2].1, 4.0);
+    assert_close(astar_results[3].1, 7.0);
+
+    let mut vm_astar_check = WamState::new(vec![], std::collections::HashMap::new());
+    let ok_astar2 = astar_weighted_path(&mut vm_astar_check,
+        Value::Atom("s".to_string()),
+        Value::Atom("d".to_string()),
+        Value::Integer(5),
+        Value::Unbound("ACostD".to_string()));
+    assert!(ok_astar2, "astar_weighted_path(s, d, 5, Cost) should succeed");
+    match vm_astar_check.bindings.get("ACostD").cloned() {
+        Some(Value::Float(cost)) => assert_close(cost, 7.0),
+        other => panic!("expected astar_weighted_path(s, d, 5, Cost) to bind float cost, got {:?}", other),
+    }
+
+    let mut vm_astar_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok_astar3 = astar_weighted_path(&mut vm_astar_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("c".to_string()),
+        Value::Integer(5),
+        Value::Float(4.0));
+    assert!(ok_astar3, "astar_weighted_path(s, c, 5, 4.0) should succeed");
+
+    let mut vm_astar_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok_astar4 = astar_weighted_path(&mut vm_astar_fail,
+        Value::Atom("d".to_string()),
+        Value::Atom("s".to_string()),
+        Value::Integer(5),
+        Value::Unbound("ACostFail".to_string()));
+    assert!(!ok_astar4, "astar_weighted_path(d, s, 5, Cost) should fail");
 
     // Test min_semantic_dist/3 aggregate wrapper over weighted_path/3
     let mut vm_min = WamState::new(vec![], std::collections::HashMap::new());

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -38,6 +38,8 @@ test_simple_fact(foo, bar).
 :- dynamic tc_step_parent_distance/5.
 :- dynamic weighted_path/3.
 :- dynamic weighted_edge/3.
+:- dynamic astar_weighted_path/4.
+:- dynamic direct_semantic_dist/3.
 :- dynamic min_semantic_dist/3.
 :- dynamic tc_parent/2.
 :- dynamic max_depth/1.
@@ -106,10 +108,28 @@ weighted_edge(a, c, 5.0).
 weighted_edge(b, c, 1.0).
 weighted_edge(c, d, 3.0).
 
+direct_semantic_dist(s, a, 1.0).
+direct_semantic_dist(s, b, 3.0).
+direct_semantic_dist(s, c, 4.0).
+direct_semantic_dist(s, d, 7.0).
+direct_semantic_dist(a, b, 2.0).
+direct_semantic_dist(a, c, 3.0).
+direct_semantic_dist(a, d, 6.0).
+direct_semantic_dist(b, c, 1.0).
+direct_semantic_dist(b, d, 4.0).
+direct_semantic_dist(c, d, 3.0).
+
 weighted_path(X, Y, W) :- weighted_edge(X, Y, W).
 weighted_path(X, Y, Cost) :-
     weighted_edge(X, Z, W),
     weighted_path(Z, Y, RestCost),
+    Cost is W + RestCost.
+
+astar_weighted_path(X, Y, _Dim, W) :- weighted_edge(X, Y, W).
+astar_weighted_path(X, Y, Dim, Cost) :-
+    weighted_edge(X, Z, W),
+    direct_semantic_dist(Z, Y, _Heuristic),
+    astar_weighted_path(Z, Y, Dim, RestCost),
     Cost is W + RestCost.
 
 min_semantic_dist(Start, Target, MinDist) :-
@@ -424,7 +444,7 @@ test_recursive_kernel_registry :-
     Test = 'WAM-Rust: recursive kernel registry enumerates supported kernels',
     findall(Kind, rust_target:rust_recursive_kernel_detector(Kind, _), Kinds0),
     sort(Kinds0, Kinds),
-    (   Kinds == [category_ancestor, countdown_sum2, list_suffix2, list_suffixes2, transitive_closure2, transitive_distance3, transitive_parent_distance4, transitive_step_parent_distance5, weighted_shortest_path3]
+    (   Kinds == [astar_shortest_path4, category_ancestor, countdown_sum2, list_suffix2, list_suffixes2, transitive_closure2, transitive_distance3, transitive_parent_distance4, transitive_step_parent_distance5, weighted_shortest_path3]
     ->  pass(Test)
     ;   fail_test(Test, 'Recursive kernel registry did not match expected supported kernels')
     ).
@@ -663,6 +683,25 @@ test_foreign_lowering_weighted_shortest_path :-
     ;   fail_test(Test, 'Foreign lowering was not selected for weighted_path/3')
     ).
 
+test_foreign_lowering_astar_shortest_path :-
+    Test = 'WAM-Rust: compiler can choose foreign lowering for astar_weighted_path/4',
+    (   rust_target:compile_predicate_to_rust(user:astar_weighted_path/4,
+            [include_main(false), foreign_lowering(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("astar_weighted_path/4", "astar_shortest_path4")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("astar_weighted_path/4", "tuple:2")'),
+        sub_string(S, _, _, _, 'register_foreign_result_mode("astar_weighted_path/4", "stream")'),
+        sub_string(S, _, _, _, 'register_foreign_string_config("astar_weighted_path/4", "weight_pred", "weighted_edge/3")'),
+        sub_string(S, _, _, _, 'register_foreign_string_config("astar_weighted_path/4", "direct_dist_pred", "direct_semantic_dist/3")'),
+        sub_string(S, _, _, _, 'register_foreign_usize_config("astar_weighted_path/4", "dimensionality", 5)'),
+        sub_string(S, _, _, _, 'register_indexed_weighted_edge_triples("weighted_edge/3", &[("s", "a", 1.0), ("s", "b", 4.0), ("a", "b", 2.0), ("a", "c", 5.0), ("b", "c", 1.0), ("c", "d", 3.0)])'),
+        sub_string(S, _, _, _, 'register_indexed_weighted_edge_triples("direct_semantic_dist/3", &[("s", "a", 1.0), ("s", "b", 3.0), ("s", "c", 4.0), ("s", "d", 7.0), ("a", "b", 2.0), ("a", "c", 3.0), ("a", "d", 6.0), ("b", "c", 1.0), ("b", "d", 4.0), ("c", "d", 3.0)])'),
+        sub_string(S, _, _, _, 'execute_foreign_predicate("astar_weighted_path", 4)'),
+        sub_string(S, _, _, _, 'vm.code = Vec::new();')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Foreign lowering was not selected for astar_weighted_path/4')
+    ).
+
 test_weighted_min_aggregate_wrapper :-
     Test = 'WAM-Rust: aggregate min wrapper delegates to weighted_path/3',
     (   rust_target:compile_predicate_to_rust(user:min_semantic_dist/3,
@@ -710,7 +749,8 @@ test_compile_wam_runtime_output :-
         sub_string(S, _, _, _, 'collect_native_transitive_closure_nodes'),
         sub_string(S, _, _, _, 'collect_native_transitive_parent_distance_results'),
         sub_string(S, _, _, _, 'collect_native_transitive_step_parent_distance_results'),
-        sub_string(S, _, _, _, 'collect_native_weighted_shortest_path_results')
+        sub_string(S, _, _, _, 'collect_native_weighted_shortest_path_results'),
+        sub_string(S, _, _, _, 'collect_native_astar_shortest_path_results')
     ->  pass(Test)
     ;   fail_test(Test, 'Runtime impl block incomplete')
     ).
@@ -989,6 +1029,7 @@ run_tests :-
     test_foreign_lowering_transitive_parent_distance,
     test_foreign_lowering_transitive_step_parent_distance,
     test_foreign_lowering_weighted_shortest_path,
+    test_foreign_lowering_astar_shortest_path,
     test_weighted_min_aggregate_wrapper,
     test_compile_wam_runtime_output,
     test_write_wam_rust_project,


### PR DESCRIPTION
## Summary

This PR catches the Rust WAM test surface up to the merged `astar_shortest_path4` kernel work.

It updates the target-suite kernel registry expectation, adds compiler-selection coverage for `astar_weighted_path/4`, and adds generated Rust runtime coverage for A* execution on a small weighted graph.

It also fixes a runtime result-packing mismatch in the merged A* handler so streamed foreign results use the generic tuple binder path already expected by the normalized foreign result machinery.

## Changes

- update recursive-kernel registry expectations to include `astar_shortest_path4`
- add target-level foreign-lowering coverage for `astar_weighted_path/4`
- add generated Rust runtime validation for:
  - streamed `astar_weighted_path/4` solutions
  - target-filtered A* queries
  - exact-cost matching
  - failure on unreachable targets
- fix A* foreign result packing to use `__tuple__` so it binds through the generic tuple result path

## Why

`main` already included the A* kernel implementation, but the tests had not been updated to reflect it.

That left two gaps:

- the target suite still expected the pre-A* kernel registry
- the runtime suite did not yet prove that A* foreign lowering executed correctly in a generated Rust project

This PR closes both gaps and aligns the tests with the merged implementation.

## Validation

Ran locally in Termux:

```sh
swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl
swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl
```

Both passed.

## Notes

- Scope is intentionally narrow: this PR is test catch-up plus the minimal runtime packing fix required for the A* path to pass through the existing generic tuple-result binder.
- This does not broaden aggregate coverage around A* wrappers yet; it validates the underlying foreign-lowered predicate path itself.
