### PR TITLE
perf(csharp-query): Skip disjoint depth-pruned buckets in the C# query runtime

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1546,6 +1546,10 @@ namespace UnifyWeaver.QueryRuntime
         public List<object?> Targets { get; } = new();
 
         public List<int> TargetNodeIds { get; } = new();
+
+        public ulong TargetMaskA { get; set; }
+
+        public ulong TargetMaskB { get; set; }
     }
 
     internal sealed class PathAwareEdgeState
@@ -6259,6 +6263,22 @@ namespace UnifyWeaver.QueryRuntime
                 nodeMaskAs[i] = ComputeVisitedMaskA(i);
                 nodeMaskBs[i] = ComputeVisitedMaskB(i);
                 nodeFingerprints[i] = ComputeVisitedFingerprint(i);
+            }
+
+            foreach (var bucket in successors.Values)
+            {
+                ulong targetMaskA = 0;
+                ulong targetMaskB = 0;
+                var targetNodeIds = bucket.TargetNodeIds;
+                for (var i = 0; i < targetNodeIds.Count; i++)
+                {
+                    var targetNodeId = targetNodeIds[i];
+                    targetMaskA |= nodeMaskAs[targetNodeId];
+                    targetMaskB |= nodeMaskBs[targetNodeId];
+                }
+
+                bucket.TargetMaskA = targetMaskA;
+                bucket.TargetMaskB = targetMaskB;
             }
 
             return new PathAwareEdgeState(successors, seeds, seedNodeIds, nodeValues, bucketsByNodeId, nodeMaskAs, nodeMaskBs, nodeFingerprints);
@@ -12575,6 +12595,28 @@ namespace UnifyWeaver.QueryRuntime
                 }
 
                 var targetNodeIds = bucket.TargetNodeIds;
+                var bulkDepthSkipCandidateCount = 0;
+                if (depth != 0)
+                {
+                    var nextDepth = checked(depth + depthIncrement);
+                    // If this bucket cannot intersect the current visited set,
+                    // every successor would fail only on depth, so we can skip
+                    // per-successor cycle probes while preserving counters.
+                    if (maxDepth > 0 &&
+                        nextDepth > maxDepth &&
+                        (((visited.MaskA & bucket.TargetMaskA) == 0) || ((visited.MaskB & bucket.TargetMaskB) == 0)))
+                    {
+                        bulkDepthSkipCandidateCount = targetNodeIds.Count;
+                    }
+                }
+
+                if (bulkDepthSkipCandidateCount > 0)
+                {
+                    metrics?.AddSuccessorCandidates(bulkDepthSkipCandidateCount);
+                    metrics?.AddDepthSkips(bulkDepthSkipCandidateCount);
+                    continue;
+                }
+
                 if (bestKnown is null)
                 {
                     for (var i = targetNodeIds.Count - 1; i >= 0; i--)
@@ -14094,9 +14136,13 @@ namespace UnifyWeaver.QueryRuntime
 
             public void RecordSuccessorCandidate() => SuccessorCandidateCount++;
 
+            public void AddSuccessorCandidates(int count) => SuccessorCandidateCount += count;
+
             public void RecordCycleSkip() => CycleSkipCount++;
 
             public void RecordDepthSkip() => DepthSkipCount++;
+
+            public void AddDepthSkips(int count) => DepthSkipCount += count;
 
             public void RecordBestKnownPrune() => BestKnownPruneCount++;
 


### PR DESCRIPTION
  ## Summary

  - Adds per-bucket target mask summaries to counted-path edge state.
  - Lets counted-path traversal bulk-handle frames whose next hop is already beyond `maxDepth` and whose successor bucket is provably disjoint from the current visited-set summaries.
  - Avoids per-successor cycle probes in that depth-pruned case while preserving exact simple-path semantics and the existing `path_state_*` counters.
  - Keeps output rows, row order, and benchmark hashes unchanged.

  ## Why

  The remaining counted-path `All` cost is still dominated by traversal, and a large fraction of that work is depth-limit churn. Earlier work already trimmed cycle-check summary derivation and other hot-loop
  overhead, but the runtime still walked every successor candidate even when a whole bucket was guaranteed to fail only on depth.

  This PR adds a narrower structural optimization: if the next step is already over `maxDepth`, and the current visited-set summaries cannot overlap any node in the successor bucket, then no child can be
  rejected for a cycle first. In that case the runtime can account for the same successor and depth-skip totals in aggregate and skip the per-successor `Contains` work.

  That keeps the current cycle-vs-depth accounting contract intact in overlapping buckets, while trimming obviously depth-only churn.

  ## Results

  Local counted shortest-path benchmark:

  ```bash
  python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 5
  ```
  | Scale | All | Min | Speedup | Output Match |
  | --- | ---: | ---: | ---: | --- |
  | 300 | 0.358s | 0.155s | 2.30x | match |
  | 1k | 0.252s | 0.128s | 1.97x | match |

  Targeted traversal effect:

  - 300 All path_state_traversal: 99.479ms -> 90.543ms
  - 1k All path_state_traversal: 58.551ms -> 54.489ms

  Representative phase split after the change:

  | Scale | Mode | Traversal | Result Materialization |
  | --- | --- | ---: | ---: |
  | 300 | All | 90.543ms | 70.436ms |
  | 300 | Min | 28.797ms | 6.019ms |
  | 1k | All | 54.489ms | 32.364ms |
  | 1k | Min | 12.257ms | 1.004ms |

  ## Validation

  - swipl -q -t run_tests tests/core/test_csharp_query_target.pl
  - python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py
  - git diff --check
  - python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 5