### PR TITLE
feat(csharp-query): Use indexed binary artifacts for selective C# query joins

### DIFF
--- a/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
+++ b/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
@@ -386,10 +386,13 @@ Prototype status:
   external-materialized access without a new planner enum yet. It also exposes
   indexed single-column lookups through `IIndexedRelationProvider`, letting
   parameterized fact scans probe preprocessed offsets without first
-  materializing the whole relation.
+  materializing the whole relation. Single-key joins can also use that provider
+  seam when one side is a selective probe and the other side is an indexed
+  artifact-backed scan.
 - `benchmark_scan_materialization.py` can now compare `preload`, `delimited`,
   and `artifact` source modes against the existing scan-family workloads,
-  including a `bound_scan` mode for indexed parameter probes.
+  including `bound_scan` and `selective_join` modes for indexed parameter
+  probes.
 
 ## Success Criteria
 

--- a/examples/benchmark/benchmark_scan_materialization.py
+++ b/examples/benchmark/benchmark_scan_materialization.py
@@ -10,6 +10,7 @@ temporary C# project:
 - `bound_scan`: parameterized `RelationScanNode` over one bound column
 - `pattern`: `PatternScanNode` with a bound category
 - `join`: `KeyJoinNode` over article/category and category-parent scans
+- `selective_join`: parameter seed joined against category-parent
 - `negation`: unary negation over scanned support relations
 - `aggregate`: grouped count aggregate over a scanned relation
 
@@ -201,6 +202,16 @@ class Program
                         2,
                         2,
                         4)),
+                "selective_join" => new QueryPlan(
+                    joinOutId,
+                    new KeyJoinNode(
+                        new ParamSeedNode(new PredicateId("category_seed", 1), new int[] { 0 }, 1),
+                        new RelationScanNode(edgeId),
+                        new int[] { 0 },
+                        new int[] { 0 },
+                        1,
+                        2,
+                        3)),
                 "negation" => new QueryPlan(
                     negationOutId,
                     new NegationNode(
@@ -226,7 +237,7 @@ class Program
                 ScanRelationRetentionStrategy: scanStrategy));
 
             var stopwatch = Stopwatch.StartNew();
-            var parameters = mode == "bound_scan"
+            var parameters = mode == "bound_scan" || mode == "selective_join"
                 ? new object[][] { new object[] { patternCategory } }
                 : null;
             var rows = executor.Execute(plan, parameters: parameters, trace: trace).ToList();
@@ -335,6 +346,13 @@ def parse_metrics(stderr: str) -> dict[str, str]:
     return metrics
 
 
+def select_planner_summary(metrics: dict[str, str]) -> str:
+    operator = metrics.get("scan_operator_strategies", "")
+    if "KeyJoinIndexedRelationProvider" in operator or "IndexedRelationProviderLookup" in operator:
+        return operator
+    return metrics.get("scan_planner_strategies", "") or operator
+
+
 def benchmark_mode(command: list[str], scale: str, mode: str, source_mode: str, strategy: str, repetitions: int) -> BenchResult:
     scale_dir = BENCH_DIR / scale
     edge_path = scale_dir / "category_parent.tsv"
@@ -387,7 +405,7 @@ def main() -> int:
         for result in sorted(results, key=lambda item: (scale_sort_key(item.scale), item.mode, item.source_mode, item.strategy)):
             grouped.setdefault((result.scale, result.mode, result.source_mode), {})[result.strategy] = result
             metrics = parse_metrics(result.stderr)
-            planner = metrics.get("scan_planner_strategies", "") or metrics.get("scan_operator_strategies", "")
+            planner = select_planner_summary(metrics)
             phases = metrics.get("scan_phase_summary", "")
             rows = metrics.get("row_count", "")
             print(
@@ -404,7 +422,7 @@ def main() -> int:
                 ratio = auto.median / best.median if best.median else float('inf')
                 print(f"{scale}	{mode}	{source_mode}	auto_vs_best	{ratio:.2f}x")
                 auto_metrics = parse_metrics(auto.stderr)
-                auto_planner = auto_metrics.get("scan_planner_strategies", "") or auto_metrics.get("scan_operator_strategies", "")
+                auto_planner = select_planner_summary(auto_metrics)
                 print(f"{scale}	{mode}	{source_mode}	auto_planner	{auto_planner}")
 
         if args.keep_temp:

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -4202,6 +4202,53 @@ namespace UnifyWeaver.QueryRuntime
 
                 if (leftIsScan || rightIsScan)
                 {
+                    if (joinKeyCount == 1)
+                    {
+                        if (rightIsScan &&
+                            TryExecuteIndexedProviderScanJoin(
+                                join,
+                                indexedScanOnLeft: false,
+                                scanPredicate: rightScanPredicate,
+                                scanPattern: rightScanPattern,
+                                scanFilter: rightScanFilter,
+                                scanKeyIndex: join.RightKeys[0],
+                                probeNode: join.Left,
+                                probeKeyIndex: join.LeftKeys[0],
+                                context,
+                                out var indexedRightRows))
+                        {
+                            trace?.RecordStrategy(join, "KeyJoinIndexedRelationProviderRight");
+                            foreach (var row in indexedRightRows)
+                            {
+                                yield return row;
+                            }
+
+                            yield break;
+                        }
+
+                        if (leftIsScan &&
+                            TryExecuteIndexedProviderScanJoin(
+                                join,
+                                indexedScanOnLeft: true,
+                                scanPredicate: leftScanPredicate,
+                                scanPattern: leftScanPattern,
+                                scanFilter: leftScanFilter,
+                                scanKeyIndex: join.LeftKeys[0],
+                                probeNode: join.Right,
+                                probeKeyIndex: join.RightKeys[0],
+                                context,
+                                out var indexedLeftRows))
+                        {
+                            trace?.RecordStrategy(join, "KeyJoinIndexedRelationProviderLeft");
+                            foreach (var row in indexedLeftRows)
+                            {
+                                yield return row;
+                            }
+
+                            yield break;
+                        }
+                    }
+
                     var useScanIndexStrategy = true;
                     if (leftIsScan != rightIsScan)
                     {
@@ -9526,6 +9573,109 @@ namespace UnifyWeaver.QueryRuntime
 
             facts = default!;
             return false;
+        }
+
+        private bool TryExecuteIndexedProviderScanJoin(
+            KeyJoinNode join,
+            bool indexedScanOnLeft,
+            PredicateId scanPredicate,
+            object[]? scanPattern,
+            Func<object[], bool>? scanFilter,
+            int scanKeyIndex,
+            PlanNode probeNode,
+            int probeKeyIndex,
+            EvaluationContext context,
+            out IEnumerable<object[]> rows)
+        {
+            rows = default!;
+            if (_provider is not IIndexedRelationProvider indexedProvider)
+            {
+                return false;
+            }
+
+            var probeRows = Evaluate(probeNode, context).Where(tuple => tuple is not null).ToList();
+            if (probeRows.Count == 0)
+            {
+                rows = Enumerable.Empty<object[]>();
+                return true;
+            }
+
+            var keys = new HashSet<object>();
+            foreach (var probeRow in probeRows)
+            {
+                var key = GetFactValue(probeRow, probeKeyIndex) ?? NullFactIndexKey;
+                keys.Add(key);
+            }
+
+            if (!indexedProvider.TryLookupFacts(scanPredicate, scanKeyIndex, keys, out var scanRows))
+            {
+                return false;
+            }
+
+            var buckets = new Dictionary<object, List<object[]>>();
+            foreach (var scanRow in scanRows)
+            {
+                if (scanRow is null)
+                {
+                    continue;
+                }
+
+                if (scanPattern is not null && !TupleMatchesPattern(scanRow, scanPattern))
+                {
+                    continue;
+                }
+
+                if (scanFilter is not null && !scanFilter(scanRow))
+                {
+                    continue;
+                }
+
+                var key = GetFactValue(scanRow, scanKeyIndex) ?? NullFactIndexKey;
+                if (!buckets.TryGetValue(key, out var bucket))
+                {
+                    bucket = new List<object[]>();
+                    buckets[key] = bucket;
+                }
+
+                bucket.Add(scanRow);
+            }
+
+            rows = EnumerateIndexedProviderJoinRows(join, indexedScanOnLeft, probeRows, probeKeyIndex, buckets);
+            return true;
+        }
+
+        private static IEnumerable<object[]> EnumerateIndexedProviderJoinRows(
+            KeyJoinNode join,
+            bool indexedScanOnLeft,
+            IReadOnlyList<object[]> probeRows,
+            int probeKeyIndex,
+            Dictionary<object, List<object[]>> indexedBuckets)
+        {
+            foreach (var probeRow in probeRows)
+            {
+                if (probeRow is null)
+                {
+                    continue;
+                }
+
+                var key = GetFactValue(probeRow, probeKeyIndex) ?? NullFactIndexKey;
+                if (!indexedBuckets.TryGetValue(key, out var bucket))
+                {
+                    continue;
+                }
+
+                foreach (var scanRow in bucket)
+                {
+                    if (indexedScanOnLeft)
+                    {
+                        yield return BuildJoinOutput(scanRow, probeRow, join.LeftWidth, join.RightWidth, join.Width);
+                    }
+                    else
+                    {
+                        yield return BuildJoinOutput(probeRow, scanRow, join.LeftWidth, join.RightWidth, join.Width);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<object[]> EnumerateBuckets(


### PR DESCRIPTION
  ## Summary

  This PR extends the C# query runtime’s binary artifact prototype so single-key joins can probe artifact indexes directly when one side is selective and the other side is an indexed artifact-backed scan.

  This builds on the existing `IIndexedRelationProvider` seam and applies it to `KeyJoinNode` without changing the default relation provider contract.

  ## What Changed

  - Added a conservative `KeyJoinNode` fast path for single-key joins against `IIndexedRelationProvider`.
  - Supports both left-scan and right-scan cases, while preserving existing join behavior as fallback.
  - Added `selective_join` mode to `benchmark_scan_materialization.py`.
  - Updated benchmark reporting to surface `KeyJoinIndexedRelationProviderRight` / indexed provider paths clearly.
  - Updated the preprocessed predicate artifact proposal status note.

  ## Benchmark Signal

  Focused benchmark command:

  ```bash
  python3 examples/benchmark/benchmark_scan_materialization.py --scales 300,10k --modes selective_join,join,bound_scan --source-modes preload,artifact --strategies auto --repetitions 5

  Observed selective-join improvement:

  - 300 selective_join artifact: median 0.050s vs preload 0.056s
  - 10k selective_join artifact: median 0.055s vs preload 0.125s
  - Both artifact selective joins use KeyJoinNode:KeyJoinIndexedRelationProviderRight=1

  Broad joins also use the indexed provider path, but remain mixed/slower at larger scale because one side still materializes and the probe set is large. That should stay follow-up work.

  ## Validation

  - dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c Release --nologo
  - python3 -m py_compile examples/benchmark/benchmark_scan_materialization.py
  - python3 examples/benchmark/benchmark_scan_materialization.py --scales 300,10k --modes selective_join,join,bound_scan --source-modes preload,artifact --strategies auto --repetitions 5
  - git diff --check HEAD~1..HEAD