### PR TITLE
feat(wam-elixir): cost_aware layout policy + ETS FactSource adaptor

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -389,6 +389,21 @@ builtin_layout_policy(inline_eager, _PredIndicator, _NClauses, FactOnly, _Option
     ->  Layout = inline_data([])
     ;   Layout = compiled
     ).
+builtin_layout_policy(cost_aware, _Pred/Arity, NClauses, FactOnly, Options, Layout) :-
+    % Static cost estimate: NClauses × max(1, Arity). Proxies the
+    % generated-module size since each clause contributes a tuple
+    % of Arity slots. Default threshold 200 keeps the classic
+    % arity-2 /count≥100 boundary (100 × 2 = 200) — same shape as
+    % the `auto` policy for 2-column fact predicates, but smarter
+    % when arity varies (arity-1 stays `compiled` longer; wide
+    % arities flip to `inline_data` sooner).
+    option(fact_cost_threshold(Threshold), Options, 200),
+    Mult is max(1, Arity),
+    CostScore is NClauses * Mult,
+    (   FactOnly == true, CostScore > Threshold
+    ->  Layout = inline_data([])
+    ;   Layout = compiled
+    ).
 
 %% format_fact_shape_comment(+Info, -Comment)
 %  Renders `Info` as an Elixir comment surfaced in the generated

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -1035,6 +1035,43 @@ defmodule WamRuntime.FactSource.Tsv do
   def close(_handle, _state), do: :ok
 end
 
+defmodule WamRuntime.FactSource.Ets do
+  @moduledoc """
+  ETS-table fact source. Lightweight second adaptor that proves the
+  FactSource behaviour is generic — zero external deps (ETS ships
+  with OTP) and a storage shape meaningfully different from the
+  TSV adaptor\'s list-of-tuples. The driver populates the table
+  before registering the source; the adaptor just wraps the table
+  reference and forwards lookups.
+
+  Spec fields:
+    table   — ETS table identifier or named atom (required)
+    arity   — number of columns per tuple (required; only 2 supported)
+
+  Keying convention: arg1 is the ETS key. Use a :bag table if a
+  single arg1 can map to multiple tuples (e.g. `category_parent/2`);
+  :set tables are fine for unique-key predicates.
+  """
+  @behaviour WamRuntime.FactSource
+  defstruct [:table, :arity]
+
+  @impl true
+  def open(%{table: table, arity: arity}, _pred_arity, _state) when arity == 2 do
+    %__MODULE__{table: table, arity: arity}
+  end
+
+  @impl true
+  def stream_all(%__MODULE__{table: table}, _state), do: :ets.tab2list(table)
+
+  @impl true
+  def lookup_by_arg1(%__MODULE__{table: table}, key, _state) do
+    :ets.lookup(table, key)
+  end
+
+  @impl true
+  def close(_handle, _state), do: :ok
+end
+
 defmodule WamRuntime.FactSourceRegistry do
   @moduledoc """
   Predicate-indicator → source-handle map. Uses :persistent_term so

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -603,6 +603,64 @@ test_phase_e_user_override_preempts_policy :-
     ;   fail_test(Test, Layout)
     ).
 
+%% cost_aware policy tests
+
+test_cost_aware_promotes_big_fact_set :-
+    Test = 'cost_aware: 150-clause arity-2 (score 300) > default threshold 200 → inline_data',
+    phase_a_fixture_setup,
+    compile_and_segments(big_fact/2, Segs),
+    classify_predicate(big_fact/2, Segs, [fact_layout_policy(cost_aware)],
+                       fact_shape_info(_, _, _, Layout)),
+    (   Layout = inline_data(_)
+    ->  pass(Test)
+    ;   fail_test(Test, Layout)
+    ).
+
+test_cost_aware_keeps_small_preds_compiled :-
+    Test = 'cost_aware: 4-clause arity-2 (score 8) < default threshold → compiled',
+    phase_a_fixture_setup,
+    compile_and_segments(small_fact/2, Segs),
+    classify_predicate(small_fact/2, Segs, [fact_layout_policy(cost_aware)],
+                       fact_shape_info(_, _, _, Layout)),
+    (   Layout == compiled
+    ->  pass(Test)
+    ;   fail_test(Test, Layout)
+    ).
+
+test_cost_aware_threshold_override :-
+    Test = 'cost_aware: fact_cost_threshold(5) promotes 4-clause predicate (score 8 > 5)',
+    phase_a_fixture_setup,
+    compile_and_segments(small_fact/2, Segs),
+    classify_predicate(small_fact/2, Segs,
+                       [fact_layout_policy(cost_aware), fact_cost_threshold(5)],
+                       fact_shape_info(_, _, _, Layout)),
+    (   Layout = inline_data(_)
+    ->  pass(Test)
+    ;   fail_test(Test, Layout)
+    ).
+
+test_cost_aware_respects_fact_only :-
+    Test = 'cost_aware: rule-bearing predicate stays compiled regardless of score',
+    phase_a_fixture_setup,
+    compile_and_segments(rule/2, Segs),
+    classify_predicate(rule/2, Segs,
+                       [fact_layout_policy(cost_aware), fact_cost_threshold(1)],
+                       fact_shape_info(_, _, _, Layout)),
+    (   Layout == compiled
+    ->  pass(Test)
+    ;   fail_test(Test, Layout)
+    ).
+
+test_ets_adaptor_emitted_in_runtime :-
+    Test = 'ETS adaptor: runtime assembly emits FactSource.Ets',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    (   sub_string(RuntimeCode, _, _, _, 'defmodule WamRuntime.FactSource.Ets do'),
+        sub_string(RuntimeCode, _, _, _, ':ets.tab2list'),
+        sub_string(RuntimeCode, _, _, _, ':ets.lookup')
+    ->  pass(Test)
+    ;   fail_test(Test, 'ETS adaptor missing from emitted runtime')
+    ).
+
 %% Test runner
 
 run_tests :-
@@ -653,5 +711,10 @@ run_tests :-
     test_phase_e_inline_eager_ignores_threshold,
     test_phase_e_inline_eager_respects_fact_only,
     test_phase_e_user_override_preempts_policy,
+    test_cost_aware_promotes_big_fact_set,
+    test_cost_aware_keeps_small_preds_compiled,
+    test_cost_aware_threshold_override,
+    test_cost_aware_respects_fact_only,
+    test_ets_adaptor_emitted_in_runtime,
     format('~n=== WAM-Elixir Target Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).


### PR DESCRIPTION
## Summary

Two small follow-ups to the Phase D / E fact-shape work, both
plugging into existing extensibility seams without adding new
emitter branches:

1. A `cost_aware` built-in layout policy that factors arity into the
   `compiled` ↔ `inline_data` decision. Pluggable via the Phase-E
   policy hook.
2. A second concrete `WamRuntime.FactSource` adaptor — `Ets` —
   that proves the behaviour introduced in Phase D is actually
   generic (not just a TSV contract).

## Why

- **cost_aware:** the Phase-E `auto` policy uses plain clause count.
  That's a fine proxy for arity-2 predicates (which dominate our
  corpus) but understates size for wider predicates and overstates
  it for arity-1. Factoring in arity gives a better
  generated-module-size proxy without any new measurement machinery.
- **ETS adaptor:** the Phase-D behaviour has shipped with exactly
  one implementer (TSV), and "generic contract with one implementer"
  is easy to accidentally tailor. A second, differently-shaped
  adaptor (in-memory, ref-addressable, `:bag` for multi-value keys)
  confirms the contract actually generalises. ETS is picked over
  SQLite because it's part of OTP — no new dep.

## What's in this PR

### `cost_aware` policy

```prolog
builtin_layout_policy(cost_aware, _Pred/Arity, NClauses, FactOnly, Options, Layout) :-
    option(fact_cost_threshold(Threshold), Options, 200),
    Mult is max(1, Arity),
    CostScore is NClauses * Mult,
    (   FactOnly == true, CostScore > Threshold
    ->  Layout = inline_data([])
    ;   Layout = compiled
    ).
```

Score formula: `NClauses × max(1, Arity)`. Default threshold 200
keeps the classic count≥100 boundary for arity-2 predicates
(100 × 2 = 200). Arity-1 predicates stay `compiled` longer; wide
arities flip sooner.

Behaviour delta vs `auto` at the default threshold:

| Pred           | count | arity | score | `auto`        | `cost_aware`  |
| -------------- | ----- | ----- | ----- | ------------- | ------------- |
| small fact set |     4 |     2 |     8 | compiled      | compiled      |
| big fact set   |   150 |     2 |   300 | inline_data   | inline_data   |
| skinny (a/1)   |   150 |     1 |   150 | inline_data   | **compiled**  |
| wide (a/6)     |    50 |     6 |   300 | compiled      | **inline_data** |

`fact_cost_threshold/1` option lets callers tune per-project.
Opt-in via `fact_layout_policy(cost_aware)`; `auto` remains the
default, so no existing generated code changes.

### `WamRuntime.FactSource.Ets`

Sibling adaptor to `WamRuntime.FactSource.Tsv`, same behaviour:

```elixir
defmodule WamRuntime.FactSource.Ets do
  @behaviour WamRuntime.FactSource
  defstruct [:table, :arity]

  @impl true
  def open(%{table: table, arity: 2}, _pred_arity, _state),
    do: %__MODULE__{table: table, arity: 2}

  @impl true
  def stream_all(%__MODULE__{table: table}, _state),
    do: :ets.tab2list(table)

  @impl true
  def lookup_by_arg1(%__MODULE__{table: table}, key, _state),
    do: :ets.lookup(table, key)

  @impl true
  def close(_handle, _state), do: :ok
end
```

Driver registration is the same as TSV — populate the ETS table,
open the handle, register:

```elixir
tab = :ets.new(:cp_facts, [:bag, :public, :named_table])
:ets.insert(tab, {"a", "b"})
:ets.insert(tab, {"b", "c"})

WamRuntime.FactSourceRegistry.register(
  "cp/2",
  WamRuntime.FactSource.Ets.open(%{table: tab, arity: 2}, 2, nil)
)
```

`:bag` supports multiple values per key (natural for
`category_parent/2`-style predicates); `:set` is fine for unique
keys. The adaptor doesn't care.

## Test plan

- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_target.pl`
      — **51/51** (46 prior + 5 new).
- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_utils.pl`
      — 7/7.
- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_target.pl` — 7/7.
- [x] `swipl -q -s examples/debug_wam_elixir_ancestor.pl -t halt` —
      4/1/4 (reproducer unchanged — `auto` still default).
- [x] End-to-end ETS probe:
      - `cp("b", Y)` via ETS-backed source → `Y="c"`.
      - `ancestor("a", Y)` via compiled CPS + ETS-backed `cp` →
        4 correct solutions, backtracking intact.

New tests:

1. `cost_aware` promotes 150-clause arity-2 to `inline_data` (score
   300 > 200).
2. `cost_aware` keeps 4-clause arity-2 as `compiled` (score 8 < 200).
3. `cost_aware` respects `fact_cost_threshold(5)` override.
4. `cost_aware` still forces rule-bearing predicates to `compiled`
   regardless of score.
5. Runtime assembly emits the `WamRuntime.FactSource.Ets` module with
   `:ets.tab2list` and `:ets.lookup` calls.

## Non-goals

- **Measurement-driven auto-tuning** of the cost threshold. Still
  deferred from Phase E — needs a representative corpus +
  measurement harness separate from this PR.
- **SQLite adaptor.** ETS covers the genericness check without
  pulling in `:exqlite`. A SQLite adaptor is a clean follow-up
  (same behaviour, new file).
- **Auto-selecting `external_source`.** The emitter can't verify a
  source is registered at codegen time, so auto-selection would
  silently break drivers. `external_source` stays user-opt-in.

## Related

- PR #1551 — Phase D `FactSource` behaviour + TSV adaptor.
- PR #1555 — Phase E pluggable layout policy this extends.
- PR #1556 — docs: plan status (lists the deferred items this PR
  partially addresses).
- `docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md` — broader
  artifact direction the FactSource behaviour maps onto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
