### PR TITLE
feat(wam-llvm): foreign dispatch scaffolding + indexed fact tables (M3 + M4)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -331,6 +331,7 @@ entry:
     i32 27, label %switch_on_constant_a2
     i32 28, label %begin_aggregate
     i32 29, label %end_aggregate
+    i32 30, label %call_foreign
   ]
 
 ~w
@@ -971,6 +972,18 @@ wam_llvm_case('end_aggregate',
   ; Fail to force backtrack — backtrack will check the agg frame and
   ; either re-run inner goals (if there are prior CPs) or finalize.
   ret i1 false').
+
+% call_foreign: dispatch to a native foreign kernel.
+% op1 = foreign kind ID (see wam_llvm_foreign_kind_id/2)
+% op2 = arity (for handler selection — different kernels have different
+%              register conventions)
+% Returns the result of @wam_execute_foreign_predicate. If false, the
+% run loop backtracks.
+wam_llvm_case('call_foreign',
+'  %cf.kind = trunc i64 %op1 to i32
+  %cf.arity = trunc i64 %op2 to i32
+  %cf.result = call i1 @wam_execute_foreign_predicate(%WamState* %vm, i32 %cf.kind, i32 %cf.arity)
+  ret i1 %cf.result').
 
 % ============================================================================
 % PHASE 3: Helper predicates → LLVM functions
@@ -1851,6 +1864,33 @@ agg_type_id(max, 3).
 agg_type_id(collect, 4).
 agg_type_id(bag, 5).
 agg_type_id(_, 4).  % fallback: collect
+
+% call_foreign KindName, Arity
+% Dispatches to a registered native foreign kernel. The kind name is
+% resolved via wam_llvm_foreign_kind_id/2 to a stable integer ID that
+% matches the switch cases in @wam_execute_foreign_predicate.
+wam_line_to_llvm_literal(["call_foreign", KindStr, ArityStr], Lit) :- !,
+    clean_comma(KindStr, CK), clean_comma(ArityStr, CA),
+    atom_string(KAtom, CK),
+    ( wam_llvm_foreign_kind_id(KAtom, KindId)
+    -> true
+    ;  KindId = 999  % sentinel for unknown — dispatch returns false
+    ),
+    ( number_string(Arity, CA) -> true ; Arity = 0 ),
+    format(atom(Lit), '%Instruction { i32 30, i64 ~w, i64 ~w }', [KindId, Arity]).
+
+%% wam_llvm_foreign_kind_id(+Kind, -Id)
+%  Map a foreign kernel kind name (atom) to its integer dispatch ID.
+%  The IDs must stay in sync with the switch cases in
+%  @wam_execute_foreign_predicate in state.ll.mustache.
+%  M3 establishes the IDs; M5 will fill in the actual kernel bodies.
+wam_llvm_foreign_kind_id(category_ancestor,        0).
+wam_llvm_foreign_kind_id(countdown_sum2,           1).
+wam_llvm_foreign_kind_id(list_suffix2,             2).
+wam_llvm_foreign_kind_id(transitive_closure2,      3).
+wam_llvm_foreign_kind_id(transitive_distance3,     4).
+wam_llvm_foreign_kind_id(weighted_shortest_path3,  5).
+wam_llvm_foreign_kind_id(astar_shortest_path4,     6).
 % call, execute, try_me_else, retry_me_else are handled by
 % wam_line_to_llvm_literal_resolved/3 (label resolution required).
 wam_line_to_llvm_literal(["proceed"], '%Instruction { i32 20, i64 0, i64 0 }').

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -30,7 +30,12 @@
     write_wam_llvm_project/3,            % +Predicates, +Options, +OutputFile
     write_wam_llvm_wasm_project/3,       % +Predicates, +Options, +OutputFile (WASM variant)
     build_wam_wasm_module/3,             % +LLFile, +OutputName, -Commands
-    builtin_op_to_id/2                   % +OpName, -IntId
+    builtin_op_to_id/2,                  % +OpName, -IntId
+    % Foreign dispatch (M3)
+    wam_llvm_foreign_kind_id/2,          % +Kind, -Id
+    % Indexed fact table emission (M4)
+    llvm_emit_atom_fact2_table/3,        % +TableName, +Pairs, -LLVMGlobal
+    llvm_emit_weighted_edge_table/3      % +TableName, +Triples, -LLVMGlobal
 ]).
 
 :- use_module(library(lists)).
@@ -40,6 +45,8 @@
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
 
 :- discontiguous wam_llvm_case/2.
+:- discontiguous wam_line_to_llvm_literal/2.
+:- discontiguous wam_instruction_to_llvm_literal/2.
 
 % ============================================================================
 % PHASE 5: Hybrid Module Assembly
@@ -1607,6 +1614,92 @@ render_switch_entries([entry(Tag, Pay, LabelIdx) | Rest], [Line | RestLines]) :-
         '  %SwitchEntry { i32 ~w, i64 ~w, i32 ~w }',
         [Tag, Pay, LabelIdx]),
     render_switch_entries(Rest, RestLines).
+
+%% llvm_emit_atom_fact2_table(+TableName, +Pairs, -LLVMGlobal)
+%
+%  Emit a private global constant array of %AtomFactPair entries for
+%  a list of (FromAtom, ToAtom) facts. Both atoms are interned via
+%  intern_atom/2 so the IDs stay consistent with switch_on_constant
+%  tables and kernel lookups.
+%
+%  Example:
+%      llvm_emit_atom_fact2_table('category_parent_table',
+%          [fact('Physics', 'Science'), fact('Chemistry', 'Science')],
+%          Code)
+%
+%  Produces an LLVM global definition:
+%      @category_parent_table = private constant [2 x %AtomFactPair] [
+%        %AtomFactPair { i64 1, i64 2 },
+%        %AtomFactPair { i64 3, i64 2 }
+%      ]
+%
+llvm_emit_atom_fact2_table(TableName, Pairs, Code) :-
+    maplist(render_atom_fact_pair, Pairs, Lines),
+    length(Pairs, Count),
+    (   Count == 0
+    ->  format(atom(Code),
+            '@~w = private constant [1 x %AtomFactPair] [%AtomFactPair { i64 0, i64 0 }]',
+            [TableName])
+    ;   atomic_list_concat(Lines, ',\n', EntriesStr),
+        format(atom(Code),
+'@~w = private constant [~w x %AtomFactPair] [
+~w
+]', [TableName, Count, EntriesStr])
+    ).
+
+render_atom_fact_pair(fact(From, To), Line) :-
+    intern_atom(From, FromId),
+    intern_atom(To, ToId),
+    format(atom(Line),
+        '  %AtomFactPair { i64 ~w, i64 ~w }',
+        [FromId, ToId]).
+render_atom_fact_pair(From-To, Line) :-
+    render_atom_fact_pair(fact(From, To), Line).
+
+%% llvm_emit_weighted_edge_table(+TableName, +Triples, -LLVMGlobal)
+%
+%  Emit a private global constant array of %WeightedFact entries for
+%  a list of (From, To, Weight) weighted edges. Atoms interned, weight
+%  emitted as a double (LLVM requires decimal form for fp constants).
+%
+%  Example:
+%      llvm_emit_weighted_edge_table('cat_weighted',
+%          [edge('ml', 'ai', 0.12), edge('ai', 'cs', 0.18)], Code)
+%
+llvm_emit_weighted_edge_table(TableName, Triples, Code) :-
+    maplist(render_weighted_fact, Triples, Lines),
+    length(Triples, Count),
+    (   Count == 0
+    ->  format(atom(Code),
+            '@~w = private constant [1 x %WeightedFact] [%WeightedFact { i64 0, i64 0, double 0.0 }]',
+            [TableName])
+    ;   atomic_list_concat(Lines, ',\n', EntriesStr),
+        format(atom(Code),
+'@~w = private constant [~w x %WeightedFact] [
+~w
+]', [TableName, Count, EntriesStr])
+    ).
+
+render_weighted_fact(edge(From, To, Weight), Line) :-
+    intern_atom(From, FromId),
+    intern_atom(To, ToId),
+    format_weight_literal(Weight, WeightStr),
+    format(atom(Line),
+        '  %WeightedFact { i64 ~w, i64 ~w, double ~w }',
+        [FromId, ToId, WeightStr]).
+render_weighted_fact(From-To-Weight, Line) :-
+    render_weighted_fact(edge(From, To, Weight), Line).
+
+%% format_weight_literal(+Weight, -Str)
+%  LLVM's double literal parser requires either decimal form (3.14) or
+%  hex form. An integer printed as "1" is rejected where a double is
+%  expected; we must emit "1.0". Also, "0" must become "0.0".
+format_weight_literal(W, Str) :-
+    number(W),
+    ( integer(W)
+    -> format(string(Str), '~w.0', [W])
+    ;  format(string(Str), '~w', [W])
+    ).
 
 %% wam_lines_to_llvm(+Lines, +PC, -LLVMLits, -LabelEntries)
 %  Two-pass approach: first collect all labels and raw instruction parts,

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -671,6 +671,66 @@ exit:
   ret void
 }
 
+; === Foreign Predicate Dispatch (M3 scaffolding) ===
+; Dispatches a call_foreign instruction to a native kernel.
+; In M3, every kind returns false — M5 will replace the stubs with real
+; kernel implementations (transitive_distance, weighted_shortest_path, etc).
+; When foreign_lowering is disabled (the default), the compile path emits
+; no call_foreign instructions and this function is never reached, so the
+; pure WAM behavior is preserved for testing.
+;
+; Kind IDs (keep in sync with wam_llvm_foreign_kind_id/2 in wam_llvm_target.pl):
+;   0 = category_ancestor
+;   1 = countdown_sum2
+;   2 = list_suffix2
+;   3 = transitive_closure2
+;   4 = transitive_distance3
+;   5 = weighted_shortest_path3
+;   6 = astar_shortest_path4
+define i1 @wam_execute_foreign_predicate(%WamState* %vm, i32 %kind, i32 %arity) {
+entry:
+  switch i32 %kind, label %not_registered [
+    i32 0, label %stub_category_ancestor
+    i32 1, label %stub_countdown_sum2
+    i32 2, label %stub_list_suffix2
+    i32 3, label %stub_transitive_closure2
+    i32 4, label %stub_transitive_distance3
+    i32 5, label %stub_weighted_shortest_path3
+    i32 6, label %stub_astar_shortest_path4
+  ]
+
+stub_category_ancestor:
+  ; M5: category_ancestor(Cat, Root, Hops, Visited)
+  ret i1 false
+
+stub_countdown_sum2:
+  ; M5: countdown_sum(N, Sum)
+  ret i1 false
+
+stub_list_suffix2:
+  ; M5: list_suffix(List, Suffix)
+  ret i1 false
+
+stub_transitive_closure2:
+  ; M5: transitive_closure(From, To) via indexed_atom_fact2
+  ret i1 false
+
+stub_transitive_distance3:
+  ; M5: transitive_distance(Start, End, Dist) via DFS with cycle detection
+  ret i1 false
+
+stub_weighted_shortest_path3:
+  ; M5: weighted_shortest_path(Start, End, Dist) via Dijkstra
+  ret i1 false
+
+stub_astar_shortest_path4:
+  ; M5: astar_shortest_path(Start, End, Dim, Dist) via L_D norm A*
+  ret i1 false
+
+not_registered:
+  ret i1 false
+}
+
 ; Finalize the top aggregate frame: apply aggregation, bind result reg,
 ; restore state, pop CP. Returns true on success, false if no agg frame.
 define i1 @wam_finalize_aggregate(%WamState* %vm) {

--- a/templates/targets/llvm_wam/types.ll.mustache
+++ b/templates/targets/llvm_wam/types.ll.mustache
@@ -20,6 +20,17 @@
 ; ptrtoint of the table pointer and operand2 holds the entry count.
 %SwitchEntry = type { i32, i64, i32 }     ; key_tag, key_payload, label_idx
 
+; === Indexed Fact Tables (for foreign kernels) ===
+; Used by transitive_closure, transitive_distance, and similar graph
+; kernels. Facts are emitted as global constant arrays; kernels scan
+; them via direct GEP loops. Atom values are stored as interned IDs
+; (same encoding used by switch_on_constant's atom keys).
+%AtomFactPair = type { i64, i64 }         ; from_atom_id, to_atom_id
+
+; Weighted edge fact for Dijkstra / A* / effective semantic distance.
+; Weight is an f64 semantic distance (1 - cosine_similarity).
+%WeightedFact = type { i64, i64, double } ; from, to, weight
+
 ; === Stack Entries ===
 ; Type: 0=EnvFrame, 1=UnifyCtx, 2=WriteCtx
 %StackEntry = type { i32, i64, %Value* }  ; type, aux (cp or n), data

--- a/tests/core/test_wam_llvm_fact_tables.pl
+++ b/tests/core/test_wam_llvm_fact_tables.pl
@@ -1,0 +1,147 @@
+:- encoding(utf8).
+% test_wam_llvm_fact_tables.pl
+% Verifies M4: indexed fact table emission as LLVM global constants.
+%
+% M4 provides Prolog predicates that take fact lists and emit LLVM IR
+% global constant definitions. Kernels (M5) will scan these tables via
+% direct GEP loops. This test verifies:
+%   - Atom fact pairs are interned to stable IDs
+%   - Weighted edges encode weights as LLVM double literals
+%   - Empty lists produce a valid placeholder (not a syntax error)
+%   - Full generated modules embedding these tables parse with llvm-as
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [llvm_emit_atom_fact2_table/3, llvm_emit_weighted_edge_table/3,
+     write_wam_llvm_project/3]).
+:- use_module(library(process)).
+
+% Test fixture for llvm-as validation (must be at top level).
+:- dynamic color/1.
+color(red).
+
+test_atom_fact2_emission :-
+    format('--- atom_fact2 table emission ---~n'),
+    llvm_emit_atom_fact2_table(test_cat_parent,
+        [ fact('Physics', 'Science'),
+          fact('Chemistry', 'Science'),
+          fact('Science', 'Knowledge')
+        ], Code),
+    ( sub_atom_or_string(Code, _, _, _, 'AtomFactPair')
+    -> format('  PASS: output contains %AtomFactPair references~n')
+    ;  format('  FAIL: missing %AtomFactPair~n'),
+       throw(missing_atom_fact_pair)
+    ),
+    ( sub_atom_or_string(Code, _, _, _, 'private constant [3 x %AtomFactPair]')
+    -> format('  PASS: array type matches fact count~n')
+    ;  format('  FAIL: array type mismatch~n'),
+       throw(wrong_array_type)
+    ),
+    ( sub_atom_or_string(Code, _, _, _, '@test_cat_parent')
+    -> format('  PASS: global name @test_cat_parent present~n')
+    ;  format('  FAIL: global name missing~n'),
+       throw(missing_global_name)
+    ).
+
+test_weighted_edge_emission :-
+    format('--- weighted_edge table emission ---~n'),
+    llvm_emit_weighted_edge_table(test_weights,
+        [ edge(ml, ai, 0.12),
+          edge(ai, cs, 0.18),
+          edge(cs, science, 0.30)
+        ], Code),
+    ( sub_atom_or_string(Code, _, _, _, 'WeightedFact')
+    -> format('  PASS: output contains %WeightedFact references~n')
+    ;  format('  FAIL: missing %WeightedFact~n'),
+       throw(missing_weighted_fact)
+    ),
+    ( sub_atom_or_string(Code, _, _, _, 'double 0.12')
+    -> format('  PASS: weight 0.12 encoded as double literal~n')
+    ;  format('  FAIL: weight 0.12 not found~n'),
+       throw(missing_weight)
+    ),
+    ( sub_atom_or_string(Code, _, _, _, '@test_weights')
+    -> format('  PASS: global name @test_weights present~n')
+    ;  format('  FAIL: global name missing~n')
+    ).
+
+test_integer_weight_formatting :-
+    format('--- integer weights formatted as doubles ---~n'),
+    % LLVM requires "1.0" not "1" for double literals
+    llvm_emit_weighted_edge_table(test_int_w,
+        [edge(a, b, 1), edge(c, d, 0)], Code),
+    ( sub_atom_or_string(Code, _, _, _, 'double 1.0')
+    -> format('  PASS: integer 1 emitted as 1.0~n')
+    ;  format('  FAIL: integer not formatted as double~n'),
+       throw(int_weight_bad_format)
+    ),
+    ( sub_atom_or_string(Code, _, _, _, 'double 0.0')
+    -> format('  PASS: integer 0 emitted as 0.0~n')
+    ;  format('  FAIL: zero not formatted as double~n')
+    ).
+
+test_empty_table :-
+    format('--- empty fact list produces valid placeholder ---~n'),
+    llvm_emit_atom_fact2_table(empty_test, [], Code),
+    ( sub_atom_or_string(Code, _, _, _, '[1 x %AtomFactPair]')
+    -> format('  PASS: empty list uses 1-entry placeholder~n')
+    ;  format('  FAIL: empty list produced unexpected output~n'),
+       throw(bad_empty_table)
+    ).
+
+test_llvm_as_accepts_tables :-
+    format('--- llvm-as accepts emitted tables ---~n'),
+    ( process_which('llvm-as')
+    -> test_llvm_as
+    ;  format('  SKIP: llvm-as not found on PATH~n')
+    ).
+
+test_llvm_as :-
+    llvm_emit_atom_fact2_table(demo_atoms,
+        [fact(a, b), fact(b, c), fact(c, d)], AtomCode),
+    llvm_emit_weighted_edge_table(demo_weights,
+        [edge(a, b, 0.5), edge(b, c, 1.5)], WeightCode),
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project([user:color/1], [module_name('m4_test')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out),
+        ( write(Out, '\n'), write(Out, AtomCode),
+          write(Out, '\n'), write(Out, WeightCode),
+          write(Out, '\n') ),
+        close(Out)),
+    format('  Wrote module: ~w~n', [LLPath]),
+    atom_concat(LLPath, '.bc', BCPath),
+    format(atom(Cmd), 'llvm-as ~w -o ~w 2>&1', [LLPath, BCPath]),
+    shell(Cmd, Exit),
+    ( Exit == 0
+    -> format('  PASS: llvm-as accepted module with fact tables~n')
+    ;  format('  FAIL: llvm-as exit=~w~n', [Exit])
+    ),
+    catch(delete_file(LLPath), _, true),
+    catch(delete_file(BCPath), _, true).
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _,
+        fail).
+
+sub_atom_or_string(Haystack, Before, Length, After, Needle) :-
+    ( atom(Haystack) -> sub_atom(Haystack, Before, Length, After, Needle)
+    ; string(Haystack) -> sub_string(Haystack, Before, Length, After, Needle)
+    ; atom_string(Atom, Haystack), sub_atom(Atom, Before, Length, After, Needle)
+    ).
+
+test_all :-
+    test_atom_fact2_emission,
+    test_weighted_edge_emission,
+    test_integer_weight_formatting,
+    test_empty_table,
+    catch(test_llvm_as_accepts_tables, E,
+        format('  ERROR in llvm-as test: ~w~n', [E])).
+
+:- initialization(test_all, main).

--- a/tests/core/test_wam_llvm_foreign_dispatch.pl
+++ b/tests/core/test_wam_llvm_foreign_dispatch.pl
@@ -1,0 +1,141 @@
+:- encoding(utf8).
+% test_wam_llvm_foreign_dispatch.pl
+% Verifies the M3 foreign dispatch scaffolding:
+%  - call_foreign text parser produces a valid %Instruction literal
+%  - Tag 30 appears in generated LLVM IR
+%  - @wam_execute_foreign_predicate helper is emitted
+%  - llvm-as accepts the complete module
+%
+% This PR only adds the dispatch infrastructure — no actual kernels are
+% registered yet. M5 will replace the stubs in @wam_execute_foreign_predicate.
+%
+% The pure-WAM path (foreign_lowering off by default) is preserved: no
+% call_foreign instructions are emitted unless the user explicitly opts in.
+
+:- use_module('../../src/unifyweaver/targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [compile_wam_predicate_to_llvm/4, write_wam_llvm_project/3, wam_llvm_foreign_kind_id/2]).
+:- use_module(library(process)).
+
+% --- Test 1: pure WAM path emits no call_foreign (default behavior) ---
+:- dynamic simple_fact/1.
+simple_fact(a).
+simple_fact(b).
+simple_fact(c).
+
+test_pure_wam_no_foreign :-
+    format('--- pure WAM path emits no call_foreign ---~n'),
+    compile_predicate_to_wam(user:simple_fact/1, [], WamCode),
+    compile_wam_predicate_to_llvm(simple_fact/1, WamCode, [], LLVMCode),
+    ( sub_atom_or_string(LLVMCode, _, _, _, 'i32 30')
+    -> format('  FAIL: pure WAM path emitted call_foreign (tag 30)~n'),
+       throw(unexpected_call_foreign)
+    ;  format('  PASS: no call_foreign in pure WAM output~n')
+    ).
+
+% --- Test 2: hand-crafted WAM text with call_foreign parses correctly ---
+test_call_foreign_parses :-
+    format('--- call_foreign text parser ---~n'),
+    % Hand-craft a minimal WAM text that uses call_foreign.
+    % This is what the M5 compile path will emit for foreign predicates.
+    atom_string(FakeWam,
+'fake_pred/3:
+    call_foreign transitive_distance3, 3
+    proceed'),
+    compile_wam_predicate_to_llvm(fake_pred/3, FakeWam, [], LLVMCode),
+    ( sub_atom_or_string(LLVMCode, _, _, _, 'i32 30')
+    -> format('  PASS: LLVM output contains tag 30 (call_foreign)~n')
+    ;  format('  FAIL: LLVM output missing tag 30~n'),
+       throw(missing_call_foreign_tag)
+    ),
+    % transitive_distance3 has kind ID 4
+    ( sub_atom_or_string(LLVMCode, _, _, _, 'i32 30, i64 4')
+    -> format('  PASS: call_foreign encodes transitive_distance3 kind ID = 4~n')
+    ;  format('  FAIL: kind ID not encoded correctly~n'),
+       throw(wrong_kind_id)
+    ).
+
+% --- Test 3: kind ID registry is consistent ---
+test_kind_registry :-
+    format('--- foreign kind ID registry ---~n'),
+    ExpectedKinds = [
+        category_ancestor-0,
+        countdown_sum2-1,
+        list_suffix2-2,
+        transitive_closure2-3,
+        transitive_distance3-4,
+        weighted_shortest_path3-5,
+        astar_shortest_path4-6
+    ],
+    forall(member(Kind-ExpectedId, ExpectedKinds),
+        ( wam_llvm_foreign_kind_id(Kind, ActualId),
+          ( ActualId == ExpectedId
+          -> format('  PASS: ~w -> ~w~n', [Kind, ActualId])
+          ;  format('  FAIL: ~w expected ~w got ~w~n', [Kind, ExpectedId, ActualId]),
+             throw(wrong_kind_id(Kind, ExpectedId, ActualId))
+          )
+        )).
+
+% --- Test 4: full module with call_foreign validates via llvm-as ---
+test_full_module_validates :-
+    format('--- Full module with call_foreign validates with llvm-as ---~n'),
+    ( process_which('llvm-as')
+    -> test_llvm_as_with_foreign
+    ;  format('  SKIP: llvm-as not found on PATH~n')
+    ).
+
+test_llvm_as_with_foreign :-
+    % Hand-craft a complete predicate module containing call_foreign.
+    % We bypass the compile_predicate_to_wam path since M3 doesn't yet
+    % have the foreign pattern matcher wired in.
+    atom_string(FakeWam,
+'demo_fp/3:
+    call_foreign weighted_shortest_path3, 3
+    proceed'),
+    compile_wam_predicate_to_llvm(demo_fp/3, FakeWam, [], PredCode),
+    format('  Predicate compiles to ~w chars of LLVM~n', [PredCode]),
+    % Build a minimal complete module that includes this predicate
+    % alongside a second pure-WAM predicate for good measure.
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project([user:simple_fact/1], [module_name('m3_test')], LLPath),
+    % Append our hand-crafted foreign predicate
+    setup_call_cleanup(
+        open(LLPath, append, Out),
+        write(Out, PredCode),
+        close(Out)),
+    format('  Wrote: ~w~n', [LLPath]),
+    atom_concat(LLPath, '.bc', BCPath),
+    format(atom(Cmd), 'llvm-as ~w -o ~w 2>&1', [LLPath, BCPath]),
+    shell(Cmd, Exit),
+    ( Exit == 0
+    -> format('  PASS: llvm-as accepted the module with call_foreign~n')
+    ;  format('  FAIL: llvm-as exit=~w~n', [Exit])
+    ),
+    catch(delete_file(LLPath), _, true),
+    catch(delete_file(BCPath), _, true).
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _,
+        fail).
+
+sub_atom_or_string(Haystack, Before, Length, After, Needle) :-
+    ( atom(Haystack) -> sub_atom(Haystack, Before, Length, After, Needle)
+    ; string(Haystack) -> sub_string(Haystack, Before, Length, After, Needle)
+    ; atom_string(Atom, Haystack), sub_atom(Atom, Before, Length, After, Needle)
+    ).
+
+test_all :-
+    test_pure_wam_no_foreign,
+    test_call_foreign_parses,
+    test_kind_registry,
+    catch(test_full_module_validates, E,
+        format('  ERROR in llvm-as test: ~w~n', [E])).
+
+:- initialization(test_all, main).


### PR DESCRIPTION
## Summary

Milestones 3 and 4 of the hybrid WAM LLVM port. This PR adds the FFI dispatch infrastructure and the constant-table emission helpers needed for the native foreign kernels (Dijkstra, A*, transitive distance, etc.) that will land in M5.

Both milestones are scaffolding only — neither is wired into the default compile path, so the existing pure-WAM behavior is unchanged. M5 will register the kernel handlers and the fact tables together when it ports the algorithms from the Rust reference.

- **M3** — `call_foreign` instruction, kind ID registry, runtime dispatch helper with stub cases.
- **M4** — Prolog helpers that emit `%AtomFactPair` and `%WeightedFact` global constant arrays from Prolog fact lists.

## Background

The hybrid WAM design lets recursive graph kernels like `weighted_shortest_path/3`, `astar_shortest_path/4`, and `transitive_distance/3` run as native code called from inside WAM execution via FFI, rather than being interpreted instruction-by-instruction. The Rust target already does this; this PR begins porting that infrastructure to the LLVM target.

The work is being done in five milestones:

| Milestone | Status | Scope |
|---|---|---|
| M1 | merged (#1298) | `switch_on_constant` + latent IR fixes |
| M2 | merged (#1301) | aggregate frames (`begin_aggregate`/`end_aggregate`) |
| **M3** | **this PR** | foreign dispatch scaffolding (`call_foreign`) |
| **M4** | **this PR** | indexed fact table emission |
| M5 | upcoming | actual kernel implementations |

## M3: Foreign Predicate Dispatch

### Instruction

A new instruction at tag 30, `call_foreign`:
- `op1` = foreign kind ID (looked up via `wam_llvm_foreign_kind_id/2`)
- `op2` = arity (kernels with different arities use different register conventions)

The dispatch case calls `@wam_execute_foreign_predicate(%vm, kind, arity)` and returns its result directly. Backtracking happens via the run loop's `false` handling — kernels that need to emit multiple solutions will use the choice-point mechanism in M5.

### Kind ID Registry

`wam_llvm_foreign_kind_id/2` maps kernel names to stable integer IDs:

| ID | Kind |
|---|---|
| 0 | `category_ancestor` |
| 1 | `countdown_sum2` |
| 2 | `list_suffix2` |
| 3 | `transitive_closure2` |
| 4 | `transitive_distance3` |
| 5 | `weighted_shortest_path3` |
| 6 | `astar_shortest_path4` |

The IDs match the cases in `@wam_execute_foreign_predicate` so the Prolog generator and the LLVM runtime stay in sync.

### Runtime Helper

`@wam_execute_foreign_predicate(%WamState*, i32 kind, i32 arity)` is a `switch i32 %kind` with one stub case per registered kind. Every stub returns `false` for now; M5 will replace each one with a real handler that reads register values, runs the algorithm, and packs results back via `@wam_set_reg`.

### Pure WAM Path Preserved

`foreign_lowering` is opt-in and not yet wired into the compile pipeline. By default no `call_foreign` instructions are emitted and the existing WAM code path runs unchanged — every existing test still validates against the pure-WAM behavior.

## M4: Indexed Fact Tables

### Types

Two new LLVM types in `types.ll.mustache`:

```llvm
%AtomFactPair = type { i64, i64 }         ; from_atom_id, to_atom_id
%WeightedFact = type { i64, i64, double } ; from, to, weight
```

Atom IDs share the `intern_atom/2` numbering used by `switch_on_constant` tables, so kernels can mix interned-atom keys across both data structures with no conversion.

### Emission Helpers

Two new exported predicates in `wam_llvm_target.pl`:

- `llvm_emit_atom_fact2_table(+TableName, +Pairs, -LLVMGlobal)` — accepts `fact(From, To)` or `From-To` terms.
- `llvm_emit_weighted_edge_table(+TableName, +Triples, -LLVMGlobal)` — accepts `edge(From, To, Weight)` or `From-To-Weight` terms.

Both produce `private constant [N x T]` global arrays. Edge cases handled:

- **Empty lists** — emit a 1-entry placeholder rather than `[0 x T]` (LLVM rejects zero-length constant arrays in some contexts).
- **Integer weights** — `format_weight_literal/2` ensures `1` becomes `"1.0"` and `0` becomes `"0.0"`. LLVM's double literal parser rejects bare integers where a `double` is expected.

### Not Yet Wired

The helpers are exported but not yet called by the compile pipeline. M5 will use them when registering each kernel's data alongside its handler.

## Test Coverage

| Suite | Assertions |
|---|---|
| `test_wam_llvm_switch.pl` (M1) | 7 |
| `test_wam_llvm_aggregate.pl` (M2) | 5 |
| `test_wam_llvm_foreign_dispatch.pl` (M3) | 11 |
| `test_wam_llvm_fact_tables.pl` (M4) | 11 |
| **Total** | **34** |

### M3 Tests (`test_wam_llvm_foreign_dispatch.pl`)

1. **Pure WAM path emits no `call_foreign`** — confirms the default compile flow is unchanged when `foreign_lowering` is off.
2. **Hand-crafted WAM text → IR** — verifies `"call_foreign transitive_distance3, 3"` produces `%Instruction { i32 30, i64 4, i64 3 }` with the expected kind ID.
3. **Kind registry consistency** — every entry in `wam_llvm_foreign_kind_id/2` matches its expected integer ID.
4. **End-to-end `llvm-as` validation** — a complete module containing a `call_foreign` instruction parses cleanly through `llvm-as`.

### M4 Tests (`test_wam_llvm_fact_tables.pl`)

1. **`atom_fact2` emission** — checks `%AtomFactPair` references, array type matches fact count, global name present.
2. **`weighted_edge` emission** — checks `%WeightedFact` references, weight `0.12` encoded as a double literal, global name present.
3. **Integer weight formatting** — `1` → `"1.0"`, `0` → `"0.0"`.
4. **Empty list placeholder** — `[1 x %AtomFactPair]` instead of `[0 x ...]`.
5. **End-to-end `llvm-as` validation** — a complete module with both an `%AtomFactPair` table and a `%WeightedFact` table appended parses cleanly.

## Files Changed

- `src/unifyweaver/targets/wam_llvm_target.pl` — `call_foreign` dispatch case + text parser, kind ID registry, `llvm_emit_atom_fact2_table/3`, `llvm_emit_weighted_edge_table/3`.
- `templates/targets/llvm_wam/types.ll.mustache` — `%AtomFactPair`, `%WeightedFact`.
- `templates/targets/llvm_wam/state.ll.mustache` — `@wam_execute_foreign_predicate` runtime helper with stub cases.
- `tests/core/test_wam_llvm_foreign_dispatch.pl` — M3 test suite (new).
- `tests/core/test_wam_llvm_fact_tables.pl` — M4 test suite (new).

## What's Next: M5

M5 will port the actual kernels from the Rust reference implementation, one at a time:

1. `transitive_distance3` — simplest, exercises the dispatch + atom fact table integration.
2. `weighted_shortest_path3` — Dijkstra with `BinaryHeap` priority queue.
3. `astar_shortest_path4` — A* with admissible heuristic.

Each kernel will:
- Replace its `false` stub in `@wam_execute_foreign_predicate` with a real handler.
- Register its fact table via the M4 emission helpers.
- Read inputs from WAM registers via the FFI bridge helpers.
- Pack outputs back into WAM registers and return `true`/`false`.

M5 will also wire `foreign_lowering` into the compile pipeline so that user-declared foreign predicates emit `call_foreign` instructions instead of going through the WAM fallback.

## Test Plan

- [x] M1 regression: `swipl -q tests/core/test_wam_llvm_switch.pl`
- [x] M2 regression: `swipl -q tests/core/test_wam_llvm_aggregate.pl`
- [x] M3: `swipl -q tests/core/test_wam_llvm_foreign_dispatch.pl`
- [x] M4: `swipl -q tests/core/test_wam_llvm_fact_tables.pl`
- [x] End-to-end `llvm-as` validation in both M3 and M4 test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)
