### PR TITLE
feat(wam-llvm): A* end-to-end foreign lowering (M5.10)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -312,16 +312,25 @@ substitute_foreign_kernel_impls(StateFuncsRaw, StateFuncs, Globals) :-
         llvm_foreign_kernel_spec(WspPredArity, weighted_shortest_path3, WspConfig),
         Wsp3Entries),
     ( Wsp3Entries == []
-    -> StateFuncs = StateFuncs0, Wsp3Tables = ''
+    -> StateFuncs1 = StateFuncs0, Wsp3Tables = ''
     ;  build_wsp3_instance_switch(Wsp3Entries, Wsp3ImplBody, Wsp3Tables),
-       replace_wsp3_weak_default(StateFuncs0, Wsp3ImplBody, StateFuncs)
+       replace_wsp3_weak_default(StateFuncs0, Wsp3ImplBody, StateFuncs1)
+    ),
+    % astar4 pass
+    findall(AsPredArity-AsConfig,
+        llvm_foreign_kernel_spec(AsPredArity, astar_shortest_path4, AsConfig),
+        Astar4Entries),
+    ( Astar4Entries == []
+    -> StateFuncs = StateFuncs1, Astar4Tables = ''
+    ;  build_astar4_instance_switch(Astar4Entries, Astar4ImplBody, Astar4Tables),
+       replace_astar4_weak_default(StateFuncs1, Astar4ImplBody, StateFuncs)
     ),
     % Concatenate the per-kind global tables into one Globals blob.
-    ( Td3Tables == '', Wsp3Tables == ''
+    ( Td3Tables == '', Wsp3Tables == '', Astar4Tables == ''
     -> Globals = ''
     ;  atomic_list_concat([
-           '; === M5.6 + M5.8 + M5.9 foreign kernel support globals ===\n',
-           Td3Tables, '\n', Wsp3Tables, '\n'
+           '; === foreign kernel support globals ===\n',
+           Td3Tables, '\n', Wsp3Tables, '\n', Astar4Tables, '\n'
        ], Globals)
     ).
 
@@ -503,6 +512,74 @@ replace_wsp3_weak_default(StateFuncsRaw, NewBody, StateFuncs) :-
     -> StateFuncs = StateFuncs0
     ;  format(user_error,
         'WARNING: M5.9 could not find wsp3 weak-default in state template; leaving unchanged~n', []),
+       StateFuncs = StateFuncsRaw
+    ).
+
+%% build_astar4_instance_switch(+Entries, -ImplBody, -TablesIR).
+%
+%  M5.10 counterpart for astar_shortest_path4. Each per-instance case
+%  emits a %WeightedFact edge table (same as wsp3) PLUS a zeroed
+%  heuristic double[] array. The zero heuristic makes A* degenerate
+%  to Dijkstra, validating the full A* pipeline without requiring a
+%  target-dependent heuristic mechanism.
+build_astar4_instance_switch(Entries, ImplBody, TablesIR) :-
+    build_astar4_instance_parts(Entries, 0, SwitchCases, CaseBodies, Tables),
+    atomic_list_concat(SwitchCases, '\n', SwitchCasesStr),
+    atomic_list_concat(CaseBodies, '\n\n', CaseBodiesStr),
+    atomic_list_concat(Tables, '\n\n', TablesIR),
+    format(atom(ImplBody),
+'define i1 @wam_astar4_kernel_impl(%WamState* %vm, i32 %instance) {
+entry:
+  switch i32 %instance, label %as_bail [
+~w
+  ]
+
+~w
+
+as_bail:
+  ret i1 false
+}',
+        [SwitchCasesStr, CaseBodiesStr]).
+
+build_astar4_instance_parts([], _, [], [], []).
+build_astar4_instance_parts([PredArity-Config | Rest], Index,
+        [SwitchCase|RestCases], [Body|RestBodies], [AllTablesIR|RestTables]) :-
+    PredArity = Pred/_,
+    sanitize_atom_for_llvm(Pred, SanePred),
+    format(atom(EdgeTableName), 'astar4_inst_~w_~w_edges', [SanePred, Index]),
+    format(atom(HeuristicName), 'astar4_inst_~w_~w_heuristic', [SanePred, Index]),
+    build_wsp3_instance_table(Config, EdgeTableName, EdgeTableIR, GepLen, EffLen, MaxAtomId),
+    % Emit a zeroed heuristic array of size (MaxAtomId+1). The zero
+    % heuristic makes A* degenerate to Dijkstra — a future refinement
+    % can compute per-node estimates from direct_dist_pred/3 facts.
+    HeuristicSize is MaxAtomId + 1,
+    ( HeuristicSize =< 0 -> HeuristicArrSize = 1 ; HeuristicArrSize = HeuristicSize ),
+    format(atom(HeuristicIR),
+        '@~w = private constant [~w x double] zeroinitializer',
+        [HeuristicName, HeuristicArrSize]),
+    format(atom(AllTablesIR), '~w\n~w', [EdgeTableIR, HeuristicIR]),
+    format(atom(SwitchCase), '    i32 ~w, label %as_inst_~w', [Index, Index]),
+    format(atom(Body),
+'as_inst_~w:
+  %as_tbl_~w = getelementptr [~w x %WeightedFact], [~w x %WeightedFact]* @~w, i64 0, i64 0
+  %as_h_~w = getelementptr [~w x double], [~w x double]* @~w, i64 0, i64 0
+  %as_r_~w = call i1 @wam_astar4_run(%WamState* %vm, %WeightedFact* %as_tbl_~w, i64 ~w, double* %as_h_~w, i64 ~w)
+  ret i1 %as_r_~w',
+        [Index,
+         Index, GepLen, GepLen, EdgeTableName,
+         Index, HeuristicArrSize, HeuristicArrSize, HeuristicName,
+         Index, Index, EffLen, Index, MaxAtomId,
+         Index]),
+    NextIndex is Index + 1,
+    build_astar4_instance_parts(Rest, NextIndex, RestCases, RestBodies, RestTables).
+
+%% replace_astar4_weak_default(+StateFuncsRaw, +NewBody, -StateFuncs).
+replace_astar4_weak_default(StateFuncsRaw, NewBody, StateFuncs) :-
+    Old = 'define weak i1 @wam_astar4_kernel_impl(%WamState* %vm, i32 %instance) {\n  ret i1 false\n}',
+    ( string_replace(StateFuncsRaw, Old, NewBody, StateFuncs0)
+    -> StateFuncs = StateFuncs0
+    ;  format(user_error,
+        'WARNING: M5.10 could not find astar4 weak-default in state template; leaving unchanged~n', []),
        StateFuncs = StateFuncsRaw
     ).
 

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -1345,7 +1345,50 @@ wsp_bail:
   ret i1 false
 }
 
-; === M5.5 + M5.8 + M5.9: Foreign kernel impl default stubs ===
+; === M5.10: astar4 common runner helper ===
+; Parallels @wam_wsp3_run but wraps @wam_astar_weighted_distance
+; (the M5.4 A* helper). Uses a zeroed heuristic array — the caller
+; allocates and passes it. This means A* degenerates to Dijkstra
+; (same results, same complexity). A future refinement can supply a
+; non-zero heuristic via a separate global or a query-time callback.
+;
+; For M5.10, the zero-heuristic path validates the full A* pipeline
+; end-to-end without requiring a target-dependent heuristic mechanism
+; (the heuristic depends on which target is being queried, which is a
+; runtime value).
+define i1 @wam_astar4_run(%WamState* %vm, %WeightedFact* %table, i64 %len, double* %heuristic, i64 %max_atom_id) {
+entry:
+  %as_s_tag = call i32 @wam_get_reg_tag(%WamState* %vm, i32 0)
+  %as_s_is_atom = icmp eq i32 %as_s_tag, 0
+  br i1 %as_s_is_atom, label %as_check_t, label %as_bail
+
+as_check_t:
+  %as_t_tag = call i32 @wam_get_reg_tag(%WamState* %vm, i32 1)
+  %as_t_is_atom = icmp eq i32 %as_t_tag, 0
+  br i1 %as_t_is_atom, label %as_run, label %as_bail
+
+as_run:
+  %as_start_id = call i64 @wam_get_reg_payload(%WamState* %vm, i32 0)
+  %as_target_id = call i64 @wam_get_reg_payload(%WamState* %vm, i32 1)
+  %as_dist_slot = alloca double
+  %as_ok = call i1 @wam_astar_weighted_distance(
+      i64 %as_start_id, i64 %as_target_id,
+      %WeightedFact* %table, i64 %len,
+      double* %heuristic,
+      i64 %max_atom_id,
+      double* %as_dist_slot)
+  br i1 %as_ok, label %as_hit, label %as_bail
+
+as_hit:
+  %as_dist = load double, double* %as_dist_slot
+  call void @wam_set_reg_double(%WamState* %vm, i32 2, double %as_dist)
+  ret i1 true
+
+as_bail:
+  ret i1 false
+}
+
+; === M5.5 + M5.8 + M5.9 + M5.10: Foreign kernel impl default stubs ===
 ; The dispatcher's stub_{transitive_distance3, weighted_shortest_path3}
 ; cases delegate to @wam_td3_kernel_impl and @wam_wsp3_kernel_impl
 ; respectively, passing the instance_id encoded in the call_foreign
@@ -1367,6 +1410,10 @@ define weak i1 @wam_td3_kernel_impl(%WamState* %vm, i32 %instance) {
 }
 
 define weak i1 @wam_wsp3_kernel_impl(%WamState* %vm, i32 %instance) {
+  ret i1 false
+}
+
+define weak i1 @wam_astar4_kernel_impl(%WamState* %vm, i32 %instance) {
   ret i1 false
 }
 
@@ -1414,8 +1461,8 @@ stub_weighted_shortest_path3:
   ret i1 %wsp_r
 
 stub_astar_shortest_path4:
-  ; M5: astar_shortest_path(Start, End, Dim, Dist) via L_D norm A*
-  ret i1 false
+  %as_r = call i1 @wam_astar4_kernel_impl(%WamState* %vm, i32 %instance)
+  ret i1 %as_r
 
 not_registered:
   ret i1 false

--- a/tests/core/test_wam_llvm_astar_execution.pl
+++ b/tests/core/test_wam_llvm_astar_execution.pl
@@ -1,0 +1,213 @@
+:- encoding(utf8).
+% test_wam_llvm_astar_execution.pl
+% M5.10: End-to-end execution test for astar_shortest_path4 via the
+% @wam_astar_weighted_distance helper with a zero heuristic.
+%
+% With h=0 A* degenerates to Dijkstra, so the expected answers match
+% M5.9's Dijkstra execution test. The value of this test is that it
+% exercises the full A* pipeline end-to-end:
+%
+%   1. A zeroed heuristic [N x double] global is emitted alongside
+%      the %WeightedFact edge table.
+%   2. @wam_astar4_run passes both the edge table AND the heuristic
+%      pointer to @wam_astar_weighted_distance.
+%   3. The A* helper's min-scan computes f(n) = g(n) + h(n) where
+%      h(n)=0, confirming the extra fadd doesn't corrupt the result.
+%   4. The float bitcast return path (@wam_set_reg_double) is
+%      validated for A* specifically.
+%
+% Test graph (same as M5.9 Dijkstra — greedy ≠ optimal):
+%
+%     a --10--> b --1--> c --1--> d    (three-hop, total 12)
+%     a --100-> d                      (direct, total 100)
+%
+% Expected: A*(a, d) = 12.0 (same as Dijkstra)
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3,
+     clear_llvm_foreign_kernel_specs/0]).
+:- use_module(library(process)).
+:- use_module(library(readutil)).
+:- use_module(library(pcre)).
+
+:- dynamic astar_wedge/3.
+astar_wedge(a, b, 10.0).
+astar_wedge(b, c, 1.0).
+astar_wedge(c, d, 1.0).
+astar_wedge(a, d, 100.0).
+
+:- dynamic my_astar/3.
+my_astar(_, _, _) :- fail.
+
+host_target_triple(Triple) :-
+    ( catch(
+        ( process_create(path(clang), ['-print-target-triple'],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, Raw), close(Out),
+          process_wait(PID, exit(0))
+        ), _, fail)
+    -> split_string(Raw, "", "\n\r\t ", [S]),
+       atom_string(Triple, S)
+    ;  Triple = 'x86_64-pc-linux-gnu'
+    ).
+
+extract_atom_ids_from_weighted(Src, TableName, Labels, AtomIds) :-
+    format(atom(StartMarker), '@~w = private constant', [TableName]),
+    once(sub_string(Src, StartIdx, _, _, StartMarker)),
+    sub_string(Src, StartIdx, _, 0, FromStart),
+    once(sub_string(FromStart, AfterTypeIdx, 3, _, "] [")),
+    BodyStart is AfterTypeIdx + 3,
+    sub_string(FromStart, BodyStart, _, 0, FromBody),
+    once(sub_string(FromBody, CloseIdx, 2, _, "\n]")),
+    sub_string(FromBody, 0, CloseIdx, _, TableBody),
+    re_foldl([Match, Acc, [FromId - ToId | Acc]]>>(
+        get_dict(from, Match, FS), get_dict(to, Match, TS),
+        number_string(FromId, FS), number_string(ToId, TS)
+    ),
+    "WeightedFact \\{ i64 (?<from>\\d+), i64 (?<to>\\d+), double",
+    TableBody, [], PairsRev, []),
+    reverse(PairsRev, Pairs),
+    zip_facts_to_ids(Labels, Pairs, Bindings),
+    dict_pairs(AtomIds, atom_ids, Bindings).
+
+zip_facts_to_ids(L, P, B) :- zip_loop(L, P, [], B).
+zip_loop([], _, A, S) :- sort(1, @<, A, S).
+zip_loop([F-T|LR], [FI-TI|PR], A, O) :- !,
+    add_b(F, FI, A, A1), add_b(T, TI, A1, A2), zip_loop(LR, PR, A2, O).
+zip_loop(_, _, A, S) :- sort(1, @<, A, S).
+add_b(L, _, A, A) :- memberchk(L-_, A), !.
+add_b(L, I, A, [L-I|A]).
+
+extract_instr_count(Src, P, C) :-
+    format(atom(Pat), "@~w_code = private constant \\[(?<n>\\d+) x %Instruction\\]", [P]),
+    re_matchsub(Pat, Src, M, []), get_dict(n, M, NS), number_string(C, NS).
+extract_label_count(Src, P, C) :-
+    format(atom(Pat), "@~w_labels = private constant \\[(?<n>\\d+) x i32\\]", [P]),
+    re_matchsub(Pat, Src, M, []), get_dict(n, M, NS), number_string(C, NS).
+
+test_astar_executes :-
+    format('--- A* execution via llc + clang (zero heuristic) ---~n'),
+    ( process_which('clang'), process_which('llc')
+    -> run_astar_test
+    ;  format('  SKIP: clang or llc not found~n')
+    ).
+
+run_astar_test :-
+    clear_llvm_foreign_kernel_specs,
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    host_target_triple(Triple),
+    write_wam_llvm_project(
+        [user:my_astar/3],
+        [ module_name('astar_exec'),
+          target_triple(Triple),
+          target_datalayout(''),
+          foreign_predicates([
+              my_astar/3 - astar_shortest_path4 - [weight_pred(astar_wedge/3)]
+          ])
+        ],
+        LLPath),
+    read_file_to_string(LLPath, Src, []),
+
+    % Structural checks.
+    ( sub_string(Src, _, _, _, 'define i1 @wam_astar4_kernel_impl(%WamState* %vm, i32 %instance)')
+    -> format('  PASS: concrete astar4 impl substituted~n')
+    ;  format('  FAIL: astar4 impl missing~n'), throw(no_astar_impl)
+    ),
+    ( sub_string(Src, _, _, _, 'zeroinitializer')
+    -> format('  PASS: zero heuristic array emitted~n')
+    ;  format('  FAIL: heuristic array missing~n')
+    ),
+    ( sub_string(Src, _, _, _, 'call i1 @wam_astar4_run')
+    -> format('  PASS: instance case calls @wam_astar4_run~n')
+    ;  format('  FAIL: @wam_astar4_run call missing~n')
+    ),
+
+    % Extract atom IDs and build a driver main().
+    extract_atom_ids_from_weighted(Src, 'astar4_inst_my_astar_0_edges',
+        [a-b, b-c, c-d, a-d], AtomIds),
+    get_dict(a, AtomIds, AId),
+    get_dict(d, AtomIds, DId),
+    extract_instr_count(Src, my_astar, IC),
+    extract_label_count(Src, my_astar, LC),
+    format(atom(DriverIR),
+'; === M5.10 A* execution driver ===
+define i32 @main() {
+entry:
+  %a1_0 = insertvalue %Value undef, i32 0, 0
+  %a1 = insertvalue %Value %a1_0, i64 ~w, 1
+  %a2_0 = insertvalue %Value undef, i32 0, 0
+  %a2 = insertvalue %Value %a2_0, i64 ~w, 1
+  %a3_0 = insertvalue %Value undef, i32 6, 0
+  %a3 = insertvalue %Value %a3_0, i64 0, 1
+
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @my_astar_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @my_astar_labels, i32 0, i32 0),
+      i32 0)
+
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %a1)
+  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %a2)
+  call void @wam_set_reg(%WamState* %vm, i32 2, %Value %a3)
+
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %hit, label %miss
+
+hit:
+  %dist = call double @wam_get_reg_double(%WamState* %vm, i32 2)
+  %dist100 = fmul double %dist, 1.0e2
+  %dist_i32 = fptosi double %dist100 to i32
+  ret i32 %dist_i32
+
+miss:
+  ret i32 255
+}
+',
+        [AId, DId, IC, IC, IC, LC, LC]),
+    setup_call_cleanup(
+        open(LLPath, append, Out),
+        ( write(Out, '\n'), write(Out, DriverIR) ),
+        close(Out)),
+    atom_concat(LLPath, '.o', OPath),
+    atom_concat(LLPath, '.out', BinPath),
+    format(atom(LlcCmd),
+        'llc -filetype=obj -relocation-model=pic ~w -o ~w 2>~w.llc.err',
+        [LLPath, OPath, LLPath]),
+    shell(LlcCmd, LlcExit),
+    ( LlcExit =\= 0
+    -> format('  FAIL: llc exit=~w~n', [LlcExit]), ExitCode = -1
+    ;  format(atom(ClangCmd), 'clang ~w -o ~w 2>~w.clang.err',
+           [OPath, BinPath, LLPath]),
+       shell(ClangCmd, ClangExit),
+       ( ClangExit =\= 0
+       -> format('  FAIL: clang exit=~w~n', [ClangExit]), ExitCode = -1
+       ;  shell(BinPath, ExitCode)
+       )
+    ),
+    % Expected: A*(a, d) = 12.0 → scaled = 1200 & 255 = 176
+    ExpectedScaled is truncate(12.0 * 100) /\ 255,
+    ( ExitCode =:= ExpectedScaled
+    -> format('  PASS: A*(a,d) returned scaled=~w (distance=12.0, matching Dijkstra)~n',
+          [ExitCode])
+    ;  format('  FAIL: returned ~w (expected ~w for distance 12.0)~n',
+          [ExitCode, ExpectedScaled])
+    ),
+    catch(delete_file(LLPath), _, true),
+    catch(delete_file(OPath), _, true),
+    catch(delete_file(BinPath), _, true),
+    clear_llvm_foreign_kernel_specs,
+    assertion(ExitCode =:= ExpectedScaled).
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _), close(Out),
+          process_wait(PID, exit(0))
+        ), _, fail).
+
+test_all :-
+    catch(test_astar_executes, E,
+        format('  ERROR: ~w~n', [E])).
+
+:- initialization(test_all, main).


### PR DESCRIPTION
## Summary

Third and final kernel wired end-to-end in the WAM LLVM target, completing the BFS / Dijkstra / A* trio. All three graph-algorithm kernels from the Rust reference implementation now have a working Prolog → LLVM → native binary → execution path, validated through 100 assertions across 17 test suites.

M5.10 uses a zeroed heuristic array (`h(n)=0` for all `n`), which makes A* degenerate to Dijkstra — same results, same exploration order. This is a deliberate design choice explained below.

## Why Zero Heuristic

The A* heuristic `h(n)` estimates the remaining distance from node `n` to the **target** — but the target is a query-time argument (register A2), not a compile-time constant. Baking a non-zero heuristic into the module at compile time would only be correct for one specific target, making the kernel incorrect for all other queries.

The zero-heuristic path validates the full A* pipeline end-to-end:
- Heuristic `[N x double] zeroinitializer` global emitted and passed through the call chain
- `@wam_astar_weighted_distance` receives the `double*` pointer and uses it in its `f(n) = g(n) + h(n)` min-scan
- The extra `fadd double %best_mi, %h_mi` in the min-scan body doesn't corrupt the result (adding zero is an identity, but the codegen path for loading h[mi], performing the fadd, and comparing f values must still be correct)
- The `double` result flows back through `@wam_set_reg_double` → A3 register → exit code

A future refinement can supply non-zero heuristics via a query-time lookup table keyed by target atom ID, or a callback mechanism. The infrastructure — heuristic array global, `@wam_astar4_run` taking a `double*`, `@wam_astar_weighted_distance` accepting the heuristic pointer — is all in place for that.

## Background

| Kernel | Helper since | Pipeline wired | Execution-tested |
|---|---|---|---|
| `transitive_distance3` (BFS) | M5.2 (#1309) | M5.6 (#1317) | M5.7 (#1321) |
| `weighted_shortest_path3` (Dijkstra) | M5.3 (#1309) | M5.9 (#1330) | M5.9 (#1330) |
| `astar_shortest_path4` (A*) | M5.4 (#1314) | **M5.10 (this PR)** | **M5.10 (this PR)** |

The A* helper has been in the runtime template since M5.4 (PR #1314) and has passed `llvm-as` + `opt -passes=verify` since then, but this is the first time it's been wired through the compile pipeline and actually executed.

## Architecture

M5.10 follows the established M5.9 pattern exactly, with one addition: a zeroed heuristic array alongside each instance's edge table.

### Runtime (`state.ll.mustache`)

**New permanent helper:**

```llvm
define i1 @wam_astar4_run(
    %WamState* %vm,
    %WeightedFact* %table,
    i64 %len,
    double* %heuristic,
    i64 %max_atom_id)
```

Reads A1/A2 atoms, calls `@wam_astar_weighted_distance` with both the edge table and the heuristic pointer, writes A3 via `@wam_set_reg_double`. Parallels `@wam_wsp3_run` but passes the extra `double*` heuristic argument.

**New weak default + delegation:**

```llvm
define weak i1 @wam_astar4_kernel_impl(%WamState* %vm, i32 %instance) {
  ret i1 false
}
```

`stub_astar_shortest_path4` delegates to this, matching the M5.5/M5.8 pattern.

### Compile pipeline (`wam_llvm_target.pl`)

`substitute_foreign_kernel_impls/3` gains a third pass for `astar_shortest_path4` specs. Each per-instance switch case emits:

1. A `%WeightedFact` edge table (reusing `build_wsp3_instance_table/6` — same weight-pred config shape)
2. A zeroed `[MaxAtomId+1 x double] zeroinitializer` heuristic global
3. A case body that GEPs both pointers and calls `@wam_astar4_run`

```llvm
as_inst_0:
  %as_tbl_0 = getelementptr [4 x %WeightedFact], ... @astar4_inst_my_astar_0_edges ...
  %as_h_0   = getelementptr [6 x double], ... @astar4_inst_my_astar_0_heuristic ...
  %as_r_0   = call i1 @wam_astar4_run(%WamState* %vm,
                  %WeightedFact* %as_tbl_0, i64 4,
                  double* %as_h_0, i64 5)
  ret i1 %as_r_0
```

### Three-kernel coexistence

All three substitution passes (td3, wsp3, astar4) run sequentially on the same state template output. A module can have foreign-lowered predicates of all three kinds simultaneously — each kind's substitution replaces its own weak default independently, and the globals are concatenated.

## Execution Test

**File:** `tests/core/test_wam_llvm_astar_execution.pl` — 4 assertions.

Same graph as the M5.9 Dijkstra test (greedy ≠ optimal):

```
a --10--> b --1--> c --1--> d    (three-hop, total 12)
a --100-> d                      (direct, total 100)
```

**Cases:**
1. Concrete astar4 impl substituted into the module.
2. Zero heuristic array emitted (`zeroinitializer`).
3. Instance case calls `@wam_astar4_run`.
4. `A*(a, d) = 12.0` — correct shortest-path distance, matching Dijkstra (since `h=0`). Exit code = 176 (1200 & 255).

## The Full Trio — 100 Assertions

| Suite | Assertions | Scope |
|---|---|---|
| `test_wam_llvm_switch.pl` (M1) | 7 | regression |
| `test_wam_llvm_aggregate.pl` (M2) | 5 | regression |
| `test_wam_llvm_foreign_dispatch.pl` (M3) | 11 | regression |
| `test_wam_llvm_fact_tables.pl` (M4) | 10 | regression |
| `test_wam_llvm_ffi_bridge.pl` (M5.1) | 7 | regression |
| `test_wam_llvm_bfs_atom.pl` (M5.2) | 3 | regression |
| `test_wam_llvm_dijkstra.pl` (M5.3) | 4 | regression |
| `test_wam_llvm_astar.pl` (M5.4) | 4 | regression |
| `test_wam_llvm_td3_wiring.pl` (M5.5) | 4 | regression |
| `test_wam_llvm_foreign_lowering_options.pl` (M5.6a) | 9 | regression |
| `test_wam_llvm_foreign_lowering_directive.pl` (M5.6b) | 6 | regression |
| `test_wam_llvm_foreign_lowering_autodetect.pl` (M5.6c) | 9 | regression |
| `test_wam_llvm_bfs_execution.pl` (M5.7) | 4 | regression |
| `test_wam_llvm_reach_execution.pl` (M5.7) | 5 | regression |
| `test_wam_llvm_multi_instance_execution.pl` (M5.8) | 4 | regression |
| `test_wam_llvm_dijkstra_execution.pl` (M5.9) | 4 | regression |
| `test_wam_llvm_astar_execution.pl` (M5.10) | 4 | **new** |
| **Total** | **100** | |

## Files Changed

- `templates/targets/llvm_wam/state.ll.mustache` — `@wam_astar4_run` permanent helper, `@wam_astar4_kernel_impl` weak default, `stub_astar_shortest_path4` delegation.
- `src/unifyweaver/targets/wam_llvm_target.pl` — astar4 substitution pass, `build_astar4_instance_switch/3` + parts, `replace_astar4_weak_default/3`, heuristic array emission.
- `tests/core/test_wam_llvm_astar_execution.pl` — new.

## Commits

- `04a596df` — feat(wam-llvm): A* end-to-end foreign lowering (M5.10)

## Milestone Retrospective

The hybrid WAM LLVM port started with M1 (switch_on_constant) and has progressed through 10 milestones across 12 PRs:

| PR | Milestone | What it added |
|---|---|---|
| #1298 | M1 | `switch_on_constant` + 4 latent IR bug fixes |
| #1301 | M2 | aggregate frames |
| #1306 | M3 + M4 | foreign dispatch scaffolding + fact table emission |
| #1309 | M5.1–M5.3 | FFI bridge + BFS + Dijkstra helpers |
| #1314 | M5.4 + M5.5 | A* helper + td3 dispatcher delegation |
| #1317 | M5.6 | end-to-end foreign lowering pipeline (3 entry paths) |
| #1321 | M5.7 | execution tests + 2 runtime bug fixes (memset, inc_pc) |
| #1325 | M5.8 | multi-instance dispatch |
| #1330 | M5.9 | Dijkstra wired end-to-end |
| **this** | **M5.10** | **A* wired end-to-end — trio complete** |

Every graph-algorithm kernel from the Rust reference (BFS, Dijkstra, A*) now has a validated path from Prolog source through three user-facing entry points (directive, options shortcut, auto-detect) to native binary execution producing correct results.

## What's Next

With the trio complete, natural follow-up directions:

1. **Non-zero A* heuristic mechanism.** Design a query-time heuristic lookup — either a per-target precomputed table or a `direct_dist_pred/3`-based callback. This is the only missing piece for A* to be genuinely faster than Dijkstra on suitable graphs.
2. **Stress tests on larger graphs.** Run all three kernels on 100–1000 node graphs to catch scaling bugs and establish a performance baseline.
3. **Cross-target parity.** Port the remaining Rust kernel kinds (`category_ancestor`, `countdown_sum2`, `list_suffix2`, `transitive_closure2`) — each is a small self-contained PR following the established pattern.
4. **Multi-kind execution test.** A single module containing all three kernel kinds exercised simultaneously — the infrastructure supports this already but there's no test that exercises it.

## Test Plan

- [x] All 16 prior WAM-LLVM regression suites green (96 assertions).
- [x] M5.10 structural checks: concrete impl substituted, zero heuristic emitted, `@wam_astar4_run` called.
- [x] M5.10 execution: `A*(a, d) = 12.0` (matching Dijkstra for `h=0`).
- [x] All generated modules compile through `llc → clang` and produce runnable binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
