### PR TITLE
docs(wam-haskell): design for WAM-lowered Haskell code-gen path

### DIFF
--- a/docs/design/WAM_HASKELL_LOWERED_BACKGROUND.md
+++ b/docs/design/WAM_HASKELL_LOWERED_BACKGROUND.md
@@ -1,0 +1,207 @@
+# WAM-Lowered Haskell: Background — Taxonomy of Haskell Targets
+
+This document captures the discussion that precipitated the WAM-lowered
+Haskell design (see `WAM_HASKELL_LOWERED_PHILOSOPHY.md`,
+`WAM_HASKELL_LOWERED_SPECIFICATION.md`, and
+`WAM_HASKELL_LOWERED_IMPLEMENTATION_PLAN.md`). It exists to ground the
+design docs in the *actual current code*, not in hand-waving about
+"modes," and to record the clarification of what "hybrid WAM with/without
+FFI" actually means at the code level.
+
+Nothing in this document is a design decision in its own right. It is
+descriptive, not prescriptive. Read the philosophy/spec/plan docs for
+the decisions; read this document to understand the state of the world
+those decisions apply to.
+
+## The three paths
+
+UnifyWeaver has (or, in the case of path 3, is introducing) three
+top-level code generation paths that produce Haskell from Prolog. They
+are not variations of the same generator. They are three distinct
+compilation strategies with different inputs, different intermediate
+analyses, and different failure modes.
+
+### Path 1 — Direct native Haskell lowering
+
+- **Source file:** `src/unifyweaver/targets/haskell_target.pl`
+- **Entry point:** `compile_predicate_to_haskell/3` (line 72), via
+  `native_haskell_clause_body/3`.
+- **What it does:** emits straight-line Haskell functions directly from
+  the Prolog clause AST. No WAM involved at all. For example, a
+  `parent/2` fact set becomes a Haskell function that pattern-matches
+  on the arguments against a list of tuples.
+- **When it fires:** only for predicates whose clauses the lowering
+  analysis (`native_haskell_clause_body/3`) can statically reason
+  about. Anything with complex backtracking, cut interactions,
+  meta-call, or aggregation semantics falls through to path 2.
+- **Emission shape:** something like
+  ```haskell
+  ancestor x y
+    | parent x y = True
+    | ...
+  ```
+  or, for facts:
+  ```haskell
+  parent :: [(Entity, Entity)]
+  parent = [(Tom, Bob), (Bob, Jim)]
+  ```
+- **Why it is fast:** GHC sees a pure functional program with no
+  interpretation layer, no boxed state, no dispatch loop. It optimizes
+  the output as if a human wrote it.
+- **Why it is narrow:** every Prolog feature the lowering analysis
+  does not support causes the predicate to fall through.
+
+### Path 2 — WAM-interpreted Haskell (current production path)
+
+- **Source file:** `src/unifyweaver/targets/wam_haskell_target.pl`
+- **Entry point:** `write_wam_haskell_project/3`.
+- **What it does:** compiles Prolog → WAM IR (via
+  `wam_target:compile_predicate_to_wam/3`) → a Haskell project
+  containing `WamTypes.hs`, `WamRuntime.hs`, `Predicates.hs` (the
+  instruction array and label map), and `Main.hs`. At runtime, the
+  `run`/`step` functions in `WamRuntime.hs` walk the instruction array
+  and execute each WAM instruction.
+- **Runtime dispatch chain at `Call`:** this is where the "hybrid" and
+  "FFI" terminology comes from. In `WamRuntime.hs` the `step` function
+  handles `Call` via `wam_haskell_target.pl:621-629`, which is a chain
+  with four branches:
+  1. **`CallResolved`** — a pre-resolved PC jump. Built by
+     `resolveCallInstrs` (`wam_haskell_target.pl:1308-1322`) at project
+     load time. Only fires for predicates that have a label and are
+     **not** in the `foreignPreds` list. This is the fast path — no
+     string lookup, no FFI, just `wsPC := targetPC`.
+  2. **`executeForeign`** — hand-written Haskell escape hatches.
+     Pattern-matches on the predicate name and dispatches to a
+     specialised Haskell helper. Currently the only predicate with an
+     escape hatch is `category_ancestor/4`, which calls
+     `nativeCategoryAncestor`. This is "the FFI."
+  3. **`callIndexedFact2`** — generic indexed dispatch for 2-arg
+     facts, backed by `wcForeignFacts`. Used for `category_parent/2`
+     and any other 2-arg fact table the user wires up. This is *not*
+     an FFI — it's an indexed lookup inside the WAM, and it's always
+     beneficial when facts are populated.
+  4. **`wcLabels` lookup** — fallback string lookup for any predicate
+     that somehow slipped past `resolveCallInstrs`. In a well-formed
+     project this branch is unreachable.
+- **Why it is fast (today):** persistent data structures so
+  backtracking is cheap (structural sharing, not copying), a hot/cold
+  split of `WamState` into hot state + `WamContext`, pre-resolved
+  `Call → CallResolved` so most calls do not hash strings,
+  compile-time arity for `PutStructure`, cached length counters so
+  cut and backtrack are O(1), and targeted FFI hot-spot escape
+  hatches.
+- **Why it is slow (today):** every instruction is dispatched through
+  a `case instr of ...` at runtime in `step`. GHC cannot see through
+  that dispatch to fuse adjacent instructions, inline predicate calls,
+  or keep registers in unboxed lets. The interpreter pays per-
+  instruction overhead forever.
+
+### Path 3 — WAM-lowered Haskell functions (this design)
+
+- **Source file:** `src/unifyweaver/targets/wam_haskell_lowered_emitter.pl`
+  (new, does not exist yet).
+- **Entry point:** `lower_predicate_to_haskell/4`, called from
+  `write_wam_haskell_project/3` when `emit_mode(functions)` or
+  `emit_mode(mixed(HotPreds))` is active.
+- **What it does:** compiles Prolog → WAM IR → **one Haskell function
+  per predicate**. The function body is straight-line Haskell that
+  mirrors the WAM instruction sequence inline. No instruction array,
+  no `step`/`run` interpreter loop for the lowered predicates.
+- **What it preserves from path 2:** `WamState` and `WamContext` are
+  still threaded through the lowered functions. Persistent data
+  structures still hold the bindings, trail, choice points, and
+  stack. The FFI/indexed-fact helpers are shared between paths —
+  lowered code calls them via ordinary Haskell function calls.
+  Backtracking still works across the path-2/path-3 boundary because
+  choice points record interpreter PCs the same way.
+- **Why it might be faster than path 2:** GHC sees the whole predicate
+  as a single Haskell function, so it can fuse adjacent WAM
+  instructions, track register values as unboxed lets, inline
+  intra-predicate calls, and specialize the generated code the same
+  way path 1 would have — but for predicates path 1 cannot reach.
+- **Why it is a separate path, not a replacement for path 2:** path 2
+  is the reference implementation — when a lowered predicate
+  misbehaves, the first debugging question is "does the same input
+  produce the same output through the interpreter?" Also, lowering
+  has a generator-complexity and GHC-compile-time cost per predicate,
+  so forcing every cold predicate through lowering is wasteful. See
+  the philosophy doc §"Why this is a third path, not a replacement"
+  for the full argument.
+
+## What "hybrid WAM with/without FFI" means, precisely
+
+This is the clarification that motivated writing this background doc.
+"Hybrid WAM with FFI" and "hybrid WAM without FFI" are real and
+meaningful, but narrower than a casual reading suggests. Specifically:
+
+- "With FFI" means **`executeForeign` is pattern-matched for at least
+  one predicate** and `wcForeignFacts`/`wcForeignConfig` are populated
+  in `Main.hs` so the escape hatch can actually fire.
+- "Without FFI" means `executeForeign` matches no predicates (or the
+  foreign facts are not populated), so the `Call` dispatch chain
+  skips that branch and falls through to indexed-fact dispatch or the
+  label lookup.
+
+`callIndexedFact2` is **not** part of this "with/without FFI" axis. It
+is a separate runtime feature — generic indexed dispatch for 2-arg
+facts — and it is always beneficial when facts are populated. Turning
+it off would mean running `category_parent/2` through clause
+enumeration, which is slower for no reason. Nobody turns it off in
+practice.
+
+So the current `wam_haskell_target.pl` output actually has **three
+independently-toggleable runtime features at the `Call` site**, not
+two:
+
+1. `CallResolved` fast path (always on, built by `resolveCallInstrs`).
+2. `executeForeign` escape hatch (on per-predicate, currently only
+   `category_ancestor/4`).
+3. `callIndexedFact2` indexed-fact dispatch (on when facts are
+   populated).
+
+All three are part of the path-2 generator output. The path-3 design
+preserves access to (2) and (3) via shared Haskell helpers that
+lowered code calls directly. (1) becomes redundant inside a lowered
+predicate, because the "call target" is either a direct Haskell
+function call (intra-lowered) or an `wsPC`-based re-entry into the
+interpreter (lowered → interpreted).
+
+## Why the philosophy doc calls path 3 "a JIT over path 2"
+
+Because the mental model maps cleanly:
+
+- Path 2's `step` function is the interpreter.
+- Path 3's emitted per-predicate Haskell function is the specialized
+  code the interpreter would have produced if it had inlined every
+  dispatch for this specific instruction sequence ahead of time.
+- Path 2 decides what to execute at runtime (one `case` per step);
+  path 3 commits that decision at generator time.
+
+The analogy breaks down in one important place: a real JIT discards
+the interpreted version once specialization is complete. Path 3 does
+**not** discard path 2. The interpreter stays as the reference
+implementation, the cold-predicate fallback, and the "does the
+lowered version produce the same answer" oracle.
+
+## Code references (for future archaeology)
+
+These are the specific line ranges you will want to read if you are
+about to touch the lowering path. All paths relative to the repo
+root.
+
+| What you want to understand | Where |
+|---|---|
+| `Call` runtime dispatch chain | `src/unifyweaver/targets/wam_haskell_target.pl:621-629` |
+| `executeForeign` entry | `src/unifyweaver/targets/wam_haskell_target.pl:482-524` |
+| `callIndexedFact2` | `src/unifyweaver/targets/wam_haskell_target.pl:448-476` |
+| `resolveCallInstrs` | `src/unifyweaver/targets/wam_haskell_target.pl:1308-1322` |
+| `foreignPreds` list (where FFI escape hatches are named) | `src/unifyweaver/targets/wam_haskell_target.pl:1022` |
+| `wcForeignFacts` population in `Main.hs` | `src/unifyweaver/targets/wam_haskell_target.pl:1032-1041` |
+| `nativeCategoryAncestor` (the one current FFI target) | `src/unifyweaver/targets/wam_haskell_target.pl:411-433` |
+| `native_haskell_clause_body/3` (path 1 entry) | `src/unifyweaver/targets/haskell_target.pl:72-102` |
+| WAM instruction → Haskell (path 2 emission) | `src/unifyweaver/targets/wam_haskell_target.pl`, `wam_instr_to_haskell/2` |
+| Interpreter `step` body (semantic reference for path 3) | `src/unifyweaver/targets/wam_haskell_target.pl`, the big `step` template string |
+
+Line numbers are accurate as of the commit on `feat/wam-haskell-ffi-optimization`
+at the time this background doc was written. If they have drifted,
+search by symbol name.

--- a/docs/design/WAM_HASKELL_LOWERED_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_HASKELL_LOWERED_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,300 @@
+# WAM-Lowered Haskell: Implementation Plan
+
+This document is the step-by-step plan for adding the **WAM-lowered
+Haskell** code-generation path (path 3) to UnifyWeaver.
+
+Companion docs:
+- [`WAM_HASKELL_LOWERED_BACKGROUND.md`](WAM_HASKELL_LOWERED_BACKGROUND.md)
+  — descriptive tour of the existing Haskell code-generation paths, with
+  source line references. Read this first if you are new to the area.
+- [`WAM_HASKELL_LOWERED_PHILOSOPHY.md`](WAM_HASKELL_LOWERED_PHILOSOPHY.md)
+  — *why* we are adding this third path.
+- [`WAM_HASKELL_LOWERED_SPECIFICATION.md`](WAM_HASKELL_LOWERED_SPECIFICATION.md)
+  — *what* the emitter must produce.
+
+This document is strictly about ordering and dependencies.
+
+## Branch strategy
+
+- New branch: `feat/wam-haskell-lowered`, forked from whatever main-
+  line state the FFI-optimization branch merged into.
+- Do **not** touch `wam_rust_target.pl`, `wam_c_target.pl`, or the
+  other WAM targets. This is Haskell-only.
+- Do **not** touch `haskell_target.pl` (path 1). It stays as-is.
+- The interpreter path (path 2) stays the default throughout this
+  branch. The branch ships with `emit_mode(interpreter)` still the
+  default.
+
+## Phase 0: prerequisites (no code changes)
+
+Before writing a single line of the new emitter, verify these hold:
+
+- [ ] Current `feat/wam-haskell-ffi-optimization` work is merged or
+      its performance/correctness results are frozen, so we have a
+      stable baseline to measure lowered code against.
+- [ ] The `effective_distance` 10k benchmark runs end-to-end through
+      `wam_haskell_target.pl` and produces output byte-identical to
+      the Prolog reference. This is the regression oracle.
+- [ ] The WAM IR instruction set as consumed by
+      `wam_haskell_target.pl` is documented or inspectable (read:
+      `wam_instr_to_haskell/2` in `wam_haskell_target.pl` already
+      lists every instruction the Haskell target supports — use that
+      list as the initial lowerability whitelist).
+
+None of the phases below start until Phase 0 is green.
+
+## Phase 1: selector plumbing (no lowering yet)
+
+Goal: add the `emit_mode/1` option and the `wam_haskell_emit_mode/1`
+dynamic fact, wire them through `write_wam_haskell_project/3`, and
+verify that `emit_mode(interpreter)` (the default) produces exactly the
+current output.
+
+- [ ] Add the `emit_mode/1` option parsing to
+      `write_wam_haskell_project/3`. Accepted values:
+      `interpreter`, `functions`, `mixed(_)`. Unknown values raise an
+      existence error.
+- [ ] Add `user:wam_haskell_emit_mode/1` lookup as the second level
+      of the selector hierarchy. Missing is fine; the generator falls
+      through to the default.
+- [ ] Add a stub `wam_haskell_lowerable(+PredIndicator, +WamCode, -Reason)`
+      that **always** fails with reason
+      `"lowering emitter not yet implemented"`. This makes
+      `emit_mode(functions)` and `mixed(_)` route everything to the
+      interpreter for now — no behavior change, but the plumbing is
+      in place.
+- [ ] Regression check: run the `effective_distance` 10k benchmark
+      with no `emit_mode` option. Output must be byte-identical to
+      the pre-Phase-1 state.
+- [ ] Regression check: run with `emit_mode(interpreter)`
+      explicitly. Same.
+- [ ] Regression check: run with `emit_mode(functions)`. Because
+      the stub lowerability check always fails, everything still
+      routes to the interpreter, and output is still identical.
+- [ ] Land as one commit.
+
+## Phase 2: `Lowered.hs` skeleton (empty lowered partition)
+
+Goal: emit a `Lowered.hs` file even when no predicates are lowered,
+wire it into `WamContext` and `WamRuntime.step`, and verify the
+interpreter still works.
+
+- [ ] Add `wcLoweredPredicates :: Map.Map String (WamContext -> WamState -> Maybe WamState)`
+      to `WamContext` (cold field). Default initialization is
+      `Map.empty`.
+- [ ] Modify `step` in the `Call` dispatch chain to check
+      `wcLoweredPredicates` first, before `executeForeign`. On miss,
+      fall through to the existing chain unchanged.
+- [ ] Emit `Lowered.hs` in `write_wam_haskell_project/3` even when
+      the lowered partition is empty. Its body is the module header,
+      the imports, and `loweredPredicates = Map.empty`.
+- [ ] Modify `Main.hs` generation to populate `wcLoweredPredicates`
+      from `Lowered.loweredPredicates` when building `ctx`.
+- [ ] Regression check: `effective_distance` 10k benchmark byte-
+      identical to Phase 1.
+- [ ] Land.
+
+## Phase 3: first lowered predicate (smoke test)
+
+Goal: hand-lower one trivial predicate end-to-end, prove the interop
+contract, and use it as the correctness oracle for the rest of the
+work.
+
+Target predicate: `max_depth/1` (the dynamic fact with one clause,
+`max_depth(10).`). Its WAM is essentially one `GetConstant` and a
+`Proceed`. There is no backtracking, no cut, no aggregation. It is
+the smallest thing that actually exercises the function-call protocol.
+
+- [ ] Create `src/unifyweaver/targets/wam_haskell_lowered_emitter.pl`.
+      Export `lower_predicate_to_haskell/4` and
+      `wam_haskell_lowerable/3`.
+- [ ] Implement the whitelist-based lowerability check for the
+      instructions in `max_depth/1`: `GetConstant`, `Proceed`.
+- [ ] Implement the emitter for those two instructions only. Output
+      a function `lowered_max_depth_1 :: WamContext -> WamState -> Maybe WamState`
+      that inlines the same logic as the interpreter's `step` cases.
+- [ ] Wire `lower_predicate_to_haskell/4` into
+      `write_wam_haskell_project/3` so that
+      `emit_mode(mixed([max_depth/1]))` actually lowers it and the
+      rest stay interpreted.
+- [ ] Add `tests/test_wam_haskell_lowered_smoke.pl`: generate a tiny
+      project with `mixed([max_depth/1])`, build it, run a query that
+      hits `max_depth/1`, and verify the answer matches the
+      interpreter-only run.
+- [ ] Land when the smoke test passes.
+
+After Phase 3, the generator has one lowered predicate that works
+end-to-end. This is where we stop if we want to bail out; everything
+from here is incremental expansion.
+
+## Phase 4: simple register and control instructions
+
+Goal: expand the lowering whitelist to cover predicates made of
+straight-line code with no backtracking.
+
+- [ ] Add to the whitelist: `GetVariable`, `GetValue`, `GetStructure`,
+      `PutConstant`, `PutVariable`, `PutValue`, `PutStructure`,
+      `CallResolved`, `Proceed`, `Allocate`, `Deallocate`.
+- [ ] Implement the Haskell emission for each. Use the interpreter's
+      `step` implementation as the semantic reference — the lowered
+      version produces the same `WamState` delta inline.
+- [ ] Pick a test predicate from the existing benchmark suite whose
+      body uses these instructions but no choice points (e.g.,
+      `dimension_n/1`, or the first clause of a simple helper).
+- [ ] Add a test comparing lowered vs interpreted output.
+- [ ] Land.
+
+## Phase 5: choice points and backtracking
+
+Goal: support `TryMeElse`, `RetryMeElse`, `TrustMe`, and prove
+backtracking crosses the path boundary correctly.
+
+- [ ] Add to the whitelist: `TryMeElse`, `RetryMeElse`, `TrustMe`,
+      and the `Call` (string-dispatched) variant for predicates whose
+      target is not known at lowering time.
+- [ ] Implement the `wsPC`-dispatched entry described in
+      `WAM_HASKELL_LOWERED_SPECIFICATION.md` §2.4. Each lowered
+      predicate that has multiple clause entry PCs starts with a
+      `case wsPC s of ...` that routes to the right clause body.
+- [ ] Verify the `cpNextPC`-as-interpreter-PC invariant in practice:
+      a lowered predicate whose `TryMeElse` alternate is also lowered
+      still records the interpreter PC in the CP, and a backtrack
+      into it still works because the `step` dispatch finds it in
+      `wcLoweredPredicates`.
+- [ ] Add a cross-path backtracking test: an interpreted predicate
+      that calls a lowered predicate whose first clause fails, and
+      the backtrack restores the correct state and tries clause 2.
+- [ ] Add the reverse: a lowered predicate that calls an interpreted
+      predicate which creates its own CPs, and verify backtracking
+      from inside the interpreted call correctly unwinds out.
+- [ ] Land.
+
+## Phase 6: builtins
+
+Goal: support the BuiltinCall variants the interpreter handles.
+
+- [ ] Add to the whitelist: `BuiltinCall "is/2"`, `BuiltinCall "!/0"`,
+      `BuiltinCall "\\+/1"`, `BuiltinCall "length/2"`,
+      `BuiltinCall "member/2"`, `BuiltinCall "</2"`,
+      `BuiltinCall ">/2"`.
+- [ ] For each builtin, emit a direct Haskell call into a shared
+      helper that the interpreter also uses. Refactor
+      `WamRuntime.hs` if needed so the helpers are top-level
+      functions, not inlined into the `step` case bodies. This is a
+      code-shape refactor; it must not change interpreter behavior.
+- [ ] Add a test predicate using each builtin and verify lowered vs
+      interpreted parity.
+- [ ] Land.
+
+## Phase 7: `SwitchOnConstant` and indexed dispatch
+
+Goal: support the one non-trivial dispatch instruction and verify
+parity with the interpreter on predicates that use it.
+
+- [ ] Add `SwitchOnConstant` to the whitelist.
+- [ ] Emit either an inline Haskell `case` (for small dispatch tables,
+      threshold: ≤ 32 entries) or a `Map.lookup` (for larger tables),
+      matching the interpreter's runtime semantics.
+- [ ] Test on a fact-indexed predicate: `category_parent/2` probably
+      works. Verify parity.
+- [ ] Land.
+
+## Phase 8: benchmark with `emit_mode(functions)`
+
+Goal: measure path 3 against path 2 honestly, document the number.
+
+- [ ] Run the `effective_distance` 10k benchmark in
+      `emit_mode(interpreter)` (baseline) and
+      `emit_mode(functions)` (lowered), 5 runs each, report median
+      query_ms and total_ms.
+- [ ] Verify output is byte-identical between the two.
+- [ ] If `emit_mode(functions)` is slower, document that honestly.
+      Do *not* ship performance claims ahead of measurements.
+- [ ] Save the numbers in `docs/benchmarks/WAM_HASKELL_LOWERED_RESULTS.md`
+      (new file). Include the commit hash and GHC version.
+
+## Phase 9: `mixed(HotPreds)` ergonomics
+
+Goal: make mixed mode first-class, not just a debugging artifact.
+
+- [ ] Add `emit_mode(mixed([category_ancestor/4, power_sum_bound/4]))`
+      as the default shape tested in the `wam_haskell` benchmark
+      target. (Still not the generator's overall default — that's
+      Phase 10.)
+- [ ] Benchmark the mixed case vs both all-interpreted and all-
+      lowered. Document.
+- [ ] If the mixed mode beats both, update
+      `examples/benchmark/benchmark_effective_distance.py` to use it
+      for the `wam_haskell` target by default.
+
+## Phase 10 (deferred): flip the default
+
+Only do this if all of the following hold:
+
+- Path 3 passes every correctness test path 2 passes on every
+  benchmark currently checked in.
+- Path 3 is faster than path 2 on the `effective_distance` 10k
+  benchmark by at least 1.5× median total_ms.
+- At least one externally-reported workload has used path 3 in
+  `mixed(HotPreds)` mode without filing a correctness bug.
+- The lowerability check has been expanded to cover every
+  instruction used by every checked-in benchmark predicate, OR the
+  generator's automatic fallback has been exercised and verified to
+  produce correct output.
+
+When all of the above hold:
+
+- [ ] Change the default in `write_wam_haskell_project/3` from
+      `interpreter` to `functions`.
+- [ ] Update `WAM_HASKELL_LOWERED_PHILOSOPHY.md` to reflect the new
+      default.
+- [ ] Leave `interpreter` mode fully supported — it is still the
+      fallback and the reference oracle.
+
+## Deferred / out of scope for this branch
+
+- **Aggregation lowering** (`AggPush`/`AggPop`/`AggEmit`). Stays
+  interpreted. A future follow-up handles aggregation in lowered
+  code after the lowering aggregation shape is designed.
+- **`PutStructureDyn`**. Tracked separately (task 16 in the current
+  todo list).
+- **Cross-target lowering parity** (lowered Rust, lowered C, etc.).
+  Different branch.
+- **Profile-guided `HotPreds` selection.** The user picks the list.
+- **Per-call-site inlining.** Whole predicate is the unit.
+- **Automated benchmark runs on CI.** Nice-to-have.
+
+## Rollback plan
+
+Each phase lands as its own commit(s). If a phase breaks something
+and can't be fixed within the phase, revert the phase's commits
+(git-revert, not force-push) and the generator is back to its
+previous shape. Because the interpreter is the default and the
+lowered emitter is additive, reverting any phase of path 3 cannot
+break path-2 users.
+
+## Coordination with other branches
+
+- **`feat/wam-haskell-ffi-optimization`**: merge first, freeze its
+  benchmark numbers, use them as the path-2 baseline for all path-3
+  comparisons.
+- **Task 16 (`PutStructureDyn`)**: independent. If it lands first,
+  the lowering whitelist can include it; if it lands second, the
+  lowering emitter gains it at that point.
+- **Task 13 (Rust target parity)**: separate branch, separate
+  design, no interaction.
+
+## Review checklist (before landing each phase)
+
+- [ ] Does the phase change `emit_mode(interpreter)` output in any
+      way? If yes, that is a bug and must be fixed before landing.
+- [ ] Does the phase's new lowered code produce byte-identical
+      output to the interpreter on every test case the phase adds?
+- [ ] Do previously-passing tests still pass?
+- [ ] Is `wam_haskell_lowerable/3` correctly rejecting predicates
+      that use instructions not yet supported? (A missed rejection
+      manifests as a generator crash or a GHC compile error, not
+      a runtime failure — both are worse than falling back to the
+      interpreter.)
+- [ ] Is the commit message specific enough that `git log
+      --oneline` tells a future reader which phase this is?

--- a/docs/design/WAM_HASKELL_LOWERED_PHILOSOPHY.md
+++ b/docs/design/WAM_HASKELL_LOWERED_PHILOSOPHY.md
@@ -1,0 +1,230 @@
+# WAM-Lowered Haskell: Philosophy
+
+> **Background.** For a descriptive walk through the *current* Haskell
+> code-generation paths — including exact source line references for the
+> `Call` dispatch chain, `executeForeign`, `callIndexedFact2`, and
+> `resolveCallInstrs` — see
+> [`WAM_HASKELL_LOWERED_BACKGROUND.md`](WAM_HASKELL_LOWERED_BACKGROUND.md).
+> This philosophy doc assumes you already know what "hybrid WAM with/without
+> FFI" means at the code level. The background doc is where that language is
+> pinned down.
+
+## Context
+
+UnifyWeaver currently has two production Haskell code-generation paths and
+is introducing a third:
+
+1. **Direct native Haskell lowering** (`src/unifyweaver/targets/haskell_target.pl`,
+   via `native_haskell_clause_body/3`). Emits straight-line Haskell functions
+   directly from the Prolog AST. Handles predicates whose clauses can be
+   statically reasoned about. No WAM at all.
+
+2. **WAM-interpreted Haskell** (`src/unifyweaver/targets/wam_haskell_target.pl`,
+   current state). Compiles Prolog → WAM IR → a Haskell `[Instruction]`
+   array plus label map, then a `step`/`run` dispatch loop interprets the
+   array at runtime. This is the path the `feat/wam-haskell-*` branches
+   have been optimizing: persistent data structures for choice-point
+   snapshots, `WamState`/`WamContext` hot/cold split, pre-resolved
+   `CallResolved`, an FFI escape hatch (`executeForeign`) for predicates
+   where hand-written Haskell beats the interpreter, and an indexed
+   dispatch for 2-arg facts (`callIndexedFact2`).
+
+3. **WAM-lowered Haskell functions** (this doc, new). Same WAM IR as path
+   2, but instead of emitting an instruction array interpreted at runtime,
+   the generator emits **one Haskell function per Prolog predicate**. The
+   function body is straight-line Haskell that mirrors the WAM semantics
+   for each instruction inline. No instruction array, no `step`/`run`
+   interpreter loop. `WamState`/`WamContext` still thread through so
+   backtracking and choice points work across predicates.
+
+This document explains *why* the third path is worth doing, *why* it is
+strictly additive to the first two, and the design principles the
+generator must respect.
+
+## The gap between paths 1 and 2
+
+Native Haskell lowering (path 1) wins by emitting code GHC can optimize as
+if a human wrote it — let-bindings, strict pattern matches, no boxed
+intermediate state. But it only fires for predicates whose clauses the
+lowering analysis can handle. Anything with complex backtracking, cut
+interactions, meta-call, or aggregation semantics falls through to the
+WAM path.
+
+WAM-interpreted Haskell (path 2) wins by being a faithful, predictable
+execution model that handles every Prolog feature UnifyWeaver's WAM IR
+supports. But the per-instruction `step` dispatch costs something even
+after the `WamContext` split: GHC can't see through a `case instr of ...`
+into the specific instruction each time, so it can't fuse adjacent
+instructions, can't keep registers in unboxed lets, and can't inline
+predicate calls.
+
+The two paths have **different reasons for being fast** and **different
+reasons for being slow**. Path 1 is fast per-instruction but narrow in
+coverage. Path 2 is wide in coverage but pays dispatch overhead on every
+instruction, on every step, forever.
+
+Path 3 is the attempt to get **path 2's coverage with path 1's inner
+loop**. The WAM compiler already knows how to produce correct WAM for
+every predicate UnifyWeaver can handle. That WAM is a specialized little
+straight-line program for each predicate — it just happens to be encoded
+as an array of `Instruction` values that a runtime interpreter walks.
+Emitting the same semantics as a Haskell function body with explicit
+`case` on tags, explicit register binds, and explicit control flow lets
+GHC see *the whole predicate at once*.
+
+## Why this is a third path, not a replacement
+
+The temptation when you describe path 3 is to say "so just delete path
+2." That is wrong for several reasons, and stating them upfront prevents
+an entire category of scope creep.
+
+**1. Path 2 stays as the reference implementation.** The interpreter loop
+in `WamRuntime.hs` is where the WAM semantics are *defined*. When a
+lowered predicate misbehaves, the first debugging question is "does the
+same input produce the same output when run through the interpreter?"
+Deleting path 2 destroys the ground-truth oracle.
+
+**2. Lowering has a cost per predicate.** Path 2 compiles one generator
+output per project (an instruction array and a dispatch loop that works
+for every predicate). Path 3 has to emit specialized code for each
+predicate, which costs generator complexity *per predicate* and GHC
+compile time *per predicate*. For a project with 200 predicates and 20
+hot ones, forcing everything through path 3 is more total work than
+letting the cold predicates stay interpreted.
+
+**3. Some predicates won't lower cleanly.** The WAM has features the
+lowered functions will have to handle — nested cut, aggregation frames
+(`AggPush`/`AggPop`), indexed-fact dispatch via `wcForeignFacts`, FFI
+escape hatches via `executeForeign`. The lowered emitter will probably
+handle most of these, but there will be edge cases where interpreting is
+simpler and safer than emitting. Having the interpreter as a fallback
+means "this predicate didn't lower cleanly, fall back to the interpreter"
+is a valid compile-time decision.
+
+**4. It lets us measure the difference.** Having paths 2 and 3 both
+available, with a per-project or per-predicate selector, is how we will
+know path 3 is actually a win. If path 3 is slower than path 2 on some
+workload we didn't predict, we need to be able to run the same
+predicates through path 2 on the same data without rewriting the
+generator. That requires the interpreter to stay.
+
+The mental model is: **path 3 is a JIT over path 2**. Path 2 knows how
+to run every predicate. Path 3 is "pre-specialize the interpreter's
+dispatch loop for this specific predicate's instruction sequence." The
+two are complementary: the generator picks which predicates to specialize
+based on expected benefit (mostly: the ones on the hot path), and leaves
+the rest interpreted.
+
+## The selector, and why it defaults to interpreted
+
+Path 3 will ship behind a selector. The user (or a calling program)
+decides which path to take per project *and* optionally per predicate.
+
+The selector hierarchy the generator checks, in order:
+
+1. **Per-call option on `write_wam_haskell_project/3`:**
+   `emit_mode(interpreter)`, `emit_mode(functions)`, or
+   `emit_mode(mixed(HotPreds))` where `HotPreds` is a list of predicate
+   indicators to lower.
+2. **User-defined Prolog predicate:** a dynamic fact `user:wam_haskell_emit_mode/1`
+   with the same allowed values. Lets a project assert its preferred
+   default at load time without threading an option through every call site.
+3. **Generator default:** `interpreter`.
+
+The generator default is **`interpreter` (path 2)**, not `functions`,
+for three reasons:
+
+1. **Path 2 is the proven path.** Every benchmark, every correctness
+   test, every regression run currently in `examples/benchmark/` and
+   `tests/` targets the interpreter. The first shipping version of
+   path 3 will *not* have comparable test coverage. Making path 3 the
+   default before its test coverage catches up means every user of
+   `write_wam_haskell_project/3` becomes an unwitting beta tester.
+
+2. **Path 3 has new failure modes.** The generator emits Haskell, so a
+   generator bug now manifests as a GHC compile error in the user's
+   project, not a runtime error in a well-tested interpreter loop. That
+   is a worse failure mode for users who are not working on the
+   generator itself.
+
+3. **Opt-in lets us measure honestly.** We want the answer to "is path
+   3 faster than path 2 on workload X" to be a clean A/B comparison
+   with no confounders. That is easier to set up when path 3 is
+   something the benchmark explicitly requests, not something that
+   happens silently when the generator feels like it.
+
+The default should flip to `functions` only when:
+- Path 3 passes every correctness test path 2 passes, on every
+  benchmark in `examples/benchmark/` relevant to the Haskell target.
+- Path 3 is faster than path 2 on the `effective_distance` 10k
+  benchmark by at least 1.5× median total_ms.
+- At least one externally-reported workload has used path 3 in
+  `mixed(HotPreds)` mode without filing a correctness bug.
+
+Until then, users who want path 3 ask for it explicitly.
+
+## What path 3 must preserve from path 2
+
+The WAM-lowered emitter is allowed to be a different code generator, but
+it is **not** allowed to be a different execution model. Specifically:
+
+- **Persistent data structures stay.** `wsBindings`, `wsTrail`, `wsCPs`,
+  `wsStack` remain `IntMap`/list of persistent snapshots. A lowered
+  predicate allocates new `WamState` records exactly when the interpreter
+  would — the win comes from GHC seeing the updates inline, not from
+  switching to mutation. The `IORef`/`STRef` rejection in
+  `WAM_HASKELL_PERF_PHILOSOPHY.md` applies with equal force here.
+- **Choice points snapshot the same fields.** A lowered `TryMeElse`
+  still builds a `ChoicePoint` with the same bindings/trail/heap
+  lengths. The emitter may inline the construction, but the shape of
+  the snapshot must match what the interpreter would have built, so
+  that a backtrack crossing a path-2→path-3 boundary is safe.
+- **`WamContext` stays read-only.** Lowered predicates take `WamContext`
+  as an argument and never modify it. The hot/cold split the interpreter
+  relies on holds for lowered code too.
+- **FFI hooks (`executeForeign`, `callIndexedFact2`) still apply.** A
+  lowered predicate encountering what would have been `Call "cat_anc/4"`
+  in the interpreter emits a direct Haskell call into the same
+  `executeForeign` / `callIndexedFact2` helpers. The lowered code and
+  the interpreter share those helpers verbatim.
+- **Mixed mode must round-trip.** A lowered predicate calling an
+  interpreted predicate (or vice versa) must produce the same final
+  `WamState` as if both were interpreted. This is the one correctness
+  invariant that makes `mixed(HotPreds)` viable. If it doesn't hold,
+  the only shipping configurations are "all interpreted" or "all
+  lowered," and that halves the value of the path.
+
+## What path 3 is *not* trying to do
+
+- **Not trying to beat native lowering (path 1)** on predicates that
+  path 1 already handles. Path 1 wins by skipping the WAM entirely and
+  handing GHC a clean functional program. Path 3 is a specialization of
+  WAM semantics, so it will always carry slightly more baggage than
+  path 1 (unboxed register tracking, CP machinery, explicit trail/heap
+  state). If path 1 can lower a predicate, let it.
+- **Not trying to JIT.** GHC does the optimization at ahead-of-time
+  compile time. The emitter's job is to produce Haskell GHC will compile
+  well, not to produce machine code or use GHC's internal APIs.
+- **Not trying to replace the WAM IR.** The WAM IR is the input to this
+  generator, and it is the same IR the other WAM-based targets
+  (`wam_rust_target.pl`, `wam_c_target.pl`, etc.) consume. Changes to
+  the IR have to justify themselves at that level, not inside this
+  emitter.
+- **Not trying to unify with path 1.** The two have different input
+  shapes (Prolog AST vs WAM IR), different intermediate analyses, and
+  different failure modes. They stay distinct.
+
+## Summary
+
+| Idea | Status | Reason |
+|---|---|---|
+| Three-path taxonomy (native / interpreted / lowered) | **New** | Each path wins for a different reason |
+| Interpreter stays as reference implementation | **Required** | Ground-truth oracle, cold-predicate fallback |
+| Default is `emit_mode(interpreter)` | **Initial** | Proven path, better failure modes, clean A/B |
+| Lowered code shares persistent data structures | **Required** | Same backtracking model as interpreter |
+| Lowered code shares FFI/indexed-facts helpers | **Required** | One set of escape hatches |
+| Mixed mode (`mixed(HotPreds)`) | **Required** | Lets users specialize only what matters |
+| Flip default to `functions` eventually | **Conditional** | Only after correctness + ≥1.5× speedup + external validation |
+| Replace the interpreter | **Rejected** | Destroys the oracle and the fallback |
+| Replace native lowering | **Rejected** | Different input, different wins |
+| IORef/mutation in lowered code | **Rejected** | Same reason as in the interpreter |

--- a/docs/design/WAM_HASKELL_LOWERED_SPECIFICATION.md
+++ b/docs/design/WAM_HASKELL_LOWERED_SPECIFICATION.md
@@ -1,0 +1,358 @@
+# WAM-Lowered Haskell: Specification
+
+> **Background.** Before reading this spec, read
+> [`WAM_HASKELL_LOWERED_BACKGROUND.md`](WAM_HASKELL_LOWERED_BACKGROUND.md)
+> for the concrete shape of the existing Haskell code-generation paths and
+> the precise meaning of "hybrid WAM with/without FFI." This document refers
+> to path 1 / path 2 / path 3 as defined there. For the rationale, see
+> [`WAM_HASKELL_LOWERED_PHILOSOPHY.md`](WAM_HASKELL_LOWERED_PHILOSOPHY.md).
+
+## Scope
+
+This document specifies the **WAM-lowered Haskell** code-generation path
+(path 3 in `WAM_HASKELL_LOWERED_PHILOSOPHY.md`). It defines:
+
+1. The selector mechanism and how the generator picks between paths 2
+   and 3 per project and per predicate.
+2. The shape of emitted Haskell code for each WAM instruction.
+3. How lowered code interoperates with the existing interpreter, the
+   FFI (`executeForeign`), and indexed-fact dispatch (`callIndexedFact2`).
+4. What the generator is required to handle, what it is allowed to
+   punt on (fall back to the interpreter), and how the fallback is
+   signalled.
+
+Out of scope: the native Haskell lowering path (`haskell_target.pl`),
+the Rust/C/LLVM/etc. WAM targets, and anything upstream of the WAM IR.
+
+## 1. Selector mechanism
+
+### 1.1 `emit_mode/1` option
+
+`write_wam_haskell_project/3` takes a new option:
+
+```prolog
+emit_mode(interpreter).                % all predicates via path 2 (default)
+emit_mode(functions).                  % all predicates via path 3
+emit_mode(mixed([Pred1/A1, ...])).     % named preds via path 3, rest via path 2
+```
+
+The selector hierarchy, checked in order:
+
+1. **Option on the call** — `emit_mode(X)` in the `Options` list passed
+   to `write_wam_haskell_project/3`.
+2. **User-asserted fact** — `user:wam_haskell_emit_mode/1` if defined.
+3. **Generator default** — `interpreter`.
+
+### 1.2 Per-predicate fallback
+
+Inside `mixed([...])` and `functions` modes, the generator evaluates each
+predicate listed (or all predicates, for `functions`) against a
+*lowering feasibility* check. The check is implemented as a Prolog
+predicate:
+
+```prolog
+wam_haskell_lowerable(+PredIndicator, +WamCode, -Reason)
+```
+
+It succeeds when every instruction in `WamCode` appears in the
+supported-instruction set (§2). On failure, `Reason` is a human-readable
+string, the generator logs the predicate to `stderr` as
+`[WAM-Haskell-Lowered] skipping Pred/Arity: Reason`, and the predicate
+is compiled via path 2 into the same project. One project may therefore
+contain a mix of interpreted and lowered predicates even in non-`mixed`
+modes, as a result of automatic fallback.
+
+### 1.3 Shared interpreter
+
+If **any** predicate falls back to the interpreter — because the user
+requested `interpreter`, because they used `mixed`, or because
+`wam_haskell_lowerable/3` failed on a listed predicate — the emitted
+project still includes `WamRuntime.hs`, `WamTypes.hs`, and a shared
+`Predicates.hs` with the instruction array for the interpreted
+predicates. Lowered predicates live in a new module `Lowered.hs` that
+imports both.
+
+If **no** predicate is interpreted, `Predicates.hs` is still emitted
+(empty instruction array, empty label map) so `Main.hs` and
+`WamRuntime.hs` compile unchanged. This is easier than conditionally
+removing the imports.
+
+## 2. Emitted code shape
+
+### 2.1 Per-predicate function signature
+
+Each lowered predicate emits a Haskell function of type:
+
+```haskell
+lowered_<pred>_<arity> :: WamContext -> WamState -> Maybe WamState
+```
+
+The body is a `do`-less pure expression — a chain of pattern-matches and
+`let`-bindings mirroring the instruction sequence. It returns
+`Just finalState` on success, `Nothing` on unification failure (which
+the caller then routes through `backtrack`).
+
+A manifest `Map.Map String (WamContext -> WamState -> Maybe WamState)`
+is emitted in `Lowered.hs`:
+
+```haskell
+loweredPredicates :: Map.Map String (WamContext -> WamState -> Maybe WamState)
+loweredPredicates = Map.fromList
+  [ ("category_ancestor/4", lowered_category_ancestor_4)
+  , ("power_sum_bound/4",   lowered_power_sum_bound_4)
+  ]
+```
+
+`WamRuntime.hs`'s `step` function gains a new case at the top of the
+`Call` dispatch (before `executeForeign`):
+
+```haskell
+step !ctx s (Call pred _arity) =
+  let sc = s { wsCP = wsPC s + 1 }
+  in case Map.lookup pred (wcLoweredPredicates ctx) of
+    Just fn -> fn ctx sc
+    Nothing -> case executeForeign ctx pred sc of
+      ...  -- unchanged
+```
+
+`WamContext` gains a new cold field `wcLoweredPredicates :: Map.Map String (WamContext -> WamState -> Maybe WamState)`
+populated from `Lowered.loweredPredicates` at startup in `Main.hs`.
+
+This gives us the full interop invariant from the philosophy doc: a
+lowered predicate can call an interpreted predicate via the normal
+interpreter loop, and an interpreted predicate can call a lowered
+predicate via `Map.lookup` at the `Call` dispatch point.
+
+### 2.2 Instruction → Haskell mapping
+
+The generator walks the WAM instruction sequence for a predicate once
+and emits straight-line Haskell. A numeric "PC label" is emitted as a
+Haskell `let ... in` boundary when there is an incoming branch target
+(the predicate's entry, or a `TryMeElse` alternate, or similar). At
+each label the emitter starts a new continuation.
+
+| WAM instruction | Emitted Haskell (sketch) |
+|---|---|
+| `GetConstant c r` | `case IM.lookup r (wsRegs s0) of { Just (Atom c') \| c' == c -> ...; Just (Unbound v) -> let s1 = s0 { wsBindings = IM.insert v (Atom c) (wsBindings s0), wsTrail = TrailEntry v (IM.lookup v (wsBindings s0)) : wsTrail s0, wsTrailLen = wsTrailLen s0 + 1 } in ...; _ -> Nothing }` |
+| `GetVariable r1 r2` | `let v = derefVar (wsBindings s0) (fromMaybe (Atom "") (IM.lookup r2 (wsRegs s0))); s1 = s0 { wsRegs = IM.insert r1 v (wsRegs s0) } in ...` |
+| `PutConstant c r` | `let s1 = s0 { wsRegs = IM.insert r (Atom c) (wsRegs s0) } in ...` |
+| `PutStructure f/n r` | Same as interpreter, inlined. Uses the compile-time arity specialization already in place. |
+| `CallResolved pc arity` | Lookup target: if it is also lowered, direct Haskell function call; otherwise `let s1 = s0 { wsPC = pc, wsCP = wsPC s0 + 1 } in run ctx s1`. See §2.3. |
+| `Call pred arity` | Same cross-path dispatch: check `wcLoweredPredicates`, then `executeForeign`, then `callIndexedFact2`, then label lookup. Matches interpreter fallback order. |
+| `TryMeElse label` | Emit `ChoicePoint` construction inline, push onto `wsCPs`. The `cpNextPC` is the interpreter PC of `label` (computed at generation time). If the alternate clause is ALSO in a lowered function, we still record the PC — backtrack goes through the interpreter's `backtrack` helper. See §2.4. |
+| `TrustMe` / `RetryMeElse` | Pop/replace top CP. Same as interpreter. |
+| `Proceed` | `let ret = wsCP s0 in if ret == 0 then Just (s0 { wsPC = 0 }) else Just (s0 { wsPC = ret, wsCP = 0 })` — and then yield the state to whichever caller. For the entry function we return `Just s0` with `wsPC` set correctly; interop contract is in §2.4. |
+| `Allocate` / `Deallocate` | Exactly the same as interpreter, inlined. |
+| `BuiltinCall "is/2" _` | Direct call into a shared helper that the interpreter also uses. No duplication. |
+| `BuiltinCall "!/0" _` | Set `wsCPsLen`/`wsCPs` truncation inline. Same shape as interpreter. |
+| `SwitchOnConstant disp` | Emit a `case` on the current argument against the dispatch map. The map is emitted as a Haskell `case` expression if it's small (≤ 32 entries) or as a `Map.lookup` otherwise. The WAM-Haskell interpreter currently keeps this as a `HashMap` lookup; lowered code may inline for small dispatch tables. |
+
+The emitter never *interprets* an instruction. Every instruction either
+emits Haskell that does the same thing inline, or the predicate fails
+the lowerability check and is punted to the interpreter.
+
+### 2.3 Intra-predicate vs inter-predicate calls
+
+When a lowered predicate's body contains a call to **itself** or to
+**another lowered predicate in the same module**, the emitter produces
+a direct Haskell function call. This is the case where GHC can inline
+across predicate boundaries and where the largest wins are expected.
+
+When the target is an **interpreted** predicate, the emitter produces:
+
+```haskell
+let s1 = s0 { wsPC = <targetPC>, wsCP = wsPC s0 + 1 }
+in run ctx s1
+```
+
+That is, it sets the PC to the interpreted target and re-enters the
+interpreter's `run` loop. On return, control comes back to the lowered
+function. This is the interop bridge in one direction.
+
+The other direction — interpreted code calling a lowered predicate —
+uses the `wcLoweredPredicates` map lookup described in §2.1.
+
+### 2.4 Backtracking across paths
+
+A `ChoicePoint` snapshot doesn't care which path installed it. It
+records `cpNextPC`, `cpRegs`, `cpBindings`, `cpTrail*`, `cpHeap*`,
+`cpStack`, `cpCP`, `cpCutBar`, and optionally `cpAggFrame`/`cpBuiltin`.
+On backtrack, the interpreter's `backtrack` function restores the
+state and jumps to `cpNextPC`.
+
+For this to work across paths:
+
+- A lowered predicate that installs a CP records `cpNextPC` as the
+  **interpreter PC** of the alternate clause. Always. Even if the
+  alternate is in the same lowered predicate. The reason is uniformity:
+  `backtrack` jumps to `wsPC = cpNextPC` and then the dispatch at the
+  top of `step` picks up. If `cpNextPC` points inside a predicate whose
+  entry is lowered, the dispatch finds it via `wcLoweredPredicates`;
+  otherwise the instruction array gets hit.
+- A lowered predicate that is *entered* on backtrack from an
+  interpreted predicate sees `wsPC` pointing to its alternate-clause
+  interpreter PC. The lowered function must therefore accept a
+  `wsPC`-indexed entry and jump into the correct clause body. In
+  practice this means the function dispatches on `wsPC` at the top:
+
+  ```haskell
+  lowered_category_ancestor_4 !ctx !s = case wsPC s of
+    5  -> entry_clause_1 ctx s   -- primary entry
+    20 -> entry_clause_2 ctx s   -- TryMeElse alternate
+    _  -> Nothing  -- should not happen
+  ```
+
+  The `case` is bounded by the number of label entries the generator
+  produced for this predicate, so it's a small constant.
+
+This is the non-trivial interop cost. It is also the thing that keeps
+the backtracking invariant across the path boundary. There is no
+shortcut: if we tried to optimize it away by having lowered code hold
+its own private CP representation, interpreted code could not backtrack
+into it.
+
+### 2.5 Aggregation and cut
+
+- **Aggregation frames** (`AggPush`/`AggPop`/`AggEmit`) are the same
+  persistent stack as the interpreter. Lowered code manipulates it
+  inline but the representation is shared.
+- **Cut** (`!/0`) truncates `wsCPs` and `wsCPsLen` the same way the
+  interpreter does, using `wsCutBar` as the barrier. Lowered code sees
+  `wsCutBar` set by `Allocate` exactly as the interpreter does.
+
+## 3. Generator structure
+
+### 3.1 New module layout
+
+```
+src/unifyweaver/targets/
+    wam_haskell_target.pl            -- existing, gains emit_mode/mixed dispatch
+    wam_haskell_lowered_emitter.pl   -- new, per-instruction Haskell emission
+```
+
+The new module exports:
+
+- `lower_predicate_to_haskell(+PredIndicator, +WamCode, +Options, -HaskellCode)`
+- `wam_haskell_lowerable(+PredIndicator, +WamCode, -Reason)`
+
+`write_wam_haskell_project/3` in `wam_haskell_target.pl` gains logic that
+partitions the input predicate list into (InterpretedList, LoweredList)
+based on the selector hierarchy and the lowerability check, then:
+
+- Calls the existing `compile_predicates_to_haskell/3` on the interpreted
+  partition, producing the usual `Predicates.hs`.
+- Calls `lower_predicate_to_haskell/4` on each predicate in the lowered
+  partition, then concatenates the results into `Lowered.hs`.
+- Adjusts `Main.hs` to populate `wcLoweredPredicates` from
+  `Lowered.loweredPredicates`.
+- Adjusts `WamRuntime.hs` (the template string in the generator) to
+  check `wcLoweredPredicates` first in the `Call` dispatch chain.
+
+### 3.2 Lowerability check
+
+The initial implementation of `wam_haskell_lowerable/3` whitelists these
+instructions:
+
+```
+GetConstant, GetVariable, GetValue, GetStructure,
+PutConstant, PutVariable, PutValue, PutStructure,
+CallResolved, Call, Proceed,
+Allocate, Deallocate,
+TryMeElse, RetryMeElse, TrustMe,
+BuiltinCall "is/2", BuiltinCall "!/0", BuiltinCall "\\+/1",
+BuiltinCall "length/2", BuiltinCall "member/2", BuiltinCall "</2", BuiltinCall ">/2",
+SwitchOnConstant
+```
+
+Any other instruction causes `wam_haskell_lowerable/3` to fail with a
+reason like `"unsupported instruction: PutStructureDyn"`. Future
+expansions add entries to this whitelist.
+
+Aggregation instructions (`AggPush`, `AggPop`, `AggEmit`) are *not* in
+the initial whitelist. They land in a follow-up that has the
+aggregation shape figured out.
+
+## 4. Testing and correctness strategy
+
+### 4.1 Oracle: the interpreter
+
+Every lowered predicate must produce the same `wsBindings`, `wsTrail`,
+`wsCPs`, and `wsRegs` state on every solution as the interpreter does
+on the same inputs. The test harness runs each predicate twice — once
+interpreted, once lowered — and compares the full solution stream via
+the same solution-extraction helper (`collectSolutions`).
+
+This is the *only* source of truth. If the two disagree, the lowered
+emitter is wrong.
+
+### 4.2 Benchmark parity
+
+- `examples/benchmark/benchmark_effective_distance.py` gains a
+  `wam_haskell_lowered` target alongside `wam_haskell`.
+- Both targets run on the same 10k dataset.
+- Rows must be byte-for-byte identical (same sort order, same number
+  of digits).
+
+### 4.3 Incremental landing
+
+Ship the generator behind a feature flag at first. Specifically:
+
+1. Phase A: `emit_mode(interpreter)` remains the default and is the
+   only mode tests use. The `wam_haskell_lowered_emitter.pl` module
+   exists but is only exercised by a single dedicated test
+   (`tests/test_wam_haskell_lowered.pl`) that lowers one simple
+   predicate and verifies it agrees with the interpreter.
+2. Phase B: `emit_mode(functions)` becomes testable in the benchmark
+   harness but not the default. Correctness tests run both modes.
+3. Phase C: `mixed(HotPreds)` becomes usable. The default stays
+   `interpreter`.
+4. Phase D: after the default-flip criteria in the philosophy doc are
+   met, `emit_mode/1` default changes to `functions` and the
+   benchmark harness' `wam_haskell` target switches over. The
+   `interpreter` mode stays available for fallback.
+
+## 5. Out of scope for the initial landing
+
+- **Aggregation in lowered code.** `AggPush`/`AggPop`/`AggEmit` stay
+  interpreted-only until there is a dedicated follow-up with the
+  aggregation frame semantics worked out.
+- **`PutStructureDyn`** (runtime-parsed functors). Tracked as a
+  separate task in the existing todo list.
+- **Cross-target lowering (Rust, C, etc.).** This spec is about
+  Haskell. The lowerability check and instruction-to-Haskell map are
+  Haskell-specific.
+- **Per-call-site inlining analysis.** The initial version is "whole
+  predicate is lowered or whole predicate is interpreted." A future
+  version could inline individual calls, but that is a separate
+  design question about GHC inlining budget and inter-module
+  optimization.
+- **Profile-guided selection of `HotPreds`.** The user picks the
+  list. An auto-selector based on profile data is a nice-to-have
+  for a later phase.
+
+## 6. Success criteria
+
+The initial landing is considered complete when:
+
+1. `emit_mode(functions)` can compile and run the
+   `effective_distance` 10k benchmark end-to-end with output
+   byte-identical to `emit_mode(interpreter)`.
+2. `emit_mode(mixed([category_ancestor/4]))` produces a working
+   project where `category_ancestor/4` is lowered and the rest of
+   the predicates are interpreted, and the result is byte-identical
+   to both other modes.
+3. Backtracking and cut round-trip correctly across a lowered ↔
+   interpreted boundary, demonstrated by a dedicated test that
+   calls both directions.
+4. The lowerability check correctly identifies at least one
+   predicate that cannot be lowered (e.g., one using aggregation)
+   and falls back to the interpreter without user intervention.
+5. A benchmark number — even a slower one — exists. We do not ship
+   a "we think this is faster" claim without a measurement. If the
+   initial landing is slower than the interpreter on the 10k
+   benchmark, that is acceptable but must be documented and
+   tracked.
+
+Performance parity (or improvement) over the interpreter is explicitly
+**not** part of the initial landing. Correctness and the interop
+contract are.


### PR DESCRIPTION
  ## Summary

  - Introduces the design docs for a **third Haskell code-generation path** in UnifyWeaver: compile the WAM IR to **one
  Haskell function per predicate** (straight-line Haskell that mirrors the WAM instruction sequence), alongside the existing
  native lowering (`haskell_target.pl`) and WAM-interpreter (`wam_haskell_target.pl`) paths.
  - Docs only — no code changes. The new path is not implemented yet; implementation will land on a follow-up
  `feat/wam-haskell-lowered` branch following the phased plan in the implementation doc.
  - The new path will ship behind a selector (`emit_mode(interpreter|functions|mixed([...]))`) with `interpreter` as the
  default, so existing users of `write_wam_haskell_project/3` see no behavior change.

  ## What's in the commit

  Four new files under `docs/design/`:

  | File | Role |
  |---|---|
  | `WAM_HASKELL_LOWERED_BACKGROUND.md` | Descriptive tour of the *current* Haskell code-gen paths with exact source-line
  references. Pins down what "hybrid WAM with/without FFI" means at the code level (narrower than it sounds —
  `callIndexedFact2` is a separate feature, not part of the FFI axis). Read first if you're new to the area. |
  | `WAM_HASKELL_LOWERED_PHILOSOPHY.md` | *Why* the third path exists, why it's additive (not a replacement) to the existing
  two paths, why the interpreter stays as the reference oracle, and rejected alternatives. |
  | `WAM_HASKELL_LOWERED_SPECIFICATION.md` | *What* the emitter must produce: `emit_mode/1` selector hierarchy,
  per-instruction → Haskell mapping, the `cpNextPC`-as-interpreter-PC invariant for cross-path backtracking, the `case wsPC s
   of ...` entry dispatch, the new `Lowered.hs` module layout, and success criteria. |
  | `WAM_HASKELL_LOWERED_IMPLEMENTATION_PLAN.md` | Phased step-by-step plan: selector plumbing → empty `Lowered.hs` skeleton
  → first lowered predicate (`max_depth/1`) → register/control instructions → choice points and backtracking → builtins →
  `SwitchOnConstant` → benchmark → mixed-mode → (deferred, conditional) flip the default. |

  ## The three paths (taxonomy recap)

  1. **Direct native Haskell lowering** (`haskell_target.pl`) — Prolog AST → straight-line Haskell functions. No WAM at all.
  Only fires for predicates the lowering analysis can statically reason about.
  2. **WAM-interpreted Haskell** (`wam_haskell_target.pl`, current production path) — Prolog → WAM IR → Haskell
  `[Instruction]` array + `step`/`run` dispatch loop. Has a runtime dispatch chain at `Call` (`CallResolved` fast path,
  `executeForeign` escape hatch, `callIndexedFact2` indexed-fact dispatch, label lookup fallback).
  3. **WAM-lowered Haskell functions** (this design, new) — Prolog → WAM IR → one Haskell function per predicate, no
  instruction array, no interpreter loop. Shares `WamState`/`WamContext`/FFI/indexed-fact helpers with path 2 so backtracking
   and cut round-trip across the path boundary.

  Mental model: **path 3 is "path 2 specialized per predicate at generator time."** The interpreter stays as the ground-truth
   oracle, the cold-predicate fallback, and the thing correctness tests diff against.

  ## Default and selector

  - **Selector hierarchy** (checked in order): `emit_mode/1` option on `write_wam_haskell_project/3` →
  `user:wam_haskell_emit_mode/1` dynamic fact → generator default.
  - **Generator default**: `interpreter`. Rationale in the philosophy doc §"The selector, and why it defaults to interpreted"
   — proven path, better failure modes, and a clean A/B for honest measurement.
  - **Default flip** to `functions` is conditional on: correctness parity with the interpreter on every checked-in benchmark,
   ≥1.5× median total_ms speedup on the `effective_distance` 10k benchmark, and at least one externally-reported workload
  using `mixed(HotPreds)` without a correctness bug.

  ## Out of scope for this PR

  - No implementation. The new emitter file (`wam_haskell_lowered_emitter.pl`) does not exist yet.
  - No changes to `wam_haskell_target.pl`, `haskell_target.pl`, `wam_target.pl`, or any runtime code.
  - No changes to benchmarks, tests, or CI.
  - The in-flight FFI accumulator fix on `feat/wam-haskell-ffi-optimization` is **not** part of this commit and remains in
  the working tree for a separate PR.

  ## Test plan

  Docs-only PR — no tests to run. Review checklist:

  - [ ] Philosophy doc's rejected-alternatives table matches the existing `WAM_HASKELL_PERF_PHILOSOPHY.md` rejection
  reasoning (IORef etc.).
  - [ ] Specification doc's per-instruction mapping covers every instruction in the current `wam_instr_to_haskell/2`
  whitelist, or explicitly defers the missing ones.
  - [ ] Implementation plan's Phase 0 prerequisites are achievable against the current branch state.
  - [ ] Background doc's code references (line numbers in `wam_haskell_target.pl`) still resolve on the tip of this branch.
  - [ ] The cross-path backtracking invariant in spec §2.4 is internally consistent — a `TryMeElse` installed by lowered code
   and re-entered via `backtrack` lands in the right clause body regardless of which path the alternate lives in.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)