### PR TITLE
perf(csharp-query): Link counted path visited states in the C# query runtime      

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -155,15 +155,16 @@ Local survey:
 | negative additive weighted `Min` | 1k | 0.563s | 1.217s | yes | `16,522,183` dominance candidates |
 
 Counted-closure phase split after typed row buffering, pre-sized
-materialization, edge-state node-id preindexing, per-row timing removal, and a
-compact `(target, depth)` buffered row shape:
+materialization, edge-state node-id preindexing, per-row timing removal, a
+compact `(target, depth)` buffered row shape, and O(1) parent-linked
+visited-path extension:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 165.620ms | 0.000ms | 76.569ms | n/a |
-| 300 | Min | 43.825ms | 0.000ms | 5.471ms | 12.509ms |
-| 1k | All | 97.050ms | 0.000ms | 35.733ms | n/a |
-| 1k | Min | 17.656ms | 0.000ms | 1.418ms | 5.662ms |
+| 300 | All | 147.247ms | 0.000ms | 64.580ms | n/a |
+| 300 | Min | 38.480ms | 0.000ms | 5.090ms | 11.550ms |
+| 1k | All | 64.303ms | 0.000ms | 52.634ms | n/a |
+| 1k | Min | 19.198ms | 0.000ms | 1.478ms | 5.629ms |
 
 Interpretation:
 
@@ -182,6 +183,10 @@ Interpretation:
 - the counted-path `All` buffer now stores only `(target, depth)` per row,
   because `seed` is constant for each per-seed traversal; this reduces buffer
   footprint and lowers final `object[]` materialization cost
+- `CompactVisitedPath.Extend` now uses a parent-linked immutable node instead
+  of copying the full visited-node array on every successor push, which
+  reduces traversal-time allocation/copy overhead while preserving exact
+  cycle checks and frontier semantics
 - weighted `Min` fallback remains the only measured shape where generic
   frontier candidate indexing is directly relevant
 - the next optimization should not add another generic frontier index by

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -324,15 +324,16 @@ raw path-state traversal:
 | counted shortest path | 1k | 0.450s | 0.180s | 2.50x | 352,522 | 10,328 | 592,698 | 38,196 |
 
 Counted-closure phase split after typed row buffering, pre-sized
-materialization, edge-state node-id preindexing, per-row timing removal, and a
-compact `(target, depth)` buffered row shape:
+materialization, edge-state node-id preindexing, per-row timing removal, a
+compact `(target, depth)` buffered row shape, and O(1) parent-linked
+visited-path extension:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 165.620ms | 0.000ms | 76.569ms | n/a |
-| 300 | Min | 43.825ms | 0.000ms | 5.471ms | 12.509ms |
-| 1k | All | 97.050ms | 0.000ms | 35.733ms | n/a |
-| 1k | Min | 17.656ms | 0.000ms | 1.418ms | 5.662ms |
+| 300 | All | 147.247ms | 0.000ms | 64.580ms | n/a |
+| 300 | Min | 38.480ms | 0.000ms | 5.090ms | 11.550ms |
+| 1k | All | 64.303ms | 0.000ms | 52.634ms | n/a |
+| 1k | Min | 19.198ms | 0.000ms | 1.478ms | 5.629ms |
 
 Interpretation:
 
@@ -364,6 +365,10 @@ Interpretation:
 - the counted-path `All` buffer now stores only `(target, depth)` per row,
   because `seed` is constant for each per-seed traversal; this reduces buffer
   footprint and lowers final `object[]` materialization cost
+- `CompactVisitedPath.Extend` now uses a parent-linked immutable node instead
+  of copying the full visited-node array on every successor push, which
+  reduces traversal-time allocation/copy overhead while preserving exact
+  cycle checks and frontier semantics
 - the next broad optimization should avoid adding more generic frontier indexes
   until another dominance-heavy fallback shape appears; for counted closure,
   remaining work should target expansion/materialization overhead

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -966,23 +966,23 @@ python examples/benchmark/benchmark_shortest_path_to_root.py \
     --scales 300,1k --repetitions 3
 ```
 
-Latest local results after compact visited paths, edge-state node-id
-preindexing, per-row timing removal, and a compact `(target, depth)` buffered
-row shape for counted path materialization:
+Latest local results after edge-state node-id preindexing, per-row timing
+removal, a compact `(target, depth)` buffered row shape, and O(1)
+parent-linked visited-path extension:
 
 | Scale | All | Min | Speedup | Output Match | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 |-------|----:|----:|--------:|--------------|----------------:|----------------:|-------------------------:|-------------------------:|
-| 300 | 0.439s | 0.179s | 2.45x | match | 602,808 | 30,968 | 982,581 | 101,371 |
-| 1k | 0.306s | 0.149s | 2.06x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+| 300 | 0.430s | 0.181s | 2.38x | match | 602,808 | 30,968 | 982,581 | 101,371 |
+| 1k | 0.270s | 0.132s | 2.05x | match | 352,522 | 10,328 | 592,698 | 38,196 |
 
 The same run reports the counted-closure phase split:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 |-------|------|----------:|-------------:|-----------------------:|----------------------:|
-| 300 | All | 165.620ms | 0.000ms | 76.569ms | n/a |
-| 300 | Min | 43.825ms | 0.000ms | 5.471ms | 12.509ms |
-| 1k | All | 97.050ms | 0.000ms | 35.733ms | n/a |
-| 1k | Min | 17.656ms | 0.000ms | 1.418ms | 5.662ms |
+| 300 | All | 147.247ms | 0.000ms | 64.580ms | n/a |
+| 300 | Min | 38.480ms | 0.000ms | 5.090ms | 11.550ms |
+| 1k | All | 64.303ms | 0.000ms | 52.634ms | n/a |
+| 1k | Min | 19.198ms | 0.000ms | 1.478ms | 5.629ms |
 
 Additional path-state observations:
 
@@ -1003,6 +1003,10 @@ Additional path-state observations:
 - the counted-path `All` buffer now stores only `(target, depth)` per row,
   because `seed` is constant for each per-seed traversal; this reduces buffer
   footprint and lowers final `object[]` materialization cost.
+- `CompactVisitedPath.Extend` now uses a parent-linked immutable node instead
+  of copying the full visited-node array on every successor push, which
+  reduces traversal-time allocation/copy overhead while preserving exact
+  cycle checks and frontier semantics.
 - This shape does not exercise the weighted `min_frontier_*` dominance
   candidate problem; generic frontier indexes would not address its primary
   cost. Further counted-closure work should target expansion/materialization

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -14026,11 +14026,13 @@ namespace UnifyWeaver.QueryRuntime
 
         private sealed class CompactVisitedPath
         {
-            private readonly int[] _nodeIds;
+            private readonly CompactVisitedPath? _previous;
+            private readonly int _nodeId;
 
-            private CompactVisitedPath(int[] nodeIds, int count, ulong maskA, ulong maskB, ulong fingerprint)
+            private CompactVisitedPath(CompactVisitedPath? previous, int nodeId, int count, ulong maskA, ulong maskB, ulong fingerprint)
             {
-                _nodeIds = nodeIds;
+                _previous = previous;
+                _nodeId = nodeId;
                 Count = count;
                 MaskA = maskA;
                 MaskB = maskB;
@@ -14047,13 +14049,26 @@ namespace UnifyWeaver.QueryRuntime
 
             public int GetNodeId(int index)
             {
-                return _nodeIds[index];
+                if ((uint)index >= (uint)Count)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                var steps = Count - 1 - index;
+                var current = this;
+                for (var i = 0; i < steps; i++)
+                {
+                    current = current._previous!;
+                }
+
+                return current._nodeId;
             }
 
             public static CompactVisitedPath Create(int nodeId)
             {
                 return new CompactVisitedPath(
-                    new[] { nodeId },
+                    previous: null,
+                    nodeId: nodeId,
                     1,
                     ComputeVisitedMaskA(nodeId),
                     ComputeVisitedMaskB(nodeId),
@@ -14074,9 +14089,9 @@ namespace UnifyWeaver.QueryRuntime
                     return false;
                 }
 
-                for (var i = 0; i < Count; i++)
+                for (var current = this; current is not null; current = current._previous)
                 {
-                    if (_nodeIds[i] == nodeId)
+                    if (current._nodeId == nodeId)
                     {
                         return true;
                     }
@@ -14087,11 +14102,9 @@ namespace UnifyWeaver.QueryRuntime
 
             public CompactVisitedPath Extend(int nodeId)
             {
-                var nodeIds = new int[Count + 1];
-                Array.Copy(_nodeIds, nodeIds, Count);
-                nodeIds[Count] = nodeId;
                 return new CompactVisitedPath(
-                    nodeIds,
+                    this,
+                    nodeId,
                     Count + 1,
                     MaskA | ComputeVisitedMaskA(nodeId),
                     MaskB | ComputeVisitedMaskB(nodeId),
@@ -14110,20 +14123,9 @@ namespace UnifyWeaver.QueryRuntime
                     return false;
                 }
 
-                for (var i = 0; i < Count; i++)
+                for (var current = this; current is not null; current = current._previous)
                 {
-                    var found = false;
-                    var value = _nodeIds[i];
-                    for (var j = 0; j < other.Count; j++)
-                    {
-                        if (value == other._nodeIds[j])
-                        {
-                            found = true;
-                            break;
-                        }
-                    }
-
-                    if (!found)
+                    if (!other.Contains(current._nodeId))
                     {
                         return false;
                     }


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                 
                                                                                                                                                                                                            
 - Replaces counted-path `CompactVisitedPath` array-copy extension with a parent-linked immutable representation.                                                                                           
 - Keeps the existing visited-path API surface used by counted traversal and weighted frontier logic:                                                                                                       
   - `Contains`                                                                                                                                                                                             
   - `GetNodeId`                                                                                                                                                                                            
   - `IsSubsetOf`                                                                                                                                                                                           
   - mask and fingerprint metadata                                                                                                                                                                          
 - Preserves output order, output hashes, and existing `path_state_*` counters.                                                                                                                             
 - Updates benchmark/proposal docs with the measured traversal reduction after removing full-array copy on each successor push.                                                                             
                                                                                                                                                                                                            
 ## Why                                                                                                                                                                                                     
                                                                                                                                                                                                            
 The counted-path hot loop still paid for `CompactVisitedPath.Extend(nextId)` by allocating and copying the entire visited-node array for every pushed successor state.                                     
                                                                                                                                                                                                            
 That is the wrong cost shape for this workload. The path extension operation only needs to add one node to an immutable chain. This change makes extension O(1) allocation instead of O(path length) array 
 copy.                                                                                                                                                                                                      
                                                                                                                                                                                                            
 ## Results                                                                                                                                                                                                 
                                                                                                                                                                                                            
 Local counted shortest-path benchmark:                                                                                                                                                                     
                                                                                                                                                                                                            
 ```bash                                                                                                                                                                                                    
 python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3                                                                                                              
 ```                                                                                                                                                                                  
 | Scale | All | Min | Speedup | Output Match |                                                                                                                                                             
 | --- | ---: | ---: | ---: | --- |                                                                                                                                                                         
 | 300 | 0.430s | 0.181s | 2.38x | match |                                                                                                                                                                  
 | 1k | 0.270s | 0.132s | 2.05x | match |                                                                                                                                                                   
                                                                                                                                                                                                            
 Counted-closure phase split:                                                                                                                                                                               
                                                                                                                                                                                                            
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |                                                                                                               
 | --- | --- | ---: | ---: | ---: | ---: |                                                                                                                                                                  
 | 300 | All | 147.247ms | 0.000ms | 64.580ms | n/a |                                                                                                                                                       
 | 300 | Min | 38.480ms | 0.000ms | 5.090ms | 11.550ms |                                                                                                                                                    
 | 1k | All | 64.303ms | 0.000ms | 52.634ms | n/a |                                                                                                                                                         
 | 1k | Min | 19.198ms | 0.000ms | 1.478ms | 5.629ms |                                                                                                                                                      
                                                                                                                                                                                                            
 ## Notes                                                                                                                                                                                                   
                                                                                                                                                                                                            
 - CompactVisitedPath.Extend is now O(1) allocation.                                                                                                                                                        
 - Exact cycle detection is preserved through the existing mask checks plus linked-path membership walk.                                                                                                    
 - Weighted fallback/frontier code still sees the same external path behavior, including representative-node selection and subset checks.                                                                   
                                                                                                                                                                                                            
 ## Validation                                                                                                                                                                                              
                                                                                                                                                                                                            
 - swipl -q -t run_tests tests/core/test_csharp_query_target.pl                                                                                                                                             
 - python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py                                                                                                                              
 - git diff --check                                                                                                                                                                                         
 - python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3                                                                                                            