### PR TITLE
perf(wam): fix O(N²) string accumulator in multi-clause WAM codegen

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -137,8 +137,15 @@ extract_segment_body([Line|Rest], PC, Body, Next, NPC) :-
         extract_segment_body(Rest, PC1, RestBody, Next, NPC)
     ).
 
-generate_all_segments([], _, []).
-generate_all_segments([Name-Instrs | Rest], Labels, SegCodes) :-
+generate_all_segments(Segments, Labels, SegCodes) :-
+    % Build a list of per-segment code-lists and flatten with append/2
+    % at the end. The previous recursive append(ThisSegCodes,
+    % RestCodes, _) was O(N²) over segment count — noticeable on
+    % predicates with thousands of fact clauses.
+    maplist(generate_one_segment(Labels), Segments, SegCodesNested),
+    append(SegCodesNested, SegCodes).
+
+generate_one_segment(Labels, Name-Instrs, ThisSegCodes) :-
     segment_func_name(Name, FuncName),
     classify_segment_head(Instrs, HeadType, BodyInstrs),
     % CPS split: every non-tail `call P, N` terminates a sub-segment;
@@ -147,9 +154,7 @@ generate_all_segments([Name-Instrs | Rest], Labels, SegCodes) :-
     % post-call code (which Elixir would otherwise have on a collapsed
     % tail-call stack).
     split_body_at_calls(BodyInstrs, SubSegs),
-    emit_sub_segments(SubSegs, FuncName, HeadType, Labels, ThisSegCodes),
-    generate_all_segments(Rest, Labels, RestCodes),
-    append(ThisSegCodes, RestCodes, SegCodes).
+    emit_sub_segments(SubSegs, FuncName, HeadType, Labels, ThisSegCodes).
 
 %% split_body_at_calls(+Instrs, -SubSegs)
 %  Splits a flat instr list into sub-segment lists, cutting after every

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -345,10 +345,17 @@ expand_aggregate_goals_for_perm_vars([G|Rest], Expanded) :-
 %% compile_multi_clause_wam(+Pred, +Arity, +Clauses, +Options, -Code)
 compile_multi_clause_wam(Pred, Arity, Clauses, Options, Code) :-
     length(Clauses, N),
-    compile_clauses_with_choice_points(Clauses, 1, N, Pred, Arity, Options, Code).
+    % Build a list of per-clause fragment strings, then atomic_list_concat
+    % once at the end. The previous nested format/3 recursion rebuilt the
+    % growing accumulator at each step — O(N²) for fact-only predicates
+    % with thousands of clauses (6009-clause category_parent/2 took ~85s
+    % before; ~3s after).
+    compile_clauses_fragments(Clauses, 1, N, Pred, Arity, Options, Fragments),
+    atomic_list_concat(Fragments, '\n', Code).
 
-compile_clauses_with_choice_points([], _, _, _, _, _, "").
-compile_clauses_with_choice_points([Head-Body|Rest], I, N, Pred, Arity, Options, Code) :-
+compile_clauses_fragments([], _, _, _, _, _, []).
+compile_clauses_fragments([Head-Body|Rest], I, N, Pred, Arity, Options,
+                         [Choice, HeadCode, BodyCode | RestFragments]) :-
     (   I == 1
     ->  format(string(Choice), "    try_me_else L_~w_~w_~w", [Pred, Arity, 2])
     ;   I == N
@@ -373,11 +380,7 @@ compile_clauses_with_choice_points([Head-Body|Rest], I, N, Pred, Arity, Options,
         )
     ),
     NextI is I + 1,
-    compile_clauses_with_choice_points(Rest, NextI, N, Pred, Arity, Options, RestCode),
-    (   RestCode == ""
-    ->  format(string(Code), "~w~n~w~n~w", [Choice, HeadCode, BodyCode])
-    ;   format(string(Code), "~w~n~w~n~w~n~w", [Choice, HeadCode, BodyCode, RestCode])
-    ).
+    compile_clauses_fragments(Rest, NextI, N, Pred, Arity, Options, RestFragments).
 
 %% compile_head_arguments(+Args, +ArgIndex, +VIn, -VOut, -Code)
 compile_head_arguments([], _, V, V, "").


### PR DESCRIPTION
## Summary

Fixes a classic O(N²) string-accumulator pattern in the WAM multi-clause
compiler and its mirror in the lowered Elixir emitter. The effective-distance
benchmark's codegen step at scale 300 drops from **85s to 1.9s** (44×
faster).

## Background

Profiling the effective-distance pipeline found the bottleneck was not
the lowered Elixir emitter but the upstream `wam_target` compiler:

```
dimension_n/1        compile=0ms     lower=5ms
max_depth/1          compile=0ms     lower=0ms
category_ancestor/4  compile=2ms     lower=1ms
category_parent/2    compile=84588ms lower=1284ms    ← 6009 facts
article_category/2   compile=1388ms  lower=126ms     ← 771 facts
root_category/1      compile=0ms     lower=1ms
```

Time scaled with the square of clause count (6009² / 771² ≈ 60×,
matching 84s / 1.4s), pointing at an accumulator copy.

## What changed

### `compile_clauses_with_choice_points/7` → `compile_clauses_fragments/7`

Was:

```prolog
compile_clauses_with_choice_points([Head-Body|Rest], I, N, Pred, Arity, Options, Code) :-
    ...
    compile_clauses_with_choice_points(Rest, NextI, N, ..., RestCode),
    format(string(Code), "~w~n~w~n~w~n~w", [Choice, HeadCode, BodyCode, RestCode]).
```

Each recursion level rebuilt a fresh `Code` string containing all of
`RestCode`. For N clauses the growing buffer is copied N times.

Now:

```prolog
compile_clauses_fragments([Head-Body|Rest], ..., [Choice, HeadCode, BodyCode | RestFragments]) :-
    ...
    compile_clauses_fragments(Rest, NextI, N, ..., RestFragments).
```

Fragments are collected into a flat list and joined by a single
`atomic_list_concat(Fragments, '\n', Code)` at the caller.

### `wam_elixir_lowered_emitter:generate_all_segments/3`

Same smell in the lowered emitter — `append(ThisSegCodes, RestCodes,
SegCodes)` accumulated per-segment lists recursively (each append is
O(|ThisSegCodes|)). Replaced with `maplist/3 + append/2` for a single
final flatten.

## Measurements

On `data/benchmark/300/facts.pl`:

| Predicate              | Before (compile) | After (compile) | Before (lower) | After (lower) |
| ---------------------- | ---------------- | --------------- | -------------- | ------------- |
| `category_parent/2`    | 84588 ms         | 323 ms          | 1284 ms        | 938 ms        |
| `article_category/2`   | 1388 ms          | 41 ms           | 126 ms         | 85 ms         |
| `category_ancestor/4`  | 2 ms             | 1 ms            | 1 ms           | 1 ms          |

End-to-end `swipl generate_wam_elixir_effective_distance_benchmark.pl --
data/benchmark/300/facts.pl <out>`:

- Before: ~85s
- After: ~1.9s

## Test plan

- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_target.pl` — 7/7
- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_target.pl` — 14/14
- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_utils.pl` — 7/7
- [x] `swipl -q -s examples/debug_wam_elixir_ancestor.pl -t halt` — 4/1/4 solutions
- [ ] End-to-end effective-distance benchmark still hits a *runtime*
      timeout at scale 300 — but that's now a separate Elixir-side
      investigation (likely CPS/backtrack overhead on 6000-clause fact
      lookups), not codegen.

## Non-goals

This PR is purely a perf fix; generated output is byte-identical to
the previous version (verified by running the reproducer and unit
tests). Runtime correctness and behaviour are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
