### PR TITLE
feat(rust): Add grouped foreign aggregate wrappers to Rust WAM lowering

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -4163,6 +4163,194 @@ compile_aggregate_rule_to_rust(Pred, _Arity, _Head, AggInfo, IncludeMain, RustCo
     ).
 
 compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _IncludeMain, RustCode) :-
+    get_dict(type, AggInfo, group),
+    get_dict(op, AggInfo, min),
+    get_dict(expr, AggInfo, Expr),
+    get_dict(group, AggInfo, GroupTerm),
+    get_dict(relations, GoalInfo, [RelGoal|_]),
+    RelGoal =.. [InnerPred, _StartArg, TargetArg, CostArg],
+    Expr == CostArg,
+    parse_group_term_rust(GroupTerm, [GroupVar]),
+    GroupVar == TargetArg,
+    functor(InnerHead, InnerPred, 3),
+    findall(InnerHead-InnerBody, user:clause(InnerHead, InnerBody), Clauses),
+    Clauses \= [],
+    rust_foreign_lowerable_weighted_shortest_path(InnerPred, 3, Clauses, WeightPred/3, FactTriples),
+    atom_string(Pred, PredStr),
+    atom_string(InnerPred, InnerPredStr),
+    format(string(PredKey), '~w/3', [Pred]),
+    format(string(WeightPredKey), '~w/3', [WeightPred]),
+    rust_weighted_fact_triples_literal(FactTriples, TriplesLiteral),
+    format(string(RustCode),
+'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool {
+    use std::collections::BTreeMap;
+
+    vm.reset_query();
+    vm.code = Vec::new();
+    vm.labels = HashMap::new();
+    vm.pc = 1;
+    vm.register_foreign_result_layout("~w", "tuple:2");
+    vm.register_foreign_result_mode("~w", "stream");
+    vm.register_foreign_native_kind("~w/3", "weighted_shortest_path3");
+    vm.register_foreign_result_layout("~w/3", "tuple:2");
+    vm.register_foreign_result_mode("~w/3", "stream");
+    vm.register_foreign_string_config("~w/3", "weight_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+
+    let target_filter = match &a2 {
+        Value::Atom(target) => Some(target.clone()),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let temp_target = "__agg_target".to_string();
+    let temp_cost = "__agg_cost".to_string();
+
+    vm.set_reg("A1", a1.clone());
+    vm.set_reg("A2", Value::Unbound(temp_target.clone()));
+    vm.set_reg("A3", Value::Unbound(temp_cost.clone()));
+
+    if !vm.execute_foreign_predicate("~w", 3) {
+        vm.bindings.remove(&temp_target);
+        vm.bindings.remove(&temp_cost);
+        return false;
+    }
+
+    let mut grouped: BTreeMap<String, f64> = BTreeMap::new();
+    loop {
+        let target = match vm.bindings.get(&temp_target).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Atom(target)) => target,
+            _ => break,
+        };
+        let cost = match vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Float(cost)) => cost,
+            _ => break,
+        };
+        if target_filter.as_ref().map(|want| want == &target).unwrap_or(true) {
+            grouped.entry(target)
+                .and_modify(|current| *current = current.min(cost))
+                .or_insert(cost);
+        }
+        if !vm.backtrack() {
+            break;
+        }
+    }
+
+    vm.bindings.remove(&temp_target);
+    vm.bindings.remove(&temp_cost);
+
+    if grouped.is_empty() {
+        return false;
+    }
+
+    let packed_results: Vec<Value> = grouped.into_iter().map(|(target, cost)| {
+        Value::Str("__tuple__".to_string(), vec![
+            Value::Atom(target),
+            Value::Float(cost),
+        ])
+    }).collect();
+    vm.finish_foreign_results("~w", vec![a2.clone(), a3.clone()], packed_results)
+}', [PredStr, PredKey, PredKey, InnerPredStr, InnerPredStr, InnerPredStr,
+      InnerPredStr, WeightPredKey, WeightPredKey, TriplesLiteral,
+      InnerPredStr, PredKey]).
+compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _IncludeMain, RustCode) :-
+    get_dict(type, AggInfo, group),
+    get_dict(op, AggInfo, min),
+    get_dict(expr, AggInfo, Expr),
+    get_dict(group, AggInfo, GroupTerm),
+    get_dict(relations, GoalInfo, [RelGoal|_]),
+    RelGoal =.. [InnerPred, _StartArg, TargetArg, _DimArg, CostArg],
+    Expr == CostArg,
+    parse_group_term_rust(GroupTerm, [GroupVar]),
+    GroupVar == TargetArg,
+    functor(InnerHead, InnerPred, 4),
+    findall(InnerHead-InnerBody, user:clause(InnerHead, InnerBody), Clauses),
+    Clauses \= [],
+    rust_foreign_lowerable_astar_shortest_path(InnerPred, 4, Clauses,
+        WeightPred/3, FactTriples, DirectPred/3, DirectTriples, DefaultDim),
+    atom_string(Pred, PredStr),
+    atom_string(InnerPred, InnerPredStr),
+    format(string(PredKey), '~w/4', [Pred]),
+    format(string(WeightPredKey), '~w/3', [WeightPred]),
+    format(string(DirectPredKey), '~w/3', [DirectPred]),
+    rust_weighted_fact_triples_literal(FactTriples, WeightTriplesLiteral),
+    rust_weighted_fact_triples_literal(DirectTriples, DirectTriplesLiteral),
+    format(string(RustCode),
+'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool {
+    use std::collections::BTreeMap;
+
+    vm.reset_query();
+    vm.code = Vec::new();
+    vm.labels = HashMap::new();
+    vm.pc = 1;
+    vm.register_foreign_result_layout("~w", "tuple:2");
+    vm.register_foreign_result_mode("~w", "stream");
+    vm.register_foreign_native_kind("~w/4", "astar_shortest_path4");
+    vm.register_foreign_result_layout("~w/4", "tuple:2");
+    vm.register_foreign_result_mode("~w/4", "stream");
+    vm.register_foreign_string_config("~w/4", "weight_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+    vm.register_foreign_string_config("~w/4", "direct_dist_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+    vm.register_foreign_usize_config("~w/4", "dimensionality", ~w);
+
+    let target_filter = match &a2 {
+        Value::Atom(target) => Some(target.clone()),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let temp_target = "__agg_target".to_string();
+    let temp_cost = "__agg_cost".to_string();
+
+    vm.set_reg("A1", a1.clone());
+    vm.set_reg("A2", Value::Unbound(temp_target.clone()));
+    vm.set_reg("A3", a3.clone());
+    vm.set_reg("A4", Value::Unbound(temp_cost.clone()));
+
+    if !vm.execute_foreign_predicate("~w", 4) {
+        vm.bindings.remove(&temp_target);
+        vm.bindings.remove(&temp_cost);
+        return false;
+    }
+
+    let mut grouped: BTreeMap<String, f64> = BTreeMap::new();
+    loop {
+        let target = match vm.bindings.get(&temp_target).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Atom(target)) => target,
+            _ => break,
+        };
+        let cost = match vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Float(cost)) => cost,
+            _ => break,
+        };
+        if target_filter.as_ref().map(|want| want == &target).unwrap_or(true) {
+            grouped.entry(target)
+                .and_modify(|current| *current = current.min(cost))
+                .or_insert(cost);
+        }
+        if !vm.backtrack() {
+            break;
+        }
+    }
+
+    vm.bindings.remove(&temp_target);
+    vm.bindings.remove(&temp_cost);
+
+    if grouped.is_empty() {
+        return false;
+    }
+
+    let packed_results: Vec<Value> = grouped.into_iter().map(|(target, cost)| {
+        Value::Str("__tuple__".to_string(), vec![
+            Value::Atom(target),
+            Value::Float(cost),
+        ])
+    }).collect();
+    vm.finish_foreign_results("~w", vec![a2.clone(), a4.clone()], packed_results)
+}', [PredStr, PredKey, PredKey, InnerPredStr, InnerPredStr, InnerPredStr,
+      InnerPredStr, WeightPredKey, WeightPredKey, WeightTriplesLiteral,
+      InnerPredStr, DirectPredKey, DirectPredKey, DirectTriplesLiteral,
+      InnerPredStr, DefaultDim, InnerPredStr, PredKey]).
+compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _IncludeMain, RustCode) :-
     get_dict(type, AggInfo, all),
     get_dict(op, AggInfo, min),
     get_dict(expr, AggInfo, Expr),

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1414,7 +1414,7 @@ compile_execute_foreign_predicate_to_rust(Code) :-
     }'.
 
 compile_foreign_result_helpers_to_rust(Code) :-
-    Code = '    fn finish_foreign_results(
+    Code = '    pub fn finish_foreign_results(
         &mut self,
         pred_key: &str,
         result_regs: Vec<Value>,

--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -118,6 +118,14 @@ min_semantic_dist(Start, Target, MinDist) :-
 min_semantic_dist_astar(Start, Target, Dim, MinDist) :-
     aggregate_all(min(Cost), astar_weighted_path(Start, Target, Dim, Cost), MinDist).
 
+:- dynamic grouped_min_semantic_dist/3.
+grouped_min_semantic_dist(Start, Target, MinDist) :-
+    aggregate_all(min(Cost), weighted_path(Start, Target, Cost), Target, MinDist).
+
+:- dynamic grouped_min_semantic_dist_astar/4.
+grouped_min_semantic_dist_astar(Start, Target, Dim, MinDist) :-
+    aggregate_all(min(Cost), astar_weighted_path(Start, Target, Dim, Cost), Target, MinDist).
+
 %% Integration test
 test_runtime_execution :-
     Test = 'WAM-Rust Runtime: end-to-end execution',
@@ -128,7 +136,7 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:astar_weighted_path/4, user:min_semantic_dist/3, user:min_semantic_dist_astar/4],
+        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:astar_weighted_path/4, user:min_semantic_dist/3, user:min_semantic_dist_astar/4, user:grouped_min_semantic_dist/3, user:grouped_min_semantic_dist_astar/4],
             [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
@@ -149,6 +157,8 @@ use runtime_test::weighted_path;
 use runtime_test::astar_weighted_path;
 use runtime_test::min_semantic_dist;
 use runtime_test::min_semantic_dist_astar;
+use runtime_test::grouped_min_semantic_dist;
+use runtime_test::grouped_min_semantic_dist_astar;
 
 #[test]
 fn test_generated_predicates() {
@@ -705,6 +715,105 @@ fn test_generated_predicates() {
         Value::Integer(5),
         Value::Unbound("AStarNoPath".to_string()));
     assert!(!ok28, "min_semantic_dist_astar(d, s, 5, NoPath) should fail");
+
+    // Test grouped_min_semantic_dist/3 streaming grouped minima over weighted_path/3
+    let mut vm_grouped = WamState::new(vec![], std::collections::HashMap::new());
+    let ok29 = grouped_min_semantic_dist(&mut vm_grouped,
+        Value::Atom("s".to_string()),
+        Value::Unbound("GroupedTarget".to_string()),
+        Value::Unbound("GroupedMin".to_string()));
+    assert!(ok29, "grouped_min_semantic_dist(s, Target, Min) first grouped result should succeed");
+    let mut grouped_results: Vec<(String, f64)> = Vec::new();
+    if let (Some(Value::Atom(target)), Some(Value::Float(cost))) =
+        (vm_grouped.bindings.get("GroupedTarget").cloned(), vm_grouped.bindings.get("GroupedMin").cloned()) {
+        grouped_results.push((target, cost));
+    } else {
+        panic!("expected first grouped_min_semantic_dist result");
+    }
+    while vm_grouped.backtrack() {
+        if let (Some(Value::Atom(target)), Some(Value::Float(cost))) =
+            (vm_grouped.bindings.get("GroupedTarget").cloned(), vm_grouped.bindings.get("GroupedMin").cloned()) {
+            grouped_results.push((target, cost));
+        } else {
+            panic!("expected grouped_min_semantic_dist backtrack result");
+        }
+    }
+    grouped_results.sort_by(|a, b| a.0.cmp(&b.0));
+    assert_eq!(grouped_results, vec![
+        ("a".to_string(), 1.0),
+        ("b".to_string(), 3.0),
+        ("c".to_string(), 4.0),
+        ("d".to_string(), 7.0),
+    ]);
+
+    let mut vm_grouped_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok30 = grouped_min_semantic_dist(&mut vm_grouped_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("c".to_string()),
+        Value::Unbound("GroupedC".to_string()));
+    assert!(ok30, "grouped_min_semantic_dist(s, c, Min) should succeed");
+    match vm_grouped_exact.bindings.get("GroupedC").cloned() {
+        Some(Value::Float(cost)) => assert_close(cost, 4.0),
+        other => panic!("expected grouped_min_semantic_dist(s, c, Min) to bind float cost, got {:?}", other),
+    }
+
+    let mut vm_grouped_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok31 = grouped_min_semantic_dist(&mut vm_grouped_fail,
+        Value::Atom("d".to_string()),
+        Value::Unbound("GroupedNoTarget".to_string()),
+        Value::Unbound("GroupedNoMin".to_string()));
+    assert!(!ok31, "grouped_min_semantic_dist(d, Target, Min) should fail");
+
+    // Test grouped_min_semantic_dist_astar/4 streaming grouped minima over astar_weighted_path/4
+    let mut vm_grouped_astar = WamState::new(vec![], std::collections::HashMap::new());
+    let ok32 = grouped_min_semantic_dist_astar(&mut vm_grouped_astar,
+        Value::Atom("s".to_string()),
+        Value::Unbound("GroupedAStarTarget".to_string()),
+        Value::Integer(5),
+        Value::Unbound("GroupedAStarMin".to_string()));
+    assert!(ok32, "grouped_min_semantic_dist_astar(s, Target, 5, Min) first grouped result should succeed");
+    let mut grouped_astar_results: Vec<(String, f64)> = Vec::new();
+    if let (Some(Value::Atom(target)), Some(Value::Float(cost))) =
+        (vm_grouped_astar.bindings.get("GroupedAStarTarget").cloned(), vm_grouped_astar.bindings.get("GroupedAStarMin").cloned()) {
+        grouped_astar_results.push((target, cost));
+    } else {
+        panic!("expected first grouped_min_semantic_dist_astar result");
+    }
+    while vm_grouped_astar.backtrack() {
+        if let (Some(Value::Atom(target)), Some(Value::Float(cost))) =
+            (vm_grouped_astar.bindings.get("GroupedAStarTarget").cloned(), vm_grouped_astar.bindings.get("GroupedAStarMin").cloned()) {
+            grouped_astar_results.push((target, cost));
+        } else {
+            panic!("expected grouped_min_semantic_dist_astar backtrack result");
+        }
+    }
+    grouped_astar_results.sort_by(|a, b| a.0.cmp(&b.0));
+    assert_eq!(grouped_astar_results, vec![
+        ("a".to_string(), 1.0),
+        ("b".to_string(), 3.0),
+        ("c".to_string(), 4.0),
+        ("d".to_string(), 7.0),
+    ]);
+
+    let mut vm_grouped_astar_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok33 = grouped_min_semantic_dist_astar(&mut vm_grouped_astar_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("d".to_string()),
+        Value::Integer(5),
+        Value::Unbound("GroupedAStarD".to_string()));
+    assert!(ok33, "grouped_min_semantic_dist_astar(s, d, 5, Min) should succeed");
+    match vm_grouped_astar_exact.bindings.get("GroupedAStarD").cloned() {
+        Some(Value::Float(cost)) => assert_close(cost, 7.0),
+        other => panic!("expected grouped_min_semantic_dist_astar(s, d, 5, Min) to bind float cost, got {:?}", other),
+    }
+
+    let mut vm_grouped_astar_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok34 = grouped_min_semantic_dist_astar(&mut vm_grouped_astar_fail,
+        Value::Atom("d".to_string()),
+        Value::Unbound("GroupedAStarNoTarget".to_string()),
+        Value::Integer(5),
+        Value::Unbound("GroupedAStarNoMin".to_string()));
+    assert!(!ok34, "grouped_min_semantic_dist_astar(d, Target, 5, Min) should fail");
 }
 ',
         setup_call_cleanup(open(TestPath, write, S), format(S, "~w", [TestContent]), close(S)),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -42,6 +42,8 @@ test_simple_fact(foo, bar).
 :- dynamic direct_semantic_dist/3.
 :- dynamic min_semantic_dist/3.
 :- dynamic min_semantic_dist_astar/4.
+:- dynamic grouped_min_semantic_dist/3.
+:- dynamic grouped_min_semantic_dist_astar/4.
 :- dynamic tc_parent/2.
 :- dynamic max_depth/1.
 
@@ -138,6 +140,12 @@ min_semantic_dist(Start, Target, MinDist) :-
 
 min_semantic_dist_astar(Start, Target, Dim, MinDist) :-
     aggregate_all(min(Cost), astar_weighted_path(Start, Target, Dim, Cost), MinDist).
+
+grouped_min_semantic_dist(Start, Target, MinDist) :-
+    aggregate_all(min(Cost), weighted_path(Start, Target, Cost), Target, MinDist).
+
+grouped_min_semantic_dist_astar(Start, Target, Dim, MinDist) :-
+    aggregate_all(min(Cost), astar_weighted_path(Start, Target, Dim, Cost), Target, MinDist).
 
 pass(Test) :-
     format('[PASS] ~w~n', [Test]).
@@ -739,6 +747,36 @@ test_astar_min_aggregate_wrapper :-
     ;   fail_test(Test, 'A* aggregate wrapper did not delegate correctly')
     ).
 
+test_grouped_weighted_min_aggregate_wrapper :-
+    Test = 'WAM-Rust: grouped aggregate min wrapper delegates to weighted_path/3',
+    (   rust_target:compile_predicate_to_rust(user:grouped_min_semantic_dist/3,
+            [include_main(false), foreign_lowering(true), wam_fallback(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'pub fn grouped_min_semantic_dist(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool'),
+        sub_string(S, _, _, _, 'use std::collections::BTreeMap;'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("grouped_min_semantic_dist/3", "tuple:2")'),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("weighted_path/3", "weighted_shortest_path3")'),
+        sub_string(S, _, _, _, 'grouped.entry(target)'),
+        sub_string(S, _, _, _, 'vm.finish_foreign_results("grouped_min_semantic_dist/3", vec![a2.clone(), a3.clone()], packed_results)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Grouped weighted aggregate wrapper did not delegate correctly')
+    ).
+
+test_grouped_astar_min_aggregate_wrapper :-
+    Test = 'WAM-Rust: grouped aggregate min wrapper delegates to astar_weighted_path/4',
+    (   rust_target:compile_predicate_to_rust(user:grouped_min_semantic_dist_astar/4,
+            [include_main(false), foreign_lowering(true), wam_fallback(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'pub fn grouped_min_semantic_dist_astar(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool'),
+        sub_string(S, _, _, _, 'use std::collections::BTreeMap;'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("grouped_min_semantic_dist_astar/4", "tuple:2")'),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("astar_weighted_path/4", "astar_shortest_path4")'),
+        sub_string(S, _, _, _, 'grouped.entry(target)'),
+        sub_string(S, _, _, _, 'vm.finish_foreign_results("grouped_min_semantic_dist_astar/4", vec![a2.clone(), a4.clone()], packed_results)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Grouped A* aggregate wrapper did not delegate correctly')
+    ).
+
 test_compile_wam_runtime_output :-
     Test = 'WAM-Rust E2E: full runtime generates valid impl block',
     (   compile_wam_runtime_to_rust([], Code),
@@ -1055,6 +1093,8 @@ run_tests :-
     test_foreign_lowering_astar_shortest_path,
     test_weighted_min_aggregate_wrapper,
     test_astar_min_aggregate_wrapper,
+    test_grouped_weighted_min_aggregate_wrapper,
+    test_grouped_astar_min_aggregate_wrapper,
     test_compile_wam_runtime_output,
     test_write_wam_rust_project,
     test_project_cargo_content,


### PR DESCRIPTION
## Summary

This PR adds grouped aggregate-wrapper lowering on top of foreign-lowered recursive kernels in the Rust WAM target.

Before this change, scalar `aggregate_all(min(...))` wrappers over `weighted_path/3` and `astar_weighted_path/4` lowered correctly, but grouped forms still fell back to the generic recursive aggregate path.

This PR closes that gap by generating grouped Rust wrappers that:

- invoke the existing foreign kernel
- reduce streamed results to per-target minima
- re-emit grouped `(target, min_cost)` results through the standard foreign-result queue

## Changes

- add grouped aggregate-wrapper lowering for:
  - `aggregate_all(min(Cost), weighted_path(Start, Target, Cost), Target, MinDist)`
  - `aggregate_all(min(Cost), astar_weighted_path(Start, Target, Dim, Cost), Target, MinDist)`
- expose `finish_foreign_results` so generated wrappers can legally stream grouped results through the runtime’s foreign-result machinery
- add target-suite assertions for grouped weighted and grouped A* wrappers
- add generated Rust runtime coverage for:
  - unbound-target grouped streaming
  - bound-target grouped lookup
  - unreachable grouped failure
  - both weighted and A* variants

## Why

The Rust WAM foreign-lowering path already had strong coverage for:

- kernel-level foreign lowering
- scalar aggregate wrappers above those kernels

The missing case was grouped aggregates above foreign kernels. That was the main remaining aggregate-shape gap in the Rust path.

This PR completes that layer and keeps grouped results on the same native/foreign execution path instead of falling back to generic recursive aggregate lowering.

## Validation

Ran locally in Termux:

```sh
swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl
swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl
```

Both passed.

## Notes

- Scope is intentionally limited to grouped `min` wrappers over the existing weighted and A* foreign kernels.
- The wrappers reuse the current foreign-result queue instead of inventing a second grouped streaming mechanism.
