### PR TITLE
perf(csharp-query): Trim counted path row timing overhead in the C# query runtime

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -155,14 +155,15 @@ Local survey:
 | negative additive weighted `Min` | 1k | 0.563s | 1.217s | yes | `16,522,183` dominance candidates |
 
 Counted-closure phase split after typed row buffering, pre-sized
-materialization, and edge-state node-id preindexing:
+materialization, edge-state node-id preindexing, and removing per-row buffer
+timing from the traversal hot path:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 201.268ms | 27.712ms | 96.200ms | n/a |
-| 300 | Min | 68.297ms | n/a | 7.207ms | 17.291ms |
-| 1k | All | 119.368ms | 23.988ms | 60.008ms | n/a |
-| 1k | Min | 19.815ms | n/a | 1.808ms | 5.863ms |
+| 300 | All | 217.951ms | 0.000ms | 99.800ms | n/a |
+| 300 | Min | 53.414ms | 0.000ms | 7.487ms | 13.907ms |
+| 1k | All | 122.026ms | 0.000ms | 63.798ms | n/a |
+| 1k | Min | 21.147ms | 0.000ms | 1.794ms | 5.640ms |
 
 Interpretation:
 
@@ -175,6 +176,9 @@ Interpretation:
 - edge-state node-id preindexing removes the per-successor candidate node-id
   dictionary lookup from traversal while preserving output hashes and
   `path_state_*` counters
+- row-buffer recording no longer starts a stopwatch for every emitted path
+  row; the explicit `path_state_row_creation` phase is now `0`, and row-buffer
+  work is included in traversal timing
 - weighted `Min` fallback remains the only measured shape where generic
   frontier candidate indexing is directly relevant
 - the next optimization should not add another generic frontier index by

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -324,14 +324,15 @@ raw path-state traversal:
 | counted shortest path | 1k | 0.450s | 0.180s | 2.50x | 352,522 | 10,328 | 592,698 | 38,196 |
 
 Counted-closure phase split after typed row buffering, pre-sized
-materialization, and edge-state node-id preindexing:
+materialization, edge-state node-id preindexing, and removing per-row buffer
+timing from the traversal hot path:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 201.268ms | 27.712ms | 96.200ms | n/a |
-| 300 | Min | 68.297ms | n/a | 7.207ms | 17.291ms |
-| 1k | All | 119.368ms | 23.988ms | 60.008ms | n/a |
-| 1k | Min | 19.815ms | n/a | 1.808ms | 5.863ms |
+| 300 | All | 217.951ms | 0.000ms | 99.800ms | n/a |
+| 300 | Min | 53.414ms | 0.000ms | 7.487ms | 13.907ms |
+| 1k | All | 122.026ms | 0.000ms | 63.798ms | n/a |
+| 1k | Min | 21.147ms | 0.000ms | 1.794ms | 5.640ms |
 
 Interpretation:
 
@@ -357,6 +358,9 @@ Interpretation:
 - edge-state node-id preindexing removes the per-successor candidate node-id
   dictionary lookup from traversal while preserving output hashes and
   `path_state_*` counters
+- row-buffer recording no longer starts a stopwatch for every emitted path
+  row; the explicit `path_state_row_creation` phase is now `0`, and row-buffer
+  work is included in traversal timing
 - the next broad optimization should avoid adding more generic frontier indexes
   until another dominance-heavy fallback shape appears; for counted closure,
   remaining work should target expansion/materialization overhead

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -941,21 +941,22 @@ python examples/benchmark/benchmark_shortest_path_to_root.py \
 ```
 
 Latest local results after compact visited paths, typed row buffering,
-pre-sized result materialization, and edge-state node-id preindexing:
+pre-sized result materialization, edge-state node-id preindexing, and removing
+per-row buffer timing from the traversal hot path:
 
 | Scale | All | Min | Speedup | Output Match | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 |-------|----:|----:|--------:|--------------|----------------:|----------------:|-------------------------:|-------------------------:|
-| 300 | 0.549s | 0.225s | 2.45x | match | 602,808 | 30,968 | 982,581 | 101,371 |
-| 1k | 0.415s | 0.168s | 2.46x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+| 300 | 0.558s | 0.219s | 2.55x | match | 602,808 | 30,968 | 982,581 | 101,371 |
+| 1k | 0.395s | 0.167s | 2.37x | match | 352,522 | 10,328 | 592,698 | 38,196 |
 
 The same run reports the counted-closure phase split:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 |-------|------|----------:|-------------:|-----------------------:|----------------------:|
-| 300 | All | 201.268ms | 27.712ms | 96.200ms | n/a |
-| 300 | Min | 68.297ms | n/a | 7.207ms | 17.291ms |
-| 1k | All | 119.368ms | 23.988ms | 60.008ms | n/a |
-| 1k | Min | 19.815ms | n/a | 1.808ms | 5.863ms |
+| 300 | All | 217.951ms | 0.000ms | 99.800ms | n/a |
+| 300 | Min | 53.414ms | 0.000ms | 7.487ms | 13.907ms |
+| 1k | All | 122.026ms | 0.000ms | 63.798ms | n/a |
+| 1k | Min | 21.147ms | 0.000ms | 1.794ms | 5.640ms |
 
 Additional path-state observations:
 
@@ -973,6 +974,9 @@ Additional path-state observations:
 - edge-state node-id preindexing removes the per-successor candidate node-id
   dictionary lookup from traversal while preserving output hashes and
   `path_state_*` counters.
+- row-buffer recording no longer starts a stopwatch for every emitted path
+  row; the explicit `path_state_row_creation` phase is now `0`, and row-buffer
+  work is included in traversal timing.
 - This shape does not exercise the weighted `min_frontier_*` dominance
   candidate problem; generic frontier indexes would not address its primary
   cost. Further counted-closure work should target expansion/materialization

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -12546,7 +12546,7 @@ namespace UnifyWeaver.QueryRuntime
                     }
                     else
                     {
-                        RecordBufferedPathAwareDepthRow(bufferedRows!, seed, next, nextDepth, metrics);
+                        RecordBufferedPathAwareDepthRow(bufferedRows!, seed, next, nextDepth);
                     }
 
                     var nextVisited = visited.Extend(nextId);
@@ -12588,18 +12588,9 @@ namespace UnifyWeaver.QueryRuntime
             List<PathAwareDepthRow> rows,
             object? seed,
             object? target,
-            int depth,
-            PathAwareTraversalMetrics? metrics)
+            int depth)
         {
-            if (metrics is null)
-            {
-                rows.Add(new PathAwareDepthRow(seed, target, depth));
-                return;
-            }
-
-            var started = Stopwatch.GetTimestamp();
             rows.Add(new PathAwareDepthRow(seed, target, depth));
-            metrics.AddRowCreationElapsed(Stopwatch.GetElapsedTime(started));
         }
 
         private static void MaterializePathAwareDepthRows(
@@ -12612,13 +12603,26 @@ namespace UnifyWeaver.QueryRuntime
             {
                 outputList.EnsureCapacity(outputList.Count + rows.Count);
             }
+            else
+            {
+                for (var i = 0; i < rows.Count; i++)
+                {
+                    var row = rows[i];
+                    output.Add(new object[] { row.Seed!, row.Target!, row.Depth });
+                    metrics?.RecordOutputRow();
+                }
+
+                metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(started));
+                return;
+            }
 
             for (var i = 0; i < rows.Count; i++)
             {
                 var row = rows[i];
-                output.Add(new object[] { row.Seed!, row.Target!, row.Depth });
+                outputList.Add(new object[] { row.Seed!, row.Target!, row.Depth });
                 metrics?.RecordOutputRow();
             }
+
             metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(started));
         }
 


### PR DESCRIPTION
## Summary

- Removes per-row stopwatch timing from counted path `All`/`Sum`/`Count` buffering in the C# query runtime.
- Keeps the compact typed row buffer and single final materialization pass.
- Preserves output order, output hashes, and existing `path_state_*` counters.
- Updates benchmark/proposal docs to reflect that `path_state_row_creation` is now intentionally `0` and that row-buffer work is folded into traversal timing.

## Why

The previous counted path work showed that the runtime was still sensitive to hot-path overhead in `PathAwareTransitiveClosureNode`. One remaining cost was measurement itself: buffered path row recording started a stopwatch for every emitted row.

That timing granularity was too expensive on the hot path. This change keeps the buffering strategy but removes the per-row timing work so the runtime is measuring the meaningful phases without paying that overhead on every buffered row.

## Results

Local counted shortest-path benchmark:

```bash
python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3
```

| Scale | All | Min | Speedup | Output Match |
| --- | ---: | ---: | ---: | --- |
| 300 | 0.558s | 0.219s | 2.55x | match |
| 1k | 0.395s | 0.167s | 2.37x | match |

Counted-closure phase split:

| Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
| --- | --- | ---: | ---: | ---: | ---: |
| 300 | All | 217.951ms | 0.000ms | 99.800ms | n/a |
| 300 | Min | 53.414ms | 0.000ms | 7.487ms | 13.907ms |
| 1k | All | 122.026ms | 0.000ms | 63.798ms | n/a |
| 1k | Min | 21.147ms | 0.000ms | 1.794ms | 5.640ms |

## Notes

- `path_state_row_creation` is now `0` by design for this counted path shape.
- Row-buffer recording still happens, but its cost is now included in `path_state_traversal` instead of being measured with a per-row stopwatch.
- This keeps the metric surface stable while removing measurement overhead from the hot path.

## Validation

- `swipl -q -t run_tests tests/core/test_csharp_query_target.pl`
- `python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py`
- `git diff --check`
- `python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3`