### PR TITLE
fix(wam-elixir): update stale Phase B inline_data assertion for Phase C indexing

### DIFF
--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -323,8 +323,13 @@ test_phase_b_emits_inline_data_when_chosen :-
     phase_a_fixture_setup,
     wam_target:compile_predicate_to_wam(phase_a_test:big_fact/2, [], WamCode),
     lower_predicate_to_elixir(big_fact/2, WamCode, [module_name('TestMod')], Code),
+    % Phase C (PR #1525) added first-arg indexing: the emitted `run/1`
+    % picks between `@facts` (unbound arg1) and the `@facts_by_arg1`
+    % indexed subset, binds the result to a local `facts` variable,
+    % then streams that. Assert the indexed shape, not the pre-Phase-C
+    % direct `stream_facts(state, @facts, 2)` call.
     (   sub_string(Code, _, _, _, '@facts ['),
-        sub_string(Code, _, _, _, 'WamRuntime.stream_facts(state, @facts, 2)'),
+        sub_string(Code, _, _, _, 'WamRuntime.stream_facts(state, facts, 2)'),
         \+ sub_string(Code, _, _, _, 'defp clause_')
     ->  pass(Test)
     ;   fail_test(Test, 'expected inline_data shape missing or leaked defp')


### PR DESCRIPTION
## Summary

The `test_phase_b_emits_inline_data_when_chosen` test was asserting
the pre-Phase-C emission shape `stream_facts(state, @facts, 2)`, but
Phase C (PR #1525) added first-arg indexing and changed the call to
`stream_facts(state, facts, 2)` where `facts` is a local variable
bound by a `case`-expression choosing between `@facts` (unbound arg1)
and the `@facts_by_arg1` indexed subset.

The test has been failing silently on main since Phase C landed. The
rest of the assertion (module has `@facts [` literal and no leaked
`defp clause_` functions) is still correct and kept intact.

## Fix

Change the substring match from `stream_facts(state, @facts, 2)` to
`stream_facts(state, facts, 2)` and add a comment explaining the
Phase C interaction.

## Test results

Before: 57 pass, 1 FAIL (this test).
After: 58 pass, 0 FAIL.

No other changes. Utils tests green, ancestor reproducer still
produces 4 solutions with integer N values.
