### PR TITLE
feat(csharp-query): plan dag fallback materialization

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -87,7 +87,8 @@ Status:
 - started for DAG grouped reach-count and DAG longest-depth relation retention,
   where the runtime can now choose between direct streamed DAG build,
   replayable buffering, and external materialized fallback before building
-  operator-owned DAG state
+  operator-owned DAG state, and where the fallback edge/seed materialization
+  path now also follows that planner-selected retention strategy explicitly
 - started for generic scan relation retention, where `RelationScanNode`,
   `PatternScanNode`, and scan-heavy join/negation/aggregate consumers can now
   choose between direct streamed scan access, replayable buffering, and

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -74,6 +74,9 @@ Examples:
   materialized rows are all viable inputs for those DAG operators, the runtime
   can choose among them through a measured retention selector and still expose
   an explicit override via `QueryExecutorOptions.DagRelationRetentionStrategy`
+- when the streamed DAG fast path is not used, the fallback edge/seed
+  materialization path now also honors that same planner-selected retention
+  strategy instead of dropping back to generic raw fact-list loading
 - path-aware shortest-path operators can build compact source->targets edge state
   instead of retaining generic edge tuples
 - where direct streaming, replayable buffering, and external materialized rows

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -33,7 +33,8 @@ using the same grouped-summary policy layer that now also drives the
 shortest-path minima family. The path-aware family now coordinates that
 grouped-summary selector with the earlier edge-retention selector through the
 shared internal materialization planner layer that also now covers the DAG
-family's relation-retention planning and the generic scan family used by
+family's relation-retention planning, including planner-driven fallback
+edge/seed materialization, and the generic scan family used by
 `RelationScanNode`, `PatternScanNode`, and scan-heavy join/negation/aggregate
 consumers. That policy now records measured cost buckets like `load_roots`,
 `load_seeds`, `strategy_select`, `build_*`, and `group_reduce`, while the

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -6679,6 +6679,66 @@ namespace UnifyWeaver.QueryRuntime
             }
         }
 
+        private List<object[]> GetDagFactsList(
+            PredicateId predicate,
+            DagRelationRetentionStrategy strategy,
+            EvaluationContext? context,
+            PlanNode traceNode,
+            bool edgeRelation)
+        {
+            if (context is null)
+            {
+                return MaterializeFacts(predicate, context);
+            }
+
+            if (context.Facts.TryGetValue(predicate, out var cached))
+            {
+                context.Trace?.RecordCacheLookup("Facts", $"{predicate.Name}/{predicate.Arity}", hit: true, built: false);
+                return cached;
+            }
+
+            context.Trace?.RecordCacheLookup("Facts", $"{predicate.Name}/{predicate.Arity}", hit: false, built: true);
+
+            var hasStreaming = TryGetDelimitedSource(predicate, RelationRetentionMode.Streaming, out var delimitedSource);
+            var hasReplayable = TryGetReplayableSource(predicate, context, out var replayableSource);
+            var hasExternal = TryGetExternalFacts(predicate, out var externalFacts);
+            var streamingPhase = edgeRelation ? "dag_materialize_streaming_edges" : "dag_materialize_streaming_seeds";
+            var replayablePhase = edgeRelation ? "dag_materialize_replayable_edges" : "dag_materialize_replayable_seeds";
+            var externalPhase = edgeRelation ? "dag_materialize_external_edges" : "dag_materialize_external_seeds";
+            List<object[]> facts;
+
+            switch (strategy)
+            {
+                case DagRelationRetentionStrategy.StreamingDirect when hasStreaming:
+                    facts = MeasurePhase(context.Trace, traceNode, streamingPhase, () => DelimitedRelationReader.ReadRows(delimitedSource).ToList());
+                    break;
+                case DagRelationRetentionStrategy.ReplayableBuffer when hasReplayable:
+                    facts = MeasurePhase(context.Trace, traceNode, replayablePhase, () => replayableSource.Materialize());
+                    break;
+                case DagRelationRetentionStrategy.ExternalMaterialized when hasExternal:
+                    facts = MeasurePhase(context.Trace, traceNode, externalPhase, () => externalFacts as List<object[]> ?? externalFacts.ToList());
+                    break;
+                default:
+                    if (hasReplayable)
+                    {
+                        facts = MeasurePhase(context.Trace, traceNode, replayablePhase, () => replayableSource.Materialize());
+                    }
+                    else if (hasStreaming)
+                    {
+                        facts = MeasurePhase(context.Trace, traceNode, streamingPhase, () => DelimitedRelationReader.ReadRows(delimitedSource).ToList());
+                    }
+                    else
+                    {
+                        var externalSource = _provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>();
+                        facts = MeasurePhase(context.Trace, traceNode, externalPhase, () => externalSource as List<object[]> ?? externalSource.ToList());
+                    }
+                    break;
+            }
+
+            context.Facts[predicate] = facts;
+            return facts;
+        }
+
         private IEnumerable<object[]> GetFactStream(PredicateId predicate, EvaluationContext? context = null)
         {
             if (context is not null && TryGetReplayableSource(predicate, context, out var replayableSource))
@@ -11804,14 +11864,15 @@ namespace UnifyWeaver.QueryRuntime
                     seeds = externalSeedFacts as List<object[]> ?? MeasurePhase(trace, closure, "dag_materialize_external_seeds", () => externalSeedFacts.ToList());
                 }
 
-                edges ??= GetFactsList(closure.EdgeRelation, context);
-                seeds ??= GetFactsList(closure.SeedRelation, context);
+                edges ??= GetDagFactsList(closure.EdgeRelation, selection.Strategy, context, closure, edgeRelation: true);
+                seeds ??= GetDagFactsList(closure.SeedRelation, selection.Strategy, context, closure, edgeRelation: false);
                 if (seeds.Count >= MinDagGroupCount &&
                     edges.Count >= MinDagEdgeCount)
                 {
                     List<object[]> dagRows = new();
                     var buildPhase = selection.Strategy switch
                     {
+                        DagRelationRetentionStrategy.StreamingDirect when hasStreaming => "dag_build_streaming_fallback",
                         DagRelationRetentionStrategy.ReplayableBuffer when hasReplayable => "dag_build_replayable_buffer",
                         DagRelationRetentionStrategy.ExternalMaterialized when hasExternal => "dag_build_external_materialized",
                         _ => "dag_build_materialized_fallback"
@@ -12014,8 +12075,15 @@ namespace UnifyWeaver.QueryRuntime
                     buildPhase = "dag_build_external_materialized";
                 }
 
-                edges ??= GetFactsList(closure.EdgeRelation, context);
-                seeds ??= GetFactsList(closure.SeedRelation, context);
+                edges ??= GetDagFactsList(closure.EdgeRelation, selection.Strategy, context, closure, edgeRelation: true);
+                seeds ??= GetDagFactsList(closure.SeedRelation, selection.Strategy, context, closure, edgeRelation: false);
+                buildPhase = selection.Strategy switch
+                {
+                    DagRelationRetentionStrategy.StreamingDirect when hasStreaming => "dag_build_streaming_fallback",
+                    DagRelationRetentionStrategy.ReplayableBuffer when hasReplayable => "dag_build_replayable_buffer",
+                    DagRelationRetentionStrategy.ExternalMaterialized when hasExternal => "dag_build_external_materialized",
+                    _ => buildPhase
+                };
                 List<object[]> rows = new();
                 if (!MeasurePhase(trace, closure, buildPhase, () => TryBuildSeedGroupedDagLongestDepthRows(closure, trace, edges, seeds, MaxDagNodeCount, out rows)))
                 {


### PR DESCRIPTION
  ## Summary

  This PR closes the remaining DAG materialization-planner gap in the C#
  query runtime.

  The streamed DAG fast path was already planner-aware, but the fallback
  path still dropped to raw `GetFactsList(...)` loads for edges and seeds.
  This change routes that fallback through the same planner-selected
  retention mode instead.

  So DAG execution now has a more consistent materialization story:

  - streamed fast path stays intact
  - replayable / external fallback is explicit
  - fallback materialization is traceable through the same runtime planner
    surface

  ## What Changed

  ### Runtime

  Updated the DAG fallback path so edge and seed fact loading no longer
  bypasses the planner.

  Added:

  - `GetDagFactsList(...)`

  This now materializes fallback DAG inputs through the selected retention
  strategy rather than using raw generic list loading.

  This applies to both DAG operators:

  - grouped transitive-closure count
  - grouped DAG longest depth

  ### Trace Surface

  Added explicit fallback trace phases, including:

  - `dag_materialize_streaming_edges`
  - `dag_materialize_streaming_seeds`
  - `dag_build_streaming_fallback`

  Existing replayable and external-materialized DAG traces remain in use.

  ### Docs

  Updated:

  - `QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `QUERY_ENGINE_MATERIALIZATION_PLAN.md`
  - `examples/benchmark/README.md`

  The docs now reflect that DAG fallback materialization also follows the
  shared runtime planner rather than silently dropping to raw fact-list
  access.

  ## Why This Matters

  This is mostly an architectural fix.

  Before this change, DAG planning was correct on the fast path but weaker
  on fallback. That meant the runtime owned the retention decision only
  part of the time.

  After this change, DAG relation access is more consistent:

  - parser streams tuples
  - runtime chooses retention mode
  - DAG operators build the graph state they need
  - even fallback materialization stays inside that runtime-owned boundary

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py
  ```
  ### Full DAG reruns
  ```
  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1
  ```

  Outputs matched across all targets.

  Representative results:

  ### Dependency reach-count

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS |
  |---|---:|---:|---:|---:|
  | 300 | 0.091s | 0.061s | 0.003s | 0.004s |
  | 1k | 0.131s | 0.069s | 0.011s | 0.007s |
  | 5k | 0.094s | 0.217s | 0.179s | 0.127s |
  | 10k | 0.112s | 0.544s | 0.742s | 0.509s |

  ### Dependency longest depth

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS |
  |---|---:|---:|---:|---:|
  | 300 | 0.093s | 0.056s | 0.003s | 0.003s |
  | 1k | 0.069s | 0.053s | 0.004s | 0.004s |
  | 5k | 0.101s | 0.067s | 0.007s | 0.006s |
  | 10k | 0.101s | 0.071s | 0.013s | 0.013s |

  ### Fallback-path validation

  Also forced replayable DAG retention at 300 and 10k for both DAG
  families to ensure the new fallback path was actually exercised.

  Those runs completed successfully and produced correct outputs.

  ### Non-regression smoke

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  Outputs still matched.

  ## Interpretation

  This PR does not introduce a new DAG algorithm.

  Its value is that DAG fallback materialization is now planner-driven,
  explicit, and traceable instead of silently bypassing the runtime policy
  layer.

  That makes the DAG family align better with the overall materialization
  direction of the query runtime.