### PR TITLE
perf(csharp-query): Intern counted path traversal targets in the C# query runtime

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -158,14 +158,15 @@ Counted-closure phase split after typed row buffering, pre-sized
 materialization, edge-state node-id preindexing, per-row timing removal, a
 compact `(target, depth)` buffered row shape, O(1) parent-linked
 visited-path extension, a dedicated counted-path traversal frame stack, and
-direct-write seed-batch materialization with a packed target/depth row buffer:
+direct-write seed-batch materialization with a packed target/depth row buffer
+and node-id driven traversal/replay:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 149.430ms | 0.000ms | 52.088ms | n/a |
-| 300 | Min | 44.722ms | 0.000ms | 5.591ms | 12.771ms |
-| 1k | All | 85.494ms | 0.000ms | 22.895ms | n/a |
-| 1k | Min | 15.479ms | 0.000ms | 1.316ms | 5.006ms |
+| 300 | All | 129.728ms | 0.000ms | 66.206ms | n/a |
+| 300 | Min | 33.449ms | 0.000ms | 11.225ms | 13.307ms |
+| 1k | All | 60.561ms | 0.000ms | 40.608ms | n/a |
+| 1k | Min | 16.909ms | 0.000ms | 1.788ms | 6.684ms |
 
 Interpretation:
 
@@ -198,6 +199,10 @@ Interpretation:
 - the counted-path `All` staging buffer now stores targets and depths in
   parallel packed lists instead of shuttling a tiny struct per row, reducing
   replay overhead on the final materialization path
+- counted-path traversal and buffered replay now operate on interned node ids
+  with edge-state lookup tables, avoiding repeated object-key dictionary
+  lookups on the hot path while preserving exact output values at final
+  materialization time
 - weighted `Min` fallback remains the only measured shape where generic
   frontier candidate indexing is directly relevant
 - the next optimization should not add another generic frontier index by

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -327,14 +327,15 @@ Counted-closure phase split after typed row buffering, pre-sized
 materialization, edge-state node-id preindexing, per-row timing removal, a
 compact `(target, depth)` buffered row shape, O(1) parent-linked
 visited-path extension, a dedicated counted-path traversal frame stack, and
-direct-write seed-batch materialization with a packed target/depth row buffer:
+direct-write seed-batch materialization with a packed target/depth row buffer
+and node-id driven traversal/replay:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 149.430ms | 0.000ms | 52.088ms | n/a |
-| 300 | Min | 44.722ms | 0.000ms | 5.591ms | 12.771ms |
-| 1k | All | 85.494ms | 0.000ms | 22.895ms | n/a |
-| 1k | Min | 15.479ms | 0.000ms | 1.316ms | 5.006ms |
+| 300 | All | 129.728ms | 0.000ms | 66.206ms | n/a |
+| 300 | Min | 33.449ms | 0.000ms | 11.225ms | 13.307ms |
+| 1k | All | 60.561ms | 0.000ms | 40.608ms | n/a |
+| 1k | Min | 16.909ms | 0.000ms | 1.788ms | 6.684ms |
 
 Interpretation:
 
@@ -380,6 +381,10 @@ Interpretation:
 - the counted-path `All` staging buffer now stores targets and depths in
   parallel packed lists instead of shuttling a tiny struct per row, reducing
   replay overhead on the final materialization path
+- counted-path traversal and buffered replay now operate on interned node ids
+  with edge-state lookup tables, avoiding repeated object-key dictionary
+  lookups on the hot path while preserving exact output values at final
+  materialization time
 - the next broad optimization should avoid adding more generic frontier indexes
   until another dominance-heavy fallback shape appears; for counted closure,
   remaining work should target expansion/materialization overhead

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -970,22 +970,23 @@ Latest local results after edge-state node-id preindexing, per-row timing
 removal, a compact `(target, depth)` buffered row shape, O(1)
 parent-linked visited-path extension, and a dedicated counted-path traversal
 frame stack with explicit initial capacity, direct-write seed-batch
-materialization into the destination output list, and a packed target/depth
-row buffer:
+materialization into the destination output list, a packed target/depth
+row buffer, and node-id driven traversal/replay through edge-state value
+tables:
 
 | Scale | All | Min | Speedup | Output Match | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 |-------|----:|----:|--------:|--------------|----------------:|----------------:|-------------------------:|-------------------------:|
-| 300 | 0.392s | 0.167s | 2.35x | match | 602,808 | 30,968 | 982,581 | 101,371 |
-| 1k | 0.256s | 0.129s | 1.98x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+| 300 | 0.386s | 0.170s | 2.27x | match | 602,808 | 30,968 | 982,581 | 101,371 |
+| 1k | 0.270s | 0.131s | 2.07x | match | 352,522 | 10,328 | 592,698 | 38,196 |
 
 The same run reports the counted-closure phase split:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 |-------|------|----------:|-------------:|-----------------------:|----------------------:|
-| 300 | All | 149.430ms | 0.000ms | 52.088ms | n/a |
-| 300 | Min | 44.722ms | 0.000ms | 5.591ms | 12.771ms |
-| 1k | All | 85.494ms | 0.000ms | 22.895ms | n/a |
-| 1k | Min | 15.479ms | 0.000ms | 1.316ms | 5.006ms |
+| 300 | All | 129.728ms | 0.000ms | 66.206ms | n/a |
+| 300 | Min | 33.449ms | 0.000ms | 11.225ms | 13.307ms |
+| 1k | All | 60.561ms | 0.000ms | 40.608ms | n/a |
+| 1k | Min | 16.909ms | 0.000ms | 1.788ms | 6.684ms |
 
 Additional path-state observations:
 
@@ -1020,6 +1021,10 @@ Additional path-state observations:
 - the counted-path `All` staging buffer now stores targets and depths in
   parallel packed lists instead of shuttling a tiny struct per row, reducing
   replay overhead on the final materialization path.
+- counted-path traversal and buffered replay now operate on interned node ids
+  with edge-state lookup tables, avoiding repeated object-key dictionary
+  lookups on the hot path while preserving exact output values at final
+  materialization time.
 - This shape does not exercise the weighted `min_frontier_*` dominance
   candidate problem; generic frontier indexes would not address its primary
   cost. Further counted-closure work should target expansion/materialization

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1553,11 +1553,15 @@ namespace UnifyWeaver.QueryRuntime
         public PathAwareEdgeState(
             IReadOnlyDictionary<object, PathAwareSuccessorBucket> successors,
             IReadOnlyList<object?> seeds,
-            IReadOnlyList<int> seedNodeIds)
+            IReadOnlyList<int> seedNodeIds,
+            IReadOnlyList<object?> nodeValues,
+            IReadOnlyList<PathAwareSuccessorBucket?> bucketsByNodeId)
         {
             Successors = successors;
             Seeds = seeds;
             SeedNodeIds = seedNodeIds;
+            NodeValues = nodeValues;
+            BucketsByNodeId = bucketsByNodeId;
         }
 
         public IReadOnlyDictionary<object, PathAwareSuccessorBucket> Successors { get; }
@@ -1565,6 +1569,10 @@ namespace UnifyWeaver.QueryRuntime
         public IReadOnlyList<object?> Seeds { get; }
 
         public IReadOnlyList<int> SeedNodeIds { get; }
+
+        public IReadOnlyList<object?> NodeValues { get; }
+
+        public IReadOnlyList<PathAwareSuccessorBucket?> BucketsByNodeId { get; }
     }
 
     internal sealed class PathAwareSccGraph
@@ -6198,7 +6206,21 @@ namespace UnifyWeaver.QueryRuntime
                 seedNodeIds.Add(nodeIds[seeds[i] ?? NullFactIndexKey]);
             }
 
-            return new PathAwareEdgeState(successors, seeds, seedNodeIds);
+            var nodeValues = new object?[nodeIds.Count];
+            foreach (var entry in nodeIds)
+            {
+                nodeValues[entry.Value] = ReferenceEquals(entry.Key, NullFactIndexKey)
+                    ? null
+                    : entry.Key;
+            }
+
+            var bucketsByNodeId = new PathAwareSuccessorBucket?[nodeIds.Count];
+            foreach (var bucket in successors.Values)
+            {
+                bucketsByNodeId[bucket.SourceNodeId] = bucket;
+            }
+
+            return new PathAwareEdgeState(successors, seeds, seedNodeIds, nodeValues, bucketsByNodeId);
         }
 
         private static int GetOrAddPathAwareNodeId(
@@ -12375,7 +12397,7 @@ namespace UnifyWeaver.QueryRuntime
                 var traversalMetrics = trace is null ? null : new PathAwareTraversalMetrics();
                 for (var i = 0; i < edgeState.Seeds.Count; i++)
                 {
-                    AppendPathAwareRowsForSeed(edgeState.Seeds[i], edgeState.SeedNodeIds[i], edgeState.Successors, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth, traversalMetrics);
+                    AppendPathAwareRowsForSeed(edgeState.Seeds[i], edgeState.SeedNodeIds[i], edgeState.NodeValues, edgeState.BucketsByNodeId, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth, traversalMetrics);
                 }
 
                 if (traversalMetrics is not null)
@@ -12446,7 +12468,7 @@ namespace UnifyWeaver.QueryRuntime
                 var traversalMetrics = trace is null ? null : new PathAwareTraversalMetrics();
                 for (var i = 0; i < seeds.Count; i++)
                 {
-                    AppendPathAwareRowsForSeed(seeds[i], seedNodeIds[i], edgeState.Successors, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth, traversalMetrics);
+                    AppendPathAwareRowsForSeed(seeds[i], seedNodeIds[i], edgeState.NodeValues, edgeState.BucketsByNodeId, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth, traversalMetrics);
                 }
 
                 if (traversalMetrics is not null)
@@ -12465,7 +12487,8 @@ namespace UnifyWeaver.QueryRuntime
         private static void AppendPathAwareRowsForSeed(
             object? seed,
             int seedNodeId,
-            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
+            IReadOnlyList<object?> nodeValues,
+            IReadOnlyList<PathAwareSuccessorBucket?> bucketsByNodeId,
             int baseDepth,
             int depthIncrement,
             ICollection<object[]> output,
@@ -12483,7 +12506,7 @@ namespace UnifyWeaver.QueryRuntime
                 ? Math.Min(Math.Max(maxDepth + 1, 4), 256)
                 : 64;
             var stack = new Stack<PathAwareTraversalFrame>(initialStackCapacity);
-            stack.Push(new PathAwareTraversalFrame(seed, 0, initialPath));
+            stack.Push(new PathAwareTraversalFrame(seedNodeId, 0, initialPath));
             metrics?.RecordEnqueuedState(1);
             metrics?.RecordStackSize(stack.Count);
 
@@ -12491,20 +12514,24 @@ namespace UnifyWeaver.QueryRuntime
             while (stack.Count > 0)
             {
                 var frame = stack.Pop();
-                var current = frame.Node;
+                var currentNodeId = frame.NodeId;
                 var depth = frame.Depth;
                 var visited = frame.Visited;
                 metrics?.RecordStackPop();
                 metrics?.RecordPathLength(visited.Count);
-                var lookupKey = current ?? NullFactIndexKey;
-                if (!succIndex.TryGetValue(lookupKey, out var bucket))
+                if ((uint)currentNodeId >= (uint)bucketsByNodeId.Count)
+                {
+                    continue;
+                }
+
+                var bucket = bucketsByNodeId[currentNodeId];
+                if (bucket is null)
                 {
                     continue;
                 }
 
                 for (var i = bucket.Targets.Count - 1; i >= 0; i--)
                 {
-                    var next = bucket.Targets[i];
                     metrics?.RecordSuccessorCandidate();
                     var nextId = bucket.TargetNodeIds[i];
                     if (visited.Contains(nextId))
@@ -12525,6 +12552,7 @@ namespace UnifyWeaver.QueryRuntime
 
                     if (bestKnown is not null)
                     {
+                        var next = nodeValues[nextId];
                         if (bestKnown.TryGetValue(next, out var bestDepth))
                         {
                             switch (accumulatorMode)
@@ -12553,11 +12581,11 @@ namespace UnifyWeaver.QueryRuntime
                     }
                     else
                     {
-                        RecordBufferedPathAwareDepthRow(bufferedRows!, next, nextDepth);
+                        RecordBufferedPathAwareDepthRow(bufferedRows!, nextId, nextDepth);
                     }
 
                     var nextVisited = visited.Extend(nextId);
-                    stack.Push(new PathAwareTraversalFrame(next, nextDepth, nextVisited));
+                    stack.Push(new PathAwareTraversalFrame(nextId, nextDepth, nextVisited));
                     metrics?.RecordEnqueuedState(nextVisited.Count);
                     metrics?.RecordStackSize(stack.Count);
                 }
@@ -12566,7 +12594,7 @@ namespace UnifyWeaver.QueryRuntime
 
             if (bufferedRows is not null)
             {
-                MaterializePathAwareDepthRows(seed, bufferedRows, output, metrics);
+                MaterializePathAwareDepthRows(seed, nodeValues, bufferedRows, output, metrics);
             }
 
             if (bestKnown is not null)
@@ -12593,14 +12621,15 @@ namespace UnifyWeaver.QueryRuntime
 
         private static void RecordBufferedPathAwareDepthRow(
             PathAwareTargetDepthBuffer rows,
-            object? target,
+            int targetNodeId,
             int depth)
         {
-            rows.Add(target, depth);
+            rows.Add(targetNodeId, depth);
         }
 
         private static void MaterializePathAwareDepthRows(
             object? seed,
+            IReadOnlyList<object?> nodeValues,
             PathAwareTargetDepthBuffer rows,
             ICollection<object[]> output,
             PathAwareTraversalMetrics? metrics)
@@ -12611,22 +12640,22 @@ namespace UnifyWeaver.QueryRuntime
                 var baseIndex = outputList.Count;
                 CollectionsMarshal.SetCount(outputList, baseIndex + rows.Count);
                 var span = CollectionsMarshal.AsSpan(outputList);
-                var targets = CollectionsMarshal.AsSpan(rows.Targets);
+                var targetNodeIds = CollectionsMarshal.AsSpan(rows.TargetNodeIds);
                 var depths = CollectionsMarshal.AsSpan(rows.Depths);
                 for (var i = 0; i < rows.Count; i++)
                 {
-                    span[baseIndex + i] = new object[] { seed!, targets[i]!, depths[i] };
+                    span[baseIndex + i] = new object[] { seed!, nodeValues[targetNodeIds[i]]!, depths[i] };
                     metrics?.RecordOutputRow();
                 }
                 metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(started));
                 return;
             }
 
-            var fallbackTargets = rows.Targets;
+            var fallbackTargetNodeIds = rows.TargetNodeIds;
             var fallbackDepths = rows.Depths;
             for (var i = 0; i < rows.Count; i++)
             {
-                output.Add(new object[] { seed!, fallbackTargets[i]!, fallbackDepths[i] });
+                output.Add(new object[] { seed!, nodeValues[fallbackTargetNodeIds[i]]!, fallbackDepths[i] });
                 metrics?.RecordOutputRow();
             }
 
@@ -14025,21 +14054,21 @@ namespace UnifyWeaver.QueryRuntime
 
         private sealed class PathAwareTargetDepthBuffer
         {
-            public List<object?> Targets { get; } = new();
+            public List<int> TargetNodeIds { get; } = new();
 
             public List<int> Depths { get; } = new();
 
-            public int Count => Targets.Count;
+            public int Count => TargetNodeIds.Count;
 
-            public void Add(object? target, int depth)
+            public void Add(int targetNodeId, int depth)
             {
-                Targets.Add(target);
+                TargetNodeIds.Add(targetNodeId);
                 Depths.Add(depth);
             }
         }
 
         private readonly record struct PathAwareTraversalFrame(
-            object? Node,
+            int NodeId,
             int Depth,
             CompactVisitedPath Visited);
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  - Switches counted-path traversal and buffered replay to operate on interned node ids instead of repeated object-key lookups on the hot path.                                                                  
  - Extends `PathAwareEdgeState` with node-value and bucket-by-node-id tables for counted-path execution.                                                                                                        
  - Keeps final output materialization identical: `object[] { seed, target, depth }` in the same order.                                                                                                          
  - Preserves output hashes and existing `path_state_*` counters.                                                                                                                                                
  - Updates benchmark/proposal docs with the measured counted-path traversal reduction after node-id driven traversal/replay.                                                                                    
                                                                                                                                                                                                                 
  ## Why                                                                                                                                                                                                         
                                                                                                                                                                                                                 
  The counted-path `All` loop was still carrying object values through traversal and replay even though the runtime had already assigned stable node ids when building the edge state.                           
                                                                                                                                                                                                                 
  That left repeated object-key dictionary work in the hot path. This change pushes the counted-path loop fully onto interned node ids and only resolves the final target object when materializing output rows. 
                                                                                                                                                                                                                 
  ## Results                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  Local counted shortest-path benchmark:                                                                                                                                                                         
                                                                                                                                                                                                                 
  ```bash                                                                                                                                                                                                        
  python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3                                                                                                                  
  ```                                                                                                                                                                                                    
  | Scale | All | Min | Speedup | Output Match |                                                                                                                                                                 
  | --- | ---: | ---: | ---: | --- |                                                                                                                                                                             
  | 300 | 0.386s | 0.170s | 2.27x | match |                                                                                                                                                                      
  | 1k | 0.270s | 0.131s | 2.07x | match |                                                                                                                                                                       
                                                                                                                                                                                                                 
  Counted-closure phase split:                                                                                                                                                                                   
                                                                                                                                                                                                                 
  | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |                                                                                                                   
  | --- | --- | ---: | ---: | ---: | ---: |                                                                                                                                                                      
  | 300 | All | 129.728ms | 0.000ms | 66.206ms | n/a |                                                                                                                                                           
  | 300 | Min | 33.449ms | 0.000ms | 11.225ms | 13.307ms |                                                                                                                                                       
  | 1k | All | 60.561ms | 0.000ms | 40.608ms | n/a |                                                                                                                                                             
  | 1k | Min | 16.909ms | 0.000ms | 1.788ms | 6.684ms |                                                                                                                                                          
                                                                                                                                                                                                                 
  ## Notes                                                                                                                                                                                                       
                                                                                                                                                                                                                 
  - This is a traversal/replay representation change only.                                                                                                                                                       
  - Exact cycle detection, best-known pruning, and output ordering are preserved.                                                                                                                                
  - Final rows are still materialized exactly as object[] { seed, target, depth }.                                                                                                                               
                                                                                                                                                                                                                 
  ## Validation                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  - swipl -q -t run_tests tests/core/test_csharp_query_target.pl                                                                                                                                                 
  - python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py                                                                                                                                  
  - git diff --check                                                                                                                                                                                             
  - python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3                                                                                                                