### PR TITLE
test(registry): cover default component categories

### DIFF
--- a/tests/core/test_component_registry.pl
+++ b/tests/core/test_component_registry.pl
@@ -50,8 +50,17 @@ assert_equal(Got, Expected, TestName) :-
 test_category_definition :-
     format('Test: Category definition~n'),
 
-    % Runtime category should already exist (from module init)
+    % Core categories should already exist (from module init)
     assert_true(category(runtime, _, _), 'runtime category exists'),
+    assert_true(category(source, _, _), 'source category exists'),
+    assert_true(category(binding, _, _), 'binding category exists'),
+
+    category(runtime, _, RuntimeOptions),
+    category(source, _, SourceOptions),
+    category(binding, _, BindingOptions),
+    assert_true(member(requires_compilation(false), RuntimeOptions), 'runtime does not require compilation'),
+    assert_true(member(requires_compilation(true), SourceOptions), 'source requires compilation'),
+    assert_true(member(requires_compilation(false), BindingOptions), 'binding does not require compilation'),
 
     % Define a new test category
     define_category(test_cat, "Test category", [requires_compilation(false)]),
@@ -60,6 +69,8 @@ test_category_definition :-
     % List categories
     list_categories(Cats),
     assert_true(member(runtime, Cats), 'runtime in category list'),
+    assert_true(member(source, Cats), 'source in category list'),
+    assert_true(member(binding, Cats), 'binding in category list'),
     assert_true(member(test_cat, Cats), 'test_cat in category list'),
 
     % Cleanup


### PR DESCRIPTION
## Summary

- Adds explicit test coverage for the component registry's default core categories.
- Verifies `runtime`, `source`, and `binding` are initialized by default.
- Checks each category has the expected `requires_compilation` option:
  - `runtime`: `false`
  - `source`: `true`
  - `binding`: `false`
- Locks in the category contract used by custom component registrations such as `custom_rust`.

## Validation

- `timeout 120 swipl -q -s tests/core/test_component_registry.pl -t halt`
- `timeout 120 swipl -q -g "use_module(src/unifyweaver/core/component_registry), test_component_registry" -t halt`
- `timeout 120 swipl -q -g "use_module(src/unifyweaver/targets/rust_target)" -t halt`
- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`
- `git diff --check`
