### PR TITLE
perf(csharp-query): tune closure pair planner

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -106,7 +106,9 @@ Status:
   mixed-with-pair-probe-cache, and memoized source/target strategies through
   an explicit planner surface
 - focused validation for that closure-pair planner surface now lives in
-  `examples/benchmark/benchmark_closure_pair_planning.py`
+  `examples/benchmark/benchmark_closure_pair_planning.py`; the grouped mode now
+  produces non-empty rows, and the summary reports the best effective pair plan
+  separately from the requested override label
 - started for path-aware support relations, where grouped minima and weight-sum
   operators can now choose streaming, replayable buffering, or external
   materialized access for `RootRelation` and `SeedRelation` before grouped

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -91,11 +91,16 @@ Examples:
   same measured relation-retention boundary before building successor,
   predecessor, or auxiliary lookup indices, with an explicit override via
   `QueryExecutorOptions.ClosureRelationRetentionStrategy`
+- delimited relation ingestion now honors `DelimitedRelationSource.ExpectedWidth`
+  beyond 2-column rows, so grouped benchmark and planner harness sources can
+  flow through the runtime without silently dropping extra fields
 - generic closure pair probes can now choose among forward, backward, mixed,
   mixed-with-pair-probe-cache, and memoized source/target strategies through
   an explicit planner surface, with an override via
   `QueryExecutorOptions.ClosurePairStrategy` and focused validation in
-  `examples/benchmark/benchmark_closure_pair_planning.py`
+  `examples/benchmark/benchmark_closure_pair_planning.py`; that harness now
+  produces non-empty grouped rows and reports the best effective pair plan
+  separately from the raw override label
 - generic scan planning now also has focused validation coverage in
   `examples/benchmark/benchmark_scan_materialization.py`, so scan-heavy join,
   negation, aggregate, relation-scan, and pattern-scan paths can be checked

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -53,7 +53,10 @@ corresponding closure buckets such as `closure_strategy_select`,
 available in `benchmark_closure_materialization.py`. Generic closure-pair
 planning now adds `closure_pair_strategy_select` and
 `*TransitiveClosurePairsMaterializationPlanPairs*` traces, with focused
-validation available in `benchmark_closure_pair_planning.py`.
+validation available in `benchmark_closure_pair_planning.py`. That harness now
+uses a real 3-column grouped edge source, produces non-empty grouped rows, and
+reports `best_effective_plan` so override-label fallbacks do not distort the
+comparison.
 
 | Target | 300 art | 1K art | 5K art | 10K art |
 |--------|---------|--------|--------|---------|

--- a/examples/benchmark/benchmark_closure_pair_planning.py
+++ b/examples/benchmark/benchmark_closure_pair_planning.py
@@ -438,6 +438,15 @@ def parse_metrics(stderr: str) -> dict[str, str]:
     return metrics
 
 
+def extract_effective_pair_plan(planner_summary: str) -> str:
+    for part in planner_summary.split("|"):
+        marker = "MaterializationPlanPairs"
+        index = part.find(marker)
+        if index >= 0:
+            return part[index + len(marker):].split("=", 1)[0]
+    return planner_summary
+
+
 def benchmark_mode(command: list[str], scale: str, mode: str, strategy: str, repetitions: int) -> BenchResult:
     scale_dir = BENCH_DIR / scale
     edge_path = scale_dir / "category_parent.tsv"
@@ -495,13 +504,37 @@ def main() -> int:
 
         for scale, mode in sorted(grouped.keys(), key=lambda item: (scale_sort_key(item[0]), item[1])):
             by_strategy = grouped[(scale, mode)]
+            metrics_by_strategy = {strategy: parse_metrics(result.stderr) for strategy, result in by_strategy.items()}
+            row_counts = {
+                strategy: int(metrics.get("row_count", "0") or 0)
+                for strategy, metrics in metrics_by_strategy.items()
+            }
+            max_row_count = max(row_counts.values(), default=0)
+            eligible_results = [
+                result
+                for strategy, result in by_strategy.items()
+                if row_counts.get(strategy, 0) == max_row_count
+            ] or list(by_strategy.values())
+
+            best = min(eligible_results, key=lambda item: item.median)
+            best_by_effective_plan: dict[str, BenchResult] = {}
+            for result in eligible_results:
+                effective_plan = extract_effective_pair_plan(
+                    metrics_by_strategy[result.strategy].get("closure_pair_planner_strategies", ""))
+                existing = best_by_effective_plan.get(effective_plan)
+                if existing is None or result.median < existing.median:
+                    best_by_effective_plan[effective_plan] = result
+            best_effective = min(best_by_effective_plan.values(), key=lambda item: item.median)
+
             auto = by_strategy.get("auto")
-            best = min(by_strategy.values(), key=lambda item: item.median)
             if auto is not None:
+                auto_metrics = metrics_by_strategy["auto"]
                 ratio = auto.median / best.median if best.median else float("inf")
-                auto_metrics = parse_metrics(auto.stderr)
+                effective_ratio = auto.median / best_effective.median if best_effective.median else float("inf")
                 print(f"{scale}	{mode}	best_strategy	{best.strategy}")
                 print(f"{scale}	{mode}	auto_vs_best	{ratio:.2f}x")
+                print(f"{scale}	{mode}	best_effective_plan	{extract_effective_pair_plan(metrics_by_strategy[best_effective.strategy].get('closure_pair_planner_strategies', ''))}")
+                print(f"{scale}	{mode}	auto_vs_best_effective	{effective_ratio:.2f}x")
                 print(f"{scale}	{mode}	auto_planner	{auto_metrics.get('closure_pair_planner_strategies', '')}")
 
         if args.keep_temp:

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1364,34 +1364,75 @@ namespace UnifyWeaver.QueryRuntime
                 }
             }
 
+            var expectedWidth = Math.Max(2, source.ExpectedWidth);
             string? line;
             while ((line = reader.ReadLine()) is not null)
             {
-                if (!TrySplitTwoColumnLine(line, source.Delimiter, out var left, out var right))
+                if (!TrySplitDelimitedLine(line, source.Delimiter, expectedWidth, out var fields))
                 {
                     continue;
                 }
 
-                yield return new object[] { left, right };
+                yield return fields;
             }
         }
 
         public static StreamReader OpenSequentialReader(string path) =>
             new(new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 1 << 16, FileOptions.SequentialScan), Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1 << 16);
 
+        public static bool TrySplitDelimitedLine(string line, char delimiter, int expectedWidth, out object[] fields)
+        {
+            if (expectedWidth <= 1)
+            {
+                expectedWidth = 2;
+            }
+
+            var parts = new object[expectedWidth];
+            var span = line.AsSpan();
+            var start = 0;
+
+            for (var i = 0; i < expectedWidth - 1; i++)
+            {
+                var remainder = span.Slice(start);
+                var split = remainder.IndexOf(delimiter);
+                if (split <= 0)
+                {
+                    fields = Array.Empty<object>();
+                    return false;
+                }
+
+                parts[i] = remainder.Slice(0, split).ToString();
+                start += split + 1;
+                if (start >= span.Length)
+                {
+                    fields = Array.Empty<object>();
+                    return false;
+                }
+            }
+
+            var tail = span.Slice(start);
+            if (tail.Length == 0 || tail.IndexOf(delimiter) >= 0)
+            {
+                fields = Array.Empty<object>();
+                return false;
+            }
+
+            parts[expectedWidth - 1] = tail.ToString();
+            fields = parts;
+            return true;
+        }
+
         public static bool TrySplitTwoColumnLine(string line, char delimiter, out string left, out string right)
         {
-            var span = line.AsSpan();
-            var split = span.IndexOf(delimiter);
-            if (split <= 0 || split >= span.Length - 1)
+            if (!TrySplitDelimitedLine(line, delimiter, 2, out var fields))
             {
                 left = string.Empty;
                 right = string.Empty;
                 return false;
             }
 
-            left = span.Slice(0, split).ToString();
-            right = span.Slice(split + 1).ToString();
+            left = fields[0]?.ToString() ?? string.Empty;
+            right = fields[1]?.ToString() ?? string.Empty;
             return true;
         }
     }
@@ -9781,6 +9822,8 @@ namespace UnifyWeaver.QueryRuntime
         }
 
         private static ClosurePairPlanStrategy ResolveStructuralClosurePairStrategy(
+            int sourceRequestCount,
+            int targetRequestCount,
             bool singleConcretePairRequest,
             bool preferForwardSingleProbe,
             bool hasForwardBatch,
@@ -9796,6 +9839,16 @@ namespace UnifyWeaver.QueryRuntime
                 return preferForwardSingleProbe
                     ? ClosurePairPlanStrategy.SingleProbeForward
                     : ClosurePairPlanStrategy.SingleProbeBackward;
+            }
+
+            if (sourceRequestCount == 1 && targetRequestCount > 1 && canMemoizePairs)
+            {
+                return ClosurePairPlanStrategy.MemoizedBySource;
+            }
+
+            if (targetRequestCount == 1 && sourceRequestCount > 1 && canMemoizePairs)
+            {
+                return ClosurePairPlanStrategy.MemoizedByTarget;
             }
 
             if (hasForwardBatch && hasBackwardBatch)
@@ -9845,6 +9898,8 @@ namespace UnifyWeaver.QueryRuntime
             QueryExecutionTrace? trace,
             PlanNode node,
             ClosurePairStrategy configuredStrategy,
+            int sourceRequestCount,
+            int targetRequestCount,
             bool singleConcretePairRequest,
             bool preferForwardSingleProbe,
             bool canBuildDirectionBatches,
@@ -9868,6 +9923,8 @@ namespace UnifyWeaver.QueryRuntime
                 }
 
                 var structural = ResolveStructuralClosurePairStrategy(
+                    sourceRequestCount,
+                    targetRequestCount,
                     singleConcretePairRequest,
                     preferForwardSingleProbe,
                     hasForwardBatch,
@@ -13945,6 +14002,8 @@ namespace UnifyWeaver.QueryRuntime
                     trace,
                     closure,
                     _closurePairStrategy,
+                    targetsBySource.Count,
+                    sourcesByTarget.Count,
                     singleConcretePairRequest,
                     preferForwardSingleProbe,
                     canBuildDirectionBatches,
@@ -13995,37 +14054,19 @@ namespace UnifyWeaver.QueryRuntime
                         forwardTargetsBySource,
                         backwardSourcesByTarget,
                         context),
-                    ClosurePairPlanStrategy.MemoizedBySource when canBuildDirectionBatches && forwardTargetsBySource.Count > 0 => ExecuteSeededGroupedTransitiveClosurePairsMemoizedBySource(
-                        closure,
-                        inputPositions,
-                        forwardTargetsBySource,
-                        context),
                     ClosurePairPlanStrategy.MemoizedBySource => ExecuteSeededGroupedTransitiveClosurePairsMemoizedBySource(
                         closure,
                         inputPositions,
                         targetsBySource,
-                        context),
-                    ClosurePairPlanStrategy.MemoizedByTarget when canBuildDirectionBatches && backwardSourcesByTarget.Count > 0 => ExecuteSeededGroupedTransitiveClosurePairsMemoizedByTarget(
-                        closure,
-                        inputPositions,
-                        backwardSourcesByTarget,
                         context),
                     ClosurePairPlanStrategy.MemoizedByTarget => ExecuteSeededGroupedTransitiveClosurePairsMemoizedByTarget(
                         closure,
                         inputPositions,
                         sourcesByTarget,
                         context),
-                    ClosurePairPlanStrategy.Forward when canBuildDirectionBatches && forwardTargetsBySource.Count > 0 => ExecuteSeededGroupedTransitiveClosurePairsForward(
-                        closure,
-                        forwardTargetsBySource,
-                        context),
                     ClosurePairPlanStrategy.Forward => ExecuteSeededGroupedTransitiveClosurePairsForward(
                         closure,
                         targetsBySource,
-                        context),
-                    ClosurePairPlanStrategy.Backward when canBuildDirectionBatches && backwardSourcesByTarget.Count > 0 => ExecuteSeededGroupedTransitiveClosurePairsBackward(
-                        closure,
-                        backwardSourcesByTarget,
                         context),
                     _ => ExecuteSeededGroupedTransitiveClosurePairsBackward(
                         closure,
@@ -17306,6 +17347,8 @@ namespace UnifyWeaver.QueryRuntime
                     trace,
                     closure,
                     _closurePairStrategy,
+                    bySource.Count,
+                    byTarget.Count,
                     singleConcretePairRequest,
                     preferForwardSingleProbe,
                     canBuildDirectionBatches,
@@ -17352,33 +17395,17 @@ namespace UnifyWeaver.QueryRuntime
                         forwardBySource,
                         backwardByTarget,
                         context),
-                    ClosurePairPlanStrategy.MemoizedBySource when canBuildDirectionBatches && forwardBySource.Count > 0 => ExecuteSeededTransitiveClosurePairsMemoizedBySource(
-                        closure,
-                        forwardBySource,
-                        context),
                     ClosurePairPlanStrategy.MemoizedBySource => ExecuteSeededTransitiveClosurePairsMemoizedBySource(
                         closure,
                         bySource,
-                        context),
-                    ClosurePairPlanStrategy.MemoizedByTarget when canBuildDirectionBatches && backwardByTarget.Count > 0 => ExecuteSeededTransitiveClosurePairsMemoizedByTarget(
-                        closure,
-                        backwardByTarget,
                         context),
                     ClosurePairPlanStrategy.MemoizedByTarget => ExecuteSeededTransitiveClosurePairsMemoizedByTarget(
                         closure,
                         byTarget,
                         context),
-                    ClosurePairPlanStrategy.Forward when canBuildDirectionBatches && forwardBySource.Count > 0 => ExecuteSeededTransitiveClosurePairsForward(
-                        closure,
-                        forwardBySource,
-                        context),
                     ClosurePairPlanStrategy.Forward => ExecuteSeededTransitiveClosurePairsForward(
                         closure,
                         bySource,
-                        context),
-                    ClosurePairPlanStrategy.Backward when canBuildDirectionBatches && backwardByTarget.Count > 0 => ExecuteSeededTransitiveClosurePairsBackward(
-                        closure,
-                        backwardByTarget,
                         context),
                     _ => ExecuteSeededTransitiveClosurePairsBackward(
                         closure,


### PR DESCRIPTION
  ## Summary

  This PR tightens the closure-pair planner in the C# query runtime and fixes
  the grouped closure-pair benchmark path so it becomes a real acceptance
  surface instead of a trace-only placeholder.

  There are two substantive parts:

  - fix grouped closure-pair input handling so grouped modes produce real rows
  - tune and validate closure-pair strategy selection against a trustworthy
    benchmark signal

  ## What Changed

  ### Runtime: grouped delimited sources now honor expected width

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  `DelimitedRelationReader.ReadRows(...)` was still effectively hard-wired to
  2-column rows.

  That meant the grouped closure-pair harness, which uses a real 3-column
  grouped edge source, could silently drop or misread fields. In practice,
  that was the reason `grouped_mixed` was returning `row_count=0`.

  This PR fixes that by:

  - generalizing delimited row splitting to `ExpectedWidth`
  - keeping `TrySplitTwoColumnLine(...)` as a thin wrapper over the general
    splitter

  So grouped benchmark and planner harness sources now flow through the
  runtime correctly.

  ### Runtime: forced closure-pair strategies now execute full requests

  Updated closure-pair execution in:

  - seeded closure pairs
  - grouped closure-pair variants

  Before this change, forced strategies such as `forward`, `backward`, and
  memoized variants could execute only the planner-assigned directional subset
  when the request shape was mixed.

  That made some overrides look artificially faster because they were doing
  less work.

  This PR fixes that by making forced strategy paths execute against the full
  request dictionaries:

  - `bySource` / `byTarget` for ungrouped
  - `targetsBySource` / `sourcesByTarget` for grouped

  The planner-specific split batches remain used for the actual mixed
  strategies, where they belong.

  ### Runtime: tuned structural closure-pair selection

  Updated:

  - `ResolveStructuralClosurePairStrategy(...)`
  - `ResolveClosurePairStrategy(...)`

  The structural selector now receives source/target request counts and uses
  them to make better decisions for pure fan-out / fan-in shapes.

  In particular:

  - pure single-source multi-target requests can now short-circuit toward the
    source-oriented memoized path
  - pure multi-source single-target requests can now short-circuit toward the
    target-oriented memoized path

  This is a small heuristic improvement, not a new planner architecture.

  ### Benchmark: grouped mode is now real and comparisons are cleaner

  Updated:

  - `examples/benchmark/benchmark_closure_pair_planning.py`

  The closure-pair suite now:

  - exercises grouped closure-pair planning with a real 3-column grouped edge
    source
  - reports non-empty grouped result rows
  - compares `auto` against the best full-row result only
  - reports `best_effective_plan` so equivalent override labels and fallback
    labels do not distort the summary

  That makes the benchmark a much better acceptance surface for planner work.

  ### Docs

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`
  - `examples/benchmark/README.md`

  These now document:

  - the `ExpectedWidth` fix for grouped delimited ingestion
  - that the closure-pair harness now produces real grouped rows
  - that the benchmark summary reports effective pair-plan comparisons

  ## Why This Matters

  The main value here is quality of signal.

  Before this PR:

  - grouped closure-pair validation was weakened by a 3-column ingestion bug
  - override comparisons could reward strategies that returned fewer rows
  - closure-pair tuning decisions were harder to trust

  After this PR:

  - grouped closure-pair benchmarking is real
  - forced strategies are measured on full work
  - `auto` is compared against meaningful effective plans

  That makes the closure-pair planner surface much more defensible.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/benchmark_closure_pair_planning.py \
      examples/benchmark/benchmark_scan_materialization.py \
      examples/benchmark/benchmark_closure_materialization.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_category_influence_cross_target.py \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py

  ### Closure-pair suite

  Ran locally:

  python examples/benchmark/benchmark_closure_pair_planning.py \
      --scales 300,10k \
      --modes single,source_fanout,target_fanin,mixed,grouped_mixed \
      --strategies auto,forward,backward,memo-source,memo-target,mixed,mixed-cache \
      --repetitions 3

  Key outcomes:

  - grouped mode now returns rows instead of 0
  - representative auto_vs_best_effective:
      - 300 source_fanout: 1.02x
      - 10k source_fanout: 1.04x
      - 10k grouped_mixed: 1.03x

  Representative planner outcomes:

  - 300 grouped_mixed
      - auto -> MixedDirection
  - 300 source_fanout
      - auto -> MemoizedBySource
  - 300 target_fanin
      - auto -> MemoizedByTarget
  - 10k grouped_mixed
      - auto -> MixedDirection

  ### Existing focused harnesses

  Also ran locally:

  python examples/benchmark/benchmark_scan_materialization.py \
      --scales 300,10k \
      --strategies auto \
      --repetitions 1

  python examples/benchmark/benchmark_closure_materialization.py \
      --scales 300,10k \
      --repetitions 1

  ### Existing workload non-regression smokes

  Also ran locally:

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated \
      --repetitions 1

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300 \
      --targets csharp-query,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  All outputs still matched.

  Representative current non-regression results:

  - shortest path 300
      - csharp-query 0.107s
  - weighted shortest path 300
      - csharp-query 0.184s
  - effective distance 300
      - csharp-query 0.273s
  - category influence 300
      - csharp-query 0.434s
  - dependency reach-count 300
      - csharp-query 0.084s
  - dependency longest depth 300
      - csharp-query 0.069s

  ## Interpretation

  This PR is mainly a correctness-and-tuning pass for the closure-pair
  planner surface.

  The biggest practical improvement is not a brand-new strategy. It is that
  the benchmark now measures the real grouped path and compares strategies on
  equal footing.

  That makes future closure-pair planner tuning much more credible.

  ## Scope

  This PR adds:

  - generalized delimited row splitting for grouped planner inputs
  - full-request semantics for forced closure-pair strategies
  - small structural tuning for closure-pair Auto
  - more trustworthy closure-pair benchmark summaries
  - documentation updates describing the corrected benchmark surface

  It does not add:

  - a new closure-pair execution strategy
  - a new global planner layer
  - a new cross-target benchmark family