### PR TITLE
feat(wam-elixir): Phase B inline_data emission + fact-stream runtime

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -16,7 +16,9 @@
     classify_predicate/4,         % +PredIndicator, +Segments, +Options, -Info
     clause_count/2,               % +Segments, -N
     fact_only/2,                  % +Segments, -Bool
-    first_arg_groundness/3        % +Segments, +Arity, -Status
+    first_arg_groundness/3,       % +Segments, +Arity, -Status
+    % Phase B fact extraction. Exported so tests can exercise it.
+    extract_facts/3               % +Segments, +Arity, -ElixirListLiteral
 ]).
 
 :- use_module(library(lists)).
@@ -29,25 +31,42 @@
 % ============================================================================
 
 %% lower_predicate_to_elixir(+PredIndicator, +WamCode, +Options, -Code)
+%
+%  Dispatches on the Phase-A classification layout:
+%    - `compiled`    — emit one `defp` per clause (unchanged path)
+%    - `inline_data` — emit `@facts [{...}, ...]` and a single
+%      `run/1` that delegates to `WamRuntime.stream_facts/3`
+%    - `external_source` — Phase D, currently falls back to `compiled`
+%
+%  Falling back to `compiled` is always safe and preserves correctness,
+%  so an extraction failure (e.g., a compound head arg we can\'t yet
+%  represent inline) silently falls back instead of erroring.
 lower_predicate_to_elixir(Pred/Arity, WamCode, Options, Code) :-
     atom_string(WamCode, WamStr),
     split_string(WamStr, "\n", "", Lines),
     collect_labels(Lines, 1, Labels),
     split_into_segments(Lines, 1, Segments),
-    generate_all_segments(Segments, Labels, FuncCodes),
-    atomic_list_concat(FuncCodes, '\n\n', FuncsBody),
     atom_string(Pred, PredStr),
     camel_case(PredStr, CamelPred),
     option(module_name(ModName), Options, 'WamPredLow'),
     camel_case(ModName, CamelMod),
-    Segments = [FirstSegName-_|_],
-    segment_func_name(FirstSegName, FirstFunc),
-    % Phase A: classify the predicate and record the chosen layout as a
-    % module-level comment. Phase A emits every predicate via the
-    % existing `compiled` path regardless of the chosen layout — this
-    % is observation-only. Phase B switches on Info.layout.
     classify_predicate(Pred/Arity, Segments, Options, Info),
     format_fact_shape_comment(Info, ShapeComment),
+    Info = fact_shape_info(_, _, _, Layout),
+    (   Layout = inline_data(_),
+        catch(extract_facts(Segments, Arity, FactsLiteral), _, fail)
+    ->  render_inline_data_module(CamelMod, CamelPred, PredStr, Arity,
+                                  ShapeComment, FactsLiteral, Code)
+    ;   render_compiled_module(CamelMod, CamelPred, PredStr, Arity,
+                               ShapeComment, Segments, Labels, Code)
+    ).
+
+render_compiled_module(CamelMod, CamelPred, PredStr, Arity, ShapeComment,
+                       Segments, Labels, Code) :-
+    generate_all_segments(Segments, Labels, FuncCodes),
+    atomic_list_concat(FuncCodes, '\n\n', FuncsBody),
+    Segments = [FirstSegName-_|_],
+    segment_func_name(FirstSegName, FirstFunc),
     format(string(Code),
 'defmodule ~w.~w do
   @moduledoc "Lowered WAM-compiled predicate: ~w/~w"
@@ -65,12 +84,6 @@ lower_predicate_to_elixir(Pred/Arity, WamCode, Options, Code) :-
 
   def run(args) when is_list(args) do
     state = %WamRuntime.WamState{code: {}, labels: %{}, pc: 1}
-    # Rewrite each caller-supplied unbound to a fresh make_ref so the id
-    # cannot collide with any register slot — subsequent put_variable on
-    # the same A-reg would otherwise corrupt the binding chain. Remember
-    # the refs in state.arg_vars so run/1 and next_solution/1 can read
-    # the correct bound value even after body code has used the A-reg as
-    # scratch.
     {state, arg_vars} = Enum.with_index(args, 1)
     |> Enum.reduce({state, []}, fn {arg, i}, {s, vars} ->
       case arg do
@@ -81,9 +94,6 @@ lower_predicate_to_elixir(Pred/Arity, WamCode, Options, Code) :-
           {%{s | regs: Map.put(s.regs, i, other)}, vars}
       end
     end)
-    # state.cp holds the current continuation — a function of
-    # `(state) -> {:ok, state} | :fail`. At the top level we terminate
-    # in WamRuntime.terminal_cp/1 which just returns {:ok, state}.
     state = %{state | arg_vars: arg_vars, cp: &WamRuntime.terminal_cp/1}
     try do
       case run(state) do
@@ -101,6 +111,54 @@ lower_predicate_to_elixir(Pred/Arity, WamCode, Options, Code) :-
 
 ~w
 end', [CamelMod, CamelPred, PredStr, Arity, ShapeComment, FirstFunc, CamelPred, FuncsBody]).
+
+render_inline_data_module(CamelMod, CamelPred, PredStr, Arity, ShapeComment,
+                          FactsLiteral, Code) :-
+    format(string(Code),
+'defmodule ~w.~w do
+  @moduledoc "Lowered WAM-compiled predicate: ~w/~w (inline_data)"
+
+~w
+
+  # Phase-B inline_data layout: facts live as a module attribute, not as
+  # per-fact defp functions. run/1 delegates to WamRuntime.stream_facts,
+  # which iterates @facts, attempts unification on each tuple, and
+  # pushes a fact-stream CP on success so backtracking resumes at the
+  # next tuple. :_var in a tuple slot means the head arg was a variable
+  # — it unifies trivially with any incoming value.
+  @facts ~w
+
+  def run(%WamRuntime.WamState{} = state) do
+    WamRuntime.stream_facts(state, @facts, ~w)
+  end
+
+  def run(args) when is_list(args) do
+    state = %WamRuntime.WamState{code: {}, labels: %{}, pc: 1}
+    {state, arg_vars} = Enum.with_index(args, 1)
+    |> Enum.reduce({state, []}, fn {arg, i}, {s, vars} ->
+      case arg do
+        {:unbound, _} ->
+          v = {:unbound, make_ref()}
+          {%{s | regs: Map.put(s.regs, i, v)}, [{i, v} | vars]}
+        other ->
+          {%{s | regs: Map.put(s.regs, i, other)}, vars}
+      end
+    end)
+    state = %{state | arg_vars: arg_vars, cp: &WamRuntime.terminal_cp/1}
+    try do
+      case run(state) do
+        {:ok, final} -> {:ok, WamRuntime.materialise_args(final)}
+        other -> other
+      end
+    catch
+      {:fail, _} -> :fail
+      {:return, result} -> result
+      error ->
+        IO.puts("Predicate ~w CRASHED: #{inspect(error)}")
+        :fail
+    end
+  end
+end', [CamelMod, CamelPred, PredStr, Arity, ShapeComment, FactsLiteral, Arity, CamelPred]).
 
 % ============================================================================
 % PHASE A: FACT-SHAPE CLASSIFICATION
@@ -187,9 +245,66 @@ pick_layout(_PredIndicator, NClauses, FactOnly, Options, Layout) :-
 %  Info to pick the emission path.
 format_fact_shape_comment(fact_shape_info(N, FactOnly, FirstArg, Layout), Comment) :-
     format(string(Comment),
-'  # Phase-A fact-shape classification (observation-only):
+'  # Fact-shape classification:
   #   clauses=~w fact_only=~w first_arg=~w layout=~w',
            [N, FactOnly, FirstArg, Layout]).
+
+% ============================================================================
+% PHASE B: INLINE_DATA FACT EXTRACTION
+% ============================================================================
+%
+% Walks each clause\'s instruction list to build an Elixir tuple of the
+% head args. Constants (from `get_constant`) become quoted strings.
+% Variables (from `get_variable`) become `:_var`, meaning the head was
+% a variable at that slot and any incoming value unifies trivially.
+% Compound args (`get_structure` / `get_list`) are not representable
+% inline yet — extraction fails and the caller falls back to `compiled`.
+
+%% extract_facts(+Segments, +Arity, -ElixirLiteral)
+%  ElixirLiteral is a string like "[\n    {\"a\", \"b\"},\n    ...\n  ]"
+%  suitable for dropping into a module attribute.
+extract_facts(Segments, Arity, ElixirLiteral) :-
+    maplist(extract_clause_tuple(Arity), Segments, TupleLiterals),
+    (   TupleLiterals = []
+    ->  ElixirLiteral = '[]'
+    ;   atomic_list_concat(TupleLiterals, ',\n    ', Joined),
+        format(string(ElixirLiteral), '[\n    ~w\n  ]', [Joined])
+    ).
+
+extract_clause_tuple(Arity, _Name-Instrs, TupleLiteral) :-
+    numlist(1, Arity, Slots),
+    maplist(extract_arg_value(Instrs), Slots, Values),
+    atomic_list_concat(Values, ', ', Inner),
+    format(string(TupleLiteral), '{~w}', [Inner]).
+
+extract_arg_value(Instrs, Slot, ElixirVal) :-
+    format(string(AStr), 'A~w', [Slot]),
+    (   member(_-get_constant(C, AStr), Instrs)
+    ->  elixir_string_literal(C, ElixirVal)
+    ;   member(_-get_variable(_, AStr), Instrs)
+    ->  ElixirVal = ':_var'
+    ;   member(_-get_value(_, AStr), Instrs)
+    ->  ElixirVal = ':_var'
+    ;   % get_structure / get_list / anything else → unrepresentable;
+        % fail the whole extraction so lower_predicate_to_elixir/4
+        % falls back to the compiled path.
+        fail
+    ).
+
+%% elixir_string_literal(+RawString, -Literal)
+%  Wraps the raw WAM operand in double quotes, escaping backslashes and
+%  embedded double-quotes so the result is a valid Elixir string.
+elixir_string_literal(C, Literal) :-
+    (   atom(C) -> atom_string(C, CStr) ; CStr = C ),
+    string_chars(CStr, Chars),
+    maplist(escape_elixir_char, Chars, NestedChars),
+    append(NestedChars, EscapedChars),
+    string_chars(Escaped, EscapedChars),
+    format(string(Literal), '"~w"', [Escaped]).
+
+escape_elixir_char('\\', ['\\', '\\']).
+escape_elixir_char('"', ['\\', '"']).
+escape_elixir_char(C, [C]).
 
 % ============================================================================
 % LABEL COLLECTION

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -378,20 +378,35 @@ compile_backtrack_to_elixir(Code) :-
         |> Map.put(:trail_len, cp.trail_len)
         |> Map.put(:choice_points, rest)
 
-        if is_function(cp.pc) do
-          # The retried clause may throw {:fail, thrown_state} (its own
-          # guards failed, with CPs accumulated during its body) or
-          # {:return, result} (it succeeded). Translate back into the
-          # {:ok, state} | :fail contract so the caller does not need to
-          # know about clause-local control flow.
-          try do
-            cp.pc.(state)
-          catch
-            {:fail, thrown_state} -> backtrack(thrown_state)
-            {:return, result} -> result
-          end
-        else
-          {:ok, state}
+        cond do
+          is_function(cp.pc) ->
+            # The retried clause may throw {:fail, thrown_state} (its own
+            # guards failed, with CPs accumulated during its body) or
+            # {:return, result} (it succeeded). Translate back into the
+            # {:ok, state} | :fail contract so the caller does not need to
+            # know about clause-local control flow.
+            try do
+              cp.pc.(state)
+            catch
+              {:fail, thrown_state} -> backtrack(thrown_state)
+              {:return, result} -> result
+            end
+
+          match?({:fact_stream, _, _}, cp.pc) ->
+            # Phase-B fact-stream CP: resume iteration over the remaining
+            # tail of the fact list. The snapshot already restored regs /
+            # trail / heap to their pre-unify state, so resume_fact_stream
+            # just needs to attempt the next fact.
+            {:fact_stream, remaining, arity} = cp.pc
+            try do
+              resume_fact_stream(state, remaining, arity)
+            catch
+              {:fail, thrown_state} -> backtrack(thrown_state)
+              {:return, result} -> result
+            end
+
+          true ->
+            {:ok, state}
         end
     end
   end', []).
@@ -506,6 +521,83 @@ compile_utility_helpers_to_elixir(Code) :-
   contract.
   """
   def terminal_cp(state), do: {:ok, state}
+
+  @doc """
+  Phase-B fact-stream entry point. Called by an `inline_data`-layout
+  predicate\'s `run/1` with the module\'s `@facts` literal. Iterates the
+  list, attempts to unify each tuple with state.regs[1..arity], and on
+  success pushes a fact-stream CP (shape `{:fact_stream, remaining,
+  arity}`) so backtracking resumes at the next tuple. Emits the driver
+  contract via state.cp — same as a CPS-lowered clause after a
+  successful head unify.
+  """
+  def stream_facts(state, facts, arity) do
+    resume_fact_stream(state, facts, arity)
+  end
+
+  @doc """
+  Resume a fact-stream scan from the current list tail. Called both from
+  `stream_facts/3` (initial call) and from `backtrack/1` (after popping
+  a fact-stream CP). Empty list → `{:fail, state}` propagates to the
+  caller; caller\'s outer catch routes to `backtrack`.
+  """
+  def resume_fact_stream(state, [], _arity), do: throw({:fail, state})
+  def resume_fact_stream(state, [tuple | rest], arity) do
+    trail_mark = state.trail_len
+    case try_unify_fact_tuple(state, tuple, 1, arity) do
+      {:ok, bound_state} ->
+        # Push a CP snapshotting PRE-unify state. On later backtrack,
+        # unwind_trail(trail_mark) rolls back any bindings we just made.
+        cp = %{
+          pc: {:fact_stream, rest, arity},
+          regs: state.regs,
+          heap: state.heap,
+          heap_len: state.heap_len,
+          cp: state.cp,
+          trail: state.trail,
+          trail_len: trail_mark,
+          stack: state.stack
+        }
+        s_with_cp = %{bound_state | choice_points: [cp | bound_state.choice_points]}
+        s_with_cp.cp.(s_with_cp)
+
+      :fail ->
+        # Partial unify may have bound regs before failing — roll back
+        # to the pre-attempt trail mark so `rest` is tried on clean state.
+        cleaned = unwind_trail(state, trail_mark)
+        resume_fact_stream(cleaned, rest, arity)
+    end
+  end
+
+  defp try_unify_fact_tuple(state, _tuple, i, arity) when i > arity, do: {:ok, state}
+  defp try_unify_fact_tuple(state, tuple, i, arity) do
+    element = elem(tuple, i - 1)
+    case element do
+      :_var ->
+        # Head was a variable — any incoming value unifies trivially.
+        try_unify_fact_tuple(state, tuple, i + 1, arity)
+
+      value ->
+        reg_val = deref_var(state, Map.get(state.regs, i))
+        case reg_val do
+          {:unbound, _} ->
+            # Caller left this arg unbound. Bind it to the fact\'s value
+            # via put_reg so the trail records it and the binding is
+            # undoable on backtrack.
+            {:unbound, id} = reg_val
+            s2 = state
+                 |> trail_binding(id)
+                 |> put_reg(id, value)
+            try_unify_fact_tuple(s2, tuple, i + 1, arity)
+
+          bound when bound == value ->
+            try_unify_fact_tuple(state, tuple, i + 1, arity)
+
+          _ ->
+            :fail
+        end
+    end
+  end
 
   @doc "Read `len` consecutive heap cells starting at `start`."
   def heap_slice(_state, _start, 0), do: []

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -5,7 +5,7 @@
 :- use_module('../src/unifyweaver/targets/wam_elixir_target').
 :- use_module('../src/unifyweaver/targets/wam_target').
 :- use_module('../src/unifyweaver/targets/wam_elixir_lowered_emitter',
-              [lower_predicate_to_elixir/4, classify_predicate/4]).
+              [lower_predicate_to_elixir/4, classify_predicate/4, extract_facts/3]).
 
 :- dynamic test_failed/0.
 
@@ -278,7 +278,7 @@ test_shape_comment_in_generated_module :-
     phase_a_fixture_setup,
     wam_target:compile_predicate_to_wam(phase_a_test:big_fact/2, [], WamCode),
     lower_predicate_to_elixir(big_fact/2, WamCode, [module_name('TestMod')], Code),
-    (   sub_string(Code, _, _, _, 'Phase-A fact-shape classification'),
+    (   sub_string(Code, _, _, _, 'Fact-shape classification'),
         sub_string(Code, _, _, _, 'clauses=150'),
         sub_string(Code, _, _, _, 'fact_only=true'),
         sub_string(Code, _, _, _, 'layout=inline_data')
@@ -287,15 +287,74 @@ test_shape_comment_in_generated_module :-
     ).
 
 test_phase_a_preserves_compiled_output :-
-    Test = 'Phase A: generated module still uses compiled defps (no behaviour change)',
+    Test = 'Phase A: small predicate with default threshold uses compiled defps',
     phase_a_fixture_setup,
-    wam_target:compile_predicate_to_wam(phase_a_test:big_fact/2, [], WamCode),
-    lower_predicate_to_elixir(big_fact/2, WamCode, [module_name('TestMod')], Code),
-    % Even though layout=inline_data, Phase A still emits defp clauses
+    wam_target:compile_predicate_to_wam(phase_a_test:small_fact/2, [], WamCode),
+    lower_predicate_to_elixir(small_fact/2, WamCode, [module_name('TestMod')], Code),
     (   sub_string(Code, _, _, _, 'defp clause_'),
         sub_string(Code, _, _, _, 'def run(%WamRuntime.WamState{}')
     ->  pass(Test)
     ;   fail_test(Test, 'expected compiled-shape output not present')
+    ).
+
+%% Phase B inline_data emission tests
+
+test_extract_facts_simple :-
+    Test = 'Phase B: extract_facts yields tuple list for fact-only predicate',
+    phase_a_fixture_setup,
+    wam_target:compile_predicate_to_wam(phase_a_test:small_fact/2, [], WamCode),
+    atom_string(WamCode, WamStr),
+    split_string(WamStr, "\n", "", Lines),
+    wam_elixir_lowered_emitter:split_into_segments(Lines, 1, Segments),
+    extract_facts(Segments, 2, Literal),
+    (   sub_string(Literal, _, _, _, '{"a", "1"}'),
+        sub_string(Literal, _, _, _, '{"d", "4"}')
+    ->  pass(Test)
+    ;   fail_test(Test, Literal)
+    ).
+
+test_phase_b_emits_inline_data_when_chosen :-
+    Test = 'Phase B: inline_data layout emits @facts and no defp clauses',
+    phase_a_fixture_setup,
+    wam_target:compile_predicate_to_wam(phase_a_test:big_fact/2, [], WamCode),
+    lower_predicate_to_elixir(big_fact/2, WamCode, [module_name('TestMod')], Code),
+    (   sub_string(Code, _, _, _, '@facts ['),
+        sub_string(Code, _, _, _, 'WamRuntime.stream_facts(state, @facts, 2)'),
+        \+ sub_string(Code, _, _, _, 'defp clause_')
+    ->  pass(Test)
+    ;   fail_test(Test, 'expected inline_data shape missing or leaked defp')
+    ).
+
+test_phase_b_variable_head_becomes_sentinel :-
+    Test = 'Phase B: variable head arg emits :_var sentinel',
+    phase_a_fixture_setup,
+    % Force variable_head/1 to inline_data via low threshold.
+    wam_target:compile_predicate_to_wam(phase_a_test:variable_head/1, [], WamCode),
+    lower_predicate_to_elixir(variable_head/1, WamCode,
+                              [module_name('TestMod'), fact_count_threshold(0)], Code),
+    (   sub_string(Code, _, _, _, ':_var'),
+        sub_string(Code, _, _, _, '@facts ['),
+        \+ sub_string(Code, _, _, _, 'defp clause_')
+    ->  pass(Test)
+    ;   fail_test(Test, 'variable_head did not lower to :_var sentinel')
+    ).
+
+test_phase_b_fallback_on_unextractable :-
+    Test = 'Phase B: unextractable fact falls back to compiled (safe default)',
+    phase_a_fixture_setup,
+    % Inject a compound-head fact; extraction should fail and fall back.
+    retractall(phase_a_test:compound_head(_)),
+    assertz((phase_a_test:compound_head(foo(1, 2)))),
+    wam_target:compile_predicate_to_wam(phase_a_test:compound_head/1, [], WamCode),
+    % Force inline_data via override, but extraction should fail and
+    % lower_predicate_to_elixir/4 falls through to compiled.
+    lower_predicate_to_elixir(compound_head/1, WamCode,
+                              [module_name('TestMod'),
+                               fact_layout(compound_head/1, inline_data([]))], Code),
+    (   sub_string(Code, _, _, _, 'defp clause_'),
+        \+ sub_string(Code, _, _, _, '@facts [')
+    ->  pass(Test)
+    ;   fail_test(Test, 'expected fallback to compiled did not occur')
     ).
 
 %% Test runner
@@ -324,5 +383,9 @@ run_tests :-
     test_classify_user_override_threshold,
     test_shape_comment_in_generated_module,
     test_phase_a_preserves_compiled_output,
+    test_extract_facts_simple,
+    test_phase_b_emits_inline_data_when_chosen,
+    test_phase_b_variable_head_becomes_sentinel,
+    test_phase_b_fallback_on_unextractable,
     format('~n=== WAM-Elixir Target Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).


### PR DESCRIPTION
## Summary

Implements Phase B from
[`docs/proposals/WAM_FACT_SHAPE_PLAN.md`](../docs/proposals/WAM_FACT_SHAPE_PLAN.md).
Phase A classified predicates and reported the chosen layout as a
comment; this PR actually emits the `inline_data` layout when chosen
and adds the runtime to back it.

A fact-only predicate with 6000 clauses now produces a module with one
`def run/1` body and an `@facts [{...}, {...}]` module attribute
instead of 6000 `defp` functions.

## Why

PR #1511 set up the classification machinery; it was observation-only.
Phase B takes the observed classification and uses it: dispatch the
emitter on `Info.layout`, emit `@facts` for `inline_data`, and teach
`backtrack/1` to iterate that list with a fact-stream choice point
shape.

## What's in this PR

### Emitter (`wam_elixir_lowered_emitter.pl`)

- **`extract_facts/3`** walks each segment's instruction list to build
  the head-arg tuple:
  - `get_constant(C, A_i)` → `"C"` (quoted, with `\\` and `"`
    escaping).
  - `get_variable(_, A_i)` / `get_value(_, A_i)` → `:_var` sentinel
    (head was a variable, unify trivially).
  - Anything else (compounds, `raw/1`) → extraction fails, caller
    falls back to `compiled`. Silent fallback keeps correctness —
    every predicate remains loadable.
- **`lower_predicate_to_elixir/4`** splits into
  `render_compiled_module/8` (unchanged body) and
  `render_inline_data_module/7` (new). Dispatch on
  `Info.layout = inline_data(_) ∧ extract_facts` succeeds; else
  fall through to compiled.
- `@facts` is a list of Elixir tuples; `run/1` is one line:
  `WamRuntime.stream_facts(state, @facts, arity)`.
  `run(args)` wrapper is identical to the compiled path.

### Runtime (`wam_elixir_target.pl`)

- **`WamRuntime.stream_facts/3`** / **`resume_fact_stream/3`** —
  iterate the list. On each attempt:
  1. `trail_mark = state.trail_len`.
  2. Unify regs[1..arity] with tuple positions via
     `try_unify_fact_tuple/4`. Caller-unbound regs get bound via
     `trail_binding/2 |> put_reg/3` so the binding is undoable.
  3. Success → push CP `{pc: {:fact_stream, rest, arity}, ...}`,
     tail-call `state.cp.(state)`.
  4. Fail → `unwind_trail(state, trail_mark)` and recurse on `rest`.
- **`backtrack/1`** gains a `cond` dispatch: `is_function(cp.pc)`
  keeps the existing catch path (CPS-lowered defp retry),
  `match?({:fact_stream, _, _}, cp.pc)` calls `resume_fact_stream/3`.
  Same `{:fail, s} / {:return, r}` catch contract in both branches.

### Sample output

```elixir
defmodule WamElixirBench.CategoryParent do
  @moduledoc "Lowered WAM-compiled predicate: category_parent/2 (inline_data)"

  # Fact-shape classification:
  #   clauses=198 fact_only=true first_arg=all_ground layout=inline_data([])

  @facts [
    {"Abstraction", "Thought"},
    {"Abstraction", "Concepts"},
    ...
  ]

  def run(%WamRuntime.WamState{} = state) do
    WamRuntime.stream_facts(state, @facts, 2)
  end

  def run(args) when is_list(args) do
    # ... unchanged arg-prep wrapper ...
  end
end
```

No per-clause `defp`. 198 facts at dev scale → ~9.5 KB module;
Elixir loads it in milliseconds instead of seconds.

## End-to-end verification

**Reproducer** (`examples/debug_wam_elixir_ancestor.pl`) — 4/1/4
correct solutions. parent/2 stays `compiled` (below default threshold
of 100), so this exercises the unchanged path.

**Forced inline_data probe** — parent/2 with
`fact_count_threshold(1)`; ancestor/2 still `compiled`. Mixed-path
enumeration:

```
=== parent("b", Y) ===
  Y="c"
=== ancestor("a", Y) — enumerate ===
  Y="b"
  Y="c"
  Y="d"
  Y="e"
  total: 4
```

`parent` ran through `@facts` + `stream_facts` + fact-stream
backtracking; `ancestor` reached it via the normal CPS chain and
recursed correctly.

**Dev-scale effective_distance benchmark** — `category_parent.ex`
drops from a few-hundred-defp module (seconds to compile) to a
9.5 KB inline_data module (milliseconds). Benchmark runs past module
load to the pre-existing `String.to_integer("2.0")` driver issue,
which is the same failure point as before this PR — not a Phase B
regression.

## Known limitations

- **Scale-300 `category_parent/2` still falls back to `compiled`.**
  76 of 6008 facts have commas in their atom names
  (`'Washington,_D.C.'`). The existing WAM-line parser splits those
  on the comma and falls through to `raw/1`. `extract_facts` can't
  pull a clean tuple from `raw/1`, so the whole predicate falls back.
  The fix belongs in the WAM emitter / line parser (proper atom
  quoting), not in Phase B. The fallback is honest and the module
  still compiles — just without the inline_data benefit.
- **No first-arg indexing.** Phase B is linear scan. Phase C adds
  `@facts_by_arg1` and indexed lookup.
- **No compound-head facts.** Phase C (or later) adds compound
  representation (structures with positional children).

## Test plan

- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_target.pl`
      — **26/26** (was 22 after Phase A; adds 4 new Phase B tests)
- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_utils.pl`
      — 7/7
- [x] `swipl -q -s examples/debug_wam_elixir_ancestor.pl -t halt`
      — 4/1/4 solutions with correct N values
- [x] End-to-end probe exercising inline_data via
      `fact_count_threshold(1)` — parent @facts + ancestor recursion
      enumerates 4 correct solutions.

New Phase B tests:

1. `extract_facts` yields the expected tuple list for a fact-only
   predicate.
2. `inline_data` layout emits `@facts` and **no** `defp clause_*`.
3. Variable-head fact lowers to `:_var` sentinel.
4. Unextractable compound-head fact falls back to `compiled`
   (safe default).

## Related

- PR #1507 — design docs (philosophy/spec/plan). This PR implements
  Phase B of that plan.
- PR #1511 — Phase A classification. This PR flips on the emission
  path Phase A was preparing for.
- #1500 — CPS continuations. Orthogonal: non-tail recursion lives
  in the `compiled` path, unchanged here.
- #1505 — Prolog-side codegen perf. Made scale-300 observable in the
  first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
