### PR TITLE
perf(csharp-query): Split the counted path `All` hot loop in the C# query runtime

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -158,17 +158,18 @@ Counted-closure phase split after typed row buffering, pre-sized
 materialization, edge-state node-id preindexing, node-id keyed retained-min
 tracking/flush, concrete-array `nodeValues` replay on the counted-path
 materialization path, cached boxed depth reuse for counted-path row
-construction, per-row timing removal, a compact `(target, depth)` buffered row
-shape, O(1) parent-linked visited-path extension, a dedicated counted-path
-traversal frame stack, and direct-write seed-batch materialization with a
-packed target/depth row buffer and node-id driven traversal/replay:
+construction, split `All` versus retained-min successor loops in the counted
+path hot traversal, per-row timing removal, a compact `(target, depth)`
+buffered row shape, O(1) parent-linked visited-path extension, a dedicated
+counted-path traversal frame stack, and direct-write seed-batch materialization
+with a packed target/depth row buffer and node-id driven traversal/replay:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 105.838ms | 0.000ms | 47.047ms | n/a |
-| 300 | Min | 29.808ms | 0.000ms | 11.718ms | 4.819ms |
-| 1k | All | 50.357ms | 0.000ms | 34.107ms | n/a |
-| 1k | Min | 11.941ms | 0.000ms | 0.980ms | 1.827ms |
+| 300 | All | 102.950ms | 0.000ms | 47.579ms | n/a |
+| 300 | Min | 33.300ms | 0.000ms | 14.862ms | 5.522ms |
+| 1k | All | 50.315ms | 0.000ms | 39.439ms | n/a |
+| 1k | Min | 12.421ms | 0.000ms | 1.026ms | 1.875ms |
 
 Interpretation:
 
@@ -215,6 +216,9 @@ Interpretation:
 - counted-path row construction now reuses cached boxed depth objects for
   common small path depths, reducing per-row boxing churn on the high-volume
   `All` materialization path
+- counted-path traversal now uses a separate `All` hot-path successor loop so
+  the high-volume `All` case no longer pays retained-min dictionary and mode
+  branching checks on every successor candidate
 - weighted `Min` fallback remains the only measured shape where generic
   frontier candidate indexing is directly relevant
 - the next optimization should not add another generic frontier index by

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -327,17 +327,18 @@ Counted-closure phase split after typed row buffering, pre-sized
 materialization, edge-state node-id preindexing, node-id keyed retained-min
 tracking/flush, concrete-array `nodeValues` replay on the counted-path
 materialization path, cached boxed depth reuse for counted-path row
-construction, per-row timing removal, a compact `(target, depth)` buffered row
-shape, O(1) parent-linked visited-path extension, a dedicated counted-path
-traversal frame stack, and direct-write seed-batch materialization with a
-packed target/depth row buffer and node-id driven traversal/replay:
+construction, split `All` versus retained-min successor loops in the counted
+path hot traversal, per-row timing removal, a compact `(target, depth)`
+buffered row shape, O(1) parent-linked visited-path extension, a dedicated
+counted-path traversal frame stack, and direct-write seed-batch materialization
+with a packed target/depth row buffer and node-id driven traversal/replay:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 105.838ms | 0.000ms | 47.047ms | n/a |
-| 300 | Min | 29.808ms | 0.000ms | 11.718ms | 4.819ms |
-| 1k | All | 50.357ms | 0.000ms | 34.107ms | n/a |
-| 1k | Min | 11.941ms | 0.000ms | 0.980ms | 1.827ms |
+| 300 | All | 102.950ms | 0.000ms | 47.579ms | n/a |
+| 300 | Min | 33.300ms | 0.000ms | 14.862ms | 5.522ms |
+| 1k | All | 50.315ms | 0.000ms | 39.439ms | n/a |
+| 1k | Min | 12.421ms | 0.000ms | 1.026ms | 1.875ms |
 
 Interpretation:
 
@@ -397,6 +398,9 @@ Interpretation:
 - counted-path row construction now reuses cached boxed depth objects for
   common small path depths, reducing per-row boxing churn on the high-volume
   `All` materialization path
+- counted-path traversal now uses a separate `All` hot-path successor loop so
+  the high-volume `All` case no longer pays retained-min dictionary and mode
+  branching checks on every successor candidate
 - the next broad optimization should avoid adding more generic frontier indexes
   until another dominance-heavy fallback shape appears; for counted closure,
   remaining work should target expansion/materialization overhead

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -977,8 +977,9 @@ python examples/benchmark/benchmark_shortest_path_to_root.py \
 Latest local results after edge-state node-id preindexing, node-id keyed
 retained-min tracking/flush, concrete-array `nodeValues` replay on the counted
 path materialization path, cached boxed depth reuse for counted-path row
-construction, per-row timing removal, a compact `(target, depth)` buffered row
-shape, O(1)
+construction, split `All` versus retained-min successor loops in the counted
+path hot traversal, per-row timing removal, a compact `(target, depth)`
+buffered row shape, O(1)
 parent-linked visited-path extension, and a dedicated counted-path traversal
 frame stack with explicit initial capacity, direct-write seed-batch
 materialization into the destination output list, a packed target/depth
@@ -987,17 +988,17 @@ tables:
 
 | Scale | All | Min | Speedup | Output Match | All Output Rows | Min Output Rows | All Successor Candidates | Min Successor Candidates |
 |-------|----:|----:|--------:|--------------|----------------:|----------------:|-------------------------:|-------------------------:|
-| 300 | 0.339s | 0.157s | 2.16x | match | 602,808 | 30,968 | 982,581 | 101,371 |
-| 1k | 0.249s | 0.129s | 1.93x | match | 352,522 | 10,328 | 592,698 | 38,196 |
+| 300 | 0.344s | 0.166s | 2.08x | match | 602,808 | 30,968 | 982,581 | 101,371 |
+| 1k | 0.262s | 0.124s | 2.11x | match | 352,522 | 10,328 | 592,698 | 38,196 |
 
 The same run reports the counted-closure phase split:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 |-------|------|----------:|-------------:|-----------------------:|----------------------:|
-| 300 | All | 105.838ms | 0.000ms | 47.047ms | n/a |
-| 300 | Min | 29.808ms | 0.000ms | 11.718ms | 4.819ms |
-| 1k | All | 50.357ms | 0.000ms | 34.107ms | n/a |
-| 1k | Min | 11.941ms | 0.000ms | 0.980ms | 1.827ms |
+| 300 | All | 102.950ms | 0.000ms | 47.579ms | n/a |
+| 300 | Min | 33.300ms | 0.000ms | 14.862ms | 5.522ms |
+| 1k | All | 50.315ms | 0.000ms | 39.439ms | n/a |
+| 1k | Min | 12.421ms | 0.000ms | 1.026ms | 1.875ms |
 
 Additional path-state observations:
 
@@ -1046,6 +1047,9 @@ Additional path-state observations:
 - counted-path row construction now reuses cached boxed depth objects for
   common small path depths, reducing per-row boxing churn on the high-volume
   `All` materialization path.
+- counted-path traversal now uses a separate `All` hot-path successor loop so
+  the high-volume `All` case no longer pays retained-min dictionary and mode
+  branching checks on every successor candidate.
 - This shape does not exercise the weighted `min_frontier_*` dominance
   candidate problem; generic frontier indexes would not address its primary
   cost. Further counted-closure work should target expansion/materialization

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -12549,28 +12549,59 @@ namespace UnifyWeaver.QueryRuntime
                     continue;
                 }
 
-                for (var i = bucket.Targets.Count - 1; i >= 0; i--)
+                var targetNodeIds = bucket.TargetNodeIds;
+                if (bestKnown is null)
                 {
-                    metrics?.RecordSuccessorCandidate();
-                    var nextId = bucket.TargetNodeIds[i];
-                    if (visited.Contains(nextId))
+                    for (var i = targetNodeIds.Count - 1; i >= 0; i--)
                     {
-                        metrics?.RecordCycleSkip();
-                        continue;
+                        metrics?.RecordSuccessorCandidate();
+                        var nextId = targetNodeIds[i];
+                        if (visited.Contains(nextId))
+                        {
+                            metrics?.RecordCycleSkip();
+                            continue;
+                        }
+
+                        var nextDepth = depth == 0
+                            ? baseDepth
+                            : checked(depth + depthIncrement);
+
+                        if (maxDepth > 0 && nextDepth > maxDepth)
+                        {
+                            metrics?.RecordDepthSkip();
+                            continue;
+                        }
+
+                        RecordBufferedPathAwareDepthRow(bufferedRows!, nextId, nextDepth);
+
+                        var nextVisited = visited.Extend(nextId);
+                        stack.Push(new PathAwareTraversalFrame(nextId, nextDepth, nextVisited));
+                        metrics?.RecordEnqueuedState(nextVisited.Count);
+                        metrics?.RecordStackSize(stack.Count);
                     }
-
-                    var nextDepth = depth == 0
-                        ? baseDepth
-                        : checked(depth + depthIncrement);
-
-                    if (maxDepth > 0 && nextDepth > maxDepth)
+                }
+                else
+                {
+                    for (var i = targetNodeIds.Count - 1; i >= 0; i--)
                     {
-                        metrics?.RecordDepthSkip();
-                        continue;
-                    }
+                        metrics?.RecordSuccessorCandidate();
+                        var nextId = targetNodeIds[i];
+                        if (visited.Contains(nextId))
+                        {
+                            metrics?.RecordCycleSkip();
+                            continue;
+                        }
 
-                    if (bestKnown is not null)
-                    {
+                        var nextDepth = depth == 0
+                            ? baseDepth
+                            : checked(depth + depthIncrement);
+
+                        if (maxDepth > 0 && nextDepth > maxDepth)
+                        {
+                            metrics?.RecordDepthSkip();
+                            continue;
+                        }
+
                         if (bestKnown.TryGetValue(nextId, out var bestDepth))
                         {
                             switch (accumulatorMode)
@@ -12596,16 +12627,12 @@ namespace UnifyWeaver.QueryRuntime
                         }
 
                         bestKnown[nextId] = nextDepth;
-                    }
-                    else
-                    {
-                        RecordBufferedPathAwareDepthRow(bufferedRows!, nextId, nextDepth);
-                    }
 
-                    var nextVisited = visited.Extend(nextId);
-                    stack.Push(new PathAwareTraversalFrame(nextId, nextDepth, nextVisited));
-                    metrics?.RecordEnqueuedState(nextVisited.Count);
-                    metrics?.RecordStackSize(stack.Count);
+                        var nextVisited = visited.Extend(nextId);
+                        stack.Push(new PathAwareTraversalFrame(nextId, nextDepth, nextVisited));
+                        metrics?.RecordEnqueuedState(nextVisited.Count);
+                        metrics?.RecordStackSize(stack.Count);
+                    }
                 }
             }
             metrics?.AddTraversalElapsed(Stopwatch.GetElapsedTime(traversalStarted));


### PR DESCRIPTION
  ## Summary

  - Splits counted-path traversal into separate `All` and retained-min hot paths.
  - Removes retained-min dictionary and mode-branch checks from the high-volume counted-path `All` successor loop.
  - Preserves exact simple-path semantics, output rows, row order, benchmark hashes, and `path_state_*` counters.
  - Updates benchmark/proposal docs with the measured traversal result after the `All` hot-loop split.

  ## Why

  The remaining counted-path `All` cost is still dominated by traversal volume. Previous work reduced materialization and replay overhead, which left the successor-processing loop as a clearer hotspot.

  Before this change, the shared traversal loop still carried retained-min logic even when running in `All` mode. That meant the hottest counted-path `All` path paid extra branching and retained-min lookup
  structure overhead on every successor candidate, even though `All` never uses that machinery.

  This PR specializes the loop so `All` runs through the simpler path directly.

  ## Results

  Local counted shortest-path benchmark:

  ```bash
  python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3
  ```
  | Scale | All | Min | Speedup | Output Match |
  | --- | ---: | ---: | ---: | --- |
  | 300 | 0.344s | 0.166s | 2.08x | match |
  | 1k | 0.262s | 0.124s | 2.11x | match |

  Counted-closure phase split:

  | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
  | --- | --- | ---: | ---: | ---: | ---: |
  | 300 | All | 102.950ms | 0.000ms | 47.579ms | n/a |
  | 300 | Min | 33.300ms | 0.000ms | 14.862ms | 5.522ms |
  | 1k | All | 50.315ms | 0.000ms | 39.439ms | n/a |
  | 1k | Min | 12.421ms | 0.000ms | 1.026ms | 1.875ms |

  Measured All traversal result:

  - 300 All path_state_traversal: 105.838ms -> 102.950ms
  - 1k All path_state_traversal: 50.357ms -> 50.315ms

  ## Validation

  - swipl -q -t run_tests tests/core/test_csharp_query_target.pl
  - python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py
  - git diff --check
  - python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3