### PR TITLE
fix(wam): quote atoms with separator chars in serialised WAM text

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -307,13 +307,71 @@ escape_elixir_char('"', ['\\', '"']).
 escape_elixir_char(C, [C]).
 
 % ============================================================================
+% QUOTE-AWARE LINE TOKENIZATION
+% ============================================================================
+%
+% The WAM text uses ` `, `,`, `\t` as token separators. Atoms containing
+% those characters (e.g. `'Washington,_D.C.'`) are wrapped in single
+% quotes by `wam_target:quote_wam_constant/2`. This tokenizer recognises
+% the quotes, strips them, and honours `\'` / `\\` escapes so quoted
+% tokens reparse to the original atom text.
+%
+% Unquoted tokens pass through unchanged — keeping hot paths (identifier
+% atoms like `A1` or labels like `L_parent_2_2`) as cheap as the previous
+% split_string-based code.
+
+%% tokenize_wam_line(+Line, -Tokens)
+%  `Line` is any string or atom; `Tokens` is a list of strings, in order,
+%  with separators removed and quoted regions unquoted/unescaped.
+tokenize_wam_line(Line, Tokens) :-
+    (   string(Line) -> LineStr = Line ; atom_string(Line, LineStr) ),
+    string_chars(LineStr, Chars),
+    tokenize_chars(Chars, Tokens).
+
+tokenize_chars([], []).
+tokenize_chars([C | Rest], Tokens) :-
+    (   wam_separator_char(C)
+    ->  tokenize_chars(Rest, Tokens)
+    ;   C == '\''
+    ->  read_quoted_chars(Rest, TokenChars, Remainder),
+        string_chars(Token, TokenChars),
+        Tokens = [Token | RestTokens],
+        tokenize_chars(Remainder, RestTokens)
+    ;   read_unquoted_chars([C | Rest], TokenChars, Remainder),
+        string_chars(Token, TokenChars),
+        Tokens = [Token | RestTokens],
+        tokenize_chars(Remainder, RestTokens)
+    ).
+
+wam_separator_char(' ').
+wam_separator_char('\t').
+wam_separator_char(',').
+
+read_quoted_chars([], [], []).             % unterminated quote — yield what we have
+read_quoted_chars(['\'' | Rest], [], Rest).
+read_quoted_chars(['\\', Escaped | Rest], [Real | More], Remainder) :-
+    !,
+    unescape_wam_char(Escaped, Real),
+    read_quoted_chars(Rest, More, Remainder).
+read_quoted_chars([C | Rest], [C | More], Remainder) :-
+    read_quoted_chars(Rest, More, Remainder).
+
+unescape_wam_char('\'', '\'').
+unescape_wam_char('\\', '\\').
+unescape_wam_char(C, C).
+
+read_unquoted_chars([], [], []).
+read_unquoted_chars([C | Rest], [], [C | Rest]) :- wam_separator_char(C), !.
+read_unquoted_chars([C | Rest], [C | More], Remainder) :-
+    read_unquoted_chars(Rest, More, Remainder).
+
+% ============================================================================
 % LABEL COLLECTION
 % ============================================================================
 
 collect_labels([], _, []).
 collect_labels([Line|Rest], PC, OutLabels) :-
-    split_string(Line, " \t,", " \t,", Parts),
-    delete(Parts, "", CleanParts),
+    tokenize_wam_line(Line, CleanParts),
     (   CleanParts = [First|_], is_label_part(First)
     ->  sub_string(First, 0, _, 1, LabelName),
         OutLabels = [LabelName-PC|RestLabels],
@@ -330,8 +388,7 @@ collect_labels([Line|Rest], PC, OutLabels) :-
 
 split_into_segments([], _, []).
 split_into_segments([Line|Rest], PC, Segments) :-
-    split_string(Line, " \t,", " \t,", Parts),
-    delete(Parts, "", CleanParts),
+    tokenize_wam_line(Line, CleanParts),
     (   CleanParts == [] -> split_into_segments(Rest, PC, Segments)
     ;   CleanParts = [First|_], is_label_part(First)
     ->  sub_string(First, 0, _, 1, LabelName),
@@ -345,8 +402,7 @@ split_into_segments([Line|Rest], PC, Segments) :-
 
 extract_segment_body([], PC, [], [], PC).
 extract_segment_body([Line|Rest], PC, Body, Next, NPC) :-
-    split_string(Line, " \t,", " \t,", Parts),
-    delete(Parts, "", CleanParts),
+    tokenize_wam_line(Line, CleanParts),
     (   CleanParts = [First|_], is_label_part(First)
     ->  Body = [], Next = [Line|Rest], NPC = PC
     ;   CleanParts == [] -> extract_segment_body(Rest, PC, Body, Next, NPC)

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -13,7 +13,10 @@
     compile_facts_to_wam/3,              % +Pred, +Arity, -WAMCode
     compile_wam_module/3,                % +Predicates, +Options, -WAMCode
     write_wam_program/2,                 % +Code, +Filename
-    init_wam_target/0                    % Initialize target
+    init_wam_target/0,                   % Initialize target
+    % WAM constant quoting — exported so downstream tokenizers can
+    % share the same rules (see wam_elixir_lowered_emitter:tokenize_wam_line/2).
+    quote_wam_constant/2                 % +Value, -QuotedString
 ]).
 
 :- use_module(library(lists)).
@@ -233,8 +236,66 @@ build_constant_index_on([Head-_|Rest], ArgPos, I, Pred, Arity, [Val-Label|RestEn
     build_constant_index_on(Rest, ArgPos, NextI, Pred, Arity, RestEntries).
 
 format_index_entries(Entries, Str) :-
-    maplist([K-V, S]>>format(atom(S), "~w:~w", [K, V]), Entries, Parts),
+    maplist([K-V, S]>>(quote_wam_constant(K, KStr),
+                       format(atom(S), "~w:~w", [KStr, V])),
+            Entries, Parts),
     atomic_list_concat(Parts, ', ', Str).
+
+% ---------------------------------------------------------------------------
+% Constant quoting
+% ---------------------------------------------------------------------------
+%
+% The symbolic WAM text uses ` `, `,`, and `\t` as token separators and
+% `:` as the key/label separator inside `switch_on_constant` entries.
+% Prolog atoms freely contain any of those characters, so a naive
+% `~w` serialisation produces output the downstream line tokenizer
+% cannot reparse (`get_constant Washington,_D.C., A1` splits on the
+% embedded comma and emits a `raw/1` catch-all).
+%
+% `quote_wam_constant/2` wraps constants that need quoting in
+% single quotes, escaping embedded `'` as `\'` and `\` as `\\`.
+% Unambiguous unquoted atoms (identifier-like, numeric) pass through
+% unchanged, keeping the common case readable.
+%
+% Downstream tokenizers (see `wam_elixir_lowered_emitter:tokenize_wam_line/2`)
+% must recognise the same quote syntax.
+
+%% quote_wam_constant(+Value, -QuotedString)
+%  Value is an atom, string, or number. QuotedString is a string
+%  suitable to embed after `get_constant`, `put_constant`, etc.
+quote_wam_constant(Value, Quoted) :-
+    (   number(Value)
+    ->  format(string(Quoted), "~w", [Value])
+    ;   ( atom(Value) -> atom_string(Value, Str) ; Str = Value ),
+        (   constant_needs_quoting(Str)
+        ->  escape_for_wam_quoting(Str, Escaped),
+            format(string(Quoted), "'~w'", [Escaped])
+        ;   Quoted = Str
+        )
+    ).
+
+constant_needs_quoting("") :- !.
+constant_needs_quoting(Str) :-
+    string_chars(Str, Chars),
+    member(C, Chars),
+    separator_or_special_char(C), !.
+
+separator_or_special_char(' ').
+separator_or_special_char('\t').
+separator_or_special_char(',').
+separator_or_special_char(':').
+separator_or_special_char('\'').
+separator_or_special_char('\\').
+
+escape_for_wam_quoting(Str, Escaped) :-
+    string_chars(Str, Chars),
+    maplist(escape_wam_char, Chars, NestedChars),
+    append(NestedChars, EscChars),
+    string_chars(Escaped, EscChars).
+
+escape_wam_char('\\', ['\\', '\\']).
+escape_wam_char('\'', ['\\', '\'']).
+escape_wam_char(C, [C]).
 
 %% compile_single_clause_wam(+Clause, +Options, -Code)
 compile_single_clause_wam(Head-Body, Options, Code) :-
@@ -405,7 +466,8 @@ compile_head_argument(Arg, I, V0, V1, Code) :-
             format(string(Code), "    get_variable ~w, A~w", [XReg, I])
         )
     ;   atomic(Arg)
-    ->  format(string(Code), "    get_constant ~w, A~w", [Arg, I]),
+    ->  quote_wam_constant(Arg, ArgStr),
+        format(string(Code), "    get_constant ~w, A~w", [ArgStr, I]),
         V1 = V0
     ;   is_list_term(Arg)
     ->  Arg = [H|T],
@@ -436,7 +498,8 @@ compile_unify_arguments([Arg|Rest], V0, Vf, Code) :-
             format(string(ArgCode), "    unify_variable ~w", [XReg])
         )
     ;   atomic(Arg)
-    ->  format(string(ArgCode), "    unify_constant ~w", [Arg]),
+    ->  quote_wam_constant(Arg, ArgStr),
+        format(string(ArgCode), "    unify_constant ~w", [ArgStr]),
         V1 = V0
     ;   % Nested structure — emit unify_variable for a temp register,
         % then get_structure + unify_* for the nested sub-arguments.
@@ -845,7 +908,8 @@ compile_put_argument(Arg, I, V0, V1, Code) :-
             format(string(Code), "    put_variable ~w, A~w", [XReg, I])
         )
     ;   atomic(Arg)
-    ->  format(string(Code), "    put_constant ~w, A~w", [Arg, I]),
+    ->  quote_wam_constant(Arg, ArgStr),
+        format(string(Code), "    put_constant ~w, A~w", [ArgStr, I]),
         V1 = V0
     ;   is_list_term(Arg)
     ->  Arg = [H|T],
@@ -891,7 +955,8 @@ compile_set_arguments([Arg|Rest], V0, Vf, Code) :-
     ;   atomic(Arg)
     ->  % For atomic sub-args, emit set_constant directly
         V1 = V0,
-        format(string(ArgCode), "    set_constant ~w", [Arg])
+        quote_wam_constant(Arg, ArgStr),
+        format(string(ArgCode), "    set_constant ~w", [ArgStr])
     ;   % Nested compound — recursively emit put_structure + set_* for sub-args
         compound(Arg)
     ->  Arg =.. [F|NestedArgs],

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -357,6 +357,72 @@ test_phase_b_fallback_on_unextractable :-
     ;   fail_test(Test, 'expected fallback to compiled did not occur')
     ).
 
+%% WAM constant quoting tests
+
+:- dynamic phase_a_test:comma_atom/2.
+
+test_quote_wam_constant_plain :-
+    Test = 'Quoting: identifier-like atom passes through unquoted',
+    wam_target:quote_wam_constant('foo_bar_123', Str),
+    (   Str == "foo_bar_123"
+    ->  pass(Test)
+    ;   fail_test(Test, Str)
+    ).
+
+test_quote_wam_constant_comma :-
+    Test = 'Quoting: atom containing comma is single-quoted',
+    wam_target:quote_wam_constant('Has,comma', Str),
+    (   Str == "'Has,comma'"
+    ->  pass(Test)
+    ;   fail_test(Test, Str)
+    ).
+
+test_quote_wam_constant_escape :-
+    Test = 'Quoting: atom containing single-quote is escaped',
+    wam_target:quote_wam_constant('it\'s', Str),
+    (   Str == "'it\\'s'"
+    ->  pass(Test)
+    ;   fail_test(Test, Str)
+    ).
+
+test_tokenize_unquoted :-
+    Test = 'Tokenizer: plain line splits on spaces and commas',
+    wam_elixir_lowered_emitter:tokenize_wam_line("    get_constant foo, A1", Tokens),
+    (   Tokens == ["get_constant", "foo", "A1"]
+    ->  pass(Test)
+    ;   fail_test(Test, Tokens)
+    ).
+
+test_tokenize_quoted_atom_with_comma :-
+    Test = 'Tokenizer: quoted atom containing comma stays one token',
+    wam_elixir_lowered_emitter:tokenize_wam_line("    get_constant 'Has,comma', A1", Tokens),
+    (   Tokens == ["get_constant", "Has,comma", "A1"]
+    ->  pass(Test)
+    ;   fail_test(Test, Tokens)
+    ).
+
+test_tokenize_quoted_atom_with_escape :-
+    Test = 'Tokenizer: quoted atom with \\\' escape unquotes to literal',
+    wam_elixir_lowered_emitter:tokenize_wam_line("    get_constant 'it\\'s', A1", Tokens),
+    (   Tokens == ["get_constant", "it's", "A1"]
+    ->  pass(Test)
+    ;   fail_test(Test, Tokens)
+    ).
+
+test_round_trip_comma_atom :-
+    Test = 'Round trip: atom with comma survives WAM-text -> tokenizer',
+    retractall(phase_a_test:comma_atom(_, _)),
+    assertz((phase_a_test:comma_atom('Has,comma', value))),
+    wam_target:compile_predicate_to_wam(phase_a_test:comma_atom/2, [], WamCode),
+    lower_predicate_to_elixir(comma_atom/2, WamCode,
+                              [module_name('TestMod'), fact_count_threshold(0)], Code),
+    % Should reach inline_data and emit the atom as an Elixir string.
+    (   sub_string(Code, _, _, _, '{"Has,comma", "value"}'),
+        \+ sub_string(Code, _, _, _, 'raw:')
+    ->  pass(Test)
+    ;   fail_test(Test, 'comma-atom round-trip failed')
+    ).
+
 %% Test runner
 
 run_tests :-
@@ -387,5 +453,12 @@ run_tests :-
     test_phase_b_emits_inline_data_when_chosen,
     test_phase_b_variable_head_becomes_sentinel,
     test_phase_b_fallback_on_unextractable,
+    test_quote_wam_constant_plain,
+    test_quote_wam_constant_comma,
+    test_quote_wam_constant_escape,
+    test_tokenize_unquoted,
+    test_tokenize_quoted_atom_with_comma,
+    test_tokenize_quoted_atom_with_escape,
+    test_round_trip_comma_atom,
     format('~n=== WAM-Elixir Target Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).


### PR DESCRIPTION
## Summary

The symbolic WAM text uses ` `, `,`, `\t` as token separators and `:` as
the key/label separator inside `switch_on_constant` entries. Prolog
atoms freely contain any of those characters — `'Washington,_D.C.'`,
`'Fluid mechanics'`, `'it\'s'`. The old emitter wrote them with `~w`
(no quoting), so the downstream line tokenizer split them on the
embedded comma/space and the instruction fell back to `raw/1`. Those
`raw/1` clauses emitted `raise "TODO"` (broken at runtime) and also
defeated Phase-B `extract_facts/3` (inline_data silently fell back to
`compiled`).

Fix in two places that share the same quoting rules.

## Why

At scale 300 of the `effective_distance` benchmark, 76 / 6008 facts
in `category_parent/2` contain commas in atom names. **1.3% of
clauses broke 100% of the predicate** — inline_data fell back, the
generated module stayed at 6.9 MB, and the host Elixir compiler
couldn't load it in ten minutes.

This PR is the last gap between Phase B merging and the
effective-distance workload actually benefiting from the fact-shape
architecture.

## What's in this PR

### `wam_target.pl`: `quote_wam_constant/2`

Atoms whose string representation contains any of ` `, `\t`, `,`,
`:`, `'`, or `\\` get wrapped in single quotes. Embedded `'` and `\`
are escaped with backslashes.

Routed through at every constant-emitting call site:
- `get_constant`
- `put_constant`
- `set_constant`
- `unify_constant`
- `switch_on_constant` entries (via `format_index_entries/2`)

Identifier-like atoms (`foo_bar_123`, `A1`, `L_parent_2_2`) and
numbers pass through unchanged. Hot paths emit byte-identical output.

### `wam_elixir_lowered_emitter.pl`: `tokenize_wam_line/2`

A quote-aware line tokenizer that replaces the three
`split_string(Line, " \\t,", " \\t,", Parts)` sites in
`collect_labels/3`, `split_into_segments/3`, and
`extract_segment_body/5`.

Char-by-char scan:
- Skip separator chars.
- On `'`, read until unescaped `'`, handle `\'` → `'` and `\\` → `\`,
  return the contents as one token.
- Otherwise, read until next separator.

## Before / after

Scale-300 `category_parent/2` (6008 facts, 76 with commas):

| metric                         | before         | after         |
| ------------------------------ | -------------- | ------------- |
| layout chosen                  | inline_data    | inline_data   |
| layout actually emitted        | **compiled**   | **inline_data** |
| `category_parent.ex` size      | 6.9 MB         | 336 KB        |
| Elixir module load time        | > 10 minutes   | ~1.1 sec      |
| First query works              | (never loaded) | ✓ `"17th_century"` |

Ancestor reproducer output is bit-identical (parent/2 uses simple
atoms, never needed quoting).

## Test plan

- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_target.pl`
      — **33/33** (adds 7: three `quote_wam_constant`, three
      `tokenize_wam_line`, one end-to-end round-trip).
- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_utils.pl`
      — 7/7
- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_target.pl`
      — 7/7
- [x] `swipl -q -s examples/debug_wam_elixir_ancestor.pl -t halt`
      — 4/1/4 solutions with correct N
- [x] Scale-300 `category_parent/2` load test: loads in 1.1 s and
      answers `category_parent("1640s", Y)` correctly with first
      solution `"17th_century"`.

## Non-goals

- Other WAM targets (Go, Clojure, Haskell, Rust, C#-native) have
  their own tokenizers; this PR only updates the Elixir target. If
  they turn out to have the same bug, they can adopt the shared
  `quote_wam_constant/2` from `wam_target.pl` and add their own
  quote-aware tokenizer.
- Structured / compound constants (e.g. `foo(1, 2)`) are not
  affected. The quoting rules apply only to atomic constants.

## Related

- PR #1519 (Phase B) — this was the specific parser bug noted as a
  Phase-B blocker that now unblocks scale-300 inline_data.
- PR #1511 (Phase A) — classification infrastructure.
- PR #1507 — the fact-shape design doc this advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
