### PR TITLE
test(csharp-query): Add C# query source policy tests for delimited provider routing

### DIFF
--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -6174,6 +6174,8 @@ verify_dynamic_source_plan_ :-
     csharp_query_target:render_plan_to_csharp(Plan, Source),
     sub_string(Source, _, _, _, 'DelimitedTextReader'),
     sub_string(Source, _, _, _, 'test_users.csv'),
+    \+ sub_string(Source, _, _, _, 'configuredProvider.RegisterDelimitedRelation'),
+    \+ sub_string(Source, _, _, _, 'configuredProvider.RegisterBinaryRelation'),
     maybe_run_query_runtime(Plan, ['Alice,30', 'Bob,25', 'Charlie,35']).
 
 verify_tsv_dynamic_source_plan :-
@@ -6189,6 +6191,7 @@ verify_tsv_dynamic_source_plan_ :-
     sub_string(Source, _, _, _, 'configuredProvider.RegisterDelimitedRelation'),
     sub_string(Source, _, _, _, 'new DelimitedRelationSource'),
     sub_string(Source, _, _, _, 'test_sales.tsv'),
+    \+ sub_string(Source, _, _, _, 'configuredProvider.RegisterBinaryRelation'),
     string_codes(TabLiteral, [39, 92, 116, 39]),
     sub_string(Source, _, _, _, TabLiteral),
     maybe_run_query_runtime(Plan, ['Laptop,1200', 'Mouse,25', 'Keyboard,75']).


### PR DESCRIPTION
  ## Summary

  This PR adds focused regression coverage for C# query target source routing after the configured delimited-source work.

  It locks down the intended policy:
  - simple non-binary TSV uses `configuredProvider.RegisterDelimitedRelation(...)`
  - non-binary TSV does not accidentally route through `RegisterBinaryRelation(...)`

  ## Why

  The previous PR expanded configured source registration beyond binary delimited relations. Artifact-backed execution is still binary-only, so the generator
    - `verify_dynamic_source_plan`
    - `verify_tsv_dynamic_source_plan`
  - `git diff --check` passed

  ## Scope

  This PR only adds tests.

  It does not change runtime behavior, artifact behavior, or source routing logic.

  You still need to commit before this PR has content:

  git add tests/core/test_csharp_query_target.pl
  git commit -m "test(csharp-query): cover delimited source routing policy"
  git push origin feat/csharp-query-delimited-source-artifact-policy-tests