### PR TITLE
feat(wam-llvm): native kernel helpers — FFI bridge + BFS + Dijkstra (M5.1–M5.3)

### DIFF
--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -761,6 +761,159 @@ exit:
 ;   4 = transitive_distance3
 ;   5 = weighted_shortest_path3
 ;   6 = astar_shortest_path4
+; === M5.2: BFS over an %AtomFactPair table ===
+; Computes the shortest path length (in edges) from %start to %target in
+; the directed graph described by an array of (from, to) atom ID pairs.
+;
+; On success, writes the distance to *%out_dist and returns true.
+; On failure (target unreachable, or start == target handled specially):
+;   - If %start == %target, writes 0 and returns true.
+;   - Otherwise returns false and does not touch *%out_dist.
+;
+; The caller must supply %max_atom_id — the largest atom ID that could
+; appear in either %start, %target, or any row of %table. This bounds
+; the visited / queue arrays. A safe upper bound is (2 * %len + 1) since
+; the table has at most 2*%len distinct atom IDs, but a tighter bound
+; improves cache behavior.
+;
+; Allocates three scratch buffers via malloc (visited, queue, dqueue),
+; all freed before return via a shared cleanup block.
+define i1 @wam_bfs_atom_distance(
+    i64 %start, i64 %target,
+    %AtomFactPair* %table, i64 %len,
+    i64 %max_atom_id,
+    i64* %out_dist) {
+entry:
+  ; Edge case: start == target → distance 0, success, no allocation needed.
+  %is_self = icmp eq i64 %start, %target
+  br i1 %is_self, label %self_hit, label %alloc
+
+self_hit:
+  store i64 0, i64* %out_dist
+  ret i1 true
+
+alloc:
+  ; Size = (max_atom_id + 1) entries.
+  %n = add i64 %max_atom_id, 1
+  %vis_bytes = shl i64 %n, 2     ; n * 4
+  %q_bytes   = shl i64 %n, 3     ; n * 8
+  %dq_bytes  = shl i64 %n, 2     ; n * 4
+
+  %vis_mem = call i8* @malloc(i64 %vis_bytes)
+  %q_mem   = call i8* @malloc(i64 %q_bytes)
+  %dq_mem  = call i8* @malloc(i64 %dq_bytes)
+
+  %visited = bitcast i8* %vis_mem to i32*
+  %queue   = bitcast i8* %q_mem  to i64*
+  %dqueue  = bitcast i8* %dq_mem to i32*
+
+  ; Zero-init visited[].
+  br label %vis_init
+
+vis_init:
+  %vi = phi i64 [0, %alloc], [%vi_next, %vis_init_body]
+  %vi_cmp = icmp ult i64 %vi, %n
+  br i1 %vi_cmp, label %vis_init_body, label %seed
+
+vis_init_body:
+  %vi_slot = getelementptr i32, i32* %visited, i64 %vi
+  store i32 0, i32* %vi_slot
+  %vi_next = add i64 %vi, 1
+  br label %vis_init
+
+seed:
+  ; Mark start as visited and push onto queue with depth 0.
+  %vis_start = getelementptr i32, i32* %visited, i64 %start
+  store i32 1, i32* %vis_start
+  %q0 = getelementptr i64, i64* %queue, i64 0
+  store i64 %start, i64* %q0
+  %dq0 = getelementptr i32, i32* %dqueue, i64 0
+  store i32 0, i32* %dq0
+  br label %loop
+
+loop:
+  %head = phi i64 [0, %seed], [%head_next, %loop_back]
+  %tail = phi i64 [1, %seed], [%tail_cur, %loop_back]
+  %more = icmp ult i64 %head, %tail
+  br i1 %more, label %pop, label %fail_free
+
+pop:
+  %q_slot = getelementptr i64, i64* %queue, i64 %head
+  %node = load i64, i64* %q_slot
+  %dq_slot = getelementptr i32, i32* %dqueue, i64 %head
+  %depth = load i32, i32* %dq_slot
+  %head_next = add i64 %head, 1
+  br label %scan
+
+scan:
+  %si = phi i64 [0, %pop], [%si_next, %scan_cont]
+  %tail_cur = phi i64 [%tail, %pop], [%tail_kept, %scan_cont]
+  %scan_cmp = icmp ult i64 %si, %len
+  br i1 %scan_cmp, label %scan_body, label %loop_back
+
+scan_body:
+  %pair_ptr = getelementptr %AtomFactPair, %AtomFactPair* %table, i64 %si
+  %from_ptr = getelementptr %AtomFactPair, %AtomFactPair* %pair_ptr, i32 0, i32 0
+  %to_ptr   = getelementptr %AtomFactPair, %AtomFactPair* %pair_ptr, i32 0, i32 1
+  %from = load i64, i64* %from_ptr
+  %to   = load i64, i64* %to_ptr
+
+  ; Skip rows whose from != current node.
+  %from_match = icmp eq i64 %from, %node
+  br i1 %from_match, label %check_to, label %scan_cont
+
+check_to:
+  ; Safety: skip if to > max_atom_id.
+  %to_in_range = icmp ule i64 %to, %max_atom_id
+  br i1 %to_in_range, label %check_visited, label %scan_cont
+
+check_visited:
+  %vis_to_ptr = getelementptr i32, i32* %visited, i64 %to
+  %vis_to = load i32, i32* %vis_to_ptr
+  %is_unseen = icmp eq i32 %vis_to, 0
+  br i1 %is_unseen, label %visit, label %scan_cont
+
+visit:
+  store i32 1, i32* %vis_to_ptr
+  %new_depth = add i32 %depth, 1
+  %is_target = icmp eq i64 %to, %target
+  br i1 %is_target, label %hit, label %enqueue
+
+hit:
+  %new_depth_64 = sext i32 %new_depth to i64
+  store i64 %new_depth_64, i64* %out_dist
+  br label %free_buffers_ok
+
+enqueue:
+  %q_push = getelementptr i64, i64* %queue, i64 %tail_cur
+  store i64 %to, i64* %q_push
+  %dq_push = getelementptr i32, i32* %dqueue, i64 %tail_cur
+  store i32 %new_depth, i32* %dq_push
+  %tail_after_push = add i64 %tail_cur, 1
+  br label %scan_cont
+
+scan_cont:
+  ; Merge tail across all paths: unchanged on skip, +1 on enqueue.
+  %tail_kept = phi i64 [%tail_cur, %scan_body], [%tail_cur, %check_to], [%tail_cur, %check_visited], [%tail_after_push, %enqueue]
+  %si_next = add i64 %si, 1
+  br label %scan
+
+loop_back:
+  br label %loop
+
+free_buffers_ok:
+  call void @free(i8* %vis_mem)
+  call void @free(i8* %q_mem)
+  call void @free(i8* %dq_mem)
+  ret i1 true
+
+fail_free:
+  call void @free(i8* %vis_mem)
+  call void @free(i8* %q_mem)
+  call void @free(i8* %dq_mem)
+  ret i1 false
+}
+
 define i1 @wam_execute_foreign_predicate(%WamState* %vm, i32 %kind, i32 %arity) {
 entry:
   switch i32 %kind, label %not_registered [

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -914,6 +914,177 @@ fail_free:
   ret i1 false
 }
 
+; === M5.3: Dijkstra over a %WeightedFact table ===
+; Computes the minimum-weight path distance from %start to %target in
+; a directed graph of (from, to, weight) triples. All weights must be
+; non-negative — negative edges produce undefined output (Dijkstra
+; doesn't handle them).
+;
+; On success, writes the distance (as a double) to *%out_dist and
+; returns true. On failure (target unreachable), returns false without
+; touching *%out_dist.
+;
+; Uses linear-scan extract-min over a %best[] array sized by
+; (%max_atom_id + 1). This is O(V²) but avoids heap data structures.
+; For small graphs (typical semantic-distance inputs) this is fine;
+; for larger graphs a binary heap can replace the inner min-scan
+; without touching the public signature.
+;
+; "Infinity" is encoded as 0x7FF0000000000000 (IEEE 754 +inf) — this
+; doubles as the "unreachable" sentinel, so a failing BFS falls out
+; naturally by comparing best[target] against +inf.
+define i1 @wam_dijkstra_weighted_distance(
+    i64 %start, i64 %target,
+    %WeightedFact* %table, i64 %len,
+    i64 %max_atom_id,
+    double* %out_dist) {
+entry:
+  %is_self = icmp eq i64 %start, %target
+  br i1 %is_self, label %self_hit, label %alloc
+
+self_hit:
+  store double 0.0, double* %out_dist
+  ret i1 true
+
+alloc:
+  %n = add i64 %max_atom_id, 1
+  %best_bytes = shl i64 %n, 3   ; n * 8 (double)
+  %vis_bytes  = shl i64 %n, 2   ; n * 4 (i32)
+
+  %best_mem = call i8* @malloc(i64 %best_bytes)
+  %vis_mem  = call i8* @malloc(i64 %vis_bytes)
+
+  %best = bitcast i8* %best_mem to double*
+  %visited = bitcast i8* %vis_mem to i32*
+
+  br label %init
+
+init:
+  %ii = phi i64 [0, %alloc], [%ii_next, %init_body]
+  %ii_cmp = icmp ult i64 %ii, %n
+  br i1 %ii_cmp, label %init_body, label %seed
+
+init_body:
+  %best_slot = getelementptr double, double* %best, i64 %ii
+  store double 0x7FF0000000000000, double* %best_slot
+  %vis_slot = getelementptr i32, i32* %visited, i64 %ii
+  store i32 0, i32* %vis_slot
+  %ii_next = add i64 %ii, 1
+  br label %init
+
+seed:
+  ; best[start] = 0.0
+  %best_start = getelementptr double, double* %best, i64 %start
+  store double 0.0, double* %best_start
+  br label %outer
+
+outer:
+  ; Extract min: linear scan over unvisited nodes.
+  br label %min_scan
+
+min_scan:
+  %mi = phi i64 [0, %outer], [%mi_next, %min_next]
+  %cur_min_node = phi i64 [-1, %outer], [%upd_node, %min_next]
+  %cur_min_val  = phi double [0x7FF0000000000000, %outer], [%upd_val, %min_next]
+  %mi_cmp = icmp ult i64 %mi, %n
+  br i1 %mi_cmp, label %min_body, label %min_done
+
+min_body:
+  %vis_mi_ptr = getelementptr i32, i32* %visited, i64 %mi
+  %vis_mi = load i32, i32* %vis_mi_ptr
+  %is_unvisited = icmp eq i32 %vis_mi, 0
+  br i1 %is_unvisited, label %min_check_val, label %min_next_noupd
+
+min_check_val:
+  %best_mi_ptr = getelementptr double, double* %best, i64 %mi
+  %best_mi = load double, double* %best_mi_ptr
+  %better = fcmp olt double %best_mi, %cur_min_val
+  br i1 %better, label %min_update, label %min_next_noupd
+
+min_update:
+  br label %min_next
+
+min_next_noupd:
+  br label %min_next
+
+min_next:
+  %upd_node = phi i64 [%mi, %min_update], [%cur_min_node, %min_next_noupd]
+  %upd_val  = phi double [%best_mi, %min_update], [%cur_min_val, %min_next_noupd]
+  %mi_next = add i64 %mi, 1
+  br label %min_scan
+
+min_done:
+  ; No unvisited node found, or all remaining have +inf distance.
+  %no_node = icmp eq i64 %cur_min_node, -1
+  br i1 %no_node, label %fail_free, label %check_inf
+
+check_inf:
+  %is_inf = fcmp oeq double %cur_min_val, 0x7FF0000000000000
+  br i1 %is_inf, label %fail_free, label %pick
+
+pick:
+  ; Mark the selected node visited.
+  %pick_vis_ptr = getelementptr i32, i32* %visited, i64 %cur_min_node
+  store i32 1, i32* %pick_vis_ptr
+
+  ; If it's the target, we're done.
+  %is_target = icmp eq i64 %cur_min_node, %target
+  br i1 %is_target, label %hit, label %relax
+
+hit:
+  store double %cur_min_val, double* %out_dist
+  br label %free_ok
+
+relax:
+  br label %relax_scan
+
+relax_scan:
+  %ri = phi i64 [0, %relax], [%ri_next, %relax_cont]
+  %ri_cmp = icmp ult i64 %ri, %len
+  br i1 %ri_cmp, label %relax_body, label %outer
+
+relax_body:
+  %fp_ptr = getelementptr %WeightedFact, %WeightedFact* %table, i64 %ri
+  %fp_from = getelementptr %WeightedFact, %WeightedFact* %fp_ptr, i32 0, i32 0
+  %fp_to   = getelementptr %WeightedFact, %WeightedFact* %fp_ptr, i32 0, i32 1
+  %fp_w    = getelementptr %WeightedFact, %WeightedFact* %fp_ptr, i32 0, i32 2
+  %edge_from = load i64, i64* %fp_from
+  %edge_to   = load i64, i64* %fp_to
+  %edge_w    = load double, double* %fp_w
+
+  %from_match = icmp eq i64 %edge_from, %cur_min_node
+  br i1 %from_match, label %check_to_range, label %relax_cont
+
+check_to_range:
+  %to_ok = icmp ule i64 %edge_to, %max_atom_id
+  br i1 %to_ok, label %do_relax, label %relax_cont
+
+do_relax:
+  %alt = fadd double %cur_min_val, %edge_w
+  %best_to_ptr = getelementptr double, double* %best, i64 %edge_to
+  %best_to = load double, double* %best_to_ptr
+  %improved = fcmp olt double %alt, %best_to
+  br i1 %improved, label %store_new, label %relax_cont
+
+store_new:
+  store double %alt, double* %best_to_ptr
+  br label %relax_cont
+
+relax_cont:
+  %ri_next = add i64 %ri, 1
+  br label %relax_scan
+
+free_ok:
+  call void @free(i8* %best_mem)
+  call void @free(i8* %vis_mem)
+  ret i1 true
+
+fail_free:
+  call void @free(i8* %best_mem)
+  call void @free(i8* %vis_mem)
+  ret i1 false
+}
+
 define i1 @wam_execute_foreign_predicate(%WamState* %vm, i32 %kind, i32 %arity) {
 entry:
   switch i32 %kind, label %not_registered [

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -106,6 +106,80 @@ define void @wam_set_reg(%WamState* %vm, i32 %idx, %Value %val) {
   ret void
 }
 
+; === FFI Bridge Helpers (for M5 native kernels) ===
+; Kernels called via @wam_execute_foreign_predicate use these to read and
+; write WAM registers without constructing %Value structs inline. All
+; helpers take a register index in the 0..31 range (A1..A16 → 0..15,
+; X1..X16 → 16..31).
+;
+; Value tag encoding (from types.ll.mustache):
+;   0 = Atom     (payload = interned atom id)
+;   1 = Integer  (payload = signed int as i64)
+;   2 = Float    (payload = double bitcast to i64)
+;   3 = Compound
+;   4 = List
+;   5 = Ref
+;   6 = Unbound
+;   7 = Bool     (payload = 0 or 1)
+
+; Get the tag of a register value.
+define i32 @wam_get_reg_tag(%WamState* %vm, i32 %idx) {
+  %reg_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 %idx
+  %tag_ptr = getelementptr %Value, %Value* %reg_ptr, i32 0, i32 0
+  %tag = load i32, i32* %tag_ptr
+  ret i32 %tag
+}
+
+; Get the raw i64 payload of a register value. Caller is responsible for
+; knowing the tag (use wam_get_reg_tag first if the type is not known).
+define i64 @wam_get_reg_payload(%WamState* %vm, i32 %idx) {
+  %reg_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 %idx
+  %pay_ptr = getelementptr %Value, %Value* %reg_ptr, i32 0, i32 1
+  %pay = load i64, i64* %pay_ptr
+  ret i64 %pay
+}
+
+; Get a register payload as a double. Tag must be 2 (Float) — the caller
+; is responsible for checking. Performs an i64 → double bitcast.
+define double @wam_get_reg_double(%WamState* %vm, i32 %idx) {
+  %reg_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 %idx
+  %pay_ptr = getelementptr %Value, %Value* %reg_ptr, i32 0, i32 1
+  %pay = load i64, i64* %pay_ptr
+  %d = bitcast i64 %pay to double
+  ret double %d
+}
+
+; Set a register to an Atom value with the given interned atom ID.
+define void @wam_set_reg_atom_id(%WamState* %vm, i32 %idx, i64 %atom_id) {
+  %reg_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 %idx
+  %tag_ptr = getelementptr %Value, %Value* %reg_ptr, i32 0, i32 0
+  %pay_ptr = getelementptr %Value, %Value* %reg_ptr, i32 0, i32 1
+  store i32 0, i32* %tag_ptr
+  store i64 %atom_id, i64* %pay_ptr
+  ret void
+}
+
+; Set a register to an Integer value.
+define void @wam_set_reg_int(%WamState* %vm, i32 %idx, i64 %n) {
+  %reg_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 %idx
+  %tag_ptr = getelementptr %Value, %Value* %reg_ptr, i32 0, i32 0
+  %pay_ptr = getelementptr %Value, %Value* %reg_ptr, i32 0, i32 1
+  store i32 1, i32* %tag_ptr
+  store i64 %n, i64* %pay_ptr
+  ret void
+}
+
+; Set a register to a Float value. Performs a double → i64 bitcast.
+define void @wam_set_reg_double(%WamState* %vm, i32 %idx, double %d) {
+  %reg_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 %idx
+  %tag_ptr = getelementptr %Value, %Value* %reg_ptr, i32 0, i32 0
+  %pay_ptr = getelementptr %Value, %Value* %reg_ptr, i32 0, i32 1
+  %pay = bitcast double %d to i64
+  store i32 2, i32* %tag_ptr
+  store i64 %pay, i64* %pay_ptr
+  ret void
+}
+
 ; Increment PC
 define void @wam_inc_pc(%WamState* %vm) {
   %pc_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 0

--- a/tests/core/test_wam_llvm_bfs_atom.pl
+++ b/tests/core/test_wam_llvm_bfs_atom.pl
@@ -1,0 +1,115 @@
+:- encoding(utf8).
+% test_wam_llvm_bfs_atom.pl
+% Verifies M5.2: @wam_bfs_atom_distance helper (shortest-path length over
+% a %AtomFactPair table).
+%
+% This is the computational core of transitive_distance3. It's a
+% standalone helper so it can be tested without the full foreign-dispatch
+% protocol wiring (which lands in M5.5).
+%
+% Checks:
+%   - The helper is defined in the generated module.
+%   - A module that appends a concrete %AtomFactPair fact table and a
+%     demo caller invoking @wam_bfs_atom_distance parses cleanly with
+%     llvm-as and llc (IR → object codegen), which exercises the phi
+%     wiring and block structure end-to-end.
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3,
+     llvm_emit_atom_fact2_table/3]).
+:- use_module(library(process)).
+
+:- dynamic color/1.
+color(red).
+
+test_helper_defined :-
+    format('--- @wam_bfs_atom_distance defined in template ---~n'),
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project([user:color/1], [module_name('bfs_test')], LLPath),
+    read_file_to_string(LLPath, Src, []),
+    ( sub_string(Src, _, _, _, 'define i1 @wam_bfs_atom_distance')
+    -> format('  PASS: helper definition present~n')
+    ;  format('  FAIL: helper missing~n'),
+       throw(helper_missing)
+    ),
+    catch(delete_file(LLPath), _, true).
+
+test_bfs_module_validates :-
+    format('--- llvm-as accepts module with bfs caller ---~n'),
+    ( process_which('llvm-as')
+    -> test_bfs_llvm_as
+    ;  format('  SKIP: llvm-as not found on PATH~n')
+    ).
+
+test_bfs_llvm_as :-
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project([user:color/1], [module_name('bfs_test')], LLPath),
+    % Build a 4-node graph: a -> b -> c -> d, with a side branch a -> e.
+    llvm_emit_atom_fact2_table(bfs_demo_graph,
+        [ fact(a, b),
+          fact(b, c),
+          fact(c, d),
+          fact(a, e)
+        ], TableCode),
+    % Demo caller: invokes BFS from atom id 1 (a) to atom id 4 (d).
+    % Atom IDs come from intern_atom/2 which starts at 1 and assigns in
+    % order of first use — in practice the test only validates that the
+    % IR compiles, not the numeric result, since interned IDs depend on
+    % load order. An end-to-end execution test would require lli or jit.
+    CallerIR = '
+define i1 @bfs_demo_caller(i64 %start_id, i64 %target_id, i64* %out) {
+entry:
+  %table_ptr = getelementptr [4 x %AtomFactPair], [4 x %AtomFactPair]* @bfs_demo_graph, i64 0, i64 0
+  %ok = call i1 @wam_bfs_atom_distance(
+      i64 %start_id, i64 %target_id,
+      %AtomFactPair* %table_ptr, i64 4,
+      i64 32,
+      i64* %out)
+  ret i1 %ok
+}
+',
+    setup_call_cleanup(
+        open(LLPath, append, Out),
+        ( write(Out, '\n'), write(Out, TableCode),
+          write(Out, '\n'), write(Out, CallerIR),
+          write(Out, '\n') ),
+        close(Out)),
+    format('  Wrote module: ~w~n', [LLPath]),
+    atom_concat(LLPath, '.bc', BCPath),
+    format(atom(Cmd), 'llvm-as ~w -o ~w 2>&1', [LLPath, BCPath]),
+    shell(Cmd, Exit),
+    ( Exit == 0
+    -> format('  PASS: llvm-as accepted module with bfs caller~n')
+    ;  format('  FAIL: llvm-as exit=~w~n', [Exit])
+    ),
+    % Also verify the IR passes LLVM's verifier pass (stricter than parse).
+    ( process_which('opt')
+    -> format(atom(VCmd),
+        'opt -passes=verify -disable-output ~w 2>&1', [BCPath]),
+       shell(VCmd, VExit),
+       ( VExit == 0
+       -> format('  PASS: opt -passes=verify accepted bitcode~n')
+       ;  format('  FAIL: opt -passes=verify exit=~w~n', [VExit])
+       )
+    ;  format('  SKIP: opt not found on PATH~n')
+    ),
+    catch(delete_file(LLPath), _, true),
+    catch(delete_file(BCPath), _, true).
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _,
+        fail).
+
+test_all :-
+    test_helper_defined,
+    catch(test_bfs_module_validates, E,
+        format('  ERROR in llvm-as test: ~w~n', [E])).
+
+:- initialization(test_all, main).

--- a/tests/core/test_wam_llvm_dijkstra.pl
+++ b/tests/core/test_wam_llvm_dijkstra.pl
@@ -1,0 +1,110 @@
+:- encoding(utf8).
+% test_wam_llvm_dijkstra.pl
+% Verifies M5.3: @wam_dijkstra_weighted_distance helper.
+%
+% This is the computational core of weighted_shortest_path3. Uses linear
+% scan extract-min over a best[] array — O(V^2), fine for small graphs.
+%
+% Checks:
+%   - Helper is defined in the generated module.
+%   - A module with a concrete %WeightedFact table and a demo caller
+%     that invokes the helper parses with llvm-as AND passes
+%     opt -passes=verify (dominance/phi/SSA check).
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3,
+     llvm_emit_weighted_edge_table/3]).
+:- use_module(library(process)).
+
+:- dynamic color/1.
+color(red).
+
+test_helper_defined :-
+    format('--- @wam_dijkstra_weighted_distance defined in template ---~n'),
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project([user:color/1], [module_name('dijk_test')], LLPath),
+    read_file_to_string(LLPath, Src, []),
+    ( sub_string(Src, _, _, _, 'define i1 @wam_dijkstra_weighted_distance')
+    -> format('  PASS: helper definition present~n')
+    ;  format('  FAIL: helper missing~n'),
+       throw(helper_missing)
+    ),
+    ( sub_string(Src, _, _, _, '0x7FF0000000000000')
+    -> format('  PASS: +inf sentinel 0x7FF0000000000000 present~n')
+    ;  format('  FAIL: +inf sentinel missing~n')
+    ),
+    catch(delete_file(LLPath), _, true).
+
+test_dijkstra_module_validates :-
+    format('--- llvm-as + opt verify accept dijkstra caller ---~n'),
+    ( process_which('llvm-as')
+    -> test_dijkstra_llvm_as
+    ;  format('  SKIP: llvm-as not found on PATH~n')
+    ).
+
+test_dijkstra_llvm_as :-
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project([user:color/1], [module_name('dijk_test')], LLPath),
+    % 4-node graph: a -0.5-> b -1.5-> c -0.3-> d
+    %               a -2.0-> d   (direct but slower)
+    llvm_emit_weighted_edge_table(dijk_demo_graph,
+        [ edge(a, b, 0.5),
+          edge(b, c, 1.5),
+          edge(c, d, 0.3),
+          edge(a, d, 2.0)
+        ], TableCode),
+    CallerIR = '
+define i1 @dijk_demo_caller(i64 %start_id, i64 %target_id, double* %out) {
+entry:
+  %table_ptr = getelementptr [4 x %WeightedFact], [4 x %WeightedFact]* @dijk_demo_graph, i64 0, i64 0
+  %ok = call i1 @wam_dijkstra_weighted_distance(
+      i64 %start_id, i64 %target_id,
+      %WeightedFact* %table_ptr, i64 4,
+      i64 32,
+      double* %out)
+  ret i1 %ok
+}
+',
+    setup_call_cleanup(
+        open(LLPath, append, Out),
+        ( write(Out, '\n'), write(Out, TableCode),
+          write(Out, '\n'), write(Out, CallerIR),
+          write(Out, '\n') ),
+        close(Out)),
+    atom_concat(LLPath, '.bc', BCPath),
+    format(atom(Cmd), 'llvm-as ~w -o ~w 2>&1', [LLPath, BCPath]),
+    shell(Cmd, Exit),
+    ( Exit == 0
+    -> format('  PASS: llvm-as accepted dijkstra caller module~n')
+    ;  format('  FAIL: llvm-as exit=~w~n', [Exit])
+    ),
+    ( process_which('opt')
+    -> format(atom(VCmd),
+        'opt -passes=verify -disable-output ~w 2>&1', [BCPath]),
+       shell(VCmd, VExit),
+       ( VExit == 0
+       -> format('  PASS: opt -passes=verify accepted bitcode~n')
+       ;  format('  FAIL: opt -passes=verify exit=~w~n', [VExit])
+       )
+    ;  format('  SKIP: opt not found on PATH~n')
+    ),
+    catch(delete_file(LLPath), _, true),
+    catch(delete_file(BCPath), _, true).
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _,
+        fail).
+
+test_all :-
+    test_helper_defined,
+    catch(test_dijkstra_module_validates, E,
+        format('  ERROR in llvm-as test: ~w~n', [E])).
+
+:- initialization(test_all, main).

--- a/tests/core/test_wam_llvm_ffi_bridge.pl
+++ b/tests/core/test_wam_llvm_ffi_bridge.pl
@@ -1,0 +1,108 @@
+:- encoding(utf8).
+% test_wam_llvm_ffi_bridge.pl
+% Verifies M5.1: FFI bridge helpers for native kernels.
+%
+% M5.1 adds @wam_get_reg_tag, @wam_get_reg_payload, @wam_get_reg_double,
+% @wam_set_reg_atom_id, @wam_set_reg_int, @wam_set_reg_double to the
+% runtime template (state.ll.mustache). These are the primitives that
+% foreign kernels will use to read and write WAM registers without
+% constructing %Value structs inline.
+%
+% This test generates a full WAM LLVM module and a small native-style
+% caller that exercises every helper, then pipes the result through
+% llvm-as to validate the IR parses cleanly.
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3]).
+:- use_module(library(process)).
+
+:- dynamic color/1.
+color(red).
+
+test_helpers_defined_in_template :-
+    format('--- bridge helpers are defined in state template ---~n'),
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project([user:color/1], [module_name('ffi_test')], LLPath),
+    read_file_to_string(LLPath, Src, []),
+    forall(
+        member(Name, [
+            'define i32 @wam_get_reg_tag',
+            'define i64 @wam_get_reg_payload',
+            'define double @wam_get_reg_double',
+            'define void @wam_set_reg_atom_id',
+            'define void @wam_set_reg_int',
+            'define void @wam_set_reg_double'
+        ]),
+        ( sub_string(Src, _, _, _, Name)
+        -> format('  PASS: ~w present~n', [Name])
+        ;  format('  FAIL: ~w missing~n', [Name]),
+           throw(helper_missing(Name))
+        )),
+    catch(delete_file(LLPath), _, true).
+
+test_bridge_module_validates :-
+    format('--- llvm-as accepts module using bridge helpers ---~n'),
+    ( process_which('llvm-as')
+    -> test_bridge_llvm_as
+    ;  format('  SKIP: llvm-as not found on PATH~n')
+    ).
+
+test_bridge_llvm_as :-
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project([user:color/1], [module_name('ffi_test')], LLPath),
+    % Append a small kernel-style function that exercises each helper.
+    % This is the shape a real M5 native kernel will take.
+    CallerIR = '
+define i1 @demo_kernel(%WamState* %vm) {
+entry:
+  ; Read register 0 tag + payload.
+  %tag0 = call i32 @wam_get_reg_tag(%WamState* %vm, i32 0)
+  %pay0 = call i64 @wam_get_reg_payload(%WamState* %vm, i32 0)
+
+  ; Read register 1 as a double.
+  %d1 = call double @wam_get_reg_double(%WamState* %vm, i32 1)
+
+  ; Write atom ID 42 into register 2.
+  call void @wam_set_reg_atom_id(%WamState* %vm, i32 2, i64 42)
+
+  ; Write integer 17 into register 3.
+  call void @wam_set_reg_int(%WamState* %vm, i32 3, i64 17)
+
+  ; Write double 3.14 into register 4.
+  call void @wam_set_reg_double(%WamState* %vm, i32 4, double 3.14)
+
+  ret i1 true
+}
+',
+    setup_call_cleanup(
+        open(LLPath, append, Out),
+        write(Out, CallerIR),
+        close(Out)),
+    format('  Wrote module: ~w~n', [LLPath]),
+    atom_concat(LLPath, '.bc', BCPath),
+    format(atom(Cmd), 'llvm-as ~w -o ~w 2>&1', [LLPath, BCPath]),
+    shell(Cmd, Exit),
+    ( Exit == 0
+    -> format('  PASS: llvm-as accepted module with bridge-helper caller~n')
+    ;  format('  FAIL: llvm-as exit=~w~n', [Exit])
+    ),
+    catch(delete_file(LLPath), _, true),
+    catch(delete_file(BCPath), _, true).
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _,
+        fail).
+
+test_all :-
+    test_helpers_defined_in_template,
+    catch(test_bridge_module_validates, E,
+        format('  ERROR in llvm-as test: ~w~n', [E])).
+
+:- initialization(test_all, main).


### PR DESCRIPTION
## Summary

First three steps of Milestone 5 of the hybrid WAM LLVM port. Adds the runtime primitives that native foreign kernels will use:

- **M5.1** — Six FFI bridge helpers for reading and writing WAM registers without constructing `%Value` tagged-union structs inline.
- **M5.2** — `@wam_bfs_atom_distance`, the computational core of `transitive_distance3` (shortest path length in edges over an `%AtomFactPair` table).
- **M5.3** — `@wam_dijkstra_weighted_distance`, the computational core of `weighted_shortest_path3` (minimum-weight path over a `%WeightedFact` table).

All three helpers are standalone — they compute results but aren't yet wired into the foreign dispatcher. The dispatcher stubs still return `false`. Remaining M5 work (A* helper, dispatcher delegation pattern, and the compile-pipeline integration that emits concrete kernel impls) will land in follow-up PRs.

## Background

The five-milestone roadmap from prior PRs:

| Milestone | Status | Scope |
|---|---|---|
| M1 | merged (#1298) | `switch_on_constant` + latent IR fixes |
| M2 | merged (#1301) | aggregate frames |
| M3 | merged (#1306) | foreign dispatch scaffolding |
| M4 | merged (#1306) | indexed fact table emission |
| **M5.1–M5.3** | **this PR** | FFI bridge + BFS + Dijkstra helpers |
| M5.4 | upcoming | A* helper |
| M5.5 | upcoming | dispatcher delegation + compile-pipeline wiring |

Kernels do not generate WAM — they are native functions called from inside WAM execution via the `call_foreign` instruction introduced in M3. This PR adds the computational primitives; a later PR wires them into the dispatcher and the compile pipeline.

## M5.1: FFI Bridge Helpers

Six runtime helpers in `state.ll.mustache` that let foreign kernels read and write WAM registers without constructing `%Value` tagged-union structs inline:

| Helper | Purpose |
|---|---|
| `@wam_get_reg_tag(vm, idx) -> i32` | Read the type tag of a register (0=Atom, 1=Int, 2=Float, …) |
| `@wam_get_reg_payload(vm, idx) -> i64` | Read the raw i64 payload |
| `@wam_get_reg_double(vm, idx) -> double` | Read payload as double via i64→double bitcast |
| `@wam_set_reg_atom_id(vm, idx, i64)` | Write Atom value (tag=0) |
| `@wam_set_reg_int(vm, idx, i64)` | Write Integer value (tag=1) |
| `@wam_set_reg_double(vm, idx, double)` | Write Float value (tag=2) via double→i64 bitcast |

Each helper `getelementptr`s directly into the `%WamState` register array (field 1 is `[32 x %Value]`) and stores the `%Value` tag and payload fields separately. No new runtime dependencies — they mirror how `@wam_get_reg` and `@wam_set_reg` already access the register array.

The tag/payload split lets kernels handle "register is not the expected type" by checking the tag first and failing cleanly (returning false from `@wam_execute_foreign_predicate`), rather than each helper implementing its own error reporting.

## M5.2: BFS Helper

`@wam_bfs_atom_distance` — the computational core of `transitive_distance3`. Computes the shortest-path length (in edges) from a start atom to a target atom in a directed graph described by an `%AtomFactPair` table.

```llvm
define i1 @wam_bfs_atom_distance(
    i64 %start, i64 %target,
    %AtomFactPair* %table, i64 %len,
    i64 %max_atom_id,
    i64* %out_dist)
```

Semantics:
- `%start == %target` fast path: writes `0`, returns `true` without allocating.
- Allocates `visited` / `queue` / `dqueue` buffers via `malloc`, sized by `%max_atom_id + 1` (caller supplies a tight upper bound).
- Standard BFS: seed `%start` with depth 0, pop the head of the queue, scan `%table` for outgoing edges from the popped node, enqueue each unvisited target with `depth + 1`, early-exit on first hit of `%target`.
- All three allocations freed on both success and failure paths via a shared cleanup block.

Block structure uses a single `phi` at `%scan_cont` to merge the tail pointer across the four paths (from-mismatch / to-out-of-range / already-visited / enqueued). Both `llvm-as` (parse) and `opt -passes=verify` (dominance + SSA check) accept the generated IR — `opt verify` caught an initial dominance bug during development.

## M5.3: Dijkstra Helper

`@wam_dijkstra_weighted_distance` — the computational core of `weighted_shortest_path3`. Minimum-weight path distance from a start atom to a target atom over a `%WeightedFact` table.

```llvm
define i1 @wam_dijkstra_weighted_distance(
    i64 %start, i64 %target,
    %WeightedFact* %table, i64 %len,
    i64 %max_atom_id,
    double* %out_dist)
```

Semantics:
- `%start == %target` fast path: writes `0.0`, returns `true`.
- `best[]` array sized by `(%max_atom_id + 1)`, initialized to `+inf` (`0x7FF0000000000000`); `visited[]` array initialized to `0`.
- `best[%start] = 0.0` to seed.
- Outer loop: extract-min over unvisited nodes via linear scan (O(V) per extract), mark visited, early-exit on target hit.
- Relaxation: scan the full edge table for outgoing edges from the extracted node, update `best[to] = min(best[to], best[node] + w)`.
- Terminates when no unvisited node has finite `best[]` — falls through to `fail_free` which releases buffers and returns `false`.

**Complexity:** O(V² + V·E). The linear-scan extract-min is simple but suboptimal for large graphs. A binary heap can replace the min-scan block without changing the public signature; deferred since typical semantic-distance inputs are small (tens to hundreds of nodes).

**Assumes non-negative edge weights** (Dijkstra's domain). Negative weights produce undefined output — the caller is responsible for validation.

**`+inf` encoding:** `double 0x7FF0000000000000` is LLVM's canonical IEEE 754 `+inf` literal. It doubles as the unreachable sentinel since `fcmp oeq double x, 0x7FF0000000000000` is the natural "unreachable" predicate.

## Test Coverage

| Suite | Assertions | Scope |
|---|---|---|
| `test_wam_llvm_switch.pl` (M1) | 7 | regression |
| `test_wam_llvm_aggregate.pl` (M2) | 5 | regression |
| `test_wam_llvm_foreign_dispatch.pl` (M3) | 11 | regression |
| `test_wam_llvm_fact_tables.pl` (M4) | 10 | regression |
| `test_wam_llvm_ffi_bridge.pl` (M5.1) | 7 | **new** |
| `test_wam_llvm_bfs_atom.pl` (M5.2) | 3 | **new** |
| `test_wam_llvm_dijkstra.pl` (M5.3) | 4 | **new** |
| **Total** | **47** | |

### M5.1 Tests

1–6. All six helper definitions (`@wam_get_reg_tag`, `@wam_get_reg_payload`, `@wam_get_reg_double`, `@wam_set_reg_atom_id`, `@wam_set_reg_int`, `@wam_set_reg_double`) appear in the generated module.

7. End-to-end `llvm-as` validation: a demo kernel that reads tag + payload, reads a double, and writes an atom, an int, and a double parses cleanly.

### M5.2 Tests

1. Helper definition present.
2. Module with a 4-node `%AtomFactPair` graph and a demo caller invoking the helper parses with `llvm-as`.
3. `opt -passes=verify` accepts the resulting bitcode.

### M5.3 Tests

1. Helper definition present.
2. `+inf` sentinel `0x7FF0000000000000` present in the IR.
3. `llvm-as` accepts a module with a 4-node `%WeightedFact` graph and a demo caller.
4. `opt -passes=verify` accepts the resulting bitcode.

Execution-level testing (compiling and running kernels via `lli` or JIT) is deferred to after the M5.5 dispatcher wiring, when the end-to-end path exists.

## Files Changed

- `templates/targets/llvm_wam/state.ll.mustache` — six FFI bridge helpers (M5.1), `@wam_bfs_atom_distance` (M5.2), `@wam_dijkstra_weighted_distance` (M5.3).
- `tests/core/test_wam_llvm_ffi_bridge.pl` — new.
- `tests/core/test_wam_llvm_bfs_atom.pl` — new.
- `tests/core/test_wam_llvm_dijkstra.pl` — new.

## What's Next

- **M5.4** — A* helper. Same structure as Dijkstra but orders the frontier by `f(n) = g(n) + h(n)` with a precomputed heuristic array. Returns the same `g` value — heuristic only affects exploration order.
- **M5.5** — Dispatcher delegation pattern + compile-pipeline integration. Replaces the stubs in `@wam_execute_foreign_predicate` with delegations to per-kernel impl functions, and teaches the compile pipeline to emit concrete impl bodies when `foreign_lowering` is enabled. This is where the full end-to-end path becomes exercisable from Prolog source.

## Test Plan

- [x] M1 regression: `swipl -q tests/core/test_wam_llvm_switch.pl`
- [x] M2 regression: `swipl -q tests/core/test_wam_llvm_aggregate.pl`
- [x] M3 regression: `swipl -q tests/core/test_wam_llvm_foreign_dispatch.pl`
- [x] M4 regression: `swipl -q tests/core/test_wam_llvm_fact_tables.pl`
- [x] M5.1: `swipl -q tests/core/test_wam_llvm_ffi_bridge.pl`
- [x] M5.2: `swipl -q tests/core/test_wam_llvm_bfs_atom.pl`
- [x] M5.3: `swipl -q tests/core/test_wam_llvm_dijkstra.pl`
- [x] All new IR validates through both `llvm-as` and `opt -passes=verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
