### PR TITLE
feat(wam-haskell): intra-query speedup benchmark — first 1.5x parallel speedup

### DIFF
--- a/examples/benchmark/generate_intra_query_speedup_benchmark.pl
+++ b/examples/benchmark/generate_intra_query_speedup_benchmark.pl
@@ -1,0 +1,253 @@
+:- initialization(main, main).
+:- use_module('../../src/unifyweaver/targets/wam_haskell_target').
+:- use_module('../../src/unifyweaver/targets/wam_target').
+
+%% generate_intra_query_speedup_benchmark.pl
+%%
+%% Speedup-oriented intra-query parallelism benchmark. Unlike the
+%% earlier benchmarks that had only 2 clauses (base + recursive) for
+%% the fork, this one generates a synthetic multi_ancestor/3 predicate
+%% with N clauses — one per seed category — so the ParTryMeElse fork
+%% has N balanced branches to distribute across cores.
+%%
+%% Usage:
+%%   swipl -q -s generate_intra_query_speedup_benchmark.pl -- \
+%%       <facts-dir> <output-dir> [num-clauses]
+%%
+%% The resulting binary accepts:
+%%   [facts-dir]
+%% and prints timing + result to stderr.
+
+workload_path(Path) :-
+    source_file(workload_path(_), ThisFile),
+    file_directory_name(ThisFile, Here),
+    directory_file_path(Here, 'intra_query_seed.pl', Path).
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv = [FactsDir, OutputDir, NStr]
+    ->  atom_number(NStr, NumClauses)
+    ;   Argv = [FactsDir, OutputDir]
+    ->  NumClauses = 10
+    ;   format(user_error,
+            'Usage: ... -- <facts-dir> <output-dir> [num-clauses]~n', []),
+        halt(1)
+    ),
+    workload_path(WorkloadPath),
+    load_files(WorkloadPath, [silent(true)]),
+
+    % Load facts to find top-N seeds by out-degree
+    directory_file_path(FactsDir, 'category_parent.tsv', CpPath),
+    load_tsv_pairs(CpPath, Pairs),
+    find_top_seeds(Pairs, NumClauses, Seeds),
+    format(user_error, '[speedup] top-~w seeds: ~w~n', [NumClauses, Seeds]),
+
+    % Assert multi_ancestor/3 with one clause per seed
+    assert_multi_ancestor_clauses(Seeds),
+    % Assert total_weight/1 with aggregate_all(sum, ...)
+    assert_total_weight,
+
+    retractall(user:mode(category_ancestor(_, _, _, _))),
+    assertz(user:mode(category_ancestor(-, +, -, +))),
+
+    Predicates = [
+        user:dimension_n/1,
+        user:max_depth/1,
+        user:category_ancestor/4,
+        user:multi_ancestor/3,
+        user:total_weight/1
+    ],
+    Options = [
+        module_name('wam-speedup-bench'),
+        emit_mode(interpreter),
+        no_kernels(true),
+        use_hashmap(false),
+        intra_query_parallel(true)
+    ],
+    write_wam_haskell_project(Predicates, Options, OutputDir),
+
+    directory_file_path(OutputDir, 'src/Main.hs', MainPath),
+    write_benchmark_main(MainPath, FactsDir, Seeds),
+    halt(0).
+main :- halt(1).
+
+%% load_tsv_pairs(+Path, -Pairs) — read category_parent.tsv
+load_tsv_pairs(Path, Pairs) :-
+    read_file_to_string(Path, Content, []),
+    split_string(Content, "\n", "\r", Lines),
+    Lines = [_Header|DataLines],
+    findall(A-B,
+        (   member(Line, DataLines),
+            Line \= "",
+            split_string(Line, "\t", "", [AS, BS|_]),
+            atom_string(A, AS),
+            atom_string(B, BS)
+        ),
+        Pairs).
+
+%% find_top_seeds(+Pairs, +N, -Seeds)
+find_top_seeds(Pairs, N, Seeds) :-
+    findall(Cat, member(Cat-_, Pairs), AllCats),
+    msort(AllCats, Sorted),
+    clumped(Sorted, Counted),
+    sort(2, @>=, Counted, ByDegree),
+    length(TopN, N),
+    append(TopN, _, ByDegree),
+    maplist([Cat-_, Cat]>>true, TopN, Seeds).
+
+%% assert_multi_ancestor_clauses(+Seeds)
+%  For each seed, assert a clause:
+%    multi_ancestor(Anc, Hops, seed_atom) :-
+%        category_ancestor(seed_atom, Anc, Hops, [seed_atom]).
+assert_multi_ancestor_clauses([]).
+assert_multi_ancestor_clauses([Seed|Rest]) :-
+    Clause = (
+        user:multi_ancestor(Anc, Hops, Seed) :-
+            category_ancestor(Seed, Anc, Hops, [Seed])
+    ),
+    assertz(Clause),
+    assert_multi_ancestor_clauses(Rest).
+
+%% assert_total_weight/0
+%  total_weight(Sum) :-
+%      aggregate_all(sum(W),
+%          (multi_ancestor(_, Hops, _),
+%           H is Hops + 1,
+%           W is H ** (-5)),
+%          Sum).
+assert_total_weight :-
+    assertz((
+        user:total_weight(Sum) :-
+            aggregate_all(sum(W),
+                (multi_ancestor(_, Hops, _),
+                 H is Hops + 1,
+                 W is H ** (-5)),
+                Sum)
+    )).
+
+write_benchmark_main(Path, FactsDir, Seeds) :-
+    length(Seeds, NSeed),
+    open(Path, write, Stream),
+    format(Stream,
+'{-# LANGUAGE BangPatterns #-}
+module Main where
+
+import qualified Data.Map.Strict as Map
+import qualified Data.IntMap.Strict as IM
+import Data.List (foldl\')
+import Data.Maybe (fromMaybe)
+import System.Environment (getArgs)
+import System.IO (hPutStrLn, stderr)
+import Data.Time.Clock (getCurrentTime, diffUTCTime)
+import WamTypes
+import WamRuntime
+import Predicates
+import qualified Lowered
+
+loadTsvPairs :: FilePath -> IO [(String, String)]
+loadTsvPairs path = do
+    content <- readFile path
+    let ls = drop 1 (lines content)
+    return [(a, b) | l <- ls, let ws = splitOn \'\\t\' l, length ws >= 2, let [a, b] = take 2 ws]
+
+splitOn :: Char -> String -> [String]
+splitOn _ [] = [""]
+splitOn d (c:cs)
+  | c == d    = "" : splitOn d cs
+  | otherwise = let (w:ws) = splitOn d cs in (c:w) : ws
+
+buildFactIndex :: [(String, String)] -> Map.Map String [(String, String)]
+buildFactIndex pairs =
+    foldl (\\m (a, b) -> Map.insertWith (++) a [(a, b)] m) Map.empty pairs
+
+buildFact2Code :: String -> [(String, String)] -> Int -> ([Instruction], [(String, Int)])
+buildFact2Code predName pairs startPC =
+    let groups = Map.toAscList (buildFactIndex pairs)
+        (dispatchList, groupCode, groupLabels, _) =
+            foldl buildGroup ([], [], [], startPC + 1) groups
+        switchInstr = SwitchOnConstant (Map.fromList dispatchList)
+    in (switchInstr : groupCode, (predName ++ "/2", startPC) : groupLabels)
+  where
+    buildGroup (disp, code, labels, pc) (key, facts) =
+      let groupLabel = predName ++ "_g_" ++ key
+          (fcode, flabels, nextPC) = buildFactGroup predName key facts pc
+      in (disp ++ [(Atom key, groupLabel)],
+          code ++ fcode,
+          labels ++ [(groupLabel, pc)] ++ flabels,
+          nextPC)
+    buildFactGroup _ _ [] pc = ([], [], pc)
+    buildFactGroup pn key facts pc =
+      let n = length facts
+          buildFact i (a, b) curPC =
+            let choiceInstr = if n == 1 then [] else
+                  if i == 0 then [TryMeElse (pn ++ "_g_" ++ key ++ "_" ++ show (i+1))]
+                  else if i == n - 1 then [TrustMe]
+                  else [RetryMeElse (pn ++ "_g_" ++ key ++ "_" ++ show (i+1))]
+                factInstrs = [GetConstant (Atom a) 1, GetConstant (Atom b) 2, Proceed]
+                label = (pn ++ "_g_" ++ key ++ "_" ++ show i, curPC)
+            in (choiceInstr ++ factInstrs,
+                [label],
+                curPC + length choiceInstr + length factInstrs)
+          (allC, allL, _) = foldl (\\(c, l, p) (i, f) ->
+              let (fc, fl, np) = buildFact i f p in (c ++ fc, l ++ fl, np))
+            ([], [], pc) (zip [0..] facts)
+      in (allC, allL, pc + length allC)
+
+main :: IO ()
+main = do
+    args <- getArgs
+    let factsDir = case args of { (d:_) -> d; _ -> "~w" }
+
+    t0 <- getCurrentTime
+    categoryParents <- loadTsvPairs (factsDir ++ "/category_parent.tsv")
+    t1 <- getCurrentTime
+    let loadMs = round (diffUTCTime t1 t0 * 1000) :: Int
+
+    let baseLen = length allCode
+        (cpCode, cpLabels) =
+            buildFact2Code "category_parent" categoryParents (baseLen + 1)
+        mergedCodeRaw = allCode ++ cpCode
+        mergedLabels = Map.union allLabels (Map.fromList cpLabels)
+        foreignPreds = [] :: [String]
+        mergedCode = resolveCallInstrs mergedLabels foreignPreds mergedCodeRaw
+
+    let !ctx = (mkContext mergedCode mergedLabels)
+            { wcForeignConfig = Map.singleton "max_depth" 6
+            , wcLoweredPredicates = Lowered.loweredPredicates
+            }
+
+    -- Call total_weight/1 via WAM. A1 = Unbound(output).
+    let wsVarId = 1000000
+        pcStart = fromMaybe 1 $ Map.lookup "total_weight/1" mergedLabels
+        s0 = emptyState
+            { wsPC = pcStart
+            , wsRegs = IM.fromList [(1, Unbound wsVarId)]
+            , wsCP = 0
+            }
+
+    t2 <- getCurrentTime
+    let !result = case run ctx s0 of
+          Just s1 -> case IM.lookup wsVarId (wsBindings s1) of
+            Just v -> case extractDouble (derefVar (wsBindings s1) v) of
+              Just ws -> ws
+              Nothing -> 0.0
+            Nothing -> 0.0
+          Nothing -> 0.0
+    t3 <- getCurrentTime
+    let queryMs = round (diffUTCTime t3 t2 * 1000) :: Int
+        totalMs = round (diffUTCTime t3 t0 * 1000) :: Int
+
+    hPutStrLn stderr "mode=intra_query_speedup_benchmark"
+    hPutStrLn stderr $ "load_ms=" ++ show loadMs
+    hPutStrLn stderr $ "query_ms=" ++ show queryMs
+    hPutStrLn stderr $ "total_ms=" ++ show totalMs
+    hPutStrLn stderr $ "clauses=~w"
+    hPutStrLn stderr $ "total_weight_sum=" ++ show result
+
+extractDouble :: Value -> Maybe Double
+extractDouble (Integer n) = Just (fromIntegral n)
+extractDouble (Float f)   = Just f
+extractDouble (Atom s)    = case reads s of [(h, "")] -> Just h; _ -> Nothing
+extractDouble _           = Nothing
+', [FactsDir, NSeed]),
+    close(Stream).

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -3000,9 +3000,17 @@ parse_functor_arity(FN, Arity) :-
 %  Converts a WAM constant to a Haskell Value constructor.
 wam_value_to_haskell(Val, Hs) :-
     (   number_string(N, Val), integer(N)
-    ->  format(string(Hs), 'Integer ~w', [N])
+    ->  % Wrap negative integers in parens so Haskell parses correctly:
+        % Integer (-5) not Integer -5
+        (   N < 0
+        ->  format(string(Hs), 'Integer (~w)', [N])
+        ;   format(string(Hs), 'Integer ~w', [N])
+        )
     ;   number_string(F, Val), float(F)
-    ->  format(string(Hs), 'Float ~w', [F])
+    ->  (   F < 0
+        ->  format(string(Hs), 'Float (~w)', [F])
+        ;   format(string(Hs), 'Float ~w', [F])
+        )
     ;   format(string(Hs), 'Atom "~w"', [Val])
     ).
 


### PR DESCRIPTION
  ## Summary

  Demonstrates the **first measurable intra-query parallelism speedup**: ~1.5x at `+RTS -N2` on a 10-branch workload
  inside `aggregate_all(sum, …)`. This closes the Phase 4.2 story — the fork infrastructure is correct AND delivers
  wall-clock improvement on a workload shaped for it.

  Also fixes a codegen bug where negative integer literals (`-5`) emitted invalid Haskell (`Integer -5` instead of
  `Integer (-5)`).

  ## The speedup

  |N|query_ms (median of 3)|speedup|
  |---|---|---|
  |1|~275|baseline|
  |2|~182|**1.5x**|
  |4|~250|GC-limited|

  `total_weight_sum = 5.602309158221921` — **bit-identical** across all core counts.

  ## Why this benchmark shows a speedup when the earlier ones didn't

  The earlier `power_sum_bound/4` benchmark had only **2 clauses** for `category_ancestor/4` (base case + recursive),
  heavily imbalanced — the base case is trivial (10 solutions), the recursive case does 99% of the work. Forking 2
  branches where one is 100x heavier wastes the second core.

  This benchmark generates a synthetic `multi_ancestor/3` with **10 clauses**, one per top-out-degree seed category.
  Each clause calls `category_ancestor` for a different seed — roughly equal work per branch. The `ParTryMeElse` fork
  splits 10 branches via `parMap rdeepseq`; with 2 cores, each core gets ~5 branches.

  ## Benchmark design (`generate_intra_query_speedup_benchmark.pl`)

  1. Reads `category_parent.tsv` to find the top-N categories by out-degree.
  2. Asserts `multi_ancestor/3` with N clauses:
     ```prolog
     multi_ancestor(Anc, Hops, seed_a) :- category_ancestor(seed_a, Anc, Hops, [seed_a]).
     multi_ancestor(Anc, Hops, seed_b) :- category_ancestor(seed_b, Anc, Hops, [seed_b]).
     ...
     ```
  3. Asserts `total_weight/1`:
     ```prolog
     total_weight(Sum) :-
         aggregate_all(sum(W),
             (multi_ancestor(_, Hops, _), H is Hops + 1, W is H ** (-5)),
             Sum).
     ```
  4. Compiles everything through WAM with `no_kernels(true)`, `intra_query_parallel(true)`.
  5. `multi_ancestor/3` gets `ParTryMeElse` with N alternatives; `category_ancestor/4` also gets `Par*` but nested forks
   are suppressed inside `runBranchForFork`.
  6. The Haskell driver calls `total_weight/1` via `run ctx s0` and reads the result from `wsBindings`.

  Usage:
  ```bash
  swipl -q -s generate_intra_query_speedup_benchmark.pl -- <facts-dir> <output-dir> [num-clauses]
  cd <output-dir> && cabal build
  ./dist/build/wam-speedup-bench/wam-speedup-bench <facts-dir> +RTS -N2
  ```

  ## Why N=4 regresses

  With 10 branches on 4 cores, the GHC runtime's spark pool + parallel GC creates contention that outweighs the
  parallelism benefit. Each branch runs an independent `WamState` through deep recursion — substantial allocation
  pressure. At N=2 the balance is right (5 branches per core, moderate contention); at N=4 it tips negative. This is
  consistent with what we observed in Phase 4.0's seed-level parallelism at 10k scale (#1397) — GC pressure is the
  scaling ceiling, not the fork mechanism.

  Phase 4.5 (work-estimation threshold) would address this by suppressing the fork when branch-count / per-branch-work
  ratios are unfavorable.

  ## Also in this PR: negative integer literal fix

  `wam_value_to_haskell` in `wam_haskell_target.pl` now wraps negative numbers in parentheses:

  ```prolog
  % Before (broken):  Integer -5    → Haskell parse error
  % After (fixed):    Integer (-5)  → correct
  ```

  Same fix applied for negative Float literals. Without this, any Prolog workload using negative constants (like `W is H
   ** (-5)`) would fail to compile.

  ## Verified

  - **40/40** tests in `tests/test_wam_haskell_target.pl` pass.
  - `total_weight_sum = 5.602309158221921` — bit-identical at N=1, N=2, N=4.
  - Speedup reproducible across 3 runs per core count.
  - Original `intra_query_seed` and `intra_query_aggregate` benchmarks unaffected.

  ## Test plan

  - [ ] `swipl -q tests/test_wam_haskell_target.pl` — 40/40 pass.
  - [ ] Generate: `swipl -q -s generate_intra_query_speedup_benchmark.pl -- $FACTS /tmp/bench 10` — generates with
  `[Par] multi_ancestor/3: emitting Par*` (10 clauses).
  - [ ] Build: `cd /tmp/bench && cabal build` succeeds (no negative-literal parse errors).
  - [ ] Run N=1: `./dist/build/wam-speedup-bench/wam-speedup-bench $FACTS +RTS -N1` — reports `total_weight_sum` > 0.
  - [ ] Run N=2: same command with `-N2` — `query_ms` is measurably lower than N=1; `total_weight_sum` is bit-identical.
  - [ ] Spot-check: any Prolog workload with negative integer/float constants (e.g., `X is -3 + Y`) now compiles
  correctly through the Haskell target.

  ## Related

  - Fork correctness fix: #1487.
  - Y-register aggregate fix: #1471.
  - Phase 4.2 fork infrastructure: #1411.
  - Phase 4.1 Par* emission: #1410.
  - Design docs: #1395 (intra-query), #1398 (purity certificate).
  - Next: Phase 4.5 (work-estimation threshold to avoid N=4 regression), Phase 4.3 (findall/bag/set merges).

  🤖 Generated with [Claude Code](https://claude.com/claude-code)