### PR TITLE
feat(csharp-query): measure closure pair selection

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -104,11 +104,13 @@ Status:
 - started for generic closure pair strategy planning, where seeded and grouped
   closure-pair probes can now choose among forward, backward, mixed,
   mixed-with-pair-probe-cache, and memoized source/target strategies through
-  an explicit planner surface
+  an explicit planner surface, and `Auto` can now run bounded measured probes
+  for ambiguous mixed request sets
 - focused validation for that closure-pair planner surface now lives in
   `examples/benchmark/benchmark_closure_pair_planning.py`; the grouped mode now
-  produces non-empty rows, and the summary reports the best effective pair plan
-  separately from the requested override label
+  produces non-empty rows, the summary reports the best effective pair plan
+  separately from the requested override label, and measured runs emit
+  `closure_pair_probe_*` phases
 - started for path-aware support relations, where grouped minima and weight-sum
   operators can now choose streaming, replayable buffering, or external
   materialized access for `RootRelation` and `SeedRelation` before grouped

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -97,10 +97,11 @@ Examples:
 - generic closure pair probes can now choose among forward, backward, mixed,
   mixed-with-pair-probe-cache, and memoized source/target strategies through
   an explicit planner surface, with an override via
-  `QueryExecutorOptions.ClosurePairStrategy` and focused validation in
-  `examples/benchmark/benchmark_closure_pair_planning.py`; that harness now
-  produces non-empty grouped rows and reports the best effective pair plan
-  separately from the raw override label
+  `QueryExecutorOptions.ClosurePairStrategy`; `Auto` can now use bounded
+  measured probes for ambiguous mixed request sets, and focused validation in
+  `examples/benchmark/benchmark_closure_pair_planning.py` now produces
+  non-empty grouped rows and reports the best effective pair plan separately
+  from the raw override label
 - generic scan planning now also has focused validation coverage in
   `examples/benchmark/benchmark_scan_materialization.py`, so scan-heavy join,
   negation, aggregate, relation-scan, and pattern-scan paths can be checked

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -51,11 +51,12 @@ scan planning now adds corresponding scan buckets such as
 corresponding closure buckets such as `closure_strategy_select`,
 `closure_probe_*`, and `closure_materialize_*`, with focused validation
 available in `benchmark_closure_materialization.py`. Generic closure-pair
-planning now adds `closure_pair_strategy_select` and
-`*TransitiveClosurePairsMaterializationPlanPairs*` traces, with focused
-validation available in `benchmark_closure_pair_planning.py`. That harness now
-uses a real 3-column grouped edge source, produces non-empty grouped rows, and
-reports `best_effective_plan` so override-label fallbacks do not distort the
+planning now adds `closure_pair_strategy_select`,
+`closure_pair_probe_*`, and `*TransitiveClosurePairsMaterializationPlanPairs*`
+traces, with focused validation available in
+`benchmark_closure_pair_planning.py`. That harness now uses a real 3-column
+grouped edge source, produces non-empty grouped rows, and reports
+`best_effective_plan` so override-label fallbacks do not distort the
 comparison.
 
 | Target | 300 art | 1K art | 5K art | 10K art |

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -9894,10 +9894,187 @@ namespace UnifyWeaver.QueryRuntime
                 : ClosurePairPlanStrategy.Backward;
         }
 
+        private static IReadOnlyList<ClosurePairPlanStrategy> DetermineClosurePairProbeStrategies(
+            ClosurePairPlanStrategy structuralStrategy,
+            int sourceRequestCount,
+            int targetRequestCount,
+            bool singleConcretePairRequest,
+            bool hasForwardBatch,
+            bool hasBackwardBatch,
+            bool canUseBatchedPairProbeCache,
+            bool canMemoizeForwardBatch,
+            bool canMemoizeBackwardBatch,
+            bool canMemoizePairs)
+        {
+            var strategies = new List<ClosurePairPlanStrategy>();
+
+            void Add(ClosurePairPlanStrategy strategy)
+            {
+                if (!strategies.Contains(strategy))
+                {
+                    strategies.Add(strategy);
+                }
+            }
+
+            Add(structuralStrategy);
+
+            if (singleConcretePairRequest)
+            {
+                return strategies;
+            }
+
+            if (sourceRequestCount == 1 && targetRequestCount > 1)
+            {
+                Add(ClosurePairPlanStrategy.MemoizedBySource);
+                Add(ClosurePairPlanStrategy.Forward);
+                Add(ClosurePairPlanStrategy.Backward);
+                if (hasForwardBatch && hasBackwardBatch)
+                {
+                    Add(ClosurePairPlanStrategy.MixedDirection);
+                    if (canUseBatchedPairProbeCache)
+                    {
+                        Add(ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache);
+                    }
+                }
+
+                return strategies;
+            }
+
+            if (targetRequestCount == 1 && sourceRequestCount > 1)
+            {
+                Add(ClosurePairPlanStrategy.MemoizedByTarget);
+                Add(ClosurePairPlanStrategy.Backward);
+                Add(ClosurePairPlanStrategy.Forward);
+                if (hasForwardBatch && hasBackwardBatch)
+                {
+                    Add(ClosurePairPlanStrategy.MixedDirection);
+                    if (canUseBatchedPairProbeCache)
+                    {
+                        Add(ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache);
+                    }
+                }
+
+                return strategies;
+            }
+
+            if (hasForwardBatch && hasBackwardBatch)
+            {
+                Add(ClosurePairPlanStrategy.MixedDirection);
+                if (canUseBatchedPairProbeCache)
+                {
+                    Add(ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache);
+                }
+
+                Add(ClosurePairPlanStrategy.Forward);
+                Add(ClosurePairPlanStrategy.Backward);
+                return strategies;
+            }
+
+            if (hasForwardBatch)
+            {
+                Add(ClosurePairPlanStrategy.Forward);
+                if (canMemoizeForwardBatch || canMemoizePairs)
+                {
+                    Add(ClosurePairPlanStrategy.MemoizedBySource);
+                }
+                Add(ClosurePairPlanStrategy.Backward);
+                return strategies;
+            }
+
+            if (hasBackwardBatch)
+            {
+                Add(ClosurePairPlanStrategy.Backward);
+                if (canMemoizeBackwardBatch || canMemoizePairs)
+                {
+                    Add(ClosurePairPlanStrategy.MemoizedByTarget);
+                }
+                Add(ClosurePairPlanStrategy.Forward);
+                return strategies;
+            }
+
+            if (canMemoizePairs)
+            {
+                Add(ClosurePairPlanStrategy.MemoizedBySource);
+                Add(ClosurePairPlanStrategy.MemoizedByTarget);
+            }
+
+            Add(ClosurePairPlanStrategy.Forward);
+            Add(ClosurePairPlanStrategy.Backward);
+            return strategies;
+        }
+
+        private static bool ShouldProbeClosurePairStrategy(
+            int requestCount,
+            bool singleConcretePairRequest,
+            IReadOnlyCollection<ClosurePairPlanStrategy> candidateStrategies)
+        {
+            if (singleConcretePairRequest || requestCount <= 1)
+            {
+                return false;
+            }
+
+            if (candidateStrategies.Count <= 1)
+            {
+                return false;
+            }
+
+            return requestCount <= 16;
+        }
+
+        private static ClosurePairPlanStrategy ResolveMeasuredClosurePairStrategy(
+            IReadOnlyDictionary<ClosurePairPlanStrategy, TimeSpan> probes,
+            ClosurePairPlanStrategy structuralStrategy)
+        {
+            if (probes.Count == 0)
+            {
+                return structuralStrategy;
+            }
+
+            var bestProbe = probes
+                .Where(entry => entry.Value > TimeSpan.Zero && entry.Value < TimeSpan.MaxValue)
+                .OrderBy(entry => entry.Value)
+                .FirstOrDefault();
+
+            if (bestProbe.Equals(default(KeyValuePair<ClosurePairPlanStrategy, TimeSpan>)) && !probes.ContainsKey(default))
+            {
+                return structuralStrategy;
+            }
+
+            if (!probes.TryGetValue(structuralStrategy, out var structuralProbe) ||
+                structuralProbe <= TimeSpan.Zero ||
+                structuralProbe == TimeSpan.MaxValue)
+            {
+                return bestProbe.Key;
+            }
+
+            if (bestProbe.Key == structuralStrategy)
+            {
+                return structuralStrategy;
+            }
+
+            return bestProbe.Value.Ticks * 1.05 < structuralProbe.Ticks
+                ? bestProbe.Key
+                : structuralStrategy;
+        }
+
+        private static string GetClosurePairProbePhase(ClosurePairPlanStrategy strategy) => strategy switch
+        {
+            ClosurePairPlanStrategy.SingleProbeForward => "closure_pair_probe_single_forward",
+            ClosurePairPlanStrategy.SingleProbeBackward => "closure_pair_probe_single_backward",
+            ClosurePairPlanStrategy.Forward => "closure_pair_probe_forward",
+            ClosurePairPlanStrategy.Backward => "closure_pair_probe_backward",
+            ClosurePairPlanStrategy.MemoizedBySource => "closure_pair_probe_memo_source",
+            ClosurePairPlanStrategy.MemoizedByTarget => "closure_pair_probe_memo_target",
+            ClosurePairPlanStrategy.MixedDirection => "closure_pair_probe_mixed",
+            ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache => "closure_pair_probe_mixed_cache",
+            _ => "closure_pair_probe_unknown"
+        };
+
         private static ClosurePairStrategySelection ResolveClosurePairStrategy(
             QueryExecutionTrace? trace,
             PlanNode node,
             ClosurePairStrategy configuredStrategy,
+            int requestCount,
             int sourceRequestCount,
             int targetRequestCount,
             bool singleConcretePairRequest,
@@ -9909,7 +10086,8 @@ namespace UnifyWeaver.QueryRuntime
             bool canMemoizeForwardBatch,
             bool canMemoizeBackwardBatch,
             bool canMemoizePairs,
-            bool preferForwardFallback)
+            bool preferForwardFallback,
+            IReadOnlyDictionary<ClosurePairPlanStrategy, Func<TimeSpan>>? measureProbes = null)
         {
             return MeasurePhase(trace, node, "closure_pair_strategy_select", () =>
             {
@@ -9940,7 +10118,56 @@ namespace UnifyWeaver.QueryRuntime
                     return new ClosurePairStrategySelection(structural, "ConfiguredFallback");
                 }
 
-                return new ClosurePairStrategySelection(structural, "Structural");
+                if (sourceRequestCount <= 1 || targetRequestCount <= 1)
+                {
+                    return new ClosurePairStrategySelection(structural, "Structural");
+                }
+
+                var candidateStrategies = DetermineClosurePairProbeStrategies(
+                    structural,
+                    sourceRequestCount,
+                    targetRequestCount,
+                    singleConcretePairRequest,
+                    hasForwardBatch,
+                    hasBackwardBatch,
+                    canUseBatchedPairProbeCache,
+                    canMemoizeForwardBatch,
+                    canMemoizeBackwardBatch,
+                    canMemoizePairs);
+
+                if (!ShouldProbeClosurePairStrategy(requestCount, singleConcretePairRequest, candidateStrategies) ||
+                    measureProbes is null ||
+                    measureProbes.Count == 0)
+                {
+                    return new ClosurePairStrategySelection(structural, "Structural");
+                }
+
+                var probes = new Dictionary<ClosurePairPlanStrategy, TimeSpan>();
+                foreach (var candidate in candidateStrategies)
+                {
+                    if (!measureProbes.TryGetValue(candidate, out var measureProbe))
+                    {
+                        continue;
+                    }
+
+                    var probe = measureProbe();
+                    if (probe <= TimeSpan.Zero || probe == TimeSpan.MaxValue)
+                    {
+                        continue;
+                    }
+
+                    trace?.RecordPhase(node, GetClosurePairProbePhase(candidate), probe);
+                    probes[candidate] = probe;
+                }
+
+                if (probes.Count == 0)
+                {
+                    return new ClosurePairStrategySelection(structural, "Structural");
+                }
+
+                return new ClosurePairStrategySelection(
+                    ResolveMeasuredClosurePairStrategy(probes, structural),
+                    "MeasuredProbe");
             });
         }
 
@@ -9952,6 +10179,350 @@ namespace UnifyWeaver.QueryRuntime
         {
             trace?.RecordStrategy(node, $"{nodeStrategyPrefix}MaterializationPlanSelection{selection.DecisionMode}");
             trace?.RecordStrategy(node, $"{nodeStrategyPrefix}MaterializationPlanPairs{selection.Strategy}");
+        }
+
+        private static int CountClosurePairRequests(IEnumerable<HashSet<object?>> requestSets) =>
+            requestSets.Sum(requestSet => requestSet.Count);
+
+        private const int MaxMeasuredClosurePairProbeRequests = 4;
+
+        private static void TakeClosurePairRequestSample(
+            IReadOnlyDictionary<object?, HashSet<object?>> bySource,
+            int maxRequestCount,
+            out Dictionary<object?, HashSet<object?>> sampleBySource,
+            out Dictionary<object?, HashSet<object?>> sampleByTarget)
+        {
+            sampleBySource = new Dictionary<object?, HashSet<object?>>();
+            sampleByTarget = new Dictionary<object?, HashSet<object?>>();
+            var remaining = maxRequestCount;
+            var active = bySource
+                .Select(entry => (Source: entry.Key, Targets: entry.Value.GetEnumerator()))
+                .ToList();
+
+            while (remaining > 0 && active.Count > 0)
+            {
+                for (var i = 0; i < active.Count && remaining > 0;)
+                {
+                    var (source, targets) = active[i];
+                    if (!targets.MoveNext())
+                    {
+                        active.RemoveAt(i);
+                        continue;
+                    }
+
+                    var target = targets.Current;
+                    if (!sampleBySource.TryGetValue(source, out var sampleTargets))
+                    {
+                        sampleTargets = new HashSet<object?>();
+                        sampleBySource.Add(source, sampleTargets);
+                    }
+
+                    sampleTargets.Add(target);
+
+                    if (!sampleByTarget.TryGetValue(target, out var sampleSources))
+                    {
+                        sampleSources = new HashSet<object?>();
+                        sampleByTarget.Add(target, sampleSources);
+                    }
+
+                    sampleSources.Add(source);
+                    remaining--;
+                    i++;
+                }
+            }
+        }
+
+        private static void TakeGroupedClosurePairRequestSample(
+            IReadOnlyDictionary<RowWrapper, HashSet<object?>> targetsBySource,
+            int maxRequestCount,
+            out Dictionary<RowWrapper, HashSet<object?>> sampleTargetsBySource,
+            out Dictionary<RowWrapper, HashSet<object?>> sampleSourcesByTarget)
+        {
+            var wrapperComparer = new RowWrapperComparer(StructuralArrayComparer.Instance);
+            sampleTargetsBySource = new Dictionary<RowWrapper, HashSet<object?>>(wrapperComparer);
+            sampleSourcesByTarget = new Dictionary<RowWrapper, HashSet<object?>>(wrapperComparer);
+            var remaining = maxRequestCount;
+            var active = targetsBySource
+                .Select(entry => (SourceWrapper: entry.Key, Targets: entry.Value.GetEnumerator()))
+                .ToList();
+
+            while (remaining > 0 && active.Count > 0)
+            {
+                for (var i = 0; i < active.Count && remaining > 0;)
+                {
+                    var (sourceWrapper, targets) = active[i];
+                    if (!targets.MoveNext())
+                    {
+                        active.RemoveAt(i);
+                        continue;
+                    }
+
+                    var sourceRow = sourceWrapper.Row;
+                    var source = sourceRow[sourceRow.Length - 1];
+                    var target = targets.Current;
+                    if (!sampleTargetsBySource.TryGetValue(sourceWrapper, out var sampleTargets))
+                    {
+                        sampleTargets = new HashSet<object?>();
+                        sampleTargetsBySource.Add(sourceWrapper, sampleTargets);
+                    }
+
+                    sampleTargets.Add(target);
+
+                    var targetRow = new object[sourceRow.Length];
+                    Array.Copy(sourceRow, targetRow, sourceRow.Length - 1);
+                    targetRow[sourceRow.Length - 1] = target;
+                    var targetWrapper = new RowWrapper(targetRow);
+
+                    if (!sampleSourcesByTarget.TryGetValue(targetWrapper, out var sampleSources))
+                    {
+                        sampleSources = new HashSet<object?>();
+                        sampleSourcesByTarget.Add(targetWrapper, sampleSources);
+                    }
+
+                    sampleSources.Add(source);
+                    remaining--;
+                    i++;
+                }
+            }
+        }
+
+        private EvaluationContext CreateClosurePairProbeContext(EvaluationContext context)
+        {
+            var probeContext = new EvaluationContext(trace: new QueryExecutionTrace(), cancellationToken: context.CancellationToken)
+            {
+                Current = context.Current,
+                FixpointDepth = context.FixpointDepth
+            };
+
+            foreach (var kvp in context.Facts)
+            {
+                probeContext.Facts[kvp.Key] = kvp.Value;
+            }
+
+            foreach (var kvp in context.FactSources)
+            {
+                probeContext.FactSources[kvp.Key] = kvp.Value;
+            }
+
+            foreach (var kvp in context.ReplayableFactSources)
+            {
+                probeContext.ReplayableFactSources[kvp.Key] = kvp.Value;
+            }
+
+            foreach (var kvp in context.ClosureRelationRetentionSelections)
+            {
+                probeContext.ClosureRelationRetentionSelections[kvp.Key] = kvp.Value;
+            }
+
+            foreach (var kvp in context.FactIndices)
+            {
+                probeContext.FactIndices[kvp.Key] = kvp.Value;
+            }
+
+            foreach (var kvp in context.JoinIndices)
+            {
+                probeContext.JoinIndices[kvp.Key] = kvp.Value;
+            }
+
+            return probeContext;
+        }
+
+        private TimeSpan MeasureGroupedClosurePairStrategyProbe(
+            GroupedTransitiveClosureNode closure,
+            ClosurePairPlanStrategy strategy,
+            IReadOnlyList<int> inputPositions,
+            IReadOnlyDictionary<RowWrapper, HashSet<object?>> targetsBySource,
+            IReadOnlyDictionary<RowWrapper, HashSet<object?>> sourcesByTarget,
+            IReadOnlyDictionary<RowWrapper, HashSet<object?>> forwardTargetsBySource,
+            IReadOnlyDictionary<RowWrapper, HashSet<object?>> backwardSourcesByTarget,
+            EvaluationContext context)
+        {
+            var sampleTargetsBySource = targetsBySource;
+            var sampleSourcesByTarget = sourcesByTarget;
+            var sampleForwardTargetsBySource = forwardTargetsBySource;
+            var sampleBackwardSourcesByTarget = backwardSourcesByTarget;
+
+            if (CountClosurePairRequests(targetsBySource.Values) > MaxMeasuredClosurePairProbeRequests)
+            {
+                TakeGroupedClosurePairRequestSample(
+                    targetsBySource,
+                    MaxMeasuredClosurePairProbeRequests,
+                    out var limitedTargetsBySource,
+                    out var limitedSourcesByTarget);
+                sampleTargetsBySource = limitedTargetsBySource;
+                sampleSourcesByTarget = limitedSourcesByTarget;
+
+                var batchProbeContext = CreateClosurePairProbeContext(context);
+                if (!TryBuildGroupedPairProbeDirectionBatches(
+                    closure,
+                    sampleTargetsBySource,
+                    batchProbeContext,
+                    out var limitedForwardTargetsBySource,
+                    out var limitedBackwardSourcesByTarget))
+                {
+                    var wrapperComparer = new RowWrapperComparer(StructuralArrayComparer.Instance);
+                    limitedForwardTargetsBySource = new Dictionary<RowWrapper, HashSet<object?>>(wrapperComparer);
+                    limitedBackwardSourcesByTarget = new Dictionary<RowWrapper, HashSet<object?>>(wrapperComparer);
+                }
+
+                sampleForwardTargetsBySource = limitedForwardTargetsBySource;
+                sampleBackwardSourcesByTarget = limitedBackwardSourcesByTarget;
+            }
+
+            return strategy switch
+            {
+                ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache when sampleForwardTargetsBySource.Count > 0 && sampleBackwardSourcesByTarget.Count > 0 => MeasureElapsed(() =>
+                {
+                    var probeContext = CreateClosurePairProbeContext(context);
+                    _ = ExecuteSeededGroupedTransitiveClosurePairsMixedDirectionWithPairProbeCache(
+                        closure,
+                        inputPositions,
+                        sampleForwardTargetsBySource,
+                        sampleBackwardSourcesByTarget,
+                        probeContext).ToList();
+                }),
+                ClosurePairPlanStrategy.MixedDirection when sampleForwardTargetsBySource.Count > 0 && sampleBackwardSourcesByTarget.Count > 0 => MeasureElapsed(() =>
+                {
+                    var probeContext = CreateClosurePairProbeContext(context);
+                    _ = ExecuteSeededGroupedTransitiveClosurePairsMixedDirection(
+                        closure,
+                        inputPositions,
+                        sampleForwardTargetsBySource,
+                        sampleBackwardSourcesByTarget,
+                        probeContext).ToList();
+                }),
+                ClosurePairPlanStrategy.MemoizedBySource => MeasureElapsed(() =>
+                {
+                    var probeContext = CreateClosurePairProbeContext(context);
+                    _ = ExecuteSeededGroupedTransitiveClosurePairsMemoizedBySource(
+                        closure,
+                        inputPositions,
+                        sampleTargetsBySource,
+                        probeContext).ToList();
+                }),
+                ClosurePairPlanStrategy.MemoizedByTarget => MeasureElapsed(() =>
+                {
+                    var probeContext = CreateClosurePairProbeContext(context);
+                    _ = ExecuteSeededGroupedTransitiveClosurePairsMemoizedByTarget(
+                        closure,
+                        inputPositions,
+                        sampleSourcesByTarget,
+                        probeContext).ToList();
+                }),
+                ClosurePairPlanStrategy.Forward => MeasureElapsed(() =>
+                {
+                    var probeContext = CreateClosurePairProbeContext(context);
+                    _ = ExecuteSeededGroupedTransitiveClosurePairsForward(
+                        closure,
+                        sampleTargetsBySource,
+                        probeContext).ToList();
+                }),
+                ClosurePairPlanStrategy.Backward => MeasureElapsed(() =>
+                {
+                    var probeContext = CreateClosurePairProbeContext(context);
+                    _ = ExecuteSeededGroupedTransitiveClosurePairsBackward(
+                        closure,
+                        sampleSourcesByTarget,
+                        probeContext).ToList();
+                }),
+                _ => TimeSpan.MaxValue
+            };
+        }
+
+        private TimeSpan MeasureUngroupedClosurePairStrategyProbe(
+            TransitiveClosureNode closure,
+            ClosurePairPlanStrategy strategy,
+            IReadOnlyDictionary<object?, HashSet<object?>> bySource,
+            IReadOnlyDictionary<object?, HashSet<object?>> byTarget,
+            IReadOnlyDictionary<object?, HashSet<object?>> forwardBySource,
+            IReadOnlyDictionary<object?, HashSet<object?>> backwardByTarget,
+            EvaluationContext context)
+        {
+            var sampleBySource = bySource;
+            var sampleByTarget = byTarget;
+            var sampleForwardBySource = forwardBySource;
+            var sampleBackwardByTarget = backwardByTarget;
+
+            if (CountClosurePairRequests(bySource.Values) > MaxMeasuredClosurePairProbeRequests)
+            {
+                TakeClosurePairRequestSample(
+                    bySource,
+                    MaxMeasuredClosurePairProbeRequests,
+                    out var limitedBySource,
+                    out var limitedByTarget);
+                sampleBySource = limitedBySource;
+                sampleByTarget = limitedByTarget;
+
+                var batchProbeContext = CreateClosurePairProbeContext(context);
+                if (!TryBuildPairProbeDirectionBatches(
+                    closure,
+                    sampleBySource,
+                    batchProbeContext,
+                    out var limitedForwardBySource,
+                    out var limitedBackwardByTarget))
+                {
+                    limitedForwardBySource = new Dictionary<object?, HashSet<object?>>();
+                    limitedBackwardByTarget = new Dictionary<object?, HashSet<object?>>();
+                }
+
+                sampleForwardBySource = limitedForwardBySource;
+                sampleBackwardByTarget = limitedBackwardByTarget;
+            }
+
+            return strategy switch
+            {
+                ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache when sampleForwardBySource.Count > 0 && sampleBackwardByTarget.Count > 0 => MeasureElapsed(() =>
+                {
+                    var probeContext = CreateClosurePairProbeContext(context);
+                    _ = ExecuteSeededTransitiveClosurePairsMixedDirectionWithPairProbeCache(
+                        closure,
+                        sampleForwardBySource,
+                        sampleBackwardByTarget,
+                        probeContext).ToList();
+                }),
+                ClosurePairPlanStrategy.MixedDirection when sampleForwardBySource.Count > 0 && sampleBackwardByTarget.Count > 0 => MeasureElapsed(() =>
+                {
+                    var probeContext = CreateClosurePairProbeContext(context);
+                    _ = ExecuteSeededTransitiveClosurePairsMixedDirection(
+                        closure,
+                        sampleForwardBySource,
+                        sampleBackwardByTarget,
+                        probeContext).ToList();
+                }),
+                ClosurePairPlanStrategy.MemoizedBySource => MeasureElapsed(() =>
+                {
+                    var probeContext = CreateClosurePairProbeContext(context);
+                    _ = ExecuteSeededTransitiveClosurePairsMemoizedBySource(
+                        closure,
+                        sampleBySource,
+                        probeContext).ToList();
+                }),
+                ClosurePairPlanStrategy.MemoizedByTarget => MeasureElapsed(() =>
+                {
+                    var probeContext = CreateClosurePairProbeContext(context);
+                    _ = ExecuteSeededTransitiveClosurePairsMemoizedByTarget(
+                        closure,
+                        sampleByTarget,
+                        probeContext).ToList();
+                }),
+                ClosurePairPlanStrategy.Forward => MeasureElapsed(() =>
+                {
+                    var probeContext = CreateClosurePairProbeContext(context);
+                    _ = ExecuteSeededTransitiveClosurePairsForward(
+                        closure,
+                        sampleBySource,
+                        probeContext).ToList();
+                }),
+                ClosurePairPlanStrategy.Backward => MeasureElapsed(() =>
+                {
+                    var probeContext = CreateClosurePairProbeContext(context);
+                    _ = ExecuteSeededTransitiveClosurePairsBackward(
+                        closure,
+                        sampleByTarget,
+                        probeContext).ToList();
+                }),
+                _ => TimeSpan.MaxValue
+            };
         }
 
         private IReadOnlyDictionary<object, Dictionary<object, double>> ExecuteSeedGroupedPathAwareWeightSumFallback(
@@ -13997,11 +14568,94 @@ namespace UnifyWeaver.QueryRuntime
                     targetsBySource.Count <= MaxMemoizedGroupedPairSeeds &&
                     sourcesByTarget.Count <= MaxMemoizedGroupedPairSeeds;
                 var preferForwardFallback = targetsBySource.Count <= sourcesByTarget.Count;
+                var pairRequestCount = CountClosurePairRequests(targetsBySource.Values);
+                IReadOnlyDictionary<ClosurePairPlanStrategy, Func<TimeSpan>>? measurePairStrategyProbes = null;
+                if (!singleConcretePairRequest && pairRequestCount > 1 && pairRequestCount <= 16)
+                {
+                    var probes = new Dictionary<ClosurePairPlanStrategy, Func<TimeSpan>>
+                    {
+                        [ClosurePairPlanStrategy.Forward] = () => MeasureGroupedClosurePairStrategyProbe(
+                            closure,
+                            ClosurePairPlanStrategy.Forward,
+                            inputPositions,
+                            targetsBySource,
+                            sourcesByTarget,
+                            forwardTargetsBySource,
+                            backwardSourcesByTarget,
+                            context),
+                        [ClosurePairPlanStrategy.Backward] = () => MeasureGroupedClosurePairStrategyProbe(
+                            closure,
+                            ClosurePairPlanStrategy.Backward,
+                            inputPositions,
+                            targetsBySource,
+                            sourcesByTarget,
+                            forwardTargetsBySource,
+                            backwardSourcesByTarget,
+                            context)
+                    };
+
+                    if (canMemoizeForwardBatch || canMemoizePairs)
+                    {
+                        probes[ClosurePairPlanStrategy.MemoizedBySource] = () => MeasureGroupedClosurePairStrategyProbe(
+                            closure,
+                            ClosurePairPlanStrategy.MemoizedBySource,
+                            inputPositions,
+                            targetsBySource,
+                            sourcesByTarget,
+                            forwardTargetsBySource,
+                            backwardSourcesByTarget,
+                            context);
+                    }
+
+                    if (canMemoizeBackwardBatch || canMemoizePairs)
+                    {
+                        probes[ClosurePairPlanStrategy.MemoizedByTarget] = () => MeasureGroupedClosurePairStrategyProbe(
+                            closure,
+                            ClosurePairPlanStrategy.MemoizedByTarget,
+                            inputPositions,
+                            targetsBySource,
+                            sourcesByTarget,
+                            forwardTargetsBySource,
+                            backwardSourcesByTarget,
+                            context);
+                    }
+
+                    if (canBuildDirectionBatches &&
+                        forwardTargetsBySource.Count > 0 &&
+                        backwardSourcesByTarget.Count > 0)
+                    {
+                        probes[ClosurePairPlanStrategy.MixedDirection] = () => MeasureGroupedClosurePairStrategyProbe(
+                            closure,
+                            ClosurePairPlanStrategy.MixedDirection,
+                            inputPositions,
+                            targetsBySource,
+                            sourcesByTarget,
+                            forwardTargetsBySource,
+                            backwardSourcesByTarget,
+                            context);
+
+                        if (canReuseBatchedPairProbeCache)
+                        {
+                            probes[ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache] = () => MeasureGroupedClosurePairStrategyProbe(
+                                closure,
+                                ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache,
+                                inputPositions,
+                                targetsBySource,
+                                sourcesByTarget,
+                                forwardTargetsBySource,
+                                backwardSourcesByTarget,
+                                context);
+                        }
+                    }
+
+                    measurePairStrategyProbes = probes;
+                }
 
                 var pairStrategySelection = ResolveClosurePairStrategy(
                     trace,
                     closure,
                     _closurePairStrategy,
+                    pairRequestCount,
                     targetsBySource.Count,
                     sourcesByTarget.Count,
                     singleConcretePairRequest,
@@ -14013,7 +14667,8 @@ namespace UnifyWeaver.QueryRuntime
                     canMemoizeForwardBatch,
                     canMemoizeBackwardBatch,
                     canMemoizePairs,
-                    preferForwardFallback);
+                    preferForwardFallback,
+                    measurePairStrategyProbes);
                 RecordClosurePairStrategy(trace, closure, "GroupedTransitiveClosurePairs", pairStrategySelection);
 
                 return pairStrategySelection.Strategy switch
@@ -17342,11 +17997,88 @@ namespace UnifyWeaver.QueryRuntime
                     bySource.Count <= MaxMemoizedPairSeeds &&
                     byTarget.Count <= MaxMemoizedPairSeeds;
                 var preferForwardFallback = bySource.Count <= byTarget.Count;
+                var pairRequestCount = CountClosurePairRequests(bySource.Values);
+                IReadOnlyDictionary<ClosurePairPlanStrategy, Func<TimeSpan>>? measurePairStrategyProbes = null;
+                if (!singleConcretePairRequest && pairRequestCount > 1 && pairRequestCount <= 16)
+                {
+                    var probes = new Dictionary<ClosurePairPlanStrategy, Func<TimeSpan>>
+                    {
+                        [ClosurePairPlanStrategy.Forward] = () => MeasureUngroupedClosurePairStrategyProbe(
+                            closure,
+                            ClosurePairPlanStrategy.Forward,
+                            bySource,
+                            byTarget,
+                            forwardBySource,
+                            backwardByTarget,
+                            context),
+                        [ClosurePairPlanStrategy.Backward] = () => MeasureUngroupedClosurePairStrategyProbe(
+                            closure,
+                            ClosurePairPlanStrategy.Backward,
+                            bySource,
+                            byTarget,
+                            forwardBySource,
+                            backwardByTarget,
+                            context)
+                    };
+
+                    if (canMemoizeForwardBatch || canMemoizePairs)
+                    {
+                        probes[ClosurePairPlanStrategy.MemoizedBySource] = () => MeasureUngroupedClosurePairStrategyProbe(
+                            closure,
+                            ClosurePairPlanStrategy.MemoizedBySource,
+                            bySource,
+                            byTarget,
+                            forwardBySource,
+                            backwardByTarget,
+                            context);
+                    }
+
+                    if (canMemoizeBackwardBatch || canMemoizePairs)
+                    {
+                        probes[ClosurePairPlanStrategy.MemoizedByTarget] = () => MeasureUngroupedClosurePairStrategyProbe(
+                            closure,
+                            ClosurePairPlanStrategy.MemoizedByTarget,
+                            bySource,
+                            byTarget,
+                            forwardBySource,
+                            backwardByTarget,
+                            context);
+                    }
+
+                    if (canBuildDirectionBatches &&
+                        forwardBySource.Count > 0 &&
+                        backwardByTarget.Count > 0)
+                    {
+                        probes[ClosurePairPlanStrategy.MixedDirection] = () => MeasureUngroupedClosurePairStrategyProbe(
+                            closure,
+                            ClosurePairPlanStrategy.MixedDirection,
+                            bySource,
+                            byTarget,
+                            forwardBySource,
+                            backwardByTarget,
+                            context);
+
+                        if (canReuseBatchedPairProbeCache)
+                        {
+                            probes[ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache] = () => MeasureUngroupedClosurePairStrategyProbe(
+                                closure,
+                                ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache,
+                                bySource,
+                                byTarget,
+                                forwardBySource,
+                                backwardByTarget,
+                                context);
+                        }
+                    }
+
+                    measurePairStrategyProbes = probes;
+                }
 
                 var pairStrategySelection = ResolveClosurePairStrategy(
                     trace,
                     closure,
                     _closurePairStrategy,
+                    pairRequestCount,
                     bySource.Count,
                     byTarget.Count,
                     singleConcretePairRequest,
@@ -17358,7 +18090,8 @@ namespace UnifyWeaver.QueryRuntime
                     canMemoizeForwardBatch,
                     canMemoizeBackwardBatch,
                     canMemoizePairs,
-                    preferForwardFallback);
+                    preferForwardFallback,
+                    measurePairStrategyProbes);
                 RecordClosurePairStrategy(trace, closure, "TransitiveClosurePairs", pairStrategySelection);
 
                 return pairStrategySelection.Strategy switch


### PR DESCRIPTION
  ## Summary

  This PR adds bounded measured selection to the generic closure-pair planner in
  the C# query runtime.

  Closure-pair planning already had an explicit `Auto` strategy surface, but it
  was still mostly structural. This change lets `Auto` run small measured probes
  for ambiguous mixed request sets, while keeping pure single-pair, fan-out, and
  fan-in shapes on the cheaper structural path.

  ## What Changed

  ### Runtime

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added bounded measured probes for closure-pair strategy selection.

  The planner can now compare candidate strategies such as:

  - `Forward`
  - `Backward`
  - `MixedDirection`
  - `MixedDirectionWithPairProbeCache`
  - `MemoizedBySource`
  - `MemoizedByTarget`

  Measured probes are intentionally limited:

  - single concrete pair requests do not probe
  - pure fan-out and pure fan-in shapes stay structural
  - ambiguous mixed request sets can probe a bounded request sample
  - probe execution uses isolated probe contexts so pair caches and trace output are not polluted by candidate runs

  ### Trace Output

  Measured closure-pair runs now emit phases such as:

  - `closure_pair_probe_forward`
  - `closure_pair_probe_backward`
  - `closure_pair_probe_mixed`
  - `closure_pair_probe_mixed_cache`
  - `closure_pair_probe_memo_source`
  - `closure_pair_probe_memo_target`

  The selected planner mode is still reported through the existing materialization-plan trace surface, for example:

  - `TransitiveClosurePairsMaterializationPlanSelectionMeasuredProbe`
  - `GroupedTransitiveClosurePairsMaterializationPlanSelectionMeasuredProbe`
  - `TransitiveClosurePairsMaterializationPlanPairsBackward`
  - `GroupedTransitiveClosurePairsMaterializationPlanPairsForward`

  ### Sampling

  Added bounded request sampling for measured closure-pair probes.

  This keeps probe overhead controlled while still giving the planner real timing data for ambiguous mixed workloads.

  ### Docs

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `examples/benchmark/README.md`

  The docs now describe closure-pair `Auto` as capable of bounded measured probes and note the new `closure_pair_probe_*` trace
  buckets.

  ## Why This Matters

  This moves closure-pair planning closer to the rest of the materialization planner.

  Other planner layers already use measured selection where structural signals are not enough. Closure-pair planning now does the
  same for the cases where it matters most: small ambiguous mixed request sets.

  The key boundary remains pragmatic:

  - cheap structural decisions stay structural
  - ambiguous mixed cases can measure
  - public override behavior remains unchanged

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/benchmark_closure_pair_planning.py \
      examples/benchmark/benchmark_scan_materialization.py \
      examples/benchmark/benchmark_closure_materialization.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_category_influence_cross_target.py \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py
  ```
  Ran the closure-pair suite:
  ```
  python examples/benchmark/benchmark_closure_pair_planning.py \
      --scales 300,10k \
      --modes single,source_fanout,target_fanin,mixed,grouped_mixed \
      --strategies auto,forward,backward,memo-source,memo-target,mixed,mixed-cache \
      --repetitions 3
  ```
  Ran focused non-regression suites:
  ```
  python examples/benchmark/benchmark_scan_materialization.py \
      --scales 300,10k \
      --strategies auto \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_closure_materialization.py \
      --scales 300,10k \
      --repetitions 1
  ```
  Ran existing workload smokes at 300:
  ```
  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300 \
      --targets csharp-query,rust-dfs,go-dfs \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1
  ```
  All output comparisons still matched.

  ## Representative Results

  Closure-pair suite, representative auto_vs_best_effective from the --repetitions 3 run:

  | Scale | Mode | Auto vs Best Effective |
  |---|---:|---:|
  | 300 | mixed | 1.10x |
  | 10k | mixed | 1.08x |
  | 10k | grouped_mixed | 1.09x |
  | 10k | source_fanout | 1.04x |
  | 10k | target_fanin | 1.07x |

  Representative non-regression results:

  - shortest path 300: csharp-query 0.146s, outputs matched
  - weighted shortest path 300: csharp-query 0.244s, outputs matched
  - effective distance 300: csharp-query 0.331s, outputs matched
  - category influence 300: csharp-query 1.095s, outputs matched
  - dependency reach-count 300: csharp-query 0.124s, outputs matched
  - dependency longest depth 300: csharp-query 0.109s, outputs matched

  ## Interpretation

  This PR does not add a new closure-pair execution strategy.

  It improves the planner’s ability to choose among existing strategies when the request shape is ambiguous enough that structural
  selection alone is weak.

  The result is a more consistent Stage 4 planner story:

  - relation retention can measure
  - grouped summaries can measure
  - scan retention can measure
  - closure-pair strategy selection can now measure too

  ## Scope

  This PR adds:

  - bounded measured probes for closure-pair Auto
  - isolated probe contexts for candidate measurement
  - sampled request probing for mixed pair sets
  - closure_pair_probe_* trace buckets
  - documentation updates

  It does not change:

  - public closure-pair override names
  - closure-pair output semantics
  - the focused benchmark harness interface