### PR TITLE
feat: Implement WAM C compound term structure unification

### DIFF
--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -52,6 +52,12 @@ typedef struct {
     WamValue y_regs[32];
 } EnvFrame;
 
+/* Wam Mode */
+typedef enum {
+    MODE_READ = 0,
+    MODE_WRITE = 1
+} WamMode;
+
 /* Instruction tags */
 typedef enum {
     INSTR_GET_CONSTANT, INSTR_GET_VARIABLE, INSTR_GET_VALUE,
@@ -88,6 +94,7 @@ typedef struct {
     int CP;   // Continuation Pointer
     int S;    // Structure Pointer
     int HB;   // Heap Backtrack Pointer
+    WamMode mode; // Read/Write mode for structure unification
     
     /* Registers: A and X registers share the same space typically */
     WamValue A[WAM_MAX_REGS];
@@ -173,6 +180,72 @@ static inline void trail_binding(WamState *state, WamValue *cell) {
     state->TR_array[state->TR].cell = cell;
     state->TR_array[state->TR].old_val = *cell;
     state->TR++;
+}
+static inline WamValue* wam_deref_ptr(WamState *state, WamValue *v) {
+    while (v->tag == VAL_REF) {
+        WamValue *next = &state->H_array[v->data.ref_addr];
+        if (next->tag == VAL_UNBOUND) break;
+        if (next->tag == VAL_REF && next->data.ref_addr == v->data.ref_addr) break;
+        v = next;
+    }
+    return v;
+}
+static inline void wam_bind(WamState *state, WamValue *v1, WamValue *v2) {
+    trail_binding(state, v1);
+    *v1 = *v2;
+}
+static inline bool wam_unify(WamState *state, WamValue *v1, WamValue *v2) {
+    WamValue *pdl[256];
+    int pdl_top = 0;
+    
+    pdl[pdl_top++] = v2;
+    pdl[pdl_top++] = v1;
+    
+    while (pdl_top > 0) {
+        WamValue *d1 = wam_deref_ptr(state, pdl[--pdl_top]);
+        WamValue *d2 = wam_deref_ptr(state, pdl[--pdl_top]);
+        
+        if (d1 == d2) continue;
+        
+        if (d1->tag == VAL_UNBOUND || d2->tag == VAL_UNBOUND) {
+            WamValue *unbound = (d1->tag == VAL_UNBOUND) ? d1 : d2;
+            WamValue *other = (d1->tag == VAL_UNBOUND) ? d2 : d1;
+            wam_bind(state, unbound, other);
+            continue;
+        }
+        
+        if (d1->tag != d2->tag) return false;
+        
+        if (d1->tag == VAL_INT) {
+            if (d1->data.integer != d2->data.integer) return false;
+        } else if (d1->tag == VAL_ATOM) {
+            if (strcmp(d1->data.atom, d2->data.atom) != 0) return false;
+        } else if (d1->tag == VAL_LIST) {
+            if (pdl_top + 4 > 256) return false; // PDL overflow
+            pdl[pdl_top++] = &state->H_array[d2->data.ref_addr];
+            pdl[pdl_top++] = &state->H_array[d1->data.ref_addr];
+            pdl[pdl_top++] = &state->H_array[d2->data.ref_addr + 1];
+            pdl[pdl_top++] = &state->H_array[d1->data.ref_addr + 1];
+        } else if (d1->tag == VAL_STR) {
+            WamValue *f1 = &state->H_array[d1->data.ref_addr];
+            WamValue *f2 = &state->H_array[d2->data.ref_addr];
+            if (f1->tag != VAL_ATOM || f2->tag != VAL_ATOM) return false;
+            if (strcmp(f1->data.atom, f2->data.atom) != 0) return false;
+            
+            const char *slash = strchr(f1->data.atom, '/');
+            assert(slash != NULL && "Functor missing arity suffix");
+            int arity = strtol(slash + 1, NULL, 10);
+            
+            if (pdl_top + arity * 2 > 256) return false; // PDL overflow
+            for (int i = 0; i < arity; i++) {
+                pdl[pdl_top++] = &state->H_array[d2->data.ref_addr + 1 + i];
+                pdl[pdl_top++] = &state->H_array[d1->data.ref_addr + 1 + i];
+            }
+        } else {
+            return false;
+        }
+    }
+    return true;
 }
 static inline void push_choice_point(WamState *state, int next_pc, int arity) {
     if (state->B >= state->B_cap) {

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -93,6 +93,27 @@ wam_instruction_to_c_literal(put_variable(Xn, Ai), Code) :-
 wam_instruction_to_c_literal(put_value(Xn, Ai), Code) :-
     c_reg_index(Xn, IsY_Xn, XIdx), c_reg_index(Ai, IsY_Ai, AIdx),
     format(atom(Code), '{ .tag = INSTR_PUT_VALUE, .reg_xn = ~w, .is_y_xn = ~w, .reg_ai = ~w, .is_y_ai = ~w }', [XIdx, IsY_Xn, AIdx, IsY_Ai]).
+wam_instruction_to_c_literal(get_structure(F, Ai), Code) :-
+    c_reg_index(Ai, IsY_Ai, AIdx),
+    format(atom(Code), '{ .tag = INSTR_GET_STRUCTURE, .pred = "~w", .reg_ai = ~w, .is_y_ai = ~w }', [F, AIdx, IsY_Ai]).
+wam_instruction_to_c_literal(put_structure(F, Xn), Code) :-
+    c_reg_index(Xn, IsY_Xn, XIdx),
+    format(atom(Code), '{ .tag = INSTR_PUT_STRUCTURE, .pred = "~w", .reg_xn = ~w, .is_y_xn = ~w }', [F, XIdx, IsY_Xn]).
+wam_instruction_to_c_literal(get_list(Ai), Code) :-
+    c_reg_index(Ai, IsY_Ai, AIdx),
+    format(atom(Code), '{ .tag = INSTR_GET_LIST, .reg_ai = ~w, .is_y_ai = ~w }', [AIdx, IsY_Ai]).
+wam_instruction_to_c_literal(put_list(Xn), Code) :-
+    c_reg_index(Xn, IsY_Xn, XIdx),
+    format(atom(Code), '{ .tag = INSTR_PUT_LIST, .reg_xn = ~w, .is_y_xn = ~w }', [XIdx, IsY_Xn]).
+wam_instruction_to_c_literal(unify_variable(Xn), Code) :-
+    c_reg_index(Xn, IsY_Xn, XIdx),
+    format(atom(Code), '{ .tag = INSTR_UNIFY_VARIABLE, .reg_xn = ~w, .is_y_xn = ~w }', [XIdx, IsY_Xn]).
+wam_instruction_to_c_literal(unify_value(Xn), Code) :-
+    c_reg_index(Xn, IsY_Xn, XIdx),
+    format(atom(Code), '{ .tag = INSTR_UNIFY_VALUE, .reg_xn = ~w, .is_y_xn = ~w }', [XIdx, IsY_Xn]).
+wam_instruction_to_c_literal(unify_constant(C), Code) :-
+    c_value_literal(C, Val),
+    format(atom(Code), '{ .tag = INSTR_UNIFY_CONSTANT, .val = ~w }', [Val]).
 wam_instruction_to_c_literal(call(P, N), Code) :-
     format(atom(Code), '{ .tag = INSTR_CALL, .pred = "~w", .arity = ~w }', [P, N]).
 wam_instruction_to_c_literal(execute(P), Code) :-
@@ -138,6 +159,34 @@ wam_line_to_c_instr(["put_constant", C, Ai], Instr) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),
     c_value_literal(CC, Val), c_reg_index(CAi, IsY, Idx),
     format(atom(Instr), '{ .tag = INSTR_PUT_CONSTANT, .val = ~w, .reg = ~w, .is_y_reg = ~w }', [Val, Idx, IsY]).
+wam_line_to_c_instr(["get_structure", F, Ai], Instr) :-
+    clean_comma(F, CF), clean_comma(Ai, CAi),
+    c_reg_index(CAi, IsY, Idx),
+    format(atom(Instr), '{ .tag = INSTR_GET_STRUCTURE, .pred = "~w", .reg_ai = ~w, .is_y_ai = ~w }', [CF, Idx, IsY]).
+wam_line_to_c_instr(["put_structure", F, Xn], Instr) :-
+    clean_comma(F, CF), clean_comma(Xn, CXn),
+    c_reg_index(CXn, IsY, Idx),
+    format(atom(Instr), '{ .tag = INSTR_PUT_STRUCTURE, .pred = "~w", .reg_xn = ~w, .is_y_xn = ~w }', [CF, Idx, IsY]).
+wam_line_to_c_instr(["get_list", Ai], Instr) :-
+    clean_comma(Ai, CAi),
+    c_reg_index(CAi, IsY, Idx),
+    format(atom(Instr), '{ .tag = INSTR_GET_LIST, .reg_ai = ~w, .is_y_ai = ~w }', [Idx, IsY]).
+wam_line_to_c_instr(["put_list", Xn], Instr) :-
+    clean_comma(Xn, CXn),
+    c_reg_index(CXn, IsY, Idx),
+    format(atom(Instr), '{ .tag = INSTR_PUT_LIST, .reg_xn = ~w, .is_y_xn = ~w }', [Idx, IsY]).
+wam_line_to_c_instr(["unify_variable", Xn], Instr) :-
+    clean_comma(Xn, CXn),
+    c_reg_index(CXn, IsY, Idx),
+    format(atom(Instr), '{ .tag = INSTR_UNIFY_VARIABLE, .reg_xn = ~w, .is_y_xn = ~w }', [Idx, IsY]).
+wam_line_to_c_instr(["unify_value", Xn], Instr) :-
+    clean_comma(Xn, CXn),
+    c_reg_index(CXn, IsY, Idx),
+    format(atom(Instr), '{ .tag = INSTR_UNIFY_VALUE, .reg_xn = ~w, .is_y_xn = ~w }', [Idx, IsY]).
+wam_line_to_c_instr(["unify_constant", C], Instr) :-
+    clean_comma(C, CC),
+    c_value_literal(CC, Val),
+    format(atom(Instr), '{ .tag = INSTR_UNIFY_CONSTANT, .val = ~w }', [Val]).
 wam_line_to_c_instr(["call", P, N], Instr) :-
     clean_comma(P, CP), clean_comma(N, CN),
     format(atom(Instr), '{ .tag = INSTR_CALL, .pred = "~w", .arity = ~w }', [CP, CN]).
@@ -243,12 +292,9 @@ compile_step_wam_to_c(_Options, CCode) :-
             case INSTR_GET_VALUE: {
                 WamValue *cell_xn = resolve_reg(state, instr->reg_xn, instr->is_y_xn);
                 WamValue *cell_ai = resolve_reg(state, instr->reg_ai, instr->is_y_ai);
-                if (val_equal(*cell_xn, *cell_ai)) {
-                    state->P++;
-                    return true;
-                }
-                // TODO: full wam_unify() fallback
-                return false;
+                if (!wam_unify(state, cell_xn, cell_ai)) return false;
+                state->P++;
+                return true;
             }
             case INSTR_PUT_CONSTANT: {
                 WamValue *cell = resolve_reg(state, instr->reg, instr->is_y_reg);
@@ -326,15 +372,151 @@ compile_step_wam_to_c(_Options, CCode) :-
                 state->P++;
                 return true;
             }
-            case INSTR_GET_STRUCTURE:
-            case INSTR_GET_LIST:
-            case INSTR_PUT_STRUCTURE:
-            case INSTR_PUT_LIST:
-            case INSTR_UNIFY_VARIABLE:
-            case INSTR_UNIFY_VALUE:
+            case INSTR_GET_STRUCTURE: {
+                WamValue *cell = wam_deref_ptr(state, resolve_reg(state, instr->reg_ai, instr->is_y_ai));
+                if (cell->tag == VAL_UNBOUND) {
+                    trail_binding(state, cell);
+                    WamValue s; s.tag = VAL_STR; s.data.ref_addr = state->H;
+                    *cell = s;
+                    
+                    const char *slash = strchr(instr->pred, '/');
+                    assert(slash != NULL && "Functor missing arity suffix");
+                    int arity = strtol(slash + 1, NULL, 10);
+                    
+                    // Invariant contract: We proactively pre-reserve capacity for the functor + all arity arguments.
+                    // Subsequent UNIFY_* instructions in write mode will push values sequentially via state->H++.
+                    // While UNIFY_* instructions have their own single-slot capacity guards, this pre-allocation 
+                    // ensures contiguous allocation and avoids multiple reallocs during the structure building sequence.
+                    int required = state->H + 1 + arity;
+                    if (required >= state->H_cap) {
+                        if (state->H_cap == 0) state->H_cap = WAM_INITIAL_CAP;
+                        while (required >= state->H_cap) state->H_cap *= 2;
+                        state->H_array = realloc(state->H_array, sizeof(WamValue) * state->H_cap);
+                    }
+                    state->H_array[state->H] = val_atom(instr->pred);
+                    state->H++;
+                    state->mode = MODE_WRITE;
+                } else if (cell->tag == VAL_STR) {
+                    WamValue *f = &state->H_array[cell->data.ref_addr];
+                    if (f->tag == VAL_ATOM && strcmp(f->data.atom, instr->pred) == 0) {
+                        state->S = cell->data.ref_addr + 1;
+                        state->mode = MODE_READ;
+                    } else { return false; }
+                } else { return false; }
+                state->P++;
+                return true;
+            }
+            case INSTR_PUT_STRUCTURE: {
+                WamValue s; s.tag = VAL_STR; s.data.ref_addr = state->H;
+                WamValue *cell = resolve_reg(state, instr->reg_xn, instr->is_y_xn);
+                *cell = s;
+                
+                const char *slash = strchr(instr->pred, '/');
+                assert(slash != NULL && "Functor missing arity suffix");
+                int arity = strtol(slash + 1, NULL, 10);
+                
+                // Invariant contract: Proactively pre-reserve capacity for functor + arguments.
+                // UNIFY_* instructions will sequentially append to H.
+                int required = state->H + 1 + arity;
+                if (required >= state->H_cap) {
+                    if (state->H_cap == 0) state->H_cap = WAM_INITIAL_CAP;
+                    while (required >= state->H_cap) state->H_cap *= 2;
+                    state->H_array = realloc(state->H_array, sizeof(WamValue) * state->H_cap);
+                }
+                state->H_array[state->H] = val_atom(instr->pred);
+                state->H++;
+                state->mode = MODE_WRITE;
+                state->P++;
+                return true;
+            }
+            case INSTR_GET_LIST: {
+                WamValue *cell = wam_deref_ptr(state, resolve_reg(state, instr->reg_ai, instr->is_y_ai));
+                if (cell->tag == VAL_UNBOUND) {
+                    trail_binding(state, cell);
+                    WamValue l; l.tag = VAL_LIST; l.data.ref_addr = state->H;
+                    *cell = l;
+                    
+                    // Invariant contract: Proactively pre-reserve capacity for [head|tail].
+                    // UNIFY_* instructions will sequentially append to H.
+                    int required = state->H + 2;
+                    if (required >= state->H_cap) {
+                        if (state->H_cap == 0) state->H_cap = WAM_INITIAL_CAP;
+                        while (required >= state->H_cap) state->H_cap *= 2;
+                        state->H_array = realloc(state->H_array, sizeof(WamValue) * state->H_cap);
+                    }
+                    state->mode = MODE_WRITE;
+                } else if (cell->tag == VAL_LIST) {
+                    state->S = cell->data.ref_addr;
+                    state->mode = MODE_READ;
+                } else { return false; }
+                state->P++;
+                return true;
+            }
+            case INSTR_PUT_LIST: {
+                WamValue l; l.tag = VAL_LIST; l.data.ref_addr = state->H;
+                WamValue *cell = resolve_reg(state, instr->reg_xn, instr->is_y_xn);
+                *cell = l;
+                
+                // Invariant contract: Proactively pre-reserve capacity for [head|tail].
+                // UNIFY_* instructions will sequentially append to H.
+                int required = state->H + 2;
+                if (required >= state->H_cap) {
+                    if (state->H_cap == 0) state->H_cap = WAM_INITIAL_CAP;
+                    while (required >= state->H_cap) state->H_cap *= 2;
+                    state->H_array = realloc(state->H_array, sizeof(WamValue) * state->H_cap);
+                }
+                state->mode = MODE_WRITE;
+                state->P++;
+                return true;
+            }
+            case INSTR_UNIFY_VARIABLE: {
+                WamValue *cell = resolve_reg(state, instr->reg_xn, instr->is_y_xn);
+                if (state->mode == MODE_READ) {
+                    *cell = state->H_array[state->S];
+                    state->S++;
+                } else {
+                    WamValue ref = wam_make_ref(state);
+                    *cell = ref;
+                }
+                state->P++;
+                return true;
+            }
+            case INSTR_UNIFY_VALUE: {
+                WamValue *cell = resolve_reg(state, instr->reg_xn, instr->is_y_xn);
+                if (state->mode == MODE_READ) {
+                    if (!wam_unify(state, cell, &state->H_array[state->S])) return false;
+                    state->S++;
+                } else {
+                    if (state->H >= state->H_cap) {
+                        state->H_cap = state->H_cap ? state->H_cap * 2 : WAM_INITIAL_CAP;
+                        state->H_array = realloc(state->H_array, sizeof(WamValue) * state->H_cap);
+                    }
+                    state->H_array[state->H] = *cell;
+                    state->H++;
+                }
+                state->P++;
+                return true;
+            }
             case INSTR_UNIFY_CONSTANT: {
-                // TODO: Full heap and structure allocation/unification
-                return false;
+                if (state->mode == MODE_READ) {
+                    WamValue *cell = wam_deref_ptr(state, &state->H_array[state->S]);
+                    if (cell->tag == VAL_UNBOUND) {
+                        trail_binding(state, cell);
+                        *cell = instr->val;
+                    } else if (!val_equal(*cell, instr->val)) {
+                        return false;
+                    }
+                    state->S++;
+                } else {
+                    if (state->H >= state->H_cap) {
+                        state->H_cap = state->H_cap ? state->H_cap * 2 : WAM_INITIAL_CAP;
+                        state->H_array = realloc(state->H_array, sizeof(WamValue) * state->H_cap);
+                    }
+                    state->H_array[state->H] = instr->val;
+                    state->H++;
+                }
+                state->P++;
+                return true;
             }
             default: return false;
         }


### PR DESCRIPTION
This PR brings robust compound term and list support to the C transpilation target. It implements the remaining unification machinery necessary for complex data structures, successfully handling both structural reads and writes on the heap.

## Overview
- **Unification Loop (`wam_unify`)**: Added an iterative, PDL (Push Down List)-based recursive unification helper to `wam_runtime.h`. It is bounded by a local depth stack (256 frames) to safely unify large, nested terms without risking stack overflows. 
- **Mode Dispatch**: Added the `WamMode mode` variable (`MODE_READ`, `MODE_WRITE`) to `WamState` to dispatch execution correctly across structure streams.
- **Heap Representation**: Adopted standard WAM heap layout where a `VAL_STR` pointer references the heap. The first heap cell stores the functor as a `VAL_ATOM` (e.g., `"parent/2"`), followed sequentially by its arguments. Lists use `VAL_LIST` and omit the implicit `[|]/2` functor cell.
- **Instruction Switch Cases**: Fleshed out `INSTR_GET_STRUCTURE`, `INSTR_PUT_STRUCTURE`, `INSTR_GET_LIST`, `INSTR_PUT_LIST`, `INSTR_UNIFY_VARIABLE`, `INSTR_UNIFY_VALUE`, and `INSTR_UNIFY_CONSTANT` inside the C target's `step_wam` loop.
- **Transpiler Support**: Registered all corresponding parsers inside `wam_c_target.pl` to accurately lower these WAM opcodes into C structs.

## Design Highlights
- **PDL Pattern**: To keep the systems-level scaffolding efficient and bulletproof against recursion bounds, `wam_unify` iterates a local `pdl` pointer array, pushing paired references and deferencing them iteratively. 
- **Memory Invariants**: Proactive block allocations are performed inside `GET_STRUCTURE` and `PUT_STRUCTURE` (as well as Lists) to safely guarantee contiguous heap allocations for sequential `UNIFY_*` instructions during write mode.
- **Dereferencing optimizations**: Integrated `wam_deref_ptr` and `wam_bind` directly within the unification logic to ensure proper variable trails during nested data unifications.

## Future Work (Follow-ups)
- Fixing upstream `test_wam_c_target.pl` tests which currently assert raw substrings of the *old* (now completely deprecated) C codegen format from Phase 1.
- Replacing the linear `$O(n)$` scan in `resolve_label` with an indexing strategy.
- Adding a dynamic memory limit checking strategy for arity clipping within `try_me_else` choice point captures.
