### PR TITLE
Pack counted path row buffers in the C# query runtime

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -158,14 +158,14 @@ Counted-closure phase split after typed row buffering, pre-sized
 materialization, edge-state node-id preindexing, per-row timing removal, a
 compact `(target, depth)` buffered row shape, O(1) parent-linked
 visited-path extension, a dedicated counted-path traversal frame stack, and
-direct-write seed-batch materialization:
+direct-write seed-batch materialization with a packed target/depth row buffer:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 136.668ms | 0.000ms | 78.053ms | n/a |
-| 300 | Min | 46.030ms | 0.000ms | 5.568ms | 12.685ms |
-| 1k | All | 58.924ms | 0.000ms | 48.248ms | n/a |
-| 1k | Min | 15.563ms | 0.000ms | 1.312ms | 4.921ms |
+| 300 | All | 149.430ms | 0.000ms | 52.088ms | n/a |
+| 300 | Min | 44.722ms | 0.000ms | 5.591ms | 12.771ms |
+| 1k | All | 85.494ms | 0.000ms | 22.895ms | n/a |
+| 1k | Min | 15.479ms | 0.000ms | 1.316ms | 5.006ms |
 
 Interpretation:
 
@@ -195,6 +195,9 @@ Interpretation:
   now grows the list once and writes the new seed batch directly into the new
   slots via `CollectionsMarshal`, avoiding per-row `Add` bookkeeping on the
   final output path
+- the counted-path `All` staging buffer now stores targets and depths in
+  parallel packed lists instead of shuttling a tiny struct per row, reducing
+  replay overhead on the final materialization path
 - weighted `Min` fallback remains the only measured shape where generic
   frontier candidate indexing is directly relevant
 - the next optimization should not add another generic frontier index by

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -327,14 +327,14 @@ Counted-closure phase split after typed row buffering, pre-sized
 materialization, edge-state node-id preindexing, per-row timing removal, a
 compact `(target, depth)` buffered row shape, O(1) parent-linked
 visited-path extension, a dedicated counted-path traversal frame stack, and
-direct-write seed-batch materialization:
+direct-write seed-batch materialization with a packed target/depth row buffer:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 136.668ms | 0.000ms | 78.053ms | n/a |
-| 300 | Min | 46.030ms | 0.000ms | 5.568ms | 12.685ms |
-| 1k | All | 58.924ms | 0.000ms | 48.248ms | n/a |
-| 1k | Min | 15.563ms | 0.000ms | 1.312ms | 4.921ms |
+| 300 | All | 149.430ms | 0.000ms | 52.088ms | n/a |
+| 300 | Min | 44.722ms | 0.000ms | 5.591ms | 12.771ms |
+| 1k | All | 85.494ms | 0.000ms | 22.895ms | n/a |
+| 1k | Min | 15.479ms | 0.000ms | 1.316ms | 5.006ms |
 
 Interpretation:
 
@@ -377,6 +377,9 @@ Interpretation:
   now grows the list once and writes the new seed batch directly into the new
   slots via `CollectionsMarshal`, avoiding per-row `Add` bookkeeping on the
   final output path
+- the counted-path `All` staging buffer now stores targets and depths in
+  parallel packed lists instead of shuttling a tiny struct per row, reducing
+  replay overhead on the final materialization path
 - the next broad optimization should avoid adding more generic frontier indexes
   until another dominance-heavy fallback shape appears; for counted closure,
   remaining work should target expansion/materialization overhead

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -969,22 +969,23 @@ python examples/benchmark/benchmark_shortest_path_to_root.py \
 Latest local results after edge-state node-id preindexing, per-row timing
 removal, a compact `(target, depth)` buffered row shape, O(1)
 parent-linked visited-path extension, and a dedicated counted-path traversal
-frame stack with explicit initial capacity, plus direct-write seed-batch
-materialization into the destination output list:
+frame stack with explicit initial capacity, direct-write seed-batch
+materialization into the destination output list, and a packed target/depth
+row buffer:
 
 | Scale | All | Min | Speedup | Output Match | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 |-------|----:|----:|--------:|--------------|----------------:|----------------:|-------------------------:|-------------------------:|
-| 300 | 0.404s | 0.168s | 2.40x | match | 602,808 | 30,968 | 982,581 | 101,371 |
-| 1k | 0.262s | 0.133s | 1.97x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+| 300 | 0.392s | 0.167s | 2.35x | match | 602,808 | 30,968 | 982,581 | 101,371 |
+| 1k | 0.256s | 0.129s | 1.98x | match | 352,522 | 10,328 | 592,698 | 38,196 |
 
 The same run reports the counted-closure phase split:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 |-------|------|----------:|-------------:|-----------------------:|----------------------:|
-| 300 | All | 136.668ms | 0.000ms | 78.053ms | n/a |
-| 300 | Min | 46.030ms | 0.000ms | 5.568ms | 12.685ms |
-| 1k | All | 58.924ms | 0.000ms | 48.248ms | n/a |
-| 1k | Min | 15.563ms | 0.000ms | 1.312ms | 4.921ms |
+| 300 | All | 149.430ms | 0.000ms | 52.088ms | n/a |
+| 300 | Min | 44.722ms | 0.000ms | 5.591ms | 12.771ms |
+| 1k | All | 85.494ms | 0.000ms | 22.895ms | n/a |
+| 1k | Min | 15.479ms | 0.000ms | 1.316ms | 5.006ms |
 
 Additional path-state observations:
 
@@ -1016,6 +1017,9 @@ Additional path-state observations:
   now grows the list once and writes the new seed batch directly into the new
   slots via `CollectionsMarshal`, avoiding per-row `Add` bookkeeping on the
   final output path.
+- the counted-path `All` staging buffer now stores targets and depths in
+  parallel packed lists instead of shuttling a tiny struct per row, reducing
+  replay overhead on the final materialization path.
 - This shape does not exercise the weighted `min_frontier_*` dominance
   candidate problem; generic frontier indexes would not address its primary
   cost. Further counted-closure work should target expansion/materialization

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -12476,7 +12476,7 @@ namespace UnifyWeaver.QueryRuntime
             metrics?.RecordSeed();
             var preserveAllPaths = accumulatorMode is TableMode.All or TableMode.Sum or TableMode.Count;
             var bestKnown = preserveAllPaths ? null : new Dictionary<object?, int>();
-            var bufferedRows = preserveAllPaths ? new List<PathAwareTargetDepthRow>() : null;
+            var bufferedRows = preserveAllPaths ? new PathAwareTargetDepthBuffer() : null;
 
             var initialPath = CompactVisitedPath.Create(seedNodeId);
             var initialStackCapacity = maxDepth > 0
@@ -12592,16 +12592,16 @@ namespace UnifyWeaver.QueryRuntime
         }
 
         private static void RecordBufferedPathAwareDepthRow(
-            List<PathAwareTargetDepthRow> rows,
+            PathAwareTargetDepthBuffer rows,
             object? target,
             int depth)
         {
-            rows.Add(new PathAwareTargetDepthRow(target, depth));
+            rows.Add(target, depth);
         }
 
         private static void MaterializePathAwareDepthRows(
             object? seed,
-            List<PathAwareTargetDepthRow> rows,
+            PathAwareTargetDepthBuffer rows,
             ICollection<object[]> output,
             PathAwareTraversalMetrics? metrics)
         {
@@ -12611,20 +12611,22 @@ namespace UnifyWeaver.QueryRuntime
                 var baseIndex = outputList.Count;
                 CollectionsMarshal.SetCount(outputList, baseIndex + rows.Count);
                 var span = CollectionsMarshal.AsSpan(outputList);
+                var targets = CollectionsMarshal.AsSpan(rows.Targets);
+                var depths = CollectionsMarshal.AsSpan(rows.Depths);
                 for (var i = 0; i < rows.Count; i++)
                 {
-                    var row = rows[i];
-                    span[baseIndex + i] = new object[] { seed!, row.Target!, row.Depth };
+                    span[baseIndex + i] = new object[] { seed!, targets[i]!, depths[i] };
                     metrics?.RecordOutputRow();
                 }
                 metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(started));
                 return;
             }
 
+            var fallbackTargets = rows.Targets;
+            var fallbackDepths = rows.Depths;
             for (var i = 0; i < rows.Count; i++)
             {
-                var row = rows[i];
-                output.Add(new object[] { seed!, row.Target!, row.Depth });
+                output.Add(new object[] { seed!, fallbackTargets[i]!, fallbackDepths[i] });
                 metrics?.RecordOutputRow();
             }
 
@@ -14021,9 +14023,20 @@ namespace UnifyWeaver.QueryRuntime
             }
         }
 
-        private readonly record struct PathAwareTargetDepthRow(
-            object? Target,
-            int Depth);
+        private sealed class PathAwareTargetDepthBuffer
+        {
+            public List<object?> Targets { get; } = new();
+
+            public List<int> Depths { get; } = new();
+
+            public int Count => Targets.Count;
+
+            public void Add(object? target, int depth)
+            {
+                Targets.Add(target);
+                Depths.Add(depth);
+            }
+        }
 
         private readonly record struct PathAwareTraversalFrame(
             object? Node,


### PR DESCRIPTION
 # Pack counted path row buffers in the C# query runtime

  ## Summary

  - Replaces the counted-path `All` staging row struct with a packed buffer of parallel target and depth lists.
  - Keeps the final replay path emitting the same `object[] { seed, target, depth }` rows in the same order.
  - Preserves output hashes and existing `path_state_*` counters.
  - Updates benchmark/proposal docs with the measured reduction in `All` materialization cost after packed row staging.

  ## Why

  The counted-path `All` path was still spending meaningful time replaying buffered rows into final output. Even after earlier buffering work, the staging path still shuffled a tiny row struct per entry.

  This change makes the per-seed staging buffer more direct: store only the two varying columns in packed parallel arrays, then replay them into the final output rows.

  ## Results

  Local counted shortest-path benchmark:

  ```bash
  python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3
  ```
  | Scale | All | Min | Speedup | Output Match |
  | --- | ---: | ---: | ---: | --- |
  | 300 | 0.392s | 0.167s | 2.35x | match |
  | 1k | 0.256s | 0.129s | 1.98x | match |

  Counted-closure phase split:

  | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
  | --- | --- | ---: | ---: | ---: | ---: |
  | 300 | All | 149.430ms | 0.000ms | 52.088ms | n/a |
  | 300 | Min | 44.722ms | 0.000ms | 5.591ms | 12.771ms |
  | 1k | All | 85.494ms | 0.000ms | 22.895ms | n/a |
  | 1k | Min | 15.479ms | 0.000ms | 1.316ms | 5.006ms |

  ## Notes

  - This is a staging/replay representation change only for counted-path All buffering.
  - Final output rows are still materialized exactly as object[] { seed, target, depth }.
  - The optimization remains exact: output hashes still match between All and Min.

  ## Validation

  - swipl -q -t run_tests tests/core/test_csharp_query_target.pl
  - python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py
  - git diff --check
  - python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3