### PR TITLE
fix(wam-elixir): implement cut, separate A/X reg ranges, repair backtrack exceptions

### DIFF
--- a/docs/design/WAM_ELIXIR_CORRECTNESS_GAPS.md
+++ b/docs/design/WAM_ELIXIR_CORRECTNESS_GAPS.md
@@ -1,0 +1,114 @@
+# WAM-Elixir — Correctness Gaps
+
+Running status doc for correctness issues in the Elixir target surfaced
+while attempting to benchmark Phase A+B+C optimizations on
+`examples/benchmark/effective_distance.pl`. The pipeline compiles and
+executes but has produced progressively less-wrong output as each
+blocker has been removed.
+
+## Fixed
+
+### `!/0` (cut) not implemented in `execute_builtin`
+
+`WamRuntime.execute_builtin/3` had no arm for `!/0`; unknown ops hit the
+`_ -> :fail` catch-all, so every clause with a cut (including
+`category_ancestor/4`'s recursive arm) threw `:fail` at the cut call.
+Added an arm that clears `choice_points` and advances `pc` — a
+conservative approximation matching the green-cut usage the compiler
+emits. Proper WAM cut-barrier semantics would prune only to the
+clause's saved barrier; not needed by current codegen.
+
+### A and X register namespace collision in `reg_id/2`
+
+`wam_elixir_utils.pl`'s `reg_id/2` mapped both `A1` and `X1` to integer
+id `1`. The WAM compiler freely emits sequences like `get_variable X3,
+A1` while `A3` is still live — under the collision, the store
+clobbered `A3` before the next `A3` read, so head unification
+consistently failed. Reg banks now map to distinct integer ranges:
+
+- `A1..A99` → `1..99`
+- `X1..X99` → `101..199`
+- `Y1..Y99` → `201..299`
+
+This matches the Haskell target's `reg_name_to_int` convention.
+
+### `write_ctx` leak from `put_structure` / `put_list` in lowered emitter
+
+The lowered emitter emitted `[{:write_ctx, N} | state.stack]` after
+`put_structure` / `put_list`, mirroring the interpreter. But the
+lowered forms of `set_variable` / `set_value` inline heap writes
+directly — they never consume the ctx. Subsequent `deallocate` popped
+`{:write_ctx, 2}` expecting an env map and raised `BadMapError`.
+Solution: stop pushing the ctx in put-mode — `set_*` don't need it.
+`get_structure` / `get_list` still push it because `unify_variable` /
+`unify_value` go through the runtime, which does consume it.
+
+### `WamDispatcher.call` had no builtin fallback
+
+Meta-calls (e.g. `\+ member(Parent, Visited)`) reach
+`WamDispatcher.call("member/2", state)` at runtime. The dispatcher only
+knew about user-compiled modules; unknown predicates threw
+`{:undefined_predicate, pred}` which surfaced as a crash on every
+negation-as-failure over a builtin. The generated default clause now
+falls through to `WamRuntime.execute_builtin` before throwing.
+
+### `backtrack/1` didn't catch exceptions from retried clauses
+
+When `backtrack/1` invoked `cp.pc.(state)` to resume the next clause,
+that clause could `throw :fail` (its own guards failed) or `throw
+{:return, result}`. Both exceptions escaped `backtrack` instead of
+being translated back into the `{:ok, state} | :fail` contract —
+callers that hold state across multiple backtrack steps (e.g. the bench
+driver's `execute_backtrack/2` loop) crashed on the first failure.
+Added a `try`/`catch` that re-enters `backtrack` on `:fail` and unwraps
+`{:return, _}`.
+
+## Status
+
+At dev scale (19-row reference), the pipeline now produces 3 rows with
+non-trivial effective distances — up from 2 rows of pure root-matches
+before any fix. That means single-hop `category_ancestor` succeeds and
+some backtracking works, but multi-hop recursion still does not find
+all paths. Reference expects articles like `Nuclear_physics`,
+`Gravitational_constant`, `Statistical_mechanics` at distance ≈ 2.5–2.9;
+these are absent from the generated output.
+
+## Likely remaining root causes
+
+Speculative — investigation hasn't pinned these yet:
+
+- **Choice-point state capture for recursive calls.** CPs save
+  `regs`, `heap`, `heap_len`, `trail`, `trail_len`, `stack`, `cp`. But
+  the `stack` field holds both env frames and transient unify-mode
+  markers; if any get-structure path leaves an unbalanced stack, CP
+  restore reinstates the wrong env height.
+- **`allocate` / `deallocate` pairing across recursive `call`s.** The
+  lowered emitter's `allocate` pushes a fresh env; `deallocate` pops
+  one. Recursive `category_ancestor(Mid, Ancestor, H1, [Mid|Visited])`
+  calls back into the same predicate with new args; if the env stack
+  isn't saved/restored correctly across nested `call`s, Y-register
+  values go stale.
+- **`unify_value` / `unify_variable` in read mode against already-bound
+  heap cells.** Lowered `step_get_structure_ref` sets up the
+  read-mode context; if the following `unify_value` paths don't
+  correctly dereference, unification against the parent category may
+  silently succeed when it shouldn't (or fail when it should).
+
+A minimal reproducer — a recursive hand-written `ancestor/2` over a
+tiny fact set — would isolate which of these is the issue without the
+full benchmark's scaffolding.
+
+## Out of scope for this doc
+
+- `switch_on_constant` duplicate-key warnings were fixed in an earlier
+  PR (`fix/wam-elixir-switch-dedup-arms`).
+- Performance-oriented work (Phase A/B/C) landed separately and is
+  unrelated to these correctness gaps.
+
+## Implication for benchmarking
+
+Phase A+B+C numbers remain unmeasurable until the remaining recursion
+correctness is resolved. The existing benchmark driver will accept the
+partially-correct output and produce a timing number, but those
+numbers would compare against Haskell/Rust results for different
+computations — not meaningful.

--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -283,7 +283,6 @@ wam_elixir_lower_instr(get_value(XnName, AiName), _PC, _Labels, _FuncName, Code)
 
 wam_elixir_lower_instr(put_structure(F, AiName), _PC, _Labels, _FuncName, Code) :-
     reg_id(AiName, Ai),
-    parse_arity(F, Arity),
     format(string(Code),
 '    addr = state.heap_len
     new_heap = Map.put(state.heap, addr, {:str, "~w"})
@@ -291,8 +290,7 @@ wam_elixir_lower_instr(put_structure(F, AiName), _PC, _Labels, _FuncName, Code) 
     |> WamRuntime.trail_binding(~w)
     |> Map.put(:regs, Map.put(state.regs, ~w, {:ref, addr}))
     |> Map.put(:heap, new_heap)
-    |> Map.put(:heap_len, addr + 1)
-    |> Map.put(:stack, [{:write_ctx, ~w} | state.stack])', [F, Ai, Ai, Arity]).
+    |> Map.put(:heap_len, addr + 1)', [F, Ai, Ai]).
 
 wam_elixir_lower_instr(get_structure(F, AiName), _PC, _Labels, _FuncName, Code) :-
     reg_id(AiName, Ai),
@@ -409,8 +407,7 @@ wam_elixir_lower_instr(put_list(AiName), _PC, _Labels, _FuncName, Code) :-
     |> WamRuntime.trail_binding(~w)
     |> Map.put(:regs, Map.put(state.regs, ~w, {:ref, addr}))
     |> Map.put(:heap, new_heap)
-    |> Map.put(:heap_len, addr + 1)
-    |> Map.put(:stack, [{:write_ctx, 2} | state.stack])', [Ai, Ai]).
+    |> Map.put(:heap_len, addr + 1)', [Ai, Ai]).
 
 wam_elixir_lower_instr(get_list(AiName), _PC, _Labels, _FuncName, Code) :-
     reg_id(AiName, Ai),

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -372,7 +372,16 @@ compile_backtrack_to_elixir(Code) :-
         |> Map.put(:choice_points, rest)
 
         if is_function(cp.pc) do
-          cp.pc.(state)
+          # The retried clause may throw :fail (its own guards failed) or
+          # {:return, result} (it succeeded). Translate back into the
+          # {:ok, state} | :fail contract so the caller does not need to
+          # know about clause-local control flow.
+          try do
+            cp.pc.(state)
+          catch
+            :fail -> backtrack(state)
+            {:return, result} -> result
+          end
         else
           {:ok, state}
         end
@@ -656,6 +665,13 @@ compile_utility_helpers_to_elixir(Code) :-
             if item in list, do: %{state | pc: new_pc}, else: :fail
           true -> :fail
         end
+      {"!/0", 0} ->
+        # Cut: discard all choice points accumulated in this clause.
+        # Conservative (prunes more than strict WAM cut-barrier semantics
+        # would) but matches green-cut usage — the only form currently
+        # emitted by the compiler.
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        %{state | choice_points: [], pc: new_pc}
       _ -> :fail
     end
   end
@@ -973,5 +989,15 @@ generate_elixir_dispatcher(Predicates, Options, Code) :-
   @moduledoc "Global dispatcher for dynamic WAM calls"
 
 ~w
-  def call(pred, _state), do: throw({:undefined_predicate, pred})
+  # Fallback: meta-calls (e.g. \\+ Goal) may target builtins whose
+  # module the compiler didn\'t register. Try the builtin table before
+  # declaring the predicate undefined.
+  def call(pred, state) do
+    arity = WamRuntime.parse_functor_arity(pred)
+    case WamRuntime.execute_builtin(state, pred, arity) do
+      :fail -> :fail
+      new_state when is_map(new_state) -> {:ok, new_state}
+      _ -> throw({:undefined_predicate, pred})
+    end
+  end
 end', [CasesStr]).

--- a/src/unifyweaver/targets/wam_elixir_utils.pl
+++ b/src/unifyweaver/targets/wam_elixir_utils.pl
@@ -35,12 +35,19 @@ capitalize_string(Str, Cap) :-
 
 %% reg_id(+Reg, -Id)
 % Maps string/atom WAM register names to integer IDs for Elixir.
-% Y-registers are offset by 100 to avoid collision with X/A registers (1-99).
+% Each register bank gets its own integer range to avoid aliasing:
+%   A1..A99 -> 1..99     (argument registers, callee-visible)
+%   X1..X99 -> 101..199  (temporary registers, clause-local)
+%   Y1..Y99 -> 201..299  (permanent registers, environment-local)
+% A and X must be in distinct ranges because the WAM compiler freely
+% emits instructions like `get_variable X3, A1` while A3 is still live —
+% if both mapped to id 3 the store would clobber A3 before the next A3
+% read. Matches the Haskell target's reg_name_to_int convention.
 reg_id(Reg, Id) :-
     (atom(Reg) -> RegAtom = Reg ; atom_string(RegAtom, Reg)),
     (   sub_atom(RegAtom, 0, 1, _, 'A') -> sub_atom(RegAtom, 1, _, 0, Num), atom_number(Num, Id)
-    ;   sub_atom(RegAtom, 0, 1, _, 'X') -> sub_atom(RegAtom, 1, _, 0, Num), atom_number(Num, Id)
-    ;   sub_atom(RegAtom, 0, 1, _, 'Y') -> sub_atom(RegAtom, 1, _, 0, Num), atom_number(Num, N), Id is N + 100
+    ;   sub_atom(RegAtom, 0, 1, _, 'X') -> sub_atom(RegAtom, 1, _, 0, Num), atom_number(Num, N), Id is N + 100
+    ;   sub_atom(RegAtom, 0, 1, _, 'Y') -> sub_atom(RegAtom, 1, _, 0, Num), atom_number(Num, N), Id is N + 200
     ;   Id = Reg
     ).
 

--- a/tests/test_wam_elixir_utils.pl
+++ b/tests/test_wam_elixir_utils.pl
@@ -39,22 +39,25 @@ test_is_label_part_invalid :-
 % --- reg_id/2 tests ---
 
 test_reg_id_x_a :-
-    Test = 'reg_id/2: X and A registers',
-    (   reg_id("X1", IdX1), integer(IdX1), IdX1 = 1,
+    Test = 'reg_id/2: X and A registers (distinct ranges)',
+    (   reg_id("A1", IdA1), integer(IdA1), IdA1 = 1,
         reg_id("A2", IdA2), integer(IdA2), IdA2 = 2,
-        reg_id('X99', 99),
-        reg_id('A100', 100) % Valid syntactically although A1-A99 are more common
+        reg_id('A99', 99),
+        reg_id("X1", IdX1), integer(IdX1), IdX1 = 101,
+        reg_id("X2", 102),
+        reg_id('X99', 199),
+        IdA1 \= IdX1   % The bug this test guards against: A/X collision
     ->  pass(Test)
-    ;   fail_test(Test, 'failed mapping X/A registers')
+    ;   fail_test(Test, 'failed mapping X/A registers into distinct ranges')
     ).
 
 test_reg_id_y :-
-    Test = 'reg_id/2: Y registers',
-    (   reg_id("Y1", IdY1), integer(IdY1), IdY1 = 101,
-        reg_id("Y2", 102),
-        reg_id('Y99', 199)
+    Test = 'reg_id/2: Y registers (+200 offset)',
+    (   reg_id("Y1", IdY1), integer(IdY1), IdY1 = 201,
+        reg_id("Y2", 202),
+        reg_id('Y99', 299)
     ->  pass(Test)
-    ;   fail_test(Test, 'failed mapping Y registers with 100 offset')
+    ;   fail_test(Test, 'failed mapping Y registers with 200 offset')
     ).
 
 test_reg_id_fallback :-


### PR DESCRIPTION
## Summary

Five correctness fixes in the WAM-Elixir target that together unblock
execution of recursive predicates using cut and negation-as-failure.
Discovered while trying to benchmark Phase A+B+C on
`examples/benchmark/effective_distance.pl` — the pipeline compiled and
ran but produced only 2 rows of "article is a direct member of root"
results instead of the reference 19.

The first two bugs were previously flagged in
`docs/design/WAM_ELIXIR_CORRECTNESS_GAPS.md` (landed with the switch
dedup PR, #1452). The remaining three were exposed once the first two
were fixed — earlier the pipeline crashed before reaching them.

### 1. `!/0` (cut) not implemented

`WamRuntime.execute_builtin/3` had no arm for `!/0`; unknown ops hit
`_ -> :fail`, so every clause with a cut — including
`category_ancestor/4`'s recursive clause — threw `:fail` at the cut
call. Added an arm that clears `choice_points` and advances `pc`. This
is a conservative approximation of WAM cut semantics (strict cut would
prune only to the clause's saved barrier), but it matches the
green-cut form the compiler emits.

### 2. A and X register namespace collision

`reg_id/2` mapped `A1` and `X1` both to id `1`. The compiler freely
emits `get_variable X3, A1` while `A3` is still live, and the store
clobbered `A3` before its next read. Now A / X / Y get distinct ranges
(`1-99` / `101-199` / `201-299`), matching the Haskell target's
`reg_name_to_int` convention.

### 3. `write_ctx` leak from `put_structure` / `put_list`

Lowered `put_structure` / `put_list` pushed `{:write_ctx, N}` on the
stack (mirroring the interpreter), but lowered `set_variable` /
`set_value` inline heap writes directly — they never consume the ctx.
Subsequent `deallocate` popped the residual `{:write_ctx, 2}` tuple
expecting an env map → `BadMapError`. Stop pushing the ctx in put-mode;
`get_structure` / `get_list` still push it because their `unify_*`
follow-ups go through the runtime, which does consume it.

### 4. `WamDispatcher.call` had no builtin fallback

Meta-calls like `\+ member(Parent, Visited)` route through
`WamDispatcher.call("member/2", state)` at runtime. The dispatcher
only knew user-compiled modules; unknown predicates threw
`{:undefined_predicate, pred}` and crashed negation-as-failure over
any builtin. The generated default clause now tries
`WamRuntime.execute_builtin` first.

### 5. `backtrack/1` let clause exceptions escape

`backtrack/1` invokes `cp.pc.(state)` to re-enter the next clause, but
didn't catch the `:fail` or `{:return, _}` throws that clause may
raise. External drivers of backtracking (the bench driver's
`execute_backtrack/2` loop) saw raw exceptions instead of the
documented `{:ok, state} | :fail` contract. Added `try`/`catch` that
cascades to the next CP on `:fail` and unwraps `{:return, _}`.

## Verification

- `tests/test_wam_elixir_target.pl` — 14/14 pass
- `tests/test_wam_elixir_utils.pl` — 7/7 pass (including an added
  regression guard that A/X now map to distinct ids)
- `effective_distance` dev scale now runs end-to-end (was crashing).
  Rows: 2 → 3. Output sha changed.

## Not solved

Full dev-scale reference has 19 rows. Only 3 currently appear —
multi-hop recursion is still not finding longer paths. Likely causes
(choice-point stack height, nested `allocate` / `deallocate`
interaction with recursive `call`) are documented in
`docs/design/WAM_ELIXIR_CORRECTNESS_GAPS.md` under "Likely remaining
root causes."

## Test plan

- [ ] `swipl -g run_tests -t halt tests/test_wam_elixir_target.pl`
- [ ] `swipl -g run_tests -t halt tests/test_wam_elixir_utils.pl`
- [ ] `python3 examples/benchmark/benchmark_wam_elixir_effective_distance.py --scales dev` (should run without crashing)

---
*Co-authored-By: Claude Opus 4.7 (1M context)*
