### PR TITLE
docs(vision): Haskell WAM target philosophy, parallelization spec, and roadmap

### DIFF
--- a/docs/vision/HASKELL_TARGET_PARALLELIZATION_SPEC.md
+++ b/docs/vision/HASKELL_TARGET_PARALLELIZATION_SPEC.md
@@ -1,0 +1,187 @@
+# Haskell WAM Target: Parallelization Specification
+
+## Overview
+
+This document specifies the parallelization model for the Haskell WAM
+target. The model is phased, starting with the simplest form (seed-level
+parallelism) and progressing to intra-query parallelism as the C# demand
+analysis matures.
+
+## 1. Seed-Level Parallelism
+
+### 1.1 Model
+
+The effective-distance benchmark (and similar workloads) queries multiple
+independent seeds:
+
+```haskell
+-- Current: sequential
+seedResults <- mapM querySeed seedCats
+
+-- Parallel: no code change needed in the WAM runtime
+seedResults <- mapConcurrently querySeed seedCats
+-- or: parMap rdeepseq querySeed seedCats
+```
+
+Each seed query receives:
+- **Shared (immutable):** `WamContext` (code array, labels, foreign
+  facts, foreign config, lowered predicates)
+- **Independent (per-seed):** `WamState` (fresh `emptyState` with
+  seed-specific register setup)
+
+No synchronization needed. No shared mutable state.
+
+### 1.2 Requirements
+
+- GHC `-threaded` runtime flag
+- `+RTS -N` to enable multi-core
+- `Control.Parallel.Strategies` or `Control.Concurrent.Async`
+- `NFData` instance for `Value` and `WamState` (for `rdeepseq`)
+
+### 1.3 Expected gain
+
+Near-linear speedup with core count for seed-dominated workloads.
+At 300 scale (386 seeds), 4 cores should give ~3.5x speedup (limited
+by seed work variance and GC contention).
+
+## 2. Intra-Query Parallelism
+
+### 2.1 Model
+
+Within a single query, parallelism arises at disjunction points:
+
+```prolog
+category_ancestor(Cat, Root, Hops, Visited) :-
+    category_parent(Cat, Mid),     % multiple solutions
+    \+ member(Mid, Visited),
+    category_ancestor(Mid, Root, H1, [Mid|Visited]),
+    Hops is H1 + 1.
+```
+
+Each `Mid` solution spawns an independent recursive subquery. With
+immutable state, these can run in parallel:
+
+```haskell
+-- At a TryMeElse choice point:
+let snapshot = currentState  -- immutable, free to share
+    branch1 = run ctx (snapshot { wsPC = clause1PC })
+    branch2 = run ctx (snapshot { wsPC = clause2PC })
+in branch1 `par` branch2 `pseq` merge branch1 branch2
+```
+
+### 2.2 Fork conditions
+
+Not all choice points should be parallelized. Forking has overhead
+(~microseconds for thread creation + GC coordination). A fork is
+profitable when:
+
+1. **The predicate is annotated or proven pure** (no side effects,
+   no assert/retract, no I/O).
+2. **The estimated branch work exceeds the fork threshold.**
+   The C# query engine's demand analysis provides selectivity
+   estimates and recursion depth bounds that can feed this decision.
+3. **The branch count is small** (2-8 branches, not 6000 fact clauses).
+
+### 2.3 Instruction design
+
+The Go hybrid WAM target has parallelization instructions. The Haskell
+equivalent would be:
+
+```
+ParTryMeElse Label    -- like TryMeElse but marks the CP as forkable
+ParRetryMeElse Label  -- like RetryMeElse for parallel branches
+ParTrustMe            -- last parallel branch
+```
+
+At runtime, `ParTryMeElse` checks a runtime flag or threshold:
+- If forking is enabled and work estimate exceeds threshold: fork
+- Otherwise: fall back to sequential TryMeElse semantics
+
+### 2.4 Merge semantics
+
+The merge strategy depends on the query context:
+
+| Context | Merge strategy |
+|---|---|
+| `aggregate_all(sum, ...)` | Sum partial results from each branch |
+| `aggregate_all(count, ...)` | Sum counts |
+| `findall(X, ...)` | Concatenate solution lists |
+| Bare disjunction | First success (race), or all solutions |
+| `\+` (negation) | Any branch succeeds → negation fails |
+
+The merge strategy is determined at compile time from the enclosing
+aggregate/findall context. Bare disjunctions default to "all solutions"
+(standard Prolog semantics).
+
+## 3. Proving Order Independence
+
+### 3.1 Sources of order dependence
+
+A predicate is order-dependent if:
+- It uses `assert`/`retract` (modifies the clause database)
+- It performs I/O (`write`, `read`, `format`)
+- It uses `!` (cut) in a way that depends on evaluation order
+- It accesses global mutable state
+
+### 3.2 Analysis pipeline
+
+The C# query engine has infrastructure for:
+- **Mode analysis:** which arguments are input (+) vs output (-)
+- **Selectivity estimation:** how many solutions a predicate produces
+- **Goal reordering:** proving that goals can be rearranged
+
+These analyses can be extended to produce a **purity certificate** for
+each predicate: a compile-time proof that the predicate is safe to
+evaluate in parallel.
+
+### 3.3 Annotations
+
+For predicates that can't be automatically proven pure, the user can
+declare parallelizability:
+
+```prolog
+:- parallel(category_ancestor/4).
+:- order_independent(power_sum_bound/3).
+```
+
+These annotations are consumed by the WAM compiler to emit
+`ParTryMeElse` instead of `TryMeElse`.
+
+## 4. Mutable-State Sections
+
+### 4.1 The hybrid approach
+
+When demand analysis identifies a non-forking section (guaranteed
+sequential execution), the WAM can use mutable state (ST monad) for
+that section:
+
+```haskell
+-- Sequential section: mutable for speed
+runSequential :: WamContext -> WamState -> ST s WamState
+runSequential ctx s = do
+  pcRef <- newSTRef (wsPC s)
+  regsRef <- newSTRef (wsRegs s)
+  -- ... fast in-place updates ...
+  
+-- Fork point: freeze back to immutable
+snapshot <- freezeState pcRef regsRef ...
+let branch1 = runST (thawAndRun ctx snapshot goals1)
+    branch2 = runST (thawAndRun ctx snapshot goals2)
+in ...
+```
+
+### 4.2 Prerequisites
+
+This requires:
+1. C# demand analysis mature enough to identify non-forking sections
+2. State monad adopted as code organization pattern (eases ST transition)
+3. Profiling showing that allocation is the bottleneck for the specific
+   workload (not all workloads are allocation-bound)
+
+## References
+
+- Go hybrid WAM parallelization instructions — reference design
+- C# query engine demand analysis — purity proofs, selectivity
+- `docs/design/WAM_HASKELL_PERF_IMPLEMENTATION_PLAN.md` §8.4 — profiling
+  data showing 48.6% allocation in step
+- `GHC.Conc`, `Control.Parallel.Strategies` — GHC parallelism primitives

--- a/docs/vision/HASKELL_TARGET_PHILOSOPHY.md
+++ b/docs/vision/HASKELL_TARGET_PHILOSOPHY.md
@@ -1,0 +1,118 @@
+# Haskell WAM Target: Philosophy
+
+## Why Haskell?
+
+Haskell's type system and immutable-by-default data model make it
+uniquely suited as a WAM target for three reasons:
+
+1. **Correctness by construction.** The WAM's complex state transitions
+   (register files, choice points, trail, bindings) are type-checked at
+   compile time. Incorrect state access is a type error, not a runtime
+   crash.
+
+2. **Parallelism without data races.** Immutable `WamContext` (code
+   array, label map, foreign facts) is shared read-only across threads.
+   Immutable `WamState` snapshots can be forked to parallel branches
+   without synchronization. This is not possible in mutable-state
+   targets like Rust or C without explicit locking.
+
+3. **GHC's optimizer.** `-O2` with `BangPatterns` and strict fields
+   produces code competitive with handwritten C for tight loops. The
+   generated WAM interpreter benefits from GHC's inlining, constructor
+   specialization, and worker-wrapper transformation.
+
+## The optimization pipeline
+
+UnifyWeaver's performance architecture is a multi-stage pipeline where
+each stage amplifies the next:
+
+```
+C# Query Engine          Rust/Haskell/LLVM WAM Targets
+  (demand analysis,        (compiled execution,
+   selectivity,      →      FFI kernels,
+   pruning)                  lowered functions,
+       ↓                     parallelization)
+Prolog Target
+  (optimized Prolog:
+   seeded accumulation,
+   branch pruning)
+```
+
+The C# engine discovers optimization opportunities (which branches to
+prune, which aggregations to precompute, which predicates are order-
+independent). The Prolog target materializes these as optimized Prolog
+predicates. The WAM targets compile those optimized predicates to
+efficient native code.
+
+This separation matters: the WAM targets don't need to rediscover
+optimization opportunities — they receive already-optimized Prolog and
+compile it faithfully. The intelligence lives in the C# analysis; the
+WAM targets provide generality.
+
+## Immutability as a strategic asset
+
+The decision to keep `WamState` immutable is deliberate, not a
+limitation:
+
+- **Parallelism.** Immutable state enables `parMap` over seed queries
+  (each seed gets the same `WamContext` + independent `WamState`). It
+  also enables intra-query parallelism: forking at choice points by
+  passing the same state snapshot to both branches.
+
+- **Backtracking for free.** Choice points are immutable snapshots of
+  the state at the branch point. Restoring on backtrack is just
+  switching pointers — no undo log needed (the trail is only needed
+  for variable bindings, not for register/stack restoration).
+
+- **Debugging and replay.** Every `WamState` is a complete, consistent
+  snapshot. You can serialize it, compare it, or replay from any point.
+
+The cost of immutability — record copying on every step — is real
+(~48% of allocation). But it's a constant factor, not an algorithmic
+issue. The FFI path (which handles the hot predicates natively) already
+beats SWI-Prolog, so the interpreter overhead matters less than the
+architectural flexibility.
+
+## When to introduce mutability
+
+Mutability (via the ST monad) should only be introduced when:
+
+1. The **C# demand analysis** can identify non-forking sections —
+   sequential execution paths where no parallel branch will ever need
+   the intermediate state.
+
+2. The **freeze/thaw cost** at fork points is amortized by sufficient
+   branch work (microseconds of overhead vs milliseconds of parallel
+   gain).
+
+3. The **State monad** has been adopted as a code organization pattern
+   first — making the transition to ST a mechanical change (`State s a`
+   → `ST s a`) rather than an architectural one.
+
+Until these conditions are met, immutable state is the right default.
+
+## Relationship to other targets
+
+- **Rust WAM:** Fastest (126ms at 300 scale). Uses mutable vectors for
+  registers. Not parallelizable without explicit Arc/Mutex.
+- **LLVM WAM:** Lowest-level, most optimization potential. Not yet
+  benchmarked with optimized Prolog.
+- **Go hybrid WAM:** Has parallelization instructions. Reference design
+  for the Haskell parallelization work.
+- **WAT:** WebAssembly target. Structured block semantics, no choice
+  point parallelism.
+
+The Haskell target's niche is **correct, parallelizable, optimized
+execution** — not raw single-threaded speed (that's Rust/LLVM's
+domain).
+
+## References
+
+- `docs/design/WAM_HASKELL_PERF_IMPLEMENTATION_PLAN.md` — optimization
+  history and profiling data
+- `docs/design/WAM_HASKELL_PERF_PHILOSOPHY.md` — earlier perf philosophy
+  (focused on closing the SWI gap, predates parallelization vision)
+- `docs/proposals/WAM_IF_THEN_ELSE_COMPILATION.md` — cross-target WAM
+  compiler enhancement
+- `docs/proposals/WAM_FOREIGN_DISPATCH_RETURN_TYPE.md` — CallForeign
+  compile-time dispatch (resolved)

--- a/docs/vision/HASKELL_TARGET_ROADMAP.md
+++ b/docs/vision/HASKELL_TARGET_ROADMAP.md
@@ -1,0 +1,136 @@
+# Haskell WAM Target: Roadmap
+
+## Current state (2026-04-13)
+
+The Haskell WAM target beats SWI-Prolog by 1.16-1.56x on the effective-
+distance benchmark (300 scale) with FFI. The pure interpreter is ~8x
+slower than FFI but 47% faster than the pre-optimization baseline.
+
+| Metric | Value |
+|---|---|
+| Haskell + FFI (300 scale) | 285ms |
+| SWI-Prolog optimized | 311ms |
+| Rust + FFI | 126ms |
+| Pure interpreter (no FFI) | 2518ms |
+| Lowered predicates | 5 of 7 |
+| Detected kernels | category_ancestor (auto-generated FFI) |
+
+## Phase 1: Seed-Level Parallelism
+
+**Goal:** Multi-core speedup with minimal code change.
+
+**Tasks:**
+1. Add `-threaded` to cabal GHC options
+2. Add `NFData` instances for `Value`, `WamState`
+3. Replace `mapM querySeed seedCats` with `parMap rdeepseq querySeed`
+   in Main.hs template
+4. Benchmark with `+RTS -N4` on the 300 and 5k scale datasets
+5. Verify output correctness (identical to sequential)
+
+**Expected outcome:** ~3-4x speedup for seed-dominated workloads.
+At 300 scale (386 seeds, 4 cores): ~70-90ms.
+
+**Risk:** Low. Immutable WamContext is shared read-only. Each seed
+gets independent WamState. No architectural change needed.
+
+## Phase 2: Atom Interning
+
+**Goal:** Eliminate string comparison and hashing from the hot loop.
+
+**Tasks:**
+1. Add `AtomTable` type (bidirectional String ↔ Int mapping)
+2. Change `Value` to `Atom !Int` (intern ID, not string)
+3. Update Main.hs fact loading to intern atom strings at load time
+4. Update `executeForeign` to intern/de-intern at the FFI boundary
+5. Update `SwitchOnConstantPc` to `Map.Map Int Int` (intern ID → PC)
+6. Benchmark pure interpreter (expected ~10% gain)
+
+**Expected outcome:** hashWithSalt drops to ~0%, `==` for atoms becomes
+O(1) integer comparison.
+
+**Risk:** Medium. Touches the `Value` type which appears everywhere.
+The AtomTable must be threaded through or stored in WamContext.
+
+## Phase 3: Expanded Lowering
+
+**Goal:** Bypass the interpreter for more predicates.
+
+**Tasks:**
+1. Lower `begin_aggregate`/`end_aggregate` via a `run`-based wrapper
+   (delegate the aggregate body to the interpreter's run loop but
+   keep the setup/teardown in the lowered function)
+2. Support nested if-then-else in lowered functions
+3. Lower predicates with `get_structure`/`unify_variable` (requires
+   read/write mode in the lowered emitter)
+4. Auto-detect lowerability: report which predicates can't be lowered
+   and why (helps prioritize whitelist expansion)
+
+**Expected outcome:** lowered=6-7 of 7 predicates in the optimized
+benchmark. Each lowered predicate avoids the step dispatch + record
+update overhead.
+
+## Phase 4: Intra-Query Parallelism
+
+**Goal:** Parallel exploration of choice point branches.
+
+**Prerequisites:**
+- Phase 1 (seed parallelism) working and benchmarked
+- C# demand analysis can estimate branch work
+- Purity annotations or proofs for target predicates
+
+**Tasks:**
+1. Add `ParTryMeElse` / `ParTrustMe` instructions to WAM compiler
+2. Add purity annotation syntax (`:- parallel(pred/arity)`)
+3. Implement fork/merge in the Haskell runtime using `par`/`pseq`
+4. Add merge strategy selection based on enclosing aggregate context
+5. Add work-estimation threshold to avoid forking cheap branches
+6. Benchmark on the 5k and 10k scale datasets
+
+**Expected outcome:** Additional 2-4x speedup for deep recursive
+predicates with multiple independent branches.
+
+**Risk:** High. Requires careful merge semantics, work estimation
+heuristics, and interaction with cut/aggregate.
+
+## Phase 5: Demand-Driven Mutable Sections
+
+**Goal:** ST monad for non-forking hot sections.
+
+**Prerequisites:**
+- Phase 4 (intra-query parallelism) working
+- C# demand analysis can identify non-forking sections
+- State monad adopted as code style (for easy ST transition)
+
+**Tasks:**
+1. Adopt State monad in the step function (pure refactor, no perf gain)
+2. Identify non-forking sections via demand analysis annotations
+3. Replace State with ST for annotated sections
+4. Add freeze/thaw at fork point boundaries
+5. Profile and benchmark to verify the allocation reduction
+
+**Expected outcome:** ~30-40% interpreter speedup in non-forking
+sections, with no loss of parallelism at fork points.
+
+**Risk:** High. Large refactor (~184 field references). Must not
+regress parallelism or correctness.
+
+## Non-goals
+
+- **Beating Rust on single-threaded speed.** Rust's mutable vectors
+  will always be faster for sequential execution. Haskell's advantage
+  is parallelism and correctness, not raw throughput.
+- **Full Prolog semantics.** The WAM target compiles a subset of Prolog
+  (the predicates UnifyWeaver generates). It doesn't need assert/retract,
+  meta-predicates, or module system support.
+- **Production deployment.** The Haskell target is a benchmark and
+  research platform. Production workloads use the C# query engine.
+
+## References
+
+- `docs/vision/HASKELL_TARGET_PHILOSOPHY.md` — strategic rationale
+- `docs/vision/HASKELL_TARGET_PARALLELIZATION_SPEC.md` — parallelism
+  semantics and merge strategies
+- `docs/design/WAM_HASKELL_PERF_IMPLEMENTATION_PLAN.md` — profiling
+  data and optimization history
+- `docs/design/WAM_HASKELL_LOWERED_IMPLEMENTATION_PLAN.md` — lowering
+  architecture and phased plan


### PR DESCRIPTION
  Summary

  - HASKELL_TARGET_PHILOSOPHY.md — Strategic rationale for the Haskell WAM target: why immutable-first, the C#→Prolog→WAM optimization pipeline, and when to introduce mutability
  - HASKELL_TARGET_PARALLELIZATION_SPEC.md — Parallelization semantics: seed-level parallelism, intra-query parallelism via ParTryMeElse, merge strategies per aggregate context, and
  order-independence proofs
  - HASKELL_TARGET_ROADMAP.md — 5-phase plan: seed parallelism → atom interning → expanded lowering → intra-query parallelism → demand-driven mutable sections

  Test plan

  - Docs only — no code changes, no tests needed
  - Verify markdown renders correctly on GitHub