### PR TITLE
fix(csharp-query): Fix C# query target generation regressions in cache smoke CI

### DIFF
--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -2360,11 +2360,14 @@ order_free_join_role(Role) :-
 %  a goal that is certified pure (confidence >= 0.85) can be freely
 %  reordered, even if its role is not a standard order-free role.
 %  Pure goals are side-effect-free, so evaluation order is
-%  semantically irrelevant — the optimizer can reorder them for
-%  better join plans (e.g., pushing selective filters earlier).
+%  semantically irrelevant. Constraint and aggregate roles are still
+%  excluded here because they depend on variable-binding order and are
+%  handled by the pipeline builder rather than the join reorderer.
 order_free_join_item(_Term, Role) :-
     order_free_join_role(Role), !.
-order_free_join_item(Term, _Role) :-
+order_free_join_item(Term, Role) :-
+    Role \== constraint,
+    Role \== aggregate,
     nonvar(Term),
     catch(
         analyze_goal_purity(Term, purity_cert(pure, _, Conf, _)),
@@ -3589,13 +3592,11 @@ namespace UnifyWeaver.Generated
         public static (IRelationProvider Provider, QueryPlan Plan) Build()
         {
             var configuredProvider = BuildProvider();
-            var memoryProvider = configuredProvider.MemoryProvider;
-            var provider = configuredProvider.Provider;
-~w            return (provider, CachedPlan.Value);
+            return (configuredProvider.Provider, CachedPlan.Value);
         }
     }
  }
-', [DynamicUsing, SchemaDeclarations, ModuleClass, ProviderMethod, PredStr, Arity, PlanExpr, RecLiteral, InputPosLiteral, ProviderSection]).
+', [DynamicUsing, SchemaDeclarations, ModuleClass, ProviderMethod, PredStr, Arity, PlanExpr, RecLiteral, InputPosLiteral]).
 
 render_plans_to_csharp(Plans, Code) :-
     Plans = [FirstPlan|_],
@@ -4379,6 +4380,11 @@ delimited_reader_literal(Metadata, Arity, Literal) :-
         [InputLiteral, FieldSepLiteral, RecSepLiteral, QuoteLiteral, SkipRows, Arity]).
 
 can_emit_configured_binary_relation(Metadata, Literal) :-
+    (   get_dict(record_format, Metadata, Format0)
+    ->  Format = Format0
+    ;   Format = text_line
+    ),
+    \+ memberchk(Format, [json, jsonl, xml]),
     get_dict(input, Metadata, file(Path)),
     get_dict(field_separator, Metadata, FieldSep0),
     field_separator_char_literal(FieldSep0, FieldSepLiteral),


### PR DESCRIPTION
  ## Summary                                                                                                                                                        
                                                                                                                                                                    
  This PR fixes a set of C# query target generation regressions that were breaking the GitHub Actions C# query cache smoke workflow.                                
                                                                                                                                                                    
  The failures showed up first as a planning regression in `verify_selection_plan`, and then as incorrect cache-admission behavior in the `admission` smoke slice.  
                                                                                                                                                                    
  ## What Was Broken                                                                                                                                                
                                                                                                                                                                    
  ### 1. Selection-plan regression                                                                                                                                  
                                                                                                                                                                    
  `verify_selection_plan` failed because purity-based join reordering was treating constraint goals as order-free join items.                                       
                                                                                                                                                                    
  That let simple filters such as `X = alice` enter the join reorderer, where they were later scored like relations instead of being handled by the constraint      
  pipeline logic.                                                                                                                                                   
                                                                                                                                                                    
  ### 2. JSON dynamic-source regression                                                                                                                             
                                                                                                                                                                    
  The generated C# query target also regressed for JSONPath-backed dynamic sources.                                                                                 
                                                                                                                                                                    
  The new configured binary-relation emission path was too broad and treated JSON inputs like simple delimited binary files, which bypassed the JSONPath-aware      
  reader generation and broke `verify_json_jsonpath_source_plan`.                                                                                                   
                                                                                                                                                                    
  ### 3. Cache smoke admission regression                                                                                                                           
                                                                                                                                                                    
  The cache smoke failures were caused by generated single-plan modules loading facts twice:                                                                        
                                                                                                                                                                    
  - once in `BuildProvider()`                                                                                                                                       
  - again in `Build()`                                                                                                                                              
                                                                                                                                                                    
  That duplicated in-memory relation contents, inflated grouped and mixed reachability inputs, and caused cache admission counters and hot/cold behavior to diverge 
  from the expected smoke outputs.                                                                                                                                  
                                                                                                                                                                    
  ## Changes                                                                                                                                                        
                                                                                                                                                                    
  In [src/unifyweaver/targets/csharp_target.pl](src/unifyweaver/targets/csharp_target.pl):                                                                          
                                                                                                                                                                    
  - excluded `constraint` and `aggregate` roles from purity-based order-free join reordering                                                                        
  - restricted configured binary-relation emission so `json`, `jsonl`, and `xml` remain on their existing specialized reader/codegen paths                          
  - removed duplicate provider population from the single-plan generated module template so `Build()` now reuses the provider built by `BuildProvider()` instead of 
  replaying fact registration                                                                                                                                       
                                                                                                                                                                    
  ## Validation                                                                                                                                                     
                                                                                                                                                                    
  ### Prolog query target suite                                                                                                                                     
                                                                                                                                                                    
  Ran:                                                                                                                                                              
                                                                                                                                                                    
  ```bash                                                                                                                                                           
  env SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g "test_csharp_query_target:test_csharp_query_target" -t halt          
                                                                                                                                                                    
  Result:                                                                                                                                                           
                                                                                                                                                                    
  - passed through the full 239/239 query-target checks                                                                                                             
                                                                                                                                                                    
  ### C# runtime build                                                                                                                                              
                                                                                                                                                                    
  Ran:                                                                                                                                                              
                                                                                                                                                                    
  dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c Release --nologo                                                
                                                                                                                                                                    
  Result:                                                                                                                                                           
                                                                                                                                                                    
  - passed with no build errors                                                                                                                                     
                                                                                                                                                                    
  ### Cache smoke workflow repro                                                                                                                                    
                                                                                                                                                                    
  Ran:                                                                                                                                                              
                                                                                                                                                                    
  pwsh -NoProfile -File scripts/testing/run_csharp_query_cache_smoke_sequence.ps1 -OutputDir tmp/csharp_query_smoke_local_fix -SummaryPath tmp/                     
  csharp_query_smoke_local_fix/cache_smoke_sequence_summary.md                                                                                                      
                                                                                                                                                                    
  Result:                                                                                                                                                           
                                                                                                                                                                    
  - the previously failing admission slice passed                                                                                                                   
  - the run advanced into the subsequent reuse slice with the formerly failing grouped and mixed admission cases now passing                                        
                                                                                                                                                                    
  ## Why This PR Is Narrow                                                                                                                                          
                                                                                                                                                                    
  This PR does not change cache policy semantics.                                                                                                                   
                                                                                                                                                                    
  It fixes code generation so the runtime sees the intended logical inputs again:                                                                                   
                                                                                                                                                                    
  - constraints stay out of the join reorderer                                                                                                                      
  - JSON sources stay on JSON-aware readers                                                                                                                         
  - generated query modules stop double-loading facts                                                                                                               
                                                                                                                                                                    
  That restores the expected planner and cache smoke behavior without widening the scope into unrelated runtime policy work.                                        