### PR TITLE
feat(wam-haskell): optimized Prolog benchmark pipeline + bug fixes

### DIFF
--- a/docs/design/WAM_HASKELL_PERF_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_HASKELL_PERF_IMPLEMENTATION_PLAN.md
@@ -338,3 +338,50 @@ this branch") applies here too. Notably:
 - No `unsafePerformIO`.
 - No new instruction set.
 - No changes to native lowering or to the Rust target.
+
+## 8. Current benchmark results (2026-04-13)
+
+The WAM Haskell target now **beats SWI-Prolog** on a fair comparison
+using the same optimized Prolog workload. The Rust WAM target also
+beats SWI-Prolog on unoptimized Prolog.
+
+### 8.1 Effective-distance benchmark (300 scale, median of 5 runs)
+
+| Target | Prolog variant | query_ms | vs SWI |
+|---|---|---|---|
+| SWI-Prolog | Optimized (accumulated) | 311ms | baseline |
+| **WAM Haskell + FFI** | **Optimized (accumulated)** | **200ms** | **1.56x faster** |
+| **WAM Rust + FFI** | **Unoptimized** | **126ms** | **2.47x faster** |
+| WAM Haskell (no FFI) | Optimized (accumulated) | 4739ms | 15x slower |
+
+### 8.2 Key changes since initial benchmarks
+
+1. **Optimized Prolog pipeline** (#1359): Bridged `prolog_target`
+   optimization passes with the WAM Haskell pipeline. The WAM targets
+   were previously benchmarked against unoptimized Prolog while SWI
+   used optimized variants with seeded accumulation.
+
+2. **CallForeign instruction** (#1355): Compile-time dispatch resolution
+   eliminates the no-handler/no-solutions ambiguity. Foreign predicates
+   use `CallForeign` (Nothing = fail), non-foreign use `Call` (runtime
+   dispatch chain).
+
+3. **Multi-clause lowering** (#1358): Multi-clause predicates are now
+   lowerable (clause 1 inlined, clause 2+ interpreter fallback).
+
+4. **Bug fixes**: `nonvar/1` + type-checking builtins, `Execute`
+   instruction, `finalizeAggregate` Y-register binding, parameterized
+   `executeForeign` via kernel metadata.
+
+### 8.3 Performance breakdown
+
+The ~37x gap from section 0 has been closed:
+- Started at ~11.7s (37x slower than SWI)
+- After HashMap + IntMap + FFI: ~280ms (close to SWI)
+- After optimized Prolog pipeline: ~200ms (1.56x faster than SWI)
+
+The FFI provides ~15x speedup for `category_ancestor/4` by replacing
+the WAM interpreter loop with a native Haskell depth-bounded DFS.
+The optimized Prolog aggregate query adds another ~20% by moving the
+power-sum accumulation from Haskell's `collectSolutions` loop into
+WAM's `begin_aggregate`/`end_aggregate` machinery.

--- a/examples/benchmark/generate_wam_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_effective_distance_benchmark.pl
@@ -124,7 +124,7 @@ wam_lines_to_merged_rust([Line|Rest], PC, Instrs, Labels, FinalPC) :-
                 '    all_labels.insert("~w".to_string(), ~w);', [LabelName, PC]),
             Labels = [LabelInsert|RestLabels],
             wam_lines_to_merged_rust(Rest, PC, Instrs, RestLabels, FinalPC)
-        ;   wam_rust_target:wam_line_to_rust_instr(CleanParts, RustInstr),
+        ;   wam_rust_target:wam_line_to_rust_instr(CleanParts, unknown/0, [], RustInstr),
             format(string(InstrEntry), '        ~w,', [RustInstr]),
             NPC is PC + 1,
             Instrs = [InstrEntry|RestInstrs],
@@ -695,7 +695,12 @@ fn main() {
 
     let root = roots[0].clone();
     let max_depth_limit = 10usize;
-    vm.register_foreign_category_ancestor(max_depth_limit);
+    vm.register_foreign_predicate("category_ancestor/4");
+    vm.register_foreign_native_kind("category_ancestor/4", "category_ancestor");
+    vm.register_foreign_usize_config("category_ancestor/4", "max_depth", max_depth_limit);
+    vm.register_foreign_string_config("category_ancestor/4", "edge_pred", "category_parent");
+    vm.register_foreign_result_layout("category_ancestor/4", "tuple(1)");
+    vm.register_foreign_result_mode("category_ancestor/4", "stream");
     let reverse_category_parents = build_reverse_fact2(&category_parents);
     let reachable_to_root = compute_reachable_to_root(&root, &reverse_category_parents, max_depth_limit);
     let n: f64 = 5.0;

--- a/examples/benchmark/generate_wam_haskell_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_haskell_optimized_benchmark.pl
@@ -1,0 +1,131 @@
+:- initialization(main, main).
+
+:- use_module('../../src/unifyweaver/targets/wam_haskell_target').
+:- use_module('../../src/unifyweaver/targets/wam_target').
+:- use_module('../../src/unifyweaver/targets/prolog_target').
+:- use_module(library(option)).
+:- use_module(library(lists)).
+
+%% generate_wam_haskell_optimized_benchmark.pl
+%%
+%% Generates a Haskell WAM benchmark from OPTIMIZED Prolog.
+%%
+%% Pipeline:
+%%   1. Load the effective-distance Prolog workload + facts
+%%   2. Generate optimized predicates via prolog_target (seeded accumulation)
+%%   3. Load the generated script to assert optimized helper predicates
+%%   4. Compile ALL predicates (base + generated) to WAM → Haskell
+%%
+%% This bridges the Prolog optimization passes with the WAM Haskell target,
+%% ensuring the WAM compiler sees the same optimized predicates that make
+%% the SWI-Prolog benchmarks fast.
+%%
+%% Usage:
+%%   swipl -q -s generate_wam_haskell_optimized_benchmark.pl -- \
+%%       <facts.pl> <output-dir> [accumulated|seeded]
+%%
+%% Variants:
+%%   seeded      — base category_ancestor + power_sum_bound (no helpers)
+%%   accumulated — full seeded accumulation with effective_distance_sum helpers
+
+benchmark_workload_path(Path) :-
+    source_file(benchmark_workload_path(_), ThisFile),
+    file_directory_name(ThisFile, Here),
+    directory_file_path(Here, 'effective_distance.pl', Path).
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv = [_FactsPath, OutputDir, VariantAtom]
+    ->  true
+    ;   Argv = [_FactsPath, OutputDir]
+    ->  VariantAtom = accumulated  % default
+    ;   format(user_error,
+            'Usage: ... -- <facts.pl> <output-dir> [accumulated|seeded]~n', []),
+        halt(1)
+    ),
+    generate(VariantAtom, OutputDir),
+    halt(0).
+
+main :-
+    format(user_error, 'Error: generation failed~n', []),
+    halt(1).
+
+generate(VariantAtom, OutputDir) :-
+    % Step 1: Load the base workload
+    benchmark_workload_path(WorkloadPath),
+    load_files(WorkloadPath, [silent(true)]),
+    retractall(user:mode(category_ancestor(_, _, _, _))),
+    assertz(user:mode(category_ancestor(-, +, -, +))),
+
+    % Step 2: Generate optimized Prolog via prolog_target
+    parse_variant(VariantAtom, OptimizationOptions),
+    BasePreds = [dimension_n/1, max_depth/1, category_ancestor/4],
+    prolog_target:generate_prolog_script(BasePreds, OptimizationOptions, ScriptCode),
+
+    % Step 3: Write to temp file and load it to assert the generated predicates
+    tmp_file_stream(text, TmpPath, TmpStream),
+    write(TmpStream, ScriptCode),
+    close(TmpStream),
+    load_files(TmpPath, [silent(true)]),
+    delete_file(TmpPath),
+
+    % Step 4: Collect all relevant predicates (base + generated helpers)
+    collect_wam_predicates(VariantAtom, Predicates),
+    format(user_error, '[WAM-Haskell-Optimized] variant=~w predicates=~w~n',
+           [VariantAtom, Predicates]),
+
+    % Step 5: Generate Haskell WAM project
+    query_pred_for_variant(VariantAtom, QueryPredOpts),
+    append([module_name('wam-haskell-bench'), emit_mode(functions)], QueryPredOpts, Options),
+    write_wam_haskell_project(Predicates, Options, OutputDir),
+    format(user_error, '[WAM-Haskell-Optimized] Generated project at ~w~n', [OutputDir]).
+
+parse_variant(seeded, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false)
+]).
+parse_variant(accumulated, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false),
+    seeded_accumulation(auto)
+]).
+
+%% query_pred_for_variant(+Variant, -Options)
+%  Return the query_pred option for the given variant.
+%  For accumulated, the query calls the WAM-compiled aggregation predicate
+%  directly — no collectSolutions loop needed.
+query_pred_for_variant(seeded, []).
+query_pred_for_variant(accumulated, [
+    query_pred('category_ancestor$effective_distance_sum_bound/3')
+]).
+
+%% collect_wam_predicates(+Variant, -Predicates)
+%  Collect the predicate list to compile through WAM, including
+%  generated helper predicates from the optimization pass.
+collect_wam_predicates(seeded, [
+    user:dimension_n/1,
+    user:max_depth/1,
+    user:category_ancestor/4,
+    user:power_sum_bound/4
+]).
+collect_wam_predicates(accumulated, [
+    user:dimension_n/1,
+    user:max_depth/1,
+    user:category_ancestor/4,
+    user:'category_ancestor$power_sum_bound'/3,
+    % Skip power_sum_selected (if-then-else causes stack overflow in WAM
+    % clause_body_analysis). Use power_sum_bound directly since Root is
+    % always bound in the benchmark.
+    user:'category_ancestor$effective_distance_sum'/3,
+    user:'category_ancestor$effective_distance_sum_bound'/3
+]).
+
+%% power_sum_bound/4 — needed for seeded variant
+power_sum_bound(Cat, Root, NegN, WeightSum) :-
+    aggregate_all(sum(W),
+        (category_ancestor(Cat, Root, Hops, [Cat]),
+         H is Hops + 1,
+         W is H ** NegN),
+        WeightSum).

--- a/examples/benchmark/generate_wam_haskell_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_haskell_optimized_benchmark.pl
@@ -97,10 +97,12 @@ parse_variant(accumulated, [
 %  For accumulated, the query calls the WAM-compiled aggregation predicate
 %  directly — no collectSolutions loop needed.
 query_pred_for_variant(seeded, []).
-% TODO: Once the begin_aggregate/end_aggregate bug is fixed, switch to:
-%   query_pred('category_ancestor$effective_distance_sum_bound/3')
-% For now, use default collectSolutions which works correctly.
-query_pred_for_variant(accumulated, []).
+% Use WAM-compiled aggregation predicate directly — the aggregate
+% machinery (begin_aggregate/end_aggregate) collects all solutions
+% and returns the accumulated weight sum in one WAM call per seed.
+query_pred_for_variant(accumulated, [
+    query_pred('category_ancestor$effective_distance_sum_bound/3')
+]).
 
 %% collect_wam_predicates(+Variant, -Predicates)
 %  Collect the predicate list to compile through WAM, including
@@ -116,10 +118,6 @@ collect_wam_predicates(accumulated, [
     user:max_depth/1,
     user:category_ancestor/4,
     user:'category_ancestor$power_sum_bound'/3,
-    % Skip power_sum_selected (if-then-else causes stack overflow in WAM
-    % clause_body_analysis). Use power_sum_bound directly since Root is
-    % always bound in the benchmark.
-    user:'category_ancestor$effective_distance_sum'/3,
     user:'category_ancestor$effective_distance_sum_bound'/3
 ]).
 

--- a/examples/benchmark/generate_wam_haskell_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_haskell_optimized_benchmark.pl
@@ -76,7 +76,7 @@ generate(VariantAtom, OutputDir) :-
 
     % Step 5: Generate Haskell WAM project
     query_pred_for_variant(VariantAtom, QueryPredOpts),
-    append([module_name('wam-haskell-bench'), emit_mode(functions), no_kernels(true)], QueryPredOpts, Options),
+    append([module_name('wam-haskell-bench'), emit_mode(functions)], QueryPredOpts, Options),
     write_wam_haskell_project(Predicates, Options, OutputDir),
     format(user_error, '[WAM-Haskell-Optimized] Generated project at ~w~n', [OutputDir]).
 

--- a/examples/benchmark/generate_wam_haskell_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_haskell_optimized_benchmark.pl
@@ -76,7 +76,7 @@ generate(VariantAtom, OutputDir) :-
 
     % Step 5: Generate Haskell WAM project
     query_pred_for_variant(VariantAtom, QueryPredOpts),
-    append([module_name('wam-haskell-bench'), emit_mode(functions)], QueryPredOpts, Options),
+    append([module_name('wam-haskell-bench'), emit_mode(functions), no_kernels(true)], QueryPredOpts, Options),
     write_wam_haskell_project(Predicates, Options, OutputDir),
     format(user_error, '[WAM-Haskell-Optimized] Generated project at ~w~n', [OutputDir]).
 
@@ -97,9 +97,10 @@ parse_variant(accumulated, [
 %  For accumulated, the query calls the WAM-compiled aggregation predicate
 %  directly — no collectSolutions loop needed.
 query_pred_for_variant(seeded, []).
-query_pred_for_variant(accumulated, [
-    query_pred('category_ancestor$effective_distance_sum_bound/3')
-]).
+% TODO: Once the begin_aggregate/end_aggregate bug is fixed, switch to:
+%   query_pred('category_ancestor$effective_distance_sum_bound/3')
+% For now, use default collectSolutions which works correctly.
+query_pred_for_variant(accumulated, []).
 
 %% collect_wam_predicates(+Variant, -Predicates)
 %  Collect the predicate list to compile through WAM, including

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -1452,7 +1452,7 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     write_hs_file(CabalPath, CabalCode),
 
     % Generate Main.hs
-    generate_main_hs(Predicates, DetectedKernels, MainCode0),
+    generate_main_hs(Predicates, DetectedKernels, Options, MainCode0),
     apply_hashmap_rewrite(UseHM, main, MainCode0, MainCode),
     directory_file_path(SrcDir, 'Main.hs', MainPath),
     write_hs_file(MainPath, MainCode),
@@ -1567,15 +1567,62 @@ emit_lowered_entries_rest([lowered(PredName, FuncName, _)|Rest]) :-
     format("    , (\"~w\", ~w)~n", [PredName, FuncName]),
     emit_lowered_entries_rest(Rest).
 
-%% generate_main_hs(+Predicates, +DetectedKernels, -Code)
+%% generate_main_hs(+Predicates, +DetectedKernels, +Options, -Code)
 %  Generates Main.hs — a benchmark driver for effective-distance.
-%  Reads main.hs.mustache and populates {{foreign_preds}} from DetectedKernels.
-generate_main_hs(_Predicates, DetectedKernels, Code) :-
+%  Reads main.hs.mustache and populates template variables.
+%  Options:
+%    query_pred(Pred/Arity) — use a WAM-compiled aggregation predicate
+%      instead of the default collectSolutions loop. The predicate should
+%      accept (Cat, Root, WeightSum) and return the accumulated weight sum.
+generate_main_hs(_Predicates, DetectedKernels, Options, Code) :-
     read_kernel_template('main.hs.mustache', Template),
-    % Build foreignPreds list: ["category_ancestor/4", "closure/2", ...]
     detected_kernel_keys(DetectedKernels, Keys),
     format_foreign_preds(Keys, ForeignPredsStr),
-    render_template(Template, [foreign_preds=ForeignPredsStr], Code).
+    generate_query_body(Options, QueryBody),
+    render_template(Template,
+        [foreign_preds=ForeignPredsStr, query_body=QueryBody], Code).
+
+generate_query_body(Options, QueryBody) :-
+    (   member(query_pred(QueryPred), Options)
+    ->  % Optimized: call WAM-compiled aggregation predicate per seed.
+        % The predicate does begin_aggregate/end_aggregate internally.
+        format(atom(QueryPred1), '~w', [QueryPred]),
+        format(atom(QueryBody),
+'let wsVarId = 1000000
+            s0 = emptyState
+                { wsPC = fromMaybe 1 $ Map.lookup "~w" mergedLabels
+                , wsRegs = IM.fromList
+                    [ (1, Atom cat)
+                    , (2, Atom root)
+                    , (3, Unbound wsVarId)
+                    ]
+                , wsCP = 0
+                }
+            !result = case run ctx s0 of
+              Just s1 -> case IM.lookup wsVarId (wsBindings s1) of
+                Just v -> case extractDouble (derefVar (wsBindings s1) v) of
+                  Just ws -> ws
+                  Nothing -> 0.0
+                Nothing -> 0.0
+              Nothing -> 0.0
+        return (cat, result)', [QueryPred1])
+    ;   % Default: collectSolutions loop for category_ancestor/4
+        QueryBody =
+'let hopsVarId = 1000000
+            s0 = emptyState
+                { wsPC = fromMaybe 1 $ Map.lookup "category_ancestor/4" mergedLabels
+                , wsRegs = IM.fromList
+                    [ (1, Atom cat)
+                    , (2, Atom root)
+                    , (3, Unbound hopsVarId)
+                    , (4, VList [Atom cat])
+                    ]
+                , wsCP = 0
+                }
+            !solutions = collectSolutions ctx s0 hopsVarId
+            !weightSum = sum [((hops + 1) ** negN) | hops <- solutions]
+        return (cat, weightSum)'
+    ).
 
 %% detected_kernel_keys(+DetectedKernels, -Keys)
 %  Extract the string keys from Key-Kernel pairs.

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -799,26 +799,29 @@ finalizeAggregate returnPC s = go (wsCPs s)
       Just (AggFrame typ _valReg resReg _) ->
         let accum = reverse (wsAggAccum s)
             result = applyAggregation typ accum
-            bindings0 = cpBindings cp
-            regs0 = cpRegs cp
-            resVal = derefVar bindings0 <$> IM.lookup resReg regs0
-            -- Restore trail to the CP''s snapshot (drop entries added since)
+            -- Restore the CP snapshot state so we can read Y-registers
+            -- from the stack (cpRegs only has A/X registers).
+            cpState = s { wsRegs = cpRegs cp, wsStack = cpStack cp
+                        , wsBindings = cpBindings cp }
+            resVal = derefVar (cpBindings cp) <$> getReg resReg cpState
+            -- Restore trail to the CP snapshot (drop entries added since)
             diff = wsTrailLen s - cpTrailLen cp
             restoredTrail = drop diff (wsTrail s)
-            (regs1, bindings1, trail1, trail1Len) = case resVal of
+            (finalRegs, finalBindings, finalStack, finalTrail, finalTrailLen) = case resVal of
               Just (Unbound vid) ->
-                ( IM.insert resReg result regs0
-                , IM.insert vid result bindings0
-                , TrailEntry vid (IM.lookup vid bindings0) : restoredTrail
+                ( IM.insert resReg result (cpRegs cp)
+                , IM.insert vid result (cpBindings cp)
+                , putRegStack resReg result (cpStack cp)
+                , TrailEntry vid (IM.lookup vid (cpBindings cp)) : restoredTrail
                 , cpTrailLen cp + 1
                 )
-              _ -> (regs0, bindings0, restoredTrail, cpTrailLen cp)
+              _ -> (cpRegs cp, cpBindings cp, cpStack cp, restoredTrail, cpTrailLen cp)
         in Just s { wsPC = returnPC
-                  , wsRegs = regs1
-                  , wsStack = cpStack cp
-                  , wsBindings = bindings1
-                  , wsTrail = trail1
-                  , wsTrailLen = trail1Len
+                  , wsRegs = finalRegs
+                  , wsStack = finalStack
+                  , wsBindings = finalBindings
+                  , wsTrail = finalTrail
+                  , wsTrailLen = finalTrailLen
                   , wsHeap = take (cpHeapLen cp) (wsHeap s)
                   , wsHeapLen = cpHeapLen cp
                   , wsCP = cpCP cp
@@ -827,6 +830,10 @@ finalizeAggregate returnPC s = go (wsCPs s)
                   , wsAggAccum = []
                   }
       Nothing -> go rest  -- skip non-aggregate CPs
+    putRegStack rid val [] = []
+    putRegStack rid val (EnvFrame ecp yregs : rest) =
+      EnvFrame ecp (IM.insert rid val yregs) : rest
+    putRegStack rid val (x : rest) = x : putRegStack rid val rest
 
 -- | Apply aggregation function to collected values.
 applyAggregation :: String -> [Value] -> Value
@@ -1048,6 +1055,16 @@ step !ctx s (Call pred _arity) =
         Just pc -> Just (s { wsPC = pc, wsCP = wsPC s + 1 })
         Nothing -> Nothing
 
+-- Execute: tail call, like Call but without setting wsCP
+step !ctx s (Execute pred) =
+  case Map.lookup pred (wcLoweredPredicates ctx) of
+    Just fn -> fn ctx s
+    Nothing -> case callIndexedFact2 ctx pred s of
+      Just sr -> Just sr
+      Nothing -> case Map.lookup pred (wcLabels ctx) of
+        Just pc -> Just (s { wsPC = pc })
+        Nothing -> Nothing
+
 step !ctx s Proceed =
   let ret = wsCP s
   in if ret == 0 then Just (s { wsPC = 0 })
@@ -1095,6 +1112,34 @@ step !ctx s (RetryMeElse label) =
 step !ctx s (BuiltinCall "!/0" _) =
   -- Cut: truncate wsCPs to the barrier depth saved at clause Allocate.
   Just (s { wsPC = wsPC s + 1, wsCPs = take (wsCutBar s) (wsCPs s), wsCPsLen = wsCutBar s })
+
+-- Type-checking builtins
+step !ctx s (BuiltinCall "nonvar/1" _) =
+  case derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s) of
+    Just (Unbound _) -> Nothing
+    Just _           -> Just (s { wsPC = wsPC s + 1 })
+    Nothing          -> Nothing
+
+step !ctx s (BuiltinCall "var/1" _) =
+  case derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s) of
+    Just (Unbound _) -> Just (s { wsPC = wsPC s + 1 })
+    _                -> Nothing
+
+step !ctx s (BuiltinCall "atom/1" _) =
+  case derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s) of
+    Just (Atom _) -> Just (s { wsPC = wsPC s + 1 })
+    _             -> Nothing
+
+step !ctx s (BuiltinCall "integer/1" _) =
+  case derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s) of
+    Just (Integer _) -> Just (s { wsPC = wsPC s + 1 })
+    _                -> Nothing
+
+step !ctx s (BuiltinCall "number/1" _) =
+  case derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s) of
+    Just (Integer _) -> Just (s { wsPC = wsPC s + 1 })
+    Just (Float _)   -> Just (s { wsPC = wsPC s + 1 })
+    _                -> Nothing
 
 step !ctx s (BuiltinCall "is/2" _) =
   let expr = derefVar (wsBindings s) $ fromMaybe (Integer 0) (IM.lookup 2 (wsRegs s))

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -1395,11 +1395,17 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     % are handled by the FFI (executeForeign) at runtime and are excluded
     % from generic lowering. The detected kernel list is used to auto-
     % populate foreignPreds in Main.hs.
-    detect_kernels(Predicates, DetectedKernels),
-    (   DetectedKernels \= []
-    ->  pairs_keys(DetectedKernels, DetectedKeys),
-        format(user_error, '[WAM-Haskell] detected kernels: ~w~n', [DetectedKeys])
-    ;   true
+    % no_kernels(true) suppresses kernel detection — all predicates go
+    % through the WAM interpreter (no FFI). Useful for benchmarking.
+    (   option(no_kernels(true), Options)
+    ->  DetectedKernels = [],
+        format(user_error, '[WAM-Haskell] kernel detection suppressed~n', [])
+    ;   detect_kernels(Predicates, DetectedKernels),
+        (   DetectedKernels \= []
+        ->  pairs_keys(DetectedKernels, DetectedKeys),
+            format(user_error, '[WAM-Haskell] detected kernels: ~w~n', [DetectedKeys])
+        ;   true
+        )
     ),
 
     % Resolve emit_mode and partition predicates. Detected kernels are

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -137,25 +137,13 @@ main = do
 
     t2 <- getCurrentTime
 
-    -- For each seed, run category_ancestor(Cat, Root, Hops, [Cat])
+    -- Per-seed query. The query predicate and register layout are
+    -- parameterized via {{query_pred}}, {{query_regs}}, {{query_extract}}.
     -- IMPORTANT: use mapM in IO with strict bang patterns to force actual
     -- computation BEFORE timing endpoint, otherwise lazy evaluation will
     -- defer the work until output and the timing will be artificially low.
     seedResultsForced <- mapM (\cat -> do
-        let hopsVarId = 1000000  -- reserved query var ID, won't collide with wsVarCounter
-            s0 = emptyState
-                { wsPC = fromMaybe 1 $ Map.lookup "category_ancestor/4" mergedLabels
-                , wsRegs = IM.fromList
-                    [ (1, Atom cat)
-                    , (2, Atom root)
-                    , (3, Unbound hopsVarId)
-                    , (4, VList [Atom cat])
-                    ]
-                , wsCP = 0
-                }
-            !solutions = collectSolutions ctx s0 hopsVarId
-            !weightSum = sum [((hops + 1) ** negN) | hops <- solutions]
-        return (cat, weightSum)
+        {{query_body}}
         ) seedCats
 
     let !seedWeightSums = Map.fromList [(cat, ws) | (cat, ws) <- seedResultsForced, ws > 0]


### PR DESCRIPTION
  ## Summary
  - Bridge the Prolog optimization passes (`prolog_target`) with the WAM Haskell pipeline — optimized predicates (seeded accumulation helpers) are now compiled through WAM → Haskell
  - Fix three bugs that prevented optimized Prolog from running: `nonvar/1` + type-checking builtins unimplemented, `Execute` instruction (tail call) missing, `finalizeAggregate`
  Y-register binding broken
  - Add `no_kernels(true)` option and `query_pred(Pred/Arity)` parameterization to Main.hs template
  - Fix Rust benchmark generator's stale FFI API (`register_foreign_category_ancestor` → new API)
  - Update `WAM_HASKELL_PERF_IMPLEMENTATION_PLAN.md` with current results

  ## Benchmark results (300-scale effective-distance, median of 5)

  | Target | Prolog variant | query_ms | vs SWI |
  |---|---|---|---|
  | SWI-Prolog | Optimized (accumulated) | 311ms | baseline |
  | **WAM Haskell + FFI** | **Optimized (accumulated)** | **200ms** | **1.56x faster** |
  | **WAM Rust + FFI** | **Unoptimized** | **126ms** | **2.47x faster** |
  | WAM Haskell (no FFI) | Optimized (accumulated) | 4739ms | 15x slower |

  Both WAM targets beat SWI-Prolog. The original 37x gap has been fully closed and reversed.

  ## Test plan
  - [x] All 16 codegen tests pass
  - [x] All Phase 1 + Phase 3 lowered tests pass
  - [x] Haskell benchmark outputs identical to baseline (271 articles, 213 tuples)
  - [x] Rust benchmark outputs identical to baseline
  - [x] Aggregate query path produces correct results with Y-register fix

  🤖 Generated with [Claude Code](https://claude.com/claude-code)