### PR TITLE
perf(csharp-query): Cache counted path depth boxes in the C# query runtime

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -157,17 +157,18 @@ Local survey:
 Counted-closure phase split after typed row buffering, pre-sized
 materialization, edge-state node-id preindexing, node-id keyed retained-min
 tracking/flush, concrete-array `nodeValues` replay on the counted-path
-materialization path, per-row timing removal, a compact `(target, depth)`
-buffered row shape, O(1) parent-linked visited-path extension, a dedicated
-counted-path traversal frame stack, and direct-write seed-batch materialization
-with a packed target/depth row buffer and node-id driven traversal/replay:
+materialization path, cached boxed depth reuse for counted-path row
+construction, per-row timing removal, a compact `(target, depth)` buffered row
+shape, O(1) parent-linked visited-path extension, a dedicated counted-path
+traversal frame stack, and direct-write seed-batch materialization with a
+packed target/depth row buffer and node-id driven traversal/replay:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 145.095ms | 0.000ms | 87.814ms | n/a |
-| 300 | Min | 33.375ms | 0.000ms | 5.672ms | 4.638ms |
-| 1k | All | 60.023ms | 0.000ms | 37.890ms | n/a |
-| 1k | Min | 16.766ms | 0.000ms | 1.284ms | 2.349ms |
+| 300 | All | 105.838ms | 0.000ms | 47.047ms | n/a |
+| 300 | Min | 29.808ms | 0.000ms | 11.718ms | 4.819ms |
+| 1k | All | 50.357ms | 0.000ms | 34.107ms | n/a |
+| 1k | Min | 11.941ms | 0.000ms | 0.980ms | 1.827ms |
 
 Interpretation:
 
@@ -211,6 +212,9 @@ Interpretation:
 - counted-path replay/materialization now uses the concrete `object?[]`
   node-value table directly instead of an `IReadOnlyList<object?>` view, which
   trims lookup overhead on the hot replay path without changing output rows
+- counted-path row construction now reuses cached boxed depth objects for
+  common small path depths, reducing per-row boxing churn on the high-volume
+  `All` materialization path
 - weighted `Min` fallback remains the only measured shape where generic
   frontier candidate indexing is directly relevant
 - the next optimization should not add another generic frontier index by

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -326,17 +326,18 @@ raw path-state traversal:
 Counted-closure phase split after typed row buffering, pre-sized
 materialization, edge-state node-id preindexing, node-id keyed retained-min
 tracking/flush, concrete-array `nodeValues` replay on the counted-path
-materialization path, per-row timing removal, a compact `(target, depth)`
-buffered row shape, O(1) parent-linked visited-path extension, a dedicated
-counted-path traversal frame stack, and direct-write seed-batch materialization
-with a packed target/depth row buffer and node-id driven traversal/replay:
+materialization path, cached boxed depth reuse for counted-path row
+construction, per-row timing removal, a compact `(target, depth)` buffered row
+shape, O(1) parent-linked visited-path extension, a dedicated counted-path
+traversal frame stack, and direct-write seed-batch materialization with a
+packed target/depth row buffer and node-id driven traversal/replay:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 145.095ms | 0.000ms | 87.814ms | n/a |
-| 300 | Min | 33.375ms | 0.000ms | 5.672ms | 4.638ms |
-| 1k | All | 60.023ms | 0.000ms | 37.890ms | n/a |
-| 1k | Min | 16.766ms | 0.000ms | 1.284ms | 2.349ms |
+| 300 | All | 105.838ms | 0.000ms | 47.047ms | n/a |
+| 300 | Min | 29.808ms | 0.000ms | 11.718ms | 4.819ms |
+| 1k | All | 50.357ms | 0.000ms | 34.107ms | n/a |
+| 1k | Min | 11.941ms | 0.000ms | 0.980ms | 1.827ms |
 
 Interpretation:
 
@@ -393,6 +394,9 @@ Interpretation:
 - counted-path replay/materialization now uses the concrete `object?[]`
   node-value table directly instead of an `IReadOnlyList<object?>` view, which
   trims lookup overhead on the hot replay path without changing output rows
+- counted-path row construction now reuses cached boxed depth objects for
+  common small path depths, reducing per-row boxing churn on the high-volume
+  `All` materialization path
 - the next broad optimization should avoid adding more generic frontier indexes
   until another dominance-heavy fallback shape appears; for counted closure,
   remaining work should target expansion/materialization overhead

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -976,8 +976,9 @@ python examples/benchmark/benchmark_shortest_path_to_root.py \
 
 Latest local results after edge-state node-id preindexing, node-id keyed
 retained-min tracking/flush, concrete-array `nodeValues` replay on the counted
-path materialization path, per-row timing removal, a compact `(target, depth)`
-buffered row shape, O(1)
+path materialization path, cached boxed depth reuse for counted-path row
+construction, per-row timing removal, a compact `(target, depth)` buffered row
+shape, O(1)
 parent-linked visited-path extension, and a dedicated counted-path traversal
 frame stack with explicit initial capacity, direct-write seed-batch
 materialization into the destination output list, a packed target/depth
@@ -986,17 +987,17 @@ tables:
 
 | Scale | All | Min | Speedup | Output Match | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 |-------|----:|----:|--------:|--------------|----------------:|----------------:|-------------------------:|-------------------------:|
-| 300 | 0.392s | 0.154s | 2.54x | match | 602,808 | 30,968 | 982,581 | 101,371 |
-| 1k | 0.266s | 0.134s | 1.99x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+| 300 | 0.339s | 0.157s | 2.16x | match | 602,808 | 30,968 | 982,581 | 101,371 |
+| 1k | 0.249s | 0.129s | 1.93x | match | 352,522 | 10,328 | 592,698 | 38,196 |
 
 The same run reports the counted-closure phase split:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 |-------|------|----------:|-------------:|-----------------------:|----------------------:|
-| 300 | All | 145.095ms | 0.000ms | 87.814ms | n/a |
-| 300 | Min | 33.375ms | 0.000ms | 5.672ms | 4.638ms |
-| 1k | All | 60.023ms | 0.000ms | 37.890ms | n/a |
-| 1k | Min | 16.766ms | 0.000ms | 1.284ms | 2.349ms |
+| 300 | All | 105.838ms | 0.000ms | 47.047ms | n/a |
+| 300 | Min | 29.808ms | 0.000ms | 11.718ms | 4.819ms |
+| 1k | All | 50.357ms | 0.000ms | 34.107ms | n/a |
+| 1k | Min | 11.941ms | 0.000ms | 0.980ms | 1.827ms |
 
 Additional path-state observations:
 
@@ -1042,6 +1043,9 @@ Additional path-state observations:
 - counted-path replay/materialization now uses the concrete `object?[]`
   node-value table directly instead of an `IReadOnlyList<object?>` view, which
   trims lookup overhead on the hot replay path without changing output rows.
+- counted-path row construction now reuses cached boxed depth objects for
+  common small path depths, reducing per-row boxing churn on the high-volume
+  `All` materialization path.
 - This shape does not exercise the weighted `min_frontier_*` dominance
   candidate problem; generic frontier indexes would not address its primary
   cost. Further counted-closure work should target expansion/materialization

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1728,6 +1728,7 @@ namespace UnifyWeaver.QueryRuntime
     {
         private readonly IRelationProvider _provider;
         private static readonly object NullFactIndexKey = new();
+        private static readonly object[] SmallIntBoxes = CreateSmallIntBoxes(256);
         private static readonly RowWrapperComparer StructuralRowWrapperComparer = new(StructuralArrayComparer.Instance);
         private readonly EvaluationContext? _cacheContext;
         private readonly int _pairProbeCacheMaxEntries;
@@ -1770,6 +1771,24 @@ namespace UnifyWeaver.QueryRuntime
             _pathAwareSupportRelationRetentionStrategy = options.PathAwareSupportRelationRetentionStrategy;
             _pathAwareGroupedMinStrategy = ToPathAwareGroupedSummaryStrategy(options.PathAwareGroupedMinStrategy);
             _pathAwareWeightSumStrategy = ToPathAwareGroupedSummaryStrategy(options.PathAwareWeightSumStrategy);
+        }
+
+        private static object[] CreateSmallIntBoxes(int count)
+        {
+            var values = new object[count];
+            for (var i = 0; i < count; i++)
+            {
+                values[i] = i;
+            }
+
+            return values;
+        }
+
+        private static object BoxCountedPathDepth(int value)
+        {
+            return (uint)value < (uint)SmallIntBoxes.Length
+                ? SmallIntBoxes[value]
+                : value;
         }
 
         public IEnumerable<object[]> Execute(
@@ -12646,7 +12665,7 @@ namespace UnifyWeaver.QueryRuntime
                 var depths = CollectionsMarshal.AsSpan(rows.Depths);
                 for (var i = 0; i < rows.Count; i++)
                 {
-                    span[baseIndex + i] = new object[] { seedValue, nodeValues[targetNodeIds[i]]!, depths[i] };
+                    span[baseIndex + i] = new object[] { seedValue, nodeValues[targetNodeIds[i]]!, BoxCountedPathDepth(depths[i]) };
                     metrics?.RecordOutputRow();
                 }
                 metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(started));
@@ -12657,7 +12676,7 @@ namespace UnifyWeaver.QueryRuntime
             var fallbackDepths = rows.Depths;
             for (var i = 0; i < rows.Count; i++)
             {
-                output.Add(new object[] { seedValue, nodeValues[fallbackTargetNodeIds[i]]!, fallbackDepths[i] });
+                output.Add(new object[] { seedValue, nodeValues[fallbackTargetNodeIds[i]]!, BoxCountedPathDepth(fallbackDepths[i]) });
                 metrics?.RecordOutputRow();
             }
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  - Reuses cached boxed depth objects for common small counted-path depths during final row construction.                                                                                                        
  - Reduces per-row boxing churn on the high-volume counted-path `All` materialization path.                                                                                                                     
  - Preserves exact output rows, order, benchmark hashes, and existing `path_state_*` metrics.                                                                                                                   
  - Updates benchmark/proposal docs with the new counted-path row-allocation measurements.                                                                                                                       
                                                                                                                                                                                                                 
  ## Why                                                                                                                                                                                                         
                                                                                                                                                                                                                 
  At this point the remaining counted-path `All` cost is still dominated by traversal volume and final row materialization. The replay lookup path was already tightened, so the next obvious allocation hotspot 
  was the boxed depth value stored in every `object[]` output row.                                                                                                                                               
                                                                                                                                                                                                                 
  For counted-path workloads, depths are small integers in the hot path and are repeatedly boxed into fresh objects during row construction. This change reuses cached boxed integers for common small depths so 
  the runtime stops paying that allocation cost on every output row.                                                                                                                                             
                                                                                                                                                                                                                 
  ## Results                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  Local counted shortest-path benchmark:                                                                                                                                                                         
                                                                                                                                                                                                                 
  ```bash                                                                                                                                                                                                        
  python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3                                                                                                                  
  ```                                                                                                                                                                                         
  | Scale | All | Min | Speedup | Output Match |                                                                                                                                                                 
  | --- | ---: | ---: | ---: | --- |                                                                                                                                                                             
  | 300 | 0.339s | 0.157s | 2.16x | match |                                                                                                                                                                      
  | 1k | 0.249s | 0.129s | 1.93x | match |                                                                                                                                                                       
                                                                                                                                                                                                                 
  Counted-closure phase split:                                                                                                                                                                                   
                                                                                                                                                                                                                 
  | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |                                                                                                                   
  | --- | --- | ---: | ---: | ---: | ---: |                                                                                                                                                                      
  | 300 | All | 105.838ms | 0.000ms | 47.047ms | n/a |                                                                                                                                                           
  | 300 | Min | 29.808ms | 0.000ms | 11.718ms | 4.819ms |                                                                                                                                                        
  | 1k | All | 50.357ms | 0.000ms | 34.107ms | n/a |                                                                                                                                                             
  | 1k | Min | 11.941ms | 0.000ms | 0.980ms | 1.827ms |                                                                                                                                                          
                                                                                                                                                                                                                 
  Measured All materialization result:                                                                                                                                                                           
                                                                                                                                                                                                                 
  - 300 All path_state_result_materialization: 64.318ms -> 47.047ms                                                                                                                                              
  - 1k All path_state_result_materialization: 38.188ms -> 34.107ms                                                                                                                                               
                                                                                                                                                                                                                 
  ## Validation                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  - swipl -q -t run_tests tests/core/test_csharp_query_target.pl                                                                                                                                                 
  - python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py                                                                                                                                  
  - git diff --check                                                                                                                                                                                             
  - python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3                                                                                                                