### PR TITLE
feat(rust): Support multi-stage joins after foreign kernels in Rust WAM

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3629,6 +3629,13 @@ compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
     functor(Head, Pred, Arity),
     findall(Head-Body, user:clause(Head, Body), Clauses),
     Clauses = [SingleHead-SingleBody],
+    compile_rust_foreign_multistage_join_stream_wrapper(Pred, Arity, SingleHead, SingleBody, IncludeMain, RustCode),
+    !.
+compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
+    option(include_main(IncludeMain), Options, true),
+    functor(Head, Pred, Arity),
+    findall(Head-Body, user:clause(Head, Body), Clauses),
+    Clauses = [SingleHead-SingleBody],
     compile_rust_foreign_join_stream_wrapper(Pred, Arity, SingleHead, SingleBody, IncludeMain, RustCode),
     !.
 compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
@@ -4141,6 +4148,242 @@ rust_foreign_lowerable_astar_shortest_path(Pred, 4, Clauses,
 
 rust_foreign_edge_pair(forward, Left, Right, Left-Right).
 rust_foreign_edge_pair(reverse, Left, Right, Right-Left).
+
+compile_rust_foreign_multistage_join_stream_wrapper(Pred, 3, Head, Body, _IncludeMain, RustCode) :-
+    Head =.. [Pred, HeadStart, HeadJoinOut, HeadResult],
+    classify_aggregate_goal(Body, GoalInfo),
+    get_dict(relations, GoalInfo, [RelGoal, JoinGoal1, JoinGoal2]),
+    RelGoal =.. [InnerPred, GoalStart, GoalTarget, GoalCost],
+    HeadStart == GoalStart,
+    JoinGoal1 =.. [JoinPred1, GoalTarget, JoinMid],
+    JoinGoal2 =.. [JoinPred2, JoinMid, GoalJoinOut],
+    HeadJoinOut == GoalJoinOut,
+    get_dict(other, GoalInfo, []),
+    functor(InnerHead, InnerPred, 3),
+    findall(InnerHead-InnerBody, user:clause(InnerHead, InnerBody), Clauses),
+    Clauses \= [],
+    rust_foreign_lowerable_weighted_shortest_path(InnerPred, 3, Clauses, WeightPred/3, FactTriples),
+    rust_binary_atom_fact_pairs(JoinPred1/2, JoinPairs1),
+    rust_binary_atom_fact_pairs(JoinPred2/2, JoinPairs2),
+    rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalJoinOut, GoalCost],
+        HeadResult, SetupCode, ValueExpr, FilterCond),
+    atom_string(Pred, PredStr),
+    atom_string(InnerPred, InnerPredStr),
+    format(string(PredKey), '~w/3', [Pred]),
+    format(string(WeightPredKey), '~w/3', [WeightPred]),
+    format(string(JoinPredKey1), '~w/2', [JoinPred1]),
+    format(string(JoinPredKey2), '~w/2', [JoinPred2]),
+    rust_weighted_fact_triples_literal(FactTriples, TriplesLiteral),
+    rust_atom_fact_pairs_literal(JoinPairs1, JoinPairsLiteral1),
+    rust_atom_fact_pairs_literal(JoinPairs2, JoinPairsLiteral2),
+    format(string(RustCode),
+'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool {
+    vm.reset_query();
+    vm.code = Vec::new();
+    vm.labels = HashMap::new();
+    vm.pc = 1;
+    vm.register_foreign_result_layout("~w", "tuple:2");
+    vm.register_foreign_result_mode("~w", "stream");
+    vm.register_foreign_native_kind("~w/3", "weighted_shortest_path3");
+    vm.register_foreign_result_layout("~w/3", "tuple:2");
+    vm.register_foreign_result_mode("~w/3", "stream");
+    vm.register_foreign_string_config("~w/3", "weight_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+    vm.register_indexed_atom_fact2_pairs("~w", &~w);
+    vm.register_indexed_atom_fact2_pairs("~w", &~w);
+
+    let join_filter = match &a2 {
+        Value::Atom(label) => Some(label.clone()),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let result_filter = match &a3 {
+        Value::Float(value) => Some(*value),
+        Value::Integer(value) => Some(*value as f64),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let temp_target = "__wrapper_target".to_string();
+    let temp_cost = "__wrapper_cost".to_string();
+
+    vm.set_reg("A1", a1.clone());
+    vm.set_reg("A2", Value::Unbound(temp_target.clone()));
+    vm.set_reg("A3", Value::Unbound(temp_cost.clone()));
+
+    if !vm.execute_foreign_predicate("~w", 3) {
+        vm.bindings.remove(&temp_target);
+        vm.bindings.remove(&temp_cost);
+        return false;
+    }
+
+    let mut packed_results: Vec<Value> = Vec::new();
+    loop {
+        let target = match vm.bindings.get(&temp_target).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Atom(target)) => target,
+            _ => break,
+        };
+        let cost = match vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Float(cost)) => cost,
+            _ => break,
+        };
+        let joined_values_1 = match vm.indexed_atom_fact2.get("~w").and_then(|table| table.get(&target)) {
+            Some(values) => values.clone(),
+            None => Vec::new(),
+        };
+        for joined_value_1 in joined_values_1.iter() {
+            let joined_values_2 = match vm.indexed_atom_fact2.get("~w").and_then(|table| table.get(joined_value_1)) {
+                Some(values) => values.clone(),
+                None => Vec::new(),
+            };
+            for joined_value_2 in joined_values_2.iter() {
+~w                let output_value = ~w;
+                if (join_filter.as_ref().map(|want| want == joined_value_2).unwrap_or(true))
+                    && (~w)
+                    && (result_filter.as_ref().map(|want| (output_value - *want).abs() < 1e-9).unwrap_or(true)) {
+                    packed_results.push(Value::Str("__tuple__".to_string(), vec![
+                        Value::Atom(joined_value_2.clone()),
+                        Value::Float(output_value),
+                    ]));
+                }
+            }
+        }
+        if !vm.backtrack() {
+            break;
+        }
+    }
+
+    vm.bindings.remove(&temp_target);
+    vm.bindings.remove(&temp_cost);
+    vm.finish_foreign_results("~w", vec![a2.clone(), a3.clone()], packed_results)
+}', [PredStr, PredKey, PredKey, InnerPredStr, InnerPredStr, InnerPredStr,
+      InnerPredStr, WeightPredKey, WeightPredKey, TriplesLiteral,
+      JoinPredKey1, JoinPairsLiteral1, JoinPredKey2, JoinPairsLiteral2,
+      InnerPredStr, JoinPredKey1, JoinPredKey2, SetupCode, ValueExpr, FilterCond, PredKey]).
+compile_rust_foreign_multistage_join_stream_wrapper(Pred, 4, Head, Body, _IncludeMain, RustCode) :-
+    Head =.. [Pred, HeadStart, HeadJoinOut, HeadDim, HeadResult],
+    classify_aggregate_goal(Body, GoalInfo),
+    get_dict(relations, GoalInfo, [RelGoal, JoinGoal1, JoinGoal2]),
+    RelGoal =.. [InnerPred, GoalStart, GoalTarget, GoalDim, GoalCost],
+    HeadStart == GoalStart,
+    HeadDim == GoalDim,
+    JoinGoal1 =.. [JoinPred1, GoalTarget, JoinMid],
+    JoinGoal2 =.. [JoinPred2, JoinMid, GoalJoinOut],
+    HeadJoinOut == GoalJoinOut,
+    get_dict(other, GoalInfo, []),
+    functor(InnerHead, InnerPred, 4),
+    findall(InnerHead-InnerBody, user:clause(InnerHead, InnerBody), Clauses),
+    Clauses \= [],
+    rust_foreign_lowerable_astar_shortest_path(InnerPred, 4, Clauses,
+        WeightPred/3, FactTriples, DirectPred/3, DirectTriples, DefaultDim),
+    rust_binary_atom_fact_pairs(JoinPred1/2, JoinPairs1),
+    rust_binary_atom_fact_pairs(JoinPred2/2, JoinPairs2),
+    rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalJoinOut, GoalDim, GoalCost],
+        HeadResult, SetupCode, ValueExpr, FilterCond),
+    atom_string(Pred, PredStr),
+    atom_string(InnerPred, InnerPredStr),
+    format(string(PredKey), '~w/4', [Pred]),
+    format(string(WeightPredKey), '~w/3', [WeightPred]),
+    format(string(DirectPredKey), '~w/3', [DirectPred]),
+    format(string(JoinPredKey1), '~w/2', [JoinPred1]),
+    format(string(JoinPredKey2), '~w/2', [JoinPred2]),
+    rust_weighted_fact_triples_literal(FactTriples, WeightTriplesLiteral),
+    rust_weighted_fact_triples_literal(DirectTriples, DirectTriplesLiteral),
+    rust_atom_fact_pairs_literal(JoinPairs1, JoinPairsLiteral1),
+    rust_atom_fact_pairs_literal(JoinPairs2, JoinPairsLiteral2),
+    format(string(RustCode),
+'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool {
+    vm.reset_query();
+    vm.code = Vec::new();
+    vm.labels = HashMap::new();
+    vm.pc = 1;
+    vm.register_foreign_result_layout("~w", "tuple:2");
+    vm.register_foreign_result_mode("~w", "stream");
+    vm.register_foreign_native_kind("~w/4", "astar_shortest_path4");
+    vm.register_foreign_result_layout("~w/4", "tuple:2");
+    vm.register_foreign_result_mode("~w/4", "stream");
+    vm.register_foreign_string_config("~w/4", "weight_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+    vm.register_foreign_string_config("~w/4", "direct_dist_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+    vm.register_foreign_usize_config("~w/4", "dimensionality", ~w);
+    vm.register_indexed_atom_fact2_pairs("~w", &~w);
+    vm.register_indexed_atom_fact2_pairs("~w", &~w);
+
+    let join_filter = match &a2 {
+        Value::Atom(label) => Some(label.clone()),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let result_filter = match &a4 {
+        Value::Float(value) => Some(*value),
+        Value::Integer(value) => Some(*value as f64),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let temp_target = "__wrapper_target".to_string();
+    let temp_cost = "__wrapper_cost".to_string();
+
+    vm.set_reg("A1", a1.clone());
+    vm.set_reg("A2", Value::Unbound(temp_target.clone()));
+    vm.set_reg("A3", a3.clone());
+    vm.set_reg("A4", Value::Unbound(temp_cost.clone()));
+
+    let dim_value = match &a3 {
+        Value::Integer(d) => *d as f64,
+        Value::Float(d) => *d,
+        _ => ~w_f64,
+    };
+
+    if !vm.execute_foreign_predicate("~w", 4) {
+        vm.bindings.remove(&temp_target);
+        vm.bindings.remove(&temp_cost);
+        return false;
+    }
+
+    let mut packed_results: Vec<Value> = Vec::new();
+    loop {
+        let target = match vm.bindings.get(&temp_target).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Atom(target)) => target,
+            _ => break,
+        };
+        let cost = match vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Float(cost)) => cost,
+            _ => break,
+        };
+        let joined_values_1 = match vm.indexed_atom_fact2.get("~w").and_then(|table| table.get(&target)) {
+            Some(values) => values.clone(),
+            None => Vec::new(),
+        };
+        for joined_value_1 in joined_values_1.iter() {
+            let joined_values_2 = match vm.indexed_atom_fact2.get("~w").and_then(|table| table.get(joined_value_1)) {
+                Some(values) => values.clone(),
+                None => Vec::new(),
+            };
+            for joined_value_2 in joined_values_2.iter() {
+~w                let output_value = ~w;
+                if (join_filter.as_ref().map(|want| want == joined_value_2).unwrap_or(true))
+                    && (~w)
+                    && (result_filter.as_ref().map(|want| (output_value - *want).abs() < 1e-9).unwrap_or(true)) {
+                    packed_results.push(Value::Str("__tuple__".to_string(), vec![
+                        Value::Atom(joined_value_2.clone()),
+                        Value::Float(output_value),
+                    ]));
+                }
+            }
+        }
+        if !vm.backtrack() {
+            break;
+        }
+    }
+
+    vm.bindings.remove(&temp_target);
+    vm.bindings.remove(&temp_cost);
+    vm.finish_foreign_results("~w", vec![a2.clone(), a4.clone()], packed_results)
+}', [PredStr, PredKey, PredKey, InnerPredStr, InnerPredStr, InnerPredStr,
+      InnerPredStr, WeightPredKey, WeightPredKey, WeightTriplesLiteral,
+      InnerPredStr, DirectPredKey, DirectPredKey, DirectTriplesLiteral,
+      InnerPredStr, DefaultDim, JoinPredKey1, JoinPairsLiteral1, JoinPredKey2, JoinPairsLiteral2,
+      DefaultDim, InnerPredStr, JoinPredKey1, JoinPredKey2, SetupCode, ValueExpr, FilterCond, PredKey]).
 
 compile_rust_foreign_join_stream_wrapper(Pred, 3, Head, Body, _IncludeMain, RustCode) :-
     Head =.. [Pred, HeadStart, HeadJoinOut, HeadResult],
@@ -5062,6 +5305,17 @@ rust_atom_fact_pairs_literal(Pairs, Literal) :-
     maplist(rust_atom_fact_pair_literal, Pairs, PairLiterals),
     atomic_list_concat(PairLiterals, ', ', Joined),
     format(string(Literal), '[~w]', [Joined]).
+
+rust_binary_atom_fact_pairs(Pred/2, Pairs) :-
+    findall(Left-Right,
+        ( functor(JoinHead, Pred, 2),
+          user:clause(JoinHead, true),
+          JoinHead =.. [Pred, Left, Right],
+          atom(Left),
+          atom(Right)
+        ),
+        Pairs),
+    Pairs \= [].
 
 rust_atom_fact_pair_literal(Left-Right, Literal) :-
     rust_literal(Left, LeftLiteral),

--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -156,6 +156,12 @@ target_label(c, branch_c).
 target_label(d, goal_d1).
 target_label(d, goal_d2).
 
+:- dynamic label_bucket/2.
+label_bucket(branch_b, branch_bucket).
+label_bucket(branch_c, branch_bucket).
+label_bucket(goal_d1, goal_bucket).
+label_bucket(goal_d2, goal_bucket).
+
 :- dynamic labeled_adjusted_weighted_path/3.
 labeled_adjusted_weighted_path(Start, Label, Adjusted) :-
     weighted_path(Start, Target, Cost),
@@ -170,6 +176,22 @@ labeled_adjusted_astar_weighted_path(Start, Label, Dim, Adjusted) :-
     Cost > 2,
     Adjusted is Cost + 1.
 
+:- dynamic bucketed_adjusted_weighted_path/3.
+bucketed_adjusted_weighted_path(Start, Bucket, Adjusted) :-
+    weighted_path(Start, Target, Cost),
+    target_label(Target, Label),
+    label_bucket(Label, Bucket),
+    Cost > 2,
+    Adjusted is Cost + 1.
+
+:- dynamic bucketed_adjusted_astar_weighted_path/4.
+bucketed_adjusted_astar_weighted_path(Start, Bucket, Dim, Adjusted) :-
+    astar_weighted_path(Start, Target, Dim, Cost),
+    target_label(Target, Label),
+    label_bucket(Label, Bucket),
+    Cost > 2,
+    Adjusted is Cost + 1.
+
 %% Integration test
 test_runtime_execution :-
     Test = 'WAM-Rust Runtime: end-to-end execution',
@@ -180,7 +202,7 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:astar_weighted_path/4, user:min_semantic_dist/3, user:min_semantic_dist_astar/4, user:grouped_min_semantic_dist/3, user:grouped_min_semantic_dist_astar/4, user:filtered_adjusted_min_semantic_dist/3, user:filtered_adjusted_min_semantic_dist_astar/4, user:filtered_adjusted_weighted_path/3, user:filtered_adjusted_astar_weighted_path/4, user:labeled_adjusted_weighted_path/3, user:labeled_adjusted_astar_weighted_path/4],
+        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:astar_weighted_path/4, user:min_semantic_dist/3, user:min_semantic_dist_astar/4, user:grouped_min_semantic_dist/3, user:grouped_min_semantic_dist_astar/4, user:filtered_adjusted_min_semantic_dist/3, user:filtered_adjusted_min_semantic_dist_astar/4, user:filtered_adjusted_weighted_path/3, user:filtered_adjusted_astar_weighted_path/4, user:labeled_adjusted_weighted_path/3, user:labeled_adjusted_astar_weighted_path/4, user:bucketed_adjusted_weighted_path/3, user:bucketed_adjusted_astar_weighted_path/4],
             [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
@@ -209,6 +231,8 @@ use runtime_test::filtered_adjusted_weighted_path;
 use runtime_test::filtered_adjusted_astar_weighted_path;
 use runtime_test::labeled_adjusted_weighted_path;
 use runtime_test::labeled_adjusted_astar_weighted_path;
+use runtime_test::bucketed_adjusted_weighted_path;
+use runtime_test::bucketed_adjusted_astar_weighted_path;
 
 #[test]
 fn test_generated_predicates() {
@@ -1124,6 +1148,97 @@ fn test_generated_predicates() {
         Value::Integer(5),
         Value::Unbound("AStarMissing".to_string()));
     assert!(!ok54, "labeled_adjusted_astar_weighted_path(s, missing, 5, Adjusted) should fail");
+
+    // Test bucketed_adjusted_weighted_path/3 multi-stage relational wrapper
+    let mut vm_bucketed_weighted = WamState::new(vec![], std::collections::HashMap::new());
+    let ok55 = bucketed_adjusted_weighted_path(&mut vm_bucketed_weighted,
+        Value::Atom("s".to_string()),
+        Value::Unbound("WeightedBucket".to_string()),
+        Value::Unbound("WeightedBucketAdjusted".to_string()));
+    assert!(ok55, "bucketed_adjusted_weighted_path(s, Bucket, Adjusted) first solution should succeed");
+    let mut bucketed_weighted_results: Vec<(String, f64)> = Vec::new();
+    if let (Some(Value::Atom(bucket)), Some(Value::Float(cost))) =
+        (vm_bucketed_weighted.bindings.get("WeightedBucket").cloned(), vm_bucketed_weighted.bindings.get("WeightedBucketAdjusted").cloned()) {
+        bucketed_weighted_results.push((bucket, cost));
+    } else {
+        panic!("expected first bucketed_adjusted_weighted_path result");
+    }
+    while vm_bucketed_weighted.backtrack() {
+        if let (Some(Value::Atom(bucket)), Some(Value::Float(cost))) =
+            (vm_bucketed_weighted.bindings.get("WeightedBucket").cloned(), vm_bucketed_weighted.bindings.get("WeightedBucketAdjusted").cloned()) {
+            bucketed_weighted_results.push((bucket, cost));
+        } else {
+            panic!("expected bucketed_adjusted_weighted_path backtrack result");
+        }
+    }
+    bucketed_weighted_results.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.partial_cmp(&b.1).unwrap()));
+    assert_eq!(bucketed_weighted_results, vec![
+        ("branch_bucket".to_string(), 4.0),
+        ("branch_bucket".to_string(), 5.0),
+        ("goal_bucket".to_string(), 8.0),
+        ("goal_bucket".to_string(), 8.0),
+    ]);
+
+    let mut vm_bucketed_weighted_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok56 = bucketed_adjusted_weighted_path(&mut vm_bucketed_weighted_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("goal_bucket".to_string()),
+        Value::Float(8.0));
+    assert!(ok56, "bucketed_adjusted_weighted_path(s, goal_bucket, 8.0) should succeed");
+
+    let mut vm_bucketed_weighted_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok57 = bucketed_adjusted_weighted_path(&mut vm_bucketed_weighted_fail,
+        Value::Atom("s".to_string()),
+        Value::Atom("missing_bucket".to_string()),
+        Value::Unbound("WeightedBucketMissing".to_string()));
+    assert!(!ok57, "bucketed_adjusted_weighted_path(s, missing_bucket, Adjusted) should fail");
+
+    // Test bucketed_adjusted_astar_weighted_path/4 multi-stage relational wrapper
+    let mut vm_bucketed_astar = WamState::new(vec![], std::collections::HashMap::new());
+    let ok58 = bucketed_adjusted_astar_weighted_path(&mut vm_bucketed_astar,
+        Value::Atom("s".to_string()),
+        Value::Unbound("AStarBucket".to_string()),
+        Value::Integer(5),
+        Value::Unbound("AStarBucketAdjusted".to_string()));
+    assert!(ok58, "bucketed_adjusted_astar_weighted_path(s, Bucket, 5, Adjusted) first solution should succeed");
+    let mut bucketed_astar_results: Vec<(String, f64)> = Vec::new();
+    if let (Some(Value::Atom(bucket)), Some(Value::Float(cost))) =
+        (vm_bucketed_astar.bindings.get("AStarBucket").cloned(), vm_bucketed_astar.bindings.get("AStarBucketAdjusted").cloned()) {
+            bucketed_astar_results.push((bucket, cost));
+    } else {
+        panic!("expected first bucketed_adjusted_astar_weighted_path result");
+    }
+    while vm_bucketed_astar.backtrack() {
+        if let (Some(Value::Atom(bucket)), Some(Value::Float(cost))) =
+            (vm_bucketed_astar.bindings.get("AStarBucket").cloned(), vm_bucketed_astar.bindings.get("AStarBucketAdjusted").cloned()) {
+            bucketed_astar_results.push((bucket, cost));
+        } else {
+            panic!("expected bucketed_adjusted_astar_weighted_path backtrack result");
+        }
+    }
+    bucketed_astar_results.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.partial_cmp(&b.1).unwrap()));
+    assert_eq!(bucketed_astar_results, vec![
+        ("branch_bucket".to_string(), 4.0),
+        ("branch_bucket".to_string(), 5.0),
+        ("goal_bucket".to_string(), 8.0),
+        ("goal_bucket".to_string(), 8.0),
+    ]);
+
+    let mut vm_bucketed_astar_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok59 = bucketed_adjusted_astar_weighted_path(&mut vm_bucketed_astar_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("goal_bucket".to_string()),
+        Value::Integer(5),
+        Value::Float(8.0));
+    assert!(ok59, "bucketed_adjusted_astar_weighted_path(s, goal_bucket, 5, 8.0) should succeed");
+
+    let mut vm_bucketed_astar_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok60 = bucketed_adjusted_astar_weighted_path(&mut vm_bucketed_astar_fail,
+        Value::Atom("s".to_string()),
+        Value::Atom("missing_bucket".to_string()),
+        Value::Integer(5),
+        Value::Unbound("AStarBucketMissing".to_string()));
+    assert!(!ok60, "bucketed_adjusted_astar_weighted_path(s, missing_bucket, 5, Adjusted) should fail");
 }
 ',
         setup_call_cleanup(open(TestPath, write, S), format(S, "~w", [TestContent]), close(S)),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -49,8 +49,11 @@ test_simple_fact(foo, bar).
 :- dynamic filtered_adjusted_weighted_path/3.
 :- dynamic filtered_adjusted_astar_weighted_path/4.
 :- dynamic target_label/2.
+:- dynamic label_bucket/2.
 :- dynamic labeled_adjusted_weighted_path/3.
 :- dynamic labeled_adjusted_astar_weighted_path/4.
+:- dynamic bucketed_adjusted_weighted_path/3.
+:- dynamic bucketed_adjusted_astar_weighted_path/4.
 :- dynamic tc_parent/2.
 :- dynamic max_depth/1.
 
@@ -133,6 +136,10 @@ target_label(b, branch_b).
 target_label(c, branch_c).
 target_label(d, goal_d1).
 target_label(d, goal_d2).
+label_bucket(branch_b, branch_bucket).
+label_bucket(branch_c, branch_bucket).
+label_bucket(goal_d1, goal_bucket).
+label_bucket(goal_d2, goal_bucket).
 
 weighted_path(X, Y, W) :- weighted_edge(X, Y, W).
 weighted_path(X, Y, Cost) :-
@@ -188,6 +195,20 @@ labeled_adjusted_weighted_path(Start, Label, Adjusted) :-
 labeled_adjusted_astar_weighted_path(Start, Label, Dim, Adjusted) :-
     astar_weighted_path(Start, Target, Dim, Cost),
     target_label(Target, Label),
+    Cost > 2,
+    Adjusted is Cost + 1.
+
+bucketed_adjusted_weighted_path(Start, Bucket, Adjusted) :-
+    weighted_path(Start, Target, Cost),
+    target_label(Target, Label),
+    label_bucket(Label, Bucket),
+    Cost > 2,
+    Adjusted is Cost + 1.
+
+bucketed_adjusted_astar_weighted_path(Start, Bucket, Dim, Adjusted) :-
+    astar_weighted_path(Start, Target, Dim, Cost),
+    target_label(Target, Label),
+    label_bucket(Label, Bucket),
     Cost > 2,
     Adjusted is Cost + 1.
 
@@ -911,6 +932,38 @@ test_labeled_astar_stream_wrapper :-
     ;   fail_test(Test, 'Relational A* stream wrapper did not lower correctly')
     ).
 
+test_bucketed_weighted_stream_wrapper :-
+    Test = 'WAM-Rust: multi-stage relational wrapper expands weighted_path/3 results',
+    (   rust_target:compile_predicate_to_rust(user:bucketed_adjusted_weighted_path/3,
+            [include_main(false), foreign_lowering(true), wam_fallback(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'pub fn bucketed_adjusted_weighted_path(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool'),
+        sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("target_label/2", &[("b", "branch_b"), ("c", "branch_c"), ("d", "goal_d1"), ("d", "goal_d2")])'),
+        sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("label_bucket/2", &[("branch_b", "branch_bucket"), ("branch_c", "branch_bucket"), ("goal_d1", "goal_bucket"), ("goal_d2", "goal_bucket")])'),
+        sub_string(S, _, _, _, 'let joined_values_1 = match vm.indexed_atom_fact2.get("target_label/2").and_then(|table| table.get(&target)) {'),
+        sub_string(S, _, _, _, 'let joined_values_2 = match vm.indexed_atom_fact2.get("label_bucket/2").and_then(|table| table.get(joined_value_1)) {'),
+        sub_string(S, _, _, _, 'for joined_value_2 in joined_values_2.iter() {'),
+        sub_string(S, _, _, _, 'vm.finish_foreign_results("bucketed_adjusted_weighted_path/3", vec![a2.clone(), a3.clone()], packed_results)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Multi-stage weighted wrapper did not lower correctly')
+    ).
+
+test_bucketed_astar_stream_wrapper :-
+    Test = 'WAM-Rust: multi-stage relational wrapper expands astar_weighted_path/4 results',
+    (   rust_target:compile_predicate_to_rust(user:bucketed_adjusted_astar_weighted_path/4,
+            [include_main(false), foreign_lowering(true), wam_fallback(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'pub fn bucketed_adjusted_astar_weighted_path(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool'),
+        sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("target_label/2", &[("b", "branch_b"), ("c", "branch_c"), ("d", "goal_d1"), ("d", "goal_d2")])'),
+        sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("label_bucket/2", &[("branch_b", "branch_bucket"), ("branch_c", "branch_bucket"), ("goal_d1", "goal_bucket"), ("goal_d2", "goal_bucket")])'),
+        sub_string(S, _, _, _, 'let joined_values_1 = match vm.indexed_atom_fact2.get("target_label/2").and_then(|table| table.get(&target)) {'),
+        sub_string(S, _, _, _, 'let joined_values_2 = match vm.indexed_atom_fact2.get("label_bucket/2").and_then(|table| table.get(joined_value_1)) {'),
+        sub_string(S, _, _, _, 'for joined_value_2 in joined_values_2.iter() {'),
+        sub_string(S, _, _, _, 'vm.finish_foreign_results("bucketed_adjusted_astar_weighted_path/4", vec![a2.clone(), a4.clone()], packed_results)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Multi-stage A* wrapper did not lower correctly')
+    ).
+
 test_compile_wam_runtime_output :-
     Test = 'WAM-Rust E2E: full runtime generates valid impl block',
     (   compile_wam_runtime_to_rust([], Code),
@@ -1235,6 +1288,8 @@ run_tests :-
     test_filtered_adjusted_astar_stream_wrapper,
     test_labeled_weighted_stream_wrapper,
     test_labeled_astar_stream_wrapper,
+    test_bucketed_weighted_stream_wrapper,
+    test_bucketed_astar_stream_wrapper,
     test_compile_wam_runtime_output,
     test_write_wam_rust_project,
     test_project_cargo_content,


### PR DESCRIPTION
## Summary

This PR extends Rust WAM foreign-wrapper lowering to support multi-stage relational composition after a foreign kernel call.

Until now, the Rust foreign path handled:

- direct foreign kernels
- aggregate wrappers over foreign kernels
- grouped aggregate wrappers
- mixed-goal numeric filter/arithmetic wrappers
- wrappers with a single relational join after a foreign kernel

This change adds support for wrappers with a two-stage join chain, so predicates of the form:

- foreign kernel
- join 1
- join 2
- filter/output logic

can be lowered through the Rust foreign-wrapper path and executed end to end in generated Rust.

## What Changed

- Added compiler lowering for multi-stage foreign stream wrappers in `src/unifyweaver/targets/rust_target.pl`.
- Extended wrapper generation for:
  - `weighted_path/3`
  - `astar_weighted_path/4`
- Added target-level coverage for:
  - `bucketed_adjusted_weighted_path/3`
  - `bucketed_adjusted_astar_weighted_path/4`
- Added generated Rust runtime coverage for the same predicates in `tests/test_wam_rust_runtime.pl`.

The new tests validate:

- unbound join-output streaming
- bound join-output lookup
- numeric filter and arithmetic logic after the join chain
- both weighted and A* foreign-kernel variants

## Why

This closes the next composition gap in the Rust WAM foreign-lowering path.

We already had good coverage for:

- foreign kernels by themselves
- aggregate wrappers
- grouped wrappers
- simple mixed-goal wrappers
- single-join relational wrappers

But we did not yet prove that a foreign kernel could participate in a broader ordinary query body with multiple relational stages before final output shaping. This PR adds that proof and keeps the implementation within the existing foreign-wrapper architecture.

## Validation

Ran locally:

```sh
swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl
swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl
```

Both passed.

## Scope

This PR is intentionally limited to a two-stage join chain after a foreign kernel. It does not yet attempt:

- arbitrary-length relational chains
- aggregate wrappers over these new multi-stage join wrappers
- broader general query-plan lowering

Those can build on this in follow-up work.
