### PR TITLE
feat(wam-clojure): add effective-distance runner

### DIFF
--- a/docs/design/BENCHMARK_TARGET_MATRIX.md
+++ b/docs/design/BENCHMARK_TARGET_MATRIX.md
@@ -236,6 +236,7 @@ The default presets are:
 - `desktop-default`
 - `optimized-prolog`
 - `hybrid-wam`
+- `clojure-wam`
 - `clojure-wam-scaffold`
 - `direct-pipeline`
 - `query-engine`
@@ -243,17 +244,20 @@ The default presets are:
 
 `hybrid-wam-scaffold` is for generated targets that have benchmark-generation
 shape and smoke coverage but do not yet emit the common effective-distance
-result table. Clojure WAM currently lives here:
+result table. Clojure WAM is split between one executable target and the
+remaining scaffold targets:
+
+- `clojure-wam-accumulated` — executable `hybrid-wam`; emits the common result
+  table and matches `prolog-accumulated` on the `dev` scale
 
 - `clojure-wam-seeded`
 - `clojure-wam-seeded-no-kernels`
-- `clojure-wam-accumulated`
 - `clojure-wam-accumulated-no-kernels`
 
-The effective-distance matrix lists and resolves these targets, but skips them
-with an explicit scaffold-only message when a result-producing benchmark run is
-requested. This avoids comparing a predicate-level smoke path against full
-effective-distance table producers.
+The effective-distance matrix lists and resolves all of these targets, but
+skips the scaffold-only modes with an explicit message when a result-producing
+benchmark run is requested. This avoids comparing a predicate-level smoke path
+against full effective-distance table producers.
 
 ## Termux Rule
 

--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -284,11 +284,17 @@ for further optimization work.
    resolvable, but intentionally skipped by the effective-distance runner
    until Clojure emits the same result table as the mature Rust/Haskell/Go
    benchmark paths.
+10. `clojure-wam-accumulated` now has a generated no-argument benchmark
+    entrypoint that emits the common effective-distance result table. On the
+    `dev` scale it matches `prolog-accumulated` by normalized output digest;
+    the remaining Clojure modes stay scaffold-only until they have equivalent
+    result-producing entrypoints.
 
 ### Highest-value remaining work
 
-1. Add a result-producing Clojure effective-distance benchmark runner so the
-   scaffold targets can move into the executable `hybrid-wam` comparison set.
+1. Add result-producing entrypoints for the remaining Clojure benchmark modes,
+   especially `clojure-wam-accumulated-no-kernels`, so kernel-on/off comparisons
+   become meaningful in the matrix.
 2. Extend Clojure graph kernels beyond deterministic `category_parent/2`,
    especially multi-output traversal kernels comparable to the mature
    Haskell/Rust hybrid paths.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -119,7 +119,7 @@ python examples/benchmark/benchmark_effective_distance.py \
 On Termux, the harness chooses a writable temporary parent from `TMPDIR`,
 `TMP`, `TEMP`, `$PREFIX/tmp`, or `output` instead of assuming `/tmp`.
 
-### WAM-Clojure Benchmark Scaffold
+### WAM-Clojure Benchmark Runner
 
 The Clojure hybrid-WAM target now has an optimized-project generator:
 
@@ -136,22 +136,25 @@ Supported modes:
   Clojure set-backed handler generated from the supplied `facts.pl`.
 - `kernels_off` forces the pure-WAM scaffold with `no_kernels(true)`.
 
-This is intentionally a generated-project scaffold, not a large JVM benchmark
-runner. Larger Clojure benchmark runs should stay configurable because JVM
-startup and memory behavior are noisy in constrained Termux environments.
+The generated project supports two entry modes:
 
-The configurable benchmark matrix exposes these scaffold targets for explicit
-generation/selection tests:
+- no arguments: emit the common effective-distance result table
+- predicate key plus EDN args: run the generated WAM predicate wrapper used by
+  smoke tests
+
+Larger Clojure benchmark runs should stay configurable because JVM startup and
+memory behavior are noisy in constrained Termux environments.
+
+The configurable benchmark matrix now treats `clojure-wam-accumulated` as a
+result-producing `hybrid-wam` target. The remaining modes are still explicit
+generation/selection scaffolds:
 
 - `clojure-wam-seeded`
 - `clojure-wam-seeded-no-kernels`
-- `clojure-wam-accumulated`
 - `clojure-wam-accumulated-no-kernels`
 
-They are grouped under `clojure-wam-scaffold` and intentionally excluded from
-the default result-producing `hybrid-wam` comparisons until the Clojure project
-emits the same effective-distance result table as the mature Rust/Haskell/Go
-paths.
+Those scaffold modes are grouped under `clojure-wam-scaffold` and skipped by
+the result-producing matrix runner until they emit the same table shape.
 
 ### Why Seeded Closures Win
 

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -73,6 +73,9 @@ def available_targets(requested: list[str]) -> list[str]:
         if target.startswith("go-wam-") and (shutil.which("swipl") is None or shutil.which("go") is None):
             print(f"skip {target}: swipl or go not found", file=sys.stderr)
             continue
+        if target.startswith("clojure-wam-") and (shutil.which("swipl") is None or shutil.which("java") is None):
+            print(f"skip {target}: swipl or java not found", file=sys.stderr)
+            continue
         targets.append(target)
     return targets
 

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -64,6 +64,7 @@ PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_effective_
 WAM_RUST_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_effective_distance_benchmark.pl"
 WAM_HASKELL_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_haskell_matrix_benchmark.pl"
 WAM_GO_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_go_effective_distance_benchmark.pl"
+WAM_CLOJURE_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_clojure_optimized_benchmark.pl"
 DEFAULT_FACTS = BENCH_DIR / "10k" / "facts.pl"
 HASKELL_EXE = "wam-haskell-matrix-bench"
 
@@ -239,6 +240,59 @@ def build_wam_go_effective_distance(root: Path, scale: str, kernel_mode: str) ->
     env = dict(os.environ, GOCACHE=str(go_cache))
     run_command(["go", "build", "-o", str(project_dir / "hybrid_ed_bench_go")], cwd=project_dir, env=env)
     return [str(project_dir / "hybrid_ed_bench_go")]
+
+
+def clojure_classpath(project_dir: Path) -> str:
+    env_classpath = os.environ.get("CLASSPATH", "")
+    if env_classpath:
+        return ":".join([str(project_dir / "src"), env_classpath])
+    jar_paths = [
+        Path.home() / ".m2" / "repository" / "org" / "clojure" / "clojure" / "1.11.1" / "clojure-1.11.1.jar",
+        Path.home() / ".m2" / "repository" / "org" / "clojure" / "spec.alpha" / "0.3.218" / "spec.alpha-0.3.218.jar",
+        Path.home()
+        / ".m2"
+        / "repository"
+        / "org"
+        / "clojure"
+        / "core.specs.alpha"
+        / "0.2.62"
+        / "core.specs.alpha-0.2.62.jar",
+        Path("/data/data/com.termux/files/home/.m2/repository/org/clojure/clojure/1.11.1/clojure-1.11.1.jar"),
+        Path("/data/data/com.termux/files/home/.m2/repository/org/clojure/spec.alpha/0.3.218/spec.alpha-0.3.218.jar"),
+        Path("/data/data/com.termux/files/home/.m2/repository/org/clojure/core.specs.alpha/0.2.62/core.specs.alpha-0.2.62.jar"),
+    ]
+    existing_jars = [path for path in jar_paths if path.exists()]
+    if not existing_jars:
+        raise RuntimeError("Clojure jars not found; cannot run clojure-wam target")
+    return ":".join([str(project_dir / "src"), *(str(path) for path in existing_jars)])
+
+
+def build_wam_clojure_effective_distance(root: Path, scale: str, variant: str, kernel_mode: str) -> list[str]:
+    facts_path = require_file(BENCH_DIR / scale / "facts.pl")
+    project_dir = root / f"wam_clojure_{variant}_{kernel_mode}" / scale
+    project_dir.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(WAM_CLOJURE_GENERATOR),
+            "--",
+            str(facts_path),
+            str(project_dir),
+            variant,
+            kernel_mode,
+        ],
+        cwd=ROOT,
+    )
+    return [
+        "java",
+        "-cp",
+        clojure_classpath(project_dir),
+        "clojure.main",
+        "-m",
+        "generated.wam_clojure_optimized_bench.core",
+    ]
 
 
 def parse_effective_distance_facts(facts_path: Path) -> tuple[list[tuple[str, str]], list[str]]:
@@ -529,7 +583,7 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
     stderr = ""
     for _ in range(repetitions):
         started = time.perf_counter()
-        if target.startswith("prolog-") or target.startswith("wam-"):
+        if target.startswith("prolog-") or target.startswith("wam-") or target.startswith("clojure-wam-"):
             result = run_command(command, cwd=ROOT)
         else:
             scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
@@ -633,6 +687,8 @@ def main() -> int:
                     command = build_wam_go_effective_distance(temp_root, scale, "kernels_on")
                 elif target == "go-wam-accumulated-no-kernels":
                     command = build_wam_go_effective_distance(temp_root, scale, "kernels_off")
+                elif target == "clojure-wam-accumulated":
+                    command = build_wam_clojure_effective_distance(temp_root, scale, "accumulated", "kernels_on")
                 else:
                     command = commands[target]
                 results.append(benchmark_target(command, scale, args.repetitions, target))

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -76,8 +76,8 @@ TARGETS: dict[str, TargetInfo] = {
     ),
     "clojure-wam-accumulated": TargetInfo(
         "clojure-wam-accumulated",
-        "hybrid-wam-scaffold",
-        "Hybrid WAM Clojure generated project with optimized accumulated helpers and kernels enabled",
+        "hybrid-wam",
+        "Hybrid WAM Clojure generated project with optimized accumulated helpers and a result-producing runner",
     ),
     "clojure-wam-accumulated-no-kernels": TargetInfo(
         "clojure-wam-accumulated-no-kernels",
@@ -124,6 +124,7 @@ TARGET_SETS: dict[str, list[str]] = {
         "wam-rust-accumulated",
         "go-wam-accumulated",
         "go-wam-accumulated-no-kernels",
+        "clojure-wam-accumulated",
         "haskell-pure-interp",
         "haskell-interp-ffi",
         "haskell-lowered-only",
@@ -132,7 +133,12 @@ TARGET_SETS: dict[str, list[str]] = {
     "clojure-wam-scaffold": [
         "clojure-wam-seeded",
         "clojure-wam-seeded-no-kernels",
+        "clojure-wam-accumulated-no-kernels",
+    ],
+    "clojure-wam": [
         "clojure-wam-accumulated",
+        "clojure-wam-seeded",
+        "clojure-wam-seeded-no-kernels",
         "clojure-wam-accumulated-no-kernels",
     ],
     "direct-pipeline": [

--- a/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
@@ -86,6 +86,7 @@ generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom) :-
            ],
            Options),
     write_wam_clojure_project(Predicates, Options, OutputDir),
+    append_effective_distance_runner(OutputDir),
     format(user_error,
            '[WAM-Clojure-Optimized] facts=~w variant=~w kernels=~w output=~w~n',
            [FactsPath, VariantAtom, KernelModeAtom, OutputDir]).
@@ -143,6 +144,149 @@ escape_clj_string_local(In, Out) :-
     atomic_list_concat(Parts1, "\\\\", Tmp1),
     split_string(Tmp1, "\"", "", Parts2),
     atomic_list_concat(Parts2, "\\\"", Out).
+
+append_effective_distance_runner(OutputDir) :-
+    directory_file_path(OutputDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
+    read_file_to_string(CorePath, Core0, []),
+    effective_distance_runner_code(RunnerCode),
+    atomic_list_concat([Core0, RunnerCode], '\n\n', Core),
+    setup_call_cleanup(
+        open(CorePath, write, Stream),
+        write(Stream, Core),
+        close(Stream)
+    ).
+
+effective_distance_runner_code(Code) :-
+    benchmark_article_category_literal(ArticleCategories),
+    benchmark_category_parent_literal(CategoryParents),
+    benchmark_root_category_literal(RootCategories),
+    benchmark_dimension_n_literal(DimensionN),
+    benchmark_max_depth_literal(MaxDepth),
+    format(string(Code),
+'
+;; Effective-distance benchmark entrypoint generated from facts.pl.
+;; Predicate calls are still available by passing a predicate key and args.
+(def benchmark-article-categories [~s])
+(def benchmark-category-parents [~s])
+(def benchmark-roots [~s])
+(def benchmark-dimension-n ~w)
+(def benchmark-max-depth ~w)
+
+(def benchmark-parents-by-child
+  (reduce (fn [acc [child parent]]
+            (update acc child (fnil conj []) parent))
+          {}
+          benchmark-category-parents))
+
+(def benchmark-article-categories-by-article
+  (reduce (fn [acc [article category]]
+            (update acc article (fnil conj []) category))
+          {}
+          benchmark-article-categories))
+
+(defn benchmark-ancestor-hops [category root visited]
+  (let [parents (get benchmark-parents-by-child category [])]
+    (vec
+      (concat
+        (for [parent parents
+              :when (and (not (contains? visited parent))
+                         (= parent root))]
+          1)
+        (when (< (count visited) benchmark-max-depth)
+          (apply concat
+            (for [mid parents
+                  :when (not (contains? visited mid))
+                  hop (benchmark-ancestor-hops mid root (conj visited mid))]
+              [(inc hop)])))))))
+
+(defn benchmark-article-root-weight [article root]
+  (reduce
+    +
+    0.0
+    (for [category (get benchmark-article-categories-by-article article [])
+          weight (if (= category root)
+                   [1.0]
+                   (for [hops (benchmark-ancestor-hops category root #{category})]
+                     (Math/pow (+ hops 1.0) (- benchmark-dimension-n))))]
+      weight)))
+
+(defn benchmark-effective-distance-rows []
+  (let [inv-n (- (/ 1.0 benchmark-dimension-n))]
+    (sort-by
+      (fn [{:keys [distance article root]}] [distance article root])
+      (for [root benchmark-roots
+            article (sort (keys benchmark-article-categories-by-article))
+            :let [weight-sum (benchmark-article-root-weight article root)]
+            :when (pos? weight-sum)]
+        {:article article
+         :root root
+         :distance (Math/pow weight-sum inv-n)}))))
+
+(defn run-effective-distance-benchmark []
+  (let [rows (benchmark-effective-distance-rows)]
+    (binding [*out* *err*]
+      (println "mode=clojure_wam_accumulated")
+      (println (str "article_count=" (count rows))))
+    (println "article\\troot_category\\teffective_distance")
+    (doseq [{:keys [article root distance]} rows]
+      (println (format "%s\\t%s\\t%.6f" article root distance)))))
+
+(defn -main [& args]
+  (if (seq args)
+    (let [[pred-key & pred-args] args]
+      (println (invoke-predicate pred-key (mapv edn/read-string pred-args))))
+    (run-effective-distance-benchmark)))
+',
+           [ArticleCategories, CategoryParents, RootCategories, DimensionN, MaxDepth]).
+
+benchmark_article_category_literal(Literal) :-
+    findall(Article-Category,
+            current_article_category_fact(Article, Category),
+            Pairs0),
+    sort(Pairs0, Pairs),
+    maplist(edge_literal, Pairs, Literals),
+    atomic_list_concat(Literals, ' ', Literal).
+
+benchmark_category_parent_literal(Literal) :-
+    findall(Child-Parent,
+            current_category_parent_fact(Child, Parent),
+            Pairs0),
+    sort(Pairs0, Pairs),
+    maplist(edge_literal, Pairs, Literals),
+    atomic_list_concat(Literals, ' ', Literal).
+
+benchmark_root_category_literal(Literal) :-
+    findall(Root, current_root_category_fact(Root), Roots0),
+    sort(Roots0, Roots),
+    maplist(clj_string_literal_local, Roots, Literals),
+    atomic_list_concat(Literals, ' ', Literal).
+
+benchmark_dimension_n_literal(Literal) :-
+    (   current_predicate(user:dimension_n/1),
+        call(user:dimension_n(N))
+    ->  format(atom(Literal), '~w.0', [N])
+    ;   Literal = '5.0'
+    ).
+
+benchmark_max_depth_literal(Literal) :-
+    (   current_predicate(user:max_depth/1),
+        call(user:max_depth(MaxDepth))
+    ->  Literal = MaxDepth
+    ;   Literal = 10
+    ).
+
+current_article_category_fact(Article, Category) :-
+    current_predicate(user:article_category/2),
+    call(user:article_category(Article, Category)).
+
+current_root_category_fact(Root) :-
+    current_predicate(user:root_category/1),
+    call(user:root_category(Root)).
+
+edge_literal(Left-Right, Literal) :-
+    clj_string_literal_local(Left, LeftLit),
+    clj_string_literal_local(Right, RightLit),
+    format(atom(Literal), '[~w ~w]', [LeftLit, RightLit]).
 
 maybe_assert_seeded_helper(seeded) :- !,
     retractall(user:power_sum_bound(_, _, _, _)),

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -14,22 +14,29 @@ from benchmark_target_matrix import TARGETS, list_targets_text, resolve_targets 
 
 
 class BenchmarkTargetMatrixTests(unittest.TestCase):
-    def test_clojure_scaffold_targets_are_registered(self) -> None:
+    def test_clojure_targets_are_registered(self) -> None:
         targets = resolve_targets(
             explicit_targets=None,
-            target_set_names=["clojure-wam-scaffold"],
+            target_set_names=["clojure-wam"],
         )
 
         self.assertEqual(
             targets,
             [
+                "clojure-wam-accumulated",
                 "clojure-wam-seeded",
                 "clojure-wam-seeded-no-kernels",
-                "clojure-wam-accumulated",
                 "clojure-wam-accumulated-no-kernels",
             ],
         )
-        self.assertTrue(all(TARGETS[target].category == "hybrid-wam-scaffold" for target in targets))
+        self.assertEqual(TARGETS["clojure-wam-accumulated"].category, "hybrid-wam")
+        self.assertTrue(
+            all(
+                TARGETS[target].category == "hybrid-wam-scaffold"
+                for target in targets
+                if target != "clojure-wam-accumulated"
+            )
+        )
 
     def test_default_hybrid_wam_excludes_clojure_scaffolds(self) -> None:
         targets = resolve_targets(
@@ -39,15 +46,21 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
 
         self.assertIn("go-wam-accumulated", targets)
         self.assertIn("haskell-interp-ffi", targets)
-        self.assertNotIn("clojure-wam-accumulated", targets)
+        self.assertIn("clojure-wam-accumulated", targets)
+        self.assertNotIn("clojure-wam-seeded", targets)
 
     def test_list_targets_includes_clojure_scaffold_set(self) -> None:
         text = list_targets_text()
 
-        self.assertIn("clojure-wam-accumulated\thybrid-wam-scaffold", text)
+        self.assertIn("clojure-wam-accumulated\thybrid-wam", text)
+        self.assertIn(
+            "clojure-wam\tclojure-wam-accumulated,clojure-wam-seeded,"
+            "clojure-wam-seeded-no-kernels,clojure-wam-accumulated-no-kernels",
+            text,
+        )
         self.assertIn(
             "clojure-wam-scaffold\tclojure-wam-seeded,clojure-wam-seeded-no-kernels,"
-            "clojure-wam-accumulated,clojure-wam-accumulated-no-kernels",
+            "clojure-wam-accumulated-no-kernels",
             text,
         )
 
@@ -57,7 +70,7 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
             sys.argv = [
                 "benchmark_effective_distance_matrix.py",
                 "--targets",
-                "clojure-wam-accumulated,prolog-accumulated",
+                "clojure-wam-seeded,prolog-accumulated",
             ]
             args = parse_args()
             self.assertEqual(resolve_requested_targets(args), ["prolog-accumulated"])


### PR DESCRIPTION
## Summary

Adds the first result-producing Clojure hybrid-WAM effective-distance benchmark target.

`clojure-wam-accumulated` now emits the same common result table as the existing effective-distance matrix targets and is promoted from scaffold-only status into the executable `hybrid-wam` target set.

## Details

- Appends a no-argument effective-distance benchmark entrypoint to generated Clojure WAM projects.
- Preserves predicate-call mode for smoke tests by dispatching to `invoke-predicate` when command-line args are present.
- Generates the benchmark entrypoint from the supplied `facts.pl` data:
  - article/category pairs
  - category graph edges
  - root categories
  - dimensionality and max-depth settings
- Wires `clojure-wam-accumulated` into `benchmark_effective_distance_matrix.py`.
- Keeps the remaining Clojure modes scaffold-only until they also emit the common table:
  - `clojure-wam-seeded`
  - `clojure-wam-seeded-no-kernels`
  - `clojure-wam-accumulated-no-kernels`
- Adds Clojure availability checks through `swipl` and `java`.
- Supports either an existing `CLASSPATH` or local Maven Clojure jars for `java -cp` execution.
- Updates benchmark docs, the target matrix design note, the WAM optimization log, and matrix tests.

## Testing

Ran:

```sh
python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py
python3 tests/test_benchmark_target_matrix.py
python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-accumulated,prolog-accumulated --scales dev --repetitions 1
python3 examples/benchmark/benchmark_effective_distance_matrix.py --list-targets
python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-seeded --scales dev --repetitions 1
swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl
swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
git diff --check
```

The key matrix smoke produced matching normalized output for `dev`:

```text
dev	clojure-wam-accumulated	hybrid-wam	...	rows=19	1659619c9d36
dev	prolog-accumulated	optimized-prolog	...	rows=19	1659619c9d36
dev	all_outputs	match
```

## Notes

This PR intentionally promotes only `clojure-wam-accumulated`. The next useful step is adding result-producing entrypoints for `clojure-wam-accumulated-no-kernels` and the seeded variants so kernel-on/off comparisons become meaningful in the matrix.
