### PR TITLE
feat(wam-clojure): enable seeded benchmark runners

### DIFF
--- a/docs/design/BENCHMARK_TARGET_MATRIX.md
+++ b/docs/design/BENCHMARK_TARGET_MATRIX.md
@@ -244,21 +244,17 @@ The default presets are:
 
 `hybrid-wam-scaffold` is for generated targets that have benchmark-generation
 shape and smoke coverage but do not yet emit the common effective-distance
-result table. Clojure WAM is split between executable accumulated targets and
-remaining seeded scaffold targets:
+result table. Clojure WAM no longer has scaffold-only effective-distance modes;
+all four Clojure modes are executable `hybrid-wam` targets:
 
 - `clojure-wam-accumulated` — executable `hybrid-wam`; emits the common result
   table and matches `prolog-accumulated` on the `dev` scale
 - `clojure-wam-accumulated-no-kernels` — executable `hybrid-wam`; same result
   table with `no_kernels(true)` for kernel-on/off comparison
-
-- `clojure-wam-seeded`
-- `clojure-wam-seeded-no-kernels`
-
-The effective-distance matrix lists and resolves all of these targets, but
-skips the scaffold-only modes with an explicit message when a result-producing
-benchmark run is requested. This avoids comparing a predicate-level smoke path
-against full effective-distance table producers.
+- `clojure-wam-seeded` — executable `hybrid-wam`; seeded helper path with
+  kernels enabled
+- `clojure-wam-seeded-no-kernels` — executable `hybrid-wam`; seeded helper
+  path with `no_kernels(true)`
 
 ## Termux Rule
 

--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -293,19 +293,22 @@ for further optimization work.
     On `dev`, both accumulated Clojure modes and `prolog-accumulated` produce
     the same normalized digest, which gives a valid Clojure kernel-on/off
     comparison surface.
+12. The seeded Clojure modes are executable too. All four Clojure
+    effective-distance modes now match `prolog-accumulated` on `dev` by
+    normalized digest:
+    `clojure-wam-accumulated`, `clojure-wam-accumulated-no-kernels`,
+    `clojure-wam-seeded`, and `clojure-wam-seeded-no-kernels`.
 
 ### Highest-value remaining work
 
-1. Add result-producing entrypoints for the seeded Clojure benchmark modes so
-   seeded/accumulated comparisons are available in the matrix.
-2. Extend Clojure graph kernels beyond deterministic `category_parent/2`,
+1. Extend Clojure graph kernels beyond deterministic `category_parent/2`,
    especially multi-output traversal kernels comparable to the mature
    Haskell/Rust hybrid paths.
-3. Add proper heap/trail semantics instead of relying primarily on the
+2. Add proper heap/trail semantics instead of relying primarily on the
    bindings table.
-4. Reduce choice-point snapshots toward the lighter Haskell/Rust model once
+3. Reduce choice-point snapshots toward the lighter Haskell/Rust model once
    the remaining runtime state is better separated.
-5. Split hot runtime state from cold code/context data, following the same
+4. Split hot runtime state from cold code/context data, following the same
    optimization pattern that paid off heavily in Haskell.
 
 ---

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -145,19 +145,15 @@ The generated project supports two entry modes:
 Larger Clojure benchmark runs should stay configurable because JVM startup and
 memory behavior are noisy in constrained Termux environments.
 
-The configurable benchmark matrix now treats both accumulated Clojure modes as
-result-producing `hybrid-wam` targets:
+The configurable benchmark matrix now treats all Clojure WAM effective-distance
+modes as result-producing `hybrid-wam` targets:
 
 - `clojure-wam-accumulated`
 - `clojure-wam-accumulated-no-kernels`
-
-The seeded modes are still explicit generation/selection scaffolds:
-
 - `clojure-wam-seeded`
 - `clojure-wam-seeded-no-kernels`
 
-Those scaffold modes are grouped under `clojure-wam-scaffold` and skipped by
-the result-producing matrix runner until they emit the same table shape.
+These targets provide both seeded/accumulated and kernel-on/off comparisons.
 
 ### Why Seeded Closures Win
 

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -691,6 +691,10 @@ def main() -> int:
                     command = build_wam_clojure_effective_distance(temp_root, scale, "accumulated", "kernels_on")
                 elif target == "clojure-wam-accumulated-no-kernels":
                     command = build_wam_clojure_effective_distance(temp_root, scale, "accumulated", "kernels_off")
+                elif target == "clojure-wam-seeded":
+                    command = build_wam_clojure_effective_distance(temp_root, scale, "seeded", "kernels_on")
+                elif target == "clojure-wam-seeded-no-kernels":
+                    command = build_wam_clojure_effective_distance(temp_root, scale, "seeded", "kernels_off")
                 else:
                     command = commands[target]
                 results.append(benchmark_target(command, scale, args.repetitions, target))

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -66,12 +66,12 @@ TARGETS: dict[str, TargetInfo] = {
     ),
     "clojure-wam-seeded": TargetInfo(
         "clojure-wam-seeded",
-        "hybrid-wam-scaffold",
+        "hybrid-wam",
         "Hybrid WAM Clojure generated project with seeded helpers and kernels enabled",
     ),
     "clojure-wam-seeded-no-kernels": TargetInfo(
         "clojure-wam-seeded-no-kernels",
-        "hybrid-wam-scaffold",
+        "hybrid-wam",
         "Hybrid WAM Clojure generated project with seeded helpers and no_kernels(true)",
     ),
     "clojure-wam-accumulated": TargetInfo(
@@ -126,15 +126,14 @@ TARGET_SETS: dict[str, list[str]] = {
         "go-wam-accumulated-no-kernels",
         "clojure-wam-accumulated",
         "clojure-wam-accumulated-no-kernels",
+        "clojure-wam-seeded",
+        "clojure-wam-seeded-no-kernels",
         "haskell-pure-interp",
         "haskell-interp-ffi",
         "haskell-lowered-only",
         "haskell-lowered-ffi",
     ],
-    "clojure-wam-scaffold": [
-        "clojure-wam-seeded",
-        "clojure-wam-seeded-no-kernels",
-    ],
+    "clojure-wam-scaffold": [],
     "clojure-wam": [
         "clojure-wam-accumulated",
         "clojure-wam-seeded",

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -31,13 +31,8 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         )
         self.assertEqual(TARGETS["clojure-wam-accumulated"].category, "hybrid-wam")
         self.assertEqual(TARGETS["clojure-wam-accumulated-no-kernels"].category, "hybrid-wam")
-        self.assertTrue(
-            all(
-                TARGETS[target].category == "hybrid-wam-scaffold"
-                for target in targets
-                if target not in {"clojure-wam-accumulated", "clojure-wam-accumulated-no-kernels"}
-            )
-        )
+        self.assertEqual(TARGETS["clojure-wam-seeded"].category, "hybrid-wam")
+        self.assertEqual(TARGETS["clojure-wam-seeded-no-kernels"].category, "hybrid-wam")
 
     def test_default_hybrid_wam_excludes_clojure_scaffolds(self) -> None:
         targets = resolve_targets(
@@ -49,24 +44,24 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         self.assertIn("haskell-interp-ffi", targets)
         self.assertIn("clojure-wam-accumulated", targets)
         self.assertIn("clojure-wam-accumulated-no-kernels", targets)
-        self.assertNotIn("clojure-wam-seeded", targets)
+        self.assertIn("clojure-wam-seeded", targets)
+        self.assertIn("clojure-wam-seeded-no-kernels", targets)
 
     def test_list_targets_includes_clojure_scaffold_set(self) -> None:
         text = list_targets_text()
 
         self.assertIn("clojure-wam-accumulated\thybrid-wam", text)
         self.assertIn("clojure-wam-accumulated-no-kernels\thybrid-wam", text)
+        self.assertIn("clojure-wam-seeded\thybrid-wam", text)
+        self.assertIn("clojure-wam-seeded-no-kernels\thybrid-wam", text)
         self.assertIn(
             "clojure-wam\tclojure-wam-accumulated,clojure-wam-seeded,"
             "clojure-wam-seeded-no-kernels,clojure-wam-accumulated-no-kernels",
             text,
         )
-        self.assertIn(
-            "clojure-wam-scaffold\tclojure-wam-seeded,clojure-wam-seeded-no-kernels",
-            text,
-        )
+        self.assertIn("clojure-wam-scaffold\t", text)
 
-    def test_effective_distance_runner_skips_scaffold_targets(self) -> None:
+    def test_effective_distance_runner_resolves_seeded_clojure_targets(self) -> None:
         original_argv = sys.argv
         try:
             sys.argv = [
@@ -75,7 +70,7 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
                 "clojure-wam-seeded,prolog-accumulated",
             ]
             args = parse_args()
-            self.assertEqual(resolve_requested_targets(args), ["prolog-accumulated"])
+            self.assertEqual(resolve_requested_targets(args), ["clojure-wam-seeded", "prolog-accumulated"])
         finally:
             sys.argv = original_argv
 


### PR DESCRIPTION
## Summary

Promotes the seeded Clojure WAM effective-distance modes to executable `hybrid-wam` benchmark targets.

With this change, all four Clojure WAM effective-distance modes are runnable through the matrix:

- `clojure-wam-accumulated`
- `clojure-wam-accumulated-no-kernels`
- `clojure-wam-seeded`
- `clojure-wam-seeded-no-kernels`

This completes the basic Clojure matrix surface for seeded vs accumulated and kernels-on vs kernels-off comparisons.

## Details

- Wires `clojure-wam-seeded` through the matrix as `seeded kernels_on`.
- Wires `clojure-wam-seeded-no-kernels` through the matrix as `seeded kernels_off`.
- Promotes both seeded Clojure targets from scaffold-only to executable `hybrid-wam`.
- Updates target-matrix tests so all four Clojure WAM modes are expected to resolve as runnable targets.
- Updates benchmark docs and the WAM optimization log to reflect that Clojure no longer has scaffold-only effective-distance modes.

## Testing

Ran:

```sh
python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py tests/test_benchmark_target_matrix.py
python3 tests/test_benchmark_target_matrix.py
python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-accumulated,clojure-wam-accumulated-no-kernels,clojure-wam-seeded,clojure-wam-seeded-no-kernels,prolog-accumulated --scales dev --repetitions 1
python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-seeded,clojure-wam-seeded-no-kernels --scales dev --repetitions 1
swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl
git diff --check
```

The five-way matrix smoke produced matching normalized output on `dev`:

```text
dev	clojure-wam-accumulated	hybrid-wam	...	rows=19	1659619c9d36
dev	clojure-wam-accumulated-no-kernels	hybrid-wam	...	rows=19	1659619c9d36
dev	clojure-wam-seeded	hybrid-wam	...	rows=19	1659619c9d36
dev	clojure-wam-seeded-no-kernels	hybrid-wam	...	rows=19	1659619c9d36
dev	prolog-accumulated	optimized-prolog	...	rows=19	1659619c9d36
dev	all_outputs	match
dev	hybrid-wam_outputs	match
```

## Notes

The next useful Clojure WAM work is deeper runtime/kernel parity, especially native multi-output traversal kernels comparable to the mature Haskell/Rust hybrid paths.
