### PR TITLE
chore(rust): clean custom component load warnings

### DIFF
--- a/src/unifyweaver/core/component_registry.pl
+++ b/src/unifyweaver/core/component_registry.pl
@@ -443,8 +443,16 @@ test_component_registry :-
 % ============================================================================
 
 :- initialization((
-    % Define the runtime category by default
+    % Define core categories by default.
     define_category(runtime, "Execution-time components", [
+        requires_compilation(false),
+        singleton(false)
+    ]),
+    define_category(source, "Compile-time source components", [
+        requires_compilation(true),
+        singleton(false)
+    ]),
+    define_category(binding, "External binding components", [
         requires_compilation(false),
         singleton(false)
     ])

--- a/src/unifyweaver/targets/rust_runtime/custom_rust.pl
+++ b/src/unifyweaver/targets/rust_runtime/custom_rust.pl
@@ -24,7 +24,7 @@
     compile_component/4
 ]).
 
-:- use_module('../../core/component_registry').
+:- use_module('../../core/component_registry', [register_component_type/4]).
 
 %% type_info(-Info)
 %


### PR DESCRIPTION
## Summary

- Narrows `custom_rust.pl` to import only `register_component_type/4` from `component_registry`, removing weak-import override warnings for locally defined component callbacks.
- Defines the core `source` and `binding` component categories by default alongside `runtime`.
- Removes the undefined-category warning when registering the `custom_rust` source component type.
- Keeps component behavior unchanged; this is load-signal cleanup for Rust target and component registry initialization.

## Validation

- `timeout 120 swipl -q -g "use_module(src/unifyweaver/targets/rust_target)" -t halt`
- `timeout 120 swipl -q -g "use_module(src/unifyweaver/core/component_registry)" -t halt`
- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`
- `timeout 120 sh tests/integration/test_rust_pipeline_generator.sh`
- `timeout 120 swipl -q -g "use_module(src/unifyweaver/core/component_registry), test_component_registry" -t halt`
- `git diff --check`
