### PR TITLE
feat(wam-clojure): add benchmark artifact mode

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -485,3 +485,23 @@ lessons for externalized/preprocessed predicate data:
 That moves the Clojure benchmark path closer to the C# materialization
 direction: policy can live with the workload, while the default still
 favors scaling safely.
+
+The next Clojure benchmark step added an explicit `artifact` mode beside
+`sidecar` and `inline`. The first artifact shape precomputes
+`category_parent_by_child` and `article_category_by_article` EDN maps so
+the generated runner and `category_ancestor/4` foreign handler can skip
+their startup regrouping pass.
+
+Initial Termux `dev` measurements were mixed rather than a clear win:
+
+- `clojure-wam-accumulated`: `1.867s`
+- `clojure-wam-accumulated-artifact`: `1.852s`
+- `clojure-wam-seeded`: `1.846s`
+- `clojure-wam-seeded-artifact`: `2.250s`
+
+All outputs still matched digest `1659619c9d36`, but these numbers are
+not strong enough to justify changing the default heuristic away from
+`sidecar`. The artifact path is valuable as an explicit comparison mode
+and as groundwork for more compact non-EDN preprocessing, but it still
+needs better desktop measurements and probably a denser artifact format
+before it should become the default.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -125,7 +125,7 @@ The Clojure hybrid-WAM target now has an optimized-project generator:
 
 ```bash
 swipl -q -s examples/benchmark/generate_wam_clojure_optimized_benchmark.pl -- \
-  data/benchmark/dev/facts.pl /tmp/wam-clojure-bench seeded kernels_on
+  data/benchmark/dev/facts.pl /tmp/wam-clojure-bench seeded kernels_on sidecar
 ```
 
 Supported modes:
@@ -137,6 +137,16 @@ Supported modes:
   result-producing runner also precomputes a native Clojure ancestor-hop index.
 - `kernels_off` forces the pure-WAM scaffold with `no_kernels(true)` and keeps
   the result-producing runner on the on-demand traversal path.
+
+The generator accepts benchmark data modes:
+
+- `inline`: embed benchmark relations directly in the generated namespace
+- `sidecar`: externalize benchmark relation rows into EDN sidecars
+- `artifact`: externalize preprocessed EDN artifacts such as
+  `category_parent_by_child` and `article_category_by_article`
+- `auto`: honor an optional workload predicate
+  (`wam_clojure_benchmark_data_mode/1` or `benchmark_data_mode/1`) and
+  otherwise fall back to the current scale-favoring heuristic
 
 The generated project supports two entry modes:
 
@@ -156,6 +166,14 @@ modes as result-producing `hybrid-wam` targets:
 - `clojure-wam-seeded-no-kernels`
 
 These targets provide both seeded/accumulated and kernel-on/off comparisons.
+
+Artifact-vs-sidecar Clojure comparisons are available through the
+`clojure-wam-artifact` target set, which adds:
+
+- `clojure-wam-accumulated-artifact`
+- `clojure-wam-accumulated-no-kernels-artifact`
+- `clojure-wam-seeded-artifact`
+- `clojure-wam-seeded-no-kernels-artifact`
 
 ### Why Seeded Closures Win
 

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -267,7 +267,9 @@ def clojure_classpath(project_dir: Path) -> str:
     return ":".join([str(project_dir / "src"), *(str(path) for path in existing_jars)])
 
 
-def build_wam_clojure_effective_distance(root: Path, scale: str, variant: str, kernel_mode: str) -> list[str]:
+def build_wam_clojure_effective_distance(
+    root: Path, scale: str, variant: str, kernel_mode: str, data_mode: str = "sidecar"
+) -> list[str]:
     facts_path = require_file(BENCH_DIR / scale / "facts.pl")
     project_dir = root / f"wam_clojure_{variant}_{kernel_mode}" / scale
     project_dir.mkdir(parents=True, exist_ok=True)
@@ -282,6 +284,7 @@ def build_wam_clojure_effective_distance(root: Path, scale: str, variant: str, k
             str(project_dir),
             variant,
             kernel_mode,
+            data_mode,
         ],
         cwd=ROOT,
     )
@@ -691,10 +694,26 @@ def main() -> int:
                     command = build_wam_clojure_effective_distance(temp_root, scale, "accumulated", "kernels_on")
                 elif target == "clojure-wam-accumulated-no-kernels":
                     command = build_wam_clojure_effective_distance(temp_root, scale, "accumulated", "kernels_off")
+                elif target == "clojure-wam-accumulated-artifact":
+                    command = build_wam_clojure_effective_distance(
+                        temp_root, scale, "accumulated", "kernels_on", "artifact"
+                    )
+                elif target == "clojure-wam-accumulated-no-kernels-artifact":
+                    command = build_wam_clojure_effective_distance(
+                        temp_root, scale, "accumulated", "kernels_off", "artifact"
+                    )
                 elif target == "clojure-wam-seeded":
                     command = build_wam_clojure_effective_distance(temp_root, scale, "seeded", "kernels_on")
                 elif target == "clojure-wam-seeded-no-kernels":
                     command = build_wam_clojure_effective_distance(temp_root, scale, "seeded", "kernels_off")
+                elif target == "clojure-wam-seeded-artifact":
+                    command = build_wam_clojure_effective_distance(
+                        temp_root, scale, "seeded", "kernels_on", "artifact"
+                    )
+                elif target == "clojure-wam-seeded-no-kernels-artifact":
+                    command = build_wam_clojure_effective_distance(
+                        temp_root, scale, "seeded", "kernels_off", "artifact"
+                    )
                 else:
                     command = commands[target]
                 results.append(benchmark_target(command, scale, args.repetitions, target))

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -74,6 +74,16 @@ TARGETS: dict[str, TargetInfo] = {
         "hybrid-wam",
         "Hybrid WAM Clojure generated project with seeded helpers and no_kernels(true)",
     ),
+    "clojure-wam-seeded-artifact": TargetInfo(
+        "clojure-wam-seeded-artifact",
+        "hybrid-wam",
+        "Hybrid WAM Clojure generated project with seeded helpers, kernels enabled, and preprocessed artifact data",
+    ),
+    "clojure-wam-seeded-no-kernels-artifact": TargetInfo(
+        "clojure-wam-seeded-no-kernels-artifact",
+        "hybrid-wam",
+        "Hybrid WAM Clojure generated project with seeded helpers, no_kernels(true), and preprocessed artifact data",
+    ),
     "clojure-wam-accumulated": TargetInfo(
         "clojure-wam-accumulated",
         "hybrid-wam",
@@ -83,6 +93,16 @@ TARGETS: dict[str, TargetInfo] = {
         "clojure-wam-accumulated-no-kernels",
         "hybrid-wam",
         "Hybrid WAM Clojure generated project with optimized accumulated helpers and no_kernels(true)",
+    ),
+    "clojure-wam-accumulated-artifact": TargetInfo(
+        "clojure-wam-accumulated-artifact",
+        "hybrid-wam",
+        "Hybrid WAM Clojure generated project with optimized accumulated helpers, kernels enabled, and preprocessed artifact data",
+    ),
+    "clojure-wam-accumulated-no-kernels-artifact": TargetInfo(
+        "clojure-wam-accumulated-no-kernels-artifact",
+        "hybrid-wam",
+        "Hybrid WAM Clojure generated project with optimized accumulated helpers, no_kernels(true), and preprocessed artifact data",
     ),
     "haskell-pure-interp": TargetInfo(
         "haskell-pure-interp",
@@ -139,6 +159,16 @@ TARGET_SETS: dict[str, list[str]] = {
         "clojure-wam-seeded",
         "clojure-wam-seeded-no-kernels",
         "clojure-wam-accumulated-no-kernels",
+    ],
+    "clojure-wam-artifact": [
+        "clojure-wam-accumulated",
+        "clojure-wam-accumulated-artifact",
+        "clojure-wam-accumulated-no-kernels",
+        "clojure-wam-accumulated-no-kernels-artifact",
+        "clojure-wam-seeded",
+        "clojure-wam-seeded-artifact",
+        "clojure-wam-seeded-no-kernels",
+        "clojure-wam-seeded-no-kernels-artifact",
     ],
     "direct-pipeline": [
         "rust-dfs",

--- a/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
@@ -30,7 +30,7 @@
 %% Usage:
 %%   swipl -q -s generate_wam_clojure_optimized_benchmark.pl -- \
 %%       <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off]
-%%       [auto|sidecar|inline]
+%%       [auto|sidecar|artifact|inline]
 
 benchmark_workload_path(Path) :-
     source_file(benchmark_workload_path(_), ThisFile),
@@ -54,7 +54,7 @@ main :-
         KernelModeAtom = kernels_on,
         DataModeAtom = auto
     ;   format(user_error,
-            'Usage: ... -- <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off] [auto|sidecar|inline]~n',
+            'Usage: ... -- <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off] [auto|sidecar|artifact|inline]~n',
             []),
         halt(1)
     ),
@@ -184,6 +184,7 @@ parse_kernel_mode(_OutputDir, kernels_off, _DataMode, [
 ]).
 
 parse_benchmark_data_mode(sidecar, sidecar).
+parse_benchmark_data_mode(artifact, artifact).
 parse_benchmark_data_mode(inline, inline).
 parse_benchmark_data_mode(auto, Mode) :-
     (   benchmark_declared_data_mode(DeclaredMode),
@@ -204,7 +205,7 @@ benchmark_declared_data_mode(Mode) :-
     current_predicate(user:Name/1),
     Goal =.. [Name, DeclaredMode],
     once(call(user:Goal)),
-    memberchk(DeclaredMode, [auto, sidecar, inline]),
+    memberchk(DeclaredMode, [auto, sidecar, artifact, inline]),
     Mode = DeclaredMode.
 
 benchmark_fact_volume(RowCount) :-
@@ -227,11 +228,20 @@ category_parent_handler_code(OutputDir, sidecar, HandlerCode) :-
     format(string(HandlerCode),
            "(let [edges-delay (delay (set (edn/read-string (slurp ~w))))] (fn [args] (contains? @edges-delay [(nth args 0) (nth args 1)])))",
            [CategoryParentPath]).
+category_parent_handler_code(OutputDir, artifact, HandlerCode) :-
+    benchmark_sidecar_file_path_literal(OutputDir, 'category_parent_by_child.edn', CategoryParentMapPath),
+    format(string(HandlerCode),
+           "(let [parents-by-child-delay (delay (edn/read-string (slurp ~w)))] (fn [args] (let [child (nth args 0) parent (nth args 1)] (boolean (some #(= parent %) (get @parents-by-child-delay child []))))))",
+           [CategoryParentMapPath]).
 category_parent_handler_code(_OutputDir, inline, HandlerCode) :-
     category_parent_handler_code(inline, HandlerCode).
 category_parent_handler_code(sidecar, HandlerCode) :-
     format(string(HandlerCode),
            "(let [edges-delay (delay (set (edn/read-string (slurp \"data/generated/wam_clojure_optimized_bench/category_parent.edn\"))))] (fn [args] (contains? @edges-delay [(nth args 0) (nth args 1)])))",
+           []).
+category_parent_handler_code(artifact, HandlerCode) :-
+    format(string(HandlerCode),
+           "(let [parents-by-child-delay (delay (edn/read-string (slurp \"data/generated/wam_clojure_optimized_bench/category_parent_by_child.edn\")))] (fn [args] (let [child (nth args 0) parent (nth args 1)] (boolean (some #(= parent %) (get @parents-by-child-delay child []))))))",
            []).
 category_parent_handler_code(inline, HandlerCode) :-
     findall(Child-Parent,
@@ -254,12 +264,23 @@ category_ancestor_handler_code(OutputDir, sidecar, HandlerCode) :-
     format(string(HandlerCode),
            "(let [parents-by-child-delay (delay (reduce (fn [acc [child parent]] (update acc child (fnil conj []) parent)) {} (edn/read-string (slurp ~w)))) max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (get @parents-by-child-delay category [])] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] {:solutions (vec solutions)})))",
            [CategoryParentPath, MaxDepth]).
+category_ancestor_handler_code(OutputDir, artifact, HandlerCode) :-
+    benchmark_max_depth_literal(MaxDepth),
+    benchmark_sidecar_file_path_literal(OutputDir, 'category_parent_by_child.edn', CategoryParentMapPath),
+    format(string(HandlerCode),
+           "(let [parents-by-child-delay (delay (edn/read-string (slurp ~w))) max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (get @parents-by-child-delay category [])] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] {:solutions (vec solutions)})))",
+           [CategoryParentMapPath, MaxDepth]).
 category_ancestor_handler_code(_OutputDir, inline, HandlerCode) :-
     category_ancestor_handler_code(inline, HandlerCode).
 category_ancestor_handler_code(sidecar, HandlerCode) :-
     benchmark_max_depth_literal(MaxDepth),
     format(string(HandlerCode),
            "(let [parents-by-child-delay (delay (reduce (fn [acc [child parent]] (update acc child (fnil conj []) parent)) {} (edn/read-string (slurp \"data/generated/wam_clojure_optimized_bench/category_parent.edn\")))) max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (get @parents-by-child-delay category [])] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] {:solutions (vec solutions)})))",
+           [MaxDepth]).
+category_ancestor_handler_code(artifact, HandlerCode) :-
+    benchmark_max_depth_literal(MaxDepth),
+    format(string(HandlerCode),
+           "(let [parents-by-child-delay (delay (edn/read-string (slurp \"data/generated/wam_clojure_optimized_bench/category_parent_by_child.edn\"))) max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (get @parents-by-child-delay category [])] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] {:solutions (vec solutions)})))",
            [MaxDepth]).
 category_ancestor_handler_code(inline, HandlerCode) :-
     benchmark_max_depth_literal(MaxDepth),
@@ -324,6 +345,7 @@ effective_distance_runner_code(OutputDir, KernelModeAtom, DataMode, BenchmarkDat
     benchmark_article_categories_code(DataMode, DataDirLiteral, BenchmarkData, ArticleCategoriesCode),
     benchmark_category_parents_code(DataMode, DataDirLiteral, BenchmarkData, CategoryParentsCode),
     benchmark_roots_code(DataMode, DataDirLiteral, BenchmarkData, RootsCode),
+    benchmark_derived_state_code(DataMode, DerivedStateCode),
     format(string(Code),
 '
 ;; Effective-distance benchmark entrypoint generated from facts.pl.
@@ -332,26 +354,10 @@ effective_distance_runner_code(OutputDir, KernelModeAtom, DataMode, BenchmarkDat
 ~s
 ~s
 ~s
+~s
 (def benchmark-dimension-n ~w)
 (def benchmark-max-depth ~w)
 (def benchmark-use-traversal-kernel? ~w)
-
-(def benchmark-parents-by-child-delay
-  (delay
-    (reduce (fn [acc [child parent]]
-              (update acc child (fnil conj []) parent))
-            {}
-            @benchmark-category-parents-delay)))
-
-(def benchmark-article-categories-by-article-delay
-  (delay
-    (reduce (fn [acc [article category]]
-              (update acc article (fnil conj []) category))
-            {}
-            @benchmark-article-categories-delay)))
-
-(def benchmark-seed-categories-delay
-  (delay (sort (set (map second @benchmark-article-categories-delay)))))
 
 (defn benchmark-ancestor-hops [category root visited]
   (let [parents (get @benchmark-parents-by-child-delay category [])]
@@ -427,13 +433,37 @@ effective_distance_runner_code(OutputDir, KernelModeAtom, DataMode, BenchmarkDat
       (println (invoke-predicate pred-key (mapv edn/read-string pred-args))))
     (run-effective-distance-benchmark)))
 ',
-           [DataDirLiteral, ArticleCategoriesCode, CategoryParentsCode, RootsCode,
+           [DataDirLiteral, ArticleCategoriesCode, CategoryParentsCode, RootsCode, DerivedStateCode,
             DimensionN, MaxDepth, UseTraversalKernel]).
+
+benchmark_derived_state_code(artifact, Code) :-
+    Code = '(def benchmark-seed-categories-delay
+  (delay (sort (set (mapcat identity (vals @benchmark-article-categories-by-article-delay))))))'.
+benchmark_derived_state_code(_DataMode, Code) :-
+    Code = '(def benchmark-parents-by-child-delay
+  (delay
+    (reduce (fn [acc [child parent]]
+              (update acc child (fnil conj []) parent))
+            {}
+            @benchmark-category-parents-delay)))
+
+(def benchmark-article-categories-by-article-delay
+  (delay
+    (reduce (fn [acc [article category]]
+              (update acc article (fnil conj []) category))
+            {}
+            @benchmark-article-categories-delay)))
+
+(def benchmark-seed-categories-delay
+  (delay (sort (set (map second @benchmark-article-categories-delay)))))'.
 
 benchmark_article_categories_code(sidecar, _DataDirLiteral, _BenchmarkData, Code) :-
     Code = '(def benchmark-article-categories-delay
   (delay (vec (edn/read-string (slurp (str benchmark-data-dir "/article_category.edn"))))))'.
-benchmark_article_categories_code(inline, _DataDirLiteral, benchmark_data(ArticleCategories, _, _, _, _, _), Code) :-
+benchmark_article_categories_code(artifact, _DataDirLiteral, _BenchmarkData, Code) :-
+    Code = '(def benchmark-article-categories-by-article-delay
+  (delay (edn/read-string (slurp (str benchmark-data-dir "/article_category_by_article.edn")))))'.
+benchmark_article_categories_code(inline, _DataDirLiteral, benchmark_data(ArticleCategories, _, _, _, _, _, _, _), Code) :-
     format(string(Code),
            "(def benchmark-article-categories-delay (delay [~s]))",
            [ArticleCategories]).
@@ -441,7 +471,10 @@ benchmark_article_categories_code(inline, _DataDirLiteral, benchmark_data(Articl
 benchmark_category_parents_code(sidecar, _DataDirLiteral, _BenchmarkData, Code) :-
     Code = '(def benchmark-category-parents-delay
   (delay (vec (edn/read-string (slurp (str benchmark-data-dir "/category_parent.edn"))))))'.
-benchmark_category_parents_code(inline, _DataDirLiteral, benchmark_data(_, CategoryParents, _, _, _, _), Code) :-
+benchmark_category_parents_code(artifact, _DataDirLiteral, _BenchmarkData, Code) :-
+    Code = '(def benchmark-parents-by-child-delay
+  (delay (edn/read-string (slurp (str benchmark-data-dir "/category_parent_by_child.edn")))))'.
+benchmark_category_parents_code(inline, _DataDirLiteral, benchmark_data(_, CategoryParents, _, _, _, _, _, _), Code) :-
     format(string(Code),
            "(def benchmark-category-parents-delay (delay [~s]))",
            [CategoryParents]).
@@ -449,12 +482,18 @@ benchmark_category_parents_code(inline, _DataDirLiteral, benchmark_data(_, Categ
 benchmark_roots_code(sidecar, _DataDirLiteral, _BenchmarkData, Code) :-
     Code = '(def benchmark-roots-delay
   (delay (vec (edn/read-string (slurp (str benchmark-data-dir "/root_category.edn"))))))'.
-benchmark_roots_code(inline, _DataDirLiteral, benchmark_data(_, _, RootCategories, _, _, _), Code) :-
+benchmark_roots_code(artifact, _DataDirLiteral, _BenchmarkData, Code) :-
+    Code = '(def benchmark-roots-delay
+  (delay (vec (edn/read-string (slurp (str benchmark-data-dir "/root_category.edn"))))))'.
+benchmark_roots_code(inline, _DataDirLiteral, benchmark_data(_, _, RootCategories, _, _, _, _, _), Code) :-
     format(string(Code),
            "(def benchmark-roots-delay (delay [~s]))",
            [RootCategories]).
 
 maybe_write_benchmark_sidecar_files(OutputDir, sidecar, BenchmarkData) :-
+    !,
+    write_benchmark_sidecar_files(OutputDir, BenchmarkData).
+maybe_write_benchmark_sidecar_files(OutputDir, artifact, BenchmarkData) :-
     !,
     write_benchmark_sidecar_files(OutputDir, BenchmarkData).
 maybe_write_benchmark_sidecar_files(_, inline, _).
@@ -463,7 +502,9 @@ write_benchmark_sidecar_files(OutputDir, BenchmarkData) :-
     benchmark_sidecar_dir(OutputDir, DataDir),
     make_directory_path(DataDir),
     write_benchmark_sidecar_file(DataDir, 'article_category.edn', BenchmarkData, benchmark_article_category_edn),
+    write_benchmark_sidecar_file(DataDir, 'article_category_by_article.edn', BenchmarkData, benchmark_article_category_by_article_edn),
     write_benchmark_sidecar_file(DataDir, 'category_parent.edn', BenchmarkData, benchmark_category_parent_edn),
+    write_benchmark_sidecar_file(DataDir, 'category_parent_by_child.edn', BenchmarkData, benchmark_category_parent_by_child_edn),
     write_benchmark_sidecar_file(DataDir, 'root_category.edn', BenchmarkData, benchmark_root_category_edn).
 
 benchmark_sidecar_dir(OutputDir, DataDir) :-
@@ -492,13 +533,16 @@ write_benchmark_sidecar_file(DataDir, FileName, BenchmarkData, Builder) :-
     ).
 
 collect_benchmark_data(benchmark_data(ArticleCategories, CategoryParents, RootCategories,
-                                      ArticleEdn, CategoryEdn, RootEdn)) :-
+                                      ArticleEdn, CategoryEdn, RootEdn,
+                                      ArticleByArticleEdn, ParentByChildEdn)) :-
     benchmark_article_category_literal(ArticleCategories),
     benchmark_category_parent_literal(CategoryParents),
     benchmark_root_category_literal(RootCategories),
     benchmark_article_category_edn_from_literal(ArticleCategories, ArticleEdn),
     benchmark_category_parent_edn_from_literal(CategoryParents, CategoryEdn),
-    benchmark_root_category_edn_from_literal(RootCategories, RootEdn).
+    benchmark_root_category_edn_from_literal(RootCategories, RootEdn),
+    benchmark_article_category_by_article_edn(ArticleByArticleEdn),
+    benchmark_category_parent_by_child_edn(ParentByChildEdn).
 
 benchmark_use_traversal_kernel_literal(kernels_on, true).
 benchmark_use_traversal_kernel_literal(kernels_off, false).
@@ -511,7 +555,7 @@ benchmark_article_category_literal(Literal) :-
     maplist(edge_literal, Pairs, Literals),
     atomic_list_concat(Literals, ' ', Literal).
 
-benchmark_article_category_edn(benchmark_data(_, _, _, Content, _, _), Content).
+benchmark_article_category_edn(benchmark_data(_, _, _, Content, _, _, _, _), Content).
 
 benchmark_article_category_edn_from_literal(Literal, Content) :-
     format(atom(Content), '[~w]', [Literal]).
@@ -524,7 +568,30 @@ benchmark_category_parent_literal(Literal) :-
     maplist(edge_literal, Pairs, Literals),
     atomic_list_concat(Literals, ' ', Literal).
 
-benchmark_category_parent_edn(benchmark_data(_, _, _, _, Content, _), Content).
+benchmark_article_category_by_article_edn(Content) :-
+    benchmark_article_category_by_article_literal(Literal),
+    format(atom(Content), '{~w}', [Literal]).
+benchmark_article_category_by_article_edn(benchmark_data(_, _, _, _, _, _, Content, _), Content).
+
+benchmark_article_category_by_article_literal(Literal) :-
+    findall(Article,
+            current_article_category_fact(Article, _),
+            Articles0),
+    sort(Articles0, Articles),
+    maplist(article_category_bucket_literal, Articles, BucketLiterals),
+    atomic_list_concat(BucketLiterals, ' ', Literal).
+
+article_category_bucket_literal(Article, Literal) :-
+    findall(Category,
+            current_article_category_fact(Article, Category),
+            Categories0),
+    sort(Categories0, Categories),
+    clj_string_literal_local(Article, ArticleLit),
+    maplist(clj_string_literal_local, Categories, CategoryLiterals),
+    atomic_list_concat(CategoryLiterals, ' ', CategoryBody),
+    format(atom(Literal), '~w [~w]', [ArticleLit, CategoryBody]).
+
+benchmark_category_parent_edn(benchmark_data(_, _, _, _, Content, _, _, _), Content).
 
 benchmark_category_parent_edn_from_literal(Literal, Content) :-
     format(atom(Content), '[~w]', [Literal]).
@@ -535,7 +602,12 @@ benchmark_root_category_literal(Literal) :-
     maplist(clj_string_literal_local, Roots, Literals),
     atomic_list_concat(Literals, ' ', Literal).
 
-benchmark_root_category_edn(benchmark_data(_, _, _, _, _, Content), Content).
+benchmark_category_parent_by_child_edn(Content) :-
+    category_parent_map_literal(Literal),
+    format(atom(Content), '{~w}', [Literal]).
+benchmark_category_parent_by_child_edn(benchmark_data(_, _, _, _, _, _, _, Content), Content).
+
+benchmark_root_category_edn(benchmark_data(_, _, _, _, _, Content, _, _), Content).
 
 benchmark_root_category_edn_from_literal(Literal, Content) :-
     format(atom(Content), '[~w]', [Literal]).

--- a/tests/test_wam_clojure_benchmark_generator.pl
+++ b/tests/test_wam_clojure_benchmark_generator.pl
@@ -15,6 +15,7 @@ test(kernel_mode_options) :-
 
 test(data_mode_options) :-
     parse_benchmark_data_mode(sidecar, sidecar),
+    parse_benchmark_data_mode(artifact, artifact),
     parse_benchmark_data_mode(inline, inline),
     setup_call_cleanup(
         load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
@@ -25,9 +26,9 @@ test(data_mode_options) :-
 test(data_mode_predicate_override) :-
     setup_call_cleanup(
         ( load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
-          assertz(user:wam_clojure_benchmark_data_mode(inline))
+          assertz(user:wam_clojure_benchmark_data_mode(artifact))
         ),
-        assertion(parse_benchmark_data_mode(auto, inline)),
+        assertion(parse_benchmark_data_mode(auto, artifact)),
         maybe_abolish_test_predicate(wam_clojure_benchmark_data_mode/1)
     ).
 
@@ -103,10 +104,29 @@ test(generate_seeded_inline_project) :-
         delete_directory_and_contents(TmpDir)
     )).
 
+test(generate_seeded_artifact_project) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_bench_artifact', TmpDir),
+        generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, artifact),
+        directory_file_path(TmpDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
+        directory_file_path(TmpDir, 'data/generated/wam_clojure_optimized_bench/category_parent_by_child.edn', ParentByChildPath),
+        directory_file_path(TmpDir, 'data/generated/wam_clojure_optimized_bench/article_category_by_article.edn', ArticleByArticlePath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(exists_file(ParentByChildPath)),
+        assertion(exists_file(ArticleByArticlePath)),
+        assertion(sub_string(CoreCode, _, _, _, '"category_parent/2" (let [parents-by-child-delay (delay (edn/read-string (slurp "/')),
+        assertion(sub_string(CoreCode, _, _, _, '"category_ancestor/4" (let [parents-by-child-delay (delay (edn/read-string (slurp "/')),
+        assertion(sub_string(CoreCode, _, _, _, '(def benchmark-article-categories-by-article-delay')),
+        assertion(sub_string(CoreCode, _, _, _, '(def benchmark-parents-by-child-delay')),
+        assertion(\+ sub_string(CoreCode, _, _, _, '(def benchmark-category-parents-delay')),
+        assertion(\+ sub_string(CoreCode, _, _, _, '(def benchmark-article-categories-delay')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
 test(generated_category_parent_handler_executes, [condition(clojure_available)]) :-
     once((
         unique_tmp_dir('tmp_wam_clojure_bench_exec', TmpDir),
-        generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, sidecar),
+        generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, artifact),
         run_clojure_predicate(TmpDir, 'category_parent/2',
                               ['Abstraction', 'Thought'], "true"),
         run_clojure_predicate(TmpDir, 'category_parent/2',


### PR DESCRIPTION
## Summary

Add an explicit `artifact` benchmark data mode for the Clojure hybrid WAM benchmark generator.

This extends the existing `inline` and `sidecar` modes with a first preprocessed-artifact path that writes grouped EDN maps for the hot benchmark relations and teaches both the generated runner and foreign handlers to consume them directly.

## What Changed

- added `artifact` as a supported Clojure benchmark data mode
- kept `auto`, `sidecar`, and `inline` behavior intact
- added preprocessed benchmark artifacts:
  - `category_parent_by_child.edn`
  - `article_category_by_article.edn`
- updated `category_parent/2` foreign handlers to use `category_parent_by_child.edn` in artifact mode
- updated `category_ancestor/4` foreign handlers to use `category_parent_by_child.edn` in artifact mode
- updated the generated effective-distance runner to load preprocessed grouped maps directly in artifact mode
- added benchmark-generator tests for:
  - `artifact` mode parsing
  - predicate-driven `auto` override to `artifact`
  - artifact project generation
  - artifact-backed JVM smoke execution
- added opt-in artifact comparison targets to the benchmark matrix:
  - `clojure-wam-accumulated-artifact`
  - `clojure-wam-accumulated-no-kernels-artifact`
  - `clojure-wam-seeded-artifact`
  - `clojure-wam-seeded-no-kernels-artifact`
- added `clojure-wam-artifact` target set
- updated the benchmark README and WAM perf log

## Why

The previous sidecar step externalized raw benchmark rows, which fixed JVM method-size failures and repo-root matrix launches. The next logical step was to move from raw row sidecars toward actual preprocessed benchmark artifacts.

This PR does that in a conservative way:

- it does not replace the current `sidecar` default
- it keeps artifact mode explicit and comparable
- it gives the benchmark matrix a direct artifact-vs-sidecar comparison path

That aligns the Clojure benchmark path more closely with the C# runtime’s explicit materialization/preprocessing direction, while staying narrow and reversible.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-accumulated,clojure-wam-accumulated-artifact,clojure-wam-accumulated-no-kernels,clojure-wam-accumulated-no-kernels-artifact,clojure-wam-seeded,clojure-wam-seeded-artifact,clojure-wam-seeded-no-kernels,clojure-wam-seeded-no-kernels-artifact,prolog-accumulated --scales dev --repetitions 1`

## Result

- all benchmark outputs still matched digest `1659619c9d36`
- artifact mode is correct and benchmarkable
- initial Termux timings were mixed rather than a clear win:
  - accumulated: `1.867s` sidecar vs `1.852s` artifact
  - accumulated no-kernels: `1.888s` sidecar vs `1.908s` artifact
  - seeded: `1.846s` sidecar vs `2.250s` artifact
  - seeded no-kernels: `2.126s` sidecar vs `2.126s` artifact

## Follow-up

This PR is still useful even without a clear Termux speedup:

- it establishes the first explicit artifact mode for Clojure benchmarks
- it gives us a clean comparison surface for desktop measurements
- it provides the scaffolding for denser, non-EDN artifact formats later

The next likely step is to replace these EDN map artifacts with a denser artifact format and re-measure on desktop.
