### PR TITLE
feat(core): capability-based shell workarounds + brush-wasm fixes

### DIFF
--- a/docs/design/BRUSH_WASM_COMPATIBILITY.md
+++ b/docs/design/BRUSH_WASM_COMPATIBILITY.md
@@ -1,0 +1,225 @@
+# Brush WASM Compatibility Notes
+
+UnifyWeaver's SciREPL package runs generated Bash scripts inside
+[Brush](https://github.com/reubeno/brush), a Rust-based bash-compatible
+shell compiled to WebAssembly. Brush aims for full bash compatibility but
+runs on a single-threaded WASM runtime without OS process support. This
+creates a small set of behavioural differences that affect generated code.
+
+Note: these limitations are **not Brush-specific** — they stem from the
+`wasm32-unknown-unknown` target, which provides no POSIX layer at all.
+There are no syscalls for process management (`getpid`, `fork`), signals
+(`SIGPIPE`), or filesystem access (`open`, `stat`). All I/O is bridged
+through JavaScript via `wasm-bindgen`. A WASI target
+(`wasm32-wasip1/p2`) would provide some of these syscalls natively, but
+SciREPL uses `wasm32-unknown-unknown` + JS VFS interop because the
+notebook's SharedVFS architecture requires tight JS integration for
+cross-kernel file sharing.
+
+## Known Differences
+
+### 1. `$$` (Process ID) hangs
+
+**Symptom:** Any script referencing `$$` hangs indefinitely.
+
+**Cause:** `std::process::id()` calls `getpid()`, which is not available
+on `wasm32-unknown-unknown`. The call blocks forever instead of returning
+an error.
+
+**Fix applied:** Return a dummy PID (`1`) on WASM
+(`brush-core/src/expansion.rs`, `SpecialParameter::ProcessId`).
+
+**Status:** Fixed in our fork. Not yet upstreamed.
+
+### 2. `trap ... PIPE` — invalid signal
+
+**Symptom:** `trap "cleanup" EXIT PIPE` errors with
+`trap: PIPE: invalid signal specification`.
+
+**Cause:** SIGPIPE doesn't exist on WASM (no OS signals). Brush's signal
+table doesn't include it.
+
+**Workaround applied:** UnifyWeaver's transitive closure template uses
+`trap ... EXIT` without `PIPE`. The PIPE trap was only a best-effort
+SIGPIPE guard for the `tee >(grep -q ...)` pattern; EXIT alone handles
+cleanup correctly.
+
+**Status:** Workaround in UnifyWeaver templates. Could also be patched in
+Brush to silently ignore unknown signals on WASM instead of erroring.
+
+### 3. `tee >(cmd)` — output process substitution deadlocks
+
+**Symptom:** `echo x | tee >(grep y) >/dev/null` hangs forever.
+
+**Cause:** On native platforms, Brush uses `tokio::spawn` to run the
+`>(cmd)` subshell concurrently with the parent. On single-threaded WASM
+tokio, the spawned task only gets polled when the parent yields. If the
+parent (e.g. `tee`) writes synchronously without yielding, the subshell
+never runs, and the shell deadlocks.
+
+**Fix applied:** On WASM, Write process substitution uses a temp-file +
+deferred execution approach: the parent writes to a real temp file
+(not `/dev/fd/NN`), and after the parent command finishes, the subshell
+runs synchronously with the temp file as stdin
+(`brush-core/src/interp.rs`).
+
+**Note:** The temp file path is passed directly in argv (not via
+`/dev/fd/NN`) because uutils builtins like `tee` call
+`wasm_open_file()` which bypasses the `/dev/fd/NN` resolver in
+`open_file_with_mode()`.
+
+**Status:** Fixed in our fork. Candidate for upstream contribution.
+
+### 4. `[ -f file ]`, `[ -e file ]`, etc. — false negatives for VFS files
+
+**Symptom:** `touch /tmp/foo && [ -f /tmp/foo ]` returns false.
+
+**Cause:** Test predicates (`-f`, `-e`, `-d`, `-r`, `-s`) used
+`std::path::Path` methods which hit the real filesystem and ignore the
+JS-backed SharedVFS where Brush WASM stores files.
+
+**Fix applied:** On WASM, check `wasm_file_exists()` / `wasm_stat()`
+first, then fall back to the real filesystem
+(`brush-core/src/extendedtests.rs`).
+
+**Status:** Fixed in our fork. Should be upstreamed.
+
+### 5. `ls file` — "No such file or directory" for single files
+
+**Symptom:** `ls /tmp/` works but `ls /tmp/foo` fails even when the file
+exists.
+
+**Cause:** The `ls` builtin only called `wasm_list_dir()`, which returns
+`None` for non-directories.
+
+**Fix applied:** Fall back to `wasm_stat()` for single-file listings
+(`brush-uutils/src/lib.rs`).
+
+**Status:** Fixed in our fork. Should be upstreamed.
+
+### 6. `mv` — not implemented
+
+**Symptom:** `mv src dst` errors with
+`failed to execute command 'mv': operation not supported on this platform`.
+
+**Cause:** No `mv` builtin existed in brush-uutils.
+
+**Fix applied:** Added `MvBuiltin` that reads source via VFS, writes to
+destination, removes source (`brush-uutils/src/lib.rs`).
+
+**Status:** Fixed in our fork. Should be upstreamed.
+
+## Design Decision: How to Handle Incompatibilities
+
+We considered three approaches and chose option 2.
+
+### Option 1: Brush Target
+
+Add a dedicated `brush` compilation target to UnifyWeaver that generates
+Brush-compatible bash — avoiding `trap PIPE`, `$$` in filenames, output
+process substitution, and any other known gaps.
+
+**Pros:**
+- Clean separation; generated code is guaranteed to work on Brush.
+- No need to patch Brush for every gap.
+
+**Cons:**
+- Another target to maintain (templates, tests, documentation).
+- Brush aims for bash compatibility, so the gap should shrink over time,
+  making a separate target increasingly redundant.
+- Risk of the two targets drifting apart, with bugs fixed in one but not
+  the other.
+
+### Option 2: Workaround in Default Bash Templates (chosen)
+
+Adjust the default bash templates to avoid constructs that are
+problematic on Brush, as long as the change is also valid (or harmless)
+on real bash.
+
+**Pros:**
+- One target, one set of templates.
+- Changes like `trap EXIT` instead of `trap EXIT PIPE` are correct on
+  all platforms.
+- Minimal maintenance burden.
+
+**Cons:**
+- Only works when the workaround is platform-neutral. If a future
+  incompatibility requires Brush-specific code that would break real
+  bash, this approach fails and we'd need option 1 or 3.
+
+### Option 3: Patch Brush
+
+Fix each incompatibility directly in the Brush source (our fork) and
+rebuild the WASM binary.
+
+**Pros:**
+- Generated code stays idiomatic bash; no workarounds needed.
+- Benefits all Brush users if upstreamed.
+
+**Cons:**
+- Requires Rust + wasm-pack toolchain for every fix.
+- Rebuild cycle is ~90 seconds; adds friction during development.
+- Some gaps (like SIGPIPE) are inherent to WASM's lack of OS signals
+  and may not have clean Brush-level fixes.
+
+### Predicate-Controlled Behaviour
+
+Regardless of which option is the default, users should be able to opt
+into or out of Brush-specific workarounds via a constraint or option
+predicate. For example:
+
+```prolog
+% Use Brush-compatible workarounds (the default in SciREPL context)
+:- set_constraint(ancestor/2, shell_compat(brush)).
+
+% Use full bash features (for native execution)
+:- set_constraint(ancestor/2, shell_compat(bash)).
+
+% Or as a compile option:
+compile_recursive(ancestor/2, [shell(brush)], Code).
+```
+
+When `shell(brush)` is active, the compiler would:
+- Use `trap ... EXIT` without `PIPE`
+- Avoid `$$` in temp file names (use `$RANDOM` or a counter instead)
+- Avoid output process substitution `tee >(cmd)` in favour of temp
+  files or sequential pipelines
+- Prefer builtins known to exist in brush-uutils
+
+When `shell(bash)` is active (or unspecified on native), the compiler
+generates idiomatic bash with no restrictions.
+
+This keeps option 2 as the default while giving users an escape hatch
+in both directions. The predicate could also be set globally via
+`preferences.pl` so SciREPL workbooks automatically compile with
+Brush compatibility without per-predicate annotations.
+
+### Recommendation
+
+Use option 2 as the default. When a workaround would compromise the
+generated code's correctness or readability on real bash, fall back to
+option 3 (patch Brush). Reserve option 1 for if the gap grows large
+enough to justify a dedicated target — currently it does not.
+
+The `shell_compat` predicate (described above) provides a migration path:
+if option 1 becomes necessary in the future, the predicate-based
+switching is already in place.
+
+## Brush Fork Location
+
+Our patched Brush lives at `~/Projects/brush` (local) and
+`github.com/s243a/brush` (remote). The WASM binary is committed to the
+SciREPL submodule at
+`examples/sci-repl/prototype/www/vendor/brush/brush_wasm_bg.wasm`.
+
+## Upstream Contribution Candidates
+
+The following fixes are general improvements that would benefit all Brush
+WASM users and are good candidates for upstream PRs to
+`github.com/reubeno/brush`:
+
+1. `$$` returning dummy PID on WASM
+2. Write process substitution temp-file approach on WASM
+3. Test predicates checking VFS before real filesystem
+4. `ls` single-file fallback to `wasm_stat`
+5. `mv` builtin for WASM

--- a/src/unifyweaver/core/shell_capabilities.pl
+++ b/src/unifyweaver/core/shell_capabilities.pl
@@ -1,0 +1,87 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+%% shell_capabilities.pl - Shell Environment Capability Detection
+%
+% Declares what the target shell environment supports. The compiler
+% uses these capabilities to choose between idiomatic bash and
+% portable workarounds (e.g. avoiding $$ on WASM where getpid()
+% is unavailable).
+%
+% Capabilities are auto-detected at load time based on the Prolog
+% runtime's architecture flags. Users can override via assert/retract
+% or compile options like shell_env(Cap).
+%
+% See: docs/design/BRUSH_WASM_COMPATIBILITY.md
+
+:- module(shell_capabilities, [
+    shell_has/1,
+    shell_lacks/1,
+    shell_is_wasm/0,
+    set_shell_capability/1,
+    clear_shell_capability/1
+]).
+
+:- dynamic shell_capability/1.
+
+%% shell_has(+Capability) is semidet.
+%
+%  True if the shell environment has the given capability.
+%
+%  Known capabilities:
+%    signals     - OS signal delivery (SIGPIPE, SIGTERM, etc.)
+%    procfs      - /dev/fd/NN file descriptor pseudo-filesystem
+%    syscalls    - POSIX syscalls (getpid, fork, exec, etc.)
+%    processes   - multiple concurrent processes / subshells
+%
+shell_has(Cap) :- shell_capability(Cap).
+
+%% shell_lacks(+Capability) is semidet.
+%
+%  True if the shell environment does NOT have the given capability.
+%
+shell_lacks(Cap) :- \+ shell_capability(Cap).
+
+%% shell_is_wasm is semidet.
+%
+%  True if running on a WebAssembly target (wasm32).
+%
+shell_is_wasm :-
+    current_prolog_flag(arch, Arch),
+    atom_string(Arch, ArchStr),
+    sub_string(ArchStr, _, _, _, "wasm").
+
+%% set_shell_capability(+Capability) is det.
+%
+%  Declare that the shell environment has a capability.
+%
+set_shell_capability(Cap) :-
+    (   shell_capability(Cap) -> true
+    ;   assertz(shell_capability(Cap))
+    ).
+
+%% clear_shell_capability(+Capability) is det.
+%
+%  Declare that the shell environment lacks a capability.
+%
+clear_shell_capability(Cap) :-
+    retractall(shell_capability(Cap)).
+
+% ============================================================================
+% AUTO-DETECTION AT LOAD TIME
+% ============================================================================
+
+:- (   shell_is_wasm
+   ->  % WASM: no OS-level features available.
+       % All I/O goes through JS VFS bridge.
+       true
+   ;   % Native: full POSIX capabilities.
+       set_shell_capability(signals),
+       set_shell_capability(procfs),
+       set_shell_capability(syscalls),
+       set_shell_capability(processes)
+   ).

--- a/src/unifyweaver/core/template_system.pl
+++ b/src/unifyweaver/core/template_system.pl
@@ -443,7 +443,7 @@ generate_transitive_closure(PredName, BaseName, Options, Code) :-
     local queue_file="/tmp/{{pred}}_queue_$$"
     local next_queue="/tmp/{{pred}}_next_$$"
     
-    trap "rm -f $queue_file $next_queue" EXIT PIPE
+    trap "rm -f $queue_file $next_queue" EXIT
     
     echo "$start" > "$queue_file"
     visited["$start"]=1

--- a/src/unifyweaver/core/template_system.pl
+++ b/src/unifyweaver/core/template_system.pl
@@ -359,9 +359,9 @@ template(bfs_init, '
     local start="$1"
     declare -A visited
     declare -A output_seen
-    local queue_file="/tmp/{{prefix}}_queue_$$"
-    local next_queue="/tmp/{{prefix}}_next_$$"
-    trap "rm -f $queue_file $next_queue" EXIT
+    local queue_file="/tmp/{{prefix}}_queue_{{tmp_suffix}}"
+    local next_queue="/tmp/{{prefix}}_next_{{tmp_suffix}}"
+    trap "rm -f $queue_file $next_queue" {{trap_signals}}
     echo "$start" > "$queue_file"
     visited["$start"]=1').
 
@@ -420,7 +420,58 @@ generate_transitive_closure(PredName, BaseName, Options, Code) :-
     atom_string(PredName, PredStr),
     atom_string(BaseName, BaseStr),
     constraint_analyzer:get_dedup_strategy(Options, Strategy),
-    
+
+    % Determine shell capabilities for portable code generation.
+    % Options can include shell_env([no_syscalls, no_processes, ...]) to
+    % declare missing capabilities. On WASM (auto-detected via
+    % shell_capabilities module), these default to the restricted set.
+    (   member(shell_env(EnvList), Options), is_list(EnvList)
+    ->  true
+    ;   detect_shell_env(EnvList)
+    ),
+
+    % When syscalls are unavailable, avoid $$ (getpid hangs on WASM).
+    (   member(no_syscalls, EnvList)
+    ->  TempSuffix = "$RANDOM",
+        TrapSignals = "EXIT"
+    ;   TempSuffix = "$$",
+        TrapSignals = "EXIT"
+    ),
+
+    % When process features are limited, avoid tee >(cmd) and use
+    % a sequential pipeline instead.
+    (   member(no_processes, EnvList)
+    ->  UseSequentialCheck = true
+    ;   UseSequentialCheck = false
+    ),
+
+    % Build the _check() function body based on capabilities.
+    atom_string(TempSuffix, TempSuffixStr),
+    atom_string(TrapSignals, TrapSignalsStr),
+    (   UseSequentialCheck = true
+    ->  CheckBody = '
+    local _result="/tmp/{{pred}}_result_{{tmp_suffix}}"
+    {{pred}}_all "$start" 2>/dev/null > "$_result"
+    if grep -q "^$start:$target$" "$_result"; then
+        rm -f "$_result"
+        return 0
+    else
+        rm -f "$_result"
+        return 1
+    fi'
+    ;   CheckBody = '
+    local tmpflag="/tmp/{{pred}}_found_{{tmp_suffix}}"
+    {{pred}}_all "$start" 2>/dev/null |
+    tee >(grep -q "^$start:$target$" && touch "$tmpflag") >/dev/null 2>&1
+    if [[ -f "$tmpflag" ]]; then
+        rm -f "$tmpflag"
+        return 0
+    else
+        rm -f "$tmpflag"
+        return 1
+    fi'
+    ),
+
     Template = '#!/bin/bash
 # {{pred}} - transitive closure of {{base}}
 
@@ -440,17 +491,17 @@ generate_transitive_closure(PredName, BaseName, Options, Code) :-
 {{pred}}_all() {
     local start="$1"
     declare -A visited
-    local queue_file="/tmp/{{pred}}_queue_$$"
-    local next_queue="/tmp/{{pred}}_next_$$"
-    
-    trap "rm -f $queue_file $next_queue" EXIT
-    
+    local queue_file="/tmp/{{pred}}_queue_{{tmp_suffix}}"
+    local next_queue="/tmp/{{pred}}_next_{{tmp_suffix}}"
+
+    trap "rm -f $queue_file $next_queue" {{trap_signals}}
+
     echo "$start" > "$queue_file"
     visited["$start"]=1
-    
+
     while [[ -s "$queue_file" ]]; do
         > "$next_queue"
-        
+
         while IFS= read -r current; do
             while IFS=":" read -r from to; do
                 if [[ "$from" == "$current" && -z "${visited[$to]}" ]]; then
@@ -460,10 +511,10 @@ generate_transitive_closure(PredName, BaseName, Options, Code) :-
                 fi
             done < <({{base}}_get_stream | grep "^$current:")
         done < "$queue_file"
-        
+
         mv "$next_queue" "$queue_file"
     done
-    
+
     rm -f "$queue_file" "$next_queue"
 }
 
@@ -471,19 +522,7 @@ generate_transitive_closure(PredName, BaseName, Options, Code) :-
 {{pred}}_check() {
     local start="$1"
     local target="$2"
-    local tmpflag="/tmp/{{pred}}_found_$$"
-    
-    # Use tee to prevent SIGPIPE when grep exits early (suppress all errors)
-    {{pred}}_all "$start" 2>/dev/null | 
-    tee >(grep -q "^$start:$target$" && touch "$tmpflag") >/dev/null 2>&1
-    
-    if [[ -f "$tmpflag" ]]; then
-        rm -f "$tmpflag"
-        return 0
-    else
-        rm -f "$tmpflag"
-        return 1
-    fi
+{{check_body}}
 }
 
 # Main entry point
@@ -520,7 +559,10 @@ generate_transitive_closure(PredName, BaseName, Options, Code) :-
     render_template(Template, [
         pred = PredStr,
         base = BaseStr,
-        strategy = Strategy
+        strategy = Strategy,
+        tmp_suffix = TempSuffixStr,
+        trap_signals = TrapSignalsStr,
+        check_body = CheckBody
     ], Code).
 
 %% Deduplication wrapper template
@@ -709,3 +751,33 @@ test_template_system :-
     clear_template_cache(test_cached),
 
     writeln('=== Template System Tests Complete ===').
+
+% ============================================================================
+% SHELL CAPABILITY DETECTION
+% ============================================================================
+
+%% detect_shell_env(-EnvList) is det.
+%
+%  Auto-detect shell environment limitations. Returns a list of atoms
+%  like [no_syscalls, no_processes, no_signals] describing what the
+%  target shell lacks. Empty list means full bash capabilities.
+%
+%  Detection order:
+%    1. If shell_capabilities module is loaded, query it.
+%    2. Otherwise assume full capabilities (native).
+%
+detect_shell_env(EnvList) :-
+    (   catch(
+            ( shell_capabilities:shell_lacks(syscalls) -> L1 = [no_syscalls] ; L1 = [] ),
+            _, L1 = []
+        ),
+        catch(
+            ( shell_capabilities:shell_lacks(processes) -> L2 = [no_processes] ; L2 = [] ),
+            _, L2 = []
+        ),
+        catch(
+            ( shell_capabilities:shell_lacks(signals) -> L3 = [no_signals] ; L3 = [] ),
+            _, L3 = []
+        ),
+        append([L1, L2, L3], EnvList)
+    ).


### PR DESCRIPTION
  ## Summary

  - **Shell capabilities module** (`shell_capabilities.pl`): auto-detects WASM at load time via Prolog `arch` flag. Declares what the target shell lacks (`syscalls`, `signals`, `processes`, `procfs`). On
  native, all capabilities are present.
  - **Capability-aware templates**: `generate_transitive_closure` checks capabilities and adjusts:
    - `no_syscalls` → `$RANDOM` instead of `$$` for temp file names
    - `no_processes` → sequential `grep -q` on temp file instead of `tee >(grep ...)`
    - Can be overridden per-compile: `compile_recursive(P/A, [shell_env([no_syscalls])], Code)`
  - **Template fix**: `trap ... EXIT` without `PIPE` (SIGPIPE doesn't exist on WASM)
  - **Design doc** (`docs/design/BRUSH_WASM_COMPATIBILITY.md`): documents all known Brush WASM gaps, the three approaches considered (Brush target / default workaround / patch Brush), capability-based
  predicate design, and upstream contribution candidates
  - **Submodule bump**: picks up brush-wasm with `$$`, `mv`, stat, ls, and tee fixes

  ## Capability detection example

  ```prolog
  % Auto-detected on WASM (no manual config needed):
  ?- shell_lacks(syscalls).   % true on wasm32, false on x86_64
  ?- shell_lacks(processes).  % true on wasm32, false on x86_64

  % Explicit override via compile options:
  compile_recursive(ancestor/2, [shell_env([no_syscalls, no_processes])], Code).

  % Native compile (no restrictions):
  compile_recursive(ancestor/2, [], Code).

  Test plan

  - Native: compile_recursive(ancestor/2, [], Code) generates $$ and tee >(...)
  - With shell_env([no_syscalls, no_processes]): generates $RANDOM and sequential grep
  - Simulated WASM (clear capabilities): auto-detects and generates portable code
  - shell_capabilities.pl loads cleanly on both native and wasm32 targets
  - Family Tree + Recursion Patterns notebooks run end-to-end in SciREPL

  � Generated with https://claude.com/claude-code