### PR TITLE
feat(csharp-query): survey non-dag path fallback costs

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -102,6 +102,15 @@ Measure:
 - candidate bucket sizes
 - exact verification counts
 
+Status:
+
+- weighted `Min` fallback now reports `min_frontier_*` counters for
+  dominance candidates, exact subset checks, and retained frontier buckets
+- counted simple-path closure now reports `path_state_*` counters for raw
+  traversal work: seeds, stack pops, successor candidates, cycle skips,
+  depth-limit skips, best-known pruning, enqueued states, output rows, max
+  stack size, and max path length
+
 ## Phase 7: Planner Integration
 
 Make the runtime selection explicit:
@@ -117,14 +126,34 @@ plan. On benchmark-scale cyclic fallback cases, dominance-candidate scans
 dominate the counters, retained buckets grow, and exact subset checks are not
 the main count driver.
 
-The next concrete coding step should start here:
+The requested comparison is now in place:
 
-- compare this weighted `Min` fallback against another non-DAG path-state
-  workload before adding more generic indexes
 - positive multiplicative weighted `Min` is now handled separately when every
   factor is finite and at least `1`
+- counted simple-path shortest-path runs expose `path_state_*` metrics from
+  `PathAwareTransitiveClosureNode`
 - preserve the current rule that fingerprints, masks, and representatives are
   only candidate filters; exact subset verification remains authoritative
+
+Local survey:
+
+| Workload | Scale | All | Min | Match | Main Counter |
+| --- | ---: | ---: | ---: | --- | --- |
+| counted shortest path | 300 | 0.920s | 0.246s | yes | `982,581` all-mode successor candidates |
+| counted shortest path | 1k | 0.679s | 0.162s | yes | `592,698` all-mode successor candidates |
+| negative additive weighted `Min` | 300 | 0.871s | 1.478s | yes | `20,404,270` dominance candidates |
+| negative additive weighted `Min` | 1k | 0.563s | 1.217s | yes | `16,522,183` dominance candidates |
+
+Interpretation:
+
+- counted closure is dominated by raw successor expansion and depth-limit
+  skips, not exact subset dominance
+- weighted `Min` fallback remains the only measured shape where generic
+  frontier candidate indexing is directly relevant
+- the next optimization should not add another generic frontier index by
+  default; if counted closure becomes the target, the more appropriate next
+  step is compact visited-state storage for `PathAwareTransitiveClosureNode`
+  rather than more dominance-frontier machinery
 
 The optimization must remain exact: fingerprints and bucket keys should reduce
 candidate scans, not replace the final simple-path dominance check.

--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_SPEC.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_SPEC.md
@@ -139,6 +139,21 @@ It should not replace:
 The planner/runtime should continue to select the cheapest correct model
 for the workload class.
 
+## Trace Metrics
+
+Runtime instrumentation should keep the main exact workload classes separate:
+
+- counted simple-path traversal reports `path_state_*` counters for stack
+  pops, successor candidates, cycle skips, depth-limit skips, best-known
+  pruning, enqueued states, output rows, and maximum path/stack size
+- weighted `Min` frontier fallback reports `min_frontier_*` counters for
+  dominance candidates, subset checks, target buckets, and retained
+  path-state partition sizes
+
+These metrics are intentionally not normalized into one generic counter set.
+The current measurements show different bottlenecks: counted closure is
+expansion-heavy, while weighted `Min` fallback is dominance-candidate-heavy.
+
 ## Success Criteria
 
 1. Exact output agreement with current exact non-DAG implementations

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -276,8 +276,10 @@ strategy rather than as a geometric-mean or log-output strategy:
    become negative steps under a log transform
 4. the runtime minimizes products directly, avoiding log/exp output drift
 
-The next coding step should compare another exact non-DAG fallback workload
-before adding more generic frontier indexes.
+The cross-workload comparison step is now complete. Counted simple-path
+shortest-path runs now emit `path_state_*` metrics from
+`PathAwareTransitiveClosureNode`, giving a non-weighted non-DAG comparison
+point before adding more generic frontier indexes.
 
 ## Frontier Fallback Metric Survey
 
@@ -311,6 +313,15 @@ benchmark shape:
 | multiplicative | 300 | 0.892s | 0.264s | 3.38x | `PathAwareAccumulationSeededMinNonNegativeMultiplicativeLayered` |
 | multiplicative | 1k | 0.587s | 0.212s | 2.76x | `PathAwareAccumulationSeededMinNonNegativeMultiplicativeLayered` |
 
+Counted simple-path closure provides the non-weighted comparison point. It does
+not use the weighted `min_frontier_*` dominance machinery; its measured cost is
+raw path-state traversal:
+
+| Shape | Scale | All | Min | Speedup | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| counted shortest path | 300 | 0.920s | 0.246s | 3.74x | 602,808 | 30,968 | 982,581 | 101,371 |
+| counted shortest path | 1k | 0.679s | 0.162s | 4.18x | 352,522 | 10,328 | 592,698 | 38,196 |
+
 Interpretation:
 
 - dominance-candidate scans are still the dominant counter, but lazy
@@ -324,6 +335,9 @@ Interpretation:
   correctness-safe tradeoff
 - positive multiplicative recurrence no longer contributes frontier counters on
   the benchmark shape because it does not enter the fallback
-- the remaining candidate scans are low enough that the next broad optimization
-  should probably move to a different fallback class before adding more generic
-  frontier indexes
+- counted closure confirms that not every non-DAG path-state workload has the
+  same bottleneck: its measured cost is successor expansion and depth-limit
+  pruning, not subset-dominance lookup
+- the next broad optimization should avoid adding more generic frontier indexes
+  until another dominance-heavy fallback shape appears; for counted closure,
+  compact visited-state storage is the more relevant follow-up

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -229,6 +229,7 @@ Tables:
 | `benchmark_common.py` | Shared build/run utilities for cross-target benchmark runners |
 | `compute_effective_distance.py` | Post-processing aggregation (validation tool) |
 | `benchmark_effective_distance.py` | Rebuild and time effective distance across the C# query engine, accumulated Prolog, optional direct article/root and root-bound Prolog variants, and C#/Rust/Go DFS binaries |
+| `benchmark_shortest_path_to_root.py` | Compare counted simple-path `All` vs minimum-depth pruning inside the C# query runtime and emit path-state metrics |
 | `benchmark_shortest_path_cross_target.py` | Compare shortest-path-to-root across C# query, seeded Prolog `min`, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_depth_cross_target.py` | Compare synthetic dependency reach-count across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_longest_depth_cross_target.py` | Compare true DAG longest dependency-chain depth across C# query, C# DFS, Rust DFS, and Go DFS |
@@ -315,6 +316,10 @@ python examples/benchmark/benchmark_prolog_effective_distance.py \
 python examples/benchmark/benchmark_shortest_path_cross_target.py \
     --scales 300,1k,5k,10k \
     --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min
+
+# Compare C# query counted simple-path All vs minimum-depth pruning
+python examples/benchmark/benchmark_shortest_path_to_root.py \
+    --scales 300,1k,5k,10k
 
 # Compare dependency reach count across query engine and DFS targets
 python examples/benchmark/benchmark_dependency_depth_cross_target.py \
@@ -919,6 +924,41 @@ Current interpretation:
 - the generic seeded accumulation helper remains the right fallback for
   workloads like effective distance where the grouped helper is not the
   better consumer fit
+
+### Counted Simple-Path State Survey
+
+The counted shortest-path benchmark now emits `path_state_*` metrics from
+`PathAwareTransitiveClosureNode`. This provides a non-weighted non-DAG
+comparison point for the weighted `Min` frontier survey: counted closure has
+no subset-dominance frontier, so its cost is mostly raw successor expansion,
+cycle checks, depth-limit skips, and retained simple-path rows.
+
+Command:
+
+```bash
+python examples/benchmark/benchmark_shortest_path_to_root.py \
+    --scales 300,1k --repetitions 1
+```
+
+Latest local results:
+
+| Scale | All | Min | Speedup | Output Match | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
+|-------|----:|----:|--------:|--------------|----------------:|----------------:|-------------------------:|-------------------------:|
+| 300 | 0.920s | 0.246s | 3.74x | match | 602,808 | 30,968 | 982,581 | 101,371 |
+| 1k | 0.679s | 0.162s | 4.18x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+
+Additional path-state observations:
+
+- `All` mode at `300` recorded `603,194` enqueued states, `11,727`
+  cycle skips, and `368,046` depth-limit skips.
+- `All` mode at `1k` recorded `352,611` enqueued states, `4,870`
+  cycle skips, and `235,306` depth-limit skips.
+- `Min` mode cuts output rows by roughly `19x` at `300` and `34x` at
+  `1k` without changing final shortest-path answers.
+- This shape does not exercise the weighted `min_frontier_*` dominance
+  candidate problem; generic frontier indexes would not address its primary
+  cost. A compact visited representation for counted closure is the more
+  relevant follow-up if this shape becomes hot again.
 
 ### Weighted `Min` Results
 

--- a/examples/benchmark/benchmark_shortest_path_to_root.py
+++ b/examples/benchmark/benchmark_shortest_path_to_root.py
@@ -43,6 +43,7 @@ PROGRAM = """\
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using UnifyWeaver.QueryRuntime;
@@ -51,6 +52,35 @@ class Program
 {
     const string ROOT_CATEGORY = "Physics";
     const int MAX_DEPTH = 10;
+
+    static void PrintRuntimeTrace(QueryExecutionTrace? trace)
+    {
+        if (trace is null)
+        {
+            return;
+        }
+
+        foreach (var strategy in trace.SnapshotStrategies()
+            .Where(s => s.NodeType == nameof(PathAwareTransitiveClosureNode))
+            .OrderBy(s => s.Strategy, StringComparer.Ordinal))
+        {
+            Console.Error.WriteLine($"strategy_{strategy.Strategy}={strategy.Count}");
+        }
+
+        foreach (var phase in trace.SnapshotPhases()
+            .Where(p => p.NodeType == nameof(PathAwareTransitiveClosureNode))
+            .OrderBy(p => p.Phase, StringComparer.Ordinal))
+        {
+            Console.Error.WriteLine($"phase_{phase.Phase}_ms={phase.Elapsed.TotalMilliseconds.ToString("F3", CultureInfo.InvariantCulture)}");
+        }
+
+        foreach (var metric in trace.SnapshotMetrics()
+            .Where(m => m.NodeType == nameof(PathAwareTransitiveClosureNode))
+            .OrderBy(m => m.Metric, StringComparer.Ordinal))
+        {
+            Console.Error.WriteLine($"metric_{metric.Metric}={metric.Value.ToString("G17", CultureInfo.InvariantCulture)}");
+        }
+    }
 
     static void Main(string[] args)
     {
@@ -149,7 +179,8 @@ class Program
 
         var swQuery = Stopwatch.StartNew();
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
-        var rows = executor.Execute(plan, seedParams).ToList();
+        var trace = new QueryExecutionTrace();
+        var rows = executor.Execute(plan, seedParams, trace: trace).ToList();
         swQuery.Stop();
 
         var swAgg = Stopwatch.StartNew();
@@ -224,6 +255,7 @@ class Program
         Console.Error.WriteLine($"seed_count={seedParams.Count}");
         Console.Error.WriteLine($"tuple_count={rows.Count}");
         Console.Error.WriteLine($"article_count={results.Count}");
+        PrintRuntimeTrace(trace);
     }
 }
 """

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -11317,6 +11317,23 @@ namespace UnifyWeaver.QueryRuntime
                     : metrics.BucketStateCount / (double)metrics.BucketCount);
         }
 
+        private static void RecordPathAwareTraversalMetrics(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            PathAwareTraversalMetrics metrics)
+        {
+            trace?.AddMetric(node, "path_state_seed_count", metrics.SeedCount);
+            trace?.AddMetric(node, "path_state_stack_pop_count", metrics.StackPopCount);
+            trace?.AddMetric(node, "path_state_successor_candidate_count", metrics.SuccessorCandidateCount);
+            trace?.AddMetric(node, "path_state_cycle_skip_count", metrics.CycleSkipCount);
+            trace?.AddMetric(node, "path_state_depth_skip_count", metrics.DepthSkipCount);
+            trace?.AddMetric(node, "path_state_best_known_prune_count", metrics.BestKnownPruneCount);
+            trace?.AddMetric(node, "path_state_enqueued_state_count", metrics.EnqueuedStateCount);
+            trace?.AddMetric(node, "path_state_output_row_count", metrics.OutputRowCount);
+            trace?.RecordMetric(node, "path_state_max_stack_size", metrics.MaxStackSize);
+            trace?.RecordMetric(node, "path_state_max_path_length", metrics.MaxPathLength);
+        }
+
         private IReadOnlyDictionary<object, Dictionary<object, int>> ExecuteSeedGroupedPathAwareDepthMinFallback(
             SeedGroupedPathAwareDepthMinNode closure,
             IReadOnlyList<object?> orderedUniqueSeeds,
@@ -12299,9 +12316,15 @@ namespace UnifyWeaver.QueryRuntime
 
                 var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context, closure);
                 var totalRows = new List<object[]>();
+                var traversalMetrics = trace is null ? null : new PathAwareTraversalMetrics();
                 foreach (var seed in edgeState.Seeds)
                 {
-                    AppendPathAwareRowsForSeed(seed, edgeState.Successors, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth);
+                    AppendPathAwareRowsForSeed(seed, edgeState.Successors, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth, traversalMetrics);
+                }
+
+                if (traversalMetrics is not null)
+                {
+                    RecordPathAwareTraversalMetrics(trace, closure, traversalMetrics);
                 }
 
                 return totalRows;
@@ -12353,9 +12376,15 @@ namespace UnifyWeaver.QueryRuntime
 
                 seeds.Sort(CompareCacheSeedValues);
                 var totalRows = new List<object[]>();
+                var traversalMetrics = trace is null ? null : new PathAwareTraversalMetrics();
                 foreach (var seed in seeds)
                 {
-                    AppendPathAwareRowsForSeed(seed, edgeState.Successors, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth);
+                    AppendPathAwareRowsForSeed(seed, edgeState.Successors, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth, traversalMetrics);
+                }
+
+                if (traversalMetrics is not null)
+                {
+                    RecordPathAwareTraversalMetrics(trace, closure, traversalMetrics);
                 }
 
                 return totalRows;
@@ -12373,16 +12402,22 @@ namespace UnifyWeaver.QueryRuntime
             int depthIncrement,
             ICollection<object[]> output,
             TableMode accumulatorMode,
-            int maxDepth = 0)
+            int maxDepth = 0,
+            PathAwareTraversalMetrics? metrics = null)
         {
+            metrics?.RecordSeed();
             var preserveAllPaths = accumulatorMode is TableMode.All or TableMode.Sum or TableMode.Count;
             var bestKnown = preserveAllPaths ? null : new Dictionary<object?, int>();
             var stack = new Stack<(object? Node, int Depth, HashSet<object?> Visited)>();
             stack.Push((seed, 0, new HashSet<object?> { seed }));
+            metrics?.RecordEnqueuedState(1);
+            metrics?.RecordStackSize(stack.Count);
 
             while (stack.Count > 0)
             {
                 var (current, depth, visited) = stack.Pop();
+                metrics?.RecordStackPop();
+                metrics?.RecordPathLength(visited.Count);
                 var lookupKey = current ?? NullFactIndexKey;
                 if (!succIndex.TryGetValue(lookupKey, out var bucket))
                 {
@@ -12392,8 +12427,10 @@ namespace UnifyWeaver.QueryRuntime
                 for (var i = bucket.Targets.Count - 1; i >= 0; i--)
                 {
                     var next = bucket.Targets[i];
+                    metrics?.RecordSuccessorCandidate();
                     if (visited.Contains(next))
                     {
+                        metrics?.RecordCycleSkip();
                         continue;
                     }
 
@@ -12403,6 +12440,7 @@ namespace UnifyWeaver.QueryRuntime
 
                     if (maxDepth > 0 && nextDepth > maxDepth)
                     {
+                        metrics?.RecordDepthSkip();
                         continue;
                     }
 
@@ -12415,16 +12453,19 @@ namespace UnifyWeaver.QueryRuntime
                                 case TableMode.Min:
                                     if (nextDepth >= bestDepth)
                                     {
+                                        metrics?.RecordBestKnownPrune();
                                         continue;
                                     }
                                     break;
                                 case TableMode.Max:
                                     if (nextDepth <= bestDepth)
                                     {
+                                        metrics?.RecordBestKnownPrune();
                                         continue;
                                     }
                                     break;
                                 case TableMode.First:
+                                    metrics?.RecordBestKnownPrune();
                                     continue;
                             }
                         }
@@ -12434,10 +12475,13 @@ namespace UnifyWeaver.QueryRuntime
                     else
                     {
                         output.Add(new object[] { seed!, next!, nextDepth });
+                        metrics?.RecordOutputRow();
                     }
 
                     var nextVisited = new HashSet<object?>(visited) { next };
                     stack.Push((next, nextDepth, nextVisited));
+                    metrics?.RecordEnqueuedState(nextVisited.Count);
+                    metrics?.RecordStackSize(stack.Count);
                 }
             }
 
@@ -12448,6 +12492,7 @@ namespace UnifyWeaver.QueryRuntime
                 foreach (var (target, depth) in bestRows)
                 {
                     output.Add(new object[] { seed!, target!, depth });
+                    metrics?.RecordOutputRow();
                 }
             }
         }
@@ -13763,6 +13808,65 @@ namespace UnifyWeaver.QueryRuntime
                 if (count > MaxBucketSize)
                 {
                     MaxBucketSize = count;
+                }
+            }
+        }
+
+        private sealed class PathAwareTraversalMetrics
+        {
+            public long SeedCount { get; private set; }
+
+            public long StackPopCount { get; private set; }
+
+            public long SuccessorCandidateCount { get; private set; }
+
+            public long CycleSkipCount { get; private set; }
+
+            public long DepthSkipCount { get; private set; }
+
+            public long BestKnownPruneCount { get; private set; }
+
+            public long EnqueuedStateCount { get; private set; }
+
+            public long OutputRowCount { get; private set; }
+
+            public int MaxStackSize { get; private set; }
+
+            public int MaxPathLength { get; private set; }
+
+            public void RecordSeed() => SeedCount++;
+
+            public void RecordStackPop() => StackPopCount++;
+
+            public void RecordSuccessorCandidate() => SuccessorCandidateCount++;
+
+            public void RecordCycleSkip() => CycleSkipCount++;
+
+            public void RecordDepthSkip() => DepthSkipCount++;
+
+            public void RecordBestKnownPrune() => BestKnownPruneCount++;
+
+            public void RecordOutputRow() => OutputRowCount++;
+
+            public void RecordEnqueuedState(int pathLength)
+            {
+                EnqueuedStateCount++;
+                RecordPathLength(pathLength);
+            }
+
+            public void RecordStackSize(int stackSize)
+            {
+                if (stackSize > MaxStackSize)
+                {
+                    MaxStackSize = stackSize;
+                }
+            }
+
+            public void RecordPathLength(int pathLength)
+            {
+                if (pathLength > MaxPathLength)
+                {
+                    MaxPathLength = pathLength;
                 }
             }
         }

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -332,6 +332,7 @@ test_csharp_query_target :-
         verify_path_aware_transitive_closure_plan,
         verify_parameterized_path_aware_transitive_closure_plan,
         verify_path_aware_transitive_closure_preserves_path_multiplicity,
+        verify_path_aware_transitive_closure_metrics_runtime,
         verify_path_aware_transitive_closure_min_mode_plan,
         verify_path_aware_accumulation_plan,
         verify_parameterized_path_aware_accumulation_plan,
@@ -3777,6 +3778,39 @@ verify_path_aware_transitive_closure_preserves_path_multiplicity :-
         [[a]],
         HarnessSource).
 
+verify_path_aware_transitive_closure_metrics_runtime :-
+    csharp_target:build_query_plan(
+        test_pathaware_reach/3,
+        [target(csharp_query)],
+        [input, output, output],
+        Plan),
+    get_dict(is_recursive, Plan, true),
+    get_dict(root, Plan, Root),
+    get_dict(type, Root, path_aware_transitive_closure),
+    csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'PathAwareTransitiveClosureNode'),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    Params = [[a]],
+    path_aware_traversal_metric_names(MetricNames),
+    path_aware_traversal_positive_metric_names(PositiveMetricNames),
+    harness_source_with_strategy_and_metric_flags_no_reuse(
+        ModuleClass,
+        Params,
+        'PathAwareTransitiveClosureSeeded',
+        MetricNames,
+        PositiveMetricNames,
+        HarnessSource),
+    path_aware_traversal_metric_expectations(MetricRows),
+    append(['a,b,1',
+            'a,c,2',
+            'STRATEGY_USED:PathAwareTransitiveClosureSeeded=true'],
+           MetricRows,
+           ExpectedRows),
+    maybe_run_query_runtime_with_harness(Plan,
+        ExpectedRows,
+        Params,
+        HarnessSource).
+
 verify_path_aware_transitive_closure_min_mode_plan :-
     csharp_target:build_query_plan(
         test_pathaware_min_reach/3,
@@ -3802,6 +3836,43 @@ verify_path_aware_transitive_closure_min_mode_plan :-
          'a,d,2',
          'a,e,2'],
         [[a]]).
+
+path_aware_traversal_metric_names([
+    'path_state_seed_count',
+    'path_state_stack_pop_count',
+    'path_state_successor_candidate_count',
+    'path_state_cycle_skip_count',
+    'path_state_depth_skip_count',
+    'path_state_best_known_prune_count',
+    'path_state_enqueued_state_count',
+    'path_state_output_row_count',
+    'path_state_max_stack_size',
+    'path_state_max_path_length'
+]).
+
+path_aware_traversal_positive_metric_names([
+    'path_state_seed_count',
+    'path_state_stack_pop_count',
+    'path_state_successor_candidate_count',
+    'path_state_cycle_skip_count',
+    'path_state_enqueued_state_count',
+    'path_state_output_row_count',
+    'path_state_max_stack_size',
+    'path_state_max_path_length'
+]).
+
+path_aware_traversal_metric_expectations(Rows) :-
+    path_aware_traversal_metric_names(MetricNames),
+    path_aware_traversal_positive_metric_names(PositiveMetricNames),
+    findall(Row,
+            (member(Metric, MetricNames),
+             format(atom(Row), 'METRIC_RECORDED:~w=true', [Metric])),
+            RecordedRows),
+    findall(Row,
+            (member(Metric, PositiveMetricNames),
+             format(atom(Row), 'METRIC_POSITIVE:~w=true', [Metric])),
+            PositiveRows),
+    append(RecordedRows, PositiveRows, Rows).
 
 verify_path_aware_accumulation_plan :-
     csharp_query_target:build_query_plan(test_weighted_path/3, [target(csharp_query)], Plan),


### PR DESCRIPTION
## Summary

  - Adds `path_state_*` trace metrics for `PathAwareTransitiveClosureNode`.
  - Extends the shortest-path-to-root benchmark to emit counted simple-path traversal metrics.
  - Adds a focused C# query runtime test covering seeded path-aware traversal metrics.
  - Documents the counted simple-path survey against the weighted `Min` frontier fallback data.

  ## Findings

  The counted simple-path workload is not bottlenecked on dominance-frontier lookup. It is dominated by raw successor expansion,
  cycle checks, depth-limit skips, and retained simple-path rows.

  Local survey results:

  | Workload | Scale | All | Min | Match | Main Counter |
  | --- | ---: | ---: | ---: | --- | --- |
  | counted shortest path | 300 | 0.920s | 0.246s | yes | `982,581` all-mode successor candidates |
  | counted shortest path | 1k | 0.679s | 0.162s | yes | `592,698` all-mode successor candidates |
  | negative additive weighted `Min` | 300 | 0.871s | 1.478s | yes | `20,404,270` dominance candidates |
  | negative additive weighted `Min` | 1k | 0.563s | 1.217s | yes | `16,522,183` dominance candidates |

  This suggests more generic `min_frontier_*` indexing is not the next broad optimization by default. For counted closure, compact
  visited-state storage is the more relevant follow-up if that workload becomes hot.