### PR TITLE
feat(rust): Support mixed-goal foreign aggregate wrappers in Rust WAM

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -4258,7 +4258,7 @@ compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _Inc
     get_dict(expr, AggInfo, Expr),
     get_dict(group, AggInfo, GroupTerm),
     get_dict(relations, GoalInfo, [RelGoal|_]),
-    RelGoal =.. [InnerPred, _StartArg, TargetArg, _DimArg, CostArg],
+    RelGoal =.. [InnerPred, _, TargetArg, DimArg, CostArg],
     Expr == CostArg,
     parse_group_term_rust(GroupTerm, [GroupVar]),
     GroupVar == TargetArg,
@@ -4356,13 +4356,14 @@ compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _Inc
     get_dict(expr, AggInfo, Expr),
     get_dict(relations, GoalInfo, [RelGoal|_]),
     RelGoal =.. [InnerPred, _StartArg, TargetArg, _DimArg, CostArg],
-    Expr == CostArg,
     var(TargetArg),
     functor(InnerHead, InnerPred, 4),
     findall(InnerHead-InnerBody, user:clause(InnerHead, InnerBody), Clauses),
     Clauses \= [],
     rust_foreign_lowerable_astar_shortest_path(InnerPred, 4, Clauses,
         WeightPred/3, FactTriples, DirectPred/3, DirectTriples, DefaultDim),
+    rust_foreign_wrapper_goal_logic(GoalInfo, [ignored_start, TargetArg, DimArg, CostArg],
+        Expr, SetupCode, ValueExpr, FilterCond),
     atom_string(Pred, PredStr),
     atom_string(InnerPred, InnerPredStr),
     format(string(WeightPredKey), '~w/3', [WeightPred]),
@@ -4396,22 +4397,34 @@ compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _Inc
     vm.set_reg("A3", a3.clone());
     vm.set_reg("A4", Value::Unbound(temp_cost.clone()));
 
+    let dim_value = match &a3 {
+        Value::Integer(d) => *d as f64,
+        Value::Float(d) => *d,
+        _ => ~w_f64,
+    };
+
     if !vm.execute_foreign_predicate("~w", 4) {
         vm.bindings.remove(&temp_target);
         vm.bindings.remove(&temp_cost);
         return false;
     }
 
-    let mut best = match vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
-        Some(Value::Float(cost)) => Some(cost),
-        _ => None,
-    };
-    while vm.backtrack() {
+    let mut best: Option<f64> = None;
+    loop {
         if let Some(Value::Float(cost)) = vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+~w            if !(~w) {
+                if !vm.backtrack() {
+                    break;
+                }
+                continue;
+            }
             best = Some(match best {
-                Some(current) => current.min(cost),
-                None => cost,
+                Some(current) => current.min(~w),
+                None => ~w,
             });
+        }
+        if !vm.backtrack() {
+            break;
         }
     }
 
@@ -4425,19 +4438,20 @@ compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _Inc
 }', [PredStr, InnerPredStr, InnerPredStr, InnerPredStr, InnerPredStr,
       WeightPredKey, WeightPredKey, WeightTriplesLiteral,
       InnerPredStr, DirectPredKey, DirectPredKey, DirectTriplesLiteral,
-      InnerPredStr, DefaultDim, InnerPredStr]).
+      InnerPredStr, DefaultDim, DefaultDim, InnerPredStr, SetupCode, FilterCond, ValueExpr, ValueExpr]).
 compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _IncludeMain, RustCode) :-
     get_dict(type, AggInfo, all),
     get_dict(op, AggInfo, min),
     get_dict(expr, AggInfo, Expr),
     get_dict(relations, GoalInfo, [RelGoal|_]),
-    RelGoal =.. [InnerPred, _StartArg, TargetArg, CostArg],
-    Expr == CostArg,
+    RelGoal =.. [InnerPred, _, TargetArg, CostArg],
     var(TargetArg),
     functor(InnerHead, InnerPred, 3),
     findall(InnerHead-InnerBody, user:clause(InnerHead, InnerBody), Clauses),
     Clauses \= [],
     rust_foreign_lowerable_weighted_shortest_path(InnerPred, 3, Clauses, WeightPred/3, FactTriples),
+    rust_foreign_wrapper_goal_logic(GoalInfo, [ignored_start, TargetArg, CostArg],
+        Expr, SetupCode, ValueExpr, FilterCond),
     atom_string(Pred, PredStr),
     atom_string(InnerPred, InnerPredStr),
     format(string(WeightPredKey), '~w/3', [WeightPred]),
@@ -4471,16 +4485,22 @@ compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _Inc
         return false;
     }
 
-    let mut best = match vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
-        Some(Value::Float(cost)) => Some(cost),
-        _ => None,
-    };
-    while vm.backtrack() {
+    let mut best: Option<f64> = None;
+    loop {
         if let Some(Value::Float(cost)) = vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+~w            if !(~w) {
+                if !vm.backtrack() {
+                    break;
+                }
+                continue;
+            }
             best = Some(match best {
-                Some(current) => current.min(cost),
-                None => cost,
+                Some(current) => current.min(~w),
+                None => ~w,
             });
+        }
+        if !vm.backtrack() {
+            break;
         }
     }
 
@@ -4491,7 +4511,97 @@ compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _Inc
         Some(cost) => vm.unify(&a3, &Value::Float(cost)),
         None => false,
     }
-}', [PredStr, InnerPredStr, InnerPredStr, InnerPredStr, InnerPredStr, WeightPredKey, WeightPredKey, TriplesLiteral, InnerPredStr]).
+}', [PredStr, InnerPredStr, InnerPredStr, InnerPredStr, InnerPredStr, WeightPredKey, WeightPredKey, TriplesLiteral, InnerPredStr, SetupCode, FilterCond, ValueExpr, ValueExpr]).
+
+rust_foreign_wrapper_goal_logic(GoalInfo, GoalArgs, Expr, SetupCode, ValueExpr, FilterCond) :-
+    get_dict(other, GoalInfo, []),
+    rust_foreign_wrapper_value_expr(Expr, GoalInfo, GoalArgs, SetupCode, ValueExpr),
+    get_dict(constraints, GoalInfo, Constraints),
+    findall(Part,
+        ( member(Constraint, Constraints),
+          rust_foreign_wrapper_constraint_expr(Constraint, GoalArgs, Expr, Part)
+        ),
+        Parts),
+    rust_combine_pipeline_conditions(Parts, FilterCond).
+
+rust_foreign_wrapper_value_expr(Expr, GoalInfo, GoalArgs, "", "cost") :-
+    last(GoalArgs, CostArg),
+    Expr == CostArg,
+    get_dict(other, GoalInfo, []).
+rust_foreign_wrapper_value_expr(Expr, GoalInfo, GoalArgs, SetupCode, "agg_value") :-
+    get_dict(other, GoalInfo, []),
+    get_dict(arithmetic, GoalInfo, Arithmetic),
+    member(Arithmetic0, Arithmetic),
+    strip_module(Arithmetic0, _, ArithmeticGoal),
+    ArithmeticGoal = (Expr is ArithmeticExpr),
+    rust_foreign_wrapper_numeric_expr(ArithmeticExpr, GoalArgs, Expr, RustExpr),
+    format(string(SetupCode), '            let agg_value = ~w;~n', [RustExpr]).
+
+rust_foreign_wrapper_numeric_expr(Expr, _GoalArgs, _AggExpr, RustExpr) :-
+    number(Expr),
+    !,
+    format(string(RustExpr), '~w_f64', [Expr]).
+rust_foreign_wrapper_numeric_expr(Expr, GoalArgs, _AggExpr, "cost") :-
+    var(Expr),
+    last(GoalArgs, CostArg),
+    Expr == CostArg,
+    !.
+rust_foreign_wrapper_numeric_expr(Expr, GoalArgs, _AggExpr, "dim_value") :-
+    var(Expr),
+    GoalArgs = [_StartArg, _TargetArg, DimArg, _CostArg],
+    Expr == DimArg,
+    !.
+rust_foreign_wrapper_numeric_expr(Expr, GoalArgs, AggExpr, RustExpr) :-
+    compound(Expr),
+    Expr =.. [Op, Left, Right],
+    member(Op-Sym, [(+)-'+', (-)-'-', (*)-'*', (/)-'/']),
+    rust_foreign_wrapper_numeric_expr(Left, GoalArgs, AggExpr, LeftExpr),
+    rust_foreign_wrapper_numeric_expr(Right, GoalArgs, AggExpr, RightExpr),
+    format(string(RustExpr), '(~w ~w ~w)', [LeftExpr, Sym, RightExpr]).
+
+rust_foreign_wrapper_constraint_expr(Constraint0, GoalArgs, AggExpr, Cond) :-
+    strip_module(Constraint0, _, Constraint),
+    Constraint =.. [Op, Left0, Right0],
+    rust_foreign_wrapper_constraint_operand(Left0, GoalArgs, AggExpr, LeftType, LeftExpr),
+    rust_foreign_wrapper_constraint_operand(Right0, GoalArgs, AggExpr, RightType, RightExpr),
+    rust_foreign_wrapper_constraint_operator(Op, LeftType, RightType, OpExpr),
+    format(string(Cond), '~w ~w ~w', [LeftExpr, OpExpr, RightExpr]).
+
+rust_foreign_wrapper_constraint_operand(Operand, GoalArgs, AggExpr, number, "agg_value") :-
+    var(Operand),
+    Operand == AggExpr,
+    \+ (last(GoalArgs, CostArg), Operand == CostArg),
+    !.
+rust_foreign_wrapper_constraint_operand(Operand, GoalArgs, _AggExpr, number, "cost") :-
+    var(Operand),
+    last(GoalArgs, CostArg),
+    Operand == CostArg,
+    !.
+rust_foreign_wrapper_constraint_operand(Operand, GoalArgs, _AggExpr, number, "dim_value") :-
+    var(Operand),
+    GoalArgs = [_StartArg, _TargetArg, DimArg, _CostArg],
+    Operand == DimArg,
+    !.
+rust_foreign_wrapper_constraint_operand(Operand, GoalArgs, _AggExpr, string, "target.as_str()") :-
+    var(Operand),
+    GoalArgs = [_StartArg, TargetArg|_],
+    Operand == TargetArg,
+    !.
+rust_foreign_wrapper_constraint_operand(Operand, _GoalArgs, _AggExpr, number, RustExpr) :-
+    number(Operand),
+    !,
+    format(string(RustExpr), '~w_f64', [Operand]).
+rust_foreign_wrapper_constraint_operand(Operand, _GoalArgs, _AggExpr, string, RustExpr) :-
+    atom(Operand),
+    !,
+    format(string(RustExpr), '"~w"', [Operand]).
+
+rust_foreign_wrapper_constraint_operator(Op, number, number, Sym) :-
+    member(Op-Sym, [(>)-'>', (<)-'<', (>=)-'>=', (=<)-'<=', (=:=)-'==', (=\\=)-'!=', (==)-'==', (\\==)-'!=']),
+    !.
+rust_foreign_wrapper_constraint_operator(Op, string, string, Sym) :-
+    member(Op-Sym, [(==)-'==', (\\==)-'!=']),
+    !.
 
 rust_weighted_fact_triples_literal(Triples, Literal) :-
     maplist(rust_weighted_fact_triple_literal, Triples, TripleLiterals),

--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -126,6 +126,18 @@ grouped_min_semantic_dist(Start, Target, MinDist) :-
 grouped_min_semantic_dist_astar(Start, Target, Dim, MinDist) :-
     aggregate_all(min(Cost), astar_weighted_path(Start, Target, Dim, Cost), Target, MinDist).
 
+:- dynamic filtered_adjusted_min_semantic_dist/3.
+filtered_adjusted_min_semantic_dist(Start, Target, MinDist) :-
+    aggregate_all(min(Adjusted),
+        (weighted_path(Start, Target, Cost), Cost > 2, Adjusted is Cost + 1),
+        MinDist).
+
+:- dynamic filtered_adjusted_min_semantic_dist_astar/4.
+filtered_adjusted_min_semantic_dist_astar(Start, Target, Dim, MinDist) :-
+    aggregate_all(min(Adjusted),
+        (astar_weighted_path(Start, Target, Dim, Cost), Cost > 2, Adjusted is Cost + 1),
+        MinDist).
+
 %% Integration test
 test_runtime_execution :-
     Test = 'WAM-Rust Runtime: end-to-end execution',
@@ -136,7 +148,7 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:astar_weighted_path/4, user:min_semantic_dist/3, user:min_semantic_dist_astar/4, user:grouped_min_semantic_dist/3, user:grouped_min_semantic_dist_astar/4],
+        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:astar_weighted_path/4, user:min_semantic_dist/3, user:min_semantic_dist_astar/4, user:grouped_min_semantic_dist/3, user:grouped_min_semantic_dist_astar/4, user:filtered_adjusted_min_semantic_dist/3, user:filtered_adjusted_min_semantic_dist_astar/4],
             [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
@@ -159,6 +171,8 @@ use runtime_test::min_semantic_dist;
 use runtime_test::min_semantic_dist_astar;
 use runtime_test::grouped_min_semantic_dist;
 use runtime_test::grouped_min_semantic_dist_astar;
+use runtime_test::filtered_adjusted_min_semantic_dist;
+use runtime_test::filtered_adjusted_min_semantic_dist_astar;
 
 #[test]
 fn test_generated_predicates() {
@@ -814,6 +828,86 @@ fn test_generated_predicates() {
         Value::Integer(5),
         Value::Unbound("GroupedAStarNoMin".to_string()));
     assert!(!ok34, "grouped_min_semantic_dist_astar(d, Target, 5, Min) should fail");
+
+    // Test filtered_adjusted_min_semantic_dist/3 mixed-goal wrapper
+    let mut vm_filtered = WamState::new(vec![], std::collections::HashMap::new());
+    let ok35 = filtered_adjusted_min_semantic_dist(&mut vm_filtered,
+        Value::Atom("s".to_string()),
+        Value::Atom("d".to_string()),
+        Value::Unbound("FilteredD".to_string()));
+    assert!(ok35, "filtered_adjusted_min_semantic_dist(s, d, Min) should succeed");
+    match vm_filtered.bindings.get("FilteredD").cloned() {
+        Some(Value::Float(cost)) => assert_close(cost, 8.0),
+        other => panic!("expected filtered_adjusted_min_semantic_dist(s, d, Min) to bind float cost, got {:?}", other),
+    }
+
+    let mut vm_filtered_any = WamState::new(vec![], std::collections::HashMap::new());
+    let ok36 = filtered_adjusted_min_semantic_dist(&mut vm_filtered_any,
+        Value::Atom("s".to_string()),
+        Value::Unbound("FilteredAnyTarget".to_string()),
+        Value::Unbound("FilteredGlobalMin".to_string()));
+    assert!(ok36, "filtered_adjusted_min_semantic_dist(s, Target, Min) should succeed");
+    assert!(vm_filtered_any.bindings.get("FilteredAnyTarget").is_none(), "filtered aggregate wrapper should not bind existential Target");
+    match vm_filtered_any.bindings.get("FilteredGlobalMin").cloned() {
+        Some(Value::Float(cost)) => assert_close(cost, 4.0),
+        other => panic!("expected filtered_adjusted_min_semantic_dist(s, Target, Min) to bind float cost, got {:?}", other),
+    }
+
+    let mut vm_filtered_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok37 = filtered_adjusted_min_semantic_dist(&mut vm_filtered_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("c".to_string()),
+        Value::Float(5.0));
+    assert!(ok37, "filtered_adjusted_min_semantic_dist(s, c, 5.0) should succeed");
+
+    let mut vm_filtered_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok38 = filtered_adjusted_min_semantic_dist(&mut vm_filtered_fail,
+        Value::Atom("s".to_string()),
+        Value::Atom("a".to_string()),
+        Value::Unbound("FilteredNoPath".to_string()));
+    assert!(!ok38, "filtered_adjusted_min_semantic_dist(s, a, Min) should fail");
+
+    // Test filtered_adjusted_min_semantic_dist_astar/4 mixed-goal wrapper
+    let mut vm_filtered_astar = WamState::new(vec![], std::collections::HashMap::new());
+    let ok39 = filtered_adjusted_min_semantic_dist_astar(&mut vm_filtered_astar,
+        Value::Atom("s".to_string()),
+        Value::Atom("d".to_string()),
+        Value::Integer(5),
+        Value::Unbound("FilteredAStarD".to_string()));
+    assert!(ok39, "filtered_adjusted_min_semantic_dist_astar(s, d, 5, Min) should succeed");
+    match vm_filtered_astar.bindings.get("FilteredAStarD").cloned() {
+        Some(Value::Float(cost)) => assert_close(cost, 8.0),
+        other => panic!("expected filtered_adjusted_min_semantic_dist_astar(s, d, 5, Min) to bind float cost, got {:?}", other),
+    }
+
+    let mut vm_filtered_astar_any = WamState::new(vec![], std::collections::HashMap::new());
+    let ok40 = filtered_adjusted_min_semantic_dist_astar(&mut vm_filtered_astar_any,
+        Value::Atom("s".to_string()),
+        Value::Unbound("FilteredAStarAnyTarget".to_string()),
+        Value::Integer(5),
+        Value::Unbound("FilteredAStarGlobalMin".to_string()));
+    assert!(ok40, "filtered_adjusted_min_semantic_dist_astar(s, Target, 5, Min) should succeed");
+    assert!(vm_filtered_astar_any.bindings.get("FilteredAStarAnyTarget").is_none(), "filtered A* aggregate wrapper should not bind existential Target");
+    match vm_filtered_astar_any.bindings.get("FilteredAStarGlobalMin").cloned() {
+        Some(Value::Float(cost)) => assert_close(cost, 4.0),
+        other => panic!("expected filtered_adjusted_min_semantic_dist_astar(s, Target, 5, Min) to bind float cost, got {:?}", other),
+    }
+
+    let mut vm_filtered_astar_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok41 = filtered_adjusted_min_semantic_dist_astar(&mut vm_filtered_astar_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("c".to_string()),
+        Value::Integer(5),
+        Value::Float(5.0));
+    assert!(ok41, "filtered_adjusted_min_semantic_dist_astar(s, c, 5, 5.0) should succeed");
+
+    let mut vm_filtered_astar_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok42 = filtered_adjusted_min_semantic_dist_astar(&mut vm_filtered_astar_fail,
+        Value::Atom("s".to_string()),
+        Value::Atom("a".to_string()),
+        Value::Integer(5),
+        Value::Unbound("FilteredAStarNoPath".to_string()));
+    assert!(!ok42, "filtered_adjusted_min_semantic_dist_astar(s, a, 5, Min) should fail");
 }
 ',
         setup_call_cleanup(open(TestPath, write, S), format(S, "~w", [TestContent]), close(S)),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -44,6 +44,8 @@ test_simple_fact(foo, bar).
 :- dynamic min_semantic_dist_astar/4.
 :- dynamic grouped_min_semantic_dist/3.
 :- dynamic grouped_min_semantic_dist_astar/4.
+:- dynamic filtered_adjusted_min_semantic_dist/3.
+:- dynamic filtered_adjusted_min_semantic_dist_astar/4.
 :- dynamic tc_parent/2.
 :- dynamic max_depth/1.
 
@@ -146,6 +148,16 @@ grouped_min_semantic_dist(Start, Target, MinDist) :-
 
 grouped_min_semantic_dist_astar(Start, Target, Dim, MinDist) :-
     aggregate_all(min(Cost), astar_weighted_path(Start, Target, Dim, Cost), Target, MinDist).
+
+filtered_adjusted_min_semantic_dist(Start, Target, MinDist) :-
+    aggregate_all(min(Adjusted),
+        (weighted_path(Start, Target, Cost), Cost > 2, Adjusted is Cost + 1),
+        MinDist).
+
+filtered_adjusted_min_semantic_dist_astar(Start, Target, Dim, MinDist) :-
+    aggregate_all(min(Adjusted),
+        (astar_weighted_path(Start, Target, Dim, Cost), Cost > 2, Adjusted is Cost + 1),
+        MinDist).
 
 pass(Test) :-
     format('[PASS] ~w~n', [Test]).
@@ -777,6 +789,32 @@ test_grouped_astar_min_aggregate_wrapper :-
     ;   fail_test(Test, 'Grouped A* aggregate wrapper did not delegate correctly')
     ).
 
+test_filtered_adjusted_weighted_min_wrapper :-
+    Test = 'WAM-Rust: mixed-goal aggregate wrapper filters and adjusts weighted_path/3',
+    (   rust_target:compile_predicate_to_rust(user:filtered_adjusted_min_semantic_dist/3,
+            [include_main(false), foreign_lowering(true), wam_fallback(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'pub fn filtered_adjusted_min_semantic_dist(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool'),
+        sub_string(S, _, _, _, 'let agg_value = (cost + 1_f64);'),
+        sub_string(S, _, _, _, 'if !(cost > 2_f64) {'),
+        sub_string(S, _, _, _, 'current.min(agg_value)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Mixed-goal weighted aggregate wrapper did not lower correctly')
+    ).
+
+test_filtered_adjusted_astar_min_wrapper :-
+    Test = 'WAM-Rust: mixed-goal aggregate wrapper filters and adjusts astar_weighted_path/4',
+    (   rust_target:compile_predicate_to_rust(user:filtered_adjusted_min_semantic_dist_astar/4,
+            [include_main(false), foreign_lowering(true), wam_fallback(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'pub fn filtered_adjusted_min_semantic_dist_astar(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool'),
+        sub_string(S, _, _, _, 'let agg_value = (cost + 1_f64);'),
+        sub_string(S, _, _, _, 'if !(cost > 2_f64) {'),
+        sub_string(S, _, _, _, 'current.min(agg_value)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Mixed-goal A* aggregate wrapper did not lower correctly')
+    ).
+
 test_compile_wam_runtime_output :-
     Test = 'WAM-Rust E2E: full runtime generates valid impl block',
     (   compile_wam_runtime_to_rust([], Code),
@@ -1095,6 +1133,8 @@ run_tests :-
     test_astar_min_aggregate_wrapper,
     test_grouped_weighted_min_aggregate_wrapper,
     test_grouped_astar_min_aggregate_wrapper,
+    test_filtered_adjusted_weighted_min_wrapper,
+    test_filtered_adjusted_astar_min_wrapper,
     test_compile_wam_runtime_output,
     test_write_wam_rust_project,
     test_project_cargo_content,


### PR DESCRIPTION
## Summary

This PR extends the Rust WAM foreign aggregate-wrapper path so it can handle aggregate bodies that include extra numeric filtering and simple arithmetic on top of foreign-lowered recursive kernels.

Before this change, the Rust foreign wrapper path was strongest for direct aggregate bodies like:

- `aggregate_all(min(Cost), weighted_path(...), MinDist)`
- `aggregate_all(min(Cost), astar_weighted_path(...), MinDist)`

But once the aggregate body added extra goals such as:

- `Cost > 2`
- `Adjusted is Cost + 1`

the wrapper path did not account for those `GoalInfo.constraints` and `GoalInfo.arithmetic` terms.

This PR adds that missing support for the scalar minimum-wrapper path over weighted and A* kernels.

## Changes

- extend foreign aggregate wrappers over `weighted_path/3` and `astar_weighted_path/4` to honor:
  - numeric constraints in the aggregate body
  - simple arithmetic derived from the foreign-kernel cost
- evaluate filtered/adjusted aggregate values before reducing to the final minimum
- add target-suite coverage for:
  - `filtered_adjusted_min_semantic_dist/3`
  - `filtered_adjusted_min_semantic_dist_astar/4`
- add generated Rust runtime coverage for:
  - bound-target queries
  - unbound-target existential minimum queries
  - exact-value matches
  - failure when filtering removes all candidate results

## Why

The foreign-lowered Rust path already covered:

- direct scalar minimum wrappers
- grouped minimum wrappers

The next missing composition point was mixed-goal bodies where the aggregate is still fundamentally “min over a foreign kernel,” but the body adds extra logic around the raw kernel cost.

This PR closes that gap without falling back to the older generic recursive aggregate path.

## Validation

Ran locally in Termux:

```sh
swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl
swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl
```

Both passed.

## Notes

- Scope is intentionally limited to simple mixed-goal numeric filtering and arithmetic in scalar minimum wrappers.
- This does not yet attempt broader non-aggregate query-plan composition around foreign kernels; it improves the aggregate-wrapper layer specifically.
