### PR TITLE
feat(wam-llvm): end-to-end execution tests + two runtime bug fixes (M5.7)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1381,13 +1381,24 @@ wam_llvm_case('end_aggregate',
 % op1 = foreign kind ID (see wam_llvm_foreign_kind_id/2)
 % op2 = arity (for handler selection — different kernels have different
 %              register conventions)
-% Returns the result of @wam_execute_foreign_predicate. If false, the
-% run loop backtracks.
+% On success, advance PC then return true so the run loop continues
+% to the next instruction. On failure, return false without advancing
+% so the run loop backtracks from the current PC. The missing
+% @wam_inc_pc call was a latent bug from M3 — it wasn't visible until
+% M5.6 made the kernels actually return true (prior M3 stubs all
+% returned false, which hid the infinite-loop).
 wam_llvm_case('call_foreign',
 '  %cf.kind = trunc i64 %op1 to i32
   %cf.arity = trunc i64 %op2 to i32
   %cf.result = call i1 @wam_execute_foreign_predicate(%WamState* %vm, i32 %cf.kind, i32 %cf.arity)
-  ret i1 %cf.result').
+  br i1 %cf.result, label %cf.success, label %cf.fail
+
+cf.success:
+  call void @wam_inc_pc(%WamState* %vm)
+  ret i1 true
+
+cf.fail:
+  ret i1 false').
 
 % ============================================================================
 % PHASE 3: Helper predicates → LLVM functions

--- a/templates/targets/llvm_wam/module.ll.mustache
+++ b/templates/targets/llvm_wam/module.ll.mustache
@@ -15,6 +15,7 @@ declare i32 @snprintf(i8*, i64, i8*, ...)
 declare i32 @strcmp(i8*, i8*)
 declare i32 @printf(i8*, ...)
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8*, i8*, i64, i1)
+declare void @llvm.memset.p0i8.i64(i8*, i8, i64, i1)
 
 ; === Value Constructors & Inspectors ===
 {{value_functions}}

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -12,11 +12,15 @@ define %WamState* @wam_state_new(%Instruction* %code, i32 %code_len, i32* %label
   %pc_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 0
   store i32 0, i32* %pc_ptr
 
-  ; Initialize registers to zero
+  ; Initialize registers to zero. Prior code used llvm.memcpy with a
+  ; zeroinitializer source pointer — a pre-existing bug that evaluates
+  ; to null and segfaults at runtime. It went unnoticed until M5.7
+  ; execution testing because llvm-as and opt -passes=verify both
+  ; accept the bogus IR without complaint.
   %regs_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 0
   %regs_raw = bitcast %Value* %regs_ptr to i8*
   %regs_size = mul i64 32, 16  ; 32 x sizeof(%Value) = 32 x {i32, i64} ≈ 32*16
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %regs_raw, i8* zeroinitializer, i64 %regs_size, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* %regs_raw, i8 0, i64 %regs_size, i1 false)
 
   ; Allocate stack (initial capacity 256)
   %stack_mem = call i8* @malloc(i64 6144)  ; 256 * sizeof(StackEntry)

--- a/tests/core/test_wam_llvm_bfs_execution.pl
+++ b/tests/core/test_wam_llvm_bfs_execution.pl
@@ -1,0 +1,177 @@
+:- encoding(utf8).
+% test_wam_llvm_bfs_execution.pl
+% M5.7: End-to-end execution test for @wam_bfs_atom_distance.
+%
+% Generates a WAM-LLVM module, appends a concrete %AtomFactPair fact
+% table and a small main() function that invokes the BFS helper, then
+% runs the resulting module through `lli` (LLVM's JIT interpreter).
+% The main() returns the computed distance as the process exit code,
+% and the test asserts it matches the expected BFS distance.
+%
+% This is the first test that actually runs the generated code — prior
+% tests stopped at llvm-as (parse) and opt -passes=verify (SSA check).
+% Execution testing catches runtime bugs that the static passes miss:
+% uninitialized memory, off-by-one loop bounds, wrong register indices,
+% double-free on cleanup paths, etc.
+%
+% Atom IDs are written literally in the fact table (not via
+% intern_atom/2) so the test is deterministic regardless of what other
+% tests interned first in the same session. The max_atom_id bound is
+% correspondingly hardcoded.
+%
+% Test graph:
+%    1 -> 2 -> 3 -> 4
+%    1 -> 5
+% Expected: BFS distance from 1 to 4 is 3 (three hops: 1->2->3->4).
+% Expected: BFS distance from 1 to 5 is 1.
+% Expected: BFS distance from 1 to 1 is 0 (self-hit fast path).
+% Expected: BFS distance from 1 to 99 fails (unreachable).
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3]).
+:- use_module(library(process)).
+
+:- dynamic color/1.
+color(red).
+
+% Append a main() function that calls @wam_bfs_atom_distance for a
+% specific (start, target) pair and returns the result (or 255 on
+% unreachable) as the process exit code.
+build_exec_driver(Start, Target, DriverIR) :-
+    format(atom(DriverIR),
+'; === M5.7 execution driver ===
+; Test graph (hand-written, not via intern_atom for determinism):
+;   1 -> 2 -> 3 -> 4
+;   1 -> 5
+@bfs_exec_edges = private constant [4 x %AtomFactPair] [
+  %AtomFactPair { i64 1, i64 2 },
+  %AtomFactPair { i64 2, i64 3 },
+  %AtomFactPair { i64 3, i64 4 },
+  %AtomFactPair { i64 1, i64 5 }
+]
+
+define i32 @main() {
+entry:
+  %dist_slot = alloca i64
+  %table_ptr = getelementptr [4 x %AtomFactPair], [4 x %AtomFactPair]* @bfs_exec_edges, i64 0, i64 0
+  %ok = call i1 @wam_bfs_atom_distance(
+      i64 ~w, i64 ~w,
+      %AtomFactPair* %table_ptr, i64 4,
+      i64 5,
+      i64* %dist_slot)
+  br i1 %ok, label %hit, label %miss
+
+hit:
+  %dist = load i64, i64* %dist_slot
+  %dist32 = trunc i64 %dist to i32
+  ret i32 %dist32
+
+miss:
+  ret i32 255
+}
+', [Start, Target]).
+
+run_bfs_for(Start, Target, ExitCode) :-
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    host_target_triple(Triple),
+    host_target_datalayout(DataLayout),
+    write_wam_llvm_project(
+        [user:color/1],
+        [ module_name('bfs_exec'),
+          target_triple(Triple),
+          target_datalayout(DataLayout)
+        ],
+        LLPath),
+    build_exec_driver(Start, Target, DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out),
+        ( write(Out, '\n'), write(Out, DriverIR) ),
+        close(Out)),
+    % Full compile path: llc → .o → clang link → run.
+    atom_concat(LLPath, '.o', OPath),
+    atom_concat(LLPath, '.out', BinPath),
+    format(atom(LlcCmd),
+        'llc -filetype=obj -relocation-model=pic ~w -o ~w 2>~w.llc.err',
+        [LLPath, OPath, LLPath]),
+    shell(LlcCmd, LlcExit),
+    ( LlcExit =\= 0
+    -> format('    llc failed (exit=~w), see ~w.llc.err~n', [LlcExit, LLPath]),
+       ExitCode = -1
+    ;  format(atom(ClangCmd),
+           'clang ~w -o ~w 2>~w.clang.err',
+           [OPath, BinPath, LLPath]),
+       shell(ClangCmd, ClangExit),
+       ( ClangExit =\= 0
+       -> format('    clang link failed (exit=~w), see ~w.clang.err~n',
+             [ClangExit, LLPath]),
+          ExitCode = -1
+       ;  shell(BinPath, ExitCode)
+       )
+    ),
+    catch(delete_file(LLPath), _, true),
+    catch(delete_file(OPath), _, true),
+    catch(delete_file(BinPath), _, true).
+
+check_bfs(Label, Start, Target, Expected) :-
+    format('  testing ~w: bfs(~w, ~w) expected ~w~n', [Label, Start, Target, Expected]),
+    run_bfs_for(Start, Target, ExitCode),
+    ( ExitCode =:= Expected
+    -> format('    PASS: ~w returned ~w~n', [Label, ExitCode])
+    ;  format('    FAIL: ~w returned ~w (expected ~w)~n', [Label, ExitCode, Expected]),
+       throw(bfs_wrong_result(Label, ExitCode, Expected))
+    ).
+
+test_bfs_executes :-
+    format('--- BFS helper execution via lli ---~n'),
+    ( process_which('lli')
+    -> check_bfs('three-hop path',    1, 4, 3),
+       check_bfs('direct edge',       1, 5, 1),
+       check_bfs('self hit',          1, 1, 0),
+       check_bfs('unreachable',       1, 99, 255)
+    ;  format('  SKIP: lli not found on PATH~n')
+    ).
+
+% Detect the host's target triple and datalayout by asking clang. We
+% need these to override the write_wam_llvm_project defaults (which
+% hardcode x86_64-pc-linux-gnu), otherwise the generated object file
+% is incompatible with the linker. Falls back to reasonable values
+% if clang is not callable.
+host_target_triple(Triple) :-
+    ( catch(
+        ( process_create(path(clang), ['-print-target-triple'],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, TripleStrRaw),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _, fail)
+    -> split_string(TripleStrRaw, "", "\n\r\t ", [TripleStr]),
+       atom_string(Triple, TripleStr)
+    ;  Triple = 'x86_64-pc-linux-gnu'
+    ).
+
+% A generic datalayout that clang accepts for most linux-like targets
+% — for aarch64-android the actual layout from clang is slightly
+% different, but keeping a tighter layout here means we compile
+% through llc → clang cleanly on the host. We only query clang's
+% triple above; for the datalayout we let llc pick its own default
+% by handing it an empty string (llc then fills in the target's
+% canonical layout).
+host_target_datalayout('').
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _,
+        fail).
+
+test_all :-
+    catch(test_bfs_executes, E,
+        format('  ERROR: ~w~n', [E])).
+
+:- initialization(test_all, main).

--- a/tests/core/test_wam_llvm_reach_execution.pl
+++ b/tests/core/test_wam_llvm_reach_execution.pl
@@ -1,0 +1,239 @@
+:- encoding(utf8).
+% test_wam_llvm_reach_execution.pl
+% M5.7: Full-pipeline end-to-end execution test.
+%
+% This is the capstone test for M5 and M5.6. It exercises the entire
+% foreign-lowering chain at runtime:
+%
+%   1. A td3-shaped `reach/3` Prolog predicate is registered via the
+%      M5.6a options path (foreign_predicates/1).
+%   2. write_wam_llvm_project compiles it to a module containing a
+%      `call_foreign transitive_distance3, 3` instruction, a concrete
+%      @wam_td3_kernel_impl body that calls @wam_bfs_atom_distance,
+%      and an %AtomFactPair edge table.
+%   3. The test appends a `main()` function to the module that
+%      duplicates @reach's vm setup (same @reach_code and
+%      @reach_labels globals), runs the WAM interpreter via
+%      @run_loop, then reads the A3 register via
+%      @wam_get_reg_payload to retrieve the computed distance.
+%   4. The full module is compiled via llc → clang → native binary
+%      and executed. The exit code carries the distance.
+%
+% The test graph uses deterministic atom IDs extracted from the
+% generated fact table via post-compile inspection: we don't assume
+% any particular intern_atom ordering, we just parse what the
+% compile pipeline chose and feed those numeric IDs to main().
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3,
+     llvm_foreign_kernel_spec/3,
+     clear_llvm_foreign_kernel_specs/0]).
+:- use_module(library(process)).
+:- use_module(library(readutil)).
+:- use_module(library(pcre)).
+
+:- dynamic edge/2.
+edge(p, q).
+edge(q, r).
+edge(r, s).
+edge(p, t).
+
+:- dynamic reach/3.
+reach(_, _, _) :- fail.
+
+host_target_triple(Triple) :-
+    ( catch(
+        ( process_create(path(clang), ['-print-target-triple'],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, TripleStrRaw),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _, fail)
+    -> split_string(TripleStrRaw, "", "\n\r\t ", [TripleStr]),
+       atom_string(Triple, TripleStr)
+    ;  Triple = 'x86_64-pc-linux-gnu'
+    ).
+
+%% extract_atom_id(+Src, +AtomLabel, -Id)
+%
+%  Find the interned atom ID for a specific atom in the generated
+%  module by searching for a comment we emit near the top of the
+%  fact table. Since llvm_emit_atom_fact2_table doesn't currently
+%  emit per-row comments, we instead search the file for a
+%  %AtomFactPair entry whose position in the array tells us which
+%  (from, to) pair it is. The fact order matches the edge/2 clause
+%  order, so:
+%
+%     fact 0: p -> q    (first `from` = id of p, first `to` = id of q)
+%     fact 1: q -> r
+%     fact 2: r -> s
+%     fact 3: p -> t
+%
+%  We parse out the four pairs and map letters to the first
+%  occurrence's ID.
+extract_atom_ids(Src, AtomIds) :-
+    re_foldl([Match, Acc, [FromId - ToId | Acc]]>>(
+        get_dict(from, Match, FromIdStr),
+        get_dict(to, Match, ToIdStr),
+        number_string(FromId, FromIdStr),
+        number_string(ToId, ToIdStr)
+    ),
+    "AtomFactPair \\{ i64 (?<from>\\d+), i64 (?<to>\\d+) \\}",
+    Src, [], PairsRev, []),
+    reverse(PairsRev, Pairs),
+    % Fact order matches edge/2 clause order:
+    %   [p->q, q->r, r->s, p->t]
+    Pairs = [P-Q, Q2-R, R2-S, P2-T],
+    P = P2, Q = Q2, R = R2,  % sanity
+    _ = S,  % suppress unused warning
+    AtomIds = atom_ids{p:P, q:Q, r:R, s:S, t:T}.
+
+%% extract_instr_count(+Src, -Count)
+%  Reach has a call_foreign + proceed = 2 instructions. We parse it
+%  from the `@reach_code = private constant [N x %Instruction]` line
+%  so the test doesn't silently break if the compile pipeline changes.
+extract_instr_count(Src, Count) :-
+    re_matchsub("@reach_code = private constant \\[(?<n>\\d+) x %Instruction\\]",
+        Src, Match, []),
+    get_dict(n, Match, NStr),
+    number_string(Count, NStr).
+
+extract_label_count(Src, Count) :-
+    re_matchsub("@reach_labels = private constant \\[(?<n>\\d+) x i32\\]",
+        Src, Match, []),
+    get_dict(n, Match, NStr),
+    number_string(Count, NStr).
+
+%% build_reach_driver(+InstrCount, +LabelArraySize, +StartId, +TargetId, -DriverIR)
+%
+%  A main() that mirrors @reach's vm setup but then reads A3 back.
+build_reach_driver(InstrCount, LabelArraySize, StartId, TargetId, DriverIR) :-
+    format(atom(DriverIR),
+'; === M5.7 reach execution driver ===
+define i32 @main() {
+entry:
+  ; Build %Value atom for start.
+  %a1.0 = insertvalue %Value undef, i32 0, 0
+  %a1 = insertvalue %Value %a1.0, i64 ~w, 1
+
+  ; Build %Value atom for target.
+  %a2.0 = insertvalue %Value undef, i32 0, 0
+  %a2 = insertvalue %Value %a2.0, i64 ~w, 1
+
+  ; Build %Value unbound for result slot.
+  %a3.0 = insertvalue %Value undef, i32 6, 0
+  %a3 = insertvalue %Value %a3.0, i64 0, 1
+
+  ; Create a fresh vm backed by reach_code / reach_labels.
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @reach_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @reach_labels, i32 0, i32 0),
+      i32 0)
+
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %a1)
+  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %a2)
+  call void @wam_set_reg(%WamState* %vm, i32 2, %Value %a3)
+
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %hit, label %miss
+
+hit:
+  ; Read A3 (register index 2) payload back as the computed distance.
+  %dist = call i64 @wam_get_reg_payload(%WamState* %vm, i32 2)
+  %dist32 = trunc i64 %dist to i32
+  ret i32 %dist32
+
+miss:
+  ret i32 255
+}
+',
+    [StartId, TargetId,
+     InstrCount, InstrCount, InstrCount,
+     LabelArraySize, LabelArraySize]).
+
+run_reach_for(Label, StartAtom, TargetAtom, Expected) :-
+    format('  testing ~w: reach(~w, ~w, _) expected ~w~n',
+        [Label, StartAtom, TargetAtom, Expected]),
+    clear_llvm_foreign_kernel_specs,
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    host_target_triple(Triple),
+    write_wam_llvm_project(
+        [user:reach/3],
+        [ module_name('reach_exec'),
+          target_triple(Triple),
+          target_datalayout(''),
+          foreign_predicates([
+              reach/3 - transitive_distance3 - [edge_pred(edge/2)]
+          ])
+        ],
+        LLPath),
+    read_file_to_string(LLPath, Src, []),
+    extract_instr_count(Src, InstrCount),
+    extract_label_count(Src, LabelArraySize),
+    extract_atom_ids(Src, AtomIds),
+    get_dict(StartAtom, AtomIds, StartId),
+    get_dict(TargetAtom, AtomIds, TargetId),
+    build_reach_driver(InstrCount, LabelArraySize, StartId, TargetId, DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out),
+        ( write(Out, '\n'), write(Out, DriverIR) ),
+        close(Out)),
+    atom_concat(LLPath, '.o', OPath),
+    atom_concat(LLPath, '.out', BinPath),
+    format(atom(LlcCmd),
+        'llc -filetype=obj -relocation-model=pic ~w -o ~w 2>~w.llc.err',
+        [LLPath, OPath, LLPath]),
+    shell(LlcCmd, LlcExit),
+    ( LlcExit =\= 0
+    -> format('    FAIL: llc failed (exit=~w)~n', [LlcExit]),
+       ExitCode = -1
+    ;  format(atom(ClangCmd),
+           'clang ~w -o ~w 2>~w.clang.err',
+           [OPath, BinPath, LLPath]),
+       shell(ClangCmd, ClangExit),
+       ( ClangExit =\= 0
+       -> format('    FAIL: clang link failed (exit=~w)~n', [ClangExit]),
+          ExitCode = -1
+       ;  shell(BinPath, ExitCode)
+       )
+    ),
+    ( ExitCode =:= Expected
+    -> format('    PASS: ~w returned ~w~n', [Label, ExitCode])
+    ;  format('    FAIL: ~w returned ~w (expected ~w)~n', [Label, ExitCode, Expected])
+    ),
+    catch(delete_file(LLPath), _, true),
+    catch(delete_file(OPath), _, true),
+    catch(delete_file(BinPath), _, true),
+    clear_llvm_foreign_kernel_specs,
+    assertion(ExitCode =:= Expected).
+
+test_reach_executes :-
+    format('--- Full-pipeline foreign-lowered reach/3 execution ---~n'),
+    ( process_which('clang'), process_which('llc')
+    -> % Graph: p -> q -> r -> s, plus p -> t
+       run_reach_for('three-hop path p->s',  p, s, 3),
+       run_reach_for('two-hop path p->r',    p, r, 2),
+       run_reach_for('direct edge p->q',     p, q, 1),
+       run_reach_for('direct edge p->t',     p, t, 1),
+       run_reach_for('self hit p->p',        p, p, 0)
+    ;  format('  SKIP: clang or llc not found on PATH~n')
+    ).
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _,
+        fail).
+
+test_all :-
+    catch(test_reach_executes, E,
+        format('  ERROR: ~w~n', [E])).
+
+:- initialization(test_all, main).


### PR DESCRIPTION
## Summary

M5.7 is the first test in the WAM LLVM series to actually **execute** generated code instead of just validating it statically. Prior milestones stopped at `llvm-as` (parse) and `opt -passes=verify` (SSA check), both of which are static passes — they never ran the IR. M5.7 adds two tests that compile generated modules through `llc → clang → native binary` and run them.

Along the way, M5.7 exposed and fixed two latent runtime bugs that went unnoticed the entire M1–M5.6 sequence because no test ever actually ran the code.

## The Two Bugs

### Bug 1: `@wam_state_new` register init was undefined behavior

The register-zeroing step in the runtime template was:

```llvm
call void @llvm.memcpy.p0i8.p0i8.i64(
    i8* %regs_raw, i8* zeroinitializer, i64 %regs_size, i1 false)
```

Passing `zeroinitializer` as the *source pointer* to `memcpy` evaluates to null. Dereferencing null is undefined behavior — on aarch64-android (and almost certainly every real platform) it segfaults on the very first call to `@wam_state_new`, which happens before any WAM instruction executes. `llvm-as` and `opt -passes=verify` both accept the IR without complaint because the misuse isn't a well-formedness issue, it's a runtime semantics issue.

**Fix:** Declare `llvm.memset.p0i8.i64` in `module.ll.mustache` and switch the register init:

```llvm
call void @llvm.memset.p0i8.i64(
    i8* %regs_raw, i8 0, i64 %regs_size, i1 false)
```

### Bug 2: `call_foreign` dispatch case never advanced PC on success

The M3 dispatch case was:

```llvm
call_foreign:
  %cf.kind = trunc i64 %op1 to i32
  %cf.arity = trunc i64 %op2 to i32
  %cf.result = call i1 @wam_execute_foreign_predicate(%WamState* %vm, i32 %cf.kind, i32 %cf.arity)
  ret i1 %cf.result
```

Missing `@wam_inc_pc` call. When the foreign kernel succeeds (returns true), the step function returns true → `@run_loop` tail-calls itself → fetches the instruction at the same PC again → **loops forever** → stack overflow and segfault.

The bug was hidden through M3–M5.5 because every registered kernel kind returned `false` (they were all stubs). Returning false causes `@run_loop` to attempt backtracking, and a freshly-created WAM state has no choice points, so backtrack fails cleanly through the `failure` block and the caller sees a normal failure exit. The infinite-loop path was only reachable on success, and no kernel succeeded until M5.6 wired the real BFS handler in place of the td3 stub.

**Fix:** Branch on the result and increment PC on the success path:

```llvm
call_foreign:
  %cf.kind = trunc i64 %op1 to i32
  %cf.arity = trunc i64 %op2 to i32
  %cf.result = call i1 @wam_execute_foreign_predicate(%WamState* %vm, i32 %cf.kind, i32 %cf.arity)
  br i1 %cf.result, label %cf.success, label %cf.fail

cf.success:
  call void @wam_inc_pc(%WamState* %vm)
  ret i1 true

cf.fail:
  ret i1 false
```

On success, advance PC then return true so `@run_loop` continues to the next instruction. On failure, leave PC alone so `@run_loop` backtracks from the current PC (matching the convention used by every other failable dispatch case in the switch).

## Test 1: BFS Helper Direct Execution

**File:** `tests/core/test_wam_llvm_bfs_execution.pl` — 4 assertions.

Generates a module containing the runtime template, appends a concrete `%AtomFactPair` fact table with hand-written atom IDs (1..5) and a `main()` function that calls `@wam_bfs_atom_distance` directly. Compiles via `llc → clang → native binary` and runs it, using the exit code to carry the computed distance.

### Test graph

```
1 → 2 → 3 → 4
1 → 5
```

### Cases

| Case | Inputs | Expected |
|---|---|---|
| Three-hop path | bfs(1, 4) | 3 |
| Direct edge | bfs(1, 5) | 1 |
| Self hit | bfs(1, 1) | 0 |
| Unreachable | bfs(1, 99) | 255 (miss sentinel) |

This is the first test that validates the M5.2 BFS helper runs correctly at the instruction level, not just that the IR parses cleanly. Hand-written atom IDs (not via `intern_atom/2`) make the test deterministic regardless of what other tests interned in the same session.

## Test 2: Full Foreign-Lowered `reach/3` Execution

**File:** `tests/core/test_wam_llvm_reach_execution.pl` — 5 assertions.

The **capstone test** for M5 and M5.6. Registers `reach/3` via the M5.6a options path, lets the compile pipeline splice the concrete td3 impl and emit the edge table from `user:edge/2` clauses, then appends a `main()` function that mirrors `@reach`'s VM setup but reads the A3 register back via `@wam_get_reg_payload` after `@run_loop` returns.

### Design notes

- **Atom IDs are extracted from the generated fact table via regex**, not assumed. The test uses PCRE to scan the `%AtomFactPair` initializer for `p`, `q`, `r`, `s`, `t` in the order they were interned during compilation, and passes those exact integer IDs into the `main()` driver. No assumptions about intern ordering.
- **`InstrCount` and `LabelArraySize` are similarly extracted** from the `@reach_code` and `@reach_labels` global declarations, so the test doesn't silently break if the compile pipeline's instruction emission changes.
- **The driver uses the same `@reach_code` and `@reach_labels` private globals** as `@reach` itself, because the `main()` function is appended to the same module (private linkage is only opaque to *other modules*, not to same-module callers).

### Test graph

```
p → q → r → s
p → t
```

### Cases

| Case | Query | Expected |
|---|---|---|
| Three-hop path | `reach(p, s, D)` | `D = 3` |
| Two-hop path | `reach(p, r, D)` | `D = 2` |
| Direct edge | `reach(p, q, D)` | `D = 1` |
| Direct edge (branch) | `reach(p, t, D)` | `D = 1` |
| Self hit | `reach(p, p, D)` | `D = 0` |

All five execute correctly, proving the **entire Prolog → LLVM → native binary → execution chain** works end-to-end for foreign-lowered recursive predicates.

## Test Infrastructure

Both tests use `clang -print-target-triple` at runtime to discover the host triple (in this case `aarch64-unknown-linux-android30`), overriding `write_wam_llvm_project`'s default `x86_64-pc-linux-gnu`. This makes the tests portable across hosts without hardcoding. The target datalayout is left empty so `llc` picks its own canonical layout.

The compile path is:

```
 .ll  →  llc -filetype=obj -relocation-model=pic  →  .o
 .o   →  clang                                    →  native binary
```

`lli` (LLVM's JIT interpreter) was tried first but crashed with an internal LLVM error on the generated IR — the static compile path via `llc`+`clang` is more robust.

## Test Coverage

| Suite | Assertions | Scope |
|---|---|---|
| `test_wam_llvm_switch.pl` (M1) | 7 | regression |
| `test_wam_llvm_aggregate.pl` (M2) | 5 | regression |
| `test_wam_llvm_foreign_dispatch.pl` (M3) | 11 | regression |
| `test_wam_llvm_fact_tables.pl` (M4) | 10 | regression |
| `test_wam_llvm_ffi_bridge.pl` (M5.1) | 7 | regression |
| `test_wam_llvm_bfs_atom.pl` (M5.2) | 3 | regression |
| `test_wam_llvm_dijkstra.pl` (M5.3) | 4 | regression |
| `test_wam_llvm_astar.pl` (M5.4) | 4 | regression |
| `test_wam_llvm_td3_wiring.pl` (M5.5) | 4 | regression |
| `test_wam_llvm_foreign_lowering_options.pl` (M5.6a) | 8 | regression |
| `test_wam_llvm_foreign_lowering_directive.pl` (M5.6b) | 6 | regression |
| `test_wam_llvm_foreign_lowering_autodetect.pl` (M5.6c) | 9 | regression |
| `test_wam_llvm_bfs_execution.pl` (M5.7) | 4 | **new** |
| `test_wam_llvm_reach_execution.pl` (M5.7) | 5 | **new** |
| **Total** | **87** | |

All 12 prior suites still green after the two bug fixes — the `call_foreign` PC fix doesn't affect M3's tests (which never exercise the success path), and the memset fix is a pure replacement of undefined behavior with defined behavior.

## What This Unlocks

M5.7 is the foundation for all future runtime validation work. Any subsequent milestone that adds new runtime helpers, new WAM instructions, or new foreign kernels can now include execution tests instead of stopping at static validation. Concretely, the next natural follow-ups:

1. **Extend foreign lowering to Dijkstra (M5.3 helper) and A* (M5.4 helper).** Mirror the M5.5 + M5.6 pattern for `weighted_shortest_path3` and `astar_shortest_path4`. Each can land with its own execution test using the same `llc → clang → run` harness.
2. **Stress-test the existing helpers with larger graphs.** M5.7 uses 4-5 nodes. Running BFS and (eventually) Dijkstra on a 100-node graph would validate the malloc/free cleanup paths under load.
3. **Multi-edge-pred support for td3** (documented as a known limitation in M5.6). Execution testing makes it much easier to verify the fix works correctly rather than just "compiles cleanly".
4. **Cross-target parity with Rust kernels** (`category_ancestor`, `countdown_sum2`, `list_suffix2`, `transitive_closure2`). Each is a candidate for the same "port helper → wire dispatcher → execution test" sequence.

## Files Changed

- `templates/targets/llvm_wam/state.ll.mustache` — `llvm.memset` replacing the undefined-behavior memcpy-from-null in `@wam_state_new`.
- `templates/targets/llvm_wam/module.ll.mustache` — added `declare void @llvm.memset.p0i8.i64(...)`.
- `src/unifyweaver/targets/wam_llvm_target.pl` — M3 `call_foreign` dispatch case now branches on the kernel result and advances PC on success.
- `tests/core/test_wam_llvm_bfs_execution.pl` — new (M5.7 Test 1).
- `tests/core/test_wam_llvm_reach_execution.pl` — new (M5.7 Test 2).

## Commits

- `cd0960e4` — feat(wam-llvm): end-to-end execution tests (M5.7) + two runtime bug fixes

## Test Plan

- [x] All 12 prior WAM-LLVM regression suites green (78 assertions).
- [x] M5.7 BFS execution: `swipl -q tests/core/test_wam_llvm_bfs_execution.pl` — 4 assertions, all cases return correct exit codes.
- [x] M5.7 reach execution: `swipl -q tests/core/test_wam_llvm_reach_execution.pl` — 5 assertions, full Prolog → LLVM → binary → execution chain validates for foreign-lowered `reach/3`.
- [x] Both tests compile successfully through `llc → clang` on aarch64-android and produce runnable binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
