### PR TITLE
perf(csharp-query): Trim counted path cycle checks in the C# query runtime

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -166,10 +166,10 @@ with a packed target/depth row buffer and node-id driven traversal/replay:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 300 | All | 102.950ms | 0.000ms | 47.579ms | n/a |
-| 300 | Min | 33.300ms | 0.000ms | 14.862ms | 5.522ms |
-| 1k | All | 50.315ms | 0.000ms | 39.439ms | n/a |
-| 1k | Min | 12.421ms | 0.000ms | 1.026ms | 1.875ms |
+| 300 | All | 95.476ms | 0.000ms | 52.799ms | n/a |
+| 300 | Min | 33.764ms | 0.000ms | 5.895ms | 4.619ms |
+| 1k | All | 62.974ms | 0.000ms | 27.954ms | n/a |
+| 1k | Min | 11.950ms | 0.000ms | 0.925ms | 1.835ms |
 
 Interpretation:
 
@@ -219,6 +219,10 @@ Interpretation:
 - counted-path traversal now uses a separate `All` hot-path successor loop so
   the high-volume `All` case no longer pays retained-min dictionary and mode
   branching checks on every successor candidate
+- counted-path cycle checks on the `All` hot path now reuse precomputed
+  node-id masks and fingerprints from edge-state construction, avoiding
+  repeated per-successor summary derivation while preserving exact
+  cycle-detection behavior
 - weighted `Min` fallback remains the only measured shape where generic
   frontier candidate indexing is directly relevant
 - the next optimization should not add another generic frontier index by

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -995,10 +995,10 @@ The same run reports the counted-closure phase split:
 
 | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
 |-------|------|----------:|-------------:|-----------------------:|----------------------:|
-| 300 | All | 102.950ms | 0.000ms | 47.579ms | n/a |
-| 300 | Min | 33.300ms | 0.000ms | 14.862ms | 5.522ms |
-| 1k | All | 50.315ms | 0.000ms | 39.439ms | n/a |
-| 1k | Min | 12.421ms | 0.000ms | 1.026ms | 1.875ms |
+| 300 | All | 95.476ms | 0.000ms | 52.799ms | n/a |
+| 300 | Min | 33.764ms | 0.000ms | 5.895ms | 4.619ms |
+| 1k | All | 62.974ms | 0.000ms | 27.954ms | n/a |
+| 1k | Min | 11.950ms | 0.000ms | 0.925ms | 1.835ms |
 
 Additional path-state observations:
 
@@ -1050,6 +1050,10 @@ Additional path-state observations:
 - counted-path traversal now uses a separate `All` hot-path successor loop so
   the high-volume `All` case no longer pays retained-min dictionary and mode
   branching checks on every successor candidate.
+- counted-path cycle checks on the `All` hot path now reuse precomputed
+  node-id masks and fingerprints from edge-state construction, keeping the
+  exact cycle test while removing repeated per-successor mask/fingerprint
+  derivation from the hottest successor loop.
 - This shape does not exercise the weighted `min_frontier_*` dominance
   candidate problem; generic frontier indexes would not address its primary
   cost. Further counted-closure work should target expansion/materialization

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1555,13 +1555,19 @@ namespace UnifyWeaver.QueryRuntime
             IReadOnlyList<object?> seeds,
             IReadOnlyList<int> seedNodeIds,
             object?[] nodeValues,
-            IReadOnlyList<PathAwareSuccessorBucket?> bucketsByNodeId)
+            IReadOnlyList<PathAwareSuccessorBucket?> bucketsByNodeId,
+            ulong[] nodeMaskAs,
+            ulong[] nodeMaskBs,
+            ulong[] nodeFingerprints)
         {
             Successors = successors;
             Seeds = seeds;
             SeedNodeIds = seedNodeIds;
             NodeValues = nodeValues;
             BucketsByNodeId = bucketsByNodeId;
+            NodeMaskAs = nodeMaskAs;
+            NodeMaskBs = nodeMaskBs;
+            NodeFingerprints = nodeFingerprints;
         }
 
         public IReadOnlyDictionary<object, PathAwareSuccessorBucket> Successors { get; }
@@ -1573,6 +1579,12 @@ namespace UnifyWeaver.QueryRuntime
         public object?[] NodeValues { get; }
 
         public IReadOnlyList<PathAwareSuccessorBucket?> BucketsByNodeId { get; }
+
+        public ulong[] NodeMaskAs { get; }
+
+        public ulong[] NodeMaskBs { get; }
+
+        public ulong[] NodeFingerprints { get; }
     }
 
     internal sealed class PathAwareSccGraph
@@ -6239,7 +6251,17 @@ namespace UnifyWeaver.QueryRuntime
                 bucketsByNodeId[bucket.SourceNodeId] = bucket;
             }
 
-            return new PathAwareEdgeState(successors, seeds, seedNodeIds, nodeValues, bucketsByNodeId);
+            var nodeMaskAs = new ulong[nodeIds.Count];
+            var nodeMaskBs = new ulong[nodeIds.Count];
+            var nodeFingerprints = new ulong[nodeIds.Count];
+            for (var i = 0; i < nodeIds.Count; i++)
+            {
+                nodeMaskAs[i] = ComputeVisitedMaskA(i);
+                nodeMaskBs[i] = ComputeVisitedMaskB(i);
+                nodeFingerprints[i] = ComputeVisitedFingerprint(i);
+            }
+
+            return new PathAwareEdgeState(successors, seeds, seedNodeIds, nodeValues, bucketsByNodeId, nodeMaskAs, nodeMaskBs, nodeFingerprints);
         }
 
         private static int GetOrAddPathAwareNodeId(
@@ -12416,7 +12438,7 @@ namespace UnifyWeaver.QueryRuntime
                 var traversalMetrics = trace is null ? null : new PathAwareTraversalMetrics();
                 for (var i = 0; i < edgeState.Seeds.Count; i++)
                 {
-                    AppendPathAwareRowsForSeed(edgeState.Seeds[i], edgeState.SeedNodeIds[i], edgeState.NodeValues, edgeState.BucketsByNodeId, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth, traversalMetrics);
+                    AppendPathAwareRowsForSeed(edgeState.Seeds[i], edgeState.SeedNodeIds[i], edgeState.NodeValues, edgeState.BucketsByNodeId, edgeState.NodeMaskAs, edgeState.NodeMaskBs, edgeState.NodeFingerprints, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth, traversalMetrics);
                 }
 
                 if (traversalMetrics is not null)
@@ -12487,7 +12509,7 @@ namespace UnifyWeaver.QueryRuntime
                 var traversalMetrics = trace is null ? null : new PathAwareTraversalMetrics();
                 for (var i = 0; i < seeds.Count; i++)
                 {
-                    AppendPathAwareRowsForSeed(seeds[i], seedNodeIds[i], edgeState.NodeValues, edgeState.BucketsByNodeId, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth, traversalMetrics);
+                    AppendPathAwareRowsForSeed(seeds[i], seedNodeIds[i], edgeState.NodeValues, edgeState.BucketsByNodeId, edgeState.NodeMaskAs, edgeState.NodeMaskBs, edgeState.NodeFingerprints, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth, traversalMetrics);
                 }
 
                 if (traversalMetrics is not null)
@@ -12508,6 +12530,9 @@ namespace UnifyWeaver.QueryRuntime
             int seedNodeId,
             object?[] nodeValues,
             IReadOnlyList<PathAwareSuccessorBucket?> bucketsByNodeId,
+            ulong[] nodeMaskAs,
+            ulong[] nodeMaskBs,
+            ulong[] nodeFingerprints,
             int baseDepth,
             int depthIncrement,
             ICollection<object[]> output,
@@ -12520,7 +12545,7 @@ namespace UnifyWeaver.QueryRuntime
             var bestKnown = preserveAllPaths ? null : new Dictionary<int, int>();
             var bufferedRows = preserveAllPaths ? new PathAwareTargetDepthBuffer() : null;
 
-            var initialPath = CompactVisitedPath.Create(seedNodeId);
+            var initialPath = CompactVisitedPath.Create(seedNodeId, nodeMaskAs[seedNodeId], nodeMaskBs[seedNodeId], nodeFingerprints[seedNodeId]);
             var initialStackCapacity = maxDepth > 0
                 ? Math.Min(Math.Max(maxDepth + 1, 4), 256)
                 : 64;
@@ -12556,7 +12581,7 @@ namespace UnifyWeaver.QueryRuntime
                     {
                         metrics?.RecordSuccessorCandidate();
                         var nextId = targetNodeIds[i];
-                        if (visited.Contains(nextId))
+                        if (visited.Contains(nextId, nodeMaskAs[nextId], nodeMaskBs[nextId]))
                         {
                             metrics?.RecordCycleSkip();
                             continue;
@@ -12574,7 +12599,7 @@ namespace UnifyWeaver.QueryRuntime
 
                         RecordBufferedPathAwareDepthRow(bufferedRows!, nextId, nextDepth);
 
-                        var nextVisited = visited.Extend(nextId);
+                        var nextVisited = visited.Extend(nextId, nodeMaskAs[nextId], nodeMaskBs[nextId], nodeFingerprints[nextId]);
                         stack.Push(new PathAwareTraversalFrame(nextId, nextDepth, nextVisited));
                         metrics?.RecordEnqueuedState(nextVisited.Count);
                         metrics?.RecordStackSize(stack.Count);
@@ -12586,7 +12611,7 @@ namespace UnifyWeaver.QueryRuntime
                     {
                         metrics?.RecordSuccessorCandidate();
                         var nextId = targetNodeIds[i];
-                        if (visited.Contains(nextId))
+                        if (visited.Contains(nextId, nodeMaskAs[nextId], nodeMaskBs[nextId]))
                         {
                             metrics?.RecordCycleSkip();
                             continue;
@@ -12628,7 +12653,7 @@ namespace UnifyWeaver.QueryRuntime
 
                         bestKnown[nextId] = nextDepth;
 
-                        var nextVisited = visited.Extend(nextId);
+                        var nextVisited = visited.Extend(nextId, nodeMaskAs[nextId], nodeMaskBs[nextId], nodeFingerprints[nextId]);
                         stack.Push(new PathAwareTraversalFrame(nextId, nextDepth, nextVisited));
                         metrics?.RecordEnqueuedState(nextVisited.Count);
                         metrics?.RecordStackSize(stack.Count);
@@ -14166,24 +14191,36 @@ namespace UnifyWeaver.QueryRuntime
 
             public static CompactVisitedPath Create(int nodeId)
             {
-                return new CompactVisitedPath(
-                    previous: null,
-                    nodeId: nodeId,
-                    1,
+                return Create(
+                    nodeId,
                     ComputeVisitedMaskA(nodeId),
                     ComputeVisitedMaskB(nodeId),
                     ComputeVisitedFingerprint(nodeId));
             }
 
+            public static CompactVisitedPath Create(int nodeId, ulong maskA, ulong maskB, ulong fingerprint)
+            {
+                return new CompactVisitedPath(
+                    previous: null,
+                    nodeId: nodeId,
+                    1,
+                    maskA,
+                    maskB,
+                    fingerprint);
+            }
+
             public bool Contains(int nodeId)
             {
-                var maskA = ComputeVisitedMaskA(nodeId);
+                return Contains(nodeId, ComputeVisitedMaskA(nodeId), ComputeVisitedMaskB(nodeId));
+            }
+
+            public bool Contains(int nodeId, ulong maskA, ulong maskB)
+            {
                 if ((MaskA & maskA) == 0)
                 {
                     return false;
                 }
 
-                var maskB = ComputeVisitedMaskB(nodeId);
                 if ((MaskB & maskB) == 0)
                 {
                     return false;
@@ -14202,13 +14239,22 @@ namespace UnifyWeaver.QueryRuntime
 
             public CompactVisitedPath Extend(int nodeId)
             {
+                return Extend(
+                    nodeId,
+                    ComputeVisitedMaskA(nodeId),
+                    ComputeVisitedMaskB(nodeId),
+                    ComputeVisitedFingerprint(nodeId));
+            }
+
+            public CompactVisitedPath Extend(int nodeId, ulong maskA, ulong maskB, ulong fingerprint)
+            {
                 return new CompactVisitedPath(
                     this,
                     nodeId,
                     Count + 1,
-                    MaskA | ComputeVisitedMaskA(nodeId),
-                    MaskB | ComputeVisitedMaskB(nodeId),
-                    Fingerprint ^ ComputeVisitedFingerprint(nodeId));
+                    MaskA | maskA,
+                    MaskB | maskB,
+                    Fingerprint ^ fingerprint);
             }
 
             public bool IsSubsetOf(CompactVisitedPath other)


### PR DESCRIPTION
  ## Summary

  - Reuses precomputed node-id masks and fingerprints from edge-state construction on the counted-path `All` hot path.
  - Removes repeated per-successor cycle-check summary derivation from the hottest counted-path traversal loop.
  - Keeps exact simple-path cycle semantics, output rows, row order, benchmark hashes, and existing `path_state_*` counters intact.
  - Preserves compatibility overloads on `CompactVisitedPath` for colder callers that do not run on the counted-path `All` hot loop.
  - Updates the counted-path benchmark notes with the latest measured phase split and the cycle-check trim.

  ## Why

  The remaining counted-path `All` cost is still dominated by raw traversal work. Earlier changes already reduced replay, row construction, and hot-loop branching overhead, which left cycle checking as another
  repeated per-successor cost in the tight traversal path.

  Before this change, the counted-path `All` loop still recomputed visited-state summary inputs for every successor candidate when probing `CompactVisitedPath`. The edge state already had stable integer node
  ids, so this PR moves the mask and fingerprint reuse to that same precomputed layer and feeds those values directly into the hot cycle-check calls.

  This keeps the exact cycle test, but removes repeated summary derivation from the highest-volume successor loop.

  ## Results

  Local counted shortest-path benchmark:

  ```bash
  python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3
  ```
  | Scale | All | Min | Speedup | Output Match |
  | --- | ---: | ---: | ---: | --- |
  | 300 | 0.340s | 0.152s | 2.23x | match |
  | 1k | 0.254s | 0.127s | 2.00x | match |

  Counted-closure phase split:

  | Scale | Mode | Traversal | Row Creation | Result Materialization | Best-Known Flush/Sort |
  | --- | --- | ---: | ---: | ---: | ---: |
  | 300 | All | 95.476ms | 0.000ms | 52.799ms | n/a |
  | 300 | Min | 33.764ms | 0.000ms | 5.895ms | 4.619ms |
  | 1k | All | 62.974ms | 0.000ms | 27.954ms | n/a |
  | 1k | Min | 11.950ms | 0.000ms | 0.925ms | 1.835ms |

  Measured effect:

  - 300 All path_state_traversal: 102.950ms -> 95.476ms
  - 1k All total median: 0.262s -> 0.254s

  ## Validation

  - swipl -q -t run_tests tests/core/test_csharp_query_target.pl
  - python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py
  - git diff --check
  - python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3