### PR TITLE
refactor(rust): split wrapper compute and filter stages

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -4348,9 +4348,6 @@ rust_foreign_scalar_min_terminal_code(Indent, FilterVar, OutputVar, SetupCode, V
       Indent,
       Indent,
       Indent,
-      Indent,
-      Indent,
-      Indent,
       Indent]).
 
 rust_foreign_grouped_min_terminal_code(Indent, FilterVar, OutputVar, SetupCode, ValueExpr, FilterCond, Code) :-
@@ -4375,25 +4372,7 @@ rust_foreign_grouped_min_terminal_code(Indent, FilterVar, OutputVar, SetupCode, 
 rust_foreign_terminal_code(stream, Indent, FilterVar, OutputVar, SetupCode, ValueExpr, FilterCond, Code) :-
     rust_foreign_stream_terminal_code(Indent, FilterVar, OutputVar, SetupCode, ValueExpr, FilterCond, Code).
 rust_foreign_terminal_code(scalar_min, Indent, FilterVar, OutputVar, SetupCode, ValueExpr, FilterCond, Code) :-
-    rust_foreign_wrapper_filter_expr(FilterVar, OutputVar, FilterExpr),
-    format(string(Code),
-'~w~wif (~w)
-~w    && (~w) {
-~w    let agg_value = ~w;
-~w    best = Some(match best {
-~w        Some(current) => current.min(agg_value),
-~w        None => agg_value,
-~w    });
-~w}
-', [SetupCode,
-      Indent, FilterExpr,
-      Indent, FilterCond,
-      Indent, ValueExpr,
-      Indent,
-      Indent,
-      Indent,
-      Indent,
-      Indent]).
+    rust_foreign_scalar_min_terminal_code(Indent, FilterVar, OutputVar, SetupCode, ValueExpr, FilterCond, Code).
 rust_foreign_terminal_code(grouped_min, Indent, FilterVar, OutputVar, SetupCode, ValueExpr, FilterCond, Code) :-
     rust_foreign_grouped_min_terminal_code(Indent, FilterVar, OutputVar, SetupCode, ValueExpr, FilterCond, Code).
 
@@ -5221,15 +5200,41 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
     ).
 
 rust_foreign_wrapper_goal_logic(GoalInfo, GoalArgs, Expr, SetupCode, ValueExpr, FilterCond) :-
+    rust_foreign_wrapper_stage_plan(GoalInfo, GoalArgs, Expr, StagePlan),
+    rust_foreign_wrapper_render_stage_plan(StagePlan, SetupCode, ValueExpr, FilterCond).
+
+rust_foreign_wrapper_stage_plan(GoalInfo, GoalArgs, Expr,
+        wrapper_stage_plan(ComputeStage, FilterStages)) :-
     get_dict(other, GoalInfo, []),
-    rust_foreign_wrapper_value_expr(Expr, GoalInfo, GoalArgs, SetupCode, ValueExpr),
+    rust_foreign_wrapper_compute_stage(Expr, GoalInfo, GoalArgs, ComputeStage),
     get_dict(constraints, GoalInfo, Constraints),
-    findall(Part,
+    findall(filter_stage(Part),
         ( member(Constraint, Constraints),
           rust_foreign_wrapper_constraint_expr(Constraint, GoalArgs, Expr, Part)
         ),
-        Parts),
+        FilterStages).
+
+rust_foreign_wrapper_render_stage_plan(wrapper_stage_plan(ComputeStage, FilterStages),
+        SetupCode, ValueExpr, FilterCond) :-
+    rust_foreign_wrapper_render_compute_stage(ComputeStage, SetupCode, ValueExpr),
+    findall(Part, member(filter_stage(Part), FilterStages), Parts),
     rust_combine_pipeline_conditions(Parts, FilterCond).
+
+rust_foreign_wrapper_compute_stage(Expr, GoalInfo, GoalArgs, passthrough_stage("cost")) :-
+    last(GoalArgs, CostArg),
+    Expr == CostArg,
+    get_dict(other, GoalInfo, []).
+rust_foreign_wrapper_compute_stage(Expr, GoalInfo, GoalArgs, compute_stage("agg_value", RustExpr)) :-
+    get_dict(other, GoalInfo, []),
+    get_dict(arithmetic, GoalInfo, Arithmetic),
+    member(Arithmetic0, Arithmetic),
+    strip_module(Arithmetic0, _, ArithmeticGoal),
+    ArithmeticGoal = (Expr is ArithmeticExpr),
+    rust_foreign_wrapper_numeric_expr(ArithmeticExpr, GoalArgs, Expr, RustExpr).
+
+rust_foreign_wrapper_render_compute_stage(passthrough_stage(ValueExpr), "", ValueExpr).
+rust_foreign_wrapper_render_compute_stage(compute_stage(ValueExpr, RustExpr), SetupCode, ValueExpr) :-
+    format(string(SetupCode), '            let ~w = ~w;~n', [ValueExpr, RustExpr]).
 
 rust_foreign_wrapper_value_expr(Expr, GoalInfo, GoalArgs, "", "cost") :-
     last(GoalArgs, CostArg),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -592,6 +592,28 @@ test_foreign_stream_wrapper_plan_ir :-
     ;   fail_test(Test, 'Foreign stream wrapper plan IR did not match expected multistage shape')
     ).
 
+test_foreign_wrapper_stage_plan_ir :-
+    Test = 'WAM-Rust: foreign wrapper stage plan separates compute and filter stages',
+    Head =.. [bucketed_adjusted_weighted_path, Start, Bucket, Adjusted],
+    Body = ( weighted_path(Start, Target, Cost),
+             target_label(Target, Label),
+             label_bucket(Label, Bucket),
+             Cost > 2,
+             Adjusted is Cost + 1 ),
+    (   rust_target:rust_foreign_stream_wrapper_plan(bucketed_adjusted_weighted_path, 3, Head, Body,
+            foreign_wrapper_plan(_, _, GoalArgs, Adjusted, GoalInfo)),
+        rust_target:rust_foreign_wrapper_stage_plan(GoalInfo, GoalArgs, Adjusted, StagePlan),
+        StagePlan = wrapper_stage_plan(
+            compute_stage("agg_value", "(cost + 1_f64)"),
+            [filter_stage("cost > 2_f64")]),
+        rust_target:rust_foreign_wrapper_render_stage_plan(StagePlan, SetupCode, ValueExpr, FilterCond),
+        SetupCode == "            let agg_value = (cost + 1_f64);\n",
+        ValueExpr == "agg_value",
+        FilterCond == 'cost > 2_f64'
+    ->  pass(Test)
+    ;   fail_test(Test, 'Foreign wrapper stage plan did not separate compute/filter stages')
+    ).
+
 test_foreign_aggregate_wrapper_plan_ir :-
     Test = 'WAM-Rust: foreign aggregate wrapper plan normalizes scalar and grouped terminals',
     ScalarHead =.. [bucketed_min_semantic_dist, Start, Bucket, MinDist],
@@ -1447,6 +1469,7 @@ run_tests :-
     test_recursive_kernel_spec_generation,
     test_recursive_kernel_registry,
     test_foreign_stream_wrapper_plan_ir,
+    test_foreign_wrapper_stage_plan_ir,
     test_foreign_aggregate_wrapper_plan_ir,
     test_wam_fallback_enabled,
     test_wam_fallback_disabled,


### PR DESCRIPTION
## Summary

This PR introduces a small wrapper-stage IR for Rust WAM foreign wrapper lowering. The existing wrapper goal logic now builds a `wrapper_stage_plan(...)` that separates compute stages from filter stages, then renders that plan back into the same generated Rust code shape.

This is a structural refactor toward a fuller recursive wrapper-plan emitter. It keeps behavior stable while making `compute(...)` and `filter(...)` explicit stage concepts instead of implicit pieces of `rust_foreign_wrapper_goal_logic/6`.

## What Changed

- Added `rust_foreign_wrapper_stage_plan/4` to normalize wrapper compute/filter logic into `wrapper_stage_plan(ComputeStage, FilterStages)`.
- Added `rust_foreign_wrapper_render_stage_plan/4` to render stage plans back into `SetupCode`, `ValueExpr`, and `FilterCond`.
- Added compute stage forms for passthrough cost values and arithmetic-derived aggregate values.
- Added filter stage normalization around existing wrapper constraint rendering.
- Routed `rust_foreign_wrapper_goal_logic/6` through the new stage-plan build/render path.
- Reused the shared scalar terminal helper for `scalar_min` terminal-mode rendering instead of duplicating scalar min emission.
- Added target coverage proving mixed-goal wrappers separate compute and filter stages.

## Why

The Rust WAM wrapper emitter now has shared terminal traversal for stream, scalar min, and grouped min outputs. The remaining architectural gap is stage ownership: filters and computes were still implicit shell logic.

This PR makes those stages explicit without changing generated wrapper behavior, which sets up the next step: letting a fuller recursive wrapper-plan emitter own source kernel execution, joins, filters, computes, and terminal selection as one staged lowering pipeline.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`

Both suites passed locally on Termux/Samsung S24+.

## Notes

Existing Prolog warnings about predicate ordering and singleton variables are unchanged by this PR.
