### PR TITLE
docs(wam-haskell): intra-query parallelism design — philosophy, spec,…

### DIFF
--- a/docs/design/WAM_HASKELL_INTRA_QUERY_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_HASKELL_INTRA_QUERY_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,323 @@
+# Haskell WAM Intra-Query Parallelism: Implementation Plan
+
+> **Phased work breakdown** for implementing intra-query parallelism per
+> the spec in `WAM_HASKELL_INTRA_QUERY_SPEC.md`. Each phase produces
+> something testable and is committable as its own PR. Skip ahead by
+> phase when picking up this work.
+
+## Overall shape
+
+Six phases, ordered to minimize integration risk:
+
+|Phase|Scope|Risk|Demonstrable outcome|
+|---|---|---|---|
+|4.0|Benchmark workload that *needs* intra-query parallelism|Low|Reproducible test case showing seed-level parallelism doesn't help|
+|4.1|Instructions + compiler emission|Low|`ParTryMeElse` emitted for annotated predicates, sequential semantics preserved|
+|4.2|Runtime fork on `ParTryMeElse` (sum/count merges only)|Med|First measurable speedup on Phase 4.0 benchmark|
+|4.3|Findall/bag/set merge strategies|Med|Multi-merge support, more workloads benefit|
+|4.4|Negation as race-to-cancel|High|Requires async primitives, careful exception handling|
+|4.5|Work-estimation threshold + degradation|Low|Cheap branches no longer fork wastefully|
+|4.6|C# purity certificate consumption (optional)|Med|Auto-detection of safe-to-parallelize predicates|
+
+Each phase below details: what changes, where, how it's tested,
+what's deferred.
+
+---
+
+## Phase 4.0: Build a benchmark that needs intra-query parallelism
+
+Before changing any runtime code, we need a workload where intra-query
+parallelism is the only available speedup vector. Without one, we can't
+measure whether our work helped.
+
+### Workload requirements
+
+- Few sources (1-10), so seed-level parallelism gives ≤10 sparks.
+- Deep recursion or rich branching per source.
+- Pure (no I/O, no side effects), with a known correct answer.
+- Reasonably realistic — not a synthetic benchmark with no analog.
+
+### Candidate: graph reachability with pruning
+
+A query like:
+
+```prolog
+:- parallel(reach/3).
+
+reach(Source, Target, Path) :-
+    edge(Source, Target),
+    Path = [Source, Target].
+reach(Source, Target, [Source|Rest]) :-
+    edge(Source, Mid),
+    reach(Mid, Target, Rest).
+```
+
+Run with `Source = a, Target = z` on a moderately branching graph.
+One seed (Source), but many parallel exploration paths through the
+recursion. Pure, deterministic answer (the set of all reachable paths).
+
+### Deliverables
+
+- New `examples/benchmark/intra_query_seed.pl` — workload definition
+- New `examples/benchmark/generate_intra_query_benchmark.pl` — wraps
+  the workload, generates a project that disables FFI (we need the
+  WAM interpreter to be in the hot path for parallelism to help).
+- Sequential timing baseline at small/medium scale.
+
+### Validation
+
+Confirms: with FFI disabled and seed-level parallelism enabled,
+`+RTS -N4` does NOT speed up this workload (1 spark = 1 core's worth of
+work). This is the gap intra-query parallelism would fill.
+
+---
+
+## Phase 4.1: Instruction emission
+
+Add the new instructions and have the WAM compiler emit them for
+annotated predicates. **No runtime behavior change yet** — they're
+treated as their sequential equivalents at runtime.
+
+### Changes
+
+- `wam_target.pl`: add `par_try_me_else`, `par_retry_me_else`,
+  `par_trust_me` to the instruction enum.
+- WAM clause-compilation: when a predicate is annotated `:- parallel(P/N)`,
+  emit `par_try_me_else` instead of `try_me_else` for the multi-clause
+  indexing.
+- `wam_haskell_target.pl` (`generate_wam_types_hs`): add
+  `ParTryMeElse !String`, `ParRetryMeElse !String`, `ParTrustMe`,
+  and the `Pc` variants to the `Instruction` data type.
+- Step function: dispatch `ParTryMeElse` to the same handler as
+  `TryMeElse` for now (no fork yet). Same for the others.
+- `resolveCallInstrs`: pre-resolve labels in the `Par*` instructions
+  the same way as the non-Par variants.
+
+### Tests
+
+- `test_wam_haskell_target.pl`:
+  - Generated code for an annotated predicate contains
+    `ParTryMeElse` (not `TryMeElse`).
+  - Generated code with `+RTS -N1` produces identical results to the
+    non-annotated baseline (semantic equivalence under serial execution).
+
+### Deferred
+
+- Actual forking. That's Phase 4.2.
+
+---
+
+## Phase 4.2: Runtime fork on ParTryMeElse (sum/count merges)
+
+Wire the runtime fork mechanism. Start with the simplest merge
+strategies — sum and count — because they're commutative and
+associative, no ordering concerns.
+
+### Changes
+
+- `WamTypes`: add `cpForkable`, `cpForkInfo`, `MergeStrategy`,
+  `ForkContext`.
+- Step function: when `ParTryMeElse` is encountered AND the surrounding
+  aggregate is `sum` or `count`, build the branches list, snapshot the
+  state, fork via `parMap rdeepseq`.
+- Merge: fold partial results.
+- `BeginAggregate` instruction needs to carry the `MergeStrategy` so
+  the inner choice points can find it. Add a field.
+
+### Tests
+
+- Sum benchmark from Phase 4.0: `+RTS -N4` gives measurable speedup vs
+  `-N1`.
+- Result comparison: parallel sum equals sequential sum (modulo
+  floating-point associativity for Double).
+- Existing tests (effective_distance) unchanged — they use FFI, no
+  `Par` instructions emitted.
+
+### Deferred
+
+- Findall/bag/set merges (Phase 4.3).
+- Race/negation (Phase 4.4).
+- Work-estimation threshold (Phase 4.5) — every parallel CP forks for now.
+
+---
+
+## Phase 4.3: Findall/bag/set merge strategies
+
+Extend the merge step to support list-collecting aggregates.
+
+### Changes
+
+- `MergeFindall`: concatenate per-branch result lists. Order is
+  non-deterministic across forks but Prolog's findall doesn't
+  guarantee order.
+- `MergeBag` / `MergeSet`: same as findall, with optional
+  deduplication for set.
+- Aggregate-frame interaction: each parallel branch builds its own
+  `wsAggAccum`; the merge concatenates them.
+
+### Tests
+
+- Findall benchmark: parallel findall returns the same set of
+  solutions as sequential (after sorting).
+- Set/bag benchmarks: similar correctness comparison.
+
+### Deferred
+
+- `setof`/`bagof` — these care about ordering and grouping. Non-trivial
+  semantics under parallelism. Punt.
+
+---
+
+## Phase 4.4: Negation as race-to-cancel
+
+`\+ Goal` succeeds iff `Goal` has no solutions. Under parallelism,
+all branches of `Goal` must fail. If any succeeds, the rest can be
+cancelled.
+
+### Why this is high-risk
+
+- Plain `par` has no cancellation. Need `Control.Concurrent.Async`.
+- Switching from `Strategies` to `async` for parallel branches is a
+  bigger refactor than it sounds — different exception handling,
+  different scheduling, different interop with GHC's spark pool.
+- Branch cancellation must clean up trail entries cleanly. Half-baked
+  bindings could corrupt the parent state.
+
+### Approach
+
+- Replace `parMap rdeepseq` with `Async.race` / `Async.cancel` for
+  branches under negation.
+- Wrap branch execution in `withAsync` so cleanup is guaranteed even
+  if the branch fails.
+- Test extensively: this is the most likely source of subtle bugs.
+
+### Tests
+
+- `\+ p(X)` over a parallelizable `p/1` returns the same answer as
+  sequential.
+- Cancellation actually fires (instrument with a counter; verify
+  branches don't all run to completion when one succeeds).
+
+### Deferred
+
+- Cross-branch cut (the spec defers this entirely; not implementing
+  in Phase 4 at all).
+
+---
+
+## Phase 4.5: Work-estimation threshold
+
+Right now, every `ParTryMeElse` forks, regardless of branch size.
+Tiny branches lose money on spark overhead. Add a threshold.
+
+### Changes
+
+- Default `FORK_THRESHOLD` constant (e.g., 100 microseconds) in
+  WamRuntime.
+- `ForkContext` carries an estimated work value (default = `Nothing` =
+  always fork).
+- At the fork point, if `fcWorkEstimate < FORK_THRESHOLD`, fall back
+  to sequential `TryMeElse` semantics.
+
+### How estimates are derived
+
+For Phase 4.5 MVP: estimates come from a static analysis pass that
+counts instructions per branch. Crude but local — no C# integration.
+
+### Tests
+
+- Tiny-branch benchmark: forking is suppressed, performance equals
+  sequential.
+- Large-branch benchmark: forking still happens, performance matches
+  Phase 4.2 numbers.
+
+### Deferred
+
+- C#-driven estimates (Phase 4.6).
+
+---
+
+## Phase 4.6: C# purity certificate consumption (optional)
+
+If the C# query engine produces purity certificates as part of its
+analysis pipeline, the WAM compiler can emit `Par*` instructions
+automatically — no user annotation required.
+
+### Why this is "optional"
+
+It depends on the C# pipeline maturing in a particular direction. If
+it doesn't, manual `:- parallel/1` annotation is fine. The spec is
+already designed to support both modes.
+
+### Changes
+
+- Define a serialization format for purity certificates (probably JSON
+  or Prolog terms).
+- WAM compiler reads certificates and treats certified predicates as
+  if they had `:- parallel/N` annotation.
+- Optionally, certificates also include selectivity / depth bounds for
+  better work estimates.
+
+### Tests
+
+- Parsing: malformed certificates are rejected.
+- End-to-end: a predicate with a certificate gets parallel emission
+  even without explicit annotation.
+
+### Deferred
+
+- Anything that requires changes to the C# engine itself.
+
+---
+
+## Cross-cutting concerns
+
+### Test infrastructure
+
+Each phase needs:
+- A Prolog test predicate exercising the new behavior
+- A Haskell test verifying generated-code shape (look for
+  `ParTryMeElse` in the output, etc.)
+- A benchmark with sequential vs parallel timing comparison
+- Output equivalence test (parallel result == sequential result, modulo
+  floating-point associativity)
+
+Existing test files to extend:
+- `tests/test_wam_haskell_target.pl` — code generation tests
+- `tests/test_wam_haskell_lowered_phase1.pl` etc. — pattern reusable
+  for `intra_query_phase4` series
+
+### Documentation
+
+Each phase merge should update:
+- `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` with new numbers
+- `docs/vision/HASKELL_TARGET_ROADMAP.md` Phase 4 status (in-progress
+  sub-phases)
+
+### Backward compatibility
+
+All existing tests + benchmarks should pass through every phase
+without modification. The `Par*` instructions are *additions*, not
+replacements. Predicates without `:- parallel/N` annotation continue
+to use the sequential `TryMeElse` family.
+
+---
+
+## When to start
+
+Start Phase 4.0 (build a benchmark that needs this) when one of:
+
+1. A user reports that a non-FFI workload is slow and would benefit.
+2. Rust target adds intra-query parallelism (don't lose the moat).
+3. C# purity certificates become available.
+
+Until then: keep this design shelved. The vision is documented and
+the path is clear; we're not blocked, just waiting for the right
+trigger to spend the implementation budget.
+
+## Related documents
+
+- `docs/design/WAM_HASKELL_INTRA_QUERY_PHILOSOPHY.md` — motivation
+- `docs/design/WAM_HASKELL_INTRA_QUERY_SPEC.md` — mechanism
+- `docs/vision/HASKELL_TARGET_PARALLELIZATION_SPEC.md` §2 — vision-level reference
+- `docs/vision/HASKELL_TARGET_ROADMAP.md` Phase 4 — current status (this Phase 4)

--- a/docs/design/WAM_HASKELL_INTRA_QUERY_PHILOSOPHY.md
+++ b/docs/design/WAM_HASKELL_INTRA_QUERY_PHILOSOPHY.md
@@ -1,0 +1,185 @@
+# Haskell WAM Intra-Query Parallelism: Philosophy
+
+> **Vision context:** This is the design-level companion to
+> `docs/vision/HASKELL_TARGET_PARALLELIZATION_SPEC.md` §2. The vision
+> doc establishes *what* we're aiming for; this doc explains *why now*,
+> *when it pays off*, and *what we're willing to spend* to get it.
+
+## What we already have
+
+Seed-level parallelism (Phase 1, PR #1377) gave us a 3-3.5x speedup
+across all tested scales. It exploits the fact that the
+effective-distance benchmark queries 386 independent seed categories,
+each with its own `WamState`, sharing only an immutable `WamContext`.
+
+That's *coarse-grained* parallelism: one Haskell spark per query.
+Each query then runs entirely sequentially.
+
+## What intra-query parallelism would add
+
+When a single query has internal parallelism — multiple choice point
+branches that don't depend on each other — we currently explore them
+serially via backtracking. Intra-query parallelism would fork those
+branches across cores.
+
+Concretely, for a recursive predicate like:
+
+```prolog
+ancestor(Cat, Mid, Hops, Visited) :-
+    parent(Cat, Mid),                  % multiple solutions
+    \+ member(Mid, Visited),
+    ancestor(Mid, Root, H1, [Mid|Visited]),
+    Hops is H1 + 1.
+```
+
+Each `Mid` solution spawns an independent recursive subquery. With N
+parents, we could explore N branches concurrently rather than
+sequentially.
+
+## Why this isn't the right next step for our current benchmark
+
+**The effective-distance benchmark wouldn't measurably benefit.**
+Three reasons, in order of importance:
+
+1. **The hot predicate (`category_ancestor/4`) is already FFI-handled.**
+   It runs as a tight Haskell function, not through the WAM
+   interpreter. There are no choice points to parallelize — the
+   recursion is just a `concatMap` over the parents list inside
+   `nativeKernel_category_ancestor`.
+
+2. **Seed-level parallelism already saturates the available cores.**
+   At 4 cores with 386 seeds, each core has ~96 seeds to chew through.
+   Adding intra-seed forks would just oversubscribe.
+
+3. **The remaining bottleneck is GC pressure, not sequential work.**
+   The 10k-scale profile showed parallel GC work imbalance (70% utility
+   on 4 cores). More forks would worsen this, not help.
+
+So why write a design doc for it at all?
+
+## Why intra-query parallelism is still strategically important
+
+Three workload classes where it would matter:
+
+### 1. Few-seed, deep-recursion queries
+
+Imagine a query like "find all transitively-related papers from this
+one citation, weighted by topic similarity." One seed (the citation),
+deep recursion, lots of branching at each step. Seed-level parallelism
+gives 1 spark — all cores idle except one. Intra-query parallelism
+would spread the recursion across cores.
+
+This is the **long-tail** of UnifyWeaver workloads — fewer seeds, more
+work per seed. Our current benchmarks happen to be the opposite shape
+(many seeds, shallow per-seed work).
+
+### 2. Predicates that *aren't* FFI-handled
+
+The kernel registry handles ~7 specific patterns. Anything outside
+that — user-defined predicates, specialized analyses, novel graph
+structures — runs through the WAM interpreter. For those, intra-query
+parallelism is the only parallelism available short of writing a new
+kernel.
+
+This is the **generality** argument: the FFI fast path will always
+cover a curated set of common patterns; the interpreter is the fallback
+for everything else, and we'd like the fallback to scale too.
+
+### 3. Validation of Haskell's parallelization advantage
+
+The Rust WAM target uses mutable vectors that can't be trivially
+forked across cores without explicit `Arc`/`Mutex`. Haskell's
+immutable `WamState` makes intra-query forks free at the type-system
+level — we just call `par`/`pseq` on alternative branches.
+
+This is the **architectural** argument from the vision doc: we chose
+immutability specifically to enable this kind of parallelism. Phase 1
+demonstrated it for seed-level; Phase 4 would demonstrate it
+*structurally*, where Rust would need significant refactoring to keep
+up.
+
+## What it costs
+
+### Direct costs
+
+- **Spark management overhead** (~microseconds per fork). For tiny
+  branches, this dominates the actual work — we need a work-estimation
+  threshold to skip parallelization for cheap branches.
+- **Choice point reification.** Currently, choice points are stored as
+  a stack on each `WamState`. To fork at a choice point, both branches
+  need their own snapshot. With immutable state this is "free" (pointer
+  copies), but the trail must be carefully tracked across branches so
+  bindings made in one branch don't leak to the other.
+- **Merge complexity.** When branches finish, their results must be
+  combined according to the enclosing aggregate context (`sum`,
+  `count`, `findall`, bare disjunction). Each merge strategy needs its
+  own implementation.
+
+### Indirect costs
+
+- **Purity proofs.** A predicate is safe to parallelize only if it has
+  no side effects (no `assert`/`retract`, no I/O, no global state,
+  cuts only as scoped). The C# query engine has analyses that can
+  produce these proofs; integrating them adds pipeline complexity.
+- **Cut interaction.** `!/0` semantics under parallelism are subtle.
+  If a cut fires in one branch, do already-running parallel branches
+  get cancelled? The standard answer is "yes" but implementing
+  cancellation in Haskell with `par` requires care (you'd want
+  `async`-based primitives).
+- **Test surface.** Every parallelizable predicate needs both
+  sequential and parallel correctness tests. Comparing outputs across
+  modes is essential — parallelism shouldn't change semantics, only
+  scheduling.
+
+## Why we'd do it anyway
+
+The cost-benefit analysis above is workload-specific. For the
+effective-distance benchmark, intra-query parallelism is a clear loss.
+For graph algorithms with deep recursion or rich branching, it's the
+only path to multi-core scaling.
+
+The deciding factor is **what UnifyWeaver wants to be**:
+
+- If it's an effective-distance benchmark optimizer: stop. We're done.
+- If it's a general-purpose Datalog/Prolog compiler that wants to
+  scale across workload shapes: intra-query parallelism is on the
+  critical path.
+
+The vision doc sides with the latter. This design doc series exists
+to make Phase 4 implementable when that need becomes concrete.
+
+## Non-goals
+
+- **Auto-parallelize everything.** Forking has overhead. We need
+  explicit annotations or proven purity, plus work-estimation
+  thresholds.
+- **Match Erlang/Cilk semantics.** Those languages are designed
+  around fine-grained concurrency; we're bolting it onto a backtracking
+  abstract machine. Our model is "fork at choice points, merge at
+  aggregate boundaries" — much narrower than general task parallelism.
+- **Replace seed-level parallelism.** Both can coexist. Seed-level is
+  always faster when applicable (no merge overhead). Intra-query is
+  what kicks in when seed-level can't.
+
+## When to revisit
+
+Implement intra-query parallelism when one of:
+
+1. **A real workload benefits** — someone tries UnifyWeaver on a
+   long-tail query and the pure interpreter is too slow.
+2. **Parallelism becomes competitive ground** — Rust target adds
+   intra-query parallelism (would be hard for them; that's our
+   architectural moat to widen).
+3. **Tooling reaches readiness** — C# query engine produces purity
+   certificates we can consume; demand analysis is mature enough to
+   inform the work-estimation threshold.
+
+Until then: this design exists, the vision is consistent, and we're
+not caught flat-footed when one of those triggers fires.
+
+## Related documents
+
+- `docs/vision/HASKELL_TARGET_PARALLELIZATION_SPEC.md` §2 — vision-level scope
+- `docs/vision/HASKELL_TARGET_PHILOSOPHY.md` — broader strategic framing
+- `docs/design/WAM_HASKELL_INTRA_QUERY_SPEC.md` — concrete mechanism (next)
+- `docs/design/WAM_HASKELL_INTRA_QUERY_IMPLEMENTATION_PLAN.md` — phased work breakdown

--- a/docs/design/WAM_HASKELL_INTRA_QUERY_SPEC.md
+++ b/docs/design/WAM_HASKELL_INTRA_QUERY_SPEC.md
@@ -1,0 +1,322 @@
+# Haskell WAM Intra-Query Parallelism: Specification
+
+> **Scope:** This specifies the WAM instructions, runtime mechanisms, and
+> semantic contracts for forking parallel branches at choice points
+> within a single query. Fork/merge happens *inside* a `run`-loop
+> invocation, in contrast to seed-level parallelism (PR #1377) which
+> forks at the level of `parMap` over independent `WamState` snapshots.
+>
+> See `WAM_HASKELL_INTRA_QUERY_PHILOSOPHY.md` for motivation, and
+> `WAM_HASKELL_INTRA_QUERY_IMPLEMENTATION_PLAN.md` for a phased work
+> breakdown.
+
+## 1. Conceptual model
+
+A **forkable choice point** is a choice point that:
+
+1. Has multiple branches whose execution doesn't share runtime state
+   (no cross-branch trail leakage, no shared mutable structures).
+2. Is in a context where the merge semantics are statically known
+   (we know whether to sum, count, collect, race, or accumulate).
+3. Has enough estimated work per branch to justify spark overhead.
+
+When all three hold, the runtime forks the alternatives across cores.
+Branches run independently using their own `WamState` snapshot of the
+shared `WamContext`. When all branches complete, results are combined
+according to the enclosing aggregate.
+
+## 2. New WAM instructions
+
+Add three instructions parallel to the existing choice-point family:
+
+```haskell
+data Instruction
+  = ...
+  | ParTryMeElse !Label    -- like TryMeElse but marks CP as forkable
+  | ParRetryMeElse !Label  -- continuation in the parallel CP chain
+  | ParTrustMe             -- last branch in the parallel CP chain
+  ...
+```
+
+Pre-resolved variants (analogous to `TryMeElsePc` etc.) follow the
+same naming convention: `ParTryMeElsePc`, `ParRetryMeElsePc`.
+
+### Why three instructions, not one
+
+The existing `TryMeElse` / `RetryMeElse` / `TrustMe` triplet establishes
+the linked structure of a choice-point chain. Parallel emission needs
+the same structure so the WAM compiler can recognize "this is a
+forkable group of N alternatives" and the runtime can collect them
+all before forking.
+
+## 3. Generator support: purity annotations
+
+A predicate is annotated parallelizable in one of two ways:
+
+### 3.1 Explicit user annotation
+
+```prolog
+:- parallel(category_ancestor/4).
+:- order_independent(power_sum_bound/3).
+```
+
+`parallel/1` declares the predicate's clauses safe to fork. The WAM
+compiler emits `ParTryMeElse` for the multi-clause indexing that would
+otherwise be `TryMeElse`.
+
+`order_independent/1` is a weaker assertion: solutions can be returned
+in any order, but the user is asserting (not proving) safety. It still
+emits parallel instructions; difference is documentation/intent.
+
+### 3.2 Compiler-derived purity (future)
+
+If the C# query engine's demand analysis produces a *purity certificate*
+for a predicate, the WAM compiler can emit `ParTryMeElse` automatically.
+This is a future hook, not a Phase 4 deliverable.
+
+A purity certificate guarantees:
+- No `assert`/`retract` in the predicate or transitively
+- No I/O
+- No global mutable state access
+- No cuts that escape the predicate's scope (`!` truncating to a
+  caller's choice point is unsafe; `!` truncating to a clause-local
+  choice point is fine)
+
+## 4. Runtime fork mechanism
+
+### 4.1 What gets snapshotted
+
+A choice point already snapshots:
+- `cpRegs`, `cpStack`, `cpBindings`, `cpHeap*`, `cpTrailLen`, `cpCutBar`
+
+For parallel forking, we need each branch to have an *independent* copy
+of the trail. The trail is currently a list shared across branches;
+forking would require either:
+
+1. **Per-branch trail copy.** Each parallel branch starts with the
+   prefix trail (up to `cpTrailLen`) and accumulates its own bindings.
+   Cost: O(trail length) per fork.
+2. **Trail journaling.** Each branch records its trail entries in a
+   thread-local buffer; the merge step interprets them. Cost: lower
+   per-fork, but more complex.
+
+**MVP picks option 1.** Trail copy is O(n) but n is typically small
+(< 100 entries at choice points). Journaling can be a future
+optimization if profiling demands it.
+
+### 4.2 Spark primitives
+
+```haskell
+import Control.Parallel (par, pseq)
+import Control.Parallel.Strategies (parMap, rdeepseq)
+
+-- At a parallel choice point with branches [b1, b2, ..., bN]:
+let snapshot = currentState
+    branches = [run ctx (snapshot { wsPC = b }) | b <- branchPcs]
+    parallelResults = parMap rdeepseq id branches
+in mergeResults parallelResults
+```
+
+We use `parMap rdeepseq` over branch results — same primitive as
+seed-level parallelism, just inside the run loop. The `rdeepseq`
+ensures each branch's `Maybe WamState` is fully evaluated before the
+merge step runs.
+
+### 4.3 Work-estimation threshold
+
+A branch is forked if:
+
+```
+estimated_work(branch) > FORK_THRESHOLD
+```
+
+For Phase 4 MVP, `FORK_THRESHOLD` is a runtime constant (e.g., "branches
+must run for at least 100 microseconds"). Future iterations can derive
+the estimate from C# demand analysis (which knows selectivity and
+recursion depth bounds).
+
+If estimate is below threshold, fall back to sequential `TryMeElse`
+semantics — the parallel instructions degrade gracefully.
+
+## 5. Merge strategies
+
+The merge function depends on the enclosing aggregate context, known
+at compile time:
+
+|Aggregate context|Merge strategy|
+|---|---|
+|`aggregate_all(sum, ...)`|Sum partial sums from each branch|
+|`aggregate_all(count, ...)`|Sum per-branch counts|
+|`aggregate_all(bag, ...)`|Concatenate per-branch lists (order arbitrary)|
+|`aggregate_all(set, ...)`|Union per-branch sets (dedup)|
+|`findall(X, ..., L)`|Concatenate per-branch lists|
+|`setof/bagof`|Concatenate, then sort/dedup at the boundary|
+|Bare disjunction in body|First success (race), or all if non-deterministic|
+|`\+ (negation)`|Any branch succeeds → negation fails (race-to-cancel)|
+
+The compiler determines which strategy applies by walking the surrounding
+aggregate frame from the choice point's position. This information is
+already available in `wsAggAccum` / `cpAggFrame`.
+
+### 5.1 Merge implementations
+
+For sum/count: a simple fold over partial results.
+
+For findall/bag: list concatenation. Order is non-deterministic across
+parallel branches but Prolog's findall doesn't guarantee order.
+
+For race: cancel still-running branches once one succeeds. This requires
+`async`-based primitives (`Control.Concurrent.Async`) rather than plain
+`par`; budget for this in Phase 4.2.
+
+### 5.2 Negation as cancellation
+
+`\+ Goal` succeeds iff `Goal` has no solutions. Under parallelism, all
+branches of `Goal` must fail before `\+` succeeds. If any branch
+succeeds, the rest can be cancelled — this is a race-to-cancel pattern.
+
+Implementing cancellation cleanly in the `Strategies` model is
+awkward; using `async`'s `race` is more natural. This is one of the
+more involved pieces of Phase 4.
+
+## 6. Cut interaction
+
+Cut (`!/0`) under parallelism is the trickiest semantic question.
+
+### 6.1 Within-branch cut
+
+If `!` fires inside a parallel branch and the cut is local to that
+branch (the cut barrier is within the branch's frame), behavior is
+unchanged — the branch trims its own choice points and continues.
+
+### 6.2 Cross-branch cut
+
+If `!` fires inside a parallel branch and the cut barrier is *outside*
+the branch (i.e., the cut would normally truncate the parallel choice
+point itself), the semantics get complex. Standard interpretations:
+
+- **Cancel siblings.** The cut commits to this branch; sibling branches
+  are abandoned.
+- **No-op for already-running branches.** Don't cancel; let them
+  complete but discard their results.
+
+The vision spec (§2.4) doesn't pin this down. **MVP picks "no
+cross-branch cut"**: the parallelizable annotation must guarantee that
+no cut in the predicate body crosses the parallel CP barrier. This is
+checkable at compile time (cut barrier analysis is standard WAM stuff).
+
+### 6.3 Cut in disjunction
+
+```prolog
+parallel_p(X) :- (clause_a(X) ; clause_b(X) ; clause_c(X)), !, post(X).
+```
+
+Here the `!` after the disjunction commits to the first solution. Under
+parallelism, "first solution" doesn't have a stable meaning — so we
+either:
+
+1. Disallow this combination (compile-time error).
+2. Use race semantics — first parallel branch to succeed wins, others
+   cancelled.
+
+MVP: option 1 (disallow). Race semantics can be added later if needed.
+
+## 7. Trail discipline
+
+The trail records variable bindings for backtracking. Across parallel
+branches:
+
+- Each branch sees a snapshot of bindings up to `cpBindings`.
+- New bindings made by branch B go into B's local trail extension.
+- On branch completion, B's trail is dropped (since the surrounding
+  aggregate consumes B's *result*, not its bindings).
+
+The key invariant: **no shared mutable bindings table**. Each branch's
+`wsBindings` is its own `IM.IntMap Value` — pointer-shared at the
+common prefix, diverging at branch-local additions.
+
+This is exactly the "immutability is a strategic asset" property from
+the philosophy doc.
+
+## 8. Type-level changes
+
+```haskell
+-- WamTypes additions
+
+data ChoicePoint = ChoicePoint
+  { ...
+  , cpForkable :: !Bool   -- emitted by ParTryMeElse, false otherwise
+  , cpForkInfo :: !(Maybe ForkContext)
+  }
+
+data ForkContext = ForkContext
+  { fcMergeStrategy :: !MergeStrategy  -- determined at compile time
+  , fcWorkEstimate  :: !(Maybe Double) -- microseconds, if known
+  }
+
+data MergeStrategy
+  = MergeSumInt | MergeSumDouble
+  | MergeCount
+  | MergeBag | MergeSet
+  | MergeFindall
+  | MergeRace
+  | MergeNegation
+```
+
+### Why a separate `ForkContext`
+
+A choice point can be forkable but not yet forked (e.g., if work
+estimate is below threshold). Carrying the merge strategy in the CP
+itself lets us defer the fork decision to runtime without losing the
+context information.
+
+## 9. What stays the same
+
+- Sequential semantics are unchanged. `ParTryMeElse` falls back to
+  `TryMeElse` semantics when work-estimate is below threshold or
+  parallelism is disabled at runtime (`+RTS -N1`).
+- The lowered-emitter path is unaffected. Lowered functions don't go
+  through choice points; they're either fully native or call back into
+  the WAM run loop for unsupported operations.
+- The FFI kernels are unaffected. They run as native Haskell functions
+  with no choice points to parallelize.
+
+## 10. What's out of scope for Phase 4
+
+- **Speculative execution.** We don't run branches that might be
+  cancelled by an unfired cut.
+- **Work-stealing scheduler.** GHC's spark pool already does this; we
+  rely on it rather than rolling our own.
+- **NUMA affinity.** Out of scope. Native Linux + `+RTS -qa` may help
+  but is orthogonal.
+- **Cross-target consistency.** Other WAM targets (Rust, LLVM, WAT)
+  may eventually need their own parallelism stories. This spec is
+  Haskell-only.
+
+## 11. Open questions for implementation
+
+1. **How do we annotate aggregate context in compiled code?** Currently
+   `aggregate_all` is wrapped via `begin_aggregate`/`end_aggregate`
+   instructions. The merge strategy might need to be carried in
+   `BeginAggregate` so the choice points emitted within know which
+   merge to use.
+
+2. **Should the work-estimation threshold be per-predicate or global?**
+   Global is simpler (one knob). Per-predicate is more accurate but
+   needs C# integration.
+
+3. **What happens if a parallel branch throws an exception?** Haskell
+   `par` doesn't have exception semantics in the spark framework.
+   Branches that error out should cause the whole query to fail,
+   matching sequential semantics. `async` gives this for free if we
+   use it.
+
+These are flagged for resolution during Phase 4 implementation, not
+in this spec.
+
+## Related documents
+
+- `docs/design/WAM_HASKELL_INTRA_QUERY_PHILOSOPHY.md` — motivation
+- `docs/design/WAM_HASKELL_INTRA_QUERY_IMPLEMENTATION_PLAN.md` — phasing
+- `docs/vision/HASKELL_TARGET_PARALLELIZATION_SPEC.md` §2 — vision-level reference
+- `docs/proposals/WAM_MULTI_OUTPUT_KERNELS.md` — sibling proposal pattern


### PR DESCRIPTION
  ## Summary

  Three design-level documents to make Phase 4 of the parallelization vision implementable when its trigger conditions fire. These complement (don't replace) the existing vision docs
  in `docs/vision/` — vision-level docs establish *what* we're aiming for; these cover *why now*, *concrete mechanism*, and *phased delivery*.

  ### `WAM_HASKELL_INTRA_QUERY_PHILOSOPHY.md`

  When to do this and when not to. Honest framing: the current `effective_distance` benchmark wouldn't measurably benefit (the hot path is FFI-handled, seed-level parallelism already
  saturates 4 cores, GC is the bottleneck). But intra-query parallelism is strategically important for:

  1. **Few-seed, deep-recursion workloads** — where seed-level gives ≤10 sparks and leaves cores idle
  2. **Predicates outside the FFI catalog** — where the interpreter is the fallback and we want it to scale too
  3. **A structural moat over Rust** — whose mutable vectors can't trivially fork across cores

  Enumerates direct costs (spark overhead, choice point reification, merge complexity) and indirect costs (purity proofs, cut interaction, test surface). Names three concrete trigger
  conditions for revisiting.

  ### `WAM_HASKELL_INTRA_QUERY_SPEC.md`

  Concrete mechanism:

  - New instructions: `ParTryMeElse` / `ParRetryMeElse` / `ParTrustMe` (parallel CP family)
  - Fork primitive: `parMap rdeepseq` with per-branch trail snapshots
  - Merge strategies per aggregate context (sum/count/findall/bag/set/race/negation) — table included
  - Cut interaction: MVP disallows cross-branch cut; within-branch cut unchanged
  - Trail discipline: each branch owns its bindings extension, common prefix pointer-shared
  - Type-level additions: `cpForkable`, `ForkContext`, `MergeStrategy` enum

  Calls out three open questions for resolution at implementation time.

  ### `WAM_HASKELL_INTRA_QUERY_IMPLEMENTATION_PLAN.md`

  Six-phase breakdown, ordered to minimize integration risk:

  |Phase|Scope|Risk|
  |---|---|---|
  |4.0|Build a benchmark that *needs* this|Low|
  |4.1|Instructions + emission, no runtime change|Low|
  |4.2|Runtime fork on `Par*` with sum/count merges|Medium|
  |4.3|Findall/bag/set merges|Medium|
  |4.4|Negation as race-to-cancel via `async`|High|
  |4.5|Work-estimation threshold|Low|
  |4.6|C# purity certificate consumption|Medium, optional|

  Each phase is committable as its own PR with deliverables, tests, and explicit deferrals.

  ## Why document before implementing

  We're not blocked on any current workload — the kernel catalogue is complete, perf beats Rust at all tested scales. Writing the design now makes Phase 4 recoverable from future
  sessions without having to re-derive the architecture.

  ## Test plan

  - [ ] Render docs on GitHub — verify tables, code blocks, cross-refs look correct
  - [ ] Confirm design is consistent with existing vision docs
  - [ ] No code changes, docs only

  ## Related

  - `docs/vision/HASKELL_TARGET_PARALLELIZATION_SPEC.md` §2 — vision-level scope
  - `docs/vision/HASKELL_TARGET_PHILOSOPHY.md` — broader strategic framing
  - `docs/vision/HASKELL_TARGET_ROADMAP.md` Phase 4 — status entry