### PR TITLE
test(wam-elixir): CPS throw/catch × Task.async_stream probe + design doc fix

### DIFF
--- a/docs/design/WAM_TIERED_LOWERING.md
+++ b/docs/design/WAM_TIERED_LOWERING.md
@@ -318,12 +318,30 @@ defp clause_main(state) do
       # it can produce. Results are merged into the surrounding
       # aggregate's accumulator (the caller was inside findall /
       # bagof / aggregate_all).
+      #
+      # CRITICAL: the task function wraps each branch call in try/catch.
+      # CPS-lowered clause bodies signal failure via `throw({:fail, s})`
+      # and (optionally) early return via `throw({:return, r})`. A naked
+      # throw inside a Task.async_stream body escapes as `{:nocatch, _}`
+      # and CRASHES THE PARENT PROCESS — async_stream does not capture
+      # thrown values by default. The per-branch try/catch converts
+      # thrown values into return values so the stream emits a clean
+      # `{:ok, list}` per branch. Verified by
+      # `examples/debug_tier2_async_stream_throw_catch.exs`.
       branch_results =
         branches
-        |> Task.async_stream(& &1.(branch_state),
-                             on_timeout: :kill_task,
-                             ordered: false,
-                             max_concurrency: System.schedulers_online())
+        |> Task.async_stream(fn branch ->
+             try do
+               branch.(branch_state)
+             catch
+               {:fail, _state} -> []
+               {:return, result} when is_list(result) -> result
+               {:return, result} -> [result]
+             end
+           end,
+           on_timeout: :kill_task,
+           ordered: false,
+           max_concurrency: System.schedulers_online())
         |> Enum.flat_map(fn
           {:ok, solutions} when is_list(solutions) -> solutions
           _ -> []
@@ -369,10 +387,17 @@ The following must hold before Tier 2 is a reasonable next PR:
    `WamState` (or equivalent), incremented when fanning out,
    consulted by `par_wrap_segment`'s emitted wrapper.
 4. **CPS `throw/catch` semantics verified under `Task.async_stream`.**
-   A branch that throws `{:fail, state}` must be captured as "this
-   alternative failed" without killing sibling tasks. The
-   `{:exit, reason}` vs `{:ok, value}` dichotomy of `async_stream`
-   maps onto this cleanly but needs a focused test.
+   ✅ Verified — `examples/debug_tier2_async_stream_throw_catch.exs`
+   (OTP 28 / Elixir 1.19). Finding: `Task.async_stream` does NOT
+   capture thrown values from a task body. A naked `throw({:fail, s})`
+   escapes as `{:nocatch, _}` and exits the parent process through
+   task linking. The emission template (above) therefore wraps each
+   branch call-site in a `try/catch` **inside the task function** so
+   thrown values become return values (`{:fail, _}` → `[]`,
+   `{:return, r}` → `[r]` or `r` if already a list). With that
+   wrapper the stream emits one `{:ok, list}` per branch and siblings
+   mid-computation survive peer throws. This is general BEAM/OTP
+   behaviour, not termux-specific.
 
 ### Deferred
 

--- a/examples/debug_tier2_async_stream_throw_catch.exs
+++ b/examples/debug_tier2_async_stream_throw_catch.exs
@@ -1,0 +1,193 @@
+# Interaction probe: Task.async_stream × CPS throw/catch (Tier-2 precondition 4).
+#
+# Run:  elixir examples/debug_tier2_async_stream_throw_catch.exs
+# Exits 0 on pass, 1 on any failure.
+#
+# Verifies the single load-bearing correctness assumption behind
+# docs/design/WAM_TIERED_LOWERING.md — that CPS-lowered branches which
+# signal failure via `throw({:fail, state})` can be fanned out through
+# Task.async_stream without killing sibling tasks or crashing the parent.
+#
+# Finding (OTP 28 / Elixir 1.19): a NAKED throw from a task body escapes
+# as `{:nocatch, thrown}` and bubbles up through Task.Supervised.invoke_mfa,
+# exiting the parent. Task.async_stream does NOT catch thrown values by
+# default. The fix is to wrap each branch call-site in a try/catch inside
+# the task function so thrown values become return values (empty list
+# for {:fail, _}, wrapped list for {:return, _}). With that wrapper the
+# stream emits one `{:ok, list}` per branch and Enum.flat_map collects
+# solutions cleanly.
+#
+# The Tier-2 wrapper emission template must therefore include the
+# per-branch try/catch layer. A later PR will revise the design doc.
+
+defmodule Tier2AsyncStreamProbe do
+  @moduledoc """
+  Reproduces the per-branch shape the Tier-2 wrapper will use. Each
+  test asserts a specific property of the interaction.
+  """
+
+  # The wrapper a Tier-2-emitted body will apply around each branch.
+  # Converts CPS throws into return values so Task.async_stream sees
+  # a normal result, not an abnormal exit.
+  def run_branch(branch_fn, branch_state) do
+    try do
+      branch_fn.(branch_state)
+    catch
+      {:fail, _state} -> []
+      {:return, result} when is_list(result) -> result
+      {:return, result} -> [result]
+    end
+  end
+
+  def run_all(branches, branch_state, opts \\ []) do
+    max_c = Keyword.get(opts, :max_concurrency, 4)
+
+    branches
+    |> Task.async_stream(
+      fn branch -> run_branch(branch, branch_state) end,
+      ordered: Keyword.get(opts, :ordered, true),
+      on_timeout: :kill_task,
+      max_concurrency: max_c
+    )
+    |> Enum.to_list()
+  end
+end
+
+defmodule Tier2ProbeRunner do
+  @moduledoc "PASS/FAIL runner. Accumulates failures in a process dict."
+
+  def init, do: Process.put(:failures, [])
+
+  def assert(cond, label) do
+    if cond do
+      IO.puts("[PASS] #{label}")
+    else
+      IO.puts("[FAIL] #{label}")
+      Process.put(:failures, [label | Process.get(:failures, [])])
+    end
+  end
+
+  def finish do
+    case Process.get(:failures, []) do
+      [] ->
+        IO.puts("\n=== All interaction probes passed ===")
+        System.halt(0)
+
+      fs ->
+        IO.puts("\n=== #{length(fs)} failure(s) ===")
+        Enum.each(Enum.reverse(fs), fn l -> IO.puts("  - #{l}") end)
+        System.halt(1)
+    end
+  end
+end
+
+# ----- probe body -----
+
+Tier2ProbeRunner.init()
+
+state = %{cut_point: [], parallel_depth: 1}
+
+# Test 1: mixed success + {:fail, _} branches all drain, no parent crash.
+branches_1 = [
+  fn _s -> [:a1, :a2] end,
+  fn s -> throw({:fail, s}) end,
+  fn _s -> [:c1] end,
+  fn s -> throw({:fail, %{s | cut_point: [:abc]}}) end
+]
+
+raw_1 = Tier2AsyncStreamProbe.run_all(branches_1, state)
+Tier2ProbeRunner.assert(length(raw_1) == 4, "all 4 branches drain to stream results")
+Tier2ProbeRunner.assert(
+  Enum.all?(raw_1, fn {:ok, v} -> is_list(v); _ -> false end),
+  "every stream entry is {:ok, list} — no {:exit, _} leaks"
+)
+
+succ_1 =
+  Enum.flat_map(raw_1, fn
+    {:ok, list} when is_list(list) -> list
+    _ -> []
+  end)
+
+Tier2ProbeRunner.assert(
+  succ_1 == [:a1, :a2, :c1],
+  "Enum.flat_map collects 3 solutions in order (ordered: true)"
+)
+
+# Test 2: {:return, result} throws are captured as a single-element list.
+branches_2 = [
+  fn _s -> [:x1] end,
+  fn _s -> throw({:return, :single_answer}) end,
+  fn _s -> [:z1, :z2] end
+]
+
+raw_2 = Tier2AsyncStreamProbe.run_all(branches_2, state)
+succ_2 =
+  Enum.flat_map(raw_2, fn
+    {:ok, list} when is_list(list) -> list
+    _ -> []
+  end)
+
+Tier2ProbeRunner.assert(
+  succ_2 == [:x1, :single_answer, :z1, :z2],
+  "{:return, result} throws convert to [result] and merge in place"
+)
+
+# Test 3: slow branch is not killed early. 50 ms sleep on one branch,
+# quick failure on another — both outcomes must land.
+branches_3 = [
+  fn _s ->
+    Process.sleep(50)
+    [:slow_answer]
+  end,
+  fn s -> throw({:fail, s}) end,
+  fn _s -> [:fast_answer] end
+]
+
+t_start = System.monotonic_time(:millisecond)
+raw_3 = Tier2AsyncStreamProbe.run_all(branches_3, state)
+t_end = System.monotonic_time(:millisecond)
+
+succ_3 =
+  Enum.flat_map(raw_3, fn
+    {:ok, list} when is_list(list) -> list
+    _ -> []
+  end)
+
+Tier2ProbeRunner.assert(
+  Enum.sort(succ_3) == [:fast_answer, :slow_answer],
+  "slow branch runs to completion alongside fast + failing siblings"
+)
+
+Tier2ProbeRunner.assert(
+  t_end - t_start >= 50,
+  "stream waited for slow branch (>=50ms elapsed, actual: #{t_end - t_start}ms)"
+)
+
+# Test 4: one throw does not kill siblings that were already mid-computation.
+# 4 branches, half throw, half sleep+return. Assert all 2 successes land.
+branches_4 = [
+  fn s -> throw({:fail, s}) end,
+  fn _s ->
+    Process.sleep(10)
+    [:s4_a]
+  end,
+  fn s -> throw({:fail, s}) end,
+  fn _s ->
+    Process.sleep(20)
+    [:s4_b]
+  end
+]
+
+raw_4 = Tier2AsyncStreamProbe.run_all(branches_4, state, ordered: false)
+succ_4 =
+  Enum.flat_map(raw_4, fn
+    {:ok, list} when is_list(list) -> list
+    _ -> []
+  end)
+
+Tier2ProbeRunner.assert(
+  Enum.sort(succ_4) == [:s4_a, :s4_b],
+  "siblings mid-computation are not killed by peer throws (ordered: false)"
+)
+
+Tier2ProbeRunner.finish()


### PR DESCRIPTION
## Summary

Delivers Tier-2 precondition 4 from
`docs/design/WAM_TIERED_LOWERING.md` (probe script), and revises the
design doc's emission template to reflect what the probe exposed.

## Key finding

**A naked `throw` from a `Task.async_stream` branch body crashes the
parent process.** The thrown value escapes as `{:nocatch, thrown}`
through `Task.Supervised.invoke_mfa`, and the stream's default link
behaviour exits the caller:

```
** (EXIT from #PID<0.95.0>) an exception was raised:
    ** (ErlangError) Erlang error: {:nocatch, {:fail, %{...}}}
```

`Task.async_stream` does NOT catch thrown values. **This is general
BEAM/OTP behaviour, not termux-specific** — the error originates in
stdlib Elixir (`Task.Supervised`) and Erlang's `throw/1` semantics,
both identical on Linux / macOS / Windows / any BEAM node.

**Fix:** wrap each branch call-site in `try/catch` **inside** the
task function so thrown values become return values:

```elixir
Task.async_stream(fn branch ->
  try do
    branch.(branch_state)
  catch
    {:fail, _state} -> []
    {:return, result} when is_list(result) -> result
    {:return, result} -> [result]
  end
end, ordered: false, on_timeout: :kill_task,
     max_concurrency: System.schedulers_online())
```

With this wrapper, every stream entry is `{:ok, list}` and
`Enum.flat_map` collects solutions cleanly. Siblings mid-computation
are not killed when peers throw.

## What this PR changes

1. **`examples/debug_tier2_async_stream_throw_catch.exs`** — standalone
   probe script. 7 assertions covering: per-branch throw capture, no
   parent crash, `{:return, result}` handling, slow-sibling survival
   (≥50 ms sleep alongside peer throws), unordered fanout with mixed
   throw/success. Exit 0 on pass, 1 on any fail. Run with
   `elixir examples/debug_tier2_async_stream_throw_catch.exs`.
2. **`docs/design/WAM_TIERED_LOWERING.md`** — emission template now
   wraps each branch in `try/catch` inside the task function, with a
   comment explaining why. Precondition 4 marked verified, with the
   finding and fix recorded inline.

Verified on OTP 28 / Elixir 1.19 (termux). Behaviour is a general
BEAM/OTP semantic; the same pattern is required on any deployment.

## Implications

- **Performance: negligible.** BEAM try/catch is zero-cost on the
  happy path (no exception thrown). On failure it's a pattern match
  on the thrown value.
- **Defence-in-depth vs. nested fanout.** If `parallel_depth > 0`
  guard is ever disabled, per-branch try/catch still prevents a
  nested parallel body from crashing the outer fan-out. The guard is
  the optimisation; the try/catch is the correctness floor.
- **Matches Haskell Tier 2.** Haskell catches branch failures in the
  ST monad — same semantic shape, different language mechanism.
  Cross-target consistency maintained.
- **Rejected alternative.** `Task.Supervisor.async_stream_nolink`
  would fix the link-kill at the stream layer but requires starting
  a supervisor. Per-branch try/catch is simpler and local.

## Not in this PR

- `par_wrap_segment/3` emitter hook — next PR. The emission template
  in the design doc is now correct; the emitter can follow it directly.
- CI integration of the probe — runs locally; will be superseded by a
  Prolog-driven end-to-end test once `par_wrap_segment/3` actually
  emits this shape.
