### PR TITLE
Refactor Rust WAM wrapper traversal around shared terminal modes

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -4332,19 +4332,19 @@ rust_foreign_stream_terminal_code(Indent, FilterVar, OutputVar, SetupCode, Value
 rust_foreign_scalar_min_terminal_code(Indent, FilterVar, OutputVar, SetupCode, ValueExpr, FilterCond, Code) :-
     rust_foreign_wrapper_filter_expr(FilterVar, OutputVar, FilterExpr),
     format(string(Code),
-'~w~wif !(~w) || !(~w) {
-~w    continue;
+'~w~wif (~w)
+~w    && (~w) {
+~w    let agg_value = ~w;
+~w    best = Some(match best {
+~w        Some(current) => current.min(agg_value),
+~w        None => agg_value,
+~w    });
 ~w}
-~wlet agg_value = ~w;
-~wbest = Some(match best {
-~w    Some(current) => current.min(agg_value),
-~w    None => agg_value,
-~w});
 ', [SetupCode,
-      Indent, FilterExpr, FilterCond,
-      Indent,
-      Indent,
+      Indent, FilterExpr,
+      Indent, FilterCond,
       Indent, ValueExpr,
+      Indent,
       Indent,
       Indent,
       Indent,
@@ -4373,6 +4373,18 @@ rust_foreign_join_chain_code(JoinSpecs, InputLookupExpr, _InputVar, Indent,
         SetupCode, ValueExpr, FilterCond, Code) :-
     rust_foreign_stage_output_var(JoinSpecs, OutputVar),
     rust_foreign_stream_terminal_code(Indent, "join_filter", OutputVar, SetupCode, ValueExpr, FilterCond, TerminalCode),
+    rust_foreign_stage_chain_code(JoinSpecs, InputLookupExpr, Indent, TerminalCode, Code).
+
+rust_foreign_scalar_wrapper_traversal_code([], FilterVar, OutputVar, _InputLookupExpr, Indent,
+        SetupCode, ValueExpr, FilterCond, Code) :-
+    rust_foreign_scalar_min_terminal_code(Indent, FilterVar, OutputVar, SetupCode, ValueExpr, FilterCond, Code).
+rust_foreign_scalar_wrapper_traversal_code(JoinPreds, FilterVar, _OutputVar, InputLookupExpr, Indent,
+        SetupCode, ValueExpr, FilterCond, Code) :-
+    JoinPreds \= [],
+    rust_render_join_specs(JoinPreds, JoinSpecs),
+    rust_foreign_stage_output_var(JoinSpecs, JoinOutputVar),
+    rust_foreign_scalar_min_terminal_code("            ", FilterVar, JoinOutputVar,
+        SetupCode, ValueExpr, FilterCond, TerminalCode),
     rust_foreign_stage_chain_code(JoinSpecs, InputLookupExpr, Indent, TerminalCode, Code).
 
 compile_rust_foreign_stream_wrapper_from_plan(Pred, 3,
@@ -4851,7 +4863,12 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 3,
       rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalOutput, GoalCost],
           Expr, SetupCode, ValueExpr, FilterCond),
       ( JoinPreds == []
-      -> FilterCode = "",
+      -> FilterCode =
+'    let target_filter = match &a2 {
+        Value::Atom(target) => Some(target.clone()),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };',
          A2RegCode =
 '    let target_arg = match &a2 {
         Value::Unbound(_) => Value::Unbound(temp_target.clone()),
@@ -4861,22 +4878,22 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 3,
     vm.set_reg("A1", a1.clone());
     vm.set_reg("A2", target_arg);
     vm.set_reg("A3", Value::Unbound(temp_cost.clone()));',
-         TargetReadCode = "",
+         TargetReadCode =
+'        let target = match &a2 {
+            Value::Atom(target) => target.clone(),
+            Value::Unbound(_) => match vm.bindings.get(&temp_target).cloned().map(|v| vm.deref_var(&v)) {
+                Some(Value::Atom(target)) => target,
+                _ => break,
+            },
+            _ => break,
+        };',
          JoinRegistrationCode = "",
-         format(string(TraversalCode),
-'~w        if ~w {
-            let agg_value = ~w;
-            best = Some(match best {
-                Some(current) => current.min(agg_value),
-                None => agg_value,
-            });
-        }
-', [SetupCode, FilterCond, ValueExpr])
+         rust_foreign_scalar_wrapper_traversal_code([], "target_filter", "target", "&target", "        ",
+             SetupCode, ValueExpr, FilterCond, TraversalCode)
       ; rust_render_join_specs(JoinPreds, JoinSpecs),
-        rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
-        rust_foreign_stage_output_var(JoinSpecs, JoinOutputVar),
+         rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
         FilterCode =
-'    let output_filter = match &a2 {
+'    let target_filter = match &a2 {
         Value::Unbound(_) => None,
         Value::Atom(group) => Some(group.clone()),
         _ => return false,
@@ -4890,9 +4907,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 3,
             Some(Value::Atom(target)) => target,
             _ => break,
         };',
-        rust_foreign_scalar_min_terminal_code("            ", "output_filter", JoinOutputVar,
-            SetupCode, ValueExpr, FilterCond, TerminalCode),
-        rust_foreign_stage_chain_code(JoinSpecs, "&target", "        ", TerminalCode, TraversalCode)
+        rust_foreign_scalar_wrapper_traversal_code(JoinPreds, "target_filter", "target", "&target", "        ",
+            SetupCode, ValueExpr, FilterCond, TraversalCode)
       ),
       format(string(RustCode),
 'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool {
@@ -5102,7 +5118,12 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
       rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalOutput, GoalDim, GoalCost],
           Expr, SetupCode, ValueExpr, FilterCond),
       ( JoinPreds == []
-      -> FilterCode = "",
+      -> FilterCode =
+'    let target_filter = match &a2 {
+        Value::Atom(target) => Some(target.clone()),
+        Value::Unbound(_) => None,
+        _ => return false,
+    };',
          A2RegCode =
 '    let target_arg = match &a2 {
         Value::Unbound(_) => Value::Unbound(temp_target.clone()),
@@ -5113,22 +5134,22 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
     vm.set_reg("A2", target_arg);
     vm.set_reg("A3", a3.clone());
     vm.set_reg("A4", Value::Unbound(temp_cost.clone()));',
-         TargetReadCode = "",
+         TargetReadCode =
+'        let target = match &a2 {
+            Value::Atom(target) => target.clone(),
+            Value::Unbound(_) => match vm.bindings.get(&temp_target).cloned().map(|v| vm.deref_var(&v)) {
+                Some(Value::Atom(target)) => target,
+                _ => break,
+            },
+            _ => break,
+        };',
          JoinRegistrationCode = "",
-         format(string(TraversalCode),
-'~w        if ~w {
-            let agg_value = ~w;
-            best = Some(match best {
-                Some(current) => current.min(agg_value),
-                None => agg_value,
-            });
-        }
-', [SetupCode, FilterCond, ValueExpr])
+         rust_foreign_scalar_wrapper_traversal_code([], "target_filter", "target", "&target", "        ",
+             SetupCode, ValueExpr, FilterCond, TraversalCode)
       ; rust_render_join_specs(JoinPreds, JoinSpecs),
         rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
-        rust_foreign_stage_output_var(JoinSpecs, JoinOutputVar),
         FilterCode =
-'    let output_filter = match &a2 {
+'    let target_filter = match &a2 {
         Value::Unbound(_) => None,
         Value::Atom(group) => Some(group.clone()),
         _ => return false,
@@ -5143,9 +5164,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
             Some(Value::Atom(target)) => target,
             _ => break,
         };',
-        rust_foreign_scalar_min_terminal_code("            ", "output_filter", JoinOutputVar,
-            SetupCode, ValueExpr, FilterCond, TerminalCode),
-        rust_foreign_stage_chain_code(JoinSpecs, "&target", "        ", TerminalCode, TraversalCode)
+        rust_foreign_scalar_wrapper_traversal_code(JoinPreds, "target_filter", "target", "&target", "        ",
+            SetupCode, ValueExpr, FilterCond, TraversalCode)
       ),
       format(string(RustCode),
 'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool {

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -4399,6 +4399,24 @@ rust_foreign_grouped_wrapper_traversal_code(JoinPreds, FilterVar, _OutputVar, In
         SetupCode, ValueExpr, FilterCond, TerminalCode),
     rust_foreign_stage_chain_code(JoinSpecs, InputLookupExpr, Indent, TerminalCode, Code).
 
+rust_foreign_wrapper_traversal_code(stream, JoinPreds, FilterVar, OutputVar, InputLookupExpr, Indent,
+        SetupCode, ValueExpr, FilterCond, Code) :-
+    (   JoinPreds == []
+    ->  rust_foreign_stream_terminal_code(Indent, FilterVar, OutputVar,
+            SetupCode, ValueExpr, FilterCond, Code)
+    ;   rust_render_join_specs(JoinPreds, JoinSpecs),
+        rust_foreign_join_chain_code(JoinSpecs, InputLookupExpr, OutputVar, Indent,
+            SetupCode, ValueExpr, FilterCond, Code)
+    ).
+rust_foreign_wrapper_traversal_code(scalar_min, JoinPreds, FilterVar, OutputVar, InputLookupExpr, Indent,
+        SetupCode, ValueExpr, FilterCond, Code) :-
+    rust_foreign_scalar_wrapper_traversal_code(JoinPreds, FilterVar, OutputVar, InputLookupExpr, Indent,
+        SetupCode, ValueExpr, FilterCond, Code).
+rust_foreign_wrapper_traversal_code(grouped_min, JoinPreds, FilterVar, OutputVar, InputLookupExpr, Indent,
+        SetupCode, ValueExpr, FilterCond, Code) :-
+    rust_foreign_grouped_wrapper_traversal_code(JoinPreds, FilterVar, OutputVar, InputLookupExpr, Indent,
+        SetupCode, ValueExpr, FilterCond, Code).
+
 compile_rust_foreign_stream_wrapper_from_plan(Pred, 3,
         foreign_wrapper_plan(
             weighted_kernel(InnerPred, WeightPred/3, FactTriples),
@@ -4434,7 +4452,8 @@ compile_rust_foreign_stream_wrapper_from_plan(Pred, 3,
             },
             _ => break,
         };',
-       rust_foreign_stream_terminal_code("        ", "target_filter", "target", SetupCode, ValueExpr, FilterCond, TraversalCode)
+       rust_foreign_wrapper_traversal_code(stream, [], "target_filter", "target", "&target", "        ",
+           SetupCode, ValueExpr, FilterCond, TraversalCode)
     ; JoinPreds \= [],
        TargetFilterCode =
 '    let join_filter = match &a2 {
@@ -4453,7 +4472,7 @@ compile_rust_foreign_stream_wrapper_from_plan(Pred, 3,
         };',
        rust_render_join_specs(JoinPreds, JoinSpecs),
        rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
-       rust_foreign_join_chain_code(JoinSpecs, "&target", "target", "        ",
+       rust_foreign_wrapper_traversal_code(stream, JoinPreds, "join_filter", "target", "&target", "        ",
            SetupCode, ValueExpr, FilterCond, TraversalCode)
     ; fail
     ),
@@ -4556,7 +4575,7 @@ compile_rust_foreign_stream_wrapper_from_plan(Pred, 4,
             },
             _ => break,
         };',
-       rust_foreign_stream_terminal_code("        ", "target_filter", "target",
+       rust_foreign_wrapper_traversal_code(stream, [], "target_filter", "target", "&target", "        ",
            SetupCode, ValueExpr, FilterCond, TraversalCode)
     ; JoinPreds \= [],
        TargetFilterCode =
@@ -4577,7 +4596,7 @@ compile_rust_foreign_stream_wrapper_from_plan(Pred, 4,
         };',
        rust_render_join_specs(JoinPreds, JoinSpecs),
        rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
-       rust_foreign_join_chain_code(JoinSpecs, "&target", "target", "        ",
+       rust_foreign_wrapper_traversal_code(stream, JoinPreds, "join_filter", "target", "&target", "        ",
            SetupCode, ValueExpr, FilterCond, TraversalCode)
     ; fail
     ),
@@ -4775,7 +4794,7 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 3,
             _ => break,
         };',
           JoinRegistrationCode = "",
-          rust_foreign_grouped_wrapper_traversal_code([], "output_filter", "target", "&target", "        ",
+          rust_foreign_wrapper_traversal_code(grouped_min, [], "output_filter", "target", "&target", "        ",
               SetupCode, ValueExpr, FilterCond, TraversalCode)
        ; rust_render_join_specs(JoinPreds, JoinSpecs),
          rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
@@ -4794,7 +4813,7 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 3,
             Some(Value::Atom(target)) => target,
             _ => break,
         };',
-         rust_foreign_grouped_wrapper_traversal_code(JoinPreds, "output_filter", "target", "&target", "        ",
+         rust_foreign_wrapper_traversal_code(grouped_min, JoinPreds, "output_filter", "target", "&target", "        ",
              SetupCode, ValueExpr, FilterCond, TraversalCode)
        ),
        format(string(RustCode),
@@ -4885,7 +4904,7 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 3,
             _ => break,
         };',
          JoinRegistrationCode = "",
-         rust_foreign_scalar_wrapper_traversal_code([], "target_filter", "target", "&target", "        ",
+         rust_foreign_wrapper_traversal_code(scalar_min, [], "target_filter", "target", "&target", "        ",
              SetupCode, ValueExpr, FilterCond, TraversalCode)
       ; rust_render_join_specs(JoinPreds, JoinSpecs),
          rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
@@ -4904,7 +4923,7 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 3,
             Some(Value::Atom(target)) => target,
             _ => break,
         };',
-        rust_foreign_scalar_wrapper_traversal_code(JoinPreds, "target_filter", "target", "&target", "        ",
+        rust_foreign_wrapper_traversal_code(scalar_min, JoinPreds, "target_filter", "target", "&target", "        ",
             SetupCode, ValueExpr, FilterCond, TraversalCode)
       ),
       format(string(RustCode),
@@ -5004,7 +5023,7 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
             _ => break,
         };',
           JoinRegistrationCode = "",
-          rust_foreign_grouped_wrapper_traversal_code([], "output_filter", "target", "&target", "        ",
+          rust_foreign_wrapper_traversal_code(grouped_min, [], "output_filter", "target", "&target", "        ",
               SetupCode, ValueExpr, FilterCond, TraversalCode)
        ; rust_render_join_specs(JoinPreds, JoinSpecs),
          rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
@@ -5024,7 +5043,7 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
             Some(Value::Atom(target)) => target,
             _ => break,
         };',
-         rust_foreign_grouped_wrapper_traversal_code(JoinPreds, "output_filter", "target", "&target", "        ",
+         rust_foreign_wrapper_traversal_code(grouped_min, JoinPreds, "output_filter", "target", "&target", "        ",
              SetupCode, ValueExpr, FilterCond, TraversalCode)
        ),
        format(string(RustCode),
@@ -5126,7 +5145,7 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
             _ => break,
         };',
          JoinRegistrationCode = "",
-         rust_foreign_scalar_wrapper_traversal_code([], "target_filter", "target", "&target", "        ",
+         rust_foreign_wrapper_traversal_code(scalar_min, [], "target_filter", "target", "&target", "        ",
              SetupCode, ValueExpr, FilterCond, TraversalCode)
       ; rust_render_join_specs(JoinPreds, JoinSpecs),
         rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
@@ -5146,7 +5165,7 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
             Some(Value::Atom(target)) => target,
             _ => break,
         };',
-        rust_foreign_scalar_wrapper_traversal_code(JoinPreds, "target_filter", "target", "&target", "        ",
+        rust_foreign_wrapper_traversal_code(scalar_min, JoinPreds, "target_filter", "target", "&target", "        ",
             SetupCode, ValueExpr, FilterCond, TraversalCode)
       ),
       format(string(RustCode),

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -4387,6 +4387,18 @@ rust_foreign_scalar_wrapper_traversal_code(JoinPreds, FilterVar, _OutputVar, Inp
         SetupCode, ValueExpr, FilterCond, TerminalCode),
     rust_foreign_stage_chain_code(JoinSpecs, InputLookupExpr, Indent, TerminalCode, Code).
 
+rust_foreign_grouped_wrapper_traversal_code([], FilterVar, OutputVar, _InputLookupExpr, Indent,
+        SetupCode, ValueExpr, FilterCond, Code) :-
+    rust_foreign_grouped_min_terminal_code(Indent, FilterVar, OutputVar, SetupCode, ValueExpr, FilterCond, Code).
+rust_foreign_grouped_wrapper_traversal_code(JoinPreds, FilterVar, _OutputVar, InputLookupExpr, Indent,
+        SetupCode, ValueExpr, FilterCond, Code) :-
+    JoinPreds \= [],
+    rust_render_join_specs(JoinPreds, JoinSpecs),
+    rust_foreign_stage_output_var(JoinSpecs, JoinOutputVar),
+    rust_foreign_grouped_min_terminal_code("            ", FilterVar, JoinOutputVar,
+        SetupCode, ValueExpr, FilterCond, TerminalCode),
+    rust_foreign_stage_chain_code(JoinSpecs, InputLookupExpr, Indent, TerminalCode, Code).
+
 compile_rust_foreign_stream_wrapper_from_plan(Pred, 3,
         foreign_wrapper_plan(
             weighted_kernel(InnerPred, WeightPred/3, FactTriples),
@@ -4763,24 +4775,10 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 3,
             _ => break,
         };',
           JoinRegistrationCode = "",
-          format(string(TraversalCode),
-'~w        if (output_filter.as_ref().map(|want| want.as_str() == target.as_str()).unwrap_or(true))
-~w            && (~w) {
-~w            let agg_value = ~w;
-~w            grouped.entry(target)
-~w                .and_modify(|current| *current = current.min(agg_value))
-~w                .or_insert(agg_value);
-~w        }
-', [SetupCode,
-      "        ", FilterCond,
-      "        ", ValueExpr,
-      "        ",
-      "        ",
-      "        ",
-      "        "])
+          rust_foreign_grouped_wrapper_traversal_code([], "output_filter", "target", "&target", "        ",
+              SetupCode, ValueExpr, FilterCond, TraversalCode)
        ; rust_render_join_specs(JoinPreds, JoinSpecs),
          rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
-         rust_foreign_stage_output_var(JoinSpecs, JoinOutputVar),
          FilterCode =
 '    let output_filter = match &a2 {
         Value::Atom(group) => Some(group.clone()),
@@ -4796,9 +4794,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 3,
             Some(Value::Atom(target)) => target,
             _ => break,
         };',
-         rust_foreign_grouped_min_terminal_code("            ", "output_filter", JoinOutputVar,
-             SetupCode, ValueExpr, FilterCond, TerminalCode),
-         rust_foreign_stage_chain_code(JoinSpecs, "&target", "        ", TerminalCode, TraversalCode)
+         rust_foreign_grouped_wrapper_traversal_code(JoinPreds, "output_filter", "target", "&target", "        ",
+             SetupCode, ValueExpr, FilterCond, TraversalCode)
        ),
        format(string(RustCode),
 'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool {
@@ -5007,24 +5004,10 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
             _ => break,
         };',
           JoinRegistrationCode = "",
-          format(string(TraversalCode),
-'~w        if (output_filter.as_ref().map(|want| want.as_str() == target.as_str()).unwrap_or(true))
-~w            && (~w) {
-~w            let agg_value = ~w;
-~w            grouped.entry(target)
-~w                .and_modify(|current| *current = current.min(agg_value))
-~w                .or_insert(agg_value);
-~w        }
-', [SetupCode,
-      "        ", FilterCond,
-      "        ", ValueExpr,
-      "        ",
-      "        ",
-      "        ",
-      "        "])
+          rust_foreign_grouped_wrapper_traversal_code([], "output_filter", "target", "&target", "        ",
+              SetupCode, ValueExpr, FilterCond, TraversalCode)
        ; rust_render_join_specs(JoinPreds, JoinSpecs),
          rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
-         rust_foreign_stage_output_var(JoinSpecs, JoinOutputVar),
          FilterCode =
 '    let output_filter = match &a2 {
         Value::Atom(group) => Some(group.clone()),
@@ -5041,9 +5024,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
             Some(Value::Atom(target)) => target,
             _ => break,
         };',
-         rust_foreign_grouped_min_terminal_code("            ", "output_filter", JoinOutputVar,
-             SetupCode, ValueExpr, FilterCond, TerminalCode),
-         rust_foreign_stage_chain_code(JoinSpecs, "&target", "        ", TerminalCode, TraversalCode)
+         rust_foreign_grouped_wrapper_traversal_code(JoinPreds, "output_filter", "target", "&target", "        ",
+             SetupCode, ValueExpr, FilterCond, TraversalCode)
        ),
        format(string(RustCode),
 'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool {

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -960,7 +960,7 @@ test_filtered_adjusted_weighted_min_wrapper :-
         atom_string(Code, S),
         sub_string(S, _, _, _, 'pub fn filtered_adjusted_min_semantic_dist(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool'),
         sub_string(S, _, _, _, 'let agg_value = (cost + 1_f64);'),
-        sub_string(S, _, _, _, 'if cost > 2_f64 {'),
+        sub_string(S, _, _, _, '&& (cost > 2_f64) {'),
         sub_string(S, _, _, _, 'current.min(agg_value)')
     ->  pass(Test)
     ;   fail_test(Test, 'Mixed-goal weighted aggregate wrapper did not lower correctly')
@@ -973,7 +973,7 @@ test_filtered_adjusted_astar_min_wrapper :-
         atom_string(Code, S),
         sub_string(S, _, _, _, 'pub fn filtered_adjusted_min_semantic_dist_astar(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool'),
         sub_string(S, _, _, _, 'let agg_value = (cost + 1_f64);'),
-        sub_string(S, _, _, _, 'if cost > 2_f64 {'),
+        sub_string(S, _, _, _, '&& (cost > 2_f64) {'),
         sub_string(S, _, _, _, 'current.min(agg_value)')
     ->  pass(Test)
     ;   fail_test(Test, 'Mixed-goal A* aggregate wrapper did not lower correctly')

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -932,7 +932,7 @@ test_grouped_weighted_min_aggregate_wrapper :-
         sub_string(S, _, _, _, 'use std::collections::BTreeMap;'),
         sub_string(S, _, _, _, 'register_foreign_result_layout("grouped_min_semantic_dist/3", "tuple:2")'),
         sub_string(S, _, _, _, 'register_foreign_native_kind("weighted_path/3", "weighted_shortest_path3")'),
-        sub_string(S, _, _, _, 'grouped.entry(target)'),
+        sub_string(S, _, _, _, 'grouped.entry(target.clone())'),
         sub_string(S, _, _, _, 'vm.finish_foreign_results("grouped_min_semantic_dist/3", vec![a2.clone(), a3.clone()], packed_results)')
     ->  pass(Test)
     ;   fail_test(Test, 'Grouped weighted aggregate wrapper did not delegate correctly')
@@ -947,7 +947,7 @@ test_grouped_astar_min_aggregate_wrapper :-
         sub_string(S, _, _, _, 'use std::collections::BTreeMap;'),
         sub_string(S, _, _, _, 'register_foreign_result_layout("grouped_min_semantic_dist_astar/4", "tuple:2")'),
         sub_string(S, _, _, _, 'register_foreign_native_kind("astar_weighted_path/4", "astar_shortest_path4")'),
-        sub_string(S, _, _, _, 'grouped.entry(target)'),
+        sub_string(S, _, _, _, 'grouped.entry(target.clone())'),
         sub_string(S, _, _, _, 'vm.finish_foreign_results("grouped_min_semantic_dist_astar/4", vec![a2.clone(), a4.clone()], packed_results)')
     ->  pass(Test)
     ;   fail_test(Test, 'Grouped A* aggregate wrapper did not delegate correctly')


### PR DESCRIPTION
## Summary

This PR continues the Rust WAM foreign-wrapper refactor by routing scalar, grouped, and stream wrapper traversal through shared terminal/traversal helpers.

It completes the next cleanup layer after the aggregate wrapper plan work: terminal emission is now shared across scalar min, grouped min, and stream modes, and wrapper lowering can select traversal behavior by terminal mode instead of each shell manually constructing its own terminal loop body.

## What Changed

- Added shared scalar min terminal traversal for zero-join and joined aggregate wrappers.
- Added shared grouped min traversal emission for zero-join and joined aggregate wrappers.
- Introduced `rust_foreign_wrapper_traversal_code/10` as a mode-based traversal entry point for:
  - `stream`
  - `scalar_min`
  - `grouped_min`
- Routed stream, scalar aggregate, and grouped aggregate wrapper lowering through the shared traversal entry point.
- Updated target assertions for the grouped aggregate zero-join case now that shared grouped terminal emission consistently clones the group key.

## Why

The Rust WAM foreign-wrapper path has been moving toward a declarative wrapper-plan emitter. This PR reduces the remaining duplication in terminal/traversal emission so the next step can focus on moving `filter(...)` and `compute(...)` ownership into a fuller recursive wrapper-plan stage emitter.

This keeps the hybrid WAM path pragmatic: high-level Prolog wrapper patterns are still detected in Prolog, but hot recursive/aggregate execution paths are lowered into native Rust foreign kernels and shared wrapper traversal code.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`

Both suites passed locally on Termux/Samsung S24+.

## Notes

Existing Prolog warnings about predicate ordering and singleton variables are unchanged by this PR.

Recommended next step after merge: introduce a fuller recursive wrapper-plan stage emitter that owns source kernel execution, join stages, filter stages, compute stages, and terminal selection through the shared traversal mode entry point.
