### PR TITLE
fix(wat): heap-top checkpointing in choice points

### DIFF
--- a/src/unifyweaver/targets/wam_wat_target.pl
+++ b/src/unifyweaver/targets/wam_wat_target.pl
@@ -45,8 +45,9 @@ wam_heap_base(131072).    % page 2
 % Register and choice point geometry (derived from register count)
 wam_num_regs(64).
 wam_val_size(12).         % bytes per tagged value
-%% wam_cp_size = 12 (metadata: next_pc + trail_mark + saved_cp) + num_regs * val_size
-wam_cp_size(Size) :- wam_num_regs(N), wam_val_size(V), Size is 12 + N * V.
+%% wam_cp_size = 16 (metadata: next_pc + trail_mark + saved_cp + saved_heap_top)
+%%             + num_regs * val_size
+wam_cp_size(Size) :- wam_num_regs(N), wam_val_size(V), Size is 16 + N * V.
 
 % Tag constants
 tag_atom(0).
@@ -950,8 +951,12 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
   (local.set $next_pc (call $cp_get_next_pc))
   (local.set $trail_mark (call $cp_get_trail_mark))
   (local.set $saved_cp (call $cp_get_saved_cp))
-  ;; Unwind trail
+  ;; Unwind trail (restores bound heap cells to their old values)
   (call $unwind_trail (local.get $trail_mark))
+  ;; Restore heap top (reclaim heap cells allocated since the CP was
+  ;; pushed — standard WAM behavior that prevents stale Ref cells in
+  ;; restored registers from pointing to garbage on the heap).
+  (call $set_heap_top (call $cp_get_saved_heap_top))
   ;; Restore registers from choice point
   (call $cp_restore_regs)
   ;; Restore state
@@ -991,7 +996,7 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
 
 ;; --- Choice point management ---
 ;; Choice points stored in a dedicated area starting at offset 98304 (page 1.5)
-;; Each CP: [next_pc:i32 +0][trail_mark:i32 +4][saved_cp:i32 +8][~w regs: ~w bytes +12] = ~w bytes
+;; Each CP: [next_pc:i32 +0][trail_mark:i32 +4][saved_cp:i32 +8][heap_top:i32 +12][~w regs: ~w bytes +16] = ~w bytes
 
 (func $cp_base_offset (result i32) (i32.const 98304))
 
@@ -1002,17 +1007,18 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
   (local $n i32) (local $off i32) (local $i i32)
   (local.set $n (call $get_cp_count))
   (local.set $off (call $cp_offset (local.get $n)))
-  ;; Save next_pc, trail mark, CP
+  ;; Save next_pc, trail mark, CP, heap_top
   (i32.store (local.get $off) (local.get $next_pc))
   (i32.store (i32.add (local.get $off) (i32.const 4)) (call $get_trail_top))
   (i32.store (i32.add (local.get $off) (i32.const 8)) (call $get_cp))
-  ;; Save all 64 registers (64 x 12 = 768 bytes)
+  (i32.store (i32.add (local.get $off) (i32.const 12)) (call $get_heap_top))
+  ;; Save all 64 registers (64 x 12 = 768 bytes) starting at +16
   (local.set $i (i32.const 0))
   (block $done
     (loop $save
       (br_if $done (i32.ge_u (local.get $i) (i32.const ~w)))
       (call $copy_from_reg (local.get $i)
-        (i32.add (i32.add (local.get $off) (i32.const 12))
+        (i32.add (i32.add (local.get $off) (i32.const 16))
                  (i32.mul (local.get $i) (i32.const 12))))
       (local.set $i (i32.add (local.get $i) (i32.const 1)))
       (br $save)))
@@ -1042,6 +1048,11 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
   (local.set $off (call $cp_offset (i32.sub (call $get_cp_count) (i32.const 1))))
   (i32.load (i32.add (local.get $off) (i32.const 8))))
 
+(func $cp_get_saved_heap_top (result i32)
+  (local $off i32)
+  (local.set $off (call $cp_offset (i32.sub (call $get_cp_count) (i32.const 1))))
+  (i32.load (i32.add (local.get $off) (i32.const 12))))
+
 (func $cp_restore_regs
   (local $off i32) (local $i i32)
   (local.set $off (call $cp_offset (i32.sub (call $get_cp_count) (i32.const 1))))
@@ -1050,7 +1061,7 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
     (loop $restore
       (br_if $done (i32.ge_u (local.get $i) (i32.const ~w)))
       (call $copy_to_reg (local.get $i)
-        (i32.add (i32.add (local.get $off) (i32.const 12))
+        (i32.add (i32.add (local.get $off) (i32.const 16))
                  (i32.mul (local.get $i) (i32.const 12))))
       (local.set $i (i32.add (local.get $i) (i32.const 1)))
       (br $restore)))


### PR DESCRIPTION
## Summary

Adds the standard WAM heap-top checkpoint to choice points so that
heap cells allocated during a failed clause are reclaimed on
backtrack. Without this, stale heap cells from failed branches
accumulate indefinitely and Ref cells in restored registers can
point to inconsistent heap state.

This is a small, focused fix (1 file, +19/−8) that completes the
choice point structure alongside the heap-based variable aliasing
landed in PR #1335.

## Problem

The WAM-WAT runtime's `$push_choice_point` saved three metadata
fields — `next_pc`, `trail_mark`, `saved_cp` — plus 64 registers.
It did **not** save `heap_top`. On backtrack, trail entries were
unwound and registers restored, but `heap_top` was never reset.

Consequence: every heap cell allocated by `put_variable`,
`put_structure`, `heap_push_val`, etc. during a failed clause
remained on the heap permanently. After PR #1335 introduced
heap-based variable aliasing (where `put_variable` allocates a
shared heap cell and both registers hold `Ref(H)`), restored
register values after backtrack could point to heap cells that
were allocated by the failed clause and still contained stale
bound values from that clause's execution — even after trail
unwinding restored explicitly-trailed cells.

## Fix

| Before | After |
|---|---|
| CP metadata: 12 bytes (`next_pc`, `trail_mark`, `saved_cp`) | CP metadata: 16 bytes (`next_pc`, `trail_mark`, `saved_cp`, **`saved_heap_top`**) |
| CP total: 780 bytes (12 + 64×12) | CP total: 784 bytes (16 + 64×12) |
| Register save area at +12 | Register save area at +16 |
| Backtrack: unwind trail, restore regs | Backtrack: unwind trail, **restore heap_top**, restore regs |

### Changes

- **`wam_cp_size/1`**: updated from `12 + N * V` to `16 + N * V`
- **`$push_choice_point`**: saves `get_heap_top` at offset +12;
  register save loop starts at +16 instead of +12
- **New `$cp_get_saved_heap_top`**: reads saved heap_top from +12
- **`$cp_restore_regs`**: register read loop starts at +16
- **`$backtrack`**: calls `set_heap_top(cp_get_saved_heap_top)`
  after trail unwinding, before register restore — so the heap is
  trimmed before any register deref could reach reclaimed cells
- **CP layout comment**: updated to document the +12 heap_top field

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_wat_target.pl` —
      **57/57 passing**
- [x] `wat2wasm` compiles every generated module
- [x] All functional tests pass (copy_term, univ, cross-pred,
      type checks, true)
- [x] `sum_ints(5, 0, _)` succeeds end-to-end (integer clause
      path exercising is/2 arithmetic + variable aliasing +
      choice point backtrack)

## Known limitation

`sum_ints(hello, 0, _)` — the atom path that backtracks from
clause 1 (integer/1 fails) to clause 2 (functor/3 + cross-pred
tail call to sum_ints_args) — still returns RESULT 0. The inlined
version of the same logic (without the cross-predicate call)
succeeds, confirming the issue is specific to the interaction
between:

- Backtracking within sum_ints (clause 1 → clause 2)
- Heap allocation in clause 2 (put_variable for functor/3 outputs)
- Functor/3 binding the heap cells
- Cross-predicate tail call (execute sum_ints_args/5)
- Sum_ints_args's own choice point + cut + =/2

The heap checkpoint alone doesn't resolve this; further
instrumented debugging of the exact deref/binding chain across
the cross-pred boundary is needed as a follow-up.

## Changes

| File | Lines |
|---|---|
| `src/unifyweaver/targets/wam_wat_target.pl` | +19 / −8 |

**Total:** 1 file changed, 19 insertions, 8 deletions in 1 commit.
