### PR TITLE
docs(wam-wat): user-facing target page + overview mention

### DIFF
--- a/docs/targets/overview.md
+++ b/docs/targets/overview.md
@@ -30,6 +30,10 @@ This document frames how UnifyWeaver maps logical predicates onto executable env
 - **SQL** (`target(sql)`)
   Generates declarative SQL queries (SELECT, CREATE VIEW) for execution on relational databases. Unlike other targets that emit executable code, SQL output is meant for external database execution. Supports full SQL feature set including JOINs, aggregations, subqueries, window functions, CTEs, recursive CTEs, and set operations.
 
+### WebAssembly Targets
+- **WAM-WAT** (`target(wam_wat)`)
+  Compiles Prolog through a textual WAM intermediate form into a self-contained WebAssembly module (`.wat`/`.wasm`). Runs in any WASM runtime (browser, Node.js, Wasmtime, Wasmer). The runtime interprets WAM bytecode via a tagged-dispatch `$step` loop; an 8-pass peephole optimizer fuses common patterns (first-arg type dispatch, neck-cut-deterministic clauses, tail-call setup, clause-end cleanups) into specialized instructions. See [`wam-wat.md`](wam-wat.md) for details. Sibling targets in the broader WAM family (Go, Rust, LLVM, ILAsm, Elixir, JVM) emit host-language source instead; see `src/unifyweaver/targets/wam_*_target.pl`.
+
 ### Scripting Targets
 - **Python** (`target(python)`)
   Generates Python scripts with strong recursion support, ML integration, and pipeline chaining. Ideal for data science workflows and rapid prototyping.
@@ -45,6 +49,7 @@ Preferences (`preferences.pl`) and runtime options choose a target. Planned beha
 - `target(csharp)` acts as a smart facade, preferring `csharp_codegen` where features exist and falling back to `csharp_query` when advanced behaviour (e.g., recursion) is required.
 - `target(bash)` continues to reference the existing Bash ecosystem (partitioning, fork, etc.).
 - `target(sql)` generates SQL queries for database execution rather than standalone programs.
+- `target(wam_wat)` compiles through the WAM intermediate form to a self-contained WebAssembly module — useful where WASM is the deployment platform (browser, embedded runtimes, sandboxed execution).
 
 ## Why Multiple Targets
 - Operational diversity: Bash fits quick shell deployment; C# unlocks integration with managed runtimes, type safety, and IDE tooling.

--- a/docs/targets/wam-wat.md
+++ b/docs/targets/wam-wat.md
@@ -1,0 +1,162 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+Copyright (c) 2025-2026 John William Creighton (@s243a)
+-->
+# WAM-WAT Target Overview (`target(wam_wat)`)
+
+The WAM-WAT target compiles Prolog predicates to WebAssembly
+(`.wasm` via `.wat`), producing self-contained modules that
+interpret a WAM bytecode stream at runtime. Unlike the other
+targets documented here — which emit source code for a specific
+host language — WAM-WAT emits a compact binary artifact that
+runs anywhere with a WebAssembly runtime: the browser, Node.js,
+Wasmtime, Wasmer, or other embedders.
+
+For implementation and architecture details, see
+[`docs/design/WAM_WAT_ARCHITECTURE.md`](../design/WAM_WAT_ARCHITECTURE.md).
+
+## Design Highlights
+
+- **WAM-first pipeline**: Predicates compile to a textual WAM
+  intermediate form via `wam_target.pl`, then to a
+  bytecode-oriented `.wat` module via `wam_wat_target.pl`. The
+  two layers share the instruction vocabulary with the broader
+  WAM family (Go, Rust, LLVM, ILAsm, Elixir, JVM backends).
+- **73-instruction bytecode**: Includes the base WAM instruction
+  set plus fused instructions (arg/3 fast paths, tail-call
+  collapses, clause-end combinations) and first-argument
+  indexing. The fused instructions are produced by an 8-pass
+  peephole optimizer during compilation.
+- **Self-contained output**: A single `.wat` file is emitted.
+  Running `wat2wasm bench_suite.wat -o bench_suite.wasm`
+  produces a `.wasm` module with no external dependencies beyond
+  three small host imports (`print_i64`, `print_char`,
+  `print_newline`) used only for optional output.
+- **V8 JIT-friendly dispatch**: The runtime uses a `br_table`
+  dispatch in a single `$step` function that returns after each
+  instruction, paired with an outer `$run_loop` driver. V8's
+  JIT inlines and tiers this pattern effectively.
+- **Structured control flow throughout**: No indirect control
+  flow primitives are used beyond `br_table` — every dispatch
+  is via a tagged instruction that the peephole layer has
+  already specialized.
+
+## Strengths
+
+- **Portable**: The compiled `.wasm` runs in any wasm runtime.
+  Ideal for embedding Prolog-derived logic in browsers, sandboxed
+  environments, or cross-platform applications.
+- **Predictable performance**: Benchmarks on the bundled
+  `bench_suite.wasm` (13 workloads covering arithmetic, unify,
+  term inspection, tree walking, and fib) show competitive times
+  vs SWI-Prolog on Termux/V8, with ~55% cumulative improvement
+  on term-walking workloads since the Phase 6 baseline (April
+  2026).
+- **Deterministic binary output**: The compiled module is a
+  pure function of the Prolog source plus the (versioned)
+  peephole pipeline. No host-toolchain variability.
+- **No runtime unification explosion**: The trail-aware
+  `neck_cut_test` and first-arg `type_dispatch_a1` eliminate
+  choice-point pushes for common cut-deterministic and
+  type-dispatched patterns.
+
+## Limitations
+
+- **Interpreter, not native code**: The runtime still executes
+  the WAM bytecode via a dispatch loop — not a transpile-to-host
+  like the Go/Rust/C# targets. Faster than naive WAM
+  implementations thanks to aggressive instruction fusion, but
+  the dispatch cost is still the dominant hot-loop overhead
+  (~50% of `bench_sum_big`).
+- **Limited to the WAM subset**: Features outside the WAM
+  intermediate form (e.g., the full query runtime, aggregate
+  semantics) aren't available through this target. Use one of
+  the higher-level targets (Go, C# query runtime, SQL) for
+  those workloads.
+- **WASM runtime required**: The output needs a V8 / Wasmtime /
+  Wasmer / equivalent to run. For pipeline integration on a
+  bare Unix box without one, the Bash target is more convenient.
+- **Peephole coverage is bench-driven**: The fused instructions
+  were motivated by specific bench workload patterns (sum-over-
+  compound, term depth, fib). Predicates with very different
+  structure will hit fewer optimized paths and may be closer
+  to the unoptimized baseline.
+
+## Usage
+
+```prolog
+% Compile a list of predicates to a WAM-WAT module
+:- use_module('src/unifyweaver/targets/wam_wat_target').
+
+?- write_wam_wat_project(
+       [bench_suite:sum_ints/3,
+        bench_suite:term_depth/2],
+       [module_name(my_module)],
+       'output.wat').
+```
+
+Then:
+
+```bash
+wat2wasm output.wat -o output.wasm
+
+# In Node.js:
+node -e '
+  const {instance} = await WebAssembly.instantiate(
+    require("fs").readFileSync("output.wasm"),
+    {env: {print_i64:()=>{}, print_char:()=>{}, print_newline:()=>{}}}
+  );
+  console.log(instance.exports.sum_ints_3(...));
+'
+```
+
+### Benchmark suite
+
+The bundled benchmark lives at
+`examples/wam_term_builtins_bench/`. Regenerate and run with:
+
+```bash
+cd examples/wam_term_builtins_bench
+swipl ../../src/unifyweaver/targets/wam_wat_target.pl  # (sanity check)
+swipl generate_wat_bench.pl                             # regenerate bench_suite.wat
+wat2wasm bench_suite.wat -o bench_suite.wasm
+node run_bench.js bench_suite.wasm                      # runs all 13 workloads
+```
+
+For single-workload focused profiling:
+
+```bash
+node --cpu-prof profile_one.js bench_suite.wasm bench_sum_big_0 300000
+```
+
+## Relation to the WAM family
+
+UnifyWeaver has several WAM-based targets that share the same
+WAM text IR via `wam_target.pl`:
+
+| Backend | Host output | Use case |
+|---------|-------------|----------|
+| `wam_go_target` | Go source | Compiled native binaries |
+| `wam_rust_target` | Rust source | Memory-safe native binaries |
+| `wam_llvm_target` | LLVM IR | Cross-platform native code |
+| `wam_ilasm_target` | CIL assembly | .NET runtime |
+| `wam_elixir_target` | Elixir source | BEAM VM / distributed apps |
+| `wam_jvm_target` | JVM bytecode | Java runtime (Jamaica/Krakatau) |
+| **`wam_wat_target`** | **WebAssembly** | **Browser / cross-platform runtime** |
+
+The WAM-WAT peephole optimizations (first-arg tag dispatch,
+neck-cut-test, tail-call fusion, clause-end fusion) are currently
+WAM-WAT-specific; moving them to the shared `wam_target.pl` layer
+so other backends benefit is a listed follow-up in the
+architecture doc.
+
+## See Also
+
+- [`docs/design/WAM_WAT_ARCHITECTURE.md`](../design/WAM_WAT_ARCHITECTURE.md)
+  — pipeline, instruction set, runtime data structures,
+  optimization family walkthroughs, performance trajectory.
+- [`docs/design/WAM_TERM_BUILTINS_PHASE_6_PERF.md`](../design/WAM_TERM_BUILTINS_PHASE_6_PERF.md)
+  — historical baseline with SWI-Prolog comparisons before the
+  recent optimization work.
+- [`examples/wam_term_builtins_bench/`](../../examples/wam_term_builtins_bench/)
+  — 13-workload benchmark suite used for A/B measurement.


### PR DESCRIPTION
## Summary

Follow-up to PR #1536 (design-level architecture doc) that adds
the user-facing entry points for the WAM-WAT target:

1. **New `docs/targets/wam-wat.md`** — target overview page
   alongside the existing `bash.md` / `go.md` / `rust.md` /
   `sql.md` etc.
2. **Updated `docs/targets/overview.md`** — new "WebAssembly
   Targets" section + addition to the "Selecting Targets" list.

WAM-WAT previously had no presence in the target documentation
despite being a distinct backend in the codebase. After this PR,
a reader browsing `docs/targets/` finds it via the normal
convention.

## Why split the documentation

The architecture doc (PR #1536, at
`docs/design/WAM_WAT_ARCHITECTURE.md`) is design-level: pipeline,
peephole passes, instruction set, env frame layout, runtime data
structures. It's the reference for contributors extending the
target.

The user-facing doc added here is in the conventional
`docs/targets/` location where users look for:
- What the target does and when to use it
- Strengths and limitations
- Concrete usage example
- Benchmark suite commands
- Pointers to deeper docs

Following the two-layer split that other subsystems use (e.g.
the C# targets split between `docs/targets/csharp-*.md` and
`docs/design/CLIENT_SERVER_*.md`).

## Content of the new target page

### Design highlights
- WAM-first pipeline (shared with Go/Rust/LLVM/ILAsm/Elixir/JVM)
- 73-instruction bytecode (base WAM + fused instructions +
  first-arg indexing)
- Self-contained `.wat`/`.wasm` output with three small host
  imports for optional I/O
- V8 JIT-friendly `$step` + `$run_loop` dispatch architecture

### Strengths
- Portable: runs in any WASM runtime
- Predictable performance (deterministic binary output)
- No runtime unification explosion (trail-aware neck_cut +
  type_dispatch)
- ~55% cumulative perf improvement since Phase 6 baseline on
  term-walking workloads

### Limitations
- Interpreter, not native transpile — still a dispatch loop
- WAM subset only (not the full query runtime)
- WASM runtime required
- Peephole coverage is bench-driven

### Usage example
Direct `write_wam_wat_project/3` call, plus Node.js embedder
snippet, plus benchmark-suite commands.

### WAM family table
Positions WAM-WAT alongside its sibling WAM backends (Go, Rust,
LLVM, ILAsm, Elixir, JVM). Each emits for a different host;
WAM-WAT is the WASM-emitting one.

## Overview.md changes

Added a new "WebAssembly Targets" section in the same style as
the existing "Shell Targets", "Systems Language Targets", ".NET
Targets", "Declarative Targets", and "Scripting Targets"
sections. Slotted between Declarative (SQL) and Scripting
(Python/Perl/Ruby).

Also added `target(wam_wat)` to the "Selecting Targets"
bulleted list.

## Changes

| File | Lines | What |
|---|---|---|
| `docs/targets/wam-wat.md` | +162 (new) | user-facing target overview |
| `docs/targets/overview.md` | +5 | "WebAssembly Targets" section + target(wam_wat) in selection list |

No code changes. Pure documentation.

## Test plan

- [x] Both files render correctly as markdown
- [x] Cross-links work (to `docs/design/WAM_WAT_ARCHITECTURE.md`,
      `docs/design/WAM_TERM_BUILTINS_PHASE_6_PERF.md`,
      `examples/wam_term_builtins_bench/`)
- [x] Usage example matches actual API surface
  (`write_wam_wat_project/3`)
- [x] Benchmark-suite commands match actual scripts in
  `examples/wam_term_builtins_bench/`
- [x] `target(wam_wat)` is the actual option name registered
  in the target dispatcher

## Follow-ups (not in this PR)

- **Enrich `comparison.md`** — the target-comparison matrix
  (`docs/targets/comparison.md`) currently compares Bash, C#,
  Go, Rust, Python, Perl, Ruby. Adding WAM-WAT as a column
  would give users the "when WAM-WAT vs when Go/Rust" signal.
  Out of scope here; left as a natural follow-up.
- **Keep the doc in sync as features evolve** — any new
  instruction, peephole pass, or runtime change should update
  both the design doc and the user-facing target page.
- **Companion target pages for other WAM-family backends** —
  `wam_go_target.pl`, `wam_rust_target.pl`, etc. don't have
  their own user-facing pages either. The WAM-WAT page could
  serve as a template if/when those get documented.
