### PR TITLE
feat(wam-llvm): A* helper + td3 dispatcher delegation (M5.4 + M5.5)

### DIFF
--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -1258,6 +1258,23 @@ fail_free:
   ret i1 false
 }
 
+; === M5.5: Foreign kernel impl default stub ===
+; The dispatcher's stub_transitive_distance3 case delegates to
+; @wam_td3_kernel_impl. The default implementation (below) returns
+; false, so pure WAM modules behave as if foreign dispatch is
+; disabled. When foreign_lowering is enabled, the compile pipeline
+; will emit a non-default definition of this function in place of
+; the default — LLVM doesn't allow two definitions of the same
+; function in one module, so the compile path picks one or the
+; other at generation time.
+;
+; The default definition being here (rather than declared-only) lets
+; llvm-as resolve the call inside stub_transitive_distance3 even for
+; pure-WAM builds that never exercise the stub at runtime.
+define weak i1 @wam_td3_kernel_impl(%WamState* %vm) {
+  ret i1 false
+}
+
 define i1 @wam_execute_foreign_predicate(%WamState* %vm, i32 %kind, i32 %arity) {
 entry:
   switch i32 %kind, label %not_registered [
@@ -1287,8 +1304,11 @@ stub_transitive_closure2:
   ret i1 false
 
 stub_transitive_distance3:
-  ; M5: transitive_distance(Start, End, Dist) via DFS with cycle detection
-  ret i1 false
+  ; Delegate to the user-provided impl. When foreign_lowering is off
+  ; the impl is only declared (not defined) and this stub is never
+  ; actually reached at runtime, so the missing symbol is benign.
+  %td3_r = call i1 @wam_td3_kernel_impl(%WamState* %vm)
+  ret i1 %td3_r
 
 stub_weighted_shortest_path3:
   ; M5: weighted_shortest_path(Start, End, Dist) via Dijkstra

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -1085,6 +1085,179 @@ fail_free:
   ret i1 false
 }
 
+; === M5.4: A* over a %WeightedFact table ===
+; Same as @wam_dijkstra_weighted_distance but orders the frontier by
+; f(n) = g(n) + h(n) instead of just g(n), where g is the best known
+; actual distance from %start and h is a precomputed heuristic estimate
+; of the remaining distance to %target.
+;
+; The heuristic is supplied as a plain double[] indexed by atom ID;
+; %heuristic[i] = estimated distance from node i to %target. Must be
+; admissible (never overestimate) for the result to be optimal.
+;
+; Returns the same g value Dijkstra would return — the heuristic only
+; affects exploration order, not the reported distance.
+;
+; With a zero heuristic this degenerates to Dijkstra. We keep the two
+; helpers separate so the simpler one has no extra parameter and so
+; callers don't allocate a zeroed h[] when they don't want A*.
+define i1 @wam_astar_weighted_distance(
+    i64 %start, i64 %target,
+    %WeightedFact* %table, i64 %len,
+    double* %heuristic,
+    i64 %max_atom_id,
+    double* %out_dist) {
+entry:
+  %is_self = icmp eq i64 %start, %target
+  br i1 %is_self, label %self_hit, label %alloc
+
+self_hit:
+  store double 0.0, double* %out_dist
+  ret i1 true
+
+alloc:
+  %n = add i64 %max_atom_id, 1
+  %best_bytes = shl i64 %n, 3
+  %vis_bytes  = shl i64 %n, 2
+
+  %best_mem = call i8* @malloc(i64 %best_bytes)
+  %vis_mem  = call i8* @malloc(i64 %vis_bytes)
+
+  %best = bitcast i8* %best_mem to double*
+  %visited = bitcast i8* %vis_mem to i32*
+
+  br label %init
+
+init:
+  %ii = phi i64 [0, %alloc], [%ii_next, %init_body]
+  %ii_cmp = icmp ult i64 %ii, %n
+  br i1 %ii_cmp, label %init_body, label %seed
+
+init_body:
+  %best_slot = getelementptr double, double* %best, i64 %ii
+  store double 0x7FF0000000000000, double* %best_slot
+  %vis_slot = getelementptr i32, i32* %visited, i64 %ii
+  store i32 0, i32* %vis_slot
+  %ii_next = add i64 %ii, 1
+  br label %init
+
+seed:
+  %best_start = getelementptr double, double* %best, i64 %start
+  store double 0.0, double* %best_start
+  br label %outer
+
+outer:
+  br label %min_scan
+
+min_scan:
+  %mi = phi i64 [0, %outer], [%mi_next, %min_next]
+  %cur_min_node = phi i64 [-1, %outer], [%upd_node, %min_next]
+  %cur_min_f    = phi double [0x7FF0000000000000, %outer], [%upd_f, %min_next]
+  %mi_cmp = icmp ult i64 %mi, %n
+  br i1 %mi_cmp, label %min_body, label %min_done
+
+min_body:
+  %vis_mi_ptr = getelementptr i32, i32* %visited, i64 %mi
+  %vis_mi = load i32, i32* %vis_mi_ptr
+  %is_unvisited = icmp eq i32 %vis_mi, 0
+  br i1 %is_unvisited, label %min_check_val, label %min_next_noupd
+
+min_check_val:
+  %best_mi_ptr = getelementptr double, double* %best, i64 %mi
+  %best_mi = load double, double* %best_mi_ptr
+  %h_mi_ptr = getelementptr double, double* %heuristic, i64 %mi
+  %h_mi = load double, double* %h_mi_ptr
+  %f_mi = fadd double %best_mi, %h_mi
+  %better = fcmp olt double %f_mi, %cur_min_f
+  br i1 %better, label %min_update, label %min_next_noupd
+
+min_update:
+  br label %min_next
+
+min_next_noupd:
+  br label %min_next
+
+min_next:
+  %upd_node = phi i64 [%mi, %min_update], [%cur_min_node, %min_next_noupd]
+  %upd_f    = phi double [%f_mi, %min_update], [%cur_min_f, %min_next_noupd]
+  %mi_next = add i64 %mi, 1
+  br label %min_scan
+
+min_done:
+  %no_node = icmp eq i64 %cur_min_node, -1
+  br i1 %no_node, label %fail_free, label %check_inf
+
+check_inf:
+  %is_inf = fcmp oeq double %cur_min_f, 0x7FF0000000000000
+  br i1 %is_inf, label %fail_free, label %pick
+
+pick:
+  %pick_vis_ptr = getelementptr i32, i32* %visited, i64 %cur_min_node
+  store i32 1, i32* %pick_vis_ptr
+
+  %is_target = icmp eq i64 %cur_min_node, %target
+  br i1 %is_target, label %hit, label %relax
+
+hit:
+  ; Return g value (actual distance), not f. Load best[target].
+  %best_target_ptr = getelementptr double, double* %best, i64 %target
+  %best_target = load double, double* %best_target_ptr
+  store double %best_target, double* %out_dist
+  br label %free_ok
+
+relax:
+  ; Load the selected node's g value for edge relaxation.
+  %best_pick_ptr = getelementptr double, double* %best, i64 %cur_min_node
+  %best_pick = load double, double* %best_pick_ptr
+  br label %relax_scan
+
+relax_scan:
+  %ri = phi i64 [0, %relax], [%ri_next, %relax_cont]
+  %ri_cmp = icmp ult i64 %ri, %len
+  br i1 %ri_cmp, label %relax_body, label %outer
+
+relax_body:
+  %fp_ptr = getelementptr %WeightedFact, %WeightedFact* %table, i64 %ri
+  %fp_from = getelementptr %WeightedFact, %WeightedFact* %fp_ptr, i32 0, i32 0
+  %fp_to   = getelementptr %WeightedFact, %WeightedFact* %fp_ptr, i32 0, i32 1
+  %fp_w    = getelementptr %WeightedFact, %WeightedFact* %fp_ptr, i32 0, i32 2
+  %edge_from = load i64, i64* %fp_from
+  %edge_to   = load i64, i64* %fp_to
+  %edge_w    = load double, double* %fp_w
+
+  %from_match = icmp eq i64 %edge_from, %cur_min_node
+  br i1 %from_match, label %check_to_range, label %relax_cont
+
+check_to_range:
+  %to_ok = icmp ule i64 %edge_to, %max_atom_id
+  br i1 %to_ok, label %do_relax, label %relax_cont
+
+do_relax:
+  %alt = fadd double %best_pick, %edge_w
+  %best_to_ptr = getelementptr double, double* %best, i64 %edge_to
+  %best_to = load double, double* %best_to_ptr
+  %improved = fcmp olt double %alt, %best_to
+  br i1 %improved, label %store_new, label %relax_cont
+
+store_new:
+  store double %alt, double* %best_to_ptr
+  br label %relax_cont
+
+relax_cont:
+  %ri_next = add i64 %ri, 1
+  br label %relax_scan
+
+free_ok:
+  call void @free(i8* %best_mem)
+  call void @free(i8* %vis_mem)
+  ret i1 true
+
+fail_free:
+  call void @free(i8* %best_mem)
+  call void @free(i8* %vis_mem)
+  ret i1 false
+}
+
 define i1 @wam_execute_foreign_predicate(%WamState* %vm, i32 %kind, i32 %arity) {
 entry:
   switch i32 %kind, label %not_registered [

--- a/tests/core/test_wam_llvm_astar.pl
+++ b/tests/core/test_wam_llvm_astar.pl
@@ -1,0 +1,120 @@
+:- encoding(utf8).
+% test_wam_llvm_astar.pl
+% Verifies M5.4: @wam_astar_weighted_distance helper.
+%
+% A* over a %WeightedFact table with a precomputed heuristic double[]
+% indexed by atom ID. Same structure as Dijkstra but orders the
+% frontier by f(n) = g(n) + h(n).
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3,
+     llvm_emit_weighted_edge_table/3]).
+:- use_module(library(process)).
+
+:- dynamic color/1.
+color(red).
+
+test_helper_defined :-
+    format('--- @wam_astar_weighted_distance defined in template ---~n'),
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project([user:color/1], [module_name('astar_test')], LLPath),
+    read_file_to_string(LLPath, Src, []),
+    ( sub_string(Src, _, _, _, 'define i1 @wam_astar_weighted_distance')
+    -> format('  PASS: helper definition present~n')
+    ;  format('  FAIL: helper missing~n'),
+       throw(helper_missing)
+    ),
+    ( sub_string(Src, _, _, _, '%heuristic')
+    -> format('  PASS: heuristic parameter present~n')
+    ;  format('  FAIL: heuristic parameter missing~n')
+    ),
+    catch(delete_file(LLPath), _, true).
+
+test_astar_module_validates :-
+    format('--- llvm-as + opt verify accept astar caller ---~n'),
+    ( process_which('llvm-as')
+    -> test_astar_llvm_as
+    ;  format('  SKIP: llvm-as not found on PATH~n')
+    ).
+
+test_astar_llvm_as :-
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project([user:color/1], [module_name('astar_test')], LLPath),
+    llvm_emit_weighted_edge_table(astar_demo_graph,
+        [ edge(a, b, 0.5),
+          edge(b, c, 1.5),
+          edge(c, d, 0.3),
+          edge(a, d, 2.0)
+        ], TableCode),
+    % Demo caller provides a 33-entry heuristic array (indices 0..32).
+    % The numbers are arbitrary — we only check that the IR compiles,
+    % not that A* finds the right answer for this particular heuristic.
+    HeuristicIR = '
+@astar_demo_heuristic = private constant [33 x double] [
+  double 0.0, double 1.8, double 1.5, double 0.3, double 0.0,
+  double 0.0, double 0.0, double 0.0, double 0.0, double 0.0,
+  double 0.0, double 0.0, double 0.0, double 0.0, double 0.0,
+  double 0.0, double 0.0, double 0.0, double 0.0, double 0.0,
+  double 0.0, double 0.0, double 0.0, double 0.0, double 0.0,
+  double 0.0, double 0.0, double 0.0, double 0.0, double 0.0,
+  double 0.0, double 0.0, double 0.0
+]
+',
+    CallerIR = '
+define i1 @astar_demo_caller(i64 %start_id, i64 %target_id, double* %out) {
+entry:
+  %table_ptr = getelementptr [4 x %WeightedFact], [4 x %WeightedFact]* @astar_demo_graph, i64 0, i64 0
+  %h_ptr = getelementptr [33 x double], [33 x double]* @astar_demo_heuristic, i64 0, i64 0
+  %ok = call i1 @wam_astar_weighted_distance(
+      i64 %start_id, i64 %target_id,
+      %WeightedFact* %table_ptr, i64 4,
+      double* %h_ptr,
+      i64 32,
+      double* %out)
+  ret i1 %ok
+}
+',
+    setup_call_cleanup(
+        open(LLPath, append, Out),
+        ( write(Out, '\n'), write(Out, TableCode),
+          write(Out, '\n'), write(Out, HeuristicIR),
+          write(Out, '\n'), write(Out, CallerIR),
+          write(Out, '\n') ),
+        close(Out)),
+    atom_concat(LLPath, '.bc', BCPath),
+    format(atom(Cmd), 'llvm-as ~w -o ~w 2>&1', [LLPath, BCPath]),
+    shell(Cmd, Exit),
+    ( Exit == 0
+    -> format('  PASS: llvm-as accepted astar caller module~n')
+    ;  format('  FAIL: llvm-as exit=~w~n', [Exit])
+    ),
+    ( process_which('opt')
+    -> format(atom(VCmd),
+        'opt -passes=verify -disable-output ~w 2>&1', [BCPath]),
+       shell(VCmd, VExit),
+       ( VExit == 0
+       -> format('  PASS: opt -passes=verify accepted bitcode~n')
+       ;  format('  FAIL: opt -passes=verify exit=~w~n', [VExit])
+       )
+    ;  format('  SKIP: opt not found on PATH~n')
+    ),
+    catch(delete_file(LLPath), _, true),
+    catch(delete_file(BCPath), _, true).
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _,
+        fail).
+
+test_all :-
+    test_helper_defined,
+    catch(test_astar_module_validates, E,
+        format('  ERROR in llvm-as test: ~w~n', [E])).
+
+:- initialization(test_all, main).

--- a/tests/core/test_wam_llvm_td3_wiring.pl
+++ b/tests/core/test_wam_llvm_td3_wiring.pl
@@ -1,0 +1,99 @@
+:- encoding(utf8).
+% test_wam_llvm_td3_wiring.pl
+% Verifies M5.5: the transitive_distance3 dispatcher stub delegates
+% to @wam_td3_kernel_impl, and a default weak stub is in place so the
+% pure WAM path still parses and verifies.
+%
+% Why not test an in-module override? LLVM disallows having both a
+% weak default and a strong definition of the same function in the
+% same module — the override mechanism relies on link-time resolution
+% across object files. The compile pipeline (in a follow-up PR) will
+% instead substitute the real body in place of the weak default at
+% template-rendering time rather than appending a duplicate symbol.
+%
+% Checks:
+%   1. @wam_td3_kernel_impl has a weak default definition in the
+%      generated module.
+%   2. stub_transitive_distance3 calls @wam_td3_kernel_impl.
+%   3. The pure WAM module parses with llvm-as.
+%   4. The pure WAM module passes opt -passes=verify.
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3]).
+:- use_module(library(process)).
+
+:- dynamic color/1.
+color(red).
+
+test_impl_weak_default :-
+    format('--- @wam_td3_kernel_impl has weak default in template ---~n'),
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project([user:color/1], [module_name('td3w_test')], LLPath),
+    read_file_to_string(LLPath, Src, []),
+    ( sub_string(Src, _, _, _, 'define weak i1 @wam_td3_kernel_impl(%WamState* %vm)')
+    -> format('  PASS: weak default present~n')
+    ;  format('  FAIL: weak default missing~n'),
+       throw(weak_default_missing)
+    ),
+    catch(delete_file(LLPath), _, true).
+
+test_stub_calls_impl :-
+    format('--- stub_transitive_distance3 delegates to impl ---~n'),
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project([user:color/1], [module_name('td3w_test')], LLPath),
+    read_file_to_string(LLPath, Src, []),
+    ( sub_string(Src, _, _, _, 'call i1 @wam_td3_kernel_impl(%WamState* %vm)')
+    -> format('  PASS: stub calls @wam_td3_kernel_impl~n')
+    ;  format('  FAIL: stub does not delegate to impl~n'),
+       throw(stub_not_wired)
+    ),
+    catch(delete_file(LLPath), _, true).
+
+test_pure_wam_parses :-
+    format('--- llvm-as accepts pure-WAM module ---~n'),
+    ( process_which('llvm-as')
+    -> test_pure_wam_llvm_as
+    ;  format('  SKIP: llvm-as not found~n')
+    ).
+
+test_pure_wam_llvm_as :-
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project([user:color/1], [module_name('td3w_pure')], LLPath),
+    atom_concat(LLPath, '.bc', BCPath),
+    format(atom(Cmd), 'llvm-as ~w -o ~w 2>&1', [LLPath, BCPath]),
+    shell(Cmd, Exit),
+    ( Exit == 0
+    -> format('  PASS: pure-WAM module parses~n')
+    ;  format('  FAIL: llvm-as exit=~w~n', [Exit])
+    ),
+    ( process_which('opt')
+    -> format(atom(VCmd),
+        'opt -passes=verify -disable-output ~w 2>&1', [BCPath]),
+       shell(VCmd, VExit),
+       ( VExit == 0
+       -> format('  PASS: opt -passes=verify accepted bitcode~n')
+       ;  format('  FAIL: opt -passes=verify exit=~w~n', [VExit])
+       )
+    ;  format('  SKIP: opt not found~n')
+    ),
+    catch(delete_file(LLPath), _, true),
+    catch(delete_file(BCPath), _, true).
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _,
+        fail).
+
+test_all :-
+    test_impl_weak_default,
+    test_stub_calls_impl,
+    catch(test_pure_wam_parses, E,
+        format('  ERROR: ~w~n', [E])).
+
+:- initialization(test_all, main).


### PR DESCRIPTION
## Summary

Fourth and fifth steps of Milestone 5 of the hybrid WAM LLVM port.

- **M5.4** — `@wam_astar_weighted_distance`, the computational core of `astar_shortest_path4`. Same structure as the M5.3 Dijkstra helper but orders the frontier by `f(n) = g(n) + h(n)` with a precomputed heuristic array.
- **M5.5** — Dispatcher delegation pattern for `transitive_distance3`. The stub no longer returns `false` directly; it delegates to `@wam_td3_kernel_impl`, which has a weak default that returns `false`. Establishes the override point that a future compile-pipeline PR will use to substitute real kernel bodies.

Both steps preserve the pure WAM path — no `call_foreign` instructions are emitted by default, the dispatcher stub is statically unreachable in pure-WAM modules, and the weak default returns `false` (same as the old inline stub).

## Background

Five-milestone roadmap from prior PRs:

| Milestone | Status | Scope |
|---|---|---|
| M1 | merged (#1298) | `switch_on_constant` + latent IR fixes |
| M2 | merged (#1301) | aggregate frames |
| M3 | merged (#1306) | foreign dispatch scaffolding |
| M4 | merged (#1306) | indexed fact table emission |
| M5.1–M5.3 | merged (#1309) | FFI bridge + BFS + Dijkstra helpers |
| **M5.4 + M5.5** | **this PR** | A* helper + td3 dispatcher delegation |
| M5.6 | upcoming | compile-pipeline substitution — make `foreign_lowering` actually wire things up |

## M5.4: A* Helper

`@wam_astar_weighted_distance` — the computational core of `astar_shortest_path4`. Minimum-weight path with an admissible heuristic over a `%WeightedFact` table.

```llvm
define i1 @wam_astar_weighted_distance(
    i64 %start, i64 %target,
    %WeightedFact* %table, i64 %len,
    double* %heuristic,           ; h[i] for i in 0..%max_atom_id
    i64 %max_atom_id,
    double* %out_dist)
```

### Semantics

- Same init / relaxation / early-exit structure as the M5.3 Dijkstra helper.
- Min-scan body computes `f_mi = best[mi] + heuristic[mi]` before comparing against the current-best `f` value. The min-scan phis carry `(node, f)` instead of `(node, g)`.
- On hit, loads `best[target]` for the return value rather than using the cached `f` value — the heuristic affects exploration order, not the reported distance. **Returns the same `g` value Dijkstra would return**, just (typically) after exploring fewer nodes.
- With a zero heuristic, A* degenerates to Dijkstra. The two helpers are kept separate so the simpler one has no extra parameter and so callers don't allocate a zeroed `h[]` when they don't want A*.
- Heuristic must be admissible (never overestimate the true remaining distance) for the result to be optimal. Non-admissible heuristics produce suboptimal (possibly very wrong) answers.

### Caller Obligation

The `%heuristic` array must have at least `(%max_atom_id + 1)` entries, even for atom IDs that don't appear in the graph (unused slots can be `0.0` or `+inf`). This mirrors the `best[]` and `visited[]` arrays' indexing scheme.

## M5.5: td3 Dispatcher Delegation

### The Change

The dispatcher's `stub_transitive_distance3` case no longer returns `false` directly. Instead it delegates to `@wam_td3_kernel_impl`, which is defined as a weak default:

```llvm
stub_transitive_distance3:
  %td3_r = call i1 @wam_td3_kernel_impl(%WamState* %vm)
  ret i1 %td3_r

define weak i1 @wam_td3_kernel_impl(%WamState* %vm) {
  ret i1 false
}
```

When `foreign_lowering` is enabled in a future PR, the compile pipeline will emit a non-default definition of `@wam_td3_kernel_impl` in place of the weak default — the substitution will happen at template-rendering time.

### Why This Specific Pattern

Two alternative patterns were tried and rejected during development:

**Attempt 1 — `declare` + `define` in the same module.** Rejected: LLVM 21 reports `invalid redefinition of function 'foo'` even though the declaration has no body. This is a behavior change from older LLVM versions.

**Attempt 2 — Extern globals for config (table pointer, length, max_atom_id) with the stub reading them and calling the M5.2 BFS helper directly.** Rejected: LLVM 21 won't let an `external global T` declaration in the runtime template coexist with a concrete `global T value` definition in the user module portion of the same file. The `@td3_edge_table` declaration and the `@td3_edge_table` definition both count as definitions for linkage purposes.

**Attempt 3 (current) — `define weak` default + template-rendering-time substitution.** Accepted: `define weak` + no override in the same module parses cleanly through `llvm-as` and passes `opt -passes=verify`. When the compile pipeline needs to emit a real body, it can splice it in *place of* the weak default rather than *in addition to* it, sidestepping the single-definition rule.

### Pure WAM Path Preserved

- No `call_foreign` instructions are emitted by the default compile flow.
- The `stub_transitive_distance3` case is statically unreachable in pure-WAM modules.
- The weak default returns `false`, which is what the old inline stub used to return.
- Pure-WAM modules still parse through `llvm-as` and pass `opt -passes=verify`.

## Test Coverage

| Suite | Assertions | Scope |
|---|---|---|
| `test_wam_llvm_switch.pl` (M1) | 7 | regression |
| `test_wam_llvm_aggregate.pl` (M2) | 5 | regression |
| `test_wam_llvm_foreign_dispatch.pl` (M3) | 11 | regression |
| `test_wam_llvm_fact_tables.pl` (M4) | 10 | regression |
| `test_wam_llvm_ffi_bridge.pl` (M5.1) | 7 | regression |
| `test_wam_llvm_bfs_atom.pl` (M5.2) | 3 | regression |
| `test_wam_llvm_dijkstra.pl` (M5.3) | 4 | regression |
| `test_wam_llvm_astar.pl` (M5.4) | 4 | **new** |
| `test_wam_llvm_td3_wiring.pl` (M5.5) | 4 | **new** |
| **Total** | **55** | |

### M5.4 Tests (`test_wam_llvm_astar.pl`)

1. `@wam_astar_weighted_distance` definition present.
2. `%heuristic` parameter present in the signature.
3. End-to-end: a module with a 4-node `%WeightedFact` graph, a 33-entry heuristic global, and a demo caller parses with `llvm-as`.
4. `opt -passes=verify` accepts the resulting bitcode.

### M5.5 Tests (`test_wam_llvm_td3_wiring.pl`)

1. `define weak i1 @wam_td3_kernel_impl` present in the generated module.
2. `stub_transitive_distance3` contains `call i1 @wam_td3_kernel_impl(%WamState* %vm)`.
3. Pure WAM module parses with `llvm-as`.
4. `opt -passes=verify` accepts the bitcode.

**What's not tested here:** the concrete override substitution. That requires the template-rendering path to splice a real body in place of the weak default, which is a compile-pipeline change — deferred to M5.6.

## Commits

- `17294213` — feat(wam-llvm): A* helper for astar_shortest_path kernel (M5.4)
- `c5817072` — feat(wam-llvm): td3 dispatcher delegation pattern (M5.5)

## Files Changed

- `templates/targets/llvm_wam/state.ll.mustache` — `@wam_astar_weighted_distance` (M5.4), weak-default `@wam_td3_kernel_impl` + stub delegation (M5.5).
- `tests/core/test_wam_llvm_astar.pl` — new (M5.4).
- `tests/core/test_wam_llvm_td3_wiring.pl` — new (M5.5).

## What's Next: M5.6

Make `foreign_lowering` actually wire things up. Concretely:

1. Add a `foreign_lowering(Kind, Config)` option to `write_wam_llvm_project/3`.
2. Teach the template-rendering path in `wam_llvm_target.pl` to splice a concrete `@wam_td3_kernel_impl` body in place of the weak default when the option is present. The concrete body reads A1/A2 as atoms via the M5.1 FFI bridge, calls `@wam_bfs_atom_distance` with a per-module edge table (emitted via M4's `llvm_emit_atom_fact2_table/3`), and writes A3 via `@wam_set_reg_int`.
3. Teach the compile pipeline to emit a `call_foreign` instruction in place of a normal body when a Prolog predicate is declared foreign (e.g., via a Prolog-level annotation).
4. End-to-end test: a real Prolog predicate annotated as `transitive_distance3` compiles to a module that contains `call_foreign 4, 3`, a concrete `@wam_td3_kernel_impl`, and an `%AtomFactPair` edge table — and the module passes `llvm-as` + `opt -passes=verify`.

Once M5.6 lands, the same pattern can be extended to `weighted_shortest_path3` (using M5.3 Dijkstra) and `astar_shortest_path4` (using M5.4 A*) — each adds a `kernel_impl` weak default and a delegation case.

## Test Plan

- [x] M1–M5.3 regression: all existing WAM-LLVM test suites green (47 assertions).
- [x] M5.4: `swipl -q tests/core/test_wam_llvm_astar.pl`
- [x] M5.5: `swipl -q tests/core/test_wam_llvm_td3_wiring.pl`
- [x] All new IR validates through both `llvm-as` (parse) and `opt -passes=verify` (dominance/SSA check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
