### PR TITLE
feat(wam-clojure): add switch regressions and trailed bindings

### DIFF
--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -117,18 +117,30 @@
                                      :stack (:stack state)
                                      :regs (snapshot-choice-regs (:regs state))
                                      :env-stack (:env-stack state)
-                                     :bindings (:bindings state)
+                                     :trail-len (count (:trail state))
                                      :cut-bar (:cut-bar state)
                                      :next-var-id (:next-var-id state)}))
+
+(defn unwind-trail [state target-len]
+  (loop [s state
+         entries (reverse (subvec (vec (:trail state)) target-len))]
+    (if-let [entry (first entries)]
+      (let [var-id (:var entry)
+            restored
+            (if (:had-old? entry)
+              (assoc-in s [:bindings var-id] (:old entry))
+              (update s :bindings dissoc var-id))]
+        (recur restored (rest entries)))
+      (assoc s :trail (vec (take target-len (:trail state)))))))
 
 (defn backtrack [state]
   (if-let [cp (peek (:choice-points state))]
     (-> state
+        (unwind-trail (:trail-len cp))
         (assoc :pc (:pc cp))
         (assoc :stack (:stack cp))
         (restore-choice-regs (:regs cp))
         (assoc :env-stack (:env-stack cp))
-        (assoc :bindings (:bindings cp))
         (assoc :cut-bar (:cut-bar cp))
         (assoc :next-var-id (:next-var-id cp))
         (update :choice-points pop)
@@ -168,7 +180,12 @@
       cur)))
 
 (defn bind-var [state var-term value]
-  (assoc-in state [:bindings (:var var-term)] value))
+  (let [var-id (:var var-term)
+        old (get-in state [:bindings var-id])
+        had-old? (contains? (:bindings state) var-id)]
+    (-> state
+        (update :trail conj {:var var-id :old old :had-old? had-old?})
+        (assoc-in [:bindings var-id] value))))
 
 (declare unify-values structure-term?)
 

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -91,6 +91,23 @@ test(project_uses_shared_wam_table_for_cross_predicate_calls) :-
         delete_directory_and_contents(TmpDir)
     )).
 
+test(switch_on_constant_preserves_default_fallthrough) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_switch', TmpDir),
+        write_wam_clojure_project([user:wam_choice_fact/1],
+                                  [namespace('generated.wam_switch_test')], TmpDir),
+        directory_file_path(TmpDir, 'src/generated/wam_switch_test/core.clj', CorePath),
+        directory_file_path(TmpDir, 'src/generated/wam_switch_test/runtime.clj', RuntimePath),
+        read_file_to_string(CorePath, CoreCode, []),
+        read_file_to_string(RuntimePath, RuntimeCode, []),
+        assertion(sub_string(CoreCode, _, _, _, '{:value "a" :label "default"}')),
+        assertion(sub_string(CoreCode, _, _, _, '{:value "b" :label "L_wam_choice_fact_1_2"}')),
+        assertion(sub_string(CoreCode, _, _, _, '{:value "c" :label "L_wam_choice_fact_1_3"}')),
+        assertion(sub_string(RuntimeCode, _, _, _, ':default-fallthrough?')),
+        assertion(sub_string(RuntimeCode, _, _, _, '(advance state)')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
 test(minimal_runtime_executes_execute_and_call_paths,
      [condition(clojure_exec_e2e_enabled)]) :-
     once((

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -22,6 +22,7 @@
 :- dynamic user:wam_env1/1.
 :- dynamic user:wam_env2/1.
 :- dynamic user:wam_env3/1.
+:- dynamic user:wam_trail_choice/1.
 :- dynamic user:wam_soft_cut_helper/1.
 :- dynamic user:wam_soft_cut_outer_ok/1.
 :- dynamic user:wam_cut_helper/1.
@@ -49,6 +50,7 @@ user:wam_make_list(X) :- X = [a,b].
 user:wam_env1(X) :- Y = X, Z = a, Y = Z.
 user:wam_env2(X) :- user:wam_fact(X), Y = X, user:wam_fact(Y).
 user:wam_env3(X) :- (X = a ; X = b), user:wam_fact(X).
+user:wam_trail_choice(X) :- (Y = a ; Y = b), X = Y.
 user:wam_soft_cut_helper(X) :- (X = a -> fail ; true).
 user:wam_soft_cut_outer_ok(X) :- (user:wam_soft_cut_helper(Y), X = Y ; X = b).
 user:wam_cut_helper(X) :- X = a, !, fail.
@@ -82,6 +84,7 @@ run_smoke :-
           user:wam_env1/1,
           user:wam_env2/1,
           user:wam_env3/1,
+          user:wam_trail_choice/1,
           user:wam_soft_cut_helper/1,
           user:wam_soft_cut_outer_ok/1,
           user:wam_cut_helper/1,
@@ -123,6 +126,9 @@ run_smoke :-
     verify_output(TmpDir, 'wam_env2/1', b, "false"),
     verify_output(TmpDir, 'wam_env3/1', a, "true"),
     verify_output(TmpDir, 'wam_env3/1', b, "false"),
+    verify_output(TmpDir, 'wam_trail_choice/1', a, "true"),
+    verify_output(TmpDir, 'wam_trail_choice/1', b, "true"),
+    verify_output(TmpDir, 'wam_trail_choice/1', c, "false"),
     verify_output(TmpDir, 'wam_soft_cut_outer_ok/1', b, "true"),
     verify_output(TmpDir, 'wam_hard_cut_outer_ok/1', b, "true"),
     delete_directory_and_contents(TmpDir),


### PR DESCRIPTION
## Summary

This PR strengthens the Clojure hybrid/WAM runtime after the recent
`switch_on_constant` default-fallthrough fix.

It adds focused regression coverage for indexed switch generation and moves the
runtime’s binding restoration closer to the Haskell/Rust WAM model by trailing
binding changes instead of cloning the full binding map into each choice point.

## What Changed

- Added a generator-level regression for `switch_on_constant` default
  fallthrough.
- Confirmed generated Clojure code preserves cases like:

```clojure
{:value "a" :label "default"}
```

- Confirmed the runtime template carries `:default-fallthrough?`.
- Added explicit binding trail support in the Clojure WAM runtime.
- Changed choice points to save `:trail-len` instead of cloning the whole
  `:bindings` map.
- Updated `bind-var` to record old binding state in `:trail`.
- Updated `backtrack` to restore bindings by unwinding trail entries.
- Added standalone smoke coverage for binding restoration across disjunction.

## Why

The previous smoke failure showed that relying only on the broad generated JVM
smoke runner made switch/indexing regressions slower to diagnose.

This PR adds a smaller regression for the exact codegen/runtime contract around
default fallthrough and improves the runtime’s backtracking model at the same
time.

The binding-trail change is also a step toward parity with the mature
Haskell/Rust WAM targets:

- choice points carry less copied state
- binding restoration becomes explicit
- future heap/trail restoration work has a cleaner foundation

## Validation

Passed locally:

- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
- `swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl`

## Notes

This does not yet implement full heap/shape restoration for compound or list
construction across backtracking. That remains the next Clojure WAM parity
boundary.
