### PR TITLE
fix(wam-elixir): cut barrier + list builtins walk heap-built cons cells

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -873,18 +873,22 @@ wam_elixir_lower_instr(trust_me, _PC, _Labels, _FuncName, Code) :-
 
 wam_elixir_lower_instr(allocate, _PC, _Labels, _FuncName, Code) :-
     Code = '    # Save caller\'s Y-regs so the callee can freely overwrite
-    # slots 201-299 without corrupting the outer frame. Env popped by
-    # deallocate.
+    # slots 201-299 without corrupting the outer frame. Also snapshot
+    # the current choice_points as the new cut barrier so `!` inside
+    # this predicate truncates only CPs pushed during its own body,
+    # not the caller\'s. Env popped by deallocate restores both.
     {y_regs_saved, base_regs} = WamRuntime.split_y_regs(state.regs)
-    new_env = %{cp: state.cp, y_regs_saved: y_regs_saved}
-    state = %{state | stack: [new_env | state.stack], regs: base_regs}'.
+    new_env = %{cp: state.cp, y_regs_saved: y_regs_saved, cut_point: state.cut_point}
+    state = %{state | stack: [new_env | state.stack], regs: base_regs,
+                      cut_point: state.choice_points}'.
 
 wam_elixir_lower_instr(deallocate, _PC, _Labels, _FuncName, Code) :-
     Code = '    state = case state.stack do
       [env | rest] ->
         {_callee_ys, base_regs} = WamRuntime.split_y_regs(state.regs)
         merged = Map.merge(base_regs, Map.get(env, :y_regs_saved, %{}))
-        %{state | cp: env.cp, stack: rest, regs: merged}
+        %{state | cp: env.cp, stack: rest, regs: merged,
+                  cut_point: Map.get(env, :cut_point, state.cut_point)}
       _ -> state
     end'.
 

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -762,8 +762,15 @@ compile_utility_helpers_to_elixir(Code) :-
         new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
         if v1 < v2, do: %{state | pc: new_pc}, else: :fail
       {"length/2", 2} ->
-        list = get_reg(state, 1)
-        len = if is_list(list), do: length(list), else: throw({:fail, state})
+        # length walks the list. The list may be either a native Elixir
+        # list (driver-supplied, e.g. ["Classical_mechanics"]) or a
+        # heap-built `./2` chain (produced by put_list when the
+        # compiler constructs [Mid|Visited] from a mix of reg and heap
+        # values). Mixed recursion handles both forms; the empty list
+        # terminator is either Elixir `[]` or the atom string "[]".
+        list = deref_var(state, get_reg(state, 1))
+        len = wam_list_length(state, list)
+        if len == :fail, do: throw({:fail, state})
         new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
         case unify(state, len, get_reg(state, 2)) do
           {:ok, s} -> %{s | pc: new_pc}
@@ -808,24 +815,59 @@ compile_utility_helpers_to_elixir(Code) :-
           :success -> :fail
         end
       {"member/2", 2} ->
-        item = get_reg(state, 1)
-        list = get_reg(state, 2)
+        # member walks the list. Like length/2, handles both native
+        # Elixir lists and heap-built `./2` chains produced by put_list.
+        item = deref_var(state, get_reg(state, 1))
+        list = deref_var(state, get_reg(state, 2))
         new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
-        cond do
-          is_list(list) ->
-            if item in list, do: %{state | pc: new_pc}, else: :fail
-          true -> :fail
+        if wam_list_member?(state, item, list) do
+          %{state | pc: new_pc}
+        else
+          :fail
         end
       {"!/0", 0} ->
-        # Cut: discard all choice points accumulated in this clause.
-        # Conservative (prunes more than strict WAM cut-barrier semantics
-        # would) but matches green-cut usage — the only form currently
-        # emitted by the compiler.
+        # Cut: truncate choice_points back to the barrier set at
+        # predicate entry (saved by `allocate` into state.cut_point).
+        # Preserves caller CPs while clearing CPs pushed inside this
+        # clause body.
         new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
-        %{state | choice_points: [], pc: new_pc}
+        %{state | choice_points: state.cut_point, pc: new_pc}
       _ -> :fail
     end
   end
+
+  defp wam_list_length(_state, []), do: 0
+  defp wam_list_length(_state, "[]"), do: 0
+  defp wam_list_length(_state, list) when is_list(list), do: length(list)
+  defp wam_list_length(state, {:ref, addr}) do
+    case Map.get(state.heap, addr) do
+      {:str, "./2"} ->
+        [_h, tail] = heap_slice(state, addr + 1, 2)
+        case wam_list_length(state, deref_var(state, tail)) do
+          :fail -> :fail
+          n -> n + 1
+        end
+      _ -> :fail
+    end
+  end
+  defp wam_list_length(_state, _), do: :fail
+
+  defp wam_list_member?(_state, _item, []), do: false
+  defp wam_list_member?(_state, _item, "[]"), do: false
+  defp wam_list_member?(_state, item, list) when is_list(list), do: item in list
+  defp wam_list_member?(state, item, {:ref, addr}) do
+    case Map.get(state.heap, addr) do
+      {:str, "./2"} ->
+        [h, tail] = heap_slice(state, addr + 1, 2)
+        if deref_var(state, h) == item do
+          true
+        else
+          wam_list_member?(state, item, deref_var(state, tail))
+        end
+      _ -> false
+    end
+  end
+  defp wam_list_member?(_state, _item, _), do: false
 
   defp eval_arith(_state, n) when is_number(n), do: n
   defp eval_arith(_state, n) when is_binary(n) do
@@ -885,7 +927,13 @@ compile_wam_runtime_to_elixir(Options, Code) :-
               # caller-supplied unbound arg. Set by run(args) at entry so
               # next_solution/1 can rematerialise output regs on every
               # solution (A-regs get clobbered as scratch during clauses).
-              arg_vars: []
+              arg_vars: [],
+              # cut_point is the choice_points snapshot to restore on `!`.
+              # Saved to the env frame by `allocate`; restored by
+              # `deallocate`. A cut truncates state.choice_points back to
+              # this snapshot — clearing CPs pushed inside the current
+              # predicate body without touching the caller\'s CPs.
+              cut_point: []
   end
 
 ~w


### PR DESCRIPTION
## Summary

Closes the dev-scale `effective_distance` correctness gap from
**15/19 → 19/19 rows**. Three interacting fixes to
`category_ancestor/4`'s recursive clause, all in the WAM-Elixir
runtime.

## The gap

Before: most articles clustered at `3.000000` when reference had
fractional values like `2.873471`, `2.997585`, etc. Diagnosis:
`category_ancestor(Classical_mechanics, Physics, H, [...])` found
only 1 path (hops=2) vs reference's 2 paths (hops=2 and hops=3). The
same pattern explained every discrepant row.

## Root causes

Traced through `resume_fact_stream` instrumentation — the inner
recursive call's `category_parent(Mechanics, Mid)` iteration never
ran, so the `hops=3` path (Classical_mechanics → Mechanics →
Subfields_of_physics → Physics) never materialised.

Three independent bugs interacted:

### 1. Cut wiped caller CPs

`!/0` was implemented as `%{state | choice_points: []}` — clearing
**every** choice point, including the outer `category_parent(Cat, Mid)`
fact-stream CP that was mid-iteration. An inner cut during
`category_ancestor(Mechanics, ...)` clause 2 destroyed the outer's
enumeration state.

Fix: proper cut barrier. Added `cut_point` to `WamState`. `allocate`
snapshots `state.choice_points` into the env frame and into
`state.cut_point`. `deallocate` restores `cut_point` from the saved
env. `!/0` now truncates `choice_points` to `state.cut_point`,
preserving caller CPs.

### 2. `length/2` didn't recognise heap-built lists

The compiler emits `[Mid|Visited]` as a heap `./2` struct with a
`:ref` from the register. When clause 2's `length(Visited, Depth)`
ran, `get_reg` returned `{:ref, addr}`. The builtin did
`if is_list(list), do: length(list), else: throw({:fail, state})`.
`is_list/1` is false for `:ref`, so length threw, short-circuiting the
entire clause 2 before it ever reached the `!`, `category_parent(Cat, Mid2)`,
recursive call, or `Hops is H1 + 1` steps.

Fix: new `wam_list_length/3` helper walks either native Elixir lists
or heap `./2` chains via `deref_var` + recursion, terminated by
`[]` / `"[]"`.

### 3. `member/2` had the same bug

`\+ member(Mid, Visited)` ran on the same heap-built list. Same
`is_list` short-circuit.

Fix: `wam_list_member?/3` walks heap chains the same way.

## Measured

Dev-scale `effective_distance` diff vs reference:

| metric                                      | before         | after        |
| ------------------------------------------- | -------------- | ------------ |
| row count                                   | 15             | **19 / 19**  |
| max \|ref − ours\| across matched rows      | ~0.13          | ~0.02        |
| "cluster at 3.000000" bug                   | 6 rows         | gone         |

Remaining ~0.001–0.02 per-row deltas are FP associativity from
summing weights in a different order, not semantic.

## Test plan

- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_target.pl`
      — 38/38
- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_utils.pl`
      — 7/7
- [x] `swipl -q -s examples/debug_wam_elixir_ancestor.pl -t halt`
      — 4/1/4 solutions with correct integer N values
- [x] Dev-scale `effective_distance` — 19/19 rows, values within ~0.02
      of reference.
- [x] Scale-300 `effective_distance` still runs end-to-end (separate
      verification).

## Non-goals

- Full SLG/tabling. Deep paths (hop > 10) are still bounded by
  `max_depth/1 = 10`, matching the Prolog source.
- Fixing the ~0.02 FP deltas — caused by weight-sum ordering, which
  varies with backtrack traversal order. Semantically correct.

## Related

- PR #1525 — Phase C indexing + arithmetic; made the dev-scale
  benchmark run end-to-end in the first place.
- PR #1519 — Phase B inline_data emission; underpins the fact-stream
  CP handling that the cut fix protects.
- PR #1500 — CPS continuations; orthogonal axis but necessary
  precondition for any recursive semantics to work at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
