### PR TITLE
test(wam-go): cover mixed foreign boundaries

### DIFF
--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -107,12 +107,15 @@ read_template_file(Path, Content) :-
 compile_predicates_for_project([], _, "").
 compile_predicates_for_project(Predicates, Options, Code) :-
     classify_predicates(Predicates, Options, Classified),
-    collect_wam_entries(Classified, 0, WamEntries, AllInstrParts, AllLabelEntries),
+    collect_wam_entries(Classified, Options, 0, WamEntries, AllInstrParts, AllLabelEntries),
+    compile_shared_foreign_setup(Classified, Options, SharedForeignSetup),
     (   WamEntries \== []
     ->  atomic_list_concat(AllInstrParts, '\n', AllInstrs),
         atomic_list_concat(AllLabelEntries, '\n', AllLabels),
         format(atom(SharedCode),
-'var sharedWamCodeRaw = []Instruction{
+'~w
+
+var sharedWamCodeRaw = []Instruction{
 ~w
 }
 
@@ -121,7 +124,7 @@ var sharedWamLabels = map[string]int{
 }
 
 var sharedWamCode = resolveInstructions(sharedWamCodeRaw, sharedWamLabels)
-', [AllInstrs, AllLabels])
+', [SharedForeignSetup, AllInstrs, AllLabels])
     ;   SharedCode = ""
     ),
     generate_predicate_codes(Classified, WamEntries, PredCodes),
@@ -162,22 +165,22 @@ classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
     ),
     classify_predicates(Rest, Options, RestEntries).
 
-collect_wam_entries([], _, [], [], []).
-collect_wam_entries([classified(_, Pred, Arity, wam, WamCode)|Rest], PC,
+collect_wam_entries([], _, _, [], [], []).
+collect_wam_entries([classified(Module, Pred, Arity, wam, WamCode)|Rest], Options, PC,
                     [wam_entry(Pred, Arity, PC)|RestEntries],
                     AllInstrs, AllLabels) :-
     atom_string(WamCode, WamStr),
     split_string(WamStr, "\n", "", Lines),
-    wam_lines_to_go(Lines, PC, Pred/Arity, [], GoLiterals, LabelEntries),
+    wam_lines_to_go(Lines, PC, Module:Pred/Arity, Options, GoLiterals, LabelEntries),
     maplist([Lit, Entry]>>(format(atom(Entry), '        ~w,', [Lit])), GoLiterals, InstrEntries),
     maplist([Label-Idx, Entry]>>(format(atom(Entry), '        "~w": ~w,', [Label, Idx])), LabelEntries, LabelRows),
     length(GoLiterals, InstrCount),
     NextPC is PC + InstrCount,
-    collect_wam_entries(Rest, NextPC, RestEntries, RestInstrs, RestLabels),
+    collect_wam_entries(Rest, Options, NextPC, RestEntries, RestInstrs, RestLabels),
     append(InstrEntries, RestInstrs, AllInstrs),
     append(LabelRows, RestLabels, AllLabels).
-collect_wam_entries([_|Rest], PC, Entries, Instrs, Labels) :-
-    collect_wam_entries(Rest, PC, Entries, Instrs, Labels).
+collect_wam_entries([_|Rest], Options, PC, Entries, Instrs, Labels) :-
+    collect_wam_entries(Rest, Options, PC, Entries, Instrs, Labels).
 
 generate_predicate_codes([], _, []).
 generate_predicate_codes([classified(_, _Pred, _Arity, native, PredCode)|Rest], WamEntries,
@@ -197,6 +200,24 @@ generate_predicate_codes([classified(_, _Pred, _Arity, failed, PredCode)|Rest], 
                          [Code|RestCodes]) :-
     format(atom(Code), '// Strategy: failed~n~w', [PredCode]),
     generate_predicate_codes(Rest, WamEntries, RestCodes).
+
+compile_shared_foreign_setup(Classified, Options, Code) :-
+    findall(Line,
+        ( member(classified(Module, Pred, Arity, wam_foreign, _), Classified),
+          go_foreign_spec(Module:Pred/Arity, Options, SetupOps, _RewriteCalls, _EntryPred/_EntryArity),
+          maplist(go_foreign_setup_line, SetupOps, SetupLines),
+          member(Line, SetupLines)
+        ),
+        RawLines),
+    sort(RawLines, Lines),
+    (   Lines == []
+    ->  Body = ""
+    ;   atomic_list_concat(Lines, '\n', Body)
+    ),
+    format(atom(Code),
+'func setupSharedForeignPredicates(vm *WamState) {
+~w
+}', [Body]).
 
 %% compile_wam_runtime_to_go(+Options, -GoCode)
 %  Placeholder for potentially transpiling larger parts of wam_runtime.pl
@@ -368,6 +389,7 @@ const ~wStartPC = ~w
 
 func ~w(~w) bool {
     vm := NewWamState(sharedWamCode, sharedWamLabels)
+    setupSharedForeignPredicates(vm)
     vm.PC = ~w
 ~w
     return vm.Run()
@@ -429,7 +451,8 @@ go_foreign_setup_code(Ops, Setup) :-
 go_foreign_setup_line(register_foreign_native_kind(Pred/Arity, Kind), Line) :-
     format(atom(Line), '    vm.registerForeignNativeKind("~w/~w", "~w")', [Pred, Arity, Kind]).
 go_foreign_setup_line(register_foreign_result_layout(Pred/Arity, tuple(ResultArity)), Line) :-
-    format(atom(Line), '    vm.registerForeignResultLayout("~w/~w", "tuple:~w")', [Pred, Arity, ResultArity]).
+    format(atom(Line), '    vm.registerForeignResultLayout("~w/~w", "tuple:~w")', [Pred, Arity, ResultArity]),
+    !.
 go_foreign_setup_line(register_foreign_result_layout(Pred/Arity, Layout), Line) :-
     format(atom(Line), '    vm.registerForeignResultLayout("~w/~w", "~w")', [Pred, Arity, Layout]).
 go_foreign_setup_line(register_foreign_result_mode(Pred/Arity, Mode), Line) :-
@@ -712,16 +735,16 @@ parse_string_to_go_val(Str, GoVal) :-
     ;   go_value_literal(Str, GoVal)
     ).
 
-wam_line_to_go_literal(["call", P, N], Pred/Arity, Options, GoLit) :-
+wam_line_to_go_literal(["call", P, N], PredIndicator, Options, GoLit) :-
     clean_comma(P, CP), clean_comma(N, CN),
     (   number_string(Num, CN) -> true ; Num = 0 ),
-    (   go_foreign_rewrite_call(Options, Pred/Arity, CP, Num, ForeignPred, ForeignArity)
+    (   go_foreign_rewrite_call(Options, PredIndicator, CP, Num, ForeignPred, ForeignArity)
     ->  format(atom(GoLit), '&CallForeign{Pred: "~w", Arity: ~w}', [ForeignPred, ForeignArity])
     ;   format(atom(GoLit), '&Call{Pred: "~w", Arity: ~w}', [CP, CN])
     ).
-wam_line_to_go_literal(["execute", P], Pred/Arity, Options, GoLit) :-
+wam_line_to_go_literal(["execute", P], PredIndicator, Options, GoLit) :-
     clean_comma(P, CP),
-    (   go_foreign_rewrite_execute(Options, Pred/Arity, CP, ForeignPred, ForeignArity)
+    (   go_foreign_rewrite_execute(Options, PredIndicator, CP, ForeignPred, ForeignArity)
     ->  format(atom(GoLit), '&CallForeign{Pred: "~w", Arity: ~w}', [ForeignPred, ForeignArity])
     ;   format(atom(GoLit), '&Execute{Pred: "~w"}', [CP])
     ).
@@ -813,12 +836,26 @@ go_foreign_rewrite_call(Options, CurrentPred, TargetPredArity, Num, ForeignPred,
     format(string(ExpectedTarget), "~w/~w", [TargetPred, TargetArity]),
     TargetPredArity == ExpectedTarget,
     Num =:= ForeignArity.
+go_foreign_rewrite_call(Options, CurrentPred, TargetPredArity, Num, ForeignPred, ForeignArity) :-
+    predicate_indicator_parts(CurrentPred, Module, _CurrentPred, _CurrentArity),
+    target_predicate_parts(TargetPredArity, TargetPred, TargetArity),
+    go_foreign_spec(Module:TargetPred/TargetArity, Options, _SetupOps, _RewriteCalls, ForeignPred/ForeignArity),
+    Num =:= ForeignArity.
 
 go_foreign_rewrite_execute(Options, CurrentPred, TargetPredArity, ForeignPred, ForeignArity) :-
     go_foreign_spec(CurrentPred, Options, _SetupOps, RewriteCalls, ForeignPred/ForeignArity),
     member(TargetPred/TargetArity, RewriteCalls),
     format(string(ExpectedTarget), "~w/~w", [TargetPred, TargetArity]),
     TargetPredArity == ExpectedTarget.
+go_foreign_rewrite_execute(Options, CurrentPred, TargetPredArity, ForeignPred, ForeignArity) :-
+    predicate_indicator_parts(CurrentPred, Module, _CurrentPred, _CurrentArity),
+    target_predicate_parts(TargetPredArity, TargetPred, TargetArity),
+    go_foreign_spec(Module:TargetPred/TargetArity, Options, _SetupOps, _RewriteCalls, ForeignPred/ForeignArity).
+
+target_predicate_parts(TargetPredArity, Pred, Arity) :-
+    split_string(TargetPredArity, "/", "", [PredStr, ArityStr]),
+    atom_string(Pred, PredStr),
+    number_string(Arity, ArityStr).
 
 wam_line_to_go_literal(Parts, _PredIndicator, _Options, GoLit) :-
     wam_line_to_go_literal(Parts, GoLit).

--- a/tests/test_wam_go_foreign_lowering.pl
+++ b/tests/test_wam_go_foreign_lowering.pl
@@ -13,6 +13,7 @@
 :- dynamic test_step_parent_distance/5.
 :- dynamic test_weighted_path/3.
 :- dynamic test_astar_weighted_path/4.
+:- dynamic test_mixed_weighted_filtered/2.
 
 edge(a, b).
 edge(b, c).
@@ -78,6 +79,12 @@ test_astar_weighted_path(X, Y, 5, Cost) :-
     weighted_edge(X, Z, W),
     test_astar_weighted_path(Z, Y, 5, RestCost),
     Cost is W + RestCost.
+
+test_mixed_weighted_filtered(Target, Cost) :-
+    test_weighted_path(s, Target, Cost),
+    Cost < 5.0,
+    atom(foo),
+    \+ atom(5).
 
 test(foreign_spec_wrapper_generation) :-
     ForeignSpec = foreign_predicate(
@@ -556,6 +563,94 @@ func TestForeignProjectAutoDetectWeightedAndAstar(t *testing.T) {
         ;   true
         ),
         delete_directory_and_contents(TmpDir)
+    )).
+
+test(foreign_mixed_boundary_weighted_backtracking) :-
+    once((
+        get_time(T),
+        format(atom(TmpDir), 'tmp_wam_go_mixed_foreign_~w', [T]),
+        write_wam_go_project(
+            [plunit_wam_go_foreign_lowering:test_mixed_weighted_filtered/2,
+             plunit_wam_go_foreign_lowering:test_weighted_path/3],
+            [module_name(go_mixed_foreign_test),
+             foreign_lowering(true)],
+            TmpDir
+        ),
+        directory_file_path(TmpDir, 'lib.go', LibPath),
+        read_file_to_string(LibPath, LibCode, []),
+        assertion(sub_string(LibCode, _, _, _, '&CallForeign{Pred: "test_weighted_path", Arity: 3}')),
+        directory_file_path(TmpDir, 'mixed_foreign_test.go', TestPath),
+        write_file(TestPath,
+'package wam
+
+import "testing"
+
+func TestMixedBoundaryWeightedBacktracking(t *testing.T) {
+    vm := NewWamState(sharedWamCode, sharedWamLabels)
+    setupSharedForeignPredicates(vm)
+    vm.PC = Test_mixed_weighted_filteredStartPC
+    target := &Unbound{Name: "TARGET"}
+    cost := &Unbound{Name: "COST"}
+    vm.Regs["A1"] = target
+    vm.Regs["A2"] = cost
+    if !vm.Run() {
+        t.Fatalf("expected mixed weighted caller to succeed")
+    }
+    gotTarget, okTarget := vm.deref(target).(*Atom)
+    gotCost, okCost := vm.deref(cost).(*Float)
+    if !okTarget || !okCost || gotTarget.Name != "a" || gotCost.Val != 1.0 {
+        t.Fatalf("expected first mixed result a/1.0, got %#v %#v", vm.deref(target), vm.deref(cost))
+    }
+    if !vm.backtrack() {
+        t.Fatalf("expected second mixed result")
+    }
+    if !vm.Run() {
+        t.Fatalf("expected mixed caller to resume after second backtrack")
+    }
+    gotTarget, okTarget = vm.deref(target).(*Atom)
+    gotCost, okCost = vm.deref(cost).(*Float)
+    if !okTarget || !okCost || gotTarget.Name != "b" || gotCost.Val != 3.0 {
+        t.Fatalf("expected second mixed result b/3.0, got %#v %#v", vm.deref(target), vm.deref(cost))
+    }
+    if !vm.backtrack() {
+        t.Fatalf("expected third mixed result")
+    }
+    if !vm.Run() {
+        t.Fatalf("expected mixed caller to resume after third backtrack")
+    }
+    gotTarget, okTarget = vm.deref(target).(*Atom)
+    gotCost, okCost = vm.deref(cost).(*Float)
+    if !okTarget || !okCost || gotTarget.Name != "c" || gotCost.Val != 4.0 {
+        t.Fatalf("expected third mixed result c/4.0, got %#v %#v", vm.deref(target), vm.deref(cost))
+    }
+    if !vm.backtrack() {
+        t.Fatalf("expected final foreign backtrack to reach filtered-out result")
+    }
+    if vm.Run() {
+        t.Fatalf("expected mixed weighted caller to stop after filtered results")
+    }
+}
+'),
+        (   catch(process_create(path(go), ['test', './...'], [cwd(TmpDir), stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]), _, fail)
+        ->  read_string(Out, _, _Stdout),
+            read_string(Err, _, Stderr),
+            process_wait(Pid, Exit),
+            assertion(Exit == exit(0)),
+            assertion(\+ sub_string(Stderr, _, _, _, 'FAIL'))
+        ;   true
+        ),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+test(foreign_no_kernels_suppresses_go_auto_detection) :-
+    once((
+        compile_wam_predicate_to_go(plunit_wam_go_foreign_lowering:test_weighted_path/3,
+            "call test_weighted_path/3, 3",
+            [foreign_lowering(true), no_kernels(true)],
+            Code),
+        assertion(\+ sub_string(Code, _, _, _, 'registerForeignNativeKind("test_weighted_path/3", "weighted_shortest_path3")')),
+        assertion(\+ sub_string(Code, _, _, _, 'executeForeignPredicate("test_weighted_path", 3)')),
+        assertion(sub_string(Code, _, _, _, '&Call{Pred: "test_weighted_path/3", Arity: 3}'))
     )).
 
 :- end_tests(wam_go_foreign_lowering).


### PR DESCRIPTION
## Summary

This PR closes the next Go hybrid/WAM correctness gap after the project-level auto-detect work:

- it adds end-to-end coverage for a shared-table WAM predicate that calls an auto-detected foreign kernel and then continues through ordinary WAM code
- it adds a regression test for `no_kernels(true)` on the Go hybrid path
- it fixes the shared-table Go project wiring needed to make that mixed execution path work

## What Changed

- adds a mixed-boundary Go regression where:
  - a WAM-fallback predicate calls `weighted_shortest_path3` through `CallForeign`
  - execution continues through ordinary WAM builtins and filtering
  - backtracking resumes through foreign stream results and re-enters WAM code correctly
- adds a `no_kernels(true)` regression test ensuring Go suppresses auto-detected foreign lowering when explicitly requested
- fixes shared-table WAM project generation so:
  - project options are preserved while lowering shared WAM instructions
  - cross-predicate rewrites can detect separately foreign-lowered callees
  - shared WAM VMs receive project-level foreign registrations for `CallForeign` dispatch
- removes a duplicate foreign result-layout emission in shared foreign setup

## Why

Before this PR, Go had direct foreign-wrapper coverage and project-level auto-detect coverage, but it still lacked proof that the most important hybrid boundary actually worked:

- interpreted/shared-table WAM caller
- foreign kernel dispatch in the middle of that caller
- resumed WAM execution after the foreign call
- backtracking across foreign stream results with downstream WAM filtering still applied

That boundary is the realistic failure surface for the Go hybrid target.

This PR also locks down the explicit pure-interpreter escape hatch:

- `no_kernels(true)` should mean no foreign/kernel lowering
- the Go target now has a regression test that enforces that contract

## Files

- `tests/test_wam_go_foreign_lowering.pl`
- `src/unifyweaver/targets/wam_go_target.pl`

## Verification

Passed locally:

- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`

## Benchmark Note

For future benchmark comparisons, the most useful setup is probably a configurable target list rather than one fixed cross-target matrix.

Reasons:

- different runs may want different comparison sets
- optimized-Prolog/transpiled targets and hybrid-WAM targets answer different performance questions
- the C# parameterized query engine is still a valuable comparison point even though it is architecturally different

Suggested benchmark grouping:

- optimized/transpiled Prolog paths
  - native Prolog
  - Rust lowered / optimized paths
  - Haskell lowered / optimized paths
  - optionally Go native/optimized paths where relevant
- hybrid WAM paths
  - Go hybrid
  - Rust hybrid
  - Haskell hybrid
- pure interpreter baselines
  - same hybrid targets with `no_kernels(true)`
- C# parameterized query engine
  - kept as an explicit comparison target, not treated as the same category

There is also a practical Termux caveat:

- running the C# comparison through `proot` Debian in this environment would add an unfair overhead penalty
- so the benchmark harness should make target selection configurable enough to exclude C# in Termux runs and include it in fairer environments

## Reviewer Notes

The key review point is the shared-table wiring change:

- `CallForeign` inside shared WAM code now has the foreign registrations it needs at runtime
- mixed WAM → foreign → WAM execution is now explicitly tested instead of being inferred from direct wrapper behavior
