### PR TITLE
feat(wam-go): add CallForeign parity for hybrid WAM execution

### DIFF
--- a/PR_WAM_GO_CALL_FOREIGN_PARITY.md
+++ b/PR_WAM_GO_CALL_FOREIGN_PARITY.md
@@ -1,0 +1,116 @@
+# PR Title
+
+`feat(wam-go): add CallForeign parity for hybrid WAM execution`
+
+# PR Description
+
+## Summary
+
+Adds the first complete Go-side `CallForeign` path for the hybrid WAM target.
+
+This closes the biggest remaining architectural gap after the earlier Go hybrid
+WAM parity work: Go can now route selected WAM calls through native foreign
+execution instead of forcing everything through ordinary interpreted WAM
+dispatch.
+
+## What Changed
+
+### `CallForeign` instruction support
+
+Added a Go WAM instruction variant for foreign dispatch:
+
+- `CallForeign`
+
+The runtime step loop now recognizes this instruction and executes the
+registered foreign predicate handler directly.
+
+### Foreign registration/runtime plumbing
+
+Added Go runtime support for registering foreign predicate metadata:
+
+- native kind
+- result layout
+- result mode
+- string config
+- usize config
+- indexed atom fact pairs
+
+This gives the Go WAM runtime the same basic setup model already used by the
+hybrid Rust/Haskell implementations.
+
+### Foreign wrapper/codegen support
+
+The Go target can now compile explicit `foreign_predicate(...)` specs into:
+
+- wrapper-level foreign setup code
+- direct `executeForeignPredicate(...)` entry paths
+- `call` / `execute` rewrite to `CallForeign` when the target matches a
+  rewrite target in the foreign spec
+
+Foreign-lowered WAM predicates are compiled separately from the shared WAM
+table path, matching the same architectural split used in Rust.
+
+### Result handling and backtracking
+
+Added Go foreign result handling for:
+
+- deterministic results
+- stream results with choice-point-backed backtracking resume
+
+Choice points now carry enough foreign state to resume multi-result foreign
+execution correctly on backtrack.
+
+### Initial Go foreign kernel coverage
+
+This PR adds the first Go-native foreign kernels for the hybrid WAM runtime:
+
+- `countdown_sum2`
+- `list_suffix2`
+- `list_suffixes2`
+- `transitive_closure2`
+
+This is intentionally a scoped first slice, not full Rust-kernel parity.
+
+## Tests
+
+Added focused tests covering:
+
+- foreign wrapper generation from explicit specs
+- `call` / `execute` rewrite to `CallForeign`
+- deterministic and stream foreign execution behavior in generated Go projects
+
+Verified locally with:
+
+```sh
+swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
+swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
+```
+
+## Why This Matters
+
+The earlier Go hybrid parity work fixed shared WAM assembly, compile-time
+control-flow resolution, and stronger backtracking state restoration. The next
+missing piece was foreign dispatch parity.
+
+Without this change, Go still had to interpret work that the Rust/Haskell
+hybrid WAM targets already hand off to native kernels. This PR establishes that
+same execution model for Go.
+
+## Scope Boundaries
+
+This PR does **not** yet add full Go foreign-lowering parity with Rust.
+
+Still missing:
+
+- `foreign_lowering(true)` auto-detection parity
+- broader foreign kernel coverage
+- grouped/tuple-heavy result shaping beyond this first slice
+- weighted / A* / distance kernel parity
+
+## Files Changed
+
+- `src/unifyweaver/targets/wam_go_target.pl`
+- `templates/targets/go_wam/instructions.go.mustache`
+- `templates/targets/go_wam/state.go.mustache`
+- `tests/test_wam_go_foreign_lowering.pl`

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -142,8 +142,13 @@ classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
     ;   option(wam_fallback(WamFB), Options, true),
         WamFB \== false,
         wam_target:compile_predicate_to_wam(Module:Pred/Arity, Options, WamCode)
-    ->  format(user_error, '  ~w/~w: WAM fallback~n', [Pred, Arity]),
-        Entry = classified(Module, Pred, Arity, wam, WamCode)
+    ->  (   go_foreign_spec(Pred/Arity, Options, _SetupOps, _RewriteCalls, _EntryPred/_EntryArity)
+        ->  compile_wam_predicate_to_go(Pred/Arity, WamCode, Options, PredCode),
+            format(user_error, '  ~w/~w: WAM fallback (foreign)~n', [Pred, Arity]),
+            Entry = classified(Module, Pred, Arity, wam_foreign, PredCode)
+        ;   format(user_error, '  ~w/~w: WAM fallback~n', [Pred, Arity]),
+            Entry = classified(Module, Pred, Arity, wam, WamCode)
+        )
     ;   format(atom(PredCode), '// ~w/~w: compilation failed', [Pred, Arity]),
         Entry = classified(Module, Pred, Arity, failed, PredCode)
     ),
@@ -155,7 +160,7 @@ collect_wam_entries([classified(_, Pred, Arity, wam, WamCode)|Rest], PC,
                     AllInstrs, AllLabels) :-
     atom_string(WamCode, WamStr),
     split_string(WamStr, "\n", "", Lines),
-    wam_lines_to_go(Lines, PC, GoLiterals, LabelEntries),
+    wam_lines_to_go(Lines, PC, Pred/Arity, [], GoLiterals, LabelEntries),
     maplist([Lit, Entry]>>(format(atom(Entry), '        ~w,', [Lit])), GoLiterals, InstrEntries),
     maplist([Label-Idx, Entry]>>(format(atom(Entry), '        "~w": ~w,', [Label, Idx])), LabelEntries, LabelRows),
     length(GoLiterals, InstrCount),
@@ -170,6 +175,10 @@ generate_predicate_codes([], _, []).
 generate_predicate_codes([classified(_, _Pred, _Arity, native, PredCode)|Rest], WamEntries,
                          [Code|RestCodes]) :-
     format(atom(Code), '// Strategy: native~n~w', [PredCode]),
+    generate_predicate_codes(Rest, WamEntries, RestCodes).
+generate_predicate_codes([classified(_, _Pred, _Arity, wam_foreign, PredCode)|Rest], WamEntries,
+                         [Code|RestCodes]) :-
+    format(atom(Code), '// Strategy: wam_foreign~n~w', [PredCode]),
     generate_predicate_codes(Rest, WamEntries, RestCodes).
 generate_predicate_codes([classified(_, Pred, Arity, wam, _WamCode)|Rest], WamEntries,
                          [Code|RestCodes]) :-
@@ -292,22 +301,30 @@ go_struct_case(Functor-Label, Case) :-
 %% compile_wam_predicate_to_go(+Pred/Arity, +WamCode, +Options, -GoCode)
 %  Takes WAM instruction output and produces Go code with instruction
 %  slice and label map.
-compile_wam_predicate_to_go(Pred/Arity, WamCode, _Options, GoCode) :-
+compile_wam_predicate_to_go(Pred/Arity, WamCode, Options, GoCode) :-
     atom_string(Pred, PredStr),
     capitalize_atom(Pred, CapPred),
     build_go_wam_arg_list(Arity, ArgList),
     build_go_wam_arg_setup(Arity, ArgSetup),
-    %% Parse WAM code lines into instruction terms
-    atom_string(WamCode, WamStr),
-    split_string(WamStr, "\n", "", Lines),
-    wam_lines_to_go(Lines, 0, GoLiterals, LabelEntries),
-    %% Build Go slice
-    maplist([Lit, Entry]>>(format(atom(Entry), '        ~w,', [Lit])), GoLiterals, Entries),
-    atomic_list_concat(Entries, '\n', EntriesStr),
-    %% Format labels
-    maplist([Label-Idx, Entry]>>(format(atom(Entry), '        "~w": ~w,', [Label, Idx])), LabelEntries, LabelRows),
-    atomic_list_concat(LabelRows, '\n', LabelsStr),
-    format(atom(GoCode),
+    (   foreign_wrapper_setup(Pred/Arity, WamCode, Options, InstrSetup, ForeignSetup, RunExpr)
+    ->  format(atom(GoCode),
+'// WAM-compiled predicate: ~w/~w
+func ~w(~w) bool {
+    vm := NewWamState(nil, nil)
+~w
+~w
+~w
+    return ~w
+}
+', [PredStr, Arity, CapPred, ArgList, InstrSetup, ForeignSetup, ArgSetup, RunExpr])
+    ;   atom_string(WamCode, WamStr),
+        split_string(WamStr, "\n", "", Lines),
+        wam_lines_to_go(Lines, 0, Pred/Arity, Options, GoLiterals, LabelEntries),
+        maplist([Lit, Entry]>>(format(atom(Entry), '        ~w,', [Lit])), GoLiterals, Entries),
+        atomic_list_concat(Entries, '\n', EntriesStr),
+        maplist([Label-Idx, Entry]>>(format(atom(Entry), '        "~w": ~w,', [Label, Idx])), LabelEntries, LabelRows),
+        atomic_list_concat(LabelRows, '\n', LabelsStr),
+        format(atom(GoCode),
 '// WAM-compiled predicate: ~w/~w
 var ~wCode = []Instruction{
 ~w
@@ -325,7 +342,8 @@ func ~w(~w) bool {
     return vm.Run()
 }
 ', [PredStr, Arity, CapPred, EntriesStr, CapPred, LabelsStr,
-    CapPred, CapPred, CapPred, CapPred, ArgList, CapPred, CapPred, ArgSetup]).
+    CapPred, CapPred, CapPred, CapPred, ArgList, CapPred, CapPred, ArgSetup])
+    ).
 
 compile_wam_predicate_to_go_shared(Pred/Arity, StartPC, GoCode) :-
     atom_string(Pred, PredStr),
@@ -361,29 +379,85 @@ build_go_wam_arg_setup(Arity, Setup) :-
     maplist([I, S]>>format(atom(S), '    vm.Regs["A~w"] = a~w', [I, I]), Indices, Lines),
     atomic_list_concat(Lines, '\n', Setup).
 
+foreign_wrapper_setup(Pred/Arity, _WamCode, Options, InstrSetup, Setup, RunExpr) :-
+    go_foreign_spec(Pred/Arity, Options, SetupOps, _RewriteCalls, EntryPred/EntryArity),
+    InstrSetup = '    vm.PC = 1',
+    go_foreign_setup_code(SetupOps, Setup),
+    format(atom(RunExpr), 'vm.executeForeignPredicate("~w", ~w)', [EntryPred, EntryArity]).
+
+go_foreign_spec(PredArity, Options, SetupOps, RewriteCalls, EntryPredArity) :-
+    option(foreign_lowering(ForeignSpec), Options),
+    nonvar(ForeignSpec),
+    ForeignSpec \== true,
+    (   is_list(ForeignSpec)
+    ->  member(Spec, ForeignSpec),
+        go_foreign_spec_term(PredArity, Spec, SetupOps, RewriteCalls, EntryPredArity)
+    ;   go_foreign_spec_term(PredArity, ForeignSpec, SetupOps, RewriteCalls, EntryPredArity)
+    ).
+
+go_foreign_spec_term(Pred/Arity,
+        foreign_predicate(Pred/Arity, SetupOps, RewriteCalls),
+        SetupOps,
+        RewriteCalls,
+        Pred/Arity) :-
+    is_list(SetupOps),
+    is_list(RewriteCalls).
+
+go_foreign_setup_code([], "").
+go_foreign_setup_code(Ops, Setup) :-
+    maplist(go_foreign_setup_line, Ops, Lines),
+    atomic_list_concat(Lines, '\n', Setup).
+
+go_foreign_setup_line(register_foreign_native_kind(Pred/Arity, Kind), Line) :-
+    format(atom(Line), '    vm.registerForeignNativeKind("~w/~w", "~w")', [Pred, Arity, Kind]).
+go_foreign_setup_line(register_foreign_result_layout(Pred/Arity, tuple(ResultArity)), Line) :-
+    format(atom(Line), '    vm.registerForeignResultLayout("~w/~w", "tuple:~w")', [Pred, Arity, ResultArity]).
+go_foreign_setup_line(register_foreign_result_layout(Pred/Arity, Layout), Line) :-
+    format(atom(Line), '    vm.registerForeignResultLayout("~w/~w", "~w")', [Pred, Arity, Layout]).
+go_foreign_setup_line(register_foreign_result_mode(Pred/Arity, Mode), Line) :-
+    format(atom(Line), '    vm.registerForeignResultMode("~w/~w", "~w")', [Pred, Arity, Mode]).
+go_foreign_setup_line(register_foreign_string_config(Pred/Arity, Key, ValuePred/ValueArity), Line) :-
+    format(atom(Line), '    vm.registerForeignStringConfig("~w/~w", "~w", "~w/~w")',
+        [Pred, Arity, Key, ValuePred, ValueArity]).
+go_foreign_setup_line(register_foreign_string_config(Pred/Arity, Key, Value), Line) :-
+    format(atom(Line), '    vm.registerForeignStringConfig("~w/~w", "~w", "~w")',
+        [Pred, Arity, Key, Value]).
+go_foreign_setup_line(register_foreign_usize_config(Pred/Arity, Key, Value), Line) :-
+    format(atom(Line), '    vm.registerForeignUsizeConfig("~w/~w", "~w", ~w)', [Pred, Arity, Key, Value]).
+go_foreign_setup_line(register_indexed_atom_fact2(Pred/Arity, Pairs), Line) :-
+    go_fact_pairs_literal(Pairs, Literal),
+    format(atom(Line), '    vm.registerIndexedAtomFact2Pairs("~w/~w", []AtomPair{~w})', [Pred, Arity, Literal]).
+
+go_fact_pairs_literal(Pairs, Literal) :-
+    maplist(go_fact_pair_literal, Pairs, PairLiterals),
+    atomic_list_concat(PairLiterals, ', ', Literal).
+
+go_fact_pair_literal(Left-Right, Literal) :-
+    format(atom(Literal), '{Left: "~w", Right: "~w"}', [Left, Right]).
+
 capitalize_atom(Atom, Cap) :-
     atom_codes(Atom, [First|Rest]),
     code_type(FirstUpper, to_upper(First)),
     atom_codes(Cap, [FirstUpper|Rest]).
 
 %% wam_lines_to_go(+Lines, +PC, -GoLits, -LabelEntries)
-wam_lines_to_go([], _, [], []).
-wam_lines_to_go([Line|Rest], PC, GoLits, Labels) :-
+wam_lines_to_go([], _, _, _, [], []).
+wam_lines_to_go([Line|Rest], PC, PredIndicator, Options, GoLits, Labels) :-
     split_string(Line, " \t", " \t", Parts),
     delete(Parts, "", CleanParts),
     (   CleanParts == []
-    ->  wam_lines_to_go(Rest, PC, GoLits, Labels)
+    ->  wam_lines_to_go(Rest, PC, PredIndicator, Options, GoLits, Labels)
     ;   CleanParts = [First|_],
         (   % Label line: "pred/2:" or "L_label:"
             sub_string(First, _, 1, 0, ":")
         ->  sub_string(First, 0, _, 1, LabelName),
             Labels = [LabelName-PC | RestLabels],
-            wam_lines_to_go(Rest, PC, GoLits, RestLabels)
+            wam_lines_to_go(Rest, PC, PredIndicator, Options, GoLits, RestLabels)
         ;   % Instruction line
-            wam_line_to_go_literal(CleanParts, GoLit),
+            wam_line_to_go_literal(CleanParts, PredIndicator, Options, GoLit),
             GoLits = [GoLit | RestLits],
             NPC is PC + 1,
-            wam_lines_to_go(Rest, NPC, RestLits, Labels)
+            wam_lines_to_go(Rest, NPC, PredIndicator, Options, RestLits, Labels)
         )
     ).
 
@@ -393,6 +467,20 @@ parse_string_to_go_val(Str, GoVal) :-
     (   number_string(N, Str)
     ->  go_value_literal(N, GoVal)
     ;   go_value_literal(Str, GoVal)
+    ).
+
+wam_line_to_go_literal(["call", P, N], Pred/Arity, Options, GoLit) :-
+    clean_comma(P, CP), clean_comma(N, CN),
+    (   number_string(Num, CN) -> true ; Num = 0 ),
+    (   go_foreign_rewrite_call(Options, Pred/Arity, CP, Num, ForeignPred, ForeignArity)
+    ->  format(atom(GoLit), '&CallForeign{Pred: "~w", Arity: ~w}', [ForeignPred, ForeignArity])
+    ;   format(atom(GoLit), '&Call{Pred: "~w", Arity: ~w}', [CP, CN])
+    ).
+wam_line_to_go_literal(["execute", P], Pred/Arity, Options, GoLit) :-
+    clean_comma(P, CP),
+    (   go_foreign_rewrite_execute(Options, Pred/Arity, CP, ForeignPred, ForeignArity)
+    ->  format(atom(GoLit), '&CallForeign{Pred: "~w", Arity: ~w}', [ForeignPred, ForeignArity])
+    ;   format(atom(GoLit), '&Execute{Pred: "~w"}', [CP])
     ).
 
 wam_line_to_go_literal(["get_constant", C, Ai], GoLit) :-
@@ -451,12 +539,6 @@ wam_line_to_go_literal(["set_constant", C], GoLit) :-
 
 wam_line_to_go_literal(["allocate"], '&Allocate{}').
 wam_line_to_go_literal(["deallocate"], '&Deallocate{}').
-wam_line_to_go_literal(["call", P, N], GoLit) :-
-    clean_comma(P, CP), clean_comma(N, CN),
-    format(atom(GoLit), '&Call{Pred: "~w", Arity: ~w}', [CP, CN]).
-wam_line_to_go_literal(["execute", P], GoLit) :-
-    clean_comma(P, CP),
-    format(atom(GoLit), '&Execute{Pred: "~w"}', [CP]).
 wam_line_to_go_literal(["proceed"], '&Proceed{}').
 wam_line_to_go_literal(["builtin_call", Op, N], GoLit) :-
     clean_comma(Op, COp), clean_comma(N, CN),
@@ -481,6 +563,22 @@ wam_line_to_go_literal(["switch_on_structure" | Table], GoLit) :-
 wam_line_to_go_literal(Parts, GoLit) :-
     atomic_list_concat(Parts, " ", Line),
     format(atom(GoLit), '// TODO: ~w', [Line]).
+
+go_foreign_rewrite_call(Options, CurrentPred, TargetPredArity, Num, ForeignPred, ForeignArity) :-
+    go_foreign_spec(CurrentPred, Options, _SetupOps, RewriteCalls, ForeignPred/ForeignArity),
+    member(TargetPred/TargetArity, RewriteCalls),
+    format(string(ExpectedTarget), "~w/~w", [TargetPred, TargetArity]),
+    TargetPredArity == ExpectedTarget,
+    Num =:= ForeignArity.
+
+go_foreign_rewrite_execute(Options, CurrentPred, TargetPredArity, ForeignPred, ForeignArity) :-
+    go_foreign_spec(CurrentPred, Options, _SetupOps, RewriteCalls, ForeignPred/ForeignArity),
+    member(TargetPred/TargetArity, RewriteCalls),
+    format(string(ExpectedTarget), "~w/~w", [TargetPred, TargetArity]),
+    TargetPredArity == ExpectedTarget.
+
+wam_line_to_go_literal(Parts, _PredIndicator, _Options, GoLit) :-
+    wam_line_to_go_literal(Parts, GoLit).
 
 clean_comma(S, Clean) :-
     (   sub_string(S, Before, 1, 0, ",")
@@ -847,6 +945,8 @@ wam_go_case('Call', '        vm.CP = vm.PC + 1
         }
         return false').
 
+wam_go_case('CallForeign', '        return vm.executeForeignPredicate(i.Pred, i.Arity)').
+
 wam_go_case('CallPc', '        vm.CP = vm.PC + 1
         vm.PC = i.TargetPC
         return true').
@@ -1104,6 +1204,8 @@ func resolveInstructions(code []Instruction, labels map[string]int) []Instructio
             } else {
                 resolved = append(resolved, instr)
             }
+        case *CallForeign:
+            resolved = append(resolved, instr)
         case *Execute:
             if pc, ok := labels[i.Pred]; ok {
                 resolved = append(resolved, &ExecutePc{TargetPC: pc})
@@ -1175,6 +1277,231 @@ func resolveInstructions(code []Instruction, labels map[string]int) []Instructio
         }
     }
     return resolved
+}
+
+func (vm *WamState) registerForeignNativeKind(predKey string, kind string) {
+    vm.ForeignNativeKinds[predKey] = kind
+}
+
+func (vm *WamState) registerForeignResultLayout(predKey string, layout string) {
+    vm.ForeignResultLayouts[predKey] = layout
+}
+
+func (vm *WamState) registerForeignResultMode(predKey string, mode string) {
+    vm.ForeignResultModes[predKey] = mode
+}
+
+func (vm *WamState) registerForeignStringConfig(predKey string, key string, value string) {
+    cfg, ok := vm.ForeignStringConfigs[predKey]
+    if !ok {
+        cfg = make(map[string]string)
+        vm.ForeignStringConfigs[predKey] = cfg
+    }
+    cfg[key] = value
+}
+
+func (vm *WamState) registerForeignUsizeConfig(predKey string, key string, value int) {
+    cfg, ok := vm.ForeignUsizeConfigs[predKey]
+    if !ok {
+        cfg = make(map[string]int)
+        vm.ForeignUsizeConfigs[predKey] = cfg
+    }
+    cfg[key] = value
+}
+
+func (vm *WamState) registerIndexedAtomFact2Pairs(predKey string, pairs []AtomPair) {
+    vm.IndexedAtomFactPairs[predKey] = pairs
+}
+
+func (vm *WamState) foreignResultLayout(predKey string) string {
+    return vm.ForeignResultLayouts[predKey]
+}
+
+func (vm *WamState) foreignResultMode(predKey string) string {
+    return vm.ForeignResultModes[predKey]
+}
+
+func (vm *WamState) foreignStringConfig(predKey string, key string) string {
+    cfg, ok := vm.ForeignStringConfigs[predKey]
+    if !ok {
+        return ""
+    }
+    return cfg[key]
+}
+
+func (vm *WamState) foreignUsizeConfig(predKey string, key string) int {
+    cfg, ok := vm.ForeignUsizeConfigs[predKey]
+    if !ok {
+        return 0
+    }
+    return cfg[key]
+}
+
+func parseForeignTupleLayout(layout string) int {
+    var arity int
+    if _, err := fmt.Sscanf(layout, "tuple:%d", &arity); err == nil {
+        return arity
+    }
+    return 0
+}
+
+func (vm *WamState) applyForeignResult(predKey string, resultRegs []string, result Value) bool {
+    tupleArity := parseForeignTupleLayout(vm.foreignResultLayout(predKey))
+    if tupleArity <= 1 {
+        if len(resultRegs) < 1 {
+            return false
+        }
+        return vm.Unify(vm.getReg(resultRegs[0]), result)
+    }
+    tuple, ok := result.(*Compound)
+    if !ok || tuple.Functor != "__tuple__" || len(tuple.Args) != tupleArity || len(resultRegs) < tupleArity {
+        return false
+    }
+    for idx := 0; idx < tupleArity; idx++ {
+        if !vm.Unify(vm.getReg(resultRegs[idx]), tuple.Args[idx]) {
+            return false
+        }
+    }
+    return true
+}
+
+func (vm *WamState) finishForeignResults(predKey string, resultRegs []string, results []Value) bool {
+    if len(results) == 0 {
+        return false
+    }
+    resumePC := vm.PC + 1
+    mode := vm.foreignResultMode(predKey)
+    switch mode {
+    case "stream":
+        baseRegs := copyMap(vm.Regs)
+        baseStack := copyStack(vm.Stack)
+        trailMark := len(vm.Trail)
+        heapTop := len(vm.Heap)
+        if !vm.applyForeignResult(predKey, resultRegs, results[0]) {
+            return false
+        }
+        if len(results) > 1 {
+            remaining := append([]Value(nil), results[1:]...)
+            vm.ChoicePoints = append(vm.ChoicePoints, ChoicePoint{
+                NextPC: resumePC,
+                ResumePC: resumePC,
+                CP: vm.CP,
+                Regs: baseRegs,
+                Stack: baseStack,
+                HeapTop: heapTop,
+                TrailMark: trailMark,
+                ForeignPredKey: predKey,
+                ForeignResultRegs: append([]string(nil), resultRegs...),
+                ForeignResults: remaining,
+            })
+        }
+        vm.PC = resumePC
+        return true
+    default:
+        if !vm.applyForeignResult(predKey, resultRegs, results[0]) {
+            return false
+        }
+        vm.PC = resumePC
+        return true
+    }
+}
+
+func valueAsAtomString(vm *WamState, v Value) (string, bool) {
+    val := vm.deref(v)
+    atom, ok := val.(*Atom)
+    if !ok {
+        return "", false
+    }
+    return atom.Name, true
+}
+
+func valueAsInteger(vm *WamState, v Value) (int64, bool) {
+    val := vm.deref(v)
+    integer, ok := val.(*Integer)
+    if !ok {
+        return 0, false
+    }
+    return integer.Val, true
+}
+
+func listAsSlice(vm *WamState, v Value) ([]Value, bool) {
+    val := vm.deref(v)
+    list, ok := val.(*List)
+    if !ok {
+        return nil, false
+    }
+    return list.Elements, true
+}
+
+func (vm *WamState) collectNativeListSuffixes(items []Value, out *[]Value) {
+    for idx := 0; idx <= len(items); idx++ {
+        suffix := append([]Value(nil), items[idx:]...)
+        *out = append(*out, &List{Elements: suffix})
+    }
+}
+
+func (vm *WamState) executeForeignPredicate(pred string, arity int) bool {
+    predKey := fmt.Sprintf("%s/%d", pred, arity)
+    nativeKind, ok := vm.ForeignNativeKinds[predKey]
+    if !ok {
+        return false
+    }
+    switch nativeKind {
+    case "countdown_sum2":
+        n, ok := valueAsInteger(vm, vm.getReg("A1"))
+        if !ok {
+            return false
+        }
+        sum := n * (n + 1) / 2
+        return vm.finishForeignResults(predKey, []string{"A2"}, []Value{&Integer{Val: sum}})
+    case "list_suffix2":
+        items, ok := listAsSlice(vm, vm.getReg("A1"))
+        if !ok {
+            return false
+        }
+        suffixes := make([]Value, 0, len(items)+1)
+        vm.collectNativeListSuffixes(items, &suffixes)
+        packed := make([]Value, 0, len(suffixes))
+        for _, suffix := range suffixes {
+            packed = append(packed, suffix)
+        }
+        return vm.finishForeignResults(predKey, []string{"A2"}, packed)
+    case "list_suffixes2":
+        items, ok := listAsSlice(vm, vm.getReg("A1"))
+        if !ok {
+            return false
+        }
+        suffixes := make([]Value, 0, len(items)+1)
+        vm.collectNativeListSuffixes(items, &suffixes)
+        return vm.finishForeignResults(predKey, []string{"A2"}, []Value{&List{Elements: suffixes}})
+    case "transitive_closure2":
+        source, ok := valueAsAtomString(vm, vm.getReg("A1"))
+        if !ok {
+            return false
+        }
+        edgePred := vm.foreignStringConfig(predKey, "edge_pred")
+        pairs := vm.IndexedAtomFactPairs[edgePred]
+        adjacency := make(map[string][]string)
+        for _, pair := range pairs {
+            adjacency[pair.Left] = append(adjacency[pair.Left], pair.Right)
+        }
+        visited := make(map[string]bool)
+        queue := append([]string(nil), adjacency[source]...)
+        results := make([]Value, 0)
+        for len(queue) > 0 {
+            node := queue[0]
+            queue = queue[1:]
+            if visited[node] {
+                continue
+            }
+            visited[node] = true
+            results = append(results, &Atom{Name: node})
+            queue = append(queue, adjacency[node]...)
+        }
+        return vm.finishForeignResults(predKey, []string{"A2"}, results)
+    default:
+        return false
+    }
 }
 ', []).
 

--- a/templates/targets/go_wam/instructions.go.mustache
+++ b/templates/targets/go_wam/instructions.go.mustache
@@ -72,6 +72,9 @@ func (i *Deallocate) instrTag() {}
 type Call struct { Pred string; Arity int }
 func (i *Call) instrTag() {}
 
+type CallForeign struct { Pred string; Arity int }
+func (i *CallForeign) instrTag() {}
+
 type CallPc struct { TargetPC int; Arity int }
 func (i *CallPc) instrTag() {}
 

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -10,13 +10,22 @@ type TrailEntry struct {
 	Var string
 }
 
+type AtomPair struct {
+	Left  string
+	Right string
+}
+
 type ChoicePoint struct {
 	NextPC    int
+	ResumePC  int
 	CP        int
 	Regs      map[string]Value
 	Stack     []StackEntry
 	HeapTop   int
 	TrailMark int
+	ForeignPredKey   string
+	ForeignResultRegs []string
+	ForeignResults   []Value
 }
 
 type EnvFrame struct {
@@ -52,6 +61,12 @@ type WamState struct {
 	Halted       bool
 	CurrentStruct *Structure
 	CurrentList   *List
+	ForeignNativeKinds   map[string]string
+	ForeignResultLayouts map[string]string
+	ForeignResultModes   map[string]string
+	ForeignStringConfigs map[string]map[string]string
+	ForeignUsizeConfigs  map[string]map[string]int
+	IndexedAtomFactPairs map[string][]AtomPair
 }
 
 func NewWamState(code []Instruction, labels map[string]int) *WamState {
@@ -59,6 +74,12 @@ func NewWamState(code []Instruction, labels map[string]int) *WamState {
 		Code:   code,
 		Labels: labels,
 		Regs:   make(map[string]Value),
+		ForeignNativeKinds:   make(map[string]string),
+		ForeignResultLayouts: make(map[string]string),
+		ForeignResultModes:   make(map[string]string),
+		ForeignStringConfigs: make(map[string]map[string]string),
+		ForeignUsizeConfigs:  make(map[string]map[string]int),
+		IndexedAtomFactPairs: make(map[string][]AtomPair),
 	}
 }
 
@@ -136,6 +157,12 @@ func (vm *WamState) Clone() *WamState {
 		Halted:       vm.Halted,
 		CurrentStruct: vm.CurrentStruct,
 		CurrentList:   vm.CurrentList,
+		ForeignNativeKinds:   vm.ForeignNativeKinds,
+		ForeignResultLayouts: vm.ForeignResultLayouts,
+		ForeignResultModes:   vm.ForeignResultModes,
+		ForeignStringConfigs: vm.ForeignStringConfigs,
+		ForeignUsizeConfigs:  vm.ForeignUsizeConfigs,
+		IndexedAtomFactPairs: vm.IndexedAtomFactPairs,
 	}
 	copy(newState.Heap, vm.Heap)
 	copy(newState.Stack, vm.Stack)
@@ -422,7 +449,33 @@ func (vm *WamState) backtrack() bool {
     if len(vm.ChoicePoints) == 0 {
         return false
     }
-    cp := vm.ChoicePoints[len(vm.ChoicePoints)-1]
+    topIdx := len(vm.ChoicePoints) - 1
+    cp := vm.ChoicePoints[topIdx]
+    if len(cp.ForeignResults) > 0 {
+        vm.unwindTrail(cp.TrailMark)
+        vm.Regs = copyMap(cp.Regs)
+        vm.Stack = copyStack(cp.Stack)
+        if cp.HeapTop >= 0 && cp.HeapTop <= len(vm.Heap) {
+            vm.Heap = vm.Heap[:cp.HeapTop]
+        }
+        vm.CP = cp.CP
+        vm.Halted = false
+        vm.CurrentStruct = nil
+        vm.CurrentList = nil
+        nextResult := cp.ForeignResults[0]
+        cp.ForeignResults = cp.ForeignResults[1:]
+        if len(cp.ForeignResults) == 0 {
+            vm.ChoicePoints = vm.ChoicePoints[:topIdx]
+        } else {
+            vm.ChoicePoints[topIdx] = cp
+        }
+        if !vm.applyForeignResult(cp.ForeignPredKey, cp.ForeignResultRegs, nextResult) {
+            return false
+        }
+        vm.PC = cp.ResumePC
+        return true
+    }
+    vm.ChoicePoints = vm.ChoicePoints[:topIdx]
     vm.unwindTrail(cp.TrailMark)
     vm.Regs = copyMap(cp.Regs)
     vm.Stack = copyStack(cp.Stack)

--- a/tests/test_wam_go_foreign_lowering.pl
+++ b/tests/test_wam_go_foreign_lowering.pl
@@ -1,0 +1,165 @@
+:- encoding(utf8).
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_go_target').
+
+:- begin_tests(wam_go_foreign_lowering).
+
+:- dynamic test_tri_sum/2.
+:- dynamic test_tail_suffix/2.
+
+test_tri_sum(0, 0).
+test_tri_sum(N, Sum) :-
+    N > 0,
+    N1 is N - 1,
+    test_tri_sum(N1, Prev),
+    Sum is Prev + N.
+
+test_tail_suffix(S, S).
+test_tail_suffix([_|T], S) :- test_tail_suffix(T, S).
+
+test(foreign_spec_wrapper_generation) :-
+    ForeignSpec = foreign_predicate(
+        test_tri_sum/2,
+        [ register_foreign_native_kind(test_tri_sum/2, countdown_sum2),
+          register_foreign_result_layout(test_tri_sum/2, tuple(1)),
+          register_foreign_result_mode(test_tri_sum/2, deterministic)
+        ],
+        [test_tri_sum/2]
+    ),
+    compile_wam_predicate_to_go(test_tri_sum/2, "call test_tri_sum/2, 2",
+        [foreign_lowering(ForeignSpec)], Code),
+    assertion(sub_string(Code, _, _, _, 'vm.registerForeignNativeKind("test_tri_sum/2", "countdown_sum2")')),
+    assertion(sub_string(Code, _, _, _, 'vm.registerForeignResultLayout("test_tri_sum/2", "tuple:1")')),
+    assertion(sub_string(Code, _, _, _, 'vm.registerForeignResultMode("test_tri_sum/2", "deterministic")')),
+    assertion(sub_string(Code, _, _, _, 'return vm.executeForeignPredicate("test_tri_sum", 2)')).
+
+test(foreign_call_rewrite_generation) :-
+    ForeignSpec = foreign_predicate(
+        test_tri_sum/2,
+        [ register_foreign_native_kind(test_tri_sum/2, countdown_sum2),
+          register_foreign_result_layout(test_tri_sum/2, tuple(1)),
+          register_foreign_result_mode(test_tri_sum/2, deterministic)
+        ],
+        [helper/2]
+    ),
+    wam_go_target:wam_line_to_go_literal(["call", "helper/2", "2"], test_tri_sum/2,
+        [foreign_lowering(ForeignSpec)], Lit1),
+    wam_go_target:wam_line_to_go_literal(["execute", "helper/2"], test_tri_sum/2,
+        [foreign_lowering(ForeignSpec)], Lit2),
+    assertion(Lit1 == '&CallForeign{Pred: "test_tri_sum", Arity: 2}'),
+    assertion(Lit2 == '&CallForeign{Pred: "test_tri_sum", Arity: 2}').
+
+test(foreign_execution_deterministic_and_stream) :-
+    get_time(T),
+    format(atom(TmpDir), 'tmp_wam_go_foreign_~w', [T]),
+    TailSpec = foreign_predicate(
+        test_tail_suffix/2,
+        [ register_foreign_native_kind(test_tail_suffix/2, list_suffix2),
+          register_foreign_result_layout(test_tail_suffix/2, tuple(1)),
+          register_foreign_result_mode(test_tail_suffix/2, stream)
+        ],
+        [test_tail_suffix/2]
+    ),
+    write_wam_go_project(
+        [plunit_wam_go_foreign_lowering:test_tail_suffix/2],
+        [ module_name(go_foreign_test),
+          foreign_lowering([TailSpec])
+        ],
+        TmpDir
+    ),
+    directory_file_path(TmpDir, 'foreign_test.go', TestPath),
+    write_file(TestPath,
+'package wam
+
+import "testing"
+
+func TestForeignCountdownSum(t *testing.T) {
+    vm := NewWamState(nil, nil)
+    vm.registerForeignNativeKind("test_tri_sum/2", "countdown_sum2")
+    vm.registerForeignResultLayout("test_tri_sum/2", "tuple:1")
+    vm.registerForeignResultMode("test_tri_sum/2", "deterministic")
+    out := &Unbound{Name: "SUM"}
+    vm.Regs["A1"] = &Integer{Val: 4}
+    vm.Regs["A2"] = out
+    if !vm.executeForeignPredicate("test_tri_sum", 2) {
+        t.Fatalf("executeForeignPredicate failed")
+    }
+    got, ok := vm.deref(out).(*Integer)
+    if !ok || got.Val != 10 {
+        t.Fatalf("expected 10, got %#v", vm.deref(out))
+    }
+}
+
+func TestForeignListSuffixStream(t *testing.T) {
+    vm := NewWamState(nil, nil)
+    vm.registerForeignNativeKind("test_tail_suffix/2", "list_suffix2")
+    vm.registerForeignResultLayout("test_tail_suffix/2", "tuple:1")
+    vm.registerForeignResultMode("test_tail_suffix/2", "stream")
+    out := &Unbound{Name: "SUF"}
+    vm.Regs["A1"] = &List{Elements: []Value{
+        &Atom{Name: "a"},
+        &Atom{Name: "b"},
+    }}
+    vm.Regs["A2"] = out
+    if !vm.executeForeignPredicate("test_tail_suffix", 2) {
+        t.Fatalf("executeForeignPredicate failed")
+    }
+    first, ok := vm.deref(out).(*List)
+    if !ok || len(first.Elements) != 2 {
+        t.Fatalf("expected first suffix [a,b], got %#v", vm.deref(out))
+    }
+    if !vm.backtrack() {
+        t.Fatalf("expected stream backtrack result")
+    }
+    second, ok := vm.deref(out).(*List)
+    if !ok || len(second.Elements) != 1 {
+        t.Fatalf("expected second suffix [b], got %#v", vm.deref(out))
+    }
+    if !vm.backtrack() {
+        t.Fatalf("expected final stream result")
+    }
+    third, ok := vm.deref(out).(*List)
+    if !ok || len(third.Elements) != 0 {
+        t.Fatalf("expected final suffix [], got %#v", vm.deref(out))
+    }
+}
+'),
+    (   catch(process_create(path(go), ['test', './...'], [cwd(TmpDir), stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]), _, fail)
+    ->  read_string(Out, _, Stdout),
+        read_string(Err, _, Stderr),
+        process_wait(Pid, Exit),
+        assertion(Exit == exit(0)),
+        assertion(\+ sub_string(Stderr, _, _, _, 'FAIL'))
+    ;   true
+    ),
+    delete_directory_and_contents(TmpDir).
+
+:- end_tests(wam_go_foreign_lowering).
+
+delete_directory_and_contents(Dir) :-
+    (   exists_directory(Dir)
+    ->  delete_directory_contents(Dir),
+        delete_directory(Dir)
+    ;   true
+    ).
+
+delete_directory_contents(Dir) :-
+    directory_files(Dir, Files),
+    member(File, Files),
+    File \== '.',
+    File \== '..',
+    directory_file_path(Dir, File, Path),
+    (   exists_directory(Path)
+    ->  delete_directory_and_contents(Path)
+    ;   delete_file(Path)
+    ),
+    fail.
+delete_directory_contents(_).
+
+write_file(Path, Content) :-
+    setup_call_cleanup(
+        open(Path, write, Stream),
+        format(Stream, "~w", [Content]),
+        close(Stream)
+    ).


### PR DESCRIPTION
## Summary

Adds the first complete Go-side `CallForeign` path for the hybrid WAM target.

This closes the biggest remaining architectural gap after the earlier Go hybrid
WAM parity work: Go can now route selected WAM calls through native foreign
execution instead of forcing everything through ordinary interpreted WAM
dispatch.

## What Changed

### `CallForeign` instruction support

Added a Go WAM instruction variant for foreign dispatch:

- `CallForeign`

The runtime step loop now recognizes this instruction and executes the
registered foreign predicate handler directly.

### Foreign registration/runtime plumbing

Added Go runtime support for registering foreign predicate metadata:

- native kind
- result layout
- result mode
- string config
- usize config
- indexed atom fact pairs

This gives the Go WAM runtime the same basic setup model already used by the
hybrid Rust/Haskell implementations.

### Foreign wrapper/codegen support

The Go target can now compile explicit `foreign_predicate(...)` specs into:

- wrapper-level foreign setup code
- direct `executeForeignPredicate(...)` entry paths
- `call` / `execute` rewrite to `CallForeign` when the target matches a
  rewrite target in the foreign spec

Foreign-lowered WAM predicates are compiled separately from the shared WAM
table path, matching the same architectural split used in Rust.

### Result handling and backtracking

Added Go foreign result handling for:

- deterministic results
- stream results with choice-point-backed backtracking resume

Choice points now carry enough foreign state to resume multi-result foreign
execution correctly on backtrack.

### Initial Go foreign kernel coverage

This PR adds the first Go-native foreign kernels for the hybrid WAM runtime:

- `countdown_sum2`
- `list_suffix2`
- `list_suffixes2`
- `transitive_closure2`

This is intentionally a scoped first slice, not full Rust-kernel parity.

## Tests

Added focused tests covering:

- foreign wrapper generation from explicit specs
- `call` / `execute` rewrite to `CallForeign`
- deterministic and stream foreign execution behavior in generated Go projects

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl
swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
```

## Why This Matters

The earlier Go hybrid parity work fixed shared WAM assembly, compile-time
control-flow resolution, and stronger backtracking state restoration. The next
missing piece was foreign dispatch parity.

Without this change, Go still had to interpret work that the Rust/Haskell
hybrid WAM targets already hand off to native kernels. This PR establishes that
same execution model for Go.

## Scope Boundaries

This PR does **not** yet add full Go foreign-lowering parity with Rust.

Still missing:

- `foreign_lowering(true)` auto-detection parity
- broader foreign kernel coverage
- grouped/tuple-heavy result shaping beyond this first slice
- weighted / A* / distance kernel parity

## Files Changed

- `src/unifyweaver/targets/wam_go_target.pl`
- `templates/targets/go_wam/instructions.go.mustache`
- `templates/targets/go_wam/state.go.mustache`
- `tests/test_wam_go_foreign_lowering.pl`
