### PR TITLE
feat(wam-haskell): lower aggregate + control flow instructions

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
@@ -99,6 +99,10 @@ supported(set_value(_)).
 supported(set_constant(_)).
 supported(call(_, _)).
 supported(builtin_call(_, _)).
+supported(begin_aggregate(_, _, _)).
+supported(end_aggregate(_)).
+supported(cut_ite).
+supported(jump(_)).
 supported(proceed).
 
 %% =====================================================================
@@ -108,7 +112,11 @@ supported(proceed).
 lower_predicate_to_haskell(PI, WamCode, Opts, lowered(PredName, FuncName, Code)) :-
     ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     format(atom(PredName), '~w/~w', [Pred, Arity]),
-    format(atom(FuncName), 'lowered_~w_~w', [Pred, Arity]),
+    % Sanitize predicate name for Haskell: replace $ with _
+    atom_string(Pred, PredStr),
+    split_string(PredStr, "$", "", Parts),
+    atomic_list_concat(Parts, '_', SanitizedPred),
+    format(atom(FuncName), 'lowered_~w_~w', [SanitizedPred, Arity]),
     % base_pc(N) offsets local PCs to match the global merged instruction array.
     ( member(base_pc(BasePC), Opts) -> true ; BasePC = 1 ),
     % foreign_preds(List) — predicate keys with CallForeign dispatch.
@@ -285,6 +293,33 @@ emit_one(builtin_call(OpStr, NStr), PC, SV, SVout, I, _FP) :-
     fresh_sv(SV, SVout),
     format("~w~w <- step ctx (~w { wsPC = ~w }) (BuiltinCall \"~w\" ~w)~n",
            [I, SVout, SV, PC, EOp, NStr]).
+
+% BeginAggregate — delegate to step (pushes aggregate frame CP)
+emit_one(begin_aggregate(TypeStr, ValRegStr, ResRegStr), PC, SV, SVout, I, _FP) :-
+    reg_to_int(ValRegStr, ValReg),
+    reg_to_int(ResRegStr, ResReg),
+    fresh_sv(SV, SVout),
+    format("~w~w <- step ctx (~w { wsPC = ~w }) (BeginAggregate \"~w\" ~w ~w)~n",
+           [I, SVout, SV, PC, TypeStr, ValReg, ResReg]).
+
+% EndAggregate — delegate to step (collects value, backtracks or finalizes)
+emit_one(end_aggregate(ValRegStr), PC, SV, SVout, I, _FP) :-
+    reg_to_int(ValRegStr, ValReg),
+    fresh_sv(SV, SVout),
+    format("~w~w <- step ctx (~w { wsPC = ~w }) (EndAggregate ~w)~n",
+           [I, SVout, SV, PC, ValReg]).
+
+% CutIte — delegate to step (soft cut: pop one CP)
+emit_one(cut_ite, PC, SV, SVout, I, _FP) :-
+    fresh_sv(SV, SVout),
+    format("~w~w <- step ctx (~w { wsPC = ~w }) CutIte~n",
+           [I, SVout, SV, PC]).
+
+% Jump — delegate to step (unconditional label jump)
+emit_one(jump(LabelStr), PC, SV, SVout, I, _FP) :-
+    fresh_sv(SV, SVout),
+    format("~w~w <- step ctx (~w { wsPC = ~w }) (Jump \"~w\")~n",
+           [I, SVout, SV, PC, LabelStr]).
 
 %% =====================================================================
 %% Helpers

--- a/tests/test_wam_haskell_lowered_phase1.pl
+++ b/tests/test_wam_haskell_lowered_phase1.pl
@@ -109,11 +109,11 @@ test_mixed_non_list_rejected :-
 
 test_lowerable_rejects_unsupported :-
     Test = 'WAM-Haskell-Lowered Phase 1: wam_haskell_lowerable/3 rejects unsupported instructions',
-    % begin_aggregate is explicitly deferred — not in the Phase 4 whitelist.
-    WamText = "foo/1:\n    begin_aggregate sum, A1, A2\n    proceed\n",
+    % get_structure is not in the lowered whitelist (requires unification mode).
+    WamText = "foo/1:\n    get_structure f/2, A1\n    proceed\n",
     (   \+ wam_haskell_lowerable(foo/1, WamText, _Reason)
     ->  pass(Test)
-    ;   fail_test(Test, 'unsupported begin_aggregate was accepted')
+    ;   fail_test(Test, 'unsupported get_structure was accepted')
     ).
 
 %% ---------------------------------------------------------------------


### PR DESCRIPTION
  ## Summary
  - Expand the lowered emitter instruction whitelist with `begin_aggregate`, `end_aggregate`, `cut_ite`, and `jump` — predicates using WAM aggregate instructions can now be lowered to
   native Haskell functions
  - `power_sum_bound/3` (the optimized Prolog aggregation predicate) is now lowered (`lowered=3`, up from 2)
  - Sanitize `$` in predicate names to `_` for valid Haskell identifiers (optimized Prolog generates names like `category_ancestor$power_sum_bound`)
  - Update Phase 1 test to use `get_structure` as the unsupported instruction example (replacing `begin_aggregate` which is now supported)

  ## Test plan
  - [x] All 16 codegen tests pass
  - [x] All 11 Phase 1 tests pass (updated unsupported instruction test)
  - [x] All 8 Phase 3 tests pass
  - [x] Benchmark: 213 tuples, 271 articles (correct, identical to baseline)
  - [x] Lowered predicate count increased: `interpreted=4 lowered=3`

  🤖 Generated with [Claude Code](https://claude.com/claude-code)