### PR TITLE
perf(wam-haskell): UNPACK pragmas + profiling analysis`

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -1970,21 +1970,21 @@ data Value = Atom String
            | Ref Int
            deriving (Eq, Ord, Show)
 
-data EnvFrame = EnvFrame !Int !(IM.IntMap Value)   -- saved CP + Y-regs (IntMap)
+data EnvFrame = EnvFrame {-# UNPACK #-} !Int !(IM.IntMap Value)
               deriving (Show)
 
-data TrailEntry = TrailEntry !Int !(Maybe Value)   -- variable ID, old value
+data TrailEntry = TrailEntry {-# UNPACK #-} !Int !(Maybe Value)
                 deriving (Show)
 
 data ChoicePoint = ChoicePoint
-  { cpNextPC   :: !Int
-  , cpRegs     :: !(IM.IntMap Value)    -- IntMap (registers)
+  { cpNextPC   :: {-# UNPACK #-} !Int
+  , cpRegs     :: !(IM.IntMap Value)
   , cpStack    :: ![EnvFrame]
-  , cpCP       :: !Int
-  , cpTrailLen :: !Int
-  , cpHeapLen  :: !Int
-  , cpBindings :: !(IM.IntMap Value)    -- IntMap (variable bindings)
-  , cpCutBar   :: !Int
+  , cpCP       :: {-# UNPACK #-} !Int
+  , cpTrailLen :: {-# UNPACK #-} !Int
+  , cpHeapLen  :: {-# UNPACK #-} !Int
+  , cpBindings :: !(IM.IntMap Value)
+  , cpCutBar   :: {-# UNPACK #-} !Int
   , cpAggFrame :: !(Maybe AggFrame)
   , cpBuiltin  :: !(Maybe BuiltinState)
   } deriving (Show)
@@ -2026,20 +2026,20 @@ data WamContext = WamContext
 -- so each step transition only allocates a record with the fields that
 -- actually change.
 data WamState = WamState
-  { wsPC       :: !Int
+  { wsPC       :: {-# UNPACK #-} !Int
   , wsRegs     :: !(IM.IntMap Value)
   , wsStack    :: ![EnvFrame]
   , wsHeap     :: ![Value]
-  , wsHeapLen  :: !Int                          -- cached length(wsHeap), avoids O(n) length calls
+  , wsHeapLen  :: {-# UNPACK #-} !Int
   , wsTrail    :: ![TrailEntry]
-  , wsTrailLen :: !Int                          -- cached length(wsTrail)
-  , wsCP       :: !Int
+  , wsTrailLen :: {-# UNPACK #-} !Int
+  , wsCP       :: {-# UNPACK #-} !Int
   , wsCPs      :: ![ChoicePoint]
-  , wsCPsLen   :: !Int                          -- cached length(wsCPs) for cut barrier
+  , wsCPsLen   :: {-# UNPACK #-} !Int
   , wsBindings :: !(IM.IntMap Value)
-  , wsCutBar   :: !Int
+  , wsCutBar   :: {-# UNPACK #-} !Int
   , wsBuilder  :: !Builder
-  , wsVarCounter :: !Int
+  , wsVarCounter :: {-# UNPACK #-} !Int
   , wsAggAccum :: ![Value]
   } deriving (Show)
 


### PR DESCRIPTION
  ## Summary
  - Add `{-# UNPACK #-}` pragmas to all strict Int fields in `WamState`, `ChoicePoint`, `EnvFrame`, and `TrailEntry` to eliminate pointer indirection for integer fields
  - Optimize `SwitchOnConstantPc` to use `Map.Map String Int` (direct atom string keys) instead of `Map.Map Value Int`
  - Add `examples/benchmark/gen_prof.pl` utility for generating pure interpreter benchmarks for profiling
  - Document profiling analysis: the remaining interpreter bottleneck (55.7% in `step`) is fundamental to Haskell's immutable record model

  ## Profiling findings

  | Cost Centre | % time | Action taken |
  |---|---|---|
  | `hashWithSalt1` | 10% → 3.2% | Fixed by label pre-resolution (previous PR) |
  | `== (Value)` | 7.5% | String equality — needs atom interning (future) |
  | `step` | 55.7% | Immutable record updates — architectural (see below) |

  Investigated hot/cold state splitting and `runPC` with separate PC argument — both regressed or showed no gain. The ST monad would reduce allocation but blocks intra-query
  parallelism. **Decision: keep immutable state** to preserve Haskell's parallelization potential. Focus future work on atom interning, expanded lowering, and seed-level parallelism
  instead.

  ## Test plan
  - [x] All 16 codegen tests pass
  - [x] Pure interpreter benchmark: correct results (271 articles)
  - [x] No performance regression from UNPACK pragmas

  🤖 Generated with [Claude Code](https://claude.com/claude-code)