### PR TITLE
fix(bench): correct cross-target WAM benchmark results

### DIFF
--- a/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
+++ b/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
@@ -1,7 +1,7 @@
 # WAM Cross-Target Benchmark Results
 
 Benchmark results comparing WAM execution across multiple compilation targets.
-All measurements at **scale 300** (6004 category_parent facts, 757 article_category facts).
+All measurements at **scale 300** (6008 category_parent facts, 770 article_category facts).
 
 ## Test Environment
 
@@ -15,70 +15,117 @@ All measurements at **scale 300** (6004 category_parent facts, 757 article_categ
 - **Root category**: `Physics`
 - **Repetitions**: 3 per query, median reported
 
-## Effective Distance (DFS with cycle detection)
+## Effective Distance (WAM-compiled predicate)
 
-| Target | Rep 1 (ms) | Rep 2 (ms) | Rep 3 (ms) | Median (ms) | Notes |
-|--------|-----------|-----------|-----------|-------------|-------|
-| SWI-Prolog (seeded) | 428 | 429 | 428 | **428** | Full WAM interpretation + unification |
-| SWI-Prolog (accumulated) | 405 | 517 | 530 | **517** | Seeded accumulation variant |
-| Haskell + FFI (1-core) | - | - | - | **107** | From WAM_PERF_OPTIMIZATION_LOG |
-| Haskell + FFI (4-core) | - | - | - | **75** | Parallel, 3.3x speedup |
-| Rust WAM (native DFS) | 3 | 3 | 4 | **3** | Native hash-indexed DFS |
-| Python WAM (native DFS) | 2.6 | 2.3 | 2.3 | **2.3** | Native dict-indexed DFS |
-| Go WAM | - | - | - | **N/A** | Build OK, fact loading not wired up |
+The benchmark predicate is `category_ancestor$effective_distance_sum_bound/3`,
+which computes effective distance via `category_ancestor/4` with path pruning
+and `begin_aggregate`/`end_aggregate` for sum accumulation.
+
+| Target | Median (ms) | Status | Notes |
+|--------|-------------|--------|-------|
+| SWI-Prolog (seeded) | **428** | Valid | Full WAM interpretation + unification |
+| SWI-Prolog (accumulated) | **517** | Valid | Seeded accumulation variant |
+| Haskell + FFI (1-core) | **107** | Valid | From WAM_PERF_OPTIMIZATION_LOG |
+| Haskell + FFI (4-core) | **75** | Valid | Parallel, 3.3x speedup |
+| Go WAM bytecode | N/A | **Runtime incomplete** | Y-register clobbering (see below) |
+| Rust WAM lowered | N/A | **Runtime incomplete** | Y-register clobbering + missing dispatch |
+| Python WAM | N/A | **Runtime incomplete** | Aggregate instructions not implemented |
 
 ## Shortest Path (Transitive Closure)
 
-| Target | Rep 1 (ms) | Rep 2 (ms) | Rep 3 (ms) | Median (ms) | Notes |
-|--------|-----------|-----------|-----------|-------------|-------|
-| SWI-Prolog (branch_pruning=auto) | 3273 | 3232 | 3332 | **3273** | BFS with branch pruning |
-| Haskell + FFI (4-core) | - | - | - | **70** | From WAM_PERF_OPTIMIZATION_LOG |
-| Rust WAM (native DFS) | <1 | <1 | <1 | **<1** | 42 reachable nodes |
-| Python WAM (native DFS) | <1 | <1 | <1 | **<1** | 42 reachable nodes |
+| Target | Median (ms) | Status | Notes |
+|--------|-------------|--------|-------|
+| SWI-Prolog (branch_pruning=auto) | **3273** | Valid | BFS with branch pruning |
+| Haskell + FFI (4-core) | **70** | Valid | From WAM_PERF_OPTIMIZATION_LOG |
 
 ## Weighted Shortest Path (Dijkstra, variant=min)
 
-| Target | Rep 1 (ms) | Rep 2 (ms) | Rep 3 (ms) | Median (ms) | Notes |
-|--------|-----------|-----------|-----------|-------------|-------|
-| SWI-Prolog | 124 | 124 | 125 | **124** | Dijkstra with semantic weights |
-| Haskell + FFI (4-core) | - | - | - | **90** | From WAM_PERF_OPTIMIZATION_LOG |
+| Target | Median (ms) | Status | Notes |
+|--------|-------------|--------|-------|
+| SWI-Prolog | **124** | Valid | Dijkstra with semantic weights |
+| Haskell + FFI (4-core) | **90** | Valid | From WAM_PERF_OPTIMIZATION_LOG |
 
 ## Speedup Analysis (Scale 300, Effective Distance)
 
 | Comparison | Speedup |
 |-----------|---------|
-| Rust native vs SWI-Prolog (seeded) | ~143x |
-| Python native vs SWI-Prolog (seeded) | ~186x |
-| Haskell FFI (4-core) vs SWI-Prolog | ~5.7x |
-| Rust native vs Haskell FFI (4-core) | ~25x |
+| Haskell FFI (4-core) vs SWI-Prolog (seeded) | ~5.7x |
+| Haskell FFI (1-core) vs SWI-Prolog (seeded) | ~4.0x |
 
-## Architecture Notes
+## WAM Runtime Failure Analysis
 
-### Why Native DFS Is So Fast
+### Root Cause: Y-Register Clobbering (Go, Rust, Python)
 
-The Rust and Python benchmarks use **native hash-indexed DFS** — category_parent
-facts are pre-indexed into a `HashMap<String, Vec<String>>`, and the DFS walks
-the graph directly. This bypasses:
-- WAM instruction decode/dispatch
-- Unification and trail management
-- Choice point save/restore
-- Register-based argument passing
+All three transpiled WAM runtimes share the same fundamental defect:
+**Y-registers (permanent variables) are stored in a flat global register array
+instead of per-environment stack frames.**
 
-The SWI-Prolog and Haskell numbers include the full WAM overhead, making them
-more representative of general Prolog workload performance but slower for this
-specific graph traversal pattern.
+In a correct WAM implementation, Y-registers are allocated on the control stack
+within environment frames. Each `allocate`/`deallocate` pair creates a new frame
+with its own Y1, Y2, etc. This means a callee's Y-registers are independent of
+the caller's.
 
-### Go Status
+The transpiler emits Y-registers as global offsets: `Y1 → reg[200]`, `Y2 → reg[201]`,
+etc. When `category_ancestor/4` (callee) stores the visited-list in `Y2` (reg 201),
+it overwrites `power_sum_bound/3` (caller)'s `Y2` (also reg 201), which the caller
+later uses as the target variable for `is/2` (the power computation).
 
-The Go WAM target builds successfully (after fixing `SharedWamCode`/`SharedWamLabels`
-export aliases), but the generated `main.go` template doesn't wire up fact data
-(category_parent/2) into the runtime. The lowered predicates reference `category_parent/2`
-through WAM label lookup, but the facts are not compiled into WAM instructions.
-This requires either:
-- Compiling all 6004 facts as WAM try_me_else chains, or
-- Implementing a foreign fact lookup similar to Rust's `indexed_atom_fact2`
+**Observed failure in Go bytecode path:**
+```
+PC=9:  GetVariable {201 3}  — stores A4=[Energy,[]] into reg 201 (callee's Y2)
+...
+PC=81: PutValue {201 0}     — reads reg 201 expecting unbound var for is/2 result
+PC=85: BuiltinCall is/2     — FAILS: arg1 is List [Energy,[]], not Unbound
+```
 
-### Larger Scale Reference Numbers (SWI-Prolog)
+This is a transpiler code-generation defect, not a runtime bug. The fix requires
+either:
+1. Making Y-registers per-environment-frame (significant refactor of all runtimes), or
+2. Having the transpiler emit unique Y-register offsets per predicate (e.g., callee
+   uses Y100+, caller uses Y200+), or
+3. Using the WAM stack properly: `allocate` saves Y-regs, `deallocate` restores.
+
+### Go WAM Bytecode: Additional Details
+
+- **Fact table lookup**: Successfully implemented via `callIndexedAtomFact2` with
+  first-argument indexing (`IndexedAtomFactMap`) and choice-point backtracking.
+- **`is/2` arithmetic**: Works correctly for standalone expressions.
+- **`begin_aggregate`/`end_aggregate`**: Implemented in runtime, correctly clones
+  sub-VM and iterates solutions. However, the cloned sub-VM inherits the clobbered
+  register state.
+- **Blocking issue**: Y-register clobbering causes the aggregate body to fail after
+  the first `category_ancestor/4` call. The aggregate collects 0 solutions.
+
+### Rust WAM Lowered: Additional Details
+
+- **Missing predicate dispatch**: Lowered functions call `vm.labels.get("category_parent/2")`
+  and `vm.labels.get("category_ancestor/4")`, but fact tables aren't in the label map
+  and lowered predicates aren't registered as labels. Needs a dispatch mechanism that
+  tries: labels → lowered functions → indexed fact tables.
+- **Y-register clobbering**: Same issue as Go — the lowered code emits
+  `vm.put_reg("Y2", ...)` which maps to global reg 201.
+- **Fact table registration**: `register_indexed_atom_fact2_pairs` exists and works.
+
+### Python WAM: Additional Details
+
+- **Aggregate instructions**: `begin_aggregate`/`end_aggregate` are not implemented
+  in the `run_wam()` interpreter loop (marked `# SKIP` in generated code).
+- **No `state.run()` method**: The runtime uses `run_wam(code, labels, entry, state)`
+  as a free function, but generated predicates call `state.run()`.
+- **Y-register clobbering**: Same fundamental issue.
+
+## Errata: Previous "Native DFS" Results Were Invalid
+
+The previous version of this document reported:
+- Rust WAM: 3ms effective distance (143x faster than SWI-Prolog)
+- Python WAM: 2.3ms effective distance (186x faster than SWI-Prolog)
+
+**These results were invalid.** The benchmark drivers used hand-written native
+DFS (`collect_native_transitive_distance_results`) that bypassed the WAM entirely.
+They measured pure in-memory hash-map graph traversal, not WAM predicate execution.
+The results have been removed.
+
+## Larger Scale Reference Numbers (SWI-Prolog)
 
 | Scale | Effective Distance Seeded (ms) | Shortest Path (ms) | Weighted SP (ms) |
 |-------|-------------------------------|--------------------|--------------------|
@@ -87,13 +134,12 @@ This requires either:
 | 5k | 1304 | 10676 | 311 |
 | 10k | 3013 | 21200 | 596 |
 
-### Previously Recorded Haskell Numbers (from WAM_PERF_OPTIMIZATION_LOG.md)
+## Previously Recorded Haskell Numbers (from WAM_PERF_OPTIMIZATION_LOG.md)
 
 | Configuration | Scale 300 (ms) | Scale 5k (ms) | Scale 10k (ms) |
 |--------------|---------------|--------------|----------------|
 | Haskell + FFI 1-core | 107 (total), 32 (query) | - | - |
 | Haskell + FFI 4-core | 75 (total) | 213 | 604 |
-| Rust native DFS (hand-fused, 1-core) | 126 | - | - |
 | Shortest path BFS (Haskell 4-core) | 70 | - | 420 |
 | Weighted SP Dijkstra (Haskell 4-core) | 90 | - | 441 |
 
@@ -113,3 +159,22 @@ This requires either:
 4. **Python target: module-qualified predicates** (wam_python_target.pl)
    - `compile_one_predicate/3` didn't handle `Module:Pred/Arity` format
    - Added clause to strip module prefix before delegation
+
+5. **Go WAM runtime: callIndexedAtomFact2 for foreign fact lookup** (runtime.go)
+   - Added inline fact table dispatch in Call/Execute handlers
+   - First-argument indexed HashMap (`IndexedAtomFactMap`) for O(1) lookup
+   - Choice point backtracking for multi-match results
+
+## Recommended Next Steps
+
+1. **Fix Y-register allocation in the transpiler** — Either emit per-predicate
+   Y-register ranges (cheapest fix) or implement proper environment frame Y-register
+   storage in all three runtimes.
+
+2. **Add predicate dispatch in Rust lowered path** — Implement a `call_predicate(name)`
+   method that tries: label-based bytecode → lowered function table → indexed fact
+   table. Currently lowered functions can only call bytecode labels.
+
+3. **Implement aggregate instructions in Python runtime** — The `begin_aggregate`/
+   `end_aggregate` pair needs to clone the VM state, iterate all solutions via
+   backtracking, and accumulate results.

--- a/reports/wam_prolog_benchmark_results.json
+++ b/reports/wam_prolog_benchmark_results.json
@@ -3,8 +3,8 @@
   "date": "2026-04-18",
   "scale": 300,
   "facts": {
-    "category_parent": 6004,
-    "article_category": 757,
+    "category_parent": 6008,
+    "article_category": 770,
     "root_category": "Physics"
   },
   "effective_distance": {
@@ -27,21 +27,32 @@
       "total_ms": 75,
       "notes": "Parallel, 3.3x speedup over 1-core"
     },
-    "rust_wam_native_dfs": {
-      "reps_ms": [3, 3, 4],
-      "median_ms": 3,
-      "result_count": 3210,
-      "notes": "Native hash-indexed DFS"
+    "go_wam_bytecode": {
+      "status": "runtime_incomplete",
+      "failure": "Y-register clobbering: callee category_ancestor/4 overwrites caller power_sum_bound/3 Y2 (reg 201), causing is/2 to fail in aggregate body",
+      "notes": "Fact lookup and arithmetic work; aggregate collects 0 solutions due to register conflict"
     },
-    "python_wam_native_dfs": {
-      "reps_ms": [2.6, 2.3, 2.3],
-      "median_ms": 2.3,
-      "result_count": 3210,
-      "notes": "Native dict-indexed DFS"
+    "rust_wam_lowered": {
+      "status": "runtime_incomplete",
+      "failure": "Y-register clobbering (same as Go) + missing predicate dispatch (lowered fns cannot call each other or fact tables via labels)",
+      "notes": "Fact table registration works; predicate calls fail at label lookup"
     },
-    "go_wam": {
-      "status": "build_ok_runtime_incomplete",
-      "notes": "Build succeeds after SharedWamCode fix, but fact loading not wired up"
+    "python_wam": {
+      "status": "runtime_incomplete",
+      "failure": "begin_aggregate/end_aggregate not implemented in interpreter + Y-register clobbering",
+      "notes": "Basic WAM instructions work but aggregate-dependent predicates cannot execute"
+    }
+  },
+  "errata": {
+    "removed_invalid_results": {
+      "rust_native_dfs": {
+        "previously_reported_median_ms": 3,
+        "reason": "Hand-written native hash-indexed DFS, not WAM execution. Bypassed WAM instruction dispatch, unification, trail, and choice points entirely."
+      },
+      "python_native_dfs": {
+        "previously_reported_median_ms": 2.3,
+        "reason": "Hand-written native dict-indexed DFS, not WAM execution. Same bypass as Rust."
+      }
     }
   },
   "shortest_path": {
@@ -53,18 +64,6 @@
     "haskell_ffi_4core": {
       "median_ms": 70,
       "notes": "From WAM_PERF_OPTIMIZATION_LOG.md"
-    },
-    "rust_wam_native_dfs": {
-      "reps_ms": [0, 0, 0],
-      "median_ms": 0,
-      "result_count": 42,
-      "notes": "42 reachable nodes via transitive closure"
-    },
-    "python_wam_native_dfs": {
-      "reps_ms": [0, 0, 0],
-      "median_ms": 0,
-      "result_count": 42,
-      "notes": "42 reachable nodes via transitive closure"
     }
   },
   "weighted_shortest_path": {
@@ -102,10 +101,20 @@
     "bfs_shortest_4core_10k": {"total_ms": 420},
     "dijkstra_4core_10k": {"total_ms": 441}
   },
+  "root_cause": {
+    "description": "Y-register clobbering: all three transpiled runtimes store Y-registers in a flat global array (Y1=reg[200], Y2=reg[201], ...) instead of per-environment stack frames. When a callee writes to Y2, it overwrites the caller's Y2.",
+    "affected_targets": ["go_wam_bytecode", "rust_wam_lowered", "python_wam"],
+    "fix_options": [
+      "Emit per-predicate Y-register offset ranges in the transpiler",
+      "Implement proper environment-frame Y-register storage in all runtimes",
+      "Use the WAM stack: allocate saves Y-regs to frame, deallocate restores"
+    ]
+  },
   "bug_fixes": [
     "Go emitter: added SharedWamCode/SharedWamLabels exported aliases in wam_go_target.pl",
     "Rust lowered emitter: added escape_rust_string for builtin_call ops in wam_rust_lowered_emitter.pl",
     "Go lowered emitter: added escape_go_string for builtin_call ops in wam_go_lowered_emitter.pl",
-    "Python target: added Module:Pred/Arity handling in compile_one_predicate in wam_python_target.pl"
+    "Python target: added Module:Pred/Arity handling in compile_one_predicate in wam_python_target.pl",
+    "Go runtime: added callIndexedAtomFact2 with first-argument indexed HashMap and choice-point backtracking"
   ]
 }


### PR DESCRIPTION
## Summary

- Removes invalid native-DFS benchmark results (3ms Rust, 2.3ms Python) that bypassed the WAM entirely — those were hand-written HashMap graph traversals, not WAM predicate execution
- Documents the root cause preventing all three transpiled WAM runtimes (Go, Rust, Python) from executing `category_ancestor$effective_distance_sum_bound/3`: **Y-register clobbering** — permanent variables stored in a flat global register array instead of per-environment stack frames
- Adds detailed per-target failure analysis with register-level trace evidence, errata section, and recommended fix paths

## Root Cause

All three runtimes encode Y-registers as global offsets (`Y1 → reg[200]`, `Y2 → reg[201]`, ...). When `category_ancestor/4` (callee) writes `Y2 = [Energy, []]` (visited list), it overwrites `power_sum_bound/3` (caller)'s `Y2` (power computation target), causing `is/2` to fail with a List where an Unbound was expected.

## Test plan

- [x] Verified Go WAM bytecode trace shows the exact register clobbering at PC=9 (`GetVariable {201 3}`) and PC=85 (`BuiltinCall is/2` fails with `arg1=List` instead of `Unbound`)
- [x] Confirmed Rust lowered code has same global Y-register encoding plus missing predicate dispatch
- [x] Confirmed Python runtime lacks aggregate instruction implementation
- [x] SWI-Prolog and Haskell baseline numbers preserved unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)