### PR TITLE
feat(rust): Support relational joins after foreign kernels in Rust WAM

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3629,6 +3629,13 @@ compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
     functor(Head, Pred, Arity),
     findall(Head-Body, user:clause(Head, Body), Clauses),
     Clauses = [SingleHead-SingleBody],
+    compile_rust_foreign_join_stream_wrapper(Pred, Arity, SingleHead, SingleBody, IncludeMain, RustCode),
+    !.
+compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
+    option(include_main(IncludeMain), Options, true),
+    functor(Head, Pred, Arity),
+    findall(Head-Body, user:clause(Head, Body), Clauses),
+    Clauses = [SingleHead-SingleBody],
     compile_rust_foreign_stream_wrapper(Pred, Arity, SingleHead, SingleBody, IncludeMain, RustCode),
     !.
 compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
@@ -4134,6 +4141,235 @@ rust_foreign_lowerable_astar_shortest_path(Pred, 4, Clauses,
 
 rust_foreign_edge_pair(forward, Left, Right, Left-Right).
 rust_foreign_edge_pair(reverse, Left, Right, Right-Left).
+
+compile_rust_foreign_join_stream_wrapper(Pred, 3, Head, Body, _IncludeMain, RustCode) :-
+    Head =.. [Pred, HeadStart, HeadJoinOut, HeadResult],
+    classify_aggregate_goal(Body, GoalInfo),
+    get_dict(relations, GoalInfo, [RelGoal, JoinGoal]),
+    RelGoal =.. [InnerPred, GoalStart, GoalTarget, GoalCost],
+    HeadStart == GoalStart,
+    JoinGoal =.. [JoinPred, GoalTarget, GoalJoinOut],
+    HeadJoinOut == GoalJoinOut,
+    get_dict(other, GoalInfo, []),
+    functor(InnerHead, InnerPred, 3),
+    findall(InnerHead-InnerBody, user:clause(InnerHead, InnerBody), Clauses),
+    Clauses \= [],
+    rust_foreign_lowerable_weighted_shortest_path(InnerPred, 3, Clauses, WeightPred/3, FactTriples),
+    findall(JoinLeft-JoinRight,
+        ( functor(JoinHead, JoinPred, 2),
+          user:clause(JoinHead, true),
+          JoinHead =.. [JoinPred, JoinLeft, JoinRight],
+          atom(JoinLeft),
+          atom(JoinRight)
+        ),
+        JoinPairs),
+    JoinPairs \= [],
+    rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalJoinOut, GoalCost],
+        HeadResult, SetupCode, ValueExpr, FilterCond),
+    atom_string(Pred, PredStr),
+    atom_string(InnerPred, InnerPredStr),
+    format(string(PredKey), '~w/3', [Pred]),
+    format(string(WeightPredKey), '~w/3', [WeightPred]),
+    format(string(JoinPredKey), '~w/2', [JoinPred]),
+    rust_weighted_fact_triples_literal(FactTriples, TriplesLiteral),
+    rust_atom_fact_pairs_literal(JoinPairs, JoinPairsLiteral),
+    format(string(RustCode),
+'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool {
+    vm.reset_query();
+    vm.code = Vec::new();
+    vm.labels = HashMap::new();
+    vm.pc = 1;
+    vm.register_foreign_result_layout("~w", "tuple:2");
+    vm.register_foreign_result_mode("~w", "stream");
+    vm.register_foreign_native_kind("~w/3", "weighted_shortest_path3");
+    vm.register_foreign_result_layout("~w/3", "tuple:2");
+    vm.register_foreign_result_mode("~w/3", "stream");
+    vm.register_foreign_string_config("~w/3", "weight_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+    vm.register_indexed_atom_fact2_pairs("~w", &~w);
+
+    let join_filter = match &a2 {
+        Value::Atom(label) => Some(label.clone()),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let result_filter = match &a3 {
+        Value::Float(value) => Some(*value),
+        Value::Integer(value) => Some(*value as f64),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let temp_target = "__wrapper_target".to_string();
+    let temp_cost = "__wrapper_cost".to_string();
+
+    vm.set_reg("A1", a1.clone());
+    vm.set_reg("A2", Value::Unbound(temp_target.clone()));
+    vm.set_reg("A3", Value::Unbound(temp_cost.clone()));
+
+    if !vm.execute_foreign_predicate("~w", 3) {
+        vm.bindings.remove(&temp_target);
+        vm.bindings.remove(&temp_cost);
+        return false;
+    }
+
+    let mut packed_results: Vec<Value> = Vec::new();
+    loop {
+        let target = match vm.bindings.get(&temp_target).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Atom(target)) => target,
+            _ => break,
+        };
+        let cost = match vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Float(cost)) => cost,
+            _ => break,
+        };
+        let joined_values = match vm.indexed_atom_fact2.get("~w").and_then(|table| table.get(&target)) {
+            Some(values) => values.clone(),
+            None => Vec::new(),
+        };
+        for joined_value in joined_values.iter() {
+~w            let output_value = ~w;
+            if (join_filter.as_ref().map(|want| want == joined_value).unwrap_or(true))
+                && (~w)
+                && (result_filter.as_ref().map(|want| (output_value - *want).abs() < 1e-9).unwrap_or(true)) {
+                packed_results.push(Value::Str("__tuple__".to_string(), vec![
+                    Value::Atom(joined_value.clone()),
+                    Value::Float(output_value),
+                ]));
+            }
+        }
+        if !vm.backtrack() {
+            break;
+        }
+    }
+
+    vm.bindings.remove(&temp_target);
+    vm.bindings.remove(&temp_cost);
+    vm.finish_foreign_results("~w", vec![a2.clone(), a3.clone()], packed_results)
+}', [PredStr, PredKey, PredKey, InnerPredStr, InnerPredStr, InnerPredStr,
+      InnerPredStr, WeightPredKey, WeightPredKey, TriplesLiteral, JoinPredKey, JoinPairsLiteral,
+      InnerPredStr, JoinPredKey, SetupCode, ValueExpr, FilterCond, PredKey]).
+compile_rust_foreign_join_stream_wrapper(Pred, 4, Head, Body, _IncludeMain, RustCode) :-
+    Head =.. [Pred, HeadStart, HeadJoinOut, HeadDim, HeadResult],
+    classify_aggregate_goal(Body, GoalInfo),
+    get_dict(relations, GoalInfo, [RelGoal, JoinGoal]),
+    RelGoal =.. [InnerPred, GoalStart, GoalTarget, GoalDim, GoalCost],
+    HeadStart == GoalStart,
+    HeadDim == GoalDim,
+    JoinGoal =.. [JoinPred, GoalTarget, GoalJoinOut],
+    HeadJoinOut == GoalJoinOut,
+    get_dict(other, GoalInfo, []),
+    functor(InnerHead, InnerPred, 4),
+    findall(InnerHead-InnerBody, user:clause(InnerHead, InnerBody), Clauses),
+    Clauses \= [],
+    rust_foreign_lowerable_astar_shortest_path(InnerPred, 4, Clauses,
+        WeightPred/3, FactTriples, DirectPred/3, DirectTriples, DefaultDim),
+    findall(JoinLeft-JoinRight,
+        ( functor(JoinHead, JoinPred, 2),
+          user:clause(JoinHead, true),
+          JoinHead =.. [JoinPred, JoinLeft, JoinRight],
+          atom(JoinLeft),
+          atom(JoinRight)
+        ),
+        JoinPairs),
+    JoinPairs \= [],
+    rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalJoinOut, GoalDim, GoalCost],
+        HeadResult, SetupCode, ValueExpr, FilterCond),
+    atom_string(Pred, PredStr),
+    atom_string(InnerPred, InnerPredStr),
+    format(string(PredKey), '~w/4', [Pred]),
+    format(string(WeightPredKey), '~w/3', [WeightPred]),
+    format(string(DirectPredKey), '~w/3', [DirectPred]),
+    format(string(JoinPredKey), '~w/2', [JoinPred]),
+    rust_weighted_fact_triples_literal(FactTriples, WeightTriplesLiteral),
+    rust_weighted_fact_triples_literal(DirectTriples, DirectTriplesLiteral),
+    rust_atom_fact_pairs_literal(JoinPairs, JoinPairsLiteral),
+    format(string(RustCode),
+'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool {
+    vm.reset_query();
+    vm.code = Vec::new();
+    vm.labels = HashMap::new();
+    vm.pc = 1;
+    vm.register_foreign_result_layout("~w", "tuple:2");
+    vm.register_foreign_result_mode("~w", "stream");
+    vm.register_foreign_native_kind("~w/4", "astar_shortest_path4");
+    vm.register_foreign_result_layout("~w/4", "tuple:2");
+    vm.register_foreign_result_mode("~w/4", "stream");
+    vm.register_foreign_string_config("~w/4", "weight_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+    vm.register_foreign_string_config("~w/4", "direct_dist_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+    vm.register_foreign_usize_config("~w/4", "dimensionality", ~w);
+    vm.register_indexed_atom_fact2_pairs("~w", &~w);
+
+    let join_filter = match &a2 {
+        Value::Atom(label) => Some(label.clone()),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let result_filter = match &a4 {
+        Value::Float(value) => Some(*value),
+        Value::Integer(value) => Some(*value as f64),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let temp_target = "__wrapper_target".to_string();
+    let temp_cost = "__wrapper_cost".to_string();
+
+    vm.set_reg("A1", a1.clone());
+    vm.set_reg("A2", Value::Unbound(temp_target.clone()));
+    vm.set_reg("A3", a3.clone());
+    vm.set_reg("A4", Value::Unbound(temp_cost.clone()));
+
+    let dim_value = match &a3 {
+        Value::Integer(d) => *d as f64,
+        Value::Float(d) => *d,
+        _ => ~w_f64,
+    };
+
+    if !vm.execute_foreign_predicate("~w", 4) {
+        vm.bindings.remove(&temp_target);
+        vm.bindings.remove(&temp_cost);
+        return false;
+    }
+
+    let mut packed_results: Vec<Value> = Vec::new();
+    loop {
+        let target = match vm.bindings.get(&temp_target).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Atom(target)) => target,
+            _ => break,
+        };
+        let cost = match vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Float(cost)) => cost,
+            _ => break,
+        };
+        let joined_values = match vm.indexed_atom_fact2.get("~w").and_then(|table| table.get(&target)) {
+            Some(values) => values.clone(),
+            None => Vec::new(),
+        };
+        for joined_value in joined_values.iter() {
+~w            let output_value = ~w;
+            if (join_filter.as_ref().map(|want| want == joined_value).unwrap_or(true))
+                && (~w)
+                && (result_filter.as_ref().map(|want| (output_value - *want).abs() < 1e-9).unwrap_or(true)) {
+                packed_results.push(Value::Str("__tuple__".to_string(), vec![
+                    Value::Atom(joined_value.clone()),
+                    Value::Float(output_value),
+                ]));
+            }
+        }
+        if !vm.backtrack() {
+            break;
+        }
+    }
+
+    vm.bindings.remove(&temp_target);
+    vm.bindings.remove(&temp_cost);
+    vm.finish_foreign_results("~w", vec![a2.clone(), a4.clone()], packed_results)
+}', [PredStr, PredKey, PredKey, InnerPredStr, InnerPredStr, InnerPredStr,
+      InnerPredStr, WeightPredKey, WeightPredKey, WeightTriplesLiteral,
+      InnerPredStr, DirectPredKey, DirectPredKey, DirectTriplesLiteral,
+      InnerPredStr, DefaultDim, JoinPredKey, JoinPairsLiteral, DefaultDim, InnerPredStr,
+      JoinPredKey, SetupCode, ValueExpr, FilterCond, PredKey]).
 
 compile_rust_foreign_stream_wrapper(Pred, 3, Head, Body, _IncludeMain, RustCode) :-
     Head =.. [Pred, HeadStart, HeadTarget, HeadResult],
@@ -4821,6 +5057,16 @@ rust_weighted_fact_triples_literal(Triples, Literal) :-
     maplist(rust_weighted_fact_triple_literal, Triples, TripleLiterals),
     atomic_list_concat(TripleLiterals, ', ', Joined),
     format(string(Literal), '[~w]', [Joined]).
+
+rust_atom_fact_pairs_literal(Pairs, Literal) :-
+    maplist(rust_atom_fact_pair_literal, Pairs, PairLiterals),
+    atomic_list_concat(PairLiterals, ', ', Joined),
+    format(string(Literal), '[~w]', [Joined]).
+
+rust_atom_fact_pair_literal(Left-Right, Literal) :-
+    rust_literal(Left, LeftLiteral),
+    rust_literal(Right, RightLiteral),
+    format(string(Literal), '(~w, ~w)', [LeftLiteral, RightLiteral]).
 
 rust_weighted_fact_triple_literal(Left-Right-Weight, Literal) :-
     rust_literal(Left, LeftLiteral),

--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -150,6 +150,26 @@ filtered_adjusted_astar_weighted_path(Start, Target, Dim, Adjusted) :-
     Cost > 2,
     Adjusted is Cost + 1.
 
+:- dynamic target_label/2.
+target_label(b, branch_b).
+target_label(c, branch_c).
+target_label(d, goal_d1).
+target_label(d, goal_d2).
+
+:- dynamic labeled_adjusted_weighted_path/3.
+labeled_adjusted_weighted_path(Start, Label, Adjusted) :-
+    weighted_path(Start, Target, Cost),
+    target_label(Target, Label),
+    Cost > 2,
+    Adjusted is Cost + 1.
+
+:- dynamic labeled_adjusted_astar_weighted_path/4.
+labeled_adjusted_astar_weighted_path(Start, Label, Dim, Adjusted) :-
+    astar_weighted_path(Start, Target, Dim, Cost),
+    target_label(Target, Label),
+    Cost > 2,
+    Adjusted is Cost + 1.
+
 %% Integration test
 test_runtime_execution :-
     Test = 'WAM-Rust Runtime: end-to-end execution',
@@ -160,7 +180,7 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:astar_weighted_path/4, user:min_semantic_dist/3, user:min_semantic_dist_astar/4, user:grouped_min_semantic_dist/3, user:grouped_min_semantic_dist_astar/4, user:filtered_adjusted_min_semantic_dist/3, user:filtered_adjusted_min_semantic_dist_astar/4, user:filtered_adjusted_weighted_path/3, user:filtered_adjusted_astar_weighted_path/4],
+        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:astar_weighted_path/4, user:min_semantic_dist/3, user:min_semantic_dist_astar/4, user:grouped_min_semantic_dist/3, user:grouped_min_semantic_dist_astar/4, user:filtered_adjusted_min_semantic_dist/3, user:filtered_adjusted_min_semantic_dist_astar/4, user:filtered_adjusted_weighted_path/3, user:filtered_adjusted_astar_weighted_path/4, user:labeled_adjusted_weighted_path/3, user:labeled_adjusted_astar_weighted_path/4],
             [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
@@ -187,6 +207,8 @@ use runtime_test::filtered_adjusted_min_semantic_dist;
 use runtime_test::filtered_adjusted_min_semantic_dist_astar;
 use runtime_test::filtered_adjusted_weighted_path;
 use runtime_test::filtered_adjusted_astar_weighted_path;
+use runtime_test::labeled_adjusted_weighted_path;
+use runtime_test::labeled_adjusted_astar_weighted_path;
 
 #[test]
 fn test_generated_predicates() {
@@ -1011,6 +1033,97 @@ fn test_generated_predicates() {
         Value::Integer(5),
         Value::Unbound("AStarStreamNoPath".to_string()));
     assert!(!ok48, "filtered_adjusted_astar_weighted_path(s, a, 5, Adjusted) should fail");
+
+    // Test labeled_adjusted_weighted_path/3 relational join wrapper
+    let mut vm_labeled_weighted = WamState::new(vec![], std::collections::HashMap::new());
+    let ok49 = labeled_adjusted_weighted_path(&mut vm_labeled_weighted,
+        Value::Atom("s".to_string()),
+        Value::Unbound("WeightedLabel".to_string()),
+        Value::Unbound("WeightedAdjusted".to_string()));
+    assert!(ok49, "labeled_adjusted_weighted_path(s, Label, Adjusted) first solution should succeed");
+    let mut labeled_weighted_results: Vec<(String, f64)> = Vec::new();
+    if let (Some(Value::Atom(label)), Some(Value::Float(cost))) =
+        (vm_labeled_weighted.bindings.get("WeightedLabel").cloned(), vm_labeled_weighted.bindings.get("WeightedAdjusted").cloned()) {
+        labeled_weighted_results.push((label, cost));
+    } else {
+        panic!("expected first labeled_adjusted_weighted_path result");
+    }
+    while vm_labeled_weighted.backtrack() {
+        if let (Some(Value::Atom(label)), Some(Value::Float(cost))) =
+            (vm_labeled_weighted.bindings.get("WeightedLabel").cloned(), vm_labeled_weighted.bindings.get("WeightedAdjusted").cloned()) {
+            labeled_weighted_results.push((label, cost));
+        } else {
+            panic!("expected labeled_adjusted_weighted_path backtrack result");
+        }
+    }
+    labeled_weighted_results.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.partial_cmp(&b.1).unwrap()));
+    assert_eq!(labeled_weighted_results, vec![
+        ("branch_b".to_string(), 4.0),
+        ("branch_c".to_string(), 5.0),
+        ("goal_d1".to_string(), 8.0),
+        ("goal_d2".to_string(), 8.0),
+    ]);
+
+    let mut vm_labeled_weighted_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok50 = labeled_adjusted_weighted_path(&mut vm_labeled_weighted_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("goal_d2".to_string()),
+        Value::Float(8.0));
+    assert!(ok50, "labeled_adjusted_weighted_path(s, goal_d2, 8.0) should succeed");
+
+    let mut vm_labeled_weighted_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok51 = labeled_adjusted_weighted_path(&mut vm_labeled_weighted_fail,
+        Value::Atom("s".to_string()),
+        Value::Atom("missing".to_string()),
+        Value::Unbound("WeightedMissing".to_string()));
+    assert!(!ok51, "labeled_adjusted_weighted_path(s, missing, Adjusted) should fail");
+
+    // Test labeled_adjusted_astar_weighted_path/4 relational join wrapper
+    let mut vm_labeled_astar = WamState::new(vec![], std::collections::HashMap::new());
+    let ok52 = labeled_adjusted_astar_weighted_path(&mut vm_labeled_astar,
+        Value::Atom("s".to_string()),
+        Value::Unbound("AStarLabel".to_string()),
+        Value::Integer(5),
+        Value::Unbound("AStarAdjusted".to_string()));
+    assert!(ok52, "labeled_adjusted_astar_weighted_path(s, Label, 5, Adjusted) first solution should succeed");
+    let mut labeled_astar_results: Vec<(String, f64)> = Vec::new();
+    if let (Some(Value::Atom(label)), Some(Value::Float(cost))) =
+        (vm_labeled_astar.bindings.get("AStarLabel").cloned(), vm_labeled_astar.bindings.get("AStarAdjusted").cloned()) {
+        labeled_astar_results.push((label, cost));
+    } else {
+        panic!("expected first labeled_adjusted_astar_weighted_path result");
+    }
+    while vm_labeled_astar.backtrack() {
+        if let (Some(Value::Atom(label)), Some(Value::Float(cost))) =
+            (vm_labeled_astar.bindings.get("AStarLabel").cloned(), vm_labeled_astar.bindings.get("AStarAdjusted").cloned()) {
+            labeled_astar_results.push((label, cost));
+        } else {
+            panic!("expected labeled_adjusted_astar_weighted_path backtrack result");
+        }
+    }
+    labeled_astar_results.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.partial_cmp(&b.1).unwrap()));
+    assert_eq!(labeled_astar_results, vec![
+        ("branch_b".to_string(), 4.0),
+        ("branch_c".to_string(), 5.0),
+        ("goal_d1".to_string(), 8.0),
+        ("goal_d2".to_string(), 8.0),
+    ]);
+
+    let mut vm_labeled_astar_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok53 = labeled_adjusted_astar_weighted_path(&mut vm_labeled_astar_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("goal_d1".to_string()),
+        Value::Integer(5),
+        Value::Float(8.0));
+    assert!(ok53, "labeled_adjusted_astar_weighted_path(s, goal_d1, 5, 8.0) should succeed");
+
+    let mut vm_labeled_astar_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok54 = labeled_adjusted_astar_weighted_path(&mut vm_labeled_astar_fail,
+        Value::Atom("s".to_string()),
+        Value::Atom("missing".to_string()),
+        Value::Integer(5),
+        Value::Unbound("AStarMissing".to_string()));
+    assert!(!ok54, "labeled_adjusted_astar_weighted_path(s, missing, 5, Adjusted) should fail");
 }
 ',
         setup_call_cleanup(open(TestPath, write, S), format(S, "~w", [TestContent]), close(S)),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -48,6 +48,9 @@ test_simple_fact(foo, bar).
 :- dynamic filtered_adjusted_min_semantic_dist_astar/4.
 :- dynamic filtered_adjusted_weighted_path/3.
 :- dynamic filtered_adjusted_astar_weighted_path/4.
+:- dynamic target_label/2.
+:- dynamic labeled_adjusted_weighted_path/3.
+:- dynamic labeled_adjusted_astar_weighted_path/4.
 :- dynamic tc_parent/2.
 :- dynamic max_depth/1.
 
@@ -126,6 +129,11 @@ direct_semantic_dist(b, c, 1.0).
 direct_semantic_dist(b, d, 4.0).
 direct_semantic_dist(c, d, 3.0).
 
+target_label(b, branch_b).
+target_label(c, branch_c).
+target_label(d, goal_d1).
+target_label(d, goal_d2).
+
 weighted_path(X, Y, W) :- weighted_edge(X, Y, W).
 weighted_path(X, Y, Cost) :-
     weighted_edge(X, Z, W),
@@ -168,6 +176,18 @@ filtered_adjusted_weighted_path(Start, Target, Adjusted) :-
 
 filtered_adjusted_astar_weighted_path(Start, Target, Dim, Adjusted) :-
     astar_weighted_path(Start, Target, Dim, Cost),
+    Cost > 2,
+    Adjusted is Cost + 1.
+
+labeled_adjusted_weighted_path(Start, Label, Adjusted) :-
+    weighted_path(Start, Target, Cost),
+    target_label(Target, Label),
+    Cost > 2,
+    Adjusted is Cost + 1.
+
+labeled_adjusted_astar_weighted_path(Start, Label, Dim, Adjusted) :-
+    astar_weighted_path(Start, Target, Dim, Cost),
+    target_label(Target, Label),
     Cost > 2,
     Adjusted is Cost + 1.
 
@@ -861,6 +881,36 @@ test_filtered_adjusted_astar_stream_wrapper :-
     ;   fail_test(Test, 'Mixed-goal A* stream wrapper did not lower correctly')
     ).
 
+test_labeled_weighted_stream_wrapper :-
+    Test = 'WAM-Rust: relational join stream wrapper expands weighted_path/3 results',
+    (   rust_target:compile_predicate_to_rust(user:labeled_adjusted_weighted_path/3,
+            [include_main(false), foreign_lowering(true), wam_fallback(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'pub fn labeled_adjusted_weighted_path(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool'),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("weighted_path/3", "weighted_shortest_path3")'),
+        sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("target_label/2", &[("b", "branch_b"), ("c", "branch_c"), ("d", "goal_d1"), ("d", "goal_d2")])'),
+        sub_string(S, _, _, _, 'let joined_values = match vm.indexed_atom_fact2.get("target_label/2").and_then(|table| table.get(&target)) {'),
+        sub_string(S, _, _, _, 'for joined_value in joined_values.iter() {'),
+        sub_string(S, _, _, _, 'vm.finish_foreign_results("labeled_adjusted_weighted_path/3", vec![a2.clone(), a3.clone()], packed_results)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Relational weighted stream wrapper did not lower correctly')
+    ).
+
+test_labeled_astar_stream_wrapper :-
+    Test = 'WAM-Rust: relational join stream wrapper expands astar_weighted_path/4 results',
+    (   rust_target:compile_predicate_to_rust(user:labeled_adjusted_astar_weighted_path/4,
+            [include_main(false), foreign_lowering(true), wam_fallback(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'pub fn labeled_adjusted_astar_weighted_path(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool'),
+        sub_string(S, _, _, _, 'register_foreign_native_kind("astar_weighted_path/4", "astar_shortest_path4")'),
+        sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("target_label/2", &[("b", "branch_b"), ("c", "branch_c"), ("d", "goal_d1"), ("d", "goal_d2")])'),
+        sub_string(S, _, _, _, 'let joined_values = match vm.indexed_atom_fact2.get("target_label/2").and_then(|table| table.get(&target)) {'),
+        sub_string(S, _, _, _, 'for joined_value in joined_values.iter() {'),
+        sub_string(S, _, _, _, 'vm.finish_foreign_results("labeled_adjusted_astar_weighted_path/4", vec![a2.clone(), a4.clone()], packed_results)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Relational A* stream wrapper did not lower correctly')
+    ).
+
 test_compile_wam_runtime_output :-
     Test = 'WAM-Rust E2E: full runtime generates valid impl block',
     (   compile_wam_runtime_to_rust([], Code),
@@ -1183,6 +1233,8 @@ run_tests :-
     test_filtered_adjusted_astar_min_wrapper,
     test_filtered_adjusted_weighted_stream_wrapper,
     test_filtered_adjusted_astar_stream_wrapper,
+    test_labeled_weighted_stream_wrapper,
+    test_labeled_astar_stream_wrapper,
     test_compile_wam_runtime_output,
     test_write_wam_rust_project,
     test_project_cargo_content,


### PR DESCRIPTION
## Summary

This PR extends Rust foreign lowering to cover wrapper predicates that compose a foreign-lowered shortest-path kernel with an additional relational join in the same body.

It adds direct foreign-only lowering for wrappers shaped like:

- foreign path kernel
- binary fact join on the hidden target
- numeric filter and/or arithmetic
- streamed `(joined_value, output_value)` results

The new path is validated for both:

- `weighted_path/3`
- `astar_weighted_path/4`

## Why

Rust foreign lowering already handled:

- direct recursive kernels
- scalar aggregate wrappers
- grouped aggregate wrappers
- mixed-goal scalar wrappers
- mixed-goal non-aggregate wrappers with numeric filters/arithmetic

The remaining composition gap was ordinary wrappers where a foreign kernel is followed by an extra relational goal, not just arithmetic or comparison logic.

This PR closes that gap for the first useful join shape: an indexed binary fact relation keyed by the foreign kernel’s hidden target.

## What Changed

- added a new lowering tier in `compile_predicate_to_rust_normal/4` for relational join stream wrappers
- introduced `compile_rust_foreign_join_stream_wrapper/6` for:
  - 3-arity weighted wrappers
  - 4-arity A* wrappers
- generated wrappers now:
  - execute the foreign shortest-path kernel
  - read the hidden target and cost from the foreign result stream
  - join the hidden target through an indexed `Pred/2` fact table
  - apply wrapper-local filters/arithmetic
  - stream packed tuple results through `finish_foreign_results`

## Validation

Passed:

- `swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`

Added target and generated-runtime coverage for:

- `labeled_adjusted_weighted_path/3`
- `labeled_adjusted_astar_weighted_path/4`

These tests validate:

- unbound joined-label streaming
- bound joined-label matching
- duplicated joined outputs where the join relation has multiple labels for one target
- failure when the join/filter path produces no matching rows

## Notes

- This PR intentionally targets the narrow join shape that reuses existing indexed binary fact support cleanly.
- The next likely follow-up is broader wrapper composition where foreign kernels are followed by more general relational joins or multiple join stages.
