### PR TITLE
Go WAM: benchmark/profiling infrastructure parity with Haskell

### DIFF
--- a/docs/design/BENCHMARK_TARGET_MATRIX.md
+++ b/docs/design/BENCHMARK_TARGET_MATRIX.md
@@ -60,7 +60,9 @@ So Rust already has both:
 
 ### Go
 
-Go now has two effective-distance benchmark paths.
+Go now has two effective-distance benchmark paths, with full support for the
+lowered emitter (`emit_mode(functions)`) and goroutine-based parallel execution
+(`parallel(true)`) via the package-level `RunParallel` on `WamContext`.
 
 Direct pipeline path:
 
@@ -73,6 +75,23 @@ Hybrid WAM Go path:
 2. Run `prolog_target` optimization passes.
 3. Force the selected predicates through the shared Go WAM path.
 4. Emit a Go benchmark driver that queries the compiled VM directly.
+
+The relevant modes are (mirroring Haskell):
+
+- `interpreter + no_kernels(true)` -> pure interpreter baseline
+- `interpreter + kernels enabled` -> hybrid WAM + FFI
+- `functions + no_kernels(true)` -> lowered-only (deterministic predicate-as-function)
+- `functions + kernels enabled` -> lowered functions with WAM fallback + FFI
+
+Optimized benchmark pipeline (mirrors `generate_wam_haskell_optimized_benchmark.pl`):
+
+1. Load the workload Prolog.
+2. Run `prolog_target` optimization passes (seeded accumulation).
+3. Load the generated optimized predicates back into Prolog.
+4. Emit a WAM Go project with `write_wam_go_project/3` using
+   `emit_mode(functions)` and `parallel(true)`.
+
+Script: `examples/benchmark/generate_wam_go_optimized_benchmark.pl`
 
 That means Go can now participate in:
 
@@ -133,6 +152,8 @@ New scripts:
 - `examples/benchmark/benchmark_effective_distance_matrix.py`
 - `examples/benchmark/generate_wam_haskell_matrix_benchmark.pl`
 - `examples/benchmark/generate_wam_go_effective_distance_benchmark.pl`
+- `examples/benchmark/generate_wam_go_optimized_benchmark.pl`
+- `examples/benchmark/gen_prof_matrix.pl` (4 Haskell + 4 Go profiling configs)
 
 Examples:
 

--- a/examples/benchmark/gen_prof_matrix.pl
+++ b/examples/benchmark/gen_prof_matrix.pl
@@ -1,6 +1,7 @@
 :- initialization(main, main).
 
 :- use_module('../../src/unifyweaver/targets/wam_haskell_target').
+:- use_module('../../src/unifyweaver/targets/wam_go_target').
 :- use_module('../../src/unifyweaver/targets/wam_target').
 :- use_module('../../src/unifyweaver/targets/prolog_target').
 :- use_module(library(option)).
@@ -8,24 +9,36 @@
 
 %% gen_prof_matrix.pl
 %%
-%% Generates 4 Haskell WAM profiling configurations from optimized Prolog:
+%% Generates 4 Haskell + 4 Go WAM profiling configurations from optimized
+%% Prolog:
 %%
-%%   A: pure-interp    — emit_mode(interpreter), no_kernels(true)
-%%   B: interp-ffi     — emit_mode(interpreter), kernels enabled
-%%   C: lowered-only   — emit_mode(functions),   no_kernels(true)
-%%   D: lowered-ffi    — emit_mode(functions),   kernels enabled
+%%   Haskell:
+%%     A: pure-interp    — emit_mode(interpreter), no_kernels(true)
+%%     B: interp-ffi     — emit_mode(interpreter), kernels enabled
+%%     C: lowered-only   — emit_mode(functions),   no_kernels(true)
+%%     D: lowered-ffi    — emit_mode(functions),   kernels enabled
 %%
-%% All configurations use GHC profiling (-prof -fprof-auto -rtsopts)
-%% so you can run with +RTS -p to get cost-centre profiling output.
+%%   Go:
+%%     E: go-pure-interp  — emit_mode(interpreter), no_kernels(true)
+%%     F: go-interp-ffi   — emit_mode(interpreter), kernels enabled
+%%     G: go-lowered-only — emit_mode(functions),   no_kernels(true)
+%%     H: go-lowered-ffi  — emit_mode(functions),   kernels enabled
+%%
+%% Haskell configurations use GHC profiling (-prof -fprof-auto -rtsopts).
+%% Go configurations are profiled via `go tool pprof` (CPU profiling).
 %%
 %% Usage:
 %%   swipl -q -s gen_prof_matrix.pl -- <facts.pl> <output-base-dir>
 %%
 %% Generates:
-%%   <output-base-dir>/A-pure-interp/
-%%   <output-base-dir>/B-interp-ffi/
-%%   <output-base-dir>/C-lowered-only/
-%%   <output-base-dir>/D-lowered-ffi/
+%%   <output-base-dir>/A-pure-interp/       (Haskell)
+%%   <output-base-dir>/B-interp-ffi/        (Haskell)
+%%   <output-base-dir>/C-lowered-only/      (Haskell)
+%%   <output-base-dir>/D-lowered-ffi/       (Haskell)
+%%   <output-base-dir>/E-go-pure-interp/    (Go)
+%%   <output-base-dir>/F-go-interp-ffi/     (Go)
+%%   <output-base-dir>/G-go-lowered-only/   (Go)
+%%   <output-base-dir>/H-go-lowered-ffi/    (Go)
 
 benchmark_workload_path(Path) :-
     source_file(benchmark_workload_path(_), ThisFile),
@@ -69,7 +82,7 @@ generate_all(OutputBase) :-
     load_files(TmpPath, [silent(true)]),
     delete_file(TmpPath),
 
-    % Step 4: Generate all 4 configurations
+    % Step 4: Generate all 8 configurations (4 Haskell + 4 Go)
     Predicates = [
         user:dimension_n/1,
         user:max_depth/1,
@@ -81,21 +94,34 @@ generate_all(OutputBase) :-
     ],
     QueryPredOpts = [query_pred('category_ancestor$effective_distance_sum_selected/3')],
 
-    configs(Configs),
+    haskell_configs(HaskellConfigs),
     forall(
-        member(config(Label, EmitMode, NoKernels), Configs),
-        generate_config(OutputBase, Label, EmitMode, NoKernels, Predicates, QueryPredOpts)
+        member(config(Label, EmitMode, NoKernels), HaskellConfigs),
+        generate_haskell_config(OutputBase, Label, EmitMode, NoKernels, Predicates, QueryPredOpts)
     ),
-    format(user_error, '~n[prof-matrix] All 4 configurations generated under ~w~n', [OutputBase]).
 
-configs([
+    go_configs(GoConfigs),
+    forall(
+        member(config(Label, EmitMode, NoKernels), GoConfigs),
+        generate_go_config(OutputBase, Label, EmitMode, NoKernels, Predicates)
+    ),
+    format(user_error, '~n[prof-matrix] All 8 configurations generated under ~w~n', [OutputBase]).
+
+haskell_configs([
     config('A-pure-interp',  interpreter, true),
     config('B-interp-ffi',   interpreter, false),
     config('C-lowered-only', functions,   true),
     config('D-lowered-ffi',  functions,   false)
 ]).
 
-generate_config(OutputBase, Label, EmitMode, NoKernels, Predicates, QueryPredOpts) :-
+go_configs([
+    config('E-go-pure-interp',  interpreter, true),
+    config('F-go-interp-ffi',   interpreter, false),
+    config('G-go-lowered-only', functions,   true),
+    config('H-go-lowered-ffi',  functions,   false)
+]).
+
+generate_haskell_config(OutputBase, Label, EmitMode, NoKernels, Predicates, QueryPredOpts) :-
     format(atom(OutputDir), '~w/~w', [OutputBase, Label]),
     format(atom(ModName), 'wam-prof-~w', [Label]),
     BaseOpts = [
@@ -108,7 +134,29 @@ generate_config(OutputBase, Label, EmitMode, NoKernels, Predicates, QueryPredOpt
     ;   KernelOpts = []
     ),
     append([BaseOpts, KernelOpts, QueryPredOpts], Options),
-    format(user_error, '[prof-matrix] Generating ~w (emit_mode=~w, no_kernels=~w)~n',
+    format(user_error, '[prof-matrix] Generating Haskell ~w (emit_mode=~w, no_kernels=~w)~n',
            [Label, EmitMode, NoKernels]),
     write_wam_haskell_project(Predicates, Options, OutputDir),
+    format(user_error, '[prof-matrix] ~w -> ~w~n', [Label, OutputDir]).
+
+generate_go_config(OutputBase, Label, EmitMode, NoKernels, Predicates) :-
+    format(atom(OutputDir), '~w/~w', [OutputBase, Label]),
+    format(atom(ModName), 'wam-prof-~w', [Label]),
+    BaseOpts = [
+        module_name(ModName),
+        package_name(main),
+        prefer_wam(true),
+        wam_fallback(true),
+        foreign_lowering(true),
+        emit_mode(EmitMode),
+        parallel(true)
+    ],
+    (   NoKernels == true
+    ->  KernelOpts = [no_kernels(true)]
+    ;   KernelOpts = []
+    ),
+    append(BaseOpts, KernelOpts, Options),
+    format(user_error, '[prof-matrix] Generating Go ~w (emit_mode=~w, no_kernels=~w)~n',
+           [Label, EmitMode, NoKernels]),
+    write_wam_go_project(Predicates, Options, OutputDir),
     format(user_error, '[prof-matrix] ~w -> ~w~n', [Label, OutputDir]).

--- a/examples/benchmark/generate_wam_go_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_go_effective_distance_benchmark.pl
@@ -70,7 +70,9 @@ generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom) :-
          package_name(main),
          prefer_wam(true),
          wam_fallback(true),
-         foreign_lowering(true)],
+         foreign_lowering(true),
+         emit_mode(functions),
+         parallel(true)],
         KernelOptions
     ], Options),
     write_wam_go_project(Predicates, Options, OutputDir),

--- a/examples/benchmark/generate_wam_go_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_go_optimized_benchmark.pl
@@ -1,0 +1,125 @@
+:- initialization(main, main).
+
+:- use_module('../../src/unifyweaver/targets/wam_go_target').
+:- use_module('../../src/unifyweaver/targets/wam_target').
+:- use_module('../../src/unifyweaver/targets/prolog_target').
+:- use_module(library(option)).
+:- use_module(library(lists)).
+
+%% generate_wam_go_optimized_benchmark.pl
+%%
+%% Generates a Go WAM benchmark from OPTIMIZED Prolog.
+%%
+%% Pipeline:
+%%   1. Load the effective-distance Prolog workload + facts
+%%   2. Generate optimized predicates via prolog_target (seeded accumulation)
+%%   3. Load the generated script to assert optimized helper predicates
+%%   4. Compile ALL predicates (base + generated) to WAM -> Go
+%%
+%% This bridges the Prolog optimization passes with the WAM Go target,
+%% ensuring the WAM compiler sees the same optimized predicates that make
+%% the SWI-Prolog benchmarks fast.
+%%
+%% Usage:
+%%   swipl -q -s generate_wam_go_optimized_benchmark.pl -- \
+%%       <facts.pl> <output-dir> [accumulated|seeded]
+%%
+%% Variants:
+%%   seeded      - base category_ancestor + power_sum_bound (no helpers)
+%%   accumulated - full seeded accumulation with effective_distance_sum helpers
+
+benchmark_workload_path(Path) :-
+    source_file(benchmark_workload_path(_), ThisFile),
+    file_directory_name(ThisFile, Here),
+    directory_file_path(Here, 'effective_distance.pl', Path).
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv = [_FactsPath, OutputDir, VariantAtom]
+    ->  true
+    ;   Argv = [_FactsPath, OutputDir]
+    ->  VariantAtom = accumulated  % default
+    ;   format(user_error,
+            'Usage: ... -- <facts.pl> <output-dir> [accumulated|seeded]~n', []),
+        halt(1)
+    ),
+    generate(VariantAtom, OutputDir),
+    halt(0).
+
+main :-
+    format(user_error, 'Error: generation failed~n', []),
+    halt(1).
+
+generate(VariantAtom, OutputDir) :-
+    % Step 1: Load the base workload
+    benchmark_workload_path(WorkloadPath),
+    load_files(WorkloadPath, [silent(true)]),
+    retractall(user:mode(category_ancestor(_, _, _, _))),
+    assertz(user:mode(category_ancestor(-, +, -, +))),
+
+    % Step 2: Generate optimized Prolog via prolog_target
+    parse_variant(VariantAtom, OptimizationOptions),
+    BasePreds = [dimension_n/1, max_depth/1, category_ancestor/4],
+    prolog_target:generate_prolog_script(BasePreds, OptimizationOptions, ScriptCode),
+
+    % Step 3: Write to temp file and load it to assert the generated predicates
+    tmp_file_stream(text, TmpPath, TmpStream),
+    write(TmpStream, ScriptCode),
+    close(TmpStream),
+    load_files(TmpPath, [silent(true)]),
+    delete_file(TmpPath),
+
+    % Step 4: Collect all relevant predicates (base + generated helpers)
+    collect_wam_predicates(VariantAtom, Predicates),
+    format(user_error, '[WAM-Go-Optimized] variant=~w predicates=~w~n',
+           [VariantAtom, Predicates]),
+
+    % Step 5: Generate Go WAM project with lowered emitter and parallel support
+    Options = [module_name('wam-go-optimized-bench'),
+               package_name(main),
+               prefer_wam(true),
+               wam_fallback(true),
+               foreign_lowering(true),
+               emit_mode(functions),
+               parallel(true)],
+    write_wam_go_project(Predicates, Options, OutputDir),
+    format(user_error, '[WAM-Go-Optimized] Generated project at ~w~n', [OutputDir]).
+
+parse_variant(seeded, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false)
+]).
+parse_variant(accumulated, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false),
+    seeded_accumulation(auto)
+]).
+
+%% collect_wam_predicates(+Variant, -Predicates)
+%  Collect the predicate list to compile through WAM, including
+%  generated helper predicates from the optimization pass.
+collect_wam_predicates(seeded, [
+    user:dimension_n/1,
+    user:max_depth/1,
+    user:category_ancestor/4,
+    user:power_sum_bound/4
+]).
+collect_wam_predicates(accumulated, [
+    user:dimension_n/1,
+    user:max_depth/1,
+    user:category_ancestor/4,
+    user:'category_ancestor$power_sum_bound'/3,
+    user:'category_ancestor$power_sum_selected'/3,
+    user:'category_ancestor$effective_distance_sum_selected'/3,
+    user:'category_ancestor$effective_distance_sum_bound'/3
+]).
+
+%% power_sum_bound/4 - needed for seeded variant
+power_sum_bound(Cat, Root, NegN, WeightSum) :-
+    aggregate_all(sum(W),
+        (category_ancestor(Cat, Root, Hops, [Cat]),
+         H is Hops + 1,
+         W is H ** NegN),
+        WeightSum).

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -1660,63 +1660,6 @@ func (vm *WamState) Run() bool {
     }
 }
 
-// RunParallel executes the WAM search in parallel using goroutines.
-func (vm *WamState) RunParallel(maxWorkers int) <-chan []Value {
-	results := make(chan []Value, 100)
-	sem := make(chan struct{}, maxWorkers)
-	var wg sync.WaitGroup
-
-	var explore func(state *WamState, hasToken bool)
-	explore = func(state *WamState, hasToken bool) {
-		defer wg.Done()
-		if !hasToken {
-			sem <- struct{}{}
-		}
-		defer func() { <-sem }()
-
-		for {
-			if state.Halted {
-				results <- state.CollectResults()
-				return
-			}
-			instr := state.fetch()
-			if instr == nil {
-				return
-			}
-
-			if !state.Step(instr) {
-				if !state.backtrack() {
-					return
-				}
-			}
-
-			// Fork choice points if we have workers available
-			if len(state.ChoicePoints) > 0 {
-				select {
-				case sem <- struct{}{}:
-					if alt := state.ForkAtChoicePoint(); alt != nil {
-						wg.Add(1)
-						go explore(alt, true)
-					} else {
-						<-sem
-					}
-				default:
-				}
-			}
-		}
-	}
-
-	wg.Add(1)
-	go explore(vm, false)
-
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-
-	return results
-}
-
 func (vm *WamState) indexedClauseBodyStart(targetPC int) int {
     if targetPC < 0 || targetPC >= len(vm.Ctx.Code) {
         return targetPC


### PR DESCRIPTION
## Summary

Closes benchmark and profiling gaps between Go and Haskell hybrid WAMs:

- **Remove duplicate WamState.RunParallel**: The old method-style `RunParallel` on `WamState` in `wam_go_target.pl` was superseded by the package-level `RunParallel(ctx *WamContext, seeds, maxWorkers)` added in PR #1458. Removed the dead code from the emitter's inline Go template.
- **Wire emit_mode(functions) + parallel(true)**: Added these options to the `write_wam_go_project/3` call in `generate_wam_go_effective_distance_benchmark.pl`, enabling the lowered emitter and parallel execution for Go benchmarks.
- **Add generate_wam_go_optimized_benchmark.pl**: New "optimized" benchmark pipeline for Go that mirrors `generate_wam_haskell_optimized_benchmark.pl` — loads workload, runs prolog_target optimization passes (seeded accumulation), then emits a Go WAM project with `emit_mode(functions)` and `parallel(true)`.
- **Add Go profiling 4-config matrix**: Extended `gen_prof_matrix.pl` with 4 Go configurations (E-H) mirroring the Haskell matrix (A-D): interpreter/functions × no_kernels/kernels.
- **Update BENCHMARK_TARGET_MATRIX.md**: Documented Go's lowered emitter support, RunParallel parallel execution, the 4-config profiling matrix, and new script paths.

## Test plan

- [x] `tests/test_wam_go_generator.pl` — 9/10 pass (1 pre-existing encoding failure on main)
- [x] `tests/test_wam_go_foreign_lowering.pl` — 4/8 pass (4 pre-existing encoding failures on main)
- [x] `tests/bench_wam_go.pl` — all 3 benchmarks run cleanly (append, fibonacci, member)

🤖 Generated with [Claude Code](https://claude.com/claude-code)