### PR TITLE
feat(wam-clojure): add traversal-index runner kernel

### DIFF
--- a/docs/design/BENCHMARK_TARGET_MATRIX.md
+++ b/docs/design/BENCHMARK_TARGET_MATRIX.md
@@ -248,11 +248,12 @@ result table. Clojure WAM no longer has scaffold-only effective-distance modes;
 all four Clojure modes are executable `hybrid-wam` targets:
 
 - `clojure-wam-accumulated` — executable `hybrid-wam`; emits the common result
-  table and matches `prolog-accumulated` on the `dev` scale
+  table, builds the native Clojure ancestor-hop index, and matches
+  `prolog-accumulated` on the `dev` scale
 - `clojure-wam-accumulated-no-kernels` — executable `hybrid-wam`; same result
   table with `no_kernels(true)` for kernel-on/off comparison
 - `clojure-wam-seeded` — executable `hybrid-wam`; seeded helper path with
-  kernels enabled
+  kernels enabled and the native Clojure ancestor-hop index
 - `clojure-wam-seeded-no-kernels` — executable `hybrid-wam`; seeded helper
   path with `no_kernels(true)`
 

--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -237,13 +237,13 @@ for further optimization work.
 | Shared code table | Done | All generated predicates dispatch into one shared instruction table with per-predicate start PCs |
 | One-time label resolution | Done | `call`, `execute`, `jump`, choice ops, and `switch_on_constant` are resolved at project load |
 | Indexed dispatch | Done | `switch_on_constant` is compiled into a direct lookup map in the runtime |
-| FFI controls | Partial | Explicit `foreign_predicates([...])` emits `call-foreign` stubs; `no_kernels(true)` and `foreign_lowering(false)` suppress stubs. Deterministic handlers work, and the optimized benchmark generator now emits a fact-backed `category_parent/2` graph handler |
+| FFI controls | Partial | Explicit `foreign_predicates([...])` emits `call-foreign` stubs; `no_kernels(true)` and `foreign_lowering(false)` suppress stubs. Deterministic handlers work, and the optimized benchmark generator now emits a fact-backed `category_parent/2` graph handler plus a Clojure ancestor-hop traversal index for `kernels_on` benchmark runners |
 | Choice points | Partial | Saves persistent regs/env stack plus trail/heap/build boundaries; avoids binding snapshots and filtered register-map allocation, but still heavier than Haskell/Rust |
 | Environment frames | Done | `allocate`/`deallocate` use explicit environment frames for `Y` slots |
 | Cut semantics | Partial | Clause cut uses a cut barrier; `cut_ite` pops only the enclosing if-then-else CP |
 | Read-mode compound terms | Done | `get_structure`, `get_list`, `unify_*` support structure/list matching |
 | Write-mode compound terms | Done | `put_structure`, `put_list`, `set_*` build nested terms via a builder stack |
-| Benchmark generation | Partial | `generate_wam_clojure_optimized_benchmark.pl` emits optimized effective-distance Clojure WAM projects with `kernels_on`/`kernels_off` controls and fact-backed graph handler generation |
+| Benchmark generation | Partial | `generate_wam_clojure_optimized_benchmark.pl` emits optimized effective-distance Clojure WAM projects with `kernels_on`/`kernels_off` controls, fact-backed graph handler generation, and a result-producing traversal-index runner |
 | End-to-end verification | Partial | Generator tests, fact-backed foreign-handler JVM smoke, and standalone runtime smoke runner pass locally; large JVM benchmarks remain constrained in Termux |
 
 ### Clojure-specific lessons from this phase
@@ -268,8 +268,7 @@ for further optimization work.
 6. Clojure now has the same basic control vocabulary used by benchmark
    matrices in other WAM targets: explicit foreign predicates can be marked,
    and `no_kernels(true)` / `foreign_lowering(false)` force the pure WAM path.
-   Deterministic handlers can be wired through `clojure_foreign_handlers/1`;
-   full Clojure graph kernels are still not implemented.
+   Deterministic handlers can be wired through `clojure_foreign_handlers/1`.
 7. Clojure now has an optimized effective-distance project generator. It
    establishes benchmark-matrix shape and kernel-mode controls without trying
    to run large JVM benchmarks in Termux.
@@ -298,12 +297,17 @@ for further optimization work.
     normalized digest:
     `clojure-wam-accumulated`, `clojure-wam-accumulated-no-kernels`,
     `clojure-wam-seeded`, and `clojure-wam-seeded-no-kernels`.
+13. The result-producing runner now distinguishes `kernels_on` and
+    `kernels_off`: `kernels_on` builds a native Clojure ancestor-hop index once
+    for the benchmark seed categories and roots, while `kernels_off` keeps the
+    on-demand recursive traversal path. Both modes still match
+    `prolog-accumulated` on `dev`.
 
 ### Highest-value remaining work
 
-1. Extend Clojure graph kernels beyond deterministic `category_parent/2`,
-   especially multi-output traversal kernels comparable to the mature
-   Haskell/Rust hybrid paths.
+1. Move the traversal-index kernel closer to the generic `call-foreign`
+   runtime surface, especially multi-output traversal kernels comparable to
+   the mature Haskell/Rust hybrid paths.
 2. Add proper heap/trail semantics instead of relying primarily on the
    bindings table.
 3. Reduce choice-point snapshots toward the lighter Haskell/Rust model once

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -133,8 +133,10 @@ Supported modes:
 - `seeded` and `accumulated` select the same optimized Prolog predicate
   generation path used by the mature WAM benchmark generators.
 - `kernels_on` emits a `category_parent/2` `call-foreign` stub and a
-  Clojure set-backed handler generated from the supplied `facts.pl`.
-- `kernels_off` forces the pure-WAM scaffold with `no_kernels(true)`.
+  Clojure set-backed handler generated from the supplied `facts.pl`; the
+  result-producing runner also precomputes a native Clojure ancestor-hop index.
+- `kernels_off` forces the pure-WAM scaffold with `no_kernels(true)` and keeps
+  the result-producing runner on the on-demand traversal path.
 
 The generated project supports two entry modes:
 

--- a/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
@@ -86,7 +86,7 @@ generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom) :-
            ],
            Options),
     write_wam_clojure_project(Predicates, Options, OutputDir),
-    append_effective_distance_runner(OutputDir),
+    append_effective_distance_runner(OutputDir, KernelModeAtom),
     format(user_error,
            '[WAM-Clojure-Optimized] facts=~w variant=~w kernels=~w output=~w~n',
            [FactsPath, VariantAtom, KernelModeAtom, OutputDir]).
@@ -145,10 +145,10 @@ escape_clj_string_local(In, Out) :-
     split_string(Tmp1, "\"", "", Parts2),
     atomic_list_concat(Parts2, "\\\"", Out).
 
-append_effective_distance_runner(OutputDir) :-
+append_effective_distance_runner(OutputDir, KernelModeAtom) :-
     directory_file_path(OutputDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
     read_file_to_string(CorePath, Core0, []),
-    effective_distance_runner_code(RunnerCode),
+    effective_distance_runner_code(KernelModeAtom, RunnerCode),
     atomic_list_concat([Core0, RunnerCode], '\n\n', Core),
     setup_call_cleanup(
         open(CorePath, write, Stream),
@@ -156,12 +156,13 @@ append_effective_distance_runner(OutputDir) :-
         close(Stream)
     ).
 
-effective_distance_runner_code(Code) :-
+effective_distance_runner_code(KernelModeAtom, Code) :-
     benchmark_article_category_literal(ArticleCategories),
     benchmark_category_parent_literal(CategoryParents),
     benchmark_root_category_literal(RootCategories),
     benchmark_dimension_n_literal(DimensionN),
     benchmark_max_depth_literal(MaxDepth),
+    benchmark_use_traversal_kernel_literal(KernelModeAtom, UseTraversalKernel),
     format(string(Code),
 '
 ;; Effective-distance benchmark entrypoint generated from facts.pl.
@@ -171,6 +172,7 @@ effective_distance_runner_code(Code) :-
 (def benchmark-roots [~s])
 (def benchmark-dimension-n ~w)
 (def benchmark-max-depth ~w)
+(def benchmark-use-traversal-kernel? ~w)
 
 (def benchmark-parents-by-child
   (reduce (fn [acc [child parent]]
@@ -183,6 +185,9 @@ effective_distance_runner_code(Code) :-
             (update acc article (fnil conj []) category))
           {}
           benchmark-article-categories))
+
+(def benchmark-seed-categories
+  (sort (set (map second benchmark-article-categories))))
 
 (defn benchmark-ancestor-hops [category root visited]
   (let [parents (get benchmark-parents-by-child category [])]
@@ -199,6 +204,23 @@ effective_distance_runner_code(Code) :-
                   hop (benchmark-ancestor-hops mid root (conj visited mid))]
               [(inc hop)])))))))
 
+(defn benchmark-build-ancestor-hops-index []
+  (into {}
+    (for [category benchmark-seed-categories
+          root benchmark-roots
+          :let [hops (benchmark-ancestor-hops category root #{category})]
+          :when (seq hops)]
+      [[category root] hops])))
+
+(def benchmark-ancestor-hops-index
+  (when benchmark-use-traversal-kernel?
+    (benchmark-build-ancestor-hops-index)))
+
+(defn benchmark-category-root-hops [category root]
+  (if benchmark-use-traversal-kernel?
+    (get benchmark-ancestor-hops-index [category root] [])
+    (benchmark-ancestor-hops category root #{category})))
+
 (defn benchmark-article-root-weight [article root]
   (reduce
     +
@@ -206,7 +228,7 @@ effective_distance_runner_code(Code) :-
     (for [category (get benchmark-article-categories-by-article article [])
           weight (if (= category root)
                    [1.0]
-                   (for [hops (benchmark-ancestor-hops category root #{category})]
+                   (for [hops (benchmark-category-root-hops category root)]
                      (Math/pow (+ hops 1.0) (- benchmark-dimension-n))))]
       weight)))
 
@@ -237,7 +259,11 @@ effective_distance_runner_code(Code) :-
       (println (invoke-predicate pred-key (mapv edn/read-string pred-args))))
     (run-effective-distance-benchmark)))
 ',
-           [ArticleCategories, CategoryParents, RootCategories, DimensionN, MaxDepth]).
+           [ArticleCategories, CategoryParents, RootCategories, DimensionN, MaxDepth,
+            UseTraversalKernel]).
+
+benchmark_use_traversal_kernel_literal(kernels_on, true).
+benchmark_use_traversal_kernel_literal(kernels_off, false).
 
 benchmark_article_category_literal(Literal) :-
     findall(Article-Category,

--- a/tests/test_wam_clojure_benchmark_generator.pl
+++ b/tests/test_wam_clojure_benchmark_generator.pl
@@ -30,6 +30,9 @@ test(generate_seeded_kernels_on_project) :-
         assertion(sub_string(CoreCode, _, _, _, '"category_parent/2" (let [edges #{')),
         assertion(sub_string(CoreCode, _, _, _, '["Abstraction" "Thought"]')),
         assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_parent" :arity 2}')),
+        assertion(sub_string(CoreCode, _, _, _, '(def benchmark-use-traversal-kernel? true)')),
+        assertion(sub_string(CoreCode, _, _, _, '(def benchmark-ancestor-hops-index')),
+        assertion(sub_string(CoreCode, _, _, _, '(benchmark-build-ancestor-hops-index)')),
         delete_directory_and_contents(TmpDir)
     )).
 
@@ -42,6 +45,8 @@ test(generate_seeded_kernels_off_project) :-
         assertion(sub_string(CoreCode, _, _, _, '(def foreign-handlers {')),
         assertion(\+ sub_string(CoreCode, _, _, _, '"category_parent/2" (let [edges #{')),
         assertion(\+ sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_parent" :arity 2}')),
+        assertion(sub_string(CoreCode, _, _, _, '(def benchmark-use-traversal-kernel? false)')),
+        assertion(sub_string(CoreCode, _, _, _, '(benchmark-ancestor-hops category root #{category})')),
         delete_directory_and_contents(TmpDir)
     )).
 


### PR DESCRIPTION
## Summary

Adds a native Clojure ancestor-hop traversal-index path for `kernels_on` effective-distance runners.

The generated Clojure benchmark runner now distinguishes kernel modes:

- `kernels_on` precomputes a native Clojure `[category root] -> hops` index for benchmark seed categories and roots.
- `kernels_off` keeps the previous on-demand recursive traversal path.

Both paths continue to emit the same common effective-distance result table.

## Details

- Threads the kernel mode into the generated Clojure effective-distance runner.
- Emits `benchmark-use-traversal-kernel?` into generated Clojure code.
- Adds `benchmark-build-ancestor-hops-index` and `benchmark-ancestor-hops-index` for `kernels_on`.
- Routes article/root weight computation through `benchmark-category-root-hops`, selecting indexed lookup or recursive traversal by kernel mode.
- Keeps the existing fact-backed `category_parent/2` `call-foreign` handler for generated WAM predicate calls.
- Adds generator assertions for the kernel-on traversal index and kernel-off recursive path.
- Updates benchmark docs, the target matrix note, and the WAM optimization log.

## Testing

Ran:

```sh
python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py tests/test_benchmark_target_matrix.py
python3 tests/test_benchmark_target_matrix.py
python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-accumulated,clojure-wam-accumulated-no-kernels,clojure-wam-seeded,clojure-wam-seeded-no-kernels,prolog-accumulated --scales dev --repetitions 1
swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl
git diff --check
```

The five-way matrix smoke produced matching normalized output on `dev`:

```text
dev	clojure-wam-accumulated	hybrid-wam	...	rows=19	1659619c9d36
dev	clojure-wam-accumulated-no-kernels	hybrid-wam	...	rows=19	1659619c9d36
dev	clojure-wam-seeded	hybrid-wam	...	rows=19	1659619c9d36
dev	clojure-wam-seeded-no-kernels	hybrid-wam	...	rows=19	1659619c9d36
dev	prolog-accumulated	optimized-prolog	...	rows=19	1659619c9d36
dev	all_outputs	match
dev	hybrid-wam_outputs	match
```

## Notes

This is still a benchmark-runner kernel, not yet a generic multi-output `call-foreign` traversal kernel. The next useful step is moving this closer to the generic runtime surface used by the mature Haskell/Rust hybrid paths.
