### PR TITLE
feat(bench): effective_distance harness reports parity vs reference TSV

### DIFF
--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -276,6 +276,46 @@ def normalize_three_column_float_rows(
     return "\n".join(normalized)
 
 
+def three_column_parity_vs_reference(
+    normalized_output: str,
+    reference_path: Path,
+    *,
+    decimals: int = 6,
+) -> str:
+    """Compare a normalized three-column benchmark output against a
+    native-SWI reference TSV. Returns a short status string suitable for
+    a benchmark-table column:
+
+      - "match"       — byte-for-byte identical after normalization.
+      - "no-ref"      — reference_path does not exist.
+      - "diff:<N>/ours:<A>/ref:<B>"
+                      — N articles shared but with different deff values,
+                        A articles only in ours, B articles only in ref.
+    """
+    if not reference_path.exists():
+        return "no-ref"
+    try:
+        reference_raw = reference_path.read_text(encoding="utf-8")
+    except OSError:
+        return "no-ref"
+    reference_normalized = normalize_three_column_float_rows(
+        reference_raw, decimals=decimals
+    )
+    if normalized_output == reference_normalized:
+        return "match"
+
+    our_rows = normalized_output.splitlines()[1:]
+    ref_rows = reference_normalized.splitlines()[1:]
+    our_by_key = {row.split("\t")[0]: row for row in our_rows if "\t" in row}
+    ref_by_key = {row.split("\t")[0]: row for row in ref_rows if "\t" in row}
+
+    only_ours = len(set(our_by_key) - set(ref_by_key))
+    only_ref = len(set(ref_by_key) - set(our_by_key))
+    shared = set(our_by_key) & set(ref_by_key)
+    diff_rows = sum(1 for k in shared if our_by_key[k] != ref_by_key[k])
+    return f"diff:{diff_rows}/ours:{only_ours}/ref:{only_ref}"
+
+
 def group_results_by_scale(results: list[object], sort_key=scale_sort_key) -> list[tuple[str, list[object]]]:
     by_scale: dict[str, list[object]] = {}
     for result in results:

--- a/examples/benchmark/benchmark_wam_elixir_effective_distance.py
+++ b/examples/benchmark/benchmark_wam_elixir_effective_distance.py
@@ -27,6 +27,7 @@ from benchmark_common import (
     print_result_table,
     require_file,
     run_command,
+    three_column_parity_vs_reference,
 )
 
 
@@ -43,6 +44,7 @@ class RunResult:
     stdout_sha256: str
     row_count: int
     stderr: str
+    parity: str  # "match" / "no-ref" / "diff:<N>/ours:<A>/ref:<B>"
 
     @property
     def median(self) -> float:
@@ -135,7 +137,17 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
 
     normalized = normalize_three_column_float_rows(last_stdout, decimals=6)
     digest, rows = digest_normalized_output(normalized)
-    return RunResult(target=target, scale=scale, times=times, stdout_sha256=digest, row_count=rows, stderr=last_stderr)
+    reference_path = BENCH_DIR / scale / "reference_output.tsv"
+    parity = three_column_parity_vs_reference(normalized, reference_path, decimals=6)
+    return RunResult(
+        target=target,
+        scale=scale,
+        times=times,
+        stdout_sha256=digest,
+        row_count=rows,
+        stderr=last_stderr,
+        parity=parity,
+    )
 
 
 def scale_sort_key(scale: str) -> tuple[int, str]:
@@ -180,9 +192,20 @@ def main() -> int:
                 raise
             results.append(benchmark_target(command, scale, args.repetitions, "wam-elixir-lowered"))
 
-        print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
+        # Custom print that includes the new `parity` column — a short
+        # string telling the reader whether our output matches the
+        # native-SWI reference TSV at this scale. "match" is the happy
+        # path; "no-ref" means data/benchmark/<scale>/reference_output.tsv
+        # is absent; "diff:N/ours:A/ref:B" breaks down the delta.
+        print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256\tparity")
         for scale, entries in group_results_by_scale(results, sort_key=scale_sort_key):
-            print_result_table(entries, scale)
+            for result in sorted(entries, key=lambda item: item.target):
+                print(
+                    f"{scale}\t{result.target}\t{result.median:.3f}\t"
+                    f"{min(result.times):.3f}\t{max(result.times):.3f}\t"
+                    f"{result.row_count}\t{result.stdout_sha256[:12]}\t"
+                    f"{result.parity}"
+                )
 
         if args.keep_temp:
             print(f"kept temp build directory: {temp_root}", file=sys.stderr)

--- a/tests/test_benchmark_common_parity.py
+++ b/tests/test_benchmark_common_parity.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Unit tests for three_column_parity_vs_reference in benchmark_common."""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
+
+from benchmark_common import (  # noqa: E402
+    normalize_three_column_float_rows,
+    three_column_parity_vs_reference,
+)
+
+
+def write_tsv(tmp: Path, name: str, contents: str) -> Path:
+    path = tmp / name
+    path.write_text(contents, encoding="utf-8")
+    return path
+
+
+class ThreeColumnParityTests(unittest.TestCase):
+    def test_match_when_normalised_outputs_identical(self) -> None:
+        output = (
+            "article\troot\tdeff\n"
+            "A\tR\t0.993073\n"
+            "B\tR\t1.999728\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            ref = write_tsv(tmp, "reference_output.tsv", output)
+            normalised = normalize_three_column_float_rows(output, decimals=6)
+            self.assertEqual(
+                three_column_parity_vs_reference(normalised, ref, decimals=6),
+                "match",
+            )
+
+    def test_no_ref_when_file_missing(self) -> None:
+        normalised = normalize_three_column_float_rows(
+            "article\troot\tdeff\nA\tR\t1.0\n", decimals=6
+        )
+        missing = Path("/tmp/uw-definitely-does-not-exist.tsv")
+        self.assertEqual(
+            three_column_parity_vs_reference(normalised, missing, decimals=6),
+            "no-ref",
+        )
+
+    def test_numeric_diff_reports_shared_article_delta(self) -> None:
+        ours = (
+            "article\troot\tdeff\n"
+            "A\tR\t0.993073\n"
+            "B\tR\t1.999700\n"   # differs from reference below
+        )
+        ref = (
+            "article\troot\tdeff\n"
+            "A\tR\t0.993073\n"
+            "B\tR\t1.999728\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            ref_path = write_tsv(tmp, "reference_output.tsv", ref)
+            normalised = normalize_three_column_float_rows(ours, decimals=6)
+            self.assertEqual(
+                three_column_parity_vs_reference(normalised, ref_path, decimals=6),
+                "diff:1/ours:0/ref:0",
+            )
+
+    def test_missing_article_reports_ref_only(self) -> None:
+        ours = (
+            "article\troot\tdeff\n"
+            "A\tR\t0.993073\n"
+        )
+        ref = (
+            "article\troot\tdeff\n"
+            "A\tR\t0.993073\n"
+            "B\tR\t1.999728\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            ref_path = write_tsv(tmp, "reference_output.tsv", ref)
+            normalised = normalize_three_column_float_rows(ours, decimals=6)
+            self.assertEqual(
+                three_column_parity_vs_reference(normalised, ref_path, decimals=6),
+                "diff:0/ours:0/ref:1",
+            )
+
+    def test_extra_article_reports_ours_only(self) -> None:
+        ours = (
+            "article\troot\tdeff\n"
+            "A\tR\t0.993073\n"
+            "B\tR\t1.999728\n"
+            "C\tR\t2.500000\n"   # only in ours
+        )
+        ref = (
+            "article\troot\tdeff\n"
+            "A\tR\t0.993073\n"
+            "B\tR\t1.999728\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            ref_path = write_tsv(tmp, "reference_output.tsv", ref)
+            normalised = normalize_three_column_float_rows(ours, decimals=6)
+            self.assertEqual(
+                three_column_parity_vs_reference(normalised, ref_path, decimals=6),
+                "diff:0/ours:1/ref:0",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The Python benchmark harness now compares its normalized output
against `data/benchmark/<scale>/reference_output.tsv` at every run
and reports a `parity` column in the printed table. Three possible
statuses: `match`, `no-ref`, or a detailed
`diff:N/ours:A/ref:B` breakdown.

No code behaviour change in any WAM target — this is purely a
harness-side correctness gate.

## Why

The scale-wide native-SWI reference TSVs landed in PR #1547. But the
existing harness only captured a SHA256 digest + row count. A future
change that silently drifts from the reference (say, a regression in
cut handling or arithmetic) would be invisible unless someone
manually diffed. This PR closes that loop with a hard regression
signal in every run.

## What's in this PR

### `benchmark_common.three_column_parity_vs_reference`

```python
def three_column_parity_vs_reference(
    normalized_output: str,
    reference_path: Path,
    *,
    decimals: int = 6,
) -> str:
```

Re-normalises the reference file using the same
`normalize_three_column_float_rows` path the benchmark output goes
through (identical sort order, identical decimal rounding), then
returns:

- `"match"` — byte-for-byte identical after normalization.
- `"no-ref"` — `reference_output.tsv` absent for this scale.
- `"diff:<N>/ours:<A>/ref:<B>"` — **N** articles shared between
  ours and the reference but with different `deff` values, **A**
  articles only in ours, **B** articles only in the reference.

### Harness wiring

- `RunResult` gains a `parity: str` field.
- The printed table gains a trailing `parity` column.
- Same `decimals=6` everywhere — matches the precision Elixir emits.

## Observed output

At the time of writing, running on current `main`:

```
scale  rows   parity
dev     19    diff:18/ours:0/ref:0   ← known FP associativity (#1535)
300    271    match
1k     580    match
5k    3224    match   (per #1547 scale-wide verification)
10x    183    match   (per #1547)
10k   5192    match   (per #1547)
```

The `dev` deltas are the pre-existing residual documented in the
category_ancestor semantics PR (#1535); every larger scale is
exact.

## Test plan

- [x] `python3 tests/test_benchmark_common_parity.py` — **5/5** unit
      tests covering match, no-ref, numeric-diff, missing-article,
      and extra-article cases.
- [x] `python3 examples/benchmark/benchmark_wam_elixir_effective_distance.py --scales dev --repetitions 1`
      — reports `diff:18/ours:0/ref:0`.
- [x] `python3 examples/benchmark/benchmark_wam_elixir_effective_distance.py --scales 300 --repetitions 1`
      — reports `match`.
- [x] `python3 examples/benchmark/benchmark_wam_elixir_effective_distance.py --scales 1k --repetitions 1`
      — reports `match`.

## Non-goals

- **Making parity mismatch a hard error.** The harness is
  informational. Callers (CI, PR reviewers, whoever) decide what's
  acceptable. A future `--require-parity match` flag would be a
  one-line change if we ever want it.
- **Changing precision.** Still 6 decimals — matches what Elixir
  emits. Reducing the tolerance (e.g. matching to 3 decimals) would
  let dev-scale `match` but hide useful signal.
- **Porting to other benchmark scripts.** Only `effective_distance`
  for now; other harnesses can follow the same template when the
  reference TSVs are in place.

## Related

- PR #1547 — added reference TSVs at scales 300/1k/5k/10x/10k that
  this PR compares against.
- PR #1535 — the category_ancestor semantics fix; source of the
  18 dev-scale FP deltas the new column surfaces.
- PR #1551 — Phase D external_source; byte-for-byte equivalent to
  inline_data at dev scale, so both layouts report the same parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
