### PR TITLE
test(rust): update pipeline generator chain assertions

### DIFF
--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -10007,8 +10007,9 @@ test_rust_pipeline_generator :-
     % Test 7: Pipeline chain code for generator
     format("Test 7: Pipeline chain code for generator mode... ", []),
     (   compile_rust_pipeline([derive/1, transform/1], [pipeline_mode(generator)], Code7),
-        sub_string(Code7, _, _, _, "stage_derive_out"),
-        sub_string(Code7, _, _, _, "stage_transform_out")
+        sub_string(Code7, _, _, _, "let mut new_records: Vec<HashMap<String, Value>> = Vec::new();"),
+        sub_string(Code7, _, _, _, "new_records.extend(stage_derive(current.clone()));"),
+        sub_string(Code7, _, _, _, "new_records.extend(stage_transform(current.clone()));")
     ->  format("PASS~n", [])
     ;   format("FAIL~n", []), fail
     ),


### PR DESCRIPTION
## Summary

- Updates the embedded Rust pipeline generator unit test to match the current generator-mode connector code.
- Replaces stale assertions for intermediate `stage_*_out` bindings with assertions for the current `new_records` accumulation and `new_records.extend(stage_*(current.clone()))` chain.
- Keeps the change scoped to test expectations only; generated runtime behavior is unchanged.

## Validation

- `timeout 120 swipl -q -g "use_module(src/unifyweaver/targets/rust_target), test_rust_pipeline_generator" -t halt`
- `timeout 120 sh tests/integration/test_rust_pipeline_generator.sh`
- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`
- `git diff --check`
