### PR TITLE
feat(csharp-query): plan dag fallback materialization

### DIFF
--- a/docs/design/WAM_HASKELL_PERF_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_HASKELL_PERF_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,340 @@
+# WAM Haskell Performance: Implementation Plan
+
+This document records the optimization history of the
+`feat/wam-haskell-perf-profile` branch and the ordered next steps.
+
+For the *why*, see `WAM_HASKELL_PERF_PHILOSOPHY.md`. For the *what*, see
+`WAM_HASKELL_PERF_SPECIFICATION.md`.
+
+## 0. Starting point
+
+Before this branch, the Haskell WAM target produced correct output (213/213
+tuples, 272/272 line matches against the SWI-Prolog reference) but ran the
+effective-distance benchmark in ~11.7 s wall time at 300 scale (depth=10,
+386 seeds, 11172 paths).
+
+For comparison at the same scale:
+- Native SWI-Prolog: ~318 ms
+- Rust WAM (with FFI): faster than native SWI-Prolog
+- Rust WAM (pure interpreter): much slower than native SWI-Prolog
+
+The gap to native SWI-Prolog was ~37x. The goal of this branch is to
+close that gap as far as is practical without changing the architectural
+shape of the WAM target.
+
+## 1. Optimization history (already on the branch)
+
+Each commit was profile-guided: run `+RTS -p -RTS`, find the hot spot,
+attack it, re-profile, repeat.
+
+### 1.1 `0daa9d65` — Data.HashMap.Strict for register/binding maps
+
+**Hot spot:** ~17 GB allocated in 10 s of wall time. The profiler showed
+the cost was in `Data.Map.Strict.insert` rebuilding tree paths.
+
+**Change:** Added a `use_hashmap` option (default `true`) to
+`write_wam_haskell_project`. The post-processing pass `apply_hashmap_rewrite`
+rewrites `Data.Map.Strict` → `Data.HashMap.Strict` and `Map.Map` →
+`Map.HashMap` in the generated Haskell. Cabal file conditionally adds
+`unordered-containers` and `hashable`. `Value` got a `Hashable` instance
+via `DeriveGeneric`.
+
+**Result:** 11,742 ms → 8,615 ms (27% faster).
+
+### 1.2 `501da4fc` — Pre-parse PutStructure arity at compile time
+
+**Hot spot:** `step.arity` was 5.9% time / 8.3% allocation. The runtime
+was parsing `"name/N"` on every `PutStructure` invocation via reverse +
+break + reads.
+
+**Change:** Added an `Int` arity field to the `PutStructure` ADT. The
+WAM compiler already knows the arity when it emits the instruction, so
+it embeds the integer directly. Runtime dropped `parseFunctorArity`.
+
+**Result:** 8,615 ms → 7,320 ms (cumulative 38% vs Map baseline).
+
+### 1.3 `221f828f` — IntMap for registers, eliminating string hashing
+
+**Hot spot:** `hashWithSalt1` at 11.2% of runtime, mostly from register
+name lookups (`Map.lookup "A1"`, `"X5"`, `"Y2"`, etc.).
+
+**Change:** Register names became `Int`s under a fixed encoding:
+- `A1`–`A99`: 1–99
+- `X1`–`X99`: 101–199
+- `Y1`–`Y99`: 201–299
+
+The compile-time helper `reg_name_to_int/2` parses register names once
+when emitting the Haskell instruction list. The runtime uses
+`Data.IntMap.Strict` for `wsRegs`. `getReg`/`putReg` detect the Y bank
+via `rid >= 200`.
+
+**Result:** Significant drop in `hashWithSalt1` cost (visible in next
+profile pass).
+
+### 1.4 `803ed711` — Intern variables as Ints, IntMap for bindings
+
+**Hot spot:** Even after register interning, `hashWithSalt1` was still
+~10% of runtime. Variable names like `"_V42"` were the remaining string
+hash work.
+
+**Change:** `Unbound String` became `Unbound !Int`, drawing IDs from
+`wsVarCounter`. `wsBindings` and `cpBindings` became `IntMap Value`.
+`TrailEntry` became `TrailEntry !Int !(Maybe Value)`. The
+`__binding__`++name string was retired. `BuiltinState` (FactRetry,
+HopsRetry) variables became `Int`.
+
+**Note:** Data-value hashing (`wsForeignFacts`, `wsLabels`) and cycle
+detection (`Set String` for visited categories) were unchanged. Only
+WAM-internal bookkeeping names were interned.
+
+**Result:** `hashWithSalt1` mostly eliminated for inner-loop work.
+
+### 1.5 `cec17ca3` — Pre-resolve Call instructions at project load
+
+**Hot spot:** `Call` dispatch was hashing predicate name strings on
+every invocation (`Map.lookup pred wsLabels`).
+
+**Change:** Added `CallResolved !Int !Int` (target PC, arity). At
+project load, `resolveCallInstrs` walks the code list and replaces every
+`Call` whose target is a known label with `CallResolved`. Foreign
+predicates (e.g., `category_ancestor/4` → `executeForeign`) and indexed
+facts (`category_parent/2` → `callIndexedFact2`) keep the original `Call`
+because they need runtime dispatch.
+
+**Result:** `hashWithSalt1` dropped from 9.2% to 7.4% of runtime.
+Benchmark: ~5,500 ms → ~4,000–5,100 ms.
+
+### 1.6 `0d9695a9` — List-based visited + unsafe instruction fetch
+
+Two small wins from the same profile pass:
+
+**Hot spot 1:** `executeForeign.visitedStrs` was 4.7% — building a
+`Set String` per recursive call into `nativeCategoryAncestor`.
+**Change:** Use a plain `[String]` for visited. With `max_depth ≤ 10`,
+`elem` on a 10-element list beats `Set.fromList + Set.member` overhead.
+
+**Hot spot 2:** `fetchInstr` had a `Maybe` wrapper that allocated 3.8%
+of total time and 10.5% of allocation.
+**Change:** `unsafeFetchInstr` uses `code ! pc` directly. The run loop
+already handles `PC = 0` as halt, and a well-formed WAM program never
+jumps out of bounds.
+
+**Result:** Profile total time dropped 14.5 s → 12.9 s. Benchmark:
+~3,000–4,200 ms.
+
+### 1.7 `f757b881` — Cache wsTrailLen/wsHeapLen, eliminate length calls
+
+**Hot spot:** Multiple step paths called `length(wsTrail)` and
+`length(wsHeap)` for choice point creation, which is O(n) on linked lists.
+Trails grew to 100s of entries during deep recursion.
+
+**Change:** Added `wsTrailLen` and `wsHeapLen` fields. Step functions
+that cons to `wsTrail` increment the length; backtrack restores from
+the CP; aggregate frame finalization recomputes correctly.
+
+**Bonus fix:** `finalizeAggregate` had a latent bug where
+`take (cpTrailLen cp) (wsTrail s)` was keeping the *newest* entries
+instead of restoring to the snapshot. Fixed to use `drop (wsTrailLen s -
+cpTrailLen cp) (wsTrail s)`. Hadn't caused observable issues because
+aggregate finalization is the end of the WAM run, but worth fixing.
+
+**Result:** Variance tightened. Benchmark: 3,100–4,100 ms.
+
+### 1.8 `bdae58cf` — Cache wsCPsLen, fix addToBuilder O(n²) append
+
+Two more list-length wins:
+
+**Hot spot 1:** `Allocate` set `cutBar = length(wsCPs)` on every clause
+entry. With deep recursion this added up.
+**Change:** `wsCPsLen` field cached the length. Updated by `TryMeElse`,
+`BeginAggregate`, `callIndexedFact2`, `executeForeign` (increment),
+`TrustMe`, backtrack pop, cut, finalizeAggregate (decrement / set).
+`!/0` cut also tracks via `wsCPsLen = wsCutBar`.
+
+**Hot spot 2:** `addToBuilder` used `args ++ [val]`, O(n) per call,
+O(n²) total for an arity-N structure.
+**Change:** Use cons (`val : args`) and reverse on finalize.
+
+**Result:** Benchmark: 3,000–4,100 ms (slightly tighter range).
+
+### 1.9 `d0e639de` — INLINE pragmas on getReg, putReg, derefVar
+
+**Hot spot:** Three helpers called many times per WAM step, no INLINE
+pragma so GHC was conservative about call-site specialization.
+
+**Change:** Added `{-# INLINE getReg #-}`, `{-# INLINE putReg #-}`,
+`{-# INLINE derefVar #-}`.
+
+**Result:** Small wins (~5% high variance), free.
+
+### 1.10 Cumulative result
+
+| Stage | Wall time at 300 scale (depth=10) |
+|---|---|
+| Pre-branch (Map baseline) | ~11,742 ms |
+| HashMap | ~8,615 ms |
+| HashMap + arity | ~7,320 ms |
+| IntMap registers | ~6,000 ms |
+| IntMap bindings + variable interning | ~5,000 ms |
+| CallResolved | ~4,500 ms |
+| List-visited + unsafeFetch | ~3,500 ms |
+| Cached lengths + INLINE | ~3,100–4,100 ms (variance ~3,400 ms typical) |
+| **Native SWI-Prolog reference** | **~318 ms** |
+
+WAM-only path: ~3.4 s typical. WAM+FFI path: ~3.4 s typical (FFI is
+slightly faster but within noise; the WAM-side overhead is now the
+dominant cost, which is the next thing to attack).
+
+Gap to native SWI-Prolog: ~37x → ~10x. Not at the "competitive" goal
+yet, but closing.
+
+## 2. Next: WamState hot/cold split
+
+See `WAM_HASKELL_PERF_SPECIFICATION.md` §2 for the data-shape spec. This
+section is the step-by-step plan.
+
+### 2.1 Phase 1: Add WamContext type, update WamTypes.hs emission
+
+- [ ] Add `WamContext` data declaration to the generator's
+      `WamTypes.hs` template.
+- [ ] Move `wsCode`, `wsLabels`, `wsForeignFacts`, `wsForeignConfig`
+      out of `WamState` and into `WamContext`.
+- [ ] Update `emptyState` to take a `WamContext` and produce a
+      `WamState` with the cold fields gone.
+- [ ] Add `mkContext :: ... -> WamContext` for the benchmark driver.
+
+**Verify:** `cabal build` of a generated project still succeeds (it will
+not yet because `step` isn't updated, that's the next phase — but
+incremental compile should at least show the new types are well-formed).
+
+### 2.2 Phase 2: Thread context through step
+
+- [ ] Change `step :: WamState -> Maybe WamState` to
+      `step :: WamContext -> WamState -> Maybe WamState`.
+- [ ] Add `!ctx !s` bang patterns.
+- [ ] In every `case` branch that currently reads `wsCode s`, `wsLabels s`,
+      `wsForeignFacts s`, or `wsForeignConfig s`, change to read from
+      `ctx`.
+- [ ] Update `executeForeign` signature to take the context.
+- [ ] Update `callIndexedFact2` signature to take the context.
+
+**Verify:** `cabal build` succeeds. Type errors here are localized
+because the field accessors are differently typed.
+
+### 2.3 Phase 3: Update run loop and Main.hs
+
+- [ ] Change `runLoop :: WamState -> Maybe WamState` to
+      `runLoop :: WamContext -> WamState -> Maybe WamState`.
+- [ ] Update `backtrack` if any of its subcases now need the context
+      (probably none, but verify).
+- [ ] In `Main.hs`, build `ctx` once before the query loop, pass it
+      into every `runLoop` call.
+
+**Verify:** `cabal run` produces the same 213 tuples. Same SHA256 of
+output if you have it.
+
+### 2.4 Phase 4: Benchmark and profile
+
+- [ ] Run the benchmark 5 times, record min/median/max.
+- [ ] Compare against the pre-split baseline (latest commit on
+      `feat/wam-haskell-perf-profile`).
+- [ ] Run with `+RTS -p -RTS` and look at the new top hot spots.
+- [ ] If a clear new hot spot appears, decide whether to attack it
+      before moving on to FFI work, or to defer.
+
+**Acceptance criteria:**
+- 213/213 tuples produced (no regression in correctness).
+- Wall time at 300 scale (depth=10) is ≤ pre-split median.
+- New profile shows the cold-field record-update cost has been
+  eliminated (not "reduced" — it should be gone).
+
+### 2.5 Risks
+
+| Risk | Mitigation |
+|---|---|
+| Lazy `ctx` reads (no bang) → silent no-op | Audit every `step`/`runLoop` for `!ctx` |
+| Forgetting a generator-side reference to a moved field | `cabal build` will catch it |
+| Unexpected cabal config issue with cached builds | `cabal clean` between baseline and split runs |
+| The split is a no-op because the per-step cost was already small | Acceptable; move on to FFI work |
+
+## 3. After the split: FFI optimization
+
+See `WAM_HASKELL_PERF_SPECIFICATION.md` §3 for the data-shape changes.
+
+### 3.1 Steps (in order)
+
+- [ ] Convert `nativeCategoryAncestor` to a difference-list (`[Int] ->
+      [Int]`) accumulator. Target: eliminate the `baseHits ++ recHits`
+      append.
+- [ ] Profile to confirm the difference-list version is faster (or
+      neutral). If neutral, keep it because it reads more cleanly.
+- [ ] Audit the WAM round-trip cost via `HopsRetry`. If profile shows
+      the round-trip is dominant, evaluate the direct-aggregate path
+      (`nativeCategoryAncestorSum`) as a separate change.
+- [ ] If the direct-aggregate path is taken, gate it on the aggregate
+      shape: only apply when the WAM is summing `H ** NegN` for some
+      `NegN`, fall back to the general path otherwise.
+
+### 3.2 Acceptance criteria
+
+- 213/213 tuples (no regression).
+- WAM+FFI path is measurably faster than the pure-WAM path (it
+  currently isn't — they're within noise).
+- Profile no longer shows the FFI path as a hot spot.
+
+## 4. Deferred: compile WAM-to-Haskell-functions
+
+See `WAM_HASKELL_PERF_SPECIFICATION.md` §4 for the concept.
+
+This is its own branch and its own design doc. The expected order is:
+
+1. **Land this branch** (perf optimizations + design docs). PR pending.
+2. **Land the WamState split** (separate branch off main).
+3. **Land the FFI optimization** (separate branch off main).
+4. **Open a discussion / write a proposal** for the compile-to-Haskell
+   path. This deserves its own `WAM_HASKELL_FUNCTIONS_*.md` triple of
+   docs because the design space is genuinely different.
+
+## 5. Test strategy
+
+Throughout all phases, the regression test is the same: the
+effective-distance benchmark at 300 scale (depth=10, 386 seeds, 11172
+paths) must produce 213 tuples that match the SWI-Prolog reference
+output exactly.
+
+The benchmark driver is generated by the `wam_haskell_target.pl` test
+helpers. The reference output is the one used in the existing
+`feat/benchmark-semantic-distance-at-scale` test path.
+
+Regression test command (from the generated project root):
+```
+cabal run -- 300 10
+```
+
+Output should match `examples/benchmark/effective_distance/reference_300.tsv`
+(or whatever the canonical reference is on `main`).
+
+## 6. Commit message conventions
+
+The branch convention so far is:
+```
+perf(wam-haskell): <one-line summary>
+
+<2-3 paragraphs of context: hot spot, change, rationale>
+
+Profile data and benchmark numbers if relevant.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+Continue this for the WamState split and FFI work.
+
+## 7. Out of scope
+
+Anything in `WAM_HASKELL_PERF_SPECIFICATION.md` §5 ("Out of scope for
+this branch") applies here too. Notably:
+
+- No `IORef`/`STRef`/mutable arrays.
+- No `unsafePerformIO`.
+- No new instruction set.
+- No changes to native lowering or to the Rust target.

--- a/docs/design/WAM_HASKELL_PERF_PHILOSOPHY.md
+++ b/docs/design/WAM_HASKELL_PERF_PHILOSOPHY.md
@@ -1,0 +1,239 @@
+# WAM Haskell Performance: Philosophy
+
+## Context
+
+The Haskell WAM target was created as a fallback path for Prolog predicates
+that resist native lowering. Once it was producing correct output (213/213
+tuples, 272/272 line matches against the SWI-Prolog reference at the
+effective-distance benchmark), the question shifted from "is it correct" to
+"how close can it get to native SWI-Prolog?"
+
+The Rust hybrid WAM had already proven that a WAM compiled to a strict,
+pre-resolved instruction stream could *beat* native SWI-Prolog when the
+foreign function interface (FFI) handled the recursive `category_ancestor/4`
+search. The Haskell WAM, by contrast, started at ~12 seconds for a workload
+that SWI-Prolog handles in ~318 ms — a ~37x gap.
+
+Closing that gap is the subject of this branch
+(`feat/wam-haskell-perf-profile`). This document explains *why* we picked the
+optimizations we did, why we are *not* taking certain other paths that look
+attractive on the surface, and how the remaining work fits together.
+
+## Core principle: persistent data structures, not mutation
+
+The Rust WAM was forced to clone the registers, bindings, and stack on every
+choice point because Rust's ownership model doesn't give you cheap structural
+sharing. The Haskell WAM started with the opposite stance: every WAM field
+that backtracks is a *persistent* data structure (`Data.Map`, then
+`Data.HashMap.Strict`, then `Data.IntMap.Strict`), so a choice point snapshot
+is a constant number of pointer copies — the unmodified subtrees are shared
+between the live state and every CP that holds a reference to them.
+
+This is the single architectural reason Haskell can match Rust on
+backtracking-heavy workloads at all. **Every optimization we keep must
+preserve this property**, and every optimization we reject is rejected
+primarily because it would break it.
+
+## Why we are *not* using IORef (or STRef, or MutVar)
+
+The most obvious "next step" for someone coming from a procedural background
+is: stop allocating new `WamState` records on every step, mutate one in
+place. Wrap the registers in an `IORef (IntMap Value)`, the trail in an
+`IORef [TrailEntry]`, and so on. The whole loop runs in `IO`. Each step is
+"cheaper" because nothing is allocated.
+
+We rejected this for four reasons:
+
+1. **It destroys the choice-point property.** A snapshot of an `IORef` is
+   not O(1) — it is "save the *current* contents", which means reading them
+   out and reinstalling them on backtrack. The persistent-data-structure
+   trick where the live state and the saved CP literally share subtrees
+   stops working. Backtracking gets *slower*, not faster.
+
+2. **It pollutes everything with `IO`.** The `step` function becomes
+   `WamState -> IO (Maybe ())`. Every helper that touches state has to live
+   in `IO`. Pure helpers that GHC currently inlines and rearranges freely
+   become opaque effectful blocks. The optimizer's job gets *harder*.
+
+3. **The marginal wins are smaller than they look.** The thing IORef
+   eliminates — record allocation — is exactly the thing GHC's strictness
+   analyzer and worker/wrapper transform are good at compressing. A strict
+   record with bang-patterned fields and `-O2` typically becomes register
+   spills, not heap allocations. GHC will *not* lift mutation out of an
+   IORef the same way.
+
+4. **It is the wrong abstraction for the wrong layer.** The right place to
+   eliminate "boxed Haskell record overhead" is to skip the WAM and emit
+   straight-line Haskell from the Prolog source. That is a separate path
+   (the native `haskell_target.pl`) and we are explicitly *not* trying to
+   merge them.
+
+The user-facing summary: IORef would turn the Haskell WAM into a worse
+version of the Rust WAM, with all of Rust's clone-on-backtrack pain *and*
+none of Haskell's structural-sharing wins.
+
+## Why we *are* doing the WamState split next
+
+`WamState` currently has 17 fields. Most of them change on every step
+(`wsPC`, `wsRegs`, `wsBindings`, `wsTrail`, `wsTrailLen`, `wsBuilder`,
+`wsVarCounter`). A handful of them never change after initialization
+(`wsCode`, `wsLabels`, `wsForeignFacts`, `wsForeignConfig`).
+
+When the step function emits `s { wsPC = pc', wsRegs = r' }`, GHC has to
+allocate a fresh 17-field record because record-update syntax allocates a
+new constructor with all fields copied. Eleven of those copies are pointless
+— the cold fields are the same pointer they always were.
+
+**Splitting** the cold fields out into a separate `WamContext` argument
+that is threaded but never modified eliminates that copy on every step. The
+record we *do* allocate becomes smaller, the constructor allocation is
+cheaper, and the GHC worker/wrapper transform has fewer fields to track.
+This is the same trick GHC's own RTS uses for `StgRegTable` vs heap.
+
+The split is a refactor, not a redesign. It preserves persistence,
+preserves purity, preserves the "step is `WamState -> Maybe WamState`"
+shape (the only difference is that step now takes a `WamContext` as well).
+It cannot regress correctness; it can only fail to be faster than expected.
+
+We are doing it *first*, before the FFI work, because once the per-step
+record allocation cost is gone the FFI wins become measurable. As long as
+the per-step overhead is masking everything, an FFI improvement of "saves
+500 ms in `nativeCategoryAncestor`" is invisible against the noise of
+"every step allocates a 17-field record".
+
+## Why FFI optimization is the *second* priority, not the first
+
+The current FFI path (`nativeCategoryAncestor`) already beats the pure WAM
+path on most runs by 10–25%. But it is doing more work than it has to:
+
+- It allocates a fresh `[String]` visited list at each recursive call.
+- It rebuilds the result list across recursive frames.
+- It re-walks `wsForeignFacts` lookups that could be hoisted.
+- It returns Hops as `[Int]` and lets the WAM enumerate them via
+  `HopsRetry`, which is correct but means each Hops value pays for one
+  full step round-trip back into the WAM dispatch.
+
+Optimizing those is straightforward — *if* the WAM-side overhead has been
+removed first. Otherwise the WAM dispatch noise hides the FFI improvements
+in benchmark variance.
+
+This is also why the user's intuition ("we should do the split first
+because once we eliminate other overhead the FFI wins will be more clear")
+is correct: profile-guided optimization is only useful when the profile
+isn't dominated by something orthogonal.
+
+## Why "compile to Haskell" is a separate path, not a continuation of this one
+
+A natural temptation, having pushed the WAM-as-interpreter path, is to
+try compiling each Prolog predicate directly to a Haskell function: skip
+the instruction array, skip the dispatch loop, just emit
+`categoryAncestor :: String -> String -> Int -> [String] -> [(Int, [String])]`.
+
+This is a real and valuable target. It already exists, in fact:
+`haskell_target.pl` is the native lowering path. The WAM target
+(`wam_haskell_target.pl`) only takes over when native lowering fails — for
+predicates with complex backtracking, cut interactions, meta-call, or other
+features that don't have an obvious closed-form lowering.
+
+We are explicitly *not* merging these. The reasons:
+
+1. **They serve different use cases.** Native lowering is for predicates
+   we can statically reason about. WAM-via-Haskell is for predicates we
+   *can't*. Trying to make the WAM path do native-lowering work means
+   re-deriving the entire native lowering analysis inside the WAM compiler.
+
+2. **Each path's wins are different.** Native lowering wins by emitting
+   straight-line code GHC can optimize as if a human wrote it. WAM-via-
+   Haskell wins by being a faithful, predictable execution model that
+   handles every Prolog feature correctly. Mixing the two means giving
+   up the strengths of both.
+
+3. **The "compile WAM to Haskell functions" approach is itself a separate
+   exercise** — a third path, distinct from both. It would take WAM
+   instructions and emit Haskell, which is a smaller specialization
+   problem than full native lowering but a larger one than what we have
+   now. It is worth doing eventually. It is not what this branch is about.
+
+For the current branch, we keep the WAM-as-interpreter shape and push as
+hard as we can on it. The compile-WAM-to-Haskell experiment can fork off
+later as its own design doc.
+
+## Why interning works (and where it stops working)
+
+Several of the optimizations on this branch intern strings as `Int`s:
+register names (`A1` → `1`, `X1` → `101`, `Y1` → `201`), variable names
+(`_V42` → integer from `wsVarCounter`), and predicate names via
+`CallResolved` (label string → target PC).
+
+These work because the interned things are *closed* at compile time —
+the WAM compiler knows every register name and every label name when it
+emits the instruction list, so it can substitute the integer at generation
+time and the runtime never has to hash a string.
+
+The key reason this is safe: **we are interning bookkeeping names, not data
+values**. The user's data (category names like `"Nuclear_physics"`) still
+flows through `Map.HashMap String [String]` and gets hashed exactly once
+per lookup, the way it should. Cycle detection (`elem` on a small visited
+list, formerly `Set.member` on a `Set String`) still uses string equality
+on data, the way it should.
+
+The line we will not cross: interning *user data*. That would require a
+global symbol table, would make string identity a global property, would
+prevent on-the-fly fact loading, and would not actually help performance
+because data hashing only happens at the boundary (loading facts,
+key lookups), not in the inner loop.
+
+## What "good enough" looks like
+
+The success criterion is *not* "match SWI-Prolog at every scale". SWI-Prolog
+has 30 years of internal optimization — argument indexing, mode analysis,
+clause-level JIT-like first-argument indexing, an in-process garbage
+collector tuned for backtracking. We will not catch up.
+
+The success criterion is:
+
+1. **The Haskell WAM is competitive enough for fallback use.** When a
+   predicate can't go through native lowering, the user pays a small
+   constant factor to use the WAM path, not a 30x penalty.
+
+2. **The pure-WAM path is within 3x of native SWI-Prolog** at the
+   effective-distance benchmark scale we use for regression testing.
+   Currently we're at ~10x and dropping.
+
+3. **The WAM+FFI path is within 2x** for the same workload, ideally faster
+   than the WAM path by enough to justify keeping the FFI code.
+
+4. **The optimization story is honest**: every claimed speedup is from a
+   measured benchmark, not from a guess about what should be faster, and
+   every optimization reflects the profiler's actual hot spots rather
+   than micro-optimization theater.
+
+## What we are *not* trying to do
+
+- We are not going to add `unsafePerformIO` to the step function.
+- We are not going to add `unsafe` array fetches anywhere except the
+  one place (`unsafeFetchInstr`) where the invariant ("PC is always in
+  range or zero, and zero is handled") is locally checkable.
+- We are not going to introduce `IORef`, `STRef`, `MutableArray`, or any
+  other mutable cell into the WAM state.
+- We are not going to fork the codebase into "fast WAM" and "correct WAM"
+  variants. There is one WAM, it is correct, and the optimizations are
+  things that make it faster *without* changing its semantics.
+- We are not going to gate optimizations on a profile flag. Either the
+  optimization is a clear win on the benchmark and gets merged, or it
+  isn't and gets reverted.
+
+## Summary
+
+| Idea | Status | Reason |
+|---|---|---|
+| Persistent maps for registers/bindings | Done (commits 0daa9d65, 221f828f, 803ed711) | The whole point of using Haskell |
+| Compile-time arity for `PutStructure` | Done (501da4fc) | Profiler showed 8.3% allocation in arity parsing |
+| Pre-resolve `Call` to `CallResolved` | Done (cec17ca3) | Profiler showed predicate-name hashing |
+| Cached lengths (trail/heap/CPs) | Done (f757b881, bdae58cf) | `length` on linked list is O(n) |
+| `INLINE` on hot helpers | Done (d0e639de) | Cheap, lets GHC specialize |
+| WamState hot/cold split | **Next** | Per-step record allocation is the next biggest cost |
+| FFI path optimization | After split | Wins are visible only after WAM overhead is gone |
+| `IORef`-based mutation | **Rejected** | Destroys structural sharing |
+| Compile WAM-to-Haskell-functions | Separate exercise | Different path, different design |
+| Match SWI-Prolog perfectly | Not a goal | 30 years of head start; "competitive fallback" is the bar |

--- a/docs/design/WAM_HASKELL_PERF_SPECIFICATION.md
+++ b/docs/design/WAM_HASKELL_PERF_SPECIFICATION.md
@@ -1,0 +1,498 @@
+# WAM Haskell Performance: Specification
+
+This document describes the technical shape of the optimizations on
+`feat/wam-haskell-perf-profile`. It covers (1) the data shapes that are
+already in place, (2) the WamState hot/cold split that is the next planned
+change, (3) the FFI optimization that follows it, and (4) a sketch of the
+"compile WAM to Haskell functions" path that is being deferred to a
+separate exercise.
+
+For the *why* of each decision, see `WAM_HASKELL_PERF_PHILOSOPHY.md`. For
+the commit-by-commit history, see `WAM_HASKELL_PERF_IMPLEMENTATION_PLAN.md`.
+
+## 1. Current state (after the perf branch optimizations)
+
+### 1.1 Value type
+
+```haskell
+data Value = Atom String
+           | Integer Int
+           | Float Double
+           | VList [Value]
+           | Str String [Value]
+           | Unbound !Int        -- variable ID, not name
+           | Ref Int
+           deriving (Eq, Ord, Show)
+```
+
+`Unbound` carries an `Int` variable ID drawn from `wsVarCounter`. The
+binding table (`wsBindings`) is keyed on the same `Int`, so binding
+lookup never hashes a string.
+
+### 1.2 Register IDs
+
+```haskell
+type RegId = Int
+-- A1-A99: 1-99
+-- X1-X99: 101-199
+-- Y1-Y99: 201-299
+```
+
+The compile-time helper `reg_name_to_int/2` (Prolog side, in
+`wam_haskell_target.pl`) parses register names like `"A1"`, `"X3"`, `"Y2"`
+once when emitting the Haskell instruction list, so the runtime never
+re-parses them.
+
+`getReg`/`putReg` use `rid >= 200` to detect Y-bank registers and dispatch
+to the environment frame instead of `wsRegs`:
+
+```haskell
+{-# INLINE getReg #-}
+getReg :: Int -> WamState -> Maybe Value
+getReg rid s
+  | rid >= 200 = findYReg rid (wsStack s)
+  | otherwise  = derefVar (wsBindings s) <$> IM.lookup rid (wsRegs s)
+```
+
+### 1.3 Trail and choice point shapes
+
+```haskell
+data TrailEntry = TrailEntry !Int !(Maybe Value)
+                deriving (Show)
+
+data EnvFrame = EnvFrame !Int !(IM.IntMap Value)
+              deriving (Show)
+
+data ChoicePoint = ChoicePoint
+  { cpNextPC   :: !Int
+  , cpRegs     :: !(IM.IntMap Value)
+  , cpStack    :: ![EnvFrame]
+  , cpCP       :: !Int
+  , cpTrailLen :: !Int
+  , cpHeapLen  :: !Int
+  , cpBindings :: !(IM.IntMap Value)
+  , cpCutBar   :: !Int
+  , cpAggFrame :: !(Maybe AggFrame)
+  , cpBuiltin  :: !(Maybe BuiltinState)
+  } deriving (Show)
+```
+
+The `IntMap` fields (`cpRegs`, `cpBindings`) are O(1) to "snapshot" because
+the live state and the CP literally share subtrees through structural
+sharing. `cpTrailLen` and `cpHeapLen` are integer indices, so trail/heap
+restore is O(k) where k is the number of entries to drop, not O(n).
+
+`BuiltinState` lets choice points carry their own retry logic, so a fact-
+indexed call can self-pop without going through `TrustMe`:
+
+```haskell
+data BuiltinState
+  = FactRetry !String ![String] !Int  -- varName, remaining values, returnPC
+  | HopsRetry !Int    ![Int]    !Int  -- varId,   remaining Hops,    returnPC
+  deriving (Show)
+```
+
+(`HopsRetry` uses an `Int` variable ID since 803ed711.)
+
+### 1.4 Current WamState (the thing we are about to split)
+
+```haskell
+data WamState = WamState
+  { wsPC            :: !Int
+  , wsRegs          :: !(IM.IntMap Value)
+  , wsStack         :: ![EnvFrame]
+  , wsHeap          :: ![Value]
+  , wsHeapLen       :: !Int
+  , wsTrail         :: ![TrailEntry]
+  , wsTrailLen      :: !Int
+  , wsCP            :: !Int
+  , wsCPs           :: ![ChoicePoint]
+  , wsCPsLen        :: !Int
+  , wsBindings      :: !(IM.IntMap Value)
+  , wsCutBar        :: !Int
+  , wsCode          :: !(Array Int Instruction)
+  , wsLabels        :: !(Map.Map String Int)
+  , wsBuilder       :: !Builder
+  , wsVarCounter    :: !Int
+  , wsAggAccum      :: ![Value]
+  , wsForeignFacts  :: !(Map.Map String (Map.Map String [String]))
+  , wsForeignConfig :: !(Map.Map String Int)
+  } deriving (Show)
+```
+
+17 fields. Every record-update expression `s { wsPC = ... }` allocates a
+fresh 17-field constructor, copies all field pointers, and writes the
+modified ones. With ~10⁵ steps per benchmark run, that is ~10⁵ × 17 = 1.7M
+pointer copies that are doing nothing useful.
+
+### 1.5 Instruction set
+
+```haskell
+data Instruction
+  = GetConstant Value !RegId
+  | GetVariable !RegId !RegId
+  | GetValue !RegId !RegId
+  | PutConstant Value !RegId
+  | PutVariable !RegId !RegId
+  | PutValue !RegId !RegId
+  | PutStructure String !RegId !Int    -- functor, target, arity (pre-parsed)
+  | PutList !RegId
+  | SetValue !RegId
+  | SetConstant Value
+  | Allocate
+  | Deallocate
+  | Call String !Int                   -- pre-resolution form
+  | CallResolved !Int !Int             -- post-resolution: target PC + arity
+  | Execute String
+  | Proceed
+  | BuiltinCall String Int
+  | TryMeElse String
+  | RetryMeElse String
+  | TrustMe
+  | SwitchOnConstant (Map.Map Value String)
+  | BeginAggregate String !RegId !RegId
+  | EndAggregate !RegId
+  deriving (Show, Eq)
+```
+
+`Call` survives in two cases:
+- Foreign predicates (e.g., `category_ancestor/4` → `executeForeign`) need
+  the runtime dispatch.
+- Indexed facts (`category_parent/2` → `callIndexedFact2`) need the
+  runtime dispatch.
+
+Everything else is converted to `CallResolved` once, at startup, by
+`resolveCallInstrs`.
+
+## 2. Planned: WamState hot/cold split
+
+### 2.1 Goal
+
+Eliminate the per-step allocation of a 17-field record by separating fields
+that change every step from fields that never change after initialization.
+
+### 2.2 New shapes
+
+```haskell
+-- | Read-only after initialization. Threaded as a function argument.
+data WamContext = WamContext
+  { wcCode          :: !(Array Int Instruction)
+  , wcLabels        :: !(Map.Map String Int)
+  , wcForeignFacts  :: !(Map.Map String (Map.Map String [String]))
+  , wcForeignConfig :: !(Map.Map String Int)
+  } deriving (Show)
+
+-- | Mutates per step. The thing we actually allocate on each transition.
+data WamState = WamState
+  { wsPC         :: !Int
+  , wsRegs       :: !(IM.IntMap Value)
+  , wsStack      :: ![EnvFrame]
+  , wsHeap       :: ![Value]
+  , wsHeapLen    :: !Int
+  , wsTrail      :: ![TrailEntry]
+  , wsTrailLen   :: !Int
+  , wsCP         :: !Int
+  , wsCPs        :: ![ChoicePoint]
+  , wsCPsLen     :: !Int
+  , wsBindings   :: !(IM.IntMap Value)
+  , wsCutBar     :: !Int
+  , wsBuilder    :: !Builder
+  , wsVarCounter :: !Int
+  , wsAggAccum   :: ![Value]
+  } deriving (Show)
+```
+
+`WamState` drops from 17 fields to 15. The two cold map fields
+(`wsForeignFacts`, `wsForeignConfig`) and the two read-only structural
+fields (`wsCode`, `wsLabels`) move into `WamContext`.
+
+### 2.3 Step function shape change
+
+Before:
+```haskell
+step :: WamState -> Maybe WamState
+step s = case unsafeFetchInstr (wsPC s) (wsCode s) of
+  GetConstant c rid -> ...
+  ...
+```
+
+After:
+```haskell
+step :: WamContext -> WamState -> Maybe WamState
+step !ctx !s = case unsafeFetchInstr (wsPC s) (wcCode ctx) of
+  GetConstant c rid -> ...
+  ...
+```
+
+The `!ctx !s` bang patterns are required: GHC must not be lazy about
+either argument or the worker/wrapper transform won't unbox the state.
+
+### 2.4 Run loop change
+
+Before:
+```haskell
+runLoop :: WamState -> Maybe WamState
+runLoop s
+  | wsPC s == 0 = Just s
+  | otherwise   = case step s of
+      Nothing -> backtrack s >>= runLoop
+      Just s' -> runLoop s'
+```
+
+After:
+```haskell
+runLoop :: WamContext -> WamState -> Maybe WamState
+runLoop !ctx !s
+  | wsPC s == 0 = Just s
+  | otherwise   = case step ctx s of
+      Nothing -> backtrack s >>= runLoop ctx
+      Just s' -> runLoop ctx s'
+```
+
+`backtrack` does *not* need the context — backtracking only touches the
+mutable state — so its signature is unchanged.
+
+### 2.5 Things that need to be edited (rough scope)
+
+The post-processing pass `apply_hashmap_rewrite` in `wam_haskell_target.pl`
+emits roughly:
+
+- `WamRuntime.hs` — `step`, `runLoop`, `backtrack`, helpers
+- `WamTypes.hs` — `WamState`, the new `WamContext`, `Instruction`
+- `Predicates.hs` — generated per-predicate code (does not touch state shape)
+- `Main.hs` — benchmark driver, builds the initial state
+
+Touchpoints inside `WamRuntime.hs`:
+- Every `case ... of` branch in `step` that currently uses `wsCode s`,
+  `wsLabels s`, `wsForeignFacts s`, or `wsForeignConfig s` must read from
+  `ctx` instead.
+- `executeForeign` and `callIndexedFact2` need the context.
+- `nativeCategoryAncestor` already takes its facts as an argument; the
+  call site needs to read from `ctx` instead of `s`.
+
+Touchpoints inside `Main.hs`:
+- The initial state setup splits into `mkContext :: ... -> WamContext`
+  and `mkState :: ... -> WamState`.
+- The query loop calls `runLoop ctx state0`.
+
+Estimated diff: ~150 lines of generator code, ~5 generated files affected.
+
+### 2.6 Expected wins
+
+The benchmark currently runs ~3.0–4.5 s wall time for 11172 paths at
+depth=10. Per-step record allocation is plausibly 15–25% of that. A win
+of "drop 0.5–1.0 s" is the realistic expectation.
+
+The bigger win is that *with the cold fields out of the way*, the next
+profile pass can see the FFI overhead clearly.
+
+### 2.7 What can go wrong
+
+- **Lazy `ctx`**: if the generator forgets `!ctx`, GHC will allocate
+  thunks for `ctx` reads inside `step`. The fix is bang patterns, but
+  the bug is silent — the program is correct, just no faster.
+- **Forgetting to update `Predicates.hs`**: the generated predicates are
+  WAM instructions and don't reference the state shape, so this should
+  be a no-op for them. Verify with `cabal build` before running benchmarks.
+- **Splitting too aggressively**: if any field that *does* change per step
+  gets put into the context, that field can't be updated and the
+  simulation is wrong. The safe rule is: if a step function ever writes
+  to it, it stays in `WamState`.
+
+## 3. Planned: FFI optimization
+
+### 3.1 Current FFI shape
+
+```haskell
+nativeCategoryAncestor
+  :: Map.Map String [String]
+  -> String   -- starting category
+  -> String   -- root we're searching toward
+  -> Int      -- max depth
+  -> Int      -- current depth
+  -> [String] -- visited (cycle detection)
+  -> [Int]    -- list of Hops counts where we hit the root
+nativeCategoryAncestor parents cat root maxDepth depth visited =
+  let directParents = fromMaybe [] (Map.lookup cat parents)
+      baseHits = [1 | p <- directParents, p == root, p `notElem` visited]
+      recHits  = if depth >= maxDepth then [] else
+        concatMap (\mid ->
+          if mid `elem` visited then []
+          else map (+1) $
+            nativeCategoryAncestor parents mid root maxDepth (depth+1) (mid : visited)
+        ) directParents
+  in baseHits ++ recHits
+```
+
+The result is consumed by `executeForeign`, which sets up a `HopsRetry`
+choice point so the WAM enumerates each Hops value via normal backtracking.
+
+### 3.2 Issues found in this shape
+
+1. **`baseHits ++ recHits` walks both lists.** Not a big deal at small
+   sizes but it does cost allocation. A difference list (`[Int] -> [Int]`)
+   or `Data.DList` would be cheaper.
+
+2. **`p `notElem` visited` is redundant for `baseHits`.** The visited
+   check has already been done by the caller before recursing, so the
+   immediate parents being checked here can never be in `visited` *as
+   the variable they were called for*. (They can still be ancestors of
+   the original starting category, which is the case the check actually
+   handles. Need to verify before removing.)
+
+3. **Building `[Int]` and then handing it to `HopsRetry`** means each
+   Hops result pays for one full WAM step round-trip back into dispatch.
+   For "give me all paths to the root" workloads where the typical
+   answer is 5–50 Hops counts, the dispatch cost of converting back is
+   non-trivial.
+
+4. **`map (+1)` allocates a fresh list per recursive call.** For deep
+   recursion this adds up. Could be inlined into the `concatMap`.
+
+5. **`directParents` is recomputed once per recursive call.** Already
+   minimal cost (it's an `IntMap`-style lookup), but could be hoisted
+   if profiling justifies it.
+
+### 3.3 Planned changes
+
+Not yet committed. Sketch:
+
+```haskell
+-- | Returns a difference list of Hops, avoiding (++) and intermediate lists.
+nativeCategoryAncestorDL
+  :: Map.Map String [String]
+  -> String -> String -> Int -> Int -> [String]
+  -> ([Int] -> [Int])
+nativeCategoryAncestorDL parents cat root maxDepth depth visited =
+  let directParents = fromMaybe [] (Map.lookup cat parents)
+      base = if any (== root) directParents then (1 :)
+             else id
+      rec  = if depth >= maxDepth then id else
+               foldr (\mid acc ->
+                 if mid `elem` visited then acc
+                 else
+                   let inner = nativeCategoryAncestorDL parents mid root maxDepth (depth+1) (mid : visited)
+                       bumped = map (+1) (inner [])  -- forced once, intentionally
+                   in (bumped ++) . acc
+               ) id directParents
+  in base . rec
+
+-- Top-level wrapper:
+nativeCategoryAncestor :: Map.Map String [String]
+                      -> String -> String -> Int
+                      -> [Int]
+nativeCategoryAncestor p c r d = nativeCategoryAncestorDL p c r d 0 [c] []
+```
+
+The structural change is small. The semantic change is zero. The win is
+that fewer intermediate lists get built.
+
+### 3.4 Bigger FFI question: do we need the WAM round-trip at all?
+
+The current path is:
+```
+WAM step → executeForeign → nativeCategoryAncestor → [Int]
+                       ↓
+                  HopsRetry CP → step → ... (WAM resumes)
+```
+
+Each `HopsRetry` consumes one element of the `[Int]` and resumes the
+WAM. For `aggregate_all(sum(W), category_ancestor(...), Sum)` the WAM is
+just summing the Hops values, which we could do entirely inside the
+foreign call:
+
+```haskell
+nativeCategoryAncestorSum :: Map.Map String [String] -> String -> String -> Int -> Int -> Int
+nativeCategoryAncestorSum parents cat root maxDepth negN =
+  sum [ (h + 1) ^^ negN | h <- nativeCategoryAncestor parents cat root maxDepth ]
+```
+
+This would skip the WAM round-trip entirely for the aggregate case. The
+risk is that it commits us to a specific aggregate shape (sum of
+power-of-Hops) that the user happens to want for the effective-distance
+benchmark. Generalizing it later means redoing the work.
+
+**Decision (deferred):** Do the difference-list cleanup first. If profile
+shows the WAM round-trip is still a bottleneck, evaluate the
+direct-aggregate approach as a separate change.
+
+## 4. Deferred: compile WAM-to-Haskell-functions
+
+This is a third path, separate from both native lowering and the current
+WAM-as-interpreter approach.
+
+### 4.1 Concept
+
+Take a WAM instruction sequence for a single predicate and emit a
+Haskell function that does the same thing without any instruction
+dispatch:
+
+```
+% Input: WAM for category_ancestor/4
+0: try_me_else 5
+1: get_constant cat1, A1
+2: get_constant root1, A2
+3: put_constant 0, A3
+4: proceed
+5: trust_me
+6: ...
+```
+
+becomes
+
+```haskell
+categoryAncestor :: WamContext -> RegId -> RegId -> RegId -> RegId -> [WamState -> WamState]
+categoryAncestor ctx a1 a2 a3 a4 = ...
+```
+
+where the function body is straight-line Haskell that mirrors the
+instruction sequence. No `case` on instructions, no `IntMap` lookups for
+register reads (the registers become Haskell `let`-bindings), no
+program counter at all for the inside of one predicate.
+
+### 4.2 What it would buy
+
+- Predicate dispatch (the `Call` / `CallResolved` instruction) becomes
+  a Haskell function call. GHC inlines it where profitable.
+- Per-predicate register reads become local lets, which GHC tracks as
+  unboxed values rather than heap allocations.
+- Loop fusion across instructions becomes possible because GHC sees
+  the whole predicate at once.
+
+### 4.3 What it would cost
+
+- A new code generator path. Different output shape, different bug
+  surface, different test surface.
+- Backtracking needs to work *across* compiled predicates, which means
+  the choice point shape from the current WAM has to flow through the
+  compiled functions. Probably the compiled functions still take and
+  return `WamState`, just internally they don't dispatch.
+- The compile-time analysis of "which fields does this predicate read
+  vs write" is not free.
+
+### 4.4 Why it is deferred
+
+The current branch's goal is to make the WAM-as-interpreter path
+competitive. The compile-WAM-to-Haskell path is a different shape with a
+different design and a different test plan. It deserves its own design
+docs and its own branch.
+
+The expected order:
+1. Land the perf branch (current)
+2. Land the WamState split (next)
+3. Land the FFI optimization (after the split)
+4. Open the compile-WAM-to-Haskell discussion separately
+
+## 5. Out of scope for this branch
+
+These are explicitly *not* in the spec for this work:
+
+- Switching to `IORef`/`STRef`/mutable arrays (see philosophy doc).
+- Adding `unsafePerformIO` to the step function.
+- A new instruction set or opcode renumbering.
+- Changes to native lowering (`haskell_target.pl`).
+- Changes to the Rust WAM target.
+- A general parser for runtime functor parsing (`PutStructureDyn` —
+  see project task #16).
+- Any change to the test or benchmark harness beyond what is needed
+  to verify the optimizations don't regress correctness.

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -540,13 +540,10 @@ step s (PutValue xn ai) =
     Just val -> Just (s { wsPC = wsPC s + 1, wsRegs = Map.insert ai val (wsRegs s) })
     Nothing -> Nothing
 
-step s (PutStructure fn ai) =
-  let arity = case break (== ''/'') (reverse fn) of
-                (ra, _:_) -> case reads (reverse ra) of [(n,"")] -> n; _ -> 0
-                _ -> 0
-  in Just (s { wsPC = wsPC s + 1
-             , wsBuilder = BuildStruct fn ai arity []
-             })
+step s (PutStructure fn ai arity) =
+  Just (s { wsPC = wsPC s + 1
+          , wsBuilder = BuildStruct fn ai arity []
+          })
 
 step s (PutList ai) =
   Just (s { wsPC = wsPC s + 1
@@ -1281,7 +1278,7 @@ data Instruction
   | PutConstant Value String
   | PutVariable String String
   | PutValue String String
-  | PutStructure String String
+  | PutStructure String String Int   -- functor, target reg, arity (pre-parsed)
   | PutList String
   | SetValue String
   | SetConstant Value
@@ -1453,7 +1450,22 @@ wam_instr_to_haskell(["put_value", Xn, Ai], Hs) :-
     format(string(Hs), 'PutValue "~w" "~w"', [CXn, CAi]).
 wam_instr_to_haskell(["put_structure", FN, Ai], Hs) :-
     clean_comma(FN, CFN), clean_comma(Ai, CAi),
-    format(string(Hs), 'PutStructure "~w" "~w"', [CFN, CAi]).
+    % Pre-parse arity from "name/N" at compile time so the runtime
+    % doesn''t need to scan the string on every PutStructure step.
+    parse_functor_arity(CFN, Arity),
+    format(string(Hs), 'PutStructure "~w" "~w" ~w', [CFN, CAi, Arity]).
+
+%% parse_functor_arity(+FunctorString, -Arity)
+%  Extract the arity from "name/N" format. Defaults to 0 if no slash.
+parse_functor_arity(FN, Arity) :-
+    atom_string(FNA, FN),
+    (   sub_atom(FNA, Before, 1, _, '/'),
+        After is Before + 1,
+        sub_atom(FNA, After, _, 0, ArityStr),
+        atom_number(ArityStr, Arity)
+    ->  true
+    ;   Arity = 0
+    ).
 wam_instr_to_haskell(["put_list", Ai], Hs) :-
     format(string(Hs), 'PutList "~w"', [Ai]).
 wam_instr_to_haskell(["set_value", Xn], Hs) :-

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -273,24 +273,21 @@ backtrack s = case wsCPs s of
               , wsCutBar   = cpCutBar cp
               } } }
   where
-    undoBinding bindings (TrailEntry key mOld)
-      | "__binding__" `isPrefixOf` key =
-          let var = drop (length "__binding__") key
-          in case mOld of
-            Just old -> Map.insert var old bindings
-            Nothing  -> Map.delete var bindings
-      | otherwise = bindings
+    undoBinding bindings (TrailEntry vid mOld) =
+      case mOld of
+        Just old -> IM.insert vid old bindings
+        Nothing  -> IM.delete vid bindings
 
 -- | Resume a builtin choice point. Tries next match, updates or pops CP.
 resumeBuiltin :: BuiltinState -> ChoicePoint -> [ChoicePoint] -> WamState -> Maybe WamState
 resumeBuiltin (FactRetry _ [] _) _ rest s =
   backtrack (s { wsCPs = rest })
-resumeBuiltin (FactRetry var (v:vs) retPC) cp rest s =
-  let newBindings = Map.insert var (Atom v) (cpBindings cp)
+resumeBuiltin (FactRetry vid (v:vs) retPC) cp rest s =
+  let newBindings = IM.insert vid (Atom v) (cpBindings cp)
       newRegs = IM.insert 2 (Atom v) (cpRegs cp)
       newCPs = case vs of
         [] -> rest
-        _  -> cp { cpBuiltin = Just (FactRetry var vs retPC) } : rest
+        _  -> cp { cpBuiltin = Just (FactRetry vid vs retPC) } : rest
   in Just s { wsPC = retPC, wsRegs = newRegs, wsStack = cpStack cp
             , wsCP = cpCP cp
             , wsTrail = drop (length (wsTrail s) - cpTrailLen cp) (wsTrail s)
@@ -298,12 +295,12 @@ resumeBuiltin (FactRetry var (v:vs) retPC) cp rest s =
             , wsBindings = newBindings, wsCutBar = cpCutBar cp, wsCPs = newCPs }
 resumeBuiltin (HopsRetry _ [] _) _ rest s =
   backtrack (s { wsCPs = rest })
-resumeBuiltin (HopsRetry var (h:hs) retPC) cp rest s =
-  let newBindings = Map.insert var (Integer (fromIntegral h)) (cpBindings cp)
+resumeBuiltin (HopsRetry vid (h:hs) retPC) cp rest s =
+  let newBindings = IM.insert vid (Integer (fromIntegral h)) (cpBindings cp)
       newRegs = IM.insert 3 (Integer (fromIntegral h)) (cpRegs cp)
       newCPs = case hs of
         [] -> rest
-        _  -> cp { cpBuiltin = Just (HopsRetry var hs retPC) } : rest
+        _  -> cp { cpBuiltin = Just (HopsRetry vid hs retPC) } : rest
   in Just s { wsPC = retPC, wsRegs = newRegs, wsStack = cpStack cp
             , wsCP = cpCP cp
             , wsTrail = drop (length (wsTrail s) - cpTrailLen cp) (wsTrail s)
@@ -342,10 +339,10 @@ finalizeAggregate returnPC s = go (wsCPs s)
             regs0 = cpRegs cp
             resVal = derefVar bindings0 <$> IM.lookup resReg regs0
             (regs1, bindings1, trail1) = case resVal of
-              Just (Unbound var) ->
+              Just (Unbound vid) ->
                 ( IM.insert resReg result regs0
-                , Map.insert var result bindings0
-                , TrailEntry ("__binding__" ++ var) (Map.lookup var bindings0)
+                , IM.insert vid result bindings0
+                , TrailEntry vid (IM.lookup vid bindings0)
                     : take (cpTrailLen cp) (wsTrail s)
                 )
               _ -> (regs0, bindings0, take (cpTrailLen cp) (wsTrail s))
@@ -404,14 +401,14 @@ callIndexedFact2 pred s =
     Nothing -> Nothing
     Just factIndex ->
       let a1 = derefVar (wsBindings s) $ fromMaybe (Atom "") (IM.lookup 1 (wsRegs s))
-          a2 = derefVar (wsBindings s) $ fromMaybe (Unbound "_") (IM.lookup 2 (wsRegs s))
+          a2 = derefVar (wsBindings s) $ fromMaybe (Unbound (-1)) (IM.lookup 2 (wsRegs s))
       in case a1 of
         Atom key -> case Map.lookup key factIndex of
           Just (v:rest) -> case a2 of
-            Unbound var ->
+            Unbound vid ->
               let newRegs = IM.insert 2 (Atom v) (wsRegs s)
-                  newBindings = Map.insert var (Atom v) (wsBindings s)
-                  newTrail = TrailEntry ("__binding__" ++ var) (Map.lookup var (wsBindings s)) : wsTrail s
+                  newBindings = IM.insert vid (Atom v) (wsBindings s)
+                  newTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
                   newCPs = case rest of
                     [] -> wsCPs s  -- single match, no CP
                     _  -> ChoicePoint
@@ -419,7 +416,7 @@ callIndexedFact2 pred s =
                             , cpCP = wsCP s, cpTrailLen = length (wsTrail s)
                             , cpHeapLen = length (wsHeap s), cpBindings = wsBindings s
                             , cpCutBar = wsCutBar s, cpAggFrame = Nothing
-                            , cpBuiltin = Just (FactRetry var rest retPC)
+                            , cpBuiltin = Just (FactRetry vid rest retPC)
                             } : wsCPs s
               in Just (s { wsPC = retPC, wsRegs = newRegs, wsBindings = newBindings
                          , wsTrail = newTrail, wsCPs = newCPs })
@@ -444,14 +441,14 @@ executeForeign "category_ancestor/4" s =
       let visitedStrs = Set.fromList [v | Atom v <- visitedVals]
           hops = nativeCategoryAncestor parents catS rootS maxD (Set.size visitedStrs) visitedStrs
           retPC = wsCP s
-          hopsReg = derefVar (wsBindings s) $ fromMaybe (Unbound "_") (IM.lookup 3 (wsRegs s))
+          hopsReg = derefVar (wsBindings s) $ fromMaybe (Unbound (-1)) (IM.lookup 3 (wsRegs s))
           bindHop hopVal =
             case hopsReg of
-              Unbound var ->
+              Unbound vid ->
                 s { wsPC = retPC
                   , wsRegs = IM.insert 3 (Integer (fromIntegral hopVal)) (wsRegs s)
-                  , wsBindings = Map.insert var (Integer (fromIntegral hopVal)) (wsBindings s)
-                  , wsTrail = TrailEntry ("__binding__" ++ var) (Map.lookup var (wsBindings s)) : wsTrail s }
+                  , wsBindings = IM.insert vid (Integer (fromIntegral hopVal)) (wsBindings s)
+                  , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s }
               _ -> s { wsPC = retPC, wsRegs = IM.insert 3 (Integer (fromIntegral hopVal)) (wsRegs s) }
       in case hops of
         [] -> Nothing
@@ -459,7 +456,7 @@ executeForeign "category_ancestor/4" s =
         (h:restHops) ->
           let s1 = bindHop h
               -- Single HopsRetry CP for all remaining matches (self-popping)
-              hopsVar = case hopsReg of { Unbound v -> v; _ -> "" }
+              hopsVar = case hopsReg of { Unbound v -> v; _ -> -1 }
               cp = ChoicePoint
                 { cpNextPC = retPC, cpRegs = wsRegs s, cpStack = wsStack s
                 , cpCP = wsCP s, cpTrailLen = length (wsTrail s)
@@ -473,15 +470,15 @@ executeForeign _ _ = Nothing
 
 -- | Unify two values, binding unbound variables.
 unifyVal :: Value -> Value -> WamState -> Maybe WamState
-unifyVal (Unbound v) val s =
+unifyVal (Unbound vid) val s =
   Just (s { wsPC = wsPC s + 1
-          , wsBindings = Map.insert v val (wsBindings s)
-          , wsTrail = TrailEntry ("__binding__" ++ v) (Map.lookup v (wsBindings s)) : wsTrail s
+          , wsBindings = IM.insert vid val (wsBindings s)
+          , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
           })
-unifyVal val (Unbound v) s =
+unifyVal val (Unbound vid) s =
   Just (s { wsPC = wsPC s + 1
-          , wsBindings = Map.insert v val (wsBindings s)
-          , wsTrail = TrailEntry ("__binding__" ++ v) (Map.lookup v (wsBindings s)) : wsTrail s
+          , wsBindings = IM.insert vid val (wsBindings s)
+          , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
           })
 unifyVal a b s | a == b = Just (s { wsPC = wsPC s + 1 })
                | otherwise = Nothing'.
@@ -497,11 +494,11 @@ step s (GetConstant c ai) =
   let val = derefVar (wsBindings s) <$> IM.lookup ai (wsRegs s)
   in case val of
     Just v | v == c -> Just (s { wsPC = wsPC s + 1 })
-    Just (Unbound var) ->
+    Just (Unbound vid) ->
       Just (s { wsPC = wsPC s + 1
               , wsRegs = IM.insert ai c (wsRegs s)
-              , wsBindings = Map.insert var c (wsBindings s)
-              , wsTrail = TrailEntry ("__binding__" ++ var) (Map.lookup var (wsBindings s)) : wsTrail s
+              , wsBindings = IM.insert vid c (wsBindings s)
+              , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
               })
     _ -> Nothing
 
@@ -516,11 +513,11 @@ step s (GetValue xn ai) =
       vx = getReg xn s
   in case (va, vx) of
     (Just a, Just x) | a == x -> Just (s { wsPC = wsPC s + 1 })
-    (Just (Unbound n), Just x) ->
+    (Just (Unbound vid), Just x) ->
       Just (s { wsPC = wsPC s + 1
               , wsRegs = IM.insert ai x (wsRegs s)
-              , wsBindings = Map.insert n x (wsBindings s)
-              , wsTrail = TrailEntry ("__binding__" ++ n) (Map.lookup n (wsBindings s)) : wsTrail s
+              , wsBindings = IM.insert vid x (wsBindings s)
+              , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
               })
     _ -> Nothing
 
@@ -528,11 +525,12 @@ step s (PutConstant c ai) =
   Just (s { wsPC = wsPC s + 1, wsRegs = IM.insert ai c (wsRegs s) })
 
 step s (PutVariable xn ai) =
-  let var = Unbound ("_V" ++ show (wsVarCounter s))
+  let vid = wsVarCounter s
+      var = Unbound vid
       s1 = putReg xn var s
   in Just (s1 { wsPC = wsPC s + 1
               , wsRegs = IM.insert ai var (wsRegs s1)
-              , wsVarCounter = wsVarCounter s + 1
+              , wsVarCounter = vid + 1
               })
 
 step s (PutValue xn ai) =
@@ -620,12 +618,12 @@ step s (BuiltinCall "is/2" _) =
       result = evalArith (wsBindings s) expr
       lhs = derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s)
   in case (lhs, result) of
-    (Just (Unbound var), Just r) ->
+    (Just (Unbound vid), Just r) ->
       let val = if fromIntegral (round r :: Int) == r then Integer (round r) else Float r
       in Just (s { wsPC = wsPC s + 1
                  , wsRegs = IM.insert 1 val (wsRegs s)
-                 , wsBindings = Map.insert var val (wsBindings s)
-                 , wsTrail = TrailEntry ("__binding__" ++ var) (Map.lookup var (wsBindings s)) : wsTrail s
+                 , wsBindings = IM.insert vid val (wsBindings s)
+                 , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
                  })
     (Just (Integer n), Just r) | fromIntegral n == r -> Just (s { wsPC = wsPC s + 1 })
     _ -> Nothing
@@ -637,12 +635,12 @@ step s (BuiltinCall "length/2" _) =
       let len = length items
           lhs = derefVar (wsBindings s) <$> IM.lookup 2 (wsRegs s)
       in case lhs of
-        Just (Unbound var) ->
+        Just (Unbound vid) ->
           let val = Integer len
           in Just (s { wsPC = wsPC s + 1
                      , wsRegs = IM.insert 2 val (wsRegs s)
-                     , wsBindings = Map.insert var val (wsBindings s)
-                     , wsTrail = TrailEntry ("__binding__" ++ var) (Map.lookup var (wsBindings s)) : wsTrail s
+                     , wsBindings = IM.insert vid val (wsBindings s)
+                     , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
                      })
         Just (Integer n) | n == len -> Just (s { wsPC = wsPC s + 1 })
         _ -> Nothing
@@ -688,7 +686,7 @@ step s (BuiltinCall ">/2" _) =
 
 -- member/2 builtin: A1=Elem, A2=List. Creates choice points for backtracking.
 step s (BuiltinCall "member/2" _) =
-  let elem_ = derefVar (wsBindings s) $ fromMaybe (Unbound "_") (IM.lookup 1 (wsRegs s))
+  let elem_ = derefVar (wsBindings s) $ fromMaybe (Unbound (-1)) (IM.lookup 1 (wsRegs s))
       list_ = derefVar (wsBindings s) $ fromMaybe (VList []) (IM.lookup 2 (wsRegs s))
   in case list_ of
     VList (x:_) -> unifyVal elem_ x s
@@ -961,12 +959,13 @@ main = do
     -- computation BEFORE timing endpoint, otherwise lazy evaluation will
     -- defer the work until output and the timing will be artificially low.
     seedResultsForced <- mapM (\\cat -> do
-        let s0 = (emptyState mergedCode mergedLabels)
+        let hopsVarId = 1000000  -- reserved query var ID, won''t collide with wsVarCounter
+            s0 = (emptyState mergedCode mergedLabels)
                 { wsPC = fromMaybe 1 $ Map.lookup "category_ancestor/4" mergedLabels
                 , wsRegs = IM.fromList
                     [ (1, Atom cat)
                     , (2, Atom root)
-                    , (3, Unbound "Hops")
+                    , (3, Unbound hopsVarId)
                     , (4, VList [Atom cat])
                     ]
                 , wsCP = 0
@@ -1017,13 +1016,14 @@ main = do
 showFFloat6 :: Double -> String
 showFFloat6 x = Numeric.showFFloat (Just 6) x ""
 
--- | Collect all Hops solutions from a query by repeated run + backtrack.
+-- | Collect all Hops solutions by reading A3 (hops register) after each run.
+-- A3 holds the hops result from category_ancestor/4.
 collectSolutions :: WamState -> [Double]
 collectSolutions s0 =
     case run s0 of
       Nothing -> []
       Just s1 ->
-        let hopsVal = case Map.lookup "Hops" (wsBindings s1) of
+        let hopsVal = case IM.lookup 3 (wsRegs s1) of
               Just v -> extractDouble (derefVar (wsBindings s1) v)
               Nothing -> Nothing
             hops = fromMaybe 0 hopsVal
@@ -1032,7 +1032,7 @@ collectSolutions s0 =
               Nothing -> []
         in case hopsVal of
           Just _ -> hops : rest
-          Nothing -> rest  -- skip solutions where Hops is not bound
+          Nothing -> rest
 
 -- | Extract a Double from a Value.
 extractDouble :: Value -> Maybe Double
@@ -1088,15 +1088,15 @@ import WamTypes
 ~w
 
 -- | Dereference an Unbound variable through the binding table.
-derefVar :: Map.Map String Value -> Value -> Value
-derefVar bindings (Unbound name) =
-  case Map.lookup name bindings of
+derefVar :: IM.IntMap Value -> Value -> Value
+derefVar bindings (Unbound vid) =
+  case IM.lookup vid bindings of
     Just val -> derefVar bindings val
-    Nothing  -> Unbound name
+    Nothing  -> Unbound vid
 derefVar _ v = v
 
 -- | Evaluate arithmetic expression.
-evalArith :: Map.Map String Value -> Value -> Maybe Double
+evalArith :: IM.IntMap Value -> Value -> Maybe Double
 evalArith _ (Integer n) = Just (fromIntegral n)
 evalArith _ (Float f) = Just f
 evalArith bindings (Atom s) = case reads s of
@@ -1211,14 +1211,14 @@ data Value = Atom String
            | Float Double
            | VList [Value]
            | Str String [Value]
-           | Unbound String
+           | Unbound !Int   -- variable ID (interned via wsVarCounter)
            | Ref Int
            deriving (Eq, Ord, Show)
 
 data EnvFrame = EnvFrame !Int !(IM.IntMap Value)   -- saved CP + Y-regs (IntMap)
               deriving (Show)
 
-data TrailEntry = TrailEntry !String !(Maybe Value)
+data TrailEntry = TrailEntry !Int !(Maybe Value)   -- variable ID, old value
                 deriving (Show)
 
 data ChoicePoint = ChoicePoint
@@ -1228,7 +1228,7 @@ data ChoicePoint = ChoicePoint
   , cpCP       :: !Int
   , cpTrailLen :: !Int
   , cpHeapLen  :: !Int
-  , cpBindings :: !(Map.Map String Value)
+  , cpBindings :: !(IM.IntMap Value)    -- IntMap (variable bindings)
   , cpCutBar   :: !Int
   , cpAggFrame :: !(Maybe AggFrame)
   , cpBuiltin  :: !(Maybe BuiltinState)
@@ -1236,8 +1236,8 @@ data ChoicePoint = ChoicePoint
 
 -- | Builtin state for choice points that need custom retry logic.
 data BuiltinState
-  = FactRetry !String ![String] !Int  -- varName, remaining values, returnPC
-  | HopsRetry !String ![Int] !Int     -- varName, remaining Hops values, returnPC
+  = FactRetry !Int ![String] !Int  -- variable ID, remaining values, returnPC
+  | HopsRetry !Int ![Int] !Int     -- variable ID, remaining Hops values, returnPC
   deriving (Show)
 
 -- | Aggregate frame for begin_aggregate/end_aggregate.
@@ -1256,16 +1256,16 @@ data Builder = BuildStruct !String !Int !Int ![Value]  -- functor, target reg ID
 
 data WamState = WamState
   { wsPC       :: !Int
-  , wsRegs     :: !(IM.IntMap Value)                         -- IntMap for O(1) integer key access
+  , wsRegs     :: !(IM.IntMap Value)                         -- registers (Int keys)
   , wsStack    :: ![EnvFrame]
   , wsHeap     :: ![Value]
   , wsTrail    :: ![TrailEntry]
   , wsCP       :: !Int
   , wsCPs      :: ![ChoicePoint]
-  , wsBindings :: !(Map.Map String Value)
+  , wsBindings :: !(IM.IntMap Value)                         -- variable bindings (Int keys)
   , wsCutBar   :: !Int
   , wsCode     :: !(Array Int Instruction)
-  , wsLabels   :: !(Map.Map String Int)
+  , wsLabels   :: !(Map.Map String Int)                      -- labels stay String-keyed (cold)
   , wsBuilder  :: !Builder
   , wsVarCounter :: !Int
   , wsAggAccum :: ![Value]
@@ -1316,7 +1316,7 @@ emptyState codeList labels = let n = length codeList; code = listArray (1, n) co
   , wsTrail    = []
   , wsCP       = 0
   , wsCPs      = []
-  , wsBindings = Map.empty
+  , wsBindings = IM.empty
   , wsCutBar   = 0
   , wsCode     = code
   , wsLabels   = labels

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -261,14 +261,17 @@ backtrack s = case wsCPs s of
     case cpBuiltin cp of { Just bs -> resumeBuiltin bs cp rest s; Nothing ->
     -- 3. Normal: restore from CP
     let trailLen = cpTrailLen cp
-        newEntries = reverse $ take (length (wsTrail s) - trailLen) (wsTrail s)
+        diff = wsTrailLen s - trailLen
+        newEntries = reverse $ take diff (wsTrail s)
         restoredBindings = foldl'' undoBinding (cpBindings cp) newEntries
     in Just s { wsPC       = cpNextPC cp
               , wsRegs     = cpRegs cp
               , wsStack    = cpStack cp
               , wsCP       = cpCP cp
-              , wsTrail    = drop (length (wsTrail s) - trailLen) (wsTrail s)
+              , wsTrail    = drop diff (wsTrail s)
+              , wsTrailLen = trailLen
               , wsHeap     = take (cpHeapLen cp) (wsHeap s)
+              , wsHeapLen  = cpHeapLen cp
               , wsBindings = restoredBindings
               , wsCutBar   = cpCutBar cp
               } } }
@@ -288,10 +291,13 @@ resumeBuiltin (FactRetry vid (v:vs) retPC) cp rest s =
       newCPs = case vs of
         [] -> rest
         _  -> cp { cpBuiltin = Just (FactRetry vid vs retPC) } : rest
+      diff = wsTrailLen s - cpTrailLen cp
   in Just s { wsPC = retPC, wsRegs = newRegs, wsStack = cpStack cp
             , wsCP = cpCP cp
-            , wsTrail = drop (length (wsTrail s) - cpTrailLen cp) (wsTrail s)
+            , wsTrail = drop diff (wsTrail s)
+            , wsTrailLen = cpTrailLen cp
             , wsHeap = take (cpHeapLen cp) (wsHeap s)
+            , wsHeapLen = cpHeapLen cp
             , wsBindings = newBindings, wsCutBar = cpCutBar cp, wsCPs = newCPs }
 resumeBuiltin (HopsRetry _ [] _) _ rest s =
   backtrack (s { wsCPs = rest })
@@ -301,10 +307,13 @@ resumeBuiltin (HopsRetry vid (h:hs) retPC) cp rest s =
       newCPs = case hs of
         [] -> rest
         _  -> cp { cpBuiltin = Just (HopsRetry vid hs retPC) } : rest
+      diff = wsTrailLen s - cpTrailLen cp
   in Just s { wsPC = retPC, wsRegs = newRegs, wsStack = cpStack cp
             , wsCP = cpCP cp
-            , wsTrail = drop (length (wsTrail s) - cpTrailLen cp) (wsTrail s)
+            , wsTrail = drop diff (wsTrail s)
+            , wsTrailLen = cpTrailLen cp
             , wsHeap = take (cpHeapLen cp) (wsHeap s)
+            , wsHeapLen = cpHeapLen cp
             , wsBindings = newBindings, wsCutBar = cpCutBar cp, wsCPs = newCPs }
 
 -- | Backtrack skipping past the aggregate_frame CP. If the top CP is
@@ -338,20 +347,25 @@ finalizeAggregate returnPC s = go (wsCPs s)
             bindings0 = cpBindings cp
             regs0 = cpRegs cp
             resVal = derefVar bindings0 <$> IM.lookup resReg regs0
-            (regs1, bindings1, trail1) = case resVal of
+            -- Restore trail to the CP''s snapshot (drop entries added since)
+            diff = wsTrailLen s - cpTrailLen cp
+            restoredTrail = drop diff (wsTrail s)
+            (regs1, bindings1, trail1, trail1Len) = case resVal of
               Just (Unbound vid) ->
                 ( IM.insert resReg result regs0
                 , IM.insert vid result bindings0
-                , TrailEntry vid (IM.lookup vid bindings0)
-                    : take (cpTrailLen cp) (wsTrail s)
+                , TrailEntry vid (IM.lookup vid bindings0) : restoredTrail
+                , cpTrailLen cp + 1
                 )
-              _ -> (regs0, bindings0, take (cpTrailLen cp) (wsTrail s))
+              _ -> (regs0, bindings0, restoredTrail, cpTrailLen cp)
         in Just s { wsPC = returnPC
                   , wsRegs = regs1
                   , wsStack = cpStack cp
                   , wsBindings = bindings1
                   , wsTrail = trail1
+                  , wsTrailLen = trail1Len
                   , wsHeap = take (cpHeapLen cp) (wsHeap s)
+                  , wsHeapLen = cpHeapLen cp
                   , wsCP = cpCP cp
                   , wsCPs = rest
                   , wsAggAccum = []
@@ -415,13 +429,13 @@ callIndexedFact2 pred s =
                     [] -> wsCPs s  -- single match, no CP
                     _  -> ChoicePoint
                             { cpNextPC = retPC, cpRegs = wsRegs s, cpStack = wsStack s
-                            , cpCP = wsCP s, cpTrailLen = length (wsTrail s)
-                            , cpHeapLen = length (wsHeap s), cpBindings = wsBindings s
+                            , cpCP = wsCP s, cpTrailLen = wsTrailLen s
+                            , cpHeapLen = wsHeapLen s, cpBindings = wsBindings s
                             , cpCutBar = wsCutBar s, cpAggFrame = Nothing
                             , cpBuiltin = Just (FactRetry vid rest retPC)
                             } : wsCPs s
               in Just (s { wsPC = retPC, wsRegs = newRegs, wsBindings = newBindings
-                         , wsTrail = newTrail, wsCPs = newCPs })
+                         , wsTrail = newTrail, wsTrailLen = wsTrailLen s + 1, wsCPs = newCPs })
             Atom existing ->
               if existing == v then Just (s { wsPC = retPC })
               else case filter (== existing) rest of
@@ -450,7 +464,8 @@ executeForeign "category_ancestor/4" s =
                 s { wsPC = retPC
                   , wsRegs = IM.insert 3 (Integer (fromIntegral hopVal)) (wsRegs s)
                   , wsBindings = IM.insert vid (Integer (fromIntegral hopVal)) (wsBindings s)
-                  , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s }
+                  , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
+                  , wsTrailLen = wsTrailLen s + 1 }
               _ -> s { wsPC = retPC, wsRegs = IM.insert 3 (Integer (fromIntegral hopVal)) (wsRegs s) }
       in case hops of
         [] -> Nothing
@@ -461,8 +476,8 @@ executeForeign "category_ancestor/4" s =
               hopsVar = case hopsReg of { Unbound v -> v; _ -> -1 }
               cp = ChoicePoint
                 { cpNextPC = retPC, cpRegs = wsRegs s, cpStack = wsStack s
-                , cpCP = wsCP s, cpTrailLen = length (wsTrail s)
-                , cpHeapLen = length (wsHeap s), cpBindings = wsBindings s
+                , cpCP = wsCP s, cpTrailLen = wsTrailLen s
+                , cpHeapLen = wsHeapLen s, cpBindings = wsBindings s
                 , cpCutBar = wsCutBar s, cpAggFrame = Nothing
                 , cpBuiltin = Just (HopsRetry hopsVar (map fromIntegral restHops) retPC)
                 }
@@ -476,11 +491,13 @@ unifyVal (Unbound vid) val s =
   Just (s { wsPC = wsPC s + 1
           , wsBindings = IM.insert vid val (wsBindings s)
           , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
+          , wsTrailLen = wsTrailLen s + 1
           })
 unifyVal val (Unbound vid) s =
   Just (s { wsPC = wsPC s + 1
           , wsBindings = IM.insert vid val (wsBindings s)
           , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
+          , wsTrailLen = wsTrailLen s + 1
           })
 unifyVal a b s | a == b = Just (s { wsPC = wsPC s + 1 })
                | otherwise = Nothing'.
@@ -501,6 +518,7 @@ step s (GetConstant c ai) =
               , wsRegs = IM.insert ai c (wsRegs s)
               , wsBindings = IM.insert vid c (wsBindings s)
               , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
+              , wsTrailLen = wsTrailLen s + 1
               })
     _ -> Nothing
 
@@ -520,6 +538,7 @@ step s (GetValue xn ai) =
               , wsRegs = IM.insert ai x (wsRegs s)
               , wsBindings = IM.insert vid x (wsBindings s)
               , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
+              , wsTrailLen = wsTrailLen s + 1
               })
     _ -> Nothing
 
@@ -594,11 +613,11 @@ step s (TryMeElse label) =
   let nextPC = fromMaybe 0 $ Map.lookup label (wsLabels s)
       cp = ChoicePoint
         { cpNextPC   = nextPC
-        , cpRegs     = wsRegs s       -- O(1): Data.Map shared reference
-        , cpStack    = wsStack s      -- O(1): list shared reference
+        , cpRegs     = wsRegs s
+        , cpStack    = wsStack s
         , cpCP       = wsCP s
-        , cpTrailLen = length (wsTrail s)
-        , cpHeapLen  = length (wsHeap s)
+        , cpTrailLen = wsTrailLen s
+        , cpHeapLen  = wsHeapLen s
         , cpBindings = wsBindings s   -- O(1): Data.Map shared reference
         , cpCutBar   = wsCutBar s
         , cpAggFrame = Nothing, cpBuiltin = Nothing
@@ -631,6 +650,7 @@ step s (BuiltinCall "is/2" _) =
                  , wsRegs = IM.insert 1 val (wsRegs s)
                  , wsBindings = IM.insert vid val (wsBindings s)
                  , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
+                 , wsTrailLen = wsTrailLen s + 1
                  })
     (Just (Integer n), Just r) | fromIntegral n == r -> Just (s { wsPC = wsPC s + 1 })
     _ -> Nothing
@@ -648,6 +668,7 @@ step s (BuiltinCall "length/2" _) =
                      , wsRegs = IM.insert 2 val (wsRegs s)
                      , wsBindings = IM.insert vid val (wsBindings s)
                      , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
+                     , wsTrailLen = wsTrailLen s + 1
                      })
         Just (Integer n) | n == len -> Just (s { wsPC = wsPC s + 1 })
         _ -> Nothing
@@ -702,12 +723,12 @@ step s (BuiltinCall "member/2" _) =
 -- begin_aggregate: push aggregate frame CP, initialize accumulator, continue to goal body
 step s (BeginAggregate typ valReg resReg) =
   let cp = ChoicePoint
-        { cpNextPC   = wsPC s   -- not used directly; aggregate frame handles return
+        { cpNextPC   = wsPC s
         , cpRegs     = wsRegs s
         , cpStack    = wsStack s
         , cpCP       = wsCP s
-        , cpTrailLen = length (wsTrail s)
-        , cpHeapLen  = length (wsHeap s)
+        , cpTrailLen = wsTrailLen s
+        , cpHeapLen  = wsHeapLen s
         , cpBindings = wsBindings s
         , cpCutBar   = wsCutBar s
         , cpAggFrame = Just (AggFrame typ valReg resReg 0), cpBuiltin = Nothing
@@ -1295,16 +1316,18 @@ data Builder = BuildStruct !String !Int !Int ![Value]  -- functor, target reg ID
 
 data WamState = WamState
   { wsPC       :: !Int
-  , wsRegs     :: !(IM.IntMap Value)                         -- registers (Int keys)
+  , wsRegs     :: !(IM.IntMap Value)
   , wsStack    :: ![EnvFrame]
   , wsHeap     :: ![Value]
+  , wsHeapLen  :: !Int                          -- cached length(wsHeap), avoids O(n) length calls
   , wsTrail    :: ![TrailEntry]
+  , wsTrailLen :: !Int                          -- cached length(wsTrail)
   , wsCP       :: !Int
   , wsCPs      :: ![ChoicePoint]
-  , wsBindings :: !(IM.IntMap Value)                         -- variable bindings (Int keys)
+  , wsBindings :: !(IM.IntMap Value)
   , wsCutBar   :: !Int
   , wsCode     :: !(Array Int Instruction)
-  , wsLabels   :: !(Map.Map String Int)                      -- labels stay String-keyed (cold)
+  , wsLabels   :: !(Map.Map String Int)
   , wsBuilder  :: !Builder
   , wsVarCounter :: !Int
   , wsAggAccum :: ![Value]
@@ -1353,7 +1376,9 @@ emptyState codeList labels = let n = length codeList; code = listArray (1, n) co
   , wsRegs     = IM.empty
   , wsStack    = []
   , wsHeap     = []
+  , wsHeapLen  = 0
   , wsTrail    = []
+  , wsTrailLen = 0
   , wsCP       = 0
   , wsCPs      = []
   , wsBindings = IM.empty

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -1130,6 +1130,7 @@ import WamTypes
 ~w
 
 -- | Dereference an Unbound variable through the binding table.
+{-# INLINE derefVar #-}
 derefVar :: IM.IntMap Value -> Value -> Value
 derefVar bindings (Unbound vid) =
   case IM.lookup vid bindings of
@@ -1168,6 +1169,7 @@ evalArith bindings (Str op [a, b]) = do
 evalArith _ _ = Nothing
 
 -- | Get register value. Y-registers (id >= 200) come from the env frame.
+{-# INLINE getReg #-}
 getReg :: Int -> WamState -> Maybe Value
 getReg rid s
   | rid >= 200 = findYReg rid (wsStack s)
@@ -1178,6 +1180,7 @@ getReg rid s
     findYReg r (_ : rest) = findYReg r rest
 
 -- | Set register value. Y-registers go to the topmost env frame.
+{-# INLINE putReg #-}
 putReg :: Int -> Value -> WamState -> WamState
 putReg rid val s
   | rid >= 200 = s { wsStack = updateTopEnv rid val (wsStack s) }

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -377,15 +377,17 @@ applyAggregation _ vals = VList vals
 
 -- | Native category_ancestor: depth-bounded DFS over indexed parent facts.
 -- Returns all (Hops) values for paths from Cat to Root within maxDepth.
--- Uses Set for O(log n) membership check on Visited.
-nativeCategoryAncestor :: Map.Map String [String] -> String -> String -> Int -> Int -> Set.Set String -> [Int]
+-- Uses a plain list for visited because depth is bounded (typically <= 10),
+-- so O(depth) elem checks are faster than O(log n) Set operations + the
+-- per-call Set construction overhead.
+nativeCategoryAncestor :: Map.Map String [String] -> String -> String -> Int -> Int -> [String] -> [Int]
 nativeCategoryAncestor parents cat root maxDepth depth visited =
   let directParents = fromMaybe [] (Map.lookup cat parents)
-      baseHits = [1 | p <- directParents, p == root, not (Set.member p visited)]
+      baseHits = [1 | p <- directParents, p == root, p `notElem` visited]
       recHits = if depth >= maxDepth then [] else
         concatMap (\\mid ->
-          if Set.member mid visited then []
-          else map (+1) $ nativeCategoryAncestor parents mid root maxDepth (depth+1) (Set.insert mid visited)
+          if mid `elem` visited then []
+          else map (+1) $ nativeCategoryAncestor parents mid root maxDepth (depth+1) (mid : visited)
         ) directParents
   in baseHits ++ recHits
 
@@ -438,8 +440,8 @@ executeForeign "category_ancestor/4" s =
       parents = fromMaybe Map.empty $ Map.lookup "category_parent" (wsForeignFacts s)
   in case (cat, root, visited) of
     (Atom catS, Atom rootS, VList visitedVals) ->
-      let visitedStrs = Set.fromList [v | Atom v <- visitedVals]
-          hops = nativeCategoryAncestor parents catS rootS maxD (Set.size visitedStrs) visitedStrs
+      let visitedStrs = [v | Atom v <- visitedVals]
+          hops = nativeCategoryAncestor parents catS rootS maxD (length visitedStrs) visitedStrs
           retPC = wsCP s
           hopsReg = derefVar (wsBindings s) $ fromMaybe (Unbound (-1)) (IM.lookup 3 (wsRegs s))
           bindHop hopVal =
@@ -731,16 +733,19 @@ step _ _ = Nothing'.
 
 run_loop_haskell(Code) :-
     Code = '-- | Main execution loop. Runs until halt (pc=0) or failure.
+-- Uses unsafeFetchInstr to avoid Maybe wrapping in the hot path.
+-- Bounds are guaranteed by the WAM compiler: PC=0 is halt, otherwise PC
+-- always points to a valid instruction within the code array.
 run :: WamState -> Maybe WamState
 run s
   | wsPC s == 0 = Just s  -- halt
-  | otherwise = case fetchInstr (wsPC s) (wsCode s) of
-      Nothing -> Nothing
-      Just instr -> case step s instr of
-        Just s'' -> run s''
-        Nothing -> case backtrack s of
-          Just s'' -> run s''
-          Nothing -> Nothing'.
+  | otherwise =
+      let instr = unsafeFetchInstr (wsPC s) (wsCode s)
+      in case step s instr of
+           Just s'' -> run s''
+           Nothing -> case backtrack s of
+             Just s'' -> run s''
+             Nothing -> Nothing'.
 
 % ============================================================================
 % PHASE 4: Project Generation
@@ -1202,11 +1207,18 @@ addToBuilder val s = case wsBuilder s of
 lookupLabel :: String -> WamState -> Int
 lookupLabel label s = fromMaybe 0 $ Map.lookup label (wsLabels s)
 
--- | Fetch instruction at PC (1-indexed).
+-- | Fetch instruction at PC (1-indexed). Bounds-checked, returns Maybe.
 fetchInstr :: Int -> Array Int Instruction -> Maybe Instruction
 fetchInstr pc code
   | let (lo, hi) = bounds code in pc < lo || pc > hi = Nothing
   | otherwise = Just (code ! pc)
+
+-- | Unsafe fetch — no bounds check, no Maybe wrapping. Use only when the
+-- caller can prove PC is in bounds (the run loop handles PC=0 as halt
+-- separately, and a well-formed WAM program never jumps out of bounds).
+{-# INLINE unsafeFetchInstr #-}
+unsafeFetchInstr :: Int -> Array Int Instruction -> Instruction
+unsafeFetchInstr pc code = code ! pc
 
 -- | Resolve Call instructions to CallResolved by looking up labels once at
 -- project load time. Calls to predicates that have foreign/indexed handlers

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -556,6 +556,11 @@ step s (SetValue xn) =
 step s (SetConstant c) =
   addToBuilder c s
 
+-- Fast path: call has been pre-resolved to a target PC at load time.
+-- No string lookup, no foreign/indexed dispatch — just a jump.
+step s (CallResolved pc _arity) =
+  Just (s { wsPC = pc, wsCP = wsPC s + 1 })
+
 step s (Call pred _arity) =
   let sc = s { wsCP = wsPC s + 1 }
   in case executeForeign pred sc of
@@ -942,9 +947,15 @@ main = do
         acEnd = cpEnd + length acCode
         (rcCode, rcLabels) = buildFact1Code "root_category" roots (acEnd + 1)
 
-        mergedCode = allCode ++ cpCode ++ acCode ++ rcCode
+        mergedCodeRaw = allCode ++ cpCode ++ acCode ++ rcCode
         mergedLabels = Map.union allLabels
                      $ Map.fromList (cpLabels ++ acLabels ++ rcLabels)
+        -- Pre-resolve Call instructions to CallResolved at startup so the
+        -- hot path skips wsLabels string lookups. Foreign/indexed predicates
+        -- are kept as Call so runtime dispatch (executeForeign/callIndexedFact2)
+        -- still applies.
+        foreignPreds = ["category_ancestor/4"]
+        mergedCode = resolveCallInstrs mergedLabels foreignPreds mergedCodeRaw
 
     -- Collect seed categories
     let seedCats = nub $ sort $ map snd articleCategories
@@ -1196,6 +1207,22 @@ fetchInstr :: Int -> Array Int Instruction -> Maybe Instruction
 fetchInstr pc code
   | let (lo, hi) = bounds code in pc < lo || pc > hi = Nothing
   | otherwise = Just (code ! pc)
+
+-- | Resolve Call instructions to CallResolved by looking up labels once at
+-- project load time. Calls to predicates that have foreign/indexed handlers
+-- (e.g., category_ancestor/4 via FFI, category_parent/2 via indexed facts)
+-- are LEFT as Call so the runtime dispatch chain still applies. Only Call
+-- targets that have a matching label and no foreign/indexed override are
+-- pre-resolved to a direct PC jump.
+resolveCallInstrs :: Map.Map String Int -> [String] -> [Instruction] -> [Instruction]
+resolveCallInstrs labels foreignPreds = map resolve
+  where
+    resolve (Call pred arity)
+      | pred `elem` foreignPreds = Call pred arity   -- keep dispatch
+      | otherwise = case Map.lookup pred labels of
+          Just pc -> CallResolved pc arity
+          Nothing -> Call pred arity   -- unresolvable, leave as-is
+    resolve i = i
 ', [StepCode, BacktrackCode, RunCode]).
 
 %% generate_wam_types_hs(-Code)
@@ -1294,7 +1321,8 @@ data Instruction
   | SetConstant Value
   | Allocate
   | Deallocate
-  | Call String !Int
+  | Call String !Int                  -- pre-resolution form (string-keyed)
+  | CallResolved !Int !Int            -- post-resolution: target PC + arity
   | Execute String
   | Proceed
   | BuiltinCall String !Int

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -757,34 +757,89 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     directory_file_path(ProjectDir, 'src', SrcDir),
     make_directory_path(SrcDir),
 
+    % Determine map backend: HashMap (faster) or Map (default fallback)
+    option(use_hashmap(UseHM), Options, true),
+
     % Generate WamTypes.hs
-    generate_wam_types_hs(TypesCode),
+    generate_wam_types_hs(TypesCode0),
+    apply_hashmap_rewrite(UseHM, types, TypesCode0, TypesCode),
     directory_file_path(SrcDir, 'WamTypes.hs', TypesPath),
     write_hs_file(TypesPath, TypesCode),
 
     % Generate WamRuntime.hs
-    compile_wam_runtime_to_haskell(Options, RuntimeCode),
+    compile_wam_runtime_to_haskell(Options, RuntimeCode0),
+    apply_hashmap_rewrite(UseHM, runtime, RuntimeCode0, RuntimeCode),
     directory_file_path(SrcDir, 'WamRuntime.hs', RuntimePath),
     write_hs_file(RuntimePath, RuntimeCode),
 
     % Compile predicates
-    compile_predicates_to_haskell(Predicates, Options, PredsCode),
+    compile_predicates_to_haskell(Predicates, Options, PredsCode0),
+    apply_hashmap_rewrite(UseHM, generic, PredsCode0, PredsCode),
     directory_file_path(SrcDir, 'Predicates.hs', PredsPath),
     write_hs_file(PredsPath, PredsCode),
 
     % Generate cabal file
     option(module_name(ModName), Options, 'wam-haskell-bench'),
-    generate_cabal_file(ModName, CabalCode),
+    generate_cabal_file(ModName, UseHM, CabalCode),
     format(atom(CabalFile), '~w.cabal', [ModName]),
     directory_file_path(ProjectDir, CabalFile, CabalPath),
     write_hs_file(CabalPath, CabalCode),
 
     % Generate Main.hs
-    generate_main_hs(Predicates, MainCode),
+    generate_main_hs(Predicates, MainCode0),
+    apply_hashmap_rewrite(UseHM, main, MainCode0, MainCode),
     directory_file_path(SrcDir, 'Main.hs', MainPath),
     write_hs_file(MainPath, MainCode),
 
-    format(user_error, '[WAM-Haskell] Generated project at: ~w~n', [ProjectDir]).
+    format(user_error, '[WAM-Haskell] Generated project at: ~w (hashmap=~w)~n', [ProjectDir, UseHM]).
+
+%% apply_hashmap_rewrite(+UseHM, +Module, +InCode, -OutCode)
+%  When UseHM=true, rewrite Data.Map.Strict references to Data.HashMap.Strict.
+apply_hashmap_rewrite(false, _, Code, Code) :- !.
+apply_hashmap_rewrite(true, Module, Code0, Code) :-
+    % Replace import line
+    replace_substr(Code0, "import qualified Data.Map.Strict as Map",
+                   "import qualified Data.HashMap.Strict as Map", Code1),
+    % Replace Map.Map type constructor with Map.HashMap
+    replace_substr(Code1, "Map.Map ", "Map.HashMap ", Code2),
+    % HashMap has no toAscList — use toList instead (loses ordering, but
+    % the only use site builds a SwitchOnConstant which doesn''t need it)
+    replace_substr(Code2, "Map.toAscList", "Map.toList", Code3),
+    % For WamTypes, add Hashable instance for Value (needed for HashMap keys)
+    (   Module == types
+    ->  replace_substr(Code3,
+            "module WamTypes where\n\nimport qualified Data.HashMap.Strict as Map",
+            "{-# LANGUAGE DeriveGeneric #-}\nmodule WamTypes where\n\nimport qualified Data.HashMap.Strict as Map\nimport Data.Hashable (Hashable)\nimport GHC.Generics (Generic)",
+            Code4),
+        replace_substr(Code4,
+            "deriving (Eq, Ord, Show)",
+            "deriving (Eq, Ord, Show, Generic)\ninstance Hashable Value",
+            Code)
+    ;   Code = Code3
+    ).
+
+%% replace_substr(+Str, +From, +To, -Result)
+%  Replace all occurrences of From with To in Str.
+replace_substr(Str, From, To, Result) :-
+    atom_string(Str, S),
+    atom_string(From, FS),
+    atom_string(To, TS),
+    split_string(S, "", "", [_]),  % normalize
+    re_split_replace(S, FS, TS, R),
+    atom_string(Result, R).
+
+re_split_replace(S, From, To, Result) :-
+    (   sub_string(S, B, L, A, From)
+    ->  sub_string(S, 0, B, _, Before),
+        sub_string(S, _, A, 0, After),
+        re_split_replace(After, From, To, AfterR),
+        atom_string(BeforeA, Before),
+        atom_string(ToA, To),
+        atom_string(AfterRA, AfterR),
+        atomic_list_concat([BeforeA, ToA, AfterRA], R),
+        atom_string(R, Result)
+    ;   Result = S
+    ).
 
 %% generate_main_hs(+Predicates, -Code)
 %  Generates Main.hs — a benchmark driver for effective-distance.
@@ -1266,8 +1321,12 @@ emptyState codeList labels = let n = length codeList; code = listArray (1, n) co
   }
 '.
 
-%% generate_cabal_file(+Name, -Code)
-generate_cabal_file(Name, Code) :-
+%% generate_cabal_file(+Name, +UseHM, -Code)
+generate_cabal_file(Name, UseHM, Code) :-
+    (   UseHM == true
+    ->  Deps = "base >= 4.12, containers >= 0.6, array, time >= 1.8, unordered-containers >= 0.2, hashable >= 1.2"
+    ;   Deps = "base >= 4.12, containers >= 0.6, array, time >= 1.8"
+    ),
     format(string(Code),
 'cabal-version: 2.4
 name:          ~w
@@ -1278,10 +1337,10 @@ executable ~w
   main-is:          Main.hs
   hs-source-dirs:   src
   other-modules:    WamTypes, WamRuntime, Predicates
-  build-depends:    base >= 4.14, containers >= 0.6, array, time >= 1.8
+  build-depends:    ~w
   default-language: Haskell2010
   ghc-options:      -O2
-', [Name, Name]).
+', [Name, Name, Deps]).
 
 %% compile_predicates_to_haskell(+Predicates, +Options, -Code)
 %  Compiles all predicates into a single merged code array and label map,

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -284,7 +284,7 @@ backtrack s = case wsCPs s of
 -- | Resume a builtin choice point. Tries next match, updates or pops CP.
 resumeBuiltin :: BuiltinState -> ChoicePoint -> [ChoicePoint] -> WamState -> Maybe WamState
 resumeBuiltin (FactRetry _ [] _) _ rest s =
-  backtrack (s { wsCPs = rest })
+  backtrack (s { wsCPs = rest, wsCPsLen = wsCPsLen s - 1 })
 resumeBuiltin (FactRetry vid (v:vs) retPC) cp rest s =
   let newBindings = IM.insert vid (Atom v) (cpBindings cp)
       newRegs = IM.insert 2 (Atom v) (cpRegs cp)
@@ -300,7 +300,7 @@ resumeBuiltin (FactRetry vid (v:vs) retPC) cp rest s =
             , wsHeapLen = cpHeapLen cp
             , wsBindings = newBindings, wsCutBar = cpCutBar cp, wsCPs = newCPs }
 resumeBuiltin (HopsRetry _ [] _) _ rest s =
-  backtrack (s { wsCPs = rest })
+  backtrack (s { wsCPs = rest, wsCPsLen = wsCPsLen s - 1 })
 resumeBuiltin (HopsRetry vid (h:hs) retPC) cp rest s =
   let newBindings = IM.insert vid (Integer (fromIntegral h)) (cpBindings cp)
       newRegs = IM.insert 3 (Integer (fromIntegral h)) (cpRegs cp)
@@ -368,6 +368,7 @@ finalizeAggregate returnPC s = go (wsCPs s)
                   , wsHeapLen = cpHeapLen cp
                   , wsCP = cpCP cp
                   , wsCPs = rest
+                  , wsCPsLen = wsCPsLen s - 1
                   , wsAggAccum = []
                   }
       Nothing -> go rest  -- skip non-aggregate CPs
@@ -434,8 +435,10 @@ callIndexedFact2 pred s =
                             , cpCutBar = wsCutBar s, cpAggFrame = Nothing
                             , cpBuiltin = Just (FactRetry vid rest retPC)
                             } : wsCPs s
+                  newCPsLen = case rest of { [] -> wsCPsLen s; _ -> wsCPsLen s + 1 }
               in Just (s { wsPC = retPC, wsRegs = newRegs, wsBindings = newBindings
-                         , wsTrail = newTrail, wsTrailLen = wsTrailLen s + 1, wsCPs = newCPs })
+                         , wsTrail = newTrail, wsTrailLen = wsTrailLen s + 1
+                         , wsCPs = newCPs, wsCPsLen = newCPsLen })
             Atom existing ->
               if existing == v then Just (s { wsPC = retPC })
               else case filter (== existing) rest of
@@ -481,7 +484,7 @@ executeForeign "category_ancestor/4" s =
                 , cpCutBar = wsCutBar s, cpAggFrame = Nothing
                 , cpBuiltin = Just (HopsRetry hopsVar (map fromIntegral restHops) retPC)
                 }
-          in Just (s1 { wsCPs = cp : wsCPs s })
+          in Just (s1 { wsCPs = cp : wsCPs s, wsCPsLen = wsCPsLen s + 1 })
     _ -> Nothing
 executeForeign _ _ = Nothing
 
@@ -601,7 +604,7 @@ step s Allocate =
   let frame = EnvFrame (wsCP s) IM.empty
   in Just (s { wsPC = wsPC s + 1
              , wsStack = frame : wsStack s
-             , wsCutBar = length (wsCPs s)
+             , wsCutBar = wsCPsLen s
              })
 
 step s Deallocate =
@@ -618,15 +621,15 @@ step s (TryMeElse label) =
         , cpCP       = wsCP s
         , cpTrailLen = wsTrailLen s
         , cpHeapLen  = wsHeapLen s
-        , cpBindings = wsBindings s   -- O(1): Data.Map shared reference
+        , cpBindings = wsBindings s
         , cpCutBar   = wsCutBar s
         , cpAggFrame = Nothing, cpBuiltin = Nothing
         }
-  in Just (s { wsPC = wsPC s + 1, wsCPs = cp : wsCPs s })
+  in Just (s { wsPC = wsPC s + 1, wsCPs = cp : wsCPs s, wsCPsLen = wsCPsLen s + 1 })
 
 step s TrustMe =
   case wsCPs s of
-    (_ : rest) -> Just (s { wsPC = wsPC s + 1, wsCPs = rest })
+    (_ : rest) -> Just (s { wsPC = wsPC s + 1, wsCPs = rest, wsCPsLen = wsCPsLen s - 1 })
     [] -> Nothing
 
 step s (RetryMeElse label) =
@@ -637,7 +640,8 @@ step s (RetryMeElse label) =
     [] -> Nothing
 
 step s (BuiltinCall "!/0" _) =
-  Just (s { wsPC = wsPC s + 1, wsCPs = take (wsCutBar s) (wsCPs s) })
+  -- Cut: truncate wsCPs to the barrier depth saved at clause Allocate.
+  Just (s { wsPC = wsPC s + 1, wsCPs = take (wsCutBar s) (wsCPs s), wsCPsLen = wsCutBar s })
 
 step s (BuiltinCall "is/2" _) =
   let expr = derefVar (wsBindings s) $ fromMaybe (Integer 0) (IM.lookup 2 (wsRegs s))
@@ -735,6 +739,7 @@ step s (BeginAggregate typ valReg resReg) =
         }
   in Just (s { wsPC = wsPC s + 1
              , wsCPs = cp : wsCPs s
+             , wsCPsLen = wsCPsLen s + 1
              , wsAggAccum = []
              })
 
@@ -1196,19 +1201,22 @@ derefHeap _ v = Just v
 addToBuilder :: Value -> WamState -> Maybe WamState
 addToBuilder val s = case wsBuilder s of
   BuildStruct fn ai arity args ->
-    let args'' = args ++ [val]
+    -- Cons to front (O(1)) and reverse only on finalize. Track count via list length
+    -- but only when finalizing — args grows from 0 to arity, max arity is small.
+    let args'' = val : args
     in if length args'' == arity
        then Just (s { wsPC = wsPC s + 1
-                    , wsRegs = IM.insert ai (Str fn args'') (wsRegs s)
+                    , wsRegs = IM.insert ai (Str fn (reverse args'')) (wsRegs s)
                     , wsBuilder = NoBuilder
                     })
        else Just (s { wsPC = wsPC s + 1
                     , wsBuilder = BuildStruct fn ai arity args''
                     })
   BuildList ai args ->
-    let args'' = args ++ [val]
+    -- BuildList always has exactly 2 args [head, tail]
+    let args'' = val : args
     in if length args'' == 2
-       then let [hd, tl] = args''
+       then let [tl, hd] = args''   -- reversed because we cons-built
                 list = case tl of
                   VList items -> VList (hd : items)
                   Atom "[]"  -> VList [hd]
@@ -1222,7 +1230,7 @@ addToBuilder val s = case wsBuilder s of
                     })
   NoBuilder ->
     -- No builder active, just push to heap (fallback)
-    Just (s { wsPC = wsPC s + 1, wsHeap = wsHeap s ++ [val] })
+    Just (s { wsPC = wsPC s + 1, wsHeap = wsHeap s ++ [val], wsHeapLen = wsHeapLen s + 1 })
 
 -- | Lookup a label in the label map.
 lookupLabel :: String -> WamState -> Int
@@ -1324,6 +1332,7 @@ data WamState = WamState
   , wsTrailLen :: !Int                          -- cached length(wsTrail)
   , wsCP       :: !Int
   , wsCPs      :: ![ChoicePoint]
+  , wsCPsLen   :: !Int                          -- cached length(wsCPs) for cut barrier
   , wsBindings :: !(IM.IntMap Value)
   , wsCutBar   :: !Int
   , wsCode     :: !(Array Int Instruction)
@@ -1381,6 +1390,7 @@ emptyState codeList labels = let n = length codeList; code = listArray (1, n) co
   , wsTrailLen = 0
   , wsCP       = 0
   , wsCPs      = []
+  , wsCPsLen   = 0
   , wsBindings = IM.empty
   , wsCutBar   = 0
   , wsCode     = code

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -287,7 +287,7 @@ resumeBuiltin (FactRetry _ [] _) _ rest s =
   backtrack (s { wsCPs = rest })
 resumeBuiltin (FactRetry var (v:vs) retPC) cp rest s =
   let newBindings = Map.insert var (Atom v) (cpBindings cp)
-      newRegs = Map.insert "A2" (Atom v) (cpRegs cp)
+      newRegs = IM.insert 2 (Atom v) (cpRegs cp)
       newCPs = case vs of
         [] -> rest
         _  -> cp { cpBuiltin = Just (FactRetry var vs retPC) } : rest
@@ -300,7 +300,7 @@ resumeBuiltin (HopsRetry _ [] _) _ rest s =
   backtrack (s { wsCPs = rest })
 resumeBuiltin (HopsRetry var (h:hs) retPC) cp rest s =
   let newBindings = Map.insert var (Integer (fromIntegral h)) (cpBindings cp)
-      newRegs = Map.insert "A3" (Integer (fromIntegral h)) (cpRegs cp)
+      newRegs = IM.insert 3 (Integer (fromIntegral h)) (cpRegs cp)
       newCPs = case hs of
         [] -> rest
         _  -> cp { cpBuiltin = Just (HopsRetry var hs retPC) } : rest
@@ -340,10 +340,10 @@ finalizeAggregate returnPC s = go (wsCPs s)
             result = applyAggregation typ accum
             bindings0 = cpBindings cp
             regs0 = cpRegs cp
-            resVal = derefVar bindings0 <$> Map.lookup resReg regs0
+            resVal = derefVar bindings0 <$> IM.lookup resReg regs0
             (regs1, bindings1, trail1) = case resVal of
               Just (Unbound var) ->
-                ( Map.insert resReg result regs0
+                ( IM.insert resReg result regs0
                 , Map.insert var result bindings0
                 , TrailEntry ("__binding__" ++ var) (Map.lookup var bindings0)
                     : take (cpTrailLen cp) (wsTrail s)
@@ -403,13 +403,13 @@ callIndexedFact2 pred s =
   in case Map.lookup basePred (wsForeignFacts s) of
     Nothing -> Nothing
     Just factIndex ->
-      let a1 = derefVar (wsBindings s) $ fromMaybe (Atom "") (Map.lookup "A1" (wsRegs s))
-          a2 = derefVar (wsBindings s) $ fromMaybe (Unbound "_") (Map.lookup "A2" (wsRegs s))
+      let a1 = derefVar (wsBindings s) $ fromMaybe (Atom "") (IM.lookup 1 (wsRegs s))
+          a2 = derefVar (wsBindings s) $ fromMaybe (Unbound "_") (IM.lookup 2 (wsRegs s))
       in case a1 of
         Atom key -> case Map.lookup key factIndex of
           Just (v:rest) -> case a2 of
             Unbound var ->
-              let newRegs = Map.insert "A2" (Atom v) (wsRegs s)
+              let newRegs = IM.insert 2 (Atom v) (wsRegs s)
                   newBindings = Map.insert var (Atom v) (wsBindings s)
                   newTrail = TrailEntry ("__binding__" ++ var) (Map.lookup var (wsBindings s)) : wsTrail s
                   newCPs = case rest of
@@ -434,9 +434,9 @@ callIndexedFact2 pred s =
 
 executeForeign :: String -> WamState -> Maybe WamState
 executeForeign "category_ancestor/4" s =
-  let cat = derefVar (wsBindings s) $ fromMaybe (Atom "") (Map.lookup "A1" (wsRegs s))
-      root = derefVar (wsBindings s) $ fromMaybe (Atom "") (Map.lookup "A2" (wsRegs s))
-      visited = derefVar (wsBindings s) $ fromMaybe (VList []) (Map.lookup "A4" (wsRegs s))
+  let cat = derefVar (wsBindings s) $ fromMaybe (Atom "") (IM.lookup 1 (wsRegs s))
+      root = derefVar (wsBindings s) $ fromMaybe (Atom "") (IM.lookup 2 (wsRegs s))
+      visited = derefVar (wsBindings s) $ fromMaybe (VList []) (IM.lookup 4 (wsRegs s))
       maxD = fromMaybe 10 $ Map.lookup "max_depth" (wsForeignConfig s)
       parents = fromMaybe Map.empty $ Map.lookup "category_parent" (wsForeignFacts s)
   in case (cat, root, visited) of
@@ -444,15 +444,15 @@ executeForeign "category_ancestor/4" s =
       let visitedStrs = Set.fromList [v | Atom v <- visitedVals]
           hops = nativeCategoryAncestor parents catS rootS maxD (Set.size visitedStrs) visitedStrs
           retPC = wsCP s
-          hopsReg = derefVar (wsBindings s) $ fromMaybe (Unbound "_") (Map.lookup "A3" (wsRegs s))
+          hopsReg = derefVar (wsBindings s) $ fromMaybe (Unbound "_") (IM.lookup 3 (wsRegs s))
           bindHop hopVal =
             case hopsReg of
               Unbound var ->
                 s { wsPC = retPC
-                  , wsRegs = Map.insert "A3" (Integer (fromIntegral hopVal)) (wsRegs s)
+                  , wsRegs = IM.insert 3 (Integer (fromIntegral hopVal)) (wsRegs s)
                   , wsBindings = Map.insert var (Integer (fromIntegral hopVal)) (wsBindings s)
                   , wsTrail = TrailEntry ("__binding__" ++ var) (Map.lookup var (wsBindings s)) : wsTrail s }
-              _ -> s { wsPC = retPC, wsRegs = Map.insert "A3" (Integer (fromIntegral hopVal)) (wsRegs s) }
+              _ -> s { wsPC = retPC, wsRegs = IM.insert 3 (Integer (fromIntegral hopVal)) (wsRegs s) }
       in case hops of
         [] -> Nothing
         [h] -> Just (bindHop h)   -- single result, no CPs
@@ -494,50 +494,50 @@ step_function_haskell(Code) :-
     Code = '-- | Execute a single WAM instruction.
 step :: WamState -> Instruction -> Maybe WamState
 step s (GetConstant c ai) =
-  let val = derefVar (wsBindings s) <$> Map.lookup ai (wsRegs s)
+  let val = derefVar (wsBindings s) <$> IM.lookup ai (wsRegs s)
   in case val of
     Just v | v == c -> Just (s { wsPC = wsPC s + 1 })
     Just (Unbound var) ->
       Just (s { wsPC = wsPC s + 1
-              , wsRegs = Map.insert ai c (wsRegs s)
+              , wsRegs = IM.insert ai c (wsRegs s)
               , wsBindings = Map.insert var c (wsBindings s)
               , wsTrail = TrailEntry ("__binding__" ++ var) (Map.lookup var (wsBindings s)) : wsTrail s
               })
     _ -> Nothing
 
 step s (GetVariable xn ai) =
-  case Map.lookup ai (wsRegs s) of
+  case IM.lookup ai (wsRegs s) of
     Just val -> let dv = derefVar (wsBindings s) val
                 in Just ((putReg xn dv s) { wsPC = wsPC s + 1 })
     Nothing -> Nothing
 
 step s (GetValue xn ai) =
-  let va = derefVar (wsBindings s) <$> Map.lookup ai (wsRegs s)
+  let va = derefVar (wsBindings s) <$> IM.lookup ai (wsRegs s)
       vx = getReg xn s
   in case (va, vx) of
     (Just a, Just x) | a == x -> Just (s { wsPC = wsPC s + 1 })
     (Just (Unbound n), Just x) ->
       Just (s { wsPC = wsPC s + 1
-              , wsRegs = Map.insert ai x (wsRegs s)
+              , wsRegs = IM.insert ai x (wsRegs s)
               , wsBindings = Map.insert n x (wsBindings s)
               , wsTrail = TrailEntry ("__binding__" ++ n) (Map.lookup n (wsBindings s)) : wsTrail s
               })
     _ -> Nothing
 
 step s (PutConstant c ai) =
-  Just (s { wsPC = wsPC s + 1, wsRegs = Map.insert ai c (wsRegs s) })
+  Just (s { wsPC = wsPC s + 1, wsRegs = IM.insert ai c (wsRegs s) })
 
 step s (PutVariable xn ai) =
   let var = Unbound ("_V" ++ show (wsVarCounter s))
       s1 = putReg xn var s
   in Just (s1 { wsPC = wsPC s + 1
-              , wsRegs = Map.insert ai var (wsRegs s1)
+              , wsRegs = IM.insert ai var (wsRegs s1)
               , wsVarCounter = wsVarCounter s + 1
               })
 
 step s (PutValue xn ai) =
   case getReg xn s of
-    Just val -> Just (s { wsPC = wsPC s + 1, wsRegs = Map.insert ai val (wsRegs s) })
+    Just val -> Just (s { wsPC = wsPC s + 1, wsRegs = IM.insert ai val (wsRegs s) })
     Nothing -> Nothing
 
 step s (PutStructure fn ai arity) =
@@ -574,7 +574,7 @@ step s Proceed =
      else Just (s { wsPC = ret, wsCP = 0 })
 
 step s Allocate =
-  let frame = EnvFrame (wsCP s) Map.empty
+  let frame = EnvFrame (wsCP s) IM.empty
   in Just (s { wsPC = wsPC s + 1
              , wsStack = frame : wsStack s
              , wsCutBar = length (wsCPs s)
@@ -616,14 +616,14 @@ step s (BuiltinCall "!/0" _) =
   Just (s { wsPC = wsPC s + 1, wsCPs = take (wsCutBar s) (wsCPs s) })
 
 step s (BuiltinCall "is/2" _) =
-  let expr = derefVar (wsBindings s) $ fromMaybe (Integer 0) (Map.lookup "A2" (wsRegs s))
+  let expr = derefVar (wsBindings s) $ fromMaybe (Integer 0) (IM.lookup 2 (wsRegs s))
       result = evalArith (wsBindings s) expr
-      lhs = derefVar (wsBindings s) <$> Map.lookup "A1" (wsRegs s)
+      lhs = derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s)
   in case (lhs, result) of
     (Just (Unbound var), Just r) ->
       let val = if fromIntegral (round r :: Int) == r then Integer (round r) else Float r
       in Just (s { wsPC = wsPC s + 1
-                 , wsRegs = Map.insert "A1" val (wsRegs s)
+                 , wsRegs = IM.insert 1 val (wsRegs s)
                  , wsBindings = Map.insert var val (wsBindings s)
                  , wsTrail = TrailEntry ("__binding__" ++ var) (Map.lookup var (wsBindings s)) : wsTrail s
                  })
@@ -631,16 +631,16 @@ step s (BuiltinCall "is/2" _) =
     _ -> Nothing
 
 step s (BuiltinCall "length/2" _) =
-  let listVal = derefVar (wsBindings s) $ fromMaybe (VList []) (Map.lookup "A1" (wsRegs s))
+  let listVal = derefVar (wsBindings s) $ fromMaybe (VList []) (IM.lookup 1 (wsRegs s))
   in case listVal of
     VList items ->
       let len = length items
-          lhs = derefVar (wsBindings s) <$> Map.lookup "A2" (wsRegs s)
+          lhs = derefVar (wsBindings s) <$> IM.lookup 2 (wsRegs s)
       in case lhs of
         Just (Unbound var) ->
           let val = Integer len
           in Just (s { wsPC = wsPC s + 1
-                     , wsRegs = Map.insert "A2" val (wsRegs s)
+                     , wsRegs = IM.insert 2 val (wsRegs s)
                      , wsBindings = Map.insert var val (wsBindings s)
                      , wsTrail = TrailEntry ("__binding__" ++ var) (Map.lookup var (wsBindings s)) : wsTrail s
                      })
@@ -649,14 +649,14 @@ step s (BuiltinCall "length/2" _) =
     _ -> Nothing
 
 step s (BuiltinCall "</2" _) =
-  let v1 = evalArith (wsBindings s) =<< (derefVar (wsBindings s) <$> Map.lookup "A1" (wsRegs s))
-      v2 = evalArith (wsBindings s) =<< (derefVar (wsBindings s) <$> Map.lookup "A2" (wsRegs s))
+  let v1 = evalArith (wsBindings s) =<< (derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s))
+      v2 = evalArith (wsBindings s) =<< (derefVar (wsBindings s) <$> IM.lookup 2 (wsRegs s))
   in case (v1, v2) of
     (Just a, Just b) | a < b -> Just (s { wsPC = wsPC s + 1 })
     _ -> Nothing
 
 step s (BuiltinCall "\\\\+/1" _) =
-  let goal = Map.lookup "A1" (wsRegs s) >>= derefHeap (wsHeap s)
+  let goal = IM.lookup 1 (wsRegs s) >>= derefHeap (wsHeap s)
   in case goal of
     Just (Str fn [needle, haystack]) | "member" `isPrefixOf` fn ->
       let n = derefVar (wsBindings s) needle
@@ -669,7 +669,7 @@ step s (BuiltinCall "\\\\+/1" _) =
 
 -- SwitchOnConstant: dispatch on A1 value via O(log n) Map lookup
 step s (SwitchOnConstant table) =
-  let val = derefVar (wsBindings s) <$> Map.lookup "A1" (wsRegs s)
+  let val = derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s)
   in case val of
     Just (Unbound _) -> Just (s { wsPC = wsPC s + 1 })  -- unbound: skip
     Just v -> case Map.lookup v table of
@@ -680,16 +680,16 @@ step s (SwitchOnConstant table) =
     Nothing -> Nothing
 
 step s (BuiltinCall ">/2" _) =
-  let v1 = evalArith (wsBindings s) =<< (derefVar (wsBindings s) <$> Map.lookup "A1" (wsRegs s))
-      v2 = evalArith (wsBindings s) =<< (derefVar (wsBindings s) <$> Map.lookup "A2" (wsRegs s))
+  let v1 = evalArith (wsBindings s) =<< (derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s))
+      v2 = evalArith (wsBindings s) =<< (derefVar (wsBindings s) <$> IM.lookup 2 (wsRegs s))
   in case (v1, v2) of
     (Just a, Just b) | a > b -> Just (s { wsPC = wsPC s + 1 })
     _ -> Nothing
 
 -- member/2 builtin: A1=Elem, A2=List. Creates choice points for backtracking.
 step s (BuiltinCall "member/2" _) =
-  let elem_ = derefVar (wsBindings s) $ fromMaybe (Unbound "_") (Map.lookup "A1" (wsRegs s))
-      list_ = derefVar (wsBindings s) $ fromMaybe (VList []) (Map.lookup "A2" (wsRegs s))
+  let elem_ = derefVar (wsBindings s) $ fromMaybe (Unbound "_") (IM.lookup 1 (wsRegs s))
+      list_ = derefVar (wsBindings s) $ fromMaybe (VList []) (IM.lookup 2 (wsRegs s))
   in case list_ of
     VList (x:_) -> unifyVal elem_ x s
     _ -> Nothing
@@ -846,6 +846,7 @@ generate_main_hs(_Predicates, Code) :-
 module Main where
 
 import qualified Data.Map.Strict as Map
+import qualified Data.IntMap.Strict as IM
 import Data.List (nub, sort, isPrefixOf, intercalate)
 import qualified Numeric
 import Data.Maybe (fromMaybe, mapMaybe)
@@ -903,7 +904,7 @@ buildFact2Code predName pairs startPC =
                   if i == 0 then [TryMeElse (pn ++ "_g_" ++ key ++ "_" ++ show (i+1))]
                   else if i == n - 1 then [TrustMe]
                   else [RetryMeElse (pn ++ "_g_" ++ key ++ "_" ++ show (i+1))]
-                factInstrs = [GetConstant (Atom a) "A1", GetConstant (Atom b) "A2", Proceed]
+                factInstrs = [GetConstant (Atom a) 1, GetConstant (Atom b) 2, Proceed]
                 label = (pn ++ "_g_" ++ key ++ "_" ++ show i, curPC)
             in (choiceInstr ++ factInstrs, [label], curPC + length choiceInstr + length factInstrs)
           (allCode, allLabels, finalPC) = foldl (\\(c, l, p) (i, f) ->
@@ -916,7 +917,7 @@ buildFact1Code :: String -> [String] -> Int -> ([Instruction], [(String, Int)])
 buildFact1Code predName vals startPC =
     let disp = [(Atom v, predName ++ "_" ++ show i) | (i, v) <- zip [0..] vals]
         switchInstr = SwitchOnConstant (Map.fromList disp)
-        factCode = concatMap (\\(i, v) -> [GetConstant (Atom v) "A1", Proceed]) (zip [0..] vals)
+        factCode = concatMap (\\(i, v) -> [GetConstant (Atom v) 1, Proceed]) (zip [0..] vals)
         factLabels = [(predName ++ "_" ++ show i, startPC + 1 + i * 2) | i <- [0..length vals - 1]]
     in (switchInstr : factCode, (predName ++ "/1", startPC) : factLabels)
 
@@ -962,11 +963,11 @@ main = do
     seedResultsForced <- mapM (\\cat -> do
         let s0 = (emptyState mergedCode mergedLabels)
                 { wsPC = fromMaybe 1 $ Map.lookup "category_ancestor/4" mergedLabels
-                , wsRegs = Map.fromList
-                    [ ("A1", Atom cat)
-                    , ("A2", Atom root)
-                    , ("A3", Unbound "Hops")
-                    , ("A4", VList [Atom cat])
+                , wsRegs = IM.fromList
+                    [ (1, Atom cat)
+                    , (2, Atom root)
+                    , (3, Unbound "Hops")
+                    , (4, VList [Atom cat])
                     ]
                 , wsCP = 0
                 }
@@ -1073,6 +1074,7 @@ compile_wam_runtime_to_haskell(_Options, Code) :-
 'module WamRuntime where
 
 import qualified Data.Map.Strict as Map
+import qualified Data.IntMap.Strict as IM
 import Data.Array (Array, listArray, (!), bounds)
 import qualified Data.Set as Set
 import Data.List (isPrefixOf, foldl'')
@@ -1123,26 +1125,26 @@ evalArith bindings (Str op [a, b]) = do
     _ -> Nothing
 evalArith _ _ = Nothing
 
--- | Get register value (Y-registers from topmost env frame).
-getReg :: String -> WamState -> Maybe Value
-getReg name s
-  | "Y" `isPrefixOf` name = findYReg name (wsStack s)
-  | otherwise = derefVar (wsBindings s) <$> Map.lookup name (wsRegs s)
+-- | Get register value. Y-registers (id >= 200) come from the env frame.
+getReg :: Int -> WamState -> Maybe Value
+getReg rid s
+  | rid >= 200 = findYReg rid (wsStack s)
+  | otherwise = derefVar (wsBindings s) <$> IM.lookup rid (wsRegs s)
   where
     findYReg _ [] = Nothing
-    findYReg n (EnvFrame _ yregs : _) = derefVar (wsBindings s) <$> Map.lookup n yregs
-    findYReg n (_ : rest) = findYReg n rest
+    findYReg r (EnvFrame _ yregs : _) = derefVar (wsBindings s) <$> IM.lookup r yregs
+    findYReg r (_ : rest) = findYReg r rest
 
--- | Set register value.
-putReg :: String -> Value -> WamState -> WamState
-putReg name val s
-  | "Y" `isPrefixOf` name = s { wsStack = updateTopEnv name val (wsStack s) }
-  | otherwise = s { wsRegs = Map.insert name val (wsRegs s) }
+-- | Set register value. Y-registers go to the topmost env frame.
+putReg :: Int -> Value -> WamState -> WamState
+putReg rid val s
+  | rid >= 200 = s { wsStack = updateTopEnv rid val (wsStack s) }
+  | otherwise = s { wsRegs = IM.insert rid val (wsRegs s) }
   where
     updateTopEnv _ _ [] = []
-    updateTopEnv n v (EnvFrame cp yregs : rest) =
-      EnvFrame cp (Map.insert n v yregs) : rest
-    updateTopEnv n v (x : rest) = x : updateTopEnv n v rest
+    updateTopEnv r v (EnvFrame cp yregs : rest) =
+      EnvFrame cp (IM.insert r v yregs) : rest
+    updateTopEnv r v (x : rest) = x : updateTopEnv r v rest
 
 -- | Dereference a heap reference.
 derefHeap :: [Value] -> Value -> Maybe Value
@@ -1160,7 +1162,7 @@ addToBuilder val s = case wsBuilder s of
     let args'' = args ++ [val]
     in if length args'' == arity
        then Just (s { wsPC = wsPC s + 1
-                    , wsRegs = Map.insert ai (Str fn args'') (wsRegs s)
+                    , wsRegs = IM.insert ai (Str fn args'') (wsRegs s)
                     , wsBuilder = NoBuilder
                     })
        else Just (s { wsPC = wsPC s + 1
@@ -1175,7 +1177,7 @@ addToBuilder val s = case wsBuilder s of
                   Atom "[]"  -> VList [hd]
                   _           -> VList [hd, tl]
             in Just (s { wsPC = wsPC s + 1
-                       , wsRegs = Map.insert ai list (wsRegs s)
+                       , wsRegs = IM.insert ai list (wsRegs s)
                        , wsBuilder = NoBuilder
                        })
        else Just (s { wsPC = wsPC s + 1
@@ -1201,6 +1203,7 @@ generate_wam_types_hs(Code) :-
     Code = 'module WamTypes where
 
 import qualified Data.Map.Strict as Map
+import qualified Data.IntMap.Strict as IM
 import Data.Array (Array, listArray, (!), bounds)
 
 data Value = Atom String
@@ -1212,7 +1215,7 @@ data Value = Atom String
            | Ref Int
            deriving (Eq, Ord, Show)
 
-data EnvFrame = EnvFrame !Int !(Map.Map String Value)
+data EnvFrame = EnvFrame !Int !(IM.IntMap Value)   -- saved CP + Y-regs (IntMap)
               deriving (Show)
 
 data TrailEntry = TrailEntry !String !(Maybe Value)
@@ -1220,15 +1223,15 @@ data TrailEntry = TrailEntry !String !(Maybe Value)
 
 data ChoicePoint = ChoicePoint
   { cpNextPC   :: !Int
-  , cpRegs     :: !(Map.Map String Value)
+  , cpRegs     :: !(IM.IntMap Value)    -- IntMap (registers)
   , cpStack    :: ![EnvFrame]
   , cpCP       :: !Int
   , cpTrailLen :: !Int
   , cpHeapLen  :: !Int
   , cpBindings :: !(Map.Map String Value)
   , cpCutBar   :: !Int
-  , cpAggFrame :: !(Maybe AggFrame)     -- aggregate frame (if this CP is an aggregate)
-  , cpBuiltin  :: !(Maybe BuiltinState) -- builtin state for fact_retry, member, etc.
+  , cpAggFrame :: !(Maybe AggFrame)
+  , cpBuiltin  :: !(Maybe BuiltinState)
   } deriving (Show)
 
 -- | Builtin state for choice points that need custom retry logic.
@@ -1240,20 +1243,20 @@ data BuiltinState
 -- | Aggregate frame for begin_aggregate/end_aggregate.
 data AggFrame = AggFrame
   { afType      :: !String   -- "sum", "count", "collect", etc.
-  , afValueReg  :: !String   -- register holding value per solution
-  , afResultReg :: !String   -- register for final result
+  , afValueReg  :: !Int      -- register ID holding value per solution
+  , afResultReg :: !Int      -- register ID for final result
   , afReturnPC  :: !Int      -- PC after end_aggregate
   } deriving (Show)
 
 -- | Builder for PutStructure/PutList + SetValue/SetConstant sequences.
-data Builder = BuildStruct !String !String !Int ![Value]  -- functor, target reg, arity, collected args
-             | BuildList !String ![Value]                  -- target reg, collected [head, tail]
+data Builder = BuildStruct !String !Int !Int ![Value]  -- functor, target reg ID, arity, collected args
+             | BuildList !Int ![Value]                  -- target reg ID, collected [head, tail]
              | NoBuilder
              deriving (Show)
 
 data WamState = WamState
   { wsPC       :: !Int
-  , wsRegs     :: !(Map.Map String Value)
+  , wsRegs     :: !(IM.IntMap Value)                         -- IntMap for O(1) integer key access
   , wsStack    :: ![EnvFrame]
   , wsHeap     :: ![Value]
   , wsTrail    :: ![TrailEntry]
@@ -1265,42 +1268,49 @@ data WamState = WamState
   , wsLabels   :: !(Map.Map String Int)
   , wsBuilder  :: !Builder
   , wsVarCounter :: !Int
-  , wsAggAccum :: ![Value]     -- aggregate accumulator (values collected so far)
-  , wsForeignFacts :: !(Map.Map String (Map.Map String [String]))  -- pred -> (key1 -> [val2s]); populated by benchmark driver
-  , wsForeignConfig :: !(Map.Map String Int)                       -- "max_depth" etc.; populated by benchmark driver
+  , wsAggAccum :: ![Value]
+  , wsForeignFacts :: !(Map.Map String (Map.Map String [String]))
+  , wsForeignConfig :: !(Map.Map String Int)
   } deriving (Show)
 
 -- | Instruction type for the WAM.
+-- | Register IDs are pre-interned at compile time as Ints to avoid string
+-- hashing on register access. Encoding:
+--   A1-A99: 1-99
+--   X1-X99: 101-199
+--   Y1-Y99: 201-299
+type RegId = Int
+
 data Instruction
-  = GetConstant Value String
-  | GetVariable String String
-  | GetValue String String
-  | PutConstant Value String
-  | PutVariable String String
-  | PutValue String String
-  | PutStructure String String Int   -- functor, target reg, arity (pre-parsed)
-  | PutList String
-  | SetValue String
+  = GetConstant Value !RegId
+  | GetVariable !RegId !RegId
+  | GetValue !RegId !RegId
+  | PutConstant Value !RegId
+  | PutVariable !RegId !RegId
+  | PutValue !RegId !RegId
+  | PutStructure String !RegId !Int   -- functor, target reg, arity (pre-parsed)
+  | PutList !RegId
+  | SetValue !RegId
   | SetConstant Value
   | Allocate
   | Deallocate
-  | Call String Int
+  | Call String !Int
   | Execute String
   | Proceed
-  | BuiltinCall String Int
+  | BuiltinCall String !Int
   | TryMeElse String
   | RetryMeElse String
   | TrustMe
   | SwitchOnConstant (Map.Map Value String)   -- pre-built Map for O(log n) dispatch
-  | BeginAggregate String String String   -- type, valueReg, resultReg
-  | EndAggregate String                   -- valueReg
+  | BeginAggregate String !RegId !RegId   -- type, valueReg, resultReg
+  | EndAggregate !RegId                   -- valueReg
   deriving (Show, Eq)
 
 -- | Create initial empty state.
 emptyState :: [Instruction] -> Map.Map String Int -> WamState
 emptyState codeList labels = let n = length codeList; code = listArray (1, n) codeList in WamState
   { wsPC       = 1
-  , wsRegs     = Map.empty
+  , wsRegs     = IM.empty
   , wsStack    = []
   , wsHeap     = []
   , wsTrail    = []
@@ -1426,34 +1436,53 @@ wam_lines_to_haskell([Line|Rest], PC, Instrs, Labels, FinalPC) :-
         )
     ).
 
+%% reg_name_to_int(+RegName, -Int)
+%  Encode register name string to integer ID for IntMap-based register storage.
+%  A1-A99 -> 1-99, X1-X99 -> 101-199, Y1-Y99 -> 201-299.
+reg_name_to_int(Reg, Int) :-
+    atom_string(RegA, Reg),
+    sub_atom(RegA, 0, 1, _, Bank),
+    sub_atom(RegA, 1, _, 0, NumA),
+    atom_number(NumA, Num),
+    (   Bank == 'A' -> Int = Num
+    ;   Bank == 'X' -> Int is Num + 100
+    ;   Bank == 'Y' -> Int is Num + 200
+    ;   Int = 0
+    ).
+
 %% wam_instr_to_haskell(+Parts, -HaskellExpr)
 %  Converts parsed WAM instruction parts to a Haskell Instruction constructor.
 wam_instr_to_haskell(["get_constant", C, Ai], Hs) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),
     wam_value_to_haskell(CC, HsVal),
-    format(string(Hs), 'GetConstant (~w) "~w"', [HsVal, CAi]).
+    reg_name_to_int(CAi, AiI),
+    format(string(Hs), 'GetConstant (~w) ~w', [HsVal, AiI]).
 wam_instr_to_haskell(["get_variable", Xn, Ai], Hs) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
-    format(string(Hs), 'GetVariable "~w" "~w"', [CXn, CAi]).
+    reg_name_to_int(CXn, XnI), reg_name_to_int(CAi, AiI),
+    format(string(Hs), 'GetVariable ~w ~w', [XnI, AiI]).
 wam_instr_to_haskell(["get_value", Xn, Ai], Hs) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
-    format(string(Hs), 'GetValue "~w" "~w"', [CXn, CAi]).
+    reg_name_to_int(CXn, XnI), reg_name_to_int(CAi, AiI),
+    format(string(Hs), 'GetValue ~w ~w', [XnI, AiI]).
 wam_instr_to_haskell(["put_constant", C, Ai], Hs) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),
     wam_value_to_haskell(CC, HsVal),
-    format(string(Hs), 'PutConstant (~w) "~w"', [HsVal, CAi]).
+    reg_name_to_int(CAi, AiI),
+    format(string(Hs), 'PutConstant (~w) ~w', [HsVal, AiI]).
 wam_instr_to_haskell(["put_variable", Xn, Ai], Hs) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
-    format(string(Hs), 'PutVariable "~w" "~w"', [CXn, CAi]).
+    reg_name_to_int(CXn, XnI), reg_name_to_int(CAi, AiI),
+    format(string(Hs), 'PutVariable ~w ~w', [XnI, AiI]).
 wam_instr_to_haskell(["put_value", Xn, Ai], Hs) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
-    format(string(Hs), 'PutValue "~w" "~w"', [CXn, CAi]).
+    reg_name_to_int(CXn, XnI), reg_name_to_int(CAi, AiI),
+    format(string(Hs), 'PutValue ~w ~w', [XnI, AiI]).
 wam_instr_to_haskell(["put_structure", FN, Ai], Hs) :-
     clean_comma(FN, CFN), clean_comma(Ai, CAi),
-    % Pre-parse arity from "name/N" at compile time so the runtime
-    % doesn''t need to scan the string on every PutStructure step.
     parse_functor_arity(CFN, Arity),
-    format(string(Hs), 'PutStructure "~w" "~w" ~w', [CFN, CAi, Arity]).
+    reg_name_to_int(CAi, AiI),
+    format(string(Hs), 'PutStructure "~w" ~w ~w', [CFN, AiI, Arity]).
 
 %% parse_functor_arity(+FunctorString, -Arity)
 %  Extract the arity from "name/N" format. Defaults to 0 if no slash.
@@ -1467,9 +1496,11 @@ parse_functor_arity(FN, Arity) :-
     ;   Arity = 0
     ).
 wam_instr_to_haskell(["put_list", Ai], Hs) :-
-    format(string(Hs), 'PutList "~w"', [Ai]).
+    clean_comma(Ai, CAi), reg_name_to_int(CAi, AiI),
+    format(string(Hs), 'PutList ~w', [AiI]).
 wam_instr_to_haskell(["set_value", Xn], Hs) :-
-    format(string(Hs), 'SetValue "~w"', [Xn]).
+    clean_comma(Xn, CXn), reg_name_to_int(CXn, XnI),
+    format(string(Hs), 'SetValue ~w', [XnI]).
 wam_instr_to_haskell(["set_constant", C], Hs) :-
     wam_value_to_haskell(C, HsVal),
     format(string(Hs), 'SetConstant (~w)', [HsVal]).
@@ -1505,10 +1536,12 @@ wam_instr_to_haskell(["switch_on_constant_a2"|Entries], Hs) :-
     format(string(Hs), 'SwitchOnConstant (Map.fromList [~w])', [PairsStr]).
 wam_instr_to_haskell(["begin_aggregate", Type, ValReg, ResReg], Hs) :-
     clean_comma(Type, CT), clean_comma(ValReg, CV), clean_comma(ResReg, CR),
-    format(string(Hs), 'BeginAggregate "~w" "~w" "~w"', [CT, CV, CR]).
+    reg_name_to_int(CV, VI), reg_name_to_int(CR, RI),
+    format(string(Hs), 'BeginAggregate "~w" ~w ~w', [CT, VI, RI]).
 wam_instr_to_haskell(["end_aggregate", ValReg], Hs) :-
     clean_comma(ValReg, CV),
-    format(string(Hs), 'EndAggregate "~w"', [CV]).
+    reg_name_to_int(CV, VI),
+    format(string(Hs), 'EndAggregate ~w', [VI]).
 % Fallback for unknown instructions
 wam_instr_to_haskell(Parts, Hs) :-
     atomic_list_concat(Parts, ' ', Joined),


### PR DESCRIPTION
  ## Summary

  Profile-guided optimization pass on the Haskell WAM target. Closes the gap
  to native SWI-Prolog from **~37x → ~10x** at the effective-distance
  benchmark (300 scale, depth=10, 386 seeds, 11172 paths) without changing
  the WAM's architectural shape — every optimization preserves the
  persistent-data-structure backtracking model.

  Wall time at 300 scale, depth=10:

  | Stage | Wall time |
  |---|---|
  | Pre-branch (Map baseline) | ~11,742 ms |
  | HashMap | ~8,615 ms |
  | HashMap + compile-time arity | ~7,320 ms |
  | IntMap registers | ~6,000 ms |
  | IntMap bindings + variable interning | ~5,000 ms |
  | `CallResolved` | ~4,500 ms |
  | List-visited + unsafeFetch | ~3,500 ms |
  | Cached lengths + INLINE | **~3,100–4,100 ms** |
  | Native SWI-Prolog reference | ~318 ms |

  Correctness is unchanged: still 213/213 tuples matching the SWI-Prolog
  reference, still 272/272 line matches.

  ## Optimizations (commit by commit)

  Each step was profile-guided: `+RTS -p -RTS`, find the hot spot, fix it,
  re-profile.

  - `0daa9d65` — `Data.HashMap.Strict` for register/binding maps via a
    `use_hashmap` post-processing pass (default on, falls back to
    `Data.Map.Strict` when `unordered-containers` is unavailable). 27% win.
  - `501da4fc` — Pre-parse `PutStructure` arity at compile time. The WAM
    compiler already knows the arity; embedding it in the instruction
    eliminates per-step `"name/N"` parsing. Cumulative 38%.
  - `221f828f` — Intern register names as `Int`s (`A1`–`A99`: 1–99,
    `X1`–`X99`: 101–199, `Y1`–`Y99`: 201–299) and use `Data.IntMap.Strict`
    for `wsRegs`. Eliminates `hashWithSalt1` for register lookups.
  - `803ed711` — Intern variables as `Int`s (drawn from `wsVarCounter`)
    and use `IntMap` for bindings. `Unbound !Int`, `TrailEntry !Int
    !(Maybe Value)`. Eliminates the remaining `hashWithSalt1` cost in
    inner loops. **Note:** data-value hashing (foreign facts, labels) and
    cycle detection (visited categories) are unchanged — only WAM-internal
    bookkeeping names are interned.
  - `cec17ca3` — Pre-resolve `Call` to `CallResolved !Int !Int` (target
    PC + arity) at project load time, walking the code list once. Foreign
    predicates and indexed facts keep `Call` because they need runtime
    dispatch. `hashWithSalt1` dropped from 9.2% → 7.4%.
  - `0d9695a9` — `nativeCategoryAncestor` uses a plain `[String]` visited
    list instead of `Set String` (with `max_depth ≤ 10`, list `elem` beats
    `Set.fromList + Set.member`). Plus `unsafeFetchInstr` drops the `Maybe`
    wrapper since the run loop already handles `PC = 0` as halt. Profile
    total time 14.5 s → 12.9 s.
  - `f757b881` — Cache `wsTrailLen`/`wsHeapLen` to eliminate per-step
    `length` calls on linked-list trails/heaps. Bonus: fixes a latent bug
    in `finalizeAggregate` where `take (cpTrailLen cp)` was keeping the
    newest entries instead of restoring to the snapshot (`drop (diff)`).
  - `bdae58cf` — Cache `wsCPsLen` for `Allocate`'s `cutBar = length(wsCPs)`
    call. Plus `addToBuilder` switched from `args ++ [val]` (O(n²) total
    for arity-N) to cons + reverse-on-finalize.
  - `d0e639de` — `INLINE` pragmas on `getReg`, `putReg`, `derefVar` so
    GHC can specialize hot call sites. Small wins (~5%, high variance), free.

  ## Design docs

  Three new docs in `docs/design/`:

  - **`WAM_HASKELL_PERF_PHILOSOPHY.md`** — Why persistent data structures
    are non-negotiable, why we are doing the WamState hot/cold split next,
    why `IORef` is explicitly **rejected** (it would destroy the structural-
    sharing property), why compile-WAM-to-Haskell-functions is a *separate*
    path rather than a continuation, and what "good enough" looks like
    (competitive fallback, not parity with 30 years of SWI-Prolog tuning).
  - **`WAM_HASKELL_PERF_SPECIFICATION.md`** — Current data shapes (`Value`,
    `RegId`, `WamState`, full `Instruction` ADT), the planned
    `WamContext`/`WamState` split (17 fields → 15 mutable + 4 read-only),
    the FFI optimization plan (difference-list accumulator, possibly
    direct-aggregate path), and a sketch of the deferred compile-to-
    Haskell-functions approach.
  - **`WAM_HASKELL_PERF_IMPLEMENTATION_PLAN.md`** — Commit history with
    hot spots and benchmark deltas, then ordered next steps:
    (1) WamState split, (2) FFI optimization, (3) compile-to-Haskell as
    a separate exercise.

  The user explicitly approved this ordering: split first because once the
  per-step record allocation cost is gone, the FFI wins become measurable
  against benchmark variance.

  ## Out of scope (intentionally not in this PR)

  - The WamState split itself — separate PR after this lands.
  - FFI optimization — separate PR after the split lands.
  - Compile-WAM-to-Haskell-functions — separate exercise, separate design
    doc triple, deferred indefinitely.
  - Any change to `IORef`/`STRef`/mutable arrays — explicitly rejected.
  - Any change to native lowering (`haskell_target.pl`) or the Rust target.

  ## Test plan

  - [x] `cabal build` succeeds for both `use_hashmap(true)` and
        `use_hashmap(false)` generated projects
  - [x] 213/213 tuples produced at 300 scale, depth=10
  - [x] 272/272 exact line matches against SWI-Prolog reference
  - [x] Benchmark wall time recorded with eager-evaluation forcing
        (`mapM` + bang patterns) to avoid laziness artifacts
  - [x] Both WAM-only and WAM+FFI paths verified
  - [ ] Reviewer to run the benchmark locally and confirm numbers are in
        the documented range (variance ~3.0–4.5 s is expected)