### PR TITLE
docs(wam-haskell): fact backend design — mmap, SQLite, Datomic-style

### DIFF
--- a/docs/proposals/WAM_HASKELL_FACT_BACKEND_DESIGN.md
+++ b/docs/proposals/WAM_HASKELL_FACT_BACKEND_DESIGN.md
@@ -1,0 +1,411 @@
+# WAM Haskell Fact Backend Design
+
+## Summary
+
+The Haskell WAM target needs pluggable fact backends that go beyond the
+current strict IntMap and inline literal list options. At 10k+ scale,
+neither compiled WAM instructions nor inline Haskell literals are viable
+(GHC compilation time is prohibitive for 100k-line arrays). The target
+needs backends that can serve indexed lookups without full in-memory
+materialization while remaining compatible with the `parMap rdeepseq`
+parallelism model.
+
+This document designs a unified `FactBackend` interface for the Haskell
+WAM target, covering memory-mapped binary files, embedded databases,
+and future backend types. It builds on the `FactSource` abstraction
+from Phase F4 and draws from the C# query runtime's
+`IRelationProvider` / `IRetentionAwareRelationProvider` hierarchy and
+the cross-target `PREPROCESSED_PREDICATE_ARTIFACTS.md` proposal.
+
+## Current state
+
+The Haskell WAM target has four fact access paths today:
+
+| Path | Introduced | Scale | Parallelism | Access |
+|------|-----------|-------|-------------|--------|
+| Compiled WAM instructions | Original | Small (<100) | Safe (immutable code array) | O(1) SwitchOnConstant dispatch |
+| Strict IntMap (FFI) | Phase E | Any | Safe (immutable) | O(log n) IntMap lookup |
+| inline_data literals (F3) | Phase F3 | Medium (100-1000) | Safe (immutable list) | O(n) scan or O(log n) with index |
+| FactSource (F4) | Phase F4 | Any (abstract) | Depends on backend | Via fsScan / fsLookupArg1 |
+
+The FactSource interface (F4) provides the right abstraction boundary
+but currently only has two concrete implementations:
+
+- `tsvFactSource` — lazy IO TSV reader. Not useful for repeated lookups
+  (caches everything on first access anyway).
+- `intMapFactSource` — wraps existing strict IntMap. No improvement over
+  the direct IntMap path.
+
+Neither solves the 10k+ scale problem where we need indexed lookups
+without full materialization.
+
+## Design principle
+
+**Separate the access contract from the storage engine.**
+
+The WAM interpreter asks for facts through a narrow interface:
+- Scan all rows
+- Lookup by first argument (indexed)
+- Close / release resources
+
+The backend decides how to serve those requests. The planner (compile
+time + runtime) decides which backend to use based on:
+- Predicate scale (clause count, estimated row count)
+- Access pattern (scan-only, repeated indexed lookups, graph expansion)
+- Platform capabilities (mmap, threading, available databases)
+- User declarations (`fact_layout/2`, `environment/1`)
+
+This mirrors the C# query runtime's approach where `IRelationProvider`
+defines the contract and concrete providers (`BinaryRelationArtifactProvider`,
+`InMemoryRelationProvider`, `ConfiguredDelimitedRelationProvider`) serve it.
+
+## The FactBackend typeclass
+
+The F4 `FactSource` record is adequate for the current two-column case
+but becomes awkward for wider arities and richer access patterns. We
+extend it to a `FactBackend` typeclass that backends implement:
+
+```haskell
+-- | Access pattern descriptors for the planner.
+data AccessPattern
+  = Scan                     -- full sequential scan
+  | PointLookup !Int         -- lookup by column N (0-indexed)
+  | PrefixLookup ![Int]      -- lookup by leading columns
+  | AdjacencyExpand !Int     -- graph expansion from column N
+  deriving (Show, Eq)
+
+-- | Backend capabilities reported to the planner.
+data BackendCaps = BackendCaps
+  { bcSupports     :: [AccessPattern]
+  , bcParSafe      :: !Bool           -- safe under parMap?
+  , bcEstimatedRows :: !(Maybe Int)   -- hint for planner
+  } deriving (Show)
+
+-- | Unified fact backend interface.
+-- All methods return IO because some backends (mmap, database) need it.
+-- The WAM interpreter bridges to pure code via unsafePerformIO in
+-- streamFacts, which is safe because backends are read-only after the
+-- force barrier.
+class FactBackend a where
+  fbScan       :: a -> IO [(Int, Int)]
+  fbLookup     :: a -> Int -> IO [(Int, Int)]  -- lookup by arg1
+  fbCaps       :: a -> BackendCaps
+  fbClose      :: a -> IO ()
+```
+
+The existing `FactSource` record becomes one implementation strategy
+(existential wrapper for the typeclass). The `wcFactSources` field in
+WamContext continues to work unchanged — backends are wrapped in a
+`FactSource` at registration time.
+
+## Backend: MmapFactSource
+
+Memory-mapped binary files for indexed point lookups. The ideal backend
+for desktop/server where mmap is available.
+
+### Why mmap
+
+- **No resident memory**: the OS page cache handles loading. Only pages
+  touched by queries are faulted in. A 100MB relation occupies zero
+  application heap.
+- **Parallelism-safe**: each thread reads by dereferencing independent
+  virtual addresses. No file handle contention, no locks. This is why
+  the philosophy doc identified mmap as the ideal parallel data source.
+- **Startup cost**: near-zero. `mmap()` returns a pointer immediately;
+  pages load on demand.
+- **GHC integration**: `bytestring` provides `ByteString` backed by
+  `ForeignPtr` which can point into an mmap'd region. The `mmap`
+  package (or `System.Posix.IO.ByteString`) handles the mapping.
+
+### Binary format
+
+Consume the C# target's `.uwbr` (UnifyWeaver Binary Relation) format,
+which already defines:
+- Row-based data with offset indexing
+- Partitioned hash index for point lookups
+- Per-column covering bucket sidecars
+- JSON manifest with predicate, arity, source hash, capabilities
+
+For the Haskell consumer, the minimum viable format is:
+
+```
+[Header: 16 bytes]
+  magic:    4 bytes  "UWBR"
+  version:  4 bytes  uint32 LE
+  nrows:    4 bytes  uint32 LE
+  ncols:    4 bytes  uint32 LE  (2 for current use)
+
+[Key directory: nkeys * 12 bytes]
+  key:      4 bytes  int32 LE (interned atom ID)
+  offset:   4 bytes  uint32 LE (byte offset into data section)
+  count:    4 bytes  uint32 LE (number of rows for this key)
+
+[Data section: nrows * ncols * 4 bytes]
+  Each row is ncols int32 LE values (interned atom IDs)
+```
+
+Point lookup: binary search the key directory (O(log n)), then read
+`count` rows starting at `offset`. All via pointer arithmetic on the
+mmap'd region — no allocation, no IO syscalls.
+
+### Haskell implementation sketch
+
+```haskell
+data MmapFactSource = MmapFactSource
+  { mfsPtr     :: !(ForeignPtr Word8)  -- mmap'd region
+  , mfsLen     :: !Int                 -- total bytes
+  , mfsNRows   :: !Int
+  , mfsNCols   :: !Int
+  , mfsKeyDir  :: !(Ptr Word8)         -- start of key directory
+  , mfsNKeys   :: !Int
+  , mfsData    :: !(Ptr Word8)         -- start of data section
+  }
+
+instance FactBackend MmapFactSource where
+  fbScan mfs = return $ readAllRows mfs
+  fbLookup mfs key = return $ binarySearchAndRead mfs key
+  fbCaps _ = BackendCaps
+    { bcSupports = [Scan, PointLookup 0]
+    , bcParSafe = True
+    , bcEstimatedRows = Nothing  -- read from header
+    }
+  fbClose _ = return ()  -- GC handles munmap via ForeignPtr
+```
+
+### Platform constraints
+
+- **Linux/macOS/Windows**: full mmap support. Default on desktop.
+- **Termux/Android**: filesystem-dependent. May work on internal
+  storage but fail on SD card (FAT32). Environment predicate
+  `environment(mmap(false))` disables this backend.
+- **WASM**: no mmap. Must use database or in-memory backend.
+
+## Backend: SqliteFactSource
+
+SQLite for platforms where mmap is unavailable or restricted.
+
+### Why SQLite
+
+- **Universal availability**: works on Termux, Android, iOS, desktop,
+  server. No filesystem restrictions.
+- **Indexed lookups**: CREATE INDEX on arg1 gives O(log n) lookups
+  without loading everything into memory.
+- **WAL mode**: concurrent readers with single writer. Adequate for
+  read-only fact access during queries.
+- **Mature Haskell bindings**: `sqlite-simple` or `direct-sqlite`.
+
+### Embedding vs system library
+
+SQLite can be statically embedded into the Haskell binary or linked
+against the system library. The tradeoff:
+
+- **Embedded** (`direct-sqlite` with bundled amalgamation): no runtime
+  dependency, works on any platform, but adds ~1MB to the binary and
+  memory footprint. Good for Termux/Android where the system SQLite
+  may be an older version.
+- **System library** (`sqlite-simple` linking to `-lsqlite3`): smaller
+  binary, shared memory with other processes using SQLite, but requires
+  the library to be installed. Good for desktop/server.
+
+The choice should be gated by a build option (e.g., `embedded_sqlite(true)`
+in the cabal generation) so the user can decide based on their deployment.
+
+### Parallelism strategy
+
+SQLite in default journal mode has a single-writer lock that blocks
+readers. Under `parMap rdeepseq`:
+
+**Option A: Read-once-then-split** (recommended for first implementation)
+Load needed facts into an immutable IntMap before the parallel section.
+The SQLite connection is used only during context construction, not
+during the parallel seed loop.
+
+**Option B: Per-worker connections**
+Each spark opens its own read-only SQLite connection. Works with WAL
+mode but multiplies connection overhead. Better for very large datasets
+where full materialization is too expensive.
+
+**Option C: Single pre-parallel query**
+Query all facts once, partition by seed assignment, pass each partition
+to its spark. The database is accessed once; parallelism operates on
+the partitioned data.
+
+### Schema
+
+```sql
+CREATE TABLE facts_2 (
+  predicate TEXT NOT NULL,
+  arg1 INTEGER NOT NULL,    -- interned atom ID
+  arg2 INTEGER NOT NULL,    -- interned atom ID
+  PRIMARY KEY (predicate, arg1, arg2)
+);
+CREATE INDEX idx_facts_2_arg1 ON facts_2(predicate, arg1);
+```
+
+For wider arities, the schema generalizes to `arg1..argN` columns.
+
+### Haskell implementation sketch
+
+```haskell
+data SqliteFactSource = SqliteFactSource
+  { sfsConn    :: !Connection          -- sqlite-simple connection
+  , sfsPred    :: !String              -- predicate name
+  }
+
+instance FactBackend SqliteFactSource where
+  fbScan sfs = query_ (sfsConn sfs)
+    "SELECT arg1, arg2 FROM facts_2 WHERE predicate = ?"
+  fbLookup sfs key = query (sfsConn sfs)
+    "SELECT arg1, arg2 FROM facts_2 WHERE predicate = ? AND arg1 = ?"
+    (sfsPred sfs, key)
+  fbCaps _ = BackendCaps
+    { bcSupports = [Scan, PointLookup 0]
+    , bcParSafe = False  -- not safe under parMap without Option A/B
+    , bcEstimatedRows = Nothing
+    }
+  fbClose sfs = close (sfsConn sfs)
+```
+
+## Backend: Immutable/append-only databases (Datomic-style)
+
+Datomic (Clojure ecosystem) is interesting because its data model
+aligns naturally with logic programming:
+
+- **Facts are immutable datoms**: `[entity attribute value tx]`. Once
+  asserted, never modified — only retracted by new assertions.
+- **Time-travel**: every query runs against a stable database value
+  (`db`). No locks needed because the value is immutable.
+- **Datalog-adjacent**: Datomic's query language IS Datalog. The
+  mapping to Prolog fact access is natural.
+- **Parallelism-safe by design**: immutable snapshots can be shared
+  across threads with zero coordination.
+
+### Relevance to Haskell
+
+Haskell's immutability model maps perfectly to Datomic's:
+- A `db` value is like a Haskell value — referentially transparent
+- Multiple threads can hold the same `db` with no locking
+- Queries are pure functions over an immutable snapshot
+
+### Candidate implementations for Haskell
+
+Datomic itself is JVM-only. Haskell equivalents:
+
+| System | Status | Notes |
+|--------|--------|-------|
+| **Datahike** | Clojure (JVM/JS) | Open-source Datomic-compatible, Datalog query engine |
+| **Datascript** | ClojureScript | In-memory Datalog database, portable |
+| **Custom Haskell** | Not yet | Build a simple datom store with HAMT-backed indexes |
+| **XTDB v2** | JVM | Bitemporal, SQL + Datalog |
+
+For a first implementation, the pragmatic path is a **datom-shaped
+IntMap store**: facts stored as `(entity, attribute, value)` triples
+with IntMap indexes on each component. This gives Datomic-like
+semantics (immutable, snapshot-queryable, parallelism-safe) without
+a JVM dependency.
+
+```haskell
+data DatomStore = DatomStore
+  { dsEAV :: !(IM.IntMap (IM.IntMap [Int]))  -- entity -> attr -> [values]
+  , dsAEV :: !(IM.IntMap (IM.IntMap [Int]))  -- attr -> entity -> [values]
+  , dsAVE :: !(IM.IntMap (IM.IntMap [Int]))  -- attr -> value -> [entities]
+  }
+```
+
+For the fact access use case (2-arg predicates like `category_parent/2`),
+the datom model maps to: entity=arg1, attribute=predicate, value=arg2.
+The AVE index gives O(log n) lookup by arg1.
+
+This is future work — the immediate priority is MmapFactSource and
+SqliteFactSource.
+
+## Other backends to consider
+
+| Backend | Ecosystem | Use case | Priority |
+|---------|-----------|----------|----------|
+| **RocksDB/LMDB** | C/C++ via FFI | Sorted key-value, range scans | Medium — when range predicates matter |
+| **DuckDB** | C via FFI | Analytical queries, columnar | Low — overkill for point lookups |
+| **Redis** | Network | Shared hot lookups across workers | Low — network latency |
+| **Arrow/Parquet** | Cross-platform | Columnar batch scans | Low — better for Python/Rust |
+
+## Planner integration
+
+The compile-time planner (Prolog codegen) already classifies predicates
+and selects layouts. The backend selection extends this:
+
+```prolog
+% User declares backend preference
+:- fact_layout(category_parent/2, external_source(mmap("data/cp.uwbr"))).
+:- fact_layout(category_parent/2, external_source(sqlite("data/facts.db"))).
+
+% Environment constraints gate backend availability
+:- environment(mmap(false)).    % Termux: disable mmap
+:- environment(sqlite(true)).   % Termux: SQLite available
+```
+
+The runtime planner checks:
+1. Is the declared backend available on this platform?
+2. Does it support the required access pattern?
+3. Fall back to the next option (SQLite → IntMap → compiled).
+
+## Interaction with existing paths
+
+The `FactBackend` typeclass does NOT replace:
+- **FFI kernel path** (`wcFfiFacts`): native kernels need strict IntMaps
+  for maximum throughput. The backend abstraction serves the WAM
+  interpreter path.
+- **Compiled WAM path**: small predicates (<100 clauses) continue to
+  use SwitchOnConstant dispatch. No overhead, no indirection.
+- **inline_data path** (F3): medium predicates (100-1000) use Haskell
+  literals. No IO, no backend indirection.
+
+The backend path activates for:
+- Large predicates (>1000 clauses) where GHC compilation and in-memory
+  lists are impractical
+- External data sources declared with `fact_layout(..., external_source(...))`
+- Runtime-loaded facts that don't benefit from compile-time indexing
+
+## Implementation phases
+
+### Phase B1: MmapFactSource (desktop/server)
+
+- Define the minimal binary format (header + key directory + data)
+- Implement `MmapFactSource` using `bytestring` + `mmap`
+- Add artifact builder (Prolog-side or standalone tool)
+- Wire into `wcFactSources` registration
+- Benchmark against IntMap at 10k and 100k
+
+### Phase B2: SqliteFactSource (Termux/constrained)
+
+- Implement `SqliteFactSource` using `sqlite-simple`
+- Add read-once-then-split strategy for parallelism
+- Add fact ingestion tool (TSV → SQLite)
+- Wire into `wcFactSources` with environment-gated selection
+- Benchmark on Termux vs desktop
+
+### Phase B3: DatomStore (future)
+
+- Implement triple-indexed IntMap store
+- Expose as FactBackend with immutable snapshot semantics
+- Explore integration with Datahike or custom Datalog engine
+
+### Phase B4: Planner-driven backend selection
+
+- Extend the compile-time planner to emit backend selection code
+- Add runtime capability detection
+- Environment predicates for cross-compilation
+
+## Dependencies
+
+- `PREPROCESSED_PREDICATE_ARTIFACTS.md` — artifact format and manifest
+- `WAM_HASKELL_FACT_ACCESS_SPEC.md` — FactSource interface (F4)
+- `WAM_HASKELL_FACT_ACCESS_PHILOSOPHY.md` — laziness and parallelism
+- C# `BinaryRelationArtifactProvider` — .uwbr format reference
+
+## What this does not change
+
+- FFI kernel path (stays on strict IntMap)
+- Compiled WAM path for small predicates
+- inline_data path for medium predicates
+- The `parMap rdeepseq` parallelism model
+- The `run`/`step`/`backtrack` core loop

--- a/examples/benchmark/generate_wam_haskell_fact_layout_benchmark.pl
+++ b/examples/benchmark/generate_wam_haskell_fact_layout_benchmark.pl
@@ -1,0 +1,76 @@
+:- initialization(main, main).
+
+:- use_module('../../src/unifyweaver/targets/wam_haskell_target').
+:- use_module('../../src/unifyweaver/targets/wam_target').
+:- use_module(library(option)).
+:- use_module(library(lists)).
+
+%% Generates Haskell WAM benchmarks for comparing fact layouts.
+%%
+%% Usage:
+%%   swipl -q -s generate_wam_haskell_fact_layout_benchmark.pl -- <facts.pl> <output-dir> <compiled|inline>
+%%
+%% The 'compiled' variant uses compiled_only layout (all facts as WAM instructions).
+%% The 'inline' variant uses fact_count_threshold(10) to trigger inline_data
+%% for fact predicates with >10 clauses, using CallFactStream + literal lists.
+%%
+%% Both variants include category_parent/2 in the WAM predicate list (not just
+%% TSV runtime loading) so the fact layout choice matters for the WAM interpreter.
+
+benchmark_workload_path(Path) :-
+    source_file(benchmark_workload_path(_), ThisFile),
+    file_directory_name(ThisFile, Here),
+    directory_file_path(Here, 'effective_distance.pl', Path).
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv = [FactsPath, OutputDir, LayoutAtom]
+    ->  true
+    ;   format(user_error,
+            'Usage: ... -- <facts.pl> <output-dir> <compiled|inline>~n', []),
+        halt(1)
+    ),
+    parse_layout(LayoutAtom, LayoutOptions),
+    generate_fact_layout_benchmark(FactsPath, OutputDir, LayoutOptions),
+    halt(0).
+
+main :-
+    format(user_error, 'Error: generation failed~n', []),
+    halt(1).
+
+parse_layout('compiled', [fact_layout_policy(compiled_only)]) :- !.
+parse_layout('inline', [fact_count_threshold(10)]) :- !.
+parse_layout(X, _) :-
+    format(user_error, 'Unknown layout: ~w (use compiled or inline)~n', [X]),
+    halt(1).
+
+%% power_sum_bound(+Cat, +Root, +NegN, -WeightSum)
+power_sum_bound(Cat, Root, NegN, WeightSum) :-
+    aggregate_all(sum(W),
+        (category_ancestor(Cat, Root, Hops, [Cat]),
+         H is Hops + 1,
+         W is H ** NegN),
+        WeightSum).
+
+generate_fact_layout_benchmark(FactsPath, OutputDir, LayoutOptions) :-
+    benchmark_workload_path(WorkloadPath),
+    load_files(WorkloadPath, [silent(true)]),
+    load_files(FactsPath, [silent(true)]),
+    retractall(user:mode(category_ancestor(_, _, _, _))),
+    assertz(user:mode(category_ancestor(-, +, -, +))),
+
+    % Include category_parent/2 in the WAM predicate list so the
+    % fact layout choice (compiled vs inline_data) is exercised.
+    Predicates = [
+        user:dimension_n/1,
+        user:max_depth/1,
+        user:category_parent/2,
+        user:category_ancestor/4,
+        user:power_sum_bound/4
+    ],
+    append([module_name('wam-haskell-bench'), no_kernels(true)],
+           LayoutOptions, Options),
+
+    write_wam_haskell_project(Predicates, Options, OutputDir),
+    format(user_error, '[WAM-Haskell] Fact layout benchmark generated (~w).~n',
+           [LayoutOptions]).


### PR DESCRIPTION
  ## Summary

  - Design doc for pluggable fact backends beyond strict IntMap and inline literals, covering MmapFactSource (desktop/server),
  SqliteFactSource (Termux/constrained), and Datomic-style immutable datom stores (future)
  - Documents key finding from 10k profiling: both compiled layout (100k WAM instructions) and inline_data (25k literal tuples) cause
  prohibitive GHC compilation times — real 10k+ performance requires mmap or database backends
  - Adds fact layout benchmark generator (`generate_wam_haskell_fact_layout_benchmark.pl`) for comparing compiled vs inline_data variants

  ## Backends covered

  | Backend | Platform | Parallelism | Priority |
  |---------|----------|-------------|----------|
  | MmapFactSource | Desktop/server | Safe (pointer dereference, no locks) | Phase B1 |
  | SqliteFactSource | Termux/Android | Read-once-then-split or per-worker connections | Phase B2 |
  | DatomStore | Any | Safe (immutable snapshots) | Phase B3 (future) |
  | RocksDB/LMDB, DuckDB, Redis | Various | Varies | Noted for later |

  ## Key design decisions

  - `FactBackend` typeclass with `fbScan`, `fbLookup`, `fbCaps`, `fbClose` unifies all backends
  - SQLite embedding is optional (tradeoff: ~1MB binary size vs no runtime dependency)
  - Planner integration via `fact_layout/2` declarations and `environment/1` capability gates
  - Existing paths (FFI kernels, compiled WAM, inline_data) unchanged — backends serve the 10k+ scale gap