### PR TITLE
feat(wam-haskell): end-to-end wiring for inline_data fact access

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -41,7 +41,9 @@
     % Phase F3: inline_data emission
     extract_fact_tuples_hs/2,            % +Segments, -Tuples
     haskell_fact_list_name/2,            % +PredName, -ListName
-    init_atom_intern_table/0             % reinitialize atom intern table
+    init_atom_intern_table/0,            % reinitialize atom intern table
+    % E2E wiring
+    generate_inline_facts_wiring/2       % +InlineDefs, -Code
 ]).
 
 :- use_module(library(lists)).
@@ -2480,7 +2482,7 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     % lowered ones — so backtrack can land on alternate clauses that the
     % lowered function doesn't handle. Phase 4+ lowered functions only
     % inline clause 1; clause 2+ runs through the interpreter on backtrack.
-    compile_predicates_to_haskell(Predicates, Options, PredsCode0),
+    compile_predicates_to_haskell(Predicates, Options, PredsCode0, InlineDefs),
     % Append compile-time atom table to Predicates.hs
     emit_atom_table_haskell(AtomTableCode),
     format(string(PredsCode0WithAtoms), "~w~n~n~w", [PredsCode0, AtomTableCode]),
@@ -2506,8 +2508,8 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     directory_file_path(ProjectDir, CabalFile, CabalPath),
     write_hs_file(CabalPath, CabalCode),
 
-    % Generate Main.hs
-    generate_main_hs(Predicates, DetectedKernels, Options, MainCode0),
+    % Generate Main.hs (InlineDefs from F3 → wcInlineFacts wiring)
+    generate_main_hs(Predicates, DetectedKernels, InlineDefs, Options, MainCode0),
     apply_hashmap_rewrite(UseHM, main, MainCode0, MainCode),
     directory_file_path(SrcDir, 'Main.hs', MainPath),
     write_hs_file(MainPath, MainCode),
@@ -2621,14 +2623,16 @@ emit_lowered_entries_rest([lowered(PredName, FuncName, _)|Rest]) :-
     format("    , (\"~w\", ~w)~n", [PredName, FuncName]),
     emit_lowered_entries_rest(Rest).
 
-%% generate_main_hs(+Predicates, +DetectedKernels, +Options, -Code)
+%% generate_main_hs(+Predicates, +DetectedKernels, +InlineDefs, +Options, -Code)
 %  Generates Main.hs — a benchmark driver for effective-distance.
 %  Reads main.hs.mustache and populates template variables.
+%  InlineDefs from Phase F3: list of inline_fact(PredName, ListName, _)
+%  terms that need wcInlineFacts wiring.
 %  Options:
 %    query_pred(Pred/Arity) — use a WAM-compiled aggregation predicate
 %      instead of the default collectSolutions loop. The predicate should
 %      accept (Cat, Root, WeightSum) and return the accumulated weight sum.
-generate_main_hs(_Predicates, DetectedKernels, Options, Code) :-
+generate_main_hs(_Predicates, DetectedKernels, InlineDefs, Options, Code) :-
     read_kernel_template('main.hs.mustache', Template),
     detected_kernel_keys(DetectedKernels, Keys),
     format_foreign_preds(Keys, ForeignPredsStr),
@@ -2648,6 +2652,8 @@ generate_main_hs(_Predicates, DetectedKernels, Options, Code) :-
     hPutStrLn stderr $ "demand_filtered_nodes=" ++ show filteredSize'
     ;   DemandMetrics = ''
     ),
+    % Phase F3/F4: generate wcInlineFacts wiring from InlineDefs
+    generate_inline_facts_wiring(InlineDefs, InlineFactsWiring),
     render_template(Template,
         [ foreign_preds=ForeignPredsStr
         , query_body=QueryBody
@@ -2655,7 +2661,21 @@ generate_main_hs(_Predicates, DetectedKernels, Options, Code) :-
         , demand_filter=DemandFilter
         , facts_source=FactsSource
         , demand_metrics=DemandMetrics
+        , inline_facts=InlineFactsWiring
         ], Code).
+
+%% generate_inline_facts_wiring(+InlineDefs, -Code)
+%  Generates the Haskell code to populate wcInlineFacts in the WamContext.
+%  Each inline_fact(PredName, ListName, _) becomes a Map entry.
+generate_inline_facts_wiring([], '') :- !.
+generate_inline_facts_wiring(InlineDefs, Code) :-
+    maplist([inline_fact(PredName, ListName, _), Entry]>>(
+        format(string(Entry), '("~w", ~w)', [PredName, ListName])
+    ), InlineDefs, Entries),
+    atomic_list_concat(Entries, ', ', EntriesStr),
+    format(string(Code),
+           '            , wcInlineFacts   = Map.fromList [~w]',
+           [EntriesStr]).
 
 %% generate_demand_filter(+DetectedKernels, +Options, -FilterCode, -FactsSource)
 %  When demand filtering is enabled (kernels detected with an edge predicate),

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -149,6 +149,7 @@ main = do
             , wcLoweredPredicates = Lowered.loweredPredicates
             , wcInternTable   = fullInternTable
             , wcFfiFacts      = Map.singleton "category_parent" {{facts_source}}
+{{inline_facts}}
             }
 
     t2 <- getCurrentTime

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1125,9 +1125,67 @@ test_f4_stream_fact_rows_helper :-
     ;   fail_test(Test, 'streamFactRows helper not found')
     ).
 
+%% E2E: fact access wiring tests
+%% -----------------------------------------------
+
+test_e2e_inline_data_project_has_call_fact_stream :-
+    Test = 'E2E: inline_data project emits CallFactStream in allCode',
+    (   retractall(user:e2e_edge(_, _)),
+        forall(between(1, 6, I), (
+            atom_number(A, I),
+            atom_concat(src_, A, S),
+            atom_concat(dst_, A, D),
+            assert(user:e2e_edge(S, D))
+        )),
+        init_atom_intern_table,
+        wam_haskell_target:compile_predicates_to_haskell(
+            [e2e_edge/2], [fact_count_threshold(5)], Code, InlineDefs),
+        atom_string(Code, CS),
+        sub_string(CS, _, _, _, "CallFactStream"),
+        InlineDefs = [inline_fact(_, _, _)]
+    ->  pass(Test)
+    ;   fail_test(Test, 'CallFactStream not in allCode or InlineDefs missing')
+    ),
+    retractall(user:e2e_edge(_, _)).
+
+test_e2e_inline_facts_wiring_generated :-
+    Test = 'E2E: generate_inline_facts_wiring produces wcInlineFacts code',
+    (   InlineDefs = [inline_fact("my_pred", 'myPredFacts', "...")],
+        wam_haskell_target:generate_inline_facts_wiring(InlineDefs, Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "wcInlineFacts"),
+        sub_string(S, _, _, _, "\"my_pred\""),
+        sub_string(S, _, _, _, "myPredFacts")
+    ->  pass(Test)
+    ;   fail_test(Test, 'wcInlineFacts wiring code not generated correctly')
+    ).
+
+test_e2e_empty_inline_defs_no_wiring :-
+    Test = 'E2E: empty InlineDefs produces no wcInlineFacts wiring',
+    (   wam_haskell_target:generate_inline_facts_wiring([], Code),
+        Code == ''
+    ->  pass(Test)
+    ;   fail_test(Test, 'Empty InlineDefs should produce empty wiring code')
+    ).
+
+test_e2e_below_threshold_no_inline :-
+    Test = 'E2E: below-threshold project has no CallFactStream or inline facts',
+    (   retractall(user:e2e_sm(_, _)),
+        assert(user:e2e_sm(x, y)),
+        init_atom_intern_table,
+        wam_haskell_target:compile_predicates_to_haskell(
+            [e2e_sm/2], [fact_count_threshold(5)], Code, InlineDefs),
+        atom_string(Code, CS),
+        \+ sub_string(CS, _, _, _, "CallFactStream"),
+        InlineDefs == []
+    ->  pass(Test)
+    ;   fail_test(Test, 'Below-threshold should have no CallFactStream or InlineDefs')
+    ),
+    retractall(user:e2e_sm(_, _)).
+
 run_tests :-
     format('~n========================================~n'),
-    format('WAM-Haskell target: Phase 5+6+7+8+F1-F4 codegen tests~n'),
+    format('WAM-Haskell target: Phase 5+6+7+8+F1-F4+E2E codegen tests~n'),
     format('========================================~n~n'),
     test_haskell_helper_functions_present,
     test_haskell_functor_builtin_present,
@@ -1217,6 +1275,11 @@ run_tests :-
     test_f4_intmap_fact_source_function,
     test_f4_stream_facts_fallback_to_fact_sources,
     test_f4_stream_fact_rows_helper,
+    %% E2E: fact access wiring
+    test_e2e_inline_data_project_has_call_fact_stream,
+    test_e2e_inline_facts_wiring_generated,
+    test_e2e_empty_inline_defs_no_wiring,
+    test_e2e_below_threshold_no_inline,
     format('~n========================================~n'),
     (   test_failed
     ->  format('Tests FAILED~n'), halt(1)


### PR DESCRIPTION
  ## Summary

  - Wires `InlineDefs` from `compile_predicates_to_haskell` through `write_wam_haskell_project` to the generated `Main.hs`, closing the last
  gap in the F1-F5 fact access pipeline
  - Above-threshold fact predicates now get the full end-to-end path: `CallFactStream` instruction in `allCode`, interned `(Int, Int)` literal
   list in `Predicates.hs`, and `wcInlineFacts = Map.fromList [...]` wiring in `Main.hs`
  - Below-threshold predicates remain on the compiled WAM path unchanged

  ## What's included

  | Component | Purpose |
  |-----------|---------|
  | `write_wam_haskell_project` uses 4-arg `compile_predicates_to_haskell` | Captures `InlineDefs` instead of discarding them |
  | `generate_main_hs` accepts `InlineDefs` parameter | Passes inline fact metadata to template rendering |
  | `generate_inline_facts_wiring/2` | Formats `Map.fromList` entries for `wcInlineFacts` |
  | `{{inline_facts}}` in `main.hs.mustache` | Template placeholder for context wiring |
  | 4 new E2E tests | Verify wiring for above-threshold and no-wiring for below-threshold |

  ## Verified with project generation

  $ swipl -g "write_wam_haskell_project([test_edge/2], [fact_count_threshold(5)], ...)"
    test_edge/2: fact_only=true, clauses=8, layout=inline_data([])
    [F3] test_edge/2: emitting inline_data (8 tuples)

  Generated `Predicates.hs` contains `CallFactStream "test_edge" 2` + `testEdgeFacts :: [(Int, Int)]`.
  Generated `Main.hs` contains `wcInlineFacts = Map.fromList [("test_edge", testEdgeFacts)]`.

  ## Test plan

  - [x] 4 new E2E tests pass (inline wiring, empty wiring, below-threshold no-wiring)
  - [x] All F1-F4 tests pass (no regressions)
  - [x] All existing Haskell target tests pass
  - [x] Purity certificate tests pass (70/70)