### PR TITLE
feat(wam-haskell): system-wide atom interning — 19% WAM interpreter speedup at 10k scale

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -342,6 +342,57 @@ Not every attempt was a win. Tracking these so we don't repeat them.
 
 ---
 
+## Phase E: System-wide atom interning (2026-04-20)
+
+**Branch:** `feat/wam-haskell-atom-interning`
+
+Changed `Value` from `Atom String` / `Str String [Value]` to `Atom !Int` /
+`Str !Int [Value]` with a system-wide `InternTable`. Compile-time atoms get
+reserved IDs (0-7: true, fail, [], ., "", member/2, +/2, **/2); runtime atoms
+from TSV data extend the table at load time.
+
+### Changes
+
+| Component | Before | After |
+|---|---|---|
+| `data Value` | `Atom String`, `Str String [Value]` | `Atom !Int`, `Str !Int [Value]` |
+| `SwitchOnConstantPc` | `Map.Map String Int` | `IM.IntMap Int` |
+| Atom equality | O(n) string compare | O(1) Int compare |
+| `WamContext` | `wcAtomIntern`/`wcAtomDeintern` maps | `wcInternTable :: !InternTable` |
+| FFI boundary | Map.lookup to intern/deintern | Identity (atoms already Int) |
+| `evalArith` | String-based operator names | Reverse-lookup via InternTable |
+| Lowered emitter | `Atom "string"` literals | `Atom <id>` via `intern_atom/2` |
+
+### Benchmark results — 10k scale (25k category_parent, 10k article_category)
+
+All configurations produce identical output: tuple_count=462, article_count=5192.
+
+| Configuration | Mean query_ms | vs Baseline |
+|---|---|---|
+| Baseline FFI (main, String atoms) | **555** | — |
+| Interned FFI (atom-interning, Int atoms) | **556** | ~0% |
+| Baseline WAM-only (main, String atoms) | **19,173** | — |
+| Interned WAM-only (atom-interning, Int atoms) | **15,546** | **-19% faster** |
+
+At 1k scale, both WAM-only paths were ~1550ms (within noise). The 19%
+improvement at 10k confirms atom interning scales with dataset size — more
+atoms mean more comparisons where Int beats String.
+
+The FFI path is unaffected because the native kernel already used `Int`
+comparison (via the old `wcAtomIntern` boundary table).
+
+### Bug fixes included in this branch
+
+| Bug | Symptom | Fix |
+|---|---|---|
+| FFI query dispatch | `tuple_count=0` on effective-distance benchmark when kernels detected | Added `collectForeignSolutions` using `executeForeign` directly instead of running WAM code (where fact code was skipped) |
+| `collectSolutions` refactoring | Infinite loop on WAM-only path | Restored `run ctx` call after `backtrack` (WAM choice points need re-execution; only FFI StreamRetry CPs bind directly) |
+
+**Note:** The FFI query dispatch bug also affected main (pre-interning) and
+was fixed separately in commit `e5a8e866` on main.
+
+---
+
 ## Related documents
 
 - `docs/vision/HASKELL_TARGET_ROADMAP.md` — where this is going

--- a/docs/vision/HASKELL_TARGET_ROADMAP.md
+++ b/docs/vision/HASKELL_TARGET_ROADMAP.md
@@ -1,6 +1,6 @@
 # Haskell WAM Target: Roadmap
 
-## Current state (2026-04-13, post-parallelization)
+## Current state (2026-04-20, post-atom-interning)
 
 The Haskell WAM target **outperforms the Rust WAM target** on the effective-
 distance benchmark (300 scale) thanks to seed-level parallelism that Rust's
@@ -12,12 +12,14 @@ mutable-vector design can't trivially match. Median numbers over 10 runs:
 | Haskell + FFI single-core (300 scale) | 193ms total, 107ms query | — |
 | Rust + FFI (300 scale) | 126ms | baseline |
 | SWI-Prolog optimized | 311ms | — |
-| Pure interpreter (no FFI) | 2518ms | — |
+| Pure interpreter (no FFI, pre-interning) | 2518ms | — |
 | Haskell at 5k scale (4 cores) | 213ms total, 86ms query | 3.5x parallel speedup |
+| Pure interpreter (10k WAM-only, interned) | **15,546ms** | 19% faster than baseline |
 | Lowered predicates | 5 of 7 | — |
 | Detected kernels | category_ancestor (auto-generated FFI) | — |
 
-**Phases 1 and 2 are now complete** (seed parallelism, atom interning).
+**Phases 1, 2, and 2c are now complete** (seed parallelism, FFI-boundary
+interning, system-wide atom interning).
 Additional optimizations beyond the original roadmap: `skip_fact_wam`
 (eliminates redundant WAM-compilation of FFI-owned facts, -70% total at
 300 scale), O(n) intern-table construction. See
@@ -64,12 +66,30 @@ scheduling/GC contention; 4 cores is the sweet spot.
 on a single core — beat Rust's 126ms on query time without needing
 parallelism.
 
-**Still-open Phase 2 work** (low priority, likely not needed):
-- Atom interning in the WAM interpreter path itself (would require
-  touching `Value`, `SwitchOnConstantPc`, `callIndexedFact2`). Only
-  useful if we start routing hot predicates through the interpreter
-  rather than FFI. Given that FFI already handles the hot path, this
-  is on hold.
+## Phase 2c: System-Wide Atom Interning — DONE
+
+**Goal:** Promote atom interning from the FFI boundary to the entire system.
+Change `Atom String` to `Atom !Int` everywhere — WAM interpreter, lowered
+emitter, FFI kernels, fact dispatch.
+
+**Delivered (branch `feat/wam-haskell-atom-interning`):**
+1. `data Value`: `Atom !Int`, `Str !Int [Value]`
+2. `InternTable` type with forward (String→Int) and reverse (Int→String) maps
+3. Well-known atom constants: atomTrue=0, atomFail=1, atomNil=2, atomDot=3
+4. `SwitchOnConstantPc` changed from `Map.Map String Int` to `IM.IntMap Int`
+5. `compileTimeAtomTable` emitted in Predicates.hs, extended at load time
+6. FFI boundary simplified — atoms already Int, no intern/deintern step
+7. Lowered emitter updated to emit `Atom <id>` via `intern_atom/2`
+8. `evalArith` threaded through `InternTable` for reverse lookup
+
+**Actual outcome:** 19% faster on the WAM-only interpreter path at 10k
+scale (19,173ms → 15,546ms). FFI path unchanged (already used Int
+comparison). Correctness verified: identical output at 1k and 10k.
+
+**Also fixed:** FFI query dispatch bug — effective-distance benchmark was
+producing `tuple_count=0` when kernels were detected (fact code skipped
+but query entered WAM code directly). Added `collectForeignSolutions`
+using `executeForeign` dispatch. This fix was also applied to main.
 
 ## Phase 2b (unplanned): Skip-Facts
 

--- a/src/unifyweaver/core/purity_certificate.pl
+++ b/src/unifyweaver/core/purity_certificate.pl
@@ -68,7 +68,12 @@
     % lower-priority `impure` verdict. Pure (no side effects by
     % default); callers decide how loud to be about findings.
     check_purity_contradictions/2,    % +PredIndicator, -Contradictions
-    warn_purity_contradictions/1      % +PredIndicator — prints to user_error
+    warn_purity_contradictions/1,     % +PredIndicator — prints to user_error
+
+    % Phase P5: JSON serialization for cross-language interop
+    cert_to_json/2,                   % +Cert, -JsonDict
+    cert_to_json/3,                   % +Cert, +Metadata, -JsonDict
+    cert_from_json/2                  % +JsonDict, -Cert
 ]).
 
 :- use_module(library(lists)).
@@ -664,6 +669,108 @@ collect_unknown_reasons(Certs, Reasons) :-
                        purity_certificate:user_annotation_analyzer,
                        [goal, predicate]),
        100).
+% ============================================================================
+% PHASE P5: JSON SERIALIZATION
+% ============================================================================
+
+%% cert_to_json(+Cert, -JsonDict) is det.
+%  Serialize a purity certificate to a SWI-Prolog dict suitable for
+%  json_write_dict/2. Convenience wrapper with empty metadata.
+cert_to_json(Cert, Json) :-
+    cert_to_json(Cert, _{}, Json).
+
+%% cert_to_json(+Cert, +Metadata, -JsonDict) is det.
+%  Serialize with optional metadata (subject, producer, producer_version).
+%  Metadata is a dict; unknown keys are passed through to the output.
+cert_to_json(purity_cert(Verdict, Proof, Confidence, Reasons), Metadata, Json) :-
+    verdict_to_json(Verdict, VerdictStr, ExtraReasons),
+    proof_to_json(Proof, ProofDict),
+    append(ExtraReasons, Reasons, AllReasons),
+    maplist(reason_to_string, AllReasons, ReasonStrs),
+    BaseDict = _{verdict: VerdictStr, proof: ProofDict,
+                 confidence: Confidence, reasons: ReasonStrs},
+    put_dict(Metadata, BaseDict, Json).
+
+verdict_to_json(pure, "pure", []).
+verdict_to_json(impure(ReasonList), "impure", ReasonList) :-
+    is_list(ReasonList), !.
+verdict_to_json(impure(_), "impure", []).
+verdict_to_json(unknown, "unknown", []).
+
+proof_to_json(declared, _{kind: "declared"}).
+proof_to_json(analyzed(Strategy), _{kind: "analyzed", strategy: StratStr}) :-
+    term_to_atom(Strategy, StratStr).
+proof_to_json(certified(Source), _{kind: "certified", source: SrcStr}) :-
+    term_to_atom(Source, SrcStr).
+proof_to_json(inferred, _{kind: "inferred"}).
+
+reason_to_string(R, S) :-
+    (   atom(R) -> atom_string(R, S)
+    ;   term_to_atom(R, A), atom_string(A, S)
+    ).
+
+%% cert_from_json(+JsonDict, -Cert) is det.
+%  Deserialize a JSON dict to a purity_cert/4 term. Unknown keys in
+%  the dict are silently ignored (forward-compat per spec §3.2).
+cert_from_json(Json, purity_cert(Verdict, Proof, Confidence, Reasons)) :-
+    (   get_dict(verdict, Json, VerdictStr) -> true
+    ;   throw(error(cert_json_error(missing_verdict), _))
+    ),
+    (   get_dict(confidence, Json, Confidence) -> true
+    ;   throw(error(cert_json_error(missing_confidence), _))
+    ),
+    (   number(Confidence), Confidence >= 0.0, Confidence =< 1.0 -> true
+    ;   throw(error(cert_json_error(confidence_out_of_range(Confidence)), _))
+    ),
+    (   get_dict(proof, Json, ProofDict) -> true
+    ;   throw(error(cert_json_error(missing_proof), _))
+    ),
+    json_to_verdict(VerdictStr, Json, Verdict),
+    json_to_proof(ProofDict, Proof),
+    json_to_reasons(Json, Reasons).
+
+json_to_verdict("pure", _, pure).
+json_to_verdict("impure", Json, impure(Reasons)) :-
+    json_to_reasons(Json, Reasons).
+json_to_verdict("unknown", _, unknown).
+json_to_verdict(Other, _, _) :-
+    throw(error(cert_json_error(unknown_verdict(Other)), _)).
+
+json_to_proof(ProofDict, Proof) :-
+    get_dict(kind, ProofDict, Kind),
+    json_to_proof_(Kind, ProofDict, Proof).
+json_to_proof_(Kind, _, _) :-
+    var(Kind),
+    throw(error(cert_json_error(missing_proof_kind), _)).
+json_to_proof_("declared", _, declared).
+json_to_proof_("analyzed", Dict, analyzed(Strategy)) :-
+    (   get_dict(strategy, Dict, StratStr)
+    ->  term_to_atom(Strategy, StratStr)
+    ;   Strategy = unknown
+    ).
+json_to_proof_("certified", Dict, certified(Source)) :-
+    (   get_dict(source, Dict, SrcStr)
+    ->  term_to_atom(Source, SrcStr)
+    ;   Source = unknown
+    ).
+json_to_proof_("inferred", _, inferred).
+json_to_proof_(Other, _, _) :-
+    \+ var(Other),
+    Other \= "declared", Other \= "analyzed",
+    Other \= "certified", Other \= "inferred",
+    throw(error(cert_json_error(unknown_proof_kind(Other)), _)).
+
+json_to_reasons(Json, Reasons) :-
+    (   get_dict(reasons, Json, RList), is_list(RList)
+    ->  maplist(string_to_reason, RList, Reasons)
+    ;   Reasons = []
+    ).
+
+string_to_reason(S, R) :-
+    (   atom_string(A, S), catch(term_to_atom(R, A), _, fail) -> true
+    ;   atom_string(R, S)
+    ).
+
 :- register_purity_producer(
        purity_producer(kernel_registry,
                        purity_certificate:kernel_analyzer,

--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -49,6 +49,7 @@
 :- use_module('csharp_runtime/custom_csharp', []).
 
 :- use_module('../core/semantic_compiler').
+:- use_module('../core/purity_certificate', [analyze_goal_purity/2]).
 
 %% semantic_compiler:semantic_dispatch(+Target, +Goal, +ProviderInfo, +VarMap, -Code)
 %  Target-specific implementation for semantic search.
@@ -2354,6 +2355,24 @@ order_free_join_role(Role) :-
     ;   Role = mutual(_, _)
     ).
 
+%% order_free_join_item(+Term, +Role) is semidet.
+%  Extends order_free_join_role/1 with purity-certificate oracle:
+%  a goal that is certified pure (confidence >= 0.85) can be freely
+%  reordered, even if its role is not a standard order-free role.
+%  Pure goals are side-effect-free, so evaluation order is
+%  semantically irrelevant — the optimizer can reorder them for
+%  better join plans (e.g., pushing selective filters earlier).
+order_free_join_item(_Term, Role) :-
+    order_free_join_role(Role), !.
+order_free_join_item(Term, _Role) :-
+    nonvar(Term),
+    catch(
+        analyze_goal_purity(Term, purity_cert(pure, _, Conf, _)),
+        _,
+        fail
+    ),
+    Conf >= 0.85.
+
 reorder_order_free_joins(BoundVars, Terms, Roles, OrderedTerms, OrderedRoles) :-
     terms_roles_pairs(Terms, Roles, Pairs),
     reorder_order_free_pairs(BoundVars, Pairs, OrderedPairs),
@@ -2373,7 +2392,7 @@ reorder_order_free_pairs(BoundVars0, Pairs, OrderedPairs) :-
 
 reorder_order_free_pairs_([], _BoundVars, Acc, Acc).
 reorder_order_free_pairs_([term_role(Term, Role)|Rest], BoundVars, Acc, Ordered) :-
-    (   order_free_join_role(Role)
+    (   order_free_join_item(Term, Role)
     ->  take_order_free_run([term_role(Term, Role)|Rest], Run, Remaining),
         reorder_order_free_run(Run, BoundVars, OrderedRun),
         run_vars(Run, RunVars),
@@ -2388,7 +2407,7 @@ reorder_order_free_pairs_([term_role(Term, Role)|Rest], BoundVars, Acc, Ordered)
 
 take_order_free_run([], [], []) :- !.
 take_order_free_run([term_role(Term, Role)|Rest], [term_role(Term, Role)|Run], Remaining) :-
-    order_free_join_role(Role),
+    order_free_join_item(Term, Role),
     !,
     take_order_free_run(Rest, Run, Remaining).
 take_order_free_run(Rest, [], Rest).

--- a/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
@@ -291,7 +291,7 @@ emit_one(deallocate, PC, SV, SVout, I, _FP) :-
 emit_one(get_variable(XnStr, AiStr), _, SV, SVout, I, _FP) :-
     reg_to_int(XnStr, Xn), reg_to_int(AiStr, Ai),
     fresh_sv(SV, SVout),
-    format("~wlet ~w = ~w { wsRegs = IM.insert ~w (derefVar (wsBindings ~w) (fromMaybe (Atom \"\") (IM.lookup ~w (wsRegs ~w)))) (wsRegs ~w) }~n",
+    format("~wlet ~w = ~w { wsRegs = IM.insert ~w (derefVar (wsBindings ~w) (fromMaybe (Atom atomEmpty) (IM.lookup ~w (wsRegs ~w)))) (wsRegs ~w) }~n",
            [I, SVout, SV, Xn, SV, Ai, SV, SV]).
 
 % GetConstant C Ai — can fail, use step
@@ -312,7 +312,7 @@ emit_one(get_value(XnStr, AiStr), PC, SV, SVout, I, _FP) :-
 emit_one(put_value(XnStr, AiStr), _, SV, SVout, I, _FP) :-
     reg_to_int(XnStr, Xn), reg_to_int(AiStr, Ai),
     fresh_sv(SV, SVout),
-    format("~wlet ~w = ~w { wsRegs = IM.insert ~w (fromMaybe (Atom \"\") (getReg ~w ~w)) (wsRegs ~w) }~n",
+    format("~wlet ~w = ~w { wsRegs = IM.insert ~w (fromMaybe (Atom atomEmpty) (getReg ~w ~w)) (wsRegs ~w) }~n",
            [I, SVout, SV, Ai, Xn, SV, SV]).
 
 % PutVariable Xn Ai — always succeeds, inline (creates fresh Unbound)
@@ -334,9 +334,10 @@ emit_one(put_constant(CStr, AiStr), _, SV, SVout, I, _FP) :-
 emit_one(put_structure(FnStr, AiStr), PC, SV, SVout, I, _FP) :-
     reg_to_int(AiStr, Ai),
     parse_functor(FnStr, FuncName, Arity),
+    wam_haskell_target:intern_atom(FuncName, FnId),
     fresh_sv(SV, SVout),
-    format("~w~w <- step ctx (~w { wsPC = ~w }) (PutStructure \"~w\" ~w ~w)~n",
-           [I, SVout, SV, PC, FuncName, Ai, Arity]).
+    format("~w~w <- step ctx (~w { wsPC = ~w }) (PutStructure ~w ~w ~w)~n",
+           [I, SVout, SV, PC, FnId, Ai, Arity]).
 
 emit_one(put_list(AiStr), PC, SV, SVout, I, _FP) :-
     reg_to_int(AiStr, Ai),
@@ -433,11 +434,13 @@ fresh_sv(Cur, Next) :-
     ).
 
 val_hs(Str, Hs) :-
-    (   number_string(N, Str), integer(N)
+    atom_string(Str, StrS),
+    (   number_string(N, StrS), integer(N)
     ->  format(atom(Hs), 'Integer ~w', [N])
-    ;   number_string(F, Str), float(F)
+    ;   number_string(F, StrS), float(F)
     ->  format(atom(Hs), 'Float ~w', [F])
-    ;   format(atom(Hs), 'Atom "~w"', [Str])
+    ;   wam_haskell_target:intern_atom(Str, AtomId),
+        format(atom(Hs), 'Atom ~w', [AtomId])
     ).
 
 reg_to_int(Reg, Int) :-

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2253,7 +2253,13 @@ generate_main_hs(_Predicates, DetectedKernels, Options, Code) :-
     read_kernel_template('main.hs.mustache', Template),
     detected_kernel_keys(DetectedKernels, Keys),
     format_foreign_preds(Keys, ForeignPredsStr),
-    generate_query_body(Options, QueryBody),
+    % When kernels are detected, the query body should use executeForeign
+    % dispatch instead of running WAM code (fact code is skipped).
+    (   DetectedKernels \= []
+    ->  QueryOptions = [use_ffi(true)|Options]
+    ;   QueryOptions = Options
+    ),
+    generate_query_body(QueryOptions, QueryBody),
     generate_merged_code_build(DetectedKernels, Options, MergedCodeBuild),
     render_template(Template,
         [ foreign_preds=ForeignPredsStr
@@ -2304,6 +2310,13 @@ generate_query_body(Options, QueryBody) :-
         format(atom(QueryBody),
 'let { wsVarId = 1000000 ; s0 = emptyState { wsPC = fromMaybe 1 $ Map.lookup "~w" mergedLabels, wsRegs = IM.fromList [ (1, Atom cat), (2, Atom root), (3, Unbound wsVarId) ], wsCP = 0 } ; !result = case run ctx s0 of { Just s1 -> case IM.lookup wsVarId (wsBindings s1) of { Just v -> case extractDouble (derefVar (wsBindings s1) v) of { Just ws -> ws ; Nothing -> 0.0 } ; Nothing -> 0.0 } ; Nothing -> 0.0 } } in (cat, result)',
             [QueryPred1])
+    ;   member(use_ffi(true), Options)
+    ->  % FFI path: call executeForeign directly instead of running WAM code.
+        % When the query predicate has an FFI kernel, the WAM code's internal
+        % Call "category_parent/2" would fail (fact code is skipped). Use
+        % collectForeignSolutions which calls the native kernel directly.
+        QueryBody =
+'let { hopsVarId = 1000000 ; s0 = emptyState { wsRegs = IM.fromList [ (1, Atom cat), (2, Atom root), (3, Unbound hopsVarId), (4, VList [Atom cat]) ], wsCP = 0 } ; !solutions = collectForeignSolutions ctx "category_ancestor/4" s0 hopsVarId ; !weightSum = sum [((hops + 1) ** negN) | hops <- solutions] } in (cat, weightSum)'
     ;   % Default: collectSolutions loop for category_ancestor/4
         QueryBody =
 'let { hopsVarId = 1000000 ; s0 = emptyState { wsPC = fromMaybe 1 $ Map.lookup "category_ancestor/4" mergedLabels, wsRegs = IM.fromList [ (1, Atom cat), (2, Atom root), (3, Unbound hopsVarId), (4, VList [Atom cat]) ], wsCP = 0 } ; !solutions = collectSolutions ctx s0 hopsVarId ; !weightSum = sum [((hops + 1) ** negN) | hops <- solutions] } in (cat, weightSum)'

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -1505,6 +1505,19 @@ step !ctx s (PutStructure fn ai arity) =
           , wsBuilder = BuildStruct fn ai arity []
           })
 
+-- PutStructureDyn: like PutStructure but functor name and arity come
+-- from registers at runtime. Used when the term shape is computed
+-- dynamically (e.g., after =../2 or functor/3 with variable args).
+step !ctx s (PutStructureDyn nameReg arityReg targetReg) =
+  let mName = derefVar (wsBindings s) <$> getReg nameReg s
+      mArity = derefVar (wsBindings s) <$> getReg arityReg s
+  in case (mName, mArity) of
+    (Just (Atom fn), Just (Integer arity)) | arity >= 0 ->
+      Just (s { wsPC = wsPC s + 1
+              , wsBuilder = BuildStruct fn targetReg (fromIntegral arity) []
+              })
+    _ -> Nothing  -- name must be an atom, arity a non-negative integer
+
 step !ctx s (PutList ai) =
   Just (s { wsPC = wsPC s + 1
            , wsBuilder = BuildList ai []
@@ -2729,6 +2742,7 @@ data Instruction
   | PutVariable !RegId !RegId
   | PutValue !RegId !RegId
   | PutStructure String !RegId !Int   -- functor, target reg, arity (pre-parsed)
+  | PutStructureDyn !RegId !RegId !RegId  -- nameReg, arityReg, targetReg (runtime-parsed)
   | PutList !RegId
   | SetValue !RegId
   | SetConstant Value
@@ -3046,6 +3060,10 @@ wam_instr_to_haskell(["put_structure", FN, Ai], Hs) :-
     parse_functor_arity(CFN, Arity),
     reg_name_to_int(CAi, AiI),
     format(string(Hs), 'PutStructure "~w" ~w ~w', [CFN, AiI, Arity]).
+wam_instr_to_haskell(["put_structure_dyn", NameReg, ArityReg, TargetReg], Hs) :-
+    clean_comma(NameReg, CN), clean_comma(ArityReg, CA), clean_comma(TargetReg, CT),
+    reg_name_to_int(CN, NI), reg_name_to_int(CA, AI), reg_name_to_int(CT, TI),
+    format(string(Hs), 'PutStructureDyn ~w ~w ~w', [NI, AI, TI]).
 wam_instr_to_haskell(["put_list", Ai], Hs) :-
     clean_comma(Ai, CAi), reg_name_to_int(CAi, AiI),
     format(string(Hs), 'PutList ~w', [AiI]).

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -1276,15 +1276,18 @@ findOuterEndAggregate !ctx !startPC =
           EndAggregate _ -> pc + 1
           _              -> go (pc + 1) hi
 
--- | Phase 4.4: parallel negation check. Run each branch of a Par*
--- chain and return True if ANY branch produces a solution (meaning
--- the negated goal succeeds, so \\+ fails). Uses parMap rdeepseq for
--- the parallel evaluation — same strategy as aggregate fork. True
--- race-to-cancel (async-based) is a future optimization.
+-- | Phase 4.4: parallel negation check with race-to-cancel.
+-- Spawn each branch as an async action; the first to return True
+-- (goal succeeded → negation fails) wins and all others are cancelled.
+-- If all branches return False, negation succeeds. Uses
+-- unsafePerformIO to keep the WAM run loop pure — safe because the
+-- branches are purity-certified and the only IO effect is thread
+-- management.
+-- {-# NOINLINE runNegationParallel #-}
 runNegationParallel :: WamContext -> WamState -> Int -> Int -> Bool
 runNegationParallel !ctx !s !entryPC !elsePC =
     let branchPCs = enumerateParBranches ctx entryPC elsePC
-        branchSucceeds pc =
+        branchAction pc = evaluate $
           let snapshot = s { wsPC = pc + 1  -- skip past the Par* instruction
                            , wsCP = 0
                            , wsCutBar = 0 }
@@ -1292,10 +1295,29 @@ runNegationParallel !ctx !s !entryPC !elsePC =
                Just _  -> True
                Nothing -> False
     in if length branchPCs >= forkMinBranches
-       then or (parMap rdeepseq branchSucceeds branchPCs)
+       then unsafePerformIO (raceToTrue (map branchAction branchPCs))
        else case run ctx (s { wsPC = entryPC, wsCP = 0, wsCutBar = 0 }) of
               Just _  -> True
               Nothing -> False
+
+-- | Run a list of IO Bool actions concurrently. Returns True as soon
+-- as any action returns True, cancelling all others. If every action
+-- returns False, returns False. Uses waitAny to poll completed
+-- asyncs and cancel to clean up.
+raceToTrue :: [IO Bool] -> IO Bool
+raceToTrue [] = return False
+raceToTrue actions = do
+    asyncs <- mapM async actions
+    result <- go asyncs
+    mapM_ cancel asyncs
+    return result
+  where
+    go [] = return False
+    go as = do
+      (completed, val) <- waitAny as
+      if val
+        then return True
+        else go (filter (/= completed) as)
 
 -- | Apply aggregation function to collected values.
 applyAggregation :: String -> [Value] -> Value
@@ -2342,6 +2364,11 @@ import Data.Maybe (fromMaybe)
 -- WamState NFData instance lives in WamTypes.
 import Control.Parallel.Strategies (parMap, rdeepseq)
 import Control.DeepSeq (NFData(..), deepseq)
+-- Phase 4.4: race-to-cancel for parallel negation. async/waitAny
+-- let us cancel remaining branches once one succeeds.
+import Control.Concurrent.Async (async, cancel, waitAny)
+import Control.Exception (evaluate)
+import System.IO.Unsafe (unsafePerformIO)
 import WamTypes
 
 ~w
@@ -2784,9 +2811,10 @@ emptyState = WamState
 %  Options: profiling(true) adds -prof -fprof-auto -rtsopts for GHC profiling.
 generate_cabal_file(Name, UseHM, Options, Code) :-
     % deepseq + parallel for seed-level parMap rdeepseq
+    % async for Phase 4.4 race-to-cancel negation
     (   UseHM == true
-    ->  Deps = "base >= 4.12, containers >= 0.6, array, time >= 1.8, unordered-containers >= 0.2, hashable >= 1.2, deepseq >= 1.4, parallel >= 3.2"
-    ;   Deps = "base >= 4.12, containers >= 0.6, array, time >= 1.8, deepseq >= 1.4, parallel >= 3.2"
+    ->  Deps = "base >= 4.12, containers >= 0.6, array, time >= 1.8, unordered-containers >= 0.2, hashable >= 1.2, deepseq >= 1.4, parallel >= 3.2, async >= 2.2"
+    ;   Deps = "base >= 4.12, containers >= 0.6, array, time >= 1.8, deepseq >= 1.4, parallel >= 3.2, async >= 2.2"
     ),
     % -threaded enables multi-core runtime (+RTS -N to use cores).
     % -rtsopts is needed so +RTS flags are accepted at runtime.

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -1424,8 +1424,10 @@ callIndexedFact2 !ctx pred s =
                          , wsTrail = newTrail, wsTrailLen = wsTrailLen s + 1
                          , wsCPs = newCPs, wsCPsLen = newCPsLen })
             Atom existingId ->
-              if existingId == vId then Just (s { wsPC = retPC })
-              else case filter (== existingId) restIds of
+              let vId2 = internAtomPure tbl v
+                  restIds2 = map (internAtomPure tbl) rest
+              in if existingId == vId2 then Just (s { wsPC = retPC })
+              else case filter (== existingId) restIds2 of
                 (_:_) -> Just (s { wsPC = retPC })
                 [] -> Nothing
             _ -> Nothing

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2158,7 +2158,10 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     % lowered function doesn't handle. Phase 4+ lowered functions only
     % inline clause 1; clause 2+ runs through the interpreter on backtrack.
     compile_predicates_to_haskell(Predicates, Options, PredsCode0),
-    apply_hashmap_rewrite(UseHM, generic, PredsCode0, PredsCode),
+    % Append compile-time atom table to Predicates.hs
+    emit_atom_table_haskell(AtomTableCode),
+    format(string(PredsCode0WithAtoms), "~w~n~n~w", [PredsCode0, AtomTableCode]),
+    apply_hashmap_rewrite(UseHM, generic, PredsCode0WithAtoms, PredsCode),
     directory_file_path(SrcDir, 'Predicates.hs', PredsPath),
     write_hs_file(PredsPath, PredsCode),
 
@@ -2341,11 +2344,11 @@ generate_merged_code_build(DetectedKernels, Options, Code) :-
         mergedLabels = allLabels'
     ;   Code =
 '    let baseLen = length allCode
-        (cpCode, cpLabels) = buildFact2Code "category_parent" categoryParents (baseLen + 1)
+        (cpCode, cpLabels) = buildFact2Code iAtom "category_parent" categoryParents (baseLen + 1)
         cpEnd = baseLen + length cpCode
-        (acCode, acLabels) = buildFact2Code "article_category" articleCategories (cpEnd + 1)
+        (acCode, acLabels) = buildFact2Code iAtom "article_category" articleCategories (cpEnd + 1)
         acEnd = cpEnd + length acCode
-        (rcCode, rcLabels) = buildFact1Code "root_category" roots (acEnd + 1)
+        (rcCode, rcLabels) = buildFact1Code iAtom "root_category" roots (acEnd + 1)
 
         mergedCodeRaw = allCode ++ cpCode ++ acCode ++ rcCode
         mergedLabels = Map.union allLabels
@@ -2361,7 +2364,7 @@ generate_query_body(Options, QueryBody) :-
     ->  % Optimized: call WAM-compiled aggregation predicate per seed.
         format(atom(QueryPred1), '~w', [QueryPred]),
         format(atom(QueryBody),
-'let { wsVarId = 1000000 ; s0 = emptyState { wsPC = fromMaybe 1 $ Map.lookup "~w" mergedLabels, wsRegs = IM.fromList [ (1, Atom cat), (2, Atom root), (3, Unbound wsVarId) ], wsCP = 0 } ; !result = case run ctx s0 of { Just s1 -> case IM.lookup wsVarId (wsBindings s1) of { Just v -> case extractDouble (derefVar (wsBindings s1) v) of { Just ws -> ws ; Nothing -> 0.0 } ; Nothing -> 0.0 } ; Nothing -> 0.0 } } in (cat, result)',
+'let { wsVarId = 1000000 ; s0 = emptyState { wsPC = fromMaybe 1 $ Map.lookup "~w" mergedLabels, wsRegs = IM.fromList [ (1, Atom (iAtom cat)), (2, Atom (iAtom root)), (3, Unbound wsVarId) ], wsCP = 0 } ; !result = case run ctx s0 of { Just s1 -> case IM.lookup wsVarId (wsBindings s1) of { Just v -> case extractDouble fullInternTable (derefVar (wsBindings s1) v) of { Just ws -> ws ; Nothing -> 0.0 } ; Nothing -> 0.0 } ; Nothing -> 0.0 } } in (cat, result)',
             [QueryPred1])
     ;   member(use_ffi(true), Options)
     ->  % FFI path: call executeForeign directly instead of running WAM code.
@@ -2372,7 +2375,7 @@ generate_query_body(Options, QueryBody) :-
 'let { hopsVarId = 1000000 ; s0 = emptyState { wsRegs = IM.fromList [ (1, Atom cat), (2, Atom root), (3, Unbound hopsVarId), (4, VList [Atom cat]) ], wsCP = 0 } ; !solutions = collectForeignSolutions ctx "category_ancestor/4" s0 hopsVarId ; !weightSum = sum [((hops + 1) ** negN) | hops <- solutions] } in (cat, weightSum)'
     ;   % Default: collectSolutions loop for category_ancestor/4
         QueryBody =
-'let { hopsVarId = 1000000 ; s0 = emptyState { wsPC = fromMaybe 1 $ Map.lookup "category_ancestor/4" mergedLabels, wsRegs = IM.fromList [ (1, Atom cat), (2, Atom root), (3, Unbound hopsVarId), (4, VList [Atom cat]) ], wsCP = 0 } ; !solutions = collectSolutions ctx s0 hopsVarId ; !weightSum = sum [((hops + 1) ** negN) | hops <- solutions] } in (cat, weightSum)'
+'let { hopsVarId = 1000000 ; s0 = emptyState { wsPC = fromMaybe 1 $ Map.lookup "category_ancestor/4" mergedLabels, wsRegs = IM.fromList [ (1, Atom (iAtom cat)), (2, Atom (iAtom root)), (3, Unbound hopsVarId), (4, VList [Atom (iAtom cat)]) ], wsCP = 0 } ; !solutions = collectSolutions ctx s0 hopsVarId ; !weightSum = sum [((hops + 1) ** negN) | hops <- solutions] } in (cat, weightSum)'
     ).
 
 %% detected_kernel_keys(+DetectedKernels, -Keys)
@@ -2963,6 +2966,7 @@ compile_predicates_to_haskell(Predicates, Options, Code) :-
 'module Predicates where
 
 import qualified Data.Map.Strict as Map
+import qualified Data.IntMap.Strict as IM
 import WamTypes
 
 -- | Merged WAM code for all predicates.
@@ -3236,14 +3240,15 @@ parse_functor_arity(FN, Arity) :-
 %% wam_value_to_haskell(+WamVal, -HaskellExpr)
 %  Converts a WAM constant to a Haskell Value constructor.
 wam_value_to_haskell(Val, Hs) :-
-    (   number_string(N, Val), integer(N)
+    atom_string(Val, ValStr),
+    (   number_string(N, ValStr), integer(N)
     ->  % Wrap negative integers in parens so Haskell parses correctly:
         % Integer (-5) not Integer -5
         (   N < 0
         ->  format(string(Hs), 'Integer (~w)', [N])
         ;   format(string(Hs), 'Integer ~w', [N])
         )
-    ;   number_string(F, Val), float(F)
+    ;   number_string(F, ValStr), float(F)
     ->  (   F < 0
         ->  format(string(Hs), 'Float (~w)', [F])
         ;   format(string(Hs), 'Float ~w', [F])

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -52,6 +52,53 @@
 :- reexport('wam_haskell_lowered_emitter',
             [wam_haskell_lowerable/3, lower_predicate_to_haskell/4]).
 
+% ============================================================================
+% ATOM INTERNING TABLE (compile-time)
+% ============================================================================
+% Built during WAM → Haskell compilation. Maps atom strings to integer IDs.
+% Well-known atoms are pre-assigned: true=0, fail=1, []=2, .=3, ""=4.
+
+:- dynamic atom_intern_id/2.    % atom_intern_id(String, IntId)
+:- dynamic atom_intern_next/1.  % atom_intern_next(NextId)
+
+init_atom_intern_table :-
+    retractall(atom_intern_id(_, _)),
+    retractall(atom_intern_next(_)),
+    % Reserve well-known atoms
+    assertz(atom_intern_id("true", 0)),
+    assertz(atom_intern_id("fail", 1)),
+    assertz(atom_intern_id("[]", 2)),
+    assertz(atom_intern_id(".", 3)),
+    assertz(atom_intern_id("", 4)),
+    assertz(atom_intern_next(5)).
+
+%% intern_atom(+AtomStr, -Id) is det.
+%  Assigns a stable integer ID to the given atom string. Idempotent.
+intern_atom(AtomStr, Id) :-
+    atom_string(AtomStr, Str),
+    (   atom_intern_id(Str, Id0)
+    ->  Id = Id0
+    ;   retract(atom_intern_next(Next)),
+        Id = Next,
+        Next1 is Next + 1,
+        assertz(atom_intern_id(Str, Id)),
+        assertz(atom_intern_next(Next1))
+    ).
+
+%% emit_atom_table_haskell(-Code) is det.
+%  Emits the compile-time atom table as Haskell code.
+emit_atom_table_haskell(Code) :-
+    findall(Id-Str, atom_intern_id(Str, Id), Pairs),
+    sort(Pairs, Sorted),
+    maplist([Id-Str, Entry]>>(
+        format(string(Entry), '(~w, "~w")', [Id, Str])
+    ), Sorted, Entries),
+    atomic_list_concat(Entries, ', ', EntryStr),
+    length(Sorted, N),
+    format(string(Code),
+        'compileTimeAtomTable :: InternTable\ncompileTimeAtomTable = \n  let pairs = [~w]\n  in InternTable (Map.fromList [(s, i) | (i, s) <- pairs])\n                (IM.fromList pairs)\n                ~w\n',
+        [EntryStr, N]).
+
 %% ============================================================================
 %% emit_mode selector (Phase 1 of WAM-lowered Haskell path)
 %% ============================================================================
@@ -318,7 +365,7 @@ emit_input_let_bindings([input(RegN, Type)|Rest], Pos) :-
 reg_var_name(N, Name) :-
     format(atom(Name), 'r~w', [N]).
 
-reg_default_value(atom, 'Atom ""').
+reg_default_value(atom, 'Atom atomEmpty').
 reg_default_value(integer, 'Integer 0').
 reg_default_value(vlist_atoms, 'VList []').
 
@@ -370,9 +417,9 @@ emit_one_call_arg(derived(length, RegN), InputRegs) :-
 %  atom lists are interned via wcAtomIntern so the kernel operates on
 %  Int IDs instead of Strings (eliminates hashing in the hot loop).
 emit_reg_extraction(VarName, atom) :-
-    format('(fromMaybe (-1) (Map.lookup ~wS (wcAtomIntern ctx)))', [VarName]).
+    format('(fromMaybe (-1) (Map.lookup ~wS (itForward (wcInternTable ctx))))', [VarName]).
 emit_reg_extraction(VarName, vlist_atoms) :-
-    format('[fromMaybe (-1) (Map.lookup v (wcAtomIntern ctx)) | Atom v <- ~wL]', [VarName]).
+    format('[fromMaybe (-1) (Map.lookup v (itForward (wcInternTable ctx))) | Atom v <- ~wL]', [VarName]).
 emit_reg_extraction(VarName, integer) :-
     format('~wI', [VarName]).
 
@@ -637,7 +684,7 @@ emit_multi_wrap_list([output(_, Type)|Rest], I) :-
 result_wrap_expr_for_rv(integer, I, Expr) :-
     format(atom(Expr), 'Integer (fromIntegral rv_~w)', [I]).
 result_wrap_expr_for_rv(atom, I, Expr) :-
-    format(atom(Expr), 'Atom (fromMaybe "" (IM.lookup rv_~w (wcAtomDeintern ctx)))', [I]).
+    format(atom(Expr), 'Atom rv_~w', [I]).
 result_wrap_expr_for_rv(float, I, Expr) :-
     format(atom(Expr), 'Float rv_~w', [I]).
 
@@ -647,7 +694,7 @@ result_wrap_expr_for_rv(float, I, Expr) :-
 %  be de-interned back to Strings before wrapping in the Atom constructor.
 %  For `integer` and `float`, no interning is involved.
 result_wrap_expr(integer, 'Integer (fromIntegral rv)').
-result_wrap_expr(atom, 'Atom (fromMaybe "" (IM.lookup rv (wcAtomDeintern ctx)))').
+result_wrap_expr(atom, 'Atom rv').
 result_wrap_expr(float, 'Float rv').
 
 %% detect_kernels(+Predicates, -DetectedKernels)
@@ -851,7 +898,7 @@ wam_to_haskell(builtin_call('!/0', 0), Code) :-
 
 wam_to_haskell(builtin_call('is/2', 2), Code) :-
     Code = '  let expr = derefVar (wsBindings s) $ fromMaybe (Integer 0) (Map.lookup "A2" (wsRegs s))
-      result = evalArith (wsBindings s) expr
+      result = evalArith (wcInternTable ctx) (wsBindings s) expr
       lhs = derefVar (wsBindings s) <$> Map.lookup "A1" (wsRegs s)
   in case (lhs, result) of
     (Just (Unbound var), Just r) ->
@@ -882,8 +929,8 @@ wam_to_haskell(builtin_call('length/2', 2), Code) :-
        _ -> Nothing'.
 
 wam_to_haskell(builtin_call('</2', 2), Code) :-
-    Code = '  let v1 = evalArith (wsBindings s) =<< (derefVar (wsBindings s) <$> Map.lookup "A1" (wsRegs s))
-      v2 = evalArith (wsBindings s) =<< (derefVar (wsBindings s) <$> Map.lookup "A2" (wsRegs s))
+    Code = '  let v1 = evalArith (wcInternTable ctx) (wsBindings s) =<< (derefVar (wsBindings s) <$> Map.lookup "A1" (wsRegs s))
+      v2 = evalArith (wcInternTable ctx) (wsBindings s) =<< (derefVar (wsBindings s) <$> Map.lookup "A2" (wsRegs s))
   in case (v1, v2) of
     (Just a, Just b) | a < b -> Just (s { wsPC = wsPC s + 1 })
     _ -> Nothing'.
@@ -942,9 +989,9 @@ backtrack s = case wsCPs s of
 resumeBuiltin :: BuiltinState -> ChoicePoint -> [ChoicePoint] -> WamState -> Maybe WamState
 resumeBuiltin (FactRetry _ [] _) _ rest s =
   backtrack (s { wsCPs = rest, wsCPsLen = wsCPsLen s - 1 })
-resumeBuiltin (FactRetry vid (v:vs) retPC) cp rest s =
-  let newBindings = IM.insert vid (Atom v) (cpBindings cp)
-      newRegs = IM.insert 2 (Atom v) (cpRegs cp)
+resumeBuiltin (FactRetry vid (vId:vs) retPC) cp rest s =
+  let newBindings = IM.insert vid (Atom vId) (cpBindings cp)
+      newRegs = IM.insert 2 (Atom vId) (cpRegs cp)
       newCPs = case vs of
         [] -> rest
         _  -> cp { cpBuiltin = Just (FactRetry vid vs retPC) } : rest
@@ -1351,31 +1398,34 @@ callIndexedFact2 !ctx pred s =
   in case Map.lookup basePred (wcForeignFacts ctx) of
     Nothing -> Nothing
     Just factIndex ->
-      let a1 = derefVar (wsBindings s) $ fromMaybe (Atom "") (IM.lookup 1 (wsRegs s))
+      let tbl = wcInternTable ctx
+          a1 = derefVar (wsBindings s) $ fromMaybe (Atom atomEmpty) (IM.lookup 1 (wsRegs s))
           a2 = derefVar (wsBindings s) $ fromMaybe (Unbound (-1)) (IM.lookup 2 (wsRegs s))
       in case a1 of
-        Atom key -> case Map.lookup key factIndex of
+        Atom aid -> case Map.lookup (lookupAtom tbl aid) factIndex of
           Just (v:rest) -> case a2 of
             Unbound vid ->
-              let newRegs = IM.insert 2 (Atom v) (wsRegs s)
-                  newBindings = IM.insert vid (Atom v) (wsBindings s)
+              let vId = internAtomPure tbl v
+                  newRegs = IM.insert 2 (Atom vId) (wsRegs s)
+                  newBindings = IM.insert vid (Atom vId) (wsBindings s)
                   newTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
-                  newCPs = case rest of
+                  restIds = map (internAtomPure tbl) rest
+                  newCPs = case restIds of
                     [] -> wsCPs s  -- single match, no CP
                     _  -> ChoicePoint
                             { cpNextPC = retPC, cpRegs = wsRegs s, cpStack = wsStack s
                             , cpCP = wsCP s, cpTrailLen = wsTrailLen s
                             , cpHeapLen = wsHeapLen s, cpBindings = wsBindings s
                             , cpCutBar = wsCutBar s, cpAggFrame = Nothing
-                            , cpBuiltin = Just (FactRetry vid rest retPC)
+                            , cpBuiltin = Just (FactRetry vid restIds retPC)
                             } : wsCPs s
-                  newCPsLen = case rest of { [] -> wsCPsLen s; _ -> wsCPsLen s + 1 }
+                  newCPsLen = case restIds of { [] -> wsCPsLen s; _ -> wsCPsLen s + 1 }
               in Just (s { wsPC = retPC, wsRegs = newRegs, wsBindings = newBindings
                          , wsTrail = newTrail, wsTrailLen = wsTrailLen s + 1
                          , wsCPs = newCPs, wsCPsLen = newCPsLen })
-            Atom existing ->
-              if existing == v then Just (s { wsPC = retPC })
-              else case filter (== existing) rest of
+            Atom existingId ->
+              if existingId == vId then Just (s { wsPC = retPC })
+              else case filter (== existingId) restIds of
                 (_:_) -> Just (s { wsPC = retPC })
                 [] -> Nothing
             _ -> Nothing
@@ -1500,9 +1550,9 @@ step !ctx s (PutValue xn ai) =
     Just val -> Just (s { wsPC = wsPC s + 1, wsRegs = IM.insert ai val (wsRegs s) })
     Nothing -> Nothing
 
-step !ctx s (PutStructure fn ai arity) =
+step !ctx s (PutStructure fnId ai arity) =
   Just (s { wsPC = wsPC s + 1
-          , wsBuilder = BuildStruct fn ai arity []
+          , wsBuilder = BuildStruct fnId ai arity []
           })
 
 -- PutStructureDyn: like PutStructure but functor name and arity come
@@ -1512,9 +1562,9 @@ step !ctx s (PutStructureDyn nameReg arityReg targetReg) =
   let mName = derefVar (wsBindings s) <$> getReg nameReg s
       mArity = derefVar (wsBindings s) <$> getReg arityReg s
   in case (mName, mArity) of
-    (Just (Atom fn), Just (Integer arity)) | arity >= 0 ->
+    (Just (Atom fnId), Just (Integer arity)) | arity >= 0 ->
       Just (s { wsPC = wsPC s + 1
-              , wsBuilder = BuildStruct fn targetReg (fromIntegral arity) []
+              , wsBuilder = BuildStruct fnId targetReg (fromIntegral arity) []
               })
     _ -> Nothing  -- name must be an atom, arity a non-negative integer
 
@@ -1670,10 +1720,10 @@ step !ctx s (SwitchOnConstantPc table) =
   let val = derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s)
   in case val of
     Just (Unbound _) -> Just (s { wsPC = wsPC s + 1 })
-    Just (Atom key) -> case Map.lookup key table of
+    Just (Atom aid) -> case IM.lookup aid table of
       Just pc -> Just (s { wsPC = pc })
       Nothing -> Nothing
-    Just (Integer n) -> case Map.lookup (show n) table of
+    Just (Integer n) -> case IM.lookup n table of
       Just pc -> Just (s { wsPC = pc })
       Nothing -> Nothing
     _ -> Nothing
@@ -1721,7 +1771,7 @@ step !ctx s (BuiltinCall "number/1" _) =
 
 step !ctx s (BuiltinCall "is/2" _) =
   let expr = derefVar (wsBindings s) $ fromMaybe (Integer 0) (IM.lookup 2 (wsRegs s))
-      result = evalArith (wsBindings s) expr
+      result = evalArith (wcInternTable ctx) (wsBindings s) expr
       lhs = derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s)
   in case (lhs, result) of
     (Just (Unbound vid), Just r) ->
@@ -1755,17 +1805,18 @@ step !ctx s (BuiltinCall "length/2" _) =
     _ -> Nothing
 
 step !ctx s (BuiltinCall "</2" _) =
-  let v1 = evalArith (wsBindings s) =<< (derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s))
-      v2 = evalArith (wsBindings s) =<< (derefVar (wsBindings s) <$> IM.lookup 2 (wsRegs s))
+  let v1 = evalArith (wcInternTable ctx) (wsBindings s) =<< (derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s))
+      v2 = evalArith (wcInternTable ctx) (wsBindings s) =<< (derefVar (wsBindings s) <$> IM.lookup 2 (wsRegs s))
   in case (v1, v2) of
     (Just a, Just b) | a < b -> Just (s { wsPC = wsPC s + 1 })
     _ -> Nothing
 
 step !ctx s (BuiltinCall "\\\\+/1" _) =
   let goal = IM.lookup 1 (wsRegs s) >>= derefHeap (wsHeap s)
+      tbl = wcInternTable ctx
   in case goal of
-    -- Fast path: \\+ member(X, L)
-    Just (Str fn [needle, haystack]) | "member" `isPrefixOf` fn ->
+    -- Fast path: \\+ member(X, L) — check functor name via reverse lookup
+    Just (Str fnId [needle, haystack]) | "member" `isPrefixOf` lookupAtom tbl fnId ->
       let n = derefVar (wsBindings s) needle
           h = derefVar (wsBindings s) haystack
           found = case h of
@@ -1773,13 +1824,13 @@ step !ctx s (BuiltinCall "\\\\+/1" _) =
             _ -> False
       in if found then Nothing else Just (s { wsPC = wsPC s + 1 })
     -- Fast path: \\+ true always fails, \\+ fail always succeeds
-    Just (Atom "true") -> Nothing
-    Just (Atom "fail") -> Just (s { wsPC = wsPC s + 1 })
+    Just (Atom aid) | aid == atomTrue -> Nothing
+    Just (Atom aid) | aid == atomFail -> Just (s { wsPC = wsPC s + 1 })
     -- General path: resolve the goal, snapshot-and-run.
     -- Phase 4.4: if the goal''s entry instruction is ParTryMeElse,
     -- fork branches in parallel via runNegationParallel.
-    Just (Str fn args) ->
-      let goalKey = fn ++ "/" ++ show (length args)
+    Just (Str fnId args) ->
+      let goalKey = lookupAtom tbl fnId ++ "/" ++ show (length args)
           dArgs = map (derefVar (wsBindings s)) args
       in case Map.lookup goalKey (wcLabels ctx) of
            Just pc ->
@@ -1804,8 +1855,8 @@ step !ctx s (BuiltinCall "\\\\+/1" _) =
                 else Just (s { wsPC = wsPC s + 1 })
            Nothing -> Just (s { wsPC = wsPC s + 1 })  -- unknown pred; treat as failing goal
     -- Atom as 0-arity goal (e.g. \\+ some_pred)
-    Just (Atom fn) ->
-      let goalKey = fn ++ "/0"
+    Just (Atom fnId) ->
+      let goalKey = lookupAtom tbl fnId ++ "/0"
       in case Map.lookup goalKey (wcLabels ctx) of
            Just pc ->
              let snapshot = s { wsPC = pc
@@ -1831,8 +1882,8 @@ step !ctx s (SwitchOnConstant table) =
     Nothing -> Nothing
 
 step !ctx s (BuiltinCall ">/2" _) =
-  let v1 = evalArith (wsBindings s) =<< (derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s))
-      v2 = evalArith (wsBindings s) =<< (derefVar (wsBindings s) <$> IM.lookup 2 (wsRegs s))
+  let v1 = evalArith (wcInternTable ctx) (wsBindings s) =<< (derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s))
+      v2 = evalArith (wcInternTable ctx) (wsBindings s) =<< (derefVar (wsBindings s) <$> IM.lookup 2 (wsRegs s))
   in case (v1, v2) of
     (Just a, Just b) | a > b -> Just (s { wsPC = wsPC s + 1 })
     _ -> Nothing
@@ -1910,9 +1961,9 @@ step !_ctx s (BuiltinCall "functor/3" _) =
     Just tVal ->
       -- Read mode: extract functor name and arity.
       let mInfo = case tVal of
-            Str fn args -> Just (Atom fn, length args)
-            VList [] -> Just (Atom "[]", 0)
-            VList _ -> Just (Atom ".", 2)
+            Str fnId args -> Just (Atom fnId, length args)
+            VList [] -> Just (Atom atomNil, 0)
+            VList _ -> Just (Atom atomDot, 2)
             Atom _ -> Just (tVal, 0)
             Integer _ -> Just (tVal, 0)
             Float _ -> Just (tVal, 0)
@@ -1974,12 +2025,12 @@ step !_ctx s (BuiltinCall "=../2" _) =
     Just tVal ->
       -- Decompose mode: build list from T.
       let mList = case tVal of
-            Str fn args -> Just (VList (Atom fn : args))
+            Str fnId args -> Just (VList (Atom fnId : args))
             Atom _ -> Just (VList [tVal])
             Integer _ -> Just (VList [tVal])
             Float _ -> Just (VList [tVal])
-            VList [] -> Just (VList [Atom "[]"])
-            VList (x : xs) -> Just (VList [Atom ".", x, VList xs])
+            VList [] -> Just (VList [Atom atomNil])
+            VList (x : xs) -> Just (VList [Atom atomDot, x, VList xs])
             _ -> Nothing
       in case mList of
         Nothing -> Nothing
@@ -2054,6 +2105,8 @@ callForeign !ctx pred !sc = executeForeign ctx pred sc'.
 %  - Predicates.hs: compiled predicates
 %  - Main.hs: benchmark driver
 write_wam_haskell_project(Predicates, Options, ProjectDir) :-
+    % Initialize the compile-time atom intern table with well-known atoms
+    init_atom_intern_table,
     make_directory_path(ProjectDir),
     directory_file_path(ProjectDir, 'src', SrcDir),
     make_directory_path(SrcDir),
@@ -2412,24 +2465,25 @@ derefVar bindings (Unbound vid) =
     Nothing  -> Unbound vid
 derefVar _ v = v
 
--- | Evaluate arithmetic expression.
-evalArith :: IM.IntMap Value -> Value -> Maybe Double
-evalArith _ (Integer n) = Just (fromIntegral n)
-evalArith _ (Float f) = Just f
-evalArith bindings (Atom s) = case reads s of
+-- | Evaluate arithmetic expression. InternTable needed for reverse
+-- lookup of atom strings (numeric atom parsing, operator names).
+evalArith :: InternTable -> IM.IntMap Value -> Value -> Maybe Double
+evalArith _ _ (Integer n) = Just (fromIntegral n)
+evalArith _ _ (Float f) = Just f
+evalArith tbl _ (Atom aid) = case reads (lookupAtom tbl aid) of
   [(n, "")] -> Just n
   _ -> Nothing
-evalArith bindings (Str op [a]) = do
-  va <- evalArith bindings (derefVar bindings a)
-  let bareOp = takeWhile (/= ''/'') op
+evalArith tbl bindings (Str opId [a]) = do
+  va <- evalArith tbl bindings (derefVar bindings a)
+  let bareOp = takeWhile (/= ''/'') (lookupAtom tbl opId)
   case bareOp of
     "-" -> Just (negate va)
     "abs" -> Just (abs va)
     _ -> Nothing
-evalArith bindings (Str op [a, b]) = do
-  va <- evalArith bindings (derefVar bindings a)
-  vb <- evalArith bindings (derefVar bindings b)
-  let bareOp = takeWhile (/= ''/'') op
+evalArith tbl bindings (Str opId [a, b]) = do
+  va <- evalArith tbl bindings (derefVar bindings a)
+  vb <- evalArith tbl bindings (derefVar bindings b)
+  let bareOp = takeWhile (/= ''/'') (lookupAtom tbl opId)
   case bareOp of
     "+" -> Just (va + vb)
     "-" -> Just (va - vb)
@@ -2440,7 +2494,7 @@ evalArith bindings (Str op [a, b]) = do
     "//" -> if vb /= 0 then Just (fromIntegral (truncate va `div` truncate vb :: Int)) else Nothing
     "mod" -> if vb /= 0 then Just (fromIntegral (truncate va `mod` truncate vb :: Int)) else Nothing
     _ -> Nothing
-evalArith _ _ = Nothing
+evalArith _ _ _ = Nothing
 
 -- | Get register value. Y-registers (id >= 200) come from the env frame.
 {-# INLINE getReg #-}
@@ -2496,7 +2550,7 @@ addToBuilder val s = case wsBuilder s of
        then let [tl, hd] = args''   -- reversed because we cons-built
                 list = case tl of
                   VList items -> VList (hd : items)
-                  Atom "[]"  -> VList [hd]
+                  Atom aid | aid == atomNil -> VList [hd]
                   _           -> VList [hd, tl]
             in Just (s { wsPC = wsPC s + 1
                        , wsRegs = IM.insert ai list (wsRegs s)
@@ -2560,11 +2614,11 @@ resolveCallInstrs labels foreignPreds = map resolve
       Just pc -> ParRetryMeElsePc pc
       Nothing -> ParRetryMeElse label
     resolve (SwitchOnConstant table) =
-      let extractKey (Atom s) = s
-          extractKey (Integer n) = show n
-          extractKey v = show v
-      in SwitchOnConstantPc (Map.fromList [(extractKey v, pc) | (v, label) <- Map.toList table,
-                                                                 Just pc <- [Map.lookup label labels]])
+      let extractId (Atom aid) = aid
+          extractId (Integer n) = n  -- integers use their value directly as key
+          extractId _ = (-1)
+      in SwitchOnConstantPc (IM.fromList [(extractId v, pc) | (v, label) <- Map.toList table,
+                                                               Just pc <- [Map.lookup label labels]])
     resolve i = i
 ', [StepCode, BacktrackCode, RunCode]).
 
@@ -2579,14 +2633,54 @@ import Data.Array (Array, listArray, (!), bounds)
 -- each forked branch''s contribution before the merge step.
 import Control.DeepSeq (NFData(..))
 
-data Value = Atom String
+-- | Core value type. Atoms and Str functor names are interned as Ints
+-- for O(1) equality. Use lookupAtom/internAtom via the InternTable in
+-- WamContext for String conversion.
+data Value = Atom !Int          -- interned atom ID
            | Integer !Int
            | Float !Double
            | VList [Value]
-           | Str String [Value]
-           | Unbound !Int   -- variable ID (interned via wsVarCounter)
+           | Str !Int [Value]   -- interned functor name, args
+           | Unbound !Int       -- variable ID (interned via wsVarCounter)
            | Ref Int
            deriving (Eq, Ord, Show)
+
+-- | Atom intern table. Built at compile time, extended at load time
+-- with runtime atoms (e.g., from TSV fact data). Read-only after
+-- construction — safe for parallelism (shared via WamContext).
+data InternTable = InternTable
+  { itForward :: !(Map.Map String Int)   -- String -> atom ID
+  , itReverse :: !(IM.IntMap String)     -- atom ID -> String
+  , itSize    :: !Int                    -- next available ID
+  } deriving (Show)
+
+emptyInternTable :: InternTable
+emptyInternTable = InternTable Map.empty IM.empty 0
+
+internAtom :: InternTable -> String -> (Int, InternTable)
+internAtom tbl s = case Map.lookup s (itForward tbl) of
+  Just aid -> (aid, tbl)
+  Nothing  -> let aid = itSize tbl
+              in (aid, tbl { itForward = Map.insert s aid (itForward tbl)
+                           , itReverse = IM.insert aid s (itReverse tbl)
+                           , itSize = aid + 1 })
+
+internAtomPure :: InternTable -> String -> Int
+internAtomPure tbl s = case Map.lookup s (itForward tbl) of
+  Just aid -> aid
+  Nothing  -> (-1)  -- should not happen for well-formed programs
+
+lookupAtom :: InternTable -> Int -> String
+lookupAtom tbl aid = IM.findWithDefault ("?atom_" ++ show aid) aid (itReverse tbl)
+
+-- | Well-known atom IDs. Reserved during compile-time atom collection.
+-- These MUST match the IDs assigned by the Prolog codegen.
+atomTrue, atomFail, atomNil, atomDot, atomEmpty :: Int
+atomTrue  = 0
+atomFail  = 1
+atomNil   = 2   -- "[]"
+atomDot   = 3   -- "."
+atomEmpty = 4   -- ""
 
 data EnvFrame = EnvFrame {-# UNPACK #-} !Int !(IM.IntMap Value)
               deriving (Show)
@@ -2609,7 +2703,7 @@ data ChoicePoint = ChoicePoint
 
 -- | Builtin state for choice points that need custom retry logic.
 data BuiltinState
-  = FactRetry !Int ![String] !Int  -- variable ID, remaining values, returnPC
+  = FactRetry !Int ![Int] !Int     -- variable ID, remaining interned atom IDs, returnPC
   | HopsRetry !Int ![Int] !Int     -- variable ID, remaining Hops values, returnPC
     -- Multi-output FFI kernel retry. Each remaining tuple is already
     -- wrapped as a list of Values (pre-interned / wrapped at call site).
@@ -2673,17 +2767,17 @@ inferMergeStrategy _       = MergeSequential
 -- aggregate values). Everything is first-order / strict already;
 -- these definitions just walk the structure to force evaluation.
 instance NFData Value where
-  rnf (Atom s)         = rnf s
+  rnf (Atom n)         = rnf n
   rnf (Integer n)      = rnf n
   rnf (Float f)        = rnf f
   rnf (VList xs)       = rnf xs
-  rnf (Str name args)  = rnf name `seq` rnf args
+  rnf (Str n args)     = rnf n `seq` rnf args
   rnf (Unbound n)      = rnf n
   rnf (Ref n)          = rnf n
 
 -- | Builder for PutStructure/PutList + SetValue/SetConstant sequences.
-data Builder = BuildStruct !String !Int !Int ![Value]  -- functor, target reg ID, arity, collected args
-             | BuildList !Int ![Value]                  -- target reg ID, collected [head, tail]
+data Builder = BuildStruct !Int !Int !Int ![Value]  -- interned functor ID, target reg ID, arity, collected args
+             | BuildList !Int ![Value]               -- target reg ID, collected [head, tail]
              | NoBuilder
              deriving (Show)
 
@@ -2696,17 +2790,12 @@ data WamContext = WamContext
   , wcForeignFacts  :: !(Map.Map String (Map.Map String [String]))
   , wcForeignConfig :: !(Map.Map String Int)
   , wcLoweredPredicates :: !(Map.Map String (WamContext -> WamState -> Maybe WamState))
-  -- | Atom interning table for the FFI boundary. Populated at startup
-  -- with String -> Int IDs. Used by executeForeign to convert WAM-side
-  -- String atoms to Int keys before calling native kernels.
-  , wcAtomIntern    :: !(Map.Map String Int)
-  -- | Reverse intern table (Int -> String) for de-interning kernel
-  -- results that return Ints but need to be wrapped as Atom String.
-  , wcAtomDeintern  :: !(IM.IntMap String)
+  -- | System-wide atom intern table. Built at compile time, extended
+  -- at load time with runtime atoms. Used for Value → String display,
+  -- evalArith reverse lookup, and FFI boundary interning.
+  , wcInternTable   :: !InternTable
   -- | Fact indexes keyed by interned Int atoms. Used exclusively by the
   -- FFI kernel path. Populated per-kernel from edge_pred config.
-  -- Separate from wcForeignFacts so callIndexedFact2 (WAM path) is
-  -- unaffected.
   , wcFfiFacts      :: !(Map.Map String (IM.IntMap [Int]))
   -- | Weighted fact indexes for kernels that need (target, weight)
   -- pairs per edge (e.g., weighted_shortest_path3 / Dijkstra). Used
@@ -2754,7 +2843,7 @@ data Instruction
   | PutConstant Value !RegId
   | PutVariable !RegId !RegId
   | PutValue !RegId !RegId
-  | PutStructure String !RegId !Int   -- functor, target reg, arity (pre-parsed)
+  | PutStructure !Int !RegId !Int     -- interned functor ID, target reg, arity
   | PutStructureDyn !RegId !RegId !RegId  -- nameReg, arityReg, targetReg (runtime-parsed)
   | PutList !RegId
   | SetValue !RegId
@@ -2772,7 +2861,7 @@ data Instruction
   | Proceed
   | TryMeElsePc !Int                   -- post-resolution: direct PC for else branch
   | RetryMeElsePc !Int                 -- post-resolution: direct PC for next branch
-  | SwitchOnConstantPc !(Map.Map String Int) -- post-resolution: atom string -> PC
+  | SwitchOnConstantPc !(IM.IntMap Int)      -- post-resolution: interned atom ID -> PC
   | BuiltinCall String !Int
   | TryMeElse String
   | RetryMeElse String
@@ -2806,8 +2895,7 @@ mkContext codeList labels =
     , wcForeignFacts  = Map.empty
     , wcForeignConfig = Map.empty
     , wcLoweredPredicates = Map.empty
-    , wcAtomIntern    = Map.empty
-    , wcAtomDeintern  = IM.empty
+    , wcInternTable   = emptyInternTable
     , wcFfiFacts      = Map.empty
     , wcFfiWeightedFacts = Map.empty
     }
@@ -3072,7 +3160,8 @@ wam_instr_to_haskell(["put_structure", FN, Ai], Hs) :-
     clean_comma(FN, CFN), clean_comma(Ai, CAi),
     parse_functor_arity(CFN, Arity),
     reg_name_to_int(CAi, AiI),
-    format(string(Hs), 'PutStructure "~w" ~w ~w', [CFN, AiI, Arity]).
+    intern_atom(CFN, FnId),
+    format(string(Hs), 'PutStructure ~w ~w ~w', [FnId, AiI, Arity]).
 wam_instr_to_haskell(["put_structure_dyn", NameReg, ArityReg, TargetReg], Hs) :-
     clean_comma(NameReg, CN), clean_comma(ArityReg, CA), clean_comma(TargetReg, CT),
     reg_name_to_int(CN, NI), reg_name_to_int(CA, AI), reg_name_to_int(CT, TI),
@@ -3159,7 +3248,8 @@ wam_value_to_haskell(Val, Hs) :-
         ->  format(string(Hs), 'Float (~w)', [F])
         ;   format(string(Hs), 'Float ~w', [F])
         )
-    ;   format(string(Hs), 'Atom "~w"', [Val])
+    ;   intern_atom(Val, AtomId),
+        format(string(Hs), 'Atom ~w', [AtomId])
     ).
 
 %% clean_comma(+Str, -Clean) — strip trailing comma
@@ -3180,7 +3270,8 @@ parse_switch_entries([Entry|Rest], [HsPair|HsRest]) :-
         sub_atom(CEntry, After, _, 0, Label),
         wam_value_to_haskell(Key, HsKey),
         format(string(HsPair), '(~w, "~w")', [HsKey, Label])
-    ;   format(string(HsPair), '(Atom "~w", "default")', [CEntry])
+    ;   intern_atom(CEntry, DefId),
+        format(string(HsPair), '(Atom ~w, "default")', [DefId])
     ),
     parse_switch_entries(Rest, HsRest).
 

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2374,7 +2374,7 @@ generate_query_body(Options, QueryBody) :-
         % Call "category_parent/2" would fail (fact code is skipped). Use
         % collectForeignSolutions which calls the native kernel directly.
         QueryBody =
-'let { hopsVarId = 1000000 ; s0 = emptyState { wsRegs = IM.fromList [ (1, Atom cat), (2, Atom root), (3, Unbound hopsVarId), (4, VList [Atom cat]) ], wsCP = 0 } ; !solutions = collectForeignSolutions ctx "category_ancestor/4" s0 hopsVarId ; !weightSum = sum [((hops + 1) ** negN) | hops <- solutions] } in (cat, weightSum)'
+'let { hopsVarId = 1000000 ; s0 = emptyState { wsRegs = IM.fromList [ (1, Atom (iAtom cat)), (2, Atom (iAtom root)), (3, Unbound hopsVarId), (4, VList [Atom (iAtom cat)]) ], wsCP = 0 } ; !solutions = collectForeignSolutions ctx "category_ancestor/4" s0 hopsVarId ; !weightSum = sum [((hops + 1) ** negN) | hops <- solutions] } in (cat, weightSum)'
     ;   % Default: collectSolutions loop for category_ancestor/4
         QueryBody =
 'let { hopsVarId = 1000000 ; s0 = emptyState { wsPC = fromMaybe 1 $ Map.lookup "category_ancestor/4" mergedLabels, wsRegs = IM.fromList [ (1, Atom (iAtom cat)), (2, Atom (iAtom root)), (3, Unbound hopsVarId), (4, VList [Atom (iAtom cat)]) ], wsCP = 0 } ; !solutions = collectSolutions ctx s0 hopsVarId ; !weightSum = sum [((hops + 1) ** negN) | hops <- solutions] } in (cat, weightSum)'

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -410,16 +410,16 @@ emit_one_call_arg(reg(RegN), InputRegs) :-
 emit_one_call_arg(derived(length, RegN), InputRegs) :-
     member(input(RegN, _Type), InputRegs),
     reg_var_name(RegN, VarName),
-    format('(length [v | Atom v <- ~wL])', [VarName]).
+    format('(length [v | Atom v <- ~wL])', [VarName]).  % v is Int, just counting elements
 
 %% emit_reg_extraction(+VarName, +Type)
 %  Emit the extraction expression for a kernel call argument. Atoms and
 %  atom lists are interned via wcAtomIntern so the kernel operates on
 %  Int IDs instead of Strings (eliminates hashing in the hot loop).
 emit_reg_extraction(VarName, atom) :-
-    format('(fromMaybe (-1) (Map.lookup ~wS (itForward (wcInternTable ctx))))', [VarName]).
+    format('~wI', [VarName]).
 emit_reg_extraction(VarName, vlist_atoms) :-
-    format('[fromMaybe (-1) (Map.lookup v (itForward (wcInternTable ctx))) | Atom v <- ~wL]', [VarName]).
+    format('[v | Atom v <- ~wL]', [VarName]).
 emit_reg_extraction(VarName, integer) :-
     format('~wI', [VarName]).
 
@@ -466,7 +466,7 @@ emit_pattern_tuple([input(RegN, Type)|Rest], Pos) :-
     emit_pattern_tuple(Rest, rest).
 
 type_pattern(atom, VarName, Pattern) :-
-    format(atom(Pattern), 'Atom ~wS', [VarName]).
+    format(atom(Pattern), 'Atom ~wI', [VarName]).
 type_pattern(integer, VarName, Pattern) :-
     format(atom(Pattern), 'Integer ~wI', [VarName]).
 type_pattern(vlist_atoms, VarName, Pattern) :-

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -96,6 +96,20 @@ main = do
     t1 <- getCurrentTime
     let loadMs = round (diffUTCTime t1 t0 * 1000) :: Int
 
+    -- Build system-wide atom intern table. Extends the compile-time atom
+    -- table (from Predicates.hs) with runtime atoms from TSV data. All
+    -- atoms that reach the WAM interpreter or FFI kernels must be interned.
+    -- The hot loop uses Int comparison instead of String comparison.
+    let atomStrings =
+            [child | (child, _) <- categoryParents] ++
+            [parent | (_, parent) <- categoryParents] ++
+            [cat | (_, cat) <- articleCategories] ++
+            roots
+        !fullInternTable = foldl'
+            (\tbl s -> snd (internAtom tbl s))
+            compileTimeAtomTable atomStrings
+        iAtom s = internAtomPure fullInternTable s
+
     -- Build merged code: compiled predicates + runtime facts.
     -- When FFI handles fact lookups, the WAM-compiled fact code is pure
     -- waste (42% of time, 85% of allocation). The generator injects the
@@ -113,20 +127,6 @@ main = do
         root = head roots
         n = 5.0 :: Double
         negN = -n
-
-    -- Build system-wide atom intern table. Extends the compile-time atom
-    -- table (from Predicates.hs) with runtime atoms from TSV data. All
-    -- atoms that reach the WAM interpreter or FFI kernels must be interned.
-    -- The hot loop uses Int comparison instead of String comparison.
-    let atomStrings =
-            [child | (child, _) <- categoryParents] ++
-            [parent | (_, parent) <- categoryParents] ++
-            [cat | (_, cat) <- articleCategories] ++
-            roots
-        !fullInternTable = foldl'
-            (\tbl s -> snd (internAtom tbl s))
-            compileTimeAtomTable atomStrings
-        iAtom s = internAtomPure fullInternTable s
 
     -- Build child -> [parents] index in interned form for the FFI fast path.
     let !parentsIndexInterned = IM.fromListWith (++)

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -236,10 +236,12 @@ collectForeignSolutions !ctx pred s0 hopsVarId =
       Just s1 -> extractFfiAndBacktrack ctx pred s1 hopsVarId
 
 -- | Extract the hops value from an FFI result state, then backtrack for more.
+-- FFIStreamRetry choice points bind the next result directly on backtrack,
+-- so no run ctx is needed between results.
 extractFfiAndBacktrack :: WamContext -> String -> WamState -> Int -> [Double]
 extractFfiAndBacktrack !ctx pred s1 hopsVarId =
     let hopsVal = case IM.lookup hopsVarId (wsBindings s1) of
-          Just v -> extractDouble (derefVar (wsBindings s1) v)
+          Just v -> extractDouble (wcInternTable ctx) (derefVar (wsBindings s1) v)
           Nothing -> Nothing
         hops = fromMaybe 0 hopsVal
         rest = case backtrack s1 of

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -42,8 +42,9 @@ buildFactIndex pairs = foldl (\m (a, b) -> Map.insertWith (++) a [(a, b)] m) Map
 
 -- | Build WAM instructions for indexed fact predicate.
 -- Returns (instructions, labels) to append to the code vector.
-buildFact2Code :: String -> [(String, String)] -> Int -> ([Instruction], [(String, Int)])
-buildFact2Code predName pairs startPC =
+-- The iAtom function interns a String to an atom ID at load time.
+buildFact2Code :: (String -> Int) -> String -> [(String, String)] -> Int -> ([Instruction], [(String, Int)])
+buildFact2Code iAtom predName pairs startPC =
     let groups = Map.toAscList (buildFactIndex pairs)
         -- SwitchOnConstant dispatch table
         (dispatchList, groupCode, groupLabels, _) = foldl buildGroup ([], [], [], startPC + 1) groups
@@ -53,7 +54,7 @@ buildFact2Code predName pairs startPC =
     buildGroup (disp, code, labels, pc) (key, facts) =
       let groupLabel = predName ++ "_g_" ++ key
           (fcode, flabels, nextPC) = buildFactGroup predName key facts pc
-      in (disp ++ [(Atom key, groupLabel)], code ++ fcode, labels ++ [(groupLabel, pc)] ++ flabels, nextPC)
+      in (disp ++ [(Atom (iAtom key), groupLabel)], code ++ fcode, labels ++ [(groupLabel, pc)] ++ flabels, nextPC)
 
     buildFactGroup _ _ [] pc = ([], [], pc)
     buildFactGroup pn key facts pc =
@@ -63,7 +64,7 @@ buildFact2Code predName pairs startPC =
                   if i == 0 then [TryMeElse (pn ++ "_g_" ++ key ++ "_" ++ show (i+1))]
                   else if i == n - 1 then [TrustMe]
                   else [RetryMeElse (pn ++ "_g_" ++ key ++ "_" ++ show (i+1))]
-                factInstrs = [GetConstant (Atom a) 1, GetConstant (Atom b) 2, Proceed]
+                factInstrs = [GetConstant (Atom (iAtom a)) 1, GetConstant (Atom (iAtom b)) 2, Proceed]
                 label = (pn ++ "_g_" ++ key ++ "_" ++ show i, curPC)
             in (choiceInstr ++ factInstrs, [label], curPC + length choiceInstr + length factInstrs)
           (allCode, allLabels, finalPC) = foldl (\(c, l, p) (i, f) ->
@@ -72,11 +73,11 @@ buildFact2Code predName pairs startPC =
       in (allCode, allLabels, finalPC)
 
 -- | Build WAM instructions for 1-column indexed fact predicate.
-buildFact1Code :: String -> [String] -> Int -> ([Instruction], [(String, Int)])
-buildFact1Code predName vals startPC =
-    let disp = [(Atom v, predName ++ "_" ++ show i) | (i, v) <- zip [0..] vals]
+buildFact1Code :: (String -> Int) -> String -> [String] -> Int -> ([Instruction], [(String, Int)])
+buildFact1Code iAtom predName vals startPC =
+    let disp = [(Atom (iAtom v), predName ++ "_" ++ show i) | (i, v) <- zip [0..] vals]
         switchInstr = SwitchOnConstant (Map.fromList disp)
-        factCode = concatMap (\(i, v) -> [GetConstant (Atom v) 1, Proceed]) (zip [0..] vals)
+        factCode = concatMap (\(i, v) -> [GetConstant (Atom (iAtom v)) 1, Proceed]) (zip [0..] vals)
         factLabels = [(predName ++ "_" ++ show i, startPC + 1 + i * 2) | i <- [0..length vals - 1]]
     in (switchInstr : factCode, (predName ++ "/1", startPC) : factLabels)
 
@@ -113,42 +114,32 @@ main = do
         n = 5.0 :: Double
         negN = -n
 
-    -- Build atom intern table. All atoms that may reach the FFI kernel
-    -- must have stable Int IDs: fact keys (children, parents), seed
-    -- categories, root atoms. Interning here happens once at startup;
-    -- the hot loop then uses IntMap + Int comparison instead of
-    -- HashMap + String hashing (~17% profiled savings).
-    --
-    -- Use a counter pair (map, next-id) in the fold so we don't call
-    -- Map.size on every insert — HashMap.size is O(n), which made the
-    -- original foldl' O(n^2) (~10% profiled time at 300 scale).
+    -- Build system-wide atom intern table. Extends the compile-time atom
+    -- table (from Predicates.hs) with runtime atoms from TSV data. All
+    -- atoms that reach the WAM interpreter or FFI kernels must be interned.
+    -- The hot loop uses Int comparison instead of String comparison.
     let atomStrings =
             [child | (child, _) <- categoryParents] ++
             [parent | (_, parent) <- categoryParents] ++
             [cat | (_, cat) <- articleCategories] ++
             roots
-        (!internMap, _) = foldl'
-            (\(!m, !i) s -> if Map.member s m
-                              then (m, i)
-                              else (Map.insert s i m, i + 1))
-            (Map.empty, 0 :: Int) atomStrings
-        !deinternMap = IM.fromList [(i, s) | (s, i) <- Map.toList internMap]
-        internAtom s = fromMaybe (-1) (Map.lookup s internMap)
+        !fullInternTable = foldl'
+            (\tbl s -> snd (internAtom tbl s))
+            compileTimeAtomTable atomStrings
+        iAtom s = internAtomPure fullInternTable s
 
     -- Build child -> [parents] index in interned form for the FFI fast path.
     let !parentsIndexInterned = IM.fromListWith (++)
-            [(internAtom child, [internAtom parent]) | (child, parent) <- categoryParents]
+            [(iAtom child, [iAtom parent]) | (child, parent) <- categoryParents]
 
     -- Build the read-only WamContext ONCE before the seed loop. The hot
     -- WamState gets a fresh copy per seed; the cold context is shared.
-    -- wcFfiFacts/wcAtomIntern/wcAtomDeintern feed the FFI kernel path.
-    -- wcForeignFacts stays empty — callIndexedFact2 is not used when FFI
-    -- handles the fact predicate.
+    -- wcInternTable is the system-wide atom intern table (compile-time +
+    -- runtime atoms). wcFfiFacts feeds the FFI kernel path.
     let !ctx = (mkContext mergedCode mergedLabels)
             { wcForeignConfig = Map.singleton "max_depth" 10
             , wcLoweredPredicates = Lowered.loweredPredicates
-            , wcAtomIntern    = internMap
-            , wcAtomDeintern  = deinternMap
+            , wcInternTable   = fullInternTable
             , wcFfiFacts      = Map.singleton "category_parent" parentsIndexInterned
             }
 
@@ -222,7 +213,7 @@ collectSolutions !ctx s0 hopsVarId =
       Nothing -> []
       Just s1 ->
         let hopsVal = case IM.lookup hopsVarId (wsBindings s1) of
-              Just v -> extractDouble (derefVar (wsBindings s1) v)
+              Just v -> extractDouble (wcInternTable ctx) (derefVar (wsBindings s1) v)
               Nothing -> Nothing
             hops = fromMaybe 0 hopsVal
             rest = case backtrack s1 of
@@ -259,8 +250,8 @@ extractFfiAndBacktrack !ctx pred s1 hopsVarId =
       Nothing -> rest
 
 -- | Extract a Double from a Value.
-extractDouble :: Value -> Maybe Double
-extractDouble (Integer h) = Just (fromIntegral h)
-extractDouble (Float h) = Just h
-extractDouble (Atom str) = case reads str of [(h, "")] -> Just h; _ -> Nothing
-extractDouble _ = Nothing
+extractDouble :: InternTable -> Value -> Maybe Double
+extractDouble _ (Integer h) = Just (fromIntegral h)
+extractDouble _ (Float h) = Just h
+extractDouble tbl (Atom aid) = case reads (lookupAtom tbl aid) of [(h, "")] -> Just h; _ -> Nothing
+extractDouble _ _ = Nothing

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -232,6 +232,32 @@ collectSolutions !ctx s0 hopsVarId =
           Just _ -> hops : rest
           Nothing -> rest
 
+-- | Collect all Hops solutions via executeForeign dispatch.
+-- Used when the query predicate has an FFI kernel — bypasses WAM
+-- code and calls the native kernel directly. The first result comes
+-- from executeForeign; subsequent results via backtrack through the
+-- ChoicePoints that executeForeign created. After backtrack, the
+-- FFIStreamRetry handler binds the next result directly — no run needed.
+collectForeignSolutions :: WamContext -> String -> WamState -> Int -> [Double]
+collectForeignSolutions !ctx pred s0 hopsVarId =
+    case executeForeign ctx pred s0 of
+      Nothing -> []
+      Just s1 -> extractFfiAndBacktrack ctx pred s1 hopsVarId
+
+-- | Extract the hops value from an FFI result state, then backtrack for more.
+extractFfiAndBacktrack :: WamContext -> String -> WamState -> Int -> [Double]
+extractFfiAndBacktrack !ctx pred s1 hopsVarId =
+    let hopsVal = case IM.lookup hopsVarId (wsBindings s1) of
+          Just v -> extractDouble (derefVar (wsBindings s1) v)
+          Nothing -> Nothing
+        hops = fromMaybe 0 hopsVal
+        rest = case backtrack s1 of
+          Just s2 -> extractFfiAndBacktrack ctx pred s2 hopsVarId
+          Nothing -> []
+    in case hopsVal of
+      Just _ -> hops : rest
+      Nothing -> rest
+
 -- | Extract a Double from a Value.
 extractDouble :: Value -> Maybe Double
 extractDouble (Integer h) = Just (fromIntegral h)

--- a/tests/core/test_purity_certificate.pl
+++ b/tests/core/test_purity_certificate.pl
@@ -477,4 +477,56 @@ test(warn_purity_contradictions_with_contradiction,
     % not an error). Output goes to user_error.
     warn_purity_contradictions(user:loud_pred/1).
 
+% ============================================================================
+% Phase P5: JSON serialization round-trips
+% ============================================================================
+
+test(json_round_trip_pure) :-
+    Cert = purity_cert(pure, declared, 1.0, [declared_by_user]),
+    cert_to_json(Cert, Json),
+    cert_from_json(Json, Cert2),
+    Cert2 = purity_cert(pure, declared, 1.0, [declared_by_user]).
+
+test(json_round_trip_impure) :-
+    Cert = purity_cert(impure([io_ops, database_mods]), analyzed(blacklist), 0.95, []),
+    cert_to_json(Cert, Json),
+    cert_from_json(Json, Cert2),
+    Cert2 = purity_cert(impure(Reasons), analyzed(blacklist), 0.95, Reasons),
+    msort(Reasons, Sorted),
+    msort([io_ops, database_mods], Sorted).
+
+test(json_round_trip_unknown_with_compound_reason) :-
+    Cert = purity_cert(unknown, inferred, 0.3, [unknown_builtin(my_op/2)]),
+    cert_to_json(Cert, Json),
+    cert_from_json(Json, Cert2),
+    Cert2 = purity_cert(unknown, inferred, 0.3, [unknown_builtin(my_op/2)]).
+
+test(json_round_trip_certified_source) :-
+    Cert = purity_cert(pure, certified(static_analysis), 0.9, [whitelisted]),
+    cert_to_json(Cert, Json),
+    cert_from_json(Json, Cert2),
+    Cert2 = purity_cert(pure, certified(static_analysis), 0.9, [whitelisted]), !.
+
+test(json_metadata_passthrough) :-
+    Cert = purity_cert(pure, declared, 1.0, []),
+    cert_to_json(Cert, _{subject: "foo/2", producer: "user_annotations"}, Json),
+    get_dict(subject, Json, "foo/2"),
+    get_dict(producer, Json, "user_annotations"),
+    get_dict(verdict, Json, "pure").
+
+test(json_missing_verdict_throws, [throws(error(cert_json_error(missing_verdict), _))]) :-
+    cert_from_json(_{proof: _{kind: "declared"}, confidence: 1.0}, _).
+
+test(json_confidence_out_of_range_throws, [throws(error(cert_json_error(confidence_out_of_range(2.0)), _))]) :-
+    cert_from_json(_{verdict: "pure", proof: _{kind: "declared"}, confidence: 2.0}, _).
+
+test(json_unknown_proof_kind_throws, [throws(error(cert_json_error(unknown_proof_kind("bogus")), _))]) :-
+    cert_from_json(_{verdict: "pure", proof: _{kind: "bogus"}, confidence: 1.0}, _).
+
+test(json_forward_compat_ignores_unknown_keys) :-
+    Json = _{verdict: "pure", proof: _{kind: "declared"},
+             confidence: 1.0, reasons: ["test"], foo: "bar", extra: 42},
+    cert_from_json(Json, Cert),
+    Cert = purity_cert(pure, declared, 1.0, [test]), !.
+
 :- end_tests(purity_certificate).

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -380,6 +380,37 @@ test_haskell_runtime_imports_parallel :-
     ;   fail_test(Test, 'parallel/deepseq imports missing from WamRuntime')
     ).
 
+%% PutStructureDyn: runtime-parsed functors
+%% --------------------------------------------
+
+test_haskell_put_structure_dyn_in_types :-
+    Test = 'WAM-Haskell: PutStructureDyn constructor in Instruction type',
+    (   wam_haskell_target:generate_wam_types_hs(TypesCode),
+        atom_string(TypesCode, S),
+        sub_string(S, _, _, _, "PutStructureDyn !RegId !RegId !RegId")
+    ->  pass(Test)
+    ;   fail_test(Test, 'PutStructureDyn missing from Instruction type')
+    ).
+
+test_haskell_put_structure_dyn_step_handler :-
+    Test = 'WAM-Haskell: PutStructureDyn step handler present',
+    (   compile_wam_runtime_to_haskell([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "step !ctx s (PutStructureDyn nameReg arityReg targetReg)"),
+        sub_string(S, _, _, _, "BuildStruct fn targetReg (fromIntegral arity)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'PutStructureDyn step handler missing or incorrect')
+    ).
+
+test_haskell_put_structure_dyn_wam_parse :-
+    Test = 'WAM-Haskell: put_structure_dyn WAM text parsed',
+    (   wam_haskell_target:wam_instr_to_haskell(
+            ["put_structure_dyn", "A1,", "A2,", "A3"], Hs),
+        sub_string(Hs, _, _, _, "PutStructureDyn")
+    ->  pass(Test)
+    ;   fail_test(Test, 'put_structure_dyn WAM text not parsed')
+    ).
+
 %% Phase 4.3: findall/bag/set merge strategies
 %% --------------------------------------------
 
@@ -700,6 +731,10 @@ run_tests :-
     test_haskell_fork_helpers_present,
     test_haskell_partryme_else_delegates_to_fork,
     test_haskell_runtime_imports_parallel,
+    %% PutStructureDyn: runtime-parsed functors
+    test_haskell_put_structure_dyn_in_types,
+    test_haskell_put_structure_dyn_step_handler,
+    test_haskell_put_structure_dyn_wam_parse,
     %% Phase 4.3: findall/bag/set merge strategies
     test_haskell_findall_bag_set_forkable,
     test_haskell_infer_collect_maps_to_findall,

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -192,15 +192,15 @@ test_transitive_closure_execute_foreign :-
         %% config_facts_from resolved to edge pred name, now using wcFfiFacts
         sub_string(Code, _, _, _, "edge_facts = fromMaybe IM.empty"),
         sub_string(Code, _, _, _, "wcFfiFacts ctx"),
-        %% Native call: first arg is facts, second is interned atom lookup
+        %% Native call: first arg is facts, input atom is already Int (interned)
         sub_string(Code, _, _, _, "nativeKernel_transitive_closure edge_facts"),
-        sub_string(Code, _, _, _, "itForward (wcInternTable ctx)"),
+        sub_string(Code, _, _, _, "r1I"),
         %% Output is atom: directly use interned ID (rv_1 after
         %% routing single-output through the multi-output FFIStreamRetry path)
         sub_string(Code, _, _, _, "Atom rv_1"),
-        %% Single-input case pattern (not tuple)
+        %% Single-input case pattern: Atom r1I (Int, not String)
         sub_string(Code, _, _, _, "case r1 of"),
-        sub_string(Code, _, _, _, "Atom r1S ->")
+        sub_string(Code, _, _, _, "Atom r1I ->")
     ->  pass(Test)
     ;   fail_test(Test, 'transitive_closure2 executeForeign generation failed')
     ).

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -53,7 +53,7 @@ test_haskell_functor_builtin_present :-
         %% Construct mode: allocates fresh Unbound cells.
         sub_string(S, _, _, _, "Unbound (c0 + i)"),
         %% Read mode: pattern matches Str and VList branches.
-        sub_string(S, _, _, _, "Str fn args -> Just (Atom fn, length args)")
+        sub_string(S, _, _, _, "Str fnId args -> Just (Atom fnId, length args)")
     ->  pass(Test)
     ;   fail_test(Test, 'Missing functor/3 step case patterns')
     ).
@@ -75,7 +75,7 @@ test_haskell_univ_builtin_present :-
         atom_string(Code, S),
         sub_string(S, _, _, _, "BuiltinCall \"=../2\""),
         %% Decompose mode: prepends functor atom to arg list.
-        sub_string(S, _, _, _, "VList (Atom fn : args)"),
+        sub_string(S, _, _, _, "VList (Atom fnId : args)"),
         %% Compose mode: rebuilds Str from list head+tail.
         sub_string(S, _, _, _, "(Atom fname : rest) -> Just (Str fname rest)")
     ->  pass(Test)
@@ -194,10 +194,10 @@ test_transitive_closure_execute_foreign :-
         sub_string(Code, _, _, _, "wcFfiFacts ctx"),
         %% Native call: first arg is facts, second is interned atom lookup
         sub_string(Code, _, _, _, "nativeKernel_transitive_closure edge_facts"),
-        sub_string(Code, _, _, _, "Map.lookup r1S (wcAtomIntern ctx)"),
-        %% Output is atom: de-intern via wcAtomDeintern (rv_1 after
+        sub_string(Code, _, _, _, "itForward (wcInternTable ctx)"),
+        %% Output is atom: directly use interned ID (rv_1 after
         %% routing single-output through the multi-output FFIStreamRetry path)
-        sub_string(Code, _, _, _, "Atom (fromMaybe \"\" (IM.lookup rv_1 (wcAtomDeintern ctx)))"),
+        sub_string(Code, _, _, _, "Atom rv_1"),
         %% Single-input case pattern (not tuple)
         sub_string(Code, _, _, _, "case r1 of"),
         sub_string(Code, _, _, _, "Atom r1S ->")
@@ -397,7 +397,7 @@ test_haskell_put_structure_dyn_step_handler :-
     (   compile_wam_runtime_to_haskell([], [], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, "step !ctx s (PutStructureDyn nameReg arityReg targetReg)"),
-        sub_string(S, _, _, _, "BuildStruct fn targetReg (fromIntegral arity)")
+        sub_string(S, _, _, _, "BuildStruct fnId targetReg (fromIntegral arity)")
     ->  pass(Test)
     ;   fail_test(Test, 'PutStructureDyn step handler missing or incorrect')
     ).
@@ -494,8 +494,8 @@ test_haskell_negation_general_handler :-
     Test = 'WAM-Haskell: general \\+/1 handler with run-based sub-execution',
     (   compile_wam_runtime_to_haskell([], [], Code),
         atom_string(Code, S),
-        % General path: resolve goal key and call run ctx snapshot
-        sub_string(S, _, _, _, "goalKey = fn ++ \"/\" ++ show (length args)"),
+        % General path: resolve goal key via lookupAtom and call run ctx snapshot
+        sub_string(S, _, _, _, "lookupAtom tbl fnId"),
         sub_string(S, _, _, _, "case run ctx snapshot of")
     ->  pass(Test)
     ;   fail_test(Test, 'general \\+/1 handler missing run-based sub-execution')
@@ -548,8 +548,8 @@ test_haskell_negation_true_fail_fast_paths :-
     Test = 'WAM-Haskell: \\+/1 has fast paths for true and fail atoms',
     (   compile_wam_runtime_to_haskell([], [], Code),
         atom_string(Code, S),
-        sub_string(S, _, _, _, "Just (Atom \"true\") -> Nothing"),
-        sub_string(S, _, _, _, "Just (Atom \"fail\") -> Just (s { wsPC = wsPC s + 1 })")
+        sub_string(S, _, _, _, "aid == atomTrue -> Nothing"),
+        sub_string(S, _, _, _, "aid == atomFail -> Just (s { wsPC = wsPC s + 1 })")
     ->  pass(Test)
     ;   fail_test(Test, '\\+ true/fail fast paths missing')
     ).

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -481,13 +481,36 @@ test_haskell_negation_parallel_dispatch :-
     ).
 
 test_haskell_negation_parallel_helper :-
-    Test = 'WAM-Haskell: runNegationParallel helper uses parMap rdeepseq',
+    Test = 'WAM-Haskell: runNegationParallel uses async race-to-cancel',
     (   compile_wam_runtime_to_haskell([], [], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, "runNegationParallel :: WamContext -> WamState -> Int -> Int -> Bool"),
-        sub_string(S, _, _, _, "parMap rdeepseq branchSucceeds branchPCs")
+        sub_string(S, _, _, _, "unsafePerformIO"),
+        sub_string(S, _, _, _, "raceToTrue")
     ->  pass(Test)
-    ;   fail_test(Test, 'runNegationParallel helper missing or incomplete')
+    ;   fail_test(Test, 'runNegationParallel race-to-cancel missing or incomplete')
+    ).
+
+test_haskell_race_to_true_helper :-
+    Test = 'WAM-Haskell: raceToTrue helper with async/waitAny/cancel',
+    (   compile_wam_runtime_to_haskell([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "raceToTrue :: [IO Bool] -> IO Bool"),
+        sub_string(S, _, _, _, "waitAny"),
+        sub_string(S, _, _, _, "mapM_ cancel")
+    ->  pass(Test)
+    ;   fail_test(Test, 'raceToTrue helper missing')
+    ).
+
+test_haskell_async_imports :-
+    Test = 'WAM-Haskell: async/unsafePerformIO imports present',
+    (   compile_wam_runtime_to_haskell([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "Control.Concurrent.Async"),
+        sub_string(S, _, _, _, "System.IO.Unsafe"),
+        sub_string(S, _, _, _, "Control.Exception (evaluate)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'async/unsafe imports missing')
     ).
 
 test_haskell_negation_true_fail_fast_paths :-
@@ -689,6 +712,8 @@ run_tests :-
     test_haskell_negation_general_handler,
     test_haskell_negation_parallel_dispatch,
     test_haskell_negation_parallel_helper,
+    test_haskell_race_to_true_helper,
+    test_haskell_async_imports,
     test_haskell_negation_true_fail_fast_paths,
     %% Phase 4.1: Par* instructions + certificate-driven emission
     test_haskell_par_instructions_in_types,


### PR DESCRIPTION
  ## Summary

  - Change `Atom String` → `Atom !Int` and `Str String` → `Str !Int` across the entire Haskell WAM target (Value type,
  interpreter, lowered emitter, FFI, codegen, templates)
  - Add `InternTable` type with compile-time atom table (Predicates.hs) extended at load time with runtime atoms from
  TSV data
  - Replace `SwitchOnConstantPc (Map String Int)` with `IM.IntMap Int` for O(1) fact dispatch
  - Fix FFI query dispatch bug: effective-distance benchmark produced `tuple_count=0` when kernels were detected (query
  entered WAM code directly, but fact code was skipped). Added `collectForeignSolutions` / `executeForeign` dispatch
  path.

  ## Benchmark results — 10k scale

  All configurations produce identical output (tuple_count=462, article_count=5192):

  | Configuration | Mean query_ms | vs Baseline |
  |---|---|---|
  | Baseline FFI (main, String atoms) | **555** | — |
  | Interned FFI (atom-interning, Int atoms) | **556** | ~0% (expected) |
  | Baseline WAM-only (main, String atoms) | **19,173** | — |
  | Interned WAM-only (atom-interning, Int atoms) | **15,546** | **-19% faster** |

  The FFI path is unaffected because native kernels already used Int comparison at the boundary. The WAM interpreter
  path benefits from O(1) atom equality (Int compare) replacing O(n) string comparison — effect scales with dataset
  size.

  ## What changed

  | File | Changes |
  |---|---|
  | `wam_haskell_target.pl` | Atom intern table init, `intern_atom/2`, `emit_atom_table_haskell`, interned
  `wam_value_to_haskell`, `SwitchOnConstantPc` with IntMap, FFI simplified (atoms already Int), `use_ffi(true)` query
  dispatch |
  | `main.hs.mustache` | `InternTable` construction, `buildFact2Code`/`buildFact1Code` accept `iAtom`,
  `collectForeignSolutions`/`extractFfiAndBacktrack` for FFI path, `extractDouble` with InternTable |
  | `wam_haskell_lowered_emitter.pl` | `val_hs` emits `Atom <id>` via `intern_atom`, `PutStructure` uses interned
  functor ID |
  | `test_wam_haskell_target.pl` | Updated assertions for interned patterns (`Atom r1I`, `atomTrue`, `atomFail`, etc.) |
  | `WAM_PERF_OPTIMIZATION_LOG.md` | Added Phase E with 10k benchmark results |
  | `HASKELL_TARGET_ROADMAP.md` | Updated current state, added Phase 2c section |

  ## Test plan

  - [x] All Prolog codegen tests pass (`tests/test_wam_haskell_target.pl`)
  - [x] All purity certificate tests pass (`tests/core/test_purity_certificate.pl`)
  - [x] Generate, build (GHC 8.6.5), and run at 1k — identical output to baseline
  - [x] Generate, build, and run at 10k — identical output to baseline, 19% faster on WAM-only
  - [x] FFI path verified at both 1k and 10k scale (was previously broken)

  🤖 Generated with [Claude Code](https://claude.com/claude-code)