### PR TITLE
perf(csharp-query): tune closure pair probe planning

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -105,11 +105,14 @@ Status:
   closure-pair probes can now choose among forward, backward, mixed,
   mixed-with-pair-probe-cache, and memoized source/target strategies through
   an explicit planner surface, and `Auto` can now run bounded measured probes
-  for ambiguous mixed request sets
+  for ambiguous request sets; current tuning keeps mixed-direction structural
+  decisions conservative and prefers direct forward/backward traversal for pure
+  fan-out/fan-in request shapes
 - focused validation for that closure-pair planner surface now lives in
   `examples/benchmark/benchmark_closure_pair_planning.py`; the grouped mode now
   produces non-empty rows, the summary reports the best effective pair plan
-  separately from the requested override label, and measured runs emit
+  separately from the requested override label, and reports both
+  `auto_strategy_select_ms` and `auto_probe_ms` alongside measured
   `closure_pair_probe_*` phases
 - started for path-aware support relations, where grouped minima and weight-sum
   operators can now choose streaming, replayable buffering, or external

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -98,10 +98,12 @@ Examples:
   mixed-with-pair-probe-cache, and memoized source/target strategies through
   an explicit planner surface, with an override via
   `QueryExecutorOptions.ClosurePairStrategy`; `Auto` can now use bounded
-  measured probes for ambiguous mixed request sets, and focused validation in
+  measured probes for ambiguous request sets, keeps mixed-direction structural
+  decisions conservative, and prefers direct forward/backward traversal for
+  pure fan-out/fan-in request shapes; focused validation in
   `examples/benchmark/benchmark_closure_pair_planning.py` now produces
-  non-empty grouped rows and reports the best effective pair plan separately
-  from the raw override label
+  non-empty grouped rows and reports the best effective pair plan, strategy
+  selection cost, and probe cost separately from the raw override label
 - generic scan planning now also has focused validation coverage in
   `examples/benchmark/benchmark_scan_materialization.py`, so scan-heavy join,
   negation, aggregate, relation-scan, and pattern-scan paths can be checked

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -56,8 +56,8 @@ planning now adds `closure_pair_strategy_select`,
 traces, with focused validation available in
 `benchmark_closure_pair_planning.py`. That harness now uses a real 3-column
 grouped edge source, produces non-empty grouped rows, and reports
-`best_effective_plan` so override-label fallbacks do not distort the
-comparison.
+`best_effective_plan`, `auto_strategy_select_ms`, and `auto_probe_ms` so
+override-label fallbacks and probe overhead do not distort the comparison.
 
 | Target | 300 art | 1K art | 5K art | 10K art |
 |--------|---------|--------|--------|---------|

--- a/examples/benchmark/benchmark_closure_pair_planning.py
+++ b/examples/benchmark/benchmark_closure_pair_planning.py
@@ -438,6 +438,19 @@ def parse_metrics(stderr: str) -> dict[str, str]:
     return metrics
 
 
+def parse_phase_summary(summary: str) -> dict[str, float]:
+    phases: dict[str, float] = {}
+    for part in summary.split("|"):
+        if ":" not in part:
+            continue
+        key, value = part.split(":", 1)
+        try:
+            phases[key] = float(value)
+        except ValueError:
+            continue
+    return phases
+
+
 def extract_effective_pair_plan(planner_summary: str) -> str:
     for part in planner_summary.split("|"):
         marker = "MaterializationPlanPairs"
@@ -536,6 +549,13 @@ def main() -> int:
                 print(f"{scale}	{mode}	best_effective_plan	{extract_effective_pair_plan(metrics_by_strategy[best_effective.strategy].get('closure_pair_planner_strategies', ''))}")
                 print(f"{scale}	{mode}	auto_vs_best_effective	{effective_ratio:.2f}x")
                 print(f"{scale}	{mode}	auto_planner	{auto_metrics.get('closure_pair_planner_strategies', '')}")
+                auto_phases = parse_phase_summary(auto_metrics.get("closure_pair_phase_summary", ""))
+                probe_ms = sum(
+                    value
+                    for phase, value in auto_phases.items()
+                    if phase.startswith("closure_pair_probe_"))
+                print(f"{scale}	{mode}	auto_strategy_select_ms	{auto_phases.get('closure_pair_strategy_select', 0.0):.3f}")
+                print(f"{scale}	{mode}	auto_probe_ms	{probe_ms:.3f}")
 
         if args.keep_temp:
             print(f"kept temp build directory: {temp_root}", file=sys.stderr)

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -9843,12 +9843,14 @@ namespace UnifyWeaver.QueryRuntime
 
             if (sourceRequestCount == 1 && targetRequestCount > 1 && canMemoizePairs)
             {
-                return ClosurePairPlanStrategy.MemoizedBySource;
+                return ClosurePairPlanStrategy.Forward;
             }
 
             if (targetRequestCount == 1 && sourceRequestCount > 1 && canMemoizePairs)
             {
-                return ClosurePairPlanStrategy.MemoizedByTarget;
+                return hasBackwardBatch
+                    ? ClosurePairPlanStrategy.Backward
+                    : ClosurePairPlanStrategy.MemoizedByTarget;
             }
 
             if (hasForwardBatch && hasBackwardBatch)
@@ -9957,6 +9959,19 @@ namespace UnifyWeaver.QueryRuntime
                 return strategies;
             }
 
+            if (hasForwardBatch && hasBackwardBatch &&
+                (structuralStrategy == ClosurePairPlanStrategy.MixedDirection ||
+                 structuralStrategy == ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache))
+            {
+                Add(ClosurePairPlanStrategy.MixedDirection);
+                if (canUseBatchedPairProbeCache)
+                {
+                    Add(ClosurePairPlanStrategy.MixedDirectionWithPairProbeCache);
+                }
+
+                return strategies;
+            }
+
             if (hasForwardBatch && hasBackwardBatch)
             {
                 Add(ClosurePairPlanStrategy.MixedDirection);
@@ -10021,6 +10036,8 @@ namespace UnifyWeaver.QueryRuntime
             return requestCount <= 16;
         }
 
+        private const double ClosurePairProbeOverrideMargin = 1.15d;
+
         private static ClosurePairPlanStrategy ResolveMeasuredClosurePairStrategy(
             IReadOnlyDictionary<ClosurePairPlanStrategy, TimeSpan> probes,
             ClosurePairPlanStrategy structuralStrategy)
@@ -10052,7 +10069,7 @@ namespace UnifyWeaver.QueryRuntime
                 return structuralStrategy;
             }
 
-            return bestProbe.Value.Ticks * 1.05 < structuralProbe.Ticks
+            return bestProbe.Value.Ticks * ClosurePairProbeOverrideMargin < structuralProbe.Ticks
                 ? bestProbe.Key
                 : structuralStrategy;
         }


### PR DESCRIPTION
# Tune C# query closure-pair probe planning

  ## Summary

  - Tunes closure-pair `Auto` planning to avoid measured-probe overcorrection when the structural mixed-direction plan is already
  the safest choice.
  - Raises the measured-probe override margin so probe results must show a clearer win before replacing the structural plan.
  - Prefers direct forward/backward traversal for pure fan-out and fan-in request shapes.
  - Extends the closure-pair benchmark summary with `auto_strategy_select_ms` and `auto_probe_ms`.
  - Updates materialization planning docs and benchmark README with the tuned selector behavior and new reporting fields.

  ## Validation

  - Ran `py_compile` for the closure-pair harness and related benchmark scripts.
  - Ran the closure-pair planning suite across `300` and `10k` scales for mixed, grouped mixed, source fanout, and target fanin
  modes.
  - Ran scan materialization and closure materialization smoke checks.
  - Ran cross-target smoke checks for shortest path, weighted shortest path, effective distance, category influence, dependency
  depth, and dependency longest depth.
  - Confirmed cross-target outputs still match where applicable.