### PR TITLE
feat(csharp-query): Preindex counted path node ids during C# query traversal

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -154,15 +154,15 @@ Local survey:
 | negative additive weighted `Min` | 300 | 0.871s | 1.478s | yes | `20,404,270` dominance candidates |
 | negative additive weighted `Min` | 1k | 0.563s | 1.217s | yes | `16,522,183` dominance candidates |
 
-Counted-closure phase split after typed row buffering and pre-sized
-materialization:
+Counted-closure phase split after typed row buffering, pre-sized
+materialization, and edge-state node-id preindexing:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 333.907ms | 27.422ms | 61.770ms | n/a |
-| 300 | Min | 57.014ms | n/a | 11.225ms | 12.363ms |
-| 1k | All | 144.563ms | 21.595ms | 62.842ms | n/a |
-| 1k | Min | 25.167ms | n/a | 1.693ms | 5.753ms |
+| 300 | All | 201.268ms | 27.712ms | 96.200ms | n/a |
+| 300 | Min | 68.297ms | n/a | 7.207ms | 17.291ms |
+| 1k | All | 119.368ms | 23.988ms | 60.008ms | n/a |
+| 1k | Min | 19.815ms | n/a | 1.808ms | 5.863ms |
 
 Interpretation:
 
@@ -172,6 +172,9 @@ Interpretation:
   preserving the same traversal counters and exact output
 - result materialization is significant enough to justify typed row buffering
   and pre-sizing, but traversal remains the largest counted-closure phase
+- edge-state node-id preindexing removes the per-successor candidate node-id
+  dictionary lookup from traversal while preserving output hashes and
+  `path_state_*` counters
 - weighted `Min` fallback remains the only measured shape where generic
   frontier candidate indexing is directly relevant
 - the next optimization should not add another generic frontier index by

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -323,15 +323,15 @@ raw path-state traversal:
 | counted shortest path | 300 | 0.634s | 0.214s | 2.97x | 602,808 | 30,968 | 982,581 | 101,371 |
 | counted shortest path | 1k | 0.450s | 0.180s | 2.50x | 352,522 | 10,328 | 592,698 | 38,196 |
 
-Counted-closure phase split after typed row buffering and pre-sized
-materialization:
+Counted-closure phase split after typed row buffering, pre-sized
+materialization, and edge-state node-id preindexing:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 333.907ms | 27.422ms | 61.770ms | n/a |
-| 300 | Min | 57.014ms | n/a | 11.225ms | 12.363ms |
-| 1k | All | 144.563ms | 21.595ms | 62.842ms | n/a |
-| 1k | Min | 25.167ms | n/a | 1.693ms | 5.753ms |
+| 300 | All | 201.268ms | 27.712ms | 96.200ms | n/a |
+| 300 | Min | 68.297ms | n/a | 7.207ms | 17.291ms |
+| 1k | All | 119.368ms | 23.988ms | 60.008ms | n/a |
+| 1k | Min | 19.815ms | n/a | 1.808ms | 5.863ms |
 
 Interpretation:
 
@@ -354,6 +354,9 @@ Interpretation:
 - typed row buffering and pre-sized final materialization reduce avoidable
   row-output overhead, but traversal is still the largest counted-closure
   phase
+- edge-state node-id preindexing removes the per-successor candidate node-id
+  dictionary lookup from traversal while preserving output hashes and
+  `path_state_*` counters
 - the next broad optimization should avoid adding more generic frontier indexes
   until another dominance-heavy fallback shape appears; for counted closure,
   remaining work should target expansion/materialization overhead

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -940,22 +940,22 @@ python examples/benchmark/benchmark_shortest_path_to_root.py \
     --scales 300,1k --repetitions 3
 ```
 
-Latest local results after compact visited paths, typed row buffering, and
-pre-sized result materialization:
+Latest local results after compact visited paths, typed row buffering,
+pre-sized result materialization, and edge-state node-id preindexing:
 
 | Scale | All | Min | Speedup | Output Match | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 |-------|----:|----:|--------:|--------------|----------------:|----------------:|-------------------------:|-------------------------:|
-| 300 | 0.634s | 0.214s | 2.97x | match | 602,808 | 30,968 | 982,581 | 101,371 |
-| 1k | 0.450s | 0.180s | 2.50x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+| 300 | 0.549s | 0.225s | 2.45x | match | 602,808 | 30,968 | 982,581 | 101,371 |
+| 1k | 0.415s | 0.168s | 2.46x | match | 352,522 | 10,328 | 592,698 | 38,196 |
 
 The same run reports the counted-closure phase split:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 |-------|------|----------:|-------------:|-----------------------:|----------------------:|
-| 300 | All | 333.907ms | 27.422ms | 61.770ms | n/a |
-| 300 | Min | 57.014ms | n/a | 11.225ms | 12.363ms |
-| 1k | All | 144.563ms | 21.595ms | 62.842ms | n/a |
-| 1k | Min | 25.167ms | n/a | 1.693ms | 5.753ms |
+| 300 | All | 201.268ms | 27.712ms | 96.200ms | n/a |
+| 300 | Min | 68.297ms | n/a | 7.207ms | 17.291ms |
+| 1k | All | 119.368ms | 23.988ms | 60.008ms | n/a |
+| 1k | Min | 19.815ms | n/a | 1.808ms | 5.863ms |
 
 Additional path-state observations:
 
@@ -970,6 +970,9 @@ Additional path-state observations:
 - typed row buffering plus pre-sized final materialization reduces avoidable
   `object[]` allocation/list-growth pressure, but traversal remains the
   largest phase.
+- edge-state node-id preindexing removes the per-successor candidate node-id
+  dictionary lookup from traversal while preserving output hashes and
+  `path_state_*` counters.
 - This shape does not exercise the weighted `min_frontier_*` dominance
   candidate problem; generic frontier indexes would not address its primary
   cost. Further counted-closure work should target expansion/materialization

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1532,29 +1532,38 @@ namespace UnifyWeaver.QueryRuntime
 
     internal sealed class PathAwareSuccessorBucket
     {
-        public PathAwareSuccessorBucket(object? source)
+        public PathAwareSuccessorBucket(object? source, int sourceNodeId)
         {
             Source = source;
+            SourceNodeId = sourceNodeId;
         }
 
         public object? Source { get; }
 
+        public int SourceNodeId { get; }
+
         public List<object?> Targets { get; } = new();
+
+        public List<int> TargetNodeIds { get; } = new();
     }
 
     internal sealed class PathAwareEdgeState
     {
         public PathAwareEdgeState(
             IReadOnlyDictionary<object, PathAwareSuccessorBucket> successors,
-            IReadOnlyList<object?> seeds)
+            IReadOnlyList<object?> seeds,
+            IReadOnlyList<int> seedNodeIds)
         {
             Successors = successors;
             Seeds = seeds;
+            SeedNodeIds = seedNodeIds;
         }
 
         public IReadOnlyDictionary<object, PathAwareSuccessorBucket> Successors { get; }
 
         public IReadOnlyList<object?> Seeds { get; }
+
+        public IReadOnlyList<int> SeedNodeIds { get; }
     }
 
     internal sealed class PathAwareSccGraph
@@ -6154,17 +6163,22 @@ namespace UnifyWeaver.QueryRuntime
             Dictionary<object, PathAwareSuccessorBucket> successors,
             List<object?> seeds,
             HashSet<object?> seenSeeds,
+            Dictionary<object, int> nodeIds,
+            ref int nextNodeId,
             object? source,
             object? target)
         {
             var lookupKey = source ?? NullFactIndexKey;
+            var sourceNodeId = GetOrAddPathAwareNodeId(nodeIds, ref nextNodeId, source);
+            var targetNodeId = GetOrAddPathAwareNodeId(nodeIds, ref nextNodeId, target);
             if (!successors.TryGetValue(lookupKey, out var bucket))
             {
-                bucket = new PathAwareSuccessorBucket(source);
+                bucket = new PathAwareSuccessorBucket(source, sourceNodeId);
                 successors[lookupKey] = bucket;
             }
 
             bucket.Targets.Add(target);
+            bucket.TargetNodeIds.Add(targetNodeId);
             if (seenSeeds.Add(source))
             {
                 seeds.Add(source);
@@ -6173,10 +6187,33 @@ namespace UnifyWeaver.QueryRuntime
 
         private static PathAwareEdgeState FinalizePathAwareEdgeState(
             Dictionary<object, PathAwareSuccessorBucket> successors,
-            List<object?> seeds)
+            List<object?> seeds,
+            IReadOnlyDictionary<object, int> nodeIds)
         {
             seeds.Sort(CompareCacheSeedValues);
-            return new PathAwareEdgeState(successors, seeds);
+            var seedNodeIds = new List<int>(seeds.Count);
+            for (var i = 0; i < seeds.Count; i++)
+            {
+                seedNodeIds.Add(nodeIds[seeds[i] ?? NullFactIndexKey]);
+            }
+
+            return new PathAwareEdgeState(successors, seeds, seedNodeIds);
+        }
+
+        private static int GetOrAddPathAwareNodeId(
+            Dictionary<object, int> nodeIds,
+            ref int nextNodeId,
+            object? value)
+        {
+            var key = value ?? NullFactIndexKey;
+            if (nodeIds.TryGetValue(key, out var existing))
+            {
+                return existing;
+            }
+
+            var id = nextNodeId++;
+            nodeIds[key] = id;
+            return id;
         }
 
         private static PathAwareEdgeState BuildPathAwareEdgeStateFromRows(IEnumerable<object[]> edges)
@@ -6184,6 +6221,8 @@ namespace UnifyWeaver.QueryRuntime
             var successors = new Dictionary<object, PathAwareSuccessorBucket>();
             var seeds = new List<object?>();
             var seenSeeds = new HashSet<object?>();
+            var nodeIds = new Dictionary<object, int>();
+            var nextNodeId = 0;
 
             foreach (var edge in edges)
             {
@@ -6192,10 +6231,10 @@ namespace UnifyWeaver.QueryRuntime
                     continue;
                 }
 
-                AddPathAwareEdge(successors, seeds, seenSeeds, edge[0], edge[1]);
+                AddPathAwareEdge(successors, seeds, seenSeeds, nodeIds, ref nextNodeId, edge[0], edge[1]);
             }
 
-            return FinalizePathAwareEdgeState(successors, seeds);
+            return FinalizePathAwareEdgeState(successors, seeds, nodeIds);
         }
 
         private static PathAwareEdgeState BuildPathAwareEdgeStateFromDelimited(DelimitedRelationSource delimitedSource)
@@ -6203,6 +6242,8 @@ namespace UnifyWeaver.QueryRuntime
             var successors = new Dictionary<object, PathAwareSuccessorBucket>();
             var seeds = new List<object?>();
             var seenSeeds = new HashSet<object?>();
+            var nodeIds = new Dictionary<object, int>();
+            var nextNodeId = 0;
 
             using var reader = DelimitedRelationReader.OpenSequentialReader(delimitedSource.InputPath);
             for (var i = 0; i < delimitedSource.SkipRows; i++)
@@ -6221,10 +6262,10 @@ namespace UnifyWeaver.QueryRuntime
                     continue;
                 }
 
-                AddPathAwareEdge(successors, seeds, seenSeeds, left, right);
+                AddPathAwareEdge(successors, seeds, seenSeeds, nodeIds, ref nextNodeId, left, right);
             }
 
-            return FinalizePathAwareEdgeState(successors, seeds);
+            return FinalizePathAwareEdgeState(successors, seeds, nodeIds);
         }
 
         private static void ProbePathAwareEdgeRows(IEnumerable<object[]> edges, int maxRows)
@@ -6232,6 +6273,8 @@ namespace UnifyWeaver.QueryRuntime
             var successors = new Dictionary<object, PathAwareSuccessorBucket>();
             var seeds = new List<object?>();
             var seenSeeds = new HashSet<object?>();
+            var nodeIds = new Dictionary<object, int>();
+            var nextNodeId = 0;
             var consumed = 0;
 
             foreach (var edge in edges)
@@ -6241,7 +6284,7 @@ namespace UnifyWeaver.QueryRuntime
                     continue;
                 }
 
-                AddPathAwareEdge(successors, seeds, seenSeeds, edge[0], edge[1]);
+                AddPathAwareEdge(successors, seeds, seenSeeds, nodeIds, ref nextNodeId, edge[0], edge[1]);
                 consumed++;
                 if (consumed >= maxRows)
                 {
@@ -6257,6 +6300,8 @@ namespace UnifyWeaver.QueryRuntime
             var successors = new Dictionary<object, PathAwareSuccessorBucket>();
             var seeds = new List<object?>();
             var seenSeeds = new HashSet<object?>();
+            var nodeIds = new Dictionary<object, int>();
+            var nextNodeId = 0;
             var consumed = 0;
 
             using var reader = DelimitedRelationReader.OpenSequentialReader(delimitedSource.InputPath);
@@ -6276,7 +6321,7 @@ namespace UnifyWeaver.QueryRuntime
                     continue;
                 }
 
-                AddPathAwareEdge(successors, seeds, seenSeeds, left, right);
+                AddPathAwareEdge(successors, seeds, seenSeeds, nodeIds, ref nextNodeId, left, right);
                 consumed++;
                 if (consumed >= maxRows)
                 {
@@ -12327,9 +12372,9 @@ namespace UnifyWeaver.QueryRuntime
                 var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context, closure);
                 var totalRows = new List<object[]>();
                 var traversalMetrics = trace is null ? null : new PathAwareTraversalMetrics();
-                foreach (var seed in edgeState.Seeds)
+                for (var i = 0; i < edgeState.Seeds.Count; i++)
                 {
-                    AppendPathAwareRowsForSeed(seed, edgeState.Successors, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth, traversalMetrics);
+                    AppendPathAwareRowsForSeed(edgeState.Seeds[i], edgeState.SeedNodeIds[i], edgeState.Successors, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth, traversalMetrics);
                 }
 
                 if (traversalMetrics is not null)
@@ -12364,7 +12409,8 @@ namespace UnifyWeaver.QueryRuntime
 
                 var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context, closure);
                 var seeds = new List<object?>();
-                var seenSeeds = new HashSet<object?>();
+                var seedNodeIds = new List<int>();
+                var seenSeeds = new Dictionary<object, int>();
 
                 foreach (var paramTuple in parameters)
                 {
@@ -12378,18 +12424,28 @@ namespace UnifyWeaver.QueryRuntime
                         continue;
                     }
 
-                    if (seenSeeds.Add(seed))
+                    var lookupKey = seed ?? NullFactIndexKey;
+                    if (!seenSeeds.ContainsKey(lookupKey))
                     {
                         seeds.Add(seed);
+                        seenSeeds[lookupKey] = edgeState.Successors.TryGetValue(lookupKey, out var bucket)
+                            ? bucket.SourceNodeId
+                            : -1;
                     }
                 }
 
                 seeds.Sort(CompareCacheSeedValues);
+                seedNodeIds.EnsureCapacity(seeds.Count);
+                for (var i = 0; i < seeds.Count; i++)
+                {
+                    seedNodeIds.Add(seenSeeds[seeds[i] ?? NullFactIndexKey]);
+                }
+
                 var totalRows = new List<object[]>();
                 var traversalMetrics = trace is null ? null : new PathAwareTraversalMetrics();
-                foreach (var seed in seeds)
+                for (var i = 0; i < seeds.Count; i++)
                 {
-                    AppendPathAwareRowsForSeed(seed, edgeState.Successors, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth, traversalMetrics);
+                    AppendPathAwareRowsForSeed(seeds[i], seedNodeIds[i], edgeState.Successors, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth, traversalMetrics);
                 }
 
                 if (traversalMetrics is not null)
@@ -12407,6 +12463,7 @@ namespace UnifyWeaver.QueryRuntime
 
         private static void AppendPathAwareRowsForSeed(
             object? seed,
+            int seedNodeId,
             IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
             int baseDepth,
             int depthIncrement,
@@ -12419,23 +12476,8 @@ namespace UnifyWeaver.QueryRuntime
             var preserveAllPaths = accumulatorMode is TableMode.All or TableMode.Sum or TableMode.Count;
             var bestKnown = preserveAllPaths ? null : new Dictionary<object?, int>();
             var bufferedRows = preserveAllPaths ? new List<PathAwareDepthRow>() : null;
-            var nodeIds = new Dictionary<object, int>();
-            var nextNodeId = 0;
 
-            int GetNodeId(object? value)
-            {
-                var key = value ?? NullFactIndexKey;
-                if (nodeIds.TryGetValue(key, out var existing))
-                {
-                    return existing;
-                }
-
-                var id = nextNodeId++;
-                nodeIds[key] = id;
-                return id;
-            }
-
-            var initialPath = CompactVisitedPath.Create(GetNodeId(seed));
+            var initialPath = CompactVisitedPath.Create(seedNodeId);
             var stack = new Stack<(object? Node, int Depth, CompactVisitedPath Visited)>();
             stack.Push((seed, 0, initialPath));
             metrics?.RecordEnqueuedState(1);
@@ -12457,7 +12499,7 @@ namespace UnifyWeaver.QueryRuntime
                 {
                     var next = bucket.Targets[i];
                     metrics?.RecordSuccessorCandidate();
-                    var nextId = GetNodeId(next);
+                    var nextId = bucket.TargetNodeIds[i];
                     if (visited.Contains(nextId))
                     {
                         metrics?.RecordCycleSkip();


### PR DESCRIPTION
  ## Summary

  - Precomputes stable node ids while building `PathAwareEdgeState`.
  - Stores target node ids alongside successor targets in `PathAwareSuccessorBucket`.
  - Reuses preindexed seed/target ids during counted path traversal instead of doing a node-id dictionary lookup for every successor
  candidate.
  - Preserves traversal order, output hashes, and existing `path_state_*` counters.
  - Updates benchmark/proposal docs with the measured counted-closure phase split after node-id preindexing.

  ## Why

  The previous counted path materialization work showed that traversal still dominated counted simple-path closure cost. A hot part
  of that traversal was assigning/looking up compact visited-path node ids while iterating successor candidates.

  This change moves that node-id assignment to edge-state construction, so traversal can use already-computed ids directly.

  ## Results

  Local counted shortest-path benchmark:

  ```bash
  python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3

  | Scale | All | Min | Speedup | Output Match |
  | --- | ---: | ---: | ---: | --- |
  | 300 | 0.549s | 0.225s | 2.45x | match |
  | 1k | 0.415s | 0.168s | 2.46x | match |

  Counted-closure phase split:

  | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
  | --- | --- | ---: | ---: | ---: | ---: |
  | 300 | All | 201.268ms | 27.712ms | 96.200ms | n/a |
  | 300 | Min | 68.297ms | n/a | 7.207ms | 17.291ms |
  | 1k | All | 119.368ms | 23.988ms | 60.008ms | n/a |
  | 1k | Min | 19.815ms | n/a | 1.808ms | 5.863ms |

  ## Validation

  - swipl -q -t run_tests tests/core/test_csharp_query_target.pl
  - python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py
  - git diff --check
  - python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3