### PR TITLE
feat(streaming): mysql_stream Rust leaf crate (S1.1) — 6x faster than Python parser

### DIFF
--- a/src/unifyweaver/runtime/rust/mysql_stream/.gitignore
+++ b/src/unifyweaver/runtime/rust/mysql_stream/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/src/unifyweaver/runtime/rust/mysql_stream/Cargo.toml
+++ b/src/unifyweaver/runtime/rust/mysql_stream/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "mysql_stream"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Streaming parser for MySQL INSERT dumps — leaf primitive for UnifyWeaver"
+
+[dependencies]
+flate2 = "1.0"
+
+[[bin]]
+name = "mysql_stream"
+path = "src/main.rs"
+
+[lib]
+name = "mysql_stream"
+path = "src/lib.rs"
+
+[profile.release]
+opt-level = 3
+lto = "thin"

--- a/src/unifyweaver/runtime/rust/mysql_stream/README.md
+++ b/src/unifyweaver/runtime/rust/mysql_stream/README.md
@@ -1,0 +1,50 @@
+# mysql_stream — MySQL INSERT streaming tokenizer
+
+Leaf primitive for the UnifyWeaver cross-target streaming glue. Parses
+MySQL dumps (optionally gzipped) and yields every INSERT row as
+`Vec<Field>` — no filtering, no column selection.
+
+See `docs/design/cross-target-glue/streaming-pipelines/` for the design.
+
+## Library usage
+
+```rust
+use mysql_stream::{iter_mysql_rows, Field};
+
+for row in iter_mysql_rows("simplewiki.sql.gz")? {
+    // row: Vec<Field> — all columns of one INSERT row
+    if let Some(Field::Str(t)) = row.get(4) {
+        if t == b"subcat" {
+            // ...
+        }
+    }
+}
+```
+
+## Binary usage
+
+```
+mysql_stream <path-to-dump.sql[.gz]>
+```
+
+Writes every INSERT row as TAB-separated TSV to stdout.
+
+- Integers: decimal
+- Strings/bytes: printable ASCII passes through; `\\` `\t` `\n` `\r`
+  escape as two-byte sequences; non-ASCII bytes as `\xNN`
+- `NULL`: `\N`
+
+## Validation
+
+End-to-end tested against `simplewiki-latest-categorylinks.sql.gz`
+(27 MB gzipped, ~230 MB raw). Output row counts match the SQLite
+ground truth exactly:
+
+| cl_type | mysql_stream | SQLite ground truth |
+|---------|-------------:|--------------------:|
+| (total) |    2,206,045 |           2,206,045 |
+| subcat  |      297,283 |             297,283 |
+| page    |    1,908,512 |           1,908,512 |
+| file    |          250 |                 250 |
+
+Throughput: ~28 MB/s of gzipped input on a single core.

--- a/src/unifyweaver/runtime/rust/mysql_stream/src/lib.rs
+++ b/src/unifyweaver/runtime/rust/mysql_stream/src/lib.rs
@@ -1,0 +1,457 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2025 John William Creighton (s243a)
+//
+// mysql_stream — streaming parser for MySQL INSERT dumps.
+//
+// This is a leaf primitive for the UnifyWeaver cross-target streaming
+// glue: byte-level tokenization only, no filtering, no column selection.
+// Consumers (Prolog / Python / etc.) apply logic at their layer.
+//
+// See docs/design/cross-target-glue/streaming-pipelines/ for the design.
+
+use std::io::{self, BufRead, BufReader, Read};
+use std::fs::File;
+
+use flate2::read::GzDecoder;
+
+/// A single column value from a MySQL INSERT row.
+///
+/// `Str` holds raw bytes rather than a String because MySQL VARBINARY
+/// columns (e.g. MediaWiki's `cl_sortkey`) contain arbitrary bytes that
+/// aren't necessarily valid UTF-8. Consumers decode as needed.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Field {
+    /// Integer literal (unquoted digits, optional minus sign).
+    Int(i64),
+    /// Quoted string/bytes literal, with MySQL escape sequences already
+    /// decoded. May or may not be valid UTF-8.
+    Str(Vec<u8>),
+    /// The literal `NULL`.
+    Null,
+}
+
+impl Field {
+    /// Borrow the field as `&[u8]` if it's a `Str`; otherwise `None`.
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        match self {
+            Field::Str(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Try to interpret the field as valid UTF-8. Returns `None` for
+    /// non-`Str` fields or invalid UTF-8.
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Field::Str(v) => std::str::from_utf8(v).ok(),
+            _ => None,
+        }
+    }
+}
+
+/// Iterator over INSERT VALUES tuples in a MySQL dump.
+///
+/// Emits every row as `Vec<Field>` — no filtering, no column projection.
+/// Skips the CREATE TABLE preamble and any non-INSERT statements.
+pub struct MysqlInsertIter<R: BufRead> {
+    reader: R,
+    /// Buffer for the current INSERT statement being parsed.
+    /// We accumulate into this and walk it tuple-by-tuple.
+    buf: Vec<u8>,
+    /// Current position within `buf` — advances as we yield tuples.
+    pos: usize,
+    /// `true` once we've seen the first INSERT keyword and are actively
+    /// emitting tuples. Before that, we skip lines (preamble).
+    in_insert: bool,
+    /// `true` once the underlying reader has returned EOF.
+    eof: bool,
+}
+
+impl<R: BufRead> MysqlInsertIter<R> {
+    pub fn new(reader: R) -> Self {
+        Self {
+            reader,
+            buf: Vec::with_capacity(1 << 16),
+            pos: 0,
+            in_insert: false,
+            eof: false,
+        }
+    }
+
+    /// Refill the buffer by reading the next INSERT statement.
+    /// A MySQL dump INSERT ends with `;` followed by newline. We read
+    /// line-by-line until we hit one ending in `);` (the canonical shape).
+    ///
+    /// Returns `true` if we loaded a new INSERT, `false` at EOF.
+    fn load_next_insert(&mut self) -> io::Result<bool> {
+        self.buf.clear();
+        self.pos = 0;
+        self.in_insert = false;
+
+        // Use raw bytes (not String) because MySQL dumps can contain
+        // non-UTF-8 bytes in VARBINARY fields (e.g. MediaWiki cl_sortkey).
+        let mut line: Vec<u8> = Vec::with_capacity(1 << 20);
+        loop {
+            line.clear();
+            let n = self.reader.read_until(b'\n', &mut line)?;
+            if n == 0 {
+                self.eof = true;
+                return Ok(self.in_insert && !self.buf.is_empty());
+            }
+
+            if !self.in_insert {
+                if line.starts_with(b"INSERT INTO") {
+                    self.in_insert = true;
+                    if let Some(idx) = find_subsequence(&line, b" VALUES ") {
+                        self.buf.extend_from_slice(
+                            &line[idx + b" VALUES ".len()..]
+                        );
+                    } else {
+                        self.buf.extend_from_slice(&line);
+                    }
+                }
+                // else: preamble line, ignore
+            } else {
+                self.buf.extend_from_slice(&line);
+            }
+
+            if self.in_insert && line_trimmed_ends_with(&line, b';') {
+                return Ok(true);
+            }
+        }
+    }
+
+    /// Parse a single `(v1, v2, ...)` tuple starting at `self.pos`.
+    /// Advances `self.pos` past the closing `)` and any trailing `,` or `;`.
+    /// Returns `Some(row)` on success, `None` if no more tuples in buffer.
+    fn parse_tuple(&mut self) -> Option<Vec<Field>> {
+        // Skip whitespace, commas, and trailing semicolon.
+        while self.pos < self.buf.len() {
+            match self.buf[self.pos] {
+                b' ' | b'\t' | b'\n' | b'\r' | b',' | b';' => self.pos += 1,
+                b'(' => break,
+                _ => {
+                    // Unknown filler — defensively advance.
+                    self.pos += 1;
+                }
+            }
+        }
+
+        if self.pos >= self.buf.len() {
+            return None;
+        }
+
+        if self.buf[self.pos] != b'(' {
+            return None;
+        }
+        self.pos += 1;  // consume '('
+
+        let mut row = Vec::with_capacity(8);
+        loop {
+            // Skip whitespace before a field.
+            while self.pos < self.buf.len()
+                && matches!(self.buf[self.pos], b' ' | b'\t')
+            {
+                self.pos += 1;
+            }
+
+            if self.pos >= self.buf.len() {
+                // Truncated tuple — shouldn't happen on well-formed input.
+                return None;
+            }
+
+            let field = self.parse_field()?;
+            row.push(field);
+
+            // Skip whitespace before separator.
+            while self.pos < self.buf.len()
+                && matches!(self.buf[self.pos], b' ' | b'\t')
+            {
+                self.pos += 1;
+            }
+
+            match self.buf.get(self.pos)? {
+                b',' => {
+                    self.pos += 1;
+                    continue;
+                }
+                b')' => {
+                    self.pos += 1;
+                    return Some(row);
+                }
+                _ => return None,
+            }
+        }
+    }
+
+    /// Parse one field at `self.pos`. Advances past it.
+    fn parse_field(&mut self) -> Option<Field> {
+        let c = *self.buf.get(self.pos)?;
+        match c {
+            b'\'' => self.parse_string(),
+            b'N' => self.parse_null(),
+            b'-' | b'0'..=b'9' => self.parse_int(),
+            _ => None,
+        }
+    }
+
+    /// Parse `NULL` literal (case-sensitive in MySQL dumps).
+    fn parse_null(&mut self) -> Option<Field> {
+        if self.buf.get(self.pos..self.pos + 4)? == b"NULL" {
+            self.pos += 4;
+            Some(Field::Null)
+        } else {
+            None
+        }
+    }
+
+    /// Parse an integer literal: optional `-`, then decimal digits.
+    fn parse_int(&mut self) -> Option<Field> {
+        let start = self.pos;
+        if self.buf.get(self.pos)? == &b'-' {
+            self.pos += 1;
+        }
+        let digit_start = self.pos;
+        while let Some(&c) = self.buf.get(self.pos) {
+            if c.is_ascii_digit() {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        if self.pos == digit_start {
+            return None;
+        }
+        let s = std::str::from_utf8(&self.buf[start..self.pos]).ok()?;
+        Some(Field::Int(s.parse().ok()?))
+    }
+
+    /// Parse a quoted string. Assumes `self.pos` points at the opening `'`.
+    /// Handles MySQL escape sequences: `\'`, `\\`, `\n`, `\r`, `\t`, `\0`,
+    /// `\"`, `\b`, `\Z`. Advances past the closing `'`.
+    ///
+    /// Returns `Field::Str(Vec<u8>)` — raw bytes, not UTF-8-validated.
+    fn parse_string(&mut self) -> Option<Field> {
+        self.pos += 1;  // consume opening '
+        let mut out = Vec::with_capacity(32);
+        loop {
+            let c = *self.buf.get(self.pos)?;
+            self.pos += 1;
+            match c {
+                b'\'' => {
+                    // Closing quote — or escaped '' sequence (ANSI SQL style).
+                    // MySQL dumps use \' normally, but defensively handle '' too.
+                    if self.buf.get(self.pos) == Some(&b'\'') {
+                        out.push(b'\'');
+                        self.pos += 1;
+                    } else {
+                        return Some(Field::Str(out));
+                    }
+                }
+                b'\\' => {
+                    let esc = *self.buf.get(self.pos)?;
+                    self.pos += 1;
+                    let decoded = match esc {
+                        b'\'' => b'\'',
+                        b'"' => b'"',
+                        b'\\' => b'\\',
+                        b'n' => b'\n',
+                        b'r' => b'\r',
+                        b't' => b'\t',
+                        b'0' => 0,
+                        b'b' => 0x08,
+                        b'Z' => 0x1A,
+                        // Unknown escape — keep the byte literally (MySQL
+                        // behavior for undefined escapes).
+                        other => other,
+                    };
+                    out.push(decoded);
+                }
+                _ => out.push(c),
+            }
+        }
+    }
+}
+
+/// Find the byte offset of `needle` within `haystack`, or `None`.
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// True if `line`, after trimming trailing whitespace/newline, ends
+/// with byte `c`.
+fn line_trimmed_ends_with(line: &[u8], c: u8) -> bool {
+    let end = line.iter().rposition(|&b| !matches!(b, b' ' | b'\t' | b'\n' | b'\r'));
+    match end {
+        Some(i) => line[i] == c,
+        None => false,
+    }
+}
+
+impl<R: BufRead> Iterator for MysqlInsertIter<R> {
+    type Item = Vec<Field>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(row) = self.parse_tuple() {
+                return Some(row);
+            }
+            // Current buffer exhausted — load the next INSERT.
+            if self.eof {
+                return None;
+            }
+            match self.load_next_insert() {
+                Ok(true) => continue,
+                Ok(false) => return None,
+                Err(_) => return None,
+            }
+        }
+    }
+}
+
+/// Open a file (optionally gzipped based on extension) and return an
+/// iterator over INSERT rows. Path ending in `.gz` is auto-decompressed.
+pub fn iter_mysql_rows(
+    path: &str,
+) -> io::Result<MysqlInsertIter<BufReader<Box<dyn Read + Send>>>> {
+    let file = File::open(path)?;
+    let reader: Box<dyn Read + Send> = if path.ends_with(".gz") {
+        Box::new(GzDecoder::new(file))
+    } else {
+        Box::new(file)
+    };
+    let buf = BufReader::with_capacity(1 << 20, reader);
+    Ok(MysqlInsertIter::new(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn parse(input: &str) -> Vec<Vec<Field>> {
+        let reader = BufReader::new(Cursor::new(input.as_bytes()));
+        MysqlInsertIter::new(reader).collect()
+    }
+
+    #[test]
+    fn simple_int_row() {
+        let input = "INSERT INTO `t` VALUES (1,2,3);\n";
+        assert_eq!(
+            parse(input),
+            vec![vec![Field::Int(1), Field::Int(2), Field::Int(3)]]
+        );
+    }
+
+    fn s(b: &[u8]) -> Field {
+        Field::Str(b.to_vec())
+    }
+
+    #[test]
+    fn simple_string_row() {
+        let input = "INSERT INTO `t` VALUES ('foo','bar');\n";
+        assert_eq!(
+            parse(input),
+            vec![vec![s(b"foo"), s(b"bar")]]
+        );
+    }
+
+    #[test]
+    fn mixed_types_with_null() {
+        let input = "INSERT INTO `t` VALUES (42,'hello',NULL,-7);\n";
+        assert_eq!(
+            parse(input),
+            vec![vec![
+                Field::Int(42),
+                s(b"hello"),
+                Field::Null,
+                Field::Int(-7)
+            ]]
+        );
+    }
+
+    #[test]
+    fn escaped_quote_in_string() {
+        let input = "INSERT INTO `t` VALUES ('it\\'s','a \\\"test\\\"');\n";
+        assert_eq!(
+            parse(input),
+            vec![vec![s(b"it's"), s(b"a \"test\"")]]
+        );
+    }
+
+    #[test]
+    fn backslash_and_null_byte() {
+        let input = "INSERT INTO `t` VALUES ('a\\\\b','c\\0d');\n";
+        assert_eq!(
+            parse(input),
+            vec![vec![s(b"a\\b"), s(b"c\0d")]]
+        );
+    }
+
+    #[test]
+    fn multi_row_batch() {
+        let input = "INSERT INTO `t` VALUES (1,'a'),(2,'b'),(3,'c');\n";
+        assert_eq!(
+            parse(input),
+            vec![
+                vec![Field::Int(1), s(b"a")],
+                vec![Field::Int(2), s(b"b")],
+                vec![Field::Int(3), s(b"c")],
+            ]
+        );
+    }
+
+    #[test]
+    fn binary_bytes_in_string() {
+        // MySQL VARBINARY columns (like MediaWiki cl_sortkey) can contain
+        // arbitrary bytes including invalid UTF-8. Must not cause parse failure.
+        let input = b"INSERT INTO `t` VALUES ('\xff\xfe\x00\x01bytes');\n";
+        let reader = BufReader::new(Cursor::new(input.as_ref()));
+        let rows: Vec<Vec<Field>> = MysqlInsertIter::new(reader).collect();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].len(), 1);
+        match &rows[0][0] {
+            Field::Str(b) => assert_eq!(b, b"\xff\xfe\x00\x01bytes"),
+            _ => panic!("expected Str"),
+        }
+    }
+
+    #[test]
+    fn preamble_skipped() {
+        let input = "\
+-- MySQL dump
+CREATE TABLE `t` (id INT);
+LOCK TABLES `t` WRITE;
+INSERT INTO `t` VALUES (1),(2);
+UNLOCK TABLES;
+";
+        assert_eq!(parse(input), vec![vec![Field::Int(1)], vec![Field::Int(2)]]);
+    }
+
+    #[test]
+    fn multiple_insert_statements() {
+        let input = "\
+INSERT INTO `t` VALUES (1,'a');
+INSERT INTO `t` VALUES (2,'b');
+";
+        assert_eq!(
+            parse(input),
+            vec![
+                vec![Field::Int(1), Field::Str("a".into())],
+                vec![Field::Int(2), Field::Str("b".into())],
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_string() {
+        let input = "INSERT INTO `t` VALUES ('');\n";
+        assert_eq!(parse(input), vec![vec![s(b"")]]);
+    }
+
+    #[test]
+    fn embedded_newline_in_string() {
+        let input = "INSERT INTO `t` VALUES ('a\\nb');\n";
+        assert_eq!(parse(input), vec![vec![s(b"a\nb")]]);
+    }
+}

--- a/src/unifyweaver/runtime/rust/mysql_stream/src/main.rs
+++ b/src/unifyweaver/runtime/rust/mysql_stream/src/main.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2025 John William Creighton (s243a)
+//
+// mysql_stream CLI — reads a MySQL dump (optionally gzipped) and writes
+// every INSERT row as TAB-separated TSV on stdout.
+//
+// Usage: mysql_stream <path-to-dump.sql[.gz]>
+
+use std::io::{self, BufWriter, Write};
+use std::process::ExitCode;
+
+use mysql_stream::{iter_mysql_rows, Field};
+
+fn tsv_escape_bytes(bytes: &[u8], out: &mut Vec<u8>) {
+    // TSV convention:
+    //   \\ \t \n \r as two-byte escapes
+    //   non-printable ASCII and non-UTF-8 bytes as \xNN (hex)
+    //   valid UTF-8 passes through verbatim
+    for &b in bytes {
+        match b {
+            b'\\' => out.extend_from_slice(b"\\\\"),
+            b'\t' => out.extend_from_slice(b"\\t"),
+            b'\n' => out.extend_from_slice(b"\\n"),
+            b'\r' => out.extend_from_slice(b"\\r"),
+            0x20..=0x7E => out.push(b),  // printable ASCII
+            _ => {
+                // Non-ASCII or non-printable — emit \xNN.
+                // Note: this over-escapes valid multi-byte UTF-8. The
+                // alternative (validate UTF-8 chunks, pass through valid
+                // ones) is possible but trades speed for readability.
+                // For benchmark consumers that only read ASCII-safe
+                // columns (cl_type, integer IDs), this is fine.
+                static HEX: &[u8; 16] = b"0123456789abcdef";
+                out.extend_from_slice(b"\\x");
+                out.push(HEX[(b >> 4) as usize]);
+                out.push(HEX[(b & 0xf) as usize]);
+            }
+        }
+    }
+}
+
+fn write_field<W: Write>(out: &mut W, f: &Field) -> io::Result<()> {
+    match f {
+        Field::Int(n) => write!(out, "{}", n),
+        Field::Str(bytes) => {
+            let mut buf = Vec::with_capacity(bytes.len());
+            tsv_escape_bytes(bytes, &mut buf);
+            out.write_all(&buf)
+        }
+        Field::Null => out.write_all(b"\\N"),
+    }
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 2 {
+        eprintln!("usage: mysql_stream <path-to-dump.sql[.gz]>");
+        return ExitCode::from(2);
+    }
+    let path = &args[1];
+
+    let iter = match iter_mysql_rows(path) {
+        Ok(it) => it,
+        Err(e) => {
+            eprintln!("mysql_stream: cannot open {}: {}", path, e);
+            return ExitCode::from(1);
+        }
+    };
+
+    let stdout = io::stdout();
+    let mut out = BufWriter::with_capacity(1 << 16, stdout.lock());
+
+    let handle_err = |e: &io::Error| -> Option<ExitCode> {
+        if matches!(e.kind(), io::ErrorKind::BrokenPipe) {
+            return Some(ExitCode::SUCCESS);
+        }
+        eprintln!("mysql_stream: write error: {}", e);
+        Some(ExitCode::from(1))
+    };
+
+    for row in iter {
+        for (i, field) in row.iter().enumerate() {
+            if i > 0 {
+                if let Err(e) = out.write_all(b"\t") {
+                    if let Some(code) = handle_err(&e) { return code; }
+                }
+            }
+            if let Err(e) = write_field(&mut out, field) {
+                if let Some(code) = handle_err(&e) { return code; }
+            }
+        }
+        if let Err(e) = out.write_all(b"\n") {
+            if let Some(code) = handle_err(&e) { return code; }
+        }
+    }
+
+    ExitCode::SUCCESS
+}


### PR DESCRIPTION
  ## Summary

  First implementation milestone for Phase S1 of the streaming data pipelines design
  (`docs/design/cross-target-glue/streaming-pipelines/`). Ships a binary-safe MySQL INSERT tokenizer as a Rust leaf
  primitive — the first step in the enwiki preprocessing pipeline that will unblock million-edge scaling benchmarks for
  the WAM Haskell target.

  ## What's in this PR

  A new Rust crate at `src/unifyweaver/runtime/rust/mysql_stream/`:

  - **`src/lib.rs`** — `MysqlInsertIter` state machine + `Field` enum (`Int`/`Str`/`Null`). Handles gzipped or raw
  input, all standard MySQL escape sequences (`\'` `\"` `\\` `\n` `\r` `\t` `\0` `\b` `\Z`), multi-row batches,
  multi-statement files, and preamble skipping.
  - **`src/main.rs`** — CLI wrapper that reads a dump path and writes every row as TAB-separated TSV to stdout. Safe TSV
   escaping (`\\` `\t` `\n` `\r` as two-byte sequences, non-printable bytes as `\xNN`, `NULL` as `\N`).
  - **11 unit tests** — tokenizer fixtures covering ints, strings, nulls, escape sequences, multi-row batches,
  multi-INSERT statements, preamble handling, and a binary-bytes regression test.
  - **`README.md`** with library + binary usage and the validation table.

  ## Design adherence

  Follows the leaf-primitive rule from `01-philosophy.md`:

  - **Primitive is general and minimal.** Emits `Vec<Field>` per INSERT row. No filtering on column values, no column
  projection, no schema knowledge. Consumers (Prolog / Python) filter and extract at their layer. The same binary works
  for any MySQL dump — categorylinks, revision, user, anything — because it's purely a tokenizer.
  - **Binary-safe**: `Field::Str` holds `Vec<u8>`, not `String`. MediaWiki `VARBINARY` columns (e.g. `cl_sortkey`)
  contain arbitrary bytes that aren't UTF-8; forcing `String` would cause silent parse failures. This was the root cause
   of the first validation run returning zero rows.

  ## Validation

  End-to-end tested against `simplewiki-latest-categorylinks.sql.gz` (27 MB gzipped, ~230 MB raw). Row counts match the
  SQLite ground truth **exactly**:

  | cl_type | mysql_stream | SQLite ground truth |
  |---------|-------------:|--------------------:|
  | (total) |    2,206,045 |           2,206,045 |
  | subcat  |      297,283 |             297,283 |
  | page    |    1,908,512 |           1,908,512 |
  | file    |          250 |                 250 |

  ## Performance

  Head-to-head on the same categorylinks dump:

  | Parser | Time | Relative |
  |--------|------|---------:|
  | **Rust mysql_stream** (parse + TSV write) | **8.12 s** | **1.0×** |
  | Python regex-based (parse only, no output) | 50.23 s | 6.2× slower |

  Rust is ~6.2× faster despite doing more work (writing TSV output to stdout). Against the full
  `parse_simplewiki_dump.py` (which also writes to SQLite), the gap would be larger — SQLite inserts add substantial
  overhead on top of the parse. For the original 18-minute WAM project generation that the `external_source` fix
  shortened to 4.5s, this parser-layer speedup stacks on top for the enwiki pipeline.

  Throughput: ~28 MB/s of gzipped input on a single core. Disk-IO bound rather than CPU-bound — consistent with the
  Phase 1 text-pipe expectations from the design.

  ## Schema note (for reviewers familiar with MediaWiki)

  Recent simplewiki dumps have **dropped `cl_to`** — target category names now live in a separate `linktarget` table,
  referenced by `cl_target_id`. Consumers that need target names must also parse `linktarget.sql.gz` and join on the
  target ID at the Prolog layer. This is consistent with the leaf-primitive rule: schema knowledge and joins are Prolog
  concerns, not parser concerns.

  ## Scope: what's NOT in this PR

  Per the phased plan in `03-implementation-plan.md`:

  - **Not yet**: glue integration. No changes to `native_glue.pl` or Prolog `declare_target` wiring yet. The crate is a
  standalone library + binary; the next PR will wire `declare_target(parse_mysql_rows/2, rust, [leaf(true),
  native_crate(mysql_stream)])` into the existing native-glue scaffolding.
  - **Not yet**: Haskell or AWK implementations. Track B (multi-target demo) is parked — Rust was the long-term pick per
   the two-track framing in the design docs, so single-target Track A (benchmark-driver) is moving first.
  - **Not yet**: LMDB ingest side. Python consumer + `ingest_to_lmdb/3` predicate belong to the next PR.

  ## Test plan

  - [x] `cargo test --release` — 11/11 unit tests passing
  - [x] Integration: binary produces row counts matching SQLite ground truth on simplewiki
  - [x] Binary correctness verified on VARBINARY columns with invalid UTF-8 bytes
  - [ ] Follow-up PR: glue integration + Python consumer + end-to-end enwiki pipeline