### PR TITLE
perf(wam-elixir): Phase A — heap as Map, cached trail_len, code as tuple

### DIFF
--- a/docs/design/WAM_ELIXIR_PERF_PHASE_A_PLAN.md
+++ b/docs/design/WAM_ELIXIR_PERF_PHASE_A_PLAN.md
@@ -87,19 +87,23 @@ args = for i <- (addr + 1)..(addr + arity), do: Map.get(state.heap, i)
 Trail rewind (`unwind_trail`) and `unify` use `List.replace_at(heap, addr, v)`.
 With a Map this becomes `Map.put(heap, addr, v)` — O(1) and simpler.
 
-### 2. Cached counters for trail and choice_points
+### 2. Cached counter for trail
 
-`trail` and `choice_points` stay as lists — prepend is already O(1). Only
-`length/1` calls are costly. Add `trail_len` / `cps_len` counter fields
-and maintain them on every push/pop.
+`trail` stays a list — prepend is already O(1). Only `length/1` calls
+are costly. Add a `trail_len` counter field and maintain it on every
+push/pop.
 
-Only two code paths actually read the length:
+Two code paths actually read the length:
 
 1. `unwind_trail(state, mark)` in the runtime — currently `length(state.trail)`
-   twice per call. Uses cached `trail_len`.
-2. `backtrack` — `length(cp.trail)` to establish the mark. The choice
-   point stores its trail snapshot; cache `cp.trail_len` at save time so
-   the restore path doesn't re-measure.
+   on each call. Uses cached `state.trail_len`.
+2. `backtrack` — `length(cp.trail)` to establish the mark. Choice
+   points snapshot `trail_len` at save time so the restore path reads
+   `cp.trail_len` directly.
+
+**Not adding `cps_len`**: no caller ever reads `length(state.choice_points)`
+in the current codebase, so there's nothing to optimize. Skip per
+"no speculative generality".
 
 ### 3. Code: tuple instead of list
 

--- a/docs/design/WAM_ELIXIR_PERF_PHASE_A_PLAN.md
+++ b/docs/design/WAM_ELIXIR_PERF_PHASE_A_PLAN.md
@@ -1,0 +1,170 @@
+# WAM-Elixir Performance — Phase A Plan
+
+Brings the Elixir WAM target in line with the Phase A–B data-structure
+work already landed for Haskell and Rust. See
+`docs/design/WAM_PERF_OPTIMIZATION_LOG.md` for the broader context.
+
+This doc covers the mechanical, language-agnostic wins — `heap`, `trail`,
+`code` container choices and length caching. FFI-path work, parallel
+seeds, and label pre-resolution are explicitly out of scope; see the
+"Out of scope" section.
+
+## Problem statement
+
+Audit of `src/unifyweaver/targets/wam_elixir_target.pl` and
+`src/unifyweaver/targets/wam_elixir_lowered_emitter.pl` shows four
+recurring O(n)-on-hot-path patterns:
+
+| Pattern | Sites | Cost |
+|---|---|---|
+| `state.heap ++ [val]` | ~15 across target + emitter | O(n) list append per heap write |
+| `length(state.heap)` to compute the new addr | co-located with above | O(n), doubled with the append |
+| `Enum.at(state.code, state.pc - 1)` | interpreter fetch loop | O(pc) per instruction step |
+| `length(state.trail)` / `length(state.choice_points)` | `backtrack`, `unwind_trail` | O(n) per choice-point restore |
+
+Haskell fixed the equivalent issues in commits `8abf0df3`
+(Array for instruction fetch), `f757b881` / `bdae58cf` (cached lengths),
+and the struct split in `ab829695`. Rust is similarly flat-time on these
+operations. Elixir is still O(n).
+
+## Design
+
+### 1. Heap: map keyed by integer addr + cached `heap_len`
+
+BEAM gives us a small set of container options:
+
+| Option | Append | Read | Replace | Notes |
+|---|---|---|---|---|
+| List + `++ [x]` (today) | O(n) | O(n) via `Enum.at` | O(n) via `List.replace_at` | Everything O(n) |
+| Reversed list + prepend | O(1) | O(n) | O(n) | Worse for read-heavy access |
+| Tuple + `Tuple.append` | O(n) | O(1) via `elem` | O(1) | Append copies the whole tuple |
+| **Map keyed by addr** | **O(1)** | **O(1)** | **O(1)** | Slightly higher constants; easiest to reason about |
+| Erlang `:array` | O(log n) | O(log n) | O(log n) | Clean API but slower constants than Map for dense writes |
+
+Choosing **Map**. Addresses are dense integers `0..heap_len-1`, so
+indexed iteration (e.g. for `Enum.slice(heap, addr+1, arity)` to read
+structure args) becomes a tight comprehension over a known integer
+range, with `Map.get/2` at O(1).
+
+**Struct change:**
+
+```elixir
+# Before
+defstruct pc: 1, cp: :halt, regs: %{}, heap: [], trail: [],
+          choice_points: [], stack: [], code: [], labels: %{}
+
+# After
+defstruct pc: 1, cp: :halt, regs: %{}, heap: %{}, heap_len: 0,
+          trail: [], trail_len: 0,
+          choice_points: [], cps_len: 0,
+          stack: [], code: {}, labels: %{}
+```
+
+**Touch-site pattern:**
+
+```elixir
+# Before
+addr = length(state.heap)
+new_heap = state.heap ++ [val]
+%{state | heap: new_heap}
+
+# After
+addr = state.heap_len
+new_heap = Map.put(state.heap, addr, val)
+%{state | heap: new_heap, heap_len: addr + 1}
+```
+
+Heap-slice reads (used in `step_get_structure_ref`, `eval_arith`):
+
+```elixir
+# Before
+args = Enum.slice(state.heap, addr + 1, arity)
+
+# After
+args = for i <- (addr + 1)..(addr + arity), do: Map.get(state.heap, i)
+```
+
+Trail rewind (`unwind_trail`) and `unify` use `List.replace_at(heap, addr, v)`.
+With a Map this becomes `Map.put(heap, addr, v)` — O(1) and simpler.
+
+### 2. Cached counters for trail and choice_points
+
+`trail` and `choice_points` stay as lists — prepend is already O(1). Only
+`length/1` calls are costly. Add `trail_len` / `cps_len` counter fields
+and maintain them on every push/pop.
+
+Only two code paths actually read the length:
+
+1. `unwind_trail(state, mark)` in the runtime — currently `length(state.trail)`
+   twice per call. Uses cached `trail_len`.
+2. `backtrack` — `length(cp.trail)` to establish the mark. The choice
+   point stores its trail snapshot; cache `cp.trail_len` at save time so
+   the restore path doesn't re-measure.
+
+### 3. Code: tuple instead of list
+
+`code` is set once at project load and never mutated. Emitting it as a
+tuple `{instr1, instr2, ...}` makes `fetch/1` a `elem(state.code, state.pc - 1)`
+— O(1). Lowered mode doesn't use `code` at all (each segment is a
+`defp`), so this only benefits interpreter mode, but the change is
+trivial.
+
+## Correctness risk assessment
+
+The change is purely representational — `heap[addr]` has the same
+semantics whether stored as a list or a map. Sites that look vulnerable:
+
+- **Heap slicing for structure args.** Switches from `Enum.slice` to a
+  comprehension over an integer range. Only subtle point: `Map.get/2`
+  returns `nil` for missing keys; if any code writes a non-contiguous
+  heap, we'd read `nil` instead of crashing on out-of-range list access.
+  This should never happen in correct WAM code, but a plunit test
+  confirms it.
+- **Trail rewind.** `List.replace_at(heap, addr, v)` on a list preserves
+  the list's length; `Map.put/3` adds a key if `addr ≥ heap_len`, which
+  would silently grow the heap. The `heap_len` field guards against
+  this: we only ever write to addrs `< heap_len`, and `Map.put` on an
+  existing key is update.
+- **Choice point save/restore.** Must save `heap_len` alongside `heap`
+  so restoration is consistent. Added to the CP struct.
+
+## Plan of commits
+
+1. **Plan doc** (this file).
+2. **Heap: Map + `heap_len`.** Covers struct, all target writes/reads,
+   all lowered-emitter writes/reads, choice point save/restore, unify,
+   unwind_trail, deref_var, eval_arith, step_get_structure_ref.
+3. **Cached `trail_len` / `cps_len`.** Covers push/pop sites and the
+   `length/1` readers.
+4. **Code as tuple.** Predicate-wrapper emitter produces `{...}`;
+   `fetch/1` uses `elem/2`; struct default updated.
+
+Each commit should keep the test suite green. Expected affected tests:
+
+- `tests/test_wam_elixir_target.pl` — pattern-match assertions on the
+  generated Elixir. Expect updates to the `heap: []` / `code: []`
+  defaults and the `state.heap ++ [...]` patterns.
+- `tests/test_wam_elixir_utils.pl` — no expected changes (touches only
+  label/reg utilities).
+
+## Out of scope (noted here so it's not forgotten)
+
+| Item | Why deferred |
+|---|---|
+| Pre-resolve string labels → PC ints | Phase C in Haskell; substantial refactor of call/execute/try_me_else/switch. Separate PR. |
+| Pre-parse functor arity into instruction tuple | Minor gain; needs generator change. Do alongside Phase C. |
+| FFI path (skip-compile fact predicates) | Phase D. No Elixir FFI infrastructure exists. |
+| Parallel seeds via `Task.async_stream` / `Flow` | Phase D. Needs benchmark-harness wiring, isolated-state verification. |
+| INLINE / UNPACK equivalents | No equivalent in Elixir/BEAM; JIT handles what it handles. |
+
+## Expected impact
+
+Haskell's Phase A–B together closed roughly an order of magnitude on
+heap/trail-heavy workloads (the ~2518ms → ~1350ms → further is mixed
+Phase A–C). Elixir starts with the same O(n) patterns in roughly the
+same places, so a similar 5–10x speedup on the effective-distance
+benchmark is plausible once Phase A lands. Actual numbers pending
+the benchmark run after implementation.
+
+---
+*Co-authored-By: Claude Opus 4.7 (1M context)*

--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -51,7 +51,7 @@ lower_predicate_to_elixir(Pred/Arity, WamCode, Options, Code) :-
   end
 
   def run(args) when is_list(args) do
-    state = %WamRuntime.WamState{code: [], labels: %{}, pc: 1}
+    state = %WamRuntime.WamState{code: {}, labels: %{}, pc: 1}
     state = Enum.with_index(args, 1)
     |> Enum.reduce(state, fn {arg, i}, s ->
       %{s | regs: Map.put(s.regs, i, arg)}

--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -167,7 +167,7 @@ wrap_segment(FuncName, try_me_else(L), BodyCode, Code) :-
     segment_func_name(L, FallbackFunc),
     format(string(Code),
 '  defp ~w(state) do
-    cp = %{pc: &~w/1, regs: state.regs, heap: state.heap,
+    cp = %{pc: &~w/1, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
            cp: state.cp, trail: state.trail, stack: state.stack}
     state = %{state | choice_points: [cp | state.choice_points]}
 ~w
@@ -179,7 +179,7 @@ wrap_segment(FuncName, retry_me_else(L), BodyCode, Code) :-
 '  defp ~w(state) do
     case state.choice_points do
       [_old | rest] ->
-        cp = %{pc: &~w/1, regs: state.regs, heap: state.heap,
+        cp = %{pc: &~w/1, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
                cp: state.cp, trail: state.trail, stack: state.stack}
         state = %{state | choice_points: [cp | rest]}
 ~w
@@ -273,13 +273,14 @@ wam_elixir_lower_instr(get_value(XnName, AiName), _PC, _Labels, _FuncName, Code)
 wam_elixir_lower_instr(put_structure(F, AiName), _PC, _Labels, _FuncName, Code) :-
     reg_id(AiName, Ai),
     format(string(Code),
-'    addr = length(state.heap)
-    new_heap = state.heap ++ [{:str, "~w"}]
+'    addr = state.heap_len
+    new_heap = Map.put(state.heap, addr, {:str, "~w"})
     arity = WamRuntime.parse_functor_arity("~w")
     state = state
     |> WamRuntime.trail_binding(~w)
     |> Map.put(:regs, Map.put(state.regs, ~w, {:ref, addr}))
     |> Map.put(:heap, new_heap)
+    |> Map.put(:heap_len, addr + 1)
     |> Map.put(:stack, [{:write_ctx, arity} | state.stack])', [F, F, Ai, Ai]).
 
 wam_elixir_lower_instr(get_structure(F, AiName), _PC, _Labels, _FuncName, Code) :-
@@ -288,13 +289,14 @@ wam_elixir_lower_instr(get_structure(F, AiName), _PC, _Labels, _FuncName, Code) 
 '    val = Map.get(state.regs, ~w)
     state = cond do
       match?({:unbound, _}, val) ->
-        addr = length(state.heap)
-        new_heap = state.heap ++ [{:str, "~w"}]
+        addr = state.heap_len
+        new_heap = Map.put(state.heap, addr, {:str, "~w"})
         arity = WamRuntime.parse_functor_arity("~w")
         state
         |> WamRuntime.trail_binding(~w)
         |> Map.put(:regs, Map.put(state.regs, ~w, {:ref, addr}))
         |> Map.put(:heap, new_heap)
+        |> Map.put(:heap_len, addr + 1)
         |> Map.put(:stack, [{:write_ctx, arity} | state.stack])
       match?({:ref, _}, val) ->
         {:ref, addr} = val
@@ -390,12 +392,13 @@ wam_elixir_lower_instr(put_value(XnName, AiName), _PC, _Labels, _FuncName, Code)
 wam_elixir_lower_instr(put_list(AiName), _PC, _Labels, _FuncName, Code) :-
     reg_id(AiName, Ai),
     format(string(Code),
-'    addr = length(state.heap)
-    new_heap = state.heap ++ [{:str, "./2"}]
+'    addr = state.heap_len
+    new_heap = Map.put(state.heap, addr, {:str, "./2"})
     state = state
     |> WamRuntime.trail_binding(~w)
     |> Map.put(:regs, Map.put(state.regs, ~w, {:ref, addr}))
     |> Map.put(:heap, new_heap)
+    |> Map.put(:heap_len, addr + 1)
     |> Map.put(:stack, [{:write_ctx, 2} | state.stack])', [Ai, Ai]).
 
 wam_elixir_lower_instr(get_list(AiName), _PC, _Labels, _FuncName, Code) :-
@@ -404,12 +407,13 @@ wam_elixir_lower_instr(get_list(AiName), _PC, _Labels, _FuncName, Code) :-
 '    val = Map.get(state.regs, ~w)
     state = cond do
       match?({:unbound, _}, val) ->
-        addr = length(state.heap)
-        new_heap = state.heap ++ [{:str, "./2"}]
+        addr = state.heap_len
+        new_heap = Map.put(state.heap, addr, {:str, "./2"})
         state
         |> WamRuntime.trail_binding(~w)
         |> Map.put(:regs, Map.put(state.regs, ~w, {:ref, addr}))
         |> Map.put(:heap, new_heap)
+        |> Map.put(:heap_len, addr + 1)
         |> Map.put(:stack, [{:write_ctx, 2} | state.stack])
       match?({:ref, _}, val) ->
         {:ref, addr} = val
@@ -426,21 +430,25 @@ wam_elixir_lower_instr(get_list(AiName), _PC, _Labels, _FuncName, Code) :-
 wam_elixir_lower_instr(set_variable(XnName), _PC, _Labels, _FuncName, Code) :-
     reg_id(XnName, Xn),
     format(string(Code),
-'    addr = length(state.heap)
+'    addr = state.heap_len
     fresh = {:unbound, {:heap_ref, addr}}
-    new_heap = state.heap ++ [fresh]
+    new_heap = Map.put(state.heap, addr, fresh)
     state = state
     |> WamRuntime.put_reg(~w, fresh)
-    |> Map.put(:heap, new_heap)', [Xn]).
+    |> Map.put(:heap, new_heap)
+    |> Map.put(:heap_len, addr + 1)', [Xn]).
 
 wam_elixir_lower_instr(set_value(XnName), _PC, _Labels, _FuncName, Code) :-
     reg_id(XnName, Xn),
     format(string(Code),
 '    val = WamRuntime.get_reg(state, ~w)
-    state = %{state | heap: state.heap ++ [val]}', [Xn]).
+    addr = state.heap_len
+    state = %{state | heap: Map.put(state.heap, addr, val), heap_len: addr + 1}', [Xn]).
 
 wam_elixir_lower_instr(set_constant(C), _PC, _Labels, _FuncName, Code) :-
-    format(string(Code), '    state = %{state | heap: state.heap ++ ["~w"]}', [C]).
+    format(string(Code),
+'    addr = state.heap_len
+    state = %{state | heap: Map.put(state.heap, addr, "~w"), heap_len: addr + 1}', [C]).
 
 wam_elixir_lower_instr(switch_on_constant(Entries), _PC, _Labels, _FuncName, Code) :-
     build_switch_arms(Entries, ArmsStr),

--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -168,7 +168,7 @@ wrap_segment(FuncName, try_me_else(L), BodyCode, Code) :-
     format(string(Code),
 '  defp ~w(state) do
     cp = %{pc: &~w/1, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
-           cp: state.cp, trail: state.trail, stack: state.stack}
+           cp: state.cp, trail: state.trail, trail_len: state.trail_len, stack: state.stack}
     state = %{state | choice_points: [cp | state.choice_points]}
 ~w
   end', [FuncName, FallbackFunc, BodyCode]).
@@ -180,7 +180,7 @@ wrap_segment(FuncName, retry_me_else(L), BodyCode, Code) :-
     case state.choice_points do
       [_old | rest] ->
         cp = %{pc: &~w/1, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
-               cp: state.cp, trail: state.trail, stack: state.stack}
+               cp: state.cp, trail: state.trail, trail_len: state.trail_len, stack: state.stack}
         state = %{state | choice_points: [cp | rest]}
 ~w
       _ -> throw(:fail)

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -329,7 +329,7 @@ compile_run_loop_to_elixir(Code) :-
   end
 
   defp fetch(state) do
-    Enum.at(state.code, state.pc - 1)
+    elem(state.code, state.pc - 1)
   end', []).
 
 compile_backtrack_to_elixir(Code) :-
@@ -684,10 +684,11 @@ compile_wam_runtime_to_elixir(Options, Code) :-
   defmodule WamState do
     # heap is a map keyed by integer address; heap_len is the next free addr.
     # trail_len caches list length to avoid O(n) re-measure on unwind.
+    # code is a tuple so fetch is O(1) via elem/2 instead of O(pc) via Enum.at.
     # Phase A perf: O(1) append/read/replace instead of list O(n) operations.
     defstruct pc: 1, cp: :halt, regs: %{}, heap: %{}, heap_len: 0,
               trail: [], trail_len: 0,
-              choice_points: [], stack: [], code: [], labels: %{}
+              choice_points: [], stack: [], code: {}, labels: %{}
   end
 
 ~w
@@ -707,10 +708,11 @@ compile_wam_predicate_to_elixir(Pred/Arity, WamCode, _Options, Code) :-
 'defmodule WamPred.~w do
   @moduledoc "WAM-compiled predicate: ~w/~w"
 
+  # code is a tuple so WamRuntime.fetch uses elem/2 for O(1) instruction lookup.
   def code do
-    [
+    {
 ~w
-    ]
+    }
   end
 
   def labels do

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -101,13 +101,14 @@ wam_elixir_case(get_structure,
         val = Map.get(state.regs, ai)
         cond do
           match?({:unbound, _}, val) ->
-            addr = length(state.heap)
-            new_heap = state.heap ++ [{:str, fn_name}]
+            addr = state.heap_len
+            new_heap = Map.put(state.heap, addr, {:str, fn_name})
             arity = parse_functor_arity(fn_name)
             state
             |> trail_binding(ai)
             |> Map.put(:regs, Map.put(state.regs, ai, {:ref, addr}))
             |> Map.put(:heap, new_heap)
+            |> Map.put(:heap_len, addr + 1)
             |> Map.put(:stack, [{:write_ctx, arity} | state.stack])
             |> Map.put(:pc, state.pc + 1)
           match?({:ref, _}, val) ->
@@ -121,12 +122,13 @@ wam_elixir_case(get_list,
         val = Map.get(state.regs, ai)
         cond do
           match?({:unbound, _}, val) ->
-            addr = length(state.heap)
-            new_heap = state.heap ++ [{:str, "./2"}]
+            addr = state.heap_len
+            new_heap = Map.put(state.heap, addr, {:str, "./2"})
             state
             |> trail_binding(ai)
             |> Map.put(:regs, Map.put(state.regs, ai, {:ref, addr}))
             |> Map.put(:heap, new_heap)
+            |> Map.put(:heap_len, addr + 1)
             |> Map.put(:stack, [{:write_ctx, 2} | state.stack])
             |> Map.put(:pc, state.pc + 1)
           match?({:ref, _}, val) ->
@@ -162,44 +164,49 @@ wam_elixir_case(put_value,
 
 wam_elixir_case(put_structure,
 '      {:put_structure, fn_name, ai} ->
-        addr = length(state.heap)
-        new_heap = state.heap ++ [{:str, fn_name}]
+        addr = state.heap_len
+        new_heap = Map.put(state.heap, addr, {:str, fn_name})
         state
         |> trail_binding(ai)
         |> Map.put(:regs, Map.put(state.regs, ai, {:ref, addr}))
         |> Map.put(:heap, new_heap)
+        |> Map.put(:heap_len, addr + 1)
         |> Map.put(:stack, [{:write_ctx, parse_functor_arity(fn_name)} | state.stack])
         |> Map.put(:pc, state.pc + 1)').
 
 wam_elixir_case(put_list,
 '      {:put_list, ai} ->
-        addr = length(state.heap)
-        new_heap = state.heap ++ [{:str, "./2"}]
+        addr = state.heap_len
+        new_heap = Map.put(state.heap, addr, {:str, "./2"})
         state
         |> trail_binding(ai)
         |> Map.put(:regs, Map.put(state.regs, ai, {:ref, addr}))
         |> Map.put(:heap, new_heap)
+        |> Map.put(:heap_len, addr + 1)
         |> Map.put(:stack, [{:write_ctx, 2} | state.stack])
         |> Map.put(:pc, state.pc + 1)').
 
 wam_elixir_case(set_variable,
 '      {:set_variable, xn} ->
-        addr = length(state.heap)
+        addr = state.heap_len
         fresh = {:unbound, {:heap_ref, addr}}
-        new_heap = state.heap ++ [fresh]
+        new_heap = Map.put(state.heap, addr, fresh)
         state
         |> put_reg(xn, fresh)
         |> Map.put(:heap, new_heap)
+        |> Map.put(:heap_len, addr + 1)
         |> Map.put(:pc, state.pc + 1)').
 
 wam_elixir_case(set_value,
 '      {:set_value, xn} ->
         val = get_reg(state, xn)
-        %{state | heap: state.heap ++ [val], pc: state.pc + 1}').
+        addr = state.heap_len
+        %{state | heap: Map.put(state.heap, addr, val), heap_len: addr + 1, pc: state.pc + 1}').
 
 wam_elixir_case(set_constant,
 '      {:set_constant, c} ->
-        %{state | heap: state.heap ++ [c], pc: state.pc + 1}').
+        addr = state.heap_len
+        %{state | heap: Map.put(state.heap, addr, c), heap_len: addr + 1, pc: state.pc + 1}').
 
 % --- Unification Instructions ---
 
@@ -256,7 +263,7 @@ wam_elixir_case(deallocate,
 wam_elixir_case(try_me_else,
 '      {:try_me_else, label} ->
         target = resolve_label(state, label)
-        cp = %{pc: target, regs: state.regs, heap: state.heap,
+        cp = %{pc: target, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
                cp: state.cp, trail: state.trail, stack: state.stack}
         %{state | choice_points: [cp | state.choice_points], pc: state.pc + 1}').
 
@@ -265,7 +272,7 @@ wam_elixir_case(retry_me_else,
         target = resolve_label(state, label)
         case state.choice_points do
           [_old | rest] ->
-            cp = %{pc: target, regs: state.regs, heap: state.heap,
+            cp = %{pc: target, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
                    cp: state.cp, trail: state.trail, stack: state.stack}
             %{state | choice_points: [cp | rest], pc: state.pc + 1}
           _ -> %{state | pc: state.pc + 1}
@@ -339,11 +346,12 @@ compile_backtrack_to_elixir(Code) :-
         |> Map.put(:pc, cp.pc)
         |> Map.put(:regs, cp.regs)
         |> Map.put(:heap, cp.heap)
+        |> Map.put(:heap_len, cp.heap_len)
         |> Map.put(:cp, cp.cp)
         |> Map.put(:stack, cp.stack)
         |> Map.put(:trail, cp.trail)
         |> Map.put(:choice_points, rest)
-        
+
         if is_function(cp.pc) do
           cp.pc.(state)
         else
@@ -364,12 +372,12 @@ compile_unwind_trail_to_elixir(Code) :-
     else
       entries_to_undo = Enum.take(state.trail, curr_len - mark)
       new_trail = Enum.drop(state.trail, curr_len - mark)
-    
+
       Enum.reduce(entries_to_undo, %{state | trail: new_trail}, fn {key, old_val}, s ->
         case key do
           {:heap_ref, addr} ->
              val = if old_val == :not_set, do: {:unbound, {:heap_ref, addr}}, else: old_val
-             %{s | heap: List.replace_at(s.heap, addr, val)}
+             %{s | heap: Map.put(s.heap, addr, val)}
           _ ->
              new_regs = if old_val == :not_set, do: Map.delete(s.regs, key), else: Map.put(s.regs, key, old_val)
              %{s | regs: new_regs}
@@ -381,7 +389,7 @@ compile_unwind_trail_to_elixir(Code) :-
 compile_utility_helpers_to_elixir(Code) :-
     format(string(Code),
 '  def trail_binding(state, {:heap_ref, addr} = key) do
-    old = Enum.at(state.heap, addr, :not_set)
+    old = Map.get(state.heap, addr, :not_set)
     %{state | trail: [{key, old} | state.trail]}
   end
 
@@ -411,8 +419,20 @@ compile_utility_helpers_to_elixir(Code) :-
     end
   end
 
+  @doc "Read `len` consecutive heap cells starting at `start`."
+  def heap_slice(_state, _start, 0), do: []
+  def heap_slice(state, start, len) when len > 0 do
+    Enum.map(0..(len - 1), fn i -> Map.get(state.heap, start + i) end)
+  end
+
+  @doc "Append `val` to the heap; returns {new_state, addr}."
+  def heap_push(state, val) do
+    addr = state.heap_len
+    {%{state | heap: Map.put(state.heap, addr, val), heap_len: addr + 1}, addr}
+  end
+
   def deref_var(state, {:unbound, {:heap_ref, addr}} = ref) do
-    case Enum.at(state.heap, addr) do
+    case Map.get(state.heap, addr) do
       {:unbound, {:heap_ref, _addr}} -> ref
       val -> deref_var(state, val)
     end
@@ -428,11 +448,11 @@ compile_utility_helpers_to_elixir(Code) :-
   def deref_var(_state, val), do: val
 
   def step_get_structure_ref(state, fn_name, addr) do
-    entry = Enum.at(state.heap, addr)
+    entry = Map.get(state.heap, addr)
     cond do
       entry == {:str, fn_name} ->
         arity = parse_functor_arity(fn_name)
-        args = Enum.slice(state.heap, addr + 1, arity)
+        args = heap_slice(state, addr + 1, arity)
         new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
         %{state | stack: [{:unify_ctx, args} | state.stack], pc: new_pc}
       true -> :fail
@@ -447,12 +467,13 @@ compile_utility_helpers_to_elixir(Code) :-
         state |> trail_binding(xn) |> put_reg(xn, arg)
         |> Map.put(:stack, new_stack) |> Map.put(:pc, new_pc)
       [{:write_ctx, n} | stack_rest] when n > 0 ->
-        addr = length(state.heap)
+        addr = state.heap_len
         fresh = {:unbound, {:heap_ref, addr}}
         new_stack = if n == 1, do: stack_rest, else: [{:write_ctx, n - 1} | stack_rest]
         new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
         state |> put_reg(xn, fresh)
-        |> Map.put(:heap, state.heap ++ [fresh])
+        |> Map.put(:heap, Map.put(state.heap, addr, fresh))
+        |> Map.put(:heap_len, addr + 1)
         |> Map.put(:stack, new_stack) |> Map.put(:pc, new_pc)
       _ -> :fail
     end
@@ -472,7 +493,8 @@ compile_utility_helpers_to_elixir(Code) :-
       [{:write_ctx, n} | stack_rest] when n > 0 ->
         new_stack = if n == 1, do: stack_rest, else: [{:write_ctx, n - 1} | stack_rest]
         new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
-        %{state | heap: state.heap ++ [val], stack: new_stack, pc: new_pc}
+        addr = state.heap_len
+        %{state | heap: Map.put(state.heap, addr, val), heap_len: addr + 1, stack: new_stack, pc: new_pc}
       _ -> :fail
     end
   end
@@ -490,7 +512,8 @@ compile_utility_helpers_to_elixir(Code) :-
       [{:write_ctx, n} | stack_rest] when n > 0 ->
         new_stack = if n == 1, do: stack_rest, else: [{:write_ctx, n - 1} | stack_rest]
         new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
-        %{state | heap: state.heap ++ [c], stack: new_stack, pc: new_pc}
+        addr = state.heap_len
+        %{state | heap: Map.put(state.heap, addr, c), heap_len: addr + 1, stack: new_stack, pc: new_pc}
       _ -> :fail
     end
   end
@@ -516,12 +539,12 @@ compile_utility_helpers_to_elixir(Code) :-
       v1 == v2 -> {:ok, state}
       match?({:unbound, {:heap_ref, _addr}}, v1) ->
         {:unbound, {:heap_ref, addr}} = v1
-        new_heap = List.replace_at(state.heap, addr, v2)
+        new_heap = Map.put(state.heap, addr, v2)
         new_state = state |> trail_binding({:heap_ref, addr})
         {:ok, %{new_state | heap: new_heap}}
       match?({:unbound, {:heap_ref, _addr}}, v2) ->
         {:unbound, {:heap_ref, addr}} = v2
-        new_heap = List.replace_at(state.heap, addr, v1)
+        new_heap = Map.put(state.heap, addr, v1)
         new_state = state |> trail_binding({:heap_ref, addr})
         {:ok, %{new_state | heap: new_heap}}
       match?({:unbound, _}, v1) ->
@@ -578,10 +601,10 @@ compile_utility_helpers_to_elixir(Code) :-
         # Determine if goal succeeds or fails
         res = case goal_val do
           {:ref, addr} ->
-            case Enum.at(state.heap, addr) do
+            case Map.get(state.heap, addr) do
               {:str, pred_arity} ->
                 arity = parse_functor_arity(pred_arity)
-                args = Enum.slice(state.heap, addr + 1, arity)
+                args = heap_slice(state, addr + 1, arity)
                 call_state = Enum.with_index(args, 1)
                 |> Enum.reduce(temp_state, fn {arg, i}, s -> %{s | regs: Map.put(s.regs, i, arg)} end)
 
@@ -630,15 +653,15 @@ compile_utility_helpers_to_elixir(Code) :-
     end
   end
   defp eval_arith(state, {:ref, addr}) do
-    case Enum.at(state.heap, addr) do
+    case Map.get(state.heap, addr) do
       {:str, "+/2"} ->
-        [v1, v2] = Enum.slice(state.heap, addr + 1, 2)
+        [v1, v2] = heap_slice(state, addr + 1, 2)
         eval_arith(state, v1) + eval_arith(state, v2)
       {:str, "-/2"} ->
-        [v1, v2] = Enum.slice(state.heap, addr + 1, 2)
+        [v1, v2] = heap_slice(state, addr + 1, 2)
         eval_arith(state, v1) - eval_arith(state, v2)
       {:str, "*/2"} ->
-        [v1, v2] = Enum.slice(state.heap, addr + 1, 2)
+        [v1, v2] = heap_slice(state, addr + 1, 2)
         eval_arith(state, v1) * eval_arith(state, v2)
       val -> eval_arith(state, val)
     end
@@ -658,7 +681,9 @@ compile_wam_runtime_to_elixir(Options, Code) :-
   @moduledoc "WAM Virtual Machine runtime - generated by UnifyWeaver"
 
   defmodule WamState do
-    defstruct pc: 1, cp: :halt, regs: %{}, heap: [], trail: [],
+    # heap is a map keyed by integer address; heap_len is the next free addr.
+    # Phase A perf: O(1) append/read/replace instead of list O(n) operations.
+    defstruct pc: 1, cp: :halt, regs: %{}, heap: %{}, heap_len: 0, trail: [],
               choice_points: [], stack: [], code: [], labels: %{}
   end
 

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -264,7 +264,7 @@ wam_elixir_case(try_me_else,
 '      {:try_me_else, label} ->
         target = resolve_label(state, label)
         cp = %{pc: target, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
-               cp: state.cp, trail: state.trail, stack: state.stack}
+               cp: state.cp, trail: state.trail, trail_len: state.trail_len, stack: state.stack}
         %{state | choice_points: [cp | state.choice_points], pc: state.pc + 1}').
 
 wam_elixir_case(retry_me_else,
@@ -273,7 +273,7 @@ wam_elixir_case(retry_me_else,
         case state.choice_points do
           [_old | rest] ->
             cp = %{pc: target, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
-                   cp: state.cp, trail: state.trail, stack: state.stack}
+                   cp: state.cp, trail: state.trail, trail_len: state.trail_len, stack: state.stack}
             %{state | choice_points: [cp | rest], pc: state.pc + 1}
           _ -> %{state | pc: state.pc + 1}
         end').
@@ -339,10 +339,9 @@ compile_backtrack_to_elixir(Code) :-
     case state.choice_points do
       [] -> :fail
       [cp | rest] ->
-        # cp.trail contains the trail snapshot at save time.
-        # mark = length(cp.trail). We unwind all entries added after that.
+        # cp.trail_len is the mark — unwind all entries pushed after that.
         state = state
-        |> unwind_trail(length(cp.trail))
+        |> unwind_trail(cp.trail_len)
         |> Map.put(:pc, cp.pc)
         |> Map.put(:regs, cp.regs)
         |> Map.put(:heap, cp.heap)
@@ -350,6 +349,7 @@ compile_backtrack_to_elixir(Code) :-
         |> Map.put(:cp, cp.cp)
         |> Map.put(:stack, cp.stack)
         |> Map.put(:trail, cp.trail)
+        |> Map.put(:trail_len, cp.trail_len)
         |> Map.put(:choice_points, rest)
 
         if is_function(cp.pc) do
@@ -364,16 +364,17 @@ compile_unwind_trail_to_elixir(Code) :-
     format(string(Code),
 '  @doc "Undo register bindings back to trail mark"
   def unwind_trail(state, mark) do
-    # mark is the length of the trail when the choice point was created.
+    # mark is the trail_len when the choice point was created.
     # Newest entries are at the head of state.trail.
-    curr_len = length(state.trail)
+    curr_len = state.trail_len
     if curr_len <= mark do
       state
     else
-      entries_to_undo = Enum.take(state.trail, curr_len - mark)
-      new_trail = Enum.drop(state.trail, curr_len - mark)
+      drop_n = curr_len - mark
+      entries_to_undo = Enum.take(state.trail, drop_n)
+      new_trail = Enum.drop(state.trail, drop_n)
 
-      Enum.reduce(entries_to_undo, %{state | trail: new_trail}, fn {key, old_val}, s ->
+      Enum.reduce(entries_to_undo, %{state | trail: new_trail, trail_len: mark}, fn {key, old_val}, s ->
         case key do
           {:heap_ref, addr} ->
              val = if old_val == :not_set, do: {:unbound, {:heap_ref, addr}}, else: old_val
@@ -390,12 +391,12 @@ compile_utility_helpers_to_elixir(Code) :-
     format(string(Code),
 '  def trail_binding(state, {:heap_ref, addr} = key) do
     old = Map.get(state.heap, addr, :not_set)
-    %{state | trail: [{key, old} | state.trail]}
+    %{state | trail: [{key, old} | state.trail], trail_len: state.trail_len + 1}
   end
 
   def trail_binding(state, key) do
     old = Map.get(state.regs, key, :not_set)
-    %{state | trail: [{key, old} | state.trail]}
+    %{state | trail: [{key, old} | state.trail], trail_len: state.trail_len + 1}
   end
 
   def put_reg(state, reg, val) do
@@ -682,8 +683,10 @@ compile_wam_runtime_to_elixir(Options, Code) :-
 
   defmodule WamState do
     # heap is a map keyed by integer address; heap_len is the next free addr.
+    # trail_len caches list length to avoid O(n) re-measure on unwind.
     # Phase A perf: O(1) append/read/replace instead of list O(n) operations.
-    defstruct pc: 1, cp: :halt, regs: %{}, heap: %{}, heap_len: 0, trail: [],
+    defstruct pc: 1, cp: :halt, regs: %{}, heap: %{}, heap_len: 0,
+              trail: [], trail_len: 0,
               choice_points: [], stack: [], code: [], labels: %{}
   end
 


### PR DESCRIPTION
Brings the Elixir WAM target in line with the Phase A–B data-structure
work already landed for Haskell and Rust (see
`docs/design/WAM_PERF_OPTIMIZATION_LOG.md`). No new features; pure
container and length-caching changes.

## Motivation

Audit of the Elixir target against the Haskell/Rust perf log showed
four recurring O(n)-on-hot-path patterns:

| Pattern | Sites | Cost |
|---|---|---|
| `state.heap ++ [val]` | ~15 across target + emitter | O(n) list append per heap write |
| `length(state.heap)` to compute the new addr | co-located with above | O(n), doubled with the append |
| `Enum.at(state.code, state.pc - 1)` | interpreter fetch loop | O(pc) per instruction step |
| `length(state.trail)` / `length(cp.trail)` | `backtrack`, `unwind_trail` | O(n) per choice-point restore |

Haskell fixed the equivalent issues in commits `8abf0df3`, `f757b881`,
`bdae58cf`. Elixir was still paying the list-append and length-scan
costs on every heap write and choice-point restore.

## What changed

### 1. Heap: addr-keyed Map + cached `heap_len`

WamState gains `heap: %{}` and `heap_len: 0` fields. Every write goes
from:

```elixir
addr = length(state.heap)                   # O(n)
new_heap = state.heap ++ [val]              # O(n)
```

to:

```elixir
addr = state.heap_len                       # O(1)
new_heap = Map.put(state.heap, addr, val)   # O(1)
# ... then bump heap_len
```

Replaces `List.replace_at` with `Map.put` in `unify` and `unwind_trail`.
Factors heap slicing (structure args) into a `heap_slice/3` helper with
safe arity-0 handling.

Touched: `get_structure`, `get_list`, `put_structure`, `put_list`,
`set_variable`, `set_value`, `set_constant`, `step_get_structure_ref`,
`step_unify_{variable,value,constant}`, `unify`, `execute_builtin` for
`\+/1`, `eval_arith`, `deref_var`, `trail_binding` (heap_ref variant).
Choice-point save/restore saves and restores `heap_len`.

### 2. Cached `trail_len`

Trail stays a list (prepend is already O(1)). Adds a `trail_len`
counter so `backtrack` and `unwind_trail` skip their `length/1` calls.
Choice points snapshot `trail_len` at save time; `backtrack` reads
`cp.trail_len` directly instead of re-measuring `cp.trail`.

No `cps_len` field: there are no `length(state.choice_points)` readers
anywhere in the codebase, so adding one would be speculative generality.
Plan doc updated to reflect this.

### 3. Code as tuple

`state.code` goes from list to tuple. `fetch/1` switches from
`Enum.at(state.code, state.pc - 1)` (O(pc)) to
`elem(state.code, state.pc - 1)` (O(1)). Predicate wrapper emits
`def code do {...} end`. Lowered emitter's empty-code init in
`run(args)` follows the same change for consistency (lowered mode
doesn't actually use `code`).

## Verification

- `tests/test_wam_elixir_target.pl` — 14/14 pass
- `tests/test_wam_elixir_utils.pl` — 7/7 pass
- Lowered predicate compiles with `elixir` and executes a 2-clause
  `foo/1` with `try_me_else` + `trust_me`
- Interpreter-mode predicate compiles and executes; `tuple_size(s.code)
  == 2` confirms the tuple literal emission works
- WamState defaults verified at runtime: `heap: %{}`, `code: {}`,
  `heap_len: 0`, `trail_len: 0`

Actual benchmark numbers on `effective_distance` are pending — the
local Elixir environment used during development doesn't have the
benchmark fixtures in a runnable state. Based on the Haskell trajectory
(same patterns in the same places) and the fact that heap-writes and
instruction-fetch are now O(1) instead of O(n) / O(pc), a 5–10x
speedup on heap-heavy workloads is plausible; concrete numbers to
follow once the benchmark harness runs.

## Out of scope

Tracked in the plan doc so they're not forgotten. Each is a separate PR
when we get to it.

| Item | Why deferred |
|---|---|
| Pre-resolve string labels → PC ints | Haskell Phase C; substantial refactor of call / execute / try_me_else / switch |
| Pre-parse functor arity into the instruction tuple | Minor win; depends on Phase C-adjacent generator changes |
| FFI path (skip-compile fact predicates) | Haskell Phase D. No Elixir FFI infrastructure exists |
| Parallel seeds via `Task.async_stream` / `Flow` | Haskell Phase D. Needs benchmark-harness wiring and isolated-state verification |

## Commits

- `e32112b4` — plan doc
- `0384c5fd` — heap: Map + heap_len
- `cfd10acc` — trail_len caching
- `496af393` — code as tuple
- `9cf410d2` — plan doc amendment (cps_len not implemented)

## Related docs

- `docs/design/WAM_ELIXIR_PERF_PHASE_A_PLAN.md` — the plan
- `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` — Haskell/Rust optimization
  timeline this PR mirrors

---
*Co-authored-By: Claude Opus 4.7 (1M context)*
