### PR TITLE
feat(csharp-query): add closure pair planner

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -101,6 +101,12 @@ Status:
   loading can now choose between direct streamed access, replayable
   buffering, and external materialized fallback before building closure
   indices
+- started for generic closure pair strategy planning, where seeded and grouped
+  closure-pair probes can now choose among forward, backward, mixed,
+  mixed-with-pair-probe-cache, and memoized source/target strategies through
+  an explicit planner surface
+- focused validation for that closure-pair planner surface now lives in
+  `examples/benchmark/benchmark_closure_pair_planning.py`
 - started for path-aware support relations, where grouped minima and weight-sum
   operators can now choose streaming, replayable buffering, or external
   materialized access for `RootRelation` and `SeedRelation` before grouped
@@ -138,6 +144,10 @@ Status:
 - `QueryExecutorOptions.ClosureRelationRetentionStrategy` can force `Auto`,
   `StreamingDirect`, `ReplayableBuffer`, or `ExternalMaterialized` for
   generic closure benchmarking and diagnosis
+- `QueryExecutorOptions.ClosurePairStrategy` can force `Auto`, `Forward`,
+  `Backward`, `MemoizedBySource`, `MemoizedByTarget`, `MixedDirection`, or
+  `MixedDirectionWithPairProbeCache` for closure-pairs benchmarking and
+  diagnosis
 - the current per-family override knobs and trace surface are still preserved
 
 Work:

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -91,6 +91,11 @@ Examples:
   same measured relation-retention boundary before building successor,
   predecessor, or auxiliary lookup indices, with an explicit override via
   `QueryExecutorOptions.ClosureRelationRetentionStrategy`
+- generic closure pair probes can now choose among forward, backward, mixed,
+  mixed-with-pair-probe-cache, and memoized source/target strategies through
+  an explicit planner surface, with an override via
+  `QueryExecutorOptions.ClosurePairStrategy` and focused validation in
+  `examples/benchmark/benchmark_closure_pair_planning.py`
 - generic scan planning now also has focused validation coverage in
   `examples/benchmark/benchmark_scan_materialization.py`, so scan-heavy join,
   negation, aggregate, relation-scan, and pattern-scan paths can be checked

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -50,7 +50,10 @@ scan planning now adds corresponding scan buckets such as
 `benchmark_scan_materialization.py`. Generic closure planning now adds
 corresponding closure buckets such as `closure_strategy_select`,
 `closure_probe_*`, and `closure_materialize_*`, with focused validation
-available in `benchmark_closure_materialization.py`.
+available in `benchmark_closure_materialization.py`. Generic closure-pair
+planning now adds `closure_pair_strategy_select` and
+`*TransitiveClosurePairsMaterializationPlanPairs*` traces, with focused
+validation available in `benchmark_closure_pair_planning.py`.
 
 | Target | 300 art | 1K art | 5K art | 10K art |
 |--------|---------|--------|--------|---------|
@@ -228,6 +231,7 @@ Tables:
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
 | `benchmark_scan_materialization.py` | Exercise relation scan, pattern scan, join, negation, and aggregate under the scan materialization planner |
 | `benchmark_closure_materialization.py` | Exercise generic seeded closure and streamed auxiliary accumulation under the closure materialization planner |
+| `benchmark_closure_pair_planning.py` | Exercise seeded and grouped closure-pair workloads under the closure-pair strategy planner |
 | `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive weighted paths |
 | `benchmark_weighted_shortest_path_cross_target.py` | Compare positive weighted shortest path across C# query, seeded Prolog `min`, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_category_influence_cross_target.py` | Compare category influence propagation across the C# query engine, Rust DFS, Go DFS, and an optional Prolog accumulated path |

--- a/examples/benchmark/benchmark_closure_pair_planning.py
+++ b/examples/benchmark/benchmark_closure_pair_planning.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""
+Measure closure-pair strategy planning in the C# query runtime.
+
+This harness exercises representative transitive-closure pair workloads against
+benchmark TSVs using a temporary C# project built around `QueryRuntime.cs`:
+
+- `single`: one concrete source/target pair
+- `source_fanout`: one source with many bound targets
+- `target_fanin`: one target with many bound sources
+- `mixed`: a blend of forward- and backward-oriented concrete pairs
+- `grouped_mixed`: the grouped closure analogue over a duplicated grouped edge relation
+
+It is intended as a focused validation tool for the closure-pair planner rather
+than a cross-target benchmark.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+QRY_RUNTIME = ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
+
+CSHARP_PROJECT = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>
+"""
+
+PROGRAM = r"""using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using UnifyWeaver.QueryRuntime;
+
+class Program
+{
+    static readonly string[] Groups = new[] { "all", "focus" };
+
+    static ClosurePairStrategy ParsePairStrategy(string value) => value.ToLowerInvariant() switch
+    {
+        "forward" => ClosurePairStrategy.Forward,
+        "backward" => ClosurePairStrategy.Backward,
+        "memo-source" => ClosurePairStrategy.MemoizedBySource,
+        "memo-target" => ClosurePairStrategy.MemoizedByTarget,
+        "mixed" => ClosurePairStrategy.MixedDirection,
+        "mixed-cache" => ClosurePairStrategy.MixedDirectionWithPairProbeCache,
+        _ => ClosurePairStrategy.Auto,
+    };
+
+    static List<string[]> ReadBinaryRows(string path)
+    {
+        return File.ReadLines(path)
+            .Skip(1)
+            .Select(line => line.Split('	'))
+            .Where(parts => parts.Length == 2)
+            .ToList();
+    }
+
+    static Dictionary<string, List<string>> BuildIndex(IEnumerable<string[]> rows, int keyIndex, int valueIndex)
+    {
+        var index = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var parts in rows)
+        {
+            var key = parts[keyIndex];
+            var value = parts[valueIndex];
+            if (!index.TryGetValue(key, out var bucket))
+            {
+                bucket = new List<string>();
+                index.Add(key, bucket);
+            }
+
+            bucket.Add(value);
+        }
+
+        foreach (var bucket in index.Values)
+        {
+            bucket.Sort(StringComparer.Ordinal);
+        }
+
+        return index;
+    }
+
+    static List<string> ExpandReachable(Dictionary<string, List<string>> graph, string seed, int limit)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var queue = new Queue<string>();
+        if (graph.TryGetValue(seed, out var initial))
+        {
+            foreach (var next in initial)
+            {
+                if (seen.Add(next))
+                {
+                    queue.Enqueue(next);
+                }
+            }
+        }
+
+        var ordered = new List<string>();
+        while (queue.Count > 0 && ordered.Count < limit)
+        {
+            var node = queue.Dequeue();
+            ordered.Add(node);
+            if (!graph.TryGetValue(node, out var bucket))
+            {
+                continue;
+            }
+
+            foreach (var next in bucket)
+            {
+                if (seen.Add(next))
+                {
+                    queue.Enqueue(next);
+                }
+            }
+        }
+
+        return ordered;
+    }
+
+    static (string Seed, List<string> Others) FindBestReachable(Dictionary<string, List<string>> graph, int desired)
+    {
+        var bestSeed = string.Empty;
+        var best = new List<string>();
+        foreach (var seed in graph.Keys.OrderBy(value => value, StringComparer.Ordinal))
+        {
+            var reachable = ExpandReachable(graph, seed, desired * 4);
+            if (reachable.Count > best.Count)
+            {
+                bestSeed = seed;
+                best = reachable;
+            }
+
+            if (best.Count >= desired)
+            {
+                break;
+            }
+        }
+
+        if (best.Count == 0)
+        {
+            throw new InvalidOperationException("Failed to derive closure-pair seeds from benchmark graph.");
+        }
+
+        return (bestSeed, best.Take(Math.Min(desired, best.Count)).ToList());
+    }
+
+    static (string Seed, List<string> Others) FindBestDirect(Dictionary<string, List<string>> graph, int desired)
+    {
+        var bestSeed = string.Empty;
+        var best = new List<string>();
+        foreach (var seed in graph.Keys.OrderBy(value => value, StringComparer.Ordinal))
+        {
+            if (!graph.TryGetValue(seed, out var bucket) || bucket.Count == 0)
+            {
+                continue;
+            }
+
+            if (bucket.Count > best.Count)
+            {
+                bestSeed = seed;
+                best = bucket.Take(Math.Min(desired, bucket.Count)).ToList();
+            }
+
+            if (best.Count >= desired)
+            {
+                break;
+            }
+        }
+
+        if (best.Count == 0)
+        {
+            throw new InvalidOperationException("Failed to derive direct grouped closure-pair seeds from benchmark graph.");
+        }
+
+        return (bestSeed, best);
+    }
+
+    static List<object[]> BuildUngroupedParameters(string mode, Dictionary<string, List<string>> succ, Dictionary<string, List<string>> pred)
+    {
+        const int FanoutSize = 8;
+        var fanout = FindBestReachable(succ, FanoutSize);
+        var fanin = FindBestReachable(pred, FanoutSize);
+
+        return mode switch
+        {
+            "single" => new List<object[]>
+            {
+                new object[] { fanout.Seed, fanout.Others.Last() }
+            },
+            "source_fanout" => fanout.Others.Select(target => new object[] { fanout.Seed, target }).ToList<object[]>(),
+            "target_fanin" => fanin.Others.Select(source => new object[] { source, fanin.Seed }).ToList<object[]>(),
+            "mixed" => fanout.Others.Take(4).Select(target => new object[] { fanout.Seed, target })
+                .Concat(fanin.Others.Take(4).Select(source => new object[] { source, fanin.Seed }))
+                .GroupBy(tuple => string.Join("	", tuple.Cast<object?>().Select(value => value?.ToString() ?? "<null>")), StringComparer.Ordinal)
+                .Select(group => group.First())
+                .ToList(),
+            _ => throw new ArgumentException($"Unknown ungrouped mode: {mode}")
+        };
+    }
+
+    static List<object[]> BuildGroupedParameters(Dictionary<string, List<string>> succ, Dictionary<string, List<string>> pred)
+    {
+        var outgoing = FindBestDirect(succ, 6);
+        var incoming = FindBestDirect(pred, 6);
+        var rows = new List<object[]>();
+
+        foreach (var target in outgoing.Others.Take(3))
+        {
+            rows.Add(new object[] { outgoing.Seed, target, Groups[0] });
+            rows.Add(new object[] { outgoing.Seed, target, Groups[1] });
+        }
+
+        foreach (var source in incoming.Others.Take(3))
+        {
+            rows.Add(new object[] { source, incoming.Seed, Groups[0] });
+            rows.Add(new object[] { source, incoming.Seed, Groups[1] });
+        }
+
+        return rows
+            .GroupBy(tuple => string.Join("	", tuple.Cast<object?>().Select(value => value?.ToString() ?? "<null>")), StringComparer.Ordinal)
+            .Select(group => group.First())
+            .ToList();
+    }
+
+    static string BuildGroupedEdgeFile(IEnumerable<string[]> edges)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"uw-closure-pairs-{Guid.NewGuid():N}.tsv");
+        using var writer = new StreamWriter(path, false);
+        writer.WriteLine("from	to	group");
+        foreach (var parts in edges)
+        {
+            foreach (var group in Groups)
+            {
+                writer.Write(parts[0]);
+                writer.Write('	');
+                writer.Write(parts[1]);
+                writer.Write('	');
+                writer.WriteLine(group);
+            }
+        }
+
+        return path;
+    }
+
+    static string SummarizeStrategies(QueryExecutionTrace trace, Func<QueryStrategyTrace, bool> predicate)
+    {
+        return string.Join(
+            "|",
+            trace.SnapshotStrategies()
+                .Where(predicate)
+                .OrderBy(s => s.NodeId)
+                .ThenBy(s => s.Strategy, StringComparer.Ordinal)
+                .Select(s => $"{s.NodeType}:{s.Strategy}={s.Count}"));
+    }
+
+    static string SummarizePhases(QueryExecutionTrace trace, string prefix)
+    {
+        return string.Join(
+            "|",
+            trace.SnapshotPhases()
+                .Where(p => p.Phase.StartsWith(prefix, StringComparison.Ordinal))
+                .GroupBy(p => p.Phase, StringComparer.Ordinal)
+                .OrderBy(group => group.Key, StringComparer.Ordinal)
+                .Select(group => $"{group.Key}:{group.Sum(p => p.Elapsed.TotalMilliseconds).ToString("F3", CultureInfo.InvariantCulture)}"));
+    }
+
+    static int Main(string[] args)
+    {
+        if (args.Length < 2)
+        {
+            Console.Error.WriteLine("Usage: program <single|source_fanout|target_fanin|mixed|grouped_mixed> <category_parent.tsv>");
+            return 1;
+        }
+
+        var mode = args[0];
+        var edgePath = args[1];
+        var traceEnabled = Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE") == "1";
+        var pairStrategy = ParsePairStrategy(Environment.GetEnvironmentVariable("UNIFYWEAVER_CLOSURE_PAIR_STRATEGY") ?? "auto");
+
+        var edgeRows = ReadBinaryRows(edgePath);
+        var succ = BuildIndex(edgeRows, 0, 1);
+        var pred = BuildIndex(edgeRows, 1, 0);
+
+        var provider = new InMemoryRelationProvider();
+        var edgeId = new PredicateId("category_parent", 2);
+        var predicateId = new PredicateId("category_ancestor", 2);
+        var groupedEdgeId = new PredicateId("grouped_category_parent", 3);
+        var groupedPredicateId = new PredicateId("grouped_category_ancestor", 3);
+
+        provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(edgePath));
+
+        var groupedEdgePath = BuildGroupedEdgeFile(edgeRows);
+        provider.RegisterDelimitedSource(groupedEdgeId, new DelimitedRelationSource(groupedEdgePath, '	', 1, 3));
+
+        try
+        {
+            QueryPlan plan;
+            List<object[]> parameters;
+            if (mode == "grouped_mixed")
+            {
+                plan = new QueryPlan(
+                    groupedPredicateId,
+                    new GroupedTransitiveClosureNode(groupedEdgeId, groupedPredicateId, new int[] { 2 }),
+                    true,
+                    new int[] { 0, 1, 2 });
+                parameters = BuildGroupedParameters(succ, pred);
+            }
+            else
+            {
+                plan = new QueryPlan(
+                    predicateId,
+                    new TransitiveClosureNode(edgeId, predicateId),
+                    true,
+                    new int[] { 0, 1 });
+                parameters = BuildUngroupedParameters(mode, succ, pred);
+            }
+
+            var trace = traceEnabled ? new QueryExecutionTrace() : null;
+            var executor = new QueryExecutor(provider, new QueryExecutorOptions(
+                ReuseCaches: true,
+                ClosurePairStrategy: pairStrategy));
+
+            var stopwatch = Stopwatch.StartNew();
+            var rows = executor.Execute(plan, parameters, trace).ToList();
+            stopwatch.Stop();
+
+            Console.Error.WriteLine($"mode={mode}");
+            Console.Error.WriteLine($"closure_pair_strategy_setting={pairStrategy}");
+            Console.Error.WriteLine($"request_count={parameters.Count}");
+            Console.Error.WriteLine($"row_count={rows.Count}");
+            Console.Error.WriteLine($"elapsed_ms={stopwatch.ElapsedMilliseconds}");
+
+            if (traceEnabled && trace is not null)
+            {
+                Console.Error.WriteLine(
+                    "closure_pair_planner_strategies=" +
+                    SummarizeStrategies(
+                        trace,
+                        strategy => strategy.Strategy.Contains("TransitiveClosurePairsMaterializationPlan", StringComparison.Ordinal) ||
+                                    strategy.Strategy.Contains("GroupedTransitiveClosurePairsMaterializationPlan", StringComparison.Ordinal)));
+                Console.Error.WriteLine(
+                    "closure_pair_operator_strategies=" +
+                    SummarizeStrategies(
+                        trace,
+                        strategy => strategy.Strategy.StartsWith("TransitiveClosurePairs", StringComparison.Ordinal) ||
+                                    strategy.Strategy.StartsWith("GroupedTransitiveClosurePairs", StringComparison.Ordinal)));
+                Console.Error.WriteLine("closure_pair_phase_summary=" + SummarizePhases(trace, "closure_pair_"));
+            }
+
+            return 0;
+        }
+        finally
+        {
+            try { File.Delete(groupedEdgePath); } catch { }
+        }
+    }
+}
+"""
+
+
+@dataclass
+class BenchResult:
+    scale: str
+    mode: str
+    strategy: str
+    times: list[float]
+    stderr: str
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.times)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="300,10k")
+    parser.add_argument("--modes", default="single,source_fanout,target_fanin,mixed,grouped_mixed")
+    parser.add_argument("--strategies", default="auto,forward,backward,memo-source,memo-target,mixed,mixed-cache")
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--keep-temp", action="store_true")
+    return parser.parse_args()
+
+
+def run(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, env=env, check=True, capture_output=True, text=True)
+
+
+def scale_sort_key(scale: str) -> tuple[int, str]:
+    digits = "".join(ch for ch in scale if ch.isdigit())
+    suffix = "".join(ch for ch in scale if not ch.isdigit())
+    if not digits:
+        return (0, scale)
+    value = int(digits)
+    if suffix.lower() == "k":
+        value *= 1000
+    return (value, scale)
+
+
+def build_harness(root: Path) -> list[str]:
+    if shutil.which("dotnet") is None:
+        raise RuntimeError("dotnet not found")
+
+    project_dir = root / "closure_pair_planning"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "Program.cs").write_text(PROGRAM, encoding="utf-8")
+    (project_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
+    (project_dir / "benchmark_closure_pair_planning.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
+    run(["dotnet", "build", "benchmark_closure_pair_planning.csproj", "-c", "Release"], cwd=project_dir)
+    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_closure_pair_planning.dll")]
+
+
+def parse_metrics(stderr: str) -> dict[str, str]:
+    metrics: dict[str, str] = {}
+    for line in stderr.splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        metrics[key.strip()] = value.strip()
+    return metrics
+
+
+def benchmark_mode(command: list[str], scale: str, mode: str, strategy: str, repetitions: int) -> BenchResult:
+    scale_dir = BENCH_DIR / scale
+    edge_path = scale_dir / "category_parent.tsv"
+    env = os.environ.copy()
+    env["UNIFYWEAVER_BENCH_TRACE"] = "1"
+    env["UNIFYWEAVER_CLOSURE_PAIR_STRATEGY"] = strategy
+
+    times: list[float] = []
+    stderr = ""
+    if repetitions > 0:
+        run(command + [mode, str(edge_path)], env=env)
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        result = run(command + [mode, str(edge_path)], env=env)
+        elapsed = time.perf_counter() - started
+        times.append(elapsed)
+        stderr = result.stderr
+
+    return BenchResult(scale=scale, mode=mode, strategy=strategy, times=times, stderr=stderr)
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    modes = [part.strip() for part in args.modes.split(",") if part.strip()]
+    strategies = [part.strip() for part in args.strategies.split(",") if part.strip()]
+
+    temp_ctx = None
+    if args.keep_temp:
+        temp_root = Path(tempfile.mkdtemp(prefix="uw-closure-pairs-"))
+    else:
+        temp_ctx = tempfile.TemporaryDirectory(prefix="uw-closure-pairs-")
+        temp_root = Path(temp_ctx.name)
+
+    try:
+        command = build_harness(temp_root)
+        results: list[BenchResult] = []
+        for scale in scales:
+            for mode in modes:
+                for strategy in strategies:
+                    results.append(benchmark_mode(command, scale, mode, strategy, args.repetitions))
+
+        print("scale	mode	strategy	median_s	min_s	max_s	requests	rows	planner	phases")
+        grouped: dict[tuple[str, str], dict[str, BenchResult]] = {}
+        for result in sorted(results, key=lambda item: (scale_sort_key(item.scale), item.mode, item.strategy)):
+            grouped.setdefault((result.scale, result.mode), {})[result.strategy] = result
+            metrics = parse_metrics(result.stderr)
+            print(
+                f"{result.scale}	{result.mode}	{result.strategy}	{result.median:.3f}	"
+                f"{min(result.times):.3f}	{max(result.times):.3f}	"
+                f"{metrics.get('request_count', '')}	{metrics.get('row_count', '')}	"
+                f"{metrics.get('closure_pair_planner_strategies', '')}	"
+                f"{metrics.get('closure_pair_phase_summary', '')}"
+            )
+
+        for scale, mode in sorted(grouped.keys(), key=lambda item: (scale_sort_key(item[0]), item[1])):
+            by_strategy = grouped[(scale, mode)]
+            auto = by_strategy.get("auto")
+            best = min(by_strategy.values(), key=lambda item: item.median)
+            if auto is not None:
+                ratio = auto.median / best.median if best.median else float("inf")
+                auto_metrics = parse_metrics(auto.stderr)
+                print(f"{scale}	{mode}	best_strategy	{best.strategy}")
+                print(f"{scale}	{mode}	auto_vs_best	{ratio:.2f}x")
+                print(f"{scale}	{mode}	auto_planner	{auto_metrics.get('closure_pair_planner_strategies', '')}")
+
+        if args.keep_temp:
+            print(f"kept temp build directory: {temp_root}", file=sys.stderr)
+        return 0
+    finally:
+        if temp_ctx is not None:
+            temp_ctx.cleanup()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -83,6 +83,17 @@ namespace UnifyWeaver.QueryRuntime
         ExternalMaterialized
     }
 
+    public enum ClosurePairStrategy
+    {
+        Auto,
+        Forward,
+        Backward,
+        MemoizedBySource,
+        MemoizedByTarget,
+        MixedDirection,
+        MixedDirectionWithPairProbeCache
+    }
+
     public readonly record struct DelimitedRelationSource(
         string InputPath,
         char Delimiter = '	',
@@ -549,6 +560,18 @@ namespace UnifyWeaver.QueryRuntime
         Support
     }
 
+    internal enum ClosurePairPlanStrategy
+    {
+        Forward,
+        Backward,
+        MemoizedBySource,
+        MemoizedByTarget,
+        MixedDirection,
+        MixedDirectionWithPairProbeCache,
+        SingleProbeForward,
+        SingleProbeBackward
+    }
+
     internal enum PathAwareSupportRelationAccessKind
     {
         Roots,
@@ -588,11 +611,16 @@ namespace UnifyWeaver.QueryRuntime
         ClosureRelationRetentionStrategy Strategy,
         string DecisionMode);
 
+    internal readonly record struct ClosurePairStrategySelection(
+        ClosurePairPlanStrategy Strategy,
+        string DecisionMode);
+
     public sealed record QueryExecutorOptions(
         bool ReuseCaches = false,
         DagRelationRetentionStrategy DagRelationRetentionStrategy = DagRelationRetentionStrategy.Auto,
         ScanRelationRetentionStrategy ScanRelationRetentionStrategy = ScanRelationRetentionStrategy.Auto,
         ClosureRelationRetentionStrategy ClosureRelationRetentionStrategy = ClosureRelationRetentionStrategy.Auto,
+        ClosurePairStrategy ClosurePairStrategy = ClosurePairStrategy.Auto,
         PathAwareEdgeRetentionStrategy PathAwareEdgeRetentionStrategy = PathAwareEdgeRetentionStrategy.Auto,
         PathAwareSupportRelationRetentionStrategy PathAwareSupportRelationRetentionStrategy = PathAwareSupportRelationRetentionStrategy.Auto,
         PathAwareGroupedMinStrategy PathAwareGroupedMinStrategy = PathAwareGroupedMinStrategy.Auto,
@@ -1546,6 +1574,7 @@ namespace UnifyWeaver.QueryRuntime
         private readonly DagRelationRetentionStrategy _dagRelationRetentionStrategy;
         private readonly ScanRelationRetentionStrategy _scanRelationRetentionStrategy;
         private readonly ClosureRelationRetentionStrategy _closureRelationRetentionStrategy;
+        private readonly ClosurePairStrategy _closurePairStrategy;
         private readonly PathAwareEdgeRetentionStrategy _pathAwareEdgeRetentionStrategy;
         private readonly PathAwareSupportRelationRetentionStrategy _pathAwareSupportRelationRetentionStrategy;
         private readonly PathAwareGroupedSummaryStrategy _pathAwareGroupedMinStrategy;
@@ -1566,6 +1595,7 @@ namespace UnifyWeaver.QueryRuntime
             _dagRelationRetentionStrategy = options.DagRelationRetentionStrategy;
             _scanRelationRetentionStrategy = options.ScanRelationRetentionStrategy;
             _closureRelationRetentionStrategy = options.ClosureRelationRetentionStrategy;
+            _closurePairStrategy = options.ClosurePairStrategy;
             _pathAwareEdgeRetentionStrategy = options.PathAwareEdgeRetentionStrategy;
             _pathAwareSupportRelationRetentionStrategy = options.PathAwareSupportRelationRetentionStrategy;
             _pathAwareGroupedMinStrategy = ToPathAwareGroupedSummaryStrategy(options.PathAwareGroupedMinStrategy);
@@ -9728,6 +9758,145 @@ namespace UnifyWeaver.QueryRuntime
             }
         }
 
+        private static ClosurePairPlanStrategy? ResolveConfiguredClosurePairStrategy(
+            ClosurePairStrategy configuredStrategy,
+            bool singleConcretePairRequest,
+            bool canBuildDirectionBatches)
+        {
+            return configuredStrategy switch
+            {
+                ClosurePairStrategy.Auto => null,
+                ClosurePairStrategy.Forward => singleConcretePairRequest
+                    ? ClosurePairPlanStrategy.SingleProbeForward
+                    : ClosurePairPlanStrategy.Forward,
+                ClosurePairStrategy.Backward => singleConcretePairRequest
+                    ? ClosurePairPlanStrategy.SingleProbeBackward
+                    : ClosurePairPlanStrategy.Backward,
+                ClosurePairStrategy.MemoizedBySource => ClosurePairPlanStrategy.MemoizedBySource,
+                ClosurePairStrategy.MemoizedByTarget => ClosurePairPlanStrategy.MemoizedByTarget,
+                ClosurePairStrategy.MixedDirection when canBuildDirectionBatches => ClosurePairPlanStrategy.MixedDirection,
+                ClosurePairStrategy.MixedDirectionWithPairProbeCache when canBuildDirectionBatches => ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache,
+                _ => null
+            };
+        }
+
+        private static ClosurePairPlanStrategy ResolveStructuralClosurePairStrategy(
+            bool singleConcretePairRequest,
+            bool preferForwardSingleProbe,
+            bool hasForwardBatch,
+            bool hasBackwardBatch,
+            bool canUseBatchedPairProbeCache,
+            bool canMemoizeForwardBatch,
+            bool canMemoizeBackwardBatch,
+            bool canMemoizePairs,
+            bool preferForwardFallback)
+        {
+            if (singleConcretePairRequest)
+            {
+                return preferForwardSingleProbe
+                    ? ClosurePairPlanStrategy.SingleProbeForward
+                    : ClosurePairPlanStrategy.SingleProbeBackward;
+            }
+
+            if (hasForwardBatch && hasBackwardBatch)
+            {
+                return canUseBatchedPairProbeCache
+                    ? ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache
+                    : ClosurePairPlanStrategy.MixedDirection;
+            }
+
+            if (hasForwardBatch)
+            {
+                if (canUseBatchedPairProbeCache)
+                {
+                    return ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache;
+                }
+
+                return canMemoizeForwardBatch
+                    ? ClosurePairPlanStrategy.MemoizedBySource
+                    : ClosurePairPlanStrategy.Forward;
+            }
+
+            if (hasBackwardBatch)
+            {
+                if (canUseBatchedPairProbeCache)
+                {
+                    return ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache;
+                }
+
+                return canMemoizeBackwardBatch
+                    ? ClosurePairPlanStrategy.MemoizedByTarget
+                    : ClosurePairPlanStrategy.Backward;
+            }
+
+            if (canMemoizePairs)
+            {
+                return preferForwardFallback
+                    ? ClosurePairPlanStrategy.MemoizedBySource
+                    : ClosurePairPlanStrategy.MemoizedByTarget;
+            }
+
+            return preferForwardFallback
+                ? ClosurePairPlanStrategy.Forward
+                : ClosurePairPlanStrategy.Backward;
+        }
+
+        private static ClosurePairStrategySelection ResolveClosurePairStrategy(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            ClosurePairStrategy configuredStrategy,
+            bool singleConcretePairRequest,
+            bool preferForwardSingleProbe,
+            bool canBuildDirectionBatches,
+            bool hasForwardBatch,
+            bool hasBackwardBatch,
+            bool canUseBatchedPairProbeCache,
+            bool canMemoizeForwardBatch,
+            bool canMemoizeBackwardBatch,
+            bool canMemoizePairs,
+            bool preferForwardFallback)
+        {
+            return MeasurePhase(trace, node, "closure_pair_strategy_select", () =>
+            {
+                var configured = ResolveConfiguredClosurePairStrategy(
+                    configuredStrategy,
+                    singleConcretePairRequest,
+                    canBuildDirectionBatches);
+                if (configured is { } configuredSelection)
+                {
+                    return new ClosurePairStrategySelection(configuredSelection, "ConfiguredOverride");
+                }
+
+                var structural = ResolveStructuralClosurePairStrategy(
+                    singleConcretePairRequest,
+                    preferForwardSingleProbe,
+                    hasForwardBatch,
+                    hasBackwardBatch,
+                    canUseBatchedPairProbeCache,
+                    canMemoizeForwardBatch,
+                    canMemoizeBackwardBatch,
+                    canMemoizePairs,
+                    preferForwardFallback);
+
+                if (configuredStrategy != ClosurePairStrategy.Auto)
+                {
+                    return new ClosurePairStrategySelection(structural, "ConfiguredFallback");
+                }
+
+                return new ClosurePairStrategySelection(structural, "Structural");
+            });
+        }
+
+        private static void RecordClosurePairStrategy(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            string nodeStrategyPrefix,
+            ClosurePairStrategySelection selection)
+        {
+            trace?.RecordStrategy(node, $"{nodeStrategyPrefix}MaterializationPlanSelection{selection.DecisionMode}");
+            trace?.RecordStrategy(node, $"{nodeStrategyPrefix}MaterializationPlanPairs{selection.Strategy}");
+        }
+
         private IReadOnlyDictionary<object, Dictionary<object, double>> ExecuteSeedGroupedPathAwareWeightSumFallback(
             SeedGroupedPathAwareWeightSumNode closure,
             IReadOnlyList<object?> orderedUniqueSeeds,
@@ -13706,231 +13875,248 @@ namespace UnifyWeaver.QueryRuntime
 
                 trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairs");
 
-                if (IsSingleConcreteGroupedPairRequest(targetsBySource, sourcesByTarget))
+                const int MaxMemoizedGroupedPairSeeds = 32;
+                var singleConcretePairRequest = IsSingleConcreteGroupedPairRequest(targetsBySource, sourcesByTarget);
+                var preferForwardSingleProbe = true;
+                Dictionary<RowWrapper, List<object[]>>? singleSuccIndex = null;
+                Dictionary<RowWrapper, List<object[]>>? singlePredIndex = null;
+                var singleForwardCost = 0;
+                var singleBackwardCost = 0;
+
+                if (singleConcretePairRequest)
                 {
-                    var probeCount = ComputeSingleGroupedPairProbeNormalizationCount(parameters, inputPositions, closure.GroupIndices);
-                    var seedEntry = targetsBySource.First();
-                    var sourceKey = seedEntry.Key.Row;
-                    var target = seedEntry.Value.First();
+                    var sourceEntry = targetsBySource.First();
+                    var sourceKey = sourceEntry.Key.Row;
+                    var target = sourceEntry.Value.First();
                     var targetKey = new object[sourceKey.Length];
                     Array.Copy(sourceKey, targetKey, sourceKey.Length - 1);
                     targetKey[sourceKey.Length - 1] = target;
 
                     var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
-                    var groupKeyCount = closure.GroupIndices.Count;
-                    var fromKeyIndices = new int[groupKeyCount + 1];
-                    var toKeyIndices = new int[groupKeyCount + 1];
-                    for (var i = 0; i < groupKeyCount; i++)
+                    var keyCount = closure.GroupIndices.Count;
+                    var fromKeyIndices = new int[keyCount + 1];
+                    var toKeyIndices = new int[keyCount + 1];
+                    for (var i = 0; i < keyCount; i++)
                     {
                         fromKeyIndices[i] = closure.GroupIndices[i];
                         toKeyIndices[i] = closure.GroupIndices[i];
                     }
-                    fromKeyIndices[groupKeyCount] = 0;
-                    toKeyIndices[groupKeyCount] = 1;
 
-                    var succIndex = GetJoinIndex(closure.EdgeRelation, fromKeyIndices, edges, context);
-                    var predIndex = GetJoinIndex(closure.EdgeRelation, toKeyIndices, edges, context);
-                    var forwardCost = CountEdgeBucket(succIndex, sourceKey);
-                    var backwardCost = CountEdgeBucket(predIndex, targetKey);
-                    var groupedCacheKey = (closure.EdgeRelation, closure.Predicate, string.Join(",", closure.GroupIndices));
-                    var groupedPairKey = new object[sourceKey.Length + 1];
-                    Array.Copy(sourceKey, groupedPairKey, sourceKey.Length);
-                    groupedPairKey[sourceKey.Length] = target;
-                    var sourceLabel = string.Join("|", sourceKey.Select(value => value is null ? "<null>" : FormatCacheSeedValue(value)));
-                    var targetLabel = target is null ? "<null>" : FormatCacheSeedValue(target);
-                    var traceKey =
-                        $"{closure.Predicate.Name}/{closure.Predicate.Arity}:edge={closure.EdgeRelation.Name}/{closure.EdgeRelation.Arity}:groups={string.Join(",", closure.GroupIndices)}:pair={sourceLabel}->{targetLabel}";
-                    var canReusePairProbeCache = _pairProbeCacheMaxEntries > 0;
-
-                    if (canReusePairProbeCache &&
-                        context.GroupedTransitiveClosurePairProbeResults.TryGetValue(groupedCacheKey, out var cachedByPair) &&
-                        TryGetLruRowWrapperCacheValue(cachedByPair, new RowWrapper(groupedPairKey), out var pairReachable))
-                    {
-                        trace?.RecordCacheLookup("GroupedTransitiveClosurePairsSingleProbe", traceKey, hit: true, built: false);
-                        if (!pairReachable)
-                        {
-                            return Array.Empty<object[]>();
-                        }
-
-                        return new List<object[]>
-                        {
-                            BuildGroupedClosureRow(closure.Predicate.Arity, groupKeyCount, closure.GroupIndices, groupedPairKey)
-                        };
-                    }
-
-                    trace?.RecordCacheLookup("GroupedTransitiveClosurePairsSingleProbe", traceKey, hit: false, built: true);
-
-                    var rows = forwardCost <= backwardCost
-                        ? ExecuteSeededGroupedTransitiveClosurePairsForward(closure, targetsBySource, context).ToList()
-                        : ExecuteSeededGroupedTransitiveClosurePairsBackward(closure, sourcesByTarget, context).ToList();
-
-                    if (forwardCost <= backwardCost)
-                    {
-                        trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsSingleProbeForward");
-                    }
-                    else
-                    {
-                        trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsSingleProbeBackward");
-                    }
-
-                    if (canReusePairProbeCache)
-                    {
-                        if (!context.GroupedTransitiveClosurePairProbeResults.TryGetValue(groupedCacheKey, out var pairStore))
-                        {
-                            pairStore = new Dictionary<RowWrapper, bool>(StructuralRowWrapperComparer);
-                            context.GroupedTransitiveClosurePairProbeResults.Add(groupedCacheKey, pairStore);
-                        }
-
-                        var admitPairProbeCache = ShouldAdmitPairProbeCacheEntry(
-                            forwardCost,
-                            backwardCost,
-                            probeCount,
-                            useCostPerProbeGate: true);
-                        TryAdmitLruBoundedRowWrapperCacheEntry(
-                            pairStore,
-                            new RowWrapper(groupedPairKey),
-                            rows.Count > 0,
-                            _pairProbeCacheMaxEntries,
-                            admitPairProbeCache,
-                            trace,
-                            "GroupedTransitiveClosurePairsSingleProbe",
-                            traceKey);
-                    }
-
-                    return rows;
+                    fromKeyIndices[keyCount] = 0;
+                    toKeyIndices[keyCount] = 1;
+                    singleSuccIndex = GetJoinIndex(closure.EdgeRelation, fromKeyIndices, edges, context);
+                    singlePredIndex = GetJoinIndex(closure.EdgeRelation, toKeyIndices, edges, context);
+                    singleForwardCost = CountEdgeBucket(singleSuccIndex, sourceKey);
+                    singleBackwardCost = CountEdgeBucket(singlePredIndex, targetKey);
+                    preferForwardSingleProbe = singleForwardCost <= singleBackwardCost;
                 }
 
-                const int MaxMemoizedGroupedPairSeeds = 32;
-                if (TryBuildGroupedPairProbeDirectionBatches(
+                Dictionary<RowWrapper, HashSet<object?>> forwardTargetsBySource = new(wrapperComparer);
+                Dictionary<RowWrapper, HashSet<object?>> backwardSourcesByTarget = new(wrapperComparer);
+                var canBuildDirectionBatches = !singleConcretePairRequest &&
+                    TryBuildGroupedPairProbeDirectionBatches(
                         closure,
                         targetsBySource,
                         context,
-                        out var forwardTargetsBySource,
-                        out var backwardSourcesByTarget))
-                {
-                    var canReuseBatchedPairProbeCache =
-                        _pairProbeCacheMaxEntries > 0 &&
-                        _pairProbeCacheAdmissionMinCostPerProbe > 0d;
-
-                    if (forwardTargetsBySource.Count > 0 && backwardSourcesByTarget.Count > 0)
-                    {
-                        trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsBatchedSingleProbeMixed");
-                        if (canReuseBatchedPairProbeCache)
-                        {
-                            return ExecuteSeededGroupedTransitiveClosurePairsMixedDirectionWithPairProbeCache(
-                                closure,
-                                inputPositions,
-                                forwardTargetsBySource,
-                                backwardSourcesByTarget,
-                                context);
-                        }
-
-                        return ExecuteSeededGroupedTransitiveClosurePairsMixedDirection(
-                            closure,
-                            inputPositions,
-                            forwardTargetsBySource,
-                            backwardSourcesByTarget,
-                            context);
-                    }
-
-                    if (forwardTargetsBySource.Count > 0)
-                    {
-                        trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsBatchedSingleProbeForward");
-                        if (canReuseBatchedPairProbeCache)
-                        {
-                            return ExecuteSeededGroupedTransitiveClosurePairsMixedDirectionWithPairProbeCache(
-                                closure,
-                                inputPositions,
-                                forwardTargetsBySource,
-                                backwardSourcesByTarget,
-                                context);
-                        }
-
-                        if (_cacheContext is not null && forwardTargetsBySource.Count <= MaxMemoizedGroupedPairSeeds)
-                        {
-                            trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsMemoized");
-                            trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsMemoizedForward");
-                            return ExecuteSeededGroupedTransitiveClosurePairsMemoizedBySource(
-                                closure,
-                                inputPositions,
-                                forwardTargetsBySource,
-                                context);
-                        }
-
-                        return ExecuteSeededGroupedTransitiveClosurePairsForward(
-                            closure,
-                            forwardTargetsBySource,
-                            context);
-                    }
-
-                    trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsBatchedSingleProbeBackward");
-                    if (canReuseBatchedPairProbeCache)
-                    {
-                        return ExecuteSeededGroupedTransitiveClosurePairsMixedDirectionWithPairProbeCache(
-                            closure,
-                            inputPositions,
-                            forwardTargetsBySource,
-                            backwardSourcesByTarget,
-                            context);
-                    }
-
-                    if (_cacheContext is not null && backwardSourcesByTarget.Count <= MaxMemoizedGroupedPairSeeds)
-                    {
-                        trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsMemoized");
-                        trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsMemoizedBackward");
-                        return ExecuteSeededGroupedTransitiveClosurePairsMemoizedByTarget(
-                            closure,
-                            inputPositions,
-                            backwardSourcesByTarget,
-                            context);
-                    }
-
-                    return ExecuteSeededGroupedTransitiveClosurePairsBackward(
-                        closure,
-                        backwardSourcesByTarget,
-                        context);
-                }
-
+                        out forwardTargetsBySource,
+                        out backwardSourcesByTarget);
+                var canReuseBatchedPairProbeCache =
+                    canBuildDirectionBatches &&
+                    _pairProbeCacheMaxEntries > 0 &&
+                    _pairProbeCacheAdmissionMinCostPerProbe > 0d;
+                var canMemoizeForwardBatch =
+                    canBuildDirectionBatches &&
+                    _cacheContext is not null &&
+                    forwardTargetsBySource.Count > 0 &&
+                    forwardTargetsBySource.Count <= MaxMemoizedGroupedPairSeeds;
+                var canMemoizeBackwardBatch =
+                    canBuildDirectionBatches &&
+                    _cacheContext is not null &&
+                    backwardSourcesByTarget.Count > 0 &&
+                    backwardSourcesByTarget.Count <= MaxMemoizedGroupedPairSeeds;
                 var canMemoizePairs =
+                    !singleConcretePairRequest &&
                     _cacheContext is not null &&
                     targetsBySource.Count <= MaxMemoizedGroupedPairSeeds &&
                     sourcesByTarget.Count <= MaxMemoizedGroupedPairSeeds;
+                var preferForwardFallback = targetsBySource.Count <= sourcesByTarget.Count;
 
-                if (canMemoizePairs && targetsBySource.Count <= sourcesByTarget.Count)
+                var pairStrategySelection = ResolveClosurePairStrategy(
+                    trace,
+                    closure,
+                    _closurePairStrategy,
+                    singleConcretePairRequest,
+                    preferForwardSingleProbe,
+                    canBuildDirectionBatches,
+                    forwardTargetsBySource.Count > 0,
+                    backwardSourcesByTarget.Count > 0,
+                    canReuseBatchedPairProbeCache,
+                    canMemoizeForwardBatch,
+                    canMemoizeBackwardBatch,
+                    canMemoizePairs,
+                    preferForwardFallback);
+                RecordClosurePairStrategy(trace, closure, "GroupedTransitiveClosurePairs", pairStrategySelection);
+
+                return pairStrategySelection.Strategy switch
                 {
-                    trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsMemoized");
-                    trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsMemoizedForward");
-                    return ExecuteSeededGroupedTransitiveClosurePairsMemoizedBySource(
+                    ClosurePairPlanStrategy.SingleProbeForward => ExecuteSeededGroupedTransitiveClosurePairsSingleProbe(
+                        closure,
+                        inputPositions,
+                        parameters,
+                        targetsBySource,
+                        sourcesByTarget,
+                        context,
+                        preferForward: true,
+                        singleSuccIndex!,
+                        singlePredIndex!,
+                        singleForwardCost,
+                        singleBackwardCost),
+                    ClosurePairPlanStrategy.SingleProbeBackward => ExecuteSeededGroupedTransitiveClosurePairsSingleProbe(
+                        closure,
+                        inputPositions,
+                        parameters,
+                        targetsBySource,
+                        sourcesByTarget,
+                        context,
+                        preferForward: false,
+                        singleSuccIndex!,
+                        singlePredIndex!,
+                        singleForwardCost,
+                        singleBackwardCost),
+                    ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache => ExecuteSeededGroupedTransitiveClosurePairsMixedDirectionWithPairProbeCache(
+                        closure,
+                        inputPositions,
+                        forwardTargetsBySource,
+                        backwardSourcesByTarget,
+                        context),
+                    ClosurePairPlanStrategy.MixedDirection => ExecuteSeededGroupedTransitiveClosurePairsMixedDirection(
+                        closure,
+                        inputPositions,
+                        forwardTargetsBySource,
+                        backwardSourcesByTarget,
+                        context),
+                    ClosurePairPlanStrategy.MemoizedBySource when canBuildDirectionBatches && forwardTargetsBySource.Count > 0 => ExecuteSeededGroupedTransitiveClosurePairsMemoizedBySource(
+                        closure,
+                        inputPositions,
+                        forwardTargetsBySource,
+                        context),
+                    ClosurePairPlanStrategy.MemoizedBySource => ExecuteSeededGroupedTransitiveClosurePairsMemoizedBySource(
                         closure,
                         inputPositions,
                         targetsBySource,
-                        context);
-                }
-
-                if (canMemoizePairs)
-                {
-                    trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsMemoized");
-                    trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsMemoizedBackward");
-                    return ExecuteSeededGroupedTransitiveClosurePairsMemoizedByTarget(
+                        context),
+                    ClosurePairPlanStrategy.MemoizedByTarget when canBuildDirectionBatches && backwardSourcesByTarget.Count > 0 => ExecuteSeededGroupedTransitiveClosurePairsMemoizedByTarget(
+                        closure,
+                        inputPositions,
+                        backwardSourcesByTarget,
+                        context),
+                    ClosurePairPlanStrategy.MemoizedByTarget => ExecuteSeededGroupedTransitiveClosurePairsMemoizedByTarget(
                         closure,
                         inputPositions,
                         sourcesByTarget,
-                        context);
-                }
-
-                if (targetsBySource.Count <= sourcesByTarget.Count)
-                {
-                    trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsForward");
-                    return ExecuteSeededGroupedTransitiveClosurePairsForward(closure, targetsBySource, context);
-                }
-
-                trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsBackward");
-                return ExecuteSeededGroupedTransitiveClosurePairsBackward(closure, sourcesByTarget, context);
+                        context),
+                    ClosurePairPlanStrategy.Forward when canBuildDirectionBatches && forwardTargetsBySource.Count > 0 => ExecuteSeededGroupedTransitiveClosurePairsForward(
+                        closure,
+                        forwardTargetsBySource,
+                        context),
+                    ClosurePairPlanStrategy.Forward => ExecuteSeededGroupedTransitiveClosurePairsForward(
+                        closure,
+                        targetsBySource,
+                        context),
+                    ClosurePairPlanStrategy.Backward when canBuildDirectionBatches && backwardSourcesByTarget.Count > 0 => ExecuteSeededGroupedTransitiveClosurePairsBackward(
+                        closure,
+                        backwardSourcesByTarget,
+                        context),
+                    _ => ExecuteSeededGroupedTransitiveClosurePairsBackward(
+                        closure,
+                        sourcesByTarget,
+                        context)
+                };
             }
             finally
             {
                 context.FixpointDepth--;
             }
+        }
+
+        private IEnumerable<object[]> ExecuteSeededGroupedTransitiveClosurePairsSingleProbe(
+            GroupedTransitiveClosureNode closure,
+            IReadOnlyList<int> inputPositions,
+            IReadOnlyList<object[]> parameters,
+            IReadOnlyDictionary<RowWrapper, HashSet<object?>> targetsBySource,
+            IReadOnlyDictionary<RowWrapper, HashSet<object?>> sourcesByTarget,
+            EvaluationContext context,
+            bool preferForward,
+            Dictionary<RowWrapper, List<object[]>> succIndex,
+            Dictionary<RowWrapper, List<object[]>> predIndex,
+            int forwardCost,
+            int backwardCost)
+        {
+            var trace = context.Trace;
+            var probeCount = ComputeSingleGroupedPairProbeNormalizationCount(parameters, inputPositions, closure.GroupIndices);
+            var sourceEntry = targetsBySource.First();
+            var sourceKey = sourceEntry.Key.Row;
+            var target = sourceEntry.Value.First();
+            var targetKey = new object[sourceKey.Length];
+            Array.Copy(sourceKey, targetKey, sourceKey.Length - 1);
+            targetKey[sourceKey.Length - 1] = target;
+            var groupedCacheKey = (closure.EdgeRelation, closure.Predicate, string.Join(",", closure.GroupIndices));
+            var groupedPairKey = new object[sourceKey.Length + 1];
+            Array.Copy(sourceKey, groupedPairKey, sourceKey.Length);
+            groupedPairKey[sourceKey.Length] = target;
+            var sourceLabel = string.Join("|", sourceKey.Select(value => value is null ? "<null>" : FormatCacheSeedValue(value)));
+            var targetLabel = target is null ? "<null>" : FormatCacheSeedValue(target);
+            var traceKey =
+                $"{closure.Predicate.Name}/{closure.Predicate.Arity}:edge={closure.EdgeRelation.Name}/{closure.EdgeRelation.Arity}:groups={string.Join(",", closure.GroupIndices)}:pair={sourceLabel}->{targetLabel}";
+            var canReusePairProbeCache = _pairProbeCacheMaxEntries > 0;
+
+            if (canReusePairProbeCache &&
+                context.GroupedTransitiveClosurePairProbeResults.TryGetValue(groupedCacheKey, out var cachedByPair) &&
+                TryGetLruRowWrapperCacheValue(cachedByPair, new RowWrapper(groupedPairKey), out var pairReachable))
+            {
+                trace?.RecordCacheLookup("GroupedTransitiveClosurePairsSingleProbe", traceKey, hit: true, built: false);
+                if (!pairReachable)
+                {
+                    return Array.Empty<object[]>();
+                }
+
+                return new List<object[]>
+                {
+                    BuildGroupedClosureRow(closure.Predicate.Arity, closure.GroupIndices.Count, closure.GroupIndices, groupedPairKey)
+                };
+            }
+
+            trace?.RecordCacheLookup("GroupedTransitiveClosurePairsSingleProbe", traceKey, hit: false, built: true);
+
+            var rows = preferForward
+                ? ExecuteSeededGroupedTransitiveClosurePairsForward(closure, targetsBySource, context).ToList()
+                : ExecuteSeededGroupedTransitiveClosurePairsBackward(closure, sourcesByTarget, context).ToList();
+
+            if (canReusePairProbeCache)
+            {
+                if (!context.GroupedTransitiveClosurePairProbeResults.TryGetValue(groupedCacheKey, out var pairStore))
+                {
+                    pairStore = new Dictionary<RowWrapper, bool>(StructuralRowWrapperComparer);
+                    context.GroupedTransitiveClosurePairProbeResults.Add(groupedCacheKey, pairStore);
+                }
+
+                var admitPairProbeCache = ShouldAdmitPairProbeCacheEntry(
+                    forwardCost,
+                    backwardCost,
+                    probeCount,
+                    useCostPerProbeGate: true);
+                TryAdmitLruBoundedRowWrapperCacheEntry(
+                    pairStore,
+                    new RowWrapper(groupedPairKey),
+                    rows.Count > 0,
+                    _pairProbeCacheMaxEntries,
+                    admitPairProbeCache,
+                    trace,
+                    "GroupedTransitiveClosurePairsSingleProbe",
+                    traceKey);
+            }
+
+            return rows;
         }
 
         private IEnumerable<object[]> ExecuteSeededGroupedTransitiveClosurePairsMixedDirection(
@@ -13940,49 +14126,12 @@ namespace UnifyWeaver.QueryRuntime
             IReadOnlyDictionary<RowWrapper, HashSet<object?>> backwardSourcesByTarget,
             EvaluationContext context)
         {
-            const int MaxMemoizedGroupedPairSeeds = 32;
-            var canMemoizeForwardPairs =
-                _cacheContext is not null &&
-                forwardTargetsBySource.Count <= MaxMemoizedGroupedPairSeeds;
-            var canMemoizeBackwardPairs =
-                _cacheContext is not null &&
-                backwardSourcesByTarget.Count <= MaxMemoizedGroupedPairSeeds;
-
-            var trace = context.Trace;
-            var forwardRows = canMemoizeForwardPairs
-                ? ExecuteSeededGroupedTransitiveClosurePairsMemoizedBySource(
-                    closure,
-                    inputPositions,
-                    forwardTargetsBySource,
-                    context)
-                : ExecuteSeededGroupedTransitiveClosurePairsForward(closure, forwardTargetsBySource, context);
-
-            if (canMemoizeForwardPairs)
-            {
-                trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsMemoized");
-                trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsMemoizedForward");
-            }
-
-            foreach (var row in forwardRows)
+            foreach (var row in ExecuteSeededGroupedTransitiveClosurePairsForward(closure, forwardTargetsBySource, context))
             {
                 yield return row;
             }
 
-            var backwardRows = canMemoizeBackwardPairs
-                ? ExecuteSeededGroupedTransitiveClosurePairsMemoizedByTarget(
-                    closure,
-                    inputPositions,
-                    backwardSourcesByTarget,
-                    context)
-                : ExecuteSeededGroupedTransitiveClosurePairsBackward(closure, backwardSourcesByTarget, context);
-
-            if (canMemoizeBackwardPairs)
-            {
-                trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsMemoized");
-                trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsMemoizedBackward");
-            }
-
-            foreach (var row in backwardRows)
+            foreach (var row in ExecuteSeededGroupedTransitiveClosurePairsBackward(closure, backwardSourcesByTarget, context))
             {
                 yield return row;
             }
@@ -17103,184 +17252,214 @@ namespace UnifyWeaver.QueryRuntime
 
                 trace?.RecordStrategy(closure, "TransitiveClosurePairs");
 
-                if (IsSingleConcretePairRequest(bySource, byTarget))
+                const int MaxMemoizedPairSeeds = 32;
+                var singleConcretePairRequest = IsSingleConcretePairRequest(bySource, byTarget);
+                var preferForwardSingleProbe = true;
+                Dictionary<object, List<object[]>>? singleSuccIndex = null;
+                Dictionary<object, List<object[]>>? singlePredIndex = null;
+                var singleForwardCost = 0;
+                var singleBackwardCost = 0;
+
+                if (singleConcretePairRequest)
                 {
-                    var probeCount = ComputeSinglePairProbeNormalizationCount(parameters);
                     var source = bySource.First().Key;
                     var target = bySource.First().Value.First();
                     var edges = GetClosureFactsList(closure.EdgeRelation, ClosureRelationAccessKind.Edge, context, closure);
-                    var succIndex = GetFactIndex(closure.EdgeRelation, 0, edges, context);
-                    var predIndex = GetFactIndex(closure.EdgeRelation, 1, edges, context);
-                    var forwardCost = CountEdgeBucket(succIndex, source);
-                    var backwardCost = CountEdgeBucket(predIndex, target);
-                    var pairCacheKey = (closure.EdgeRelation, closure.Predicate);
-                    var pairProbeKey = new object[] { source!, target! };
-                    var sourceLabel = source is null ? "<null>" : FormatCacheSeedValue(source);
-                    var targetLabel = target is null ? "<null>" : FormatCacheSeedValue(target);
-                    var traceKey =
-                        $"{closure.Predicate.Name}/{closure.Predicate.Arity}:edge={closure.EdgeRelation.Name}/{closure.EdgeRelation.Arity}:pair={sourceLabel}->{targetLabel}";
-                    var canReusePairProbeCache = _pairProbeCacheMaxEntries > 0;
-
-                    if (canReusePairProbeCache &&
-                        context.TransitiveClosurePairProbeResults.TryGetValue(pairCacheKey, out var cachedByPair) &&
-                        TryGetLruRowWrapperCacheValue(cachedByPair, new RowWrapper(pairProbeKey), out var pairReachable))
-                    {
-                        trace?.RecordCacheLookup("TransitiveClosurePairsSingleProbe", traceKey, hit: true, built: false);
-                        if (!pairReachable)
-                        {
-                            return Array.Empty<object[]>();
-                        }
-
-                        return new List<object[]> { new object[] { source!, target! } };
-                    }
-
-                    trace?.RecordCacheLookup("TransitiveClosurePairsSingleProbe", traceKey, hit: false, built: true);
-
-                    var rows = forwardCost <= backwardCost
-                        ? ExecuteSeededTransitiveClosurePairsForward(closure, bySource, context).ToList()
-                        : ExecuteSeededTransitiveClosurePairsBackward(closure, byTarget, context).ToList();
-
-                    if (forwardCost <= backwardCost)
-                    {
-                        trace?.RecordStrategy(closure, "TransitiveClosurePairsSingleProbeForward");
-                    }
-                    else
-                    {
-                        trace?.RecordStrategy(closure, "TransitiveClosurePairsSingleProbeBackward");
-                    }
-
-                    if (canReusePairProbeCache)
-                    {
-                        if (!context.TransitiveClosurePairProbeResults.TryGetValue(pairCacheKey, out var pairStore))
-                        {
-                            pairStore = new Dictionary<RowWrapper, bool>(StructuralRowWrapperComparer);
-                            context.TransitiveClosurePairProbeResults.Add(pairCacheKey, pairStore);
-                        }
-
-                        var admitPairProbeCache = ShouldAdmitPairProbeCacheEntry(
-                            forwardCost,
-                            backwardCost,
-                            probeCount,
-                            useCostPerProbeGate: true);
-                        TryAdmitLruBoundedRowWrapperCacheEntry(
-                            pairStore,
-                            new RowWrapper(pairProbeKey),
-                            rows.Count > 0,
-                            _pairProbeCacheMaxEntries,
-                            admitPairProbeCache,
-                            trace,
-                            "TransitiveClosurePairsSingleProbe",
-                            traceKey);
-                    }
-
-                    return rows;
+                    singleSuccIndex = GetFactIndex(closure.EdgeRelation, 0, edges, context);
+                    singlePredIndex = GetFactIndex(closure.EdgeRelation, 1, edges, context);
+                    singleForwardCost = CountEdgeBucket(singleSuccIndex, source);
+                    singleBackwardCost = CountEdgeBucket(singlePredIndex, target);
+                    preferForwardSingleProbe = singleForwardCost <= singleBackwardCost;
                 }
 
-                const int MaxMemoizedPairSeeds = 32;
-                if (TryBuildPairProbeDirectionBatches(
+                Dictionary<object?, HashSet<object?>> forwardBySource = new();
+                Dictionary<object?, HashSet<object?>> backwardByTarget = new();
+                var canBuildDirectionBatches = !singleConcretePairRequest &&
+                    TryBuildPairProbeDirectionBatches(
                         closure,
                         bySource,
                         context,
-                        out var forwardBySource,
-                        out var backwardByTarget))
-                {
-                    var canReuseBatchedPairProbeCache =
-                        _pairProbeCacheMaxEntries > 0 &&
-                        _pairProbeCacheAdmissionMinCostPerProbe > 0d;
-
-                    if (forwardBySource.Count > 0 && backwardByTarget.Count > 0)
-                    {
-                        trace?.RecordStrategy(closure, "TransitiveClosurePairsBatchedSingleProbeMixed");
-                        if (canReuseBatchedPairProbeCache)
-                        {
-                            return ExecuteSeededTransitiveClosurePairsMixedDirectionWithPairProbeCache(
-                                closure,
-                                forwardBySource,
-                                backwardByTarget,
-                                context);
-                        }
-
-                        return ExecuteSeededTransitiveClosurePairsMixedDirection(
-                            closure,
-                            forwardBySource,
-                            backwardByTarget,
-                            context);
-                    }
-
-                    if (forwardBySource.Count > 0)
-                    {
-                        trace?.RecordStrategy(closure, "TransitiveClosurePairsBatchedSingleProbeForward");
-                        if (canReuseBatchedPairProbeCache)
-                        {
-                            return ExecuteSeededTransitiveClosurePairsMixedDirectionWithPairProbeCache(
-                                closure,
-                                forwardBySource,
-                                backwardByTarget,
-                                context);
-                        }
-
-                        if (_cacheContext is not null && forwardBySource.Count <= MaxMemoizedPairSeeds)
-                        {
-                            trace?.RecordStrategy(closure, "TransitiveClosurePairsMemoized");
-                            trace?.RecordStrategy(closure, "TransitiveClosurePairsMemoizedForward");
-                            return ExecuteSeededTransitiveClosurePairsMemoizedBySource(closure, forwardBySource, context);
-                        }
-
-                        return ExecuteSeededTransitiveClosurePairsForward(closure, forwardBySource, context);
-                    }
-
-                    trace?.RecordStrategy(closure, "TransitiveClosurePairsBatchedSingleProbeBackward");
-                    if (canReuseBatchedPairProbeCache)
-                    {
-                        return ExecuteSeededTransitiveClosurePairsMixedDirectionWithPairProbeCache(
-                            closure,
-                            forwardBySource,
-                            backwardByTarget,
-                            context);
-                    }
-
-                    if (_cacheContext is not null && backwardByTarget.Count <= MaxMemoizedPairSeeds)
-                    {
-                        trace?.RecordStrategy(closure, "TransitiveClosurePairsMemoized");
-                        trace?.RecordStrategy(closure, "TransitiveClosurePairsMemoizedBackward");
-                        return ExecuteSeededTransitiveClosurePairsMemoizedByTarget(closure, backwardByTarget, context);
-                    }
-
-                    return ExecuteSeededTransitiveClosurePairsBackward(closure, backwardByTarget, context);
-                }
-
+                        out forwardBySource,
+                        out backwardByTarget);
+                var canReuseBatchedPairProbeCache =
+                    canBuildDirectionBatches &&
+                    _pairProbeCacheMaxEntries > 0 &&
+                    _pairProbeCacheAdmissionMinCostPerProbe > 0d;
+                var canMemoizeForwardBatch =
+                    canBuildDirectionBatches &&
+                    _cacheContext is not null &&
+                    forwardBySource.Count > 0 &&
+                    forwardBySource.Count <= MaxMemoizedPairSeeds;
+                var canMemoizeBackwardBatch =
+                    canBuildDirectionBatches &&
+                    _cacheContext is not null &&
+                    backwardByTarget.Count > 0 &&
+                    backwardByTarget.Count <= MaxMemoizedPairSeeds;
                 var canMemoizePairs =
+                    !singleConcretePairRequest &&
                     _cacheContext is not null &&
                     bySource.Count <= MaxMemoizedPairSeeds &&
                     byTarget.Count <= MaxMemoizedPairSeeds;
+                var preferForwardFallback = bySource.Count <= byTarget.Count;
 
-                if (canMemoizePairs && bySource.Count <= byTarget.Count)
+                var pairStrategySelection = ResolveClosurePairStrategy(
+                    trace,
+                    closure,
+                    _closurePairStrategy,
+                    singleConcretePairRequest,
+                    preferForwardSingleProbe,
+                    canBuildDirectionBatches,
+                    forwardBySource.Count > 0,
+                    backwardByTarget.Count > 0,
+                    canReuseBatchedPairProbeCache,
+                    canMemoizeForwardBatch,
+                    canMemoizeBackwardBatch,
+                    canMemoizePairs,
+                    preferForwardFallback);
+                RecordClosurePairStrategy(trace, closure, "TransitiveClosurePairs", pairStrategySelection);
+
+                return pairStrategySelection.Strategy switch
                 {
-                    trace?.RecordStrategy(closure, "TransitiveClosurePairsMemoized");
-                    trace?.RecordStrategy(closure, "TransitiveClosurePairsMemoizedForward");
-                    return ExecuteSeededTransitiveClosurePairsMemoizedBySource(closure, bySource, context);
-                }
-
-                if (canMemoizePairs)
-                {
-                    trace?.RecordStrategy(closure, "TransitiveClosurePairsMemoized");
-                    trace?.RecordStrategy(closure, "TransitiveClosurePairsMemoizedBackward");
-                    return ExecuteSeededTransitiveClosurePairsMemoizedByTarget(closure, byTarget, context);
-                }
-
-                if (bySource.Count <= byTarget.Count)
-                {
-                    trace?.RecordStrategy(closure, "TransitiveClosurePairsForward");
-                    return ExecuteSeededTransitiveClosurePairsForward(closure, bySource, context);
-                }
-
-                trace?.RecordStrategy(closure, "TransitiveClosurePairsBackward");
-                return ExecuteSeededTransitiveClosurePairsBackward(closure, byTarget, context);
+                    ClosurePairPlanStrategy.SingleProbeForward => ExecuteSeededTransitiveClosurePairsSingleProbe(
+                        closure,
+                        parameters,
+                        bySource,
+                        byTarget,
+                        context,
+                        preferForward: true,
+                        singleSuccIndex!,
+                        singlePredIndex!,
+                        singleForwardCost,
+                        singleBackwardCost),
+                    ClosurePairPlanStrategy.SingleProbeBackward => ExecuteSeededTransitiveClosurePairsSingleProbe(
+                        closure,
+                        parameters,
+                        bySource,
+                        byTarget,
+                        context,
+                        preferForward: false,
+                        singleSuccIndex!,
+                        singlePredIndex!,
+                        singleForwardCost,
+                        singleBackwardCost),
+                    ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache => ExecuteSeededTransitiveClosurePairsMixedDirectionWithPairProbeCache(
+                        closure,
+                        forwardBySource,
+                        backwardByTarget,
+                        context),
+                    ClosurePairPlanStrategy.MixedDirection => ExecuteSeededTransitiveClosurePairsMixedDirection(
+                        closure,
+                        forwardBySource,
+                        backwardByTarget,
+                        context),
+                    ClosurePairPlanStrategy.MemoizedBySource when canBuildDirectionBatches && forwardBySource.Count > 0 => ExecuteSeededTransitiveClosurePairsMemoizedBySource(
+                        closure,
+                        forwardBySource,
+                        context),
+                    ClosurePairPlanStrategy.MemoizedBySource => ExecuteSeededTransitiveClosurePairsMemoizedBySource(
+                        closure,
+                        bySource,
+                        context),
+                    ClosurePairPlanStrategy.MemoizedByTarget when canBuildDirectionBatches && backwardByTarget.Count > 0 => ExecuteSeededTransitiveClosurePairsMemoizedByTarget(
+                        closure,
+                        backwardByTarget,
+                        context),
+                    ClosurePairPlanStrategy.MemoizedByTarget => ExecuteSeededTransitiveClosurePairsMemoizedByTarget(
+                        closure,
+                        byTarget,
+                        context),
+                    ClosurePairPlanStrategy.Forward when canBuildDirectionBatches && forwardBySource.Count > 0 => ExecuteSeededTransitiveClosurePairsForward(
+                        closure,
+                        forwardBySource,
+                        context),
+                    ClosurePairPlanStrategy.Forward => ExecuteSeededTransitiveClosurePairsForward(
+                        closure,
+                        bySource,
+                        context),
+                    ClosurePairPlanStrategy.Backward when canBuildDirectionBatches && backwardByTarget.Count > 0 => ExecuteSeededTransitiveClosurePairsBackward(
+                        closure,
+                        backwardByTarget,
+                        context),
+                    _ => ExecuteSeededTransitiveClosurePairsBackward(
+                        closure,
+                        byTarget,
+                        context)
+                };
             }
             finally
             {
                 context.FixpointDepth--;
             }
+        }
+
+        private IEnumerable<object[]> ExecuteSeededTransitiveClosurePairsSingleProbe(
+            TransitiveClosureNode closure,
+            IReadOnlyList<object[]> parameters,
+            IReadOnlyDictionary<object?, HashSet<object?>> bySource,
+            IReadOnlyDictionary<object?, HashSet<object?>> byTarget,
+            EvaluationContext context,
+            bool preferForward,
+            Dictionary<object, List<object[]>> succIndex,
+            Dictionary<object, List<object[]>> predIndex,
+            int forwardCost,
+            int backwardCost)
+        {
+            var trace = context.Trace;
+            var probeCount = ComputeSinglePairProbeNormalizationCount(parameters);
+            var source = bySource.First().Key;
+            var target = bySource.First().Value.First();
+            var pairCacheKey = (closure.EdgeRelation, closure.Predicate);
+            var pairProbeKey = new object[] { source!, target! };
+            var sourceLabel = source is null ? "<null>" : FormatCacheSeedValue(source);
+            var targetLabel = target is null ? "<null>" : FormatCacheSeedValue(target);
+            var traceKey =
+                $"{closure.Predicate.Name}/{closure.Predicate.Arity}:edge={closure.EdgeRelation.Name}/{closure.EdgeRelation.Arity}:pair={sourceLabel}->{targetLabel}";
+            var canReusePairProbeCache = _pairProbeCacheMaxEntries > 0;
+
+            if (canReusePairProbeCache &&
+                context.TransitiveClosurePairProbeResults.TryGetValue(pairCacheKey, out var cachedByPair) &&
+                TryGetLruRowWrapperCacheValue(cachedByPair, new RowWrapper(pairProbeKey), out var pairReachable))
+            {
+                trace?.RecordCacheLookup("TransitiveClosurePairsSingleProbe", traceKey, hit: true, built: false);
+                if (!pairReachable)
+                {
+                    return Array.Empty<object[]>();
+                }
+
+                return new List<object[]> { new object[] { source!, target! } };
+            }
+
+            trace?.RecordCacheLookup("TransitiveClosurePairsSingleProbe", traceKey, hit: false, built: true);
+
+            var rows = preferForward
+                ? ExecuteSeededTransitiveClosurePairsForward(closure, bySource, context).ToList()
+                : ExecuteSeededTransitiveClosurePairsBackward(closure, byTarget, context).ToList();
+
+            if (canReusePairProbeCache)
+            {
+                if (!context.TransitiveClosurePairProbeResults.TryGetValue(pairCacheKey, out var pairStore))
+                {
+                    pairStore = new Dictionary<RowWrapper, bool>(StructuralRowWrapperComparer);
+                    context.TransitiveClosurePairProbeResults.Add(pairCacheKey, pairStore);
+                }
+
+                var admitPairProbeCache = ShouldAdmitPairProbeCacheEntry(
+                    forwardCost,
+                    backwardCost,
+                    probeCount,
+                    useCostPerProbeGate: true);
+                TryAdmitLruBoundedRowWrapperCacheEntry(
+                    pairStore,
+                    new RowWrapper(pairProbeKey),
+                    rows.Count > 0,
+                    _pairProbeCacheMaxEntries,
+                    admitPairProbeCache,
+                    trace,
+                    "TransitiveClosurePairsSingleProbe",
+                    traceKey);
+            }
+
+            return rows;
         }
 
         private IEnumerable<object[]> ExecuteSeededTransitiveClosurePairsMixedDirection(
@@ -17289,41 +17468,12 @@ namespace UnifyWeaver.QueryRuntime
             IReadOnlyDictionary<object?, HashSet<object?>> backwardByTarget,
             EvaluationContext context)
         {
-            const int MaxMemoizedPairSeeds = 32;
-            var canMemoizeForwardPairs =
-                _cacheContext is not null &&
-                forwardBySource.Count <= MaxMemoizedPairSeeds;
-            var canMemoizeBackwardPairs =
-                _cacheContext is not null &&
-                backwardByTarget.Count <= MaxMemoizedPairSeeds;
-
-            var trace = context.Trace;
-            var forwardRows = canMemoizeForwardPairs
-                ? ExecuteSeededTransitiveClosurePairsMemoizedBySource(closure, forwardBySource, context)
-                : ExecuteSeededTransitiveClosurePairsForward(closure, forwardBySource, context);
-
-            if (canMemoizeForwardPairs)
-            {
-                trace?.RecordStrategy(closure, "TransitiveClosurePairsMemoized");
-                trace?.RecordStrategy(closure, "TransitiveClosurePairsMemoizedForward");
-            }
-
-            foreach (var row in forwardRows)
+            foreach (var row in ExecuteSeededTransitiveClosurePairsForward(closure, forwardBySource, context))
             {
                 yield return row;
             }
 
-            var backwardRows = canMemoizeBackwardPairs
-                ? ExecuteSeededTransitiveClosurePairsMemoizedByTarget(closure, backwardByTarget, context)
-                : ExecuteSeededTransitiveClosurePairsBackward(closure, backwardByTarget, context);
-
-            if (canMemoizeBackwardPairs)
-            {
-                trace?.RecordStrategy(closure, "TransitiveClosurePairsMemoized");
-                trace?.RecordStrategy(closure, "TransitiveClosurePairsMemoizedBackward");
-            }
-
-            foreach (var row in backwardRows)
+            foreach (var row in ExecuteSeededTransitiveClosurePairsBackward(closure, backwardByTarget, context))
             {
                 yield return row;
             }


### PR DESCRIPTION
  ## Summary

  This PR adds explicit planner selection for generic closure-pair execution in
  the C# query runtime.

  Before this change, seeded closure-pair execution already had several internal
  strategy shapes:

  - forward
  - backward
  - mixed direction
  - mixed direction with pair-probe cache
  - memoized by source
  - memoized by target

  But those choices were still local operator branching, not an explicit planner
  decision.

  This PR makes closure-pair strategy selection explicit, traceable, and
  benchmarkable.

  ## What Changed

  ### Runtime: explicit closure-pair planner

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `ClosurePairStrategy`
  - `ClosurePairPlanStrategy`
  - `ClosurePairStrategySelection`
  - `QueryExecutorOptions.ClosurePairStrategy`

  The runtime now resolves closure-pair strategy through explicit planner
  helpers and records planner-visible traces such as:

  - `TransitiveClosurePairsMaterializationPlanPairs...`
  - `GroupedTransitiveClosurePairsMaterializationPlanPairs...`

  This now covers:

  - `ExecuteSeededTransitiveClosurePairs(...)`
  - grouped closure-pair variants

  ### New focused benchmark harness

  Added:

  - `examples/benchmark/benchmark_closure_pair_planning.py`

  The new suite exercises representative closure-pair workloads:

  - `single`
  - `source_fanout`
  - `target_fanin`
  - `mixed`
  - `grouped_mixed`

  and sweeps:

  - `auto`
  - `forward`
  - `backward`
  - `memo-source`
  - `memo-target`
  - `mixed`
  - `mixed-cache`

  It prints:

  - planner strategy summaries
  - `closure_pair_strategy_select` timing
  - `auto` vs best forced strategy by mode/scale

  ### Docs

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `examples/benchmark/README.md`

  These now reflect that generic closure planning includes not just
  relation-retention planning, but also explicit pair-strategy planning.

  ## Why This Matters

  This is the next step for the generic closure family.

  The runtime already planned how closure relations should be retained. This PR
  adds planning for how closure-pair requests should actually be executed once
  those relations are available.

  That makes the closure family more consistent with the broader
  materialization-planner direction:

  - runtime chooses relation retention
  - runtime chooses pair strategy
  - both decisions are visible and benchmarkable

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/benchmark_closure_pair_planning.py \
      examples/benchmark/benchmark_closure_materialization.py \
      examples/benchmark/benchmark_scan_materialization.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_category_influence_cross_target.py \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py

  ### New closure-pair suite

  Ran locally:

  python examples/benchmark/benchmark_closure_pair_planning.py \
      --scales 300,10k \
      --modes single,source_fanout,target_fanin,mixed,grouped_mixed \
      --strategies auto,forward,backward,memo-source,memo-target,mixed,mixed-cache \
      --repetitions 1

  Representative planner outcomes:

  - single
      - auto -> SingleProbeForward
  - source_fanout
      - auto -> MemoizedBySource
  - mixed
      - auto -> MixedDirection
  - target_fanin
      - auto -> MixedDirection at 300
      - auto -> MemoizedByTarget at 10k

  ### Existing focused harnesses

  Also ran locally:

  python examples/benchmark/benchmark_scan_materialization.py \
      --scales 300,10k \
      --strategies auto \
      --repetitions 1

  python examples/benchmark/benchmark_closure_materialization.py \
      --scales 300,10k \
      --repetitions 1

  ### Existing workload non-regression smokes

  Also ran locally:

  python examples/benchmark/benchmark_shortest_path_cross_target.py --scales 300 --targets csharp-query,csharp-dfs,rust-dfs,go-
  dfs,prolog-min --repetitions 1
  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py --scales 300 --targets csharp-query,csharp-dfs,rust-
  dfs,go-dfs,prolog-min --repetitions 1
  python examples/benchmark/benchmark_effective_distance.py --scales 300 --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-
  accumulated --repetitions 1
  python examples/benchmark/benchmark_category_influence_cross_target.py --scales 300 --targets csharp-query,rust-dfs,go-dfs
  --repetitions 1
  python examples/benchmark/benchmark_dependency_depth_cross_target.py --scales 300 --targets csharp-query,csharp-dfs,rust-dfs,go-
  dfs --repetitions 1
  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py --scales 300 --targets csharp-query,csharp-dfs,rust-
  dfs,go-dfs --repetitions 1

  All still matched on outputs.

  Representative current results:

  - shortest path 300
      - csharp-query 0.122s
  - weighted shortest path 300
      - csharp-query 0.210s
  - effective distance 300
      - csharp-query 0.328s
  - category influence 300
      - csharp-query 0.257s
  - dependency reach-count 300
      - csharp-query 0.091s
  - dependency longest depth 300
      - csharp-query 0.082s

  ## Note

  The new grouped_mixed harness mode is exercising grouped closure-pair planner
  traces correctly, but in its current synthetic setup it still reports
  row_count=0. I left that visible rather than hiding it, so the grouped mode
  is currently more useful as a planner-trace validation path than as a result
  cardinality benchmark.

  ## Scope

  This PR adds:

  - explicit closure-pair planner selection
  - benchmark-visible closure-pair planner traces
  - a focused closure-pair benchmark harness
  - docs describing the broader closure planner coverage

  It does not yet add:

  - a tuned Auto heuristic for every closure-pair mode
  - a corrected grouped synthetic harness shape for non-zero grouped result rows