### PR TITLE
docs(perf): WAM optimization log + update roadmap with post-parallelization numbers

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -1,0 +1,211 @@
+# WAM Target Performance Optimization Log
+
+Chronological record of performance optimizations applied to the Haskell
+and Rust WAM targets. This is a reference document — not a narrative. For
+the strategic framing (why these optimizations matter, where we're going
+next), see `docs/vision/HASKELL_TARGET_ROADMAP.md`.
+
+## Executive summary — where we ended up
+
+All numbers are medians of 10 runs on the 300-scale effective-distance
+benchmark, non-profiled, 4-core WSL2 host:
+
+| Target | total_ms | query_ms | Notes |
+|---|---|---|---|
+| **Haskell + FFI + parallel** | **75** | **32** | 4 cores, `+RTS -N4` |
+| Haskell + FFI (single core) | 193 | 107 | after atom interning |
+| Rust + FFI | 126 | — | hand-tuned, single-threaded |
+| SWI-Prolog (optimized) | 311 | — | baseline reference |
+| Haskell pure interpreter | 2518 | — | no FFI, no kernels |
+| Haskell initial (pre-optimization) | ~4700 | — | naive `Map String Value` |
+
+**Haskell net speedup from baseline: ~63x.** The target now outperforms
+the single-threaded Rust implementation by 1.75x on total time.
+
+---
+
+## Haskell WAM — optimization timeline
+
+### Phase A: Data structures (weeks 1-2)
+
+Early work — moving from naive associative lookups to efficient containers.
+
+| Commit | Date | What | Why it matters |
+|---|---|---|---|
+| `8abf0df3` | 2026-04-09 | O(1) Array for instruction fetch + Atom [] list fix | Instruction fetch was O(log n) via Map lookup on PC; Array turns it into O(1) |
+| `0daa9d65` | 2026-04-09 | `Data.HashMap.Strict` for register/binding maps | Replaced `Data.Map`; better constants for String keys |
+| `221f828f` | 2026-04-09 | `IntMap` for registers, eliminating string hashing | Registers are Ints at compile time; no reason to hash strings |
+| `803ed711` | 2026-04-09 | Intern variables as Ints, `IntMap` for bindings | Same idea for runtime-allocated variables |
+| `da115dec` | 2026-04-08 | O(log n) SwitchOnConstant + parser | Indexed clause selection via Map instead of linear scan |
+
+**Lesson:** The biggest early wins came from matching data structures to
+access patterns. `Data.Map String` with String keys was doing a lot of
+unnecessary hashing; the "right" container was usually `IntMap` with
+Ints that were already available at compile time.
+
+### Phase B: Eliminate repeated work (weeks 2-3)
+
+Caching fields and pre-computing at compile time.
+
+| Commit | Date | What | Why it matters |
+|---|---|---|---|
+| `501da4fc` | 2026-04-09 | Pre-parse PutStructure arity at compile time | Runtime was re-parsing functor strings on every call |
+| `cec17ca3` | 2026-04-09 | Pre-resolve Call instructions at project load | String label → Int PC, one-time cost at startup |
+| `f757b881` | 2026-04-09 | Cache `wsTrailLen`/`wsHeapLen`, eliminate `length` calls | Lists don't cache length; counters do |
+| `bdae58cf` | 2026-04-09 | Cache `wsCPsLen`, fix `addToBuilder` O(n²) append | Appending to a list with `++` at each step was quadratic |
+| `0d9695a9` | 2026-04-09 | List-based visited + unsafe instruction fetch | Replaced Set for tiny visited lists; `unsafeAt` skips bounds check |
+| `d0e639de` | 2026-04-09 | INLINE pragmas on `getReg`, `putReg`, `derefVar` | Force GHC to inline hot accessors |
+| `ab829695` | 2026-04-09 | Split `WamState` into hot `WamState` + cold `WamContext` | Code array, labels, foreign facts — shouldn't be copied per step |
+| `76a0619d` | 2026-04-13 | UNPACK pragmas for Int fields in `WamState`/`ChoicePoint` | Force unboxing of strict fields; fewer heap indirections |
+
+**Lesson:** "Cache the length" and "pre-compute at compile time" are
+recurring themes. Haskell laziness makes it easy to accidentally re-do
+work; `BangPatterns` + strict fields + UNPACK are the tools that fix this.
+
+### Phase C: Label resolution + profiling (week 3)
+
+| Commit | Date | What | Why it matters |
+|---|---|---|---|
+| `1ecca565` | 2026-04-13 | Pre-resolve all label lookups to direct PC jumps | Introduces `TryMeElsePc`, `RetryMeElsePc`, `ExecutePc`, `JumpPc`, `SwitchOnConstantPc` — the interpreter hot loop never touches string labels |
+| `a6280d1a` | 2026-04-13 | String-key `SwitchOnConstantPc` + profiling utility | `gen_prof.pl` for generating pure-interpreter profiling benchmarks |
+
+Interpreter speedup was **47%** on pure-interpreter path after label
+pre-resolution (2518ms → ~1350ms). This is the work that motivated the
+profiling matrix below.
+
+### Phase D: Profile-guided wins (April 13 — final push)
+
+This is when we systematically profiled and attacked the biggest costs.
+
+| Commit | PR | Date | What | Impact |
+|---|---|---|---|---|
+| `fcaa885c` | #1375 | 2026-04-13 | Skip WAM-compilation of FFI-owned fact predicates | **-70% total** (740ms→225ms). `buildFact2Code` was allocating ~2GB of WAM instructions that the FFI path never executed |
+| `d139991f` | #1376 | 2026-04-13 | Atom interning at FFI boundary | **-48% query** (200ms→107ms). Kills `hashWithSalt1` in the kernel's recursive HashMap lookups — IntMap of interned Ints replaces HashMap String |
+| `74d9e9b4` | #1377 | 2026-04-13 | Parallel seeds + O(n) intern build | **-67% total** (225ms→75ms). `parMap rdeepseq` over 386 seeds; each gets independent WamState, WamContext shared read-only |
+
+**Lesson from the profiling matrix**: the biggest optimizations were
+*not* in the code we were optimizing. The pure interpreter (`step` at
+59% of time) was a red herring — once FFI handled the hot predicate,
+`step` dropped to 2.8% and `buildFact2Code` took over. Without profiling
+all four configurations (pure-interp, interp+FFI, lowered-only, lowered+FFI),
+we would have chased the wrong bottleneck.
+
+### Additional refinements
+
+| Commit | Date | What | Notes |
+|---|---|---|---|
+| `7bbdbdbb` | 2026-04-13 | Enable FFI for optimized aggregate benchmark | Wire-up for benchmarks |
+
+---
+
+## Rust WAM — optimization timeline
+
+### Phase A: Core data structures
+
+| Commit | Date | What | Why it matters |
+|---|---|---|---|
+| `3e3d526b` | 2026-04-05 | Binary search for SwitchOnConstant dispatch | Sorted array + bsearch instead of linear scan |
+| `fae8fbdd` | 2026-04-06 | O(log n) instruction fetch and switch_on_constant dispatch | Shared with Haskell work |
+
+### Phase B: Choice points
+
+Choice points are hit on every disjunction — making them cheap is critical.
+
+| Commit | Date | What | Why it matters |
+|---|---|---|---|
+| `6bec8b7e` | 2026-04-06 | Lightweight ChoicePoints — save indices, not full clones | Avoid O(n) snapshot of stack/trail/heap |
+| `006f6548` | 2026-04-06 | Lightweight ChoicePoints + member/2 fast path in `\+/1` | Skip CP creation when the negation can be decided trivially |
+| `fcc88aca` | 2026-04-06 | Hybrid ChoicePoint — stack clone + trail/heap indices | Stack must be cloned (mutable through env frames); trail/heap are append-only so indices suffice |
+| `6815f9a3` | 2026-04-06 | `Rc<Vec<StackEntry>>` for O(1) stack clone | Reference-counted stack so CP creation is a pointer bump |
+| `fea72426` | 2026-04-08 | Save only argument regs in choice points | X-registers can be trashed across choice points; only A-regs carry query state |
+| `4a6e374e` | 2026-04-08 | Drop redundant binding snapshots | Bindings are reconstructable from trail, don't clone them |
+
+### Phase C: Bindings
+
+| Commit | Date | What | Notes |
+|---|---|---|---|
+| `7ca8e964` | 2026-04-07 | Save/restore var counter in CP bindings snapshot | Correctness + perf |
+| `f339df5b` | 2026-04-08 | `nb_setarg` box for zero-copy binding table + deferred fact binds | Biggest Rust-specific win |
+
+### Phase D: Benchmark specialization
+
+| Commit | Date | What | Why it matters |
+|---|---|---|---|
+| `ff154028` | 2026-04-08 | Add benchmark profiling counters | Instrumentation |
+| `90130350` | 2026-04-08 | Pre-resolve benchmark call targets | Compile-time call resolution |
+| `1c914bb1` | 2026-04-08 | Resolve choice and switch targets | Same pattern |
+| `25663f2d` | 2026-04-08 | Fast-path indexed benchmark fact calls | Avoid general dispatch for facts |
+| `7f7899a6` | 2026-04-08 | Fuse benchmark not-member guards | Inline negation check |
+| `89f947b6` | 2026-04-08 | Fuse benchmark length guards | Inline arithmetic |
+| `c65b8f80` | 2026-04-08 | Fuse recursive category_ancestor calls | Tight recursion loop |
+| `ebfca29d` | 2026-04-08 | Fuse benchmark ancestor base clause | Base case inlined |
+
+**Lesson:** The Rust target's most impactful Phase-D work was
+**benchmark fusion** — inlining the specific shape of the query into
+hot paths. This is what got Rust to 126ms. It's also why the Rust
+target doesn't generalize cleanly to other graph benchmarks without
+re-doing the fusion.
+
+---
+
+## Patterns that recurred across both targets
+
+These are the generalizable lessons — they'd apply to any WAM
+implementation regardless of host language.
+
+### 1. Pre-resolve at compile time what you can
+
+Both targets saw significant wins from replacing runtime string lookups
+with compile-time-resolved indices. Call instructions become PC values;
+SwitchOnConstant becomes a sorted Int array. At runtime you do a
+dereference, not a hash+lookup.
+
+### 2. Cache lengths that the container doesn't track
+
+Linked lists don't cache length; neither does HashMap (Haskell) for
+`size`. If you're reading length in a hot path, cache it in a counter
+field.
+
+### 3. Match container to access pattern
+
+HashMap for many-random-insert, IntMap for dense-Int keys, Array for
+sequential index access, Vec for ordered append. "Use HashMap everywhere"
+doesn't work — each container has an access pattern it wins on.
+
+### 4. Snapshot only what mutates
+
+Choice points need to restore state on backtrack. But what *has* to be
+saved? In the Rust target, `nb_setarg` + deferred fact binds means the
+trail does most of the work. In the Haskell target, immutability means
+snapshots are free (just pointer copies).
+
+### 5. Profile before optimizing
+
+The Phase-D Haskell wins all came from profiling the actual hot
+configuration (interp+FFI, lowered+FFI) rather than the pure-interpreter
+baseline everyone was focused on. The real bottleneck — `buildFact2Code`
+at 42% — was invisible in the pre-FFI profile.
+
+---
+
+## Optimizations that did NOT work
+
+Not every attempt was a win. Tracking these so we don't repeat them.
+
+| Attempt | Why it didn't work |
+|---|---|
+| Splitting PC into a separate argument threaded through `step` | Added a record copy (`s { wsPC = pc }`) before each step call — regressed from 2518ms to 2975ms. Reverted. |
+| ST monad for the hot section | Would kill intra-query parallelism (future roadmap item). Not worth the ~30-40% interpreter gain when FFI is already in play. Documented in `project_wam_haskell_st_monad_plan.md` memory. |
+| `nub $ ...` for intern-table dedup | O(n²) at ~130ms overhead at 300 scale. Replaced with foldl' + Map.member. Then had to fix *that* too (next row). |
+| `Map.size` inside foldl' to get next intern ID | HashMap.size is O(n); made intern-build O(n²). Fixed with a counter pair `(map, nextId)`. |
+
+---
+
+## Related documents
+
+- `docs/vision/HASKELL_TARGET_ROADMAP.md` — where this is going
+- `docs/vision/HASKELL_TARGET_PHILOSOPHY.md` — why Haskell as a target
+- `docs/design/WAM_HASKELL_PERF_IMPLEMENTATION_PLAN.md` — earlier plan,
+  now largely delivered
+- `docs/design/WAM_HASKELL_FFI_PROFILING_REPORT.md` — the profiling
+  matrix that drove the Phase-D wins

--- a/docs/vision/HASKELL_TARGET_ROADMAP.md
+++ b/docs/vision/HASKELL_TARGET_ROADMAP.md
@@ -1,41 +1,92 @@
 # Haskell WAM Target: Roadmap
 
-## Current state (2026-04-13)
+## Current state (2026-04-13, post-parallelization)
 
-The Haskell WAM target beats SWI-Prolog by 1.16-1.56x on the effective-
-distance benchmark (300 scale) with FFI. The pure interpreter is ~8x
-slower than FFI but 47% faster than the pre-optimization baseline.
+The Haskell WAM target **outperforms the Rust WAM target** on the effective-
+distance benchmark (300 scale) thanks to seed-level parallelism that Rust's
+mutable-vector design can't trivially match. Median numbers over 10 runs:
 
-| Metric | Value |
-|---|---|
-| Haskell + FFI (300 scale) | 285ms |
-| SWI-Prolog optimized | 311ms |
-| Rust + FFI | 126ms |
-| Pure interpreter (no FFI) | 2518ms |
-| Lowered predicates | 5 of 7 |
-| Detected kernels | category_ancestor (auto-generated FFI) |
+| Metric | Value | vs Rust |
+|---|---|---|
+| Haskell + FFI + parallel (300 scale, 4 cores) | **75ms total, 32ms query** | 1.75x faster total |
+| Haskell + FFI single-core (300 scale) | 193ms total, 107ms query | — |
+| Rust + FFI (300 scale) | 126ms | baseline |
+| SWI-Prolog optimized | 311ms | — |
+| Pure interpreter (no FFI) | 2518ms | — |
+| Haskell at 5k scale (4 cores) | 213ms total, 86ms query | 3.5x parallel speedup |
+| Lowered predicates | 5 of 7 | — |
+| Detected kernels | category_ancestor (auto-generated FFI) | — |
 
-## Phase 1: Seed-Level Parallelism
+**Phases 1 and 2 are now complete** (seed parallelism, atom interning).
+Additional optimizations beyond the original roadmap: `skip_fact_wam`
+(eliminates redundant WAM-compilation of FFI-owned facts, -70% total at
+300 scale), O(n) intern-table construction. See
+`docs/design/WAM_PERF_OPTIMIZATION_LOG.md` for the complete history.
+
+## Phase 1: Seed-Level Parallelism — DONE
 
 **Goal:** Multi-core speedup with minimal code change.
 
-**Tasks:**
-1. Add `-threaded` to cabal GHC options
-2. Add `NFData` instances for `Value`, `WamState`
-3. Replace `mapM querySeed seedCats` with `parMap rdeepseq querySeed`
-   in Main.hs template
-4. Benchmark with `+RTS -N4` on the 300 and 5k scale datasets
-5. Verify output correctness (identical to sequential)
+**Delivered (PR #1377, commit 74d9e9b4):**
+1. `-threaded -rtsopts` added to cabal GHC options
+2. `deepseq` + `parallel` build-deps added
+3. Query body generator emits pure `let { ... } in (cat, result)` so
+   it can be used in a `parMap rdeepseq` lambda
+4. Main.hs template replaces `mapM` with `parMap rdeepseq`, forces
+   sparks via `seedResultsForced \`deepseq\` ()`
+5. No NFData instances needed — `(String, Double)` is already NFData
+   through base. WamState is ephemeral inside each seed's pure
+   computation and never crosses a spark boundary.
 
-**Expected outcome:** ~3-4x speedup for seed-dominated workloads.
-At 300 scale (386 seeds, 4 cores): ~70-90ms.
+**Actual outcome:** 3.3x speedup at 300 scale (query 107ms → 32ms with
+4 cores), 3.5x at 5k scale. 8-core regressed on this WSL2 host due to
+scheduling/GC contention; 4 cores is the sweet spot.
 
-**Risk:** Low. Immutable WamContext is shared read-only. Each seed
-gets independent WamState. No architectural change needed.
-
-## Phase 2: Atom Interning
+## Phase 2: Atom Interning — DONE (scoped)
 
 **Goal:** Eliminate string comparison and hashing from the hot loop.
+
+**Delivered (PRs #1376, #1377):**
+- Rather than changing the `Value` type (landmine: mixed atom/integer
+  dispatch in SwitchOnConstant, pervasive `Atom ""` defaults), interning
+  happens **at the FFI boundary** only. The WAM path still uses
+  `Atom String`.
+- `WamContext` gains `wcAtomIntern`/`wcAtomDeintern`/`wcFfiFacts` fields.
+- Kernel templates (`kernel_category_ancestor`, `kernel_transitive_closure`)
+  now take `IntMap [Int]` and `Int` args.
+- executeForeign emitter interns atom/vlist_atoms register reads,
+  de-interns atom results.
+- Main.hs builds the intern table once at startup via a single O(n)
+  foldl' (the initial O(n²) `Map.size`-per-insert version was fixed
+  in the parallel-seeds PR).
+
+**Actual outcome:** query_ms dropped from ~200ms to ~107ms (median)
+on a single core — beat Rust's 126ms on query time without needing
+parallelism.
+
+**Still-open Phase 2 work** (low priority, likely not needed):
+- Atom interning in the WAM interpreter path itself (would require
+  touching `Value`, `SwitchOnConstantPc`, `callIndexedFact2`). Only
+  useful if we start routing hot predicates through the interpreter
+  rather than FFI. Given that FFI already handles the hot path, this
+  is on hold.
+
+## Phase 2b (unplanned): Skip-Facts
+
+**Goal:** Don't WAM-compile fact predicates that FFI already handles.
+
+**Delivered (PR #1375, commit fcaa885c):**
+- When any FFI kernel is detected, the Main.hs template skips the
+  `buildFact2Code`/`buildFact1Code` calls for category_parent,
+  article_category, and root_category — they'd be allocated but never
+  executed.
+
+**Actual outcome:** 300-scale total_ms dropped from 740ms to 225ms
+(-70%), eliminating the largest single startup cost.
+
+## Phase 3: Expanded Lowering
+
+**Goal:** Bypass the interpreter for more predicates.
 
 **Tasks:**
 1. Add `AtomTable` type (bidirectional String ↔ Int mapping)


### PR DESCRIPTION
  ## Summary

  Two documentation updates closing out the WAM perf work:

  1. **New `docs/design/WAM_PERF_OPTIMIZATION_LOG.md`** — chronological reference of every perf commit on the Haskell and Rust WAM targets. Four-phase Haskell timeline (data
  structures → eliminate repeated work → label resolution + profiling → profile-guided wins), Rust timeline (data structures → choice points → bindings → benchmark specialization),
  cross-target patterns, and a "what did NOT work" section so we don't repeat mistakes.

  2. **Updates to `docs/vision/HASKELL_TARGET_ROADMAP.md`** — replaces the stale "Current state (2026-04-13)" table's pre-optimization 285ms number with the post-parallelization 75ms.
   Marks Phases 1 & 2 done (with the Phase-2 "scoped interning" caveat). Adds Phase 2b (skip-facts) which wasn't in the original plan but turned out to be the single biggest win.

  ## Executive summary from the new log

  | Target | total_ms | query_ms | Notes |
  |---|---|---|---|
  | **Haskell + FFI + parallel** | **75** | **32** | 4 cores, `+RTS -N4` |
  | Haskell single-core | 193 | 107 | after atom interning |
  | Rust + FFI | 126 | — | single-threaded |
  | SWI-Prolog | 311 | — | baseline |
  | Haskell initial | ~4700 | — | naive |

  **Net Haskell speedup from baseline: ~63x.**

  ## Test plan

  - [ ] Review `WAM_PERF_OPTIMIZATION_LOG.md` for accuracy against commit history
  - [ ] Verify roadmap doc reflects actual current state and links to the log

  No code changes, docs only.