### PR TITLE
docs(core): purity certificate design — proposal, spec, implementation plan

### DIFF
--- a/docs/design/PURITY_CERTIFICATE_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PURITY_CERTIFICATE_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,357 @@
+# Shared Purity Certificate Module: Implementation Plan
+
+> **Phased work breakdown** for implementing the module specified in
+> `PURITY_CERTIFICATE_SPECIFICATION.md`. Each phase produces something
+> testable and commits cleanly as its own PR. Skip ahead by phase when
+> picking up this work.
+
+## Overall shape
+
+Five phases, ordered to minimize risk and keep every step
+independently shippable:
+
+|Phase|Scope|Risk|Demonstrable outcome|
+|---|---|---|---|
+|P1|Create `core/purity_certificate.pl` with certificate shape + blacklist producer|Low|Existing `is_pure_goal` callers still work; new API returns the same verdicts wrapped in certificates|
+|P2|Absorb `advanced/purity_analysis.pl` as whitelist strategy|Low|Tail-recursion pipeline unchanged; whitelist verdicts now flow through the same certificate API|
+|P3|Kernel registry producer|Low|Every detected kernel has an explicit `purity_cert(pure, certified(kernel_registry), 1.0, [kernel_owned])`|
+|P4|Wire into Haskell WAM Phase 4.1 `ParTryMeElse` emission|Med|Annotated predicates emit `ParTryMeElse`; unannotated emit `TryMeElse`; tests confirm equivalence under `+RTS -N1`|
+|P5|JSON serialization + documentation|Low|`purity_cert/1` can cross the Prolog↔C# boundary when that integration becomes real|
+
+Phase 4 is the first one that touches an emitter; Phases 1–3 are pure
+refactors with strong test equivalence guarantees.
+
+Each phase below details: what changes, where, how it's tested, what's
+deferred.
+
+---
+
+## Phase P1: Create `core/purity_certificate.pl`
+
+Extract the certificate shape and wire the existing blacklist
+(`clause_body_analysis.pl`'s `is_impure_builtin/1`) in as the first
+producer.
+
+### Changes
+
+- New file: `src/unifyweaver/core/purity_certificate.pl`
+  - Defines `purity_cert/4` compound term (verdict, proof, confidence,
+    reasons).
+  - Public API per spec §2: `analyze_goal_purity/2`,
+    `analyze_predicate_purity/2`, `analyze_clause_purity/2`,
+    `merge_certificates/2`.
+  - Convenience predicates: `is_certified_pure/1`,
+    `is_certified_impure/2`, `purity_confidence/2`.
+  - Registration API: `register_purity_producer/2`.
+  - `user_annotation_analyzer/2` — reads `:- parallel/1` /
+    `:- order_independent/1` / `:- parallel_safe/1` directives.
+  - `blacklist_analyzer/2` — wraps `clause_body_analysis:is_impure_builtin/1`.
+
+- `clause_body_analysis.pl` — **no deletions in P1**:
+  - `is_pure_goal/1`, `is_order_independent/2`, `classify_parallelism/3`
+    all continue to exist. They become thin wrappers that call the new
+    API internally. Callers unaware of the change see identical
+    behavior.
+
+### Tests
+
+- `tests/core/test_purity_certificate.pl` — new file.
+  - Every existing `:- parallel/1` and `:- order_independent/1`
+    annotation in the codebase produces `purity_cert(pure, declared,
+    1.0, [declared_by_user])`.
+  - Every predicate the old `is_pure_goal/1` considered pure now
+    certifies `pure` via the new API.
+  - Every predicate the old logic considered impure certifies
+    `impure(_)` with the correct reason atoms (`io_ops`,
+    `database_mods`, `global_state`).
+  - Known-unknown builtin (e.g., a synthetic `my_custom_op/2` with no
+    declaration) certifies `unknown`.
+  - Determinism: 1000 repeated calls return bit-identical certificates.
+  - Termination: an artificial deeply-nested goal (`conj(conj(...))`
+    nested 10k deep) returns in under 100ms.
+
+- `tests/core/test_clause_body_analysis.pl` — existing tests unchanged.
+  All pass. This is the equivalence gate: if anything regresses, P1
+  is not shippable.
+
+### Deferred
+
+- Kernel registry producer (Phase P3).
+- Whitelist absorbed from `advanced/purity_analysis.pl` (Phase P2).
+- Haskell emission integration (Phase P4).
+
+### Risk
+
+Low. The certificate shape is purely additive; `clause_body_analysis.pl`'s
+old API remains as a thin wrapper. The only way this breaks is if the
+new wrapper computes a verdict differently from the old code — which
+the tests will catch.
+
+---
+
+## Phase P2: Absorb the whitelist strategy
+
+Migrate `advanced/purity_analysis.pl`'s whitelist (`pure_builtin/1`)
+into the new module as an alternative strategy. The tail-recursion
+transformation switches to consuming certificates instead of booleans.
+
+### Changes
+
+- `purity_certificate.pl` — add `whitelist_analyzer/2`:
+  - Consults a `pure_builtin/1` clause table identical to the old
+    `advanced/purity_analysis.pl` module.
+  - Registered at priority 40 (below blacklist — whitelist is
+    strictly safer but more conservative; callers that want
+    whitelist-only semantics filter on `Proof = analyzed(whitelist)`).
+
+- `advanced/purity_analysis.pl` — thin wrapper:
+  - `is_pure_goal/1` and `is_pure_body/1` become wrappers that call
+    `analyze_goal_purity/2` and filter for whitelist strategy.
+  - File stays for back-compat; can be deprecated in a later pass.
+
+- `core/recursion/linear_to_tail.pl` (or wherever tail-recursion
+  transformation lives) — update to use the new API directly.
+
+### Tests
+
+- `tests/core/test_purity_certificate.pl` — add:
+  - Whitelist-only consumer gets `pure` only for builtins in the
+    strict whitelist; falls back to `unknown` for others even when the
+    blacklist would say pure.
+  - Tail-recursion transformation test fixtures produce the same
+    transformed output as before the migration.
+
+- `tests/core/advanced/test_purity_analysis.pl` — existing tests pass
+  unchanged.
+
+- `tests/core/test_linear_to_tail.pl` — existing tests pass. This is
+  the equivalence gate for Phase P2.
+
+### Deferred
+
+- Removing `advanced/purity_analysis.pl` entirely. We keep the wrapper
+  to avoid touching every caller in one PR. A follow-up can delete it
+  once confident.
+
+### Risk
+
+Low. Whitelist semantics are strictly narrower than blacklist; any
+verdict the whitelist returns is also returned by the blacklist.
+Tail-recursion transformation either gets the same verdict (safe) or a
+more conservative one (also safe — just fewer transformations).
+
+---
+
+## Phase P3: Kernel registry producer
+
+Every detected recursive kernel gets an explicit purity certificate.
+
+### Changes
+
+- `purity_certificate.pl` — add `kernel_analyzer/2`:
+  - Given a predicate indicator, checks
+    `recursive_kernel_detection:kernel_detector/2` membership.
+  - If present, returns `purity_cert(pure, certified(kernel_registry),
+    1.0, [kernel_owned])`.
+  - Registered at priority 90 (trusts registry over blacklist — kernels
+    are hand-coded and audited).
+
+- `recursive_kernel_detection.pl` — no changes. The analyzer reads the
+  existing registry; no new metadata needed.
+
+- Documentation update: `recursive_kernel_detection.pl` header comment
+  notes that kernels are trusted pure and surfaces through the
+  certificate module.
+
+### Tests
+
+- Every kernel in the current registry (7 kernels as of this writing —
+  `category_ancestor`, `transitive_closure2`, `transitive_distance3`,
+  `weighted_shortest_path3`, `transitive_parent_distance4`,
+  `astar_shortest_path4`, `transitive_step_parent_distance5`)
+  certifies `purity_cert(pure, certified(kernel_registry), 1.0,
+  [kernel_owned])`.
+- A predicate not in the registry does not pick up this certificate.
+- The kernel certificate takes priority over the blacklist — even if a
+  kernel's Prolog shape looks impure (e.g., uses a builtin the
+  blacklist doesn't recognize), the registry says pure.
+
+### Deferred
+
+- Validating that a kernel's Prolog shape *actually is* pure. The
+  registry is trust-by-construction. A future auditing pass could
+  cross-check against the blacklist; for now, reviewer discipline is
+  the enforcement mechanism.
+
+### Risk
+
+Low. Adding a producer is additive. The only new failure mode is a
+reviewer adding an impure kernel; the audit proposal above addresses
+that as a follow-up.
+
+---
+
+## Phase P4: Wire into Haskell WAM Phase 4.1 emission
+
+First real consumer. When Phase 4.1 emits `ParTryMeElse` vs
+`TryMeElse`, it consults the certificate module.
+
+**Precondition:** Phase 4.1 of the intra-query parallelism
+implementation plan (WAM instruction additions). P4 of this plan
+depends on that.
+
+### Changes
+
+- `src/unifyweaver/targets/wam_haskell_target.pl` — emission decision:
+  ```prolog
+  (   analyze_predicate_purity(Pred/Arity, purity_cert(pure, _, Conf, _)),
+      Conf >= 0.85,
+      \+ option(intra_query_parallel(false), Options)
+  ->  emit_par_try_me_else(...)
+  ;   emit_try_me_else(...)
+  ).
+  ```
+
+- The `intra_query_parallel(false)` kill switch from
+  `WAM_HASKELL_INTRA_QUERY_SPEC.md` §3.3 lands here — it's a single
+  option check wrapped around the emit call.
+
+### Tests
+
+- `tests/test_wam_haskell_target.pl`:
+  - Predicate with `:- parallel(P/N).`: generated code contains
+    `ParTryMeElse`.
+  - Predicate without annotation: generated code contains `TryMeElse`
+    (default-safe).
+  - Predicate with impure body (e.g., calls `format/2`): generated
+    code contains `TryMeElse` even if annotated (the blacklist
+    overrides the annotation — verdict merge returns `impure`).
+  - With `intra_query_parallel(false)`: all predicates emit
+    `TryMeElse` regardless of annotation or verdict.
+
+- `tests/test_wam_haskell_intra_query_integration.pl` — new:
+  - An annotated parallelizable predicate generates code that runs
+    identically under `+RTS -N1` to the unannotated version
+    (sequential semantic equivalence).
+
+### Deferred
+
+- Actually forking at runtime (that's Phase 4.2 of the intra-query
+  plan, not this plan's phase 4).
+- Work-estimation threshold wiring — the certificate provides verdict
+  + confidence; threshold logic is a separate concern in the
+  intra-query plan (§4.5).
+
+### Risk
+
+Medium. First time the certificate module drives code generation.
+Risk areas: certificate cache invalidation (if a predicate is
+redefined between analysis and emission), verdict merging when both
+annotation and blacklist produce opinions, and edge cases around
+user-defined predicates calling each other.
+
+---
+
+## Phase P5: JSON serialization + cross-process story
+
+Enables certificates to cross language boundaries. Not urgent, but
+the right time is while the certificate shape is still fresh and
+producer/consumer contracts are recent.
+
+### Changes
+
+- `purity_certificate.pl` — add:
+  - `cert_to_json(+Cert, +Metadata, -JsonTerm)` — serializes to a dict
+    in the format specified in spec §3.2.
+  - `cert_from_json(+JsonTerm, -Cert)` — deserializes. Rejects
+    malformed input with informative error terms.
+
+- `docs/design/PURITY_CERTIFICATE_SPECIFICATION.md` — update §3.2 with
+  any refinements discovered during implementation.
+
+### Tests
+
+- Round-trip: `cert → json → cert` produces the original certificate
+  bit-identical.
+- Malformed JSON rejected: missing `verdict`, invalid confidence range,
+  unknown proof kind.
+- Cross-version forward-compat: unknown metadata fields are tolerated
+  (accepted but not consumed). Enables future producer-versioning
+  without breaking existing consumers.
+
+### Deferred
+
+- Actually connecting to the C# engine. That requires the C# side to
+  start producing verdicts, which is its own project (probably Phase
+  4.6 of the intra-query plan).
+
+### Risk
+
+Low. Serialization is mechanical; tests catch drift.
+
+---
+
+## Cross-cutting concerns
+
+### Backward compatibility
+
+Every phase's non-test changes are behavior-preserving refactors with
+one exception: Phase P4 introduces a new emission path (`ParTryMeElse`).
+That path only activates when:
+
+- The predicate is annotated OR certified pure.
+- `intra_query_parallel(false)` is not set.
+- Phase 4.1+ of the intra-query plan is merged.
+
+Until all three hold, output is bit-identical to pre-certificate code
+generation.
+
+### Test infrastructure
+
+Each phase ships with tests that:
+- Exercise the new functionality directly.
+- Confirm the affected existing functionality is unchanged (equivalence
+  gate).
+
+Phase P4 needs runtime equivalence testing — actually running the
+generated Haskell with `+RTS -N1` and comparing output with the
+pre-certificate version for a battery of predicates.
+
+### Documentation
+
+Each phase's merge updates:
+- `docs/design/PURITY_CERTIFICATE_SPECIFICATION.md` with any
+  refinements from implementation.
+- `docs/design/PURITY_CERTIFICATE_IMPLEMENTATION_PLAN.md` marking the
+  phase complete.
+- The first time a target consumes certificates (Phase P4),
+  the target's documentation updates too
+  (`docs/vision/HASKELL_TARGET_ROADMAP.md`).
+
+### Target-scope reminder
+
+This plan's consumers are demonstrated on Haskell WAM (Phase P4), but
+the module is **target-agnostic**. Rust WAM, LLVM, WAT, C#, and other
+targets can consume certificates without changes to the module. When
+those targets need verdicts, they call the same `analyze_predicate_purity/2`
+API and decide — per their own cost model — whether to act on the
+result. Phase P4 is *first consumer*, not *only consumer*.
+
+## When to start
+
+Ship P1–P3 as soon as the plan is approved. They're low-risk refactors
+that pay back by removing the scattered-analyzer problem immediately.
+
+P4 waits for Phase 4.1 of the intra-query parallelism plan — the
+`Par*` instructions don't exist yet, so there's nothing for the
+certificate module to drive.
+
+P5 (JSON) can ship anytime after P1 but is lowest priority until a
+cross-process consumer materializes.
+
+## Related documents
+
+- `docs/design/PURITY_CERTIFICATE_PROPOSAL.md` — motivation
+- `docs/design/PURITY_CERTIFICATE_SPECIFICATION.md` — mechanism
+- `docs/design/WAM_HASKELL_INTRA_QUERY_IMPLEMENTATION_PLAN.md` — Phase 4.1 is P4's precondition
+- `docs/design/WAM_HASKELL_INTRA_QUERY_SPEC.md` §3 — consumer contract

--- a/docs/design/PURITY_CERTIFICATE_PROPOSAL.md
+++ b/docs/design/PURITY_CERTIFICATE_PROPOSAL.md
@@ -1,0 +1,250 @@
+# Shared Purity Certificate Module: Proposal
+
+> **Motivation and direction** for extracting UnifyWeaver's existing
+> purity / order-independence analyses into a single `core/` module
+> with a shared certificate shape. This doc establishes *what* and
+> *why*; see `PURITY_CERTIFICATE_SPECIFICATION.md` for the concrete
+> shape, and `PURITY_CERTIFICATE_IMPLEMENTATION_PLAN.md` for the
+> phased rollout.
+
+## The problem
+
+Purity-like analyses are scattered across the project. Each consumer
+invents its own return shape, its own conservative rules, and its own
+opinion on what "safe" means. Nothing crosses target boundaries.
+
+Concrete symptoms:
+
+- **Two purity modules already exist**, overlapping but not unified:
+  - `src/unifyweaver/core/clause_body_analysis.pl` — blacklist
+    (`is_impure_builtin/1`), `is_pure_goal/1`, `is_order_independent/2`,
+    `classify_parallelism/3`, `partition_parallel_goals/5`.
+  - `src/unifyweaver/core/advanced/purity_analysis.pl` — a narrower
+    whitelist (`pure_builtin/1`: 20 clauses for arithmetic, comparison,
+    type checks, list ops), used by the tail-recursion transformation.
+- **The Haskell WAM intra-query parallelism spec** (§3.1) already
+  *assumes* a centralized purity module exists — Phase 4.1 will need
+  it to decide whether to emit `ParTryMeElse` instead of `TryMeElse`.
+- **Kernel detection implicitly assumes purity** — FFI-owned kernels
+  (`src/unifyweaver/core/recursive_kernel_detection.pl`) are trusted
+  without any certificate because they're hand-coded native. There's
+  no explicit statement of that trust, and no way to validate it.
+- **No serialization.** A verdict can't cross the Prolog↔C# boundary,
+  so if the C# pipeline ever *did* produce purity verdicts, we'd have
+  nowhere to put them.
+
+## What the Prolog side already knows
+
+**`clause_body_analysis.pl` is doing most of the real work.**
+
+| Predicate | What it decides |
+|---|---|
+|`is_pure_goal/1`|Single goal side-effect-free — blacklist-based, allows user-declared `parallel_safe/1`.|
+|`is_impure_builtin/1`|Hardcoded list: I/O (`write`, `read`, `format`, `get_char`, …), database (`assert*`, `retract*`), globals (`nb_setval`, `b_setval`), and domain-specific impurities.|
+|`is_order_independent/2`|Predicate safe to reorder clauses — returns `declared` (user said so) or `proven([pure_goals])` (static check that every goal in every clause is pure).|
+|`goals_are_independent/1`|Conjunction safe to parallelize — pure **and** disjoint bindings.|
+|`classify_parallelism/3`|High-level verdict: `goal_parallel(...)` / `clause_parallel` / `sequential`.|
+|`partition_parallel_goals/5`|Splits a goal list into an independent prefix + dependent tail.|
+
+Sophistication level: **simple syntactic checks**. Functor membership
+plus variable-set intersection. No abstract interpretation, no fixpoint
+analysis. That's the right call for a conservative analyzer — cheap,
+predictable, easy to extend.
+
+**`advanced/purity_analysis.pl`** is the whitelist counterpart: 92 lines
+defining `pure_builtin/1` for the tail-recursion transformation. Narrower
+(strict whitelist vs permissive blacklist) because of its different
+use case — refusing to transform anything not provably pure vs refusing
+to parallelize anything provably impure.
+
+**User annotations already feed in:**
+- `:- parallel(P/N).`
+- `:- order_independent(P/N).`
+- `:- parallel_safe(F/A).` (per-functor)
+
+The two forms are correctly recognized by `is_order_independent/2`
+but the plumbing isn't exposed as a shared API.
+
+## What the C# target does — and why we're not borrowing from it
+
+The agent investigation surfaced one C# helper that might *look* like
+purity analysis but isn't. In `src/unifyweaver/targets/csharp_target.pl`
+lines 1981–2006:
+
+```prolog
+safe_recursive_clause_for_need(HeadSpec, _-Body) :-
+    ...
+    body_to_list(Body, Terms),
+    findall(Index, (nth0(Index, Terms, Term0), ...), Occs),
+    Occs \= [],
+    forall(member(Index, Occs), (
+        prefix_terms(Index, Terms, Pred, Arity, Prefix),
+        \+ (member(T, Prefix), aggregate_goal(T))
+    )).
+```
+
+This predicate decides whether a recursive clause is **safe for demand
+("need") closure materialization** — a query-planning optimization
+that pushes demand propagation into a fixpoint computation. It checks:
+
+- The recursive call occurs at least once.
+- No `aggregate_*` goal appears in the prefix *before* each recursive call.
+
+That's **a structural property for query-planning safety, not a purity
+or order-independence claim**. It doesn't ask "does this goal have side
+effects?" — it asks "can I hoist demand analysis through this
+recursion without losing aggregate semantics?"
+
+Similarly, `safe_mutual_need_prefixes/1` (line 2055) checks that mutual
+recursion has compatible prefixes across clauses. Again structural, not
+effect-based.
+
+### Why we're not borrowing the C# logic
+
+1. **Different semantics.** Side-effect freedom ≠ aggregate-compatible
+   recursion structure. Borrowing would conflate two distinct concerns.
+2. **Narrower scope.** The C# checks are coupled to the need-closure
+   optimizer; they wouldn't transfer meaningfully to "should the WAM
+   emit `ParTryMeElse`?"
+3. **The Prolog side is already richer** than the C# side for purity
+   specifically. The C# engine has no `is_pure_goal` equivalent, no
+   side-effect blacklist, no I/O detection.
+
+### What (minimally) we *could* borrow later
+
+The C# need-closure safety check is **orthogonal to purity but adjacent
+to parallelism safety**: a predicate might be pure *and* unsafe to
+parallelize under the need-closure optimization, or vice versa. When
+Phase 4.x eventually needs to compose parallelism decisions with
+query-plan optimizations, the two analyses might meet at a joint
+"safe to parallelize *and* safe to hoist through this fixpoint"
+predicate. That joint predicate would call both the purity certificate
+and the C# structural check, not merge them.
+
+So the eventual relationship is **cooperation, not absorption**: the
+purity module owns effect-freeness; the C# module owns
+need-closure-compatibility; a thin integration layer combines them
+when a caller needs both.
+
+For Phase 1 of this proposal, we borrow nothing from C#. The C# side
+gets the ability to *consume* purity certificates in the future, and
+contribute its own structural verdicts through the same certificate
+shape if it ever grows side-effect analysis.
+
+## Direction
+
+**Extract, don't invent.** A new module `core/purity_certificate.pl`:
+
+1. Defines a **shared certificate shape** (see the specification doc).
+2. **Wraps the existing logic** in `clause_body_analysis.pl` — produces
+   certificates from the same blacklist + clause walker.
+3. **Absorbs** `advanced/purity_analysis.pl`'s whitelist as an
+   alternative strategy (strict mode).
+4. **Exposes a registration API** for extra producers (kernel registry,
+   user annotations, future C# certificates).
+5. **Documents the serialization format** (Prolog term, JSON for
+   cross-process) so the Prolog↔C# boundary has an answer when the time
+   comes.
+
+The rest of the project gets thin wrappers or migrates gradually.
+
+## Target scope: general, not Haskell-specific
+
+The certificate is a verdict about the **source predicate's semantics**
+— does it have side effects? can its clauses be reordered? The verdict
+is the same regardless of which backend consumes it. So the module is
+**target-agnostic** in principle:
+
+- **Haskell WAM (immutable).** Primary near-term consumer. `ParTryMeElse`
+  emission decision. Immutability makes the cost of acting on a
+  pure-verdict low — forking a choice point just copies pointers.
+- **Rust WAM (mutable).** Can still consume the same verdicts. A pure
+  predicate is forkable in Rust too; the target just pays a different
+  implementation cost (`Arc`/`Mutex` around shared state, or per-branch
+  state cloning via `Clone` derives). The certificate says *whether*
+  parallelism is safe; the target decides *whether it's worth the cost*.
+- **C# target.** Can consume verdicts for query-plan reordering
+  (pure goals can be hoisted past aggregates), join reordering, and —
+  eventually — parallel materialization. The structural need-closure
+  check it already has is orthogonal; both can be consulted.
+- **AWK, Bash, Go, LLVM, WAT** and other targets can reuse the same
+  certificate for whatever safety gate they expose. The certificate is
+  their oracle, not their implementation strategy.
+
+**What differs across targets is not the verdict — it's the cost/benefit
+the target pays to act on it.** Imperative targets may choose to
+consume `pure` verdicts more selectively (only when per-branch
+cloning is cheap); functional targets can consume them more
+aggressively. That decision lives in the target, not in the
+certificate.
+
+**Orthogonality to target memory model.** The certificate says nothing
+about whether the target can cheaply copy state to fork. That's an
+implementation concern for the target's fork primitive. Rust needs
+`.clone()` bounds + possibly `Arc` sharing; Haskell needs `rdeepseq`;
+C# needs value-type semantics or defensive copies. All three can
+consume the same verdict and use it to guide, not dictate, their fork
+strategy. A target may even choose to never fork even when the
+certificate is `pure` — that's the target's call.
+
+This matters for the implementation plan: we explicitly do *not* put
+fork-primitive logic in the certificate module. The module produces
+verdicts; targets consume them and decide what to do.
+
+## Non-goals
+
+- **Abstract interpretation.** We stay syntactic. A goal is pure iff
+  none of its builtins match the impure blacklist (or all match the
+  pure whitelist, in strict mode). No constraint solving, no
+  abstract domains, no dataflow analysis.
+- **Cross-module call-graph analysis.** The certificate analyzes a
+  predicate's clauses directly; it does not chase transitive calls.
+  "Calls a user predicate" is treated as `unknown` unless that user
+  predicate has its own certificate (declared or analyzed).
+- **Proving termination.** Orthogonal concern.
+- **Unifying every safety analysis in the project.** The C# need-closure
+  check, termination bounds, mode inference — these stay separate.
+  This module is specifically about **side-effect freedom and
+  order-independence**.
+
+## Why now
+
+Three reasons, in order of weight:
+
+1. **Phase 4.1 of the intra-query parallelism plan will need it.**
+   `ParTryMeElse` emission must consult a purity verdict. The spec
+   assumes this module exists; the plan slots it in at Phase 4.1. If
+   we extract now, Phase 4.1 becomes a simple emission decision
+   instead of a full analysis.
+
+2. **The existing logic is fragmenting.** Two modules with subtly
+   different rules are easier to reconcile now (a few hundred lines
+   total) than after both have grown more callers. Debt is linear in
+   caller count.
+
+3. **The certificate shape is a natural place for future producers.**
+   Kernel-detection purity (trusted-by-construction), user annotations
+   (trusted-by-declaration), static analysis (proven), and eventual
+   C#-engine verdicts (certified) all have different provenance and
+   different confidence. A shared shape with provenance metadata lets
+   consumers make informed fallback decisions (e.g., "this predicate
+   has confidence 0.8 — fork, but estimate work conservatively").
+
+## When to stop extracting
+
+If the new module grows past ~400 lines of non-trivial code, we've
+probably absorbed something that should have stayed separate.
+The target is: thin producers + thin consumers + a stable certificate
+shape in the middle. If it becomes a behemoth, we're re-inventing a
+static analyzer. That's a different project.
+
+## Related documents
+
+- `docs/design/PURITY_CERTIFICATE_SPECIFICATION.md` — concrete shape
+- `docs/design/PURITY_CERTIFICATE_IMPLEMENTATION_PLAN.md` — phased rollout
+- `docs/design/WAM_HASKELL_INTRA_QUERY_SPEC.md` §3 — first consumer
+- `docs/design/WAM_HASKELL_INTRA_QUERY_IMPLEMENTATION_PLAN.md` §4.1 — emission site
+- `src/unifyweaver/core/clause_body_analysis.pl` — existing donor
+- `src/unifyweaver/core/advanced/purity_analysis.pl` — alternate whitelist
+- `src/unifyweaver/targets/csharp_target.pl` §1975+ — the C# logic we
+  are *not* absorbing

--- a/docs/design/PURITY_CERTIFICATE_SPECIFICATION.md
+++ b/docs/design/PURITY_CERTIFICATE_SPECIFICATION.md
@@ -1,0 +1,349 @@
+# Shared Purity Certificate Module: Specification
+
+> **Scope:** This specifies the data shape, public API, producer/consumer
+> contract, and serialization format for the shared purity certificate
+> module proposed in `PURITY_CERTIFICATE_PROPOSAL.md`. The certificate
+> is target-agnostic — same shape consumed by Haskell WAM, Rust WAM,
+> C# query engine, and any future backend.
+>
+> See `PURITY_CERTIFICATE_IMPLEMENTATION_PLAN.md` for the phased rollout.
+
+## 1. Certificate shape
+
+```prolog
+%% purity_cert(+Verdict, +Proof, +Confidence, +Reasons)
+%
+% A single certificate captures one analysis result about one
+% predicate (or one goal). The shape is a compound term so it can
+% be pattern-matched directly and serialized without schema drift.
+
+purity_cert(
+    Verdict,       % pure | impure(ReasonList) | unknown
+    Proof,         % declared | analyzed(Strategy) | certified(Source) | inferred
+    Confidence,    % float in [0.0, 1.0]
+    Reasons        % list of atom — e.g. [io_ops, retract, cuts_escape, ...]
+).
+```
+
+### 1.1 Verdict
+
+|Value|Meaning|
+|---|---|
+|`pure`|No side effects; clauses are order-independent.|
+|`impure(ReasonList)`|Side effects detected; `ReasonList` enumerates culprits.|
+|`unknown`|Analysis could not reach a conclusion (e.g., transitive call to a predicate without its own certificate).|
+
+`pure` is the only verdict that justifies emitting parallel instructions
+or reordering clauses. `impure` is always a reject. `unknown` is
+treated as `impure` by conservative consumers but may be upgraded by
+a future producer (e.g., a user annotation arriving later).
+
+### 1.2 Proof provenance
+
+|Value|Meaning|Typical confidence|
+|---|---|---|
+|`declared`|User asserted via `:- parallel(P/N).` or `:- order_independent(P/N).`|1.0 (trust the user)|
+|`analyzed(Strategy)`|Static analysis — `Strategy` names the analyzer (`blacklist`, `whitelist`, `clause_walk`, …)|0.85–0.95|
+|`certified(Source)`|External certifier — `Source` is an atom like `kernel_registry`, `csharp_demand_analysis`, `user_review`|0.90–1.0|
+|`inferred`|Weak heuristic (e.g., "all recursive calls hit certified predicates")|0.50–0.75|
+
+### 1.3 Confidence
+
+Float in `[0.0, 1.0]`. Advisory — tells a consumer how much to trust the
+verdict when multiple certificates disagree or when a consumer weighs
+verdict against cost (e.g., a Rust target may require confidence ≥ 0.9
+before paying the `Clone` cost, while Haskell may act on ≥ 0.5).
+
+Producer convention: exactly what the producer's own process guarantees.
+A user `:- parallel/1` annotation is 1.0. A blacklist analyzer on a
+predicate with no transitive user-predicate calls is 0.9. A
+kernel-registry certification is 1.0 (handwritten and reviewed).
+
+### 1.4 Reasons
+
+List of atoms identifying either the **culprits** (for `impure`) or
+the **evidence** (for `pure`).
+
+**For `impure`:**
+- `io_ops` — `write`, `read`, `format`, `get_char`, etc.
+- `database_mods` — `assert*`, `retract*`.
+- `global_state` — `nb_setval`, `b_setval`.
+- `cuts_escape` — `!` whose barrier is outside the predicate.
+- `calls_impure_pred(Pred/Arity)` — transitive call to an impure predicate.
+- `unknown_builtin(Name/Arity)` — builtin not in any whitelist/blacklist.
+- `mutable_state` — for targets that track this (e.g., aliased refs).
+
+**For `pure`:**
+- `blacklist_clean` — no impure builtins detected.
+- `whitelist_only` — all builtins in the strict whitelist.
+- `disjoint_bindings` — for `goals_are_independent` derivations.
+- `declared_by_user` — from `:- parallel/1` or `:- order_independent/1`.
+- `kernel_owned` — FFI-owned predicate; trusted by construction.
+
+A `Reasons` list is never empty for `impure`. It may be empty `[]` for
+`pure` if `Proof = declared` (the user's word is the entire evidence).
+
+## 2. Public API
+
+### 2.1 Producer API
+
+```prolog
+%% analyze_goal_purity(+Goal, -Cert)
+%  Certify a single goal. Looks up the goal's functor in the
+%  registered analyzers (blacklist, whitelist, user annotations,
+%  kernel registry). Returns the highest-confidence verdict.
+analyze_goal_purity(Goal, Cert).
+
+%% analyze_predicate_purity(+PredIndicator, -Cert)
+%  Certify a predicate by analyzing its clauses. PredIndicator is
+%  `Module:Name/Arity` or bare `Name/Arity` (user:-prefixed).
+%
+%  Resolution order:
+%    1. User annotation (:- parallel/1 or :- order_independent/1) → declared
+%    2. Kernel registry membership → certified(kernel_registry)
+%    3. Clause-body analysis over every clause → analyzed(clause_walk)
+%    4. Otherwise → unknown
+analyze_predicate_purity(PredIndicator, Cert).
+
+%% analyze_clause_purity(+ClauseTerm, -Cert)
+%  Certify a single clause (Head-Body). Rarely called directly; used
+%  internally by analyze_predicate_purity.
+analyze_clause_purity(Head-Body, Cert).
+```
+
+### 2.2 Registration API
+
+```prolog
+%% register_purity_producer(+ProducerSpec, +Priority)
+%  Add a new producer to the analysis chain. Priority is checked in
+%  descending order; first verdict wins.
+%
+%  ProducerSpec = purity_producer(Name, Analyzer, SupportedConstructs)
+%  Analyzer is a pred:(+Input, -Cert) meeting the API.
+register_purity_producer(purity_producer(user_annotations, user_annotation_analyzer, [predicate]), 100).
+register_purity_producer(purity_producer(kernel_registry,  kernel_analyzer,          [predicate]), 90).
+register_purity_producer(purity_producer(blacklist,        blacklist_analyzer,       [goal, clause, predicate]), 50).
+register_purity_producer(purity_producer(whitelist,        whitelist_analyzer,       [goal, clause, predicate]), 40).
+```
+
+Producers are registered at startup via directives; consumers don't
+see them directly.
+
+### 2.3 Consumer API
+
+```prolog
+%% Convenience predicates for common questions.
+is_certified_pure(+PredIndicator)       :- ...  % Cert = purity_cert(pure, _, _, _).
+is_certified_impure(+PredIndicator, -Reasons). % Cert = purity_cert(impure(Reasons), _, _, _).
+purity_confidence(+PredIndicator, -Conf).      % Float in [0,1] regardless of verdict.
+```
+
+### 2.4 Merge API (for multi-producer scenarios)
+
+```prolog
+%% merge_certificates(+CertList, -MergedCert)
+%  Combine multiple certificates for the same predicate. Resolution:
+%    - Any impure → impure (short-circuit, conservative).
+%    - All pure → pure with max(Confidence) and merged Reasons.
+%    - Mixed pure + unknown → pure if at least one producer has
+%      Confidence ≥ 0.9, else unknown.
+merge_certificates(Certs, Merged).
+```
+
+Used when the C# engine contributes a verdict *and* the Prolog analyzer
+has one, or when `:- parallel/1` coexists with a blacklist warning.
+
+## 3. Serialization format
+
+For cross-process communication (Prolog ↔ C# query engine, future
+persistence to disk, test fixtures). Two formats:
+
+### 3.1 Prolog term (native)
+
+```prolog
+purity_cert(pure, declared, 1.0, [declared_by_user])
+purity_cert(impure([io_ops, database_mods]), analyzed(blacklist), 0.95, [])
+purity_cert(unknown, inferred, 0.3, [unknown_builtin(my_op/2)])
+```
+
+Use when the consumer is another Prolog module.
+
+### 3.2 JSON (interop)
+
+```json
+{
+  "verdict": "pure",
+  "proof": {"kind": "declared"},
+  "confidence": 1.0,
+  "reasons": ["declared_by_user"],
+  "subject": "category_ancestor/4",
+  "producer": "user_annotations",
+  "producer_version": "1.0.0"
+}
+```
+
+Use when crossing a language boundary. `producer` and `producer_version`
+are metadata not in the core term but useful for debugging
+provenance in a multi-producer pipeline.
+
+The `impure` verdict wraps its reason list into the top-level
+`reasons` field:
+
+```json
+{
+  "verdict": "impure",
+  "proof": {"kind": "analyzed", "strategy": "blacklist"},
+  "confidence": 0.95,
+  "reasons": ["io_ops", "database_mods"],
+  "subject": "log_and_dispatch/2"
+}
+```
+
+## 4. Producer contracts
+
+Each producer must meet:
+
+- **Determinism.** Given the same input, return the same certificate.
+  No reliance on assert order, clock time, or GHC optimization level.
+- **Termination.** No infinite loops even on deeply nested goals.
+  Cycles in call graphs must be detected and terminated with `unknown`.
+- **Conservative defaults.** Unknown builtins, unknown functors, and
+  unanalyzable structures produce `unknown` — never `pure`.
+- **No global state mutation.** The analysis itself must be pure —
+  otherwise the analyzer is a side-effect source, destroying its own
+  verdict's meaning.
+
+## 5. Consumer contracts
+
+Each consumer must meet:
+
+- **Treat `unknown` as `impure` by default.** Only override with explicit
+  user policy (e.g., a debug flag).
+- **Respect `Confidence` when the action is costly.** A Rust target
+  may refuse to fork on confidence < 0.9 even if verdict is `pure`.
+  The certificate says "safe"; the target decides "worthwhile."
+- **Record verdicts consumed.** When the consumer makes a compilation
+  decision (emit Par* vs Try*), log the verdict that drove it — for
+  debugging and for the `intra_query_parallel(false)` future kill
+  switch (see intra-query spec §3.3).
+
+## 6. Relationship to existing modules
+
+### 6.1 `clause_body_analysis.pl`
+
+**Role: principal donor.** Current predicates map to the new module as:
+
+|Old API|New API|Migration|
+|---|---|---|
+|`is_pure_goal(G)`|`analyze_goal_purity(G, purity_cert(pure, _, _, _))`|wrapper in old module|
+|`is_order_independent(P, declared)`|`analyze_predicate_purity(P, purity_cert(pure, declared, _, _))`|wrapper|
+|`is_order_independent(P, proven(R))`|`analyze_predicate_purity(P, purity_cert(pure, analyzed(_), _, R))`|wrapper|
+|`classify_parallelism/3`|Stays — now internally calls `analyze_predicate_purity`|refactor|
+|`partition_parallel_goals/5`|Stays — uses `analyze_goal_purity` per-goal|refactor|
+
+`is_impure_builtin/1`'s clauses move into `blacklist_analyzer`'s
+definition.
+
+### 6.2 `advanced/purity_analysis.pl`
+
+**Role: whitelist strategy.** `pure_builtin/1` becomes the body of
+`whitelist_analyzer`. Callers get the same semantics via
+`analyze_goal_purity` with a strict-mode consumer preference:
+
+```prolog
+% Consumer picks whitelist-only by filtering on Proof.
+analyze_goal_purity(G, Cert),
+Cert = purity_cert(pure, analyzed(whitelist), _, _).
+```
+
+The old `is_pure_goal/1` in that module becomes a thin wrapper for
+back-compat.
+
+### 6.3 `recursive_kernel_detection.pl`
+
+**Role: kernel producer.** Every kernel registered via `kernel_detector/2`
+(and its companions `kernel_native_kind/2`, etc.) gains an implicit
+certificate:
+
+```prolog
+purity_cert(pure, certified(kernel_registry), 1.0, [kernel_owned])
+```
+
+The certificate exists because FFI-owned kernels are hand-coded native
+implementations audited for purity by whoever wrote them. Making this
+explicit lets consumers (e.g., Haskell WAM `ParTryMeElse` emission)
+treat kernels and user-annotated predicates uniformly.
+
+### 6.4 `csharp_target.pl`
+
+**Role: consumer only in Phase 1. Potential producer later.**
+`safe_recursive_clause_for_need/2` (lines 1990–2006) is **structural
+need-closure safety**, not purity — it stays where it is. The C# target
+may start consuming certificates in Phase 5+ for query-plan
+reordering. If the C# engine eventually produces side-effect verdicts
+(from LINQ analysis or Roslyn data-flow), those become a new producer
+at priority ≥ 80 (trusted external certification).
+
+## 7. What stays the same
+
+- **User annotations** keep their existing syntax. `:- parallel(P/N).`
+  and `:- order_independent(P/N).` are parsed and turned into
+  declared-verdict certificates, not replaced.
+- **Existing callers of `is_pure_goal/1`** continue to work — the old
+  predicate becomes a thin wrapper returning a boolean.
+- **Performance.** The new module is no slower than the old per-call;
+  the first call to `analyze_predicate_purity/2` memoizes the verdict
+  so repeated queries (e.g., during WAM emission) are constant-time
+  lookups.
+
+## 8. Target-scope applicability
+
+The certificate shape is **target-agnostic**. Verdicts apply equally to:
+
+- **Haskell WAM (immutable).** First consumer. Uses verdicts to emit
+  `ParTryMeElse` / `ParRetryMeElse` / `ParTrustMe` where purity allows.
+- **Rust WAM (mutable).** Consumes the same verdicts. Fork cost is
+  higher (needs `Clone` bounds or `Arc` wrapping), so Rust may apply
+  stricter confidence thresholds or defer to user opt-in via
+  `:- parallel/1` only. The certificate is the oracle; Rust's fork
+  primitive decides how to act.
+- **C# query engine.** Verdict consumers for query-plan reordering
+  (pure goals hoist past aggregates), join ordering, and eventual
+  parallel materialization. The existing structural need-closure check
+  stays separate — a joint caller combines both verdicts when
+  relevant.
+- **Other targets (Go, AWK, LLVM, WAT, Bash).** Any target that needs
+  to know "can I reorder this" or "is this side-effect-free" plugs in
+  as a consumer. The module makes no commitments about the target's
+  memory model.
+
+**What the certificate does not include:** fork primitives, state-copy
+strategies, runtime spark management. Those are target concerns. A
+Rust target may decide *never* to fork even on a 1.0-confidence pure
+verdict because `Clone` is too expensive for the workload; that's a
+target policy, not a certificate concern.
+
+## 9. Open questions
+
+1. **How do we handle `meta_predicate/1`?** E.g., `findall/3` is
+   pure iff its Goal argument is pure. Current blacklists don't handle
+   this. Options: (a) special-case meta-calls in the analyzer; (b) punt
+   to `unknown` and require user annotation; (c) introduce a
+   "contingent purity" verdict. MVP picks (b); (c) is a future
+   refinement.
+
+2. **Caching policy for `analyze_predicate_purity`.** Memoize forever?
+   Invalidate on `assertz`? MVP: memoize per-module-load, invalidate
+   on `retractall` of the target predicate.
+
+3. **Should `certified(Source)` include a version?** For forward-compat
+   when a certifier's semantics change. MVP: no; version lives only in
+   JSON serialization for cross-process correlation.
+
+## Related documents
+
+- `docs/design/PURITY_CERTIFICATE_PROPOSAL.md` — motivation
+- `docs/design/PURITY_CERTIFICATE_IMPLEMENTATION_PLAN.md` — rollout
+- `docs/design/WAM_HASKELL_INTRA_QUERY_SPEC.md` §3 — first consumer
+- `src/unifyweaver/core/clause_body_analysis.pl` — existing donor
+- `src/unifyweaver/core/advanced/purity_analysis.pl` — whitelist source


### PR DESCRIPTION
  ## Summary

  Three design docs (matching the philosophy/spec/plan pattern used for the intra-query parallelism series in #1395) for
   extracting UnifyWeaver's scattered purity and order-independence analyses into a single `core/` module with a shared
  certificate shape. Target-agnostic by construction — Haskell WAM is the first consumer, but Rust, C#, and other
  targets can consume the same verdicts under their own cost models.

  - `docs/design/PURITY_CERTIFICATE_PROPOSAL.md` — motivation and direction.
  - `docs/design/PURITY_CERTIFICATE_SPECIFICATION.md` — concrete shape, API, serialization.
  - `docs/design/PURITY_CERTIFICATE_IMPLEMENTATION_PLAN.md` — five-phase rollout.

  ## Why now

  - **Phase 4.1 of intra-query parallelism needs it.** `ParTryMeElse` emission must consult a purity verdict; the spec
  from #1395 already assumes this module exists.
  - **Existing logic is fragmenting.** Two modules (`clause_body_analysis.pl`, `advanced/purity_analysis.pl`) with
  subtly different rules are easier to reconcile now than after more callers accumulate.
  - **No shared shape today.** A verdict can't cross the Prolog↔C# boundary; each consumer invents its own return
  format.

  ## Key design decisions

  ### Target-agnostic, not Haskell-specific

  The certificate is a verdict about **the source predicate's semantics** (side effects, clause order-independence). The
   verdict is the same regardless of backend. What differs is *how a target acts* on the verdict — Haskell forks freely
  on `pure`, Rust may apply stricter confidence thresholds because `Clone`/`Arc` costs are higher, C# may use verdicts
  for query-plan reordering rather than parallelism. The module does not embed fork primitives or memory-model
  assumptions.

  ### Not borrowing from the C# target

  The agent investigation found that `csharp_target.pl`'s `safe_recursive_clause_for_need/2` (lines 1990–2006) is
  **structural need-closure safety**, not side-effect analysis. It checks whether aggregate goals appear in the prefix
  before recursive calls — orthogonal to purity. The docs explain why conflating them would be a mistake, and note that
  the C# target becomes a future *consumer* (and potential *producer* if LINQ-side analysis ever materializes) through
  the same certificate shape, not a donor for the MVP.

  ### Certificate shape

  ```prolog
  purity_cert(
      Verdict,       % pure | impure(ReasonList) | unknown
      Proof,         % declared | analyzed(Strategy) | certified(Source) | inferred
      Confidence,    % float in [0.0, 1.0]
      Reasons        % list of atom
  ).
  ```

  `Confidence` is advisory — lets imperative targets require `≥ 0.9` before paying fork costs while functional targets
  act on `≥ 0.5`. `Proof` provenance lets consumers distinguish user-declared (`1.0`) from statically-analyzed
  (`0.85–0.95`) from inferred (`0.50–0.75`).

  ### Producers already in the codebase

  - `clause_body_analysis.pl` — blacklist (`is_impure_builtin/1`), order-independence (`is_order_independent/2`),
  parallelism classification (`classify_parallelism/3`). **Principal donor.**
  - `advanced/purity_analysis.pl` — narrower whitelist (20 builtins), used by tail-recursion transformation. **Absorbed
  as alternate strategy in P2.**
  - `recursive_kernel_detection.pl` — FFI-owned kernels are trusted-by-construction. **Becomes explicit producer in
  P3.**
  - User annotations (`:- parallel/1.`, `:- order_independent/1.`, `:- parallel_safe/1.`) — already recognized, just
  plumb them through.

  ## Rollout (five phases)

  |Phase|Scope|Risk|
  |---|---|---|
  |P1|Create `core/purity_certificate.pl`; blacklist producer; thin wrappers keep existing callers working|Low|
  |P2|Absorb `advanced/purity_analysis.pl` whitelist as alternate strategy|Low|
  |P3|Kernel registry producer (every detected kernel → `certified(kernel_registry)` cert)|Low|
  |P4|Wire into Haskell WAM Phase 4.1 `ParTryMeElse` emission + the `intra_query_parallel(false)` kill switch from #1395
   §3.3|Med|
  |P5|JSON serialization for cross-process interop|Low|

  P1–P3 are pure refactors with equivalence-gate tests — every existing caller gets the same verdict wrapped in a
  certificate. P4 depends on intra-query Phase 4.1. P5 ships anytime a cross-process consumer shows up.

  ## Regression risk

  None — docs only. No source code touched. Zero runtime impact.

  ## Test plan (for the eventual implementation)

  - [ ] Every existing `:- parallel(P/N).` and `:- order_independent(P/N).` annotation produces `purity_cert(pure,
  declared, 1.0, [declared_by_user])`.
  - [ ] Every predicate the old `is_pure_goal/1` considered pure certifies `pure` via the new API.
  - [ ] Every impure case produces correct reason atoms (`io_ops`, `database_mods`, `global_state`, …).
  - [ ] Tail-recursion transformation test fixtures produce identical output after P2.
  - [ ] All 7 current kernels certify `kernel_owned` after P3.
  - [ ] P4: annotated predicate emits `ParTryMeElse`; unannotated emits `TryMeElse`; impure-bodied annotated predicate
  emits `TryMeElse` (blacklist overrides annotation).
  - [ ] P5: `cert → json → cert` round-trips bit-identical.

  ## Related

  - Intra-query parallelism design series: #1395 (spec §3 is the first consumer contract)
  - Intra-query Phase 4.0 benchmark: #1397
  - `src/unifyweaver/core/clause_body_analysis.pl` — principal donor
  - `src/unifyweaver/core/advanced/purity_analysis.pl` — whitelist source
  - `src/unifyweaver/targets/csharp_target.pl` §1975+ — the C# logic we explicitly are **not** absorbing, with the
  reasoning in the proposal

  🤖 Generated with [Claude Code](https://claude.com/claude-code)