### PR TITLE
Add binary relation artifacts with indexed C# query lookups

### DIFF
--- a/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
+++ b/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
@@ -376,16 +376,20 @@ integration until the exact local artifact boundary is proven.
 Prototype status:
 
 - The first runtime seam is a string-row binary relation artifact with a JSON
-  manifest and `.uwbr` data file.
+  manifest, `.uwbr` data file, and per-column offset index sidecars.
 - `BinaryRelationArtifactBuilder` can build an artifact from a delimited
   relation source and records predicate, arity, row count, source length, and
   source SHA-256 metadata.
 - `BinaryRelationArtifactProvider` exposes artifacts through the existing
   `IRelationProvider` and `IRetentionAwareRelationProvider` boundaries, so the
   current scan materialization planner can compare artifact replayable and
-  external-materialized access without a new planner enum yet.
+  external-materialized access without a new planner enum yet. It also exposes
+  indexed single-column lookups through `IIndexedRelationProvider`, letting
+  parameterized fact scans probe preprocessed offsets without first
+  materializing the whole relation.
 - `benchmark_scan_materialization.py` can now compare `preload`, `delimited`,
-  and `artifact` source modes against the existing scan-family workloads.
+  and `artifact` source modes against the existing scan-family workloads,
+  including a `bound_scan` mode for indexed parameter probes.
 
 ## Success Criteria
 

--- a/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
+++ b/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
@@ -373,6 +373,20 @@ The recommended first implementation is intentionally narrow:
 This prototype should avoid vector search, Redis, Hadoop, and general database
 integration until the exact local artifact boundary is proven.
 
+Prototype status:
+
+- The first runtime seam is a string-row binary relation artifact with a JSON
+  manifest and `.uwbr` data file.
+- `BinaryRelationArtifactBuilder` can build an artifact from a delimited
+  relation source and records predicate, arity, row count, source length, and
+  source SHA-256 metadata.
+- `BinaryRelationArtifactProvider` exposes artifacts through the existing
+  `IRelationProvider` and `IRetentionAwareRelationProvider` boundaries, so the
+  current scan materialization planner can compare artifact replayable and
+  external-materialized access without a new planner enum yet.
+- `benchmark_scan_materialization.py` can now compare `preload`, `delimited`,
+  and `artifact` source modes against the existing scan-family workloads.
+
 ## Success Criteria
 
 - A valid artifact can replace runtime-built state for a narrow exact predicate

--- a/examples/benchmark/benchmark_scan_materialization.py
+++ b/examples/benchmark/benchmark_scan_materialization.py
@@ -3,7 +3,8 @@
 Measure generic scan-family materialization planning in the C# query runtime.
 
 This harness exercises representative scan-heavy plans against the benchmark
-TSVs using streamed relation sources inside a temporary C# project:
+TSVs using preloaded, streamed, or binary-artifact relation sources inside a
+temporary C# project:
 
 - `scan`: plain `RelationScanNode`
 - `pattern`: `PatternScanNode` with a bound category
@@ -70,12 +71,31 @@ class Program
             .ToList();
     }
 
-    static void RegisterBinaryRelation(InMemoryRelationProvider provider, PredicateId predicate, string path)
+    static void RegisterBinaryRelation(
+        InMemoryRelationProvider memoryProvider,
+        BinaryRelationArtifactProvider artifactProvider,
+        PredicateId predicate,
+        string path,
+        string sourceMode,
+        string artifactDir)
     {
-        provider.RegisterDelimitedSource(predicate, new DelimitedRelationSource(path, '	', 1, 2));
-        foreach (var parts in ReadDelimitedRows(path, 2))
+        var source = new DelimitedRelationSource(path, '	', 1, 2);
+        switch (sourceMode)
         {
-            provider.AddFact(predicate, parts[0], parts[1]);
+            case "artifact":
+                var manifestPath = BinaryRelationArtifactBuilder.BuildFromDelimited(predicate, source, artifactDir);
+                artifactProvider.RegisterArtifact(predicate, manifestPath);
+                break;
+            case "delimited":
+                memoryProvider.RegisterDelimitedSource(predicate, source);
+                break;
+            default:
+                memoryProvider.RegisterDelimitedSource(predicate, source);
+                foreach (var parts in ReadDelimitedRows(path, 2))
+                {
+                    memoryProvider.AddFact(predicate, parts[0], parts[1]);
+                }
+                break;
         }
     }
 
@@ -114,14 +134,23 @@ class Program
         var articlePath = args[2];
         var traceEnabled = Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE") == "1";
         var scanStrategy = ParseScanStrategy(Environment.GetEnvironmentVariable("UNIFYWEAVER_SCAN_RETENTION_STRATEGY") ?? "auto");
+        var sourceMode = (Environment.GetEnvironmentVariable("UNIFYWEAVER_SCAN_SOURCE_MODE") ?? "preload").ToLowerInvariant();
+        if (sourceMode != "preload" && sourceMode != "delimited" && sourceMode != "artifact")
+        {
+            Console.Error.WriteLine($"Unknown UNIFYWEAVER_SCAN_SOURCE_MODE: {sourceMode}");
+            return 1;
+        }
 
-        var provider = new InMemoryRelationProvider();
+        var memoryProvider = new InMemoryRelationProvider();
+        var artifactDir = Path.Combine(Path.GetTempPath(), $"uw-scan-artifacts-{Guid.NewGuid():N}");
+        var artifactProvider = new BinaryRelationArtifactProvider(memoryProvider);
+        IRelationProvider provider = sourceMode == "artifact" ? artifactProvider : memoryProvider;
         var edgeId = new PredicateId("category_parent", 2);
         var articleId = new PredicateId("article_category", 2);
         var blockedId = new PredicateId("blocked_article_category", 2);
 
-        RegisterBinaryRelation(provider, edgeId, edgePath);
-        RegisterBinaryRelation(provider, articleId, articlePath);
+        RegisterBinaryRelation(memoryProvider, artifactProvider, edgeId, edgePath, sourceMode, artifactDir);
+        RegisterBinaryRelation(memoryProvider, artifactProvider, articleId, articlePath, sourceMode, artifactDir);
 
         var articleRows = ReadDelimitedRows(articlePath, 2);
         var patternCategory = articleRows.Count > 0
@@ -142,7 +171,7 @@ class Program
 
         try
         {
-            RegisterBinaryRelation(provider, blockedId, blockedPath);
+            RegisterBinaryRelation(memoryProvider, artifactProvider, blockedId, blockedPath, sourceMode, artifactDir);
 
             var scanOutId = new PredicateId("scan_rows", 2);
             var patternOutId = new PredicateId("pattern_rows", 2);
@@ -197,6 +226,7 @@ class Program
             stopwatch.Stop();
 
             Console.Error.WriteLine($"mode={mode}");
+            Console.Error.WriteLine($"source_mode={sourceMode}");
             Console.Error.WriteLine($"scan_retention_strategy_setting={scanStrategy}");
             Console.Error.WriteLine($"pattern_category={patternCategory}");
             Console.Error.WriteLine($"row_count={rows.Count}");
@@ -227,6 +257,7 @@ class Program
         finally
         {
             try { File.Delete(blockedPath); } catch { }
+            try { Directory.Delete(artifactDir, recursive: true); } catch { }
         }
     }
 }
@@ -237,6 +268,7 @@ class Program
 class BenchResult:
     scale: str
     mode: str
+    source_mode: str
     strategy: str
     times: list[float]
     stderr: str
@@ -250,6 +282,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--scales", default="300,10k")
     parser.add_argument("--modes", default="scan,pattern,join,negation,aggregate")
+    parser.add_argument("--source-modes", default="preload,artifact")
     parser.add_argument("--strategies", default="auto,streaming,replayable,external")
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--keep-temp", action="store_true")
@@ -294,13 +327,14 @@ def parse_metrics(stderr: str) -> dict[str, str]:
     return metrics
 
 
-def benchmark_mode(command: list[str], scale: str, mode: str, strategy: str, repetitions: int) -> BenchResult:
+def benchmark_mode(command: list[str], scale: str, mode: str, source_mode: str, strategy: str, repetitions: int) -> BenchResult:
     scale_dir = BENCH_DIR / scale
     edge_path = scale_dir / "category_parent.tsv"
     article_path = scale_dir / "article_category.tsv"
     env = os.environ.copy()
     env["UNIFYWEAVER_BENCH_TRACE"] = "1"
     env["UNIFYWEAVER_SCAN_RETENTION_STRATEGY"] = strategy
+    env["UNIFYWEAVER_SCAN_SOURCE_MODE"] = source_mode
 
     times: list[float] = []
     stderr = ""
@@ -313,13 +347,14 @@ def benchmark_mode(command: list[str], scale: str, mode: str, strategy: str, rep
         times.append(elapsed)
         stderr = result.stderr
 
-    return BenchResult(scale=scale, mode=mode, strategy=strategy, times=times, stderr=stderr)
+    return BenchResult(scale=scale, mode=mode, source_mode=source_mode, strategy=strategy, times=times, stderr=stderr)
 
 
 def main() -> int:
     args = parse_args()
     scales = [part.strip() for part in args.scales.split(",") if part.strip()]
     modes = [part.strip() for part in args.modes.split(",") if part.strip()]
+    source_modes = [part.strip() for part in args.source_modes.split(",") if part.strip()]
     strategies = [part.strip() for part in args.strategies.split(",") if part.strip()]
 
     temp_ctx = None
@@ -334,32 +369,33 @@ def main() -> int:
         results: list[BenchResult] = []
         for scale in scales:
             for mode in modes:
-                for strategy in strategies:
-                    results.append(benchmark_mode(command, scale, mode, strategy, args.repetitions))
+                for source_mode in source_modes:
+                    for strategy in strategies:
+                        results.append(benchmark_mode(command, scale, mode, source_mode, strategy, args.repetitions))
 
-        print("scale	mode	strategy	median_s	min_s	max_s	rows	planner	phases")
-        grouped: dict[tuple[str, str], dict[str, BenchResult]] = {}
-        for result in sorted(results, key=lambda item: (scale_sort_key(item.scale), item.mode, item.strategy)):
-            grouped.setdefault((result.scale, result.mode), {})[result.strategy] = result
+        print("scale	mode	source_mode	strategy	median_s	min_s	max_s	rows	planner	phases")
+        grouped: dict[tuple[str, str, str], dict[str, BenchResult]] = {}
+        for result in sorted(results, key=lambda item: (scale_sort_key(item.scale), item.mode, item.source_mode, item.strategy)):
+            grouped.setdefault((result.scale, result.mode, result.source_mode), {})[result.strategy] = result
             metrics = parse_metrics(result.stderr)
             planner = metrics.get("scan_planner_strategies", "")
             phases = metrics.get("scan_phase_summary", "")
             rows = metrics.get("row_count", "")
             print(
-                f"{result.scale}	{result.mode}	{result.strategy}	{result.median:.3f}	"
+                f"{result.scale}	{result.mode}	{result.source_mode}	{result.strategy}	{result.median:.3f}	"
                 f"{min(result.times):.3f}	{max(result.times):.3f}	{rows}	{planner}	{phases}"
             )
 
-        for scale, mode in sorted(grouped.keys(), key=lambda item: (scale_sort_key(item[0]), item[1])):
-            by_strategy = grouped[(scale, mode)]
+        for scale, mode, source_mode in sorted(grouped.keys(), key=lambda item: (scale_sort_key(item[0]), item[1], item[2])):
+            by_strategy = grouped[(scale, mode, source_mode)]
             auto = by_strategy.get("auto")
             best = min(by_strategy.values(), key=lambda item: item.median)
             if auto is not None:
-                print(f"{scale}	{mode}	best_strategy	{best.strategy}")
+                print(f"{scale}	{mode}	{source_mode}	best_strategy	{best.strategy}")
                 ratio = auto.median / best.median if best.median else float('inf')
-                print(f"{scale}	{mode}	auto_vs_best	{ratio:.2f}x")
+                print(f"{scale}	{mode}	{source_mode}	auto_vs_best	{ratio:.2f}x")
                 auto_metrics = parse_metrics(auto.stderr)
-                print(f"{scale}	{mode}	auto_planner	{auto_metrics.get('scan_planner_strategies', '')}")
+                print(f"{scale}	{mode}	{source_mode}	auto_planner	{auto_metrics.get('scan_planner_strategies', '')}")
 
         if args.keep_temp:
             print(f"kept temp build directory: {temp_root}", file=sys.stderr)

--- a/examples/benchmark/benchmark_scan_materialization.py
+++ b/examples/benchmark/benchmark_scan_materialization.py
@@ -7,6 +7,7 @@ TSVs using preloaded, streamed, or binary-artifact relation sources inside a
 temporary C# project:
 
 - `scan`: plain `RelationScanNode`
+- `bound_scan`: parameterized `RelationScanNode` over one bound column
 - `pattern`: `PatternScanNode` with a bound category
 - `join`: `KeyJoinNode` over article/category and category-parent scans
 - `negation`: unary negation over scanned support relations
@@ -25,7 +26,6 @@ import statistics
 import subprocess
 import sys
 import tempfile
-import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -184,6 +184,10 @@ class Program
                 "scan" => new QueryPlan(
                     scanOutId,
                     new RelationScanNode(articleId)),
+                "bound_scan" => new QueryPlan(
+                    patternOutId,
+                    new RelationScanNode(articleId),
+                    InputPositions: new int[] { 1 }),
                 "pattern" => new QueryPlan(
                     patternOutId,
                     new PatternScanNode(articleId, new object[] { Wildcard.Value, patternCategory })),
@@ -222,7 +226,10 @@ class Program
                 ScanRelationRetentionStrategy: scanStrategy));
 
             var stopwatch = Stopwatch.StartNew();
-            var rows = executor.Execute(plan, trace: trace).ToList();
+            var parameters = mode == "bound_scan"
+                ? new object[][] { new object[] { patternCategory } }
+                : null;
+            var rows = executor.Execute(plan, parameters: parameters, trace: trace).ToList();
             stopwatch.Stop();
 
             Console.Error.WriteLine($"mode={mode}");
@@ -246,6 +253,7 @@ class Program
                     SummarizeStrategies(
                         trace,
                         strategy => strategy.Strategy.StartsWith("KeyJoin", StringComparison.Ordinal) ||
+                                    strategy.Strategy.StartsWith("IndexedRelationProvider", StringComparison.Ordinal) ||
                                     strategy.Strategy.StartsWith("ScanRelationRetention", StringComparison.Ordinal) ||
                                     strategy.Strategy.StartsWith("ScanMaterializationPlan", StringComparison.Ordinal)));
 
@@ -341,11 +349,12 @@ def benchmark_mode(command: list[str], scale: str, mode: str, source_mode: str, 
     if repetitions > 0:
         run(command + [mode, str(edge_path), str(article_path)], env=env)
     for _ in range(repetitions):
-        started = time.perf_counter()
         result = run(command + [mode, str(edge_path), str(article_path)], env=env)
-        elapsed = time.perf_counter() - started
-        times.append(elapsed)
         stderr = result.stderr
+        metrics = parse_metrics(stderr)
+        elapsed_ms = metrics.get("elapsed_ms")
+        elapsed = float(elapsed_ms) / 1000.0 if elapsed_ms is not None else 0.0
+        times.append(elapsed)
 
     return BenchResult(scale=scale, mode=mode, source_mode=source_mode, strategy=strategy, times=times, stderr=stderr)
 
@@ -378,7 +387,7 @@ def main() -> int:
         for result in sorted(results, key=lambda item: (scale_sort_key(item.scale), item.mode, item.source_mode, item.strategy)):
             grouped.setdefault((result.scale, result.mode, result.source_mode), {})[result.strategy] = result
             metrics = parse_metrics(result.stderr)
-            planner = metrics.get("scan_planner_strategies", "")
+            planner = metrics.get("scan_planner_strategies", "") or metrics.get("scan_operator_strategies", "")
             phases = metrics.get("scan_phase_summary", "")
             rows = metrics.get("row_count", "")
             print(
@@ -395,7 +404,8 @@ def main() -> int:
                 ratio = auto.median / best.median if best.median else float('inf')
                 print(f"{scale}	{mode}	{source_mode}	auto_vs_best	{ratio:.2f}x")
                 auto_metrics = parse_metrics(auto.stderr)
-                print(f"{scale}	{mode}	{source_mode}	auto_planner	{auto_metrics.get('scan_planner_strategies', '')}")
+                auto_planner = auto_metrics.get("scan_planner_strategies", "") or auto_metrics.get("scan_operator_strategies", "")
+                print(f"{scale}	{mode}	{source_mode}	auto_planner	{auto_planner}")
 
         if args.keep_temp:
             print(f"kept temp build directory: {temp_root}", file=sys.stderr)

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -123,6 +123,8 @@ namespace UnifyWeaver.QueryRuntime
         public long? SourceLength { get; set; }
 
         public string? SourceSha256 { get; set; }
+
+        public Dictionary<string, string> IndexPaths { get; set; } = new();
     }
 
     public interface IReplayableRelationSource
@@ -139,6 +141,11 @@ namespace UnifyWeaver.QueryRuntime
     public interface IRetentionAwareRelationProvider : IRelationProvider
     {
         bool TryBindRelation(PredicateId predicate, RelationRetentionMode preferredMode, out RelationBinding binding);
+    }
+
+    public interface IIndexedRelationProvider : IRelationProvider
+    {
+        bool TryLookupFacts(PredicateId predicate, int columnIndex, IEnumerable<object> keys, out IEnumerable<object[]> facts);
     }
 
     /// <summary>
@@ -1571,7 +1578,7 @@ namespace UnifyWeaver.QueryRuntime
             var dataPath = Path.Combine(artifactDirectory, artifactName + ".uwbr");
             var manifestPath = Path.Combine(artifactDirectory, artifactName + ".uwbr.json");
 
-            var rowCount = BinaryRelationArtifactReader.WriteRows(dataPath, DelimitedRelationReader.ReadRows(source), source.ExpectedWidth);
+            var writeResult = BinaryRelationArtifactReader.WriteRows(dataPath, DelimitedRelationReader.ReadRows(source), source.ExpectedWidth);
             var sourceInfo = File.Exists(source.InputPath)
                 ? new FileInfo(source.InputPath)
                 : null;
@@ -1580,10 +1587,11 @@ namespace UnifyWeaver.QueryRuntime
                 PredicateName = predicate.Name,
                 Arity = Math.Max(2, source.ExpectedWidth),
                 DataPath = Path.GetFileName(dataPath),
-                RowCount = rowCount,
+                RowCount = writeResult.RowCount,
                 SourcePath = source.InputPath,
                 SourceLength = sourceInfo?.Length,
-                SourceSha256 = sourceInfo is null ? null : ComputeSha256(source.InputPath)
+                SourceSha256 = sourceInfo is null ? null : ComputeSha256(source.InputPath),
+                IndexPaths = writeResult.IndexPaths
             };
 
             var json = JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true });
@@ -1614,6 +1622,9 @@ namespace UnifyWeaver.QueryRuntime
     public static class BinaryRelationArtifactReader
     {
         private static readonly byte[] Magic = Encoding.ASCII.GetBytes("UWBR0001");
+        private static readonly byte[] IndexMagic = Encoding.ASCII.GetBytes("UWBI0001");
+
+        internal sealed record WriteResult(long RowCount, Dictionary<string, string> IndexPaths);
 
         public static BinaryRelationArtifactManifest LoadManifest(string manifestPath)
         {
@@ -1637,7 +1648,7 @@ namespace UnifyWeaver.QueryRuntime
             return ReadRowsFromData(dataPath, manifest.Arity, manifest.RowCount);
         }
 
-        internal static long WriteRows(string dataPath, IEnumerable<object[]> rows, int width)
+        internal static WriteResult WriteRows(string dataPath, IEnumerable<object[]> rows, int width)
         {
             if (dataPath is null) throw new ArgumentNullException(nameof(dataPath));
             if (rows is null) throw new ArgumentNullException(nameof(rows));
@@ -1652,6 +1663,12 @@ namespace UnifyWeaver.QueryRuntime
             writer.Write(0L);
 
             long rowCount = 0;
+            var indexes = new Dictionary<int, Dictionary<string, List<long>>>();
+            for (var i = 0; i < width; i++)
+            {
+                indexes[i] = new Dictionary<string, List<long>>(StringComparer.Ordinal);
+            }
+
             foreach (var row in rows)
             {
                 if (row is null || row.Length < width)
@@ -1659,9 +1676,18 @@ namespace UnifyWeaver.QueryRuntime
                     continue;
                 }
 
+                var rowOffset = stream.Position;
                 for (var i = 0; i < width; i++)
                 {
-                    WriteString(writer, row[i]?.ToString() ?? string.Empty);
+                    var value = row[i]?.ToString() ?? string.Empty;
+                    if (!indexes[i].TryGetValue(value, out var offsets))
+                    {
+                        offsets = new List<long>();
+                        indexes[i][value] = offsets;
+                    }
+
+                    offsets.Add(rowOffset);
+                    WriteString(writer, value);
                 }
 
                 rowCount++;
@@ -1670,7 +1696,48 @@ namespace UnifyWeaver.QueryRuntime
             writer.Flush();
             stream.Position = Magic.Length + sizeof(int) + sizeof(int);
             writer.Write(rowCount);
-            return rowCount;
+
+            var artifactDirectory = Path.GetDirectoryName(Path.GetFullPath(dataPath)) ?? ".";
+            var artifactName = Path.GetFileNameWithoutExtension(dataPath);
+            var indexPaths = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var kvp in indexes)
+            {
+                var indexPath = Path.Combine(artifactDirectory, $"{artifactName}.col{kvp.Key}.uwbri");
+                WriteIndex(indexPath, kvp.Key, kvp.Value);
+                indexPaths[kvp.Key.ToString(CultureInfo.InvariantCulture)] = Path.GetFileName(indexPath);
+            }
+
+            return new WriteResult(rowCount, indexPaths);
+        }
+
+        public static IEnumerable<object[]> LookupRows(string manifestPath, int columnIndex, IEnumerable<object> keys)
+        {
+            var manifest = LoadManifest(manifestPath);
+            return LookupRows(manifest, manifestPath, columnIndex, keys);
+        }
+
+        public static IEnumerable<object[]> LookupRows(BinaryRelationArtifactManifest manifest, string manifestPath, int columnIndex, IEnumerable<object> keys)
+        {
+            if (manifest is null) throw new ArgumentNullException(nameof(manifest));
+            if (keys is null) throw new ArgumentNullException(nameof(keys));
+            if (columnIndex < 0 || columnIndex >= manifest.Arity)
+            {
+                return Enumerable.Empty<object[]>();
+            }
+
+            var columnKey = columnIndex.ToString(CultureInfo.InvariantCulture);
+            if (!manifest.IndexPaths.TryGetValue(columnKey, out var indexPathValue))
+            {
+                return Enumerable.Empty<object[]>();
+            }
+
+            var manifestDirectory = Path.GetDirectoryName(Path.GetFullPath(manifestPath)) ?? ".";
+            var indexPath = Path.IsPathRooted(indexPathValue)
+                ? indexPathValue
+                : Path.Combine(manifestDirectory, indexPathValue);
+            var dataPath = ResolveDataPath(manifest, manifestPath);
+            var offsets = ReadOffsets(indexPath, columnIndex, keys.Select(key => key?.ToString() ?? string.Empty));
+            return ReadRowsAtOffsets(dataPath, manifest.Arity, offsets);
         }
 
         private static IEnumerable<object[]> ReadRowsFromData(string dataPath, int expectedWidth, long expectedRows)
@@ -1712,6 +1779,124 @@ namespace UnifyWeaver.QueryRuntime
 
                 yield return row;
             }
+        }
+
+        private static IEnumerable<object[]> ReadRowsAtOffsets(string dataPath, int expectedWidth, IReadOnlyList<long> offsets)
+        {
+            if (offsets.Count == 0)
+            {
+                yield break;
+            }
+
+            using var stream = new FileStream(dataPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1 << 16, FileOptions.RandomAccess);
+            using var reader = new BinaryReader(stream, Encoding.UTF8);
+            ValidateDataHeader(reader, dataPath, expectedWidth);
+
+            foreach (var offset in offsets)
+            {
+                stream.Position = offset;
+                var row = new object[expectedWidth];
+                for (var i = 0; i < expectedWidth; i++)
+                {
+                    row[i] = ReadString(reader);
+                }
+
+                yield return row;
+            }
+        }
+
+        private static void ValidateDataHeader(BinaryReader reader, string dataPath, int expectedWidth)
+        {
+            var magic = reader.ReadBytes(Magic.Length);
+            if (!magic.SequenceEqual(Magic))
+            {
+                throw new InvalidDataException($"Invalid binary relation artifact magic: {dataPath}");
+            }
+
+            var version = reader.ReadInt32();
+            if (version != 1)
+            {
+                throw new InvalidDataException($"Unsupported binary relation artifact version {version}: {dataPath}");
+            }
+
+            var width = reader.ReadInt32();
+            if (width != expectedWidth)
+            {
+                throw new InvalidDataException($"Binary relation artifact width mismatch. Expected {expectedWidth}, found {width}: {dataPath}");
+            }
+
+            _ = reader.ReadInt64();
+        }
+
+        private static void WriteIndex(string indexPath, int columnIndex, Dictionary<string, List<long>> index)
+        {
+            using var stream = new FileStream(indexPath, FileMode.Create, FileAccess.Write, FileShare.None);
+            using var writer = new BinaryWriter(stream, Encoding.UTF8);
+            writer.Write(IndexMagic);
+            writer.Write(1);
+            writer.Write(columnIndex);
+            writer.Write(index.Count);
+
+            foreach (var kvp in index.OrderBy(item => item.Key, StringComparer.Ordinal))
+            {
+                WriteString(writer, kvp.Key);
+                writer.Write(kvp.Value.Count);
+                foreach (var offset in kvp.Value)
+                {
+                    writer.Write(offset);
+                }
+            }
+        }
+
+        private static IReadOnlyList<long> ReadOffsets(string indexPath, int expectedColumnIndex, IEnumerable<string> keys)
+        {
+            var keySet = new HashSet<string>(keys, StringComparer.Ordinal);
+            if (keySet.Count == 0)
+            {
+                return Array.Empty<long>();
+            }
+
+            var offsets = new List<long>();
+            using var stream = new FileStream(indexPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1 << 16, FileOptions.SequentialScan);
+            using var reader = new BinaryReader(stream, Encoding.UTF8);
+
+            var magic = reader.ReadBytes(IndexMagic.Length);
+            if (!magic.SequenceEqual(IndexMagic))
+            {
+                throw new InvalidDataException($"Invalid binary relation index artifact magic: {indexPath}");
+            }
+
+            var version = reader.ReadInt32();
+            if (version != 1)
+            {
+                throw new InvalidDataException($"Unsupported binary relation index artifact version {version}: {indexPath}");
+            }
+
+            var columnIndex = reader.ReadInt32();
+            if (columnIndex != expectedColumnIndex)
+            {
+                throw new InvalidDataException($"Binary relation index column mismatch. Expected {expectedColumnIndex}, found {columnIndex}: {indexPath}");
+            }
+
+            var keyCount = reader.ReadInt32();
+            for (var i = 0; i < keyCount; i++)
+            {
+                var key = ReadString(reader);
+                var offsetCount = reader.ReadInt32();
+                if (keySet.Contains(key))
+                {
+                    for (var j = 0; j < offsetCount; j++)
+                    {
+                        offsets.Add(reader.ReadInt64());
+                    }
+                }
+                else
+                {
+                    stream.Position += sizeof(long) * offsetCount;
+                }
+            }
+
+            return offsets;
         }
 
         private static string ResolveDataPath(BinaryRelationArtifactManifest manifest, string manifestPath)
@@ -1775,7 +1960,7 @@ namespace UnifyWeaver.QueryRuntime
         }
     }
 
-    public sealed class BinaryRelationArtifactProvider : IRetentionAwareRelationProvider
+    public sealed class BinaryRelationArtifactProvider : IRetentionAwareRelationProvider, IIndexedRelationProvider
     {
         private readonly IRelationProvider? _fallback;
         private readonly Dictionary<PredicateId, string> _manifestPaths = new();
@@ -1840,6 +2025,29 @@ namespace UnifyWeaver.QueryRuntime
             }
 
             binding = default;
+            return false;
+        }
+
+        public bool TryLookupFacts(PredicateId predicate, int columnIndex, IEnumerable<object> keys, out IEnumerable<object[]> facts)
+        {
+            if (_manifestPaths.TryGetValue(predicate, out var manifestPath))
+            {
+                var manifest = BinaryRelationArtifactReader.LoadManifest(manifestPath);
+                var columnKey = columnIndex.ToString(CultureInfo.InvariantCulture);
+                if (manifest.IndexPaths.ContainsKey(columnKey))
+                {
+                    facts = BinaryRelationArtifactReader.LookupRows(manifest, manifestPath, columnIndex, keys);
+                    return true;
+                }
+            }
+
+            if (_fallback is IIndexedRelationProvider indexedFallback &&
+                indexedFallback.TryLookupFacts(predicate, columnIndex, keys, out facts))
+            {
+                return true;
+            }
+
+            facts = default!;
             return false;
         }
     }
@@ -9246,10 +9454,9 @@ namespace UnifyWeaver.QueryRuntime
             if (parameters is null) throw new ArgumentNullException(nameof(parameters));
             if (context is null) throw new ArgumentNullException(nameof(context));
 
-            var facts = GetScanFactsList(scan.Relation, context, scan);
             if (inputPositions.Count == 0)
             {
-                return facts;
+                return GetScanFactsList(scan.Relation, context, scan);
             }
 
             if (parameters.Count == 0)
@@ -9260,7 +9467,6 @@ namespace UnifyWeaver.QueryRuntime
             if (inputPositions.Count == 1)
             {
                 var columnIndex = inputPositions[0];
-                var index = GetFactIndex(scan.Relation, columnIndex, facts, context);
                 var keys = new HashSet<object>();
 
                 foreach (var paramTuple in parameters)
@@ -9279,10 +9485,19 @@ namespace UnifyWeaver.QueryRuntime
                     keys.Add(value ?? NullFactIndexKey);
                 }
 
+                if (TryLookupIndexedFacts(scan.Relation, columnIndex, keys, out var indexedFacts))
+                {
+                    context.Trace?.RecordStrategy(scan, "IndexedRelationProviderLookup");
+                    return indexedFacts;
+                }
+
+                var scanFacts = GetScanFactsList(scan.Relation, context, scan);
+                var index = GetFactIndex(scan.Relation, columnIndex, scanFacts, context);
                 return EnumerateBuckets(index, keys);
             }
 
-            var joinIndex = GetJoinIndex(scan.Relation, inputPositions, facts, context);
+            var multiColumnFacts = GetScanFactsList(scan.Relation, context, scan);
+            var joinIndex = GetJoinIndex(scan.Relation, inputPositions, multiColumnFacts, context);
             var keySet = new HashSet<RowWrapper>(new RowWrapperComparer(StructuralArrayComparer.Instance));
 
             foreach (var paramTuple in parameters)
@@ -9295,6 +9510,22 @@ namespace UnifyWeaver.QueryRuntime
             }
 
             return EnumerateBuckets(joinIndex, keySet);
+        }
+
+        private bool TryLookupIndexedFacts(
+            PredicateId predicate,
+            int columnIndex,
+            IEnumerable<object> keys,
+            out IEnumerable<object[]> facts)
+        {
+            if (_provider is IIndexedRelationProvider indexedProvider &&
+                indexedProvider.TryLookupFacts(predicate, columnIndex, keys, out facts))
+            {
+                return true;
+            }
+
+            facts = default!;
+            return false;
         }
 
         private static IEnumerable<object[]> EnumerateBuckets(

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -15,6 +15,7 @@ using System.Text.Json;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -100,6 +101,29 @@ namespace UnifyWeaver.QueryRuntime
         char Delimiter = '	',
         int SkipRows = 1,
         int ExpectedWidth = 2);
+
+    public sealed class BinaryRelationArtifactManifest
+    {
+        public const string CurrentFormat = "unifyweaver.binary_relation.v1";
+
+        public string Format { get; set; } = CurrentFormat;
+
+        public int Version { get; set; } = 1;
+
+        public string PredicateName { get; set; } = string.Empty;
+
+        public int Arity { get; set; } = 2;
+
+        public string DataPath { get; set; } = string.Empty;
+
+        public long RowCount { get; set; }
+
+        public string? SourcePath { get; set; }
+
+        public long? SourceLength { get; set; }
+
+        public string? SourceSha256 { get; set; }
+    }
 
     public interface IReplayableRelationSource
     {
@@ -1529,6 +1553,294 @@ namespace UnifyWeaver.QueryRuntime
             }
 
             return _factory().Take(Math.Max(0, maxRows)).ToList();
+        }
+    }
+
+    public static class BinaryRelationArtifactBuilder
+    {
+        public static string BuildFromDelimited(
+            PredicateId predicate,
+            DelimitedRelationSource source,
+            string artifactDirectory,
+            string? artifactName = null)
+        {
+            if (artifactDirectory is null) throw new ArgumentNullException(nameof(artifactDirectory));
+            Directory.CreateDirectory(artifactDirectory);
+
+            artifactName ??= SanitizeArtifactName(predicate);
+            var dataPath = Path.Combine(artifactDirectory, artifactName + ".uwbr");
+            var manifestPath = Path.Combine(artifactDirectory, artifactName + ".uwbr.json");
+
+            var rowCount = BinaryRelationArtifactReader.WriteRows(dataPath, DelimitedRelationReader.ReadRows(source), source.ExpectedWidth);
+            var sourceInfo = File.Exists(source.InputPath)
+                ? new FileInfo(source.InputPath)
+                : null;
+            var manifest = new BinaryRelationArtifactManifest
+            {
+                PredicateName = predicate.Name,
+                Arity = Math.Max(2, source.ExpectedWidth),
+                DataPath = Path.GetFileName(dataPath),
+                RowCount = rowCount,
+                SourcePath = source.InputPath,
+                SourceLength = sourceInfo?.Length,
+                SourceSha256 = sourceInfo is null ? null : ComputeSha256(source.InputPath)
+            };
+
+            var json = JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(manifestPath, json, Encoding.UTF8);
+            return manifestPath;
+        }
+
+        private static string SanitizeArtifactName(PredicateId predicate)
+        {
+            var raw = $"{predicate.Name}_{predicate.Arity}";
+            var builder = new StringBuilder(raw.Length);
+            foreach (var ch in raw)
+            {
+                builder.Append(char.IsLetterOrDigit(ch) || ch == '_' || ch == '-' ? ch : '_');
+            }
+
+            return builder.ToString();
+        }
+
+        private static string ComputeSha256(string path)
+        {
+            using var stream = File.OpenRead(path);
+            var hash = SHA256.HashData(stream);
+            return Convert.ToHexString(hash).ToLowerInvariant();
+        }
+    }
+
+    public static class BinaryRelationArtifactReader
+    {
+        private static readonly byte[] Magic = Encoding.ASCII.GetBytes("UWBR0001");
+
+        public static BinaryRelationArtifactManifest LoadManifest(string manifestPath)
+        {
+            if (manifestPath is null) throw new ArgumentNullException(nameof(manifestPath));
+            var manifest = JsonSerializer.Deserialize<BinaryRelationArtifactManifest>(File.ReadAllText(manifestPath, Encoding.UTF8))
+                ?? throw new InvalidDataException($"Binary relation artifact manifest is empty: {manifestPath}");
+            ValidateManifest(manifest, manifestPath);
+            return manifest;
+        }
+
+        public static IEnumerable<object[]> ReadRows(string manifestPath)
+        {
+            var manifest = LoadManifest(manifestPath);
+            return ReadRows(manifest, manifestPath);
+        }
+
+        public static IEnumerable<object[]> ReadRows(BinaryRelationArtifactManifest manifest, string manifestPath)
+        {
+            if (manifest is null) throw new ArgumentNullException(nameof(manifest));
+            var dataPath = ResolveDataPath(manifest, manifestPath);
+            return ReadRowsFromData(dataPath, manifest.Arity, manifest.RowCount);
+        }
+
+        internal static long WriteRows(string dataPath, IEnumerable<object[]> rows, int width)
+        {
+            if (dataPath is null) throw new ArgumentNullException(nameof(dataPath));
+            if (rows is null) throw new ArgumentNullException(nameof(rows));
+
+            width = Math.Max(2, width);
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(dataPath)) ?? ".");
+            using var stream = new FileStream(dataPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+            using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+            writer.Write(Magic);
+            writer.Write(1);
+            writer.Write(width);
+            writer.Write(0L);
+
+            long rowCount = 0;
+            foreach (var row in rows)
+            {
+                if (row is null || row.Length < width)
+                {
+                    continue;
+                }
+
+                for (var i = 0; i < width; i++)
+                {
+                    WriteString(writer, row[i]?.ToString() ?? string.Empty);
+                }
+
+                rowCount++;
+            }
+
+            writer.Flush();
+            stream.Position = Magic.Length + sizeof(int) + sizeof(int);
+            writer.Write(rowCount);
+            return rowCount;
+        }
+
+        private static IEnumerable<object[]> ReadRowsFromData(string dataPath, int expectedWidth, long expectedRows)
+        {
+            using var stream = new FileStream(dataPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1 << 16, FileOptions.SequentialScan);
+            using var reader = new BinaryReader(stream, Encoding.UTF8);
+
+            var magic = reader.ReadBytes(Magic.Length);
+            if (!magic.SequenceEqual(Magic))
+            {
+                throw new InvalidDataException($"Invalid binary relation artifact magic: {dataPath}");
+            }
+
+            var version = reader.ReadInt32();
+            if (version != 1)
+            {
+                throw new InvalidDataException($"Unsupported binary relation artifact version {version}: {dataPath}");
+            }
+
+            var width = reader.ReadInt32();
+            if (width != expectedWidth)
+            {
+                throw new InvalidDataException($"Binary relation artifact width mismatch. Expected {expectedWidth}, found {width}: {dataPath}");
+            }
+
+            var rowCount = reader.ReadInt64();
+            if (expectedRows >= 0 && rowCount != expectedRows)
+            {
+                throw new InvalidDataException($"Binary relation artifact row-count mismatch. Expected {expectedRows}, found {rowCount}: {dataPath}");
+            }
+
+            for (var rowIndex = 0L; rowIndex < rowCount; rowIndex++)
+            {
+                var row = new object[width];
+                for (var i = 0; i < width; i++)
+                {
+                    row[i] = ReadString(reader);
+                }
+
+                yield return row;
+            }
+        }
+
+        private static string ResolveDataPath(BinaryRelationArtifactManifest manifest, string manifestPath)
+        {
+            var dataPath = manifest.DataPath;
+            if (string.IsNullOrWhiteSpace(dataPath))
+            {
+                throw new InvalidDataException($"Binary relation artifact manifest has no data path: {manifestPath}");
+            }
+
+            return Path.IsPathRooted(dataPath)
+                ? dataPath
+                : Path.Combine(Path.GetDirectoryName(Path.GetFullPath(manifestPath)) ?? ".", dataPath);
+        }
+
+        private static void ValidateManifest(BinaryRelationArtifactManifest manifest, string manifestPath)
+        {
+            if (!string.Equals(manifest.Format, BinaryRelationArtifactManifest.CurrentFormat, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException($"Unsupported binary relation artifact format '{manifest.Format}': {manifestPath}");
+            }
+
+            if (manifest.Version != 1)
+            {
+                throw new InvalidDataException($"Unsupported binary relation artifact manifest version {manifest.Version}: {manifestPath}");
+            }
+
+            if (manifest.Arity < 1)
+            {
+                throw new InvalidDataException($"Binary relation artifact arity must be positive: {manifestPath}");
+            }
+
+            if (manifest.RowCount < 0)
+            {
+                throw new InvalidDataException($"Binary relation artifact row count must be non-negative: {manifestPath}");
+            }
+        }
+
+        private static void WriteString(BinaryWriter writer, string value)
+        {
+            var bytes = Encoding.UTF8.GetBytes(value);
+            writer.Write(bytes.Length);
+            writer.Write(bytes);
+        }
+
+        private static string ReadString(BinaryReader reader)
+        {
+            var length = reader.ReadInt32();
+            if (length < 0)
+            {
+                throw new InvalidDataException("Binary relation artifact contains a negative string length.");
+            }
+
+            var bytes = reader.ReadBytes(length);
+            if (bytes.Length != length)
+            {
+                throw new EndOfStreamException("Binary relation artifact ended while reading a string field.");
+            }
+
+            return Encoding.UTF8.GetString(bytes);
+        }
+    }
+
+    public sealed class BinaryRelationArtifactProvider : IRetentionAwareRelationProvider
+    {
+        private readonly IRelationProvider? _fallback;
+        private readonly Dictionary<PredicateId, string> _manifestPaths = new();
+        private readonly Dictionary<PredicateId, IReplayableRelationSource> _replayableSources = new();
+
+        public BinaryRelationArtifactProvider(IRelationProvider? fallback = null)
+        {
+            _fallback = fallback;
+        }
+
+        public void RegisterArtifact(PredicateId predicate, string manifestPath)
+        {
+            if (manifestPath is null) throw new ArgumentNullException(nameof(manifestPath));
+            var manifest = BinaryRelationArtifactReader.LoadManifest(manifestPath);
+            if (!string.Equals(manifest.PredicateName, predicate.Name, StringComparison.Ordinal) ||
+                manifest.Arity != predicate.Arity)
+            {
+                throw new InvalidDataException($"Binary relation artifact manifest describes {manifest.PredicateName}/{manifest.Arity}, not {predicate}.");
+            }
+
+            _manifestPaths[predicate] = manifestPath;
+            _replayableSources.Remove(predicate);
+        }
+
+        public IEnumerable<object[]> GetFacts(PredicateId predicate)
+        {
+            if (_manifestPaths.TryGetValue(predicate, out var manifestPath))
+            {
+                return BinaryRelationArtifactReader.ReadRows(manifestPath);
+            }
+
+            return _fallback?.GetFacts(predicate) ?? Array.Empty<object[]>();
+        }
+
+        public bool TryBindRelation(PredicateId predicate, RelationRetentionMode preferredMode, out RelationBinding binding)
+        {
+            if (_manifestPaths.TryGetValue(predicate, out var manifestPath))
+            {
+                if (preferredMode == RelationRetentionMode.Replayable)
+                {
+                    if (!_replayableSources.TryGetValue(predicate, out var source))
+                    {
+                        source = new ReplayableRelationSource(() => BinaryRelationArtifactReader.ReadRows(manifestPath));
+                        _replayableSources[predicate] = source;
+                    }
+
+                    binding = new RelationBinding(RelationRetentionMode.Replayable, ReplayableSource: source);
+                    return true;
+                }
+
+                if (preferredMode == RelationRetentionMode.ExternalMaterialized)
+                {
+                    binding = new RelationBinding(RelationRetentionMode.ExternalMaterialized);
+                    return true;
+                }
+            }
+
+            if (_fallback is IRetentionAwareRelationProvider retentionAwareFallback &&
+                retentionAwareFallback.TryBindRelation(predicate, preferredMode, out binding))
+            {
+                return true;
+            }
+
+            binding = default;
+            return false;
         }
     }
 


### PR DESCRIPTION
  ## Summary

  This PR adds a first C# query-runtime prototype for preprocessed binary relation artifacts.

  It introduces a binary relation artifact format with JSON manifests, `.uwbr` data files, and per-column offset index sidecars. Artifact-backed predicates can now participate through the existing relation
  provider boundaries and can serve indexed single-column parameter probes without materializing the full relation first.

  ## What Changed

  - Added `BinaryRelationArtifactManifest`, `BinaryRelationArtifactBuilder`, `BinaryRelationArtifactReader`, and `BinaryRelationArtifactProvider`.
  - Added `IIndexedRelationProvider` for provider-level indexed fact lookups.
  - Updated parameterized `RelationScanNode` execution to use indexed provider lookups when available.
  - Extended `benchmark_scan_materialization.py` with:
    - `--source-modes preload,delimited,artifact`
    - `bound_scan` mode for parameterized scan probes
    - internal C# elapsed-time reporting instead of Python process wall time
  - Updated the preprocessed predicate artifacts proposal with prototype status.

  ## Benchmark Signal

  Focused benchmark command:

  ```bash
  python3 examples/benchmark/benchmark_scan_materialization.py --scales 300,10k --modes bound_scan,scan,join --source-modes preload,artifact --strategies auto --repetitions 3
  ```
  Observed targeted lookup improvement:

  - 300 bound_scan artifact: median 0.013s vs preload 0.028s
  - 10k bound_scan artifact: median 0.016s vs preload 0.029s
  - Artifact bound scans report RelationScanNode:IndexedRelationProviderLookup=1

  Plain scans and joins are still mixed or slower because they still materialize rows from the artifact. This PR establishes the indexed artifact seam and shows payoff for bound/probe workloads; broader
  planner integration and scan-oriented artifact optimization should remain follow-up work.

  ## Validation

  - dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c Release --nologo
  - python3 -m py_compile examples/benchmark/benchmark_scan_materialization.py
  - python3 examples/benchmark/benchmark_scan_materialization.py --scales 300,10k --modes bound_scan,scan,join --source-modes preload,artifact --strategies auto --repetitions 3
  - git diff --check HEAD~2..HEAD

  ## Notes

  The full Prolog-driven C# query suite was not run to completion because it was taking too long for this loop and had already surfaced unrelated STRATEGY_USED:* closure-pair expectation mismatches. This
  branch is validated with targeted runtime build and artifact benchmark coverage.