### PR TITLE
feat(wam-clojure): run benchmark via foreign ancestor

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -321,12 +321,16 @@ for further optimization work.
     solutions via `:solutions`, and keeps `kernels_off` on the pure WAM path.
     The effective-distance runner still has its runner-side traversal index,
     but the WAM predicate surface now has the same shape needed to replace it.
+17. Clojure `kernels_on` effective-distance runner now consumes the generic
+    streaming `category_ancestor/4` foreign handler directly. The bespoke
+    runner-side `benchmark-ancestor-hops-index` materialization is gone;
+    `kernels_off` still uses the pure recursive runner path for comparison.
 
 ### Highest-value remaining work
 
-1. Update the Clojure effective-distance runner to consume the generic
-   streaming `category_ancestor/4` foreign path instead of its bespoke
-   runner-side traversal index.
+1. Start reducing Clojure runtime overhead now that the traversal kernel path
+   is generic: avoid full choice-point snapshots where foreign choice points
+   only need a narrow state slice.
 2. Add proper heap/trail semantics instead of relying primarily on the
    bindings table.
 3. Reduce choice-point snapshots toward the lighter Haskell/Rust model once

--- a/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
@@ -232,21 +232,25 @@ effective_distance_runner_code(KernelModeAtom, Code) :-
                   hop (benchmark-ancestor-hops mid root (conj visited mid))]
               [(inc hop)])))))))
 
-(defn benchmark-build-ancestor-hops-index []
-  (into {}
-    (for [category benchmark-seed-categories
-          root benchmark-roots
-          :let [hops (benchmark-ancestor-hops category root #{category})]
-          :when (seq hops)]
-      [[category root] hops])))
+(defn benchmark-list-term [items]
+  (reduce
+    (fn [tail item]
+      {:tag :struct :functor "[|]/2" :args [item tail]})
+    "[]"
+    (reverse items)))
 
-(def benchmark-ancestor-hops-index
-  (when benchmark-use-traversal-kernel?
-    (benchmark-build-ancestor-hops-index)))
+(defn benchmark-foreign-category-root-hops [category root]
+  (let [handler (get foreign-handlers "category_ancestor/4")
+        result (when handler
+                 (handler [category root {:var 9001} (benchmark-list-term [category])]))]
+    (vec
+      (keep (fn [solution]
+              (get-in solution [:bindings 3]))
+            (:solutions result)))))
 
 (defn benchmark-category-root-hops [category root]
   (if benchmark-use-traversal-kernel?
-    (get benchmark-ancestor-hops-index [category root] [])
+    (benchmark-foreign-category-root-hops category root)
     (benchmark-ancestor-hops category root #{category})))
 
 (defn benchmark-article-root-weight [article root]

--- a/tests/test_wam_clojure_benchmark_generator.pl
+++ b/tests/test_wam_clojure_benchmark_generator.pl
@@ -33,8 +33,11 @@ test(generate_seeded_kernels_on_project) :-
         assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_parent" :arity 2}')),
         assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_ancestor" :arity 4}')),
         assertion(sub_string(CoreCode, _, _, _, '(def benchmark-use-traversal-kernel? true)')),
-        assertion(sub_string(CoreCode, _, _, _, '(def benchmark-ancestor-hops-index')),
-        assertion(sub_string(CoreCode, _, _, _, '(benchmark-build-ancestor-hops-index)')),
+        assertion(sub_string(CoreCode, _, _, _, '(defn benchmark-foreign-category-root-hops [category root]')),
+        assertion(sub_string(CoreCode, _, _, _, '(handler [category root {:var 9001} (benchmark-list-term [category])]')),
+        assertion(sub_string(CoreCode, _, _, _, '(benchmark-foreign-category-root-hops category root)')),
+        assertion(\+ sub_string(CoreCode, _, _, _, 'benchmark-ancestor-hops-index')),
+        assertion(\+ sub_string(CoreCode, _, _, _, 'benchmark-build-ancestor-hops-index')),
         delete_directory_and_contents(TmpDir)
     )).
 
@@ -51,6 +54,8 @@ test(generate_seeded_kernels_off_project) :-
         assertion(\+ sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_ancestor" :arity 4}')),
         assertion(sub_string(CoreCode, _, _, _, '(def benchmark-use-traversal-kernel? false)')),
         assertion(sub_string(CoreCode, _, _, _, '(benchmark-ancestor-hops category root #{category})')),
+        assertion(\+ sub_string(CoreCode, _, _, _, 'benchmark-ancestor-hops-index')),
+        assertion(\+ sub_string(CoreCode, _, _, _, 'benchmark-build-ancestor-hops-index')),
         delete_directory_and_contents(TmpDir)
     )).
 


### PR DESCRIPTION
## Summary

Updates the Clojure effective-distance benchmark runner so `kernels_on` consumes the generic streaming `category_ancestor/4` foreign path instead of using a bespoke runner-side ancestor index.

`kernels_off` still uses the pure recursive Clojure runner path, preserving the kernel-on/kernel-off comparison surface.

## Details

- Removes generated `benchmark-build-ancestor-hops-index`.
- Removes generated `benchmark-ancestor-hops-index`.
- Adds `benchmark-list-term` for constructing the visited-list term passed to `category_ancestor/4`.
- Adds `benchmark-foreign-category-root-hops`, which invokes the generated `category_ancestor/4` foreign handler and extracts hop values from `:solutions`.
- Updates `benchmark-category-root-hops` so `kernels_on` routes through the generic streaming foreign predicate.
- Keeps `kernels_off` on the existing recursive fallback.
- Extends generator tests to assert the foreign-runner path is emitted and the bespoke index materialization is not emitted.
- Updates the WAM performance optimization log with the new Clojure runner milestone.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
- `git diff --check`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-accumulated,clojure-wam-accumulated-no-kernels,clojure-wam-seeded,clojure-wam-seeded-no-kernels,prolog-accumulated --scales dev --repetitions 1`

The small `dev` matrix still reports matching normalized output digests across all Clojure WAM modes and `prolog-accumulated`.

## Remaining Work

The next useful Clojure WAM work is runtime-overhead reduction now that traversal is on the generic foreign path. In particular, foreign choice points can likely avoid the full choice-point snapshot used by ordinary WAM backtracking.
