### PR TITLE
feat(wam-clojure): add optimized benchmark generator

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -243,7 +243,8 @@ for further optimization work.
 | Cut semantics | Partial | Clause cut uses a cut barrier; `cut_ite` pops only the enclosing if-then-else CP |
 | Read-mode compound terms | Done | `get_structure`, `get_list`, `unify_*` support structure/list matching |
 | Write-mode compound terms | Done | `put_structure`, `put_list`, `set_*` build nested terms via a builder stack |
-| End-to-end verification | Partial | Generator test plus standalone smoke runner; plunit JVM subprocess tests remain disabled in Termux |
+| Benchmark generation | Scaffolded | `generate_wam_clojure_optimized_benchmark.pl` emits optimized effective-distance Clojure WAM projects with `kernels_on`/`kernels_off` controls |
+| End-to-end verification | Partial | Generator tests plus standalone smoke runner; plunit JVM subprocess tests remain disabled in Termux |
 
 ### Clojure-specific lessons from this phase
 
@@ -269,16 +270,21 @@ for further optimization work.
    and `no_kernels(true)` / `foreign_lowering(false)` force the pure WAM path.
    Deterministic handlers can be wired through `clojure_foreign_handlers/1`;
    full Clojure graph kernels are still not implemented.
+7. Clojure now has an optimized effective-distance project generator. It
+   establishes benchmark-matrix shape and kernel-mode controls without trying
+   to run large JVM benchmarks in Termux.
 
 ### Highest-value remaining work
 
 1. Implement native Clojure graph kernels behind the existing `call-foreign`
    handler surface.
-2. Add proper heap/trail semantics instead of relying primarily on the
+2. Wire the Clojure generator into configurable benchmark target lists once
+   a real fact-backed handler or graph kernel exists.
+3. Add proper heap/trail semantics instead of relying primarily on the
    bindings table.
-3. Reduce choice-point snapshots toward the lighter Haskell/Rust model once
+4. Reduce choice-point snapshots toward the lighter Haskell/Rust model once
    the remaining runtime state is better separated.
-4. Split hot runtime state from cold code/context data, following the same
+5. Split hot runtime state from cold code/context data, following the same
    optimization pattern that paid off heavily in Haskell.
 
 ---

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -115,6 +115,27 @@ python examples/benchmark/benchmark_effective_distance.py \
 On Termux, the harness chooses a writable temporary parent from `TMPDIR`,
 `TMP`, `TEMP`, `$PREFIX/tmp`, or `output` instead of assuming `/tmp`.
 
+### WAM-Clojure Benchmark Scaffold
+
+The Clojure hybrid-WAM target now has an optimized-project generator:
+
+```bash
+swipl -q -s examples/benchmark/generate_wam_clojure_optimized_benchmark.pl -- \
+  data/benchmark/dev/facts.pl /tmp/wam-clojure-bench seeded kernels_on
+```
+
+Supported modes:
+
+- `seeded` and `accumulated` select the same optimized Prolog predicate
+  generation path used by the mature WAM benchmark generators.
+- `kernels_on` emits a `category_parent/2` `call-foreign` stub and a
+  deterministic placeholder Clojure handler.
+- `kernels_off` forces the pure-WAM scaffold with `no_kernels(true)`.
+
+This is intentionally a generated-project scaffold, not a large JVM benchmark
+runner. Native Clojure graph kernels and fact-backed handler loading are still
+future work.
+
 ### Why Seeded Closures Win
 
 The main advantage comes from **seed deduplication**: many articles

--- a/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
@@ -1,0 +1,195 @@
+:- module(generate_wam_clojure_optimized_benchmark,
+          [ main/0,
+            generate/3,
+            generate/4,
+            parse_kernel_mode/2,
+            collect_wam_predicates/2,
+            collect_wam_predicates/3
+          ]).
+:- initialization(main, main).
+
+:- use_module('../../src/unifyweaver/targets/wam_clojure_target').
+:- use_module('../../src/unifyweaver/targets/prolog_target').
+:- use_module(library(filesex), [directory_file_path/3]).
+
+%% generate_wam_clojure_optimized_benchmark.pl
+%%
+%% Generates a Clojure WAM project from the optimized effective-distance
+%% Prolog workload. This is the Clojure counterpart to the optimized Go,
+%% Python, Haskell, and Rust WAM benchmark generators.
+%%
+%% The generated project is intentionally a benchmark scaffold, not a large
+%% Termux benchmark runner. JVM startup and memory use make large local runs
+%% noisy; this generator gives the benchmark matrix a reproducible Clojure
+%% project shape and explicit kernel controls.
+%%
+%% Usage:
+%%   swipl -q -s generate_wam_clojure_optimized_benchmark.pl -- \
+%%       <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off]
+
+benchmark_workload_path(Path) :-
+    source_file(benchmark_workload_path(_), ThisFile),
+    file_directory_name(ThisFile, Here),
+    directory_file_path(Here, 'effective_distance.pl', Path).
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv == []
+    ->  true
+    ;   Argv = [FactsPath, OutputDir, VariantAtom, KernelModeAtom]
+    ->  true
+    ;   Argv = [FactsPath, OutputDir, VariantAtom]
+    ->  KernelModeAtom = kernels_on
+    ;   Argv = [FactsPath, OutputDir]
+    ->  VariantAtom = accumulated,
+        KernelModeAtom = kernels_on
+    ;   format(user_error,
+            'Usage: ... -- <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off]~n',
+            []),
+        halt(1)
+    ),
+    (   Argv == []
+    ->  true
+    ;   generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom),
+        halt(0)
+    ).
+
+main :-
+    format(user_error, 'Error: Clojure WAM benchmark generation failed~n', []),
+    halt(1).
+
+generate(FactsPath, OutputDir, VariantAtom) :-
+    generate(FactsPath, OutputDir, VariantAtom, kernels_on).
+
+generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom) :-
+    must_exist_file(FactsPath),
+    benchmark_workload_path(WorkloadPath),
+    load_files(user:WorkloadPath, [silent(true)]),
+    retractall(user:mode(category_ancestor(_, _, _, _))),
+    assertz(user:mode(category_ancestor(-, +, -, +))),
+
+    parse_variant(VariantAtom, OptimizationOptions),
+    BasePreds = [dimension_n/1, max_depth/1, category_ancestor/4],
+    prolog_target:generate_prolog_script(BasePreds, OptimizationOptions, ScriptCode),
+
+    maybe_load_optimized_predicates(VariantAtom, ScriptCode),
+
+    maybe_assert_seeded_helper(VariantAtom),
+    parse_kernel_mode(KernelModeAtom, KernelOptions),
+    collect_wam_predicates(VariantAtom, KernelModeAtom, Predicates),
+    append([ [ module_name('wam-clojure-optimized-bench'),
+               namespace('generated.wam_clojure_optimized_bench')
+             ],
+             KernelOptions
+           ],
+           Options),
+    write_wam_clojure_project(Predicates, Options, OutputDir),
+    format(user_error,
+           '[WAM-Clojure-Optimized] facts=~w variant=~w kernels=~w output=~w~n',
+           [FactsPath, VariantAtom, KernelModeAtom, OutputDir]).
+
+parse_variant(seeded, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false)
+]).
+parse_variant(accumulated, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false),
+    seeded_accumulation(auto)
+]).
+
+parse_kernel_mode(kernels_on, [
+    foreign_predicates([category_parent/2]),
+    clojure_foreign_handlers([
+        handler(category_parent/2, "(fn [_args] false)")
+    ])
+]).
+parse_kernel_mode(kernels_off, [
+    no_kernels(true)
+]).
+
+maybe_assert_seeded_helper(seeded) :- !,
+    retractall(user:power_sum_bound(_, _, _, _)),
+    assertz((user:power_sum_bound(Cat, Root, NegN, WeightSum) :-
+        aggregate_all(sum(W),
+            (user:category_ancestor(Cat, Root, Hops, [Cat]),
+             H is Hops + 1,
+             W is H ** NegN),
+            WeightSum))).
+maybe_assert_seeded_helper(_).
+
+maybe_load_optimized_predicates(seeded, _) :- !.
+maybe_load_optimized_predicates(accumulated, ScriptCode) :-
+    strip_generated_initialization(ScriptCode, LoadableScript),
+    tmp_file_stream(text, TmpPath, TmpStream),
+    write(TmpStream, LoadableScript),
+    close(TmpStream),
+    load_files(user:TmpPath, [silent(true)]),
+    delete_file(TmpPath),
+    cleanup_generated_script_entrypoint.
+
+strip_generated_initialization(ScriptCode, LoadableScript) :-
+    split_string(ScriptCode, "\n", "", Lines0),
+    exclude(generated_initialization_line, Lines0, Lines),
+    atomic_list_concat(Lines, '\n', LoadableScript).
+
+generated_initialization_line(Line) :-
+    sub_string(Line, _, _, _, "initialization(main").
+
+cleanup_generated_script_entrypoint :-
+    (   current_predicate(user:main/0)
+    ->  abolish(user:main/0)
+    ;   true
+    ).
+
+collect_wam_predicates(Variant, Predicates) :-
+    collect_wam_predicates(Variant, kernels_on, Predicates).
+
+collect_wam_predicates(seeded, kernels_on, [
+    user:dimension_n/1,
+    user:max_depth/1,
+    user:category_parent/2,
+    user:category_ancestor/4,
+    user:power_sum_bound/4
+]).
+collect_wam_predicates(seeded, kernels_off, [
+    user:dimension_n/1,
+    user:max_depth/1,
+    user:category_ancestor/4,
+    user:power_sum_bound/4
+]).
+collect_wam_predicates(accumulated, kernels_on, [
+    user:dimension_n/1,
+    user:max_depth/1,
+    user:category_parent/2,
+    user:category_ancestor/4,
+    user:'category_ancestor$power_sum_bound'/3,
+    user:'category_ancestor$power_sum_selected'/3,
+    user:'category_ancestor$effective_distance_sum_selected'/3,
+    user:'category_ancestor$effective_distance_sum_bound'/3
+]).
+collect_wam_predicates(accumulated, kernels_off, [
+    user:dimension_n/1,
+    user:max_depth/1,
+    user:category_ancestor/4,
+    user:'category_ancestor$power_sum_bound'/3,
+    user:'category_ancestor$power_sum_selected'/3,
+    user:'category_ancestor$effective_distance_sum_selected'/3,
+    user:'category_ancestor$effective_distance_sum_bound'/3
+]).
+
+must_exist_file(Path) :-
+    (   exists_file(Path)
+    ->  true
+    ;   throw(error(existence_error(file, Path), _))
+    ).
+
+%% power_sum_bound/4 - needed for seeded variant.
+power_sum_bound(Cat, Root, NegN, WeightSum) :-
+    aggregate_all(sum(W),
+        (category_ancestor(Cat, Root, Hops, [Cat]),
+         H is Hops + 1,
+         W is H ** NegN),
+        WeightSum).

--- a/tests/test_wam_clojure_benchmark_generator.pl
+++ b/tests/test_wam_clojure_benchmark_generator.pl
@@ -1,0 +1,51 @@
+:- encoding(utf8).
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../examples/benchmark/generate_wam_clojure_optimized_benchmark').
+
+:- begin_tests(wam_clojure_benchmark_generator).
+
+test(kernel_mode_options) :-
+    parse_kernel_mode(kernels_on, OnOptions),
+    parse_kernel_mode(kernels_off, OffOptions),
+    assertion(member(foreign_predicates([category_parent/2]), OnOptions)),
+    assertion(member(clojure_foreign_handlers(_), OnOptions)),
+    assertion(OffOptions == [no_kernels(true)]).
+
+test(collect_seeded_predicates) :-
+    collect_wam_predicates(seeded, Predicates),
+    assertion(member(user:dimension_n/1, Predicates)),
+    assertion(member(user:max_depth/1, Predicates)),
+    assertion(member(user:category_ancestor/4, Predicates)),
+    assertion(member(user:power_sum_bound/4, Predicates)).
+
+test(generate_seeded_kernels_on_project) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_bench_on', TmpDir),
+        generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on),
+        directory_file_path(TmpDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(sub_string(CoreCode, _, _, _, '(def foreign-handlers {')),
+        assertion(sub_string(CoreCode, _, _, _, '"category_parent/2" (fn [_args] false)')),
+        assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_parent" :arity 2}')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+test(generate_seeded_kernels_off_project) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_bench_off', TmpDir),
+        generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_off),
+        directory_file_path(TmpDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(sub_string(CoreCode, _, _, _, '(def foreign-handlers {')),
+        assertion(\+ sub_string(CoreCode, _, _, _, '"category_parent/2" (fn [_args] false)')),
+        assertion(\+ sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_parent" :arity 2}')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+:- end_tests(wam_clojure_benchmark_generator).
+
+unique_tmp_dir(Prefix, TmpDir) :-
+    get_time(T),
+    Stamp is floor(T * 1000),
+    format(atom(TmpDir), '~w_~w', [Prefix, Stamp]).


### PR DESCRIPTION
## Summary

Adds a Clojure hybrid WAM benchmark project generator for optimized effective-distance workloads.

The generator mirrors the existing optimized WAM benchmark scaffolds for other targets while preserving Clojure-specific runtime controls:

- emits a standalone generated Clojure WAM project from optimized effective-distance Prolog
- supports `seeded` and `accumulated` benchmark variants
- supports `kernels_on` and `kernels_off` modes for explicit foreign-kernel comparison
- documents the new workflow in the benchmark README
- records the Clojure benchmark-generation milestone in the WAM optimization log

## Details

- Added `examples/benchmark/generate_wam_clojure_optimized_benchmark.pl`.
- Added focused PlUnit coverage for generator predicate selection and kernel-mode emission.
- Verified `kernels_on` emits a deterministic `category_parent/2` foreign handler and `call-foreign` instruction.
- Verified `kernels_off` leaves category traversal as ordinary WAM calls without foreign-handler scaffolding.
- Kept this as a generated-project scaffold rather than a large JVM benchmark runner, which is safer for constrained Termux runs.

## Testing

Ran:

```sh
swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl
swipl -q -s examples/benchmark/generate_wam_clojure_optimized_benchmark.pl -- data/benchmark/dev/facts.pl tmp_wam_clojure_bench_probe seeded kernels_on
swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
```

## Notes

This does not yet add real Clojure graph kernels behind `call-foreign`; it establishes the benchmark-generation path and kernel toggle needed to compare that work cleanly in a later PR.
