### PR TITLE
feat(wam-clojure): externalize benchmark sidecars

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -330,16 +330,25 @@ for further optimization work.
     trail boundary, regs/env/stack, cut barrier, next-var-id, resume PC, and
     remaining foreign results, but they no longer snapshot heap/unify/build
     state that deterministic foreign handlers do not touch.
+19. Large Clojure benchmark scaffolds now externalize benchmark relation data
+    and foreign-kernel lookup tables into EDN sidecars instead of embedding
+    giant handler literals in generated source. This avoids JVM bytecode
+    `Method code too large` failures on larger scales and is the first concrete
+    Clojure step toward the same preprocessing/materialization direction that
+    already exists in the C# query runtime.
 
 ### Highest-value remaining work
 
-1. Measure whether the slimmer foreign choice points improve the `dev`
+1. Push the new Clojure benchmark sidecars toward a real preprocessed artifact
+   path so larger scales reuse compact adjacency data instead of reparsing EDN
+   into generic vectors and maps on every JVM start.
+2. Measure whether the slimmer foreign choice points improve the `dev`
    Clojure benchmark timings enough to justify similar hot-state split work.
-2. Add proper heap/trail semantics instead of relying primarily on the
+3. Add proper heap/trail semantics instead of relying primarily on the
    bindings table.
-3. Reduce choice-point snapshots toward the lighter Haskell/Rust model once
+4. Reduce choice-point snapshots toward the lighter Haskell/Rust model once
    the remaining runtime state is better separated.
-4. Split hot runtime state from cold code/context data, following the same
+5. Split hot runtime state from cold code/context data, following the same
    optimization pattern that paid off heavily in Haskell.
 
 ---
@@ -405,3 +414,23 @@ Not every attempt was a win. Tracking these so we don't repeat them.
   now largely delivered
 - `docs/design/WAM_HASKELL_FFI_PROFILING_REPORT.md` — the profiling
   matrix that drove the Phase-D wins
+
+## Clojure benchmark preprocessing follow-up
+
+Recent Clojure hybrid WAM benchmark work exposed two practical
+lessons for externalized/preprocessed predicate data:
+
+1. Sidecar paths must be generation-time absolute for benchmark harnesses
+   that launch projects from a repository root rather than the generated
+   project directory. Relative sidecar paths were enough for direct
+   smoke runs but broke the cross-target matrix.
+2. Preprocessing policy should be declarative, not only a CLI switch.
+   The benchmark generator now lets `auto` honor an optional benchmark
+   predicate (`wam_clojure_benchmark_data_mode/1` or
+   `benchmark_data_mode/1`) before falling back to the scale-favoring
+   heuristic (`sidecar` above the current fact-volume threshold,
+   `inline` otherwise).
+
+That moves the Clojure benchmark path closer to the C# materialization
+direction: policy can live with the workload, while the default still
+favors scaling safely.

--- a/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
@@ -2,7 +2,9 @@
           [ main/0,
             generate/3,
             generate/4,
+            generate/5,
             parse_kernel_mode/2,
+            parse_benchmark_data_mode/2,
             category_parent_handler_code/1,
             category_ancestor_handler_code/1,
             collect_wam_predicates/2,
@@ -12,7 +14,7 @@
 
 :- use_module('../../src/unifyweaver/targets/wam_clojure_target').
 :- use_module('../../src/unifyweaver/targets/prolog_target').
-:- use_module(library(filesex), [directory_file_path/3]).
+:- use_module(library(filesex), [directory_file_path/3, make_directory_path/1]).
 
 %% generate_wam_clojure_optimized_benchmark.pl
 %%
@@ -28,6 +30,7 @@
 %% Usage:
 %%   swipl -q -s generate_wam_clojure_optimized_benchmark.pl -- \
 %%       <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off]
+%%       [auto|sidecar|inline]
 
 benchmark_workload_path(Path) :-
     source_file(benchmark_workload_path(_), ThisFile),
@@ -38,21 +41,26 @@ main :-
     current_prolog_flag(argv, Argv),
     (   Argv == []
     ->  true
-    ;   Argv = [FactsPath, OutputDir, VariantAtom, KernelModeAtom]
+    ;   Argv = [FactsPath, OutputDir, VariantAtom, KernelModeAtom, DataModeAtom]
     ->  true
+    ;   Argv = [FactsPath, OutputDir, VariantAtom, KernelModeAtom]
+    ->  DataModeAtom = auto
     ;   Argv = [FactsPath, OutputDir, VariantAtom]
     ->  KernelModeAtom = kernels_on
+        ,
+        DataModeAtom = auto
     ;   Argv = [FactsPath, OutputDir]
     ->  VariantAtom = accumulated,
-        KernelModeAtom = kernels_on
+        KernelModeAtom = kernels_on,
+        DataModeAtom = auto
     ;   format(user_error,
-            'Usage: ... -- <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off]~n',
+            'Usage: ... -- <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off] [auto|sidecar|inline]~n',
             []),
         halt(1)
     ),
     (   Argv == []
     ->  true
-    ;   generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom),
+    ;   generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom, DataModeAtom),
         halt(0)
     ).
 
@@ -61,14 +69,19 @@ main :-
     halt(1).
 
 generate(FactsPath, OutputDir, VariantAtom) :-
-    generate(FactsPath, OutputDir, VariantAtom, kernels_on).
+    generate(FactsPath, OutputDir, VariantAtom, kernels_on, auto).
 
 generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom) :-
+    generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom, auto).
+
+generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom, DataModeAtom) :-
     must_exist_file(FactsPath),
     benchmark_workload_path(WorkloadPath),
-    load_files(user:FactsPath, [silent(true)]),
-    parse_kernel_mode(KernelModeAtom, KernelOptions),
-    load_files(user:WorkloadPath, [silent(true)]),
+    reset_benchmark_predicates,
+    load_files(user:WorkloadPath, [silent(true), if(true)]),
+    load_files(user:FactsPath, [silent(true), if(true)]),
+    parse_benchmark_data_mode(DataModeAtom, DataMode),
+    parse_kernel_mode(OutputDir, KernelModeAtom, DataMode, KernelOptions),
     retractall(user:mode(category_ancestor(_, _, _, _))),
     assertz(user:mode(category_ancestor(-, +, -, +))),
 
@@ -80,17 +93,43 @@ generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom) :-
 
     maybe_assert_seeded_helper(VariantAtom),
     collect_wam_predicates(VariantAtom, KernelModeAtom, Predicates),
+    collect_benchmark_data(BenchmarkData),
+    effective_distance_runner_code(OutputDir, KernelModeAtom, DataMode, BenchmarkData, RunnerCode),
     append([ [ module_name('wam-clojure-optimized-bench'),
-               namespace('generated.wam_clojure_optimized_bench')
+               namespace('generated.wam_clojure_optimized_bench'),
+               clojure_benchmark_data_mode(DataMode)
              ],
              KernelOptions
            ],
            Options),
     write_wam_clojure_project(Predicates, Options, OutputDir),
-    append_effective_distance_runner(OutputDir, KernelModeAtom),
+    maybe_write_benchmark_sidecar_files(OutputDir, DataMode, BenchmarkData),
+    append_effective_distance_runner(OutputDir, RunnerCode),
     format(user_error,
-           '[WAM-Clojure-Optimized] facts=~w variant=~w kernels=~w output=~w~n',
-           [FactsPath, VariantAtom, KernelModeAtom, OutputDir]).
+           '[WAM-Clojure-Optimized] facts=~w variant=~w kernels=~w data_mode=~w output=~w~n',
+           [FactsPath, VariantAtom, KernelModeAtom, DataMode, OutputDir]).
+
+reset_benchmark_predicates :-
+    forall(member(Name/Arity,
+                  [ article_category/2,
+                    category_parent/2,
+                    root_category/1,
+                    dimension_n/1,
+                    max_depth/1,
+                    category_ancestor/4,
+                    power_sum_bound/4,
+                    'category_ancestor$power_sum_bound'/3,
+                    'category_ancestor$power_sum_selected'/3,
+                    'category_ancestor$effective_distance_sum_selected'/3,
+                    'category_ancestor$effective_distance_sum_bound'/3
+                  ]),
+           maybe_abolish_user_predicate(Name/Arity)).
+
+maybe_abolish_user_predicate(Name/Arity) :-
+    (   current_predicate(user:Name/Arity)
+    ->  abolish(user:Name/Arity)
+    ;   true
+    ).
 
 parse_variant(seeded, [
     dialect(swi),
@@ -111,13 +150,90 @@ parse_kernel_mode(kernels_on, [
         handler(category_ancestor/4, AncestorHandlerCode)
     ])
 ]) :-
-    category_parent_handler_code(ParentHandlerCode),
-    category_ancestor_handler_code(AncestorHandlerCode).
+    DataMode = sidecar,
+    category_parent_handler_code(DataMode, ParentHandlerCode),
+    category_ancestor_handler_code(DataMode, AncestorHandlerCode).
 parse_kernel_mode(kernels_off, [
     no_kernels(true)
 ]).
 
+parse_kernel_mode(kernels_on, DataMode, [
+    foreign_predicates([category_parent/2, category_ancestor/4]),
+    clojure_foreign_handlers([
+        handler(category_parent/2, ParentHandlerCode),
+        handler(category_ancestor/4, AncestorHandlerCode)
+    ])
+]) :-
+    category_parent_handler_code(DataMode, ParentHandlerCode),
+    category_ancestor_handler_code(DataMode, AncestorHandlerCode).
+parse_kernel_mode(kernels_off, _DataMode, [
+    no_kernels(true)
+]).
+
+parse_kernel_mode(OutputDir, kernels_on, DataMode, [
+    foreign_predicates([category_parent/2, category_ancestor/4]),
+    clojure_foreign_handlers([
+        handler(category_parent/2, ParentHandlerCode),
+        handler(category_ancestor/4, AncestorHandlerCode)
+    ])
+]) :-
+    category_parent_handler_code(OutputDir, DataMode, ParentHandlerCode),
+    category_ancestor_handler_code(OutputDir, DataMode, AncestorHandlerCode).
+parse_kernel_mode(_OutputDir, kernels_off, _DataMode, [
+    no_kernels(true)
+]).
+
+parse_benchmark_data_mode(sidecar, sidecar).
+parse_benchmark_data_mode(inline, inline).
+parse_benchmark_data_mode(auto, Mode) :-
+    (   benchmark_declared_data_mode(DeclaredMode),
+        DeclaredMode \== auto
+    ->  parse_benchmark_data_mode(DeclaredMode, Mode)
+    ;   benchmark_fact_volume(RowCount),
+        (   RowCount >= 128
+        ->  Mode = sidecar
+        ;   Mode = inline
+        )
+    ).
+
+benchmark_declared_data_mode(Mode) :-
+    member(Name,
+           [ wam_clojure_benchmark_data_mode,
+             benchmark_data_mode
+           ]),
+    current_predicate(user:Name/1),
+    Goal =.. [Name, DeclaredMode],
+    once(call(user:Goal)),
+    memberchk(DeclaredMode, [auto, sidecar, inline]),
+    Mode = DeclaredMode.
+
+benchmark_fact_volume(RowCount) :-
+    benchmark_fact_count(user:category_parent/2, ParentCount),
+    benchmark_fact_count(user:article_category/2, ArticleCount),
+    benchmark_fact_count(user:root_category/1, RootCount),
+    RowCount is ParentCount + ArticleCount + RootCount.
+
+benchmark_fact_count(Module:Name/Arity, Count) :-
+    functor(Goal, Name, Arity),
+    findall(Goal, Module:Goal, Goals),
+    length(Goals, Count).
+
 category_parent_handler_code(HandlerCode) :-
+    parse_benchmark_data_mode(auto, DataMode),
+    category_parent_handler_code(DataMode, HandlerCode).
+
+category_parent_handler_code(OutputDir, sidecar, HandlerCode) :-
+    benchmark_sidecar_file_path_literal(OutputDir, 'category_parent.edn', CategoryParentPath),
+    format(string(HandlerCode),
+           "(let [edges-delay (delay (set (edn/read-string (slurp ~w))))] (fn [args] (contains? @edges-delay [(nth args 0) (nth args 1)])))",
+           [CategoryParentPath]).
+category_parent_handler_code(_OutputDir, inline, HandlerCode) :-
+    category_parent_handler_code(inline, HandlerCode).
+category_parent_handler_code(sidecar, HandlerCode) :-
+    format(string(HandlerCode),
+           "(let [edges-delay (delay (set (edn/read-string (slurp \"data/generated/wam_clojure_optimized_bench/category_parent.edn\"))))] (fn [args] (contains? @edges-delay [(nth args 0) (nth args 1)])))",
+           []).
+category_parent_handler_code(inline, HandlerCode) :-
     findall(Child-Parent,
             current_category_parent_fact(Child, Parent),
             Pairs0),
@@ -128,6 +244,30 @@ category_parent_handler_code(HandlerCode) :-
            "(let [edges #{~s}] (fn [args] (contains? edges [(nth args 0) (nth args 1)])))",
            [Edges]).
 
+category_ancestor_handler_code(HandlerCode) :-
+    parse_benchmark_data_mode(auto, DataMode),
+    category_ancestor_handler_code(DataMode, HandlerCode).
+
+category_ancestor_handler_code(OutputDir, sidecar, HandlerCode) :-
+    benchmark_max_depth_literal(MaxDepth),
+    benchmark_sidecar_file_path_literal(OutputDir, 'category_parent.edn', CategoryParentPath),
+    format(string(HandlerCode),
+           "(let [parents-by-child-delay (delay (reduce (fn [acc [child parent]] (update acc child (fnil conj []) parent)) {} (edn/read-string (slurp ~w)))) max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (get @parents-by-child-delay category [])] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] {:solutions (vec solutions)})))",
+           [CategoryParentPath, MaxDepth]).
+category_ancestor_handler_code(_OutputDir, inline, HandlerCode) :-
+    category_ancestor_handler_code(inline, HandlerCode).
+category_ancestor_handler_code(sidecar, HandlerCode) :-
+    benchmark_max_depth_literal(MaxDepth),
+    format(string(HandlerCode),
+           "(let [parents-by-child-delay (delay (reduce (fn [acc [child parent]] (update acc child (fnil conj []) parent)) {} (edn/read-string (slurp \"data/generated/wam_clojure_optimized_bench/category_parent.edn\")))) max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (get @parents-by-child-delay category [])] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] {:solutions (vec solutions)})))",
+           [MaxDepth]).
+category_ancestor_handler_code(inline, HandlerCode) :-
+    benchmark_max_depth_literal(MaxDepth),
+    category_parent_map_literal(ParentsByChild),
+    format(string(HandlerCode),
+           "(let [parents-by-child {~s} max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (get parents-by-child category [])] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] {:solutions (vec solutions)})))",
+           [ParentsByChild, MaxDepth]).
+
 current_category_parent_fact(Child, Parent) :-
     current_predicate(user:category_parent/2),
     call(user:category_parent(Child, Parent)).
@@ -136,13 +276,6 @@ category_parent_edge_literal(Child-Parent, Literal) :-
     clj_string_literal_local(Child, ChildLit),
     clj_string_literal_local(Parent, ParentLit),
     format(atom(Literal), '[~w ~w]', [ChildLit, ParentLit]).
-
-category_ancestor_handler_code(HandlerCode) :-
-    category_parent_map_literal(ParentsByChild),
-    benchmark_max_depth_literal(MaxDepth),
-    format(string(HandlerCode),
-           "(let [parents-by-child {~s} max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (get parents-by-child category [])] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] {:solutions (vec solutions)})))",
-           [ParentsByChild, MaxDepth]).
 
 category_parent_map_literal(Literal) :-
     findall(Child,
@@ -173,10 +306,9 @@ escape_clj_string_local(In, Out) :-
     split_string(Tmp1, "\"", "", Parts2),
     atomic_list_concat(Parts2, "\\\"", Out).
 
-append_effective_distance_runner(OutputDir, KernelModeAtom) :-
+append_effective_distance_runner(OutputDir, RunnerCode) :-
     directory_file_path(OutputDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
     read_file_to_string(CorePath, Core0, []),
-    effective_distance_runner_code(KernelModeAtom, RunnerCode),
     atomic_list_concat([Core0, RunnerCode], '\n\n', Core),
     setup_call_cleanup(
         open(CorePath, write, Stream),
@@ -184,41 +316,45 @@ append_effective_distance_runner(OutputDir, KernelModeAtom) :-
         close(Stream)
     ).
 
-effective_distance_runner_code(KernelModeAtom, Code) :-
-    benchmark_article_category_literal(ArticleCategories),
-    benchmark_category_parent_literal(CategoryParents),
-    benchmark_root_category_literal(RootCategories),
+effective_distance_runner_code(OutputDir, KernelModeAtom, DataMode, BenchmarkData, Code) :-
     benchmark_dimension_n_literal(DimensionN),
     benchmark_max_depth_literal(MaxDepth),
     benchmark_use_traversal_kernel_literal(KernelModeAtom, UseTraversalKernel),
+    benchmark_sidecar_dir_literal(OutputDir, DataDirLiteral),
+    benchmark_article_categories_code(DataMode, DataDirLiteral, BenchmarkData, ArticleCategoriesCode),
+    benchmark_category_parents_code(DataMode, DataDirLiteral, BenchmarkData, CategoryParentsCode),
+    benchmark_roots_code(DataMode, DataDirLiteral, BenchmarkData, RootsCode),
     format(string(Code),
 '
 ;; Effective-distance benchmark entrypoint generated from facts.pl.
 ;; Predicate calls are still available by passing a predicate key and args.
-(def benchmark-article-categories [~s])
-(def benchmark-category-parents [~s])
-(def benchmark-roots [~s])
+(def benchmark-data-dir ~w)
+~s
+~s
+~s
 (def benchmark-dimension-n ~w)
 (def benchmark-max-depth ~w)
 (def benchmark-use-traversal-kernel? ~w)
 
-(def benchmark-parents-by-child
-  (reduce (fn [acc [child parent]]
-            (update acc child (fnil conj []) parent))
-          {}
-          benchmark-category-parents))
+(def benchmark-parents-by-child-delay
+  (delay
+    (reduce (fn [acc [child parent]]
+              (update acc child (fnil conj []) parent))
+            {}
+            @benchmark-category-parents-delay)))
 
-(def benchmark-article-categories-by-article
-  (reduce (fn [acc [article category]]
-            (update acc article (fnil conj []) category))
-          {}
-          benchmark-article-categories))
+(def benchmark-article-categories-by-article-delay
+  (delay
+    (reduce (fn [acc [article category]]
+              (update acc article (fnil conj []) category))
+            {}
+            @benchmark-article-categories-delay)))
 
-(def benchmark-seed-categories
-  (sort (set (map second benchmark-article-categories))))
+(def benchmark-seed-categories-delay
+  (delay (sort (set (map second @benchmark-article-categories-delay)))))
 
 (defn benchmark-ancestor-hops [category root visited]
-  (let [parents (get benchmark-parents-by-child category [])]
+  (let [parents (get @benchmark-parents-by-child-delay category [])]
     (vec
       (concat
         (for [parent parents
@@ -257,7 +393,7 @@ effective_distance_runner_code(KernelModeAtom, Code) :-
   (reduce
     +
     0.0
-    (for [category (get benchmark-article-categories-by-article article [])
+    (for [category (get @benchmark-article-categories-by-article-delay article [])
           weight (if (= category root)
                    [1.0]
                    (for [hops (benchmark-category-root-hops category root)]
@@ -268,8 +404,8 @@ effective_distance_runner_code(KernelModeAtom, Code) :-
   (let [inv-n (- (/ 1.0 benchmark-dimension-n))]
     (sort-by
       (fn [{:keys [distance article root]}] [distance article root])
-      (for [root benchmark-roots
-            article (sort (keys benchmark-article-categories-by-article))
+      (for [root @benchmark-roots-delay
+            article (sort (keys @benchmark-article-categories-by-article-delay))
             :let [weight-sum (benchmark-article-root-weight article root)]
             :when (pos? weight-sum)]
         {:article article
@@ -291,8 +427,78 @@ effective_distance_runner_code(KernelModeAtom, Code) :-
       (println (invoke-predicate pred-key (mapv edn/read-string pred-args))))
     (run-effective-distance-benchmark)))
 ',
-           [ArticleCategories, CategoryParents, RootCategories, DimensionN, MaxDepth,
-            UseTraversalKernel]).
+           [DataDirLiteral, ArticleCategoriesCode, CategoryParentsCode, RootsCode,
+            DimensionN, MaxDepth, UseTraversalKernel]).
+
+benchmark_article_categories_code(sidecar, _DataDirLiteral, _BenchmarkData, Code) :-
+    Code = '(def benchmark-article-categories-delay
+  (delay (vec (edn/read-string (slurp (str benchmark-data-dir "/article_category.edn"))))))'.
+benchmark_article_categories_code(inline, _DataDirLiteral, benchmark_data(ArticleCategories, _, _, _, _, _), Code) :-
+    format(string(Code),
+           "(def benchmark-article-categories-delay (delay [~s]))",
+           [ArticleCategories]).
+
+benchmark_category_parents_code(sidecar, _DataDirLiteral, _BenchmarkData, Code) :-
+    Code = '(def benchmark-category-parents-delay
+  (delay (vec (edn/read-string (slurp (str benchmark-data-dir "/category_parent.edn"))))))'.
+benchmark_category_parents_code(inline, _DataDirLiteral, benchmark_data(_, CategoryParents, _, _, _, _), Code) :-
+    format(string(Code),
+           "(def benchmark-category-parents-delay (delay [~s]))",
+           [CategoryParents]).
+
+benchmark_roots_code(sidecar, _DataDirLiteral, _BenchmarkData, Code) :-
+    Code = '(def benchmark-roots-delay
+  (delay (vec (edn/read-string (slurp (str benchmark-data-dir "/root_category.edn"))))))'.
+benchmark_roots_code(inline, _DataDirLiteral, benchmark_data(_, _, RootCategories, _, _, _), Code) :-
+    format(string(Code),
+           "(def benchmark-roots-delay (delay [~s]))",
+           [RootCategories]).
+
+maybe_write_benchmark_sidecar_files(OutputDir, sidecar, BenchmarkData) :-
+    !,
+    write_benchmark_sidecar_files(OutputDir, BenchmarkData).
+maybe_write_benchmark_sidecar_files(_, inline, _).
+
+write_benchmark_sidecar_files(OutputDir, BenchmarkData) :-
+    benchmark_sidecar_dir(OutputDir, DataDir),
+    make_directory_path(DataDir),
+    write_benchmark_sidecar_file(DataDir, 'article_category.edn', BenchmarkData, benchmark_article_category_edn),
+    write_benchmark_sidecar_file(DataDir, 'category_parent.edn', BenchmarkData, benchmark_category_parent_edn),
+    write_benchmark_sidecar_file(DataDir, 'root_category.edn', BenchmarkData, benchmark_root_category_edn).
+
+benchmark_sidecar_dir(OutputDir, DataDir) :-
+    directory_file_path(OutputDir, 'data', DataRoot),
+    directory_file_path(DataRoot, 'generated', GeneratedDir),
+    directory_file_path(GeneratedDir, 'wam_clojure_optimized_bench', DataDir).
+
+benchmark_sidecar_dir_literal(OutputDir, Literal) :-
+    benchmark_sidecar_dir(OutputDir, DataDir),
+    absolute_file_name(DataDir, AbsoluteDir),
+    clj_string_literal_local(AbsoluteDir, Literal).
+
+benchmark_sidecar_file_path_literal(OutputDir, FileName, Literal) :-
+    benchmark_sidecar_dir(OutputDir, DataDir),
+    directory_file_path(DataDir, FileName, FilePath),
+    absolute_file_name(FilePath, AbsolutePath),
+    clj_string_literal_local(AbsolutePath, Literal).
+
+write_benchmark_sidecar_file(DataDir, FileName, BenchmarkData, Builder) :-
+    call(Builder, BenchmarkData, Content),
+    directory_file_path(DataDir, FileName, Path),
+    setup_call_cleanup(
+        open(Path, write, Stream),
+        write(Stream, Content),
+        close(Stream)
+    ).
+
+collect_benchmark_data(benchmark_data(ArticleCategories, CategoryParents, RootCategories,
+                                      ArticleEdn, CategoryEdn, RootEdn)) :-
+    benchmark_article_category_literal(ArticleCategories),
+    benchmark_category_parent_literal(CategoryParents),
+    benchmark_root_category_literal(RootCategories),
+    benchmark_article_category_edn_from_literal(ArticleCategories, ArticleEdn),
+    benchmark_category_parent_edn_from_literal(CategoryParents, CategoryEdn),
+    benchmark_root_category_edn_from_literal(RootCategories, RootEdn).
 
 benchmark_use_traversal_kernel_literal(kernels_on, true).
 benchmark_use_traversal_kernel_literal(kernels_off, false).
@@ -305,6 +511,11 @@ benchmark_article_category_literal(Literal) :-
     maplist(edge_literal, Pairs, Literals),
     atomic_list_concat(Literals, ' ', Literal).
 
+benchmark_article_category_edn(benchmark_data(_, _, _, Content, _, _), Content).
+
+benchmark_article_category_edn_from_literal(Literal, Content) :-
+    format(atom(Content), '[~w]', [Literal]).
+
 benchmark_category_parent_literal(Literal) :-
     findall(Child-Parent,
             current_category_parent_fact(Child, Parent),
@@ -313,11 +524,21 @@ benchmark_category_parent_literal(Literal) :-
     maplist(edge_literal, Pairs, Literals),
     atomic_list_concat(Literals, ' ', Literal).
 
+benchmark_category_parent_edn(benchmark_data(_, _, _, _, Content, _), Content).
+
+benchmark_category_parent_edn_from_literal(Literal, Content) :-
+    format(atom(Content), '[~w]', [Literal]).
+
 benchmark_root_category_literal(Literal) :-
     findall(Root, current_root_category_fact(Root), Roots0),
     sort(Roots0, Roots),
     maplist(clj_string_literal_local, Roots, Literals),
     atomic_list_concat(Literals, ' ', Literal).
+
+benchmark_root_category_edn(benchmark_data(_, _, _, _, _, Content), Content).
+
+benchmark_root_category_edn_from_literal(Literal, Content) :-
+    format(atom(Content), '[~w]', [Literal]).
 
 benchmark_dimension_n_literal(Literal) :-
     (   current_predicate(user:dimension_n/1),

--- a/tests/test_wam_clojure_benchmark_generator.pl
+++ b/tests/test_wam_clojure_benchmark_generator.pl
@@ -13,6 +13,24 @@ test(kernel_mode_options) :-
     assertion(member(clojure_foreign_handlers(_), OnOptions)),
     assertion(OffOptions == [no_kernels(true)]).
 
+test(data_mode_options) :-
+    parse_benchmark_data_mode(sidecar, sidecar),
+    parse_benchmark_data_mode(inline, inline),
+    setup_call_cleanup(
+        load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
+        assertion(parse_benchmark_data_mode(auto, sidecar)),
+        true
+    ).
+
+test(data_mode_predicate_override) :-
+    setup_call_cleanup(
+        ( load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
+          assertz(user:wam_clojure_benchmark_data_mode(inline))
+        ),
+        assertion(parse_benchmark_data_mode(auto, inline)),
+        maybe_abolish_test_predicate(wam_clojure_benchmark_data_mode/1)
+    ).
+
 test(collect_seeded_predicates) :-
     collect_wam_predicates(seeded, Predicates),
     assertion(member(user:dimension_n/1, Predicates)),
@@ -23,13 +41,20 @@ test(collect_seeded_predicates) :-
 test(generate_seeded_kernels_on_project) :-
     once((
         unique_tmp_dir('tmp_wam_clojure_bench_on', TmpDir),
-        generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on),
+        generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, sidecar),
         directory_file_path(TmpDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
+        directory_file_path(TmpDir, 'data/generated/wam_clojure_optimized_bench/category_parent.edn', CategoryParentPath),
+        directory_file_path(TmpDir, 'data/generated/wam_clojure_optimized_bench/article_category.edn', ArticleCategoryPath),
+        directory_file_path(TmpDir, 'data/generated/wam_clojure_optimized_bench/root_category.edn', RootCategoryPath),
         read_file_to_string(CorePath, CoreCode, []),
+        assertion(exists_file(CategoryParentPath)),
+        assertion(exists_file(ArticleCategoryPath)),
+        assertion(exists_file(RootCategoryPath)),
         assertion(sub_string(CoreCode, _, _, _, '(def foreign-handlers {')),
-        assertion(sub_string(CoreCode, _, _, _, '"category_parent/2" (let [edges #{')),
-        assertion(sub_string(CoreCode, _, _, _, '"category_ancestor/4" (let [parents-by-child {')),
-        assertion(sub_string(CoreCode, _, _, _, '["Abstraction" "Thought"]')),
+        assertion(sub_string(CoreCode, _, _, _, 'slurp "/')),
+        assertion(sub_string(CoreCode, _, _, _, '"category_ancestor/4" (let [parents-by-child-delay (delay (reduce')),
+        assertion(sub_string(CoreCode, _, _, _, '(def benchmark-data-dir "/')),
+        assertion(sub_string(CoreCode, _, _, _, '(slurp (str benchmark-data-dir "/category_parent.edn"))')),
         assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_parent" :arity 2}')),
         assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_ancestor" :arity 4}')),
         assertion(sub_string(CoreCode, _, _, _, '(def benchmark-use-traversal-kernel? true)')),
@@ -44,25 +69,44 @@ test(generate_seeded_kernels_on_project) :-
 test(generate_seeded_kernels_off_project) :-
     once((
         unique_tmp_dir('tmp_wam_clojure_bench_off', TmpDir),
-        generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_off),
+        generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_off, sidecar),
         directory_file_path(TmpDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
+        directory_file_path(TmpDir, 'data/generated/wam_clojure_optimized_bench/category_parent.edn', CategoryParentPath),
         read_file_to_string(CorePath, CoreCode, []),
+        assertion(exists_file(CategoryParentPath)),
         assertion(sub_string(CoreCode, _, _, _, '(def foreign-handlers {')),
-        assertion(\+ sub_string(CoreCode, _, _, _, '"category_parent/2" (let [edges #{')),
-        assertion(\+ sub_string(CoreCode, _, _, _, '"category_ancestor/4" (let [parents-by-child {')),
+        assertion(\+ sub_string(CoreCode, _, _, _, '"category_parent/2" (let [edges-delay (delay')),
+        assertion(\+ sub_string(CoreCode, _, _, _, '"category_ancestor/4" (let [parents-by-child-delay (delay')),
         assertion(\+ sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_parent" :arity 2}')),
         assertion(\+ sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_ancestor" :arity 4}')),
         assertion(sub_string(CoreCode, _, _, _, '(def benchmark-use-traversal-kernel? false)')),
+        assertion(sub_string(CoreCode, _, _, _, '(def benchmark-data-dir "/')),
         assertion(sub_string(CoreCode, _, _, _, '(benchmark-ancestor-hops category root #{category})')),
         assertion(\+ sub_string(CoreCode, _, _, _, 'benchmark-ancestor-hops-index')),
         assertion(\+ sub_string(CoreCode, _, _, _, 'benchmark-build-ancestor-hops-index')),
         delete_directory_and_contents(TmpDir)
     )).
 
+test(generate_seeded_inline_project) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_bench_inline', TmpDir),
+        generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, inline),
+        directory_file_path(TmpDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
+        directory_file_path(TmpDir, 'data/generated/wam_clojure_optimized_bench/category_parent.edn', CategoryParentPath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(\+ exists_file(CategoryParentPath)),
+        assertion(sub_string(CoreCode, _, _, _, '"category_parent/2" (let [edges #{')),
+        assertion(sub_string(CoreCode, _, _, _, '"category_ancestor/4" (let [parents-by-child {')),
+        assertion(sub_string(CoreCode, _, _, _, '(def benchmark-article-categories-delay (delay [[')),
+        assertion(sub_string(CoreCode, _, _, _, '(def benchmark-category-parents-delay (delay [[')),
+        assertion(sub_string(CoreCode, _, _, _, '(def benchmark-roots-delay (delay [')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
 test(generated_category_parent_handler_executes, [condition(clojure_available)]) :-
     once((
         unique_tmp_dir('tmp_wam_clojure_bench_exec', TmpDir),
-        generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on),
+        generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, sidecar),
         run_clojure_predicate(TmpDir, 'category_parent/2',
                               ['Abstraction', 'Thought'], "true"),
         run_clojure_predicate(TmpDir, 'category_parent/2',
@@ -144,3 +188,9 @@ find_clojure_classpath(ClassPath) :-
         JarPaths),
     JarPaths \= [],
     atomic_list_concat(['src'|JarPaths], :, ClassPath).
+
+maybe_abolish_test_predicate(Name/Arity) :-
+    (   current_predicate(user:Name/Arity)
+    ->  abolish(user:Name/Arity)
+    ;   true
+    ).


### PR DESCRIPTION
## Summary

Externalize Clojure hybrid WAM benchmark relation data into sidecar files and make benchmark preprocessing policy explicit.

This removes the large inline benchmark literals from generated Clojure code, fixes repo-root benchmark matrix launches, and adds a declarative `auto` preprocessing override that is closer to the C# materialization/preprocessing direction.

## What Changed

- externalized benchmark relation data into EDN sidecars for `sidecar` mode
- switched generated benchmark runner sidecar loading to absolute generation-time paths
- switched `kernels_on` foreign handlers to use absolute sidecar paths too
- added explicit benchmark data modes:
  - `auto`
  - `sidecar`
  - `inline`
- made `auto` honor optional workload predicates before the size heuristic:
  - `wam_clojure_benchmark_data_mode/1`
  - `benchmark_data_mode/1`
- kept the scale-favoring default heuristic when no predicate override is present
- updated benchmark-generator tests to cover:
  - sidecar generation
  - inline generation
  - predicate-driven `auto` override
  - repo-root-safe emitted paths
- updated the WAM perf log with the new preprocessing/materialization notes

## Why

At larger scales, the generated Clojure benchmark scaffold was embedding enough literal benchmark data to hit JVM bytecode size limits (`Method code too large!`).

Even after sidecar externalization, the benchmark matrix still failed when launched from the repository root because the generated sidecar paths were cwd-relative. This change fixes that by emitting absolute sidecar paths in the benchmark scaffold and foreign handlers.

The additional declarative preprocessing hook moves the benchmark path closer to the C# runtime's materialization/preprocessing policy style, where workload-local policy can override defaults without changing the harness.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-accumulated,clojure-wam-accumulated-no-kernels,clojure-wam-seeded,clojure-wam-seeded-no-kernels,prolog-accumulated --scales dev --repetitions 1`

## Result

- all benchmark outputs still match digest `1659619c9d36`
- the previous repo-root Clojure matrix launch failure is gone
- Clojure benchmark generation now has a clearer path toward compact preprocessed artifacts beyond EDN sidecars
