### PR TITLE
feat(wam-haskell): Phase B1 — LmdbFactSource backend

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2794,7 +2794,7 @@ build_predicate_loads(Predicates, Code) :-
     let allLabels = ~w', [CodeConcat, LabelUnion]).
 
 %% compile_wam_runtime_to_haskell(+Options, +DetectedKernels, -Code)
-compile_wam_runtime_to_haskell(_Options, DetectedKernels, Code) :-
+compile_wam_runtime_to_haskell(Options, DetectedKernels, Code) :-
     step_function_haskell(StepCode),
     backtrack_haskell(BacktrackCodeTemplate),
     run_loop_haskell(RunCode),
@@ -2805,6 +2805,13 @@ compile_wam_runtime_to_haskell(_Options, DetectedKernels, Code) :-
                     [kernel_functions=KernelFunctionsCode,
                      execute_foreign=ExecuteForeignCode],
                     BacktrackCode),
+    % Phase B1: conditional LMDB imports and functions
+    (   option(use_lmdb(true), Options)
+    ->  LmdbImports = "import Database.LMDB.Simple (Environment, Database, Limits(..), ReadOnly,\n                                    openReadOnlyEnvironment, readOnlyTransaction,\n                                    getDatabase, defaultLimits)\nimport Database.LMDB.Simple.View (View, newView)\nimport qualified Database.LMDB.Simple.View as View\nimport Codec.Serialise (Serialise)",
+        generate_lmdb_functions(LmdbFunctions)
+    ;   LmdbImports = "",
+        LmdbFunctions = ""
+    ),
     format(string(Code),
 '{-# LANGUAGE BangPatterns #-}
 module WamRuntime where
@@ -2826,12 +2833,14 @@ import Control.DeepSeq (NFData(..), deepseq)
 import Control.Concurrent.Async (async, cancel, waitAny)
 import Control.Exception (evaluate)
 import System.IO.Unsafe (unsafePerformIO)
+~w
 import WamTypes
 
 ~w
 
 ~w
 
+~w
 ~w
 
 -- | Dereference an Unbound variable through the binding table.
@@ -2998,7 +3007,7 @@ resolveCallInstrs labels foreignPreds = map resolve
       in SwitchOnConstantPc (IM.fromList [(extractId v, pc) | (v, label) <- Map.toList table,
                                                                Just pc <- [Map.lookup label labels]])
     resolve i = i
-', [StepCode, BacktrackCode, RunCode]).
+', [LmdbImports, StepCode, BacktrackCode, RunCode, LmdbFunctions]).
 
 %% generate_wam_types_hs(-Code)
 generate_wam_types_hs(Code) :-
@@ -3339,8 +3348,13 @@ generate_cabal_file(Name, UseHM, Options, Code) :-
     % deepseq + parallel for seed-level parMap rdeepseq
     % async for Phase 4.4 race-to-cancel negation
     (   UseHM == true
-    ->  Deps = "base >= 4.12, containers >= 0.6, array, time >= 1.8, unordered-containers >= 0.2, hashable >= 1.2, deepseq >= 1.4, parallel >= 3.2, async >= 2.2"
-    ;   Deps = "base >= 4.12, containers >= 0.6, array, time >= 1.8, deepseq >= 1.4, parallel >= 3.2, async >= 2.2"
+    ->  BaseDeps = "base >= 4.12, containers >= 0.6, array, time >= 1.8, unordered-containers >= 0.2, hashable >= 1.2, deepseq >= 1.4, parallel >= 3.2, async >= 2.2"
+    ;   BaseDeps = "base >= 4.12, containers >= 0.6, array, time >= 1.8, deepseq >= 1.4, parallel >= 3.2, async >= 2.2"
+    ),
+    % Phase B1: conditional LMDB dependency
+    (   option(use_lmdb(true), Options)
+    ->  format(string(Deps), "~w, lmdb-simple >= 0.4, serialise >= 0.2", [BaseDeps])
+    ;   Deps = BaseDeps
     ),
     % -threaded enables multi-core runtime (+RTS -N to use cores).
     % -rtsopts is needed so +RTS flags are accepted at runtime.
@@ -3494,6 +3508,59 @@ emit_inline_fact_literal(ListName, Tuples, Code) :-
         atomic_list_concat(AllLines, '\n', Body),
         format(string(Code), '~w :: [(Int, Int)]\n~w =\n~w\n    ]\n', [ListName, ListName, Body])
     ).
+
+%% generate_lmdb_functions(-Code)
+%  Generates the Haskell LMDB FactSource functions for Phase B1.
+%  Only called when use_lmdb(true).
+generate_lmdb_functions(Code) :-
+    Code = '
+-- | Phase B1: Create a FactSource backed by an LMDB database.
+-- Uses lmdb-simple View for pure concurrent reads compatible with parMap.
+-- The View is a consistent snapshot — all lookups see the same database
+-- state. Reads are zero-copy from mmap''d pages (LMDB uses mmap internally).
+--
+-- Key schema: Int (interned arg1)
+-- Value schema: [Int] (list of interned arg2 values for that arg1)
+-- One named LMDB database per predicate.
+lmdbFactSource :: FilePath -> String -> IO FactSource
+lmdbFactSource dbPath dbName = do
+    env <- openReadOnlyEnvironment dbPath defaultLimits
+             { mapSize = 1073741824, maxDatabases = 16, maxReaders = 126 }
+    (db, view) <- readOnlyTransaction env $ do
+      db <- getDatabase (Just dbName) :: Transaction ReadOnly (Database Int [Int])
+      v  <- View.newView db
+      return (db, v)
+    return FactSource
+      { fsScan       = return $ concatMap (\\(k, vs) -> [(k, v) | v <- vs])
+                                          (View.toList view)
+      , fsLookupArg1 = \\key -> return $ case View.lookup key view of
+                                           Just vs -> [(key, v) | v <- vs]
+                                           Nothing -> []
+      , fsClose      = return ()  -- GC handles env cleanup
+      }
+
+-- | Phase B1: Ingest a TSV file into an LMDB database.
+-- Reads the TSV, interns atoms, groups by arg1, and writes to LMDB.
+-- Called once during preprocessing, not at query time.
+ingestTsvToLmdb :: InternTable -> FilePath -> FilePath -> String -> IO ()
+ingestTsvToLmdb tbl tsvPath dbPath dbName = do
+    content <- readFile tsvPath
+    let ls = drop 1 (lines content)  -- skip header
+        pairs = [ (internAtomPure tbl a, internAtomPure tbl b)
+                | l <- ls, not (null l)
+                , let (a, rest) = break (== ''\\t'') l
+                , not (null rest)
+                , let b = drop 1 rest
+                , not (null b)
+                ]
+        grouped = IM.fromListWith (++) [(k, [v]) | (k, v) <- pairs]
+    env <- openEnvironment dbPath defaultLimits
+             { mapSize = 1073741824, maxDatabases = 16 }
+    readWriteTransaction env $ do
+      db <- getDatabase (Just dbName) :: Transaction ReadWrite (Database Int [Int])
+      mapM_ (\\(k, vs) -> put db k (Just vs)) (IM.toList grouped)
+    return ()
+'.
 
 %% maybe_parallelize_instrs(+PredIndicator, +Options, +InstrExprs0, -InstrExprs)
 %  Rewrite TryMeElse → ParTryMeElse etc. when the predicate certifies

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -3510,57 +3510,10 @@ emit_inline_fact_literal(ListName, Tuples, Code) :-
     ).
 
 %% generate_lmdb_functions(-Code)
-%  Generates the Haskell LMDB FactSource functions for Phase B1.
+%  Loads the LMDB FactSource functions from the Mustache template.
 %  Only called when use_lmdb(true).
 generate_lmdb_functions(Code) :-
-    Code = '
--- | Phase B1: Create a FactSource backed by an LMDB database.
--- Uses lmdb-simple View for pure concurrent reads compatible with parMap.
--- The View is a consistent snapshot — all lookups see the same database
--- state. Reads are zero-copy from mmap''d pages (LMDB uses mmap internally).
---
--- Key schema: Int (interned arg1)
--- Value schema: [Int] (list of interned arg2 values for that arg1)
--- One named LMDB database per predicate.
-lmdbFactSource :: FilePath -> String -> IO FactSource
-lmdbFactSource dbPath dbName = do
-    env <- openReadOnlyEnvironment dbPath defaultLimits
-             { mapSize = 1073741824, maxDatabases = 16, maxReaders = 126 }
-    (db, view) <- readOnlyTransaction env $ do
-      db <- getDatabase (Just dbName) :: Transaction ReadOnly (Database Int [Int])
-      v  <- View.newView db
-      return (db, v)
-    return FactSource
-      { fsScan       = return $ concatMap (\\(k, vs) -> [(k, v) | v <- vs])
-                                          (View.toList view)
-      , fsLookupArg1 = \\key -> return $ case View.lookup key view of
-                                           Just vs -> [(key, v) | v <- vs]
-                                           Nothing -> []
-      , fsClose      = return ()  -- GC handles env cleanup
-      }
-
--- | Phase B1: Ingest a TSV file into an LMDB database.
--- Reads the TSV, interns atoms, groups by arg1, and writes to LMDB.
--- Called once during preprocessing, not at query time.
-ingestTsvToLmdb :: InternTable -> FilePath -> FilePath -> String -> IO ()
-ingestTsvToLmdb tbl tsvPath dbPath dbName = do
-    content <- readFile tsvPath
-    let ls = drop 1 (lines content)  -- skip header
-        pairs = [ (internAtomPure tbl a, internAtomPure tbl b)
-                | l <- ls, not (null l)
-                , let (a, rest) = break (== ''\\t'') l
-                , not (null rest)
-                , let b = drop 1 rest
-                , not (null b)
-                ]
-        grouped = IM.fromListWith (++) [(k, [v]) | (k, v) <- pairs]
-    env <- openEnvironment dbPath defaultLimits
-             { mapSize = 1073741824, maxDatabases = 16 }
-    readWriteTransaction env $ do
-      db <- getDatabase (Just dbName) :: Transaction ReadWrite (Database Int [Int])
-      mapM_ (\\(k, vs) -> put db k (Just vs)) (IM.toList grouped)
-    return ()
-'.
+    read_kernel_template('lmdb_fact_source.hs.mustache', Code).
 
 %% maybe_parallelize_instrs(+PredIndicator, +Options, +InstrExprs0, -InstrExprs)
 %  Rewrite TryMeElse → ParTryMeElse etc. when the predicate certifies

--- a/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
+++ b/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
@@ -1,0 +1,46 @@
+-- | Phase B1: Create a FactSource backed by an LMDB database.
+-- Uses lmdb-simple View for pure concurrent reads compatible with parMap.
+-- The View is a consistent snapshot — all lookups see the same database
+-- state. Reads are zero-copy from mmap'd pages (LMDB uses mmap internally).
+--
+-- Key schema: Int (interned arg1)
+-- Value schema: [Int] (list of interned arg2 values for that arg1)
+-- One named LMDB database per predicate.
+lmdbFactSource :: FilePath -> String -> IO FactSource
+lmdbFactSource dbPath dbName = do
+    env <- openReadOnlyEnvironment dbPath defaultLimits
+             { mapSize = 1073741824, maxDatabases = 16, maxReaders = 126 }
+    (db, view) <- readOnlyTransaction env $ do
+      db <- getDatabase (Just dbName) :: Transaction ReadOnly (Database Int [Int])
+      v  <- View.newView db
+      return (db, v)
+    return FactSource
+      { fsScan       = return $ concatMap (\(k, vs) -> [(k, v) | v <- vs])
+                                          (View.toList view)
+      , fsLookupArg1 = \key -> return $ case View.lookup key view of
+                                           Just vs -> [(key, v) | v <- vs]
+                                           Nothing -> []
+      , fsClose      = return ()  -- GC handles env cleanup
+      }
+
+-- | Phase B1: Ingest a TSV file into an LMDB database.
+-- Reads the TSV, interns atoms, groups by arg1, and writes to LMDB.
+-- Called once during preprocessing, not at query time.
+ingestTsvToLmdb :: InternTable -> FilePath -> FilePath -> String -> IO ()
+ingestTsvToLmdb tbl tsvPath dbPath dbName = do
+    content <- readFile tsvPath
+    let ls = drop 1 (lines content)  -- skip header
+        pairs = [ (internAtomPure tbl a, internAtomPure tbl b)
+                | l <- ls, not (null l)
+                , let (a, rest) = break (== '\t') l
+                , not (null rest)
+                , let b = drop 1 rest
+                , not (null b)
+                ]
+        grouped = IM.fromListWith (++) [(k, [v]) | (k, v) <- pairs]
+    env <- openEnvironment dbPath defaultLimits
+             { mapSize = 1073741824, maxDatabases = 16 }
+    readWriteTransaction env $ do
+      db <- getDatabase (Just dbName) :: Transaction ReadWrite (Database Int [Int])
+      mapM_ (\(k, vs) -> put db k (Just vs)) (IM.toList grouped)
+    return ()

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1183,9 +1183,72 @@ test_e2e_below_threshold_no_inline :-
     ),
     retractall(user:e2e_sm(_, _)).
 
+%% Phase B1: LMDB backend tests
+%% -----------------------------------------------
+
+test_b1_lmdb_functions_present_when_enabled :-
+    Test = 'B1: lmdbFactSource emitted when use_lmdb(true)',
+    (   compile_wam_runtime_to_haskell([use_lmdb(true)], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "lmdbFactSource :: FilePath -> String -> IO FactSource"),
+        sub_string(S, _, _, _, "ingestTsvToLmdb")
+    ->  pass(Test)
+    ;   fail_test(Test, 'LMDB functions not found when use_lmdb(true)')
+    ).
+
+test_b1_lmdb_imports_present_when_enabled :-
+    Test = 'B1: LMDB imports emitted when use_lmdb(true)',
+    (   compile_wam_runtime_to_haskell([use_lmdb(true)], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "import Database.LMDB.Simple"),
+        sub_string(S, _, _, _, "import Database.LMDB.Simple.View")
+    ->  pass(Test)
+    ;   fail_test(Test, 'LMDB imports not found when use_lmdb(true)')
+    ).
+
+test_b1_lmdb_absent_when_disabled :-
+    Test = 'B1: no LMDB code when use_lmdb not set',
+    (   compile_wam_runtime_to_haskell([], [], Code),
+        atom_string(Code, S),
+        \+ sub_string(S, _, _, _, "lmdbFactSource"),
+        \+ sub_string(S, _, _, _, "import Database.LMDB")
+    ->  pass(Test)
+    ;   fail_test(Test, 'LMDB code should not appear without use_lmdb(true)')
+    ).
+
+test_b1_lmdb_cabal_dependency :-
+    Test = 'B1: cabal includes lmdb-simple when use_lmdb(true)',
+    (   wam_haskell_target:generate_cabal_file('test', false, [use_lmdb(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "lmdb-simple"),
+        sub_string(S, _, _, _, "serialise")
+    ->  pass(Test)
+    ;   fail_test(Test, 'lmdb-simple not in cabal deps when use_lmdb(true)')
+    ).
+
+test_b1_no_lmdb_cabal_default :-
+    Test = 'B1: cabal excludes lmdb-simple by default',
+    (   wam_haskell_target:generate_cabal_file('test', false, [], Code),
+        atom_string(Code, S),
+        \+ sub_string(S, _, _, _, "lmdb-simple")
+    ->  pass(Test)
+    ;   fail_test(Test, 'lmdb-simple should not appear in default cabal deps')
+    ).
+
+test_b1_lmdb_view_for_parallelism :-
+    Test = 'B1: lmdbFactSource uses View for pure concurrent reads',
+    (   compile_wam_runtime_to_haskell([use_lmdb(true)], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "View.lookup"),
+        sub_string(S, _, _, _, "View.toList"),
+        sub_string(S, _, _, _, "View.newView")
+    ->  pass(Test)
+    ;   fail_test(Test, 'View-based pure reads not found in lmdbFactSource')
+    ).
+
 run_tests :-
     format('~n========================================~n'),
-    format('WAM-Haskell target: Phase 5+6+7+8+F1-F4+E2E codegen tests~n'),
+    format('WAM-Haskell target: Phase 5+6+7+8+F1-F4+E2E+B1 codegen tests~n'),
     format('========================================~n~n'),
     test_haskell_helper_functions_present,
     test_haskell_functor_builtin_present,
@@ -1280,6 +1343,13 @@ run_tests :-
     test_e2e_inline_facts_wiring_generated,
     test_e2e_empty_inline_defs_no_wiring,
     test_e2e_below_threshold_no_inline,
+    %% Phase B1: LMDB backend
+    test_b1_lmdb_functions_present_when_enabled,
+    test_b1_lmdb_imports_present_when_enabled,
+    test_b1_lmdb_absent_when_disabled,
+    test_b1_lmdb_cabal_dependency,
+    test_b1_no_lmdb_cabal_default,
+    test_b1_lmdb_view_for_parallelism,
     format('~n========================================~n'),
     (   test_failed
     ->  format('Tests FAILED~n'), halt(1)


### PR DESCRIPTION
  ## Summary

  - Adds LMDB-backed fact source using `lmdb-simple` with `View` for pure concurrent reads, conditional on `use_lmdb(true)` option
  - LMDB uses mmap internally — reads are zero-copy pointer dereferences with no locks (MVCC), ideal for `parMap rdeepseq` parallelism
  - When `use_lmdb` is not set, no LMDB code or dependencies are emitted — zero impact on existing projects

  ## What's included

  | Component | Purpose |
  |-----------|---------|
  | `lmdbFactSource` | Creates `FactSource` from LMDB database via `View` snapshot (pure lookups, no IO in hot path) |
  | `ingestTsvToLmdb` | Preprocesses TSV into LMDB database (groups by arg1, writes via transaction) |
  | `lmdb_fact_source.hs.mustache` | Template file for LMDB functions (follows project convention) |
  | Conditional LMDB imports | `Database.LMDB.Simple`, `Database.LMDB.Simple.View` |
  | Conditional cabal deps | `lmdb-simple >= 0.4, serialise >= 0.2` |

  ## Not yet wired

  Main.hs does not yet call `lmdbFactSource` or `ingestTsvToLmdb` at startup — the E2E wiring (TSV preprocessing + `wcFactSources`
  registration) is a follow-up. The generated code is correct but needs the Main.hs plumbing to exercise at scale.

  ## Test plan

  - [x] 6 new B1 tests pass (functions present when enabled, absent when disabled, imports, cabal deps, View usage)
  - [x] All F1-F4 + E2E tests pass (no regressions)
  - [x] Purity certificate tests pass (70/70)