### PR TITLE
feat(wam-haskell): LMDB E2E wiring in Main.hs template

### DIFF
--- a/examples/benchmark/generate_wam_haskell_fact_layout_benchmark.pl
+++ b/examples/benchmark/generate_wam_haskell_fact_layout_benchmark.pl
@@ -40,8 +40,9 @@ main :-
 
 parse_layout('compiled', [fact_layout_policy(compiled_only)]) :- !.
 parse_layout('inline', [fact_count_threshold(10)]) :- !.
+parse_layout('lmdb', [use_lmdb(true)]) :- !.
 parse_layout(X, _) :-
-    format(user_error, 'Unknown layout: ~w (use compiled or inline)~n', [X]),
+    format(user_error, 'Unknown layout: ~w (use compiled, inline, or lmdb)~n', [X]),
     halt(1).
 
 %% power_sum_bound(+Cat, +Root, +NegN, -WeightSum)

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2654,6 +2654,8 @@ generate_main_hs(_Predicates, DetectedKernels, InlineDefs, Options, Code) :-
     ),
     % Phase F3/F4: generate wcInlineFacts wiring from InlineDefs
     generate_inline_facts_wiring(InlineDefs, InlineFactsWiring),
+    % Phase B1: generate LMDB setup and context wiring
+    generate_lmdb_wiring(Options, LmdbSetup, LmdbContext, LmdbImport),
     render_template(Template,
         [ foreign_preds=ForeignPredsStr
         , query_body=QueryBody
@@ -2662,6 +2664,9 @@ generate_main_hs(_Predicates, DetectedKernels, InlineDefs, Options, Code) :-
         , facts_source=FactsSource
         , demand_metrics=DemandMetrics
         , inline_facts=InlineFactsWiring
+        , lmdb_setup=LmdbSetup
+        , lmdb_context=LmdbContext
+        , lmdb_import=LmdbImport
         ], Code).
 
 %% generate_inline_facts_wiring(+InlineDefs, -Code)
@@ -2676,6 +2681,37 @@ generate_inline_facts_wiring(InlineDefs, Code) :-
     format(string(Code),
            '            , wcInlineFacts   = Map.fromList [~w]',
            [EntriesStr]).
+
+%% generate_lmdb_wiring(+Options, -SetupCode, -ContextCode, -ImportCode)
+%  When use_lmdb(true), generates:
+%  - SetupCode: LMDB ingestion + FactSource creation at startup
+%  - ContextCode: wcFactSources wiring in the WamContext
+%  - ImportCode: System.Directory import for doesDirectoryExist
+%  Ingestion is idempotent — skips if the LMDB directory already exists.
+%  When not enabled, all are empty strings.
+generate_lmdb_wiring(Options, SetupCode, ContextCode, ImportCode) :-
+    (   option(use_lmdb(true), Options)
+    ->  ImportCode = 'import System.Directory (doesDirectoryExist, createDirectory)',
+        SetupCode =
+'    -- Phase B1: LMDB fact source setup
+    let lmdbDir = factsDir ++ "/lmdb"
+    -- Ingest TSV into LMDB (idempotent — skips if directory exists)
+    lmdbExists <- doesDirectoryExist lmdbDir
+    if not lmdbExists then do
+      createDirectory lmdbDir
+      hPutStrLn stderr "Ingesting TSV into LMDB..."
+      ingestTsvToLmdb fullInternTable (factsDir ++ "/category_parent.tsv") lmdbDir "category_parent"
+      hPutStrLn stderr "LMDB ingestion complete."
+    else
+      hPutStrLn stderr "LMDB database found, skipping ingestion."
+    -- Open LMDB as a FactSource for the WAM interpreter
+    cpFactSource <- lmdbFactSource lmdbDir "category_parent"',
+        ContextCode =
+'            , wcFactSources   = Map.singleton "category_parent" cpFactSource'
+    ;   SetupCode = '',
+        ContextCode = '',
+        ImportCode = ''
+    ).
 
 %% generate_demand_filter(+DetectedKernels, +Options, -FilterCode, -FactsSource)
 %  When demand filtering is enabled (kernels detected with an edge predicate),
@@ -3353,7 +3389,7 @@ generate_cabal_file(Name, UseHM, Options, Code) :-
     ),
     % Phase B1: conditional LMDB dependency
     (   option(use_lmdb(true), Options)
-    ->  format(string(Deps), "~w, lmdb-simple >= 0.4, serialise >= 0.2", [BaseDeps])
+    ->  format(string(Deps), "~w, lmdb-simple >= 0.4, serialise >= 0.2, directory >= 1.3", [BaseDeps])
     ;   Deps = BaseDeps
     ),
     % -threaded enables multi-core runtime (+RTS -N to use cores).

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -16,6 +16,7 @@ import WamTypes
 import WamRuntime
 import Predicates
 import qualified Lowered
+{{lmdb_import}}
 
 -- | Load a TSV file, skip header, return pairs.
 loadTsvPairs :: FilePath -> IO [(String, String)]
@@ -140,6 +141,9 @@ main = do
     -- (like Wikipedia categories, ~95% reachable) the effect is small.
 {{demand_filter}}
 
+    -- Phase B1: LMDB fact source setup (conditional, empty when not enabled)
+{{lmdb_setup}}
+
     -- Build the read-only WamContext ONCE before the seed loop. The hot
     -- WamState gets a fresh copy per seed; the cold context is shared.
     -- wcInternTable is the system-wide atom intern table (compile-time +
@@ -150,6 +154,7 @@ main = do
             , wcInternTable   = fullInternTable
             , wcFfiFacts      = Map.singleton "category_parent" {{facts_source}}
 {{inline_facts}}
+{{lmdb_context}}
             }
 
     t2 <- getCurrentTime


### PR DESCRIPTION
 ##Summary

  - Wires `lmdbFactSource` and `ingestTsvToLmdb` into the generated Main.hs when `use_lmdb(true)`, completing the end-to-end LMDB fact access
 ─path  atom-interning-haskell-wam ──
 - TSV→LMDB ingestion is idempotent — skips if the `lmdb/` directory already exists
  - LMDB database opened as `FactSource` via `View` snapshot, registered in `wcFactSources`
  - Benchmark generator gains `lmdb` layout variant alongside `compiled` and `inline`

  ## Generated Main.hs flow with use_lmdb(true)

  1. Load TSV → build intern table (unchanged)
  2. Check if `lmdb/` directory exists (`doesDirectoryExist`)
  3. If not: `ingestTsvToLmdb` (one-time preprocessing)
  4. `lmdbFactSource` opens LMDB → `View` snapshot
  5. `wcFactSources = Map.singleton "category_parent" cpFactSource`
  6. `parMap` queries use `streamFacts` → `wcFactSources` → `View.lookup`

  ## What's included

  | Component | Purpose |
  |-----------|---------|
  | `{{lmdb_setup}}` template variable | Ingestion + FactSource creation in Main.hs |
  | `{{lmdb_context}}` template variable | `wcFactSources` wiring in WamContext |
  | `{{lmdb_import}}` template variable | Conditional `System.Directory` import |
  | `generate_lmdb_wiring/4` | Produces all three blocks when `use_lmdb(true)` |
  | `directory >= 1.3` cabal dep | For `doesDirectoryExist`/`createDirectory` |
  | Benchmark generator `lmdb` variant | `parse_layout('lmdb', [use_lmdb(true)])` |

  ## Test plan

  - [x] All existing tests pass (no regressions)
  - [x] Generated project with `use_lmdb(true)` has correct LMDB wiring in Main.hs
  - [x] Generated project without `use_lmdb` has empty LMDB placeholders
  - [x] Cabal includes `lmdb-simple`, `serialise`, `directory` when LMDB enabled

  ## Next step

  Build and profile the LMDB variant at 10k scale against the current strict IntMap baseline.