### PR TITLE
feat(wam-clojure): register benchmark matrix scaffolds

### DIFF
--- a/docs/design/BENCHMARK_TARGET_MATRIX.md
+++ b/docs/design/BENCHMARK_TARGET_MATRIX.md
@@ -225,6 +225,7 @@ The new matrix script uses these categories:
 
 - `optimized-prolog`
 - `hybrid-wam`
+- `hybrid-wam-scaffold`
 - `direct-pipeline`
 - `query-engine`
 
@@ -235,9 +236,24 @@ The default presets are:
 - `desktop-default`
 - `optimized-prolog`
 - `hybrid-wam`
+- `clojure-wam-scaffold`
 - `direct-pipeline`
 - `query-engine`
 - `all`
+
+`hybrid-wam-scaffold` is for generated targets that have benchmark-generation
+shape and smoke coverage but do not yet emit the common effective-distance
+result table. Clojure WAM currently lives here:
+
+- `clojure-wam-seeded`
+- `clojure-wam-seeded-no-kernels`
+- `clojure-wam-accumulated`
+- `clojure-wam-accumulated-no-kernels`
+
+The effective-distance matrix lists and resolves these targets, but skips them
+with an explicit scaffold-only message when a result-producing benchmark run is
+requested. This avoids comparing a predicate-level smoke path against full
+effective-distance table producers.
 
 ## Termux Rule
 
@@ -271,6 +287,7 @@ New scripts:
 - `examples/benchmark/generate_wam_python_optimized_benchmark.pl`
 - `examples/benchmark/generate_wam_fsharp_optimized_benchmark.pl`
 - `examples/benchmark/generate_wam_rust_optimized_benchmark.pl`
+- `examples/benchmark/generate_wam_clojure_optimized_benchmark.pl`
 - `tests/bench_wam_fsharp.pl` (F# compilation throughput benchmarks)
 - `tests/bench_wam_rust.pl` (Rust compilation throughput benchmarks)
 - `examples/benchmark/gen_prof_matrix.pl` (4 Haskell + 4 Go + 4 Python + 4 F# + 4 Rust profiling configs)

--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -279,11 +279,16 @@ for further optimization work.
    Synthesizing the handler immediately after loading facts is important
    because later optimization/loading steps can alter predicate visibility in
    PlUnit contexts.
+9. Clojure WAM scaffold targets are now registered in the configurable
+   benchmark target matrix under `clojure-wam-scaffold`. They are listed and
+   resolvable, but intentionally skipped by the effective-distance runner
+   until Clojure emits the same result table as the mature Rust/Haskell/Go
+   benchmark paths.
 
 ### Highest-value remaining work
 
-1. Wire the Clojure generator into configurable benchmark target lists now
-   that `kernels_on` has a real fact-backed graph handler.
+1. Add a result-producing Clojure effective-distance benchmark runner so the
+   scaffold targets can move into the executable `hybrid-wam` comparison set.
 2. Extend Clojure graph kernels beyond deterministic `category_parent/2`,
    especially multi-output traversal kernels comparable to the mature
    Haskell/Rust hybrid paths.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -140,6 +140,19 @@ This is intentionally a generated-project scaffold, not a large JVM benchmark
 runner. Larger Clojure benchmark runs should stay configurable because JVM
 startup and memory behavior are noisy in constrained Termux environments.
 
+The configurable benchmark matrix exposes these scaffold targets for explicit
+generation/selection tests:
+
+- `clojure-wam-seeded`
+- `clojure-wam-seeded-no-kernels`
+- `clojure-wam-accumulated`
+- `clojure-wam-accumulated-no-kernels`
+
+They are grouped under `clojure-wam-scaffold` and intentionally excluded from
+the default result-producing `hybrid-wam` comparisons until the Clojure project
+emits the same effective-distance result table as the mature Rust/Haskell/Go
+paths.
+
 ### Why Seeded Closures Win
 
 The main advantage comes from **seed deduplication**: many articles

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -583,7 +583,16 @@ def resolve_requested_targets(args: argparse.Namespace) -> list[str]:
         include_targets=include_targets,
         exclude_targets=exclude_targets,
     )
-    return available_targets(resolved)
+    runnable = []
+    for target in resolved:
+        if TARGETS[target].category == "hybrid-wam-scaffold":
+            print(
+                f"skip {target}: scaffold-only target; no result-producing effective-distance runner yet",
+                file=sys.stderr,
+            )
+            continue
+        runnable.append(target)
+    return available_targets(runnable)
 
 
 def main() -> int:

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -64,6 +64,26 @@ TARGETS: dict[str, TargetInfo] = {
         "hybrid-wam",
         "Hybrid WAM Go benchmark with optimized accumulated helpers and no_kernels(true)",
     ),
+    "clojure-wam-seeded": TargetInfo(
+        "clojure-wam-seeded",
+        "hybrid-wam-scaffold",
+        "Hybrid WAM Clojure generated project with seeded helpers and kernels enabled",
+    ),
+    "clojure-wam-seeded-no-kernels": TargetInfo(
+        "clojure-wam-seeded-no-kernels",
+        "hybrid-wam-scaffold",
+        "Hybrid WAM Clojure generated project with seeded helpers and no_kernels(true)",
+    ),
+    "clojure-wam-accumulated": TargetInfo(
+        "clojure-wam-accumulated",
+        "hybrid-wam-scaffold",
+        "Hybrid WAM Clojure generated project with optimized accumulated helpers and kernels enabled",
+    ),
+    "clojure-wam-accumulated-no-kernels": TargetInfo(
+        "clojure-wam-accumulated-no-kernels",
+        "hybrid-wam-scaffold",
+        "Hybrid WAM Clojure generated project with optimized accumulated helpers and no_kernels(true)",
+    ),
     "haskell-pure-interp": TargetInfo(
         "haskell-pure-interp",
         "hybrid-wam",
@@ -108,6 +128,12 @@ TARGET_SETS: dict[str, list[str]] = {
         "haskell-interp-ffi",
         "haskell-lowered-only",
         "haskell-lowered-ffi",
+    ],
+    "clojure-wam-scaffold": [
+        "clojure-wam-seeded",
+        "clojure-wam-seeded-no-kernels",
+        "clojure-wam-accumulated",
+        "clojure-wam-accumulated-no-kernels",
     ],
     "direct-pipeline": [
         "rust-dfs",

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
+
+from benchmark_effective_distance_matrix import parse_args, resolve_requested_targets  # noqa: E402
+from benchmark_target_matrix import TARGETS, list_targets_text, resolve_targets  # noqa: E402
+
+
+class BenchmarkTargetMatrixTests(unittest.TestCase):
+    def test_clojure_scaffold_targets_are_registered(self) -> None:
+        targets = resolve_targets(
+            explicit_targets=None,
+            target_set_names=["clojure-wam-scaffold"],
+        )
+
+        self.assertEqual(
+            targets,
+            [
+                "clojure-wam-seeded",
+                "clojure-wam-seeded-no-kernels",
+                "clojure-wam-accumulated",
+                "clojure-wam-accumulated-no-kernels",
+            ],
+        )
+        self.assertTrue(all(TARGETS[target].category == "hybrid-wam-scaffold" for target in targets))
+
+    def test_default_hybrid_wam_excludes_clojure_scaffolds(self) -> None:
+        targets = resolve_targets(
+            explicit_targets=None,
+            target_set_names=["hybrid-wam"],
+        )
+
+        self.assertIn("go-wam-accumulated", targets)
+        self.assertIn("haskell-interp-ffi", targets)
+        self.assertNotIn("clojure-wam-accumulated", targets)
+
+    def test_list_targets_includes_clojure_scaffold_set(self) -> None:
+        text = list_targets_text()
+
+        self.assertIn("clojure-wam-accumulated\thybrid-wam-scaffold", text)
+        self.assertIn(
+            "clojure-wam-scaffold\tclojure-wam-seeded,clojure-wam-seeded-no-kernels,"
+            "clojure-wam-accumulated,clojure-wam-accumulated-no-kernels",
+            text,
+        )
+
+    def test_effective_distance_runner_skips_scaffold_targets(self) -> None:
+        original_argv = sys.argv
+        try:
+            sys.argv = [
+                "benchmark_effective_distance_matrix.py",
+                "--targets",
+                "clojure-wam-accumulated,prolog-accumulated",
+            ]
+            args = parse_args()
+            self.assertEqual(resolve_requested_targets(args), ["prolog-accumulated"])
+        finally:
+            sys.argv = original_argv
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Registers Clojure hybrid-WAM benchmark scaffold targets in the configurable effective-distance benchmark matrix.

This makes the Clojure WAM benchmark generator visible to target discovery and explicit target-set selection without treating it as a full result-producing benchmark path yet.

## Details

- Adds Clojure scaffold targets:
  - `clojure-wam-seeded`
  - `clojure-wam-seeded-no-kernels`
  - `clojure-wam-accumulated`
  - `clojure-wam-accumulated-no-kernels`
- Adds the `clojure-wam-scaffold` target set.
- Keeps Clojure scaffolds out of executable `hybrid-wam`, `portable-default`, and `desktop-default` comparisons until they emit the same effective-distance result table as the mature Rust/Haskell/Go paths.
- Updates the effective-distance matrix runner to skip scaffold-only Clojure targets with an explicit message rather than failing later or producing misleading comparisons.
- Adds Python unit coverage for Clojure scaffold registration, default exclusion, list output, and runner skip behavior.
- Updates benchmark docs and the WAM optimization log.

## Testing

Ran:

```sh
python3 tests/test_benchmark_target_matrix.py
python3 examples/benchmark/benchmark_effective_distance_matrix.py --list-targets
python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-accumulated --scales dev --repetitions 1
python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-accumulated,prolog-accumulated --scales dev --repetitions 1
swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl
git diff --check
```

## Notes

The next step is to add a result-producing Clojure effective-distance benchmark runner. Once that exists, these Clojure targets can move from `hybrid-wam-scaffold` into executable benchmark comparison sets.
