### PR TITLE
feat(wat): WAM-to-WAT hybrid transpilation target (Phases 0-3)

### DIFF
--- a/docs/design/WAM_TERM_BUILTINS_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_TERM_BUILTINS_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,409 @@
+# WAM Term Builtins: Implementation Plan
+
+This document records the phased rollout plan for adding the four Group A
+term inspection builtins (`functor/3`, `arg/3`, `=../2`, `copy_term/2`) to
+the WAM target layer and the three hybrid backends.
+
+For the *why*, see `WAM_TERM_BUILTINS_PHILOSOPHY.md`. For the *what*, see
+`WAM_TERM_BUILTINS_SPECIFICATION.md`.
+
+The plan is structured to **fail fast** if the underlying hypothesis — that
+these builtins are load-bearing for transpiling reach and possibly for
+performance — turns out to be wrong. Phase 0 validates the premise before
+any runtime code is written. Phase 2 implements in one target only before
+committing to a multi-target rollout. Phase 6 explicitly tests the perf
+hypothesis and is willing to report a negative result.
+
+## 0. Starting point
+
+As of 2026-04-10, none of the three hybrid WAM targets (WAM-WAT, WAM-Rust,
+WAM-Haskell) implements any of `functor/3`, `arg/3`, `=../2`, `copy_term/2`,
+`assert/1`, `retract/1`. The canonical `is_builtin_pred/2` table in
+`wam_target.pl:606-619` does not list them either, which means predicates
+using them currently emit `call` to a non-existent predicate and fail at
+the WAM-generation layer (or fall through to host SWI-Prolog interop, the
+slowest path).
+
+The three most recent WAM targets' builtin sets are nearly identical:
+cut, arithmetic, type checks, `\+/1`, list operations, I/O. Rust's
+`category_ancestor` performance does *not* come from term inspection; it
+comes from specialized WAM instructions bypassing the general dispatch.
+
+## Phase 0 — Audit the premise
+
+**Goal:** Before any runtime code is written, confirm that Group A builtins
+are actually load-bearing for any Prolog code we care about.
+
+**Tasks:**
+
+1. Grep the full test corpus (`tests/`, `examples/`, any sample Prolog in
+   `docs/`) for literal uses of `functor(`, `arg(`, `=..`, `copy_term(`.
+2. For each hit, classify:
+   - Is it in **generated** code (e.g. `wam_target.pl` uses `=..` internally
+     for goal decomposition at compile time — not relevant)?
+   - Is it in a **test predicate** that exercises Prolog-level features?
+   - Is it in an **example** of user-facing Prolog that UnifyWeaver is
+     supposed to transpile?
+3. For each user-facing hit, determine what happens today: does the test
+   pass via host SWI fallback? Does it skip? Does it error?
+4. Write up findings in a short note, tentatively placed at
+   `docs/design/WAM_TERM_BUILTINS_PHASE_0_AUDIT.md`, covering:
+   - Total hits, classified
+   - Which predicates are actively blocked on this feature
+   - Whether the transpiling-reach argument survives first contact with
+     the test corpus
+
+**Exit criterion:** Either (a) at least one user-facing predicate is
+demonstrably blocked by the gap, justifying Phases 1–6, or (b) the corpus
+shows no real demand, in which case the plan is either shelved or narrowed
+to "future-proofing only, lowest priority."
+
+**Deliverable:** 1 commit — the audit note. No code changes.
+
+## Phase 1 — Canonical WAM layer
+
+**Goal:** Teach the WAM compiler (`wam_target.pl`) to recognize the four
+builtins so it emits `builtin_call functor/3, 3` etc. instead of a `call`
+to a non-existent predicate. No backend yet handles the new IDs; calls
+will fail loudly at runtime with "unknown builtin", which is correct
+intermediate behavior.
+
+**Tasks:**
+
+1. Extend `is_builtin_pred/2` in `wam_target.pl` (around line 619) with:
+   ```prolog
+   is_builtin_pred(functor, 3).
+   is_builtin_pred(arg, 3).
+   is_builtin_pred((=..), 2).
+   is_builtin_pred(copy_term, 2).
+   ```
+2. Verify: run the existing test suite. Nothing should regress — the only
+   change is that previously-unknown builtins now compile to `builtin_call`
+   instructions, which backends will refuse with "unknown builtin ID" at
+   runtime.
+3. Decide whether any currently-passing tests now *fail* because a
+   predicate was silently doing something wrong (e.g. routing to host
+   SWI) and is now routed to a backend that doesn't support it. If so,
+   mark those tests pending on Phase 2+ completion.
+
+**Exit criterion:** `is_builtin_pred/2` lists all four; existing tests
+either pass or are marked pending with a clear reason.
+
+**Deliverable:** 1 commit — the `is_builtin_pred/2` extension plus a note
+in the commit message about any tests that moved to pending.
+
+## Phase 2 — WAM-WAT implementation (smallest blast radius)
+
+**Goal:** Implement all four builtins in WAM-WAT first. This target has
+the most context from recent work (PR #1224), the fewest downstream
+consumers, and the simplest test surface (codegen assertions only, no
+end-to-end execution yet — that comes in Phase 3).
+
+The implementation order matches difficulty: start with the easiest,
+build confidence, then tackle `copy_term`.
+
+### 2.1 `arg/3` (easiest)
+
+`arg(+N, +T, ?A)` is O(1) heap access — read the Nth argument cell of a
+compound.
+
+**Tasks:**
+
+1. Add `builtin_id('arg/3', 19).` to `wam_wat_target.pl`
+2. Add `$builtin_arg` helper to `compile_wam_helpers_to_wat/2`:
+   - Read A1 (N), A2 (T), A3 (A) via `$get_reg_*`
+   - Dereference
+   - If T is not compound, return 0 (fail)
+   - If N is out of range, return 0
+   - Load the Nth argument cell from T's heap offset
+   - Unify with A via `$unify_regs` (or direct set if A is unbound)
+3. Add case `18` to `$execute_builtin` dispatch
+4. Add a generation test: compile `test :- arg(2, foo(a,b,c), X), X == b.`,
+   assert the emitted `.wat` contains `$builtin_arg`
+5. Commit.
+
+**Deliverable:** 1 commit.
+
+### 2.2 `functor/3`
+
+Both modes — read and construct. Read mode is trivial; construct mode
+needs heap allocation for the fresh arg cells.
+
+**Tasks:**
+
+1. Add `builtin_id('functor/3', 18).`
+2. Add `$builtin_functor`:
+   - Read A1 (T), A2 (N), A3 (A), deref
+   - Branch on `T`'s tag: if unbound → construct mode, else read mode
+   - Read mode: extract name and arity, unify into A2 and A3
+   - Construct mode: N must be atomic, A must be a non-negative integer
+     - If A = 0: bind T to N
+     - Else: allocate compound header + A fresh unbound cells on the heap
+       via `$heap_alloc`, bind T to the compound
+3. Add dispatch case
+4. Add generation tests for both modes (read + construct)
+5. Commit.
+
+**Deliverable:** 1 commit.
+
+### 2.3 `=../2` (univ)
+
+Both modes. Decompose uses `functor/3` + `arg/3` patterns internally.
+Compose uses `functor/3` construct mode + iterative unification of args
+from a list.
+
+**Tasks:**
+
+1. Add `builtin_id('=../2', 20).`
+2. Add `$builtin_univ`:
+   - Decompose: walk T, emit `[F, a1, ..., an]` as a list on the heap,
+     bind to L
+   - Compose: walk L, extract head (functor) and remaining args, call
+     into the same construct-compound logic used by `$builtin_functor`
+3. Dispatch case 20
+4. Generation tests for both modes
+5. Commit.
+
+**Deliverable:** 1 commit.
+
+### 2.4 `copy_term/2` (hardest)
+
+The only builtin that needs a scratch var map. Implementation follows
+§3.1.1 of the spec.
+
+**Tasks:**
+
+1. Add `builtin_id('copy_term/2', 21).`
+2. Reserve a 64-entry scratch area in the WAM state layout for the var
+   map (update `wam_state.wat.mustache` and the state-base constants)
+3. Add `$builtin_copy_term`:
+   - Initialize the scratch var map
+   - Push A1's heap offset onto a work stack (reuse env/choice stack area)
+   - Iterate: pop, copy the cell (with var-map lookup for Unbound/Ref
+     cases), push child offsets for Compound/List
+   - Bind A2 to the root of the copied term
+4. Dispatch case 21
+5. Generation tests **including the sharing test** — this is the single
+   most important test. Compile `test :- copy_term(f(X,X), C), C = f(A,B),
+   A == B.` and verify generation.
+6. Commit.
+
+**Deliverable:** 1 commit.
+
+**Exit criterion for Phase 2:** All four builtins have WAM-WAT helpers
+and generation tests. The `.wat` files parse with `wat2wasm`. No runtime
+execution is validated yet — that is Phase 3's job.
+
+## Phase 3 — WAM-WAT functional execution test harness
+
+**Goal:** Stand up the first-ever functional execution test for WAM-WAT,
+so Phase 2's builtins can be validated against actual runtime behavior
+(not just codegen shape). This phase is also the prerequisite for the
+functional-test follow-up identified in the previous conversation, and
+doing it here amortizes the infrastructure cost across both workstreams.
+
+**Tasks:**
+
+1. Verify `wat2wasm` and `wasmtime` (or equivalent) are available in the
+   Termux environment. If not, document the requirement and skip this
+   phase with tests marked pending.
+2. Add a `record_result(reg, tag, payload)` host import to the WAT module
+   template (`module.wat.mustache`) and the state initialization code.
+3. Write a Prolog helper `run_wam_wat_module/3` that:
+   - Takes a predicate and test input
+   - Generates the `.wat`, compiles with `wat2wasm`
+   - Runs the `.wasm` via `wasmtime` with the `record_result` host import
+     connected to a temp file
+   - Reads back the results and returns them to the test
+4. Write functional tests for each Phase 2 builtin:
+   - `test_functor_read_runtime` — compile + run, assert the recorded output
+   - `test_functor_construct_runtime`
+   - `test_arg_runtime`
+   - `test_univ_decompose_runtime` and `test_univ_compose_runtime`
+   - `test_copy_term_ground_runtime`
+   - `test_copy_term_sharing_runtime` — the critical one
+5. Commit per-builtin as tests come online.
+
+**Exit criterion:** At least one functional test per builtin passes
+end-to-end. The `copy_term` sharing test explicitly passes.
+
+**Deliverable:** 3–5 commits — harness infrastructure + per-builtin
+runtime tests.
+
+**Risk:** If `wasmtime` is not available in Termux or the harness hits
+subtle WAT codegen bugs that were masked by "parses with wat2wasm", this
+phase could balloon. Budget for 1–2 debugging commits fixing real WAM-WAT
+runtime bugs surfaced by the new tests. This is a *good* outcome — it is
+exactly the reason to have functional tests at all.
+
+## Phase 4 — Port to WAM-Rust
+
+**Goal:** Same four builtins in the Rust backend. The Rust target already
+has functional execution tests (`test_wam_rust_runtime.pl`), so validation
+is easier than WAM-WAT.
+
+**Tasks:**
+
+1. Add `arg/3`, `functor/3`, `=../2`, `copy_term/2` handlers to the WAM
+   interpreter loop in `wam_rust_target.pl` (around line 195)
+2. Extend `Value` impl in `templates/targets/rust_wam/value.rs.mustache`
+   with any missing helpers (likely `functor_and_arity()` and a
+   `copy_fresh(&mut VarIdSource, &mut HashMap<VarId, VarId>)` method)
+3. Add integration tests to `test_wam_rust_runtime.pl` that compile a
+   predicate using each builtin, invoke via `cargo test`, assert on bindings
+4. Include the `copy_term` sharing test
+5. Commit per-builtin or bundle — Rust tends to be clean enough to bundle
+
+**Exit criterion:** All four builtins work in Rust end-to-end via
+`cargo test`.
+
+**Deliverable:** 2–3 commits.
+
+## Phase 5 — Port to WAM-Haskell
+
+**Goal:** Same four builtins in the Haskell backend.
+
+**Tasks:**
+
+1. Add cases to the builtin dispatch in `wam_haskell_target.pl`'s inline
+   Haskell code generator (around line 195–245)
+2. Leverage Haskell's pattern matching and persistent data structures —
+   `functor/3`, `arg/3`, `=../2` should each be a few lines of generated
+   Haskell
+3. `copy_term` uses `IntMap` as the var map, state-threaded through the
+   recursive walker
+4. Add codegen tests to `test_haskell_target.pl` (string-presence
+   assertions, matching the existing Haskell test style — no execution)
+5. Commit per-builtin or bundle
+
+**Exit criterion:** All four builtins are emitted in the generated
+Haskell for test predicates. Codegen tests pass.
+
+**Note:** Haskell does not get functional execution tests as part of this
+plan. That gap is not this plan's responsibility — it is a known
+architectural asymmetry (Haskell tests are syntactic, Rust tests are
+functional). Adding Haskell functional tests is a separate, larger
+workstream.
+
+**Deliverable:** 1–2 commits.
+
+## Phase 6 — Perf investigation
+
+**Goal:** Test the performance hypothesis from the philosophy doc with a
+real predicate and a real measurement. Be willing to report a negative
+result honestly.
+
+**Tasks:**
+
+1. Identify a predicate (from the Phase 0 audit, or construct one) that
+   currently falls back to host SWI-Prolog interop because it uses one
+   of the new builtins. Something in the neighborhood of:
+   - A small meta-interpreter that uses `=..` and `call`
+   - A term-walker that uses `functor` + `arg`
+   - A memo predicate that uses `copy_term`
+2. Establish a baseline: measure wall time on host SWI interop
+3. Measure: wall time when the same predicate runs through each of
+   WAM-Rust, WAM-Haskell, WAM-WAT using the new builtins
+4. Compare. Four outcomes are all acceptable:
+   - **Clear win**: native builtin is significantly faster than host
+     interop. Write up and move the predicate class to the "definitely
+     transpile via WAM" list.
+   - **Modest win**: native is faster but not dramatically so. Document
+     the factor and the workload characteristics.
+   - **No measurable difference**: host interop was fine all along for
+     this workload. Document that the transpiling-reach argument is the
+     sole justification.
+   - **Native is slower**: unlikely but possible (e.g., if the predicate
+     is dominated by a fast-path in SWI that the WAM reimplements
+     inefficiently). Investigate the hot spot, decide whether it's
+     fixable within this plan or requires a follow-up.
+5. Write up results in a new `docs/design/WAM_TERM_BUILTINS_PHASE_6_PERF.md`
+   (mirroring the structure of the wam-haskell perf implementation plan
+   retrospectives).
+
+**Exit criterion:** A written perf writeup with numbers, regardless of
+whether the numbers are flattering. A negative result is a valid outcome.
+
+**Deliverable:** 1–2 commits — benchmark harness additions + the writeup.
+
+## Phase sequencing summary
+
+| Phase | Content                                        | Est. commits | Blocks next? |
+|-------|------------------------------------------------|-------------|--------------|
+| 0     | Audit: are these builtins actually needed?     | 1           | Yes          |
+| 1     | Canonical WAM layer (`is_builtin_pred/2`)      | 1           | Yes          |
+| 2     | WAM-WAT implementation (4 builtins)            | 4           | No (3 runs in parallel) |
+| 3     | WAM-WAT functional test harness                | 3–5         | No           |
+| 4     | WAM-Rust port                                  | 2–3         | No           |
+| 5     | WAM-Haskell port                               | 1–2         | No           |
+| 6     | Perf investigation + writeup                   | 1–2         | — (terminal) |
+
+**Total:** ~13–18 commits across ~5 PRs.
+
+**Suggested PR grouping:**
+
+- **PR 1:** Phase 0 + Phase 1 — audit note + `is_builtin_pred/2` extension.
+  Small, low-risk, establishes the workstream.
+- **PR 2:** Phase 2 — WAM-WAT codegen for all four builtins.
+- **PR 3:** Phase 3 — WAM-WAT functional test harness + runtime validation.
+  This is where real runtime bugs may surface.
+- **PR 4:** Phase 4 + Phase 5 — WAM-Rust and WAM-Haskell ports. Could be
+  split into two PRs if the Rust change is large.
+- **PR 5:** Phase 6 — perf writeup.
+
+Phase 3 runs in parallel with Phase 2 only if the functional harness is
+designed independently of specific builtins. In practice, because Phase 3
+depends on having Phase 2 code to execute, sequential is cleaner.
+
+## Risks and open questions
+
+### Risk: Phase 0 finds no real demand
+
+If the audit shows no test predicates currently use these builtins, the
+transpiling-reach argument becomes speculative. Two responses:
+
+1. **Shelve the plan** — document the finding, revisit when a real demand
+   appears.
+2. **Construct demand** — write a new example that demonstrates where the
+   gap bites (e.g., a tiny meta-interpreter that can't currently be
+   transpiled), and use that as the justification.
+
+The philosophy doc leans toward option 2 if the gap is small, and
+option 1 if the audit is genuinely bare.
+
+### Risk: `copy_term` sharing bug
+
+The most likely source of silent correctness failure across all three
+backends. The fix for this risk is in the spec: the sharing test
+(`test_copy_term_sharing`) is mandatory and runs in every backend that
+has functional tests. Rust's test harness makes it easy. WAM-WAT's new
+harness (Phase 3) must include it. Haskell only gets codegen verification,
+which is weaker — explicitly note this in the per-builtin commit.
+
+### Risk: WAM-WAT functional harness balloons
+
+Phase 3 is the most speculative part of the plan. If `wasmtime` isn't
+available in the test environment, or if subtle runtime bugs in the
+existing WAM-WAT code surface under real execution, Phase 3 could grow
+significantly. **Budget for it.** If it blocks progress, split off the
+harness work as its own PR and continue Phases 4–5 using codegen-only
+tests for WAM-WAT.
+
+### Open question: arity limit
+
+The WAM-WAT spec assumes `A1-A32` as argument registers. `functor/3`
+construct mode with `A > 32` is an edge case. For v1, document the limit
+and fail on over-sized compounds. Real code rarely needs arity > 8.
+
+### Open question: scratch var map size
+
+The spec fixes the `copy_term` scratch var map at 64 entries. For most
+realistic terms this is sufficient. If a test predicate needs more, the
+easy fix is to double the constant. The long-term fix is to grow the
+scratch area dynamically, which is a Phase-7+ refinement.
+
+### Open question: should `assert`/`retract` be scoped in?
+
+Explicitly no. Group B (dynamic database) is architecturally different
+(mutable clause store, dispatch plumbing, indexing) and deserves its own
+philosophy/spec/plan triple. Noted in the spec as deferred.

--- a/docs/design/WAM_TERM_BUILTINS_PHASE_0_AUDIT.md
+++ b/docs/design/WAM_TERM_BUILTINS_PHASE_0_AUDIT.md
@@ -1,0 +1,199 @@
+# WAM Term Builtins: Phase 0 Audit
+
+**Date:** 2026-04-10
+**Status:** Complete
+**Branch:** `feat/wam-term-builtins`
+
+This note records the findings of the Phase 0 audit described in
+`WAM_TERM_BUILTINS_IMPLEMENTATION_PLAN.md`. The goal was to determine
+whether any user-facing Prolog predicate in the repository currently
+needs `functor/3`, `arg/3`, `=../2`, or `copy_term/2` to be transpilable,
+and whether to proceed with Phases 1–6.
+
+## Methodology
+
+Searched every `.pl` file under `tests/`, `examples/`, `docs/`, and
+`src/` for literal uses of the four builtins:
+
+```
+grep -rn 'functor(\|copy_term(\|=\.\.' <path>
+grep -rn '\barg(' <path>
+```
+
+For each hit, classified as one of:
+
+- **(H) Host-side harness**: runs inside SWI-Prolog at test time, not
+  transpiled. Includes test goal construction, assertions about term
+  shape, test-runner plumbing.
+- **(C) Compile-time infrastructure**: part of UnifyWeaver's compilation
+  machinery itself, runs in SWI at build time when transpiling. Not a
+  transpiled predicate.
+- **(U) User-facing transpiled predicate**: a Prolog predicate passed as
+  input to `write_wam_*_project` / `compile_predicate_to_wam`. These are
+  the ones that matter for the hypothesis.
+
+## Findings
+
+### Category H — host-side test harness (all hits)
+
+All five files with hits in `tests/` are in this category:
+
+| File | Builtin usage |
+|------|---------------|
+| `tests/core/test_csharp_query_target.pl` | 24x `=..` building test Head/Body terms to pass to the compiler |
+| `tests/core/test_prolog_target.pl` | 9x `=..` building `Goal` terms for `call/1` test runners |
+| `tests/core/test_semantic_dispatch.pl` | 4x `=..` destructuring goal wrappers in test dispatcher |
+| `tests/integration/glue/test_visualization_glue.pl` | 1x `copy_term(Goal, FreshGoal)` for test isolation |
+| `tests/test_go_goal_parallel.pl` | 1x `assertion(functor(Head, p, 2))` for term-shape check |
+
+None of these are transpiled. They all run inside SWI-Prolog as part of
+the test framework. The builtins here are supplied by SWI natively and
+are used to construct/inspect Prolog terms that will then be handed off
+to the WAM compiler — the compiler sees the *result* of `=..`, not the
+`=..` call itself.
+
+### Category C — compile-time infrastructure
+
+Many files under `src/unifyweaver/` use these builtins (confirmed via
+`grep -rln 'functor(\|copy_term(\|=\.\.' src/ --include='*.pl'`). All
+sampled files fall into this category:
+
+- `src/unifyweaver/targets/wam_target.pl` uses `=..` at line 609 to
+  construct a mock goal for `is_guard_goal/2` — compile-time only
+- `src/unifyweaver/targets/wam_target.pl` lines 52, 133, 144, 153, etc.
+  use `functor/3` and `=..` to destructure user clause heads during
+  compilation
+- `src/unifyweaver/core/advanced/*.pl` pattern matchers and clause-body
+  analyzers — compile-time term walking
+- `src/unifyweaver/bindings/*_wam_bindings.pl` — compile-time target
+  dispatch
+
+These are the Prolog meta-programming idioms that UnifyWeaver itself is
+built on. They run in SWI at build time; they are not transpiled.
+
+### Category U — user-facing transpiled predicates
+
+**Zero hits.**
+
+The predicates that actually get compiled to WAM in the existing test
+suites are all structural recursion patterns:
+
+- `tc_ancestor/2`, `tc_descendant/2` — transitive closure
+- `tc_distance/3`, `tc_parent_distance/4` — depth-bounded closure
+- `tri_sum/2` — arithmetic accumulator recursion
+- `tail_suffix/2`, `tail_suffixes/2` — list tail extraction
+- `weighted_path/3`, `astar_weighted_path/4` — A* with weighted edges
+- `min_semantic_dist/3`, `grouped_min_semantic_dist/3`,
+  `filtered_adjusted_min_semantic_dist/3` — aggregate kernels
+
+None of these use `functor/3`, `arg/3`, `=../2`, or `copy_term/2`. They
+all work by clause-head pattern matching, which is the WAM's native
+operation and requires no term introspection builtins.
+
+### Indirect evidence from target specs
+
+Two existing target specification docs already list `=../2` in their
+intended builtin mapping tables, but neither actually implements it:
+
+- `docs/design/WAM_GO_TRANSPILATION_SPECIFICATION.md:237` —
+  `` `=../2` (univ) | `Compound` construction/destructure ``
+- `docs/design/WAM_ILASM_TRANSPILATION_SPECIFICATION.md:278` —
+  `` `=../2` (univ) | CompoundValue field access ``
+
+This confirms the gap has been **documented intent** for at least two
+targets, even though no code landed. The gap is known; it just hasn't
+bit anyone hard enough to prioritize.
+
+## Conclusion
+
+The audit finding is **"genuinely bare" for existing code**, but the
+gap is **acknowledged in target specs**. This matches the risk
+contingency described in
+`WAM_TERM_BUILTINS_IMPLEMENTATION_PLAN.md` under "Risk: Phase 0 finds
+no real demand":
+
+> Two responses:
+> 1. **Shelve the plan** — document the finding, revisit when a real
+>    demand appears.
+> 2. **Construct demand** — write a new example that demonstrates where
+>    the gap bites, and use that as the justification.
+
+This plan takes **option 2: construct demand**. The reasoning:
+
+1. **The gap is not hypothetical** — multiple target specs list `=../2`
+   as intended, so the designers of those targets expected it to be
+   implemented.
+2. **The current test corpus is narrow by construction** — UnifyWeaver's
+   existing tests focus on structural recursion patterns because that's
+   what the pattern-matching compiler specializes in. Absence of these
+   builtins in the test suite doesn't mean absence of demand in real
+   Prolog code; it means the test suite hasn't yet tried to transpile
+   anything meta-programming-flavored.
+3. **The implementation cost is bounded** — per the spec, each of the
+   four builtins is a few helpers per target. The Phase 2/4/5 plan is
+   small enough that constructing demand via new test predicates is
+   cheaper than the effort saved by shelving.
+4. **Future-proofing has value** — landing these builtins now means
+   that when a user *does* try to transpile a meta-interpreter, a
+   serializer, or a memo-tabled predicate, it just works.
+
+## Constructed demand: test predicate classes
+
+Phases 2–5 will introduce new test predicates in each target's test
+suite to exercise the builtins. At minimum:
+
+### For `functor/3` and `arg/3`
+```prolog
+% Generic binary tree walker that reports functor + arity + first arg
+walk_term(T, Name, Arity, FirstArg) :-
+    functor(T, Name, Arity),
+    Arity >= 1,
+    arg(1, T, FirstArg).
+```
+
+### For `=../2`
+```prolog
+% Tiny meta-interpreter: runtime goal construction
+invoke(Pred, Args, Result) :-
+    Goal =.. [Pred | Args],
+    call(Goal),
+    Result = ok.
+```
+
+### For `copy_term/2`
+```prolog
+% Freeze a template before unification — the canonical use case
+with_fresh_copy(Template, Result) :-
+    copy_term(Template, Fresh),
+    Fresh = Result.
+
+% The sharing test — critical correctness check
+sharing_test(X) :-
+    copy_term(f(V, V), X).  % X should unify with f(Y, Y), not f(Y, Z)
+```
+
+These will be added to `test_wam_wat_target.pl`, `test_wam_rust_target.pl`,
+and `test_haskell_target.pl` as Phases 2, 4, and 5 come online. Each
+predicate is small enough to serve as both motivation and regression
+test.
+
+## Implications for subsequent phases
+
+- **Phase 1 proceeds as planned** — extend `is_builtin_pred/2`. No
+  regressions are expected because no existing predicate uses these
+  builtins; the change is additive.
+- **Phase 2/4/5 gain a new responsibility**: write the test predicates
+  in `docs/examples/` or inline in test files, so future contributors
+  see what the feature enables.
+- **Phase 6 (perf investigation) becomes harder** — there is no current
+  workload that falls back to host SWI because of these builtins,
+  because there is no current workload that uses them at all. Phase 6
+  will need to construct a synthetic benchmark. The philosophy doc
+  already anticipates a negative result here, and the constructed
+  benchmark should explicitly test the "many small copy_term in a
+  memoization loop" scenario rather than re-running the existing
+  effective-distance benchmark (which won't be affected).
+
+## Decision
+
+**Proceed with Phase 1.**

--- a/docs/design/WAM_TERM_BUILTINS_PHILOSOPHY.md
+++ b/docs/design/WAM_TERM_BUILTINS_PHILOSOPHY.md
@@ -1,0 +1,264 @@
+# WAM Term Builtins: Philosophy
+
+## The question
+
+Three hybrid WAM targets are now in the tree (Rust, Haskell, WAT). All three
+share the same gap: none of them implements `functor/3`, `arg/3`, `=../2`,
+`copy_term/2`, `assert/1`, or `retract/1`. Predicates that use these builtins
+either fail to lower at all, or get pushed to the slowest fallback path
+(host SWI-Prolog interop).
+
+This branch is an **investigation**, not a foregone conclusion. The question
+to answer is:
+
+> Does adding these builtins improve UnifyWeaver in measurable ways — either
+> by **expanding what can be transpiled** (correctness/reach) or by **letting
+> more predicates run on the WAM fast path** (performance) — and if so, which
+> builtins matter and in what order?
+
+The reason this is worth asking carefully is that the existing WAM targets
+have been productive *without* these builtins. The transitive closure /
+recursion patterns UnifyWeaver targets are structural, not meta. They walk
+arguments by clause-head pattern matching, not by calling `arg/3`. They build
+results by unification, not by `=..`. So the gap has not been load-bearing
+*so far*.
+
+The hypothesis this document is built around: the gap **is** load-bearing
+once you step outside the recursion-pattern niche, and a meaningful slice of
+real Prolog code is currently un-transpilable for this reason alone.
+
+## What the existing targets actually do
+
+Both Rust and Haskell hybrid WAMs implement essentially the same builtin set:
+
+- Cut (`!/0`) via cut-barrier truncation
+- Arithmetic (`is/2`, `</2`, `>/2`, `=:=/2`, `=\=/2`, `=</2`, `>=/2`)
+- Type checks (`var/1`, `atom/1`, `integer/1`, etc.)
+- Negation as failure (`\+/1`)
+- A handful of list operations (`length/2`, `member/2`)
+- I/O (`write/1`, `nl/0`)
+
+WAM-WAT matches this set. The four "term inspection" builtins
+(`functor/3`, `arg/3`, `=../2`, `copy_term/2`) are absent everywhere. The two
+"dynamic database" builtins (`assert/1`, `retract/1`) are also absent
+everywhere, but for very different reasons (see "The two categories" below).
+
+How does Rust achieve its impressive `category_ancestor` performance, then?
+Not via term inspection — via **specialized WAM instructions**
+(`BaseCategoryAncestor`, `RecurseCategoryAncestorPc`) that bypass the general
+WAM machinery entirely. That tells us the path to perf wins on specific
+bottlenecks is custom instructions, not generic introspection. Generic
+introspection is for *transpiling reach*.
+
+## The two categories
+
+The six builtins the user named split cleanly into two groups:
+
+### Group A: term inspection (pure functions on heap cells)
+
+- `functor/3` — read or construct a compound's name and arity
+- `arg/3` — random-access into a compound's arguments
+- `=../2` — convert between `f(a,b,c)` and `[f,a,b,c]`
+- `copy_term/2` — fresh-variable copy of a term
+
+These are pure: they read (and possibly allocate fresh) heap cells. They do
+not touch the dynamic database, the trail in interesting ways, or the clause
+store. Their semantics are well-defined and identical across all Prolog
+systems. The implementation is **mechanical** — walk the heap, allocate, bind.
+
+This group is the subject of this plan.
+
+### Group B: dynamic database (stateful, separate workstream)
+
+- `assert/1`, `asserta/1`, `assertz/1`
+- `retract/1`, `retractall/1`
+
+These require something none of the existing targets have: a **runtime-extensible
+clause store**. The current WAM targets compile every predicate to a fixed
+data segment of WAM instructions, indexed by static labels. There is no path
+for new clauses to enter the dispatch table at runtime.
+
+Adding `assert`/`retract` would require:
+
+1. A separate dynamic-predicate dispatch table (per-target)
+2. Decisions about backtracking semantics (standard Prolog: asserts survive
+   backtracking; retracts are undone — but only the *physical* removal, not
+   the *logical* effect)
+3. Re-indexing strategy when clauses are added
+4. A test story for memoization/tabling patterns that motivate the feature
+
+This is a substantially larger workstream than Group A, with its own
+philosophy/spec/plan. **It is out of scope here** and tracked as a follow-up.
+
+## Why Group A matters: the case for transpiling reach
+
+Three classes of Prolog code currently fail to lower because of Group A:
+
+1. **DSL interpreters and rule engines.** Anything that builds a goal at
+   runtime via `Goal =.. [Pred|Args], call(Goal)` cannot be transpiled. This
+   pattern is endemic in business-rule systems, configuration languages, and
+   meta-interpreters.
+
+2. **Generic walkers.** Predicates that operate on "any compound term"
+   without knowing its functor in advance — pretty-printers, serializers,
+   structural diff, generic equality variants — all need `functor/3` and
+   `arg/3` to walk subterms.
+
+3. **Tabling and memoization built on `copy_term`.** When user code
+   implements its own memo table to avoid recomputation, it almost always
+   uses `copy_term` to freeze the key without aliasing the live query
+   variables. Without `copy_term`, the user-level memo silently shares state
+   across iterations and breaks.
+
+Each of these classes is a meaningful slice of real Prolog code. None of
+them are exotic. A "Prolog-to-WASM transpiler" that cannot handle them is
+selling itself short.
+
+## Why Group A matters less for performance (probably)
+
+The honest answer is: **probably not much**, with one possible exception.
+
+The reasoning:
+
+- The hot loops in UnifyWeaver's existing benchmarks (effective semantic
+  distance, transitive closure, A* aggregates) don't use these builtins at
+  all. Adding them won't speed those up.
+- For predicates that *do* use them, the alternative today is "fall back to
+  host SWI-Prolog over an FFI bridge". A native WAM implementation will
+  almost certainly beat that bridge by a wide margin — but only on those
+  predicates. The benchmark needle won't move on existing workloads.
+- The exception is `copy_term/2` in tabling-heavy code. If a predicate
+  currently emulates `copy_term` by re-running unification N times against
+  fresh variables, a native O(N-heap-cells) `copy_term` is asymptotically
+  better. But UnifyWeaver doesn't currently have such a workload to measure.
+
+The conclusion is that the philosophy doc should set expectations honestly:
+**this is a transpiling-reach feature with possible perf upside on specific
+predicates, not a perf optimization**. Phase 6 of the implementation plan
+is dedicated to validating or refuting that more rigorously.
+
+## Why each builtin individually
+
+### `functor/3`
+
+The atomic operation. `arg/3` and `=../2` are both expressible in terms of
+`functor` + heap walks. If only one of the four were to be implemented,
+this would be it. In the WAM, it is essentially "read the tag and arity
+fields of a heap cell" — O(1).
+
+The construct mode (`functor(-T, +N, +A)`) is slightly more interesting:
+it must allocate `A` fresh unbound cells on the heap and tag them as
+arguments of a fresh compound. The implementation pattern already exists
+in the heap allocator paths used by `put_structure`.
+
+### `arg/3`
+
+`arg(+N, +Term, ?A)` is `O(1)` heap access — read the Nth cell after the
+compound header. Trivial once `functor/3` machinery exists.
+
+The reason it gets its own builtin (rather than being expressed as `=..`)
+is that `=..` allocates a list with one cons cell per argument, which is
+wasteful for "I just need the third arg".
+
+### `=../2` (univ)
+
+Decompose mode is `functor/3` + `arg/3` in a loop, building a list. Compose
+mode is `functor/3` build mode + `arg/3` write in a loop.
+
+It's the most syntactically common of the four in user-facing code,
+because `Goal =.. [Pred|Args], call(Goal)` is the canonical Prolog idiom
+for runtime goal construction.
+
+### `copy_term/2`
+
+The hardest of the four. Requires:
+
+- A traversal of the source term
+- A temporary mapping (var-id → fresh-var-id) so that shared variables
+  in the source remain shared in the copy (`copy_term(f(X,X), C)` must
+  give `C = f(Y,Y)`, not `f(Y,Z)`)
+- Heap allocation for every cell of the copy
+
+Persistent-data-structure WAMs (Haskell) and Rc-snapshot WAMs (Rust)
+both handle this cleanly because their underlying value representation
+is already structural. WAT has neither — it has a flat linear-memory
+heap. The `copy_term` helper for WAT will need an explicit work stack
+(same pattern as `$unify_regs`) and a small temporary mapping table
+allocated on the heap.
+
+## Rejected alternatives
+
+### "Implement them in user-level Prolog and let the WAM compile that"
+
+Doesn't work. The four Group A builtins are mutually defining at the
+runtime level — at least one of them must be primitive because they all
+need to inspect heap-cell tags, which user-level Prolog cannot do directly.
+And `copy_term` requires variable freshness, which only the runtime can
+provide (the var counter is not exposed to user code).
+
+### "Skip them and document the gap"
+
+This is what the project does today. The cost is invisible (predicates
+that would have used them simply aren't written, or get rewritten in awkward
+ways) but real. The investigation question is whether that cost is high
+enough to justify the implementation work.
+
+### "Implement them only in WAM-WAT and not in Rust/Haskell"
+
+Tempting (smallest blast radius) but creates a permanent capability
+asymmetry between targets. Better to add them at the canonical WAM layer
+(`is_builtin_pred/2` in `wam_target.pl`) and roll out to all three
+backends, even if WAM-WAT goes first.
+
+### "Add them as specialized WAM instructions, not as `builtin_call`"
+
+This is how Rust handles `category_ancestor`. The performance argument is
+that fixed-register builtin dispatch costs an extra indirection.
+
+For these four, it doesn't matter — they're not on hot paths. The existing
+`builtin_call` pattern is fine, and avoids growing the instruction set.
+Reserve specialized instructions for cases where the perf cost is measured.
+
+### "Add `assert`/`retract` too while we're here"
+
+No. They are a fundamentally different feature (mutable clause store,
+backtracking semantics, re-indexing, dynamic dispatch). Bundling them into
+a "term builtins" PR would conflate two unrelated workstreams and make
+the change much harder to review. They get their own future plan.
+
+## Experiment-first stance
+
+The implementation plan is structured to **fail fast** if the hypothesis is
+wrong:
+
+- **Phase 0** is a one-pass audit of the existing test corpus. If no test
+  predicate uses these builtins, the transpiling-reach claim is weakened
+  and we should reconsider.
+- **Phase 2** implements in WAM-WAT only. If codegen is harder than expected
+  or the runtime cost is surprising, we stop there and reconsider before
+  porting to Rust/Haskell.
+- **Phase 6** is an explicit perf comparison: pick one predicate that
+  currently falls back to host SWI for using these builtins, re-benchmark
+  with the WAM-only path, and write up the result honestly — even if it
+  shows no improvement.
+
+If Phase 6 says "no perf win, modest reach win", that is still a successful
+outcome — it bounds the claim and tells future contributors what to expect.
+
+## What "good enough" looks like
+
+A successful term-builtins workstream means:
+
+1. The four Group A builtins are implemented in WAM-WAT, Rust, and Haskell
+2. The canonical `is_builtin_pred/2` in `wam_target.pl` lists them
+3. There is at least one Prolog predicate per builtin that previously could
+   not be transpiled and now can
+4. Either: (a) a measured perf improvement on at least one predicate, or
+   (b) a documented finding that no perf improvement was achievable on the
+   existing benchmark suite, with the predicate-class examples that *would*
+   benefit identified for future work
+5. `assert`/`retract` are clearly tracked as separate follow-up work, with
+   a stub design doc identifying the architectural questions
+
+The success criterion is **honesty** about what was unlocked, not raw
+benchmark numbers.

--- a/docs/design/WAM_TERM_BUILTINS_SPECIFICATION.md
+++ b/docs/design/WAM_TERM_BUILTINS_SPECIFICATION.md
@@ -1,0 +1,411 @@
+# WAM Term Builtins: Specification
+
+This document describes the technical shape of adding the four Group A term
+inspection builtins — `functor/3`, `arg/3`, `=../2`, `copy_term/2` — to the
+WAM target layer and the three hybrid backends (WAM-WAT, WAM-Rust, WAM-Haskell).
+
+For the *why* of each decision, see `WAM_TERM_BUILTINS_PHILOSOPHY.md`. For
+the phased rollout order, see `WAM_TERM_BUILTINS_IMPLEMENTATION_PLAN.md`.
+
+`assert`/`retract` (Group B) are explicitly out of scope; they are tracked
+separately because they require runtime-extensible clause storage, which is
+an architectural change the three pure term-inspection builtins do not need.
+
+## 1. Semantics
+
+The semantics below mirror ISO Prolog plus SWI-Prolog conventions where the
+standard leaves room. Error reporting is deliberately minimal in the v1
+implementation (see §1.5) — we aim for correct behavior on well-formed
+inputs first and defer full ISO error terms.
+
+### 1.1 `functor/3`
+
+Two modes:
+
+**Read mode** `functor(+T, ?N, ?A)`
+- `T` is instantiated (not an unbound variable)
+- Binds `N` to the functor name, `A` to the arity
+- For compound `T = f(a1,...,an)`: `N = f`, `A = n`
+- For atom `T = foo`: `N = foo`, `A = 0`
+- For integer `T = 42`: `N = 42`, `A = 0`
+- For float `T = 3.14`: `N = 3.14`, `A = 0`
+
+**Construct mode** `functor(-T, +N, +A)`
+- `T` is unbound; `N` is an atom (or number, for arity-0); `A` is a
+  non-negative integer
+- If `A = 0`: `T` is bound to `N` itself
+- If `A > 0`: `T` is bound to a fresh compound `N(_1,_2,...,_A)` with
+  `A` fresh unbound argument cells
+
+### 1.2 `arg/3`
+
+`arg(+N, +T, ?A)`
+- `N` is a positive integer
+- `T` is a compound term with arity ≥ N
+- Unifies `A` with the Nth argument of `T` (1-indexed)
+
+### 1.3 `=../2` (univ)
+
+**Decompose mode** `=..(+T, ?L)`
+- `T` is instantiated
+- For compound `T = f(a1,...,an)`: `L = [f, a1, ..., an]`
+- For atomic `T = a`: `L = [a]`
+
+**Compose mode** `=..(-T, +L)`
+- `L` is a proper list `[F | Args]`
+- If `Args = []`: `T` is bound to `F` (where `F` must be atomic)
+- Otherwise: `F` must be an atom, and `T` is bound to the fresh compound
+  `F(a1,...,an)` where the `ai` unify with the elements of `Args`
+
+### 1.4 `copy_term/2`
+
+`copy_term(+T, -Copy)`
+- `T` may be any term (ground or with free variables)
+- `Copy` is a structurally identical term in which every unbound variable
+  of `T` has been replaced by a fresh unbound variable
+- **Sharing is preserved within the copy**: if two positions in `T` share a
+  variable, the corresponding positions in `Copy` share the *same* fresh
+  variable. `copy_term(f(X,X), C)` gives `C = f(Y,Y)`, not `C = f(Y,Z)`.
+- No attributed variables. The current WAM targets do not support them, and
+  this spec does not introduce them.
+
+### 1.5 Error handling (v1)
+
+The v1 implementation is permissive:
+
+- Type errors (non-atom in `functor/3` construct mode, non-integer in
+  `arg/3`, etc.) produce `fail`, not ISO error terms
+- Out-of-range errors (`arg(5, f(a,b), X)`) produce `fail`
+- Mode errors (`functor(-T, -N, -A)`) produce `fail`
+
+This matches how the existing `is/2` and arithmetic comparisons currently
+handle errors in the WAM targets (silent fail on bad inputs). A follow-up
+can add ISO-compliant error terms uniformly across all builtins.
+
+## 2. WAM-level encoding
+
+The four builtins are encoded as `builtin_call` instructions with new
+builtin IDs, following the existing pattern in `wam_wat_target.pl:89-106`.
+Arguments are passed in fixed registers `A1`, `A2`, `A3`. Output bindings
+are written back to the same argument registers (the caller is responsible
+for having placed input values there and for reading output values back).
+
+### 2.1 Builtin ID extension
+
+Extend the builtin ID table in each target:
+
+```prolog
+%% Existing (wam_wat_target.pl:89-106)
+builtin_id('write/1',  0).
+builtin_id('nl/0',     1).
+builtin_id('is/2',     2).
+builtin_id('=:=/2',    3).
+builtin_id('=\\=/2',   4).
+builtin_id('</2',      5).
+builtin_id('>/2',      6).
+builtin_id('=</2',     7).
+builtin_id('>=/2',     8).
+builtin_id('var/1',    9).
+builtin_id('nonvar/1', 10).
+builtin_id('atom/1',   11).
+builtin_id('integer/1', 12).
+builtin_id('float/1',  13).
+builtin_id('number/1', 14).
+builtin_id('true/0',   15).
+builtin_id('fail/0',   16).
+builtin_id('!/0',      17).
+
+%% New
+builtin_id('functor/3',    18).
+builtin_id('arg/3',        19).
+builtin_id('=../2',        20).
+builtin_id('copy_term/2',  21).
+```
+
+The same four IDs (18–21) are used in all three backends for consistency.
+Each backend's `$execute_builtin` (or equivalent) gets four new cases.
+
+### 2.2 Register conventions
+
+| Builtin       | A1 (in/out)   | A2 (in/out)       | A3 (in/out) |
+|---------------|---------------|-------------------|-------------|
+| `functor/3`   | `T` in/out    | `N` in/out        | `A` in/out  |
+| `arg/3`       | `N` in        | `T` in            | `A` in/out  |
+| `=../2`       | `T` in/out    | `L` in/out        | —           |
+| `copy_term/2` | `T` in        | `Copy` out        | —           |
+
+The "in/out" distinction is runtime-determined: the builtin implementation
+inspects each register's tag to decide mode. An `Unbound` input means
+"output position"; anything else means "input position".
+
+### 2.3 Canonical WAM layer change
+
+Add to `wam_target.pl` around line 619:
+
+```prolog
+is_builtin_pred(functor, 3).
+is_builtin_pred(arg, 3).
+is_builtin_pred((=..), 2).
+is_builtin_pred(copy_term, 2).
+```
+
+After this change, any user predicate that calls `functor/3` etc. will be
+compiled to a `builtin_call functor/3, 3` instruction instead of a regular
+`call` to a non-existent predicate. Predicates that were previously
+unlowerable now emit valid WAM; they still fail at runtime until a backend
+implements the new builtin IDs.
+
+## 3. Per-target implementation requirements
+
+### 3.1 WAM-WAT (`src/unifyweaver/targets/wam_wat_target.pl`, `templates/targets/wat_wam/`)
+
+Four new WAT helper functions are added to `compile_wam_helpers_to_wat/2`:
+
+- `$builtin_functor` (no params, returns i32 success/fail)
+- `$builtin_arg`
+- `$builtin_univ`
+- `$builtin_copy_term`
+
+Each helper:
+
+1. Reads `A1`, `A2`, `A3` from the register file via `$get_reg_tag`/`$get_reg_payload`
+2. Dereferences via `$deref`
+3. Branches on the input mode (unbound output vs instantiated input)
+4. Performs the operation against the heap
+5. Writes results via `$set_reg` and uses `$trail_binding` for any
+   bindings created on existing variables
+6. Returns `1` on success, `0` on failure (triggers backtrack via `$run_loop`)
+
+Dispatch in `$execute_builtin`:
+
+```wat
+;; ... existing cases 0–17 ...
+(i32.eq (local.get $id) (i32.const 18))
+  (if (result i32) (then (return (call $builtin_functor))))
+(i32.eq (local.get $id) (i32.const 19))
+  (if (result i32) (then (return (call $builtin_arg))))
+(i32.eq (local.get $id) (i32.const 20))
+  (if (result i32) (then (return (call $builtin_univ))))
+(i32.eq (local.get $id) (i32.const 21))
+  (if (result i32) (then (return (call $builtin_copy_term))))
+```
+
+#### 3.1.1 `copy_term` on flat linear memory
+
+This is the only helper with significant complexity. Algorithm:
+
+1. Allocate a small "var map" table on the heap: pairs `(old_var_id, new_var_id)`.
+   Size bound: the number of distinct variables in the source term. For v1,
+   a fixed 64-entry table is sufficient for the test corpus; overflow
+   triggers fail.
+2. Push the source term's heap offset onto a work stack.
+3. While the work stack is non-empty, pop an offset, read its cell:
+   - `Atom`/`Integer`/`Float`: write a matching cell into the destination
+     and continue
+   - `Unbound(id)`: look up `id` in the var map; if present, emit a `Ref`
+     to the mapped new variable; if absent, allocate a fresh unbound
+     variable, add the mapping, emit `Ref` to it
+   - `Compound(functor, arity, arg_offset)`: allocate a fresh compound
+     header at the destination, push each of the `arity` arg offsets
+     onto the work stack (in reverse order, for left-to-right copy)
+   - `List(head_off, tail_off)`: allocate a fresh list cell, push both
+     offsets
+   - `Ref(target)`: follow once and retry
+4. Bind `A2` to the root of the destination.
+
+The work stack reuses the WAM state area — there is already an env/choice
+stack, and `copy_term` can claim a slice of it as scratch.
+
+### 3.2 WAM-Rust (`src/unifyweaver/targets/wam_rust_target.pl`)
+
+The Rust backend is the easiest of the three. It already has a `Value::univ()`
+method (`templates/targets/rust_wam/value.rs.mustache`), a `deref_var`
+helper, and persistent-enough data structures via `Rc<...>` that `copy_term`
+can reuse existing variable-fresh allocation paths.
+
+New builtin handlers go in the instruction interpreter loop where
+`BuiltinCall` is handled (around `wam_rust_target.pl:195-209`):
+
+```rust
+// Builtin 18: functor/3
+18 => {
+    let t = vm.get_reg_deref("A1");
+    let n = vm.get_reg_deref("A2");
+    let a = vm.get_reg_deref("A3");
+    match (t, n, a) {
+        (Value::Unbound(_), n_val, Value::Integer(arity)) => {
+            // Construct mode
+            let fresh = vm.build_skeleton(n_val, arity as usize);
+            vm.bind_reg("A1", fresh);
+            true
+        }
+        (t_val, _, _) => {
+            // Read mode
+            let (name, arity) = t_val.functor_and_arity();
+            vm.bind_reg("A2", name);
+            vm.bind_reg("A3", Value::Integer(arity as i64));
+            true
+        }
+    }
+}
+// ... similar for 19, 20, 21
+```
+
+`copy_term` uses a `HashMap<VarId, VarId>` as the local var map, recursively
+walks the source, and builds a fresh term tree. The existing `Value` enum
+and heap are sufficient.
+
+### 3.3 WAM-Haskell (`src/unifyweaver/targets/wam_haskell_target.pl`)
+
+Haskell has no template directory — all code is generated as inline format
+strings. The four new builtins are added to the builtin dispatch case
+expression (around `wam_haskell_target.pl:195-245`).
+
+Haskell's persistent data structures make `copy_term` the simplest of the
+three implementations:
+
+```haskell
+copyTerm :: Value -> WamM Value
+copyTerm = go IntMap.empty
+  where
+    go m (Unbound i) = case IntMap.lookup i m of
+        Just j  -> return (Unbound j)
+        Nothing -> do
+            j <- freshVar
+            return (Unbound j)  -- sharing handled via returned map
+    go m (Str f args) = Str f <$> mapM (go m) args
+    go _ v = return v  -- Atom, Integer, Float: structural
+```
+
+The real implementation threads the `IntMap` properly (the sketch above
+drops it between recursive calls; the actual code needs a `StateT` or
+explicit map passing).
+
+`functor/3`, `arg/3`, and `=../2` all fall out of Haskell pattern matching
+on the existing `Value` type — implementations are a few lines each.
+
+## 4. Heap and state impact
+
+### 4.1 Heap growth
+
+- `functor/3` construct mode: allocates one compound header + A fresh
+  unbound cells
+- `arg/3`: no heap allocation (just reads)
+- `=../2` decompose mode: allocates one list cell per argument (O(arity))
+- `=../2` compose mode: allocates one compound header + N arg cells
+- `copy_term/2`: O(source-term-heap-cells) for the copy + O(distinct-vars)
+  for the scratch var map
+
+All allocations use the existing heap allocator (`$heap_alloc` in WAT,
+`vm.heap.alloc()` in Rust, pure value construction in Haskell).
+
+### 4.2 Trail impact
+
+Bindings created on existing registers are trailed normally. The only
+interesting case is `copy_term`: the fresh variables in `Copy` are *not*
+trailed — they didn't exist before the call, so there's nothing to restore.
+The scratch var map is also not trailed (it's scoped to the single call).
+
+### 4.3 Choice point impact
+
+None of the four builtins introduce choice points. They are deterministic.
+If a future extension adds nondeterministic `arg/3` (iterate over arguments),
+that would be in scope for a separate plan.
+
+## 5. Test plan shape
+
+Three layers of tests per builtin, per target:
+
+### 5.1 Canonical layer (`tests/test_wam_target.pl` extension)
+
+Verify that a predicate using the builtin produces a WAM instruction stream
+containing `builtin_call functor/3, 3` (or the equivalent). This is the
+cheapest test and catches regressions in `is_builtin_pred/2`.
+
+### 5.2 Per-target codegen test
+
+For each of WAM-WAT, WAM-Rust, WAM-Haskell: compile a predicate using each
+builtin and assert that the generated code contains the expected helper
+call. For WAT this is `sub_string` assertions on the emitted `.wat` text
+(matching the existing `test_wam_wat_target.pl` style). For Rust it's
+`sub_string` assertions on the generated `.rs`. For Haskell, same.
+
+### 5.3 Functional execution test
+
+For WAM-Rust (existing `test_wam_rust_runtime.pl` pattern): compile, run
+via `cargo test`, assert on bindings.
+
+For WAM-WAT (new harness needed, see the functional-test discussion from
+the prior conversation): compile, run via `wat2wasm` + `wasmtime` with a
+`record_result` host import, assert on captured bindings.
+
+For WAM-Haskell: matches the existing Haskell test pattern — codegen
+assertions only, no execution. (This is a known gap in Haskell testing and
+is not this plan's job to fix.)
+
+### 5.4 Specific test predicates
+
+At minimum:
+
+```prolog
+% functor/3 read
+test_functor_read :- functor(foo(1,2,3), F, A), F == foo, A == 3.
+
+% functor/3 construct
+test_functor_construct :- functor(T, bar, 2), T = bar(_, _).
+
+% arg/3
+test_arg :- arg(2, foo(a,b,c), X), X == b.
+
+% =../2 decompose
+test_univ_decompose :- foo(a,b) =.. L, L == [foo, a, b].
+
+% =../2 compose
+test_univ_compose :- T =.. [baz, 1, 2], T == baz(1, 2).
+
+% copy_term: ground input
+test_copy_ground :- copy_term(f(1,2), C), C == f(1,2).
+
+% copy_term: variable sharing preserved
+test_copy_sharing :-
+    copy_term(f(X,X), C),
+    C = f(A,B),
+    A == B.  % <-- the critical assertion
+
+% copy_term: variables are fresh
+test_copy_fresh :-
+    X = hello,
+    copy_term(f(X,Y), C),
+    C = f(hello, Z),
+    var(Z).  % Z must be unbound — not aliased to Y
+```
+
+The `copy_term` sharing test (`test_copy_sharing`) is the single most
+important test in this entire workstream. It is the property most likely
+to be silently broken by an implementation bug, and the symptom is
+correctness corruption rather than a crash.
+
+## 6. Deferred items
+
+### 6.1 Group B — assert/retract
+
+Not in this spec. Requires:
+
+- Runtime-extensible clause store per target
+- Dispatch plumbing that lets `call` find dynamically-added clauses
+- A backtracking-semantics decision (logical vs immediate update view)
+- An indexing strategy for dynamic predicates
+
+These are tracked for a separate `WAM_DYNAMIC_DATABASE_*` doc set.
+
+### 6.2 ISO error terms
+
+The v1 implementation uses silent-fail on malformed inputs. A follow-up can
+introduce a uniform `throw/1`-compatible error path across all builtins.
+This is cross-cutting work and should not be bundled with term builtins.
+
+### 6.3 Nondeterministic `arg/3`
+
+Standard Prolog's `arg/3` is deterministic. A nondeterministic variant that
+iterates over all arguments is useful but non-ISO and introduces a choice
+point. Deferred.

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -502,6 +502,46 @@ executeForeign !ctx "category_ancestor/4" s =
     _ -> Nothing
 executeForeign _ _ _ = Nothing
 
+-- | Bind an output register to a value WITHOUT advancing PC.
+-- Used by term-inspection builtins that need to bind multiple
+-- output positions in sequence before a single PC advance at the
+-- end of the case. If the register is already bound to an equal
+-- value, succeeds without side-effects; if it''s bound to an
+-- unequal value, fails. Otherwise binds and trails.
+bindOutput :: Int -> Value -> WamState -> Maybe WamState
+bindOutput reg val s = case derefVar (wsBindings s) <$> IM.lookup reg (wsRegs s) of
+  Just (Unbound vid) -> Just (s
+    { wsRegs = IM.insert reg val (wsRegs s)
+    , wsBindings = IM.insert vid val (wsBindings s)
+    , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
+    , wsTrailLen = wsTrailLen s + 1
+    })
+  Just existing | existing == val -> Just s
+  _ -> Nothing
+
+-- | copy_term/2 walker: recursively copies a Value, mapping each
+-- distinct source variable id to exactly one fresh destination
+-- variable id to preserve sharing within the copy. Threaded state
+-- is (counter, varMap). Atomic values clone as-is.
+copyTermWalk :: Int -> IM.IntMap Int -> Value -> (Value, Int, IM.IntMap Int)
+copyTermWalk !c !m (Unbound vid) = case IM.lookup vid m of
+  Just nv -> (Unbound nv, c, m)
+  Nothing -> (Unbound c, c + 1, IM.insert vid c m)
+copyTermWalk !c !m (Str fn args) =
+  let (newArgs, c1, m1) = copyTermArgs c m args
+  in (Str fn newArgs, c1, m1)
+copyTermWalk !c !m (VList items) =
+  let (newItems, c1, m1) = copyTermArgs c m items
+  in (VList newItems, c1, m1)
+copyTermWalk !c !m v = (v, c, m)
+
+copyTermArgs :: Int -> IM.IntMap Int -> [Value] -> ([Value], Int, IM.IntMap Int)
+copyTermArgs !c !m [] = ([], c, m)
+copyTermArgs !c !m (x : xs) =
+  let (x1, c1, m1) = copyTermWalk c m x
+      (xs1, c2, m2) = copyTermArgs c1 m1 xs
+  in (x1 : xs1, c2, m2)
+
 -- | Unify two values, binding unbound variables.
 unifyVal :: Value -> Value -> WamState -> Maybe WamState
 unifyVal (Unbound vid) val s =
@@ -769,6 +809,130 @@ step !ctx s (EndAggregate valReg) =
   in case backtrackInner returnPC s1 of
     Just s2 -> Just s2
     Nothing -> finalizeAggregate returnPC s1
+
+-- functor/3: A1 = T, A2 = N, A3 = A. Read and construct modes
+-- are dispatched on A1''s tag after dereferencing.
+step !_ctx s (BuiltinCall "functor/3" _) =
+  let t = derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s)
+  in case t of
+    Just (Unbound vid) ->
+      -- Construct mode: need A2 (atom name) and A3 (integer arity).
+      let nArg = derefVar (wsBindings s) <$> IM.lookup 2 (wsRegs s)
+          aArg = derefVar (wsBindings s) <$> IM.lookup 3 (wsRegs s)
+      in case (nArg, aArg) of
+        (Just nameVal, Just (Integer arity)) | arity >= 0 ->
+          let mBuilt = if arity == 0
+                then Just (nameVal, wsVarCounter s)
+                else case nameVal of
+                  Atom fname ->
+                    let c0 = wsVarCounter s
+                        newArgs = [Unbound (c0 + i) | i <- [0 .. arity - 1]]
+                    in Just (Str fname newArgs, c0 + arity)
+                  _ -> Nothing
+          in case mBuilt of
+            Nothing -> Nothing
+            Just (built, newCounter) -> Just (s
+              { wsPC = wsPC s + 1
+              , wsRegs = IM.insert 1 built (wsRegs s)
+              , wsBindings = IM.insert vid built (wsBindings s)
+              , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
+              , wsTrailLen = wsTrailLen s + 1
+              , wsVarCounter = newCounter
+              })
+        _ -> Nothing
+    Just tVal ->
+      -- Read mode: extract functor name and arity.
+      let mInfo = case tVal of
+            Str fn args -> Just (Atom fn, length args)
+            VList [] -> Just (Atom "[]", 0)
+            VList _ -> Just (Atom ".", 2)
+            Atom _ -> Just (tVal, 0)
+            Integer _ -> Just (tVal, 0)
+            Float _ -> Just (tVal, 0)
+            _ -> Nothing
+      in case mInfo of
+        Nothing -> Nothing
+        Just (name, arity) ->
+          case bindOutput 2 name s of
+            Nothing -> Nothing
+            Just s1 -> case bindOutput 3 (Integer arity) s1 of
+              Nothing -> Nothing
+              Just s2 -> Just (s2 { wsPC = wsPC s2 + 1 })
+    Nothing -> Nothing
+
+-- arg/3: A1 = N (integer, 1-based), A2 = T (compound/list),
+-- A3 = output unified with the selected argument.
+step !_ctx s (BuiltinCall "arg/3" _) =
+  let n = derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s)
+      t = derefVar (wsBindings s) <$> IM.lookup 2 (wsRegs s)
+  in case (n, t) of
+    (Just (Integer idx), Just tVal) | idx >= 1 ->
+      let mArg = case tVal of
+            Str _ args | idx <= length args -> Just (args !! (idx - 1))
+            VList (x : _) | idx == 1 -> Just x
+            VList (_ : xs) | idx == 2 -> Just (VList xs)
+            _ -> Nothing
+      in case mArg of
+        Nothing -> Nothing
+        Just a -> case bindOutput 3 a s of
+          Nothing -> Nothing
+          Just s1 -> Just (s1 { wsPC = wsPC s1 + 1 })
+    _ -> Nothing
+
+-- =../2 (univ): A1 = T, A2 = L. Decompose (instantiated A1) or
+-- compose (unbound A1, list in A2).
+step !_ctx s (BuiltinCall "=../2" _) =
+  let t = derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s)
+  in case t of
+    Just (Unbound vid) ->
+      -- Compose mode: read proper list from A2.
+      let l = derefVar (wsBindings s) <$> IM.lookup 2 (wsRegs s)
+      in case l of
+        Just (VList items) ->
+          let mBuilt = case items of
+                [] -> Nothing
+                [x] -> Just x
+                (Atom fname : rest) -> Just (Str fname rest)
+                _ -> Nothing
+          in case mBuilt of
+            Nothing -> Nothing
+            Just built -> Just (s
+              { wsPC = wsPC s + 1
+              , wsRegs = IM.insert 1 built (wsRegs s)
+              , wsBindings = IM.insert vid built (wsBindings s)
+              , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
+              , wsTrailLen = wsTrailLen s + 1
+              })
+        _ -> Nothing
+    Just tVal ->
+      -- Decompose mode: build list from T.
+      let mList = case tVal of
+            Str fn args -> Just (VList (Atom fn : args))
+            Atom _ -> Just (VList [tVal])
+            Integer _ -> Just (VList [tVal])
+            Float _ -> Just (VList [tVal])
+            VList [] -> Just (VList [Atom "[]"])
+            VList (x : xs) -> Just (VList [Atom ".", x, VList xs])
+            _ -> Nothing
+      in case mList of
+        Nothing -> Nothing
+        Just lv -> case bindOutput 2 lv s of
+          Nothing -> Nothing
+          Just s1 -> Just (s1 { wsPC = wsPC s1 + 1 })
+    Nothing -> Nothing
+
+-- copy_term/2: A1 = T, A2 = Copy. Walks T with a var map to
+-- preserve sharing, bumps wsVarCounter, binds A2 to the fresh copy.
+step !_ctx s (BuiltinCall "copy_term/2" _) =
+  let t = derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s)
+  in case t of
+    Just tVal ->
+      let (copy, newCounter, _) = copyTermWalk (wsVarCounter s) IM.empty tVal
+          s0 = s { wsVarCounter = newCounter }
+      in case bindOutput 2 copy s0 of
+        Nothing -> Nothing
+        Just s1 -> Just (s1 { wsPC = wsPC s1 + 1 })
+    Nothing -> Nothing
 
 -- Fallback for unhandled instructions
 step _ _ _ = Nothing'.

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1056,7 +1056,198 @@ compile_execute_term_builtin_to_rust(Code) :-
                 eprintln!("Warning: append/3 is not yet implemented in WAM-Rust runtime");
                 false
             }
+            "functor/3" => {
+                let t = self.regs.get("A1").cloned()
+                    .map(|v| self.deref_heap(&self.deref_var(&v)));
+                match t {
+                    Some(Value::Unbound(ref var_name)) => {
+                        // Construct mode: read N (atom) and A (integer).
+                        let n = self.regs.get("A2").cloned()
+                            .map(|v| self.deref_heap(&self.deref_var(&v)));
+                        let a = self.regs.get("A3").cloned()
+                            .map(|v| self.deref_heap(&self.deref_var(&v)));
+                        match (n, a) {
+                            (Some(name_val), Some(Value::Integer(arity))) if arity >= 0 => {
+                                let built = if arity == 0 {
+                                    name_val
+                                } else if let Value::Atom(fname) = name_val {
+                                    let args: Vec<Value> = (0..arity as usize).map(|_| {
+                                        self.var_counter += 1;
+                                        Value::Unbound(format!("_F{}", self.var_counter))
+                                    }).collect();
+                                    Value::Str(fname, args)
+                                } else { return false; };
+                                self.trail_binding("A1");
+                                self.regs.insert("A1".to_string(), built.clone());
+                                self.bind_var(var_name, built);
+                                self.pc += 1; true
+                            }
+                            _ => false,
+                        }
+                    }
+                    Some(t_val) => {
+                        // Read mode: extract functor name and arity.
+                        let (name, arity): (Value, i64) = match &t_val {
+                            Value::Str(f, args) => (Value::Atom(f.clone()), args.len() as i64),
+                            Value::List(items) if items.is_empty() =>
+                                (Value::Atom("[]".to_string()), 0),
+                            Value::List(_) => (Value::Atom(".".to_string()), 2),
+                            Value::Atom(s) => (Value::Atom(s.clone()), 0),
+                            Value::Integer(_) | Value::Float(_) | Value::Bool(_) =>
+                                (t_val.clone(), 0),
+                            _ => return false,
+                        };
+                        if let Some(a2) = self.regs.get("A2").cloned() {
+                            let derefed = self.deref_var(&self.deref_heap(&a2));
+                            if !self.unify(&derefed, &name) { return false; }
+                        }
+                        if let Some(a3) = self.regs.get("A3").cloned() {
+                            let derefed = self.deref_var(&self.deref_heap(&a3));
+                            if !self.unify(&derefed, &Value::Integer(arity)) { return false; }
+                        }
+                        self.pc += 1; true
+                    }
+                    None => false,
+                }
+            }
+            "arg/3" => {
+                let n_val = self.regs.get("A1").cloned()
+                    .map(|v| self.deref_heap(&self.deref_var(&v)));
+                let t_val = self.regs.get("A2").cloned()
+                    .map(|v| self.deref_heap(&self.deref_var(&v)));
+                match (n_val, t_val) {
+                    (Some(Value::Integer(n)), Some(t)) if n >= 1 => {
+                        let idx = (n - 1) as usize;
+                        let arg = match &t {
+                            Value::Str(_, args) => args.get(idx).cloned(),
+                            Value::List(items) if n == 1 && !items.is_empty() =>
+                                Some(items[0].clone()),
+                            Value::List(items) if n == 2 && !items.is_empty() =>
+                                Some(Value::List(items[1..].to_vec())),
+                            _ => None,
+                        };
+                        match arg {
+                            Some(a) => {
+                                if let Some(a3) = self.regs.get("A3").cloned() {
+                                    let derefed = self.deref_var(&self.deref_heap(&a3));
+                                    if self.unify(&derefed, &a) { self.pc += 1; true }
+                                    else { false }
+                                } else { false }
+                            }
+                            None => false,
+                        }
+                    }
+                    _ => false,
+                }
+            }
+            "=../2" => {
+                let t_val = self.regs.get("A1").cloned()
+                    .map(|v| self.deref_heap(&self.deref_var(&v)));
+                match t_val {
+                    Some(Value::Unbound(ref var_name)) => {
+                        // Compose mode: build T from list in A2.
+                        let l_val = self.regs.get("A2").cloned()
+                            .map(|v| self.deref_heap(&self.deref_var(&v)));
+                        if let Some(Value::List(items)) = l_val {
+                            if items.is_empty() { return false; }
+                            let built = if items.len() == 1 {
+                                items[0].clone()
+                            } else if let Value::Atom(fname) = &items[0] {
+                                Value::Str(fname.clone(), items[1..].to_vec())
+                            } else { return false; };
+                            self.trail_binding("A1");
+                            self.regs.insert("A1".to_string(), built.clone());
+                            self.bind_var(var_name, built);
+                            self.pc += 1; true
+                        } else { false }
+                    }
+                    Some(t) => {
+                        // Decompose mode: build list from T.
+                        let list = match &t {
+                            Value::Str(f, args) => {
+                                let mut items = vec![Value::Atom(f.clone())];
+                                items.extend(args.iter().cloned());
+                                Value::List(items)
+                            }
+                            Value::Atom(_) | Value::Integer(_)
+                            | Value::Float(_) | Value::Bool(_) => {
+                                Value::List(vec![t.clone()])
+                            }
+                            Value::List(items) if items.is_empty() => {
+                                Value::List(vec![Value::Atom("[]".to_string())])
+                            }
+                            Value::List(items) => Value::List(vec![
+                                Value::Atom(".".to_string()),
+                                items[0].clone(),
+                                Value::List(items[1..].to_vec()),
+                            ]),
+                            _ => return false,
+                        };
+                        if let Some(a2) = self.regs.get("A2").cloned() {
+                            let derefed = self.deref_var(&self.deref_heap(&a2));
+                            if self.unify(&derefed, &list) { self.pc += 1; true }
+                            else { false }
+                        } else { false }
+                    }
+                    None => false,
+                }
+            }
+            "copy_term/2" => {
+                let t_val = self.regs.get("A1").cloned()
+                    .map(|v| self.deref_heap(&self.deref_var(&v)));
+                if let Some(t) = t_val {
+                    // Sharing is preserved via a var_map from source
+                    // variable name to the single fresh name used for
+                    // ALL occurrences of that source variable. The
+                    // counter is bumped once per distinct source var.
+                    let mut var_map: std::collections::HashMap<String, String>
+                        = std::collections::HashMap::new();
+                    let copy = Self::copy_term_walk(
+                        &mut self.var_counter, &mut var_map, &t);
+                    if let Some(a2) = self.regs.get("A2").cloned() {
+                        let derefed = self.deref_var(&self.deref_heap(&a2));
+                        if self.unify(&derefed, &copy) { self.pc += 1; true }
+                        else { false }
+                    } else { false }
+                } else { false }
+            }
             _ => false,
+        }
+    }
+
+    /// Recursive walker for copy_term/2. Preserves variable sharing
+    /// by mapping each source variable name to exactly one fresh
+    /// destination variable name via var_map. Non-var values are
+    /// rebuilt structurally; atomic values clone as-is.
+    fn copy_term_walk(
+        counter: &mut usize,
+        var_map: &mut std::collections::HashMap<String, String>,
+        v: &Value,
+    ) -> Value {
+        match v {
+            Value::Unbound(name) => {
+                if let Some(new_name) = var_map.get(name) {
+                    Value::Unbound(new_name.clone())
+                } else {
+                    *counter += 1;
+                    let new_name = format!("_C{}", counter);
+                    var_map.insert(name.clone(), new_name.clone());
+                    Value::Unbound(new_name)
+                }
+            }
+            Value::Str(f, args) => {
+                let new_args: Vec<Value> = args.iter()
+                    .map(|a| Self::copy_term_walk(counter, var_map, a))
+                    .collect();
+                Value::Str(f.clone(), new_args)
+            }
+            Value::List(items) => {
+                let new_items: Vec<Value> = items.iter()
+                    .map(|i| Self::copy_term_walk(counter, var_map, i))
+                    .collect();
+                Value::List(new_items)
+            }
+            _ => v.clone(),
         }
     }'.
 

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -617,6 +617,10 @@ is_builtin_pred(\+, 1).      % negation-as-failure
 is_builtin_pred(member, 2).  % list operations
 is_builtin_pred(append, 3).
 is_builtin_pred(length, 2).
+is_builtin_pred(functor, 3). % term inspection: name/arity read or construct
+is_builtin_pred(arg, 3).     % term inspection: Nth argument access
+is_builtin_pred((=..), 2).   % term inspection: univ (decompose/compose)
+is_builtin_pred(copy_term, 2). % term inspection: fresh-variable copy
 
 compile_put_arguments([], _, V, V, "").
 compile_put_arguments([Arg|Rest], I, V0, Vf, Code) :-

--- a/src/unifyweaver/targets/wam_wat_target.pl
+++ b/src/unifyweaver/targets/wam_wat_target.pl
@@ -469,11 +469,24 @@ compile_wam_predicate_to_wat(Pred/Arity, WamCode, Options, WatResult) :-
         [CodeBase, DataBytes]),
     %% Generate entry function
     wat_pred_name(Pred, Arity, FuncName),
+    %% Heap must start AFTER the instruction data segment — otherwise
+    %% heap_push_val on the first allocation overwrites instruction 0
+    %% bytes, and any subsequent allocations walk forward through the
+    %% code. We observed this concretely with $builtin_univ decompose
+    %% of a compound: the decompose path builds (arity+1) cons cells
+    %% (36 bytes each) plus any prior compound writes, and the write
+    %% range crossed into proceed''s bytes, causing the next step to
+    %% misinterpret proceed as garbage and fail. Atomic-only tests
+    %% masked the bug because they allocate fewer cells and never
+    %% reached the proceed bytes. Put the heap on page 3 (offset
+    %% 196608) which is past any plausible code segment in the current
+    %% 4-page module layout.
+    option(wam_heap_start(HeapStart), Options, 196608),
     format(atom(EntryFunc),
 '(func $~w (export "~w") (result i32)
   (call $wam_init (i32.const ~w))
   (call $run_loop (i32.const ~w) (i32.const ~w)))',
-        [FuncName, FuncName, CodeBase, CodeBase, NumInstrs]),
+        [FuncName, FuncName, HeapStart, CodeBase, NumInstrs]),
     WatResult = wat_pred(DataSeg, EntryFunc, CodeBase, NumInstrs).
 
 encode_instr_with_labels(Labels, Instr, Hex) :-
@@ -1052,6 +1065,8 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
     (then (return (call $builtin_functor))))
   (if (i32.eq (local.get $id) (i32.const 19))
     (then (return (call $builtin_arg))))
+  (if (i32.eq (local.get $id) (i32.const 20))
+    (then (return (call $builtin_univ))))
   (i32.const 0)
 )
 
@@ -1235,6 +1250,201 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
       (call $set_reg (i32.const 1) (local.get $t_tag) (local.get $t_payload))
       (call $trail_binding (i32.const 2))
       (call $set_reg (i32.const 2) (i32.const 1) (i64.const 0))
+      (return (i32.const 1))))
+  (i32.const 0)
+)
+
+;; --- =../2 (univ): A1 = T, A2 = L ---
+;; Two modes determined by A1''s tag:
+;;   - Instantiated A1 (atomic or compound ref): decompose. Build a
+;;     fresh cons list [functor | args] on the heap and bind A2 to it.
+;;   - Unbound A1: compose. Walk the cons list in A2, take the head as
+;;     the functor and the tail elements as args, build a fresh
+;;     compound, bind A1.
+;; List representation: cons cells are tag=4 ''list'' cells with payload
+;; zero, whose head is stored at offset +12 and tail at offset +24. This
+;; matches what the canonical WAM''s put_list + set_constant/set_value
+;; instructions produce at runtime (see wam_wat_case(put_list, ...)).
+;; The empty list is the atom ''[]'' — tag=0 with payload 2914 (DJB2-like
+;; acc*31+char applied to chars 91, 93).
+;;
+;; Decompose mode writes freshly-allocated cells to an unbound A2 (v1
+;; limitation: if A2 is already bound to a list, this helper does NOT
+;; structurally unify — it blindly rebinds). Compose mode requires A2
+;; to deref to a cons cell and produces a fresh compound for an unbound
+;; A1.
+(func $builtin_univ (result i32)
+  (local $t_tag i32)
+  (local $t_payload i64)
+  (local $comp_addr i32)
+  (local $header_payload i64)
+  (local $arity i32)
+  (local $functor_hash i64)
+  (local $list_root i32)
+  (local $i i32)
+  (local $cons_addr i32)
+  (local $arg_off i32)
+  (local $next_cons i32)
+  (local $cur i32)
+  (local $head_tag i32)
+  (local $head_payload i64)
+  (local $tail_tag i32)
+  (local $tail_payload i64)
+  (local $nelts i32)
+  (local $list_start i32)
+  (local.set $t_tag (call $get_reg_tag (i32.const 0)))
+  ;; --- Decompose: atomic T (atom/integer/float, tag <= 2) ---
+  (if (i32.le_u (local.get $t_tag) (i32.const 2))
+    (then
+      (local.set $t_payload (call $get_reg_payload (i32.const 0)))
+      ;; Cons cell header (tag=4, payload 0) — head and tail follow.
+      (local.set $list_root
+        (call $heap_push_val (i32.const 4) (i64.const 0)))
+      ;; head = T (copied tag+payload as-is)
+      (drop (call $heap_push_val (local.get $t_tag) (local.get $t_payload)))
+      ;; tail = atom([])
+      (drop (call $heap_push_val (i32.const 0) (i64.const 2914)))
+      (call $trail_binding (i32.const 1))
+      (call $set_reg (i32.const 1) (i32.const 5)
+        (i64.extend_i32_u (local.get $list_root)))
+      (return (i32.const 1))))
+  ;; --- Decompose: compound T via ref ---
+  (if (i32.eq (local.get $t_tag) (i32.const 5))
+    (then
+      (local.set $comp_addr
+        (i32.wrap_i64 (call $get_reg_payload (i32.const 0))))
+      (if (i32.eq (call $val_tag (local.get $comp_addr)) (i32.const 3))
+        (then
+          (local.set $header_payload (call $val_payload (local.get $comp_addr)))
+          (local.set $arity
+            (i32.wrap_i64 (i64.shr_u (local.get $header_payload) (i64.const 32))))
+          (local.set $functor_hash
+            (i64.and (local.get $header_payload) (i64.const 0xFFFFFFFF)))
+          ;; Allocate (arity+1) cons cells in heap order. Each cons cell
+          ;; takes 36 bytes: list header at base+i*36, head at +12,
+          ;; tail at +24.
+          (local.set $list_root (call $get_heap_top))
+          (local.set $i (i32.const 0))
+          (block $done_cells
+            (loop $cell_loop
+              (br_if $done_cells
+                (i32.gt_s (local.get $i) (local.get $arity)))
+              ;; List header
+              (local.set $cons_addr
+                (call $heap_push_val (i32.const 4) (i64.const 0)))
+              ;; Head
+              (if (i32.eqz (local.get $i))
+                (then
+                  ;; element 0 = functor atom
+                  (drop (call $heap_push_val (i32.const 0)
+                          (local.get $functor_hash))))
+                (else
+                  ;; element i (i>=1) = compound''s i-th arg cell
+                  (local.set $arg_off
+                    (i32.add (local.get $comp_addr)
+                             (i32.mul (local.get $i) (i32.const 12))))
+                  (drop (call $heap_push_val
+                          (call $val_tag (local.get $arg_off))
+                          (call $val_payload (local.get $arg_off))))))
+              ;; Tail
+              (if (i32.eq (local.get $i) (local.get $arity))
+                (then
+                  (drop (call $heap_push_val (i32.const 0) (i64.const 2914))))
+                (else
+                  (local.set $next_cons
+                    (i32.add (local.get $cons_addr) (i32.const 36)))
+                  (drop (call $heap_push_val (i32.const 5)
+                          (i64.extend_i32_u (local.get $next_cons))))))
+              (local.set $i (i32.add (local.get $i) (i32.const 1)))
+              (br $cell_loop)))
+          (call $trail_binding (i32.const 1))
+          (call $set_reg (i32.const 1) (i32.const 5)
+            (i64.extend_i32_u (local.get $list_root)))
+          (return (i32.const 1))))
+      (return (i32.const 0))))
+  ;; --- Compose: A1 unbound, A2 = cons-list. ---
+  (if (i32.eq (local.get $t_tag) (i32.const 6))
+    (then
+      ;; A2 must be a ref to a cons cell (tag=4).
+      (if (i32.ne (call $get_reg_tag (i32.const 1)) (i32.const 5))
+        (then (return (i32.const 0))))
+      (local.set $list_start
+        (i32.wrap_i64 (call $get_reg_payload (i32.const 1))))
+      ;; Pass 1: count elements and validate cons-list structure.
+      (local.set $cur (local.get $list_start))
+      (local.set $nelts (i32.const 0))
+      (block $count_done
+        (loop $count_loop
+          (if (i32.ne (call $val_tag (local.get $cur)) (i32.const 4))
+            (then (return (i32.const 0))))
+          (local.set $nelts (i32.add (local.get $nelts) (i32.const 1)))
+          (local.set $tail_tag
+            (call $val_tag (i32.add (local.get $cur) (i32.const 24))))
+          (local.set $tail_payload
+            (call $val_payload (i32.add (local.get $cur) (i32.const 24))))
+          (if (i32.eq (local.get $tail_tag) (i32.const 0))
+            (then
+              ;; tail must be the atom []
+              (if (i64.eq (local.get $tail_payload) (i64.const 2914))
+                (then (br $count_done))
+                (else (return (i32.const 0))))))
+          (if (i32.eq (local.get $tail_tag) (i32.const 5))
+            (then
+              (local.set $cur (i32.wrap_i64 (local.get $tail_payload)))
+              (br $count_loop)))
+          ;; Any other tail tag is malformed for our cons representation.
+          (return (i32.const 0))))
+      (if (i32.eqz (local.get $nelts))
+        (then (return (i32.const 0))))
+      ;; Head of first cons must be the functor.
+      (local.set $head_tag
+        (call $val_tag (i32.add (local.get $list_start) (i32.const 12))))
+      (local.set $head_payload
+        (call $val_payload (i32.add (local.get $list_start) (i32.const 12))))
+      ;; Single-element list: bind T to that element verbatim.
+      (if (i32.eq (local.get $nelts) (i32.const 1))
+        (then
+          (call $trail_binding (i32.const 0))
+          (call $set_reg (i32.const 0) (local.get $head_tag) (local.get $head_payload))
+          (return (i32.const 1))))
+      ;; Multi-element list: head must be an atom (the functor).
+      (if (i32.ne (local.get $head_tag) (i32.const 0))
+        (then (return (i32.const 0))))
+      ;; arity = nelts - 1. Allocate compound header + arity arg cells.
+      (local.set $arity (i32.sub (local.get $nelts) (i32.const 1)))
+      (local.set $header_payload
+        (i64.or
+          (i64.shl (i64.extend_i32_u (local.get $arity)) (i64.const 32))
+          (i64.and (local.get $head_payload) (i64.const 0xFFFFFFFF))))
+      (local.set $comp_addr
+        (call $heap_push_val (i32.const 3) (local.get $header_payload)))
+      ;; Pass 2: walk tail of list, copy each element into a fresh arg cell.
+      (local.set $cur
+        (i32.wrap_i64
+          (call $val_payload (i32.add (local.get $list_start) (i32.const 24)))))
+      (local.set $i (i32.const 0))
+      (block $copy_done
+        (loop $copy_loop
+          (br_if $copy_done (i32.ge_s (local.get $i) (local.get $arity)))
+          ;; head of cons at $cur
+          (local.set $head_tag
+            (call $val_tag (i32.add (local.get $cur) (i32.const 12))))
+          (local.set $head_payload
+            (call $val_payload (i32.add (local.get $cur) (i32.const 12))))
+          (drop (call $heap_push_val (local.get $head_tag) (local.get $head_payload)))
+          ;; advance to next cons via tail ref
+          (local.set $tail_tag
+            (call $val_tag (i32.add (local.get $cur) (i32.const 24))))
+          (if (i32.eq (local.get $tail_tag) (i32.const 5))
+            (then
+              (local.set $cur
+                (i32.wrap_i64
+                  (call $val_payload (i32.add (local.get $cur) (i32.const 24)))))))
+          (local.set $i (i32.add (local.get $i) (i32.const 1)))
+          (br $copy_loop)))
+      (call $trail_binding (i32.const 0))
+      (call $set_reg (i32.const 0) (i32.const 5)
+        (i64.extend_i32_u (local.get $comp_addr)))
       (return (i32.const 1))))
   (i32.const 0)
 )

--- a/src/unifyweaver/targets/wam_wat_target.pl
+++ b/src/unifyweaver/targets/wam_wat_target.pl
@@ -1038,6 +1038,8 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
   ;; --- Term inspection builtins (IDs 18-21) ---
   ;; Handled via a short if-chain after the main br_table default.
   ;; These are not hot paths, so the extra compares are negligible.
+  (if (i32.eq (local.get $id) (i32.const 18))
+    (then (return (call $builtin_functor))))
   (if (i32.eq (local.get $id) (i32.const 19))
     (then (return (call $builtin_arg))))
   (i32.const 0)
@@ -1128,6 +1130,94 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
       (i64.eq (call $get_reg_payload (i32.const 2)) (local.get $arg_payload)))
     (then (i32.const 1))
     (else (i32.const 0)))
+)
+
+;; --- functor/3: A1 = T, A2 = N, A3 = A ---
+;; Two modes determined by A1''s tag:
+;;   - Unbound A1: construct mode. Read N and A from A2/A3, allocate a
+;;     fresh compound with $arity unbound args, bind A1 to the result.
+;;   - Instantiated A1: read mode. Extract functor/arity and bind A2/A3.
+;; Atomic T (atom/integer/float): N = T, A = 0.
+;; List case (tag=4) not handled in v1 — returns fail. Follow-up.
+(func $builtin_functor (result i32)
+  (local $t_tag i32)
+  (local $t_payload i64)
+  (local $n_tag i32)
+  (local $n_payload i64)
+  (local $arity i32)
+  (local $comp_addr i32)
+  (local $header_payload i64)
+  (local $i i32)
+  (local.set $t_tag (call $get_reg_tag (i32.const 0)))
+  ;; --- Construct mode ---
+  (if (i32.eq (local.get $t_tag) (i32.const 6))
+    (then
+      (local.set $n_tag (call $get_reg_tag (i32.const 1)))
+      (local.set $n_payload (call $get_reg_payload (i32.const 1)))
+      (local.set $arity
+        (i32.wrap_i64 (call $get_reg_payload (i32.const 2))))
+      ;; Arity must be >= 0.
+      (if (i32.lt_s (local.get $arity) (i32.const 0))
+        (then (return (i32.const 0))))
+      ;; Arity 0: bind T to N verbatim (atom or integer).
+      (if (i32.eq (local.get $arity) (i32.const 0))
+        (then
+          (call $trail_binding (i32.const 0))
+          (call $set_reg (i32.const 0) (local.get $n_tag) (local.get $n_payload))
+          (return (i32.const 1))))
+      ;; Arity > 0: N must be an atom to form a valid compound.
+      (if (i32.ne (local.get $n_tag) (i32.const 0))
+        (then (return (i32.const 0))))
+      ;; header payload = (arity << 32) | (hash & 0xFFFFFFFF)
+      (local.set $header_payload
+        (i64.or
+          (i64.shl (i64.extend_i32_u (local.get $arity)) (i64.const 32))
+          (i64.and (local.get $n_payload) (i64.const 0xFFFFFFFF))))
+      (local.set $comp_addr
+        (call $heap_push_val (i32.const 3) (local.get $header_payload)))
+      ;; Push $arity fresh unbound argument cells.
+      (local.set $i (i32.const 0))
+      (block $done_args
+        (loop $arg_loop
+          (br_if $done_args (i32.ge_s (local.get $i) (local.get $arity)))
+          (drop (call $heap_push_val (i32.const 6) (i64.const 0)))
+          (local.set $i (i32.add (local.get $i) (i32.const 1)))
+          (br $arg_loop)))
+      ;; Bind T = ref(comp_addr).
+      (call $trail_binding (i32.const 0))
+      (call $set_reg (i32.const 0) (i32.const 5)
+        (i64.extend_i32_u (local.get $comp_addr)))
+      (return (i32.const 1))))
+  ;; --- Read mode: compound via ref ---
+  (if (i32.eq (local.get $t_tag) (i32.const 5))
+    (then
+      (local.set $comp_addr
+        (i32.wrap_i64 (call $get_reg_payload (i32.const 0))))
+      (if (i32.eq (call $val_tag (local.get $comp_addr)) (i32.const 3))
+        (then
+          (local.set $header_payload (call $val_payload (local.get $comp_addr)))
+          (local.set $arity
+            (i32.wrap_i64 (i64.shr_u (local.get $header_payload) (i64.const 32))))
+          ;; Bind A2 = atom(functor_hash)
+          (call $trail_binding (i32.const 1))
+          (call $set_reg (i32.const 1) (i32.const 0)
+            (i64.and (local.get $header_payload) (i64.const 0xFFFFFFFF)))
+          ;; Bind A3 = integer(arity)
+          (call $trail_binding (i32.const 2))
+          (call $set_reg (i32.const 2) (i32.const 1)
+            (i64.extend_i32_u (local.get $arity)))
+          (return (i32.const 1))))))
+  ;; --- Read mode: atomic (atom/integer/float) ---
+  ;; For atomic T: N = T (same tag + payload), A = 0
+  (if (i32.le_u (local.get $t_tag) (i32.const 2))
+    (then
+      (local.set $t_payload (call $get_reg_payload (i32.const 0)))
+      (call $trail_binding (i32.const 1))
+      (call $set_reg (i32.const 1) (local.get $t_tag) (local.get $t_payload))
+      (call $trail_binding (i32.const 2))
+      (call $set_reg (i32.const 2) (i32.const 1) (i64.const 0))
+      (return (i32.const 1))))
+  (i32.const 0)
 )
 ', [CPSize, NumRegs, NumRegs, RegBytes, CPSize, CPSize, NumRegs, NumRegs]).
 

--- a/src/unifyweaver/targets/wam_wat_target.pl
+++ b/src/unifyweaver/targets/wam_wat_target.pl
@@ -1067,6 +1067,8 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
     (then (return (call $builtin_arg))))
   (if (i32.eq (local.get $id) (i32.const 20))
     (then (return (call $builtin_univ))))
+  (if (i32.eq (local.get $id) (i32.const 21))
+    (then (return (call $builtin_copy_term))))
   (i32.const 0)
 )
 
@@ -1446,6 +1448,171 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
       (call $set_reg (i32.const 0) (i32.const 5)
         (i64.extend_i32_u (local.get $comp_addr)))
       (return (i32.const 1))))
+  (i32.const 0)
+)
+
+;; --- copy_term/2: A1 = T, A2 = Copy ---
+;; Builds a structurally identical copy of T in which every unbound
+;; variable has been replaced by a fresh unbound. Sharing is preserved
+;; within the copy: two positions that share a source variable map to
+;; the SAME fresh variable in the copy (the spec''s critical property
+;; for copy_term/2).
+;;
+;; v1 scope:
+;;   - Atomic T (atom/integer/float): bind Copy = T verbatim.
+;;   - Unbound T: allocate a fresh unbound on the heap and bind Copy
+;;     to a ref to it.
+;;   - Ref to compound T: SHALLOW copy with sharing preserved. The new
+;;     compound header is copied, and each argument cell is either
+;;     copied verbatim (non-unbound) or materialized as a fresh
+;;     unbound / ref-to-shared-unbound.
+;;   - Nested compounds inside the args are NOT deep-copied — they are
+;;     structure-shared with the source. This is a documented v1
+;;     limitation; a follow-up would use a work stack.
+;;   - Lists (tag=4) are not handled in v1.
+;;
+;; Sharing preservation algorithm:
+;;   - Maintain a small var map keyed on the source unbound''s payload
+;;     (the variable id), valued at the heap address where the fresh
+;;     cell for that variable was materialized.
+;;   - First occurrence of variable V: push a tag=6 cell in-place in
+;;     the next arg slot. Record (src_payload, that addr) in the map.
+;;     The arg slot IS the fresh variable.
+;;   - Subsequent occurrences: look up V in the map, push a tag=5 ref
+;;     cell whose payload is the recorded addr. Dereffing the arg
+;;     reaches the first occurrence''s cell — the two slots share.
+;;
+;; Var map layout: 256 bytes allocated at heap_top before the copy
+;; starts, consumed but never reclaimed (each call wastes 256 heap
+;; bytes — acceptable for v1 test scale). Each entry is 12 bytes:
+;; [key:i64 source_payload][new_offset:i32]. 21 entries max.
+(func $builtin_copy_term (result i32)
+  (local $t_tag i32)
+  (local $t_payload i64)
+  (local $src_addr i32)
+  (local $dst_addr i32)
+  (local $header_payload i64)
+  (local $arity i32)
+  (local $i i32)
+  (local $j i32)
+  (local $arg_src i32)
+  (local $arg_tag i32)
+  (local $arg_payload i64)
+  (local $map_base i32)
+  (local $map_n i32)
+  (local $map_limit i32)
+  (local $entry_off i32)
+  (local $found i32)
+  (local $found_off i32)
+  (local $new_cell i32)
+  (local.set $t_tag (call $get_reg_tag (i32.const 0)))
+  (local.set $t_payload (call $get_reg_payload (i32.const 0)))
+  ;; --- Atomic T ---
+  (if (i32.le_u (local.get $t_tag) (i32.const 2))
+    (then
+      (call $trail_binding (i32.const 1))
+      (call $set_reg (i32.const 1) (local.get $t_tag) (local.get $t_payload))
+      (return (i32.const 1))))
+  ;; --- Unbound T ---
+  (if (i32.eq (local.get $t_tag) (i32.const 6))
+    (then
+      (local.set $new_cell
+        (call $heap_push_val (i32.const 6) (i64.const 0)))
+      (call $trail_binding (i32.const 1))
+      (call $set_reg (i32.const 1) (i32.const 5)
+        (i64.extend_i32_u (local.get $new_cell)))
+      (return (i32.const 1))))
+  ;; --- Ref to compound T ---
+  (if (i32.eq (local.get $t_tag) (i32.const 5))
+    (then
+      (local.set $src_addr (i32.wrap_i64 (local.get $t_payload)))
+      (if (i32.eq (call $val_tag (local.get $src_addr)) (i32.const 3))
+        (then
+          (local.set $header_payload
+            (call $val_payload (local.get $src_addr)))
+          (local.set $arity
+            (i32.wrap_i64 (i64.shr_u (local.get $header_payload) (i64.const 32))))
+          ;; Reserve var map: 256 bytes (21 entries x 12 bytes), not
+          ;; reclaimed. The fresh compound header will sit right after
+          ;; the map area.
+          (local.set $map_base (call $get_heap_top))
+          (call $set_heap_top
+            (i32.add (local.get $map_base) (i32.const 256)))
+          (local.set $map_n (i32.const 0))
+          (local.set $map_limit (i32.const 21))
+          ;; Allocate fresh compound header (header payload carries the
+          ;; arity-packed functor, same as the source).
+          (local.set $dst_addr
+            (call $heap_push_val (i32.const 3) (local.get $header_payload)))
+          ;; Walk source args i=1..arity and materialize each dst arg.
+          (local.set $i (i32.const 1))
+          (block $done_args
+            (loop $arg_loop
+              (br_if $done_args (i32.gt_s (local.get $i) (local.get $arity)))
+              (local.set $arg_src
+                (i32.add (local.get $src_addr)
+                         (i32.mul (local.get $i) (i32.const 12))))
+              (local.set $arg_tag (call $val_tag (local.get $arg_src)))
+              (local.set $arg_payload (call $val_payload (local.get $arg_src)))
+              (if (i32.eq (local.get $arg_tag) (i32.const 6))
+                (then
+                  ;; Unbound source arg — search the var map.
+                  (local.set $found (i32.const 0))
+                  (local.set $found_off (i32.const 0))
+                  (local.set $j (i32.const 0))
+                  (block $search_done
+                    (loop $search
+                      (br_if $search_done
+                        (i32.ge_u (local.get $j) (local.get $map_n)))
+                      (local.set $entry_off
+                        (i32.add (local.get $map_base)
+                                 (i32.mul (local.get $j) (i32.const 12))))
+                      (if (i64.eq (i64.load (local.get $entry_off))
+                                  (local.get $arg_payload))
+                        (then
+                          (local.set $found_off
+                            (i32.load
+                              (i32.add (local.get $entry_off) (i32.const 8))))
+                          (local.set $found (i32.const 1))
+                          (br $search_done)))
+                      (local.set $j (i32.add (local.get $j) (i32.const 1)))
+                      (br $search)))
+                  (if (local.get $found)
+                    (then
+                      ;; Subsequent occurrence: push ref to existing cell.
+                      (drop (call $heap_push_val (i32.const 5)
+                              (i64.extend_i32_u (local.get $found_off)))))
+                    (else
+                      ;; First occurrence: materialize in-place as an
+                      ;; unbound cell. heap_push_val returns this arg
+                      ;; slot''s addr, which becomes the map value for
+                      ;; future occurrences of the same source var.
+                      (local.set $new_cell
+                        (call $heap_push_val (i32.const 6) (i64.const 0)))
+                      (if (i32.lt_u (local.get $map_n) (local.get $map_limit))
+                        (then
+                          (local.set $entry_off
+                            (i32.add (local.get $map_base)
+                                     (i32.mul (local.get $map_n) (i32.const 12))))
+                          (i64.store (local.get $entry_off)
+                                     (local.get $arg_payload))
+                          (i32.store
+                            (i32.add (local.get $entry_off) (i32.const 8))
+                            (local.get $new_cell))
+                          (local.set $map_n
+                            (i32.add (local.get $map_n) (i32.const 1))))))))
+                (else
+                  ;; Non-unbound: copy tag/payload verbatim (v1: no
+                  ;; deep copy of nested compounds).
+                  (drop (call $heap_push_val
+                          (local.get $arg_tag)
+                          (local.get $arg_payload)))))
+              (local.set $i (i32.add (local.get $i) (i32.const 1)))
+              (br $arg_loop)))
+          (call $trail_binding (i32.const 1))
+          (call $set_reg (i32.const 1) (i32.const 5)
+            (i64.extend_i32_u (local.get $dst_addr)))
+          (return (i32.const 1))))))
   (i32.const 0)
 )
 ', [CPSize, NumRegs, NumRegs, RegBytes, CPSize, CPSize, NumRegs, NumRegs]).

--- a/src/unifyweaver/targets/wam_wat_target.pl
+++ b/src/unifyweaver/targets/wam_wat_target.pl
@@ -104,6 +104,13 @@ builtin_id('number/1', 14).
 builtin_id('true/0',   15).
 builtin_id('fail/0',   16).
 builtin_id('!/0',      17).
+%% Term inspection builtins (WAM_TERM_BUILTINS plan). IDs 18-21 are
+%% reserved here in one block; individual backends may implement them
+%% incrementally. An unimplemented ID returns fail from $execute_builtin.
+builtin_id('functor/3',   18).
+builtin_id('arg/3',       19).
+builtin_id('=../2',       20).
+builtin_id('copy_term/2', 21).
 
 % ============================================================================
 % Register name -> index mapping
@@ -1028,6 +1035,11 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
     (call $set_cp_count (i32.const 0))
     (return (i32.const 1))
   )
+  ;; --- Term inspection builtins (IDs 18-21) ---
+  ;; Handled via a short if-chain after the main br_table default.
+  ;; These are not hot paths, so the extra compares are negligible.
+  (if (i32.eq (local.get $id) (i32.const 19))
+    (then (return (call $builtin_arg))))
   (i32.const 0)
 )
 
@@ -1061,6 +1073,61 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
     ) (return (i64.ge_s (local.get $a) (local.get $b))))
   )
   (i32.const 0)
+)
+
+;; --- arg/3: A1 = N (1-based), A2 = T (ref->compound), A3 = result ---
+;; Reads the Nth argument cell of the compound T references, unifies it
+;; with A3. Argument cells are laid out contiguously after the compound
+;; header, each cell 12 bytes. Arity is recovered from the high 32 bits
+;; of the compound header payload (see encode_structure_op1 in
+;; wam_wat_target.pl).
+(func $builtin_arg (result i32)
+  (local $n i32)
+  (local $t_tag i32)
+  (local $comp_addr i32)
+  (local $comp_tag i32)
+  (local $comp_payload i64)
+  (local $arity i32)
+  (local $arg_off i32)
+  (local $arg_tag i32)
+  (local $arg_payload i64)
+  (local $a3_tag i32)
+  ;; N from A1 (register index 0). Payload is the raw integer value.
+  (local.set $n (i32.wrap_i64 (call $get_reg_payload (i32.const 0))))
+  (if (i32.lt_s (local.get $n) (i32.const 1))
+    (then (return (i32.const 0))))
+  ;; T from A2 (register index 1). Must be a ref (tag=5).
+  (local.set $t_tag (call $get_reg_tag (i32.const 1)))
+  (if (i32.ne (local.get $t_tag) (i32.const 5))
+    (then (return (i32.const 0))))
+  (local.set $comp_addr (i32.wrap_i64 (call $get_reg_payload (i32.const 1))))
+  (local.set $comp_tag (call $val_tag (local.get $comp_addr)))
+  (if (i32.ne (local.get $comp_tag) (i32.const 3))
+    (then (return (i32.const 0))))
+  (local.set $comp_payload (call $val_payload (local.get $comp_addr)))
+  (local.set $arity
+    (i32.wrap_i64 (i64.shr_u (local.get $comp_payload) (i64.const 32))))
+  (if (i32.gt_s (local.get $n) (local.get $arity))
+    (then (return (i32.const 0))))
+  ;; Argument N at compound_addr + N*12 (header at +0, args start at +12).
+  (local.set $arg_off
+    (i32.add (local.get $comp_addr)
+             (i32.mul (local.get $n) (i32.const 12))))
+  (local.set $arg_tag (call $val_tag (local.get $arg_off)))
+  (local.set $arg_payload (call $val_payload (local.get $arg_off)))
+  ;; A3 (register index 2): bind if unbound, else shallow compare.
+  (local.set $a3_tag (call $get_reg_tag (i32.const 2)))
+  (if (i32.eq (local.get $a3_tag) (i32.const 6))
+    (then
+      (call $trail_binding (i32.const 2))
+      (call $set_reg (i32.const 2) (local.get $arg_tag) (local.get $arg_payload))
+      (return (i32.const 1))))
+  (if (result i32)
+    (i32.and
+      (i32.eq (local.get $a3_tag) (local.get $arg_tag))
+      (i64.eq (call $get_reg_payload (i32.const 2)) (local.get $arg_payload)))
+    (then (i32.const 1))
+    (else (i32.const 0)))
 )
 ', [CPSize, NumRegs, NumRegs, RegBytes, CPSize, CPSize, NumRegs, NumRegs]).
 

--- a/src/unifyweaver/targets/wam_wat_target.pl
+++ b/src/unifyweaver/targets/wam_wat_target.pl
@@ -506,9 +506,19 @@ gen_do_func(Tag-Body, Code) :-
 
 gen_step_function(Cases, Code) :-
     %% Generate br_table dispatch with nested blocks.
-    %% WAT br_table jumps to block N (counting from innermost).
-    %% We nest blocks so that tag 0 breaks to the outermost (first to close),
-    %% and after each block close we call the corresponding do_ function.
+    %%
+    %% Block nesting: $default is outermost, $b0 is innermost. br_table
+    %% dispatches tag N to $bN. Exiting $bN puts control just after
+    %% $bN's close, where the case body for tag N runs — a return that
+    %% exits the function with the $do_<instr> call result.
+    %%
+    %% There must be NO bare `)` between br_table and the first case
+    %% body: if present, that `)` would close $b0 before its case body,
+    %% making tag N run the body for tag N-1 (an off-by-one dispatch
+    %% bug). The original WAM-WAT target PR #1224 had this bug; it went
+    %% unnoticed because wat2wasm_validates used assertion/1 which
+    %% warns rather than failing the test, so runtime behavior was
+    %% never actually validated.
     length(Cases, N),
     MaxTag is N - 1,
     %% br_table labels: $b0 $b1 ... $bN $default
@@ -519,7 +529,7 @@ gen_step_function(Cases, Code) :-
     maplist(open_block, TagNums, OpenBlocks),
     reverse(OpenBlocks, RevOpenBlocks),
     atomic_list_concat(RevOpenBlocks, '\n', OpenBlocksStr),
-    %% Closing blocks + dispatch calls (outermost first = tag 0)
+    %% Closing blocks + dispatch calls (innermost first = tag 0)
     maplist(close_and_call, Cases, CloseBlocks),
     atomic_list_concat(CloseBlocks, '\n', CloseBlocksStr),
     format(atom(Code),
@@ -533,8 +543,8 @@ gen_step_function(Cases, Code) :-
   (block $default
 ~w
     (br_table ~w $default (local.get $tag))
-  )
 ~w
+  )
   (i32.const 0)
 )', [OpenBlocksStr, BrTableStr, CloseBlocksStr]).
 
@@ -1060,6 +1070,15 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
 )
 
 ;; --- Arithmetic comparison: 0==eq, 1==ne, 2==lt, 3==gt, 4==le, 5==ge ---
+;; Nested-block br_table dispatch. Each case line has the form
+;;   ) (return (i64.XX ...))
+;; where the leading `)` closes the corresponding $XX block and the
+;; return expression must balance its own parens — one too many closes
+;; per line makes the function paren-imbalanced and wat2wasm rejects
+;; the entire module with cascading "undefined function" errors on
+;; downstream symbols. (The original WAM-WAT target PR #1224 had an
+;; extra `)` per line; it was never caught because the wat2wasm_validates
+;; test used assertion/1 which only warns rather than failing the test.)
 (func $builtin_arith_cmp (param $op i32) (result i32)
   (local $a i64) (local $b i64)
   (local.set $a (call $get_reg_payload (i32.const 0)))
@@ -1067,12 +1086,12 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
   (block $default
     (block $ge (block $le (block $gt (block $lt (block $ne (block $eq
       (br_table $eq $ne $lt $gt $le $ge $default (local.get $op))
-    ) (return (i64.eq (local.get $a) (local.get $b))))
-    ) (return (i64.ne (local.get $a) (local.get $b))))
-    ) (return (i64.lt_s (local.get $a) (local.get $b))))
-    ) (return (i64.gt_s (local.get $a) (local.get $b))))
-    ) (return (i64.le_s (local.get $a) (local.get $b))))
-    ) (return (i64.ge_s (local.get $a) (local.get $b))))
+    ) (return (i64.eq (local.get $a) (local.get $b)))
+    ) (return (i64.ne (local.get $a) (local.get $b)))
+    ) (return (i64.lt_s (local.get $a) (local.get $b)))
+    ) (return (i64.gt_s (local.get $a) (local.get $b)))
+    ) (return (i64.le_s (local.get $a) (local.get $b)))
+    ) (return (i64.ge_s (local.get $a) (local.get $b)))
   )
   (i32.const 0)
 )

--- a/src/unifyweaver/targets/wam_wat_target.pl
+++ b/src/unifyweaver/targets/wam_wat_target.pl
@@ -164,9 +164,9 @@ wam_instruction_to_wat_bytes(get_value(Xn, Ai), _Labels, Hex) :-
 
 wam_instruction_to_wat_bytes(get_structure(F, Ai), _Labels, Hex) :-
     instr_tag(get_structure, Tag),
-    atom_hash_i64(F, FHash),
+    encode_structure_op1(F, Op1),
     reg_name_to_index(Ai, AiIdx),
-    encode_instr_hex(Tag, FHash, AiIdx, Hex).
+    encode_instr_hex(Tag, Op1, AiIdx, Hex).
 
 wam_instruction_to_wat_bytes(get_list(Ai), _Labels, Hex) :-
     instr_tag(get_list, Tag),
@@ -208,9 +208,9 @@ wam_instruction_to_wat_bytes(put_value(Xn, Ai), _Labels, Hex) :-
 
 wam_instruction_to_wat_bytes(put_structure(F, Ai), _Labels, Hex) :-
     instr_tag(put_structure, Tag),
-    atom_hash_i64(F, FHash),
+    encode_structure_op1(F, Op1),
     reg_name_to_index(Ai, AiIdx),
-    encode_instr_hex(Tag, FHash, AiIdx, Hex).
+    encode_instr_hex(Tag, Op1, AiIdx, Hex).
 
 wam_instruction_to_wat_bytes(put_list(Ai), _Labels, Hex) :-
     instr_tag(put_list, Tag),
@@ -284,6 +284,31 @@ encode_constant(N, N) :- integer(N), !.
 encode_constant(N, Bits) :- float(N), !, Bits is float_integer_part(N).
 encode_constant(A, Hash) :- atom(A), !, atom_hash_i64(A, Hash).
 encode_constant(_, 0).
+
+%% encode_structure_op1(+FSlashArity, -I64)
+%  Encodes a functor/arity descriptor (e.g. 'f/2') as an i64 payload.
+%  Layout: high 32 bits = arity, low 32 bits = DJB2 hash of the full
+%  'Functor/Arity' atom form. The low 32 bits retain the existing hash
+%  behavior so backwards compatibility with earlier encoding is exact
+%  when arity fits in 31 bits (it always does here — atom_hash_i64
+%  already limits the hash to 2^31-1). The high 32 bits let the runtime
+%  recover arity for functor/3 and arg/3 without a separate table.
+encode_structure_op1(FSlashArity, Op1) :-
+    atom_hash_i64(FSlashArity, Hash),
+    functor_arity_of(FSlashArity, Arity),
+    Op1 is (Arity << 32) \/ (Hash /\ 0xFFFFFFFF).
+
+%% functor_arity_of(+FSlashArity, -Arity)
+%  Extracts the integer arity from an atom of the form 'Functor/Arity'.
+%  Falls back to 0 if the atom does not match this shape.
+functor_arity_of(FSlashArity, Arity) :-
+    atom_string(FSlashArity, Str),
+    (   split_string(Str, "/", "", Parts),
+        Parts = [_, AStr],
+        number_string(A, AStr)
+    ->  Arity = A
+    ;   Arity = 0
+    ).
 
 %% resolve_label(+Label, +LabelMap, -PC)
 resolve_label(Label, Labels, PC) :-

--- a/templates/targets/wat_wam/module.wat.mustache
+++ b/templates/targets/wat_wam/module.wat.mustache
@@ -3,13 +3,13 @@
 ;; Module: {{module_name}}
 
 (module
-  ;; Memory: page 0 = native WAT, page 1 = WAM state, page 2+ = WAM heap
-  (memory (export "memory") {{memory_pages}})
-
-  ;; Host imports for I/O
+  ;; Host imports for I/O — must appear before any non-import definition
   (import "env" "print_i64" (func $print_i64 (param i64)))
   (import "env" "print_char" (func $print_char (param i32)))
   (import "env" "print_newline" (func $print_newline))
+
+  ;; Memory: page 0 = native WAT, page 1 = WAM state, page 2+ = WAM heap
+  (memory (export "memory") {{memory_pages}})
 
   ;; === Data segments: instruction arrays ===
   {{data_segments}}

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1,0 +1,127 @@
+:- encoding(utf8).
+% Codegen tests for WAM-to-Haskell transpilation.
+%
+% Unlike the WAM-Rust and WAM-WAT targets, Haskell does not have a
+% functional execution harness in this project — there is no GHC on
+% the CI/dev environment and building a full stack/cabal project per
+% test would be prohibitively slow. These tests therefore assert only
+% that the generated Haskell source contains the expected identifiers,
+% patterns, and dispatch cases. Runtime correctness of the new term
+% inspection builtins (functor/3, arg/3, =../2, copy_term/2) is
+% validated via the parallel WAM-Rust integration tests in
+% tests/test_wam_rust_target.pl + the manual cargo-test suite.
+%
+% Usage: swipl -g run_tests -t halt tests/test_wam_haskell_target.pl
+
+:- use_module('../src/unifyweaver/targets/wam_haskell_target').
+
+:- dynamic test_failed/0.
+
+pass(Test) :-
+    format('[PASS] ~w~n', [Test]).
+
+fail_test(Test, Reason) :-
+    format('[FAIL] ~w: ~w~n', [Test, Reason]),
+    (   test_failed -> true ; assert(test_failed) ).
+
+%% Phase 5: Term inspection builtins codegen
+%% --------------------------------------------
+
+test_haskell_helper_functions_present :-
+    Test = 'WAM-Haskell: term-builtin helpers generated',
+    (   compile_wam_runtime_to_haskell([], Code),
+        atom_string(Code, S),
+        %% bindOutput: non-PC-advancing register-binding helper used
+        %% by functor/3, arg/3, =../2 for output positions.
+        sub_string(S, _, _, _, "bindOutput :: Int -> Value -> WamState"),
+        %% copyTermWalk: recursive walker for copy_term/2 that threads
+        %% (counter, varMap) to preserve variable sharing.
+        sub_string(S, _, _, _, "copyTermWalk :: Int -> IM.IntMap Int"),
+        sub_string(S, _, _, _, "copyTermArgs :: Int -> IM.IntMap Int")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing bindOutput/copyTermWalk/copyTermArgs helpers')
+    ).
+
+test_haskell_functor_builtin_present :-
+    Test = 'WAM-Haskell: functor/3 step case generated',
+    (   compile_wam_runtime_to_haskell([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall \"functor/3\""),
+        %% Construct mode: allocates fresh Unbound cells.
+        sub_string(S, _, _, _, "Unbound (c0 + i)"),
+        %% Read mode: pattern matches Str and VList branches.
+        sub_string(S, _, _, _, "Str fn args -> Just (Atom fn, length args)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing functor/3 step case patterns')
+    ).
+
+test_haskell_arg_builtin_present :-
+    Test = 'WAM-Haskell: arg/3 step case generated',
+    (   compile_wam_runtime_to_haskell([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall \"arg/3\""),
+        %% 1-based indexing into Str args list.
+        sub_string(S, _, _, _, "args !! (idx - 1)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing arg/3 step case patterns')
+    ).
+
+test_haskell_univ_builtin_present :-
+    Test = 'WAM-Haskell: =../2 step case generated',
+    (   compile_wam_runtime_to_haskell([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall \"=../2\""),
+        %% Decompose mode: prepends functor atom to arg list.
+        sub_string(S, _, _, _, "VList (Atom fn : args)"),
+        %% Compose mode: rebuilds Str from list head+tail.
+        sub_string(S, _, _, _, "(Atom fname : rest) -> Just (Str fname rest)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing =../2 step case patterns')
+    ).
+
+test_haskell_copy_term_builtin_present :-
+    Test = 'WAM-Haskell: copy_term/2 step case generated',
+    (   compile_wam_runtime_to_haskell([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall \"copy_term/2\""),
+        %% Drives copyTermWalk with the current var counter and an
+        %% empty IntMap (the var map scopes per call).
+        sub_string(S, _, _, _, "copyTermWalk (wsVarCounter s) IM.empty tVal"),
+        %% The walker''s Unbound branch: reuse existing mapping, else
+        %% allocate next counter and extend the map.
+        sub_string(S, _, _, _, "IM.insert vid c m")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing copy_term/2 step case patterns')
+    ).
+
+test_haskell_no_regressions :-
+    %% Smoke-test that adding Phase 5 has not broken pre-existing
+    %% generated helpers (unifyVal, is/2, length/2 dispatch).
+    Test = 'WAM-Haskell: pre-existing builtins still present',
+    (   compile_wam_runtime_to_haskell([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "unifyVal :: Value -> Value -> WamState"),
+        sub_string(S, _, _, _, "BuiltinCall \"is/2\""),
+        sub_string(S, _, _, _, "BuiltinCall \"length/2\""),
+        sub_string(S, _, _, _, "BuiltinCall \"member/2\"")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Pre-existing builtin dispatch cases missing')
+    ).
+
+run_tests :-
+    format('~n========================================~n'),
+    format('WAM-Haskell target: Phase 5 codegen tests~n'),
+    format('========================================~n~n'),
+    test_haskell_helper_functions_present,
+    test_haskell_functor_builtin_present,
+    test_haskell_arg_builtin_present,
+    test_haskell_univ_builtin_present,
+    test_haskell_copy_term_builtin_present,
+    test_haskell_no_regressions,
+    format('~n========================================~n'),
+    (   test_failed
+    ->  format('Tests FAILED~n'), halt(1)
+    ;   format('All tests passed~n')
+    ).
+
+:- initialization(run_tests, main).

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -302,7 +302,14 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, 'number/1'),
         sub_string(S, _, _, _, 'member/2'),
         sub_string(S, _, _, _, 'builtin_state'),
-        sub_string(S, _, _, _, 'eprintln!')
+        sub_string(S, _, _, _, 'eprintln!'),
+        %% Phase 4: Group A term inspection builtins are present.
+        sub_string(S, _, _, _, '"functor/3"'),
+        sub_string(S, _, _, _, '"arg/3"'),
+        sub_string(S, _, _, _, '"=../2"'),
+        sub_string(S, _, _, _, '"copy_term/2"'),
+        %% copy_term_walk helper (sharing-preserving recursive copy).
+        sub_string(S, _, _, _, 'copy_term_walk')
     ->  pass(Test)
     ;   fail_test(Test, 'Missing builtin dispatch cases')
     ).

--- a/tests/test_wam_wat_target.pl
+++ b/tests/test_wam_wat_target.pl
@@ -179,6 +179,32 @@ test(helpers_generated) :-
     assertion(sub_string(HelpersCode, _, _, _, "$unify_regs")),
     assertion(sub_string(HelpersCode, _, _, _, "$execute_builtin")).
 
+%% --- Phase 2.1: arg/3 codegen ---
+
+test(arg_builtin_id_registered) :-
+    assertion(wam_wat_target:builtin_id('arg/3', 19)).
+
+test(arg_helper_generated) :-
+    wam_wat_target:compile_wam_helpers_to_wat([], HelpersCode),
+    %% The $builtin_arg function must be emitted
+    assertion(sub_string(HelpersCode, _, _, _, "$builtin_arg")),
+    %% It must be reachable from $execute_builtin's dispatch — the
+    %% if-chain checks id == 19 and calls $builtin_arg.
+    assertion(sub_string(HelpersCode, _, _, _, "(i32.const 19)")),
+    %% Sanity: the helper body should reference the arity-extraction
+    %% shift (high 32 bits of compound payload).
+    assertion(sub_string(HelpersCode, _, _, _, "i64.shr_u")).
+
+test(arg_builtin_call_encoding) :-
+    %% Verify a builtin_call arg/3 instruction encodes with builtin ID 19.
+    wam_instruction_to_wat_bytes(builtin_call('arg/3', 3), [], Hex),
+    assertion(atom(Hex)),
+    %% Tag byte is builtin_call = 21 = 0x15
+    assertion(sub_string(Hex, 0, _, _, "\\15")),
+    %% Op1 (low byte of i64) should be builtin ID 19 = 0x13
+    sub_atom(Hex, 12, 3, _, FirstOp1Byte),
+    assertion(FirstOp1Byte == '\\13').
+
 %% --- Predicate compilation ---
 
 test(compile_simple_predicate) :-

--- a/tests/test_wam_wat_target.pl
+++ b/tests/test_wam_wat_target.pl
@@ -248,6 +248,26 @@ test(univ_builtin_call_encoding) :-
     sub_atom(Hex, 12, 3, _, FirstOp1Byte),
     assertion(FirstOp1Byte == '\\14').
 
+%% --- Phase 2.4: copy_term/2 codegen ---
+
+test(copy_term_builtin_id_registered) :-
+    assertion(wam_wat_target:builtin_id('copy_term/2', 21)).
+
+test(copy_term_helper_generated) :-
+    wam_wat_target:compile_wam_helpers_to_wat([], HelpersCode),
+    assertion(sub_string(HelpersCode, _, _, _, "$builtin_copy_term")),
+    %% Sharing-preservation var map is referenced explicitly.
+    assertion(sub_string(HelpersCode, _, _, _, "var map")),
+    %% Dispatch: if-chain checks id == 21.
+    assertion(sub_string(HelpersCode, _, _, _, "(i32.const 21)")).
+
+test(copy_term_builtin_call_encoding) :-
+    wam_instruction_to_wat_bytes(builtin_call('copy_term/2', 2), [], Hex),
+    assertion(atom(Hex)),
+    %% Op1 low byte = builtin ID 21 = 0x15
+    sub_atom(Hex, 12, 3, _, FirstOp1Byte),
+    assertion(FirstOp1Byte == '\\15').
+
 %% --- Predicate compilation ---
 
 test(compile_simple_predicate) :-
@@ -367,6 +387,35 @@ run_wam_wat_module_export(WatFile, ExportName, Result) :-
         number_string(Result, RS)
     ->  true
     ;   throw(wam_wat_runtime_error(run(RExit, RunOut)))
+    ).
+
+test(functional_copy_term_compound, [condition(tool_available(wat2wasm)),
+                                       condition(tool_available(node))]) :-
+    %% End-to-end: copy_term(foo(a, b), _) should succeed. The source
+    %% compound has only atomic args, so the sharing-preservation path
+    %% is not exercised here — that is covered by codegen assertions
+    %% only in v1. The test validates that the dispatch + in-place
+    %% compound copy + trail binding path all run to completion.
+    get_time(T),
+    format(atom(WatFile),
+        '/data/data/com.termux/files/home/tmp/test_wam_func_copy_~w.wat', [T]),
+    assertz(user:test_func_copy :- copy_term(foo(a, b), _)),
+    setup_call_cleanup(
+        true,
+        (   write_wam_wat_project([test_func_copy/0],
+                                  [module_name(func_copy_test)], WatFile),
+            run_wam_wat_module_export(WatFile, test_func_copy_0, Result),
+            (   Result =:= 1
+            ->  true
+            ;   throw(wam_wat_runtime_error(copy_term_failed(Result)))
+            )
+        ),
+        (   retractall(user:test_func_copy),
+            (exists_file(WatFile) -> delete_file(WatFile) ; true),
+            file_name_extension(Base, _, WatFile),
+            file_name_extension(Base, wasm, WasmFile),
+            (exists_file(WasmFile) -> delete_file(WasmFile) ; true)
+        )
     ).
 
 test(functional_univ_decompose_compound, [condition(tool_available(wat2wasm)),

--- a/tests/test_wam_wat_target.pl
+++ b/tests/test_wam_wat_target.pl
@@ -226,6 +226,28 @@ test(functor_builtin_call_encoding) :-
     sub_atom(Hex, 12, 3, _, FirstOp1Byte),
     assertion(FirstOp1Byte == '\\12').
 
+%% --- Phase 2.3: =../2 (univ) codegen ---
+
+test(univ_builtin_id_registered) :-
+    assertion(wam_wat_target:builtin_id('=../2', 20)).
+
+test(univ_helper_generated) :-
+    wam_wat_target:compile_wam_helpers_to_wat([], HelpersCode),
+    assertion(sub_string(HelpersCode, _, _, _, "$builtin_univ")),
+    %% Cons cells use tag=4 (list) to match put_list''s runtime layout.
+    %% The empty-list atom hash literal 2914 must appear as the nil
+    %% terminator in the decompose-mode build path.
+    assertion(sub_string(HelpersCode, _, _, _, "2914")),
+    %% Dispatch: if-chain checks id == 20.
+    assertion(sub_string(HelpersCode, _, _, _, "(i32.const 20)")).
+
+test(univ_builtin_call_encoding) :-
+    wam_instruction_to_wat_bytes(builtin_call('=../2', 2), [], Hex),
+    assertion(atom(Hex)),
+    %% Op1 low byte = builtin ID 20 = 0x14
+    sub_atom(Hex, 12, 3, _, FirstOp1Byte),
+    assertion(FirstOp1Byte == '\\14').
+
 %% --- Predicate compilation ---
 
 test(compile_simple_predicate) :-
@@ -345,6 +367,37 @@ run_wam_wat_module_export(WatFile, ExportName, Result) :-
         number_string(Result, RS)
     ->  true
     ;   throw(wam_wat_runtime_error(run(RExit, RunOut)))
+    ).
+
+test(functional_univ_decompose_compound, [condition(tool_available(wat2wasm)),
+                                            condition(tool_available(node))]) :-
+    %% End-to-end: bar(a, b) =.. L should succeed (L is a fresh var on
+    %% first use so decompose mode just builds a fresh cons list and
+    %% binds L). We do not try to unify L with a pre-built list here —
+    %% v1 decompose mode does not structurally unify a bound A2; that
+    %% path is deferred. The test exercises the entire pipeline:
+    %% canonical WAM → builtin_call =../2 → $builtin_univ → cons-list
+    %% construction on the heap → success return.
+    get_time(T),
+    format(atom(WatFile),
+        '/data/data/com.termux/files/home/tmp/test_wam_func_univ_~w.wat', [T]),
+    assertz(user:test_func_univ :- (bar(a, b) =.. _)),
+    setup_call_cleanup(
+        true,
+        (   write_wam_wat_project([test_func_univ/0],
+                                  [module_name(func_univ_test)], WatFile),
+            run_wam_wat_module_export(WatFile, test_func_univ_0, Result),
+            (   Result =:= 1
+            ->  true
+            ;   throw(wam_wat_runtime_error(univ_failed(Result)))
+            )
+        ),
+        (   retractall(user:test_func_univ),
+            (exists_file(WatFile) -> delete_file(WatFile) ; true),
+            file_name_extension(Base, _, WatFile),
+            file_name_extension(Base, wasm, WasmFile),
+            (exists_file(WasmFile) -> delete_file(WasmFile) ; true)
+        )
     ).
 
 test(functional_true_succeeds, [condition(tool_available(wat2wasm)),

--- a/tests/test_wam_wat_target.pl
+++ b/tests/test_wam_wat_target.pl
@@ -263,6 +263,111 @@ test(write_wat_project) :-
 
 %% --- wat2wasm syntax validation ---
 
+%% --- Functional execution via wat2wasm + node ---
+%%
+%% These tests compile a generated .wat to .wasm and actually run it
+%% via Node.js, which provides the `env` host imports the WAM-WAT
+%% runtime requires (print_i64, print_char, print_newline). This is
+%% the first layer of real runtime validation for the WAM-WAT target
+%% — everything prior was codegen-only. Tests skip gracefully if
+%% either wat2wasm or node is missing.
+
+tool_available(Tool) :-
+    catch(
+        process_create(path(Tool), ['--version'],
+            [stdout(null), stderr(null)]),
+        _, fail).
+
+%% Build the node harness script that loads a .wasm and calls an export.
+%% Written to a tmp file on first use. Returns the RESULT value on stdout.
+node_harness_source(Src) :-
+    Src = "const fs=require('fs');\n\c
+const [,,wasmPath,exportName]=process.argv;\n\c
+const bytes=fs.readFileSync(wasmPath);\n\c
+const log=[];\n\c
+const imports={env:{\n\c
+  print_i64:v=>log.push(String(v)),\n\c
+  print_char:c=>log.push(String.fromCharCode(c)),\n\c
+  print_newline:()=>log.push('\\n')\n\c
+}};\n\c
+(async()=>{\n\c
+  try{\n\c
+    const{instance}=await WebAssembly.instantiate(bytes,imports);\n\c
+    const fn=instance.exports[exportName];\n\c
+    if(typeof fn!=='function'){console.log('ERROR export '+exportName+' not found');process.exit(1);}\n\c
+    const result=fn();\n\c
+    for(const line of log)process.stderr.write(line);\n\c
+    console.log('RESULT '+result);\n\c
+  }catch(e){console.log('ERROR '+e.message);process.exit(1);}\n\c
+})();\n".
+
+ensure_node_harness(HarnessPath) :-
+    HarnessPath = '/data/data/com.termux/files/home/tmp/wam_wat_test_harness.js',
+    (   exists_file(HarnessPath)
+    ->  true
+    ;   node_harness_source(Src),
+        open(HarnessPath, write, S),
+        write(S, Src),
+        close(S)
+    ).
+
+%% run_wam_wat_module_export(+WatFile, +ExportName, -Result)
+%%   Compile WatFile with wat2wasm, run with node harness, unify Result
+%%   with the i32 return value. Throws wam_wat_runtime_skip(Reason) if
+%%   the toolchain is unavailable. Throws wam_wat_runtime_error(Detail)
+%%   on compilation or execution failure.
+run_wam_wat_module_export(WatFile, ExportName, Result) :-
+    (   tool_available(wat2wasm), tool_available(node)
+    ->  true
+    ;   throw(wam_wat_runtime_skip(tools_missing))
+    ),
+    file_name_extension(Base, _, WatFile),
+    file_name_extension(Base, wasm, WasmFile),
+    format(string(CompileCmd), "wat2wasm ~w -o ~w 2>&1", [WatFile, WasmFile]),
+    process_create(path(sh), ['-c', CompileCmd],
+        [stdout(pipe(COut)), process(CPid)]),
+    read_string(COut, _, CompileOut),
+    close(COut),
+    process_wait(CPid, CExit),
+    (   CExit == exit(0)
+    ->  true
+    ;   throw(wam_wat_runtime_error(compile(CompileOut)))
+    ),
+    ensure_node_harness(Harness),
+    process_create(path(node), [Harness, WasmFile, ExportName],
+        [stdout(pipe(ROut)), stderr(null), process(RPid)]),
+    read_string(ROut, _, RunOut),
+    close(ROut),
+    process_wait(RPid, RExit),
+    (   sub_string(RunOut, _, _, _, "RESULT "),
+        split_string(RunOut, " \n", " \n", Parts),
+        append(_, ["RESULT", RS|_], Parts),
+        number_string(Result, RS)
+    ->  true
+    ;   throw(wam_wat_runtime_error(run(RExit, RunOut)))
+    ).
+
+test(functional_true_succeeds, [condition(tool_available(wat2wasm)),
+                                 condition(tool_available(node))]) :-
+    get_time(T),
+    format(atom(WatFile),
+        '/data/data/com.termux/files/home/tmp/test_wam_func_true_~w.wat', [T]),
+    assertz(user:test_func_true :- true),
+    setup_call_cleanup(
+        true,
+        (   write_wam_wat_project([test_func_true/0],
+                                  [module_name(func_true_test)], WatFile),
+            run_wam_wat_module_export(WatFile, test_func_true_0, Result),
+            assertion(Result =:= 1)
+        ),
+        (   retractall(user:test_func_true),
+            (exists_file(WatFile) -> delete_file(WatFile) ; true),
+            file_name_extension(Base, _, WatFile),
+            file_name_extension(Base, wasm, WasmFile),
+            (exists_file(WasmFile) -> delete_file(WasmFile) ; true)
+        )
+    ).
+
 test(wat2wasm_validates) :-
     %% Generate a minimal WAM-WAT module and verify wat2wasm accepts it
     %% (exit 0). The earlier version of this test used assertion/1 on

--- a/tests/test_wam_wat_target.pl
+++ b/tests/test_wam_wat_target.pl
@@ -264,31 +264,42 @@ test(write_wat_project) :-
 %% --- wat2wasm syntax validation ---
 
 test(wat2wasm_validates) :-
+    %% Generate a minimal WAM-WAT module and verify wat2wasm accepts it
+    %% (exit 0). The earlier version of this test used assertion/1 on
+    %% the exit code, which only *warns* on failure rather than failing
+    %% the test; that allowed the step-dispatch off-by-one bug and a
+    %% paren imbalance in $builtin_arith_cmp to ship unnoticed. The
+    %% assertion is now replaced with a direct unification that fails
+    %% the test on non-zero exit.
     get_time(T),
-    format(atom(TmpWat), '/tmp/test_wam_validate_~w.wat', [T]),
-    format(atom(TmpWasm), '/tmp/test_wam_validate_~w.wasm', [T]),
+    TmpDir = '/data/data/com.termux/files/home/tmp',
+    format(atom(TmpWat), '~w/test_wam_validate_~w.wat', [TmpDir, T]),
+    format(atom(TmpWasm), '~w/test_wam_validate_~w.wasm', [TmpDir, T]),
     assertz(user:test_validate :- true),
     Predicates = [test_validate/0],
     Options = [module_name(validate_test)],
-    (   catch(
-            write_wam_wat_project(Predicates, Options, TmpWat),
-            _, fail)
-    ->  %% Try wat2wasm validation
-        (   catch(process_create(path(wat2wasm), ['--version'],
-                    [stdout(null), stderr(null)]), _, fail)
-        ->  format(string(Cmd), "wat2wasm ~w -o ~w 2>&1", [TmpWat, TmpWasm]),
-            process_create(path(sh), ['-c', Cmd],
-                [stdout(pipe(Out)), process(Pid)]),
-            read_string(Out, _, Output),
-            process_wait(Pid, Exit),
-            format('wat2wasm output: ~s~n', [Output]),
-            assertion(Exit == exit(0))
-        ;   format("wat2wasm not found, skipping syntax validation.~n")
+    setup_call_cleanup(
+        true,
+        (   write_wam_wat_project(Predicates, Options, TmpWat),
+            (   catch(process_create(path(wat2wasm), ['--version'],
+                        [stdout(null), stderr(null)]), _, fail)
+            ->  format(string(Cmd), "wat2wasm ~w -o ~w 2>&1", [TmpWat, TmpWasm]),
+                process_create(path(sh), ['-c', Cmd],
+                    [stdout(pipe(Out)), process(Pid)]),
+                read_string(Out, _, Output),
+                process_wait(Pid, Exit),
+                (   Exit == exit(0)
+                ->  true
+                ;   format(user_error, 'wat2wasm failed: ~s~n', [Output]),
+                    fail
+                )
+            ;   format("wat2wasm not found, skipping syntax validation.~n")
+            )
+        ),
+        (   retractall(user:test_validate),
+            (exists_file(TmpWat) -> delete_file(TmpWat) ; true),
+            (exists_file(TmpWasm) -> delete_file(TmpWasm) ; true)
         )
-    ;   format("write_wam_wat_project failed, skipping validation.~n")
-    ),
-    retractall(user:test_validate),
-    (exists_file(TmpWat) -> delete_file(TmpWat) ; true),
-    (exists_file(TmpWasm) -> delete_file(TmpWasm) ; true).
+    ).
 
 :- end_tests(wam_wat_target).

--- a/tests/test_wam_wat_target.pl
+++ b/tests/test_wam_wat_target.pl
@@ -71,6 +71,21 @@ test(encode_get_structure) :-
     assertion(atom(Hex)),
     assertion(sub_string(Hex, 0, _, _, "\\03")).  % tag=3
 
+%% Verify arity is packed into the high 32 bits of the op1 i64.
+%% Byte layout: bytes 0-3 = tag, 4-11 = op1 (little-endian), 12-19 = op2.
+%% Each byte renders as 3 chars in the hex atom: "\XX". So byte N starts
+%% at offset N*3. Bytes 8-11 (high 32 bits of op1) contain the arity.
+%% For 'f/2' we expect \02\00\00\00 at bytes 8-11 (offset 24, length 12).
+test(encode_get_structure_arity_packed) :-
+    wam_instruction_to_wat_bytes(get_structure('f/2', 'A1'), [], Hex),
+    sub_atom(Hex, 24, 12, _, HighBytes),
+    assertion(HighBytes == '\\02\\00\\00\\00').
+
+test(encode_put_structure_arity_packed) :-
+    wam_instruction_to_wat_bytes(put_structure('g/3', 'A1'), [], Hex),
+    sub_atom(Hex, 24, 12, _, HighBytes),
+    assertion(HighBytes == '\\03\\00\\00\\00').
+
 test(encode_get_list) :-
     wam_instruction_to_wat_bytes(get_list('A1'), [], Hex),
     assertion(atom(Hex)),

--- a/tests/test_wam_wat_target.pl
+++ b/tests/test_wam_wat_target.pl
@@ -205,6 +205,27 @@ test(arg_builtin_call_encoding) :-
     sub_atom(Hex, 12, 3, _, FirstOp1Byte),
     assertion(FirstOp1Byte == '\\13').
 
+%% --- Phase 2.2: functor/3 codegen ---
+
+test(functor_builtin_id_registered) :-
+    assertion(wam_wat_target:builtin_id('functor/3', 18)).
+
+test(functor_helper_generated) :-
+    wam_wat_target:compile_wam_helpers_to_wat([], HelpersCode),
+    assertion(sub_string(HelpersCode, _, _, _, "$builtin_functor")),
+    %% Both modes: construct branch uses i64.shl to pack arity,
+    %% read branch uses i64.shr_u to extract it.
+    assertion(sub_string(HelpersCode, _, _, _, "i64.shl")),
+    %% Dispatch: if-chain checks id == 18 for functor/3.
+    assertion(sub_string(HelpersCode, _, _, _, "(i32.const 18)")).
+
+test(functor_builtin_call_encoding) :-
+    wam_instruction_to_wat_bytes(builtin_call('functor/3', 3), [], Hex),
+    assertion(atom(Hex)),
+    %% Op1 low byte = builtin ID 18 = 0x12
+    sub_atom(Hex, 12, 3, _, FirstOp1Byte),
+    assertion(FirstOp1Byte == '\\12').
+
 %% --- Predicate compilation ---
 
 test(compile_simple_predicate) :-


### PR DESCRIPTION
## Summary

- Implement a new WAM transpilation target generating self-contained `.wat` (WebAssembly Text format) modules
- Eliminates the LLVM toolchain dependency for WASM output — generates readable WAT that compiles directly with `wat2wasm`
- Follows the established WAM target pattern (Go, Rust, LLVM, ILAsm, Elixir, JVM) as the 7th transpilation target

## Architecture

### Memory Layout (linear memory, 4 pages)

| Page | Offset | Purpose |
|------|--------|---------|
| 0 | 0–65535 | Reserved for native WAT target (strings, memo, graphs, facts) |
| 1 | 65536–131071 | WAM state: globals, 64 registers (12 bytes each), trail stack, env/choice point stack |
| 2+ | 131072+ | WAM heap (bump-allocated, backtrack-rewindable) |

### Value Representation

12-byte tagged cells: `[tag:i32][payload:i64]`
- Tags 0–7: Atom, Integer, Float, Compound, List, Ref, Unbound, Bool
- Atoms encoded as DJB2 hashes matching the native WAT target

### Instruction Dispatch

- 25 WAM instructions encoded as 20-byte data segments (`[tag:i32][op1:i64][op2:i64]`)
- O(1) dispatch via `br_table` with nested blocks calling `$do_*` helper functions
- Iterative `$run_loop` (fetch/step/backtrack) — no musttail needed

### Choice Points

- Full register save/restore (780 bytes per CP, derived from `wam_cp_size/1`)
- Trail-based backtracking with `$unwind_trail`
- CP size derived from constants (`wam_num_regs/1`, `wam_val_size/1`) — auto-adapts to register count changes

### Hybrid Compilation

- Tries native WAT lowering first via `wat_target:compile_predicate_to_wat/3`
- Falls back to WAM compilation for complex predicates
- Both coexist in the same `.wat` module without memory conflicts

## Changes

### New files (6 files, +1,670 lines)

**`src/unifyweaver/targets/wam_wat_target.pl`** (1,141 lines) — Core transpiler:
- `wam_instruction_to_wat_bytes/3` — encodes all 25 WAM instructions to data segments
- `compile_step_wam_to_wat/2` — generates `br_table` dispatch + 25 `$do_*` functions
- `compile_wam_helpers_to_wat/2` — run loop, backtracking, trail, unification, builtin dispatch
- `compile_wam_predicate_to_wat/4` — WAM text → data segment + entry function
- `write_wam_wat_project/3` — full `.wat` module assembly with hybrid compilation

**`templates/targets/wat_wam/`** (4 mustache templates):
- `value.wat.mustache` (82 lines) — tag constants, value load/store/compare helpers
- `state.wat.mustache` (170 lines) — WAM state accessors, register file, trail, heap, stack management
- `runtime.wat.mustache` (11 lines) — wrapper for generated step + helper functions
- `module.wat.mustache` (34 lines) — top-level `(module ...)` assembly with imports/exports

**`tests/test_wam_wat_target.pl`** (232 lines) — 33 unit tests

### Builtins implemented

`write/1`, `nl/0`, `is/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `true/0`, `fail/0`, `!/0`

## Test plan

- [x] 4 register mapping tests (A1→0, A2→1, X1→32, Y1→32)
- [x] 2 atom hashing tests (deterministic, collision-free)
- [x] 22 instruction encoding tests (all 25 instruction types, minus call/execute/retry which need labels)
- [x] 1 `br_table` step dispatch generation test
- [x] 1 helpers generation test
- [x] 1 predicate compilation test
- [x] 1 end-to-end `.wat` module generation test
- [x] 1 `wat2wasm` syntax validation test (compiles generated `.wat`, asserts exit(0))

### Known limitations (tracked for follow-up)

- Builtins `functor/3`, `arg/3`, `=../2`, `copy_term/2`, `assert`/`retract` not yet implemented
- `runtime.wat.mustache` template boundary documentation pending
