### PR TITLE
bench: add configurable effective-distance target matrix

### DIFF
--- a/docs/design/BENCHMARK_TARGET_MATRIX.md
+++ b/docs/design/BENCHMARK_TARGET_MATRIX.md
@@ -1,0 +1,127 @@
+# Benchmark Target Matrix
+
+## Goal
+
+Benchmark comparisons need to separate execution families that look similar at the command line but are not the same compilation path.
+
+The important distinction is whether a target is:
+
+- optimized Prolog transpilation
+- hybrid WAM execution
+- direct target-language pipeline generation
+- a query engine
+
+If those are mixed without labeling, the numbers are hard to interpret.
+
+## Current Effective-Distance Paths
+
+### Haskell
+
+The Haskell effective-distance benchmark can start from optimized Prolog.
+
+Path:
+
+1. Load the workload Prolog.
+2. Run `prolog_target` optimization passes.
+3. Load the generated optimized predicates back into Prolog.
+4. Emit a WAM Haskell project with `write_wam_haskell_project/3`.
+
+That means Haskell is not "always WAM first, then Haskell" in a naive sense. The benchmark can start from optimized Prolog, and WAM remains the lowering substrate and fallback path.
+
+The relevant modes are:
+
+- `interpreter + no_kernels(true)` -> pure interpreter baseline
+- `interpreter + kernels enabled` -> hybrid WAM + FFI
+- `functions + no_kernels(true)` -> lowered-only
+- `functions + kernels enabled` -> lowered functions with WAM fallback + FFI
+
+### Rust
+
+There are two materially different Rust benchmark paths today.
+
+Direct pipeline path:
+
+1. `generate_pipeline.py`
+2. Emit a direct Rust executable
+
+This is not the same thing as compiling optimized Prolog into a WAM Rust project.
+
+Hybrid WAM Rust path:
+
+1. Load the workload Prolog.
+2. Optionally run `prolog_target` optimization passes.
+3. Compile selected predicates to WAM.
+4. Emit a merged-code Rust WAM benchmark project.
+
+So Rust already has both:
+
+- a direct pipeline benchmark path
+- a hybrid WAM benchmark path
+
+### Go
+
+The current effective-distance benchmark surface for Go is the direct pipeline path from `generate_pipeline.py`.
+
+That is useful for comparison, but it is not yet the same kind of optimized-Prolog-to-hybrid-WAM benchmark path that exists for Haskell and WAM Rust.
+
+### C#
+
+The C# query runtime is still a useful comparison point because it is heavily optimized, but it belongs in its own category.
+
+It should not be treated as just another transpiled target.
+
+## Target Categories
+
+The new matrix script uses these categories:
+
+- `optimized-prolog`
+- `hybrid-wam`
+- `direct-pipeline`
+- `query-engine`
+
+The default presets are:
+
+- `portable-default`
+- `desktop-default`
+- `optimized-prolog`
+- `hybrid-wam`
+- `direct-pipeline`
+- `query-engine`
+- `all`
+
+## Termux Rule
+
+On Termux, the default set excludes C#.
+
+Reason:
+
+- running C# through `proot` Debian adds an environment penalty
+- that penalty is not part of the query engine itself
+- including it in default local comparisons would bias the numbers
+
+C# stays available in the harness as an explicit opt-in target for environments where it can run natively.
+
+## Scripts
+
+New scripts:
+
+- `examples/benchmark/benchmark_effective_distance_matrix.py`
+- `examples/benchmark/generate_wam_haskell_matrix_benchmark.pl`
+
+Examples:
+
+```bash
+python examples/benchmark/benchmark_effective_distance_matrix.py --list-targets
+```
+
+```bash
+python examples/benchmark/benchmark_effective_distance_matrix.py --target-sets optimized-prolog,hybrid-wam --scales 300,1k
+```
+
+```bash
+python examples/benchmark/benchmark_effective_distance_matrix.py --targets prolog-accumulated,wam-rust-accumulated,haskell-lowered-ffi
+```
+
+```bash
+python examples/benchmark/benchmark_effective_distance_matrix.py --target-sets portable-default --include-targets csharp-query
+```

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -33,6 +33,11 @@ def require_file(path: Path) -> Path:
     return path
 
 
+def is_termux_environment() -> bool:
+    prefix = os.environ.get("PREFIX", "")
+    return "com.termux" in prefix or "termux" in prefix.lower() or "TERMUX_VERSION" in os.environ
+
+
 def scale_sort_key(scale: str) -> tuple[int, str]:
     digits = "".join(ch for ch in scale if ch.isdigit())
     suffix = "".join(ch for ch in scale if not ch.isdigit())
@@ -49,6 +54,9 @@ def available_targets(requested: list[str]) -> list[str]:
     for target in requested:
         if target.startswith("csharp-") and shutil.which("dotnet") is None:
             print(f"skip {target}: dotnet not found", file=sys.stderr)
+            continue
+        if target.startswith("haskell-") and (shutil.which("cabal") is None or shutil.which("ghc") is None):
+            print(f"skip {target}: cabal or ghc not found", file=sys.stderr)
             continue
         if target.startswith("rust-") and shutil.which("rustc") is None:
             print(f"skip {target}: rustc not found", file=sys.stderr)
@@ -193,6 +201,15 @@ def build_go_binary(
     env = dict(os.environ, GOCACHE=str(go_cache))
     run_command(["go", "build", "-o", str(binary), str(source)], env=env)
     return [str(binary)]
+
+
+def build_haskell_project(project_dir: Path, executable_name: str) -> list[str]:
+    run_command(["cabal", "build", f"exe:{executable_name}"], cwd=project_dir)
+    result = run_command(["cabal", "list-bin", f"exe:{executable_name}"], cwd=project_dir)
+    binary = result.stdout.strip()
+    if not binary:
+        raise RuntimeError(f"could not resolve cabal binary for {executable_name}")
+    return [binary]
 
 
 def digest_normalized_output(normalized: str) -> tuple[str, int]:

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""
+Benchmark effective-distance across multiple execution families without
+mixing them implicitly.
+
+The important distinction is the compilation path:
+
+  - optimized-prolog:
+      Prolog workload -> prolog_target optimization -> generated benchmark
+      surface or lowered Haskell with WAM fallback available
+  - hybrid-wam:
+      optimized Prolog helpers compiled to WAM-backed targets
+  - direct-pipeline:
+      direct target-language pipeline generators, not the optimized-Prolog path
+  - query-engine:
+      the C# parameterized query runtime
+
+On Termux, the default target set excludes C# because running it through
+proot Debian would impose an unfair benchmark penalty.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmark_common import (
+    available_targets,
+    build_csharp_package,
+    build_go_binary,
+    build_haskell_project,
+    build_rust_binary,
+    digest_normalized_output,
+    find_result,
+    group_results_by_scale,
+    normalize_three_column_float_rows,
+    print_match_status,
+    print_result_table,
+    print_speedup,
+    require_file,
+    run_command,
+)
+from benchmark_target_matrix import (
+    TARGETS,
+    default_target_set_name,
+    list_targets_text,
+    parse_csv,
+    resolve_targets,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
+PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_effective_distance_benchmark.pl"
+WAM_RUST_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_effective_distance_benchmark.pl"
+WAM_HASKELL_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_haskell_matrix_benchmark.pl"
+DEFAULT_FACTS = BENCH_DIR / "10k" / "facts.pl"
+HASKELL_EXE = "wam-haskell-matrix-bench"
+
+
+@dataclass
+class RunResult:
+    target: str
+    scale: str
+    times: list[float]
+    stdout_sha256: str
+    row_count: int
+    stderr: str
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.times)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="300,1k,5k,10k")
+    parser.add_argument(
+        "--target-sets",
+        default="",
+        help=f"Comma-separated target sets. Defaults to {default_target_set_name()} for this environment.",
+    )
+    parser.add_argument(
+        "--targets",
+        default="",
+        help="Comma-separated explicit targets. Overrides the default target set selection.",
+    )
+    parser.add_argument("--include-targets", default="")
+    parser.add_argument("--exclude-targets", default="")
+    parser.add_argument("--baseline-target", default="prolog-accumulated")
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--keep-temp", action="store_true")
+    parser.add_argument("--list-targets", action="store_true")
+    return parser.parse_args()
+
+
+def benchmark_temp_parent() -> Path:
+    candidates: list[Path] = []
+    for var in ("TMPDIR", "TMP", "TEMP"):
+        raw = os.environ.get(var)
+        if raw:
+            candidates.append(Path(raw))
+    prefix = os.environ.get("PREFIX")
+    if prefix:
+        candidates.append(Path(prefix) / "tmp")
+    candidates.extend([ROOT / "output", Path("/tmp")])
+    for candidate in candidates:
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+            probe = candidate / ".uw_matrix_probe"
+            probe.write_text("", encoding="utf-8")
+            probe.unlink()
+            return candidate
+        except OSError:
+            continue
+    raise RuntimeError("no writable temporary directory found")
+
+
+def build_csharp_query(root: Path) -> list[str]:
+    return build_csharp_package(
+        GENERATOR, DEFAULT_FACTS, "effective_distance", "csharp_query", root / "csharp_query", root="Physics"
+    )
+
+
+def build_csharp_dfs(root: Path) -> list[str]:
+    return build_csharp_package(
+        GENERATOR, DEFAULT_FACTS, "effective_distance", "csharp", root / "csharp_dfs", root="Physics"
+    )
+
+
+def build_rust_dfs(root: Path) -> list[str]:
+    return build_rust_binary(
+        GENERATOR, DEFAULT_FACTS, "effective_distance", root / "rust_dfs", "effective_distance_rust", root="Physics"
+    )
+
+
+def build_go_dfs(root: Path) -> list[str]:
+    return build_go_binary(
+        GENERATOR, DEFAULT_FACTS, "effective_distance", root / "go_dfs", "effective_distance_go", root="Physics"
+    )
+
+
+def build_prolog_effective_distance(root: Path, scale: str, variant: str) -> list[str]:
+    facts_path = require_file(BENCH_DIR / scale / "facts.pl")
+    script_path = root / f"prolog_{variant}" / scale / f"effective_distance_{variant}.pl"
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(PROLOG_GENERATOR),
+            "--",
+            str(facts_path),
+            str(script_path),
+            variant,
+        ],
+        cwd=ROOT,
+    )
+    return ["swipl", "-q", "-s", str(script_path)]
+
+
+def build_wam_rust_effective_distance(root: Path, scale: str, variant: str) -> list[str]:
+    facts_path = require_file(BENCH_DIR / scale / "facts.pl")
+    project_dir = root / f"wam_rust_{variant}" / scale
+    project_dir.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(WAM_RUST_GENERATOR),
+            "--",
+            str(facts_path),
+            str(project_dir),
+            variant,
+        ],
+        cwd=ROOT,
+    )
+    run_command(["cargo", "build", "--release"], cwd=project_dir)
+    binary = project_dir / "target" / "release" / "hybrid_ed_bench"
+    scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
+    return [str(binary), str(scale_dir)]
+
+
+def build_haskell_effective_distance(root: Path, mode: str, kernel_mode: str) -> list[str]:
+    project_dir = root / f"haskell_{mode}_{kernel_mode}"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(WAM_HASKELL_GENERATOR),
+            "--",
+            str(DEFAULT_FACTS),
+            str(project_dir),
+            "accumulated",
+            mode,
+            kernel_mode,
+        ],
+        cwd=ROOT,
+    )
+    return build_haskell_project(project_dir, HASKELL_EXE)
+
+
+def build_scale_independent_commands(root: Path, targets: list[str]) -> dict[str, list[str]]:
+    commands: dict[str, list[str]] = {}
+    for target in targets:
+        if target == "csharp-query":
+            commands[target] = build_csharp_query(root)
+        elif target == "csharp-dfs":
+            commands[target] = build_csharp_dfs(root)
+        elif target == "rust-dfs":
+            commands[target] = build_rust_dfs(root)
+        elif target == "go-dfs":
+            commands[target] = build_go_dfs(root)
+        elif target == "haskell-pure-interp":
+            commands[target] = build_haskell_effective_distance(root, "interpreter", "kernels_off")
+        elif target == "haskell-interp-ffi":
+            commands[target] = build_haskell_effective_distance(root, "interpreter", "kernels_on")
+        elif target == "haskell-lowered-only":
+            commands[target] = build_haskell_effective_distance(root, "functions", "kernels_off")
+        elif target == "haskell-lowered-ffi":
+            commands[target] = build_haskell_effective_distance(root, "functions", "kernels_on")
+    return commands
+
+
+def normalize_output(output: str) -> str:
+    return normalize_three_column_float_rows(output, decimals=9)
+
+
+def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
+    times: list[float] = []
+    stdout = ""
+    stderr = ""
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        if target.startswith("prolog-") or target.startswith("wam-"):
+            result = run_command(command, cwd=ROOT)
+        else:
+            scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
+            edge_path = scale_dir / "category_parent.tsv"
+            article_path = scale_dir / "article_category.tsv"
+            result = run_command(command + [str(edge_path), str(article_path)], cwd=ROOT)
+        times.append(time.perf_counter() - started)
+        stdout = result.stdout
+        stderr = result.stderr
+
+    normalized = normalize_output(stdout)
+    digest, row_count = digest_normalized_output(normalized)
+    return RunResult(target, scale, times, digest, row_count, stderr)
+
+
+def print_summary(results: list[RunResult], baseline_target: str) -> None:
+    print("scale\ttarget\tcategory\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
+    for scale, entries in group_results_by_scale(results):
+        for result in sorted(entries, key=lambda item: item.target):
+            category = TARGETS[result.target].category
+            print(
+                f"{scale}\t{result.target}\t{category}\t{result.median:.3f}\t"
+                f"{min(result.times):.3f}\t{max(result.times):.3f}\t"
+                f"{result.row_count}\t{result.stdout_sha256[:12]}"
+            )
+
+        if len(entries) > 1:
+            print_match_status(scale, "all_outputs", entries)
+
+        for category in sorted({TARGETS[item.target].category for item in entries}):
+            category_entries = [item for item in entries if TARGETS[item.target].category == category]
+            if len(category_entries) > 1:
+                print_match_status(scale, f"{category}_outputs", category_entries)
+
+        baseline = find_result(entries, baseline_target)
+        if baseline:
+            for result in sorted(entries, key=lambda item: item.target):
+                if result.target == baseline_target:
+                    continue
+                print_speedup(scale, f"speedup_vs_{baseline_target}_{result.target}", baseline, result)
+
+
+def resolve_requested_targets(args: argparse.Namespace) -> list[str]:
+    explicit_targets = parse_csv(args.targets) if args.targets else None
+    target_set_names = parse_csv(args.target_sets) if args.target_sets else None
+    include_targets = parse_csv(args.include_targets) if args.include_targets else None
+    exclude_targets = parse_csv(args.exclude_targets) if args.exclude_targets else None
+    resolved = resolve_targets(
+        explicit_targets=explicit_targets,
+        target_set_names=target_set_names,
+        include_targets=include_targets,
+        exclude_targets=exclude_targets,
+    )
+    return available_targets(resolved)
+
+
+def main() -> int:
+    args = parse_args()
+    if args.list_targets:
+        print(list_targets_text())
+        return 0
+
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    targets = resolve_requested_targets(args)
+    if not targets:
+        print("no benchmark targets available", file=sys.stderr)
+        return 1
+
+    temp_parent = benchmark_temp_parent()
+    temp_ctx = None
+    if args.keep_temp:
+        temp_root = Path(tempfile.mkdtemp(prefix="uw-effective-matrix-", dir=temp_parent))
+    else:
+        temp_ctx = tempfile.TemporaryDirectory(prefix="uw-effective-matrix-", dir=temp_parent)
+        temp_root = Path(temp_ctx.name)
+
+    try:
+        commands = build_scale_independent_commands(temp_root, targets)
+        results: list[RunResult] = []
+        for scale in scales:
+            for target in targets:
+                if target == "prolog-seeded":
+                    command = build_prolog_effective_distance(temp_root, scale, "seeded")
+                elif target == "prolog-accumulated":
+                    command = build_prolog_effective_distance(temp_root, scale, "accumulated")
+                elif target == "wam-rust-seeded":
+                    command = build_wam_rust_effective_distance(temp_root, scale, "seeded")
+                elif target == "wam-rust-accumulated":
+                    command = build_wam_rust_effective_distance(temp_root, scale, "accumulated")
+                else:
+                    command = commands[target]
+                results.append(benchmark_target(command, scale, args.repetitions, target))
+
+        print_summary(results, args.baseline_target)
+        return 0
+    finally:
+        if temp_ctx is not None:
+            temp_ctx.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from benchmark_common import is_termux_environment
+
+
+@dataclass(frozen=True)
+class TargetInfo:
+    name: str
+    category: str
+    description: str
+
+
+TARGETS: dict[str, TargetInfo] = {
+    "csharp-query": TargetInfo(
+        "csharp-query",
+        "query-engine",
+        "Parameterized C# query runtime",
+    ),
+    "csharp-dfs": TargetInfo(
+        "csharp-dfs",
+        "direct-pipeline",
+        "Generated C# DFS executable",
+    ),
+    "rust-dfs": TargetInfo(
+        "rust-dfs",
+        "direct-pipeline",
+        "Generated Rust DFS executable",
+    ),
+    "go-dfs": TargetInfo(
+        "go-dfs",
+        "direct-pipeline",
+        "Generated Go DFS executable",
+    ),
+    "prolog-seeded": TargetInfo(
+        "prolog-seeded",
+        "optimized-prolog",
+        "Generated Prolog seeded benchmark",
+    ),
+    "prolog-accumulated": TargetInfo(
+        "prolog-accumulated",
+        "optimized-prolog",
+        "Generated Prolog accumulated benchmark",
+    ),
+    "wam-rust-seeded": TargetInfo(
+        "wam-rust-seeded",
+        "hybrid-wam",
+        "Hybrid WAM Rust benchmark with seeded host accumulation",
+    ),
+    "wam-rust-accumulated": TargetInfo(
+        "wam-rust-accumulated",
+        "hybrid-wam",
+        "Hybrid WAM Rust benchmark with optimized accumulated helpers",
+    ),
+    "haskell-pure-interp": TargetInfo(
+        "haskell-pure-interp",
+        "hybrid-wam",
+        "Optimized Prolog -> WAM Haskell interpreter with no_kernels(true)",
+    ),
+    "haskell-interp-ffi": TargetInfo(
+        "haskell-interp-ffi",
+        "hybrid-wam",
+        "Optimized Prolog -> WAM Haskell interpreter with kernels enabled",
+    ),
+    "haskell-lowered-only": TargetInfo(
+        "haskell-lowered-only",
+        "optimized-prolog",
+        "Optimized Prolog -> lowered Haskell functions with no_kernels(true)",
+    ),
+    "haskell-lowered-ffi": TargetInfo(
+        "haskell-lowered-ffi",
+        "optimized-prolog",
+        "Optimized Prolog -> lowered Haskell functions with kernels enabled",
+    ),
+}
+
+
+TARGET_SETS: dict[str, list[str]] = {
+    "optimized-prolog": [
+        "prolog-seeded",
+        "prolog-accumulated",
+        "haskell-lowered-only",
+        "haskell-lowered-ffi",
+    ],
+    "hybrid-wam": [
+        "wam-rust-seeded",
+        "wam-rust-accumulated",
+        "haskell-pure-interp",
+        "haskell-interp-ffi",
+        "haskell-lowered-only",
+        "haskell-lowered-ffi",
+    ],
+    "direct-pipeline": [
+        "rust-dfs",
+        "go-dfs",
+        "csharp-dfs",
+    ],
+    "query-engine": [
+        "csharp-query",
+    ],
+    "portable-default": [
+        "prolog-accumulated",
+        "wam-rust-accumulated",
+        "haskell-lowered-ffi",
+        "rust-dfs",
+        "go-dfs",
+    ],
+    "desktop-default": [
+        "prolog-accumulated",
+        "wam-rust-accumulated",
+        "haskell-lowered-ffi",
+        "rust-dfs",
+        "go-dfs",
+        "csharp-query",
+        "csharp-dfs",
+    ],
+}
+
+TARGET_SETS["all"] = list(TARGETS.keys())
+
+
+def default_target_set_name() -> str:
+    return "portable-default" if is_termux_environment() else "desktop-default"
+
+
+def parse_csv(value: str) -> list[str]:
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def list_targets_text() -> str:
+    lines = ["name\tcategory\tdescription"]
+    for name in sorted(TARGETS):
+        info = TARGETS[name]
+        lines.append(f"{info.name}\t{info.category}\t{info.description}")
+    lines.append("")
+    lines.append("target_set\ttargets")
+    for set_name in sorted(TARGET_SETS):
+        lines.append(f"{set_name}\t{','.join(TARGET_SETS[set_name])}")
+    return "\n".join(lines)
+
+
+def resolve_targets(
+    *,
+    explicit_targets: list[str] | None,
+    target_set_names: list[str] | None,
+    include_targets: list[str] | None = None,
+    exclude_targets: list[str] | None = None,
+) -> list[str]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+
+    def add_target(name: str) -> None:
+        if name not in TARGETS:
+            raise ValueError(f"unknown benchmark target: {name}")
+        if name not in seen:
+            ordered.append(name)
+            seen.add(name)
+
+    if explicit_targets:
+        for name in explicit_targets:
+            add_target(name)
+    else:
+        set_names = target_set_names or [default_target_set_name()]
+        for set_name in set_names:
+            if set_name not in TARGET_SETS:
+                raise ValueError(f"unknown target set: {set_name}")
+            for name in TARGET_SETS[set_name]:
+                add_target(name)
+
+    for name in include_targets or []:
+        add_target(name)
+
+    excluded = set(exclude_targets or [])
+    unknown_excluded = sorted(name for name in excluded if name not in TARGETS)
+    if unknown_excluded:
+        raise ValueError(f"unknown benchmark targets in exclude list: {', '.join(unknown_excluded)}")
+    return [name for name in ordered if name not in excluded]

--- a/examples/benchmark/generate_wam_haskell_matrix_benchmark.pl
+++ b/examples/benchmark/generate_wam_haskell_matrix_benchmark.pl
@@ -1,0 +1,115 @@
+:- initialization(main, main).
+
+:- use_module('../../src/unifyweaver/targets/wam_haskell_target').
+:- use_module('../../src/unifyweaver/targets/wam_target').
+:- use_module('../../src/unifyweaver/targets/prolog_target').
+
+%% generate_wam_haskell_matrix_benchmark.pl
+%%
+%% Generates an effective-distance Haskell benchmark from OPTIMIZED Prolog,
+%% with explicit control over the execution mode:
+%%
+%%   - interpreter + no_kernels(true)  => pure interpreter baseline
+%%   - interpreter + kernels enabled   => hybrid WAM + FFI
+%%   - functions   + no_kernels(true)  => lowered-only
+%%   - functions   + kernels enabled   => lowered with WAM fallback + FFI
+%%
+%% This makes the benchmark path explicit:
+%%   workload Prolog
+%%     -> prolog_target optimization
+%%     -> optimized Prolog predicates
+%%     -> WAM/Haskell project generation
+%%
+%% Usage:
+%%   swipl -q -s generate_wam_haskell_matrix_benchmark.pl -- \
+%%       <facts.pl> <output-dir> <seeded|accumulated> <interpreter|functions> <kernels_on|kernels_off>
+
+benchmark_workload_path(Path) :-
+    source_file(benchmark_workload_path(_), ThisFile),
+    file_directory_name(ThisFile, Here),
+    directory_file_path(Here, 'effective_distance.pl', Path).
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv = [_FactsPath, OutputDir, VariantAtom, EmitModeAtom, KernelModeAtom]
+    ->  true
+    ;   format(user_error,
+            'Usage: ... -- <facts.pl> <output-dir> <seeded|accumulated> <interpreter|functions> <kernels_on|kernels_off>~n',
+            []),
+        halt(1)
+    ),
+    generate(VariantAtom, EmitModeAtom, KernelModeAtom, OutputDir),
+    halt(0).
+
+main :-
+    format(user_error, 'Error: generation failed~n', []),
+    halt(1).
+
+generate(VariantAtom, EmitModeAtom, KernelModeAtom, OutputDir) :-
+    benchmark_workload_path(WorkloadPath),
+    load_files(WorkloadPath, [silent(true)]),
+    retractall(user:mode(category_ancestor(_, _, _, _))),
+    assertz(user:mode(category_ancestor(-, +, -, +))),
+    parse_variant(VariantAtom, OptimizationOptions),
+    parse_emit_mode(EmitModeAtom, EmitMode),
+    parse_kernel_mode(KernelModeAtom, KernelOptions),
+    BasePreds = [dimension_n/1, max_depth/1, category_ancestor/4],
+    prolog_target:generate_prolog_script(BasePreds, OptimizationOptions, ScriptCode),
+    tmp_file_stream(text, TmpPath, TmpStream),
+    write(TmpStream, ScriptCode),
+    close(TmpStream),
+    load_files(TmpPath, [silent(true)]),
+    delete_file(TmpPath),
+    collect_wam_predicates(VariantAtom, Predicates),
+    query_pred_for_variant(VariantAtom, QueryPredOpts),
+    append([[module_name('wam-haskell-matrix-bench'), emit_mode(EmitMode)], KernelOptions, QueryPredOpts], Options),
+    write_wam_haskell_project(Predicates, Options, OutputDir),
+    format(user_error,
+           '[WAM-Haskell-Matrix] variant=~w emit_mode=~w kernels=~w output=~w~n',
+           [VariantAtom, EmitMode, KernelModeAtom, OutputDir]).
+
+parse_variant(seeded, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false)
+]).
+parse_variant(accumulated, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false),
+    seeded_accumulation(auto)
+]).
+
+parse_emit_mode(interpreter, interpreter).
+parse_emit_mode(functions, functions).
+
+parse_kernel_mode(kernels_on, []).
+parse_kernel_mode(kernels_off, [no_kernels(true)]).
+
+query_pred_for_variant(seeded, []).
+query_pred_for_variant(accumulated, [
+    query_pred('category_ancestor$effective_distance_sum_selected/3')
+]).
+
+collect_wam_predicates(seeded, [
+    user:dimension_n/1,
+    user:max_depth/1,
+    user:category_ancestor/4,
+    user:power_sum_bound/4
+]).
+collect_wam_predicates(accumulated, [
+    user:dimension_n/1,
+    user:max_depth/1,
+    user:category_ancestor/4,
+    user:'category_ancestor$power_sum_bound'/3,
+    user:'category_ancestor$power_sum_selected'/3,
+    user:'category_ancestor$effective_distance_sum_selected'/3,
+    user:'category_ancestor$effective_distance_sum_bound'/3
+]).
+
+power_sum_bound(Cat, Root, NegN, WeightSum) :-
+    aggregate_all(sum(W),
+        (category_ancestor(Cat, Root, Hops, [Cat]),
+         H is Hops + 1,
+         W is H ** NegN),
+        WeightSum).


### PR DESCRIPTION
## Summary

Adds a configurable benchmark matrix for the effective-distance workload so benchmark comparisons can be grouped by execution family instead of mixing structurally different targets together.

This also makes the current Rust and Haskell benchmark paths explicit:

- Haskell can benchmark from optimized Prolog into WAM/Haskell with selectable `emit_mode(...)` and `no_kernels(true)`.
- Rust currently has both direct-pipeline and hybrid-WAM benchmark paths.
- C# remains available as a comparison target, but is excluded from the default Termux target set because `proot` Debian would impose an unfair runtime penalty.

## What Changed

- added a shared benchmark target catalog and target-set resolver
- added a configurable effective-distance matrix benchmark script
- added a Haskell matrix generator for:
  - interpreter + kernels off
  - interpreter + kernels on
  - functions + kernels off
  - functions + kernels on
- added shared benchmark helpers for:
  - Haskell project builds via `cabal`
  - Termux environment detection
- documented the benchmark categories and current target paths

## New Target Categories

- `optimized-prolog`
- `hybrid-wam`
- `direct-pipeline`
- `query-engine`

## Default Behavior

Desktop default target set:

- `prolog-accumulated`
- `wam-rust-accumulated`
- `haskell-lowered-ffi`
- `rust-dfs`
- `go-dfs`
- `csharp-query`
- `csharp-dfs`

Termux portable default target set:

- `prolog-accumulated`
- `wam-rust-accumulated`
- `haskell-lowered-ffi`
- `rust-dfs`
- `go-dfs`

## Why

Before this change, the benchmark scripts made it too easy to compare targets that were not actually running the same kind of compilation pipeline.

That was especially misleading across:

- optimized-Prolog transpilation
- hybrid WAM execution
- direct target-language pipeline generation
- the C# parameterized query engine

This change makes those distinctions explicit and gives us configurable target lists so different runs can compare different subsets without editing the scripts.

## Files

- `examples/benchmark/benchmark_effective_distance_matrix.py`
- `examples/benchmark/benchmark_target_matrix.py`
- `examples/benchmark/generate_wam_haskell_matrix_benchmark.pl`
- `examples/benchmark/benchmark_common.py`
- `docs/design/BENCHMARK_TARGET_MATRIX.md`

## Verification

- `python -m py_compile examples/benchmark/benchmark_common.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_effective_distance_matrix.py`
- `python examples/benchmark/benchmark_effective_distance_matrix.py --list-targets`
- `swipl -q -s examples/benchmark/generate_wam_haskell_matrix_benchmark.pl -- data/benchmark/300/facts.pl /data/data/com.termux/files/usr/tmp/uw_haskell_matrix_probe accumulated functions kernels_off`
- `python examples/benchmark/benchmark_effective_distance_matrix.py --targets prolog-accumulated --scales 300 --repetitions 1`

## Follow-Up

- add a Go effective-distance hybrid/WAM benchmark generator so Go can participate in the same optimized-Prolog / hybrid-WAM matrix more directly
- extend the target matrix pattern to other benchmark workloads beyond effective-distance
