### PR TITLE
test(wam-elixir): discharge Tier-2 wiring prerequisite 1 — switch-arm segment coverage

### DIFF
--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -821,6 +821,74 @@ test_par_wrap_segment_rejects_impure :-
     ;   fail_test(Test, 'purity gate did not reject unknown predicate')
     ).
 
+%% switch_arm_targets(+Instrs, -Targets)
+%  Extract the non-default arm targets from the first segment's
+%  switch_on_constant instruction. Used by the switch-arm coverage
+%  test to confirm every switch target corresponds to a segment in
+%  the Segments list — the invariant par_wrap_segment/4 relies on
+%  to fan out all clause alternatives when first-arg indexing is
+%  present.
+%
+%  Each arm is represented as a string "Key:Target" (not a compound
+%  term), so splitting on ":" is required to extract the target.
+switch_arm_targets(Instrs, Targets) :-
+    member(_PC-switch_on_constant(Arms), Instrs),
+    !,
+    findall(TargetStr,
+            (  member(Arm, Arms),
+               split_string(Arm, ":", "", [_KeyStr, TargetStr]),
+               TargetStr \= "default"
+            ),
+            Targets).
+switch_arm_targets(_, []).
+
+test_switch_arm_targets_are_segments :-
+    Test = 'Tier-2 wrapper: switch_on_constant arm targets are all named segments (prereq 1)',
+    phase_a_fixture_setup,
+    wam_target:compile_predicate_to_wam(phase_a_test:small_fact/2, [], WamCode),
+    atom_string(WamCode, WamStr),
+    split_string(WamStr, "\n", "", Lines),
+    wam_elixir_lowered_emitter:split_into_segments(Lines, 1, Segments),
+    Segments = [_-FirstInstrs | _],
+    switch_arm_targets(FirstInstrs, ArmTargets),
+    % Turn each segment name into an atom for comparison.
+    findall(Name, member(Name-_, Segments), SegNames),
+    % Every non-default arm target must appear as a segment name.
+    (   ArmTargets \= [],
+        forall(member(T, ArmTargets), memberchk(T, SegNames))
+    ->  pass(Test)
+    ;   format(atom(Reason),
+               'arm targets ~w not all in segment names ~w',
+               [ArmTargets, SegNames]),
+        fail_test(Test, Reason)
+    ).
+
+test_par_wrap_segment_covers_switch_targets :-
+    Test = 'Tier-2 wrapper: emitted branch list references every switch_on_constant target',
+    setup_call_cleanup(
+        assertz(clause_body_analysis:order_independent(user:small_fact/2)),
+        (   phase_a_fixture_setup,
+            wam_target:compile_predicate_to_wam(phase_a_test:small_fact/2, [], WamCode),
+            atom_string(WamCode, WamStr),
+            split_string(WamStr, "\n", "", Lines),
+            wam_elixir_lowered_emitter:split_into_segments(Lines, 1, Segments),
+            Segments = [_-FirstInstrs | _],
+            switch_arm_targets(FirstInstrs, ArmTargets),
+            par_wrap_segment(small_fact/2, Segments, [], Code),
+            Code \= "",
+            % For each switch arm target, confirm the emitted super-wrapper
+            % references &clause_<camelCase(target)>_impl/1.
+            forall(member(Target, ArmTargets),
+                   (  wam_elixir_lowered_emitter:segment_func_name(Target, BaseFunc),
+                      format(string(ImplRef), '&~w_impl/1', [BaseFunc]),
+                      sub_string(Code, _, _, _, ImplRef)
+                   ))
+        ->  pass(Test)
+        ;   fail_test(Test, 'emitted branch list does not cover every switch_on_constant target')
+        ),
+        retract(clause_body_analysis:order_independent(user:small_fact/2))
+    ).
+
 test_par_wrap_segment_kill_switch :-
     Test = 'Tier-2 wrapper: intra_query_parallel(false) option forces fall-through',
     setup_call_cleanup(
@@ -900,6 +968,8 @@ run_tests :-
     test_par_wrap_segment_references_all_branches,
     test_par_wrap_segment_rejects_two_clauses,
     test_par_wrap_segment_rejects_impure,
+    test_switch_arm_targets_are_segments,
+    test_par_wrap_segment_covers_switch_targets,
     test_par_wrap_segment_kill_switch,
     format('~n=== WAM-Elixir Target Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).


### PR DESCRIPTION
## Summary

Adds two tests to confirm the structural invariant Perplexity flagged
in its review of `docs/proposals/WAM_ELIXIR_TIER2_WIRING.md`
(**prerequisite 1** for the wiring PR): when a predicate has
`switch_on_constant`, every non-default arm target appears as a named
segment in the `Segments` list that `par_wrap_segment/4` iterates over.

## Why this matters

The Tier-2 super-wrapper emitted by `par_wrap_segment/4` does:

```prolog
maplist([Name-_Instrs, ImplFunc]>>(
    segment_func_name(Name, BaseFunc),
    format(string(ImplFunc), '~w_impl', [BaseFunc])
), Segments, BranchImplFuncs),
```

It enumerates branches by mapping over `Segments`. If a
`switch_on_constant` opcode could dispatch to a label that is *not*
its own segment (e.g., a label embedded inside a larger segment), that
clause alternative would be invisible to the fan-out and never run in
parallel — silent solution loss. Perplexity flagged this as a
prerequisite to confirm before the wiring PR lands.

## What this PR adds

### `switch_arm_targets/2` helper

Parses the first segment's `switch_on_constant` instruction and
returns the list of non-default arm target labels. Each arm is a
string `"Key:Target"`, so the helper splits on `":"` and filters out
`"default"`.

### `test_switch_arm_targets_are_segments`

Uses the 4-clause `small_fact/2` fixture (which emits
`switch_on_constant` for first-arg indexing). Extracts arm targets;
asserts every one is also the name of a segment in the `Segments`
list. **Passes** — arm targets `[L_small_fact_2_2, L_small_fact_2_3,
L_small_fact_2_4]` are all in segment names `[small_fact/2,
L_small_fact_2_2, L_small_fact_2_3, L_small_fact_2_4]`.

### `test_par_wrap_segment_covers_switch_targets`

Declares `small_fact/2` pure, runs it through `par_wrap_segment/4`,
and confirms the emitted super-wrapper's branch list contains
`&clause_<target>_impl/1` for every switch-arm target. **Passes** —
the emitted code references all three arm targets plus the default
(first segment, `small_fact/2`).

## Test results

- 65 pass, 0 fail (was 63). No regressions.

## Finding

The invariant holds by construction: `split_into_segments/3`
(`wam_elixir_lowered_emitter.pl:636`) creates a new segment at every
label, and `switch_on_constant` arms always target labels. Therefore
every arm target is a segment boundary, and `par_wrap_segment/4`'s
maplist over `Segments` covers every clause that the switch could
dispatch to. **Safe for the wiring PR to proceed.**

The two new tests act as regression guards — if the WAM target or
`split_into_segments` ever changes in a way that breaks this
invariant, these tests catch it.

## Not in this PR

- No emitter code changes.
- No wiring of `par_wrap_segment/4` into `lower_predicate_to_elixir/4`
  yet — that's the next PR, now unblocked by this confirmation.
- Prerequisites 2 (`next_solution/1` integration test via
  `clause_main_sequential`) and 3 (`render_compiled_module/8` Options
  threading) remain for the wiring PR itself.

## References

- `docs/proposals/WAM_ELIXIR_TIER2_WIRING.md` — the proposal this
  discharges a prerequisite for.
- Perplexity review feedback: "First-arg indexing: confirm the
  segment enumeration covers switch-arm targets before merging the
  wiring PR. This is the one item I'd call a prerequisite for the
  wiring PR rather than a follow-up."
