### PR TITLE
feat(wam-llvm): Dijkstra end-to-end foreign lowering (M5.9)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -149,6 +149,8 @@ foreign_kernel(PredArity, Kind, Config) :-
 %  on success.
 llvm_recursive_kernel_detector(transitive_distance3,
     llvm_recursive_kernel_transitive_distance).
+llvm_recursive_kernel_detector(weighted_shortest_path3,
+    llvm_recursive_kernel_weighted_shortest_path).
 
 %% llvm_recursive_kernel_transitive_distance(+Pred, +Arity, +Clauses, -RecKernel).
 %
@@ -185,6 +187,42 @@ llvm_foreign_lowerable_transitive_distance(Pred, 3, Clauses, EdgePred) :-
     RecGoal =.. [Pred, RecMid, RecTarget, PrevDepth],
     IsGoal =.. [is, RecDepth, Expr],
     Expr =.. [+, PrevDepth, 1].
+
+%% llvm_recursive_kernel_weighted_shortest_path(+Pred, +Arity, +Clauses, -RecKernel).
+%
+%  Detects the weighted_shortest_path3 clause shape:
+%    pred(X, Y, W) :- weight_pred(X, Y, W).
+%    pred(X, Y, Cost) :-
+%        weight_pred(X, Z, W),
+%        pred(Z, Y, RestCost),
+%        Cost is W + RestCost.
+%
+%  On success binds RecKernel to
+%    recursive_kernel(weighted_shortest_path3, Pred/Arity,
+%                     [weight_pred(WeightPred/3)]).
+llvm_recursive_kernel_weighted_shortest_path(Pred, Arity, Clauses,
+        recursive_kernel(weighted_shortest_path3, Pred/Arity,
+            [weight_pred(WeightPred/3)])) :-
+    llvm_foreign_lowerable_weighted_shortest_path(Pred, Arity, Clauses, WeightPred).
+
+%% llvm_foreign_lowerable_weighted_shortest_path(+Pred, +Arity, +Clauses, -WeightPred).
+%
+%  Ported from rust_target.pl:4045. Accepts the simple-form recursive
+%  body; the Rust target also accepts a visited-list form, which
+%  M5.9 does not yet mirror because Dijkstra doesn't need cycle
+%  checks (it tracks visited internally via best[]).
+llvm_foreign_lowerable_weighted_shortest_path(Pred, 3, Clauses, WeightPred) :-
+    member(BaseHead-BaseBody, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseHead \== RecHead,
+    BaseHead =.. [Pred, BaseStart, BaseTarget, BaseWeight],
+    BaseBody =.. [WeightPred, BaseStart, BaseTarget, BaseWeight],
+    RecHead =.. [Pred, RecStart, RecTarget, RecCost],
+    RecBody = (WeightGoal, (RecGoal, IsGoal)),
+    WeightGoal =.. [WeightPred, RecStart, RecMid, W],
+    RecGoal =.. [Pred, RecMid, RecTarget, RestCost],
+    IsGoal =.. [is, RecCost, PlusExpr],
+    PlusExpr =.. [+, W, RestCost].
 
 %% llvm_auto_detect_foreign_kernels(+Predicates) is det.
 %
@@ -260,18 +298,31 @@ lookup_foreign_kernel_spec(Pred, Arity, Kind, Config) :-
 %  edge_preds coexist in one module — each gets its own instance_id
 %  and its own edge table.
 substitute_foreign_kernel_impls(StateFuncsRaw, StateFuncs, Globals) :-
+    % td3 pass
     findall(PredArity-Config,
         llvm_foreign_kernel_spec(PredArity, transitive_distance3, Config),
         Td3Entries),
     ( Td3Entries == []
-    -> StateFuncs = StateFuncsRaw,
-       Globals = ''
-    ;  build_td3_instance_switch(Td3Entries, ImplBody, TablesIR),
-       replace_td3_weak_default(StateFuncsRaw, ImplBody, StateFuncs),
-       format(atom(Globals),
-'; === M5.6 + M5.8 foreign kernel support globals ===
-~w
-', [TablesIR])
+    -> StateFuncs0 = StateFuncsRaw, Td3Tables = ''
+    ;  build_td3_instance_switch(Td3Entries, Td3ImplBody, Td3Tables),
+       replace_td3_weak_default(StateFuncsRaw, Td3ImplBody, StateFuncs0)
+    ),
+    % wsp3 pass — mirror of the td3 pass but for weighted_shortest_path3.
+    findall(WspPredArity-WspConfig,
+        llvm_foreign_kernel_spec(WspPredArity, weighted_shortest_path3, WspConfig),
+        Wsp3Entries),
+    ( Wsp3Entries == []
+    -> StateFuncs = StateFuncs0, Wsp3Tables = ''
+    ;  build_wsp3_instance_switch(Wsp3Entries, Wsp3ImplBody, Wsp3Tables),
+       replace_wsp3_weak_default(StateFuncs0, Wsp3ImplBody, StateFuncs)
+    ),
+    % Concatenate the per-kind global tables into one Globals blob.
+    ( Td3Tables == '', Wsp3Tables == ''
+    -> Globals = ''
+    ;  atomic_list_concat([
+           '; === M5.6 + M5.8 + M5.9 foreign kernel support globals ===\n',
+           Td3Tables, '\n', Wsp3Tables, '\n'
+       ], Globals)
     ).
 
 %% build_td3_instance_switch(+Entries, -ImplBody, -TablesIR).
@@ -359,6 +410,101 @@ build_td3_instance_table(Config, TableName, TableIR, GepLen, EffLen, MaxAtomId) 
     llvm_emit_atom_fact2_table(TableName, Pairs, TableIR),
     length(Pairs, Len),
     ( Len == 0 -> EffLen = 0, GepLen = 1 ; EffLen = Len, GepLen = Len ).
+
+%% build_wsp3_instance_switch(+Entries, -ImplBody, -TablesIR).
+%
+%  M5.9 counterpart of build_td3_instance_switch. Emits one
+%  `define i1 @wam_wsp3_kernel_impl(...)` with a switch dispatching
+%  each instance to its own %WeightedFact edge table and a call to
+%  @wam_wsp3_run.
+build_wsp3_instance_switch(Entries, ImplBody, TablesIR) :-
+    build_wsp3_instance_parts(Entries, 0, SwitchCases, CaseBodies, Tables),
+    atomic_list_concat(SwitchCases, '\n', SwitchCasesStr),
+    atomic_list_concat(CaseBodies, '\n\n', CaseBodiesStr),
+    atomic_list_concat(Tables, '\n\n', TablesIR),
+    format(atom(ImplBody),
+'define i1 @wam_wsp3_kernel_impl(%WamState* %vm, i32 %instance) {
+entry:
+  switch i32 %instance, label %wsp_bail [
+~w
+  ]
+
+~w
+
+wsp_bail:
+  ret i1 false
+}',
+        [SwitchCasesStr, CaseBodiesStr]).
+
+build_wsp3_instance_parts([], _, [], [], []).
+build_wsp3_instance_parts([PredArity-Config | Rest], Index,
+        [SwitchCase|RestCases], [Body|RestBodies], [TableIR|RestTables]) :-
+    PredArity = Pred/_,
+    sanitize_atom_for_llvm(Pred, SanePred),
+    format(atom(TableName), 'wsp3_inst_~w_~w_edges', [SanePred, Index]),
+    build_wsp3_instance_table(Config, TableName, TableIR, GepLen, EffLen, MaxAtomId),
+    format(atom(SwitchCase), '    i32 ~w, label %wsp_inst_~w', [Index, Index]),
+    format(atom(Body),
+'wsp_inst_~w:
+  %wsp_tbl_~w = getelementptr [~w x %WeightedFact], [~w x %WeightedFact]* @~w, i64 0, i64 0
+  %wsp_r_~w = call i1 @wam_wsp3_run(%WamState* %vm, %WeightedFact* %wsp_tbl_~w, i64 ~w, i64 ~w)
+  ret i1 %wsp_r_~w',
+        [Index, Index, GepLen, GepLen, TableName, Index, Index, EffLen, MaxAtomId, Index]),
+    NextIndex is Index + 1,
+    build_wsp3_instance_parts(Rest, NextIndex, RestCases, RestBodies, RestTables).
+
+%% build_wsp3_instance_table(+Config, +TableName, -TableIR, -GepLen, -EffLen, -MaxAtomId).
+%
+%  Reads the weight predicate clauses from Config, emits a
+%  %WeightedFact private constant under TableName, and returns the
+%  sizing info the caller needs for the GEP and the @wam_wsp3_run
+%  call. The weight predicate has arity 3: weight_pred(From, To, Weight).
+build_wsp3_instance_table(Config, TableName, TableIR, GepLen, EffLen, MaxAtomId) :-
+    ( member(weight_pred(WeightPred), Config) -> true
+    ; WeightPred = weight/3  % default for smoke tests
+    ),
+    WeightPred = WPName/WPArity,
+    ( WPArity =:= 3 -> true
+    ; throw(foreign_lowering_weight_pred_arity(WPName/WPArity))
+    ),
+    catch(
+        findall(edge(From, To, Weight),
+            ( Goal =.. [WPName, From, To, Weight],
+              user:Goal
+            ),
+            Triples),
+        _, Triples = []),
+    compute_max_atom_id_weighted(Triples, MaxAtomId),
+    llvm_emit_weighted_edge_table(TableName, Triples, TableIR),
+    length(Triples, Len),
+    ( Len == 0 -> EffLen = 0, GepLen = 1 ; EffLen = Len, GepLen = Len ).
+
+%% compute_max_atom_id_weighted(+Triples, -MaxAtomId).
+%  Like compute_max_atom_id/2 but for edge(From, To, Weight) terms.
+%  Weight is ignored for the max-id bound.
+compute_max_atom_id_weighted([], 0).
+compute_max_atom_id_weighted(Triples, MaxAtomId) :-
+    findall(Id,
+        ( member(edge(From, To, _), Triples),
+          ( intern_atom(From, Id)
+          ; intern_atom(To, Id)
+          )
+        ),
+        Ids),
+    ( Ids == []
+    -> MaxAtomId = 0
+    ;  max_list(Ids, MaxAtomId)
+    ).
+
+%% replace_wsp3_weak_default(+StateFuncsRaw, +NewBody, -StateFuncs).
+replace_wsp3_weak_default(StateFuncsRaw, NewBody, StateFuncs) :-
+    Old = 'define weak i1 @wam_wsp3_kernel_impl(%WamState* %vm, i32 %instance) {\n  ret i1 false\n}',
+    ( string_replace(StateFuncsRaw, Old, NewBody, StateFuncs0)
+    -> StateFuncs = StateFuncs0
+    ;  format(user_error,
+        'WARNING: M5.9 could not find wsp3 weak-default in state template; leaving unchanged~n', []),
+       StateFuncs = StateFuncsRaw
+    ).
 
 %% sanitize_atom_for_llvm(+Atom, -Sanitized).
 %  Replace any characters that would be awkward in an LLVM global

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -1304,25 +1304,69 @@ bail:
   ret i1 false
 }
 
-; === M5.5 + M5.8: Foreign kernel impl default stub ===
-; The dispatcher's stub_transitive_distance3 case delegates to
-; @wam_td3_kernel_impl, passing the instance_id that was encoded in
-; the call_foreign instruction's op2. The default implementation
-; below returns false for any instance, so pure WAM modules behave
-; as if foreign dispatch is disabled.
+; === M5.9: wsp3 common runner helper ===
+; Parallels @wam_td3_run but wraps @wam_dijkstra_weighted_distance
+; (the M5.3 helper) instead of BFS. The concrete M5.9
+; @wam_wsp3_kernel_impl substituted body calls this with per-instance
+; (table, len, max_atom_id).
+;
+; Signature differences from @wam_td3_run:
+;   - %table is a %WeightedFact*, not %AtomFactPair*
+;   - the result slot is double*, not i64*
+;   - success writes A3 via @wam_set_reg_double, not @wam_set_reg_int
+define i1 @wam_wsp3_run(%WamState* %vm, %WeightedFact* %table, i64 %len, i64 %max_atom_id) {
+entry:
+  %wsp_s_tag = call i32 @wam_get_reg_tag(%WamState* %vm, i32 0)
+  %wsp_s_is_atom = icmp eq i32 %wsp_s_tag, 0
+  br i1 %wsp_s_is_atom, label %wsp_check_t, label %wsp_bail
+
+wsp_check_t:
+  %wsp_t_tag = call i32 @wam_get_reg_tag(%WamState* %vm, i32 1)
+  %wsp_t_is_atom = icmp eq i32 %wsp_t_tag, 0
+  br i1 %wsp_t_is_atom, label %wsp_run_dijkstra, label %wsp_bail
+
+wsp_run_dijkstra:
+  %wsp_start_id = call i64 @wam_get_reg_payload(%WamState* %vm, i32 0)
+  %wsp_target_id = call i64 @wam_get_reg_payload(%WamState* %vm, i32 1)
+  %wsp_dist_slot = alloca double
+  %wsp_ok = call i1 @wam_dijkstra_weighted_distance(
+      i64 %wsp_start_id, i64 %wsp_target_id,
+      %WeightedFact* %table, i64 %len,
+      i64 %max_atom_id,
+      double* %wsp_dist_slot)
+  br i1 %wsp_ok, label %wsp_hit, label %wsp_bail
+
+wsp_hit:
+  %wsp_dist = load double, double* %wsp_dist_slot
+  call void @wam_set_reg_double(%WamState* %vm, i32 2, double %wsp_dist)
+  ret i1 true
+
+wsp_bail:
+  ret i1 false
+}
+
+; === M5.5 + M5.8 + M5.9: Foreign kernel impl default stubs ===
+; The dispatcher's stub_{transitive_distance3, weighted_shortest_path3}
+; cases delegate to @wam_td3_kernel_impl and @wam_wsp3_kernel_impl
+; respectively, passing the instance_id encoded in the call_foreign
+; instruction's op2. The default implementations below return false
+; for any instance, so pure WAM modules behave as if foreign dispatch
+; is disabled.
 ;
 ; When foreign_lowering is enabled, the compile pipeline emits a
-; non-default definition of this function in place of the default.
-; The substituted version contains a `switch i32 %instance` with one
-; case per registered foreign-lowered predicate, each with its own
-; baked-in edge table as a module-local private constant. This lets
-; multiple td3 predicates with *different* edge_preds coexist in one
-; module — each gets its own instance_id and its own edge table.
+; non-default definition of each relevant function in place of the
+; default. The substituted version contains a `switch i32 %instance`
+; with one case per registered foreign-lowered predicate, each with
+; its own baked-in table as a module-local private constant.
 ;
 ; LLVM 21 disallows two definitions of the same function in one
 ; module, so the compile path picks one or the other (weak default
 ; or concrete substituted body) at template-rendering time.
 define weak i1 @wam_td3_kernel_impl(%WamState* %vm, i32 %instance) {
+  ret i1 false
+}
+
+define weak i1 @wam_wsp3_kernel_impl(%WamState* %vm, i32 %instance) {
   ret i1 false
 }
 
@@ -1363,8 +1407,11 @@ stub_transitive_distance3:
   ret i1 %td3_r
 
 stub_weighted_shortest_path3:
-  ; M5: weighted_shortest_path(Start, End, Dist) via Dijkstra
-  ret i1 false
+  ; Delegate to the user-provided impl, passing the instance_id so
+  ; the concrete substituted body can dispatch to the right
+  ; per-predicate weighted-edge table.
+  %wsp_r = call i1 @wam_wsp3_kernel_impl(%WamState* %vm, i32 %instance)
+  ret i1 %wsp_r
 
 stub_astar_shortest_path4:
   ; M5: astar_shortest_path(Start, End, Dim, Dist) via L_D norm A*

--- a/tests/core/test_wam_llvm_dijkstra_execution.pl
+++ b/tests/core/test_wam_llvm_dijkstra_execution.pl
@@ -1,0 +1,320 @@
+:- encoding(utf8).
+% test_wam_llvm_dijkstra_execution.pl
+% M5.9: End-to-end execution test for weighted_shortest_path3 via the
+% @wam_dijkstra_weighted_distance helper.
+%
+% This is the first test that actually runs the M5.3 Dijkstra helper
+% at runtime. Prior M5.3 tests only validated that the IR parses. M5.9
+% ports the full M5.6+M5.8 compile-pipeline infrastructure to
+% weighted_shortest_path3 (via the M5.9 @wam_wsp3_run helper, the
+% weak default @wam_wsp3_kernel_impl, and the substitution path in
+% substitute_foreign_kernel_impls) and then executes a compiled
+% binary to verify it computes the right answer.
+%
+% Critical test design choice: the graph is constructed so that the
+% GREEDY first-discovered path is NOT the optimal shortest path. If
+% @wam_dijkstra_weighted_distance's extract-min logic is broken (e.g.
+% it returned the first-reached target distance like BFS would), the
+% test would catch it. The graph:
+%
+%     a --10--> b --1--> c --1--> d    (three-hop path, total 12)
+%     a --100-> d                      (direct edge, total 100)
+%
+% Optimal shortest path from a to d is 12 (three hops), NOT 100
+% (direct). BFS would pick the direct edge if evaluated by hop count,
+% but Dijkstra's extract-min picks the lowest accumulated weight.
+%
+% A second test uses atoms with irrational-looking float weights to
+% exercise the @wam_set_reg_double bitcast path (float payload via
+% the M5.1 FFI bridge helper — first time this path is exercised at
+% runtime).
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3,
+     llvm_foreign_kernel_spec/3,
+     clear_llvm_foreign_kernel_specs/0]).
+:- use_module(library(process)).
+:- use_module(library(readutil)).
+:- use_module(library(pcre)).
+
+% Weight predicate — the fact table Dijkstra scans. Three-hop path
+% (a->b->c->d total weight 12) is cheaper than the direct edge (a->d
+% weight 100), so Dijkstra must find 12.
+:- dynamic wedge/3.
+wedge(a, b, 10.0).
+wedge(b, c, 1.0).
+wedge(c, d, 1.0).
+wedge(a, d, 100.0).
+
+% A second weight predicate for the "simple direct edge" case.
+:- dynamic wedge_simple/3.
+wedge_simple(x, y, 2.5).
+wedge_simple(y, z, 3.75).
+
+:- dynamic wsp/3.
+wsp(_, _, _) :- fail.
+
+:- dynamic wsp_simple/3.
+wsp_simple(_, _, _) :- fail.
+
+host_target_triple(Triple) :-
+    ( catch(
+        ( process_create(path(clang), ['-print-target-triple'],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, TripleStrRaw),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _, fail)
+    -> split_string(TripleStrRaw, "", "\n\r\t ", [TripleStr]),
+       atom_string(Triple, TripleStr)
+    ;  Triple = 'x86_64-pc-linux-gnu'
+    ).
+
+%% extract_atom_ids_from_weighted(+Src, +TableName, +Labels, -AtomIds)
+%
+%  Parse a %WeightedFact global's body to recover the interned atom
+%  IDs used for its from/to columns. Labels is the caller's known
+%  fact-order list of (FromLabel-ToLabel) pairs. Weights are ignored.
+extract_atom_ids_from_weighted(Src, TableName, Labels, AtomIds) :-
+    format(atom(StartMarker), '@~w = private constant', [TableName]),
+    once(sub_string(Src, StartIdx, _, _, StartMarker)),
+    sub_string(Src, StartIdx, _, 0, FromStart),
+    once(sub_string(FromStart, AfterTypeIdx, 3, _, "] [")),
+    BodyStart is AfterTypeIdx + 3,
+    sub_string(FromStart, BodyStart, _, 0, FromBody),
+    once(sub_string(FromBody, CloseIdx, 2, _, "\n]")),
+    sub_string(FromBody, 0, CloseIdx, _, TableBody),
+    re_foldl([Match, Acc, [FromId - ToId | Acc]]>>(
+        get_dict(from, Match, FromIdStr),
+        get_dict(to, Match, ToIdStr),
+        number_string(FromId, FromIdStr),
+        number_string(ToId, ToIdStr)
+    ),
+    "WeightedFact \\{ i64 (?<from>\\d+), i64 (?<to>\\d+), double",
+    TableBody, [], PairsRev, []),
+    reverse(PairsRev, Pairs),
+    zip_facts_to_ids(Labels, Pairs, Bindings),
+    dict_pairs(AtomIds, atom_ids, Bindings).
+
+zip_facts_to_ids(Labels, Pairs, Bindings) :-
+    zip_facts_loop(Labels, Pairs, [], Bindings).
+
+zip_facts_loop([], _, Acc, Sorted) :-
+    sort(1, @<, Acc, Sorted).
+zip_facts_loop([FromLabel-ToLabel | LRest], [FromId-ToId | PRest], Acc, Out) :- !,
+    add_binding(FromLabel, FromId, Acc, Acc1),
+    add_binding(ToLabel, ToId, Acc1, Acc2),
+    zip_facts_loop(LRest, PRest, Acc2, Out).
+zip_facts_loop(_, _, Acc, Sorted) :-
+    sort(1, @<, Acc, Sorted).
+
+add_binding(Label, _, Acc, Acc) :-
+    memberchk(Label-_, Acc), !.
+add_binding(Label, Id, Acc, [Label-Id | Acc]).
+
+extract_instr_count(Src, PredName, Count) :-
+    format(atom(Pat),
+        "@~w_code = private constant \\[(?<n>\\d+) x %Instruction\\]",
+        [PredName]),
+    re_matchsub(Pat, Src, Match, []),
+    get_dict(n, Match, NStr),
+    number_string(Count, NStr).
+
+extract_label_count(Src, PredName, Count) :-
+    format(atom(Pat),
+        "@~w_labels = private constant \\[(?<n>\\d+) x i32\\]",
+        [PredName]),
+    re_matchsub(Pat, Src, Match, []),
+    get_dict(n, Match, NStr),
+    number_string(Count, NStr).
+
+%% build_wsp_driver(+PredName, +InstrCount, +LabelArraySize,
+%%                  +StartId, +TargetId, +ExpectedScaled, -DriverIR)
+%
+%  A main() that mirrors @wsp's vm setup but reads A3 back as a
+%  double, multiplies by 100, converts to i32, and returns it. The
+%  test caller compares the exit code to the expected integer value
+%  (expected-distance * 100 truncated to int), which lets us check
+%  double distances via a 0-255 exit code.
+%
+%  Example: true distance 12.0 → exit 1200 & 0xff = 176
+%           true distance 2.5  → exit 250 & 0xff = 250
+%
+%  We pre-compute the expected scaled value in Prolog and compare
+%  exactly. The `& 0xff` truncation means distances above 2.55 require
+%  a different expected computation — the test handles that in
+%  run_wsp_for.
+build_wsp_driver(PredName, InstrCount, LabelArraySize, StartId, TargetId,
+        DriverIR) :-
+    format(atom(DriverIR),
+'; === M5.9 wsp execution driver ===
+define i32 @main() {
+entry:
+  %a1_0 = insertvalue %Value undef, i32 0, 0
+  %a1 = insertvalue %Value %a1_0, i64 ~w, 1
+  %a2_0 = insertvalue %Value undef, i32 0, 0
+  %a2 = insertvalue %Value %a2_0, i64 ~w, 1
+  %a3_0 = insertvalue %Value undef, i32 6, 0
+  %a3 = insertvalue %Value %a3_0, i64 0, 1
+
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @~w_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @~w_labels, i32 0, i32 0),
+      i32 0)
+
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %a1)
+  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %a2)
+  call void @wam_set_reg(%WamState* %vm, i32 2, %Value %a3)
+
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %hit, label %miss
+
+hit:
+  ; Read A3 tag: must be 2 (Float) for success.
+  %tag = call i32 @wam_get_reg_tag(%WamState* %vm, i32 2)
+  %tag_ok = icmp eq i32 %tag, 2
+  br i1 %tag_ok, label %read_double, label %wrong_tag
+
+read_double:
+  %dist = call double @wam_get_reg_double(%WamState* %vm, i32 2)
+  ; Scale by 100 and truncate to i32 so we can return the value
+  ; through the process exit code, which is unsigned 8-bit on most
+  ; platforms but reads as i32 from the LLVM side.
+  %dist100 = fmul double %dist, 1.0e2
+  %dist_i32 = fptosi double %dist100 to i32
+  ret i32 %dist_i32
+
+wrong_tag:
+  ; If the impl wrote the wrong tag, return a sentinel we can tell
+  ; apart from any valid scaled distance.
+  ret i32 254
+
+miss:
+  ret i32 255
+}
+',
+        [StartId, TargetId,
+         InstrCount, InstrCount, PredName, InstrCount,
+         LabelArraySize, LabelArraySize, PredName]).
+
+run_wsp_for(Label, PredIndicator, WeightPred, Facts, StartAtom, TargetAtom,
+        ExpectedDist) :-
+    format('  testing ~w: ~w(~w, ~w, _) expected ~w~n',
+        [Label, PredIndicator, StartAtom, TargetAtom, ExpectedDist]),
+    clear_llvm_foreign_kernel_specs,
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    host_target_triple(Triple),
+    PredIndicator = PredName/_,
+    write_wam_llvm_project(
+        [user:PredIndicator],
+        [ module_name('wsp_exec'),
+          target_triple(Triple),
+          target_datalayout(''),
+          foreign_predicates([
+              PredIndicator - weighted_shortest_path3 - [weight_pred(WeightPred)]
+          ])
+        ],
+        LLPath),
+    read_file_to_string(LLPath, Src, []),
+    % Find the instance-0 table name matching the predicate.
+    sanitize_for_test(PredName, SanePred),
+    format(atom(TableName), 'wsp3_inst_~w_0_edges', [SanePred]),
+    extract_atom_ids_from_weighted(Src, TableName, Facts, AtomIds),
+    get_dict(StartAtom, AtomIds, StartId),
+    get_dict(TargetAtom, AtomIds, TargetId),
+    extract_instr_count(Src, PredName, InstrCount),
+    extract_label_count(Src, PredName, LabelArraySize),
+    build_wsp_driver(PredName, InstrCount, LabelArraySize, StartId, TargetId,
+        DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out),
+        ( write(Out, '\n'), write(Out, DriverIR) ),
+        close(Out)),
+    atom_concat(LLPath, '.o', OPath),
+    atom_concat(LLPath, '.out', BinPath),
+    format(atom(LlcCmd),
+        'llc -filetype=obj -relocation-model=pic ~w -o ~w 2>~w.llc.err',
+        [LLPath, OPath, LLPath]),
+    shell(LlcCmd, LlcExit),
+    ( LlcExit =\= 0
+    -> format('    FAIL: llc exit=~w~n', [LlcExit]),
+       ExitCode = -1
+    ;  format(atom(ClangCmd),
+           'clang ~w -o ~w 2>~w.clang.err',
+           [OPath, BinPath, LLPath]),
+       shell(ClangCmd, ClangExit),
+       ( ClangExit =\= 0
+       -> format('    FAIL: clang link exit=~w~n', [ClangExit]),
+          ExitCode = -1
+       ;  shell(BinPath, ExitCode)
+       )
+    ),
+    % Expected exit code = expected_distance * 100, truncated to 8 bits.
+    ExpectedScaled is truncate(ExpectedDist * 100) /\ 255,
+    ( ExitCode =:= ExpectedScaled
+    -> format('    PASS: ~w returned scaled=~w (distance ≈ ~w)~n',
+          [Label, ExitCode, ExpectedDist])
+    ;  format('    FAIL: ~w returned ~w (expected scaled ~w for distance ~w)~n',
+          [Label, ExitCode, ExpectedScaled, ExpectedDist])
+    ),
+    catch(delete_file(LLPath), _, true),
+    catch(delete_file(OPath), _, true),
+    catch(delete_file(BinPath), _, true),
+    clear_llvm_foreign_kernel_specs,
+    assertion(ExitCode =:= ExpectedScaled).
+
+sanitize_for_test(Atom, Sane) :-
+    atom_codes(Atom, Codes),
+    maplist(sanitize_code_t, Codes, SaneCodes),
+    atom_codes(Sane, SaneCodes).
+sanitize_code_t(C, C) :-
+    ( (C >= 0'a, C =< 0'z) ; (C >= 0'A, C =< 0'Z)
+    ; (C >= 0'0, C =< 0'9) ; C =:= 0'_ ), !.
+sanitize_code_t(_, 0'_).
+
+test_dijkstra_executes :-
+    format('--- Dijkstra execution via llc + clang ---~n'),
+    ( process_which('clang'), process_which('llc')
+    -> % Critical test: greedy direct edge (100) vs three-hop path (12).
+       % Dijkstra must pick 12. If the kernel were BFS-shaped
+       % (first-reached wins), it would return 100 and this would fail.
+       run_wsp_for('three-hop beats direct (12 < 100)',
+           wsp/3, wedge/3,
+           [a-b, b-c, c-d, a-d],
+           a, d, 12.0),
+       % Sanity: direct-edge path returns its weight unchanged.
+       run_wsp_for('single direct edge',
+           wsp_simple/3, wedge_simple/3,
+           [x-y, y-z],
+           x, y, 2.5),
+       % Two-hop through simple weights.
+       run_wsp_for('two-hop float chain',
+           wsp_simple/3, wedge_simple/3,
+           [x-y, y-z],
+           x, z, 6.25),
+       % Self-hit fast path.
+       run_wsp_for('self hit',
+           wsp_simple/3, wedge_simple/3,
+           [x-y, y-z],
+           x, x, 0.0)
+    ;  format('  SKIP: clang or llc not found~n')
+    ).
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _),
+          close(Out),
+          process_wait(PID, exit(0))
+        ),
+        _,
+        fail).
+
+test_all :-
+    catch(test_dijkstra_executes, E,
+        format('  ERROR: ~w~n', [E])).
+
+:- initialization(test_all, main).


### PR DESCRIPTION
## Summary

Ports the full foreign-lowering pipeline from `transitive_distance3` to `weighted_shortest_path3`, making the M5.3 Dijkstra helper exercisable from Prolog source through all three M5.6 entry paths (options list, directive, auto-detect). This is the second kernel wired end-to-end in the LLVM target (after td3 in M5.6/M5.8) and the first to exercise the float-valued register path (`@wam_set_reg_double` / `@wam_get_reg_double`) at runtime.

The critical execution test uses a graph where the **greedy first-discovered path is NOT the optimal shortest path**, proving that Dijkstra's extract-min logic works correctly — not just that the IR compiles.

## Background

| Milestone | Status | Scope |
|---|---|---|
| M5.3 | merged (#1309) | Dijkstra helper `@wam_dijkstra_weighted_distance` — static validation only |
| M5.6 | merged (#1317) | foreign lowering pipeline — td3 only |
| M5.8 | merged (#1325) | multi-instance dispatch |
| **M5.9** | **this PR** | Dijkstra wired end-to-end — runtime execution validated |

M5.3 added the Dijkstra helper but never ran it. M5.6 built the compile pipeline but only for td3. M5.8 made multi-instance dispatch robust. M5.9 plugs Dijkstra into the existing pipeline and proves it works by compiling and running a native binary.

## Architecture

M5.9 follows the established M5.6 + M5.8 pattern exactly — no new infrastructure, just a second kernel kind wired through the same machinery.

### Runtime side (`state.ll.mustache`)

**New permanent helper:**

```llvm
define i1 @wam_wsp3_run(
    %WamState* %vm,
    %WeightedFact* %table,
    i64 %len,
    i64 %max_atom_id)
```

Parallels `@wam_td3_run` — reads A1/A2 atoms via the FFI bridge, calls `@wam_dijkstra_weighted_distance`, writes A3 via `@wam_set_reg_double`. The key difference from td3 is that the result is a `double` (shortest-path weight) instead of an `i64` (hop count).

**New weak default + delegation:**

```llvm
define weak i1 @wam_wsp3_kernel_impl(%WamState* %vm, i32 %instance) {
  ret i1 false
}
```

`stub_weighted_shortest_path3` now delegates to this function (passing `%instance` through from `call_foreign`'s op2), matching the M5.5/M5.8 pattern established for td3.

### Compile pipeline (`wam_llvm_target.pl`)

**`substitute_foreign_kernel_impls/3` gains a second pass** for `weighted_shortest_path3` specs, mirroring the td3 pass:

1. Gathers all specs registered with kind `weighted_shortest_path3`.
2. For each, reads the `weight_pred/3` facts from the user module, emits a `%WeightedFact` table via M4's `llvm_emit_weighted_edge_table/3`.
3. Builds a `switch i32 %instance` body for `@wam_wsp3_kernel_impl` with one case per registered spec, each calling `@wam_wsp3_run` with its own table pointer/len/max.
4. Replaces the weak default via `replace_wsp3_weak_default/3`.

The td3 and wsp3 passes run sequentially on the same state template output — wsp3 substitution happens after td3 substitution, so a module can have both kinds of foreign-lowered predicates simultaneously.

**Config shape:** `weight_pred(Name/3)` instead of `edge_pred(Name/2)`. The weight predicate has arity 3: `weight_pred(From, To, Weight)`. Weight must be a number (checked at fact-gathering time, not at registration time).

### Auto-detect matcher

New detector registration:

```prolog
llvm_recursive_kernel_detector(weighted_shortest_path3,
    llvm_recursive_kernel_weighted_shortest_path).
```

Ported from `rust_target.pl:4045-4089`. Recognizes the clause shape:

```prolog
pred(X, Y, W)    :- weight_pred(X, Y, W).
pred(X, Y, Cost) :- weight_pred(X, Z, W),
                     pred(Z, Y, RestCost),
                     Cost is W + RestCost.
```

The Rust target also accepts a `\+ member(Z, Visited)` form for cycle checking — M5.9 defers that since Dijkstra tracks visited internally and doesn't need cycle checks from the Prolog side.

## The Critical Test: Greedy ≠ Optimal

```
    a --10--> b --1--> c --1--> d    (three-hop path, total weight 12)
    a --100-> d                      (direct edge, total weight 100)
```

If `@wam_dijkstra_weighted_distance` were broken — for example, returning the first-reached target distance (like BFS) instead of the minimum-weight distance — it would return 100 (the direct edge is discovered first in a scan). The test asserts the correct answer is 12 (the three-hop path through b and c), which only comes out if the extract-min loop genuinely picks the node with the lowest accumulated weight at each step.

**This is the test case that distinguishes Dijkstra from BFS.** The td3 execution tests (M5.7) couldn't catch this class of bug because BFS and Dijkstra agree on unweighted graphs — both return the minimum-hop-count path. Only a weighted graph where the greedy path differs from the optimal path reveals whether the extract-min logic is correct.

## Additional Test Cases

| Case | Graph | Query | Expected | What it exercises |
|---|---|---|---|---|
| Three-hop beats direct | `wedge/3` | `wsp(a, d, D)` | `D = 12.0` | Dijkstra extract-min correctness |
| Single direct edge | `wedge_simple/3` | `wsp_simple(x, y, D)` | `D = 2.5` | `@wam_set_reg_double` / `@wam_get_reg_double` bitcast path |
| Two-hop float chain | `wedge_simple/3` | `wsp_simple(x, z, D)` | `D = 6.25` | `fadd double` precision through relaxation loop |
| Self-hit fast path | `wedge_simple/3` | `wsp_simple(x, x, D)` | `D = 0.0` | Early-exit in `@wam_dijkstra_weighted_distance` |

### Return-value encoding

The driver `main()` reads A3 as a double, multiplies by 100, truncates to `i32`, and returns it as the exit code. The Prolog test computes `truncate(ExpectedDist * 100) /\ 255` and compares. This lets us validate double distances through the integer-only process-exit-code channel without needing printf or file I/O in the generated LLVM module.

## Test Coverage

| Suite | Assertions | Scope |
|---|---|---|
| `test_wam_llvm_switch.pl` (M1) | 7 | regression |
| `test_wam_llvm_aggregate.pl` (M2) | 5 | regression |
| `test_wam_llvm_foreign_dispatch.pl` (M3) | 11 | regression |
| `test_wam_llvm_fact_tables.pl` (M4) | 10 | regression |
| `test_wam_llvm_ffi_bridge.pl` (M5.1) | 7 | regression |
| `test_wam_llvm_bfs_atom.pl` (M5.2) | 3 | regression |
| `test_wam_llvm_dijkstra.pl` (M5.3) | 4 | regression |
| `test_wam_llvm_astar.pl` (M5.4) | 4 | regression |
| `test_wam_llvm_td3_wiring.pl` (M5.5) | 4 | regression |
| `test_wam_llvm_foreign_lowering_options.pl` (M5.6a) | 9 | regression |
| `test_wam_llvm_foreign_lowering_directive.pl` (M5.6b) | 6 | regression |
| `test_wam_llvm_foreign_lowering_autodetect.pl` (M5.6c) | 9 | regression |
| `test_wam_llvm_bfs_execution.pl` (M5.7) | 4 | regression |
| `test_wam_llvm_reach_execution.pl` (M5.7) | 5 | regression |
| `test_wam_llvm_multi_instance_execution.pl` (M5.8) | 4 | regression |
| `test_wam_llvm_dijkstra_execution.pl` (M5.9) | 4 | **new** |
| **Total** | **96** | |

## Files Changed

- `templates/targets/llvm_wam/state.ll.mustache` — `@wam_wsp3_run` permanent helper, `@wam_wsp3_kernel_impl` weak default, `stub_weighted_shortest_path3` delegation.
- `src/unifyweaver/targets/wam_llvm_target.pl` — wsp3 substitution pass in `substitute_foreign_kernel_impls`, `build_wsp3_instance_switch/3` + parts + table helpers, `compute_max_atom_id_weighted/2`, `replace_wsp3_weak_default/3`, wsp3 auto-detect registration + matcher.
- `tests/core/test_wam_llvm_dijkstra_execution.pl` — new.

## Commits

- `928765f0` — feat(wam-llvm): Dijkstra end-to-end foreign lowering (M5.9)

## What's Next

Two wired kernels down, one to go:

1. **M5.10 — A* lowering.** Same pattern as M5.9 but adds a precomputed heuristic `double[]` as a fourth dimension. The Rust target uses `direct_dist_pred/3` config to compute heuristic values — the LLVM target would mirror that, emitting the heuristic array alongside the `%WeightedFact` edge table. This is the final kernel in the Dijkstra/A*/BFS trio.
2. **Stress tests.** With three kernels wired, run them on 100–1000 node graphs to catch scaling bugs and establish a performance baseline.
3. **Cross-target parity.** Port the remaining Rust kernel kinds (`category_ancestor`, `countdown_sum2`, `list_suffix2`, `transitive_closure2`) — each is a small self-contained PR following the established pattern.

## Test Plan

- [x] All 15 prior WAM-LLVM regression suites green (92 assertions).
- [x] M5.9 Dijkstra execution: `swipl -q tests/core/test_wam_llvm_dijkstra_execution.pl`
- [x] Critical greedy-vs-optimal test passes (three-hop path weight 12 beats direct edge weight 100).
- [x] Float register path (`@wam_set_reg_double` / `@wam_get_reg_double`) exercised at runtime for the first time.
- [x] All generated modules validate through `llvm-as` + `opt -passes=verify` (implicit via the `llc → clang` compile succeeding — llc runs the verifier pass internally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
