### PR TITLE
feat(wam-clojure): emit fact-backed graph handler

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -237,14 +237,14 @@ for further optimization work.
 | Shared code table | Done | All generated predicates dispatch into one shared instruction table with per-predicate start PCs |
 | One-time label resolution | Done | `call`, `execute`, `jump`, choice ops, and `switch_on_constant` are resolved at project load |
 | Indexed dispatch | Done | `switch_on_constant` is compiled into a direct lookup map in the runtime |
-| FFI controls | Scaffolded | Explicit `foreign_predicates([...])` emits `call-foreign` stubs; `no_kernels(true)` and `foreign_lowering(false)` suppress stubs. Deterministic Clojure handlers can be registered; native graph kernels remain future work |
+| FFI controls | Partial | Explicit `foreign_predicates([...])` emits `call-foreign` stubs; `no_kernels(true)` and `foreign_lowering(false)` suppress stubs. Deterministic handlers work, and the optimized benchmark generator now emits a fact-backed `category_parent/2` graph handler |
 | Choice points | Partial | Saves persistent regs/env stack plus trail/heap/build boundaries; avoids binding snapshots and filtered register-map allocation, but still heavier than Haskell/Rust |
 | Environment frames | Done | `allocate`/`deallocate` use explicit environment frames for `Y` slots |
 | Cut semantics | Partial | Clause cut uses a cut barrier; `cut_ite` pops only the enclosing if-then-else CP |
 | Read-mode compound terms | Done | `get_structure`, `get_list`, `unify_*` support structure/list matching |
 | Write-mode compound terms | Done | `put_structure`, `put_list`, `set_*` build nested terms via a builder stack |
-| Benchmark generation | Scaffolded | `generate_wam_clojure_optimized_benchmark.pl` emits optimized effective-distance Clojure WAM projects with `kernels_on`/`kernels_off` controls |
-| End-to-end verification | Partial | Generator tests plus standalone smoke runner; plunit JVM subprocess tests remain disabled in Termux |
+| Benchmark generation | Partial | `generate_wam_clojure_optimized_benchmark.pl` emits optimized effective-distance Clojure WAM projects with `kernels_on`/`kernels_off` controls and fact-backed graph handler generation |
+| End-to-end verification | Partial | Generator tests, fact-backed foreign-handler JVM smoke, and standalone runtime smoke runner pass locally; large JVM benchmarks remain constrained in Termux |
 
 ### Clojure-specific lessons from this phase
 
@@ -273,13 +273,20 @@ for further optimization work.
 7. Clojure now has an optimized effective-distance project generator. It
    establishes benchmark-matrix shape and kernel-mode controls without trying
    to run large JVM benchmarks in Termux.
+8. The first Clojure graph-kernel path is now fact-backed rather than a
+   placeholder: `kernels_on` emits a Clojure set-backed `category_parent/2`
+   handler from `facts.pl`, while `kernels_off` keeps the pure WAM fallback.
+   Synthesizing the handler immediately after loading facts is important
+   because later optimization/loading steps can alter predicate visibility in
+   PlUnit contexts.
 
 ### Highest-value remaining work
 
-1. Implement native Clojure graph kernels behind the existing `call-foreign`
-   handler surface.
-2. Wire the Clojure generator into configurable benchmark target lists once
-   a real fact-backed handler or graph kernel exists.
+1. Wire the Clojure generator into configurable benchmark target lists now
+   that `kernels_on` has a real fact-backed graph handler.
+2. Extend Clojure graph kernels beyond deterministic `category_parent/2`,
+   especially multi-output traversal kernels comparable to the mature
+   Haskell/Rust hybrid paths.
 3. Add proper heap/trail semantics instead of relying primarily on the
    bindings table.
 4. Reduce choice-point snapshots toward the lighter Haskell/Rust model once

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -133,12 +133,12 @@ Supported modes:
 - `seeded` and `accumulated` select the same optimized Prolog predicate
   generation path used by the mature WAM benchmark generators.
 - `kernels_on` emits a `category_parent/2` `call-foreign` stub and a
-  deterministic placeholder Clojure handler.
+  Clojure set-backed handler generated from the supplied `facts.pl`.
 - `kernels_off` forces the pure-WAM scaffold with `no_kernels(true)`.
 
 This is intentionally a generated-project scaffold, not a large JVM benchmark
-runner. Native Clojure graph kernels and fact-backed handler loading are still
-future work.
+runner. Larger Clojure benchmark runs should stay configurable because JVM
+startup and memory behavior are noisy in constrained Termux environments.
 
 ### Why Seeded Closures Win
 

--- a/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
@@ -3,6 +3,7 @@
             generate/3,
             generate/4,
             parse_kernel_mode/2,
+            category_parent_handler_code/1,
             collect_wam_predicates/2,
             collect_wam_predicates/3
           ]).
@@ -64,6 +65,8 @@ generate(FactsPath, OutputDir, VariantAtom) :-
 generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom) :-
     must_exist_file(FactsPath),
     benchmark_workload_path(WorkloadPath),
+    load_files(user:FactsPath, [silent(true)]),
+    parse_kernel_mode(KernelModeAtom, KernelOptions),
     load_files(user:WorkloadPath, [silent(true)]),
     retractall(user:mode(category_ancestor(_, _, _, _))),
     assertz(user:mode(category_ancestor(-, +, -, +))),
@@ -75,7 +78,6 @@ generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom) :-
     maybe_load_optimized_predicates(VariantAtom, ScriptCode),
 
     maybe_assert_seeded_helper(VariantAtom),
-    parse_kernel_mode(KernelModeAtom, KernelOptions),
     collect_wam_predicates(VariantAtom, KernelModeAtom, Predicates),
     append([ [ module_name('wam-clojure-optimized-bench'),
                namespace('generated.wam_clojure_optimized_bench')
@@ -103,12 +105,44 @@ parse_variant(accumulated, [
 parse_kernel_mode(kernels_on, [
     foreign_predicates([category_parent/2]),
     clojure_foreign_handlers([
-        handler(category_parent/2, "(fn [_args] false)")
+        handler(category_parent/2, HandlerCode)
     ])
-]).
+]) :-
+    category_parent_handler_code(HandlerCode).
 parse_kernel_mode(kernels_off, [
     no_kernels(true)
 ]).
+
+category_parent_handler_code(HandlerCode) :-
+    findall(Child-Parent,
+            current_category_parent_fact(Child, Parent),
+            Pairs0),
+    sort(Pairs0, Pairs),
+    maplist(category_parent_edge_literal, Pairs, EdgeLiterals),
+    atomic_list_concat(EdgeLiterals, ' ', Edges),
+    format(string(HandlerCode),
+           "(let [edges #{~s}] (fn [args] (contains? edges [(nth args 0) (nth args 1)])))",
+           [Edges]).
+
+current_category_parent_fact(Child, Parent) :-
+    current_predicate(user:category_parent/2),
+    call(user:category_parent(Child, Parent)).
+
+category_parent_edge_literal(Child-Parent, Literal) :-
+    clj_string_literal_local(Child, ChildLit),
+    clj_string_literal_local(Parent, ParentLit),
+    format(atom(Literal), '[~w ~w]', [ChildLit, ParentLit]).
+
+clj_string_literal_local(In, Literal) :-
+    atom_string(In, InStr0),
+    escape_clj_string_local(InStr0, Escaped),
+    format(atom(Literal), '"~w"', [Escaped]).
+
+escape_clj_string_local(In, Out) :-
+    split_string(In, "\\", "", Parts1),
+    atomic_list_concat(Parts1, "\\\\", Tmp1),
+    split_string(Tmp1, "\"", "", Parts2),
+    atomic_list_concat(Parts2, "\\\"", Out).
 
 maybe_assert_seeded_helper(seeded) :- !,
     retractall(user:power_sum_bound(_, _, _, _)),

--- a/tests/test_wam_clojure_benchmark_generator.pl
+++ b/tests/test_wam_clojure_benchmark_generator.pl
@@ -1,6 +1,7 @@
 :- encoding(utf8).
 :- use_module(library(plunit)).
 :- use_module(library(filesex)).
+:- use_module(library(process)).
 :- use_module('../examples/benchmark/generate_wam_clojure_optimized_benchmark').
 
 :- begin_tests(wam_clojure_benchmark_generator).
@@ -26,7 +27,8 @@ test(generate_seeded_kernels_on_project) :-
         directory_file_path(TmpDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
         read_file_to_string(CorePath, CoreCode, []),
         assertion(sub_string(CoreCode, _, _, _, '(def foreign-handlers {')),
-        assertion(sub_string(CoreCode, _, _, _, '"category_parent/2" (fn [_args] false)')),
+        assertion(sub_string(CoreCode, _, _, _, '"category_parent/2" (let [edges #{')),
+        assertion(sub_string(CoreCode, _, _, _, '["Abstraction" "Thought"]')),
         assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_parent" :arity 2}')),
         delete_directory_and_contents(TmpDir)
     )).
@@ -38,8 +40,19 @@ test(generate_seeded_kernels_off_project) :-
         directory_file_path(TmpDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
         read_file_to_string(CorePath, CoreCode, []),
         assertion(sub_string(CoreCode, _, _, _, '(def foreign-handlers {')),
-        assertion(\+ sub_string(CoreCode, _, _, _, '"category_parent/2" (fn [_args] false)')),
+        assertion(\+ sub_string(CoreCode, _, _, _, '"category_parent/2" (let [edges #{')),
         assertion(\+ sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_parent" :arity 2}')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+test(generated_category_parent_handler_executes, [condition(clojure_available)]) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_bench_exec', TmpDir),
+        generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on),
+        run_clojure_predicate(TmpDir, 'category_parent/2',
+                              ['Abstraction', 'Thought'], "true"),
+        run_clojure_predicate(TmpDir, 'category_parent/2',
+                              ['Abstraction', 'NotAParent'], "false"),
         delete_directory_and_contents(TmpDir)
     )).
 
@@ -49,3 +62,52 @@ unique_tmp_dir(Prefix, TmpDir) :-
     get_time(T),
     Stamp is floor(T * 1000),
     format(atom(TmpDir), '~w_~w', [Prefix, Stamp]).
+
+run_clojure_predicate(ProjectDir, PredKey, Args, Output) :-
+    find_clojure_classpath(ClassPath),
+    maplist(clojure_string_arg, Args, EdnArgs),
+    process_create(path(java),
+                   ['-cp', ClassPath, 'clojure.main', '-m',
+                    'generated.wam_clojure_optimized_bench.core', PredKey|EdnArgs],
+                   [ cwd(ProjectDir),
+                     stdout(pipe(Out)),
+                     stderr(pipe(Err)),
+                     process(PID)
+                   ]),
+    process_wait(PID, Status, [timeout(20)]),
+    (   Status == timeout
+    ->  process_kill(PID)
+    ;   true
+    ),
+    read_string(Out, _, OutStr0),
+    read_string(Err, _, ErrStr),
+    close(Out),
+    close(Err),
+    (   Status == exit(0)
+    ->  true
+    ;   throw(error(java_exit(PredKey, Args, Status, ErrStr), _))
+    ),
+    normalize_space(string(Output), OutStr0),
+    (   ErrStr == ""
+    ->  true
+    ;   throw(error(java_stderr(PredKey, Args, ErrStr), _))
+    ).
+
+clojure_string_arg(Atom, Edn) :-
+    format(string(Edn), '"~w"', [Atom]).
+
+clojure_available :-
+    find_clojure_classpath(_).
+
+find_clojure_classpath(ClassPath) :-
+    findall(Path,
+        ( member(Path,
+              [ '/data/data/com.termux/files/home/.m2/repository/org/clojure/clojure/1.11.1/clojure-1.11.1.jar',
+                '/data/data/com.termux/files/home/.m2/repository/org/clojure/spec.alpha/0.3.218/spec.alpha-0.3.218.jar',
+                '/data/data/com.termux/files/home/.m2/repository/org/clojure/core.specs.alpha/0.2.62/core.specs.alpha-0.2.62.jar'
+              ]),
+          exists_file(Path)
+        ),
+        JarPaths),
+    JarPaths \= [],
+    atomic_list_concat(['src'|JarPaths], :, ClassPath).


### PR DESCRIPTION
## Summary

Adds the first real Clojure hybrid-WAM graph kernel path for optimized benchmark projects.

`kernels_on` now emits a `category_parent/2` `call-foreign` stub backed by a generated Clojure set of graph edges loaded from the supplied `facts.pl`. `kernels_off` remains the pure-WAM fallback path through `no_kernels(true)`, preserving the comparison shape needed for future benchmark matrix runs.

## Details

- Loads benchmark facts before optimized workload generation so graph edges are available to the Clojure handler generator.
- Replaces the placeholder `(fn [_args] false)` Clojure handler with a fact-backed set membership handler.
- Keeps handler synthesis early in generation because later optimized-load steps can affect predicate visibility under PlUnit.
- Adds JVM-backed generator coverage for both a present and absent `category_parent/2` edge.
- Updates benchmark docs and the WAM optimization log to reflect that Clojure now has a real deterministic graph-handler path.

## Testing

Ran:

```sh
swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl
swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
git diff --check
```

## Notes

This PR does not yet add multi-output traversal kernels comparable to the mature Haskell/Rust hybrid paths. It establishes the fact-backed `category_parent/2` foreign-handler path needed before wiring Clojure into configurable benchmark target lists.
