### PR TITLE
feat(wat): =/2 builtin, type-check dispatch, and constant tag encoding

### DIFF
--- a/docs/design/WAM_TERM_BUILTINS_PHASE_6_PERF.md
+++ b/docs/design/WAM_TERM_BUILTINS_PHASE_6_PERF.md
@@ -202,8 +202,103 @@ the previous cross-predicate blocker had been masking:
   implementations do.
 
 Both are orthogonal to Group A, orthogonal to cross-predicate
-labels, and orthogonal to each other. They are new tracked items in
-§8.
+labels, and orthogonal to each other.
+
+### 4.5a Post-commit update: =/2 + type checks + constant tag encoding landed
+
+Branch `feat/wam-unify-and-type-checks` fixes both blockers from
+§4.5 plus a third one surfaced during investigation:
+
+  **(1) `=/2` routed through the canonical builtin pipeline.**
+  `is_builtin_pred(=, 2)` is added to `wam_target.pl`, so the
+  canonical WAM compiler now emits `builtin_call =/2, 2` for body
+  goals of the form `X = Y`. A new WAM-WAT builtin ID 22 (`=/2`)
+  is wired into the `br_table` at its own `$eq` block and
+  dispatches to the existing `$unify_regs A1 A2` helper — which
+  handles both unbound-on-either-side and shallow bound-bound
+  equality.
+
+  **(2) Type checks 9–14 implemented in the br_table.** The six
+  `$default` slots for IDs 9–14 in `$execute_builtin` are
+  replaced by real handlers (`$var`, `$nonvar`, `$atom`,
+  `$integer`, `$float`, `$number`) that inspect A1's runtime tag.
+  Integer/1 returns `tag == 1`, atom/1 returns `tag == 0`, and so
+  on. Direct tag compare, no deref through refs.
+
+  **(3) Constant tag encoding for put_constant / get_constant /
+  set_constant / unify_constant.** Before this fix, all four
+  constant-using instructions encoded the value unconditionally
+  with runtime tag=0 (atom), regardless of whether the source
+  constant was an atom, integer, or float. `put_constant 42, A1`
+  stored A1 as `atom(42)` not `integer(42)`, so `integer(42)`
+  would legitimately return 0 even with the type-check dispatch
+  in place — the real bug was in encoding, not dispatch. The fix
+  adds `encode_constant_with_tag/3` which returns both a
+  value-cell tag hint (0/1/2 for atom/integer/float) and the
+  payload; the four instruction encoders pack this tag into
+  `op2`'s high 32 bits (or directly in op2 for set/unify_constant
+  which don't need a reg idx), and the runtime handlers extract
+  it via `i64.shr_u`. `encode_constant_with_tag/3` also properly
+  handles the case where the canonical WAM layer hands constants
+  down as strings (`"42"`) rather than typed Prolog terms —
+  previously these hit the catch-all clause and encoded as 0,
+  meaning every string constant was stored as `atom("")`.
+
+Validation: five new assertions in `test_wam_wat_target.pl`:
+
+  - `eq_builtin_id_registered` — codegen: `=/2` is in the builtin
+    table at ID 22 and the canonical WAM recognizes `=` as builtin
+  - `eq_dispatch_in_br_table` — codegen: `$eq` block is present in
+    the emitted helpers and dispatches to `$unify_regs A1 A2`
+  - `constant_tag_encoded_in_op2` — codegen: verifies
+    `put_constant(integer(42), A1)` emits byte 16 = 0x01 (tag=1 =
+    integer in op2's high 32 bits' low byte)
+  - `functional_integer_type_check` — runtime: `integer(42)`
+    returns 1 via wat2wasm + node
+  - `functional_atom_type_check_fail` — runtime (negative):
+    `atom(42)` returns 0, proving dispatch distinguishes tags
+    rather than unconditionally returning 1
+
+All five pass. All 57 WAM-WAT tests pass.
+
+### 4.5b Still blocked: Y/A register variable aliasing
+
+Attempting to run `sum_ints` end-to-end after landing §4.5a
+reveals a **deeper pre-existing WAM-WAT runtime bug** that was
+masked by the earlier blockers. `put_variable Xn, Ai` creates two
+independent `Unbound` cells in registers `Xn` and `Ai`, each with
+`payload = xn_idx`, rather than aliasing both registers to a
+single heap reference cell as a standard WAM implementation would.
+
+Consequences observed:
+
+  - When a callee binds `Ai` via `set_reg`, the caller's `Xn`
+    stays unbound — the binding does not propagate back.
+  - `X = Y` within a single clause appears to succeed for any
+    pair of values: the first `=/2` binds A1 (from a temporarily
+    unbound Xn copy), the next `put_value Xn, A1` copies the
+    stale unbound Xn back into A1, and the next `=/2` binds A1
+    again to whatever RHS it sees. Test probe:
+    `unify_ok :- X = 42, X = 42` and
+    `unify_fail :- X = 42, X = 99` both return 1 (both "succeed")
+    — clear evidence that X does not retain its binding across
+    the two body goals.
+  - `sum_ints(f(1, g(2, 3), 4), 0, Sum)` returns "success" but
+    `Sum = 10` and `Sum = 999` BOTH unify successfully against
+    the output, proving Sum was never actually computed. The
+    predicate short-circuits via the buggy path rather than
+    walking the term.
+
+Proper fix: implement heap-allocated variable cells + binding
+through refs. Each `put_variable Xn, Ai` should allocate one heap
+cell (tag=6, unbound) at address H, and both Xn and Ai should
+hold `Ref(H)`. When a binding occurs, `val_store` updates the
+heap cell at H; deref from either register reaches the shared
+cell. Trail bindings record the heap address, not the register
+index.
+
+This is a substantially larger refactor and is out of scope for
+`feat/wam-unify-and-type-checks`. Tracked as a new follow-up in §8.
 
 ### 4.6 WAM-Rust port status
 
@@ -361,16 +456,24 @@ future refactor breaks the shared `HashMap` threading.
 - **Cross-predicate label resolution in WAM-Rust** — still pending
   (§4.6). Larger refactor than the WAT case due to the per-predicate
   `pub fn` architecture; needs a module-level shared CODE/LABELS.
-- **Type-check builtin handlers** for IDs 9–14 (`var/1`, `nonvar/1`,
-  `atom/1`, `integer/1`, `float/1`, `number/1`) in WAM-WAT's
-  `$execute_builtin` br_table. Currently all fall through to
-  `$default` which returns 0. Blocks any benchmark with a type
-  guard on its happy path — including the `sum_ints` walker.
-- **`=/2` lowering** in the canonical WAM compiler — currently
-  emits `execute =/2` which is not a recognized builtin and
-  resolves to PC=0 at runtime, corrupting execution. Should lower
-  to `get_value` / `unify_value` instructions directly, as
-  standard WAM implementations do.
+- **~~Type-check builtin handlers~~** for IDs 9–14 (`var/1`,
+  `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`) —
+  **landed in `feat/wam-unify-and-type-checks`**. See §4.5a.
+- **~~`=/2` lowering~~** in the canonical WAM compiler — **landed
+  in `feat/wam-unify-and-type-checks`**. `is_builtin_pred(=, 2)`
+  is now in `wam_target.pl`; WAM-WAT builtin ID 22 dispatches to
+  `$unify_regs A1 A2`. See §4.5a.
+- **Y/A register variable aliasing** in WAM-WAT — new blocker
+  surfaced by §4.5b. Put_variable creates two independent unbound
+  cells instead of aliasing both registers to one heap cell, so
+  bindings don't propagate from A_i back to Y_n. Proper fix:
+  heap-allocated variable cells with binding through refs.
+  Blocks real sum_ints execution.
+- **Real `is/2` arithmetic evaluation** in WAM-WAT — currently a
+  stub that only copies A2 to A1 if A2 is already an integer, so
+  `N1 is N - 1` (compound RHS) always fails. Needs a recursive
+  evaluator over the arithmetic AST built from `put_structure +/2`
+  + `set_value`/`set_constant` cells on the heap.
 - **If-then-else lowering hang** in the canonical WAM compiler on
   hybrid backends — would remove the need for cut-style rewrites of
   benchmark predicates.

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -621,6 +621,13 @@ is_builtin_pred(functor, 3). % term inspection: name/arity read or construct
 is_builtin_pred(arg, 3).     % term inspection: Nth argument access
 is_builtin_pred((=..), 2).   % term inspection: univ (decompose/compose)
 is_builtin_pred(copy_term, 2). % term inspection: fresh-variable copy
+is_builtin_pred(=, 2).       % unification: bind / structurally unify two terms.
+                             % Without this entry, X = Y in a body goal
+                             % would compile to `execute =/2`, which looks
+                             % up "=/2" as a user predicate, misses, and
+                             % resolves to PC=0 at runtime — silently
+                             % re-entering the project's first predicate
+                             % and corrupting execution state.
 
 compile_put_arguments([], _, V, V, "").
 compile_put_arguments([Arg|Rest], I, V0, Vf, Code) :-

--- a/src/unifyweaver/targets/wam_wat_target.pl
+++ b/src/unifyweaver/targets/wam_wat_target.pl
@@ -111,6 +111,7 @@ builtin_id('functor/3',   18).
 builtin_id('arg/3',       19).
 builtin_id('=../2',       20).
 builtin_id('copy_term/2', 21).
+builtin_id('=/2',         22).
 
 % ============================================================================
 % Register name -> index mapping
@@ -153,9 +154,14 @@ hash_codes([C|Cs], Acc, Hash) :-
 
 wam_instruction_to_wat_bytes(get_constant(C, Ai), _Labels, Hex) :-
     instr_tag(get_constant, Tag),
-    encode_constant(C, Op1),
+    encode_constant_with_tag(C, ConstTag, Op1),
     reg_name_to_index(Ai, RegIdx),
-    encode_instr_hex(Tag, Op1, RegIdx, Hex).
+    %% op2 layout: high 32 bits = value-cell tag hint, low 32 bits = reg idx.
+    %% Runtime extracts RegIdx via i32.wrap_i64 and ConstTag via
+    %% i64.shr_u 32 + i32.wrap_i64. See wam_wat_case(put_constant, ...)
+    %% and friends for the decode side.
+    Op2 is (ConstTag << 32) \/ RegIdx,
+    encode_instr_hex(Tag, Op1, Op2, Hex).
 
 wam_instruction_to_wat_bytes(get_variable(Xn, Ai), _Labels, Hex) :-
     instr_tag(get_variable, Tag),
@@ -192,14 +198,17 @@ wam_instruction_to_wat_bytes(unify_value(Xn), _Labels, Hex) :-
 
 wam_instruction_to_wat_bytes(unify_constant(C), _Labels, Hex) :-
     instr_tag(unify_constant, Tag),
-    encode_constant(C, Op1),
-    encode_instr_hex(Tag, Op1, 0, Hex).
+    encode_constant_with_tag(C, ConstTag, Op1),
+    %% op2 = value-cell tag hint (atom=0, integer=1, float=2).
+    encode_instr_hex(Tag, Op1, ConstTag, Hex).
 
 wam_instruction_to_wat_bytes(put_constant(C, Ai), _Labels, Hex) :-
     instr_tag(put_constant, Tag),
-    encode_constant(C, Op1),
+    encode_constant_with_tag(C, ConstTag, Op1),
     reg_name_to_index(Ai, RegIdx),
-    encode_instr_hex(Tag, Op1, RegIdx, Hex).
+    %% op2: high 32 = tag hint, low 32 = reg idx. See note on get_constant.
+    Op2 is (ConstTag << 32) \/ RegIdx,
+    encode_instr_hex(Tag, Op1, Op2, Hex).
 
 wam_instruction_to_wat_bytes(put_variable(Xn, Ai), _Labels, Hex) :-
     instr_tag(put_variable, Tag),
@@ -236,8 +245,9 @@ wam_instruction_to_wat_bytes(set_value(Xn), _Labels, Hex) :-
 
 wam_instruction_to_wat_bytes(set_constant(C), _Labels, Hex) :-
     instr_tag(set_constant, Tag),
-    encode_constant(C, Op1),
-    encode_instr_hex(Tag, Op1, 0, Hex).
+    encode_constant_with_tag(C, ConstTag, Op1),
+    %% op2 = value-cell tag hint.
+    encode_instr_hex(Tag, Op1, ConstTag, Hex).
 
 wam_instruction_to_wat_bytes(allocate, _Labels, Hex) :-
     instr_tag(allocate, Tag),
@@ -285,12 +295,35 @@ wam_instruction_to_wat_bytes(trust_me, _Labels, Hex) :-
 %% encode_constant(+C, -I64Val)
 %  Encodes a Prolog constant as an i64 value.
 %  For atoms: the hash. For integers: the raw value.
-encode_constant(atom(A), Hash) :- !, atom_hash_i64(A, Hash).
-encode_constant(integer(I), I) :- !.
-encode_constant(N, N) :- integer(N), !.
-encode_constant(N, Bits) :- float(N), !, Bits is float_integer_part(N).
-encode_constant(A, Hash) :- atom(A), !, atom_hash_i64(A, Hash).
-encode_constant(_, 0).
+encode_constant(C, Val) :- encode_constant_with_tag(C, _Tag, Val).
+
+%% encode_constant_with_tag(+C, -Tag, -I64Val)
+%  Encodes a Prolog constant as (Tag, Value) where Tag is the runtime
+%  value-cell tag (0 = atom, 1 = integer, 2 = float) and I64Val is the
+%  payload stored in the instruction's op1 field.
+%
+%  The canonical WAM layer hands constants down as strings parsed
+%  from WAM assembly text, not as typed Prolog terms — so "42" arrives
+%  as the string "42", not the integer 42. We parse strings back into
+%  their original types here so the type/1 family of builtins
+%  (integer/1, atom/1, etc.) can dispatch on a meaningful runtime
+%  tag at the A_i register. Prior to this change, all constants
+%  unconditionally stored tag=0 (atom), which made integer/1 always
+%  fail and atom/1 always "succeed" — including on integer constants.
+encode_constant_with_tag(atom(A), 0, Hash) :- !, atom_hash_i64(A, Hash).
+encode_constant_with_tag(integer(I), 1, I) :- !.
+encode_constant_with_tag(I, 1, I) :- integer(I), !.
+encode_constant_with_tag(F, 2, Bits) :- float(F), !, Bits is float_integer_part(F).
+encode_constant_with_tag(A, 0, Hash) :- atom(A), !, atom_hash_i64(A, Hash).
+encode_constant_with_tag(S, Tag, Val) :-
+    string(S), !,
+    (   number_string(I, S), integer(I)
+    ->  Tag = 1, Val = I
+    ;   atom_string(A, S),
+        atom_hash_i64(A, Hash),
+        Tag = 0, Val = Hash
+    ).
+encode_constant_with_tag(_, 0, 0).
 
 %% encode_structure_op1(+FSlashArity, -I64)
 %  Encodes a functor/arity descriptor (e.g. 'f/2') as an i64 payload.
@@ -578,17 +611,19 @@ close_and_call(Tag-_, Code) :-
 % --- Head unification ---
 
 wam_wat_case(get_constant,
-'  (local $reg_idx i32)
+'  ;; op2 layout: high 32 = value-cell tag hint, low 32 = reg idx.
+  (local $reg_idx i32) (local $c_tag i32)
   (local.set $reg_idx (i32.wrap_i64 (local.get $op2)))
+  (local.set $c_tag (i32.wrap_i64 (i64.shr_u (local.get $op2) (i64.const 32))))
   (if (result i32) (call $val_is_unbound (call $reg_offset (local.get $reg_idx)))
     (then
       (call $trail_binding (local.get $reg_idx))
-      (call $set_reg (local.get $reg_idx) (i32.const 0) (local.get $op1))
+      (call $set_reg (local.get $reg_idx) (local.get $c_tag) (local.get $op1))
       (call $inc_pc)
       (i32.const 1))
     (else
       (if (result i32) (i32.and
-            (i32.eq (call $get_reg_tag (local.get $reg_idx)) (i32.const 0))
+            (i32.eq (call $get_reg_tag (local.get $reg_idx)) (local.get $c_tag))
             (i64.eq (call $get_reg_payload (local.get $reg_idx)) (local.get $op1)))
         (then (call $inc_pc) (i32.const 1))
         (else (i32.const 0)))))').
@@ -684,9 +719,12 @@ wam_wat_case(unify_value,
       (i32.const 1)))').
 
 wam_wat_case(unify_constant,
-'  (if (result i32) (call $get_mode) ;; write mode
+'  ;; op2 = value-cell tag hint (0 atom, 1 integer, 2 float).
+  (local $c_tag i32)
+  (local.set $c_tag (i32.wrap_i64 (local.get $op2)))
+  (if (result i32) (call $get_mode) ;; write mode
     (then
-      (drop (call $heap_push_val (i32.const 0) (local.get $op1)))
+      (drop (call $heap_push_val (local.get $c_tag) (local.get $op1)))
       (call $inc_pc)
       (i32.const 1))
     (else
@@ -697,11 +735,13 @@ wam_wat_case(unify_constant,
 % --- Body construction ---
 
 wam_wat_case(put_constant,
-'  (local $ai i32)
+'  ;; op2 layout: high 32 = value-cell tag hint (0 atom, 1 integer,
+  ;; 2 float), low 32 = target reg index. Encoder packs this in
+  ;; wam_instruction_to_wat_bytes/3 via encode_constant_with_tag/3.
+  (local $ai i32) (local $c_tag i32)
   (local.set $ai (i32.wrap_i64 (local.get $op2)))
-  ;; Determine tag from constant type (op1 encodes either atom hash or integer)
-  ;; For now, use atom tag=0 for hashed values, integer tag=1 for raw integers
-  (call $set_reg (local.get $ai) (i32.const 0) (local.get $op1))
+  (local.set $c_tag (i32.wrap_i64 (i64.shr_u (local.get $op2) (i64.const 32))))
+  (call $set_reg (local.get $ai) (local.get $c_tag) (local.get $op1))
   (call $inc_pc)
   (i32.const 1)').
 
@@ -760,7 +800,10 @@ wam_wat_case(set_value,
   (i32.const 1)').
 
 wam_wat_case(set_constant,
-'  (drop (call $heap_push_val (i32.const 0) (local.get $op1)))
+'  ;; op2 = value-cell tag hint (0 atom, 1 integer, 2 float).
+  (local $c_tag i32)
+  (local.set $c_tag (i32.wrap_i64 (local.get $op2)))
+  (drop (call $heap_push_val (local.get $c_tag) (local.get $op1)))
   (call $inc_pc)
   (i32.const 1)').
 
@@ -1021,25 +1064,32 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
     (i64.eq (local.get $p1) (local.get $p2))))
 
 ;; --- Builtin dispatch ---
-;; O(1) br_table dispatch for ALL builtins including term inspection
-;; (functor/3, arg/3, =../2, copy_term/2 at IDs 18-21). Earlier
-;; versions routed 18-21 through a linear if-chain AFTER the br_table
-;; default — correct but O(k) in the number of term builtins, and
-;; on the hot path for any predicate that uses them. Folding them
-;; into the br_table makes every builtin call one compare (the
-;; br_table bounds check) and one indirect branch regardless of
-;; which builtin is selected.
+;; O(1) br_table dispatch for ALL builtins. Earlier versions routed
+;; term inspection (18-21) through a linear if-chain and left IDs
+;; 9-14 (type checks) + ID 22 (=/2) unimplemented — IDs 9-14 mapped
+;; to $default (returning 0), and =/2 was never even in the id table
+;; so the canonical WAM layer emitted `execute =/2` which resolved
+;; to PC=0 and corrupted execution. This version:
+;;   * maps IDs 9-14 to real type-check handlers ($var, $nonvar,
+;;     $atom, $integer, $float, $number)
+;;   * adds ID 22 $eq for =/2 calling $unify_regs A1 A2
+;; All builtins still dispatch in O(1) via one bounds check + one
+;; indirect branch.
 (func $execute_builtin (param $id i32) (param $arity i32) (result i32)
   (block $default
+    (block $eq
     (block $copy_term (block $univ (block $arg (block $functor
     (block $cut (block $fail (block $true_b
+    (block $number (block $float (block $integer
+    (block $atom (block $nonvar (block $var
     (block $arith_ge (block $arith_le (block $arith_gt (block $arith_lt
     (block $arith_ne (block $arith_eq (block $is
     (block $nl (block $write
       (br_table $write $nl $is $arith_eq $arith_ne $arith_lt $arith_gt $arith_le $arith_ge
-                $default $default $default $default $default $default
+                $var $nonvar $atom $integer $float $number
                 $true_b $fail $cut
                 $functor $arg $univ $copy_term
+                $eq
                 $default (local.get $id))
     ) ;; write
     (call $print_i64 (call $get_reg_payload (i32.const 0)))
@@ -1061,11 +1111,25 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
     (return (call $builtin_arith_cmp (i32.const 4)))
     ) ;; >=
     (return (call $builtin_arith_cmp (i32.const 5)))
-    ) ;; true
+    ) ;; var/1 (ID 9): A1 tag == 6 (unbound)
+    (return (i32.eq (call $get_reg_tag (i32.const 0)) (i32.const 6)))
+    ) ;; nonvar/1 (ID 10): A1 tag != 6
+    (return (i32.ne (call $get_reg_tag (i32.const 0)) (i32.const 6)))
+    ) ;; atom/1 (ID 11): A1 tag == 0
+    (return (i32.eq (call $get_reg_tag (i32.const 0)) (i32.const 0)))
+    ) ;; integer/1 (ID 12): A1 tag == 1
+    (return (i32.eq (call $get_reg_tag (i32.const 0)) (i32.const 1)))
+    ) ;; float/1 (ID 13): A1 tag == 2
+    (return (i32.eq (call $get_reg_tag (i32.const 0)) (i32.const 2)))
+    ) ;; number/1 (ID 14): A1 tag == 1 (integer) or 2 (float)
+    (return (i32.or
+              (i32.eq (call $get_reg_tag (i32.const 0)) (i32.const 1))
+              (i32.eq (call $get_reg_tag (i32.const 0)) (i32.const 2))))
+    ) ;; true (ID 15)
     (return (i32.const 1))
-    ) ;; fail
+    ) ;; fail (ID 16)
     (return (i32.const 0))
-    ) ;; cut
+    ) ;; cut (ID 17)
     (call $set_cp_count (i32.const 0))
     (return (i32.const 1))
     ) ;; functor/3 (ID 18)
@@ -1076,6 +1140,8 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
     (return (call $builtin_univ))
     ) ;; copy_term/2 (ID 21)
     (return (call $builtin_copy_term))
+    ) ;; =/2 (ID 22): unify A1 and A2 via the shared $unify_regs helper
+    (return (call $unify_regs (i32.const 0) (i32.const 1)))
   )
   ;; $default fall-through: unknown builtin ID
   (i32.const 0)

--- a/tests/test_wam_wat_target.pl
+++ b/tests/test_wam_wat_target.pl
@@ -398,6 +398,103 @@ run_wam_wat_module_export(WatFile, ExportName, Result) :-
     ;   throw(wam_wat_runtime_error(run(RExit, RunOut)))
     ).
 
+test(eq_builtin_id_registered) :-
+    %% =/2 is recognized by the canonical WAM layer and assigned
+    %% builtin ID 22 in WAM-WAT''s builtin_id table. Prior to this
+    %% branch, X = Y body goals compiled to `execute =/2`, which
+    %% (since =/2 was never registered) resolved to PC=0 and
+    %% corrupted execution at runtime.
+    assertion(wam_target:is_builtin_pred('=', 2)),
+    assertion(wam_wat_target:builtin_id('=/2', 22)).
+
+test(eq_dispatch_in_br_table) :-
+    %% =/2 is wired into the br_table via the new $eq block, so
+    %% dispatch is O(1) and calls $unify_regs A1 A2 directly.
+    wam_wat_target:compile_wam_helpers_to_wat([], HelpersCode),
+    assertion(sub_string(HelpersCode, _, _, _, "$eq")),
+    assertion(sub_string(HelpersCode, _, _, _, "(block $eq")),
+    assertion(sub_string(HelpersCode, _, _, _,
+        "(call $unify_regs (i32.const 0) (i32.const 1))")).
+
+test(constant_tag_encoded_in_op2) :-
+    %% put_constant encodes the value-cell tag hint (0=atom, 1=int,
+    %% 2=float) in op2''s high 32 bits alongside the target reg idx
+    %% in the low 32 bits. Before this fix, put_constant always
+    %% assumed tag=0 (atom), so integer constants were stored with
+    %% the wrong runtime tag and integer/1 always failed on them.
+    %%
+    %% Test: put_constant with integer 42 targeting A1 (reg idx 0).
+    %% 20-byte instruction layout:
+    %%   tag (4 bytes): \08 \00 \00 \00  (put_constant = 8)
+    %%   op1 (8 bytes): \2a \00 \00 \00 \00 \00 \00 \00  (LE i64 = 42)
+    %%   op2 (8 bytes): \00 \00 \00 \00 \01 \00 \00 \00
+    %%                  low 32 bits = 0 (reg A1)
+    %;                  high 32 bits = 0x00000001 (integer tag)
+    %% Each byte is encoded as "\xx" (3 chars). Byte 16 (op2 byte 4,
+    %% which carries the low byte of the high 32 bits) is at string
+    %% position 48 and should be "\\01".
+    wam_instruction_to_wat_bytes(put_constant(integer(42), 'A1'), [], Hex),
+    assertion(atom(Hex)),
+    sub_atom(Hex, 48, 3, _, Op2Byte4),
+    assertion(Op2Byte4 == '\\01').
+
+test(functional_integer_type_check, [condition(tool_available(wat2wasm)),
+                                       condition(tool_available(node))]) :-
+    %% integer/1 as a guard: `integer(42)` should succeed, returning 1.
+    %% Before this PR, integer/1 at ID 12 fell through the br_table to
+    %% $default which returned 0 (fail) unconditionally. After the fix,
+    %% the br_table routes ID 12 to a real handler that checks
+    %% A1.tag == 1 (integer).
+    get_time(T),
+    format(atom(WatFile),
+        '/data/data/com.termux/files/home/tmp/test_wam_func_int_~w.wat', [T]),
+    assertz(user:test_int_check :- integer(42)),
+    setup_call_cleanup(
+        true,
+        (   write_wam_wat_project([test_int_check/0],
+                                  [module_name(func_int_test)], WatFile),
+            run_wam_wat_module_export(WatFile, test_int_check_0, Result),
+            (   Result =:= 1
+            ->  true
+            ;   throw(wam_wat_runtime_error(int_check_failed(Result)))
+            )
+        ),
+        (   retractall(user:test_int_check),
+            (exists_file(WatFile) -> delete_file(WatFile) ; true),
+            file_name_extension(Base, _, WatFile),
+            file_name_extension(Base, wasm, WasmFile),
+            (exists_file(WasmFile) -> delete_file(WasmFile) ; true)
+        )
+    ).
+
+test(functional_atom_type_check_fail, [condition(tool_available(wat2wasm)),
+                                         condition(tool_available(node))]) :-
+    %% atom/1 as a guard: `atom(42)` should FAIL (42 is integer, not
+    %% atom). Return value 0 proves the dispatch distinguishes tags
+    %% correctly rather than unconditionally returning 1. Pairs with
+    %% functional_integer_type_check as a negative test.
+    get_time(T),
+    format(atom(WatFile),
+        '/data/data/com.termux/files/home/tmp/test_wam_func_atomfail_~w.wat', [T]),
+    assertz(user:test_atom_fail :- atom(42)),
+    setup_call_cleanup(
+        true,
+        (   write_wam_wat_project([test_atom_fail/0],
+                                  [module_name(func_atomfail_test)], WatFile),
+            run_wam_wat_module_export(WatFile, test_atom_fail_0, Result),
+            (   Result =:= 0
+            ->  true
+            ;   throw(wam_wat_runtime_error(atom_fail_wrong(Result)))
+            )
+        ),
+        (   retractall(user:test_atom_fail),
+            (exists_file(WatFile) -> delete_file(WatFile) ; true),
+            file_name_extension(Base, _, WatFile),
+            file_name_extension(Base, wasm, WasmFile),
+            (exists_file(WasmFile) -> delete_file(WasmFile) ; true)
+        )
+    ).
+
 test(functional_cross_predicate_call, [condition(tool_available(wat2wasm)),
                                          condition(tool_available(node))]) :-
     %% Cross-predicate label resolution end-to-end:


### PR DESCRIPTION
## Summary

Fixes three orthogonal pre-existing WAM-WAT codegen/dispatch bugs
called out as blockers in the Phase 6 perf writeup (§4.5). Together
they blocked any workload that uses unification in a body goal
(`X = Y`), uses a type check as a guard (`integer/1`, `atom/1`,
etc.), or expects an integer constant to actually have `tag=integer`
at runtime. Each fix is independent but they were developed and
tested together since all three surfaced in the same investigation.

During validation of these fixes, a **deeper pre-existing runtime
bug** was uncovered — Y/A register variable aliasing — which is
documented in the updated Phase 6 writeup but out of scope for
this PR.

## Fix 1: `=/2` lowered as a builtin

### Before

The canonical WAM compiler (`wam_target.pl`) did not recognize `=`
as a builtin predicate. A body goal like `Sum = Acc` compiled to
`execute =/2`, which is treated as an external user predicate call.
`resolve_label/3` misses (no user predicate named `=/2` exists),
returns `PC = 0`, and the VM jumps to the first instruction of the
merged project at runtime — silently re-entering an unrelated
predicate and corrupting execution state, eventually hitting
`memory access out of bounds`.

### After

- `wam_target.pl`: adds `is_builtin_pred(=, 2)`. The canonical
  WAM compiler now emits `builtin_call =/2, 2` for `X = Y`.
- `wam_wat_target.pl`: adds `builtin_id('=/2', 22)` and a new
  `$eq` block in the `$execute_builtin` `br_table`. The handler
  calls the existing `$unify_regs(A1, A2)` helper, which handles
  unbound-on-either-side binding and shallow bound-bound equality.
  O(1) dispatch, no if-chain.

## Fix 2: Type-check builtins (IDs 9–14)

### Before

`var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`
(IDs 9–14) were reserved in the `builtin_id` table but mapped to
`$default` in the `br_table`, which returns 0 (fail). Any predicate
that guards on `integer(T)` always took the failure path regardless
of T's actual type.

### After

The six `$default` slots in the `br_table` are replaced by real
handler blocks (`$var`, `$nonvar`, `$atom`, `$integer`, `$float`,
`$number`), each of which reads A1's runtime tag and returns
`tag == expected`:

| Builtin | Handler | Check |
|---|---|---|
| `var/1` (ID 9) | `$var` | `tag == 6` (Unbound) |
| `nonvar/1` (ID 10) | `$nonvar` | `tag != 6` |
| `atom/1` (ID 11) | `$atom` | `tag == 0` |
| `integer/1` (ID 12) | `$integer` | `tag == 1` |
| `float/1` (ID 13) | `$float` | `tag == 2` |
| `number/1` (ID 14) | `$number` | `tag == 1 ∨ tag == 2` |

Direct `i32.eq` / `i32.or` on the tag, no deref through refs (a
simplification adequate for values loaded into A_i via
`put_constant` — upgrading to deref-through-compound would be a
follow-up).

## Fix 3: Constant tag encoding

### Before

All four constant-using instructions (`put_constant`,
`get_constant`, `set_constant`, `unify_constant`) unconditionally
stored the runtime value-cell tag as 0 (atom). `put_constant 42, A1`
set A1 to `atom(42)`, not `integer(42)`. Consequently, `integer(42)`
legitimately returned 0 and `atom(42)` legitimately returned 1 — the
type-check dispatch (Fix 2) was correct, but the encoding was wrong.

Additionally, the canonical WAM layer hands constants down as
**strings** parsed from WAM assembly text (`"42"`, not the Prolog
integer `42`). The existing `encode_constant/2` had a catch-all
clause that returned 0 for strings — meaning every string constant
was silently stored as `atom("")`.

### After

New `encode_constant_with_tag/3` returns both a tag hint (0 = atom,
1 = integer, 2 = float) and the payload. It handles:

- `atom(A)` → tag 0, hash(A)
- `integer(I)` / Prolog integer → tag 1, raw I
- `float(F)` → tag 2, bit-cast
- **string** `"42"` → parse via `number_string` → tag 1, 42
- **string** `"hello"` → hash as atom → tag 0, hash("hello")
- catch-all → tag 0, 0

The four instruction encoders pack this tag into `op2`'s high 32
bits (for `put/get_constant`, which also carry a reg index in the
low 32 bits) or directly in `op2` (for `set/unify_constant`, which
don't need a reg index). The corresponding runtime case handlers
extract the tag via `i64.shr_u` and pass it to `set_reg` /
`heap_push_val`.

## New blocker surfaced: Y/A register variable aliasing (§4.5b)

Attempting to run `sum_ints` end-to-end after landing all three
fixes revealed a deeper pre-existing WAM-WAT runtime bug:
`put_variable Xn, Ai` creates **two independent** `Unbound` cells
in registers `Xn` and `Ai`, rather than aliasing both to a single
heap reference cell as standard WAM implementations do.

**Consequences observed:**

- When a callee binds `Ai` via `set_reg`, the caller's `Xn` stays
  unbound — the binding does not propagate.
- `X = 42, X = 42` and `X = 42, X = 99` both succeed: the first
  `=/2` binds A1, then `put_value Y1, A1` copies the stale
  unbound Y1 back into A1, and the second `=/2` re-binds A1 to
  a new value without error.
- `sum_ints` returns "success" but `Sum = 10` and `Sum = 999` both
  unify against the output, proving Sum was never actually
  computed.

**Proper fix** (out of scope for this PR): heap-allocated variable
cells with binding through refs. Each `put_variable Xn, Ai`
allocates one heap cell at address H; both `Xn` and `Ai` hold
`Ref(H)`. When a binding occurs, `val_store` updates the heap cell;
deref from either register reaches the shared cell. Trail bindings
record the heap address, not the register index.

## Changes

| File | Lines | Change |
|---|---|---|
| `src/unifyweaver/targets/wam_target.pl` | +7 | `is_builtin_pred(=, 2)` with explanatory comment |
| `src/unifyweaver/targets/wam_wat_target.pl` | +138 / −48 | `builtin_id('=/2', 22)`; `$execute_builtin` rewritten with 7 new blocks ($eq + 6 type checks); `encode_constant_with_tag/3` + 4 instruction encoder updates + 4 runtime handler updates |
| `tests/test_wam_wat_target.pl` | +97 | 5 new tests (2 codegen, 1 byte-layout, 2 functional runtime) |
| `docs/design/WAM_TERM_BUILTINS_PHASE_6_PERF.md` | +127 / −13 | §4.5a (three fixes landed), §4.5b (Y/A aliasing blocker), §8 follow-ups updated |

**Total:** 4 files changed, 321 insertions, 48 deletions in 1 commit.

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_wat_target.pl` —
      **57/57 passing** (52 from main + 5 new)
- [x] `wat2wasm` compiles every generated module (enforced by
      `wat2wasm_validates`)
- [x] `functional_integer_type_check` — `integer(42)` returns 1
      via wat2wasm + node (was 0 before the constant tag fix)
- [x] `functional_atom_type_check_fail` — `atom(42)` returns 0
      (negative test, was 1 before the constant tag fix)
- [x] `functional_cross_predicate_call` — still passing (from
      previous branch, validates cross-pred dispatch)
- [x] All other functional tests still pass (copy_term, univ,
      true)
- [x] No changes to WAM-Rust or WAM-Haskell, so their test
      suites are unaffected

## Follow-ups (tracked in §8 of the Phase 6 writeup)

1. **Y/A register variable aliasing** — heap-allocated variable
   cells with ref binding. Blocks real `sum_ints` execution.
2. **Real `is/2` arithmetic evaluator** — recursive evaluator over
   the arithmetic AST built from `put_structure +/2` +
   `set_value`/`set_constant` cells on the heap. Needed for
   `N1 is N - 1` style loops.
3. **WAM-Rust cross-predicate port** — module-level shared
   CODE/LABELS.
4. **Phase 6 perf rerun** — downstream of (1) + (2) at minimum.
