### PR TITLE
perf(csharp-query): Survey counted path row shape in the C# query runtim

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -208,6 +208,10 @@ Interpretation:
   `path_state_result_replay_max_batch_size`; on the current benchmark shape,
   replay setup is small while replay writes dominate the remaining
   materialization cost
+- counted-path `All` replay write is now further split into
+  `path_state_result_replay_value_lookup` and
+  `path_state_result_replay_row_alloc`; on the current benchmark shape, row
+  allocation is the larger write-side cost, with value lookup still visible
 - counted-path traversal and buffered replay now operate on interned node ids
   with edge-state lookup tables, avoiding repeated object-key dictionary
   lookups on the hot path while preserving exact output values at final

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -1050,6 +1050,10 @@ Additional path-state observations:
   `path_state_result_replay_batch_count`, and
   `path_state_result_replay_max_batch_size`, so replay tuning can target the
   dominant write cost without violating the documented ordering contract.
+- counted-path `All` now also splits replay write into
+  `path_state_result_replay_value_lookup` and
+  `path_state_result_replay_row_alloc`; on the current benchmark shape, row
+  allocation is the larger share of replay write cost.
 - counted-path replay/materialization now uses the concrete `object?[]`
   node-value table directly instead of an `IReadOnlyList<object?>` view, which
   trims lookup overhead on the hot replay path without changing output rows.

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -11463,6 +11463,8 @@ namespace UnifyWeaver.QueryRuntime
             trace?.RecordPhase(node, "path_state_result_materialization", metrics.ResultMaterializationElapsed);
             trace?.RecordPhase(node, "path_state_result_replay_setup", metrics.ResultReplaySetupElapsed);
             trace?.RecordPhase(node, "path_state_result_replay_write", metrics.ResultReplayWriteElapsed);
+            trace?.RecordPhase(node, "path_state_result_replay_value_lookup", metrics.ResultReplayValueLookupElapsed);
+            trace?.RecordPhase(node, "path_state_result_replay_row_alloc", metrics.ResultReplayRowAllocElapsed);
             trace?.AddMetric(node, "path_state_seed_count", metrics.SeedCount);
             trace?.AddMetric(node, "path_state_stack_pop_count", metrics.StackPopCount);
             trace?.AddMetric(node, "path_state_successor_candidate_count", metrics.SuccessorCandidateCount);
@@ -12767,11 +12769,22 @@ namespace UnifyWeaver.QueryRuntime
                 var depths = CollectionsMarshal.AsSpan(rows.Depths);
                 metrics?.AddResultReplaySetupElapsed(Stopwatch.GetElapsedTime(setupStarted));
                 var writeStarted = Stopwatch.GetTimestamp();
+                var valueLookupStarted = Stopwatch.GetTimestamp();
+                var targetValues = new object?[rows.Count];
+                var boxedDepths = new object[rows.Count];
                 for (var i = 0; i < rows.Count; i++)
                 {
-                    span[baseIndex + i] = new object[] { seedValue, nodeValues[targetNodeIds[i]]!, BoxCountedPathDepth(depths[i]) };
+                    targetValues[i] = nodeValues[targetNodeIds[i]]!;
+                    boxedDepths[i] = BoxCountedPathDepth(depths[i]);
+                }
+                metrics?.AddResultReplayValueLookupElapsed(Stopwatch.GetElapsedTime(valueLookupStarted));
+                var rowAllocStarted = Stopwatch.GetTimestamp();
+                for (var i = 0; i < rows.Count; i++)
+                {
+                    span[baseIndex + i] = new object[] { seedValue, targetValues[i], boxedDepths[i] };
                     metrics?.RecordOutputRow();
                 }
+                metrics?.AddResultReplayRowAllocElapsed(Stopwatch.GetElapsedTime(rowAllocStarted));
                 metrics?.AddResultReplayWriteElapsed(Stopwatch.GetElapsedTime(writeStarted));
                 metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(started));
                 return;
@@ -12780,11 +12793,22 @@ namespace UnifyWeaver.QueryRuntime
             var fallbackTargetNodeIds = rows.TargetNodeIds;
             var fallbackDepths = rows.Depths;
             var fallbackWriteStarted = Stopwatch.GetTimestamp();
+            var fallbackValueLookupStarted = Stopwatch.GetTimestamp();
+            var fallbackTargetValues = new object?[rows.Count];
+            var fallbackBoxedDepths = new object[rows.Count];
             for (var i = 0; i < rows.Count; i++)
             {
-                output.Add(new object[] { seedValue, nodeValues[fallbackTargetNodeIds[i]]!, BoxCountedPathDepth(fallbackDepths[i]) });
+                fallbackTargetValues[i] = nodeValues[fallbackTargetNodeIds[i]]!;
+                fallbackBoxedDepths[i] = BoxCountedPathDepth(fallbackDepths[i]);
+            }
+            metrics?.AddResultReplayValueLookupElapsed(Stopwatch.GetElapsedTime(fallbackValueLookupStarted));
+            var fallbackRowAllocStarted = Stopwatch.GetTimestamp();
+            for (var i = 0; i < rows.Count; i++)
+            {
+                output.Add(new object[] { seedValue, fallbackTargetValues[i], fallbackBoxedDepths[i] });
                 metrics?.RecordOutputRow();
             }
+            metrics?.AddResultReplayRowAllocElapsed(Stopwatch.GetElapsedTime(fallbackRowAllocStarted));
             metrics?.AddResultReplayWriteElapsed(Stopwatch.GetElapsedTime(fallbackWriteStarted));
 
             metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(started));
@@ -14119,6 +14143,10 @@ namespace UnifyWeaver.QueryRuntime
 
             public TimeSpan ResultReplayWriteElapsed { get; private set; }
 
+            public TimeSpan ResultReplayValueLookupElapsed { get; private set; }
+
+            public TimeSpan ResultReplayRowAllocElapsed { get; private set; }
+
             public long SeedCount { get; private set; }
 
             public long StackPopCount { get; private set; }
@@ -14154,6 +14182,10 @@ namespace UnifyWeaver.QueryRuntime
             public void AddResultReplaySetupElapsed(TimeSpan elapsed) => ResultReplaySetupElapsed += elapsed;
 
             public void AddResultReplayWriteElapsed(TimeSpan elapsed) => ResultReplayWriteElapsed += elapsed;
+
+            public void AddResultReplayValueLookupElapsed(TimeSpan elapsed) => ResultReplayValueLookupElapsed += elapsed;
+
+            public void AddResultReplayRowAllocElapsed(TimeSpan elapsed) => ResultReplayRowAllocElapsed += elapsed;
 
             public void RecordSeed() => SeedCount++;
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                
                                                                                                                                                                            
  - Adds write-shape survey phases for counted-path `All` replay:                                                                                                           
    - `path_state_result_replay_value_lookup`                                                                                                                               
    - `path_state_result_replay_row_alloc`                                                                                                                                  
  - Preserves the existing higher-level replay/materialization phases:                                                                                                      
    - `path_state_result_replay_setup`                                                                                                                                      
    - `path_state_result_replay_write`                                                                                                                                      
    - `path_state_result_materialization`                                                                                                                                   
  - Updates the counted-path benchmark/proposal notes with the new write-shape result.                                                                                      
  - Narrows the next optimization target from generic replay-write cost to row allocation specifically.                                                                     
                                                                                                                                                                            
  ## Why                                                                                                                                                                    
                                                                                                                                                                            
  The previous replay-shape survey already showed that counted-path `All` replay setup is small and that replay write dominates the remaining materialization cost.         
                                                                                                                                                                            
  That still left one important question unresolved:                                                                                                                        
                                                                                                                                                                            
  “Inside replay write, is the cost mostly value lookup, or mostly row allocation/layout?”                                                                                  
                                                                                                                                                                            
  This PR answers that directly by splitting the write path into those two measurable parts without changing runtime behavior.                                              
                                                                                                                                                                            
  ## Results                                                                                                                                                                
                                                                                                                                                                            
  Local counted shortest-path benchmark:                                                                                                                                    
                                                                                                                                                                            
  ```bash                                                                                                                                                                   
  python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3                                                                             
  ```                                                                                                                                                        
  Counted-path All row-shape survey:                                                                                                                                        
                                                                                                                                                                            
  | Scale | Result Materialization | Replay Write | Value Lookup | Row Allocation |                                                                                         
  | --- | ---: | ---: | ---: | ---: |                                                                                                                                       
  | 300 | 69.258ms | 66.573ms | 13.867ms | 52.457ms |                                                                                                                       
  | 1k | 27.038ms | 25.604ms | 11.835ms | 13.568ms |                                                                                                                        
                                                                                                                                                                            
  Key conclusion:                                                                                                                                                           
                                                                                                                                                                            
  - replay setup is already small                                                                                                                                           
  - replay write still dominates counted-path All materialization                                                                                                           
  - within replay write, row allocation is the larger share of cost on the current benchmark shape                                                                          
                                                                                                                                                                            
  That materially narrows the next runtime change: optimize row allocation/layout, not replay setup.                                                                        
                                                                                                                                                                            
  ## Validation                                                                                                                                                             
                                                                                                                                                                            
  - swipl -q -t run_tests tests/core/test_csharp_query_target.pl                                                                                                            
  - python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py                                                                                             
  - git diff --check                                                                                                                                                        
  - python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3                                                                           