### PR TITLE
perf(csharp-query): Tighten counted path replay lookups in the C# query runtime

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -156,17 +156,18 @@ Local survey:
 
 Counted-closure phase split after typed row buffering, pre-sized
 materialization, edge-state node-id preindexing, node-id keyed retained-min
-tracking/flush, per-row timing removal, a compact `(target, depth)` buffered
-row shape, O(1) parent-linked visited-path extension, a dedicated counted-path
-traversal frame stack, and direct-write seed-batch materialization with a
-packed target/depth row buffer and node-id driven traversal/replay:
+tracking/flush, concrete-array `nodeValues` replay on the counted-path
+materialization path, per-row timing removal, a compact `(target, depth)`
+buffered row shape, O(1) parent-linked visited-path extension, a dedicated
+counted-path traversal frame stack, and direct-write seed-batch materialization
+with a packed target/depth row buffer and node-id driven traversal/replay:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 124.070ms | 0.000ms | 70.186ms | n/a |
-| 300 | Min | 33.045ms | 0.000ms | 6.058ms | 5.755ms |
-| 1k | All | 59.255ms | 0.000ms | 39.878ms | n/a |
-| 1k | Min | 11.824ms | 0.000ms | 1.074ms | 2.195ms |
+| 300 | All | 145.095ms | 0.000ms | 87.814ms | n/a |
+| 300 | Min | 33.375ms | 0.000ms | 5.672ms | 4.638ms |
+| 1k | All | 60.023ms | 0.000ms | 37.890ms | n/a |
+| 1k | Min | 16.766ms | 0.000ms | 1.284ms | 2.349ms |
 
 Interpretation:
 
@@ -207,6 +208,9 @@ Interpretation:
   node id until the final target-sorted flush, cutting object-key hashing and
   reducing `best_known_flush_sort` plus final `Min` materialization cost while
   preserving the deterministic ordering contract
+- counted-path replay/materialization now uses the concrete `object?[]`
+  node-value table directly instead of an `IReadOnlyList<object?>` view, which
+  trims lookup overhead on the hot replay path without changing output rows
 - weighted `Min` fallback remains the only measured shape where generic
   frontier candidate indexing is directly relevant
 - the next optimization should not add another generic frontier index by

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -325,17 +325,18 @@ raw path-state traversal:
 
 Counted-closure phase split after typed row buffering, pre-sized
 materialization, edge-state node-id preindexing, node-id keyed retained-min
-tracking/flush, per-row timing removal, a compact `(target, depth)` buffered
-row shape, O(1) parent-linked visited-path extension, a dedicated counted-path
-traversal frame stack, and direct-write seed-batch materialization with a
-packed target/depth row buffer and node-id driven traversal/replay:
+tracking/flush, concrete-array `nodeValues` replay on the counted-path
+materialization path, per-row timing removal, a compact `(target, depth)`
+buffered row shape, O(1) parent-linked visited-path extension, a dedicated
+counted-path traversal frame stack, and direct-write seed-batch materialization
+with a packed target/depth row buffer and node-id driven traversal/replay:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 124.070ms | 0.000ms | 70.186ms | n/a |
-| 300 | Min | 33.045ms | 0.000ms | 6.058ms | 5.755ms |
-| 1k | All | 59.255ms | 0.000ms | 39.878ms | n/a |
-| 1k | Min | 11.824ms | 0.000ms | 1.074ms | 2.195ms |
+| 300 | All | 145.095ms | 0.000ms | 87.814ms | n/a |
+| 300 | Min | 33.375ms | 0.000ms | 5.672ms | 4.638ms |
+| 1k | All | 60.023ms | 0.000ms | 37.890ms | n/a |
+| 1k | Min | 16.766ms | 0.000ms | 1.284ms | 2.349ms |
 
 Interpretation:
 
@@ -389,6 +390,9 @@ Interpretation:
   node id until the final target-sorted flush, cutting object-key hashing and
   reducing `best_known_flush_sort` plus final `Min` materialization cost while
   preserving the deterministic ordering contract
+- counted-path replay/materialization now uses the concrete `object?[]`
+  node-value table directly instead of an `IReadOnlyList<object?>` view, which
+  trims lookup overhead on the hot replay path without changing output rows
 - the next broad optimization should avoid adding more generic frontier indexes
   until another dominance-heavy fallback shape appears; for counted closure,
   remaining work should target expansion/materialization overhead

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -975,7 +975,8 @@ python examples/benchmark/benchmark_shortest_path_to_root.py \
 ```
 
 Latest local results after edge-state node-id preindexing, node-id keyed
-retained-min tracking/flush, per-row timing removal, a compact `(target, depth)`
+retained-min tracking/flush, concrete-array `nodeValues` replay on the counted
+path materialization path, per-row timing removal, a compact `(target, depth)`
 buffered row shape, O(1)
 parent-linked visited-path extension, and a dedicated counted-path traversal
 frame stack with explicit initial capacity, direct-write seed-batch
@@ -985,17 +986,17 @@ tables:
 
 | Scale | All | Min | Speedup | Output Match | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 |-------|----:|----:|--------:|--------------|----------------:|----------------:|-------------------------:|-------------------------:|
-| 300 | 0.383s | 0.163s | 2.34x | match | 602,808 | 30,968 | 982,581 | 101,371 |
-| 1k | 0.269s | 0.129s | 2.08x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+| 300 | 0.392s | 0.154s | 2.54x | match | 602,808 | 30,968 | 982,581 | 101,371 |
+| 1k | 0.266s | 0.134s | 1.99x | match | 352,522 | 10,328 | 592,698 | 38,196 |
 
 The same run reports the counted-closure phase split:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 |-------|------|----------:|-------------:|-----------------------:|----------------------:|
-| 300 | All | 124.070ms | 0.000ms | 70.186ms | n/a |
-| 300 | Min | 33.045ms | 0.000ms | 6.058ms | 5.755ms |
-| 1k | All | 59.255ms | 0.000ms | 39.878ms | n/a |
-| 1k | Min | 11.824ms | 0.000ms | 1.074ms | 2.195ms |
+| 300 | All | 145.095ms | 0.000ms | 87.814ms | n/a |
+| 300 | Min | 33.375ms | 0.000ms | 5.672ms | 4.638ms |
+| 1k | All | 60.023ms | 0.000ms | 37.890ms | n/a |
+| 1k | Min | 16.766ms | 0.000ms | 1.284ms | 2.349ms |
 
 Additional path-state observations:
 
@@ -1038,6 +1039,9 @@ Additional path-state observations:
   node id until the final target-sorted flush, cutting object-key hashing and
   reducing `best_known_flush_sort` plus final `Min` materialization cost while
   preserving the deterministic ordering contract.
+- counted-path replay/materialization now uses the concrete `object?[]`
+  node-value table directly instead of an `IReadOnlyList<object?>` view, which
+  trims lookup overhead on the hot replay path without changing output rows.
 - This shape does not exercise the weighted `min_frontier_*` dominance
   candidate problem; generic frontier indexes would not address its primary
   cost. Further counted-closure work should target expansion/materialization

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1554,7 +1554,7 @@ namespace UnifyWeaver.QueryRuntime
             IReadOnlyDictionary<object, PathAwareSuccessorBucket> successors,
             IReadOnlyList<object?> seeds,
             IReadOnlyList<int> seedNodeIds,
-            IReadOnlyList<object?> nodeValues,
+            object?[] nodeValues,
             IReadOnlyList<PathAwareSuccessorBucket?> bucketsByNodeId)
         {
             Successors = successors;
@@ -1570,7 +1570,7 @@ namespace UnifyWeaver.QueryRuntime
 
         public IReadOnlyList<int> SeedNodeIds { get; }
 
-        public IReadOnlyList<object?> NodeValues { get; }
+        public object?[] NodeValues { get; }
 
         public IReadOnlyList<PathAwareSuccessorBucket?> BucketsByNodeId { get; }
     }
@@ -12487,7 +12487,7 @@ namespace UnifyWeaver.QueryRuntime
         private static void AppendPathAwareRowsForSeed(
             object? seed,
             int seedNodeId,
-            IReadOnlyList<object?> nodeValues,
+            object?[] nodeValues,
             IReadOnlyList<PathAwareSuccessorBucket?> bucketsByNodeId,
             int baseDepth,
             int depthIncrement,
@@ -12630,12 +12630,13 @@ namespace UnifyWeaver.QueryRuntime
 
         private static void MaterializePathAwareDepthRows(
             object? seed,
-            IReadOnlyList<object?> nodeValues,
+            object?[] nodeValues,
             PathAwareTargetDepthBuffer rows,
             ICollection<object[]> output,
             PathAwareTraversalMetrics? metrics)
         {
             var started = Stopwatch.GetTimestamp();
+            var seedValue = seed!;
             if (output is List<object[]> outputList)
             {
                 var baseIndex = outputList.Count;
@@ -12645,7 +12646,7 @@ namespace UnifyWeaver.QueryRuntime
                 var depths = CollectionsMarshal.AsSpan(rows.Depths);
                 for (var i = 0; i < rows.Count; i++)
                 {
-                    span[baseIndex + i] = new object[] { seed!, nodeValues[targetNodeIds[i]]!, depths[i] };
+                    span[baseIndex + i] = new object[] { seedValue, nodeValues[targetNodeIds[i]]!, depths[i] };
                     metrics?.RecordOutputRow();
                 }
                 metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(started));
@@ -12656,7 +12657,7 @@ namespace UnifyWeaver.QueryRuntime
             var fallbackDepths = rows.Depths;
             for (var i = 0; i < rows.Count; i++)
             {
-                output.Add(new object[] { seed!, nodeValues[fallbackTargetNodeIds[i]]!, fallbackDepths[i] });
+                output.Add(new object[] { seedValue, nodeValues[fallbackTargetNodeIds[i]]!, fallbackDepths[i] });
                 metrics?.RecordOutputRow();
             }
 


### PR DESCRIPTION
  ## Summary

  - Keeps counted-path replay/materialization on the same exact-output path.
  - Switches counted-path replay to use the concrete `object?[]` node-value table directly instead of an `IReadOnlyList<object?>` view.
  - Preserves exact output rows, order, hashes, and existing `path_state_*` metrics.
  - Updates benchmark/proposal docs with the measured replay/materialization result after the lookup-path tightening.

  ## Why

  The current counted-path `All` workload is still dominated by traversal volume and final replay/materialization cost. The previous work already removed several larger sources of overhead, so the next useful
  step was to trim hot replay-path costs without touching semantics.

  The runtime already builds `nodeValues` as a concrete array during edge-state construction. This change keeps using that concrete array on the replay/materialization path instead of going through an
  interface-shaped `IReadOnlyList<object?>` view.

  That is a narrow optimization, but it directly targets the high-volume `All` replay loop.

  ## Results

  Local counted shortest-path benchmark:

  ```bash
  python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3
  ```
  | Scale | All | Min | Speedup | Output Match |
  | --- | ---: | ---: | ---: | --- |
  | 300 | 0.392s | 0.154s | 2.54x | match |
  | 1k | 0.266s | 0.134s | 1.99x | match |

  Counted-closure phase split:

  | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
  | --- | --- | ---: | ---: | ---: | ---: |
  | 300 | All | 145.095ms | 0.000ms | 87.814ms | n/a |
  | 300 | Min | 33.375ms | 0.000ms | 5.672ms | 4.638ms |
  | 1k | All | 60.023ms | 0.000ms | 37.890ms | n/a |
  | 1k | Min | 16.766ms | 0.000ms | 1.284ms | 2.349ms |

  Measured replay/materialization result:

  - 1k All path_state_result_materialization: 39.878ms -> 37.890ms

  ## Validation

  - swipl -q -t run_tests tests/core/test_csharp_query_target.pl
  - python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py
  - git diff --check
  - python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3