### PR TITLE
feat(wam-clojure): stream ancestor foreign kernel

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -315,11 +315,18 @@ for further optimization work.
     restores the pre-foreign state and tries the next solution. This is the
     generic runtime surface needed before moving traversal kernels out of
     runner-specific code.
+16. Clojure `kernels_on` now exposes `category_ancestor/4` through that
+    generic streaming `call-foreign` surface. The generated handler builds a
+    parent adjacency map from facts, returns multiple `{Ancestor, Hops}`
+    solutions via `:solutions`, and keeps `kernels_off` on the pure WAM path.
+    The effective-distance runner still has its runner-side traversal index,
+    but the WAM predicate surface now has the same shape needed to replace it.
 
 ### Highest-value remaining work
 
-1. Move the Clojure traversal kernel onto the generic streaming `call-foreign`
-   surface instead of keeping it runner-specific.
+1. Update the Clojure effective-distance runner to consume the generic
+   streaming `category_ancestor/4` foreign path instead of its bespoke
+   runner-side traversal index.
 2. Add proper heap/trail semantics instead of relying primarily on the
    bindings table.
 3. Reduce choice-point snapshots toward the lighter Haskell/Rust model once

--- a/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
@@ -4,6 +4,7 @@
             generate/4,
             parse_kernel_mode/2,
             category_parent_handler_code/1,
+            category_ancestor_handler_code/1,
             collect_wam_predicates/2,
             collect_wam_predicates/3
           ]).
@@ -104,12 +105,14 @@ parse_variant(accumulated, [
 ]).
 
 parse_kernel_mode(kernels_on, [
-    foreign_predicates([category_parent/2]),
+    foreign_predicates([category_parent/2, category_ancestor/4]),
     clojure_foreign_handlers([
-        handler(category_parent/2, HandlerCode)
+        handler(category_parent/2, ParentHandlerCode),
+        handler(category_ancestor/4, AncestorHandlerCode)
     ])
 ]) :-
-    category_parent_handler_code(HandlerCode).
+    category_parent_handler_code(ParentHandlerCode),
+    category_ancestor_handler_code(AncestorHandlerCode).
 parse_kernel_mode(kernels_off, [
     no_kernels(true)
 ]).
@@ -133,6 +136,31 @@ category_parent_edge_literal(Child-Parent, Literal) :-
     clj_string_literal_local(Child, ChildLit),
     clj_string_literal_local(Parent, ParentLit),
     format(atom(Literal), '[~w ~w]', [ChildLit, ParentLit]).
+
+category_ancestor_handler_code(HandlerCode) :-
+    category_parent_map_literal(ParentsByChild),
+    benchmark_max_depth_literal(MaxDepth),
+    format(string(HandlerCode),
+           "(let [parents-by-child {~s} max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (get parents-by-child category [])] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] {:solutions (vec solutions)})))",
+           [ParentsByChild, MaxDepth]).
+
+category_parent_map_literal(Literal) :-
+    findall(Child,
+            current_category_parent_fact(Child, _),
+            Children0),
+    sort(Children0, Children),
+    maplist(category_parent_bucket_literal, Children, BucketLiterals),
+    atomic_list_concat(BucketLiterals, ' ', Literal).
+
+category_parent_bucket_literal(Child, Literal) :-
+    findall(Parent,
+            current_category_parent_fact(Child, Parent),
+            Parents0),
+    sort(Parents0, Parents),
+    clj_string_literal_local(Child, ChildLit),
+    maplist(clj_string_literal_local, Parents, ParentLiterals),
+    atomic_list_concat(ParentLiterals, ' ', ParentBody),
+    format(atom(Literal), '~w [~w]', [ChildLit, ParentBody]).
 
 clj_string_literal_local(In, Literal) :-
     atom_string(In, InStr0),

--- a/tests/test_wam_clojure_benchmark_generator.pl
+++ b/tests/test_wam_clojure_benchmark_generator.pl
@@ -9,7 +9,7 @@
 test(kernel_mode_options) :-
     parse_kernel_mode(kernels_on, OnOptions),
     parse_kernel_mode(kernels_off, OffOptions),
-    assertion(member(foreign_predicates([category_parent/2]), OnOptions)),
+    assertion(member(foreign_predicates([category_parent/2, category_ancestor/4]), OnOptions)),
     assertion(member(clojure_foreign_handlers(_), OnOptions)),
     assertion(OffOptions == [no_kernels(true)]).
 
@@ -28,8 +28,10 @@ test(generate_seeded_kernels_on_project) :-
         read_file_to_string(CorePath, CoreCode, []),
         assertion(sub_string(CoreCode, _, _, _, '(def foreign-handlers {')),
         assertion(sub_string(CoreCode, _, _, _, '"category_parent/2" (let [edges #{')),
+        assertion(sub_string(CoreCode, _, _, _, '"category_ancestor/4" (let [parents-by-child {')),
         assertion(sub_string(CoreCode, _, _, _, '["Abstraction" "Thought"]')),
         assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_parent" :arity 2}')),
+        assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_ancestor" :arity 4}')),
         assertion(sub_string(CoreCode, _, _, _, '(def benchmark-use-traversal-kernel? true)')),
         assertion(sub_string(CoreCode, _, _, _, '(def benchmark-ancestor-hops-index')),
         assertion(sub_string(CoreCode, _, _, _, '(benchmark-build-ancestor-hops-index)')),
@@ -44,7 +46,9 @@ test(generate_seeded_kernels_off_project) :-
         read_file_to_string(CorePath, CoreCode, []),
         assertion(sub_string(CoreCode, _, _, _, '(def foreign-handlers {')),
         assertion(\+ sub_string(CoreCode, _, _, _, '"category_parent/2" (let [edges #{')),
+        assertion(\+ sub_string(CoreCode, _, _, _, '"category_ancestor/4" (let [parents-by-child {')),
         assertion(\+ sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_parent" :arity 2}')),
+        assertion(\+ sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_ancestor" :arity 4}')),
         assertion(sub_string(CoreCode, _, _, _, '(def benchmark-use-traversal-kernel? false)')),
         assertion(sub_string(CoreCode, _, _, _, '(benchmark-ancestor-hops category root #{category})')),
         delete_directory_and_contents(TmpDir)
@@ -58,6 +62,15 @@ test(generated_category_parent_handler_executes, [condition(clojure_available)])
                               ['Abstraction', 'Thought'], "true"),
         run_clojure_predicate(TmpDir, 'category_parent/2',
                               ['Abstraction', 'NotAParent'], "false"),
+        run_clojure_predicate(TmpDir, 'category_ancestor/4',
+                              ['Abstraction', 'Thought', raw('{:var 1000}'), visited(['Abstraction'])],
+                              "true"),
+        run_clojure_predicate(TmpDir, 'category_ancestor/4',
+                              ['Abstraction', 'Cognition', raw('{:var 1000}'), visited(['Abstraction'])],
+                              "true"),
+        run_clojure_predicate(TmpDir, 'category_ancestor/4',
+                              ['Abstraction', 'NotAParent', raw('{:var 1000}'), visited(['Abstraction'])],
+                              "false"),
         delete_directory_and_contents(TmpDir)
     )).
 
@@ -70,7 +83,7 @@ unique_tmp_dir(Prefix, TmpDir) :-
 
 run_clojure_predicate(ProjectDir, PredKey, Args, Output) :-
     find_clojure_classpath(ClassPath),
-    maplist(clojure_string_arg, Args, EdnArgs),
+    maplist(clojure_edn_arg, Args, EdnArgs),
     process_create(path(java),
                    ['-cp', ClassPath, 'clojure.main', '-m',
                     'generated.wam_clojure_optimized_bench.core', PredKey|EdnArgs],
@@ -98,8 +111,18 @@ run_clojure_predicate(ProjectDir, PredKey, Args, Output) :-
     ;   throw(error(java_stderr(PredKey, Args, ErrStr), _))
     ).
 
-clojure_string_arg(Atom, Edn) :-
+clojure_edn_arg(raw(Edn), Edn) :- !.
+clojure_edn_arg(visited(Atoms), Edn) :- !,
+    visited_list_edn(Atoms, Edn).
+clojure_edn_arg(Atom, Edn) :-
     format(string(Edn), '"~w"', [Atom]).
+
+visited_list_edn([], '"[]"').
+visited_list_edn([Atom|Rest], Edn) :-
+    visited_list_edn(Rest, Tail),
+    format(string(Edn),
+           '{:tag :struct :functor "[|]/2" :args ["~w" ~w]}',
+           [Atom, Tail]).
 
 clojure_available :-
     find_clojure_classpath(_).


### PR DESCRIPTION
## Summary

Moves the Clojure benchmark `category_ancestor/4` predicate surface onto the generic streaming `call-foreign` runtime path.

`kernels_on` now emits a generated Clojure foreign handler for `category_ancestor/4` that returns multiple `{Ancestor, Hops}` answers through `{:solutions [...]}`. `kernels_off` remains the pure WAM fallback.

## Details

- Extends the Clojure optimized benchmark generator so `kernels_on` marks both `category_parent/2` and `category_ancestor/4` as foreign predicates.
- Adds a generated `category_ancestor/4` handler that builds a parent adjacency map from facts, respects visited-cycle checks, applies the benchmark max-depth bound, and binds output arguments 2 and 3.
- Keeps `category_parent/2` foreign handling intact.
- Keeps `kernels_off` suppressing foreign stubs for fallback comparisons.
- Extends benchmark generator tests to assert `category_ancestor/4` foreign stub generation and suppression.
- Adds generated Clojure execution checks for direct ancestry, recursive ancestry, and a failing ancestry query.
- Updates the WAM performance optimization log with the new Clojure ancestor-kernel milestone.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
- `git diff --check`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-accumulated,clojure-wam-accumulated-no-kernels,clojure-wam-seeded,clojure-wam-seeded-no-kernels,prolog-accumulated --scales dev --repetitions 1`

The small `dev` matrix still reports matching normalized output digests across all Clojure WAM modes and `prolog-accumulated`.

## Remaining Work

The full effective-distance runner still uses its bespoke runner-side traversal index. The next step is to update that runner to consume the generic streaming `category_ancestor/4` foreign path directly.
