### PR TITLE
test(csharp-query): survey weighted min frontier fallbacks

### DIFF
--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -17,6 +17,9 @@ Current status:
 - the additive fast-path boundary now includes non-negative steps, so
   zero-cost source weights no longer force the exact visited-state frontier
   fallback when the additive form is otherwise safe and depth-bounded
+- negative additive steps and non-additive recurrence expressions are now
+  covered by explicit fallback-shape survey tests and runtime strategy
+  labeling
 - on the current positive-additive benchmark shape, the measured selector
   rejects SCC condensation because the layered path is still cheaper after
   SCC build/probe overhead
@@ -112,9 +115,13 @@ Current selection boundary:
 
 Next selection work:
 
-- determine whether any remaining non-additive or negative-step frontier
-  fallback shapes can be summarized safely without losing exact simple-path
-  semantics
+- use the explicit frontier-fallback labels to measure the remaining
+  unsupported shapes before adding more shortcuts
+- determine whether a restricted non-additive class, such as positive
+  multiplicative weights, can be transformed safely without losing exact
+  simple-path semantics
+- keep negative-step additive recurrences on the exact frontier path until
+  there is a proof that pruning and condensation remain sound
 
 Deliverable:
 
@@ -124,6 +131,7 @@ Examples:
 
 - `PathAwareAccumulation-Min-Frontier`
 - `PathAwareAccumulation-Min-SccCondensed`
+- `PathAwareAccumulationSeededMinFrontierFallback`
 
 ## Phase 4: Benchmark Loop
 
@@ -211,9 +219,19 @@ The original first code step after this document set was:
 
 That step is now complete.
 
+The fallback survey step now covers two representative cases:
+
+1. negative additive weighted `Min`, which matches the additive expression
+   shape but is rejected by the non-negative proof
+2. positive multiplicative weighted `Min`, which is monotone for the test
+   data but is not additive and therefore still requires exact path-state
+   evaluation
+
 The next coding step should be:
 
-1. identify weighted `Min` recurrence shapes still not covered by the current
-   non-negative additive fast path
-2. prototype a safe summarized evaluation for one of those broader cases
-3. benchmark it against the exact frontier fallback
+1. add lightweight frontier-fallback instrumentation for candidate count,
+   dominance checks, subset checks, and frontier bucket sizes
+2. run it on the negative-additive and multiplicative survey fixtures plus
+   cyclic benchmark data
+3. decide whether the next optimization should be exact state hashing or a
+   narrower multiplicative-to-additive transform

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_SPEC.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_SPEC.md
@@ -26,7 +26,7 @@ with:
 
 - `TableMode.Min`
 - per-path uniqueness
-- monotone positive accumulation
+- monotone non-negative additive accumulation for the current fast path
 
 ## Supported Semantic Class
 
@@ -36,6 +36,7 @@ The fast path is only sound when all of the following hold:
    Examples:
    - `Acc is Acc1 + Cost`
    - `Acc is Acc1 + log(Deg) / log(N)` with positive step
+   - zero-cost additive steps when the query is depth-bounded
 
 2. The result contract is minimum accumulated cost per `(source,target)`.
 
@@ -45,10 +46,10 @@ The fast path is only sound when all of the following hold:
 4. The optimizer may transform the graph via SCC condensation, but may
    not change the final result set.
 
-Out of scope initially:
+Still on the exact frontier fallback path:
 
 - negative increments
-- zero-cost cyclic edge systems where monotonicity gives no pruning
+- non-additive recurrence expressions such as `Acc is Acc1 * Factor`
 - `max`, `first`, `sum`, `count`
 - multi-auxiliary or non-linear accumulation beyond the current path-aware
   accumulation shape
@@ -137,6 +138,8 @@ The runtime should fall back to the current exact frontier algorithm
 when:
 
 - applicability cannot be proven
+- the additive step is negative for any reachable edge/auxiliary row
+- the recursive expression is non-additive
 - SCC preprocessing fails
 - internal transfer summarization would be lossy
 - measured SCC overhead dominates the existing positive-min path

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -12488,6 +12488,10 @@ namespace UnifyWeaver.QueryRuntime
                         ? "PathAwareAccumulationMinSccCondensed"
                         : GetAdditiveMinLayeredStrategy("PathAwareAccumulationMin", additiveMinStepSafety));
                 }
+                else if (closure.AccumulatorMode == TableMode.Min)
+                {
+                    trace?.RecordStrategy(closure, "PathAwareAccumulationMinFrontierFallback");
+                }
 
                 var totalRows = new List<object[]>();
                 long localStates = 0;
@@ -12648,6 +12652,10 @@ namespace UnifyWeaver.QueryRuntime
                     trace?.RecordStrategy(closure, useSccCondensedMinFastPath
                         ? "PathAwareAccumulationSeededMinSccCondensed"
                         : GetAdditiveMinLayeredStrategy("PathAwareAccumulationSeededMin", additiveMinStepSafety));
+                }
+                else if (closure.AccumulatorMode == TableMode.Min)
+                {
+                    trace?.RecordStrategy(closure, "PathAwareAccumulationSeededMinFrontierFallback");
                 }
 
                 var totalRows = new List<object[]>();

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -172,6 +172,12 @@
 :- dynamic user:test_weighted_zero_min_edge/2.
 :- dynamic user:test_weighted_zero_min_cost/2.
 :- dynamic user:test_weighted_zero_min_path/3.
+:- dynamic user:test_weighted_negative_min_edge/2.
+:- dynamic user:test_weighted_negative_min_cost/2.
+:- dynamic user:test_weighted_negative_min_path/3.
+:- dynamic user:test_weighted_product_min_edge/2.
+:- dynamic user:test_weighted_product_min_factor/2.
+:- dynamic user:test_weighted_product_min_path/3.
 :- dynamic user:test_scanindex_allowed/1.
 :- dynamic user:test_scanindex_step/2.
 :- dynamic user:test_scanindex_reach_param/2.
@@ -331,6 +337,8 @@ test_csharp_query_target :-
         verify_path_aware_accumulation_positive_guard_plan,
         verify_path_aware_accumulation_positive_metadata_plan,
         verify_path_aware_accumulation_nonnegative_min_strategy_runtime,
+        verify_path_aware_accumulation_negative_min_frontier_fallback_runtime,
+        verify_path_aware_accumulation_product_min_frontier_fallback_runtime,
         verify_grouped_transitive_closure_plan,
         verify_parameterized_grouped_transitive_closure_plan,
         verify_parameterized_grouped_transitive_closure_pairs_strategy_runtime,
@@ -1290,6 +1298,46 @@ setup_test_data :-
         Acc is Acc1 + Cost
     )),
     assertz(user:'table'(test_weighted_zero_min_path(_, _, min))),
+    assertz(user:test_weighted_negative_min_edge(a, b)),
+    assertz(user:test_weighted_negative_min_edge(a, c)),
+    assertz(user:test_weighted_negative_min_edge(b, a)),
+    assertz(user:test_weighted_negative_min_edge(b, d)),
+    assertz(user:test_weighted_negative_min_edge(c, d)),
+    assertz(user:test_weighted_negative_min_cost(a, -1)),
+    assertz(user:test_weighted_negative_min_cost(b, 3)),
+    assertz(user:test_weighted_negative_min_cost(c, 4)),
+    assertz(user:(test_weighted_negative_min_path(X, Y, Acc) :-
+        test_weighted_negative_min_edge(X, Y),
+        test_weighted_negative_min_cost(X, Cost),
+        Acc is Cost
+    )),
+    assertz(user:(test_weighted_negative_min_path(X, Z, Acc) :-
+        test_weighted_negative_min_edge(X, Y),
+        test_weighted_negative_min_cost(X, Cost),
+        test_weighted_negative_min_path(Y, Z, Acc1),
+        Acc is Acc1 + Cost
+    )),
+    assertz(user:'table'(test_weighted_negative_min_path(_, _, min))),
+    assertz(user:test_weighted_product_min_edge(a, b)),
+    assertz(user:test_weighted_product_min_edge(a, c)),
+    assertz(user:test_weighted_product_min_edge(b, a)),
+    assertz(user:test_weighted_product_min_edge(b, d)),
+    assertz(user:test_weighted_product_min_edge(c, d)),
+    assertz(user:test_weighted_product_min_factor(a, 2)),
+    assertz(user:test_weighted_product_min_factor(b, 3)),
+    assertz(user:test_weighted_product_min_factor(c, 5)),
+    assertz(user:(test_weighted_product_min_path(X, Y, Acc) :-
+        test_weighted_product_min_edge(X, Y),
+        test_weighted_product_min_factor(X, Factor),
+        Acc is Factor
+    )),
+    assertz(user:(test_weighted_product_min_path(X, Z, Acc) :-
+        test_weighted_product_min_edge(X, Y),
+        test_weighted_product_min_factor(X, Factor),
+        test_weighted_product_min_path(Y, Z, Acc1),
+        Acc is Acc1 * Factor
+    )),
+    assertz(user:'table'(test_weighted_product_min_path(_, _, min))),
     assert_binary_recursive_fixture(
         test_probe_dir_forward_edge,
         test_probe_dir_forward_reach,
@@ -1525,6 +1573,12 @@ cleanup_test_data :-
     retractall(user:test_weighted_zero_min_edge(_, _)),
     retractall(user:test_weighted_zero_min_cost(_, _)),
     retractall(user:test_weighted_zero_min_path(_, _, _)),
+    retractall(user:test_weighted_negative_min_edge(_, _)),
+    retractall(user:test_weighted_negative_min_cost(_, _)),
+    retractall(user:test_weighted_negative_min_path(_, _, _)),
+    retractall(user:test_weighted_product_min_edge(_, _)),
+    retractall(user:test_weighted_product_min_factor(_, _)),
+    retractall(user:test_weighted_product_min_path(_, _, _)),
     cleanup_recursive_fixture(test_probe_dir_forward_edge, test_probe_dir_forward_reach, 2),
     cleanup_recursive_fixture(test_probe_dir_backward_edge, test_probe_dir_backward_reach, 2),
     cleanup_recursive_fixture(test_probe_dir_mixed_edge, test_probe_dir_mixed_reach, 2),
@@ -3893,6 +3947,64 @@ verify_path_aware_accumulation_nonnegative_min_strategy_runtime :-
          'a,c,0',
          'a,d,2',
          'STRATEGY_USED:PathAwareAccumulationSeededMinNonNegativeAdditiveLayered=true'],
+        Params,
+        HarnessSource).
+
+verify_path_aware_accumulation_negative_min_frontier_fallback_runtime :-
+    csharp_target:build_query_plan(
+        test_weighted_negative_min_path/3,
+        [target(csharp_query)],
+        [input, output, output],
+        Plan),
+    get_dict(is_recursive, Plan, true),
+    get_dict(root, Plan, Root),
+    get_dict(type, Root, path_aware_accumulation),
+    get_dict(head, Root, predicate{name:test_weighted_negative_min_path, arity:3}),
+    get_dict(table_modes, Root, [lattice, lattice, min]),
+    csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'PathAwareAccumulationNode'),
+    sub_string(Source, _, _, _, 'TableMode.Min'),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    Params = [[a]],
+    harness_source_with_strategy_flag_no_reuse(
+        ModuleClass,
+        Params,
+        'PathAwareAccumulationSeededMinFrontierFallback',
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,b,-1',
+         'a,c,-1',
+         'a,d,2',
+         'STRATEGY_USED:PathAwareAccumulationSeededMinFrontierFallback=true'],
+        Params,
+        HarnessSource).
+
+verify_path_aware_accumulation_product_min_frontier_fallback_runtime :-
+    csharp_target:build_query_plan(
+        test_weighted_product_min_path/3,
+        [target(csharp_query)],
+        [input, output, output],
+        Plan),
+    get_dict(is_recursive, Plan, true),
+    get_dict(root, Plan, Root),
+    get_dict(type, Root, path_aware_accumulation),
+    get_dict(head, Root, predicate{name:test_weighted_product_min_path, arity:3}),
+    get_dict(table_modes, Root, [lattice, lattice, min]),
+    csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'PathAwareAccumulationNode'),
+    sub_string(Source, _, _, _, 'TableMode.Min'),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    Params = [[a]],
+    harness_source_with_strategy_flag_no_reuse(
+        ModuleClass,
+        Params,
+        'PathAwareAccumulationSeededMinFrontierFallback',
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,b,2',
+         'a,c,2',
+         'a,d,6',
+         'STRATEGY_USED:PathAwareAccumulationSeededMinFrontierFallback=true'],
         Params,
         HarnessSource).
 


### PR DESCRIPTION
# Survey weighted Min frontier fallback shapes

  ## Summary

  This PR adds explicit runtime tracing and regression coverage for weighted `Min` path-aware accumulation shapes that still require
  the exact frontier fallback.

  The recently optimized positive and non-negative additive paths stay on their fast layered/SCC-measured strategies. This PR makes
  the remaining unsupported cases visible by labeling fallback execution and adding representative survey fixtures.

  ## Changes

  - Adds explicit C# runtime strategy labels for weighted `Min` fallback:
    - `PathAwareAccumulationMinFrontierFallback`
    - `PathAwareAccumulationSeededMinFrontierFallback`
  - Adds seeded runtime coverage for negative additive weighted `Min`.
  - Adds seeded runtime coverage for positive multiplicative weighted `Min`.
  - Confirms both fallback shapes preserve exact simple-path behavior.
  - Updates SCC weighted-min plan/spec docs with the current fast-path boundary and next instrumentation step.

  ## Testing

  - `swipl -q -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:configure_csharp_query_options,test_csharp_query_target:setup_test_data,test_csharp_query_target:verify_
  path_aware_accumulation_negative_min_frontier_fallback_runtime,test_csharp_query_target:verify_path_aware_accumulation_product_min
  _frontier_fallback_runtime,halt."`
  - `swipl -q -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:configure_csharp_query_options,test_csharp_query_target:setup_test_data,test_csharp_query_target:verify_
  path_aware_accumulation_min_mode_plan,test_csharp_query_target:verify_path_aware_accumulation_positive_guard_plan,test_csharp_quer
  y_target:verify_path_aware_accumulation_positive_metadata_plan,test_csharp_query_target:verify_path_aware_accumulation_nonnegative
  _min_strategy_runtime,halt."`
  - `env SKIP_CSHARP_EXECUTION=1 swipl -q -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target,halt."`
  - `git diff --check`