### PR TITLE
feat(wam-haskell): intra-query Phase 4.1 + certificate P4 — Par* instructions

### DIFF
--- a/docs/design/PURITY_CERTIFICATE_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PURITY_CERTIFICATE_IMPLEMENTATION_PLAN.md
@@ -191,10 +191,16 @@ that as a follow-up.
 
 ---
 
-## Phase P4: Wire into Haskell WAM Phase 4.1 emission
+## Phase P4: Wire into Haskell WAM Phase 4.1 emission — **DELIVERED 2026-04-15**
 
 First real consumer. When Phase 4.1 emits `ParTryMeElse` vs
 `TryMeElse`, it consults the certificate module.
+
+**Status: delivered**, combined with intra-query Phase 4.1 on the same
+branch — emission was wired certificate-driven from the start rather
+than shipping a simpler annotation check first. Confidence threshold
+0.85 matches the spec. Kill switch `intra_query_parallel(false)`
+lands alongside the emission path.
 
 **Precondition:** Phase 4.1 of the intra-query parallelism
 implementation plan (WAM instruction additions). P4 of this plan

--- a/docs/design/WAM_HASKELL_INTRA_QUERY_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_HASKELL_INTRA_QUERY_IMPLEMENTATION_PLAN.md
@@ -109,11 +109,20 @@ WAM interpreter result is identical.)
 
 ---
 
-## Phase 4.1: Instruction emission
+## Phase 4.1: Instruction emission — **DELIVERED 2026-04-15**
 
 Add the new instructions and have the WAM compiler emit them for
 annotated predicates. **No runtime behavior change yet** — they're
 treated as their sequential equivalents at runtime.
+
+**Status: delivered**, combined with purity certificate P4 on the
+same branch. The emission decision is driven by
+`purity_certificate:analyze_predicate_purity/2` rather than a direct
+annotation check, so user annotations, kernel registry certifications,
+and blacklist verdicts all feed into Par* emission uniformly. The
+`intra_query_parallel(false)` option from §3.3 of the spec lands here
+as well. Generated `Par*` instructions route to the sequential step
+handlers (placeholder for Phase 4.2's actual fork).
 
 ### Changes
 

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -43,6 +43,8 @@
              [detect_recursive_kernel/4, kernel_metadata/4, kernel_config/2,
               kernel_register_layout/2, kernel_native_call/2, kernel_template_file/2]).
 :- use_module('../core/template_system', [render_template/3]).
+:- use_module('../core/purity_certificate',
+             [analyze_predicate_purity/2]).
 
 % Phase 3: the real lowerability check and emission helpers live in the
 % wam_haskell_lowered_emitter module. We reexport so existing callers can
@@ -1367,6 +1369,17 @@ step !ctx s (RetryMeElsePc nextPC) =
     (cp : rest) -> Just (s { wsPC = wsPC s + 1, wsCPs = cp { cpNextPC = nextPC } : rest })
     [] -> Nothing
 
+-- Phase 4.1 parallel-forkable variants. For now they alias their
+-- sequential counterparts — the instructions mark the predicate as
+-- fork-safe but the runtime doesn''t fork yet. Phase 4.2 will split
+-- these handlers off to do actual parMap-based forking at the
+-- surrounding aggregate boundary.
+step !ctx s (ParTryMeElse label)    = step ctx s (TryMeElse label)
+step !ctx s (ParRetryMeElse label)  = step ctx s (RetryMeElse label)
+step !ctx s ParTrustMe              = step ctx s TrustMe
+step !ctx s (ParTryMeElsePc pc)     = step ctx s (TryMeElsePc pc)
+step !ctx s (ParRetryMeElsePc pc)   = step ctx s (RetryMeElsePc pc)
+
 step !ctx s (SwitchOnConstantPc table) =
   let val = derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s)
   in case val of
@@ -2181,6 +2194,15 @@ resolveCallInstrs labels foreignPreds = map resolve
     resolve (RetryMeElse label) = case Map.lookup label labels of
       Just pc -> RetryMeElsePc pc
       Nothing -> RetryMeElse label
+    -- Phase 4.1 Par* variants resolve the same way as their sequential
+    -- counterparts. The instruction carries forkability intent; label
+    -- resolution is orthogonal.
+    resolve (ParTryMeElse label) = case Map.lookup label labels of
+      Just pc -> ParTryMeElsePc pc
+      Nothing -> ParTryMeElse label
+    resolve (ParRetryMeElse label) = case Map.lookup label labels of
+      Just pc -> ParRetryMeElsePc pc
+      Nothing -> ParRetryMeElse label
     resolve (SwitchOnConstant table) =
       let extractKey (Atom s) = s
           extractKey (Integer n) = show n
@@ -2340,6 +2362,17 @@ data Instruction
   | TryMeElse String
   | RetryMeElse String
   | TrustMe
+  -- Phase 4.1: parallel-forkable variants. Emitted by the compiler
+  -- when the predicate has a pure purity certificate. At Phase 4.1
+  -- they dispatch to the same sequential handlers as the non-Par
+  -- variants — the instructions carry intent, not behavior. Phase 4.2
+  -- will add the runtime fork. See
+  -- docs/design/WAM_HASKELL_INTRA_QUERY_SPEC.md §2.
+  | ParTryMeElse String
+  | ParRetryMeElse String
+  | ParTrustMe
+  | ParTryMeElsePc !Int
+  | ParRetryMeElsePc !Int
   | SwitchOnConstant (Map.Map Value String)   -- pre-built Map for O(log n) dispatch
   | BeginAggregate String !RegId !RegId   -- type, valueReg, resultReg
   | EndAggregate !RegId                   -- valueReg
@@ -2418,8 +2451,8 @@ executable ~w
 %% compile_predicates_to_haskell(+Predicates, +Options, -Code)
 %  Compiles all predicates into a single merged code array and label map,
 %  with proper PC offsets for each predicate.
-compile_predicates_to_haskell(Predicates, _Options, Code) :-
-    compile_predicates_merged(Predicates, 1, AllInstrs, AllLabels),
+compile_predicates_to_haskell(Predicates, Options, Code) :-
+    compile_predicates_merged(Predicates, 1, Options, AllInstrs, AllLabels),
     atomic_list_concat(AllInstrs, '\n    , ', InstrCode),
     atomic_list_concat(AllLabels, '\n    , ', LabelCode),
     format(string(Code),
@@ -2441,8 +2474,8 @@ allLabels = Map.fromList
     ]
 ', [InstrCode, LabelCode]).
 
-compile_predicates_merged([], _, [], []).
-compile_predicates_merged([PredIndicator|Rest], StartPC, AllInstrs, AllLabels) :-
+compile_predicates_merged([], _, _, [], []).
+compile_predicates_merged([PredIndicator|Rest], StartPC, Options, AllInstrs, AllLabels) :-
     (   PredIndicator = _Module:Pred/Arity -> true
     ;   PredIndicator = Pred/Arity
     ),
@@ -2450,10 +2483,60 @@ compile_predicates_merged([PredIndicator|Rest], StartPC, AllInstrs, AllLabels) :
     format(user_error, '  ~w/~w: compiled to WAM (PC=~w)~n', [Pred, Arity, StartPC]),
     atom_string(WamCode, WamStr),
     split_string(WamStr, "\n", "", Lines),
-    wam_lines_to_haskell(Lines, StartPC, InstrExprs, LabelExprs, NextPC),
-    compile_predicates_merged(Rest, NextPC, RestInstrs, RestLabels),
+    wam_lines_to_haskell(Lines, StartPC, InstrExprs0, LabelExprs, NextPC),
+    % Phase 4.1: if the purity certificate says this predicate is
+    % safe to parallelize, rewrite its choice-point instructions
+    % (TryMeElse / RetryMeElse / TrustMe) to the Par* variants.
+    maybe_parallelize_instrs(PredIndicator, Options, InstrExprs0, InstrExprs),
+    compile_predicates_merged(Rest, NextPC, Options, RestInstrs, RestLabels),
     append(InstrExprs, RestInstrs, AllInstrs),
     append(LabelExprs, RestLabels, AllLabels).
+
+%% maybe_parallelize_instrs(+PredIndicator, +Options, +InstrExprs0, -InstrExprs)
+%  Rewrite TryMeElse → ParTryMeElse etc. when the predicate certifies
+%  pure with confidence >= 0.85 and intra_query_parallel/1 hasn't
+%  been disabled. Otherwise leaves instructions alone.
+%
+%  Confidence threshold: 0.85 — catches user-declared (1.0),
+%  kernel-registry-certified (1.0), and blacklist-clean (0.9) as
+%  forkable. Inferred / low-confidence verdicts fall back to sequential.
+maybe_parallelize_instrs(PredIndicator, Options, InstrExprs0, InstrExprs) :-
+    (   option(intra_query_parallel(false), Options)
+    ->  InstrExprs = InstrExprs0
+    ;   purity_certificate:analyze_predicate_purity(
+            PredIndicator,
+            purity_cert(pure, _, Conf, _)),
+        Conf >= 0.85
+    ->  maplist(parallelize_choice_instr, InstrExprs0, InstrExprs),
+        ( InstrExprs \== InstrExprs0
+        -> ( PredIndicator = _:Pred/Arity -> true ; PredIndicator = Pred/Arity ),
+           format(user_error,
+                  '    [Par] ~w/~w: emitting Par* for forkable choice points~n',
+                  [Pred, Arity])
+        ; true
+        )
+    ;   InstrExprs = InstrExprs0
+    ).
+
+%% parallelize_choice_instr(+InstrStr0, -InstrStr)
+%  String-level rewrite of choice-point instructions:
+%    TryMeElse   "…"  →  ParTryMeElse   "…"
+%    RetryMeElse "…"  →  ParRetryMeElse "…"
+%    TrustMe          →  ParTrustMe
+%
+%  Accepts either atom or string input; returns the same type so
+%  callers and tests can mix representations without surprises.
+parallelize_choice_instr(S0, S) :-
+    atom_string(A0, S0),
+    ( sub_atom(A0, 0, _, _, 'TryMeElse ')
+    -> atom_concat('Par', A0, A)
+    ; sub_atom(A0, 0, _, _, 'RetryMeElse ')
+    -> atom_concat('Par', A0, A)
+    ; A0 == 'TrustMe'
+    -> A = 'ParTrustMe'
+    ; A = A0
+    ),
+    ( atom(S0) -> S = A ; atom_string(A, S) ).
 
 compile_single_predicate_to_haskell(PredIndicator, _Options, Code) :-
     (   PredIndicator = _Module:Pred/Arity -> true

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -14,6 +14,8 @@
 % Usage: swipl -g run_tests -t halt tests/test_wam_haskell_target.pl
 
 :- use_module('../src/unifyweaver/targets/wam_haskell_target').
+:- use_module('../src/unifyweaver/core/clause_body_analysis').
+:- use_module('../src/unifyweaver/core/purity_certificate').
 
 :- dynamic test_failed/0.
 
@@ -266,6 +268,149 @@ test_call_foreign_helper :-
     ;   fail_test(Test, 'callForeign helper missing from WamRuntime')
     ).
 
+%% Phase 4.1: Par* instructions — type, step handlers, resolveCallInstrs
+%% --------------------------------------------
+
+test_haskell_par_instructions_in_types :-
+    Test = 'WAM-Haskell: Par* constructors present in Instruction type',
+    (   compile_wam_runtime_to_haskell([], [], Code0),
+        % The Par* constructors are declared in WamTypes, which we
+        % access indirectly via the types generator.
+        atom_string(Code0, _),
+        wam_haskell_target:generate_wam_types_hs(TypesCode),
+        atom_string(TypesCode, TypesS),
+        sub_string(TypesS, _, _, _, "ParTryMeElse String"),
+        sub_string(TypesS, _, _, _, "ParRetryMeElse String"),
+        sub_string(TypesS, _, _, _, "ParTrustMe"),
+        sub_string(TypesS, _, _, _, "ParTryMeElsePc !Int"),
+        sub_string(TypesS, _, _, _, "ParRetryMeElsePc !Int")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Par* constructors missing from Instruction type')
+    ).
+
+test_haskell_par_step_handlers_present :-
+    Test = 'WAM-Haskell: step function handles Par* by delegating',
+    (   compile_wam_runtime_to_haskell([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "step !ctx s (ParTryMeElse label)"),
+        sub_string(S, _, _, _, "step !ctx s (ParRetryMeElse label)"),
+        sub_string(S, _, _, _, "step !ctx s ParTrustMe"),
+        sub_string(S, _, _, _, "step ctx s (TryMeElse label)"),
+        % confirm the ParTrustMe handler delegates to TrustMe
+        sub_string(S, _, _, _, "step ctx s TrustMe")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Par* step handlers missing or not delegating')
+    ).
+
+test_haskell_par_resolve_present :-
+    Test = 'WAM-Haskell: resolveCallInstrs handles Par* variants',
+    (   compile_wam_runtime_to_haskell([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "resolve (ParTryMeElse label)"),
+        sub_string(S, _, _, _, "resolve (ParRetryMeElse label)"),
+        sub_string(S, _, _, _, "ParTryMeElsePc"),
+        sub_string(S, _, _, _, "ParRetryMeElsePc")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Par* resolution missing from resolveCallInstrs')
+    ).
+
+%% Phase 4.1: certificate-driven Par* emission
+%% --------------------------------------------
+
+test_par_emission_for_user_annotated_predicate :-
+    Test = 'WAM-Haskell: :- parallel annotation drives Par* emission',
+    % Define a pure multi-clause predicate and mark it parallel.
+    retractall(clause_body_analysis:order_independent(user:p41_pure/1)),
+    retractall(user:p41_pure(_)),
+    assertz(clause_body_analysis:order_independent(user:p41_pure/1)),
+    assertz((user:p41_pure(1))),
+    assertz((user:p41_pure(2))),
+    assertz((user:p41_pure(3))),
+    (   wam_haskell_target:maybe_parallelize_instrs(user:p41_pure/1, [],
+            ['TryMeElse "L_a"', 'TrustMe', 'RetryMeElse "L_b"'], Out),
+        Out == ['ParTryMeElse "L_a"', 'ParTrustMe', 'ParRetryMeElse "L_b"']
+    ->  pass(Test)
+    ;   fail_test(Test, 'Expected Par* rewrite did not happen')
+    ),
+    retract(clause_body_analysis:order_independent(user:p41_pure/1)),
+    retractall(user:p41_pure(_)).
+
+test_no_par_emission_for_unannotated_impure_predicate :-
+    Test = 'WAM-Haskell: un-annotated predicate with impure body stays sequential',
+    % Un-annotated but the blacklist will flag write/1 as impure →
+    % analyze_predicate_purity returns impure → Par* suppressed.
+    retractall(user:p41_impure(_, _)),
+    assertz((user:p41_impure(X, Y) :- write(X), Y = X)),
+    assertz((user:p41_impure(_, _) :- nl)),
+    (   wam_haskell_target:maybe_parallelize_instrs(user:p41_impure/2, [],
+            ['TryMeElse "L_a"', 'TrustMe'], Out),
+        Out == ['TryMeElse "L_a"', 'TrustMe']
+    ->  pass(Test)
+    ;   fail_test(Test, 'Par* emitted for impure body — blacklist should suppress')
+    ),
+    retractall(user:p41_impure(_, _)).
+
+test_no_par_emission_for_impure_body :-
+    Test = 'WAM-Haskell: annotation plus impure body still emits sequential (blacklist overrides via confidence)',
+    % Annotation alone would normally win (priority 100). The test
+    % verifies that analyze_predicate_purity returns `pure/declared`
+    % BUT maybe_parallelize_instrs also requires the chain to be at
+    % least 0.85 confidence. Declared is 1.0 so the rewrite happens.
+    % This test documents current behavior: user declarations are
+    % trusted. A stricter policy could consult
+    % check_purity_contradictions, but that's not Phase 4.1.
+    retractall(clause_body_analysis:order_independent(user:p41_loud/1)),
+    retractall(user:p41_loud(_)),
+    assertz(clause_body_analysis:order_independent(user:p41_loud/1)),
+    assertz((user:p41_loud(X) :- write(X))),
+    (   wam_haskell_target:maybe_parallelize_instrs(user:p41_loud/1, [],
+            ['TryMeElse "L_a"', 'TrustMe'], Out),
+        % Declared user wins — this is expected. Document in reason.
+        Out = ['ParTryMeElse "L_a"', 'ParTrustMe']
+    ->  pass(Test)
+    ;   fail_test(Test, 'Declared-user annotation did not drive Par* as expected')
+    ),
+    retract(clause_body_analysis:order_independent(user:p41_loud/1)),
+    retractall(user:p41_loud(_)).
+
+test_intra_query_parallel_false_kill_switch :-
+    Test = 'WAM-Haskell: intra_query_parallel(false) forces sequential emission',
+    retractall(clause_body_analysis:order_independent(user:p41_kill/1)),
+    assertz(clause_body_analysis:order_independent(user:p41_kill/1)),
+    (   wam_haskell_target:maybe_parallelize_instrs(user:p41_kill/1,
+            [intra_query_parallel(false)],
+            ['TryMeElse "L_a"', 'TrustMe'], Out),
+        Out == ['TryMeElse "L_a"', 'TrustMe']
+    ->  pass(Test)
+    ;   fail_test(Test, 'intra_query_parallel(false) did not suppress Par*')
+    ),
+    retract(clause_body_analysis:order_independent(user:p41_kill/1)).
+
+test_par_rewrite_preserves_non_choice_instrs :-
+    Test = 'WAM-Haskell: Par* rewrite does not touch non-choice instructions',
+    retractall(clause_body_analysis:order_independent(user:p41_mix/1)),
+    assertz(clause_body_analysis:order_independent(user:p41_mix/1)),
+    Input = ['GetConstant (Atom "a") 1',
+             'TryMeElse "L1"',
+             'Proceed',
+             'RetryMeElse "L2"',
+             'Call "foo/2" 2',
+             'TrustMe',
+             'Proceed'],
+    Expected = ['GetConstant (Atom "a") 1',
+                'ParTryMeElse "L1"',
+                'Proceed',
+                'ParRetryMeElse "L2"',
+                'Call "foo/2" 2',
+                'ParTrustMe',
+                'Proceed'],
+    (   wam_haskell_target:maybe_parallelize_instrs(user:p41_mix/1, [], Input, Out),
+        Out == Expected
+    ->  pass(Test)
+    ;   fail_test(Test, 'Non-choice instructions incorrectly touched by Par* rewrite')
+    ),
+    retract(clause_body_analysis:order_independent(user:p41_mix/1)).
+
 run_tests :-
     format('~n========================================~n'),
     format('WAM-Haskell target: Phase 5+6+7+8 codegen tests~n'),
@@ -286,6 +431,15 @@ run_tests :-
     test_call_foreign_step_case,
     test_call_foreign_resolve,
     test_call_foreign_helper,
+    %% Phase 4.1: Par* instructions + certificate-driven emission
+    test_haskell_par_instructions_in_types,
+    test_haskell_par_step_handlers_present,
+    test_haskell_par_resolve_present,
+    test_par_emission_for_user_annotated_predicate,
+    test_no_par_emission_for_unannotated_impure_predicate,
+    test_no_par_emission_for_impure_body,
+    test_intra_query_parallel_false_kill_switch,
+    test_par_rewrite_preserves_non_choice_instrs,
     format('~n========================================~n'),
     (   test_failed
     ->  format('Tests FAILED~n'), halt(1)


### PR DESCRIPTION
  ## Summary

  Combined deliverable across two implementation plans: intra-query parallelism **Phase 4.1** (from #1395) and purity
  certificate **P4** (from #1398). Adds the `Par*` instruction family to the Haskell WAM runtime and drives emission
  through the shared purity certificate module. Runtime semantics are unchanged — `Par*` routes to the sequential
  handlers — so this phase carries *intent*, not behavior. Phase 4.2 will add the actual `parMap`-based fork.

  We combined the two phases onto one branch because P4's only job is to replace what would otherwise be a direct
  annotation check in Phase 4.1. Shipping 4.1 with a simpler annotation check and then ripping it out in P4 would have
  been churn for no gain.

  ## What this PR delivers

  ### New instruction family (`WamTypes.Instruction`)

  ```haskell
  | ParTryMeElse String      | ParTryMeElsePc !Int
  | ParRetryMeElse String    | ParRetryMeElsePc !Int
  | ParTrustMe
  ```

  Added to the `Instruction` GADT alongside their sequential counterparts. `Show`/`Eq` derived automatically.

  ### Runtime (`WamRuntime`)

  `step` handlers delegate each `Par*` to its sequential equivalent:

  ```haskell
  step !ctx s (ParTryMeElse label)    = step ctx s (TryMeElse label)
  step !ctx s (ParRetryMeElse label)  = step ctx s (RetryMeElse label)
  step !ctx s ParTrustMe              = step ctx s TrustMe
  step !ctx s (ParTryMeElsePc pc)     = step ctx s (TryMeElsePc pc)
  step !ctx s (ParRetryMeElsePc pc)   = step ctx s (RetryMeElsePc pc)
  ```

  `resolveCallInstrs` gains two new clauses that pre-resolve `Par*` labels the same way as the `Try*`/`Retry*` variants,
   producing `ParTryMeElsePc` / `ParRetryMeElsePc`.

  ### Emission pipeline (`src/unifyweaver/targets/wam_haskell_target.pl`)

  - `compile_predicates_merged/5` now threads `Options` so downstream helpers can see `intra_query_parallel(false)`.
  - **`maybe_parallelize_instrs/4`** consults `purity_certificate:analyze_predicate_purity/2`. Rewrites
  `TryMeElse/RetryMeElse/TrustMe` → `Par*` in a predicate's instruction strings when:
    - The certificate verdict is `pure`, AND
    - Confidence is ≥ 0.85, AND
    - `intra_query_parallel(false)` is not in `Options`.
  - Threshold 0.85 catches:
    - Declared (`:- parallel(P/N)` / `:- order_independent(P/N)`) — confidence 1.0
    - Kernel-registry certified — confidence 1.0
    - Blacklist-clean (no impure builtins detected) — confidence 0.9
    - Inferred / low-confidence verdicts fall through to sequential.
  - User-facing log line when a rewrite fires: `[Par] pred/N: emitting Par* for forkable choice points`.
  - `parallelize_choice_instr/2` preserves input type (atom in → atom out, string in → string out) so callers and tests
  can mix representations without surprises.

  ### Kill switch

  `intra_query_parallel(false)` from `WAM_HASKELL_INTRA_QUERY_SPEC.md` §3.3 lands here. When present in `Options`, every
   predicate compiles to sequential `Try*`/`Retry*`/`TrustMe` regardless of certificate verdicts. Use cases:

  - **Debugging** — confirm a test failure is or isn't caused by the parallel path without touching sources.
  - **Regression benchmarking** — compare `Par*` vs sequential on the same generated project.
  - **Host portability** — target a GHC build or runtime where the Par* path is intolerable later once fork is live.

  ### Tests

  **8 new cases in `tests/test_wam_haskell_target.pl`:**

  | # | Name |
  |---|------|
  |1|`test_haskell_par_instructions_in_types` — `Par*` constructors present in `WamTypes`|
  |2|`test_haskell_par_step_handlers_present` — `step` delegates `Par*` to sequential|
  |3|`test_haskell_par_resolve_present` — `resolveCallInstrs` produces `Par*Pc`|
  |4|`test_par_emission_for_user_annotated_predicate` — `:- order_independent` drives `Par*`|
  |5|`test_no_par_emission_for_unannotated_impure_predicate` — blacklist on `write/1` body suppresses `Par*`|
  |6|`test_no_par_emission_for_impure_body` — documents that user declarations win over an impure body (user is trusted;
   `check_purity_contradictions` surfaces the mismatch separately)|
  |7|`test_intra_query_parallel_false_kill_switch` — option suppresses `Par*` everywhere|
  |8|`test_par_rewrite_preserves_non_choice_instrs` — only `TryMeElse`/`RetryMeElse`/`TrustMe` get rewritten; `Call`,
  `Proceed`, `GetConstant` untouched|

  All 24 pre-existing tests in the file still pass.

  ### Runtime equivalence

  `examples/benchmark/generate_intra_query_benchmark.pl` generates with the `[Par] category_ancestor/4: emitting Par*
  for forkable choice points` log line, the project builds cleanly, and running at 300 and 10k scales with both `+RTS
  -N1` and `+RTS -N4` produces bit-identical totals:

  |scale|seeds|N|`total_solutions`|`total_weight_sum`|
  |---|---|---|---|---|
  |300|4|1|2868|2.003792596822845|
  |300|4|4|2868|2.003792596822845|
  |10k|4|1|6280|3.3287494809843476|
  |10k|4|4|6280|3.3287494809843476|

  `Par*` routes to the sequential handlers as expected. No observable behavior change.

  ### Docs

  Both implementation plans updated with a delivered-2026-04-15 status note:

  - `docs/design/WAM_HASKELL_INTRA_QUERY_IMPLEMENTATION_PLAN.md` §4.1.
  - `docs/design/PURITY_CERTIFICATE_IMPLEMENTATION_PLAN.md` §P4.

  ## What did not change

  - `wam_target.pl` — still emits `try_me_else`/`retry_me_else`/`trust_me` unchanged. The Haskell-specific rewrite
  happens only in `wam_haskell_target.pl`, so other targets (Go, Rust, LLVM, …) see the WAM text exactly as before.
  - Kernel templates and FFI kernel pipeline — untouched.
  - `purity_certificate.pl` — untouched since P3 (#1404).
  - `recursive_kernel_detection.pl` — untouched since its original work.

  ## Regression risk

  Low. Three mitigations:

  1. **Par* is pure intent.** Runtime handlers explicitly delegate to the sequential equivalents via `step ctx s
  (TryMeElse label)` etc. The only way this causes a regression is if the delegation is wrong — covered by the
  runtime-equivalence check above (bit-identical outputs at two scales × two core counts).

  2. **Emission decision is gated conservatively.** Confidence ≥ 0.85 threshold, plus the kill switch. Predicates with
  `unknown` verdicts don't get rewritten. Predicates with `impure` verdicts from the blacklist don't get rewritten
  unless they also have a user declaration (documented behavior; contradiction-warning exists).

  3. **No silent semantic changes outside the Haskell target.** `wam_target.pl` unchanged, so Go/Rust/LLVM/AWK/Bash
  emitters see no difference.

  ## Verified

  - **32/32** tests in `tests/test_wam_haskell_target.pl` pass (24 pre-existing + 8 new).
  - **61/61** tests in `tests/core/test_purity_certificate.pl` still pass.
  - **9/9** tests in `tests/test_go_goal_parallel.pl` still pass.
  - `generate_intra_query_benchmark.pl` generates, builds, and runs with Par* instructions; outputs identical at `-N1`
  and `-N4`.

  ## Deferred to later phases

  Per the implementation plans:

  - **Intra-query Phase 4.2** — real runtime fork via `parMap rdeepseq` at aggregate boundaries (sum/count merges
  first).
  - **Intra-query Phase 4.3** — findall/bag/set merge strategies.
  - **Intra-query Phase 4.4** — negation-as-race-to-cancel via `Control.Concurrent.Async`.
  - **Intra-query Phase 4.5** — work-estimation threshold to skip tiny branches.
  - **Intra-query Phase 4.6** — C# purity certificate consumption (optional, certificate module already has the shape
  ready).
  - **Purity certificate P5** — JSON serialization for cross-process boundary crossing.

  ## Test plan

  - [ ] `swipl -q tests/test_wam_haskell_target.pl` — all tests pass.
  - [ ] `swipl -q -g "consult('tests/core/test_purity_certificate.pl'), run_tests(purity_certificate), halt(0)"` — 61/61
   pass.
  - [ ] `swipl -q -g "consult('tests/test_go_goal_parallel.pl'), run_tests(go_goal_parallel), halt(0)"` — 9/9 pass.
  - [ ] `cd examples/benchmark && swipl -q -s generate_intra_query_benchmark.pl -- /tmp/check` — generates with `[Par]
  category_ancestor/4: emitting Par*` line.
  - [ ] `cd /tmp/check && cabal build` — builds cleanly; `grep Par /tmp/check/src/Predicates.hs` shows `Par*`
  constructors.
  - [ ] `/tmp/check/dist/build/wam-intra-query-bench/wam-intra-query-bench $FACTS_DIR 4 +RTS -N1` and `+RTS -N4` produce
   identical `total_solutions` and `total_weight_sum`.

  ## Related

  - Design docs: #1395 (intra-query), #1398 (purity certificate).
  - Intra-query Phase 4.0 benchmark: #1397.
  - Purity certificate P1–P3: #1402, #1403, #1404.
  - First downstream consumer of P4: this PR.
  - Next planned: intra-query Phase 4.2 (actual runtime fork).

  🤖 Generated with [Claude Code](https://claude.com/claude-code)