### PR TITLE
feat(wam-clojure): add foreign lowering controls

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -237,6 +237,7 @@ for further optimization work.
 | Shared code table | Done | All generated predicates dispatch into one shared instruction table with per-predicate start PCs |
 | One-time label resolution | Done | `call`, `execute`, `jump`, choice ops, and `switch_on_constant` are resolved at project load |
 | Indexed dispatch | Done | `switch_on_constant` is compiled into a direct lookup map in the runtime |
+| FFI controls | Scaffolded | Explicit `foreign_predicates([...])` emits `call-foreign` stubs; `no_kernels(true)` and `foreign_lowering(false)` suppress stubs. Runtime foreign handlers/kernels remain future work |
 | Choice points | Partial | Saves persistent regs/env stack plus trail/heap/build boundaries; avoids binding snapshots and filtered register-map allocation, but still heavier than Haskell/Rust |
 | Environment frames | Done | `allocate`/`deallocate` use explicit environment frames for `Y` slots |
 | Cut semantics | Partial | Clause cut uses a cut barrier; `cut_ite` pops only the enclosing if-then-else CP |
@@ -263,14 +264,20 @@ for further optimization work.
    across failing branches, including an env-mediated retry path. Nested
    disjunction/cut shapes remain a generator-level gap rather than a runtime
    optimization target.
+6. Clojure now has the same basic control vocabulary used by benchmark
+   matrices in other WAM targets: explicit foreign predicates can be marked,
+   and `no_kernels(true)` / `foreign_lowering(false)` force the pure WAM path.
+   Full Clojure kernel execution is still not implemented.
 
 ### Highest-value remaining work
 
-1. Add proper heap/trail semantics instead of relying primarily on the
+1. Implement Clojure foreign handler registration and native graph kernels
+   behind the existing `call-foreign` stub/control surface.
+2. Add proper heap/trail semantics instead of relying primarily on the
    bindings table.
-2. Reduce choice-point snapshots toward the lighter Haskell/Rust model once
+3. Reduce choice-point snapshots toward the lighter Haskell/Rust model once
    the remaining runtime state is better separated.
-3. Split hot runtime state from cold code/context data, following the same
+4. Split hot runtime state from cold code/context data, following the same
    optimization pattern that paid off heavily in Haskell.
 
 ---

--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -15,7 +15,8 @@
 
 :- module(wam_clojure_target, [
     compile_wam_predicate_to_clojure/4,  % +Pred/Arity, +WamCode, +Options, -ClojureCode
-    write_wam_clojure_project/3          % +Predicates, +Options, +ProjectDir
+    write_wam_clojure_project/3,         % +Predicates, +Options, +ProjectDir
+    clojure_foreign_predicate/3          % +Pred, +Arity, +Options
 ]).
 
 :- use_module(library(lists)).
@@ -137,8 +138,11 @@ collect_wam_entries([], _, _, [], [], [], []).
 collect_wam_entries([PredIndicator|Rest], Options, PC,
                     [WrapperCode|RestWrappers], AllInstrs, AllLabels, [DispatchEntry|RestDispatch]) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
-    wam_target:compile_predicate_to_wam(PredIndicator, Options, WamCode),
-    wam_code_to_clojure_data(WamCode, PC, GoLiterals, LabelPairs, NextPC),
+    (   clojure_foreign_predicate(Pred, Arity, Options)
+    ->  clojure_foreign_stub_data(Pred, Arity, PC, GoLiterals, LabelPairs, NextPC)
+    ;   wam_target:compile_predicate_to_wam(PredIndicator, Options, WamCode),
+        wam_code_to_clojure_data(WamCode, PC, GoLiterals, LabelPairs, NextPC)
+    ),
     maplist([Lit, Entry]>>format(atom(Entry), '~w', [Lit]), GoLiterals, InstrEntries),
     maplist([Label-Idx, Entry]>>format(atom(Entry), '~w ~w', [Label, Idx]), LabelPairs, LabelRows),
     compile_wam_predicate_to_clojure_shared(Pred/Arity, PC, WrapperCode),
@@ -147,6 +151,29 @@ collect_wam_entries([PredIndicator|Rest], Options, PC,
     collect_wam_entries(Rest, Options, NextPC, RestWrappers, RestInstrs, RestLabels, RestDispatch),
     append(InstrEntries, RestInstrs, AllInstrs),
     append(LabelRows, RestLabels, AllLabels).
+
+%% clojure_foreign_predicate(+Pred, +Arity, +Options) is semidet.
+%  True when a predicate should be represented by a Clojure WAM
+%  call-foreign stub instead of compiling its normal WAM body.
+%
+%  This first Clojure pass intentionally supports explicit controls only:
+%  - foreign_predicates([p/n, ...]) opts predicates into foreign stubs.
+%  - foreign_lowering(false) disables foreign stubs.
+%  - no_kernels(true) disables foreign stubs for benchmark parity.
+clojure_foreign_predicate(Pred, Arity, Options) :-
+    \+ option(no_kernels(true), Options),
+    \+ option(foreign_lowering(false), Options),
+    option(foreign_predicates(ForeignPreds), Options, []),
+    member(Pred/Arity, ForeignPreds).
+
+clojure_foreign_stub_data(Pred, Arity, PC, Literals, LabelPairs, NextPC) :-
+    format(atom(PredKey), '~w/~w', [Pred, Arity]),
+    clj_string_literal(PredKey, PredKeyLit),
+    clj_string_literal(Pred, PredLit),
+    format(atom(CallLit), '{:op :call-foreign :pred ~w :arity ~w}', [PredLit, Arity]),
+    Literals = [CallLit, '{:op :proceed}'],
+    LabelPairs = [PredKeyLit-PC],
+    NextPC is PC + 2.
 
 compile_wam_predicate_to_clojure(PredIndicator, WamCode, _Options, ClojureCode) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
@@ -225,6 +252,10 @@ wam_op_to_clojure_literal("call", [Pred, ArityStr], _, Literal) :-
     clj_string_literal(Pred, PredLit),
     number_string(Arity, ArityStr),
     format(atom(Literal), '{:op :call :pred ~w :arity ~w}', [PredLit, Arity]).
+wam_op_to_clojure_literal("call_foreign", [Pred, ArityStr], _, Literal) :-
+    clj_string_literal(Pred, PredLit),
+    number_string(Arity, ArityStr),
+    format(atom(Literal), '{:op :call-foreign :pred ~w :arity ~w}', [PredLit, Arity]).
 wam_op_to_clojure_literal("execute", [Pred], _, Literal) :-
     clj_string_literal(Pred, PredLit),
     format(atom(Literal), '{:op :execute :pred ~w}', [PredLit]).

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -509,6 +509,12 @@
 
           (backtrack state))
 
+        :call-foreign
+        ;; Foreign handlers are introduced by target-specific kernels.
+        ;; Until a handler is registered, foreign calls fail cleanly rather
+        ;; than falling through to a missing WAM body.
+        (backtrack state)
+
         :cut-ite
         (-> state
             (update :choice-points #(if (seq %) (pop %) %))

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -73,6 +73,7 @@ test(project_uses_shared_wam_table_for_cross_predicate_calls) :-
         assertion(sub_string(RuntimeCode, _, _, _, ':execute-pc')),
         assertion(sub_string(RuntimeCode, _, _, _, ':jump-pc')),
         assertion(sub_string(RuntimeCode, _, _, _, ':builtin-call')),
+        assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, ':cut-ite')),
         assertion(sub_string(RuntimeCode, _, _, _, ':put-structure')),
         assertion(sub_string(RuntimeCode, _, _, _, ':put-list')),
@@ -90,6 +91,58 @@ test(project_uses_shared_wam_table_for_cross_predicate_calls) :-
         assertion(sub_string(RuntimeCode, _, _, _, '(defn step [state]')),
         assertion(sub_string(DepsCode, _, _, _, '"-m" "generated.wam_test.core"')),
         assertion(sub_string(ProjectCode, _, _, _, ':main generated.wam_test.core')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+test(foreign_predicates_emit_call_foreign_stub) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_foreign', TmpDir),
+        write_wam_clojure_project([user:wam_fact/1,
+                                   user:wam_execute_caller/1],
+                                  [ namespace('generated.wam_foreign_test'),
+                                    foreign_predicates([wam_fact/1])
+                                  ], TmpDir),
+        directory_file_path(TmpDir, 'src/generated/wam_foreign_test/core.clj', CorePath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(wam_clojure_target:clojure_foreign_predicate(wam_fact, 1,
+                   [foreign_predicates([wam_fact/1])])),
+        assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "wam_fact" :arity 1}')),
+        assertion(sub_string(CoreCode, _, _, _, '"wam_fact/1" 0')),
+        assertion(\+ sub_string(CoreCode, _, _, _, '{:op :get-constant :constant "a" :reg "A1"}')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+test(no_kernels_suppresses_clojure_foreign_stub) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_no_kernels', TmpDir),
+        write_wam_clojure_project([user:wam_fact/1],
+                                  [ namespace('generated.wam_no_kernels_test'),
+                                    foreign_predicates([wam_fact/1]),
+                                    no_kernels(true)
+                                  ], TmpDir),
+        directory_file_path(TmpDir, 'src/generated/wam_no_kernels_test/core.clj', CorePath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(\+ wam_clojure_target:clojure_foreign_predicate(wam_fact, 1,
+                   [foreign_predicates([wam_fact/1]), no_kernels(true)])),
+        assertion(\+ sub_string(CoreCode, _, _, _, ':call-foreign')),
+        assertion(sub_string(CoreCode, _, _, _, '{:op :get-constant :constant "a" :reg "A1"}')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+test(foreign_lowering_false_suppresses_clojure_foreign_stub) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_foreign_off', TmpDir),
+        write_wam_clojure_project([user:wam_fact/1],
+                                  [ namespace('generated.wam_foreign_off_test'),
+                                    foreign_predicates([wam_fact/1]),
+                                    foreign_lowering(false)
+                                  ], TmpDir),
+        directory_file_path(TmpDir, 'src/generated/wam_foreign_off_test/core.clj', CorePath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(\+ wam_clojure_target:clojure_foreign_predicate(wam_fact, 1,
+                   [foreign_predicates([wam_fact/1]), foreign_lowering(false)])),
+        assertion(\+ sub_string(CoreCode, _, _, _, ':call-foreign')),
+        assertion(sub_string(CoreCode, _, _, _, '{:op :get-constant :constant "a" :reg "A1"}')),
         delete_directory_and_contents(TmpDir)
     )).
 


### PR DESCRIPTION
This PR adds the first Clojure hybrid WAM foreign-control surface, aligning the target with the option vocabulary used by the more mature WAM targets and benchmark matrix.

It does not implement native Clojure graph kernels yet. Instead, it adds explicit opt-in foreign predicate stubs and the controls needed to force the pure WAM path for benchmarking and correctness comparisons.

## Changes

- Add Clojure WAM foreign predicate detection through `foreign_predicates([p/n, ...])`.
- Emit `:call-foreign` stubs for explicitly foreign-owned predicates instead of compiling their normal WAM bodies.
- Add suppression controls:
  - `no_kernels(true)` disables Clojure foreign stubs.
  - `foreign_lowering(false)` disables Clojure foreign stubs.
- Add Clojure literal support for `call_foreign`.
- Add runtime `:call-foreign` handling that fails cleanly until real handlers/kernels are registered.
- Add generator tests covering stub emission and both suppression paths.
- Update `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` with the Clojure FFI-control status and next work.

## Why

The largest Haskell/Rust WAM wins came from routing hot predicates through foreign/kernel paths and from being able to benchmark pure WAM versus kernel-backed execution explicitly. Clojure needed the same control vocabulary before implementing native kernels, otherwise benchmark comparisons could not reliably switch between pure and hybrid modes.

This PR establishes that foundation without changing default Clojure WAM behavior.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

