### PR TITLE
perf(wam-haskell): multi-output kernel support + transitive_distance3 + 10k GC investigation

### DIFF
--- a/src/unifyweaver/core/recursive_kernel_detection.pl
+++ b/src/unifyweaver/core/recursive_kernel_detection.pl
@@ -80,6 +80,7 @@ registered_kernel(KernelKind, Arity) :-
 
 kernel_detector(category_ancestor, detect_category_ancestor).
 kernel_detector(transitive_closure2, detect_transitive_closure).
+kernel_detector(transitive_distance3, detect_transitive_distance).
 
 %% =====================================================================
 %% Kernel metadata
@@ -87,15 +88,19 @@ kernel_detector(transitive_closure2, detect_transitive_closure).
 
 kernel_native_kind(category_ancestor, category_ancestor).
 kernel_native_kind(transitive_closure2, transitive_closure2).
+kernel_native_kind(transitive_distance3, transitive_distance3).
 
 kernel_result_layout(category_ancestor, tuple(1)).
 kernel_result_layout(transitive_closure2, tuple(1)).
+kernel_result_layout(transitive_distance3, tuple(2)).  % (target, distance)
 
 kernel_result_mode(category_ancestor, stream).
 kernel_result_mode(transitive_closure2, stream).
+kernel_result_mode(transitive_distance3, stream).
 
 kernel_expected_arity(category_ancestor, 4).
 kernel_expected_arity(transitive_closure2, 2).
+kernel_expected_arity(transitive_distance3, 3).
 
 %% =====================================================================
 %% Register layout — describes input/output registers for each kernel
@@ -117,6 +122,12 @@ kernel_register_layout(category_ancestor, [
 kernel_register_layout(transitive_closure2, [
     input(1, atom),          % source node
     output(2, atom)          % target node (result)
+]).
+
+kernel_register_layout(transitive_distance3, [
+    input(1, atom),          % source node
+    output(2, atom),         % target node (result, part 1 of tuple)
+    output(3, integer)       % distance (result, part 2 of tuple)
 ]).
 
 %% =====================================================================
@@ -148,12 +159,19 @@ kernel_native_call(transitive_closure2,
         reg(1)                            % source node
     ])).
 
+kernel_native_call(transitive_distance3,
+    call(nativeKernel_transitive_distance, [
+        config_facts_from(edge_pred),     % edges map
+        reg(1)                            % source node
+    ])).
+
 %% =====================================================================
 %% Template file mapping — Mustache template for each kernel kind
 %% =====================================================================
 
 kernel_template_file(category_ancestor, 'kernel_category_ancestor.hs.mustache').
 kernel_template_file(transitive_closure2, 'kernel_transitive_closure.hs.mustache').
+kernel_template_file(transitive_distance3, 'kernel_transitive_distance.hs.mustache').
 
 %% =====================================================================
 %% Detector: category_ancestor
@@ -239,6 +257,97 @@ detect_transitive_closure(Pred, 2, Clauses, Kernel) :-
     EdgeArg2 == RecMid,
     Kernel = recursive_kernel(transitive_closure2, Pred/2,
                               [edge_pred(EdgePred/2)]).
+
+%% =====================================================================
+%% Detector: transitive_distance (BFS with distance)
+%%
+%% Matches the shape:
+%%   tdist(X, Y, 1) :- edge(X, Y).
+%%   tdist(X, Y, D) :- edge(X, Z), tdist(Z, Y, D1), D is D1 + 1.
+%%
+%% Or with the 1 spelled out as:
+%%   tdist(X, Y, D) :- D = 1, edge(X, Y).
+%%
+%% Extracted config: edge_pred(EdgePred/2).
+%% =====================================================================
+
+detect_transitive_distance(Pred, 3, Clauses, Kernel) :-
+    member(BaseHead-BaseBody, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseBody \= RecBody,
+    BaseHead =.. [Pred, BaseStart, BaseTarget, BaseDist],
+    RecHead =.. [Pred, RecStart, RecTarget, RecDist],
+    % Base clause: either `tdist(X,Y,1) :- edge(X,Y)` or with D=1 in body
+    find_edge_in_body(BaseBody, BaseStart, BaseTarget, EdgePred),
+    % Check base binds distance to 1 (either literally or in head)
+    (   BaseDist == 1
+    ;   find_unify_one(BaseBody, BaseDist)
+    ),
+    % Recursive clause: find edge(RecStart, Mid), recursive call, D is D1+1
+    find_edge_from(RecBody, RecStart, EdgePred, Mid),
+    find_recursive_call(RecBody, Pred, Mid, RecTarget, D1),
+    find_is_plus_one(RecBody, RecDist, D1),
+    Kernel = recursive_kernel(transitive_distance3, Pred/3,
+                              [edge_pred(EdgePred/2)]).
+
+%% find_edge_in_body(+Body, +Start, +Target, -EdgePred)
+%  Find `edge(Start, Target)` call somewhere in the body (base clause).
+find_edge_in_body((A, _), Start, Target, EdgePred) :-
+    find_edge_in_body(A, Start, Target, EdgePred), !.
+find_edge_in_body((_, B), Start, Target, EdgePred) :-
+    find_edge_in_body(B, Start, Target, EdgePred), !.
+find_edge_in_body(Goal, Start, Target, EdgePred) :-
+    Goal \= (_, _),
+    Goal \= (_ = _),
+    Goal \= (_ is _),
+    compound(Goal),
+    Goal =.. [EdgePred, Arg1, Arg2],
+    EdgePred \= member,
+    Arg1 == Start,
+    Arg2 == Target.
+
+%% find_edge_from(+Body, +Start, -EdgePred, -Mid)
+%  Find `EdgePred(Start, Mid)` call — EdgePred name bound from caller.
+find_edge_from((A, _), Start, EdgePred, Mid) :-
+    find_edge_from(A, Start, EdgePred, Mid), !.
+find_edge_from((_, B), Start, EdgePred, Mid) :-
+    find_edge_from(B, Start, EdgePred, Mid), !.
+find_edge_from(Goal, Start, EdgePred, Mid) :-
+    Goal \= (_, _),
+    compound(Goal),
+    Goal =.. [EdgePred, Arg1, Arg2],
+    Arg1 == Start,
+    Mid = Arg2.
+
+%% find_recursive_call(+Body, +Pred, +Start, +Target, -Dist)
+%  Find `Pred(Start, Target, Dist)` call.
+find_recursive_call((A, _), Pred, Start, Target, Dist) :-
+    find_recursive_call(A, Pred, Start, Target, Dist), !.
+find_recursive_call((_, B), Pred, Start, Target, Dist) :-
+    find_recursive_call(B, Pred, Start, Target, Dist), !.
+find_recursive_call(Goal, Pred, Start, Target, Dist) :-
+    Goal \= (_, _),
+    compound(Goal),
+    Goal =.. [Pred, A1, A2, A3],
+    A1 == Start,
+    A2 == Target,
+    Dist = A3.
+
+%% find_is_plus_one(+Body, +Target, +Source)
+%  Find `Target is Source + 1`.
+find_is_plus_one((A, _), T, S) :- find_is_plus_one(A, T, S), !.
+find_is_plus_one((_, B), T, S) :- find_is_plus_one(B, T, S), !.
+find_is_plus_one((T is Expr), T0, S) :-
+    T == T0,
+    Expr = S0 + 1,
+    S0 == S.
+
+%% find_unify_one(+Body, +Var)
+%  Find `Var = 1` or `Var is 1`.
+find_unify_one((A, _), V) :- find_unify_one(A, V), !.
+find_unify_one((_, B), V) :- find_unify_one(B, V), !.
+find_unify_one((V1 = 1), V) :- V1 == V.
+find_unify_one((V1 is 1), V) :- V1 == V.
 
 %% =====================================================================
 %% Helper: sub_term/2 — check if a term appears anywhere in a body

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -285,11 +285,13 @@ emit_ef_clause(Key, RegSpecs, call(FuncName, ArgSpecs)) :-
     emit_input_let_bindings(InputRegs, first),
     % Emit config bindings from ArgSpecs
     emit_config_let_bindings(ArgSpecs),
-    % Find output register(s)
+    % Find output register(s). Single-output kernels (category_ancestor,
+    % transitive_closure2) keep the existing fast path; multi-output
+    % kernels (transitive_distance3, weighted_shortest_path3) use a
+    % tuple-based bindResult that binds multiple registers per solution.
     include(is_output_reg, RegSpecs, OutputRegs),
-    OutputRegs = [output(OutRegN, OutType)|_],
     % Emit case expression over input regs, then native call + binding inside
-    emit_case_and_call(InputRegs, OutRegN, OutType, FuncName, ArgSpecs),
+    emit_case_and_call(InputRegs, OutputRegs, FuncName, ArgSpecs),
     format('~n').
 
 is_input_reg(input(_, _)).
@@ -360,32 +362,32 @@ emit_reg_extraction(VarName, vlist_atoms) :-
 emit_reg_extraction(VarName, integer) :-
     format('~wI', [VarName]).
 
-%% emit_case_and_call(+InputRegs, +OutRegN, +OutType, +FuncName, +ArgSpecs)
+%% emit_case_and_call(+InputRegs, +OutputRegs, +FuncName, +ArgSpecs)
 %  Emit the case expression that pattern-matches inputs, then the native
 %  call and stream binding INSIDE the case branch (so extracted string
 %  variables are in scope for the call).
-emit_case_and_call(InputRegs, OutRegN, OutType, FuncName, ArgSpecs) :-
+emit_case_and_call(InputRegs, OutputRegs, FuncName, ArgSpecs) :-
     length(InputRegs, NInputs),
     (   NInputs =:= 1
     ->  InputRegs = [input(RegN1, _)],
         reg_var_name(RegN1, ScrutName),
         format('  in case ~w of~n', [ScrutName]),
-        emit_single_case_branch(InputRegs, OutRegN, OutType, FuncName, ArgSpecs)
+        emit_single_case_branch(InputRegs, OutputRegs, FuncName, ArgSpecs)
     ;   format('  in case ('),
         emit_scrutinee_tuple(InputRegs, first),
         format(') of~n'),
         format('    ('),
         emit_pattern_tuple(InputRegs, first),
         format(') ->~n'),
-        emit_native_call_and_binding(OutRegN, OutType, FuncName, ArgSpecs, InputRegs, "      ")
+        emit_native_call_and_binding(OutputRegs, FuncName, ArgSpecs, InputRegs, "      ")
     ),
     format('    _ -> Nothing~n').
 
-emit_single_case_branch([input(RegN, Type)|_], OutRegN, OutType, FuncName, ArgSpecs) :-
+emit_single_case_branch([input(RegN, Type)|_], OutputRegs, FuncName, ArgSpecs) :-
     reg_var_name(RegN, VarName),
     type_pattern(Type, VarName, Pattern),
     format('    ~w ->~n', [Pattern]),
-    emit_native_call_and_binding(OutRegN, OutType, FuncName, ArgSpecs, [input(RegN, Type)], "      ").
+    emit_native_call_and_binding(OutputRegs, FuncName, ArgSpecs, [input(RegN, Type)], "      ").
 
 emit_scrutinee_tuple([], _).
 emit_scrutinee_tuple([input(RegN, _)|Rest], Pos) :-
@@ -409,18 +411,27 @@ type_pattern(integer, VarName, Pattern) :-
 type_pattern(vlist_atoms, VarName, Pattern) :-
     format(atom(Pattern), 'VList ~wL', [VarName]).
 
-%% emit_native_call_and_binding(+OutRegN, +OutType, +FuncName, +ArgSpecs, +InputRegs, +Indent)
+%% emit_native_call_and_binding(+OutputRegs, +FuncName, +ArgSpecs, +InputRegs, +Indent)
 %  Emit the native function call followed by stream binding, all inside
 %  a case branch at the given indentation level.
-emit_native_call_and_binding(OutRegN, OutType, FuncName, ArgSpecs, InputRegs, Indent) :-
+%  Single-output kernels (length OutputRegs = 1) keep the original fast
+%  path using HopsRetry. Multi-output kernels use a generalized
+%  FFIStreamRetry variant.
+emit_native_call_and_binding(OutputRegs, FuncName, ArgSpecs, InputRegs, Indent) :-
     format('~wlet results = ~w', [Indent, FuncName]),
     emit_call_args(ArgSpecs, InputRegs),
     format('~n'),
-    emit_stream_binding(OutRegN, OutType, Indent).
+    length(OutputRegs, NOuts),
+    (   NOuts =:= 1
+    ->  OutputRegs = [output(OutRegN, OutType)],
+        emit_stream_binding_single(OutRegN, OutType, Indent)
+    ;   emit_stream_binding_multi(OutputRegs, Indent)
+    ).
 
-%% emit_stream_binding(+OutRegN, +OutType, +Indent)
-%  Emit the stream-mode result binding: first result bound, rest as CPs.
-emit_stream_binding(OutRegN, OutType, Indent) :-
+%% emit_stream_binding_single(+OutRegN, +OutType, +Indent)
+%  Single-output stream binding. Unchanged from the original for
+%  back-compat with category_ancestor and transitive_closure2.
+emit_stream_binding_single(OutRegN, OutType, Indent) :-
     result_wrap_expr(OutType, WrapExpr),
     format('~w    retPC = wsCP s~n', [Indent]),
     format('~w    outReg = derefVar (wsBindings s) $ fromMaybe (Unbound (-1)) (IM.lookup ~w (wsRegs s))~n', [Indent, OutRegN]),
@@ -447,6 +458,168 @@ emit_stream_binding(OutRegN, OutType, Indent) :-
     format('~w          , cpBuiltin = Just (HopsRetry outVar (map fromIntegral restResults) retPC)~n', [Indent]),
     format('~w          }~n', [Indent]),
     format('~w    in Just (s1 { wsCPs = cp : wsCPs s, wsCPsLen = wsCPsLen s + 1 })~n', [Indent]).
+
+%% emit_stream_binding_multi(+OutputRegs, +Indent)
+%  Multi-output stream binding. The kernel returns `[(T1, T2, ...)]` and
+%  bindResult takes a tuple, binding each output to its register.
+%  Uses FFIStreamRetry to store remaining tuples (as pre-wrapped Values)
+%  in the choice point.
+emit_stream_binding_multi(OutputRegs, Indent) :-
+    length(OutputRegs, NOuts),
+    format('~w    retPC = wsCP s~n', [Indent]),
+    % Deref each output register
+    emit_multi_out_derefs(OutputRegs, Indent),
+    % Emit bindResult: pattern matches a tuple, binds each output
+    format('~w    bindResult ', [Indent]),
+    emit_tuple_pattern(NOuts),
+    format(' =~n', []),
+    format('~w      let ', [Indent]),
+    emit_multi_wrap_bindings(OutputRegs, 1),
+    format('~w      in s { wsPC = retPC~n', [Indent]),
+    emit_multi_reg_updates(OutputRegs, Indent),
+    emit_multi_binding_updates(OutputRegs, Indent),
+    emit_multi_trail_updates(OutputRegs, Indent),
+    format('~w         , wsTrailLen = wsTrailLen s + ~w~n', [Indent, NOuts]),
+    format('~w         }~n', [Indent]),
+    % Dispatch over result stream
+    format('~win case results of~n', [Indent]),
+    format('~w  [] -> Nothing~n', [Indent]),
+    format('~w  [h] -> Just (bindResult h)~n', [Indent]),
+    format('~w  (h:restResults) ->~n', [Indent]),
+    format('~w    let s1 = bindResult h~n', [Indent]),
+    emit_multi_outvars(OutputRegs, Indent),
+    format('~w        restWrapped = map (\\', [Indent]),
+    emit_tuple_pattern(NOuts),
+    format(' -> [', []),
+    emit_multi_wrap_list(OutputRegs, 1),
+    format(']) restResults~n', []),
+    format('~w        cp = ChoicePoint~n', [Indent]),
+    format('~w          { cpNextPC = retPC, cpRegs = wsRegs s, cpStack = wsStack s~n', [Indent]),
+    format('~w          , cpCP = wsCP s, cpTrailLen = wsTrailLen s~n', [Indent]),
+    format('~w          , cpHeapLen = wsHeapLen s, cpBindings = wsBindings s~n', [Indent]),
+    format('~w          , cpCutBar = wsCutBar s, cpAggFrame = Nothing~n', [Indent]),
+    format('~w          , cpBuiltin = Just (FFIStreamRetry ', [Indent]),
+    emit_outregs_list(OutputRegs),
+    format(' outVars restWrapped retPC)~n', []),
+    format('~w          }~n', [Indent]),
+    format('~w    in Just (s1 { wsCPs = cp : wsCPs s, wsCPsLen = wsCPsLen s + 1 })~n', [Indent]).
+
+%% Helpers for multi-output emission:
+
+% Emit `outReg_1 = ...`, `outReg_2 = ...`
+emit_multi_out_derefs([], _).
+emit_multi_out_derefs([output(RegN, _)|Rest], Indent) :-
+    format('~w    outReg_~w = derefVar (wsBindings s) $ fromMaybe (Unbound (-1)) (IM.lookup ~w (wsRegs s))~n',
+           [Indent, RegN, RegN]),
+    emit_multi_out_derefs(Rest, Indent).
+
+% Emit tuple pattern like (rv_1, rv_2)
+emit_tuple_pattern(1) :- format('rv_1', []).
+emit_tuple_pattern(N) :-
+    N > 1,
+    format('(', []),
+    emit_tuple_pattern_args(1, N),
+    format(')', []).
+
+emit_tuple_pattern_args(I, N) :-
+    I < N, !,
+    format('rv_~w, ', [I]),
+    I1 is I + 1,
+    emit_tuple_pattern_args(I1, N).
+emit_tuple_pattern_args(N, N) :-
+    format('rv_~w', [N]).
+
+% Emit `w_1 = WrapExpr_1; w_2 = WrapExpr_2` for wrapped values
+emit_multi_wrap_bindings([], _) :- format('~n', []).
+emit_multi_wrap_bindings([output(_, Type)|Rest], I) :-
+    result_wrap_expr_for_rv(Type, I, WrapExpr),
+    (   I =:= 1
+    ->  format('w_~w = ~w', [I, WrapExpr])
+    ;   format('; w_~w = ~w', [I, WrapExpr])
+    ),
+    I1 is I + 1,
+    emit_multi_wrap_bindings(Rest, I1).
+
+% Emit `, wsRegs = IM.insert R1 w_1 $ IM.insert R2 w_2 $ wsRegs s`
+emit_multi_reg_updates(OutputRegs, Indent) :-
+    format('~w         , wsRegs = ', [Indent]),
+    emit_reg_insert_chain(OutputRegs, 1),
+    format('wsRegs s~n', []).
+
+emit_reg_insert_chain([], _).
+emit_reg_insert_chain([output(RegN, _)|Rest], I) :-
+    format('IM.insert ~w w_~w $ ', [RegN, I]),
+    I1 is I + 1,
+    emit_reg_insert_chain(Rest, I1).
+
+% Emit `, wsBindings = IM.insert vid_1 w_1 $ IM.insert vid_2 w_2 $ wsBindings s`
+% Only inserts for Unbound outputs; bound outputs are no-ops.
+emit_multi_binding_updates(OutputRegs, Indent) :-
+    format('~w         , wsBindings = ', [Indent]),
+    emit_binding_insert_chain(OutputRegs, 1),
+    format('wsBindings s~n', []).
+
+emit_binding_insert_chain([], _).
+emit_binding_insert_chain([output(RegN, _)|Rest], I) :-
+    format('(case outReg_~w of { Unbound v -> IM.insert v w_~w; _ -> id }) $ ',
+           [RegN, I]),
+    I1 is I + 1,
+    emit_binding_insert_chain(Rest, I1).
+
+% Emit `, wsTrail = TrailEntry vid_1 _ : TrailEntry vid_2 _ : wsTrail s`
+emit_multi_trail_updates(OutputRegs, Indent) :-
+    format('~w         , wsTrail = ', [Indent]),
+    emit_trail_entry_chain(OutputRegs, 1),
+    format('wsTrail s~n', []).
+
+emit_trail_entry_chain([], _).
+emit_trail_entry_chain([output(RegN, _)|Rest], I) :-
+    format('(case outReg_~w of { Unbound v -> (TrailEntry v (IM.lookup v (wsBindings s)) :); _ -> id }) $ ',
+           [RegN]),
+    I1 is I + 1,
+    emit_trail_entry_chain(Rest, I1).
+
+% outVars list: [case outReg_R1 of { Unbound v -> v; _ -> -1 }, ...]
+emit_multi_outvars(OutputRegs, Indent) :-
+    format('~w        outVars = [', [Indent]),
+    emit_outvars_list(OutputRegs, 1),
+    format(']~n', []).
+
+emit_outvars_list([], _).
+emit_outvars_list([output(RegN, _)|Rest], I) :-
+    (   I =:= 1 -> true ; format(', ', []) ),
+    format('case outReg_~w of { Unbound v -> v; _ -> -1 }', [RegN]),
+    I1 is I + 1,
+    emit_outvars_list(Rest, I1).
+
+% Output register numbers list for FFIStreamRetry
+emit_outregs_list(OutputRegs) :-
+    format('[', []),
+    emit_outregs_list_items(OutputRegs, 1),
+    format(']', []).
+
+emit_outregs_list_items([], _).
+emit_outregs_list_items([output(RegN, _)|Rest], I) :-
+    (   I =:= 1 -> true ; format(', ', []) ),
+    format('~w', [RegN]),
+    I1 is I + 1,
+    emit_outregs_list_items(Rest, I1).
+
+% restWrapped list wrapping each tuple value
+emit_multi_wrap_list([], _).
+emit_multi_wrap_list([output(_, Type)|Rest], I) :-
+    result_wrap_expr_for_rv(Type, I, WrapExpr),
+    (   I =:= 1 -> true ; format(', ', []) ),
+    format('~w', [WrapExpr]),
+    I1 is I + 1,
+    emit_multi_wrap_list(Rest, I1).
+
+%% result_wrap_expr_for_rv(+Type, +Index, -HaskellExpr)
+%  Like result_wrap_expr but using rv_<I> instead of rv.
+result_wrap_expr_for_rv(integer, I, Expr) :-
+    format(atom(Expr), 'Integer (fromIntegral rv_~w)', [I]).
+result_wrap_expr_for_rv(atom, I, Expr) :-
+    format(atom(Expr), 'Atom (fromMaybe "" (IM.lookup rv_~w (wcAtomDeintern ctx)))', [I]).
 
 %% result_wrap_expr(+Type, -HaskellExpr)
 %  Haskell expression wrapping `rv` (kernel result) into a Value
@@ -770,6 +943,32 @@ resumeBuiltin (HopsRetry vid (h:hs) retPC) cp rest s =
       newCPs = case hs of
         [] -> rest
         _  -> cp { cpBuiltin = Just (HopsRetry vid hs retPC) } : rest
+      diff = wsTrailLen s - cpTrailLen cp
+  in Just s { wsPC = retPC, wsRegs = newRegs, wsStack = cpStack cp
+            , wsCP = cpCP cp
+            , wsTrail = drop diff (wsTrail s)
+            , wsTrailLen = cpTrailLen cp
+            , wsHeap = take (cpHeapLen cp) (wsHeap s)
+            , wsHeapLen = cpHeapLen cp
+            , wsBindings = newBindings, wsCutBar = cpCutBar cp, wsCPs = newCPs }
+
+-- Multi-output FFI retry: each remaining tuple is already a list of
+-- wrapped Values matching outRegs/outVars in order.
+resumeBuiltin (FFIStreamRetry _ _ [] _) _ rest s =
+  backtrack (s { wsCPs = rest, wsCPsLen = wsCPsLen s - 1 })
+resumeBuiltin (FFIStreamRetry outRegs outVars (tuple:rest_tuples) retPC) cp rest s =
+  let -- Insert each (reg, value) from the tuple into the registers.
+      newRegs = foldr (\\(rN, v) m -> IM.insert rN v m) (cpRegs cp)
+                      (zip outRegs tuple)
+      -- Insert each (varId, value) into bindings, skipping varId = -1
+      -- (meaning the output was originally bound, so no binding update).
+      newBindings = foldr (\\(vid, v) m ->
+                             if vid == -1 then m else IM.insert vid v m)
+                          (cpBindings cp)
+                          (zip outVars tuple)
+      newCPs = case rest_tuples of
+        [] -> rest
+        _  -> cp { cpBuiltin = Just (FFIStreamRetry outRegs outVars rest_tuples retPC) } : rest
       diff = wsTrailLen s - cpTrailLen cp
   in Just s { wsPC = retPC, wsRegs = newRegs, wsStack = cpStack cp
             , wsCP = cpCP cp
@@ -2012,6 +2211,11 @@ data ChoicePoint = ChoicePoint
 data BuiltinState
   = FactRetry !Int ![String] !Int  -- variable ID, remaining values, returnPC
   | HopsRetry !Int ![Int] !Int     -- variable ID, remaining Hops values, returnPC
+    -- Multi-output FFI kernel retry. Each remaining tuple is already
+    -- wrapped as a list of Values (pre-interned / wrapped at call site).
+    -- outRegs and outVars are parallel lists (same length as each tuple).
+    -- outVars contains -1 for originally-bound outputs (no binding update).
+  | FFIStreamRetry ![Int] ![Int] ![[Value]] !Int  -- outRegs, outVars, remaining tuples, returnPC
   deriving (Show)
 
 -- | Aggregate frame for begin_aggregate/end_aggregate.

--- a/templates/targets/haskell_wam/kernel_transitive_distance.hs.mustache
+++ b/templates/targets/haskell_wam/kernel_transitive_distance.hs.mustache
@@ -1,0 +1,24 @@
+-- | Native BFS with distance tracking for binary edge relations.
+-- Auto-generated from kernel detection. Edge predicate: {{edge_pred}}.
+-- Given a source node, returns a stream of (target, distance) pairs
+-- where distance is the shortest path length from source to target
+-- through the edge relation.
+--
+-- Atoms are interned at the FFI boundary so lookups are IntMap-based
+-- (no hashing in the hot loop). The returned target is an interned
+-- Int that the executeForeign wrapper will de-intern back to an atom.
+nativeKernel_transitive_distance :: IM.IntMap [Int] -> Int -> [(Int, Int)]
+nativeKernel_transitive_distance edges source =
+  bfs [(source, 0)] IS.empty []
+  where
+    bfs [] _ acc = acc
+    bfs ((node, dist):queue) visited acc
+      | IS.member node visited = bfs queue visited acc
+      | otherwise =
+          let visited' = IS.insert node visited
+              neighbors = IM.findWithDefault [] node edges
+              expanded = [(n, dist + 1) | n <- neighbors,
+                                          not (IS.member n visited')]
+              -- Don't emit the source itself (distance 0 is trivial)
+              acc' = if node == source then acc else acc ++ [(node, dist)]
+          in bfs (queue ++ expanded) visited' acc'


### PR DESCRIPTION
  ## Summary

  Two pieces of work bundled:

  ### 1. Multi-output kernel support

  Implements the `WAM_MULTI_OUTPUT_KERNELS` proposal. The executeForeign generator previously only emitted binding code for a single output register. This refactors
  `emit_stream_binding` to handle kernels with N outputs where each solution is a tuple of Values:

  - **Single-output kernels** (`category_ancestor`, `transitive_closure2`) keep the original fast path — dispatches to `emit_stream_binding_single`
  - **Multi-output kernels** use `emit_stream_binding_multi` which:
    - Pattern-matches a tuple `(rv_1, rv_2, ...)` in `bindResult`
    - Binds each output to its register via an `IM.insert` chain
    - Updates bindings only for originally-unbound outputs
    - Adds trail entries for each bound variable
    - Stores remaining tuples as pre-wrapped `[[Value]]` in `FFIStreamRetry`

  New `BuiltinState` variant `FFIStreamRetry` carries `(outRegs, outVars, remaining tuples, retPC)`. `resumeBuiltin` handles it by folding inserts over the tuple.

  ### 2. First multi-output kernel: `transitive_distance3/3`

  Canonical Prolog shape:
  ```prolog
  tdist(X, Y, 1) :- edge(X, Y).
  tdist(X, Y, D) :- edge(X, Z), tdist(Z, Y, D1), D is D1 + 1.
  ```
  Detector uses explicit walker predicates (not sub_term, which was too permissive). Metadata: result_layout tuple(2), register layout output(2, atom) + output(3, integer), native call needs edge_facts + source.
 
  Native kernel: BFS with IntSet visited and distance tracked in queue. Returns [(Int, Int)] where the target is interned (de-interned by executeForeign wrapper).

  3. 10k GC investigation (findings, no code change)

  Profiled with +RTS -s: 36% productivity (64% in parallel GC) at 10k scale. Tried -A16m, -A32m, -A64m, -A256m, -qa (thread affinity), -qn4 (limit GC threads). None gave stable
  improvement over default on this WSL2 host. The 2.9x→3.5x scaling gap from 5k→10k is intrinsic (parallel GC work imbalance, HashMap contention). Not pursued — current scaling is
  acceptable.

  Verification

  - All existing tests pass (test_wam_haskell_target, phase1, phase3)
  - tdist/3 kernel detected, generated, compiles cleanly, runs on a diamond-shape test graph
  - 300-scale benchmark: query 31-40ms (consistent with pre-change median 32ms)
  - 10k-scale benchmark: query 282-326ms (consistent with pre-change median 284ms)
  - tuple_count=213 (300), 462 (10k) — match reference

  Test plan

  - Run tests/test_wam_haskell_target.pl — all pass
  - Generate and build transitive_distance3 test (/tmp/gen_tdist_test.pl) — compiles cleanly
  - Run effective_distance benchmark at 300 and 10k — numbers match baseline
  - Review generated WamRuntime.hs for transitive_distance3 — tuple binding looks correct

  Follow-ups

  Proposal scope is now clear enough that additional multi-output kernels (weighted_shortest_path3, astar_shortest_path4) can follow the same pattern — just add template + detector +
  metadata entries.