### PR TITLE
feat(wam-haskell): WAM-lowered Haskell function emission (Phases 1-4)

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
@@ -1,0 +1,208 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% wam_haskell_lowered_emitter.pl - WAM-lowered Haskell emission (Phase 3+)
+%
+% Emits one Haskell function per Prolog predicate, mirroring the WAM
+% interpreter's step-function semantics inline. The resulting function
+% has the shape:
+%
+%     lowered_<name>_<arity> :: WamContext -> WamState -> Maybe WamState
+%
+% and is invoked by WamRuntime.step's Call dispatch chain via the
+% wcLoweredPredicates lookup (see Phase 2).
+%
+% Phase 3 ships only the smallest useful whitelist — `get_constant` and
+% `proceed` — which covers single-clause facts with integer/atom
+% arguments. Phase 4+ expands the whitelist.
+%
+% See docs/design/WAM_HASKELL_LOWERED_SPECIFICATION.md §2 for the
+% per-instruction → Haskell mapping contract, and
+% docs/design/WAM_HASKELL_LOWERED_IMPLEMENTATION_PLAN.md §"Phase 3" for
+% the ordering.
+
+:- module(wam_haskell_lowered_emitter, [
+    wam_haskell_lowerable/3,       % +PredIndicator, +WamCode, -Reason
+    lower_predicate_to_haskell/4   % +PredIndicator, +WamCode, +Options, -Lowered
+]).
+
+:- use_module(library(lists)).
+
+%% ---------------------------------------------------------------------
+%% Parsing
+%% ---------------------------------------------------------------------
+%
+% The WAM target (wam_target.pl) emits WAM as text. Each predicate's
+% WamCode argument is a multi-line atom/string with one line per
+% instruction. The first line is always the predicate label
+% (`<name>/<arity>:`), followed by indented instruction lines. An
+% instruction line splits into a mnemonic (e.g. `get_constant`) and
+% argument tokens, possibly with trailing commas.
+
+%% parse_wam_text(+WamText, -Instructions)
+%  Parse a WAM text atom/string into a list of instruction terms.
+%  Returns a list of compound terms whose functor is the mnemonic and
+%  whose arguments are the token strings in order (commas stripped).
+%  Skips blank lines and the predicate-label line.
+parse_wam_text(WamText, Instructions) :-
+    atom_string(WamText, S),
+    split_string(S, "\n", "", Lines),
+    parse_wam_lines(Lines, Instructions).
+
+parse_wam_lines([], []).
+parse_wam_lines([Line|Rest], Instructions) :-
+    string_trim(Line, Trimmed),
+    (   Trimmed == ""
+    ->  parse_wam_lines(Rest, Instructions)
+    ;   sub_string(Trimmed, _, 1, 0, ":")   % label line like "foo/1:"
+    ->  parse_wam_lines(Rest, Instructions)
+    ;   tokenize_instruction(Trimmed, Instr),
+        Instructions = [Instr|InstructionsRest],
+        parse_wam_lines(Rest, InstructionsRest)
+    ).
+
+string_trim(S, T) :-
+    split_string(S, "", " \t", [T0]),
+    T = T0.
+
+tokenize_instruction(Line, Term) :-
+    split_string(Line, " \t", " \t,", Tokens),
+    exclude(=(""), Tokens, NonEmpty),
+    NonEmpty = [MnemonicStr|Args],
+    atom_string(Mnemonic, MnemonicStr),
+    Term =.. [Mnemonic|Args].
+
+%% ---------------------------------------------------------------------
+%% Lowerability
+%% ---------------------------------------------------------------------
+
+%% wam_haskell_lowerable(+PredIndicator, +WamCode, -Reason)
+%  True iff PredIndicator's WamCode consists entirely of instructions
+%  in the Phase 3 whitelist. On failure, Reason is left unbound — the
+%  caller that cares why a predicate could not be lowered should log
+%  the Reason via a separate helper.
+wam_haskell_lowerable(_PredIndicator, WamCode, _Reason) :-
+    parse_wam_text(WamCode, Instructions),
+    % Phase 3 whitelist + structural constraint: all instructions must
+    % be supported, the sequence must end with proceed, and there must
+    % be exactly one proceed (no branching within the predicate body).
+    forall(member(I, Instructions), phase3_supported(I)),
+    last(Instructions, proceed),
+    include(=(proceed), Instructions, Proceeds),
+    length(Proceeds, 1).
+
+phase3_supported(get_constant(_, _)).
+phase3_supported(proceed).
+
+%% ---------------------------------------------------------------------
+%% Emission
+%% ---------------------------------------------------------------------
+
+%% lower_predicate_to_haskell(+PredIndicator, +WamCode, +Options, -Lowered)
+%  Lower PredIndicator to a Haskell function. Lowered is a term
+%      lowered(PredName, FuncName, HaskellCode)
+%  where PredName is the Prolog-style "<name>/<arity>" key used by
+%  wcLoweredPredicates dispatch, FuncName is the Haskell identifier of
+%  the generated function, and HaskellCode is the full source text of
+%  that function (ready to splice into Lowered.hs).
+lower_predicate_to_haskell(PredIndicator, WamCode, _Options,
+                           lowered(PredName, FuncName, HaskellCode)) :-
+    (   PredIndicator = _Module:Pred/Arity -> true
+    ;   PredIndicator = Pred/Arity
+    ),
+    format(atom(PredName), '~w/~w', [Pred, Arity]),
+    format(atom(FuncName), 'lowered_~w_~w', [Pred, Arity]),
+    parse_wam_text(WamCode, Instructions),
+    emit_function(FuncName, Instructions, HaskellCode).
+
+%% emit_function(+FuncName, +Instructions, -HaskellCode)
+%  Emit a complete Haskell function definition for the whitelisted
+%  instruction sequence. Phase 3 only supports a run of GetConstants
+%  followed by a single Proceed.
+emit_function(FuncName, Instructions, HaskellCode) :-
+    append(GetConstants, [proceed], Instructions),
+    forall(member(GC, GetConstants), GC = get_constant(_, _)),
+    with_output_to(string(HaskellCode), (
+        format("-- | Lowered form (Phase 3: get_constant+proceed)~n"),
+        format("~w :: WamContext -> WamState -> Maybe WamState~n", [FuncName]),
+        format("~w !_ctx s0 =~n", [FuncName]),
+        emit_chain(GetConstants, 0)
+    )).
+
+%% emit_chain(+GetConstantList, +Depth)
+%  Print the body chain directly to current output. Each recursive step
+%  handles one GetConstant at state variable s<Depth>, threading into
+%  s<Depth+1>. When the list is empty, prints the inlined Proceed tail
+%  at the current state variable.
+emit_chain([], Depth) :-
+    format(atom(SV), 's~w', [Depth]),
+    emit_proceed_tail(SV).
+emit_chain([get_constant(CStr, RegStr)|Rest], Depth) :-
+    value_to_haskell(CStr, HsConst),
+    reg_to_int(RegStr, RegId),
+    NextDepth is Depth + 1,
+    format(atom(SV),   's~w',   [Depth]),
+    format(atom(SVn),  's~w',   [NextDepth]),
+    format(atom(VIDn), 'vid~w', [Depth]),
+    indent_for(Depth, Pad),
+    format("~w  case fmap (derefVar (wsBindings ~w)) (IM.lookup ~w (wsRegs ~w)) of~n",
+           [Pad, SV, RegId, SV]),
+    format("~w    Just v | v == (~w) ->~n", [Pad, HsConst]),
+    format("~w      let ~w = ~w in~n",      [Pad, SVn, SV]),
+    emit_chain(Rest, NextDepth),
+    format("~w    Just (Unbound ~w) ->~n",  [Pad, VIDn]),
+    format("~w      let ~w = ~w { wsRegs = IM.insert ~w (~w) (wsRegs ~w)~n",
+           [Pad, SVn, SV, RegId, HsConst, SV]),
+    format("~w                  , wsBindings = IM.insert ~w (~w) (wsBindings ~w)~n",
+           [Pad, VIDn, HsConst, SV]),
+    format("~w                  , wsTrail = TrailEntry ~w (IM.lookup ~w (wsBindings ~w)) : wsTrail ~w~n",
+           [Pad, VIDn, VIDn, SV, SV]),
+    format("~w                  , wsTrailLen = wsTrailLen ~w + 1~n", [Pad, SV]),
+    format("~w                  }~n", [Pad]),
+    format("~w      in~n", [Pad]),
+    emit_chain(Rest, NextDepth),
+    format("~w    _ -> Nothing~n", [Pad]).
+
+%% emit_proceed_tail(+StateVar)
+%  Emit the inline Proceed logic as the innermost continuation of a
+%  lowered predicate at the given state variable.
+emit_proceed_tail(StateVar) :-
+    format("      let retAddr = wsCP ~w~n", [StateVar]),
+    format("      in if retAddr == 0~n"),
+    format("         then Just (~w { wsPC = 0 })~n", [StateVar]),
+    format("         else Just (~w { wsPC = retAddr, wsCP = 0 })~n", [StateVar]).
+
+%% indent_for(+Depth, -Indent)
+%  Produce an indentation string for a given nesting depth.
+indent_for(0, '').
+indent_for(N, Indent) :-
+    N > 0,
+    N1 is N - 1,
+    indent_for(N1, Prev),
+    atom_concat(Prev, '      ', Indent).
+
+%% ---------------------------------------------------------------------
+%% Value and register translation (local to the emitter; intentionally
+%% duplicates the equivalent helpers in wam_haskell_target.pl so the
+%% emitter module has no circular import into its caller).
+%% ---------------------------------------------------------------------
+
+value_to_haskell(Str, Hs) :-
+    (   number_string(N, Str), integer(N)
+    ->  format(string(Hs), 'Integer ~w', [N])
+    ;   number_string(F, Str), float(F)
+    ->  format(string(Hs), 'Float ~w', [F])
+    ;   format(string(Hs), 'Atom "~w"', [Str])
+    ).
+
+reg_to_int(Reg, Int) :-
+    atom_string(RegA, Reg),
+    sub_atom(RegA, 0, 1, _, Bank),
+    sub_atom(RegA, 1, _, 0, NumA),
+    atom_number(NumA, Num),
+    (   Bank == 'A' -> Int = Num
+    ;   Bank == 'X' -> Int is Num + 100
+    ;   Bank == 'Y' -> Int is Num + 200
+    ;   Int = 0
+    ).

--- a/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
@@ -2,207 +2,306 @@
 % SPDX-License-Identifier: MIT OR Apache-2.0
 % Copyright (c) 2026 John William Creighton (@s243a)
 %
-% wam_haskell_lowered_emitter.pl - WAM-lowered Haskell emission (Phase 3+)
+% wam_haskell_lowered_emitter.pl — WAM-lowered Haskell emission (Phase 4+)
 %
-% Emits one Haskell function per Prolog predicate, mirroring the WAM
-% interpreter's step-function semantics inline. The resulting function
-% has the shape:
+% Emits one Haskell function per predicate using Maybe-monad do-notation.
+% Simple register operations are inlined as `let` bindings; complex
+% instructions (Call, BuiltinCall, GetConstant, PutStructure sequences)
+% delegate to `step` or `dispatchCall` from WamRuntime. This gives us:
+%   - No per-instruction array-fetch for the hot path
+%   - GHC can specialize step calls for known instruction constructors
+%   - Correctness for free via step's existing semantics
 %
-%     lowered_<name>_<arity> :: WamContext -> WamState -> Maybe WamState
-%
-% and is invoked by WamRuntime.step's Call dispatch chain via the
-% wcLoweredPredicates lookup (see Phase 2).
-%
-% Phase 3 ships only the smallest useful whitelist — `get_constant` and
-% `proceed` — which covers single-clause facts with integer/atom
-% arguments. Phase 4+ expands the whitelist.
-%
-% See docs/design/WAM_HASKELL_LOWERED_SPECIFICATION.md §2 for the
-% per-instruction → Haskell mapping contract, and
-% docs/design/WAM_HASKELL_LOWERED_IMPLEMENTATION_PLAN.md §"Phase 3" for
-% the ordering.
+% For multi-clause predicates, only clause 1 is lowered. Clause 2+ stays
+% in the interpreter's instruction array for backtrack fallback.
 
 :- module(wam_haskell_lowered_emitter, [
-    wam_haskell_lowerable/3,       % +PredIndicator, +WamCode, -Reason
-    lower_predicate_to_haskell/4   % +PredIndicator, +WamCode, +Options, -Lowered
+    wam_haskell_lowerable/3,
+    lower_predicate_to_haskell/4
 ]).
 
 :- use_module(library(lists)).
 
-%% ---------------------------------------------------------------------
+%% =====================================================================
 %% Parsing
-%% ---------------------------------------------------------------------
-%
-% The WAM target (wam_target.pl) emits WAM as text. Each predicate's
-% WamCode argument is a multi-line atom/string with one line per
-% instruction. The first line is always the predicate label
-% (`<name>/<arity>:`), followed by indented instruction lines. An
-% instruction line splits into a mnemonic (e.g. `get_constant`) and
-% argument tokens, possibly with trailing commas.
+%% =====================================================================
 
-%% parse_wam_text(+WamText, -Instructions)
-%  Parse a WAM text atom/string into a list of instruction terms.
-%  Returns a list of compound terms whose functor is the mnemonic and
-%  whose arguments are the token strings in order (commas stripped).
-%  Skips blank lines and the predicate-label line.
-parse_wam_text(WamText, Instructions) :-
+parse_wam_text(WamText, PCInstrs, LabelMap) :-
     atom_string(WamText, S),
     split_string(S, "\n", "", Lines),
-    parse_wam_lines(Lines, Instructions).
+    parse_lines(Lines, 1, PCInstrs, LabelMap).
 
-parse_wam_lines([], []).
-parse_wam_lines([Line|Rest], Instructions) :-
-    string_trim(Line, Trimmed),
+parse_lines([], _, [], []).
+parse_lines([Line|Rest], PC, Instrs, Labels) :-
+    split_string(Line, "", " \t", [Trimmed]),
     (   Trimmed == ""
-    ->  parse_wam_lines(Rest, Instructions)
-    ;   sub_string(Trimmed, _, 1, 0, ":")   % label line like "foo/1:"
-    ->  parse_wam_lines(Rest, Instructions)
-    ;   tokenize_instruction(Trimmed, Instr),
-        Instructions = [Instr|InstructionsRest],
-        parse_wam_lines(Rest, InstructionsRest)
+    ->  parse_lines(Rest, PC, Instrs, Labels)
+    ;   sub_string(Trimmed, _, 1, 0, ":")
+    ->  sub_string(Trimmed, 0, _, 1, LStr),
+        atom_string(LAtom, LStr),
+        Labels = [LAtom-PC|LabelsRest],
+        parse_lines(Rest, PC, Instrs, LabelsRest)
+    ;   tokenize(Trimmed, Instr),
+        PC1 is PC + 1,
+        Instrs = [pc(PC, Instr)|InstrsRest],
+        parse_lines(Rest, PC1, InstrsRest, Labels)
     ).
 
-string_trim(S, T) :-
-    split_string(S, "", " \t", [T0]),
-    T = T0.
-
-tokenize_instruction(Line, Term) :-
+tokenize(Line, Term) :-
     split_string(Line, " \t", " \t,", Tokens),
-    exclude(=(""), Tokens, NonEmpty),
-    NonEmpty = [MnemonicStr|Args],
-    atom_string(Mnemonic, MnemonicStr),
-    Term =.. [Mnemonic|Args].
+    exclude(=(""), Tokens, [MStr|Args]),
+    atom_string(M, MStr),
+    Term =.. [M|Args].
 
-%% ---------------------------------------------------------------------
+%% =====================================================================
 %% Lowerability
-%% ---------------------------------------------------------------------
+%% =====================================================================
 
-%% wam_haskell_lowerable(+PredIndicator, +WamCode, -Reason)
-%  True iff PredIndicator's WamCode consists entirely of instructions
-%  in the Phase 3 whitelist. On failure, Reason is left unbound — the
-%  caller that cares why a predicate could not be lowered should log
-%  the Reason via a separate helper.
-wam_haskell_lowerable(_PredIndicator, WamCode, _Reason) :-
-    parse_wam_text(WamCode, Instructions),
-    % Phase 3 whitelist + structural constraint: all instructions must
-    % be supported, the sequence must end with proceed, and there must
-    % be exactly one proceed (no branching within the predicate body).
-    forall(member(I, Instructions), phase3_supported(I)),
-    last(Instructions, proceed),
-    include(=(proceed), Instructions, Proceeds),
-    length(Proceeds, 1).
+wam_haskell_lowerable(_PI, WamCode, _Reason) :-
+    parse_wam_text(WamCode, PCInstrs, _),
+    clause1_instrs(PCInstrs, C1),
+    forall(member(I, C1), supported(I)).
 
-phase3_supported(get_constant(_, _)).
-phase3_supported(proceed).
+clause1_instrs([], []).
+clause1_instrs([pc(_, try_me_else(_))|Rest], C1) :- !,
+    take_to_proceed(Rest, C1).
+clause1_instrs(PCInstrs, Instrs) :-
+    maplist([pc(_, I), I]>>true, PCInstrs, Instrs).
 
-%% ---------------------------------------------------------------------
+take_to_proceed([], []).
+take_to_proceed([pc(_, proceed)|_], [proceed]) :- !.
+take_to_proceed([pc(_, I)|Rest], [I|More]) :- take_to_proceed(Rest, More).
+
+supported(try_me_else(_)).
+supported(allocate).
+supported(deallocate).
+supported(get_constant(_, _)).
+supported(get_variable(_, _)).
+supported(get_value(_, _)).
+supported(put_constant(_, _)).
+supported(put_variable(_, _)).
+supported(put_value(_, _)).
+supported(put_structure(_, _)).
+supported(put_list(_)).
+supported(set_value(_)).
+supported(set_constant(_)).
+supported(call(_, _)).
+supported(builtin_call(_, _)).
+supported(proceed).
+
+%% =====================================================================
 %% Emission
-%% ---------------------------------------------------------------------
+%% =====================================================================
 
-%% lower_predicate_to_haskell(+PredIndicator, +WamCode, +Options, -Lowered)
-%  Lower PredIndicator to a Haskell function. Lowered is a term
-%      lowered(PredName, FuncName, HaskellCode)
-%  where PredName is the Prolog-style "<name>/<arity>" key used by
-%  wcLoweredPredicates dispatch, FuncName is the Haskell identifier of
-%  the generated function, and HaskellCode is the full source text of
-%  that function (ready to splice into Lowered.hs).
-lower_predicate_to_haskell(PredIndicator, WamCode, _Options,
-                           lowered(PredName, FuncName, HaskellCode)) :-
-    (   PredIndicator = _Module:Pred/Arity -> true
-    ;   PredIndicator = Pred/Arity
-    ),
+lower_predicate_to_haskell(PI, WamCode, Opts, lowered(PredName, FuncName, Code)) :-
+    ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     format(atom(PredName), '~w/~w', [Pred, Arity]),
     format(atom(FuncName), 'lowered_~w_~w', [Pred, Arity]),
-    parse_wam_text(WamCode, Instructions),
-    emit_function(FuncName, Instructions, HaskellCode).
+    % base_pc(N) offsets local PCs to match the global merged instruction array.
+    ( member(base_pc(BasePC), Opts) -> true ; BasePC = 1 ),
+    parse_wam_text(WamCode, PCInstrs, LabelMap),
+    % Offset all PCs: local PC 1 maps to global BasePC.
+    Offset is BasePC - 1,
+    offset_pcs(PCInstrs, Offset, GlobalPCInstrs),
+    offset_labels(LabelMap, Offset, GlobalLabelMap),
+    with_output_to(string(Code), emit_func(FuncName, GlobalPCInstrs, GlobalLabelMap)).
 
-%% emit_function(+FuncName, +Instructions, -HaskellCode)
-%  Emit a complete Haskell function definition for the whitelisted
-%  instruction sequence. Phase 3 only supports a run of GetConstants
-%  followed by a single Proceed.
-emit_function(FuncName, Instructions, HaskellCode) :-
-    append(GetConstants, [proceed], Instructions),
-    forall(member(GC, GetConstants), GC = get_constant(_, _)),
-    with_output_to(string(HaskellCode), (
-        format("-- | Lowered form (Phase 3: get_constant+proceed)~n"),
-        format("~w :: WamContext -> WamState -> Maybe WamState~n", [FuncName]),
-        format("~w !_ctx s0 =~n", [FuncName]),
-        emit_chain(GetConstants, 0)
-    )).
+offset_pcs([], _, []).
+offset_pcs([pc(PC, I)|Rest], Off, [pc(GPC, I)|Rest2]) :-
+    GPC is PC + Off,
+    offset_pcs(Rest, Off, Rest2).
 
-%% emit_chain(+GetConstantList, +Depth)
-%  Print the body chain directly to current output. Each recursive step
-%  handles one GetConstant at state variable s<Depth>, threading into
-%  s<Depth+1>. When the list is empty, prints the inlined Proceed tail
-%  at the current state variable.
-emit_chain([], Depth) :-
-    format(atom(SV), 's~w', [Depth]),
-    emit_proceed_tail(SV).
-emit_chain([get_constant(CStr, RegStr)|Rest], Depth) :-
-    value_to_haskell(CStr, HsConst),
-    reg_to_int(RegStr, RegId),
-    NextDepth is Depth + 1,
-    format(atom(SV),   's~w',   [Depth]),
-    format(atom(SVn),  's~w',   [NextDepth]),
-    format(atom(VIDn), 'vid~w', [Depth]),
-    indent_for(Depth, Pad),
-    format("~w  case fmap (derefVar (wsBindings ~w)) (IM.lookup ~w (wsRegs ~w)) of~n",
-           [Pad, SV, RegId, SV]),
-    format("~w    Just v | v == (~w) ->~n", [Pad, HsConst]),
-    format("~w      let ~w = ~w in~n",      [Pad, SVn, SV]),
-    emit_chain(Rest, NextDepth),
-    format("~w    Just (Unbound ~w) ->~n",  [Pad, VIDn]),
-    format("~w      let ~w = ~w { wsRegs = IM.insert ~w (~w) (wsRegs ~w)~n",
-           [Pad, SVn, SV, RegId, HsConst, SV]),
-    format("~w                  , wsBindings = IM.insert ~w (~w) (wsBindings ~w)~n",
-           [Pad, VIDn, HsConst, SV]),
-    format("~w                  , wsTrail = TrailEntry ~w (IM.lookup ~w (wsBindings ~w)) : wsTrail ~w~n",
-           [Pad, VIDn, VIDn, SV, SV]),
-    format("~w                  , wsTrailLen = wsTrailLen ~w + 1~n", [Pad, SV]),
-    format("~w                  }~n", [Pad]),
-    format("~w      in~n", [Pad]),
-    emit_chain(Rest, NextDepth),
-    format("~w    _ -> Nothing~n", [Pad]).
+offset_labels([], _, []).
+offset_labels([L-PC|Rest], Off, [L-GPC|Rest2]) :-
+    GPC is PC + Off,
+    offset_labels(Rest, Off, Rest2).
 
-%% emit_proceed_tail(+StateVar)
-%  Emit the inline Proceed logic as the innermost continuation of a
-%  lowered predicate at the given state variable.
-emit_proceed_tail(StateVar) :-
-    format("      let retAddr = wsCP ~w~n", [StateVar]),
-    format("      in if retAddr == 0~n"),
-    format("         then Just (~w { wsPC = 0 })~n", [StateVar]),
-    format("         else Just (~w { wsPC = retAddr, wsCP = 0 })~n", [StateVar]).
+emit_func(FN, PCInstrs, LabelMap) :-
+    format("-- | Lowered: ~w~n", [FN]),
+    format("~w :: WamContext -> WamState -> Maybe WamState~n", [FN]),
+    % Multi-clause: push CP, try clause 1, if it fails backtrack into
+    % the interpreter for clause 2+. This ensures the CP is visible
+    % to the backtrack machinery even when clause 1 returns Nothing.
+    (   PCInstrs = [pc(_, try_me_else(LStr))|BodyPCs]
+    ->  atom_string(LAtom, LStr),
+        (   member(LAtom-AltPC, LabelMap) -> true ; AltPC = 0 ),
+        format("~w !ctx s_init =~n", [FN]),
+        format("  let s_cp = s_init { wsCPs = ChoicePoint~n"),
+        format("        { cpNextPC = ~w, cpRegs = wsRegs s_init, cpStack = wsStack s_init~n", [AltPC]),
+        format("        , cpCP = wsCP s_init, cpTrailLen = wsTrailLen s_init~n"),
+        format("        , cpHeapLen = wsHeapLen s_init, cpBindings = wsBindings s_init~n"),
+        format("        , cpCutBar = wsCutBar s_init, cpAggFrame = Nothing, cpBuiltin = Nothing~n"),
+        format("        } : wsCPs s_init~n"),
+        format("        , wsCPsLen = wsCPsLen s_init + 1 }~n"),
+        format("  in case clause1 s_cp of~n"),
+        format("       Just result -> Just result~n"),
+        format("       Nothing -> backtrack s_cp >>= \\s_bt -> run ctx s_bt~n"),
+        format("  where~n"),
+        format("    clause1 s_c1 = do~n"),
+        take_to_proceed_pc(BodyPCs, Clause1PCs),
+        emit_instrs(Clause1PCs, "s_c1", "      ")
+    ;   % Single-clause: simple do-notation
+        format("~w !ctx s_init = do~n", [FN]),
+        emit_instrs(PCInstrs, "s_init", "  ")
+    ).
 
-%% indent_for(+Depth, -Indent)
-%  Produce an indentation string for a given nesting depth.
-indent_for(0, '').
-indent_for(N, Indent) :-
-    N > 0,
-    N1 is N - 1,
-    indent_for(N1, Prev),
-    atom_concat(Prev, '      ', Indent).
+take_to_proceed_pc([], []).
+take_to_proceed_pc([pc(PC, proceed)|_], [pc(PC, proceed)]) :- !.
+take_to_proceed_pc([H|T], [H|R]) :- take_to_proceed_pc(T, R).
 
-%% ---------------------------------------------------------------------
-%% Value and register translation (local to the emitter; intentionally
-%% duplicates the equivalent helpers in wam_haskell_target.pl so the
-%% emitter module has no circular import into its caller).
-%% ---------------------------------------------------------------------
+%% emit_instrs(+PCInstrs, +CurrentStateVar, +IndentPrefix)
+%  Emit one line of do-notation per instruction, threading state vars.
+emit_instrs([], _, _).
+emit_instrs([pc(PC, Instr)|Rest], SV, Ind) :-
+    emit_one(Instr, PC, SV, SVout, Ind),
+    emit_instrs(Rest, SVout, Ind).
 
-value_to_haskell(Str, Hs) :-
+%% emit_one(+Instr, +PC, +StateVarIn, -StateVarOut, +IndentPrefix)
+%  Emit do-notation for a single instruction.
+
+% Terminal: proceed
+emit_one(proceed, _, SV, SV, I) :-
+    format("~wlet ret_ = wsCP ~w~n", [I, SV]),
+    format("~wif ret_ == 0 then Just (~w { wsPC = 0 }) else Just (~w { wsPC = ret_, wsCP = 0 })~n",
+           [I, SV, SV]).
+
+% Allocate — always succeeds, use let
+emit_one(allocate, _, SV, SVout, I) :-
+    fresh_sv(SV, SVout),
+    format("~wlet ~w = ~w { wsStack = EnvFrame (wsCP ~w) IM.empty : wsStack ~w, wsCutBar = wsCPsLen ~w }~n",
+           [I, SVout, SV, SV, SV, SV]).
+
+% Deallocate — use step
+emit_one(deallocate, PC, SV, SVout, I) :-
+    fresh_sv(SV, SVout),
+    format("~w~w <- step ctx (~w { wsPC = ~w }) Deallocate~n", [I, SVout, SV, PC]).
+
+% GetVariable Xn Ai — always succeeds, inline register copy
+emit_one(get_variable(XnStr, AiStr), _, SV, SVout, I) :-
+    reg_to_int(XnStr, Xn), reg_to_int(AiStr, Ai),
+    fresh_sv(SV, SVout),
+    format("~wlet ~w = ~w { wsRegs = IM.insert ~w (derefVar (wsBindings ~w) (fromMaybe (Atom \"\") (IM.lookup ~w (wsRegs ~w)))) (wsRegs ~w) }~n",
+           [I, SVout, SV, Xn, SV, Ai, SV, SV]).
+
+% GetConstant C Ai — can fail, use step
+emit_one(get_constant(CStr, AiStr), PC, SV, SVout, I) :-
+    val_hs(CStr, HC), reg_to_int(AiStr, Ai),
+    fresh_sv(SV, SVout),
+    format("~w~w <- step ctx (~w { wsPC = ~w }) (GetConstant (~w) ~w)~n",
+           [I, SVout, SV, PC, HC, Ai]).
+
+% GetValue — can fail (unification), use step
+emit_one(get_value(XnStr, AiStr), PC, SV, SVout, I) :-
+    reg_to_int(XnStr, Xn), reg_to_int(AiStr, Ai),
+    fresh_sv(SV, SVout),
+    format("~w~w <- step ctx (~w { wsPC = ~w }) (GetValue ~w ~w)~n",
+           [I, SVout, SV, PC, Xn, Ai]).
+
+% PutValue Xn Ai — always succeeds, inline
+emit_one(put_value(XnStr, AiStr), _, SV, SVout, I) :-
+    reg_to_int(XnStr, Xn), reg_to_int(AiStr, Ai),
+    fresh_sv(SV, SVout),
+    format("~wlet ~w = ~w { wsRegs = IM.insert ~w (fromMaybe (Atom \"\") (getReg ~w ~w)) (wsRegs ~w) }~n",
+           [I, SVout, SV, Ai, Xn, SV, SV]).
+
+% PutVariable Xn Ai — always succeeds, inline (creates fresh Unbound)
+emit_one(put_variable(XnStr, AiStr), _, SV, SVout, I) :-
+    reg_to_int(XnStr, Xn), reg_to_int(AiStr, Ai),
+    fresh_sv(SV, SVout),
+    format("~wlet v_~w = Unbound (wsVarCounter ~w)~n", [I, SVout, SV]),
+    format("~w    ~w = (putReg ~w v_~w ~w) { wsRegs = IM.insert ~w v_~w (wsRegs (putReg ~w v_~w ~w)), wsVarCounter = wsVarCounter ~w + 1 }~n",
+           [I, SVout, Xn, SVout, SV, Ai, SVout, Xn, SVout, SV, SV]).
+
+% PutConstant C Ai — always succeeds, inline
+emit_one(put_constant(CStr, AiStr), _, SV, SVout, I) :-
+    val_hs(CStr, HC), reg_to_int(AiStr, Ai),
+    fresh_sv(SV, SVout),
+    format("~wlet ~w = ~w { wsRegs = IM.insert ~w (~w) (wsRegs ~w) }~n",
+           [I, SVout, SV, Ai, HC, SV]).
+
+% PutStructure, PutList, SetValue, SetConstant — delegate to step
+emit_one(put_structure(FnStr, AiStr), PC, SV, SVout, I) :-
+    reg_to_int(AiStr, Ai),
+    parse_functor(FnStr, FuncName, Arity),
+    fresh_sv(SV, SVout),
+    format("~w~w <- step ctx (~w { wsPC = ~w }) (PutStructure \"~w\" ~w ~w)~n",
+           [I, SVout, SV, PC, FuncName, Ai, Arity]).
+
+emit_one(put_list(AiStr), PC, SV, SVout, I) :-
+    reg_to_int(AiStr, Ai),
+    fresh_sv(SV, SVout),
+    format("~w~w <- step ctx (~w { wsPC = ~w }) (PutList ~w)~n",
+           [I, SVout, SV, PC, Ai]).
+
+emit_one(set_value(XnStr), PC, SV, SVout, I) :-
+    reg_to_int(XnStr, Xn),
+    fresh_sv(SV, SVout),
+    format("~w~w <- step ctx (~w { wsPC = ~w }) (SetValue ~w)~n",
+           [I, SVout, SV, PC, Xn]).
+
+emit_one(set_constant(CStr), PC, SV, SVout, I) :-
+    val_hs(CStr, HC),
+    fresh_sv(SV, SVout),
+    format("~w~w <- step ctx (~w { wsPC = ~w }) (SetConstant (~w))~n",
+           [I, SVout, SV, PC, HC]).
+
+% Call — use dispatchCall helper
+emit_one(call(PredStr, _NStr), PC, SV, SVout, I) :-
+    RetPC is PC + 1,
+    fresh_sv(SV, SVout),
+    format("~w~w <- dispatchCall ctx \"~w\" (~w { wsCP = ~w })~n",
+           [I, SVout, PredStr, SV, RetPC]).
+
+% BuiltinCall — delegate to step
+emit_one(builtin_call(OpStr, NStr), PC, SV, SVout, I) :-
+    escape_bs(OpStr, EOp),
+    fresh_sv(SV, SVout),
+    format("~w~w <- step ctx (~w { wsPC = ~w }) (BuiltinCall \"~w\" ~w)~n",
+           [I, SVout, SV, PC, EOp, NStr]).
+
+%% =====================================================================
+%% Helpers
+%% =====================================================================
+
+%% fresh_sv(+Current, -Next) — generate next state variable name
+fresh_sv(Cur, Next) :-
+    atom_string(Cur, CStr),
+    (   sub_string(CStr, 0, _, _, "s_")
+    ->  sub_string(CStr, 2, _, 0, NumPart),
+        (   number_string(N, NumPart) -> N1 is N + 1
+        ;   N1 = 0
+        ),
+        format(atom(Next), 's_~w', [N1])
+    ;   Next = 's_0'
+    ).
+
+val_hs(Str, Hs) :-
     (   number_string(N, Str), integer(N)
-    ->  format(string(Hs), 'Integer ~w', [N])
+    ->  format(atom(Hs), 'Integer ~w', [N])
     ;   number_string(F, Str), float(F)
-    ->  format(string(Hs), 'Float ~w', [F])
-    ;   format(string(Hs), 'Atom "~w"', [Str])
+    ->  format(atom(Hs), 'Float ~w', [F])
+    ;   format(atom(Hs), 'Atom "~w"', [Str])
     ).
 
 reg_to_int(Reg, Int) :-
     atom_string(RegA, Reg),
-    sub_atom(RegA, 0, 1, _, Bank),
-    sub_atom(RegA, 1, _, 0, NumA),
-    atom_number(NumA, Num),
-    (   Bank == 'A' -> Int = Num
-    ;   Bank == 'X' -> Int is Num + 100
-    ;   Bank == 'Y' -> Int is Num + 200
-    ;   Int = 0
+    sub_atom(RegA, 0, 1, _, B),
+    sub_atom(RegA, 1, _, 0, NA),
+    atom_number(NA, Num),
+    ( B == 'A' -> Int = Num ; B == 'X' -> Int is Num + 100
+    ; B == 'Y' -> Int is Num + 200 ; Int = 0 ).
+
+parse_functor(FnStr, Name, Arity) :-
+    atom_string(FA, FnStr),
+    (   sub_atom(FA, B, 1, _, '/')
+    ->  sub_atom(FA, 0, B, _, Name),
+        B1 is B + 1,
+        sub_atom(FA, B1, _, 0, AS),
+        atom_number(AS, Arity)
+    ;   Name = FA, Arity = 0
     ).
+
+escape_bs(Str, Esc) :-
+    split_string(Str, "\\", "", Parts),
+    atomic_list_concat(Parts, "\\\\", E0),
+    atom_string(E0, Esc).

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -148,15 +148,48 @@ wam_haskell_predicate_wamcode(PredIndicator, WamCode) :-
     ),
     wam_target:compile_predicate_to_wam(Pred/Arity, [], WamCode).
 
-%% lower_all(+LoweredList, -LoweredEntries)
-%  Run the Phase 3+ emitter over each predicate in LoweredList (which
-%  is assumed to contain only predicates the whitelist already accepted).
-%  Each output entry is a term lowered(PredName, FuncName, HaskellCode).
-lower_all([], []).
-lower_all([P|Rest], [Entry|RestEntries]) :-
+%% lower_all(+LoweredList, +BasePCMap, -LoweredEntries)
+%  Run the Phase 3+ emitter over each predicate in LoweredList, using
+%  BasePCMap (a list of PredIndicator-StartPC pairs computed from the
+%  merged instruction array) to offset local PCs to global PCs.
+lower_all([], _, []).
+lower_all([P|Rest], BasePCMap, [Entry|RestEntries]) :-
     wam_haskell_predicate_wamcode(P, WamCode),
-    lower_predicate_to_haskell(P, WamCode, [], Entry),
-    lower_all(Rest, RestEntries).
+    predicate_base_pc(P, BasePCMap, BasePC),
+    lower_predicate_to_haskell(P, WamCode, [base_pc(BasePC)], Entry),
+    lower_all(Rest, BasePCMap, RestEntries).
+
+predicate_base_pc(P, Map, PC) :-
+    (   P = _Mod:Pred/Arity -> true ; P = Pred/Arity ),
+    format(atom(Key), '~w/~w', [Pred, Arity]),
+    (   member(Key-PC, Map) -> true ; PC = 1 ).
+
+%% compute_base_pcs(+Predicates, -BasePCMap)
+%  Compute global start PCs for each predicate, matching the PC
+%  assignment in compile_predicates_merged/4. Returns a list of
+%  "pred/arity"-StartPC pairs.
+compute_base_pcs(Predicates, Map) :-
+    compute_base_pcs_(Predicates, 1, Map).
+
+compute_base_pcs_([], _, []).
+compute_base_pcs_([PI|Rest], StartPC, [Key-StartPC|RestMap]) :-
+    (   PI = _Mod:Pred/Arity -> true ; PI = Pred/Arity ),
+    format(atom(Key), '~w/~w', [Pred, Arity]),
+    wam_haskell_predicate_wamcode(PI, WamCode),
+    count_wam_instructions(WamCode, Count),
+    NextPC is StartPC + Count,
+    compute_base_pcs_(Rest, NextPC, RestMap).
+
+count_wam_instructions(WamCode, Count) :-
+    atom_string(WamCode, S),
+    split_string(S, "\n", "", Lines),
+    include(is_wam_instruction_line, Lines, InstrLines),
+    length(InstrLines, Count).
+
+is_wam_instruction_line(Line) :-
+    split_string(Line, "", " \t", [Trimmed]),
+    Trimmed \== "",
+    \+ sub_string(Trimmed, _, 1, 0, ":").
 
 % ============================================================================
 % Haskell WAM Runtime Data Types
@@ -1075,7 +1108,24 @@ run !ctx !s
            Just s'' -> run ctx s''
            Nothing -> case backtrack s of
              Just s'' -> run ctx s''
-             Nothing -> Nothing'.
+             Nothing -> Nothing
+
+-- | Dispatch a Call to another predicate, trying all resolution paths.
+-- Used by lowered predicate functions for inter-predicate calls.
+-- Mirrors the step (Call pred _arity) dispatch chain but as a callable
+-- helper: lowered → foreign → indexed-facts → label-lookup+run.
+{-# NOINLINE dispatchCall #-}
+dispatchCall :: WamContext -> String -> WamState -> Maybe WamState
+dispatchCall !ctx pred !sc =
+  case Map.lookup pred (wcLoweredPredicates ctx) of
+    Just fn -> fn ctx sc
+    Nothing -> case executeForeign ctx pred sc of
+      Just sr -> Just sr
+      Nothing -> case callIndexedFact2 ctx pred sc of
+        Just sr -> Just sr
+        Nothing -> case Map.lookup pred (wcLabels ctx) of
+          Just pc -> run ctx (sc { wsPC = pc })
+          Nothing -> Nothing'.
 
 % ============================================================================
 % PHASE 4: Project Generation
@@ -1118,19 +1168,21 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     directory_file_path(SrcDir, 'WamRuntime.hs', RuntimePath),
     write_hs_file(RuntimePath, RuntimeCode),
 
-    % Compile the interpreted partition (Phase 1: this is always the full
-    % Predicates list, because LoweredList is always empty).
-    compile_predicates_to_haskell(InterpretedList, Options, PredsCode0),
+    % ALL predicates go into the interpreter's instruction array — even
+    % lowered ones — so backtrack can land on alternate clauses that the
+    % lowered function doesn't handle. Phase 4+ lowered functions only
+    % inline clause 1; clause 2+ runs through the interpreter on backtrack.
+    compile_predicates_to_haskell(Predicates, Options, PredsCode0),
     apply_hashmap_rewrite(UseHM, generic, PredsCode0, PredsCode),
     directory_file_path(SrcDir, 'Predicates.hs', PredsPath),
     write_hs_file(PredsPath, PredsCode),
 
     % Lower each predicate in LoweredList via the Phase 3+ emitter.
-    % Phase 1 stub returned an empty list here; Phase 3 produces one
-    % lowered/3 entry per predicate. The emitter's whitelist check
-    % runs inside the partition helper, so everything in LoweredList
-    % is guaranteed to be lowerable.
-    lower_all(LoweredList, LoweredEntries),
+    % We first compute global base PCs matching the merged instruction
+    % array so the lowered functions' PC references (wsCP for Call return
+    % addresses, wsPC for step calls) are correct.
+    compute_base_pcs(Predicates, BasePCMap),
+    lower_all(LoweredList, BasePCMap, LoweredEntries),
     generate_lowered_hs(LoweredEntries, LoweredCode0),
     apply_hashmap_rewrite(UseHM, generic, LoweredCode0, LoweredCode),
     directory_file_path(SrcDir, 'Lowered.hs', LoweredPath),
@@ -1219,7 +1271,8 @@ generate_lowered_hs([], Code) :- !,
         format("import qualified Data.Map.Strict as Map~n"),
         format("import qualified Data.IntMap.Strict as IM~n"),
         format("import WamTypes~n"),
-        format("import WamRuntime (derefVar)~n~n"),
+        format("import Data.Maybe (fromMaybe)~n"),
+        format("import WamRuntime~n~n"),
         format("loweredPredicates :: Map.Map String (WamContext -> WamState -> Maybe WamState)~n"),
         format("loweredPredicates = Map.empty~n")
     )).
@@ -1235,7 +1288,8 @@ generate_lowered_hs(LoweredEntries, Code) :-
         format("import qualified Data.Map.Strict as Map~n"),
         format("import qualified Data.IntMap.Strict as IM~n"),
         format("import WamTypes~n"),
-        format("import WamRuntime (derefVar)~n~n"),
+        format("import Data.Maybe (fromMaybe)~n"),
+        format("import WamRuntime~n~n"),
         % Function definitions
         forall(member(lowered(_, _, HsCode), LoweredEntries),
                format("~w~n", [HsCode])),

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -31,7 +31,6 @@
     compile_wam_runtime_to_haskell/2,    % +Options, -HaskellCode
     write_wam_haskell_project/3,         % +Predicates, +Options, +ProjectDir
     wam_haskell_resolve_emit_mode/2,     % +Options, -Mode
-    wam_haskell_lowerable/3,             % +PredIndicator, +WamCode, -Reason
     wam_haskell_partition_predicates/4   % +Mode, +Predicates, -InterpretedList, -LoweredList
 ]).
 
@@ -39,6 +38,12 @@
 :- use_module(library(option)).
 :- use_module(library(filesex), [make_directory_path/1, directory_file_path/3]).
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+
+% Phase 3: the real lowerability check and emission helpers live in the
+% wam_haskell_lowered_emitter module. We reexport so existing callers can
+% still see wam_haskell_lowerable/3 through this module.
+:- reexport('wam_haskell_lowered_emitter',
+            [wam_haskell_lowerable/3, lower_predicate_to_haskell/4]).
 
 %% ============================================================================
 %% emit_mode selector (Phase 1 of WAM-lowered Haskell path)
@@ -87,20 +92,10 @@ wam_haskell_validate_emit_mode(Other, _) :-
     throw(error(domain_error(wam_haskell_emit_mode, Other),
                 wam_haskell_resolve_emit_mode/2)).
 
-%% wam_haskell_lowerable(+PredIndicator, +WamCode, -Reason)
-%  Phase 1 stub. True if PredIndicator can be lowered to a standalone
-%  Haskell function given its WamCode. Always fails in Phase 1 with
-%  Reason bound to "lowering emitter not yet implemented" — callers
-%  that want to know *why* a predicate could not be lowered should
-%  pre-bind Reason to a variable and inspect it on failure via
-%  catch/wrapper logic. In practice Phase 1 callers only check
-%  success/failure and log a partition summary.
-%
-%  Real lowerability check lands in Phase 3 of the implementation plan,
-%  at which point this stub is replaced with a per-instruction whitelist
-%  check against the WAM IR.
-wam_haskell_lowerable(_PredIndicator, _WamCode, "lowering emitter not yet implemented") :-
-    fail.
+%% wam_haskell_lowerable/3 lives in wam_haskell_lowered_emitter.pl and is
+%% re-exported above. Phase 1 shipped a stub that always failed; Phase 3
+%% replaces it with a real whitelist check against the WAM instruction
+%% sequence.
 
 %% wam_haskell_partition_predicates(+Mode, +Predicates, -InterpretedList, -LoweredList)
 %  Partition Predicates into the two sublists based on Mode and the
@@ -146,15 +141,22 @@ wam_haskell_indicator_in_list(P, HotPreds) :-
 wam_haskell_indicator_in_list(_Mod:Pred/Arity, HotPreds) :-
     member(Pred/Arity, HotPreds), !.
 
-% Compile WAM code on demand for the lowerability check. In Phase 1 the
-% stub always fails, so this is unused in practice — but making it
-% available here means Phase 3 can reuse the same plumbing without
-% touching the partition predicates.
+% Compile WAM code on demand for the lowerability check and emission.
 wam_haskell_predicate_wamcode(PredIndicator, WamCode) :-
     (   PredIndicator = _Module:Pred/Arity -> true
     ;   PredIndicator = Pred/Arity
     ),
     wam_target:compile_predicate_to_wam(Pred/Arity, [], WamCode).
+
+%% lower_all(+LoweredList, -LoweredEntries)
+%  Run the Phase 3+ emitter over each predicate in LoweredList (which
+%  is assumed to contain only predicates the whitelist already accepted).
+%  Each output entry is a term lowered(PredName, FuncName, HaskellCode).
+lower_all([], []).
+lower_all([P|Rest], [Entry|RestEntries]) :-
+    wam_haskell_predicate_wamcode(P, WamCode),
+    lower_predicate_to_haskell(P, WamCode, [], Entry),
+    lower_all(Rest, RestEntries).
 
 % ============================================================================
 % Haskell WAM Runtime Data Types
@@ -1123,11 +1125,13 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     directory_file_path(SrcDir, 'Predicates.hs', PredsPath),
     write_hs_file(PredsPath, PredsCode),
 
-    % Emit Lowered.hs — Phase 2 ships the empty skeleton regardless of
-    % whether LoweredList has entries (it never does in Phase 2, since
-    % the lowerability stub still always fails). This lets Main.hs
-    % unconditionally import qualified Lowered.
-    generate_lowered_hs(LoweredList, LoweredCode0),
+    % Lower each predicate in LoweredList via the Phase 3+ emitter.
+    % Phase 1 stub returned an empty list here; Phase 3 produces one
+    % lowered/3 entry per predicate. The emitter's whitelist check
+    % runs inside the partition helper, so everything in LoweredList
+    % is guaranteed to be lowerable.
+    lower_all(LoweredList, LoweredEntries),
+    generate_lowered_hs(LoweredEntries, LoweredCode0),
     apply_hashmap_rewrite(UseHM, generic, LoweredCode0, LoweredCode),
     directory_file_path(SrcDir, 'Lowered.hs', LoweredPath),
     write_hs_file(LoweredPath, LoweredCode),
@@ -1195,39 +1199,63 @@ re_split_replace(S, From, To, Result) :-
     ;   Result = S
     ).
 
-%% generate_lowered_hs(+LoweredList, -Code)
+%% generate_lowered_hs(+LoweredEntries, -Code)
 %  Emit the Lowered.hs module containing one function per predicate in
-%  LoweredList and a loweredPredicates dispatch Map. Phase 2 always
-%  receives an empty LoweredList (Phase 1 stub fails for every predicate),
-%  so this generator emits the skeleton module with Map.empty. Phase 3+
-%  will walk LoweredList and emit a function per predicate via
-%  lower_predicate_to_haskell/4.
+%  LoweredEntries and a loweredPredicates dispatch Map. Each entry is a
+%  term lowered(PredName, FuncName, HaskellCode) produced by the
+%  wam_haskell_lowered_emitter:lower_predicate_to_haskell/4 helper.
 %
-%  The module is emitted regardless of the partition being empty so that
-%  Main.hs can unconditionally `import qualified Lowered` — it is simpler
-%  than making the import conditional on the emit_mode.
-generate_lowered_hs(LoweredList, Code) :-
-    LoweredList = [],   % Phase 2: always empty (enforced by caller's expectation)
-    Code = '{-# LANGUAGE BangPatterns #-}
--- WAM-lowered Haskell predicates.
---
--- Phase 2: empty skeleton. Phase 3+ will emit one function per predicate
--- in the lowered partition and register them in loweredPredicates.
---
--- See docs/design/WAM_HASKELL_LOWERED_SPECIFICATION.md §2.1.
-module Lowered where
+%  When the list is empty, emits a skeleton module with
+%  loweredPredicates = Map.empty (Phase 2 shape). The Lowered.hs module
+%  is emitted unconditionally so Main.hs can unconditionally
+%  `import qualified Lowered`.
+%
+%  See docs/design/WAM_HASKELL_LOWERED_SPECIFICATION.md §2.1.
+generate_lowered_hs([], Code) :- !,
+    with_output_to(string(Code), (
+        format("{-# LANGUAGE BangPatterns #-}~n"),
+        format("-- WAM-lowered Haskell predicates (empty — no preds lowered).~n"),
+        format("module Lowered where~n~n"),
+        format("import qualified Data.Map.Strict as Map~n"),
+        format("import qualified Data.IntMap.Strict as IM~n"),
+        format("import WamTypes~n"),
+        format("import WamRuntime (derefVar)~n~n"),
+        format("loweredPredicates :: Map.Map String (WamContext -> WamState -> Maybe WamState)~n"),
+        format("loweredPredicates = Map.empty~n")
+    )).
+generate_lowered_hs(LoweredEntries, Code) :-
+    LoweredEntries = [_|_],  % non-empty
+    with_output_to(string(Code), (
+        format("{-# LANGUAGE BangPatterns #-}~n"),
+        format("-- WAM-lowered Haskell predicates.~n"),
+        format("--~n"),
+        format("-- One function per predicate in the lowered partition, plus a~n"),
+        format("-- dispatch map wired into WamContext.wcLoweredPredicates by Main.hs.~n"),
+        format("module Lowered where~n~n"),
+        format("import qualified Data.Map.Strict as Map~n"),
+        format("import qualified Data.IntMap.Strict as IM~n"),
+        format("import WamTypes~n"),
+        format("import WamRuntime (derefVar)~n~n"),
+        % Function definitions
+        forall(member(lowered(_, _, HsCode), LoweredEntries),
+               format("~w~n", [HsCode])),
+        % Dispatch map
+        format("loweredPredicates :: Map.Map String (WamContext -> WamState -> Maybe WamState)~n"),
+        format("loweredPredicates = Map.fromList~n"),
+        format("    [ "),
+        emit_lowered_entries(LoweredEntries),
+        format("    ]~n")
+    )).
 
-import qualified Data.Map.Strict as Map
-import WamTypes
-
--- | Dispatch map from predicate indicator (e.g. "category_ancestor/4") to
--- a Haskell function mirroring the WAM semantics of that predicate.
--- Populated by Main.hs into WamContext.wcLoweredPredicates. Phase 2
--- ships this as Map.empty so the runtime dispatch chain falls through
--- to the interpreter unchanged.
-loweredPredicates :: Map.Map String (WamContext -> WamState -> Maybe WamState)
-loweredPredicates = Map.empty
-'.
+% Emit the Map.fromList entries, one per line with a leading comma on
+% all but the first.
+emit_lowered_entries([lowered(PredName, FuncName, _)|Rest]) :-
+    format("(\"~w\", ~w)~n", [PredName, FuncName]),
+    emit_lowered_entries_rest(Rest).
+emit_lowered_entries_rest([]).
+emit_lowered_entries_rest([lowered(PredName, FuncName, _)|Rest]) :-
+    format("    , (\"~w\", ~w)~n", [PredName, FuncName]),
+    emit_lowered_entries_rest(Rest).
 
 %% generate_main_hs(+Predicates, -Code)
 %  Generates Main.hs — a benchmark driver for effective-distance.

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -762,13 +762,15 @@ step !ctx s (CallResolved pc _arity) =
 
 step !ctx s (Call pred _arity) =
   let sc = s { wsCP = wsPC s + 1 }
-  in case executeForeign ctx pred sc of
-    Just sr -> Just sr
-    Nothing -> case callIndexedFact2 ctx pred sc of
+  in case Map.lookup pred (wcLoweredPredicates ctx) of
+    Just fn -> fn ctx sc
+    Nothing -> case executeForeign ctx pred sc of
       Just sr -> Just sr
-      Nothing -> case Map.lookup pred (wcLabels ctx) of
-        Just pc -> Just (s { wsPC = pc, wsCP = wsPC s + 1 })
-        Nothing -> Nothing
+      Nothing -> case callIndexedFact2 ctx pred sc of
+        Just sr -> Just sr
+        Nothing -> case Map.lookup pred (wcLabels ctx) of
+          Just pc -> Just (s { wsPC = pc, wsCP = wsPC s + 1 })
+          Nothing -> Nothing
 
 step !ctx s Proceed =
   let ret = wsCP s
@@ -1115,12 +1117,20 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     write_hs_file(RuntimePath, RuntimeCode),
 
     % Compile the interpreted partition (Phase 1: this is always the full
-    % Predicates list, because LoweredList is always empty). Phase 2 emits
-    % Lowered.hs for the non-empty case.
+    % Predicates list, because LoweredList is always empty).
     compile_predicates_to_haskell(InterpretedList, Options, PredsCode0),
     apply_hashmap_rewrite(UseHM, generic, PredsCode0, PredsCode),
     directory_file_path(SrcDir, 'Predicates.hs', PredsPath),
     write_hs_file(PredsPath, PredsCode),
+
+    % Emit Lowered.hs — Phase 2 ships the empty skeleton regardless of
+    % whether LoweredList has entries (it never does in Phase 2, since
+    % the lowerability stub still always fails). This lets Main.hs
+    % unconditionally import qualified Lowered.
+    generate_lowered_hs(LoweredList, LoweredCode0),
+    apply_hashmap_rewrite(UseHM, generic, LoweredCode0, LoweredCode),
+    directory_file_path(SrcDir, 'Lowered.hs', LoweredPath),
+    write_hs_file(LoweredPath, LoweredCode),
 
     % Generate cabal file
     option(module_name(ModName), Options, 'wam-haskell-bench'),
@@ -1185,6 +1195,40 @@ re_split_replace(S, From, To, Result) :-
     ;   Result = S
     ).
 
+%% generate_lowered_hs(+LoweredList, -Code)
+%  Emit the Lowered.hs module containing one function per predicate in
+%  LoweredList and a loweredPredicates dispatch Map. Phase 2 always
+%  receives an empty LoweredList (Phase 1 stub fails for every predicate),
+%  so this generator emits the skeleton module with Map.empty. Phase 3+
+%  will walk LoweredList and emit a function per predicate via
+%  lower_predicate_to_haskell/4.
+%
+%  The module is emitted regardless of the partition being empty so that
+%  Main.hs can unconditionally `import qualified Lowered` — it is simpler
+%  than making the import conditional on the emit_mode.
+generate_lowered_hs(LoweredList, Code) :-
+    LoweredList = [],   % Phase 2: always empty (enforced by caller's expectation)
+    Code = '{-# LANGUAGE BangPatterns #-}
+-- WAM-lowered Haskell predicates.
+--
+-- Phase 2: empty skeleton. Phase 3+ will emit one function per predicate
+-- in the lowered partition and register them in loweredPredicates.
+--
+-- See docs/design/WAM_HASKELL_LOWERED_SPECIFICATION.md §2.1.
+module Lowered where
+
+import qualified Data.Map.Strict as Map
+import WamTypes
+
+-- | Dispatch map from predicate indicator (e.g. "category_ancestor/4") to
+-- a Haskell function mirroring the WAM semantics of that predicate.
+-- Populated by Main.hs into WamContext.wcLoweredPredicates. Phase 2
+-- ships this as Map.empty so the runtime dispatch chain falls through
+-- to the interpreter unchanged.
+loweredPredicates :: Map.Map String (WamContext -> WamState -> Maybe WamState)
+loweredPredicates = Map.empty
+'.
+
 %% generate_main_hs(+Predicates, -Code)
 %  Generates Main.hs — a benchmark driver for effective-distance.
 %  Loads facts from TSV, runs category_ancestor queries, outputs TSV.
@@ -1203,6 +1247,7 @@ import Data.Time.Clock (getCurrentTime, diffUTCTime)
 import WamTypes
 import WamRuntime
 import Predicates
+import qualified Lowered
 
 -- | Load a TSV file, skip header, return pairs.
 loadTsvPairs :: FilePath -> IO [(String, String)]
@@ -1316,9 +1361,13 @@ main = do
     -- Build the read-only WamContext ONCE before the seed loop. The hot
     -- WamState gets a fresh copy per seed; the cold context is shared.
     -- Populate wcForeignFacts/wcForeignConfig so executeForeign can fire.
+    -- Populate wcLoweredPredicates from Lowered.loweredPredicates — Phase 2
+    -- ships this as Map.empty, Phase 3+ replaces it with real lowered
+    -- predicate functions.
     let !ctx = (mkContext mergedCode mergedLabels)
             { wcForeignFacts  = Map.singleton "category_parent" parentsIndex
             , wcForeignConfig = Map.singleton "max_depth" 10
+            , wcLoweredPredicates = Lowered.loweredPredicates
             }
 
     t2 <- getCurrentTime
@@ -1665,7 +1714,10 @@ data WamContext = WamContext
   , wcLabels        :: !(Map.Map String Int)
   , wcForeignFacts  :: !(Map.Map String (Map.Map String [String]))
   , wcForeignConfig :: !(Map.Map String Int)
-  } deriving (Show)
+  , wcLoweredPredicates :: !(Map.Map String (WamContext -> WamState -> Maybe WamState))
+  }
+-- Note: no `deriving (Show)` because wcLoweredPredicates is function-valued
+-- and functions have no Show instance. Add a manual instance if needed.
 
 -- | Mutable state. Updated on every WAM step. Held separate from WamContext
 -- so each step transition only allocates a record with the fields that
@@ -1734,6 +1786,7 @@ mkContext codeList labels =
     , wcLabels        = labels
     , wcForeignFacts  = Map.empty
     , wcForeignConfig = Map.empty
+    , wcLoweredPredicates = Map.empty
     }
 
 -- | Create initial empty mutable state. The cold fields (code, labels,
@@ -1773,7 +1826,7 @@ build-type:    Simple
 executable ~w
   main-is:          Main.hs
   hs-source-dirs:   src
-  other-modules:    WamTypes, WamRuntime, Predicates
+  other-modules:    WamTypes, WamRuntime, Predicates, Lowered
   build-depends:    ~w
   default-language: Haskell2010
   ghc-options:      -O2

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -29,13 +29,132 @@
 :- module(wam_haskell_target, [
     compile_wam_predicate_to_haskell/4,  % +Pred/Arity, +WamCode, +Options, -HaskellCode
     compile_wam_runtime_to_haskell/2,    % +Options, -HaskellCode
-    write_wam_haskell_project/3          % +Predicates, +Options, +ProjectDir
+    write_wam_haskell_project/3,         % +Predicates, +Options, +ProjectDir
+    wam_haskell_resolve_emit_mode/2,     % +Options, -Mode
+    wam_haskell_lowerable/3,             % +PredIndicator, +WamCode, -Reason
+    wam_haskell_partition_predicates/4   % +Mode, +Predicates, -InterpretedList, -LoweredList
 ]).
 
 :- use_module(library(lists)).
 :- use_module(library(option)).
 :- use_module(library(filesex), [make_directory_path/1, directory_file_path/3]).
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+
+%% ============================================================================
+%% emit_mode selector (Phase 1 of WAM-lowered Haskell path)
+%% ============================================================================
+%%
+%% See docs/design/WAM_HASKELL_LOWERED_{PHILOSOPHY,SPECIFICATION,IMPLEMENTATION_PLAN}.md
+%%
+%% Three modes are recognised:
+%%   - interpreter          : every predicate compiles via the existing
+%%                            instruction-array interpreter path (default).
+%%   - functions            : every predicate attempts lowering to a
+%%                            standalone Haskell function. Any predicate
+%%                            that fails wam_haskell_lowerable/3 falls back
+%%                            to the interpreter automatically.
+%%   - mixed(HotPreds)      : the predicates named in HotPreds attempt
+%%                            lowering; the rest go to the interpreter.
+%%
+%% Selector hierarchy, checked in order:
+%%   1. emit_mode(Mode) option on the write_wam_haskell_project/3 call
+%%   2. user:wam_haskell_emit_mode(Mode) dynamic fact (if defined)
+%%   3. default: interpreter
+%%
+%% Phase 1 ships the plumbing only. wam_haskell_lowerable/3 is a stub that
+%% always fails, so all three modes route every predicate to the interpreter.
+%% Output is byte-identical to the pre-Phase-1 state. Real lowering starts
+%% in Phase 3 of the implementation plan.
+
+:- multifile user:wam_haskell_emit_mode/1.
+
+%% wam_haskell_resolve_emit_mode(+Options, -Mode)
+%  Resolve the emit_mode selector using the hierarchy above. Throws a
+%  domain_error on an unknown value.
+wam_haskell_resolve_emit_mode(Options, Mode) :-
+    (   option(emit_mode(M0), Options)
+    ->  wam_haskell_validate_emit_mode(M0, Mode)
+    ;   catch(user:wam_haskell_emit_mode(M1), _, fail)
+    ->  wam_haskell_validate_emit_mode(M1, Mode)
+    ;   Mode = interpreter
+    ).
+
+wam_haskell_validate_emit_mode(interpreter, interpreter) :- !.
+wam_haskell_validate_emit_mode(functions, functions)     :- !.
+wam_haskell_validate_emit_mode(mixed(L), mixed(L)) :-
+    is_list(L), !.
+wam_haskell_validate_emit_mode(Other, _) :-
+    throw(error(domain_error(wam_haskell_emit_mode, Other),
+                wam_haskell_resolve_emit_mode/2)).
+
+%% wam_haskell_lowerable(+PredIndicator, +WamCode, -Reason)
+%  Phase 1 stub. True if PredIndicator can be lowered to a standalone
+%  Haskell function given its WamCode. Always fails in Phase 1 with
+%  Reason bound to "lowering emitter not yet implemented" — callers
+%  that want to know *why* a predicate could not be lowered should
+%  pre-bind Reason to a variable and inspect it on failure via
+%  catch/wrapper logic. In practice Phase 1 callers only check
+%  success/failure and log a partition summary.
+%
+%  Real lowerability check lands in Phase 3 of the implementation plan,
+%  at which point this stub is replaced with a per-instruction whitelist
+%  check against the WAM IR.
+wam_haskell_lowerable(_PredIndicator, _WamCode, "lowering emitter not yet implemented") :-
+    fail.
+
+%% wam_haskell_partition_predicates(+Mode, +Predicates, -InterpretedList, -LoweredList)
+%  Partition Predicates into the two sublists based on Mode and the
+%  lowerability check. In Phase 1, LoweredList is always empty because
+%  the stub always fails — but the partition machinery runs anyway so
+%  Phase 3+ can plug in without changing the call site in
+%  write_wam_haskell_project/3.
+wam_haskell_partition_predicates(interpreter, Predicates, Predicates, []) :- !.
+wam_haskell_partition_predicates(functions, Predicates, Interpreted, Lowered) :- !,
+    wam_haskell_partition_try_lower(Predicates, Interpreted, Lowered).
+wam_haskell_partition_predicates(mixed(HotPreds), Predicates, Interpreted, Lowered) :- !,
+    wam_haskell_partition_mixed(Predicates, HotPreds, Interpreted, Lowered).
+
+% functions mode: every predicate attempts lowering.
+wam_haskell_partition_try_lower([], [], []).
+wam_haskell_partition_try_lower([P|Rest], Interpreted, Lowered) :-
+    wam_haskell_predicate_wamcode(P, WamCode),
+    (   wam_haskell_lowerable(P, WamCode, _Reason)
+    ->  Lowered = [P|LR],
+        wam_haskell_partition_try_lower(Rest, Interpreted, LR)
+    ;   Interpreted = [P|IR],
+        wam_haskell_partition_try_lower(Rest, IR, Lowered)
+    ).
+
+% mixed(HotPreds) mode: predicates in HotPreds attempt lowering; rest are interpreted.
+wam_haskell_partition_mixed([], _, [], []).
+wam_haskell_partition_mixed([P|Rest], HotPreds, Interpreted, Lowered) :-
+    (   wam_haskell_indicator_in_list(P, HotPreds)
+    ->  wam_haskell_predicate_wamcode(P, WamCode),
+        (   wam_haskell_lowerable(P, WamCode, _Reason)
+        ->  Lowered = [P|LR],
+            wam_haskell_partition_mixed(Rest, HotPreds, Interpreted, LR)
+        ;   Interpreted = [P|IR],
+            wam_haskell_partition_mixed(Rest, HotPreds, IR, Lowered)
+        )
+    ;   Interpreted = [P|IR],
+        wam_haskell_partition_mixed(Rest, HotPreds, IR, Lowered)
+    ).
+
+% Handle both Module:Pred/Arity and Pred/Arity comparisons against HotPreds.
+wam_haskell_indicator_in_list(P, HotPreds) :-
+    member(P, HotPreds), !.
+wam_haskell_indicator_in_list(_Mod:Pred/Arity, HotPreds) :-
+    member(Pred/Arity, HotPreds), !.
+
+% Compile WAM code on demand for the lowerability check. In Phase 1 the
+% stub always fails, so this is unused in practice — but making it
+% available here means Phase 3 can reuse the same plumbing without
+% touching the partition predicates.
+wam_haskell_predicate_wamcode(PredIndicator, WamCode) :-
+    (   PredIndicator = _Module:Pred/Arity -> true
+    ;   PredIndicator = Pred/Arity
+    ),
+    wam_target:compile_predicate_to_wam(Pred/Arity, [], WamCode).
 
 % ============================================================================
 % Haskell WAM Runtime Data Types
@@ -972,6 +1091,17 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     % Determine map backend: HashMap (faster) or Map (default fallback)
     option(use_hashmap(UseHM), Options, true),
 
+    % Resolve emit_mode and partition predicates accordingly. In Phase 1
+    % the stub wam_haskell_lowerable/3 always fails, so LoweredList is
+    % always empty and the generator's compile path is unchanged.
+    wam_haskell_resolve_emit_mode(Options, EmitMode),
+    wam_haskell_partition_predicates(EmitMode, Predicates, InterpretedList, LoweredList),
+    length(InterpretedList, NInterp),
+    length(LoweredList, NLower),
+    format(user_error,
+           '[WAM-Haskell] emit_mode=~w  interpreted=~w  lowered=~w~n',
+           [EmitMode, NInterp, NLower]),
+
     % Generate WamTypes.hs
     generate_wam_types_hs(TypesCode0),
     apply_hashmap_rewrite(UseHM, types, TypesCode0, TypesCode),
@@ -984,8 +1114,10 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     directory_file_path(SrcDir, 'WamRuntime.hs', RuntimePath),
     write_hs_file(RuntimePath, RuntimeCode),
 
-    % Compile predicates
-    compile_predicates_to_haskell(Predicates, Options, PredsCode0),
+    % Compile the interpreted partition (Phase 1: this is always the full
+    % Predicates list, because LoweredList is always empty). Phase 2 emits
+    % Lowered.hs for the non-empty case.
+    compile_predicates_to_haskell(InterpretedList, Options, PredsCode0),
     apply_hashmap_rewrite(UseHM, generic, PredsCode0, PredsCode),
     directory_file_path(SrcDir, 'Predicates.hs', PredsPath),
     write_hs_file(PredsPath, PredsCode),

--- a/tests/test_wam_haskell_lowered_phase1.pl
+++ b/tests/test_wam_haskell_lowered_phase1.pl
@@ -1,0 +1,186 @@
+:- encoding(utf8).
+% Phase 1 tests for the WAM-lowered Haskell code-generation path.
+%
+% Phase 1 is plumbing only: the emit_mode/1 selector, the
+% user:wam_haskell_emit_mode/1 dynamic fallback, the stub
+% wam_haskell_lowerable/3, and the partition helper. The real lowering
+% emitter lands in Phase 3+.
+%
+% These tests assert only that the plumbing resolves correctly and
+% that every mode partitions predicates identically (all interpreted)
+% because the stub fails for every predicate.
+%
+% Usage: swipl -g run_tests -t halt tests/test_wam_haskell_lowered_phase1.pl
+
+:- use_module('../src/unifyweaver/targets/wam_haskell_target')  .
+
+:- dynamic test_failed/0.
+:- dynamic user:wam_haskell_emit_mode/1.
+
+pass(Test) :-
+    format('[PASS] ~w~n', [Test]).
+
+fail_test(Test, Reason) :-
+    format('[FAIL] ~w: ~w~n', [Test, Reason]),
+    (   test_failed -> true ; assert(test_failed) ).
+
+%% ---------------------------------------------------------------------
+%% Selector resolution
+%% ---------------------------------------------------------------------
+
+test_default_mode_is_interpreter :-
+    Test = 'WAM-Haskell-Lowered Phase 1: default mode is interpreter',
+    retractall(user:wam_haskell_emit_mode(_)),
+    wam_haskell_resolve_emit_mode([], Mode),
+    (   Mode == interpreter
+    ->  pass(Test)
+    ;   fail_test(Test, ['expected interpreter, got ', Mode])
+    ).
+
+test_option_overrides_default :-
+    Test = 'WAM-Haskell-Lowered Phase 1: emit_mode option overrides default',
+    retractall(user:wam_haskell_emit_mode(_)),
+    wam_haskell_resolve_emit_mode([emit_mode(functions)], Mode),
+    (   Mode == functions
+    ->  pass(Test)
+    ;   fail_test(Test, ['expected functions, got ', Mode])
+    ).
+
+test_user_fact_fallback :-
+    Test = 'WAM-Haskell-Lowered Phase 1: user:wam_haskell_emit_mode fallback',
+    retractall(user:wam_haskell_emit_mode(_)),
+    assertz(user:wam_haskell_emit_mode(functions)),
+    wam_haskell_resolve_emit_mode([], Mode),
+    retractall(user:wam_haskell_emit_mode(_)),
+    (   Mode == functions
+    ->  pass(Test)
+    ;   fail_test(Test, ['expected functions from user fact, got ', Mode])
+    ).
+
+test_option_beats_user_fact :-
+    Test = 'WAM-Haskell-Lowered Phase 1: option beats user fact',
+    retractall(user:wam_haskell_emit_mode(_)),
+    assertz(user:wam_haskell_emit_mode(functions)),
+    wam_haskell_resolve_emit_mode([emit_mode(interpreter)], Mode),
+    retractall(user:wam_haskell_emit_mode(_)),
+    (   Mode == interpreter
+    ->  pass(Test)
+    ;   fail_test(Test, ['expected interpreter from option, got ', Mode])
+    ).
+
+test_mixed_mode_accepted :-
+    Test = 'WAM-Haskell-Lowered Phase 1: mixed(List) mode accepted',
+    retractall(user:wam_haskell_emit_mode(_)),
+    wam_haskell_resolve_emit_mode([emit_mode(mixed([cat_anc/4, pow_sum/4]))], Mode),
+    (   Mode == mixed([cat_anc/4, pow_sum/4])
+    ->  pass(Test)
+    ;   fail_test(Test, ['expected mixed(...), got ', Mode])
+    ).
+
+test_unknown_mode_throws :-
+    Test = 'WAM-Haskell-Lowered Phase 1: unknown mode throws domain_error',
+    retractall(user:wam_haskell_emit_mode(_)),
+    catch(
+        wam_haskell_resolve_emit_mode([emit_mode(nonsense)], _),
+        error(domain_error(wam_haskell_emit_mode, nonsense), _),
+        ThrewCorrectly = true
+    ),
+    (   ThrewCorrectly == true
+    ->  pass(Test)
+    ;   fail_test(Test, 'unknown mode did not throw domain_error')
+    ).
+
+test_mixed_non_list_rejected :-
+    Test = 'WAM-Haskell-Lowered Phase 1: mixed(non-list) rejected',
+    retractall(user:wam_haskell_emit_mode(_)),
+    catch(
+        wam_haskell_resolve_emit_mode([emit_mode(mixed(not_a_list))], _),
+        error(domain_error(wam_haskell_emit_mode, mixed(not_a_list)), _),
+        ThrewCorrectly = true
+    ),
+    (   ThrewCorrectly == true
+    ->  pass(Test)
+    ;   fail_test(Test, 'mixed(non-list) did not throw')
+    ).
+
+%% ---------------------------------------------------------------------
+%% Lowerability stub
+%% ---------------------------------------------------------------------
+
+test_lowerable_stub_always_fails :-
+    Test = 'WAM-Haskell-Lowered Phase 1: wam_haskell_lowerable/3 stub fails',
+    (   \+ wam_haskell_lowerable(foo/1, [], _Reason)
+    ->  pass(Test)
+    ;   fail_test(Test, 'stub unexpectedly succeeded')
+    ).
+
+%% ---------------------------------------------------------------------
+%% Partition
+%% ---------------------------------------------------------------------
+
+test_partition_interpreter_mode :-
+    Test = 'WAM-Haskell-Lowered Phase 1: partition in interpreter mode is identity',
+    Preds = [a/1, b/2, c/3],
+    wam_haskell_partition_predicates(interpreter, Preds, Interp, Lower),
+    (   Interp == Preds, Lower == []
+    ->  pass(Test)
+    ;   fail_test(Test, ['unexpected partition ', Interp, Lower])
+    ).
+
+% functions and mixed modes attempt lowering, which requires calling
+% wam_target:compile_predicate_to_wam/3 on each listed predicate. Those
+% calls exercise a wider stack than the pure selector tests above, so
+% rather than fabricate a WAM body we ship a trivial predicate to the
+% user module and partition against it.
+
+:- dynamic user:phase1_probe/1.
+user:phase1_probe(a).
+user:phase1_probe(b).
+
+test_partition_functions_mode :-
+    Test = 'WAM-Haskell-Lowered Phase 1: partition in functions mode routes all to interpreter',
+    wam_haskell_partition_predicates(functions, [user:phase1_probe/1], Interp, Lower),
+    (   Interp == [user:phase1_probe/1], Lower == []
+    ->  pass(Test)
+    ;   fail_test(Test, ['unexpected partition ', Interp, Lower])
+    ).
+
+test_partition_mixed_mode_hot_and_cold :-
+    Test = 'WAM-Haskell-Lowered Phase 1: partition in mixed mode — hot attempts lowering, cold straight to interpreter',
+    % user:phase1_probe/1 is in HotPreds: attempts lowering (stub fails), goes to Interp.
+    % user:phase1_cold/1 is NOT in HotPreds: goes straight to Interp without a WAM compile.
+    % We synthesize a second indicator that does not have clauses, which is
+    % fine because the cold branch never calls wam_target:compile_predicate_to_wam/3.
+    wam_haskell_partition_predicates(
+        mixed([phase1_probe/1]),
+        [user:phase1_probe/1, user:phase1_cold/1],
+        Interp,
+        Lower),
+    (   Interp == [user:phase1_probe/1, user:phase1_cold/1], Lower == []
+    ->  pass(Test)
+    ;   fail_test(Test, ['unexpected partition ', Interp, Lower])
+    ).
+
+%% ---------------------------------------------------------------------
+%% Runner
+%% ---------------------------------------------------------------------
+
+run_tests :-
+    retractall(test_failed),
+    format('~n=== WAM-Haskell-Lowered Phase 1 tests ===~n', []),
+    test_default_mode_is_interpreter,
+    test_option_overrides_default,
+    test_user_fact_fallback,
+    test_option_beats_user_fact,
+    test_mixed_mode_accepted,
+    test_unknown_mode_throws,
+    test_mixed_non_list_rejected,
+    test_lowerable_stub_always_fails,
+    test_partition_interpreter_mode,
+    test_partition_functions_mode,
+    test_partition_mixed_mode_hot_and_cold,
+    format('~n', []),
+    (   test_failed
+    ->  format('=== FAILED ===~n', []), halt(1)
+    ;   format('=== All Phase 1 tests passed ===~n', [])
+    ).

--- a/tests/test_wam_haskell_lowered_phase1.pl
+++ b/tests/test_wam_haskell_lowered_phase1.pl
@@ -107,11 +107,14 @@ test_mixed_non_list_rejected :-
 %% Lowerability stub
 %% ---------------------------------------------------------------------
 
-test_lowerable_stub_always_fails :-
-    Test = 'WAM-Haskell-Lowered Phase 1: wam_haskell_lowerable/3 stub fails',
-    (   \+ wam_haskell_lowerable(foo/1, [], _Reason)
+test_lowerable_rejects_unsupported :-
+    Test = 'WAM-Haskell-Lowered Phase 1: wam_haskell_lowerable/3 rejects unsupported instructions',
+    % Phase 3 whitelist only covers get_constant+proceed. A WAM text
+    % containing a Call instruction must fail lowerability.
+    WamText = "foo/1:\n    call bar/0, 0\n    proceed\n",
+    (   \+ wam_haskell_lowerable(foo/1, WamText, _Reason)
     ->  pass(Test)
-    ;   fail_test(Test, 'stub unexpectedly succeeded')
+    ;   fail_test(Test, 'unsupported Call instruction was accepted')
     ).
 
 %% ---------------------------------------------------------------------
@@ -175,7 +178,7 @@ run_tests :-
     test_mixed_mode_accepted,
     test_unknown_mode_throws,
     test_mixed_non_list_rejected,
-    test_lowerable_stub_always_fails,
+    test_lowerable_rejects_unsupported,
     test_partition_interpreter_mode,
     test_partition_functions_mode,
     test_partition_mixed_mode_hot_and_cold,

--- a/tests/test_wam_haskell_lowered_phase2.pl
+++ b/tests/test_wam_haskell_lowered_phase2.pl
@@ -1,0 +1,165 @@
+:- encoding(utf8).
+% Phase 2 codegen tests for the WAM-lowered Haskell path.
+%
+% Phase 2 adds:
+%   - wcLoweredPredicates field to WamContext (a Map from predicate name to
+%     a (WamContext -> WamState -> Maybe WamState) function)
+%   - a new case at the top of the Call dispatch chain in step that checks
+%     wcLoweredPredicates before executeForeign
+%   - a Lowered.hs module emitted alongside Predicates.hs, body
+%     loweredPredicates = Map.empty
+%   - Main.hs wiring that imports Lowered and populates wcLoweredPredicates
+%   - the cabal other-modules list includes Lowered
+%
+% These are codegen-only assertions — they inspect the text of generated
+% files, not GHC compilation. The build+run verification was done manually
+% via /tmp/wam_hs_lowered_phase2 with the effective_distance 10k benchmark,
+% output byte-identical to the Prolog reference.
+%
+% Usage: swipl -g run_tests -t halt tests/test_wam_haskell_lowered_phase2.pl
+
+:- use_module('../src/unifyweaver/targets/wam_haskell_target').
+:- use_module(library(filesex), [make_directory_path/1]).
+
+:- dynamic test_failed/0.
+
+pass(Test) :-
+    format('[PASS] ~w~n', [Test]).
+
+fail_test(Test, Reason) :-
+    format('[FAIL] ~w: ~w~n', [Test, Reason]),
+    (   test_failed -> true ; assert(test_failed) ).
+
+%% A tiny user predicate so we can exercise write_wam_haskell_project/3
+%% without depending on the benchmark fixtures.
+:- dynamic user:phase2_probe/1.
+user:phase2_probe(42).
+
+project_dir('/tmp/uw_wam_hs_lowered_phase2_test').
+
+generate_phase2_project :-
+    project_dir(Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ),
+    write_wam_haskell_project(
+        [user:phase2_probe/1],
+        [module_name('wam-bench-hm-phase2-test'), use_hashmap(false)],
+        Dir).
+
+read_file_to_string(Path, Str) :-
+    open(Path, read, S),
+    read_string(S, _, Str),
+    close(S).
+
+test_lowered_hs_emitted :-
+    Test = 'WAM-Haskell-Lowered Phase 2: Lowered.hs emitted',
+    generate_phase2_project,
+    project_dir(Dir),
+    atom_concat(Dir, '/src/Lowered.hs', Path),
+    (   exists_file(Path)
+    ->  pass(Test)
+    ;   fail_test(Test, ['file missing: ', Path])
+    ).
+
+test_lowered_hs_module_header :-
+    Test = 'WAM-Haskell-Lowered Phase 2: Lowered.hs has module header and empty Map',
+    project_dir(Dir),
+    atom_concat(Dir, '/src/Lowered.hs', Path),
+    read_file_to_string(Path, S),
+    (   sub_string(S, _, _, _, "module Lowered where"),
+        sub_string(S, _, _, _, "loweredPredicates :: Map.Map String (WamContext -> WamState -> Maybe WamState)"),
+        sub_string(S, _, _, _, "loweredPredicates = Map.empty")
+    ->  pass(Test)
+    ;   fail_test(Test, 'module header or Map.empty body missing')
+    ).
+
+test_wam_types_has_wcLoweredPredicates :-
+    Test = 'WAM-Haskell-Lowered Phase 2: WamContext has wcLoweredPredicates field',
+    project_dir(Dir),
+    atom_concat(Dir, '/src/WamTypes.hs', Path),
+    read_file_to_string(Path, S),
+    (   sub_string(S, _, _, _, "wcLoweredPredicates :: !(Map.Map String (WamContext -> WamState -> Maybe WamState))")
+    ->  pass(Test)
+    ;   fail_test(Test, 'wcLoweredPredicates field missing from WamContext')
+    ).
+
+test_wam_types_no_deriving_show :-
+    Test = 'WAM-Haskell-Lowered Phase 2: WamContext no longer derives Show',
+    project_dir(Dir),
+    atom_concat(Dir, '/src/WamTypes.hs', Path),
+    read_file_to_string(Path, S),
+    % Find data WamContext block and check the closing brace line is not followed by deriving Show.
+    % Easiest: assert absence of literal "WamContext ... deriving (Show)".
+    (   \+ sub_string(S, _, _, _, "WamContext\n  { wcCode          :: !(Array Int Instruction)")
+    ->  fail_test(Test, 'could not find WamContext block at all')
+    ;   sub_string(S, _, _, _, "-- Note: no `deriving (Show)`")
+    ->  pass(Test)
+    ;   fail_test(Test, 'deriving (Show) comment missing — check that deriving was actually dropped')
+    ).
+
+test_mkcontext_initializes_wcLoweredPredicates :-
+    Test = 'WAM-Haskell-Lowered Phase 2: mkContext initializes wcLoweredPredicates',
+    project_dir(Dir),
+    atom_concat(Dir, '/src/WamTypes.hs', Path),
+    read_file_to_string(Path, S),
+    (   sub_string(S, _, _, _, "wcLoweredPredicates = Map.empty")
+    ->  pass(Test)
+    ;   fail_test(Test, 'mkContext missing wcLoweredPredicates = Map.empty')
+    ).
+
+test_step_call_dispatch_checks_lowered_first :-
+    Test = 'WAM-Haskell-Lowered Phase 2: step Call dispatch checks wcLoweredPredicates before executeForeign',
+    compile_wam_runtime_to_haskell([], Code),
+    atom_string(Code, S),
+    (   sub_string(S, _, _, _, "case Map.lookup pred (wcLoweredPredicates ctx) of"),
+        sub_string(S, _, _, _, "Just fn -> fn ctx sc")
+    ->  pass(Test)
+    ;   fail_test(Test, 'step dispatch does not check wcLoweredPredicates first')
+    ).
+
+test_main_imports_lowered :-
+    Test = 'WAM-Haskell-Lowered Phase 2: Main.hs imports Lowered',
+    project_dir(Dir),
+    atom_concat(Dir, '/src/Main.hs', Path),
+    read_file_to_string(Path, S),
+    (   sub_string(S, _, _, _, "import qualified Lowered")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Main.hs missing import Lowered')
+    ).
+
+test_main_populates_wcLoweredPredicates :-
+    Test = 'WAM-Haskell-Lowered Phase 2: Main.hs populates wcLoweredPredicates from Lowered',
+    project_dir(Dir),
+    atom_concat(Dir, '/src/Main.hs', Path),
+    read_file_to_string(Path, S),
+    (   sub_string(S, _, _, _, "wcLoweredPredicates = Lowered.loweredPredicates")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Main.hs does not populate wcLoweredPredicates')
+    ).
+
+test_cabal_other_modules_has_lowered :-
+    Test = 'WAM-Haskell-Lowered Phase 2: cabal other-modules lists Lowered',
+    project_dir(Dir),
+    atom_concat(Dir, '/wam-bench-hm-phase2-test.cabal', Path),
+    read_file_to_string(Path, S),
+    (   sub_string(S, _, _, _, "WamTypes, WamRuntime, Predicates, Lowered")
+    ->  pass(Test)
+    ;   fail_test(Test, 'cabal other-modules missing Lowered')
+    ).
+
+run_tests :-
+    retractall(test_failed),
+    format('~n=== WAM-Haskell-Lowered Phase 2 tests ===~n', []),
+    test_lowered_hs_emitted,
+    test_lowered_hs_module_header,
+    test_wam_types_has_wcLoweredPredicates,
+    test_wam_types_no_deriving_show,
+    test_mkcontext_initializes_wcLoweredPredicates,
+    test_step_call_dispatch_checks_lowered_first,
+    test_main_imports_lowered,
+    test_main_populates_wcLoweredPredicates,
+    test_cabal_other_modules_has_lowered,
+    format('~n', []),
+    (   test_failed
+    ->  format('=== FAILED ===~n', []), halt(1)
+    ;   format('=== All Phase 2 tests passed ===~n', [])
+    ).

--- a/tests/test_wam_haskell_lowered_phase3.pl
+++ b/tests/test_wam_haskell_lowered_phase3.pl
@@ -1,0 +1,184 @@
+:- encoding(utf8).
+% Phase 3 smoke tests for the WAM-lowered Haskell path.
+%
+% Phase 3 adds:
+%   - wam_haskell_lowered_emitter.pl with a real wam_haskell_lowerable/3
+%     (whitelist: get_constant + proceed) and lower_predicate_to_haskell/4
+%   - Re-export through wam_haskell_target.pl
+%   - Lowered.hs emits actual function definitions when the lowered
+%     partition is non-empty, plus a non-empty loweredPredicates map
+%
+% These are codegen-only assertions. The build+run verification is done
+% manually via /tmp/wam_hs_lowered_phase3 with the effective_distance
+% 10k benchmark, output byte-identical to the Prolog reference (verified
+% to match Phase 2 output via diff, Temperature=2.840088).
+%
+% Usage: swipl -g run_tests -t halt tests/test_wam_haskell_lowered_phase3.pl
+
+:- use_module('../src/unifyweaver/targets/wam_haskell_target').
+:- use_module('../src/unifyweaver/targets/wam_haskell_lowered_emitter').
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module(library(filesex), [make_directory_path/1]).
+
+:- dynamic test_failed/0.
+
+pass(Test) :-
+    format('[PASS] ~w~n', [Test]).
+
+fail_test(Test, Reason) :-
+    format('[FAIL] ~w: ~w~n', [Test, Reason]),
+    (   test_failed -> true ; assert(test_failed) ).
+
+%% A probe predicate with a single-clause integer fact body. Compiles to
+%% get_constant + proceed, exactly what the Phase 3 whitelist accepts.
+:- dynamic user:phase3_constant/1.
+user:phase3_constant(42).
+
+%% A probe predicate with multiple clauses — its WAM uses try_me_else /
+%% trust_me and must NOT be lowerable under the Phase 3 whitelist.
+:- dynamic user:phase3_multi/1.
+user:phase3_multi(a).
+user:phase3_multi(b).
+
+project_dir('/tmp/uw_wam_hs_lowered_phase3_test').
+
+read_file_to_string(Path, Str) :-
+    open(Path, read, S),
+    read_string(S, _, Str),
+    close(S).
+
+%% ---------------------------------------------------------------------
+%% Emitter unit tests
+%% ---------------------------------------------------------------------
+
+test_lowerable_accepts_single_clause_fact :-
+    Test = 'Phase 3: wam_haskell_lowerable accepts single-clause fact',
+    wam_target:compile_predicate_to_wam(phase3_constant/1, [], WamCode),
+    (   wam_haskell_lowerable(user:phase3_constant/1, WamCode, _)
+    ->  pass(Test)
+    ;   fail_test(Test, 'single-clause integer fact was rejected')
+    ).
+
+test_lowerable_rejects_multi_clause :-
+    Test = 'Phase 3: wam_haskell_lowerable rejects multi-clause fact (try_me_else)',
+    wam_target:compile_predicate_to_wam(phase3_multi/1, [], WamCode),
+    (   \+ wam_haskell_lowerable(user:phase3_multi/1, WamCode, _)
+    ->  pass(Test)
+    ;   fail_test(Test, 'multi-clause fact was accepted despite try_me_else')
+    ).
+
+test_lower_predicate_produces_function :-
+    Test = 'Phase 3: lower_predicate_to_haskell emits expected function',
+    wam_target:compile_predicate_to_wam(phase3_constant/1, [], WamCode),
+    lower_predicate_to_haskell(user:phase3_constant/1, WamCode, [],
+                               lowered(PredName, FuncName, HsCode)),
+    (   PredName == 'phase3_constant/1',
+        FuncName == lowered_phase3_constant_1,
+        sub_string(HsCode, _, _, _, "lowered_phase3_constant_1 :: WamContext -> WamState -> Maybe WamState"),
+        sub_string(HsCode, _, _, _, "v == (Integer 42)")
+    ->  pass(Test)
+    ;   fail_test(Test, ['unexpected emitter output; PredName=', PredName, ' FuncName=', FuncName])
+    ).
+
+%% ---------------------------------------------------------------------
+%% Partition behavior
+%% ---------------------------------------------------------------------
+
+test_partition_mixed_lowers_supported :-
+    Test = 'Phase 3: partition in mixed mode routes supported preds to LoweredList',
+    wam_haskell_partition_predicates(
+        mixed([phase3_constant/1]),
+        [user:phase3_constant/1, user:phase3_multi/1],
+        Interpreted,
+        Lowered),
+    (   Lowered   == [user:phase3_constant/1],
+        Interpreted == [user:phase3_multi/1]
+    ->  pass(Test)
+    ;   fail_test(Test, ['unexpected partition Interp=', Interpreted, ' Lower=', Lowered])
+    ).
+
+test_partition_functions_lowers_all_supported :-
+    Test = 'Phase 3: partition in functions mode lowers every supported pred',
+    wam_haskell_partition_predicates(
+        functions,
+        [user:phase3_constant/1, user:phase3_multi/1],
+        Interpreted,
+        Lowered),
+    (   Lowered   == [user:phase3_constant/1],
+        Interpreted == [user:phase3_multi/1]
+    ->  pass(Test)
+    ;   fail_test(Test, ['unexpected partition Interp=', Interpreted, ' Lower=', Lowered])
+    ).
+
+%% ---------------------------------------------------------------------
+%% End-to-end project-file codegen
+%% ---------------------------------------------------------------------
+
+generate_phase3_project :-
+    project_dir(Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ),
+    % Only phase3_constant/1 — keep the interpreted partition empty so
+    % the test does not exercise the pre-existing wam_value_to_haskell
+    % parser bug on switch_on_constant with atom keys (out of scope
+    % for this branch).
+    write_wam_haskell_project(
+        [user:phase3_constant/1],
+        [module_name('uw-wam-hs-lowered-phase3-test'),
+         use_hashmap(false),
+         emit_mode(mixed([phase3_constant/1]))],
+        Dir).
+
+test_lowered_hs_has_function_definition :-
+    Test = 'Phase 3: Lowered.hs contains the emitted function',
+    generate_phase3_project,
+    project_dir(Dir),
+    atom_concat(Dir, '/src/Lowered.hs', Path),
+    read_file_to_string(Path, S),
+    (   sub_string(S, _, _, _, "lowered_phase3_constant_1 :: WamContext -> WamState -> Maybe WamState"),
+        sub_string(S, _, _, _, "v == (Integer 42)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Lowered.hs missing expected function body')
+    ).
+
+test_lowered_hs_dispatch_map_populated :-
+    Test = 'Phase 3: Lowered.hs loweredPredicates dispatch map is non-empty',
+    project_dir(Dir),
+    atom_concat(Dir, '/src/Lowered.hs', Path),
+    read_file_to_string(Path, S),
+    (   sub_string(S, _, _, _, "loweredPredicates = Map.fromList"),
+        sub_string(S, _, _, _, "(\"phase3_constant/1\", lowered_phase3_constant_1)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'loweredPredicates missing expected entry')
+    ).
+
+test_predicates_hs_still_emitted :-
+    Test = 'Phase 3: Predicates.hs still emitted (empty instruction array) so Main.hs compiles',
+    project_dir(Dir),
+    atom_concat(Dir, '/src/Predicates.hs', Path),
+    read_file_to_string(Path, S),
+    (   sub_string(S, _, _, _, "allCode :: [Instruction]"),
+        sub_string(S, _, _, _, "allLabels")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Predicates.hs missing allCode/allLabels even in pure-lowered mode')
+    ).
+
+%% ---------------------------------------------------------------------
+%% Runner
+%% ---------------------------------------------------------------------
+
+run_tests :-
+    retractall(test_failed),
+    format('~n=== WAM-Haskell-Lowered Phase 3 tests ===~n', []),
+    test_lowerable_accepts_single_clause_fact,
+    test_lowerable_rejects_multi_clause,
+    test_lower_predicate_produces_function,
+    test_partition_mixed_lowers_supported,
+    test_partition_functions_lowers_all_supported,
+    test_lowered_hs_has_function_definition,
+    test_lowered_hs_dispatch_map_populated,
+    test_predicates_hs_still_emitted,
+    format('~n', []),
+    (   test_failed
+    ->  format('=== FAILED ===~n', []), halt(1)
+    ;   format('=== All Phase 3 tests passed ===~n', [])
+    ).


### PR DESCRIPTION
  ## Summary

  - Adds the **WAM-lowered Haskell code-generation path** — a new `emit_mode` option on `write_wam_haskell_project/3` that
  emits one Haskell function per predicate using Maybe-monad do-notation, bypassing the interpreter's per-instruction
  dispatch loop for the hot path.
  - Ships behind a selector (`emit_mode(interpreter|functions|mixed([...]))`) with **`interpreter` as the default** —
  existing users see zero behavior change.
  - Simple single-clause predicates (`max_depth/1`, `dimension_n/1`) lower correctly and produce benchmark output
  byte-identical to the Prolog reference.
  - Multi-clause predicate lowering (`category_ancestor/4`) compiles but has a **known non-termination bug** when
  clause-1-only lowering interacts with interpreter clause-2 recursion. This only triggers with explicit opt-in
  (`emit_mode(mixed([category_ancestor/4]))`); the default `interpreter` path is unaffected.

  ## Commits

  | Phase | What |
  |---|---|
  | **Phase 1** `9e7bb03f` | `emit_mode/1` selector plumbing: option parsing, `user:wam_haskell_emit_mode/1` dynamic
  fallback, stub `wam_haskell_lowerable/3`, partition helper. 11 unit tests. Generator output byte-identical across all modes
   (SHA-256 verified). |
  | **Phase 2** `d88fe5d2` | `Lowered.hs` skeleton: `wcLoweredPredicates` field on `WamContext`, dispatch wiring in `step`'s
  `Call` chain (checked before `executeForeign`), empty `Lowered.hs` module, `Main.hs` wiring, cabal `other-modules`. 9
  codegen tests. `cabal build` clean, 10k benchmark byte-identical to Prolog. |
  | **Phase 3** `4c7debcd` | First lowered predicate: new `wam_haskell_lowered_emitter.pl` module with real whitelist check
  (`get_constant` + `proceed`) and per-instruction Haskell emitter. `max_depth/1` lowered to `lowered_max_depth_1` in
  `Lowered.hs` with populated `loweredPredicates` dispatch Map. 8 tests. Benchmark byte-identical. |
  | **Phase 4** `a82a1a03` | Full instruction-set expansion: do-notation emission, `dispatchCall` helper in `WamRuntime.hs`,
  global PC offsetting via `compute_base_pcs/2`, multi-clause support (clause-1-only lowering with interpreter backtrack
  fallback). 16 instruction types whitelisted. Simple predicates work; `category_ancestor/4` has non-termination bug (see
  below). |

  ## Architecture

  Three-level selector hierarchy (checked in order):
  1. `emit_mode(Mode)` option on `write_wam_haskell_project/3`
  2. `user:wam_haskell_emit_mode(Mode)` dynamic fact
  3. Generator default: `interpreter`

  Lowered predicates coexist with the interpreter:
  - ALL predicates compile into the interpreter's instruction array (`Predicates.hs`) for backtrack fallback
  - Lowered predicates ALSO get standalone Haskell functions in `Lowered.hs`
  - `step`'s `Call` dispatch checks `wcLoweredPredicates` first, then `executeForeign`, then `callIndexedFact2`, then label
  lookup
  - On clause-1 failure, the lowered function calls `backtrack` and `run` to enter clause 2+ through the interpreter

  New files:
  - `src/unifyweaver/targets/wam_haskell_lowered_emitter.pl` — instruction parser, whitelist check, Haskell emission
  - `tests/test_wam_haskell_lowered_phase1.pl` — 11 selector/partition tests
  - `tests/test_wam_haskell_lowered_phase2.pl` — 9 codegen tests
  - `tests/test_wam_haskell_lowered_phase3.pl` — 8 emitter + end-to-end tests

  ## Known issue: category_ancestor/4 non-termination

  When `emit_mode(mixed([category_ancestor/4]))` is used, the benchmark hangs. Root cause under investigation — two likely
  candidates:

  1. **Dispatch priority conflict:** The lowered function is registered in `wcLoweredPredicates` and intercepts recursive
  `Call "category_ancestor/4"` before `executeForeign` can route to `nativeCategoryAncestor` (the FFI). The lowered
  clause-1-only path + interpreter clause-2 recursive interaction may not terminate correctly, whereas the FFI handled the
  full recursion natively.

  2. **Backtrack state mismatch:** The lowered function backtracks from `s_cp` (post-CP-push, pre-clause-1 state) rather than
   from the state after clause-1 execution. Trail undo may be incomplete if clause-1's bindings aren't properly reflected in
  `s_cp`.

  **This bug is strictly opt-in.** The default `emit_mode(interpreter)` is completely unaffected. Users must explicitly
  request lowering of `category_ancestor/4` to hit it.

  ## Test plan

  - [x] Phase 1: 11 unit tests for selector hierarchy, mode validation, partition shape
  - [x] Phase 2: 9 codegen assertions for WamContext field, step dispatch, Lowered.hs, Main.hs wiring, cabal modules
  - [x] Phase 3: 8 tests for emitter unit (accepts/rejects), partition behavior, end-to-end codegen
  - [x] Phase 5 upstream regression: 6 term-builtin codegen tests still pass
  - [x] `effective_distance` 10k benchmark with `emit_mode(interpreter)`: byte-identical to Prolog reference (5193 rows,
  Temperature=2.840088)
  - [x] `effective_distance` 10k benchmark with `emit_mode(mixed([max_depth/1]))`: byte-identical
  - [x] No performance regression on interpreter path (median query_ms within noise of pre-branch baseline)
  - [ ] `emit_mode(mixed([category_ancestor/4]))`: **known non-termination** — tracked for follow-up

  🤖 Generated with [Claude Code](https://claude.com/claude-code)