### PR TITLE
fix(rust): fail unsupported pipeline stages explicitly

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -9210,7 +9210,8 @@ extract_rust_pred_name(Name/_Arity, NameStr) :-
 
 %% generate_rust_stage_functions(+Predicates, -Code)
 %  Generate pipeline stage implementations when a predicate matches a
-%  supported lowering shape, otherwise fall back to a placeholder.
+%  supported lowering shape, otherwise emit an explicit unsupported-stage
+%  failure so generated pipelines do not silently pass data through.
 generate_rust_stage_functions([], "").
 generate_rust_stage_functions([PredIndicator|Rest], Code) :-
     generate_rust_stage_function(PredIndicator, StageCode),
@@ -9224,11 +9225,11 @@ generate_rust_stage_function(PredIndicator, StageCode) :-
     ;   format(string(StageCode),
 "/// Stage: ~w
 fn stage_~w(input: Vec<HashMap<String, Value>>) -> Vec<HashMap<String, Value>> {
-    // TODO: Implement stage logic
-    input
+    let _ = input;
+    panic!(\"unsupported Rust pipeline stage: ~w\");
 }
 
-", [Name, Name])
+", [Name, Name, Name])
     ).
 
 rust_pipeline_stage_code(PredIndicator, Name, StageCode) :-
@@ -11534,11 +11535,11 @@ generate_rust_single_enhanced_stage(Pred/Arity, Code) :-
     format(string(Code),
 "/// Pipeline stage: ~w/~w
 fn ~w(input: &[Record]) -> Vec<Record> {
-    // TODO: Implement based on predicate bindings
-    input.to_vec()
+    let _ = input;
+    panic!(\"unsupported Rust enhanced pipeline stage: ~w/~w\");
 }
 
-", [Pred, Arity, Pred]).
+", [Pred, Arity, Pred, Pred, Arity]).
 generate_rust_single_enhanced_stage(_, "").
 
 %% generate_rust_enhanced_connector(+Stages, +PipelineName, -Code)

--- a/tests/core/test_rust_pipeline_stage_placeholders.pl
+++ b/tests/core/test_rust_pipeline_stage_placeholders.pl
@@ -1,0 +1,23 @@
+:- module(test_rust_pipeline_stage_placeholders, [test_rust_pipeline_stage_placeholders/0]).
+
+:- use_module(library(plunit)).
+:- use_module('../../src/unifyweaver/targets/rust_target').
+
+:- begin_tests(rust_pipeline_stage_placeholders).
+
+test(unsupported_standard_stage_fails_explicitly) :-
+    once(compile_rust_pipeline([unknown_stage/1], [pipeline_mode(generator)], Code)),
+    once(sub_string(Code, _, _, _, 'fn stage_unknown_stage')),
+    \+ sub_string(Code, _, _, _, 'TODO: Implement stage logic'),
+    once(sub_string(Code, _, _, _, 'panic!("unsupported Rust pipeline stage: unknown_stage")')).
+
+test(unsupported_enhanced_stage_fails_explicitly) :-
+    once(compile_rust_enhanced_pipeline([unknown_stage/1], [validate(false)], Code)),
+    once(sub_string(Code, _, _, _, 'fn unknown_stage')),
+    \+ sub_string(Code, _, _, _, 'TODO: Implement based on predicate bindings'),
+    once(sub_string(Code, _, _, _, 'panic!("unsupported Rust enhanced pipeline stage: unknown_stage/1")')).
+
+:- end_tests(rust_pipeline_stage_placeholders).
+
+test_rust_pipeline_stage_placeholders :-
+    run_tests([rust_pipeline_stage_placeholders]).


### PR DESCRIPTION
## Summary

This PR removes silent TODO passthrough behavior from unsupported Rust pipeline stage generation.

- Replaces unsupported standard Rust pipeline stage placeholders with explicit `panic!` failures.
- Replaces unsupported enhanced Rust pipeline predicate-stage placeholders with explicit `panic!` failures.
- Adds focused PlUnit coverage asserting unsupported stages no longer emit TODO placeholders and instead fail with clear generated runtime messages.

## Why

Previously, an unsupported generated Rust stage could silently return its input unchanged with a `TODO` comment. That made generated pipelines look runnable while hiding missing lowering support. This change preserves code generation for unsupported stages, but makes the generated behavior fail loudly and explain which stage is unsupported.

## Validation

- `timeout 120 swipl -q -g test_rust_pipeline_stage_placeholders -t halt tests/core/test_rust_pipeline_stage_placeholders.pl`
- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`
- `git diff --check`

## Note

The existing `test_rust_pipeline_generator` helper still has a stale expectation for `stage_derive_out`; current connector generation emits `new_records.extend(stage_derive(...))`. That is unrelated to this PR and was not changed here.

