### PR TITLE
chore(wam-haskell): force eager evaluation in benchmark driver

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -790,7 +790,8 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
 %  Generates Main.hs — a benchmark driver for effective-distance.
 %  Loads facts from TSV, runs category_ancestor queries, outputs TSV.
 generate_main_hs(_Predicates, Code) :-
-    Code = 'module Main where
+    Code = '{-# LANGUAGE BangPatterns #-}
+module Main where
 
 import qualified Data.Map.Strict as Map
 import Data.List (nub, sort, isPrefixOf, intercalate)
@@ -903,8 +904,11 @@ main = do
     t2 <- getCurrentTime
 
     -- For each seed, run category_ancestor(Cat, Root, Hops, [Cat])
-    let seedResults = map (\\cat ->
-          let s0 = (emptyState mergedCode mergedLabels)
+    -- IMPORTANT: use mapM in IO with strict bang patterns to force actual
+    -- computation BEFORE timing endpoint, otherwise lazy evaluation will
+    -- defer the work until output and the timing will be artificially low.
+    seedResultsForced <- mapM (\\cat -> do
+        let s0 = (emptyState mergedCode mergedLabels)
                 { wsPC = fromMaybe 1 $ Map.lookup "category_ancestor/4" mergedLabels
                 , wsRegs = Map.fromList
                     [ ("A1", Atom cat)
@@ -914,12 +918,13 @@ main = do
                     ]
                 , wsCP = 0
                 }
-              solutions = collectSolutions s0
-              weightSum = sum [((hops + 1) ** negN) | hops <- solutions]
-          in (cat, weightSum)
-          ) seedCats
+            !solutions = collectSolutions s0
+            !weightSum = sum [((hops + 1) ** negN) | hops <- solutions]
+        return (cat, weightSum)
+        ) seedCats
 
-    let seedWeightSums = Map.fromList [(cat, ws) | (cat, ws) <- seedResults, ws > 0]
+    let !seedWeightSums = Map.fromList [(cat, ws) | (cat, ws) <- seedResultsForced, ws > 0]
+        !forcedSize = Map.size seedWeightSums  -- force the map
 
     t3 <- getCurrentTime
     let queryMs = round (diffUTCTime t3 t2 * 1000) :: Int


### PR DESCRIPTION
  ## Summary
  The generated `Main.hs` measured `query_ms` before the lazy `seedResults` were forced. Strict bang-pattern annotations on
  `let` bindings weren't enough because `Map.fromList` was deferred until the print loop. This caused the benchmark to report
   unrealistically low timings ("<1ms" at depth=10).

  Fix:
  - Add `{-# LANGUAGE BangPatterns #-}` to generated `Main.hs`
  - Convert `seedResults` to `mapM` in IO (forces evaluation per-seed)
  - Bang patterns on `solutions`, `weightSum` inside the lambda
  - Force `seedWeightSums` via `Map.size` before the timing endpoint

  ## Real benchmark numbers (300-scale, depth=10, 386 seeds, 11,172 paths)
  | Implementation | Time | vs Native |
  |---|---|---|
  | Native SWI-Prolog | 318ms | 1x |
  | Haskell WAM + FFI | ~7,400ms | 23x |
  | Haskell WAM-only | ~10,500ms | 33x |
  | Prolog WAM emulator | ~18,000ms | 57x |

  The compiled Haskell WAM is ~1.7x faster than the Prolog WAM emulator (real win), and the FFI gives ~1.5x over WAM-only
  (smaller than Rust's FFI advantage, because Haskell's `Data.Array`-based interpreter is already comparatively fast).

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

  What's next: now that we have honest numbers, the next optimizations should target specific Haskell WAM hot spots — likely
  the Map.lookup overhead in wsRegs/wsBindings. Profiling with +RTS -p would identify where to focus. Or implement the "fused
   instructions" the Rust target defines but doesn't yet emit (NotMember, ListLengthLt) — these would reduce instruction
  dispatch count for the inner loop of category_ancestor.