### PR TITLE
feat(csharp-query): add weighted min product strategy

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -121,8 +121,8 @@ The next concrete coding step should start here:
 
 - compare this weighted `Min` fallback against another non-DAG path-state
   workload before adding more generic indexes
-- keep multiplicative-specific transforms separate unless the next benchmark
-  still points specifically at non-additive weighted recurrence
+- positive multiplicative weighted `Min` is now handled separately when every
+  factor is finite and at least `1`
 - preserve the current rule that fingerprints, masks, and representatives are
   only candidate filters; exact subset verification remains authoritative
 

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -266,9 +266,18 @@ The lower-cardinality prefilter step is also now implemented:
    retained dominated states are correctness-safe and the measured removals
    stayed at `0`
 
-The next coding step should keep the multiplicative-to-additive transform as a
-narrower later optimization unless a broader exact fallback workload shows that
-the remaining lower-count scans need another generic prefilter.
+The positive multiplicative step is now implemented as a direct-product layered
+strategy rather than as a geometric-mean or log-output strategy:
+
+1. recurrence must be `Acc is Acc1 * Factor` with the base expression matching
+   `Factor`
+2. every reachable factor must be finite and at least `1`
+3. subunit factors stay on the exact frontier fallback because they would
+   become negative steps under a log transform
+4. the runtime minimizes products directly, avoiding log/exp output drift
+
+The next coding step should compare another exact non-DAG fallback workload
+before adding more generic frontier indexes.
 
 ## Frontier Fallback Metric Survey
 
@@ -284,17 +293,23 @@ python examples/benchmark/benchmark_weighted_shortest_path.py \
   --recurrence-mode multiplicative
 ```
 
-Both fallback cases preserve output agreement between `All` and `Min`. After
-lazy lower-count representative prefiltering, the exact `Min` fallback is still
-slower than `All` on these benchmark-scale cyclic cases, but it is faster than
-the previous path-state partitioning-only fallback.
+The negative-additive fallback preserves output agreement between `All` and
+`Min`. After lazy lower-count representative prefiltering, the exact `Min`
+fallback is still slower than `All` on these benchmark-scale cyclic cases, but
+it is faster than the previous path-state partitioning-only fallback.
 
 | Shape | Scale | All | Min | Speedup | Dominance Candidates | Lower Candidates | Index Probes | Subset Checks |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | negative additive | 300 | 0.871s | 1.478s | 0.59x | 20,404,270 | 19,826,544 | 912,133 | 12,621 |
 | negative additive | 1k | 0.563s | 1.217s | 0.46x | 16,522,183 | 16,183,799 | 1,138,494 | 11,157 |
-| multiplicative | 300 | 0.819s | 1.064s | 0.77x | 8,013,834 | 7,617,196 | 209,002 | 92,019 |
-| multiplicative | 1k | 0.563s | 0.856s | 0.66x | 7,601,868 | 7,370,947 | 302,487 | 59,735 |
+
+Positive multiplicative recurrence now uses the product layered strategy on the
+benchmark shape:
+
+| Shape | Scale | All | Min | Speedup | Strategy |
+| --- | ---: | ---: | ---: | ---: | --- |
+| multiplicative | 300 | 0.892s | 0.264s | 3.38x | `PathAwareAccumulationSeededMinNonNegativeMultiplicativeLayered` |
+| multiplicative | 1k | 0.587s | 0.212s | 2.76x | `PathAwareAccumulationSeededMinNonNegativeMultiplicativeLayered` |
 
 Interpretation:
 
@@ -307,6 +322,8 @@ Interpretation:
 - `min_frontier_removed_state_count` stayed at `0` for these runs, so the
   runtime avoids eager removal scans and keeps dominated retained states as a
   correctness-safe tradeoff
+- positive multiplicative recurrence no longer contributes frontier counters on
+  the benchmark shape because it does not enter the fallback
 - the remaining candidate scans are low enough that the next broad optimization
-  should probably move to a different fallback class or the narrower
-  multiplicative transform before adding more generic frontier indexes
+  should probably move to a different fallback class before adding more generic
+  frontier indexes

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_SPEC.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_SPEC.md
@@ -49,7 +49,8 @@ The fast path is only sound when all of the following hold:
 Still on the exact frontier fallback path:
 
 - negative increments
-- non-additive recurrence expressions such as `Acc is Acc1 * Factor`
+- multiplicative recurrence with any finite factor below `1`
+- non-additive recurrence expressions outside the direct positive-product form
 - `max`, `first`, `sum`, `count`
 - multi-auxiliary or non-linear accumulation beyond the current path-aware
   accumulation shape

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -939,10 +939,12 @@ fall back to the exact visited-state frontier.
 
 Use `--weight-mode negative --recurrence-mode additive` to force the exact
 frontier fallback for negative additive steps. Use
-`--weight-mode positive --recurrence-mode multiplicative` to force the exact
-frontier fallback for positive multiplicative recurrence. These variants emit
-the `min_frontier_*` trace metrics used to profile candidate growth, dominance
-checks, subset checks, target buckets, and retained path-state partition sizes.
+`--weight-mode positive --recurrence-mode multiplicative` to exercise the
+direct positive-product `Min` strategy when every factor is at least one.
+Subunit multiplicative factors remain on the exact frontier fallback. Fallback
+variants emit the `min_frontier_*` trace metrics used to profile candidate
+growth, dominance checks, subset checks, target buckets, and retained
+path-state partition sizes.
 
 Latest local results:
 
@@ -979,15 +981,21 @@ trace label, while zero-cost non-negative steps report
 `metric_scc_probe_outer_dag_states_explored`; on the current benchmark
 shape the selector keeps the layered path when the SCC probe is slower.
 
-Fallback metric runs on `300` and `1k` now use exact path-state partitioning for
-weighted `Min` frontier states plus lazy lower-count representative prefilters.
+Negative-additive fallback metric runs on `300` and `1k` now use exact
+path-state partitioning for weighted `Min` frontier states plus lazy
+lower-count representative prefilters.
 The negative-additive fallback reached `20,404,270` dominance-candidate checks
 at `300` and `16,522,183` at `1k`, down from the previous path-partition-only
-counts of `34,704,185` and `35,271,278`. The multiplicative fallback reached
-`8,013,834` at `300` and `7,601,868` at `1k`, down from `10,906,078` and
-`11,043,000`. Output agreement still reports `match`; the remaining fallback
-work is mostly lower-count dominance probing, now measured separately from
-same-fingerprint checks.
+counts of `34,704,185` and `35,271,278`. Output agreement still reports
+`match`; the remaining fallback work is mostly lower-count dominance probing,
+now measured separately from same-fingerprint checks.
+
+Positive multiplicative `Min` no longer uses the exact frontier fallback on the
+benchmark shape. The runtime minimizes direct products with a layered strategy
+when all factors are finite and at least `1`; it does not compute a geometric
+mean or normalize by path length. Current runs report `all_vs_min=match` with
+`300`: `0.264s` `Min` and `3.38x` speedup, and `1k`: `0.212s` `Min` and
+`2.76x` speedup.
 
 ### Available Targets
 

--- a/examples/benchmark/benchmark_weighted_shortest_path.py
+++ b/examples/benchmark/benchmark_weighted_shortest_path.py
@@ -10,8 +10,9 @@ By default the harness derives a positive source weight from category out-degree
 so the recursive increment remains monotone and min-pruning is sound. The
 `--weight-mode nonnegative-zero` variant leaves degree-one sources at zero cost
 to exercise the broader non-negative additive `Min` fast path. The
-`--weight-mode negative` and `--recurrence-mode multiplicative` variants force
-the exact frontier fallback and expose its trace metrics at benchmark scale.
+`--weight-mode negative` forces the exact frontier fallback and exposes its
+trace metrics at benchmark scale. `--recurrence-mode multiplicative` exercises
+the positive product `Min` strategy when all factors are at least one.
 """
 
 from __future__ import annotations
@@ -462,7 +463,7 @@ def parse_args() -> argparse.Namespace:
         "--recurrence-mode",
         choices=["additive", "multiplicative"],
         default="additive",
-        help="Use additive accumulation or multiplicative accumulation. Multiplicative Min uses the exact frontier fallback.",
+        help="Use additive accumulation or multiplicative accumulation. Multiplicative Min uses the product layered strategy when all factors are at least one.",
     )
     parser.add_argument("--keep-temp", action="store_true")
     return parser.parse_args()

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -11257,6 +11257,16 @@ namespace UnifyWeaver.QueryRuntime
                 ? "positive_min_layered_solve"
                 : "nonnegative_min_layered_solve";
 
+        private static string GetMultiplicativeMinLayeredStrategy(string strategyPrefix, AdditiveMinStepSafety stepSafety) =>
+            stepSafety == AdditiveMinStepSafety.StrictlyPositive
+                ? $"{strategyPrefix}PositiveMultiplicativeLayered"
+                : $"{strategyPrefix}NonNegativeMultiplicativeLayered";
+
+        private static string GetMultiplicativeMinLayeredSolvePhase(AdditiveMinStepSafety stepSafety) =>
+            stepSafety == AdditiveMinStepSafety.StrictlyPositive
+                ? "positive_multiplicative_min_layered_solve"
+                : "nonnegative_multiplicative_min_layered_solve";
+
         private static void RecordPathAwareSccGraphMetrics(QueryExecutionTrace? trace, PlanNode node, PathAwareSccGraph graph)
         {
             trace?.RecordMetric(node, "scc_node_count", graph.NodeCount);
@@ -12469,6 +12479,18 @@ namespace UnifyWeaver.QueryRuntime
                         closure.PositiveStepProven,
                         out stepEvaluator,
                         out additiveMinStepSafety);
+                var useMultiplicativeMinFastPath = false;
+                if (!useAdditiveMinFastPath && closure.AccumulatorMode == TableMode.Min && closure.MaxDepth > 0)
+                {
+                    useMultiplicativeMinFastPath = TryCreateNonNegativeMultiplicativeStepEvaluator(
+                        closure.BaseExpression,
+                        closure.RecursiveExpression,
+                        succIndex,
+                        auxIndex,
+                        out stepEvaluator,
+                        out additiveMinStepSafety);
+                }
+
                 PathAwareSccGraph? sccGraph = null;
                 var useSccCondensedMinFastPath = false;
                 if (useAdditiveMinFastPath)
@@ -12515,6 +12537,10 @@ namespace UnifyWeaver.QueryRuntime
                         ? "PathAwareAccumulationMinSccCondensed"
                         : GetAdditiveMinLayeredStrategy("PathAwareAccumulationMin", additiveMinStepSafety));
                 }
+                else if (useMultiplicativeMinFastPath)
+                {
+                    trace?.RecordStrategy(closure, GetMultiplicativeMinLayeredStrategy("PathAwareAccumulationMin", additiveMinStepSafety));
+                }
                 else if (closure.AccumulatorMode == TableMode.Min)
                 {
                     trace?.RecordStrategy(closure, "PathAwareAccumulationMinFrontierFallback");
@@ -12524,7 +12550,8 @@ namespace UnifyWeaver.QueryRuntime
                 long localStates = 0;
                 long outerDagStates = 0;
                 long queuePops = 0;
-                var frontierMetrics = useAdditiveMinFastPath
+                var useLayeredMinFastPath = useAdditiveMinFastPath || useMultiplicativeMinFastPath;
+                var frontierMetrics = useLayeredMinFastPath
                     ? null
                     : new PathAwareMinFrontierMetrics();
                 void BuildAccumulationRows()
@@ -12542,6 +12569,10 @@ namespace UnifyWeaver.QueryRuntime
                         {
                             AppendPositiveMinAccumulationRowsForSeed(seed, succIndex, auxIndex, stepEvaluator!, totalRows, closure.MaxDepth);
                         }
+                        else if (useMultiplicativeMinFastPath)
+                        {
+                            AppendPositiveProductMinAccumulationRowsForSeed(seed, succIndex, auxIndex, stepEvaluator!, totalRows, closure.MaxDepth);
+                        }
                         else
                         {
                             AppendPathAwareAccumulationRowsForSeed(seed, succIndex, auxIndex, closure.BaseExpression, closure.RecursiveExpression, totalRows, closure.AccumulatorMode, closure.MaxDepth, frontierMetrics);
@@ -12556,6 +12587,10 @@ namespace UnifyWeaver.QueryRuntime
                 else if (useAdditiveMinFastPath)
                 {
                     MeasurePhase(trace, closure, GetAdditiveMinLayeredSolvePhase(additiveMinStepSafety), BuildAccumulationRows);
+                }
+                else if (useMultiplicativeMinFastPath)
+                {
+                    MeasurePhase(trace, closure, GetMultiplicativeMinLayeredSolvePhase(additiveMinStepSafety), BuildAccumulationRows);
                 }
                 else
                 {
@@ -12618,6 +12653,18 @@ namespace UnifyWeaver.QueryRuntime
                         closure.PositiveStepProven,
                         out stepEvaluator,
                         out additiveMinStepSafety);
+                var useMultiplicativeMinFastPath = false;
+                if (!useAdditiveMinFastPath && closure.AccumulatorMode == TableMode.Min && closure.MaxDepth > 0)
+                {
+                    useMultiplicativeMinFastPath = TryCreateNonNegativeMultiplicativeStepEvaluator(
+                        closure.BaseExpression,
+                        closure.RecursiveExpression,
+                        succIndex,
+                        auxIndex,
+                        out stepEvaluator,
+                        out additiveMinStepSafety);
+                }
+
                 PathAwareSccGraph? sccGraph = null;
                 var useSccCondensedMinFastPath = false;
                 if (useAdditiveMinFastPath)
@@ -12687,6 +12734,10 @@ namespace UnifyWeaver.QueryRuntime
                         ? "PathAwareAccumulationSeededMinSccCondensed"
                         : GetAdditiveMinLayeredStrategy("PathAwareAccumulationSeededMin", additiveMinStepSafety));
                 }
+                else if (useMultiplicativeMinFastPath)
+                {
+                    trace?.RecordStrategy(closure, GetMultiplicativeMinLayeredStrategy("PathAwareAccumulationSeededMin", additiveMinStepSafety));
+                }
                 else if (closure.AccumulatorMode == TableMode.Min)
                 {
                     trace?.RecordStrategy(closure, "PathAwareAccumulationSeededMinFrontierFallback");
@@ -12696,7 +12747,8 @@ namespace UnifyWeaver.QueryRuntime
                 long localStates = 0;
                 long outerDagStates = 0;
                 long queuePops = 0;
-                var frontierMetrics = useAdditiveMinFastPath
+                var useLayeredMinFastPath = useAdditiveMinFastPath || useMultiplicativeMinFastPath;
+                var frontierMetrics = useLayeredMinFastPath
                     ? null
                     : new PathAwareMinFrontierMetrics();
                 void BuildAccumulationRows()
@@ -12714,6 +12766,10 @@ namespace UnifyWeaver.QueryRuntime
                         {
                             AppendPositiveMinAccumulationRowsForSeed(seed, succIndex, auxIndex, stepEvaluator!, totalRows, closure.MaxDepth);
                         }
+                        else if (useMultiplicativeMinFastPath)
+                        {
+                            AppendPositiveProductMinAccumulationRowsForSeed(seed, succIndex, auxIndex, stepEvaluator!, totalRows, closure.MaxDepth);
+                        }
                         else
                         {
                             AppendPathAwareAccumulationRowsForSeed(seed, succIndex, auxIndex, closure.BaseExpression, closure.RecursiveExpression, totalRows, closure.AccumulatorMode, closure.MaxDepth, frontierMetrics);
@@ -12728,6 +12784,10 @@ namespace UnifyWeaver.QueryRuntime
                 else if (useAdditiveMinFastPath)
                 {
                     MeasurePhase(trace, closure, GetAdditiveMinLayeredSolvePhase(additiveMinStepSafety), BuildAccumulationRows);
+                }
+                else if (useMultiplicativeMinFastPath)
+                {
+                    MeasurePhase(trace, closure, GetMultiplicativeMinLayeredSolvePhase(additiveMinStepSafety), BuildAccumulationRows);
                 }
                 else
                 {
@@ -12767,8 +12827,10 @@ namespace UnifyWeaver.QueryRuntime
             IReadOnlyDictionary<object, List<object[]>> auxIndex,
             PositiveStepEvaluator stepEvaluator,
             ICollection<object[]> output,
-            int maxDepth = 0)
+            int maxDepth = 0,
+            Func<double, object>? resultProjector = null)
         {
+            resultProjector ??= static cost => cost;
             var effectiveMaxDepth = maxDepth > 0 ? maxDepth : int.MaxValue;
             var seedKey = seed ?? NullFactIndexKey;
             var depthCosts = new List<Dictionary<object?, double>>(effectiveMaxDepth == int.MaxValue ? 16 : effectiveMaxDepth + 1)
@@ -12843,7 +12905,93 @@ namespace UnifyWeaver.QueryRuntime
                 .ToList();
             foreach (var (target, cost) in bestRows)
             {
-                output.Add(new object[] { seed!, target!, cost });
+                output.Add(new object[] { seed!, target!, resultProjector(cost) });
+            }
+        }
+
+        private void AppendPositiveProductMinAccumulationRowsForSeed(
+            object? seed,
+            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
+            IReadOnlyDictionary<object, List<object[]>> auxIndex,
+            PositiveStepEvaluator factorEvaluator,
+            ICollection<object[]> output,
+            int maxDepth = 0)
+        {
+            var effectiveMaxDepth = maxDepth > 0 ? maxDepth : int.MaxValue;
+            var seedKey = seed ?? NullFactIndexKey;
+            var depthProducts = new List<Dictionary<object?, double>>(effectiveMaxDepth == int.MaxValue ? 16 : effectiveMaxDepth + 1)
+            {
+                new Dictionary<object?, double> { [seed] = 1d }
+            };
+            var bestKnown = new Dictionary<object?, double>();
+
+            for (var depth = 0; depth < effectiveMaxDepth && depth < depthProducts.Count; depth++)
+            {
+                var currentLayer = depthProducts[depth];
+                if (currentLayer.Count == 0)
+                {
+                    continue;
+                }
+
+                foreach (var (current, currentProduct) in currentLayer)
+                {
+                    var currentKey = current ?? NullFactIndexKey;
+                    if (!succIndex.TryGetValue(currentKey, out var edgeBucket) || !auxIndex.TryGetValue(currentKey, out var auxBucket))
+                    {
+                        continue;
+                    }
+
+                    var nextDepth = depth + 1;
+                    if (nextDepth > effectiveMaxDepth)
+                    {
+                        continue;
+                    }
+
+                    while (depthProducts.Count <= nextDepth)
+                    {
+                        depthProducts.Add(new Dictionary<object?, double>());
+                    }
+
+                    var nextLayer = depthProducts[nextDepth];
+                    for (var edgeIndex = edgeBucket.Targets.Count - 1; edgeIndex >= 0; edgeIndex--)
+                    {
+                        var next = edgeBucket.Targets[edgeIndex];
+                        if (Equals(next ?? NullFactIndexKey, seedKey))
+                        {
+                            continue;
+                        }
+
+                        for (var auxIndexPos = auxBucket.Count - 1; auxIndexPos >= 0; auxIndexPos--)
+                        {
+                            var auxRow = auxBucket[auxIndexPos];
+                            if (auxRow is null || auxRow.Length < 2)
+                            {
+                                continue;
+                            }
+
+                            var factor = factorEvaluator(current!, next!, auxRow[1]!);
+                            var nextProduct = currentProduct * factor;
+
+                            if (!nextLayer.TryGetValue(next, out var existingProduct) || nextProduct < existingProduct)
+                            {
+                                nextLayer[next] = nextProduct;
+                            }
+
+                            if (!bestKnown.TryGetValue(next, out var bestProduct) || nextProduct < bestProduct)
+                            {
+                                bestKnown[next] = nextProduct;
+                            }
+                        }
+                    }
+                }
+            }
+
+            var bestRows = bestKnown
+                .OrderBy(kvp => kvp.Key, Comparer<object?>.Create(CompareCacheSeedValues))
+                .ToList();
+            foreach (var (target, product) in bestRows)
+            {
+                output.Add(new object[] { seed!, target!, product });
             }
         }
 
@@ -12959,6 +13107,75 @@ namespace UnifyWeaver.QueryRuntime
             return true;
         }
 
+        private bool TryCreateNonNegativeMultiplicativeStepEvaluator(
+            ArithmeticExpression baseExpression,
+            ArithmeticExpression recursiveExpression,
+            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
+            IReadOnlyDictionary<object, List<object[]>> auxIndex,
+            out PositiveStepEvaluator? evaluator,
+            out AdditiveMinStepSafety stepSafety)
+        {
+            evaluator = null;
+            stepSafety = AdditiveMinStepSafety.StrictlyPositive;
+            if (!TryExtractMinProductFactorExpression(baseExpression, recursiveExpression, out var factorExpression))
+            {
+                return false;
+            }
+
+            var strictlyGreaterThanOne = true;
+            foreach (var (currentKey, edgeBucket) in succIndex)
+            {
+                if (!auxIndex.TryGetValue(currentKey, out var auxBucket))
+                {
+                    continue;
+                }
+
+                foreach (var next in edgeBucket.Targets)
+                {
+                    foreach (var auxRow in auxBucket)
+                    {
+                        if (auxRow is null || auxRow.Length < 2)
+                        {
+                            continue;
+                        }
+
+                        var evalTuple = new object[] { edgeBucket.Source!, next!, 1, auxRow[1]! };
+                        var factorObject = EvaluateArithmeticExpression(factorExpression, evalTuple);
+                        double factor;
+                        try
+                        {
+                            factor = Convert.ToDouble(factorObject, CultureInfo.InvariantCulture);
+                        }
+                        catch
+                        {
+                            return false;
+                        }
+
+                        if (!double.IsFinite(factor) || !(factor >= 1d))
+                        {
+                            return false;
+                        }
+
+                        if (!(factor > 1d))
+                        {
+                            strictlyGreaterThanOne = false;
+                        }
+                    }
+                }
+            }
+
+            stepSafety = strictlyGreaterThanOne
+                ? AdditiveMinStepSafety.StrictlyPositive
+                : AdditiveMinStepSafety.NonNegative;
+            evaluator = (current, next, auxValue) =>
+            {
+                var evalTuple = new object[] { current, next, 1, auxValue };
+                var factorObject = EvaluateArithmeticExpression(factorExpression, evalTuple);
+                return Convert.ToDouble(factorObject, CultureInfo.InvariantCulture);
+            };
+            return true;
+        }
+
         private static bool TryExtractMinStepExpression(
             ArithmeticExpression baseExpression,
             ArithmeticExpression recursiveExpression,
@@ -12984,6 +13201,37 @@ namespace UnifyWeaver.QueryRuntime
             if (add.Right is ColumnExpression { Index: 2 } && ArithmeticExpressionStructuralEquals(baseExpression, add.Left))
             {
                 stepExpression = add.Left;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryExtractMinProductFactorExpression(
+            ArithmeticExpression baseExpression,
+            ArithmeticExpression recursiveExpression,
+            out ArithmeticExpression factorExpression)
+        {
+            factorExpression = baseExpression;
+            if (ReferencesAccumulator(baseExpression))
+            {
+                return false;
+            }
+
+            if (recursiveExpression is not BinaryArithmeticExpression { Operator: ArithmeticBinaryOperator.Multiply } multiply)
+            {
+                return false;
+            }
+
+            if (multiply.Left is ColumnExpression { Index: 2 } && ArithmeticExpressionStructuralEquals(baseExpression, multiply.Right))
+            {
+                factorExpression = multiply.Right;
+                return true;
+            }
+
+            if (multiply.Right is ColumnExpression { Index: 2 } && ArithmeticExpressionStructuralEquals(baseExpression, multiply.Left))
+            {
+                factorExpression = multiply.Left;
                 return true;
             }
 

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -178,6 +178,9 @@
 :- dynamic user:test_weighted_product_min_edge/2.
 :- dynamic user:test_weighted_product_min_factor/2.
 :- dynamic user:test_weighted_product_min_path/3.
+:- dynamic user:test_weighted_discount_min_edge/2.
+:- dynamic user:test_weighted_discount_min_factor/2.
+:- dynamic user:test_weighted_discount_min_path/3.
 :- dynamic user:test_scanindex_allowed/1.
 :- dynamic user:test_scanindex_step/2.
 :- dynamic user:test_scanindex_reach_param/2.
@@ -338,7 +341,8 @@ test_csharp_query_target :-
         verify_path_aware_accumulation_positive_metadata_plan,
         verify_path_aware_accumulation_nonnegative_min_strategy_runtime,
         verify_path_aware_accumulation_negative_min_frontier_fallback_runtime,
-        verify_path_aware_accumulation_product_min_frontier_fallback_runtime,
+        verify_path_aware_accumulation_product_min_multiplicative_strategy_runtime,
+        verify_path_aware_accumulation_product_min_subunit_factor_fallback_runtime,
         verify_grouped_transitive_closure_plan,
         verify_parameterized_grouped_transitive_closure_plan,
         verify_parameterized_grouped_transitive_closure_pairs_strategy_runtime,
@@ -1338,6 +1342,26 @@ setup_test_data :-
         Acc is Acc1 * Factor
     )),
     assertz(user:'table'(test_weighted_product_min_path(_, _, min))),
+    assertz(user:test_weighted_discount_min_edge(a, b)),
+    assertz(user:test_weighted_discount_min_edge(a, c)),
+    assertz(user:test_weighted_discount_min_edge(b, a)),
+    assertz(user:test_weighted_discount_min_edge(b, d)),
+    assertz(user:test_weighted_discount_min_edge(c, d)),
+    assertz(user:test_weighted_discount_min_factor(a, 0.5)),
+    assertz(user:test_weighted_discount_min_factor(b, 3)),
+    assertz(user:test_weighted_discount_min_factor(c, 5)),
+    assertz(user:(test_weighted_discount_min_path(X, Y, Acc) :-
+        test_weighted_discount_min_edge(X, Y),
+        test_weighted_discount_min_factor(X, Factor),
+        Acc is Factor
+    )),
+    assertz(user:(test_weighted_discount_min_path(X, Z, Acc) :-
+        test_weighted_discount_min_edge(X, Y),
+        test_weighted_discount_min_factor(X, Factor),
+        test_weighted_discount_min_path(Y, Z, Acc1),
+        Acc is Acc1 * Factor
+    )),
+    assertz(user:'table'(test_weighted_discount_min_path(_, _, min))),
     assert_binary_recursive_fixture(
         test_probe_dir_forward_edge,
         test_probe_dir_forward_reach,
@@ -1579,6 +1603,9 @@ cleanup_test_data :-
     retractall(user:test_weighted_product_min_edge(_, _)),
     retractall(user:test_weighted_product_min_factor(_, _)),
     retractall(user:test_weighted_product_min_path(_, _, _)),
+    retractall(user:test_weighted_discount_min_edge(_, _)),
+    retractall(user:test_weighted_discount_min_factor(_, _)),
+    retractall(user:test_weighted_discount_min_path(_, _, _)),
     cleanup_recursive_fixture(test_probe_dir_forward_edge, test_probe_dir_forward_reach, 2),
     cleanup_recursive_fixture(test_probe_dir_backward_edge, test_probe_dir_backward_reach, 2),
     cleanup_recursive_fixture(test_probe_dir_mixed_edge, test_probe_dir_mixed_reach, 2),
@@ -3987,7 +4014,7 @@ verify_path_aware_accumulation_negative_min_frontier_fallback_runtime :-
         Params,
         HarnessSource).
 
-verify_path_aware_accumulation_product_min_frontier_fallback_runtime :-
+verify_path_aware_accumulation_product_min_multiplicative_strategy_runtime :-
     csharp_target:build_query_plan(
         test_weighted_product_min_path/3,
         [target(csharp_query)],
@@ -4003,24 +4030,45 @@ verify_path_aware_accumulation_product_min_frontier_fallback_runtime :-
     sub_string(Source, _, _, _, 'TableMode.Min'),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
     Params = [[a]],
-    weighted_min_frontier_metric_names(MetricNames),
-    weighted_min_frontier_positive_metric_names(PositiveMetricNames),
-    harness_source_with_strategy_and_metric_flags_no_reuse(
+    harness_source_with_strategy_flag_no_reuse(
+        ModuleClass,
+        Params,
+        'PathAwareAccumulationSeededMinPositiveMultiplicativeLayered',
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,b,2',
+         'a,c,2',
+         'a,d,6',
+         'STRATEGY_USED:PathAwareAccumulationSeededMinPositiveMultiplicativeLayered=true'],
+        Params,
+        HarnessSource).
+
+verify_path_aware_accumulation_product_min_subunit_factor_fallback_runtime :-
+    csharp_target:build_query_plan(
+        test_weighted_discount_min_path/3,
+        [target(csharp_query)],
+        [input, output, output],
+        Plan),
+    get_dict(is_recursive, Plan, true),
+    get_dict(root, Plan, Root),
+    get_dict(type, Root, path_aware_accumulation),
+    get_dict(head, Root, predicate{name:test_weighted_discount_min_path, arity:3}),
+    get_dict(table_modes, Root, [lattice, lattice, min]),
+    csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'PathAwareAccumulationNode'),
+    sub_string(Source, _, _, _, 'TableMode.Min'),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    Params = [[a]],
+    harness_source_with_strategy_flag_no_reuse(
         ModuleClass,
         Params,
         'PathAwareAccumulationSeededMinFrontierFallback',
-        MetricNames,
-        PositiveMetricNames,
         HarnessSource),
-    weighted_min_frontier_metric_expectations(MetricRows),
-    append(['a,b,2',
-            'a,c,2',
-            'a,d,6',
-            'STRATEGY_USED:PathAwareAccumulationSeededMinFrontierFallback=true'],
-           MetricRows,
-           ExpectedRows),
     maybe_run_query_runtime_with_harness(Plan,
-        ExpectedRows,
+        ['a,b,0.5',
+         'a,c,0.5',
+         'a,d,1.5',
+         'STRATEGY_USED:PathAwareAccumulationSeededMinFrontierFallback=true'],
         Params,
         HarnessSource).
 


### PR DESCRIPTION
 # Add weighted Min product strategy for C# query runtime

  ## Summary

  - Adds a direct product-minimization strategy for multiplicative weighted `Min` path accumulation.
  - Uses the fast layered strategy only when all reachable multiplicative factors are finite and `>= 1`.
  - Keeps subunit multiplicative factors on the exact frontier fallback to preserve correctness.
  - Updates weighted shortest-path benchmarks and docs to distinguish direct product minimization from geometric mean normalization.

  ## Validation

  - Ran focused C# query runtime tests for additive, multiplicative, and subunit fallback weighted `Min` cases.
  - Ran C# query target codegen sweep with `SKIP_CSHARP_EXECUTION=1`: `237/237` tests passed.
  - Ran weighted shortest-path benchmarks for positive additive, negative additive fallback, and positive multiplicative modes.