### PR TITLE
test(go-wam-builtins): ensure `tmp_wam_builtins_*` is always cleaned up

### DIFF
--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -8,25 +8,30 @@
 test(builtins_execution) :-
     get_time(T),
     format(atom(TmpDir), 'tmp_wam_builtins_~w', [T]),
-    % Define a predicate that uses builtins
-    assertz(user:test_builtins(X) :- (X is 1 + 2, X < 5, X =:= 3, atom(foo), \+ atom(5))),
-    
+    setup_call_cleanup(
+        assertz(user:test_builtins(X) :- (X is 1 + 2, X < 5, X =:= 3, atom(foo), \+ atom(5))),
+        run_builtins_test(TmpDir),
+        ( retractall(user:test_builtins(_)),
+          delete_directory_and_contents(TmpDir) )
+    ).
+
+run_builtins_test(TmpDir) :-
     Predicates = [test_builtins/1],
     Options = [module_name(builtin_test)],
-    
+
     write_wam_go_project(Predicates, Options, TmpDir),
-    
+
     % Verify generated code has our fixes
     directory_file_path(TmpDir, 'value.go', ValuePath),
     read_file_to_string(ValuePath, ValueCode, []),
     assertion(sub_string(ValueCode, _, _, _, "type Structure struct")),
-    
+
     % Add a main.go to run the test in a separate cmd directory
     directory_file_path(TmpDir, 'cmd', CmdDir),
     directory_file_path(CmdDir, 'test', TestDir),
     make_directory_path(TestDir),
     directory_file_path(TestDir, 'main.go', MainPath),
-    write_file(MainPath, 
+    write_file(MainPath,
 'package main
 
 import (
@@ -48,7 +53,7 @@ func main() {
 	}
 }
 '),
-    
+
     % Update go.mod to include local replace for the module
     directory_file_path(TmpDir, 'go.mod', GoModPath),
     read_file_to_string(GoModPath, GoModOld, []),
@@ -65,9 +70,7 @@ func main() {
         assertion(Exit == exit(0)),
         assertion(sub_string(FullOutput, _, _, _, "SUCCESS: X=3"))
     ;   format("Go not found, skipping execution test.~n")
-    ),
-    
-    retractall(user:test_builtins(_)).
+    ).
 
 :- end_tests(go_wam_builtins).
 


### PR DESCRIPTION
`tests/test_go_wam_builtins.pl` creates a timestamped
`tmp_wam_builtins_<T>` directory at the repo root and only cleans it up
on the happy path. Any failing assertion or thrown exception along the
way left the dir behind. `delete_directory_and_contents/1` was already
defined in the file but never called.

Two such strays were observed locally during recent work, e.g.
`tmp_wam_builtins_1776365427.3883183/`.

## Fix

Wrap the test body in `setup_call_cleanup/3`:

- **Setup**: `assertz` the synthetic test predicate
- **Call**: `run_builtins_test/1` (extracted from the inlined body —
  no behavior change)
- **Cleanup**: `retractall` the predicate AND
  `delete_directory_and_contents/1`

Cleanup now runs unconditionally — on test pass, test failure,
assertion failure, thrown exception, AND when the optional
Go-execution branch is skipped (`go` binary not available).

## Out of scope

A pre-existing `Test succeeded with choicepoint` warning is emitted
during this test's run. Verified (by running the unmodified test from
main) that this warning predates this change and is unrelated to
cleanup hygiene. Leaving it for a separate follow-up.

---
*Co-authored-By: Claude Opus 4.7 (1M context)*
