### PR TITLE
Route Rust WAM stream wrappers through the stage emitter

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -4388,6 +4388,12 @@ rust_foreign_wrapper_traversal_code(JoinPreds, FilterVar, _OutputVar, InputLooku
         SetupCode, ValueExpr, FilterCond, TerminalCode),
     rust_foreign_stage_chain_code(JoinSpecs, InputLookupExpr, Indent, TerminalCode, Code).
 
+rust_foreign_wrapper_stage_traversal_code(JoinPreds, FilterVar, OutputVar, InputLookupExpr, Indent,
+        TerminalMode, StagePlan, Code) :-
+    rust_foreign_wrapper_render_stage_plan(StagePlan, SetupCode, ValueExpr, FilterCond),
+    rust_foreign_wrapper_traversal_code(JoinPreds, FilterVar, OutputVar, InputLookupExpr, Indent,
+        TerminalMode, SetupCode, ValueExpr, FilterCond, Code).
+
 compile_rust_foreign_stream_wrapper_from_plan(Pred, 3,
         foreign_wrapper_plan(
             weighted_kernel(InnerPred, WeightPred/3, FactTriples),
@@ -4396,8 +4402,8 @@ compile_rust_foreign_stream_wrapper_from_plan(Pred, 3,
             HeadResult,
             GoalInfo),
         RustCode) :-
-    rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalOutput, GoalCost],
-        HeadResult, SetupCode, ValueExpr, FilterCond),
+    GoalArgs = [GoalStart, GoalOutput, GoalCost],
+    rust_foreign_wrapper_stage_plan(GoalInfo, GoalArgs, HeadResult, StagePlan),
     ( JoinPreds == []
     -> TargetFilterCode =
 '    let target_filter = match &a2 {
@@ -4423,8 +4429,8 @@ compile_rust_foreign_stream_wrapper_from_plan(Pred, 3,
             },
             _ => break,
         };',
-       rust_foreign_wrapper_traversal_code([], "target_filter", "target", "&target", "        ",
-           stream, SetupCode, ValueExpr, FilterCond, TraversalCode)
+       rust_foreign_wrapper_stage_traversal_code([], "target_filter", "target", "&target", "        ",
+           stream, StagePlan, TraversalCode)
     ; JoinPreds \= [],
        TargetFilterCode =
 '    let join_filter = match &a2 {
@@ -4443,8 +4449,8 @@ compile_rust_foreign_stream_wrapper_from_plan(Pred, 3,
         };',
        rust_render_join_specs(JoinPreds, JoinSpecs),
        rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
-       rust_foreign_wrapper_traversal_code(JoinPreds, "join_filter", "target", "&target", "        ",
-           stream, SetupCode, ValueExpr, FilterCond, TraversalCode)
+       rust_foreign_wrapper_stage_traversal_code(JoinPreds, "join_filter", "target", "&target", "        ",
+           stream, StagePlan, TraversalCode)
     ; fail
     ),
     atom_string(Pred, PredStr),
@@ -4518,8 +4524,8 @@ compile_rust_foreign_stream_wrapper_from_plan(Pred, 4,
             HeadResult,
             GoalInfo),
         RustCode) :-
-    rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalOutput, GoalDim, GoalCost],
-        HeadResult, SetupCode, ValueExpr, FilterCond),
+    GoalArgs = [GoalStart, GoalOutput, GoalDim, GoalCost],
+    rust_foreign_wrapper_stage_plan(GoalInfo, GoalArgs, HeadResult, StagePlan),
     ( JoinPreds == []
     -> TargetFilterCode =
 '    let target_filter = match &a2 {
@@ -4546,8 +4552,8 @@ compile_rust_foreign_stream_wrapper_from_plan(Pred, 4,
             },
             _ => break,
         };',
-       rust_foreign_wrapper_traversal_code([], "target_filter", "target", "&target", "        ",
-           stream, SetupCode, ValueExpr, FilterCond, TraversalCode)
+       rust_foreign_wrapper_stage_traversal_code([], "target_filter", "target", "&target", "        ",
+           stream, StagePlan, TraversalCode)
     ; JoinPreds \= [],
        TargetFilterCode =
 '    let join_filter = match &a2 {
@@ -4567,8 +4573,8 @@ compile_rust_foreign_stream_wrapper_from_plan(Pred, 4,
         };',
        rust_render_join_specs(JoinPreds, JoinSpecs),
        rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
-       rust_foreign_wrapper_traversal_code(JoinPreds, "join_filter", "target", "&target", "        ",
-           stream, SetupCode, ValueExpr, FilterCond, TraversalCode)
+       rust_foreign_wrapper_stage_traversal_code(JoinPreds, "join_filter", "target", "&target", "        ",
+           stream, StagePlan, TraversalCode)
     ; fail
     ),
     rust_render_astar_kernel(

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -621,6 +621,27 @@ test_foreign_wrapper_stage_plan_ir :-
     ;   fail_test(Test, 'Foreign wrapper stage plan did not separate compute/filter stages')
     ).
 
+test_foreign_stream_stage_traversal_ir :-
+    Test = 'WAM-Rust: foreign stream wrapper stage emitter renders joined traversal',
+    Head =.. [bucketed_adjusted_weighted_path, Start, Bucket, Adjusted],
+    Body = ( weighted_path(Start, Target, Cost),
+             target_label(Target, Label),
+             label_bucket(Label, Bucket),
+             Cost > 2,
+             Adjusted is Cost + 1 ),
+    (   rust_target:rust_foreign_stream_wrapper_plan(bucketed_adjusted_weighted_path, 3, Head, Body,
+            foreign_wrapper_plan(_, JoinPreds, GoalArgs, Adjusted, GoalInfo)),
+        rust_target:rust_foreign_wrapper_stage_plan(GoalInfo, GoalArgs, Adjusted, StagePlan),
+        rust_target:rust_foreign_wrapper_stage_traversal_code(JoinPreds, "join_filter", "target", "&target", "        ",
+            stream, StagePlan, TraversalCode),
+        sub_string(TraversalCode, _, _, _, 'let joined_values_1 = match vm.indexed_atom_fact2.get("target_label/2").and_then(|table| table.get(&target)) {'),
+        sub_string(TraversalCode, _, _, _, 'let joined_values_2 = match vm.indexed_atom_fact2.get("label_bucket/2").and_then(|table| table.get(joined_value_1)) {'),
+        sub_string(TraversalCode, _, _, _, 'let agg_value = (cost + 1_f64);'),
+        sub_string(TraversalCode, _, _, _, 'packed_results.push(Value::Str("__tuple__".to_string(), vec![')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Foreign stream stage traversal did not render expected joined traversal')
+    ).
+
 test_foreign_aggregate_wrapper_plan_ir :-
     Test = 'WAM-Rust: foreign aggregate wrapper plan normalizes scalar and grouped terminals',
     ScalarHead =.. [bucketed_min_semantic_dist, Start, Bucket, MinDist],
@@ -1477,6 +1498,7 @@ run_tests :-
     test_recursive_kernel_registry,
     test_foreign_stream_wrapper_plan_ir,
     test_foreign_wrapper_stage_plan_ir,
+    test_foreign_stream_stage_traversal_ir,
     test_foreign_aggregate_wrapper_plan_ir,
     test_wam_fallback_enabled,
     test_wam_fallback_disabled,


### PR DESCRIPTION
## Summary

This PR routes Rust WAM foreign stream wrapper lowering through the explicit wrapper-stage traversal emitter.

The previous PR introduced `wrapper_stage_plan(...)` for compute/filter ownership. This PR uses that stage plan in stream wrapper codegen by adding a helper that renders `StagePlan + TerminalMode` into traversal code, then applying it to both weighted-path and A* stream wrapper variants.

## What Changed

- Added `rust_foreign_wrapper_stage_traversal_code/8`.
- Routed 3-arg weighted stream wrappers through the stage traversal helper.
- Routed 4-arg A* stream wrappers through the stage traversal helper.
- Kept scalar and grouped aggregate wrapper lowering unchanged for a later, smaller follow-up.
- Added target coverage proving joined stream traversal can be emitted directly from a stage plan.

## Why

The Rust WAM wrapper lowering path is moving from ad-hoc wrapper shell code toward a staged wrapper-plan emitter.

This is the first consumer of the new stage-plan IR in wrapper codegen. It keeps generated stream wrapper behavior stable while making the emitter boundary explicit: joins, compute/filter stages, and terminal mode now flow through one shared traversal helper for stream wrappers.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`

Both suites passed locally on Termux/Samsung S24+.

## Notes

Existing Prolog warnings about predicate ordering and singleton variables are unchanged by this PR.

Recommended next step after merge: route scalar aggregate wrappers through `rust_foreign_wrapper_stage_traversal_code/8`, then follow with grouped aggregate wrappers in a separate PR.
