### PR TITLE
fix(wat): aggregate_all end-to-end (nop indexing + CP save/restore)

### DIFF
--- a/src/unifyweaver/targets/wam_wat_target.pl
+++ b/src/unifyweaver/targets/wam_wat_target.pl
@@ -98,6 +98,7 @@ instr_tag(cut_ite,         26).
 instr_tag(jump,            27).
 instr_tag(begin_aggregate, 28).
 instr_tag(end_aggregate,   29).
+instr_tag(nop,             30).
 
 % Builtin operation IDs
 builtin_id('write/1',  0).
@@ -338,6 +339,10 @@ wam_instruction_to_wat_bytes(end_aggregate(ValReg), _Labels, Hex) :-
     reg_name_to_index(ValReg, ValIdx),
     encode_instr_hex(Tag, ValIdx, 0, Hex).
 
+wam_instruction_to_wat_bytes(nop, _Labels, Hex) :-
+    instr_tag(nop, Tag),
+    encode_instr_hex(Tag, 0, 0, Hex).
+
 agg_type_id(sum, 0).
 agg_type_id(count, 1).
 agg_type_id(max, 2).
@@ -574,10 +579,10 @@ wam_parts_to_instr(["jump", L], jump(CL)) :-
 %% is correct because the clause bodies still have try_me_else/trust_me
 %% for linear dispatch. A future optimization would implement them as
 %% O(log n) dispatch, but for now a no-op is sufficient for correctness.
-wam_parts_to_instr(["switch_on_constant"|_], proceed) :- !.
-wam_parts_to_instr(["switch_on_structure"|_], proceed) :- !.
-wam_parts_to_instr(["switch_on_term"|_], proceed) :- !.
-wam_parts_to_instr(["switch_on_constant_a2"|_], proceed) :- !.
+wam_parts_to_instr(["switch_on_constant"|_], nop) :- !.
+wam_parts_to_instr(["switch_on_structure"|_], nop) :- !.
+wam_parts_to_instr(["switch_on_term"|_], nop) :- !.
+wam_parts_to_instr(["switch_on_constant_a2"|_], nop) :- !.
 
 wam_parts_to_instr(["begin_aggregate", Type, ValReg, ResReg],
                    begin_aggregate(CType, CValReg, CResReg)) :-
@@ -1112,6 +1117,11 @@ wam_wat_case(begin_aggregate,
   (global.set $agg_sum (i64.const 0))
   (global.set $agg_count (i32.const 0))
   (global.set $agg_return_pc (i32.const 0))
+  ;; Save caller CP so finalization can restore it. The inner call
+  ;; (e.g. my_fact) will overwrite CP; without saving, the proceed
+  ;; at the end of the aggregate predicate would jump back into the
+  ;; end_aggregate instruction rather than returning to the caller.
+  (global.set $agg_saved_cp (call $get_cp))
   (call $inc_pc)
   (i32.const 1)').
 
@@ -1143,6 +1153,12 @@ wam_wat_case(end_aggregate,
   (global.set $agg_return_pc (i32.add (call $get_pc) (i32.const 1)))
   ;; Force-backtrack to try next solution (return 0 = step failed)
   (i32.const 0)').
+
+wam_wat_case(nop,
+'  ;; No-op: placeholder for unimplemented indexing instructions.
+  ;; Just advance PC and continue.
+  (call $inc_pc)
+  (i32.const 1)').
 
 wam_wat_case(trust_me,
 '  ;; Remove choice point (last alternative)
@@ -1212,6 +1228,11 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
             (else
               (call $bind_reg_deref (global.get $agg_res_reg)
                 (i32.const 1) (global.get $agg_sum))))
+          ;; Restore the CP that was current when begin_aggregate ran.
+          ;; The inner call (e.g. my_fact) overwrote CP; the proceed
+          ;; at the end of the aggregate predicate needs the original
+          ;; caller CP so it returns properly.
+          (call $set_cp (global.get $agg_saved_cp))
           ;; Jump to the return PC (instruction after end_aggregate)
           (call $set_pc (global.get $agg_return_pc))
           (return (i32.const 1))))

--- a/templates/targets/wat_wam/module.wat.mustache
+++ b/templates/targets/wat_wam/module.wat.mustache
@@ -25,6 +25,7 @@
   (global $agg_val_reg (mut i32) (i32.const 0))
   (global $agg_res_reg (mut i32) (i32.const 0))
   (global $agg_return_pc (mut i32) (i32.const 0))
+  (global $agg_saved_cp (mut i32) (i32.const -1))
   (global $agg_sum (mut i64) (i64.const 0))
   (global $agg_count (mut i32) (i32.const 0))
 


### PR DESCRIPTION
## Summary

Resolves the known limitation documented in PR #1409: the aggregate
skeleton was in place but end-to-end `aggregate_all(sum(X),
my_fact(X), Sum)` returned `RESULT 0` instead of binding `Sum`
correctly. After this fix, a canonical three-fact test
(`my_fact(10). my_fact(20). my_fact(30).`) runs to
`RESULT 1` with `Sum = 60`. All 57 WAM-WAT tests continue to pass.

Two distinct bugs were at fault — one introduced in PR #1409, one
latent in the aggregate-CP lifecycle.

## Bug 1: `switch_on_*` mapped to `proceed` (semantically wrong)

In PR #1409 the first-argument indexing instructions
(`switch_on_constant`, `switch_on_structure`, `switch_on_term`,
`switch_on_constant_a2`) were routed to `proceed` as "no-ops".
But `proceed` is **not** a no-op in WAM — it restores PC from CP,
effectively returning from the current predicate.

Impact: when control entered `my_fact/1` (which begins with
`switch_on_constant`), it immediately returned without running any
clause, so the aggregate saw zero values and finalized Sum = 0.

### Fix

Introduce a real `nop` instruction (tag 30) whose handler is just
`inc_pc + return 1`. Reroute all four `switch_on_*` parsers to
`nop` instead of `proceed`.

| Tag | Instruction | Semantics |
|---|---|---|
| 30 | `nop` | Advance PC by 1 and continue. Placeholder for unimplemented indexing. |

## Bug 2: Caller's CP clobbered across internal `call` during aggregation

`sum_facts/1` is a single-clause predicate with no
`allocate`/`deallocate` — the compiled body is just:

```
begin_aggregate(sum, X4, X5)
put_variable X4, A1
call user:my_fact/1
end_aggregate(X4)
get_value X5, A1
proceed
```

When `call my_fact/1` ran, it overwrote CP with the return address
inside `sum_facts` (the PC of `end_aggregate`). After aggregate
finalization reached the trailing `proceed`, CP pointed back into
`end_aggregate` rather than the original caller (CP = -1),
causing misrouted control flow.

### Fix

In the `begin_aggregate` handler, capture the current CP into a new
`$agg_saved_cp` global. In `$backtrack`'s finalize branch
(`cp_count = 0` and `agg_active = 1`), restore CP from
`$agg_saved_cp` **before** jumping to `$agg_return_pc`. This
guarantees the `proceed` after `end_aggregate` returns to the real
caller.

```wat
;; templates/targets/wat_wam/module.wat.mustache
(global $agg_saved_cp (mut i32) (i32.const -1))
```

```wat
;; begin_aggregate handler — save CP
(global.set $agg_saved_cp (call $get_cp))
```

```wat
;; $backtrack finalize path — restore CP before jumping
(call $set_cp (global.get $agg_saved_cp))
(call $set_pc (global.get $agg_return_pc))
```

## Verification

End-to-end test (`/tmp/gen_agg_test.pl`):

```prolog
:- dynamic my_fact/1.
my_fact(10).
my_fact(20).
my_fact(30).
sum_facts(Sum) :- aggregate_all(sum(X), my_fact(X), Sum).
```

Generated WAT → `wat2wasm` → Node.js execution:

```
Exports: [ 'memory', 'sum_facts_1', 'my_fact_1' ]
sum_facts_1 => RESULT 1
```

Execution trace (debug-instrumented run) confirms:
- `begin_aggregate` fires once (CP saved = caller's CP)
- All three clauses run in sequence (10, 20, 30) with
  `end_aggregate` accumulating each value
- `$backtrack` sees `cp_count = 0` + `agg_active = 1` and finalizes
  with `$agg_sum = 60`
- `proceed` returns cleanly via the restored caller CP

## Changes

| File | Lines | What |
|---|---|---|
| `src/unifyweaver/targets/wam_wat_target.pl` | +22 / −4 | `nop` instruction tag (30) + encoding + parser + WAT handler; reroute `switch_on_*` parsers to `nop`; save/restore `$agg_saved_cp` in `begin_aggregate` + `$backtrack` finalize path |
| `templates/targets/wat_wam/module.wat.mustache` | +1 | `(global $agg_saved_cp (mut i32) (i32.const -1))` |

## Test plan

- [x] All 57 WAM-WAT tests pass
- [x] `aggregate_all(sum(X), my_fact(X), Sum)` with three facts returns `RESULT 1`, Sum = 60
- [x] `switch_on_constant` in multi-clause fact predicates no longer short-circuits
- [x] `wat2wasm` validates the generated module
- [x] No regression in `bench_suite` workloads (13 benchmarks still OK)
