### PR TITLE
docs(wam): cross-reference Haskell fact-access trilogy from Elixir plan

### DIFF
--- a/docs/proposals/WAM_FACT_SHAPE_PLAN.md
+++ b/docs/proposals/WAM_FACT_SHAPE_PLAN.md
@@ -191,7 +191,17 @@ Targets in rough priority order (unchanged from the original plan):
 2. `wam_go_target`, `wam_rust_target` — both compile facts to
    functions today.
 3. `wam_haskell_target` — has its own fact-heavy fast paths; fit may
-   already be acceptable, worth measuring first.
+   already be acceptable, worth measuring first. **Design trilogy
+   already drafted** — see
+   `WAM_HASKELL_FACT_ACCESS_PHILOSOPHY.md`,
+   `WAM_HASKELL_FACT_ACCESS_SPEC.md`, and
+   `WAM_HASKELL_FACT_ACCESS_PLAN.md` (commit `776c9c2`). Those docs
+   reuse the `compiled` / `inline_data` / `external_source`
+   vocabulary from this plan verbatim, confirming it as the
+   cross-target standard. Phased rollout F1–F6 mirrors this one;
+   F6 in particular specs a `MmapFactSource` that Elixir could
+   parallel once the binary artifact format stabilises
+   (see below).
 4. `wam_csharp_native_target` — the C# side is already on the
    materialization-aware runtime, but the WAM-generated-code side may
    still compile facts as methods.
@@ -267,3 +277,33 @@ matches native SWI byte-for-byte at every scale except dev (where
 summation-order difference — semantically correct, dominant on tiny
 data because bigger data aggregates more paths). Total parity:
 **9193 rows across 10x / 300 / 1k / 5k / 10k scales exact**.
+
+## Cross-target alignment notes
+
+Ideas surfaced in sibling target-design docs that would cross-apply
+back to the Elixir side without changing Phases A–E's scope:
+
+- **Binary-artifact (`Mmap`) `FactSource` adaptor.** Parallels the
+  Haskell plan's Phase F6 and consumes the artifact format described
+  in `PREPROCESSED_PREDICATE_ARTIFACTS.md`. Would slot alongside
+  `Tsv` / `Ets` / `Sqlite` in the existing
+  `WamRuntime.FactSource` behaviour without any emitter or registry
+  change. Deferred until the artifact format stabilises on the C#
+  side (ongoing via the `csharp-query` PRs).
+- **Purity / order-independence feedback loop.** The Haskell
+  philosophy doc (`WAM_HASKELL_FACT_ACCESS_PHILOSOPHY.md` §
+  "Connection to purity, order-independence, and parallelism")
+  observes that goal reordering affects which fact predicates get
+  probed, which access patterns dominate, and therefore which
+  layout is optimal. If `PURITY_CERTIFICATE_SPECIFICATION.md`-style
+  certificates reach the Elixir target, the `cost_aware` policy
+  (PR #1559) becomes a natural consumer — probe-count hints could
+  feed the `user:wam_elixir_layout_policy/5` hook that Phase E
+  exposed.
+- **Laziness trade-offs.** Haskell's default lazy semantics let its
+  fact sources stream without special machinery; Elixir is strict
+  by default, so our `inline_data` holds the full `@facts` list in
+  the BEAM literal pool. A future `Stream`-based `inline_data`
+  variant would only help if paired with a predicate that never
+  backtracks past the first solution — the existing shape is fine
+  for now and matches how other strict targets behave.

--- a/docs/proposals/WAM_FACT_SHAPE_SPEC.md
+++ b/docs/proposals/WAM_FACT_SHAPE_SPEC.md
@@ -1,5 +1,17 @@
 # WAM Fact Shape Specification
 
+## Cross-target status
+
+This spec was originally written for the Elixir target (landed in
+Phases A–E, PRs #1511/#1519/#1525/#1551/#1555). The Haskell target's
+fact-access trilogy
+(`WAM_HASKELL_FACT_ACCESS_{PHILOSOPHY,SPEC,PLAN}.md`, commit
+`776c9c2`) adopts the same classification vocabulary
+(`compiled` / `inline_data` / `external_source`) and the same
+`FactSource` shape (`open/3`, `stream_all/2`, `lookup_by_arg1/3`,
+`close/2`) verbatim — so the terms defined below are treated as the
+cross-target contract, not just Elixir nomenclature.
+
 ## Scope
 
 This document specifies the contract between the WAM lowered emitter


### PR DESCRIPTION
## Summary

Docs-only. Adds mutual back-references between the existing Elixir
fact-shape proposal triplet and the new Haskell fact-access trilogy
landed in commit `776c9c2`
(`WAM_HASKELL_FACT_ACCESS_{PHILOSOPHY,SPEC,PLAN}.md`). Also captures
three ideas surfaced by the Haskell docs that cross-apply back to
Elixir **without changing any of Phases A–E**.

## Why

The Haskell fact-access trilogy reuses Elixir's classification
vocabulary and `FactSource` shape verbatim, confirming them as the
cross-target contract — but neither side references the other, so
future readers have to discover the connection on their own. This PR
makes the contract-sharing explicit.

## What's in this PR

### `WAM_FACT_SHAPE_PLAN.md`

- **Phase F § `wam_haskell_target` bullet** — updated to note that
  the design trilogy already exists (the three new docs) and that
  their phased rollout F1–F6 mirrors this plan's A–E plus a future
  `MmapFactSource` (F6).

- **New "Cross-target alignment notes" section** at the end,
  capturing three ideas from the Haskell docs that cross-apply to
  Elixir:

  1. **Binary-artifact (`Mmap`) `FactSource` adaptor.** Parallels
     Haskell's F6 and consumes the binary artifact format from
     `PREPROCESSED_PREDICATE_ARTIFACTS.md`. Slots alongside
     `Tsv` / `Ets` / `Sqlite` in the existing behaviour without
     any emitter or registry change. Deferred until the format
     stabilises on the C# side.

  2. **Purity / order-independence feedback loop.** From the
     Haskell philosophy doc's § "Connection to purity,
     order-independence, and parallelism": goal reordering
     affects which fact predicates get probed and how, which
     affects optimal layout. If purity certificates reach the
     Elixir target, the `cost_aware` policy (PR #1559) becomes a
     natural consumer — probe-count hints could feed the Phase-E
     user hook (`user:wam_elixir_layout_policy/5`).

  3. **Laziness trade-offs.** Haskell streams for free; Elixir is
     strict, so `inline_data` holds the full `@facts` list in the
     BEAM literal pool. A `Stream`-based variant would only pay
     off for first-solution-only queries — current shape matches
     other strict targets and is fine.

### `WAM_FACT_SHAPE_SPEC.md`

- **New "Cross-target status" preamble** at the top. Declares that
  the terms defined below are the cross-target contract (not just
  Elixir-specific) since the Haskell trilogy adopts them verbatim.
  Future Clojure / Go / Rust / C# ports can cite this spec without
  disclaiming "Elixir-only."

## Test plan

No code changes. Sanity-checked:

- [x] Docs render correctly — section headers and cross-refs
      resolve.
- [x] `swipl -q -g run_tests -t halt -s tests/test_wam_elixir_target.pl`
      — 52/52 unchanged (docs-only PR).

## Non-goals

- **Implementing any of the three cross-apply ideas.** They're
  documented as future work. Each would be a separate PR.
- **Scope creep into Phase F.** Cross-target ports stay deferred
  per the existing plan entry; this PR just cross-links the
  Haskell-side design work that will inform Phase F when it
  happens.
- **Changing the Haskell docs.** They're correct as-landed; we're
  adding back-references from Elixir, not forward-references from
  Haskell.

## Related

- Commit `776c9c2` — the Haskell fact-access trilogy this PR
  cross-references.
- PR #1556 — the Elixir plan-status PR this extends.
- `docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md` — the C# artifact
  direction that both the Haskell F6 and the proposed Elixir
  `Mmap` adaptor would consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
