### PR TITLE
feat(wam-haskell): auto-generate kernel FFI from templates

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
@@ -59,12 +59,17 @@ tokenize(Line, Term) :-
 
 wam_haskell_lowerable(_PI, WamCode, _Reason) :-
     parse_wam_text(WamCode, PCInstrs, _),
-    % Phase 4 restriction: only single-clause predicates (no try_me_else)
-    % are lowerable. Multi-clause lowering requires resolving the dispatch
-    % conflict between executeForeign (which returns Nothing for "no
-    % solutions") and the lowered function (which would fruitlessly explore
-    % the graph via WAM dispatch). See fix/wam-haskell-lowered-backtrack.
     PCInstrs = [pc(_, FirstInstr)|_],
+    % Multi-clause predicates (try_me_else) are not lowerable yet:
+    %   - Detected kernels (e.g. category_ancestor) use the FFI path
+    %     (executeForeign takes dispatch priority) — lowering them would
+    %     produce dead code that never runs.
+    %   - Non-kernel multi-clause predicates cause exponential blowup
+    %     because clause-1-only lowering + interpreter clause-2 recursion
+    %     bypasses the FFI's authoritative "no solutions" signal.
+    % Multi-clause lowering requires either auto-generated kernel FFI
+    % (see docs/proposals/WAM_FOREIGN_DISPATCH_RETURN_TYPE.md) or the
+    % full all-clauses-inline approach from the spec §2.4.
     FirstInstr \= try_me_else(_),
     clause1_instrs(PCInstrs, C1),
     forall(member(I, C1), supported(I)).

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -28,7 +28,7 @@
 
 :- module(wam_haskell_target, [
     compile_wam_predicate_to_haskell/4,  % +Pred/Arity, +WamCode, +Options, -HaskellCode
-    compile_wam_runtime_to_haskell/2,    % +Options, -HaskellCode
+    compile_wam_runtime_to_haskell/3,    % +Options, +DetectedKernels, -HaskellCode
     write_wam_haskell_project/3,         % +Predicates, +Options, +ProjectDir
     wam_haskell_resolve_emit_mode/2,     % +Options, -Mode
     wam_haskell_partition_predicates/4   % +Mode, +Predicates, -InterpretedList, -LoweredList
@@ -40,6 +40,7 @@
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
 :- use_module('../core/recursive_kernel_detection',
              [detect_recursive_kernel/4, kernel_metadata/4, kernel_config/2]).
+:- use_module('../core/template_system', [render_template/3]).
 
 % Phase 3: the real lowerability check and emission helpers live in the
 % wam_haskell_lowered_emitter module. We reexport so existing callers can
@@ -165,6 +166,92 @@ predicate_base_pc(P, Map, PC) :-
     (   P = _Mod:Pred/Arity -> true ; P = Pred/Arity ),
     format(atom(Key), '~w/~w', [Pred, Arity]),
     (   member(Key-PC, Map) -> true ; PC = 1 ).
+
+%% generate_kernel_haskell(+DetectedKernels, -KernelFunctionsCode, -ExecuteForeignCode)
+%  Render Mustache templates for detected kernels into Haskell source.
+%  KernelFunctionsCode: native kernel function bodies (one per kernel).
+%  ExecuteForeignCode: the executeForeign dispatch function with entries
+%  for each detected kernel.
+generate_kernel_haskell([], KF, EF) :- !,
+    KF = "-- No kernels detected; no native functions generated.",
+    EF = "executeForeign :: WamContext -> String -> WamState -> Maybe WamState\nexecuteForeign _ _ _ = Nothing".
+generate_kernel_haskell(DetectedKernels, KernelFunctionsCode, ExecuteForeignCode) :-
+    % For each detected kernel, find its template and render
+    maplist(render_kernel_function, DetectedKernels, KernelParts),
+    atomic_list_concat(KernelParts, '\n\n', KernelFunctionsCode),
+    % Generate executeForeign with entries for each kernel
+    generate_execute_foreign(DetectedKernels, ExecuteForeignCode).
+
+render_kernel_function(KernelKey, Code) :-
+    % Currently only category_ancestor has a Mustache template
+    (   KernelKey = 'category_ancestor/4'
+    ->  read_kernel_template('kernel_category_ancestor.hs.mustache', Template),
+        render_template(Template, [edge_pred='category_parent'], Code0),
+        atom_string(Code0, Code)
+    ;   format(atom(Code), '-- Kernel ~w: no template available', [KernelKey])
+    ).
+
+read_kernel_template(FileName, Template) :-
+    atom_concat('templates/targets/haskell_wam/', FileName, RelPath),
+    (   source_file(wam_haskell_target, SrcFile)
+    ->  file_directory_name(SrcFile, SrcDir),
+        file_directory_name(SrcDir, TargetsDir),
+        file_directory_name(TargetsDir, UnifyWeaverDir),
+        file_directory_name(UnifyWeaverDir, ProjectDir),
+        atom_concat(ProjectDir, '/', P1),
+        atom_concat(P1, RelPath, AbsPath)
+    ;   AbsPath = RelPath
+    ),
+    (   exists_file(AbsPath)
+    ->  read_file_to_string(AbsPath, Template, [])
+    ;   format(atom(Template), '-- Template not found: ~w', [AbsPath])
+    ).
+
+generate_execute_foreign(DetectedKernels, Code) :-
+    with_output_to(string(Code), (
+        format("executeForeign :: WamContext -> String -> WamState -> Maybe WamState~n"),
+        forall(member(K, DetectedKernels), emit_execute_foreign_entry(K)),
+        format("executeForeign _ _ _ = Nothing~n")
+    )).
+
+emit_execute_foreign_entry('category_ancestor/4') :-
+    format('executeForeign !ctx "category_ancestor/4" s =~n'),
+    format('  let cat = derefVar (wsBindings s) $ fromMaybe (Atom "") (IM.lookup 1 (wsRegs s))~n'),
+    format('      root = derefVar (wsBindings s) $ fromMaybe (Atom "") (IM.lookup 2 (wsRegs s))~n'),
+    format('      visited = derefVar (wsBindings s) $ fromMaybe (VList []) (IM.lookup 4 (wsRegs s))~n'),
+    format('      maxD = fromMaybe 10 $ Map.lookup "max_depth" (wcForeignConfig ctx)~n'),
+    format('      parents = fromMaybe Map.empty $ Map.lookup "category_parent" (wcForeignFacts ctx)~n'),
+    format('  in case (cat, root, visited) of~n'),
+    format('    (Atom catS, Atom rootS, VList visitedVals) ->~n'),
+    format('      let visitedStrs = [v | Atom v <- visitedVals]~n'),
+    format('          hops = nativeKernel_category_ancestor parents catS rootS maxD (length visitedStrs) visitedStrs~n'),
+    format('          retPC = wsCP s~n'),
+    format('          hopsReg = derefVar (wsBindings s) $ fromMaybe (Unbound (-1)) (IM.lookup 3 (wsRegs s))~n'),
+    format('          bindHop hopVal =~n'),
+    format('            case hopsReg of~n'),
+    format('              Unbound vid ->~n'),
+    format('                s { wsPC = retPC~n'),
+    format('                  , wsRegs = IM.insert 3 (Integer (fromIntegral hopVal)) (wsRegs s)~n'),
+    format('                  , wsBindings = IM.insert vid (Integer (fromIntegral hopVal)) (wsBindings s)~n'),
+    format('                  , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s~n'),
+    format('                  , wsTrailLen = wsTrailLen s + 1 }~n'),
+    format('              _ -> s { wsPC = retPC, wsRegs = IM.insert 3 (Integer (fromIntegral hopVal)) (wsRegs s) }~n'),
+    format('      in case hops of~n'),
+    format('        [] -> Nothing~n'),
+    format('        [h] -> Just (bindHop h)~n'),
+    format('        (h:restHops) ->~n'),
+    format('          let s1 = bindHop h~n'),
+    format('              hopsVar = case hopsReg of { Unbound v -> v; _ -> -1 }~n'),
+    format('              cp = ChoicePoint~n'),
+    format('                { cpNextPC = retPC, cpRegs = wsRegs s, cpStack = wsStack s~n'),
+    format('                , cpCP = wsCP s, cpTrailLen = wsTrailLen s~n'),
+    format('                , cpHeapLen = wsHeapLen s, cpBindings = wsBindings s~n'),
+    format('                , cpCutBar = wsCutBar s, cpAggFrame = Nothing~n'),
+    format('                , cpBuiltin = Just (HopsRetry hopsVar (map fromIntegral restHops) retPC)~n'),
+    format('                }~n'),
+    format('          in Just (s1 { wsCPs = cp : wsCPs s, wsCPsLen = wsCPsLen s + 1 })~n'),
+    format('    _ -> Nothing~n').
+emit_execute_foreign_entry(_).  % Unknown kernels: skip
 
 %% detect_kernels(+Predicates, -DetectedKernels)
 %  Run shared kernel detection on each predicate. Returns a list of
@@ -559,38 +646,10 @@ applyAggregation _ vals = VList vals
 
 -- ============================================================================
 -- Foreign Function Interface: native Haskell implementations of expensive
--- recursive predicates. Avoids ~100x WAM interpretation overhead.
+-- recursive predicates. Auto-generated from kernel detection.
 -- ============================================================================
 
--- | Native category_ancestor: depth-bounded DFS over indexed parent facts.
--- Returns all (Hops) values for paths from Cat to Root within maxDepth.
---
--- Hops semantics matches the source Prolog (examples/benchmark/effective_distance.pl):
---   category_ancestor(Cat, Parent, 1, Visited) :- category_parent(Cat, Parent), \\+ member(Parent, Visited).
---   category_ancestor(Cat, Ancestor, Hops, Visited) :- ..., category_ancestor(Mid, Ancestor, H1, [Mid|Visited]), Hops is H1 + 1.
--- A DIRECT parent contributes Hops=1 (not 0!). Grandparent contributes Hops=2.
--- The recursive case adds 1 per level.
---
--- Uses a plain list for visited because depth is bounded (typically <= 10),
--- so O(depth) elem checks are faster than O(log n) Set operations + the
--- per-call Set construction overhead.
-nativeCategoryAncestor :: Map.Map String [String] -> String -> String -> Int -> Int -> [String] -> [Int]
-nativeCategoryAncestor parents cat root maxDepth depth visited =
-  let directParents = fromMaybe [] (Map.lookup cat parents)
-      -- Base case (Prolog clause 1): any direct parent that IS the root
-      -- contributes Hops=1. The Prolog also requires \\+ member(Parent, Visited)
-      -- but since Visited starts as [Cat] and grows with intermediate categories,
-      -- the root cannot normally appear in Visited unless cat == root, in which
-      -- case the cycle check below covers it.
-      baseHits = [1 | p <- directParents, p == root]
-      -- Recursive case (Prolog clause 2): for each direct parent that is not
-      -- yet visited, recurse and add 1 to every returned Hops.
-      recHits = if depth >= maxDepth then [] else
-        concatMap (\\mid ->
-          if mid `elem` visited then []
-          else map (+1) $ nativeCategoryAncestor parents mid root maxDepth (depth+1) (mid : visited)
-        ) directParents
-  in baseHits ++ recHits
+{{kernel_functions}}
 
 -- | Execute a foreign predicate call. Computes all results natively,
 -- returns first result with CPs for the rest.
@@ -634,45 +693,7 @@ callIndexedFact2 !ctx pred s =
           _ -> Nothing
         _ -> Nothing
 
-executeForeign :: WamContext -> String -> WamState -> Maybe WamState
-executeForeign !ctx "category_ancestor/4" s =
-  let cat = derefVar (wsBindings s) $ fromMaybe (Atom "") (IM.lookup 1 (wsRegs s))
-      root = derefVar (wsBindings s) $ fromMaybe (Atom "") (IM.lookup 2 (wsRegs s))
-      visited = derefVar (wsBindings s) $ fromMaybe (VList []) (IM.lookup 4 (wsRegs s))
-      maxD = fromMaybe 10 $ Map.lookup "max_depth" (wcForeignConfig ctx)
-      parents = fromMaybe Map.empty $ Map.lookup "category_parent" (wcForeignFacts ctx)
-  in case (cat, root, visited) of
-    (Atom catS, Atom rootS, VList visitedVals) ->
-      let visitedStrs = [v | Atom v <- visitedVals]
-          hops = nativeCategoryAncestor parents catS rootS maxD (length visitedStrs) visitedStrs
-          retPC = wsCP s
-          hopsReg = derefVar (wsBindings s) $ fromMaybe (Unbound (-1)) (IM.lookup 3 (wsRegs s))
-          bindHop hopVal =
-            case hopsReg of
-              Unbound vid ->
-                s { wsPC = retPC
-                  , wsRegs = IM.insert 3 (Integer (fromIntegral hopVal)) (wsRegs s)
-                  , wsBindings = IM.insert vid (Integer (fromIntegral hopVal)) (wsBindings s)
-                  , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
-                  , wsTrailLen = wsTrailLen s + 1 }
-              _ -> s { wsPC = retPC, wsRegs = IM.insert 3 (Integer (fromIntegral hopVal)) (wsRegs s) }
-      in case hops of
-        [] -> Nothing
-        [h] -> Just (bindHop h)   -- single result, no CPs
-        (h:restHops) ->
-          let s1 = bindHop h
-              -- Single HopsRetry CP for all remaining matches (self-popping)
-              hopsVar = case hopsReg of { Unbound v -> v; _ -> -1 }
-              cp = ChoicePoint
-                { cpNextPC = retPC, cpRegs = wsRegs s, cpStack = wsStack s
-                , cpCP = wsCP s, cpTrailLen = wsTrailLen s
-                , cpHeapLen = wsHeapLen s, cpBindings = wsBindings s
-                , cpCutBar = wsCutBar s, cpAggFrame = Nothing
-                , cpBuiltin = Just (HopsRetry hopsVar (map fromIntegral restHops) retPC)
-                }
-          in Just (s1 { wsCPs = cp : wsCPs s, wsCPsLen = wsCPsLen s + 1 })
-    _ -> Nothing
-executeForeign _ _ _ = Nothing
+{{execute_foreign}}
 
 -- | Bind an output register to a value WITHOUT advancing PC.
 -- Used by term-inspection builtins that need to bind multiple
@@ -1197,7 +1218,7 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     write_hs_file(TypesPath, TypesCode),
 
     % Generate WamRuntime.hs
-    compile_wam_runtime_to_haskell(Options, RuntimeCode0),
+    compile_wam_runtime_to_haskell(Options, DetectedKernels, RuntimeCode0),
     apply_hashmap_rewrite(UseHM, runtime, RuntimeCode0, RuntimeCode),
     directory_file_path(SrcDir, 'WamRuntime.hs', RuntimePath),
     write_hs_file(RuntimePath, RuntimeCode),
@@ -1607,11 +1628,18 @@ build_predicate_loads(Predicates, Code) :-
 '    let allCode = ~w
     let allLabels = ~w', [CodeConcat, LabelUnion]).
 
-%% compile_wam_runtime_to_haskell(+Options, -Code)
-compile_wam_runtime_to_haskell(_Options, Code) :-
+%% compile_wam_runtime_to_haskell(+Options, +DetectedKernels, -Code)
+compile_wam_runtime_to_haskell(_Options, DetectedKernels, Code) :-
     step_function_haskell(StepCode),
-    backtrack_haskell(BacktrackCode),
+    backtrack_haskell(BacktrackCodeTemplate),
     run_loop_haskell(RunCode),
+    % Render kernel-specific Haskell from Mustache templates
+    generate_kernel_haskell(DetectedKernels, KernelFunctionsCode, ExecuteForeignCode),
+    % Inject into the backtrack_haskell template via {{placeholder}} substitution
+    render_template(BacktrackCodeTemplate,
+                    [kernel_functions=KernelFunctionsCode,
+                     execute_foreign=ExecuteForeignCode],
+                    BacktrackCode),
     format(string(Code),
 '{-# LANGUAGE BangPatterns #-}
 module WamRuntime where

--- a/templates/targets/haskell_wam/execute_foreign.hs.mustache
+++ b/templates/targets/haskell_wam/execute_foreign.hs.mustache
@@ -1,0 +1,43 @@
+-- | Execute a foreign predicate call. Auto-generated from kernel detection.
+-- Dispatch: checks predicate name, reads registers, calls the native kernel,
+-- returns first result with CPs for the rest.
+executeForeign :: WamContext -> String -> WamState -> Maybe WamState
+{{#kernels}}
+executeForeign !ctx "{{pred_indicator}}" s =
+  let cat = derefVar (wsBindings s) $ fromMaybe (Atom "") (IM.lookup 1 (wsRegs s))
+      root = derefVar (wsBindings s) $ fromMaybe (Atom "") (IM.lookup 2 (wsRegs s))
+      visited = derefVar (wsBindings s) $ fromMaybe (VList []) (IM.lookup 4 (wsRegs s))
+      maxD = fromMaybe {{max_depth}} $ Map.lookup "max_depth" (wcForeignConfig ctx)
+      parents = fromMaybe Map.empty $ Map.lookup "{{edge_pred}}" (wcForeignFacts ctx)
+  in case (cat, root, visited) of
+    (Atom catS, Atom rootS, VList visitedVals) ->
+      let visitedStrs = [v | Atom v <- visitedVals]
+          hops = nativeKernel_category_ancestor parents catS rootS maxD (length visitedStrs) visitedStrs
+          retPC = wsCP s
+          hopsReg = derefVar (wsBindings s) $ fromMaybe (Unbound (-1)) (IM.lookup 3 (wsRegs s))
+          bindHop hopVal =
+            case hopsReg of
+              Unbound vid ->
+                s { wsPC = retPC
+                  , wsRegs = IM.insert 3 (Integer (fromIntegral hopVal)) (wsRegs s)
+                  , wsBindings = IM.insert vid (Integer (fromIntegral hopVal)) (wsBindings s)
+                  , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
+                  , wsTrailLen = wsTrailLen s + 1 }
+              _ -> s { wsPC = retPC, wsRegs = IM.insert 3 (Integer (fromIntegral hopVal)) (wsRegs s) }
+      in case hops of
+        [] -> Nothing
+        [h] -> Just (bindHop h)
+        (h:restHops) ->
+          let s1 = bindHop h
+              hopsVar = case hopsReg of { Unbound v -> v; _ -> -1 }
+              cp = ChoicePoint
+                { cpNextPC = retPC, cpRegs = wsRegs s, cpStack = wsStack s
+                , cpCP = wsCP s, cpTrailLen = wsTrailLen s
+                , cpHeapLen = wsHeapLen s, cpBindings = wsBindings s
+                , cpCutBar = wsCutBar s, cpAggFrame = Nothing
+                , cpBuiltin = Just (HopsRetry hopsVar (map fromIntegral restHops) retPC)
+                }
+          in Just (s1 { wsCPs = cp : wsCPs s, wsCPsLen = wsCPsLen s + 1 })
+    _ -> Nothing
+{{/kernels}}
+executeForeign _ _ _ = Nothing

--- a/templates/targets/haskell_wam/kernel_category_ancestor.hs.mustache
+++ b/templates/targets/haskell_wam/kernel_category_ancestor.hs.mustache
@@ -1,0 +1,12 @@
+-- | Native depth-bounded DFS for the category_ancestor kernel.
+-- Auto-generated from kernel detection. Edge predicate: {{edge_pred}}.
+nativeKernel_category_ancestor :: Map.Map String [String] -> String -> String -> Int -> Int -> [String] -> [Int]
+nativeKernel_category_ancestor parents cat root maxDepth depth visited =
+  let directParents = fromMaybe [] (Map.lookup cat parents)
+      baseHits = [1 | p <- directParents, p == root]
+      recHits = if depth >= maxDepth then [] else
+        concatMap (\mid ->
+          if mid `elem` visited then []
+          else map (+1) $ nativeKernel_category_ancestor parents mid root maxDepth (depth+1) (mid : visited)
+        ) directParents
+  in baseHits ++ recHits

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -29,7 +29,7 @@ fail_test(Test, Reason) :-
 
 test_haskell_helper_functions_present :-
     Test = 'WAM-Haskell: term-builtin helpers generated',
-    (   compile_wam_runtime_to_haskell([], Code),
+    (   compile_wam_runtime_to_haskell([], [], Code),
         atom_string(Code, S),
         %% bindOutput: non-PC-advancing register-binding helper used
         %% by functor/3, arg/3, =../2 for output positions.
@@ -44,7 +44,7 @@ test_haskell_helper_functions_present :-
 
 test_haskell_functor_builtin_present :-
     Test = 'WAM-Haskell: functor/3 step case generated',
-    (   compile_wam_runtime_to_haskell([], Code),
+    (   compile_wam_runtime_to_haskell([], [], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, "BuiltinCall \"functor/3\""),
         %% Construct mode: allocates fresh Unbound cells.
@@ -57,7 +57,7 @@ test_haskell_functor_builtin_present :-
 
 test_haskell_arg_builtin_present :-
     Test = 'WAM-Haskell: arg/3 step case generated',
-    (   compile_wam_runtime_to_haskell([], Code),
+    (   compile_wam_runtime_to_haskell([], [], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, "BuiltinCall \"arg/3\""),
         %% 1-based indexing into Str args list.
@@ -68,7 +68,7 @@ test_haskell_arg_builtin_present :-
 
 test_haskell_univ_builtin_present :-
     Test = 'WAM-Haskell: =../2 step case generated',
-    (   compile_wam_runtime_to_haskell([], Code),
+    (   compile_wam_runtime_to_haskell([], [], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, "BuiltinCall \"=../2\""),
         %% Decompose mode: prepends functor atom to arg list.
@@ -81,7 +81,7 @@ test_haskell_univ_builtin_present :-
 
 test_haskell_copy_term_builtin_present :-
     Test = 'WAM-Haskell: copy_term/2 step case generated',
-    (   compile_wam_runtime_to_haskell([], Code),
+    (   compile_wam_runtime_to_haskell([], [], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, "BuiltinCall \"copy_term/2\""),
         %% Drives copyTermWalk with the current var counter and an
@@ -98,7 +98,7 @@ test_haskell_no_regressions :-
     %% Smoke-test that adding Phase 5 has not broken pre-existing
     %% generated helpers (unifyVal, is/2, length/2 dispatch).
     Test = 'WAM-Haskell: pre-existing builtins still present',
-    (   compile_wam_runtime_to_haskell([], Code),
+    (   compile_wam_runtime_to_haskell([], [], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, "unifyVal :: Value -> Value -> WamState"),
         sub_string(S, _, _, _, "BuiltinCall \"is/2\""),


### PR DESCRIPTION
  ## Summary

  - Replaces the **hand-written** `nativeCategoryAncestor` and `executeForeign` in WamRuntime.hs with code **auto-generated**
   from kernel detection + Mustache templates.
  - The generated code is functionally identical — benchmark output is byte-identical to the hand-written version. The win is
   in **code generation reach**: new recursive kernels can be supported by adding a detector + template, without hand-writing
   FFI code.
  - Builds on the shared kernel detection from #1349.

  ## How it works

  ```
  User Prolog clauses
      ↓ clause analysis
  recursive_kernel_detection.pl         ← shared, target-independent
      ↓ recursive_kernel(category_ancestor, Pred/4, [max_depth(10)])
  wam_haskell_target.pl
      ↓ render_template with kernel config
  kernel_category_ancestor.hs.mustache  ← Mustache template for the native function
      ↓
  Generated WamRuntime.hs with nativeKernel_category_ancestor + executeForeign
  ```

  ### Template injection

  The `backtrack_haskell` template atom now has two placeholders:
  - `{{kernel_functions}}` — filled with rendered kernel function bodies (one per detected kernel)
  - `{{execute_foreign}}` — filled with the auto-generated `executeForeign` dispatch function

  `compile_wam_runtime_to_haskell/3` gains a `DetectedKernels` parameter. When kernels are detected, it:
  1. Reads the Mustache template for each kernel kind (`kernel_category_ancestor.hs.mustache`)
  2. Renders it with kernel config (`edge_pred=category_parent`)
  3. Generates the `executeForeign` pattern-match entries via `emit_execute_foreign_entry/1`
  4. Injects both into the template via `render_template/3`

  When no kernels are detected, stubs are emitted (`executeForeign _ _ _ = Nothing`).

  ### Lowerability check

  Improved documentation on why multi-clause predicates are rejected, with explicit references to:
  - Detected kernels → use FFI (executeForeign takes dispatch priority)
  - Non-kernel multi-clause → exponential blowup from clause-1-only lowering
  - Links to `docs/proposals/WAM_FOREIGN_DISPATCH_RETURN_TYPE.md` for the dispatch fix design

  ## New files

  | File | Role |
  |---|---|
  | `templates/targets/haskell_wam/kernel_category_ancestor.hs.mustache` | Native depth-bounded DFS function template.
  Parameterized by `{{edge_pred}}`. |
  | `templates/targets/haskell_wam/execute_foreign.hs.mustache` | Reference template for the executeForeign dispatch (actual
  generation is in Prolog via `emit_execute_foreign_entry/1` since register layout varies by kernel kind). |

  ## Modified files

  | File | Change |
  |---|---|
  | `wam_haskell_target.pl` | `compile_wam_runtime_to_haskell/3` (was `/2`), `generate_kernel_haskell/3`,
  `render_kernel_function/2`, `read_kernel_template/2`, `generate_execute_foreign/2`, `emit_execute_foreign_entry/1`.
  Template import + `render_template` injection. |
  | `wam_haskell_lowered_emitter.pl` | Improved lowerability comments linking to proposal doc. |
  | `tests/test_wam_haskell_target.pl` | Updated calls from `compile_wam_runtime_to_haskell([], Code)` to
  `compile_wam_runtime_to_haskell([], [], Code)`. |

  ## Verification

  - [x] `cabal build`: clean (5 modules compiled)
  - [x] `effective_distance` 10k benchmark: Temperature=2.840088, 5192 articles — byte-identical to hand-written FFI
  - [x] Small dataset: correct output, <1s
  - [x] Phase 1 tests: 11/11 pass
  - [x] Phase 3 tests: 8/8 pass
  - [x] Phase 5 codegen tests: 6/6 pass (updated for new arity)
  - [x] Generated `WamRuntime.hs` contains `nativeKernel_category_ancestor` (generated) instead of `nativeCategoryAncestor`
  (hardcoded)

  ## Adding a new kernel (recipe)

  To support a new recursive kernel shape (e.g., `transitive_closure`):

  1. **Add a detector** to `src/unifyweaver/core/recursive_kernel_detection.pl` — a Prolog predicate that pattern-matches the
   user's clause structure
  2. **Add metadata** — `kernel_native_kind`, `kernel_result_layout`, `kernel_result_mode` entries
  3. **Add a Mustache template** to `templates/targets/haskell_wam/kernel_<name>.hs.mustache` with the native Haskell
  function body
  4. **Add an `emit_execute_foreign_entry` clause** in `wam_haskell_target.pl` for the register layout / result binding logic
  5. **Register** the kernel in `kernel_detector/2`

  Steps 1-2 are target-independent (shared with Rust, LLVM, etc.). Steps 3-5 are Haskell-specific.

  ## Future work

  - **More kernels**: port remaining 8 detectors from `rust_target.pl` (`transitive_distance3`, `weighted_shortest_path3`,
  `astar_shortest_path4`, etc.)
  - **Main.hs foreignPreds**: auto-populate from `DetectedKernels` (currently hardcoded — blocked by the Main.hs template
  being a single large atom; needs Mustache migration or template splitting)
  - **Fully parameterized executeForeign**: the current `emit_execute_foreign_entry/1` has the category_ancestor register
  layout hardcoded. A generic version would derive the register reading + result binding from `kernel_result_layout` and
  `kernel_result_mode`.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)