### PR TITLE
feat(wam-go): harden runtime and benchmark matrix

### DIFF
--- a/docs/design/BENCHMARK_TARGET_MATRIX.md
+++ b/docs/design/BENCHMARK_TARGET_MATRIX.md
@@ -60,9 +60,24 @@ So Rust already has both:
 
 ### Go
 
-The current effective-distance benchmark surface for Go is the direct pipeline path from `generate_pipeline.py`.
+Go now has two effective-distance benchmark paths.
 
-That is useful for comparison, but it is not yet the same kind of optimized-Prolog-to-hybrid-WAM benchmark path that exists for Haskell and WAM Rust.
+Direct pipeline path:
+
+1. `generate_pipeline.py`
+2. Emit a direct Go executable
+
+Hybrid WAM Go path:
+
+1. Load the workload Prolog and benchmark facts.
+2. Run `prolog_target` optimization passes.
+3. Force the selected predicates through the shared Go WAM path.
+4. Emit a Go benchmark driver that queries the compiled VM directly.
+
+That means Go can now participate in:
+
+- `direct-pipeline`
+- `hybrid-wam`
 
 ### C#
 
@@ -81,6 +96,7 @@ The new matrix script uses these categories:
 
 The default presets are:
 
+- `termux-smoke`
 - `portable-default`
 - `desktop-default`
 - `optimized-prolog`
@@ -91,15 +107,24 @@ The default presets are:
 
 ## Termux Rule
 
-On Termux, the default set excludes C#.
+On Termux, the default local mode is intentionally smaller:
+
+- default target set: `termux-smoke`
+- default scales: `dev,10x`
 
 Reason:
 
+- larger effective-distance runs can destabilize the Termux session
 - running C# through `proot` Debian adds an environment penalty
 - that penalty is not part of the query engine itself
 - including it in default local comparisons would bias the numbers
 
-C# stays available in the harness as an explicit opt-in target for environments where it can run natively.
+So:
+
+- C# stays available as an explicit opt-in target for native desktop environments
+- larger benchmark scales should be run outside Termux
+- Termux should be treated as a smoke-test environment for benchmark correctness, not the primary profiling environment
+- the matrix script rejects larger Termux scales unless `--allow-large-termux-scales` is passed explicitly
 
 ## Scripts
 
@@ -107,6 +132,7 @@ New scripts:
 
 - `examples/benchmark/benchmark_effective_distance_matrix.py`
 - `examples/benchmark/generate_wam_haskell_matrix_benchmark.pl`
+- `examples/benchmark/generate_wam_go_effective_distance_benchmark.pl`
 
 Examples:
 

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import statistics
 import sys
 import tempfile
@@ -39,6 +40,7 @@ from benchmark_common import (
     digest_normalized_output,
     find_result,
     group_results_by_scale,
+    is_termux_environment,
     normalize_three_column_float_rows,
     print_match_status,
     print_result_table,
@@ -61,8 +63,13 @@ GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
 PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_effective_distance_benchmark.pl"
 WAM_RUST_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_effective_distance_benchmark.pl"
 WAM_HASKELL_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_haskell_matrix_benchmark.pl"
+WAM_GO_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_go_effective_distance_benchmark.pl"
 DEFAULT_FACTS = BENCH_DIR / "10k" / "facts.pl"
 HASKELL_EXE = "wam-haskell-matrix-bench"
+
+
+def default_scales_csv() -> str:
+    return "dev,10x" if is_termux_environment() else "300,1k,5k,10k"
 
 
 @dataclass
@@ -81,7 +88,7 @@ class RunResult:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--scales", default="300,1k,5k,10k")
+    parser.add_argument("--scales", default=default_scales_csv())
     parser.add_argument(
         "--target-sets",
         default="",
@@ -98,7 +105,25 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--keep-temp", action="store_true")
     parser.add_argument("--list-targets", action="store_true")
+    parser.add_argument(
+        "--allow-large-termux-scales",
+        action="store_true",
+        help="Allow scales beyond the Termux-safe smoke set (dev,10x).",
+    )
     return parser.parse_args()
+
+
+def validate_termux_scales(scales: list[str], allow_large: bool) -> None:
+    if not is_termux_environment() or allow_large:
+        return
+    safe_scales = {"dev", "10x"}
+    large_scales = [scale for scale in scales if scale not in safe_scales]
+    if large_scales:
+        joined = ",".join(large_scales)
+        raise ValueError(
+            f"large scales are disabled on Termux by default: {joined}. "
+            "Use --allow-large-termux-scales to override."
+        )
 
 
 def benchmark_temp_parent() -> Path:
@@ -188,6 +213,267 @@ def build_wam_rust_effective_distance(root: Path, scale: str, variant: str) -> l
     binary = project_dir / "target" / "release" / "hybrid_ed_bench"
     scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
     return [str(binary), str(scale_dir)]
+
+
+def build_wam_go_effective_distance(root: Path, scale: str, kernel_mode: str) -> list[str]:
+    facts_path = require_file(BENCH_DIR / scale / "facts.pl")
+    project_dir = root / f"wam_go_{kernel_mode}" / scale
+    project_dir.mkdir(parents=True, exist_ok=True)
+    variant = "accumulated"
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(WAM_GO_GENERATOR),
+            "--",
+            str(facts_path),
+            str(project_dir),
+            variant,
+            kernel_mode,
+        ],
+        cwd=ROOT,
+    )
+    go_cache = project_dir / ".gocache"
+    go_cache.mkdir(exist_ok=True)
+    env = dict(os.environ, GOCACHE=str(go_cache))
+    run_command(["go", "build", "-o", str(project_dir / "hybrid_ed_bench_go")], cwd=project_dir, env=env)
+    return [str(project_dir / "hybrid_ed_bench_go")]
+
+
+def parse_effective_distance_facts(facts_path: Path) -> tuple[list[tuple[str, str]], list[str]]:
+    article_categories: list[tuple[str, str]] = []
+    roots: list[str] = []
+    article_re = re.compile(r"^article_category\('((?:\\.|[^'])*)', '((?:\\.|[^'])*)'\)\.$")
+    root_re = re.compile(r"^root_category\('((?:\\.|[^'])*)'\)\.$")
+    with facts_path.open(encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line:
+                continue
+            article_match = article_re.match(line)
+            if article_match:
+                article_categories.append(
+                    (unescape_prolog_atom(article_match.group(1)), unescape_prolog_atom(article_match.group(2)))
+                )
+                continue
+            root_match = root_re.match(line)
+            if root_match:
+                roots.append(unescape_prolog_atom(root_match.group(1)))
+    article_categories = sorted(set(article_categories))
+    roots = sorted(set(roots))
+    return article_categories, roots
+
+
+def unescape_prolog_atom(value: str) -> str:
+    return value.replace("\\'", "'").replace("\\\\", "\\")
+
+
+def go_string_literal(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\t", "\\t")
+    return f'"{escaped}"'
+
+
+def extract_shared_wam_label(project_dir: Path, label: str) -> int:
+    lib_path = require_file(project_dir / "lib.go")
+    pattern = re.compile(rf'"{re.escape(label)}":\s*(\d+),')
+    content = lib_path.read_text(encoding="utf-8")
+    match = pattern.search(content)
+    if not match:
+        raise RuntimeError(f"could not find sharedWam label {label!r} in {lib_path}")
+    return int(match.group(1))
+
+
+def write_go_effective_distance_main(project_dir: Path, facts_path: Path) -> None:
+    article_categories, roots = parse_effective_distance_facts(facts_path)
+    category_ancestor_pc = extract_shared_wam_label(project_dir, "category_ancestor/4")
+    article_rows = "\n".join(
+        f"    {{Article: {go_string_literal(article)}, Category: {go_string_literal(category)}}},"
+        for article, category in article_categories
+    )
+    roots_literal = ", ".join(go_string_literal(root) for root in roots)
+    main_code = f"""package main
+
+import (
+    "fmt"
+    "math"
+    "os"
+    "sort"
+    "time"
+)
+
+const (
+    categoryAncestorStartPC = {category_ancestor_pc}
+    dimensionN = 5.0
+    inverseDimensionN = -1.0 / dimensionN
+)
+
+type articleCategoryPair struct {{
+    Article string
+    Category string
+}}
+
+type resultRow struct {{
+    Article string
+    Root string
+    Distance float64
+}}
+
+var benchmarkArticleCategories = []articleCategoryPair{{
+{article_rows}
+}}
+
+var benchmarkRoots = []string{{{roots_literal}}}
+
+func newBenchmarkVM(startPC int, args ...Value) *WamState {{
+    vm := NewWamState(sharedWamCode, sharedWamLabels)
+    setupSharedForeignPredicates(vm)
+    vm.PC = startPC
+    for i, arg := range args {{
+        vm.Regs[fmt.Sprintf("A%d", i+1)] = arg
+    }}
+    return vm
+}}
+
+func collectSolutions(startPC int, args ...Value) [][]Value {{
+    vm := newBenchmarkVM(startPC, args...)
+    solutions := make([][]Value, 0)
+    if !vm.Run() {{
+        return solutions
+    }}
+    solutions = append(solutions, append([]Value(nil), vm.CollectResults()...))
+    for vm.backtrack() {{
+        if !vm.Run() {{
+            break
+        }}
+        solutions = append(solutions, append([]Value(nil), vm.CollectResults()...))
+    }}
+    return solutions
+}}
+
+func atomName(v Value) string {{
+    if a, ok := v.(*Atom); ok {{
+        return a.Name
+    }}
+    if v == nil {{
+        return ""
+    }}
+    return v.String()
+}}
+
+func floatValue(v Value) (float64, bool) {{
+    switch t := v.(type) {{
+    case *Float:
+        return t.Val, true
+    case *Integer:
+        return float64(t.Val), true
+    default:
+        return 0, false
+    }}
+}}
+
+func hopsForCategoryRoot(category string, root string) []int {{
+    rows := collectSolutions(
+        categoryAncestorStartPC,
+        &Atom{{Name: category}},
+        &Atom{{Name: root}},
+        &Unbound{{Name: "hops"}},
+        &List{{Elements: []Value{{&Atom{{Name: category}}}}}},
+    )
+    hops := make([]int, 0, len(rows))
+    for _, row := range rows {{
+        if len(row) < 3 {{
+            continue
+        }}
+        switch t := row[2].(type) {{
+        case *Integer:
+            hops = append(hops, int(t.Val))
+        case *Float:
+            hops = append(hops, int(t.Val))
+        }}
+    }}
+    return hops
+}}
+
+func main() {{
+    started := time.Now()
+    articleCats := append([]articleCategoryPair(nil), benchmarkArticleCategories...)
+    roots := append([]string(nil), benchmarkRoots...)
+    loadMs := time.Since(started).Milliseconds()
+    if len(roots) == 0 {{
+        fmt.Fprintln(os.Stderr, "no root categories")
+        os.Exit(1)
+    }}
+
+    queryStart := time.Now()
+    articleToCategories := make(map[string][]string)
+    for _, pair := range articleCats {{
+        articleToCategories[pair.Article] = append(articleToCategories[pair.Article], pair.Category)
+    }}
+    articles := make([]string, 0, len(articleToCategories))
+    for article := range articleToCategories {{
+        articles = append(articles, article)
+    }}
+    sort.Strings(articles)
+    rows := make([]resultRow, 0)
+    rootCount := 0
+    tupleCount := 0
+    for _, root := range roots {{
+        rootCount++
+        for _, article := range articles {{
+            weightSum := 0.0
+            for _, category := range articleToCategories[article] {{
+                if category == root {{
+                    weightSum += 1.0
+                    continue
+                }}
+                hops := hopsForCategoryRoot(category, root)
+                tupleCount += len(hops)
+                for _, hop := range hops {{
+                    weightSum += math.Pow(float64(hop+1), -dimensionN)
+                }}
+            }}
+            if weightSum <= 0 {{
+                continue
+            }}
+            rows = append(rows, resultRow{{
+                Article: article,
+                Root: root,
+                Distance: math.Pow(weightSum, inverseDimensionN),
+            }})
+        }}
+    }}
+    queryMs := time.Since(queryStart).Milliseconds()
+
+    aggregationStart := time.Now()
+    sort.Slice(rows, func(i, j int) bool {{
+        if rows[i].Distance != rows[j].Distance {{
+            return rows[i].Distance < rows[j].Distance
+        }}
+        if rows[i].Root != rows[j].Root {{
+            return rows[i].Root < rows[j].Root
+        }}
+        return rows[i].Article < rows[j].Article
+    }})
+    aggregationMs := time.Since(aggregationStart).Milliseconds()
+    totalMs := time.Since(started).Milliseconds()
+
+    fmt.Println("article\\troot_category\\teffective_distance")
+    for _, row := range rows {{
+        fmt.Printf("%s\\t%s\\t%.6f\\n", row.Article, row.Root, row.Distance)
+    }}
+
+    fmt.Fprintf(os.Stderr, "mode=accumulated_go_wam\\n")
+    fmt.Fprintf(os.Stderr, "load_ms=%d\\n", loadMs)
+    fmt.Fprintf(os.Stderr, "query_ms=%d\\n", queryMs)
+    fmt.Fprintf(os.Stderr, "aggregation_ms=%d\\n", aggregationMs)
+    fmt.Fprintf(os.Stderr, "total_ms=%d\\n", totalMs)
+    fmt.Fprintf(os.Stderr, "root_count=%d\\n", rootCount)
+    fmt.Fprintf(os.Stderr, "tuple_count=%d\\n", tupleCount)
+    fmt.Fprintf(os.Stderr, "article_count=%d\\n", len(rows))
+}}
+"""
+    (project_dir / "main.go").write_text(main_code, encoding="utf-8")
 
 
 def build_haskell_effective_distance(root: Path, mode: str, kernel_mode: str) -> list[str]:
@@ -307,6 +593,7 @@ def main() -> int:
         return 0
 
     scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    validate_termux_scales(scales, args.allow_large_termux_scales)
     targets = resolve_requested_targets(args)
     if not targets:
         print("no benchmark targets available", file=sys.stderr)
@@ -333,6 +620,10 @@ def main() -> int:
                     command = build_wam_rust_effective_distance(temp_root, scale, "seeded")
                 elif target == "wam-rust-accumulated":
                     command = build_wam_rust_effective_distance(temp_root, scale, "accumulated")
+                elif target == "go-wam-accumulated":
+                    command = build_wam_go_effective_distance(temp_root, scale, "kernels_on")
+                elif target == "go-wam-accumulated-no-kernels":
+                    command = build_wam_go_effective_distance(temp_root, scale, "kernels_off")
                 else:
                     command = commands[target]
                 results.append(benchmark_target(command, scale, args.repetitions, target))

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -54,6 +54,16 @@ TARGETS: dict[str, TargetInfo] = {
         "hybrid-wam",
         "Hybrid WAM Rust benchmark with optimized accumulated helpers",
     ),
+    "go-wam-accumulated": TargetInfo(
+        "go-wam-accumulated",
+        "hybrid-wam",
+        "Hybrid WAM Go benchmark with optimized accumulated helpers and kernels enabled",
+    ),
+    "go-wam-accumulated-no-kernels": TargetInfo(
+        "go-wam-accumulated-no-kernels",
+        "hybrid-wam",
+        "Hybrid WAM Go benchmark with optimized accumulated helpers and no_kernels(true)",
+    ),
     "haskell-pure-interp": TargetInfo(
         "haskell-pure-interp",
         "hybrid-wam",
@@ -78,6 +88,11 @@ TARGETS: dict[str, TargetInfo] = {
 
 
 TARGET_SETS: dict[str, list[str]] = {
+    "termux-smoke": [
+        "prolog-accumulated",
+        "go-wam-accumulated-no-kernels",
+        "go-dfs",
+    ],
     "optimized-prolog": [
         "prolog-seeded",
         "prolog-accumulated",
@@ -87,6 +102,8 @@ TARGET_SETS: dict[str, list[str]] = {
     "hybrid-wam": [
         "wam-rust-seeded",
         "wam-rust-accumulated",
+        "go-wam-accumulated",
+        "go-wam-accumulated-no-kernels",
         "haskell-pure-interp",
         "haskell-interp-ffi",
         "haskell-lowered-only",
@@ -103,6 +120,7 @@ TARGET_SETS: dict[str, list[str]] = {
     "portable-default": [
         "prolog-accumulated",
         "wam-rust-accumulated",
+        "go-wam-accumulated",
         "haskell-lowered-ffi",
         "rust-dfs",
         "go-dfs",
@@ -110,6 +128,7 @@ TARGET_SETS: dict[str, list[str]] = {
     "desktop-default": [
         "prolog-accumulated",
         "wam-rust-accumulated",
+        "go-wam-accumulated",
         "haskell-lowered-ffi",
         "rust-dfs",
         "go-dfs",
@@ -122,7 +141,7 @@ TARGET_SETS["all"] = list(TARGETS.keys())
 
 
 def default_target_set_name() -> str:
-    return "portable-default" if is_termux_environment() else "desktop-default"
+    return "termux-smoke" if is_termux_environment() else "desktop-default"
 
 
 def parse_csv(value: str) -> list[str]:

--- a/examples/benchmark/generate_wam_go_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_go_effective_distance_benchmark.pl
@@ -1,0 +1,397 @@
+:- module(generate_wam_go_effective_distance_benchmark, [main/0, generate/4]).
+:- initialization(main, main).
+
+:- use_module('../../src/unifyweaver/targets/prolog_target').
+:- use_module('../../src/unifyweaver/targets/wam_target').
+:- use_module('../../src/unifyweaver/targets/wam_go_target').
+:- use_module(library(filesex), [make_directory_path/1, directory_file_path/3]).
+
+%% generate_wam_go_effective_distance_benchmark.pl
+%%
+%% Generates a Go hybrid-WAM benchmark for the effective-distance workload.
+%%
+%% Pipeline:
+%%   1. Load the effective-distance workload and the benchmark facts.
+%%   2. Generate optimized predicates via prolog_target (accumulated variant).
+%%   3. Force the selected predicates through the shared Go WAM path.
+%%   4. Emit a Go main package with a benchmark driver that queries the VM.
+%%
+%% Usage:
+%%   swipl -q -s generate_wam_go_effective_distance_benchmark.pl -- \
+%%       <facts.pl> <output-dir> [accumulated] [kernels_on|kernels_off]
+
+benchmark_workload_path(Path) :-
+    source_file(benchmark_workload_path(_), ThisFile),
+    file_directory_name(ThisFile, Here),
+    directory_file_path(Here, 'effective_distance.pl', Path).
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv = [FactsPath, OutputDir, VariantAtom, KernelModeAtom]
+    ->  true
+    ;   Argv = [FactsPath, OutputDir, VariantAtom]
+    ->  KernelModeAtom = kernels_on
+    ;   Argv = [FactsPath, OutputDir]
+    ->  VariantAtom = accumulated,
+        KernelModeAtom = kernels_on
+    ;   format(user_error,
+            'Usage: ... -- <facts.pl> <output-dir> [accumulated] [kernels_on|kernels_off]~n',
+            []),
+        halt(1)
+    ),
+    generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom),
+    halt(0).
+
+main :-
+    format(user_error, 'Error: generation failed~n', []),
+    halt(1).
+
+generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom) :-
+    benchmark_workload_path(WorkloadPath),
+    load_files(WorkloadPath, [silent(true)]),
+    retractall(user:mode(category_ancestor(_, _, _, _))),
+    assertz(user:mode(category_ancestor(-, +, -, +))),
+    parse_variant(VariantAtom, OptimizationOptions),
+    parse_kernel_mode(KernelModeAtom, KernelOptions),
+    BasePreds = [dimension_n/1, max_depth/1, category_ancestor/4],
+    prolog_target:generate_prolog_script(BasePreds, OptimizationOptions, ScriptCode0),
+    replace_all_atoms(ScriptCode0, 'main :-', 'generated_main :-', ScriptCode),
+    tmp_file_stream(text, TmpPath, TmpStream),
+    write(TmpStream, ScriptCode),
+    close(TmpStream),
+    load_files(TmpPath, [silent(true)]),
+    delete_file(TmpPath),
+    load_files(FactsPath, [silent(true)]),
+    collect_wam_predicates(user, KernelModeAtom, Predicates),
+    collect_article_categories(user, ArticleCategories),
+    collect_roots(user, Roots),
+    append([
+        [module_name('wam-go-effective-distance-bench'),
+         package_name(main),
+         prefer_wam(true),
+         wam_fallback(true),
+         foreign_lowering(true)],
+        KernelOptions
+    ], Options),
+    write_wam_go_project(Predicates, Options, OutputDir),
+    extract_shared_start_pc(OutputDir,
+        "category_ancestor$effective_distance_sum_selected/3",
+        WeightPC),
+    write_main_go(OutputDir, WeightPC, KernelModeAtom, ArticleCategories, Roots),
+    format(user_error,
+           '[WAM-Go-EffectiveDistance] variant=~w kernels=~w output=~w~n',
+           [VariantAtom, KernelModeAtom, OutputDir]).
+
+parse_variant(accumulated, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false),
+    seeded_accumulation(auto)
+]).
+
+parse_kernel_mode(kernels_on, []).
+parse_kernel_mode(kernels_off, [no_kernels(true)]).
+
+collect_wam_predicates(Module, kernels_on, [
+    Module:dimension_n/1,
+    Module:max_depth/1,
+    Module:category_ancestor/4,
+    Module:'category_ancestor$power_sum_bound'/3,
+    Module:'category_ancestor$power_sum_selected'/3,
+    Module:'category_ancestor$effective_distance_sum_selected'/3,
+    Module:'category_ancestor$effective_distance_sum_bound'/3
+]).
+
+collect_wam_predicates(Module, kernels_off, [
+    Module:dimension_n/1,
+    Module:max_depth/1,
+    Module:category_parent/2,
+    Module:category_ancestor/4,
+    Module:'category_ancestor$power_sum_bound'/3,
+    Module:'category_ancestor$power_sum_selected'/3,
+    Module:'category_ancestor$effective_distance_sum_selected'/3,
+    Module:'category_ancestor$effective_distance_sum_bound'/3
+]).
+
+collect_article_categories(Module, Pairs) :-
+    findall(Article-Category,
+        Module:article_category(Article, Category),
+        RawPairs),
+    sort(RawPairs, Pairs).
+
+collect_roots(Module, Roots) :-
+    findall(Root, Module:root_category(Root), RawRoots),
+    sort(RawRoots, Roots).
+
+extract_shared_start_pc(OutputDir, Label, PC) :-
+    directory_file_path(OutputDir, 'lib.go', LibPath),
+    read_file_to_string(LibPath, Content, []),
+    format(string(Needle), '"~w":', [Label]),
+    sub_string(Content, Start, _, _, Needle),
+    After is Start + string_length(Needle),
+    sub_string(Content, After, _, _, Rest0),
+    string_trim_left(Rest0, Rest),
+    string_digits_prefix(Rest, Digits),
+    number_string(PC, Digits).
+
+string_trim_left(In, Out) :-
+    string_codes(In, Codes),
+    drop_ws(Codes, Trimmed),
+    string_codes(Out, Trimmed).
+
+drop_ws([C|Rest], Out) :-
+    code_type(C, space),
+    !,
+    drop_ws(Rest, Out).
+drop_ws(Codes, Codes).
+
+string_digits_prefix(In, Digits) :-
+    string_codes(In, Codes),
+    take_digits(Codes, DigitCodes),
+    DigitCodes \= [],
+    string_codes(Digits, DigitCodes).
+
+take_digits([C|Rest], [C|Digits]) :-
+    code_type(C, digit),
+    !,
+    take_digits(Rest, Digits).
+take_digits(_, []).
+
+write_main_go(OutputDir, WeightPC, KernelModeAtom, ArticleCategories, Roots) :-
+    go_article_categories_literal(ArticleCategories, ArticleCategoriesLiteral),
+    go_string_slice_literal(Roots, RootsLiteral),
+    make_directory_path(OutputDir),
+    directory_file_path(OutputDir, 'main.go', MainPath),
+    format(string(Code),
+'package main
+
+import (
+    "fmt"
+    "math"
+    "os"
+    "sort"
+    "time"
+)
+
+const (
+    effectiveDistanceWeightStartPC = ~w
+)
+
+var benchmarkArticleCategories = []articleCategoryPair{
+~w
+}
+
+var benchmarkRoots = []string{~w}
+
+type articleCategoryPair struct {
+    Article string
+    Category string
+}
+
+type resultRow struct {
+    Article string
+    Root string
+    Distance float64
+}
+
+func newBenchmarkVM(startPC int, args ...Value) *WamState {
+    vm := NewWamState(sharedWamCode, sharedWamLabels)
+    setupSharedForeignPredicates(vm)
+    vm.PC = startPC
+    for i, arg := range args {
+        vm.Regs[fmt.Sprintf("A%%d", i+1)] = arg
+    }
+    return vm
+}
+
+func collectSolutions(startPC int, args ...Value) [][]Value {
+    vm := newBenchmarkVM(startPC, args...)
+    solutions := make([][]Value, 0)
+    if !vm.Run() {
+        return solutions
+    }
+    solutions = append(solutions, append([]Value(nil), vm.CollectResults()...))
+    for vm.backtrack() {
+        if !vm.Run() {
+            break
+        }
+        solutions = append(solutions, append([]Value(nil), vm.CollectResults()...))
+    }
+    return solutions
+}
+
+func atomName(v Value) string {
+    if a, ok := v.(*Atom); ok {
+        return a.Name
+    }
+    return vmString(v)
+}
+
+func vmString(v Value) string {
+    if v == nil {
+        return ""
+    }
+    return v.String()
+}
+
+func floatValue(v Value) (float64, bool) {
+    switch t := v.(type) {
+    case *Float:
+        return t.Val, true
+    case *Integer:
+        return float64(t.Val), true
+    default:
+        return 0, false
+    }
+}
+
+func weightSumForCategoryRoot(category string, root string) (float64, bool) {
+    rows := collectSolutions(
+        effectiveDistanceWeightStartPC,
+        &Atom{Name: category},
+        &Atom{Name: root},
+        &Unbound{Name: "weight"},
+    )
+    if len(rows) == 0 || len(rows[0]) < 3 {
+        return 0, false
+    }
+    return floatValue(rows[0][2])
+}
+
+func computeResults(root string, articleCats []articleCategoryPair) ([]resultRow, int, int) {
+    uniqueSeeds := make(map[string]struct{})
+    for _, pair := range articleCats {
+        uniqueSeeds[pair.Category] = struct{}{}
+    }
+    seedWeights := make(map[string]float64)
+    tupleCount := 0
+    for seed := range uniqueSeeds {
+        if seed == root {
+            continue
+        }
+        if weight, ok := weightSumForCategoryRoot(seed, root); ok && weight > 0 {
+            seedWeights[seed] = weight
+            tupleCount++
+        }
+    }
+
+    articleWeightSums := make(map[string]float64)
+    for _, pair := range articleCats {
+        if pair.Category == root {
+            articleWeightSums[pair.Article] += 1.0
+            continue
+        }
+        if weight, ok := seedWeights[pair.Category]; ok {
+            articleWeightSums[pair.Article] += weight
+        }
+    }
+
+    n := 5.0
+    invN := -1.0 / n
+    rows := make([]resultRow, 0, len(articleWeightSums))
+    for article, weightSum := range articleWeightSums {
+        if weightSum <= 0 {
+            continue
+        }
+        rows = append(rows, resultRow{
+            Article: article,
+            Root: root,
+            Distance: math.Pow(weightSum, invN),
+        })
+    }
+    sort.Slice(rows, func(i, j int) bool {
+        if rows[i].Distance != rows[j].Distance {
+            return rows[i].Distance < rows[j].Distance
+        }
+        return rows[i].Article < rows[j].Article
+    })
+    return rows, len(uniqueSeeds), tupleCount
+}
+
+func main() {
+    started := time.Now()
+    roots := append([]string(nil), benchmarkRoots...)
+    articleCats := append([]articleCategoryPair(nil), benchmarkArticleCategories...)
+    loadMs := time.Since(started).Milliseconds()
+    if len(roots) == 0 {
+        fmt.Fprintln(os.Stderr, "no root categories")
+        os.Exit(1)
+    }
+    root := roots[0]
+
+    queryStart := time.Now()
+    rows, seedCount, tupleCount := computeResults(root, articleCats)
+    queryMs := time.Since(queryStart).Milliseconds()
+
+    aggregationStart := time.Now()
+    sort.Slice(rows, func(i, j int) bool {
+        if rows[i].Distance != rows[j].Distance {
+            return rows[i].Distance < rows[j].Distance
+        }
+        return rows[i].Article < rows[j].Article
+    })
+    aggregationMs := time.Since(aggregationStart).Milliseconds()
+    totalMs := time.Since(started).Milliseconds()
+
+    fmt.Println("article\\troot_category\\teffective_distance")
+    for _, row := range rows {
+        fmt.Printf("%%s\\t%%s\\t%%.6f\\n", row.Article, row.Root, row.Distance)
+    }
+
+    fmt.Fprintf(os.Stderr, "mode=accumulated_go_wam\\n")
+    fmt.Fprintf(os.Stderr, "kernel_mode=~w\\n")
+    fmt.Fprintf(os.Stderr, "load_ms=%%d\\n", loadMs)
+    fmt.Fprintf(os.Stderr, "query_ms=%%d\\n", queryMs)
+    fmt.Fprintf(os.Stderr, "aggregation_ms=%%d\\n", aggregationMs)
+    fmt.Fprintf(os.Stderr, "total_ms=%%d\\n", totalMs)
+    fmt.Fprintf(os.Stderr, "seed_count=%%d\\n", seedCount)
+    fmt.Fprintf(os.Stderr, "tuple_count=%%d\\n", tupleCount)
+    fmt.Fprintf(os.Stderr, "article_count=%%d\\n", len(rows))
+}
+', [WeightPC, ArticleCategoriesLiteral, RootsLiteral, KernelModeAtom]),
+    setup_call_cleanup(
+        open(MainPath, write, Stream),
+        format(Stream, '~w', [Code]),
+        close(Stream)
+    ).
+
+go_article_categories_literal([], '').
+go_article_categories_literal(Pairs, Literal) :-
+    maplist(go_article_category_entry, Pairs, Entries),
+    atomic_list_concat(Entries, ",\n", Literal).
+
+go_article_category_entry(Article-Category, Entry) :-
+    escape_go_string(Article, EscArticle),
+    escape_go_string(Category, EscCategory),
+    format(atom(Entry), '    {Article: "~w", Category: "~w"}', [EscArticle, EscCategory]).
+
+go_string_slice_literal([], '').
+go_string_slice_literal(Strings, Literal) :-
+    maplist(go_string_literal, Strings, Quoted),
+    atomic_list_concat(Quoted, ', ', Literal).
+
+go_string_literal(String, Literal) :-
+    escape_go_string(String, Escaped),
+    format(atom(Literal), '"~w"', [Escaped]).
+
+replace_all_atoms(Input, Search, Replace, Output) :-
+    (   sub_atom(Input, Before, _, After, Search)
+    ->  sub_atom(Input, 0, Before, _, Prefix),
+        sub_atom(Input, _, After, 0, Suffix),
+        atom_concat(Prefix, Replace, Tmp),
+        atom_concat(Tmp, Suffix, Next),
+        replace_all_atoms(Next, Search, Replace, Output)
+    ;   Output = Input
+    ).
+
+escape_go_string(Input, Escaped) :-
+    atom_chars(Input, Chars),
+    phrase(go_escaped_chars(Chars), EscChars),
+    atom_chars(Escaped, EscChars).
+
+go_escaped_chars([]) --> [].
+go_escaped_chars(['\\'|Rest]) --> ['\\','\\'], go_escaped_chars(Rest).
+go_escaped_chars(['"'|Rest]) --> ['\\','"'], go_escaped_chars(Rest).
+go_escaped_chars(['\n'|Rest]) --> ['\\','n'], go_escaped_chars(Rest).
+go_escaped_chars(['\t'|Rest]) --> ['\\','t'], go_escaped_chars(Rest).
+go_escaped_chars([Char|Rest]) --> [Char], go_escaped_chars(Rest).

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -137,7 +137,21 @@ var sharedWamCode = resolveInstructions(sharedWamCodeRaw, sharedWamLabels)
 classify_predicates([], _, []).
 classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
     predicate_indicator_parts(PredIndicator, Module, Pred, Arity),
-    (   go_foreign_spec(Module:Pred/Arity, Options, _SetupOps, _RewriteCalls, _EntryPred/_EntryArity),
+    (   option(prefer_wam(true), Options),
+        option(wam_fallback(WamFB0), Options, true),
+        WamFB0 \== false,
+        go_foreign_spec(Module:Pred/Arity, Options, _SetupOps0, _RewriteCalls0, _EntryPred0/_EntryArity0),
+        wam_target:compile_predicate_to_wam(Module:Pred/Arity, Options, WamCode0)
+    ->  compile_wam_predicate_to_go(Module:Pred/Arity, WamCode0, Options, PredCode0),
+        format(user_error, '  ~w/~w: WAM fallback (foreign, preferred)~n', [Pred, Arity]),
+        Entry = classified(Module, Pred, Arity, wam_foreign, PredCode0)
+    ;   option(prefer_wam(true), Options),
+        option(wam_fallback(WamFB1), Options, true),
+        WamFB1 \== false,
+        wam_target:compile_predicate_to_wam(Module:Pred/Arity, Options, WamCode1)
+    ->  format(user_error, '  ~w/~w: WAM fallback (preferred)~n', [Pred, Arity]),
+        Entry = classified(Module, Pred, Arity, wam, WamCode1)
+    ;   go_foreign_spec(Module:Pred/Arity, Options, _SetupOps, _RewriteCalls, _EntryPred/_EntryArity),
         option(wam_fallback(WamFB), Options, true),
         WamFB \== false,
         wam_target:compile_predicate_to_wam(Module:Pred/Arity, Options, WamCode)
@@ -333,7 +347,7 @@ go_struct_case(Functor-Label, Case) :-
 compile_wam_predicate_to_go(PredIndicator, WamCode, Options, GoCode) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
     atom_string(Pred, PredStr),
-    capitalize_atom(Pred, CapPred),
+    predicate_go_name(Pred, CapPred),
     build_go_wam_arg_list(Arity, ArgList),
     build_go_wam_arg_setup(Arity, ArgSetup),
     (   foreign_wrapper_setup(PredIndicator, WamCode, Options, InstrSetup, ForeignSetup, RunExpr)
@@ -377,7 +391,7 @@ func ~w(~w) bool {
 
 compile_wam_predicate_to_go_shared(Pred/Arity, StartPC, GoCode) :-
     atom_string(Pred, PredStr),
-    capitalize_atom(Pred, CapPred),
+    predicate_go_name(Pred, CapPred),
     build_go_wam_arg_list(Arity, ArgList),
     build_go_wam_arg_setup(Arity, ArgSetup),
     format(atom(GoCode),
@@ -490,6 +504,22 @@ capitalize_atom(Atom, Cap) :-
     atom_codes(Atom, [First|Rest]),
     code_type(FirstUpper, to_upper(First)),
     atom_codes(Cap, [FirstUpper|Rest]).
+
+predicate_go_name(Pred, Name) :-
+    atom_codes(Pred, Codes),
+    maplist(go_ident_code, Codes, SafeCodes0),
+    (   SafeCodes0 = [First|Rest]
+    ->  code_type(UpperFirst, to_upper(First)),
+        SafeCodes = [UpperFirst|Rest]
+    ;   SafeCodes = [0'P]
+    ),
+    atom_codes(Name, SafeCodes).
+
+go_ident_code(Code, Safe) :-
+    (   code_type(Code, alnum)
+    ->  Safe = Code
+    ;   Safe = 0'_
+    ).
 
 predicate_indicator_parts(Module:Pred/Arity, Module, Pred, Arity) :- !.
 predicate_indicator_parts(Pred/Arity, user, Pred, Arity).
@@ -748,6 +778,19 @@ wam_line_to_go_literal(["execute", P], PredIndicator, Options, GoLit) :-
     ->  format(atom(GoLit), '&CallForeign{Pred: "~w", Arity: ~w}', [ForeignPred, ForeignArity])
     ;   format(atom(GoLit), '&Execute{Pred: "~w"}', [CP])
     ).
+wam_line_to_go_literal(["jump", L], GoLit) :-
+    clean_comma(L, CL),
+    format(atom(GoLit), '&Jump{Label: "~w"}', [CL]).
+wam_line_to_go_literal(["cut_ite"], '&CutIte{}').
+wam_line_to_go_literal(["begin_aggregate", AggType, ValueReg, ResultReg], GoLit) :-
+    clean_comma(AggType, CAggType),
+    clean_comma(ValueReg, CValueReg),
+    clean_comma(ResultReg, CResultReg),
+    format(atom(GoLit), '&BeginAggregate{AggType: "~w", ValueReg: "~w", ResultReg: "~w"}',
+        [CAggType, CValueReg, CResultReg]).
+wam_line_to_go_literal(["end_aggregate", ValueReg], GoLit) :-
+    clean_comma(ValueReg, CValueReg),
+    format(atom(GoLit), '&EndAggregate{ValueReg: "~w"}', [CValueReg]).
 
 wam_line_to_go_literal(["get_constant", C, Ai], GoLit) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),
@@ -1208,7 +1251,7 @@ wam_go_case('SetConstant', '        vm.Heap = append(vm.Heap, i.C)
 
 % --- Control Instructions ---
 
-wam_go_case('Allocate', '        vm.Stack = append(vm.Stack, &EnvFrame{CP: vm.CP})
+wam_go_case('Allocate', '        vm.Stack = append(vm.Stack, &EnvFrame{CP: vm.CP, B0: len(vm.ChoicePoints)})
         vm.PC++
         return true').
 
@@ -1238,6 +1281,26 @@ wam_go_case('Execute', '        if pc, ok := vm.Labels[i.Pred]; ok {
         return false').
 
 wam_go_case('ExecutePc', '        vm.PC = i.TargetPC
+        return true').
+
+wam_go_case('Jump', '        if pc, ok := vm.Labels[i.Label]; ok {
+            vm.PC = pc
+            return true
+        }
+        return false').
+
+wam_go_case('JumpPc', '        vm.PC = i.TargetPC
+        return true').
+
+wam_go_case('CutIte', '        if len(vm.ChoicePoints) > 0 {
+            vm.ChoicePoints = vm.ChoicePoints[:len(vm.ChoicePoints)-1]
+        }
+        vm.PC++
+        return true').
+
+wam_go_case('BeginAggregate', '        return vm.executeAggregate(i.AggType, i.ValueReg, i.ResultReg)').
+
+wam_go_case('EndAggregate', '        vm.PC++
         return true').
 
 wam_go_case('Proceed', '        if vm.CP > 0 {
@@ -1290,24 +1353,35 @@ wam_go_case('TrustMe', '        if len(vm.ChoicePoints) > 0 {
 % --- Indexing Instructions ---
 
 wam_go_case('SwitchOnConstant', '        if val, ok := vm.Regs["A1"]; ok && !isUnbound(val) {
+            targets := make([]int, 0)
             for _, c := range i.Cases {
-                if valueEquals(c.Val, val) {
-                    if pc, ok := vm.Labels[c.Label]; ok {
-                        vm.PC = pc
-                        return true
-                    }
+                if !valueEquals(c.Val, val) {
+                    continue
                 }
+                if c.Label == "default" {
+                    targets = append(targets, vm.indexedClauseBodyStart(vm.PC+1))
+                    continue
+                }
+                if pc, ok := vm.Labels[c.Label]; ok {
+                    targets = append(targets, vm.indexedClauseBodyStart(pc))
+                }
+            }
+            if len(targets) > 0 {
+                return vm.enterIndexedAlternatives(targets)
             }
         }
         vm.PC++
         return true').
 
 wam_go_case('SwitchOnConstantPc', '        if val, ok := vm.Regs["A1"]; ok && !isUnbound(val) {
+            targets := make([]int, 0)
             for _, c := range i.Cases {
                 if valueEquals(c.Val, val) {
-                    vm.PC = c.TargetPC
-                    return true
+                    targets = append(targets, vm.indexedClauseBodyStart(c.TargetPC))
                 }
+            }
+            if len(targets) > 0 {
+                return vm.enterIndexedAlternatives(targets)
             }
         }
         vm.PC++
@@ -1316,13 +1390,21 @@ wam_go_case('SwitchOnConstantPc', '        if val, ok := vm.Regs["A1"]; ok && !i
 wam_go_case('SwitchOnStructure', '        if val, ok := vm.Regs["A1"]; ok {
             if f, args := decompose(val); f != "" {
                 key := fmt.Sprintf("%s/%d", f, len(args))
+                targets := make([]int, 0)
                 for _, c := range i.Cases {
-                    if c.Functor == key {
-                        if pc, ok := vm.Labels[c.Label]; ok {
-                            vm.PC = pc
-                            return true
-                        }
+                    if c.Functor != key {
+                        continue
                     }
+                    if c.Label == "default" {
+                        targets = append(targets, vm.indexedClauseBodyStart(vm.PC+1))
+                        continue
+                    }
+                    if pc, ok := vm.Labels[c.Label]; ok {
+                        targets = append(targets, vm.indexedClauseBodyStart(pc))
+                    }
+                }
+                if len(targets) > 0 {
+                    return vm.enterIndexedAlternatives(targets)
                 }
             }
         }
@@ -1332,11 +1414,14 @@ wam_go_case('SwitchOnStructure', '        if val, ok := vm.Regs["A1"]; ok {
 wam_go_case('SwitchOnStructurePc', '        if val, ok := vm.Regs["A1"]; ok {
             if f, args := decompose(val); f != "" {
                 key := fmt.Sprintf("%s/%d", f, len(args))
+                targets := make([]int, 0)
                 for _, c := range i.Cases {
                     if c.Functor == key {
-                        vm.PC = c.TargetPC
-                        return true
+                        targets = append(targets, vm.indexedClauseBodyStart(c.TargetPC))
                     }
+                }
+                if len(targets) > 0 {
+                    return vm.enterIndexedAlternatives(targets)
                 }
             }
         }
@@ -1344,24 +1429,35 @@ wam_go_case('SwitchOnStructurePc', '        if val, ok := vm.Regs["A1"]; ok {
         return true').
 
 wam_go_case('SwitchOnConstantA2', '        if val, ok := vm.Regs["A2"]; ok && !isUnbound(val) {
+            targets := make([]int, 0)
             for _, c := range i.Cases {
-                if valueEquals(c.Val, val) {
-                    if pc, ok := vm.Labels[c.Label]; ok {
-                        vm.PC = pc
-                        return true
-                    }
+                if !valueEquals(c.Val, val) {
+                    continue
                 }
+                if c.Label == "default" {
+                    targets = append(targets, vm.indexedClauseBodyStart(vm.PC+1))
+                    continue
+                }
+                if pc, ok := vm.Labels[c.Label]; ok {
+                    targets = append(targets, vm.indexedClauseBodyStart(pc))
+                }
+            }
+            if len(targets) > 0 {
+                return vm.enterIndexedAlternatives(targets)
             }
         }
         vm.PC++
         return true').
 
 wam_go_case('SwitchOnConstantA2Pc', '        if val, ok := vm.Regs["A2"]; ok && !isUnbound(val) {
+            targets := make([]int, 0)
             for _, c := range i.Cases {
                 if valueEquals(c.Val, val) {
-                    vm.PC = c.TargetPC
-                    return true
+                    targets = append(targets, vm.indexedClauseBodyStart(c.TargetPC))
                 }
+            }
+            if len(targets) > 0 {
+                return vm.enterIndexedAlternatives(targets)
             }
         }
         vm.PC++
@@ -1452,6 +1548,33 @@ func (vm *WamState) RunParallel(maxWorkers int) <-chan []Value {
 	return results
 }
 
+func (vm *WamState) indexedClauseBodyStart(targetPC int) int {
+    if targetPC < 0 || targetPC >= len(vm.Code) {
+        return targetPC
+    }
+    switch vm.Code[targetPC].(type) {
+    case *TryMeElse, *TryMeElsePc, *RetryMeElse, *RetryMeElsePc, *TrustMe:
+        return targetPC + 1
+    default:
+        return targetPC
+    }
+}
+
+func (vm *WamState) enterIndexedAlternatives(targets []int) bool {
+    if len(targets) == 0 {
+        return false
+    }
+    if len(targets) > 1 {
+        vm.pushIndexedChoicePoint(targets[1:])
+    }
+    vm.PC = targets[0]
+    return true
+}
+
+func (vm *WamState) enterIndexedClause(targetPC int) bool {
+    return vm.enterIndexedAlternatives([]int{vm.indexedClauseBodyStart(targetPC)})
+}
+
 // CollectResults gathers values from A registers.
 func (vm *WamState) CollectResults() []Value {
 	results := make([]Value, 0)
@@ -1489,6 +1612,12 @@ func resolveInstructions(code []Instruction, labels map[string]int) []Instructio
         case *Execute:
             if pc, ok := labels[i.Pred]; ok {
                 resolved = append(resolved, &ExecutePc{TargetPC: pc})
+            } else {
+                resolved = append(resolved, instr)
+            }
+        case *Jump:
+            if pc, ok := labels[i.Label]; ok {
+                resolved = append(resolved, &JumpPc{TargetPC: pc})
             } else {
                 resolved = append(resolved, instr)
             }
@@ -1557,6 +1686,169 @@ func resolveInstructions(code []Instruction, labels map[string]int) []Instructio
         }
     }
     return resolved
+}
+
+func (vm *WamState) executeAggregate(aggType string, valueReg string, resultReg string) bool {
+    endPC, ok := vm.findMatchingAggregateEnd(vm.PC)
+    if !ok {
+        return false
+    }
+    sub := vm.Clone()
+    baseChoicePoints := len(sub.ChoicePoints)
+    sub.PC = vm.PC + 1
+    sub.Halted = false
+    sub.CurrentStruct = nil
+    sub.CurrentList = nil
+
+    values := make([]Value, 0)
+    count := 0
+    for {
+        if !sub.runUntilPC(endPC, baseChoicePoints) {
+            break
+        }
+        count++
+        if aggType != "count" {
+            val, ok := sub.Regs[valueReg]
+            if !ok {
+                return false
+            }
+            values = append(values, sub.deref(val))
+        }
+        if !sub.backtrackAbove(baseChoicePoints) {
+            break
+        }
+    }
+
+    result, ok := aggregateResultValue(aggType, values, count)
+    if !ok {
+        return false
+    }
+    if !vm.bindOrUnifyReg(resultReg, result) {
+        return false
+    }
+    vm.PC = endPC + 1
+    return true
+}
+
+func (vm *WamState) findMatchingAggregateEnd(startPC int) (int, bool) {
+    depth := 1
+    for pc := startPC + 1; pc < len(vm.Code); pc++ {
+        switch vm.Code[pc].(type) {
+        case *BeginAggregate:
+            depth++
+        case *EndAggregate:
+            depth--
+            if depth == 0 {
+                return pc, true
+            }
+        }
+    }
+    return 0, false
+}
+
+func (vm *WamState) runUntilPC(targetPC int, baseChoicePoints int) bool {
+    for {
+        if vm.Halted {
+            return false
+        }
+        if vm.PC == targetPC {
+            return true
+        }
+        instr := vm.fetch()
+        if instr == nil {
+            return false
+        }
+        if !vm.Step(instr) {
+            if !vm.backtrackAbove(baseChoicePoints) {
+                return false
+            }
+        }
+    }
+}
+
+func (vm *WamState) backtrackAbove(limit int) bool {
+    if len(vm.ChoicePoints) <= limit {
+        return false
+    }
+    return vm.backtrack()
+}
+
+func (vm *WamState) bindOrUnifyReg(reg string, val Value) bool {
+    existing, ok := vm.Regs[reg]
+    if !ok {
+        vm.trailBinding(reg)
+        vm.putReg(reg, val)
+        return true
+    }
+    return vm.Unify(existing, val)
+}
+
+func aggregateResultValue(aggType string, values []Value, count int) (Value, bool) {
+    switch aggType {
+    case "count":
+        return &Integer{Val: int64(count)}, true
+    case "collect":
+        return &List{Elements: append([]Value(nil), values...)}, true
+    case "sum":
+        total := 0.0
+        for _, value := range values {
+            number, ok := aggregateNumericValue(value)
+            if !ok {
+                return nil, false
+            }
+            total += number
+        }
+        return &Float{Val: total}, true
+    case "max":
+        if len(values) == 0 {
+            return nil, false
+        }
+        best, ok := aggregateNumericValue(values[0])
+        if !ok {
+            return nil, false
+        }
+        for _, value := range values[1:] {
+            number, ok := aggregateNumericValue(value)
+            if !ok {
+                return nil, false
+            }
+            if number > best {
+                best = number
+            }
+        }
+        return &Float{Val: best}, true
+    case "min":
+        if len(values) == 0 {
+            return nil, false
+        }
+        best, ok := aggregateNumericValue(values[0])
+        if !ok {
+            return nil, false
+        }
+        for _, value := range values[1:] {
+            number, ok := aggregateNumericValue(value)
+            if !ok {
+                return nil, false
+            }
+            if number < best {
+                best = number
+            }
+        }
+        return &Float{Val: best}, true
+    default:
+        return nil, false
+    }
+}
+
+func aggregateNumericValue(value Value) (float64, bool) {
+    switch t := value.(type) {
+    case *Integer:
+        return float64(t.Val), true
+    case *Float:
+        return t.Val, true
+    default:
+        return 0, false
+    }
 }
 
 func (vm *WamState) registerForeignNativeKind(predKey string, kind string) {

--- a/templates/targets/go_wam/instructions.go.mustache
+++ b/templates/targets/go_wam/instructions.go.mustache
@@ -84,6 +84,21 @@ func (i *Execute) instrTag() {}
 type ExecutePc struct { TargetPC int }
 func (i *ExecutePc) instrTag() {}
 
+type Jump struct { Label string }
+func (i *Jump) instrTag() {}
+
+type JumpPc struct { TargetPC int }
+func (i *JumpPc) instrTag() {}
+
+type CutIte struct{}
+func (i *CutIte) instrTag() {}
+
+type BeginAggregate struct { AggType string; ValueReg string; ResultReg string }
+func (i *BeginAggregate) instrTag() {}
+
+type EndAggregate struct { ValueReg string }
+func (i *EndAggregate) instrTag() {}
+
 type Proceed struct{}
 func (i *Proceed) instrTag() {}
 

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -29,6 +29,7 @@ type ChoicePoint struct {
 	Stack     []StackEntry
 	HeapTop   int
 	TrailMark int
+	IndexedClausePCs []int
 	ForeignPredKey   string
 	ForeignResultRegs []string
 	ForeignResults   []Value
@@ -36,6 +37,7 @@ type ChoicePoint struct {
 
 type EnvFrame struct {
 	CP int
+	B0 int
 }
 
 type UnifyCtx struct {
@@ -114,6 +116,17 @@ func (vm *WamState) pushChoicePoint(nextPC int) {
 	})
 }
 
+func (vm *WamState) pushIndexedChoicePoint(pcs []int) {
+	vm.ChoicePoints = append(vm.ChoicePoints, ChoicePoint{
+		CP:        vm.CP,
+		Regs:      copyMap(vm.Regs),
+		Stack:     copyStack(vm.Stack),
+		HeapTop:   len(vm.Heap),
+		TrailMark: len(vm.Trail),
+		IndexedClausePCs: append([]int(nil), pcs...),
+	})
+}
+
 func (vm *WamState) popEnvFrame() *EnvFrame {
 	for i := len(vm.Stack) - 1; i >= 0; i-- {
 		if f, ok := vm.Stack[i].(*EnvFrame); ok {
@@ -136,6 +149,15 @@ func (vm *WamState) peekWriteCtx() *WriteCtx {
 	if len(vm.Stack) == 0 { return nil }
 	if ctx, ok := vm.Stack[len(vm.Stack)-1].(*WriteCtx); ok {
 		return ctx
+	}
+	return nil
+}
+
+func (vm *WamState) peekEnvFrame() *EnvFrame {
+	for i := len(vm.Stack) - 1; i >= 0; i-- {
+		if f, ok := vm.Stack[i].(*EnvFrame); ok {
+			return f
+		}
 	}
 	return nil
 }
@@ -233,6 +255,72 @@ func parseFunctorName(f string) string {
 	return f
 }
 
+func isEmptyListValue(v Value) bool {
+	if atom, ok := v.(*Atom); ok {
+		return atom.Name == "[]"
+	}
+	if list, ok := v.(*List); ok {
+		return len(list.Elements) == 0
+	}
+	return false
+}
+
+func rawListHeadTail(list *List) (Value, Value, bool) {
+	switch len(list.Elements) {
+	case 0:
+		return nil, nil, false
+	case 1:
+		return list.Elements[0], &Atom{Name: "[]"}, true
+	case 2:
+		tail := list.Elements[1]
+		if _, ok := tail.(*List); ok {
+			return list.Elements[0], tail, true
+		}
+		if isEmptyListValue(tail) {
+			return list.Elements[0], &Atom{Name: "[]"}, true
+		}
+	}
+	return list.Elements[0], &List{Elements: list.Elements[1:]}, true
+}
+
+func (vm *WamState) listHeadTail(list *List) (Value, Value, bool) {
+	switch len(list.Elements) {
+	case 0:
+		return nil, nil, false
+	case 1:
+		return list.Elements[0], &Atom{Name: "[]"}, true
+	case 2:
+		tail := vm.deref(list.Elements[1])
+		if _, ok := tail.(*List); ok {
+			return list.Elements[0], tail, true
+		}
+		if isEmptyListValue(tail) {
+			return list.Elements[0], &Atom{Name: "[]"}, true
+		}
+	}
+	return list.Elements[0], &List{Elements: list.Elements[1:]}, true
+}
+
+func (vm *WamState) listToSlice(v Value) ([]Value, bool) {
+	v = vm.deref(v)
+	if isEmptyListValue(v) {
+		return []Value{}, true
+	}
+	list, ok := v.(*List)
+	if !ok {
+		return nil, false
+	}
+	head, tail, ok := vm.listHeadTail(list)
+	if !ok {
+		return []Value{}, true
+	}
+	rest, ok := vm.listToSlice(tail)
+	if !ok {
+		return nil, false
+	}
+	return append([]Value{head}, rest...), true
+}
+
 func decompose(v Value) (string, []Value) {
 	switch t := v.(type) {
 	case *Atom:
@@ -242,9 +330,7 @@ func decompose(v Value) (string, []Value) {
 	case *Structure:
 		return parseFunctorName(t.Functor), t.Args
 	case *List:
-		if len(t.Elements) > 0 {
-			head := t.Elements[0]
-			tail := &List{Elements: t.Elements[1:]}
+		if head, tail, ok := rawListHeadTail(t); ok {
 			return ".", []Value{head, tail}
 		}
 		return "[]", nil
@@ -331,7 +417,16 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 	case "fail/0":
 		return false
 	case "!/0":
-		vm.ChoicePoints = nil
+		limit := 0
+		if env := vm.peekEnvFrame(); env != nil {
+			limit = env.B0
+		}
+		if limit < 0 {
+			limit = 0
+		}
+		if limit < len(vm.ChoicePoints) {
+			vm.ChoicePoints = vm.ChoicePoints[:limit]
+		}
 		return true
 	case "is/2":
 		val, ok := vm.evalArithmetic(arg2)
@@ -397,23 +492,21 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 		return false
 
 	case "length/2":
-		l, ok := vm.deref(arg2).(*Integer)
+		elements, ok := vm.listToSlice(arg1)
 		if !ok { return false }
-		list, ok := vm.deref(arg1).(*List)
-		if !ok { return false }
-		return int64(len(list.Elements)) == l.Val
+		return vm.Unify(arg2, &Integer{Val: int64(len(elements))})
 	case "member/2":
-		list, ok := vm.deref(arg2).(*List)
+		elements, ok := vm.listToSlice(arg2)
 		if !ok { return false }
-		for _, e := range list.Elements {
+		for _, e := range elements {
 			if vm.Unify(arg1, e) { return true }
 		}
 		return false
 	case "append/3":
-		l1, ok1 := vm.deref(arg1).(*List)
-		l2, ok2 := vm.deref(arg2).(*List)
+		l1, ok1 := vm.listToSlice(arg1)
+		l2, ok2 := vm.listToSlice(arg2)
 		if !ok1 || !ok2 { return false }
-		combined := &List{Elements: append(l1.Elements, l2.Elements...)}
+		combined := &List{Elements: append(append([]Value{}, l1...), l2...)}
 		return vm.Unify(arg3, combined)
 	}
 	return false
@@ -460,6 +553,27 @@ func (vm *WamState) backtrack() bool {
     }
     topIdx := len(vm.ChoicePoints) - 1
     cp := vm.ChoicePoints[topIdx]
+    if len(cp.IndexedClausePCs) > 0 {
+        vm.unwindTrail(cp.TrailMark)
+        vm.Regs = copyMap(cp.Regs)
+        vm.Stack = copyStack(cp.Stack)
+        if cp.HeapTop >= 0 && cp.HeapTop <= len(vm.Heap) {
+            vm.Heap = vm.Heap[:cp.HeapTop]
+        }
+        vm.CP = cp.CP
+        vm.Halted = false
+        vm.CurrentStruct = nil
+        vm.CurrentList = nil
+        nextPC := cp.IndexedClausePCs[0]
+        cp.IndexedClausePCs = cp.IndexedClausePCs[1:]
+        if len(cp.IndexedClausePCs) == 0 {
+            vm.ChoicePoints = vm.ChoicePoints[:topIdx]
+        } else {
+            vm.ChoicePoints[topIdx] = cp
+        }
+        vm.PC = nextPC
+        return true
+    }
     if len(cp.ForeignResults) > 0 {
         for len(cp.ForeignResults) > 0 {
             vm.unwindTrail(cp.TrailMark)
@@ -487,7 +601,6 @@ func (vm *WamState) backtrack() bool {
         }
         return false
     }
-    vm.ChoicePoints = vm.ChoicePoints[:topIdx]
     vm.unwindTrail(cp.TrailMark)
     vm.Regs = copyMap(cp.Regs)
     vm.Stack = copyStack(cp.Stack)


### PR DESCRIPTION
## Summary

This PR hardens the Go hybrid/WAM runtime and extends the benchmark matrix so Go can participate more safely in effective-distance comparisons.

The main runtime work fixes correctness issues that showed up in deeper recursive/indexed execution, especially around backtracking and list-oriented builtins. The benchmark work adds a dedicated Go hybrid/WAM effective-distance generator and introduces Termux-safe defaults so local smoke runs do not accidentally trigger unstable large-scale benchmark jobs.

## What Changed

- fixed Go WAM indexed backtracking for grouped clause dispatch
- fixed ordinary choice-point restoration so resumed `retry_me_else` / `trust_me` execution keeps the right choice point alive
- scoped cut behavior to the current environment instead of clearing all choice points globally
- improved Go list handling for nested tails and recursive traversal
- made `length/2` support output binding, which was required by recursive benchmark predicates
- added Go aggregate instruction/runtime support for benchmark-oriented generated code
- added a dedicated Go hybrid/WAM effective-distance benchmark generator
- wired Go hybrid/WAM benchmark targets into the benchmark matrix
- added Termux-safe benchmark defaults and a guard against large benchmark scales unless explicitly overridden
- documented the benchmark target matrix and Termux constraints

## Why

The Go target had reached the point where remaining correctness issues were showing up primarily in recursive indexed execution rather than in isolated instruction coverage. Those bugs directly affected the effective-distance benchmark path and would have made any comparison misleading.

At the same time, this Termux environment is not a reliable place to run large benchmark generations or profiling jobs. The benchmark harness now reflects that by defaulting to smoke-test scales on Termux and requiring an explicit override for larger runs.

## Validation

Passed:

- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `python -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py`
- `python examples/benchmark/benchmark_effective_distance_matrix.py --list-targets`
- `python examples/benchmark/benchmark_effective_distance_matrix.py --targets prolog-accumulated --scales dev --repetitions 1`

Also verified:

- large Termux benchmark scales are now rejected by default unless `--allow-large-termux-scales` is passed

## Notes

- This PR improves Go runtime correctness and benchmark wiring, but it does not claim full large-scale benchmark parity inside Termux.
- For meaningful benchmark comparisons beyond smoke scale, the next runs should happen on a roomier non-Termux environment.
