### PR TITLE
test(wam-go): tighten weighted and astar semantics

### DIFF
--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -434,6 +434,9 @@ go_foreign_setup_line(register_foreign_usize_config(Pred/Arity, Key, Value), Lin
 go_foreign_setup_line(register_indexed_atom_fact2(Pred/Arity, Pairs), Line) :-
     go_fact_pairs_literal(Pairs, Literal),
     format(atom(Line), '    vm.registerIndexedAtomFact2Pairs("~w/~w", []AtomPair{~w})', [Pred, Arity, Literal]).
+go_foreign_setup_line(register_indexed_weighted_edge(Pred/Arity, Triples), Line) :-
+    go_fact_triples_literal(Triples, Literal),
+    format(atom(Line), '    vm.registerIndexedWeightedEdgeTriples("~w/~w", []WeightedEdgeTriple{~w})', [Pred, Arity, Literal]).
 
 go_fact_pairs_literal(Pairs, Literal) :-
     maplist(go_fact_pair_literal, Pairs, PairLiterals),
@@ -441,6 +444,13 @@ go_fact_pairs_literal(Pairs, Literal) :-
 
 go_fact_pair_literal(Left-Right, Literal) :-
     format(atom(Literal), '{Left: "~w", Right: "~w"}', [Left, Right]).
+
+go_fact_triples_literal(Triples, Literal) :-
+    maplist(go_fact_triple_literal, Triples, TripleLiterals),
+    atomic_list_concat(TripleLiterals, ', ', Literal).
+
+go_fact_triple_literal(Left-Right-Weight, Literal) :-
+    format(atom(Literal), '{Left: "~w", Right: "~w", Weight: ~15g}', [Left, Right, Weight]).
 
 capitalize_atom(Atom, Cap) :-
     atom_codes(Atom, [First|Rest]),
@@ -464,21 +474,30 @@ go_recursive_kernel(_Module, Pred, Arity, Clauses, recursive_kernel(list_suffix2
     go_foreign_lowerable_list_suffix(Pred, Arity, Clauses).
 go_recursive_kernel(_Module, Pred, Arity, Clauses, recursive_kernel(list_suffixes2, Pred/Arity, [])) :-
     go_foreign_lowerable_list_suffixes(Pred, Arity, Clauses).
+go_recursive_kernel(Module, Pred, Arity, Clauses,
+        recursive_kernel(weighted_shortest_path3, Pred/Arity,
+            [weight_pred(WeightPred/3), fact_triples(FactTriples)])) :-
+    go_foreign_lowerable_weighted_shortest_path(Module, Pred, Arity, Clauses, WeightPred/3, FactTriples).
+go_recursive_kernel(Module, Pred, Arity, Clauses, Kernel) :-
+    go_foreign_lowerable_astar_shortest_path(Module, Pred, Arity, Clauses, Kernel).
 go_recursive_kernel(Module, Pred, Arity, Clauses, Kernel) :-
     detect_recursive_kernel(Pred, Arity, Clauses, Kernel0),
     go_supported_shared_kernel(Kernel0),
     go_recursive_kernel_with_facts(Module, Kernel0, Kernel).
 
 go_supported_shared_kernel(recursive_kernel(transitive_closure2, _, _)).
-
+go_supported_shared_kernel(recursive_kernel(transitive_distance3, _, _)).
+go_supported_shared_kernel(recursive_kernel(transitive_parent_distance4, _, _)).
+go_supported_shared_kernel(recursive_kernel(transitive_step_parent_distance5, _, _)).
 go_recursive_kernel_with_facts(Module,
-        recursive_kernel(transitive_closure2, PredIndicator, KernelConfig0),
-        recursive_kernel(transitive_closure2, PredIndicator,
+        recursive_kernel(KernelKind, PredIndicator, KernelConfig0),
+        recursive_kernel(KernelKind, PredIndicator,
             [edge_pred(EdgePred/2), fact_pairs(FactPairs)])) :-
+    member(KernelKind, [transitive_closure2, transitive_distance3,
+        transitive_parent_distance4, transitive_step_parent_distance5]),
     member(edge_pred(EdgePred/2), KernelConfig0),
     go_binary_edge_fact_pairs(Module, EdgePred/2, FactPairs),
     FactPairs \= [].
-
 go_recursive_kernel_spec(recursive_kernel(KernelKind, PredIndicator, KernelConfig),
         SetupOps, RewriteCalls, PredIndicator) :-
     go_recursive_kernel_setup_ops(KernelKind, PredIndicator, KernelConfig, SetupOps),
@@ -495,6 +514,7 @@ go_recursive_kernel_setup_ops(KernelKind, PredIndicator, KernelConfig,
 go_recursive_kernel_metadata(countdown_sum2, _KernelConfig, countdown_sum2, tuple(1), deterministic).
 go_recursive_kernel_metadata(list_suffix2, _KernelConfig, list_suffix2, tuple(1), stream).
 go_recursive_kernel_metadata(list_suffixes2, _KernelConfig, list_suffixes2, tuple(1), deterministic_collection).
+go_recursive_kernel_metadata(astar_shortest_path4, _KernelConfig, astar_shortest_path4, tuple(1), stream).
 go_recursive_kernel_metadata(KernelKind, KernelConfig, NativeKind, ResultLayout, ResultMode) :-
     kernel_metadata(recursive_kernel(KernelKind, _PredIndicator, KernelConfig),
         NativeKind, ResultLayout, ResultMode).
@@ -503,6 +523,27 @@ go_recursive_kernel_config_ops(_PredIndicator, [], []).
 go_recursive_kernel_config_ops(PredIndicator, [edge_pred(EdgePred/2), fact_pairs(FactPairs)], [
         register_foreign_string_config(PredIndicator, edge_pred, EdgePred/2),
         register_indexed_atom_fact2(EdgePred/2, FactPairs)
+    ]).
+go_recursive_kernel_config_ops(PredIndicator, [weight_pred(WeightPred/3), fact_triples(FactTriples)], [
+        register_foreign_string_config(PredIndicator, weight_pred, WeightPred/3),
+        register_indexed_weighted_edge(WeightPred/3, FactTriples)
+    ]).
+go_recursive_kernel_config_ops(PredIndicator,
+        [weight_pred(WeightPred/3), fact_triples(FactTriples),
+         direct_dist_pred(DirectPred/3), direct_triples(DirectTriples),
+         dimensionality(Dim)], [
+        register_foreign_string_config(PredIndicator, weight_pred, WeightPred/3),
+        register_indexed_weighted_edge(WeightPred/3, FactTriples),
+        register_foreign_string_config(PredIndicator, direct_dist_pred, DirectPred/3),
+        register_indexed_weighted_edge(DirectPred/3, DirectTriples),
+        register_foreign_usize_config(PredIndicator, dimensionality, Dim)
+    ]).
+go_recursive_kernel_config_ops(PredIndicator,
+        [weight_pred(WeightPred/3), fact_triples(FactTriples),
+         dimensionality(Dim)], [
+        register_foreign_string_config(PredIndicator, weight_pred, WeightPred/3),
+        register_indexed_weighted_edge(WeightPred/3, FactTriples),
+        register_foreign_usize_config(PredIndicator, dimensionality, Dim)
     ]).
 
 go_binary_edge_fact_pairs(Module, EdgePred/2, FactPairs) :-
@@ -514,6 +555,17 @@ go_binary_edge_fact_pairs(Module, EdgePred/2, FactPairs) :-
           atom(Right)
         ),
         FactPairs).
+
+go_weighted_edge_fact_triples(Module, WeightPred/3, FactTriples) :-
+    findall(Left-Right-Weight,
+        ( functor(WeightHead, WeightPred, 3),
+          Module:clause(WeightHead, true),
+          WeightHead =.. [WeightPred, Left, Right, Weight],
+          atom(Left),
+          atom(Right),
+          number(Weight)
+        ),
+        FactTriples).
 
 go_foreign_lowerable_countdown_sum(Pred, 2, Clauses) :-
     member(BaseHead-true, Clauses),
@@ -545,6 +597,80 @@ go_foreign_lowerable_list_suffixes(Pred, 2, Clauses) :-
     BaseHead =.. [Pred, [], [[]]],
     RecHead =.. [Pred, [Head|Tail], [[Head|Tail]|Rest]],
     RecBody =.. [Pred, Tail, Rest].
+
+go_foreign_lowerable_weighted_shortest_path(Module, Pred, 3, Clauses, WeightPred/3, FactTriples) :-
+    member(BaseHead-BaseBody, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseHead \== RecHead,
+    BaseHead =.. [Pred, BaseStart, BaseTarget, BaseWeight],
+    BaseBody =.. [WeightPred, BaseStart, BaseTarget, BaseWeight],
+    RecHead =.. [Pred, RecStart, RecTarget, RecCost],
+    go_extract_weighted_rec_body(Pred, WeightPred, RecStart, RecTarget, RecCost, RecBody),
+    go_weighted_edge_fact_triples(Module, WeightPred/3, FactTriples),
+    FactTriples \= [].
+
+go_extract_weighted_rec_body(Pred, WeightPred, Start, Target, Cost, Body) :-
+    Body = (WeightGoal, (RecGoal, IsGoal)),
+    WeightGoal =.. [WeightPred, Start, Mid, W],
+    RecGoal =.. [Pred, Mid, Target, RestCost],
+    IsGoal =.. [is, Cost, PlusExpr],
+    (   PlusExpr =.. [+, W, RestCost]
+    ;   PlusExpr =.. [+, RestCost, W]
+    ),
+    !.
+go_extract_weighted_rec_body(Pred, WeightPred, Start, Target, Cost, Body) :-
+    Body = (WeightGoal, (NegGoal, (RecGoal, IsGoal))),
+    WeightGoal =.. [WeightPred, Start, Mid, W],
+    NegGoal = (\+ _),
+    RecGoal =.. [Pred, Mid, Target, RestCost],
+    IsGoal =.. [is, Cost, PlusExpr],
+    (   PlusExpr =.. [+, W, RestCost]
+    ;   PlusExpr =.. [+, RestCost, W]
+    ),
+    !.
+
+go_foreign_lowerable_astar_shortest_path(Module, Pred, 4, Clauses,
+        recursive_kernel(astar_shortest_path4, Pred/4, KernelConfig)) :-
+    member(BaseHead-BaseBody, Clauses),
+    member(RecHead-RecBody, Clauses),
+    BaseHead \== RecHead,
+    BaseHead =.. [Pred, BaseStart, BaseTarget, _BaseDim, BaseWeight],
+    BaseBody =.. [WeightPred, BaseStart, BaseTarget, BaseWeight],
+    RecHead =.. [Pred, RecStart, RecTarget, RecDim, RecCost],
+    RecBody = (WeightGoal, (RecGoal, IsGoal)),
+    WeightGoal =.. [WeightPred, RecStart, Mid, W],
+    RecGoal =.. [Pred, Mid, RecTarget, RecDim, RestCost],
+    IsGoal =.. [is, RecCost, PlusExpr],
+    (   PlusExpr =.. [+, W, RestCost]
+    ;   PlusExpr =.. [+, RestCost, W]
+    ),
+    go_weighted_edge_fact_triples(Module, WeightPred/3, FactTriples),
+    FactTriples \= [],
+    go_foreign_astar_direct_pred(Module, WeightPred/3, DirectPred/3, DirectTriples),
+    go_foreign_astar_dimensionality(Module, Dim),
+    KernelConfig = [weight_pred(WeightPred/3), fact_triples(FactTriples),
+                    direct_dist_pred(DirectPred/3), direct_triples(DirectTriples),
+                    dimensionality(Dim)].
+
+go_foreign_astar_direct_pred(Module, _FallbackPred, DirectPred/3, DirectTriples) :-
+    go_weighted_edge_fact_triples(Module, direct_semantic_dist/3, DirectTriples),
+    DirectTriples \= [],
+    DirectPred = direct_semantic_dist,
+    !.
+go_foreign_astar_direct_pred(_Module, FallbackPred, DirectPred, DirectTriples) :-
+    FallbackPred = DirectPred,
+    DirectTriples = [].
+
+go_foreign_astar_dimensionality(Module, Dim) :-
+    (   current_predicate(Module:dimensionality/1),
+        Module:dimensionality(Dim0)
+    ;   current_predicate(user:dimensionality/1),
+        user:dimensionality(Dim0)
+    ),
+    integer(Dim0),
+    !,
+    Dim = Dim0.
+go_foreign_astar_dimensionality(_Module, 5).
 
 %% wam_lines_to_go(+Lines, +PC, -GoLits, -LabelEntries)
 wam_lines_to_go([], _, _, _, [], []).
@@ -1419,6 +1545,10 @@ func (vm *WamState) registerIndexedAtomFact2Pairs(predKey string, pairs []AtomPa
     vm.IndexedAtomFactPairs[predKey] = pairs
 }
 
+func (vm *WamState) registerIndexedWeightedEdgeTriples(predKey string, triples []WeightedEdgeTriple) {
+    vm.IndexedWeightedEdgeTriples[predKey] = triples
+}
+
 func (vm *WamState) foreignResultLayout(predKey string) string {
     return vm.ForeignResultLayouts[predKey]
 }
@@ -1483,26 +1613,39 @@ func (vm *WamState) finishForeignResults(predKey string, resultRegs []string, re
         baseStack := copyStack(vm.Stack)
         trailMark := len(vm.Trail)
         heapTop := len(vm.Heap)
-        if !vm.applyForeignResult(predKey, resultRegs, results[0]) {
-            return false
+        for idx, result := range results {
+            vm.unwindTrail(trailMark)
+            vm.Regs = copyMap(baseRegs)
+            vm.Stack = copyStack(baseStack)
+            if heapTop >= 0 && heapTop <= len(vm.Heap) {
+                vm.Heap = vm.Heap[:heapTop]
+            }
+            vm.CP = vm.CP
+            vm.Halted = false
+            vm.CurrentStruct = nil
+            vm.CurrentList = nil
+            if !vm.applyForeignResult(predKey, resultRegs, result) {
+                continue
+            }
+            if idx+1 < len(results) {
+                remaining := append([]Value(nil), results[idx+1:]...)
+                vm.ChoicePoints = append(vm.ChoicePoints, ChoicePoint{
+                    NextPC: resumePC,
+                    ResumePC: resumePC,
+                    CP: vm.CP,
+                    Regs: baseRegs,
+                    Stack: baseStack,
+                    HeapTop: heapTop,
+                    TrailMark: trailMark,
+                    ForeignPredKey: predKey,
+                    ForeignResultRegs: append([]string(nil), resultRegs...),
+                    ForeignResults: remaining,
+                })
+            }
+            vm.PC = resumePC
+            return true
         }
-        if len(results) > 1 {
-            remaining := append([]Value(nil), results[1:]...)
-            vm.ChoicePoints = append(vm.ChoicePoints, ChoicePoint{
-                NextPC: resumePC,
-                ResumePC: resumePC,
-                CP: vm.CP,
-                Regs: baseRegs,
-                Stack: baseStack,
-                HeapTop: heapTop,
-                TrailMark: trailMark,
-                ForeignPredKey: predKey,
-                ForeignResultRegs: append([]string(nil), resultRegs...),
-                ForeignResults: remaining,
-            })
-        }
-        vm.PC = resumePC
-        return true
+        return false
     default:
         if !vm.applyForeignResult(predKey, resultRegs, results[0]) {
             return false
@@ -1530,6 +1673,18 @@ func valueAsInteger(vm *WamState, v Value) (int64, bool) {
     return integer.Val, true
 }
 
+func valueAsFloat(vm *WamState, v Value) (float64, bool) {
+    val := vm.deref(v)
+    switch n := val.(type) {
+    case *Integer:
+        return float64(n.Val), true
+    case *Float:
+        return n.Val, true
+    default:
+        return 0, false
+    }
+}
+
 func listAsSlice(vm *WamState, v Value) ([]Value, bool) {
     val := vm.deref(v)
     list, ok := val.(*List)
@@ -1544,6 +1699,226 @@ func (vm *WamState) collectNativeListSuffixes(items []Value, out *[]Value) {
         suffix := append([]Value(nil), items[idx:]...)
         *out = append(*out, &List{Elements: suffix})
     }
+}
+
+func tupleValue(items ...Value) Value {
+    return &Compound{Functor: "__tuple__", Args: items}
+}
+
+func atomAdjacency(pairs []AtomPair) map[string][]string {
+    adjacency := make(map[string][]string)
+    for _, pair := range pairs {
+        adjacency[pair.Left] = append(adjacency[pair.Left], pair.Right)
+    }
+    return adjacency
+}
+
+func weightedAdjacency(triples []WeightedEdgeTriple) map[string][]WeightedEdgeTriple {
+    adjacency := make(map[string][]WeightedEdgeTriple)
+    for _, triple := range triples {
+        adjacency[triple.Left] = append(adjacency[triple.Left], triple)
+    }
+    return adjacency
+}
+
+func (vm *WamState) collectNativeTransitiveClosureResults(source string, pairs []AtomPair) []Value {
+    adjacency := atomAdjacency(pairs)
+    visited := make(map[string]bool)
+    queue := append([]string(nil), adjacency[source]...)
+    results := make([]Value, 0)
+    for len(queue) > 0 {
+        node := queue[0]
+        queue = queue[1:]
+        if visited[node] {
+            continue
+        }
+        visited[node] = true
+        results = append(results, &Atom{Name: node})
+        queue = append(queue, adjacency[node]...)
+    }
+    return results
+}
+
+func (vm *WamState) collectNativeTransitiveDistanceResults(source string, pairs []AtomPair) []Value {
+    adjacency := atomAdjacency(pairs)
+    visited := map[string]bool{source: true}
+    dist := map[string]int{source: 0}
+    queue := []string{source}
+    results := make([]Value, 0)
+    for len(queue) > 0 {
+        current := queue[0]
+        queue = queue[1:]
+        for _, next := range adjacency[current] {
+            if visited[next] {
+                continue
+            }
+            visited[next] = true
+            dist[next] = dist[current] + 1
+            queue = append(queue, next)
+            results = append(results, tupleValue(
+                &Atom{Name: next},
+                &Integer{Val: int64(dist[next])},
+            ))
+        }
+    }
+    return results
+}
+
+func (vm *WamState) collectNativeTransitiveParentDistanceResults(source string, pairs []AtomPair) []Value {
+    adjacency := atomAdjacency(pairs)
+    visited := map[string]bool{source: true}
+    dist := map[string]int{source: 0}
+    parent := make(map[string]string)
+    queue := []string{source}
+    results := make([]Value, 0)
+    for len(queue) > 0 {
+        current := queue[0]
+        queue = queue[1:]
+        for _, next := range adjacency[current] {
+            if visited[next] {
+                continue
+            }
+            visited[next] = true
+            dist[next] = dist[current] + 1
+            parent[next] = current
+            queue = append(queue, next)
+            results = append(results, tupleValue(
+                &Atom{Name: next},
+                &Atom{Name: parent[next]},
+                &Integer{Val: int64(dist[next])},
+            ))
+        }
+    }
+    return results
+}
+
+func (vm *WamState) collectNativeTransitiveStepParentDistanceResults(source string, pairs []AtomPair) []Value {
+    adjacency := atomAdjacency(pairs)
+    visited := map[string]bool{source: true}
+    dist := map[string]int{source: 0}
+    parent := make(map[string]string)
+    firstStep := make(map[string]string)
+    queue := []string{source}
+    results := make([]Value, 0)
+    for len(queue) > 0 {
+        current := queue[0]
+        queue = queue[1:]
+        for _, next := range adjacency[current] {
+            if visited[next] {
+                continue
+            }
+            visited[next] = true
+            dist[next] = dist[current] + 1
+            parent[next] = current
+            if current == source {
+                firstStep[next] = next
+            } else {
+                firstStep[next] = firstStep[current]
+            }
+            queue = append(queue, next)
+            results = append(results, tupleValue(
+                &Atom{Name: next},
+                &Atom{Name: firstStep[next]},
+                &Atom{Name: parent[next]},
+                &Integer{Val: int64(dist[next])},
+            ))
+        }
+    }
+    return results
+}
+
+func pickShortestCandidate(dist map[string]float64, settled map[string]bool) (string, bool) {
+    bestNode := ""
+    bestDist := 0.0
+    found := false
+    for node, d := range dist {
+        if settled[node] {
+            continue
+        }
+        if !found || d < bestDist || (d == bestDist && node < bestNode) {
+            bestNode = node
+            bestDist = d
+            found = true
+        }
+    }
+    return bestNode, found
+}
+
+func heuristicLookup(triples []WeightedEdgeTriple, from string, target string) float64 {
+    for _, triple := range triples {
+        if triple.Left == from && triple.Right == target {
+            return triple.Weight
+        }
+    }
+    return 0
+}
+
+func (vm *WamState) collectNativeWeightedShortestPathResults(source string, triples []WeightedEdgeTriple) []Value {
+    adjacency := weightedAdjacency(triples)
+    dist := map[string]float64{source: 0}
+    settled := make(map[string]bool)
+    results := make([]Value, 0)
+    for {
+        current, ok := pickShortestCandidate(dist, settled)
+        if !ok {
+            break
+        }
+        settled[current] = true
+        if current != source {
+            results = append(results, tupleValue(
+                &Atom{Name: current},
+                &Float{Val: dist[current]},
+            ))
+        }
+        for _, edge := range adjacency[current] {
+            candidate := dist[current] + edge.Weight
+            prev, exists := dist[edge.Right]
+            if !exists || candidate < prev {
+                dist[edge.Right] = candidate
+            }
+        }
+    }
+    return results
+}
+
+func (vm *WamState) collectNativeAstarShortestPathResult(source string, target string, weighted []WeightedEdgeTriple, direct []WeightedEdgeTriple) []Value {
+    adjacency := weightedAdjacency(weighted)
+    gScore := map[string]float64{source: 0}
+    open := map[string]bool{source: true}
+    closed := make(map[string]bool)
+    for len(open) > 0 {
+        current := ""
+        bestScore := 0.0
+        found := false
+        for node := range open {
+            score := gScore[node] + heuristicLookup(direct, node, target)
+            if !found || score < bestScore || (score == bestScore && node < current) {
+                current = node
+                bestScore = score
+                found = true
+            }
+        }
+        if !found {
+            break
+        }
+        delete(open, current)
+        if current == target {
+            return []Value{&Float{Val: gScore[current]}}
+        }
+        closed[current] = true
+        for _, edge := range adjacency[current] {
+            if closed[edge.Right] {
+                continue
+            }
+            candidate := gScore[current] + edge.Weight
+            prev, exists := gScore[edge.Right]
+            if !exists || candidate < prev {
+                gScore[edge.Right] = candidate
+                open[edge.Right] = true
+            }
+        }
+    }
+    return nil
 }
 
 func (vm *WamState) executeForeignPredicate(pred string, arity int) bool {
@@ -1587,24 +1962,62 @@ func (vm *WamState) executeForeignPredicate(pred string, arity int) bool {
         }
         edgePred := vm.foreignStringConfig(predKey, "edge_pred")
         pairs := vm.IndexedAtomFactPairs[edgePred]
-        adjacency := make(map[string][]string)
-        for _, pair := range pairs {
-            adjacency[pair.Left] = append(adjacency[pair.Left], pair.Right)
-        }
-        visited := make(map[string]bool)
-        queue := append([]string(nil), adjacency[source]...)
-        results := make([]Value, 0)
-        for len(queue) > 0 {
-            node := queue[0]
-            queue = queue[1:]
-            if visited[node] {
-                continue
-            }
-            visited[node] = true
-            results = append(results, &Atom{Name: node})
-            queue = append(queue, adjacency[node]...)
-        }
+        results := vm.collectNativeTransitiveClosureResults(source, pairs)
         return vm.finishForeignResults(predKey, []string{"A2"}, results)
+    case "transitive_distance3":
+        source, ok := valueAsAtomString(vm, vm.getReg("A1"))
+        if !ok {
+            return false
+        }
+        edgePred := vm.foreignStringConfig(predKey, "edge_pred")
+        pairs := vm.IndexedAtomFactPairs[edgePred]
+        results := vm.collectNativeTransitiveDistanceResults(source, pairs)
+        return vm.finishForeignResults(predKey, []string{"A2", "A3"}, results)
+    case "transitive_parent_distance4":
+        source, ok := valueAsAtomString(vm, vm.getReg("A1"))
+        if !ok {
+            return false
+        }
+        edgePred := vm.foreignStringConfig(predKey, "edge_pred")
+        pairs := vm.IndexedAtomFactPairs[edgePred]
+        results := vm.collectNativeTransitiveParentDistanceResults(source, pairs)
+        return vm.finishForeignResults(predKey, []string{"A2", "A3", "A4"}, results)
+    case "transitive_step_parent_distance5":
+        source, ok := valueAsAtomString(vm, vm.getReg("A1"))
+        if !ok {
+            return false
+        }
+        edgePred := vm.foreignStringConfig(predKey, "edge_pred")
+        pairs := vm.IndexedAtomFactPairs[edgePred]
+        results := vm.collectNativeTransitiveStepParentDistanceResults(source, pairs)
+        return vm.finishForeignResults(predKey, []string{"A2", "A3", "A4", "A5"}, results)
+    case "weighted_shortest_path3":
+        source, ok := valueAsAtomString(vm, vm.getReg("A1"))
+        if !ok {
+            return false
+        }
+        weightPred := vm.foreignStringConfig(predKey, "weight_pred")
+        triples := vm.IndexedWeightedEdgeTriples[weightPred]
+        results := vm.collectNativeWeightedShortestPathResults(source, triples)
+        return vm.finishForeignResults(predKey, []string{"A2", "A3"}, results)
+    case "astar_shortest_path4":
+        source, ok := valueAsAtomString(vm, vm.getReg("A1"))
+        if !ok {
+            return false
+        }
+        target, ok := valueAsAtomString(vm, vm.getReg("A2"))
+        if !ok {
+            return false
+        }
+        if _, ok := valueAsFloat(vm, vm.getReg("A3")); !ok {
+            return false
+        }
+        weightPred := vm.foreignStringConfig(predKey, "weight_pred")
+        directPred := vm.foreignStringConfig(predKey, "direct_dist_pred")
+        weighted := vm.IndexedWeightedEdgeTriples[weightPred]
+        direct := vm.IndexedWeightedEdgeTriples[directPred]
+        results := vm.collectNativeAstarShortestPathResult(source, target, weighted, direct)
+        return vm.finishForeignResults(predKey, []string{"A4"}, results)
     default:
         return false
     }

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -15,6 +15,12 @@ type AtomPair struct {
 	Right string
 }
 
+type WeightedEdgeTriple struct {
+	Left   string
+	Right  string
+	Weight float64
+}
+
 type ChoicePoint struct {
 	NextPC    int
 	ResumePC  int
@@ -67,6 +73,7 @@ type WamState struct {
 	ForeignStringConfigs map[string]map[string]string
 	ForeignUsizeConfigs  map[string]map[string]int
 	IndexedAtomFactPairs map[string][]AtomPair
+	IndexedWeightedEdgeTriples map[string][]WeightedEdgeTriple
 }
 
 func NewWamState(code []Instruction, labels map[string]int) *WamState {
@@ -80,6 +87,7 @@ func NewWamState(code []Instruction, labels map[string]int) *WamState {
 		ForeignStringConfigs: make(map[string]map[string]string),
 		ForeignUsizeConfigs:  make(map[string]map[string]int),
 		IndexedAtomFactPairs: make(map[string][]AtomPair),
+		IndexedWeightedEdgeTriples: make(map[string][]WeightedEdgeTriple),
 	}
 }
 
@@ -163,6 +171,7 @@ func (vm *WamState) Clone() *WamState {
 		ForeignStringConfigs: vm.ForeignStringConfigs,
 		ForeignUsizeConfigs:  vm.ForeignUsizeConfigs,
 		IndexedAtomFactPairs: vm.IndexedAtomFactPairs,
+		IndexedWeightedEdgeTriples: vm.IndexedWeightedEdgeTriples,
 	}
 	copy(newState.Heap, vm.Heap)
 	copy(newState.Stack, vm.Stack)
@@ -452,28 +461,31 @@ func (vm *WamState) backtrack() bool {
     topIdx := len(vm.ChoicePoints) - 1
     cp := vm.ChoicePoints[topIdx]
     if len(cp.ForeignResults) > 0 {
-        vm.unwindTrail(cp.TrailMark)
-        vm.Regs = copyMap(cp.Regs)
-        vm.Stack = copyStack(cp.Stack)
-        if cp.HeapTop >= 0 && cp.HeapTop <= len(vm.Heap) {
-            vm.Heap = vm.Heap[:cp.HeapTop]
+        for len(cp.ForeignResults) > 0 {
+            vm.unwindTrail(cp.TrailMark)
+            vm.Regs = copyMap(cp.Regs)
+            vm.Stack = copyStack(cp.Stack)
+            if cp.HeapTop >= 0 && cp.HeapTop <= len(vm.Heap) {
+                vm.Heap = vm.Heap[:cp.HeapTop]
+            }
+            vm.CP = cp.CP
+            vm.Halted = false
+            vm.CurrentStruct = nil
+            vm.CurrentList = nil
+            nextResult := cp.ForeignResults[0]
+            cp.ForeignResults = cp.ForeignResults[1:]
+            if len(cp.ForeignResults) == 0 {
+                vm.ChoicePoints = vm.ChoicePoints[:topIdx]
+            } else {
+                vm.ChoicePoints[topIdx] = cp
+            }
+            if !vm.applyForeignResult(cp.ForeignPredKey, cp.ForeignResultRegs, nextResult) {
+                continue
+            }
+            vm.PC = cp.ResumePC
+            return true
         }
-        vm.CP = cp.CP
-        vm.Halted = false
-        vm.CurrentStruct = nil
-        vm.CurrentList = nil
-        nextResult := cp.ForeignResults[0]
-        cp.ForeignResults = cp.ForeignResults[1:]
-        if len(cp.ForeignResults) == 0 {
-            vm.ChoicePoints = vm.ChoicePoints[:topIdx]
-        } else {
-            vm.ChoicePoints[topIdx] = cp
-        }
-        if !vm.applyForeignResult(cp.ForeignPredKey, cp.ForeignResultRegs, nextResult) {
-            return false
-        }
-        vm.PC = cp.ResumePC
-        return true
+        return false
     }
     vm.ChoicePoints = vm.ChoicePoints[:topIdx]
     vm.unwindTrail(cp.TrailMark)

--- a/tests/test_wam_go_foreign_lowering.pl
+++ b/tests/test_wam_go_foreign_lowering.pl
@@ -8,10 +8,33 @@
 :- dynamic test_tri_sum/2.
 :- dynamic test_tail_suffix/2.
 :- dynamic test_reaches/2.
+:- dynamic test_reaches_dist/3.
+:- dynamic test_parent_distance/4.
+:- dynamic test_step_parent_distance/5.
+:- dynamic test_weighted_path/3.
+:- dynamic test_astar_weighted_path/4.
 
 edge(a, b).
 edge(b, c).
 edge(c, d).
+
+weighted_edge(s, a, 1.0).
+weighted_edge(s, b, 4.0).
+weighted_edge(a, b, 2.0).
+weighted_edge(a, c, 5.0).
+weighted_edge(b, c, 1.0).
+weighted_edge(c, d, 3.0).
+
+user:direct_semantic_dist(s, a, 1.0).
+user:direct_semantic_dist(s, b, 3.0).
+user:direct_semantic_dist(s, c, 4.0).
+user:direct_semantic_dist(s, d, 7.0).
+user:direct_semantic_dist(a, b, 2.0).
+user:direct_semantic_dist(a, c, 3.0).
+user:direct_semantic_dist(a, d, 6.0).
+user:direct_semantic_dist(b, c, 1.0).
+user:direct_semantic_dist(b, d, 4.0).
+user:direct_semantic_dist(c, d, 3.0).
 
 test_tri_sum(0, 0).
 test_tri_sum(N, Sum) :-
@@ -25,6 +48,36 @@ test_tail_suffix([_|T], S) :- test_tail_suffix(T, S).
 
 test_reaches(X, Y) :- edge(X, Y).
 test_reaches(X, Y) :- edge(X, Z), test_reaches(Z, Y).
+
+test_reaches_dist(X, Y, 1) :- edge(X, Y).
+test_reaches_dist(X, Y, D) :-
+    edge(X, Z),
+    test_reaches_dist(Z, Y, D1),
+    D is D1 + 1.
+
+test_parent_distance(X, Y, X, 1) :- edge(X, Y).
+test_parent_distance(X, Y, Parent, D) :-
+    edge(X, Z),
+    test_parent_distance(Z, Y, Parent, D1),
+    D is D1 + 1.
+
+test_step_parent_distance(X, Y, Y, X, 1) :- edge(X, Y).
+test_step_parent_distance(X, Y, Step, Parent, D) :-
+    edge(X, Step),
+    test_step_parent_distance(Step, Y, _Inner, Parent, D1),
+    D is D1 + 1.
+
+test_weighted_path(X, Y, W) :- weighted_edge(X, Y, W).
+test_weighted_path(X, Y, Cost) :-
+    weighted_edge(X, Z, W),
+    test_weighted_path(Z, Y, RestCost),
+    Cost is W + RestCost.
+
+test_astar_weighted_path(X, Y, 5, W) :- weighted_edge(X, Y, W).
+test_astar_weighted_path(X, Y, 5, Cost) :-
+    weighted_edge(X, Z, W),
+    test_astar_weighted_path(Z, Y, 5, RestCost),
+    Cost is W + RestCost.
 
 test(foreign_spec_wrapper_generation) :-
     ForeignSpec = foreign_predicate(
@@ -62,12 +115,33 @@ test(foreign_call_rewrite_generation) :-
 
 test(foreign_auto_detect_generation) :-
     compile_wam_predicate_to_go(plunit_wam_go_foreign_lowering:test_reaches/2, "call test_reaches/2, 2",
-        [foreign_lowering(true)], Code),
-    assertion(sub_string(Code, _, _, _, 'vm.registerForeignNativeKind("test_reaches/2", "transitive_closure2")')),
-    assertion(sub_string(Code, _, _, _, 'vm.registerForeignResultMode("test_reaches/2", "stream")')),
-    assertion(sub_string(Code, _, _, _, 'vm.registerForeignStringConfig("test_reaches/2", "edge_pred", "edge/2")')),
-    assertion(sub_string(Code, _, _, _, 'vm.registerIndexedAtomFact2Pairs("edge/2", []AtomPair{{Left: "a", Right: "b"}, {Left: "b", Right: "c"}, {Left: "c", Right: "d"}})')),
-    assertion(sub_string(Code, _, _, _, 'return vm.executeForeignPredicate("test_reaches", 2)')).
+        [foreign_lowering(true)], ClosureCode),
+    assertion(sub_string(ClosureCode, _, _, _, 'vm.registerForeignNativeKind("test_reaches/2", "transitive_closure2")')),
+    assertion(sub_string(ClosureCode, _, _, _, 'vm.registerForeignStringConfig("test_reaches/2", "edge_pred", "edge/2")')),
+    assertion(sub_string(ClosureCode, _, _, _, 'vm.registerIndexedAtomFact2Pairs("edge/2", []AtomPair{{Left: "a", Right: "b"}, {Left: "b", Right: "c"}, {Left: "c", Right: "d"}})')),
+    compile_wam_predicate_to_go(plunit_wam_go_foreign_lowering:test_reaches_dist/3, "call test_reaches_dist/3, 3",
+        [foreign_lowering(true)], DistanceCode),
+    assertion(sub_string(DistanceCode, _, _, _, 'vm.registerForeignNativeKind("test_reaches_dist/3", "transitive_distance3")')),
+    assertion(sub_string(DistanceCode, _, _, _, 'vm.registerForeignResultLayout("test_reaches_dist/3", "tuple:2")')),
+    compile_wam_predicate_to_go(plunit_wam_go_foreign_lowering:test_parent_distance/4, "call test_parent_distance/4, 4",
+        [foreign_lowering(true)], ParentCode),
+    assertion(sub_string(ParentCode, _, _, _, 'vm.registerForeignNativeKind("test_parent_distance/4", "transitive_parent_distance4")')),
+    assertion(sub_string(ParentCode, _, _, _, 'vm.registerForeignResultLayout("test_parent_distance/4", "tuple:3")')),
+    compile_wam_predicate_to_go(plunit_wam_go_foreign_lowering:test_step_parent_distance/5, "call test_step_parent_distance/5, 5",
+        [foreign_lowering(true)], StepCode),
+    assertion(sub_string(StepCode, _, _, _, 'vm.registerForeignNativeKind("test_step_parent_distance/5", "transitive_step_parent_distance5")')),
+    assertion(sub_string(StepCode, _, _, _, 'vm.registerForeignResultLayout("test_step_parent_distance/5", "tuple:4")')),
+    compile_wam_predicate_to_go(plunit_wam_go_foreign_lowering:test_weighted_path/3, "call test_weighted_path/3, 3",
+        [foreign_lowering(true)], WeightedCode),
+    assertion(sub_string(WeightedCode, _, _, _, 'vm.registerForeignNativeKind("test_weighted_path/3", "weighted_shortest_path3")')),
+    assertion(sub_string(WeightedCode, _, _, _, 'vm.registerForeignStringConfig("test_weighted_path/3", "weight_pred", "weighted_edge/3")')),
+    assertion(sub_string(WeightedCode, _, _, _, 'vm.registerIndexedWeightedEdgeTriples("weighted_edge/3", []WeightedEdgeTriple{')),
+    compile_wam_predicate_to_go(plunit_wam_go_foreign_lowering:test_astar_weighted_path/4, "call test_astar_weighted_path/4, 4",
+        [foreign_lowering(true)], AstarCode),
+    assertion(sub_string(AstarCode, _, _, _, 'vm.registerForeignNativeKind("test_astar_weighted_path/4", "astar_shortest_path4")')),
+    assertion(sub_string(AstarCode, _, _, _, 'vm.registerForeignStringConfig("test_astar_weighted_path/4", "weight_pred", "weighted_edge/3")')),
+    assertion(sub_string(AstarCode, _, _, _, 'vm.registerForeignUsizeConfig("test_astar_weighted_path/4", "dimensionality", 5)')),
+    assertion(sub_string(AstarCode, _, _, _, 'return vm.executeForeignPredicate("test_astar_weighted_path", 4)')).
 
 test(foreign_execution_deterministic_and_stream) :-
     once((
@@ -142,6 +216,284 @@ func TestForeignListSuffixStream(t *testing.T) {
     third, ok := vm.deref(out).(*List)
     if !ok || len(third.Elements) != 0 {
         t.Fatalf("expected final suffix [], got %#v", vm.deref(out))
+    }
+}
+'),
+        (   catch(process_create(path(go), ['test', './...'], [cwd(TmpDir), stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]), _, fail)
+        ->  read_string(Out, _, _Stdout),
+            read_string(Err, _, Stderr),
+            process_wait(Pid, Exit),
+            assertion(Exit == exit(0)),
+            assertion(\+ sub_string(Stderr, _, _, _, 'FAIL'))
+        ;   true
+        ),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+test(foreign_execution_graph_kernels) :-
+    once((
+        get_time(T),
+        format(atom(TmpDir), 'tmp_wam_go_graph_~w', [T]),
+        write_wam_go_project(
+            [plunit_wam_go_foreign_lowering:test_reaches/2],
+            [module_name(go_graph_test)],
+            TmpDir
+        ),
+        directory_file_path(TmpDir, 'foreign_graph_test.go', TestPath),
+        write_file(TestPath,
+'package wam
+
+import "testing"
+
+func TestForeignGraphKernels(t *testing.T) {
+    vm := NewWamState(nil, nil)
+    vm.registerForeignNativeKind("test_reaches_dist/3", "transitive_distance3")
+    vm.registerForeignResultLayout("test_reaches_dist/3", "tuple:2")
+    vm.registerForeignResultMode("test_reaches_dist/3", "stream")
+    vm.registerForeignStringConfig("test_reaches_dist/3", "edge_pred", "edge/2")
+    vm.registerIndexedAtomFact2Pairs("edge/2", []AtomPair{
+        {Left: "a", Right: "b"},
+        {Left: "b", Right: "c"},
+        {Left: "c", Right: "d"},
+    })
+    target := &Unbound{Name: "TARGET"}
+    dist := &Unbound{Name: "DIST"}
+    vm.Regs["A1"] = &Atom{Name: "a"}
+    vm.Regs["A2"] = target
+    vm.Regs["A3"] = dist
+    if !vm.executeForeignPredicate("test_reaches_dist", 3) {
+        t.Fatalf("transitive_distance3 failed")
+    }
+    if got, ok := vm.deref(target).(*Atom); !ok || got.Name != "b" {
+        t.Fatalf("expected first target b, got %#v", vm.deref(target))
+    }
+    if got, ok := vm.deref(dist).(*Integer); !ok || got.Val != 1 {
+        t.Fatalf("expected first distance 1, got %#v", vm.deref(dist))
+    }
+    if !vm.backtrack() {
+        t.Fatalf("expected second transitive_distance3 result")
+    }
+    if got, ok := vm.deref(target).(*Atom); !ok || got.Name != "c" {
+        t.Fatalf("expected second target c, got %#v", vm.deref(target))
+    }
+    if got, ok := vm.deref(dist).(*Integer); !ok || got.Val != 2 {
+        t.Fatalf("expected second distance 2, got %#v", vm.deref(dist))
+    }
+
+    vm2 := NewWamState(nil, nil)
+    vm2.registerForeignNativeKind("test_parent_distance/4", "transitive_parent_distance4")
+    vm2.registerForeignResultLayout("test_parent_distance/4", "tuple:3")
+    vm2.registerForeignResultMode("test_parent_distance/4", "stream")
+    vm2.registerForeignStringConfig("test_parent_distance/4", "edge_pred", "edge/2")
+    vm2.registerIndexedAtomFact2Pairs("edge/2", []AtomPair{
+        {Left: "a", Right: "b"},
+        {Left: "b", Right: "c"},
+        {Left: "c", Right: "d"},
+    })
+    pTarget := &Unbound{Name: "PTARGET"}
+    pParent := &Unbound{Name: "PPARENT"}
+    pDist := &Unbound{Name: "PDIST"}
+    vm2.Regs["A1"] = &Atom{Name: "a"}
+    vm2.Regs["A2"] = pTarget
+    vm2.Regs["A3"] = pParent
+    vm2.Regs["A4"] = pDist
+    if !vm2.executeForeignPredicate("test_parent_distance", 4) {
+        t.Fatalf("transitive_parent_distance4 failed")
+    }
+    if got, ok := vm2.deref(pTarget).(*Atom); !ok || got.Name != "b" {
+        t.Fatalf("expected parent-distance target b, got %#v", vm2.deref(pTarget))
+    }
+    if got, ok := vm2.deref(pParent).(*Atom); !ok || got.Name != "a" {
+        t.Fatalf("expected parent-distance parent a, got %#v", vm2.deref(pParent))
+    }
+
+    vm3 := NewWamState(nil, nil)
+    vm3.registerForeignNativeKind("test_step_parent_distance/5", "transitive_step_parent_distance5")
+    vm3.registerForeignResultLayout("test_step_parent_distance/5", "tuple:4")
+    vm3.registerForeignResultMode("test_step_parent_distance/5", "stream")
+    vm3.registerForeignStringConfig("test_step_parent_distance/5", "edge_pred", "edge/2")
+    vm3.registerIndexedAtomFact2Pairs("edge/2", []AtomPair{
+        {Left: "a", Right: "b"},
+        {Left: "b", Right: "c"},
+        {Left: "c", Right: "d"},
+    })
+    sTarget := &Unbound{Name: "STARGET"}
+    sStep := &Unbound{Name: "SSTEP"}
+    sParent := &Unbound{Name: "SPARENT"}
+    sDist := &Unbound{Name: "SDIST"}
+    vm3.Regs["A1"] = &Atom{Name: "a"}
+    vm3.Regs["A2"] = sTarget
+    vm3.Regs["A3"] = sStep
+    vm3.Regs["A4"] = sParent
+    vm3.Regs["A5"] = sDist
+    if !vm3.executeForeignPredicate("test_step_parent_distance", 5) {
+        t.Fatalf("transitive_step_parent_distance5 failed")
+    }
+    if got, ok := vm3.deref(sStep).(*Atom); !ok || got.Name != "b" {
+        t.Fatalf("expected step b, got %#v", vm3.deref(sStep))
+    }
+
+    weighted := []WeightedEdgeTriple{
+        {Left: "s", Right: "a", Weight: 1.0},
+        {Left: "s", Right: "b", Weight: 4.0},
+        {Left: "a", Right: "b", Weight: 2.0},
+        {Left: "a", Right: "c", Weight: 5.0},
+        {Left: "b", Right: "c", Weight: 1.0},
+        {Left: "c", Right: "d", Weight: 3.0},
+    }
+    vm4 := NewWamState(nil, nil)
+    vm4.registerForeignNativeKind("test_weighted_path/3", "weighted_shortest_path3")
+    vm4.registerForeignResultLayout("test_weighted_path/3", "tuple:2")
+    vm4.registerForeignResultMode("test_weighted_path/3", "stream")
+    vm4.registerForeignStringConfig("test_weighted_path/3", "weight_pred", "weighted_edge/3")
+    vm4.registerIndexedWeightedEdgeTriples("weighted_edge/3", weighted)
+    wTarget := &Unbound{Name: "WTARGET"}
+    wCost := &Unbound{Name: "WCOST"}
+    vm4.Regs["A1"] = &Atom{Name: "s"}
+    vm4.Regs["A2"] = wTarget
+    vm4.Regs["A3"] = wCost
+    if !vm4.executeForeignPredicate("test_weighted_path", 3) {
+        t.Fatalf("weighted_shortest_path3 failed")
+    }
+    weightedResults := make([]string, 0)
+    if gotT, okT := vm4.deref(wTarget).(*Atom); okT {
+        if gotC, okC := vm4.deref(wCost).(*Float); okC {
+            weightedResults = append(weightedResults, gotT.Name+":"+gotC.String())
+        } else {
+            t.Fatalf("expected first weighted cost float, got %#v", vm4.deref(wCost))
+        }
+    } else {
+        t.Fatalf("expected first weighted target atom, got %#v", vm4.deref(wTarget))
+    }
+    for vm4.backtrack() {
+        gotT, okT := vm4.deref(wTarget).(*Atom)
+        gotC, okC := vm4.deref(wCost).(*Float)
+        if !okT || !okC {
+            t.Fatalf("expected weighted backtrack tuple, got %#v %#v", vm4.deref(wTarget), vm4.deref(wCost))
+        }
+        weightedResults = append(weightedResults, gotT.Name+":"+gotC.String())
+    }
+    expectedWeighted := []string{"a:1", "b:3", "c:4", "d:7"}
+    if len(weightedResults) != len(expectedWeighted) {
+        t.Fatalf("expected %d weighted results, got %#v", len(expectedWeighted), weightedResults)
+    }
+    for i := range expectedWeighted {
+        if weightedResults[i] != expectedWeighted[i] {
+            t.Fatalf("expected weighted results %v, got %v", expectedWeighted, weightedResults)
+        }
+    }
+
+    vm4Exact := NewWamState(nil, nil)
+    vm4Exact.registerForeignNativeKind("test_weighted_path/3", "weighted_shortest_path3")
+    vm4Exact.registerForeignResultLayout("test_weighted_path/3", "tuple:2")
+    vm4Exact.registerForeignResultMode("test_weighted_path/3", "stream")
+    vm4Exact.registerForeignStringConfig("test_weighted_path/3", "weight_pred", "weighted_edge/3")
+    vm4Exact.registerIndexedWeightedEdgeTriples("weighted_edge/3", weighted)
+    vm4Exact.Regs["A1"] = &Atom{Name: "s"}
+    vm4Exact.Regs["A2"] = &Atom{Name: "d"}
+    vm4Exact.Regs["A3"] = &Float{Val: 7.0}
+    if !vm4Exact.executeForeignPredicate("test_weighted_path", 3) {
+        t.Fatalf("expected weighted exact match for s->d cost 7.0")
+    }
+
+    vm4Fail := NewWamState(nil, nil)
+    vm4Fail.registerForeignNativeKind("test_weighted_path/3", "weighted_shortest_path3")
+    vm4Fail.registerForeignResultLayout("test_weighted_path/3", "tuple:2")
+    vm4Fail.registerForeignResultMode("test_weighted_path/3", "stream")
+    vm4Fail.registerForeignStringConfig("test_weighted_path/3", "weight_pred", "weighted_edge/3")
+    vm4Fail.registerIndexedWeightedEdgeTriples("weighted_edge/3", weighted)
+    vm4Fail.Regs["A1"] = &Atom{Name: "d"}
+    vm4Fail.Regs["A2"] = &Unbound{Name: "WTFAIL"}
+    vm4Fail.Regs["A3"] = &Unbound{Name: "WCFAIL"}
+    if vm4Fail.executeForeignPredicate("test_weighted_path", 3) {
+        t.Fatalf("expected weighted path from d to fail")
+    }
+
+    heuristic := []WeightedEdgeTriple{
+        {Left: "s", Right: "a", Weight: 1.0},
+        {Left: "s", Right: "b", Weight: 3.0},
+        {Left: "s", Right: "c", Weight: 4.0},
+        {Left: "s", Right: "d", Weight: 7.0},
+        {Left: "a", Right: "b", Weight: 2.0},
+        {Left: "a", Right: "c", Weight: 3.0},
+        {Left: "a", Right: "d", Weight: 6.0},
+        {Left: "b", Right: "c", Weight: 1.0},
+        {Left: "b", Right: "d", Weight: 4.0},
+        {Left: "c", Right: "d", Weight: 3.0},
+    }
+    vm5 := NewWamState(nil, nil)
+    vm5.registerForeignNativeKind("test_astar_weighted_path/4", "astar_shortest_path4")
+    vm5.registerForeignResultLayout("test_astar_weighted_path/4", "tuple:1")
+    vm5.registerForeignResultMode("test_astar_weighted_path/4", "stream")
+    vm5.registerForeignStringConfig("test_astar_weighted_path/4", "weight_pred", "weighted_edge/3")
+    vm5.registerForeignStringConfig("test_astar_weighted_path/4", "direct_dist_pred", "direct_semantic_dist/3")
+    vm5.registerForeignUsizeConfig("test_astar_weighted_path/4", "dimensionality", 5)
+    vm5.registerIndexedWeightedEdgeTriples("weighted_edge/3", weighted)
+    vm5.registerIndexedWeightedEdgeTriples("direct_semantic_dist/3", heuristic)
+    aCost := &Unbound{Name: "ACOST"}
+    vm5.Regs["A1"] = &Atom{Name: "s"}
+    vm5.Regs["A2"] = &Atom{Name: "d"}
+    vm5.Regs["A3"] = &Integer{Val: 5}
+    vm5.Regs["A4"] = aCost
+    if !vm5.executeForeignPredicate("test_astar_weighted_path", 4) {
+        t.Fatalf("astar_shortest_path4 failed")
+    }
+    if got, ok := vm5.deref(aCost).(*Float); !ok || got.Val != 7.0 {
+        t.Fatalf("expected astar cost 7.0, got %#v", vm5.deref(aCost))
+    }
+    if vm5.backtrack() {
+        t.Fatalf("expected astar_shortest_path4 single result")
+    }
+
+    vm5Fallback := NewWamState(nil, nil)
+    vm5Fallback.registerForeignNativeKind("test_astar_weighted_path/4", "astar_shortest_path4")
+    vm5Fallback.registerForeignResultLayout("test_astar_weighted_path/4", "tuple:1")
+    vm5Fallback.registerForeignResultMode("test_astar_weighted_path/4", "stream")
+    vm5Fallback.registerForeignStringConfig("test_astar_weighted_path/4", "weight_pred", "weighted_edge/3")
+    vm5Fallback.registerForeignUsizeConfig("test_astar_weighted_path/4", "dimensionality", 5)
+    vm5Fallback.registerIndexedWeightedEdgeTriples("weighted_edge/3", weighted)
+    fallbackCost := &Unbound{Name: "FALLBACK_COST"}
+    vm5Fallback.Regs["A1"] = &Atom{Name: "s"}
+    vm5Fallback.Regs["A2"] = &Atom{Name: "d"}
+    vm5Fallback.Regs["A3"] = &Integer{Val: 5}
+    vm5Fallback.Regs["A4"] = fallbackCost
+    if !vm5Fallback.executeForeignPredicate("test_astar_weighted_path", 4) {
+        t.Fatalf("expected astar fallback without heuristic to succeed")
+    }
+    if got, ok := vm5Fallback.deref(fallbackCost).(*Float); !ok || got.Val != 7.0 {
+        t.Fatalf("expected astar fallback cost 7.0, got %#v", vm5Fallback.deref(fallbackCost))
+    }
+
+    vm5Exact := NewWamState(nil, nil)
+    vm5Exact.registerForeignNativeKind("test_astar_weighted_path/4", "astar_shortest_path4")
+    vm5Exact.registerForeignResultLayout("test_astar_weighted_path/4", "tuple:1")
+    vm5Exact.registerForeignResultMode("test_astar_weighted_path/4", "stream")
+    vm5Exact.registerForeignStringConfig("test_astar_weighted_path/4", "weight_pred", "weighted_edge/3")
+    vm5Exact.registerForeignStringConfig("test_astar_weighted_path/4", "direct_dist_pred", "direct_semantic_dist/3")
+    vm5Exact.registerForeignUsizeConfig("test_astar_weighted_path/4", "dimensionality", 5)
+    vm5Exact.registerIndexedWeightedEdgeTriples("weighted_edge/3", weighted)
+    vm5Exact.registerIndexedWeightedEdgeTriples("direct_semantic_dist/3", heuristic)
+    vm5Exact.Regs["A1"] = &Atom{Name: "s"}
+    vm5Exact.Regs["A2"] = &Atom{Name: "d"}
+    vm5Exact.Regs["A3"] = &Integer{Val: 5}
+    vm5Exact.Regs["A4"] = &Float{Val: 7.0}
+    if !vm5Exact.executeForeignPredicate("test_astar_weighted_path", 4) {
+        t.Fatalf("expected exact astar match for s->d cost 7.0")
+    }
+
+    vm5Fail := NewWamState(nil, nil)
+    vm5Fail.registerForeignNativeKind("test_astar_weighted_path/4", "astar_shortest_path4")
+    vm5Fail.registerForeignResultLayout("test_astar_weighted_path/4", "tuple:1")
+    vm5Fail.registerForeignResultMode("test_astar_weighted_path/4", "stream")
+    vm5Fail.registerForeignStringConfig("test_astar_weighted_path/4", "weight_pred", "weighted_edge/3")
+    vm5Fail.registerForeignUsizeConfig("test_astar_weighted_path/4", "dimensionality", 5)
+    vm5Fail.registerIndexedWeightedEdgeTriples("weighted_edge/3", weighted)
+    vm5Fail.Regs["A1"] = &Atom{Name: "d"}
+    vm5Fail.Regs["A2"] = &Atom{Name: "s"}
+    vm5Fail.Regs["A3"] = &Integer{Val: 5}
+    vm5Fail.Regs["A4"] = &Unbound{Name: "NO_ASTAR"}
+    if vm5Fail.executeForeignPredicate("test_astar_weighted_path", 4) {
+        t.Fatalf("expected astar path from d to s to fail")
     }
 }
 '),


### PR DESCRIPTION
## Summary

This PR strengthens Go hybrid/WAM validation for the recently added weighted shortest-path and A* graph kernels.

The main change is not new kernel surface area. It is stronger semantic coverage for the kernels that already exist, plus the runtime fix required to satisfy those stricter assertions.

## What Changed

- adds deterministic Go execution assertions for `weighted_shortest_path3`
- verifies exact-match weighted queries succeed when a later streamed result is the first unifying candidate
- verifies weighted queries fail cleanly when no path exists
- adds stricter A* assertions for:
  - exact-match success
  - no-path failure
  - fallback behavior when heuristic data is not registered
  - single-result backtracking behavior
- fixes Go foreign stream result handling so both initial execution and backtracking skip non-unifying candidates instead of failing early

## Why

The previous Go tests proved that the graph kernels could execute, but they did not adequately validate semantic behavior under realistic binding patterns.

The new assertions exposed a real bug in foreign stream handling:

- if the first foreign result did not unify with already-bound output registers, the Go runtime failed immediately
- it did not continue scanning later streamed candidates that might unify

That behavior was incorrect for exact-match weighted and A* queries. This PR fixes that path and locks the behavior down with focused tests.

## Files

- `tests/test_wam_go_foreign_lowering.pl`
- `src/unifyweaver/targets/wam_go_target.pl`
- `templates/targets/go_wam/state.go.mustache`

## Verification

Passed locally:

- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`

## Reviewer Notes

The key review point is the foreign stream-result behavior change:

- initial foreign result application now scans forward until it finds a unifying candidate
- foreign choice-point backtracking now does the same

That change is what makes exact-match weighted/A* queries behave like the rest of the hybrid execution model instead of incorrectly failing on the first non-matching candidate.
