### PR TITLE
feat(csharp-query): Measure counted path materialization costs

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -149,10 +149,20 @@ Local survey:
 
 | Workload | Scale | All | Min | Match | Main Counter |
 | --- | ---: | ---: | ---: | --- | --- |
-| counted shortest path | 300 | 0.766s | 0.234s | yes | `982,581` all-mode successor candidates |
-| counted shortest path | 1k | 0.502s | 0.176s | yes | `592,698` all-mode successor candidates |
+| counted shortest path | 300 | 0.634s | 0.214s | yes | `982,581` all-mode successor candidates |
+| counted shortest path | 1k | 0.450s | 0.180s | yes | `592,698` all-mode successor candidates |
 | negative additive weighted `Min` | 300 | 0.871s | 1.478s | yes | `20,404,270` dominance candidates |
 | negative additive weighted `Min` | 1k | 0.563s | 1.217s | yes | `16,522,183` dominance candidates |
+
+Counted-closure phase split after typed row buffering and pre-sized
+materialization:
+
+| Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 300 | All | 333.907ms | 27.422ms | 61.770ms | n/a |
+| 300 | Min | 57.014ms | n/a | 11.225ms | 12.363ms |
+| 1k | All | 144.563ms | 21.595ms | 62.842ms | n/a |
+| 1k | Min | 25.167ms | n/a | 1.693ms | 5.753ms |
 
 Interpretation:
 
@@ -160,6 +170,8 @@ Interpretation:
   skips, not exact subset dominance
 - compact visited state reduces counted-closure allocation overhead while
   preserving the same traversal counters and exact output
+- result materialization is significant enough to justify typed row buffering
+  and pre-sizing, but traversal remains the largest counted-closure phase
 - weighted `Min` fallback remains the only measured shape where generic
   frontier candidate indexing is directly relevant
 - the next optimization should not add another generic frontier index by

--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_SPEC.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_SPEC.md
@@ -153,6 +153,10 @@ Runtime instrumentation should keep the main exact workload classes separate:
 - counted simple-path traversal reports `path_state_*` counters for stack
   pops, successor candidates, cycle skips, depth-limit skips, best-known
   pruning, enqueued states, output rows, and maximum path/stack size
+- counted simple-path traversal also reports phase timings for
+  `path_state_traversal`, `path_state_row_creation`,
+  `path_state_result_materialization`, and
+  `path_state_best_known_flush_sort`
 - weighted `Min` frontier fallback reports `min_frontier_*` counters for
   dominance candidates, subset checks, target buckets, and retained
   path-state partition sizes

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -320,8 +320,18 @@ raw path-state traversal:
 
 | Shape | Scale | All | Min | Speedup | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| counted shortest path | 300 | 0.766s | 0.234s | 3.27x | 602,808 | 30,968 | 982,581 | 101,371 |
-| counted shortest path | 1k | 0.502s | 0.176s | 2.86x | 352,522 | 10,328 | 592,698 | 38,196 |
+| counted shortest path | 300 | 0.634s | 0.214s | 2.97x | 602,808 | 30,968 | 982,581 | 101,371 |
+| counted shortest path | 1k | 0.450s | 0.180s | 2.50x | 352,522 | 10,328 | 592,698 | 38,196 |
+
+Counted-closure phase split after typed row buffering and pre-sized
+materialization:
+
+| Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 300 | All | 333.907ms | 27.422ms | 61.770ms | n/a |
+| 300 | Min | 57.014ms | n/a | 11.225ms | 12.363ms |
+| 1k | All | 144.563ms | 21.595ms | 62.842ms | n/a |
+| 1k | Min | 25.167ms | n/a | 1.693ms | 5.753ms |
 
 Interpretation:
 
@@ -341,6 +351,9 @@ Interpretation:
   pruning, not subset-dominance lookup
 - compact visited paths reduce counted-closure allocation overhead while
   leaving the measured traversal counters unchanged
+- typed row buffering and pre-sized final materialization reduce avoidable
+  row-output overhead, but traversal is still the largest counted-closure
+  phase
 - the next broad optimization should avoid adding more generic frontier indexes
   until another dominance-heavy fallback shape appears; for counted closure,
   remaining work should target expansion/materialization overhead

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -940,12 +940,22 @@ python examples/benchmark/benchmark_shortest_path_to_root.py \
     --scales 300,1k --repetitions 3
 ```
 
-Latest local results after switching counted closure to compact visited paths:
+Latest local results after compact visited paths, typed row buffering, and
+pre-sized result materialization:
 
 | Scale | All | Min | Speedup | Output Match | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 |-------|----:|----:|--------:|--------------|----------------:|----------------:|-------------------------:|-------------------------:|
-| 300 | 0.766s | 0.234s | 3.27x | match | 602,808 | 30,968 | 982,581 | 101,371 |
-| 1k | 0.502s | 0.176s | 2.86x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+| 300 | 0.634s | 0.214s | 2.97x | match | 602,808 | 30,968 | 982,581 | 101,371 |
+| 1k | 0.450s | 0.180s | 2.50x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+
+The same run reports the counted-closure phase split:
+
+| Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
+|-------|------|----------:|-------------:|-----------------------:|----------------------:|
+| 300 | All | 333.907ms | 27.422ms | 61.770ms | n/a |
+| 300 | Min | 57.014ms | n/a | 11.225ms | 12.363ms |
+| 1k | All | 144.563ms | 21.595ms | 62.842ms | n/a |
+| 1k | Min | 25.167ms | n/a | 1.693ms | 5.753ms |
 
 Additional path-state observations:
 
@@ -957,6 +967,9 @@ Additional path-state observations:
   `1k` without changing final shortest-path answers.
 - compact visited paths reduce the allocation-heavy `All` traversal while
   preserving the same path-state counters and output digests.
+- typed row buffering plus pre-sized final materialization reduces avoidable
+  `object[]` allocation/list-growth pressure, but traversal remains the
+  largest phase.
 - This shape does not exercise the weighted `min_frontier_*` dominance
   candidate problem; generic frontier indexes would not address its primary
   cost. Further counted-closure work should target expansion/materialization

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -11322,6 +11322,16 @@ namespace UnifyWeaver.QueryRuntime
             PlanNode node,
             PathAwareTraversalMetrics metrics)
         {
+            var traversalElapsed = metrics.TraversalElapsed - metrics.RowCreationElapsed;
+            if (traversalElapsed < TimeSpan.Zero)
+            {
+                traversalElapsed = TimeSpan.Zero;
+            }
+
+            trace?.RecordPhase(node, "path_state_traversal", traversalElapsed);
+            trace?.RecordPhase(node, "path_state_row_creation", metrics.RowCreationElapsed);
+            trace?.RecordPhase(node, "path_state_best_known_flush_sort", metrics.BestKnownFlushSortElapsed);
+            trace?.RecordPhase(node, "path_state_result_materialization", metrics.ResultMaterializationElapsed);
             trace?.AddMetric(node, "path_state_seed_count", metrics.SeedCount);
             trace?.AddMetric(node, "path_state_stack_pop_count", metrics.StackPopCount);
             trace?.AddMetric(node, "path_state_successor_candidate_count", metrics.SuccessorCandidateCount);
@@ -12408,6 +12418,7 @@ namespace UnifyWeaver.QueryRuntime
             metrics?.RecordSeed();
             var preserveAllPaths = accumulatorMode is TableMode.All or TableMode.Sum or TableMode.Count;
             var bestKnown = preserveAllPaths ? null : new Dictionary<object?, int>();
+            var bufferedRows = preserveAllPaths ? new List<PathAwareDepthRow>() : null;
             var nodeIds = new Dictionary<object, int>();
             var nextNodeId = 0;
 
@@ -12430,6 +12441,7 @@ namespace UnifyWeaver.QueryRuntime
             metrics?.RecordEnqueuedState(1);
             metrics?.RecordStackSize(stack.Count);
 
+            var traversalStarted = Stopwatch.GetTimestamp();
             while (stack.Count > 0)
             {
                 var (current, depth, visited) = stack.Pop();
@@ -12492,8 +12504,7 @@ namespace UnifyWeaver.QueryRuntime
                     }
                     else
                     {
-                        output.Add(new object[] { seed!, next!, nextDepth });
-                        metrics?.RecordOutputRow();
+                        RecordBufferedPathAwareDepthRow(bufferedRows!, seed, next, nextDepth, metrics);
                     }
 
                     var nextVisited = visited.Extend(nextId);
@@ -12502,17 +12513,71 @@ namespace UnifyWeaver.QueryRuntime
                     metrics?.RecordStackSize(stack.Count);
                 }
             }
+            metrics?.AddTraversalElapsed(Stopwatch.GetElapsedTime(traversalStarted));
+
+            if (bufferedRows is not null)
+            {
+                MaterializePathAwareDepthRows(bufferedRows, output, metrics);
+            }
 
             if (bestKnown is not null)
             {
+                var flushStarted = Stopwatch.GetTimestamp();
                 var bestRows = new List<KeyValuePair<object?, int>>(bestKnown);
                 bestRows.Sort((left, right) => CompareCacheSeedValues(left.Key, right.Key));
+                metrics?.AddBestKnownFlushSortElapsed(Stopwatch.GetElapsedTime(flushStarted));
+
+                var materializationStarted = Stopwatch.GetTimestamp();
+                if (output is List<object[]> outputList)
+                {
+                    outputList.EnsureCapacity(outputList.Count + bestRows.Count);
+                }
+
                 foreach (var (target, depth) in bestRows)
                 {
                     output.Add(new object[] { seed!, target!, depth });
                     metrics?.RecordOutputRow();
                 }
+                metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(materializationStarted));
             }
+        }
+
+        private static void RecordBufferedPathAwareDepthRow(
+            List<PathAwareDepthRow> rows,
+            object? seed,
+            object? target,
+            int depth,
+            PathAwareTraversalMetrics? metrics)
+        {
+            if (metrics is null)
+            {
+                rows.Add(new PathAwareDepthRow(seed, target, depth));
+                return;
+            }
+
+            var started = Stopwatch.GetTimestamp();
+            rows.Add(new PathAwareDepthRow(seed, target, depth));
+            metrics.AddRowCreationElapsed(Stopwatch.GetElapsedTime(started));
+        }
+
+        private static void MaterializePathAwareDepthRows(
+            List<PathAwareDepthRow> rows,
+            ICollection<object[]> output,
+            PathAwareTraversalMetrics? metrics)
+        {
+            var started = Stopwatch.GetTimestamp();
+            if (output is List<object[]> outputList)
+            {
+                outputList.EnsureCapacity(outputList.Count + rows.Count);
+            }
+
+            for (var i = 0; i < rows.Count; i++)
+            {
+                var row = rows[i];
+                output.Add(new object[] { row.Seed!, row.Target!, row.Depth });
+                metrics?.RecordOutputRow();
+            }
+            metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(started));
         }
 
         private IEnumerable<object[]> ExecutePathAwareAccumulation(PathAwareAccumulationNode closure, EvaluationContext? parentContext)
@@ -13832,6 +13897,14 @@ namespace UnifyWeaver.QueryRuntime
 
         private sealed class PathAwareTraversalMetrics
         {
+            public TimeSpan TraversalElapsed { get; private set; }
+
+            public TimeSpan RowCreationElapsed { get; private set; }
+
+            public TimeSpan BestKnownFlushSortElapsed { get; private set; }
+
+            public TimeSpan ResultMaterializationElapsed { get; private set; }
+
             public long SeedCount { get; private set; }
 
             public long StackPopCount { get; private set; }
@@ -13851,6 +13924,14 @@ namespace UnifyWeaver.QueryRuntime
             public int MaxStackSize { get; private set; }
 
             public int MaxPathLength { get; private set; }
+
+            public void AddTraversalElapsed(TimeSpan elapsed) => TraversalElapsed += elapsed;
+
+            public void AddRowCreationElapsed(TimeSpan elapsed) => RowCreationElapsed += elapsed;
+
+            public void AddBestKnownFlushSortElapsed(TimeSpan elapsed) => BestKnownFlushSortElapsed += elapsed;
+
+            public void AddResultMaterializationElapsed(TimeSpan elapsed) => ResultMaterializationElapsed += elapsed;
 
             public void RecordSeed() => SeedCount++;
 
@@ -13888,6 +13969,11 @@ namespace UnifyWeaver.QueryRuntime
                 }
             }
         }
+
+        private readonly record struct PathAwareDepthRow(
+            object? Seed,
+            object? Target,
+            int Depth);
 
         private sealed record VisitedAccumulatorState(
             object Accumulator,


### PR DESCRIPTION
## Summary

- Adds phase timings for counted `PathAwareTransitiveClosureNode` execution:
  - `path_state_traversal`
  - `path_state_row_creation`
  - `path_state_result_materialization`
  - `path_state_best_known_flush_sort`
- Keeps existing `path_state_*` traversal counters stable for before/after comparison.
- Buffers counted `All` rows as typed `PathAwareDepthRow` values before final `object[]` materialization.
- Pre-sizes final output lists during counted-path materialization.
- Updates non-DAG path-state docs and benchmark notes with the new phase split.

## Results

Local counted shortest-path benchmark:

| Scale | All | Min | Output Match |
| --- | ---: | ---: | --- |
| 300 | 0.634s | 0.214s | match |
| 1k | 0.450s | 0.180s | match |

Counted-closure phase split:

| Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
| --- | --- | ---: | ---: | ---: | ---: |
| 300 | All | 333.907ms | 27.422ms | 61.770ms | n/a |
| 300 | Min | 57.014ms | n/a | 11.225ms | 12.363ms |
| 1k | All | 144.563ms | 21.595ms | 62.842ms | n/a |
| 1k | Min | 25.167ms | n/a | 1.693ms | 5.753ms |

The data shows traversal is still the largest counted-closure phase, but `object[]` materialization is now visible and non-trivial. The typed row buffer and pre-sized final output list reduce avoidable row-output overhead while preserving exact output.

## Validation

- Focused counted closure runtime tests passed, including multiplicity, min mode, and traversal metric emission.
- `python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py`
- `git diff --check`
- `SKIP_CSHARP_EXECUTION=1` C# query sweep: `238/238`
- `python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3`