### PR TITLE
feat: Implement `SWITCH_ON_TERM` for WAM C first-argument indexing

### DIFF
--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -96,6 +96,8 @@ typedef struct {
     int target_pc;
     HashEntry *hash_table;
     int hash_size;
+    HashEntry *s_hash_table;
+    int s_hash_size;
 } Instruction;
 
 /* WAM state */

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -273,18 +273,25 @@ wam_generate_c_instruction(PC, Parts, LabelMap, Arity, CodeLines) :-
     ->  length(Entries, HashSize),
         format(atom(L0), '    state->code[~w] = (Instruction){ .tag = INSTR_SWITCH_ON_CONSTANT, .hash_size = ~w };', [PC, HashSize]),
         format(atom(L1), '    state->code[~w].hash_table = malloc(sizeof(HashEntry) * ~w);', [PC, HashSize]),
-        generate_hash_table_entries(PC, Entries, 0, LabelMap, HashLines),
+        generate_hash_table_entries(PC, "hash_table", Entries, 0, LabelMap, HashLines),
         append([L0, L1], HashLines, CodeLines)
     ;   Parts = ["switch_on_structure" | Entries]
     ->  length(Entries, HashSize),
         format(atom(L0), '    state->code[~w] = (Instruction){ .tag = INSTR_SWITCH_ON_STRUCTURE, .hash_size = ~w };', [PC, HashSize]),
         format(atom(L1), '    state->code[~w].hash_table = malloc(sizeof(HashEntry) * ~w);', [PC, HashSize]),
-        generate_hash_table_entries(PC, Entries, 0, LabelMap, HashLines),
+        generate_hash_table_entries(PC, "hash_table", Entries, 0, LabelMap, HashLines),
         append([L0, L1], HashLines, CodeLines)
-    ;   Parts = ["switch_on_term" | _]
-    ->  % TODO: Implement switch_on_term
-        format(atom(L0), '    state->code[~w] = (Instruction){0}; // TODO: switch_on_term', [PC]),
-        CodeLines = [L0]
+    ;   Parts = ["switch_on_term", CLenStr | Rest1]
+    ->  number_string(CLen, CLenStr),
+        length(CEntries, CLen),
+        append(CEntries, [SLenStr | SEntries], Rest1),
+        number_string(SLen, SLenStr),
+        format(atom(L0), '    state->code[~w] = (Instruction){ .tag = INSTR_SWITCH_ON_TERM, .hash_size = ~w, .s_hash_size = ~w };', [PC, CLen, SLen]),
+        format(atom(L1), '    state->code[~w].hash_table = malloc(sizeof(HashEntry) * ~w);', [PC, CLen]),
+        format(atom(L2), '    state->code[~w].s_hash_table = malloc(sizeof(HashEntry) * ~w);', [PC, SLen]),
+        generate_hash_table_entries(PC, "hash_table", CEntries, 0, LabelMap, CHashLines),
+        generate_hash_table_entries(PC, "s_hash_table", SEntries, 0, LabelMap, SHashLines),
+        append([L0, L1, L2 | CHashLines], SHashLines, CodeLines)
     ;   (   wam_line_to_c_instr(Parts, LabelMap, Arity, CInstr)
         ->  true
         ;   wam_line_to_c_instr(Parts, LabelMap, CInstr_NoArity)
@@ -297,8 +304,8 @@ wam_generate_c_instruction(PC, Parts, LabelMap, Arity, CodeLines) :-
         CodeLines = [L0]
     ).
 
-generate_hash_table_entries(_, [], _, _, []).
-generate_hash_table_entries(PC, [Entry|Rest], Idx, LabelMap, [Line|RestLines]) :-
+generate_hash_table_entries(_, _, [], _, _, []).
+generate_hash_table_entries(PC, TableName, [Entry|Rest], Idx, LabelMap, [Line|RestLines]) :-
     split_string(Entry, ":", "", Parts),
     (   Parts = [KeyStr, LabelStr]
     ->  (   LabelStr == "default"
@@ -312,9 +319,9 @@ generate_hash_table_entries(PC, [Entry|Rest], Idx, LabelMap, [Line|RestLines]) :
         ;   atom_string(KeyAtom, KeyStr),
             c_value_literal(KeyAtom, ValLit)
         ),
-        format(atom(Line), '    state->code[~w].hash_table[~w] = (HashEntry){ ~w, ~w };', [PC, Idx, ValLit, TargetPC]),
+        format(atom(Line), '    state->code[~w].~w[~w] = (HashEntry){ ~w, ~w };', [PC, TableName, Idx, ValLit, TargetPC]),
         NextIdx is Idx + 1,
-        generate_hash_table_entries(PC, Rest, NextIdx, LabelMap, RestLines)
+        generate_hash_table_entries(PC, TableName, Rest, NextIdx, LabelMap, RestLines)
     ;   throw(error(wam_c_target_error(invalid_switch_entry(Entry)), _))
     ).
 
@@ -335,9 +342,13 @@ compile_wam_predicate_to_c(PredIndicator, WamCode, _Options, CCode) :-
 void setup_~w_~w(WamState* state) {
     if (state->code) {
         for (int i = 0; i < state->code_size; i++) {
-            if ((state->code[i].tag == INSTR_SWITCH_ON_CONSTANT || state->code[i].tag == INSTR_SWITCH_ON_STRUCTURE) && state->code[i].hash_table) {
+            if ((state->code[i].tag == INSTR_SWITCH_ON_CONSTANT || state->code[i].tag == INSTR_SWITCH_ON_STRUCTURE || state->code[i].tag == INSTR_SWITCH_ON_TERM) && state->code[i].hash_table) {
                 free(state->code[i].hash_table);
                 state->code[i].hash_table = NULL;
+            }
+            if (state->code[i].tag == INSTR_SWITCH_ON_TERM && state->code[i].s_hash_table) {
+                free(state->code[i].s_hash_table);
+                state->code[i].s_hash_table = NULL;
             }
         }
     }
@@ -463,8 +474,12 @@ compile_step_wam_to_c(_Options, CCode) :-
             }
             case INSTR_SWITCH_ON_CONSTANT: {
                 WamValue *cell = wam_deref_ptr(state, &state->A[0]); // A1 is register index 0 (or X1 in 1-based, A array is 0-indexed)
+                if (val_is_unbound(*cell)) {
+                    state->P++;
+                    return true; // Unbound variable falls through to the sequential try_me_else chain
+                }
                 if (cell->tag != VAL_ATOM && cell->tag != VAL_INT) {
-                    return false; // falls through to backtracking (variable case unimplemented, pending switch_on_term)
+                    return false; // Type mismatch, fail
                 }
                 for (int i = 0; i < instr->hash_size; i++) {
                     if (val_equal(*cell, instr->hash_table[i].key)) {
@@ -476,8 +491,12 @@ compile_step_wam_to_c(_Options, CCode) :-
             }
             case INSTR_SWITCH_ON_STRUCTURE: {
                 WamValue *cell = wam_deref_ptr(state, &state->A[0]);
+                if (val_is_unbound(*cell)) {
+                    state->P++;
+                    return true; // Unbound variable falls through to the sequential try_me_else chain
+                }
                 if (cell->tag != VAL_STR) {
-                    return false; // falls through to backtracking (variable case unimplemented, pending switch_on_term)
+                    return false; // Type mismatch, fail
                 }
                 WamValue *f = &state->H_array[cell->data.ref_addr];
                 for (int i = 0; i < instr->hash_size; i++) {
@@ -487,6 +506,30 @@ compile_step_wam_to_c(_Options, CCode) :-
                     }
                 }
                 return false; // Not found in index, fail
+            }
+            case INSTR_SWITCH_ON_TERM: {
+                WamValue *cell = wam_deref_ptr(state, &state->A[0]);
+                if (val_is_unbound(*cell)) {
+                    state->P++;
+                    return true; // Unbound variable falls through to the sequential try_me_else chain
+                }
+                if (cell->tag == VAL_ATOM || cell->tag == VAL_INT) {
+                    for (int i = 0; i < instr->hash_size; i++) {
+                        if (val_equal(*cell, instr->hash_table[i].key)) {
+                            state->P = instr->hash_table[i].target_pc;
+                            return true;
+                        }
+                    }
+                } else if (cell->tag == VAL_STR) {
+                    WamValue *f = &state->H_array[cell->data.ref_addr];
+                    for (int i = 0; i < instr->s_hash_size; i++) {
+                        if (val_equal(*f, instr->s_hash_table[i].key)) {
+                            state->P = instr->s_hash_table[i].target_pc;
+                            return true;
+                        }
+                    }
+                }
+                return false; // Not found in either index or unsupported type (e.g. VAL_LIST unsupported yet), fail
             }
             case INSTR_GET_STRUCTURE: {
                 WamValue *cell = wam_deref_ptr(state, resolve_reg(state, instr->reg_ai, instr->is_y_ai));

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -234,7 +234,7 @@ clean_comma(S, Clean) :-
 
 wam_lines_to_c_pass1([], _, []).
 wam_lines_to_c_pass1([Line|Rest], PC, LabelMap) :-
-    split_string(Line, " \t,", " \t,", Parts),
+    split_string(Line, " \t", " \t", Parts),  % comma intentionally excluded: entries are now space-separated
     delete(Parts, "", CleanParts),
     (   CleanParts == [] -> wam_lines_to_c_pass1(Rest, PC, LabelMap)
     ;   CleanParts = [First|_],
@@ -528,8 +528,11 @@ compile_step_wam_to_c(_Options, CCode) :-
                             return true;
                         }
                     }
+                } else if (cell->tag == VAL_LIST) {
+                    state->P++;
+                    return true; // VAL_LIST: no list index table yet, fall through to try_me_else chain
                 }
-                return false; // Not found in either index or unsupported type (e.g. VAL_LIST unsupported yet), fail
+                return false; // Not found in either index — fail and backtrack
             }
             case INSTR_GET_STRUCTURE: {
                 WamValue *cell = wam_deref_ptr(state, resolve_reg(state, instr->reg_ai, instr->is_y_ai));

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -187,19 +187,13 @@ build_term_index([Head-_|Rest], I, Pred, Arity, [Type|RestTypes],
     ).
 
 format_switch_on_term(ConstEntries, StructEntries, IndexCode) :-
-    (   ConstEntries \= []
-    ->  format_index_entries(ConstEntries, CStr),
-        ConstPart = CStr
-    ;   ConstPart = "none"
-    ),
-    (   StructEntries \= []
-    ->  format_index_entries(StructEntries, SStr),
-        StructPart = SStr
-    ;   StructPart = "none"
-    ),
+    length(ConstEntries, CLen),
+    length(StructEntries, SLen),
+    format_index_entries(ConstEntries, CStr),
+    format_index_entries(StructEntries, SStr),
     format(string(IndexCode),
-           "    switch_on_term constant:~w, structure:~w",
-           [ConstPart, StructPart]).
+           "    switch_on_term ~w ~w ~w ~w",
+           [CLen, CStr, SLen, SStr]).
 
 %% build_second_arg_index(+Pred, +Arity, +Clauses, -IndexCode)
 %  When first-arg indexing fails (e.g., all variable first args),
@@ -239,7 +233,7 @@ format_index_entries(Entries, Str) :-
     maplist([K-V, S]>>(quote_wam_constant(K, KStr),
                        format(atom(S), "~w:~w", [KStr, V])),
             Entries, Parts),
-    atomic_list_concat(Parts, ', ', Str).
+    atomic_list_concat(Parts, ' ', Str).
 
 % ---------------------------------------------------------------------------
 % Constant quoting


### PR DESCRIPTION
Completes the first-argument indexing layer started in `feat/wam-c-indexing` by implementing the mixed-type `SWITCH_ON_TERM` dispatch instruction, fixing variable/list fallthrough for all three switch instructions, and hardening the token format for downstream parsers.

## Changes

### `wam_target.pl`
- Refactored `format_switch_on_term` to emit a flat, space-delimited token format:
  `switch_on_term <CLen> <C_Entries...> <SLen> <S_Entries...>`
  The length-prefixed slice approach avoids the nested `constant:..., structure:...` format that previously broke the downstream space/comma tokenizer.
- `format_index_entries/2` now uses space as the separator (was comma). This change is uniform across all five call-sites: `switch_on_constant`, `switch_on_structure`, `switch_on_constant_a2`, and both halves of `switch_on_term`.

### `wam_c_target.pl`
- Implemented `wam_generate_c_instruction` for `switch_on_term`. Parses the flat token stream by reading `CLen`, slicing `CEntries`, then reading `SLen` and slicing `SEntries`. Emits `malloc` for both `hash_table` (constants) and `s_hash_table` (structures) and populates both via `generate_hash_table_entries/6`.
- Updated `generate_hash_table_entries` from arity 5 to 6, adding a `TableName` parameter so it can emit code targeting either `hash_table` or `s_hash_table` without duplication.
- Updated the `setup_` cleanup loop to also `free` and `NULL` the `s_hash_table` for `INSTR_SWITCH_ON_TERM` on re-load.
- Implemented `INSTR_SWITCH_ON_TERM` in `step_wam`: dispatches on the first-argument tag — constants search `hash_table`, structures search `s_hash_table` (by functor atom).
- Fixed variable fallthrough: `INSTR_SWITCH_ON_CONSTANT`, `INSTR_SWITCH_ON_STRUCTURE`, and `INSTR_SWITCH_ON_TERM` all now do `P++; return true` for unbound variables, matching the WAM spec.
- Fixed `VAL_LIST` fallthrough in `INSTR_SWITCH_ON_TERM`: list-headed arguments now fall through to the `try_me_else` chain rather than hard-failing.
- `wam_lines_to_c_pass1` no longer splits on commas. Entries are now space-separated, so the comma was a latent mismatch. Comment added explaining the contract.

### `wam_runtime.h`
- Added `s_hash_table` (`HashEntry *`) and `s_hash_size` (`int`) fields to the `Instruction` struct to hold the structure sub-table for `INSTR_SWITCH_ON_TERM`.

## Pending Items
- **`VAL_LIST` index table** — list-headed clauses fall through correctly but do not yet get O(1) dispatch. A `list_target_pc` field on `Instruction` would complete the full WAM spec. Deferred as a follow-up.
- **Elixir target audit** — downstream consumers of `switch_on_constant`/`switch_on_structure` text (e.g. the Elixir lowered emitter) previously expected comma-separated entries. Those targets should be audited before being exercised against predicates with multiple clauses.
