### PR TITLE
perf(csharp-query): Tune counted path traversal stack in the C# query runtime

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -156,15 +156,15 @@ Local survey:
 
 Counted-closure phase split after typed row buffering, pre-sized
 materialization, edge-state node-id preindexing, per-row timing removal, a
-compact `(target, depth)` buffered row shape, and O(1) parent-linked
-visited-path extension:
+compact `(target, depth)` buffered row shape, O(1) parent-linked
+visited-path extension, and a dedicated counted-path traversal frame stack:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 147.247ms | 0.000ms | 64.580ms | n/a |
-| 300 | Min | 38.480ms | 0.000ms | 5.090ms | 11.550ms |
-| 1k | All | 64.303ms | 0.000ms | 52.634ms | n/a |
-| 1k | Min | 19.198ms | 0.000ms | 1.478ms | 5.629ms |
+| 300 | All | 133.261ms | 0.000ms | 81.388ms | n/a |
+| 300 | Min | 44.482ms | 0.000ms | 5.550ms | 12.525ms |
+| 1k | All | 58.902ms | 0.000ms | 48.229ms | n/a |
+| 1k | Min | 15.291ms | 0.000ms | 1.277ms | 4.789ms |
 
 Interpretation:
 
@@ -187,6 +187,9 @@ Interpretation:
   of copying the full visited-node array on every successor push, which
   reduces traversal-time allocation/copy overhead while preserving exact
   cycle checks and frontier semantics
+- counted-path traversal now uses a dedicated frame struct and an explicit
+  initial stack capacity, which trims hot-path stack overhead without changing
+  the reported `path_state_*` counters
 - weighted `Min` fallback remains the only measured shape where generic
   frontier candidate indexing is directly relevant
 - the next optimization should not add another generic frontier index by

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -325,15 +325,15 @@ raw path-state traversal:
 
 Counted-closure phase split after typed row buffering, pre-sized
 materialization, edge-state node-id preindexing, per-row timing removal, a
-compact `(target, depth)` buffered row shape, and O(1) parent-linked
-visited-path extension:
+compact `(target, depth)` buffered row shape, O(1) parent-linked
+visited-path extension, and a dedicated counted-path traversal frame stack:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 147.247ms | 0.000ms | 64.580ms | n/a |
-| 300 | Min | 38.480ms | 0.000ms | 5.090ms | 11.550ms |
-| 1k | All | 64.303ms | 0.000ms | 52.634ms | n/a |
-| 1k | Min | 19.198ms | 0.000ms | 1.478ms | 5.629ms |
+| 300 | All | 133.261ms | 0.000ms | 81.388ms | n/a |
+| 300 | Min | 44.482ms | 0.000ms | 5.550ms | 12.525ms |
+| 1k | All | 58.902ms | 0.000ms | 48.229ms | n/a |
+| 1k | Min | 15.291ms | 0.000ms | 1.277ms | 4.789ms |
 
 Interpretation:
 
@@ -369,6 +369,9 @@ Interpretation:
   of copying the full visited-node array on every successor push, which
   reduces traversal-time allocation/copy overhead while preserving exact
   cycle checks and frontier semantics
+- counted-path traversal now uses a dedicated frame struct and an explicit
+  initial stack capacity, which trims hot-path stack overhead without changing
+  the reported `path_state_*` counters
 - the next broad optimization should avoid adding more generic frontier indexes
   until another dominance-heavy fallback shape appears; for counted closure,
   remaining work should target expansion/materialization overhead

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -967,22 +967,23 @@ python examples/benchmark/benchmark_shortest_path_to_root.py \
 ```
 
 Latest local results after edge-state node-id preindexing, per-row timing
-removal, a compact `(target, depth)` buffered row shape, and O(1)
-parent-linked visited-path extension:
+removal, a compact `(target, depth)` buffered row shape, O(1)
+parent-linked visited-path extension, and a dedicated counted-path traversal
+frame stack with explicit initial capacity:
 
 | Scale | All | Min | Speedup | Output Match | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 |-------|----:|----:|--------:|--------------|----------------:|----------------:|-------------------------:|-------------------------:|
-| 300 | 0.430s | 0.181s | 2.38x | match | 602,808 | 30,968 | 982,581 | 101,371 |
-| 1k | 0.270s | 0.132s | 2.05x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+| 300 | 0.408s | 0.170s | 2.40x | match | 602,808 | 30,968 | 982,581 | 101,371 |
+| 1k | 0.272s | 0.127s | 2.14x | match | 352,522 | 10,328 | 592,698 | 38,196 |
 
 The same run reports the counted-closure phase split:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 |-------|------|----------:|-------------:|-----------------------:|----------------------:|
-| 300 | All | 147.247ms | 0.000ms | 64.580ms | n/a |
-| 300 | Min | 38.480ms | 0.000ms | 5.090ms | 11.550ms |
-| 1k | All | 64.303ms | 0.000ms | 52.634ms | n/a |
-| 1k | Min | 19.198ms | 0.000ms | 1.478ms | 5.629ms |
+| 300 | All | 133.261ms | 0.000ms | 81.388ms | n/a |
+| 300 | Min | 44.482ms | 0.000ms | 5.550ms | 12.525ms |
+| 1k | All | 58.902ms | 0.000ms | 48.229ms | n/a |
+| 1k | Min | 15.291ms | 0.000ms | 1.277ms | 4.789ms |
 
 Additional path-state observations:
 
@@ -1007,6 +1008,9 @@ Additional path-state observations:
   of copying the full visited-node array on every successor push, which
   reduces traversal-time allocation/copy overhead while preserving exact
   cycle checks and frontier semantics.
+- counted-path traversal now uses a dedicated frame struct and an explicit
+  initial stack capacity, which trims hot-path stack overhead without changing
+  the reported `path_state_*` counters.
 - This shape does not exercise the weighted `min_frontier_*` dominance
   candidate problem; generic frontier indexes would not address its primary
   cost. Further counted-closure work should target expansion/materialization

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -12478,15 +12478,21 @@ namespace UnifyWeaver.QueryRuntime
             var bufferedRows = preserveAllPaths ? new List<PathAwareTargetDepthRow>() : null;
 
             var initialPath = CompactVisitedPath.Create(seedNodeId);
-            var stack = new Stack<(object? Node, int Depth, CompactVisitedPath Visited)>();
-            stack.Push((seed, 0, initialPath));
+            var initialStackCapacity = maxDepth > 0
+                ? Math.Min(Math.Max(maxDepth + 1, 4), 256)
+                : 64;
+            var stack = new Stack<PathAwareTraversalFrame>(initialStackCapacity);
+            stack.Push(new PathAwareTraversalFrame(seed, 0, initialPath));
             metrics?.RecordEnqueuedState(1);
             metrics?.RecordStackSize(stack.Count);
 
             var traversalStarted = Stopwatch.GetTimestamp();
             while (stack.Count > 0)
             {
-                var (current, depth, visited) = stack.Pop();
+                var frame = stack.Pop();
+                var current = frame.Node;
+                var depth = frame.Depth;
+                var visited = frame.Visited;
                 metrics?.RecordStackPop();
                 metrics?.RecordPathLength(visited.Count);
                 var lookupKey = current ?? NullFactIndexKey;
@@ -12550,7 +12556,7 @@ namespace UnifyWeaver.QueryRuntime
                     }
 
                     var nextVisited = visited.Extend(nextId);
-                    stack.Push((next, nextDepth, nextVisited));
+                    stack.Push(new PathAwareTraversalFrame(next, nextDepth, nextVisited));
                     metrics?.RecordEnqueuedState(nextVisited.Count);
                     metrics?.RecordStackSize(stack.Count);
                 }
@@ -14019,6 +14025,11 @@ namespace UnifyWeaver.QueryRuntime
         private readonly record struct PathAwareTargetDepthRow(
             object? Target,
             int Depth);
+
+        private readonly record struct PathAwareTraversalFrame(
+            object? Node,
+            int Depth,
+            CompactVisitedPath Visited);
 
         private sealed record VisitedAccumulatorState(
             object Accumulator,


### PR DESCRIPTION
  ## Summary

  - Replaces the counted-path traversal stack’s ad hoc tuple payload with a dedicated frame struct.
  - Gives the counted-path traversal stack an explicit initial capacity derived from the depth setting.
  - Preserves output order, output hashes, and existing `path_state_*` counters.
  - Updates benchmark/proposal docs with the measured traversal reduction after the stack hot-path cleanup.

  ## Why

  After the visited-path and materialization improvements, counted-path `All` mode was still spending most of its remaining time in traversal. One remaining hot-path cost was the traversal stack shape itself.

  This change makes that stack path more explicit and cheaper without changing the traversal algorithm or metric semantics.

  ## Results

  Local counted shortest-path benchmark:

  ```bash
  python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3
  ```
  | Scale | All | Min | Speedup | Output Match |
  | --- | ---: | ---: | ---: | --- |
  | 300 | 0.408s | 0.170s | 2.40x | match |
  | 1k | 0.272s | 0.127s | 2.14x | match |

  Counted-closure phase split:

  | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
  | --- | --- | ---: | ---: | ---: | ---: |
  | 300 | All | 133.261ms | 0.000ms | 81.388ms | n/a |
  | 300 | Min | 44.482ms | 0.000ms | 5.550ms | 12.525ms |
  | 1k | All | 58.902ms | 0.000ms | 48.229ms | n/a |
  | 1k | Min | 15.291ms | 0.000ms | 1.277ms | 4.789ms |

  ## Notes

  - This is a traversal hot-path cleanup, not a semantic change.
  - The reported traversal counters remain stable:
      - path_state_seed_count
      - path_state_stack_pop_count
      - path_state_successor_candidate_count
      - path_state_cycle_skip_count
      - path_state_depth_skip_count
      - path_state_best_known_prune_count
      - path_state_enqueued_state_count
      - path_state_output_row_count
      - path_state_max_stack_size
      - path_state_max_path_length

  ## Validation

  - swipl -q -t run_tests tests/core/test_csharp_query_target.pl
  - python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py
  - git diff --check
  - python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3