### PR TITLE
bench(csharp-query): Add auto source-mode planning to the C# scan materialization benchmark

### DIFF
--- a/examples/benchmark/benchmark_scan_materialization.py
+++ b/examples/benchmark/benchmark_scan_materialization.py
@@ -15,7 +15,8 @@ relation sources inside a temporary C# project:
 - `aggregate`: grouped count aggregate over a scanned relation
 
 It is intended as a focused validation tool for the scan materialization
-planner rather than a cross-target benchmark.
+planner rather than a cross-target benchmark. It can also exercise a simple
+source-mode planner via `--source-modes auto,...`.
 """
 
 from __future__ import annotations
@@ -306,6 +307,7 @@ class BenchResult:
     scale: str
     mode: str
     source_mode: str
+    resolved_source_mode: str
     strategy: str
     times: list[float]
     stderr: str
@@ -374,15 +376,46 @@ def select_planner_summary(metrics: dict[str, str]) -> str:
     return metrics.get("scan_planner_strategies", "") or operator
 
 
-def benchmark_mode(command: list[str], scale: str, mode: str, source_mode: str, strategy: str, repetitions: int) -> BenchResult:
+def choose_auto_source_mode(scale: str, mode: str, available_source_modes: list[str]) -> str:
+    scale_value = scale_sort_key(scale)[0]
+    requested = set(available_source_modes)
+
+    if mode in {"bound_scan", "selective_join"}:
+        preference = ["artifact-prebuilt", "artifact", "preload", "delimited"]
+    elif mode == "join":
+        if scale_value <= 1_000:
+            preference = ["artifact-prebuilt", "artifact", "preload", "delimited"]
+        else:
+            preference = ["artifact", "artifact-prebuilt", "preload", "delimited"]
+    else:
+        preference = ["preload", "artifact-prebuilt", "artifact", "delimited"]
+
+    for candidate in preference:
+        if candidate in requested:
+            return candidate
+
+    return available_source_modes[0] if available_source_modes else "preload"
+
+
+def benchmark_mode(
+    command: list[str],
+    scale: str,
+    mode: str,
+    source_mode: str,
+    strategy: str,
+    repetitions: int,
+    available_source_modes: list[str],
+) -> BenchResult:
     scale_dir = BENCH_DIR / scale
     edge_path = scale_dir / "category_parent.tsv"
     article_path = scale_dir / "article_category.tsv"
     env = os.environ.copy()
     env["UNIFYWEAVER_BENCH_TRACE"] = "1"
     env["UNIFYWEAVER_SCAN_RETENTION_STRATEGY"] = strategy
-    env["UNIFYWEAVER_SCAN_SOURCE_MODE"] = source_mode
-    if source_mode == "artifact-prebuilt":
+    candidate_source_modes = [mode_name for mode_name in available_source_modes if mode_name != "auto"]
+    resolved_source_mode = choose_auto_source_mode(scale, mode, candidate_source_modes) if source_mode == "auto" else source_mode
+    env["UNIFYWEAVER_SCAN_SOURCE_MODE"] = resolved_source_mode
+    if resolved_source_mode == "artifact-prebuilt":
         artifact_dir = Path(tempfile.gettempdir()) / f"uw-scan-prebuilt-artifacts-{RUNTIME_CACHE_VERSION}" / scale
         artifact_dir.mkdir(parents=True, exist_ok=True)
         env["UNIFYWEAVER_SCAN_ARTIFACT_DIR"] = str(artifact_dir)
@@ -399,7 +432,15 @@ def benchmark_mode(command: list[str], scale: str, mode: str, source_mode: str, 
         elapsed = float(elapsed_ms) / 1000.0 if elapsed_ms is not None else 0.0
         times.append(elapsed)
 
-    return BenchResult(scale=scale, mode=mode, source_mode=source_mode, strategy=strategy, times=times, stderr=stderr)
+    return BenchResult(
+        scale=scale,
+        mode=mode,
+        source_mode=source_mode,
+        resolved_source_mode=resolved_source_mode,
+        strategy=strategy,
+        times=times,
+        stderr=stderr,
+    )
 
 
 def main() -> int:
@@ -423,18 +464,21 @@ def main() -> int:
             for mode in modes:
                 for source_mode in source_modes:
                     for strategy in strategies:
-                        results.append(benchmark_mode(command, scale, mode, source_mode, strategy, args.repetitions))
+                        results.append(benchmark_mode(command, scale, mode, source_mode, strategy, args.repetitions, source_modes))
 
-        print("scale	mode	source_mode	strategy	median_s	min_s	max_s	rows	planner	phases")
+        print("scale	mode	source_mode	resolved_source_mode	strategy	median_s	min_s	max_s	rows	planner	phases")
         grouped: dict[tuple[str, str, str], dict[str, BenchResult]] = {}
+        by_source_mode: dict[tuple[str, str, str], BenchResult] = {}
         for result in sorted(results, key=lambda item: (scale_sort_key(item.scale), item.mode, item.source_mode, item.strategy)):
             grouped.setdefault((result.scale, result.mode, result.source_mode), {})[result.strategy] = result
+            if result.strategy == "auto":
+                by_source_mode[(result.scale, result.mode, result.source_mode)] = result
             metrics = parse_metrics(result.stderr)
             planner = select_planner_summary(metrics)
             phases = metrics.get("scan_phase_summary", "")
             rows = metrics.get("row_count", "")
             print(
-                f"{result.scale}	{result.mode}	{result.source_mode}	{result.strategy}	{result.median:.3f}	"
+                f"{result.scale}	{result.mode}	{result.source_mode}	{result.resolved_source_mode}	{result.strategy}	{result.median:.3f}	"
                 f"{min(result.times):.3f}	{max(result.times):.3f}	{rows}	{planner}	{phases}"
             )
 
@@ -449,6 +493,27 @@ def main() -> int:
                 auto_metrics = parse_metrics(auto.stderr)
                 auto_planner = select_planner_summary(auto_metrics)
                 print(f"{scale}	{mode}	{source_mode}	auto_planner	{auto_planner}")
+
+        if "auto" in source_modes:
+            for scale in scales:
+                for mode in modes:
+                    auto = by_source_mode.get((scale, mode, "auto"))
+                    if auto is None:
+                        continue
+
+                    concrete = [
+                        result
+                        for (result_scale, result_mode, result_source_mode), result in by_source_mode.items()
+                        if result_scale == scale and result_mode == mode and result_source_mode != "auto"
+                    ]
+                    if not concrete:
+                        continue
+
+                    best = min(concrete, key=lambda item: item.median)
+                    ratio = auto.median / best.median if best.median else float("inf")
+                    print(f"{scale}	{mode}	auto	best_source_mode	{best.source_mode}")
+                    print(f"{scale}	{mode}	auto	chosen_source_mode	{auto.resolved_source_mode}")
+                    print(f"{scale}	{mode}	auto	auto_vs_best_source_mode	{ratio:.2f}x")
 
         if args.keep_temp:
             print(f"kept temp build directory: {temp_root}", file=sys.stderr)


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  This PR adds an `auto` source-mode planner to the C# scan materialization benchmark harness so we can evaluate when `preload`, `artifact`, or `artifact-prebuilt` should be preferred for different workload   
  shapes.                                                                                                                                                                                                        
                                                                                                                                                                                                                 
  It does not change the runtime planner yet. Instead, it adds a measured benchmark-layer planner that:                                                                                                          
                                                                                                                                                                                                                 
  - resolves `--source-modes auto,...` to a concrete source mode                                                                                                                                                 
  - records the chosen source mode alongside the benchmark result                                                                                                                                                
  - reports the best concrete source mode for each workload                                                                                                                                                      
  - reports how close the `auto` choice is to the best measured source mode                                                                                                                                      
                                                                                                                                                                                                                 
  ## Why                                                                                                                                                                                                         
                                                                                                                                                                                                                 
  We now have enough artifact-runtime support that the next question is no longer just “can artifact access be made faster?” but “when should we use artifact-backed execution at all?”                          
                                                                                                                                                                                                                 
  The benchmark already exercises the right workload shapes:                                                                                                                                                     
  - plain scans                                                                                                                                                                                                  
  - bound scans                                                                                                                                                                                                  
  - pattern scans                                                                                                                                                                                                
  - joins                                                                                                                                                                                                        
  - selective joins                                                                                                                                                                                              
  - negation                                                                                                                                                                                                     
  - aggregates                                                                                                                                                                                                   
                                                                                                                                                                                                                 
  This PR adds a lightweight source-mode planner on top of that harness so we can validate source-mode heuristics against measured outcomes before baking those choices into the runtime or codegen path.        
                                                                                                                                                                                                                 
  ## Heuristic                                                                                                                                                                                                   
                                                                                                                                                                                                                 
  The new `auto` source-mode logic currently uses workload-shape heuristics:                                                                                                                                     
                                                                                                                                                                                                                 
  - `bound_scan` and `selective_join` prefer artifact modes                                                                                                                                                      
  - `join` prefers artifact modes, with a small/large scale split between `artifact-prebuilt` and `artifact`                                                                                                     
  - `scan`, `pattern`, `negation`, and `aggregate` prefer `preload`                                                                                                                                              
                                                                                                                                                                                                                 
  This is intentionally simple. The point of this PR is to create a measurable source-mode planning surface, not to claim that the heuristic is final.                                                           
                                                                                                                                                                                                                 
  ## Benchmark Signal                                                                                                                                                                                            
                                                                                                                                                                                                                 
  Validation command:                                                                                                                                                                                            
                                                                                                                                                                                                                 
  ```bash                                                                                                                                                                                                        
  python3 examples/benchmark/benchmark_scan_materialization.py \                                                                                                                                                 
    --scales 300,10k \                                                                                                                                                                                           
    --modes scan,bound_scan,pattern,join,selective_join,negation,aggregate \                                                                                                                                     
    --source-modes auto,preload,artifact,artifact-prebuilt \                                                                                                                                                     
    --strategies auto \                                                                                                                                                                                          
    --repetitions 3                                                                                                                                                                                              
                                                                                                                                                                                                                 
  Representative auto results:                                                                                                                                                                                   
                                                                                                                                                                                                                 
  - 300 join: chose artifact-prebuilt, 0.98x vs best source mode                                                                                                                                                 
  - 10k join: chose artifact, 1.08x vs best source mode                                                                                                                                                          
  - 300 bound_scan: chose artifact family, 1.08x vs best                                                                                                                                                         
  - 10k bound_scan: chose artifact family, 1.08x vs best                                                                                                                                                         
  - 300 pattern: chose preload, 1.00x vs best                                                                                                                                                                    
  - 10k pattern: chose preload, 1.00x vs best                                                                                                                                                                    
  - 300 negation: chose preload, 0.92x vs best                                                                                                                                                                   
  - 10k negation: chose preload, 0.93x vs best                                                                                                                                                                   
  - 300 aggregate: chose preload, 1.06x vs best                                                                                                                                                                  
  - 10k aggregate: chose preload, 1.15x vs best                                                                                                                                                                  
                                                                                                                                                                                                                 
  That is good enough to justify keeping the planner surface: it generally chooses the right source-mode family and stays close to the best measured option.                                                     
                                                                                                                                                                                                                 
  ## Implementation Details                                                                                                                                                                                      
                                                                                                                                                                                                                 
  - Added auto support to --source-modes                                                                                                                                                                         
  - Added resolved_source_mode to benchmark output                                                                                                                                                               
  - Added a simple choose_auto_source_mode(...) heuristic                                                                                                                                                        
  - Added per-workload summary lines for:                                                                                                                                                                        
      - best_source_mode                                                                                                                                                                                         
      - chosen_source_mode                                                                                                                                                                                       
      - auto_vs_best_source_mode                                                                                                                                                                                 
                                                                                                                                                                                                                 
  ## Validation                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  - python3 -m py_compile examples/benchmark/benchmark_scan_materialization.py                                                                                                                                   
  - git diff --check                                                                                                                                                                                             
  - benchmark run with auto,preload,artifact,artifact-prebuilt                                                                                                                                                   
                                                                                                                                                                                                                 
  ## Follow-Up                                                                                                                                                                                                   
                                                                                                                                                                                                                 
  The next step after this PR is to decide whether to push similar source-mode selection into the runtime or generated benchmark/query configuration, using the benchmark summaries from this branch as the      
  initial policy input.                                                                                                                                                                                          