### PR TITLE
feat(csharp-query): Compact counted transitive path state

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -31,6 +31,13 @@ Normalize relevant non-DAG recursive executors to use:
 This is a prerequisite for compact exact path-state representation and
 cheap hashing.
 
+Status:
+
+- counted `PathAwareTransitiveClosureNode` traversal now uses integer node ids
+  and `CompactVisitedPath` instead of cloning per-state `HashSet<object?>`
+  instances
+- weighted `Min` frontier fallback already uses compact integer path state
+
 ## Phase 3: Fingerprint-Carrying State
 
 Extend the relevant recursive state structures to carry:
@@ -48,6 +55,9 @@ Status:
   runtime
 - compact visited paths now carry deterministic set fingerprints alongside
   exact node-id arrays and summary masks
+- counted transitive closure uses the same compact exact path representation
+  for cycle checks, but does not use frontier fingerprint lookup because it
+  has no subset-dominance frontier
 
 ## Phase 4: Bucketed Lookup
 
@@ -139,8 +149,8 @@ Local survey:
 
 | Workload | Scale | All | Min | Match | Main Counter |
 | --- | ---: | ---: | ---: | --- | --- |
-| counted shortest path | 300 | 0.920s | 0.246s | yes | `982,581` all-mode successor candidates |
-| counted shortest path | 1k | 0.679s | 0.162s | yes | `592,698` all-mode successor candidates |
+| counted shortest path | 300 | 0.766s | 0.234s | yes | `982,581` all-mode successor candidates |
+| counted shortest path | 1k | 0.502s | 0.176s | yes | `592,698` all-mode successor candidates |
 | negative additive weighted `Min` | 300 | 0.871s | 1.478s | yes | `20,404,270` dominance candidates |
 | negative additive weighted `Min` | 1k | 0.563s | 1.217s | yes | `16,522,183` dominance candidates |
 
@@ -148,12 +158,13 @@ Interpretation:
 
 - counted closure is dominated by raw successor expansion and depth-limit
   skips, not exact subset dominance
+- compact visited state reduces counted-closure allocation overhead while
+  preserving the same traversal counters and exact output
 - weighted `Min` fallback remains the only measured shape where generic
   frontier candidate indexing is directly relevant
 - the next optimization should not add another generic frontier index by
-  default; if counted closure becomes the target, the more appropriate next
-  step is compact visited-state storage for `PathAwareTransitiveClosureNode`
-  rather than more dominance-frontier machinery
+  default; if counted closure stays the target, the remaining work is in
+  expansion/materialization overhead rather than dominance-frontier machinery
 
 The optimization must remain exact: fingerprints and bucket keys should reduce
 candidate scans, not replace the final simple-path dominance check.

--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_SPEC.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_SPEC.md
@@ -118,6 +118,13 @@ Preferred direction:
 - compact exact visited encoding
 - path fingerprint derived from that encoding
 
+Current C# query-runtime status:
+
+- counted `PathAwareTransitiveClosureNode` traversal uses integer node ids and
+  compact exact visited paths for cycle checks
+- weighted `Min` fallback uses compact exact visited paths plus fingerprints,
+  masks, and exact subset verification for frontier dominance candidates
+
 Exact structure options include:
 
 1. sorted integer path vector

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -276,10 +276,11 @@ strategy rather than as a geometric-mean or log-output strategy:
    become negative steps under a log transform
 4. the runtime minimizes products directly, avoiding log/exp output drift
 
-The cross-workload comparison step is now complete. Counted simple-path
-shortest-path runs now emit `path_state_*` metrics from
-`PathAwareTransitiveClosureNode`, giving a non-weighted non-DAG comparison
-point before adding more generic frontier indexes.
+The cross-workload comparison step is now complete, and counted simple-path
+closure now uses compact visited paths for cycle checks.
+`PathAwareTransitiveClosureNode` emits `path_state_*` metrics, giving a
+non-weighted non-DAG comparison point before adding more generic frontier
+indexes.
 
 ## Frontier Fallback Metric Survey
 
@@ -319,8 +320,8 @@ raw path-state traversal:
 
 | Shape | Scale | All | Min | Speedup | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| counted shortest path | 300 | 0.920s | 0.246s | 3.74x | 602,808 | 30,968 | 982,581 | 101,371 |
-| counted shortest path | 1k | 0.679s | 0.162s | 4.18x | 352,522 | 10,328 | 592,698 | 38,196 |
+| counted shortest path | 300 | 0.766s | 0.234s | 3.27x | 602,808 | 30,968 | 982,581 | 101,371 |
+| counted shortest path | 1k | 0.502s | 0.176s | 2.86x | 352,522 | 10,328 | 592,698 | 38,196 |
 
 Interpretation:
 
@@ -338,6 +339,8 @@ Interpretation:
 - counted closure confirms that not every non-DAG path-state workload has the
   same bottleneck: its measured cost is successor expansion and depth-limit
   pruning, not subset-dominance lookup
+- compact visited paths reduce counted-closure allocation overhead while
+  leaving the measured traversal counters unchanged
 - the next broad optimization should avoid adding more generic frontier indexes
   until another dominance-heavy fallback shape appears; for counted closure,
-  compact visited-state storage is the more relevant follow-up
+  remaining work should target expansion/materialization overhead

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -937,15 +937,15 @@ Command:
 
 ```bash
 python examples/benchmark/benchmark_shortest_path_to_root.py \
-    --scales 300,1k --repetitions 1
+    --scales 300,1k --repetitions 3
 ```
 
-Latest local results:
+Latest local results after switching counted closure to compact visited paths:
 
 | Scale | All | Min | Speedup | Output Match | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 |-------|----:|----:|--------:|--------------|----------------:|----------------:|-------------------------:|-------------------------:|
-| 300 | 0.920s | 0.246s | 3.74x | match | 602,808 | 30,968 | 982,581 | 101,371 |
-| 1k | 0.679s | 0.162s | 4.18x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+| 300 | 0.766s | 0.234s | 3.27x | match | 602,808 | 30,968 | 982,581 | 101,371 |
+| 1k | 0.502s | 0.176s | 2.86x | match | 352,522 | 10,328 | 592,698 | 38,196 |
 
 Additional path-state observations:
 
@@ -955,10 +955,12 @@ Additional path-state observations:
   cycle skips, and `235,306` depth-limit skips.
 - `Min` mode cuts output rows by roughly `19x` at `300` and `34x` at
   `1k` without changing final shortest-path answers.
+- compact visited paths reduce the allocation-heavy `All` traversal while
+  preserving the same path-state counters and output digests.
 - This shape does not exercise the weighted `min_frontier_*` dominance
   candidate problem; generic frontier indexes would not address its primary
-  cost. A compact visited representation for counted closure is the more
-  relevant follow-up if this shape becomes hot again.
+  cost. Further counted-closure work should target expansion/materialization
+  overhead rather than dominance-frontier machinery.
 
 ### Weighted `Min` Results
 

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -12408,8 +12408,25 @@ namespace UnifyWeaver.QueryRuntime
             metrics?.RecordSeed();
             var preserveAllPaths = accumulatorMode is TableMode.All or TableMode.Sum or TableMode.Count;
             var bestKnown = preserveAllPaths ? null : new Dictionary<object?, int>();
-            var stack = new Stack<(object? Node, int Depth, HashSet<object?> Visited)>();
-            stack.Push((seed, 0, new HashSet<object?> { seed }));
+            var nodeIds = new Dictionary<object, int>();
+            var nextNodeId = 0;
+
+            int GetNodeId(object? value)
+            {
+                var key = value ?? NullFactIndexKey;
+                if (nodeIds.TryGetValue(key, out var existing))
+                {
+                    return existing;
+                }
+
+                var id = nextNodeId++;
+                nodeIds[key] = id;
+                return id;
+            }
+
+            var initialPath = CompactVisitedPath.Create(GetNodeId(seed));
+            var stack = new Stack<(object? Node, int Depth, CompactVisitedPath Visited)>();
+            stack.Push((seed, 0, initialPath));
             metrics?.RecordEnqueuedState(1);
             metrics?.RecordStackSize(stack.Count);
 
@@ -12428,7 +12445,8 @@ namespace UnifyWeaver.QueryRuntime
                 {
                     var next = bucket.Targets[i];
                     metrics?.RecordSuccessorCandidate();
-                    if (visited.Contains(next))
+                    var nextId = GetNodeId(next);
+                    if (visited.Contains(nextId))
                     {
                         metrics?.RecordCycleSkip();
                         continue;
@@ -12478,7 +12496,7 @@ namespace UnifyWeaver.QueryRuntime
                         metrics?.RecordOutputRow();
                     }
 
-                    var nextVisited = new HashSet<object?>(visited) { next };
+                    var nextVisited = visited.Extend(nextId);
                     stack.Push((next, nextDepth, nextVisited));
                     metrics?.RecordEnqueuedState(nextVisited.Count);
                     metrics?.RecordStackSize(stack.Count);


### PR DESCRIPTION
  ## Summary

  - Replaces per-state `HashSet<object?>` cloning in `PathAwareTransitiveClosureNode` with integer node IDs and
  `CompactVisitedPath`.
  - Preserves exact simple-path cycle checks and existing traversal ordering/output semantics.
  - Keeps `path_state_*` trace metrics stable so before/after benchmark counters remain comparable.
  - Updates non-DAG path-state docs and benchmark notes with compact-state results.

  ## Results

  Local counted shortest-path benchmark:

  | Scale | All | Min | Output Match |
  | --- | ---: | ---: | --- |
  | 300 | 0.766s | 0.234s | match |
  | 1k | 0.502s | 0.176s | match |

  The measured `path_state_*` counters remain unchanged, which indicates the improvement comes from reducing visited-state
  allocation overhead rather than changing traversal work.

  ## Validation

  - Focused counted closure runtime tests passed, including path multiplicity, min mode, and traversal metric emission.
  - `python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py`
  - `git diff --check`
  - `SKIP_CSHARP_EXECUTION=1` C# query sweep: `238/238`
  - `python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3