### PR TITLE
refactor: Resolve labels to absolute offsets at compile time

### DIFF
--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -9,6 +9,7 @@
 #include <assert.h>
 
 #define WAM_HALT -1
+#define WAM_ERR_OOB -2
 #define WAM_MAX_REGS 256
 #define WAM_INITIAL_CAP 64
 
@@ -85,7 +86,7 @@ typedef struct {
     WamValue val;
     int arity;
     char *pred;
-    char *label;
+    int target_pc;
 } Instruction;
 
 /* WAM state */
@@ -124,11 +125,11 @@ typedef struct {
     Instruction *code;
     int code_size;
     
-    /* Labels */
-    char **label_names;
-    int *label_pcs;
-    int label_count;
-    int label_cap;
+    /* Predicate Map (for CALL/EXECUTE) */
+    char **pred_names;
+    int *pred_pcs;
+    int pred_count;
+    int pred_cap;
 } WamState;
 
 /* Helpers */
@@ -143,6 +144,9 @@ static inline WamValue val_int(int n) {
 static inline WamValue val_unbound(const char *name) {
     WamValue v; v.tag = VAL_UNBOUND; v.data.unbound_name = name; return v;
 }
+// Creates a new unbound reference on the heap.
+// Note: This function allocates a cell in H_array and increments state->H.
+// This fulfills the 1-slot allocation invariant expected by UNIFY_* write-mode operations.
 static inline WamValue wam_make_ref(WamState *state) {
     if (state->H >= state->H_cap) {
         state->H_cap = state->H_cap ? state->H_cap * 2 : WAM_INITIAL_CAP;
@@ -222,10 +226,11 @@ static inline bool wam_unify(WamState *state, WamValue *v1, WamValue *v2) {
             if (strcmp(d1->data.atom, d2->data.atom) != 0) return false;
         } else if (d1->tag == VAL_LIST) {
             if (pdl_top + 4 > 256) return false; // PDL overflow
-            pdl[pdl_top++] = &state->H_array[d2->data.ref_addr];
-            pdl[pdl_top++] = &state->H_array[d1->data.ref_addr];
+            // Push tail first, then head, so head is popped and unified first
             pdl[pdl_top++] = &state->H_array[d2->data.ref_addr + 1];
             pdl[pdl_top++] = &state->H_array[d1->data.ref_addr + 1];
+            pdl[pdl_top++] = &state->H_array[d2->data.ref_addr];
+            pdl[pdl_top++] = &state->H_array[d1->data.ref_addr];
         } else if (d1->tag == VAL_STR) {
             WamValue *f1 = &state->H_array[d1->data.ref_addr];
             WamValue *f2 = &state->H_array[d2->data.ref_addr];
@@ -237,7 +242,8 @@ static inline bool wam_unify(WamState *state, WamValue *v1, WamValue *v2) {
             int arity = strtol(slash + 1, NULL, 10);
             
             if (pdl_top + arity * 2 > 256) return false; // PDL overflow
-            for (int i = 0; i < arity; i++) {
+            // Push right-to-left so arguments are popped and unified left-to-right
+            for (int i = arity - 1; i >= 0; i--) {
                 pdl[pdl_top++] = &state->H_array[d2->data.ref_addr + 1 + i];
                 pdl[pdl_top++] = &state->H_array[d1->data.ref_addr + 1 + i];
             }
@@ -294,10 +300,22 @@ static inline void update_choice_point(WamState *state, int next_pc) {
         state->B_array[state->B - 1].next_pc = next_pc;
     }
 }
-static inline int resolve_label(WamState *state, const char *label) {
+
+static inline void wam_register_predicate(WamState *state, const char *pred, int pc) {
+    if (state->pred_count >= state->pred_cap) {
+        state->pred_cap = state->pred_cap ? state->pred_cap * 2 : WAM_INITIAL_CAP;
+        state->pred_names = realloc(state->pred_names, sizeof(char*) * state->pred_cap);
+        state->pred_pcs = realloc(state->pred_pcs, sizeof(int) * state->pred_cap);
+    }
+    state->pred_names[state->pred_count] = (char*)pred;
+    state->pred_pcs[state->pred_count] = pc;
+    state->pred_count++;
+}
+
+static inline int resolve_predicate(WamState *state, const char *pred) {
     // TODO: Optimize from O(n) to O(1) or O(log n) via hash map or bsearch
-    for (int i = 0; i < state->label_count; i++) {
-        if (strcmp(state->label_names[i], label) == 0) return state->label_pcs[i];
+    for (int i = 0; i < state->pred_count; i++) {
+        if (strcmp(state->pred_names[i], pred) == 0) return state->pred_pcs[i];
     }
     return -1;
 }

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -18,11 +18,13 @@
     compile_wam_runtime_to_c/2,       % +Options, -CCode
     compile_wam_predicate_to_c/4,     % +Pred/Arity, +WamCode, +Options, -CCode
     wam_instruction_to_c_literal/2,   % +WamInstr, -CCode
+    wam_instruction_to_c_literal/3,   % +WamInstr, +LabelMap, -CCode
     write_wam_c_project/3             % +Predicates, +Options, +ProjectDir
 ]).
 
 :- use_module(library(lists)).
 :- use_module(library(option)).
+
 :- use_module(library(filesex), [make_directory_path/1, directory_file_path/3]).
 :- use_module('../core/template_system').
 :- use_module('../bindings/c_wam_bindings').
@@ -118,16 +120,27 @@ wam_instruction_to_c_literal(call(P, N), Code) :-
     format(atom(Code), '{ .tag = INSTR_CALL, .pred = "~w", .arity = ~w }', [P, N]).
 wam_instruction_to_c_literal(execute(P), Code) :-
     format(atom(Code), '{ .tag = INSTR_EXECUTE, .pred = "~w" }', [P]).
-wam_instruction_to_c_literal(try_me_else(Label), Code) :-
-    format(atom(Code), '{ .tag = INSTR_TRY_ME_ELSE, .label = "~w" }', [Label]).
-wam_instruction_to_c_literal(retry_me_else(Label), Code) :-
-    format(atom(Code), '{ .tag = INSTR_RETRY_ME_ELSE, .label = "~w" }', [Label]).
+wam_instruction_to_c_literal(try_me_else(_Label), _) :-
+    throw(error(context_error(missing_label_map, "try_me_else/1 requires LabelMap for target_pc resolution. Use wam_instruction_to_c_literal/3 instead."), _)).
+wam_instruction_to_c_literal(retry_me_else(_Label), _) :-
+    throw(error(context_error(missing_label_map, "retry_me_else/1 requires LabelMap for target_pc resolution. Use wam_instruction_to_c_literal/3 instead."), _)).
+
+
 wam_instruction_to_c_literal(trust_me, '{ .tag = INSTR_TRUST_ME }').
 wam_instruction_to_c_literal(proceed, '{ .tag = INSTR_PROCEED }').
 wam_instruction_to_c_literal(allocate, '{ .tag = INSTR_ALLOCATE }').
 wam_instruction_to_c_literal(deallocate, '{ .tag = INSTR_DEALLOCATE }').
 wam_instruction_to_c_literal(Instr, Code) :-
     format(atom(Code), '// TODO: ~w', [Instr]).
+
+wam_instruction_to_c_literal(try_me_else(Label), LabelMap, Code) :-
+    ( member(Label-TargetPC, LabelMap) -> true ; TargetPC = -1 ),
+    format(atom(Code), '{ .tag = INSTR_TRY_ME_ELSE, .target_pc = ~w }', [TargetPC]).
+wam_instruction_to_c_literal(retry_me_else(Label), LabelMap, Code) :-
+    ( member(Label-TargetPC, LabelMap) -> true ; TargetPC = -1 ),
+    format(atom(Code), '{ .tag = INSTR_RETRY_ME_ELSE, .target_pc = ~w }', [TargetPC]).
+wam_instruction_to_c_literal(Instr, _, Code) :- wam_instruction_to_c_literal(Instr, Code).
+
 
 c_value_literal(Atom, Lit) :- atom(Atom), format(atom(Lit), 'val_atom("~w")', [Atom]).
 c_value_literal(Int, Lit) :- integer(Int), format(atom(Lit), 'val_int(~w)', [Int]).
@@ -193,17 +206,19 @@ wam_line_to_c_instr(["call", P, N], Instr) :-
 wam_line_to_c_instr(["execute", P], Instr) :-
     clean_comma(P, CP),
     format(atom(Instr), '{ .tag = INSTR_EXECUTE, .pred = "~w" }', [CP]).
-wam_line_to_c_instr(["try_me_else", L], Instr) :-
+wam_line_to_c_instr(["try_me_else", L], LabelMap, Arity, Instr) :-
     clean_comma(L, CL),
-    format(atom(Instr), '{ .tag = INSTR_TRY_ME_ELSE, .label = "~w" }', [CL]).
-wam_line_to_c_instr(["retry_me_else", L], Instr) :-
+    ( member(CL-TargetPC, LabelMap) -> true ; TargetPC = -1 ),
+    format(atom(Instr), '{ .tag = INSTR_TRY_ME_ELSE, .target_pc = ~w, .arity = ~w }', [TargetPC, Arity]).
+wam_line_to_c_instr(["retry_me_else", L], LabelMap, Arity, Instr) :-
     clean_comma(L, CL),
-    format(atom(Instr), '{ .tag = INSTR_RETRY_ME_ELSE, .label = "~w" }', [CL]).
-wam_line_to_c_instr(["trust_me"], '{ .tag = INSTR_TRUST_ME }').
-wam_line_to_c_instr(["proceed"], '{ .tag = INSTR_PROCEED }').
-wam_line_to_c_instr(["allocate"], '{ .tag = INSTR_ALLOCATE }').
-wam_line_to_c_instr(["deallocate"], '{ .tag = INSTR_DEALLOCATE }').
-wam_line_to_c_instr(Parts, Instr) :-
+    ( member(CL-TargetPC, LabelMap) -> true ; TargetPC = -1 ),
+    format(atom(Instr), '{ .tag = INSTR_RETRY_ME_ELSE, .target_pc = ~w, .arity = ~w }', [TargetPC, Arity]).
+wam_line_to_c_instr(["trust_me"], _, '{ .tag = INSTR_TRUST_ME }').
+wam_line_to_c_instr(["proceed"], _, '{ .tag = INSTR_PROCEED }').
+wam_line_to_c_instr(["allocate"], _, '{ .tag = INSTR_ALLOCATE }').
+wam_line_to_c_instr(["deallocate"], _, '{ .tag = INSTR_DEALLOCATE }').
+wam_line_to_c_instr(Parts, _, Instr) :-
     atomic_list_concat(Parts, ' ', Combined),
     format(atom(Instr), '/* TODO: ~w */ {0}', [Combined]).
 
@@ -213,23 +228,47 @@ clean_comma(S, Clean) :-
     ;   Clean = S
     ).
 
-wam_lines_to_c([], _, [], []).
-wam_lines_to_c([Line|Rest], PC, Instrs, Labels) :-
+wam_lines_to_c_pass1([], _, []).
+wam_lines_to_c_pass1([Line|Rest], PC, LabelMap) :-
     split_string(Line, " \t,", " \t,", Parts),
     delete(Parts, "", CleanParts),
-    (   CleanParts == []
-    ->  wam_lines_to_c(Rest, PC, Instrs, Labels)
+    (   CleanParts == [] -> wam_lines_to_c_pass1(Rest, PC, LabelMap)
     ;   CleanParts = [First|_],
         (   sub_string(First, _, 1, 0, ":")
         ->  sub_string(First, 0, _, 1, LabelName),
-            format(atom(LabelInsert), '    state->label_names[state->label_count] = "~w"; state->label_pcs[state->label_count++] = ~w;', [LabelName, PC]),
-            Labels = [LabelInsert|RestLabels],
-            wam_lines_to_c(Rest, PC, Instrs, RestLabels)
-        ;   wam_line_to_c_instr(CleanParts, CInstr),
+            LabelMap = [LabelName-PC|RestMap],
+            wam_lines_to_c_pass1(Rest, PC, RestMap)
+        ;   NPC is PC + 1,
+            wam_lines_to_c_pass1(Rest, NPC, LabelMap)
+        )
+    ).
+
+wam_lines_to_c_pass2([], _, _, _, []).
+wam_lines_to_c_pass2([Line|Rest], PC, LabelMap, Arity, Instrs) :-
+    split_string(Line, " \t,", " \t,", Parts),
+    delete(Parts, "", CleanParts),
+    (   CleanParts == [] -> wam_lines_to_c_pass2(Rest, PC, LabelMap, Arity, Instrs)
+    ;   CleanParts = [First|_],
+        (   sub_string(First, _, 1, 0, ":")
+        ->  sub_string(First, 0, _, 1, LabelName),
+            (   sub_string(LabelName, 0, 2, _, "L_")
+            ->  wam_lines_to_c_pass2(Rest, PC, LabelMap, Arity, Instrs)
+            ;   format(atom(PredReg), '    wam_register_predicate(state, "~w", ~w);', [LabelName, PC]),
+                Instrs = [PredReg|RestInstrs],
+                wam_lines_to_c_pass2(Rest, PC, LabelMap, Arity, RestInstrs)
+            )
+        ;   (   wam_line_to_c_instr(CleanParts, LabelMap, Arity, CInstr)
+            ->  true
+            ;   wam_line_to_c_instr(CleanParts, LabelMap, CInstr_NoArity)
+            ->  CInstr = CInstr_NoArity
+            ;   wam_line_to_c_instr(CleanParts, CInstr_NoMap)
+            ->  CInstr = CInstr_NoMap
+            ;   CInstr = '{0}'
+            ),
             format(atom(InstrEntry), '    state->code[~w] = (Instruction)~w;', [PC, CInstr]),
             NPC is PC + 1,
             Instrs = [InstrEntry|RestInstrs],
-            wam_lines_to_c(Rest, NPC, RestInstrs, Labels)
+            wam_lines_to_c_pass2(Rest, NPC, LabelMap, Arity, RestInstrs)
         )
     ).
 
@@ -241,23 +280,22 @@ compile_wam_predicate_to_c(PredIndicator, WamCode, _Options, CCode) :-
     % (e.g. "get_constant a, A1\ncall foo/2, 2\n"), NOT a list of terms.
     % We parse it line-by-line into structural C literals.
     split_string(WamStr, "\n", "", Lines),
-    wam_lines_to_c(Lines, 0, InstrParts, LabelParts),
+    wam_lines_to_c_pass1(Lines, 0, LabelMap),
+    wam_lines_to_c_pass2(Lines, 0, LabelMap, Arity, InstrParts),
     atomic_list_concat(InstrParts, '\n', InstrLiterals),
-    atomic_list_concat(LabelParts, '\n', LabelLiterals),
+    
+    % Calculate required code_size dynamically
+    length(InstrParts, CodeSize),
+    
     format(atom(CCode), 
 '/* WAM-compiled predicate: ~w/~w */
 void setup_~w_~w(WamState* state) {
-    if (!state->code) {
-        state->code_size = 1000; // placeholder size
-        state->code = malloc(sizeof(Instruction) * state->code_size);
-        state->label_cap = 100;
-        state->label_names = malloc(sizeof(char*) * state->label_cap);
-        state->label_pcs = malloc(sizeof(int) * state->label_cap);
-        state->label_count = 0;
+    if (!state->code || state->code_size < ~w) {
+        state->code_size = ~w;
+        state->code = realloc(state->code, sizeof(Instruction) * state->code_size);
     }
 ~w
-~w
-}', [PredStr, Arity, PredStr, Arity, InstrLiterals, LabelLiterals]).
+}', [PredStr, Arity, PredStr, Arity, CodeSize, CodeSize, InstrLiterals]).
 
 % ============================================================================
 % PHASE 3: step_wam/3 -> C switch statement
@@ -344,24 +382,24 @@ compile_step_wam_to_c(_Options, CCode) :-
             }
             case INSTR_CALL: {
                 state->CP = state->P + 1;
-                int target = resolve_label(state, instr->pred);
+                int target = resolve_predicate(state, instr->pred);
                 if (target >= 0) { state->P = target; return true; }
                 return false;
             }
             case INSTR_EXECUTE: {
-                int target = resolve_label(state, instr->pred);
+                int target = resolve_predicate(state, instr->pred);
                 if (target >= 0) { state->P = target; return true; }
                 return false;
             }
             case INSTR_TRY_ME_ELSE: {
-                int target = resolve_label(state, instr->label);
-                // TODO: extract actual arity from context; defaulting to 32
-                push_choice_point(state, target, 32);
+                int target = instr->target_pc;
+                int arity = instr->arity ? instr->arity : 32;
+                push_choice_point(state, target, arity);
                 state->P++;
                 return true;
             }
             case INSTR_RETRY_ME_ELSE: {
-                int target = resolve_label(state, instr->label);
+                int target = instr->target_pc;
                 ChoicePoint *cp = &state->B_array[state->B - 1];
                 cp->next_pc = target;
                 state->P++;
@@ -379,6 +417,7 @@ compile_step_wam_to_c(_Options, CCode) :-
                     WamValue s; s.tag = VAL_STR; s.data.ref_addr = state->H;
                     *cell = s;
                     
+                    // Note: instr->pred includes the arity suffix (e.g. "foo/2"), which is stored as the functor atom
                     const char *slash = strchr(instr->pred, '/');
                     assert(slash != NULL && "Functor missing arity suffix");
                     int arity = strtol(slash + 1, NULL, 10);
@@ -475,6 +514,8 @@ compile_step_wam_to_c(_Options, CCode) :-
                     *cell = state->H_array[state->S];
                     state->S++;
                 } else {
+                    // Note: wam_make_ref allocates an unbound cell in H_array and increments H,
+                    // satisfying the 1-slot heap pre-reservation invariant.
                     WamValue ref = wam_make_ref(state);
                     *cell = ref;
                 }
@@ -535,7 +576,7 @@ compile_step_wam_to_c(_Options, CCode) :-
                 state->P = cp->next_pc; // Explicitly jump to alternative
             }
         }
-        return (state->P == WAM_HALT) ? 0 : (WAM_HALT - 1); // 0 on success (HALT), else OOB error
+        return (state->P == WAM_HALT) ? 0 : WAM_ERR_OOB; // 0 on success (HALT), else OOB error
     }').
 
 compile_wam_helpers_to_c(_Options, CCode) :-


### PR DESCRIPTION
This PR addresses the primary technical debt items from the previous WAM C runtime review. It completely eliminates the $O(n)$ label resolution overhead, removes the hardcoded code size limits, and fixes a handful of minor inconsistencies.

## Changes
- **Compile-Time Label Resolution**: The WAM C transpiler (`wam_c_target.pl`) has been refactored to use a two-pass generation strategy. 
  - **Pass 1** scans the instructions to calculate the PC (Program Counter) offset of every label and builds a `LabelMap`.
  - **Pass 2** generates the C instruction structs using the calculated integer offsets (`target_pc`) instead of string labels.
- **$O(1)$ Dispatch**: Eliminated the `label_names` and `label_pcs` array from the C runtime entirely! Branch instructions like `TRY_ME_ELSE` and `RETRY_ME_ELSE` now do an $O(1)$ array-index lookup directly (`cp->next_pc = instr->target_pc`).
- **Dynamic Code Sizing**: Eliminated the hardcoded `1000` limit for `state->code_size`. The transpiler now dynamically calculates the exact number of output instructions and generates the appropriate `realloc` boundaries.
- **Global Predicate Registry**: `INSTR_CALL` and `INSTR_EXECUTE` correctly use a global `pred_names` array (`resolve_predicate`), keeping global external calls logically distinct from local branch jumps.
- **Minor Fixes**: 
  - Unified the PDL push order in `wam_unify` so that elements are popped and unified in standard WAM left-to-right execution order.
  - Added missing documentation for `wam_make_ref` noting that it correctly handles the 1-slot structural allocation invariant.
  - Added a functor convention comment to `INSTR_GET_STRUCTURE`.
  - Threaded dynamic `arity` downwards into choice point generation for branch instructions.
  - Introduced `WAM_ERR_OOB` for the `wam_run` failure sentinel.
