### PR TITLE
feat(preprocess): add shared artifact metadata seam

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -588,3 +588,38 @@ This does not change runtime behavior. It makes the generated data
 layout explicit enough for desktop benchmarking, artifact invalidation
 work, and later provider-style loaders without forcing another change to
 the benchmark target names.
+
+The next follow-up starts lifting those Clojure benchmark storage-policy
+knobs into shared infrastructure. A new
+`src/unifyweaver/core/predicate_preprocessing.pl` layer now normalizes
+source-level `preprocess/2` declarations onto the same small storage
+surface used by the benchmark generator: `artifact`, `sidecar`, and
+`inline`.
+
+The Clojure effective-distance generator now consumes that shared
+declaration layer in addition to its existing benchmark-local predicates:
+
+- benchmark-local relation overrides still win first
+- shared `preprocess/2` declarations are the next policy source
+- generator defaults remain the final fallback
+
+That is a better match for the C# and Haskell direction than adding more
+one-off benchmark predicates. It turns the current Clojure artifact and
+sidecar work into a reusable seam for later cross-target preprocessing
+and artifact-provider work, while keeping the current benchmark
+interface stable.
+
+The next small extension makes that seam inspectable instead of only
+actionable. The shared preprocessing module now exposes normalized
+metadata for a declaration:
+
+- originating declaration kind
+- normalized physical format
+- normalized access contracts
+- preserved declaration options
+
+The Clojure benchmark manifest now includes that metadata whenever a
+relation's resolved mode came from the shared `preprocess/2` layer. That
+brings the current Clojure path closer to the C# provider/materializer
+shape: generated artifacts now carry both the chosen storage mode and
+the declaration intent that selected it.

--- a/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
+++ b/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
@@ -100,6 +100,44 @@ The proposed boundary has three layers:
    distance metadata. Approximate artifacts must not masquerade as exact
    relation providers.
 
+   For exact artifacts, the target-neutral manifest seam should also preserve
+   the declaration intent that selected the physical layout. The current
+   Clojure benchmark path is the first proving ground for this narrower schema:
+
+   ```json
+   {
+     "predicate": "article_category/2",
+     "resolved_mode": "artifact",
+     "file_format": "grouped_tsv_arg1",
+     "access": ["scan", "arg1_grouped_lookup"],
+     "declaration": {
+       "source": "shared_preprocess",
+       "mode": "artifact",
+       "kind": "exact_hash_index",
+       "format": "exact_hash_index",
+       "access_contracts": [
+         "exact_key_lookup",
+         "arg_position_lookup(1)",
+         "grouped_values_lookup([2])",
+         "scan"
+       ],
+       "options": ["key([1])", "values([2])"]
+     }
+   }
+   ```
+
+   Not every runtime needs to emit the exact same file names or storage
+   encodings. The important cross-target seam is:
+
+   - resolved storage mode
+   - physical format
+   - supported runtime access contracts
+   - originating preprocess declaration kind/options
+   - source and schema invalidation metadata
+
+   That is enough for a planner or provider to explain both what artifact was
+   chosen and why it was considered semantically valid.
+
 3. Runtime access layer
 
    The runtime opens artifacts through a narrow provider interface and asks for
@@ -324,6 +362,44 @@ implementation:
 
 The exact syntax is intentionally open. The important fields are predicate,
 access pattern, exactness, invalidation inputs, and fallback.
+
+## Shared Manifest Schema Notes
+
+The current C# prototype and the current Clojure benchmark generator are using
+different concrete manifest encodings, but they are already converging on the
+same logical fields. A small shared schema should standardize the metadata
+shape before attempting a common binary format:
+
+- `predicate`
+- `resolved_mode`
+- `artifact_kind` or declaration `kind`
+- `format_version`
+- `physical_format`
+- `exactness`
+- `source_hash`
+- `schema_hash`
+- `target_capabilities`
+- `access`
+- `declaration`
+  - `source`
+  - `mode`
+  - `kind`
+  - `format`
+  - `access_contracts`
+  - `options`
+- `files`
+
+This should stay intentionally target-neutral:
+
+- C# may keep JSON and binary sidecars.
+- Clojure may keep EDN manifests with TSV or EDN sidecars.
+- Haskell may eventually pair this with LMDB, mmap, or FactSource-backed
+  providers.
+- Elixir `external_source` can consume the same declaration metadata even if
+  the first runtime adaptor is TSV, ETS, or SQLite.
+
+The shared declaration layer should therefore stabilize before the physical
+artifact formats do.
 
 ## Build And Invalidation Lifecycle
 

--- a/docs/proposals/WAM_HASKELL_FACT_ACCESS_PHILOSOPHY.md
+++ b/docs/proposals/WAM_HASKELL_FACT_ACCESS_PHILOSOPHY.md
@@ -231,6 +231,16 @@ SQLite isn't good at multi-process access means the materialization
 planner must account for concurrency when choosing a layout — not just
 access pattern and scale.
 
+The current Clojure benchmark artifact manifest work is also useful
+here. It is the first local implementation that records both resolved
+storage mode and the originating shared preprocess declaration metadata.
+That is the right seam for Haskell and Elixir too: parallelism planning
+should not only know that a predicate is "external", but whether the
+chosen artifact advertises scan-only access, arg1 lookup, grouped
+adjacency, or some stronger exact-key contract, and whether that
+contract came from a declaration that remains valid for the current
+runtime environment.
+
 **The feedback loop:**
 
 ```

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -163,12 +163,31 @@ These are applied on top of `artifact` mode so a workload can, for
 example, keep `category_parent` on the grouped artifact path while
 forcing `article_category` back to row sidecars, or vice versa.
 
+The generator also now honors the shared predicate-preprocessing
+declaration surface from
+`src/unifyweaver/core/predicate_preprocessing.pl`. For the current
+Clojure benchmark relations, declarations such as:
+
+- `preprocess(article_category/2, exact_hash_index([key([1]), values([2])])).`
+- `preprocess(category_parent/2, relation_rows([format(tsv_grouped)])).`
+
+are normalized onto the same `artifact` / `sidecar` / `inline` storage
+choices used by the benchmark-specific predicates. The current
+precedence is:
+
+1. benchmark-specific relation overrides
+2. shared `preprocess/2` declarations
+3. generator defaults for the selected top-level benchmark mode
+
 Sidecar-backed modes also emit
 `data/generated/wam_clojure_optimized_bench/manifest.edn`. The manifest
 records the resolved top-level mode, per-relation storage policy, file
-format, row counts, and access contracts. It is intentionally small and
-EDN-readable so desktop validation can inspect the generated data layout
-without parsing generated Clojure source.
+format, row counts, and access contracts. When a relation mode came from
+the shared `preprocess/2` layer, the manifest also records the
+originating declaration shape (`kind`, serialized `options`, normalized
+`format`, and normalized `access_contracts`). It is intentionally small
+and EDN-readable so desktop validation can inspect the generated data
+layout without parsing generated Clojure source.
 
 The generated project supports two entry modes:
 

--- a/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
@@ -14,6 +14,9 @@
 
 :- use_module('../../src/unifyweaver/targets/wam_clojure_target').
 :- use_module('../../src/unifyweaver/targets/prolog_target').
+:- use_module('../../src/unifyweaver/core/predicate_preprocessing',
+              [declared_preprocess/3,
+               declared_preprocess_metadata/4]).
 :- use_module(library(filesex), [directory_file_path/3, make_directory_path/1]).
 :- discontiguous benchmark_article_category_by_article_artifact/1.
 :- discontiguous benchmark_category_parent_by_child_artifact/1.
@@ -465,8 +468,14 @@ benchmark_effective_relation_mode(Relation, DefaultMode, Mode) :-
     (   benchmark_relation_declared_data_mode(Relation, DeclaredMode),
         DeclaredMode \== auto
     ->  Mode = DeclaredMode
+    ;   benchmark_relation_predicate(Relation, PredIndicator),
+        declared_preprocess(PredIndicator, DeclaredMode, _Info)
+    ->  Mode = DeclaredMode
     ;   Mode = DefaultMode
     ).
+
+benchmark_relation_predicate(article_category, article_category/2).
+benchmark_relation_predicate(category_parent, category_parent/2).
 
 benchmark_derived_state_code(artifact, artifact, Code) :-
     Code = '(def benchmark-seed-categories-delay
@@ -622,14 +631,55 @@ benchmark_artifact_manifest(FactsPath, VariantAtom, KernelModeAtom, DataMode, Ma
 
 relation_manifest_entry(Relation, Mode, RowCount, Entry) :-
     relation_manifest_shape(Relation, Mode, FileName, Format, Access),
+    relation_manifest_preprocess_decl(Relation, DeclDecl),
     clj_string_literal_local(Relation, RelationLit),
     clj_string_literal_local(Mode, ModeLit),
     clj_string_literal_local(FileName, FileNameLit),
     clj_string_literal_local(Format, FormatLit),
     clj_string_literal_local(Access, AccessLit),
+    preprocess_decl_field(DeclDecl, DeclField),
     format(atom(Entry),
-           '~w {:mode ~w :file ~w :format ~w :row_count ~w :access ~w}',
-           [RelationLit, ModeLit, FileNameLit, FormatLit, RowCount, AccessLit]).
+           '~w {:mode ~w :file ~w :format ~w :row_count ~w :access ~w~w}',
+           [RelationLit, ModeLit, FileNameLit, FormatLit, RowCount, AccessLit, DeclField]).
+
+relation_manifest_preprocess_decl(Relation, Decl) :-
+    benchmark_relation_predicate(Relation, PredIndicator),
+    declared_preprocess_metadata(PredIndicator, Mode,
+                                 preprocess_info(Kind, Options),
+                                 Metadata),
+    !,
+    Decl = preprocess_decl(Mode, Kind, Options, Metadata).
+relation_manifest_preprocess_decl(_Relation, none).
+
+preprocess_decl_field(none, '').
+preprocess_decl_field(preprocess_decl(Mode, Kind, Options, Metadata), Field) :-
+    clj_string_literal_local(shared_preprocess, SourceLit),
+    clj_string_literal_local(Mode, ModeLit),
+    clj_string_literal_local(Kind, KindLit),
+    metadata_format_literal(Metadata, FormatLit),
+    metadata_access_contracts_literal(Metadata, AccessLit),
+    preprocess_options_literal(Options, OptionsLit),
+    format(atom(Field),
+           ' :declaration {:source ~w :mode ~w :kind ~w :format ~w :access_contracts ~w :options ~w}',
+           [SourceLit, ModeLit, KindLit, FormatLit, AccessLit, OptionsLit]).
+
+metadata_format_literal(Metadata, Literal) :-
+    clj_string_literal_local(Metadata.format, Literal).
+
+metadata_access_contracts_literal(Metadata, Literal) :-
+    maplist(term_string, Metadata.access_contracts, AccessStrings0),
+    sort(AccessStrings0, AccessStrings),
+    maplist(atom_string, AccessAtoms, AccessStrings),
+    maplist(clj_string_literal_local, AccessAtoms, AccessLiterals),
+    atomic_list_concat(AccessLiterals, ' ', AccessBody),
+    format(atom(Literal), '[~w]', [AccessBody]).
+
+preprocess_options_literal(Options, Literal) :-
+    maplist(term_string, Options, OptionStrings0),
+    maplist(atom_string, OptionAtoms, OptionStrings0),
+    maplist(clj_string_literal_local, OptionAtoms, OptionLiterals),
+    atomic_list_concat(OptionLiterals, ' ', OptionBody),
+    format(atom(Literal), '[~w]', [OptionBody]).
 
 relation_manifest_shape(article_category, artifact,
                         'article_category_by_article.tsv',

--- a/src/unifyweaver/core/predicate_preprocessing.pl
+++ b/src/unifyweaver/core/predicate_preprocessing.pl
@@ -1,0 +1,140 @@
+:- module(predicate_preprocessing, [
+    declared_preprocess/3,          % +PredIndicator, -Mode, -Info
+    declared_preprocess_metadata/4, % +PredIndicator, -Mode, -Info, -Metadata
+    preprocess_mode/2,              % +Spec, -Mode
+    preprocess_metadata/3           % +Spec, -Mode, -Metadata
+]).
+
+:- use_module(library(lists), [memberchk/2]).
+
+%% predicate_preprocessing.pl
+%%
+%% Shared preprocessing declaration surface for targets that want to
+%% consume source-level artifact/materialization intent without hardcoding
+%% benchmark-local predicates.
+%%
+%% Supported declaration shapes (all via user:preprocess/2):
+%%
+%%   preprocess(edge/2, artifact).
+%%   preprocess(edge/2, artifact([format(grouped_tsv_arg1)])).
+%%   preprocess(edge/2, exact_hash_index([key([1]), values([2])])).
+%%   preprocess(edge/2, adjacency_index([key([1]), values([2])])).
+%%   preprocess(edge/2, relation_rows([format(edn_rows)])).
+%%   preprocess(edge/2, inline_data([])).
+%%
+%% The normalised Mode is intentionally small for now:
+%%   artifact | sidecar | inline
+%%
+%% Info preserves the original kind/options so target-specific code can
+%% grow into richer providers later.
+
+declared_preprocess(PredIndicator, Mode, preprocess_info(Kind, Options)) :-
+    current_predicate(user:preprocess/2),
+    preprocess_lookup(PredIndicator, Spec),
+    normalize_preprocess_spec(Spec, Kind, Mode, Options),
+    !.
+
+declared_preprocess_metadata(PredIndicator, Mode, Info, Metadata) :-
+    declared_preprocess(PredIndicator, Mode, Info),
+    Info = preprocess_info(Kind, Options),
+    metadata_for_preprocess(Kind, Options, Metadata).
+
+preprocess_mode(Spec, Mode) :-
+    normalize_preprocess_spec(Spec, _Kind, Mode, _Options).
+
+preprocess_metadata(Spec, Mode, Metadata) :-
+    normalize_preprocess_spec(Spec, Kind, Mode, Options),
+    metadata_for_preprocess(Kind, Options, Metadata).
+
+preprocess_lookup(Module:Pred/Arity, Spec) :-
+    !,
+    (   call(user:preprocess(Module:Pred/Arity, Spec))
+    ;   call(user:preprocess(Pred/Arity, Spec))
+    ).
+preprocess_lookup(Pred/Arity, Spec) :-
+    call(user:preprocess(Pred/Arity, Spec)).
+
+normalize_preprocess_spec(artifact, artifact, artifact, []) :- !.
+normalize_preprocess_spec(artifact(Options), artifact, artifact, Options) :- !.
+normalize_preprocess_spec(exact_hash_index(Options), exact_hash_index, artifact, Options) :- !.
+normalize_preprocess_spec(adjacency_index(Options), adjacency_index, artifact, Options) :- !.
+normalize_preprocess_spec(grouped_tsv(Options), grouped_tsv, artifact, Options) :- !.
+normalize_preprocess_spec(relation_rows, relation_rows, sidecar, []) :- !.
+normalize_preprocess_spec(relation_rows(Options), relation_rows, sidecar, Options) :- !.
+normalize_preprocess_spec(sidecar, sidecar, sidecar, []) :- !.
+normalize_preprocess_spec(sidecar(Options), sidecar, sidecar, Options) :- !.
+normalize_preprocess_spec(inline_data, inline_data, inline, []) :- !.
+normalize_preprocess_spec(inline_data(Options), inline_data, inline, Options) :- !.
+normalize_preprocess_spec(inline, inline, inline, []) :- !.
+normalize_preprocess_spec(inline(Options), inline, inline, Options) :- !.
+normalize_preprocess_spec(benchmark_mode(Mode), benchmark_mode, Mode, []) :-
+    valid_mode(Mode),
+    !.
+normalize_preprocess_spec(benchmark_mode(Mode, Options), benchmark_mode, Mode, Options) :-
+    valid_mode(Mode),
+    !.
+
+valid_mode(Mode) :-
+    memberchk(Mode, [artifact, sidecar, inline]).
+
+metadata_for_preprocess(Kind, Options,
+                        preprocess_metadata{
+                            kind: Kind,
+                            format: Format,
+                            access_contracts: AccessContracts,
+                            options: Options
+                        }) :-
+    preprocess_format(Kind, Options, Format),
+    preprocess_access_contracts(Kind, Options, AccessContracts).
+
+preprocess_format(_Kind, Options, Format) :-
+    memberchk(format(Format), Options),
+    !.
+preprocess_format(artifact, _Options, artifact).
+preprocess_format(exact_hash_index, _Options, exact_hash_index).
+preprocess_format(adjacency_index, _Options, adjacency_index).
+preprocess_format(grouped_tsv, _Options, grouped_tsv).
+preprocess_format(relation_rows, _Options, relation_rows).
+preprocess_format(sidecar, _Options, sidecar).
+preprocess_format(inline_data, _Options, inline_data).
+preprocess_format(inline, _Options, inline).
+preprocess_format(benchmark_mode, _Options, benchmark_mode).
+
+preprocess_access_contracts(_Kind, Options, AccessContracts) :-
+    memberchk(access(Declared), Options),
+    !,
+    sort(Declared, AccessContracts).
+preprocess_access_contracts(exact_hash_index, Options, AccessContracts) :-
+    !,
+    preprocess_index_access_contracts(Options,
+                                      [exact_key_lookup, scan],
+                                      AccessContracts).
+preprocess_access_contracts(adjacency_index, Options, AccessContracts) :-
+    !,
+    preprocess_index_access_contracts(Options,
+                                      [adjacency_lookup, scan],
+                                      AccessContracts).
+preprocess_access_contracts(grouped_tsv, Options, AccessContracts) :-
+    !,
+    preprocess_index_access_contracts(Options,
+                                      [grouped_lookup, scan],
+                                      AccessContracts).
+preprocess_access_contracts(relation_rows, _Options, [scan]).
+preprocess_access_contracts(sidecar, _Options, [scan]).
+preprocess_access_contracts(inline_data, _Options, [scan]).
+preprocess_access_contracts(inline, _Options, [scan]).
+preprocess_access_contracts(artifact, _Options, [scan]).
+preprocess_access_contracts(benchmark_mode, _Options, [scan]).
+
+preprocess_index_access_contracts(Options, Base, AccessContracts) :-
+    findall(Contract,
+            preprocess_option_access_contract(Options, Contract),
+            OptionContracts0),
+    append(Base, OptionContracts0, Contracts0),
+    sort(Contracts0, AccessContracts).
+
+preprocess_option_access_contract(Options, arg_position_lookup(Arg)) :-
+    memberchk(key(Keys), Options),
+    member(Arg, Keys).
+preprocess_option_access_contract(Options, grouped_values_lookup(Args)) :-
+    memberchk(values(Args), Options).

--- a/tests/core/test_predicate_preprocessing.pl
+++ b/tests/core/test_predicate_preprocessing.pl
@@ -1,0 +1,52 @@
+:- use_module(library(plunit)).
+:- use_module('../../src/unifyweaver/core/predicate_preprocessing').
+
+:- begin_tests(predicate_preprocessing).
+
+test(preprocess_mode_normalization) :-
+    preprocess_mode(artifact, artifact),
+    preprocess_mode(artifact([format(grouped_tsv_arg1)]), artifact),
+    preprocess_mode(exact_hash_index([key([1])]), artifact),
+    preprocess_mode(adjacency_index([access([adjacency])]), artifact),
+    preprocess_mode(relation_rows([format(edn_rows)]), sidecar),
+    preprocess_mode(inline_data([]), inline),
+    preprocess_mode(benchmark_mode(sidecar), sidecar).
+
+test(shared_declaration_lookup) :-
+    setup_call_cleanup(
+        assertz(user:preprocess(article_category/2, exact_hash_index([key([1]), values([2])]))),
+        ( declared_preprocess(article_category/2, Mode, preprocess_info(Kind, Options)),
+          assertion(Mode == artifact),
+          assertion(Kind == exact_hash_index),
+          assertion(member(key([1]), Options)),
+          assertion(member(values([2]), Options))
+        ),
+        maybe_abolish_test_predicate(preprocess/2)
+    ).
+
+test(shared_declaration_metadata) :-
+    setup_call_cleanup(
+        assertz(user:preprocess(category_parent/2,
+                                exact_hash_index([key([1]), values([2])]))),
+        ( declared_preprocess_metadata(category_parent/2, Mode,
+                                       preprocess_info(Kind, Options),
+                                       Metadata),
+          assertion(Mode == artifact),
+          assertion(Kind == exact_hash_index),
+          assertion(member(key([1]), Options)),
+          assertion(member(values([2]), Options)),
+          assertion(Metadata.format == exact_hash_index),
+          assertion(member(exact_key_lookup, Metadata.access_contracts)),
+          assertion(member(arg_position_lookup(1), Metadata.access_contracts)),
+          assertion(member(grouped_values_lookup([2]), Metadata.access_contracts))
+        ),
+        maybe_abolish_test_predicate(preprocess/2)
+    ).
+
+:- end_tests(predicate_preprocessing).
+
+maybe_abolish_test_predicate(Name/Arity) :-
+    (   current_predicate(user:Name/Arity)
+    ->  abolish(user:Name/Arity)
+    ;   true
+    ).

--- a/tests/test_wam_clojure_benchmark_generator.pl
+++ b/tests/test_wam_clojure_benchmark_generator.pl
@@ -76,6 +76,31 @@ test(relation_data_mode_override_accumulated_parent_sidecar) :-
         maybe_abolish_test_predicate(wam_clojure_benchmark_relation_data_mode/2)
     ).
 
+test(shared_preprocess_override_seeded_article_artifact) :-
+    setup_call_cleanup(
+        ( load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
+          assertz(user:preprocess(article_category/2,
+                                  exact_hash_index([key([1]), values([2])])))
+        ),
+        once((
+            unique_tmp_dir('tmp_wam_clojure_bench_shared_pre', TmpDir),
+            generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, artifact),
+            directory_file_path(TmpDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
+            directory_file_path(TmpDir, 'data/generated/wam_clojure_optimized_bench/manifest.edn', ManifestPath),
+            read_file_to_string(CorePath, CoreCode, []),
+            read_file_to_string(ManifestPath, Manifest, []),
+            assertion(sub_string(CoreCode, _, _, _, 'article_category_by_article.tsv')),
+            assertion(\+ sub_string(CoreCode, _, _, _, '(def benchmark-article-categories-delay')),
+            assertion(sub_string(Manifest, _, _, _, '"article_category" {:mode "artifact"')),
+            assertion(sub_string(Manifest, _, _, _, ':declaration {:source "shared_preprocess"')),
+            assertion(sub_string(Manifest, _, _, _, ':kind "exact_hash_index"')),
+            assertion(sub_string(Manifest, _, _, _, ':access_contracts ["arg_position_lookup(1)" "exact_key_lookup" "grouped_values_lookup([2])" "scan"]')),
+            assertion(sub_string(Manifest, _, _, _, ':options ["key([1])" "values([2])"]')),
+            delete_directory_and_contents(TmpDir)
+        )),
+        maybe_abolish_test_predicate(preprocess/2)
+    ).
+
 test(collect_seeded_predicates) :-
     collect_wam_predicates(seeded, Predicates),
     assertion(member(user:dimension_n/1, Predicates)),
@@ -107,6 +132,7 @@ test(generate_seeded_kernels_on_project) :-
         assertion(sub_string(Manifest, _, _, _, ':data_mode "sidecar"')),
         assertion(sub_string(Manifest, _, _, _, '"category_parent" {:mode "sidecar"')),
         assertion(sub_string(Manifest, _, _, _, ':row_count')),
+        assertion(\+ sub_string(Manifest, _, _, _, ':declaration {:source "shared_preprocess"')),
         assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_parent" :arity 2}')),
         assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_ancestor" :arity 4}')),
         assertion(sub_string(CoreCode, _, _, _, '(def benchmark-use-traversal-kernel? true)')),


### PR DESCRIPTION
## Summary

Adds a shared predicate-preprocessing metadata layer and threads it into the
Clojure benchmark artifact manifest so preprocess declarations now carry both:

- the resolved storage mode used by a target
- the originating declaration intent that selected that mode

This turns the recent Clojure artifact work into a reusable cross-target seam
instead of another benchmark-local policy hook.

## What Changed

- added `src/unifyweaver/core/predicate_preprocessing.pl`
  - normalizes `preprocess/2` declarations onto `artifact | sidecar | inline`
  - exposes normalized metadata for declaration kind, format, access contracts,
    and preserved options
- added `tests/core/test_predicate_preprocessing.pl`
  - covers normalization
  - covers shared declaration lookup
  - covers normalized metadata extraction
- updated the Clojure effective-distance benchmark generator
  - benchmark relation mode resolution now checks:
    1. benchmark-specific relation overrides
    2. shared `preprocess/2` declarations
    3. generator defaults
  - manifest output now records shared preprocess declaration metadata when it
    is the source of a resolved relation mode
- updated Clojure benchmark generator tests to verify:
  - shared `preprocess/2` declarations drive artifact selection
  - manifest output includes shared declaration metadata
- updated docs:
  - benchmark README
  - WAM perf optimization log
  - preprocessed predicate artifacts proposal
  - Haskell fact-access/materialization philosophy note

## Why

The current C# and Haskell directions already depend on a clean separation
between:

- physical artifact format
- runtime access contract
- materialization/planner policy

This PR establishes the first shared source-level seam for that split.

For the current Clojure benchmark path, the manifest can now explain not just
that a relation ended up in `artifact` mode, but also:

- which preprocess declaration kind selected it
- what normalized access contracts it implies
- which declaration options were preserved

That is a better foundation for later Elixir `external_source`, Haskell
FactSource / mmap work, and eventual cross-target artifact-provider planning.

## Verification

- `swipl -q -g run_tests -t halt tests/core/test_predicate_preprocessing.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`
- `git diff --check`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-accumulated,clojure-wam-accumulated-artifact,clojure-wam-seeded,clojure-wam-seeded-artifact,prolog-accumulated --scales dev --repetitions 1`

Small serial Termux smoke still matched digest `1659619c9d36` across all
tested Clojure WAM and optimized Prolog variants.

## Notes

- this does not attempt to standardize a single cross-target artifact file
  format yet
- it standardizes the declaration and manifest seam first, which is the safer
  boundary to share before desktop validation and broader provider work
