### PR TITLE
Adopt runtime-configured source modes for C# file-backed query programs

### DIFF
--- a/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
+++ b/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
@@ -411,6 +411,12 @@ Prototype status:
   `RelationSourceModePolicy` helpers instead of a benchmark-local string switch,
   which is the current seam for moving source selection out of Python-only
   configuration.
+- Runtime-owned `ConfiguredDelimitedRelationProvider` now encapsulates
+  delimited-source registration for `preload`, `delimited`, `artifact`, and
+  `artifact-prebuilt` modes. The scan benchmark and generated C# pipeline
+  programs use that helper, and pipeline programs can now take
+  `UNIFYWEAVER_RELATION_SOURCE_MODE` plus `UNIFYWEAVER_RELATION_ARTIFACT_DIR`
+  without re-implementing artifact registration in each generated template.
 
 ## Success Criteria
 

--- a/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
+++ b/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
@@ -406,7 +406,11 @@ Prototype status:
   indexed parameter probes. The prebuilt mode keeps artifacts in a stable
   benchmark directory keyed by the current runtime source so runtime
   measurements can separate query execution from preprocessing cost without
-  reusing stale artifact formats.
+  reusing stale artifact formats. The benchmark now resolves source-family
+  choices through runtime-owned `RelationSourceMode` and
+  `RelationSourceModePolicy` helpers instead of a benchmark-local string switch,
+  which is the current seam for moving source selection out of Python-only
+  configuration.
 
 ## Success Criteria
 

--- a/examples/benchmark/benchmark_scan_materialization.py
+++ b/examples/benchmark/benchmark_scan_materialization.py
@@ -85,45 +85,6 @@ class Program
             .ToList();
     }
 
-    static void RegisterBinaryRelation(
-        InMemoryRelationProvider memoryProvider,
-        BinaryRelationArtifactProvider artifactProvider,
-        PredicateId predicate,
-        string path,
-        RelationSourceMode sourceMode,
-        string artifactDir)
-    {
-        var source = new DelimitedRelationSource(path, '	', 1, 2);
-        switch (sourceMode)
-        {
-            case RelationSourceMode.Artifact:
-                var manifestPath = BinaryRelationArtifactBuilder.BuildFromDelimited(predicate, source, artifactDir);
-                artifactProvider.RegisterArtifact(predicate, manifestPath);
-                break;
-            case RelationSourceMode.ArtifactPrebuilt:
-                Directory.CreateDirectory(artifactDir);
-                var artifactName = $"{predicate.Name}_{predicate.Arity}";
-                var prebuiltManifestPath = Path.Combine(artifactDir, artifactName + ".uwbr.json");
-                if (!File.Exists(prebuiltManifestPath))
-                {
-                    prebuiltManifestPath = BinaryRelationArtifactBuilder.BuildFromDelimited(predicate, source, artifactDir, artifactName);
-                }
-
-                artifactProvider.RegisterArtifact(predicate, prebuiltManifestPath);
-                break;
-            case RelationSourceMode.Delimited:
-                memoryProvider.RegisterDelimitedSource(predicate, source);
-                break;
-            default:
-                memoryProvider.RegisterDelimitedSource(predicate, source);
-                foreach (var parts in ReadDelimitedRows(path, 2))
-                {
-                    memoryProvider.AddFact(predicate, parts[0], parts[1]);
-                }
-                break;
-        }
-    }
-
     static string SummarizeStrategies(QueryExecutionTrace trace, Func<QueryStrategyTrace, bool> predicate)
     {
         return string.Join(
@@ -169,21 +130,16 @@ class Program
         var edgeRowCount = CountDataRows(edgePath);
         var sourceMode = RelationSourceModePolicy.ResolveScanBenchmarkMode(configuredSourceMode, mode, articleRowCount, edgeRowCount);
 
-        var memoryProvider = new InMemoryRelationProvider();
         var artifactDir = Environment.GetEnvironmentVariable("UNIFYWEAVER_SCAN_ARTIFACT_DIR");
-        artifactDir = string.IsNullOrWhiteSpace(artifactDir)
-            ? Path.Combine(Path.GetTempPath(), $"uw-scan-artifacts-{Guid.NewGuid():N}")
-            : artifactDir;
-        var artifactProvider = new BinaryRelationArtifactProvider(memoryProvider);
-        IRelationProvider provider = sourceMode == RelationSourceMode.Artifact || sourceMode == RelationSourceMode.ArtifactPrebuilt
-            ? artifactProvider
-            : memoryProvider;
+        var configuredProvider = new ConfiguredDelimitedRelationProvider(sourceMode, artifactDir);
+        var memoryProvider = configuredProvider.MemoryProvider;
+        IRelationProvider provider = configuredProvider.Provider;
         var edgeId = new PredicateId("category_parent", 2);
         var articleId = new PredicateId("article_category", 2);
         var blockedId = new PredicateId("blocked_article_category", 2);
 
-        RegisterBinaryRelation(memoryProvider, artifactProvider, edgeId, edgePath, sourceMode, artifactDir);
-        RegisterBinaryRelation(memoryProvider, artifactProvider, articleId, articlePath, sourceMode, artifactDir);
+        configuredProvider.RegisterBinaryRelation(edgeId, new DelimitedRelationSource(edgePath, '	', 1, 2), $"{edgeId.Name}_{edgeId.Arity}");
+        configuredProvider.RegisterBinaryRelation(articleId, new DelimitedRelationSource(articlePath, '	', 1, 2), $"{articleId.Name}_{articleId.Arity}");
 
         var articleRows = ReadDelimitedRows(articlePath, 2);
         var patternCategory = articleRows.Count > 0
@@ -204,7 +160,7 @@ class Program
 
         try
         {
-            RegisterBinaryRelation(memoryProvider, artifactProvider, blockedId, blockedPath, sourceMode, artifactDir);
+            configuredProvider.RegisterBinaryRelation(blockedId, new DelimitedRelationSource(blockedPath, '	', 1, 2), $"{blockedId.Name}_{blockedId.Arity}");
 
             var scanOutId = new PredicateId("scan_rows", 2);
             var patternOutId = new PredicateId("pattern_rows", 2);
@@ -311,7 +267,10 @@ class Program
             try { File.Delete(blockedPath); } catch { }
             if (sourceMode != RelationSourceMode.ArtifactPrebuilt)
             {
-                try { Directory.Delete(artifactDir, recursive: true); } catch { }
+                if (!string.IsNullOrWhiteSpace(configuredProvider.ArtifactDirectory))
+                {
+                    try { Directory.Delete(configuredProvider.ArtifactDirectory, recursive: true); } catch { }
+                }
             }
         }
     }

--- a/examples/benchmark/benchmark_scan_materialization.py
+++ b/examples/benchmark/benchmark_scan_materialization.py
@@ -76,24 +76,6 @@ class Program
         return count;
     }
 
-    static string ResolveSourceMode(string configuredSourceMode, string mode, long articleRows, long edgeRows)
-    {
-        if (!string.Equals(configuredSourceMode, "auto", StringComparison.Ordinal))
-        {
-            return configuredSourceMode;
-        }
-
-        var totalRows = articleRows + edgeRows;
-        return mode switch
-        {
-            "bound_scan" => "artifact",
-            "selective_join" => "artifact",
-            "join" when totalRows <= 5_000L => "artifact-prebuilt",
-            "join" => "artifact",
-            _ => "preload",
-        };
-    }
-
     static List<string[]> ReadDelimitedRows(string path, int expectedWidth)
     {
         return File.ReadLines(path)
@@ -108,17 +90,17 @@ class Program
         BinaryRelationArtifactProvider artifactProvider,
         PredicateId predicate,
         string path,
-        string sourceMode,
+        RelationSourceMode sourceMode,
         string artifactDir)
     {
         var source = new DelimitedRelationSource(path, '	', 1, 2);
         switch (sourceMode)
         {
-            case "artifact":
+            case RelationSourceMode.Artifact:
                 var manifestPath = BinaryRelationArtifactBuilder.BuildFromDelimited(predicate, source, artifactDir);
                 artifactProvider.RegisterArtifact(predicate, manifestPath);
                 break;
-            case "artifact-prebuilt":
+            case RelationSourceMode.ArtifactPrebuilt:
                 Directory.CreateDirectory(artifactDir);
                 var artifactName = $"{predicate.Name}_{predicate.Arity}";
                 var prebuiltManifestPath = Path.Combine(artifactDir, artifactName + ".uwbr.json");
@@ -129,7 +111,7 @@ class Program
 
                 artifactProvider.RegisterArtifact(predicate, prebuiltManifestPath);
                 break;
-            case "delimited":
+            case RelationSourceMode.Delimited:
                 memoryProvider.RegisterDelimitedSource(predicate, source);
                 break;
             default:
@@ -177,16 +159,15 @@ class Program
         var articlePath = args[2];
         var traceEnabled = Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE") == "1";
         var scanStrategy = ParseScanStrategy(Environment.GetEnvironmentVariable("UNIFYWEAVER_SCAN_RETENTION_STRATEGY") ?? "auto");
-        var configuredSourceMode = (Environment.GetEnvironmentVariable("UNIFYWEAVER_SCAN_SOURCE_MODE") ?? "preload").ToLowerInvariant();
-        if (configuredSourceMode != "auto" && configuredSourceMode != "preload" && configuredSourceMode != "delimited" && configuredSourceMode != "artifact" && configuredSourceMode != "artifact-prebuilt")
+        if (!RelationSourceModePolicy.TryParse(Environment.GetEnvironmentVariable("UNIFYWEAVER_SCAN_SOURCE_MODE"), out var configuredSourceMode))
         {
-            Console.Error.WriteLine($"Unknown UNIFYWEAVER_SCAN_SOURCE_MODE: {configuredSourceMode}");
+            Console.Error.WriteLine($"Unknown UNIFYWEAVER_SCAN_SOURCE_MODE: {Environment.GetEnvironmentVariable("UNIFYWEAVER_SCAN_SOURCE_MODE")}");
             return 1;
         }
 
         var articleRowCount = CountDataRows(articlePath);
         var edgeRowCount = CountDataRows(edgePath);
-        var sourceMode = ResolveSourceMode(configuredSourceMode, mode, articleRowCount, edgeRowCount);
+        var sourceMode = RelationSourceModePolicy.ResolveScanBenchmarkMode(configuredSourceMode, mode, articleRowCount, edgeRowCount);
 
         var memoryProvider = new InMemoryRelationProvider();
         var artifactDir = Environment.GetEnvironmentVariable("UNIFYWEAVER_SCAN_ARTIFACT_DIR");
@@ -194,7 +175,9 @@ class Program
             ? Path.Combine(Path.GetTempPath(), $"uw-scan-artifacts-{Guid.NewGuid():N}")
             : artifactDir;
         var artifactProvider = new BinaryRelationArtifactProvider(memoryProvider);
-        IRelationProvider provider = sourceMode == "artifact" || sourceMode == "artifact-prebuilt" ? artifactProvider : memoryProvider;
+        IRelationProvider provider = sourceMode == RelationSourceMode.Artifact || sourceMode == RelationSourceMode.ArtifactPrebuilt
+            ? artifactProvider
+            : memoryProvider;
         var edgeId = new PredicateId("category_parent", 2);
         var articleId = new PredicateId("article_category", 2);
         var blockedId = new PredicateId("blocked_article_category", 2);
@@ -293,8 +276,8 @@ class Program
             stopwatch.Stop();
 
             Console.Error.WriteLine($"mode={mode}");
-            Console.Error.WriteLine($"source_mode={configuredSourceMode}");
-            Console.Error.WriteLine($"resolved_source_mode={sourceMode}");
+            Console.Error.WriteLine($"source_mode={RelationSourceModePolicy.ToConfigValue(configuredSourceMode)}");
+            Console.Error.WriteLine($"resolved_source_mode={RelationSourceModePolicy.ToConfigValue(sourceMode)}");
             Console.Error.WriteLine($"scan_retention_strategy_setting={scanStrategy}");
             Console.Error.WriteLine($"pattern_category={patternCategory}");
             Console.Error.WriteLine($"row_count={rows.Count}");
@@ -326,7 +309,7 @@ class Program
         finally
         {
             try { File.Delete(blockedPath); } catch { }
-            if (sourceMode != "artifact-prebuilt")
+            if (sourceMode != RelationSourceMode.ArtifactPrebuilt)
             {
                 try { Directory.Delete(artifactDir, recursive: true); } catch { }
             }

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1487,14 +1487,25 @@ class Program
         var swTotal = Stopwatch.StartNew();
         var swLoad = Stopwatch.StartNew();
 
-        var provider = new InMemoryRelationProvider();
+        if (!RelationSourceModePolicy.TryParse(Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_SOURCE_MODE"), out var configuredSourceMode))
+        {{
+            Console.Error.WriteLine($"Unknown UNIFYWEAVER_RELATION_SOURCE_MODE: {{Environment.GetEnvironmentVariable(\"UNIFYWEAVER_RELATION_SOURCE_MODE\")}}");
+            Environment.Exit(1);
+        }}
+
+        var sourceMode = configuredSourceMode == RelationSourceMode.Auto ? RelationSourceMode.Preload : configuredSourceMode;
+        var configuredProvider = new ConfiguredDelimitedRelationProvider(
+            sourceMode,
+            Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_ARTIFACT_DIR"));
+        var provider = configuredProvider.MemoryProvider;
+        IRelationProvider relationProvider = configuredProvider.Provider;
         var edgeId = new PredicateId("category_parent", 2);
         var seedId = new PredicateId("project_dependency", 2);
         var predId = new PredicateId("dependency_reach", 2);
         var projects = new HashSet<string>(StringComparer.Ordinal);
 
-        provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
-        provider.RegisterDelimitedSource(seedId, new DelimitedRelationSource(args[1]));
+        configuredProvider.RegisterBinaryRelation(edgeId, new DelimitedRelationSource(args[0]), "category_parent_2");
+        configuredProvider.RegisterBinaryRelation(seedId, new DelimitedRelationSource(args[1]), "project_dependency_2");
         foreach (var line in File.ReadLines(args[1]).Skip(1))
         {{
             var tab = line.IndexOf('	');
@@ -1513,7 +1524,7 @@ class Program
 
         var dagRetentionStrategy = ReadDagRetentionStrategy();
         var swQuery = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(
+        var executor = new QueryExecutor(relationProvider, new QueryExecutorOptions(
             ReuseCaches: false,
             DagRelationRetentionStrategy: dagRetentionStrategy));
         var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
@@ -1992,14 +2003,25 @@ class Program
         var swTotal = Stopwatch.StartNew();
         var swLoad = Stopwatch.StartNew();
 
-        var provider = new InMemoryRelationProvider();
+        if (!RelationSourceModePolicy.TryParse(Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_SOURCE_MODE"), out var configuredSourceMode))
+        {{
+            Console.Error.WriteLine($"Unknown UNIFYWEAVER_RELATION_SOURCE_MODE: {{Environment.GetEnvironmentVariable(\"UNIFYWEAVER_RELATION_SOURCE_MODE\")}}");
+            Environment.Exit(1);
+        }}
+
+        var sourceMode = configuredSourceMode == RelationSourceMode.Auto ? RelationSourceMode.Preload : configuredSourceMode;
+        var configuredProvider = new ConfiguredDelimitedRelationProvider(
+            sourceMode,
+            Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_ARTIFACT_DIR"));
+        var provider = configuredProvider.MemoryProvider;
+        IRelationProvider relationProvider = configuredProvider.Provider;
         var edgeId = new PredicateId("category_parent", 2);
         var seedId = new PredicateId("project_dependency", 2);
         var predId = new PredicateId("dependency_longest_depth", 2);
         var projects = new HashSet<string>(StringComparer.Ordinal);
 
-        provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
-        provider.RegisterDelimitedSource(seedId, new DelimitedRelationSource(args[1]));
+        configuredProvider.RegisterBinaryRelation(edgeId, new DelimitedRelationSource(args[0]), "category_parent_2");
+        configuredProvider.RegisterBinaryRelation(seedId, new DelimitedRelationSource(args[1]), "project_dependency_2");
         foreach (var line in File.ReadLines(args[1]).Skip(1))
         {{
             var tab = line.IndexOf('\t');
@@ -2018,7 +2040,7 @@ class Program
 
         var dagRetentionStrategy = ReadDagRetentionStrategy();
         var swQuery = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(
+        var executor = new QueryExecutor(relationProvider, new QueryExecutorOptions(
             ReuseCaches: false,
             DagRelationRetentionStrategy: dagRetentionStrategy));
         var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
@@ -2635,14 +2657,25 @@ class Program
         var swTotal = Stopwatch.StartNew();
         var swLoad = Stopwatch.StartNew();
 
-        var provider = new InMemoryRelationProvider();
+        if (!RelationSourceModePolicy.TryParse(Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_SOURCE_MODE"), out var configuredSourceMode))
+        {{
+            Console.Error.WriteLine($"Unknown UNIFYWEAVER_RELATION_SOURCE_MODE: {{Environment.GetEnvironmentVariable(\"UNIFYWEAVER_RELATION_SOURCE_MODE\")}}");
+            Environment.Exit(1);
+        }}
+
+        var sourceMode = configuredSourceMode == RelationSourceMode.Auto ? RelationSourceMode.Preload : configuredSourceMode;
+        var configuredProvider = new ConfiguredDelimitedRelationProvider(
+            sourceMode,
+            Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_ARTIFACT_DIR"));
+        var provider = configuredProvider.MemoryProvider;
+        IRelationProvider relationProvider = configuredProvider.Provider;
         var edgeId = new PredicateId("category_parent", 2);
         var seedId = new PredicateId("article_category", 2);
         var rootId = new PredicateId("root_category", 1);
         var resultId = new PredicateId("article_root_weight_sum", 3);
 
-        provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
-        provider.RegisterDelimitedSource(seedId, new DelimitedRelationSource(args[1]));
+        configuredProvider.RegisterBinaryRelation(edgeId, new DelimitedRelationSource(args[0]), "category_parent_2");
+        configuredProvider.RegisterBinaryRelation(seedId, new DelimitedRelationSource(args[1]), "article_category_2");
         foreach (var root in ROOTS.OrderBy(x => x, StringComparer.Ordinal))
         {{
             provider.AddFact(rootId, root);
@@ -2664,7 +2697,7 @@ class Program
         QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
 
         var swQuery = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(
+        var executor = new QueryExecutor(relationProvider, new QueryExecutorOptions(
             ReuseCaches: false,
             PathAwareEdgeRetentionStrategy: edgeRetentionStrategy,
             PathAwareSupportRelationRetentionStrategy: supportRetentionStrategy,
@@ -2808,14 +2841,25 @@ class Program
         var swTotal = Stopwatch.StartNew();
         var swLoad = Stopwatch.StartNew();
 
-        var provider = new InMemoryRelationProvider();
+        if (!RelationSourceModePolicy.TryParse(Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_SOURCE_MODE"), out var configuredSourceMode))
+        {{
+            Console.Error.WriteLine($"Unknown UNIFYWEAVER_RELATION_SOURCE_MODE: {{Environment.GetEnvironmentVariable(\"UNIFYWEAVER_RELATION_SOURCE_MODE\")}}");
+            Environment.Exit(1);
+        }}
+
+        var sourceMode = configuredSourceMode == RelationSourceMode.Auto ? RelationSourceMode.Preload : configuredSourceMode;
+        var configuredProvider = new ConfiguredDelimitedRelationProvider(
+            sourceMode,
+            Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_ARTIFACT_DIR"));
+        var provider = configuredProvider.MemoryProvider;
+        IRelationProvider relationProvider = configuredProvider.Provider;
         var edgeId = new PredicateId("category_parent", 2);
         var seedId = new PredicateId("article_category", 2);
         var rootId = new PredicateId("root_category", 1);
         var resultId = new PredicateId("article_root_weight_sum", 3);
 
-        provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
-        provider.RegisterDelimitedSource(seedId, new DelimitedRelationSource(args[1]));
+        configuredProvider.RegisterBinaryRelation(edgeId, new DelimitedRelationSource(args[0]), "category_parent_2");
+        configuredProvider.RegisterBinaryRelation(seedId, new DelimitedRelationSource(args[1]), "article_category_2");
         provider.AddFact(rootId, ROOT_CATEGORY);
         swLoad.Stop();
 
@@ -2833,7 +2877,7 @@ class Program
         QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
 
         var swExec = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(
+        var executor = new QueryExecutor(relationProvider, new QueryExecutorOptions(
             ReuseCaches: false,
             PathAwareEdgeRetentionStrategy: edgeRetentionStrategy,
             PathAwareSupportRelationRetentionStrategy: supportRetentionStrategy,
@@ -2973,14 +3017,25 @@ class Program
         var swTotal = Stopwatch.StartNew();
         var swLoad = Stopwatch.StartNew();
 
-        var provider = new InMemoryRelationProvider();
+        if (!RelationSourceModePolicy.TryParse(Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_SOURCE_MODE"), out var configuredSourceMode))
+        {{
+            Console.Error.WriteLine($"Unknown UNIFYWEAVER_RELATION_SOURCE_MODE: {{Environment.GetEnvironmentVariable(\"UNIFYWEAVER_RELATION_SOURCE_MODE\")}}");
+            Environment.Exit(1);
+        }}
+
+        var sourceMode = configuredSourceMode == RelationSourceMode.Auto ? RelationSourceMode.Preload : configuredSourceMode;
+        var configuredProvider = new ConfiguredDelimitedRelationProvider(
+            sourceMode,
+            Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_ARTIFACT_DIR"));
+        var provider = configuredProvider.MemoryProvider;
+        IRelationProvider relationProvider = configuredProvider.Provider;
         var edgeId = new PredicateId("category_parent", 2);
         var seedId = new PredicateId("article_category", 2);
         var rootId = new PredicateId("root_category", 1);
         var resultId = new PredicateId("article_root_shortest_path", 3);
 
-        provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
-        provider.RegisterDelimitedSource(seedId, new DelimitedRelationSource(args[1]));
+        configuredProvider.RegisterBinaryRelation(edgeId, new DelimitedRelationSource(args[0]), "category_parent_2");
+        configuredProvider.RegisterBinaryRelation(seedId, new DelimitedRelationSource(args[1]), "article_category_2");
         provider.AddFact(rootId, ROOT_CATEGORY);
         swLoad.Stop();
 
@@ -2998,7 +3053,7 @@ class Program
         QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
 
         var swQuery = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(
+        var executor = new QueryExecutor(relationProvider, new QueryExecutorOptions(
             ReuseCaches: false,
             PathAwareEdgeRetentionStrategy: edgeRetentionStrategy,
             PathAwareSupportRelationRetentionStrategy: supportRetentionStrategy,
@@ -3149,7 +3204,18 @@ class Program
         var swTotal = Stopwatch.StartNew();
         var swLoad = Stopwatch.StartNew();
 
-        var provider = new InMemoryRelationProvider();
+        if (!RelationSourceModePolicy.TryParse(Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_SOURCE_MODE"), out var configuredSourceMode))
+        {{
+            Console.Error.WriteLine($"Unknown UNIFYWEAVER_RELATION_SOURCE_MODE: {{Environment.GetEnvironmentVariable(\"UNIFYWEAVER_RELATION_SOURCE_MODE\")}}");
+            Environment.Exit(1);
+        }}
+
+        var sourceMode = configuredSourceMode == RelationSourceMode.Auto ? RelationSourceMode.Preload : configuredSourceMode;
+        var configuredProvider = new ConfiguredDelimitedRelationProvider(
+            sourceMode,
+            Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_ARTIFACT_DIR"));
+        var provider = configuredProvider.MemoryProvider;
+        IRelationProvider relationProvider = configuredProvider.Provider;
         var edgeId = new PredicateId("category_parent", 2);
         var seedId = new PredicateId("article_category", 2);
         var rootId = new PredicateId("root_category", 1);
@@ -3158,8 +3224,8 @@ class Program
         var outDegree = new Dictionary<string, int>(StringComparer.Ordinal);
         var sourceNodes = new HashSet<string>(StringComparer.Ordinal);
 
-        provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
-        provider.RegisterDelimitedSource(seedId, new DelimitedRelationSource(args[1]));
+        configuredProvider.RegisterBinaryRelation(edgeId, new DelimitedRelationSource(args[0]), "category_parent_2");
+        configuredProvider.RegisterBinaryRelation(seedId, new DelimitedRelationSource(args[1]), "article_category_2");
         foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
         {{
             if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
@@ -3214,7 +3280,7 @@ class Program
         QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
 
         var swQuery = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(
+        var executor = new QueryExecutor(relationProvider, new QueryExecutorOptions(
             ReuseCaches: false,
             PathAwareEdgeRetentionStrategy: edgeRetentionStrategy,
             PathAwareSupportRelationRetentionStrategy: supportRetentionStrategy,

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -3456,6 +3456,67 @@ namespace UnifyWeaver.QueryRuntime
         }
     }
 
+    public sealed class ConfiguredDelimitedRelationProvider
+    {
+        public RelationSourceMode SourceMode { get; }
+
+        public InMemoryRelationProvider MemoryProvider { get; }
+
+        public BinaryRelationArtifactProvider? ArtifactProvider { get; }
+
+        public IRelationProvider Provider => (IRelationProvider?)ArtifactProvider ?? MemoryProvider;
+
+        public string? ArtifactDirectory { get; }
+
+        public ConfiguredDelimitedRelationProvider(
+            RelationSourceMode sourceMode,
+            string? artifactDirectory = null,
+            InMemoryRelationProvider? memoryProvider = null)
+        {
+            if (sourceMode == RelationSourceMode.Auto)
+            {
+                throw new ArgumentException("Auto source mode must be resolved before provider construction.", nameof(sourceMode));
+            }
+
+            SourceMode = sourceMode;
+            MemoryProvider = memoryProvider ?? new InMemoryRelationProvider();
+
+            if (sourceMode == RelationSourceMode.Artifact || sourceMode == RelationSourceMode.ArtifactPrebuilt)
+            {
+                ArtifactDirectory = string.IsNullOrWhiteSpace(artifactDirectory)
+                    ? Path.Combine(Path.GetTempPath(), $"uw-rel-artifacts-{Guid.NewGuid():N}")
+                    : artifactDirectory;
+                ArtifactProvider = new BinaryRelationArtifactProvider(MemoryProvider);
+            }
+        }
+
+        public void RegisterBinaryRelation(PredicateId predicate, DelimitedRelationSource source, string? artifactName = null)
+        {
+            switch (SourceMode)
+            {
+                case RelationSourceMode.Preload:
+                    MemoryProvider.RegisterDelimitedSource(predicate, source);
+                    MemoryProvider.AddFacts(predicate, DelimitedRelationReader.ReadRows(source));
+                    return;
+                case RelationSourceMode.Delimited:
+                    MemoryProvider.RegisterDelimitedSource(predicate, source);
+                    return;
+                case RelationSourceMode.Artifact:
+                case RelationSourceMode.ArtifactPrebuilt:
+                    if (ArtifactProvider is null || string.IsNullOrWhiteSpace(ArtifactDirectory))
+                    {
+                        throw new InvalidOperationException("Artifact mode requires an initialized artifact provider.");
+                    }
+
+                    var manifestPath = BinaryRelationArtifactBuilder.BuildFromDelimited(predicate, source, ArtifactDirectory, artifactName);
+                    ArtifactProvider.RegisterArtifact(predicate, manifestPath);
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(SourceMode), SourceMode, null);
+            }
+        }
+    }
+
     public sealed class QueryExecutor
     {
         private readonly IRelationProvider _provider;

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -77,6 +77,15 @@ namespace UnifyWeaver.QueryRuntime
         ExternalMaterialized
     }
 
+    public enum RelationSourceMode
+    {
+        Auto,
+        Preload,
+        Delimited,
+        Artifact,
+        ArtifactPrebuilt
+    }
+
     public enum ClosureRelationRetentionStrategy
     {
         Auto,
@@ -101,6 +110,66 @@ namespace UnifyWeaver.QueryRuntime
         char Delimiter = '	',
         int SkipRows = 1,
         int ExpectedWidth = 2);
+
+    public static class RelationSourceModePolicy
+    {
+        public static bool TryParse(string? value, out RelationSourceMode mode)
+        {
+            switch ((value ?? "preload").Trim().ToLowerInvariant())
+            {
+                case "auto":
+                    mode = RelationSourceMode.Auto;
+                    return true;
+                case "preload":
+                    mode = RelationSourceMode.Preload;
+                    return true;
+                case "delimited":
+                    mode = RelationSourceMode.Delimited;
+                    return true;
+                case "artifact":
+                    mode = RelationSourceMode.Artifact;
+                    return true;
+                case "artifact-prebuilt":
+                    mode = RelationSourceMode.ArtifactPrebuilt;
+                    return true;
+                default:
+                    mode = RelationSourceMode.Preload;
+                    return false;
+            }
+        }
+
+        public static string ToConfigValue(RelationSourceMode mode) => mode switch
+        {
+            RelationSourceMode.Auto => "auto",
+            RelationSourceMode.Preload => "preload",
+            RelationSourceMode.Delimited => "delimited",
+            RelationSourceMode.Artifact => "artifact",
+            RelationSourceMode.ArtifactPrebuilt => "artifact-prebuilt",
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
+        public static RelationSourceMode ResolveScanBenchmarkMode(
+            RelationSourceMode configuredMode,
+            string mode,
+            long articleRows,
+            long edgeRows)
+        {
+            if (configuredMode != RelationSourceMode.Auto)
+            {
+                return configuredMode;
+            }
+
+            var totalRows = articleRows + edgeRows;
+            return mode switch
+            {
+                "bound_scan" => RelationSourceMode.Artifact,
+                "selective_join" => RelationSourceMode.Artifact,
+                "join" when totalRows <= 5_000L => RelationSourceMode.ArtifactPrebuilt,
+                "join" => RelationSourceMode.Artifact,
+                _ => RelationSourceMode.Preload,
+            };
+        }
+    }
 
     public sealed class BinaryRelationArtifactManifest
     {


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                
                                                                                                                                                                                            
  This PR moves C# file-backed source-mode handling onto runtime-owned abstractions instead of leaving it split across benchmark-local string switches and per-template relation-           
  registration code.                                                                                                                                                                        
                                                                                                                                                                                            
  It adds:                                                                                                                                                                                  
                                                                                                                                                                                            
  - `RelationSourceMode` and `RelationSourceModePolicy` as runtime-owned source-family types.                                                                                               
  - `ConfiguredDelimitedRelationProvider` as a reusable runtime helper for file-backed binary relations.                                                                                    
  - Scan benchmark adoption of that runtime helper.                                                                                                                                         
  - Generated C# pipeline adoption of runtime-configured source modes via environment variables.                                                                                            
                                                                                                                                                                                            
  ## Why                                                                                                                                                                                    
                                                                                                                                                                                            
  The previous work established that source-family choice should live on the C# side, not in Python. But the actual provider construction logic was still duplicated:                       
                                                                                                                                                                                            
  - the scan benchmark had its own artifact/delimited/preload registration logic                                                                                                            
  - generated file-backed pipeline programs still hard-coded `InMemoryRelationProvider` plus `RegisterDelimitedSource(...)`                                                                 
                                                                                                                                                                                            
  That meant the policy seam existed, but the runtime did not yet own the provider-construction path.                                                                                       
                                                                                                                                                                                            
  This PR fixes that by making the runtime responsible for configuring file-backed relation providers for:                                                                                  
                                                                                                                                                                                            
  - `preload`                                                                                                                                                                               
  - `delimited`                                                                                                                                                                             
  - `artifact`                                                                                                                                                                              
  - `artifact-prebuilt`                                                                                                                                                                     
                                                                                                                                                                                            
  ## What Changed                                                                                                                                                                           
                                                                                                                                                                                            
  ### Runtime                                                                                                                                                                               
                                                                                                                                                                                            
  In [QueryRuntime.cs](src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs):                                                                                                       
                                                                                                                                                                                            
  - added `RelationSourceMode`                                                                                                                                                              
  - added `RelationSourceModePolicy`                                                                                                                                                        
  - added `ConfiguredDelimitedRelationProvider`                                                                                                                                             
                                                                                                                                                                                            
  `ConfiguredDelimitedRelationProvider` now encapsulates:                                                                                                                                   
                                                                                                                                                                                            
  - creation of the backing `InMemoryRelationProvider`                                                                                                                                      
  - optional `BinaryRelationArtifactProvider`                                                                                                                                               
  - artifact directory handling                                                                                                                                                             
  - registration of delimited binary relations according to source mode                                                                                                                     
                                                                                                                                                                                            
  This gives the runtime one place to own file-backed source-family behavior.                                                                                                               
                                                                                                                                                                                            
  ### Scan Benchmark                                                                                                                                                                        
                                                                                                                                                                                            
  In [examples/benchmark/benchmark_scan_materialization.py](examples/benchmark/benchmark_scan_materialization.py):                                                                          
                                                                                                                                                                                            
  - removed benchmark-local relation registration logic                                                                                                                                     
  - switched the generated C# program to use `ConfiguredDelimitedRelationProvider`                                                                                                          
  - kept `auto` source-mode resolution on the runtime side through `RelationSourceModePolicy`                                                                                               
                                                                                                                                                                                            
  So the benchmark now consumes the runtime seam instead of partially re-implementing it.                                                                                                   
                                                                                                                                                                                            
  ### Generated Pipelines                                                                                                                                                                   
                                                                                                                                                                                            
  In [examples/benchmark/generate_pipeline.py](examples/benchmark/generate_pipeline.py):                                                                                                    
                                                                                                                                                                                            
  - updated generated C# pipeline templates that read TSV relations from disk to use the runtime helper                                                                                     
  - added support for:                                                                                                                                                                      
    - `UNIFYWEAVER_RELATION_SOURCE_MODE`                                                                                                                                                    
    - `UNIFYWEAVER_RELATION_ARTIFACT_DIR`                                                                                                                                                   
                                                                                                                                                                                            
  These generated programs now resolve source-family configuration through the runtime helper instead of assuming preload/delimited-only behavior.                                          
                                                                                                                                                                                            
  ## Validation                                                                                                                                                                             
                                                                                                                                                                                            
  - `python3 -m py_compile examples/benchmark/benchmark_scan_materialization.py examples/benchmark/generate_pipeline.py`                                                                    
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c Release --nologo`                                                                    
  - `git diff --check`                                                                                                                                                                      
                                                                                                                                                                                            
  Focused benchmark validation:                                                                                                                                                             
                                                                                                                                                                                            
  ```bash                                                                                                                                                                                   
  python3 examples/benchmark/benchmark_scan_materialization.py \                                                                                                                            
    --scales 300 \                                                                                                                                                                          
    --modes join,selective_join \                                                                                                                                                           
    --source-modes auto,artifact,artifact-prebuilt,preload \                                                                                                                                
    --strategies auto \                                                                                                                                                                     
    --repetitions 2                                                                                                                                                                         
  ```                                                                                                                                                                            
  Representative results from that check:                                                                                                                                                   
                                                                                                                                                                                            
  - 300 join: auto chose artifact, 0.95x vs best source mode                                                                                                                                
  - 300 selective_join: auto chose artifact, 0.96x vs best source mode                                                                                                                      
                                                                                                                                                                                            
  Generated pipeline compile smoke also passed by emitting a C# program from generate_pipeline.py and building it with the current runtime.                                                 
                                                                                                                                                                                            
  ## Scope                                                                                                                                                                                  
                                                                                                                                                                                            
  This PR does not add a full general planner for source-family selection across all generated queries.                                                                                     
                                                                                                                                                                                            
  It does the narrower, correct step first:                                                                                                                                                 
                                                                                                                                                                                            
  - put source-family types in the runtime                                                                                                                                                  
  - put file-backed provider construction in the runtime                                                                                                                                    
  - make benchmark and generated pipeline code consume that runtime seam                                                                                                                    
                                                                                                                                                                                            
  ## Follow-Up                                                                                                                                                                              
                                                                                                                                                                                            
  The next likely step is to extend runtime-configured source-mode selection into more generated query/program families, now that the provider-construction seam is no longer benchmark-    
  specific.                                                                                                                                                                                 