### PR TITLE
perf(wam-haskell): SwitchOnConstant string keys + scale benchmarks

### DIFF
--- a/docs/design/WAM_HASKELL_PERF_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_HASKELL_PERF_IMPLEMENTATION_PLAN.md
@@ -411,7 +411,26 @@ Result: pure interpreter **4739ms → 2518ms (47% faster)**.
 - **Atom interning** (~10% combined from `==` + `hash`): Store atoms as
   `Atom !Int` with a global intern table. Eliminates string comparison
   and hashing in the hot loop. The Rust target already does this.
+- **Hot/cold state splitting**: Separate `WamState` into frequently-
+  updated fields (PC, registers) and rarely-updated fields (stack,
+  bindings, trail). Reduces record copy size on every step. The Rust
+  target uses this approach.
 - **Mutable registers**: The fundamental perf gap vs Rust is that
   Haskell's persistent IntMap register file allocates on every write.
   `IORef`/`STRef`-based mutable registers would close this but changes
   the architecture significantly.
+
+### 8.5 Scale benchmarks (2026-04-13)
+
+Haskell WAM + FFI vs SWI-Prolog (optimized accumulated), single run:
+
+| Scale | Seeds | Articles | SWI (ms) | Haskell+FFI (ms) | Ratio |
+|---|---|---|---|---|---|
+| 300 | 386 | 271 | 331 | 285 | 1.16x faster |
+| 1k | 89 | 580 | 187 | 202 | 0.93x |
+| 5k | 284 | 3224 | 747 | 716 | 1.04x faster |
+
+The Haskell WAM with FFI is competitive with SWI-Prolog at all scales.
+The advantage is most pronounced at 300 scale (more seeds = more FFI
+DFS calls). At 1k scale (fewer seeds, more articles), SWI's optimized
+Prolog has a slight edge.

--- a/examples/benchmark/gen_prof.pl
+++ b/examples/benchmark/gen_prof.pl
@@ -1,0 +1,27 @@
+:- initialization(main, main).
+:- use_module('../../src/unifyweaver/targets/wam_haskell_target').
+:- use_module('../../src/unifyweaver/targets/wam_target').
+
+benchmark_workload_path(Path) :-
+    source_file(benchmark_workload_path(_), ThisFile),
+    file_directory_name(ThisFile, Here),
+    directory_file_path(Here, 'effective_distance.pl', Path).
+
+main :-
+    current_prolog_flag(argv, [_, OutputDir]),
+    benchmark_workload_path(WorkloadPath),
+    load_files(WorkloadPath, [silent(true)]),
+    retractall(user:mode(category_ancestor(_, _, _, _))),
+    assertz(user:mode(category_ancestor(-, +, -, +))),
+    Predicates = [user:dimension_n/1, user:max_depth/1, user:category_ancestor/4, user:power_sum_bound/4],
+    Options = [module_name('wam-prof'), no_kernels(true), emit_mode(interpreter)],
+    write_wam_haskell_project(Predicates, Options, OutputDir),
+    halt(0).
+main :- halt(1).
+
+power_sum_bound(Cat, Root, NegN, WeightSum) :-
+    aggregate_all(sum(W),
+        (category_ancestor(Cat, Root, Hops, [Cat]),
+         H is Hops + 1,
+         W is H ** NegN),
+        WeightSum).

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -1145,10 +1145,13 @@ step !ctx s (SwitchOnConstantPc table) =
   let val = derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s)
   in case val of
     Just (Unbound _) -> Just (s { wsPC = wsPC s + 1 })
-    Just v -> case Map.lookup v table of
+    Just (Atom key) -> case Map.lookup key table of
       Just pc -> Just (s { wsPC = pc })
       Nothing -> Nothing
-    Nothing -> Nothing
+    Just (Integer n) -> case Map.lookup (show n) table of
+      Just pc -> Just (s { wsPC = pc })
+      Nothing -> Nothing
+    _ -> Nothing
 
 step !ctx s (BuiltinCall "!/0" _) =
   -- Cut: truncate wsCPs to the barrier depth saved at clause Allocate.
@@ -1942,8 +1945,11 @@ resolveCallInstrs labels foreignPreds = map resolve
       Just pc -> RetryMeElsePc pc
       Nothing -> RetryMeElse label
     resolve (SwitchOnConstant table) =
-      SwitchOnConstantPc (Map.fromList [(v, pc) | (v, label) <- Map.toList table,
-                                                   Just pc <- [Map.lookup label labels]])
+      let extractKey (Atom s) = s
+          extractKey (Integer n) = show n
+          extractKey v = show v
+      in SwitchOnConstantPc (Map.fromList [(extractKey v, pc) | (v, label) <- Map.toList table,
+                                                                 Just pc <- [Map.lookup label labels]])
     resolve i = i
 ', [StepCode, BacktrackCode, RunCode]).
 
@@ -1956,8 +1962,8 @@ import qualified Data.IntMap.Strict as IM
 import Data.Array (Array, listArray, (!), bounds)
 
 data Value = Atom String
-           | Integer Int
-           | Float Double
+           | Integer !Int
+           | Float !Double
            | VList [Value]
            | Str String [Value]
            | Unbound !Int   -- variable ID (interned via wsVarCounter)
@@ -2069,7 +2075,7 @@ data Instruction
   | Proceed
   | TryMeElsePc !Int                   -- post-resolution: direct PC for else branch
   | RetryMeElsePc !Int                 -- post-resolution: direct PC for next branch
-  | SwitchOnConstantPc (Map.Map Value Int)  -- post-resolution: value -> PC
+  | SwitchOnConstantPc !(Map.Map String Int) -- post-resolution: atom string -> PC
   | BuiltinCall String !Int
   | TryMeElse String
   | RetryMeElse String


### PR DESCRIPTION
  ## Summary
  - Optimize `SwitchOnConstantPc` to use `Map.Map String Int` (direct atom string keys) instead of `Map.Map Value Int`, avoiding the Value wrapper overhead in fact dispatch
  - Add `examples/benchmark/gen_prof.pl` utility for generating pure interpreter benchmarks for profiling
  - Run scale benchmarks at 300, 1k, 5k to verify performance scales

  ## Scale benchmark results (Haskell+FFI vs SWI-Prolog)

  | Scale | Seeds | Articles | SWI (ms) | Haskell+FFI (ms) | Ratio |
  |---|---|---|---|---|---|
  | 300 | 386 | 271 | 331 | 285 | 1.16x faster |
  | 1k | 89 | 580 | 187 | 202 | 0.93x |
  | 5k | 284 | 3224 | 747 | 716 | 1.04x faster |

  The Haskell WAM with FFI is competitive with SWI-Prolog at all tested scales.

  ## Profiling analysis

  Remaining hot spots in the pure interpreter (no FFI):
  - `step`: 55.7% — fundamental to Haskell's immutable record updates
  - `== (Value)`: 7.5% — string equality in atom comparison
  - `hashWithSalt`: 3.2% — remaining HashMap lookups

  Further gains require architectural changes: hot/cold state splitting (reduce record copy size per step) or atom interning (eliminate string operations). Both documented in the
  implementation plan.

  ## Test plan
  - [x] All 16 codegen tests pass
  - [x] Scale benchmarks produce correct results at all 3 scales

  🤖 Generated with [Claude Code](https://claude.com/claude-code)