### PR TITLE
fix(csharp-query): make compact seeded cache rows opt-in

### DIFF
--- a/docs/proposals/ROW_CONTAINER_ABSTRACTION_SURVEY.md
+++ b/docs/proposals/ROW_CONTAINER_ABSTRACTION_SURVEY.md
@@ -117,13 +117,16 @@ cache prototype extends the same seam into cache storage for the simple
 two-column shape while leaving grouped and wider row shapes on object rows.
 This trades retained cache size and row-array isolation against hit-path
 latency, because compact cache hits must allocate fresh public `object[]` rows
-instead of reusing cached row arrays. `benchmark_seeded_cache_hits.py` now
+instead of reusing cached row arrays. It is therefore exposed as the opt-in
+`QueryExecutorOptions.CompactSeededCacheRows` mode; object-row seeded cache
+storage remains the default hot-hit path. `benchmark_seeded_cache_hits.py` now
 reports both coarse warm-cache GC deltas and a direct seeded-cache storage
-estimate. On the 300 and 1k category-parent slices with 16 seeds, compact
-two-column cache storage reduces estimated seeded-cache row storage from about
-204-883 KB to about 69-295 KB, while median cache-hit latency remains slower
-than object-row reuse. The next step is to decide whether this memory/row
-isolation tradeoff is valuable enough to expose behind a runtime option.
+estimate, and can run object, compact, or both row-storage modes. On the 300
+and 1k category-parent slices with 16 seeds, compact two-column cache storage
+reduces estimated seeded-cache row storage from about 204-883 KB to about
+69-295 KB, while median cache-hit latency remains slower than object-row reuse.
+The next step is to evaluate larger or preprocessed external storage shapes
+where retained-memory pressure dominates cache-hit row allocation cost.
 
 ## Non-Goals
 

--- a/examples/benchmark/benchmark_seeded_cache_hits.py
+++ b/examples/benchmark/benchmark_seeded_cache_hits.py
@@ -240,7 +240,7 @@ class Program
     {
         if (args.Length < 4)
         {
-            Console.Error.WriteLine("Usage: program <source|target> <category_parent.tsv> <seed-count> <repetitions>");
+            Console.Error.WriteLine("Usage: program <source|target> <category_parent.tsv> <seed-count> <repetitions> [compact-cache-rows]");
             Environment.Exit(1);
         }
 
@@ -248,6 +248,7 @@ class Program
         var edgePath = args[1];
         var seedCount = int.Parse(args[2], CultureInfo.InvariantCulture);
         var repetitions = int.Parse(args[3], CultureInfo.InvariantCulture);
+        var compactSeededCacheRows = args.Length >= 5 && bool.Parse(args[4]);
 
         var edgeRows = ReadEdges(edgePath);
         var provider = new InMemoryRelationProvider();
@@ -269,7 +270,8 @@ class Program
             ReuseCaches: true,
             SeededCacheMaxEntries: Math.Max(seedCount * 2, 8),
             SeededCacheAdmissionMinRows: 0,
-            SeededCacheAdmissionMinRowsPerSeed: 0));
+            SeededCacheAdmissionMinRowsPerSeed: 0,
+            CompactSeededCacheRows: compactSeededCacheRows));
         var cacheName = mode == "source"
             ? "TransitiveClosureSeeded"
             : "TransitiveClosureSeededByTarget";
@@ -309,6 +311,7 @@ class Program
         Console.WriteLine(string.Join('\t', new[]
         {
             mode,
+            compactSeededCacheRows ? "compact" : "object",
             parameters.Count.ToString(CultureInfo.InvariantCulture),
             repetitions.ToString(CultureInfo.InvariantCulture),
             warmRowCount.ToString(CultureInfo.InvariantCulture),
@@ -345,6 +348,7 @@ class Program
 class BenchmarkResult:
     scale: str
     mode: str
+    cache_rows: str
     seed_count: int
     repetitions: int
     warm_rows: int
@@ -363,6 +367,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--scales", default="300,1k")
     parser.add_argument("--modes", default="source,target")
+    parser.add_argument("--cache-rows", choices=("object", "compact", "both"), default="object")
     parser.add_argument("--seed-count", type=int, default=16)
     parser.add_argument("--repetitions", type=int, default=25)
     parser.add_argument(
@@ -394,31 +399,33 @@ def build_harness(root: Path, runtime_source: Path) -> list[str]:
     return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "seeded_cache_hits.dll")]
 
 
-def run_benchmark(command: list[str], scale: str, mode: str, seed_count: int, repetitions: int) -> BenchmarkResult:
+def run_benchmark(command: list[str], scale: str, mode: str, seed_count: int, repetitions: int, cache_rows: str) -> BenchmarkResult:
     edge_path = BENCH_DIR / scale / "category_parent.tsv"
     if not edge_path.exists():
         raise FileNotFoundError(edge_path)
 
-    result = run(command + [mode, str(edge_path), str(seed_count), str(repetitions)])
+    compact_cache_rows = "true" if cache_rows == "compact" else "false"
+    result = run(command + [mode, str(edge_path), str(seed_count), str(repetitions), compact_cache_rows])
     fields = result.stdout.strip().split("\t")
-    if len(fields) != 13:
+    if len(fields) != 14:
         raise RuntimeError(f"Unexpected benchmark output: {result.stdout!r}\n{result.stderr}")
 
     return BenchmarkResult(
         scale=scale,
         mode=fields[0],
-        seed_count=int(fields[1]),
-        repetitions=int(fields[2]),
-        warm_rows=int(fields[3]),
-        rows=int(fields[4]),
-        min_ms=float(fields[5]),
-        max_ms=float(fields[6]),
-        median_ms=float(fields[7]),
-        cache_hits=int(fields[8]),
-        cache_builds=int(fields[9]),
-        warm_retained_bytes=int(fields[10]),
-        warm_allocated_bytes=int(fields[11]),
-        cache_storage_estimate_bytes=int(fields[12]),
+        cache_rows=fields[1],
+        seed_count=int(fields[2]),
+        repetitions=int(fields[3]),
+        warm_rows=int(fields[4]),
+        rows=int(fields[5]),
+        min_ms=float(fields[6]),
+        max_ms=float(fields[7]),
+        median_ms=float(fields[8]),
+        cache_hits=int(fields[9]),
+        cache_builds=int(fields[10]),
+        warm_retained_bytes=int(fields[11]),
+        warm_allocated_bytes=int(fields[12]),
+        cache_storage_estimate_bytes=int(fields[13]),
     )
 
 
@@ -426,22 +433,25 @@ def main() -> int:
     args = parse_args()
     scales = [scale.strip() for scale in args.scales.split(",") if scale.strip()]
     modes = [mode.strip() for mode in args.modes.split(",") if mode.strip()]
+    cache_row_modes = ["object", "compact"] if args.cache_rows == "both" else [args.cache_rows]
 
     temp_root = Path(tempfile.mkdtemp(prefix="unifyweaver_seeded_cache_hits_"))
     try:
         command = build_harness(temp_root, args.runtime_source)
-        print("scale\tmode\tseeds\trepetitions\twarm_rows\trows\tmedian_ms\tmin_ms\tmax_ms\tcache_hits\tcache_builds\twarm_retained_bytes\twarm_allocated_bytes\tcache_storage_estimate_bytes")
+        print("scale\tmode\tcache_rows\tseeds\trepetitions\twarm_rows\trows\tmedian_ms\tmin_ms\tmax_ms\tcache_hits\tcache_builds\twarm_retained_bytes\twarm_allocated_bytes\tcache_storage_estimate_bytes")
         for scale in scales:
             for mode in modes:
-                result = run_benchmark(command, scale, mode, args.seed_count, args.repetitions)
-                print(
-                    f"{result.scale}\t{result.mode}\t{result.seed_count}\t{result.repetitions}\t"
-                    f"{result.warm_rows}\t{result.rows}\t{result.median_ms:.3f}\t"
-                    f"{result.min_ms:.3f}\t{result.max_ms:.3f}\t"
-                    f"{result.cache_hits}\t{result.cache_builds}\t"
-                    f"{result.warm_retained_bytes}\t{result.warm_allocated_bytes}\t"
-                    f"{result.cache_storage_estimate_bytes}"
-                )
+                for cache_rows in cache_row_modes:
+                    result = run_benchmark(command, scale, mode, args.seed_count, args.repetitions, cache_rows)
+                    print(
+                        f"{result.scale}\t{result.mode}\t{result.cache_rows}\t"
+                        f"{result.seed_count}\t{result.repetitions}\t"
+                        f"{result.warm_rows}\t{result.rows}\t{result.median_ms:.3f}\t"
+                        f"{result.min_ms:.3f}\t{result.max_ms:.3f}\t"
+                        f"{result.cache_hits}\t{result.cache_builds}\t"
+                        f"{result.warm_retained_bytes}\t{result.warm_allocated_bytes}\t"
+                        f"{result.cache_storage_estimate_bytes}"
+                    )
     finally:
         if args.keep_temp:
             print(f"kept temp: {temp_root}")

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -632,6 +632,7 @@ namespace UnifyWeaver.QueryRuntime
         double PairProbeCacheAdmissionMinCostPerProbe = 0,
         int SeededCacheAdmissionMinRows = 0,
         double SeededCacheAdmissionMinRowsPerSeed = 0,
+        bool CompactSeededCacheRows = false,
         /// <summary>
         /// Maximum number of fixpoint iterations before termination.
         /// Prevents non-convergence on cyclic graphs with counter-bearing
@@ -2022,6 +2023,7 @@ namespace UnifyWeaver.QueryRuntime
         private readonly double _pairProbeCacheAdmissionMinCostPerProbe;
         private readonly int _seededCacheAdmissionMinRows;
         private readonly double _seededCacheAdmissionMinRowsPerSeed;
+        private readonly bool _compactSeededCacheRows;
         private readonly int _maxFixpointIterations;
         private readonly DagRelationRetentionStrategy _dagRelationRetentionStrategy;
         private readonly ScanRelationRetentionStrategy _scanRelationRetentionStrategy;
@@ -2045,6 +2047,7 @@ namespace UnifyWeaver.QueryRuntime
             _pairProbeCacheAdmissionMinCostPerProbe = Math.Max(0d, options.PairProbeCacheAdmissionMinCostPerProbe);
             _seededCacheAdmissionMinRows = Math.Max(0, options.SeededCacheAdmissionMinRows);
             _seededCacheAdmissionMinRowsPerSeed = Math.Max(0d, options.SeededCacheAdmissionMinRowsPerSeed);
+            _compactSeededCacheRows = options.CompactSeededCacheRows;
             _maxFixpointIterations = Math.Max(0, options.MaxFixpointIterations);
             _dagRelationRetentionStrategy = options.DagRelationRetentionStrategy;
             _scanRelationRetentionStrategy = options.ScanRelationRetentionStrategy;
@@ -19491,7 +19494,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             dagStoreBySeed,
                             new RowWrapper(seedsKey),
-                            CacheBinaryRows(dagRows),
+                            CacheSeededRows(dagRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -19537,7 +19540,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             memoizedStoreBySeed,
                             new RowWrapper(seedsKey),
-                            CacheBinaryRows(memoizedRows),
+                            CacheSeededRows(memoizedRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -19627,7 +19630,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             singleStoreBySeed,
                             new RowWrapper(seedsKey),
-                            CacheBinaryRows(singleRows),
+                            CacheSeededRows(singleRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -19719,7 +19722,7 @@ namespace UnifyWeaver.QueryRuntime
                     TryAdmitLruBoundedRowWrapperCacheEntry(
                         storeBySeed,
                         new RowWrapper(seedsKey),
-                        CacheBinaryRows(totalRows),
+                        CacheSeededRows(totalRows),
                         _seededCacheMaxEntries,
                         admitSeededCache,
                         trace,
@@ -19734,6 +19737,11 @@ namespace UnifyWeaver.QueryRuntime
                 context.FixpointDepth--;
             }
         }
+
+        private CachedResultRows CacheSeededRows(IReadOnlyList<object[]> rows) =>
+            _compactSeededCacheRows
+                ? CacheBinaryRows(rows)
+                : CachedResultRows.FromObjectRows(rows);
 
         private static CachedResultRows CacheBinaryRows(IReadOnlyList<object[]> rows)
         {
@@ -19958,7 +19966,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             memoizedStoreBySeed,
                             new RowWrapper(seedsKey),
-                            CacheBinaryRows(memoizedRows),
+                            CacheSeededRows(memoizedRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -20048,7 +20056,7 @@ namespace UnifyWeaver.QueryRuntime
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             singleStoreBySeed,
                             new RowWrapper(seedsKey),
-                            CacheBinaryRows(singleRows),
+                            CacheSeededRows(singleRows),
                             _seededCacheMaxEntries,
                             admitSeededCache,
                             trace,
@@ -20140,7 +20148,7 @@ namespace UnifyWeaver.QueryRuntime
                     TryAdmitLruBoundedRowWrapperCacheEntry(
                         storeBySeed,
                         new RowWrapper(seedsKey),
-                        CacheBinaryRows(totalRows),
+                        CacheSeededRows(totalRows),
                         _seededCacheMaxEntries,
                         admitSeededCache,
                         trace,


### PR DESCRIPTION
  ## Summary

  This PR restores object-row seeded cache storage as the default C# query runtime behavior, and makes compact seeded cache rows an explicit opt-in mode.

  The previous compact seeded-cache prototype reduced estimated cache storage, but slowed hot cache hits because public `object[]` rows had to be rebuilt on every hit. This change keeps the compact
  representation available for memory-sensitive workloads without imposing that latency cost by default.

  ## What Changed

  - Added `QueryExecutorOptions.CompactSeededCacheRows`, defaulting to `false`.
  - Changed ungrouped seeded source/target closure cache storage to use object rows by default.
  - Preserved compact two-column seeded cache storage behind the new option.
  - Extended `benchmark_seeded_cache_hits.py` with `--cache-rows object|compact|both`.
  - Updated the row-container survey to document the default/compact tradeoff and the external/preprocessed storage direction.

  ## Results

  The seeded-cache benchmark now compares both row-storage modes directly.

  Object-row mode remains the faster hot-hit path:

  ```text
  300 source object:  median 0.135 ms, storage 233,208 bytes
  300 target object:  median 0.428 ms, storage 799,992 bytes
  1k source object:   median 0.122 ms, storage 203,928 bytes
  1k target object:   median 0.499 ms, storage 882,648 bytes

  ```
  Compact mode remains available for lower estimated cache storage:
  ```text
  300 source compact: median 0.309 ms, storage 78,416 bytes
  300 target compact: median 1.042 ms, storage 267,344 bytes
  1k source compact:  median 0.247 ms, storage 68,656 bytes
  1k target compact:  median 1.793 ms, storage 294,896 bytes
  ```
  ## Validation

  - dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c Release
  - swipl -q -t run_tests tests/core/test_csharp_query_target.pl
  - python3 -m py_compile examples/benchmark/benchmark_seeded_cache_hits.py
  - python3 examples/benchmark/benchmark_seeded_cache_hits.py --scales 300,1k --modes source,target --cache-rows both --seed-count 16 --repetitions 25
  - git diff --check

  ## Follow-Up

  - Explore predicate-controlled preprocessing for larger data-structure wins.
  - Prototype durable/external predicate indexes such as partitioned hash tables, memory-mapped adjacency blocks, or sorted block runs.
  - Use compact seeded cache rows only where memory pressure dominates hot-hit latency.