### PR TITLE
fix(wat): cross-predicate label resolution via merged project-level label table

### DIFF
--- a/docs/design/WAM_TERM_BUILTINS_PHASE_6_PERF.md
+++ b/docs/design/WAM_TERM_BUILTINS_PHASE_6_PERF.md
@@ -134,6 +134,98 @@ WAM-level recursion).
 
 The fix is tracked as a follow-up; it's out of scope for Phase 6.
 
+### 4.4 Post-commit update: WAM-WAT cross-predicate fix landed
+
+Immediately after Phase 6, the WAM-WAT half of this blocker was
+fixed in [`feat/wam-cross-pred-labels`](#). The fix restructures
+`compile_wat_predicates/6` into a two-pass project-level pipeline:
+
+  1. **Pass 1** parses every predicate's WAM text into `(Instrs,
+     LocalLabels, NumInstrs)` and computes each predicate's
+     cumulative start PC in a single merged instruction array.
+  2. **Label merge** shifts every local label by its predicate's
+     start PC and accumulates into one project-wide table.
+  3. **Pass 2** re-encodes every predicate's instructions against
+     the merged global labels, so both internal try_me_else targets
+     and external `call`/`execute` targets resolve to correct
+     absolute PCs.
+  4. **Assembly** emits ONE data segment at a fixed `CodeBase` with
+     all bytes concatenated; every predicate's entry function now
+     calls `$set_pc` with its start PC before invoking a `$run_loop`
+     that takes the shared `CodeBase` and the total instruction
+     count.
+
+Validation: `tests/test_wam_wat_target.pl` gains
+`functional_cross_predicate_call`, which compiles
+
+```prolog
+simple_id(X, X).
+cross_caller :- simple_id(hello, _).
+```
+
+through `write_wam_wat_project`, runs `cross_caller_0` via
+wat2wasm + node, and asserts the return value is 1. This is the
+first WAM-WAT test in the suite that exercises a WAM-level call
+from one user predicate to another. Before the fix it returned 0
+(the `execute simple_id/2` encoded PC=0 and re-entered the caller);
+after the fix it returns 1.
+
+### 4.5 New layer of blockers surfaced by the cross-predicate fix
+
+Unblocking cross-predicate calls let Phase 6 attempt to run the
+`sum_ints` benchmark end-to-end for the first time. The attempt
+failed with `memory access out of bounds`, and tracing back from
+the generated WAM revealed two **separate** layers of blockers that
+the previous cross-predicate blocker had been masking:
+
+  **(a) Type-check builtins are stubs / missing.**
+  `integer/1`, `atom/1`, `var/1`, `nonvar/1`, `float/1`,
+  `number/1` (IDs 9–14) are reserved in the builtin table but map
+  to `$default` in `$execute_builtin`'s `br_table`, which returns
+  0 (fail). Sum_ints's first clause guards on `integer(T)`, so it
+  always fails and always triggers backtracking to clause 2 —
+  correct for the walker path on compound terms, but means no
+  workload that relies on any type check can make forward
+  progress via its "happy path".
+
+  **(b) `=/2` is lowered as an external predicate call rather than
+  primitive unification.** The canonical WAM compiler emits
+  `execute =/2` (or `call =/2, 2`) for body goals of the form
+  `X = Y`, but `=/2` is not in WAM-WAT's `builtin_id/2` table, so
+  it is treated as a regular user predicate. `resolve_label/3`
+  misses and returns `PC = 0`; at runtime the VM jumps to the
+  first instruction of the merged project (the first predicate's
+  allocate or put_value), corrupting state and eventually hitting
+  an out-of-bounds memory access on some downstream load. The
+  proper fix is to lower `=/2` into `get_value`/`unify_value`
+  directly in the canonical WAM layer, as standard Prolog WAM
+  implementations do.
+
+Both are orthogonal to Group A, orthogonal to cross-predicate
+labels, and orthogonal to each other. They are new tracked items in
+§8.
+
+### 4.6 WAM-Rust port status
+
+The same cross-predicate fix has NOT yet been ported to WAM-Rust.
+The architectures differ substantially:
+
+  * WAM-WAT emits a single data segment with absolute PCs; the run
+    loop is a shared `$run_loop(code_base, num_instrs)` function.
+  * WAM-Rust emits one `pub fn pred_name(vm, a1, ..)` per predicate,
+    each of which constructs its own local `code: Vec<Instruction>`
+    and `labels: HashMap<String, usize>`, assigns `vm.code = code;
+    vm.labels = labels`, and calls `vm.run()`. The instruction Vec
+    and label map are ephemeral per-call.
+
+Porting the fix requires either (i) switching to a module-level
+shared `static CODE: OnceLock<Vec<Instruction>>` + `static LABELS:
+OnceLock<HashMap<_>>` with thin `pub fn` wrappers that set PC and
+call `vm.run()`, or (ii) lazily merging all predicates' code into
+one shared Vec at first call. Both are larger refactors than the
+WAM-WAT case and deserve their own PR/branch — tracked as a
+follow-up in §8.
+
 ## 5. Optimization: O(1) term-builtin dispatch
 
 Even without end-to-end benchmarking, one concrete optimization was
@@ -262,15 +354,32 @@ future refactor breaks the shared `HashMap` threading.
 
 ## 8. Follow-ups (explicitly out of scope here)
 
-- **Cross-predicate label resolution** in both WAM-Rust and WAM-WAT
-  (fix `resolve_label/3` + its callers to use a project-level label
-  table built in `write_wam_*_project/3`).
+- **~~Cross-predicate label resolution in WAM-WAT~~** —
+  landed in `feat/wam-cross-pred-labels` as a two-pass project-level
+  pipeline with a merged global label table and single shared data
+  segment. Validated by `functional_cross_predicate_call`. See §4.4.
+- **Cross-predicate label resolution in WAM-Rust** — still pending
+  (§4.6). Larger refactor than the WAT case due to the per-predicate
+  `pub fn` architecture; needs a module-level shared CODE/LABELS.
+- **Type-check builtin handlers** for IDs 9–14 (`var/1`, `nonvar/1`,
+  `atom/1`, `integer/1`, `float/1`, `number/1`) in WAM-WAT's
+  `$execute_builtin` br_table. Currently all fall through to
+  `$default` which returns 0. Blocks any benchmark with a type
+  guard on its happy path — including the `sum_ints` walker.
+- **`=/2` lowering** in the canonical WAM compiler — currently
+  emits `execute =/2` which is not a recognized builtin and
+  resolves to PC=0 at runtime, corrupting execution. Should lower
+  to `get_value` / `unify_value` instructions directly, as
+  standard WAM implementations do.
 - **If-then-else lowering hang** in the canonical WAM compiler on
   hybrid backends — would remove the need for cut-style rewrites of
   benchmark predicates.
-- **Rerun perf comparison** once (1) lands: measure `sum_ints` on
-  host SWI, WAM-WAT (via wat2wasm + node), and WAM-Rust (via cargo
-  test), and tabulate ns/call for each. Report honestly, even if
-  native WAM is 10–100x slower.
+- **Rerun perf comparison** once all three codegen blockers above
+  land: measure `sum_ints` on host SWI, WAM-WAT (via wat2wasm +
+  node), and WAM-Rust (via cargo test), and tabulate ns/call for
+  each. Report honestly, even if native WAM is 10–100x slower.
 - **Profile-guided optimization of the `$unify` / `$deref` hot
   paths** in WAM-WAT if the rerun shows they dominate the cost.
+- **`copy_term` scratch overflow** — currently hard-caps at 64
+  distinct source variables and 128 pending work items per call.
+  A dynamic scratch region would lift this.

--- a/src/unifyweaver/targets/wam_wat_target.pl
+++ b/src/unifyweaver/targets/wam_wat_target.pl
@@ -1828,31 +1828,136 @@ write_wam_wat_project(Predicates, Options, OutputFile) :-
     write_file(OutputFile, FullModule),
     format('WAM-WAT module written to: ~w~n', [OutputFile]).
 
-%% compile_wat_predicates(+Preds, +Opts, +BaseOff, -DataSegs, -Funcs, -Exports)
-compile_wat_predicates([], _, _, '', '', '').
-compile_wat_predicates([PredInd|Rest], Options, BaseOff, DataSegs, Funcs, Exports) :-
+%% compile_wat_predicates(+Preds, +Opts, +CodeBase, -DataSegs, -Funcs, -Exports)
+%
+%  Two-pass project-level compilation:
+%
+%    Pass 1: parse each predicate's WAM text into instructions + local
+%            labels, compute each predicate's cumulative start PC.
+%    Build:  global label table = union of every predicate's labels
+%            with their local PCs shifted by the predicate's start PC.
+%            Each predicate's entry label (e.g. 'sum_ints/3') lives at
+%            its start PC, so cross-predicate call/execute instructions
+%            resolve correctly.
+%    Pass 2: re-encode each predicate's instructions using the global
+%            label table so internal labels (try_me_else targets) and
+%            external references (call sibling/N) both resolve to
+%            absolute PCs within a single merged instruction array.
+%    Assemble: concatenate all encoded bytes into ONE data segment at
+%            CodeBase. Entry functions share the same CodeBase and
+%            total instruction count, but each sets PC to its own
+%            start offset before calling $run_loop.
+%
+%  Prior to this change, each predicate had its own per-predicate
+%  label table and emitted its own data segment at a distinct base.
+%  Cross-predicate Execute / Call instructions encoded the target
+%  with local-label resolution, which defaults to PC=0 on miss —
+%  the VM would then jump to PC=0 of the CALLING predicate's code,
+%  silently re-entering the caller and creating an infinite loop
+%  (or immediate failure if the re-entry path failed a guard). This
+%  fix unifies the label namespace across all predicates in a
+%  project, making multi-predicate WAM programs runnable end-to-end.
+compile_wat_predicates(Predicates, Options, CodeBase, DataSegs, Funcs, Exports) :-
+    %% Pass 1: parse + collect per-predicate data with cumulative PCs.
+    pass1_parse_predicates(Predicates, Options, 0, PredData, TotalInstrs),
+    %% Build global label table (shift each predicate's local labels).
+    build_global_labels(PredData, [], GlobalLabels),
+    %% Pass 2: re-encode each predicate's instructions against global
+    %% labels and concatenate the byte sequences.
+    encode_all_predicates(PredData, GlobalLabels, AllHex),
+    (   AllHex == ''
+    ->  DataSegs = ''
+    ;   format(atom(DataSegs),
+            '(data (i32.const ~w) "~w")', [CodeBase, AllHex])
+    ),
+    %% Entry functions: one per predicate, each setting its own
+    %% start PC before invoking the shared run loop.
+    option(wam_heap_start(HeapStart), Options, 196608),
+    gen_all_entry_funcs(PredData, HeapStart, CodeBase, TotalInstrs,
+                        Funcs, Exports).
+
+%% pass1_parse_predicates(+Preds, +Opts, +StartPC, -PredData, -TotalInstrs)
+%
+%  PredData is a list of pred_data(Pred/Arity, Instrs, LocalLabels,
+%  StartPC, NumInstrs) entries in input order, where StartPC is the
+%  cumulative instruction index at which this predicate's first
+%  instruction lives in the merged instruction array.
+pass1_parse_predicates([], _, _, [], 0).
+pass1_parse_predicates([PredInd|Rest], Options, StartPC,
+                       [pred_data(Pred/Arity, Instrs, LocalLabels,
+                                  StartPC, NumInstrs) | RestData],
+                       TotalInstrs) :-
     (   PredInd = _Module:Pred/Arity -> true
     ;   PredInd = Pred/Arity
     ),
-    %% Try WAM compilation
     (   catch(
             wam_target:compile_predicate_to_wam(PredInd, Options, WamCode),
             _, fail)
-    ->  PredOpts = [code_base(BaseOff)|Options],
-        compile_wam_predicate_to_wat(Pred/Arity, WamCode, PredOpts, WatResult),
-        WatResult = wat_pred(DS, EF, _, NumInstrs),
-        NextBase is BaseOff + NumInstrs * 20,
-        format(user_error, '  ~w/~w: WAM compilation (~w instructions)~n',
-               [Pred, Arity, NumInstrs]),
-        wat_pred_name(Pred, Arity, FName),
-        format(atom(Export), '  ;; exported: ~w', [FName])
-    ;   DS = '', EF = '', NextBase = BaseOff,
-        Export = '',
+    ->  atom_string(WamCode, WamStr),
+        split_string(WamStr, "\n", "", Lines),
+        wam_lines_to_instrs(Lines, 0, Instrs, LocalLabels),
+        length(Instrs, NumInstrs),
+        format(user_error,
+               '  ~w/~w: WAM compilation (~w instructions, start PC ~w)~n',
+               [Pred, Arity, NumInstrs, StartPC])
+    ;   Instrs = [], LocalLabels = [], NumInstrs = 0,
         format(user_error, '  ~w/~w: compilation failed~n', [Pred, Arity])
     ),
-    compile_wat_predicates(Rest, Options, NextBase, RestDS, RestFuncs, RestExports),
-    atomic_list_concat([DS, '\n', RestDS], DataSegs),
-    atomic_list_concat([EF, '\n', RestFuncs], Funcs),
+    NextPC is StartPC + NumInstrs,
+    pass1_parse_predicates(Rest, Options, NextPC, RestData, RestTotal),
+    TotalInstrs is NumInstrs + RestTotal.
+
+%% build_global_labels(+PredData, +Acc, -GlobalLabels)
+%  For each predicate, shift its local labels by its start PC and
+%  accumulate into a single project-wide LabelName-PC list. Labels
+%  are expected to be globally unique (internal WAM labels already
+%  encode the predicate name; entry labels are the Pred/Arity form).
+build_global_labels([], Acc, Acc).
+build_global_labels([pred_data(_, _, LocalLabels, StartPC, _)|Rest],
+                    Acc, GlobalLabels) :-
+    shift_labels(LocalLabels, StartPC, Shifted),
+    append(Shifted, Acc, NewAcc),
+    build_global_labels(Rest, NewAcc, GlobalLabels).
+
+shift_labels([], _, []).
+shift_labels([Name-LocalPC|Rest], Shift, [Name-GlobalPC|RestShifted]) :-
+    GlobalPC is LocalPC + Shift,
+    shift_labels(Rest, Shift, RestShifted).
+
+%% encode_all_predicates(+PredData, +GlobalLabels, -AllHex)
+%  Re-encode every predicate's instructions against the merged label
+%  table, concatenating the resulting hex byte strings in predicate
+%  order. The order matches pass1 so instruction indices remain
+%  consistent with start PCs.
+encode_all_predicates([], _, '').
+encode_all_predicates([pred_data(_, Instrs, _, _, _)|Rest],
+                      GlobalLabels, AllHex) :-
+    maplist(encode_instr_with_labels(GlobalLabels), Instrs, HexParts),
+    atomic_list_concat(HexParts, PredHex),
+    encode_all_predicates(Rest, GlobalLabels, RestHex),
+    atomic_list_concat([PredHex, RestHex], AllHex).
+
+%% gen_all_entry_funcs(+PredData, +HeapStart, +CodeBase, +TotalInstrs,
+%%                     -Funcs, -Exports)
+%  Emit one exported entry function per predicate. All entry functions
+%  share the same CodeBase and TotalInstrs; they differ only in their
+%  StartPC, which each function writes into the VM's PC register
+%  immediately after $wam_init (before invoking the run loop).
+gen_all_entry_funcs([], _, _, _, '', '').
+gen_all_entry_funcs([pred_data(Pred/Arity, _, _, StartPC, _)|Rest],
+                    HeapStart, CodeBase, TotalInstrs,
+                    EntryFuncs, Exports) :-
+    wat_pred_name(Pred, Arity, FName),
+    format(atom(EF),
+'(func $~w (export "~w") (result i32)
+  (call $wam_init (i32.const ~w))
+  (call $set_pc (i32.const ~w))
+  (call $run_loop (i32.const ~w) (i32.const ~w)))',
+        [FName, FName, HeapStart, StartPC, CodeBase, TotalInstrs]),
+    format(atom(Export), '  ;; exported: ~w', [FName]),
+    gen_all_entry_funcs(Rest, HeapStart, CodeBase, TotalInstrs,
+                        RestEF, RestExports),
+    atomic_list_concat([EF, '\n', RestEF], EntryFuncs),
     atomic_list_concat([Export, '\n', RestExports], Exports).
 
 %% read_template_file(+Path, -Content)

--- a/tests/test_wam_wat_target.pl
+++ b/tests/test_wam_wat_target.pl
@@ -398,6 +398,56 @@ run_wam_wat_module_export(WatFile, ExportName, Result) :-
     ;   throw(wam_wat_runtime_error(run(RExit, RunOut)))
     ).
 
+test(functional_cross_predicate_call, [condition(tool_available(wat2wasm)),
+                                         condition(tool_available(node))]) :-
+    %% Cross-predicate label resolution end-to-end:
+    %%
+    %%   simple_id(X, X).
+    %%   cross_caller :- simple_id(hello, _).
+    %%
+    %% cross_caller executes simple_id/2 as a tail call. Before the
+    %% cross-predicate fix, resolve_label/3 used each predicate''s
+    %% LOCAL label table — so `execute simple_id/2` from inside
+    %% cross_caller''s instruction stream would not find simple_id/2
+    %% (it''s in simple_id''s own label table, not cross_caller''s),
+    %% fall back to PC=0, and the VM would re-enter cross_caller,
+    %% creating an infinite loop or silent failure depending on
+    %% exact timing.
+    %%
+    %% The two-pass compile_wat_predicates/6 builds a project-level
+    %% merged label table where both cross_caller''s and simple_id''s
+    %% entries live at their absolute start PCs in the single merged
+    %% instruction array. A return value of 1 proves:
+    %%   (a) cross_caller''s entry PC is set correctly on the VM
+    %%   (b) the `execute simple_id/2` encodes an absolute PC that
+    %%       reaches simple_id''s first instruction
+    %%   (c) simple_id''s head unifies with A1 and A2 correctly
+    %%       using the shared single data segment
+    %%   (d) simple_id''s proceed halts cleanly since CP=-1
+    get_time(T),
+    format(atom(WatFile),
+        '/data/data/com.termux/files/home/tmp/test_wam_func_cross_~w.wat', [T]),
+    assertz(user:simple_id(X, X)),
+    assertz(user:cross_caller :- simple_id(hello, _)),
+    setup_call_cleanup(
+        true,
+        (   write_wam_wat_project([cross_caller/0, simple_id/2],
+                                  [module_name(func_cross_test)], WatFile),
+            run_wam_wat_module_export(WatFile, cross_caller_0, Result),
+            (   Result =:= 1
+            ->  true
+            ;   throw(wam_wat_runtime_error(cross_pred_failed(Result)))
+            )
+        ),
+        (   retractall(user:simple_id/2),
+            retractall(user:cross_caller),
+            (exists_file(WatFile) -> delete_file(WatFile) ; true),
+            file_name_extension(Base, _, WatFile),
+            file_name_extension(Base, wasm, WasmFile),
+            (exists_file(WasmFile) -> delete_file(WasmFile) ; true)
+        )
+    ).
+
 test(functional_copy_term_nested, [condition(tool_available(wat2wasm)),
                                      condition(tool_available(node))]) :-
     %% Deep copy_term follow-up: copy_term(outer(inner(a, b), c), _)


### PR DESCRIPTION
## Summary

Fixes the single most-impactful pre-existing blocker called out in
the Phase 6 perf writeup: **cross-predicate `call` / `execute`
instructions in WAM-WAT resolve labels against each predicate's
LOCAL label table rather than a project-level merged table**,
causing any multi-predicate WAM program to silently re-enter the
caller on the first cross-predicate dispatch.

After this PR, a WAM-level `execute sibling_pred/N` from inside
predicate A correctly jumps to `sibling_pred`'s absolute PC in a
single shared instruction array. Validated end-to-end by a new
functional test that compiles two user predicates linked by a
WAM-level call, runs them via wat2wasm + node, and asserts the
return value.

Attempting to run the `sum_ints` benchmark from Phase 6 through the
fixed pipeline surfaced **two new orthogonal blockers** (type-check
builtins are stubs, and `=/2` is lowered as an external predicate
call rather than primitive unification) — the Phase 6 writeup is
updated with both. These new blockers are out of scope for this PR
and tracked as separate follow-ups.

## Problem

Prior to this fix, `compile_wat_predicates/6` compiled each
predicate in isolation:

```
parse WAM text → local LocalLabels_i table
              → encode Instrs_i using resolve_label(_, LocalLabels_i)
              → emit a separate (data ...) segment at its own CodeBase
              → emit an entry function that called $run_loop(CodeBase_i, N_i)
```

When an `execute sum_ints_args/5` instruction sat inside
`sum_ints/3`'s body, `resolve_label("sum_ints_args/5", LocalLabels_i)`
couldn't find the label (only internal `L_sum_ints_3_*` labels were
in `sum_ints/3`'s local map) and fell back to `PC = 0`. At runtime
the VM jumped to PC=0 of `sum_ints/3`'s code segment — the first
instruction of `sum_ints/3` itself — silently re-entering the caller
and creating either an infinite loop or immediate failure.

This affected **every** multi-predicate WAM program compiled through
WAM-WAT. It simply wasn't exercised by the existing test corpus,
which uses native-lowered predicates with Rust-level recursion at
the host, not WAM-level recursion.

## Fix

`compile_wat_predicates/6` is refactored into a two-pass
project-level pipeline:

### Pass 1 — `pass1_parse_predicates/5`

For each predicate, compile to WAM and parse into `(Instrs,
LocalLabels, NumInstrs)`. Compute each predicate's cumulative
`StartPC` in the merged instruction array. Collect into
`pred_data(Pred/Arity, Instrs, LocalLabels, StartPC, NumInstrs)`
records in input order.

### Label merge — `build_global_labels/3`, `shift_labels/3`

For each predicate, shift every local label's PC by its `StartPC`
and accumulate into a project-wide `LabelName-AbsolutePC` list.

  * Entry labels (e.g. `sum_ints_args/5`, parsed from the first
    line of each WAM text) land at their predicate's `StartPC`.
  * Internal labels (e.g. `L_sum_ints_3_2` from try_me_else
    alternates) land at `StartPC + local_offset`.

Labels are expected to be globally unique; internal WAM labels
already encode the predicate name, and entry labels are the
`Pred/Arity` form.

### Pass 2 — `encode_all_predicates/3`

Re-encode every predicate's instructions against the merged
`GlobalLabels` table. Both `try_me_else` (internal) and
`execute`/`call` (possibly external) now resolve to correct
absolute PCs.

### Assembly — `gen_all_entry_funcs/6`

Concatenate all hex bytes into **ONE** `(data (i32.const CodeBase)
"...")` segment. Emit one entry function per predicate:

```wat
(func $sum_ints_3 (export "sum_ints_3") (result i32)
  (call $wam_init (i32.const 196608))
  (call $set_pc (i32.const 0))                  ;; sum_ints/3's StartPC
  (call $run_loop (i32.const 131072) (i32.const 141)))  ;; CodeBase, TotalInstrs
```

All entry functions share the same `CodeBase` and `TotalInstrs`;
they differ only in the `StartPC` they write into the VM's PC
register before invoking `$run_loop`. The shared run loop
bounds-checks against `TotalInstrs` so execution can freely hop
between predicate PC ranges via `call` / `execute`.

## Validation

### New functional test

`tests/test_wam_wat_target.pl` gains `functional_cross_predicate_call`:

```prolog
simple_id(X, X).
cross_caller :- simple_id(hello, _).
```

Compiles both predicates through `write_wam_wat_project`, runs
`cross_caller_0` via `wat2wasm` + `node`, asserts the return value
is 1. Before the fix this returned 0 (the `execute simple_id/2`
encoded PC=0 and re-entered the caller on the first step); after
the fix it returns 1.

This is the first WAM-WAT test in the suite that exercises a
WAM-level call from one user predicate to another — a shape that
was previously unreachable.

### Regression check

All **52** WAM-WAT tests pass (51 pre-existing + the new
functional test). Key existing tests that continue to pass:

- `wat2wasm_validates` — generated module compiles cleanly
- `functional_true_succeeds` — baseline single-predicate runtime
- `functional_univ_decompose_compound` — `=../2` end-to-end
- `functional_copy_term_compound`, `functional_copy_term_nested` —
  shallow and deep `copy_term/2` end-to-end
- `compile_simple_predicate` — still uses the single-predicate
  `compile_wam_predicate_to_wat/4` path, which is kept as-is
  (local label resolution is correct when there are no cross-
  predicate references)

### Attempted sum_ints benchmark — new blockers surfaced

Unblocking cross-predicate calls let Phase 6 attempt to actually
run the `sum_ints` walker end-to-end for the first time. The
attempt failed with `memory access out of bounds`. Tracing back
from the generated WAM revealed **two separate blockers** that the
cross-predicate fix does not address:

  **(a) Type-check builtins are stubs.** `integer/1`, `atom/1`,
  `var/1`, `nonvar/1`, `float/1`, `number/1` (IDs 9–14) are
  reserved in the builtin table but map to `$default` in
  `$execute_builtin`'s `br_table`, which returns 0 (fail).
  `sum_ints`'s first clause guards on `integer(T)`, so it always
  fails and triggers backtracking to clause 2 — correct for
  compound terms, but means any workload relying on a type check
  on its happy path cannot make forward progress.

  **(b) `=/2` is lowered as `execute =/2`.** The canonical WAM
  compiler emits `execute =/2` for body goals of the form `X = Y`
  (e.g. `Sum = Acc` in `sum_ints_args`'s first clause), but `=/2`
  is not in WAM-WAT's `builtin_id/2` table, so it's treated as a
  regular user predicate. `resolve_label/3` misses and returns
  `PC = 0`; at runtime the VM jumps to the first instruction of
  the merged project (usually an `allocate` or `put_value`),
  corrupting state and eventually hitting an out-of-bounds
  memory access on some downstream load. The proper fix is to
  lower `=/2` into `get_value`/`unify_value` instructions
  directly in the canonical WAM layer, as standard WAM
  implementations do.

Both are orthogonal to Group A, orthogonal to cross-predicate
labels, and orthogonal to each other. They are tracked as new
follow-up items in `WAM_TERM_BUILTINS_PHASE_6_PERF.md` §8.

## Changes

### Modified files

| File | Lines | Change |
|---|---|---|
| `src/unifyweaver/targets/wam_wat_target.pl` | +139 / −24 | Two-pass `compile_wat_predicates/6` pipeline; 4 new helper predicates (`pass1_parse_predicates/5`, `build_global_labels/3`, `shift_labels/3`, `encode_all_predicates/3`, `gen_all_entry_funcs/6`) |
| `tests/test_wam_wat_target.pl` | +50 | New `functional_cross_predicate_call` end-to-end test |
| `docs/design/WAM_TERM_BUILTINS_PHASE_6_PERF.md` | +116 / −7 | New §4.4 (fix landed), §4.5 (new blockers surfaced), §4.6 (WAM-Rust port status); §8 follow-ups updated |

**Total:** 3 files changed, 288 insertions, 24 deletions across 2
commits.

## Commit breakdown

| # | Commit | Scope |
|---|---|---|
| 1 | `fix(wat): cross-predicate label resolution via merged project table` | The actual two-pass refactor + functional test |
| 2 | `docs(wat): update Phase 6 writeup — cross-pred fix landed, new blockers` | Phase 6 writeup updated with §4.4, §4.5, §4.6 and follow-ups |

## What this PR does NOT include

Explicitly deferred to separate follow-ups:

- **WAM-Rust cross-predicate port.** The WAM-Rust target has a
  substantially different architecture — each predicate emits its
  own `pub fn pred_name(vm, a1, ..)` that constructs a local
  `code: Vec<Instruction>` and `labels: HashMap`, assigns them to
  `vm.code` / `vm.labels`, and calls `vm.run()`. Porting the
  cross-pred fix requires either (i) switching to a module-level
  shared `static CODE: OnceLock<Vec<Instruction>>` with thin
  wrappers, or (ii) lazily merging at first call. Both are larger
  refactors than the WAM-WAT case and deserve their own PR.
- **Type-check builtin implementations** (`integer/1`, `atom/1`,
  etc. at IDs 9–14 in `$execute_builtin`'s `br_table`).
- **`=/2` lowering fix** in the canonical WAM compiler — currently
  emits `execute =/2` which misbehaves under any backend whose
  builtin dispatch doesn't recognize `=/2`. Should lower to
  `get_value`/`unify_value` directly.
- **Phase 6 perf rerun** — blocked until all three codegen items
  above land and `sum_ints` can actually execute end-to-end.

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_wat_target.pl` —
      52/52 passing (51 pre-existing + 1 new)
- [x] `wat2wasm` compiles every generated module (enforced by
      `wat2wasm_validates` test)
- [x] `node` runtime harness confirms the new cross-pred test
      returns 1 (not 0 or crash)
- [x] No changes to WAM-Rust or WAM-Haskell, so their test suites
      are unaffected
