### PR TITLE
fix(wam-haskell-lowered): dispatch priority + single-clause gate

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
@@ -59,6 +59,13 @@ tokenize(Line, Term) :-
 
 wam_haskell_lowerable(_PI, WamCode, _Reason) :-
     parse_wam_text(WamCode, PCInstrs, _),
+    % Phase 4 restriction: only single-clause predicates (no try_me_else)
+    % are lowerable. Multi-clause lowering requires resolving the dispatch
+    % conflict between executeForeign (which returns Nothing for "no
+    % solutions") and the lowered function (which would fruitlessly explore
+    % the graph via WAM dispatch). See fix/wam-haskell-lowered-backtrack.
+    PCInstrs = [pc(_, FirstInstr)|_],
+    FirstInstr \= try_me_else(_),
     clause1_instrs(PCInstrs, C1),
     forall(member(I, C1), supported(I)).
 
@@ -135,7 +142,8 @@ emit_func(FN, PCInstrs, LabelMap) :-
         format("        , wsCPsLen = wsCPsLen s_init + 1 }~n"),
         format("  in case clause1 s_cp of~n"),
         format("       Just result -> Just result~n"),
-        format("       Nothing -> backtrack s_cp >>= \\s_bt -> run ctx s_bt~n"),
+        format("       Nothing -> backtrack s_cp >>= \\s_bt -> run ctx (s_bt { wsPC = wsPC s_bt + 1 })~n"),
+        format("       -- ^ skip TrustMe at cpNextPC: backtrack already popped the CP~n"),
         format("  where~n"),
         format("    clause1 s_c1 = do~n"),
         take_to_proceed_pc(BodyPCs, Clause1PCs),

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -795,12 +795,18 @@ step !ctx s (SetConstant c) =
 step !ctx s (CallResolved pc _arity) =
   Just (s { wsPC = pc, wsCP = wsPC s + 1 })
 
+-- Call dispatch priority: hand-written FFI (executeForeign) takes precedence
+-- over automated lowering (wcLoweredPredicates). This is critical because
+-- FFI handlers like nativeCategoryAncestor do the full depth-bounded search
+-- natively, while the lowered function only handles clause 1 and relies on
+-- the interpreter for clause 2+ recursion (which is exponentially slower
+-- for deep search trees).
 step !ctx s (Call pred _arity) =
   let sc = s { wsCP = wsPC s + 1 }
-  in case Map.lookup pred (wcLoweredPredicates ctx) of
-    Just fn -> fn ctx sc
-    Nothing -> case executeForeign ctx pred sc of
-      Just sr -> Just sr
+  in case executeForeign ctx pred sc of
+    Just sr -> Just sr
+    Nothing -> case Map.lookup pred (wcLoweredPredicates ctx) of
+      Just fn -> fn ctx sc
       Nothing -> case callIndexedFact2 ctx pred sc of
         Just sr -> Just sr
         Nothing -> case Map.lookup pred (wcLabels ctx) of
@@ -1112,15 +1118,16 @@ run !ctx !s
 
 -- | Dispatch a Call to another predicate, trying all resolution paths.
 -- Used by lowered predicate functions for inter-predicate calls.
--- Mirrors the step (Call pred _arity) dispatch chain but as a callable
--- helper: lowered → foreign → indexed-facts → label-lookup+run.
+-- Priority: FFI (executeForeign) > lowered > indexed-facts > labels.
+-- FFI takes precedence because hand-written native handlers (e.g.
+-- nativeCategoryAncestor) handle full recursive search natively.
 {-# NOINLINE dispatchCall #-}
 dispatchCall :: WamContext -> String -> WamState -> Maybe WamState
 dispatchCall !ctx pred !sc =
-  case Map.lookup pred (wcLoweredPredicates ctx) of
-    Just fn -> fn ctx sc
-    Nothing -> case executeForeign ctx pred sc of
-      Just sr -> Just sr
+  case executeForeign ctx pred sc of
+    Just sr -> Just sr
+    Nothing -> case Map.lookup pred (wcLoweredPredicates ctx) of
+      Just fn -> fn ctx sc
       Nothing -> case callIndexedFact2 ctx pred sc of
         Just sr -> Just sr
         Nothing -> case Map.lookup pred (wcLabels ctx) of

--- a/tests/test_wam_haskell_lowered_phase1.pl
+++ b/tests/test_wam_haskell_lowered_phase1.pl
@@ -109,12 +109,11 @@ test_mixed_non_list_rejected :-
 
 test_lowerable_rejects_unsupported :-
     Test = 'WAM-Haskell-Lowered Phase 1: wam_haskell_lowerable/3 rejects unsupported instructions',
-    % Phase 3 whitelist only covers get_constant+proceed. A WAM text
-    % containing a Call instruction must fail lowerability.
-    WamText = "foo/1:\n    call bar/0, 0\n    proceed\n",
+    % begin_aggregate is explicitly deferred — not in the Phase 4 whitelist.
+    WamText = "foo/1:\n    begin_aggregate sum, A1, A2\n    proceed\n",
     (   \+ wam_haskell_lowerable(foo/1, WamText, _Reason)
     ->  pass(Test)
-    ;   fail_test(Test, 'unsupported Call instruction was accepted')
+    ;   fail_test(Test, 'unsupported begin_aggregate was accepted')
     ).
 
 %% ---------------------------------------------------------------------

--- a/tests/test_wam_haskell_lowered_phase3.pl
+++ b/tests/test_wam_haskell_lowered_phase3.pl
@@ -75,7 +75,7 @@ test_lower_predicate_produces_function :-
     (   PredName == 'phase3_constant/1',
         FuncName == lowered_phase3_constant_1,
         sub_string(HsCode, _, _, _, "lowered_phase3_constant_1 :: WamContext -> WamState -> Maybe WamState"),
-        sub_string(HsCode, _, _, _, "v == (Integer 42)")
+        sub_string(HsCode, _, _, _, "GetConstant (Integer 42)")
     ->  pass(Test)
     ;   fail_test(Test, ['unexpected emitter output; PredName=', PredName, ' FuncName=', FuncName])
     ).
@@ -135,7 +135,7 @@ test_lowered_hs_has_function_definition :-
     atom_concat(Dir, '/src/Lowered.hs', Path),
     read_file_to_string(Path, S),
     (   sub_string(S, _, _, _, "lowered_phase3_constant_1 :: WamContext -> WamState -> Maybe WamState"),
-        sub_string(S, _, _, _, "v == (Integer 42)")
+        sub_string(S, _, _, _, "GetConstant (Integer 42)")
     ->  pass(Test)
     ;   fail_test(Test, 'Lowered.hs missing expected function body')
     ).


### PR DESCRIPTION
  ## Summary

  - Fixes the non-termination bug reported in #1344 where `emit_mode(mixed([category_ancestor/4]))` caused the benchmark to
  hang.
  - Changes the `Call` dispatch priority so hand-written FFI handlers (`executeForeign`) run **before** automated lowered
  functions (`wcLoweredPredicates`).
  - Restricts lowering to **single-clause predicates only** until the multi-clause dispatch semantic is resolved.
  - No behavior change for `emit_mode(interpreter)` (the default).

  ## Root cause

  Two interacting issues:

  1. **Wrong dispatch priority.** `wcLoweredPredicates` was checked before `executeForeign` in step's `Call` chain. When
  `executeForeign`'s FFI handler (`nativeCategoryAncestor`) returned `Nothing` for "no paths found," the dispatch fell
  through to the lowered function. The lowered function only handled clause 1 (base case), then backtracked to clause 2 via
  the interpreter, which explored the category graph clause-by-clause — exponentially slower than the FFI's native
  depth-bounded recursion.

  2. **`executeForeign` conflates two failure modes.** It returns `Nothing` for both "no handler for this predicate" and
  "handler exists but found no solutions." The dispatch chain can't distinguish these, so after the FFI correctly reports "no
   paths from X to Physics," the lowered function redundantly searches the same graph.

  ## Fix

  **Dispatch priority reversed** in both `step`'s `Call` case and the `dispatchCall` helper:

  ```
  Before: wcLoweredPredicates → executeForeign → callIndexedFact2 → wcLabels
  After:  executeForeign → wcLoweredPredicates → callIndexedFact2 → wcLabels
  ```

  Hand-written FFI handlers always take priority over automated lowering. This is correct because FFI handlers (like
  `nativeCategoryAncestor`) handle full recursive search natively — they're strictly better than clause-by-clause WAM
  dispatch for predicates they cover.

  **Single-clause restriction** added to `wam_haskell_lowerable/3`: predicates with `try_me_else` (multi-clause) are
  rejected. This sidesteps the dispatch semantic gap entirely for now. Single-clause predicates (`max_depth/1`,
  `dimension_n/1`) lower correctly and show ~9% query improvement on the 10k benchmark.

  Multi-clause lowering is deferred as future work requiring a richer `executeForeign` return type (e.g., a three-valued
  `Just state | NoHandler | NoSolutions`) so the dispatch chain can distinguish "no FFI handler" from "FFI handler found no
  solutions."

  ## Benchmark (effective_distance 10k, 5 runs each, median)

  | Mode | query_ms | total_ms |
  |---|---|---|
  | Interpreter-only (baseline) | 12751 | 28642 |
  | Lowered (max_depth + dimension_n) | 11638 | 26388 |
  | **Delta** | **-8.7%** | **-7.9%** |

  Gains are modest because only two rarely-called single-clause predicates are lowered. The hot predicate
  (`category_ancestor/4`) uses the FFI in both modes. Output is byte-identical between modes (verified via diff, 5193 rows,
  Temperature=2.840088).

  ## Test plan

  - [x] `effective_distance` 10k benchmark: byte-identical to Prolog reference in both modes
  - [x] Small dataset (`/tmp/wam_spike/small`): completes in <1s (was non-terminating before fix)
  - [x] Phase 1 tests: 11/11 pass (updated `test_lowerable_rejects_unsupported` to use `begin_aggregate` instead of `call`,
  since `call` is now whitelisted)
  - [x] Phase 3 tests: 8/8 pass (updated assertions for Phase 4 do-notation emission shape)
  - [x] Phase 5 upstream codegen tests: 6/6 pass
  - [x] No regression on `emit_mode(interpreter)` path

  ## Future work

  - **Multi-clause lowering:** Requires `executeForeign` to return a richer result type distinguishing "no handler" from "no
  solutions." Tracked as a design problem, not a quick fix.
  - **Rust kernel lowering patterns:** The Rust WAM target uses specialized instructions (`BaseCategoryAncestor`,
  `RecurseCategoryAncestorPc`) that bypass the general WAM for hot predicates. Similar patterns could inform how the Haskell
  emitter handles multi-clause predicates without conflicting with the FFI.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)