### PR TITLE
test(wam-go): add auto-detect e2e coverage

### DIFF
--- a/src/unifyweaver/targets/go_runtime/custom_go.pl
+++ b/src/unifyweaver/targets/go_runtime/custom_go.pl
@@ -6,7 +6,7 @@
     compile_component/4
 ]).
 
-:- use_module('../../core/component_registry').
+:- use_module('../../core/component_registry', [register_component_type/4]).
 
 type_info(info(
     name('Custom Go Component'),

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -134,7 +134,14 @@ var sharedWamCode = resolveInstructions(sharedWamCodeRaw, sharedWamLabels)
 classify_predicates([], _, []).
 classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
     predicate_indicator_parts(PredIndicator, Module, Pred, Arity),
-    (   catch(
+    (   go_foreign_spec(Module:Pred/Arity, Options, _SetupOps, _RewriteCalls, _EntryPred/_EntryArity),
+        option(wam_fallback(WamFB), Options, true),
+        WamFB \== false,
+        wam_target:compile_predicate_to_wam(Module:Pred/Arity, Options, WamCode)
+    ->  compile_wam_predicate_to_go(Module:Pred/Arity, WamCode, Options, PredCode),
+        format(user_error, '  ~w/~w: WAM fallback (foreign)~n', [Pred, Arity]),
+        Entry = classified(Module, Pred, Arity, wam_foreign, PredCode)
+    ;   catch(
             go_target:compile_predicate_to_go(Module:Pred/Arity,
                 [include_package(false)|Options], PredCode),
             _, fail)
@@ -387,6 +394,10 @@ foreign_wrapper_setup(PredIndicator, _WamCode, Options, InstrSetup, Setup, RunEx
     go_foreign_setup_code(SetupOps, Setup),
     format(atom(RunExpr), 'vm.executeForeignPredicate("~w", ~w)', [EntryPred, EntryArity]).
 
+go_foreign_spec(_PredArity, Options, _SetupOps, _RewriteCalls, _EntryPredArity) :-
+    option(no_kernels(true), Options),
+    !,
+    fail.
 go_foreign_spec(PredArity, Options, SetupOps, RewriteCalls, EntryPredArity) :-
     option(foreign_lowering(ForeignSpec), Options),
     nonvar(ForeignSpec),

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -607,7 +607,7 @@ flatten_conjunction(Goal, [Goal]).
 %  Compile (Cond -> Then ; Else) to WAM try/cut/trust + jump pattern.
 %  The condition runs in a temporary choice point; if it succeeds, cut
 %  commits to Then. If it fails, backtrack to Else.
-compile_if_then_else(CondGoal, ThenGoal, ElseGoal, V0, Vf, HasEnv, Code) :-
+compile_if_then_else(CondGoal, ThenGoal, ElseGoal, V0, Vf, _HasEnv, Code) :-
     next_ite_label(ElseLabel, ContLabel),
     % Flatten condition and branch bodies into goal lists
     flatten_conjunction(CondGoal, CondGoals),

--- a/tests/test_wam_go_foreign_lowering.pl
+++ b/tests/test_wam_go_foreign_lowering.pl
@@ -508,6 +508,56 @@ func TestForeignGraphKernels(t *testing.T) {
         delete_directory_and_contents(TmpDir)
     )).
 
+test(foreign_project_auto_detect_weighted_and_astar) :-
+    once((
+        get_time(T),
+        format(atom(TmpDir), 'tmp_wam_go_project_foreign_~w', [T]),
+        write_wam_go_project(
+            [plunit_wam_go_foreign_lowering:test_weighted_path/3,
+             plunit_wam_go_foreign_lowering:test_astar_weighted_path/4],
+            [module_name(go_project_foreign_test),
+             foreign_lowering(true)],
+            TmpDir
+        ),
+        directory_file_path(TmpDir, 'lib.go', LibPath),
+        read_file_to_string(LibPath, LibCode, []),
+        assertion(sub_string(LibCode, _, _, _, 'func Test_weighted_path(a1 Value, a2 Value, a3 Value) bool {')),
+        assertion(sub_string(LibCode, _, _, _, 'func Test_astar_weighted_path(a1 Value, a2 Value, a3 Value, a4 Value) bool {')),
+        assertion(sub_string(LibCode, _, _, _, 'vm.registerForeignNativeKind("test_weighted_path/3", "weighted_shortest_path3")')),
+        assertion(sub_string(LibCode, _, _, _, 'vm.registerForeignNativeKind("test_astar_weighted_path/4", "astar_shortest_path4")')),
+        directory_file_path(TmpDir, 'foreign_project_test.go', TestPath),
+        write_file(TestPath,
+'package wam
+
+import "testing"
+
+func TestForeignProjectAutoDetectWeightedAndAstar(t *testing.T) {
+    if !Test_weighted_path(&Atom{Name: "s"}, &Atom{Name: "d"}, &Float{Val: 7.0}) {
+        t.Fatalf("expected auto-detected weighted exact match to succeed")
+    }
+    if Test_weighted_path(&Atom{Name: "d"}, &Atom{Name: "s"}, &Unbound{Name: "WEIGHTED_FAIL"}) {
+        t.Fatalf("expected weighted project reverse query to fail")
+    }
+
+    if !Test_astar_weighted_path(&Atom{Name: "s"}, &Atom{Name: "d"}, &Integer{Val: 5}, &Float{Val: 7.0}) {
+        t.Fatalf("expected auto-detected astar exact match to succeed")
+    }
+    if Test_astar_weighted_path(&Atom{Name: "d"}, &Atom{Name: "s"}, &Integer{Val: 5}, &Unbound{Name: "ASTAR_FAIL"}) {
+        t.Fatalf("expected astar project reverse query to fail")
+    }
+}
+'),
+        (   catch(process_create(path(go), ['test', './...'], [cwd(TmpDir), stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]), _, fail)
+        ->  read_string(Out, _, _Stdout),
+            read_string(Err, _, Stderr),
+            process_wait(Pid, Exit),
+            assertion(Exit == exit(0)),
+            assertion(\+ sub_string(Stderr, _, _, _, 'FAIL'))
+        ;   true
+        ),
+        delete_directory_and_contents(TmpDir)
+    )).
+
 :- end_tests(wam_go_foreign_lowering).
 
 write_file(Path, Content) :-


### PR DESCRIPTION
## Summary

This PR closes the next Go hybrid/WAM confidence gap after the weighted and A* semantic work:

- it adds end-to-end generated-project coverage for auto-detected weighted and A* foreign lowering
- it aligns Go with the existing `no_kernels(true)` escape hatch used to disable kernel/FFI dispatch
- it removes the recurring warning noise from the focused Go verification path

## What Changed

- adds a generated-project test for auto-detected:
  - `weighted_shortest_path3`
  - `astar_shortest_path4`
- verifies the generated Go project emits foreign wrapper functions for both predicates
- verifies exact-match success and reverse-query failure through the generated project wrappers
- updates Go foreign-spec detection to honor `no_kernels(true)`
- adjusts Go project classification so explicit `foreign_lowering(true)` uses the hybrid foreign wrapper path instead of bypassing it through standalone native lowering
- removes two persistent warnings from focused Go test runs:
  - singleton warning in `wam_target.pl`
  - weak-import override warnings in `go_runtime/custom_go.pl`

## Why

Before this PR, the Go target had good unit-level and runtime-level coverage for weighted/A* foreign kernels, but it still lacked proof that `write_wam_go_project/3` exercised the same auto-detect foreign path end-to-end.

While adding that coverage, the generated project probe exposed a gap in project classification:

- explicit `foreign_lowering(true)` could still be routed through the standalone native Go target
- that meant project generation could miss the hybrid foreign wrapper path entirely

This PR fixes that by preferring the WAM foreign-wrapper route when foreign lowering is explicitly requested, while still respecting `no_kernels(true)` as the opt-out switch.

## Files

- `tests/test_wam_go_foreign_lowering.pl`
- `src/unifyweaver/targets/wam_go_target.pl`
- `src/unifyweaver/targets/wam_target.pl`
- `src/unifyweaver/targets/go_runtime/custom_go.pl`

## Verification

Passed locally:

- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`

## Reviewer Notes

Two review points matter most:

1. `no_kernels(true)` now disables Go foreign/kernel detection in the same spirit as the Haskell path.
2. Project-level explicit `foreign_lowering(true)` now prefers the hybrid foreign wrapper path, which is required for meaningful end-to-end Go auto-detect coverage.
