### PR TITLE
feat(wam-elixir): Phase A fact-shape classification (observation-only)

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -9,7 +9,14 @@
 
 :- module(wam_elixir_lowered_emitter, [
     lower_predicate_to_elixir/4,  % +PredIndicator, +WamCode, +Options, -Code
-    wam_elixir_lower_instr/5      % +Instr, +PC, +Labels, +FuncName, -Code
+    wam_elixir_lower_instr/5,     % +Instr, +PC, +Labels, +FuncName, -Code
+    % Phase A fact-shape classification (see docs/proposals/WAM_FACT_SHAPE_*.md).
+    % Emitter-internal for now; may move to its own module once other
+    % targets adopt the same classification.
+    classify_predicate/4,         % +PredIndicator, +Segments, +Options, -Info
+    clause_count/2,               % +Segments, -N
+    fact_only/2,                  % +Segments, -Bool
+    first_arg_groundness/3        % +Segments, +Arity, -Status
 ]).
 
 :- use_module(library(lists)).
@@ -35,9 +42,17 @@ lower_predicate_to_elixir(Pred/Arity, WamCode, Options, Code) :-
     camel_case(ModName, CamelMod),
     Segments = [FirstSegName-_|_],
     segment_func_name(FirstSegName, FirstFunc),
+    % Phase A: classify the predicate and record the chosen layout as a
+    % module-level comment. Phase A emits every predicate via the
+    % existing `compiled` path regardless of the chosen layout — this
+    % is observation-only. Phase B switches on Info.layout.
+    classify_predicate(Pred/Arity, Segments, Options, Info),
+    format_fact_shape_comment(Info, ShapeComment),
     format(string(Code),
 'defmodule ~w.~w do
   @moduledoc "Lowered WAM-compiled predicate: ~w/~w"
+
+~w
 
   # run/1 is a plain tail call into the first clause segment. No
   # try/catch here — failures propagate via throw({:fail, state}) up to
@@ -85,7 +100,96 @@ lower_predicate_to_elixir(Pred/Arity, WamCode, Options, Code) :-
   end
 
 ~w
-end', [CamelMod, CamelPred, PredStr, Arity, FirstFunc, CamelPred, FuncsBody]).
+end', [CamelMod, CamelPred, PredStr, Arity, ShapeComment, FirstFunc, CamelPred, FuncsBody]).
+
+% ============================================================================
+% PHASE A: FACT-SHAPE CLASSIFICATION
+% ============================================================================
+%
+% Observation-only in this phase — the chosen `Layout` field is
+% surfaced as a module-level comment, but every predicate still emits
+% via the existing `compiled` code path. Phase B switches actual
+% emission on Layout. See docs/proposals/WAM_FACT_SHAPE_SPEC.md for
+% the wider contract.
+
+%% classify_predicate(+PredIndicator, +Segments, +Options, -Info)
+%  Info is the term `fact_shape_info(NClauses, FactOnly, FirstArg, Layout)`.
+classify_predicate(Pred/Arity, Segments, Options, Info) :-
+    clause_count(Segments, NClauses),
+    fact_only(Segments, FactOnly),
+    first_arg_groundness(Segments, Arity, FirstArg),
+    pick_layout(Pred/Arity, NClauses, FactOnly, Options, Layout),
+    Info = fact_shape_info(NClauses, FactOnly, FirstArg, Layout).
+
+%% clause_count(+Segments, -N)
+%  Each top-level segment corresponds to one clause (or the predicate
+%  header segment, which is still per-clause since the WAM emitter
+%  synthesises one segment per clause). CPS sub-segments (`_kN`) are
+%  generated later and never appear in this list.
+clause_count(Segments, N) :-
+    length(Segments, N).
+
+%% fact_only(+Segments, -Bool)
+%  `true` iff no clause has a body-level call.
+fact_only(Segments, true) :-
+    forall(member(_-Instrs, Segments),
+           forall(member(_-Instr, Instrs),
+                  \+ is_body_call_instr(Instr))), !.
+fact_only(_, false).
+
+is_body_call_instr(call(_, _)).
+is_body_call_instr(execute(_)).
+is_body_call_instr(builtin_call(_, _)).
+
+%% first_arg_groundness(+Segments, +Arity, -Status)
+%  Status is one of: `none` (arity 0), `all_ground`, `all_variable`,
+%  `mixed`. Determined by which head-unification instruction binds A1
+%  in each clause.
+first_arg_groundness(_Segments, 0, none) :- !.
+first_arg_groundness(Segments, Arity, Status) :-
+    Arity > 0,
+    maplist(clause_arg1_type, Segments, Types),
+    combine_groundness(Types, Status).
+
+clause_arg1_type(_-Instrs, Type) :-
+    (   member(_-get_constant(_, "A1"), Instrs) -> Type = ground
+    ;   member(_-get_structure(_, "A1"), Instrs) -> Type = ground
+    ;   member(_-get_variable(_, "A1"), Instrs) -> Type = variable
+    ;   member(_-get_value(_, "A1"), Instrs)    -> Type = variable
+    ;   Type = unknown
+    ).
+
+combine_groundness(Types, all_ground)   :- forall(member(T, Types), T == ground), !.
+combine_groundness(Types, all_variable) :- forall(member(T, Types), T == variable), !.
+combine_groundness(_, mixed).
+
+%% pick_layout(+PredIndicator, +NClauses, +FactOnly, +Options, -Layout)
+%  User override via `fact_layout/2` in Options or `user:fact_layout/2`
+%  always wins. Otherwise default policy: fact-only ∧ count > threshold
+%  → `inline_data`; else `compiled`. Threshold from `fact_count_threshold`
+%  option, default 100.
+pick_layout(PredIndicator, _NClauses, _FactOnly, Options, Layout) :-
+    option(fact_layout(PredIndicator, UserLayout), Options), !,
+    Layout = UserLayout.
+pick_layout(PredIndicator, _NClauses, _FactOnly, _Options, Layout) :-
+    catch(user:fact_layout(PredIndicator, UserLayout), _, fail), !,
+    Layout = UserLayout.
+pick_layout(_PredIndicator, NClauses, FactOnly, Options, Layout) :-
+    option(fact_count_threshold(Threshold), Options, 100),
+    (   FactOnly == true, NClauses > Threshold
+    ->  Layout = inline_data([])
+    ;   Layout = compiled
+    ).
+
+%% format_fact_shape_comment(+Info, -Comment)
+%  Renders `Info` as an Elixir comment surfaced in the generated
+%  module. Phase A uses this purely as documentation; Phase B+ reads
+%  Info to pick the emission path.
+format_fact_shape_comment(fact_shape_info(N, FactOnly, FirstArg, Layout), Comment) :-
+    format(string(Comment),
+'  # Phase-A fact-shape classification (observation-only):
+  #   clauses=~w fact_only=~w first_arg=~w layout=~w',
+           [N, FactOnly, FirstArg, Layout]).
 
 % ============================================================================
 % LABEL COLLECTION

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -4,6 +4,8 @@
 
 :- use_module('../src/unifyweaver/targets/wam_elixir_target').
 :- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_elixir_lowered_emitter',
+              [lower_predicate_to_elixir/4, classify_predicate/4]).
 
 :- dynamic test_failed/0.
 
@@ -172,6 +174,130 @@ test_functional_run_loop :-
     ;   fail_test(Test, 'run loop not recursive')
     ).
 
+%% Phase A fact-shape classification tests
+
+:- dynamic
+    phase_a_test:small_fact/2,
+    phase_a_test:big_fact/2,
+    phase_a_test:rule/2,
+    phase_a_test:variable_head/1.
+
+phase_a_fixture_setup :-
+    % Small fact-only predicate (4 clauses).
+    retractall(phase_a_test:small_fact(_, _)),
+    forall(member(X-Y, [a-1, b-2, c-3, d-4]),
+           assertz(phase_a_test:small_fact(X, Y))),
+    % Big fact-only predicate (150 clauses — above default threshold of 100).
+    retractall(phase_a_test:big_fact(_, _)),
+    forall(between(1, 150, I), (
+        atom_number(K, I),
+        assertz(phase_a_test:big_fact(K, I))
+    )),
+    % Rule-bearing predicate (non-fact-only).
+    retractall(phase_a_test:rule(_, _)),
+    assertz((phase_a_test:rule(X, Y) :- phase_a_test:small_fact(X, Y))),
+    % Variable-head fact (for first_arg_groundness=all_variable).
+    retractall(phase_a_test:variable_head(_)),
+    assertz((phase_a_test:variable_head(_X))).
+
+compile_and_segments(PredArity, Segments) :-
+    wam_target:compile_predicate_to_wam(phase_a_test:PredArity, [], WamCode),
+    atom_string(WamCode, WamStr),
+    split_string(WamStr, "\n", "", Lines),
+    wam_elixir_lowered_emitter:split_into_segments(Lines, 1, Segments).
+
+test_classify_small_fact_only :-
+    Test = 'Phase A: small fact-only predicate → compiled (below threshold)',
+    phase_a_fixture_setup,
+    compile_and_segments(small_fact/2, Segs),
+    classify_predicate(small_fact/2, Segs, [],
+                       fact_shape_info(NCl, FactOnly, G, Layout)),
+    (   NCl == 4, FactOnly == true, G == all_ground, Layout == compiled
+    ->  pass(Test)
+    ;   fail_test(Test, classified(NCl, FactOnly, G, Layout))
+    ).
+
+test_classify_big_fact_only :-
+    Test = 'Phase A: big fact-only predicate → inline_data',
+    phase_a_fixture_setup,
+    compile_and_segments(big_fact/2, Segs),
+    classify_predicate(big_fact/2, Segs, [],
+                       fact_shape_info(NCl, FactOnly, _G, Layout)),
+    (   NCl == 150, FactOnly == true, Layout = inline_data(_)
+    ->  pass(Test)
+    ;   fail_test(Test, classified(NCl, FactOnly, Layout))
+    ).
+
+test_classify_rule :-
+    Test = 'Phase A: rule-bearing predicate → compiled (not fact-only)',
+    phase_a_fixture_setup,
+    compile_and_segments(rule/2, Segs),
+    classify_predicate(rule/2, Segs, [],
+                       fact_shape_info(_NCl, FactOnly, _G, Layout)),
+    (   FactOnly == false, Layout == compiled
+    ->  pass(Test)
+    ;   fail_test(Test, classified(FactOnly, Layout))
+    ).
+
+test_classify_variable_head :-
+    Test = 'Phase A: all-variable first arg → first_arg=all_variable',
+    phase_a_fixture_setup,
+    compile_and_segments(variable_head/1, Segs),
+    classify_predicate(variable_head/1, Segs, [],
+                       fact_shape_info(_, _, G, _)),
+    (   G == all_variable
+    ->  pass(Test)
+    ;   fail_test(Test, groundness(G))
+    ).
+
+test_classify_user_override_layout :-
+    Test = 'Phase A: user fact_layout/2 override wins over default',
+    phase_a_fixture_setup,
+    compile_and_segments(small_fact/2, Segs),
+    Opts = [fact_layout(small_fact/2, external_source(tsv("/tmp/x.tsv")))],
+    classify_predicate(small_fact/2, Segs, Opts,
+                       fact_shape_info(_, _, _, Layout)),
+    (   Layout = external_source(_)
+    ->  pass(Test)
+    ;   fail_test(Test, layout(Layout))
+    ).
+
+test_classify_user_override_threshold :-
+    Test = 'Phase A: fact_count_threshold(1) promotes small fact set to inline_data',
+    phase_a_fixture_setup,
+    compile_and_segments(small_fact/2, Segs),
+    classify_predicate(small_fact/2, Segs, [fact_count_threshold(1)],
+                       fact_shape_info(_, _, _, Layout)),
+    (   Layout = inline_data(_)
+    ->  pass(Test)
+    ;   fail_test(Test, layout(Layout))
+    ).
+
+test_shape_comment_in_generated_module :-
+    Test = 'Phase A: generated module carries fact-shape comment',
+    phase_a_fixture_setup,
+    wam_target:compile_predicate_to_wam(phase_a_test:big_fact/2, [], WamCode),
+    lower_predicate_to_elixir(big_fact/2, WamCode, [module_name('TestMod')], Code),
+    (   sub_string(Code, _, _, _, 'Phase-A fact-shape classification'),
+        sub_string(Code, _, _, _, 'clauses=150'),
+        sub_string(Code, _, _, _, 'fact_only=true'),
+        sub_string(Code, _, _, _, 'layout=inline_data')
+    ->  pass(Test)
+    ;   fail_test(Test, 'comment missing or wrong content')
+    ).
+
+test_phase_a_preserves_compiled_output :-
+    Test = 'Phase A: generated module still uses compiled defps (no behaviour change)',
+    phase_a_fixture_setup,
+    wam_target:compile_predicate_to_wam(phase_a_test:big_fact/2, [], WamCode),
+    lower_predicate_to_elixir(big_fact/2, WamCode, [module_name('TestMod')], Code),
+    % Even though layout=inline_data, Phase A still emits defp clauses
+    (   sub_string(Code, _, _, _, 'defp clause_'),
+        sub_string(Code, _, _, _, 'def run(%WamRuntime.WamState{}')
+    ->  pass(Test)
+    ;   fail_test(Test, 'expected compiled-shape output not present')
+    ).
+
 %% Test runner
 
 run_tests :-
@@ -190,5 +316,13 @@ run_tests :-
     test_elixir_idioms,
     test_immutable_state_updates,
     test_functional_run_loop,
+    test_classify_small_fact_only,
+    test_classify_big_fact_only,
+    test_classify_rule,
+    test_classify_variable_head,
+    test_classify_user_override_layout,
+    test_classify_user_override_threshold,
+    test_shape_comment_in_generated_module,
+    test_phase_a_preserves_compiled_output,
     format('~n=== WAM-Elixir Target Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).


### PR DESCRIPTION
## Summary

Implements Phase A of
[`docs/proposals/WAM_FACT_SHAPE_PLAN.md`](../docs/proposals/WAM_FACT_SHAPE_PLAN.md)
(merged in #1507). Adds classification infrastructure and user
override plumbing. No behaviour change — every predicate still emits
via the existing `compiled` code path. This PR just makes the chosen
layout observable and lays down the option API the later phases will
consume.

## Why

Before Phase B can switch emission based on layout, we need:

1. A classifier that decides layout per predicate.
2. A user-overridable policy surface.
3. Observability in the generated output (without running a debugger).
4. A regression guarantee that the change is strictly additive.

Phase A covers all four, so Phase B becomes a focused change: flip
`Info.layout` on at the `generate_all_segments/3` call site and emit
the `inline_data` shape.

## What's in this PR

### New emitter-internal API

Exported from `wam_elixir_lowered_emitter`:

- `classify_predicate(+PredIndicator, +Segments, +Options, -Info)`
  returns `fact_shape_info(NClauses, FactOnly, FirstArg, Layout)`.
- `clause_count/2` — counts top-level segments.
- `fact_only/2` — scans every segment's instruction list for any
  `call/execute/builtin_call`.
- `first_arg_groundness/3` — reports `all_ground`, `all_variable`,
  `mixed`, or `none` (for arity-0 predicates).
- Internal: `pick_layout/5` applies the default policy;
  `format_fact_shape_comment/2` renders the Info for the generated
  module.

### Option API

- `fact_layout(PredIndicator, Layout)` — per-predicate override;
  wins over the default policy. Can also be a `user:fact_layout/2`
  fact.
- `fact_count_threshold(N)` — count above which fact-only predicates
  are classified as `inline_data`. Default 100.

### Generated output

Every generated module now carries a fact-shape comment right below
`@moduledoc`:

```elixir
defmodule WamElixirBench.CategoryParent do
  @moduledoc "Lowered WAM-compiled predicate: category_parent/2"

  # Phase-A fact-shape classification (observation-only):
  #   clauses=6008 fact_only=true first_arg=mixed layout=inline_data([])

  def run(%WamRuntime.WamState{} = state), do: ...
```

Phase A still emits all the usual `defp clause_*` functions; the
`layout=inline_data` comment documents what Phase B will choose once
the `inline_data` emission path lands.

## Observed classifications

On the existing benchmark corpus:

| predicate              | clauses | fact_only | first_arg     | layout         |
| ---------------------- | ------- | --------- | ------------- | -------------- |
| `parent/2` (test)      | 4       | true      | `all_ground`  | `compiled`     |
| `ancestor/2` (test)    | 2       | false     | `all_variable`| `compiled`     |
| `ancestor_h/3` (test)  | 2       | false     | `all_variable`| `compiled`     |
| `category_parent/2`    | 6008    | true      | `mixed` (*)   | `inline_data`  |
| `article_category/2`   | 770     | true      | `all_ground`  | `inline_data`  |
| `category_ancestor/4`  | 2       | false     | `all_variable`| `compiled`     |

(*) `category_parent/2` is truly all-ground; the `mixed` classification
comes from a pre-existing WAM-line-parser issue: atom names containing
commas (`'Washington,_D.C.'`) are tokenised wrong and fall back to
`raw/1`, so the classifier can't read their A1 type. Same clauses
already emit `raise "TODO"` today. Not Phase A's job to fix.

## Test plan

- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_target.pl`
      — 22/22 (14 existing + 8 new Phase A)
- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_utils.pl`
      — 7/7
- [x] `swipl -q -s examples/debug_wam_elixir_ancestor.pl -t halt`
      — 4/1/4 solutions with correct N values

The 8 new Phase A tests cover:

1. Small fact-only predicate (4 clauses) → `compiled`.
2. Big fact-only predicate (150 clauses) → `inline_data`.
3. Rule-bearing predicate → `compiled`, `fact_only=false`.
4. Variable-head fact → `first_arg=all_variable`.
5. `fact_layout/2` option overrides default → `external_source(_)`.
6. `fact_count_threshold(1)` promotes small fact set → `inline_data`.
7. Fact-shape comment appears in generated module with expected fields.
8. Generated module still uses `defp clause_*` (no behaviour change).

## Non-goals

- No emission path change. Phase B is responsible for the
  `inline_data` emitter branch and the runtime `stream_facts/3` /
  `resume_fact_stream/2` hooks.
- No runtime changes. `wam_elixir_target.pl` is untouched.
- No fix for the WAM-line-parser comma bug — pre-existing, tracked,
  orthogonal to fact-shape.

## Related

- #1507 — design-only docs this PR implements Phase A of.
- #1500 — CPS continuations. Orthogonal: fact-shape addresses the
  scaling failure; CPS addresses the non-tail-recursion gap.
- #1505 — Prolog-side O(N²) codegen fix. Made this scaling failure
  visible by removing the upstream bottleneck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
