### PR TITLE
Measure and prototype compact seeded closure cache rows

### DIFF
--- a/docs/proposals/ROW_CONTAINER_ABSTRACTION_SURVEY.md
+++ b/docs/proposals/ROW_CONTAINER_ABSTRACTION_SURVEY.md
@@ -103,6 +103,8 @@ It is intentionally narrow:
   store `CachedResultRows`
 - counted-path replay can construct `CachedResultRows` from compact
   path-aware target/depth buffers
+- ungrouped seeded source/target closure caches can store two-column results
+  as parallel value buffers and materialize `object[]` rows on cache hits
 - existing consumers still call `AsObjectRows()` and receive
   `IReadOnlyList<object[]>`
 - public execution APIs and row order are unchanged
@@ -110,9 +112,13 @@ It is intentionally narrow:
 This proves the cached-result-container boundary can be inserted without a
 full row-wrapper/index rewrite. The compact counted-path replay prototype
 keeps final `object[]` row materialization at the boundary, but avoids the
-previous intermediate target-value and boxed-depth arrays. The next step is to
-decide whether to keep extending this seam toward cache storage or stop at the
-direct materialization win.
+previous intermediate target-value and boxed-depth arrays. The seeded closure
+cache prototype extends the same seam into cache storage for the simple
+two-column shape while leaving grouped and wider row shapes on object rows.
+This trades retained cache size and row-array isolation against hit-path
+latency, because compact cache hits must allocate fresh public `object[]` rows
+instead of reusing cached row arrays. The next step is to add retained-memory
+measurement before moving more cache families onto specialized buffers.
 
 ## Non-Goals
 

--- a/docs/proposals/ROW_CONTAINER_ABSTRACTION_SURVEY.md
+++ b/docs/proposals/ROW_CONTAINER_ABSTRACTION_SURVEY.md
@@ -117,8 +117,13 @@ cache prototype extends the same seam into cache storage for the simple
 two-column shape while leaving grouped and wider row shapes on object rows.
 This trades retained cache size and row-array isolation against hit-path
 latency, because compact cache hits must allocate fresh public `object[]` rows
-instead of reusing cached row arrays. The next step is to add retained-memory
-measurement before moving more cache families onto specialized buffers.
+instead of reusing cached row arrays. `benchmark_seeded_cache_hits.py` now
+reports both coarse warm-cache GC deltas and a direct seeded-cache storage
+estimate. On the 300 and 1k category-parent slices with 16 seeds, compact
+two-column cache storage reduces estimated seeded-cache row storage from about
+204-883 KB to about 69-295 KB, while median cache-hit latency remains slower
+than object-row reuse. The next step is to decide whether this memory/row
+isolation tradeoff is valuable enough to expose behind a runtime option.
 
 ## Non-Goals
 

--- a/examples/benchmark/benchmark_seeded_cache_hits.py
+++ b/examples/benchmark/benchmark_seeded_cache_hits.py
@@ -39,6 +39,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using UnifyWeaver.QueryRuntime;
 
 class Program
@@ -100,6 +101,141 @@ class Program
         };
     }
 
+    static long ForceFullCollectionAndGetMemory()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        return GC.GetTotalMemory(forceFullCollection: true);
+    }
+
+    static long EstimateCacheStorageBytes(QueryExecutor executor, string mode)
+    {
+        var executorType = typeof(QueryExecutor);
+        var cacheContextField = executorType.GetField("_cacheContext", BindingFlags.Instance | BindingFlags.NonPublic);
+        var cacheContext = cacheContextField?.GetValue(executor);
+        if (cacheContext is null)
+        {
+            return 0;
+        }
+
+        var cacheFieldName = mode == "source"
+            ? "TransitiveClosureSeededResults"
+            : "TransitiveClosureSeededByTargetResults";
+        var cacheField = cacheContext.GetType().GetProperty(cacheFieldName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        var outerCache = cacheField?.GetValue(cacheContext) as System.Collections.IEnumerable;
+        if (outerCache is null)
+        {
+            return 0;
+        }
+
+        long bytes = 0;
+        foreach (var outerEntry in outerCache)
+        {
+            var innerCache = outerEntry.GetType().GetProperty("Value")?.GetValue(outerEntry) as System.Collections.IEnumerable;
+            if (innerCache is null)
+            {
+                continue;
+            }
+
+            foreach (var innerEntry in innerCache)
+            {
+                var cachedRows = innerEntry.GetType().GetProperty("Value")?.GetValue(innerEntry);
+                if (cachedRows is not null)
+                {
+                    bytes += EstimateCachedResultRowsStorageBytes(cachedRows);
+                }
+            }
+        }
+
+        return bytes;
+    }
+
+    static long EstimateCachedResultRowsStorageBytes(object cachedRows)
+    {
+        var type = cachedRows.GetType();
+        var objectRows = type.GetField("_objectRows", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(cachedRows);
+        if (objectRows is not null)
+        {
+            return EstimateObjectRowsStorageBytes(objectRows);
+        }
+
+        var leftValues = type.GetField("_leftValues", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(cachedRows);
+        if (leftValues is not null)
+        {
+            var rightValues = type.GetField("_rightValues", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(cachedRows);
+            return EstimateReferenceListStorageBytes(leftValues) + EstimateReferenceListStorageBytes(rightValues);
+        }
+
+        var targetNodeIds = type.GetField("_targetNodeIds", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(cachedRows);
+        var depths = type.GetField("_depths", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(cachedRows);
+        return EstimateIntListStorageBytes(targetNodeIds) + EstimateIntListStorageBytes(depths);
+    }
+
+    static long EstimateObjectRowsStorageBytes(object objectRows)
+    {
+        if (objectRows is not IReadOnlyCollection<object[]> rows)
+        {
+            return 0;
+        }
+
+        long bytes = EstimateReferenceListStorageBytes(objectRows);
+        foreach (var row in rows)
+        {
+            bytes += EstimateArrayStorageBytes(row?.Length ?? 0, IntPtr.Size);
+        }
+
+        return bytes;
+    }
+
+    static long EstimateReferenceListStorageBytes(object? values)
+    {
+        if (values is null)
+        {
+            return 0;
+        }
+
+        if (values is Array array)
+        {
+            return EstimateArrayStorageBytes(array.Length, IntPtr.Size);
+        }
+
+        if (values is System.Collections.ICollection collection)
+        {
+            return EstimateArrayStorageBytes(collection.Count, IntPtr.Size);
+        }
+
+        return 0;
+    }
+
+    static long EstimateIntListStorageBytes(object? values)
+    {
+        if (values is null)
+        {
+            return 0;
+        }
+
+        if (values is Array array)
+        {
+            return EstimateArrayStorageBytes(array.Length, sizeof(int));
+        }
+
+        if (values is System.Collections.ICollection collection)
+        {
+            return EstimateArrayStorageBytes(collection.Count, sizeof(int));
+        }
+
+        return 0;
+    }
+
+    static long EstimateArrayStorageBytes(int count, int elementSize)
+    {
+        var bytes = 24L + ((long)count * elementSize);
+        var alignment = IntPtr.Size;
+        var remainder = bytes % alignment;
+        return remainder == 0 ? bytes : bytes + alignment - remainder;
+    }
+
     static void Main(string[] args)
     {
         if (args.Length < 4)
@@ -138,8 +274,17 @@ class Program
             ? "TransitiveClosureSeeded"
             : "TransitiveClosureSeededByTarget";
 
+        var retainedBeforeWarm = ForceFullCollectionAndGetMemory();
+        var allocatedBeforeWarm = GC.GetTotalAllocatedBytes(precise: true);
         var warmTrace = new QueryExecutionTrace();
-        var warmRows = executor.Execute(plan, parameters, warmTrace).ToList();
+        List<object[]>? warmRows = executor.Execute(plan, parameters, warmTrace).ToList();
+        var warmRowCount = warmRows.Count;
+        var warmAllocatedBytes = GC.GetTotalAllocatedBytes(precise: true) - allocatedBeforeWarm;
+        warmRows = null;
+        warmTrace = null;
+        var retainedAfterWarm = ForceFullCollectionAndGetMemory();
+        var warmRetainedBytes = Math.Max(0, retainedAfterWarm - retainedBeforeWarm);
+        var cacheStorageEstimateBytes = EstimateCacheStorageBytes(executor, mode);
 
         var elapsedMs = new List<double>();
         long lastRows = 0;
@@ -166,13 +311,16 @@ class Program
             mode,
             parameters.Count.ToString(CultureInfo.InvariantCulture),
             repetitions.ToString(CultureInfo.InvariantCulture),
-            warmRows.Count.ToString(CultureInfo.InvariantCulture),
+            warmRowCount.ToString(CultureInfo.InvariantCulture),
             lastRows.ToString(CultureInfo.InvariantCulture),
             statistics(elapsedMs, values => values.Min()),
             statistics(elapsedMs, values => values.Max()),
             statistics(elapsedMs, values => Median(values)),
             totalHits.ToString(CultureInfo.InvariantCulture),
-            totalBuilds.ToString(CultureInfo.InvariantCulture)
+            totalBuilds.ToString(CultureInfo.InvariantCulture),
+            warmRetainedBytes.ToString(CultureInfo.InvariantCulture),
+            warmAllocatedBytes.ToString(CultureInfo.InvariantCulture),
+            cacheStorageEstimateBytes.ToString(CultureInfo.InvariantCulture)
         }));
     }
 
@@ -206,6 +354,9 @@ class BenchmarkResult:
     median_ms: float
     cache_hits: int
     cache_builds: int
+    warm_retained_bytes: int
+    warm_allocated_bytes: int
+    cache_storage_estimate_bytes: int
 
 
 def parse_args() -> argparse.Namespace:
@@ -214,6 +365,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--modes", default="source,target")
     parser.add_argument("--seed-count", type=int, default=16)
     parser.add_argument("--repetitions", type=int, default=25)
+    parser.add_argument(
+        "--runtime-source",
+        type=Path,
+        default=QRY_RUNTIME,
+        help="QueryRuntime.cs to compile into the temporary benchmark harness",
+    )
     parser.add_argument("--keep-temp", action="store_true")
     return parser.parse_args()
 
@@ -222,14 +379,16 @@ def run(cmd: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProce
     return subprocess.run(cmd, cwd=cwd, check=True, capture_output=True, text=True)
 
 
-def build_harness(root: Path) -> list[str]:
+def build_harness(root: Path, runtime_source: Path) -> list[str]:
     if shutil.which("dotnet") is None:
         raise RuntimeError("dotnet not found")
+    if not runtime_source.exists():
+        raise FileNotFoundError(runtime_source)
 
     project_dir = root / "seeded_cache_hits"
     project_dir.mkdir(parents=True, exist_ok=True)
     (project_dir / "Program.cs").write_text(PROGRAM, encoding="utf-8")
-    (project_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
+    (project_dir / "QueryRuntime.cs").write_text(runtime_source.read_text(encoding="utf-8"), encoding="utf-8")
     (project_dir / "seeded_cache_hits.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
     run(["dotnet", "build", "seeded_cache_hits.csproj", "-c", "Release"], cwd=project_dir)
     return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "seeded_cache_hits.dll")]
@@ -242,7 +401,7 @@ def run_benchmark(command: list[str], scale: str, mode: str, seed_count: int, re
 
     result = run(command + [mode, str(edge_path), str(seed_count), str(repetitions)])
     fields = result.stdout.strip().split("\t")
-    if len(fields) != 10:
+    if len(fields) != 13:
         raise RuntimeError(f"Unexpected benchmark output: {result.stdout!r}\n{result.stderr}")
 
     return BenchmarkResult(
@@ -257,6 +416,9 @@ def run_benchmark(command: list[str], scale: str, mode: str, seed_count: int, re
         median_ms=float(fields[7]),
         cache_hits=int(fields[8]),
         cache_builds=int(fields[9]),
+        warm_retained_bytes=int(fields[10]),
+        warm_allocated_bytes=int(fields[11]),
+        cache_storage_estimate_bytes=int(fields[12]),
     )
 
 
@@ -267,8 +429,8 @@ def main() -> int:
 
     temp_root = Path(tempfile.mkdtemp(prefix="unifyweaver_seeded_cache_hits_"))
     try:
-        command = build_harness(temp_root)
-        print("scale\tmode\tseeds\trepetitions\twarm_rows\trows\tmedian_ms\tmin_ms\tmax_ms\tcache_hits\tcache_builds")
+        command = build_harness(temp_root, args.runtime_source)
+        print("scale\tmode\tseeds\trepetitions\twarm_rows\trows\tmedian_ms\tmin_ms\tmax_ms\tcache_hits\tcache_builds\twarm_retained_bytes\twarm_allocated_bytes\tcache_storage_estimate_bytes")
         for scale in scales:
             for mode in modes:
                 result = run_benchmark(command, scale, mode, args.seed_count, args.repetitions)
@@ -276,7 +438,9 @@ def main() -> int:
                     f"{result.scale}\t{result.mode}\t{result.seed_count}\t{result.repetitions}\t"
                     f"{result.warm_rows}\t{result.rows}\t{result.median_ms:.3f}\t"
                     f"{result.min_ms:.3f}\t{result.max_ms:.3f}\t"
-                    f"{result.cache_hits}\t{result.cache_builds}"
+                    f"{result.cache_hits}\t{result.cache_builds}\t"
+                    f"{result.warm_retained_bytes}\t{result.warm_allocated_bytes}\t"
+                    f"{result.cache_storage_estimate_bytes}"
                 )
     finally:
         if args.keep_temp:

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1534,6 +1534,8 @@ namespace UnifyWeaver.QueryRuntime
     internal sealed class CachedResultRows
     {
         private readonly IReadOnlyList<object[]>? _objectRows;
+        private readonly IReadOnlyList<object?>? _leftValues;
+        private readonly IReadOnlyList<object?>? _rightValues;
         private readonly object? _seedValue;
         private readonly object?[]? _nodeValues;
         private readonly IReadOnlyList<int>? _targetNodeIds;
@@ -1544,6 +1546,22 @@ namespace UnifyWeaver.QueryRuntime
         private CachedResultRows(IReadOnlyList<object[]> objectRows)
         {
             _objectRows = objectRows ?? throw new ArgumentNullException(nameof(objectRows));
+        }
+
+        private CachedResultRows(
+            IReadOnlyList<object?> leftValues,
+            IReadOnlyList<object?> rightValues)
+        {
+            if (leftValues is null) throw new ArgumentNullException(nameof(leftValues));
+            if (rightValues is null) throw new ArgumentNullException(nameof(rightValues));
+
+            if (leftValues.Count != rightValues.Count)
+            {
+                throw new ArgumentException("Binary row buffers must have the same row count.", nameof(rightValues));
+            }
+
+            _leftValues = leftValues;
+            _rightValues = rightValues;
         }
 
         private CachedResultRows(
@@ -1570,6 +1588,11 @@ namespace UnifyWeaver.QueryRuntime
 
         public static CachedResultRows FromObjectRows(IReadOnlyList<object[]> rows) => new(rows);
 
+        public static CachedResultRows FromBinaryRows(
+            IReadOnlyList<object?> leftValues,
+            IReadOnlyList<object?> rightValues) =>
+            new(leftValues, rightValues);
+
         public static CachedResultRows FromPathAwareDepthRows(
             object? seedValue,
             object?[] nodeValues,
@@ -1578,7 +1601,7 @@ namespace UnifyWeaver.QueryRuntime
             Func<int, object> boxDepth) =>
             new(seedValue, nodeValues, targetNodeIds, depths, boxDepth);
 
-        public int Count => _objectRows?.Count ?? _targetNodeIds?.Count ?? 0;
+        public int Count => _objectRows?.Count ?? _leftValues?.Count ?? _targetNodeIds?.Count ?? 0;
 
         public IReadOnlyList<object[]> AsObjectRows()
         {
@@ -1594,8 +1617,92 @@ namespace UnifyWeaver.QueryRuntime
 
             var rows = new List<object[]>(Count);
             AppendTo(rows);
-            _materializedRows = rows;
+            if (_leftValues is null)
+            {
+                _materializedRows = rows;
+            }
             return rows;
+        }
+
+        public IEnumerable<object[]> AsEnumerable()
+        {
+            if (_objectRows is not null)
+            {
+                return _objectRows;
+            }
+
+            if (_leftValues is not null)
+            {
+                return new BinaryRowsView(_leftValues, _rightValues!);
+            }
+
+            return AsObjectRows();
+        }
+
+        private sealed class BinaryRowsView :
+            IReadOnlyList<object[]>,
+            ICollection<object[]>
+        {
+            private readonly IReadOnlyList<object?> _leftValues;
+            private readonly IReadOnlyList<object?> _rightValues;
+
+            public BinaryRowsView(
+                IReadOnlyList<object?> leftValues,
+                IReadOnlyList<object?> rightValues)
+            {
+                _leftValues = leftValues;
+                _rightValues = rightValues;
+            }
+
+            public int Count => _leftValues.Count;
+
+            public bool IsReadOnly => true;
+
+            public object[] this[int index] => new object[] { _leftValues[index]!, _rightValues[index]! };
+
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                for (var i = 0; i < _leftValues.Count; i++)
+                {
+                    yield return new object[] { _leftValues[i]!, _rightValues[i]! };
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            public void CopyTo(object[][] array, int arrayIndex)
+            {
+                if (array is null) throw new ArgumentNullException(nameof(array));
+
+                for (var i = 0; i < _leftValues.Count; i++)
+                {
+                    array[arrayIndex + i] = new object[] { _leftValues[i]!, _rightValues[i]! };
+                }
+            }
+
+            public bool Contains(object[] item)
+            {
+                if (item is null || item.Length < 2)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < _leftValues.Count; i++)
+                {
+                    if (Equals(_leftValues[i], item[0]) && Equals(_rightValues[i], item[1]))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            public void Add(object[] item) => throw new NotSupportedException();
+
+            public void Clear() => throw new NotSupportedException();
+
+            public bool Remove(object[] item) => throw new NotSupportedException();
         }
 
         public void AppendTo(
@@ -1615,6 +1722,43 @@ namespace UnifyWeaver.QueryRuntime
                     recordOutputRow?.Invoke();
                 }
 
+                return;
+            }
+
+            if (_leftValues is not null)
+            {
+                var leftValues = _leftValues;
+                var rightValues = _rightValues!;
+
+                if (output is List<object[]> binaryOutputList)
+                {
+                    var setupStarted = Stopwatch.GetTimestamp();
+                    var baseIndex = binaryOutputList.Count;
+                    CollectionsMarshal.SetCount(binaryOutputList, baseIndex + leftValues.Count);
+                    var span = CollectionsMarshal.AsSpan(binaryOutputList);
+                    addSetupElapsed?.Invoke(Stopwatch.GetElapsedTime(setupStarted));
+
+                    var writeStarted = Stopwatch.GetTimestamp();
+                    var rowAllocStarted = Stopwatch.GetTimestamp();
+                    for (var i = 0; i < leftValues.Count; i++)
+                    {
+                        span[baseIndex + i] = new object[] { leftValues[i]!, rightValues[i]! };
+                        recordOutputRow?.Invoke();
+                    }
+                    addRowAllocElapsed?.Invoke(Stopwatch.GetElapsedTime(rowAllocStarted));
+                    addWriteElapsed?.Invoke(Stopwatch.GetElapsedTime(writeStarted));
+                    return;
+                }
+
+                var binaryFallbackWriteStarted = Stopwatch.GetTimestamp();
+                var binaryFallbackRowAllocStarted = Stopwatch.GetTimestamp();
+                for (var i = 0; i < leftValues.Count; i++)
+                {
+                    output.Add(new object[] { leftValues[i]!, rightValues[i]! });
+                    recordOutputRow?.Invoke();
+                }
+                addRowAllocElapsed?.Invoke(Stopwatch.GetElapsedTime(binaryFallbackRowAllocStarted));
+                addWriteElapsed?.Invoke(Stopwatch.GetElapsedTime(binaryFallbackWriteStarted));
                 return;
             }
 
@@ -19295,10 +19439,10 @@ namespace UnifyWeaver.QueryRuntime
 
                 if (canReuseSeededCache &&
                     context.TransitiveClosureSeededResults.TryGetValue(cacheKey, out var cachedBySeed) &&
-                    TryGetLruRowWrapperCacheValue(cachedBySeed, new RowWrapper(seedsKey), out var cachedRows))
+                TryGetLruRowWrapperCacheValue(cachedBySeed, new RowWrapper(seedsKey), out var cachedRows))
                 {
                     trace?.RecordCacheLookup("TransitiveClosureSeeded", traceKey, hit: true, built: false);
-                    return cachedRows.AsObjectRows();
+                    return cachedRows.AsEnumerable();
                 }
 
                 trace?.RecordCacheLookup("TransitiveClosureSeeded", traceKey, hit: false, built: true);
@@ -19347,7 +19491,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             dagStoreBySeed,
                             new RowWrapper(seedsKey),
-                            CachedResultRows.FromObjectRows(dagRows),
+                            CacheBinaryRows(dagRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -19393,7 +19537,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             memoizedStoreBySeed,
                             new RowWrapper(seedsKey),
-                            CachedResultRows.FromObjectRows(memoizedRows),
+                            CacheBinaryRows(memoizedRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -19483,7 +19627,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             singleStoreBySeed,
                             new RowWrapper(seedsKey),
-                            CachedResultRows.FromObjectRows(singleRows),
+                            CacheBinaryRows(singleRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -19575,7 +19719,7 @@ namespace UnifyWeaver.QueryRuntime
                     TryAdmitLruBoundedRowWrapperCacheEntry(
                         storeBySeed,
                         new RowWrapper(seedsKey),
-                        CachedResultRows.FromObjectRows(totalRows),
+                        CacheBinaryRows(totalRows),
                         _seededCacheMaxEntries,
                         admitSeededCache,
                         trace,
@@ -19589,6 +19733,28 @@ namespace UnifyWeaver.QueryRuntime
             {
                 context.FixpointDepth--;
             }
+        }
+
+        private static CachedResultRows CacheBinaryRows(IReadOnlyList<object[]> rows)
+        {
+            if (rows is null) throw new ArgumentNullException(nameof(rows));
+
+            var leftValues = new object?[rows.Count];
+            var rightValues = new object?[rows.Count];
+
+            for (var i = 0; i < rows.Count; i++)
+            {
+                var row = rows[i];
+                if (row is null || row.Length < 2)
+                {
+                    return CachedResultRows.FromObjectRows(rows);
+                }
+
+                leftValues[i] = row[0];
+                rightValues[i] = row[1];
+            }
+
+            return CachedResultRows.FromBinaryRows(leftValues, rightValues);
         }
 
         private static bool TryBuildDagReachabilityBitsets(
@@ -19749,10 +19915,10 @@ namespace UnifyWeaver.QueryRuntime
 
                 if (canReuseSeededCache &&
                     context.TransitiveClosureSeededByTargetResults.TryGetValue(cacheKey, out var cachedBySeed) &&
-                    TryGetLruRowWrapperCacheValue(cachedBySeed, new RowWrapper(seedsKey), out var cachedRows))
+                TryGetLruRowWrapperCacheValue(cachedBySeed, new RowWrapper(seedsKey), out var cachedRows))
                 {
                     trace?.RecordCacheLookup("TransitiveClosureSeededByTarget", traceKey, hit: true, built: false);
-                    return cachedRows.AsObjectRows();
+                    return cachedRows.AsEnumerable();
                 }
 
                 trace?.RecordCacheLookup("TransitiveClosureSeededByTarget", traceKey, hit: false, built: true);
@@ -19792,7 +19958,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             memoizedStoreBySeed,
                             new RowWrapper(seedsKey),
-                            CachedResultRows.FromObjectRows(memoizedRows),
+                            CacheBinaryRows(memoizedRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -19882,7 +20048,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             singleStoreBySeed,
                             new RowWrapper(seedsKey),
-                            CachedResultRows.FromObjectRows(singleRows),
+                            CacheBinaryRows(singleRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -19974,7 +20140,7 @@ namespace UnifyWeaver.QueryRuntime
                     TryAdmitLruBoundedRowWrapperCacheEntry(
                         storeBySeed,
                         new RowWrapper(seedsKey),
-                        CachedResultRows.FromObjectRows(totalRows),
+                        CacheBinaryRows(totalRows),
                         _seededCacheMaxEntries,
                         admitSeededCache,
                         trace,


### PR DESCRIPTION
  ## Summary

  This PR prototypes compact two-column storage for ungrouped seeded transitive-closure cache entries in the C# query runtime, and extends the seeded cache-hit benchmark to measure the memory/latency tradeoff
  directly.

  The compact cache representation stores seeded source/target closure rows as parallel value buffers instead of retaining full `object[]` row arrays. Cache hits still expose the existing public
  `IEnumerable<object[]>` shape, so public runtime behavior and row order remain unchanged.

  ## What Changed

  - Added compact binary-row support to `CachedResultRows`.
  - Routed ungrouped `TransitiveClosureSeeded` and `TransitiveClosureSeededByTarget` cache entries through compact row storage.
  - Added a read-only cache-hit view so compact rows can be materialized without an extra intermediate list.
  - Extended `benchmark_seeded_cache_hits.py` with:
    - `warm_retained_bytes`
    - `warm_allocated_bytes`
    - `cache_storage_estimate_bytes`
    - `--runtime-source` for comparing the working runtime against another `QueryRuntime.cs`, such as `origin/main`.
  - Documented the observed tradeoff in the row-container abstraction survey.

  ## Results

  On the 300 and 1k category-parent benchmark slices with 16 seeds:

  - Estimated seeded-cache row storage dropped from about `204-883 KB` on `origin/main` to about `69-295 KB` with compact storage.
  - Median cache-hit latency was slower with compact storage because each hit rebuilds public `object[]` rows instead of reusing cached row arrays.

  This suggests compact seeded cache rows are useful as a memory/row-isolation option, but should not become the default hot-hit cache path without more evidence.

  ## Validation

  - `dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c Release`
  - `swipl -q -t run_tests tests/core/test_csharp_query_target.pl`
  - `python3 -m py_compile examples/benchmark/benchmark_seeded_cache_hits.py`
  - `python3 examples/benchmark/benchmark_seeded_cache_hits.py --runtime-source /tmp/unifyweaver_queryruntime_main.cs --scales 300,1k --modes source,target --seed-count 16 --repetitions 25`
  - `python3 examples/benchmark/benchmark_seeded_cache_hits.py --scales 300,1k --modes source,target --seed-count 16 --repetitions 25`
  - `git diff --check`

  ## Follow-Up

  - Consider putting compact seeded cache rows behind a runtime option.
  - Add larger-scale benchmarks where cache storage is large enough for memory pressure to matter.
  - Explore mmap/external row storage for larger retained cache entries, where compact in-memory arrays may not be the right long-term shape.