### PR TITLE
Improve C# artifact broad joins with streamed bucket matching

### DIFF
--- a/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
+++ b/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
@@ -390,10 +390,10 @@ Prototype status:
   seam when one side is a selective probe and the other side is an indexed
   artifact-backed scan.
 - Binary relation index sidecars now include an appended key directory for
-  small lookup sets. The reader can seek directly from key hash to index entry
-  and still falls back to the original sequential index scan for old artifacts
-  or broad probe sets where sequential access is cheaper than many random
-  seeks.
+  small lookup sets. The reader binary-searches the fixed directory table on
+  disk, seeks from key hash to index entry, and still falls back to the
+  original sequential index scan for old artifacts or broad probe sets where
+  sequential access is cheaper than many random seeks.
 - `benchmark_scan_materialization.py` can now compare `preload`, `delimited`,
   and `artifact` source modes against the existing scan-family workloads,
   including `bound_scan` and `selective_join` modes for indexed parameter

--- a/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
+++ b/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
@@ -395,11 +395,11 @@ Prototype status:
   original sequential index scan for old artifacts or broad probe sets where
   sequential access is cheaper than many random seeks.
 - The binary artifact builder also emits per-column covering bucket sidecars
-  for broad indexed joins. When relation cardinalities are available, scan-scan
-  joins build grouped hash state from the smaller side and stream the larger
-  side's buckets instead of issuing a large number of point probes or random
-  row-offset reads. Older artifacts still fall back through the prior
-  bucket-stream path when that metadata is unavailable.
+  for broad indexed joins. The current runtime can merge those sorted sidecars
+  directly and only deserialize rows for matching keys, which avoids
+  materializing the full bucket stream for broad joins. When bucket sidecars
+  are unavailable, it falls back to the smaller-side hash build path when
+  relation cardinalities are known, and then to the older generic bucket path.
 - `benchmark_scan_materialization.py` can now compare `preload`, `delimited`,
   `artifact`, and `artifact-prebuilt` source modes against the existing
   scan-family workloads, including `bound_scan` and `selective_join` modes for

--- a/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
+++ b/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
@@ -402,8 +402,9 @@ Prototype status:
   `artifact`, and `artifact-prebuilt` source modes against the existing
   scan-family workloads, including `bound_scan` and `selective_join` modes for
   indexed parameter probes. The prebuilt mode keeps artifacts in a stable
-  benchmark directory so runtime measurements can separate query execution
-  from preprocessing cost.
+  benchmark directory keyed by the current runtime source so runtime
+  measurements can separate query execution from preprocessing cost without
+  reusing stale artifact formats.
 
 ## Success Criteria
 

--- a/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
+++ b/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
@@ -395,9 +395,11 @@ Prototype status:
   original sequential index scan for old artifacts or broad probe sets where
   sequential access is cheaper than many random seeks.
 - The binary artifact builder also emits per-column covering bucket sidecars
-  for broad indexed joins. Scan-scan joins can stream key-ordered buckets from
-  both sides and merge them linearly instead of issuing a large number of point
-  probes or random row-offset reads.
+  for broad indexed joins. When relation cardinalities are available, scan-scan
+  joins build grouped hash state from the smaller side and stream the larger
+  side's buckets instead of issuing a large number of point probes or random
+  row-offset reads. Older artifacts still fall back through the prior
+  bucket-stream path when that metadata is unavailable.
 - `benchmark_scan_materialization.py` can now compare `preload`, `delimited`,
   `artifact`, and `artifact-prebuilt` source modes against the existing
   scan-family workloads, including `bound_scan` and `selective_join` modes for

--- a/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
+++ b/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
@@ -394,6 +394,10 @@ Prototype status:
   disk, seeks from key hash to index entry, and still falls back to the
   original sequential index scan for old artifacts or broad probe sets where
   sequential access is cheaper than many random seeks.
+- The binary artifact builder also emits per-column covering bucket sidecars
+  for broad indexed joins. Scan-scan joins can stream key-ordered buckets from
+  both sides and merge them linearly instead of issuing a large number of point
+  probes or random row-offset reads.
 - `benchmark_scan_materialization.py` can now compare `preload`, `delimited`,
   and `artifact` source modes against the existing scan-family workloads,
   including `bound_scan` and `selective_join` modes for indexed parameter

--- a/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
+++ b/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
@@ -399,9 +399,11 @@ Prototype status:
   both sides and merge them linearly instead of issuing a large number of point
   probes or random row-offset reads.
 - `benchmark_scan_materialization.py` can now compare `preload`, `delimited`,
-  and `artifact` source modes against the existing scan-family workloads,
-  including `bound_scan` and `selective_join` modes for indexed parameter
-  probes.
+  `artifact`, and `artifact-prebuilt` source modes against the existing
+  scan-family workloads, including `bound_scan` and `selective_join` modes for
+  indexed parameter probes. The prebuilt mode keeps artifacts in a stable
+  benchmark directory so runtime measurements can separate query execution
+  from preprocessing cost.
 
 ## Success Criteria
 

--- a/examples/benchmark/benchmark_scan_materialization.py
+++ b/examples/benchmark/benchmark_scan_materialization.py
@@ -21,6 +21,7 @@ planner rather than a cross-target benchmark.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import shutil
 import statistics
@@ -314,6 +315,9 @@ class BenchResult:
         return statistics.median(self.times)
 
 
+RUNTIME_CACHE_VERSION = hashlib.sha256(QRY_RUNTIME.read_bytes()).hexdigest()[:12]
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--scales", default="300,10k")
@@ -379,7 +383,7 @@ def benchmark_mode(command: list[str], scale: str, mode: str, source_mode: str, 
     env["UNIFYWEAVER_SCAN_RETENTION_STRATEGY"] = strategy
     env["UNIFYWEAVER_SCAN_SOURCE_MODE"] = source_mode
     if source_mode == "artifact-prebuilt":
-        artifact_dir = Path(tempfile.gettempdir()) / "uw-scan-prebuilt-artifacts-v2" / scale
+        artifact_dir = Path(tempfile.gettempdir()) / f"uw-scan-prebuilt-artifacts-{RUNTIME_CACHE_VERSION}" / scale
         artifact_dir.mkdir(parents=True, exist_ok=True)
         env["UNIFYWEAVER_SCAN_ARTIFACT_DIR"] = str(artifact_dir)
 

--- a/examples/benchmark/benchmark_scan_materialization.py
+++ b/examples/benchmark/benchmark_scan_materialization.py
@@ -3,8 +3,8 @@
 Measure generic scan-family materialization planning in the C# query runtime.
 
 This harness exercises representative scan-heavy plans against the benchmark
-TSVs using preloaded, streamed, or binary-artifact relation sources inside a
-temporary C# project:
+TSVs using preloaded, streamed, binary-artifact, or prebuilt binary-artifact
+relation sources inside a temporary C# project:
 
 - `scan`: plain `RelationScanNode`
 - `bound_scan`: parameterized `RelationScanNode` over one bound column
@@ -87,6 +87,17 @@ class Program
                 var manifestPath = BinaryRelationArtifactBuilder.BuildFromDelimited(predicate, source, artifactDir);
                 artifactProvider.RegisterArtifact(predicate, manifestPath);
                 break;
+            case "artifact-prebuilt":
+                Directory.CreateDirectory(artifactDir);
+                var artifactName = $"{predicate.Name}_{predicate.Arity}";
+                var prebuiltManifestPath = Path.Combine(artifactDir, artifactName + ".uwbr.json");
+                if (!File.Exists(prebuiltManifestPath))
+                {
+                    prebuiltManifestPath = BinaryRelationArtifactBuilder.BuildFromDelimited(predicate, source, artifactDir, artifactName);
+                }
+
+                artifactProvider.RegisterArtifact(predicate, prebuiltManifestPath);
+                break;
             case "delimited":
                 memoryProvider.RegisterDelimitedSource(predicate, source);
                 break;
@@ -136,16 +147,19 @@ class Program
         var traceEnabled = Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE") == "1";
         var scanStrategy = ParseScanStrategy(Environment.GetEnvironmentVariable("UNIFYWEAVER_SCAN_RETENTION_STRATEGY") ?? "auto");
         var sourceMode = (Environment.GetEnvironmentVariable("UNIFYWEAVER_SCAN_SOURCE_MODE") ?? "preload").ToLowerInvariant();
-        if (sourceMode != "preload" && sourceMode != "delimited" && sourceMode != "artifact")
+        if (sourceMode != "preload" && sourceMode != "delimited" && sourceMode != "artifact" && sourceMode != "artifact-prebuilt")
         {
             Console.Error.WriteLine($"Unknown UNIFYWEAVER_SCAN_SOURCE_MODE: {sourceMode}");
             return 1;
         }
 
         var memoryProvider = new InMemoryRelationProvider();
-        var artifactDir = Path.Combine(Path.GetTempPath(), $"uw-scan-artifacts-{Guid.NewGuid():N}");
+        var artifactDir = Environment.GetEnvironmentVariable("UNIFYWEAVER_SCAN_ARTIFACT_DIR");
+        artifactDir = string.IsNullOrWhiteSpace(artifactDir)
+            ? Path.Combine(Path.GetTempPath(), $"uw-scan-artifacts-{Guid.NewGuid():N}")
+            : artifactDir;
         var artifactProvider = new BinaryRelationArtifactProvider(memoryProvider);
-        IRelationProvider provider = sourceMode == "artifact" ? artifactProvider : memoryProvider;
+        IRelationProvider provider = sourceMode == "artifact" || sourceMode == "artifact-prebuilt" ? artifactProvider : memoryProvider;
         var edgeId = new PredicateId("category_parent", 2);
         var articleId = new PredicateId("article_category", 2);
         var blockedId = new PredicateId("blocked_article_category", 2);
@@ -276,7 +290,10 @@ class Program
         finally
         {
             try { File.Delete(blockedPath); } catch { }
-            try { Directory.Delete(artifactDir, recursive: true); } catch { }
+            if (sourceMode != "artifact-prebuilt")
+            {
+                try { Directory.Delete(artifactDir, recursive: true); } catch { }
+            }
         }
     }
 }
@@ -361,6 +378,10 @@ def benchmark_mode(command: list[str], scale: str, mode: str, source_mode: str, 
     env["UNIFYWEAVER_BENCH_TRACE"] = "1"
     env["UNIFYWEAVER_SCAN_RETENTION_STRATEGY"] = strategy
     env["UNIFYWEAVER_SCAN_SOURCE_MODE"] = source_mode
+    if source_mode == "artifact-prebuilt":
+        artifact_dir = Path(tempfile.gettempdir()) / "uw-scan-prebuilt-artifacts-v2" / scale
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        env["UNIFYWEAVER_SCAN_ARTIFACT_DIR"] = str(artifact_dir)
 
     times: list[float] = []
     stderr = ""

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1811,6 +1811,43 @@ namespace UnifyWeaver.QueryRuntime
             return ReadBuckets(indexPath, dataPath, columnIndex, manifest.Arity);
         }
 
+        public static bool TryReadBucketJoinRows(
+            string leftManifestPath,
+            int leftColumnIndex,
+            object[]? leftPattern,
+            Func<object[], bool>? leftFilter,
+            string rightManifestPath,
+            int rightColumnIndex,
+            object[]? rightPattern,
+            Func<object[], bool>? rightFilter,
+            KeyJoinNode join,
+            out IEnumerable<object[]> rows)
+        {
+            rows = Enumerable.Empty<object[]>();
+
+            var leftManifest = LoadManifest(leftManifestPath);
+            var rightManifest = LoadManifest(rightManifestPath);
+            if (!TryResolveBucketRowsPath(leftManifest, leftManifestPath, leftColumnIndex, out var leftBucketRowsPath) ||
+                !TryResolveBucketRowsPath(rightManifest, rightManifestPath, rightColumnIndex, out var rightBucketRowsPath))
+            {
+                return false;
+            }
+
+            rows = EnumerateBucketMergeJoinRows(
+                leftBucketRowsPath,
+                leftColumnIndex,
+                leftManifest.Arity,
+                leftPattern,
+                leftFilter,
+                rightBucketRowsPath,
+                rightColumnIndex,
+                rightManifest.Arity,
+                rightPattern,
+                rightFilter,
+                join);
+            return true;
+        }
+
         private static IEnumerable<object[]> ReadRowsFromData(string dataPath, int expectedWidth, long expectedRows)
         {
             using var stream = new FileStream(dataPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1 << 16, FileOptions.SequentialScan);
@@ -2109,6 +2146,273 @@ namespace UnifyWeaver.QueryRuntime
 
                 yield return new IndexedRelationBucket(key, rows);
             }
+        }
+
+        private static bool TryResolveBucketRowsPath(BinaryRelationArtifactManifest manifest, string manifestPath, int columnIndex, out string bucketRowsPath)
+        {
+            bucketRowsPath = string.Empty;
+            if (columnIndex < 0 || columnIndex >= manifest.Arity)
+            {
+                return false;
+            }
+
+            var columnKey = columnIndex.ToString(CultureInfo.InvariantCulture);
+            if (!manifest.IndexPaths.TryGetValue(columnKey, out var indexPathValue))
+            {
+                return false;
+            }
+
+            var manifestDirectory = Path.GetDirectoryName(Path.GetFullPath(manifestPath)) ?? ".";
+            var indexPath = Path.IsPathRooted(indexPathValue)
+                ? indexPathValue
+                : Path.Combine(manifestDirectory, indexPathValue);
+            var candidate = Path.ChangeExtension(indexPath, ".uwbrb");
+            if (!File.Exists(candidate))
+            {
+                return false;
+            }
+
+            bucketRowsPath = candidate;
+            return true;
+        }
+
+        private static IEnumerable<object[]> EnumerateBucketMergeJoinRows(
+            string leftBucketRowsPath,
+            int leftColumnIndex,
+            int leftWidth,
+            object[]? leftPattern,
+            Func<object[], bool>? leftFilter,
+            string rightBucketRowsPath,
+            int rightColumnIndex,
+            int rightWidth,
+            object[]? rightPattern,
+            Func<object[], bool>? rightFilter,
+            KeyJoinNode join)
+        {
+            using var leftCursor = new BucketRowsCursor(leftBucketRowsPath, leftColumnIndex, leftWidth);
+            using var rightCursor = new BucketRowsCursor(rightBucketRowsPath, rightColumnIndex, rightWidth);
+
+            var hasLeft = leftCursor.MoveNext();
+            var hasRight = rightCursor.MoveNext();
+            while (hasLeft && hasRight)
+            {
+                var comparison = string.CompareOrdinal(leftCursor.Key, rightCursor.Key);
+                if (comparison < 0)
+                {
+                    hasLeft = leftCursor.MoveNext();
+                    continue;
+                }
+
+                if (comparison > 0)
+                {
+                    hasRight = rightCursor.MoveNext();
+                    continue;
+                }
+
+                var leftRows = FilterBucketRowsForArtifactJoin(leftCursor.ReadRows(), leftPattern, leftFilter);
+                var rightRows = FilterBucketRowsForArtifactJoin(rightCursor.ReadRows(), rightPattern, rightFilter);
+                if (leftRows.Count != 0 && rightRows.Count != 0)
+                {
+                    foreach (var leftRow in leftRows)
+                    {
+                        foreach (var rightRow in rightRows)
+                        {
+                            yield return BuildArtifactJoinOutput(leftRow, rightRow, join.LeftWidth, join.RightWidth, join.Width);
+                        }
+                    }
+                }
+
+                hasLeft = leftCursor.MoveNext();
+                hasRight = rightCursor.MoveNext();
+            }
+        }
+
+        private sealed class BucketRowsCursor : IDisposable
+        {
+            private readonly FileStream _stream;
+            private readonly BinaryReader _reader;
+            private readonly int _width;
+            private int _remainingKeys;
+            private bool _rowsConsumed;
+
+            public BucketRowsCursor(string bucketRowsPath, int expectedColumnIndex, int expectedWidth)
+            {
+                _stream = new FileStream(bucketRowsPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1 << 16, FileOptions.SequentialScan);
+                _reader = new BinaryReader(_stream, Encoding.UTF8);
+
+                var magic = _reader.ReadBytes(BucketRowsMagic.Length);
+                if (!magic.SequenceEqual(BucketRowsMagic))
+                {
+                    throw new InvalidDataException($"Invalid binary relation bucket artifact magic: {bucketRowsPath}");
+                }
+
+                var version = _reader.ReadInt32();
+                if (version != 1)
+                {
+                    throw new InvalidDataException($"Unsupported binary relation bucket artifact version {version}: {bucketRowsPath}");
+                }
+
+                var columnIndex = _reader.ReadInt32();
+                if (columnIndex != expectedColumnIndex)
+                {
+                    throw new InvalidDataException($"Binary relation bucket column mismatch. Expected {expectedColumnIndex}, found {columnIndex}: {bucketRowsPath}");
+                }
+
+                _width = _reader.ReadInt32();
+                if (_width != expectedWidth)
+                {
+                    throw new InvalidDataException($"Binary relation bucket width mismatch. Expected {expectedWidth}, found {_width}: {bucketRowsPath}");
+                }
+
+                _remainingKeys = _reader.ReadInt32();
+                if (_remainingKeys < 0)
+                {
+                    throw new InvalidDataException($"Binary relation bucket key count is negative: {bucketRowsPath}");
+                }
+            }
+
+            public string Key { get; private set; } = string.Empty;
+
+            public int RowCount { get; private set; }
+
+            public bool MoveNext()
+            {
+                if (_remainingKeys <= 0)
+                {
+                    return false;
+                }
+
+                if (!_rowsConsumed)
+                {
+                    SkipRows();
+                }
+
+                Key = ReadString(_reader);
+                RowCount = _reader.ReadInt32();
+                if (RowCount < 0)
+                {
+                    throw new InvalidDataException("Binary relation bucket row count is negative.");
+                }
+
+                _remainingKeys--;
+                _rowsConsumed = false;
+                return true;
+            }
+
+            public IReadOnlyList<object[]> ReadRows()
+            {
+                if (_rowsConsumed)
+                {
+                    return Array.Empty<object[]>();
+                }
+
+                var rows = new List<object[]>(RowCount);
+                for (var rowIndex = 0; rowIndex < RowCount; rowIndex++)
+                {
+                    var row = new object[_width];
+                    for (var column = 0; column < _width; column++)
+                    {
+                        row[column] = ReadString(_reader);
+                    }
+
+                    rows.Add(row);
+                }
+
+                _rowsConsumed = true;
+                return rows;
+            }
+
+            public void Dispose()
+            {
+                _reader.Dispose();
+                _stream.Dispose();
+            }
+
+            private void SkipRows()
+            {
+                for (var rowIndex = 0; rowIndex < RowCount; rowIndex++)
+                {
+                    for (var column = 0; column < _width; column++)
+                    {
+                        SkipString(_reader);
+                    }
+                }
+
+                _rowsConsumed = true;
+            }
+        }
+
+        private static List<object[]> FilterBucketRowsForArtifactJoin(
+            IReadOnlyList<object[]> rows,
+            object[]? pattern,
+            Func<object[], bool>? filter)
+        {
+            var filtered = new List<object[]>(rows.Count);
+            foreach (var row in rows)
+            {
+                if (row is null)
+                {
+                    continue;
+                }
+
+                if (pattern is not null && !TupleMatchesPatternForArtifactJoin(row, pattern))
+                {
+                    continue;
+                }
+
+                if (filter is not null && !filter(row))
+                {
+                    continue;
+                }
+
+                filtered.Add(row);
+            }
+
+            return filtered;
+        }
+
+        private static bool TupleMatchesPatternForArtifactJoin(object[] tuple, object[] pattern)
+        {
+            var max = Math.Min(tuple.Length, pattern.Length);
+            for (var i = 0; i < max; i++)
+            {
+                var expected = pattern[i];
+                if (ReferenceEquals(expected, Wildcard.Value))
+                {
+                    continue;
+                }
+
+                if (!Equals(tuple[i], expected))
+                {
+                    return false;
+                }
+            }
+
+            for (var i = max; i < pattern.Length; i++)
+            {
+                if (!ReferenceEquals(pattern[i], Wildcard.Value))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static object[] BuildArtifactJoinOutput(object[] leftTuple, object[] rightTuple, int leftWidth, int rightWidth, int width)
+        {
+            var output = new object[width];
+            if (leftWidth > 0)
+            {
+                Array.Copy(leftTuple, output, Math.Min(leftWidth, leftTuple.Length));
+            }
+
+            if (rightWidth > 0)
+            {
+                Array.Copy(rightTuple, 0, output, leftWidth, Math.Min(rightWidth, rightTuple.Length));
+            }
+
+            return output;
         }
 
         private static void WriteIndexDirectory(BinaryWriter writer, IReadOnlyList<(string Key, long EntryOffset)> entries)
@@ -2426,6 +2730,17 @@ namespace UnifyWeaver.QueryRuntime
 
             return Encoding.UTF8.GetString(bytes);
         }
+
+        private static void SkipString(BinaryReader reader)
+        {
+            var length = reader.ReadInt32();
+            if (length < 0)
+            {
+                throw new InvalidDataException("Binary relation artifact contains a negative string length.");
+            }
+
+            reader.BaseStream.Position += length;
+        }
     }
 
     public sealed class BinaryRelationArtifactProvider : IRetentionAwareRelationProvider, IIndexedRelationProvider, IIndexedRelationBucketProvider, IRelationCardinalityProvider
@@ -2540,6 +2855,38 @@ namespace UnifyWeaver.QueryRuntime
 
             buckets = default!;
             return false;
+        }
+
+        public bool TryReadBucketJoinRows(
+            PredicateId leftPredicate,
+            int leftColumnIndex,
+            object[]? leftPattern,
+            Func<object[], bool>? leftFilter,
+            PredicateId rightPredicate,
+            int rightColumnIndex,
+            object[]? rightPattern,
+            Func<object[], bool>? rightFilter,
+            KeyJoinNode join,
+            out IEnumerable<object[]> rows)
+        {
+            rows = Enumerable.Empty<object[]>();
+            if (!_manifestPaths.TryGetValue(leftPredicate, out var leftManifestPath) ||
+                !_manifestPaths.TryGetValue(rightPredicate, out var rightManifestPath))
+            {
+                return false;
+            }
+
+            return BinaryRelationArtifactReader.TryReadBucketJoinRows(
+                leftManifestPath,
+                leftColumnIndex,
+                leftPattern,
+                leftFilter,
+                rightManifestPath,
+                rightColumnIndex,
+                rightPattern,
+                rightFilter,
+                join,
+                out rows);
         }
 
         public bool TryGetRelationCardinality(PredicateId predicate, out long rowCount)
@@ -10120,6 +10467,22 @@ namespace UnifyWeaver.QueryRuntime
             out IEnumerable<object[]> rows)
         {
             rows = default!;
+            if (_provider is BinaryRelationArtifactProvider binaryArtifactProvider &&
+                binaryArtifactProvider.TryReadBucketJoinRows(
+                    leftPredicate,
+                    leftKeyIndex,
+                    leftPattern,
+                    leftFilter,
+                    rightPredicate,
+                    rightKeyIndex,
+                    rightPattern,
+                    rightFilter,
+                    join,
+                    out rows))
+            {
+                return true;
+            }
+
             if (_provider is not IIndexedRelationBucketProvider bucketProvider ||
                 !bucketProvider.TryReadIndexedBuckets(leftPredicate, leftKeyIndex, out var leftBuckets) ||
                 !bucketProvider.TryReadIndexedBuckets(rightPredicate, rightKeyIndex, out var rightBuckets))

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -159,6 +159,11 @@ namespace UnifyWeaver.QueryRuntime
         bool TryReadIndexedBuckets(PredicateId predicate, int columnIndex, out IEnumerable<IndexedRelationBucket> buckets);
     }
 
+    public interface IRelationCardinalityProvider : IRelationProvider
+    {
+        bool TryGetRelationCardinality(PredicateId predicate, out long rowCount);
+    }
+
     /// <summary>
     /// Base class for all query plan nodes.
     /// </summary>
@@ -2423,7 +2428,7 @@ namespace UnifyWeaver.QueryRuntime
         }
     }
 
-    public sealed class BinaryRelationArtifactProvider : IRetentionAwareRelationProvider, IIndexedRelationProvider, IIndexedRelationBucketProvider
+    public sealed class BinaryRelationArtifactProvider : IRetentionAwareRelationProvider, IIndexedRelationProvider, IIndexedRelationBucketProvider, IRelationCardinalityProvider
     {
         private readonly IRelationProvider? _fallback;
         private readonly Dictionary<PredicateId, string> _manifestPaths = new();
@@ -2534,6 +2539,25 @@ namespace UnifyWeaver.QueryRuntime
             }
 
             buckets = default!;
+            return false;
+        }
+
+        public bool TryGetRelationCardinality(PredicateId predicate, out long rowCount)
+        {
+            if (_manifestPaths.TryGetValue(predicate, out var manifestPath))
+            {
+                var manifest = BinaryRelationArtifactReader.LoadManifest(manifestPath);
+                rowCount = manifest.RowCount;
+                return true;
+            }
+
+            if (_fallback is IRelationCardinalityProvider cardinalityFallback &&
+                cardinalityFallback.TryGetRelationCardinality(predicate, out rowCount))
+            {
+                return true;
+            }
+
+            rowCount = 0;
             return false;
         }
     }
@@ -10103,87 +10127,91 @@ namespace UnifyWeaver.QueryRuntime
                 return false;
             }
 
-            rows = EnumerateIndexedProviderBucketJoinRows(
-                join,
-                leftBuckets,
-                leftPattern,
-                leftFilter,
-                rightBuckets,
-                rightPattern,
-                rightFilter);
+            var buildLeft = true;
+            if (_provider is IRelationCardinalityProvider cardinalityProvider &&
+                cardinalityProvider.TryGetRelationCardinality(leftPredicate, out var leftCount) &&
+                cardinalityProvider.TryGetRelationCardinality(rightPredicate, out var rightCount))
+            {
+                buildLeft = leftCount <= rightCount;
+            }
+
+            rows = buildLeft
+                ? EnumerateIndexedProviderBucketHashJoinRows(
+                    join,
+                    buildBuckets: leftBuckets,
+                    buildPattern: leftPattern,
+                    buildFilter: leftFilter,
+                    probeBuckets: rightBuckets,
+                    probePattern: rightPattern,
+                    probeFilter: rightFilter,
+                    buildOnLeft: true)
+                : EnumerateIndexedProviderBucketHashJoinRows(
+                    join,
+                    buildBuckets: rightBuckets,
+                    buildPattern: rightPattern,
+                    buildFilter: rightFilter,
+                    probeBuckets: leftBuckets,
+                    probePattern: leftPattern,
+                    probeFilter: leftFilter,
+                    buildOnLeft: false);
             return true;
         }
 
-        private static IEnumerable<object[]> EnumerateIndexedProviderBucketJoinRows(
+        private static IEnumerable<object[]> EnumerateIndexedProviderBucketHashJoinRows(
             KeyJoinNode join,
-            IEnumerable<IndexedRelationBucket> leftBuckets,
-            object[]? leftPattern,
-            Func<object[], bool>? leftFilter,
-            IEnumerable<IndexedRelationBucket> rightBuckets,
-            object[]? rightPattern,
-            Func<object[], bool>? rightFilter)
+            IEnumerable<IndexedRelationBucket> buildBuckets,
+            object[]? buildPattern,
+            Func<object[], bool>? buildFilter,
+            IEnumerable<IndexedRelationBucket> probeBuckets,
+            object[]? probePattern,
+            Func<object[], bool>? probeFilter,
+            bool buildOnLeft)
         {
-            using var leftEnumerator = leftBuckets.GetEnumerator();
-            using var rightEnumerator = rightBuckets.GetEnumerator();
-            var hasLeft = leftEnumerator.MoveNext();
-            var hasRight = rightEnumerator.MoveNext();
-
-            while (hasLeft && hasRight)
+            var buildIndex = new Dictionary<string, List<object[]>>(StringComparer.Ordinal);
+            foreach (var bucket in buildBuckets)
             {
-                var comparison = CompareBucketKeys(leftEnumerator.Current.Key, rightEnumerator.Current.Key);
-                if (comparison < 0)
+                var buildRows = FilterBucketRows(bucket.Rows, buildPattern, buildFilter);
+                if (buildRows.Count == 0)
                 {
-                    hasLeft = leftEnumerator.MoveNext();
                     continue;
                 }
 
-                if (comparison > 0)
-                {
-                    hasRight = rightEnumerator.MoveNext();
-                    continue;
-                }
-
-                var rightRows = FilterBucketRows(rightEnumerator.Current.Rows, rightPattern, rightFilter);
-                if (rightRows.Count == 0)
-                {
-                    hasLeft = leftEnumerator.MoveNext();
-                    hasRight = rightEnumerator.MoveNext();
-                    continue;
-                }
-
-                foreach (var leftRow in leftEnumerator.Current.Rows)
-                {
-                    if (leftRow is null)
-                    {
-                        continue;
-                    }
-
-                    if (leftPattern is not null && !TupleMatchesPattern(leftRow, leftPattern))
-                    {
-                        continue;
-                    }
-
-                    if (leftFilter is not null && !leftFilter(leftRow))
-                    {
-                        continue;
-                    }
-
-                    foreach (var rightRow in rightRows)
-                    {
-                        yield return BuildJoinOutput(leftRow, rightRow, join.LeftWidth, join.RightWidth, join.Width);
-                    }
-                }
-
-                hasLeft = leftEnumerator.MoveNext();
-                hasRight = rightEnumerator.MoveNext();
+                buildIndex[bucket.Key?.ToString() ?? string.Empty] = buildRows;
             }
-        }
 
-        private static int CompareBucketKeys(object left, object right)
-        {
-            var leftKey = left?.ToString() ?? string.Empty;
-            var rightKey = right?.ToString() ?? string.Empty;
-            return string.CompareOrdinal(leftKey, rightKey);
+            foreach (var probeBucket in probeBuckets)
+            {
+                var key = probeBucket.Key?.ToString() ?? string.Empty;
+                if (!buildIndex.TryGetValue(key, out var buildRows))
+                {
+                    continue;
+                }
+
+                foreach (var probeRow in probeBucket.Rows)
+                {
+                    if (probeRow is null)
+                    {
+                        continue;
+                    }
+
+                    if (probePattern is not null && !TupleMatchesPattern(probeRow, probePattern))
+                    {
+                        continue;
+                    }
+
+                    if (probeFilter is not null && !probeFilter(probeRow))
+                    {
+                        continue;
+                    }
+
+                    foreach (var buildRow in buildRows)
+                    {
+                        yield return buildOnLeft
+                            ? BuildJoinOutput(buildRow, probeRow, join.LeftWidth, join.RightWidth, join.Width)
+                            : BuildJoinOutput(probeRow, buildRow, join.LeftWidth, join.RightWidth, join.Width);
+                    }
+                }
+            }
         }
 
         private static List<object[]> FilterBucketRows(

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -148,6 +148,17 @@ namespace UnifyWeaver.QueryRuntime
         bool TryLookupFacts(PredicateId predicate, int columnIndex, IEnumerable<object> keys, out IEnumerable<object[]> facts);
     }
 
+    public sealed record IndexedRelationBucket(object Key, IReadOnlyList<object[]> Rows);
+
+    /// <summary>
+    /// Supplies key-ordered row buckets for providers that already maintain
+    /// physical indexes over relation columns.
+    /// </summary>
+    public interface IIndexedRelationBucketProvider : IRelationProvider
+    {
+        bool TryReadIndexedBuckets(PredicateId predicate, int columnIndex, out IEnumerable<IndexedRelationBucket> buckets);
+    }
+
     /// <summary>
     /// Base class for all query plan nodes.
     /// </summary>
@@ -1623,12 +1634,15 @@ namespace UnifyWeaver.QueryRuntime
     {
         private static readonly byte[] Magic = Encoding.ASCII.GetBytes("UWBR0001");
         private static readonly byte[] IndexMagic = Encoding.ASCII.GetBytes("UWBI0001");
+        private static readonly byte[] BucketRowsMagic = Encoding.ASCII.GetBytes("UWBB0001");
         private static readonly byte[] IndexDirectoryMagic = Encoding.ASCII.GetBytes("UWBD0001");
         private static readonly byte[] IndexDirectoryFooterMagic = Encoding.ASCII.GetBytes("UWBF0001");
         private const int IndexDirectoryEntrySize = sizeof(ulong) + sizeof(long) + sizeof(int) + sizeof(long);
         private const int MaxDirectoryLookupKeys = 256;
 
         internal sealed record WriteResult(long RowCount, Dictionary<string, string> IndexPaths);
+
+        private sealed record IndexRowRef(long Offset, string[] Values);
 
         private readonly record struct IndexDirectoryInfo(long TableOffset, int EntryCount);
 
@@ -1671,10 +1685,10 @@ namespace UnifyWeaver.QueryRuntime
             writer.Write(0L);
 
             long rowCount = 0;
-            var indexes = new Dictionary<int, Dictionary<string, List<long>>>();
+            var indexes = new Dictionary<int, Dictionary<string, List<IndexRowRef>>>();
             for (var i = 0; i < width; i++)
             {
-                indexes[i] = new Dictionary<string, List<long>>(StringComparer.Ordinal);
+                indexes[i] = new Dictionary<string, List<IndexRowRef>>(StringComparer.Ordinal);
             }
 
             foreach (var row in rows)
@@ -1685,17 +1699,25 @@ namespace UnifyWeaver.QueryRuntime
                 }
 
                 var rowOffset = stream.Position;
+                var values = new string[width];
                 for (var i = 0; i < width; i++)
                 {
                     var value = row[i]?.ToString() ?? string.Empty;
-                    if (!indexes[i].TryGetValue(value, out var offsets))
+                    values[i] = value;
+                }
+
+                var rowRef = new IndexRowRef(rowOffset, values);
+                for (var i = 0; i < width; i++)
+                {
+                    var value = values[i];
+                    if (!indexes[i].TryGetValue(value, out var rowsForKey))
                     {
-                        offsets = new List<long>();
-                        indexes[i][value] = offsets;
+                        rowsForKey = new List<IndexRowRef>();
+                        indexes[i][value] = rowsForKey;
                     }
 
-                    offsets.Add(rowOffset);
-                    WriteString(writer, value);
+                    rowsForKey.Add(rowRef);
+                    WriteString(writer, values[i]);
                 }
 
                 rowCount++;
@@ -1712,6 +1734,8 @@ namespace UnifyWeaver.QueryRuntime
             {
                 var indexPath = Path.Combine(artifactDirectory, $"{artifactName}.col{kvp.Key}.uwbri");
                 WriteIndex(indexPath, kvp.Key, kvp.Value);
+                var bucketRowsPath = Path.Combine(artifactDirectory, $"{artifactName}.col{kvp.Key}.uwbrb");
+                WriteBucketRows(bucketRowsPath, kvp.Key, width, kvp.Value);
                 indexPaths[kvp.Key.ToString(CultureInfo.InvariantCulture)] = Path.GetFileName(indexPath);
             }
 
@@ -1746,6 +1770,40 @@ namespace UnifyWeaver.QueryRuntime
             var dataPath = ResolveDataPath(manifest, manifestPath);
             var offsets = ReadOffsets(indexPath, columnIndex, keys.Select(key => key?.ToString() ?? string.Empty));
             return ReadRowsAtOffsets(dataPath, manifest.Arity, offsets);
+        }
+
+        public static IEnumerable<IndexedRelationBucket> ReadBuckets(string manifestPath, int columnIndex)
+        {
+            var manifest = LoadManifest(manifestPath);
+            return ReadBuckets(manifest, manifestPath, columnIndex);
+        }
+
+        public static IEnumerable<IndexedRelationBucket> ReadBuckets(BinaryRelationArtifactManifest manifest, string manifestPath, int columnIndex)
+        {
+            if (manifest is null) throw new ArgumentNullException(nameof(manifest));
+            if (columnIndex < 0 || columnIndex >= manifest.Arity)
+            {
+                return Enumerable.Empty<IndexedRelationBucket>();
+            }
+
+            var columnKey = columnIndex.ToString(CultureInfo.InvariantCulture);
+            if (!manifest.IndexPaths.TryGetValue(columnKey, out var indexPathValue))
+            {
+                return Enumerable.Empty<IndexedRelationBucket>();
+            }
+
+            var manifestDirectory = Path.GetDirectoryName(Path.GetFullPath(manifestPath)) ?? ".";
+            var indexPath = Path.IsPathRooted(indexPathValue)
+                ? indexPathValue
+                : Path.Combine(manifestDirectory, indexPathValue);
+            var bucketRowsPath = Path.ChangeExtension(indexPath, ".uwbrb");
+            if (File.Exists(bucketRowsPath))
+            {
+                return ReadBucketsFromBucketRows(bucketRowsPath, columnIndex, manifest.Arity);
+            }
+
+            var dataPath = ResolveDataPath(manifest, manifestPath);
+            return ReadBuckets(indexPath, dataPath, columnIndex, manifest.Arity);
         }
 
         private static IEnumerable<object[]> ReadRowsFromData(string dataPath, int expectedWidth, long expectedRows)
@@ -1836,7 +1894,7 @@ namespace UnifyWeaver.QueryRuntime
             _ = reader.ReadInt64();
         }
 
-        private static void WriteIndex(string indexPath, int columnIndex, Dictionary<string, List<long>> index)
+        private static void WriteIndex(string indexPath, int columnIndex, Dictionary<string, List<IndexRowRef>> index)
         {
             using var stream = new FileStream(indexPath, FileMode.Create, FileAccess.Write, FileShare.None);
             using var writer = new BinaryWriter(stream, Encoding.UTF8);
@@ -1851,13 +1909,37 @@ namespace UnifyWeaver.QueryRuntime
                 directoryEntries.Add((kvp.Key, stream.Position));
                 WriteString(writer, kvp.Key);
                 writer.Write(kvp.Value.Count);
-                foreach (var offset in kvp.Value)
+                foreach (var row in kvp.Value)
                 {
-                    writer.Write(offset);
+                    writer.Write(row.Offset);
                 }
             }
 
             WriteIndexDirectory(writer, directoryEntries);
+        }
+
+        private static void WriteBucketRows(string bucketRowsPath, int columnIndex, int width, Dictionary<string, List<IndexRowRef>> index)
+        {
+            using var stream = new FileStream(bucketRowsPath, FileMode.Create, FileAccess.Write, FileShare.None);
+            using var writer = new BinaryWriter(stream, Encoding.UTF8);
+            writer.Write(BucketRowsMagic);
+            writer.Write(1);
+            writer.Write(columnIndex);
+            writer.Write(width);
+            writer.Write(index.Count);
+
+            foreach (var kvp in index.OrderBy(item => item.Key, StringComparer.Ordinal))
+            {
+                WriteString(writer, kvp.Key);
+                writer.Write(kvp.Value.Count);
+                foreach (var row in kvp.Value)
+                {
+                    for (var i = 0; i < width; i++)
+                    {
+                        WriteString(writer, row.Values[i]);
+                    }
+                }
+            }
         }
 
         private static IReadOnlyList<long> ReadOffsets(string indexPath, int expectedColumnIndex, IEnumerable<string> keys)
@@ -1920,6 +2002,108 @@ namespace UnifyWeaver.QueryRuntime
             }
 
             return offsets;
+        }
+
+        private static IEnumerable<IndexedRelationBucket> ReadBuckets(string indexPath, string dataPath, int expectedColumnIndex, int expectedWidth)
+        {
+            using var indexStream = new FileStream(indexPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1 << 16, FileOptions.SequentialScan);
+            using var indexReader = new BinaryReader(indexStream, Encoding.UTF8);
+            ValidateIndexHeader(indexReader, indexPath, expectedColumnIndex, out var keyCount);
+
+            using var dataStream = new FileStream(dataPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1 << 16, FileOptions.RandomAccess);
+            using var dataReader = new BinaryReader(dataStream, Encoding.UTF8);
+            ValidateDataHeader(dataReader, dataPath, expectedWidth);
+
+            for (var i = 0; i < keyCount; i++)
+            {
+                var key = ReadString(indexReader);
+                var offsetCount = indexReader.ReadInt32();
+                if (offsetCount < 0)
+                {
+                    throw new InvalidDataException($"Binary relation index offset count is negative for column {expectedColumnIndex}: {indexPath}");
+                }
+
+                var offsets = new long[offsetCount];
+                for (var j = 0; j < offsetCount; j++)
+                {
+                    offsets[j] = indexReader.ReadInt64();
+                }
+
+                var rows = new List<object[]>(offsetCount);
+                foreach (var offset in offsets)
+                {
+                    dataStream.Position = offset;
+                    var row = new object[expectedWidth];
+                    for (var column = 0; column < expectedWidth; column++)
+                    {
+                        row[column] = ReadString(dataReader);
+                    }
+
+                    rows.Add(row);
+                }
+
+                yield return new IndexedRelationBucket(key, rows);
+            }
+        }
+
+        private static IEnumerable<IndexedRelationBucket> ReadBucketsFromBucketRows(string bucketRowsPath, int expectedColumnIndex, int expectedWidth)
+        {
+            using var stream = new FileStream(bucketRowsPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1 << 16, FileOptions.SequentialScan);
+            using var reader = new BinaryReader(stream, Encoding.UTF8);
+
+            var magic = reader.ReadBytes(BucketRowsMagic.Length);
+            if (!magic.SequenceEqual(BucketRowsMagic))
+            {
+                throw new InvalidDataException($"Invalid binary relation bucket artifact magic: {bucketRowsPath}");
+            }
+
+            var version = reader.ReadInt32();
+            if (version != 1)
+            {
+                throw new InvalidDataException($"Unsupported binary relation bucket artifact version {version}: {bucketRowsPath}");
+            }
+
+            var columnIndex = reader.ReadInt32();
+            if (columnIndex != expectedColumnIndex)
+            {
+                throw new InvalidDataException($"Binary relation bucket column mismatch. Expected {expectedColumnIndex}, found {columnIndex}: {bucketRowsPath}");
+            }
+
+            var width = reader.ReadInt32();
+            if (width != expectedWidth)
+            {
+                throw new InvalidDataException($"Binary relation bucket width mismatch. Expected {expectedWidth}, found {width}: {bucketRowsPath}");
+            }
+
+            var keyCount = reader.ReadInt32();
+            if (keyCount < 0)
+            {
+                throw new InvalidDataException($"Binary relation bucket key count is negative: {bucketRowsPath}");
+            }
+
+            for (var i = 0; i < keyCount; i++)
+            {
+                var key = ReadString(reader);
+                var rowCount = reader.ReadInt32();
+                if (rowCount < 0)
+                {
+                    throw new InvalidDataException($"Binary relation bucket row count is negative: {bucketRowsPath}");
+                }
+
+                var rows = new List<object[]>(rowCount);
+                for (var rowIndex = 0; rowIndex < rowCount; rowIndex++)
+                {
+                    var row = new object[width];
+                    for (var column = 0; column < width; column++)
+                    {
+                        row[column] = ReadString(reader);
+                    }
+
+                    rows.Add(row);
+                }
+
+                yield return new IndexedRelationBucket(key, rows);
+            }
         }
 
         private static void WriteIndexDirectory(BinaryWriter writer, IReadOnlyList<(string Key, long EntryOffset)> entries)
@@ -2132,6 +2316,11 @@ namespace UnifyWeaver.QueryRuntime
 
         private static void ValidateIndexHeader(BinaryReader reader, string indexPath, int expectedColumnIndex)
         {
+            ValidateIndexHeader(reader, indexPath, expectedColumnIndex, out _);
+        }
+
+        private static void ValidateIndexHeader(BinaryReader reader, string indexPath, int expectedColumnIndex, out int keyCount)
+        {
             var magic = reader.ReadBytes(IndexMagic.Length);
             if (!magic.SequenceEqual(IndexMagic))
             {
@@ -2150,7 +2339,11 @@ namespace UnifyWeaver.QueryRuntime
                 throw new InvalidDataException($"Binary relation index column mismatch. Expected {expectedColumnIndex}, found {columnIndex}: {indexPath}");
             }
 
-            _ = reader.ReadInt32();
+            keyCount = reader.ReadInt32();
+            if (keyCount < 0)
+            {
+                throw new InvalidDataException($"Binary relation index key count is negative: {indexPath}");
+            }
         }
 
         private static ulong StableHash(string value)
@@ -2230,7 +2423,7 @@ namespace UnifyWeaver.QueryRuntime
         }
     }
 
-    public sealed class BinaryRelationArtifactProvider : IRetentionAwareRelationProvider, IIndexedRelationProvider
+    public sealed class BinaryRelationArtifactProvider : IRetentionAwareRelationProvider, IIndexedRelationProvider, IIndexedRelationBucketProvider
     {
         private readonly IRelationProvider? _fallback;
         private readonly Dictionary<PredicateId, string> _manifestPaths = new();
@@ -2318,6 +2511,29 @@ namespace UnifyWeaver.QueryRuntime
             }
 
             facts = default!;
+            return false;
+        }
+
+        public bool TryReadIndexedBuckets(PredicateId predicate, int columnIndex, out IEnumerable<IndexedRelationBucket> buckets)
+        {
+            if (_manifestPaths.TryGetValue(predicate, out var manifestPath))
+            {
+                var manifest = BinaryRelationArtifactReader.LoadManifest(manifestPath);
+                var columnKey = columnIndex.ToString(CultureInfo.InvariantCulture);
+                if (manifest.IndexPaths.ContainsKey(columnKey))
+                {
+                    buckets = BinaryRelationArtifactReader.ReadBuckets(manifest, manifestPath, columnIndex);
+                    return true;
+                }
+            }
+
+            if (_fallback is IIndexedRelationBucketProvider bucketFallback &&
+                bucketFallback.TryReadIndexedBuckets(predicate, columnIndex, out buckets))
+            {
+                return true;
+            }
+
+            buckets = default!;
             return false;
         }
     }
@@ -4474,6 +4690,28 @@ namespace UnifyWeaver.QueryRuntime
                 {
                     if (joinKeyCount == 1)
                     {
+                        if (leftIsScan && rightIsScan &&
+                            TryExecuteIndexedProviderBucketJoin(
+                                join,
+                                leftScanPredicate,
+                                leftScanPattern,
+                                leftScanFilter,
+                                join.LeftKeys[0],
+                                rightScanPredicate,
+                                rightScanPattern,
+                                rightScanFilter,
+                                join.RightKeys[0],
+                                out var indexedBucketRows))
+                        {
+                            trace?.RecordStrategy(join, "KeyJoinIndexedRelationProviderBuckets");
+                            foreach (var row in indexedBucketRows)
+                            {
+                                yield return row;
+                            }
+
+                            yield break;
+                        }
+
                         if (rightIsScan &&
                             TryExecuteIndexedProviderScanJoin(
                                 join,
@@ -9843,6 +10081,138 @@ namespace UnifyWeaver.QueryRuntime
 
             facts = default!;
             return false;
+        }
+
+        private bool TryExecuteIndexedProviderBucketJoin(
+            KeyJoinNode join,
+            PredicateId leftPredicate,
+            object[]? leftPattern,
+            Func<object[], bool>? leftFilter,
+            int leftKeyIndex,
+            PredicateId rightPredicate,
+            object[]? rightPattern,
+            Func<object[], bool>? rightFilter,
+            int rightKeyIndex,
+            out IEnumerable<object[]> rows)
+        {
+            rows = default!;
+            if (_provider is not IIndexedRelationBucketProvider bucketProvider ||
+                !bucketProvider.TryReadIndexedBuckets(leftPredicate, leftKeyIndex, out var leftBuckets) ||
+                !bucketProvider.TryReadIndexedBuckets(rightPredicate, rightKeyIndex, out var rightBuckets))
+            {
+                return false;
+            }
+
+            rows = EnumerateIndexedProviderBucketJoinRows(
+                join,
+                leftBuckets,
+                leftPattern,
+                leftFilter,
+                rightBuckets,
+                rightPattern,
+                rightFilter);
+            return true;
+        }
+
+        private static IEnumerable<object[]> EnumerateIndexedProviderBucketJoinRows(
+            KeyJoinNode join,
+            IEnumerable<IndexedRelationBucket> leftBuckets,
+            object[]? leftPattern,
+            Func<object[], bool>? leftFilter,
+            IEnumerable<IndexedRelationBucket> rightBuckets,
+            object[]? rightPattern,
+            Func<object[], bool>? rightFilter)
+        {
+            using var leftEnumerator = leftBuckets.GetEnumerator();
+            using var rightEnumerator = rightBuckets.GetEnumerator();
+            var hasLeft = leftEnumerator.MoveNext();
+            var hasRight = rightEnumerator.MoveNext();
+
+            while (hasLeft && hasRight)
+            {
+                var comparison = CompareBucketKeys(leftEnumerator.Current.Key, rightEnumerator.Current.Key);
+                if (comparison < 0)
+                {
+                    hasLeft = leftEnumerator.MoveNext();
+                    continue;
+                }
+
+                if (comparison > 0)
+                {
+                    hasRight = rightEnumerator.MoveNext();
+                    continue;
+                }
+
+                var rightRows = FilterBucketRows(rightEnumerator.Current.Rows, rightPattern, rightFilter);
+                if (rightRows.Count == 0)
+                {
+                    hasLeft = leftEnumerator.MoveNext();
+                    hasRight = rightEnumerator.MoveNext();
+                    continue;
+                }
+
+                foreach (var leftRow in leftEnumerator.Current.Rows)
+                {
+                    if (leftRow is null)
+                    {
+                        continue;
+                    }
+
+                    if (leftPattern is not null && !TupleMatchesPattern(leftRow, leftPattern))
+                    {
+                        continue;
+                    }
+
+                    if (leftFilter is not null && !leftFilter(leftRow))
+                    {
+                        continue;
+                    }
+
+                    foreach (var rightRow in rightRows)
+                    {
+                        yield return BuildJoinOutput(leftRow, rightRow, join.LeftWidth, join.RightWidth, join.Width);
+                    }
+                }
+
+                hasLeft = leftEnumerator.MoveNext();
+                hasRight = rightEnumerator.MoveNext();
+            }
+        }
+
+        private static int CompareBucketKeys(object left, object right)
+        {
+            var leftKey = left?.ToString() ?? string.Empty;
+            var rightKey = right?.ToString() ?? string.Empty;
+            return string.CompareOrdinal(leftKey, rightKey);
+        }
+
+        private static List<object[]> FilterBucketRows(
+            IReadOnlyList<object[]> rows,
+            object[]? pattern,
+            Func<object[], bool>? filter)
+        {
+            var filtered = new List<object[]>(rows.Count);
+            foreach (var row in rows)
+            {
+                if (row is null)
+                {
+                    continue;
+                }
+
+                if (pattern is not null && !TupleMatchesPattern(row, pattern))
+                {
+                    continue;
+                }
+
+                if (filter is not null && !filter(row))
+                {
+                    continue;
+                }
+
+                filtered.Add(row);
+            }
+
+            return filtered;
         }
 
         private bool TryExecuteIndexedProviderScanJoin(

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1625,8 +1625,12 @@ namespace UnifyWeaver.QueryRuntime
         private static readonly byte[] IndexMagic = Encoding.ASCII.GetBytes("UWBI0001");
         private static readonly byte[] IndexDirectoryMagic = Encoding.ASCII.GetBytes("UWBD0001");
         private static readonly byte[] IndexDirectoryFooterMagic = Encoding.ASCII.GetBytes("UWBF0001");
+        private const int IndexDirectoryEntrySize = sizeof(ulong) + sizeof(long) + sizeof(int) + sizeof(long);
+        private const int MaxDirectoryLookupKeys = 256;
 
         internal sealed record WriteResult(long RowCount, Dictionary<string, string> IndexPaths);
+
+        private readonly record struct IndexDirectoryInfo(long TableOffset, int EntryCount);
 
         private readonly record struct IndexDirectoryEntry(ulong Hash, long KeyOffset, int KeyLength, long EntryOffset);
 
@@ -1864,7 +1868,7 @@ namespace UnifyWeaver.QueryRuntime
                 return Array.Empty<long>();
             }
 
-            if (keySet.Count <= 256 &&
+            if (keySet.Count <= MaxDirectoryLookupKeys &&
                 TryReadOffsetsFromDirectory(indexPath, expectedColumnIndex, keySet, out var directoryOffsets))
             {
                 return directoryOffsets;
@@ -1965,7 +1969,7 @@ namespace UnifyWeaver.QueryRuntime
             using var reader = new BinaryReader(stream, Encoding.UTF8);
 
             ValidateIndexHeader(reader, indexPath, expectedColumnIndex);
-            if (!TryReadIndexDirectory(reader, indexPath, out var entries))
+            if (!TryReadIndexDirectoryInfo(reader, indexPath, out var directory))
             {
                 return false;
             }
@@ -1974,12 +1978,18 @@ namespace UnifyWeaver.QueryRuntime
             foreach (var key in keySet)
             {
                 var hash = StableHash(key);
-                var index = LowerBoundByHash(entries, hash);
-                while (index < entries.Count && entries[index].Hash == hash)
+                var index = LowerBoundByHash(reader, directory, hash);
+                while (index < directory.EntryCount)
                 {
-                    if (ReadDirectoryKey(stream, entries[index]) == key)
+                    var entry = ReadIndexDirectoryEntry(reader, directory, index);
+                    if (entry.Hash != hash)
                     {
-                        AddOffsetsFromIndexEntry(reader, indexPath, expectedColumnIndex, entries[index].EntryOffset, key, result);
+                        break;
+                    }
+
+                    if (ReadDirectoryKey(stream, entry) == key)
+                    {
+                        AddOffsetsFromIndexEntry(reader, indexPath, expectedColumnIndex, entry.EntryOffset, key, result);
                         break;
                     }
 
@@ -1991,9 +2001,9 @@ namespace UnifyWeaver.QueryRuntime
             return true;
         }
 
-        private static bool TryReadIndexDirectory(BinaryReader reader, string indexPath, out List<IndexDirectoryEntry> entries)
+        private static bool TryReadIndexDirectoryInfo(BinaryReader reader, string indexPath, out IndexDirectoryInfo directory)
         {
-            entries = new List<IndexDirectoryEntry>();
+            directory = default;
             var stream = reader.BaseStream;
             var footerLength = sizeof(long) + IndexDirectoryFooterMagic.Length;
             if (stream.Length < footerLength)
@@ -2030,22 +2040,30 @@ namespace UnifyWeaver.QueryRuntime
                 throw new InvalidDataException($"Binary relation index directory entry count is negative: {indexPath}");
             }
 
-            entries = new List<IndexDirectoryEntry>(entryCount);
-            for (var i = 0; i < entryCount; i++)
-            {
-                var hash = reader.ReadUInt64();
-                var keyOffset = reader.ReadInt64();
-                var keyLength = reader.ReadInt32();
-                var entryOffset = reader.ReadInt64();
-                if (keyOffset < 0 || keyLength < 0 || entryOffset < 0)
-                {
-                    throw new InvalidDataException($"Binary relation index directory contains a negative offset or length: {indexPath}");
-                }
+            var tableOffset = stream.Position;
+            directory = new IndexDirectoryInfo(tableOffset, entryCount);
+            return true;
+        }
 
-                entries.Add(new IndexDirectoryEntry(hash, keyOffset, keyLength, entryOffset));
+        private static IndexDirectoryEntry ReadIndexDirectoryEntry(BinaryReader reader, IndexDirectoryInfo directory, int index)
+        {
+            if (index < 0 || index >= directory.EntryCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
             }
 
-            return true;
+            var stream = reader.BaseStream;
+            stream.Position = directory.TableOffset + ((long)index * IndexDirectoryEntrySize);
+            var hash = reader.ReadUInt64();
+            var keyOffset = reader.ReadInt64();
+            var keyLength = reader.ReadInt32();
+            var entryOffset = reader.ReadInt64();
+            if (keyOffset < 0 || keyLength < 0 || entryOffset < 0)
+            {
+                throw new InvalidDataException("Binary relation index directory contains a negative offset or length.");
+            }
+
+            return new IndexDirectoryEntry(hash, keyOffset, keyLength, entryOffset);
         }
 
         private static void AddOffsetsFromIndexEntry(
@@ -2089,14 +2107,17 @@ namespace UnifyWeaver.QueryRuntime
             return Encoding.UTF8.GetString(bytes);
         }
 
-        private static int LowerBoundByHash(IReadOnlyList<IndexDirectoryEntry> entries, ulong hash)
+        private static int LowerBoundByHash(BinaryReader reader, IndexDirectoryInfo directory, ulong hash)
         {
             var lo = 0;
-            var hi = entries.Count;
+            var hi = directory.EntryCount;
+            var stream = reader.BaseStream;
             while (lo < hi)
             {
                 var mid = lo + ((hi - lo) / 2);
-                if (entries[mid].Hash < hash)
+                stream.Position = directory.TableOffset + ((long)mid * IndexDirectoryEntrySize);
+                var midHash = reader.ReadUInt64();
+                if (midHash < hash)
                 {
                     lo = mid + 1;
                 }


### PR DESCRIPTION
  # PR Description

  ## Summary

  This PR continues the C# query runtime artifact work by making broad artifact-backed joins substantially cheaper while preserving the selective probe wins from the earlier artifact index changes.

  It adds and lands the follow-up work from the artifact bucket join branch:

  - Direct on-disk lookup through artifact index key directories.
  - `artifact-prebuilt` benchmark mode with runtime-source versioned cache keys.
  - Smaller-side hash build fallback for generic artifact bucket joins when relation cardinalities are available.
  - A direct sorted bucket-sidecar merge path that only deserializes rows for matching keys instead of materializing full bucket streams.

  ## Why

  The initial artifact work improved bound scans and selective joins, but broad scan-scan joins were still paying too much for bucket materialization and row decoding.

  This change improves the broad-join path by using the sorted `.uwbrb` sidecars as an actual join surface rather than just a pre-expanded bucket source. The runtime can now advance through both key-ordered
  streams, skip unmatched keys cheaply, and deserialize rows only when the join keys match.

  That keeps the artifact path aligned with the larger preprocessed-data direction: preprocess once, then execute query-time access with less runtime reconstruction.

  ## Implementation Details

  - Added direct bucket-stream join support for binary relation artifacts.
  - Added provider wiring so `KeyJoinIndexedRelationProviderBuckets` can use the streamed bucket path first when both sides are artifact-backed.
  - Preserved the previous fallback ladder:
    - direct bucket merge when `.uwbrb` sidecars exist
    - smaller-side hash build when generic bucket streams are available and cardinalities are known
    - older generic bucket path otherwise
  - Added `artifact-prebuilt` benchmark mode and versioned its cache by the current `QueryRuntime.cs` hash so stale artifacts are not reused across format/runtime changes.
  - Updated the proposal doc to reflect the current prototype behavior.

  ## Benchmark Signal

  Focused benchmark command:

  ```bash
  python3 examples/benchmark/benchmark_scan_materialization.py --scales 300,10k --modes selective_join,join,bound_scan --source-modes preload,artifact,artifact-prebuilt --strategies auto --repetitions 5
  ```
  Representative results after this branch:

  - 300 join: artifact 0.050s, artifact-prebuilt 0.045s, preload 0.059s
  - 10k join: artifact 0.079s, artifact-prebuilt 0.082s, preload 0.075s
  - 10k bound_scan: artifact 0.013s, preload 0.032s
  - 10k selective_join: artifact 0.052s, preload 0.109s

  The broad artifact join path is now near preload parity at 10k, while bound scans and selective joins remain clearly faster on artifacts.

  ## Validation

  - dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c Release --nologo
  - python3 -m py_compile examples/benchmark/benchmark_scan_materialization.py
  - git diff --check
  - Focused scan materialization benchmark over preload, artifact, and artifact-prebuilt

  ## Follow-Up

  This branch gets the current binary artifact format close to the point of diminishing returns for exact broad joins. The next likely step is a more explicit streamed or file-backed hash-state artifact format
  for larger joins, rather than continuing to enrich the current row-oriented bucket sidecars indefinitely.