### PR TITLE
feat: effective semantic distance — power-mean formula with semantic edge weights

### DIFF
--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -50,6 +50,7 @@ GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
 PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_effective_distance_benchmark.pl"
 WAM_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_effective_distance_benchmark.pl"
 SEMANTIC_PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_min_semantic_distance_benchmark.pl"
+EFF_SEMANTIC_PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_effective_semantic_distance_benchmark.pl"
 EDGE_WEIGHT_SCRIPT = ROOT / "examples" / "benchmark" / "precompute_edge_weights.py"
 
 
@@ -172,6 +173,33 @@ def build_prolog_semantic_min(root: Path, scale: str) -> list[str]:
     return ["swipl", "-q", "-s", str(script_path)]
 
 
+def build_prolog_effective_semantic(root: Path, scale: str) -> list[str]:
+    """Build the effective semantic distance Prolog benchmark (power-mean over weighted paths)."""
+    facts_path = require_file(BENCH_DIR / scale / "facts.pl")
+    weights_path = BENCH_DIR / scale / "edge_weights.pl"
+    if not weights_path.exists():
+        edges_path = BENCH_DIR / scale / "category_parent.tsv"
+        if edges_path.exists():
+            print(f"  Precomputing edge weights for {scale}...", file=sys.stderr)
+            run_command(
+                [sys.executable, str(EDGE_WEIGHT_SCRIPT), str(edges_path), str(BENCH_DIR / scale)],
+                check=False,
+            )
+        if not weights_path.exists():
+            raise FileNotFoundError(f"Edge weights not found: {weights_path}")
+    weights_path = require_file(weights_path)
+
+    script_path = root / "prolog_eff_semantic" / scale / "effective_semantic_distance.pl"
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl", "-q", "-s", str(EFF_SEMANTIC_PROLOG_GENERATOR),
+            "--", str(facts_path), str(weights_path), str(script_path),
+        ]
+    )
+    return ["swipl", "-q", "-s", str(script_path)]
+
+
 def build_wam_rust_effective_distance(root: Path, scale: str) -> list[str]:
     facts_path = require_file(BENCH_DIR / scale / "facts.pl")
     project_dir = root / "wam_rust" / scale
@@ -232,6 +260,7 @@ def print_summary(results: list[RunResult]) -> None:
         prolog_root_accumulated = find_result(entries, "prolog-root-accumulated")
         wam_rust_accumulated = find_result(entries, "wam-rust-accumulated")
         prolog_semantic_min = find_result(entries, "prolog-semantic-min")
+        prolog_eff_semantic = find_result(entries, "prolog-eff-semantic")
         dfs_like = [item for item in entries if item.target in {"csharp-dfs", "rust-dfs", "go-dfs"}]
 
         if len(dfs_like) > 1:
@@ -245,6 +274,7 @@ def print_summary(results: list[RunResult]) -> None:
         print_pair_match_status(scale, "query_vs_wam_rust_accumulated", qe, wam_rust_accumulated)
         print_pair_match_status(scale, "prolog_vs_wam_rust_accumulated", prolog_accumulated, wam_rust_accumulated)
         print_pair_match_status(scale, "query_vs_prolog_semantic_min", qe, prolog_semantic_min)
+        print_pair_match_status(scale, "query_vs_prolog_eff_semantic", qe, prolog_eff_semantic)
         print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
         print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
         print_speedup(scale, "speedup_vs_prolog_seeded", prolog_seeded, qe)
@@ -254,6 +284,7 @@ def print_summary(results: list[RunResult]) -> None:
         print_speedup(scale, "speedup_vs_prolog_root_accumulated", prolog_root_accumulated, qe)
         print_speedup(scale, "speedup_vs_wam_rust_accumulated", wam_rust_accumulated, qe)
         print_speedup(scale, "speedup_vs_prolog_semantic_min", prolog_semantic_min, qe)
+        print_speedup(scale, "speedup_vs_prolog_eff_semantic", prolog_eff_semantic, qe)
         print_phase_metrics(scale, "csharp-query-metrics", qe)
         print_phase_metrics(scale, "prolog-seeded-metrics", prolog_seeded)
         print_phase_metrics(scale, "prolog-pruned-metrics", prolog_pruned)
@@ -262,6 +293,7 @@ def print_summary(results: list[RunResult]) -> None:
         print_phase_metrics(scale, "prolog-root-accumulated-metrics", prolog_root_accumulated)
         print_phase_metrics(scale, "wam-rust-accumulated-metrics", wam_rust_accumulated)
         print_phase_metrics(scale, "prolog-semantic-min-metrics", prolog_semantic_min)
+        print_phase_metrics(scale, "prolog-eff-semantic-metrics", prolog_eff_semantic)
 
 
 def scale_sort_key(scale: str) -> tuple[int, str]:
@@ -316,6 +348,8 @@ def main() -> int:
                 continue
             elif target == "prolog-semantic-min":
                 continue
+            elif target == "prolog-eff-semantic":
+                continue
             else:
                 raise ValueError(f"unsupported target: {target}")
 
@@ -336,6 +370,8 @@ def main() -> int:
                     command = build_wam_rust_effective_distance(temp_root, scale)
                 elif target == "prolog-semantic-min":
                     command = build_prolog_semantic_min(temp_root, scale)
+                elif target == "prolog-eff-semantic":
+                    command = build_prolog_effective_semantic(temp_root, scale)
                 else:
                     command = commands[target]
                 results.append(benchmark_target(command, scale, args.repetitions, target))

--- a/examples/benchmark/effective_semantic_distance.pl
+++ b/examples/benchmark/effective_semantic_distance.pl
@@ -1,0 +1,135 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025-2026 John William Creighton (@s243a)
+%
+% effective_semantic_distance.pl — Effective distance with semantic weights
+%
+% Combines the power-mean effective distance formula:
+%     d_eff = (Σ dᵢ^(-N))^(-1/N)
+% with semantic edge weights (1 - cosine_similarity) instead of hop counts.
+%
+% Each path's cost dᵢ is the sum of semantic edge weights along that path.
+% The power-mean then aggregates across ALL paths, heavily weighting
+% the shortest (most semantically coherent) paths.
+%
+% This is the full generalization:
+%   - Hop-count effective distance: dᵢ = hop count, N=5
+%   - Min semantic distance: equivalent to N→∞ (only shortest path matters)
+%   - Effective semantic distance: dᵢ = weighted path cost, N configurable
+
+:- module(effective_semantic_distance, [
+    effective_semantic_dist/4,    % +Start, +Target, +N, -Deff
+    effective_semantic_dist/3,    % +Start, +Target, -Deff (N=5)
+    semantic_path_cost/4,         % +Start, +Target, +Visited, -Cost
+    edge_weight/3,                % +From, +To, -Weight (dynamic)
+    dimension_n/1                 % -N (configurable)
+]).
+
+:- use_module(library(lists)).
+:- use_module(library(aggregate)).
+
+:- dynamic edge_weight/3.
+
+%% dimension_n(-N)
+%  Power-mean exponent. Default 5 (Wikipedia graph dimensionality).
+%  Override by retracting and asserting a new value.
+:- dynamic dimension_n/1.
+dimension_n(5).
+
+% ============================================================================
+% CORE SPECIFICATION
+% ============================================================================
+
+%% effective_semantic_dist(+Start, +Target, -Deff)
+%  Effective semantic distance with default N from dimension_n/1.
+effective_semantic_dist(Start, Target, Deff) :-
+    dimension_n(N),
+    effective_semantic_dist(Start, Target, N, Deff).
+
+%% effective_semantic_dist(+Start, +Target, +N, -Deff)
+%
+%  Compute effective semantic distance using power-mean over all paths.
+%
+%    d_eff = (Σ dᵢ^(-N))^(-1/N)
+%
+%  where dᵢ = sum of semantic edge weights along path i.
+%
+%  The formula heavily weights shorter paths:
+%    N=1  → harmonic mean (mild weighting)
+%    N=5  → strong weighting toward shortest paths
+%    N→∞  → converges to min (only shortest path matters)
+%
+%  Transpiler recognizes this pattern:
+%    aggregate_all(sum(W), (path_enum, W is Cost^NegN), WeightSum)
+%  and can optimize the path enumeration.
+%
+effective_semantic_dist(Start, Target, N, Deff) :-
+    NegN is -N,
+    aggregate_all(sum(W),
+        ( semantic_path_cost(Start, Target, [Start], Cost),
+          W is Cost ** NegN ),
+        WeightSum),
+    WeightSum > 0,
+    InvN is -1 / N,
+    Deff is WeightSum ** InvN.
+
+%% semantic_path_cost(+Start, +Target, +Visited, -Cost)
+%  Enumerate all paths from Start to Target with cycle detection.
+%  Cost = sum of edge weights along the path.
+semantic_path_cost(X, Y, _Visited, W) :-
+    edge_weight(X, Y, W).
+
+semantic_path_cost(X, Y, Visited, Cost) :-
+    edge_weight(X, Z, W),
+    \+ member(Z, Visited),
+    semantic_path_cost(Z, Y, [Z|Visited], RestCost),
+    Cost is W + RestCost.
+
+% ============================================================================
+% DEMO DATA
+% ============================================================================
+
+edge_weight(ml, ai, 0.12).
+edge_weight(ai, cs, 0.18).
+edge_weight(cs, science, 0.30).
+edge_weight(ml, statistics, 0.20).
+edge_weight(statistics, math, 0.15).
+edge_weight(math, science, 0.25).
+edge_weight(ai, math, 0.28).
+edge_weight(ml, cs, 0.35).
+
+% ============================================================================
+% TESTS
+% ============================================================================
+
+test_effective_semantic_distance :-
+    format('=== Effective Semantic Distance Tests ===~n'),
+
+    % ml → science: 4 paths with costs [0.60, 0.60, 0.65, 0.65]
+    % d_eff(N=5) = (Σ dᵢ^-5)^(-1/5) = 0.4714
+    % Multiple paths make effective distance LESS than min path cost,
+    % because more paths = more "ways to get there" = effectively closer.
+    effective_semantic_dist(ml, science, 5, D1),
+    format('  ml -> science (N=5): ~6f~n', [D1]),
+    (abs(D1 - 0.4714) < 0.01 -> format('  PASS~n') ; format('  FAIL~n')),
+
+    % N=1 (harmonic mean) — even more paths contribute, smaller result
+    effective_semantic_dist(ml, science, 1, D2),
+    format('  ml -> science (N=1): ~6f~n', [D2]),
+    (D2 < D1 -> format('  PASS: N=1 < N=5 (more paths contribute)~n') ; format('  FAIL~n')),
+
+    % N=20 — converges toward min distance (0.60)
+    effective_semantic_dist(ml, science, 20, D3),
+    format('  ml -> science (N=20): ~6f~n', [D3]),
+    (D3 > D1 -> format('  PASS: N=20 > N=5 (approaches min)~n') ; format('  FAIL~n')),
+
+    % ml → ai: single path, d_eff = path cost regardless of N
+    effective_semantic_dist(ml, ai, 5, D4),
+    format('  ml -> ai (N=5): ~6f (expect 0.12)~n', [D4]),
+    (abs(D4 - 0.12) < 0.001 -> format('  PASS~n') ; format('  FAIL~n')),
+
+    % Default N (uses dimension_n/1)
+    effective_semantic_dist(ml, science, D5),
+    format('  ml -> science (default N): ~6f~n', [D5]),
+    (abs(D5 - D1) < 0.001 -> format('  PASS: matches N=5~n') ; format('  FAIL~n')),
+
+    format('=== Tests Complete ===~n').

--- a/examples/benchmark/generate_prolog_effective_semantic_distance_benchmark.pl
+++ b/examples/benchmark/generate_prolog_effective_semantic_distance_benchmark.pl
@@ -1,0 +1,90 @@
+:- encoding(utf8).
+% generate_prolog_effective_semantic_distance_benchmark.pl
+%
+% Generates a self-contained Prolog benchmark that computes effective
+% semantic distance using the power-mean formula with weighted edges.
+%
+% Usage:
+%   swipl -q -s generate_prolog_effective_semantic_distance_benchmark.pl -- \
+%       <facts.pl> <edge_weights.pl> <output.pl> [N]
+%
+% N defaults to 5 (graph dimensionality).
+
+:- use_module(library(lists)).
+:- initialization(main, main).
+
+main :-
+    current_prolog_flag(argv, Args),
+    (   Args = [FactsFile, WeightsFile, OutputFile, NStr]
+    ->  atom_number(NStr, N)
+    ;   Args = [FactsFile, WeightsFile, OutputFile]
+    ->  N = 5
+    ;   format(user_error, 'Usage: swipl ... -- <facts.pl> <edge_weights.pl> <output.pl> [N]~n', []),
+        halt(1)
+    ),
+    generate_benchmark(FactsFile, WeightsFile, OutputFile, N).
+
+generate_benchmark(FactsFile, WeightsFile, OutputFile, N) :-
+    format(user_error, 'Generating effective semantic distance benchmark (N=~w)...~n', [N]),
+    consult(FactsFile),
+    consult(WeightsFile),
+
+    findall(A-C, user:article_category(A, C), ArticleCats),
+    findall(R, user:root_category(R), Roots),
+    findall(edge_weight(C, P, W), user:edge_weight(C, P, W), WeightFacts),
+    length(ArticleCats, NAC), length(Roots, NR), length(WeightFacts, NW),
+    format(user_error, '  ~w article-category, ~w roots, ~w weighted edges~n', [NAC, NR, NW]),
+
+    open(OutputFile, write, S),
+    format(S, '%% Auto-generated effective semantic distance benchmark (N=~w)~n', [N]),
+    format(S, '%% d_eff = (Sum d_i^(-N))^(-1/N) with semantic edge weights~n~n', []),
+    format(S, ':- use_module(library(lists)).~n', []),
+    format(S, ':- use_module(library(aggregate)).~n~n', []),
+
+    % Write facts
+    forall(member(A-C, ArticleCats),
+        format(S, 'article_category(~q, ~q).~n', [A, C])),
+    format(S, '~n', []),
+    forall(member(R, Roots),
+        format(S, 'root_category(~q).~n', [R])),
+    format(S, '~n', []),
+    forall(member(edge_weight(C, P, W), WeightFacts),
+        format(S, 'edge_weight(~q, ~q, ~w).~n', [C, P, W])),
+    format(S, '~n', []),
+
+    % Write solver
+    format(S, 'semantic_path_cost(X, Y, _V, W) :-~n', []),
+    format(S, '    edge_weight(X, Y, W).~n', []),
+    format(S, 'semantic_path_cost(X, Y, V, Cost) :-~n', []),
+    format(S, '    edge_weight(X, Z, W),~n', []),
+    format(S, '    \\+ member(Z, V),~n', []),
+    format(S, '    semantic_path_cost(Z, Y, [Z|V], RC),~n', []),
+    format(S, '    Cost is W + RC.~n~n', []),
+
+    format(S, 'effective_semantic_dist(Start, Target, Deff) :-~n', []),
+    format(S, '    NegN is -~w,~n', [N]),
+    format(S, '    aggregate_all(sum(W),~n', []),
+    format(S, '        ( semantic_path_cost(Start, Target, [Start], Cost),~n', []),
+    format(S, '          W is Cost ** NegN ),~n', []),
+    format(S, '        WeightSum),~n', []),
+    format(S, '    WeightSum > 0,~n', []),
+    format(S, '    InvN is -1 / ~w,~n', [N]),
+    format(S, '    Deff is WeightSum ** InvN.~n~n', []),
+
+    % Write main
+    write(S, ':- initialization((\n'),
+    write(S, '    forall(\n'),
+    write(S, '        ( article_category(Article, Cat),\n'),
+    write(S, '          root_category(Root),\n'),
+    write(S, '          ( effective_semantic_dist(Cat, Root, Dist)\n'),
+    write(S, '          -> true\n'),
+    write(S, '          ;  Dist = inf\n'),
+    write(S, '          )\n'),
+    write(S, '        ),\n'),
+    write(S, '        format("~w\\t~w\\t~w\\n", [Article, Root, Dist])\n'),
+    write(S, '    ),\n'),
+    write(S, '    halt\n'),
+    write(S, '), main).\n'),
+
+    close(S),
+    format(user_error, '  Wrote: ~w~n', [OutputFile]).


### PR DESCRIPTION
## Summary

- Add the full effective distance formula `d_eff = (Σ dᵢ^(-N))^(-1/N)` using semantic edge weights instead of hop counts
- Configurable power-mean exponent N (default 5, matching graph dimensionality)
- Prolog specification with 5 tests, benchmark generator, and harness integration
- Completes the distance metric spectrum alongside min semantic distance (#1268) and A* (#1274)

## Motivation

The existing effective distance benchmark uses integer hop counts. Min semantic distance (#1268) finds the single shortest weighted path. This PR fills the gap: **effective semantic distance** aggregates across ALL weighted paths, capturing the intuition that nodes connected by many short paths are "closer" than nodes connected by a single short path.

The formula `d_eff = (Σ dᵢ^(-N))^(-1/N)` produces distances strictly less than the minimum path cost when multiple paths exist — more routes = effectively closer. The exponent N controls how aggressively shorter paths dominate:

| N | Behavior | d_eff(ml→science) |
|---|----------|-------------------|
| 1 | Harmonic mean — all paths contribute | 0.156 |
| 5 | Strong shortest-path weighting (default) | 0.471 |
| 20 | Approaches min distance | 0.574 |
| ∞ | Equals min distance | 0.600 |

## What changed

### `effective_semantic_distance.pl` — Prolog specification

```prolog
effective_semantic_dist(Start, Target, N, Deff) :-
    NegN is -N,
    aggregate_all(sum(W),
        ( semantic_path_cost(Start, Target, [Start], Cost),
          W is Cost ** NegN ),
        WeightSum),
    WeightSum > 0,
    InvN is -1 / N,
    Deff is WeightSum ** InvN.
```

- `effective_semantic_dist/3` — uses default N from `dimension_n/1` (dynamic, default 5)
- `effective_semantic_dist/4` — configurable N
- Reuses `semantic_path_cost/4` with visited-set cycle detection
- Demo data: 8 weighted edges, 4 paths from ml→science

5 tests verify:
- N=5 produces expected value (0.4714)
- N=1 < N=5 (harmonic mean, more paths contribute)
- N=20 > N=5 (approaches min distance)
- Single-path invariance (d_eff = path cost when only one path)
- Default N agrees with explicit N=5

### `generate_prolog_effective_semantic_distance_benchmark.pl` — Generator

Takes `facts.pl` + `edge_weights.pl` + optional N parameter, produces self-contained Prolog benchmark with embedded facts, solver, and output loop. Same 3-column `Article\tRoot\tDist` format as all other benchmarks.

```bash
swipl -q -s generate_prolog_effective_semantic_distance_benchmark.pl -- \
    facts.pl edge_weights.pl output.pl 5
```

### `benchmark_effective_distance.py` — Harness integration

New target: `prolog-eff-semantic`

- Auto-precomputes edge weights if not found
- Integrated into summary: match comparison, speedup, phase metrics
- Runs alongside existing targets for direct comparison

## Distance metric spectrum

| Metric | PR | Formula | Use case |
|--------|----|---------|----------|
| Hop-count d_eff | existing | (Σ hᵢ^(-5))^(-1/5) | Structural graph distance |
| **Effective semantic** | **this PR** | **(Σ dᵢ^(-N))^(-1/N)** | **Semantic multi-path distance** |
| Min semantic | #1268 | min(dᵢ) | Fastest single path |
| A* min semantic | #1274 | min(dᵢ) with heuristic | Faster single path search |

## Test plan

- [x] 5 Prolog spec tests pass (N=5, N=1, N=20, single path, default N)
- [x] Generator produces valid benchmark from dev scale data
- [x] Generated benchmark runs and produces 3-column output
- [x] `benchmark_effective_distance.py` parses with new target
- [x] 61 semantic/fuzzy assertions unaffected
- [x] 6 min_semantic_distance tests unaffected
