### PR TITLE
Define the counted path `All` ordering contract

### DIFF
--- a/docs/proposals/COUNTED_PATH_ALL_ORDERING_CONTRACT.md
+++ b/docs/proposals/COUNTED_PATH_ALL_ORDERING_CONTRACT.md
@@ -1,0 +1,86 @@
+# Counted Path `All` Ordering Contract
+
+This note defines the current ordering contract for counted-path `All`
+materialization in the C# query runtime.
+
+It complements
+[`COUNTED_PATH_MIN_ORDERING_CONTRACT.md`](./COUNTED_PATH_MIN_ORDERING_CONTRACT.md),
+which covers the separate retained-min flush path.
+
+## Current Runtime Contract
+
+For counted-path `All` in `PathAwareTransitiveClosureNode`, the runtime does
+not sort rows by target before materialization.
+
+Instead, it currently emits rows in two layers of order:
+
+1. seeds are processed in deterministic seed-sorted order via
+   `CompareCacheSeedValues`
+2. rows for each seed are replayed in the same order they were buffered during
+   traversal
+
+That means counted-path `All` is currently:
+
+- deterministic across runs for the same edge insertion order
+- grouped by sorted seed
+- ordered within each seed by traversal/discovery order, not target sort
+- multiplicity-preserving when multiple distinct paths reach the same target
+
+In code, that contract currently lives in:
+
+- `ExecutePathAwareTransitiveClosure`
+- `ExecuteSeededPathAwareTransitiveClosure`
+- `AppendPathAwareRowsForSeed`
+- `MaterializePathAwareDepthRows`
+
+all in
+[`QueryRuntime.cs`](../../src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs).
+
+## Why This Matters
+
+For counted-path `All`, replay/materialization optimizations are only valid if
+they preserve the current row sequence, or if the consumer contract is
+explicitly relaxed.
+
+Unlike counted-path `Min`, the `All` path does not currently pay for a final
+target sort. Its observable order is tied to traversal details such as:
+
+- reverse bucket iteration
+- stack push/pop behavior
+- when rows are buffered relative to child-state pushes
+
+Those details are implementation choices, but they are still part of the
+current public runtime behavior because exact-row-order tests can observe them.
+
+## Which Current Checks Depend On It
+
+The benchmark harness commonly normalizes output order before hashing, so the
+benchmarks alone do not define the public order contract.
+
+The stronger constraint comes from the core runtime tests, which compare exact
+row lists. In particular:
+
+- `verify_path_aware_transitive_closure_plan`
+- `verify_path_aware_transitive_closure_all_mode_order_plan`
+- `verify_path_aware_transitive_closure_min_mode_plan`
+
+in
+[`test_csharp_query_target.pl`](../../tests/core/test_csharp_query_target.pl)
+
+make row order observable.
+
+## Practical Implication
+
+If we want to optimize counted-path `All` replay/materialization further, the
+first question is not "can we reorder rows more cheaply?"
+
+The first question is:
+
+"Which execution paths are actually allowed to change counted-path `All`
+output order?"
+
+Until that contract changes, safe optimization means:
+
+1. keep per-seed traversal/discovery order intact
+2. keep sorted-seed grouping intact
+3. make buffering/replay cheaper without introducing a different row sequence

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -1041,6 +1041,10 @@ Additional path-state observations:
   node id until the final target-sorted flush, cutting object-key hashing and
   reducing `best_known_flush_sort` plus final `Min` materialization cost while
   preserving the deterministic ordering contract.
+- counted-path `All` keeps sorted-seed grouping but currently preserves
+  per-seed traversal/discovery order during replay rather than target-sorting
+  rows; that contract is documented explicitly before any larger replay
+  simplification work.
 - counted-path replay/materialization now uses the concrete `object?[]`
   node-value table directly instead of an `IReadOnlyList<object?>` view, which
   trims lookup overhead on the hot replay path without changing output rows.

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -12639,6 +12639,8 @@ namespace UnifyWeaver.QueryRuntime
                             continue;
                         }
 
+                        // Counted-path All preserves current per-seed traversal
+                        // discovery order during replay, including duplicates.
                         RecordBufferedPathAwareDepthRow(bufferedRows!, nextId, nextDepth);
 
                         var nextVisited = visited.Extend(nextId, nodeMaskAs[nextId], nodeMaskBs[nextId], nodeFingerprints[nextId]);

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -332,6 +332,7 @@ test_csharp_query_target :-
         verify_path_aware_transitive_closure_plan,
         verify_parameterized_path_aware_transitive_closure_plan,
         verify_path_aware_transitive_closure_preserves_path_multiplicity,
+        verify_path_aware_transitive_closure_all_mode_order_plan,
         verify_path_aware_transitive_closure_metrics_runtime,
         verify_path_aware_transitive_closure_min_mode_plan,
         verify_path_aware_accumulation_plan,
@@ -3777,6 +3778,35 @@ verify_path_aware_transitive_closure_preserves_path_multiplicity :-
         ['MATCH_COUNT:2'],
         [[a]],
         HarnessSource).
+
+verify_path_aware_transitive_closure_all_mode_order_plan :-
+    % The expected rows are intentionally in current traversal/discovery order
+    % for counted-path All mode. This guards the runtime contract that All
+    % preserves per-seed replay order, including duplicates, rather than
+    % target-sorting rows like Min mode does.
+    csharp_target:build_query_plan(
+        test_pathaware_multi_reach/3,
+        [target(csharp_query)],
+        [input, output, output],
+        Plan),
+    get_dict(is_recursive, Plan, true),
+    get_dict(root, Plan, path_aware_transitive_closure{type:path_aware_transitive_closure,
+        head:predicate{name:test_pathaware_multi_reach, arity:3},
+        edge:predicate{name:test_pathaware_multi_edge, arity:2},
+        base_depth:1,
+        depth_increment:1,
+        max_depth:10,
+        table_modes:[lattice, lattice, lattice],
+        width:3
+    }),
+    csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'PathAwareTransitiveClosureNode'),
+    maybe_run_query_runtime(Plan,
+        ['a,c,1',
+         'a,b,1',
+         'a,d,2',
+         'a,d,2'],
+        [[a]]).
 
 verify_path_aware_transitive_closure_metrics_runtime :-
     csharp_target:build_query_plan(


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  - Adds a dedicated proposal note documenting the current counted-path `All` ordering contract in the C# query runtime.                                                                                         
  - Clarifies that counted-path `All` keeps seeds in deterministic seed-sorted order, but preserves per-seed traversal/discovery order during replay instead of target-sorting rows.                             
  - Makes that `All` ordering behavior explicit in core C# query runtime tests using the branching `test_pathaware_multi_reach/3` fixture.                                                                       
  - Adds a small runtime comment at the buffered-row append path to anchor the behavior in code.                                                                                                                 
  - Updates the benchmark notes to mention the counted-path `All` ordering contract before further replay/materialization tuning.                                                                                
                                                                                                                                                                                                                 
  ## Why                                                                                                                                                                                                         
                                                                                                                                                                                                                 
  Recent counted-path optimization work has pushed the remaining performance discussion toward replay/materialization simplifications. Before making larger changes there, the runtime needs a clear statement of
  what counted-path `All` is actually allowed to reorder.                                                                                                                                                        
                                                                                                                                                                                                                 
  For counted-path `Min`, that contract is already explicit: retained rows are target-sorted before final flush. Counted-path `All` is different. It does not currently perform a final target sort. Instead, it 
  emits rows grouped by sorted seed and then replays each seed’s buffered rows in current traversal/discovery order, including duplicates.                                                                       
                                                                                                                                                                                                                 
  That distinction matters because a replay/materialization optimization that changes row order would not be a private implementation detail anymore; it would be an observable runtime behavior change.         
                                                                                                                                                                                                                 
  ## Contract                                                                                                                                                                                                    
                                                                                                                                                                                                                 
  For counted-path `All` in `PathAwareTransitiveClosureNode`, the runtime currently:                                                                                                                             
                                                                                                                                                                                                                 
  1. processes seeds in deterministic order via `CompareCacheSeedValues`                                                                                                                                         
  2. buffers rows for each seed during traversal                                                                                                                                                                 
  3. replays those buffered rows in the same per-seed traversal/discovery order                                                                                                                                  
  4. preserves duplicate rows when multiple distinct paths reach the same target                                                                                                                                 
                                                                                                                                                                                                                 
  So counted-path `All` is currently:                                                                                                                                                                            
                                                                                                                                                                                                                 
  - deterministic for a fixed runtime traversal shape                                                                                                                                                            
  - grouped by sorted seed                                                                                                                                                                                       
  - not target-sorted within a seed                                                                                                                                                                              
  - multiplicity-preserving                                                                                                                                                                                      
                                                                                                                                                                                                                 
  ## Validation                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  - `swipl -q -t run_tests tests/core/test_csharp_query_target.pl`                                                                                                                                               
  - `python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py`                                                                                                                                
  - `git diff --check`                                                                                                                                                                                           