### PR TITLE
test(haskell): use writable temp roots in lowered tests

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2131,6 +2131,31 @@ compile_single_predicate_to_haskell(PredIndicator, _Options, Code) :-
     [ ~w
     ]', [Pred, Arity, FuncName, FuncName, InstrCode, FuncName, FuncName, LabelCode]).
 
+compile_wam_predicate_to_haskell(PredIndicator, WamCode, _Options, Code) :-
+    (   PredIndicator = _Module:Pred/Arity -> true
+    ;   PredIndicator = Pred/Arity
+    ),
+    (   string(WamCode)
+    ->  WamStr = WamCode
+    ;   atom_string(WamCode, WamStr)
+    ),
+    split_string(WamStr, "\n", "", Lines),
+    wam_lines_to_haskell(Lines, 1, InstrExprs, LabelExprs),
+    atomic_list_concat(InstrExprs, '\n    , ', InstrCode),
+    atomic_list_concat(LabelExprs, '\n    , ', LabelCode),
+    format(atom(FuncName), '~w_~w', [Pred, Arity]),
+    format(string(Code),
+'-- WAM-compiled predicate: ~w/~w
+~w_code :: [Instruction]
+~w_code =
+    [ ~w
+    ]
+
+~w_labels :: Map.Map String Int
+~w_labels = Map.fromList
+    [ ~w
+    ]', [Pred, Arity, FuncName, FuncName, InstrCode, FuncName, FuncName, LabelCode]).
+
 %% wam_lines_to_haskell(+Lines, +PC, -InstrExprs, -LabelExprs, -NextPC)
 %  Parses WAM assembly lines into Haskell Instruction constructor expressions
 %  and label (String, Int) pairs. Returns NextPC for merging multiple predicates.

--- a/tests/test_wam_haskell_lowered_phase2.pl
+++ b/tests/test_wam_haskell_lowered_phase2.pl
@@ -13,13 +13,13 @@
 %
 % These are codegen-only assertions — they inspect the text of generated
 % files, not GHC compilation. The build+run verification was done manually
-% via /tmp/wam_hs_lowered_phase2 with the effective_distance 10k benchmark,
+% via a temporary project directory with the effective_distance 10k benchmark,
 % output byte-identical to the Prolog reference.
 %
 % Usage: swipl -g run_tests -t halt tests/test_wam_haskell_lowered_phase2.pl
 
 :- use_module('../src/unifyweaver/targets/wam_haskell_target').
-:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(filesex), [directory_file_path/3, make_directory_path/1]).
 
 :- dynamic test_failed/0.
 
@@ -35,7 +35,25 @@ fail_test(Test, Reason) :-
 :- dynamic user:phase2_probe/1.
 user:phase2_probe(42).
 
-project_dir('/tmp/uw_wam_hs_lowered_phase2_test').
+tmp_root_candidate(Root) :-
+    member(Env, ['TMPDIR', 'TMP', 'TEMP']),
+    getenv(Env, Root),
+    Root \== ''.
+tmp_root_candidate(Root) :-
+    getenv('PREFIX', Prefix),
+    Prefix \== '',
+    directory_file_path(Prefix, tmp, Root).
+tmp_root_candidate('output').
+
+writable_tmp_root(Root) :-
+    tmp_root_candidate(Root),
+    catch(make_directory_path(Root), _, fail),
+    access_file(Root, write),
+    !.
+
+project_dir(Dir) :-
+    writable_tmp_root(Root),
+    directory_file_path(Root, 'uw_wam_hs_lowered_phase2_test', Dir).
 
 generate_phase2_project :-
     project_dir(Dir),
@@ -108,7 +126,7 @@ test_mkcontext_initializes_wcLoweredPredicates :-
 
 test_step_call_dispatch_checks_lowered_first :-
     Test = 'WAM-Haskell-Lowered Phase 2: step Call dispatch checks wcLoweredPredicates before executeForeign',
-    compile_wam_runtime_to_haskell([], Code),
+    compile_wam_runtime_to_haskell([], [], Code),
     atom_string(Code, S),
     (   sub_string(S, _, _, _, "case Map.lookup pred (wcLoweredPredicates ctx) of"),
         sub_string(S, _, _, _, "Just fn -> fn ctx sc")

--- a/tests/test_wam_haskell_lowered_phase3.pl
+++ b/tests/test_wam_haskell_lowered_phase3.pl
@@ -9,7 +9,7 @@
 %     partition is non-empty, plus a non-empty loweredPredicates map
 %
 % These are codegen-only assertions. The build+run verification is done
-% manually via /tmp/wam_hs_lowered_phase3 with the effective_distance
+% manually via a temporary project directory with the effective_distance
 % 10k benchmark, output byte-identical to the Prolog reference (verified
 % to match Phase 2 output via diff, Temperature=2.840088).
 %
@@ -18,7 +18,7 @@
 :- use_module('../src/unifyweaver/targets/wam_haskell_target').
 :- use_module('../src/unifyweaver/targets/wam_haskell_lowered_emitter').
 :- use_module('../src/unifyweaver/targets/wam_target').
-:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(filesex), [directory_file_path/3, make_directory_path/1]).
 
 :- dynamic test_failed/0.
 
@@ -40,7 +40,25 @@ user:phase3_constant(42).
 user:phase3_multi(a).
 user:phase3_multi(b).
 
-project_dir('/tmp/uw_wam_hs_lowered_phase3_test').
+tmp_root_candidate(Root) :-
+    member(Env, ['TMPDIR', 'TMP', 'TEMP']),
+    getenv(Env, Root),
+    Root \== ''.
+tmp_root_candidate(Root) :-
+    getenv('PREFIX', Prefix),
+    Prefix \== '',
+    directory_file_path(Prefix, tmp, Root).
+tmp_root_candidate('output').
+
+writable_tmp_root(Root) :-
+    tmp_root_candidate(Root),
+    catch(make_directory_path(Root), _, fail),
+    access_file(Root, write),
+    !.
+
+project_dir(Dir) :-
+    writable_tmp_root(Root),
+    directory_file_path(Root, 'uw_wam_hs_lowered_phase3_test', Dir).
 
 read_file_to_string(Path, Str) :-
     open(Path, read, S),


### PR DESCRIPTION
# Use writable temp roots for Haskell WAM lowered tests

## Summary

- Update Haskell lowered phase2/phase3 tests to select a writable temp root instead of hardcoding `/tmp`.
- Prefer environment-provided temp directories via `TMPDIR`, `TMP`, or `TEMP`, then Termux `$PREFIX/tmp`, then repo-local `output`.
- Fix the phase2 test to call the current `compile_wam_runtime_to_haskell/3` API.
- Restore the exported `compile_wam_predicate_to_haskell/4` wrapper so `wam_haskell_target` loads without an undefined-export error.

## Validation

- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_haskell_lowered_phase2.pl`
- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_haskell_lowered_phase3.pl`
- `timeout 120 swipl -q -g run_tests -t halt tests/test_wam_haskell_target.pl`
- `git diff --check`

## Notes

- Existing load warnings remain for singleton `L` and discontiguous `wam_instr_to_haskell/2`; those are separate cleanup candidates and should be handled by code reordering rather than warning suppression.
