### PR TITLE
feat(wam-llvm): countdown_sum2 kernel + document remaining blockers (M5.13)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -147,6 +147,8 @@ foreign_kernel(PredArity, Kind, Config) :-
 %  DetectorPredicate(+Pred, +Arity, +Clauses, -RecKernel) should bind
 %  RecKernel to a `recursive_kernel(Kind, Pred/Arity, Config)` term
 %  on success.
+llvm_recursive_kernel_detector(countdown_sum2,
+    llvm_recursive_kernel_countdown_sum).
 llvm_recursive_kernel_detector(transitive_closure2,
     llvm_recursive_kernel_transitive_closure).
 llvm_recursive_kernel_detector(transitive_distance3,
@@ -170,6 +172,31 @@ llvm_recursive_kernel_transitive_distance(Pred, Arity, Clauses,
         recursive_kernel(transitive_distance3, Pred/Arity,
             [edge_pred(EdgePred/2)])) :-
     llvm_foreign_lowerable_transitive_distance(Pred, Arity, Clauses, EdgePred).
+
+%% llvm_recursive_kernel_countdown_sum(+Pred, +Arity, +Clauses, -RecKernel).
+%
+%  Detects the countdown_sum2 clause shape:
+%    pred(0, 0).
+%    pred(N, Sum) :- N > 0, N1 is N - 1, pred(N1, PrevSum), Sum is PrevSum + N.
+llvm_recursive_kernel_countdown_sum(Pred, Arity, Clauses,
+        recursive_kernel(countdown_sum2, Pred/Arity, [])) :-
+    llvm_foreign_lowerable_countdown_sum(Pred, Arity, Clauses).
+
+%% llvm_foreign_lowerable_countdown_sum(+Pred, +Arity, +Clauses).
+%
+%  Ported from rust_target.pl:3902. Matches the countdown-sum recurrence.
+llvm_foreign_lowerable_countdown_sum(Pred, 2, Clauses) :-
+    member(BaseHead-true, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseHead =.. [Pred, 0, 0],
+    RecHead =.. [Pred, N, Sum],
+    RecBody = (GtGoal, (StepGoal, (RecGoal, SumGoal))),
+    GtGoal =.. [>, N, 0],
+    StepGoal =.. [is, PrevN, StepExpr],
+    ( StepExpr =.. [-, N, 1] ; StepExpr =.. [+, N, -1] ),
+    RecGoal =.. [Pred, PrevN, PrevSum],
+    SumGoal =.. [is, Sum, SumExpr],
+    SumExpr =.. [+, PrevSum, N].
 
 %% llvm_recursive_kernel_transitive_closure(+Pred, +Arity, +Clauses, -RecKernel).
 %
@@ -333,14 +360,23 @@ substitute_foreign_kernel_impls(StateFuncsRaw, StateFuncs, Globals) :-
     ;  build_td3_instance_switch(Td3Entries, Td3ImplBody, Td3Tables),
        replace_td3_weak_default(StateFuncsRaw, Td3ImplBody, StateFuncs0)
     ),
+    % cds2 pass — countdown_sum2 (deterministic arithmetic).
+    findall(CdsPredArity-CdsConfig,
+        llvm_foreign_kernel_spec(CdsPredArity, countdown_sum2, CdsConfig),
+        Cds2Entries),
+    ( Cds2Entries == []
+    -> StateFuncsCds = StateFuncs0, Cds2Tables = ''
+    ;  build_cds2_instance_switch(Cds2Entries, Cds2ImplBody, Cds2Tables),
+       replace_cds2_weak_default(StateFuncs0, Cds2ImplBody, StateFuncsCds)
+    ),
     % tc2 pass — transitive_closure2 (boolean reachability).
     findall(TcPredArity-TcConfig,
         llvm_foreign_kernel_spec(TcPredArity, transitive_closure2, TcConfig),
         Tc2Entries),
     ( Tc2Entries == []
-    -> StateFuncsTc = StateFuncs0, Tc2Tables = ''
+    -> StateFuncsTc = StateFuncsCds, Tc2Tables = ''
     ;  build_tc2_instance_switch(Tc2Entries, Tc2ImplBody, Tc2Tables),
-       replace_tc2_weak_default(StateFuncs0, Tc2ImplBody, StateFuncsTc)
+       replace_tc2_weak_default(StateFuncsCds, Tc2ImplBody, StateFuncsTc)
     ),
     % wsp3 pass — mirror of the td3 pass but for weighted_shortest_path3.
     findall(WspPredArity-WspConfig,
@@ -361,11 +397,11 @@ substitute_foreign_kernel_impls(StateFuncsRaw, StateFuncs, Globals) :-
        replace_astar4_weak_default(StateFuncs1, Astar4ImplBody, StateFuncs)
     ),
     % Concatenate the per-kind global tables into one Globals blob.
-    ( Td3Tables == '', Tc2Tables == '', Wsp3Tables == '', Astar4Tables == ''
+    ( Cds2Tables == '', Td3Tables == '', Tc2Tables == '', Wsp3Tables == '', Astar4Tables == ''
     -> Globals = ''
     ;  atomic_list_concat([
            '; === foreign kernel support globals ===\n',
-           Tc2Tables, '\n', Td3Tables, '\n', Wsp3Tables, '\n', Astar4Tables, '\n'
+           Cds2Tables, '\n', Tc2Tables, '\n', Td3Tables, '\n', Wsp3Tables, '\n', Astar4Tables, '\n'
        ], Globals)
     ).
 
@@ -454,6 +490,50 @@ build_td3_instance_table(Config, TableName, TableIR, GepLen, EffLen, MaxAtomId) 
     llvm_emit_atom_fact2_table(TableName, Pairs, TableIR),
     length(Pairs, Len),
     ( Len == 0 -> EffLen = 0, GepLen = 1 ; EffLen = Len, GepLen = Len ).
+
+%% build_cds2_instance_switch(+Entries, -ImplBody, -TablesIR).
+%
+%  countdown_sum2 is pure arithmetic — no per-instance tables. Every
+%  case calls the same @wam_cds2_run helper. TablesIR is always ''.
+build_cds2_instance_switch(Entries, ImplBody, '') :-
+    build_cds2_instance_parts(Entries, 0, SwitchCases, CaseBodies),
+    atomic_list_concat(SwitchCases, '\n', SwitchCasesStr),
+    atomic_list_concat(CaseBodies, '\n\n', CaseBodiesStr),
+    format(atom(ImplBody),
+'define i1 @wam_cds2_kernel_impl(%WamState* %vm, i32 %instance) {
+entry:
+  switch i32 %instance, label %cds_bail [
+~w
+  ]
+
+~w
+
+cds_bail:
+  ret i1 false
+}',
+        [SwitchCasesStr, CaseBodiesStr]).
+
+build_cds2_instance_parts([], _, [], []).
+build_cds2_instance_parts([_PredArity-_Config | Rest], Index,
+        [SwitchCase|RestCases], [Body|RestBodies]) :-
+    format(atom(SwitchCase), '    i32 ~w, label %cds_inst_~w', [Index, Index]),
+    format(atom(Body),
+'cds_inst_~w:
+  %cds_r_~w = call i1 @wam_cds2_run(%WamState* %vm)
+  ret i1 %cds_r_~w',
+        [Index, Index, Index]),
+    NextIndex is Index + 1,
+    build_cds2_instance_parts(Rest, NextIndex, RestCases, RestBodies).
+
+%% replace_cds2_weak_default(+StateFuncsRaw, +NewBody, -StateFuncs).
+replace_cds2_weak_default(StateFuncsRaw, NewBody, StateFuncs) :-
+    Old = 'define weak i1 @wam_cds2_kernel_impl(%WamState* %vm, i32 %instance) {\n  ret i1 false\n}',
+    ( string_replace(StateFuncsRaw, Old, NewBody, StateFuncs0)
+    -> StateFuncs = StateFuncs0
+    ;  format(user_error,
+        'WARNING: could not find cds2 weak-default in state template; leaving unchanged~n', []),
+       StateFuncs = StateFuncsRaw
+    ).
 
 %% build_tc2_instance_switch(+Entries, -ImplBody, -TablesIR).
 %

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -1345,6 +1345,33 @@ wsp_bail:
   ret i1 false
 }
 
+; === M5.13: countdown_sum2 common runner helper ===
+; Pure arithmetic: reads A1 as an integer N, computes S = N*(N+1)/2,
+; writes A2 as integer S. No tables needed — the same computation
+; works for every instance.
+define i1 @wam_cds2_run(%WamState* %vm) {
+entry:
+  %n_tag = call i32 @wam_get_reg_tag(%WamState* %vm, i32 0)
+  %n_is_int = icmp eq i32 %n_tag, 1
+  br i1 %n_is_int, label %compute, label %cds_bail
+
+compute:
+  %n = call i64 @wam_get_reg_payload(%WamState* %vm, i32 0)
+  %n_neg = icmp slt i64 %n, 0
+  br i1 %n_neg, label %cds_bail, label %do_sum
+
+do_sum:
+  ; S = N * (N + 1) / 2
+  %n_plus_1 = add i64 %n, 1
+  %n_times = mul i64 %n, %n_plus_1
+  %s = sdiv i64 %n_times, 2
+  call void @wam_set_reg_int(%WamState* %vm, i32 1, i64 %s)
+  ret i1 true
+
+cds_bail:
+  ret i1 false
+}
+
 ; === M5.12: tc2 common runner helper ===
 ; Boolean reachability: is there any path from start to target in the
 ; %AtomFactPair graph? Calls @wam_bfs_atom_distance and discards the
@@ -1483,6 +1510,10 @@ as_bail:
 ; LLVM 21 disallows two definitions of the same function in one
 ; module, so the compile path picks one or the other (weak default
 ; or concrete substituted body) at template-rendering time.
+define weak i1 @wam_cds2_kernel_impl(%WamState* %vm, i32 %instance) {
+  ret i1 false
+}
+
 define weak i1 @wam_tc2_kernel_impl(%WamState* %vm, i32 %instance) {
   ret i1 false
 }
@@ -1516,8 +1547,8 @@ stub_category_ancestor:
   ret i1 false
 
 stub_countdown_sum2:
-  ; M5: countdown_sum(N, Sum)
-  ret i1 false
+  %cds_r = call i1 @wam_cds2_kernel_impl(%WamState* %vm, i32 %instance)
+  ret i1 %cds_r
 
 stub_list_suffix2:
   ; M5: list_suffix(List, Suffix)

--- a/tests/core/test_wam_llvm_countdown_sum_execution.pl
+++ b/tests/core/test_wam_llvm_countdown_sum_execution.pl
@@ -1,0 +1,164 @@
+:- encoding(utf8).
+% test_wam_llvm_countdown_sum_execution.pl
+% End-to-end execution test for countdown_sum2 (deterministic
+% arithmetic recurrence). The kernel computes S = N*(N+1)/2 via
+% closed-form arithmetic, then writes the result to A2.
+%
+% Tests:
+%   1. sum(10) = 55
+%   2. sum(0)  = 0
+%   3. sum(1)  = 1
+%   4. Auto-detect matches the countdown_sum clause shape.
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3,
+     llvm_foreign_kernel_spec/3,
+     clear_llvm_foreign_kernel_specs/0]).
+:- use_module(library(process)).
+:- use_module(library(readutil)).
+:- use_module(library(pcre)).
+
+% A predicate matching the countdown_sum2 clause shape.
+:- dynamic my_sum/2.
+my_sum(0, 0).
+my_sum(N, Sum) :-
+    N > 0,
+    N1 is N - 1,
+    my_sum(N1, PrevSum),
+    Sum is PrevSum + N.
+
+host_target_triple(Triple) :-
+    ( catch(
+        ( process_create(path(clang), ['-print-target-triple'],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, Raw), close(Out),
+          process_wait(PID, exit(0))
+        ), _, fail)
+    -> split_string(Raw, "", "\n\r\t ", [S]), atom_string(Triple, S)
+    ;  Triple = 'x86_64-pc-linux-gnu'
+    ).
+
+extract_instr_count(Src, P, C) :-
+    format(atom(Pat), "@~w_code = private constant \\[(?<n>\\d+) x %Instruction\\]", [P]),
+    re_matchsub(Pat, Src, M, []), get_dict(n, M, NS), number_string(C, NS).
+extract_label_count(Src, P, C) :-
+    format(atom(Pat), "@~w_labels = private constant \\[(?<n>\\d+) x i32\\]", [P]),
+    re_matchsub(Pat, Src, M, []), get_dict(n, M, NS), number_string(C, NS).
+
+run_sum_case(Label, N, Expected) :-
+    format('  testing ~w: my_sum(~w, S) expected ~w~n', [Label, N, Expected]),
+    clear_llvm_foreign_kernel_specs,
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    host_target_triple(Triple),
+    write_wam_llvm_project(
+        [user:my_sum/2],
+        [ module_name('cds2_exec'),
+          target_triple(Triple),
+          target_datalayout(''),
+          foreign_lowering(true)
+        ],
+        LLPath),
+    read_file_to_string(LLPath, Src, []),
+    extract_instr_count(Src, my_sum, IC),
+    extract_label_count(Src, my_sum, LC),
+    % A1 = N (integer, tag=1), A2 = result slot (unbound, tag=6).
+    format(atom(DriverIR),
+'define i32 @main() {
+entry:
+  %a1_0 = insertvalue %Value undef, i32 1, 0
+  %a1 = insertvalue %Value %a1_0, i64 ~w, 1
+  %a2_0 = insertvalue %Value undef, i32 6, 0
+  %a2 = insertvalue %Value %a2_0, i64 0, 1
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @my_sum_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @my_sum_labels, i32 0, i32 0),
+      i32 0)
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %a1)
+  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %a2)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %hit, label %miss
+hit:
+  %sum = call i64 @wam_get_reg_payload(%WamState* %vm, i32 1)
+  %sum32 = trunc i64 %sum to i32
+  ret i32 %sum32
+miss:
+  ret i32 255
+}
+',
+        [N, IC, IC, IC, LC, LC]),
+    setup_call_cleanup(
+        open(LLPath, append, Out),
+        ( write(Out, '\n'), write(Out, DriverIR) ),
+        close(Out)),
+    atom_concat(LLPath, '.o', OPath),
+    atom_concat(LLPath, '.out', BinPath),
+    format(atom(LlcCmd),
+        'llc -filetype=obj -relocation-model=pic ~w -o ~w 2>~w.llc.err',
+        [LLPath, OPath, LLPath]),
+    shell(LlcCmd, LlcExit),
+    ( LlcExit =\= 0
+    -> format('    FAIL: llc exit=~w~n', [LlcExit]), ExitCode = -1
+    ;  format(atom(ClangCmd), 'clang ~w -o ~w 2>~w.clang.err',
+           [OPath, BinPath, LLPath]),
+       shell(ClangCmd, ClangExit),
+       ( ClangExit =\= 0
+       -> format('    FAIL: clang exit=~w~n', [ClangExit]), ExitCode = -1
+       ;  shell(BinPath, ExitCode)
+       )
+    ),
+    ( ExitCode =:= Expected
+    -> format('    PASS: ~w returned ~w~n', [Label, ExitCode])
+    ;  format('    FAIL: ~w returned ~w (expected ~w)~n', [Label, ExitCode, Expected])
+    ),
+    catch(delete_file(LLPath), _, true),
+    catch(delete_file(OPath), _, true),
+    catch(delete_file(BinPath), _, true),
+    clear_llvm_foreign_kernel_specs,
+    assertion(ExitCode =:= Expected).
+
+test_autodetect :-
+    format('--- countdown_sum2 auto-detect ---~n'),
+    clear_llvm_foreign_kernel_specs,
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    host_target_triple(Triple),
+    write_wam_llvm_project(
+        [user:my_sum/2],
+        [ module_name('cds2_autodetect'),
+          target_triple(Triple),
+          target_datalayout(''),
+          foreign_lowering(true)
+        ],
+        LLPath),
+    ( llvm_foreign_kernel_spec(my_sum/2, countdown_sum2, _)
+    -> format('  PASS: auto-detect registered my_sum/2 as countdown_sum2~n')
+    ;  format('  FAIL: auto-detect did not match my_sum/2~n'),
+       throw(autodetect_failed)
+    ),
+    catch(delete_file(LLPath), _, true),
+    clear_llvm_foreign_kernel_specs.
+
+test_cds2_executes :-
+    format('--- countdown_sum2 execution ---~n'),
+    ( process_which('clang'), process_which('llc')
+    -> run_sum_case('sum(10)', 10, 55),
+       run_sum_case('sum(0)',   0,  0),
+       run_sum_case('sum(1)',   1,  1)
+    ;  format('  SKIP: clang or llc not found~n')
+    ).
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _), close(Out),
+          process_wait(PID, exit(0))
+        ), _, fail).
+
+test_all :-
+    catch(test_autodetect, E1,
+        format('  ERROR: ~w~n', [E1])),
+    catch(test_cds2_executes, E2,
+        format('  ERROR: ~w~n', [E2])).
+
+:- initialization(test_all, main).


### PR DESCRIPTION
## Summary

Fifth kernel wired end-to-end in the WAM LLVM target. `countdown_sum2` is a deterministic arithmetic recurrence — the first non-graph kernel in the series. Unlike the graph algorithms (td3, tc2, wsp3, astar4), this is pure computation with no tables: reads A1 as integer N, writes A2 = N*(N+1)/2.

This is the last of the seven Rust kernel kinds that can be ported without multi-result dispatch infrastructure. The commit documents why the remaining two (`list_suffix2`, `category_ancestor`) are blocked and what infrastructure they need.

## The Kernel

### What it does

Triangular sum: `sum(N) = 0 + 1 + 2 + ... + N = N*(N+1)/2`.

Register convention: A1 = N (integer, tag=1), A2 = result (integer). Returns `true` on success, `false` if A1 is not a non-negative integer.

### Clause shape (auto-detect)

```prolog
my_sum(0, 0).
my_sum(N, Sum) :-
    N > 0,
    N1 is N - 1,
    my_sum(N1, PrevSum),
    Sum is PrevSum + N.
```

Ported from `rust_target.pl:3902`. The Prolog source defines the recurrence recursively, but the LLVM kernel replaces it with the closed-form `N*(N+1)/2` at native speed.

### Implementation

**`@wam_cds2_run(%WamState*)`** — permanent runtime helper in `state.ll.mustache`:
1. Reads A1 tag (must be 1 = Integer).
2. Reads A1 payload as `i64 N`.
3. Checks `N >= 0` (negative → bail with `false`).
4. Computes `S = N * (N + 1) / 2` via `mul` + `sdiv`.
5. Writes A2 via `@wam_set_reg_int`.

No tables, no malloc, no cleanup. The simplest kernel body in the series.

### Instance dispatch

Every `countdown_sum2` instance calls the same `@wam_cds2_run` — the computation is stateless. The per-instance switch still exists (for pattern consistency with the other kernel kinds and to support the multi-instance dispatch mechanism) but every case body is identical: `call i1 @wam_cds2_run(%vm)`.

## Execution Test

**File:** `tests/core/test_wam_llvm_countdown_sum_execution.pl` — 4 assertions.

| Case | Input | Expected | What it tests |
|---|---|---|---|
| Auto-detect | `my_sum/2` clauses | registered as `countdown_sum2` | Clause-shape matcher |
| `sum(10)` | N=10 | 55 | Core arithmetic |
| `sum(0)` | N=0 | 0 | Base case / zero handling |
| `sum(1)` | N=1 | 1 | Minimal non-zero case |

The test uses `foreign_lowering(true)` (auto-detect path) to verify the clause-shape matcher recognizes the recurrence pattern and registers it as `countdown_sum2` without explicit annotation.

## The Remaining Two Kernels

### Why they're blocked

Both `list_suffix2` and `category_ancestor` are **stream** (non-deterministic) kernels in the Rust target. They yield multiple results via backtracking — `list_suffix2` enumerates all suffixes of a list, `category_ancestor` enumerates all ancestors within a depth bound.

Our foreign-kernel infrastructure returns a single `i1` from `@wam_execute_foreign_predicate`. There's no mechanism to:
- Push a choice point containing a result iterator
- Yield one result per backtracking attempt
- Resume the kernel where it left off on retry

The Rust target handles this via `finish_foreign_results` which pushes a choice point with a pre-computed result vector and iterates through it on backtracking. The LLVM target would need an analogous mechanism.

### What's needed

**Multi-result foreign dispatch** — a new infrastructure project (not kernel-specific):
1. A `ForeignResultIterator` struct stored in a choice point, holding a pointer to a result array and a current-index cursor.
2. On first call: the kernel computes all results, packs them into the iterator, pushes a choice point, and yields the first result.
3. On backtracking: the run loop detects the foreign-result choice point, advances the cursor, yields the next result (or fails if exhausted).

**For `list_suffix2` specifically**: also needs Prolog list structural operations in LLVM IR — head/tail decomposition on the `%Value` tagged union (tag=4 for List). The LLVM runtime currently doesn't have list-manipulation primitives.

**For `category_ancestor` specifically**: also needs depth-bounded BFS with a `max_depth` config parameter and negation checks (`\+ member(X, Visited)`). The BFS helper already tracks visited internally, but the depth bound and the negation pattern are new.

Both blockers are substantial but well-defined. Multi-result dispatch is the larger of the two and would unblock both kernels (plus make `transitive_closure2` and `transitive_distance3` work in their full Rust-compatible stream mode, which the current LLVM versions simplify to deterministic single-result).

## Kernel Parity Summary

| Rust kernel kind | LLVM status | Result mode | Blocker |
|---|---|---|---|
| `transitive_closure2` | **wired** (M5.12) | deterministic (simplified) | — |
| `transitive_distance3` | **wired** (M5.6) | deterministic (simplified) | — |
| `weighted_shortest_path3` | **wired** (M5.9) | deterministic | — |
| `astar_shortest_path4` | **wired** (M5.10) | deterministic | — |
| `countdown_sum2` | **wired** (this PR) | deterministic | — |
| `list_suffix2` | deferred | stream | multi-result dispatch + list ops |
| `category_ancestor` | deferred | stream | multi-result dispatch + depth bound |

Five of seven ported. The two remaining both need the same infrastructure investment (multi-result foreign dispatch), making that the natural next project if full parity is desired.

## Test Coverage

| Suite | Assertions | Scope |
|---|---|---|
| `test_wam_llvm_switch.pl` (M1) | 7 | regression |
| `test_wam_llvm_aggregate.pl` (M2) | 5 | regression |
| `test_wam_llvm_foreign_dispatch.pl` (M3) | 11 | regression |
| `test_wam_llvm_fact_tables.pl` (M4) | 10 | regression |
| `test_wam_llvm_ffi_bridge.pl` (M5.1) | 7 | regression |
| `test_wam_llvm_bfs_atom.pl` (M5.2) | 3 | regression |
| `test_wam_llvm_dijkstra.pl` (M5.3) | 4 | regression |
| `test_wam_llvm_astar.pl` (M5.4) | 4 | regression |
| `test_wam_llvm_td3_wiring.pl` (M5.5) | 4 | regression |
| `test_wam_llvm_foreign_lowering_options.pl` (M5.6a) | 9 | regression |
| `test_wam_llvm_foreign_lowering_directive.pl` (M5.6b) | 6 | regression |
| `test_wam_llvm_foreign_lowering_autodetect.pl` (M5.6c) | 9 | regression |
| `test_wam_llvm_bfs_execution.pl` (M5.7) | 4 | regression |
| `test_wam_llvm_reach_execution.pl` (M5.7) | 5 | regression |
| `test_wam_llvm_multi_instance_execution.pl` (M5.8) | 4 | regression |
| `test_wam_llvm_dijkstra_execution.pl` (M5.9) | 4 | regression |
| `test_wam_llvm_astar_execution.pl` (M5.10) | 4 | regression |
| `test_wam_llvm_stress.pl` (M5.11) | 2 | regression |
| `test_wam_llvm_astar_heuristic.pl` (M5.11) | 3 | regression |
| `test_wam_llvm_tc2_execution.pl` (M5.12) | 3 | regression |
| `test_wam_llvm_astar_runtime_heuristic.pl` (M5.12) | 3 | regression |
| `test_wam_llvm_countdown_sum_execution.pl` (M5.13) | 4 | **new** |
| **Total** | **115** | |

## Files Changed

- `templates/targets/llvm_wam/state.ll.mustache` — `@wam_cds2_run`, `@wam_cds2_kernel_impl` weak default, `stub_countdown_sum2` delegation.
- `src/unifyweaver/targets/wam_llvm_target.pl` — cds2 substitution pass, `build_cds2_instance_switch/3` + parts, `replace_cds2_weak_default/3`, auto-detect registration + matcher.
- `tests/core/test_wam_llvm_countdown_sum_execution.pl` — new.

## Commits

- `57c502df` — feat(wam-llvm): countdown_sum2 kernel + document remaining blockers (M5.13)

## Full Series Summary

15 PRs shipped since M1. The WAM LLVM target now supports:

- 31 WAM instruction cases (including switch_on_constant, aggregate frames, call_foreign)
- 5 foreign kernel kinds wired end-to-end with execution testing
- 4 graph algorithms (BFS, Dijkstra, A*, transitive closure) + 1 arithmetic recurrence
- 3 user-facing foreign-lowering entry paths (directive, options, auto-detect)
- Multi-instance dispatch (per-predicate edge tables)
- Compile-time AND runtime A* heuristic support
- 100-node stress tests
- 115 assertions across 22 test suites

## Test Plan

- [x] All 21 prior suites green (111 assertions).
- [x] Auto-detect matches `my_sum/2` as `countdown_sum2`.
- [x] `sum(10) = 55`, `sum(0) = 0`, `sum(1) = 1` — all execute correctly.
- [x] All generated modules compile through `llc → clang` and produce runnable binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
