### PR TITLE
feat(rust): add panic fallback wrapper for pipelines

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -9061,11 +9061,14 @@ dep_to_toml(candle, "candle-core = \"0.9\"\ncandle-nn = \"0.9\"\ncandle-transfor
 %    pipeline_name(Name) - Name for the pipeline function (default: 'pipeline')
 %    pipeline_mode(Mode) - 'sequential' (default) or 'generator' (fixpoint)
 %    output_format(Format) - 'jsonl' (default) or 'json'
+%    panic_fallback(input) - have main call a safe wrapper that returns the
+%      original input if generated stage execution panics
 %
 compile_rust_pipeline(Predicates, Options, RustCode) :-
     option(pipeline_name(PipelineName), Options, pipeline),
     option(pipeline_mode(PipelineMode), Options, sequential),
     option(output_format(OutputFormat), Options, jsonl),
+    option(panic_fallback(PanicFallback), Options, none),
 
     % Generate header based on mode
     rust_pipeline_header(PipelineMode, Header),
@@ -9082,8 +9085,11 @@ compile_rust_pipeline(Predicates, Options, RustCode) :-
     % Generate the pipeline connector (mode-aware)
     generate_rust_pipeline_connector(StageNames, PipelineName, PipelineMode, ConnectorCode),
 
+    % Optionally generate a panic-catching entrypoint for outer fallback use.
+    generate_rust_pipeline_panic_fallback(PipelineName, PanicFallback, FallbackCode, MainPipelineName),
+
     % Generate main execution block
-    generate_rust_main_block(PipelineName, OutputFormat, MainBlock),
+    generate_rust_main_block(MainPipelineName, OutputFormat, MainBlock),
 
     % Combine all parts
     format(string(RustCode),
@@ -9093,9 +9099,10 @@ compile_rust_pipeline(Predicates, Options, RustCode) :-
 
 ~w
 ~w
+~w
 
 ~w
-", [Header, Helpers, StageFunctions, ConnectorCode, MainBlock]).
+", [Header, Helpers, StageFunctions, ConnectorCode, FallbackCode, MainBlock]).
 
 %% rust_pipeline_header(+Mode, -Header)
 %  Generate mode-aware header with use statements
@@ -9878,6 +9885,26 @@ generate_rust_fixpoint_stages(Names, Code) :-
     format(string(Code),
 "        let mut new_records: Vec<HashMap<String, Value>> = Vec::new();
 ~w", [StageCallsCode]).
+
+%% generate_rust_pipeline_panic_fallback(+PipelineName, +FallbackMode, -Code, -MainPipelineName)
+%  Generate an optional safe entrypoint around a standard Rust pipeline.
+generate_rust_pipeline_panic_fallback(PipelineName, input, Code, SafePipelineName) :-
+    !,
+    atom_string(PipelineName, PipelineNameStr),
+    format(string(SafePipelineNameStr), 'safe_~w', [PipelineNameStr]),
+    atom_string(SafePipelineName, SafePipelineNameStr),
+    format(string(Code),
+"
+/// Panic-catching entrypoint for outer fallback.
+fn ~w(input: Vec<HashMap<String, Value>>) -> Vec<HashMap<String, Value>> {
+    let fallback = input.clone();
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| ~w(input))) {
+        Ok(output) => output,
+        Err(_) => fallback,
+    }
+}
+", [SafePipelineNameStr, PipelineNameStr]).
+generate_rust_pipeline_panic_fallback(PipelineName, _FallbackMode, "", PipelineName).
 
 %% generate_rust_main_block(+PipelineName, +Format, -Code)
 %  Generate main execution block

--- a/tests/core/test_rust_pipeline_stage_placeholders.pl
+++ b/tests/core/test_rust_pipeline_stage_placeholders.pl
@@ -17,6 +17,16 @@ test(unsupported_enhanced_stage_fails_explicitly) :-
     \+ sub_string(Code, _, _, _, 'TODO: Implement based on predicate bindings'),
     once(sub_string(Code, _, _, _, 'panic!("unsupported Rust enhanced pipeline stage: unknown_stage/1")')).
 
+test(standard_pipeline_can_wrap_stage_panics_for_fallback) :-
+    once(compile_rust_pipeline([unknown_stage/1],
+        [pipeline_name(test_pipe), pipeline_mode(generator), panic_fallback(input)],
+        Code)),
+    once(sub_string(Code, _, _, _, 'fn test_pipe')),
+    once(sub_string(Code, _, _, _, 'fn safe_test_pipe')),
+    once(sub_string(Code, _, _, _, 'std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| test_pipe(input)))')),
+    once(sub_string(Code, _, _, _, 'Err(_) => fallback')),
+    once(sub_string(Code, _, _, _, 'let output = safe_test_pipe(input);')).
+
 :- end_tests(rust_pipeline_stage_placeholders).
 
 test_rust_pipeline_stage_placeholders :-


### PR DESCRIPTION
## Summary

This PR adds an explicit runtime fallback boundary for standard generated Rust pipelines.

- Adds `panic_fallback(input)` to `compile_rust_pipeline/3` options.
- Generates a `safe_<pipeline>` wrapper around the normal pipeline using `std::panic::catch_unwind`.
- Makes generated `main` call the safe wrapper when `panic_fallback(input)` is enabled.
- Returns the original input records if a generated stage panics.
- Adds test coverage for the generated wrapper, catch boundary, fallback arm, and main entrypoint routing.

## Why

Unsupported Rust pipeline stages now fail explicitly with `panic!` instead of silently passing input through. That is correct for surfacing missing lowering support, but any outer runtime fallback needs a catch boundary if the generated Rust pipeline is used speculatively.

This PR keeps the explicit panic behavior by default and adds an opt-in fallback wrapper for callers that want runtime recovery.

## Validation

- `timeout 120 swipl -q -g test_rust_pipeline_stage_placeholders -t halt tests/core/test_rust_pipeline_stage_placeholders.pl`
- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`
- `git diff --check`

