### PR TITLE
fix(wam-llvm): compound terms use arena allocator instead of malloc (M5.25)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1820,35 +1820,32 @@ wam_llvm_case('put_value',
 
 wam_llvm_case('put_structure',
 '  ; put_structure: op1 = ptrtoint of functor string, op2 = (arity << 16) | reg_idx
-  ; Allocate a %Compound struct, set functor/arity, allocate args array.
-  ; Bind register to Compound value (tag=3, payload=ptr to %Compound).
+  ; Allocate %Compound struct + args array from the arena (not malloc).
+  ; Compounds are transient and reclaimed on @wam_cleanup().
   %ps.fn_ptr = inttoptr i64 %op1 to i8*
   %ps.op2_32 = trunc i64 %op2 to i32
   %ps.arity = lshr i32 %ps.op2_32, 16
   %ps.ai = and i32 %ps.op2_32, 65535
-  ; Allocate %Compound struct.
+  call void @wam_arena_ensure()
+  ; Allocate %Compound struct from arena.
   %ps.cp_size = ptrtoint %Compound* getelementptr (%Compound, %Compound* null, i32 1) to i64
-  %ps.cp_mem = call i8* @malloc(i64 %ps.cp_size)
+  %ps.cp_mem = call i8* @wam_arena_alloc(i64 %ps.cp_size)
   %ps.cp = bitcast i8* %ps.cp_mem to %Compound*
-  ; Set functor.
   %ps.fn_slot = getelementptr %Compound, %Compound* %ps.cp, i32 0, i32 0
   store i8* %ps.fn_ptr, i8** %ps.fn_slot
-  ; Set arity.
   %ps.ar_slot = getelementptr %Compound, %Compound* %ps.cp, i32 0, i32 1
   store i32 %ps.arity, i32* %ps.ar_slot
-  ; Allocate args array: arity x %Value.
+  ; Allocate args array from arena.
   %ps.arity64 = zext i32 %ps.arity to i64
   %ps.args_bytes = shl i64 %ps.arity64, 4
-  %ps.args_mem = call i8* @malloc(i64 %ps.args_bytes)
+  %ps.args_mem = call i8* @wam_arena_alloc(i64 %ps.args_bytes)
   %ps.args = bitcast i8* %ps.args_mem to %Value*
   %ps.args_slot = getelementptr %Compound, %Compound* %ps.cp, i32 0, i32 2
   store %Value* %ps.args, %Value** %ps.args_slot
-  ; Create Compound value (tag=3) and bind register.
   %ps.cp_i64 = ptrtoint %Compound* %ps.cp to i64
   %ps.val0 = insertvalue %Value undef, i32 3, 0
   %ps.val = insertvalue %Value %ps.val0, i64 %ps.cp_i64, 1
   call void @wam_set_reg(%WamState* %vm, i32 %ps.ai, %Value %ps.val)
-  ; Push WriteCtx with args pointer so set_value/set_constant fill the args.
   call void @wam_push_write_ctx(%WamState* %vm, i32 %ps.arity)
   call void @wam_write_ctx_set_args(%WamState* %vm, %Value* %ps.args)
   call void @wam_inc_pc(%WamState* %vm)


### PR DESCRIPTION
## Summary

Plugs a memory leak in `put_structure`. Compound terms (created for `is/2` expressions like `X + 1`) are now allocated from the bump arena rather than via `@malloc`, making them WASM-portable and eliminating per-compound leak pressure.

## Problem

Since M5.23 introduced proper `%Compound` struct creation in `put_structure`, each compound term leaked two allocations:

1. The `%Compound` struct itself (~16 bytes: `i8* functor, i32 arity, %Value* args`)
2. The args array (`arity × %Value` = 16-32 bytes per arg)

For a recursive arithmetic predicate like `factorial(N)` with `factorial(N) :- N1 is N - 1, ...`, each recursive call allocated a fresh `-(N, 1)` compound that was never freed. Over many iterations, this would exhaust process memory. In WASM, the impact is worse: there's no OS-level reclaim on process exit.

## Fix

`put_structure` now calls `@wam_arena_alloc` (the M5.14 bump arena) instead of `@malloc`:

```llvm
call void @wam_arena_ensure()
%ps.cp_mem = call i8* @wam_arena_alloc(i64 %ps.cp_size)  ; was @malloc
...
%ps.args_mem = call i8* @wam_arena_alloc(i64 %ps.args_bytes)  ; was @malloc
```

Compounds are transient — they're read once by `is/2`'s `eval_arith` and then discarded. The arena is freed in bulk by `@wam_cleanup()` at VM teardown (which is already wired into WASM export wrappers in M5.17).

## Why this is the right fit

The arena allocator is designed exactly for this pattern: many small, short-lived allocations freed together. Compounds match perfectly:

- **Transient:** alive only from `put_structure` through the next `is/2` that reads them. After `is/2` binds its result register, the compound is dead.
- **Small:** a 2-ary compound is 16 + 32 = 48 bytes. Thousands fit in the 1 MiB arena.
- **Bulk-freeable:** nothing else references them after evaluation, so rewinding the arena at cleanup is safe.

## Net benefits

| Aspect | Before (malloc) | After (arena) |
|---|---|---|
| Alloc cost | `malloc` syscall / heap walk | pointer bump (single `add`) |
| Free cost | per-compound `free` (never happened → leak) | single rewind at cleanup |
| WASM compat | requires libc malloc | self-contained in linear memory |
| Recursion pressure | leaks proportional to depth | bounded by arena capacity |

## Test Coverage

No new tests — this is a drop-in replacement that preserves all behavior. The 10 existing compound arithmetic + multi-clause + head unification tests in `test_wam_llvm_builtin_execution.pl` continue to pass, plus all 33 prior test suites (165 assertions total).

## Files Changed

- `src/unifyweaver/targets/wam_llvm_target.pl` — `put_structure` step function now calls `@wam_arena_alloc` + `@wam_arena_ensure` instead of `@malloc`.

## Commits

- `d41cecdc` — fix(wam-llvm): compound terms use arena allocator instead of malloc (M5.25)

## Test Plan

- [x] Compound arithmetic (10+1, 0+1, 7*3): still correct.
- [x] Multi-clause backtracking (choice 1/2/3): still correct.
- [x] Head unification + `=/2`: still correct.
- [x] Foreign kernels (BFS, Dijkstra, A*, countdown_sum, stream kernels): all regression green.
- [x] WASM pipeline (native + wasmtime runtime): unchanged, all green.
- [x] `llvm-as` accepts generated IR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
