### PR TITLE
feat(rust): Support grouped aggregates over multistage foreign joins in Rust WAM

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -4860,6 +4860,252 @@ compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _Inc
     get_dict(op, AggInfo, min),
     get_dict(expr, AggInfo, Expr),
     get_dict(group, AggInfo, GroupTerm),
+    get_dict(relations, GoalInfo, [RelGoal, JoinGoal1, JoinGoal2]),
+    RelGoal =.. [InnerPred, GoalStart, GoalTarget, GoalCost],
+    JoinGoal1 =.. [JoinPred1, GoalTarget, JoinMid],
+    JoinGoal2 =.. [JoinPred2, JoinMid, GoalJoinOut],
+    parse_group_term_rust(GroupTerm, [GroupVar]),
+    GroupVar == GoalJoinOut,
+    functor(InnerHead, InnerPred, 3),
+    findall(InnerHead-InnerBody, user:clause(InnerHead, InnerBody), Clauses),
+    Clauses \= [],
+    rust_foreign_lowerable_weighted_shortest_path(InnerPred, 3, Clauses, WeightPred/3, FactTriples),
+    rust_binary_atom_fact_pairs(JoinPred1/2, JoinPairs1),
+    rust_binary_atom_fact_pairs(JoinPred2/2, JoinPairs2),
+    rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalJoinOut, GoalCost],
+        Expr, SetupCode, ValueExpr, FilterCond),
+    atom_string(Pred, PredStr),
+    atom_string(InnerPred, InnerPredStr),
+    format(string(PredKey), '~w/3', [Pred]),
+    format(string(WeightPredKey), '~w/3', [WeightPred]),
+    format(string(JoinPredKey1), '~w/2', [JoinPred1]),
+    format(string(JoinPredKey2), '~w/2', [JoinPred2]),
+    rust_weighted_fact_triples_literal(FactTriples, TriplesLiteral),
+    rust_atom_fact_pairs_literal(JoinPairs1, JoinPairsLiteral1),
+    rust_atom_fact_pairs_literal(JoinPairs2, JoinPairsLiteral2),
+    format(string(RustCode),
+'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool {
+    use std::collections::BTreeMap;
+
+    vm.reset_query();
+    vm.code = Vec::new();
+    vm.labels = HashMap::new();
+    vm.pc = 1;
+    vm.register_foreign_result_layout("~w", "tuple:2");
+    vm.register_foreign_result_mode("~w", "stream");
+    vm.register_foreign_native_kind("~w/3", "weighted_shortest_path3");
+    vm.register_foreign_result_layout("~w/3", "tuple:2");
+    vm.register_foreign_result_mode("~w/3", "stream");
+    vm.register_foreign_string_config("~w/3", "weight_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+    vm.register_indexed_atom_fact2_pairs("~w", &~w);
+    vm.register_indexed_atom_fact2_pairs("~w", &~w);
+
+    let group_filter = match &a2 {
+        Value::Atom(group) => Some(group.clone()),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let temp_target = "__agg_target".to_string();
+    let temp_cost = "__agg_cost".to_string();
+
+    vm.set_reg("A1", a1.clone());
+    vm.set_reg("A2", Value::Unbound(temp_target.clone()));
+    vm.set_reg("A3", Value::Unbound(temp_cost.clone()));
+
+    if !vm.execute_foreign_predicate("~w", 3) {
+        vm.bindings.remove(&temp_target);
+        vm.bindings.remove(&temp_cost);
+        return false;
+    }
+
+    let mut grouped: BTreeMap<String, f64> = BTreeMap::new();
+    loop {
+        let target = match vm.bindings.get(&temp_target).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Atom(target)) => target,
+            _ => break,
+        };
+        let cost = match vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Float(cost)) => cost,
+            _ => break,
+        };
+        let joined_values_1 = match vm.indexed_atom_fact2.get("~w").and_then(|table| table.get(&target)) {
+            Some(values) => values.clone(),
+            None => Vec::new(),
+        };
+        for joined_value_1 in joined_values_1.iter() {
+            let joined_values_2 = match vm.indexed_atom_fact2.get("~w").and_then(|table| table.get(joined_value_1)) {
+                Some(values) => values.clone(),
+                None => Vec::new(),
+            };
+            for joined_value_2 in joined_values_2.iter() {
+~w                if (group_filter.as_ref().map(|want| want == joined_value_2).unwrap_or(true))
+                    && (~w) {
+                    let agg_value = ~w;
+                    grouped.entry(joined_value_2.clone())
+                        .and_modify(|current| *current = current.min(agg_value))
+                        .or_insert(agg_value);
+                }
+            }
+        }
+        if !vm.backtrack() {
+            break;
+        }
+    }
+
+    vm.bindings.remove(&temp_target);
+    vm.bindings.remove(&temp_cost);
+
+    if grouped.is_empty() {
+        return false;
+    }
+
+    let packed_results: Vec<Value> = grouped.into_iter().map(|(group_key, cost)| {
+        Value::Str("__tuple__".to_string(), vec![
+            Value::Atom(group_key),
+            Value::Float(cost),
+        ])
+    }).collect();
+    vm.finish_foreign_results("~w", vec![a2.clone(), a3.clone()], packed_results)
+}', [PredStr, PredKey, PredKey, InnerPredStr, InnerPredStr, InnerPredStr,
+      InnerPredStr, WeightPredKey, WeightPredKey, TriplesLiteral,
+      JoinPredKey1, JoinPairsLiteral1, JoinPredKey2, JoinPairsLiteral2,
+      InnerPredStr, JoinPredKey1, JoinPredKey2, SetupCode, FilterCond, ValueExpr, PredKey]).
+compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _IncludeMain, RustCode) :-
+    get_dict(type, AggInfo, group),
+    get_dict(op, AggInfo, min),
+    get_dict(expr, AggInfo, Expr),
+    get_dict(group, AggInfo, GroupTerm),
+    get_dict(relations, GoalInfo, [RelGoal, JoinGoal1, JoinGoal2]),
+    RelGoal =.. [InnerPred, GoalStart, GoalTarget, GoalDim, GoalCost],
+    JoinGoal1 =.. [JoinPred1, GoalTarget, JoinMid],
+    JoinGoal2 =.. [JoinPred2, JoinMid, GoalJoinOut],
+    parse_group_term_rust(GroupTerm, [GroupVar]),
+    GroupVar == GoalJoinOut,
+    functor(InnerHead, InnerPred, 4),
+    findall(InnerHead-InnerBody, user:clause(InnerHead, InnerBody), Clauses),
+    Clauses \= [],
+    rust_foreign_lowerable_astar_shortest_path(InnerPred, 4, Clauses,
+        WeightPred/3, FactTriples, DirectPred/3, DirectTriples, DefaultDim),
+    rust_binary_atom_fact_pairs(JoinPred1/2, JoinPairs1),
+    rust_binary_atom_fact_pairs(JoinPred2/2, JoinPairs2),
+    rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalJoinOut, GoalDim, GoalCost],
+        Expr, SetupCode, ValueExpr, FilterCond),
+    atom_string(Pred, PredStr),
+    atom_string(InnerPred, InnerPredStr),
+    format(string(PredKey), '~w/4', [Pred]),
+    format(string(WeightPredKey), '~w/3', [WeightPred]),
+    format(string(DirectPredKey), '~w/3', [DirectPred]),
+    format(string(JoinPredKey1), '~w/2', [JoinPred1]),
+    format(string(JoinPredKey2), '~w/2', [JoinPred2]),
+    rust_weighted_fact_triples_literal(FactTriples, WeightTriplesLiteral),
+    rust_weighted_fact_triples_literal(DirectTriples, DirectTriplesLiteral),
+    rust_atom_fact_pairs_literal(JoinPairs1, JoinPairsLiteral1),
+    rust_atom_fact_pairs_literal(JoinPairs2, JoinPairsLiteral2),
+    format(string(RustCode),
+'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool {
+    use std::collections::BTreeMap;
+
+    vm.reset_query();
+    vm.code = Vec::new();
+    vm.labels = HashMap::new();
+    vm.pc = 1;
+    vm.register_foreign_result_layout("~w", "tuple:2");
+    vm.register_foreign_result_mode("~w", "stream");
+    vm.register_foreign_native_kind("~w/4", "astar_shortest_path4");
+    vm.register_foreign_result_layout("~w/4", "tuple:2");
+    vm.register_foreign_result_mode("~w/4", "stream");
+    vm.register_foreign_string_config("~w/4", "weight_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+    vm.register_foreign_string_config("~w/4", "direct_dist_pred", "~w");
+    vm.register_indexed_weighted_edge_triples("~w", &~w);
+    vm.register_foreign_usize_config("~w/4", "dimensionality", ~w);
+    vm.register_indexed_atom_fact2_pairs("~w", &~w);
+    vm.register_indexed_atom_fact2_pairs("~w", &~w);
+
+    let group_filter = match &a2 {
+        Value::Atom(group) => Some(group.clone()),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };
+    let temp_target = "__agg_target".to_string();
+    let temp_cost = "__agg_cost".to_string();
+
+    vm.set_reg("A1", a1.clone());
+    vm.set_reg("A2", Value::Unbound(temp_target.clone()));
+    vm.set_reg("A3", a3.clone());
+    vm.set_reg("A4", Value::Unbound(temp_cost.clone()));
+
+    let dim_value = match &a3 {
+        Value::Integer(d) => *d as f64,
+        Value::Float(d) => *d,
+        _ => ~w_f64,
+    };
+
+    if !vm.execute_foreign_predicate("~w", 4) {
+        vm.bindings.remove(&temp_target);
+        vm.bindings.remove(&temp_cost);
+        return false;
+    }
+
+    let mut grouped: BTreeMap<String, f64> = BTreeMap::new();
+    loop {
+        let target = match vm.bindings.get(&temp_target).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Atom(target)) => target,
+            _ => break,
+        };
+        let cost = match vm.bindings.get(&temp_cost).cloned().map(|v| vm.deref_var(&v)) {
+            Some(Value::Float(cost)) => cost,
+            _ => break,
+        };
+        let joined_values_1 = match vm.indexed_atom_fact2.get("~w").and_then(|table| table.get(&target)) {
+            Some(values) => values.clone(),
+            None => Vec::new(),
+        };
+        for joined_value_1 in joined_values_1.iter() {
+            let joined_values_2 = match vm.indexed_atom_fact2.get("~w").and_then(|table| table.get(joined_value_1)) {
+                Some(values) => values.clone(),
+                None => Vec::new(),
+            };
+            for joined_value_2 in joined_values_2.iter() {
+~w                if (group_filter.as_ref().map(|want| want == joined_value_2).unwrap_or(true))
+                    && (~w) {
+                    let agg_value = ~w;
+                    grouped.entry(joined_value_2.clone())
+                        .and_modify(|current| *current = current.min(agg_value))
+                        .or_insert(agg_value);
+                }
+            }
+        }
+        if !vm.backtrack() {
+            break;
+        }
+    }
+
+    vm.bindings.remove(&temp_target);
+    vm.bindings.remove(&temp_cost);
+
+    if grouped.is_empty() {
+        return false;
+    }
+
+    let packed_results: Vec<Value> = grouped.into_iter().map(|(group_key, cost)| {
+        Value::Str("__tuple__".to_string(), vec![
+            Value::Atom(group_key),
+            Value::Float(cost),
+        ])
+    }).collect();
+    vm.finish_foreign_results("~w", vec![a2.clone(), a4.clone()], packed_results)
+}', [PredStr, PredKey, PredKey, InnerPredStr, InnerPredStr, InnerPredStr,
+      InnerPredStr, WeightPredKey, WeightPredKey, WeightTriplesLiteral,
+      InnerPredStr, DirectPredKey, DirectPredKey, DirectTriplesLiteral,
+      InnerPredStr, DefaultDim, JoinPredKey1, JoinPairsLiteral1, JoinPredKey2, JoinPairsLiteral2,
+      DefaultDim, InnerPredStr, JoinPredKey1, JoinPredKey2, SetupCode, FilterCond, ValueExpr, PredKey]).
+compile_rust_weighted_min_aggregate_wrapper(Pred, _Goal, GoalInfo, AggInfo, _IncludeMain, RustCode) :-
+    get_dict(type, AggInfo, group),
+    get_dict(op, AggInfo, min),
+    get_dict(expr, AggInfo, Expr),
+    get_dict(group, AggInfo, GroupTerm),
     get_dict(relations, GoalInfo, [RelGoal|_]),
     RelGoal =.. [InnerPred, _StartArg, TargetArg, CostArg],
     Expr == CostArg,

--- a/tests/test_wam_rust_runtime.pl
+++ b/tests/test_wam_rust_runtime.pl
@@ -192,6 +192,30 @@ bucketed_adjusted_astar_weighted_path(Start, Bucket, Dim, Adjusted) :-
     Cost > 2,
     Adjusted is Cost + 1.
 
+:- dynamic grouped_bucketed_min_semantic_dist/3.
+grouped_bucketed_min_semantic_dist(Start, Bucket, MinDist) :-
+    aggregate_all(min(Adjusted),
+        ( weighted_path(Start, Target, Cost),
+          target_label(Target, Label),
+          label_bucket(Label, Bucket),
+          Cost > 2,
+          Adjusted is Cost + 1
+        ),
+        Bucket,
+        MinDist).
+
+:- dynamic grouped_bucketed_min_semantic_dist_astar/4.
+grouped_bucketed_min_semantic_dist_astar(Start, Bucket, Dim, MinDist) :-
+    aggregate_all(min(Adjusted),
+        ( astar_weighted_path(Start, Target, Dim, Cost),
+          target_label(Target, Label),
+          label_bucket(Label, Bucket),
+          Cost > 2,
+          Adjusted is Cost + 1
+        ),
+        Bucket,
+        MinDist).
+
 %% Integration test
 test_runtime_execution :-
     Test = 'WAM-Rust Runtime: end-to-end execution',
@@ -202,7 +226,7 @@ test_runtime_execution :-
         pass(Test)
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         % 1. Generate project
-        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:astar_weighted_path/4, user:min_semantic_dist/3, user:min_semantic_dist_astar/4, user:grouped_min_semantic_dist/3, user:grouped_min_semantic_dist_astar/4, user:filtered_adjusted_min_semantic_dist/3, user:filtered_adjusted_min_semantic_dist_astar/4, user:filtered_adjusted_weighted_path/3, user:filtered_adjusted_astar_weighted_path/4, user:labeled_adjusted_weighted_path/3, user:labeled_adjusted_astar_weighted_path/4, user:bucketed_adjusted_weighted_path/3, user:bucketed_adjusted_astar_weighted_path/4],
+        write_wam_rust_project([user:tc_ancestor/2, user:tc_descendant/2, user:tc_distance/3, user:tc_parent_distance/4, user:tc_step_parent_distance/5, user:tri_sum/2, user:tail_suffix/2, user:tail_suffixes/2, user:weighted_path/3, user:astar_weighted_path/4, user:min_semantic_dist/3, user:min_semantic_dist_astar/4, user:grouped_min_semantic_dist/3, user:grouped_min_semantic_dist_astar/4, user:filtered_adjusted_min_semantic_dist/3, user:filtered_adjusted_min_semantic_dist_astar/4, user:filtered_adjusted_weighted_path/3, user:filtered_adjusted_astar_weighted_path/4, user:labeled_adjusted_weighted_path/3, user:labeled_adjusted_astar_weighted_path/4, user:bucketed_adjusted_weighted_path/3, user:bucketed_adjusted_astar_weighted_path/4, user:grouped_bucketed_min_semantic_dist/3, user:grouped_bucketed_min_semantic_dist_astar/4],
             [module_name('runtime_test'), wam_fallback(true), foreign_lowering(true)], TmpDir),
         
         % 2. Add a test file
@@ -233,6 +257,8 @@ use runtime_test::labeled_adjusted_weighted_path;
 use runtime_test::labeled_adjusted_astar_weighted_path;
 use runtime_test::bucketed_adjusted_weighted_path;
 use runtime_test::bucketed_adjusted_astar_weighted_path;
+use runtime_test::grouped_bucketed_min_semantic_dist;
+use runtime_test::grouped_bucketed_min_semantic_dist_astar;
 
 #[test]
 fn test_generated_predicates() {
@@ -1239,6 +1265,101 @@ fn test_generated_predicates() {
         Value::Integer(5),
         Value::Unbound("AStarBucketMissing".to_string()));
     assert!(!ok60, "bucketed_adjusted_astar_weighted_path(s, missing_bucket, 5, Adjusted) should fail");
+
+    // Test grouped_bucketed_min_semantic_dist/3 grouped aggregate over multi-stage weighted wrapper shape
+    let mut vm_grouped_bucketed_weighted = WamState::new(vec![], std::collections::HashMap::new());
+    let ok61 = grouped_bucketed_min_semantic_dist(&mut vm_grouped_bucketed_weighted,
+        Value::Atom("s".to_string()),
+        Value::Unbound("GroupedBucket".to_string()),
+        Value::Unbound("GroupedBucketMin".to_string()));
+    assert!(ok61, "grouped_bucketed_min_semantic_dist(s, Bucket, Min) first grouped result should succeed");
+    let mut grouped_bucketed_weighted_results: Vec<(String, f64)> = Vec::new();
+    if let (Some(Value::Atom(bucket)), Some(Value::Float(cost))) =
+        (vm_grouped_bucketed_weighted.bindings.get("GroupedBucket").cloned(), vm_grouped_bucketed_weighted.bindings.get("GroupedBucketMin").cloned()) {
+        grouped_bucketed_weighted_results.push((bucket, cost));
+    } else {
+        panic!("expected first grouped_bucketed_min_semantic_dist result");
+    }
+    while vm_grouped_bucketed_weighted.backtrack() {
+        if let (Some(Value::Atom(bucket)), Some(Value::Float(cost))) =
+            (vm_grouped_bucketed_weighted.bindings.get("GroupedBucket").cloned(), vm_grouped_bucketed_weighted.bindings.get("GroupedBucketMin").cloned()) {
+            grouped_bucketed_weighted_results.push((bucket, cost));
+        } else {
+            panic!("expected grouped_bucketed_min_semantic_dist backtrack result");
+        }
+    }
+    grouped_bucketed_weighted_results.sort_by(|a, b| a.0.cmp(&b.0));
+    assert_eq!(grouped_bucketed_weighted_results, vec![
+        ("branch_bucket".to_string(), 4.0),
+        ("goal_bucket".to_string(), 8.0),
+    ]);
+
+    let mut vm_grouped_bucketed_weighted_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok62 = grouped_bucketed_min_semantic_dist(&mut vm_grouped_bucketed_weighted_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("goal_bucket".to_string()),
+        Value::Unbound("GroupedGoalBucket".to_string()));
+    assert!(ok62, "grouped_bucketed_min_semantic_dist(s, goal_bucket, Min) should succeed");
+    match vm_grouped_bucketed_weighted_exact.bindings.get("GroupedGoalBucket").cloned() {
+        Some(Value::Float(cost)) => assert_close(cost, 8.0),
+        other => panic!("expected grouped_bucketed_min_semantic_dist(s, goal_bucket, Min) to bind float cost, got {:?}", other),
+    }
+
+    let mut vm_grouped_bucketed_weighted_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok63 = grouped_bucketed_min_semantic_dist(&mut vm_grouped_bucketed_weighted_fail,
+        Value::Atom("s".to_string()),
+        Value::Atom("missing_bucket".to_string()),
+        Value::Unbound("GroupedMissingBucket".to_string()));
+    assert!(!ok63, "grouped_bucketed_min_semantic_dist(s, missing_bucket, Min) should fail");
+
+    // Test grouped_bucketed_min_semantic_dist_astar/4 grouped aggregate over multi-stage A* wrapper shape
+    let mut vm_grouped_bucketed_astar = WamState::new(vec![], std::collections::HashMap::new());
+    let ok64 = grouped_bucketed_min_semantic_dist_astar(&mut vm_grouped_bucketed_astar,
+        Value::Atom("s".to_string()),
+        Value::Unbound("GroupedAStarBucket".to_string()),
+        Value::Integer(5),
+        Value::Unbound("GroupedAStarBucketMin".to_string()));
+    assert!(ok64, "grouped_bucketed_min_semantic_dist_astar(s, Bucket, 5, Min) first grouped result should succeed");
+    let mut grouped_bucketed_astar_results: Vec<(String, f64)> = Vec::new();
+    if let (Some(Value::Atom(bucket)), Some(Value::Float(cost))) =
+        (vm_grouped_bucketed_astar.bindings.get("GroupedAStarBucket").cloned(), vm_grouped_bucketed_astar.bindings.get("GroupedAStarBucketMin").cloned()) {
+        grouped_bucketed_astar_results.push((bucket, cost));
+    } else {
+        panic!("expected first grouped_bucketed_min_semantic_dist_astar result");
+    }
+    while vm_grouped_bucketed_astar.backtrack() {
+        if let (Some(Value::Atom(bucket)), Some(Value::Float(cost))) =
+            (vm_grouped_bucketed_astar.bindings.get("GroupedAStarBucket").cloned(), vm_grouped_bucketed_astar.bindings.get("GroupedAStarBucketMin").cloned()) {
+            grouped_bucketed_astar_results.push((bucket, cost));
+        } else {
+            panic!("expected grouped_bucketed_min_semantic_dist_astar backtrack result");
+        }
+    }
+    grouped_bucketed_astar_results.sort_by(|a, b| a.0.cmp(&b.0));
+    assert_eq!(grouped_bucketed_astar_results, vec![
+        ("branch_bucket".to_string(), 4.0),
+        ("goal_bucket".to_string(), 8.0),
+    ]);
+
+    let mut vm_grouped_bucketed_astar_exact = WamState::new(vec![], std::collections::HashMap::new());
+    let ok65 = grouped_bucketed_min_semantic_dist_astar(&mut vm_grouped_bucketed_astar_exact,
+        Value::Atom("s".to_string()),
+        Value::Atom("goal_bucket".to_string()),
+        Value::Integer(5),
+        Value::Unbound("GroupedAStarGoalBucket".to_string()));
+    assert!(ok65, "grouped_bucketed_min_semantic_dist_astar(s, goal_bucket, 5, Min) should succeed");
+    match vm_grouped_bucketed_astar_exact.bindings.get("GroupedAStarGoalBucket").cloned() {
+        Some(Value::Float(cost)) => assert_close(cost, 8.0),
+        other => panic!("expected grouped_bucketed_min_semantic_dist_astar(s, goal_bucket, 5, Min) to bind float cost, got {:?}", other),
+    }
+
+    let mut vm_grouped_bucketed_astar_fail = WamState::new(vec![], std::collections::HashMap::new());
+    let ok66 = grouped_bucketed_min_semantic_dist_astar(&mut vm_grouped_bucketed_astar_fail,
+        Value::Atom("s".to_string()),
+        Value::Atom("missing_bucket".to_string()),
+        Value::Integer(5),
+        Value::Unbound("GroupedAStarMissingBucket".to_string()));
+    assert!(!ok66, "grouped_bucketed_min_semantic_dist_astar(s, missing_bucket, 5, Min) should fail");
 }
 ',
         setup_call_cleanup(open(TestPath, write, S), format(S, "~w", [TestContent]), close(S)),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -54,6 +54,8 @@ test_simple_fact(foo, bar).
 :- dynamic labeled_adjusted_astar_weighted_path/4.
 :- dynamic bucketed_adjusted_weighted_path/3.
 :- dynamic bucketed_adjusted_astar_weighted_path/4.
+:- dynamic grouped_bucketed_min_semantic_dist/3.
+:- dynamic grouped_bucketed_min_semantic_dist_astar/4.
 :- dynamic tc_parent/2.
 :- dynamic max_depth/1.
 
@@ -211,6 +213,28 @@ bucketed_adjusted_astar_weighted_path(Start, Bucket, Dim, Adjusted) :-
     label_bucket(Label, Bucket),
     Cost > 2,
     Adjusted is Cost + 1.
+
+grouped_bucketed_min_semantic_dist(Start, Bucket, MinDist) :-
+    aggregate_all(min(Adjusted),
+        ( weighted_path(Start, Target, Cost),
+          target_label(Target, Label),
+          label_bucket(Label, Bucket),
+          Cost > 2,
+          Adjusted is Cost + 1
+        ),
+        Bucket,
+        MinDist).
+
+grouped_bucketed_min_semantic_dist_astar(Start, Bucket, Dim, MinDist) :-
+    aggregate_all(min(Adjusted),
+        ( astar_weighted_path(Start, Target, Dim, Cost),
+          target_label(Target, Label),
+          label_bucket(Label, Bucket),
+          Cost > 2,
+          Adjusted is Cost + 1
+        ),
+        Bucket,
+        MinDist).
 
 pass(Test) :-
     format('[PASS] ~w~n', [Test]).
@@ -964,6 +988,44 @@ test_bucketed_astar_stream_wrapper :-
     ;   fail_test(Test, 'Multi-stage A* wrapper did not lower correctly')
     ).
 
+test_grouped_bucketed_weighted_min_wrapper :-
+    Test = 'WAM-Rust: grouped aggregate wrapper delegates over weighted_path/3 with two joins',
+    (   rust_target:compile_predicate_to_rust(user:grouped_bucketed_min_semantic_dist/3,
+            [include_main(false), foreign_lowering(true), wam_fallback(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'pub fn grouped_bucketed_min_semantic_dist(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool'),
+        sub_string(S, _, _, _, 'use std::collections::BTreeMap;'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("grouped_bucketed_min_semantic_dist/3", "tuple:2")'),
+        sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("target_label/2", &[("b", "branch_b"), ("c", "branch_c"), ("d", "goal_d1"), ("d", "goal_d2")])'),
+        sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("label_bucket/2", &[("branch_b", "branch_bucket"), ("branch_c", "branch_bucket"), ("goal_d1", "goal_bucket"), ("goal_d2", "goal_bucket")])'),
+        sub_string(S, _, _, _, 'let joined_values_1 = match vm.indexed_atom_fact2.get("target_label/2").and_then(|table| table.get(&target)) {'),
+        sub_string(S, _, _, _, 'let joined_values_2 = match vm.indexed_atom_fact2.get("label_bucket/2").and_then(|table| table.get(joined_value_1)) {'),
+        sub_string(S, _, _, _, 'let agg_value = (cost + 1_f64);'),
+        sub_string(S, _, _, _, 'grouped.entry(joined_value_2.clone())'),
+        sub_string(S, _, _, _, 'vm.finish_foreign_results("grouped_bucketed_min_semantic_dist/3", vec![a2.clone(), a3.clone()], packed_results)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Grouped weighted multistage aggregate wrapper did not lower correctly')
+    ).
+
+test_grouped_bucketed_astar_min_wrapper :-
+    Test = 'WAM-Rust: grouped aggregate wrapper delegates over astar_weighted_path/4 with two joins',
+    (   rust_target:compile_predicate_to_rust(user:grouped_bucketed_min_semantic_dist_astar/4,
+            [include_main(false), foreign_lowering(true), wam_fallback(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'pub fn grouped_bucketed_min_semantic_dist_astar(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool'),
+        sub_string(S, _, _, _, 'use std::collections::BTreeMap;'),
+        sub_string(S, _, _, _, 'register_foreign_result_layout("grouped_bucketed_min_semantic_dist_astar/4", "tuple:2")'),
+        sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("target_label/2", &[("b", "branch_b"), ("c", "branch_c"), ("d", "goal_d1"), ("d", "goal_d2")])'),
+        sub_string(S, _, _, _, 'register_indexed_atom_fact2_pairs("label_bucket/2", &[("branch_b", "branch_bucket"), ("branch_c", "branch_bucket"), ("goal_d1", "goal_bucket"), ("goal_d2", "goal_bucket")])'),
+        sub_string(S, _, _, _, 'let joined_values_1 = match vm.indexed_atom_fact2.get("target_label/2").and_then(|table| table.get(&target)) {'),
+        sub_string(S, _, _, _, 'let joined_values_2 = match vm.indexed_atom_fact2.get("label_bucket/2").and_then(|table| table.get(joined_value_1)) {'),
+        sub_string(S, _, _, _, 'let agg_value = (cost + 1_f64);'),
+        sub_string(S, _, _, _, 'grouped.entry(joined_value_2.clone())'),
+        sub_string(S, _, _, _, 'vm.finish_foreign_results("grouped_bucketed_min_semantic_dist_astar/4", vec![a2.clone(), a4.clone()], packed_results)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Grouped A* multistage aggregate wrapper did not lower correctly')
+    ).
+
 test_compile_wam_runtime_output :-
     Test = 'WAM-Rust E2E: full runtime generates valid impl block',
     (   compile_wam_runtime_to_rust([], Code),
@@ -1290,6 +1352,8 @@ run_tests :-
     test_labeled_astar_stream_wrapper,
     test_bucketed_weighted_stream_wrapper,
     test_bucketed_astar_stream_wrapper,
+    test_grouped_bucketed_weighted_min_wrapper,
+    test_grouped_bucketed_astar_min_wrapper,
     test_compile_wam_runtime_output,
     test_write_wam_rust_project,
     test_project_cargo_content,


### PR DESCRIPTION
## Summary

This PR extends Rust WAM foreign-wrapper lowering to support grouped aggregate wrappers over the existing multistage relational composition path.

Before this change, the Rust foreign path already covered:

- direct foreign kernels
- scalar aggregate wrappers
- grouped aggregate wrappers over direct foreign kernels
- mixed-goal wrappers with numeric filtering and arithmetic
- single-join relational wrappers
- two-stage relational wrappers

What it did not cover was the next combined shape:

- foreign kernel
- join 1
- join 2
- grouped aggregate

This PR adds that path for both weighted shortest-path and A* shortest-path wrappers.

## What Changed

- Added grouped aggregate lowering for multistage foreign join compositions in `src/unifyweaver/targets/rust_target.pl`.
- Reused the existing two-join foreign wrapper shape and grouped min aggregation logic rather than introducing a separate runtime path.
- Added target-level coverage for:
  - `grouped_bucketed_min_semantic_dist/3`
  - `grouped_bucketed_min_semantic_dist_astar/4`
- Added generated Rust runtime coverage for the same predicates in `tests/test_wam_rust_runtime.pl`.

The new predicates validate grouped minima over this body shape:

- foreign weighted or A* path kernel
- `target_label/2`
- `label_bucket/2`
- numeric filter and arithmetic adjustment
- grouped `aggregate_all(min(...), ..., Bucket, MinDist)`

## Why

This closes the next integration gap in the Rust foreign-lowering path.

We already had proof that:

- foreign kernels stream correctly
- grouped aggregates over direct foreign kernels work
- multistage relational wrappers after foreign kernels work

But we did not yet prove that grouped aggregation still lowers correctly once those relational stages are composed into the same wrapper. This PR adds that proof and keeps the implementation inside the existing wrapper architecture.

## Validation

Ran locally:

```sh
swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl
swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl
```

Both passed.

## Scope

This PR is intentionally limited to grouped `min` aggregates over the current two-stage foreign join composition path.

It does not yet attempt:

- scalar aggregate wrappers over the same multistage composition
- arbitrary-length join chains
- more general aggregate planning across composed foreign query bodies

Those can build on this in follow-up work.
