### PR TITLE
fix(wam-elixir): isolate Y-regs per env frame; document non-tail recursion bug

### DIFF
--- a/docs/design/WAM_ELIXIR_CORRECTNESS_GAPS.md
+++ b/docs/design/WAM_ELIXIR_CORRECTNESS_GAPS.md
@@ -2,138 +2,126 @@
 
 Running status doc for correctness issues in the Elixir target surfaced
 while attempting to benchmark Phase A+B+C optimizations on
-`examples/benchmark/effective_distance.pl`. The pipeline compiles and
-executes but still produces fewer result rows than the reference.
+`examples/benchmark/effective_distance.pl`.
 
 ## Fixed
 
 ### `!/0` (cut) not implemented in `execute_builtin`
 
-`WamRuntime.execute_builtin/3` had no arm for `!/0`; unknown ops hit the
-`_ -> :fail` catch-all, so every clause with a cut (including
-`category_ancestor/4`'s recursive arm) threw `:fail` at the cut call.
-Added an arm that clears `choice_points` and advances `pc` — a
-conservative approximation matching the green-cut usage the compiler
-emits.
+`WamRuntime.execute_builtin/3` had no arm for `!/0`; every clause with a
+cut threw `:fail` at the cut call. Added an arm that clears
+`choice_points` and advances `pc`.
 
 ### A and X register namespace collision in `reg_id/2`
 
-Both `A1` and `X1` mapped to integer id `1`. The WAM compiler freely
-emits sequences like `get_variable X3, A1` while `A3` is still live, so
-the store clobbered `A3` before its next read. Reg banks now map to
-distinct ranges (`A: 1-99`, `X: 101-199`, `Y: 201-299`), matching the
-Haskell target's `reg_name_to_int` convention.
+Both `A1` and `X1` mapped to integer id `1`. Reg banks now map to
+distinct ranges (`A: 1-99`, `X: 101-199`, `Y: 201-299`).
 
 ### `write_ctx` leak from `put_structure` / `put_list` in lowered emitter
 
-The lowered emitter pushed `[{:write_ctx, N} | state.stack]` mirroring
-the interpreter, but lowered `set_variable` / `set_value` inline heap
-writes directly — they never consume the ctx. Subsequent `deallocate`
-popped the residual tuple expecting an env map → `BadMapError`. Stop
-pushing the ctx in put-mode.
+Lowered put-mode ops pushed a `write_ctx` frame that `set_variable` /
+`set_value` never consumed, corrupting the stack for `deallocate`.
+Fixed by removing the push from put-mode ops.
 
 ### `WamDispatcher.call` had no builtin fallback
 
-Meta-calls like `\+ member(Parent, Visited)` route through
-`WamDispatcher.call` at runtime. The dispatcher threw
-`{:undefined_predicate, pred}` for anything outside the user-compiled
-module table. Default clause now falls through to
-`WamRuntime.execute_builtin` before throwing.
+Default clause now falls through to `WamRuntime.execute_builtin` before
+throwing `{:undefined_predicate, _}`, so meta-calls like `\+ member(...)`
+resolve.
 
 ### `backtrack/1` let clause exceptions escape
 
-`backtrack/1` invokes `cp.pc.(state)` to resume the next clause, which
-may `throw :fail` or `throw {:return, result}`. Both escaped instead of
-translating back into the `{:ok, state} | :fail` contract. Added
-`try`/`catch` that cascades to the next CP on `:fail` and unwraps
+Added `try`/`catch` that cascades to the next CP on `:fail` and unwraps
 `{:return, _}`.
 
 ### Caller-supplied unbound id collided with register numbers
 
-`run(args)` put caller-supplied `{:unbound, N}` literally at
-`state.regs[N]`. When a subsequent `put_variable` during the body
-overwrote `regs[N]` with a fresh unbound, any saved copy of the
-original unbound (e.g., `Y2` holding `{:unbound, N}`) would deref
-through the overwritten slot and pick up the unrelated new chain.
-
-Fix: `run(args)` now rewrites every caller-supplied unbound to
-`{:unbound, make_ref()}` — the make_ref cannot collide with any reg
-slot, so overwriting an A-reg no longer corrupts the binding chain of
-the original variable.
+`run(args)` now rewrites each caller-supplied `{:unbound, _}` to
+`{:unbound, make_ref()}` so the id cannot collide with any reg slot.
 
 ### A-registers used as scratch; driver couldn't read outputs
 
-Even with the unbound-id rewrite, A-regs get used as scratch during
-body execution (e.g., `put_structure +/2, A2` overwrites A2 with a
-heap ref for the arithmetic expression). After the predicate returns,
-`state.regs[i]` holds whatever intermediate value the body last wrote,
-not the caller's output binding.
+Added `WamState.arg_vars`, `WamRuntime.materialise_args/1`, and
+`WamRuntime.next_solution/1`. Drivers read outputs from `state.regs[i]`
+transparently after the wrappers deref the tracked unbound.
 
-Fix: track each caller-supplied unbound's ref in `state.arg_vars`,
-added as a field to `WamState`. The driver-facing `run/1` calls
-`WamRuntime.materialise_args/1` before returning, which derefs each
-tracked ref against the final state and writes the resolved value
-back to `regs[i]`. Added `WamRuntime.next_solution/1` wrapping
-`backtrack/1` with the same materialisation so enumerating alternatives
-gives correct output regs on every iteration.
+### Y-registers globally shared across recursive calls
 
-## Remaining: Y-register clobbering across recursive calls
+Y-registers (ids 201-299) lived in the global `state.regs` map, so
+recursive calls to the same predicate overwrote each other's
+permanents. `allocate` now saves the current Y-reg subset into
+`env.y_regs_saved` and clears those slots; `deallocate` discards
+current Y-regs and merges the saved ones back. Correctness improvement
+but not observable in the current benchmark because of the
+non-tail-call continuation bug below.
 
-Y-registers (permanent variables) live in `state.regs` at ids 201-299
-— the same flat map that holds A/X regs. `allocate` pushes an empty
-env frame but doesn't isolate Y-reg slots; `deallocate` pops but
-doesn't restore. So recursive calls to the same predicate overwrite
-each other's Y-regs.
+## Remaining: non-tail recursive calls lose the outer continuation in lowered mode
 
-Concretely, for `ancestor_h(X, Y, N) :- parent(X, Z), ancestor_h(Z, Y, N1), N is N1 + 1`:
+The lowered emitter represents each clause as a standalone Elixir
+function. `WamDispatcher.call` invokes a predicate's clause; the clause
+runs to completion and returns `{:ok, state}`. For a non-tail body like
+`body_goal(...), is/2` (`ancestor_h(X,Y,N) :- parent(X,Z), ancestor_h(Z,Y,N1), N is N1+1`):
 
-- Outer's `Y3` (holding caller's `N` ref) lives at `state.regs[203]`.
-- Inner recursive call's `Y3` (holding inner's `N1` ref) also writes
-  `state.regs[203]`, overwriting the outer's.
-- After the inner returns, outer's `put_value Y3, A1` picks up the
-  inner's ref instead of its own — `is/2` binds the wrong variable.
+- First solution works: outer's clause runs straight through, calls
+  inner, gets its return, runs outer's `is/2`, returns.
+- On backtrack: `backtrack/1` pops inner's CP and invokes
+  `&clause_LAncestorH32/1` directly with the restored state. Inner's
+  clause runs to completion — including its own `is/2` — and returns.
+  The result propagates through `backtrack` to `next_solution` and out
+  to the driver. **Outer's post-call code (reading Y3 for N, running
+  its own is/2) is never re-entered.**
 
-Observable in `examples/debug_wam_elixir_ancestor.pl`:
+Consequence: alternative solutions show the inner's `N` binding but
+not the outer's. In `examples/debug_wam_elixir_ancestor.pl` Test 3
+with a 4-level fact chain:
 
-- **Test 1** (`ancestor(X, Y) :- parent(X, Y); parent(X, Z), ancestor(Z, Y)`) — plain
-  variable propagation, no body-side A-reg clobbering. Returns all 3
-  solutions correctly.
-- **Test 2** (`ancestor_h("a", "d", N)` — bound Y, unbound N). Returns
-  no solutions. The 3-hop case requires recursion; the Y-reg corruption
-  makes the final `is/2` fail.
-- **Test 3** (`ancestor_h("a", Y, N)` — both unbound). First two
-  solutions partially correct (Y right, N right for depth 1 and 2). Third
-  solution has Y correct ("d") but N unbound — the deepest recursion
-  clobbers the outer-most Y-reg.
+```
+Y="b" N="1"                                (1st — base case, ok)
+Y="c" N=2.0                                (2nd — 1-hop recursion, ok)
+Y="d" N={:unbound, <caller's N ref>}      (3rd — 2-hop, N not bound)
+Y="e" N={:unbound, <caller's N ref>}      (4th — 3-hop, N not bound)
+```
+
+Traces confirm: on the 3rd+ backtrack, inner's `is/2` binds inner's
+local `N` ref (~206372) but outer's caller-`N` ref (~206345) stays
+unbound because outer's `is/2` never runs.
 
 ### Fix shape
 
-Y-regs need to live in the env frame, not the global regs map. Minimal
-approach:
+The lowered emitter needs to preserve the outer's continuation across
+a `call`. Options:
 
-- `allocate` saves the current Y-reg subset (keys 201-299 from
-  `state.regs`) into `env.y_regs`, then clears those keys.
-- `deallocate` pops the env, removes the current Y-reg subset, and
-  merges the saved ones back.
-- Trail entries for Y-regs during the body need careful handling —
-  either scope the trail per env frame, or ensure `deallocate` strips
-  body-time trail entries for Y-regs before they can corrupt a later
-  unwind.
+1. **Continuation passing.** A clause takes a `k` (continuation)
+   parameter and tail-calls it with the final state. Every `call` in
+   the body captures the post-call code in a closure and passes it as
+   `k` to the callee. Backtrack's `cp.pc.(state, k)` would then invoke
+   the retry with the saved continuation.
+2. **State.cp as function ref.** Store the post-call function in
+   `state.cp` before each `call`; have `proceed` invoke `state.cp`.
+   Matches the interpreter-mode abstraction but requires the lowered
+   emitter to synthesise a fresh `defp` for each call-point's
+   continuation.
+3. **Interpreter fallback.** Detect non-tail recursive calls at
+   codegen time and emit interpreter-style dispatch for those
+   predicates.
 
-This is a larger refactor than the run/next-solution API fix and is
-staged as its own PR.
+Option 2 is probably the cleanest given the existing `state.cp` field
+already exists. Option 3 is the smallest change but splits the
+generated code into two regimes.
+
+Fact-only predicates, plain tail-recursive predicates, and
+deterministic clauses work correctly today; only non-tail recursion is
+affected.
 
 ## Out of scope for this doc
 
-- `switch_on_constant` duplicate-key warnings were fixed earlier
-  (`fix/wam-elixir-switch-dedup-arms`).
+- `switch_on_constant` duplicate-key warnings — fixed in
+  `fix/wam-elixir-switch-dedup-arms`.
 - Phase A/B/C perf work is orthogonal.
 
 ## Implication for benchmarking
 
 `effective_distance` at dev scale still produces 3 rows vs the 19-row
-reference. The driver-API fixes in this PR don't change the benchmark
-number because the benchmark's bottleneck is multi-hop recursion
-through `category_ancestor/4`, which trips the Y-reg clobbering bug on
-every non-trivial path. Meaningful perf comparisons against
-Haskell/Rust still require the Y-reg fix.
+reference because `category_ancestor/4` has non-tail recursion (cut
+and `H is H1 + 1` after the recursive call). Meaningful perf
+comparisons still require the continuation fix.

--- a/examples/debug_wam_elixir_ancestor.pl
+++ b/examples/debug_wam_elixir_ancestor.pl
@@ -36,6 +36,7 @@ load_test_predicates :-
     assertz((user:parent("a", "b"))),
     assertz((user:parent("b", "c"))),
     assertz((user:parent("c", "d"))),
+    assertz((user:parent("d", "e"))),
     assertz((user:ancestor(X, Y) :- user:parent(X, Y))),
     assertz((user:ancestor(X, Y) :- user:parent(X, Z), user:ancestor(Z, Y))),
     % Mirror category_ancestor's arithmetic-hops pattern:

--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -365,12 +365,19 @@ wam_elixir_lower_instr(trust_me, _PC, _Labels, _FuncName, Code) :-
     Code = '    :ok # Handled by wrap_segment'.
 
 wam_elixir_lower_instr(allocate, _PC, _Labels, _FuncName, Code) :-
-    Code = '    new_env = %{cp: state.cp, regs: %{}}
-    state = %{state | stack: [new_env | state.stack]}'.
+    Code = '    # Save caller\'s Y-regs so the callee can freely overwrite
+    # slots 201-299 without corrupting the outer frame. Env popped by
+    # deallocate.
+    {y_regs_saved, base_regs} = WamRuntime.split_y_regs(state.regs)
+    new_env = %{cp: state.cp, y_regs_saved: y_regs_saved}
+    state = %{state | stack: [new_env | state.stack], regs: base_regs}'.
 
 wam_elixir_lower_instr(deallocate, _PC, _Labels, _FuncName, Code) :-
     Code = '    state = case state.stack do
-      [env | rest] -> %{state | cp: env.cp, stack: rest}
+      [env | rest] ->
+        {_callee_ys, base_regs} = WamRuntime.split_y_regs(state.regs)
+        merged = Map.merge(base_regs, Map.get(env, :y_regs_saved, %{}))
+        %{state | cp: env.cp, stack: rest, regs: merged}
       _ -> state
     end'.
 

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -251,13 +251,20 @@ wam_elixir_case(proceed,
 
 wam_elixir_case(allocate,
 '      {:allocate, _n} ->
-        new_env = %{cp: state.cp, regs: %{}}
-        %{state | stack: [new_env | state.stack], pc: state.pc + 1}').
+        # Save caller\'s Y-regs in the new env so the callee can freely
+        # use Y-reg slots (ids 201-299) without clobbering the caller.
+        {y_regs_saved, base_regs} = WamRuntime.split_y_regs(state.regs)
+        new_env = %{cp: state.cp, y_regs_saved: y_regs_saved}
+        %{state | stack: [new_env | state.stack], regs: base_regs, pc: state.pc + 1}').
 
 wam_elixir_case(deallocate,
 '      :deallocate ->
         case state.stack do
-          [env | rest] -> %{state | cp: env.cp, stack: rest, pc: state.pc + 1}
+          [env | rest] ->
+            # Discard current frame\'s Y-regs and restore the caller\'s.
+            {_callee_ys, base_regs} = WamRuntime.split_y_regs(state.regs)
+            merged = Map.merge(base_regs, Map.get(env, :y_regs_saved, %{}))
+            %{state | cp: env.cp, stack: rest, regs: merged, pc: state.pc + 1}
           _ -> %{state | pc: state.pc + 1}
         end').
 
@@ -446,6 +453,23 @@ compile_utility_helpers_to_elixir(Code) :-
       [_, arity_str] -> String.to_integer(arity_str)
       _ -> 0
     end
+  end
+
+  @doc """
+  Partition a regs map into {y_regs, other_regs} by reg-id range.
+  Y-registers use ids 201..299 (see wam_elixir_utils:reg_id/2).
+  Used by allocate/deallocate to isolate Y-regs per env frame —
+  without this, recursive calls to the same predicate clobber each
+  other\'s permanents.
+  """
+  def split_y_regs(regs) do
+    Enum.reduce(regs, {%{}, %{}}, fn {k, v}, {ys, others} ->
+      if is_integer(k) and k >= 201 and k < 300 do
+        {Map.put(ys, k, v), others}
+      else
+        {ys, Map.put(others, k, v)}
+      end
+    end)
   end
 
   @doc """


### PR DESCRIPTION
## Summary

Y-register frame isolation plus investigation that pinpoints the next
correctness blocker. Neither piece lands a benchmark-visible win on
its own, but together they narrow the remaining work to one concrete
architectural problem in the lowered emitter. Full picture in
`docs/design/WAM_ELIXIR_CORRECTNESS_GAPS.md`.

## Fix 1 — Y-register frame isolation

Y-registers (ids 201-299) previously shared the global `state.regs`
map, so recursive calls to the same predicate overwrote each other's
permanents.

- Added `WamRuntime.split_y_regs/1` to partition regs by id range.
- `allocate` now saves the current Y-reg subset into
  `env.y_regs_saved` and clears those slots from `state.regs`.
- `deallocate` discards the current frame's Y-regs and merges the
  saved ones back.
- Applied to both the lowered emitter (`wam_elixir_lowered_emitter.pl`)
  and the interpreter opcode arms (`wam_elixir_target.pl`).

This is a correctness improvement but doesn't change observable
benchmark behavior — the non-tail-continuation bug below masks it at
dev scale.

## Investigation — non-tail recursive calls lose the outer continuation

Traced the `ancestor_h/3` reproducer with `IO.puts` around
`allocate`/`deallocate` and post-call reads. Y-regs are now correctly
restored. But non-tail recursion still fails at depth 3+ because:

The lowered emitter represents each clause as a standalone Elixir
`defp`. `WamRuntime.backtrack/1` invokes `cp.pc.(state)` as a fresh
call; the inner clause runs to completion — including its own
`is/2` — and returns. **The outer's post-call code (reading `Y3`,
computing `N = N1 + 1`) is never re-entered for alternative
solutions.**

Concretely, for `ancestor_h(X, Y, N) :- parent(X, Z), ancestor_h(Z, Y, N1), N is N1 + 1`:

- 1st / 2nd solution (base case, 1-hop recursion): works.
- 3rd+ solution: traces show inner's `is/2` binds inner's local `N1`
  ref; outer's caller-`N` ref stays unbound because outer's `is/2`
  never runs.

Reproducer `examples/debug_wam_elixir_ancestor.pl` extended to a
4-level fact chain. Test 3 demonstrates the symptom clearly:

```
Y="b" N="1"                                (base case)
Y="c" N=2.0                                (1-hop, ok)
Y="d" N={:unbound, <caller's N ref>}      (2-hop, N never bound)
Y="e" N={:unbound, <caller's N ref>}      (3-hop, N never bound)
```

## Fix shape (future PR)

Three options discussed in the gaps doc:

1. Continuation-passing — clauses take a `k` parameter; every `call`
   captures post-call code in a closure; backtrack's
   `cp.pc.(state, k)` invokes the retry with the saved continuation.
2. **`state.cp` as function ref** — store the post-call function in
   `state.cp` before each `call`; `proceed` invokes `state.cp`.
   Matches the interpreter-mode abstraction. Probably cleanest.
3. Interpreter fallback — detect non-tail recursive calls at codegen
   time and emit interpreter-style dispatch for those predicates.

Left as the next PR — substantial enough to not bundle here.

## Verification

- `tests/test_wam_elixir_target.pl` — 14/14 pass
- `tests/test_wam_elixir_utils.pl` — 7/7 pass
- `swipl -q -s examples/debug_wam_elixir_ancestor.pl -t halt`:
  - Test 1 (plain ancestor/2, 4-level chain): 4/4 solutions, all
    correct. Unchanged — plain recursion isn't affected.
  - Test 3 (ancestor_h/3, 4-level chain): demonstrates the non-tail
    bug at depth 3+.
- `effective_distance` dev scale: 3/19 rows, unchanged — benchmark
  hits the non-tail bug on every multi-hop path.

## Test plan

- [ ] `swipl -g run_tests -t halt tests/test_wam_elixir_target.pl`
- [ ] `swipl -g run_tests -t halt tests/test_wam_elixir_utils.pl`
- [ ] `swipl -q -s examples/debug_wam_elixir_ancestor.pl -t halt` (Test 1 green, Test 3 shows the symptom at depth 3+)

---
*Co-authored-By: Claude Opus 4.7 (1M context)*
