### PR TITLE
fix+perf(wam-go): 7 remaining gaps — correctness fixes and perf improvements

### DIFF
--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -819,43 +819,43 @@ wam_line_to_go_literal(["begin_aggregate", AggType, ValueReg, ResultReg], GoLit)
     clean_comma(AggType, CAggType),
     clean_comma(ValueReg, CValueReg),
     clean_comma(ResultReg, CResultReg),
-    go_reg_string_to_index(CValueReg, ValueRegIdx),
-    go_reg_string_to_index(CResultReg, ResultRegIdx),
+    go_reg_index(CValueReg, ValueRegIdx),
+    go_reg_index(CResultReg, ResultRegIdx),
     format(atom(GoLit), '&BeginAggregate{AggType: "~w", ValueReg: ~w, ResultReg: ~w}',
         [CAggType, ValueRegIdx, ResultRegIdx]).
 wam_line_to_go_literal(["end_aggregate", ValueReg], GoLit) :-
     clean_comma(ValueReg, CValueReg),
-    go_reg_string_to_index(CValueReg, ValueRegIdx),
+    go_reg_index(CValueReg, ValueRegIdx),
     format(atom(GoLit), '&EndAggregate{ValueReg: ~w}', [ValueRegIdx]).
 
 wam_line_to_go_literal(["get_constant", C, Ai], GoLit) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),
     parse_string_to_go_val(CC, GoVal),
-    go_reg_string_to_index(CAi, AiIdx),
+    go_reg_index(CAi, AiIdx),
     format(atom(GoLit), '&GetConstant{C: ~w, Ai: ~w}', [GoVal, AiIdx]).
 wam_line_to_go_literal(["get_variable", Xn, Ai], GoLit) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
-    go_reg_string_to_index(CXn, XnIdx), go_reg_string_to_index(CAi, AiIdx),
+    go_reg_index(CXn, XnIdx), go_reg_index(CAi, AiIdx),
     format(atom(GoLit), '&GetVariable{Xn: ~w, Ai: ~w}', [XnIdx, AiIdx]).
 wam_line_to_go_literal(["get_value", Xn, Ai], GoLit) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
-    go_reg_string_to_index(CXn, XnIdx), go_reg_string_to_index(CAi, AiIdx),
+    go_reg_index(CXn, XnIdx), go_reg_index(CAi, AiIdx),
     format(atom(GoLit), '&GetValue{Xn: ~w, Ai: ~w}', [XnIdx, AiIdx]).
 wam_line_to_go_literal(["get_structure", FN, Ai], GoLit) :-
     clean_comma(FN, CFN), clean_comma(Ai, CAi),
-    go_reg_string_to_index(CAi, AiIdx),
+    go_reg_index(CAi, AiIdx),
     format(atom(GoLit), '&GetStructure{Functor: "~w", Ai: ~w}', [CFN, AiIdx]).
 wam_line_to_go_literal(["get_list", Ai], GoLit) :-
     clean_comma(Ai, CAi),
-    go_reg_string_to_index(CAi, AiIdx),
+    go_reg_index(CAi, AiIdx),
     format(atom(GoLit), '&GetList{Ai: ~w}', [AiIdx]).
 wam_line_to_go_literal(["unify_variable", Xn], GoLit) :-
     clean_comma(Xn, CXn),
-    go_reg_string_to_index(CXn, XnIdx),
+    go_reg_index(CXn, XnIdx),
     format(atom(GoLit), '&UnifyVariable{Xn: ~w}', [XnIdx]).
 wam_line_to_go_literal(["unify_value", Xn], GoLit) :-
     clean_comma(Xn, CXn),
-    go_reg_string_to_index(CXn, XnIdx),
+    go_reg_index(CXn, XnIdx),
     format(atom(GoLit), '&UnifyValue{Xn: ~w}', [XnIdx]).
 wam_line_to_go_literal(["unify_constant", C], GoLit) :-
     clean_comma(C, CC),
@@ -865,31 +865,31 @@ wam_line_to_go_literal(["unify_constant", C], GoLit) :-
 wam_line_to_go_literal(["put_constant", C, Ai], GoLit) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),
     parse_string_to_go_val(CC, GoVal),
-    go_reg_string_to_index(CAi, AiIdx),
+    go_reg_index(CAi, AiIdx),
     format(atom(GoLit), '&PutConstant{C: ~w, Ai: ~w}', [GoVal, AiIdx]).
 wam_line_to_go_literal(["put_variable", Xn, Ai], GoLit) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
-    go_reg_string_to_index(CXn, XnIdx), go_reg_string_to_index(CAi, AiIdx),
+    go_reg_index(CXn, XnIdx), go_reg_index(CAi, AiIdx),
     format(atom(GoLit), '&PutVariable{Xn: ~w, Ai: ~w}', [XnIdx, AiIdx]).
 wam_line_to_go_literal(["put_value", Xn, Ai], GoLit) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
-    go_reg_string_to_index(CXn, XnIdx), go_reg_string_to_index(CAi, AiIdx),
+    go_reg_index(CXn, XnIdx), go_reg_index(CAi, AiIdx),
     format(atom(GoLit), '&PutValue{Xn: ~w, Ai: ~w}', [XnIdx, AiIdx]).
 wam_line_to_go_literal(["put_structure", FN, Ai], GoLit) :-
     clean_comma(FN, CFN), clean_comma(Ai, CAi),
-    go_reg_string_to_index(CAi, AiIdx),
+    go_reg_index(CAi, AiIdx),
     format(atom(GoLit), '&PutStructure{Functor: "~w", Ai: ~w}', [CFN, AiIdx]).
 wam_line_to_go_literal(["put_list", Ai], GoLit) :-
     clean_comma(Ai, CAi),
-    go_reg_string_to_index(CAi, AiIdx),
+    go_reg_index(CAi, AiIdx),
     format(atom(GoLit), '&PutList{Ai: ~w}', [AiIdx]).
 wam_line_to_go_literal(["set_variable", Xn], GoLit) :-
     clean_comma(Xn, CXn),
-    go_reg_string_to_index(CXn, XnIdx),
+    go_reg_index(CXn, XnIdx),
     format(atom(GoLit), '&SetVariable{Xn: ~w}', [XnIdx]).
 wam_line_to_go_literal(["set_value", Xn], GoLit) :-
     clean_comma(Xn, CXn),
-    go_reg_string_to_index(CXn, XnIdx),
+    go_reg_index(CXn, XnIdx),
     format(atom(GoLit), '&SetValue{Xn: ~w}', [XnIdx]).
 wam_line_to_go_literal(["set_constant", C], GoLit) :-
     clean_comma(C, CC),
@@ -983,12 +983,12 @@ go_reg_index(y(N), Idx) :- !, Idx is N + 199.
 go_reg_index(Atom, Idx) :-
     atom(Atom), !,
     atom_string(Atom, Str),
-    go_reg_string_to_index(Str, Idx).
+    go_reg_index_str(Str, Idx).
 go_reg_index(Str, Idx) :-
     string(Str), !,
-    go_reg_string_to_index(Str, Idx).
+    go_reg_index_str(Str, Idx).
 
-go_reg_string_to_index(Str, Idx) :-
+go_reg_index_str(Str, Idx) :-
     (   sub_string(Str, 0, 1, _, "A"),
         sub_string(Str, 1, _, 0, NumStr),
         number_string(N, NumStr)
@@ -1641,7 +1641,13 @@ func (vm *WamState) enterIndexedAlternatives(targets []int) bool {
         return false
     }
     if len(targets) > 1 {
-        vm.pushIndexedChoicePoint(targets[1:])
+        // count non-nil A-regs as arity approximation when not statically known
+        arity := 0
+        for i := 0; i < 32; i++ {
+            if vm.Regs[i] != nil { arity = i + 1 }
+        }
+        if arity < 1 { arity = 1 }
+        vm.pushIndexedChoicePoint(targets[1:], arity)
     }
     vm.PC = targets[0]
     return true
@@ -2030,7 +2036,7 @@ func (vm *WamState) finishForeignResults(predKey string, resultRegs []int, resul
         trailMark := vm.TrailLen
         heapTop := vm.HeapLen
         for idx, result := range results {
-            vm.unwindTrail(trailMark)
+            vm.unwindTrailTo(trailMark)
             vm.Regs = baseRegs
             vm.Stack = copyStack(baseStack)
             if heapTop >= 0 && heapTop <= vm.HeapLen {

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -1453,11 +1453,14 @@ wam_go_case('SwitchOnConstant', '        if val := vm.Regs[0]; val != nil && !is
         return true').
 
 wam_go_case('SwitchOnConstantPc', '        if val := vm.Regs[0]; val != nil && !isUnbound(val) {
+            n := len(i.Cases)
+            idx := sort.Search(n, func(j int) bool {
+                return compareValues(i.Cases[j].Val, val) >= 0
+            })
             targets := make([]int, 0)
-            for _, c := range i.Cases {
-                if valueEquals(c.Val, val) {
-                    targets = append(targets, vm.indexedClauseBodyStart(c.TargetPC))
-                }
+            for idx < n && valueEquals(i.Cases[idx].Val, val) {
+                targets = append(targets, vm.indexedClauseBodyStart(i.Cases[idx].TargetPC))
+                idx++
             }
             if len(targets) > 0 {
                 return vm.enterIndexedAlternatives(targets)
@@ -1529,11 +1532,14 @@ wam_go_case('SwitchOnConstantA2', '        if val := vm.Regs[1]; val != nil && !
         return true').
 
 wam_go_case('SwitchOnConstantA2Pc', '        if val := vm.Regs[1]; val != nil && !isUnbound(val) {
+            n := len(i.Cases)
+            idx := sort.Search(n, func(j int) bool {
+                return compareValues(i.Cases[j].Val, val) >= 0
+            })
             targets := make([]int, 0)
-            for _, c := range i.Cases {
-                if valueEquals(c.Val, val) {
-                    targets = append(targets, vm.indexedClauseBodyStart(c.TargetPC))
-                }
+            for idx < n && valueEquals(i.Cases[idx].Val, val) {
+                targets = append(targets, vm.indexedClauseBodyStart(i.Cases[idx].TargetPC))
+                idx++
             }
             if len(targets) > 0 {
                 return vm.enterIndexedAlternatives(targets)
@@ -1726,6 +1732,9 @@ func resolveInstructions(code []Instruction, labels map[string]int) []Instructio
                 cases = append(cases, ConstPcCase{Val: c.Val, TargetPC: pc})
             }
             if complete {
+                sort.Slice(cases, func(a, b int) bool {
+                    return compareValues(cases[a].Val, cases[b].Val) < 0
+                })
                 resolved = append(resolved, &SwitchOnConstantPc{Cases: cases})
             } else {
                 resolved = append(resolved, instr)
@@ -1758,6 +1767,9 @@ func resolveInstructions(code []Instruction, labels map[string]int) []Instructio
                 cases = append(cases, ConstPcCase{Val: c.Val, TargetPC: pc})
             }
             if complete {
+                sort.Slice(cases, func(a, b int) bool {
+                    return compareValues(cases[a].Val, cases[b].Val) < 0
+                })
                 resolved = append(resolved, &SwitchOnConstantA2Pc{Cases: cases})
             } else {
                 resolved = append(resolved, instr)

--- a/templates/targets/go_wam/runtime.go.mustache
+++ b/templates/targets/go_wam/runtime.go.mustache
@@ -2,6 +2,7 @@ package {{package_name}}
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 )
 

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -161,9 +161,7 @@ func (vm *WamState) pushChoicePoint(nextPC int, arity int) {
 	})
 }
 
-func (vm *WamState) pushIndexedChoicePoint(pcs []int) {
-	// Save all A-regs (0..99) that are non-nil — use a reasonable default arity
-	arity := 100
+func (vm *WamState) pushIndexedChoicePoint(pcs []int, arity int) {
 	saved := make([]Value, arity)
 	copy(saved, vm.Regs[:arity])
 	vm.ChoicePoints = append(vm.ChoicePoints, ChoicePoint{
@@ -378,23 +376,22 @@ func (vm *WamState) Deref(v Value) Value {
 }
 
 func (vm *WamState) deref(v Value) Value {
-	// Depth limit guards against circular ref chains from bugs.
-	for i := 0; i < 10000; i++ {
-		if r, ok := v.(*Ref); ok {
-			next := vm.Heap[r.Addr]
+	for {
+		switch t := v.(type) {
+		case *Ref:
+			next := vm.Heap[t.Addr]
 			if next == v { return v }
 			v = next
-		} else if u, ok := v.(*Unbound); ok {
-			if boundVal := vm.Regs[u.Idx]; boundVal != nil && boundVal != v {
-				v = boundVal
+		case *Unbound:
+			if bound := vm.Regs[t.Idx]; bound != nil && bound != v {
+				v = bound
 			} else {
 				return v
 			}
-		} else {
+		default:
 			return v
 		}
 	}
-	return v
 }
 
 func (vm *WamState) evalArithmetic(v Value) (float64, bool) {
@@ -591,7 +588,7 @@ func (vm *WamState) backtrack() bool {
     topIdx := len(vm.ChoicePoints) - 1
     cp := vm.ChoicePoints[topIdx]
     if len(cp.IndexedClausePCs) > 0 {
-        vm.unwindTrail(cp.TrailMark)
+        vm.unwindTrailTo(cp.TrailMark)
         copy(vm.Regs[:len(cp.SavedRegs)], cp.SavedRegs)
         vm.Stack = copyStack(cp.Stack)
         if cp.HeapTop >= 0 && cp.HeapTop <= vm.HeapLen {
@@ -613,7 +610,7 @@ func (vm *WamState) backtrack() bool {
     }
     if len(cp.ForeignResults) > 0 {
         for len(cp.ForeignResults) > 0 {
-            vm.unwindTrail(cp.TrailMark)
+            vm.unwindTrailTo(cp.TrailMark)
             copy(vm.Regs[:len(cp.SavedRegs)], cp.SavedRegs)
             vm.Stack = copyStack(cp.Stack)
             if cp.HeapTop >= 0 && cp.HeapTop <= vm.HeapLen {
@@ -638,7 +635,7 @@ func (vm *WamState) backtrack() bool {
         }
         return false
     }
-    vm.unwindTrail(cp.TrailMark)
+    vm.unwindTrailTo(cp.TrailMark)
     copy(vm.Regs[:len(cp.SavedRegs)], cp.SavedRegs)
     vm.Stack = copyStack(cp.Stack)
     if cp.HeapTop >= 0 && cp.HeapTop <= vm.HeapLen {
@@ -652,13 +649,12 @@ func (vm *WamState) backtrack() bool {
     return true
 }
 
-func (vm *WamState) unwindTrail(mark int) {
-    for vm.TrailLen > mark {
-        vm.TrailLen--
-        entry := vm.Trail[vm.TrailLen]
-        vm.Regs[entry.Addr] = nil
+func (vm *WamState) unwindTrailTo(mark int) {
+    for i := vm.TrailLen - 1; i >= mark; i-- {
+        vm.Regs[vm.Trail[i].Addr] = nil
     }
-    vm.trailTrimTo(mark)
+    vm.Trail = vm.Trail[:mark]
+    vm.TrailLen = mark
 }
 
 // buildAtomInternTable interns all atom strings from fact pairs and weighted

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -2,6 +2,7 @@ package {{package_name}}
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"strconv"
 )
@@ -288,6 +289,39 @@ func parseFunctorName(f string) string {
 	return f
 }
 
+// compareValues returns <0, 0, or >0 for sort ordering of atoms/integers.
+func compareValues(a, b Value) int {
+	// Type ordering: Atom < Integer < Float < other
+	typeRank := func(v Value) int {
+		switch v.(type) {
+		case *Atom:    return 0
+		case *Integer: return 1
+		case *Float:   return 2
+		default:       return 3
+		}
+	}
+	ra, rb := typeRank(a), typeRank(b)
+	if ra != rb { return ra - rb }
+	switch ta := a.(type) {
+	case *Atom:
+		tb := b.(*Atom)
+		if ta.Name < tb.Name { return -1 }
+		if ta.Name > tb.Name { return 1 }
+		return 0
+	case *Integer:
+		tb := b.(*Integer)
+		if ta.Val < tb.Val { return -1 }
+		if ta.Val > tb.Val { return 1 }
+		return 0
+	case *Float:
+		tb := b.(*Float)
+		if ta.Val < tb.Val { return -1 }
+		if ta.Val > tb.Val { return 1 }
+		return 0
+	}
+	return 0
+}
+
 func isEmptyListValue(v Value) bool {
 	if atom, ok := v.(*Atom); ok {
 		return atom.Name == "[]"
@@ -404,6 +438,26 @@ func (vm *WamState) evalArithmetic(v Value) (float64, bool) {
 	}
 
 	f, args := decompose(v)
+	if len(args) == 1 {
+		a, okA := vm.evalArithmetic(args[0])
+		if !okA { return 0, false }
+		switch f {
+		case "-":
+			return -a, true
+		case "abs":
+			return math.Abs(a), true
+		case "sign":
+			if a > 0 { return 1, true }
+			if a < 0 { return -1, true }
+			return 0, true
+		case "float":
+			return a, true
+		case "truncate", "integer":
+			return float64(int64(a)), true
+		case "float_integer_part":
+			return math.Trunc(a), true
+		}
+	}
 	if len(args) == 2 {
 		a, okA := vm.evalArithmetic(args[0])
 		b, okB := vm.evalArithmetic(args[1])
@@ -426,6 +480,26 @@ func (vm *WamState) evalArithmetic(v Value) (float64, bool) {
 		case "mod":
 			if b == 0 { return 0, false }
 			return float64(int64(a) % int64(b)), true
+		case "abs":
+			return math.Abs(a), true
+		case "max":
+			if a > b { return a, true }
+			return b, true
+		case "min":
+			if a < b { return a, true }
+			return b, true
+		case "**", "^":
+			return math.Pow(a, b), true
+		case "/\\":
+			return float64(int64(a) & int64(b)), true
+		case "\\/":
+			return float64(int64(a) | int64(b)), true
+		case "xor":
+			return float64(int64(a) ^ int64(b)), true
+		case ">>":
+			return float64(int64(a) >> uint(int64(b))), true
+		case "<<":
+			return float64(int64(a) << uint(int64(b))), true
 		}
 	}
 	return 0, false

--- a/tests/bench_wam_go.pl
+++ b/tests/bench_wam_go.pl
@@ -1,0 +1,167 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (@s243a)
+%
+% bench_wam_go.pl — Benchmark suite for WAM-to-Go compilation
+%
+% Compares compile_wam_predicate_to_go/4 (interpreter mode) vs
+% direct wam_instruction_to_go_literal/2 (literal generation)
+% compilation throughput on three standard WAM benchmarks:
+% append/3, fib/2, member/2.
+%
+% Measures Prolog-side compilation time (how long it takes to generate
+% the Go code), not Go runtime execution.
+%
+% Usage: swipl -g run_benchmarks -t halt tests/bench_wam_go.pl
+
+:- module(bench_wam_go, [run_benchmarks/0]).
+
+:- use_module(library(lists)).
+:- use_module('../src/unifyweaver/targets/wam_go_target').
+
+% ============================================================================
+% Top-level entry
+% ============================================================================
+
+run_benchmarks :-
+	format("~n========================================~n"),
+	format("  WAM-to-Go Compilation Benchmark~n"),
+	format("========================================~n~n"),
+	bench_append,
+	bench_fibonacci,
+	bench_member,
+	format("~n========================================~n"),
+	format("  Benchmark complete~n"),
+	format("========================================~n~n").
+
+% ============================================================================
+% Benchmark 1: append/3
+% ============================================================================
+%
+% append([], Y, Y).
+% append([H|T], Y, [H|R]) :- append(T, Y, R).
+
+bench_append :-
+	format("=== append/3 benchmark ===~n"),
+	N = 10000,
+
+	% --- Interpreter mode (compile_wam_predicate_to_go/4) ---
+	AppendWam = 'append/3:\n  get_nil 1\n  get_value 3, 2\n  proceed',
+	time_compilation(append/3, AppendWam, N, InterpMs),
+	format("  compile_wam_predicate_to_go (~w iterations): ~w ms~n", [N, InterpMs]),
+
+	% --- Literal mode (wam_instruction_to_go_literal/2) ---
+	AppendInstrs = [
+		get_constant(atom([]), a(1)),
+		get_value(a(3), a(2)),
+		proceed
+	],
+	time_literal(AppendInstrs, N, LiteralMs),
+	format("  wam_instruction_to_go_literal (~w iterations): ~w ms~n", [N, LiteralMs]),
+
+	% --- Summary ---
+	(   LiteralMs > 0
+	->  Speedup is InterpMs / max(LiteralMs, 1),
+	    format("  Speedup: ~2fx~n~n", [Speedup])
+	;   format("  Speedup: N/A (literal too fast to measure)~n~n")
+	).
+
+% ============================================================================
+% Benchmark 2: fibonacci/2
+% ============================================================================
+%
+% fib(0, 0).
+% fib(1, 1).
+% fib(N, F) :- N > 1, N1 is N-1, N2 is N-2, fib(N1,F1), fib(N2,F2), F is F1+F2.
+
+bench_fibonacci :-
+	format("=== fibonacci/2 benchmark ===~n"),
+	N = 10000,
+
+	% --- Interpreter mode ---
+	FibWam = 'fib/2:\n  get_integer 0, 1\n  get_integer 0, 2\n  proceed',
+	time_compilation(fib/2, FibWam, N, InterpMs),
+	format("  compile_wam_predicate_to_go (~w iterations): ~w ms~n", [N, InterpMs]),
+
+	% --- Literal mode (base case) ---
+	FibInstrs = [
+		get_constant(integer(0), a(1)),
+		get_constant(integer(0), a(2)),
+		proceed
+	],
+	time_literal(FibInstrs, N, LiteralMs),
+	format("  wam_instruction_to_go_literal (~w iterations): ~w ms~n", [N, LiteralMs]),
+
+	% --- Summary ---
+	(   LiteralMs > 0
+	->  Speedup is InterpMs / max(LiteralMs, 1),
+	    format("  Speedup: ~2fx~n~n", [Speedup])
+	;   format("  Speedup: N/A~n~n")
+	).
+
+% ============================================================================
+% Benchmark 3: member/2
+% ============================================================================
+%
+% member(X, [X|_]).
+% member(X, [_|T]) :- member(X, T).
+
+bench_member :-
+	format("=== member/2 benchmark ===~n"),
+	N = 10000,
+
+	% --- Interpreter mode ---
+	MemberWam = 'member/2:\n  get_list 2\n  unify_value 1\n  unify_void 1\n  proceed',
+	time_compilation(member/2, MemberWam, N, InterpMs),
+	format("  compile_wam_predicate_to_go (~w iterations): ~w ms~n", [N, InterpMs]),
+
+	% --- Literal mode (clause 1) ---
+	MemberInstrs = [
+		get_list(a(2)),
+		unify_value(a(1)),
+		proceed
+	],
+	time_literal(MemberInstrs, N, LiteralMs),
+	format("  wam_instruction_to_go_literal (~w iterations): ~w ms~n", [N, LiteralMs]),
+
+	% --- Summary ---
+	(   LiteralMs > 0
+	->  Speedup is InterpMs / max(LiteralMs, 1),
+	    format("  Speedup: ~2fx~n~n", [Speedup])
+	;   format("  Speedup: N/A (literal too fast to measure)~n~n")
+	).
+
+% ============================================================================
+% Timing helpers
+% ============================================================================
+
+%% time_compilation(+PredIndicator, +WamCode, +N, -Ms)
+%  Time N iterations of compile_wam_predicate_to_go/4.
+time_compilation(PredIndicator, WamCode, N, Ms) :-
+	get_time(T0),
+	forall(
+		between(1, N, _),
+		(   compile_wam_predicate_to_go(PredIndicator, WamCode, [], _Code)
+		->  true
+		;   true
+		)
+	),
+	get_time(T1),
+	Ms is round((T1 - T0) * 1000).
+
+%% time_literal(+Instrs, +N, -Ms)
+%  Time N iterations of wam_instruction_to_go_literal/2.
+time_literal(Instrs, N, Ms) :-
+	get_time(T0),
+	forall(
+		between(1, N, _),
+		forall(
+			member(Instr, Instrs),
+			(   wam_instruction_to_go_literal(Instr, _GoLit)
+			->  true
+			;   true
+			)
+		)
+	),
+	get_time(T1),
+	Ms is round((T1 - T0) * 1000).


### PR DESCRIPTION
## Summary

- **Bug A**: Combine redundant `unwindTrail` + `trailTrimTo` into single `unwindTrailTo` method that unbinds and trims in one pass
- **Bug B**: `pushIndexedChoicePoint` now accepts arity parameter; `enterIndexedAlternatives` computes arity from non-nil A-regs instead of hardcoding 100
- **Bug C**: Remove `deref` 10000-iteration limit (which silently hid circular ref bugs); use clean switch-based infinite loop
- **Bug D**: Consolidate `go_reg_string_to_index` into `go_reg_index`, eliminating the redundant string-key register access path
- **Perf E**: `evalArithmetic` now supports unary ops (`-`, `abs`, `sign`, `float`, `truncate`, `float_integer_part`), binary ops (`abs`, `max`, `min`, `**`/`^`), and bitwise ops (`/\`, `\/`, `xor`, `>>`, `<<`)
- **Perf F**: Add `tests/bench_wam_go.pl` benchmarking WAM-to-Go compilation throughput for append/3, fib/2, member/2
- **Perf G**: `SwitchOnConstantPc` and `SwitchOnConstantA2Pc` use `sort.Search` binary search instead of linear scan; cases sorted at resolution time via `compareValues`

## Test plan

- [ ] Verify existing WAM Go tests pass (`test_wam_go_generator.pl`, `test_wam_go_foreign_lowering.pl`)
- [ ] Run `swipl -g run_benchmarks -t halt tests/bench_wam_go.pl` to verify benchmark file loads
- [ ] Verify generated Go code compiles with `go build` for a sample project
- [ ] Spot-check `unwindTrailTo` method correctness on backtracking scenarios
- [ ] Verify `compareValues` ordering is consistent (atoms < integers < floats)

🤖 Generated with [Claude Code](https://claude.com/claude-code)