### PR TITLE
feat(wam-clojure): enable no-kernels benchmark runner

### DIFF
--- a/docs/design/BENCHMARK_TARGET_MATRIX.md
+++ b/docs/design/BENCHMARK_TARGET_MATRIX.md
@@ -244,15 +244,16 @@ The default presets are:
 
 `hybrid-wam-scaffold` is for generated targets that have benchmark-generation
 shape and smoke coverage but do not yet emit the common effective-distance
-result table. Clojure WAM is split between one executable target and the
-remaining scaffold targets:
+result table. Clojure WAM is split between executable accumulated targets and
+remaining seeded scaffold targets:
 
 - `clojure-wam-accumulated` — executable `hybrid-wam`; emits the common result
   table and matches `prolog-accumulated` on the `dev` scale
+- `clojure-wam-accumulated-no-kernels` — executable `hybrid-wam`; same result
+  table with `no_kernels(true)` for kernel-on/off comparison
 
 - `clojure-wam-seeded`
 - `clojure-wam-seeded-no-kernels`
-- `clojure-wam-accumulated-no-kernels`
 
 The effective-distance matrix lists and resolves all of these targets, but
 skips the scaffold-only modes with an explicit message when a result-producing

--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -289,12 +289,15 @@ for further optimization work.
     `dev` scale it matches `prolog-accumulated` by normalized output digest;
     the remaining Clojure modes stay scaffold-only until they have equivalent
     result-producing entrypoints.
+11. `clojure-wam-accumulated-no-kernels` is now also executable in the matrix.
+    On `dev`, both accumulated Clojure modes and `prolog-accumulated` produce
+    the same normalized digest, which gives a valid Clojure kernel-on/off
+    comparison surface.
 
 ### Highest-value remaining work
 
-1. Add result-producing entrypoints for the remaining Clojure benchmark modes,
-   especially `clojure-wam-accumulated-no-kernels`, so kernel-on/off comparisons
-   become meaningful in the matrix.
+1. Add result-producing entrypoints for the seeded Clojure benchmark modes so
+   seeded/accumulated comparisons are available in the matrix.
 2. Extend Clojure graph kernels beyond deterministic `category_parent/2`,
    especially multi-output traversal kernels comparable to the mature
    Haskell/Rust hybrid paths.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -145,13 +145,16 @@ The generated project supports two entry modes:
 Larger Clojure benchmark runs should stay configurable because JVM startup and
 memory behavior are noisy in constrained Termux environments.
 
-The configurable benchmark matrix now treats `clojure-wam-accumulated` as a
-result-producing `hybrid-wam` target. The remaining modes are still explicit
-generation/selection scaffolds:
+The configurable benchmark matrix now treats both accumulated Clojure modes as
+result-producing `hybrid-wam` targets:
+
+- `clojure-wam-accumulated`
+- `clojure-wam-accumulated-no-kernels`
+
+The seeded modes are still explicit generation/selection scaffolds:
 
 - `clojure-wam-seeded`
 - `clojure-wam-seeded-no-kernels`
-- `clojure-wam-accumulated-no-kernels`
 
 Those scaffold modes are grouped under `clojure-wam-scaffold` and skipped by
 the result-producing matrix runner until they emit the same table shape.

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -689,6 +689,8 @@ def main() -> int:
                     command = build_wam_go_effective_distance(temp_root, scale, "kernels_off")
                 elif target == "clojure-wam-accumulated":
                     command = build_wam_clojure_effective_distance(temp_root, scale, "accumulated", "kernels_on")
+                elif target == "clojure-wam-accumulated-no-kernels":
+                    command = build_wam_clojure_effective_distance(temp_root, scale, "accumulated", "kernels_off")
                 else:
                     command = commands[target]
                 results.append(benchmark_target(command, scale, args.repetitions, target))

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -81,7 +81,7 @@ TARGETS: dict[str, TargetInfo] = {
     ),
     "clojure-wam-accumulated-no-kernels": TargetInfo(
         "clojure-wam-accumulated-no-kernels",
-        "hybrid-wam-scaffold",
+        "hybrid-wam",
         "Hybrid WAM Clojure generated project with optimized accumulated helpers and no_kernels(true)",
     ),
     "haskell-pure-interp": TargetInfo(
@@ -125,6 +125,7 @@ TARGET_SETS: dict[str, list[str]] = {
         "go-wam-accumulated",
         "go-wam-accumulated-no-kernels",
         "clojure-wam-accumulated",
+        "clojure-wam-accumulated-no-kernels",
         "haskell-pure-interp",
         "haskell-interp-ffi",
         "haskell-lowered-only",
@@ -133,7 +134,6 @@ TARGET_SETS: dict[str, list[str]] = {
     "clojure-wam-scaffold": [
         "clojure-wam-seeded",
         "clojure-wam-seeded-no-kernels",
-        "clojure-wam-accumulated-no-kernels",
     ],
     "clojure-wam": [
         "clojure-wam-accumulated",

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -30,11 +30,12 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
             ],
         )
         self.assertEqual(TARGETS["clojure-wam-accumulated"].category, "hybrid-wam")
+        self.assertEqual(TARGETS["clojure-wam-accumulated-no-kernels"].category, "hybrid-wam")
         self.assertTrue(
             all(
                 TARGETS[target].category == "hybrid-wam-scaffold"
                 for target in targets
-                if target != "clojure-wam-accumulated"
+                if target not in {"clojure-wam-accumulated", "clojure-wam-accumulated-no-kernels"}
             )
         )
 
@@ -47,20 +48,21 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         self.assertIn("go-wam-accumulated", targets)
         self.assertIn("haskell-interp-ffi", targets)
         self.assertIn("clojure-wam-accumulated", targets)
+        self.assertIn("clojure-wam-accumulated-no-kernels", targets)
         self.assertNotIn("clojure-wam-seeded", targets)
 
     def test_list_targets_includes_clojure_scaffold_set(self) -> None:
         text = list_targets_text()
 
         self.assertIn("clojure-wam-accumulated\thybrid-wam", text)
+        self.assertIn("clojure-wam-accumulated-no-kernels\thybrid-wam", text)
         self.assertIn(
             "clojure-wam\tclojure-wam-accumulated,clojure-wam-seeded,"
             "clojure-wam-seeded-no-kernels,clojure-wam-accumulated-no-kernels",
             text,
         )
         self.assertIn(
-            "clojure-wam-scaffold\tclojure-wam-seeded,clojure-wam-seeded-no-kernels,"
-            "clojure-wam-accumulated-no-kernels",
+            "clojure-wam-scaffold\tclojure-wam-seeded,clojure-wam-seeded-no-kernels",
             text,
         )
 


### PR DESCRIPTION
## Summary

Promotes `clojure-wam-accumulated-no-kernels` from scaffold-only status to an executable `hybrid-wam` benchmark target.

This gives the Clojure WAM target a valid accumulated kernel-on/off comparison surface in the effective-distance matrix.

## Details

- Wires `clojure-wam-accumulated-no-kernels` through the matrix as:
  - variant: `accumulated`
  - kernel mode: `kernels_off`
- Keeps seeded Clojure modes scaffold-only:
  - `clojure-wam-seeded`
  - `clojure-wam-seeded-no-kernels`
- Updates target metadata and target sets so both accumulated Clojure modes are executable `hybrid-wam` targets.
- Updates matrix tests to expect only seeded Clojure modes in `clojure-wam-scaffold`.
- Updates benchmark docs and the WAM optimization log.

## Testing

Ran:

```sh
python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py tests/test_benchmark_target_matrix.py
python3 tests/test_benchmark_target_matrix.py
python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-accumulated,clojure-wam-accumulated-no-kernels,prolog-accumulated --scales dev --repetitions 1
python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-accumulated-no-kernels --scales dev --repetitions 1
swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl
git diff --check
```

The three-way matrix smoke produced matching normalized output on `dev`:

```text
dev	clojure-wam-accumulated	hybrid-wam	...	rows=19	1659619c9d36
dev	clojure-wam-accumulated-no-kernels	hybrid-wam	...	rows=19	1659619c9d36
dev	prolog-accumulated	optimized-prolog	...	rows=19	1659619c9d36
dev	all_outputs	match
dev	hybrid-wam_outputs	match
```

## Notes

The next useful step is adding result-producing entrypoints for the seeded Clojure modes so seeded/accumulated comparisons are available in the matrix.
