### PR TITLE
feat(wam-clojure): wire deterministic foreign handlers

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -237,7 +237,7 @@ for further optimization work.
 | Shared code table | Done | All generated predicates dispatch into one shared instruction table with per-predicate start PCs |
 | One-time label resolution | Done | `call`, `execute`, `jump`, choice ops, and `switch_on_constant` are resolved at project load |
 | Indexed dispatch | Done | `switch_on_constant` is compiled into a direct lookup map in the runtime |
-| FFI controls | Scaffolded | Explicit `foreign_predicates([...])` emits `call-foreign` stubs; `no_kernels(true)` and `foreign_lowering(false)` suppress stubs. Runtime foreign handlers/kernels remain future work |
+| FFI controls | Scaffolded | Explicit `foreign_predicates([...])` emits `call-foreign` stubs; `no_kernels(true)` and `foreign_lowering(false)` suppress stubs. Deterministic Clojure handlers can be registered; native graph kernels remain future work |
 | Choice points | Partial | Saves persistent regs/env stack plus trail/heap/build boundaries; avoids binding snapshots and filtered register-map allocation, but still heavier than Haskell/Rust |
 | Environment frames | Done | `allocate`/`deallocate` use explicit environment frames for `Y` slots |
 | Cut semantics | Partial | Clause cut uses a cut barrier; `cut_ite` pops only the enclosing if-then-else CP |
@@ -267,12 +267,13 @@ for further optimization work.
 6. Clojure now has the same basic control vocabulary used by benchmark
    matrices in other WAM targets: explicit foreign predicates can be marked,
    and `no_kernels(true)` / `foreign_lowering(false)` force the pure WAM path.
-   Full Clojure kernel execution is still not implemented.
+   Deterministic handlers can be wired through `clojure_foreign_handlers/1`;
+   full Clojure graph kernels are still not implemented.
 
 ### Highest-value remaining work
 
-1. Implement Clojure foreign handler registration and native graph kernels
-   behind the existing `call-foreign` stub/control surface.
+1. Implement native Clojure graph kernels behind the existing `call-foreign`
+   handler surface.
 2. Add proper heap/trail semantics instead of relying primarily on the
    bindings table.
 3. Reduce choice-point snapshots toward the lighter Haskell/Rust model once

--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -80,6 +80,7 @@ compile_predicates_for_project([], _, CoreNamespace, RuntimeNamespace, Code) :-
 (def shared-wam-code-raw [])
 (def shared-wam-labels {})
 (def shared-wam-code (runtime/resolve-instructions shared-wam-code-raw shared-wam-labels))
+(def foreign-handlers {})
 
 (def predicate-dispatch {})
 
@@ -91,6 +92,7 @@ compile_predicates_for_project([], _, CoreNamespace, RuntimeNamespace, Code) :-
 ', [CoreNamespace, CoreNamespace, RuntimeNamespace]).
 compile_predicates_for_project(Predicates, Options, CoreNamespace, RuntimeNamespace, Code) :-
     collect_wam_entries(Predicates, Options, 0, WamEntries, RawEntries, LabelEntries, DispatchEntries),
+    clojure_foreign_handlers_code(Options, ForeignHandlersCode),
     atomic_list_concat(RawEntries, '\n  ', RawBody0),
     atomic_list_concat(LabelEntries, '\n  ', LabelBody0),
     atomic_list_concat(WamEntries, '\n\n', WrapperCode),
@@ -117,6 +119,10 @@ compile_predicates_for_project(Predicates, Options, CoreNamespace, RuntimeNamesp
 (def shared-wam-code
   (runtime/resolve-instructions shared-wam-code-raw shared-wam-labels))
 
+(def foreign-handlers {
+~w
+})
+
 ~w
 
 (def predicate-dispatch {
@@ -132,7 +138,7 @@ compile_predicates_for_project(Predicates, Options, CoreNamespace, RuntimeNamesp
   (let [[pred-key & pred-args] args]
     (println (invoke-predicate pred-key (mapv edn/read-string pred-args)))))
 
-', [CoreNamespace, CoreNamespace, RuntimeNamespace, RawBody, LabelBody, WrapperCode, DispatchBody]).
+', [CoreNamespace, CoreNamespace, RuntimeNamespace, RawBody, LabelBody, ForeignHandlersCode, WrapperCode, DispatchBody]).
 
 collect_wam_entries([], _, _, [], [], [], []).
 collect_wam_entries([PredIndicator|Rest], Options, PC,
@@ -175,6 +181,26 @@ clojure_foreign_stub_data(Pred, Arity, PC, Literals, LabelPairs, NextPC) :-
     LabelPairs = [PredKeyLit-PC],
     NextPC is PC + 2.
 
+clojure_foreign_handlers_code(Options, Code) :-
+    option(clojure_foreign_handlers(Handlers), Options, []),
+    maplist(clojure_foreign_handler_entry, Handlers, Entries),
+    atomic_list_concat(Entries, '\n  ', Body),
+    (Body == "" -> Code = "" ; format(atom(Code), '  ~w', [Body])).
+
+clojure_foreign_handler_entry(handler(Pred/Arity, HandlerCode), Entry) :- !,
+    clojure_foreign_handler_entry(Pred/Arity-HandlerCode, Entry).
+clojure_foreign_handler_entry(Pred/Arity-HandlerCode, Entry) :-
+    format(atom(PredKey), '~w/~w', [Pred, Arity]),
+    clj_string_literal(PredKey, PredKeyLit),
+    clojure_handler_code_text(HandlerCode, HandlerText),
+    format(atom(Entry), '~w ~s', [PredKeyLit, HandlerText]).
+
+clojure_handler_code_text(HandlerCode, HandlerCode) :-
+    string(HandlerCode), !.
+clojure_handler_code_text(HandlerCode, HandlerText) :-
+    atom(HandlerCode),
+    atom_string(HandlerCode, HandlerText).
+
 compile_wam_predicate_to_clojure(PredIndicator, WamCode, _Options, ClojureCode) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
     wam_code_to_clojure_data(WamCode, 0, RawEntries, LabelPairs, _),
@@ -195,6 +221,8 @@ compile_wam_predicate_to_clojure(PredIndicator, WamCode, _Options, ClojureCode) 
 (def shared-wam-code
   (runtime/resolve-instructions shared-wam-code-raw shared-wam-labels))
 
+(def foreign-handlers {})
+
 ~w
 ', [RawBody, LabelBody, WrapperCode]).
 
@@ -206,7 +234,7 @@ compile_wam_predicate_to_clojure_shared(Pred/Arity, StartPC, Code) :-
 '(def ~w-start-pc ~w)
 
 (defn ~w [~w]
-  (runtime/run-wam-predicate shared-wam-code shared-wam-labels ~w-start-pc ~w))
+  (runtime/run-wam-predicate shared-wam-code shared-wam-labels ~w-start-pc ~w foreign-handlers))
 ', [CljName, StartPC, CljName, ArgList, CljName, RegMap]).
 
 wam_code_to_clojure_data(WamCode, BasePC, Entries, LabelPairs, NextPC) :-

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -68,11 +68,15 @@
 (defn resolve-instructions [code labels]
   (mapv #(resolve-instruction labels %) code))
 
-(defn new-state [code labels start-pc regs]
+(defn new-state
+  ([code labels start-pc regs]
+   (new-state code labels start-pc regs {}))
+  ([code labels start-pc regs foreign-handlers]
   {:code code
    :labels labels
    :pc start-pc
    :regs regs
+   :foreign-handlers foreign-handlers
    :env-stack []
    :bindings {}
    :stack []
@@ -83,7 +87,7 @@
    :choice-points []
    :cut-bar 0
    :next-var-id 0
-   :status :running})
+   :status :running}))
 
 (defn fail-state [state]
   (assoc state :status :failed))
@@ -309,6 +313,24 @@
       :else
       (backtrack state))))
 
+(defn foreign-key [pred arity]
+  (str pred "/" arity))
+
+(defn foreign-args [state arity]
+  (mapv (fn [idx]
+          (deref-value (:bindings state)
+                       (reg-get-raw state (str "A" idx))))
+        (range 1 (inc arity))))
+
+(defn execute-foreign [state instr]
+  (let [key (foreign-key (:pred instr) (:arity instr))
+        handler (get (:foreign-handlers state) key)]
+    (if handler
+      (if (boolean (handler (foreign-args state (:arity instr))))
+        (advance state)
+        (backtrack state))
+      (backtrack state))))
+
 (defn step [state]
   (let [instr (fetch-instr state)]
     (if-not instr
@@ -510,10 +532,7 @@
           (backtrack state))
 
         :call-foreign
-        ;; Foreign handlers are introduced by target-specific kernels.
-        ;; Until a handler is registered, foreign calls fail cleanly rather
-        ;; than falling through to a missing WAM body.
-        (backtrack state)
+        (execute-foreign state instr)
 
         :cut-ite
         (-> state
@@ -535,5 +554,8 @@
       :failed false
       (recur (step s)))))
 
-(defn run-wam-predicate [code labels start-pc regs]
-  (run-wam (new-state code labels start-pc regs)))
+(defn run-wam-predicate
+  ([code labels start-pc regs]
+   (run-wam-predicate code labels start-pc regs {}))
+  ([code labels start-pc regs foreign-handlers]
+   (run-wam (new-state code labels start-pc regs foreign-handlers))))

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -62,6 +62,7 @@ test(project_uses_shared_wam_table_for_cross_predicate_calls) :-
         assertion(sub_string(CoreCode, _, _, _, '(defn wam-execute-caller [a1]')),
         assertion(sub_string(CoreCode, _, _, _, '(defn wam-call-caller [a1]')),
         assertion(sub_string(CoreCode, _, _, _, 'runtime/run-wam-predicate shared-wam-code shared-wam-labels wam-execute-caller-start-pc')),
+        assertion(sub_string(CoreCode, _, _, _, 'foreign-handlers')),
         assertion(sub_string(CoreCode, _, _, _, '(def predicate-dispatch {')),
         assertion(sub_string(CoreCode, _, _, _, '"wam_execute_caller/1" wam-execute-caller')),
         assertion(sub_string(CoreCode, _, _, _, '"wam_call_caller/1" wam-call-caller')),
@@ -109,6 +110,24 @@ test(foreign_predicates_emit_call_foreign_stub) :-
         assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "wam_fact" :arity 1}')),
         assertion(sub_string(CoreCode, _, _, _, '"wam_fact/1" 0')),
         assertion(\+ sub_string(CoreCode, _, _, _, '{:op :get-constant :constant "a" :reg "A1"}')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+test(clojure_foreign_handlers_emit_handler_map) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_foreign_handler', TmpDir),
+        write_wam_clojure_project([user:wam_fact/1],
+                                  [ namespace('generated.wam_foreign_handler_test'),
+                                    foreign_predicates([wam_fact/1]),
+                                    clojure_foreign_handlers([
+                                        handler(wam_fact/1, "(fn [args] (= (first args) \"a\"))")
+                                    ])
+                                  ], TmpDir),
+        directory_file_path(TmpDir, 'src/generated/wam_foreign_handler_test/core.clj', CorePath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(sub_string(CoreCode, _, _, _, '(def foreign-handlers {')),
+        assertion(sub_string(CoreCode, _, _, _, '"wam_fact/1" (fn [args] (= (first args) "a"))')),
+        assertion(sub_string(CoreCode, _, _, _, 'foreign-handlers)')),
         delete_directory_and_contents(TmpDir)
     )).
 

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -100,7 +100,11 @@ run_smoke :-
           user:wam_hard_cut_outer_ok/1
         ],
         [ namespace('generated.wam_exec_test'),
-          module_name('wam-clojure-exec-test')
+          module_name('wam-clojure-exec-test'),
+          foreign_predicates([wam_fact/1]),
+          clojure_foreign_handlers([
+              handler(wam_fact/1, "(fn [args] (= (first args) \"a\"))")
+          ])
         ],
         TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),


### PR DESCRIPTION
## Description

This PR completes the first executable layer of the Clojure hybrid WAM foreign path. The previous Clojure foreign-controls work could emit `:call-foreign` stubs and suppress them with `no_kernels(true)` / `foreign_lowering(false)`, but unregistered foreign calls failed by design. This change adds deterministic handler registration and passes handler maps through generated Clojure WAM projects.

It does not add graph kernels yet. It establishes the runtime and codegen surface those kernels can plug into.

## Changes

- Add generated `foreign-handlers` maps to Clojure WAM projects.
- Add `clojure_foreign_handlers([handler(pred/arity, Code)])` project option.
- Extend generated predicate wrappers to pass `foreign-handlers` into `runtime/run-wam-predicate`.
- Extend `new-state` and `run-wam-predicate` with handler-map overloads while preserving the existing no-handler API.
- Add runtime execution for deterministic `:call-foreign` handlers.
- Add generator coverage for emitted handler maps.
- Update the standalone Clojure WAM smoke runner so `wam_fact/1` is served through a deterministic Clojure handler.
- Update `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` to reflect that deterministic Clojure foreign handlers are scaffolded and graph kernels remain future work.

## Why

The mature WAM targets get their largest performance wins from routing hot predicates through foreign/kernel paths. Clojure now has the same staged path:

- `foreign_predicates([...])` marks predicates as foreign-owned.
- `no_kernels(true)` and `foreign_lowering(false)` preserve the pure WAM comparison path.
- `clojure_foreign_handlers(...)` lets generated projects execute deterministic foreign predicates.

This gives the next PR a concrete place to add native graph kernels without changing the option contract again.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

