### PR TITLE
fix(wam-elixir): CPS continuations + state-carrying fail throws

### DIFF
--- a/docs/design/WAM_ELIXIR_CORRECTNESS_GAPS.md
+++ b/docs/design/WAM_ELIXIR_CORRECTNESS_GAPS.md
@@ -51,77 +51,45 @@ Y-registers (ids 201-299) lived in the global `state.regs` map, so
 recursive calls to the same predicate overwrote each other's
 permanents. `allocate` now saves the current Y-reg subset into
 `env.y_regs_saved` and clears those slots; `deallocate` discards
-current Y-regs and merges the saved ones back. Correctness improvement
-but not observable in the current benchmark because of the
-non-tail-call continuation bug below.
+current Y-regs and merges the saved ones back.
 
-## Remaining: non-tail recursive calls lose the outer continuation in lowered mode
+### Non-tail recursive calls lost the outer continuation (CPS refactor)
 
-The lowered emitter represents each clause as a standalone Elixir
-function. `WamDispatcher.call` invokes a predicate's clause; the clause
-runs to completion and returns `{:ok, state}`. For a non-tail body like
-`body_goal(...), is/2` (`ancestor_h(X,Y,N) :- parent(X,Z), ancestor_h(Z,Y,N1), N is N1+1`):
+Fixed in `fix/wam-elixir-cps-continuations`. Each body call now
+terminates its sub-segment; subsequent instructions go into a fresh
+`defp BaseFunc_kN/1` continuation function. Before each call,
+`state.cp` is set to `&BaseFunc_kN/1`; `proceed` tail-calls
+`state.cp.(state)`. Top-level callers seed `state.cp =
+&WamRuntime.terminal_cp/1`. BEAM TCO collapses the stack across
+predicates, so deep recursion doesn't grow it. `backtrack` retries
+invoke the stored continuation, so outer post-call code runs on every
+solution. `examples/debug_wam_elixir_ancestor.pl` now reports 4/4
+correct solutions with bound `N` values across all three tests.
 
-- First solution works: outer's clause runs straight through, calls
-  inner, gets its return, runs outer's `is/2`, returns.
-- On backtrack: `backtrack/1` pops inner's CP and invokes
-  `&clause_LAncestorH32/1` directly with the restored state. Inner's
-  clause runs to completion — including its own `is/2` — and returns.
-  The result propagates through `backtrack` to `next_solution` and out
-  to the driver. **Outer's post-call code (reading Y3 for N, running
-  its own is/2) is never re-entered.**
+### Catch-snapshot hiding mid-body choice points
 
-Consequence: alternative solutions show the inner's `N` binding but
-not the outer's. In `examples/debug_wam_elixir_ancestor.pl` Test 3
-with a 4-level fact chain:
+The initial CPS wrapping used `catch :fail -> backtrack(state)` where
+`state` was the pre-try snapshot — any choice points pushed during the
+body were invisible to the catch, causing either lost CPs or infinite
+retry loops (seen as a hang). Fixed by threading state through the
+throw: every `throw(:fail)` is now `throw({:fail, state})`, and every
+catch pattern-matches on `{:fail, s}` and passes `s` to `backtrack`.
 
-```
-Y="b" N="1"                                (1st — base case, ok)
-Y="c" N=2.0                                (2nd — 1-hop recursion, ok)
-Y="d" N={:unbound, <caller's N ref>}      (3rd — 2-hop, N not bound)
-Y="e" N={:unbound, <caller's N ref>}      (4th — 3-hop, N not bound)
-```
+### `switch_on_constant` duplicated solutions
 
-Traces confirm: on the 3rd+ backtrack, inner's `is/2` binds inner's
-local `N` ref (~206372) but outer's caller-`N` ref (~206345) stays
-unbound because outer's `is/2` never runs.
+Inline dispatch from `switch_on_constant` into the target clause ran
+in the presence of the outer `try_me_else` CP (pushed just before the
+switch) — on backtrack, that CP retried the same clause, producing
+duplicates. The inline-dispatch arm now pops that outer CP before
+calling the target clause.
 
-### Fix shape
+## Remaining / follow-ups
 
-The lowered emitter needs to preserve the outer's continuation across
-a `call`. Options:
-
-1. **Continuation passing.** A clause takes a `k` (continuation)
-   parameter and tail-calls it with the final state. Every `call` in
-   the body captures the post-call code in a closure and passes it as
-   `k` to the callee. Backtrack's `cp.pc.(state, k)` would then invoke
-   the retry with the saved continuation.
-2. **State.cp as function ref.** Store the post-call function in
-   `state.cp` before each `call`; have `proceed` invoke `state.cp`.
-   Matches the interpreter-mode abstraction but requires the lowered
-   emitter to synthesise a fresh `defp` for each call-point's
-   continuation.
-3. **Interpreter fallback.** Detect non-tail recursive calls at
-   codegen time and emit interpreter-style dispatch for those
-   predicates.
-
-Option 2 is probably the cleanest given the existing `state.cp` field
-already exists. Option 3 is the smallest change but splits the
-generated code into two regimes.
-
-Fact-only predicates, plain tail-recursive predicates, and
-deterministic clauses work correctly today; only non-tail recursion is
-affected.
+Codegen time dominates benchmark runs at scale 300+ — emitting the
+lowered Elixir for six predicates on 300-row facts takes ~80s in the
+Prolog side. Not a correctness issue, but worth investigating before
+meaningful perf comparison on larger scales.
 
 ## Out of scope for this doc
 
-- `switch_on_constant` duplicate-key warnings — fixed in
-  `fix/wam-elixir-switch-dedup-arms`.
 - Phase A/B/C perf work is orthogonal.
-
-## Implication for benchmarking
-
-`effective_distance` at dev scale still produces 3 rows vs the 19-row
-reference because `category_ancestor/4` has non-tail recursion (cut
-and `H is H1 + 1` after the recursive call). Meaningful perf
-comparisons still require the continuation fix.

--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -39,17 +39,14 @@ lower_predicate_to_elixir(Pred/Arity, WamCode, Options, Code) :-
 'defmodule ~w.~w do
   @moduledoc "Lowered WAM-compiled predicate: ~w/~w"
 
-  def run(%WamRuntime.WamState{} = state) do
-    try do
-      ~w(state)
-    catch
-      :fail -> :fail
-      {:return, result} -> result
-      error ->
-        IO.puts("Predicate ~w CRASHED: #{inspect(error)}")
-        :fail
-    end
-  end
+  # run/1 is a plain tail call into the first clause segment. No
+  # try/catch here — failures propagate via throw({:fail, state}) up to
+  # the outermost catch in run(args). Without this, every cross-predicate
+  # dispatch (WamDispatcher.call → Pred.run) would add a try frame that
+  # defeats tail-call optimisation. Carrying state in the throw lets each
+  # enclosing catch backtrack on the most-current state (with CPs pushed
+  # during body execution intact), not the pre-try snapshot.
+  def run(%WamRuntime.WamState{} = state), do: ~w(state)
 
   def run(args) when is_list(args) do
     state = %WamRuntime.WamState{code: {}, labels: %{}, pc: 1}
@@ -69,10 +66,21 @@ lower_predicate_to_elixir(Pred/Arity, WamCode, Options, Code) :-
           {%{s | regs: Map.put(s.regs, i, other)}, vars}
       end
     end)
-    state = %{state | arg_vars: arg_vars}
-    case run(state) do
-      {:ok, final} -> {:ok, WamRuntime.materialise_args(final)}
-      other -> other
+    # state.cp holds the current continuation — a function of
+    # `(state) -> {:ok, state} | :fail`. At the top level we terminate
+    # in WamRuntime.terminal_cp/1 which just returns {:ok, state}.
+    state = %{state | arg_vars: arg_vars, cp: &WamRuntime.terminal_cp/1}
+    try do
+      case run(state) do
+        {:ok, final} -> {:ok, WamRuntime.materialise_args(final)}
+        other -> other
+      end
+    catch
+      {:fail, _} -> :fail
+      {:return, result} -> result
+      error ->
+        IO.puts("Predicate ~w CRASHED: #{inspect(error)}")
+        :fail
     end
   end
 
@@ -130,13 +138,103 @@ extract_segment_body([Line|Rest], PC, Body, Next, NPC) :-
     ).
 
 generate_all_segments([], _, []).
-generate_all_segments([Name-Instrs | Rest], Labels, [Code | RestCodes]) :-
+generate_all_segments([Name-Instrs | Rest], Labels, SegCodes) :-
     segment_func_name(Name, FuncName),
     classify_segment_head(Instrs, HeadType, BodyInstrs),
-    lower_instr_list(BodyInstrs, Labels, FuncName, BodyExprs),
-    atomic_list_concat(BodyExprs, '\n', BodyCode),
-    wrap_segment(FuncName, HeadType, BodyCode, Code),
-    generate_all_segments(Rest, Labels, RestCodes).
+    % CPS split: every non-tail `call P, N` terminates a sub-segment;
+    % subsequent instrs go into a fresh continuation function. This lets
+    % backtrack re-enter a retry point without losing the outer caller's
+    % post-call code (which Elixir would otherwise have on a collapsed
+    % tail-call stack).
+    split_body_at_calls(BodyInstrs, SubSegs),
+    emit_sub_segments(SubSegs, FuncName, HeadType, Labels, ThisSegCodes),
+    generate_all_segments(Rest, Labels, RestCodes),
+    append(ThisSegCodes, RestCodes, SegCodes).
+
+%% split_body_at_calls(+Instrs, -SubSegs)
+%  Splits a flat instr list into sub-segment lists, cutting after every
+%  `call P, N` opcode. The call is the last element of its sub-segment;
+%  the next sub-segment starts with the first instr after it. A body with
+%  no `call`s yields exactly one sub-segment.
+split_body_at_calls(Instrs, SubSegs) :-
+    split_body_at_calls_(Instrs, [], SubSegs).
+
+split_body_at_calls_([], AccRev, [Seg]) :-
+    reverse(AccRev, Seg).
+split_body_at_calls_([PC-call(P, N) | Rest], AccRev, [Seg | RestSegs]) :-
+    !,
+    reverse([PC-call(P, N) | AccRev], Seg),
+    split_body_at_calls_(Rest, [], RestSegs).
+split_body_at_calls_([Instr | Rest], AccRev, Segs) :-
+    split_body_at_calls_(Rest, [Instr | AccRev], Segs).
+
+%% emit_sub_segments(+SubSegs, +BaseFunc, +HeadType, +Labels, -Codes)
+%  Emits one `defp` per sub-segment. The first uses wrap_segment (with
+%  CP push for try_me_else / retry_me_else). Subsequent sub-segments are
+%  plain `defp BaseFunc_kN(state) do ... end` continuations. Every
+%  sub-segment except the last ends with a tail call to the next
+%  continuation; the last ends with its natural tail (execute/proceed).
+emit_sub_segments([OnlySeg], BaseFunc, HeadType, Labels, [Code]) :-
+    lower_instr_list(OnlySeg, Labels, BaseFunc, Exprs),
+    atomic_list_concat(Exprs, '\n', BodyCode),
+    wrap_segment(BaseFunc, HeadType, BodyCode, Code).
+
+emit_sub_segments([FirstSeg | MoreSegs], BaseFunc, HeadType, Labels, [FirstCode | MoreCodes]) :-
+    MoreSegs = [_|_],
+    format(string(NextFunc), '~w_k1', [BaseFunc]),
+    lower_seg_with_continuation(FirstSeg, NextFunc, Labels, BaseFunc, FirstBody),
+    wrap_segment(BaseFunc, HeadType, FirstBody, FirstCode),
+    emit_cont_segments(MoreSegs, BaseFunc, 1, Labels, MoreCodes).
+
+emit_cont_segments([FinalSeg], BaseFunc, Idx, Labels, [Code]) :-
+    format(string(FuncName), '~w_k~w', [BaseFunc, Idx]),
+    lower_instr_list(FinalSeg, Labels, FuncName, Exprs),
+    atomic_list_concat(Exprs, '\n', BodyCode),
+    format(string(Code),
+'  defp ~w(state) do
+    try do
+~w
+    catch
+      {:fail, s} ->
+        case WamRuntime.backtrack(s) do
+          :fail -> throw({:fail, %{s | choice_points: []}})
+          other -> other
+        end
+    end
+  end', [FuncName, BodyCode]).
+emit_cont_segments([Seg | More], BaseFunc, Idx, Labels, [Code | RestCodes]) :-
+    More = [_|_],
+    format(string(FuncName), '~w_k~w', [BaseFunc, Idx]),
+    NextIdx is Idx + 1,
+    format(string(NextFunc), '~w_k~w', [BaseFunc, NextIdx]),
+    lower_seg_with_continuation(Seg, NextFunc, Labels, FuncName, Body),
+    format(string(Code),
+'  defp ~w(state) do
+    try do
+~w
+    catch
+      {:fail, s} ->
+        case WamRuntime.backtrack(s) do
+          :fail -> throw({:fail, %{s | choice_points: []}})
+          other -> other
+        end
+    end
+  end', [FuncName, Body]),
+    emit_cont_segments(More, BaseFunc, NextIdx, Labels, RestCodes).
+
+%% lower_seg_with_continuation(+Instrs, +NextFunc, +Labels, +FuncName, -Body)
+%  Lowers a sub-segment that ends with `call P, N`. The body is the
+%  ordinary lowering of the pre-call instrs, followed by a tail-call that
+%  stores NextFunc in state.cp so the called predicate\'s `proceed`
+%  routes control back to NextFunc rather than collapsing the stack.
+lower_seg_with_continuation(Instrs, NextFunc, Labels, FuncName, Body) :-
+    append(InitInstrs, [_PC-call(P, _N)], Instrs),
+    lower_instr_list(InitInstrs, Labels, FuncName, InitExprs),
+    format(string(TailCallCode),
+'    state = %{state | cp: &~w/1}
+    WamDispatcher.call("~w", state)', [NextFunc, P]),
+    append(InitExprs, [TailCallCode], AllExprs),
+    atomic_list_concat(AllExprs, '\n', Body).
 
 %% split_last_colon(+Entry, -Key, -Label)
 %  Splits an "apple:L1" entry into Key="apple" and Label="L1".
@@ -174,7 +272,14 @@ build_switch_arm_group(Key-Labels, Arm) :-
     (   Labels = [OnlyLabel],
         OnlyLabel \== "default"
     ->  segment_func_name(OnlyLabel, LocalFunc),
-        format(string(Arm), '"~w" -> throw({:return, ~w(state)})', [Key, LocalFunc])
+        % Drop the outer try_me_else CP (pushed just before this switch):
+        % we are deterministically dispatching to LocalFunc, so the outer
+        % CP — which points at that same clause — would cause a duplicate
+        % solution on backtracking. The inline-dispatched clause pushes
+        % its own retry CP, which remains correct.
+        format(string(Arm),
+               '"~w" -> throw({:return, ~w(%{state | choice_points: tl(state.choice_points)})})',
+               [Key, LocalFunc])
     ;   format(string(Arm), '"~w" -> :ok', [Key])
     ).
 
@@ -197,33 +302,61 @@ wrap_segment(FuncName, try_me_else(L), BodyCode, Code) :-
     cp = %{pc: &~w/1, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
            cp: state.cp, trail: state.trail, trail_len: state.trail_len, stack: state.stack}
     state = %{state | choice_points: [cp | state.choice_points]}
+    try do
 ~w
+    catch
+      {:fail, s} ->
+        case WamRuntime.backtrack(s) do
+          :fail -> throw({:fail, %{s | choice_points: []}})
+          other -> other
+        end
+    end
   end', [FuncName, FallbackFunc, BodyCode]).
 
 wrap_segment(FuncName, retry_me_else(L), BodyCode, Code) :-
     segment_func_name(L, FallbackFunc),
     format(string(Code),
 '  defp ~w(state) do
-    case state.choice_points do
-      [_old | rest] ->
-        cp = %{pc: &~w/1, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
-               cp: state.cp, trail: state.trail, trail_len: state.trail_len, stack: state.stack}
-        state = %{state | choice_points: [cp | rest]}
+    cp = %{pc: &~w/1, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
+           cp: state.cp, trail: state.trail, trail_len: state.trail_len, stack: state.stack}
+    state = %{state | choice_points: [cp | state.choice_points]}
+    try do
 ~w
-      _ -> throw(:fail)
+    catch
+      {:fail, s} ->
+        case WamRuntime.backtrack(s) do
+          :fail -> throw({:fail, %{s | choice_points: []}})
+          other -> other
+        end
     end
   end', [FuncName, FallbackFunc, BodyCode]).
 
 wrap_segment(FuncName, trust_me, BodyCode, Code) :-
     format(string(Code),
 '  defp ~w(state) do
+    try do
 ~w
+    catch
+      {:fail, s} ->
+        case WamRuntime.backtrack(s) do
+          :fail -> throw({:fail, %{s | choice_points: []}})
+          other -> other
+        end
+    end
   end', [FuncName, BodyCode]).
 
 wrap_segment(FuncName, none, BodyCode, Code) :-
     format(string(Code),
 '  defp ~w(state) do
+    try do
 ~w
+    catch
+      {:fail, s} ->
+        case WamRuntime.backtrack(s) do
+          :fail -> throw({:fail, %{s | choice_points: []}})
+          other -> other
+        end
+    end
   end', [FuncName, BodyCode]).
 
 lower_instr_list([], _, _, []).
@@ -278,7 +411,7 @@ wam_elixir_lower_instr(get_constant(C, AiName), _PC, _Labels, _FuncName, Code) :
       match?({:unbound, _}, val) ->
         {:unbound, id} = val
         state |> WamRuntime.trail_binding(id) |> WamRuntime.put_reg(id, "~w")
-      true -> throw(:fail)
+      true -> throw({:fail, state})
     end', [Ai, C, C]).
 
 wam_elixir_lower_instr(get_variable(XnName, AiName), _PC, _Labels, _FuncName, Code) :-
@@ -294,7 +427,7 @@ wam_elixir_lower_instr(get_value(XnName, AiName), _PC, _Labels, _FuncName, Code)
     val_x = WamRuntime.get_reg(state, ~w)
     state = case WamRuntime.unify(state, val_a, val_x) do
       {:ok, s} -> s
-      :fail -> throw(:fail)
+      :fail -> throw({:fail, state})
     end', [Ai, Xn]).
 
 wam_elixir_lower_instr(put_structure(F, AiName), _PC, _Labels, _FuncName, Code) :-
@@ -326,17 +459,17 @@ wam_elixir_lower_instr(get_structure(F, AiName), _PC, _Labels, _FuncName, Code) 
       match?({:ref, _}, val) ->
         {:ref, addr} = val
         case WamRuntime.step_get_structure_ref(state, "~w", ~w, addr) do
-          :fail -> throw(:fail)
+          :fail -> throw({:fail, state})
           s -> s
         end
-      true -> throw(:fail)
+      true -> throw({:fail, state})
     end', [Ai, F, Ai, Ai, Arity, F, Arity]).
 
 wam_elixir_lower_instr(unify_variable(XnName), _PC, _Labels, _FuncName, Code) :-
     reg_id(XnName, Xn),
     format(string(Code),
 '    state = case WamRuntime.step_unify_variable(state, ~w) do
-      :fail -> throw(:fail)
+      :fail -> throw({:fail, state})
       s -> s
     end', [Xn]).
 
@@ -344,14 +477,14 @@ wam_elixir_lower_instr(unify_value(XnName), _PC, _Labels, _FuncName, Code) :-
     reg_id(XnName, Xn),
     format(string(Code),
 '    state = case WamRuntime.step_unify_value(state, ~w) do
-      :fail -> throw(:fail)
+      :fail -> throw({:fail, state})
       s -> s
     end', [Xn]).
 
 wam_elixir_lower_instr(unify_constant(C), _PC, _Labels, _FuncName, Code) :-
     format(string(Code),
 '    state = case WamRuntime.step_unify_constant(state, "~w") do
-      :fail -> throw(:fail)
+      :fail -> throw({:fail, state})
       s -> s
     end', [C]).
 
@@ -386,7 +519,7 @@ wam_elixir_lower_instr(call(P, _N), PC, _Labels, _FuncName, Code) :-
     format(string(Code),
 '    state = case WamDispatcher.call("~w", state) do
       {:ok, s} -> %{s | pc: ~w}
-      :fail -> throw(:fail)
+      :fail -> throw({:fail, state})
     end', [P, NPC]).
 
 wam_elixir_lower_instr(execute(P), _PC, _Labels, _FuncName, Code) :-
@@ -396,7 +529,7 @@ wam_elixir_lower_instr(execute(P), _PC, _Labels, _FuncName, Code) :-
 wam_elixir_lower_instr(builtin_call(Op, Ar), _PC, _Labels, _FuncName, Code) :-
     format(string(Code),
 '    state = case WamRuntime.execute_builtin(state, "~w", ~w) do
-      :fail -> throw(:fail)
+      :fail -> throw({:fail, state})
       s -> s
     end', [Op, Ar]).
 
@@ -449,13 +582,13 @@ wam_elixir_lower_instr(get_list(AiName), _PC, _Labels, _FuncName, Code) :-
       match?({:ref, _}, val) ->
         {:ref, addr} = val
         case WamRuntime.step_get_structure_ref(state, "./2", 2, addr) do
-          :fail -> throw(:fail)
+          :fail -> throw({:fail, state})
           s -> s
         end
       is_list(val) ->
         [h | t] = val
         %{state | stack: [{:unify_ctx, [h, t]} | state.stack]}
-      true -> throw(:fail)
+      true -> throw({:fail, state})
     end', [Ai, Ai, Ai]).
 
 wam_elixir_lower_instr(set_variable(XnName), _PC, _Labels, _FuncName, Code) :-
@@ -490,7 +623,7 @@ wam_elixir_lower_instr(switch_on_constant(Entries), _PC, _Labels, _FuncName, Cod
       _ ->
         case val do
           ~w
-          _ -> throw(:fail)
+          _ -> throw({:fail, state})
         end
     end', [ArmsStr]).
 
@@ -503,12 +636,16 @@ wam_elixir_lower_instr(switch_on_constant_a2(Entries), _PC, _Labels, _FuncName, 
       _ ->
         case val do
           ~w
-          _ -> throw(:fail)
+          _ -> throw({:fail, state})
         end
     end', [ArmsStr]).
 
 wam_elixir_lower_instr(proceed, _PC, _Labels, _FuncName, Code) :-
-    Code = '    {:ok, %{state | pc: state.cp}}'.
+    % CPS: proceed = tail-call the continuation stored in state.cp. The
+    % caller\'s post-call code (or the driver\'s terminal_cp) lives in
+    % state.cp — this tail call invokes it. BEAM TCO collapses the stack
+    % so deep recursion doesn\'t grow it.
+    Code = '    state.cp.(state)'.
 
 wam_elixir_lower_instr(raw(Combined), _PC, _Labels, _FuncName, Code) :-
     format(string(Code), '    # raw: ~w\n    raise "TODO: ~w"', [Combined, Combined]).

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -379,14 +379,15 @@ compile_backtrack_to_elixir(Code) :-
         |> Map.put(:choice_points, rest)
 
         if is_function(cp.pc) do
-          # The retried clause may throw :fail (its own guards failed) or
+          # The retried clause may throw {:fail, thrown_state} (its own
+          # guards failed, with CPs accumulated during its body) or
           # {:return, result} (it succeeded). Translate back into the
           # {:ok, state} | :fail contract so the caller does not need to
           # know about clause-local control flow.
           try do
             cp.pc.(state)
           catch
-            :fail -> backtrack(state)
+            {:fail, thrown_state} -> backtrack(thrown_state)
             {:return, result} -> result
           end
         else
@@ -495,6 +496,16 @@ compile_utility_helpers_to_elixir(Code) :-
       other -> other
     end
   end
+
+  @doc """
+  Terminal continuation for CPS-lowered predicates. When a clause\'s
+  `proceed` opcode runs, it tail-calls the continuation stored in
+  state.cp. At the top level of a driver-initiated call, state.cp is
+  this function — `run(args)` installs it before entering the clause
+  chain. All it does is wrap the final state in the run/1 success
+  contract.
+  """
+  def terminal_cp(state), do: {:ok, state}
 
   @doc "Read `len` consecutive heap cells starting at `start`."
   def heap_slice(_state, _start, 0), do: []
@@ -660,7 +671,7 @@ compile_utility_helpers_to_elixir(Code) :-
         if v1 < v2, do: %{state | pc: new_pc}, else: :fail
       {"length/2", 2} ->
         list = get_reg(state, 1)
-        len = if is_list(list), do: length(list), else: throw(:fail)
+        len = if is_list(list), do: length(list), else: throw({:fail, state})
         new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
         case unify(state, len, get_reg(state, 2)) do
           {:ok, s} -> %{s | pc: new_pc}


### PR DESCRIPTION
## Summary

Fixes the non-tail-recursion correctness gap in the WAM-Elixir lowered
emitter (tracked in `docs/design/WAM_ELIXIR_CORRECTNESS_GAPS.md`).
Each body `call P,N` now splits the clause into a fresh continuation
`defp`; `state.cp` carries the continuation function, and `proceed`
tail-calls it. Outer post-call code is re-entered on every backtrack
solution.

Two correctness adjuncts stabilise the CPS scheme:

1. **Fail throws carry state.** `throw(:fail)` → `throw({:fail, state})`
   everywhere. Catches pattern-match `{:fail, s}` and pass `s` to
   `backtrack`, so mid-body choice points are visible to the catch —
   previously, each catch ran with the pre-try snapshot and either lost
   CPs or looped infinitely on already-exhausted ones.
2. **`switch_on_constant` dedup.** The inline-dispatch arm now pops the
   outer `try_me_else` CP before calling the target clause. That CP
   pointed at the same clause the switch was inlining; on backtrack it
   retried the clause and produced duplicate solutions.

Also applies a lesson from the parallel wam-haskell fork fix
([#1487](https://github.com/s243a/UnifyWeaver/pull/1487)
"fork backtrack must not finalize the aggregate"): when local
`backtrack(s)` returns `:fail`, re-throw with empty `choice_points` so
outer catchers short-circuit instead of re-iterating an
already-exhausted CP list. Same theme — don't let `backtrack` redo or
undo work past a boundary condition.

## What changed

### `src/unifyweaver/targets/wam_elixir_lowered_emitter.pl`

- `generate_all_segments` now runs each clause's body through
  `split_body_at_calls` + `emit_sub_segments`. The first sub-segment is
  wrapped with `try_me_else` / `retry_me_else` / `trust_me` push logic;
  subsequent sub-segments emit as `defp BaseFunc_kN/1`.
- `lower_seg_with_continuation` emits the tail-call at the end of each
  non-terminal sub-segment: `state = %{state | cp: &_kN/1}` followed by
  `WamDispatcher.call("P", state)`.
- `proceed` opcode lowers to `state.cp.(state)` — a tail call into the
  continuation stored by the caller.
- `run/1` clause-state entry point is now a plain tail call
  (`def run(%WamState{} = state), do: first_clause(state)`) with no
  try/catch, so cross-predicate dispatch benefits from BEAM TCO.
- `run(args)` seeds `state.cp = &WamRuntime.terminal_cp/1` and wraps
  the call in the outer try/catch.
- Every `throw(:fail)` emission now carries `state`:
  `throw({:fail, state})`. Every generated catch pattern-matches
  `{:fail, s}` and invokes `backtrack(s)`; on exhaustion, re-throws
  with empty `choice_points`.
- `switch_on_constant` arm for a unique match now dispatches via
  `throw({:return, clause_LXxx(%{state | choice_points: tl(state.choice_points)})})`,
  dropping the redundant outer CP.

### `src/unifyweaver/targets/wam_elixir_target.pl`

- `backtrack`'s internal catch matches `{:fail, thrown_state}` and
  recurses on `thrown_state` (so CPs pushed during `cp.pc` are honoured).
- New `WamRuntime.terminal_cp/1` = `{:ok, state}` — terminal
  continuation for driver-level calls.
- `execute_builtin`'s `length/2` arm throws `{:fail, state}` instead of
  bare `:fail` to match the new protocol.

### `docs/design/WAM_ELIXIR_CORRECTNESS_GAPS.md`

Moved the "non-tail recursion" item from **Remaining** to **Fixed**,
added entries for the two adjuncts, and noted that codegen time is now
the bottleneck at larger benchmark scales.

## Verification

`examples/debug_wam_elixir_ancestor.pl` runs three tests over a 4-link
parent chain (`a→b→c→d→e`) compiled through the lowered pipeline:

| Test                                       | Expected                     | Got                          |
| ------------------------------------------ | ---------------------------- | ---------------------------- |
| `ancestor("a", Y)`                         | 4 solutions: `b,c,d,e`       | `b,c,d,e` (total 4)          |
| `ancestor_h("a", "d", N)`                  | `N=3`                        | `N=3.0` (total 1)            |
| `ancestor_h("a", Y, N)`                    | 4 solutions, N=1..4          | `Y=b,N=1; c,2; d,3; e,4`     |

Before this PR, Test 3 returned `Y=d` and `Y=e` with `N` still unbound
because outer's `N is N1+1` never re-entered on backtrack.

Test suites:

- `tests/test_wam_elixir_target.pl` — 14/14 pass
- `tests/test_wam_elixir_utils.pl` — 7/7 pass

## Test plan

- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_target.pl`
- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_utils.pl`
- [x] `swipl -q -s examples/debug_wam_elixir_ancestor.pl -t halt` —
      verify 4/4, 1/1, 4/4 solution counts with correct `N` values
- [ ] `python3 examples/benchmark/benchmark_wam_elixir_effective_distance.py --scales 300`
      — currently bottlenecked by codegen time (~80s for 6 predicates);
      not a correctness issue, tracked as follow-up

## Related

- Parallels the wam-haskell fix in
  [#1487](https://github.com/s243a/UnifyWeaver/pull/1487)
  ("fork backtrack must not finalize the aggregate") — both address
  backtrack doing the wrong thing past a boundary.
- Builds on the Y-reg frame isolation fix (PR #1480) already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
