### PR TITLE
feat(wam-llvm): astar4 auto-detect, stream A*, WASM cleanup wiring (M5.17)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -159,6 +159,8 @@ llvm_recursive_kernel_detector(transitive_distance3,
     llvm_recursive_kernel_transitive_distance).
 llvm_recursive_kernel_detector(weighted_shortest_path3,
     llvm_recursive_kernel_weighted_shortest_path).
+llvm_recursive_kernel_detector(astar_shortest_path4,
+    llvm_recursive_kernel_astar_shortest_path).
 
 %% llvm_recursive_kernel_transitive_distance(+Pred, +Arity, +Clauses, -RecKernel).
 %
@@ -343,6 +345,48 @@ llvm_foreign_lowerable_weighted_shortest_path(Pred, 3, Clauses, WeightPred) :-
     RecGoal =.. [Pred, RecMid, RecTarget, RestCost],
     IsGoal =.. [is, RecCost, PlusExpr],
     PlusExpr =.. [+, W, RestCost].
+
+%% llvm_recursive_kernel_astar_shortest_path(+Pred, +Arity, +Clauses, -RecKernel).
+%
+%  Detects the astar_shortest_path4 clause shape (arity 4):
+%    pred(X, Y, W, _Vis) :- weight_pred(X, Y, W).
+%    pred(X, Y, Cost, Vis) :-
+%        weight_pred(X, Z, W),
+%        pred(Z, Y, RC, [Z|Vis]),
+%        Cost is W + RC.
+%
+%  Extracts weight_pred. If user:direct_semantic_dist/3 is defined,
+%  includes it as direct_dist_pred for runtime heuristic support.
+llvm_recursive_kernel_astar_shortest_path(Pred, Arity, Clauses,
+        recursive_kernel(astar_shortest_path4, Pred/Arity, Config)) :-
+    llvm_foreign_lowerable_astar_shortest_path(Pred, Arity, Clauses, WeightPred),
+    ( predicate_property(user:direct_semantic_dist(_,_,_), defined)
+    -> Config = [weight_pred(WeightPred/3), direct_dist_pred(direct_semantic_dist/3)]
+    ;  Config = [weight_pred(WeightPred/3)]
+    ).
+
+%% llvm_foreign_lowerable_astar_shortest_path(+Pred, +Arity, +Clauses, -WeightPred).
+%
+%  Matches arity-4 predicates with weighted shortest path + visited list.
+%  Base clause: pred(X, Y, W, _) :- weight(X, Y, W).
+%  Recursive clause: pred(X, Y, Cost, Vis) :- weight(X, Z, W), pred(Z, Y, RC, ...), Cost is W + RC.
+llvm_foreign_lowerable_astar_shortest_path(Pred, 4, Clauses, WeightPred) :-
+    member(BaseHead-BaseBody, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseHead \== RecHead,
+    BaseHead =.. [Pred, _, _, _, _],
+    RecHead =.. [Pred, _, _, _, _],
+    % Base body is a single weight_pred call (ignoring visited arg).
+    BaseBody =.. [WeightPred, _, _, _],
+    WeightPred \== Pred,
+    % Recursive body contains weight call, recursive call, and arithmetic.
+    RecBody = (WeightGoal, RestBody),
+    WeightGoal =.. [WeightPred, _, _, _],
+    % Rest may have \+ member(...) interleaved; just check for the recursive call and is/2.
+    term_string(RestBody, RestStr),
+    atom_string(Pred, PredStr),
+    sub_string(RestStr, _, _, _, PredStr),
+    sub_string(RestStr, _, _, _, " is ").
 
 %% llvm_auto_detect_foreign_kernels(+Predicates) is det.
 %
@@ -1252,6 +1296,7 @@ entry:
     %Instruction* getelementptr ([0 x %Instruction], [0 x %Instruction]* null, i32 0, i32 0),
     i32 0, i32* null, i32 0)
   %result = call i1 @run_loop(%WamState* %vm)
+  call void @wam_cleanup()
   %ret = zext i1 %result to i32
   ret i32 %ret
 }', [PredStr, Arity, PredStr])

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -2574,7 +2574,20 @@ entry:
 as_check_t:
   %as_t_tag = call i32 @wam_get_reg_tag(%WamState* %vm, i32 1)
   %as_t_is_atom = icmp eq i32 %as_t_tag, 0
-  br i1 %as_t_is_atom, label %as_run, label %as_bail
+  br i1 %as_t_is_atom, label %as_run, label %as_check_unbound
+
+as_check_unbound:
+  %as_t_unbound = icmp eq i32 %as_t_tag, 6
+  br i1 %as_t_unbound, label %as_stream, label %as_bail
+
+as_stream:
+  ; Stream mode: enumerate all reachable (target, distance) pairs.
+  ; Heuristic only affects exploration order for single-target queries;
+  ; for full enumeration the result set is identical to Dijkstra.
+  %as_st_ok = call i1 @wam_wsp3_stream_run(
+      %WamState* %vm,
+      %WeightedFact* %table, i64 %len, i64 %max_atom_id)
+  ret i1 %as_st_ok
 
 as_run:
   %as_start_id = call i64 @wam_get_reg_payload(%WamState* %vm, i32 0)

--- a/tests/core/test_wam_llvm_astar_autodetect.pl
+++ b/tests/core/test_wam_llvm_astar_autodetect.pl
@@ -1,0 +1,83 @@
+:- encoding(utf8).
+% test_wam_llvm_astar_autodetect.pl
+% Verifies auto-detect recognizes astar_shortest_path4 clause shape.
+%
+% Tests:
+%   1. my_astar_path/4 matched as astar_shortest_path4 with weight_pred.
+%   2. wsp3 auto-detect still works (regression).
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3,
+     llvm_foreign_kernel_spec/3,
+     clear_llvm_foreign_kernel_specs/0]).
+
+% A* clause shape (arity 4 with visited list).
+:- dynamic my_astar_path/4.
+my_astar_path(X, Y, W, _Vis) :- my_aweight(X, Y, W).
+my_astar_path(X, Y, Cost, Vis) :-
+    my_aweight(X, Z, W),
+    my_astar_path(Z, Y, RC, [Z|Vis]),
+    Cost is W + RC.
+
+:- dynamic my_aweight/3.
+my_aweight(a, b, 3.0).
+my_aweight(b, c, 4.0).
+
+% wsp3 clause shape (arity 3, no visited list).
+:- dynamic my_wsp/3.
+my_wsp(X, Y, W) :- my_wedge(X, Y, W).
+my_wsp(X, Y, Cost) :-
+    my_wedge(X, Z, W),
+    my_wsp(Z, Y, RC),
+    Cost is W + RC.
+
+:- dynamic my_wedge/3.
+my_wedge(x, y, 1.0).
+
+test_astar4_autodetect :-
+    format('--- astar4 auto-detect ---~n'),
+    clear_llvm_foreign_kernel_specs,
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project(
+        [user:my_astar_path/4],
+        [ module_name('astar_ad'),
+          target_triple('x86_64-pc-linux-gnu'),
+          target_datalayout(''),
+          foreign_lowering(true)
+        ],
+        LLPath),
+    ( llvm_foreign_kernel_spec(my_astar_path/4, astar_shortest_path4, Config)
+    -> format('  PASS: auto-detect matched astar4, config=~w~n', [Config])
+    ;  format('  FAIL: auto-detect did not match astar4~n'),
+       throw(astar4_autodetect_failed)
+    ),
+    catch(delete_file(LLPath), _, true),
+    clear_llvm_foreign_kernel_specs.
+
+test_wsp3_autodetect :-
+    format('--- wsp3 auto-detect (regression) ---~n'),
+    clear_llvm_foreign_kernel_specs,
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    write_wam_llvm_project(
+        [user:my_wsp/3],
+        [ module_name('wsp_ad'),
+          target_triple('x86_64-pc-linux-gnu'),
+          target_datalayout(''),
+          foreign_lowering(true)
+        ],
+        LLPath),
+    ( llvm_foreign_kernel_spec(my_wsp/3, weighted_shortest_path3, _)
+    -> format('  PASS: auto-detect matched wsp3~n')
+    ;  format('  FAIL: auto-detect did not match wsp3~n'),
+       throw(wsp3_autodetect_failed)
+    ),
+    catch(delete_file(LLPath), _, true),
+    clear_llvm_foreign_kernel_specs.
+
+test_all :-
+    catch(test_astar4_autodetect, E1,
+        format('  ERROR: ~w~n', [E1])),
+    catch(test_wsp3_autodetect, E2,
+        format('  ERROR: ~w~n', [E2])).
+
+:- initialization(test_all, main).


### PR DESCRIPTION
## Summary

Closes the last three gaps in the WAM LLVM foreign kernel infrastructure: adds the missing auto-detect matcher for `astar_shortest_path4` (completing auto-detect coverage for all 7 kernel kinds), upgrades A* to stream mode, and wires `@wam_cleanup()` into WASM export wrappers for proper memory cleanup in environments without OS reclamation.

## 1. astar_shortest_path4 Auto-Detect

### Clause shape

```prolog
my_astar(X, Y, W, _Vis) :- weight(X, Y, W).
my_astar(X, Y, Cost, Vis) :-
    weight(X, Z, W),
    my_astar(Z, Y, RC, [Z|Vis]),
    Cost is W + RC.
```

### Matcher

`llvm_foreign_lowerable_astar_shortest_path/4` recognizes arity-4 predicates where:
- Two clause bodies (neither `true`)
- Base body is a single `weight_pred/3` call (ignoring the visited-list arg)
- Recursive body contains the weight call, a recursive call, and `Cost is W + RC` arithmetic

### Config extraction

- `weight_pred(Pred/3)` — always extracted from the base body
- `direct_dist_pred(direct_semantic_dist/3)` — included if `user:direct_semantic_dist/3` is defined, enabling runtime heuristic support

### Auto-detect coverage

| Kernel kind | Auto-detect | Since |
|---|---|---|
| `transitive_closure2` | yes | M5.6c |
| `transitive_distance3` | yes | M5.6c |
| `weighted_shortest_path3` | yes | M5.6c |
| `countdown_sum2` | yes | M5.13 |
| `list_suffix2` | yes | M5.15 |
| `category_ancestor` | yes | M5.16 |
| `astar_shortest_path4` | **yes** | **this PR** |

All 7 kernel kinds now support all three foreign-lowering entry paths: directive, options list, and auto-detect.

## 2. Stream-Mode A*

`@wam_astar4_run` now checks A2's tag:
- **A2 is atom (tag=0):** Deterministic A* to specific target (existing behavior, uses heuristic).
- **A2 is unbound (tag=6):** Stream mode — enumerates all reachable (target, distance) pairs.

The stream path delegates to `@wam_wsp3_stream_run` (full Dijkstra exploration). This is correct because the heuristic only affects exploration order for single-target queries — for full enumeration, the result set and optimal distances are identical regardless of heuristic.

All 7 kernel kinds now support stream mode where applicable:

| Kernel | Deterministic | Stream |
|---|---|---|
| `transitive_closure2` | A2 bound → boolean | A2 unbound → all reachable |
| `transitive_distance3` | A2 bound → single pair | A2 unbound → all (target, dist) |
| `weighted_shortest_path3` | A2 bound → single pair | A2 unbound → all (target, dist) |
| `astar_shortest_path4` | A2 bound → single pair | A2 unbound → all (target, dist) |
| `countdown_sum2` | always deterministic | N/A |
| `list_suffix2` | N/A | always stream |
| `category_ancestor` | N/A | always stream (depth-bounded) |

## 3. WASM Cleanup Wiring

### Problem

`@wam_cleanup()` (added in the memory cleanup PR) frees the 1 MiB arena buffer. Native targets don't need it (OS reclaims on exit), but WASM targets have no automatic cleanup — the arena would leak on every invocation.

### Fix

`generate_wasm_exports/2` now emits `call void @wam_cleanup()` after `@run_loop` in every WASM export wrapper:

```llvm
define dso_local i32 @pred_wasm() #0 {
entry:
  %vm = call %WamState* @wam_state_new(...)
  %result = call i1 @run_loop(%WamState* %vm)
  call void @wam_cleanup()          ; ← new
  %ret = zext i1 %result to i32
  ret i32 %ret
}
```

## Test

**File:** `tests/core/test_wam_llvm_astar_autodetect.pl` — 2 assertions.

| Case | What it tests |
|---|---|
| `my_astar_path/4` matched as `astar_shortest_path4` | New auto-detect matcher |
| `my_wsp/3` matched as `weighted_shortest_path3` | Regression for existing wsp3 matcher |

## Test Coverage

| Suite | Assertions | Scope |
|---|---|---|
| Prior 29 suites | 141 | regression |
| `test_wam_llvm_astar_autodetect.pl` (M5.17) | 2 | **new** |
| **Total** | **143** | |

## Files Changed

- `src/unifyweaver/targets/wam_llvm_target.pl` — astar4 detector registration, `llvm_recursive_kernel_astar_shortest_path/4`, `llvm_foreign_lowerable_astar_shortest_path/4`, WASM export `@wam_cleanup()` call.
- `templates/targets/llvm_wam/state.ll.mustache` — stream-mode branch in `@wam_astar4_run`.
- `tests/core/test_wam_llvm_astar_autodetect.pl` — new.

## Commits

- `76bb0049` — feat(wam-llvm): astar4 auto-detect, stream A*, WASM cleanup wiring (M5.17)

## Test Plan

- [x] Auto-detect matches `my_astar_path/4` as `astar_shortest_path4` with `weight_pred` config.
- [x] Auto-detect regression: `my_wsp/3` still matched as `weighted_shortest_path3`.
- [x] A* deterministic tests (zero heuristic, non-zero heuristic, runtime heuristic) all green.
- [x] WASM export includes `@wam_cleanup()` call.
- [x] All 29 prior test suites green (141 assertions unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
