### PR TITLE
feat(rust): Support mixed-goal foreign stream wrappers in Rust WAM

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -349,7 +349,8 @@ generate_rust_batch_dist_complement_terms([Term|Rest], Code) :-
 :- use_module('../core/advanced/pattern_matchers', [
     is_per_path_visited_pattern/4,
     parse_table_spec/2,
-    classify_aggregate/2
+    classify_aggregate/2,
+    classify_aggregate_goal/2
 ]).
 
 % Track collected components for code generation
@@ -3627,6 +3628,13 @@ compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
     option(include_main(IncludeMain), Options, true),
     functor(Head, Pred, Arity),
     findall(Head-Body, user:clause(Head, Body), Clauses),
+    Clauses = [SingleHead-SingleBody],
+    compile_rust_foreign_stream_wrapper(Pred, Arity, SingleHead, SingleBody, IncludeMain, RustCode),
+    !.
+compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
+    option(include_main(IncludeMain), Options, true),
+    functor(Head, Pred, Arity),
+    findall(Head-Body, user:clause(Head, Body), Clauses),
     Clauses \= [],
     native_rust_clause_body(Pred/Arity, Clauses, FuncBody),
     !,
@@ -4126,6 +4134,212 @@ rust_foreign_lowerable_astar_shortest_path(Pred, 4, Clauses,
 
 rust_foreign_edge_pair(forward, Left, Right, Left-Right).
 rust_foreign_edge_pair(reverse, Left, Right, Right-Left).
+
+compile_rust_foreign_stream_wrapper(Pred, 3, Head, Body, _IncludeMain, RustCode) :-
+    Head =.. [Pred, HeadStart, HeadTarget, HeadResult],
+    classify_aggregate_goal(Body, GoalInfo),
+    get_dict(relations, GoalInfo, [RelGoal]),
+    RelGoal =.. [InnerPred, GoalStart, GoalTarget, GoalCost],
+    HeadStart == GoalStart,
+    HeadTarget == GoalTarget,
+    get_dict(other, GoalInfo, []),
+    functor(InnerHead, InnerPred, 3),
+    findall(InnerHead-InnerBody, user:clause(InnerHead, InnerBody), Clauses),
+    Clauses \= [],
+    rust_foreign_lowerable_weighted_shortest_path(InnerPred, 3, Clauses, WeightPred/3, FactTriples),
+    rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalTarget, GoalCost],
+        HeadResult, SetupCode, ValueExpr, FilterCond),
+    atom_string(Pred, PredStr),
+    atom_string(InnerPred, InnerPredStr),
+    format(string(PredKey), '~w/3', [Pred]),
+    format(string(WeightPredKey), '~w/3', [WeightPred]),
+    rust_weighted_fact_triples_literal(FactTriples, TriplesLiteral),
+    format(string(RustCode),
+'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool {
+    vm.reset_query();
+    vm.code = Vec::new();
+    vm.labels = HashMap::new();
+    vm.pc = 1;
+    vm.register_foreign_result_layout("~w", "tuple:2");
+    vm.register_foreign_result_mode("~w", "stream");
+    vm.register_foreign_native_kind("~w/3", "weighted_shortest_path3");
+    vm.register_foreign_result_layout("~w/3", "tuple:2");
+    vm.register_foreign_result_mode("~w/3", "stream");
+    vm.register_foreign_string_config("~w/3", "weight_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+
+    let target_filter = match &a2 {
+        Value::Atom(target) => Some(target.clone()),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let result_filter = match &a3 {
+        Value::Float(value) => Some(*value),
+        Value::Integer(value) => Some(*value as f64),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let temp_target = "__wrapper_target".to_string();
+    let temp_cost = "__wrapper_cost".to_string();
+    let target_arg = match &a2 {
+        Value::Unbound(_) => Value::Unbound(temp_target.clone()),
+        _ => a2.clone(),
+    };
+
+    vm.set_reg("A1", a1.clone());
+    vm.set_reg("A2", target_arg);
+    vm.set_reg("A3", Value::Unbound(temp_cost.clone()));
+
+    if !vm.execute_foreign_predicate("~w", 3) {
+        vm.bindings.remove(&temp_target);
+        vm.bindings.remove(&temp_cost);
+        return false;
+    }
+
+    let mut packed_results: Vec<Value> = Vec::new();
+    loop {
+        let target = match &a2 {
+            Value::Atom(target) => target.clone(),
+            Value::Unbound(_) => match vm.bindings.get(&temp_target).cloned().map(|v| vm.deref_var(&v)) {
+                Some(Value::Atom(target)) => target,
+                _ => break,
+            },
+            _ => break,
+        };
+        let cost = match vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Float(cost)) => cost,
+            _ => break,
+        };
+~w        let output_value = ~w;
+        if (target_filter.as_ref().map(|want| want == &target).unwrap_or(true))
+            && (~w)
+            && (result_filter.as_ref().map(|want| (output_value - *want).abs() < 1e-9).unwrap_or(true)) {
+            packed_results.push(Value::Str("__tuple__".to_string(), vec![
+                Value::Atom(target.clone()),
+                Value::Float(output_value),
+            ]));
+        }
+        if !vm.backtrack() {
+            break;
+        }
+    }
+
+    vm.bindings.remove(&temp_target);
+    vm.bindings.remove(&temp_cost);
+    vm.finish_foreign_results("~w", vec![a2.clone(), a3.clone()], packed_results)
+}', [PredStr, PredKey, PredKey, InnerPredStr, InnerPredStr, InnerPredStr,
+      InnerPredStr, WeightPredKey, WeightPredKey, TriplesLiteral,
+      InnerPredStr, SetupCode, ValueExpr, FilterCond, PredKey]).
+compile_rust_foreign_stream_wrapper(Pred, 4, Head, Body, _IncludeMain, RustCode) :-
+    Head =.. [Pred, HeadStart, HeadTarget, HeadDim, HeadResult],
+    classify_aggregate_goal(Body, GoalInfo),
+    get_dict(relations, GoalInfo, [RelGoal]),
+    RelGoal =.. [InnerPred, GoalStart, GoalTarget, GoalDim, GoalCost],
+    HeadStart == GoalStart,
+    HeadTarget == GoalTarget,
+    HeadDim == GoalDim,
+    get_dict(other, GoalInfo, []),
+    functor(InnerHead, InnerPred, 4),
+    findall(InnerHead-InnerBody, user:clause(InnerHead, InnerBody), Clauses),
+    Clauses \= [],
+    rust_foreign_lowerable_astar_shortest_path(InnerPred, 4, Clauses,
+        WeightPred/3, FactTriples, DirectPred/3, DirectTriples, DefaultDim),
+    rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalTarget, GoalDim, GoalCost],
+        HeadResult, SetupCode, ValueExpr, FilterCond),
+    atom_string(Pred, PredStr),
+    atom_string(InnerPred, InnerPredStr),
+    format(string(PredKey), '~w/4', [Pred]),
+    format(string(WeightPredKey), '~w/3', [WeightPred]),
+    format(string(DirectPredKey), '~w/3', [DirectPred]),
+    rust_weighted_fact_triples_literal(FactTriples, WeightTriplesLiteral),
+    rust_weighted_fact_triples_literal(DirectTriples, DirectTriplesLiteral),
+    format(string(RustCode),
+'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool {
+    vm.reset_query();
+    vm.code = Vec::new();
+    vm.labels = HashMap::new();
+    vm.pc = 1;
+    vm.register_foreign_result_layout("~w", "tuple:2");
+    vm.register_foreign_result_mode("~w", "stream");
+    vm.register_foreign_native_kind("~w/4", "astar_shortest_path4");
+    vm.register_foreign_result_layout("~w/4", "tuple:2");
+    vm.register_foreign_result_mode("~w/4", "stream");
+    vm.register_foreign_string_config("~w/4", "weight_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+    vm.register_foreign_string_config("~w/4", "direct_dist_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+    vm.register_foreign_usize_config("~w/4", "dimensionality", ~w);
+
+    let target_filter = match &a2 {
+        Value::Atom(target) => Some(target.clone()),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let result_filter = match &a4 {
+        Value::Float(value) => Some(*value),
+        Value::Integer(value) => Some(*value as f64),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let temp_target = "__wrapper_target".to_string();
+    let temp_cost = "__wrapper_cost".to_string();
+    let target_arg = match &a2 {
+        Value::Unbound(_) => Value::Unbound(temp_target.clone()),
+        _ => a2.clone(),
+    };
+
+    vm.set_reg("A1", a1.clone());
+    vm.set_reg("A2", target_arg);
+    vm.set_reg("A3", a3.clone());
+    vm.set_reg("A4", Value::Unbound(temp_cost.clone()));
+
+    let dim_value = match &a3 {
+        Value::Integer(d) => *d as f64,
+        Value::Float(d) => *d,
+        _ => ~w_f64,
+    };
+
+    if !vm.execute_foreign_predicate("~w", 4) {
+        vm.bindings.remove(&temp_target);
+        vm.bindings.remove(&temp_cost);
+        return false;
+    }
+
+    let mut packed_results: Vec<Value> = Vec::new();
+    loop {
+        let target = match &a2 {
+            Value::Atom(target) => target.clone(),
+            Value::Unbound(_) => match vm.bindings.get(&temp_target).cloned().map(|v| vm.deref_var(&v)) {
+                Some(Value::Atom(target)) => target,
+                _ => break,
+            },
+            _ => break,
+        };
+        let cost = match vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Float(cost)) => cost,
+            _ => break,
+        };
+~w        let output_value = ~w;
+        if (target_filter.as_ref().map(|want| want == &target).unwrap_or(true))
+            && (~w)
+            && (result_filter.as_ref().map(|want| (output_value - *want).abs() < 1e-9).unwrap_or(true)) {
+            packed_results.push(Value::Str("__tuple__".to_string(), vec![
+                Value::Atom(target.clone()),
+                Value::Float(output_value),
+            ]));
+        }
+        if !vm.backtrack() {
+            break;
+        }
+    }
+
+    vm.bindings.remove(&temp_target);
+    vm.bindings.remove(&temp_cost);
+    vm.finish_foreign_results("~w", vec![a2.clone(), a4.clone()], packed_results)
+}', [PredStr, PredKey, PredKey, InnerPredStr, InnerPredStr, InnerPredStr,
+      InnerPredStr, WeightPredKey, WeightPredKey, WeightTriplesLiteral,
+      InnerPredStr, DirectPredKey, DirectPredKey, DirectTriplesLiteral,
+      InnerPredStr, DefaultDim, DefaultDim, InnerPredStr, SetupCode, ValueExpr, FilterCond, PredKey]).
 
 compile_aggregate_rule_to_rust(Pred, _Arity, _Head, AggInfo, IncludeMain, RustCode) :-
     get_dict(goal, AggInfo, Goal),

--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -138,6 +138,18 @@ filtered_adjusted_min_semantic_dist_astar(Start, Target, Dim, MinDist) :-
         (astar_weighted_path(Start, Target, Dim, Cost), Cost > 2, Adjusted is Cost + 1),
         MinDist).
 
+:- dynamic filtered_adjusted_weighted_path/3.
+filtered_adjusted_weighted_path(Start, Target, Adjusted) :-
+    weighted_path(Start, Target, Cost),
+    Cost > 2,
+    Adjusted is Cost + 1.
+
+:- dynamic filtered_adjusted_astar_weighted_path/4.
+filtered_adjusted_astar_weighted_path(Start, Target, Dim, Adjusted) :-
+    astar_weighted_path(Start, Target, Dim, Cost),
+    Cost > 2,
+    Adjusted is Cost + 1.
+
 %% Integration test
 test_runtime_execution :-
     Test = 'WAM-Rust Runtime: end-to-end execution',
@@ -148,7 +160,7 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:astar_weighted_path/4, user:min_semantic_dist/3, user:min_semantic_dist_astar/4, user:grouped_min_semantic_dist/3, user:grouped_min_semantic_dist_astar/4, user:filtered_adjusted_min_semantic_dist/3, user:filtered_adjusted_min_semantic_dist_astar/4],
+        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:astar_weighted_path/4, user:min_semantic_dist/3, user:min_semantic_dist_astar/4, user:grouped_min_semantic_dist/3, user:grouped_min_semantic_dist_astar/4, user:filtered_adjusted_min_semantic_dist/3, user:filtered_adjusted_min_semantic_dist_astar/4, user:filtered_adjusted_weighted_path/3, user:filtered_adjusted_astar_weighted_path/4],
             [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
@@ -173,6 +185,8 @@ use runtime_test::grouped_min_semantic_dist;
 use runtime_test::grouped_min_semantic_dist_astar;
 use runtime_test::filtered_adjusted_min_semantic_dist;
 use runtime_test::filtered_adjusted_min_semantic_dist_astar;
+use runtime_test::filtered_adjusted_weighted_path;
+use runtime_test::filtered_adjusted_astar_weighted_path;
 
 #[test]
 fn test_generated_predicates() {
@@ -908,6 +922,95 @@ fn test_generated_predicates() {
         Value::Integer(5),
         Value::Unbound("FilteredAStarNoPath".to_string()));
     assert!(!ok42, "filtered_adjusted_min_semantic_dist_astar(s, a, 5, Min) should fail");
+
+    // Test filtered_adjusted_weighted_path/3 mixed-goal non-aggregate wrapper
+    let mut vm_weighted_stream = WamState::new(vec![], std::collections::HashMap::new());
+    let ok43 = filtered_adjusted_weighted_path(&mut vm_weighted_stream,
+        Value::Atom("s".to_string()),
+        Value::Unbound("WeightedStreamTarget".to_string()),
+        Value::Unbound("WeightedStreamAdjusted".to_string()));
+    assert!(ok43, "filtered_adjusted_weighted_path(s, Target, Adjusted) first solution should succeed");
+    let mut weighted_stream_results: Vec<(String, f64)> = Vec::new();
+    if let (Some(Value::Atom(target)), Some(Value::Float(cost))) =
+        (vm_weighted_stream.bindings.get("WeightedStreamTarget").cloned(), vm_weighted_stream.bindings.get("WeightedStreamAdjusted").cloned()) {
+        weighted_stream_results.push((target, cost));
+    } else {
+        panic!("expected first filtered_adjusted_weighted_path result");
+    }
+    while vm_weighted_stream.backtrack() {
+        if let (Some(Value::Atom(target)), Some(Value::Float(cost))) =
+            (vm_weighted_stream.bindings.get("WeightedStreamTarget").cloned(), vm_weighted_stream.bindings.get("WeightedStreamAdjusted").cloned()) {
+            weighted_stream_results.push((target, cost));
+        } else {
+            panic!("expected filtered_adjusted_weighted_path backtrack result");
+        }
+    }
+    weighted_stream_results.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.partial_cmp(&b.1).unwrap()));
+    assert_eq!(weighted_stream_results, vec![
+        ("b".to_string(), 4.0),
+        ("c".to_string(), 5.0),
+        ("d".to_string(), 8.0),
+    ]);
+
+    let mut vm_weighted_stream_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok44 = filtered_adjusted_weighted_path(&mut vm_weighted_stream_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("d".to_string()),
+        Value::Float(8.0));
+    assert!(ok44, "filtered_adjusted_weighted_path(s, d, 8.0) should succeed");
+
+    let mut vm_weighted_stream_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok45 = filtered_adjusted_weighted_path(&mut vm_weighted_stream_fail,
+        Value::Atom("s".to_string()),
+        Value::Atom("a".to_string()),
+        Value::Unbound("WeightedStreamNoPath".to_string()));
+    assert!(!ok45, "filtered_adjusted_weighted_path(s, a, Adjusted) should fail");
+
+    // Test filtered_adjusted_astar_weighted_path/4 mixed-goal non-aggregate wrapper
+    let mut vm_astar_stream = WamState::new(vec![], std::collections::HashMap::new());
+    let ok46 = filtered_adjusted_astar_weighted_path(&mut vm_astar_stream,
+        Value::Atom("s".to_string()),
+        Value::Unbound("AStarStreamTarget".to_string()),
+        Value::Integer(5),
+        Value::Unbound("AStarStreamAdjusted".to_string()));
+    assert!(ok46, "filtered_adjusted_astar_weighted_path(s, Target, 5, Adjusted) first solution should succeed");
+    let mut astar_stream_results: Vec<(String, f64)> = Vec::new();
+    if let (Some(Value::Atom(target)), Some(Value::Float(cost))) =
+        (vm_astar_stream.bindings.get("AStarStreamTarget").cloned(), vm_astar_stream.bindings.get("AStarStreamAdjusted").cloned()) {
+        astar_stream_results.push((target, cost));
+    } else {
+        panic!("expected first filtered_adjusted_astar_weighted_path result");
+    }
+    while vm_astar_stream.backtrack() {
+        if let (Some(Value::Atom(target)), Some(Value::Float(cost))) =
+            (vm_astar_stream.bindings.get("AStarStreamTarget").cloned(), vm_astar_stream.bindings.get("AStarStreamAdjusted").cloned()) {
+            astar_stream_results.push((target, cost));
+        } else {
+            panic!("expected filtered_adjusted_astar_weighted_path backtrack result");
+        }
+    }
+    astar_stream_results.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.partial_cmp(&b.1).unwrap()));
+    assert_eq!(astar_stream_results, vec![
+        ("b".to_string(), 4.0),
+        ("c".to_string(), 5.0),
+        ("d".to_string(), 8.0),
+    ]);
+
+    let mut vm_astar_stream_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok47 = filtered_adjusted_astar_weighted_path(&mut vm_astar_stream_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("d".to_string()),
+        Value::Integer(5),
+        Value::Float(8.0));
+    assert!(ok47, "filtered_adjusted_astar_weighted_path(s, d, 5, 8.0) should succeed");
+
+    let mut vm_astar_stream_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok48 = filtered_adjusted_astar_weighted_path(&mut vm_astar_stream_fail,
+        Value::Atom("s".to_string()),
+        Value::Atom("a".to_string()),
+        Value::Integer(5),
+        Value::Unbound("AStarStreamNoPath".to_string()));
+    assert!(!ok48, "filtered_adjusted_astar_weighted_path(s, a, 5, Adjusted) should fail");
 }
 ',
         setup_call_cleanup(open(TestPath, write, S), format(S, "~w", [TestContent]), close(S)),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -46,6 +46,8 @@ test_simple_fact(foo, bar).
 :- dynamic grouped_min_semantic_dist_astar/4.
 :- dynamic filtered_adjusted_min_semantic_dist/3.
 :- dynamic filtered_adjusted_min_semantic_dist_astar/4.
+:- dynamic filtered_adjusted_weighted_path/3.
+:- dynamic filtered_adjusted_astar_weighted_path/4.
 :- dynamic tc_parent/2.
 :- dynamic max_depth/1.
 
@@ -158,6 +160,16 @@ filtered_adjusted_min_semantic_dist_astar(Start, Target, Dim, MinDist) :-
     aggregate_all(min(Adjusted),
         (astar_weighted_path(Start, Target, Dim, Cost), Cost > 2, Adjusted is Cost + 1),
         MinDist).
+
+filtered_adjusted_weighted_path(Start, Target, Adjusted) :-
+    weighted_path(Start, Target, Cost),
+    Cost > 2,
+    Adjusted is Cost + 1.
+
+filtered_adjusted_astar_weighted_path(Start, Target, Dim, Adjusted) :-
+    astar_weighted_path(Start, Target, Dim, Cost),
+    Cost > 2,
+    Adjusted is Cost + 1.
 
 pass(Test) :-
     format('[PASS] ~w~n', [Test]).
@@ -815,6 +827,40 @@ test_filtered_adjusted_astar_min_wrapper :-
     ;   fail_test(Test, 'Mixed-goal A* aggregate wrapper did not lower correctly')
     ).
 
+test_filtered_adjusted_weighted_stream_wrapper :-
+    Test = 'WAM-Rust: mixed-goal stream wrapper filters and adjusts weighted_path/3',
+    (   rust_target:compile_predicate_to_rust(user:filtered_adjusted_weighted_path/3,
+            [include_main(false), foreign_lowering(true), wam_fallback(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'pub fn filtered_adjusted_weighted_path(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("filtered_adjusted_weighted_path/3", "tuple:2")'),
+        sub_string(S, _, _, _, 'register_foreign_result_mode("filtered_adjusted_weighted_path/3", "stream")'),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("weighted_path/3", "weighted_shortest_path3")'),
+        sub_string(S, _, _, _, 'let agg_value = (cost + 1_f64);'),
+        sub_string(S, _, _, _, 'let output_value = agg_value;'),
+        sub_string(S, _, _, _, '(cost > 2_f64)'),
+        sub_string(S, _, _, _, 'vm.finish_foreign_results("filtered_adjusted_weighted_path/3", vec![a2.clone(), a3.clone()], packed_results)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Mixed-goal weighted stream wrapper did not lower correctly')
+    ).
+
+test_filtered_adjusted_astar_stream_wrapper :-
+    Test = 'WAM-Rust: mixed-goal stream wrapper filters and adjusts astar_weighted_path/4',
+    (   rust_target:compile_predicate_to_rust(user:filtered_adjusted_astar_weighted_path/4,
+            [include_main(false), foreign_lowering(true), wam_fallback(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'pub fn filtered_adjusted_astar_weighted_path(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("filtered_adjusted_astar_weighted_path/4", "tuple:2")'),
+        sub_string(S, _, _, _, 'register_foreign_result_mode("filtered_adjusted_astar_weighted_path/4", "stream")'),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("astar_weighted_path/4", "astar_shortest_path4")'),
+        sub_string(S, _, _, _, 'let agg_value = (cost + 1_f64);'),
+        sub_string(S, _, _, _, 'let output_value = agg_value;'),
+        sub_string(S, _, _, _, '(cost > 2_f64)'),
+        sub_string(S, _, _, _, 'vm.finish_foreign_results("filtered_adjusted_astar_weighted_path/4", vec![a2.clone(), a4.clone()], packed_results)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Mixed-goal A* stream wrapper did not lower correctly')
+    ).
+
 test_compile_wam_runtime_output :-
     Test = 'WAM-Rust E2E: full runtime generates valid impl block',
     (   compile_wam_runtime_to_rust([], Code),
@@ -1135,6 +1181,8 @@ run_tests :-
     test_grouped_astar_min_aggregate_wrapper,
     test_filtered_adjusted_weighted_min_wrapper,
     test_filtered_adjusted_astar_min_wrapper,
+    test_filtered_adjusted_weighted_stream_wrapper,
+    test_filtered_adjusted_astar_stream_wrapper,
     test_compile_wam_runtime_output,
     test_write_wam_rust_project,
     test_project_cargo_content,


### PR DESCRIPTION
## Summary

This PR extends Rust foreign lowering beyond aggregate wrappers to support ordinary predicate wrappers whose bodies compose around foreign-lowered path kernels.

It adds direct foreign-only lowering for mixed-goal stream wrappers over:

- `weighted_path/3`
- `astar_weighted_path/4`

The new path reuses the existing foreign kernel execution, applies wrapper-local numeric filters and arithmetic, and then streams the resulting `(target, value)` tuples back through the existing foreign result queue.

## Why

Rust WAM foreign lowering already handled:

- direct foreign-lowered recursive kernels
- scalar aggregate wrappers
- grouped aggregate wrappers
- mixed-goal aggregate wrappers

The remaining gap was ordinary non-aggregate wrapper predicates such as:

- `filtered_adjusted_weighted_path/3`
- `filtered_adjusted_astar_weighted_path/4`

Without this change, that composition pattern was not covered by the direct foreign wrapper path.

## What Changed

- imported `classify_aggregate_goal/2` into the Rust target so non-aggregate wrapper bodies can reuse the same goal-shape analysis already used by aggregate wrappers
- added `compile_rust_foreign_stream_wrapper/6` for:
  - 3-arity weighted wrappers
  - 4-arity A* wrappers
- wired `compile_predicate_to_rust_normal/4` to try this new stream-wrapper lowering tier after aggregate-wrapper lowering and before older native/fallback tiers
- generated wrappers now:
  - initialize a foreign-only VM wrapper
  - delegate to `weighted_path/3` or `astar_weighted_path/4`
  - apply local constraints like `Cost > 2`
  - apply local arithmetic like `Adjusted is Cost + 1`
  - stream packed tuple results back through `finish_foreign_results`

## Validation

Passed:

- `swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`

Added target coverage for:

- `filtered_adjusted_weighted_path/3`
- `filtered_adjusted_astar_weighted_path/4`

Added generated Rust runtime coverage for:

- unbound-target streaming
- exact bound-target matching
- failure when filtering removes all solutions

## Notes

- These wrappers compose over the foreign shortest-path kernels, so streamed results reflect the kernel semantics: filtered shortest results per target, not every recursive proof.
- This PR closes the non-aggregate mixed-goal composition gap for simple numeric filter/arithmetic wrappers. The next likely follow-up is broader wrapper composition with additional relational joins after a foreign kernel call.
