### PR TITLE
docs(csharp-query): Define the counted path `All` row allocation contract

### DIFF
--- a/docs/proposals/COUNTED_PATH_ALL_ROW_ALLOCATION_CONTRACT.md
+++ b/docs/proposals/COUNTED_PATH_ALL_ROW_ALLOCATION_CONTRACT.md
@@ -1,0 +1,90 @@
+# Counted Path `All` Row Allocation Contract
+
+This note defines the current row-allocation contract for counted-path `All`
+materialization in the C# query runtime.
+
+It complements
+[`COUNTED_PATH_ALL_ORDERING_CONTRACT.md`](./COUNTED_PATH_ALL_ORDERING_CONTRACT.md),
+which explains the current observable row ordering.
+
+## Current Runtime Contract
+
+Today, counted-path `All` rows are materialized as fresh `object[]` instances
+at the replay boundary in `PathAwareTransitiveClosureNode`.
+
+That is not an isolated implementation detail. It fits into a broader runtime
+shape where query rows are represented pervasively as `object[]`:
+
+- plan execution surfaces return `IEnumerable<object[]>`
+- replay/materialization surfaces use `List<object[]>`
+- caches and retained result maps store `IReadOnlyList<object[]>`
+- set/index helpers such as `RowWrapper` and fact/join indexes are defined in
+  terms of `object[]`
+- the C# runtime test harnesses print and compare rows through `object[]`
+
+In code, the relevant boundaries include:
+
+- `IReplayableRelationSource`
+- `ReplayableRelationSource`
+- `EvaluationContext` result caches and materialized stores
+- `RowWrapper`
+- `MaterializePathAwareDepthRows`
+
+all in
+[`QueryRuntime.cs`](../../src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs),
+plus the test harness entry points in
+[`test_csharp_query_target.pl`](../../tests/core/test_csharp_query_target.pl).
+
+## Why This Matters
+
+The recent counted-path `All` replay survey showed that row allocation is the
+largest write-side cost on the current benchmark shape.
+
+That naturally raises the question:
+
+"Can counted-path `All` avoid allocating a fresh `object[]` per row?"
+
+Under the current runtime structure, the answer is effectively "not locally."
+
+The materialization site is only the last step in a runtime that already
+expects rows to be `object[]` across:
+
+- execution interfaces
+- replayable sources
+- memoized result caches
+- structural row wrappers
+- fact and join indexing
+- test harness consumption
+
+That means a narrower counted-path-only row-shape substitution would still
+have to cross back into `object[]` immediately at the surrounding runtime
+boundary, unless the broader row representation contract changes too.
+
+## What This Does And Does Not Rule Out
+
+This contract does **not** mean counted-path `All` can never get faster.
+
+It does mean:
+
+- allocator swaps at the final `object[]` construction site are likely to be
+  low-signal unless they materially change allocation behavior
+- the runtime is near the end of easy counted-path-only row-shape wins that do
+  not affect broader row representation
+- larger gains probably require either fewer rows, later conversion to
+  `object[]`, or a broader runtime/container contract change
+
+## Practical Implication
+
+If we want a larger counted-path `All` replay win from row shaping, the next
+question is not:
+
+"Which tiny `object[]` allocation variant should we try next?"
+
+The next question is:
+
+"Is there a broader runtime boundary where rows can remain in a narrower
+internal representation longer before conversion to `object[]`?"
+
+Until that broader contract changes, fresh `object[]` row materialization is a
+real current runtime boundary, not just a local counted-path implementation
+choice.

--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -212,6 +212,9 @@ Interpretation:
   `path_state_result_replay_value_lookup` and
   `path_state_result_replay_row_alloc`; on the current benchmark shape, row
   allocation is the larger write-side cost, with value lookup still visible
+- counted-path `All` row allocation is now documented as a broader runtime
+  boundary rather than a purely local replay-loop choice, because execution
+  surfaces, caches, wrappers, and tests all currently expect `object[]` rows
 - counted-path traversal and buffered replay now operate on interned node ids
   with edge-state lookup tables, avoiding repeated object-key dictionary
   lookups on the hot path while preserving exact output values at final

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -1054,6 +1054,10 @@ Additional path-state observations:
   `path_state_result_replay_value_lookup` and
   `path_state_result_replay_row_alloc`; on the current benchmark shape, row
   allocation is the larger share of replay write cost.
+- counted-path `All` row allocation is now documented as a broader runtime
+  boundary, not just a local replay-loop choice, because execution surfaces,
+  caches, wrappers, and test harnesses all currently traffic in `object[]`
+  rows.
 - counted-path replay/materialization now uses the concrete `object?[]`
   node-value table directly instead of an `IReadOnlyList<object?>` view, which
   trims lookup overhead on the hot replay path without changing output rows.

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -12781,6 +12781,8 @@ namespace UnifyWeaver.QueryRuntime
                 var rowAllocStarted = Stopwatch.GetTimestamp();
                 for (var i = 0; i < rows.Count; i++)
                 {
+                    // The broader query runtime, caches, and test harnesses all
+                    // currently expect fresh object[] rows at this boundary.
                     span[baseIndex + i] = new object[] { seedValue, targetValues[i], boxedDepths[i] };
                     metrics?.RecordOutputRow();
                 }


### PR DESCRIPTION
  ## Summary

  - Adds a dedicated proposal note documenting the current counted-path `All` row-allocation contract in the C# query runtime.
  - Clarifies that fresh `object[]` row materialization at counted-path `All` replay is not just a local implementation choice; it aligns with broader runtime expectations across execution interfaces,
  replayable sources, caches, wrappers, indexes, and test harnesses.
  - Adds a small runtime comment at the counted-path replay row-construction site to anchor that boundary in code.
  - Updates the counted-path benchmark/proposal notes to reflect that row allocation is currently a broader runtime boundary, not just a replay-loop detail.

  ## Why

  Recent counted-path `All` survey work narrowed the remaining write-side cost to row allocation. That naturally suggests trying alternative row-allocation strategies at the replay boundary.

  But before continuing down that path, the runtime needs a clear statement of whether fresh `object[]` rows are actually a soft local choice or a harder boundary imposed by the surrounding runtime.

  This PR documents the current answer: today, `object[]` row materialization is a broader runtime contract, not just a counted-path replay-loop convenience.

  ## Contract

  For counted-path `All` in `PathAwareTransitiveClosureNode`, the runtime currently materializes rows as fresh `object[]` instances at replay.

  That boundary is reinforced by broader runtime structure:

  - execution surfaces return `IEnumerable<object[]>`
  - replay/materialization surfaces use `List<object[]>`
  - caches store `IReadOnlyList<object[]>`
  - row wrappers and structural comparisons are defined in terms of `object[]`
  - fact/join indexes traffic in `object[]`
  - the C# runtime test harnesses consume and compare rows as `object[]`

  So a counted-path-only row-shape substitution would still have to cross back into `object[]` almost immediately unless the broader runtime contract changes too.

  ## Practical Implication

  The next question is no longer:

  “Which tiny `object[]` allocation variant should we try next?”

  The next question is:

  “Is there a broader runtime boundary where rows can remain in a narrower internal representation longer before conversion to `object[]`?”

  Until that contract changes, fresh `object[]` materialization is a real current runtime boundary.

  ## Validation

  - `swipl -q -t run_tests tests/core/test_csharp_query_target.pl`
  - `python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py`
  - `git diff --check`