### PR TITLE
feat(wam-elixir): Tier-2 super-wrapper emitter (par_wrap_segment/4)

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -22,9 +22,14 @@
     % Phase C first-argument indexing.
     extract_arg1_index/3,         % +Segments, +Arity, -IndexResult
     % Tier-2 purity gate (see docs/design/WAM_TIERED_LOWERING.md).
-    % Consumed by `par_wrap_segment/3` (PR2) to decide whether a
-    % predicate is eligible for host-native parallel emission.
-    tier2_purity_eligible/3       % +Pred, +Arity, -Cert
+    % Consumed by `par_wrap_segment/4` to decide whether a predicate
+    % is eligible for host-native parallel emission.
+    tier2_purity_eligible/3,      % +Pred, +Arity, -Cert
+    % Tier-2 super-wrapper emitter. Takes clause segments + options,
+    % emits either the cond-based Task.async_stream fan-out or an
+    % empty string (gates rejected). Not wired into the main emission
+    % path yet — live hook-up is a follow-on PR.
+    par_wrap_segment/4            % +Pred/Arity, +Segments, +Options, -Code
 ]).
 
 :- use_module(library(lists)).
@@ -890,6 +895,102 @@ lower_instr_list([], _, _, []).
 lower_instr_list([PC-Instr|Rest], Labels, FuncName, [Expr|Exprs]) :-
     wam_elixir_lower_instr(Instr, PC, Labels, FuncName, Expr),
     lower_instr_list(Rest, Labels, FuncName, Exprs).
+
+% ============================================================================
+% TIER-2 SUPER-WRAPPER EMITTER
+% ============================================================================
+%
+% `par_wrap_segment/4` is the emitter-side analogue of Haskell\'s
+% `parWrapSegment` (purity_certificate Phase P4). It replaces the
+% sequential clause-chain entry point with a `cond`-based super-wrapper
+% that:
+%
+%   - checks `in_forkable_aggregate_frame?/1` — outside a forkable
+%     aggregate (findall / aggregate_all), falls back to sequential;
+%   - checks `parallel_depth > 0` — nested forks suppressed, fall back;
+%   - otherwise pins the cut barrier, increments parallel_depth, fans
+%     out via `Task.async_stream` with a per-branch try/catch so CPS
+%     throws convert to return values (see
+%     `examples/debug_tier2_async_stream_throw_catch.exs` — naked throws
+%     crash the parent process on any BEAM node, not just termux), and
+%     hands full-exhaustion branch results to `merge_into_aggregate/2`.
+%
+% Three static gates at Prolog level:
+%   1. `intra_query_parallel(false)` option absent — runtime kill-switch.
+%   2. `tier2_purity_eligible/3` succeeds (purity ≥ 0.85, verdict pure).
+%   3. Segment count ≥ 3 — matches Haskell\'s `forkMinBranches`.
+%
+% Live wiring (rename existing clause funcs to `*_impl` suffix, emit
+% `clause_main_sequential` orchestrator, route callers through the
+% super-wrapper) is a follow-on PR. This predicate is exported + tested
+% but not yet called from `lower_predicate_to_elixir/4`.
+
+%% par_wrap_segment(+Pred/Arity, +Segments, +Options, -Code)
+%  On gate-pass: Code is the emitted Elixir super-wrapper. On
+%  gate-reject: Code is the empty string `""` — caller (future wiring
+%  PR) falls back to the existing sequential emission path.
+par_wrap_segment(Pred/Arity, Segments, Options, Code) :-
+    \+ option(intra_query_parallel(false), Options),
+    tier2_purity_eligible(Pred, Arity, _Cert),
+    length(Segments, N), N >= 3,
+    !,
+    maplist([Name-_Instrs, ImplFunc]>>(
+        segment_func_name(Name, BaseFunc),
+        format(string(ImplFunc), '~w_impl', [BaseFunc])
+    ), Segments, BranchImplFuncs),
+    emit_par_tier2_wrapper(BranchImplFuncs, Code).
+par_wrap_segment(_Pred, _Segments, _Options, "").
+
+%% emit_par_tier2_wrapper(+BranchImplFuncs, -Code)
+%  Formats the `cond`-based super-wrapper per the template in
+%  `docs/design/WAM_TIERED_LOWERING.md`. BranchImplFuncs is the list
+%  of per-clause `_impl` function names; the caller delegates to
+%  `clause_main_sequential/1` on gate-miss. Both that sequential
+%  orchestrator and the `_impl` functions are the wiring PR\'s
+%  concern — this predicate emits the super-wrapper shell only.
+emit_par_tier2_wrapper(BranchImplFuncs, Code) :-
+    maplist([F, Ref]>>format(string(Ref), '&~w/1', [F]),
+            BranchImplFuncs, BranchRefs),
+    atomic_list_concat(BranchRefs, ', ', BranchListInner),
+    format(string(Code),
+'  defp clause_main(state) do
+    cond do
+      not WamRuntime.in_forkable_aggregate_frame?(state) ->
+        clause_main_sequential(state)
+
+      Map.get(state, :parallel_depth, 0) > 0 ->
+        clause_main_sequential(state)
+
+      true ->
+        branch_state = %{state |
+          cut_point: state.choice_points,
+          parallel_depth: Map.get(state, :parallel_depth, 0) + 1
+        }
+
+        branches = [~w]
+
+        branch_results =
+          branches
+          |> Task.async_stream(fn branch ->
+               try do
+                 branch.(branch_state)
+               catch
+                 {:fail, _state} -> []
+                 {:return, result} when is_list(result) -> result
+                 {:return, result} -> [result]
+               end
+             end,
+             on_timeout: :kill_task,
+             ordered: false,
+             max_concurrency: System.schedulers_online())
+          |> Enum.flat_map(fn
+            {:ok, solutions} when is_list(solutions) -> solutions
+            _ -> []
+          end)
+
+        WamRuntime.merge_into_aggregate(state, branch_results)
+    end
+  end', [BranchListInner]).
 
 % ============================================================================
 % INSTRUCTION PARSING

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -7,7 +7,7 @@
 :- use_module('../src/unifyweaver/targets/wam_elixir_lowered_emitter',
               [lower_predicate_to_elixir/4, classify_predicate/4,
                extract_facts/3, extract_arg1_index/3,
-               tier2_purity_eligible/3]).
+               tier2_purity_eligible/3, par_wrap_segment/4]).
 % For Tier-2 purity-gate tests — user-annotation producer reads
 % clause_body_analysis:order_independent/1 dynamic facts.
 :- use_module('../src/unifyweaver/core/clause_body_analysis').
@@ -749,6 +749,91 @@ test_tier2_purity_gate_accepts_declared :-
         retract(clause_body_analysis:order_independent(user:tier2_test_pred/2))
     ).
 
+%% par_wrap_segment/4 tests — exercise the three static gates (purity,
+%% clause count, kill-switch) plus the shape of the emitted super-wrapper.
+
+three_segment_fixture([
+    'clause_start'-[1-try_me_else(l_b), 2-proceed],
+    'l_b'-[3-retry_me_else(l_c), 4-proceed],
+    'l_c'-[5-trust_me, 6-proceed]
+]).
+
+two_segment_fixture([
+    'clause_start'-[1-try_me_else(l_b), 2-proceed],
+    'l_b'-[3-trust_me, 4-proceed]
+]).
+
+test_par_wrap_segment_emits_super_wrapper :-
+    Test = 'Tier-2 wrapper: 3-clause declared-pure predicate emits cond-based super-wrapper',
+    setup_call_cleanup(
+        assertz(clause_body_analysis:order_independent(user:tier2_pure3/2)),
+        (   three_segment_fixture(Segs),
+            par_wrap_segment(tier2_pure3/2, Segs, [], Code),
+            Code \= "",
+            sub_string(Code, _, _, _, 'defp clause_main(state) do'),
+            sub_string(Code, _, _, _, 'not WamRuntime.in_forkable_aggregate_frame?(state)'),
+            sub_string(Code, _, _, _, 'Map.get(state, :parallel_depth, 0) > 0'),
+            sub_string(Code, _, _, _, 'cut_point: state.choice_points'),
+            sub_string(Code, _, _, _, 'Task.async_stream'),
+            sub_string(Code, _, _, _, 'try do'),
+            sub_string(Code, _, _, _, '{:fail, _state} -> []'),
+            sub_string(Code, _, _, _, 'WamRuntime.merge_into_aggregate(state, branch_results)')
+        ->  pass(Test)
+        ;   fail_test(Test, 'super-wrapper shape missing')
+        ),
+        retract(clause_body_analysis:order_independent(user:tier2_pure3/2))
+    ).
+
+test_par_wrap_segment_references_all_branches :-
+    Test = 'Tier-2 wrapper: branch list references every clause _impl function',
+    setup_call_cleanup(
+        assertz(clause_body_analysis:order_independent(user:tier2_pure3/2)),
+        (   three_segment_fixture(Segs),
+            par_wrap_segment(tier2_pure3/2, Segs, [], Code),
+            sub_string(Code, _, _, _, '&clause_ClauseStart_impl/1'),
+            sub_string(Code, _, _, _, '&clause_LB_impl/1'),
+            sub_string(Code, _, _, _, '&clause_LC_impl/1')
+        ->  pass(Test)
+        ;   fail_test(Test, 'branch list does not reference all three clause _impl functions')
+        ),
+        retract(clause_body_analysis:order_independent(user:tier2_pure3/2))
+    ).
+
+test_par_wrap_segment_rejects_two_clauses :-
+    Test = 'Tier-2 wrapper: 2-clause predicate falls through (clause-count gate)',
+    setup_call_cleanup(
+        assertz(clause_body_analysis:order_independent(user:tier2_pure2/2)),
+        (   two_segment_fixture(Segs),
+            par_wrap_segment(tier2_pure2/2, Segs, [], Code),
+            Code == ""
+        ->  pass(Test)
+        ;   fail_test(Test, 'clause-count gate did not reject 2-clause predicate')
+        ),
+        retract(clause_body_analysis:order_independent(user:tier2_pure2/2))
+    ).
+
+test_par_wrap_segment_rejects_impure :-
+    Test = 'Tier-2 wrapper: impure predicate falls through (no certificate)',
+    three_segment_fixture(Segs),
+    par_wrap_segment(no_such_pred/2, Segs, [], Code),
+    (   Code == ""
+    ->  pass(Test)
+    ;   fail_test(Test, 'purity gate did not reject unknown predicate')
+    ).
+
+test_par_wrap_segment_kill_switch :-
+    Test = 'Tier-2 wrapper: intra_query_parallel(false) option forces fall-through',
+    setup_call_cleanup(
+        assertz(clause_body_analysis:order_independent(user:tier2_pure3/2)),
+        (   three_segment_fixture(Segs),
+            par_wrap_segment(tier2_pure3/2, Segs, [intra_query_parallel(false)], Code),
+            Code == ""
+        ->  pass(Test)
+        ;   fail_test(Test, 'kill-switch did not force fall-through')
+        ),
+        retract(clause_body_analysis:order_independent(user:tier2_pure3/2))
+    ).
+
 %% Test runner
 
 run_tests :-
@@ -811,5 +896,10 @@ run_tests :-
     test_tier2_aggregate_forkable_types,
     test_tier2_purity_gate_rejects_unknown,
     test_tier2_purity_gate_accepts_declared,
+    test_par_wrap_segment_emits_super_wrapper,
+    test_par_wrap_segment_references_all_branches,
+    test_par_wrap_segment_rejects_two_clauses,
+    test_par_wrap_segment_rejects_impure,
+    test_par_wrap_segment_kill_switch,
     format('~n=== WAM-Elixir Target Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).


### PR DESCRIPTION
## Summary

Second PR of the Elixir Tier-2 landing arc. Adds `par_wrap_segment/4`
— the emitter-side analogue of Haskell's `parWrapSegment` — that
emits the `cond`-based `Task.async_stream` super-wrapper per the
(corrected) template in `docs/design/WAM_TIERED_LOWERING.md`. Lands
as dead code: exported + tested, but not wired into
`lower_predicate_to_elixir/4`. Live wiring is a follow-on PR.

## What this PR adds

### `par_wrap_segment(+Pred/Arity, +Segments, +Options, -Code)`

Three static gates:

1. `intra_query_parallel(false)` option absent (runtime kill-switch).
2. `tier2_purity_eligible/3` succeeds — purity certificate verdict
   `pure` with confidence ≥ 0.85 (from PR #1586).
3. `length(Segments) >= 3` — matches Haskell's `forkMinBranches`.

On pass, emits the super-wrapper with:
- Aggregate-frame gate (`in_forkable_aggregate_frame?/1`).
- `parallel_depth > 0` nested-fork suppression.
- Cut-barrier pinning (`cut_point: state.choice_points`).
- `parallel_depth` increment.
- Per-branch try/catch inside `Task.async_stream` — converts CPS
  `{:fail, _}` to `[]` and `{:return, r}` to `[r]` / `r`. This is
  load-bearing; naked throws crash the parent on any BEAM node
  (verified in PR #1607 probe — general behaviour, not termux-specific).
- Full-exhaustion collection via `Enum.flat_map`.
- Hand-off to `WamRuntime.merge_into_aggregate/2`.

On gate-reject, returns `""` so the caller can fall through to the
existing sequential emission.

### Tests

5 new tests in `tests/test_wam_elixir_target.pl`:

- Super-wrapper shape: `defp clause_main` + aggregate-frame check +
  `parallel_depth` check + `cut_point` pin + `Task.async_stream` +
  per-branch `try/catch` + `{:fail, _state} -> []` + `merge_into_aggregate`.
- Branch list references every clause `_impl` function.
- 2-clause predicate falls through (clause-count gate).
- Impure predicate falls through (no certificate).
- Kill-switch `intra_query_parallel(false)` forces fall-through.

## Test results

- `tests/test_wam_elixir_target.pl`: **63 pass, 0 fail** (was 58).
- No regressions in utils tests or the async_stream probe.

## Not in this PR (deliberate)

- **Live wiring.** `lower_predicate_to_elixir/4` does not call
  `par_wrap_segment/4` yet. Wiring requires renaming existing clause
  funcs to `*_impl` suffix, emitting `clause_main_sequential/1` as
  the sequential orchestrator, and routing callers through the super-
  wrapper. That's a follow-on PR.
- **findall/bagof/aggregate_all emission.** Nothing pushes the
  aggregate-frame marker yet, so even once the super-wrapper is live,
  Tier 2 only fires for direct-aggregate callers. Producer side lands
  in a separate PR.
- **Measurement-driven threshold tuning.** `forkMinBranches = 3` is
  hardcoded to match Haskell; tuning is desktop-follow-up scope.

## References

- `docs/design/WAM_TIERED_LOWERING.md` (PR #1607 — aggregate-frame
  precondition + corrected emission template).
- `examples/debug_tier2_async_stream_throw_catch.exs` (PR #1607 —
  per-branch try/catch requirement).
- PR #1586 — Tier-2 infrastructure (purity gate, aggregate helpers,
  `parallel_depth` field) consumed by this PR.
- Haskell Phase P4 (`PURITY_CERTIFICATE_IMPLEMENTATION_PLAN.md`) —
  reference implementation this translates.
