### PR TITLE
perf(wam-clojure): lighten choice point register snapshots

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -237,7 +237,7 @@ for further optimization work.
 | Shared code table | Done | All generated predicates dispatch into one shared instruction table with per-predicate start PCs |
 | One-time label resolution | Done | `call`, `execute`, `jump`, choice ops, and `switch_on_constant` are resolved at project load |
 | Indexed dispatch | Done | `switch_on_constant` is compiled into a direct lookup map in the runtime |
-| Choice points | Partial | Saves `A`/`X` regs plus env stack, bindings, and var counter; still heavier than Haskell/Rust |
+| Choice points | Partial | Saves persistent regs/env stack plus trail/heap/build boundaries; avoids binding snapshots and filtered register-map allocation, but still heavier than Haskell/Rust |
 | Environment frames | Done | `allocate`/`deallocate` use explicit environment frames for `Y` slots |
 | Cut semantics | Partial | Clause cut uses a cut barrier; `cut_ite` pops only the enclosing if-then-else CP |
 | Read-mode compound terms | Done | `get_structure`, `get_list`, `unify_*` support structure/list matching |
@@ -251,12 +251,18 @@ for further optimization work.
    string lookup costs.
 2. Choice-point snapshots cannot be reduced to `A` registers in the current
    Clojure runtime. `X` registers are still needed across retry paths such as
-   generated if-then-else code.
+   generated if-then-else code. Because Clojure maps/vectors are persistent,
+   saving the full register map is cheaper than rebuilding a filtered `A`/`X`
+   snapshot at every choice point.
 3. Treating `!/0` and `cut_ite` as "clear all choice points" is incorrect.
    The runtime now distinguishes clause-level cuts from soft cuts.
 4. The current runtime is still a bindings-centric approximation, not a full
    heap/trail WAM. That keeps the implementation moving, but it also defines
    the next real parity boundary.
+5. The standalone smoke suite now covers structure and list construction
+   across failing branches, including an env-mediated retry path. Nested
+   disjunction/cut shapes remain a generator-level gap rather than a runtime
+   optimization target.
 
 ### Highest-value remaining work
 

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -101,21 +101,13 @@
   (let [stk (:stack state)]
     [(peek stk) (assoc state :stack (pop stk))]))
 
-(defn query-reg? [reg]
-  (and (string? reg)
-       (or (.startsWith reg "A")
-           (.startsWith reg "X"))))
-
-(defn snapshot-choice-regs [regs]
-  (into {} (filter (fn [[reg _]] (query-reg? reg)) regs)))
-
 (defn restore-choice-regs [state saved-regs]
   (assoc state :regs saved-regs))
 
 (defn push-choice-point [state target-pc]
   (update state :choice-points conj {:pc target-pc
                                      :stack (:stack state)
-                                     :regs (snapshot-choice-regs (:regs state))
+                                     :regs (:regs state)
                                      :env-stack (:env-stack state)
                                      :trail-len (count (:trail state))
                                      :heap-len (count (:heap state))

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -85,6 +85,8 @@ test(project_uses_shared_wam_table_for_cross_predicate_calls) :-
         assertion(sub_string(RuntimeCode, _, _, _, ':unify-variable')),
         assertion(sub_string(RuntimeCode, _, _, _, ':retry-me-else-pc')),
         assertion(sub_string(RuntimeCode, _, _, _, ':trust-me')),
+        assertion(sub_string(RuntimeCode, _, _, _, ':regs (:regs state)')),
+        assertion(\+ sub_string(RuntimeCode, _, _, _, 'snapshot-choice-regs')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn step [state]')),
         assertion(sub_string(DepsCode, _, _, _, '"-m" "generated.wam_test.core"')),
         assertion(sub_string(ProjectCode, _, _, _, ':main generated.wam_test.core')),

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -20,6 +20,8 @@
 :- dynamic user:wam_make_struct/1.
 :- dynamic user:wam_make_list/1.
 :- dynamic user:wam_build_backtrack/1.
+:- dynamic user:wam_env_build_backtrack/1.
+:- dynamic user:wam_list_build_backtrack/1.
 :- dynamic user:wam_env1/1.
 :- dynamic user:wam_env2/1.
 :- dynamic user:wam_env3/1.
@@ -49,6 +51,8 @@ user:wam_use_list(X) :- user:wam_list_fact(X).
 user:wam_make_struct(X) :- X = f(a).
 user:wam_make_list(X) :- X = [a,b].
 user:wam_build_backtrack(X) :- (X = f(a), fail ; X = f(b)).
+user:wam_env_build_backtrack(X) :- (Y = f(a), fail ; Y = f(b)), X = Y.
+user:wam_list_build_backtrack(X) :- (X = [a,b], fail ; X = [a,c]).
 user:wam_env1(X) :- Y = X, Z = a, Y = Z.
 user:wam_env2(X) :- user:wam_fact(X), Y = X, user:wam_fact(Y).
 user:wam_env3(X) :- (X = a ; X = b), user:wam_fact(X).
@@ -84,6 +88,8 @@ run_smoke :-
           user:wam_make_struct/1,
           user:wam_make_list/1,
           user:wam_build_backtrack/1,
+          user:wam_env_build_backtrack/1,
+          user:wam_list_build_backtrack/1,
           user:wam_env1/1,
           user:wam_env2/1,
           user:wam_env3/1,
@@ -125,6 +131,10 @@ run_smoke :-
     verify_output(TmpDir, 'wam_make_list/1', '[a,b]', "true"),
     verify_output(TmpDir, 'wam_build_backtrack/1', 'f(a)', "false"),
     verify_output(TmpDir, 'wam_build_backtrack/1', 'f(b)', "true"),
+    verify_output(TmpDir, 'wam_env_build_backtrack/1', 'f(a)', "false"),
+    verify_output(TmpDir, 'wam_env_build_backtrack/1', 'f(b)', "true"),
+    verify_output(TmpDir, 'wam_list_build_backtrack/1', '[a,b]', "false"),
+    verify_output(TmpDir, 'wam_list_build_backtrack/1', '[a,c]', "true"),
     verify_output(TmpDir, 'wam_env1/1', a, "true"),
     verify_output(TmpDir, 'wam_env1/1', b, "false"),
     verify_output(TmpDir, 'wam_env2/1', a, "true"),


### PR DESCRIPTION
This PR reduces Clojure hybrid WAM choice-point overhead by avoiding a per-choice filtered register-map allocation. The runtime now snapshots the persistent Clojure register map directly, preserving current `A`/`X` retry semantics while relying on Clojure's immutable data structures for cheap snapshot sharing.

## Changes

- Replace `snapshot-choice-regs` filtering with a direct persistent `:regs` snapshot in Clojure WAM choice points.
- Add a generator-level assertion that the emitted runtime no longer contains `snapshot-choice-regs`.
- Add smoke regressions for construction state across failing branches:
  - env-mediated structure construction retry
  - list construction retry
- Update the WAM performance optimization log with the current Clojure choice-point status and the remaining nested disjunction/cut generator gap.

## Why

The Clojure runtime still needs both `A` and `X` registers across retry paths, so narrowing snapshots to `A` registers is not currently safe. Since Clojure maps are persistent, saving the full register map is cheaper and simpler than rebuilding a filtered `A`/`X` map at every choice point. This moves the Clojure target closer to the Haskell/Rust lightweight choice-point model without weakening existing backtracking behavior.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

