### PR TITLE
docs(csharp-query): Survey row container abstraction seams in the C# query runtime

### DIFF
--- a/docs/proposals/LATE_OBJECT_ARRAY_MATERIALIZATION_SURVEY.md
+++ b/docs/proposals/LATE_OBJECT_ARRAY_MATERIALIZATION_SURVEY.md
@@ -111,3 +111,9 @@ boundary layers, most likely:
 
 Without that broader move, counted-path `All` remains boxed in by the current
 `object[]` runtime boundary.
+
+The follow-up
+[`ROW_CONTAINER_ABSTRACTION_SURVEY.md`](./ROW_CONTAINER_ABSTRACTION_SURVEY.md)
+narrows this to a recommended first prototype seam: cached result containers,
+because that layer is broad enough to matter but smaller than a full
+row-wrapper/index rewrite.

--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -219,6 +219,9 @@ Interpretation:
   boundary layers where a narrower internal row shape would actually have to
   land to matter: replayable sources, cached result containers, and row
   wrapper/index abstractions
+- a row-container abstraction survey now identifies cached result containers
+  as the smallest useful prototype seam before attempting a broader
+  row-wrapper/index rewrite
 - counted-path traversal and buffered replay now operate on interned node ids
   with edge-state lookup tables, avoiding repeated object-key dictionary
   lookups on the hot path while preserving exact output values at final

--- a/docs/proposals/ROW_CONTAINER_ABSTRACTION_SURVEY.md
+++ b/docs/proposals/ROW_CONTAINER_ABSTRACTION_SURVEY.md
@@ -1,0 +1,123 @@
+# Row Container Abstraction Survey
+
+This note surveys the smallest plausible abstraction seam for delaying
+`object[]` row materialization in the C# query runtime.
+
+It follows from:
+
+- [`LATE_OBJECT_ARRAY_MATERIALIZATION_SURVEY.md`](./LATE_OBJECT_ARRAY_MATERIALIZATION_SURVEY.md)
+- [`COUNTED_PATH_ALL_ROW_ALLOCATION_CONTRACT.md`](./COUNTED_PATH_ALL_ROW_ALLOCATION_CONTRACT.md)
+
+## Problem Statement
+
+Counted-path `All` replay surveys show that row allocation is the largest
+write-side cost. However, the runtime currently exposes and stores rows as
+`object[]` across execution, replayable sources, caches, wrappers, and indexes.
+
+That means a counted-path-local row shape is not enough. The runtime needs an
+abstraction seam where a narrower row container can survive long enough to
+avoid immediate conversion back to `object[]`.
+
+## Candidate Seams
+
+### Seam 1: Replayable Source Layer
+
+Add a sibling abstraction to `IReplayableRelationSource` that can store typed
+rows internally and expose `object[]` only when a consumer requires the public
+row shape.
+
+Pros:
+
+- narrower than changing every execution node
+- aligns with existing replay/materialization behavior
+- a good fit for counted-path replay output
+
+Cons:
+
+- consumers still need an `object[]` view
+- fact and join indexes still force conversion unless they are taught the new
+  row shape too
+
+### Seam 2: Cached Result Container Layer
+
+Introduce a cache container that can hold either `object[]` rows or a typed
+row representation, with explicit conversion at `IEnumerable<object[]>`
+boundaries.
+
+Pros:
+
+- directly targets closure and grouped-closure result caches
+- avoids changing the top-level public execution API first
+- provides a migration path for hot internal producers
+
+Cons:
+
+- every cache consumer must be audited for whether it needs arrays or only
+  structural access
+- indexing still needs an abstraction if cached rows are probed by key
+
+### Seam 3: Row Wrapper And Index Layer
+
+Generalize `RowWrapper`, structural equality, fact indexes, and join indexes
+to accept a row-view interface rather than only `object[]`.
+
+Pros:
+
+- strongest foundation for late materialization
+- lets typed rows participate in indexing without immediate conversion
+
+Cons:
+
+- largest surface area
+- highest risk of behavioral regressions
+- likely requires changes across many plan nodes, not just counted paths
+
+## Recommended Prototype Path
+
+The smallest useful prototype is the cached result container layer.
+
+Rationale:
+
+- replayable sources are too close to the public `IEnumerable<object[]>`
+  boundary by themselves
+- row wrapper/index generalization is too broad for the first prototype
+- cached closure result containers are broad enough to matter but narrow
+  enough to audit
+
+The first prototype should introduce a small internal container abstraction
+that can:
+
+1. expose an `IReadOnlyList<object[]>` view for existing consumers
+2. optionally retain a specialized internal row representation
+3. make conversion points explicit and measurable
+4. preserve exact row order and row equality behavior
+
+## Non-Goals
+
+The first abstraction should not change:
+
+- the public `QueryExecutor.Execute(...)` row type
+- external relation provider APIs
+- counted-path `All` ordering
+- counted-path `Min` ordering
+
+Those can be revisited only after the internal conversion boundary is proven.
+
+## Open Questions
+
+- Which existing closure caches are hot enough to justify container migration
+  first?
+- Can key probes operate over a typed row view without constructing full
+  arrays?
+- Should the first container be generic, or should it start as a counted-path
+  target/depth container and generalize later?
+- How should trace metrics report delayed conversion cost versus true row
+  write cost?
+
+## Practical Implication
+
+The next implementation step should not attempt a full row-interface rewrite.
+
+It should prototype a cached result container boundary for one measured hot
+path, then use metrics to decide whether row wrapper/index generalization is
+worth the larger surface-area cost.


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  - Adds a dedicated proposal note comparing possible seams for delaying `object[]` materialization in the C# query runtime.                                                                                     
  - Evaluates three candidate abstraction layers:                                                                                                                                                                
    - replayable source layer                                                                                                                                                                                    
    - cached result container layer                                                                                                                                                                              
    - row wrapper/index layer                                                                                                                                                                                    
  - Recommends cached result containers as the smallest useful first prototype seam.                                                                                                                             
  - Cross-links the survey from the late `object[]` materialization survey and the non-DAG path-state plan.                                                                                                      
                                                                                                                                                                                                                 
  ## Why                                                                                                                                                                                                         
                                                                                                                                                                                                                 
  Recent counted-path `All` work showed that replay write cost is dominated by row allocation. The follow-up contract and late-materialization surveys established that this is not just a counted-path-local    
  issue: the runtime broadly commits to `object[]` rows across execution, replay, caching, wrappers, indexes, and tests.                                                                                         
                                                                                                                                                                                                                 
  This PR narrows the next design question:                                                                                                                                                                      
                                                                                                                                                                                                                 
  “Where is the smallest runtime seam where a narrower internal row container could survive long enough to matter?”                                                                                              
                                                                                                                                                                                                                 
  The answer from this survey is: cached result containers are the best first prototype boundary.                                                                                                                
                                                                                                                                                                                                                 
  ## Findings                                                                                                                                                                                                    
                                                                                                                                                                                                                 
  ### Replayable source layer                                                                                                                                                                                    
                                                                                                                                                                                                                 
  Useful, but too close to the public `IEnumerable<object[]>` boundary by itself. It can store typed rows internally, but most consumers still force conversion unless deeper layers change.                     
                                                                                                                                                                                                                 
  ### Cached result container layer                                                                                                                                                                              
                                                                                                                                                                                                                 
  Best first prototype seam. It is broad enough to affect closure and grouped-closure results, but narrow enough to audit before changing all row wrappers and indexes.                                          
                                                                                                                                                                                                                 
  A prototype container should:                                                                                                                                                                                  
                                                                                                                                                                                                                 
  1. expose an `IReadOnlyList<object[]>` view for existing consumers                                                                                                                                             
  2. optionally retain a specialized internal row representation                                                                                                                                                 
  3. make conversion points explicit and measurable                                                                                                                                                              
  4. preserve exact row order and equality behavior                                                                                                                                                              
                                                                                                                                                                                                                 
  ### Row wrapper/index layer                                                                                                                                                                                    
                                                                                                                                                                                                                 
  Most powerful, but too broad for the first step. It likely requires changes across many plan nodes and carries the highest regression risk.                                                                    
                                                                                                                                                                                                                 
  ## Validation                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  - `swipl -q -t run_tests tests/core/test_csharp_query_target.pl`                                                                                                                                               
  - `python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py`                                                                                                                                
  - `git diff --check`                                                                                                                                                                                           