### PR TITLE
perf(wam-clojure): narrow foreign choice snapshots

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -325,12 +325,16 @@ for further optimization work.
     streaming `category_ancestor/4` foreign handler directly. The bespoke
     runner-side `benchmark-ancestor-hops-index` materialization is gone;
     `kernels_off` still uses the pure recursive runner path for comparison.
+18. Streamed foreign alternatives in Clojure now use a narrower choice-point
+    shape than ordinary WAM backtracking. Foreign choice points retain the
+    trail boundary, regs/env/stack, cut barrier, next-var-id, resume PC, and
+    remaining foreign results, but they no longer snapshot heap/unify/build
+    state that deterministic foreign handlers do not touch.
 
 ### Highest-value remaining work
 
-1. Start reducing Clojure runtime overhead now that the traversal kernel path
-   is generic: avoid full choice-point snapshots where foreign choice points
-   only need a narrow state slice.
+1. Measure whether the slimmer foreign choice points improve the `dev`
+   Clojure benchmark timings enough to justify similar hot-state split work.
 2. Add proper heap/trail semantics instead of relying primarily on the
    bindings table.
 3. Reduce choice-point snapshots toward the lighter Haskell/Rust model once

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -111,7 +111,8 @@
 (declare activate-foreign-choice)
 
 (defn choice-snapshot [state target-pc]
-  {:pc target-pc
+  {:kind :wam
+   :pc target-pc
    :stack (:stack state)
    :regs (:regs state)
    :env-stack (:env-stack state)
@@ -121,6 +122,17 @@
    :build-stack (:build-stack state)
    :cut-bar (:cut-bar state)
    :next-var-id (:next-var-id state)})
+
+(defn foreign-choice-snapshot [state target-pc results]
+  {:pc target-pc
+   :kind :foreign
+   :stack (:stack state)
+   :regs (:regs state)
+   :env-stack (:env-stack state)
+   :trail-len (count (:trail state))
+   :cut-bar (:cut-bar state)
+   :next-var-id (:next-var-id state)
+   :foreign-results (vec results)})
 
 (defn push-choice-point [state target-pc]
   (update state :choice-points conj (choice-snapshot state target-pc)))
@@ -138,18 +150,30 @@
       (assoc s :trail (vec (take target-len (:trail state)))))))
 
 (defn restore-choice-state [state cp]
-  (-> state
-      (unwind-trail (:trail-len cp))
-      (assoc :pc (:pc cp))
-      (assoc :stack (:stack cp))
-      (restore-choice-regs (:regs cp))
-      (assoc :env-stack (:env-stack cp))
-      (assoc :heap (vec (take (:heap-len cp) (:heap state))))
-      (assoc :unify-queue (:unify-queue cp))
-      (assoc :build-stack (:build-stack cp))
-      (assoc :cut-bar (:cut-bar cp))
-      (assoc :next-var-id (:next-var-id cp))
-      (update :choice-points pop)))
+  (case (:kind cp)
+    :foreign
+    (-> state
+        (unwind-trail (:trail-len cp))
+        (assoc :pc (:pc cp))
+        (assoc :stack (:stack cp))
+        (restore-choice-regs (:regs cp))
+        (assoc :env-stack (:env-stack cp))
+        (assoc :cut-bar (:cut-bar cp))
+        (assoc :next-var-id (:next-var-id cp))
+        (update :choice-points pop))
+
+    (-> state
+        (unwind-trail (:trail-len cp))
+        (assoc :pc (:pc cp))
+        (assoc :stack (:stack cp))
+        (restore-choice-regs (:regs cp))
+        (assoc :env-stack (:env-stack cp))
+        (assoc :heap (vec (take (:heap-len cp) (:heap state))))
+        (assoc :unify-queue (:unify-queue cp))
+        (assoc :build-stack (:build-stack cp))
+        (assoc :cut-bar (:cut-bar cp))
+        (assoc :next-var-id (:next-var-id cp))
+        (update :choice-points pop))))
 
 (defn backtrack [state]
   (if-let [cp (peek (:choice-points state))]
@@ -381,8 +405,7 @@
 (defn push-foreign-choice-point [state base-state resume-pc results]
   (if (seq results)
     (update state :choice-points conj
-            (assoc (choice-snapshot base-state resume-pc)
-                   :foreign-results (vec results)))
+            (foreign-choice-snapshot base-state resume-pc results))
     state))
 
 (defn apply-first-foreign-solution [base-state resume-pc results]

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -78,6 +78,8 @@ test(project_uses_shared_wam_table_for_cross_predicate_calls) :-
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-bindings [state bindings]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-first-foreign-solution [base-state resume-pc results]')),
+        assertion(sub_string(RuntimeCode, _, _, _, '(defn foreign-choice-snapshot [state target-pc results]')),
+        assertion(sub_string(RuntimeCode, _, _, _, ':kind :foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, ':bindings')),
         assertion(sub_string(RuntimeCode, _, _, _, ':solutions')),
         assertion(sub_string(RuntimeCode, _, _, _, ':cut-ite')),


### PR DESCRIPTION
## Summary

This PR reduces Clojure hybrid WAM runtime overhead for streamed foreign predicates by introducing a dedicated slim foreign choice-point snapshot.

Ordinary WAM choice points still use the existing full snapshot path. Only streamed foreign alternatives now avoid capturing state they do not need to restore.

## Changes

- add a dedicated `foreign-choice-snapshot` in the Clojure WAM runtime
- tag choice points by kind so restore logic can distinguish ordinary WAM vs streamed foreign alternatives
- keep ordinary WAM choice points on the existing full-state snapshot path
- narrow foreign choice points to the state actually needed for retrying alternative foreign solutions:
  - resume `pc`
  - `stack`
  - `regs`
  - `env-stack`
  - `trail-len`
  - `cut-bar`
  - `next-var-id`
  - remaining `:foreign-results`
- stop snapshotting `heap-len`, `unify-queue`, and `build-stack` for streamed foreign alternatives
- add generator assertions covering the new foreign snapshot/runtime shape
- update the WAM optimization log with the new Clojure runtime step

## Why

The previous streaming foreign path reused the ordinary WAM choice-point snapshot shape, which was more expensive than necessary for foreign result backtracking. This change narrows that hot path without changing ordinary WAM semantics.

## Validation

Passed:

- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
- `git diff --check`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-accumulated,clojure-wam-accumulated-no-kernels,clojure-wam-seeded,clojure-wam-seeded-no-kernels,prolog-accumulated --scales dev --repetitions 1`

Benchmark smoke output still matched digest `1659619c9d36` across all tested Clojure WAM modes and `prolog-accumulated`.

## Perf Note

This branch showed a noticeably faster single `dev` benchmark smoke in Termux than the prior merged baseline, but that result is still noisy. Reliable benchmarking and profiling for the next phase should move to a desktop environment where JVM startup, memory pressure, and sampling tools are less distorted by the mobile Termux environment.

## Next

- repeat the small benchmark matrix on desktop to confirm the foreign choice-point reduction is a real improvement
- if confirmed, split hotter runtime state from colder code/context data in the Clojure runtime
- then revisit whether ordinary WAM choice points can also be narrowed safely in selected paths
