### PR TITLE
feat(wam-go): auto-detect foreign lowering and clean target hygiene`

### DIFF
--- a/PR_WAM_GO_AUTODETECT_AND_HYGIENE.md
+++ b/PR_WAM_GO_AUTODETECT_AND_HYGIENE.md
@@ -1,0 +1,53 @@
+# PR Title
+
+`feat(wam-go): auto-detect foreign lowering and clean target hygiene`
+
+# PR Description
+
+## Summary
+
+This PR closes the next major parity gap between the Go hybrid/WAM target and the Rust/Haskell hybrid targets by adding `foreign_lowering(true)` auto-detection to the Go WAM pipeline.
+
+It also cleans the focused warning noise introduced by the Go foreign-lowering path so local verification is easier to read.
+
+## What Changed
+
+- Added Go-side auto-detection for `foreign_lowering(true)` in the WAM Go target.
+- Preserved module-qualified predicate handling so detection works for non-`user` predicates, including plunit-defined predicates.
+- Synthesized Go foreign-lowering specs from detected recursive kernels instead of requiring explicit `foreign_predicate(...)` declarations.
+- Added support for these Go auto-detected kernels:
+  - `countdown_sum2`
+  - `list_suffix2`
+  - `list_suffixes2`
+  - `transitive_closure2`
+- Reused the existing Go `CallForeign` setup path by generating the same setup ops used by explicit foreign lowering.
+- Added a focused test covering auto-detected transitive-closure lowering.
+- Cleaned focused warning hygiene in the touched code:
+  - declared `wam_line_to_go_literal/4` discontiguous in the Go WAM target
+  - removed singleton/local override noise from the Go foreign-lowering test file
+  - removed avoidable choicepoints from the edited foreign-lowering tests
+
+## Why
+
+Before this change, the Go hybrid/WAM target only supported foreign lowering when the caller provided an explicit `foreign_predicate(...)` spec.
+
+Rust and Haskell already go further by recognizing known recursive kernel shapes and lowering them automatically. This PR brings Go onto that same path for the kernels the current Go runtime can already execute.
+
+## Verification
+
+Passed locally:
+
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+
+## Scope Notes
+
+- This PR does not add new Go native kernels beyond those already supported by the runtime.
+- This PR does not attempt repo-wide warning cleanup; it only cleans the focused warning noise in the touched Go foreign-lowering path.
+- Remaining warning output still comes from older unrelated areas such as `go_target.pl` and legacy Go WAM tests.
+
+## Follow-Ups
+
+- Add Go auto-detection parity for the remaining graph kernels once the Go runtime supports them.
+- Do a separate warning-hygiene pass over existing Go target and Go WAM test files.

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -23,12 +23,15 @@
 :- use_module(library(lists)).
 :- use_module(library(option)).
 :- use_module(library(filesex), [make_directory_path/1, directory_file_path/3]).
+:- use_module('../core/recursive_kernel_detection',
+             [detect_recursive_kernel/4, kernel_metadata/4]).
 :- use_module('../core/template_system').
 :- use_module('../bindings/go_wam_bindings').
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
 :- use_module('../targets/go_target', [compile_predicate_to_go/3]).
 
 :- discontiguous wam_go_case/2.
+:- discontiguous wam_line_to_go_literal/4.
 
 % ============================================================================
 % PHASE 4: Hybrid Module Assembly
@@ -130,9 +133,7 @@ var sharedWamCode = resolveInstructions(sharedWamCodeRaw, sharedWamLabels)
 
 classify_predicates([], _, []).
 classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
-    (   PredIndicator = Module:Pred/Arity -> true
-    ;   PredIndicator = Pred/Arity, Module = user
-    ),
+    predicate_indicator_parts(PredIndicator, Module, Pred, Arity),
     (   catch(
             go_target:compile_predicate_to_go(Module:Pred/Arity,
                 [include_package(false)|Options], PredCode),
@@ -142,8 +143,8 @@ classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
     ;   option(wam_fallback(WamFB), Options, true),
         WamFB \== false,
         wam_target:compile_predicate_to_wam(Module:Pred/Arity, Options, WamCode)
-    ->  (   go_foreign_spec(Pred/Arity, Options, _SetupOps, _RewriteCalls, _EntryPred/_EntryArity)
-        ->  compile_wam_predicate_to_go(Pred/Arity, WamCode, Options, PredCode),
+    ->  (   go_foreign_spec(Module:Pred/Arity, Options, _SetupOps, _RewriteCalls, _EntryPred/_EntryArity)
+        ->  compile_wam_predicate_to_go(Module:Pred/Arity, WamCode, Options, PredCode),
             format(user_error, '  ~w/~w: WAM fallback (foreign)~n', [Pred, Arity]),
             Entry = classified(Module, Pred, Arity, wam_foreign, PredCode)
         ;   format(user_error, '  ~w/~w: WAM fallback~n', [Pred, Arity]),
@@ -301,12 +302,13 @@ go_struct_case(Functor-Label, Case) :-
 %% compile_wam_predicate_to_go(+Pred/Arity, +WamCode, +Options, -GoCode)
 %  Takes WAM instruction output and produces Go code with instruction
 %  slice and label map.
-compile_wam_predicate_to_go(Pred/Arity, WamCode, Options, GoCode) :-
+compile_wam_predicate_to_go(PredIndicator, WamCode, Options, GoCode) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
     atom_string(Pred, PredStr),
     capitalize_atom(Pred, CapPred),
     build_go_wam_arg_list(Arity, ArgList),
     build_go_wam_arg_setup(Arity, ArgSetup),
-    (   foreign_wrapper_setup(Pred/Arity, WamCode, Options, InstrSetup, ForeignSetup, RunExpr)
+    (   foreign_wrapper_setup(PredIndicator, WamCode, Options, InstrSetup, ForeignSetup, RunExpr)
     ->  format(atom(GoCode),
 '// WAM-compiled predicate: ~w/~w
 func ~w(~w) bool {
@@ -379,8 +381,8 @@ build_go_wam_arg_setup(Arity, Setup) :-
     maplist([I, S]>>format(atom(S), '    vm.Regs["A~w"] = a~w', [I, I]), Indices, Lines),
     atomic_list_concat(Lines, '\n', Setup).
 
-foreign_wrapper_setup(Pred/Arity, _WamCode, Options, InstrSetup, Setup, RunExpr) :-
-    go_foreign_spec(Pred/Arity, Options, SetupOps, _RewriteCalls, EntryPred/EntryArity),
+foreign_wrapper_setup(PredIndicator, _WamCode, Options, InstrSetup, Setup, RunExpr) :-
+    go_foreign_spec(PredIndicator, Options, SetupOps, _RewriteCalls, EntryPred/EntryArity),
     InstrSetup = '    vm.PC = 1',
     go_foreign_setup_code(SetupOps, Setup),
     format(atom(RunExpr), 'vm.executeForeignPredicate("~w", ~w)', [EntryPred, EntryArity]).
@@ -393,7 +395,12 @@ go_foreign_spec(PredArity, Options, SetupOps, RewriteCalls, EntryPredArity) :-
     ->  member(Spec, ForeignSpec),
         go_foreign_spec_term(PredArity, Spec, SetupOps, RewriteCalls, EntryPredArity)
     ;   go_foreign_spec_term(PredArity, ForeignSpec, SetupOps, RewriteCalls, EntryPredArity)
-    ).
+    ),
+    !.
+go_foreign_spec(PredIndicator, Options, SetupOps, RewriteCalls, EntryPredArity) :-
+    option(foreign_lowering(true), Options),
+    go_foreign_lowering_spec(PredIndicator, SetupOps, RewriteCalls, EntryPredArity),
+    !.
 
 go_foreign_spec_term(Pred/Arity,
         foreign_predicate(Pred/Arity, SetupOps, RewriteCalls),
@@ -439,6 +446,105 @@ capitalize_atom(Atom, Cap) :-
     atom_codes(Atom, [First|Rest]),
     code_type(FirstUpper, to_upper(First)),
     atom_codes(Cap, [FirstUpper|Rest]).
+
+predicate_indicator_parts(Module:Pred/Arity, Module, Pred, Arity) :- !.
+predicate_indicator_parts(Pred/Arity, user, Pred, Arity).
+
+go_foreign_lowering_spec(PredIndicator, SetupOps, RewriteCalls, EntryPred/EntryArity) :-
+    predicate_indicator_parts(PredIndicator, Module, Pred, Arity),
+    functor(Head, Pred, Arity),
+    findall(Head-Body, Module:clause(Head, Body), Clauses),
+    Clauses \= [],
+    go_recursive_kernel(Module, Pred, Arity, Clauses, Kernel),
+    go_recursive_kernel_spec(Kernel, SetupOps, RewriteCalls, EntryPred/EntryArity).
+
+go_recursive_kernel(_Module, Pred, Arity, Clauses, recursive_kernel(countdown_sum2, Pred/Arity, [])) :-
+    go_foreign_lowerable_countdown_sum(Pred, Arity, Clauses).
+go_recursive_kernel(_Module, Pred, Arity, Clauses, recursive_kernel(list_suffix2, Pred/Arity, [])) :-
+    go_foreign_lowerable_list_suffix(Pred, Arity, Clauses).
+go_recursive_kernel(_Module, Pred, Arity, Clauses, recursive_kernel(list_suffixes2, Pred/Arity, [])) :-
+    go_foreign_lowerable_list_suffixes(Pred, Arity, Clauses).
+go_recursive_kernel(Module, Pred, Arity, Clauses, Kernel) :-
+    detect_recursive_kernel(Pred, Arity, Clauses, Kernel0),
+    go_supported_shared_kernel(Kernel0),
+    go_recursive_kernel_with_facts(Module, Kernel0, Kernel).
+
+go_supported_shared_kernel(recursive_kernel(transitive_closure2, _, _)).
+
+go_recursive_kernel_with_facts(Module,
+        recursive_kernel(transitive_closure2, PredIndicator, KernelConfig0),
+        recursive_kernel(transitive_closure2, PredIndicator,
+            [edge_pred(EdgePred/2), fact_pairs(FactPairs)])) :-
+    member(edge_pred(EdgePred/2), KernelConfig0),
+    go_binary_edge_fact_pairs(Module, EdgePred/2, FactPairs),
+    FactPairs \= [].
+
+go_recursive_kernel_spec(recursive_kernel(KernelKind, PredIndicator, KernelConfig),
+        SetupOps, RewriteCalls, PredIndicator) :-
+    go_recursive_kernel_setup_ops(KernelKind, PredIndicator, KernelConfig, SetupOps),
+    RewriteCalls = [PredIndicator].
+
+go_recursive_kernel_setup_ops(KernelKind, PredIndicator, KernelConfig,
+        [ register_foreign_native_kind(PredIndicator, NativeKind),
+          register_foreign_result_layout(PredIndicator, ResultLayout),
+          register_foreign_result_mode(PredIndicator, ResultMode)
+        |ConfigOps]) :-
+    go_recursive_kernel_metadata(KernelKind, KernelConfig, NativeKind, ResultLayout, ResultMode),
+    go_recursive_kernel_config_ops(PredIndicator, KernelConfig, ConfigOps).
+
+go_recursive_kernel_metadata(countdown_sum2, _KernelConfig, countdown_sum2, tuple(1), deterministic).
+go_recursive_kernel_metadata(list_suffix2, _KernelConfig, list_suffix2, tuple(1), stream).
+go_recursive_kernel_metadata(list_suffixes2, _KernelConfig, list_suffixes2, tuple(1), deterministic_collection).
+go_recursive_kernel_metadata(KernelKind, KernelConfig, NativeKind, ResultLayout, ResultMode) :-
+    kernel_metadata(recursive_kernel(KernelKind, _PredIndicator, KernelConfig),
+        NativeKind, ResultLayout, ResultMode).
+
+go_recursive_kernel_config_ops(_PredIndicator, [], []).
+go_recursive_kernel_config_ops(PredIndicator, [edge_pred(EdgePred/2), fact_pairs(FactPairs)], [
+        register_foreign_string_config(PredIndicator, edge_pred, EdgePred/2),
+        register_indexed_atom_fact2(EdgePred/2, FactPairs)
+    ]).
+
+go_binary_edge_fact_pairs(Module, EdgePred/2, FactPairs) :-
+    findall(Left-Right,
+        ( functor(EdgeHead, EdgePred, 2),
+          Module:clause(EdgeHead, true),
+          EdgeHead =.. [EdgePred, Left, Right],
+          atom(Left),
+          atom(Right)
+        ),
+        FactPairs).
+
+go_foreign_lowerable_countdown_sum(Pred, 2, Clauses) :-
+    member(BaseHead-true, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseHead =.. [Pred, 0, 0],
+    RecHead =.. [Pred, N, Sum],
+    RecBody = (GtGoal, (StepGoal, (RecGoal, SumGoal))),
+    GtGoal =.. [>, N, 0],
+    StepGoal =.. [is, PrevN, StepExpr],
+    (   StepExpr =.. [-, N, 1]
+    ;   StepExpr =.. [+, N, -1]
+    ),
+    RecGoal =.. [Pred, PrevN, PrevSum],
+    SumGoal =.. [is, Sum, SumExpr],
+    SumExpr =.. [+, PrevSum, N].
+
+go_foreign_lowerable_list_suffix(Pred, 2, Clauses) :-
+    member(BaseHead-true, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseHead =.. [Pred, BaseList, BaseList],
+    var(BaseList),
+    RecHead =.. [Pred, InputList, Suffix],
+    InputList = [_|Tail],
+    RecBody =.. [Pred, Tail, Suffix].
+
+go_foreign_lowerable_list_suffixes(Pred, 2, Clauses) :-
+    member(BaseHead-true, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseHead =.. [Pred, [], [[]]],
+    RecHead =.. [Pred, [Head|Tail], [[Head|Tail]|Rest]],
+    RecBody =.. [Pred, Tail, Rest].
 
 %% wam_lines_to_go(+Lines, +PC, -GoLits, -LabelEntries)
 wam_lines_to_go([], _, _, _, [], []).

--- a/tests/test_wam_go_foreign_lowering.pl
+++ b/tests/test_wam_go_foreign_lowering.pl
@@ -7,6 +7,11 @@
 
 :- dynamic test_tri_sum/2.
 :- dynamic test_tail_suffix/2.
+:- dynamic test_reaches/2.
+
+edge(a, b).
+edge(b, c).
+edge(c, d).
 
 test_tri_sum(0, 0).
 test_tri_sum(N, Sum) :-
@@ -17,6 +22,9 @@ test_tri_sum(N, Sum) :-
 
 test_tail_suffix(S, S).
 test_tail_suffix([_|T], S) :- test_tail_suffix(T, S).
+
+test_reaches(X, Y) :- edge(X, Y).
+test_reaches(X, Y) :- edge(X, Z), test_reaches(Z, Y).
 
 test(foreign_spec_wrapper_generation) :-
     ForeignSpec = foreign_predicate(
@@ -35,41 +43,53 @@ test(foreign_spec_wrapper_generation) :-
     assertion(sub_string(Code, _, _, _, 'return vm.executeForeignPredicate("test_tri_sum", 2)')).
 
 test(foreign_call_rewrite_generation) :-
-    ForeignSpec = foreign_predicate(
-        test_tri_sum/2,
-        [ register_foreign_native_kind(test_tri_sum/2, countdown_sum2),
-          register_foreign_result_layout(test_tri_sum/2, tuple(1)),
-          register_foreign_result_mode(test_tri_sum/2, deterministic)
-        ],
-        [helper/2]
-    ),
-    wam_go_target:wam_line_to_go_literal(["call", "helper/2", "2"], test_tri_sum/2,
-        [foreign_lowering(ForeignSpec)], Lit1),
-    wam_go_target:wam_line_to_go_literal(["execute", "helper/2"], test_tri_sum/2,
-        [foreign_lowering(ForeignSpec)], Lit2),
-    assertion(Lit1 == '&CallForeign{Pred: "test_tri_sum", Arity: 2}'),
-    assertion(Lit2 == '&CallForeign{Pred: "test_tri_sum", Arity: 2}').
+    once((
+        ForeignSpec = foreign_predicate(
+            test_tri_sum/2,
+            [ register_foreign_native_kind(test_tri_sum/2, countdown_sum2),
+              register_foreign_result_layout(test_tri_sum/2, tuple(1)),
+              register_foreign_result_mode(test_tri_sum/2, deterministic)
+            ],
+            [helper/2]
+        ),
+        wam_go_target:wam_line_to_go_literal(["call", "helper/2", "2"], test_tri_sum/2,
+            [foreign_lowering(ForeignSpec)], Lit1),
+        wam_go_target:wam_line_to_go_literal(["execute", "helper/2"], test_tri_sum/2,
+            [foreign_lowering(ForeignSpec)], Lit2),
+        assertion(Lit1 == '&CallForeign{Pred: "test_tri_sum", Arity: 2}'),
+        assertion(Lit2 == '&CallForeign{Pred: "test_tri_sum", Arity: 2}')
+    )).
+
+test(foreign_auto_detect_generation) :-
+    compile_wam_predicate_to_go(plunit_wam_go_foreign_lowering:test_reaches/2, "call test_reaches/2, 2",
+        [foreign_lowering(true)], Code),
+    assertion(sub_string(Code, _, _, _, 'vm.registerForeignNativeKind("test_reaches/2", "transitive_closure2")')),
+    assertion(sub_string(Code, _, _, _, 'vm.registerForeignResultMode("test_reaches/2", "stream")')),
+    assertion(sub_string(Code, _, _, _, 'vm.registerForeignStringConfig("test_reaches/2", "edge_pred", "edge/2")')),
+    assertion(sub_string(Code, _, _, _, 'vm.registerIndexedAtomFact2Pairs("edge/2", []AtomPair{{Left: "a", Right: "b"}, {Left: "b", Right: "c"}, {Left: "c", Right: "d"}})')),
+    assertion(sub_string(Code, _, _, _, 'return vm.executeForeignPredicate("test_reaches", 2)')).
 
 test(foreign_execution_deterministic_and_stream) :-
-    get_time(T),
-    format(atom(TmpDir), 'tmp_wam_go_foreign_~w', [T]),
-    TailSpec = foreign_predicate(
-        test_tail_suffix/2,
-        [ register_foreign_native_kind(test_tail_suffix/2, list_suffix2),
-          register_foreign_result_layout(test_tail_suffix/2, tuple(1)),
-          register_foreign_result_mode(test_tail_suffix/2, stream)
-        ],
-        [test_tail_suffix/2]
-    ),
-    write_wam_go_project(
-        [plunit_wam_go_foreign_lowering:test_tail_suffix/2],
-        [ module_name(go_foreign_test),
-          foreign_lowering([TailSpec])
-        ],
-        TmpDir
-    ),
-    directory_file_path(TmpDir, 'foreign_test.go', TestPath),
-    write_file(TestPath,
+    once((
+        get_time(T),
+        format(atom(TmpDir), 'tmp_wam_go_foreign_~w', [T]),
+        TailSpec = foreign_predicate(
+            test_tail_suffix/2,
+            [ register_foreign_native_kind(test_tail_suffix/2, list_suffix2),
+              register_foreign_result_layout(test_tail_suffix/2, tuple(1)),
+              register_foreign_result_mode(test_tail_suffix/2, stream)
+            ],
+            [test_tail_suffix/2]
+        ),
+        write_wam_go_project(
+            [plunit_wam_go_foreign_lowering:test_tail_suffix/2],
+            [ module_name(go_foreign_test),
+              foreign_lowering([TailSpec])
+            ],
+            TmpDir
+        ),
+        directory_file_path(TmpDir, 'foreign_test.go', TestPath),
+        write_file(TestPath,
 'package wam
 
 import "testing"
@@ -125,37 +145,18 @@ func TestForeignListSuffixStream(t *testing.T) {
     }
 }
 '),
-    (   catch(process_create(path(go), ['test', './...'], [cwd(TmpDir), stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]), _, fail)
-    ->  read_string(Out, _, Stdout),
-        read_string(Err, _, Stderr),
-        process_wait(Pid, Exit),
-        assertion(Exit == exit(0)),
-        assertion(\+ sub_string(Stderr, _, _, _, 'FAIL'))
-    ;   true
-    ),
-    delete_directory_and_contents(TmpDir).
+        (   catch(process_create(path(go), ['test', './...'], [cwd(TmpDir), stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]), _, fail)
+        ->  read_string(Out, _, _Stdout),
+            read_string(Err, _, Stderr),
+            process_wait(Pid, Exit),
+            assertion(Exit == exit(0)),
+            assertion(\+ sub_string(Stderr, _, _, _, 'FAIL'))
+        ;   true
+        ),
+        delete_directory_and_contents(TmpDir)
+    )).
 
 :- end_tests(wam_go_foreign_lowering).
-
-delete_directory_and_contents(Dir) :-
-    (   exists_directory(Dir)
-    ->  delete_directory_contents(Dir),
-        delete_directory(Dir)
-    ;   true
-    ).
-
-delete_directory_contents(Dir) :-
-    directory_files(Dir, Files),
-    member(File, Files),
-    File \== '.',
-    File \== '..',
-    directory_file_path(Dir, File, Path),
-    (   exists_directory(Path)
-    ->  delete_directory_and_contents(Path)
-    ;   delete_file(Path)
-    ),
-    fail.
-delete_directory_contents(_).
 
 write_file(Path, Content) :-
     setup_call_cleanup(


### PR DESCRIPTION
## Summary

This PR closes the next major parity gap between the Go hybrid/WAM target and the Rust/Haskell hybrid targets by adding `foreign_lowering(true)` auto-detection to the Go WAM pipeline.

It also cleans the focused warning noise introduced by the Go foreign-lowering path so local verification is easier to read.

## What Changed

- Added Go-side auto-detection for `foreign_lowering(true)` in the WAM Go target.
- Preserved module-qualified predicate handling so detection works for non-`user` predicates, including plunit-defined predicates.
- Synthesized Go foreign-lowering specs from detected recursive kernels instead of requiring explicit `foreign_predicate(...)` declarations.
- Added support for these Go auto-detected kernels:
  - `countdown_sum2`
  - `list_suffix2`
  - `list_suffixes2`
  - `transitive_closure2`
- Reused the existing Go `CallForeign` setup path by generating the same setup ops used by explicit foreign lowering.
- Added a focused test covering auto-detected transitive-closure lowering.
- Cleaned focused warning hygiene in the touched code:
  - declared `wam_line_to_go_literal/4` discontiguous in the Go WAM target
  - removed singleton/local override noise from the Go foreign-lowering test file
  - removed avoidable choicepoints from the edited foreign-lowering tests

## Why

Before this change, the Go hybrid/WAM target only supported foreign lowering when the caller provided an explicit `foreign_predicate(...)` spec.

Rust and Haskell already go further by recognizing known recursive kernel shapes and lowering them automatically. This PR brings Go onto that same path for the kernels the current Go runtime can already execute.

## Verification

Passed locally:

- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`

## Scope Notes

- This PR does not add new Go native kernels beyond those already supported by the runtime.
- This PR does not attempt repo-wide warning cleanup; it only cleans the focused warning noise in the touched Go foreign-lowering path.
- Remaining warning output still comes from older unrelated areas such as `go_target.pl` and legacy Go WAM tests.

## Follow-Ups

- Add Go auto-detection parity for the remaining graph kernels once the Go runtime supports them.
- Do a separate warning-hygiene pass over existing Go target and Go WAM test files.
