### PR TITLE
feat(bench): fact-layout measurement harness (Phase-E tuning start)

### DIFF
--- a/examples/benchmark/measure_wam_elixir_fact_layouts.pl
+++ b/examples/benchmark/measure_wam_elixir_fact_layouts.pl
@@ -1,0 +1,165 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% measure_wam_elixir_fact_layouts.pl
+%
+% Emits a single predicate under each of the fact-shape layouts
+% (compiled / inline_data / inline_data with arg1 index /
+% external_source) and reports the cheap-to-measure signals:
+%
+%   - Prolog-side codegen time (walltime ms).
+%   - Emitted Elixir source size (bytes).
+%
+% This is the MVP of the Phase-E "measurement-driven tuning" the plan
+% describes. It measures what we can cheaply here and in CI; the
+% richer side (host-compile cost, query latency, RAM footprint)
+% belongs in a desktop-environment follow-up.
+%
+% Usage:
+%
+%   swipl -q -s measure_wam_elixir_fact_layouts.pl -- \
+%         <facts-path> <pred>/<arity>
+%
+% Example:
+%
+%   swipl -q -s measure_wam_elixir_fact_layouts.pl -- \
+%         data/benchmark/dev/facts.pl category_parent/2
+
+:- use_module('../../src/unifyweaver/targets/wam_target').
+:- use_module('../../src/unifyweaver/targets/wam_elixir_lowered_emitter',
+              [lower_predicate_to_elixir/4, classify_predicate/4]).
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv = [FactsPathAtom, PredIndAtom]
+    ->  true
+    ;   format(user_error,
+               'Usage: swipl -q -s measure_wam_elixir_fact_layouts.pl -- <facts-path> <pred>/<arity>~n', []),
+        halt(1)
+    ),
+    atom_string(FactsPathAtom, FactsPath),
+    parse_pred_indicator(PredIndAtom, Pred, Arity),
+    load_files(FactsPath, [silent(true)]),
+    % Introspection pass: run the classification once to surface
+    % clause count and groundness before measuring.
+    wam_target:compile_predicate_to_wam(user:Pred/Arity, [], IntroWam),
+    atom_string(IntroWam, IntroWamStr),
+    split_string(IntroWamStr, "\n", "", IntroLines),
+    wam_elixir_lowered_emitter:split_into_segments(IntroLines, 1, IntroSegs),
+    classify_predicate(Pred/Arity, IntroSegs, [],
+                       fact_shape_info(NClauses, FactOnly, FirstArg, _)),
+    format(user_error,
+           'classification: pred=~w/~w clauses=~w fact_only=~w first_arg=~w~n',
+           [Pred, Arity, NClauses, FactOnly, FirstArg]),
+    % Measurement header. Tab-separated so the output is easy to
+    % pipe into awk, spreadsheet, or the Python harness.
+    format('scale\tpred\tlayout\tcodegen_ms\tmodule_bytes\tresolved_as~n'),
+    scale_label(FactsPath, ScaleLabel),
+    % Explicit layouts first — the "ground truth" per-layout cost.
+    % Then the two auto-policies that report which explicit layout
+    % they resolve to for this predicate at this scale. Matches the
+    % C# hybrid-WAM matrix harness pattern: explicit modes +
+    % `auto` side-by-side so the planner's choice is observable.
+    Layouts = [
+        compiled,
+        inline_data_no_index,
+        inline_data_indexed,
+        external_source,
+        auto,
+        cost_aware
+    ],
+    forall(member(Layout, Layouts),
+           measure_one(ScaleLabel, Pred, Arity, Layout)),
+    halt(0).
+
+parse_pred_indicator(Indicator, Pred, Arity) :-
+    atom_string(Indicator, Str),
+    split_string(Str, "/", "", [PredStr, ArityStr]),
+    atom_string(Pred, PredStr),
+    number_string(Arity, ArityStr).
+
+%% scale_label(+FactsPath, -Label)
+%  Extracts a human-readable scale tag from the facts path.
+%  `data/benchmark/dev/facts.pl` → "dev"; any other shape → "?".
+scale_label(FactsPath, Label) :-
+    (   file_directory_name(FactsPath, Dir),
+        file_base_name(Dir, BaseAtom),
+        atom_string(BaseAtom, Label)
+    ->  true
+    ;   Label = "?"
+    ).
+
+%% measure_one(+Scale, +Pred, +Arity, +Layout)
+%  Emits one measurement row to stdout. Row shape:
+%    scale  pred  layout  codegen_ms  module_bytes  resolved_as
+%  For explicit layouts (`compiled`, `inline_data_*`, `external_source`)
+%  the `resolved_as` field just echoes the layout label. For the
+%  auto-policies (`auto`, `cost_aware`) it reports which concrete
+%  layout the classifier actually chose — matches the C# harness's
+%  `auto_planner` column.
+measure_one(Scale, Pred, Arity, Layout) :-
+    options_for_layout(Layout, Opts),
+    statistics(walltime, [T0|_]),
+    catch(wam_target:compile_predicate_to_wam(user:Pred/Arity, [], WamCode),
+          _, (WamCode = "", fail)),
+    lower_predicate_to_elixir(Pred/Arity, WamCode,
+                              [module_name('MeasureModule') | Opts],
+                              Code),
+    statistics(walltime, [T1|_]),
+    Elapsed is T1 - T0,
+    atom_string(Code, CodeStr),
+    string_length(CodeStr, Bytes),
+    layout_label(Layout, LayoutLabel),
+    resolved_layout(Layout, WamCode, Pred, Arity, Opts, ResolvedLabel),
+    format('~w\t~w/~w\t~w\t~w\t~w\t~w~n',
+           [Scale, Pred, Arity, LayoutLabel, Elapsed, Bytes, ResolvedLabel]).
+
+%% resolved_layout(+Layout, +WamCode, +Pred, +Arity, +Opts, -ResolvedLabel)
+%  Echoes the concrete layout an auto-policy picks; for explicit
+%  layouts returns the same label.
+resolved_layout(auto, WamCode, Pred, Arity, Opts, ResolvedLabel) :- !,
+    classify_into_label(WamCode, Pred, Arity, Opts, ResolvedLabel).
+resolved_layout(cost_aware, WamCode, Pred, Arity, Opts, ResolvedLabel) :- !,
+    classify_into_label(WamCode, Pred, Arity, Opts, ResolvedLabel).
+resolved_layout(Layout, _WamCode, _Pred, _Arity, _Opts, Label) :-
+    layout_label(Layout, Label).
+
+classify_into_label(WamCode, Pred, Arity, Opts, Label) :-
+    atom_string(WamCode, WamStr),
+    split_string(WamStr, "\n", "", Lines),
+    wam_elixir_lowered_emitter:split_into_segments(Lines, 1, Segments),
+    classify_predicate(Pred/Arity, Segments, Opts,
+                       fact_shape_info(_, _, _, Layout)),
+    concrete_layout_label(Layout, Label).
+
+concrete_layout_label(compiled,           "compiled").
+concrete_layout_label(inline_data(_),     "inline_data").
+concrete_layout_label(external_source(_), "external_source").
+
+%% options_for_layout(+Layout, -Options)
+%  Maps the measurement layout enum onto the emitter's option
+%  surface. `external_source` stays opt-in (the default classifier
+%  doesn't pick it), so we force it via `fact_layout/2`.
+options_for_layout(compiled, [fact_layout_policy(compiled_only),
+                              fact_index_policy(none)]).
+options_for_layout(inline_data_no_index,
+                   [fact_layout_policy(inline_eager),
+                    fact_index_policy(none)]).
+options_for_layout(inline_data_indexed,
+                   [fact_layout_policy(inline_eager),
+                    fact_index_policy(first_arg)]).
+options_for_layout(external_source, Options) :-
+    % Use a dummy tag; the emitter doesn't consult the spec at
+    % codegen time (drivers register the real source at runtime).
+    Options = [fact_layout(_/_, external_source(measurement_tag))].
+options_for_layout(auto, []).  % default policy — no options needed
+options_for_layout(cost_aware, [fact_layout_policy(cost_aware)]).
+
+layout_label(compiled,              "compiled").
+layout_label(inline_data_no_index,  "inline_data").
+layout_label(inline_data_indexed,   "inline_data_indexed").
+layout_label(external_source,       "external_source").
+layout_label(auto,                  "auto").
+layout_label(cost_aware,            "cost_aware").
+
+:- initialization(main, main).

--- a/examples/benchmark/measure_wam_elixir_fact_layouts.py
+++ b/examples/benchmark/measure_wam_elixir_fact_layouts.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Measure WAM-Elixir fact-shape layouts across scales.
+
+Thin driver around ``measure_wam_elixir_fact_layouts.pl``. Follows the
+C# hybrid-WAM matrix-harness pattern
+(``benchmark_effective_distance_matrix.py``): run each explicit layout
+plus the auto-policies, then print a summary table with the layout the
+planner actually picked and a ``ratio_vs_min_bytes`` column showing how
+close each non-winner got to the cheapest-by-bytes choice.
+
+Host-compile / query-latency measurements are left out here
+intentionally. The cheap signals (codegen time, module size) are what
+actually runs in CI / on the development box; the richer profiling
+belongs on a desktop environment and can plug into the same output
+format later.
+
+Example::
+
+    python3 measure_wam_elixir_fact_layouts.py \\
+        --scales dev,300 --predicates category_parent/2
+
+Emits a TSV block per scale/predicate plus a `ratio` summary that
+makes it obvious which layout is cheapest and how much worse auto /
+cost_aware is.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+PL_SCRIPT = Path(__file__).with_suffix(".pl")
+
+
+@dataclass
+class Row:
+    scale: str
+    predicate: str
+    layout: str
+    codegen_ms: int
+    module_bytes: int
+    resolved_as: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scales",
+        default="dev,300",
+        help="Comma-separated scale directories under data/benchmark/",
+    )
+    parser.add_argument(
+        "--predicates",
+        default="category_parent/2,article_category/2",
+        help="Comma-separated predicate indicators to measure (pred/arity)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=60,
+        help="Per-invocation swipl timeout in seconds",
+    )
+    return parser.parse_args()
+
+
+def run_measurement(scale: str, predicate: str, timeout_s: int) -> list[Row]:
+    facts_path = BENCH_DIR / scale / "facts.pl"
+    if not facts_path.exists():
+        raise FileNotFoundError(f"facts not found: {facts_path}")
+    cmd = [
+        "swipl",
+        "-q",
+        "-s",
+        str(PL_SCRIPT),
+        "--",
+        str(facts_path),
+        predicate,
+    ]
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        raise subprocess.CalledProcessError(result.returncode, cmd)
+    rows: list[Row] = []
+    for line in result.stdout.splitlines():
+        if not line or line.startswith("scale\t"):
+            continue
+        parts = line.split("\t")
+        if len(parts) != 6:
+            continue
+        rows.append(
+            Row(
+                scale=parts[0],
+                predicate=parts[1],
+                layout=parts[2],
+                codegen_ms=int(parts[3]),
+                module_bytes=int(parts[4]),
+                resolved_as=parts[5],
+            )
+        )
+    return rows
+
+
+def print_summary(all_rows: list[Row]) -> None:
+    print("scale\tpredicate\tlayout\tcodegen_ms\tmodule_bytes\tresolved_as\tratio_vs_min_bytes")
+    grouped: dict[tuple[str, str], list[Row]] = defaultdict(list)
+    for row in all_rows:
+        grouped[(row.scale, row.predicate)].append(row)
+    for (scale, predicate), entries in sorted(grouped.items()):
+        # Ratio vs cheapest-by-bytes among the EXPLICIT layouts — the
+        # auto-policies themselves don't count as candidates, they
+        # reflect a choice AMONG the explicit ones.
+        explicit_bytes = [
+            row.module_bytes
+            for row in entries
+            if row.layout not in ("auto", "cost_aware")
+        ]
+        min_bytes = min(explicit_bytes) if explicit_bytes else 0
+        for row in sorted(entries, key=lambda r: (r.layout,)):
+            ratio = (row.module_bytes / min_bytes) if min_bytes else float("nan")
+            print(
+                f"{row.scale}\t{row.predicate}\t{row.layout}\t"
+                f"{row.codegen_ms}\t{row.module_bytes}\t{row.resolved_as}\t"
+                f"{ratio:.2f}x"
+            )
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [s.strip() for s in args.scales.split(",") if s.strip()]
+    predicates = [p.strip() for p in args.predicates.split(",") if p.strip()]
+
+    all_rows: list[Row] = []
+    for scale in scales:
+        for predicate in predicates:
+            try:
+                rows = run_measurement(scale, predicate, args.timeout)
+            except (subprocess.TimeoutExpired, subprocess.CalledProcessError) as err:
+                sys.stderr.write(f"[skip] {scale}/{predicate}: {err}\n")
+                continue
+            except FileNotFoundError as err:
+                sys.stderr.write(f"[skip] {err}\n")
+                continue
+            all_rows.extend(rows)
+
+    if not all_rows:
+        sys.stderr.write("no measurements collected\n")
+        return 1
+    print_summary(all_rows)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Starts the measurement-driven tuning sub-goal that
[Phase E (PR #1555)](https://github.com/s243a/UnifyWeaver/pull/1555)
deferred. Two cooperating pieces, shaped after the C# hybrid-WAM
matrix-harness pattern
(`benchmark_effective_distance_matrix.py`, `benchmark_scan_materialization.py`):

- **`measure_wam_elixir_fact_layouts.pl`** — Prolog core. For a given
  (facts-file, pred/arity), emits one row per layout with codegen time
  and emitted module size.
- **`measure_wam_elixir_fact_layouts.py`** — Python driver. Iterates
  `--scales × --predicates`, aggregates into a TSV with a
  `ratio_vs_min_bytes` column.

No code changes to the WAM target or runtime. This is tooling only.

## Why

Phase E landed the pluggable-policy surface; the measurement / tuning
half stayed deferred because we had no way to cheaply compare layouts
side-by-side. This PR fixes that:

- Run the same predicate through every layout (explicit + both
  auto-policies).
- Report the cheap signals — codegen time + emitted byte count.
- Report what `auto` / `cost_aware` actually picked for this
  predicate (`resolved_as` column), matching the C# harness's
  `auto_planner` line.
- Ratio each row against the cheapest-by-bytes explicit layout, so
  the planner's choice is quantified at a glance.

Host-compile cost and query latency are intentionally out of scope.
Those belong on a desktop environment and can plug into the same TSV
format later.

## What's in this PR

### `measure_wam_elixir_fact_layouts.pl`

Usage:

```
swipl -q -s examples/benchmark/measure_wam_elixir_fact_layouts.pl -- \
    <facts-path> <pred>/<arity>
```

Emits six rows per invocation (one per layout):

- `compiled` — `fact_layout_policy(compiled_only)`.
- `inline_data` — `inline_eager` + `fact_index_policy(none)`.
- `inline_data_indexed` — `inline_eager` + `fact_index_policy(first_arg)`.
- `external_source` — explicit `fact_layout/2` override.
- `auto` — default classifier; `resolved_as` reports which concrete
  layout it chose.
- `cost_aware` — arity-aware policy from PR #1559; same deal.

### `measure_wam_elixir_fact_layouts.py`

Runs the Prolog tool over each `--scales × --predicates` combination,
aggregates, emits a summary:

```
scale  predicate             layout              codegen_ms  module_bytes  resolved_as  ratio_vs_min_bytes
...
```

Defaults cover the small end of the corpus (`dev,300` × `category_parent/2,article_category/2`)
so it runs in under a minute on this box.

## Observed data (current `main`)

```
dev    category_parent/2  compiled             226 KB   10.83x
dev    category_parent/2  inline_data            9 KB    5.28x
dev    category_parent/2  inline_data_indexed   19 KB   10.83x
dev    category_parent/2  external_source      1.8 KB    1.00x
dev    category_parent/2  auto                  19 KB   10.83x  → inline_data
dev    category_parent/2  cost_aware            19 KB   10.83x  → inline_data

300    category_parent/2  compiled             6.9 MB  3827.11x
300    category_parent/2  inline_data          336 KB   185.36x
300    category_parent/2  inline_data_indexed  716 KB   395.35x
300    category_parent/2  external_source      1.8 KB     1.00x
300    category_parent/2  auto                 716 KB   395.35x  → inline_data
300    category_parent/2  cost_aware           716 KB   395.35x  → inline_data
```

Immediate tuning signal worth following up on: at dev scale,
`article_category/2` (32 clauses) has `auto → compiled` but
`inline_data` would be 12× smaller. The default
`fact_count_threshold(100)` / `fact_cost_threshold(200)` may be too
conservative for small-but-ground fact predicates — but confirming
that needs **runtime data**, not just size, which is what a
desktop-environment follow-up will add.

## Test plan

- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_target.pl`
      — 52/52 unchanged (no code changes to emitter/runtime).
- [x] `swipl -q -s examples/benchmark/measure_wam_elixir_fact_layouts.pl -- data/benchmark/dev/facts.pl category_parent/2`
      — emits six rows as expected, resolved_as on auto / cost_aware matches classifier.
- [x] `python3 examples/benchmark/measure_wam_elixir_fact_layouts.py --scales dev,300 --predicates category_parent/2,article_category/2`
      — ~60 seconds end-to-end; output verified above.
- [x] Reproducer `examples/debug_wam_elixir_ancestor.pl` — 4/1/4 unchanged.

No new unit tests — the harness is a thin subprocess-wrapping integration
tool; its correctness is verified by running it. Lightweight enough that
adding unit tests for the glue would be over-engineered.

## Non-goals

- **Runtime profiling** (host-compile ms, query latency, memory).
  Deferred to desktop environment. TSV column set leaves room for
  these to be added without breaking consumers.
- **Auto-tuning** the existing thresholds based on the measured data.
  That's the natural next PR once runtime numbers exist —
  `fact_count_threshold` / `fact_cost_threshold` default values
  calibrated to minimise module size + compile time across a
  representative corpus.
- **Per-arity policies**. The `cost_aware` policy already factors
  arity in; this PR just measures whether its current formula is
  well-tuned.

## Related

- PR #1555 — Phase E pluggable layout policy (this PR measures the
  output of that mechanism).
- PR #1559 — `cost_aware` policy + ETS adaptor (one of the layouts
  this PR compares).
- PR #1561 — SQLite adaptor (another layout).
- `benchmark_effective_distance_matrix.py`, `benchmark_scan_materialization.py`
  — the C# hybrid-WAM harnesses whose output format inspired this
  tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
