### PR TITLE
docs(wam-wat): add WAM-WAT column to target comparison matrix

### DIFF
--- a/docs/targets/comparison.md
+++ b/docs/targets/comparison.md
@@ -4,80 +4,104 @@ This document compares all UnifyWeaver compilation targets to help choose the ap
 
 ## Full Comparison Matrix
 
-| Capability | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL |
-|------------|------|-----|------|--------|------------|----------|-----|
-| **Artefact Form** | Shell script | Go binary | Rust binary | Python script | C# source | Query IR | SQL queries |
-| **Runtime Deps** | POSIX shell | None | None | Python 3 | .NET | .NET | Database |
-| **Binary Output** | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Capability | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL | WAM-WAT |
+|------------|------|-----|------|--------|------------|----------|-----|---------|
+| **Artefact Form** | Shell script | Go binary | Rust binary | Python script | C# source | Query IR | SQL queries | `.wasm` module |
+| **Runtime Deps** | POSIX shell | None | None | Python 3 | .NET | .NET | Database | WASM runtime |
+| **Binary Output** | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 
 ### Execution Model
 
-| Feature | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL |
-|---------|------|-----|------|--------|------------|----------|-----|
-| Facts | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Single Rules | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Multiple Rules (OR) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Feature | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL | WAM-WAT |
+|---------|------|-----|------|--------|------------|----------|-----|---------|
+| Facts | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Single Rules | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Multiple Rules (OR) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ### Recursion Support
 
-| Pattern | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL |
-|---------|------|-----|------|--------|------------|----------|-----|
-| Tail Recursion | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ |
-| Linear Recursion | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ |
-| Mutual Recursion | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ |
-| Transitive Closure | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ (CTE) |
+| Pattern | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL | WAM-WAT |
+|---------|------|-----|------|--------|------------|----------|-----|---------|
+| Tail Recursion | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ |
+| Linear Recursion | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ |
+| Mutual Recursion | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ |
+| Transitive Closure | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ (CTE) | ✅ |
 
 ### Aggregations
 
-| Feature | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL |
-|---------|------|-----|------|--------|------------|----------|-----|
-| count/sum/avg | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| min/max | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **stddev** | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| **median** | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| **percentile** | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| **collect_list** | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ |
-| **collect_set** | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ |
+| Feature | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL | WAM-WAT |
+|---------|------|-----|------|--------|------------|----------|-----|---------|
+| count/sum/avg | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
+| min/max | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
+| **stddev** | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **median** | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **percentile** | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **collect_list** | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ |
+| **collect_set** | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ |
 
 ### Window Functions
 
-| Feature | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL |
-|---------|------|-----|------|--------|------------|----------|-----|
-| row_number | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| rank/dense_rank | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| **LAG** | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
-| **LEAD** | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
-| **first_value** | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
-| **last_value** | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Feature | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL | WAM-WAT |
+|---------|------|-----|------|--------|------------|----------|-----|---------|
+| row_number | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| rank/dense_rank | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| **LAG** | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| **LEAD** | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| **first_value** | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| **last_value** | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
 
 ### Joins
 
-| Feature | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL |
-|---------|------|-----|------|--------|------------|----------|-----|
-| Inner Join | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **LEFT OUTER** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **RIGHT OUTER** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **FULL OUTER** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Feature | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL | WAM-WAT |
+|---------|------|-----|------|--------|------------|----------|-----|---------|
+| Inner Join | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **LEFT OUTER** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
+| **RIGHT OUTER** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
+| **FULL OUTER** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 
 ### Observability
 
-| Feature | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL |
-|---------|------|-----|------|--------|------------|----------|-----|
-| **Progress Reporting** | ❌ | ✅ | ✅ | ✅ | ❌ | ⚠️ | ❌ |
-| **Error Logging** | ❌ | ✅ | ✅ | ✅ | ❌ | ⚠️ | ❌ |
-| **Error Threshold** | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| **Metrics Export** | ❌ | ✅ | ✅ | ✅ | ❌ | ⚠️ | ❌ |
+| Feature | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL | WAM-WAT |
+|---------|------|-----|------|--------|------------|----------|-----|---------|
+| **Progress Reporting** | ❌ | ✅ | ✅ | ✅ | ❌ | ⚠️ | ❌ | ❌ |
+| **Error Logging** | ❌ | ✅ | ✅ | ✅ | ❌ | ⚠️ | ❌ | ❌ |
+| **Error Threshold** | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Metrics Export** | ❌ | ✅ | ✅ | ✅ | ❌ | ⚠️ | ❌ | ❌ |
 
 ### Data Sources
 
-| Source | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL |
-|--------|------|-----|------|--------|------------|----------|-----|
-| JSONL Stream | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ❌ |
-| CSV/Delimited | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ❌ |
-| XML | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| Database | ❌ | ✅ (BoltDB) | ✅ (sled) | ⚠️ (SQLite) | ❌ | ❌ | ✅ |
+| Source | Bash | Go | Rust | Python | C# Codegen | C# Query | SQL | WAM-WAT |
+|--------|------|-----|------|--------|------------|----------|-----|---------|
+| JSONL Stream | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ❌ | ❌ |
+| CSV/Delimited | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ❌ | ❌ |
+| XML | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Database | ❌ | ✅ (BoltDB) | ✅ (sled) | ⚠️ (SQLite) | ❌ | ❌ | ✅ | ❌ |
 
 Legend: ✅ Complete | ⚠️ Partial | ❌ Not Implemented
+
+### WAM-WAT notes
+
+The WAM-WAT column reflects the WAM interpreter's feature set
+rather than per-backend code generation:
+
+- **Aggregations** (⚠️): The WAM instruction set includes
+  `begin_aggregate` / `end_aggregate` framing, but the richer
+  aggregation DSL that the source-code backends expose isn't
+  fully wired through this target.
+- **Outer joins** (⚠️): Disjunctions like
+  `(left(X, Y) ; X = null)` execute correctly via `try_me_else`
+  chains, but the backend-specific pattern detection that the
+  Bash/Go/Rust targets use to generate specialized join code is
+  absent. You get "whatever WAM gives you" rather than
+  "optimized for join shape".
+- **Observability / data sources** (❌): WAM-WAT is a pure
+  predicate executor. It doesn't ingest data streams or emit
+  metrics. Predicates either encode facts directly or are
+  called with pre-materialized arguments.
+
+See [`wam-wat.md`](wam-wat.md) for the target overview and
+[`../design/WAM_WAT_ARCHITECTURE.md`](../design/WAM_WAT_ARCHITECTURE.md)
+for the implementation-level reference.
 
 ---
 
@@ -95,6 +119,8 @@ Legend: ✅ Complete | ⚠️ Partial | ❌ Not Implemented
 | Enterprise .NET stack | C# Query | LINQ integration |
 | Database analytics | SQL | Native window functions |
 | Analytics with LAG/LEAD | Go or SQL | Full window function support |
+| Browser / sandboxed execution | WAM-WAT | Portable WASM module |
+| Cross-runtime predicate logic | WAM-WAT | Same `.wasm` runs anywhere |
 
 ### By Feature Priority
 
@@ -104,8 +130,9 @@ Legend: ✅ Complete | ⚠️ Partial | ❌ Not Implemented
 | Window functions | Go, SQL |
 | Database integration | Go (BoltDB), SQL |
 | Observability | Go, Rust, Python |
-| Recursion | Bash, Go, Python, C# Query |
+| Recursion | Bash, Go, Python, C# Query, WAM-WAT |
 | Type safety | Rust, Go, C# |
+| Portable deployment | WAM-WAT, Go |
 
 ---
 
@@ -128,3 +155,4 @@ This approach gives immediate value from the existing code generator while allow
 - [SQL Target](sql.md)
 - [Bash Target](bash.md)
 - [C# Targets](csharp-codegen.md)
+- [WAM-WAT Target](wam-wat.md)


### PR DESCRIPTION
## Summary

Extends `docs/targets/comparison.md` to include WAM-WAT alongside
the existing Bash / Go / Rust / Python / C# Codegen / C# Query /
SQL columns. Completes the WAM-WAT documentation thread (design
doc, user-facing overview, and now the comparison page).

## What the new column shows

### Added as an 8th column to every table

- **Full capability matrix**: artefact form (`.wasm` module),
  runtime deps (WASM runtime), binary output (✅)
- **Execution model**: facts / single rules / multiple rules —
  all ✅ (WAM handles these generically)
- **Recursion**: tail / linear / mutual / transitive closure —
  all ✅
- **Aggregations**: count/sum/avg and min/max as ⚠️ (framing
  instructions exist but the DSL isn't fully wired); others as ❌
- **Window functions**: all ❌ (analytics-level, not at WAM layer)
- **Joins**: inner ✅; outer joins ⚠️ (disjunctions work but
  without backend-specific pattern detection)
- **Observability / data sources**: all ❌ (pure executor)

### Added to selection guide tables

- "By Use Case" table: new rows for _browser / sandboxed
  execution_ and _cross-runtime predicate logic_ recommending
  WAM-WAT
- "By Feature Priority" table: WAM-WAT added to recursion
  support and portable deployment rows

### Added "WAM-WAT notes" subsection

Under the main matrix, a prose section explains the ⚠️ and ❌
ratings — why aggregations are partial, what the outer-join
caveat means, and why observability/data-source columns are
empty. Links to the deeper docs.

### Added to "See Also" links

## Why conservative ratings

The ⚠️ and ❌ ratings were chosen to avoid overclaiming. The
WAM-WAT target executes any WAM-compiled predicate correctly,
but doesn't expose the host-language-specific conveniences that
the source-code backends do (JSON ingestion, CSV parsing,
BoltDB integration, LINQ bridging, etc.). Users comparing
targets should see that the backend has a different scope
rather than a smaller feature count.

When a feature is genuinely present but not as rich as the
source-code targets (aggregation framing, disjunction-as-outer-
join), the rating is ⚠️ with an explanatory note. When a
feature is outside the target's scope entirely (data-source
ingestion, metrics export), the rating is ❌.

## Changes

| File | Lines | What |
|---|---|---|
| `docs/targets/comparison.md` | +80 / −52 | 8th column added to 8 tables; WAM-WAT rows added to 2 selection guide tables; "WAM-WAT notes" subsection; See Also link |

No code changes. Documentation only.

## Test plan

- [x] All tables still render correctly after column addition
- [x] Values in the new column are consistent with the
      WAM-WAT target's actual capabilities
- [x] Cross-links to `wam-wat.md` and `WAM_WAT_ARCHITECTURE.md`
      resolve correctly
- [x] Selection guide recommendations align with the target's
      design strengths

## Thread complete

This PR closes the three-document WAM-WAT documentation thread:

1. PR #1536 — `docs/design/WAM_WAT_ARCHITECTURE.md` (design)
2. PR #1538 — `docs/targets/wam-wat.md` + overview.md (user-facing)
3. **This PR** — `docs/targets/comparison.md` (matrix)

A reader browsing the target docs now finds WAM-WAT:
- In the target overview list (from #1538)
- On its own page alongside other targets (from #1538)
- As a column in the comparison matrix (this PR)
- With links to the deep design doc (from #1536)

## Follow-ups (not in this PR)

- **Perl / Ruby in the comparison matrix** — they're in
  `overview.md` but the comparison matrix doesn't include them
  either. Consistency fix; out of scope here.
- **Add columns for other WAM-family backends** — `wam_go_target`,
  `wam_rust_target`, etc. aren't represented in the comparison
  at all. Whether they should be distinct columns or bundled
  under their "host language" column is a design decision that
  needs their respective owners' input.
