### PR TITLE
fix(rust): lower A* aggregate wrappers correctly

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -4167,6 +4167,82 @@ compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _Inc
     get_dict(op, AggInfo, min),
     get_dict(expr, AggInfo, Expr),
     get_dict(relations, GoalInfo, [RelGoal|_]),
+    RelGoal =.. [InnerPred, _StartArg, TargetArg, _DimArg, CostArg],
+    Expr == CostArg,
+    var(TargetArg),
+    functor(InnerHead, InnerPred, 4),
+    findall(InnerHead-InnerBody, user:clause(InnerHead, InnerBody), Clauses),
+    Clauses \= [],
+    rust_foreign_lowerable_astar_shortest_path(InnerPred, 4, Clauses,
+        WeightPred/3, FactTriples, DirectPred/3, DirectTriples, DefaultDim),
+    atom_string(Pred, PredStr),
+    atom_string(InnerPred, InnerPredStr),
+    format(string(WeightPredKey), '~w/3', [WeightPred]),
+    format(string(DirectPredKey), '~w/3', [DirectPred]),
+    rust_weighted_fact_triples_literal(FactTriples, WeightTriplesLiteral),
+    rust_weighted_fact_triples_literal(DirectTriples, DirectTriplesLiteral),
+    format(string(RustCode),
+'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool {
+    vm.reset_query();
+    vm.code = Vec::new();
+    vm.labels = HashMap::new();
+    vm.pc = 1;
+    vm.register_foreign_native_kind("~w/4", "astar_shortest_path4");
+    vm.register_foreign_result_layout("~w/4", "tuple:2");
+    vm.register_foreign_result_mode("~w/4", "stream");
+    vm.register_foreign_string_config("~w/4", "weight_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+    vm.register_foreign_string_config("~w/4", "direct_dist_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+    vm.register_foreign_usize_config("~w/4", "dimensionality", ~w);
+
+    let temp_target = "__agg_target".to_string();
+    let temp_cost = "__agg_cost".to_string();
+    let target_arg = match &a2 {
+        Value::Unbound(_) => Value::Unbound(temp_target.clone()),
+        _ => a2.clone(),
+    };
+
+    vm.set_reg("A1", a1.clone());
+    vm.set_reg("A2", target_arg);
+    vm.set_reg("A3", a3.clone());
+    vm.set_reg("A4", Value::Unbound(temp_cost.clone()));
+
+    if !vm.execute_foreign_predicate("~w", 4) {
+        vm.bindings.remove(&temp_target);
+        vm.bindings.remove(&temp_cost);
+        return false;
+    }
+
+    let mut best = match vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+        Some(Value::Float(cost)) => Some(cost),
+        _ => None,
+    };
+    while vm.backtrack() {
+        if let Some(Value::Float(cost)) = vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+            best = Some(match best {
+                Some(current) => current.min(cost),
+                None => cost,
+            });
+        }
+    }
+
+    vm.bindings.remove(&temp_target);
+    vm.bindings.remove(&temp_cost);
+
+    match best {
+        Some(cost) => vm.unify(&a4, &Value::Float(cost)),
+        None => false,
+    }
+}', [PredStr, InnerPredStr, InnerPredStr, InnerPredStr, InnerPredStr,
+      WeightPredKey, WeightPredKey, WeightTriplesLiteral,
+      InnerPredStr, DirectPredKey, DirectPredKey, DirectTriplesLiteral,
+      InnerPredStr, DefaultDim, InnerPredStr]).
+compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _IncludeMain, RustCode) :-
+    get_dict(type, AggInfo, all),
+    get_dict(op, AggInfo, min),
+    get_dict(expr, AggInfo, Expr),
+    get_dict(relations, GoalInfo, [RelGoal|_]),
     RelGoal =.. [InnerPred, _StartArg, TargetArg, CostArg],
     Expr == CostArg,
     var(TargetArg),

--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -114,6 +114,10 @@ astar_weighted_path(X, Y, Dim, Cost) :-
 min_semantic_dist(Start, Target, MinDist) :-
     aggregate_all(min(Cost), weighted_path(Start, Target, Cost), MinDist).
 
+:- dynamic min_semantic_dist_astar/4.
+min_semantic_dist_astar(Start, Target, Dim, MinDist) :-
+    aggregate_all(min(Cost), astar_weighted_path(Start, Target, Dim, Cost), MinDist).
+
 %% Integration test
 test_runtime_execution :-
     Test = 'WAM-Rust Runtime: end-to-end execution',
@@ -124,7 +128,7 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:astar_weighted_path/4, user:min_semantic_dist/3],
+        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:astar_weighted_path/4, user:min_semantic_dist/3, user:min_semantic_dist_astar/4],
             [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
@@ -144,6 +148,7 @@ use runtime_test::tail_suffixes;
 use runtime_test::weighted_path;
 use runtime_test::astar_weighted_path;
 use runtime_test::min_semantic_dist;
+use runtime_test::min_semantic_dist_astar;
 
 #[test]
 fn test_generated_predicates() {
@@ -658,6 +663,48 @@ fn test_generated_predicates() {
         Value::Atom("s".to_string()),
         Value::Unbound("NoPath".to_string()));
     assert!(!ok24, "min_semantic_dist(d, s, NoPath) should fail");
+
+    // Test min_semantic_dist_astar/4 aggregate wrapper over astar_weighted_path/4
+    let mut vm_astar_min = WamState::new(vec![], std::collections::HashMap::new());
+    let ok25 = min_semantic_dist_astar(&mut vm_astar_min,
+        Value::Atom("s".to_string()),
+        Value::Atom("d".to_string()),
+        Value::Integer(5),
+        Value::Unbound("AStarMinCost".to_string()));
+    assert!(ok25, "min_semantic_dist_astar(s, d, 5, MinCost) should succeed");
+    match vm_astar_min.bindings.get("AStarMinCost").cloned() {
+        Some(Value::Float(cost)) => assert_close(cost, 7.0),
+        other => panic!("expected min_semantic_dist_astar(s, d, 5, MinCost) to bind float cost, got {:?}", other),
+    }
+
+    let mut vm_astar_min_any = WamState::new(vec![], std::collections::HashMap::new());
+    let ok26 = min_semantic_dist_astar(&mut vm_astar_min_any,
+        Value::Atom("s".to_string()),
+        Value::Unbound("AStarAnyTarget".to_string()),
+        Value::Integer(5),
+        Value::Unbound("AStarGlobalMin".to_string()));
+    assert!(ok26, "min_semantic_dist_astar(s, Target, 5, GlobalMin) should succeed");
+    assert!(vm_astar_min_any.bindings.get("AStarAnyTarget").is_none(), "A* aggregate wrapper should not bind existential Target");
+    match vm_astar_min_any.bindings.get("AStarGlobalMin").cloned() {
+        Some(Value::Float(cost)) => assert_close(cost, 1.0),
+        other => panic!("expected min_semantic_dist_astar(s, Target, 5, GlobalMin) to bind float cost, got {:?}", other),
+    }
+
+    let mut vm_astar_min_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok27 = min_semantic_dist_astar(&mut vm_astar_min_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("c".to_string()),
+        Value::Integer(5),
+        Value::Float(4.0));
+    assert!(ok27, "min_semantic_dist_astar(s, c, 5, 4.0) should succeed");
+
+    let mut vm_astar_min_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok28 = min_semantic_dist_astar(&mut vm_astar_min_fail,
+        Value::Atom("d".to_string()),
+        Value::Atom("s".to_string()),
+        Value::Integer(5),
+        Value::Unbound("AStarNoPath".to_string()));
+    assert!(!ok28, "min_semantic_dist_astar(d, s, 5, NoPath) should fail");
 }
 ',
         setup_call_cleanup(open(TestPath, write, S), format(S, "~w", [TestContent]), close(S)),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -41,6 +41,7 @@ test_simple_fact(foo, bar).
 :- dynamic astar_weighted_path/4.
 :- dynamic direct_semantic_dist/3.
 :- dynamic min_semantic_dist/3.
+:- dynamic min_semantic_dist_astar/4.
 :- dynamic tc_parent/2.
 :- dynamic max_depth/1.
 
@@ -134,6 +135,9 @@ astar_weighted_path(X, Y, Dim, Cost) :-
 
 min_semantic_dist(Start, Target, MinDist) :-
     aggregate_all(min(Cost), weighted_path(Start, Target, Cost), MinDist).
+
+min_semantic_dist_astar(Start, Target, Dim, MinDist) :-
+    aggregate_all(min(Cost), astar_weighted_path(Start, Target, Dim, Cost), MinDist).
 
 pass(Test) :-
     format('[PASS] ~w~n', [Test]).
@@ -716,6 +720,25 @@ test_weighted_min_aggregate_wrapper :-
     ;   fail_test(Test, 'Weighted aggregate wrapper did not delegate correctly')
     ).
 
+test_astar_min_aggregate_wrapper :-
+    Test = 'WAM-Rust: aggregate min wrapper delegates to astar_weighted_path/4',
+    (   rust_target:compile_predicate_to_rust(user:min_semantic_dist_astar/4,
+            [include_main(false), foreign_lowering(true), wam_fallback(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'pub fn min_semantic_dist_astar(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool'),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("astar_weighted_path/4", "astar_shortest_path4")'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("astar_weighted_path/4", "tuple:2")'),
+        sub_string(S, _, _, _, 'register_foreign_string_config("astar_weighted_path/4", "weight_pred", "weighted_edge/3")'),
+        sub_string(S, _, _, _, 'register_foreign_string_config("astar_weighted_path/4", "direct_dist_pred", "direct_semantic_dist/3")'),
+        sub_string(S, _, _, _, 'register_indexed_weighted_edge_triples("weighted_edge/3", &[("s", "a", 1.0), ("s", "b", 4.0), ("a", "b", 2.0), ("a", "c", 5.0), ("b", "c", 1.0), ("c", "d", 3.0)])'),
+        sub_string(S, _, _, _, 'register_indexed_weighted_edge_triples("direct_semantic_dist/3", &[("s", "a", 1.0), ("s", "b", 3.0), ("s", "c", 4.0), ("s", "d", 7.0), ("a", "b", 2.0), ("a", "c", 3.0), ("a", "d", 6.0), ("b", "c", 1.0), ("b", "d", 4.0), ("c", "d", 3.0)])'),
+        sub_string(S, _, _, _, 'register_foreign_usize_config("astar_weighted_path/4", "dimensionality", 5)'),
+        sub_string(S, _, _, _, 'if !vm.execute_foreign_predicate("astar_weighted_path", 4) {'),
+        sub_string(S, _, _, _, 'vm.unify(&a4, &Value::Float(cost))')
+    ->  pass(Test)
+    ;   fail_test(Test, 'A* aggregate wrapper did not delegate correctly')
+    ).
+
 test_compile_wam_runtime_output :-
     Test = 'WAM-Rust E2E: full runtime generates valid impl block',
     (   compile_wam_runtime_to_rust([], Code),
@@ -1031,6 +1054,7 @@ run_tests :-
     test_foreign_lowering_weighted_shortest_path,
     test_foreign_lowering_astar_shortest_path,
     test_weighted_min_aggregate_wrapper,
+    test_astar_min_aggregate_wrapper,
     test_compile_wam_runtime_output,
     test_write_wam_rust_project,
     test_project_cargo_content,


### PR DESCRIPTION
## Summary

This PR adds the missing Rust WAM aggregate-wrapper lowering for A*-backed minimum semantic distance predicates.

Before this change, the Rust target could foreign-lower the underlying `astar_weighted_path/4` kernel, but `aggregate_all(min(Cost), astar_weighted_path(...), MinDist)` did not lower through the same wrapper path that already existed for `weighted_path/3`.

This PR closes that gap by generating a dedicated Rust wrapper for the A* aggregate case and validating it end to end in the generated Rust runtime.

## Changes

- add Rust aggregate-wrapper lowering for `aggregate_all(min(Cost), astar_weighted_path(...), MinDist)`
- register and invoke the `astar_shortest_path4` foreign kernel from the generated wrapper
- preserve existential target semantics when the target argument is unbound
- add target-suite assertions for `min_semantic_dist_astar/4`
- add generated Rust runtime coverage for:
  - bound-target minimum-cost queries
  - unbound-target global minimum queries
  - exact-cost matches
  - unreachable-target failure

## Why

`main` already had:

- foreign lowering for `astar_weighted_path/4`
- generated-runtime validation for the A* kernel itself

But it did not yet prove or implement the aggregate layer above that kernel. That left the A* path behind the already-supported `min_semantic_dist/3` wrapper over `weighted_path/3`.

This PR makes the A* aggregate path consistent with the weighted shortest-path aggregate path.

## Validation

Ran locally in Termux:

```sh
swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl
swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl
```

Both passed.

## Notes

- Scope is intentionally narrow: this is the aggregate-wrapper completion for the existing A* foreign kernel, not a broader aggregate refactor.
- The wrapper follows the same general pattern as the existing weighted minimum wrapper, but targets `astar_weighted_path/4` and threads the dimensionality argument through the generated Rust entrypoint.
