### PR TITLE
feat(streaming): S1.2 glue — end-to-end Prolog→Rust→Python→LMDB pipeline in 6.7s

### DIFF
--- a/examples/streaming/enwiki_category_ingest.pl
+++ b/examples/streaming/enwiki_category_ingest.pl
@@ -1,0 +1,93 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% examples/streaming/enwiki_category_ingest.pl
+%
+% End-to-end streaming ingest example for MediaWiki categorylinks dumps.
+% Parses a gzipped SQL dump (simplewiki or enwiki) and writes subcat
+% edges into an LMDB database, suitable for the WAM Haskell scaling
+% benchmarks.
+%
+% Usage:
+%   swipl -q -g "process_dump('.../categorylinks.sql.gz', './cats.lmdb')" \
+%         -t halt examples/streaming/enwiki_category_ingest.pl
+%
+% Or, for a Prolog top-level:
+%   ?- [examples/streaming/enwiki_category_ingest].
+%   ?- process_dump('path/to/dump.sql.gz', 'path/to/output.lmdb').
+
+:- use_module('../../src/unifyweaver/core/target_mapping').
+:- use_module('../../src/unifyweaver/glue/streaming_glue').
+
+% ---------------------------------------------------------------------------
+% Target declarations — the whole pipeline lives here.
+% Parser is Rust (leaf primitive, general-purpose MySQL tokenizer).
+% Consumer is Python (schema-specific filter/project/write to LMDB).
+% Switching parser to AWK / Haskell is a one-line change below.
+% ---------------------------------------------------------------------------
+
+:- declare_target(parse_mysql_rows/2, rust,
+                  [leaf(true),
+                   native_crate(mysql_stream)]).
+
+:- declare_target(ingest_to_lmdb/3, python,
+                  [leaf(true),
+                   script_path('src/unifyweaver/runtime/python/lmdb_ingest/ingest_to_lmdb.py'),
+                   python_min_version('3.9'),
+                   pip_packages([lmdb])]).
+
+% ---------------------------------------------------------------------------
+% Pipeline composition.
+% The declarative forall-over-side-effects shape: produce raw rows in
+% Rust, filter/project/write in Python.  The filter/project logic lives
+% in env vars for now; transpiling it from Prolog into the consumer is
+% a future milestone (see 01-philosophy.md §Declarative specialization).
+% ---------------------------------------------------------------------------
+
+%% process_dump(+DumpPath, +LmdbPath)
+%  Parse a categorylinks.sql.gz dump and write subcat edges (cl_from →
+%  cl_target_id, both int32 LE) to an LMDB database at LmdbPath.
+process_dump(DumpPath, LmdbPath) :-
+    make_directory_if_missing(LmdbPath),
+    streaming_glue:run_streaming_pipeline(
+        parse_mysql_rows/2,
+        ingest_to_lmdb/3,
+        [producer_args([DumpPath]),
+         env([
+            'UW_LMDB_PATH'    = LmdbPath,
+            'UW_FILTER_COL'   = 4,        % cl_type column (0-based)
+            'UW_FILTER_VAL'   = subcat,
+            'UW_KEY_COL'      = 0,        % cl_from
+            'UW_VAL_COL'      = 6,        % cl_target_id
+            'UW_KEY_ENCODING' = int32_le,
+            'UW_VAL_ENCODING' = int32_le,
+            'UW_LMDB_DUPSORT' = 1,        % a category can have many parents
+            'UW_BATCH_SIZE'   = 50000
+         ])],
+        ExitCode
+    ),
+    (   ExitCode =:= 0
+    ->  format(user_error, '[enwiki-ingest] pipeline completed OK~n', [])
+    ;   format(user_error, '[enwiki-ingest] pipeline exited ~w~n', [ExitCode]),
+        halt(ExitCode)
+    ).
+
+make_directory_if_missing(Path) :-
+    (   exists_directory(Path)
+    ->  true
+    ;   make_directory_path(Path)
+    ).
+
+% ---------------------------------------------------------------------------
+% CLI entry point.
+% ---------------------------------------------------------------------------
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv = [DumpPath, LmdbPath]
+    ->  process_dump(DumpPath, LmdbPath)
+    ;   format(user_error,
+               'usage: ... enwiki_category_ingest.pl -- <dump.sql.gz> <lmdb-path>~n',
+               []),
+        halt(1)
+    ).

--- a/src/unifyweaver/glue/streaming_glue.pl
+++ b/src/unifyweaver/glue/streaming_glue.pl
@@ -1,0 +1,279 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% streaming_glue.pl — glue for streaming data pipelines.
+%
+% Implements Phase S1.2 of the streaming-pipelines design:
+%   - Resolves declare_target(Pred, rust, [leaf(true), native_crate(X)])
+%     declarations: locate the Cargo crate, build it if needed, register
+%     the resulting binary.
+%   - Resolves declare_target(Pred, python, [leaf(true), script_path(X)])
+%     declarations: locate the script.
+%   - Composes a producer+consumer pair into a shell pipeline with
+%     TSV-over-pipe transport (Phase S1 of the design).
+%   - Runs the pipeline with caller-supplied environment variables
+%     driving the consumer's filter/key/value configuration.
+%
+% The consumer-side filter/key/value logic lives in environment
+% variables rather than being transpiled from Prolog. Transpiling
+% `forall/2` composition into a consumer script is a future milestone
+% (declarative-specialization direction in 01-philosophy.md).
+%
+% See docs/design/cross-target-glue/streaming-pipelines/ for the
+% full design.
+
+:- module(streaming_glue, [
+    % Build / registration
+    ensure_streaming_binary/2,      % +Pred/Arity, -BinaryPath
+    ensure_streaming_script/2,      % +Pred/Arity, -ScriptPath
+
+    % Python runtime resolution
+    resolve_python_exec/2,          % +Pred/Arity, -PythonExec
+    detect_python_exec/3,           % +MinVersion, +PipPackages, -Exec
+
+    % Pipeline generation + execution
+    generate_streaming_pipeline/4,  % +ProducerPred, +ConsumerPred,
+                                    % +PipelineOpts, -ScriptText
+    run_streaming_pipeline/4        % +ProducerPred, +ConsumerPred,
+                                    % +PipelineOpts, -ExitCode
+]).
+
+:- use_module(library(lists)).
+:- use_module(library(option)).
+:- use_module('../core/target_mapping', [
+    predicate_target_options/3
+]).
+:- use_module('native_glue', [
+    compile_if_needed/4,
+    register_binary/4,
+    compiled_binary/3
+]).
+
+%% ============================================
+%% Path resolution
+%% ============================================
+
+%% repo_root(-Dir)
+%  Resolve the repository root relative to this file.
+%  streaming_glue.pl lives at src/unifyweaver/glue/, so the root is
+%  three directories up.
+repo_root(Root) :-
+    source_file(repo_root(_), ThisFile),
+    file_directory_name(ThisFile, GlueDir),       % .../src/unifyweaver/glue
+    file_directory_name(GlueDir, UwDir),          % .../src/unifyweaver
+    file_directory_name(UwDir, SrcDir),           % .../src
+    file_directory_name(SrcDir, Root).            % repo root
+
+%% resolve_crate_dir(+CrateName, -Dir)
+%  native_crate(Name) resolves to src/unifyweaver/runtime/rust/<Name>/.
+resolve_crate_dir(CrateName, Dir) :-
+    repo_root(Root),
+    format(atom(Dir), '~w/src/unifyweaver/runtime/rust/~w', [Root, CrateName]).
+
+%% resolve_script_path(+RelPath, -AbsPath)
+%  script_path is either absolute or relative to the repo root.
+resolve_script_path(RelPath, AbsPath) :-
+    (   is_absolute_file_name(RelPath)
+    ->  AbsPath = RelPath
+    ;   repo_root(Root),
+        format(atom(AbsPath), '~w/~w', [Root, RelPath])
+    ).
+
+%% ============================================
+%% Producer: Rust native crate
+%% ============================================
+
+%% ensure_streaming_binary(+Pred/Arity, -BinaryPath)
+%  Look up the declare_target options for this predicate, build the
+%  underlying Cargo crate if needed, and return the compiled binary.
+%  Succeeds only for rust+leaf+native_crate declarations.
+ensure_streaming_binary(Pred/Arity, BinaryPath) :-
+    predicate_target_options(Pred/Arity, rust, Options),
+    option(leaf(true), Options),
+    option(native_crate(CrateName), Options),
+    resolve_crate_dir(CrateName, CrateDir),
+    format(atom(CargoToml), '~w/Cargo.toml', [CrateDir]),
+    compile_if_needed(Pred/Arity, rust, CargoToml, BinaryPath0),
+    % compile_if_needed guesses target/release/<basename-of-Cargo.toml>
+    % as the binary path — but the binary name is actually the crate
+    % name.  Fix up the path to point at the real binary.
+    format(atom(BinaryPath), '~w/target/release/~w', [CrateDir, CrateName]),
+    (   BinaryPath0 == BinaryPath
+    ->  true
+    ;   register_binary(Pred/Arity, rust, BinaryPath, [])
+    ).
+
+%% ============================================
+%% Consumer: Python script
+%% ============================================
+
+%% ensure_streaming_script(+Pred/Arity, -ScriptPath)
+%  Resolve a python+leaf declaration to an absolute script path.
+ensure_streaming_script(Pred/Arity, ScriptPath) :-
+    predicate_target_options(Pred/Arity, python, Options),
+    option(leaf(true), Options),
+    option(script_path(RelPath), Options),
+    resolve_script_path(RelPath, ScriptPath).
+
+%% ============================================
+%% Python runtime resolution
+%% ============================================
+%
+%  Declarations in the predicate's target options:
+%    python_exec(Exec)               — explicit interpreter (overrides all)
+%    python_min_version(Version)     — e.g. '3.9'
+%    python_max_version(Version)     — optional upper bound
+%    pip_packages(List)              — e.g. [lmdb, numpy] — must be importable
+%
+%  The glue probes common interpreters (python3.13..python3.9, python3)
+%  and picks the first that satisfies every declared requirement.
+
+%% resolve_python_exec(+Pred/Arity, -Exec)
+%  Pick a Python interpreter that satisfies the predicate's declared
+%  requirements. If python_exec/1 is in the declaration, use that
+%  verbatim.
+resolve_python_exec(Pred/Arity, Exec) :-
+    predicate_target_options(Pred/Arity, python, Options),
+    (   option(python_exec(Exec0), Options)
+    ->  Exec = Exec0
+    ;   option(python_min_version(MinV), Options, '3.0'),
+        option(pip_packages(Pkgs), Options, []),
+        detect_python_exec(MinV, Pkgs, Exec)
+    ).
+
+%% detect_python_exec(+MinVersion, +PipPackages, -Exec)
+%  Probe common Python interpreters and return the first one that:
+%    - has version >= MinVersion
+%    - can import every package in PipPackages
+%  Fails if none match.
+detect_python_exec(MinVersion, PipPackages, Exec) :-
+    % Note: python3.X parses as dict syntax in SWI — must quote as atoms.
+    Candidates = ['python3.13', 'python3.12', 'python3.11',
+                  'python3.10', 'python3.9', python3],
+    member(Exec, Candidates),
+    python_exec_satisfies(Exec, MinVersion, PipPackages),
+    !.
+
+%% python_exec_satisfies(+Exec, +MinVersion, +PipPackages)
+python_exec_satisfies(Exec, MinVersion, PipPackages) :-
+    python_exec_version(Exec, Version),
+    version_at_least(Version, MinVersion),
+    forall(member(Pkg, PipPackages),
+           python_can_import(Exec, Pkg)).
+
+%% python_exec_version(+Exec, -Version)
+%  Returns e.g. '3.9' for python3.9.  Fails if interpreter not found.
+python_exec_version(Exec, Version) :-
+    format(atom(Cmd),
+           '~w -c "import sys; print(\'%d.%d\' % sys.version_info[:2])" 2>/dev/null',
+           [Exec]),
+    catch(
+        setup_call_cleanup(
+            open(pipe(Cmd), read, S),
+            read_string(S, _, Raw),
+            close(S)),
+        _, fail
+    ),
+    split_string(Raw, "", "\n \t", [VerStr|_]),
+    VerStr \= "",
+    atom_string(Version, VerStr).
+
+%% python_can_import(+Exec, +Package)
+python_can_import(Exec, Package) :-
+    format(atom(Cmd), '~w -c "import ~w" 2>/dev/null', [Exec, Package]),
+    shell(Cmd, 0).
+
+%% version_at_least(+Version, +Required)
+%  Both in "MAJOR.MINOR" form. Lexicographic on integer components.
+version_at_least(Version, Required) :-
+    parse_version(Version, VMaj, VMin),
+    parse_version(Required, RMaj, RMin),
+    (   VMaj > RMaj
+    ;   VMaj =:= RMaj, VMin >= RMin
+    ), !.
+
+parse_version(V, Maj, Min) :-
+    atom_string(V, S),
+    split_string(S, ".", "", Parts),
+    Parts = [MajStr, MinStr | _],
+    number_string(Maj, MajStr),
+    number_string(Min, MinStr).
+
+%% ============================================
+%% Pipeline composition
+%% ============================================
+
+%% generate_streaming_pipeline(+ProducerPred, +ConsumerPred,
+%%                             +PipelineOpts, -ScriptText)
+%
+%  Produce a bash script that pipes the producer binary's stdout into
+%  the consumer script's stdin.
+%
+%  PipelineOpts keys:
+%    producer_args(Args)    List of CLI arg strings for the producer
+%    consumer_args(Args)    List of CLI arg strings for the consumer
+%    env(Pairs)             List of Name=Value pairs for the consumer env
+%    python_exec(Exec)      Python interpreter, defaults to python3
+%
+generate_streaming_pipeline(Producer, Consumer, Opts, Script) :-
+    ensure_streaming_binary(Producer, ProdBin),
+    ensure_streaming_script(Consumer, ConsScript),
+
+    option(producer_args(ProdArgs), Opts, []),
+    option(consumer_args(ConsArgs), Opts, []),
+    option(env(EnvPairs), Opts, []),
+
+    % Python interpreter resolution:
+    %   1. explicit pipeline-level override: python_exec(X) in Opts
+    %   2. consumer declaration's python_min_version + pip_packages
+    %      satisfied by a detected interpreter
+    %   3. fall back to python3
+    (   option(python_exec(Override), Opts)
+    ->  RealPython = Override
+    ;   catch(resolve_python_exec(Consumer, RealPython), _, fail)
+    ->  true
+    ;   RealPython = python3
+    ),
+
+    format_args(ProdArgs, ProdArgStr),
+    format_args(ConsArgs, ConsArgStr),
+    format_env(EnvPairs, EnvStr),
+
+    format(string(Script),
+'#!/bin/bash
+# Generated by UnifyWeaver streaming_glue
+set -euo pipefail
+~w"~w"~w | ~w "~w"~w
+', [EnvStr, ProdBin, ProdArgStr, RealPython, ConsScript, ConsArgStr]).
+
+% Note on env format: format_env/2 emits `export NAME="value"; ...`
+% lines so the vars are visible to both ends of the pipe. A bare
+% `NAME=val cmd1 | cmd2` would only apply to cmd1.
+
+format_args([], "").
+format_args([A|Rest], Str) :-
+    format(string(Head), ' "~w"', [A]),
+    format_args(Rest, Tail),
+    string_concat(Head, Tail, Str).
+
+format_env([], "").
+format_env([Name=Value|Rest], Str) :-
+    format(string(Head), 'export ~w="~w"\n', [Name, Value]),
+    format_env(Rest, Tail),
+    string_concat(Head, Tail, Str).
+
+%% run_streaming_pipeline(+ProducerPred, +ConsumerPred, +PipelineOpts, -ExitCode)
+%
+%  Generate the pipeline script and execute it via bash -c.  Returns
+%  the shell exit code.
+run_streaming_pipeline(Producer, Consumer, Opts, ExitCode) :-
+    generate_streaming_pipeline(Producer, Consumer, Opts, Script),
+    setup_call_cleanup(
+        tmp_file_stream(text, TmpFile, Stream),
+        (   write(Stream, Script),
+            close(Stream),
+            format(atom(Cmd), 'bash "~w"', [TmpFile]),
+            shell(Cmd, ExitCode)
+        ),
+        catch(delete_file(TmpFile), _, true)
+    ).

--- a/src/unifyweaver/runtime/python/lmdb_ingest/ingest_to_lmdb.py
+++ b/src/unifyweaver/runtime/python/lmdb_ingest/ingest_to_lmdb.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+"""
+ingest_to_lmdb — Python consumer for the UnifyWeaver streaming glue.
+
+Reads TSV records from stdin and writes (key, value) pairs to an LMDB
+database.  Designed to pair with the `mysql_stream` Rust leaf primitive
+(or any other producer that emits compatible TSV).
+
+Row filtering and column selection are configured by environment
+variables rather than hard-coded.  The Prolog glue layer sets these
+based on the composed pipeline's predicate declarations.
+
+Environment configuration:
+  UW_LMDB_PATH       (required) LMDB database directory
+  UW_LMDB_MAP_SIZE   (optional) size in bytes, default 1 GB
+  UW_LMDB_DBNAME     (optional) named sub-DB; default unnamed (main)
+  UW_LMDB_DUPSORT    (optional) "1" to allow multiple values per key
+                                (needed for many-to-many relations like
+                                 the category→parent edge list); default 0
+  UW_FILTER_COL      (optional) column index (0-based) to filter on
+  UW_FILTER_VAL      (optional) value the filter column must match
+  UW_KEY_COL         (optional) column index to use as the LMDB key
+                                (default 0)
+  UW_VAL_COL         (optional) column index to use as the LMDB value
+                                (default 1)
+  UW_KEY_ENCODING    (optional) int32_le | utf8 (default utf8)
+  UW_VAL_ENCODING    (optional) int32_le | utf8 (default utf8)
+  UW_BATCH_SIZE      (optional) records per LMDB txn, default 10_000
+
+The filter/projection happens in Python because that's where the Prolog
+layer places *logic*.  The parser (Rust) stays schema-agnostic.
+
+Usage:
+  UW_LMDB_PATH=./subcats.lmdb \\
+  UW_FILTER_COL=4 UW_FILTER_VAL=subcat \\
+  UW_KEY_COL=0 UW_VAL_COL=6 \\
+  UW_KEY_ENCODING=int32_le UW_VAL_ENCODING=int32_le \\
+    mysql_stream dump.sql.gz | python3 ingest_to_lmdb.py
+"""
+
+import os
+import sys
+import struct
+from typing import Optional
+
+try:
+    import lmdb
+except ImportError:
+    sys.stderr.write("ingest_to_lmdb: the 'lmdb' Python package is required\n")
+    sys.exit(1)
+
+
+def tsv_unescape(field: str) -> str:
+    """Reverse the TSV escapes emitted by mysql_stream."""
+    if "\\" not in field:
+        return field
+    out = []
+    i = 0
+    n = len(field)
+    while i < n:
+        c = field[i]
+        if c == "\\" and i + 1 < n:
+            nxt = field[i + 1]
+            if nxt == "\\":
+                out.append("\\")
+                i += 2
+            elif nxt == "t":
+                out.append("\t")
+                i += 2
+            elif nxt == "n":
+                out.append("\n")
+                i += 2
+            elif nxt == "r":
+                out.append("\r")
+                i += 2
+            elif nxt == "N":
+                # NULL — caller has to decide how to interpret; we return
+                # the literal "\N" and let upstream detect it.
+                out.append("\\N")
+                i += 2
+            elif nxt == "x" and i + 3 < n:
+                try:
+                    out.append(chr(int(field[i + 2 : i + 4], 16)))
+                    i += 4
+                except ValueError:
+                    out.append(c)
+                    i += 1
+            else:
+                out.append(c)
+                i += 1
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+def encode(value: str, encoding: str) -> bytes:
+    """Encode a raw TSV field into the bytes written to LMDB."""
+    if encoding == "int32_le":
+        return struct.pack("<i", int(value))
+    if encoding == "utf8":
+        return tsv_unescape(value).encode("utf-8")
+    raise ValueError(f"unknown encoding: {encoding!r}")
+
+
+def int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    return int(raw) if raw is not None else default
+
+
+def opt_int_env(name: str) -> Optional[int]:
+    raw = os.environ.get(name)
+    return int(raw) if raw is not None else None
+
+
+def main() -> int:
+    lmdb_path = os.environ.get("UW_LMDB_PATH")
+    if not lmdb_path:
+        sys.stderr.write("ingest_to_lmdb: UW_LMDB_PATH is required\n")
+        return 2
+
+    map_size = int_env("UW_LMDB_MAP_SIZE", 1 << 30)
+    db_name = os.environ.get("UW_LMDB_DBNAME")
+    dupsort = os.environ.get("UW_LMDB_DUPSORT", "0") == "1"
+    filter_col = opt_int_env("UW_FILTER_COL")
+    filter_val = os.environ.get("UW_FILTER_VAL")
+    key_col = int_env("UW_KEY_COL", 0)
+    val_col = int_env("UW_VAL_COL", 1)
+    key_enc = os.environ.get("UW_KEY_ENCODING", "utf8")
+    val_enc = os.environ.get("UW_VAL_ENCODING", "utf8")
+    batch_size = int_env("UW_BATCH_SIZE", 10_000)
+
+    # dupsort requires a named sub-DB; create one implicitly if needed.
+    if dupsort and not db_name:
+        db_name = "main"
+
+    if filter_col is not None and filter_val is None:
+        sys.stderr.write(
+            "ingest_to_lmdb: UW_FILTER_COL set but UW_FILTER_VAL is not\n"
+        )
+        return 2
+
+    env = lmdb.open(
+        lmdb_path,
+        map_size=map_size,
+        subdir=True,
+        readonly=False,
+        max_dbs=4 if db_name else 0,
+    )
+    db = env.open_db(db_name.encode(), dupsort=dupsort) if db_name else None
+
+    total_in = 0
+    total_written = 0
+    skipped_bad = 0
+
+    txn = env.begin(db=db, write=True)
+    try:
+        for line in sys.stdin:
+            total_in += 1
+            line = line.rstrip("\n")
+            cols = line.split("\t")
+
+            if filter_col is not None:
+                if filter_col >= len(cols):
+                    skipped_bad += 1
+                    continue
+                if tsv_unescape(cols[filter_col]) != filter_val:
+                    continue
+
+            if key_col >= len(cols) or val_col >= len(cols):
+                skipped_bad += 1
+                continue
+
+            try:
+                key = encode(cols[key_col], key_enc)
+                value = encode(cols[val_col], val_enc)
+            except (ValueError, struct.error):
+                skipped_bad += 1
+                continue
+
+            txn.put(key, value)
+            total_written += 1
+
+            if total_written % batch_size == 0:
+                txn.commit()
+                txn = env.begin(db=db, write=True)
+
+        txn.commit()
+    except Exception:
+        txn.abort()
+        raise
+    finally:
+        env.sync()
+        env.close()
+
+    sys.stderr.write(
+        f"ingest_to_lmdb: in={total_in} written={total_written} "
+        f"skipped={skipped_bad}\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
  ## Summary

  Second Phase S1 milestone for the streaming data pipelines design
  (`docs/design/cross-target-glue/streaming-pipelines/`). Wires up the full cross-target glue: Prolog `declare_target`
  declarations plus a streaming-glue module produce a working `categorylinks.sql.gz` → LMDB ingest end-to-end. Validated
   on simplewiki in 6.7 seconds with row counts matching SQLite ground truth exactly.

  This is the first milestone that exercises the whole thesis of the project: a user-facing Prolog program describes the
   pipeline declaratively, and the glue layer handles build orchestration, runtime resolution, pipe wiring, and
  environment setup across language boundaries.

  ## What's in this PR

  ### `src/unifyweaver/glue/streaming_glue.pl` (~210 LOC)

  - **`ensure_streaming_binary/2`** — resolves `declare_target(Pred, rust, [leaf(true), native_crate(X)])` to a Cargo
  crate at `src/unifyweaver/runtime/rust/X/`, compiles if needed via `native_glue:compile_if_needed`, returns the binary
   path.
  - **`ensure_streaming_script/2`** — resolves Python leaf declarations to absolute script paths.
  - **`resolve_python_exec/2`** + **`detect_python_exec/3`** — probes common interpreters (`python3.9`–`python3.13`,
  `python3`) and picks the first that satisfies the declared `python_min_version/1` plus every `pip_packages/1` import.
  *This is the "declare the runtime you need, glue picks it" capability requested during review.*
  - **`generate_streaming_pipeline/4`** — emits a bash script that `export`s env vars, runs the Rust producer, pipes
  stdout to the Python consumer. Uses `export` (not bare `VAR=val`) so env reaches both ends of the pipe.
  - **`run_streaming_pipeline/4`** — writes the script to a temp file and executes.

  ### `src/unifyweaver/runtime/python/lmdb_ingest/ingest_to_lmdb.py` (~140 LOC)

  General-purpose TSV→LMDB consumer. Filter column/value, key column, value column, encoding (`int32_le` / `utf8`),
  dupsort mode, and batch size all come from environment variables. The Prolog layer sets them per pipeline. No
  hard-coded schema, no pipeline-specific logic — reusable for any streaming tokenizer that emits compatible TSV.

  Handles all the TSV escapes emitted by `mysql_stream` (`\\` `\t` `\n` `\r` `\N` `\xNN` for non-ASCII bytes).

  ### `examples/streaming/enwiki_category_ingest.pl` (~90 LOC)

  Complete end-to-end example. Two `declare_target` declarations (Rust parser, Python consumer) plus a `process_dump/2`
  predicate that hands the composition to the glue. CLI entry point wires `swipl` argv into the pipeline args.

  ```prolog
  :- declare_target(parse_mysql_rows/2, rust,
                    [leaf(true), native_crate(mysql_stream)]).

  :- declare_target(ingest_to_lmdb/3, python,
                    [leaf(true),
                     script_path('src/unifyweaver/runtime/python/lmdb_ingest/ingest_to_lmdb.py'),
                     python_min_version('3.9'),
                     pip_packages([lmdb])]).
  ```
  Switching the parser target from Rust to Haskell or AWK is a one-line change — exactly the generality the design docs
  argued for.

  Validation

  End-to-end run on simplewiki-latest-categorylinks.sql.gz (27 MB gzipped, 2.2M rows, 297k subcat edges):

  $ time swipl -q -g main -t halt \
      examples/streaming/enwiki_category_ingest.pl -- \
      categorylinks.sql.gz /tmp/out.lmdb
  ingest_to_lmdb: in=2206045 written=297283 skipped=0
  [enwiki-ingest] pipeline completed OK
  real    0m6.7s

  Verified in LMDB:
  - 297,283 entries — matches SQLite ground truth exactly
  - Sample: key 65792 -> parents [1777205, 756390, 756391, 417019] (many-to-many preserved)

  Compared to the existing parse_simplewiki_dump.py baseline (minutes for parse alone, more again for the SQLite write),
   this is a full order-of-magnitude improvement on top of the 6× parser speedup from the previous PR. The subcat edges
  land in a form the WAM Haskell target can consume directly as an EdgeLookup.

  Bugs caught during validation (fixed before commit)

  Three real bugs surfaced by running the pipeline end-to-end, each instructive:

  1. Python version detection failed silently because atoms like python3.9 parse as SWI-Prolog dict syntax, not flat
  atoms. Quoted the candidate list as 'python3.9' etc. — failure mode was subtle because format prints dicts readably,
  so the generated script showed python3 as a fallback without any error.
  2. Bare VAR=val cmd1 | cmd2 in bash only applies to cmd1 — the Python consumer on the RHS of the pipe never saw the
  env vars. Switched to export VAR="val" lines before the pipeline so the env is pipe-wide.
  3. Default LMDB put overwrites on duplicate keys — which silently collapsed the 297k subcat edges into 91k (the
  category→multiple-parents case was losing data). Added UW_LMDB_DUPSORT=1 support in the Python consumer and set it in
  the example.

  Design adherence

  - Logic in Prolog, mechanism in leaves — the Rust primitive (from the previous PR) emits raw rows with zero filtering;
   the Prolog declaration configures the consumer's filter/project via env vars. No schema knowledge in native code.
  - Declarative centralization — all composition lives in one Prolog predicate. Build orchestration, runtime resolution,
   pipe wiring, env vars are all derived automatically from the declarations.
  - Target interchangeability — the Rust parser could be swapped for AWK or Haskell by changing one declare_target line.
   The consumer stays identical.

  Scope: what's NOT in this PR

  - Phase 1.5 (binary framing) — still text TSV as per the design's "Phase 1 is the default" principle
  - Phase 2 (pyo3 API transport) — research status per the design docs
  - Haskell / AWK parser variants — Track B of the two-track plan; deferred unless we want the generality-showcase demo
  - enwiki run — simplewiki validated the whole pipeline; enwiki is the next natural follow-up now that the path works

  Test plan

  - ensure_streaming_binary triggers cargo build when binary is stale; no-ops when fresh
  - detect_python_exec('3.9', [lmdb], _) returns python3.9 on this system
  - Generated bash script uses export for env vars (visible to both pipe ends)
  - End-to-end: simplewiki categorylinks.sql.gz → LMDB with correct row count and many-to-many semantics
  - Follow-up: repeat end-to-end run on a fresh machine without cached builds to validate first-run behavior
  - Follow-up: enwiki scale run to drive the IntMap/LMDB crossover benchmark