### PR TITLE
feat(wam-llvm): end-to-end foreign kernel lowering pipeline (M5.6)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -121,6 +121,118 @@ assert_foreign_entry(_) :- true.  % ignore unrecognized shapes
 foreign_kernel(PredArity, Kind, Config) :-
     assertz(llvm_foreign_kernel_spec(PredArity, Kind, Config)).
 
+% ============================================================================
+% M5.6c — Automatic Foreign Kernel Detection
+% ============================================================================
+%
+% When `foreign_lowering(true)` is set in Options, the compile pipeline
+% walks each user predicate's clauses and runs them against a registry
+% of detectors. A detector is a predicate that returns a
+% `recursive_kernel(Kind, Pred/Arity, Config)` term when the clauses
+% match a known recursive-kernel shape. The matched spec is then
+% asserted into the same llvm_foreign_kernel_spec/3 table that paths
+% (a) and (b) populate, so there's only one downstream code path.
+%
+% This mirrors the Rust target's rust_recursive_kernel_detector/2
+% registry at rust_target.pl:3742-3751 and the matcher predicates at
+% rust_target.pl:3968-3988. Currently only transitive_distance3 is
+% implemented; weighted_shortest_path3 and astar_shortest_path4 can
+% be added by porting the same matcher structure once their
+% dispatcher stubs are wired (the M5.5 weak-default pattern only
+% covers td3 so far).
+
+%% llvm_recursive_kernel_detector(?Kind, ?DetectorPredicate).
+%
+%  Registry of kernel kinds and the predicates that can detect them.
+%  DetectorPredicate(+Pred, +Arity, +Clauses, -RecKernel) should bind
+%  RecKernel to a `recursive_kernel(Kind, Pred/Arity, Config)` term
+%  on success.
+llvm_recursive_kernel_detector(transitive_distance3,
+    llvm_recursive_kernel_transitive_distance).
+
+%% llvm_recursive_kernel_transitive_distance(+Pred, +Arity, +Clauses, -RecKernel).
+%
+%  Detects the transitive_distance3 shape:
+%    pred(Start, Target, 1)     :- edge(Start, Target).
+%    pred(Start, Target, Depth) :-
+%        edge(Start, Mid),
+%        pred(Mid, Target, PrevDepth),
+%        Depth is PrevDepth + 1.
+%
+%  On success binds RecKernel to
+%    recursive_kernel(transitive_distance3, Pred/Arity,
+%                     [edge_pred(EdgePred/2)]).
+llvm_recursive_kernel_transitive_distance(Pred, Arity, Clauses,
+        recursive_kernel(transitive_distance3, Pred/Arity,
+            [edge_pred(EdgePred/2)])) :-
+    llvm_foreign_lowerable_transitive_distance(Pred, Arity, Clauses, EdgePred).
+
+%% llvm_foreign_lowerable_transitive_distance(+Pred, +Arity, +Clauses, -EdgePred).
+%
+%  Clause-shape matcher ported from rust_target.pl:3968. The only
+%  difference from the Rust version is that we do not gather the
+%  fact pairs here — the M5.6a build_td3_concrete_impl/6 helper
+%  reads them from the user module at codegen time, so the matcher
+%  just needs to confirm the EdgePred name and arity.
+llvm_foreign_lowerable_transitive_distance(Pred, 3, Clauses, EdgePred) :-
+    member(BaseHead-BaseBody, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseHead =.. [Pred, BaseStart, BaseTarget, 1],
+    RecHead =.. [Pred, RecStart, RecTarget, RecDepth],
+    BaseBody =.. [EdgePred, BaseStart, BaseTarget],
+    RecBody = (EdgeGoal, (RecGoal, IsGoal)),
+    EdgeGoal =.. [EdgePred, RecStart, RecMid],
+    RecGoal =.. [Pred, RecMid, RecTarget, PrevDepth],
+    IsGoal =.. [is, RecDepth, Expr],
+    Expr =.. [+, PrevDepth, 1].
+
+%% llvm_auto_detect_foreign_kernels(+Predicates) is det.
+%
+%  For each predicate indicator in the list, read its clauses from
+%  the user module and run them against every registered detector.
+%  When a detector matches, assert a llvm_foreign_kernel_spec/3 fact
+%  for the result. Idempotent — if a spec already exists for the
+%  predicate (e.g., from the options-list path), the auto-detect
+%  skips it to avoid duplicate registration.
+llvm_auto_detect_foreign_kernels([]).
+llvm_auto_detect_foreign_kernels([PredIndicator|Rest]) :-
+    ( PredIndicator = Module:Pred/Arity -> true
+    ; PredIndicator = Pred/Arity, Module = user
+    ),
+    ( lookup_foreign_kernel_spec(Pred, Arity, _, _)
+    -> true   % already registered via (a) or (b); don't override
+    ;  llvm_collect_clause_pairs(Module, Pred, Arity, Clauses),
+       ( llvm_try_detectors(Pred, Arity, Clauses, Kind, Config)
+       -> assertz(llvm_foreign_kernel_spec(Pred/Arity, Kind, Config))
+       ;  true
+       )
+    ),
+    llvm_auto_detect_foreign_kernels(Rest).
+
+%% llvm_collect_clause_pairs(+Module, +Pred, +Arity, -Pairs) is det.
+%
+%  Gather (Head - Body) pairs for every clause of Module:Pred/Arity.
+%  Catch + default to empty list so predicates with no clauses (or
+%  predicates that are opaque to clause/2) don't blow up the compile.
+llvm_collect_clause_pairs(Module, Pred, Arity, Pairs) :-
+    catch(
+        findall(Head-Body,
+            ( functor(Head, Pred, Arity),
+              clause(Module:Head, Body)
+            ),
+            Pairs),
+        _, Pairs = []).
+
+%% llvm_try_detectors(+Pred, +Arity, +Clauses, -Kind, -Config) is semidet.
+%
+%  Iterate the detector registry and return the first match.
+llvm_try_detectors(Pred, Arity, Clauses, Kind, Config) :-
+    llvm_recursive_kernel_detector(Kind, DetectorName),
+    Goal =.. [DetectorName, Pred, Arity, Clauses, Result],
+    call(Goal),
+    Result = recursive_kernel(Kind, _, Config),
+    !.
+
 %% lookup_foreign_kernel_spec(+Pred, +Arity, -Kind, -Config) is semidet.
 %
 %  Succeeds iff a spec is registered for the given predicate. Strips
@@ -303,10 +415,15 @@ write_wam_llvm_project(Predicates, Options, OutputFile) :-
     get_time(TimeStamp),
     format_time(string(Date), "%Y-%m-%d %H:%M:%S", TimeStamp),
 
-    % M5.6: populate the foreign kernel spec table from the options list.
-    % Path (a) directives have already run by the time we get here; (c)
-    % auto-detection runs later. This call handles (b).
+    % M5.6: populate the foreign kernel spec table.
+    % Path (a) directives have already run by load time. Path (b) is
+    % the options-list form; path (c) walks clause shapes when
+    % foreign_lowering(true) is set.
     apply_foreign_predicates_option(Options),
+    ( option(foreign_lowering(true), Options)
+    -> llvm_auto_detect_foreign_kernels(Predicates)
+    ;  true
+    ),
 
     % Read and render type definitions template
     read_template_file('templates/targets/llvm_wam/types.ll.mustache', TypesTemplate),

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -35,7 +35,10 @@
     wam_llvm_foreign_kind_id/2,          % +Kind, -Id
     % Indexed fact table emission (M4)
     llvm_emit_atom_fact2_table/3,        % +TableName, +Pairs, -LLVMGlobal
-    llvm_emit_weighted_edge_table/3      % +TableName, +Triples, -LLVMGlobal
+    llvm_emit_weighted_edge_table/3,     % +TableName, +Triples, -LLVMGlobal
+    % Foreign lowering pipeline (M5.6)
+    llvm_foreign_kernel_spec/3,          % ?Pred/Arity, ?KernelKind, ?Config (dynamic)
+    clear_llvm_foreign_kernel_specs/0    % retractall helper (for test isolation)
 ]).
 
 :- use_module(library(lists)).
@@ -47,6 +50,226 @@
 :- discontiguous wam_llvm_case/2.
 :- discontiguous wam_line_to_llvm_literal/2.
 :- discontiguous wam_instruction_to_llvm_literal/2.
+
+% ============================================================================
+% Foreign Lowering Spec Table (M5.6)
+% ============================================================================
+%
+% The canonical record for "this predicate should be lowered to a native
+% foreign kernel instead of being compiled to WAM". Populated via three
+% user-facing paths that all funnel into this single table:
+%
+%   (a) :- foreign_kernel(Pred/Arity, Kind, Config) directive (M5.6b)
+%   (b) foreign_predicates([...]) entry in Options (M5.6a, this commit)
+%   (c) foreign_lowering(true) + automatic pattern matching (M5.6c)
+%
+% Path (b) is a thin wrapper around (a) — the options-list helper just
+% asserts the same facts the directive would. Path (c) invokes detector
+% predicates that inspect clause shape and assert specs when a known
+% recursive kernel pattern matches.
+%
+% The compile pipeline checks this table *before* trying native LLVM
+% lowering or WAM fallback. When a spec exists, the predicate body is
+% replaced with a single `call_foreign Kind, Arity` instruction, and the
+% runtime template's weak @wam_<kind>_kernel_impl default is spliced
+% out and replaced with a concrete body that reads registers, scans the
+% fact table, and writes the result.
+
+:- dynamic llvm_foreign_kernel_spec/3.
+
+clear_llvm_foreign_kernel_specs :-
+    retractall(llvm_foreign_kernel_spec(_, _, _)).
+
+%% apply_foreign_predicates_option(+Options) is det.
+%
+%  Reads a `foreign_predicates([...])` entry from the options list and
+%  asserts a llvm_foreign_kernel_spec/3 fact for each entry. Accepted
+%  entry shapes:
+%
+%    Pred/Arity - Kind - Config
+%    foreign_kernel(Pred/Arity, Kind, Config)
+%
+%  Any other shape is silently ignored so future extensions don't break
+%  old option lists.
+apply_foreign_predicates_option(Options) :-
+    ( option(foreign_predicates(Entries), Options)
+    -> forall(member(Entry, Entries), assert_foreign_entry(Entry))
+    ; true
+    ).
+
+assert_foreign_entry(PredArity - Kind - Config) :- !,
+    assertz(llvm_foreign_kernel_spec(PredArity, Kind, Config)).
+assert_foreign_entry(foreign_kernel(PredArity, Kind, Config)) :- !,
+    assertz(llvm_foreign_kernel_spec(PredArity, Kind, Config)).
+assert_foreign_entry(_) :- true.  % ignore unrecognized shapes
+
+%% lookup_foreign_kernel_spec(+Pred, +Arity, -Kind, -Config) is semidet.
+%
+%  Succeeds iff a spec is registered for the given predicate. Strips
+%  any Module: qualifier so callers can pass `user:foo/3` or `foo/3`
+%  interchangeably.
+lookup_foreign_kernel_spec(Pred, Arity, Kind, Config) :-
+    ( llvm_foreign_kernel_spec(Pred/Arity, Kind, Config)
+    ; llvm_foreign_kernel_spec(_:Pred/Arity, Kind, Config)
+    ), !.
+
+%% substitute_foreign_kernel_impls(+StateFuncsRaw, -StateFuncs, -Globals).
+%
+%  Post-processes the rendered state template output to splice concrete
+%  kernel impl bodies in place of the weak defaults, and collects any
+%  module-level globals (fact tables, etc.) the impls depend on.
+%
+%  When no foreign specs are registered this is a pass-through:
+%    StateFuncs = StateFuncsRaw, Globals = ''.
+%
+%  For each registered td3 spec, the weak default
+%    define weak i1 @wam_td3_kernel_impl(%WamState* %vm) {
+%      ret i1 false
+%    }
+%  is replaced with a concrete body that reads A1/A2 atoms, calls
+%  @wam_bfs_atom_distance over a module-local %AtomFactPair table, and
+%  writes A3 via @wam_set_reg_int. The fact table is emitted as a
+%  private constant and returned via Globals.
+substitute_foreign_kernel_impls(StateFuncsRaw, StateFuncs, Globals) :-
+    findall(td3(PredArity, Config),
+        llvm_foreign_kernel_spec(PredArity, transitive_distance3, Config),
+        Td3Specs),
+    ( Td3Specs == []
+    -> StateFuncs = StateFuncsRaw,
+       Globals = ''
+    ;  % Current design: one concrete impl regardless of how many td3
+       % predicates are foreign-lowered. They all go through the same
+       % @wam_td3_kernel_impl entry point and read the same fact table.
+       % If multiple predicates use *different* edge_preds this needs
+       % refinement — currently the first wins.
+       Td3Specs = [td3(_FirstPred, FirstConfig)|_],
+       build_td3_concrete_impl(FirstConfig, ImplBody, FactTableIR, TableName, TableLen, MaxAtomId),
+       replace_td3_weak_default(StateFuncsRaw, ImplBody, StateFuncs),
+       format(atom(Globals),
+'; === M5.6 foreign kernel support globals ===
+~w
+
+; max_atom_id upper bound baked into the concrete kernel at compile time:
+;   table=~w  len=~w  max_atom_id=~w
+', [FactTableIR, TableName, TableLen, MaxAtomId])
+    ).
+
+%% build_td3_concrete_impl(+Config, -ImplBody, -FactTableIR, -TableName, -TableLen, -MaxAtomId).
+%
+%  Reads the edge predicate facts from Config, emits an %AtomFactPair
+%  global constant for them, computes max_atom_id from the interned
+%  atom IDs, and builds the LLVM IR for a concrete @wam_td3_kernel_impl
+%  that calls @wam_bfs_atom_distance against that table.
+build_td3_concrete_impl(Config, ImplBody, FactTableIR, TableName, TableLen, MaxAtomId) :-
+    ( member(edge_pred(EdgePred), Config) -> true
+    ; EdgePred = edge/2  % sensible default for smoke tests
+    ),
+    EdgePred = EPName/EPArity,
+    ( EPArity =:= 2 -> true
+    ; throw(foreign_lowering_edge_pred_arity(EPName/EPArity))
+    ),
+    % Gather facts from the user module. Wrap in findall/catch so a
+    % missing predicate produces an empty table rather than crashing.
+    catch(
+        findall(fact(From, To),
+            ( Goal =.. [EPName, From, To],
+              user:Goal
+            ),
+            Pairs),
+        _, Pairs = []),
+    % Intern all atoms to get a tight max_atom_id bound.
+    compute_max_atom_id(Pairs, MaxAtomId),
+    format(atom(TableName), 'foreign_td3_~w_~w', [EPName, EPArity]),
+    llvm_emit_atom_fact2_table(TableName, Pairs, FactTableIR),
+    length(Pairs, TableLen),
+    % When len == 0, llvm_emit_atom_fact2_table produces a 1-entry
+    % placeholder. The kernel still needs to be told len=0 so it
+    % doesn't scan the placeholder as a real row.
+    ( TableLen == 0 -> EffectiveLen = 0 ; EffectiveLen = TableLen ),
+    ( TableLen == 0 -> GepLen = 1 ; GepLen = TableLen ),
+    format(atom(ImplBody),
+'define i1 @wam_td3_kernel_impl(%WamState* %vm) {
+entry:
+  ; M5.6 concrete td3 impl — generated from edge_pred(~w).
+  %s_tag = call i32 @wam_get_reg_tag(%WamState* %vm, i32 0)
+  %s_is_atom = icmp eq i32 %s_tag, 0
+  br i1 %s_is_atom, label %check_t, label %bail
+
+check_t:
+  %t_tag = call i32 @wam_get_reg_tag(%WamState* %vm, i32 1)
+  %t_is_atom = icmp eq i32 %t_tag, 0
+  br i1 %t_is_atom, label %run, label %bail
+
+run:
+  %start_id = call i64 @wam_get_reg_payload(%WamState* %vm, i32 0)
+  %target_id = call i64 @wam_get_reg_payload(%WamState* %vm, i32 1)
+  %table_ptr = getelementptr [~w x %AtomFactPair], [~w x %AtomFactPair]* @~w, i64 0, i64 0
+  %dist_slot = alloca i64
+  %ok = call i1 @wam_bfs_atom_distance(
+      i64 %start_id, i64 %target_id,
+      %AtomFactPair* %table_ptr, i64 ~w,
+      i64 ~w,
+      i64* %dist_slot)
+  br i1 %ok, label %hit, label %bail
+
+hit:
+  %dist = load i64, i64* %dist_slot
+  call void @wam_set_reg_int(%WamState* %vm, i32 2, i64 %dist)
+  ret i1 true
+
+bail:
+  ret i1 false
+}',
+        [EPName, GepLen, GepLen, TableName, EffectiveLen, MaxAtomId]).
+
+%% compute_max_atom_id(+Pairs, -MaxAtomId).
+%
+%  Interns every atom in a list of fact(From, To) pairs and returns
+%  the highest resulting ID. Empty list → 0.
+compute_max_atom_id([], 0).
+compute_max_atom_id(Pairs, MaxAtomId) :-
+    findall(Id,
+        ( member(fact(From, To), Pairs),
+          ( intern_atom(From, Id)
+          ; intern_atom(To, Id)
+          )
+        ),
+        Ids),
+    ( Ids == []
+    -> MaxAtomId = 0
+    ;  max_list(Ids, MaxAtomId)
+    ).
+
+%% replace_td3_weak_default(+StateFuncsRaw, +NewBody, -StateFuncs).
+%
+%  Replaces the M5.5 weak default of @wam_td3_kernel_impl with NewBody
+%  in the rendered state template. If the exact weak-default fragment
+%  isn't found (template drift, etc.) the original text is returned
+%  unchanged and an error is logged — the M5.5 delegation test would
+%  have caught any drift in the weak-default fragment itself.
+replace_td3_weak_default(StateFuncsRaw, NewBody, StateFuncs) :-
+    Old = 'define weak i1 @wam_td3_kernel_impl(%WamState* %vm) {\n  ret i1 false\n}',
+    ( string_replace(StateFuncsRaw, Old, NewBody, StateFuncs0)
+    -> StateFuncs = StateFuncs0
+    ;  format(user_error,
+        'WARNING: M5.6 could not find td3 weak-default in state template; leaving unchanged~n', []),
+       StateFuncs = StateFuncsRaw
+    ).
+
+%% string_replace(+Haystack, +Needle, +Replacement, -Result) is semidet.
+%
+%  Simple substring replacement. Fails if Needle is not found.
+string_replace(Haystack, Needle, Replacement, Result) :-
+    ( atom(Haystack) -> atom_string(Haystack, HayStr) ; HayStr = Haystack ),
+    ( atom(Needle)   -> atom_string(Needle, NeedleStr) ; NeedleStr = Needle ),
+    ( atom(Replacement) -> atom_string(Replacement, ReplStr) ; ReplStr = Replacement ),
+    sub_string(HayStr, Before, _, After, NeedleStr), !,
+    sub_string(HayStr, 0, Before, _, Prefix),
+    string_length(HayStr, HayLen),
+    SuffixStart is HayLen - After,
+    sub_string(HayStr, SuffixStart, After, 0, Suffix),
+    string_concat(Prefix, ReplStr, Tmp),
+    string_concat(Tmp, Suffix, Result).
 
 % ============================================================================
 % PHASE 5: Hybrid Module Assembly
@@ -62,6 +285,11 @@ write_wam_llvm_project(Predicates, Options, OutputFile) :-
     get_time(TimeStamp),
     format_time(string(Date), "%Y-%m-%d %H:%M:%S", TimeStamp),
 
+    % M5.6: populate the foreign kernel spec table from the options list.
+    % Path (a) directives have already run by the time we get here; (c)
+    % auto-detection runs later. This call handles (b).
+    apply_foreign_predicates_option(Options),
+
     % Read and render type definitions template
     read_template_file('templates/targets/llvm_wam/types.ll.mustache', TypesTemplate),
     render_template(TypesTemplate, [module_name=ModuleName, date=Date], TypesDef),
@@ -70,9 +298,12 @@ write_wam_llvm_project(Predicates, Options, OutputFile) :-
     read_template_file('templates/targets/llvm_wam/value.ll.mustache', ValueTemplate),
     render_template(ValueTemplate, [], ValueFuncs),
 
-    % Read and render state functions template
+    % Read and render state functions template. When foreign lowering
+    % is active, splice concrete kernel impl bodies in place of the
+    % weak defaults in the rendered state template.
     read_template_file('templates/targets/llvm_wam/state.ll.mustache', StateTemplate),
-    render_template(StateTemplate, [], StateFuncs),
+    render_template(StateTemplate, [], StateFuncsRaw),
+    substitute_foreign_kernel_impls(StateFuncsRaw, StateFuncs, ForeignGlobals),
 
     % Generate runtime (step + helpers)
     compile_step_wam_to_llvm(Options, StepFunc),
@@ -83,8 +314,17 @@ write_wam_llvm_project(Predicates, Options, OutputFile) :-
         helper_functions=HelpersCode
     ], RuntimeFuncs),
 
-    % Compile predicates (native or WAM fallback)
+    % Compile predicates (native or WAM fallback). Any predicate with a
+    % llvm_foreign_kernel_spec/3 entry is compiled to a body of
+    % WAM instructions ending in `call_foreign Kind, Arity`.
     compile_predicates_for_llvm(Predicates, Options, NativeCode, WamCode),
+
+    % Prepend foreign kernel globals (fact tables, etc.) to the native
+    % predicates section so they are at module scope before any use.
+    ( ForeignGlobals == ''
+    -> FinalNativeCode = NativeCode
+    ;  atomic_list_concat([ForeignGlobals, '\n\n', NativeCode], FinalNativeCode)
+    ),
 
     % Assemble full module
     read_template_file('templates/targets/llvm_wam/module.ll.mustache', ModuleTemplate),
@@ -97,7 +337,7 @@ write_wam_llvm_project(Predicates, Options, OutputFile) :-
         value_functions=ValueFuncs,
         state_functions=StateFuncs,
         runtime_functions=RuntimeFuncs,
-        native_predicates=NativeCode,
+        native_predicates=FinalNativeCode,
         wam_predicates=WamCode,
         interop_bridge=""
     ], FullModule),
@@ -267,7 +507,13 @@ compile_predicates_collect([PredIndicator|Rest], Options, NativeParts, WamParts)
     ;   PredIndicator = Pred/Arity, Module = user
     ),
     compile_predicates_collect(Rest, Options, RestNative, RestWam),
-    (   % Try native LLVM lowering first
+    (   % M5.6: foreign kernel lowering — check spec table first.
+        lookup_foreign_kernel_spec(Pred, Arity, Kind, _Config)
+    ->  format(user_error, '  ~w/~w: foreign kernel (~w)~n', [Pred, Arity, Kind]),
+        compile_foreign_kernel_predicate(Pred/Arity, Kind, Arity, Options, PredCode),
+        NativeParts = RestNative,
+        WamParts = [PredCode | RestWam]
+    ;   % Try native LLVM lowering
         catch(
             llvm_target:compile_predicate_to_llvm(Module:Pred/Arity, Options, PredCode),
             _, fail)
@@ -288,6 +534,22 @@ compile_predicates_collect([PredIndicator|Rest], Options, NativeParts, WamParts)
         format(atom(FailComment), '; ~w/~w: compilation failed', [Pred, Arity]),
         WamParts = [FailComment | RestWam]
     ).
+
+%% compile_foreign_kernel_predicate(+PredArity, +Kind, +Arity, +Options, -PredCode).
+%
+%  Generate an LLVM predicate body consisting of a single
+%  `call_foreign Kind, Arity` instruction followed by `proceed`. Takes
+%  the WAM-fallback compile path (not native) so the result plugs into
+%  the same %Instruction array / step dispatch machinery as any
+%  WAM-compiled predicate.
+%
+%  compile_wam_predicate_to_llvm/4 expects WamCode as a newline-joined
+%  atom/string (it splits internally), so we format the two lines into
+%  a single blob here.
+compile_foreign_kernel_predicate(Pred/Arity, Kind, Arity, Options, PredCode) :-
+    wam_llvm_foreign_kind_id(Kind, _KindId),  % fail fast if kind unknown
+    format(atom(WamCode), 'call_foreign ~w, ~w\nproceed', [Kind, Arity]),
+    compile_wam_predicate_to_llvm(Pred/Arity, WamCode, Options, PredCode).
 
 % ============================================================================
 % PHASE 2: step_wam/3 → LLVM switch dispatch
@@ -1541,11 +1803,17 @@ compile_wam_predicate_to_llvm(Pred/Arity, WamCode, _Options, LLVMCode) :-
     % Build instruction array entries
     maplist([Lit, Entry]>>(format(atom(Entry), '  ~w', [Lit])), ResolvedLiterals, Entries),
     atomic_list_concat(Entries, ',\n', EntriesStr),
-    % Build label array entries
+    % Build label array entries. When the predicate has zero labels we
+    % still emit a 1-element placeholder (LLVM rejects [0 x i32] with a
+    % 1-element initializer, and vice versa). The logical count passed
+    % to wam_state_new stays zero, but the declared array type has to
+    % match the initializer length so the two are tracked separately.
     maplist([_-Idx, Entry]>>(format(atom(Entry), '  i32 ~w', [Idx])), LabelEntries, LabelRows),
     (   LabelRows == []
-    ->  LabelsStr = "  i32 0"
-    ;   atomic_list_concat(LabelRows, ',\n', LabelsStr)
+    ->  LabelsStr = "  i32 0",
+        LabelArraySize = 1
+    ;   atomic_list_concat(LabelRows, ',\n', LabelsStr),
+        LabelArraySize = LabelCount
     ),
     % Build arg setup
     build_llvm_arg_setup(Arity, ArgSetup),
@@ -1580,10 +1848,10 @@ entry:
 ', [PredStr, Arity,
     SwitchTablesStr,
     PredStr, InstrCount, EntriesStr,
-    PredStr, LabelCount, LabelsStr,
+    PredStr, LabelArraySize, LabelsStr,
     PredStr, ParamList,
     InstrCount, InstrCount, PredStr, InstrCount,
-    LabelCount, LabelCount, PredStr, LabelCount,
+    LabelArraySize, LabelArraySize, PredStr, LabelCount,
     ArgSetup]).
 
 %% resolve_switch_tables(+LiteralsIn, +PredStr, +NextIdx, -LiteralsOut, -TableDefs)

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -38,7 +38,8 @@
     llvm_emit_weighted_edge_table/3,     % +TableName, +Triples, -LLVMGlobal
     % Foreign lowering pipeline (M5.6)
     llvm_foreign_kernel_spec/3,          % ?Pred/Arity, ?KernelKind, ?Config (dynamic)
-    clear_llvm_foreign_kernel_specs/0    % retractall helper (for test isolation)
+    clear_llvm_foreign_kernel_specs/0,   % retractall helper (for test isolation)
+    foreign_kernel/3                     % +Pred/Arity, +Kind, +Config (user directive)
 ]).
 
 :- use_module(library(lists)).
@@ -102,6 +103,23 @@ assert_foreign_entry(PredArity - Kind - Config) :- !,
 assert_foreign_entry(foreign_kernel(PredArity, Kind, Config)) :- !,
     assertz(llvm_foreign_kernel_spec(PredArity, Kind, Config)).
 assert_foreign_entry(_) :- true.  % ignore unrecognized shapes
+
+%% foreign_kernel(+PredArity, +Kind, +Config) is det.
+%
+%  M5.6b: user-facing directive-style entry point. A user source file
+%  can import this predicate and use it as a directive to declare that
+%  a predicate should be lowered to a native foreign kernel:
+%
+%    :- use_module(library(wam_llvm_target),
+%         [foreign_kernel/3, write_wam_llvm_project/3]).
+%    :- foreign_kernel(my_distance/3, transitive_distance3,
+%         [edge_pred(edge/2)]).
+%
+%  The directive simply asserts a llvm_foreign_kernel_spec/3 fact —
+%  the rest of the pipeline treats it identically to specs that come
+%  in via the options-list path or the auto-detector path.
+foreign_kernel(PredArity, Kind, Config) :-
+    assertz(llvm_foreign_kernel_spec(PredArity, Kind, Config)).
 
 %% lookup_foreign_kernel_spec(+Pred, +Arity, -Kind, -Config) is semidet.
 %

--- a/tests/core/test_wam_llvm_foreign_lowering_autodetect.pl
+++ b/tests/core/test_wam_llvm_foreign_lowering_autodetect.pl
@@ -1,0 +1,154 @@
+:- encoding(utf8).
+% test_wam_llvm_foreign_lowering_autodetect.pl
+% Verifies M5.6c: clause-shape auto-detection of foreign kernels.
+% Mirrors the Rust target's rust_recursive_kernel_detector/2 registry.
+%
+% The user writes a normal recursive Prolog predicate matching a
+% known kernel shape (here: transitive_distance3). When they pass
+% `foreign_lowering(true)` in the options list, the compile pipeline
+% walks each predicate's clauses, runs them through the detectors,
+% and asserts a llvm_foreign_kernel_spec/3 for any that match.
+% Downstream behavior is identical to paths (a) and (b).
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3,
+     llvm_foreign_kernel_spec/3,
+     clear_llvm_foreign_kernel_specs/0]).
+:- use_module(library(process)).
+
+% Edge predicate — facts the kernel's fact-table emitter will read.
+:- dynamic edge/2.
+edge(p, q).
+edge(q, r).
+edge(r, s).
+edge(p, t).
+
+% A predicate matching the transitive_distance3 clause shape:
+%   base: pred(Start, Target, 1) :- edge(Start, Target).
+%   rec:  pred(Start, Target, Depth) :-
+%             edge(Start, Mid),
+%             pred(Mid, Target, Prev),
+%             Depth is Prev + 1.
+:- dynamic reach/3.
+reach(Start, Target, 1) :- edge(Start, Target).
+reach(Start, Target, Depth) :-
+    edge(Start, Mid),
+    reach(Mid, Target, Prev),
+    Depth is Prev + 1.
+
+test_autodetect_populates_spec :-
+    format('--- auto-detect registers td3 from clause shape ---~n'),
+    clear_llvm_foreign_kernel_specs,
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project(
+        [user:reach/3],
+        [ module_name('td3auto_test'),
+          foreign_lowering(true)
+        ],
+        LLPath),
+    ( llvm_foreign_kernel_spec(reach/3, transitive_distance3, Config)
+    -> format('  PASS: auto-detect registered reach/3 as td3, config=~w~n', [Config])
+    ;  format('  FAIL: auto-detect did not match reach/3~n'),
+       throw(no_autodetect_match)
+    ),
+    read_file_to_string(LLPath, Src, []),
+    ( sub_string(Src, _, _, _, '%Instruction { i32 30, i64 4, i64 3 }')
+    -> format('  PASS: call_foreign emitted for auto-detected predicate~n')
+    ;  format('  FAIL: no call_foreign instruction~n')
+    ),
+    ( sub_string(Src, _, _, _, 'M5.6 concrete td3 impl')
+    -> format('  PASS: concrete td3 impl spliced in~n')
+    ;  format('  FAIL: concrete impl missing~n')
+    ),
+    ( sub_string(Src, _, _, _, '@foreign_td3_edge_2')
+    -> format('  PASS: fact table global present~n')
+    ;  format('  FAIL: fact table missing~n')
+    ),
+    ( process_which('llvm-as')
+    -> atom_concat(LLPath, '.bc', BCPath),
+       format(atom(Cmd), 'llvm-as ~w -o ~w 2>&1', [LLPath, BCPath]),
+       shell(Cmd, Exit),
+       ( Exit == 0
+       -> format('  PASS: llvm-as accepted the auto-detected module~n')
+       ;  format('  FAIL: llvm-as exit=~w~n', [Exit])
+       ),
+       ( process_which('opt')
+       -> format(atom(VCmd),
+           'opt -passes=verify -disable-output ~w 2>&1', [BCPath]),
+          shell(VCmd, VExit),
+          ( VExit == 0
+          -> format('  PASS: opt -passes=verify accepted bitcode~n')
+          ;  format('  FAIL: opt -passes=verify exit=~w~n', [VExit])
+          )
+       ;  format('  SKIP: opt not found~n')
+       ),
+       catch(delete_file(BCPath), _, true)
+    ;  format('  SKIP: llvm-as not found~n')
+    ),
+    catch(delete_file(LLPath), _, true),
+    clear_llvm_foreign_kernel_specs.
+
+test_autodetect_off_by_default :-
+    format('--- auto-detect off by default (no foreign_lowering flag) ---~n'),
+    clear_llvm_foreign_kernel_specs,
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    % Same td3-shaped reach/3 predicate, but WITHOUT foreign_lowering(true).
+    % The auto-detector should not run, so reach/3 falls through to
+    % the normal WAM compilation path.
+    write_wam_llvm_project(
+        [user:reach/3],
+        [module_name('td3auto_off_test')],
+        LLPath),
+    ( llvm_foreign_kernel_spec(reach/3, _, _)
+    -> format('  FAIL: spec registered without foreign_lowering(true)~n'),
+       throw(spec_leaked)
+    ;  format('  PASS: no spec registered when flag is off~n')
+    ),
+    read_file_to_string(LLPath, Src, []),
+    ( sub_string(Src, _, _, _, '%Instruction { i32 30, i64 4, i64 3 }')
+    -> format('  FAIL: call_foreign emitted despite flag off~n'),
+       throw(call_foreign_leaked)
+    ;  format('  PASS: no call_foreign emitted (normal WAM path taken)~n')
+    ),
+    catch(delete_file(LLPath), _, true).
+
+test_non_matching_predicate_ignored :-
+    format('--- non-matching predicate is not auto-registered ---~n'),
+    clear_llvm_foreign_kernel_specs,
+    assertz((user:unrelated(X, Y) :- X = Y)),
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project(
+        [user:unrelated/2],
+        [ module_name('td3auto_nomatch_test'),
+          foreign_lowering(true)
+        ],
+        LLPath),
+    ( llvm_foreign_kernel_spec(unrelated/2, _, _)
+    -> format('  FAIL: non-td3 predicate was wrongly auto-registered~n'),
+       throw(false_positive)
+    ;  format('  PASS: unrelated/2 did not match any detector~n')
+    ),
+    retractall(user:unrelated(_, _)),
+    catch(delete_file(LLPath), _, true),
+    clear_llvm_foreign_kernel_specs.
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _,
+        fail).
+
+test_all :-
+    catch(test_autodetect_populates_spec, E1,
+        format('  ERROR: ~w~n', [E1])),
+    catch(test_autodetect_off_by_default, E2,
+        format('  ERROR: ~w~n', [E2])),
+    catch(test_non_matching_predicate_ignored, E3,
+        format('  ERROR: ~w~n', [E3])).
+
+:- initialization(test_all, main).

--- a/tests/core/test_wam_llvm_foreign_lowering_directive.pl
+++ b/tests/core/test_wam_llvm_foreign_lowering_directive.pl
@@ -1,0 +1,107 @@
+:- encoding(utf8).
+% test_wam_llvm_foreign_lowering_directive.pl
+% Verifies M5.6b: the Prolog directive entry point for foreign kernel
+% lowering (path (a) in the M5.6 design).
+%
+% The user writes `:- foreign_kernel(Pred/Arity, Kind, Config)` at
+% load time in their Prolog source, and the directive asserts a
+% llvm_foreign_kernel_spec/3 fact that the compile pipeline picks up.
+% Downstream of that assertion the behavior is identical to the
+% options-list path tested in M5.6a.
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3,
+     foreign_kernel/3,
+     llvm_foreign_kernel_spec/3,
+     clear_llvm_foreign_kernel_specs/0]).
+:- use_module(library(process)).
+
+% Edge predicate used as the kernel's fact source.
+:- dynamic edge/2.
+edge(x, y).
+edge(y, z).
+edge(z, w).
+
+% The predicate we want to lower. No real body — the compile pipeline
+% replaces it with a call_foreign instruction.
+:- dynamic trav/3.
+trav(_, _, _) :- fail.
+
+% Clear any stale specs from other tests, then use the directive form
+% to register trav/3 as a foreign td3 kernel.
+:- clear_llvm_foreign_kernel_specs.
+:- foreign_kernel(trav/3, transitive_distance3, [edge_pred(edge/2)]).
+
+test_directive_populated_spec_table :-
+    format('--- :- foreign_kernel(...) directive asserts spec ---~n'),
+    ( llvm_foreign_kernel_spec(trav/3, transitive_distance3, Config)
+    -> format('  PASS: spec present, config=~w~n', [Config])
+    ;  format('  FAIL: directive did not populate spec table~n'),
+       throw(directive_failed)
+    ).
+
+test_directive_path_generates_module :-
+    format('--- directive-path compile produces valid module ---~n'),
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project(
+        [user:trav/3],
+        [module_name('td3dir_test')],
+        LLPath),
+    read_file_to_string(LLPath, Src, []),
+
+    ( sub_string(Src, _, _, _, 'M5.6 concrete td3 impl')
+    -> format('  PASS: concrete td3 impl spliced in~n')
+    ;  format('  FAIL: concrete td3 impl missing~n'),
+       throw(no_concrete_impl)
+    ),
+    ( sub_string(Src, _, _, _, '%Instruction { i32 30, i64 4, i64 3 }')
+    -> format('  PASS: call_foreign tag=30 kind=4 arity=3 emitted~n')
+    ;  format('  FAIL: call_foreign instruction not emitted~n'),
+       throw(no_call_foreign)
+    ),
+    ( sub_string(Src, _, _, _, '@foreign_td3_edge_2')
+    -> format('  PASS: fact table global present~n')
+    ;  format('  FAIL: fact table global missing~n')
+    ),
+
+    ( process_which('llvm-as')
+    -> atom_concat(LLPath, '.bc', BCPath),
+       format(atom(Cmd), 'llvm-as ~w -o ~w 2>&1', [LLPath, BCPath]),
+       shell(Cmd, Exit),
+       ( Exit == 0
+       -> format('  PASS: llvm-as accepted the directive-driven module~n')
+       ;  format('  FAIL: llvm-as exit=~w~n', [Exit])
+       ),
+       ( process_which('opt')
+       -> format(atom(VCmd),
+           'opt -passes=verify -disable-output ~w 2>&1', [BCPath]),
+          shell(VCmd, VExit),
+          ( VExit == 0
+          -> format('  PASS: opt -passes=verify accepted bitcode~n')
+          ;  format('  FAIL: opt -passes=verify exit=~w~n', [VExit])
+          )
+       ;  format('  SKIP: opt not found~n')
+       ),
+       catch(delete_file(BCPath), _, true)
+    ;  format('  SKIP: llvm-as not found~n')
+    ),
+    catch(delete_file(LLPath), _, true).
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _,
+        fail).
+
+test_all :-
+    test_directive_populated_spec_table,
+    catch(test_directive_path_generates_module, E,
+        format('  ERROR: ~w~n', [E])),
+    clear_llvm_foreign_kernel_specs.
+
+:- initialization(test_all, main).

--- a/tests/core/test_wam_llvm_foreign_lowering_options.pl
+++ b/tests/core/test_wam_llvm_foreign_lowering_options.pl
@@ -1,0 +1,152 @@
+:- encoding(utf8).
+% test_wam_llvm_foreign_lowering_options.pl
+% Verifies M5.6a: the options-list entry point for foreign kernel
+% lowering (path (b) in the M5.6 design).
+%
+% The user passes `foreign_predicates([pred/3 - kind - [edge_pred(...)]])`
+% in the options list; the compile pipeline:
+%   1. Asserts a llvm_foreign_kernel_spec/3 fact for each entry.
+%   2. Emits a `call_foreign Kind, Arity` predicate body instead of
+%      normal WAM compilation for those predicates.
+%   3. Gathers the edge-pred facts from the user module, emits them as
+%      an %AtomFactPair global constant, and splices a concrete
+%      @wam_td3_kernel_impl body into the state template that calls
+%      @wam_bfs_atom_distance over that table.
+%   4. The resulting module parses with llvm-as and passes
+%      opt -passes=verify.
+%
+% Checks:
+%   1. clear_llvm_foreign_kernel_specs + apply_foreign_predicates_option
+%      populate the spec table correctly.
+%   2. The compile pipeline emits the concrete td3 impl (no weak default).
+%   3. The compile pipeline emits the edge-pred fact table.
+%   4. The compile pipeline emits `call_foreign transitive_distance3, 3`
+%      (tag 30, kind id 4) for the foreign-lowered predicate.
+%   5. llvm-as accepts the module.
+%   6. opt -passes=verify accepts the bitcode.
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3,
+     llvm_foreign_kernel_spec/3,
+     clear_llvm_foreign_kernel_specs/0]).
+:- use_module(library(process)).
+
+% Edge predicate used as the kernel's fact source. These are plain
+% facts in the user module — the compile pipeline reads them via
+% findall/user:edge/2 at compile time.
+:- dynamic edge/2.
+edge(a, b).
+edge(b, c).
+edge(c, d).
+edge(a, e).
+
+% A predicate we want to lower to a foreign td3 kernel. The body is
+% irrelevant — the compile pipeline replaces it entirely with a
+% `call_foreign transitive_distance3, 3` instruction. We just need a
+% definition so the compile path has something to walk.
+:- dynamic my_distance/3.
+my_distance(_, _, _) :- fail.
+
+test_spec_table_populates :-
+    format('--- apply_foreign_predicates_option asserts specs ---~n'),
+    clear_llvm_foreign_kernel_specs,
+    % We can't call apply_foreign_predicates_option directly (not
+    % exported), but write_wam_llvm_project calls it. Tail-piggyback
+    % on the full test below and check the table afterwards.
+    % For this standalone check we drive the internal table directly.
+    assertz(wam_llvm_target:llvm_foreign_kernel_spec(
+        my_distance/3, transitive_distance3, [edge_pred(edge/2)])),
+    ( llvm_foreign_kernel_spec(my_distance/3, transitive_distance3, Config)
+    -> format('  PASS: spec registered, config=~w~n', [Config])
+    ;  format('  FAIL: spec not registered~n'),
+       throw(spec_not_registered)
+    ),
+    clear_llvm_foreign_kernel_specs.
+
+test_options_path_generates_module :-
+    format('--- options-path compile produces module with call_foreign ---~n'),
+    clear_llvm_foreign_kernel_specs,
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project(
+        [user:my_distance/3],
+        [ module_name('td3opts_test'),
+          foreign_predicates([
+              my_distance/3 - transitive_distance3 - [edge_pred(edge/2)]
+          ])
+        ],
+        LLPath),
+    read_file_to_string(LLPath, Src, []),
+
+    % 1. Concrete impl present (NOT the weak default).
+    ( sub_string(Src, _, _, _, 'M5.6 concrete td3 impl')
+    -> format('  PASS: concrete td3 impl spliced into state template~n')
+    ;  format('  FAIL: concrete td3 impl missing~n'),
+       throw(no_concrete_impl)
+    ),
+    ( sub_string(Src, _, _, _, 'define weak i1 @wam_td3_kernel_impl')
+    -> format('  FAIL: weak default still present after substitution~n'),
+       throw(weak_default_not_replaced)
+    ;  format('  PASS: weak default replaced~n')
+    ),
+
+    % 2. Fact table global emitted.
+    ( sub_string(Src, _, _, _, '@foreign_td3_edge_2')
+    -> format('  PASS: foreign_td3_edge_2 fact table global present~n')
+    ;  format('  FAIL: fact table global missing~n'),
+       throw(no_fact_table)
+    ),
+    ( sub_string(Src, _, _, _, 'private constant [4 x %AtomFactPair]')
+    -> format('  PASS: fact table has 4 entries matching edge/2 facts~n')
+    ;  format('  FAIL: fact table array length mismatch~n')
+    ),
+
+    % 3. call_foreign instruction for the predicate.
+    % tag 30 = call_foreign, kind id 4 = transitive_distance3.
+    ( sub_string(Src, _, _, _, '%Instruction { i32 30, i64 4, i64 3 }')
+    -> format('  PASS: call_foreign tag=30 kind=4 arity=3 emitted~n')
+    ;  format('  FAIL: call_foreign instruction not emitted~n'),
+       throw(no_call_foreign)
+    ),
+
+    % 4. llvm-as accepts the module.
+    ( process_which('llvm-as')
+    -> atom_concat(LLPath, '.bc', BCPath),
+       format(atom(Cmd), 'llvm-as ~w -o ~w 2>&1', [LLPath, BCPath]),
+       shell(Cmd, Exit),
+       ( Exit == 0
+       -> format('  PASS: llvm-as accepted the module~n')
+       ;  format('  FAIL: llvm-as exit=~w~n', [Exit])
+       ),
+       ( process_which('opt')
+       -> format(atom(VCmd),
+           'opt -passes=verify -disable-output ~w 2>&1', [BCPath]),
+          shell(VCmd, VExit),
+          ( VExit == 0
+          -> format('  PASS: opt -passes=verify accepted bitcode~n')
+          ;  format('  FAIL: opt -passes=verify exit=~w~n', [VExit])
+          )
+       ;  format('  SKIP: opt not found~n')
+       ),
+       catch(delete_file(BCPath), _, true)
+    ;  format('  SKIP: llvm-as not found~n')
+    ),
+    catch(delete_file(LLPath), _, true),
+    clear_llvm_foreign_kernel_specs.
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _,
+        fail).
+
+test_all :-
+    test_spec_table_populates,
+    catch(test_options_path_generates_module, E,
+        format('  ERROR: ~w~n', [E])).
+
+:- initialization(test_all, main).


### PR DESCRIPTION
## Summary

Completes Milestone 5.6 — the compile-pipeline wiring that makes `foreign_lowering` actually do something. This PR brings the full chain from Prolog source to LLVM IR online for `transitive_distance3`: a user-declared foreign predicate now compiles to a module containing a `call_foreign` instruction, a concrete `@wam_td3_kernel_impl` body that calls the M5.2 BFS helper, and an `%AtomFactPair` edge table emitted from the user's edge-predicate facts.

Three user-facing entry paths all feed a single internal spec table and a single downstream compile path:

- **Path (a) — Prolog directive.** `:- foreign_kernel(Pred/Arity, Kind, Config)` in user source.
- **Path (b) — Options list shortcut.** `foreign_predicates([Pred/Arity - Kind - Config, ...])` passed to `write_wam_llvm_project/3`.
- **Path (c) — Automatic clause-shape detection.** `foreign_lowering(true)` + detector registry mirroring the Rust target.

## Background

Six-step roadmap from prior PRs in this milestone series:

| Milestone | Status | Scope |
|---|---|---|
| M1 | merged (#1298) | `switch_on_constant` + latent IR fixes |
| M2 | merged (#1301) | aggregate frames |
| M3 | merged (#1306) | foreign dispatch scaffolding (`call_foreign`) |
| M4 | merged (#1306) | indexed fact table emission |
| M5.1–M5.3 | merged (#1309) | FFI bridge + BFS + Dijkstra helpers |
| M5.4 + M5.5 | merged (#1314) | A* helper + td3 dispatcher delegation |
| **M5.6** | **this PR** | end-to-end foreign lowering pipeline |

Prior PRs built the runtime primitives in isolation. M5.6 bolts them together into an exercisable compile path.

## Architecture

### Single canonical spec table

All three entry paths assert into one dynamic table:

```prolog
:- dynamic llvm_foreign_kernel_spec/3.
% llvm_foreign_kernel_spec(?Pred/Arity, ?KernelKind, ?Config)
```

Downstream of assertion, the three paths are indistinguishable. The compile pipeline reads this table once per predicate; there's no parallel code path per entry style.

### Compile pipeline integration

`compile_predicates_collect/4` grows a new first-check branch before native LLVM lowering and WAM fallback:

```
1. If llvm_foreign_kernel_spec(Pred/Arity, Kind, _) exists →
      emit `call_foreign Kind, Arity; proceed` as the predicate body
2. Else try native LLVM lowering
3. Else WAM fallback
```

When branch 1 fires, `compile_foreign_kernel_predicate/5` formats a two-line WAM program and hands it to the existing text-WAM→LLVM compile path, producing a valid `%Instruction` array just like any other WAM-compiled predicate.

### Template-rendering-time substitution

The M5.5 `state.ll.mustache` template defines `@wam_td3_kernel_impl` as a `define weak` default that returns false. LLVM 21 disallows multiple definitions of the same function in one module, so the compile pipeline replaces (not appends) the weak default when any td3 spec is registered.

`substitute_foreign_kernel_impls/3` runs right after the state template is rendered:

1. Queries `llvm_foreign_kernel_spec/3` for td3 entries.
2. If any exist, `build_td3_concrete_impl/6` gathers the edge facts from the user module, emits them as an `%AtomFactPair` global constant via the M4 `llvm_emit_atom_fact2_table/3` helper, computes `max_atom_id` by interning every atom in the table, and formats a concrete impl body that:
   - Reads A1/A2 atom IDs via `@wam_get_reg_tag` + `@wam_get_reg_payload` (M5.1)
   - GEPs into the module-local edge table
   - Calls `@wam_bfs_atom_distance` (M5.2) with inline length and max_atom_id
   - On success writes A3 via `@wam_set_reg_int` (M5.1) and returns true
   - On miss returns false
3. `replace_td3_weak_default/3` does a substring swap: the weak default fragment from M5.5 is replaced with the concrete body.
4. The edge-table global is returned separately and prepended to the module's native predicates section so it's at module scope.

### Auto-detection (path c)

Mirrors the Rust target's pattern-matching detection at `rust_target.pl:3742-3988`:

```prolog
llvm_recursive_kernel_detector(transitive_distance3,
    llvm_recursive_kernel_transitive_distance).

llvm_foreign_lowerable_transitive_distance(Pred, 3, Clauses, EdgePred) :-
    member(BaseHead-BaseBody, Clauses),
    member(RecHead-RecBody, Clauses),
    BaseHead =.. [Pred, BaseStart, BaseTarget, 1],
    RecHead =.. [Pred, RecStart, RecTarget, RecDepth],
    BaseBody =.. [EdgePred, BaseStart, BaseTarget],
    RecBody = (EdgeGoal, (RecGoal, IsGoal)),
    EdgeGoal =.. [EdgePred, RecStart, RecMid],
    RecGoal =.. [Pred, RecMid, RecTarget, PrevDepth],
    IsGoal =.. [is, RecDepth, Expr],
    Expr =.. [+, PrevDepth, 1].
```

The matcher confirms the two-clause shape:

```prolog
pred(Start, Target, 1)     :- edge(Start, Target).
pred(Start, Target, Depth) :-
    edge(Start, Mid),
    pred(Mid, Target, Prev),
    Depth is Prev + 1.
```

`llvm_auto_detect_foreign_kernels/1` iterates predicates, runs each detector, and asserts matches. It skips predicates that already have a spec (from paths a or b), so mixing entry styles in one compile is safe.

## Why These Particular Design Choices

- **One canonical table, three entry paths.** Earlier M5.5 work hit a wall with LLVM's "one definition per symbol in a module" rule. Having a single internal data model collapsed three potential testing matrices into one, which lets us test each entry path in isolation and trust the shared downstream behavior.

- **Directive path is a plain exported predicate, not `term_expansion`.** Global term-expansion hooks are fragile and affect unrelated modules. `foreign_kernel/3` is just an exported side-effect predicate that happens to be callable as a directive — the same pattern used by `dynamic`, `discontiguous`, and `multifile`.

- **Options path maps to directive path via one helper.** `apply_foreign_predicates_option/1` iterates the list and asserts the same facts the directive would. The user interface is more convenient; the internal code path is identical.

- **Template substitution, not runtime dispatch.** Replacing the weak default at render time sidesteps LLVM 21's ban on `declare` + `define` and `define weak` + strong definition in a single module. Future kernels (Dijkstra, A*) can reuse the same pattern once their dispatcher stubs gain the M5.5 weak-default treatment.

## Latent Bug Fix

`compile_wam_predicate_to_llvm/4` was emitting `@pred_labels = private constant [0 x i32] [i32 0]` for predicates with zero labels — LLVM rejects the array-type vs initializer length mismatch. The bug was latent because every predicate compiled through the WAM fallback so far had at least one label (usually from `try_me_else` clause dispatch). Foreign-kernel predicates are the first to legitimately have zero labels — their body is literally `call_foreign; proceed`, no choice points. Fix decouples `LabelArraySize` (for LLVM type-checking, always ≥ 1) from `LabelCount` (logical count, may be 0, passed to `wam_state_new`).

## Test Coverage

| Suite | Assertions | Scope |
|---|---|---|
| `test_wam_llvm_switch.pl` (M1) | 7 | regression |
| `test_wam_llvm_aggregate.pl` (M2) | 5 | regression |
| `test_wam_llvm_foreign_dispatch.pl` (M3) | 11 | regression |
| `test_wam_llvm_fact_tables.pl` (M4) | 10 | regression |
| `test_wam_llvm_ffi_bridge.pl` (M5.1) | 7 | regression |
| `test_wam_llvm_bfs_atom.pl` (M5.2) | 3 | regression |
| `test_wam_llvm_dijkstra.pl` (M5.3) | 4 | regression |
| `test_wam_llvm_astar.pl` (M5.4) | 4 | regression |
| `test_wam_llvm_td3_wiring.pl` (M5.5) | 4 | regression |
| `test_wam_llvm_foreign_lowering_options.pl` (M5.6a) | 8 | **new** |
| `test_wam_llvm_foreign_lowering_directive.pl` (M5.6b) | 6 | **new** |
| `test_wam_llvm_foreign_lowering_autodetect.pl` (M5.6c) | 9 | **new** |
| **Total** | **78** | |

### M5.6a Tests — Options Path

End-to-end validation of `foreign_predicates([...])` entry:
1. Spec table populates correctly.
2. Concrete td3 impl spliced into the module.
3. Weak default is gone after substitution (no duplicate definition).
4. `@foreign_td3_edge_2` fact table global emitted.
5. Fact table has 4 entries matching `user:edge/2` clauses.
6. `call_foreign tag=30 kind=4 arity=3` instruction emitted.
7. `llvm-as` accepts the full module.
8. `opt -passes=verify` accepts the bitcode.

### M5.6b Tests — Directive Path

Uses `:- foreign_kernel(trav/3, transitive_distance3, [edge_pred(edge/2)])` in a loaded test file. Verifies the directive populates the spec table at load time and the downstream compile produces the same end-state as the options path (concrete impl, `call_foreign` instruction, fact table, `llvm-as` + `opt verify` clean).

### M5.6c Tests — Auto-Detect

Three scenarios:

1. **Positive case.** A real `reach/3` predicate matching the td3 clause shape + `foreign_lowering(true)` → auto-registers, emits `call_foreign`, splices concrete impl, validates through `llvm-as` + `opt verify`.
2. **Off-by-default.** Same td3-shaped predicate *without* `foreign_lowering(true)` → spec does not leak, no `call_foreign` emitted, falls through to normal WAM compilation.
3. **False-positive guard.** An unrelated predicate (`unrelated(X, Y) :- X = Y`) with `foreign_lowering(true)` → does not match any detector, no spec registered.

## Known Limitations

- **Only `transitive_distance3` is fully wired.** Dijkstra (`weighted_shortest_path3`) and A* (`astar_shortest_path4`) still use the M5.5 plain-stub pattern — their helpers (`@wam_dijkstra_weighted_distance` and `@wam_astar_weighted_distance`) are in place but not yet reachable via `call_foreign`. Extending the M5.5 weak-default and M5.6 substitution pattern to those kinds is follow-up work.
- **Single-config td3.** When multiple td3 predicates are registered with *different* `edge_pred` configs, the current implementation uses the first spec's config to drive the concrete impl. The Rust target handles this via `register_indexed_atom_fact2` calls keyed by edge_pred name — a later refinement can adopt the same shape.
- **No execution testing.** Tests validate through `llvm-as` and `opt -passes=verify` but not via `lli` or a linked object. End-to-end execution validation is a stretch goal for after Dijkstra and A* are wired.

## Commits

- `b585b81e` — M5.6a: spec table + options path + pipeline wiring
- `f2e8b89e` — M5.6b: foreign_kernel/3 directive path
- `078fac39` — M5.6c: auto-detect foreign kernels from clause shape

## Files Changed

- `src/unifyweaver/targets/wam_llvm_target.pl` — spec table, options/directive/auto-detect entry points, compile-pipeline integration, template substitution, concrete impl builder, latent `LabelArraySize` bug fix.
- `tests/core/test_wam_llvm_foreign_lowering_options.pl` — new (M5.6a).
- `tests/core/test_wam_llvm_foreign_lowering_directive.pl` — new (M5.6b).
- `tests/core/test_wam_llvm_foreign_lowering_autodetect.pl` — new (M5.6c).

## What's Next

1. **Extend to Dijkstra and A* kernels.** Add M5.5-style weak-default `@wam_wsp3_kernel_impl` and `@wam_astar4_kernel_impl`, mirror `build_td3_concrete_impl/6` for weighted edges, and port the Rust `rust_foreign_lowerable_weighted_shortest_path` / `rust_foreign_lowerable_astar_shortest_path` matchers.
2. **Multi-edge-pred support.** Refactor the concrete impl to read config from a per-predicate dispatch table rather than baking the first spec's edge table globally.
3. **Execution testing.** Link the generated bitcode against a small host and verify `reach(a, d, D)` actually returns `D=3` for the test graph.
4. **Cross-target consistency review.** Compare the LLVM foreign-lowering surface to the Rust target's and reconcile any gaps (e.g., the Rust target also handles `category_ancestor`, `countdown_sum2`, `list_suffix2`, `transitive_closure2` — none of which are wired in LLVM yet).

## Test Plan

- [x] All 9 prior M1–M5.5 regression suites green (55 assertions).
- [x] M5.6a: `swipl -q tests/core/test_wam_llvm_foreign_lowering_options.pl`
- [x] M5.6b: `swipl -q tests/core/test_wam_llvm_foreign_lowering_directive.pl`
- [x] M5.6c: `swipl -q tests/core/test_wam_llvm_foreign_lowering_autodetect.pl`
- [x] Every generated foreign-kernel module validates through `llvm-as` AND `opt -passes=verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
