### PR TITLE
perf(csharp-query): Tighten counted path `Min` flush in the C# query runtime

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -155,18 +155,18 @@ Local survey:
 | negative additive weighted `Min` | 1k | 0.563s | 1.217s | yes | `16,522,183` dominance candidates |
 
 Counted-closure phase split after typed row buffering, pre-sized
-materialization, edge-state node-id preindexing, per-row timing removal, a
-compact `(target, depth)` buffered row shape, O(1) parent-linked
-visited-path extension, a dedicated counted-path traversal frame stack, and
-direct-write seed-batch materialization with a packed target/depth row buffer
-and node-id driven traversal/replay:
+materialization, edge-state node-id preindexing, node-id keyed retained-min
+tracking/flush, per-row timing removal, a compact `(target, depth)` buffered
+row shape, O(1) parent-linked visited-path extension, a dedicated counted-path
+traversal frame stack, and direct-write seed-batch materialization with a
+packed target/depth row buffer and node-id driven traversal/replay:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 129.728ms | 0.000ms | 66.206ms | n/a |
-| 300 | Min | 33.449ms | 0.000ms | 11.225ms | 13.307ms |
-| 1k | All | 60.561ms | 0.000ms | 40.608ms | n/a |
-| 1k | Min | 16.909ms | 0.000ms | 1.788ms | 6.684ms |
+| 300 | All | 124.070ms | 0.000ms | 70.186ms | n/a |
+| 300 | Min | 33.045ms | 0.000ms | 6.058ms | 5.755ms |
+| 1k | All | 59.255ms | 0.000ms | 39.878ms | n/a |
+| 1k | Min | 11.824ms | 0.000ms | 1.074ms | 2.195ms |
 
 Interpretation:
 
@@ -203,6 +203,10 @@ Interpretation:
   with edge-state lookup tables, avoiding repeated object-key dictionary
   lookups on the hot path while preserving exact output values at final
   materialization time
+- counted-path `Min` now keeps retained best depths keyed by interned target
+  node id until the final target-sorted flush, cutting object-key hashing and
+  reducing `best_known_flush_sort` plus final `Min` materialization cost while
+  preserving the deterministic ordering contract
 - weighted `Min` fallback remains the only measured shape where generic
   frontier candidate indexing is directly relevant
 - the next optimization should not add another generic frontier index by

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -324,18 +324,18 @@ raw path-state traversal:
 | counted shortest path | 1k | 0.450s | 0.180s | 2.50x | 352,522 | 10,328 | 592,698 | 38,196 |
 
 Counted-closure phase split after typed row buffering, pre-sized
-materialization, edge-state node-id preindexing, per-row timing removal, a
-compact `(target, depth)` buffered row shape, O(1) parent-linked
-visited-path extension, a dedicated counted-path traversal frame stack, and
-direct-write seed-batch materialization with a packed target/depth row buffer
-and node-id driven traversal/replay:
+materialization, edge-state node-id preindexing, node-id keyed retained-min
+tracking/flush, per-row timing removal, a compact `(target, depth)` buffered
+row shape, O(1) parent-linked visited-path extension, a dedicated counted-path
+traversal frame stack, and direct-write seed-batch materialization with a
+packed target/depth row buffer and node-id driven traversal/replay:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 129.728ms | 0.000ms | 66.206ms | n/a |
-| 300 | Min | 33.449ms | 0.000ms | 11.225ms | 13.307ms |
-| 1k | All | 60.561ms | 0.000ms | 40.608ms | n/a |
-| 1k | Min | 16.909ms | 0.000ms | 1.788ms | 6.684ms |
+| 300 | All | 124.070ms | 0.000ms | 70.186ms | n/a |
+| 300 | Min | 33.045ms | 0.000ms | 6.058ms | 5.755ms |
+| 1k | All | 59.255ms | 0.000ms | 39.878ms | n/a |
+| 1k | Min | 11.824ms | 0.000ms | 1.074ms | 2.195ms |
 
 Interpretation:
 
@@ -385,6 +385,10 @@ Interpretation:
   with edge-state lookup tables, avoiding repeated object-key dictionary
   lookups on the hot path while preserving exact output values at final
   materialization time
+- counted-path `Min` now keeps retained best depths keyed by interned target
+  node id until the final target-sorted flush, cutting object-key hashing and
+  reducing `best_known_flush_sort` plus final `Min` materialization cost while
+  preserving the deterministic ordering contract
 - the next broad optimization should avoid adding more generic frontier indexes
   until another dominance-heavy fallback shape appears; for counted closure,
   remaining work should target expansion/materialization overhead

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -974,8 +974,9 @@ python examples/benchmark/benchmark_shortest_path_to_root.py \
     --scales 300,1k --repetitions 3
 ```
 
-Latest local results after edge-state node-id preindexing, per-row timing
-removal, a compact `(target, depth)` buffered row shape, O(1)
+Latest local results after edge-state node-id preindexing, node-id keyed
+retained-min tracking/flush, per-row timing removal, a compact `(target, depth)`
+buffered row shape, O(1)
 parent-linked visited-path extension, and a dedicated counted-path traversal
 frame stack with explicit initial capacity, direct-write seed-batch
 materialization into the destination output list, a packed target/depth
@@ -984,17 +985,17 @@ tables:
 
 | Scale | All | Min | Speedup | Output Match | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 |-------|----:|----:|--------:|--------------|----------------:|----------------:|-------------------------:|-------------------------:|
-| 300 | 0.386s | 0.170s | 2.27x | match | 602,808 | 30,968 | 982,581 | 101,371 |
-| 1k | 0.270s | 0.131s | 2.07x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+| 300 | 0.383s | 0.163s | 2.34x | match | 602,808 | 30,968 | 982,581 | 101,371 |
+| 1k | 0.269s | 0.129s | 2.08x | match | 352,522 | 10,328 | 592,698 | 38,196 |
 
 The same run reports the counted-closure phase split:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 |-------|------|----------:|-------------:|-----------------------:|----------------------:|
-| 300 | All | 129.728ms | 0.000ms | 66.206ms | n/a |
-| 300 | Min | 33.449ms | 0.000ms | 11.225ms | 13.307ms |
-| 1k | All | 60.561ms | 0.000ms | 40.608ms | n/a |
-| 1k | Min | 16.909ms | 0.000ms | 1.788ms | 6.684ms |
+| 300 | All | 124.070ms | 0.000ms | 70.186ms | n/a |
+| 300 | Min | 33.045ms | 0.000ms | 6.058ms | 5.755ms |
+| 1k | All | 59.255ms | 0.000ms | 39.878ms | n/a |
+| 1k | Min | 11.824ms | 0.000ms | 1.074ms | 2.195ms |
 
 Additional path-state observations:
 
@@ -1033,6 +1034,10 @@ Additional path-state observations:
   with edge-state lookup tables, avoiding repeated object-key dictionary
   lookups on the hot path while preserving exact output values at final
   materialization time.
+- counted-path `Min` now keeps retained best depths keyed by interned target
+  node id until the final target-sorted flush, cutting object-key hashing and
+  reducing `best_known_flush_sort` plus final `Min` materialization cost while
+  preserving the deterministic ordering contract.
 - This shape does not exercise the weighted `min_frontier_*` dominance
   candidate problem; generic frontier indexes would not address its primary
   cost. Further counted-closure work should target expansion/materialization

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -12498,7 +12498,7 @@ namespace UnifyWeaver.QueryRuntime
         {
             metrics?.RecordSeed();
             var preserveAllPaths = accumulatorMode is TableMode.All or TableMode.Sum or TableMode.Count;
-            var bestKnown = preserveAllPaths ? null : new Dictionary<object?, int>();
+            var bestKnown = preserveAllPaths ? null : new Dictionary<int, int>();
             var bufferedRows = preserveAllPaths ? new PathAwareTargetDepthBuffer() : null;
 
             var initialPath = CompactVisitedPath.Create(seedNodeId);
@@ -12552,8 +12552,7 @@ namespace UnifyWeaver.QueryRuntime
 
                     if (bestKnown is not null)
                     {
-                        var next = nodeValues[nextId];
-                        if (bestKnown.TryGetValue(next, out var bestDepth))
+                        if (bestKnown.TryGetValue(nextId, out var bestDepth))
                         {
                             switch (accumulatorMode)
                             {
@@ -12577,7 +12576,7 @@ namespace UnifyWeaver.QueryRuntime
                             }
                         }
 
-                        bestKnown[next] = nextDepth;
+                        bestKnown[nextId] = nextDepth;
                     }
                     else
                     {
@@ -12600,10 +12599,10 @@ namespace UnifyWeaver.QueryRuntime
             if (bestKnown is not null)
             {
                 var flushStarted = Stopwatch.GetTimestamp();
-                var bestRows = new List<KeyValuePair<object?, int>>(bestKnown);
+                var bestRows = new List<int>(bestKnown.Keys);
                 // Min-mode retained rows are flushed in deterministic target order
                 // rather than traversal/discovery order.
-                bestRows.Sort((left, right) => CompareCacheSeedValues(left.Key, right.Key));
+                bestRows.Sort((left, right) => CompareCacheSeedValues(nodeValues[left], nodeValues[right]));
                 metrics?.AddBestKnownFlushSortElapsed(Stopwatch.GetElapsedTime(flushStarted));
 
                 var materializationStarted = Stopwatch.GetTimestamp();
@@ -12612,9 +12611,9 @@ namespace UnifyWeaver.QueryRuntime
                     outputList.EnsureCapacity(outputList.Count + bestRows.Count);
                 }
 
-                foreach (var (target, depth) in bestRows)
+                foreach (var targetNodeId in bestRows)
                 {
-                    output.Add(new object[] { seed!, target!, depth });
+                    output.Add(new object[] { seed!, nodeValues[targetNodeId]!, bestKnown[targetNodeId] });
                     metrics?.RecordOutputRow();
                 }
                 metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(materializationStarted));


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  - Keeps counted-path `Min` retained best depths keyed by interned target node id until the final flush.                                                                                                        
  - Removes object-key hashing and `KeyValuePair<object?, int>` churn from the retained-minima flush path.                                                                                                       
  - Preserves the documented deterministic target-sorted ordering contract by sorting retained node ids through `CompareCacheSeedValues(nodeValues[left], nodeValues[right])`.                                   
  - Updates benchmark/proposal docs with the new counted-path `Min` flush measurements.                                                                                                                          
                                                                                                                                                                                                                 
  ## Why                                                                                                                                                                                                         
                                                                                                                                                                                                                 
  The previous work made the counted-path `Min` ordering contract explicit. That narrowed the next optimization target: make the retained-minima finishing path cheaper without weakening deterministic target-  
  sorted output.                                                                                                                                                                                                 
                                                                                                                                                                                                                 
  Before this change, counted-path `Min` used an object-keyed `Dictionary<object?, int>` and then copied that into a `List<KeyValuePair<object?, int>>` for sorting and final projection. That paid unnecessary  
  object-key hashing and extra retained-row allocation/churn even though traversal already had stable interned node ids.                                                                                         
                                                                                                                                                                                                                 
  This PR keeps the retained minima keyed by target node id until the final ordered flush, then maps back through `nodeValues` only for the final sorted output rows.                                            
                                                                                                                                                                                                                 
  ## Results                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  Local counted shortest-path benchmark:                                                                                                                                                                         
                                                                                                                                                                                                                 
  ```bash                                                                                                                                                                                                        
  python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3                                                                                                                  
  ```                                                                                                                                                                                       
  | Scale | All | Min | Speedup | Output Match |                                                                                                                                                                 
  | --- | ---: | ---: | ---: | --- |                                                                                                                                                                             
  | 300 | 0.383s | 0.163s | 2.34x | match |                                                                                                                                                                      
  | 1k | 0.269s | 0.129s | 2.08x | match |                                                                                                                                                                       
                                                                                                                                                                                                                 
  Counted-closure phase split:                                                                                                                                                                                   
                                                                                                                                                                                                                 
  | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |                                                                                                                   
  | --- | --- | ---: | ---: | ---: | ---: |                                                                                                                                                                      
  | 300 | All | 124.070ms | 0.000ms | 70.186ms | n/a |                                                                                                                                                           
  | 300 | Min | 33.045ms | 0.000ms | 6.058ms | 5.755ms |                                                                                                                                                         
  | 1k | All | 59.255ms | 0.000ms | 39.878ms | n/a |                                                                                                                                                             
  | 1k | Min | 11.824ms | 0.000ms | 1.074ms | 2.195ms |                                                                                                                                                          
                                                                                                                                                                                                                 
  Measured Min flush improvement versus the prior retained-min path:                                                                                                                                             
                                                                                                                                                                                                                 
  - 300 best_known_flush_sort: 13.307ms -> 5.755ms                                                                                                                                                               
  - 1k best_known_flush_sort: 6.684ms -> 2.195ms                                                                                                                                                                 
                                                                                                                                                                                                                 
  ## Validation                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  - swipl -q -t run_tests tests/core/test_csharp_query_target.pl                                                                                                                                                 
  - python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py                                                                                                                                  
  - git diff --check                                                                                                                                                                                             
  - python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3                                                                                                                