### PR TITLE
fix(wam-haskell): fork backtrack must not finalize the aggregate

### DIFF
--- a/examples/benchmark/generate_intra_query_aggregate_benchmark.pl
+++ b/examples/benchmark/generate_intra_query_aggregate_benchmark.pl
@@ -47,12 +47,7 @@ main :-
         emit_mode(interpreter),
         no_kernels(true),
         use_hashmap(false),
-        % Fork disabled for now: the WAM aggregate is correct in
-        % sequential mode (matching native SWI-Prolog exactly), but
-        % the fork's runBranchForFork doesn't collect recursive-clause
-        % solutions yet. See the commit message for the investigation
-        % trail. Re-enable once the fork correctness is resolved.
-        intra_query_parallel(false)
+        intra_query_parallel(true)
     ],
     write_wam_haskell_project(Predicates, Options, OutputDir),
 

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -1202,9 +1202,21 @@ runBranchForFork !ctx !parent !branchPC =
                          other              -> other
                     in case step ctx s seqInstr of
                          Just s2 -> runBranchLoop s2
-                         Nothing -> case backtrack s of
-                           Just s3 -> runBranchLoop s3
-                           Nothing -> wsAggAccum s
+                         Nothing ->
+                           -- Custom backtrack: if the top CP has an
+                           -- aggregate frame, DON''T call finalizeAggregate
+                           -- (which would clear wsAggAccum). Instead,
+                           -- return our accumulated values — the branch
+                           -- is done. Without this, the standard
+                           -- backtrack function wipes wsAggAccum by
+                           -- calling finalizeAggregate when it hits the
+                           -- aggregate-frame CP.
+                           case wsCPs s of
+                             (cp : _) | Just _ <- cpAggFrame cp ->
+                               wsAggAccum s
+                             _ -> case backtrack s of
+                               Just s3 -> runBranchLoop s3
+                               Nothing -> wsAggAccum s
 
 -- | Fork every branch of a Par* chain and merge their aggregate
 -- contributions via the outer aggregate''s strategy. Returns the


### PR DESCRIPTION
  ## Summary

  Fixes the Phase 4.2 fork's `runBranchForFork` returning empty results for recursive branches. The fork now produces
  correct results end-to-end — the first time intra-query parallelism computes a verifiably correct aggregate across
  forked branches.

  ## The bug

  When `runBranchForFork` ran a recursive branch (clause 2 of `category_ancestor/4` inside a `sum` aggregate), the
  branch collected solutions correctly via the `EndAggregate` intercept. But when a `step` call inside the branch
  returned `Nothing`, the fallback path called the standard `backtrack` function. If the top CP had an aggregate frame,
  `backtrack` dispatched to `finalizeAggregate` — which **cleared `wsAggAccum` to `[]`**. The branch lost all 651
  collected values and eventually exited at `PC=0` with an empty accumulator.

  **Diagnostic trace that found it:**
  ```
  branch@21 EndAgg PC=80 val=Float 4.11e-3 accum=1 cps=4
  branch@21 EndAgg PC=80 val=Float 4.11e-3 accum=2 cps=4
  ...
  branch@21 OOB-lo PC=0 steps=47167 accum=0   ← values wiped!
  ```

  The branch hit `EndAggregate` multiple times (accumulating values), then a `backtrack → finalizeAggregate` cycle reset
   the accumulator.

  ## The fix

  In `runBranchForFork`'s fallback-to-backtrack path, check the top CP for an `cpAggFrame` **before** calling
  `backtrack`. If found, return `wsAggAccum` immediately — the branch is done. This mirrors the existing `EndAggregate →
   backtrackInner → Nothing` intercept — both paths now correctly stop at the aggregate boundary without clearing the
  accumulator.

  ```haskell
  -- Before (broken):
  _ -> case step ctx s seqInstr of
         Just s2 -> runBranchLoop s2
         Nothing -> case backtrack s of          -- ← calls finalizeAggregate!
           Just s3 -> runBranchLoop s3
           Nothing -> wsAggAccum s

  -- After (fixed):
  _ -> case step ctx s seqInstr of
         Just s2 -> runBranchLoop s2
         Nothing -> case wsCPs s of
           (cp : _) | Just _ <- cpAggFrame cp -> wsAggAccum s  -- ← stop here
           _ -> case backtrack s of
             Just s3 -> runBranchLoop s3
             Nothing -> wsAggAccum s
  ```

  ## Result

  Fork now produces correct results for both branches:

  ```
  branch@6  (clause 1, base case): 10 solutions
  branch@21 (clause 2, recursive): 651 solutions
  total_weight_sum = 0.4561512339452879
  ```

  **Native SWI-Prolog returns `0.4561512339452847`.** The 14-digit agreement is excellent; the last-digit difference is
  float associativity from parallel accumulation ordering (`sum(branch0 ++ branch1)` vs
  `sum(all_solutions_sequential)`).

  ## Also in this PR

  - **Aggregate benchmark re-enabled:** `intra_query_parallel(true)` is now the default in
  `generate_intra_query_aggregate_benchmark.pl`. The `intra_query_parallel(false)` workaround from the previous PR is
  removed.

  ## Speedup status

  At 300 scale with 4 seeds, N=1 (191ms) vs N=4 (243ms) — no speedup yet. This is expected:
  - Only 2 branches per fork (clause 1 vs clause 2), heavily imbalanced (clause 2 does 99% of the work).
  - Nested forks are suppressed to prevent exponential spark explosion.
  - `parMap rdeepseq` overhead exceeds the benefit at this granularity.

  The correctness milestone is the primary deliverable. Speedup requires either more balanced branches (many-clause
  predicates), selective nested forking, or a work-estimation threshold (Phase 4.5) — all of which build on the
  now-correct fork mechanism.

  ## Verified

  - **40/40** tests in `tests/test_wam_haskell_target.pl` pass.
  - Fork produces `0.4561512339452879` — matches SWI-Prolog to 14 significant digits.
  - Sequential aggregate (with `intra_query_parallel(false)` from the previous PR) still produces `0.4561512339452847` —
   the Y-register fix is independently correct.
  - Original `intra_query_seed` benchmark (collectSolutions path): bit-identical output at 300 scale.

  ## Test plan

  - [ ] `swipl -q tests/test_wam_haskell_target.pl` — 40/40 pass.
  - [ ] Generate aggregate benchmark: `cd examples/benchmark && swipl -q -s generate_intra_query_aggregate_benchmark.pl
  -- /tmp/agg` — generates with `[Par] category_ancestor/4: emitting Par*`.
  - [ ] Build and run: `cd /tmp/agg && cabal build && ./dist/build/wam-intra-agg-bench/wam-intra-agg-bench $FACTS 1 +RTS
   -N1` — reports `w=0.456151…` (not 0.0, not 0.3125).
  - [ ] N=1 and N=4 produce identical `total_weight_sum` (correctness under parallelism).
  - [ ] Original intra_query_seed benchmark still produces `total_solutions=2868`, `total_weight_sum=2.003792…`.

  ## Related

  - Phase 4.2 fork infrastructure: #1411 (merged).
  - Y-register aggregate fix: #1471 (merged).
  - Phase 4.1 Par* emission: #1410.
  - Purity certificate P1–P3: #1402, #1403, #1404.
  - Design docs: #1395 (intra-query), #1398 (purity certificate).
  - Next: speedup tuning — workloads with more balanced branches, selective nested forking, Phase 4.5 work-estimation
  threshold.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)