### PR TITLE
feat(wam-elixir): Tier-2 infrastructure — purity gate, aggregate-frame helpers, parallel_depth

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -20,13 +20,18 @@
     % Phase B fact extraction. Exported so tests can exercise it.
     extract_facts/3,              % +Segments, +Arity, -ElixirListLiteral
     % Phase C first-argument indexing.
-    extract_arg1_index/3          % +Segments, +Arity, -IndexResult
+    extract_arg1_index/3,         % +Segments, +Arity, -IndexResult
+    % Tier-2 purity gate (see docs/design/WAM_TIERED_LOWERING.md).
+    % Consumed by `par_wrap_segment/3` (PR2) to decide whether a
+    % predicate is eligible for host-native parallel emission.
+    tier2_purity_eligible/3       % +Pred, +Arity, -Cert
 ]).
 
 :- use_module(library(lists)).
 :- use_module(library(option)).
 :- use_module(library(pairs), [group_pairs_by_key/2]).
 :- use_module('wam_elixir_utils', [reg_id/2, is_label_part/1, camel_case/2, parse_arity/2]).
+:- use_module('../core/purity_certificate', [analyze_predicate_purity/2]).
 
 % ============================================================================
 % MAIN ENTRY POINT
@@ -414,6 +419,32 @@ format_fact_shape_comment(fact_shape_info(N, FactOnly, FirstArg, Layout), Commen
 '  # Fact-shape classification:
   #   clauses=~w fact_only=~w first_arg=~w layout=~w',
            [N, FactOnly, FirstArg, Layout]).
+
+% ============================================================================
+% TIER-2 PURITY GATE
+% ============================================================================
+%
+% `par_wrap_segment/3` (PR2) checks a predicate\'s purity certificate
+% before emitting the host-native parallel wrapper. Encapsulated here
+% so the threshold (0.85) lives alongside the other emitter-facing
+% classification helpers — and so a failing certificate fails the
+% whole gate predicate (no partial-match leakage of Cert into the
+% sequential fallback path). The 0.85 threshold matches Haskell\'s
+% Tier-2 implementation (Phase P4).
+%
+% This is the Tier-2 infrastructure hand-off: the gate is wired but
+% nothing calls it yet. PR2 adds `par_wrap_segment/3` in the
+% SEGMENTATION section, which depends on this predicate.
+
+%% tier2_purity_eligible(+Pred, +Arity, -Cert)
+%  Succeeds iff `Pred/Arity` has a purity certificate with verdict
+%  `pure` and confidence ≥ 0.85. Binds `Cert` for downstream logging
+%  / debug. Fails silently for any other verdict — Tier-2 emission
+%  defers to the Tier-3 sequential fallback when this fails.
+tier2_purity_eligible(Pred, Arity, Cert) :-
+    analyze_predicate_purity(Pred/Arity, Cert),
+    Cert = purity_cert(pure, _Proof, Confidence, _Reasons),
+    Confidence >= 0.85.
 
 % ============================================================================
 % PHASE B: INLINE_DATA FACT EXTRACTION

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -333,7 +333,8 @@ compile_wam_helpers_to_elixir(_Options, Code) :-
     compile_backtrack_to_elixir(BTCode),
     compile_unwind_trail_to_elixir(UnwindCode),
     compile_utility_helpers_to_elixir(UtilCode),
-    atomic_list_concat([RunCode, '\n\n', BTCode, '\n\n', UnwindCode, '\n\n', UtilCode], Code).
+    compile_aggregate_helpers_to_elixir(AggCode),
+    atomic_list_concat([RunCode, '\n\n', BTCode, '\n\n', UnwindCode, '\n\n', UtilCode, '\n\n', AggCode], Code).
 
 compile_run_loop_to_elixir(Code) :-
     format(string(Code),
@@ -903,6 +904,75 @@ compile_utility_helpers_to_elixir(Code) :-
   end
   defp eval_arith(state, val), do: eval_arith(state, deref_var(state, val))', []).
 
+%% compile_aggregate_helpers_to_elixir(-Code)
+%
+%  Emits the Tier-2 aggregate-frame substrate: two runtime helpers that
+%  consume aggregate-frame choice points but don\'t produce them. See
+%  docs/design/WAM_TIERED_LOWERING.md for the full plan.
+%
+%  An "aggregate frame" is a choice point with an `:agg_type` field set
+%  to one of `:findall | :bagof | :setof | :aggregate_all | :sum | :count`.
+%  Aggregate wrappers (findall/3, bagof/3, etc.) push such a CP at entry
+%  and consume it at exit, accumulating solutions in the CP\'s `:agg_accum`
+%  list. Infrastructure PR: no wrapper pushes the marker yet; these
+%  helpers are dead code until PR2 adds Tier-2 emission and a later PR
+%  adds findall/bagof/aggregate_all.
+%
+%  `in_forkable_aggregate_frame?/1` answers "may a Tier-2 fan-out emit
+%  under the current CP stack?" — true only if the nearest aggregate
+%  frame is order-independent (findall/aggregate_all). bagof/setof have
+%  witness-variable semantics that forbid naive parallelisation.
+%
+%  `merge_into_aggregate/2` takes a state and a branch-results list,
+%  locates the nearest aggregate frame, and appends the results to its
+%  accumulator. Returns the updated state.
+compile_aggregate_helpers_to_elixir(Code) :-
+    format(string(Code),
+'  @doc """
+  True if the nearest aggregate frame on the CP stack is forkable
+  (findall / aggregate_all — both order-independent). Returns false
+  for bagof/setof (witness-variable dependency) and for an empty or
+  non-aggregate-bearing CP stack.
+
+  Consumed by the Tier-2 wrapper (`par_wrap_segment/3`, PR2) as a
+  correctness gate: outside a forkable aggregate, parallel fan-out
+  would strand solutions that the sequential `next_solution/1`
+  enumeration path would otherwise surface.
+  """
+  def in_forkable_aggregate_frame?(state) do
+    Enum.any?(state.choice_points, fn cp ->
+      case Map.get(cp, :agg_type) do
+        :findall -> true
+        :aggregate_all -> true
+        _ -> false
+      end
+    end)
+  end
+
+  @doc """
+  Append branch results to the nearest aggregate frame\'s accumulator.
+  Used by the Tier-2 wrapper after `Task.async_stream` fully exhausts
+  all branches — each branch produces a list of solutions, and the
+  wrapper hands the flattened list to this function before returning
+  the updated state to the aggregate-wrapper continuation.
+
+  If no aggregate frame is present (caller misuse — Tier-2 gate should
+  have prevented this), the state is returned unchanged.
+  """
+  def merge_into_aggregate(state, branch_results) when is_list(branch_results) do
+    {updated_cps, _merged} =
+      Enum.map_reduce(state.choice_points, false, fn cp, merged ->
+        cond do
+          merged -> {cp, merged}
+          Map.has_key?(cp, :agg_type) ->
+            prior = Map.get(cp, :agg_accum, [])
+            {Map.put(cp, :agg_accum, prior ++ branch_results), true}
+          true -> {cp, merged}
+        end
+      end)
+    %{state | choice_points: updated_cps}
+  end', []).
+
 % ============================================================================
 % ASSEMBLY: Combine Phase 2 + Phase 3
 % ============================================================================
@@ -934,7 +1004,14 @@ compile_wam_runtime_to_elixir(Options, Code) :-
               # `deallocate`. A cut truncates state.choice_points back to
               # this snapshot — clearing CPs pushed inside the current
               # predicate body without touching the caller\'s CPs.
-              cut_point: []
+              cut_point: [],
+              # parallel_depth counts how many Tier-2 parallel fan-outs
+              # are currently active on this branch of the search. The
+              # Tier-2 wrapper increments it when spawning Task.async_stream
+              # children and checks > 0 to short-circuit back to
+              # sequential — prevents B^D spark explosion on recursive
+              # predicates. See docs/design/WAM_TIERED_LOWERING.md.
+              parallel_depth: 0
   end
 
 ~w

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -6,7 +6,11 @@
 :- use_module('../src/unifyweaver/targets/wam_target').
 :- use_module('../src/unifyweaver/targets/wam_elixir_lowered_emitter',
               [lower_predicate_to_elixir/4, classify_predicate/4,
-               extract_facts/3, extract_arg1_index/3]).
+               extract_facts/3, extract_arg1_index/3,
+               tier2_purity_eligible/3]).
+% For Tier-2 purity-gate tests — user-annotation producer reads
+% clause_body_analysis:order_independent/1 dynamic facts.
+:- use_module('../src/unifyweaver/core/clause_body_analysis').
 
 :- dynamic test_failed/0.
 
@@ -687,6 +691,59 @@ test_sqlite_adaptor_uses_indirect_module_resolution :-
     ;   fail_test(Test, 'SQLite adaptor has literal Exqlite references — will warn without dep')
     ).
 
+%% Tier-2 infrastructure tests (see docs/design/WAM_TIERED_LOWERING.md)
+%% These exercise precondition scaffolding only — PR2 wires
+%% par_wrap_segment/3 on top of them.
+
+test_tier2_wamstate_has_parallel_depth :-
+    Test = 'Tier-2 infra: WamState defstruct carries parallel_depth: 0',
+    (   compile_wam_runtime_to_elixir([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'parallel_depth: 0')
+    ->  pass(Test)
+    ;   fail_test(Test, 'parallel_depth field missing from emitted WamState')
+    ).
+
+test_tier2_aggregate_helpers_emitted :-
+    Test = 'Tier-2 infra: WamRuntime emits in_forkable_aggregate_frame?/1 + merge_into_aggregate/2',
+    (   compile_wam_runtime_to_elixir([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'def in_forkable_aggregate_frame?(state)'),
+        sub_string(S, _, _, _, 'def merge_into_aggregate(state, branch_results)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'aggregate-frame helpers missing from emitted runtime')
+    ).
+
+test_tier2_aggregate_forkable_types :-
+    Test = 'Tier-2 infra: forkable-frame check covers findall + aggregate_all',
+    (   compile_wam_runtime_to_elixir([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, ':findall -> true'),
+        sub_string(S, _, _, _, ':aggregate_all -> true')
+    ->  pass(Test)
+    ;   fail_test(Test, 'emitted forkable predicate does not cover both findall and aggregate_all')
+    ).
+
+test_tier2_purity_gate_rejects_unknown :-
+    Test = 'Tier-2 infra: purity gate fails for unknown predicate',
+    (   \+ tier2_purity_eligible(no_such_pred, 2, _)
+    ->  pass(Test)
+    ;   fail_test(Test, 'gate should have rejected predicate with no purity certificate')
+    ).
+
+test_tier2_purity_gate_accepts_declared :-
+    Test = 'Tier-2 infra: purity gate accepts user-declared parallel predicate (confidence 1.0)',
+    setup_call_cleanup(
+        assertz(clause_body_analysis:order_independent(user:tier2_test_pred/2)),
+        (   tier2_purity_eligible(tier2_test_pred, 2, Cert),
+            Cert = purity_cert(pure, declared, Conf, _Reasons),
+            Conf >= 0.85
+        ->  pass(Test)
+        ;   fail_test(Test, 'gate did not accept declared parallel predicate')
+        ),
+        retract(clause_body_analysis:order_independent(user:tier2_test_pred/2))
+    ).
+
 %% Test runner
 
 run_tests :-
@@ -744,5 +801,10 @@ run_tests :-
     test_ets_adaptor_emitted_in_runtime,
     test_sqlite_adaptor_emitted_in_runtime,
     test_sqlite_adaptor_uses_indirect_module_resolution,
+    test_tier2_wamstate_has_parallel_depth,
+    test_tier2_aggregate_helpers_emitted,
+    test_tier2_aggregate_forkable_types,
+    test_tier2_purity_gate_rejects_unknown,
+    test_tier2_purity_gate_accepts_declared,
     format('~n=== WAM-Elixir Target Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).


### PR DESCRIPTION
## Summary

First of two PRs implementing host-native parallel lowering for the
Elixir WAM target (see `docs/design/WAM_TIERED_LOWERING.md`). Lands
the correctness scaffolding that the Tier-2 wrapper depends on, as
dead code — no emitted predicate calls it yet. PR2 will add
`par_wrap_segment/3` on top.

## What this PR adds

### 1. `WamState.parallel_depth`

New field on the Elixir `WamState` defstruct, defaulting to 0. The
Tier-2 wrapper (PR2) increments it when spawning `Task.async_stream`
children and checks `> 0` to short-circuit back to sequential — the
nested-fork suppression knob that prevents B^D spark explosion on
recursive predicates.

### 2. `WamRuntime.in_forkable_aggregate_frame?/1` + `merge_into_aggregate/2`

- `in_forkable_aggregate_frame?/1` walks `state.choice_points` and
  returns `true` iff the nearest aggregate frame has `:agg_type ∈
  {:findall, :aggregate_all}`. `bagof` / `setof` are intentionally
  rejected (witness-variable semantics forbid naive parallelisation).
- `merge_into_aggregate/2` appends branch results to the nearest
  aggregate frame's `:agg_accum`. Used by the Tier-2 wrapper after
  `Task.async_stream` fully exhausts all branches.

Neither helper is called by emitted code yet — nothing pushes the
aggregate marker CP shape in PR1. A later PR (findall/bagof/aggregate_all
emission) wires the producer side. The Tier-2 wrapper (PR2) wires the
consumer side.

### 3. `tier2_purity_eligible/3` purity gate

New exported predicate on `wam_elixir_lowered_emitter` that wraps
`purity_certificate:analyze_predicate_purity/2` and gates on
`purity_cert(pure, _, Conf, _), Conf >= 0.85`. Threshold matches
Haskell Tier-2 (Phase P4). Consumed by `par_wrap_segment/3` in PR2.

## Tests

5 new tests in `tests/test_wam_elixir_target.pl`:

- `parallel_depth: 0` present in emitted WamState.
- `in_forkable_aggregate_frame?/1` + `merge_into_aggregate/2` present
  in emitted runtime.
- Forkable-type check covers both `:findall` and `:aggregate_all`.
- Purity gate rejects predicates with no certificate.
- Purity gate accepts user-declared `order_independent` predicate
  (confidence 1.0).

## Test results

- `tests/test_wam_elixir_target.pl`: 57 pass, 1 pre-existing FAIL
  (`Phase B: inline_data layout emits @facts and no defp clauses` —
  on main before this branch; unrelated).
- `tests/test_wam_elixir_utils.pl`: 7 pass.

## What this PR does not do

- Does not add `par_wrap_segment/3` — that's PR2.
- Does not add `findall/bagof/aggregate_all` emission — separate PR.
- Does not add the CPS `throw/catch` × `Task.async_stream` interaction
  test — that will land with PR2 where the interaction actually runs.
- Does not wire the gate into any emission path. The helpers are dead
  code in PR1 by design, so the diff stays reviewable in isolation.

## References

- `docs/design/WAM_TIERED_LOWERING.md` (PR #1584 final revision).
- `src/unifyweaver/core/purity_certificate.pl` (Phase P1 deliverable).
- Haskell Tier-2 (`PURITY_CERTIFICATE_IMPLEMENTATION_PLAN.md` Phase
  P4) — the reference implementation this translates to Elixir.
