### PR TITLE
perf(wam-haskell): skip WAM compilation for LMDB-backed facts — 100k project gen 18 min → 4.5 s

### DIFF
--- a/docs/design/WAM_HASKELL_BENCHMARK_STRATEGY.md
+++ b/docs/design/WAM_HASKELL_BENCHMARK_STRATEGY.md
@@ -1,0 +1,176 @@
+# WAM Haskell Benchmark Strategy — Notes
+
+Working notes for the IntMap-vs-LMDB scaling comparison. These are
+decisions-in-progress rather than a finished spec. Captured here so we can
+revisit them when the data lands.
+
+## Current benchmark registry
+
+| Directory | Shape | Scale | Generator |
+|-----------|-------|-------|-----------|
+| `data/benchmark/dev/` | Dev (~20 articles from physics JSONL) | tiny | `generate_facts_from_db.py` |
+| `data/benchmark/300/` | Physics subset, 300 articles | 300 | `generate_facts.py` (API) |
+| `data/benchmark/1k/` | Physics subset, 1k articles | 1k | `generate_facts_from_db.py` |
+| `data/benchmark/5k/` | Physics subset, 5k articles | 5k | `generate_facts_from_db.py` |
+| `data/benchmark/10k/` | Science subset, 10k articles | 10k (25k edges) | `generate_facts_from_db.py --root Science --max-articles 10000` |
+| `data/benchmark/100k_cats/` | Full simplewiki category hierarchy, categories as seeds | ~84k cats / ~197k edges | `generate_category_only_benchmark.py` |
+| `data/benchmark/10x/` | Legacy scale variant | varies | ad hoc |
+
+**What each scale is good for:**
+
+- **dev/300/1k** — fast correctness checks; WAM-interpreter timing fits in
+  seconds.
+- **5k/10k** — backend throughput comparisons (IntMap vs LMDB raw). 10k
+  is the documented baseline in scaling-insights.
+- **100k_cats** — next step up in graph size; ~8× the hierarchy edges of
+  10k. Still fits in RAM comfortably so IntMap should still win, but
+  starts to exercise GC. First chance to see the IntMap/LMDB ratio
+  shift under pressure.
+- **Future 1M / full-383k-articles** — crossover territory. Requires
+  rerunning `generate_facts_from_db.py` with `--max-articles 383000`
+  against the local DB.
+
+## What we're trying to measure
+
+Two separable questions hide inside "how does fact access scale":
+
+1. **Backend throughput** — for a fixed graph, how does `EdgeLookup`
+   perform when implemented as IntMap vs LMDB raw? Dominated by per-lookup
+   cost.
+2. **Scaling behaviour** — as the graph grows, at what size does
+   in-memory IntMap lose (RAM, GC pressure) and LMDB's mmap story win?
+   Dominated by working-set vs RAM and GC pause time.
+
+At 10k (25k edges) we answered (1): LMDB raw is 1.29x IntMap warm. We
+haven't stressed (2) yet — IntMap is still trivially resident.
+
+100k is the next step up. Simplewiki has ~300k category edges total, so
+100k articles with the full category hierarchy gives us roughly 12x the
+hierarchy size of the 10k run — enough to start exercising GC but still
+well inside RAM.
+
+## Axes of variation
+
+| Axis | Choices | What it tests |
+|------|---------|---------------|
+| Article count | 1k, 5k, 10k, 100k, 1M | Seed-level work; parallelism scale |
+| Category set | Full simplewiki (~97k cats / ~297k edges), descendant-of-root, descendant-of-Science | Graph connectivity vs sparsity; orphan rate |
+| Article filter | All, top-k by category count, top-k semantic (embeddings), random-seeded | Information density per seed; reproducibility |
+| Backend | IntMap (FFI), LMDB raw (FFI) | Backend throughput |
+| Workload | effective-distance, closure, shortest-path | Access pattern (DFS, BFS, Dijkstra) |
+
+## Recommended strategy (for 100k)
+
+**Phase 1 — confirm the crossover direction is what we projected:**
+- Full category set (~300k hierarchy edges).
+- Articles: top-100k by category count (deterministic, reproducible,
+  no embedding dependency).
+- Effective-distance workload, Science root, max_depth=20.
+- Both backends, FFI kernels, same seeds for both runs.
+
+If IntMap still wins comfortably, crossover is past 100k and we should
+jump to ~1M or the full 383k-article set to see it.
+
+If LMDB closes the gap (< 1.29x), we've started hitting GC territory in
+IntMap and can measure GC pause time directly.
+
+**Phase 2 — variant axis:**
+- Descendant-of-root vs full category set, same article filter. Tests
+  how orphan categories affect DFS — the descendant-filtered run should
+  be faster for both backends because the graph is smaller, but the
+  ratio between backends is what's interesting.
+
+**Phase 3 — only if phases 1–2 motivate it:**
+- Top-k semantic filter (embeddings) to compare "rich" seeds against
+  "shallow" seeds. Probably doesn't change the scaling story, but
+  affects per-seed workload variance — relevant for parallelism.
+
+## Embedding-based filtering (for 1M+ scale)
+
+Not needed at 100k — deferred notes:
+
+- Cohere's Wikipedia embeddings on HuggingFace
+  (`Supabase/wikipedia-en-embeddings`) use MiniLM embeddings. Locally
+  cached folder exists but parquet data is not populated.
+- The typical pipeline for "rich" embeddings over a subset: **filter
+  top-k with MiniLM first, then recompute with a heavier model
+  (BGE/E5/nomic) on the smaller set**. We have BGE, E5, ModernBERT,
+  nomic-embed-text cached locally (`~/.cache/huggingface/hub`).
+- For benchmark reproducibility, prefer deterministic ranking (e.g.,
+  MiniLM cosine to a fixed centroid) over randomness.
+
+## Category-only workloads (small scales)
+
+At ≤100k we don't need articles in the graph at all — simplewiki's
+full category hierarchy (~97k categories / ~297k child→parent edges)
+is already near the 100k target. Shape for a category-only run:
+
+- `category_parent.tsv`: full hierarchy unchanged.
+- `article_category.tsv`: synthesized as `(C, C)` for each seed
+  category so the existing `effective_distance` workload still has
+  "article" seeds to iterate — each seed enters `category_ancestor`
+  at exactly its own category.
+- `root_categories.tsv`: one or more well-connected top-level
+  categories (e.g., `Main_topic_classifications`) that reach most of
+  the hierarchy.
+
+This keeps the `effective_distance.pl` workload shape unchanged —
+only the data it runs on differs.
+
+## Data generation considerations
+
+- **Reproducibility**: prefer deterministic article selection (top-k by
+  some fixed metric, or fixed-seed random sample) over API-driven
+  crawls. The simplewiki SQLite DB at
+  `context/gemini/UnifyWeaver/data/simplewiki/simplewiki_categories.db`
+  is already a frozen snapshot — use it.
+- **Correctness check**: both backends must produce identical query
+  results. Already enforced at 10k — repeat at every scale.
+- **Idempotent ingestion**: LMDB directory should be reused across runs
+  once populated. First run pays ingestion cost; subsequent runs don't.
+- **Cold vs warm**: `echo 3 > /proc/sys/vm/drop_caches` (requires sudo)
+  to force cold pages. Without that, "warm" is the default after first
+  run.
+
+## Profiling considerations
+
+- GHC `-p`: watch for `peekElemOff`, `mdb_get'`, `mapM` showing up in
+  the LMDB run. In the IntMap run, watch for `IntMap.lookup` and GC
+  time.
+- RTS `-s`: compare total GC time between backends at each scale. This
+  is the signal for LMDB's eventual win.
+- `+RTS -hT`: heap profile by closure type. IntMap heap residency
+  should grow roughly linearly with graph size; LMDB stays near-flat.
+
+## Optimization hypotheses (to evaluate, not pre-commit)
+
+Neither should be implemented until the profile justifies it.
+
+- **LRU hot-key cache over LMDB**: effective-distance DFS revisits
+  high-degree nodes often. If `mdb_get'` dominates the LMDB profile,
+  a small cache (1k-10k entries) should help. Risk: adds complexity
+  for narrow gain if profile shows the bottleneck is elsewhere.
+- **Demand-set pre-materialization**: walk the demand set once via
+  LMDB, build a transient IntMap of just the touched keys, query
+  against that. Half-defeats the point of LMDB (working set must fit
+  in RAM) but useful when demand sets are small relative to the full
+  graph.
+
+## What we're NOT testing (yet)
+
+- SQLite backend (Termux target — deferred to B2)
+- Raw mmap `.uwbr` artifact (deferred to B3)
+- Multi-predicate workloads (category_ancestor is the only FFI-backed
+  predicate at scale right now)
+- Write throughput (everything here is read-only after ingestion)
+
+## Open questions
+
+- Does the GC cost of a 300k-edge IntMap actually show up in total
+  query time, or does generational GC promote it to old-gen once and
+  forget about it?
+- Is the long-lived read transaction's page-cache pinning helping or
+  hurting at larger scales? At 1M+ it could pin more than we want.
+- For the "orphan" variant — do disconnected categories just sit
+  unqueried (zero cost) or do they somehow slow down lookups in both
+  backends?

--- a/docs/design/WAM_HASKELL_SCALING_INSIGHTS.md
+++ b/docs/design/WAM_HASKELL_SCALING_INSIGHTS.md
@@ -169,6 +169,33 @@ of IntMap with warm OS page cache.
 | LMDB raw (cold pages) | 1018 | 1.9x |
 | LMDB raw (warm pages) | 684 | 1.29x |
 
+### 100k scale (category-only workload)
+
+Dataset: full simplewiki category hierarchy (84,136 categories,
+196,900 child→parent edges) with every category acting as its own
+query seed. No article predicates; the graph is just the category
+tree. Queries: effective-distance aggregation via the
+`category_ancestor/4` FFI kernel.
+
+| Backend | query_ms (100k_cats) | Ratio |
+|---------|---------------------|-------|
+| IntMap (avg of 2) | ~172,000 | 1.0x |
+| LMDB raw (cold) | 191,550 | 1.11x |
+| LMDB raw (warm) | 181,263 | 1.05x |
+
+The warm ratio narrowed from 1.29x at 10k to **1.05x at 100k_cats** —
+within noise. This is consistent with the projected crossover: as the
+in-memory IntMap grows, per-query GC and pointer-chasing cost
+creeps up while LMDB's mmap'd B+ tree lookups stay flat.
+
+**Key compile-time lesson**: the first 100k LMDB build took 18+ minutes
+before we identified and fixed it. The compile_predicates pipeline
+was still running full WAM compilation for `category_parent` even
+though the runtime path served it from LMDB. Adding an
+`external_source` layout — which short-circuits WAM compilation for
+LMDB-backed fact predicates — dropped project generation to 4.5
+seconds. The runtime numbers above use that fix.
+
 The lesson: **serialization format matters enormously for database-backed
 lookups in hot loops**. CBOR's flexibility (arbitrary Haskell types) is
 not worth the cost when the data is just arrays of integers.

--- a/examples/benchmark/generate_category_only_benchmark.py
+++ b/examples/benchmark/generate_category_only_benchmark.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Generate a category-only benchmark dataset from simplewiki.
+
+Emits the full category_parent hierarchy (~97k categories, ~297k edges)
+and synthesizes article seeds as (C, C) so the existing effective_distance
+workload runs against category seeds directly — no Wikipedia articles
+involved.
+
+All true root categories (categories with no parent of their own, excluding
+maintenance cats) are declared as root_category/1 so seeds can reach any
+reachable top-level category.
+
+Usage:
+    python examples/benchmark/generate_category_only_benchmark.py \
+        --output data/benchmark/100k_cats/ \
+        --db context/gemini/UnifyWeaver/data/simplewiki/simplewiki_categories.db
+"""
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+SKIP_PREFIXES = (
+    "Articles_", "Pages_", "All_", "CS1_", "Webarchive_",
+    "Wikipedia_", "Commons_", "Wikidata_", "Use_", "Hidden",
+    "Container_", "Navseasoncats", "Category_redirects",
+    "Short_description", "Good_articles", "Featured_articles",
+    "CatAutoTOC",
+)
+SKIP_SUFFIXES = (
+    "_stubs", "_stub", "_templates", "_navigational_templates",
+    "_navigational_boxes", "_disambiguation", "_redirects",
+)
+
+
+def is_maintenance(cat: str) -> bool:
+    return (
+        any(cat.startswith(p) for p in SKIP_PREFIXES)
+        or any(cat.endswith(s) for s in SKIP_SUFFIXES)
+    )
+
+
+def prolog_atom(s: str) -> str:
+    escaped = s.replace("\\", "\\\\").replace("'", "\\'")
+    return f"'{escaped}'"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--output", required=True)
+    ap.add_argument("--db", default="context/gemini/UnifyWeaver/data/simplewiki/simplewiki_categories.db")
+    ap.add_argument("--max-seeds", type=int, default=None,
+                    help="Cap number of seed categories (default: all content categories)")
+    args = ap.parse_args()
+
+    if not Path(args.db).exists():
+        print(f"DB not found: {args.db}", file=sys.stderr)
+        sys.exit(1)
+
+    conn = sqlite3.connect(args.db)
+
+    print("Loading full subcat graph...")
+    edges = []
+    for child, parent in conn.execute("""
+        SELECT p.page_title AS child, cl.cl_to AS parent
+        FROM categorylinks cl
+        JOIN page p ON cl.cl_from = p.page_id
+        WHERE cl.cl_type = 'subcat' AND p.page_namespace = 14
+    """):
+        if is_maintenance(child) or is_maintenance(parent):
+            continue
+        edges.append((child, parent))
+
+    children_of = defaultdict(list)
+    parents_of = defaultdict(list)
+    all_cats = set()
+    for child, parent in edges:
+        children_of[parent].append(child)
+        parents_of[child].append(parent)
+        all_cats.add(child)
+        all_cats.add(parent)
+
+    print(f"  {len(all_cats):,} content categories")
+    print(f"  {len(edges):,} subcat edges after filtering")
+
+    # Roots: appear as parent, have no parent themselves
+    roots = sorted(
+        c for c in children_of.keys()
+        if c not in parents_of and not is_maintenance(c)
+    )
+    print(f"  {len(roots):,} root categories (top-level)")
+
+    # Seeds: every content category is its own "article"
+    seeds = sorted(all_cats)
+    if args.max_seeds and len(seeds) > args.max_seeds:
+        seeds = seeds[:args.max_seeds]
+    print(f"  {len(seeds):,} seed categories")
+
+    out = Path(args.output)
+    out.mkdir(parents=True, exist_ok=True)
+
+    with open(out / "category_parent.tsv", "w") as f:
+        f.write("child\tparent\n")
+        for c, p in sorted(edges):
+            f.write(f"{c}\t{p}\n")
+
+    with open(out / "article_category.tsv", "w") as f:
+        f.write("article\tcategory\n")
+        for c in seeds:
+            f.write(f"{c}\t{c}\n")
+
+    with open(out / "root_categories.tsv", "w") as f:
+        f.write("category\n")
+        for r in roots:
+            f.write(f"{r}\n")
+
+    with open(out / "facts.pl", "w") as f:
+        f.write("%% Auto-generated category-only benchmark facts\n")
+        f.write("%% Source: Simple English Wikipedia (simplewiki dumps)\n")
+        f.write(f"%% Seeds: each category appears as its own 'article'\n\n")
+
+        f.write("%% article_category(ArticleTitle, CategoryName).\n")
+        for c in seeds:
+            f.write(f"article_category({prolog_atom(c)}, {prolog_atom(c)}).\n")
+
+        f.write("\n%% category_parent(ChildCategory, ParentCategory).\n")
+        for child, parent in sorted(edges):
+            f.write(f"category_parent({prolog_atom(child)}, {prolog_atom(parent)}).\n")
+
+        f.write("\n%% root_category(CategoryName).\n")
+        for r in roots:
+            f.write(f"root_category({prolog_atom(r)}).\n")
+
+    meta = {
+        "source": "Simple English Wikipedia dumps (simplewiki)",
+        "database": args.db,
+        "shape": "category-only — seeds are categories themselves",
+        "n_categories": len(all_cats),
+        "n_hierarchy_edges": len(edges),
+        "n_seeds": len(seeds),
+        "n_roots": len(roots),
+    }
+    with open(out / "metadata.json", "w") as f:
+        json.dump(meta, f, indent=2)
+
+    total = len(seeds) + len(edges) + len(roots)
+    print(f"\nWrote to {out}/")
+    print(f"  facts.pl: {total:,} Prolog facts")
+    print(f"  metadata.json: {meta}")
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2446,6 +2446,14 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     % Determine map backend: HashMap (faster) or Map (default fallback)
     option(use_hashmap(UseHM), Options, true),
 
+    % Phase B1: split external_source (LMDB-backed) predicates from
+    % internal ones. External_source preds have no clauses-at-compile-
+    % time to inspect — their data lives in the database — so they
+    % must bypass kernel detection, lowering, PC computation, and WAM
+    % compilation. They still appear in `Predicates` so
+    % compile_predicates_to_haskell emits a skip-comment for each.
+    partition(pred_is_external_source(Options), Predicates, _ExternalPreds, InternalPreds),
+
     % Detect recursive kernels in the predicate list. Detected kernels
     % are handled by the FFI (executeForeign) at runtime and are excluded
     % from generic lowering. The detected kernel list is used to auto-
@@ -2455,7 +2463,7 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     (   option(no_kernels(true), Options)
     ->  DetectedKernels = [],
         format(user_error, '[WAM-Haskell] kernel detection suppressed~n', [])
-    ;   detect_kernels(Predicates, DetectedKernels),
+    ;   detect_kernels(InternalPreds, DetectedKernels),
         (   DetectedKernels \= []
         ->  pairs_keys(DetectedKernels, DetectedKeys),
             format(user_error, '[WAM-Haskell] detected kernels: ~w~n', [DetectedKeys])
@@ -2466,7 +2474,7 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     % Resolve emit_mode and partition predicates. Detected kernels are
     % explicitly excluded from lowering (they use FFI via CallForeign).
     wam_haskell_resolve_emit_mode(Options, EmitMode),
-    wam_haskell_partition_predicates(EmitMode, Predicates, DetectedKernels, InterpretedList, LoweredList),
+    wam_haskell_partition_predicates(EmitMode, InternalPreds, DetectedKernels, InterpretedList, LoweredList),
     length(InterpretedList, NInterp),
     length(LoweredList, NLower),
     format(user_error,
@@ -2501,7 +2509,7 @@ write_wam_haskell_project(Predicates, Options, ProjectDir) :-
     % We first compute global base PCs matching the merged instruction
     % array so the lowered functions' PC references (wsCP for Call return
     % addresses, wsPC for step calls) are correct.
-    compute_base_pcs(Predicates, BasePCMap),
+    compute_base_pcs(InternalPreds, BasePCMap),
     lower_all(LoweredList, BasePCMap, DetectedKernels, LoweredEntries),
     generate_lowered_hs(LoweredEntries, LoweredCode0),
     apply_hashmap_rewrite(UseHM, generic, LoweredCode0, LoweredCode),
@@ -3479,11 +3487,58 @@ allLabels = Map.fromList
     ]
 ~w', [ShapeBlock, InstrCode, LabelCode, InlineBlock]).
 
+%% use_external_source(+Pred/Arity, +Options)
+%  True when this predicate's data lives in an external store (LMDB)
+%  rather than compiled WAM code. Default allow-list is [category_parent/2]
+%  because the LMDB ingestion wiring in generate_lmdb_wiring/4 is
+%  hardcoded to that predicate. Override with option
+%  lmdb_backed_facts([P1/A1, P2/A2, ...]) when additional predicates
+%  are also LMDB-ingested.
+use_external_source(Pred/Arity, Options) :-
+    option(use_lmdb(true), Options),
+    option(lmdb_backed_facts(LmdbPreds), Options, [category_parent/2]),
+    memberchk(Pred/Arity, LmdbPreds).
+
+%% pred_is_external_source(+Options, +PredIndicator)
+%  partition/4 adapter for use_external_source/2. Accepts either
+%  Module:Pred/Arity or Pred/Arity form.
+pred_is_external_source(Options, PredIndicator) :-
+    (   PredIndicator = _Module:Pred/Arity -> true
+    ;   PredIndicator = Pred/Arity
+    ),
+    use_external_source(Pred/Arity, Options).
+
 compile_predicates_merged([], _, _, [], [], [], []).
 compile_predicates_merged([PredIndicator|Rest], StartPC, Options, AllInstrs, AllLabels, AllComments, AllInlineDefs) :-
     (   PredIndicator = _Module:Pred/Arity -> true
     ;   PredIndicator = Pred/Arity
     ),
+    % Phase B1 optimization: predicates whose data lives in an external
+    % store (LMDB) are resolved at runtime via wcEdgeLookups, so the
+    % WAM bytecode for each fact is dead weight. Skip compilation
+    % entirely for those.
+    (   use_external_source(Pred/Arity, Options)
+    ->  format(user_error,
+               '  ~w/~w: external_source — skipping WAM compilation (LMDB-backed)~n',
+               [Pred, Arity]),
+        format(string(Comment),
+               '-- ~w/~w: fact_only=true, layout=external_source (data in LMDB)',
+               [Pred, Arity]),
+        InstrExprs = [],
+        LabelExprs = [],
+        InlineDefs = [],
+        NextPC = StartPC,
+        compile_predicates_merged(Rest, NextPC, Options, RestInstrs, RestLabels, RestComments, RestInlineDefs),
+        append(InstrExprs, RestInstrs, AllInstrs),
+        append(LabelExprs, RestLabels, AllLabels),
+        AllComments = [Comment | RestComments],
+        append(InlineDefs, RestInlineDefs, AllInlineDefs)
+    ;   compile_predicates_merged_normal(PredIndicator, Pred, Arity, Rest, StartPC, Options,
+                                         AllInstrs, AllLabels, AllComments, AllInlineDefs)
+    ).
+
+compile_predicates_merged_normal(PredIndicator, Pred, Arity, Rest, StartPC, Options,
+                                 AllInstrs, AllLabels, AllComments, AllInlineDefs) :-
     wam_target:compile_predicate_to_wam(PredIndicator, [], WamCode),
     format(user_error, '  ~w/~w: compiled to WAM (PC=~w)~n', [Pred, Arity, StartPC]),
     atom_string(WamCode, WamStr),

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1234,6 +1234,74 @@ test_b1_no_lmdb_cabal_default :-
     ;   fail_test(Test, 'lmdb-simple should not appear in default cabal deps')
     ).
 
+test_b1_external_source_skips_wam_compilation :-
+    Test = 'B1: external_source fact predicate skips WAM compilation',
+    (   retractall(user:b1_ext(_, _)),
+        forall(between(1, 10, I), (
+            atom_number(A, I),
+            atom_concat(parent_, A, P),
+            assert(user:b1_ext(A, P))
+        )),
+        init_atom_intern_table,
+        wam_haskell_target:compile_predicates_to_haskell(
+            [b1_ext/2],
+            [use_lmdb(true), lmdb_backed_facts([b1_ext/2])],
+            Code, _),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "external_source"),
+        % No per-fact emission in any path — neither CallFactStream nor
+        % an inline fact list nor WAM label entry for b1_ext
+        \+ sub_string(S, _, _, _, "CallFactStream"),
+        \+ sub_string(S, _, _, _, "b1ExtFacts"),
+        \+ sub_string(S, _, _, _, "(\"b1_ext/2\"")
+    ->  pass(Test)
+    ;   fail_test(Test, 'external_source predicate should emit no WAM code')
+    ),
+    retractall(user:b1_ext(_, _)).
+
+test_b1_external_source_default_allow_list :-
+    Test = 'B1: default lmdb_backed_facts covers category_parent/2',
+    (   retractall(user:category_parent(_, _)),
+        forall(between(1, 10, I), (
+            atom_number(A, I),
+            atom_concat(cp_p_, A, P),
+            atom_concat(cp_c_, A, C),
+            assert(user:category_parent(C, P))
+        )),
+        init_atom_intern_table,
+        wam_haskell_target:compile_predicates_to_haskell(
+            [category_parent/2],
+            [use_lmdb(true)],
+            Code, _),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "external_source"),
+        \+ sub_string(S, _, _, _, "CallFactStream"),
+        \+ sub_string(S, _, _, _, "categoryParentFacts")
+    ->  pass(Test)
+    ;   fail_test(Test, 'category_parent/2 should be skipped by default under use_lmdb(true)')
+    ),
+    retractall(user:category_parent(_, _)).
+
+test_b1_external_source_off_without_use_lmdb :-
+    Test = 'B1: without use_lmdb(true) fact predicates still compile',
+    (   retractall(user:b1_noext(_, _)),
+        forall(between(1, 6, I), (
+            atom_number(A, I),
+            atom_concat(p_, A, P),
+            assert(user:b1_noext(A, P))
+        )),
+        init_atom_intern_table,
+        wam_haskell_target:compile_predicates_to_haskell(
+            [b1_noext/2],
+            [lmdb_backed_facts([b1_noext/2])],
+            Code, _),
+        atom_string(Code, S),
+        \+ sub_string(S, _, _, _, "external_source")
+    ->  pass(Test)
+    ;   fail_test(Test, 'external_source should require use_lmdb(true)')
+    ),
+    retractall(user:b1_noext(_, _)).
+
 test_b1_lmdb_raw_zero_copy_reads :-
     Test = 'B1: lmdbRawEdgeLookup uses mdb_get for zero-copy reads',
     (   compile_wam_runtime_to_haskell([use_lmdb(true)], [], Code),
@@ -1349,6 +1417,9 @@ run_tests :-
     test_b1_lmdb_cabal_dependency,
     test_b1_no_lmdb_cabal_default,
     test_b1_lmdb_raw_zero_copy_reads,
+    test_b1_external_source_skips_wam_compilation,
+    test_b1_external_source_default_allow_list,
+    test_b1_external_source_off_without_use_lmdb,
     format('~n========================================~n'),
     (   test_failed
     ->  format('Tests FAILED~n'), halt(1)


### PR DESCRIPTION
  ## Summary

  LMDB-backed fact predicates (e.g. `category_parent/2`) were still being compiled to WAM bytecode at codegen time even
  though runtime lookups bypass WAM via `wcEdgeLookups`. At 100k_cats (197k edges) this produced 18+ minutes of bytecode
   that was never executed.

  This PR adds an `external_source` layout that short-circuits WAM compilation for LMDB-backed facts and produces the
  first 100k_cats scaling measurement.

  ## The fix

  When `use_lmdb(true)` and the predicate is in the `lmdb_backed_facts` allow-list (default `[category_parent/2]`), skip
   WAM compilation across **three independent paths** that all re-ran it on the same fact list:

  | Path | Role |
  |------|------|
  | `compile_predicates_merged_normal` | Main Predicates.hs emitter |
  | `compute_base_pcs_` | Global PC assignment across predicates |
  | `wam_haskell_partition_try_lower` / `_mixed` | Haskell-native lowering |

  Predicates are filtered out of `detect_kernels`, partitioning, PC computation, and lowering via `partition/4` over
  `pred_is_external_source/2`. They still appear in emitted `Predicates.hs` as a layout comment for transparency.

  ## Impact

  ### Compile time (100k_cats: 84k categories, 197k hierarchy edges)

  | Step | Before | After |
  |------|--------|-------|
  | `swipl` project generation | 18+ min (not completed) | **4.5 s** |

  ### Runtime benchmark

  | Backend | query_ms | Ratio vs IntMap |
  |---------|----------|-----------------|
  | IntMap (FFI, avg of 2 runs) | ~172,000 | 1.00x |
  | LMDB raw (cold pages) | 191,550 | 1.11x |
  | LMDB raw (warm pages) | 181,263 | 1.05x |

  The warm LMDB gap narrowed from **1.29x at 10k to 1.05x at 100k_cats** — the projected IntMap/LMDB crossover is coming
   into view. Next data point: ~1M edges.

  ## Tests

  Three new B1 tests in `tests/test_wam_haskell_target.pl`:

  - `test_b1_external_source_skips_wam_compilation` — verifies no WAM code or inline fact literal is emitted for the
  allow-listed predicate.
  - `test_b1_external_source_default_allow_list` — verifies `category_parent/2` is covered by the default list.
  - `test_b1_external_source_off_without_use_lmdb` — verifies the skip only fires under `use_lmdb(true)`.

  All existing tests pass.

  ## Also in this PR

  - `examples/benchmark/generate_category_only_benchmark.py` — generator for the category-only benchmark shape (full
  simplewiki hierarchy, categories as seeds).
  - `docs/design/WAM_HASKELL_BENCHMARK_STRATEGY.md` — new testing-strategy doc covering axes, scale registry, and the
  deferred MiniLM→heavy-embedding semantic filter pipeline for future 1M+ workloads.
  - `docs/design/WAM_HASKELL_SCALING_INSIGHTS.md` — appended 100k_cats row and the compile-time lesson.

  ## Test plan

  - [x] `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl` — all pass
  - [x] 100k_cats IntMap project builds and produces 11 result tuples
  - [x] 100k_cats LMDB project builds, ingests 84k edges, produces identical 11 result tuples
  - [x] External_source predicate emits no WAM bytecode (verified by tests + manual inspection of generated
  `Predicates.hs`)