### PR TITLE
feat(csharp-query): add scan materialization planner

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -88,6 +88,10 @@ Status:
   where the runtime can now choose between direct streamed DAG build,
   replayable buffering, and external materialized fallback before building
   operator-owned DAG state
+- started for generic scan relation retention, where `RelationScanNode`,
+  `PatternScanNode`, and scan-heavy join/negation/aggregate consumers can now
+  choose between direct streamed scan access, replayable buffering, and
+  external materialized fallback before building list/set views
 - the runtime can now choose between compact grouped summaries and legacy
   seeded-row regrouping for both operator families through a shared
   grouped-summary policy layer
@@ -114,8 +118,8 @@ Status:
 - the runtime now shares one internal materialization-planner layer above
   the shared relation-retention and grouped-summary policy components
 - the path-aware grouped-summary family uses both branches of that planner,
-  while the DAG family currently uses the relation-retention branch of the
-  same planner
+  while the DAG family and the generic scan family currently use the
+  relation-retention branch of the same planner
 - the current per-family override knobs and trace surface are still preserved
 
 Work:

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -159,16 +159,24 @@ For the current benchmark/runtime surface, the streamed path is:
    runtime can select between them through that same grouped-summary policy
    layer, record measured cost buckets for that decision, and use bounded
    probes in ambiguous cases before falling back to an explicit executor option
-12. the current runtime now routes both path-aware and DAG planning through
-   a shared internal materialization-planner layer
-13. for the current path-aware grouped-summary family, that planner
+12. generic `RelationScanNode` and `PatternScanNode` access now also route
+   through measured relation-retention selection, so scan-heavy join,
+   negation, and aggregate paths can choose between direct streaming,
+   replayable buffering, and external materialized fallback before building
+   list/set views
+13. the current runtime now routes path-aware, DAG, and generic scan planning
+   through a shared internal materialization-planner layer
+14. for the current path-aware grouped-summary family, that planner
    coordinates the earlier edge-retention choice with the later
    grouped-summary choice and records the combined plan in trace output
-14. for the current DAG family, that same planner currently records the
+15. for the current DAG family, that same planner currently records the
    coordinated relation-retention plan before the operator-owned DAG state is
    built
-15. the operator builds only the retained state it actually needs
-16. benchmark code avoids preloading raw facts into in-memory relations first
+16. for the current generic scan family, that same planner currently records
+   the coordinated relation-retention plan before scan-heavy consumers build
+   list/set views
+17. the operator builds only the retained state it actually needs
+18. benchmark code avoids preloading raw facts into in-memory relations first
 
 This is still a first step, not the full endpoint, but it is now broader than
 just the original DAG-only fast paths.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -33,11 +33,15 @@ using the same grouped-summary policy layer that now also drives the
 shortest-path minima family. The path-aware family now coordinates that
 grouped-summary selector with the earlier edge-retention selector through the
 shared internal materialization planner layer that also now covers the DAG
-family's relation-retention planning. That policy now records measured cost
-buckets like `load_roots`, `load_seeds`, `strategy_select`, `build_*`, and
-`group_reduce`, while the earlier path-aware edge-retention boundary now also
-records buckets like `edge_strategy_select`, `edge_probe_*`,
-`edge_materialize_replayable`, and `edge_build_*`.
+family's relation-retention planning and the generic scan family used by
+`RelationScanNode`, `PatternScanNode`, and scan-heavy join/negation/aggregate
+consumers. That policy now records measured cost buckets like `load_roots`,
+`load_seeds`, `strategy_select`, `build_*`, and `group_reduce`, while the
+earlier path-aware edge-retention boundary now also records buckets like
+`edge_strategy_select`, `edge_probe_*`, `edge_materialize_replayable`, and
+`edge_build_*`. Generic scan planning now adds corresponding scan buckets such
+as `scan_strategy_select`, `scan_probe_*`, `scan_materialize_*`, and
+`scan_build_fact_set`.
 
 | Target | 300 art | 1K art | 5K art | 10K art |
 |--------|---------|--------|--------|---------|

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -59,6 +59,14 @@ namespace UnifyWeaver.QueryRuntime
         ExternalMaterialized
     }
 
+    public enum ScanRelationRetentionStrategy
+    {
+        Auto,
+        StreamingDirect,
+        ReplayableBuffer,
+        ExternalMaterialized
+    }
+
     public readonly record struct DelimitedRelationSource(
         string InputPath,
         char Delimiter = '	',
@@ -512,6 +520,13 @@ namespace UnifyWeaver.QueryRuntime
         ExternalMaterialized
     }
 
+    internal enum ScanRelationAccessKind
+    {
+        Stream,
+        List,
+        Set
+    }
+
     internal readonly record struct RelationRetentionSelection(
         RelationRetentionPolicyStrategy Strategy,
         string DecisionMode);
@@ -533,9 +548,14 @@ namespace UnifyWeaver.QueryRuntime
         DagRelationRetentionStrategy Strategy,
         string DecisionMode);
 
+    internal readonly record struct ScanRelationRetentionSelection(
+        ScanRelationRetentionStrategy Strategy,
+        string DecisionMode);
+
     public sealed record QueryExecutorOptions(
         bool ReuseCaches = false,
         DagRelationRetentionStrategy DagRelationRetentionStrategy = DagRelationRetentionStrategy.Auto,
+        ScanRelationRetentionStrategy ScanRelationRetentionStrategy = ScanRelationRetentionStrategy.Auto,
         PathAwareEdgeRetentionStrategy PathAwareEdgeRetentionStrategy = PathAwareEdgeRetentionStrategy.Auto,
         PathAwareGroupedMinStrategy PathAwareGroupedMinStrategy = PathAwareGroupedMinStrategy.Auto,
         PathAwareWeightSumStrategy PathAwareWeightSumStrategy = PathAwareWeightSumStrategy.Auto,
@@ -1486,6 +1506,7 @@ namespace UnifyWeaver.QueryRuntime
         private readonly double _seededCacheAdmissionMinRowsPerSeed;
         private readonly int _maxFixpointIterations;
         private readonly DagRelationRetentionStrategy _dagRelationRetentionStrategy;
+        private readonly ScanRelationRetentionStrategy _scanRelationRetentionStrategy;
         private readonly PathAwareEdgeRetentionStrategy _pathAwareEdgeRetentionStrategy;
         private readonly PathAwareGroupedSummaryStrategy _pathAwareGroupedMinStrategy;
         private readonly PathAwareGroupedSummaryStrategy _pathAwareWeightSumStrategy;
@@ -1503,6 +1524,7 @@ namespace UnifyWeaver.QueryRuntime
             _seededCacheAdmissionMinRowsPerSeed = Math.Max(0d, options.SeededCacheAdmissionMinRowsPerSeed);
             _maxFixpointIterations = Math.Max(0, options.MaxFixpointIterations);
             _dagRelationRetentionStrategy = options.DagRelationRetentionStrategy;
+            _scanRelationRetentionStrategy = options.ScanRelationRetentionStrategy;
             _pathAwareEdgeRetentionStrategy = options.PathAwareEdgeRetentionStrategy;
             _pathAwareGroupedMinStrategy = ToPathAwareGroupedSummaryStrategy(options.PathAwareGroupedMinStrategy);
             _pathAwareWeightSumStrategy = ToPathAwareGroupedSummaryStrategy(options.PathAwareWeightSumStrategy);
@@ -1763,6 +1785,7 @@ namespace UnifyWeaver.QueryRuntime
             _cacheContext.Facts.Clear();
             _cacheContext.FactSources.Clear();
             _cacheContext.ReplayableFactSources.Clear();
+            _cacheContext.ScanRelationRetentionSelections.Clear();
             _cacheContext.PathAwareEdgeStates.Clear();
             _cacheContext.PathAwareEdgeRetentionSelections.Clear();
             _cacheContext.FactSets.Clear();
@@ -1810,7 +1833,7 @@ namespace UnifyWeaver.QueryRuntime
                 case RelationScanNode scan:
                     result = context is null
                         ? GetFactStream(scan.Relation, context)
-                        : GetFactsList(scan.Relation, context);
+                        : GetScanFactStream(scan.Relation, context, scan);
                     break;
 
                 case PatternScanNode scan:
@@ -2071,7 +2094,7 @@ namespace UnifyWeaver.QueryRuntime
                     tuple is not null && TupleMatchesPattern(tuple, scan.Pattern));
             }
 
-            var facts = GetFactsList(scan.Relation, context);
+            var facts = GetScanFactsList(scan.Relation, context, scan);
             var candidates = SelectFactsForPattern(scan.Relation, facts, scan.Pattern, context);
             return candidates.Where(tuple => tuple is not null && TupleMatchesPattern(tuple, scan.Pattern));
         }
@@ -2892,12 +2915,12 @@ namespace UnifyWeaver.QueryRuntime
                     }
 
                     case RelationScanNode scan:
-                        upperBound = GetFactsList(scan.Relation, context).Count;
+                        upperBound = GetScanFactsList(scan.Relation, context, scan).Count;
                         return true;
 
                     case PatternScanNode scan:
                     {
-                        var facts = GetFactsList(scan.Relation, context);
+                        var facts = GetScanFactsList(scan.Relation, context, scan);
                         upperBound = facts.Count;
 
                         List<int>? boundColumns = null;
@@ -3137,8 +3160,8 @@ namespace UnifyWeaver.QueryRuntime
 
                     if (useScanIndexStrategy && leftIsScan && rightIsScan)
                     {
-                        var leftFacts = GetFactsList(leftScanPredicate, context);
-                        var rightFacts = GetFactsList(rightScanPredicate, context);
+                        var leftFacts = GetScanFactsList(leftScanPredicate, context, join);
+                        var rightFacts = GetScanFactsList(rightScanPredicate, context, join);
                         var keyCount = join.LeftKeys.Count;
                         var leftIndexKeys = GetScanIndexKeys(join.LeftKeys, leftScanPattern);
                         var rightIndexKeys = GetScanIndexKeys(join.RightKeys, rightScanPattern);
@@ -3754,7 +3777,7 @@ namespace UnifyWeaver.QueryRuntime
 
                     if (useScanIndexStrategy && rightIsScan)
                     {
-                        var facts = GetFactsList(rightScanPredicate, context);
+                        var facts = GetScanFactsList(rightScanPredicate, context, join);
                         var keyCount = join.RightKeys.Count;
                         var rightIndexKeys = GetScanIndexKeys(join.RightKeys, rightScanPattern);
 
@@ -4112,7 +4135,7 @@ namespace UnifyWeaver.QueryRuntime
 
                     if (useScanIndexStrategy && leftIsScan)
                     {
-                        var facts = GetFactsList(leftScanPredicate, context);
+                        var facts = GetScanFactsList(leftScanPredicate, context, join);
                         var keyCount = join.LeftKeys.Count;
                         var leftIndexKeys = GetScanIndexKeys(join.LeftKeys, leftScanPattern);
 
@@ -5569,7 +5592,7 @@ namespace UnifyWeaver.QueryRuntime
                 if (buildLeft && join.Left is RelationScanNode leftScan)
                 {
                     trace?.RecordStrategy(join, "KeyJoinScanIndexReuse");
-                    var facts = GetFactsList(leftScan.Relation, context);
+                    var facts = GetScanFactsList(leftScan.Relation, context, join);
                     if (joinKeyCount == 1)
                     {
                         var index = GetFactIndex(leftScan.Relation, join.LeftKeys[0], facts, context);
@@ -5620,7 +5643,7 @@ namespace UnifyWeaver.QueryRuntime
                 if (!buildLeft && join.Right is RelationScanNode rightScan)
                 {
                     trace?.RecordStrategy(join, "KeyJoinScanIndexReuse");
-                    var facts = GetFactsList(rightScan.Relation, context);
+                    var facts = GetScanFactsList(rightScan.Relation, context, join);
                     if (joinKeyCount == 1)
                     {
                         var index = GetFactIndex(rightScan.Relation, join.RightKeys[0], facts, context);
@@ -6172,6 +6195,197 @@ namespace UnifyWeaver.QueryRuntime
                     }
                 }
             }
+        }
+
+        private static void ProbeFactRows(IEnumerable<object[]> facts, int maxRows)
+        {
+            var consumed = 0;
+            foreach (var fact in facts)
+            {
+                if (fact is null)
+                {
+                    continue;
+                }
+
+                consumed++;
+                if (consumed >= maxRows)
+                {
+                    break;
+                }
+            }
+        }
+
+        private ScanRelationRetentionSelection GetScanRelationRetentionSelection(
+            PredicateId predicate,
+            ScanRelationAccessKind accessKind,
+            EvaluationContext context,
+            PlanNode traceNode)
+        {
+            var cacheKey = (predicate, accessKind);
+            if (context.ScanRelationRetentionSelections.TryGetValue(cacheKey, out var cachedSelection))
+            {
+                return cachedSelection;
+            }
+
+            var hasStreaming = TryGetDelimitedSource(predicate, RelationRetentionMode.Streaming, out var delimitedSource);
+            var hasReplayable = TryGetReplayableSource(predicate, context, out var replayableSource);
+            var hasExternal = TryGetExternalFacts(predicate, out var externalFacts);
+            var concreteReplayable = replayableSource as ReplayableRelationSource;
+            var relationBytes = hasStreaming && !string.IsNullOrEmpty(delimitedSource.InputPath) && File.Exists(delimitedSource.InputPath)
+                ? new FileInfo(delimitedSource.InputPath).Length
+                : (long?)null;
+            const int scanProbeRowLimit = 256;
+
+            Func<TimeSpan>? measureStreamingProbe = hasStreaming
+                ? () => MeasureElapsed(() => ProbeFactRows(DelimitedRelationReader.ReadRows(delimitedSource), scanProbeRowLimit))
+                : null;
+            Func<TimeSpan>? measureReplayableProbe = hasReplayable
+                ? () => MeasureElapsed(() =>
+                {
+                    var probeRows = concreteReplayable is not null
+                        ? concreteReplayable.ProbeMaterialize(scanProbeRowLimit)
+                        : replayableSource.Stream().Take(scanProbeRowLimit).ToList();
+                    ProbeFactRows(probeRows, scanProbeRowLimit);
+                })
+                : null;
+            Func<TimeSpan>? measureExternalProbe = hasExternal
+                ? () => MeasureElapsed(() => ProbeFactRows(externalFacts, scanProbeRowLimit))
+                : null;
+
+            var selection = ResolveScanRelationRetentionStrategy(
+                context.Trace,
+                traceNode,
+                _scanRelationRetentionStrategy,
+                accessKind,
+                relationBytes,
+                hasStreaming,
+                hasReplayable,
+                hasExternal,
+                concreteReplayable?.IsMaterialized == true,
+                measureStreamingProbe,
+                measureReplayableProbe,
+                measureExternalProbe);
+            context.ScanRelationRetentionSelections[cacheKey] = selection;
+            return selection;
+        }
+
+        private MaterializationPlanSelection ResolveScanMaterializationPlan(
+            PredicateId predicate,
+            ScanRelationAccessKind accessKind,
+            EvaluationContext context,
+            PlanNode traceNode)
+        {
+            var relationRetentionSelection = ToRelationRetentionSelection(
+                GetScanRelationRetentionSelection(predicate, accessKind, context, traceNode));
+            var plan = ResolveMaterializationPlan(context.Trace, traceNode, relationRetentionSelection);
+            RecordScanRelationRetentionStrategy(
+                context.Trace,
+                traceNode,
+                new ScanRelationRetentionSelection(ToScanRelationRetentionStrategy(plan.RelationRetention.Strategy), plan.RelationRetention.DecisionMode));
+            RecordMaterializationPlanStrategy(context.Trace, traceNode, "Scan", plan);
+            return plan;
+        }
+
+        private IEnumerable<object[]> GetScanFactStream(PredicateId predicate, EvaluationContext? context, PlanNode traceNode)
+        {
+            if (context is null)
+            {
+                return GetFactStream(predicate, context);
+            }
+
+            if (context.Facts.TryGetValue(predicate, out var cachedFacts))
+            {
+                context.Trace?.RecordCacheLookup("Facts", $"{predicate.Name}/{predicate.Arity}", hit: true, built: false);
+                return cachedFacts;
+            }
+
+            var plan = ResolveScanMaterializationPlan(predicate, ScanRelationAccessKind.Stream, context, traceNode);
+            var hasStreaming = TryGetDelimitedSource(predicate, RelationRetentionMode.Streaming, out var delimitedSource);
+            var hasReplayable = TryGetReplayableSource(predicate, context, out var replayableSource);
+            var hasExternal = TryGetExternalFacts(predicate, out var externalFacts);
+
+            return plan.RelationRetention.Strategy switch
+            {
+                RelationRetentionPolicyStrategy.StreamingDirect when hasStreaming => DelimitedRelationReader.ReadRows(delimitedSource),
+                RelationRetentionPolicyStrategy.ReplayableBuffer when hasReplayable => replayableSource.Stream(),
+                RelationRetentionPolicyStrategy.ExternalMaterialized when hasExternal => externalFacts,
+                _ when hasReplayable => replayableSource.Stream(),
+                _ when hasStreaming => DelimitedRelationReader.ReadRows(delimitedSource),
+                _ => _provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>()
+            };
+        }
+
+        private List<object[]> GetScanFactsList(PredicateId predicate, EvaluationContext? context, PlanNode traceNode)
+        {
+            if (context is null)
+            {
+                return MaterializeFacts(predicate, context);
+            }
+
+            if (context.Facts.TryGetValue(predicate, out var cached))
+            {
+                context.Trace?.RecordCacheLookup("Facts", $"{predicate.Name}/{predicate.Arity}", hit: true, built: false);
+                return cached;
+            }
+
+            context.Trace?.RecordCacheLookup("Facts", $"{predicate.Name}/{predicate.Arity}", hit: false, built: true);
+
+            var plan = ResolveScanMaterializationPlan(predicate, ScanRelationAccessKind.List, context, traceNode);
+            var hasStreaming = TryGetDelimitedSource(predicate, RelationRetentionMode.Streaming, out var delimitedSource);
+            var hasReplayable = TryGetReplayableSource(predicate, context, out var replayableSource);
+            var hasExternal = TryGetExternalFacts(predicate, out var externalFacts);
+            List<object[]> facts;
+
+            switch (plan.RelationRetention.Strategy)
+            {
+                case RelationRetentionPolicyStrategy.StreamingDirect when hasStreaming:
+                    facts = MeasurePhase(context.Trace, traceNode, "scan_materialize_streaming_direct", () => DelimitedRelationReader.ReadRows(delimitedSource).ToList());
+                    break;
+                case RelationRetentionPolicyStrategy.ReplayableBuffer when hasReplayable:
+                    facts = MeasurePhase(context.Trace, traceNode, "scan_materialize_replayable", () => replayableSource.Materialize());
+                    break;
+                case RelationRetentionPolicyStrategy.ExternalMaterialized when hasExternal:
+                    facts = MeasurePhase(context.Trace, traceNode, "scan_materialize_external_materialized", () => externalFacts as List<object[]> ?? externalFacts.ToList());
+                    break;
+                default:
+                    if (hasReplayable)
+                    {
+                        facts = MeasurePhase(context.Trace, traceNode, "scan_materialize_replayable", () => replayableSource.Materialize());
+                    }
+                    else if (hasStreaming)
+                    {
+                        facts = MeasurePhase(context.Trace, traceNode, "scan_materialize_streaming_direct", () => DelimitedRelationReader.ReadRows(delimitedSource).ToList());
+                    }
+                    else
+                    {
+                        var externalSource = _provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>();
+                        facts = MeasurePhase(context.Trace, traceNode, "scan_materialize_external_materialized", () => externalSource as List<object[]> ?? externalSource.ToList());
+                    }
+                    break;
+            }
+
+            context.Facts[predicate] = facts;
+            return facts;
+        }
+
+        private HashSet<object[]> GetScanFactsSet(PredicateId predicate, EvaluationContext? context, PlanNode traceNode)
+        {
+            if (context is null)
+            {
+                return new HashSet<object[]>(MaterializeFacts(predicate, context), StructuralArrayComparer.Instance);
+            }
+
+            if (context.FactSets.TryGetValue(predicate, out var cached))
+            {
+                context.Trace?.RecordCacheLookup("FactSet", $"{predicate.Name}/{predicate.Arity}", hit: true, built: false);
+                return cached;
+            }
+
+            context.Trace?.RecordCacheLookup("FactSet", $"{predicate.Name}/{predicate.Arity}", hit: false, built: true);
+            var facts = GetScanFactsList(predicate, context, traceNode);
+            var set = MeasurePhase(context.Trace, traceNode, "scan_build_fact_set", () => new HashSet<object[]>(facts, StructuralArrayComparer.Instance));
+            context.FactSets[predicate] = set;
+            return set;
         }
 
         private IEnumerable<object[]> GetFactStream(PredicateId predicate, EvaluationContext? context = null)
@@ -6842,7 +7056,7 @@ namespace UnifyWeaver.QueryRuntime
         private IEnumerable<object[]> ExecuteNegation(NegationNode negation, EvaluationContext? context)
         {
             var input = Evaluate(negation.Input, context);
-            var factSet = GetFactsSet(negation.Predicate, context);
+            var factSet = GetScanFactsSet(negation.Predicate, context, negation);
 
             foreach (var tuple in input)
             {
@@ -6859,7 +7073,7 @@ namespace UnifyWeaver.QueryRuntime
             if (aggregate is null) throw new ArgumentNullException(nameof(aggregate));
 
             var input = Evaluate(aggregate.Input, context);
-            var facts = GetFactsList(aggregate.Predicate, context);
+            var facts = GetScanFactsList(aggregate.Predicate, context, aggregate);
             var cache = new Dictionary<RowWrapper, List<object[]>>(new RowWrapperComparer(StructuralArrayComparer.Instance));
             var groupCount = aggregate.GroupByIndices?.Count ?? 0;
             var extensionSize = groupCount + 1;
@@ -7786,7 +8000,7 @@ namespace UnifyWeaver.QueryRuntime
             if (parameters is null) throw new ArgumentNullException(nameof(parameters));
             if (context is null) throw new ArgumentNullException(nameof(context));
 
-            var facts = GetFactsList(scan.Relation, context);
+            var facts = GetScanFactsList(scan.Relation, context, scan);
             if (inputPositions.Count == 0)
             {
                 return facts;
@@ -8020,6 +8234,24 @@ namespace UnifyWeaver.QueryRuntime
                 _ => DagRelationRetentionStrategy.Auto
             };
 
+        private static RelationRetentionPolicyStrategy ToRelationRetentionPolicyStrategy(ScanRelationRetentionStrategy strategy)
+            => strategy switch
+            {
+                ScanRelationRetentionStrategy.StreamingDirect => RelationRetentionPolicyStrategy.StreamingDirect,
+                ScanRelationRetentionStrategy.ReplayableBuffer => RelationRetentionPolicyStrategy.ReplayableBuffer,
+                ScanRelationRetentionStrategy.ExternalMaterialized => RelationRetentionPolicyStrategy.ExternalMaterialized,
+                _ => RelationRetentionPolicyStrategy.Auto
+            };
+
+        private static ScanRelationRetentionStrategy ToScanRelationRetentionStrategy(RelationRetentionPolicyStrategy strategy)
+            => strategy switch
+            {
+                RelationRetentionPolicyStrategy.StreamingDirect => ScanRelationRetentionStrategy.StreamingDirect,
+                RelationRetentionPolicyStrategy.ReplayableBuffer => ScanRelationRetentionStrategy.ReplayableBuffer,
+                RelationRetentionPolicyStrategy.ExternalMaterialized => ScanRelationRetentionStrategy.ExternalMaterialized,
+                _ => ScanRelationRetentionStrategy.Auto
+            };
+
         private static RelationRetentionPolicyStrategy ToRelationRetentionPolicyStrategy(PathAwareEdgeRetentionStrategy strategy)
             => strategy switch
             {
@@ -8039,6 +8271,9 @@ namespace UnifyWeaver.QueryRuntime
             };
 
         private static RelationRetentionSelection ToRelationRetentionSelection(DagRelationRetentionSelection selection)
+            => new(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode);
+
+        private static RelationRetentionSelection ToRelationRetentionSelection(ScanRelationRetentionSelection selection)
             => new(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode);
 
         private static RelationRetentionSelection ToRelationRetentionSelection(PathAwareEdgeRetentionSelection selection)
@@ -8327,6 +8562,102 @@ namespace UnifyWeaver.QueryRuntime
                 new RelationRetentionSelection(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode),
                 "DagRelationRetentionSelection",
                 "DagRelationRetention");
+        }
+
+        private static ScanRelationRetentionStrategy ResolveStructuralScanRelationRetentionStrategy(
+            ScanRelationAccessKind accessKind,
+            bool hasStreaming,
+            bool hasReplayable,
+            bool hasExternal,
+            bool replayableMaterialized)
+        {
+            var preferredStrategy = accessKind == ScanRelationAccessKind.Stream
+                ? RelationRetentionPolicyStrategy.StreamingDirect
+                : RelationRetentionPolicyStrategy.ReplayableBuffer;
+            return ToScanRelationRetentionStrategy(
+                ResolveStructuralRelationRetentionStrategy(
+                    preferredStrategy,
+                    hasStreaming,
+                    hasReplayable,
+                    hasExternal,
+                    replayableMaterialized));
+        }
+
+        private static bool ShouldProbeScanRelationRetentionStrategy(
+            ScanRelationAccessKind accessKind,
+            long? relationBytes,
+            bool hasStreaming,
+            bool hasReplayable,
+            bool hasExternal,
+            bool replayableMaterialized)
+        {
+            var thresholdBytes = accessKind switch
+            {
+                ScanRelationAccessKind.Stream => 192 * 1024L,
+                ScanRelationAccessKind.Set => 320 * 1024L,
+                _ => 256 * 1024L,
+            };
+            return ShouldProbeRelationRetentionStrategy(
+                relationBytes,
+                thresholdBytes,
+                hasStreaming,
+                hasReplayable,
+                hasExternal,
+                replayableMaterialized);
+        }
+
+        private static ScanRelationRetentionSelection ResolveScanRelationRetentionStrategy(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            ScanRelationRetentionStrategy configuredStrategy,
+            ScanRelationAccessKind accessKind,
+            long? relationBytes,
+            bool hasStreaming,
+            bool hasReplayable,
+            bool hasExternal,
+            bool replayableMaterialized,
+            Func<TimeSpan>? measureStreamingProbe = null,
+            Func<TimeSpan>? measureReplayableProbe = null,
+            Func<TimeSpan>? measureExternalProbe = null)
+        {
+            var structuralStrategy = ToRelationRetentionPolicyStrategy(
+                ResolveStructuralScanRelationRetentionStrategy(
+                    accessKind,
+                    hasStreaming,
+                    hasReplayable,
+                    hasExternal,
+                    replayableMaterialized));
+            var selection = ResolveRelationRetentionStrategy(
+                trace,
+                node,
+                "scan_strategy_select",
+                "scan_probe_streaming_direct",
+                "scan_probe_replayable_buffer",
+                "scan_probe_external_materialized",
+                ToRelationRetentionPolicyStrategy(configuredStrategy),
+                structuralStrategy,
+                ShouldProbeScanRelationRetentionStrategy(accessKind, relationBytes, hasStreaming, hasReplayable, hasExternal, replayableMaterialized),
+                hasStreaming,
+                hasReplayable,
+                hasExternal,
+                replayableMaterialized,
+                measureStreamingProbe,
+                measureReplayableProbe,
+                measureExternalProbe);
+            return new ScanRelationRetentionSelection(ToScanRelationRetentionStrategy(selection.Strategy), selection.DecisionMode);
+        }
+
+        private static void RecordScanRelationRetentionStrategy(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            ScanRelationRetentionSelection selection)
+        {
+            RecordRelationRetentionStrategy(
+                trace,
+                node,
+                new RelationRetentionSelection(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode),
+                "ScanRelationRetentionSelection",
+                "ScanRelationRetention");
         }
 
         private static PathAwareEdgeRetentionStrategy ResolveStructuralPathAwareEdgeRetentionStrategy(
@@ -17258,6 +17589,7 @@ namespace UnifyWeaver.QueryRuntime
                 Facts = parent?.Facts ?? new Dictionary<PredicateId, List<object[]>>();
                 FactSources = parent?.FactSources ?? new Dictionary<PredicateId, PlanNode>();
                 ReplayableFactSources = parent?.ReplayableFactSources ?? new Dictionary<PredicateId, IReplayableRelationSource>();
+                ScanRelationRetentionSelections = parent?.ScanRelationRetentionSelections ?? new Dictionary<(PredicateId Predicate, ScanRelationAccessKind AccessKind), ScanRelationRetentionSelection>();
                 PathAwareEdgeStates = parent?.PathAwareEdgeStates ?? new Dictionary<PredicateId, PathAwareEdgeState>();
                 PathAwareEdgeRetentionSelections = parent?.PathAwareEdgeRetentionSelections ?? new Dictionary<PredicateId, PathAwareEdgeRetentionSelection>();
                 FactSets = parent?.FactSets ?? new Dictionary<PredicateId, HashSet<object[]>>();
@@ -17323,6 +17655,8 @@ namespace UnifyWeaver.QueryRuntime
             public Dictionary<PredicateId, PlanNode> FactSources { get; }
 
             public Dictionary<PredicateId, IReplayableRelationSource> ReplayableFactSources { get; }
+
+            public Dictionary<(PredicateId Predicate, ScanRelationAccessKind AccessKind), ScanRelationRetentionSelection> ScanRelationRetentionSelections { get; }
 
             public Dictionary<PredicateId, PathAwareEdgeState> PathAwareEdgeStates { get; }
 


### PR DESCRIPTION
  ## Summary

  This PR extends the C# query runtime’s shared materialization planner to
  generic scan access.

  Until now, the runtime had already moved much of the materialization
  story into the engine for:

  - DAG relation retention
  - path-aware edge retention
  - grouped minima
  - grouped weight sums

  But generic scan-heavy execution still had a real gap:

  - `RelationScanNode`
  - `PatternScanNode`
  - scan-heavy `JoinNode` / `KeyJoinNode`
  - `NegationNode`
  - `AggregateNode`

  still mostly flowed through direct `GetFactsList(...)` /
  `GetFactsSet(...)` access without going through the shared planner.

  This PR fixes that.

  ## What Changed

  ### New Public Runtime Option

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `ScanRelationRetentionStrategy`
    - `Auto`
    - `StreamingDirect`
    - `ReplayableBuffer`
    - `ExternalMaterialized`

  Extended:

  - `QueryExecutorOptions`
    - `ScanRelationRetentionStrategy`

  This is the scan-side analogue of the earlier DAG and path-aware
  retention knobs.

  ### Shared Planner Coverage For Generic Scans

  Added scan-specific planner support on top of the existing shared
  relation-retention and materialization-planner layers.

  New internal pieces include:

  - `ScanRelationAccessKind`
    - `Stream`
    - `List`
    - `Set`
  - `ScanRelationRetentionSelection`
  - scan-specific structural resolution
  - scan-specific measured probing
  - scan-specific trace recording

  The planner now decides how generic scan consumers should obtain relation
  data before building list/set views.

  ### New Planned Scan Accessors

  Added:

  - `GetScanFactStream(...)`
  - `GetScanFactsList(...)`
  - `GetScanFactsSet(...)`

  These route generic scan access through the shared planner and record
  measured scan-retention phases such as:

  - `scan_strategy_select`
  - `scan_probe_streaming_direct`
  - `scan_probe_replayable_buffer`
  - `scan_probe_external_materialized`
  - `scan_materialize_streaming_direct`
  - `scan_materialize_replayable`
  - `scan_materialize_external_materialized`
  - `scan_build_fact_set`

  ### Generic Scan Consumers Now Use The Planner

  Updated:

  - `RelationScanNode`
  - `PatternScanNode`
  - `NegationNode`
  - `AggregateNode`
  - `ExecuteBoundFactScan(...)`
  - scan-index join reuse / scan-aware join planning paths
  - row-upper-bound estimation for `RelationScanNode` / `PatternScanNode`

  These paths no longer bypass the shared planner by immediately pulling
  raw fact lists where the runtime should be making a retention decision.

  ### Docs Updated

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`
  - `examples/benchmark/README.md`

  These now reflect that Stage 4 applies not only to DAG and path-aware
  families, but also to generic scan-heavy execution.

  ## Why This Matters

  This PR closes an important architectural gap.

  Before this change, the runtime had a strong retained-state story for the
  specialized benchmark families, but generic scans still sat partly
  outside that planner surface.

  That was a mismatch.

  If the engine is supposed to own materialization decisions, then generic
  scan access is one of the most important places to make that true.

  This PR brings generic scan/list/set access into the same runtime-owned
  materialization framework.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_category_influence_cross_target.py \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py

  ### Existing benchmark non-regression smokes

  Ran locally:

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query \
      --repetitions 1

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  All still matched on outputs.

  Representative results:

  - shortest path 300
      - csharp-query 0.091s
  - weighted shortest path 300
      - csharp-query 0.188s
  - effective distance 300
      - csharp-query 0.286s
  - dependency reach-count 300
      - csharp-query 0.084s
  - dependency longest depth 300
      - csharp-query 0.194s

  ### Focused scan-planner harness

  Because the current cross-target benchmark generator mostly exercises
  specialized DAG/path-aware nodes rather than generic RelationScanNode /
  PatternScanNode plans, I also ran a focused local C# harness against the
  benchmark TSVs to validate the new scan planner directly.

  That harness exercised:

  - scan join
  - pattern scan
  - negation over a scanned relation
  - aggregate over a scanned relation

  and confirmed that Auto now chooses different retention modes based on
  scan shape.

  Representative findings:

  #### 300 join

  - strategy: StreamingDirect
  - combined planner trace present:
      - ScanMaterializationPlanRelationStreamingDirect
  - runtime stayed on streamed scan access without building a replayed list

  #### 300 pattern

  - strategy: ReplayableBuffer
  - trace included:
      - ScanRelationRetentionReplayableBuffer
      - ScanMaterializationPlanRelationReplayableBuffer
      - scan_materialize_replayable

  #### 300 negation / aggregate

  - measured selection was exercised on smaller-scale ambiguous cases
  - traces included:
      - ScanRelationRetentionSelectionMeasuredProbe
      - ScanMaterializationPlanSelectionMeasuredRelation
      - scan_probe_*
      - scan_build_fact_set

  #### 10k join

  - strategy: StreamingDirect
  - structural short-circuiting was used

  #### 10k pattern / negation / aggregate

  - replayable buffering remained preferred where list/set reuse paid off

  This is the main new validation in the PR: generic scan planning is now
  real, measurable, and traceable.

  ## Interpretation

  This PR is not about adding another specialized retained-summary node.

  Its value is that it extends the runtime’s materialization ownership to
  the generic scan layer.

  That matters because many operators depend on scan/list/set access even
  when they are not part of the specialized DAG/path-aware families.

  So the runtime now has a more coherent materialization story:

  - specialized operators use operator-owned retained forms
  - generic scans also go through planned retention selection
  - both surfaces now live under the shared materialization-planner
    architecture

  ## Scope

  This PR adds:

  - scan relation-retention strategy selection
  - shared planner integration for generic scan access
  - scan-phase trace visibility
  - doc updates describing the broader Stage 4 coverage

  It does not yet add:

  - benchmark-generator surfaces dedicated to generic scan-family
    cross-target comparisons
  - a universal planner for every remaining direct fact-access path in the
    runtime

  ## Follow-Up

  Likely next work:

  - identify the remaining direct GetFactsList(...) / GetFactsSet(...)
    paths that still sit outside the shared planner
  - broaden the planner to more generic operator families that are not yet
    represented in the benchmark surface
  - consider adding a dedicated scan-heavy benchmark family so this planner
    layer is validated by the main benchmark suite, not only by focused
    local harnesses