### PR TITLE
perf(csharp-query): Survey counted path replay shape in the C# query runtime

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -202,6 +202,12 @@ Interpretation:
 - the counted-path `All` staging buffer now stores targets and depths in
   parallel packed lists instead of shuttling a tiny struct per row, reducing
   replay overhead on the final materialization path
+- counted-path `All` now reports replay-shape survey phases and metrics:
+  `path_state_result_replay_setup`, `path_state_result_replay_write`,
+  `path_state_result_replay_batch_count`, and
+  `path_state_result_replay_max_batch_size`; on the current benchmark shape,
+  replay setup is small while replay writes dominate the remaining
+  materialization cost
 - counted-path traversal and buffered replay now operate on interned node ids
   with edge-state lookup tables, avoiding repeated object-key dictionary
   lookups on the hot path while preserving exact output values at final

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -1045,6 +1045,11 @@ Additional path-state observations:
   per-seed traversal/discovery order during replay rather than target-sorting
   rows; that contract is documented explicitly before any larger replay
   simplification work.
+- counted-path `All` now reports replay-shape survey phases and metrics:
+  `path_state_result_replay_setup`, `path_state_result_replay_write`,
+  `path_state_result_replay_batch_count`, and
+  `path_state_result_replay_max_batch_size`, so replay tuning can target the
+  dominant write cost without violating the documented ordering contract.
 - counted-path replay/materialization now uses the concrete `object?[]`
   node-value table directly instead of an `IReadOnlyList<object?>` view, which
   trims lookup overhead on the hot replay path without changing output rows.

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -11461,6 +11461,8 @@ namespace UnifyWeaver.QueryRuntime
             trace?.RecordPhase(node, "path_state_row_creation", metrics.RowCreationElapsed);
             trace?.RecordPhase(node, "path_state_best_known_flush_sort", metrics.BestKnownFlushSortElapsed);
             trace?.RecordPhase(node, "path_state_result_materialization", metrics.ResultMaterializationElapsed);
+            trace?.RecordPhase(node, "path_state_result_replay_setup", metrics.ResultReplaySetupElapsed);
+            trace?.RecordPhase(node, "path_state_result_replay_write", metrics.ResultReplayWriteElapsed);
             trace?.AddMetric(node, "path_state_seed_count", metrics.SeedCount);
             trace?.AddMetric(node, "path_state_stack_pop_count", metrics.StackPopCount);
             trace?.AddMetric(node, "path_state_successor_candidate_count", metrics.SuccessorCandidateCount);
@@ -11469,8 +11471,10 @@ namespace UnifyWeaver.QueryRuntime
             trace?.AddMetric(node, "path_state_best_known_prune_count", metrics.BestKnownPruneCount);
             trace?.AddMetric(node, "path_state_enqueued_state_count", metrics.EnqueuedStateCount);
             trace?.AddMetric(node, "path_state_output_row_count", metrics.OutputRowCount);
+            trace?.AddMetric(node, "path_state_result_replay_batch_count", metrics.ResultReplayBatchCount);
             trace?.RecordMetric(node, "path_state_max_stack_size", metrics.MaxStackSize);
             trace?.RecordMetric(node, "path_state_max_path_length", metrics.MaxPathLength);
+            trace?.RecordMetric(node, "path_state_result_replay_max_batch_size", metrics.ResultReplayMaxBatchSize);
         }
 
         private IReadOnlyDictionary<object, Dictionary<object, int>> ExecuteSeedGroupedPathAwareDepthMinFallback(
@@ -12750,31 +12754,38 @@ namespace UnifyWeaver.QueryRuntime
             ICollection<object[]> output,
             PathAwareTraversalMetrics? metrics)
         {
+            metrics?.RecordResultReplayBatch(rows.Count);
             var started = Stopwatch.GetTimestamp();
             var seedValue = seed!;
             if (output is List<object[]> outputList)
             {
+                var setupStarted = Stopwatch.GetTimestamp();
                 var baseIndex = outputList.Count;
                 CollectionsMarshal.SetCount(outputList, baseIndex + rows.Count);
                 var span = CollectionsMarshal.AsSpan(outputList);
                 var targetNodeIds = CollectionsMarshal.AsSpan(rows.TargetNodeIds);
                 var depths = CollectionsMarshal.AsSpan(rows.Depths);
+                metrics?.AddResultReplaySetupElapsed(Stopwatch.GetElapsedTime(setupStarted));
+                var writeStarted = Stopwatch.GetTimestamp();
                 for (var i = 0; i < rows.Count; i++)
                 {
                     span[baseIndex + i] = new object[] { seedValue, nodeValues[targetNodeIds[i]]!, BoxCountedPathDepth(depths[i]) };
                     metrics?.RecordOutputRow();
                 }
+                metrics?.AddResultReplayWriteElapsed(Stopwatch.GetElapsedTime(writeStarted));
                 metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(started));
                 return;
             }
 
             var fallbackTargetNodeIds = rows.TargetNodeIds;
             var fallbackDepths = rows.Depths;
+            var fallbackWriteStarted = Stopwatch.GetTimestamp();
             for (var i = 0; i < rows.Count; i++)
             {
                 output.Add(new object[] { seedValue, nodeValues[fallbackTargetNodeIds[i]]!, BoxCountedPathDepth(fallbackDepths[i]) });
                 metrics?.RecordOutputRow();
             }
+            metrics?.AddResultReplayWriteElapsed(Stopwatch.GetElapsedTime(fallbackWriteStarted));
 
             metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(started));
         }
@@ -14104,6 +14115,10 @@ namespace UnifyWeaver.QueryRuntime
 
             public TimeSpan ResultMaterializationElapsed { get; private set; }
 
+            public TimeSpan ResultReplaySetupElapsed { get; private set; }
+
+            public TimeSpan ResultReplayWriteElapsed { get; private set; }
+
             public long SeedCount { get; private set; }
 
             public long StackPopCount { get; private set; }
@@ -14120,9 +14135,13 @@ namespace UnifyWeaver.QueryRuntime
 
             public long OutputRowCount { get; private set; }
 
+            public long ResultReplayBatchCount { get; private set; }
+
             public int MaxStackSize { get; private set; }
 
             public int MaxPathLength { get; private set; }
+
+            public int ResultReplayMaxBatchSize { get; private set; }
 
             public void AddTraversalElapsed(TimeSpan elapsed) => TraversalElapsed += elapsed;
 
@@ -14131,6 +14150,10 @@ namespace UnifyWeaver.QueryRuntime
             public void AddBestKnownFlushSortElapsed(TimeSpan elapsed) => BestKnownFlushSortElapsed += elapsed;
 
             public void AddResultMaterializationElapsed(TimeSpan elapsed) => ResultMaterializationElapsed += elapsed;
+
+            public void AddResultReplaySetupElapsed(TimeSpan elapsed) => ResultReplaySetupElapsed += elapsed;
+
+            public void AddResultReplayWriteElapsed(TimeSpan elapsed) => ResultReplayWriteElapsed += elapsed;
 
             public void RecordSeed() => SeedCount++;
 
@@ -14149,6 +14172,15 @@ namespace UnifyWeaver.QueryRuntime
             public void RecordBestKnownPrune() => BestKnownPruneCount++;
 
             public void RecordOutputRow() => OutputRowCount++;
+
+            public void RecordResultReplayBatch(int size)
+            {
+                ResultReplayBatchCount++;
+                if (size > ResultReplayMaxBatchSize)
+                {
+                    ResultReplayMaxBatchSize = size;
+                }
+            }
 
             public void RecordEnqueuedState(int pathLength)
             {


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  - Adds replay-shape survey phases for counted-path materialization:                                                                                                                                            
    - `path_state_result_replay_setup`                                                                                                                                                                           
    - `path_state_result_replay_write`                                                                                                                                                                           
  - Adds replay-shape batch metrics:                                                                                                                                                                             
    - `path_state_result_replay_batch_count`                                                                                                                                                                     
    - `path_state_result_replay_max_batch_size`                                                                                                                                                                  
  - Keeps the existing top-level `path_state_result_materialization` phase intact.                                                                                                                               
  - Updates the counted-path benchmark/proposal notes with the survey result so future `All` replay work can target the real remaining cost.                                                                     
                                                                                                                                                                                                                 
  ## Why                                                                                                                                                                                                         
                                                                                                                                                                                                                 
  The recent counted-path `All` follow-ups showed a consistent pattern: blind micro-optimizations in replay/materialization were not paying off reliably.                                                        
                                                                                                                                                                                                                 
  At that point the right move was not another speculative change. The right move was to split the finishing path into measurable pieces under the now-explicit counted-path `All` ordering contract.            
                                                                                                                                                                                                                 
  This PR does that. It keeps the current behavior and top-level metrics, but adds enough detail to answer the next question cleanly:                                                                            
                                                                                                                                                                                                                 
  “Is the remaining counted-path `All` materialization cost dominated by setup, or by the actual row writes?”                                                                                                    
                                                                                                                                                                                                                 
  ## Results                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  Local counted shortest-path benchmark:                                                                                                                                                                         
                                                                                                                                                                                                                 
  ```bash                                                                                                                                                                                                        
  python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3                                                                                                                  
  ```                                                                                                                                                                                          
  Counted-path All replay-shape survey:                                                                                                                                                                          
                                                                                                                                                                                                                 
  | Scale | Result Materialization | Replay Setup | Replay Write | Replay Batch Count | Replay Max Batch Size |                                                                                                  
  | --- | ---: | ---: | ---: | ---: | ---: |                                                                                                                                                                     
  | 300 | 75.197ms | 2.416ms | 72.459ms | 386 | 26812 |                                                                                                                                                          
  | 1k | 46.376ms | 2.304ms | 43.855ms | 89 | 23993 |                                                                                                                                                            
                                                                                                                                                                                                                 
  Key conclusion:                                                                                                                                                                                                
                                                                                                                                                                                                                 
  - replay setup is small                                                                                                                                                                                        
  - replay write dominates the remaining counted-path All materialization cost                                                                                                                                   
                                                                                                                                                                                                                 
  That materially narrows the next optimization target.                                                                                                                                                          
                                                                                                                                                                                                                 
  ## Validation                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  - swipl -q -t run_tests tests/core/test_csharp_query_target.pl                                                                                                                                                 
  - python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py                                                                                                                                  
  - git diff --check                                                                                                                                                                                             
  - python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3                                                                                                                