### PR TITLE
feat(wam-haskell): compile-time CallForeign dispatch

### DIFF
--- a/docs/proposals/WAM_FOREIGN_DISPATCH_RETURN_TYPE.md
+++ b/docs/proposals/WAM_FOREIGN_DISPATCH_RETURN_TYPE.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Draft — written to capture the design gap discovered during the
-WAM-lowered Haskell work (#1344, #1346).
+**Resolved** — implemented via Option 4 (compile-time instruction
+resolution) in PR #1354. See "Implemented Solution" section below.
 
 ## Problem
 
@@ -135,20 +135,72 @@ can never handle predicates like `category_ancestor/4` even if it
 could generate correct code, because the dispatch can't tell when
 to skip the FFI.
 
-## Recommendation
+## Implemented Solution: Option 4 — Compile-time instruction resolution
 
-**Option 2** (predicate-set check) for the near term. It's the
-smallest change that unblocks multi-clause lowering:
+Instead of changing `executeForeign`'s return type (Option 1) or adding
+a runtime predicate-set check (Option 2), the ambiguity is resolved
+entirely at **compile time** by introducing a new WAM instruction:
 
-- One new field on `WamContext` (Haskell) / `VmState` (Rust) /
-  equivalent (WAT, LLVM).
-- One `if` check at the top of the `Call` dispatch.
-- The `foreignPreds` list already exists in `Main.hs` — just
-  thread it into `WamContext`.
+```haskell
+data Instruction
+  = ...
+  | Call String !Int         -- runtime dispatch (lowered → indexed → labels)
+  | CallResolved !Int !Int   -- compile-time resolved label (direct PC jump)
+  | CallForeign String !Int  -- compile-time resolved foreign pred (direct FFI)
+```
 
-Option 1 (three-valued return) is the long-term clean solution but
-should be tackled as a cross-target refactor after the lowered-Haskell
-path has proven its value. It's overkill for unblocking one feature.
+`resolveCallInstrs` (called once at project load time) now resolves
+each `Call` instruction to one of three forms:
+
+| Instruction | Resolved when | `Nothing` means |
+|---|---|---|
+| `CallResolved pc` | Known WAM label | *(never returns Nothing)* |
+| `CallForeign pred` | Detected kernel (foreign) | No solutions → backtrack |
+| `Call pred` | Runtime fallback | Full dispatch chain |
+
+The `step` function dispatches each form differently:
+
+```haskell
+-- Direct FFI: Nothing = no solutions, never falls through
+step !ctx s (CallForeign pred _arity) =
+  executeForeign ctx pred (s { wsCP = wsPC s + 1 })
+
+-- Non-foreign dispatch: executeForeign is NOT checked here
+step !ctx s (Call pred _arity) =
+  let sc = s { wsCP = wsPC s + 1 }
+  in case Map.lookup pred (wcLoweredPredicates ctx) of
+    Just fn -> fn ctx sc
+    Nothing -> case callIndexedFact2 ctx pred sc of
+      ...
+```
+
+For lowered functions, a `callForeign` helper provides the same
+semantics as `CallForeign` for inter-predicate calls:
+
+```haskell
+callForeign :: WamContext -> String -> WamState -> Maybe WamState
+callForeign !ctx pred !sc = executeForeign ctx pred sc
+```
+
+**Why this is better than Options 1–3:**
+
+- **No runtime overhead** — the dispatch decision is baked into the
+  instruction at compile time. No predicate-set lookup, no three-valued
+  return check on every call.
+- **No return type change** — `executeForeign` still returns
+  `Maybe WamState`. The ambiguity doesn't exist because `CallForeign`
+  is only emitted for predicates that ARE foreign.
+- **No sync risk** — the `foreignPreds` list that drives resolution is
+  derived from `DetectedKernels` (auto-detected), not manually maintained.
+- **Unblocks multi-clause lowering** — lowered functions can safely call
+  foreign predicates via `callForeign` knowing Nothing = failure.
+
+## Original Recommendation (superseded)
+
+**Option 2** (predicate-set check) was the original near-term
+recommendation. Option 4 was implemented instead because it avoids
+runtime overhead entirely and emerged from the observation that the
+`foreignPreds` list was already known at compile time.
 
 ## Scope
 
@@ -156,18 +208,17 @@ This proposal covers only the dispatch semantics. It does NOT cover:
 
 - Which predicates to lower (that's the kernel detection work).
 - How to lower multi-clause predicates (that's the emitter design).
-- Whether the Rust target should adopt `wcLoweredPredicates` too
-  (separate discussion).
+- Whether the Rust/LLVM targets should adopt `CallForeign` too
+  (separate discussion — the same pattern applies).
 
 ## References
 
 - #1344 — feat: WAM-lowered Haskell Phases 1–4
 - #1346 — fix: dispatch priority + single-clause restriction
+- #1354 — feat: CallForeign instruction (this resolution)
 - `docs/design/WAM_HASKELL_LOWERED_BACKGROUND.md` — taxonomy of
   Haskell code-gen paths
 - `docs/design/WAM_HASKELL_LOWERED_SPECIFICATION.md` §2.1 — the
   `wcLoweredPredicates` dispatch mechanism
-- `src/unifyweaver/targets/wam_rust_target.pl:1255` —
-  `execute_foreign_predicate` (Rust equivalent)
-- `src/unifyweaver/targets/wam_haskell_target.pl:608` —
-  `executeForeign` (Haskell)
+- `src/unifyweaver/targets/wam_haskell_target.pl` —
+  `resolveCallInstrs`, `step (CallForeign ...)`, `callForeign`

--- a/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
@@ -111,12 +111,15 @@ lower_predicate_to_haskell(PI, WamCode, Opts, lowered(PredName, FuncName, Code))
     format(atom(FuncName), 'lowered_~w_~w', [Pred, Arity]),
     % base_pc(N) offsets local PCs to match the global merged instruction array.
     ( member(base_pc(BasePC), Opts) -> true ; BasePC = 1 ),
+    % foreign_preds(List) — predicate keys with CallForeign dispatch.
+    ( member(foreign_preds(ForeignPreds), Opts) -> true ; ForeignPreds = [] ),
     parse_wam_text(WamCode, PCInstrs, LabelMap),
     % Offset all PCs: local PC 1 maps to global BasePC.
     Offset is BasePC - 1,
     offset_pcs(PCInstrs, Offset, GlobalPCInstrs),
     offset_labels(LabelMap, Offset, GlobalLabelMap),
-    with_output_to(string(Code), emit_func(FuncName, GlobalPCInstrs, GlobalLabelMap)).
+    with_output_to(string(Code),
+        emit_func(FuncName, GlobalPCInstrs, GlobalLabelMap, ForeignPreds)).
 
 offset_pcs([], _, []).
 offset_pcs([pc(PC, I)|Rest], Off, [pc(GPC, I)|Rest2]) :-
@@ -128,7 +131,7 @@ offset_labels([L-PC|Rest], Off, [L-GPC|Rest2]) :-
     GPC is PC + Off,
     offset_labels(Rest, Off, Rest2).
 
-emit_func(FN, PCInstrs, LabelMap) :-
+emit_func(FN, PCInstrs, LabelMap, ForeignPreds) :-
     format("-- | Lowered: ~w~n", [FN]),
     format("~w :: WamContext -> WamState -> Maybe WamState~n", [FN]),
     % Multi-clause: push CP, try clause 1, if it fails backtrack into
@@ -152,73 +155,73 @@ emit_func(FN, PCInstrs, LabelMap) :-
         format("  where~n"),
         format("    clause1 s_c1 = do~n"),
         take_to_proceed_pc(BodyPCs, Clause1PCs),
-        emit_instrs(Clause1PCs, "s_c1", "      ")
+        emit_instrs(Clause1PCs, "s_c1", "      ", ForeignPreds)
     ;   % Single-clause: simple do-notation
         format("~w !ctx s_init = do~n", [FN]),
-        emit_instrs(PCInstrs, "s_init", "  ")
+        emit_instrs(PCInstrs, "s_init", "  ", ForeignPreds)
     ).
 
 take_to_proceed_pc([], []).
 take_to_proceed_pc([pc(PC, proceed)|_], [pc(PC, proceed)]) :- !.
 take_to_proceed_pc([H|T], [H|R]) :- take_to_proceed_pc(T, R).
 
-%% emit_instrs(+PCInstrs, +CurrentStateVar, +IndentPrefix)
+%% emit_instrs(+PCInstrs, +CurrentStateVar, +IndentPrefix, +ForeignPreds)
 %  Emit one line of do-notation per instruction, threading state vars.
-emit_instrs([], _, _).
-emit_instrs([pc(PC, Instr)|Rest], SV, Ind) :-
-    emit_one(Instr, PC, SV, SVout, Ind),
-    emit_instrs(Rest, SVout, Ind).
+emit_instrs([], _, _, _).
+emit_instrs([pc(PC, Instr)|Rest], SV, Ind, FP) :-
+    emit_one(Instr, PC, SV, SVout, Ind, FP),
+    emit_instrs(Rest, SVout, Ind, FP).
 
-%% emit_one(+Instr, +PC, +StateVarIn, -StateVarOut, +IndentPrefix)
+%% emit_one(+Instr, +PC, +StateVarIn, -StateVarOut, +IndentPrefix, +ForeignPreds)
 %  Emit do-notation for a single instruction.
 
 % Terminal: proceed
-emit_one(proceed, _, SV, SV, I) :-
+emit_one(proceed, _, SV, SV, I, _FP) :-
     format("~wlet ret_ = wsCP ~w~n", [I, SV]),
     format("~wif ret_ == 0 then Just (~w { wsPC = 0 }) else Just (~w { wsPC = ret_, wsCP = 0 })~n",
            [I, SV, SV]).
 
 % Allocate — always succeeds, use let
-emit_one(allocate, _, SV, SVout, I) :-
+emit_one(allocate, _, SV, SVout, I, _FP) :-
     fresh_sv(SV, SVout),
     format("~wlet ~w = ~w { wsStack = EnvFrame (wsCP ~w) IM.empty : wsStack ~w, wsCutBar = wsCPsLen ~w }~n",
            [I, SVout, SV, SV, SV, SV]).
 
 % Deallocate — use step
-emit_one(deallocate, PC, SV, SVout, I) :-
+emit_one(deallocate, PC, SV, SVout, I, _FP) :-
     fresh_sv(SV, SVout),
     format("~w~w <- step ctx (~w { wsPC = ~w }) Deallocate~n", [I, SVout, SV, PC]).
 
 % GetVariable Xn Ai — always succeeds, inline register copy
-emit_one(get_variable(XnStr, AiStr), _, SV, SVout, I) :-
+emit_one(get_variable(XnStr, AiStr), _, SV, SVout, I, _FP) :-
     reg_to_int(XnStr, Xn), reg_to_int(AiStr, Ai),
     fresh_sv(SV, SVout),
     format("~wlet ~w = ~w { wsRegs = IM.insert ~w (derefVar (wsBindings ~w) (fromMaybe (Atom \"\") (IM.lookup ~w (wsRegs ~w)))) (wsRegs ~w) }~n",
            [I, SVout, SV, Xn, SV, Ai, SV, SV]).
 
 % GetConstant C Ai — can fail, use step
-emit_one(get_constant(CStr, AiStr), PC, SV, SVout, I) :-
+emit_one(get_constant(CStr, AiStr), PC, SV, SVout, I, _FP) :-
     val_hs(CStr, HC), reg_to_int(AiStr, Ai),
     fresh_sv(SV, SVout),
     format("~w~w <- step ctx (~w { wsPC = ~w }) (GetConstant (~w) ~w)~n",
            [I, SVout, SV, PC, HC, Ai]).
 
 % GetValue — can fail (unification), use step
-emit_one(get_value(XnStr, AiStr), PC, SV, SVout, I) :-
+emit_one(get_value(XnStr, AiStr), PC, SV, SVout, I, _FP) :-
     reg_to_int(XnStr, Xn), reg_to_int(AiStr, Ai),
     fresh_sv(SV, SVout),
     format("~w~w <- step ctx (~w { wsPC = ~w }) (GetValue ~w ~w)~n",
            [I, SVout, SV, PC, Xn, Ai]).
 
 % PutValue Xn Ai — always succeeds, inline
-emit_one(put_value(XnStr, AiStr), _, SV, SVout, I) :-
+emit_one(put_value(XnStr, AiStr), _, SV, SVout, I, _FP) :-
     reg_to_int(XnStr, Xn), reg_to_int(AiStr, Ai),
     fresh_sv(SV, SVout),
     format("~wlet ~w = ~w { wsRegs = IM.insert ~w (fromMaybe (Atom \"\") (getReg ~w ~w)) (wsRegs ~w) }~n",
            [I, SVout, SV, Ai, Xn, SV, SV]).
 
 % PutVariable Xn Ai — always succeeds, inline (creates fresh Unbound)
-emit_one(put_variable(XnStr, AiStr), _, SV, SVout, I) :-
+emit_one(put_variable(XnStr, AiStr), _, SV, SVout, I, _FP) :-
     reg_to_int(XnStr, Xn), reg_to_int(AiStr, Ai),
     fresh_sv(SV, SVout),
     format("~wlet v_~w = Unbound (wsVarCounter ~w)~n", [I, SVout, SV]),
@@ -226,47 +229,52 @@ emit_one(put_variable(XnStr, AiStr), _, SV, SVout, I) :-
            [I, SVout, Xn, SVout, SV, Ai, SVout, Xn, SVout, SV, SV]).
 
 % PutConstant C Ai — always succeeds, inline
-emit_one(put_constant(CStr, AiStr), _, SV, SVout, I) :-
+emit_one(put_constant(CStr, AiStr), _, SV, SVout, I, _FP) :-
     val_hs(CStr, HC), reg_to_int(AiStr, Ai),
     fresh_sv(SV, SVout),
     format("~wlet ~w = ~w { wsRegs = IM.insert ~w (~w) (wsRegs ~w) }~n",
            [I, SVout, SV, Ai, HC, SV]).
 
 % PutStructure, PutList, SetValue, SetConstant — delegate to step
-emit_one(put_structure(FnStr, AiStr), PC, SV, SVout, I) :-
+emit_one(put_structure(FnStr, AiStr), PC, SV, SVout, I, _FP) :-
     reg_to_int(AiStr, Ai),
     parse_functor(FnStr, FuncName, Arity),
     fresh_sv(SV, SVout),
     format("~w~w <- step ctx (~w { wsPC = ~w }) (PutStructure \"~w\" ~w ~w)~n",
            [I, SVout, SV, PC, FuncName, Ai, Arity]).
 
-emit_one(put_list(AiStr), PC, SV, SVout, I) :-
+emit_one(put_list(AiStr), PC, SV, SVout, I, _FP) :-
     reg_to_int(AiStr, Ai),
     fresh_sv(SV, SVout),
     format("~w~w <- step ctx (~w { wsPC = ~w }) (PutList ~w)~n",
            [I, SVout, SV, PC, Ai]).
 
-emit_one(set_value(XnStr), PC, SV, SVout, I) :-
+emit_one(set_value(XnStr), PC, SV, SVout, I, _FP) :-
     reg_to_int(XnStr, Xn),
     fresh_sv(SV, SVout),
     format("~w~w <- step ctx (~w { wsPC = ~w }) (SetValue ~w)~n",
            [I, SVout, SV, PC, Xn]).
 
-emit_one(set_constant(CStr), PC, SV, SVout, I) :-
+emit_one(set_constant(CStr), PC, SV, SVout, I, _FP) :-
     val_hs(CStr, HC),
     fresh_sv(SV, SVout),
     format("~w~w <- step ctx (~w { wsPC = ~w }) (SetConstant (~w))~n",
            [I, SVout, SV, PC, HC]).
 
-% Call — use dispatchCall helper
-emit_one(call(PredStr, _NStr), PC, SV, SVout, I) :-
+% Call — use callForeign for known foreign preds, dispatchCall otherwise
+emit_one(call(PredStr, _NStr), PC, SV, SVout, I, FP) :-
     RetPC is PC + 1,
     fresh_sv(SV, SVout),
-    format("~w~w <- dispatchCall ctx \"~w\" (~w { wsCP = ~w })~n",
-           [I, SVout, PredStr, SV, RetPC]).
+    atom_string(PredAtom, PredStr),
+    (   member(PredAtom, FP)
+    ->  format("~w~w <- callForeign ctx \"~w\" (~w { wsCP = ~w })~n",
+               [I, SVout, PredStr, SV, RetPC])
+    ;   format("~w~w <- dispatchCall ctx \"~w\" (~w { wsCP = ~w })~n",
+               [I, SVout, PredStr, SV, RetPC])
+    ).
 
 % BuiltinCall — delegate to step
-emit_one(builtin_call(OpStr, NStr), PC, SV, SVout, I) :-
+emit_one(builtin_call(OpStr, NStr), PC, SV, SVout, I, _FP) :-
     escape_bs(OpStr, EOp),
     fresh_sv(SV, SVout),
     format("~w~w <- step ctx (~w { wsPC = ~w }) (BuiltinCall \"~w\" ~w)~n",

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -152,16 +152,20 @@ wam_haskell_predicate_wamcode(PredIndicator, WamCode) :-
     ),
     wam_target:compile_predicate_to_wam(Pred/Arity, [], WamCode).
 
-%% lower_all(+LoweredList, +BasePCMap, -LoweredEntries)
+%% lower_all(+LoweredList, +BasePCMap, +DetectedKernels, -LoweredEntries)
 %  Run the Phase 3+ emitter over each predicate in LoweredList, using
 %  BasePCMap (a list of PredIndicator-StartPC pairs computed from the
 %  merged instruction array) to offset local PCs to global PCs.
-lower_all([], _, []).
-lower_all([P|Rest], BasePCMap, [Entry|RestEntries]) :-
+%  DetectedKernels (Key-Kernel pairs) is passed through so the emitter
+%  can emit callForeign for known foreign predicates.
+lower_all([], _, _, []).
+lower_all([P|Rest], BasePCMap, DetectedKernels, [Entry|RestEntries]) :-
     wam_haskell_predicate_wamcode(P, WamCode),
     predicate_base_pc(P, BasePCMap, BasePC),
-    lower_predicate_to_haskell(P, WamCode, [base_pc(BasePC)], Entry),
-    lower_all(Rest, BasePCMap, RestEntries).
+    pairs_keys(DetectedKernels, ForeignKeys),
+    lower_predicate_to_haskell(P, WamCode,
+        [base_pc(BasePC), foreign_preds(ForeignKeys)], Entry),
+    lower_all(Rest, BasePCMap, DetectedKernels, RestEntries).
 
 predicate_base_pc(P, Map, PC) :-
     (   P = _Mod:Pred/Arity -> true ; P = Pred/Arity ),
@@ -1009,23 +1013,23 @@ step !ctx s (SetConstant c) =
 step !ctx s (CallResolved pc _arity) =
   Just (s { wsPC = pc, wsCP = wsPC s + 1 })
 
--- Call dispatch priority: hand-written FFI (executeForeign) takes precedence
--- over automated lowering (wcLoweredPredicates). This is critical because
--- FFI handlers like nativeCategoryAncestor do the full depth-bounded search
--- natively, while the lowered function only handles clause 1 and relies on
--- the interpreter for clause 2+ recursion (which is exponentially slower
--- for deep search trees).
+-- Foreign call: compile-time resolved. executeForeign is the sole dispatch
+-- path — Nothing means no solutions (backtrack), never fallthrough.
+step !ctx s (CallForeign pred _arity) =
+  executeForeign ctx pred (s { wsCP = wsPC s + 1 })
+
+-- Call dispatch for non-foreign, non-resolved predicates. Foreign predicates
+-- are handled by CallForeign (resolved at compile time), so executeForeign
+-- is NOT checked here — no ambiguity between "unhandled" and "no solutions".
 step !ctx s (Call pred _arity) =
   let sc = s { wsCP = wsPC s + 1 }
-  in case executeForeign ctx pred sc of
-    Just sr -> Just sr
-    Nothing -> case Map.lookup pred (wcLoweredPredicates ctx) of
-      Just fn -> fn ctx sc
-      Nothing -> case callIndexedFact2 ctx pred sc of
-        Just sr -> Just sr
-        Nothing -> case Map.lookup pred (wcLabels ctx) of
-          Just pc -> Just (s { wsPC = pc, wsCP = wsPC s + 1 })
-          Nothing -> Nothing
+  in case Map.lookup pred (wcLoweredPredicates ctx) of
+    Just fn -> fn ctx sc
+    Nothing -> case callIndexedFact2 ctx pred sc of
+      Just sr -> Just sr
+      Nothing -> case Map.lookup pred (wcLabels ctx) of
+        Just pc -> Just (s { wsPC = pc, wsCP = wsPC s + 1 })
+        Nothing -> Nothing
 
 step !ctx s Proceed =
   let ret = wsCP s
@@ -1332,21 +1336,25 @@ run !ctx !s
 
 -- | Dispatch a Call to another predicate, trying all resolution paths.
 -- Used by lowered predicate functions for inter-predicate calls.
--- Priority: FFI (executeForeign) > lowered > indexed-facts > labels.
--- FFI takes precedence because hand-written native handlers (e.g.
--- nativeCategoryAncestor) handle full recursive search natively.
+-- Non-foreign call dispatch for lowered functions. Foreign predicates
+-- are dispatched via callForeign (compile-time resolved), so
+-- executeForeign is NOT checked here.
 {-# NOINLINE dispatchCall #-}
 dispatchCall :: WamContext -> String -> WamState -> Maybe WamState
 dispatchCall !ctx pred !sc =
-  case executeForeign ctx pred sc of
-    Just sr -> Just sr
-    Nothing -> case Map.lookup pred (wcLoweredPredicates ctx) of
-      Just fn -> fn ctx sc
-      Nothing -> case callIndexedFact2 ctx pred sc of
-        Just sr -> Just sr
-        Nothing -> case Map.lookup pred (wcLabels ctx) of
-          Just pc -> run ctx (sc { wsPC = pc })
-          Nothing -> Nothing'.
+  case Map.lookup pred (wcLoweredPredicates ctx) of
+    Just fn -> fn ctx sc
+    Nothing -> case callIndexedFact2 ctx pred sc of
+      Just sr -> Just sr
+      Nothing -> case Map.lookup pred (wcLabels ctx) of
+        Just pc -> run ctx (sc { wsPC = pc })
+        Nothing -> Nothing
+
+-- Foreign call for lowered functions. Calls executeForeign directly;
+-- Nothing means no solutions (backtrack). No fallthrough.
+{-# INLINE callForeign #-}
+callForeign :: WamContext -> String -> WamState -> Maybe WamState
+callForeign !ctx pred !sc = executeForeign ctx pred sc'.
 
 % ============================================================================
 % PHASE 4: Project Generation
@@ -1413,7 +1421,7 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     % array so the lowered functions' PC references (wsCP for Call return
     % addresses, wsPC for step calls) are correct.
     compute_base_pcs(Predicates, BasePCMap),
-    lower_all(LoweredList, BasePCMap, LoweredEntries),
+    lower_all(LoweredList, BasePCMap, DetectedKernels, LoweredEntries),
     generate_lowered_hs(LoweredEntries, LoweredCode0),
     apply_hashmap_rewrite(UseHM, generic, LoweredCode0, LoweredCode),
     directory_file_path(SrcDir, 'Lowered.hs', LoweredPath),
@@ -1745,17 +1753,15 @@ fetchInstr pc code
 unsafeFetchInstr :: Int -> Array Int Instruction -> Instruction
 unsafeFetchInstr pc code = code ! pc
 
--- | Resolve Call instructions to CallResolved by looking up labels once at
--- project load time. Calls to predicates that have foreign/indexed handlers
--- (e.g., category_ancestor/4 via FFI, category_parent/2 via indexed facts)
--- are LEFT as Call so the runtime dispatch chain still applies. Only Call
--- targets that have a matching label and no foreign/indexed override are
--- pre-resolved to a direct PC jump.
+-- | Resolve Call instructions at project load time:
+--   - Foreign predicates (detected kernels) → CallForeign (direct FFI, Nothing = fail)
+--   - Known labels → CallResolved (direct PC jump, no dispatch)
+--   - Everything else → left as Call (runtime dispatch chain)
 resolveCallInstrs :: Map.Map String Int -> [String] -> [Instruction] -> [Instruction]
 resolveCallInstrs labels foreignPreds = map resolve
   where
     resolve (Call pred arity)
-      | pred `elem` foreignPreds = Call pred arity   -- keep dispatch
+      | pred `elem` foreignPreds = CallForeign pred arity
       | otherwise = case Map.lookup pred labels of
           Just pc -> CallResolved pc arity
           Nothing -> Call pred arity   -- unresolvable, leave as-is
@@ -1875,6 +1881,7 @@ data Instruction
   | Deallocate
   | Call String !Int                  -- pre-resolution form (string-keyed)
   | CallResolved !Int !Int            -- post-resolution: target PC + arity
+  | CallForeign String !Int           -- compile-time resolved foreign pred (Nothing = fail)
   | Execute String
   | Proceed
   | BuiltinCall String !Int

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -214,9 +214,55 @@ test_multi_kernel_execute_foreign :-
     ;   fail_test(Test, 'Multi-kernel executeForeign generation failed')
     ).
 
+%% Phase 8: CallForeign instruction codegen
+%% -------------------------------------------
+
+test_call_foreign_in_types :-
+    Test = 'WAM-Haskell: CallForeign in Instruction data type',
+    (   wam_haskell_target:generate_wam_types_hs(Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "CallForeign String !Int")
+    ->  pass(Test)
+    ;   fail_test(Test, 'CallForeign not in Instruction data type')
+    ).
+
+test_call_foreign_step_case :-
+    Test = 'WAM-Haskell: CallForeign step case dispatches to executeForeign',
+    (   compile_wam_runtime_to_haskell([], [], Code),
+        atom_string(Code, S),
+        %% CallForeign step calls executeForeign directly
+        sub_string(S, _, _, _, "step !ctx s (CallForeign pred _arity)"),
+        sub_string(S, _, _, _, "executeForeign ctx pred"),
+        %% Call step does NOT call executeForeign (removed from fallthrough)
+        %% The Call case should have wcLoweredPredicates but NOT executeForeign
+        sub_string(S, _, _, _, "step !ctx s (Call pred _arity)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'CallForeign step case missing or Call still has executeForeign')
+    ).
+
+test_call_foreign_resolve :-
+    Test = 'WAM-Haskell: resolveCallInstrs produces CallForeign',
+    (   compile_wam_runtime_to_haskell([], [], Code),
+        atom_string(Code, S),
+        %% resolveCallInstrs should map foreign preds to CallForeign
+        sub_string(S, _, _, _, "CallForeign pred arity")
+    ->  pass(Test)
+    ;   fail_test(Test, 'resolveCallInstrs does not produce CallForeign')
+    ).
+
+test_call_foreign_helper :-
+    Test = 'WAM-Haskell: callForeign helper for lowered functions',
+    (   compile_wam_runtime_to_haskell([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "callForeign :: WamContext -> String -> WamState -> Maybe WamState"),
+        sub_string(S, _, _, _, "callForeign !ctx pred !sc = executeForeign ctx pred sc")
+    ->  pass(Test)
+    ;   fail_test(Test, 'callForeign helper missing from WamRuntime')
+    ).
+
 run_tests :-
     format('~n========================================~n'),
-    format('WAM-Haskell target: Phase 5+6+7 codegen tests~n'),
+    format('WAM-Haskell target: Phase 5+6+7+8 codegen tests~n'),
     format('========================================~n~n'),
     test_haskell_helper_functions_present,
     test_haskell_functor_builtin_present,
@@ -230,6 +276,10 @@ run_tests :-
     test_transitive_closure_kernel_function,
     test_transitive_closure_execute_foreign,
     test_multi_kernel_execute_foreign,
+    test_call_foreign_in_types,
+    test_call_foreign_step_case,
+    test_call_foreign_resolve,
+    test_call_foreign_helper,
     format('~n========================================~n'),
     (   test_failed
     ->  format('Tests FAILED~n'), halt(1)


### PR DESCRIPTION
  ## Summary
  - Add `CallForeign` instruction that resolves the no-handler vs no-solutions ambiguity at compile time, eliminating the
  dispatch priority workaround that blocked multi-clause lowering
  - `resolveCallInstrs` now maps detected-kernel predicates to `CallForeign` (direct FFI, `Nothing` = fail) instead of
  leaving them as `Call` (runtime fallthrough)
  - Remove `executeForeign` from the `Call` step dispatch chain — foreign predicates are handled exclusively by
  `CallForeign`, non-foreign by `Call`
  - Add `callForeign` helper for lowered functions and thread `foreign_preds` through the lowered emitter pipeline
  - Update `WAM_FOREIGN_DISPATCH_RETURN_TYPE.md` proposal: mark resolved, document the implemented Option 4 (compile-time
  instruction resolution)

  ## Test plan
  - [x] All 16 codegen tests pass (`test_wam_haskell_target.pl`)
  - [x] 4 new tests: `CallForeign` in data type, step case, `resolveCallInstrs` output, `callForeign` helper
  - [x] Phase 1 + Phase 3 lowered emitter tests still pass
  - [ ] Full benchmark run after merge to verify no performance regression

  🤖 Generated with [Claude Code](https://claude.com/claude-code)