### PR TITLE
fix(wam-elixir): dedup switch_on_constant case arms (unreachable-clause warnings)

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -14,6 +14,7 @@
 
 :- use_module(library(lists)).
 :- use_module(library(option)).
+:- use_module(library(pairs), [group_pairs_by_key/2]).
 :- use_module('wam_elixir_utils', [reg_id/2, is_label_part/1, camel_case/2, parse_arity/2]).
 
 % ============================================================================
@@ -136,19 +137,29 @@ split_last_colon(Entry, Key, Label) :-
     ).
 
 %% build_switch_arms(+Entries, -ArmsStr)
-%  Builds inline Elixir case arms for switch_on_constant.
-%  "default" labels fall through (:ok); real labels call the local segment
-%  function directly (local labels, not WamDispatcher predicates).
+%  Builds inline Elixir case arms for switch_on_constant. Groups entries by
+%  key first, because the WAM emitter may produce multiple entries for the
+%  same first-arg constant (when multiple clauses share a first arg) — and
+%  Elixir would then warn that later case-arms are unreachable.
+%
+%  For a key with a single non-"default" entry: dispatch directly to the
+%  labeled clause (the switch's whole reason for existing — skip the
+%  try_me_else chain). For any key with multiple entries OR a single
+%  "default" entry: fall through to :ok, letting the surrounding
+%  try_me_else / retry_me_else chain handle the choice non-deterministically.
 build_switch_arms(Entries, ArmsStr) :-
-    maplist(build_switch_arm, Entries, Arms),
+    maplist([E,K-L]>>split_last_colon(E, K, L), Entries, Pairs),
+    keysort(Pairs, SortedPairs),
+    group_pairs_by_key(SortedPairs, Groups),
+    maplist(build_switch_arm_group, Groups, Arms),
     atomic_list_concat(Arms, '\n          ', ArmsStr).
 
-build_switch_arm(Entry, Arm) :-
-    split_last_colon(Entry, Key, Label),
-    (   Label == "default"
-    ->  format(string(Arm), '"~w" -> :ok', [Key])
-    ;   segment_func_name(Label, LocalFunc),
+build_switch_arm_group(Key-Labels, Arm) :-
+    (   Labels = [OnlyLabel],
+        OnlyLabel \== "default"
+    ->  segment_func_name(OnlyLabel, LocalFunc),
         format(string(Arm), '"~w" -> throw({:return, ~w(state)})', [Key, LocalFunc])
+    ;   format(string(Arm), '"~w" -> :ok', [Key])
     ).
 
 segment_func_name("clause_start", "clause_main") :- !.


### PR DESCRIPTION
Discovered while attempting to benchmark the Phase A+B+C Elixir runtime.
The benchmark harness compiled the generated Elixir cleanly on the toy
test predicates but emitted ~20 duplicate-clause warnings on the
`article_category` predicate in the `effective_distance` workload.

## Bug

The WAM emitter produces `switch_on_constant` entries in clause order,
so a predicate like:

```prolog
article_category("Special_relativity", "Physics").
article_category("Special_relativity", "Modern_physics").
article_category("Bose-Einstein_statistics", "Physics").
% ... many more
```

generates WAM entries:

```
switch_on_constant "Special_relativity":default,
                   "Special_relativity":L_article_category_2_2,
                   "Bose-Einstein_statistics":L_article_category_2_3,
                   ...
```

Two entries share the key `"Special_relativity"`. My earlier inlining
fix (PR #1433) emitted one Elixir case-arm per entry:

```elixir
case val do
  "Special_relativity" -> :ok                               # from default entry
  "Special_relativity" -> throw({:return, clause_L...225(state)})  # unreachable
  ...
end
```

The second arm can never match — Elixir emits a warning and silently
drops it. Worse, the semantic was also wrong: we should fall through
to the `try_me_else` / `retry_me_else` chain so backtracking finds all
matching clauses, not dispatch to one of them arbitrarily.

## Fix

Group entries by key first (keysort + `library(pairs)`'s
`group_pairs_by_key/2`). Then for each unique key:

- **Exactly one non-`"default"` entry** → dispatch directly to the
  labeled local clause (this is the optimization the switch exists for:
  skip the try chain for deterministic matches)
- **Multiple entries, OR a single `"default"` entry** → fall through to
  `:ok`, letting the surrounding `try_me_else` / `retry_me_else` chain
  handle the choice non-deterministically

This matches standard WAM semantics for indexed dispatch with
collisions: the switch is a hint, not a mandate — when the hint isn't
selective, fall back to the choice-point chain.

## Verification

- `tests/test_wam_elixir_target.pl` — 14/14 pass
- `tests/test_wam_elixir_utils.pl` — 7/7 pass
- Generated `article_category.ex` from the effective_distance benchmark
  now compiles with **zero** "previous clause matches the same pattern"
  warnings (was ~20 before the fix)

## Context: this branch is not a benchmark-numbers PR

This was scoped to deliver benchmark numbers for Phase A+B+C. That
work turned up two **pre-existing** correctness issues in the Elixir
target that block meaningful benchmarking:

1. **`!/0` (cut) is not implemented** in `execute_builtin`. Every
   predicate that uses cut — including `category_ancestor/4`'s
   recursive clause — fails at the cut call. Effect on the benchmark:
   only base-case matches fire, and the harness reports just 2
   "article is in root" rows instead of the reference's 19.
2. **Register namespace collision**: `reg_id("A1")` and `reg_id("X1")`
   both map to integer id 1. The WAM compiler emits `get_variable X3, A1`
   *while* `A3` is still live; the store clobbers `A3` before
   `get_constant 1, A3` runs. Unrelated to whether cut is implemented.

Neither is introduced by Phase A/B/C, and neither is in scope for a
"fix a codegen warning" PR. Flagged in
`docs/design/WAM_ELIXIR_CORRECTNESS_GAPS.md` (follow-up PR).

Performance benchmarking blocked until correctness lands.

---
*Co-authored-By: Claude Opus 4.7 (1M context)*
