### PR TITLE
Measure weighted Min frontier fallback at benchmark scale

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -87,14 +87,18 @@ Make the runtime selection explicit:
 - hashed non-DAG path-state strategy when simple-path cyclic semantics
   are required
 
-## Immediate Follow-Up After This Proposal
+## Immediate Follow-Up After Weighted-Min Frontier Metrics
 
-Do **not** implement this before finishing the current DAG benchmark
-follow-up work.
+The weighted `Min` frontier fallback metric survey now points back to this
+plan. On benchmark-scale cyclic fallback cases, dominance-candidate scans
+dominate the counters, retained buckets grow, and exact subset checks are not
+the main count driver.
 
-The next concrete coding step after these docs should still be DAG-side:
+The next concrete coding step should start here:
 
-- improve the dependency reach / depth story on acyclic graphs
+- normalize weighted `Min` frontier states around stable integer node ids
+- carry deterministic fingerprints with exact visited paths
+- partition candidate buckets before exact subset/dominance verification
 
-This proposal exists so the non-DAG direction is not lost while that DAG
-work proceeds.
+The optimization must remain exact: fingerprints and bucket keys should reduce
+candidate scans, not replace the final simple-path dominance check.

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -246,9 +246,45 @@ The frontier metric step now records:
 
 The next coding step should be:
 
-1. run the frontier metrics on cyclic benchmark-scale weighted `Min`
-   fallback cases
-2. compare whether the hot path is dominated by candidate growth, bucket
-   fanout, or exact subset checks
-3. decide whether the next optimization should be exact state hashing or a
-   narrower multiplicative-to-additive transform
+1. implement exact frontier-state hashing / bucket partitioning for weighted
+   `Min` fallback states
+2. keep the multiplicative-to-additive transform as a narrower later
+   optimization, not the next broad fix
+3. validate that dominance-candidate scans and retained bucket sizes drop on
+   the benchmark fallback cases below
+
+## Frontier Fallback Metric Survey
+
+Measured with:
+
+```bash
+python examples/benchmark/benchmark_weighted_shortest_path.py \
+  --scales 300,1k --repetitions 1 --weight-mode negative \
+  --recurrence-mode additive
+
+python examples/benchmark/benchmark_weighted_shortest_path.py \
+  --scales 300,1k --repetitions 1 --weight-mode positive \
+  --recurrence-mode multiplicative
+```
+
+Both fallback cases preserve output agreement between `All` and `Min`, but the
+exact `Min` fallback is slower than `All` on these benchmark-scale cyclic
+cases.
+
+| Shape | Scale | All | Min | Speedup | Dominance Candidates | Dominance Checks | Subset Checks | Avg Bucket | Max Bucket |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| negative additive | 300 | 0.984s | 1.885s | 0.52x | 104,874,704 | 1,163,485 | 93,771 | 18.66 | 2,651 |
+| negative additive | 1k | 0.783s | 1.882s | 0.42x | 112,962,813 | 682,397 | 74,865 | 32.76 | 3,281 |
+| multiplicative | 300 | 0.991s | 1.132s | 0.88x | 36,195,447 | 863,266 | 148,532 | 12.81 | 1,227 |
+| multiplicative | 1k | 0.688s | 1.184s | 0.58x | 39,638,003 | 505,982 | 106,165 | 22.36 | 1,168 |
+
+Interpretation:
+
+- dominance-candidate scans dominate the measured counters by one to two
+  orders of magnitude
+- subset checks are not the primary cost by count; the runtime spends most of
+  its work reaching candidate states in broad target buckets
+- `min_frontier_removed_state_count` stayed at `0` for these runs, so the
+  current retained buckets grow but rarely compact themselves
+- the next optimization should partition/index exact frontier states before
+  adding a multiplicative-specific transform

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -236,7 +236,7 @@ Tables:
 | `benchmark_scan_materialization.py` | Exercise relation scan, pattern scan, join, negation, and aggregate under the scan materialization planner |
 | `benchmark_closure_materialization.py` | Exercise generic seeded closure and streamed auxiliary accumulation under the closure materialization planner |
 | `benchmark_closure_pair_planning.py` | Exercise seeded and grouped closure-pair workloads under the closure-pair strategy planner |
-| `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive weighted paths |
+| `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive, non-negative, and fallback weighted paths |
 | `benchmark_weighted_shortest_path_cross_target.py` | Compare positive weighted shortest path across C# query, seeded Prolog `min`, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_category_influence_cross_target.py` | Compare category influence propagation across the C# query engine, Rust DFS, Go DFS, and an optional Prolog accumulated path |
 | `generate_prolog_shortest_path_benchmark.pl` | Generate standalone SWI-Prolog shortest-path benchmark scripts with `branch_pruning(auto|false)` |
@@ -937,6 +937,13 @@ Use `--weight-mode nonnegative-zero` to keep degree-one source weights at zero
 and exercise the broader non-negative additive `Min` path that would otherwise
 fall back to the exact visited-state frontier.
 
+Use `--weight-mode negative --recurrence-mode additive` to force the exact
+frontier fallback for negative additive steps. Use
+`--weight-mode positive --recurrence-mode multiplicative` to force the exact
+frontier fallback for positive multiplicative recurrence. These variants emit
+the `min_frontier_*` trace metrics used to profile candidate growth, dominance
+checks, subset checks, and retained frontier bucket sizes.
+
 Latest local results:
 
 | Scale | All | Min | Speedup | Output Match |
@@ -971,6 +978,14 @@ trace label, while zero-cost non-negative steps report
 `metric_scc_probe_local_states_explored`, and
 `metric_scc_probe_outer_dag_states_explored`; on the current benchmark
 shape the selector keeps the layered path when the SCC probe is slower.
+
+Fallback metric runs on `300` and `1k` show that broad dominance-candidate
+scans, not the raw number of exact subset checks, dominate the measured
+frontier counters. The negative-additive fallback reached
+`104,874,704` dominance-candidate checks at `300` and `112,962,813` at `1k`.
+The multiplicative fallback reached `36,195,447` at `300` and `39,638,003` at
+`1k`. That points the next optimization toward exact frontier-state hashing or
+bucket partitioning before a narrow multiplicative-specific transform.
 
 ### Available Targets
 

--- a/examples/benchmark/benchmark_weighted_shortest_path.py
+++ b/examples/benchmark/benchmark_weighted_shortest_path.py
@@ -9,7 +9,9 @@ PathAwareAccumulationNode runtime modes:
 By default the harness derives a positive source weight from category out-degree
 so the recursive increment remains monotone and min-pruning is sound. The
 `--weight-mode nonnegative-zero` variant leaves degree-one sources at zero cost
-to exercise the broader non-negative additive `Min` fast path.
+to exercise the broader non-negative additive `Min` fast path. The
+`--weight-mode negative` and `--recurrence-mode multiplicative` variants force
+the exact frontier fallback and expose its trace metrics at benchmark scale.
 """
 
 from __future__ import annotations
@@ -85,14 +87,15 @@ class Program
 
     static void Main(string[] args)
     {
-        if (args.Length < 4)
+        if (args.Length < 5)
         {
-            Console.Error.WriteLine("Usage: program <all|min> <positive|nonnegative-zero> <category_parent.tsv> <article_category.tsv>");
+            Console.Error.WriteLine("Usage: program <all|min> <positive|nonnegative-zero|negative> <additive|multiplicative> <category_parent.tsv> <article_category.tsv>");
             Environment.Exit(1);
         }
 
         var modeName = args[0];
         var weightMode = args[1];
+        var recurrenceMode = args[2];
         var mode = modeName switch
         {
             "all" => TableMode.All,
@@ -114,7 +117,7 @@ class Program
         var allNodes = new HashSet<string>(StringComparer.Ordinal);
         var edgeCount = 0;
 
-        foreach (var (line, i) in File.ReadLines(args[2]).Select((l, i) => (l, i)))
+        foreach (var (line, i) in File.ReadLines(args[3]).Select((l, i) => (l, i)))
         {
             if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
             {
@@ -155,12 +158,13 @@ class Program
             {
                 "positive" => 1.0 + Math.Log(Math.Max(1, degree), 5.0),
                 "nonnegative-zero" => degree <= 1 ? 0.0 : Math.Log(degree, 5.0),
+                "negative" => degree <= 1 ? 1.0 : -Math.Log(degree, 5.0),
                 _ => throw new ArgumentException($"Unknown weight mode: {weightMode}")
             };
             provider.AddFact(weightId, source, weight);
         }
 
-        foreach (var (line, i) in File.ReadLines(args[3]).Select((l, i) => (l, i)))
+        foreach (var (line, i) in File.ReadLines(args[4]).Select((l, i) => (l, i)))
         {
             if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
             {
@@ -185,6 +189,19 @@ class Program
         var sccStats = ComputeSccStats(adjacency);
         swLoad.Stop();
 
+        ArithmeticExpression recursiveExpression = recurrenceMode switch
+        {
+            "additive" => new BinaryArithmeticExpression(
+                ArithmeticBinaryOperator.Add,
+                new ColumnExpression(2),
+                new ColumnExpression(3)),
+            "multiplicative" => new BinaryArithmeticExpression(
+                ArithmeticBinaryOperator.Multiply,
+                new ColumnExpression(2),
+                new ColumnExpression(3)),
+            _ => throw new ArgumentException($"Unknown recurrence mode: {recurrenceMode}")
+        };
+
         var plan = new QueryPlan(
             predId,
             new PathAwareAccumulationNode(
@@ -192,10 +209,7 @@ class Program
                 predId,
                 weightId,
                 new ColumnExpression(3),
-                new BinaryArithmeticExpression(
-                    ArithmeticBinaryOperator.Add,
-                    new ColumnExpression(2),
-                    new ColumnExpression(3)),
+                recursiveExpression,
                 MAX_DEPTH,
                 mode),
             true,
@@ -287,6 +301,7 @@ class Program
 
         Console.Error.WriteLine($"mode={modeName}");
         Console.Error.WriteLine($"weight_mode={weightMode}");
+        Console.Error.WriteLine($"recurrence_mode={recurrenceMode}");
         Console.Error.WriteLine($"load_ms={swLoad.ElapsedMilliseconds}");
         Console.Error.WriteLine($"query_ms={swQuery.ElapsedMilliseconds}");
         Console.Error.WriteLine($"aggregation_ms={swAgg.ElapsedMilliseconds}");
@@ -439,9 +454,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--repetitions", type=int, default=5)
     parser.add_argument(
         "--weight-mode",
-        choices=["positive", "nonnegative-zero"],
+        choices=["positive", "nonnegative-zero", "negative"],
         default="positive",
-        help="Use strictly positive source weights or include zero-cost source weights for non-negative Min coverage.",
+        help="Use strictly positive, non-negative zero, or negative source weights.",
+    )
+    parser.add_argument(
+        "--recurrence-mode",
+        choices=["additive", "multiplicative"],
+        default="additive",
+        help="Use additive accumulation or multiplicative accumulation. Multiplicative Min uses the exact frontier fallback.",
     )
     parser.add_argument("--keep-temp", action="store_true")
     return parser.parse_args()
@@ -475,7 +496,14 @@ def build_harness(root: Path) -> list[str]:
     return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_weighted_shortest_path.dll")]
 
 
-def benchmark_mode(command: list[str], scale: str, mode: str, weight_mode: str, repetitions: int) -> RunResult:
+def benchmark_mode(
+    command: list[str],
+    scale: str,
+    mode: str,
+    weight_mode: str,
+    recurrence_mode: str,
+    repetitions: int,
+) -> RunResult:
     scale_dir = BENCH_DIR / scale
     edge_path = scale_dir / "category_parent.tsv"
     article_path = scale_dir / "article_category.tsv"
@@ -485,7 +513,7 @@ def benchmark_mode(command: list[str], scale: str, mode: str, weight_mode: str, 
     stderr = ""
     for _ in range(repetitions):
         started = time.perf_counter()
-        result = run(command + [mode, weight_mode, str(edge_path), str(article_path)])
+        result = run(command + [mode, weight_mode, recurrence_mode, str(edge_path), str(article_path)])
         elapsed = time.perf_counter() - started
         times.append(elapsed)
         stdout = result.stdout
@@ -511,8 +539,8 @@ def main() -> int:
         command = build_harness(temp_root)
         results: list[RunResult] = []
         for scale in scales:
-            results.append(benchmark_mode(command, scale, "all", args.weight_mode, args.repetitions))
-            results.append(benchmark_mode(command, scale, "min", args.weight_mode, args.repetitions))
+            results.append(benchmark_mode(command, scale, "all", args.weight_mode, args.recurrence_mode, args.repetitions))
+            results.append(benchmark_mode(command, scale, "min", args.weight_mode, args.recurrence_mode, args.repetitions))
 
         print("scale\tmode\tmedian_s\tmin_s\tmax_s\trows")
         grouped: dict[str, dict[str, RunResult]] = {}


### PR DESCRIPTION
  ## Summary

  This PR extends the weighted shortest-path benchmark so it can exercise weighted `Min` shapes that intentionally use the exact
  frontier fallback, then records the resulting frontier metrics at benchmark scale.

  The measured fallback cases preserve output agreement between `All` and `Min`, but `Min` is slower than `All` on these cyclic
  benchmark workloads. The metrics show that dominance-candidate scans dominate the fallback cost, pointing the next optimization
  toward exact frontier-state hashing or bucket partitioning before a narrower multiplicative-specific transform.

  ## Changes

  - Adds `--weight-mode negative` to `benchmark_weighted_shortest_path.py`.
  - Adds `--recurrence-mode additive|multiplicative`.
  - Emits `recurrence_mode` in benchmark trace output.
  - Documents benchmark-scale fallback measurements for:
    - negative additive weighted `Min`
    - positive multiplicative weighted `Min`
  - Updates planning docs to make exact frontier-state hashing / bucket partitioning the recommended next step.

  ## Key Findings

  | Shape | Scale | All | Min | Speedup | Dominance Candidates | Avg Bucket | Max Bucket |
  | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
  | negative additive | 300 | 0.984s | 1.885s | 0.52x | 104,874,704 | 18.66 | 2,651 |
  | negative additive | 1k | 0.783s | 1.882s | 0.42x | 112,962,813 | 32.76 | 3,281 |
  | multiplicative | 300 | 0.991s | 1.132s | 0.88x | 36,195,447 | 12.81 | 1,227 |
  | multiplicative | 1k | 0.688s | 1.184s | 0.58x | 39,638,003 | 22.36 | 1,168 |

  ## Testing

  - `python3 -m py_compile examples/benchmark/benchmark_weighted_shortest_path.py`
  - `python3 examples/benchmark/benchmark_weighted_shortest_path.py --scales 300 --repetitions 1`
  - `python3 examples/benchmark/benchmark_weighted_shortest_path.py --scales 300 --repetitions 1 --weight-mode negative
  --recurrence-mode additive`
  - `python3 examples/benchmark/benchmark_weighted_shortest_path.py --scales 300 --repetitions 1 --weight-mode positive
  --recurrence-mode multiplicative`
  - `python3 examples/benchmark/benchmark_weighted_shortest_path.py --scales 1k --repetitions 1 --weight-mode negative --recurrence-
  mode additive`
  - `python3 examples/benchmark/benchmark_weighted_shortest_path.py --scales 1k --repetitions 1 --weight-mode positive --recurrence-
  mode multiplicative`
  - `git diff --check`