### PR TITLE
docs(wam): fact-shape proposal — philosophy, spec, plan

### DIFF
--- a/docs/proposals/WAM_FACT_SHAPE_PHILOSOPHY.md
+++ b/docs/proposals/WAM_FACT_SHAPE_PHILOSOPHY.md
@@ -1,0 +1,118 @@
+# WAM Fact Shape Philosophy
+
+## Summary
+
+Facts should live in the generated program as **data**, not as **code**.
+The lowered WAM emitters (Elixir today; others to follow) currently
+compile each clause of a fact-only predicate into its own host-language
+function. That choice is source of one class of failure — the target
+host compiler refuses, or refuses-in-practice, to compile a module with
+thousands of functions in it.
+
+This document argues the fix is architectural, not a micro-optimisation,
+and should mirror the direction the parameterized query engine is
+already taking: the parser / code generator prefers *streaming* tuples
+into the engine, and the engine decides how much to retain.
+
+## Core position
+
+The emitter should not eagerly decide to turn every fact into a
+standalone function.
+
+That decision belongs in the WAM runtime because only the runtime knows:
+
+- which predicate is being called
+- which argument positions are ground at call time
+- whether backtracking will demand another solution
+- whether the predicate will be queried once, thousands of times, or as
+  part of a hot loop
+- whether first-argument indexing will pay for itself
+
+So the preferred ownership boundary is:
+
+- emitter responsibility: emit facts as **data** (or point at an
+  external data source), and emit small *code* wrappers around them
+- runtime responsibility: iterate, index, and retain that data
+  according to the query pattern
+
+## Why this matters
+
+### Observed failure mode
+
+Profiling the `effective_distance` benchmark exposed this:
+
+| predicate                | clauses | compile (Prolog) | compile (Elixir) |
+| ------------------------ | ------- | ---------------- | ---------------- |
+| `category_ancestor/4`    | 2       | 1 ms             | OK               |
+| `article_category/2`     | 771     | 40 ms            | ~seconds         |
+| `category_parent/2`      | 6009    | 320 ms           | **> 10 minutes** |
+
+After fixing the Prolog-side codegen slowness (PR #1505), the Prolog
+emitter produces 6.9 MB of Elixir source in 1.9 s. The Elixir
+compiler then fails to produce a loaded module in under ten minutes.
+The source is valid; it is simply the wrong **shape**. A module with
+6000 `defp clause_*/1` functions is a pathological input for the host
+compiler, regardless of size.
+
+Once this shape is eliminated, facts scale with data-structure cost
+(`Map`, `list`, ETS) rather than with compiler cost.
+
+### Why the same fix helps across targets
+
+The problem is not specific to Elixir. Every WAM target that compiles
+each fact into a host function — Go, Clojure, Haskell, Rust, C#-native
+WAM — inherits the same scaling failure. The proposed boundary applies
+to all of them, though each target picks the local "data" representation
+that fits best.
+
+### Alignment with the query engine
+
+The C# parameterized query engine already distinguishes `Streaming`,
+`Replayable`, `ExternalMaterialized`, and operator-owned retained state
+(see `QUERY_ENGINE_MATERIALIZATION_PHILOSOPHY.md`). WAM targets making
+the same distinction means both layers of the system can speak the same
+language about retention.
+
+## Preferred order of strategies
+
+When the emitter has a choice, it should prefer these shapes in roughly
+this order. Each step trades a small amount of codegen complexity for
+much better host-compile and runtime behaviour:
+
+1. **Host literal data, streamed** — emit the fact tuples as a
+   host-language literal (e.g. Elixir `@facts [{...}, {...}]`); the
+   runtime iterates lazily.
+2. **Host literal data, indexed** — same literal tuples, plus a
+   compile-time-built index on the first ground arg (Map).
+3. **External data source loaded at boot** — facts live outside the
+   module source (TSV, ETS, database). Runtime hits a `FactSource`
+   adaptor.
+4. **Compiled clauses (current default)** — each fact becomes its own
+   host function. Reserved for predicates with dynamic heads, guarded
+   unification, or very small clause counts where the overhead does
+   not matter.
+
+Defaults lean toward shapes that scale well. Users override explicitly
+via Prolog-side configuration predicates.
+
+## What does not change
+
+- Recursive or rule-bearing predicates stay in the current CPS-lowered
+  shape. The fact-shape question is orthogonal to non-tail recursion
+  handling.
+- The `run/1`, `next_solution/1`, `materialise_args/1` contract stays
+  identical at the module boundary, so drivers and caller tests are
+  unaffected.
+- Existing `emit_mode(lowered)` / `emit_mode(interpreted)` continue to
+  work; fact-shape is a third axis ("fact layout"), not a fourth
+  emit-mode.
+
+## Non-goals
+
+- This document does not specify an index format, a serialisation
+  format, or a query-time planner. Those are deferred to the spec and
+  plan docs.
+- It does not propose removing the compiled-clause path. Small
+  fact-only predicates and all non-fact predicates continue to use it.
+- It does not specify which targets receive the change first beyond
+  "start with Elixir, where the scaling failure is already observable."

--- a/docs/proposals/WAM_FACT_SHAPE_PLAN.md
+++ b/docs/proposals/WAM_FACT_SHAPE_PLAN.md
@@ -1,0 +1,192 @@
+# WAM Fact Shape Implementation Plan
+
+## Goal
+
+Move the WAM lowered emitters from "every fact is a function" toward
+"facts are data." Start with Elixir, where the scaling failure is
+already observable (a 6009-clause `category_parent/2` that the host
+compiler cannot load in ten minutes). Generalise to other WAM targets
+once the contract stabilises.
+
+The phased rollout is designed so each phase is shippable on its own
+and produces observable results.
+
+## Phase A: Classification infrastructure (no behaviour change)
+
+Status: not started.
+
+Work:
+
+- Implement `fact_only/1`, `clause_count/2`, `first_arg_groundness/2`
+  as emitter-internal predicates operating on the already-loaded clause
+  list.
+- Add option plumbing: `fact_layout/2`, `fact_count_threshold/1`,
+  `fact_layout_defaults/1`.
+- At `lower_predicate_to_elixir/4` entry, compute the layout for each
+  predicate. Store it on a new fact that later phases consume.
+- Emit layout choice as a comment in the generated module so it is
+  observable without a debugger.
+
+Acceptance:
+
+- New unit tests assert correct classification for: empty predicate,
+  one-clause rule, 100-clause facts, 1000-clause facts, user override.
+- All existing WAM-Elixir tests still pass (behaviour unchanged —
+  everything still emits as `compiled`).
+
+## Phase B: `inline_data` emission for Elixir
+
+Status: not started.
+
+Work:
+
+- In `wam_elixir_lowered_emitter`, add an `emit_inline_data/4` branch
+  selected by the Phase-A layout choice.
+- Emit `@facts` module attribute as an Elixir list of tuples. Convert
+  atoms/strings/numbers to host literals; variable head args become a
+  sentinel. Structure/list args are deferred to Phase C.
+- Emit a `run/1` that delegates to `WamRuntime.stream_facts/3`, and a
+  `run(args)` wrapper that mirrors the current arg-prep code.
+- In `wam_elixir_target`, implement `stream_facts/3`,
+  `resume_fact_stream/2`, and make `backtrack/1` recognise the
+  fact-stream CP shape.
+
+Acceptance:
+
+- `examples/debug_wam_elixir_ancestor.pl` still produces the expected
+  4/1/4 solution counts with correct N values.
+- `examples/benchmark/benchmark_wam_elixir_effective_distance.py`
+  at dev scale completes without timing out (driver issue
+  notwithstanding — a separate arithmetic fix may be needed).
+- `category_parent/2` at scale 300 emits a module < 100 KB with one
+  `defp run/1` instead of 6009 `defp clause_*/1`; the Elixir compiler
+  loads it in seconds, not minutes.
+- A new unit test asserts the shape of a generated `inline_data`
+  module for a small fact set.
+
+## Phase C: First-argument indexing
+
+Status: not started.
+
+Work:
+
+- When `first_arg_groundness = all_ground` and `fact_index_policy` is
+  `first_arg` or `auto`, emit an additional `@facts_by_arg1`
+  attribute: an Elixir map grouping facts by their first-arg value.
+- Update `stream_facts/3` to accept an optional index hint and
+  dispatch to the indexed bucket when `regs[1]` is bound at call
+  time.
+- Keep the flat-scan fallback as the default and as the
+  mixed-groundness path.
+
+Acceptance:
+
+- A new unit test exercises a seeded call (first arg bound) on a
+  >1000-clause fact-only predicate and measures a significant
+  speed-up over the flat-scan path.
+- The reproducer and ancestor-scale benchmark still produce correct
+  answers.
+
+## Phase D: `external_source` layout and `FactSource` behaviour
+
+Status: not started.
+
+Work:
+
+- Define the `FactSource` behaviour in `wam_elixir_target.pl`:
+  `open/3`, `next/2`, `close/2`, `lookup_by_first_arg/3`.
+- Ship one concrete implementation: `WamRuntime.FactSource.Tsv`
+  backed by two-column TSV files, matching the formats already in
+  `data/benchmark/*/`.
+- Add the emitter path for `fact_layout(P/A, external_source(SourceSpec))`.
+- Update the benchmark generator to route very large fact-only
+  predicates through `external_source(tsv(...))` rather than
+  inlining 6 MB of literals.
+
+Acceptance:
+
+- `benchmark_wam_elixir_effective_distance.py` at scale 300 runs
+  end-to-end, producing output the reference TSV can be diffed
+  against.
+- An explicit `fact_layout(cat_parent/2, external_source(tsv(...)))`
+  declaration in the benchmark generator overrides the default and
+  is exercised by tests.
+
+## Phase E: Cost-based default selection
+
+Status: not started.
+
+Work:
+
+- Move the Phase-A threshold policy behind a pluggable selector in
+  the emitter.
+- Measure compile-time and size cost for each layout across a
+  representative corpus.
+- Tune defaults so that the chosen layout minimises host-compile
+  time while keeping small predicates in `compiled` form.
+
+Acceptance:
+
+- Default behaviour across the existing benchmark corpus is
+  measurably better than any fixed threshold.
+- Selection is overridable per-predicate and per-module, and is
+  observable in the generated module's layout-comment.
+
+## Phase F: Port to other WAM targets
+
+Status: not started.
+
+Targets in rough priority order:
+
+1. `wam_clojure_target` — Clojure is next most likely to see the same
+   pathology at scale.
+2. `wam_go_target`, `wam_rust_target` — both compile facts to
+   functions today.
+3. `wam_haskell_target` — has its own fact-heavy fast paths; fit may
+   already be acceptable, worth measuring first.
+4. `wam_csharp_native_target` — the C# side is already on the
+   materialization-aware runtime, but the WAM-generated-code side may
+   still compile facts as methods.
+5. Other targets as measurement warrants.
+
+For each target:
+
+- Implement the `inline_data` path using the host's most natural
+  literal shape.
+- Implement `stream_facts` / `resume_fact_stream` / fact-stream CP
+  handling in the target's runtime.
+- Add a regression test against a fact-only predicate that would
+  previously have triggered the host compiler limit.
+
+Acceptance:
+
+- Each ported target compiles a >5000-clause fact-only predicate in
+  seconds.
+- The target's existing correctness tests still pass.
+
+## Risks and mitigations
+
+- **Risk: correctness drift between `compiled` and `inline_data`.**
+  Mitigation: a golden-output test suite that exercises a predicate
+  with each layout and diffs the solution stream.
+- **Risk: indexed and flat-scan paths diverge semantically when arg 1
+  starts bound and becomes unbound mid-backtrack.**
+  Mitigation: the CP snapshot records the list being scanned, so a
+  restore always resumes the same list; indexed lookup only happens
+  at the entry call, never mid-stream.
+- **Risk: third-party drivers depend on the per-clause `defp`
+  naming.**
+  Mitigation: drivers talk to `run/1` and `next_solution/1` only; the
+  spec explicitly keeps those stable. A note in the CHANGELOG flags
+  the private-function-name change.
+
+## Exit criteria
+
+The project is considered done when:
+
+1. `category_parent/2` at scale 300 compiles and runs through the
+   effective-distance benchmark to a correct reference-row count on
+   Elixir.
+2. At least one other WAM target has the same layout available.
+3. Documentation in `docs/design/WAM_ELIXIR_CORRECTNESS_GAPS.md` and
+   the parallel target-design docs reflect the new default shape.

--- a/docs/proposals/WAM_FACT_SHAPE_SPEC.md
+++ b/docs/proposals/WAM_FACT_SHAPE_SPEC.md
@@ -1,0 +1,193 @@
+# WAM Fact Shape Specification
+
+## Scope
+
+This document specifies the contract between the WAM lowered emitter
+and the WAM runtime for representing fact-only predicates. It does not
+redesign unification, backtracking, or the broader lowered-emitter
+pipeline. It specifies:
+
+1. how the emitter classifies a predicate as "fact-only" and chooses a
+   layout for it;
+2. the Prolog-side configuration predicates the user can set to
+   override that choice;
+3. the runtime interface that every fact layout must satisfy, so
+   drivers and calling code remain unchanged.
+
+## Terminology
+
+- **fact-only predicate** — every clause is a head-only clause: body
+  is `true`, or equivalently absent. Head arguments may be ground
+  terms (atoms, strings, numbers, compounds of those) or variables.
+- **layout** — the host-language representation the emitter picks for
+  a predicate: `compiled`, `inline_data`, or `external_source`.
+- **fact source** — the runtime-side adaptor that yields tuples for
+  an `external_source` layout. Analogous to `IRetentionAwareRelationProvider`
+  in the C# query runtime.
+- **fact stream** — the per-call iteration state carried in
+  `state.choice_points` while enumerating a fact-only predicate's
+  solutions.
+
+## Classification predicates
+
+The emitter consults these Prolog-side predicates before lowering a
+predicate. Users may declare any of them in their program or in
+`Options`; none are required.
+
+### Introspection (emitter-provided, read-only)
+
+- `fact_only(+PredIndicator)` — true when every clause's body is
+  `true` after normalisation. Computed by the emitter from the
+  already-loaded clauses.
+- `clause_count(+PredIndicator, -N)` — number of clauses for the
+  predicate.
+- `first_arg_groundness(+PredIndicator, -Status)` — `all_ground`,
+  `all_variable`, or `mixed`.
+
+### User-controllable (optional)
+
+- `fact_layout(+PredIndicator, -Layout)` — user-supplied override.
+  If set, the emitter uses it without consulting the default policy.
+  Valid `Layout` values are `compiled`, `inline_data(Options)`,
+  `external_source(SourceSpec)`.
+- `fact_count_threshold(-N)` — threshold used by the default policy
+  to pick `inline_data` over `compiled`. Default: 100.
+- `fact_index_policy(+PredIndicator, -Policy)` — `none`,
+  `first_arg`, `auto`. Default is `auto`.
+
+### Default layout policy
+
+In absence of a user `fact_layout/2` fact, the emitter picks:
+
+```
+if not fact_only(P/A):
+    layout = compiled              % current behaviour, CPS-lowered
+elif clause_count(P/A, N), N =< fact_count_threshold:
+    layout = compiled              % small fact sets don't need it
+else:
+    layout = inline_data([])
+```
+
+The choice should favour shapes that scale well. `compiled` remains
+the fallback only when the numbers are small enough that it does not
+matter, or when the user overrides explicitly.
+
+## Layout contracts
+
+Every layout produces a host-language module that satisfies the same
+public interface:
+
+```
+Mod.run(%WamState{} = state) :: {:ok, state} | :fail
+Mod.run(args :: list) :: {:ok, state} | :fail
+```
+
+This is the existing contract. Drivers do not observe the layout.
+
+The differences are internal — what `run/1` does under the hood, and
+how `backtrack/1` is expected to re-enter it.
+
+### Layout: `compiled`
+
+No change from today. Each clause becomes a `defp` function; choice
+points refer to those functions.
+
+Applies when: non-fact-only, small fact-only, or explicit user
+override.
+
+### Layout: `inline_data`
+
+The emitter emits the fact tuples as a host literal (an `@facts`
+module attribute in Elixir; analogous literal in other targets).
+`run/1` delegates to a single per-target helper that iterates the
+literal.
+
+Requirements on the emitter:
+
+- `@facts` is a list (or similar) of host-native tuples in clause
+  order; element shape matches the head arity.
+- Arguments that were variables in the head become a sentinel
+  (`:_var`) in the tuple; the helper treats them as "unify with
+  anything."
+- Ground terms are lowered to their host-native equivalents.
+
+Requirements on the runtime:
+
+- `WamRuntime.stream_facts(state, facts, arity)` advances through
+  `facts` attempting unification at each index; pushes a single
+  "fact-stream CP" carrying `{facts, next_index}` when a match
+  succeeds, so `backtrack/1` resumes the scan without popping
+  per-fact choice points.
+- `backtrack/1` recognises the fact-stream CP shape and dispatches to
+  `resume_fact_stream(state, cp)` instead of invoking a `cp.pc`
+  function reference.
+- Trailing/unwinding behaves as today: the fact-stream CP snapshot
+  holds the usual `trail_len`, `heap_len`, `regs` fields.
+
+Indexing (when `fact_index_policy = first_arg` and the caller binds
+arg 1 before the call):
+
+- The emitter emits `@facts_by_arg1 %{arg1_val => [tuple, tuple, ...]}`
+  alongside `@facts`. The helper picks the indexed list when `regs[1]`
+  is ground; otherwise falls back to the flat `@facts`. One extra CP
+  slot records which list is being scanned, so backtracking within
+  the indexed bucket works the same way.
+
+### Layout: `external_source`
+
+The emitter emits only a thin wrapper that delegates to a runtime
+`WamRuntime.FactSource` registered at boot time. The caller-supplied
+source may back onto a TSV reader, an ETS table, a database iterator,
+or any other retained state owner.
+
+Requirements on the emitter:
+
+- `SourceSpec` in `fact_layout(P/A, external_source(SourceSpec))` is
+  an opaque term passed through to the runtime registration.
+  Minimum: `tsv(Path, ArityHeader)`.
+- `run/1` / `run/0` bodies call `WamRuntime.FactSource.open(SourceSpec, state, P/A)`
+  and then use the same `stream_facts` / `backtrack` contract as
+  `inline_data`.
+
+Requirements on the runtime:
+
+- A `FactSource` behaviour with `open/3`, `next/2`, `close/2`,
+  `lookup_by_first_arg/3` callbacks. The last is optional; when
+  absent, the runtime falls back to linear scan.
+- A registration helper so drivers can bind a `SourceSpec` atom to a
+  concrete implementation before calling `Mod.run/1`.
+
+## Option plumbing
+
+The lowered emitter's `Options` list gains one new recognised key:
+
+- `fact_layout_defaults(+List)` — overrides the default policy per
+  module. Example: `fact_layout_defaults([threshold(200), index(auto)])`.
+
+Existing options — `module_name/1`, `emit_mode/1` — are unchanged.
+
+## Backward-compatibility
+
+- Drivers that only call `run/1` and `next_solution/1` are
+  unaffected.
+- Predicates not classified as `inline_data` or `external_source`
+  still emit as `compiled`, producing byte-identical output.
+- Existing tests that inspect emitted code for specific `defp` names
+  may need updating if they happen to reference a predicate that
+  crosses the threshold. Mitigation: keep the threshold low enough
+  in the default-test scenarios that test-sized predicates stay
+  `compiled`.
+
+## Non-goals
+
+- Join planning, cost-based selection between layouts, or an
+  integrated cost model. The default policy is intentionally simple
+  so the behaviour is predictable; richer planning is a follow-up.
+- Arbitrary body goals. A predicate with any body goal is not
+  fact-only; it keeps the existing `compiled` shape.
+- Cross-target uniformity. Each target implements the `inline_data`
+  layout with the literal shape that suits its host language
+  (Elixir module attributes, Go package-level `var`, Clojure `def`,
+  Haskell `let`, etc.). The specification above is written in Elixir
+  terms because Elixir is the first target; other targets follow the
+  same contract with host-appropriate syntax.


### PR DESCRIPTION
## Summary

Three parallel proposal docs in `docs/proposals/` covering the decision
to move WAM lowered emitters from "every fact is a function" toward
"facts are data." Structured to match the existing query-engine
materialization proposal triplet so the WAM and query-engine layers
speak the same language about retention.

No code changes. This PR is design-only.

## Why

Profiling the `effective_distance` benchmark at scale 300 surfaced a
concrete scaling failure:

| predicate                | clauses | prolog compile | elixir load  |
| ------------------------ | ------- | -------------- | ------------ |
| `category_parent/2`      | 6009    | 320 ms         | **> 10 min** |

After PR #1505 fixed the upstream Prolog-side O(N²) string accumulator,
the emitter produces the 6.9 MB Elixir source in 1.9 s. The Elixir
compiler then refuses to load the resulting module in under ten
minutes. A module with 6000 `defp` functions is a pathological input
for the host compiler regardless of host language — the same failure
looms for every WAM target that emits per-fact functions (Go, Clojure,
Haskell, Rust, C#-native).

The fix is architectural, and it should mirror the direction the C#
parameterized query engine is already taking
(`QUERY_ENGINE_MATERIALIZATION_PHILOSOPHY.md` and siblings):

> parser responsibility: stream decoded tuples
> engine responsibility: retain only the state warranted by the plan

Translated to WAM terms: the emitter emits facts as **data**; the
**runtime** decides how to iterate, index, and retain them.

## What's in the three docs

### `WAM_FACT_SHAPE_PHILOSOPHY.md` (118 lines)

- Core position: facts live in the generated program as data, not as
  code. Emitter streams; runtime retains.
- Why this matters now: observed 10-minute-plus host-compile failure
  on 6009-clause `category_parent/2`.
- Preferred layout order: host literal data streamed → host literal
  data indexed → external data source loaded at boot → compiled
  clauses (current default, reserved for small/dynamic cases).
- Alignment with the existing query-engine materialization docs.

### `WAM_FACT_SHAPE_SPEC.md` (193 lines)

- Classification predicates: `fact_only/1`, `clause_count/2`,
  `first_arg_groundness/2`, plus user-controllable
  `fact_layout/2`, `fact_count_threshold/1`, `fact_index_policy/2`.
- Three layouts with stable public interface:
  - `compiled` — unchanged, current behaviour
  - `inline_data` — `@facts` module attribute + single streaming
    `defp run/1`
  - `external_source` — thin wrapper over a runtime `FactSource`
    behaviour
- Runtime contract: a fact-stream CP shape carrying
  `{facts, next_index}` that `backtrack/1` resumes via
  `resume_fact_stream/2`, preserving the existing `trail_len` /
  `heap_len` / `regs` snapshot semantics.
- Default policy: fact-only ∧ count > 100 → `inline_data`,
  otherwise `compiled`. User override wins.

### `WAM_FACT_SHAPE_PLAN.md` (192 lines)

Six phases, each individually shippable:

- **A** — classification + option plumbing (no behaviour change)
- **B** — `inline_data` emission for Elixir + runtime support
- **C** — first-argument indexing via `@facts_by_arg1`
- **D** — `external_source` layout + TSV-backed `FactSource`
- **E** — cost-based default selection
- **F** — port to Clojure, Go, Rust, Haskell, C#-native

Each phase lists its acceptance criteria. Exit criteria: scale-300
`category_parent/2` compiles + the effective-distance benchmark
produces the reference row count, and at least one other target has
the same layout available.

## Test plan

No code changes, nothing to run.

## Related

- `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PHILOSOPHY.md` — the
  C#-side counterpart this proposal mirrors.
- PR #1500 (CPS continuations) — fixed non-tail recursion.
  Orthogonal axis from fact-shape.
- PR #1505 (O(N²) string accumulator) — fixed Prolog-side codegen
  slowness. Made this scaling failure visible by removing the
  upstream bottleneck.

## Non-goals

- No code. The three docs agree on *what* and *why*; the code lands
  in subsequent PRs aligned with the Phase-A/B/C/D/E/F breakdown.
- Not removing `compiled` layout. Small fact-only predicates and all
  non-fact predicates continue to use it.
- Not redesigning unification, backtracking, or the lowered-emitter
  pipeline more broadly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
