### PR TITLE
refactor(csharp-query): unify materialization planner

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -111,10 +111,12 @@ Status:
 - the current implementation now shares one internal relation-retention policy
   layer for DAG and path-aware edge selection, while keeping separate public
   override knobs for benchmarking and diagnosis
-- the path-aware grouped-summary family now coordinates that relation-retention
-  choice with grouped-summary selection through a small internal
-  materialization-planner layer, while preserving the current per-family
-  override knobs and trace surface
+- the runtime now shares one internal materialization-planner layer above
+  the shared relation-retention and grouped-summary policy components
+- the path-aware grouped-summary family uses both branches of that planner,
+  while the DAG family currently uses the relation-retention branch of the
+  same planner
+- the current per-family override knobs and trace surface are still preserved
 
 Work:
 
@@ -123,8 +125,9 @@ Work:
   - replayable buffering
   - indexed retained state
   - fallback external materialization
-- coordinate relation-retention and grouped-summary choices when both policy
-  layers exist for the same operator family
+- keep broadening the shared planner so relation-retention and
+  grouped-summary choices can be coordinated through one runtime layer when
+  both policy components exist for an operator family
 - keep this heuristic-driven at first, then refine as profiling improves
 
 Success criteria:

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -36,10 +36,11 @@ retention choice explicit at the runtime/provider boundary instead of hiding it
 inside benchmark-specific wiring. The current runtime now also shares one
 internal measured relation-retention policy layer between DAG relation
 selection and path-aware edge selection, while preserving separate public
-override surfaces for those families. For the path-aware grouped-summary
-family, the runtime now coordinates that relation-retention choice with the
-grouped-summary selector through a small internal materialization planner
-layer.
+override surfaces for those families. The runtime now also shares one
+internal materialization-planner layer above those policy components: the
+path-aware grouped-summary family uses both relation-retention and
+grouped-summary planning through that shared layer, while the DAG family
+currently uses the relation-retention branch of the same planner.
 
 ## Required Capabilities
 
@@ -89,10 +90,10 @@ Examples:
   runtime can choose between them through that same grouped-summary policy
   layer, record measured cost buckets for that choice, and still expose an
   explicit override via `QueryExecutorOptions.PathAwareWeightSumStrategy`
-- when a path-aware operator family has both relation-retention and
-  grouped-summary policy layers available, the runtime can coordinate them
-  through a materialization planner layer instead of treating them as
-  unrelated decisions
+- when an operator family has both relation-retention and grouped-summary
+  policy layers available, the runtime can coordinate them through a shared
+  materialization planner layer instead of treating them as unrelated
+  decisions
 - other operators may request replay buffers or indexes when needed
 
 ### 3. External materialization fallback
@@ -158,11 +159,16 @@ For the current benchmark/runtime surface, the streamed path is:
    runtime can select between them through that same grouped-summary policy
    layer, record measured cost buckets for that decision, and use bounded
    probes in ambiguous cases before falling back to an explicit executor option
-12. for the current path-aware grouped-summary family, a materialization
-   planner layer now coordinates the earlier edge-retention choice with the
-   later grouped-summary choice and records the combined plan in trace output
-13. the operator builds only the retained state it actually needs
-14. benchmark code avoids preloading raw facts into in-memory relations first
+12. the current runtime now routes both path-aware and DAG planning through
+   a shared internal materialization-planner layer
+13. for the current path-aware grouped-summary family, that planner
+   coordinates the earlier edge-retention choice with the later
+   grouped-summary choice and records the combined plan in trace output
+14. for the current DAG family, that same planner currently records the
+   coordinated relation-retention plan before the operator-owned DAG state is
+   built
+15. the operator builds only the retained state it actually needs
+16. benchmark code avoids preloading raw facts into in-memory relations first
 
 This is still a first step, not the full endpoint, but it is now broader than
 just the original DAG-only fast paths.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -30,12 +30,13 @@ pipelines across the full benchmark range while preserving the same
 all-path semantics. It also now supports cost-guided selection between
 compact grouped weight sums and the legacy seeded-row regrouping path,
 using the same grouped-summary policy layer that now also drives the
-shortest-path minima family. The path-aware family now also coordinates that
-grouped-summary selector with the earlier edge-retention selector through a
-small internal materialization planner layer. That policy now records measured
-cost buckets like `load_roots`, `load_seeds`, `strategy_select`, `build_*`,
-and `group_reduce`, while the earlier path-aware edge-retention boundary now
-also records buckets like `edge_strategy_select`, `edge_probe_*`,
+shortest-path minima family. The path-aware family now coordinates that
+grouped-summary selector with the earlier edge-retention selector through the
+shared internal materialization planner layer that also now covers the DAG
+family's relation-retention planning. That policy now records measured cost
+buckets like `load_roots`, `load_seeds`, `strategy_select`, `build_*`, and
+`group_reduce`, while the earlier path-aware edge-retention boundary now also
+records buckets like `edge_strategy_select`, `edge_probe_*`,
 `edge_materialize_replayable`, and `edge_build_*`.
 
 | Target | 300 art | 1K art | 5K art | 10K art |
@@ -558,7 +559,9 @@ Comparison note:
   selection, and on the current benchmark surface `Auto` prefers
   `ReplayableBuffer`; that selection now runs through the same internal
   relation-retention policy layer that also drives the DAG family, while the
-  benchmark-visible override knobs stay separate
+  combined path-aware materialization decision now flows through the shared
+  internal planner layer and the benchmark-visible override knobs stay
+  separate
 - trace output now exposes edge buckets such as
   `edge_strategy_select`, `edge_probe_streaming_direct`,
   `edge_probe_replayable_buffer`, `edge_materialize_replayable`, and
@@ -707,9 +710,10 @@ Comparison note:
 - relation ingestion now also goes through a measured DAG retention
   selector, and the generated benchmarks expose
   `UNIFYWEAVER_DAG_RETENTION_STRATEGY=auto|streaming|replayable|external`
-- the DAG selector now shares the same internal relation-retention policy layer
-  as path-aware edge retention, while preserving a DAG-specific public override
-  surface
+- the DAG selector now shares the same internal relation-retention policy
+  layer as path-aware edge retention, and now also flows through the same
+  shared internal materialization planner framework while preserving a
+  DAG-specific public override surface
 - on the current synthetic benchmark surface, `Auto` picks
   `StreamingDirect` for the reach-count DAG path; at smaller scales it can
   use bounded probes (`dag_probe_streaming_direct`,

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -524,9 +524,9 @@ namespace UnifyWeaver.QueryRuntime
         PathAwareGroupedSummaryStrategy Strategy,
         string DecisionMode);
 
-    internal readonly record struct PathAwareMaterializationPlanSelection(
-        PathAwareEdgeRetentionSelection EdgeRetention,
-        PathAwareGroupedSummarySelection GroupedSummary,
+    internal readonly record struct MaterializationPlanSelection(
+        RelationRetentionSelection RelationRetention,
+        PathAwareGroupedSummarySelection? GroupedSummary,
         string DecisionMode);
 
     internal readonly record struct DagRelationRetentionSelection(
@@ -8038,6 +8038,12 @@ namespace UnifyWeaver.QueryRuntime
                 _ => PathAwareEdgeRetentionStrategy.Auto
             };
 
+        private static RelationRetentionSelection ToRelationRetentionSelection(DagRelationRetentionSelection selection)
+            => new(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode);
+
+        private static RelationRetentionSelection ToRelationRetentionSelection(PathAwareEdgeRetentionSelection selection)
+            => new(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode);
+
         private static RelationRetentionPolicyStrategy ResolveStructuralRelationRetentionStrategy(
             RelationRetentionPolicyStrategy preferredStrategy,
             bool hasStreaming,
@@ -8623,59 +8629,67 @@ namespace UnifyWeaver.QueryRuntime
                 : $"{nodeStrategyPrefix}CompactGrouped");
         }
 
-        private static PathAwareMaterializationPlanSelection ResolvePathAwareMaterializationPlan(
+        private static string ResolveMaterializationPlanDecisionMode(
+            RelationRetentionSelection relationRetentionSelection,
+            PathAwareGroupedSummarySelection? groupedSummarySelection)
+        {
+            if (groupedSummarySelection is { } groupedSummary)
+            {
+                return groupedSummary.DecisionMode switch
+                {
+                    "ConfiguredOverride" => "ConfiguredSummary",
+                    "MeasuredProbe" when relationRetentionSelection.DecisionMode == "MeasuredProbe" => "MeasuredRelationAndSummary",
+                    "MeasuredProbe" => "MeasuredSummary",
+                    _ when relationRetentionSelection.DecisionMode == "ConfiguredOverride" => "ConfiguredRelation",
+                    _ when relationRetentionSelection.DecisionMode == "MeasuredProbe" => "MeasuredRelation",
+                    _ when relationRetentionSelection.DecisionMode == "ReplayableCached" => "ReplayableCached",
+                    _ when relationRetentionSelection.DecisionMode == "OnlyAvailable" => "OnlyAvailable",
+                    _ => "Structural"
+                };
+            }
+
+            return relationRetentionSelection.DecisionMode switch
+            {
+                "ConfiguredOverride" => "ConfiguredRelation",
+                "MeasuredProbe" => "MeasuredRelation",
+                "ReplayableCached" => "ReplayableCached",
+                "OnlyAvailable" => "OnlyAvailable",
+                _ => "Structural"
+            };
+        }
+
+        private static MaterializationPlanSelection ResolveMaterializationPlan(
             QueryExecutionTrace? trace,
             PlanNode node,
-            PathAwareEdgeRetentionSelection edgeRetentionSelection,
-            PathAwareGroupedSummaryStrategy configuredSummaryStrategy,
-            int groupCount,
-            IReadOnlyList<object?> orderedUniqueSeeds,
-            int rootCount,
-            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
-            Func<IReadOnlyList<object?>, TimeSpan>? measureCompactProbe = null,
-            Func<IReadOnlyList<object?>, TimeSpan>? measureLegacyProbe = null)
+            RelationRetentionSelection relationRetentionSelection,
+            Func<PathAwareGroupedSummarySelection>? resolveGroupedSummarySelection = null)
         {
             return MeasurePhase(trace, node, "materialization_plan_select", () =>
             {
-                var groupedSummarySelection = ResolvePathAwareGroupedSummaryStrategy(
-                    trace,
-                    node,
-                    configuredSummaryStrategy,
-                    groupCount,
-                    orderedUniqueSeeds,
-                    rootCount,
-                    succIndex,
-                    edgeRetentionSelection.Strategy,
-                    measureCompactProbe,
-                    measureLegacyProbe);
-
-                var decisionMode = groupedSummarySelection.DecisionMode switch
-                {
-                    "ConfiguredOverride" => "ConfiguredSummary",
-                    "MeasuredProbe" when edgeRetentionSelection.DecisionMode == "MeasuredProbe" => "MeasuredRelationAndSummary",
-                    "MeasuredProbe" => "MeasuredSummary",
-                    _ when edgeRetentionSelection.DecisionMode == "MeasuredProbe" => "MeasuredRelation",
-                    _ when edgeRetentionSelection.DecisionMode == "ConfiguredOverride" => "ConfiguredRelation",
-                    _ when edgeRetentionSelection.DecisionMode == "ReplayableCached" => "ReplayableCached",
-                    _ => "Structural"
-                };
-
-                return new PathAwareMaterializationPlanSelection(
-                    edgeRetentionSelection,
+                var groupedSummarySelection = resolveGroupedSummarySelection?.Invoke();
+                return new MaterializationPlanSelection(
+                    relationRetentionSelection,
                     groupedSummarySelection,
-                    decisionMode);
+                    ResolveMaterializationPlanDecisionMode(relationRetentionSelection, groupedSummarySelection));
             });
         }
 
-        private static void RecordPathAwareMaterializationPlanStrategy(
+        private static void RecordMaterializationPlanStrategy(
             QueryExecutionTrace? trace,
             PlanNode node,
             string nodeStrategyPrefix,
-            PathAwareMaterializationPlanSelection selection)
+            MaterializationPlanSelection selection)
         {
             trace?.RecordStrategy(node, $"{nodeStrategyPrefix}MaterializationPlanSelection{selection.DecisionMode}");
-            trace?.RecordStrategy(node,
-                $"{nodeStrategyPrefix}MaterializationPlanEdge{selection.EdgeRetention.Strategy}Summary{selection.GroupedSummary.Strategy}");
+            if (selection.GroupedSummary is { } groupedSummary)
+            {
+                trace?.RecordStrategy(node,
+                    $"{nodeStrategyPrefix}MaterializationPlanRelation{selection.RelationRetention.Strategy}Summary{groupedSummary.Strategy}");
+            }
+            else
+            {
+                trace?.RecordStrategy(node, $"{nodeStrategyPrefix}MaterializationPlanRelation{selection.RelationRetention.Strategy}");
+            }
         }
 
         private IReadOnlyDictionary<object, Dictionary<object, double>> ExecuteSeedGroupedPathAwareWeightSumFallback(
@@ -8905,21 +8919,27 @@ namespace UnifyWeaver.QueryRuntime
                 TimeSpan MeasureLegacyProbe(IReadOnlyList<object?> sampleSeeds) =>
                     MeasureElapsed(() => _ = ExecuteSeedGroupedPathAwareWeightSumFallback(closure, sampleSeeds, rootKeys, context));
 
-                var materializationPlan = ResolvePathAwareMaterializationPlan(
+                var materializationPlan = ResolveMaterializationPlan(
                     trace,
                     closure,
-                    edgeRetentionSelection,
-                    _pathAwareWeightSumStrategy,
-                    groupValues.Count,
-                    orderedUniqueSeeds,
-                    rootKeys.Count,
-                    succIndex,
-                    MeasureCompactProbe,
-                    MeasureLegacyProbe);
-                RecordPathAwareMaterializationPlanStrategy(trace, closure, "SeedGroupedPathAwareWeightSum", materializationPlan);
-                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareWeightSum", materializationPlan.GroupedSummary);
+                    ToRelationRetentionSelection(edgeRetentionSelection),
+                    () => ResolvePathAwareGroupedSummaryStrategy(
+                        trace,
+                        closure,
+                        _pathAwareWeightSumStrategy,
+                        groupValues.Count,
+                        orderedUniqueSeeds,
+                        rootKeys.Count,
+                        succIndex,
+                        edgeRetentionSelection.Strategy,
+                        MeasureCompactProbe,
+                        MeasureLegacyProbe));
+                RecordMaterializationPlanStrategy(trace, closure, "SeedGroupedPathAwareWeightSum", materializationPlan);
+                var groupedSummarySelection = materializationPlan.GroupedSummary
+                    ?? throw new InvalidOperationException("Expected grouped-summary selection for SeedGroupedPathAwareWeightSumNode.");
+                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareWeightSum", groupedSummarySelection);
 
-                IReadOnlyDictionary<object, Dictionary<object, double>> seedWeightSums = materializationPlan.GroupedSummary.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows
+                IReadOnlyDictionary<object, Dictionary<object, double>> seedWeightSums = groupedSummarySelection.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows
                     ? MeasurePhase(trace, closure, "build_legacy_seeded_rows", () =>
                         (IReadOnlyDictionary<object, Dictionary<object, double>>)ExecuteSeedGroupedPathAwareWeightSumFallback(closure, orderedUniqueSeeds, rootKeys, context))
                     : MeasurePhase(trace, closure, "build_compact_grouped", () =>
@@ -9240,21 +9260,27 @@ namespace UnifyWeaver.QueryRuntime
                 TimeSpan MeasureLegacyProbe(IReadOnlyList<object?> sampleSeeds) =>
                     MeasureElapsed(() => _ = ExecuteSeedGroupedPathAwareDepthMinFallback(closure, sampleSeeds, rootKeys, context));
 
-                var materializationPlan = ResolvePathAwareMaterializationPlan(
+                var materializationPlan = ResolveMaterializationPlan(
                     trace,
                     closure,
-                    edgeRetentionSelection,
-                    _pathAwareGroupedMinStrategy,
-                    groupValues.Count,
-                    orderedUniqueSeeds,
-                    rootKeys.Count,
-                    succIndex,
-                    MeasureCompactProbe,
-                    MeasureLegacyProbe);
-                RecordPathAwareMaterializationPlanStrategy(trace, closure, "SeedGroupedPathAwareDepthMin", materializationPlan);
-                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareDepthMin", materializationPlan.GroupedSummary);
+                    ToRelationRetentionSelection(edgeRetentionSelection),
+                    () => ResolvePathAwareGroupedSummaryStrategy(
+                        trace,
+                        closure,
+                        _pathAwareGroupedMinStrategy,
+                        groupValues.Count,
+                        orderedUniqueSeeds,
+                        rootKeys.Count,
+                        succIndex,
+                        edgeRetentionSelection.Strategy,
+                        MeasureCompactProbe,
+                        MeasureLegacyProbe));
+                RecordMaterializationPlanStrategy(trace, closure, "SeedGroupedPathAwareDepthMin", materializationPlan);
+                var groupedSummarySelection = materializationPlan.GroupedSummary
+                    ?? throw new InvalidOperationException("Expected grouped-summary selection for SeedGroupedPathAwareDepthMinNode.");
+                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareDepthMin", groupedSummarySelection);
 
-                IReadOnlyDictionary<object, Dictionary<object, int>> seedDepthMins = materializationPlan.GroupedSummary.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows
+                IReadOnlyDictionary<object, Dictionary<object, int>> seedDepthMins = groupedSummarySelection.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows
                     ? MeasurePhase(trace, closure, "build_legacy_seeded_rows", () =>
                         (IReadOnlyDictionary<object, Dictionary<object, int>>)ExecuteSeedGroupedPathAwareDepthMinFallback(closure, orderedUniqueSeeds, rootKeys, context))
                     : MeasurePhase(trace, closure, "build_compact_grouped", () =>
@@ -9530,22 +9556,28 @@ namespace UnifyWeaver.QueryRuntime
                 TimeSpan MeasureLegacyProbe(IReadOnlyList<object?> sampleSeeds) =>
                     MeasureElapsed(() => _ = ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, sampleSeeds, rootKeys, context));
 
-                var materializationPlan = ResolvePathAwareMaterializationPlan(
+                var materializationPlan = ResolveMaterializationPlan(
                     trace,
                     closure,
-                    edgeRetentionSelection,
-                    _pathAwareGroupedMinStrategy,
-                    groupValues.Count,
-                    orderedUniqueSeeds,
-                    rootKeys.Count,
-                    succIndex,
-                    MeasureCompactProbe,
-                    MeasureLegacyProbe);
-                RecordPathAwareMaterializationPlanStrategy(trace, closure, "SeedGroupedPathAwareAccumulationMin", materializationPlan);
-                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareAccumulationMin", materializationPlan.GroupedSummary);
+                    ToRelationRetentionSelection(edgeRetentionSelection),
+                    () => ResolvePathAwareGroupedSummaryStrategy(
+                        trace,
+                        closure,
+                        _pathAwareGroupedMinStrategy,
+                        groupValues.Count,
+                        orderedUniqueSeeds,
+                        rootKeys.Count,
+                        succIndex,
+                        edgeRetentionSelection.Strategy,
+                        MeasureCompactProbe,
+                        MeasureLegacyProbe));
+                RecordMaterializationPlanStrategy(trace, closure, "SeedGroupedPathAwareAccumulationMin", materializationPlan);
+                var groupedSummarySelection = materializationPlan.GroupedSummary
+                    ?? throw new InvalidOperationException("Expected grouped-summary selection for SeedGroupedPathAwareAccumulationMinNode.");
+                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareAccumulationMin", groupedSummarySelection);
 
                 IReadOnlyDictionary<object, Dictionary<object, object>> seedMinima;
-                if (materializationPlan.GroupedSummary.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows)
+                if (groupedSummarySelection.Strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows)
                 {
                     seedMinima = MeasurePhase(trace, closure, "build_legacy_seeded_rows", () =>
                         (IReadOnlyDictionary<object, Dictionary<object, object>>)ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, orderedUniqueSeeds, rootKeys, context));
@@ -10879,6 +10911,11 @@ namespace UnifyWeaver.QueryRuntime
                     measureReplayableProbe,
                     measureExternalProbe);
                 RecordDagRelationRetentionStrategy(trace, closure, selection);
+                var materializationPlan = ResolveMaterializationPlan(
+                    trace,
+                    closure,
+                    ToRelationRetentionSelection(selection));
+                RecordMaterializationPlanStrategy(trace, closure, "SeedGroupedTransitiveClosureCount", materializationPlan);
 
                 List<object[]>? edges = null;
                 List<object[]>? seeds = null;
@@ -11083,6 +11120,11 @@ namespace UnifyWeaver.QueryRuntime
                     measureReplayableProbe,
                     measureExternalProbe);
                 RecordDagRelationRetentionStrategy(trace, closure, selection);
+                var materializationPlan = ResolveMaterializationPlan(
+                    trace,
+                    closure,
+                    ToRelationRetentionSelection(selection));
+                RecordMaterializationPlanStrategy(trace, closure, "SeedGroupedDagLongestDepth", materializationPlan);
 
                 if (selection.Strategy == DagRelationRetentionStrategy.StreamingDirect && hasStreaming)
                 {


### PR DESCRIPTION
  ## Summary

  This PR lifts the recent path-aware materialization planner into a shared
  internal runtime materialization-planning layer.

  Before this change, the runtime already had:

  - a shared grouped-summary policy
  - a shared relation-retention policy
  - a path-aware materialization planner that coordinated those two
    policies for the path-aware family

  That was a good intermediate step, but the planner itself was still
  path-aware-specific.

  This PR generalizes that layer so the runtime now has one shared internal
  materialization planner:

  - path-aware operators use both the relation-retention and grouped-summary
    branches
  - DAG operators use the same planner framework and trace vocabulary,
    currently through the relation-retention branch

  ## What Changed

  ### Shared Internal Materialization Planner

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added/refactored:

  - a shared internal `MaterializationPlanSelection`
  - shared plan-decision-mode resolution
  - shared plan-resolution helpers
  - shared materialization-plan trace recording

  The planner now sits above the existing shared policy layers and provides
  one internal place where the runtime coordinates retained-state choices.

  ### Path-Aware Family Now Uses Shared Planner Directly

  The path-aware grouped-summary family now routes through the shared
  planner rather than a path-aware-specific planner record.

  This applies to:

  - `SeedGroupedPathAwareDepthMinNode`
  - `SeedGroupedPathAwareAccumulationMinNode`
  - `SeedGroupedPathAwareWeightSumNode`

  The planner coordinates:

  - relation retention
  - grouped-summary retained form

  and records combined plan traces such as:

  - `...MaterializationPlanRelationReplayableBufferSummaryCompactGrouped`
  - `...MaterializationPlanSelectionMeasuredRelation`

  ### DAG Family Now Uses The Same Planner Framework

  The DAG family now also routes through the same shared planner framework
  and trace vocabulary.

  This currently applies to:

  - `SeedGroupedTransitiveClosureCountNode`
  - `SeedGroupedDagLongestDepthNode`

  For DAG, the planner currently only uses:

  - the relation-retention branch

  because DAG does not yet have an alternative grouped-summary retained form
  analogous to the path-aware family.

  But the planner surface is now shared rather than separate.

  ### Public Override Knobs Preserved

  This PR is an internal planner refactor. It does **not** change the
  benchmark-visible public option surface.

  These still remain intact:

  - `DagRelationRetentionStrategy`
  - `PathAwareEdgeRetentionStrategy`
  - `PathAwareGroupedMinStrategy`
  - `PathAwareWeightSumStrategy`

  So existing benchmark override and trace workflows remain valid.

  ### Documentation Updates

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`
  - `examples/benchmark/README.md`

  These docs now describe the runtime more accurately:

  - one shared internal materialization planner
  - one shared relation-retention policy
  - one shared grouped-summary policy
  - family-specific override knobs preserved on top

  ## Why This Matters

  The main value of this PR is architectural.

  The runtime had reached the point where:

  - retained-form policy was already shared
  - relation-retention policy was already shared
  - but the planner that coordinates them was still local to one family

  That duplication was the next bottleneck.

  This PR turns the planner itself into a reusable runtime capability.

  That matters because it gives the engine a cleaner foundation for future
  materialization work:

  - more operator families can plug into one planner framework
  - trace vocabulary becomes more consistent
  - coordination between lower-level retention and higher-level retained
    summary form now has a natural home

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_category_influence_cross_target.py \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py

  ### Full reruns

  Ran locally:

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated \
      --repetitions 1

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  All outputs still matched.

  ### Trace sanity check

  With:

  UNIFYWEAVER_BENCH_TRACE=1 \
  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query \
      --repetitions 1

  the runtime now reports the combined planner traces alongside the existing
  strategy traces, for example:

  - strategy_PathAwareEdgeRetentionReplayableBuffer=1
  - strategy_SeedGroupedPathAwareDepthMinCompactGrouped=1
  - strategy_SeedGroupedPathAwareDepthMinMaterializationPlanRelationReplayableBufferSummaryCompactGrouped=1

  This confirms that the shared planner layer is active and visible.

  ## Representative Results

  ### Shortest path

  - 300: csharp-query 0.172s
  - 10k: csharp-query 0.202s

  ### Weighted shortest path

  - 300: csharp-query 0.359s
  - 10k: csharp-query 0.435s

  ### Effective distance

  - 300: csharp-query 0.312s
  - 10k: csharp-query 0.931s

  ### Category influence

  - 300: csharp-query 0.422s
  - 10k: csharp-query 1.009s

  ### Dependency reach-count

  - 300: csharp-query 0.077s
  - 10k: csharp-query 0.089s

  ### Dependency longest depth

  - 300: csharp-query 0.068s
  - 10k: csharp-query 0.092s

  ## Interpretation

  This PR is a planner-layer refactor, not a new retained-summary
  optimization by itself.

  The important result is that the runtime now has:

  - one shared internal materialization planner
  - shared coordination of retention and retained-form choice
  - consistent planner traces across families
  - preserved public override surfaces for benchmarking and diagnosis

  That is the right foundation for expanding the planner to additional
  operator families and eventually making the materialization story more
  globally coherent across the runtime.

  ## Scope

  This PR adds:

  - a shared internal materialization-planner layer
  - path-aware adaptation to that layer
  - DAG adaptation to the same planner framework and trace vocabulary
  - documentation updates describing the unified planner architecture

  It does not yet add:

  - new retained-summary forms for DAG operators
  - a universal planner across every operator family in the runtime
  - global cost optimization across all runtime planning choices

  ## Follow-Up

  Likely next work:

  - extend the shared planner to additional operator families
  - connect more retained-form choices into the shared planner rather than
    leaving them as local operator decisions
  - continue refining measured planning so relation-retention and retained
    summary decisions can be coordinated more broadly across the runtime