### PR TITLE
Refactor WAM-Rust aggregate wrappers through stage emitter

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -4743,8 +4743,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 3,
     ( Type == group
     -> parse_group_term_rust(GroupTerm, [GroupVar]),
        GroupVar == GoalOutput,
-       rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalOutput, GoalCost],
-           Expr, SetupCode, ValueExpr, FilterCond),
+       GoalArgs = [GoalStart, GoalOutput, GoalCost],
+       rust_foreign_wrapper_stage_plan(GoalInfo, GoalArgs, Expr, StagePlan),
        ( JoinPreds == []
        -> FilterCode =
 '    let output_filter = match &a2 {
@@ -4771,8 +4771,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 3,
             _ => break,
         };',
           JoinRegistrationCode = "",
-          rust_foreign_wrapper_traversal_code([], "output_filter", "target", "&target", "        ",
-              grouped_min, SetupCode, ValueExpr, FilterCond, TraversalCode)
+          rust_foreign_wrapper_stage_traversal_code([], "output_filter", "target", "&target", "        ",
+              grouped_min, StagePlan, TraversalCode)
        ; rust_render_join_specs(JoinPreds, JoinSpecs),
          rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
          FilterCode =
@@ -4790,8 +4790,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 3,
             Some(Value::Atom(target)) => target,
             _ => break,
         };',
-         rust_foreign_wrapper_traversal_code(JoinPreds, "output_filter", "target", "&target", "        ",
-             grouped_min, SetupCode, ValueExpr, FilterCond, TraversalCode)
+         rust_foreign_wrapper_stage_traversal_code(JoinPreds, "output_filter", "target", "&target", "        ",
+             grouped_min, StagePlan, TraversalCode)
        ),
        format(string(RustCode),
 'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool {
@@ -4971,8 +4971,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
     ( Type == group
     -> parse_group_term_rust(GroupTerm, [GroupVar]),
        GroupVar == GoalOutput,
-       rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalOutput, GoalDim, GoalCost],
-           Expr, SetupCode, ValueExpr, FilterCond),
+       GoalArgs = [GoalStart, GoalOutput, GoalDim, GoalCost],
+       rust_foreign_wrapper_stage_plan(GoalInfo, GoalArgs, Expr, StagePlan),
        ( JoinPreds == []
        -> FilterCode =
 '    let output_filter = match &a2 {
@@ -5000,8 +5000,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
             _ => break,
         };',
           JoinRegistrationCode = "",
-          rust_foreign_wrapper_traversal_code([], "output_filter", "target", "&target", "        ",
-              grouped_min, SetupCode, ValueExpr, FilterCond, TraversalCode)
+          rust_foreign_wrapper_stage_traversal_code([], "output_filter", "target", "&target", "        ",
+              grouped_min, StagePlan, TraversalCode)
        ; rust_render_join_specs(JoinPreds, JoinSpecs),
          rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
          FilterCode =
@@ -5020,8 +5020,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
             Some(Value::Atom(target)) => target,
             _ => break,
         };',
-         rust_foreign_wrapper_traversal_code(JoinPreds, "output_filter", "target", "&target", "        ",
-             grouped_min, SetupCode, ValueExpr, FilterCond, TraversalCode)
+         rust_foreign_wrapper_stage_traversal_code(JoinPreds, "output_filter", "target", "&target", "        ",
+             grouped_min, StagePlan, TraversalCode)
        ),
        format(string(RustCode),
 'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool {

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -4853,8 +4853,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 3,
       JoinRegistrationCode, FilterCode, A2RegCode, InnerPredStr, TargetReadCode,
       TraversalCode, PredKey])
     ; Type == all,
-      rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalOutput, GoalCost],
-          Expr, SetupCode, ValueExpr, FilterCond),
+      GoalArgs = [GoalStart, GoalOutput, GoalCost],
+      rust_foreign_wrapper_stage_plan(GoalInfo, GoalArgs, Expr, StagePlan),
       ( JoinPreds == []
       -> FilterCode =
 '    let target_filter = match &a2 {
@@ -4881,8 +4881,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 3,
             _ => break,
         };',
          JoinRegistrationCode = "",
-         rust_foreign_wrapper_traversal_code([], "target_filter", "target", "&target", "        ",
-             scalar_min, SetupCode, ValueExpr, FilterCond, TraversalCode)
+         rust_foreign_wrapper_stage_traversal_code([], "target_filter", "target", "&target", "        ",
+             scalar_min, StagePlan, TraversalCode)
       ; rust_render_join_specs(JoinPreds, JoinSpecs),
          rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
         FilterCode =
@@ -4900,8 +4900,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 3,
             Some(Value::Atom(target)) => target,
             _ => break,
         };',
-        rust_foreign_wrapper_traversal_code(JoinPreds, "target_filter", "target", "&target", "        ",
-            scalar_min, SetupCode, ValueExpr, FilterCond, TraversalCode)
+        rust_foreign_wrapper_stage_traversal_code(JoinPreds, "target_filter", "target", "&target", "        ",
+            scalar_min, StagePlan, TraversalCode)
       ),
       format(string(RustCode),
 'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool {
@@ -5093,8 +5093,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
       InnerPredStr, DefaultDim, JoinRegistrationCode, FilterCode, A2RegCode,
       DefaultDim, InnerPredStr, TargetReadCode, TraversalCode, PredKey])
     ; Type == all,
-      rust_foreign_wrapper_goal_logic(GoalInfo, [GoalStart, GoalOutput, GoalDim, GoalCost],
-          Expr, SetupCode, ValueExpr, FilterCond),
+      GoalArgs = [GoalStart, GoalOutput, GoalDim, GoalCost],
+      rust_foreign_wrapper_stage_plan(GoalInfo, GoalArgs, Expr, StagePlan),
       ( JoinPreds == []
       -> FilterCode =
 '    let target_filter = match &a2 {
@@ -5122,8 +5122,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
             _ => break,
         };',
          JoinRegistrationCode = "",
-         rust_foreign_wrapper_traversal_code([], "target_filter", "target", "&target", "        ",
-             scalar_min, SetupCode, ValueExpr, FilterCond, TraversalCode)
+         rust_foreign_wrapper_stage_traversal_code([], "target_filter", "target", "&target", "        ",
+             scalar_min, StagePlan, TraversalCode)
       ; rust_render_join_specs(JoinPreds, JoinSpecs),
         rust_foreign_join_registration_code(JoinSpecs, JoinRegistrationCode),
         FilterCode =
@@ -5142,8 +5142,8 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
             Some(Value::Atom(target)) => target,
             _ => break,
         };',
-        rust_foreign_wrapper_traversal_code(JoinPreds, "target_filter", "target", "&target", "        ",
-            scalar_min, SetupCode, ValueExpr, FilterCond, TraversalCode)
+        rust_foreign_wrapper_stage_traversal_code(JoinPreds, "target_filter", "target", "&target", "        ",
+            scalar_min, StagePlan, TraversalCode)
       ),
       format(string(RustCode),
 'pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value) -> bool {

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -5205,10 +5205,6 @@ compile_rust_foreign_min_aggregate_wrapper_from_plan(Pred, 4,
       DefaultDim, InnerPredStr, TargetReadCode, TraversalCode])
     ).
 
-rust_foreign_wrapper_goal_logic(GoalInfo, GoalArgs, Expr, SetupCode, ValueExpr, FilterCond) :-
-    rust_foreign_wrapper_stage_plan(GoalInfo, GoalArgs, Expr, StagePlan),
-    rust_foreign_wrapper_render_stage_plan(StagePlan, SetupCode, ValueExpr, FilterCond).
-
 rust_foreign_wrapper_stage_plan(GoalInfo, GoalArgs, Expr,
         wrapper_stage_plan(ComputeStage, FilterStages)) :-
     get_dict(other, GoalInfo, []),
@@ -5241,19 +5237,6 @@ rust_foreign_wrapper_compute_stage(Expr, GoalInfo, GoalArgs, compute_stage("agg_
 rust_foreign_wrapper_render_compute_stage(passthrough_stage(ValueExpr), "", ValueExpr).
 rust_foreign_wrapper_render_compute_stage(compute_stage(ValueExpr, RustExpr), SetupCode, ValueExpr) :-
     format(string(SetupCode), '            let ~w = ~w;~n', [ValueExpr, RustExpr]).
-
-rust_foreign_wrapper_value_expr(Expr, GoalInfo, GoalArgs, "", "cost") :-
-    last(GoalArgs, CostArg),
-    Expr == CostArg,
-    get_dict(other, GoalInfo, []).
-rust_foreign_wrapper_value_expr(Expr, GoalInfo, GoalArgs, SetupCode, "agg_value") :-
-    get_dict(other, GoalInfo, []),
-    get_dict(arithmetic, GoalInfo, Arithmetic),
-    member(Arithmetic0, Arithmetic),
-    strip_module(Arithmetic0, _, ArithmeticGoal),
-    ArithmeticGoal = (Expr is ArithmeticExpr),
-    rust_foreign_wrapper_numeric_expr(ArithmeticExpr, GoalArgs, Expr, RustExpr),
-    format(string(SetupCode), '            let agg_value = ~w;~n', [RustExpr]).
 
 rust_foreign_wrapper_numeric_expr(Expr, _GoalArgs, _AggExpr, RustExpr) :-
     number(Expr),

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -669,6 +669,34 @@ test_foreign_scalar_stage_traversal_ir :-
     ;   fail_test(Test, 'Foreign scalar stage traversal did not render expected joined min traversal')
     ).
 
+test_foreign_grouped_stage_traversal_ir :-
+    Test = 'WAM-Rust: foreign grouped wrapper stage emitter renders joined min traversal',
+    GroupedHead =.. [grouped_bucketed_min_semantic_dist, Start, Bucket, GroupMin],
+    GroupedBody = aggregate_all(min(Adjusted),
+        ( weighted_path(Start, Target, Cost),
+          target_label(Target, Label),
+          label_bucket(Label, Bucket),
+          Cost > 2,
+          Adjusted is Cost + 1
+        ),
+        Bucket,
+        GroupMin),
+    rust_target:classify_aggregate(GroupedBody, GroupedAggInfo),
+    (   rust_target:rust_foreign_aggregate_wrapper_plan(grouped_bucketed_min_semantic_dist, 3,
+            GroupedHead, GroupedAggInfo,
+            foreign_aggregate_plan(_, JoinPreds, GoalArgs, Expr, group, Bucket, GoalInfo)),
+        rust_target:rust_foreign_wrapper_stage_plan(GoalInfo, GoalArgs, Expr, StagePlan),
+        rust_target:rust_foreign_wrapper_stage_traversal_code(JoinPreds, "output_filter", "target", "&target", "        ",
+            grouped_min, StagePlan, TraversalCode),
+        sub_string(TraversalCode, _, _, _, 'let joined_values_1 = match vm.indexed_atom_fact2.get("target_label/2").and_then(|table| table.get(&target)) {'),
+        sub_string(TraversalCode, _, _, _, 'let joined_values_2 = match vm.indexed_atom_fact2.get("label_bucket/2").and_then(|table| table.get(joined_value_1)) {'),
+        sub_string(TraversalCode, _, _, _, 'let agg_value = (cost + 1_f64);'),
+        sub_string(TraversalCode, _, _, _, 'grouped.entry(joined_value_2.clone())'),
+        sub_string(TraversalCode, _, _, _, '.and_modify(|current| *current = current.min(agg_value))')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Foreign grouped stage traversal did not render expected joined min traversal')
+    ).
+
 test_foreign_aggregate_wrapper_plan_ir :-
     Test = 'WAM-Rust: foreign aggregate wrapper plan normalizes scalar and grouped terminals',
     ScalarHead =.. [bucketed_min_semantic_dist, Start, Bucket, MinDist],
@@ -1527,6 +1555,7 @@ run_tests :-
     test_foreign_wrapper_stage_plan_ir,
     test_foreign_stream_stage_traversal_ir,
     test_foreign_scalar_stage_traversal_ir,
+    test_foreign_grouped_stage_traversal_ir,
     test_foreign_aggregate_wrapper_plan_ir,
     test_wam_fallback_enabled,
     test_wam_fallback_disabled,

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -642,6 +642,33 @@ test_foreign_stream_stage_traversal_ir :-
     ;   fail_test(Test, 'Foreign stream stage traversal did not render expected joined traversal')
     ).
 
+test_foreign_scalar_stage_traversal_ir :-
+    Test = 'WAM-Rust: foreign scalar wrapper stage emitter renders joined min traversal',
+    ScalarHead =.. [bucketed_min_semantic_dist, Start, Bucket, MinDist],
+    ScalarBody = aggregate_all(min(Adjusted),
+        ( weighted_path(Start, Target, Cost),
+          target_label(Target, Label),
+          label_bucket(Label, Bucket),
+          Cost > 2,
+          Adjusted is Cost + 1
+        ),
+        MinDist),
+    rust_target:classify_aggregate(ScalarBody, ScalarAggInfo),
+    (   rust_target:rust_foreign_aggregate_wrapper_plan(bucketed_min_semantic_dist, 3,
+            ScalarHead, ScalarAggInfo,
+            foreign_aggregate_plan(_, JoinPreds, GoalArgs, Expr, all, none, GoalInfo)),
+        rust_target:rust_foreign_wrapper_stage_plan(GoalInfo, GoalArgs, Expr, StagePlan),
+        rust_target:rust_foreign_wrapper_stage_traversal_code(JoinPreds, "target_filter", "target", "&target", "        ",
+            scalar_min, StagePlan, TraversalCode),
+        sub_string(TraversalCode, _, _, _, 'let joined_values_1 = match vm.indexed_atom_fact2.get("target_label/2").and_then(|table| table.get(&target)) {'),
+        sub_string(TraversalCode, _, _, _, 'let joined_values_2 = match vm.indexed_atom_fact2.get("label_bucket/2").and_then(|table| table.get(joined_value_1)) {'),
+        sub_string(TraversalCode, _, _, _, 'let agg_value = (cost + 1_f64);'),
+        sub_string(TraversalCode, _, _, _, 'best = Some(match best {'),
+        sub_string(TraversalCode, _, _, _, 'Some(current) => current.min(agg_value)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Foreign scalar stage traversal did not render expected joined min traversal')
+    ).
+
 test_foreign_aggregate_wrapper_plan_ir :-
     Test = 'WAM-Rust: foreign aggregate wrapper plan normalizes scalar and grouped terminals',
     ScalarHead =.. [bucketed_min_semantic_dist, Start, Bucket, MinDist],
@@ -1499,6 +1526,7 @@ run_tests :-
     test_foreign_stream_wrapper_plan_ir,
     test_foreign_wrapper_stage_plan_ir,
     test_foreign_stream_stage_traversal_ir,
+    test_foreign_scalar_stage_traversal_ir,
     test_foreign_aggregate_wrapper_plan_ir,
     test_wam_fallback_enabled,
     test_wam_fallback_disabled,


### PR DESCRIPTION
## Summary

This PR completes the wrapper stage-emitter consolidation for WAM-Rust aggregate wrappers.

- Routes scalar min aggregate wrappers through `rust_foreign_wrapper_stage_traversal_code/8`.
- Routes grouped min aggregate wrappers through the same stage traversal path.
- Adds target IR coverage for scalar and grouped joined aggregate traversal rendering.
- Removes the legacy wrapper goal/value helper predicates now that compute/filter handling goes through the explicit stage-plan representation.

## Why

The prior wrapper refactors introduced a stage-plan IR and moved stream wrappers onto the shared stage traversal emitter. Scalar and grouped aggregate wrappers still had direct setup/value/filter plumbing, which left three terminal modes using two emitter paths.

After this change, stream, scalar min, and grouped min wrapper generation all share the same stage traversal flow while preserving terminal-specific behavior for result streaming, scalar best-value aggregation, and grouped `BTreeMap` aggregation.

## Validation

- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`
- `git diff --check`

