### PR TITLE
test(registry): avoid duplicate entrypoint runs

### DIFF
--- a/tests/core/test_component_registry.pl
+++ b/tests/core/test_component_registry.pl
@@ -142,4 +142,15 @@ test_builtin_test :-
 %% Main
 %% ============================================
 
-:- initialization(run_tests, main).
+main :-
+    current_prolog_flag(os_argv, Args),
+    explicit_run_tests_goal(Args),
+    !.
+main :-
+    run_tests.
+
+explicit_run_tests_goal(['-g', run_tests|_]) :- !.
+explicit_run_tests_goal([_|Rest]) :-
+    explicit_run_tests_goal(Rest).
+
+:- initialization(main, main).


### PR DESCRIPTION
## Summary

- Updates `tests/core/test_component_registry.pl` so explicit `-g run_tests` execution does not also trigger the file's `initialization(..., main)` test path.
- Keeps script-style execution via `swipl -q -s tests/core/test_component_registry.pl -t halt` working.
- Makes the component registry test entrypoint predictable for both direct and explicit-goal invocation styles.

## Validation

- `timeout 120 swipl -q -g run_tests -t halt tests/core/test_component_registry.pl`
- `timeout 120 swipl -q -s tests/core/test_component_registry.pl -t halt`
- `timeout 120 swipl -q -g "use_module(src/unifyweaver/targets/rust_target)" -t halt`
- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl`
- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_rust_runtime.pl`
- `git diff --check`
