### PR TITLE
Prototype cached result row containers for C# query runtime caches

### DIFF
--- a/docs/proposals/ROW_CONTAINER_ABSTRACTION_SURVEY.md
+++ b/docs/proposals/ROW_CONTAINER_ABSTRACTION_SURVEY.md
@@ -99,6 +99,8 @@ The first prototype seam is `CachedResultRows`.
 It is intentionally narrow:
 
 - `TransitiveClosureResults` stores `CachedResultRows`
+- seeded transitive-closure source/target caches, including grouped variants,
+  store `CachedResultRows`
 - counted-path replay can construct `CachedResultRows` from compact
   path-aware target/depth buffers
 - existing consumers still call `AsObjectRows()` and receive

--- a/docs/proposals/ROW_CONTAINER_ABSTRACTION_SURVEY.md
+++ b/docs/proposals/ROW_CONTAINER_ABSTRACTION_SURVEY.md
@@ -92,6 +92,22 @@ that can:
 3. make conversion points explicit and measurable
 4. preserve exact row order and row equality behavior
 
+## Prototype Status
+
+The first prototype seam is `CachedResultRows`.
+
+It is intentionally narrow:
+
+- `TransitiveClosureResults` stores `CachedResultRows`
+- existing consumers still call `AsObjectRows()` and receive
+  `IReadOnlyList<object[]>`
+- public execution APIs and row order are unchanged
+- no typed row representation is introduced yet
+
+This proves the cached-result-container boundary can be inserted without a
+full row-wrapper/index rewrite. The next step is to migrate one measured hot
+cache to a specialized internal representation behind the same container.
+
 ## Non-Goals
 
 The first abstraction should not change:

--- a/docs/proposals/ROW_CONTAINER_ABSTRACTION_SURVEY.md
+++ b/docs/proposals/ROW_CONTAINER_ABSTRACTION_SURVEY.md
@@ -99,14 +99,18 @@ The first prototype seam is `CachedResultRows`.
 It is intentionally narrow:
 
 - `TransitiveClosureResults` stores `CachedResultRows`
+- counted-path replay can construct `CachedResultRows` from compact
+  path-aware target/depth buffers
 - existing consumers still call `AsObjectRows()` and receive
   `IReadOnlyList<object[]>`
 - public execution APIs and row order are unchanged
-- no typed row representation is introduced yet
 
 This proves the cached-result-container boundary can be inserted without a
-full row-wrapper/index rewrite. The next step is to migrate one measured hot
-cache to a specialized internal representation behind the same container.
+full row-wrapper/index rewrite. The compact counted-path replay prototype
+keeps final `object[]` row materialization at the boundary, but avoids the
+previous intermediate target-value and boxed-depth arrays. The next step is to
+decide whether to keep extending this seam toward cache storage or stop at the
+direct materialization win.
 
 ## Non-Goals
 

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -17417,7 +17417,7 @@ namespace UnifyWeaver.QueryRuntime
                     TryGetLruRowWrapperCacheValue(cachedBySeed, new RowWrapper(flatSeedKey), out var cachedRows))
                 {
                     trace?.RecordCacheLookup("GroupedTransitiveClosureSeeded", traceKey, hit: true, built: false);
-                    return cachedRows;
+                    return cachedRows.AsObjectRows();
                 }
 
                 trace?.RecordCacheLookup("GroupedTransitiveClosureSeeded", traceKey, hit: false, built: true);
@@ -17451,7 +17451,7 @@ namespace UnifyWeaver.QueryRuntime
                     {
                         if (!context.GroupedTransitiveClosureSeededResults.TryGetValue(cacheKey, out var memoizedStoreBySeed))
                         {
-                            memoizedStoreBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                            memoizedStoreBySeed = new Dictionary<RowWrapper, CachedResultRows>(StructuralRowWrapperComparer);
                             context.GroupedTransitiveClosureSeededResults.Add(cacheKey, memoizedStoreBySeed);
                         }
 
@@ -17462,7 +17462,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             memoizedStoreBySeed,
                             new RowWrapper(flatSeedKey),
-                            memoizedRows,
+                            CachedResultRows.FromObjectRows(memoizedRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -17555,7 +17555,7 @@ namespace UnifyWeaver.QueryRuntime
                     {
                         if (!context.GroupedTransitiveClosureSeededResults.TryGetValue(cacheKey, out var singleStoreBySeed))
                         {
-                            singleStoreBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                            singleStoreBySeed = new Dictionary<RowWrapper, CachedResultRows>(StructuralRowWrapperComparer);
                             context.GroupedTransitiveClosureSeededResults.Add(cacheKey, singleStoreBySeed);
                         }
 
@@ -17566,7 +17566,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             singleStoreBySeed,
                             new RowWrapper(flatSeedKey),
-                            singleRows,
+                            CachedResultRows.FromObjectRows(singleRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -17627,7 +17627,7 @@ namespace UnifyWeaver.QueryRuntime
                 {
                     if (!context.GroupedTransitiveClosureSeededResults.TryGetValue(cacheKey, out var storeBySeed))
                     {
-                        storeBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                        storeBySeed = new Dictionary<RowWrapper, CachedResultRows>(StructuralRowWrapperComparer);
                         context.GroupedTransitiveClosureSeededResults.Add(cacheKey, storeBySeed);
                     }
 
@@ -17638,7 +17638,7 @@ namespace UnifyWeaver.QueryRuntime
                     TryAdmitLruBoundedRowWrapperCacheEntry(
                         storeBySeed,
                         new RowWrapper(flatSeedKey),
-                        totalRows,
+                        CachedResultRows.FromObjectRows(totalRows),
                         _seededCacheMaxEntries,
                         admitSeededCache,
                         trace,
@@ -17835,7 +17835,7 @@ namespace UnifyWeaver.QueryRuntime
                     TryGetLruRowWrapperCacheValue(cachedBySeed, new RowWrapper(flatSeedKey), out var cachedRows))
                 {
                     trace?.RecordCacheLookup("GroupedTransitiveClosureSeededByTarget", traceKey, hit: true, built: false);
-                    return cachedRows;
+                    return cachedRows.AsObjectRows();
                 }
 
                 trace?.RecordCacheLookup("GroupedTransitiveClosureSeededByTarget", traceKey, hit: false, built: true);
@@ -17869,7 +17869,7 @@ namespace UnifyWeaver.QueryRuntime
                     {
                         if (!context.GroupedTransitiveClosureSeededByTargetResults.TryGetValue(cacheKey, out var memoizedStoreBySeed))
                         {
-                            memoizedStoreBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                            memoizedStoreBySeed = new Dictionary<RowWrapper, CachedResultRows>(StructuralRowWrapperComparer);
                             context.GroupedTransitiveClosureSeededByTargetResults.Add(cacheKey, memoizedStoreBySeed);
                         }
 
@@ -17880,7 +17880,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             memoizedStoreBySeed,
                             new RowWrapper(flatSeedKey),
-                            memoizedRows,
+                            CachedResultRows.FromObjectRows(memoizedRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -17976,7 +17976,7 @@ namespace UnifyWeaver.QueryRuntime
                     {
                         if (!context.GroupedTransitiveClosureSeededByTargetResults.TryGetValue(cacheKey, out var singleStoreBySeed))
                         {
-                            singleStoreBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                            singleStoreBySeed = new Dictionary<RowWrapper, CachedResultRows>(StructuralRowWrapperComparer);
                             context.GroupedTransitiveClosureSeededByTargetResults.Add(cacheKey, singleStoreBySeed);
                         }
 
@@ -17987,7 +17987,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             singleStoreBySeed,
                             new RowWrapper(flatSeedKey),
-                            singleRows,
+                            CachedResultRows.FromObjectRows(singleRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -18048,7 +18048,7 @@ namespace UnifyWeaver.QueryRuntime
                 {
                     if (!context.GroupedTransitiveClosureSeededByTargetResults.TryGetValue(cacheKey, out var storeBySeed))
                     {
-                        storeBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                        storeBySeed = new Dictionary<RowWrapper, CachedResultRows>(StructuralRowWrapperComparer);
                         context.GroupedTransitiveClosureSeededByTargetResults.Add(cacheKey, storeBySeed);
                     }
 
@@ -18059,7 +18059,7 @@ namespace UnifyWeaver.QueryRuntime
                     TryAdmitLruBoundedRowWrapperCacheEntry(
                         storeBySeed,
                         new RowWrapper(flatSeedKey),
-                        totalRows,
+                        CachedResultRows.FromObjectRows(totalRows),
                         _seededCacheMaxEntries,
                         admitSeededCache,
                         trace,
@@ -19298,7 +19298,7 @@ namespace UnifyWeaver.QueryRuntime
                     TryGetLruRowWrapperCacheValue(cachedBySeed, new RowWrapper(seedsKey), out var cachedRows))
                 {
                     trace?.RecordCacheLookup("TransitiveClosureSeeded", traceKey, hit: true, built: false);
-                    return cachedRows;
+                    return cachedRows.AsObjectRows();
                 }
 
                 trace?.RecordCacheLookup("TransitiveClosureSeeded", traceKey, hit: false, built: true);
@@ -19336,7 +19336,7 @@ namespace UnifyWeaver.QueryRuntime
                     {
                         if (!context.TransitiveClosureSeededResults.TryGetValue(cacheKey, out var dagStoreBySeed))
                         {
-                            dagStoreBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                            dagStoreBySeed = new Dictionary<RowWrapper, CachedResultRows>(StructuralRowWrapperComparer);
                             context.TransitiveClosureSeededResults.Add(cacheKey, dagStoreBySeed);
                         }
 
@@ -19347,7 +19347,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             dagStoreBySeed,
                             new RowWrapper(seedsKey),
-                            dagRows,
+                            CachedResultRows.FromObjectRows(dagRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -19382,7 +19382,7 @@ namespace UnifyWeaver.QueryRuntime
                     {
                         if (!context.TransitiveClosureSeededResults.TryGetValue(cacheKey, out var memoizedStoreBySeed))
                         {
-                            memoizedStoreBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                            memoizedStoreBySeed = new Dictionary<RowWrapper, CachedResultRows>(StructuralRowWrapperComparer);
                             context.TransitiveClosureSeededResults.Add(cacheKey, memoizedStoreBySeed);
                         }
 
@@ -19393,7 +19393,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             memoizedStoreBySeed,
                             new RowWrapper(seedsKey),
-                            memoizedRows,
+                            CachedResultRows.FromObjectRows(memoizedRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -19472,7 +19472,7 @@ namespace UnifyWeaver.QueryRuntime
                     {
                         if (!context.TransitiveClosureSeededResults.TryGetValue(cacheKey, out var singleStoreBySeed))
                         {
-                            singleStoreBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                            singleStoreBySeed = new Dictionary<RowWrapper, CachedResultRows>(StructuralRowWrapperComparer);
                             context.TransitiveClosureSeededResults.Add(cacheKey, singleStoreBySeed);
                         }
 
@@ -19483,7 +19483,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             singleStoreBySeed,
                             new RowWrapper(seedsKey),
-                            singleRows,
+                            CachedResultRows.FromObjectRows(singleRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -19564,7 +19564,7 @@ namespace UnifyWeaver.QueryRuntime
                 {
                     if (!context.TransitiveClosureSeededResults.TryGetValue(cacheKey, out var storeBySeed))
                     {
-                        storeBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                        storeBySeed = new Dictionary<RowWrapper, CachedResultRows>(StructuralRowWrapperComparer);
                         context.TransitiveClosureSeededResults.Add(cacheKey, storeBySeed);
                     }
 
@@ -19575,7 +19575,7 @@ namespace UnifyWeaver.QueryRuntime
                     TryAdmitLruBoundedRowWrapperCacheEntry(
                         storeBySeed,
                         new RowWrapper(seedsKey),
-                        totalRows,
+                        CachedResultRows.FromObjectRows(totalRows),
                         _seededCacheMaxEntries,
                         admitSeededCache,
                         trace,
@@ -19752,7 +19752,7 @@ namespace UnifyWeaver.QueryRuntime
                     TryGetLruRowWrapperCacheValue(cachedBySeed, new RowWrapper(seedsKey), out var cachedRows))
                 {
                     trace?.RecordCacheLookup("TransitiveClosureSeededByTarget", traceKey, hit: true, built: false);
-                    return cachedRows;
+                    return cachedRows.AsObjectRows();
                 }
 
                 trace?.RecordCacheLookup("TransitiveClosureSeededByTarget", traceKey, hit: false, built: true);
@@ -19781,7 +19781,7 @@ namespace UnifyWeaver.QueryRuntime
                     {
                         if (!context.TransitiveClosureSeededByTargetResults.TryGetValue(cacheKey, out var memoizedStoreBySeed))
                         {
-                            memoizedStoreBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                            memoizedStoreBySeed = new Dictionary<RowWrapper, CachedResultRows>(StructuralRowWrapperComparer);
                             context.TransitiveClosureSeededByTargetResults.Add(cacheKey, memoizedStoreBySeed);
                         }
 
@@ -19792,7 +19792,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             memoizedStoreBySeed,
                             new RowWrapper(seedsKey),
-                            memoizedRows,
+                            CachedResultRows.FromObjectRows(memoizedRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -19871,7 +19871,7 @@ namespace UnifyWeaver.QueryRuntime
                     {
                         if (!context.TransitiveClosureSeededByTargetResults.TryGetValue(cacheKey, out var singleStoreBySeed))
                         {
-                            singleStoreBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                            singleStoreBySeed = new Dictionary<RowWrapper, CachedResultRows>(StructuralRowWrapperComparer);
                             context.TransitiveClosureSeededByTargetResults.Add(cacheKey, singleStoreBySeed);
                         }
 
@@ -19882,7 +19882,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             singleStoreBySeed,
                             new RowWrapper(seedsKey),
-                            singleRows,
+                            CachedResultRows.FromObjectRows(singleRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -19963,7 +19963,7 @@ namespace UnifyWeaver.QueryRuntime
                 {
                     if (!context.TransitiveClosureSeededByTargetResults.TryGetValue(cacheKey, out var storeBySeed))
                     {
-                        storeBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                        storeBySeed = new Dictionary<RowWrapper, CachedResultRows>(StructuralRowWrapperComparer);
                         context.TransitiveClosureSeededByTargetResults.Add(cacheKey, storeBySeed);
                     }
 
@@ -19974,7 +19974,7 @@ namespace UnifyWeaver.QueryRuntime
                     TryAdmitLruBoundedRowWrapperCacheEntry(
                         storeBySeed,
                         new RowWrapper(seedsKey),
-                        totalRows,
+                        CachedResultRows.FromObjectRows(totalRows),
                         _seededCacheMaxEntries,
                         admitSeededCache,
                         trace,
@@ -21339,9 +21339,9 @@ namespace UnifyWeaver.QueryRuntime
                 TransitiveClosureResults = parent?.TransitiveClosureResults
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), CachedResultRows>();
                 TransitiveClosureSeededResults = parent?.TransitiveClosureSeededResults
-                    ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, IReadOnlyList<object[]>>>();
+                    ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, CachedResultRows>>();
                 TransitiveClosureSeededByTargetResults = parent?.TransitiveClosureSeededByTargetResults
-                    ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, IReadOnlyList<object[]>>>();
+                    ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, CachedResultRows>>();
                 TransitiveClosurePairProbeResults = parent?.TransitiveClosurePairProbeResults
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, bool>>();
                 GroupedTransitiveClosureResults = parent?.GroupedTransitiveClosureResults
@@ -21357,9 +21357,9 @@ namespace UnifyWeaver.QueryRuntime
                 SeedGroupedPathAwareAccumulationMinResults = parent?.SeedGroupedPathAwareAccumulationMinResults
                     ?? new Dictionary<SeedGroupedPathAwareAccumulationMinNode, IReadOnlyList<object[]>>();
                 GroupedTransitiveClosureSeededResults = parent?.GroupedTransitiveClosureSeededResults
-                    ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, IReadOnlyList<object[]>>>();
+                    ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, CachedResultRows>>();
                 GroupedTransitiveClosureSeededByTargetResults = parent?.GroupedTransitiveClosureSeededByTargetResults
-                    ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, IReadOnlyList<object[]>>>();
+                    ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, CachedResultRows>>();
                 GroupedTransitiveClosurePairProbeResults = parent?.GroupedTransitiveClosurePairProbeResults
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, bool>>();
             }
@@ -21415,9 +21415,9 @@ namespace UnifyWeaver.QueryRuntime
 
             public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), CachedResultRows> TransitiveClosureResults { get; }
 
-            public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, IReadOnlyList<object[]>>> TransitiveClosureSeededResults { get; }
+            public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, CachedResultRows>> TransitiveClosureSeededResults { get; }
 
-            public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, IReadOnlyList<object[]>>> TransitiveClosureSeededByTargetResults { get; }
+            public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, CachedResultRows>> TransitiveClosureSeededByTargetResults { get; }
 
             public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, bool>> TransitiveClosurePairProbeResults { get; }
 
@@ -21433,9 +21433,9 @@ namespace UnifyWeaver.QueryRuntime
 
             public Dictionary<SeedGroupedPathAwareAccumulationMinNode, IReadOnlyList<object[]>> SeedGroupedPathAwareAccumulationMinResults { get; }
 
-            public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, IReadOnlyList<object[]>>> GroupedTransitiveClosureSeededResults { get; }
+            public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, CachedResultRows>> GroupedTransitiveClosureSeededResults { get; }
 
-            public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, IReadOnlyList<object[]>>> GroupedTransitiveClosureSeededByTargetResults { get; }
+            public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, CachedResultRows>> GroupedTransitiveClosureSeededByTargetResults { get; }
 
             public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, bool>> GroupedTransitiveClosurePairProbeResults { get; }
         }

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1533,16 +1533,127 @@ namespace UnifyWeaver.QueryRuntime
 
     internal sealed class CachedResultRows
     {
-        private readonly IReadOnlyList<object[]> _objectRows;
+        private readonly IReadOnlyList<object[]>? _objectRows;
+        private readonly object? _seedValue;
+        private readonly object?[]? _nodeValues;
+        private readonly IReadOnlyList<int>? _targetNodeIds;
+        private readonly IReadOnlyList<int>? _depths;
+        private readonly Func<int, object>? _boxDepth;
+        private IReadOnlyList<object[]>? _materializedRows;
 
         private CachedResultRows(IReadOnlyList<object[]> objectRows)
         {
             _objectRows = objectRows ?? throw new ArgumentNullException(nameof(objectRows));
         }
 
+        private CachedResultRows(
+            object? seedValue,
+            object?[] nodeValues,
+            IReadOnlyList<int> targetNodeIds,
+            IReadOnlyList<int> depths,
+            Func<int, object> boxDepth)
+        {
+            if (targetNodeIds is null) throw new ArgumentNullException(nameof(targetNodeIds));
+            if (depths is null) throw new ArgumentNullException(nameof(depths));
+
+            if (targetNodeIds.Count != depths.Count)
+            {
+                throw new ArgumentException("Target and depth buffers must have the same row count.", nameof(depths));
+            }
+
+            _seedValue = seedValue;
+            _nodeValues = nodeValues ?? throw new ArgumentNullException(nameof(nodeValues));
+            _targetNodeIds = targetNodeIds;
+            _depths = depths;
+            _boxDepth = boxDepth ?? throw new ArgumentNullException(nameof(boxDepth));
+        }
+
         public static CachedResultRows FromObjectRows(IReadOnlyList<object[]> rows) => new(rows);
 
-        public IReadOnlyList<object[]> AsObjectRows() => _objectRows;
+        public static CachedResultRows FromPathAwareDepthRows(
+            object? seedValue,
+            object?[] nodeValues,
+            IReadOnlyList<int> targetNodeIds,
+            IReadOnlyList<int> depths,
+            Func<int, object> boxDepth) =>
+            new(seedValue, nodeValues, targetNodeIds, depths, boxDepth);
+
+        public int Count => _objectRows?.Count ?? _targetNodeIds?.Count ?? 0;
+
+        public IReadOnlyList<object[]> AsObjectRows()
+        {
+            if (_objectRows is not null)
+            {
+                return _objectRows;
+            }
+
+            if (_materializedRows is not null)
+            {
+                return _materializedRows;
+            }
+
+            var rows = new List<object[]>(Count);
+            AppendTo(rows);
+            _materializedRows = rows;
+            return rows;
+        }
+
+        public void AppendTo(
+            ICollection<object[]> output,
+            Action? recordOutputRow = null,
+            Action<TimeSpan>? addSetupElapsed = null,
+            Action<TimeSpan>? addRowAllocElapsed = null,
+            Action<TimeSpan>? addWriteElapsed = null)
+        {
+            if (output is null) throw new ArgumentNullException(nameof(output));
+
+            if (_objectRows is not null)
+            {
+                foreach (var row in _objectRows)
+                {
+                    output.Add(row);
+                    recordOutputRow?.Invoke();
+                }
+
+                return;
+            }
+
+            var nodeValues = _nodeValues!;
+            var targetNodeIds = _targetNodeIds!;
+            var depths = _depths!;
+            var boxDepth = _boxDepth!;
+            var seedValue = _seedValue!;
+
+            if (output is List<object[]> outputList)
+            {
+                var setupStarted = Stopwatch.GetTimestamp();
+                var baseIndex = outputList.Count;
+                CollectionsMarshal.SetCount(outputList, baseIndex + targetNodeIds.Count);
+                var span = CollectionsMarshal.AsSpan(outputList);
+                addSetupElapsed?.Invoke(Stopwatch.GetElapsedTime(setupStarted));
+
+                var writeStarted = Stopwatch.GetTimestamp();
+                var rowAllocStarted = Stopwatch.GetTimestamp();
+                for (var i = 0; i < targetNodeIds.Count; i++)
+                {
+                    span[baseIndex + i] = new object[] { seedValue, nodeValues[targetNodeIds[i]]!, boxDepth(depths[i]) };
+                    recordOutputRow?.Invoke();
+                }
+                addRowAllocElapsed?.Invoke(Stopwatch.GetElapsedTime(rowAllocStarted));
+                addWriteElapsed?.Invoke(Stopwatch.GetElapsedTime(writeStarted));
+                return;
+            }
+
+            var fallbackWriteStarted = Stopwatch.GetTimestamp();
+            var fallbackRowAllocStarted = Stopwatch.GetTimestamp();
+            for (var i = 0; i < targetNodeIds.Count; i++)
+            {
+                output.Add(new object[] { seedValue, nodeValues[targetNodeIds[i]]!, boxDepth(depths[i]) });
+                recordOutputRow?.Invoke();
+            }
+            addRowAllocElapsed?.Invoke(Stopwatch.GetElapsedTime(fallbackRowAllocStarted));
+            addWriteElapsed?.Invoke(Stopwatch.GetElapsedTime(fallbackWriteStarted));
+        }
     }
 
     internal sealed class PathAwareSuccessorBucket
@@ -12772,60 +12883,18 @@ namespace UnifyWeaver.QueryRuntime
         {
             metrics?.RecordResultReplayBatch(rows.Count);
             var started = Stopwatch.GetTimestamp();
-            var seedValue = seed!;
-            if (output is List<object[]> outputList)
-            {
-                var setupStarted = Stopwatch.GetTimestamp();
-                var baseIndex = outputList.Count;
-                CollectionsMarshal.SetCount(outputList, baseIndex + rows.Count);
-                var span = CollectionsMarshal.AsSpan(outputList);
-                var targetNodeIds = CollectionsMarshal.AsSpan(rows.TargetNodeIds);
-                var depths = CollectionsMarshal.AsSpan(rows.Depths);
-                metrics?.AddResultReplaySetupElapsed(Stopwatch.GetElapsedTime(setupStarted));
-                var writeStarted = Stopwatch.GetTimestamp();
-                var valueLookupStarted = Stopwatch.GetTimestamp();
-                var targetValues = new object?[rows.Count];
-                var boxedDepths = new object[rows.Count];
-                for (var i = 0; i < rows.Count; i++)
-                {
-                    targetValues[i] = nodeValues[targetNodeIds[i]]!;
-                    boxedDepths[i] = BoxCountedPathDepth(depths[i]);
-                }
-                metrics?.AddResultReplayValueLookupElapsed(Stopwatch.GetElapsedTime(valueLookupStarted));
-                var rowAllocStarted = Stopwatch.GetTimestamp();
-                for (var i = 0; i < rows.Count; i++)
-                {
-                    // The broader query runtime, caches, and test harnesses all
-                    // currently expect fresh object[] rows at this boundary.
-                    span[baseIndex + i] = new object[] { seedValue, targetValues[i], boxedDepths[i] };
-                    metrics?.RecordOutputRow();
-                }
-                metrics?.AddResultReplayRowAllocElapsed(Stopwatch.GetElapsedTime(rowAllocStarted));
-                metrics?.AddResultReplayWriteElapsed(Stopwatch.GetElapsedTime(writeStarted));
-                metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(started));
-                return;
-            }
-
-            var fallbackTargetNodeIds = rows.TargetNodeIds;
-            var fallbackDepths = rows.Depths;
-            var fallbackWriteStarted = Stopwatch.GetTimestamp();
-            var fallbackValueLookupStarted = Stopwatch.GetTimestamp();
-            var fallbackTargetValues = new object?[rows.Count];
-            var fallbackBoxedDepths = new object[rows.Count];
-            for (var i = 0; i < rows.Count; i++)
-            {
-                fallbackTargetValues[i] = nodeValues[fallbackTargetNodeIds[i]]!;
-                fallbackBoxedDepths[i] = BoxCountedPathDepth(fallbackDepths[i]);
-            }
-            metrics?.AddResultReplayValueLookupElapsed(Stopwatch.GetElapsedTime(fallbackValueLookupStarted));
-            var fallbackRowAllocStarted = Stopwatch.GetTimestamp();
-            for (var i = 0; i < rows.Count; i++)
-            {
-                output.Add(new object[] { seedValue, fallbackTargetValues[i], fallbackBoxedDepths[i] });
-                metrics?.RecordOutputRow();
-            }
-            metrics?.AddResultReplayRowAllocElapsed(Stopwatch.GetElapsedTime(fallbackRowAllocStarted));
-            metrics?.AddResultReplayWriteElapsed(Stopwatch.GetElapsedTime(fallbackWriteStarted));
+            Action? recordOutputRow = metrics is null ? null : metrics.RecordOutputRow;
+            Action<TimeSpan>? addSetupElapsed = metrics is null ? null : metrics.AddResultReplaySetupElapsed;
+            Action<TimeSpan>? addRowAllocElapsed = metrics is null ? null : metrics.AddResultReplayRowAllocElapsed;
+            Action<TimeSpan>? addWriteElapsed = metrics is null ? null : metrics.AddResultReplayWriteElapsed;
+            CachedResultRows
+                .FromPathAwareDepthRows(seed, nodeValues, rows.TargetNodeIds, rows.Depths, BoxCountedPathDepth)
+                .AppendTo(
+                    output,
+                    recordOutputRow,
+                    addSetupElapsed,
+                    addRowAllocElapsed,
+                    addWriteElapsed);
 
             metrics?.AddResultMaterializationElapsed(Stopwatch.GetElapsedTime(started));
         }

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1531,6 +1531,20 @@ namespace UnifyWeaver.QueryRuntime
         }
     }
 
+    internal sealed class CachedResultRows
+    {
+        private readonly IReadOnlyList<object[]> _objectRows;
+
+        private CachedResultRows(IReadOnlyList<object[]> objectRows)
+        {
+            _objectRows = objectRows ?? throw new ArgumentNullException(nameof(objectRows));
+        }
+
+        public static CachedResultRows FromObjectRows(IReadOnlyList<object[]> rows) => new(rows);
+
+        public IReadOnlyList<object[]> AsObjectRows() => _objectRows;
+    }
+
     internal sealed class PathAwareSuccessorBucket
     {
         public PathAwareSuccessorBucket(object? source, int sourceNodeId)
@@ -8803,7 +8817,7 @@ namespace UnifyWeaver.QueryRuntime
                 if (context.TransitiveClosureResults.TryGetValue(cacheKey, out var cachedRows))
                 {
                     trace?.RecordCacheLookup("TransitiveClosure", traceKey, hit: true, built: false);
-                    return cachedRows;
+                    return cachedRows.AsObjectRows();
                 }
 
                 trace?.RecordCacheLookup("TransitiveClosure", traceKey, hit: false, built: true);
@@ -8869,7 +8883,7 @@ namespace UnifyWeaver.QueryRuntime
                     trace?.RecordFixpointIteration(closure, predicate, iteration, delta.Count, totalRows.Count);
                 }
 
-                context.TransitiveClosureResults[cacheKey] = totalRows;
+                context.TransitiveClosureResults[cacheKey] = CachedResultRows.FromObjectRows(totalRows);
                 return totalRows;
             }
             finally
@@ -21254,7 +21268,7 @@ namespace UnifyWeaver.QueryRuntime
                 FactIndices = parent?.FactIndices ?? new Dictionary<(PredicateId Predicate, int ColumnIndex), Dictionary<object, List<object[]>>>();
                 JoinIndices = parent?.JoinIndices ?? new Dictionary<(PredicateId Predicate, string KeySignature), Dictionary<RowWrapper, List<object[]>>>();
                 TransitiveClosureResults = parent?.TransitiveClosureResults
-                    ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), IReadOnlyList<object[]>>();
+                    ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), CachedResultRows>();
                 TransitiveClosureSeededResults = parent?.TransitiveClosureSeededResults
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, IReadOnlyList<object[]>>>();
                 TransitiveClosureSeededByTargetResults = parent?.TransitiveClosureSeededByTargetResults
@@ -21330,7 +21344,7 @@ namespace UnifyWeaver.QueryRuntime
 
             public Dictionary<(PredicateId Predicate, string KeySignature), Dictionary<RowWrapper, List<object[]>>> JoinIndices { get; }
 
-            public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), IReadOnlyList<object[]>> TransitiveClosureResults { get; }
+            public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), CachedResultRows> TransitiveClosureResults { get; }
 
             public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, IReadOnlyList<object[]>>> TransitiveClosureSeededResults { get; }
 


### PR DESCRIPTION
  ## Summary

  This PR introduces `CachedResultRows` as an internal cached-row container seam in the C# query runtime.

  It keeps the public runtime surface unchanged while moving selected cache/materialization paths behind a container abstraction:

  - Adds `CachedResultRows` with an `AsObjectRows()` compatibility view for existing `IReadOnlyList<object[]>` consumers.
  - Migrates unseeded transitive-closure cache storage to `CachedResultRows`.
  - Routes counted path-aware depth replay through `CachedResultRows`, preserving final `object[]` row output while avoiding the previous intermediate target-value and boxed-depth arrays.
  - Migrates seeded transitive-closure source/target caches, including grouped variants, to store `CachedResultRows`.
  - Updates the row-container abstraction survey with the prototype status and next-step guidance.

  ## Rationale

  The existing runtime stores cached query results directly as `IReadOnlyList<object[]>`, which makes it hard to experiment with more compact or specialized internal result layouts.

  This PR creates a narrow compatibility boundary:

  - Existing execution APIs still return `IEnumerable<object[]>`.
  - Existing cache-hit behavior still exposes `IReadOnlyList<object[]>` where needed.
  - Row order and equality behavior are preserved.
  - Future cache-specific layouts can be introduced behind `CachedResultRows` without forcing a broad runtime rewrite.

  ## Validation

  - `dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c Release`
  - `swipl -q -t run_tests tests/core/test_csharp_query_target.pl`
  - `python3 -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py`
  - `git diff --check`
  - `python3 examples/benchmark/benchmark_shortest_path_to_root.py --scales 300,1k --repetitions 3`
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_cache_smoke_sequence.ps1 -OutputDir tmp/csharp_query_smoke_local -SummaryPath tmp/csharp_query_smoke_local/cache_smoke_sequence_summary.md`

  The full C# query cache smoke sequence passed across admission, reuse, and LRU slices.