### PR TITLE
feat(wam-go): improve hybrid WAM parity

### DIFF
--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -102,33 +102,84 @@ read_template_file(Path, Content) :-
 
 %% compile_predicates_for_project(+Predicates, +Options, -Code)
 compile_predicates_for_project([], _, "").
-compile_predicates_for_project([PredIndicator|Rest], Options, Code) :-
+compile_predicates_for_project(Predicates, Options, Code) :-
+    classify_predicates(Predicates, Options, Classified),
+    collect_wam_entries(Classified, 0, WamEntries, AllInstrParts, AllLabelEntries),
+    (   WamEntries \== []
+    ->  atomic_list_concat(AllInstrParts, '\n', AllInstrs),
+        atomic_list_concat(AllLabelEntries, '\n', AllLabels),
+        format(atom(SharedCode),
+'var sharedWamCodeRaw = []Instruction{
+~w
+}
+
+var sharedWamLabels = map[string]int{
+~w
+}
+
+var sharedWamCode = resolveInstructions(sharedWamCodeRaw, sharedWamLabels)
+', [AllInstrs, AllLabels])
+    ;   SharedCode = ""
+    ),
+    generate_predicate_codes(Classified, WamEntries, PredCodes),
+    atomic_list_concat(PredCodes, '\n\n', PredicatesCode),
+    (   SharedCode == ""
+    ->  Code = PredicatesCode
+    ;   format(atom(Code), '~w~n~w', [SharedCode, PredicatesCode])
+    ).
+
+classify_predicates([], _, []).
+classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
     (   PredIndicator = Module:Pred/Arity -> true
     ;   PredIndicator = Pred/Arity, Module = user
     ),
-    (   % Try native Go lowering first
-        catch(
+    (   catch(
             go_target:compile_predicate_to_go(Module:Pred/Arity,
                 [include_package(false)|Options], PredCode),
             _, fail)
     ->  format(user_error, '  ~w/~w: native lowering~n', [Pred, Arity]),
-        Strategy = native
-    ;   % Fall back to WAM compilation
-        option(wam_fallback(WamFB), Options, true),
+        Entry = classified(Module, Pred, Arity, native, PredCode)
+    ;   option(wam_fallback(WamFB), Options, true),
         WamFB \== false,
-        wam_target:compile_predicate_to_wam(Module:Pred/Arity, Options, WamCode),
-        compile_wam_predicate_to_go(Pred/Arity, WamCode, Options, PredCode)
+        wam_target:compile_predicate_to_wam(Module:Pred/Arity, Options, WamCode)
     ->  format(user_error, '  ~w/~w: WAM fallback~n', [Pred, Arity]),
-        Strategy = wam
-    ;   % Neither worked
-        format(atom(PredCode), '// ~w/~w: compilation failed', [Pred, Arity]),
-        Strategy = failed
+        Entry = classified(Module, Pred, Arity, wam, WamCode)
+    ;   format(atom(PredCode), '// ~w/~w: compilation failed', [Pred, Arity]),
+        Entry = classified(Module, Pred, Arity, failed, PredCode)
     ),
-    compile_predicates_for_project(Rest, Options, RestCode),
-    (   RestCode == ""
-    ->  format(atom(Code), "// Strategy: ~w\n~w", [Strategy, PredCode])
-    ;   format(atom(Code), "// Strategy: ~w\n~w\n\n~w", [Strategy, PredCode, RestCode])
-    ).
+    classify_predicates(Rest, Options, RestEntries).
+
+collect_wam_entries([], _, [], [], []).
+collect_wam_entries([classified(_, Pred, Arity, wam, WamCode)|Rest], PC,
+                    [wam_entry(Pred, Arity, PC)|RestEntries],
+                    AllInstrs, AllLabels) :-
+    atom_string(WamCode, WamStr),
+    split_string(WamStr, "\n", "", Lines),
+    wam_lines_to_go(Lines, PC, GoLiterals, LabelEntries),
+    maplist([Lit, Entry]>>(format(atom(Entry), '        ~w,', [Lit])), GoLiterals, InstrEntries),
+    maplist([Label-Idx, Entry]>>(format(atom(Entry), '        "~w": ~w,', [Label, Idx])), LabelEntries, LabelRows),
+    length(GoLiterals, InstrCount),
+    NextPC is PC + InstrCount,
+    collect_wam_entries(Rest, NextPC, RestEntries, RestInstrs, RestLabels),
+    append(InstrEntries, RestInstrs, AllInstrs),
+    append(LabelRows, RestLabels, AllLabels).
+collect_wam_entries([_|Rest], PC, Entries, Instrs, Labels) :-
+    collect_wam_entries(Rest, PC, Entries, Instrs, Labels).
+
+generate_predicate_codes([], _, []).
+generate_predicate_codes([classified(_, _Pred, _Arity, native, PredCode)|Rest], WamEntries,
+                         [Code|RestCodes]) :-
+    format(atom(Code), '// Strategy: native~n~w', [PredCode]),
+    generate_predicate_codes(Rest, WamEntries, RestCodes).
+generate_predicate_codes([classified(_, Pred, Arity, wam, _WamCode)|Rest], WamEntries,
+                         [Code|RestCodes]) :-
+    member(wam_entry(Pred, Arity, StartPC), WamEntries),
+    compile_wam_predicate_to_go_shared(Pred/Arity, StartPC, Code),
+    generate_predicate_codes(Rest, WamEntries, RestCodes).
+generate_predicate_codes([classified(_, _Pred, _Arity, failed, PredCode)|Rest], WamEntries,
+                         [Code|RestCodes]) :-
+    format(atom(Code), '// Strategy: failed~n~w', [PredCode]),
+    generate_predicate_codes(Rest, WamEntries, RestCodes).
 
 %% compile_wam_runtime_to_go(+Options, -GoCode)
 %  Placeholder for potentially transpiling larger parts of wam_runtime.pl
@@ -244,6 +295,8 @@ go_struct_case(Functor-Label, Case) :-
 compile_wam_predicate_to_go(Pred/Arity, WamCode, _Options, GoCode) :-
     atom_string(Pred, PredStr),
     capitalize_atom(Pred, CapPred),
+    build_go_wam_arg_list(Arity, ArgList),
+    build_go_wam_arg_setup(Arity, ArgSetup),
     %% Parse WAM code lines into instruction terms
     atom_string(WamCode, WamStr),
     split_string(WamStr, "\n", "", Lines),
@@ -263,7 +316,50 @@ var ~wCode = []Instruction{
 var ~wLabels = map[string]int{
 ~w
 }
-', [PredStr, Arity, CapPred, EntriesStr, CapPred, LabelsStr]).
+
+var ~wResolvedCode = resolveInstructions(~wCode, ~wLabels)
+
+func ~w(~w) bool {
+    vm := NewWamState(~wResolvedCode, ~wLabels)
+~w
+    return vm.Run()
+}
+', [PredStr, Arity, CapPred, EntriesStr, CapPred, LabelsStr,
+    CapPred, CapPred, CapPred, CapPred, ArgList, CapPred, CapPred, ArgSetup]).
+
+compile_wam_predicate_to_go_shared(Pred/Arity, StartPC, GoCode) :-
+    atom_string(Pred, PredStr),
+    capitalize_atom(Pred, CapPred),
+    build_go_wam_arg_list(Arity, ArgList),
+    build_go_wam_arg_setup(Arity, ArgSetup),
+    format(atom(GoCode),
+'// Strategy: wam
+// WAM-compiled predicate: ~w/~w (shared table, pc=~w)
+var ~wCode = sharedWamCode
+var ~wLabels = sharedWamLabels
+const ~wStartPC = ~w
+
+func ~w(~w) bool {
+    vm := NewWamState(sharedWamCode, sharedWamLabels)
+    vm.PC = ~w
+~w
+    return vm.Run()
+}
+', [PredStr, Arity, StartPC,
+    CapPred, CapPred, CapPred, StartPC,
+    CapPred, ArgList, StartPC, ArgSetup]).
+
+build_go_wam_arg_list(0, "") :- !.
+build_go_wam_arg_list(Arity, ArgList) :-
+    numlist(1, Arity, Indices),
+    maplist([I, S]>>format(atom(S), 'a~w Value', [I]), Indices, Parts),
+    atomic_list_concat(Parts, ', ', ArgList).
+
+build_go_wam_arg_setup(0, "") :- !.
+build_go_wam_arg_setup(Arity, Setup) :-
+    numlist(1, Arity, Indices),
+    maplist([I, S]>>format(atom(S), '    vm.Regs["A~w"] = a~w', [I, I]), Indices, Lines),
+    atomic_list_concat(Lines, '\n', Setup).
 
 capitalize_atom(Atom, Cap) :-
     atom_codes(Atom, [First|Rest]),
@@ -751,11 +847,18 @@ wam_go_case('Call', '        vm.CP = vm.PC + 1
         }
         return false').
 
+wam_go_case('CallPc', '        vm.CP = vm.PC + 1
+        vm.PC = i.TargetPC
+        return true').
+
 wam_go_case('Execute', '        if pc, ok := vm.Labels[i.Pred]; ok {
             vm.PC = pc
             return true
         }
         return false').
+
+wam_go_case('ExecutePc', '        vm.PC = i.TargetPC
+        return true').
 
 wam_go_case('Proceed', '        if vm.CP > 0 {
             vm.PC = vm.CP
@@ -780,10 +883,20 @@ wam_go_case('TryMeElse', '        nextPC := 0
         vm.PC++
         return true').
 
+wam_go_case('TryMeElsePc', '        vm.pushChoicePoint(i.NextPC)
+        vm.PC++
+        return true').
+
 wam_go_case('RetryMeElse', '        if pc, ok := vm.Labels[i.Label]; ok {
             if len(vm.ChoicePoints) > 0 {
                 vm.ChoicePoints[len(vm.ChoicePoints)-1].NextPC = pc
             }
+        }
+        vm.PC++
+        return true').
+
+wam_go_case('RetryMeElsePc', '        if len(vm.ChoicePoints) > 0 {
+            vm.ChoicePoints[len(vm.ChoicePoints)-1].NextPC = i.NextPC
         }
         vm.PC++
         return true').
@@ -809,6 +922,17 @@ wam_go_case('SwitchOnConstant', '        if val, ok := vm.Regs["A1"]; ok && !isU
         vm.PC++
         return true').
 
+wam_go_case('SwitchOnConstantPc', '        if val, ok := vm.Regs["A1"]; ok && !isUnbound(val) {
+            for _, c := range i.Cases {
+                if valueEquals(c.Val, val) {
+                    vm.PC = c.TargetPC
+                    return true
+                }
+            }
+        }
+        vm.PC++
+        return true').
+
 wam_go_case('SwitchOnStructure', '        if val, ok := vm.Regs["A1"]; ok {
             if f, args := decompose(val); f != "" {
                 key := fmt.Sprintf("%s/%d", f, len(args))
@@ -825,6 +949,20 @@ wam_go_case('SwitchOnStructure', '        if val, ok := vm.Regs["A1"]; ok {
         vm.PC++
         return true').
 
+wam_go_case('SwitchOnStructurePc', '        if val, ok := vm.Regs["A1"]; ok {
+            if f, args := decompose(val); f != "" {
+                key := fmt.Sprintf("%s/%d", f, len(args))
+                for _, c := range i.Cases {
+                    if c.Functor == key {
+                        vm.PC = c.TargetPC
+                        return true
+                    }
+                }
+            }
+        }
+        vm.PC++
+        return true').
+
 wam_go_case('SwitchOnConstantA2', '        if val, ok := vm.Regs["A2"]; ok && !isUnbound(val) {
             for _, c := range i.Cases {
                 if valueEquals(c.Val, val) {
@@ -832,6 +970,17 @@ wam_go_case('SwitchOnConstantA2', '        if val, ok := vm.Regs["A2"]; ok && !i
                         vm.PC = pc
                         return true
                     }
+                }
+            }
+        }
+        vm.PC++
+        return true').
+
+wam_go_case('SwitchOnConstantA2Pc', '        if val, ok := vm.Regs["A2"]; ok && !isUnbound(val) {
+            for _, c := range i.Cases {
+                if valueEquals(c.Val, val) {
+                    vm.PC = c.TargetPC
+                    return true
                 }
             }
         }
@@ -943,6 +1092,89 @@ func (vm *WamState) fetch() Instruction {
         return vm.Code[vm.PC]
     }
     return nil
+}
+
+func resolveInstructions(code []Instruction, labels map[string]int) []Instruction {
+    resolved := make([]Instruction, 0, len(code))
+    for _, instr := range code {
+        switch i := instr.(type) {
+        case *Call:
+            if pc, ok := labels[i.Pred]; ok {
+                resolved = append(resolved, &CallPc{TargetPC: pc, Arity: i.Arity})
+            } else {
+                resolved = append(resolved, instr)
+            }
+        case *Execute:
+            if pc, ok := labels[i.Pred]; ok {
+                resolved = append(resolved, &ExecutePc{TargetPC: pc})
+            } else {
+                resolved = append(resolved, instr)
+            }
+        case *TryMeElse:
+            if pc, ok := labels[i.Label]; ok {
+                resolved = append(resolved, &TryMeElsePc{NextPC: pc})
+            } else {
+                resolved = append(resolved, instr)
+            }
+        case *RetryMeElse:
+            if pc, ok := labels[i.Label]; ok {
+                resolved = append(resolved, &RetryMeElsePc{NextPC: pc})
+            } else {
+                resolved = append(resolved, instr)
+            }
+        case *SwitchOnConstant:
+            cases := make([]ConstPcCase, 0, len(i.Cases))
+            complete := true
+            for _, c := range i.Cases {
+                pc, ok := labels[c.Label]
+                if !ok {
+                    complete = false
+                    break
+                }
+                cases = append(cases, ConstPcCase{Val: c.Val, TargetPC: pc})
+            }
+            if complete {
+                resolved = append(resolved, &SwitchOnConstantPc{Cases: cases})
+            } else {
+                resolved = append(resolved, instr)
+            }
+        case *SwitchOnStructure:
+            cases := make([]StructPcCase, 0, len(i.Cases))
+            complete := true
+            for _, c := range i.Cases {
+                pc, ok := labels[c.Label]
+                if !ok {
+                    complete = false
+                    break
+                }
+                cases = append(cases, StructPcCase{Functor: c.Functor, TargetPC: pc})
+            }
+            if complete {
+                resolved = append(resolved, &SwitchOnStructurePc{Cases: cases})
+            } else {
+                resolved = append(resolved, instr)
+            }
+        case *SwitchOnConstantA2:
+            cases := make([]ConstPcCase, 0, len(i.Cases))
+            complete := true
+            for _, c := range i.Cases {
+                pc, ok := labels[c.Label]
+                if !ok {
+                    complete = false
+                    break
+                }
+                cases = append(cases, ConstPcCase{Val: c.Val, TargetPC: pc})
+            }
+            if complete {
+                resolved = append(resolved, &SwitchOnConstantA2Pc{Cases: cases})
+            } else {
+                resolved = append(resolved, instr)
+            }
+        default:
+            resolved = append(resolved, instr)
+        }
+    }
+    return resolved
 }
 ', []).
 

--- a/templates/targets/go_wam/instructions.go.mustache
+++ b/templates/targets/go_wam/instructions.go.mustache
@@ -72,8 +72,14 @@ func (i *Deallocate) instrTag() {}
 type Call struct { Pred string; Arity int }
 func (i *Call) instrTag() {}
 
+type CallPc struct { TargetPC int; Arity int }
+func (i *CallPc) instrTag() {}
+
 type Execute struct { Pred string }
 func (i *Execute) instrTag() {}
+
+type ExecutePc struct { TargetPC int }
+func (i *ExecutePc) instrTag() {}
 
 type Proceed struct{}
 func (i *Proceed) instrTag() {}
@@ -84,8 +90,14 @@ func (i *BuiltinCall) instrTag() {}
 type TryMeElse struct { Label string }
 func (i *TryMeElse) instrTag() {}
 
+type TryMeElsePc struct { NextPC int }
+func (i *TryMeElsePc) instrTag() {}
+
 type RetryMeElse struct { Label string }
 func (i *RetryMeElse) instrTag() {}
+
+type RetryMeElsePc struct { NextPC int }
+func (i *RetryMeElsePc) instrTag() {}
 
 type TrustMe struct{}
 func (i *TrustMe) instrTag() {}
@@ -93,8 +105,27 @@ func (i *TrustMe) instrTag() {}
 type SwitchOnConstant struct { Cases []ConstCase }
 func (i *SwitchOnConstant) instrTag() {}
 
+type ConstPcCase struct {
+	Val      Value
+	TargetPC int
+}
+
+type SwitchOnConstantPc struct { Cases []ConstPcCase }
+func (i *SwitchOnConstantPc) instrTag() {}
+
 type SwitchOnStructure struct { Cases []StructCase }
 func (i *SwitchOnStructure) instrTag() {}
 
+type StructPcCase struct {
+	Functor  string
+	TargetPC int
+}
+
+type SwitchOnStructurePc struct { Cases []StructPcCase }
+func (i *SwitchOnStructurePc) instrTag() {}
+
 type SwitchOnConstantA2 struct { Cases []ConstCase }
 func (i *SwitchOnConstantA2) instrTag() {}
+
+type SwitchOnConstantA2Pc struct { Cases []ConstPcCase }
+func (i *SwitchOnConstantA2Pc) instrTag() {}

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -14,6 +14,8 @@ type ChoicePoint struct {
 	NextPC    int
 	CP        int
 	Regs      map[string]Value
+	Stack     []StackEntry
+	HeapTop   int
 	TrailMark int
 }
 
@@ -77,6 +79,8 @@ func (vm *WamState) pushChoicePoint(nextPC int) {
 		NextPC:    nextPC,
 		CP:        vm.CP,
 		Regs:      copyMap(vm.Regs),
+		Stack:     copyStack(vm.Stack),
+		HeapTop:   len(vm.Heap),
 		TrailMark: len(vm.Trail),
 	})
 }
@@ -158,6 +162,15 @@ func copyMap(m map[string]Value) map[string]Value {
 		m2[k] = v
 	}
 	return m2
+}
+
+func copyStack(stack []StackEntry) []StackEntry {
+	if len(stack) == 0 {
+		return nil
+	}
+	stack2 := make([]StackEntry, len(stack))
+	copy(stack2, stack)
+	return stack2
 }
 
 func parseFunctorArity(f string) int {
@@ -412,6 +425,10 @@ func (vm *WamState) backtrack() bool {
     cp := vm.ChoicePoints[len(vm.ChoicePoints)-1]
     vm.unwindTrail(cp.TrailMark)
     vm.Regs = copyMap(cp.Regs)
+    vm.Stack = copyStack(cp.Stack)
+    if cp.HeapTop >= 0 && cp.HeapTop <= len(vm.Heap) {
+        vm.Heap = vm.Heap[:cp.HeapTop]
+    }
     vm.PC = cp.NextPC
     vm.CP = cp.CP
     vm.Halted = false

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -36,6 +36,7 @@ import (
 
 func main() {
 	vm := wam.NewWamState(wam.Test_builtinsCode, wam.Test_builtinsLabels)
+	vm.PC = wam.Test_builtinsStartPC
 	// A1 will hold X — use named unbound so we can deref after execution
 	x := &wam.Unbound{Name: "X"}
 	vm.Regs["A1"] = x

--- a/tests/test_wam_go_generator.pl
+++ b/tests/test_wam_go_generator.pl
@@ -1,8 +1,24 @@
 :- encoding(utf8).
 :- use_module(library(plunit)).
 :- use_module('../src/unifyweaver/targets/wam_go_target').
+:- use_module(library(filesex)).
 
 :- begin_tests(wam_go_generator).
+
+:- dynamic test_resistant/3.
+:- dynamic test_resistant_helper/2.
+:- dynamic test_caller/2.
+:- dynamic wam_only_inner/2.
+:- dynamic wam_only_caller/2.
+
+test_resistant(X, Y, Z) :- test_resistant_helper(X, Y), test_resistant_helper(Y, Z).
+test_resistant(X, _, X).
+test_resistant_helper(a, b).
+test_resistant_helper(b, c).
+test_caller(X, Z) :- test_resistant(X, _, Z), test_resistant(Z, _, X).
+test_caller(X, X).
+wam_only_inner(X, Y) :- Y is X + 1, atom(foo), \+ atom(5).
+wam_only_caller(X, Z) :- wam_only_inner(X, Y), wam_only_inner(Y, Z).
 
 test(wam_get_constant) :-
     wam_instruction_to_go_literal(get_constant(atom(john), 'A1'), Literal),
@@ -38,9 +54,52 @@ test(parse_wam_line_switch) :-
     compile_wam_predicate_to_go(test/1, WamCode, [], GoCode),
     assertion(sub_string(GoCode, _, _, _, '&SwitchOnConstant{Cases: []ConstCase{')).
 
+test(compiled_predicate_emits_resolved_code_and_wrapper) :-
+    WamCode = "test/1:\n    call helper/1, 1\n    execute done/1\n    try_me_else L1\n    retry_me_else L2\n    switch_on_constant john:L1\n",
+    compile_wam_predicate_to_go(test/1, WamCode, [], GoCode),
+    assertion(sub_string(GoCode, _, _, _, 'var TestResolvedCode = resolveInstructions(TestCode, TestLabels)')),
+    assertion(sub_string(GoCode, _, _, _, 'func Test(a1 Value) bool {')),
+    assertion(sub_string(GoCode, _, _, _, 'vm := NewWamState(TestResolvedCode, TestLabels)')).
+
+test(project_uses_shared_wam_table_for_cross_predicate_calls) :-
+    get_time(T),
+    format(atom(TmpDir), 'tmp_wam_go_shared_~w', [T]),
+    write_wam_go_project([plunit_wam_go_generator:wam_only_caller/2,
+                          plunit_wam_go_generator:wam_only_inner/2],
+                         [module_name(go_shared_test)], TmpDir),
+    directory_file_path(TmpDir, 'lib.go', LibPath),
+    read_file_to_string(LibPath, LibCode, []),
+    assertion(sub_string(LibCode, _, _, _, 'var sharedWamCodeRaw = []Instruction{')),
+    assertion(sub_string(LibCode, _, _, _, 'var sharedWamCode = resolveInstructions(sharedWamCodeRaw, sharedWamLabels)')),
+    assertion(sub_string(LibCode, _, _, _, 'var Wam_only_callerCode = sharedWamCode')),
+    assertion(sub_string(LibCode, _, _, _, 'func Wam_only_caller(a1 Value, a2 Value) bool {')),
+    assertion(sub_string(LibCode, _, _, _, 'vm := NewWamState(sharedWamCode, sharedWamLabels)')),
+    assertion(sub_string(LibCode, _, _, _, 'vm.PC = ')),
+    delete_directory_and_contents(TmpDir).
+
 test(robust_switch_parsing) :-
     % Test malformed input robustness
     wam_line_to_go_literal(["switch_on_constant", "john"], Literal),
     assertion(sub_string(Literal, _, _, _, '&Atom{Name: "malformed"}')).
 
 :- end_tests(wam_go_generator).
+
+delete_directory_and_contents(Dir) :-
+    (   exists_directory(Dir)
+    ->  delete_directory_contents(Dir),
+        delete_directory(Dir)
+    ;   true
+    ).
+
+delete_directory_contents(Dir) :-
+    directory_files(Dir, Files),
+    member(File, Files),
+    File \== '.',
+    File \== '..',
+    directory_file_path(Dir, File, Path),
+    (   exists_directory(Path)
+    ->  delete_directory_and_contents(Path)
+    ;   delete_file(Path)
+    ),
+    fail.
+delete_directory_contents(_).


### PR DESCRIPTION
## Summary

Brings the hybrid Go/WAM target closer to the architectural quality of the
hybrid Rust and Haskell WAM targets.

This change focuses on three gaps in the Go backend:

- shared WAM assembly across fallback predicates
- one-time resolution of hot control-flow and indexing instructions
- stronger choice-point restoration during backtracking

## What Changed

### Shared WAM table for hybrid fallback

The Go project generator now classifies predicates first, then collects all
WAM-fallback predicates into a shared code/label space.

This fixes the previous per-predicate isolation problem where fallback
predicates each got their own code array and label map, making cross-predicate
WAM calls unreliable.

Each WAM predicate now gets a thin wrapper that:

- reuses `sharedWamCode`
- reuses `sharedWamLabels`
- starts execution at a predicate-specific entry PC

### Pre-resolved hot instructions

Added resolved `*Pc` instruction variants for the hot paths that were still
doing runtime label lookups:

- `CallPc`
- `ExecutePc`
- `TryMeElsePc`
- `RetryMeElsePc`
- `SwitchOnConstantPc`
- `SwitchOnStructurePc`
- `SwitchOnConstantA2Pc`

The Go runtime now runs a one-time `resolveInstructions(...)` pass to rewrite
label-based instructions into direct-PC instructions where possible.

This mirrors the same general optimization direction already used in the
Rust/Haskell WAM targets: move resolution cost out of the interpreter hot path.

### Choice-point restoration fixes

Go choice points now save:

- register state
- stack snapshot
- heap top
- trail mark
- continuation state

Backtracking restores stack and heap shape in addition to register state.

That makes the Go runtime materially safer for non-trivial WAM execution and
aligns it more closely with the state-restoration expectations of the other
hybrid WAM targets.

## Tests

Added/updated focused tests for:

- resolved-code emission in generated Go WAM wrappers
- shared WAM table generation for cross-predicate fallback
- Go builtin execution through the updated shared-table entry-point flow

Verified with:

```sh
swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
```

## Why This Matters

The optimization log for the Haskell and Rust WAM targets shows the same
recurring pattern:

- pre-resolve what can be resolved at compile/load time
- avoid repeated runtime dispatch work
- keep fallback/runtime structure coherent across predicates

This PR applies those same lessons to the Go hybrid target, without yet taking
on the larger foreign-lowering / `CallForeign` parity work.

## Remaining Gaps

This does not yet bring full parity with Rust/Haskell.

Still missing:

- Go-side foreign-lowering / `CallForeign` path parity
- Go-specific FFI-owned predicate skipping
- deeper runtime specialization beyond these architectural fixes

## Files Changed

- `src/unifyweaver/targets/wam_go_target.pl`
- `templates/targets/go_wam/instructions.go.mustache`
- `templates/targets/go_wam/state.go.mustache`
- `tests/test_wam_go_generator.pl`
- `tests/test_go_wam_builtins.pl`
