### PR TITLE
feat(csharp-query): plan path-aware support relations

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -97,6 +97,10 @@ Status:
   loading can now choose between direct streamed access, replayable
   buffering, and external materialized fallback before building closure
   indices
+- started for path-aware support relations, where grouped minima and weight-sum
+  operators can now choose streaming, replayable buffering, or external
+  materialized access for `RootRelation` and `SeedRelation` before grouped
+  summary construction
 - the runtime can now choose between compact grouped summaries and legacy
   seeded-row regrouping for both operator families through a shared
   grouped-summary policy layer
@@ -123,8 +127,10 @@ Status:
 - the runtime now shares one internal materialization-planner layer above
   the shared relation-retention and grouped-summary policy components
 - the path-aware grouped-summary family uses both branches of that planner,
-  while the DAG family, the generic scan family, and the generic closure
-  family currently use the relation-retention branch of the same planner
+  and now also routes root/seed support-relation access through the shared
+  relation-retention side of the same planner surface, while the DAG family,
+  the generic scan family, and the generic closure family currently use the
+  relation-retention branch of that planner
 - `QueryExecutorOptions.ClosureRelationRetentionStrategy` can force `Auto`,
   `StreamingDirect`, `ReplayableBuffer`, or `ExternalMaterialized` for
   generic closure benchmarking and diagnosis

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -80,6 +80,10 @@ Examples:
   are all viable sources for that edge state, the runtime can choose among
   them through a measured retention selector and still expose an explicit
   override via `QueryExecutorOptions.PathAwareEdgeRetentionStrategy`
+- path-aware grouped-summary operators can now also route their root and seed
+  support relations through that same measured relation-retention boundary,
+  with an explicit override via
+  `QueryExecutorOptions.PathAwareSupportRelationRetentionStrategy`
 - generic closure operators can route edge and support relations through the
   same measured relation-retention boundary before building successor,
   predecessor, or auxiliary lookup indices, with an explicit override via
@@ -176,20 +180,24 @@ For the current benchmark/runtime surface, the streamed path is:
 14. the current runtime now routes path-aware, DAG, generic scan, and
    generic closure planning through a shared internal
    materialization-planner layer
-15. for the current path-aware grouped-summary family, that planner
+15. the current path-aware grouped-summary family now also routes its
+   root and seed support relations through measured planner-driven relation
+   retention before grouped-summary construction
+16. for the current path-aware grouped-summary family, that planner
    coordinates the earlier edge-retention choice with the later
-   grouped-summary choice and records the combined plan in trace output
-16. for the current DAG family, that same planner currently records the
+   grouped-summary choice and records the combined plan in trace output,
+   while support-relation loads now use the same planner trace surface
+17. for the current DAG family, that same planner currently records the
    coordinated relation-retention plan before the operator-owned DAG state is
    built
-17. for the current generic scan family, that same planner currently records
+18. for the current generic scan family, that same planner currently records
    the coordinated relation-retention plan before scan-heavy consumers build
    list/set views
-18. for the current generic closure family, that same planner currently
+19. for the current generic closure family, that same planner currently
    records the coordinated relation-retention plan before closure consumers
    build edge or auxiliary indices
-19. the operator builds only the retained state it actually needs
-20. benchmark code avoids preloading raw facts into in-memory relations first
+20. the operator builds only the retained state it actually needs
+21. benchmark code avoids preloading raw facts into in-memory relations first
 
 This is still a first step, not the full endpoint, but it is now broader than
 just the original DAG-only fast paths.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -39,8 +39,12 @@ consumers. That policy now records measured cost buckets like `load_roots`,
 `load_seeds`, `strategy_select`, `build_*`, and `group_reduce`, while the
 earlier path-aware edge-retention boundary now also records buckets like
 `edge_strategy_select`, `edge_probe_*`, `edge_materialize_replayable`, and
-`edge_build_*`. Generic scan planning now adds corresponding scan buckets such
-as `scan_strategy_select`, `scan_probe_*`, `scan_materialize_*`, and
+`edge_build_*`. The grouped path-aware family now also routes its root and
+seed support relations through the same planner surface, adding buckets like
+`support_roots_strategy_select`, `support_roots_probe_*`,
+`support_seeds_strategy_select`, and `support_seeds_materialize_*`. Generic
+scan planning now adds corresponding scan buckets such as
+`scan_strategy_select`, `scan_probe_*`, `scan_materialize_*`, and
 `scan_build_fact_set`. Generic closure planning now adds corresponding closure
 buckets such as `closure_strategy_select`, `closure_probe_*`, and
 `closure_materialize_*`, with focused validation available in

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -2582,6 +2582,18 @@ class Program
         }};
     }}
 
+    static PathAwareSupportRelationRetentionStrategy ReadSupportRetentionStrategy()
+    {{
+        var value = Environment.GetEnvironmentVariable("UNIFYWEAVER_SUPPORT_RETENTION_STRATEGY");
+        return value?.ToLowerInvariant() switch
+        {{
+            "streaming" => PathAwareSupportRelationRetentionStrategy.StreamingDirect,
+            "replayable" => PathAwareSupportRelationRetentionStrategy.ReplayableBuffer,
+            "external" => PathAwareSupportRelationRetentionStrategy.ExternalMaterialized,
+            _ => PathAwareSupportRelationRetentionStrategy.Auto
+        }};
+    }}
+
     static void PrintWeightSumStrategies(QueryExecutionTrace? trace)
     {{
         if (trace is null)
@@ -2647,6 +2659,7 @@ class Program
 
         var weightSumStrategy = ReadWeightSumStrategy();
         var edgeRetentionStrategy = ReadEdgeRetentionStrategy();
+        var supportRetentionStrategy = ReadSupportRetentionStrategy();
         var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
         QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
 
@@ -2654,6 +2667,7 @@ class Program
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(
             ReuseCaches: false,
             PathAwareEdgeRetentionStrategy: edgeRetentionStrategy,
+            PathAwareSupportRelationRetentionStrategy: supportRetentionStrategy,
             PathAwareWeightSumStrategy: weightSumStrategy));
         var rows = executor.Execute(plan, trace: trace).ToList();
         swQuery.Stop();
@@ -2693,6 +2707,7 @@ class Program
         Console.Error.WriteLine($"root_count={{results.Count}}");
         Console.Error.WriteLine($"weight_sum_strategy_setting={{weightSumStrategy}}");
         Console.Error.WriteLine($"edge_retention_strategy_setting={{edgeRetentionStrategy}}");
+        Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintWeightSumStrategies(trace);
         PrintWeightSumPhases(trace);
     }}
@@ -2737,6 +2752,18 @@ class Program
             "replayable" => PathAwareEdgeRetentionStrategy.ReplayableBuffer,
             "external" => PathAwareEdgeRetentionStrategy.ExternalMaterialized,
             _ => PathAwareEdgeRetentionStrategy.Auto
+        }};
+    }}
+
+    static PathAwareSupportRelationRetentionStrategy ReadSupportRetentionStrategy()
+    {{
+        var value = Environment.GetEnvironmentVariable("UNIFYWEAVER_SUPPORT_RETENTION_STRATEGY");
+        return value?.ToLowerInvariant() switch
+        {{
+            "streaming" => PathAwareSupportRelationRetentionStrategy.StreamingDirect,
+            "replayable" => PathAwareSupportRelationRetentionStrategy.ReplayableBuffer,
+            "external" => PathAwareSupportRelationRetentionStrategy.ExternalMaterialized,
+            _ => PathAwareSupportRelationRetentionStrategy.Auto
         }};
     }}
 
@@ -2801,6 +2828,7 @@ class Program
 
         var weightSumStrategy = ReadWeightSumStrategy();
         var edgeRetentionStrategy = ReadEdgeRetentionStrategy();
+        var supportRetentionStrategy = ReadSupportRetentionStrategy();
         var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
         QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
 
@@ -2808,6 +2836,7 @@ class Program
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(
             ReuseCaches: false,
             PathAwareEdgeRetentionStrategy: edgeRetentionStrategy,
+            PathAwareSupportRelationRetentionStrategy: supportRetentionStrategy,
             PathAwareWeightSumStrategy: weightSumStrategy));
         var rows = executor.Execute(plan, trace: trace).ToList();
         swExec.Stop();
@@ -2840,6 +2869,7 @@ class Program
         Console.Error.WriteLine($"article_count={{results.Count}}");
         Console.Error.WriteLine($"weight_sum_strategy_setting={{weightSumStrategy}}");
         Console.Error.WriteLine($"edge_retention_strategy_setting={{edgeRetentionStrategy}}");
+        Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintWeightSumStrategies(trace);
         PrintWeightSumPhases(trace);
     }}
@@ -2887,6 +2917,18 @@ class Program
             "replayable" => PathAwareEdgeRetentionStrategy.ReplayableBuffer,
             "external" => PathAwareEdgeRetentionStrategy.ExternalMaterialized,
             _ => PathAwareEdgeRetentionStrategy.Auto
+        }};
+    }}
+
+    static PathAwareSupportRelationRetentionStrategy ReadSupportRetentionStrategy()
+    {{
+        var value = Environment.GetEnvironmentVariable("UNIFYWEAVER_SUPPORT_RETENTION_STRATEGY");
+        return value?.ToLowerInvariant() switch
+        {{
+            "streaming" => PathAwareSupportRelationRetentionStrategy.StreamingDirect,
+            "replayable" => PathAwareSupportRelationRetentionStrategy.ReplayableBuffer,
+            "external" => PathAwareSupportRelationRetentionStrategy.ExternalMaterialized,
+            _ => PathAwareSupportRelationRetentionStrategy.Auto
         }};
     }}
 
@@ -2951,6 +2993,7 @@ class Program
 
         var pathMinStrategy = ReadPathMinStrategy();
         var edgeRetentionStrategy = ReadEdgeRetentionStrategy();
+        var supportRetentionStrategy = ReadSupportRetentionStrategy();
         var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
         QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
 
@@ -2958,6 +3001,7 @@ class Program
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(
             ReuseCaches: false,
             PathAwareEdgeRetentionStrategy: edgeRetentionStrategy,
+            PathAwareSupportRelationRetentionStrategy: supportRetentionStrategy,
             PathAwareGroupedMinStrategy: pathMinStrategy));
         var rows = executor.Execute(plan, trace: trace).ToList();
         swQuery.Stop();
@@ -2989,6 +3033,7 @@ class Program
         Console.Error.WriteLine($"article_count={{results.Count}}");
         Console.Error.WriteLine($"path_min_strategy_setting={{pathMinStrategy}}");
         Console.Error.WriteLine($"edge_retention_strategy_setting={{edgeRetentionStrategy}}");
+        Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintPathMinStrategies(trace);
         PrintPathMinPhases(trace);
     }}
@@ -3033,6 +3078,18 @@ class Program
             "replayable" => PathAwareEdgeRetentionStrategy.ReplayableBuffer,
             "external" => PathAwareEdgeRetentionStrategy.ExternalMaterialized,
             _ => PathAwareEdgeRetentionStrategy.Auto
+        }};
+    }}
+
+    static PathAwareSupportRelationRetentionStrategy ReadSupportRetentionStrategy()
+    {{
+        var value = Environment.GetEnvironmentVariable("UNIFYWEAVER_SUPPORT_RETENTION_STRATEGY");
+        return value?.ToLowerInvariant() switch
+        {{
+            "streaming" => PathAwareSupportRelationRetentionStrategy.StreamingDirect,
+            "replayable" => PathAwareSupportRelationRetentionStrategy.ReplayableBuffer,
+            "external" => PathAwareSupportRelationRetentionStrategy.ExternalMaterialized,
+            _ => PathAwareSupportRelationRetentionStrategy.Auto
         }};
     }}
 
@@ -3137,6 +3194,7 @@ class Program
 
         var pathMinStrategy = ReadPathMinStrategy();
         var edgeRetentionStrategy = ReadEdgeRetentionStrategy();
+        var supportRetentionStrategy = ReadSupportRetentionStrategy();
         var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
         QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
 
@@ -3144,6 +3202,7 @@ class Program
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(
             ReuseCaches: false,
             PathAwareEdgeRetentionStrategy: edgeRetentionStrategy,
+            PathAwareSupportRelationRetentionStrategy: supportRetentionStrategy,
             PathAwareGroupedMinStrategy: pathMinStrategy));
         var rows = executor.Execute(plan, trace: trace).ToList();
         swQuery.Stop();
@@ -3175,6 +3234,7 @@ class Program
         Console.Error.WriteLine($"article_count={{results.Count}}");
         Console.Error.WriteLine($"path_min_strategy_setting={{pathMinStrategy}}");
         Console.Error.WriteLine($"edge_retention_strategy_setting={{edgeRetentionStrategy}}");
+        Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintPathMinStrategies(trace);
         PrintPathMinPhases(trace);
     }}

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -51,6 +51,14 @@ namespace UnifyWeaver.QueryRuntime
         ExternalMaterialized
     }
 
+    public enum PathAwareSupportRelationRetentionStrategy
+    {
+        Auto,
+        StreamingDirect,
+        ReplayableBuffer,
+        ExternalMaterialized
+    }
+
     public enum DagRelationRetentionStrategy
     {
         Auto,
@@ -541,12 +549,22 @@ namespace UnifyWeaver.QueryRuntime
         Support
     }
 
+    internal enum PathAwareSupportRelationAccessKind
+    {
+        Roots,
+        Seeds
+    }
+
     internal readonly record struct RelationRetentionSelection(
         RelationRetentionPolicyStrategy Strategy,
         string DecisionMode);
 
     internal readonly record struct PathAwareEdgeRetentionSelection(
         PathAwareEdgeRetentionStrategy Strategy,
+        string DecisionMode);
+
+    internal readonly record struct PathAwareSupportRelationRetentionSelection(
+        PathAwareSupportRelationRetentionStrategy Strategy,
         string DecisionMode);
 
     internal readonly record struct PathAwareGroupedSummarySelection(
@@ -576,6 +594,7 @@ namespace UnifyWeaver.QueryRuntime
         ScanRelationRetentionStrategy ScanRelationRetentionStrategy = ScanRelationRetentionStrategy.Auto,
         ClosureRelationRetentionStrategy ClosureRelationRetentionStrategy = ClosureRelationRetentionStrategy.Auto,
         PathAwareEdgeRetentionStrategy PathAwareEdgeRetentionStrategy = PathAwareEdgeRetentionStrategy.Auto,
+        PathAwareSupportRelationRetentionStrategy PathAwareSupportRelationRetentionStrategy = PathAwareSupportRelationRetentionStrategy.Auto,
         PathAwareGroupedMinStrategy PathAwareGroupedMinStrategy = PathAwareGroupedMinStrategy.Auto,
         PathAwareWeightSumStrategy PathAwareWeightSumStrategy = PathAwareWeightSumStrategy.Auto,
         int PairProbeCacheMaxEntries = 4096,
@@ -1528,6 +1547,7 @@ namespace UnifyWeaver.QueryRuntime
         private readonly ScanRelationRetentionStrategy _scanRelationRetentionStrategy;
         private readonly ClosureRelationRetentionStrategy _closureRelationRetentionStrategy;
         private readonly PathAwareEdgeRetentionStrategy _pathAwareEdgeRetentionStrategy;
+        private readonly PathAwareSupportRelationRetentionStrategy _pathAwareSupportRelationRetentionStrategy;
         private readonly PathAwareGroupedSummaryStrategy _pathAwareGroupedMinStrategy;
         private readonly PathAwareGroupedSummaryStrategy _pathAwareWeightSumStrategy;
 
@@ -1547,6 +1567,7 @@ namespace UnifyWeaver.QueryRuntime
             _scanRelationRetentionStrategy = options.ScanRelationRetentionStrategy;
             _closureRelationRetentionStrategy = options.ClosureRelationRetentionStrategy;
             _pathAwareEdgeRetentionStrategy = options.PathAwareEdgeRetentionStrategy;
+            _pathAwareSupportRelationRetentionStrategy = options.PathAwareSupportRelationRetentionStrategy;
             _pathAwareGroupedMinStrategy = ToPathAwareGroupedSummaryStrategy(options.PathAwareGroupedMinStrategy);
             _pathAwareWeightSumStrategy = ToPathAwareGroupedSummaryStrategy(options.PathAwareWeightSumStrategy);
         }
@@ -1808,6 +1829,7 @@ namespace UnifyWeaver.QueryRuntime
             _cacheContext.ReplayableFactSources.Clear();
             _cacheContext.ScanRelationRetentionSelections.Clear();
             _cacheContext.ClosureRelationRetentionSelections.Clear();
+            _cacheContext.PathAwareSupportRelationRetentionSelections.Clear();
             _cacheContext.PathAwareEdgeStates.Clear();
             _cacheContext.PathAwareEdgeRetentionSelections.Clear();
             _cacheContext.FactSets.Clear();
@@ -6530,6 +6552,133 @@ namespace UnifyWeaver.QueryRuntime
             return facts;
         }
 
+        private PathAwareSupportRelationRetentionSelection GetPathAwareSupportRelationRetentionSelection(
+            PredicateId predicate,
+            PathAwareSupportRelationAccessKind accessKind,
+            EvaluationContext context,
+            PlanNode traceNode)
+        {
+            var cacheKey = (predicate, accessKind);
+            if (context.PathAwareSupportRelationRetentionSelections.TryGetValue(cacheKey, out var cachedSelection))
+            {
+                return cachedSelection;
+            }
+
+            var hasStreaming = TryGetDelimitedSource(predicate, RelationRetentionMode.Streaming, out var delimitedSource);
+            var hasReplayable = TryGetReplayableSource(predicate, context, out var replayableSource);
+            var hasExternal = TryGetExternalFacts(predicate, out var externalFacts);
+            var concreteReplayable = replayableSource as ReplayableRelationSource;
+            var relationBytes = hasStreaming && !string.IsNullOrEmpty(delimitedSource.InputPath) && File.Exists(delimitedSource.InputPath)
+                ? new FileInfo(delimitedSource.InputPath).Length
+                : (long?)null;
+            const int supportProbeRowLimit = 256;
+
+            Func<TimeSpan>? measureStreamingProbe = hasStreaming
+                ? () => MeasureElapsed(() => ProbeFactRows(DelimitedRelationReader.ReadRows(delimitedSource), supportProbeRowLimit))
+                : null;
+            Func<TimeSpan>? measureReplayableProbe = hasReplayable
+                ? () => MeasureElapsed(() =>
+                {
+                    var probeRows = concreteReplayable is not null
+                        ? concreteReplayable.ProbeMaterialize(supportProbeRowLimit)
+                        : replayableSource.Stream().Take(supportProbeRowLimit).ToList();
+                    ProbeFactRows(probeRows, supportProbeRowLimit);
+                })
+                : null;
+            Func<TimeSpan>? measureExternalProbe = hasExternal
+                ? () => MeasureElapsed(() => ProbeFactRows(externalFacts, supportProbeRowLimit))
+                : null;
+
+            var selection = ResolvePathAwareSupportRelationRetentionStrategy(
+                context.Trace,
+                traceNode,
+                _pathAwareSupportRelationRetentionStrategy,
+                accessKind,
+                relationBytes,
+                hasStreaming,
+                hasReplayable,
+                hasExternal,
+                concreteReplayable?.IsMaterialized == true,
+                measureStreamingProbe,
+                measureReplayableProbe,
+                measureExternalProbe);
+            context.PathAwareSupportRelationRetentionSelections[cacheKey] = selection;
+            return selection;
+        }
+
+        private IEnumerable<object[]> GetPathAwareSupportFactStream(
+            PredicateId predicate,
+            PathAwareSupportRelationAccessKind accessKind,
+            EvaluationContext? context,
+            PlanNode traceNode)
+        {
+            if (context is null)
+            {
+                return GetFactStream(predicate, context);
+            }
+
+            if (context.Facts.TryGetValue(predicate, out var cachedFacts))
+            {
+                context.Trace?.RecordCacheLookup("Facts", $"{predicate.Name}/{predicate.Arity}", hit: true, built: false);
+                return cachedFacts;
+            }
+
+            var plan = ResolveMaterializationPlan(
+                context.Trace,
+                traceNode,
+                ToRelationRetentionSelection(GetPathAwareSupportRelationRetentionSelection(predicate, accessKind, context, traceNode)));
+            RecordPathAwareSupportRelationRetentionStrategy(
+                context.Trace,
+                traceNode,
+                accessKind,
+                new PathAwareSupportRelationRetentionSelection(ToPathAwareSupportRelationRetentionStrategy(plan.RelationRetention.Strategy), plan.RelationRetention.DecisionMode));
+            RecordMaterializationPlanStrategy(
+                context.Trace,
+                traceNode,
+                accessKind == PathAwareSupportRelationAccessKind.Roots ? "PathAwareSupportRoots" : "PathAwareSupportSeeds",
+                plan);
+
+            var hasStreaming = TryGetDelimitedSource(predicate, RelationRetentionMode.Streaming, out var delimitedSource);
+            var hasReplayable = TryGetReplayableSource(predicate, context, out var replayableSource);
+            var hasExternal = TryGetExternalFacts(predicate, out var externalFacts);
+            var phasePrefix = accessKind == PathAwareSupportRelationAccessKind.Roots ? "support_roots" : "support_seeds";
+
+            switch (plan.RelationRetention.Strategy)
+            {
+                case RelationRetentionPolicyStrategy.StreamingDirect when hasStreaming:
+                    return DelimitedRelationReader.ReadRows(delimitedSource);
+                case RelationRetentionPolicyStrategy.ReplayableBuffer when hasReplayable:
+                {
+                    var facts = MeasurePhase(context.Trace, traceNode, $"{phasePrefix}_materialize_replayable", () => replayableSource.Materialize());
+                    context.Facts[predicate] = facts;
+                    return facts;
+                }
+                case RelationRetentionPolicyStrategy.ExternalMaterialized when hasExternal:
+                {
+                    var facts = MeasurePhase(context.Trace, traceNode, $"{phasePrefix}_materialize_external_materialized", () => externalFacts as List<object[]> ?? externalFacts.ToList());
+                    context.Facts[predicate] = facts;
+                    return facts;
+                }
+                default:
+                    if (hasReplayable)
+                    {
+                        var facts = MeasurePhase(context.Trace, traceNode, $"{phasePrefix}_materialize_replayable", () => replayableSource.Materialize());
+                        context.Facts[predicate] = facts;
+                        return facts;
+                    }
+
+                    if (hasStreaming)
+                    {
+                        return DelimitedRelationReader.ReadRows(delimitedSource);
+                    }
+
+                    var externalSource = _provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>();
+                    var externalList = MeasurePhase(context.Trace, traceNode, $"{phasePrefix}_materialize_external_materialized", () => externalSource as List<object[]> ?? externalSource.ToList());
+                    context.Facts[predicate] = externalList;
+                    return externalList;
+            }
+        }
+
         private IEnumerable<object[]> GetFactStream(PredicateId predicate, EvaluationContext? context = null)
         {
             if (context is not null && TryGetReplayableSource(predicate, context, out var replayableSource))
@@ -8430,6 +8579,24 @@ namespace UnifyWeaver.QueryRuntime
                 _ => PathAwareEdgeRetentionStrategy.Auto
             };
 
+        private static RelationRetentionPolicyStrategy ToRelationRetentionPolicyStrategy(PathAwareSupportRelationRetentionStrategy strategy)
+            => strategy switch
+            {
+                PathAwareSupportRelationRetentionStrategy.StreamingDirect => RelationRetentionPolicyStrategy.StreamingDirect,
+                PathAwareSupportRelationRetentionStrategy.ReplayableBuffer => RelationRetentionPolicyStrategy.ReplayableBuffer,
+                PathAwareSupportRelationRetentionStrategy.ExternalMaterialized => RelationRetentionPolicyStrategy.ExternalMaterialized,
+                _ => RelationRetentionPolicyStrategy.Auto
+            };
+
+        private static PathAwareSupportRelationRetentionStrategy ToPathAwareSupportRelationRetentionStrategy(RelationRetentionPolicyStrategy strategy)
+            => strategy switch
+            {
+                RelationRetentionPolicyStrategy.StreamingDirect => PathAwareSupportRelationRetentionStrategy.StreamingDirect,
+                RelationRetentionPolicyStrategy.ReplayableBuffer => PathAwareSupportRelationRetentionStrategy.ReplayableBuffer,
+                RelationRetentionPolicyStrategy.ExternalMaterialized => PathAwareSupportRelationRetentionStrategy.ExternalMaterialized,
+                _ => PathAwareSupportRelationRetentionStrategy.Auto
+            };
+
         private static RelationRetentionSelection ToRelationRetentionSelection(DagRelationRetentionSelection selection)
             => new(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode);
 
@@ -8440,6 +8607,9 @@ namespace UnifyWeaver.QueryRuntime
             => new(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode);
 
         private static RelationRetentionSelection ToRelationRetentionSelection(PathAwareEdgeRetentionSelection selection)
+            => new(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode);
+
+        private static RelationRetentionSelection ToRelationRetentionSelection(PathAwareSupportRelationRetentionSelection selection)
             => new(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode);
 
         private static RelationRetentionPolicyStrategy ResolveStructuralRelationRetentionStrategy(
@@ -8918,6 +9088,108 @@ namespace UnifyWeaver.QueryRuntime
                 "ClosureRelationRetention");
         }
 
+        private static PathAwareSupportRelationRetentionStrategy ResolveStructuralPathAwareSupportRelationRetentionStrategy(
+            PathAwareSupportRelationAccessKind accessKind,
+            bool hasStreaming,
+            bool hasReplayable,
+            bool hasExternal,
+            bool replayableMaterialized)
+        {
+            var preferredStrategy = accessKind switch
+            {
+                PathAwareSupportRelationAccessKind.Seeds => RelationRetentionPolicyStrategy.StreamingDirect,
+                _ => RelationRetentionPolicyStrategy.StreamingDirect,
+            };
+            return ToPathAwareSupportRelationRetentionStrategy(
+                ResolveStructuralRelationRetentionStrategy(
+                    preferredStrategy,
+                    hasStreaming,
+                    hasReplayable,
+                    hasExternal,
+                    replayableMaterialized));
+        }
+
+        private static bool ShouldProbePathAwareSupportRelationRetentionStrategy(
+            PathAwareSupportRelationAccessKind accessKind,
+            long? relationBytes,
+            bool hasStreaming,
+            bool hasReplayable,
+            bool hasExternal,
+            bool replayableMaterialized)
+        {
+            var thresholdBytes = accessKind switch
+            {
+                PathAwareSupportRelationAccessKind.Roots => 128 * 1024L,
+                _ => 256 * 1024L,
+            };
+            return ShouldProbeRelationRetentionStrategy(
+                relationBytes,
+                thresholdBytes,
+                hasStreaming,
+                hasReplayable,
+                hasExternal,
+                replayableMaterialized);
+        }
+
+        private static PathAwareSupportRelationRetentionSelection ResolvePathAwareSupportRelationRetentionStrategy(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            PathAwareSupportRelationRetentionStrategy configuredStrategy,
+            PathAwareSupportRelationAccessKind accessKind,
+            long? relationBytes,
+            bool hasStreaming,
+            bool hasReplayable,
+            bool hasExternal,
+            bool replayableMaterialized,
+            Func<TimeSpan>? measureStreamingProbe = null,
+            Func<TimeSpan>? measureReplayableProbe = null,
+            Func<TimeSpan>? measureExternalProbe = null)
+        {
+            var structuralStrategy = ToRelationRetentionPolicyStrategy(
+                ResolveStructuralPathAwareSupportRelationRetentionStrategy(
+                    accessKind,
+                    hasStreaming,
+                    hasReplayable,
+                    hasExternal,
+                    replayableMaterialized));
+            var selection = ResolveRelationRetentionStrategy(
+                trace,
+                node,
+                accessKind == PathAwareSupportRelationAccessKind.Roots ? "support_roots_strategy_select" : "support_seeds_strategy_select",
+                accessKind == PathAwareSupportRelationAccessKind.Roots ? "support_roots_probe_streaming_direct" : "support_seeds_probe_streaming_direct",
+                accessKind == PathAwareSupportRelationAccessKind.Roots ? "support_roots_probe_replayable_buffer" : "support_seeds_probe_replayable_buffer",
+                accessKind == PathAwareSupportRelationAccessKind.Roots ? "support_roots_probe_external_materialized" : "support_seeds_probe_external_materialized",
+                ToRelationRetentionPolicyStrategy(configuredStrategy),
+                structuralStrategy,
+                ShouldProbePathAwareSupportRelationRetentionStrategy(accessKind, relationBytes, hasStreaming, hasReplayable, hasExternal, replayableMaterialized),
+                hasStreaming,
+                hasReplayable,
+                hasExternal,
+                replayableMaterialized,
+                measureStreamingProbe,
+                measureReplayableProbe,
+                measureExternalProbe);
+            return new PathAwareSupportRelationRetentionSelection(ToPathAwareSupportRelationRetentionStrategy(selection.Strategy), selection.DecisionMode);
+        }
+
+        private static void RecordPathAwareSupportRelationRetentionStrategy(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            PathAwareSupportRelationAccessKind accessKind,
+            PathAwareSupportRelationRetentionSelection selection)
+        {
+            RecordRelationRetentionStrategy(
+                trace,
+                node,
+                new RelationRetentionSelection(ToRelationRetentionPolicyStrategy(selection.Strategy), selection.DecisionMode),
+                accessKind == PathAwareSupportRelationAccessKind.Roots
+                    ? "PathAwareSupportRootsRelationRetentionSelection"
+                    : "PathAwareSupportSeedsRelationRetentionSelection",
+                accessKind == PathAwareSupportRelationAccessKind.Roots
+                    ? "PathAwareSupportRootsRelationRetention"
+                    : "PathAwareSupportSeedsRelationRetention");
+        }
+
         private static PathAwareEdgeRetentionStrategy ResolveStructuralPathAwareEdgeRetentionStrategy(
             PlanNode node,
             bool hasStreaming,
@@ -9394,7 +9666,7 @@ namespace UnifyWeaver.QueryRuntime
                 var rootValues = new Dictionary<object, object?>();
                 MeasurePhase(trace, closure, "load_roots", () =>
                 {
-                    foreach (var row in GetFactStream(closure.RootRelation, context))
+                    foreach (var row in GetPathAwareSupportFactStream(closure.RootRelation, PathAwareSupportRelationAccessKind.Roots, context, closure))
                     {
                         if (row is null || row.Length == 0)
                         {
@@ -9423,7 +9695,7 @@ namespace UnifyWeaver.QueryRuntime
                 var orderedUniqueSeeds = new List<object?>();
                 MeasurePhase(trace, closure, "load_seeds", () =>
                 {
-                    foreach (var row in GetFactStream(closure.SeedRelation, context))
+                    foreach (var row in GetPathAwareSupportFactStream(closure.SeedRelation, PathAwareSupportRelationAccessKind.Seeds, context, closure))
                     {
                         if (row is null || row.Length < 2)
                         {
@@ -9764,7 +10036,7 @@ namespace UnifyWeaver.QueryRuntime
                 var rootValues = new Dictionary<object, object?>();
                 MeasurePhase(trace, closure, "load_roots", () =>
                 {
-                    foreach (var row in GetFactStream(closure.RootRelation, context))
+                    foreach (var row in GetPathAwareSupportFactStream(closure.RootRelation, PathAwareSupportRelationAccessKind.Roots, context, closure))
                     {
                         if (row is null || row.Length == 0)
                         {
@@ -9793,7 +10065,7 @@ namespace UnifyWeaver.QueryRuntime
                 var orderedUniqueSeeds = new List<object?>();
                 MeasurePhase(trace, closure, "load_seeds", () =>
                 {
-                    foreach (var row in GetFactStream(closure.SeedRelation, context))
+                    foreach (var row in GetPathAwareSupportFactStream(closure.SeedRelation, PathAwareSupportRelationAccessKind.Seeds, context, closure))
                     {
                         if (row is null || row.Length < 2)
                         {
@@ -10025,7 +10297,7 @@ namespace UnifyWeaver.QueryRuntime
                 var rootValues = new Dictionary<object, object?>();
                 MeasurePhase(trace, closure, "load_roots", () =>
                 {
-                    foreach (var row in GetFactStream(closure.RootRelation, context))
+                    foreach (var row in GetPathAwareSupportFactStream(closure.RootRelation, PathAwareSupportRelationAccessKind.Roots, context, closure))
                     {
                         if (row is null || row.Length == 0)
                         {
@@ -10054,7 +10326,7 @@ namespace UnifyWeaver.QueryRuntime
                 var orderedUniqueSeeds = new List<object?>();
                 MeasurePhase(trace, closure, "load_seeds", () =>
                 {
-                    foreach (var row in GetFactStream(closure.SeedRelation, context))
+                    foreach (var row in GetPathAwareSupportFactStream(closure.SeedRelation, PathAwareSupportRelationAccessKind.Seeds, context, closure))
                     {
                         if (row is null || row.Length < 2)
                         {
@@ -17849,6 +18121,7 @@ namespace UnifyWeaver.QueryRuntime
                 ReplayableFactSources = parent?.ReplayableFactSources ?? new Dictionary<PredicateId, IReplayableRelationSource>();
                 ScanRelationRetentionSelections = parent?.ScanRelationRetentionSelections ?? new Dictionary<(PredicateId Predicate, ScanRelationAccessKind AccessKind), ScanRelationRetentionSelection>();
                 ClosureRelationRetentionSelections = parent?.ClosureRelationRetentionSelections ?? new Dictionary<(PredicateId Predicate, ClosureRelationAccessKind AccessKind), ClosureRelationRetentionSelection>();
+                PathAwareSupportRelationRetentionSelections = parent?.PathAwareSupportRelationRetentionSelections ?? new Dictionary<(PredicateId Predicate, PathAwareSupportRelationAccessKind AccessKind), PathAwareSupportRelationRetentionSelection>();
                 PathAwareEdgeStates = parent?.PathAwareEdgeStates ?? new Dictionary<PredicateId, PathAwareEdgeState>();
                 PathAwareEdgeRetentionSelections = parent?.PathAwareEdgeRetentionSelections ?? new Dictionary<PredicateId, PathAwareEdgeRetentionSelection>();
                 FactSets = parent?.FactSets ?? new Dictionary<PredicateId, HashSet<object[]>>();
@@ -17918,6 +18191,8 @@ namespace UnifyWeaver.QueryRuntime
             public Dictionary<(PredicateId Predicate, ScanRelationAccessKind AccessKind), ScanRelationRetentionSelection> ScanRelationRetentionSelections { get; }
 
             public Dictionary<(PredicateId Predicate, ClosureRelationAccessKind AccessKind), ClosureRelationRetentionSelection> ClosureRelationRetentionSelections { get; }
+
+            public Dictionary<(PredicateId Predicate, PathAwareSupportRelationAccessKind AccessKind), PathAwareSupportRelationRetentionSelection> PathAwareSupportRelationRetentionSelections { get; }
 
             public Dictionary<PredicateId, PathAwareEdgeState> PathAwareEdgeStates { get; }
 


### PR DESCRIPTION
  ## Summary

  This PR extends the C# query runtime’s shared materialization planner to
  the path-aware support relations used by the grouped-summary family.

  Until now, the runtime already planned:

  - path-aware edge retention
  - grouped-summary retained form
  - DAG relation retention
  - generic scan relation retention
  - generic closure relation retention

  But the path-aware grouped-summary family still had one remaining gap:

  - `RootRelation`
  - `SeedRelation`

  were still loaded through raw `GetFactStream(...)` calls inside the
  grouped-summary nodes.

  This PR fixes that by routing those support relations through the shared
  measured relation-retention and materialization-planner surface.

  ## What Changed

  ### New Public Runtime Option

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `PathAwareSupportRelationRetentionStrategy`
    - `Auto`
    - `StreamingDirect`
    - `ReplayableBuffer`
    - `ExternalMaterialized`

  Extended:

  - `QueryExecutorOptions`
    - `PathAwareSupportRelationRetentionStrategy`

  This is the support-relation analogue of the existing path-aware edge
  retention knob.

  ### Support-Relation Access Kind And Cached Selection

  Added internal types:

  - `PathAwareSupportRelationAccessKind`
    - `Roots`
    - `Seeds`
  - `PathAwareSupportRelationRetentionSelection`

  Extended `EvaluationContext` with:

  - `PathAwareSupportRelationRetentionSelections`

  This allows the runtime to cache support-relation retention choices
  independently for roots vs seeds.

  ### Measured Support-Relation Retention Selection

  Added shared-path-aware support helpers on top of the existing relation
  policy layer:

  - `ResolveStructuralPathAwareSupportRelationRetentionStrategy(...)`
  - `ShouldProbePathAwareSupportRelationRetentionStrategy(...)`
  - `ResolvePathAwareSupportRelationRetentionStrategy(...)`
  - `RecordPathAwareSupportRelationRetentionStrategy(...)`

  The support-relation planner now records measured buckets such as:

  - `support_roots_strategy_select`
  - `support_roots_probe_streaming_direct`
  - `support_roots_probe_replayable_buffer`
  - `support_roots_probe_external_materialized`
  - `support_roots_materialize_replayable`
  - `support_roots_materialize_external_materialized`

  and the analogous `support_seeds_*` buckets.

  ### New Planner-Driven Support Accessor

  Added:

  - `GetPathAwareSupportFactStream(...)`

  This uses the shared materialization planner and the new support-relation
  selection to decide how grouped-summary nodes should access:

  - `RootRelation`
  - `SeedRelation`

  before grouped-summary construction.

  ### Path-Aware Grouped-Summary Nodes Now Use Planned Support Access

  Updated:

  - `ExecuteSeedGroupedPathAwareWeightSum(...)`
  - `ExecuteSeedGroupedPathAwareDepthMin(...)`
  - `ExecuteSeedGroupedPathAwareAccumulationMin(...)`

  These no longer read support relations via raw:

  - `GetFactStream(closure.RootRelation, context)`
  - `GetFactStream(closure.SeedRelation, context)`

  They now route those loads through:

  - `GetPathAwareSupportFactStream(...)`

  So the path-aware grouped-summary family now plans:

  - edge retention
  - grouped-summary retained form
  - root/seed support relation access

  within the runtime.

  ### Generated Benchmark Support

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The generated C# query programs for:

  - `shortest_path_to_root`
  - `weighted_shortest_path`
  - `effective_distance`
  - `category_influence`

  now support:

  - `UNIFYWEAVER_SUPPORT_RETENTION_STRATEGY=auto|streaming|replayable|external`

  and print:

  - `support_retention_strategy_setting=...`

  This keeps the new planner surface benchmark-visible and overridable.

  ### Docs Updated

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`
  - `examples/benchmark/README.md`

  These now reflect that the path-aware grouped-summary family no longer
  only plans edge retention and grouped summary form. It also now plans
  support-relation access for roots and seeds.

  ## Why This Matters

  This PR closes the clearest remaining planner gap in the path-aware
  family.

  Before this change, the runtime had already moved most of the important
  retained-state choices into the engine for these workloads, but roots and
  seeds still bypassed that planner surface.

  That was inconsistent with the broader engine-owned materialization
  direction.

  Now the path-aware grouped-summary family has a cleaner boundary:

  - parser streams tuples
  - runtime chooses edge retention
  - runtime chooses support-relation access
  - runtime chooses grouped summary form
  - operator builds only the retained state it actually needs

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_category_influence_cross_target.py \
      examples/benchmark/benchmark_closure_materialization.py \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py
  ```
  ### Path-aware non-regression runs

  Ran locally:
  ```
  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated \
      --repetitions 1

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300 \
      --targets csharp-query,rust-dfs,go-dfs \
      --repetitions 1
  ```
  All still matched on outputs.

  Representative results:

  - shortest path 300
      - csharp-query 0.129s
  - weighted shortest path 300
      - csharp-query 0.177s
  - effective distance 300
      - csharp-query 0.286s
  - category influence 300
      - csharp-query 0.368s

  ### Closure harness non-regression

  Ran locally:

  python examples/benchmark/benchmark_closure_materialization.py \
      --scales 300,10k \
      --repetitions 1

  Representative results:

  - 300 seeded
      - 0.140s
  - 300 weighted
      - 0.876s
  - 10k seeded
      - 0.238s
  - 10k weighted
      - 3.287s

  ### DAG non-regression smokes

  Ran locally:
  ```
  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1
  ```
  Both still matched.

  Representative results:

  - dependency reach-count 300
      - csharp-query 0.072s
  - dependency longest depth 300
      - csharp-query 0.072s

  ### Trace validation

  Also ran with trace enabled:
  ```
  UNIFYWEAVER_BENCH_TRACE=1 \
  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300,10k \
      --targets csharp-query \
      --repetitions 1

  UNIFYWEAVER_BENCH_TRACE=1 \
  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300,10k \
      --targets csharp-query \
      --repetitions 1
  ```
  Observed:

  - support_retention_strategy_setting=Auto

  At 300:

  - roots selected ExternalMaterialized via measured probe
  - seeds selected ReplayableBuffer via measured probe

  At 10k:

  - roots still selected ExternalMaterialized
  - seeds selected StreamingDirect structurally

  Representative trace entries included:

  - PathAwareSupportRootsRelationRetentionExternalMaterialized
  - PathAwareSupportRootsRelationRetentionSelectionMeasuredProbe
  - PathAwareSupportSeedsRelationRetentionReplayableBuffer
  - PathAwareSupportSeedsRelationRetentionStreamingDirect
  - PathAwareSupportRootsMaterializationPlanRelationExternalMaterialized
  - PathAwareSupportSeedsMaterializationPlanRelationReplayableBuffer
  - PathAwareSupportSeedsMaterializationPlanRelationStreamingDirect

  ## Interpretation

  This PR is not a new retained-summary optimization.

  Its value is that the path-aware grouped-summary family now has a more
  complete planner surface.

  The main result is:

  - roots and seeds no longer bypass the shared runtime planner
  - the new support-relation decision is explicit, traceable, and
    benchmark-overridable
  - the path-aware family now has a cleaner end-to-end materialization
    story

  The current benchmark surface suggests:

  - roots are cheap enough that external materialized access remains fine
  - seeds can prefer replayable buffering at smaller scale
  - seeds can prefer streaming at larger scale

  That is exactly the kind of decision that belongs in the runtime.

  ## Scope

  This PR adds:

  - planner-driven path-aware support-relation retention
  - benchmark override/trace support for support relations
  - doc updates describing the broader path-aware planner coverage

  It does not yet add:

  - a new retained-summary form
  - support-relation planning for every remaining operator family
  - a fully global materialization planner across all runtime choices

  ## Follow-Up

  Likely next work:

  - identify any remaining direct support-relation loads that still bypass
    the shared planner
  - continue broadening planner coverage to the remaining raw
    GetFactStream(...) / GetFactsList(...) paths
  - keep tightening the engine-owned materialization boundary so relation
    access and retained-state choice are decided inside the runtime rather
    than in benchmark harnesses or parsers