### PR TITLE
feat(csharp-query): Configure non-binary delimited sources through the C# query runtime provider

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -3515,6 +3515,30 @@ namespace UnifyWeaver.QueryRuntime
                     throw new ArgumentOutOfRangeException(nameof(SourceMode), SourceMode, null);
             }
         }
+
+        public void RegisterDelimitedRelation(PredicateId predicate, DelimitedRelationSource source, string? artifactName = null)
+        {
+            if (source.ExpectedWidth == 2)
+            {
+                RegisterBinaryRelation(predicate, source, artifactName);
+                return;
+            }
+
+            switch (SourceMode)
+            {
+                case RelationSourceMode.Delimited:
+                    MemoryProvider.RegisterDelimitedSource(predicate, source);
+                    return;
+                case RelationSourceMode.Preload:
+                case RelationSourceMode.Artifact:
+                case RelationSourceMode.ArtifactPrebuilt:
+                    MemoryProvider.RegisterDelimitedSource(predicate, source);
+                    MemoryProvider.AddFacts(predicate, DelimitedRelationReader.ReadRows(source));
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(SourceMode), SourceMode, null);
+            }
+        }
     }
 
     public sealed class QueryExecutor

--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -4340,11 +4340,14 @@ dynamic_relation_block(Name, Arity, Metadata, Block) :-
     ).
 
 configured_binary_relation_block(NameStr, Arity, Metadata, Block) :-
-    Arity =:= 2,
-    can_emit_configured_binary_relation(Metadata, SourceLiteral),
+    can_emit_configured_delimited_relation(Arity, Metadata, SourceLiteral),
+    (   Arity =:= 2
+    ->  Method = 'RegisterBinaryRelation'
+    ;   Method = 'RegisterDelimitedRelation'
+    ),
     format(atom(Block),
-'            configuredProvider.RegisterBinaryRelation(new PredicateId(\"~w\", ~w), ~w, \"~w_~w\");',
-        [NameStr, Arity, SourceLiteral, NameStr, Arity]).
+'            configuredProvider.~w(new PredicateId(\"~w\", ~w), ~w, \"~w_~w\");',
+        [Method, NameStr, Arity, SourceLiteral, NameStr, Arity]).
 
 dynamic_reader_literal(Metadata, Arity, Literal) :-
     (   get_dict(record_format, Metadata, Format)
@@ -4379,7 +4382,7 @@ delimited_reader_literal(Metadata, Arity, Literal) :-
             })',
         [InputLiteral, FieldSepLiteral, RecSepLiteral, QuoteLiteral, SkipRows, Arity]).
 
-can_emit_configured_binary_relation(Metadata, Literal) :-
+can_emit_configured_delimited_relation(Arity, Metadata, Literal) :-
     (   get_dict(record_format, Metadata, Format0)
     ->  Format = Format0
     ;   Format = text_line
@@ -4400,7 +4403,7 @@ can_emit_configured_binary_relation(Metadata, Literal) :-
     ),
     QuoteStyle == none,
     csharp_literal(Path, PathLiteral),
-    format(atom(Literal), 'new DelimitedRelationSource(~w, ~w, ~w, 2)', [PathLiteral, FieldSepLiteral, SkipRows]).
+    format(atom(Literal), 'new DelimitedRelationSource(~w, ~w, ~w, ~w)', [PathLiteral, FieldSepLiteral, SkipRows, Arity]).
 
 json_reader_literal(Metadata, Arity, Literal) :-
     metadata_input_literal(Metadata, InputLiteral),

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -6186,8 +6186,10 @@ verify_tsv_dynamic_source_plan :-
 verify_tsv_dynamic_source_plan_ :-
     csharp_query_target:build_query_plan(test_sales_total/2, [target(csharp_query)], Plan),
     csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'configuredProvider.RegisterDelimitedRelation'),
+    sub_string(Source, _, _, _, 'new DelimitedRelationSource'),
     sub_string(Source, _, _, _, 'test_sales.tsv'),
-    string_codes(TabLiteral, [0'@, 34, 9, 34]),
+    string_codes(TabLiteral, [39, 92, 116, 39]),
     sub_string(Source, _, _, _, TabLiteral),
     maybe_run_query_runtime(Plan, ['Laptop,1200', 'Mouse,25', 'Keyboard,75']).
 


### PR DESCRIPTION
  ## Summary

  This PR extends the C# query runtime configured-source path beyond binary delimited relations.

  It adds runtime support for simple non-binary delimited sources, while keeping artifact-backed execution limited to the existing binary artifact format.

  ## What Changed

  ### Runtime

  `ConfiguredDelimitedRelationProvider` now has:

  - `RegisterDelimitedRelation(...)`

  For width-2 sources, this delegates to the existing binary path:

  - `RegisterBinaryRelation(...)`

  For wider delimited sources:

  - `Delimited` mode registers the source for streaming reads
  - `Preload` mode loads rows into the memory provider
  - `Artifact` and `ArtifactPrebuilt` currently fall back to preload behavior because the artifact format is still binary-only

  ### C# Query Target Codegen

  The generated C# query target now emits configured provider registration for simple delimited sources of any arity when the source is compatible with
  `DelimitedRelationSource`.

  It still excludes sources that require specialized readers, including:

  - JSON
  - JSONL
  - XML
  - quoted CSV-style sources

  ### Tests

  The TSV dynamic-source test now asserts that generated code uses:

  - `configuredProvider.RegisterDelimitedRelation(...)`
  - `DelimitedRelationSource`

  CSV with quote handling remains on `DelimitedTextReader`, which preserves the previous specialized reader behavior.

  ## Why

  The previous runtime-configured source path only handled binary delimited relations. That was enough for artifact-backed binary indexes, but it left simple wider
  TSV-style relations on the older generated reader path.

  This PR moves the simple non-binary delimited case onto the same runtime-owned provider configuration path without pretending the artifact backend supports
  general N-ary artifacts yet.

  ## Validation

  Ran:

  ```bash
  env SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g "test_csharp_query_target:test_csharp_query_target" -t halt

  Result:

  - passed at 241/241

  Ran:

  dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c Release --nologo

  Result:

  - passed with existing nullable warnings
  - 0 errors

  Also ran:

  git diff --check

  Result:

  - passed

  Targeted runtime check:

  - initialized verify_tsv_dynamic_source_plan
  - passed generated C# execution

  ## Scope

  This PR does not add a general N-ary artifact format.

  For now, artifact modes for non-binary delimited sources fall back to preloaded memory-provider rows. That keeps the behavior correct while allowing more
  generated query modules to use the runtime-configured source path.