### PR TITLE
feat(csharp-query): trace weighted min frontier metrics

### DIFF
--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -20,6 +20,9 @@ Current status:
 - negative additive steps and non-additive recurrence expressions are now
   covered by explicit fallback-shape survey tests and runtime strategy
   labeling
+- the exact weighted `Min` frontier fallback now records lightweight
+  frontier metrics for candidate counts, dominance checks, subset checks,
+  and retained frontier bucket sizes
 - on the current positive-additive benchmark shape, the measured selector
   rejects SCC condensation because the layered path is still cheaper after
   SCC build/probe overhead
@@ -227,11 +230,25 @@ The fallback survey step now covers two representative cases:
    data but is not additive and therefore still requires exact path-state
    evaluation
 
+The frontier metric step now records:
+
+1. `min_frontier_candidate_count`
+2. `min_frontier_dominance_check_count`
+3. `min_frontier_dominance_candidate_check_count`
+4. `min_frontier_subset_check_count`
+5. `min_frontier_dominated_state_count`
+6. `min_frontier_recorded_state_count`
+7. `min_frontier_removed_state_count`
+8. `min_frontier_bucket_count`
+9. `min_frontier_bucket_state_count`
+10. `min_frontier_bucket_max_size`
+11. `min_frontier_bucket_avg_size`
+
 The next coding step should be:
 
-1. add lightweight frontier-fallback instrumentation for candidate count,
-   dominance checks, subset checks, and frontier bucket sizes
-2. run it on the negative-additive and multiplicative survey fixtures plus
-   cyclic benchmark data
+1. run the frontier metrics on cyclic benchmark-scale weighted `Min`
+   fallback cases
+2. compare whether the hot path is dominated by candidate growth, bucket
+   fanout, or exact subset checks
 3. decide whether the next optimization should be exact state hashing or a
    narrower multiplicative-to-additive transform

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_SPEC.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_SPEC.md
@@ -157,6 +157,10 @@ At minimum:
 - number of exact local states explored
 - number of outer DAG states explored
 - SCC condensation, SCC probe, and SCC solve phase timings
+- exact frontier fallback candidate count
+- exact frontier fallback dominance and subset-check counts
+- exact frontier fallback bucket count, total retained states, maximum
+  bucket size, and average bucket size
 - final output row count
 - total runtime
 

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -11280,6 +11280,29 @@ namespace UnifyWeaver.QueryRuntime
             trace?.AddMetric(node, "scc_output_rows", outputRows);
         }
 
+        private static void RecordPathAwareMinFrontierMetrics(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            PathAwareMinFrontierMetrics metrics)
+        {
+            trace?.AddMetric(node, "min_frontier_candidate_count", metrics.CandidateCount);
+            trace?.AddMetric(node, "min_frontier_dominance_check_count", metrics.DominanceCheckCount);
+            trace?.AddMetric(node, "min_frontier_dominance_candidate_check_count", metrics.DominanceCandidateCheckCount);
+            trace?.AddMetric(node, "min_frontier_subset_check_count", metrics.SubsetCheckCount);
+            trace?.AddMetric(node, "min_frontier_dominated_state_count", metrics.DominatedStateCount);
+            trace?.AddMetric(node, "min_frontier_recorded_state_count", metrics.RecordedStateCount);
+            trace?.AddMetric(node, "min_frontier_removed_state_count", metrics.RemovedStateCount);
+            trace?.AddMetric(node, "min_frontier_bucket_count", metrics.BucketCount);
+            trace?.AddMetric(node, "min_frontier_bucket_state_count", metrics.BucketStateCount);
+            trace?.RecordMetric(node, "min_frontier_bucket_max_size", metrics.MaxBucketSize);
+            trace?.RecordMetric(
+                node,
+                "min_frontier_bucket_avg_size",
+                metrics.BucketCount == 0
+                    ? 0d
+                    : metrics.BucketStateCount / (double)metrics.BucketCount);
+        }
+
         private IReadOnlyDictionary<object, Dictionary<object, int>> ExecuteSeedGroupedPathAwareDepthMinFallback(
             SeedGroupedPathAwareDepthMinNode closure,
             IReadOnlyList<object?> orderedUniqueSeeds,
@@ -12497,6 +12520,9 @@ namespace UnifyWeaver.QueryRuntime
                 long localStates = 0;
                 long outerDagStates = 0;
                 long queuePops = 0;
+                var frontierMetrics = useAdditiveMinFastPath
+                    ? null
+                    : new PathAwareMinFrontierMetrics();
                 void BuildAccumulationRows()
                 {
                     foreach (var seed in edgeState.Seeds)
@@ -12514,7 +12540,7 @@ namespace UnifyWeaver.QueryRuntime
                         }
                         else
                         {
-                            AppendPathAwareAccumulationRowsForSeed(seed, succIndex, auxIndex, closure.BaseExpression, closure.RecursiveExpression, totalRows, closure.AccumulatorMode, closure.MaxDepth);
+                            AppendPathAwareAccumulationRowsForSeed(seed, succIndex, auxIndex, closure.BaseExpression, closure.RecursiveExpression, totalRows, closure.AccumulatorMode, closure.MaxDepth, frontierMetrics);
                         }
                     }
                 }
@@ -12539,6 +12565,10 @@ namespace UnifyWeaver.QueryRuntime
                         closure,
                         new SccCondensedWeightedMinStats(localStates, outerDagStates, queuePops),
                         totalRows.Count);
+                }
+                else if (!useAdditiveMinFastPath && closure.AccumulatorMode == TableMode.Min && frontierMetrics is not null)
+                {
+                    RecordPathAwareMinFrontierMetrics(trace, closure, frontierMetrics);
                 }
 
                 return totalRows;
@@ -12662,6 +12692,9 @@ namespace UnifyWeaver.QueryRuntime
                 long localStates = 0;
                 long outerDagStates = 0;
                 long queuePops = 0;
+                var frontierMetrics = useAdditiveMinFastPath
+                    ? null
+                    : new PathAwareMinFrontierMetrics();
                 void BuildAccumulationRows()
                 {
                     foreach (var seed in seeds)
@@ -12679,7 +12712,7 @@ namespace UnifyWeaver.QueryRuntime
                         }
                         else
                         {
-                            AppendPathAwareAccumulationRowsForSeed(seed, succIndex, auxIndex, closure.BaseExpression, closure.RecursiveExpression, totalRows, closure.AccumulatorMode, closure.MaxDepth);
+                            AppendPathAwareAccumulationRowsForSeed(seed, succIndex, auxIndex, closure.BaseExpression, closure.RecursiveExpression, totalRows, closure.AccumulatorMode, closure.MaxDepth, frontierMetrics);
                         }
                     }
                 }
@@ -12704,6 +12737,10 @@ namespace UnifyWeaver.QueryRuntime
                         closure,
                         new SccCondensedWeightedMinStats(localStates, outerDagStates, queuePops),
                         totalRows.Count);
+                }
+                else if (!useAdditiveMinFastPath && closure.AccumulatorMode == TableMode.Min && frontierMetrics is not null)
+                {
+                    RecordPathAwareMinFrontierMetrics(trace, closure, frontierMetrics);
                 }
 
                 return totalRows;
@@ -12982,7 +13019,8 @@ namespace UnifyWeaver.QueryRuntime
             ArithmeticExpression recursiveExpression,
             ICollection<object[]> output,
             TableMode accumulatorMode,
-            int maxDepth = 0)
+            int maxDepth = 0,
+            PathAwareMinFrontierMetrics? frontierMetrics = null)
         {
             var useMinPruning = accumulatorMode == TableMode.Min;
             var preserveAllPaths = !useMinPruning;
@@ -13016,8 +13054,9 @@ namespace UnifyWeaver.QueryRuntime
             while (stack.Count > 0)
             {
                 var (current, state, depth) = stack.Pop();
-                if (useMinPruning && current is not null && IsDominatedMinState(frontier!, current, state))
+                if (useMinPruning && current is not null && IsDominatedMinState(frontier!, current, state, frontierMetrics))
                 {
+                    frontierMetrics?.RecordDominatedState();
                     continue;
                 }
 
@@ -13066,12 +13105,14 @@ namespace UnifyWeaver.QueryRuntime
                         }
                         else
                         {
-                            if (IsDominatedMinState(frontier!, next, nextState))
+                            frontierMetrics?.RecordCandidate();
+                            if (IsDominatedMinState(frontier!, next, nextState, frontierMetrics))
                             {
+                                frontierMetrics?.RecordDominatedState();
                                 continue;
                             }
 
-                            RecordMinState(frontier!, next, nextState);
+                            RecordMinState(frontier!, next, nextState, frontierMetrics);
                             if (!bestKnown!.TryGetValue(next, out var bestAccumulator) ||
                                 CompareValues(nextAccumulator, bestAccumulator) < 0)
                             {
@@ -13086,6 +13127,7 @@ namespace UnifyWeaver.QueryRuntime
 
             if (!preserveAllPaths && bestKnown is not null)
             {
+                frontierMetrics?.RecordBucketSnapshot(frontier!);
                 var bestRows = bestKnown
                     .OrderBy(kvp => kvp.Key, Comparer<object?>.Create(CompareCacheSeedValues))
                     .ToList();
@@ -13100,8 +13142,10 @@ namespace UnifyWeaver.QueryRuntime
         private static bool IsDominatedMinState(
             IReadOnlyDictionary<object?, List<VisitedAccumulatorState>> frontier,
             object? node,
-            VisitedAccumulatorState state)
+            VisitedAccumulatorState state,
+            PathAwareMinFrontierMetrics? metrics = null)
         {
+            metrics?.RecordDominanceCheck();
             if (!frontier.TryGetValue(node, out var states))
             {
                 return false;
@@ -13109,6 +13153,7 @@ namespace UnifyWeaver.QueryRuntime
 
             foreach (var candidate in states)
             {
+                metrics?.RecordDominanceCandidateCheck();
                 var sameState = ReferenceEquals(candidate.Path, state.Path) && Equals(candidate.Accumulator, state.Accumulator);
                 if (sameState)
                 {
@@ -13126,6 +13171,7 @@ namespace UnifyWeaver.QueryRuntime
                 }
 
                 if (CompareValues(candidate.Accumulator, state.Accumulator) <= 0 &&
+                    (metrics?.RecordSubsetCheckAndReturnTrue() ?? true) &&
                     candidate.Path.IsSubsetOf(state.Path))
                 {
                     return true;
@@ -13138,7 +13184,8 @@ namespace UnifyWeaver.QueryRuntime
         private static void RecordMinState(
             IDictionary<object?, List<VisitedAccumulatorState>> frontier,
             object? node,
-            VisitedAccumulatorState state)
+            VisitedAccumulatorState state,
+            PathAwareMinFrontierMetrics? metrics = null)
         {
             if (!frontier.TryGetValue(node, out var states))
             {
@@ -13160,13 +13207,71 @@ namespace UnifyWeaver.QueryRuntime
                 }
 
                 if (CompareValues(state.Accumulator, existing.Accumulator) <= 0 &&
+                    (metrics?.RecordSubsetCheckAndReturnTrue() ?? true) &&
                     state.Path.IsSubsetOf(existing.Path))
                 {
                     states.RemoveAt(i);
+                    metrics?.RecordRemovedState();
                 }
             }
 
             states.Add(state);
+            metrics?.RecordRecordedState();
+        }
+
+        private sealed class PathAwareMinFrontierMetrics
+        {
+            public long CandidateCount { get; private set; }
+
+            public long DominanceCheckCount { get; private set; }
+
+            public long DominanceCandidateCheckCount { get; private set; }
+
+            public long SubsetCheckCount { get; private set; }
+
+            public long DominatedStateCount { get; private set; }
+
+            public long RecordedStateCount { get; private set; }
+
+            public long RemovedStateCount { get; private set; }
+
+            public long BucketCount { get; private set; }
+
+            public long BucketStateCount { get; private set; }
+
+            public long MaxBucketSize { get; private set; }
+
+            public void RecordCandidate() => CandidateCount++;
+
+            public void RecordDominanceCheck() => DominanceCheckCount++;
+
+            public void RecordDominanceCandidateCheck() => DominanceCandidateCheckCount++;
+
+            public bool RecordSubsetCheckAndReturnTrue()
+            {
+                SubsetCheckCount++;
+                return true;
+            }
+
+            public void RecordDominatedState() => DominatedStateCount++;
+
+            public void RecordRecordedState() => RecordedStateCount++;
+
+            public void RecordRemovedState() => RemovedStateCount++;
+
+            public void RecordBucketSnapshot(IReadOnlyDictionary<object?, List<VisitedAccumulatorState>> frontier)
+            {
+                BucketCount += frontier.Count;
+                foreach (var states in frontier.Values)
+                {
+                    var count = states.Count;
+                    BucketStateCount += count;
+                    if (count > MaxBucketSize)
+                    {
+                        MaxBucketSize = count;
+                    }
+                }
+            }
         }
 
         private sealed record VisitedAccumulatorState(

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -3966,16 +3966,24 @@ verify_path_aware_accumulation_negative_min_frontier_fallback_runtime :-
     sub_string(Source, _, _, _, 'TableMode.Min'),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
     Params = [[a]],
-    harness_source_with_strategy_flag_no_reuse(
+    weighted_min_frontier_metric_names(MetricNames),
+    weighted_min_frontier_positive_metric_names(PositiveMetricNames),
+    harness_source_with_strategy_and_metric_flags_no_reuse(
         ModuleClass,
         Params,
         'PathAwareAccumulationSeededMinFrontierFallback',
+        MetricNames,
+        PositiveMetricNames,
         HarnessSource),
+    weighted_min_frontier_metric_expectations(MetricRows),
+    append(['a,b,-1',
+            'a,c,-1',
+            'a,d,2',
+            'STRATEGY_USED:PathAwareAccumulationSeededMinFrontierFallback=true'],
+           MetricRows,
+           ExpectedRows),
     maybe_run_query_runtime_with_harness(Plan,
-        ['a,b,-1',
-         'a,c,-1',
-         'a,d,2',
-         'STRATEGY_USED:PathAwareAccumulationSeededMinFrontierFallback=true'],
+        ExpectedRows,
         Params,
         HarnessSource).
 
@@ -3995,18 +4003,64 @@ verify_path_aware_accumulation_product_min_frontier_fallback_runtime :-
     sub_string(Source, _, _, _, 'TableMode.Min'),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
     Params = [[a]],
-    harness_source_with_strategy_flag_no_reuse(
+    weighted_min_frontier_metric_names(MetricNames),
+    weighted_min_frontier_positive_metric_names(PositiveMetricNames),
+    harness_source_with_strategy_and_metric_flags_no_reuse(
         ModuleClass,
         Params,
         'PathAwareAccumulationSeededMinFrontierFallback',
+        MetricNames,
+        PositiveMetricNames,
         HarnessSource),
+    weighted_min_frontier_metric_expectations(MetricRows),
+    append(['a,b,2',
+            'a,c,2',
+            'a,d,6',
+            'STRATEGY_USED:PathAwareAccumulationSeededMinFrontierFallback=true'],
+           MetricRows,
+           ExpectedRows),
     maybe_run_query_runtime_with_harness(Plan,
-        ['a,b,2',
-         'a,c,2',
-         'a,d,6',
-         'STRATEGY_USED:PathAwareAccumulationSeededMinFrontierFallback=true'],
+        ExpectedRows,
         Params,
         HarnessSource).
+
+weighted_min_frontier_metric_names([
+    'min_frontier_candidate_count',
+    'min_frontier_dominance_check_count',
+    'min_frontier_dominance_candidate_check_count',
+    'min_frontier_subset_check_count',
+    'min_frontier_dominated_state_count',
+    'min_frontier_recorded_state_count',
+    'min_frontier_removed_state_count',
+    'min_frontier_bucket_count',
+    'min_frontier_bucket_state_count',
+    'min_frontier_bucket_max_size',
+    'min_frontier_bucket_avg_size'
+]).
+
+weighted_min_frontier_positive_metric_names([
+    'min_frontier_candidate_count',
+    'min_frontier_dominance_check_count',
+    'min_frontier_dominance_candidate_check_count',
+    'min_frontier_recorded_state_count',
+    'min_frontier_bucket_count',
+    'min_frontier_bucket_state_count',
+    'min_frontier_bucket_max_size',
+    'min_frontier_bucket_avg_size'
+]).
+
+weighted_min_frontier_metric_expectations(Rows) :-
+    weighted_min_frontier_metric_names(MetricNames),
+    weighted_min_frontier_positive_metric_names(PositiveMetricNames),
+    findall(Row,
+            (member(Metric, MetricNames),
+             format(atom(Row), 'METRIC_RECORDED:~w=true', [Metric])),
+            RecordedRows),
+    findall(Row,
+            (member(Metric, PositiveMetricNames),
+             format(atom(Row), 'METRIC_POSITIVE:~w=true', [Metric])),
+            PositiveRows),
+    append(RecordedRows, PositiveRows, Rows).
 
 verify_grouped_transitive_closure_plan :-
     csharp_query_target:build_query_plan(test_label_cat_reach/4, [target(csharp_query)], Plan),
@@ -7203,7 +7257,7 @@ var executor = new QueryExecutor(result.Provider, new QueryExecutorOptions(Reuse
 
      Console.WriteLine(string.Join(\",\", projected));
    }
- 
+
    var used = trace.SnapshotStrategies().Any(s => s.Strategy == \"~w\");
    Console.WriteLine(\"STRATEGY_USED:~w=\" + (used ? \"true\" : \"false\"));
    ', [ModuleClass, ParamDecl, ExecCall, Strategy, Strategy]).
@@ -7317,10 +7371,68 @@ var executor = new QueryExecutor(result.Provider, new QueryExecutorOptions(Reuse
 
      Console.WriteLine(string.Join(\",\", projected));
    }
- 
+
    var used = trace.SnapshotStrategies().Any(s => s.Strategy == \"~w\");
    Console.WriteLine(\"STRATEGY_USED:~w=\" + (used ? \"true\" : \"false\"));
    ', [ModuleClass, ParamDecl, ExecCall, Strategy, Strategy]).
+
+harness_source_with_strategy_and_metric_flags_no_reuse(ModuleClass, Params, Strategy, MetricNames, PositiveMetricNames, Source) :-
+    csharp_string_array_literal(MetricNames, MetricNamesLiteral),
+    csharp_string_array_literal(PositiveMetricNames, PositiveMetricNamesLiteral),
+    (   Params == []
+    ->  ParamDecl = 'var _planText = QueryPlanExplainer.Explain(result.Plan);\nvar trace = new QueryExecutionTrace();\n',
+        ExecCall = 'executor.Execute(result.Plan, null, trace)'
+    ;   csharp_params_literal(Params, ParamsLiteral),
+        format(atom(ParamDecl), 'var parameters = ~w;~nvar _planText = QueryPlanExplainer.Explain(result.Plan);~nvar trace = new QueryExecutionTrace();~n', [ParamsLiteral]),
+        ExecCall = 'executor.Execute(result.Plan, parameters, trace)'
+    ),
+    format(atom(Source),
+'using System;
+ using System.Linq;
+ using System.Globalization;
+ using UnifyWeaver.QueryRuntime;
+ using System.Text.Json;
+ using System.Text.Json.Nodes;
+
+var result = UnifyWeaver.Generated.~w.Build();
+var executor = new QueryExecutor(result.Provider, new QueryExecutorOptions(ReuseCaches: false));
+~wvar jsonOptions = new JsonSerializerOptions { WriteIndented = false };
+
+ string FormatValue(object? value) => value switch
+ {
+     JsonNode node => node.ToJsonString(jsonOptions),
+     JsonElement element => element.GetRawText(),
+      System.Collections.IEnumerable enumerable when value is not string => "[" + string.Join("|", enumerable.Cast<object?>().Select(FormatValue).OrderBy(s => s, StringComparer.Ordinal)) + "]",
+      IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+      _ => value?.ToString() ?? string.Empty
+  };
+ foreach (var row in ~w)
+ {
+    var projected = row.Take(result.Plan.Head.Arity)
+                       .Select(FormatValue)
+                       .ToArray();
+
+    if (projected.Length == 0)
+    {
+        continue;
+    }
+
+     Console.WriteLine(string.Join(\",\", projected));
+   }
+   var used = trace.SnapshotStrategies().Any(s => s.Strategy == \"~w\");
+   Console.WriteLine(\"STRATEGY_USED:~w=\" + (used ? \"true\" : \"false\"));
+   var metrics = trace.SnapshotMetrics().ToDictionary(m => m.Metric, m => m.Value, StringComparer.Ordinal);
+   foreach (var metricName in ~w)
+   {
+       var recorded = metrics.TryGetValue(metricName, out var metricValue);
+       Console.WriteLine(\"METRIC_RECORDED:\" + metricName + \"=\" + (recorded ? \"true\" : \"false\"));
+   }
+   foreach (var metricName in ~w)
+   {
+       metrics.TryGetValue(metricName, out var metricValue);
+       Console.WriteLine(\"METRIC_POSITIVE:\" + metricName + \"=\" + (metricValue > 0 ? \"true\" : \"false\"));
+   }
+   ', [ModuleClass, ParamDecl, ExecCall, Strategy, Strategy, MetricNamesLiteral, PositiveMetricNamesLiteral]).
 
 cache_query_executor_options(_Cache, BaseOptions, OptionsLiteral) :-
     format(atom(OptionsLiteral),


### PR DESCRIPTION
  ## Summary

  This PR adds lightweight runtime metrics for exact weighted `Min` frontier fallback execution in the C# query runtime.

  The existing positive and non-negative additive fast paths remain unchanged. When weighted `Min` cannot use those fast paths and
  falls back to exact path-state frontier evaluation, the runtime now records counters that make the fallback cost profile visible.

  ## Changes

  - Adds frontier fallback metrics for weighted `Min` path-aware accumulation:
    - `min_frontier_candidate_count`
    - `min_frontier_dominance_check_count`
    - `min_frontier_dominance_candidate_check_count`
    - `min_frontier_subset_check_count`
    - `min_frontier_dominated_state_count`
    - `min_frontier_recorded_state_count`
    - `min_frontier_removed_state_count`
    - `min_frontier_bucket_count`
    - `min_frontier_bucket_state_count`
    - `min_frontier_bucket_max_size`
    - `min_frontier_bucket_avg_size`
  - Extends the negative-additive and multiplicative weighted `Min` fallback survey tests to assert metrics are emitted.
  - Updates the SCC weighted-min plan/spec docs with the new metric set.
  - Sets up the next decision point: determine whether the next optimization should target exact state hashing or a narrower
  multiplicative transform.

  ## Testing

  - `swipl -q -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:configure_csharp_query_options,test_csharp_query_target:setup_test_data,test_csharp_query_target:verify_
  path_aware_accumulation_negative_min_frontier_fallback_runtime,test_csharp_query_target:verify_path_aware_accumulation_product_min
  _frontier_fallback_runtime,halt."`
  - `swipl -q -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:configure_csharp_query_options,test_csharp_query_target:setup_test_data,test_csharp_query_target:verify_
  path_aware_accumulation_min_mode_plan,test_csharp_query_target:verify_path_aware_accumulation_positive_guard_plan,test_csharp_quer
  y_target:verify_path_aware_accumulation_positive_metadata_plan,test_csharp_query_target:verify_path_aware_accumulation_nonnegative
  _min_strategy_runtime,halt."`
  - `env SKIP_CSHARP_EXECUTION=1 swipl -q -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target,halt."`
  - `git diff --check`