### PR TITLE
perf(csharp-query): Batch counted path seed output in the C# query runtime

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -157,14 +157,15 @@ Local survey:
 Counted-closure phase split after typed row buffering, pre-sized
 materialization, edge-state node-id preindexing, per-row timing removal, a
 compact `(target, depth)` buffered row shape, O(1) parent-linked
-visited-path extension, and a dedicated counted-path traversal frame stack:
+visited-path extension, a dedicated counted-path traversal frame stack, and
+direct-write seed-batch materialization:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 133.261ms | 0.000ms | 81.388ms | n/a |
-| 300 | Min | 44.482ms | 0.000ms | 5.550ms | 12.525ms |
-| 1k | All | 58.902ms | 0.000ms | 48.229ms | n/a |
-| 1k | Min | 15.291ms | 0.000ms | 1.277ms | 4.789ms |
+| 300 | All | 136.668ms | 0.000ms | 78.053ms | n/a |
+| 300 | Min | 46.030ms | 0.000ms | 5.568ms | 12.685ms |
+| 1k | All | 58.924ms | 0.000ms | 48.248ms | n/a |
+| 1k | Min | 15.563ms | 0.000ms | 1.312ms | 4.921ms |
 
 Interpretation:
 
@@ -190,6 +191,10 @@ Interpretation:
 - counted-path traversal now uses a dedicated frame struct and an explicit
   initial stack capacity, which trims hot-path stack overhead without changing
   the reported `path_state_*` counters
+- when the destination is a `List<object[]>`, counted-path `All` materialization
+  now grows the list once and writes the new seed batch directly into the new
+  slots via `CollectionsMarshal`, avoiding per-row `Add` bookkeeping on the
+  final output path
 - weighted `Min` fallback remains the only measured shape where generic
   frontier candidate indexing is directly relevant
 - the next optimization should not add another generic frontier index by

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -326,14 +326,15 @@ raw path-state traversal:
 Counted-closure phase split after typed row buffering, pre-sized
 materialization, edge-state node-id preindexing, per-row timing removal, a
 compact `(target, depth)` buffered row shape, O(1) parent-linked
-visited-path extension, and a dedicated counted-path traversal frame stack:
+visited-path extension, a dedicated counted-path traversal frame stack, and
+direct-write seed-batch materialization:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 133.261ms | 0.000ms | 81.388ms | n/a |
-| 300 | Min | 44.482ms | 0.000ms | 5.550ms | 12.525ms |
-| 1k | All | 58.902ms | 0.000ms | 48.229ms | n/a |
-| 1k | Min | 15.291ms | 0.000ms | 1.277ms | 4.789ms |
+| 300 | All | 136.668ms | 0.000ms | 78.053ms | n/a |
+| 300 | Min | 46.030ms | 0.000ms | 5.568ms | 12.685ms |
+| 1k | All | 58.924ms | 0.000ms | 48.248ms | n/a |
+| 1k | Min | 15.563ms | 0.000ms | 1.312ms | 4.921ms |
 
 Interpretation:
 
@@ -372,6 +373,10 @@ Interpretation:
 - counted-path traversal now uses a dedicated frame struct and an explicit
   initial stack capacity, which trims hot-path stack overhead without changing
   the reported `path_state_*` counters
+- when the destination is a `List<object[]>`, counted-path `All` materialization
+  now grows the list once and writes the new seed batch directly into the new
+  slots via `CollectionsMarshal`, avoiding per-row `Add` bookkeeping on the
+  final output path
 - the next broad optimization should avoid adding more generic frontier indexes
   until another dominance-heavy fallback shape appears; for counted closure,
   remaining work should target expansion/materialization overhead

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -969,21 +969,22 @@ python examples/benchmark/benchmark_shortest_path_to_root.py \
 Latest local results after edge-state node-id preindexing, per-row timing
 removal, a compact `(target, depth)` buffered row shape, O(1)
 parent-linked visited-path extension, and a dedicated counted-path traversal
-frame stack with explicit initial capacity:
+frame stack with explicit initial capacity, plus direct-write seed-batch
+materialization into the destination output list:
 
 | Scale | All | Min | Speedup | Output Match | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 |-------|----:|----:|--------:|--------------|----------------:|----------------:|-------------------------:|-------------------------:|
-| 300 | 0.408s | 0.170s | 2.40x | match | 602,808 | 30,968 | 982,581 | 101,371 |
-| 1k | 0.272s | 0.127s | 2.14x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+| 300 | 0.404s | 0.168s | 2.40x | match | 602,808 | 30,968 | 982,581 | 101,371 |
+| 1k | 0.262s | 0.133s | 1.97x | match | 352,522 | 10,328 | 592,698 | 38,196 |
 
 The same run reports the counted-closure phase split:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 |-------|------|----------:|-------------:|-----------------------:|----------------------:|
-| 300 | All | 133.261ms | 0.000ms | 81.388ms | n/a |
-| 300 | Min | 44.482ms | 0.000ms | 5.550ms | 12.525ms |
-| 1k | All | 58.902ms | 0.000ms | 48.229ms | n/a |
-| 1k | Min | 15.291ms | 0.000ms | 1.277ms | 4.789ms |
+| 300 | All | 136.668ms | 0.000ms | 78.053ms | n/a |
+| 300 | Min | 46.030ms | 0.000ms | 5.568ms | 12.685ms |
+| 1k | All | 58.924ms | 0.000ms | 48.248ms | n/a |
+| 1k | Min | 15.563ms | 0.000ms | 1.312ms | 4.921ms |
 
 Additional path-state observations:
 
@@ -1011,6 +1012,10 @@ Additional path-state observations:
 - counted-path traversal now uses a dedicated frame struct and an explicit
   initial stack capacity, which trims hot-path stack overhead without changing
   the reported `path_state_*` counters.
+- when the destination is a `List<object[]>`, counted-path `All` materialization
+  now grows the list once and writes the new seed batch directly into the new
+  slots via `CollectionsMarshal`, avoiding per-row `Add` bookkeeping on the
+  final output path.
 - This shape does not exercise the weighted `min_frontier_*` dominance
   candidate problem; generic frontier indexes would not address its primary
   cost. Further counted-closure work should target expansion/materialization

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Text.Json;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -12607,17 +12608,15 @@ namespace UnifyWeaver.QueryRuntime
             var started = Stopwatch.GetTimestamp();
             if (output is List<object[]> outputList)
             {
-                outputList.EnsureCapacity(outputList.Count + rows.Count);
-            }
-            else
-            {
+                var baseIndex = outputList.Count;
+                CollectionsMarshal.SetCount(outputList, baseIndex + rows.Count);
+                var span = CollectionsMarshal.AsSpan(outputList);
                 for (var i = 0; i < rows.Count; i++)
                 {
                     var row = rows[i];
-                    output.Add(new object[] { seed!, row.Target!, row.Depth });
+                    span[baseIndex + i] = new object[] { seed!, row.Target!, row.Depth };
                     metrics?.RecordOutputRow();
                 }
-
                 metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(started));
                 return;
             }
@@ -12625,7 +12624,7 @@ namespace UnifyWeaver.QueryRuntime
             for (var i = 0; i < rows.Count; i++)
             {
                 var row = rows[i];
-                outputList.Add(new object[] { seed!, row.Target!, row.Depth });
+                output.Add(new object[] { seed!, row.Target!, row.Depth });
                 metrics?.RecordOutputRow();
             }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                    
                                                                                                                                                                                                               
 - Optimizes counted path `All` materialization for `List<object[]>` outputs.                                                                                                                                  
 - Reserves the destination list once per seed batch and writes the new rows directly into the new slots via `CollectionsMarshal`.                                                                             
 - Preserves output order, output hashes, and existing `path_state_*` counters.                                                                                                                                
 - Updates benchmark/proposal docs with the measured per-seed output-path results.                                                                                                                             
                                                                                                                                                                                                               
 ## Why                                                                                                                                                                                                        
                                                                                                                                                                                                               
 After the traversal and buffer-shape work, counted path `All` still spent a meaningful amount of time in final per-seed output materialization. The remaining work was mostly on the destination write path.  
                                                                                                                                                                                                               
 This change keeps the same buffered row representation and final `object[]` shape, but removes per-row `List.Add` bookkeeping when the output target is already a `List<object[]>`.                           
                                                                                                                                                                                                               
 ## Results                                                                                                                                                                                                    
                                                                                                                                                                                                               
 Local counted shortest-path benchmark:                                                                                                                                                                        
                                                                                                                                                                                                               
 ```bash                                                                                                                                                                                                       
 python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3                                                                                                                 
 ```                                                                                                                                                                                                  
 | Scale | All | Min | Speedup | Output Match |                                                                                                                                                                
 | --- | ---: | ---: | ---: | --- |                                                                                                                                                                            
 | 300 | 0.404s | 0.168s | 2.40x | match |                                                                                                                                                                     
 | 1k | 0.262s | 0.133s | 1.97x | match |                                                                                                                                                                      
                                                                                                                                                                                                               
 Counted-closure phase split:                                                                                                                                                                                  
                                                                                                                                                                                                               
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |                                                                                                                  
 | --- | --- | ---: | ---: | ---: | ---: |                                                                                                                                                                     
 | 300 | All | 136.668ms | 0.000ms | 78.053ms | n/a |                                                                                                                                                          
 | 300 | Min | 46.030ms | 0.000ms | 5.568ms | 12.685ms |                                                                                                                                                       
 | 1k | All | 58.924ms | 0.000ms | 48.248ms | n/a |                                                                                                                                                            
 | 1k | Min | 15.563ms | 0.000ms | 1.312ms | 4.921ms |                                                                                                                                                         
                                                                                                                                                                                                               
 ## Notes                                                                                                                                                                                                      
                                                                                                                                                                                                               
 - This is a destination-write optimization only.                                                                                                                                                              
 - Final rows are still materialized as object[] { seed, target, depth }.                                                                                                                                      
 - The optimization applies only when the destination is a List<object[]>; other ICollection<object[]> targets keep the existing fallback path.                                                                
                                                                                                                                                                                                               
 ## Validation                                                                                                                                                                                                 
                                                                                                                                                                                                               
 - swipl -q -t run_tests tests/core/test_csharp_query_target.pl                                                                                                                                                
 - python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py                                                                                                                                 
 - git diff --check                                                                                                                                                                                            
 - python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3                                                                                                               
                                                                                                                                                                                                               