### PR TITLE
feat(csharp-query): add closure materialization planner

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -92,6 +92,11 @@ Status:
   `PatternScanNode`, and scan-heavy join/negation/aggregate consumers can now
   choose between direct streamed scan access, replayable buffering, and
   external materialized fallback before building list/set views
+- started for generic closure relation retention, where `TransitiveClosureNode`,
+  grouped closure variants, and `PathAwareAccumulationNode` auxiliary-relation
+  loading can now choose between direct streamed access, replayable
+  buffering, and external materialized fallback before building closure
+  indices
 - the runtime can now choose between compact grouped summaries and legacy
   seeded-row regrouping for both operator families through a shared
   grouped-summary policy layer
@@ -118,8 +123,11 @@ Status:
 - the runtime now shares one internal materialization-planner layer above
   the shared relation-retention and grouped-summary policy components
 - the path-aware grouped-summary family uses both branches of that planner,
-  while the DAG family and the generic scan family currently use the
-  relation-retention branch of the same planner
+  while the DAG family, the generic scan family, and the generic closure
+  family currently use the relation-retention branch of the same planner
+- `QueryExecutorOptions.ClosureRelationRetentionStrategy` can force `Auto`,
+  `StreamingDirect`, `ReplayableBuffer`, or `ExternalMaterialized` for
+  generic closure benchmarking and diagnosis
 - the current per-family override knobs and trace surface are still preserved
 
 Work:

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -35,12 +35,14 @@ These hooks do not solve every ingestion case yet, but they make the
 retention choice explicit at the runtime/provider boundary instead of hiding it
 inside benchmark-specific wiring. The current runtime now also shares one
 internal measured relation-retention policy layer between DAG relation
-selection and path-aware edge selection, while preserving separate public
-override surfaces for those families. The runtime now also shares one
-internal materialization-planner layer above those policy components: the
-path-aware grouped-summary family uses both relation-retention and
-grouped-summary planning through that shared layer, while the DAG family
-currently uses the relation-retention branch of the same planner.
+selection, path-aware edge selection, generic scan selection, and generic
+closure relation selection, while preserving separate public override
+surfaces for those families. The runtime now also shares one internal
+materialization-planner layer above those policy components: the path-aware
+grouped-summary family uses both relation-retention and grouped-summary
+planning through that shared layer, while the DAG, generic scan, and
+generic closure families currently use the relation-retention branch of the
+same planner.
 
 ## Required Capabilities
 
@@ -78,6 +80,10 @@ Examples:
   are all viable sources for that edge state, the runtime can choose among
   them through a measured retention selector and still expose an explicit
   override via `QueryExecutorOptions.PathAwareEdgeRetentionStrategy`
+- generic closure operators can route edge and support relations through the
+  same measured relation-retention boundary before building successor,
+  predecessor, or auxiliary lookup indices, with an explicit override via
+  `QueryExecutorOptions.ClosureRelationRetentionStrategy`
 - shortest-path and weighted-shortest-path operators can emit compact
   `(group, root, min_value)` summaries instead of retaining full seeded path rows
 - where both grouped minima and legacy seeded-row regrouping are available, the
@@ -164,19 +170,26 @@ For the current benchmark/runtime surface, the streamed path is:
    negation, and aggregate paths can choose between direct streaming,
    replayable buffering, and external materialized fallback before building
    list/set views
-13. the current runtime now routes path-aware, DAG, and generic scan planning
-   through a shared internal materialization-planner layer
-14. for the current path-aware grouped-summary family, that planner
+13. generic closure operators now also route edge and support relations
+   through measured relation-retention selection before building successor,
+   predecessor, or auxiliary lookup indices
+14. the current runtime now routes path-aware, DAG, generic scan, and
+   generic closure planning through a shared internal
+   materialization-planner layer
+15. for the current path-aware grouped-summary family, that planner
    coordinates the earlier edge-retention choice with the later
    grouped-summary choice and records the combined plan in trace output
-15. for the current DAG family, that same planner currently records the
+16. for the current DAG family, that same planner currently records the
    coordinated relation-retention plan before the operator-owned DAG state is
    built
-16. for the current generic scan family, that same planner currently records
+17. for the current generic scan family, that same planner currently records
    the coordinated relation-retention plan before scan-heavy consumers build
    list/set views
-17. the operator builds only the retained state it actually needs
-18. benchmark code avoids preloading raw facts into in-memory relations first
+18. for the current generic closure family, that same planner currently
+   records the coordinated relation-retention plan before closure consumers
+   build edge or auxiliary indices
+19. the operator builds only the retained state it actually needs
+20. benchmark code avoids preloading raw facts into in-memory relations first
 
 This is still a first step, not the full endpoint, but it is now broader than
 just the original DAG-only fast paths.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -41,7 +41,10 @@ earlier path-aware edge-retention boundary now also records buckets like
 `edge_strategy_select`, `edge_probe_*`, `edge_materialize_replayable`, and
 `edge_build_*`. Generic scan planning now adds corresponding scan buckets such
 as `scan_strategy_select`, `scan_probe_*`, `scan_materialize_*`, and
-`scan_build_fact_set`.
+`scan_build_fact_set`. Generic closure planning now adds corresponding closure
+buckets such as `closure_strategy_select`, `closure_probe_*`, and
+`closure_materialize_*`, with focused validation available in
+`benchmark_closure_materialization.py`.
 
 | Target | 300 art | 1K art | 5K art | 10K art |
 |--------|---------|--------|--------|---------|
@@ -217,6 +220,7 @@ Tables:
 | `benchmark_dependency_depth_cross_target.py` | Compare synthetic dependency reach-count across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_longest_depth_cross_target.py` | Compare true DAG longest dependency-chain depth across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
+| `benchmark_closure_materialization.py` | Exercise generic seeded closure and streamed auxiliary accumulation under the closure materialization planner |
 | `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive weighted paths |
 | `benchmark_weighted_shortest_path_cross_target.py` | Compare positive weighted shortest path across C# query, seeded Prolog `min`, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_category_influence_cross_target.py` | Compare category influence propagation across the C# query engine, Rust DFS, Go DFS, and an optional Prolog accumulated path |

--- a/examples/benchmark/benchmark_closure_materialization.py
+++ b/examples/benchmark/benchmark_closure_materialization.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+Measure generic closure-family materialization planning in the C# query runtime.
+
+This harness exercises two representative closure paths against the benchmark
+TSVs using streamed relation sources inside a temporary C# project:
+
+- `seeded`: generic `TransitiveClosureNode` with seeded execution
+- `weighted`: `PathAwareAccumulationNode` with a streamed auxiliary relation
+
+It is intended as a focused validation tool for the closure materialization
+planner rather than a cross-target benchmark.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import statistics
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+QRY_RUNTIME = ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
+
+CSHARP_PROJECT = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>
+"""
+
+PROGRAM = r"""using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using UnifyWeaver.QueryRuntime;
+
+class Program
+{
+    static ClosureRelationRetentionStrategy ParseClosureStrategy(string value) => value.ToLowerInvariant() switch
+    {
+        "streaming" => ClosureRelationRetentionStrategy.StreamingDirect,
+        "replayable" => ClosureRelationRetentionStrategy.ReplayableBuffer,
+        "external" => ClosureRelationRetentionStrategy.ExternalMaterialized,
+        _ => ClosureRelationRetentionStrategy.Auto,
+    };
+
+    static int Main(string[] args)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: program <seeded|weighted> <category_parent.tsv> <article_category.tsv>");
+            return 1;
+        }
+
+        var mode = args[0];
+        var edgePath = args[1];
+        var articlePath = args[2];
+        var traceEnabled = Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE") == "1";
+        var closureStrategy = ParseClosureStrategy(Environment.GetEnvironmentVariable("UNIFYWEAVER_CLOSURE_RETENTION_STRATEGY") ?? "auto");
+
+        var provider = new InMemoryRelationProvider();
+        var edgeId = new PredicateId("category_parent", 2);
+        var predicateId = new PredicateId(mode == "seeded" ? "category_ancestor_seeded" : "category_weighted_ancestor", 3);
+        var weightId = new PredicateId("category_weight", 2);
+
+        provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(edgePath));
+
+        var sourceNodes = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (var line in File.ReadLines(edgePath).Skip(1))
+        {
+            var parts = line.Split('	', 2);
+            if (parts.Length == 2)
+            {
+                sourceNodes.Add(parts[0]);
+            }
+        }
+
+        var weightPath = Path.GetTempFileName();
+        using (var writer = new StreamWriter(weightPath, false))
+        {
+            writer.WriteLine("child	weight");
+            foreach (var source in sourceNodes)
+            {
+                writer.Write(source);
+                writer.Write('	');
+                writer.WriteLine("1");
+            }
+        }
+        provider.RegisterDelimitedSource(weightId, new DelimitedRelationSource(weightPath));
+
+        var parameters = File.ReadLines(articlePath)
+            .Skip(1)
+            .Select(line => line.Split('	', 2))
+            .Where(parts => parts.Length == 2)
+            .Select(parts => parts[1])
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(value => value, StringComparer.Ordinal)
+            .Select(value => new object[] { value })
+            .ToList();
+
+        QueryPlan plan = mode switch
+        {
+            "seeded" => new QueryPlan(
+                predicateId,
+                new TransitiveClosureNode(edgeId, predicateId),
+                true,
+                new int[] { 0 }),
+            "weighted" => new QueryPlan(
+                predicateId,
+                new PathAwareAccumulationNode(
+                    edgeId,
+                    predicateId,
+                    weightId,
+                    new ColumnExpression(3),
+                    new BinaryArithmeticExpression(
+                        ArithmeticBinaryOperator.Add,
+                        new ColumnExpression(2),
+                        new ColumnExpression(3)),
+                    10),
+                true,
+                new int[] { 0 }),
+            _ => throw new ArgumentException($"Unknown mode: {mode}")
+        };
+
+        var trace = traceEnabled ? new QueryExecutionTrace() : null;
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(
+            ReuseCaches: false,
+            ClosureRelationRetentionStrategy: closureStrategy));
+
+        var stopwatch = Stopwatch.StartNew();
+        var rows = executor.Execute(plan, parameters, trace).ToList();
+        stopwatch.Stop();
+
+        Console.Error.WriteLine($"mode={mode}");
+        Console.Error.WriteLine($"closure_strategy_setting={closureStrategy}");
+        Console.Error.WriteLine($"seed_count={parameters.Count}");
+        Console.Error.WriteLine($"row_count={rows.Count}");
+        Console.Error.WriteLine($"elapsed_ms={stopwatch.ElapsedMilliseconds}");
+
+        if (traceEnabled && trace is not null)
+        {
+            foreach (var strategy in trace.SnapshotStrategies().OrderBy(s => s.NodeId).ThenBy(s => s.Strategy, StringComparer.Ordinal))
+            {
+                Console.Error.WriteLine($"strategy_{strategy.Strategy}={strategy.Count}");
+            }
+
+            foreach (var phase in trace.SnapshotPhases().OrderBy(p => p.NodeId).ThenBy(p => p.Phase, StringComparer.Ordinal))
+            {
+                Console.Error.WriteLine($"phase_{phase.NodeType}_{phase.Phase}={phase.Elapsed.TotalMilliseconds.ToString("F3", CultureInfo.InvariantCulture)}");
+            }
+        }
+
+        return 0;
+    }
+}
+"""
+
+
+@dataclass
+class BenchResult:
+    scale: str
+    mode: str
+    times: list[float]
+    stderr: str
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.times)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="300,10k")
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--keep-temp", action="store_true")
+    return parser.parse_args()
+
+
+def run(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, env=env, check=True, capture_output=True, text=True)
+
+
+def scale_sort_key(scale: str) -> tuple[int, str]:
+    digits = "".join(ch for ch in scale if ch.isdigit())
+    suffix = "".join(ch for ch in scale if not ch.isdigit())
+    if not digits:
+        return (0, scale)
+    value = int(digits)
+    if suffix.lower() == "k":
+        value *= 1000
+    return (value, scale)
+
+
+def build_harness(root: Path) -> list[str]:
+    if shutil.which("dotnet") is None:
+        raise RuntimeError("dotnet not found")
+
+    project_dir = root / "closure_materialization"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "Program.cs").write_text(PROGRAM, encoding="utf-8")
+    (project_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
+    (project_dir / "benchmark_closure_materialization.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
+    run(["dotnet", "build", "benchmark_closure_materialization.csproj", "-c", "Release"], cwd=project_dir)
+    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_closure_materialization.dll")]
+
+
+def benchmark_mode(command: list[str], scale: str, mode: str, repetitions: int) -> BenchResult:
+    scale_dir = BENCH_DIR / scale
+    edge_path = scale_dir / "category_parent.tsv"
+    article_path = scale_dir / "article_category.tsv"
+    env = os.environ.copy()
+
+    times: list[float] = []
+    stderr = ""
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        result = run(command + [mode, str(edge_path), str(article_path)], env=env)
+        elapsed = time.perf_counter() - started
+        times.append(elapsed)
+        stderr = result.stderr
+
+    return BenchResult(scale=scale, mode=mode, times=times, stderr=stderr)
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+
+    temp_ctx = None
+    if args.keep_temp:
+        temp_root = Path(tempfile.mkdtemp(prefix="uw-closure-materialization-"))
+    else:
+        temp_ctx = tempfile.TemporaryDirectory(prefix="uw-closure-materialization-")
+        temp_root = Path(temp_ctx.name)
+
+    try:
+        command = build_harness(temp_root)
+        results: list[BenchResult] = []
+        for scale in scales:
+            results.append(benchmark_mode(command, scale, "seeded", args.repetitions))
+            results.append(benchmark_mode(command, scale, "weighted", args.repetitions))
+
+        print("scale	mode	median_s	min_s	max_s")
+        for result in sorted(results, key=lambda item: (scale_sort_key(item.scale), item.mode)):
+            print(
+                f"{result.scale}	{result.mode}	{result.median:.3f}	"
+                f"{min(result.times):.3f}	{max(result.times):.3f}"
+            )
+            for line in result.stderr.splitlines():
+                if line.startswith(("mode=", "closure_strategy_setting=", "seed_count=", "row_count=", "elapsed_ms=")):
+                    print(f"{result.scale}	{result.mode}_metrics	{line}")
+        return 0
+    finally:
+        if temp_ctx is not None:
+            temp_ctx.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -67,6 +67,14 @@ namespace UnifyWeaver.QueryRuntime
         ExternalMaterialized
     }
 
+    public enum ClosureRelationRetentionStrategy
+    {
+        Auto,
+        StreamingDirect,
+        ReplayableBuffer,
+        ExternalMaterialized
+    }
+
     public readonly record struct DelimitedRelationSource(
         string InputPath,
         char Delimiter = '	',
@@ -527,6 +535,12 @@ namespace UnifyWeaver.QueryRuntime
         Set
     }
 
+    internal enum ClosureRelationAccessKind
+    {
+        Edge,
+        Support
+    }
+
     internal readonly record struct RelationRetentionSelection(
         RelationRetentionPolicyStrategy Strategy,
         string DecisionMode);
@@ -552,10 +566,15 @@ namespace UnifyWeaver.QueryRuntime
         ScanRelationRetentionStrategy Strategy,
         string DecisionMode);
 
+    internal readonly record struct ClosureRelationRetentionSelection(
+        ClosureRelationRetentionStrategy Strategy,
+        string DecisionMode);
+
     public sealed record QueryExecutorOptions(
         bool ReuseCaches = false,
         DagRelationRetentionStrategy DagRelationRetentionStrategy = DagRelationRetentionStrategy.Auto,
         ScanRelationRetentionStrategy ScanRelationRetentionStrategy = ScanRelationRetentionStrategy.Auto,
+        ClosureRelationRetentionStrategy ClosureRelationRetentionStrategy = ClosureRelationRetentionStrategy.Auto,
         PathAwareEdgeRetentionStrategy PathAwareEdgeRetentionStrategy = PathAwareEdgeRetentionStrategy.Auto,
         PathAwareGroupedMinStrategy PathAwareGroupedMinStrategy = PathAwareGroupedMinStrategy.Auto,
         PathAwareWeightSumStrategy PathAwareWeightSumStrategy = PathAwareWeightSumStrategy.Auto,
@@ -1507,6 +1526,7 @@ namespace UnifyWeaver.QueryRuntime
         private readonly int _maxFixpointIterations;
         private readonly DagRelationRetentionStrategy _dagRelationRetentionStrategy;
         private readonly ScanRelationRetentionStrategy _scanRelationRetentionStrategy;
+        private readonly ClosureRelationRetentionStrategy _closureRelationRetentionStrategy;
         private readonly PathAwareEdgeRetentionStrategy _pathAwareEdgeRetentionStrategy;
         private readonly PathAwareGroupedSummaryStrategy _pathAwareGroupedMinStrategy;
         private readonly PathAwareGroupedSummaryStrategy _pathAwareWeightSumStrategy;
@@ -1525,6 +1545,7 @@ namespace UnifyWeaver.QueryRuntime
             _maxFixpointIterations = Math.Max(0, options.MaxFixpointIterations);
             _dagRelationRetentionStrategy = options.DagRelationRetentionStrategy;
             _scanRelationRetentionStrategy = options.ScanRelationRetentionStrategy;
+            _closureRelationRetentionStrategy = options.ClosureRelationRetentionStrategy;
             _pathAwareEdgeRetentionStrategy = options.PathAwareEdgeRetentionStrategy;
             _pathAwareGroupedMinStrategy = ToPathAwareGroupedSummaryStrategy(options.PathAwareGroupedMinStrategy);
             _pathAwareWeightSumStrategy = ToPathAwareGroupedSummaryStrategy(options.PathAwareWeightSumStrategy);
@@ -1786,6 +1807,7 @@ namespace UnifyWeaver.QueryRuntime
             _cacheContext.FactSources.Clear();
             _cacheContext.ReplayableFactSources.Clear();
             _cacheContext.ScanRelationRetentionSelections.Clear();
+            _cacheContext.ClosureRelationRetentionSelections.Clear();
             _cacheContext.PathAwareEdgeStates.Clear();
             _cacheContext.PathAwareEdgeRetentionSelections.Clear();
             _cacheContext.FactSets.Clear();
@@ -6388,6 +6410,126 @@ namespace UnifyWeaver.QueryRuntime
             return set;
         }
 
+        private ClosureRelationRetentionSelection GetClosureRelationRetentionSelection(
+            PredicateId predicate,
+            ClosureRelationAccessKind accessKind,
+            EvaluationContext context,
+            PlanNode traceNode)
+        {
+            var cacheKey = (predicate, accessKind);
+            if (context.ClosureRelationRetentionSelections.TryGetValue(cacheKey, out var cachedSelection))
+            {
+                return cachedSelection;
+            }
+
+            var hasStreaming = TryGetDelimitedSource(predicate, RelationRetentionMode.Streaming, out var delimitedSource);
+            var hasReplayable = TryGetReplayableSource(predicate, context, out var replayableSource);
+            var hasExternal = TryGetExternalFacts(predicate, out var externalFacts);
+            var concreteReplayable = replayableSource as ReplayableRelationSource;
+            var relationBytes = hasStreaming && !string.IsNullOrEmpty(delimitedSource.InputPath) && File.Exists(delimitedSource.InputPath)
+                ? new FileInfo(delimitedSource.InputPath).Length
+                : (long?)null;
+            const int closureProbeRowLimit = 256;
+
+            Func<TimeSpan>? measureStreamingProbe = hasStreaming
+                ? () => MeasureElapsed(() => ProbeFactRows(DelimitedRelationReader.ReadRows(delimitedSource), closureProbeRowLimit))
+                : null;
+            Func<TimeSpan>? measureReplayableProbe = hasReplayable
+                ? () => MeasureElapsed(() =>
+                {
+                    var probeRows = concreteReplayable is not null
+                        ? concreteReplayable.ProbeMaterialize(closureProbeRowLimit)
+                        : replayableSource.Stream().Take(closureProbeRowLimit).ToList();
+                    ProbeFactRows(probeRows, closureProbeRowLimit);
+                })
+                : null;
+            Func<TimeSpan>? measureExternalProbe = hasExternal
+                ? () => MeasureElapsed(() => ProbeFactRows(externalFacts, closureProbeRowLimit))
+                : null;
+
+            var selection = ResolveClosureRelationRetentionStrategy(
+                context.Trace,
+                traceNode,
+                _closureRelationRetentionStrategy,
+                accessKind,
+                relationBytes,
+                hasStreaming,
+                hasReplayable,
+                hasExternal,
+                concreteReplayable?.IsMaterialized == true,
+                measureStreamingProbe,
+                measureReplayableProbe,
+                measureExternalProbe);
+            context.ClosureRelationRetentionSelections[cacheKey] = selection;
+            return selection;
+        }
+
+        private List<object[]> GetClosureFactsList(
+            PredicateId predicate,
+            ClosureRelationAccessKind accessKind,
+            EvaluationContext? context,
+            PlanNode traceNode)
+        {
+            if (context is null)
+            {
+                return MaterializeFacts(predicate, context);
+            }
+
+            if (context.Facts.TryGetValue(predicate, out var cached))
+            {
+                context.Trace?.RecordCacheLookup("Facts", $"{predicate.Name}/{predicate.Arity}", hit: true, built: false);
+                return cached;
+            }
+
+            context.Trace?.RecordCacheLookup("Facts", $"{predicate.Name}/{predicate.Arity}", hit: false, built: true);
+
+            var plan = ResolveMaterializationPlan(
+                context.Trace,
+                traceNode,
+                ToRelationRetentionSelection(GetClosureRelationRetentionSelection(predicate, accessKind, context, traceNode)));
+            RecordClosureRelationRetentionStrategy(
+                context.Trace,
+                traceNode,
+                new ClosureRelationRetentionSelection(ToClosureRelationRetentionStrategy(plan.RelationRetention.Strategy), plan.RelationRetention.DecisionMode));
+            RecordMaterializationPlanStrategy(context.Trace, traceNode, "Closure", plan);
+
+            var hasStreaming = TryGetDelimitedSource(predicate, RelationRetentionMode.Streaming, out var delimitedSource);
+            var hasReplayable = TryGetReplayableSource(predicate, context, out var replayableSource);
+            var hasExternal = TryGetExternalFacts(predicate, out var externalFacts);
+            List<object[]> facts;
+
+            switch (plan.RelationRetention.Strategy)
+            {
+                case RelationRetentionPolicyStrategy.StreamingDirect when hasStreaming:
+                    facts = MeasurePhase(context.Trace, traceNode, "closure_materialize_streaming_direct", () => DelimitedRelationReader.ReadRows(delimitedSource).ToList());
+                    break;
+                case RelationRetentionPolicyStrategy.ReplayableBuffer when hasReplayable:
+                    facts = MeasurePhase(context.Trace, traceNode, "closure_materialize_replayable", () => replayableSource.Materialize());
+                    break;
+                case RelationRetentionPolicyStrategy.ExternalMaterialized when hasExternal:
+                    facts = MeasurePhase(context.Trace, traceNode, "closure_materialize_external_materialized", () => externalFacts as List<object[]> ?? externalFacts.ToList());
+                    break;
+                default:
+                    if (hasReplayable)
+                    {
+                        facts = MeasurePhase(context.Trace, traceNode, "closure_materialize_replayable", () => replayableSource.Materialize());
+                    }
+                    else if (hasStreaming)
+                    {
+                        facts = MeasurePhase(context.Trace, traceNode, "closure_materialize_streaming_direct", () => DelimitedRelationReader.ReadRows(delimitedSource).ToList());
+                    }
+                    else
+                    {
+                        var externalSource = _provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>();
+                        facts = MeasurePhase(context.Trace, traceNode, "closure_materialize_external_materialized", () => externalSource as List<object[]> ?? externalSource.ToList());
+                    }
+                    break;
+            }
+
+            context.Facts[predicate] = facts;
+            return facts;
+        }
+
         private IEnumerable<object[]> GetFactStream(PredicateId predicate, EvaluationContext? context = null)
         {
             if (context is not null && TryGetReplayableSource(predicate, context, out var replayableSource))
@@ -8146,7 +8288,7 @@ namespace UnifyWeaver.QueryRuntime
 
                 trace?.RecordCacheLookup("TransitiveClosure", traceKey, hit: false, built: true);
 
-                var edges = GetFactsList(closure.EdgeRelation, context);
+                var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
                 var succIndex = GetFactIndex(closure.EdgeRelation, 0, edges, context);
 
                 var visited = new HashSet<PairKey>();
@@ -8252,6 +8394,24 @@ namespace UnifyWeaver.QueryRuntime
                 _ => ScanRelationRetentionStrategy.Auto
             };
 
+        private static RelationRetentionPolicyStrategy ToRelationRetentionPolicyStrategy(ClosureRelationRetentionStrategy strategy)
+            => strategy switch
+            {
+                ClosureRelationRetentionStrategy.StreamingDirect => RelationRetentionPolicyStrategy.StreamingDirect,
+                ClosureRelationRetentionStrategy.ReplayableBuffer => RelationRetentionPolicyStrategy.ReplayableBuffer,
+                ClosureRelationRetentionStrategy.ExternalMaterialized => RelationRetentionPolicyStrategy.ExternalMaterialized,
+                _ => RelationRetentionPolicyStrategy.Auto
+            };
+
+        private static ClosureRelationRetentionStrategy ToClosureRelationRetentionStrategy(RelationRetentionPolicyStrategy strategy)
+            => strategy switch
+            {
+                RelationRetentionPolicyStrategy.StreamingDirect => ClosureRelationRetentionStrategy.StreamingDirect,
+                RelationRetentionPolicyStrategy.ReplayableBuffer => ClosureRelationRetentionStrategy.ReplayableBuffer,
+                RelationRetentionPolicyStrategy.ExternalMaterialized => ClosureRelationRetentionStrategy.ExternalMaterialized,
+                _ => ClosureRelationRetentionStrategy.Auto
+            };
+
         private static RelationRetentionPolicyStrategy ToRelationRetentionPolicyStrategy(PathAwareEdgeRetentionStrategy strategy)
             => strategy switch
             {
@@ -8274,6 +8434,9 @@ namespace UnifyWeaver.QueryRuntime
             => new(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode);
 
         private static RelationRetentionSelection ToRelationRetentionSelection(ScanRelationRetentionSelection selection)
+            => new(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode);
+
+        private static RelationRetentionSelection ToRelationRetentionSelection(ClosureRelationRetentionSelection selection)
             => new(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode);
 
         private static RelationRetentionSelection ToRelationRetentionSelection(PathAwareEdgeRetentionSelection selection)
@@ -8658,6 +8821,101 @@ namespace UnifyWeaver.QueryRuntime
                 new RelationRetentionSelection(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode),
                 "ScanRelationRetentionSelection",
                 "ScanRelationRetention");
+        }
+
+        private static ClosureRelationRetentionStrategy ResolveStructuralClosureRelationRetentionStrategy(
+            ClosureRelationAccessKind accessKind,
+            bool hasStreaming,
+            bool hasReplayable,
+            bool hasExternal,
+            bool replayableMaterialized)
+        {
+            var preferredStrategy = accessKind == ClosureRelationAccessKind.Edge
+                ? RelationRetentionPolicyStrategy.ReplayableBuffer
+                : RelationRetentionPolicyStrategy.ReplayableBuffer;
+            return ToClosureRelationRetentionStrategy(
+                ResolveStructuralRelationRetentionStrategy(
+                    preferredStrategy,
+                    hasStreaming,
+                    hasReplayable,
+                    hasExternal,
+                    replayableMaterialized));
+        }
+
+        private static bool ShouldProbeClosureRelationRetentionStrategy(
+            ClosureRelationAccessKind accessKind,
+            long? relationBytes,
+            bool hasStreaming,
+            bool hasReplayable,
+            bool hasExternal,
+            bool replayableMaterialized)
+        {
+            var thresholdBytes = accessKind switch
+            {
+                ClosureRelationAccessKind.Edge => 384 * 1024L,
+                _ => 256 * 1024L,
+            };
+            return ShouldProbeRelationRetentionStrategy(
+                relationBytes,
+                thresholdBytes,
+                hasStreaming,
+                hasReplayable,
+                hasExternal,
+                replayableMaterialized);
+        }
+
+        private static ClosureRelationRetentionSelection ResolveClosureRelationRetentionStrategy(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            ClosureRelationRetentionStrategy configuredStrategy,
+            ClosureRelationAccessKind accessKind,
+            long? relationBytes,
+            bool hasStreaming,
+            bool hasReplayable,
+            bool hasExternal,
+            bool replayableMaterialized,
+            Func<TimeSpan>? measureStreamingProbe = null,
+            Func<TimeSpan>? measureReplayableProbe = null,
+            Func<TimeSpan>? measureExternalProbe = null)
+        {
+            var structuralStrategy = ToRelationRetentionPolicyStrategy(
+                ResolveStructuralClosureRelationRetentionStrategy(
+                    accessKind,
+                    hasStreaming,
+                    hasReplayable,
+                    hasExternal,
+                    replayableMaterialized));
+            var selection = ResolveRelationRetentionStrategy(
+                trace,
+                node,
+                "closure_strategy_select",
+                "closure_probe_streaming_direct",
+                "closure_probe_replayable_buffer",
+                "closure_probe_external_materialized",
+                ToRelationRetentionPolicyStrategy(configuredStrategy),
+                structuralStrategy,
+                ShouldProbeClosureRelationRetentionStrategy(accessKind, relationBytes, hasStreaming, hasReplayable, hasExternal, replayableMaterialized),
+                hasStreaming,
+                hasReplayable,
+                hasExternal,
+                replayableMaterialized,
+                measureStreamingProbe,
+                measureReplayableProbe,
+                measureExternalProbe);
+            return new ClosureRelationRetentionSelection(ToClosureRelationRetentionStrategy(selection.Strategy), selection.DecisionMode);
+        }
+
+        private static void RecordClosureRelationRetentionStrategy(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            ClosureRelationRetentionSelection selection)
+        {
+            RecordRelationRetentionStrategy(
+                trace,
+                node,
+                new RelationRetentionSelection(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode),
+                "ClosureRelationRetentionSelection",
+                "ClosureRelationRetention");
         }
 
         private static PathAwareEdgeRetentionStrategy ResolveStructuralPathAwareEdgeRetentionStrategy(
@@ -9845,7 +10103,7 @@ namespace UnifyWeaver.QueryRuntime
                     }
 
                     positiveFastPathPrepared = true;
-                    var auxRows = MeasurePhase(trace, closure, "load_auxiliary", () => GetFactsList(closure.AuxiliaryRelation, context));
+                    var auxRows = MeasurePhase(trace, closure, "load_auxiliary", () => GetClosureFactsList(closure.AuxiliaryRelation, ClosureRelationAccessKind.Support, context, closure));
                     auxIndex = MeasurePhase(trace, closure, "build_auxiliary_index", () => GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context));
                     usePositiveMinFastPath = closure.MaxDepth > 0 &&
                         TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, closure.PositiveStepProven, out stepEvaluator);
@@ -10311,7 +10569,7 @@ namespace UnifyWeaver.QueryRuntime
 
                 var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context, closure);
                 var succIndex = edgeState.Successors;
-                var auxRows = GetFactsList(closure.AuxiliaryRelation, context);
+                var auxRows = GetClosureFactsList(closure.AuxiliaryRelation, ClosureRelationAccessKind.Support, context, closure);
                 var auxIndex = GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context);
                 PositiveStepEvaluator? stepEvaluator = null;
                 var usePositiveMinFastPath = closure.AccumulatorMode == TableMode.Min &&
@@ -10357,7 +10615,7 @@ namespace UnifyWeaver.QueryRuntime
 
                 var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context, closure);
                 var succIndex = edgeState.Successors;
-                var auxRows = GetFactsList(closure.AuxiliaryRelation, context);
+                var auxRows = GetClosureFactsList(closure.AuxiliaryRelation, ClosureRelationAccessKind.Support, context, closure);
                 var auxIndex = GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context);
                 var seeds = new List<object?>();
                 var seenSeeds = new HashSet<object?>();
@@ -10955,7 +11213,7 @@ namespace UnifyWeaver.QueryRuntime
 
                 trace?.RecordCacheLookup("GroupedTransitiveClosure", traceKey, hit: false, built: true);
 
-                var edges = GetFactsList(closure.EdgeRelation, context);
+                var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
 
                 var edgeKeyIndices = new int[groupCount + 1];
                 for (var i = 0; i < groupCount; i++)
@@ -11070,8 +11328,8 @@ namespace UnifyWeaver.QueryRuntime
 
                 var predicate = closure.Predicate;
                 var traceKey = $"{predicate.Name}/{predicate.Arity}:edge={closure.EdgeRelation.Name}/{closure.EdgeRelation.Arity}:seeds={closure.SeedRelation.Name}/{closure.SeedRelation.Arity}";
-                var edges = GetFactsList(closure.EdgeRelation, context);
-                var seeds = GetFactsList(closure.SeedRelation, context);
+                var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
+                var seeds = GetClosureFactsList(closure.SeedRelation, ClosureRelationAccessKind.Support, context, closure);
 
                 const int MaxDagNodeCount = 16384;
                 const int MaxDagGroupCount = 4096;
@@ -13003,7 +13261,7 @@ namespace UnifyWeaver.QueryRuntime
                     Array.Copy(sourceKey, targetKey, sourceKey.Length - 1);
                     targetKey[sourceKey.Length - 1] = target;
 
-                    var edges = GetFactsList(closure.EdgeRelation, context);
+                    var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
                     var groupKeyCount = closure.GroupIndices.Count;
                     var fromKeyIndices = new int[groupKeyCount + 1];
                     var toKeyIndices = new int[groupKeyCount + 1];
@@ -13290,7 +13548,7 @@ namespace UnifyWeaver.QueryRuntime
                 context.GroupedTransitiveClosurePairProbeResults.Add(groupedCacheKey, pairStore);
             }
 
-            var edges = GetFactsList(closure.EdgeRelation, context);
+            var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
             var groupKeyCount = closure.GroupIndices.Count;
             var fromKeyIndices = new int[groupKeyCount + 1];
             var toKeyIndices = new int[groupKeyCount + 1];
@@ -13518,7 +13776,7 @@ namespace UnifyWeaver.QueryRuntime
                 return false;
             }
 
-            var edges = GetFactsList(closure.EdgeRelation, context);
+            var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
             var groupKeyCount = closure.GroupIndices.Count;
             var fromKeyIndices = new int[groupKeyCount + 1];
             var toKeyIndices = new int[groupKeyCount + 1];
@@ -13614,7 +13872,7 @@ namespace UnifyWeaver.QueryRuntime
                 trace?.RecordStrategy(closure, "GroupedTransitiveClosureSeeded");
 
                 var predicate = closure.Predicate;
-                var edges = GetFactsList(closure.EdgeRelation, context);
+                var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
 
                 var edgeKeyIndices = new int[groupCount + 1];
                 for (var i = 0; i < groupCount; i++)
@@ -14031,7 +14289,7 @@ namespace UnifyWeaver.QueryRuntime
                 trace?.RecordStrategy(closure, "GroupedTransitiveClosureSeededByTarget");
 
                 var predicate = closure.Predicate;
-                var edges = GetFactsList(closure.EdgeRelation, context);
+                var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
 
                 var edgeKeyIndices = new int[groupCount + 1];
                 for (var i = 0; i < groupCount; i++)
@@ -14655,7 +14913,7 @@ namespace UnifyWeaver.QueryRuntime
             var maxRequiredIndex = ValidateGroupedClosureIndices(closure.GroupIndices, width);
             var trace = context.Trace;
             var predicate = closure.Predicate;
-            var edges = GetFactsList(closure.EdgeRelation, context);
+            var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
 
             var edgeKeyIndices = new int[groupCount + 1];
             for (var i = 0; i < groupCount; i++)
@@ -14801,7 +15059,7 @@ namespace UnifyWeaver.QueryRuntime
             var maxRequiredIndex = ValidateGroupedClosureIndices(closure.GroupIndices, width);
             var trace = context.Trace;
             var predicate = closure.Predicate;
-            var edges = GetFactsList(closure.EdgeRelation, context);
+            var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
 
             var edgeKeyIndices = new int[groupCount + 1];
             for (var i = 0; i < groupCount; i++)
@@ -15612,7 +15870,7 @@ namespace UnifyWeaver.QueryRuntime
                 trace?.RecordStrategy(closure, "TransitiveClosureSeeded");
 
                 var predicate = closure.Predicate;
-                var edges = GetFactsList(closure.EdgeRelation, context);
+                var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
                 var succIndex = GetFactIndex(closure.EdgeRelation, 0, edges, context);
 
                 var seeds = new List<object?>();
@@ -16057,7 +16315,7 @@ namespace UnifyWeaver.QueryRuntime
                 trace?.RecordStrategy(closure, "TransitiveClosureSeededByTarget");
 
                 var predicate = closure.Predicate;
-                var edges = GetFactsList(closure.EdgeRelation, context);
+                var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
                 var predIndex = GetFactIndex(closure.EdgeRelation, 1, edges, context);
 
                 var seeds = new List<object?>();
@@ -16395,7 +16653,7 @@ namespace UnifyWeaver.QueryRuntime
                     var probeCount = ComputeSinglePairProbeNormalizationCount(parameters);
                     var source = bySource.First().Key;
                     var target = bySource.First().Value.First();
-                    var edges = GetFactsList(closure.EdgeRelation, context);
+                    var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
                     var succIndex = GetFactIndex(closure.EdgeRelation, 0, edges, context);
                     var predIndex = GetFactIndex(closure.EdgeRelation, 1, edges, context);
                     var forwardCost = CountEdgeBucket(succIndex, source);
@@ -16630,7 +16888,7 @@ namespace UnifyWeaver.QueryRuntime
                 context.TransitiveClosurePairProbeResults.Add(pairCacheKey, pairStore);
             }
 
-            var edges = GetFactsList(closure.EdgeRelation, context);
+            var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
             var succIndex = GetFactIndex(closure.EdgeRelation, 0, edges, context);
             var predIndex = GetFactIndex(closure.EdgeRelation, 1, edges, context);
             var sourceCostCache = new Dictionary<object?, int>();
@@ -16815,7 +17073,7 @@ namespace UnifyWeaver.QueryRuntime
                 return false;
             }
 
-            var edges = GetFactsList(closure.EdgeRelation, context);
+            var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
             var succIndex = GetFactIndex(closure.EdgeRelation, 0, edges, context);
             var predIndex = GetFactIndex(closure.EdgeRelation, 1, edges, context);
             var sourceCostCache = new Dictionary<object?, int>();
@@ -16958,7 +17216,7 @@ namespace UnifyWeaver.QueryRuntime
         {
             var trace = context.Trace;
             var predicate = closure.Predicate;
-            var edges = GetFactsList(closure.EdgeRelation, context);
+            var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
             var succIndex = GetFactIndex(closure.EdgeRelation, 0, edges, context);
 
             var totalRows = new List<object[]>();
@@ -17088,7 +17346,7 @@ namespace UnifyWeaver.QueryRuntime
         {
             var trace = context.Trace;
             var predicate = closure.Predicate;
-            var edges = GetFactsList(closure.EdgeRelation, context);
+            var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
             var predIndex = GetFactIndex(closure.EdgeRelation, 1, edges, context);
 
             var totalRows = new List<object[]>();
@@ -17590,6 +17848,7 @@ namespace UnifyWeaver.QueryRuntime
                 FactSources = parent?.FactSources ?? new Dictionary<PredicateId, PlanNode>();
                 ReplayableFactSources = parent?.ReplayableFactSources ?? new Dictionary<PredicateId, IReplayableRelationSource>();
                 ScanRelationRetentionSelections = parent?.ScanRelationRetentionSelections ?? new Dictionary<(PredicateId Predicate, ScanRelationAccessKind AccessKind), ScanRelationRetentionSelection>();
+                ClosureRelationRetentionSelections = parent?.ClosureRelationRetentionSelections ?? new Dictionary<(PredicateId Predicate, ClosureRelationAccessKind AccessKind), ClosureRelationRetentionSelection>();
                 PathAwareEdgeStates = parent?.PathAwareEdgeStates ?? new Dictionary<PredicateId, PathAwareEdgeState>();
                 PathAwareEdgeRetentionSelections = parent?.PathAwareEdgeRetentionSelections ?? new Dictionary<PredicateId, PathAwareEdgeRetentionSelection>();
                 FactSets = parent?.FactSets ?? new Dictionary<PredicateId, HashSet<object[]>>();
@@ -17657,6 +17916,8 @@ namespace UnifyWeaver.QueryRuntime
             public Dictionary<PredicateId, IReplayableRelationSource> ReplayableFactSources { get; }
 
             public Dictionary<(PredicateId Predicate, ScanRelationAccessKind AccessKind), ScanRelationRetentionSelection> ScanRelationRetentionSelections { get; }
+
+            public Dictionary<(PredicateId Predicate, ClosureRelationAccessKind AccessKind), ClosureRelationRetentionSelection> ClosureRelationRetentionSelections { get; }
 
             public Dictionary<PredicateId, PathAwareEdgeState> PathAwareEdgeStates { get; }
 


### PR DESCRIPTION
  ## Summary

  This PR extends the C# query runtime’s shared materialization planner to
  the generic closure family.

  Until now, the runtime already had planner coverage for:

  - DAG relation retention
  - path-aware edge retention
  - grouped minima / grouped weight sums
  - generic scan access

  But generic closure execution still had a real gap.

  The non-DAG closure family still built successor/predecessor/auxiliary
  indices from raw `GetFactsList(...)` access outside the shared planner,
  especially in:

  - `TransitiveClosureNode`
  - grouped closure variants
  - `PathAwareAccumulationNode` auxiliary-relation loading

  This PR fixes that by routing closure-family relation access through the
  same runtime-owned measured retention policy layer.

  ## What Changed

  ### New Public Runtime Option

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `ClosureRelationRetentionStrategy`
    - `Auto`
    - `StreamingDirect`
    - `ReplayableBuffer`
    - `ExternalMaterialized`

  Extended:

  - `QueryExecutorOptions`
    - `ClosureRelationRetentionStrategy`

  This is the closure-family analogue of the existing DAG, scan, and
  path-aware retention knobs.

  ### Closure-Specific Planner Access Layer

  Added internal closure planner types and helpers:

  - `ClosureRelationAccessKind`
    - `Edge`
    - `Support`
  - `ClosureRelationRetentionSelection`
  - `GetClosureRelationRetentionSelection(...)`
  - `GetClosureFactsList(...)`

  These sit on top of the shared relation-retention policy and shared
  materialization planner rather than introducing a separate planner stack.

  The runtime now records closure-family planner traces and phases such as:

  - `ClosureRelationRetentionSelection...`
  - `ClosureRelationRetention...`
  - `ClosureMaterializationPlan...`
  - `closure_strategy_select`
  - `closure_probe_streaming_direct`
  - `closure_probe_replayable_buffer`
  - `closure_probe_external_materialized`
  - `closure_materialize_streaming_direct`
  - `closure_materialize_replayable`
  - `closure_materialize_external_materialized`

  ### Generic Closure Consumers Now Use Planner-Driven Relation Access

  Updated closure-family execution paths to use planned closure relation
  access instead of direct raw fact loading.

  This now covers the main generic closure surfaces, including:

  - `ExecuteTransitiveClosure(...)`
  - `ExecuteSeededTransitiveClosure(...)`
  - `ExecuteSeededTransitiveClosureByTarget(...)`
  - `ExecuteSeededTransitiveClosurePairs(...)`
  - grouped transitive-closure variants and their pair-probe helpers
  - `PathAwareAccumulationNode` auxiliary-relation loading
  - `SeedGroupedPathAwareAccumulationMinNode` auxiliary fast-path loading

  So the runtime now chooses how those edge/support relations should be
  accessed before the closure operators build successor, predecessor, or
  auxiliary lookup indices.

  ### Focused Closure Harness Added

  Added:

  - `examples/benchmark/benchmark_closure_materialization.py`

  This is a focused validation harness for the new closure planner layer.

  It exercises two generic closure-family cases against the benchmark TSVs
  inside a temporary C# project:

  - `seeded`
    - generic `TransitiveClosureNode` with streamed edge input
  - `weighted`
    - `PathAwareAccumulationNode` with streamed edge and auxiliary input

  It is intentionally not a new cross-target benchmark. Its role is to
  keep the closure planner path directly testable.

  ### Documentation Updates

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `examples/benchmark/README.md`

  These docs now reflect that the shared planner and measured
  relation-retention policy also cover the generic closure family.

  ## Why This Matters

  This PR closes another important planner gap.

  Before this change, the runtime had a coherent materialization story for:

  - specialized DAG operators
  - path-aware operators
  - grouped-summary operators
  - generic scan-heavy execution

  But generic closure operators still bypassed that planner surface and
  went straight to raw fact lists.

  That was inconsistent with the engine-owned materialization direction.

  Now the runtime has a cleaner model:

  - parser streams tuples
  - runtime chooses relation retention
  - closure operators build only the indices they actually need

  That is exactly the ownership boundary we have been moving toward.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_closure_materialization.py \
      examples/benchmark/benchmark_path_aware_accumulation.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py
  ```
  ### Focused closure harness

  Ran locally:
  ```
  UNIFYWEAVER_BENCH_TRACE=1 \
  python examples/benchmark/benchmark_closure_materialization.py \
      --scales 300,10k \
      --repetitions 1
  ```
  Representative results:

  | Scale | Mode | Median | Seed Count | Row Count | Elapsed |
  |---|---:|---:|---:|---:|---:|
  | 300 | seeded | 0.138s | 386 | 39,990 | 71ms |
  | 300 | weighted | 0.838s | 386 | 602,808 | 769ms |
  | 10k | seeded | 0.249s | 888 | 129,474 | 156ms |
  | 10k | weighted | 3.322s | 888 | 3,616,699 | 3203ms |

  Trace observations:

  - 300 seeded
      - ClosureRelationRetentionSelectionMeasuredProbe
      - ClosureRelationRetentionReplayableBuffer
      - ClosureMaterializationPlanRelationReplayableBuffer
  - 300 weighted
      - ClosureRelationRetentionSelectionMeasuredProbe
      - ClosureRelationRetentionReplayableBuffer
      - ClosureMaterializationPlanRelationReplayableBuffer
  - 10k seeded
      - ClosureRelationRetentionSelectionStructural
      - ClosureRelationRetentionReplayableBuffer
  - 10k weighted
      - ClosureRelationRetentionSelectionMeasuredProbe
      - ClosureRelationRetentionReplayableBuffer

  So the closure planner is now active and measurable.

  ### Existing non-regression checks

  Also ran locally:

  python examples/benchmark/benchmark_path_aware_accumulation.py \
      --scales 300 \
      --repetitions 1

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  All still matched on outputs.

  Representative current non-regression results:

  - shortest path 300
      - csharp-query 0.112s
  - weighted shortest path 300
      - csharp-query 0.189s
  - effective distance 300
      - csharp-query 0.282s
  - dependency reach-count 300
      - csharp-query 0.088s
  - dependency longest depth 300
      - csharp-query 0.078s

  ## Interpretation

  This PR is not adding a new specialized closure algorithm.

  Its value is that the generic closure family now participates in the same
  runtime-owned materialization planning model as the rest of the recent
  engine work.

  On the current focused harness surface, the result is clear:

  - Auto currently prefers ReplayableBuffer
  - at smaller scales it can use measured probes
  - at larger scales it can short-circuit structurally

  That is exactly the kind of decision that should live in the runtime
  rather than in the parser or benchmark harness.

  ## Scope

  This PR adds:

  - closure-family relation-retention strategy selection
  - shared-planner integration for generic closure access
  - a focused closure-materialization benchmark harness
  - doc updates describing the broader planner coverage

  It does not yet add:

  - a new cross-target benchmark family for generic closure planning
  - new closure-specific retained summary forms beyond the existing
    operators’ index-building logic
  - a global planner across every remaining direct fact-access path

  ## Follow-Up

  Likely next work:

  - identify any remaining direct GetFactsList(...) / GetFactsSet(...)
    paths that still bypass the shared planner
  - consider a dedicated generic closure cross-target benchmark if this
    family becomes central to the performance story
  - continue broadening the planner so more operator families use one
    runtime-owned materialization surface rather than local fact-loading
    behavior