### PR TITLE
fix(wam-llvm): free iterator result arrays on exhaustion + arena cleanup

### DIFF
--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -846,6 +846,15 @@ done:
   ret void
 }
 
+; Module-level cleanup: frees the arena buffer. Callers should invoke
+; this after all WAM execution is complete. For native targets, the OS
+; reclaims memory on exit, so this is optional but good practice. For
+; WASM targets (where there is no OS cleanup), this is required.
+define void @wam_cleanup() {
+  call void @wam_arena_destroy()
+  ret void
+}
+
 ; === M5.2: BFS over an %AtomFactPair table ===
 ; Computes the shortest path length (in edges) from %start to %target in
 ; the directed graph described by an array of (from, to) atom ID pairs.
@@ -2912,6 +2921,17 @@ pop_cp:
   ; Iterator exhausted — pop the choice point.
   store i32 %top_idx, i32* %cpn_ptr
 
+  ; Free the malloc'd result array before popping.
+  %pop_fr_ptr = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 8
+  %pop_fr = load i8*, i8** %pop_fr_ptr
+  %pop_fr_null = icmp eq i8* %pop_fr, null
+  br i1 %pop_fr_null, label %pop_restore, label %pop_free_results
+
+pop_free_results:
+  call void @free(i8* %pop_fr)
+  br label %pop_restore
+
+pop_restore:
   ; Restore registers and trail one last time.
   %pop_dst = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 0
   %pop_src = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 1, i32 0


### PR DESCRIPTION
## Summary

Two memory management fixes for the WAM LLVM target. Plugs a leak in the multi-result foreign dispatch iterator and adds a module-level cleanup function for the bump arena.

## 1. Free Iterator Result Arrays on Exhaustion

### Problem

Stream-mode kernels (tc2, td3, wsp3, list_suffix2, category_ancestor) `malloc` a `%Value[]` result array that gets stored in the foreign choice point's `foreign_results` field (field 8). When the iterator exhausts (all results yielded), the choice point was popped but the result array was never freed — a leak proportional to the number of reachable nodes.

### Fix

`@wam_foreign_iter_next`'s `pop_cp` path now reads the `foreign_results` pointer and calls `@free()` before popping the choice point. The pointer is null-checked for safety (though in practice it's always non-null for foreign iterator CPs).

```
pop_cp:
  ; Read foreign_results from the exhausted choice point.
  %pop_fr = load i8*, i8** [field 8]
  ; Null-check → free if non-null.
  br i1 (null?), label %pop_restore, label %pop_free_results
pop_free_results:
  call void @free(i8* %pop_fr)
  br label %pop_restore
pop_restore:
  ; ... existing register/trail restore + CP pop ...
```

This covers all five stream kernels since they all use the same `@wam_foreign_iter_next` codepath.

## 2. Arena Cleanup Function

### Problem

The bump arena (`@wam_arena_buf`) is lazily initialized on first kernel use (1 MiB `malloc`). For native targets, the OS reclaims this on process exit. For WASM targets (no OS cleanup), this buffer leaks.

### Fix

Added `@wam_cleanup()` — a module-level teardown function that calls `@wam_arena_destroy()` to free the arena buffer. Callers should invoke this after all WAM execution is complete.

- **Native targets:** Optional (OS cleanup handles it), but good practice.
- **WASM targets:** Required, since there is no automatic cleanup.

## Files Changed

- `templates/targets/llvm_wam/state.ll.mustache` — result array free in `pop_cp`, `@wam_cleanup` function.

## Commits

- `1f69c455` — fix(wam-llvm): free iterator result arrays on exhaustion + arena cleanup

## Test Plan

- [x] All 27 test suites green (135 assertions unchanged).
- [x] `llvm-as` accepts all generated modules.
- [x] Multi-result dispatch test (3-result iteration) still returns correct count.
- [x] Stream tc2, list_suffix2, category_ancestor all produce correct results with the free path active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
