### PR TITLE
fix(wam-clojure): preserve switch default fallthrough

### DIFF
--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -50,11 +50,18 @@
           (some (fn [entry]
                   (when (= "default" (:label entry))
                     (:target-pc entry)))
-                resolved-cases)]
+                resolved-cases)
+          default-fallthrough?
+          (boolean
+           (some (fn [entry]
+                   (and (= "default" (:label entry))
+                        (not (contains? entry :target-pc))))
+                 resolved-cases))]
       (assoc instr
              :cases resolved-cases
              :case-map case-map
-             :default-target-pc default-target-pc))
+             :default-target-pc default-target-pc
+             :default-fallthrough? default-fallthrough?))
 
     instr))
 
@@ -272,13 +279,17 @@
 (defn switch-target [state instr]
   (let [reg-val (deref-value (:bindings state) (reg-get-raw state "A1"))
         case-map (:case-map instr)
-        default-target-pc (:default-target-pc instr)]
+        default-target-pc (:default-target-pc instr)
+        default-fallthrough? (:default-fallthrough? instr)]
     (cond
       (contains? case-map reg-val)
       (assoc state :pc (get case-map reg-val))
 
       default-target-pc
       (assoc state :pc default-target-pc)
+
+      default-fallthrough?
+      (advance state)
 
       :else
       (backtrack state))))


### PR DESCRIPTION
## Summary

This PR fixes a Clojure WAM runtime regression in indexed fact dispatch.

The standalone Clojure WAM smoke runner was failing on:

- `wam_choice_caller/1`
- input: `a`
- expected: `true`
- actual: `false`

The failing path used `switch_on_constant` with a `default` case that
represents WAM fallthrough into the first clause body.

## Root Cause

The Clojure WAM runtime pre-resolves `switch_on_constant` cases at project load
time. During that resolution, cases with a real label are converted to direct
target PCs.

However, WAM can also emit a case like:

```clojure
{:value "a" :label "default"}
```

In this shape, `default` does not name a label. It means "fall through to the
next instruction."

The resolver previously dropped that fallthrough information because there was
no label PC to attach. At runtime, the indexed dispatch then failed to match the
`a` case and backtracked instead of advancing into the first clause body.

## Fix

- Preserve a `:default-fallthrough?` flag during `switch_on_constant`
  resolution.
- Teach `switch-target` to `advance` when the active default case represents
  fallthrough.
- Keep direct PC dispatch for ordinary resolved labels unchanged.

## Validation

Passed locally:

- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`

## Notes

This is intentionally narrow. It fixes indexed fact dispatch without changing
the broader Clojure WAM runtime model.
