### PR TITLE
perf(csharp-query): Compact counted path row buffers in the C# query runtime

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -155,15 +155,15 @@ Local survey:
 | negative additive weighted `Min` | 1k | 0.563s | 1.217s | yes | `16,522,183` dominance candidates |
 
 Counted-closure phase split after typed row buffering, pre-sized
-materialization, edge-state node-id preindexing, and removing per-row buffer
-timing from the traversal hot path:
+materialization, edge-state node-id preindexing, per-row timing removal, and a
+compact `(target, depth)` buffered row shape:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 217.951ms | 0.000ms | 99.800ms | n/a |
-| 300 | Min | 53.414ms | 0.000ms | 7.487ms | 13.907ms |
-| 1k | All | 122.026ms | 0.000ms | 63.798ms | n/a |
-| 1k | Min | 21.147ms | 0.000ms | 1.794ms | 5.640ms |
+| 300 | All | 165.620ms | 0.000ms | 76.569ms | n/a |
+| 300 | Min | 43.825ms | 0.000ms | 5.471ms | 12.509ms |
+| 1k | All | 97.050ms | 0.000ms | 35.733ms | n/a |
+| 1k | Min | 17.656ms | 0.000ms | 1.418ms | 5.662ms |
 
 Interpretation:
 
@@ -179,6 +179,9 @@ Interpretation:
 - row-buffer recording no longer starts a stopwatch for every emitted path
   row; the explicit `path_state_row_creation` phase is now `0`, and row-buffer
   work is included in traversal timing
+- the counted-path `All` buffer now stores only `(target, depth)` per row,
+  because `seed` is constant for each per-seed traversal; this reduces buffer
+  footprint and lowers final `object[]` materialization cost
 - weighted `Min` fallback remains the only measured shape where generic
   frontier candidate indexing is directly relevant
 - the next optimization should not add another generic frontier index by

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -324,15 +324,15 @@ raw path-state traversal:
 | counted shortest path | 1k | 0.450s | 0.180s | 2.50x | 352,522 | 10,328 | 592,698 | 38,196 |
 
 Counted-closure phase split after typed row buffering, pre-sized
-materialization, edge-state node-id preindexing, and removing per-row buffer
-timing from the traversal hot path:
+materialization, edge-state node-id preindexing, per-row timing removal, and a
+compact `(target, depth)` buffered row shape:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 217.951ms | 0.000ms | 99.800ms | n/a |
-| 300 | Min | 53.414ms | 0.000ms | 7.487ms | 13.907ms |
-| 1k | All | 122.026ms | 0.000ms | 63.798ms | n/a |
-| 1k | Min | 21.147ms | 0.000ms | 1.794ms | 5.640ms |
+| 300 | All | 165.620ms | 0.000ms | 76.569ms | n/a |
+| 300 | Min | 43.825ms | 0.000ms | 5.471ms | 12.509ms |
+| 1k | All | 97.050ms | 0.000ms | 35.733ms | n/a |
+| 1k | Min | 17.656ms | 0.000ms | 1.418ms | 5.662ms |
 
 Interpretation:
 
@@ -361,6 +361,9 @@ Interpretation:
 - row-buffer recording no longer starts a stopwatch for every emitted path
   row; the explicit `path_state_row_creation` phase is now `0`, and row-buffer
   work is included in traversal timing
+- the counted-path `All` buffer now stores only `(target, depth)` per row,
+  because `seed` is constant for each per-seed traversal; this reduces buffer
+  footprint and lowers final `object[]` materialization cost
 - the next broad optimization should avoid adding more generic frontier indexes
   until another dominance-heavy fallback shape appears; for counted closure,
   remaining work should target expansion/materialization overhead

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -966,23 +966,23 @@ python examples/benchmark/benchmark_shortest_path_to_root.py \
     --scales 300,1k --repetitions 3
 ```
 
-Latest local results after compact visited paths, typed row buffering,
-pre-sized result materialization, edge-state node-id preindexing, and removing
-per-row buffer timing from the traversal hot path:
+Latest local results after compact visited paths, edge-state node-id
+preindexing, per-row timing removal, and a compact `(target, depth)` buffered
+row shape for counted path materialization:
 
 | Scale | All | Min | Speedup | Output Match | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 |-------|----:|----:|--------:|--------------|----------------:|----------------:|-------------------------:|-------------------------:|
-| 300 | 0.558s | 0.219s | 2.55x | match | 602,808 | 30,968 | 982,581 | 101,371 |
-| 1k | 0.395s | 0.167s | 2.37x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+| 300 | 0.439s | 0.179s | 2.45x | match | 602,808 | 30,968 | 982,581 | 101,371 |
+| 1k | 0.306s | 0.149s | 2.06x | match | 352,522 | 10,328 | 592,698 | 38,196 |
 
 The same run reports the counted-closure phase split:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 |-------|------|----------:|-------------:|-----------------------:|----------------------:|
-| 300 | All | 217.951ms | 0.000ms | 99.800ms | n/a |
-| 300 | Min | 53.414ms | 0.000ms | 7.487ms | 13.907ms |
-| 1k | All | 122.026ms | 0.000ms | 63.798ms | n/a |
-| 1k | Min | 21.147ms | 0.000ms | 1.794ms | 5.640ms |
+| 300 | All | 165.620ms | 0.000ms | 76.569ms | n/a |
+| 300 | Min | 43.825ms | 0.000ms | 5.471ms | 12.509ms |
+| 1k | All | 97.050ms | 0.000ms | 35.733ms | n/a |
+| 1k | Min | 17.656ms | 0.000ms | 1.418ms | 5.662ms |
 
 Additional path-state observations:
 
@@ -994,15 +994,15 @@ Additional path-state observations:
   `1k` without changing final shortest-path answers.
 - compact visited paths reduce the allocation-heavy `All` traversal while
   preserving the same path-state counters and output digests.
-- typed row buffering plus pre-sized final materialization reduces avoidable
-  `object[]` allocation/list-growth pressure, but traversal remains the
-  largest phase.
 - edge-state node-id preindexing removes the per-successor candidate node-id
   dictionary lookup from traversal while preserving output hashes and
   `path_state_*` counters.
 - row-buffer recording no longer starts a stopwatch for every emitted path
   row; the explicit `path_state_row_creation` phase is now `0`, and row-buffer
   work is included in traversal timing.
+- the counted-path `All` buffer now stores only `(target, depth)` per row,
+  because `seed` is constant for each per-seed traversal; this reduces buffer
+  footprint and lowers final `object[]` materialization cost.
 - This shape does not exercise the weighted `min_frontier_*` dominance
   candidate problem; generic frontier indexes would not address its primary
   cost. Further counted-closure work should target expansion/materialization

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -12475,7 +12475,7 @@ namespace UnifyWeaver.QueryRuntime
             metrics?.RecordSeed();
             var preserveAllPaths = accumulatorMode is TableMode.All or TableMode.Sum or TableMode.Count;
             var bestKnown = preserveAllPaths ? null : new Dictionary<object?, int>();
-            var bufferedRows = preserveAllPaths ? new List<PathAwareDepthRow>() : null;
+            var bufferedRows = preserveAllPaths ? new List<PathAwareTargetDepthRow>() : null;
 
             var initialPath = CompactVisitedPath.Create(seedNodeId);
             var stack = new Stack<(object? Node, int Depth, CompactVisitedPath Visited)>();
@@ -12546,7 +12546,7 @@ namespace UnifyWeaver.QueryRuntime
                     }
                     else
                     {
-                        RecordBufferedPathAwareDepthRow(bufferedRows!, seed, next, nextDepth);
+                        RecordBufferedPathAwareDepthRow(bufferedRows!, next, nextDepth);
                     }
 
                     var nextVisited = visited.Extend(nextId);
@@ -12559,7 +12559,7 @@ namespace UnifyWeaver.QueryRuntime
 
             if (bufferedRows is not null)
             {
-                MaterializePathAwareDepthRows(bufferedRows, output, metrics);
+                MaterializePathAwareDepthRows(seed, bufferedRows, output, metrics);
             }
 
             if (bestKnown is not null)
@@ -12585,16 +12585,16 @@ namespace UnifyWeaver.QueryRuntime
         }
 
         private static void RecordBufferedPathAwareDepthRow(
-            List<PathAwareDepthRow> rows,
-            object? seed,
+            List<PathAwareTargetDepthRow> rows,
             object? target,
             int depth)
         {
-            rows.Add(new PathAwareDepthRow(seed, target, depth));
+            rows.Add(new PathAwareTargetDepthRow(target, depth));
         }
 
         private static void MaterializePathAwareDepthRows(
-            List<PathAwareDepthRow> rows,
+            object? seed,
+            List<PathAwareTargetDepthRow> rows,
             ICollection<object[]> output,
             PathAwareTraversalMetrics? metrics)
         {
@@ -12608,7 +12608,7 @@ namespace UnifyWeaver.QueryRuntime
                 for (var i = 0; i < rows.Count; i++)
                 {
                     var row = rows[i];
-                    output.Add(new object[] { row.Seed!, row.Target!, row.Depth });
+                    output.Add(new object[] { seed!, row.Target!, row.Depth });
                     metrics?.RecordOutputRow();
                 }
 
@@ -12619,7 +12619,7 @@ namespace UnifyWeaver.QueryRuntime
             for (var i = 0; i < rows.Count; i++)
             {
                 var row = rows[i];
-                outputList.Add(new object[] { row.Seed!, row.Target!, row.Depth });
+                outputList.Add(new object[] { seed!, row.Target!, row.Depth });
                 metrics?.RecordOutputRow();
             }
 
@@ -14016,8 +14016,7 @@ namespace UnifyWeaver.QueryRuntime
             }
         }
 
-        private readonly record struct PathAwareDepthRow(
-            object? Seed,
+        private readonly record struct PathAwareTargetDepthRow(
             object? Target,
             int Depth);
 


### PR DESCRIPTION
  ## Summary

  - Changes counted path `All` buffering to store only `(target, depth)` per buffered row.
  - Reconstructs final `object[]` output rows with the current seed during materialization.
  - Preserves output order, output hashes, and existing `path_state_*` counters.
  - Updates benchmark/proposal docs with the measured reduction in counted-path `All` materialization cost.

  ## Why

  For counted path `All` mode, the buffered row shape still carried `seed`, `target`, and `depth` even though `seed` is constant for the entire per-seed traversal. That wasted buffer space and added
  unnecessary field traffic during final materialization.

  This change compacts the buffered row representation so the runtime holds only the data that actually varies per row.

  ## Results

  Local counted shortest-path benchmark:

  ```bash
  python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3
  ```
  | 1k | 0.306s | 0.149s | 2.06x | match |

  Counted-closure phase split:

  | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
  | --- | --- | ---: | ---: | ---: | ---: |
  | 300 | All | 165.620ms | 0.000ms | 76.569ms | n/a |
  | 300 | Min | 43.825ms | 0.000ms | 5.471ms | 12.509ms |
  | 1k | All | 97.050ms | 0.000ms | 35.733ms | n/a |
  | 1k | Min | 17.656ms | 0.000ms | 1.418ms | 5.662ms |

  ## Notes

  - This is a representation change only for buffered counted-path All rows.
  - Final output rows are still materialized as object[] { seed, target, depth }.
  - The optimization is exact: output hashes still match between All and Min.

  ## Validation

  - swipl -q -t run_tests tests/core/test_csharp_query_target.pl
  - python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py
  - git diff --check
  - python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3