### PR TITLE
feat(csharp-query): widen weighted min fast path

### DIFF
--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -14,6 +14,9 @@ Current status:
 - an internal SCC-condensed weighted-min candidate now exists for
   positive-additive `PathAwareAccumulationNode` workloads, with bounded
   measured selection against the existing layered dynamic-programming path
+- the additive fast-path boundary now includes non-negative steps, so
+  zero-cost source weights no longer force the exact visited-state frontier
+  fallback when the additive form is otherwise safe and depth-bounded
 - on the current positive-additive benchmark shape, the measured selector
   rejects SCC condensation because the layered path is still cheaper after
   SCC build/probe overhead
@@ -90,25 +93,28 @@ Deliverable:
 
 ## Phase 3: Strategy Selection
 
-Status: implemented for the positive-additive candidate path with bounded
+Status: implemented for additive non-negative candidate paths with bounded
 measured probes.
 
 Add a runtime applicability check:
 
 - use SCC-condensed strategy when safe and the bounded probe beats the
-  layered positive-min path by a margin
+  layered additive-min path by a margin
 - otherwise fall back to current exact frontier
 
 Current selection boundary:
 
-- use the layered dynamic-programming fast path for strictly positive
-  additive `min` unless the SCC-condensed measured probe wins
+- strictly positive additive `Min` keeps the existing positive layered/SCC
+  measured path
+- non-negative additive `Min` now uses the same depth-bounded layered/SCC
+  measured candidate and reports separate non-negative trace labels
 - use the exact frontier fallback otherwise
 
 Next selection work:
 
-- determine where SCC-condensed evaluation can replace the non-positive
-  frontier fallback safely
+- determine whether any remaining non-additive or negative-step frontier
+  fallback shapes can be summarized safely without losing exact simple-path
+  semantics
 
 Deliverable:
 
@@ -207,7 +213,7 @@ That step is now complete.
 
 The next coding step should be:
 
-1. identify weighted `Min` recurrence shapes not covered by the current
-   positive-additive fast path
-2. prototype SCC-condensed evaluation for one of those broader cases
+1. identify weighted `Min` recurrence shapes still not covered by the current
+   non-negative additive fast path
+2. prototype a safe summarized evaluation for one of those broader cases
 3. benchmark it against the exact frontier fallback

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -933,6 +933,10 @@ python examples/benchmark/benchmark_weighted_shortest_path.py \
     --scales 300,1k,5k,10k --repetitions 1
 ```
 
+Use `--weight-mode nonnegative-zero` to keep degree-one source weights at zero
+and exercise the broader non-negative additive `Min` path that would otherwise
+fall back to the exact visited-state frontier.
+
 Latest local results:
 
 | Scale | All | Min | Speedup | Output Match |
@@ -956,10 +960,13 @@ small and localized, which is favorable for future SCC-condensed
 strategies on broader weighted `Min` workloads.
 
 The runtime now also exposes SCC-condensed weighted-min planning through
-trace metrics. For positive-additive `Min`, SCC condensation is a measured
-candidate rather than an unconditional replacement for the layered dynamic
-programming path. Current trace output includes `phase_scc_condense_graph_ms`,
-`phase_scc_probe_condensed_ms`, `phase_scc_probe_positive_layered_ms`,
+trace metrics. For additive `Min`, SCC condensation is a measured candidate
+rather than an unconditional replacement for the layered dynamic programming
+path. Strictly positive steps keep the `phase_scc_probe_positive_layered_ms`
+trace label, while zero-cost non-negative steps report
+`phase_scc_probe_nonnegative_layered_ms` and
+`phase_nonnegative_min_layered_solve_ms`. Current trace output also includes
+`phase_scc_condense_graph_ms`, `phase_scc_probe_condensed_ms`,
 `metric_scc_count`, `metric_scc_condensed_edge_count`,
 `metric_scc_probe_local_states_explored`, and
 `metric_scc_probe_outer_dag_states_explored`; on the current benchmark

--- a/examples/benchmark/benchmark_weighted_shortest_path.py
+++ b/examples/benchmark/benchmark_weighted_shortest_path.py
@@ -6,8 +6,10 @@ PathAwareAccumulationNode runtime modes:
   - all : preserve all simple weighted paths
   - min : mode-directed pruning on the accumulator
 
-The harness derives a positive source weight from category out-degree so the
-recursive increment remains monotone and min-pruning is sound.
+By default the harness derives a positive source weight from category out-degree
+so the recursive increment remains monotone and min-pruning is sound. The
+`--weight-mode nonnegative-zero` variant leaves degree-one sources at zero cost
+to exercise the broader non-negative additive `Min` fast path.
 """
 
 from __future__ import annotations
@@ -83,13 +85,14 @@ class Program
 
     static void Main(string[] args)
     {
-        if (args.Length < 3)
+        if (args.Length < 4)
         {
-            Console.Error.WriteLine("Usage: program <all|min> <category_parent.tsv> <article_category.tsv>");
+            Console.Error.WriteLine("Usage: program <all|min> <positive|nonnegative-zero> <category_parent.tsv> <article_category.tsv>");
             Environment.Exit(1);
         }
 
         var modeName = args[0];
+        var weightMode = args[1];
         var mode = modeName switch
         {
             "all" => TableMode.All,
@@ -111,7 +114,7 @@ class Program
         var allNodes = new HashSet<string>(StringComparer.Ordinal);
         var edgeCount = 0;
 
-        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
+        foreach (var (line, i) in File.ReadLines(args[2]).Select((l, i) => (l, i)))
         {
             if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
             {
@@ -148,11 +151,16 @@ class Program
         foreach (var source in sourceNodes)
         {
             outDegree.TryGetValue(source, out var degree);
-            var weight = 1.0 + Math.Log(Math.Max(1, degree), 5.0);
+            var weight = weightMode switch
+            {
+                "positive" => 1.0 + Math.Log(Math.Max(1, degree), 5.0),
+                "nonnegative-zero" => degree <= 1 ? 0.0 : Math.Log(degree, 5.0),
+                _ => throw new ArgumentException($"Unknown weight mode: {weightMode}")
+            };
             provider.AddFact(weightId, source, weight);
         }
 
-        foreach (var (line, i) in File.ReadLines(args[2]).Select((l, i) => (l, i)))
+        foreach (var (line, i) in File.ReadLines(args[3]).Select((l, i) => (l, i)))
         {
             if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
             {
@@ -278,6 +286,7 @@ class Program
         }
 
         Console.Error.WriteLine($"mode={modeName}");
+        Console.Error.WriteLine($"weight_mode={weightMode}");
         Console.Error.WriteLine($"load_ms={swLoad.ElapsedMilliseconds}");
         Console.Error.WriteLine($"query_ms={swQuery.ElapsedMilliseconds}");
         Console.Error.WriteLine($"aggregation_ms={swAgg.ElapsedMilliseconds}");
@@ -428,6 +437,12 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--scales", default="300,1k,5k,10k")
     parser.add_argument("--repetitions", type=int, default=5)
+    parser.add_argument(
+        "--weight-mode",
+        choices=["positive", "nonnegative-zero"],
+        default="positive",
+        help="Use strictly positive source weights or include zero-cost source weights for non-negative Min coverage.",
+    )
     parser.add_argument("--keep-temp", action="store_true")
     return parser.parse_args()
 
@@ -460,7 +475,7 @@ def build_harness(root: Path) -> list[str]:
     return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_weighted_shortest_path.dll")]
 
 
-def benchmark_mode(command: list[str], scale: str, mode: str, repetitions: int) -> RunResult:
+def benchmark_mode(command: list[str], scale: str, mode: str, weight_mode: str, repetitions: int) -> RunResult:
     scale_dir = BENCH_DIR / scale
     edge_path = scale_dir / "category_parent.tsv"
     article_path = scale_dir / "article_category.tsv"
@@ -470,7 +485,7 @@ def benchmark_mode(command: list[str], scale: str, mode: str, repetitions: int) 
     stderr = ""
     for _ in range(repetitions):
         started = time.perf_counter()
-        result = run(command + [mode, str(edge_path), str(article_path)])
+        result = run(command + [mode, weight_mode, str(edge_path), str(article_path)])
         elapsed = time.perf_counter() - started
         times.append(elapsed)
         stdout = result.stdout
@@ -496,8 +511,8 @@ def main() -> int:
         command = build_harness(temp_root)
         results: list[RunResult] = []
         for scale in scales:
-            results.append(benchmark_mode(command, scale, "all", args.repetitions))
-            results.append(benchmark_mode(command, scale, "min", args.repetitions))
+            results.append(benchmark_mode(command, scale, "all", args.weight_mode, args.repetitions))
+            results.append(benchmark_mode(command, scale, "min", args.weight_mode, args.repetitions))
 
         print("scale\tmode\tmedian_s\tmin_s\tmax_s\trows")
         grouped: dict[str, dict[str, RunResult]] = {}

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1605,6 +1605,12 @@ namespace UnifyWeaver.QueryRuntime
         TimeSpan Elapsed,
         SccCondensedWeightedMinStats Stats);
 
+    internal enum AdditiveMinStepSafety
+    {
+        StrictlyPositive,
+        NonNegative
+    }
+
     public sealed class InMemoryRelationProvider : IRetentionAwareRelationProvider
     {
         private readonly Dictionary<PredicateId, List<object[]>> _store = new();
@@ -11180,7 +11186,7 @@ namespace UnifyWeaver.QueryRuntime
                 condensedEdges.Count);
         }
 
-        private static bool ShouldUseSccCondensedPositiveMin(PathAwareSccGraph graph, int maxDepth)
+        private static bool ShouldUseSccCondensedAdditiveMin(PathAwareSccGraph graph, int maxDepth)
         {
             const int MaxCyclicComponentSize = 128;
             return maxDepth > 0 &&
@@ -11190,17 +11196,18 @@ namespace UnifyWeaver.QueryRuntime
 
         private const double SccCondensedProbeWinMargin = 0.50d;
 
-        private static bool ResolveMeasuredSccCondensedPositiveMinStrategy(
+        private static bool ResolveMeasuredSccCondensedAdditiveMinStrategy(
             QueryExecutionTrace? trace,
             PlanNode node,
             string strategyPrefix,
             PathAwareSccGraph graph,
             int maxDepth,
+            string layeredProbePhase,
             IReadOnlyList<object?> orderedSeeds,
             Func<IReadOnlyList<object?>, TimeSpan> measureLayeredProbe,
             Func<IReadOnlyList<object?>, SccCondensedWeightedMinProbe> measureSccProbe)
         {
-            if (!ShouldUseSccCondensedPositiveMin(graph, maxDepth))
+            if (!ShouldUseSccCondensedAdditiveMin(graph, maxDepth))
             {
                 trace?.RecordStrategy(node, $"{strategyPrefix}SccCondensedRejectedStructural");
                 return false;
@@ -11215,7 +11222,7 @@ namespace UnifyWeaver.QueryRuntime
             var sampleSeedCount = Math.Min(orderedSeeds.Count, 16);
             var sampleSeeds = orderedSeeds.Take(sampleSeedCount).ToList();
             var layeredProbe = measureLayeredProbe(sampleSeeds);
-            trace?.RecordPhase(node, "scc_probe_positive_layered", layeredProbe);
+            trace?.RecordPhase(node, layeredProbePhase, layeredProbe);
             var sccProbe = measureSccProbe(sampleSeeds);
             trace?.RecordPhase(node, "scc_probe_condensed", sccProbe.Elapsed);
             trace?.RecordMetric(node, "scc_probe_local_states_explored", sccProbe.Stats.LocalStatesExplored);
@@ -11234,6 +11241,21 @@ namespace UnifyWeaver.QueryRuntime
                 : $"{strategyPrefix}SccCondensedRejectedMeasured");
             return useScc;
         }
+
+        private static string GetAdditiveMinLayeredStrategy(string strategyPrefix, AdditiveMinStepSafety stepSafety) =>
+            stepSafety == AdditiveMinStepSafety.StrictlyPositive
+                ? $"{strategyPrefix}PositiveAdditiveLayered"
+                : $"{strategyPrefix}NonNegativeAdditiveLayered";
+
+        private static string GetAdditiveMinLayeredProbePhase(AdditiveMinStepSafety stepSafety) =>
+            stepSafety == AdditiveMinStepSafety.StrictlyPositive
+                ? "scc_probe_positive_layered"
+                : "scc_probe_nonnegative_layered";
+
+        private static string GetAdditiveMinLayeredSolvePhase(AdditiveMinStepSafety stepSafety) =>
+            stepSafety == AdditiveMinStepSafety.StrictlyPositive
+                ? "positive_min_layered_solve"
+                : "nonnegative_min_layered_solve";
 
         private static void RecordPathAwareSccGraphMetrics(QueryExecutionTrace? trace, PlanNode node, PathAwareSccGraph graph)
         {
@@ -11683,34 +11705,43 @@ namespace UnifyWeaver.QueryRuntime
 
                 Dictionary<object, List<object[]>>? auxIndex = null;
                 PositiveStepEvaluator? stepEvaluator = null;
+                var additiveMinStepSafety = AdditiveMinStepSafety.StrictlyPositive;
                 PathAwareSccGraph? sccGraph = null;
                 var directSeedValue = Convert.ToDouble(closure.DirectSeedValue, CultureInfo.InvariantCulture);
-                var positiveFastPathPrepared = false;
-                var usePositiveMinFastPath = false;
+                var additiveFastPathPrepared = false;
+                var useAdditiveMinFastPath = false;
                 var useSccCondensedMinFastPath = false;
 
-                void EnsurePositiveMinFastPathPrepared()
+                void EnsureAdditiveMinFastPathPrepared()
                 {
-                    if (positiveFastPathPrepared)
+                    if (additiveFastPathPrepared)
                     {
                         return;
                     }
 
-                    positiveFastPathPrepared = true;
+                    additiveFastPathPrepared = true;
                     var auxRows = MeasurePhase(trace, closure, "load_auxiliary", () => GetClosureFactsList(closure.AuxiliaryRelation, ClosureRelationAccessKind.Support, context, closure));
                     auxIndex = MeasurePhase(trace, closure, "build_auxiliary_index", () => GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context));
-                    usePositiveMinFastPath = closure.MaxDepth > 0 &&
-                        TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, closure.PositiveStepProven, out stepEvaluator);
-                    if (usePositiveMinFastPath)
+                    useAdditiveMinFastPath = closure.MaxDepth > 0 &&
+                        TryCreateNonNegativeAdditiveStepEvaluator(
+                            closure.BaseExpression,
+                            closure.RecursiveExpression,
+                            succIndex,
+                            auxIndex,
+                            closure.PositiveStepProven,
+                            out stepEvaluator,
+                            out additiveMinStepSafety);
+                    if (useAdditiveMinFastPath)
                     {
                         sccGraph = MeasurePhase(trace, closure, "scc_condense_graph", () => BuildPathAwareSccGraph(succIndex));
                         RecordPathAwareSccGraphMetrics(trace, closure, sccGraph);
-                        useSccCondensedMinFastPath = ResolveMeasuredSccCondensedPositiveMinStrategy(
+                        useSccCondensedMinFastPath = ResolveMeasuredSccCondensedAdditiveMinStrategy(
                             trace,
                             closure,
                             "SeedGroupedPathAwareAccumulationMin",
                             sccGraph,
                             closure.MaxDepth,
+                            GetAdditiveMinLayeredProbePhase(additiveMinStepSafety),
                             orderedUniqueSeeds,
                             sampleSeeds => MeasureElapsed(() =>
                             {
@@ -11759,8 +11790,8 @@ namespace UnifyWeaver.QueryRuntime
 
                 Dictionary<object, Dictionary<object, object>> BuildCompactSeedMinima(IReadOnlyList<object?> seeds, bool recordMetrics)
                 {
-                    EnsurePositiveMinFastPathPrepared();
-                    if (!usePositiveMinFastPath || auxIndex is null || stepEvaluator is null)
+                    EnsureAdditiveMinFastPathPrepared();
+                    if (!useAdditiveMinFastPath || auxIndex is null || stepEvaluator is null)
                     {
                         return new Dictionary<object, Dictionary<object, object>>();
                     }
@@ -11819,7 +11850,9 @@ namespace UnifyWeaver.QueryRuntime
 
                     if (recordMetrics)
                     {
-                        trace?.RecordStrategy(closure, "SeedGroupedPathAwareAccumulationMinPositiveAdditiveLayered");
+                        trace?.RecordStrategy(closure, GetAdditiveMinLayeredStrategy(
+                            "SeedGroupedPathAwareAccumulationMin",
+                            additiveMinStepSafety));
                     }
 
                     var fastSeedMinima = new Dictionary<object, Dictionary<object, object>>();
@@ -11837,7 +11870,7 @@ namespace UnifyWeaver.QueryRuntime
 
                     if (recordMetrics)
                     {
-                        MeasurePhase(trace, closure, "positive_min_layered_solve", BuildLayeredMinima);
+                        MeasurePhase(trace, closure, GetAdditiveMinLayeredSolvePhase(additiveMinStepSafety), BuildLayeredMinima);
                     }
                     else
                     {
@@ -11850,8 +11883,8 @@ namespace UnifyWeaver.QueryRuntime
                 TimeSpan MeasureCompactProbe(IReadOnlyList<object?> sampleSeeds) =>
                     MeasureElapsed(() =>
                     {
-                        EnsurePositiveMinFastPathPrepared();
-                        if (!usePositiveMinFastPath || auxIndex is null || stepEvaluator is null)
+                        EnsureAdditiveMinFastPathPrepared();
+                        if (!useAdditiveMinFastPath || auxIndex is null || stepEvaluator is null)
                         {
                             return;
                         }
@@ -11890,16 +11923,16 @@ namespace UnifyWeaver.QueryRuntime
                 }
                 else
                 {
-                    EnsurePositiveMinFastPathPrepared();
-                    if (usePositiveMinFastPath && auxIndex is not null && stepEvaluator is not null)
+                    EnsureAdditiveMinFastPathPrepared();
+                    if (useAdditiveMinFastPath && auxIndex is not null && stepEvaluator is not null)
                     {
                         seedMinima = MeasurePhase(trace, closure, "build_compact_grouped", () =>
                             (IReadOnlyDictionary<object, Dictionary<object, object>>)BuildCompactSeedMinima(orderedUniqueSeeds, recordMetrics: true));
                     }
                     else
                     {
-                        trace?.RecordStrategy(closure, "SeedGroupedPathAwareAccumulationMinLegacySeededRowsNoPositiveFastPath");
-                        trace?.RecordStrategy(closure, "SeedGroupedPathAwareAccumulationMinMaterializationPlanFallbackLegacyNoPositiveFastPath");
+                        trace?.RecordStrategy(closure, "SeedGroupedPathAwareAccumulationMinLegacySeededRowsNoAdditiveFastPath");
+                        trace?.RecordStrategy(closure, "SeedGroupedPathAwareAccumulationMinMaterializationPlanFallbackLegacyNoAdditiveFastPath");
                         seedMinima = MeasurePhase(trace, closure, "build_legacy_seeded_rows", () =>
                             (IReadOnlyDictionary<object, Dictionary<object, object>>)ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, orderedUniqueSeeds, rootKeys, context));
                     }
@@ -12075,6 +12108,11 @@ namespace UnifyWeaver.QueryRuntime
                     {
                         var next = edgeBucket.Targets[edgeIndex];
                         var nextKey = next ?? NullFactIndexKey;
+                        if (Equals(nextKey, seedKey))
+                        {
+                            continue;
+                        }
+
                         for (var auxIndexPos = auxBucket.Count - 1; auxIndexPos >= 0; auxIndexPos--)
                         {
                             var auxRow = auxBucket[auxIndexPos];
@@ -12161,6 +12199,11 @@ namespace UnifyWeaver.QueryRuntime
                 {
                     var next = edgeBucket.Targets[edgeIndex];
                     var nextKey = next ?? NullFactIndexKey;
+                    if (Equals(nextKey, seedKey))
+                    {
+                        continue;
+                    }
+
                     sccGraph.ComponentByNode.TryGetValue(nextKey, out var nextComponent);
                     for (var auxIndexPos = auxBucket.Count - 1; auxIndexPos >= 0; auxIndexPos--)
                     {
@@ -12388,20 +12431,30 @@ namespace UnifyWeaver.QueryRuntime
                 var auxRows = GetClosureFactsList(closure.AuxiliaryRelation, ClosureRelationAccessKind.Support, context, closure);
                 var auxIndex = GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context);
                 PositiveStepEvaluator? stepEvaluator = null;
-                var usePositiveMinFastPath = closure.AccumulatorMode == TableMode.Min &&
-                    TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, closure.PositiveStepProven, out stepEvaluator);
+                var additiveMinStepSafety = AdditiveMinStepSafety.StrictlyPositive;
+                var useAdditiveMinFastPath = closure.AccumulatorMode == TableMode.Min &&
+                    closure.MaxDepth > 0 &&
+                    TryCreateNonNegativeAdditiveStepEvaluator(
+                        closure.BaseExpression,
+                        closure.RecursiveExpression,
+                        succIndex,
+                        auxIndex,
+                        closure.PositiveStepProven,
+                        out stepEvaluator,
+                        out additiveMinStepSafety);
                 PathAwareSccGraph? sccGraph = null;
                 var useSccCondensedMinFastPath = false;
-                if (usePositiveMinFastPath)
+                if (useAdditiveMinFastPath)
                 {
                     sccGraph = MeasurePhase(trace, closure, "scc_condense_graph", () => BuildPathAwareSccGraph(succIndex));
                     RecordPathAwareSccGraphMetrics(trace, closure, sccGraph);
-                    useSccCondensedMinFastPath = ResolveMeasuredSccCondensedPositiveMinStrategy(
+                    useSccCondensedMinFastPath = ResolveMeasuredSccCondensedAdditiveMinStrategy(
                         trace,
                         closure,
                         "PathAwareAccumulationMin",
                         sccGraph,
                         closure.MaxDepth,
+                        GetAdditiveMinLayeredProbePhase(additiveMinStepSafety),
                         edgeState.Seeds,
                         sampleSeeds => MeasureElapsed(() =>
                         {
@@ -12433,7 +12486,7 @@ namespace UnifyWeaver.QueryRuntime
                         });
                     trace?.RecordStrategy(closure, useSccCondensedMinFastPath
                         ? "PathAwareAccumulationMinSccCondensed"
-                        : "PathAwareAccumulationMinPositiveAdditiveLayered");
+                        : GetAdditiveMinLayeredStrategy("PathAwareAccumulationMin", additiveMinStepSafety));
                 }
 
                 var totalRows = new List<object[]>();
@@ -12451,7 +12504,7 @@ namespace UnifyWeaver.QueryRuntime
                             outerDagStates += stats.OuterDagStatesExplored;
                             queuePops += stats.QueuePops;
                         }
-                        else if (usePositiveMinFastPath)
+                        else if (useAdditiveMinFastPath)
                         {
                             AppendPositiveMinAccumulationRowsForSeed(seed, succIndex, auxIndex, stepEvaluator!, totalRows, closure.MaxDepth);
                         }
@@ -12466,9 +12519,9 @@ namespace UnifyWeaver.QueryRuntime
                 {
                     MeasurePhase(trace, closure, "scc_condensed_solve", BuildAccumulationRows);
                 }
-                else if (usePositiveMinFastPath)
+                else if (useAdditiveMinFastPath)
                 {
-                    MeasurePhase(trace, closure, "positive_min_layered_solve", BuildAccumulationRows);
+                    MeasurePhase(trace, closure, GetAdditiveMinLayeredSolvePhase(additiveMinStepSafety), BuildAccumulationRows);
                 }
                 else
                 {
@@ -12516,11 +12569,20 @@ namespace UnifyWeaver.QueryRuntime
                 var seeds = new List<object?>();
                 var seenSeeds = new HashSet<object?>();
                 PositiveStepEvaluator? stepEvaluator = null;
-                var usePositiveMinFastPath = closure.AccumulatorMode == TableMode.Min &&
-                    TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, closure.PositiveStepProven, out stepEvaluator);
+                var additiveMinStepSafety = AdditiveMinStepSafety.StrictlyPositive;
+                var useAdditiveMinFastPath = closure.AccumulatorMode == TableMode.Min &&
+                    closure.MaxDepth > 0 &&
+                    TryCreateNonNegativeAdditiveStepEvaluator(
+                        closure.BaseExpression,
+                        closure.RecursiveExpression,
+                        succIndex,
+                        auxIndex,
+                        closure.PositiveStepProven,
+                        out stepEvaluator,
+                        out additiveMinStepSafety);
                 PathAwareSccGraph? sccGraph = null;
                 var useSccCondensedMinFastPath = false;
-                if (usePositiveMinFastPath)
+                if (useAdditiveMinFastPath)
                 {
                     sccGraph = MeasurePhase(trace, closure, "scc_condense_graph", () => BuildPathAwareSccGraph(succIndex));
                     RecordPathAwareSccGraphMetrics(trace, closure, sccGraph);
@@ -12545,14 +12607,15 @@ namespace UnifyWeaver.QueryRuntime
                 }
 
                 seeds.Sort(CompareCacheSeedValues);
-                if (usePositiveMinFastPath && sccGraph is not null)
+                if (useAdditiveMinFastPath && sccGraph is not null)
                 {
-                    useSccCondensedMinFastPath = ResolveMeasuredSccCondensedPositiveMinStrategy(
+                    useSccCondensedMinFastPath = ResolveMeasuredSccCondensedAdditiveMinStrategy(
                         trace,
                         closure,
                         "PathAwareAccumulationSeededMin",
                         sccGraph,
                         closure.MaxDepth,
+                        GetAdditiveMinLayeredProbePhase(additiveMinStepSafety),
                         seeds,
                         sampleSeeds => MeasureElapsed(() =>
                         {
@@ -12584,7 +12647,7 @@ namespace UnifyWeaver.QueryRuntime
                         });
                     trace?.RecordStrategy(closure, useSccCondensedMinFastPath
                         ? "PathAwareAccumulationSeededMinSccCondensed"
-                        : "PathAwareAccumulationSeededMinPositiveAdditiveLayered");
+                        : GetAdditiveMinLayeredStrategy("PathAwareAccumulationSeededMin", additiveMinStepSafety));
                 }
 
                 var totalRows = new List<object[]>();
@@ -12602,7 +12665,7 @@ namespace UnifyWeaver.QueryRuntime
                             outerDagStates += stats.OuterDagStatesExplored;
                             queuePops += stats.QueuePops;
                         }
-                        else if (usePositiveMinFastPath)
+                        else if (useAdditiveMinFastPath)
                         {
                             AppendPositiveMinAccumulationRowsForSeed(seed, succIndex, auxIndex, stepEvaluator!, totalRows, closure.MaxDepth);
                         }
@@ -12617,9 +12680,9 @@ namespace UnifyWeaver.QueryRuntime
                 {
                     MeasurePhase(trace, closure, "scc_condensed_solve", BuildAccumulationRows);
                 }
-                else if (usePositiveMinFastPath)
+                else if (useAdditiveMinFastPath)
                 {
-                    MeasurePhase(trace, closure, "positive_min_layered_solve", BuildAccumulationRows);
+                    MeasurePhase(trace, closure, GetAdditiveMinLayeredSolvePhase(additiveMinStepSafety), BuildAccumulationRows);
                 }
                 else
                 {
@@ -12645,9 +12708,10 @@ namespace UnifyWeaver.QueryRuntime
 
         private delegate double PositiveStepEvaluator(object current, object next, object auxValue);
 
-        // For strictly positive additive steps, the minimum-cost walk within a hop
-        // budget is simple automatically. That lets us replace the expensive
-        // visited-state frontier with dynamic programming over (node, depth).
+        // For non-negative additive steps, any repeated-node walk can have its
+        // cycle removed without increasing cost. That lets us replace the
+        // expensive visited-state frontier with dynamic programming over
+        // (node, depth) for bounded Min queries.
         private void AppendPositiveMinAccumulationRowsForSeed(
             object? seed,
             IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
@@ -12657,6 +12721,7 @@ namespace UnifyWeaver.QueryRuntime
             int maxDepth = 0)
         {
             var effectiveMaxDepth = maxDepth > 0 ? maxDepth : int.MaxValue;
+            var seedKey = seed ?? NullFactIndexKey;
             var depthCosts = new List<Dictionary<object?, double>>(effectiveMaxDepth == int.MaxValue ? 16 : effectiveMaxDepth + 1)
             {
                 new Dictionary<object?, double> { [seed] = 0d }
@@ -12694,6 +12759,11 @@ namespace UnifyWeaver.QueryRuntime
                     for (var edgeIndex = edgeBucket.Targets.Count - 1; edgeIndex >= 0; edgeIndex--)
                     {
                         var next = edgeBucket.Targets[edgeIndex];
+                        if (Equals(next ?? NullFactIndexKey, seedKey))
+                        {
+                            continue;
+                        }
+
                         for (var auxIndexPos = auxBucket.Count - 1; auxIndexPos >= 0; auxIndexPos--)
                         {
                             var auxRow = auxBucket[auxIndexPos];
@@ -12759,15 +12829,17 @@ namespace UnifyWeaver.QueryRuntime
             return stats;
         }
 
-        private bool TryCreatePositiveAdditiveStepEvaluator(
+        private bool TryCreateNonNegativeAdditiveStepEvaluator(
             ArithmeticExpression baseExpression,
             ArithmeticExpression recursiveExpression,
             IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
             IReadOnlyDictionary<object, List<object[]>> auxIndex,
             bool positiveStepProven,
-            out PositiveStepEvaluator? evaluator)
+            out PositiveStepEvaluator? evaluator,
+            out AdditiveMinStepSafety stepSafety)
         {
             evaluator = null;
+            stepSafety = AdditiveMinStepSafety.StrictlyPositive;
             if (!TryExtractMinStepExpression(baseExpression, recursiveExpression, out var stepExpression))
             {
                 return false;
@@ -12784,6 +12856,7 @@ namespace UnifyWeaver.QueryRuntime
                 return true;
             }
 
+            var strictlyPositive = true;
             foreach (var (currentKey, edgeBucket) in succIndex)
             {
                 if (!auxIndex.TryGetValue(currentKey, out var auxBucket))
@@ -12812,14 +12885,22 @@ namespace UnifyWeaver.QueryRuntime
                             return false;
                         }
 
-                        if (!(step > 0d))
+                        if (!(step >= 0d))
                         {
                             return false;
+                        }
+
+                        if (!(step > 0d))
+                        {
+                            strictlyPositive = false;
                         }
                     }
                 }
             }
 
+            stepSafety = strictlyPositive
+                ? AdditiveMinStepSafety.StrictlyPositive
+                : AdditiveMinStepSafety.NonNegative;
             evaluator = (current, next, auxValue) =>
             {
                 var evalTuple = new object[] { current, next, 0, auxValue };

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -169,6 +169,9 @@
 :- dynamic user:test_weighted_min_metadata_edge/2.
 :- dynamic user:test_weighted_min_metadata_cost/2.
 :- dynamic user:test_weighted_min_metadata_path/3.
+:- dynamic user:test_weighted_zero_min_edge/2.
+:- dynamic user:test_weighted_zero_min_cost/2.
+:- dynamic user:test_weighted_zero_min_path/3.
 :- dynamic user:test_scanindex_allowed/1.
 :- dynamic user:test_scanindex_step/2.
 :- dynamic user:test_scanindex_reach_param/2.
@@ -327,6 +330,7 @@ test_csharp_query_target :-
         verify_path_aware_accumulation_min_mode_plan,
         verify_path_aware_accumulation_positive_guard_plan,
         verify_path_aware_accumulation_positive_metadata_plan,
+        verify_path_aware_accumulation_nonnegative_min_strategy_runtime,
         verify_grouped_transitive_closure_plan,
         verify_parameterized_grouped_transitive_closure_plan,
         verify_parameterized_grouped_transitive_closure_pairs_strategy_runtime,
@@ -1266,6 +1270,26 @@ setup_test_data :-
     )),
     assertz(user:'table'(test_weighted_min_metadata_path(_, _, min))),
     declare_constraint(test_weighted_min_metadata_path/3, [positive_step(3)]),
+    assertz(user:test_weighted_zero_min_edge(a, b)),
+    assertz(user:test_weighted_zero_min_edge(a, c)),
+    assertz(user:test_weighted_zero_min_edge(b, a)),
+    assertz(user:test_weighted_zero_min_edge(b, d)),
+    assertz(user:test_weighted_zero_min_edge(c, d)),
+    assertz(user:test_weighted_zero_min_cost(a, 0)),
+    assertz(user:test_weighted_zero_min_cost(b, 2)),
+    assertz(user:test_weighted_zero_min_cost(c, 4)),
+    assertz(user:(test_weighted_zero_min_path(X, Y, Acc) :-
+        test_weighted_zero_min_edge(X, Y),
+        test_weighted_zero_min_cost(X, Cost),
+        Acc is Cost
+    )),
+    assertz(user:(test_weighted_zero_min_path(X, Z, Acc) :-
+        test_weighted_zero_min_edge(X, Y),
+        test_weighted_zero_min_cost(X, Cost),
+        test_weighted_zero_min_path(Y, Z, Acc1),
+        Acc is Acc1 + Cost
+    )),
+    assertz(user:'table'(test_weighted_zero_min_path(_, _, min))),
     assert_binary_recursive_fixture(
         test_probe_dir_forward_edge,
         test_probe_dir_forward_reach,
@@ -1498,6 +1522,9 @@ cleanup_test_data :-
     retractall(user:test_weighted_min_metadata_cost(_, _)),
     retractall(user:test_weighted_min_metadata_path(_, _, _)),
     clear_constraints(test_weighted_min_metadata_path/3),
+    retractall(user:test_weighted_zero_min_edge(_, _)),
+    retractall(user:test_weighted_zero_min_cost(_, _)),
+    retractall(user:test_weighted_zero_min_path(_, _, _)),
     cleanup_recursive_fixture(test_probe_dir_forward_edge, test_probe_dir_forward_reach, 2),
     cleanup_recursive_fixture(test_probe_dir_backward_edge, test_probe_dir_backward_reach, 2),
     cleanup_recursive_fixture(test_probe_dir_mixed_edge, test_probe_dir_mixed_reach, 2),
@@ -3839,6 +3866,35 @@ verify_path_aware_accumulation_positive_metadata_plan :-
          'a,c,1',
          'a,d,3'],
         [[a]]).
+
+verify_path_aware_accumulation_nonnegative_min_strategy_runtime :-
+    csharp_target:build_query_plan(
+        test_weighted_zero_min_path/3,
+        [target(csharp_query)],
+        [input, output, output],
+        Plan),
+    get_dict(is_recursive, Plan, true),
+    get_dict(root, Plan, Root),
+    get_dict(type, Root, path_aware_accumulation),
+    get_dict(head, Root, predicate{name:test_weighted_zero_min_path, arity:3}),
+    get_dict(table_modes, Root, [lattice, lattice, min]),
+    csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'PathAwareAccumulationNode'),
+    sub_string(Source, _, _, _, 'TableMode.Min'),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    Params = [[a]],
+    harness_source_with_strategy_flag_no_reuse(
+        ModuleClass,
+        Params,
+        'PathAwareAccumulationSeededMinNonNegativeAdditiveLayered',
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,b,0',
+         'a,c,0',
+         'a,d,2',
+         'STRATEGY_USED:PathAwareAccumulationSeededMinNonNegativeAdditiveLayered=true'],
+        Params,
+        HarnessSource).
 
 verify_grouped_transitive_closure_plan :-
     csharp_query_target:build_query_plan(test_label_cat_reach/4, [target(csharp_query)], Plan),


### PR DESCRIPTION
 # Widen weighted Min fast path to non-negative additive steps

  ## Summary

  This PR extends the C# query runtime’s weighted `Min` fast path from strictly positive additive step costs to bounded non-negative
  additive costs. Zero-cost edges can now use the layered additive min strategy when the runtime can prove all steps are numeric and
  non-negative, while negative or non-numeric steps continue to fall back to the safer frontier path.

  It also preserves path-aware cycle semantics by preventing additive min helpers from emitting cycle-back-to-seed rows, keeping the
  optimized path aligned with the exact visited-state behavior.

  ## Changes

  - Adds additive min step safety classification for strictly positive vs non-negative costs.
  - Enables non-negative additive layered min selection for seeded and grouped path-aware accumulation.
  - Keeps existing positive strategy labels unchanged while adding non-negative trace labels.
  - Adds regression coverage for zero-cost weighted min paths.
  - Adds benchmark support for `--weight-mode nonnegative-zero`.
  - Updates benchmark and SCC weighted-min planning docs.

  ## Testing

  - `swipl -q -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:configure_csharp_query_options,test_csharp_query_target:setup_test_data,test_csharp_query_target:verify_
  path_aware_accumulation_nonnegative_min_strategy_runtime,halt."`
  - `swipl -q -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:configure_csharp_query_options,test_csharp_query_target:setup_test_data,test_csharp_query_target:verify_
  path_aware_accumulation_min_mode_plan,test_csharp_query_target:verify_path_aware_accumulation_positive_guard_plan,test_csharp_quer
  y_target:verify_path_aware_accumulation_positive_metadata_plan,halt."`
  - `python3 examples/benchmark/benchmark_weighted_shortest_path.py --scales 300 --repetitions 1 --weight-mode nonnegative-zero`
  - `python3 examples/benchmark/benchmark_weighted_shortest_path.py --scales 300 --repetitions 1`
  - `env SKIP_CSHARP_EXECUTION=1 swipl -q -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target,halt."`
  - `git diff --check`