### PR TITLE
bench(wam-rust): add no-kernel effective-distance profiling targets

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -106,13 +106,21 @@ The effective-distance harness also includes WAM-Rust benchmark targets:
   the merged WAM code vector. The measured driver still uses the stable
   Rust-side accumulation path until direct WAM aggregate-helper execution
   has separate runtime coverage.
+- `wam-rust-seeded-no-kernels` and `wam-rust-accumulated-no-kernels`
+  use the same generated WAM code but disable native recursive kernels.
+  These are intended for WAM fallback profiling; `total_steps` and
+  `total_backtracks` should be non-zero when the fallback path is exercised.
+  Use `WAM_SEED_LIMIT=<n>` or `WAM_SEED_FILTER=CatA|CatB` for bounded
+  fallback probes before running full-scale comparisons. Seed-limited runs
+  intentionally produce partial output and should not be used for output
+  completeness comparisons.
 
 Example focused run:
 
 ```bash
 python examples/benchmark/benchmark_effective_distance.py \
   --scales dev \
-  --targets prolog-accumulated,wam-rust-seeded,wam-rust-accumulated \
+  --targets prolog-accumulated,wam-rust-seeded,wam-rust-accumulated,wam-rust-accumulated-no-kernels \
   --repetitions 1
 ```
 

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -113,7 +113,9 @@ The effective-distance harness also includes WAM-Rust benchmark targets:
   Use `WAM_SEED_LIMIT=<n>` or `WAM_SEED_FILTER=CatA|CatB` for bounded
   fallback probes before running full-scale comparisons. Seed-limited runs
   intentionally produce partial output and should not be used for output
-  completeness comparisons.
+  completeness comparisons. These environment variables apply to the entire
+  benchmark invocation; when either is set, no-kernel parity and speedup lines
+  are treated as seed-subset probes rather than full-output comparisons.
 
 Example focused run:
 

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -79,7 +79,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--targets",
         default="csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated",
-        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded,prolog-pruned,prolog-accumulated,prolog-article-accumulated,prolog-root-accumulated,wam-rust-seeded,wam-rust-accumulated",
+        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded,prolog-pruned,prolog-accumulated,prolog-article-accumulated,prolog-root-accumulated,wam-rust-seeded,wam-rust-accumulated,wam-rust-seeded-no-kernels,wam-rust-accumulated-no-kernels",
     )
     parser.add_argument(
         "--repetitions",
@@ -285,6 +285,8 @@ def print_summary(results: list[RunResult]) -> None:
         prolog_root_accumulated = find_result(entries, "prolog-root-accumulated")
         wam_rust_seeded = find_result(entries, "wam-rust-seeded")
         wam_rust_accumulated = find_result(entries, "wam-rust-accumulated")
+        wam_rust_seeded_no_kernels = find_result(entries, "wam-rust-seeded-no-kernels")
+        wam_rust_accumulated_no_kernels = find_result(entries, "wam-rust-accumulated-no-kernels")
         prolog_semantic_min = find_result(entries, "prolog-semantic-min")
         prolog_eff_semantic = find_result(entries, "prolog-eff-semantic")
         dfs_like = [item for item in entries if item.target in {"csharp-dfs", "rust-dfs", "go-dfs"}]
@@ -299,8 +301,12 @@ def print_summary(results: list[RunResult]) -> None:
         print_pair_match_status(scale, "query_vs_prolog_root_accumulated", qe, prolog_root_accumulated)
         print_pair_match_status(scale, "query_vs_wam_rust_seeded", qe, wam_rust_seeded)
         print_pair_match_status(scale, "query_vs_wam_rust_accumulated", qe, wam_rust_accumulated)
+        print_pair_match_status(scale, "query_vs_wam_rust_seeded_no_kernels", qe, wam_rust_seeded_no_kernels)
+        print_pair_match_status(scale, "query_vs_wam_rust_accumulated_no_kernels", qe, wam_rust_accumulated_no_kernels)
         print_pair_match_status(scale, "prolog_vs_wam_rust_seeded", prolog_accumulated, wam_rust_seeded)
         print_pair_match_status(scale, "prolog_vs_wam_rust_accumulated", prolog_accumulated, wam_rust_accumulated)
+        print_pair_match_status(scale, "prolog_vs_wam_rust_seeded_no_kernels", prolog_accumulated, wam_rust_seeded_no_kernels)
+        print_pair_match_status(scale, "prolog_vs_wam_rust_accumulated_no_kernels", prolog_accumulated, wam_rust_accumulated_no_kernels)
         print_pair_match_status(scale, "query_vs_prolog_semantic_min", qe, prolog_semantic_min)
         print_pair_match_status(scale, "query_vs_prolog_eff_semantic", qe, prolog_eff_semantic)
         print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
@@ -312,6 +318,8 @@ def print_summary(results: list[RunResult]) -> None:
         print_speedup(scale, "speedup_vs_prolog_root_accumulated", prolog_root_accumulated, qe)
         print_speedup(scale, "speedup_vs_wam_rust_seeded", wam_rust_seeded, qe)
         print_speedup(scale, "speedup_vs_wam_rust_accumulated", wam_rust_accumulated, qe)
+        print_speedup(scale, "speedup_vs_wam_rust_seeded_no_kernels", wam_rust_seeded_no_kernels, qe)
+        print_speedup(scale, "speedup_vs_wam_rust_accumulated_no_kernels", wam_rust_accumulated_no_kernels, qe)
         print_speedup(scale, "speedup_vs_prolog_semantic_min", prolog_semantic_min, qe)
         print_speedup(scale, "speedup_vs_prolog_eff_semantic", prolog_eff_semantic, qe)
         print_phase_metrics(scale, "csharp-query-metrics", qe)
@@ -322,6 +330,8 @@ def print_summary(results: list[RunResult]) -> None:
         print_phase_metrics(scale, "prolog-root-accumulated-metrics", prolog_root_accumulated)
         print_phase_metrics(scale, "wam-rust-seeded-metrics", wam_rust_seeded)
         print_phase_metrics(scale, "wam-rust-accumulated-metrics", wam_rust_accumulated)
+        print_phase_metrics(scale, "wam-rust-seeded-no-kernels-metrics", wam_rust_seeded_no_kernels)
+        print_phase_metrics(scale, "wam-rust-accumulated-no-kernels-metrics", wam_rust_accumulated_no_kernels)
         print_phase_metrics(scale, "prolog-semantic-min-metrics", prolog_semantic_min)
         print_phase_metrics(scale, "prolog-eff-semantic-metrics", prolog_eff_semantic)
 
@@ -379,6 +389,10 @@ def main() -> int:
                 continue
             elif target == "wam-rust-accumulated":
                 continue
+            elif target == "wam-rust-seeded-no-kernels":
+                continue
+            elif target == "wam-rust-accumulated-no-kernels":
+                continue
             elif target == "prolog-semantic-min":
                 continue
             elif target == "prolog-eff-semantic":
@@ -403,6 +417,10 @@ def main() -> int:
                     command = build_wam_rust_effective_distance(temp_root, scale, "seeded")
                 elif target == "wam-rust-accumulated":
                     command = build_wam_rust_effective_distance(temp_root, scale, "accumulated")
+                elif target == "wam-rust-seeded-no-kernels":
+                    command = build_wam_rust_effective_distance(temp_root, scale, "seeded_no_kernels")
+                elif target == "wam-rust-accumulated-no-kernels":
+                    command = build_wam_rust_effective_distance(temp_root, scale, "accumulated_no_kernels")
                 elif target == "prolog-semantic-min":
                     command = build_prolog_semantic_min(temp_root, scale)
                 elif target == "prolog-eff-semantic":

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -319,8 +319,8 @@ def print_summary(results: list[RunResult]) -> None:
         print_speedup(scale, "speedup_vs_prolog_root_accumulated", prolog_root_accumulated, qe)
         print_speedup(scale, "speedup_vs_wam_rust_seeded", wam_rust_seeded, qe)
         print_speedup(scale, "speedup_vs_wam_rust_accumulated", wam_rust_accumulated, qe)
-        print_speedup(scale, "speedup_vs_wam_rust_seeded_no_kernels", wam_rust_seeded_no_kernels, qe)
-        print_speedup(scale, "speedup_vs_wam_rust_accumulated_no_kernels", wam_rust_accumulated_no_kernels, qe)
+        print_no_kernel_speedup(scale, "speedup_vs_wam_rust_seeded_no_kernels", wam_rust_seeded_no_kernels, qe, seed_subset_probe)
+        print_no_kernel_speedup(scale, "speedup_vs_wam_rust_accumulated_no_kernels", wam_rust_accumulated_no_kernels, qe, seed_subset_probe)
         print_speedup(scale, "speedup_vs_prolog_semantic_min", prolog_semantic_min, qe)
         print_speedup(scale, "speedup_vs_prolog_eff_semantic", prolog_eff_semantic, qe)
         print_phase_metrics(scale, "csharp-query-metrics", qe)
@@ -354,6 +354,18 @@ def print_no_kernel_match_status(
         print(f"{scale}\t{label}\tSKIPPED_SEED_SUBSET")
         return
     print_pair_match_status(scale, label, left, right)
+
+
+def print_no_kernel_speedup(
+    scale: str,
+    label: str,
+    faster_baseline: RunResult | None,
+    measured: RunResult | None,
+    seed_subset_probe: bool,
+) -> None:
+    if seed_subset_probe:
+        return
+    print_speedup(scale, label, faster_baseline, measured)
 
 
 def scale_sort_key(scale: str) -> tuple[int, str]:

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -271,6 +271,7 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
 
 
 def print_summary(results: list[RunResult]) -> None:
+    seed_subset_probe = wam_seed_subset_probe_enabled()
     print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
     for scale, entries in group_results_by_scale(results, sort_key=scale_sort_key):
         print_result_table(entries, scale)
@@ -301,12 +302,12 @@ def print_summary(results: list[RunResult]) -> None:
         print_pair_match_status(scale, "query_vs_prolog_root_accumulated", qe, prolog_root_accumulated)
         print_pair_match_status(scale, "query_vs_wam_rust_seeded", qe, wam_rust_seeded)
         print_pair_match_status(scale, "query_vs_wam_rust_accumulated", qe, wam_rust_accumulated)
-        print_pair_match_status(scale, "query_vs_wam_rust_seeded_no_kernels", qe, wam_rust_seeded_no_kernels)
-        print_pair_match_status(scale, "query_vs_wam_rust_accumulated_no_kernels", qe, wam_rust_accumulated_no_kernels)
+        print_no_kernel_match_status(scale, "query_vs_wam_rust_seeded_no_kernels", qe, wam_rust_seeded_no_kernels, seed_subset_probe)
+        print_no_kernel_match_status(scale, "query_vs_wam_rust_accumulated_no_kernels", qe, wam_rust_accumulated_no_kernels, seed_subset_probe)
         print_pair_match_status(scale, "prolog_vs_wam_rust_seeded", prolog_accumulated, wam_rust_seeded)
         print_pair_match_status(scale, "prolog_vs_wam_rust_accumulated", prolog_accumulated, wam_rust_accumulated)
-        print_pair_match_status(scale, "prolog_vs_wam_rust_seeded_no_kernels", prolog_accumulated, wam_rust_seeded_no_kernels)
-        print_pair_match_status(scale, "prolog_vs_wam_rust_accumulated_no_kernels", prolog_accumulated, wam_rust_accumulated_no_kernels)
+        print_no_kernel_match_status(scale, "prolog_vs_wam_rust_seeded_no_kernels", prolog_accumulated, wam_rust_seeded_no_kernels, seed_subset_probe)
+        print_no_kernel_match_status(scale, "prolog_vs_wam_rust_accumulated_no_kernels", prolog_accumulated, wam_rust_accumulated_no_kernels, seed_subset_probe)
         print_pair_match_status(scale, "query_vs_prolog_semantic_min", qe, prolog_semantic_min)
         print_pair_match_status(scale, "query_vs_prolog_eff_semantic", qe, prolog_eff_semantic)
         print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
@@ -334,6 +335,25 @@ def print_summary(results: list[RunResult]) -> None:
         print_phase_metrics(scale, "wam-rust-accumulated-no-kernels-metrics", wam_rust_accumulated_no_kernels)
         print_phase_metrics(scale, "prolog-semantic-min-metrics", prolog_semantic_min)
         print_phase_metrics(scale, "prolog-eff-semantic-metrics", prolog_eff_semantic)
+
+
+def wam_seed_subset_probe_enabled() -> bool:
+    return bool(os.environ.get("WAM_SEED_LIMIT") or os.environ.get("WAM_SEED_FILTER"))
+
+
+def print_no_kernel_match_status(
+    scale: str,
+    label: str,
+    left: RunResult | None,
+    right: RunResult | None,
+    seed_subset_probe: bool,
+) -> None:
+    if not (left and right):
+        return
+    if seed_subset_probe:
+        print(f"{scale}\t{label}\tSKIPPED_SEED_SUBSET")
+        return
+    print_pair_match_status(scale, label, left, right)
 
 
 def scale_sort_key(scale: str) -> tuple[int, str]:
@@ -385,6 +405,8 @@ def main() -> int:
                 continue
             elif target == "prolog-root-accumulated":
                 continue
+            # WAM-Rust variants are generated per scale because facts and
+            # optional optimized helpers are loaded into the generated project.
             elif target == "wam-rust-seeded":
                 continue
             elif target == "wam-rust-accumulated":

--- a/examples/benchmark/generate_wam_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_effective_distance_benchmark.pl
@@ -27,11 +27,13 @@
 %%
 %% Usage:
 %%   swipl -q -s generate_wam_effective_distance_benchmark.pl -- \
-%%       <facts.pl> <output-dir> [seeded|accumulated]
+%%       <facts.pl> <output-dir> [seeded|accumulated|seeded_no_kernels|accumulated_no_kernels]
 %%
 %% Variants:
-%%   seeded      - base category_ancestor + host-side Rust accumulation
-%%   accumulated - Prolog-generated effective_distance_sum helpers compiled into WAM
+%%   seeded                 - base category_ancestor + host-side Rust accumulation
+%%   accumulated            - Prolog-generated effective_distance_sum helpers compiled into WAM
+%%   seeded_no_kernels      - seeded, with native recursive kernels disabled
+%%   accumulated_no_kernels - accumulated, with native recursive kernels disabled
 
 benchmark_workload_path(Path) :-
     source_file(benchmark_workload_path(_), ThisFile),
@@ -45,7 +47,7 @@ main :-
     ;   Argv = [FactsPath, OutputDir]
     ->  VariantAtom = seeded
     ;   format(user_error,
-            'Usage: swipl -q -s generate_wam_effective_distance_benchmark.pl -- <facts.pl> <output-dir> [seeded|accumulated]~n',
+            'Usage: swipl -q -s generate_wam_effective_distance_benchmark.pl -- <facts.pl> <output-dir> [seeded|accumulated|seeded_no_kernels|accumulated_no_kernels]~n',
             []),
         halt(1)
     ),
@@ -57,20 +59,24 @@ main :-
     halt(1).
 
 generate_wam_benchmark(_FactsPath, OutputDir, VariantAtom) :-
-    parse_variant(VariantAtom, OptimizationOptions),
+    parse_variant(VariantAtom, BaseVariant, KernelMode, OptimizationOptions),
     % Load the benchmark workload to get predicate definitions
     benchmark_workload_path(WorkloadPath),
     load_files(WorkloadPath, [silent(true)]),
     retractall(user:mode(category_ancestor(_, _, _, _))),
     assertz(user:mode(category_ancestor(-, +, -, +))),
 
-    maybe_load_optimized_predicates(VariantAtom, OptimizationOptions),
-    collect_wam_predicates(VariantAtom, WamPredicates),
-    format(user_error, '[WAM-Rust] variant=~w predicates=~w~n',
-           [VariantAtom, WamPredicates]),
+    maybe_load_optimized_predicates(BaseVariant, OptimizationOptions),
+    collect_wam_predicates(BaseVariant, WamPredicates),
+    format(user_error, '[WAM-Rust] variant=~w base_variant=~w kernels=~w predicates=~w~n',
+           [VariantAtom, BaseVariant, KernelMode, WamPredicates]),
 
     % Auto-detect FFI kernels from predicate clauses
-    wam_rust_target:detect_kernels(WamPredicates, DetectedKernels),
+    (   KernelMode == kernels_off
+    ->  DetectedKernels = [],
+        format(user_error, '[WAM-Rust] native kernels disabled; using WAM fallback~n', [])
+    ;   wam_rust_target:detect_kernels(WamPredicates, DetectedKernels)
+    ),
     (   DetectedKernels \= []
     ->  pairs_keys(DetectedKernels, DetectedKeys),
         format(user_error, '[WAM-Rust] detected kernels: ~w~n', [DetectedKeys])
@@ -99,12 +105,23 @@ generate_wam_benchmark(_FactsPath, OutputDir, VariantAtom) :-
 
     format(user_error, '[WAM-Rust] Generated benchmark project at: ~w~n', [OutputDir]).
 
-parse_variant(seeded, [
+parse_variant(seeded, seeded, kernels_on, [
     dialect(swi),
     branch_pruning(false),
     min_closure(false)
 ]).
-parse_variant(accumulated, [
+parse_variant(accumulated, accumulated, kernels_on, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false),
+    seeded_accumulation(auto)
+]).
+parse_variant(seeded_no_kernels, seeded, kernels_off, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false)
+]).
+parse_variant(accumulated_no_kernels, accumulated, kernels_off, [
     dialect(swi),
     branch_pruning(false),
     min_closure(false),
@@ -778,6 +795,13 @@ fn main() {
             seed_cats.retain(|cat| wanted.contains(cat));
         }
     }
+    if let Ok(limit_raw) = std::env::var("WAM_SEED_LIMIT") {
+        if let Ok(limit) = limit_raw.parse::<usize>() {
+            if limit > 0 && seed_cats.len() > limit {
+                seed_cats.truncate(limit);
+            }
+        }
+    }
     let seed_count = seed_cats.len();
 
     let root = roots[0].clone();
@@ -976,6 +1000,12 @@ fn main() {
     eprintln!("aggregation_ms={}", agg_ms);
     eprintln!("total_ms={}", total_ms);
     eprintln!("seed_count={}", seed_count);
+    if let Ok(seed_limit) = std::env::var("WAM_SEED_LIMIT") {
+        eprintln!("seed_limit={}", seed_limit);
+    }
+    if let Ok(seed_filter) = std::env::var("WAM_SEED_FILTER") {
+        eprintln!("seed_filter={}", seed_filter);
+    }
     eprintln!("tuple_count={}", seed_weight_sums.len());
     eprintln!("article_count={}", results.len());
     eprintln!("total_steps={}", total_steps);

--- a/examples/benchmark/generate_wam_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_effective_distance_benchmark.pl
@@ -796,10 +796,16 @@ fn main() {
         }
     }
     if let Ok(limit_raw) = std::env::var("WAM_SEED_LIMIT") {
-        if let Ok(limit) = limit_raw.parse::<usize>() {
-            if limit > 0 && seed_cats.len() > limit {
-                seed_cats.truncate(limit);
+        match limit_raw.parse::<usize>() {
+            Ok(limit) => {
+                if limit > 0 && seed_cats.len() > limit {
+                    seed_cats.truncate(limit);
+                }
             }
+            Err(_) => eprintln!(
+                "[WAM-Rust] WARNING: WAM_SEED_LIMIT={} is not a valid usize, ignoring",
+                limit_raw,
+            ),
         }
     }
     let seed_count = seed_cats.len();


### PR DESCRIPTION
  ## Summary

  Adds explicit WAM-Rust effective-distance benchmark variants that disable native recursive kernels:

  - `wam-rust-seeded-no-kernels`
  - `wam-rust-accumulated-no-kernels`

  These variants keep the same generated WAM code path but force execution through the WAM fallback so we can profile
  interpreter work separately from the faster native-kernel hybrid path.

  ## Details

  - Adds `seeded_no_kernels` and `accumulated_no_kernels` generator variants.
  - Adds benchmark harness target wiring and summary metrics for the no-kernel variants.
  - Adds `WAM_SEED_LIMIT` and `WAM_SEED_FILTER` controls for bounded fallback probes.
  - Documents that seed-limited runs intentionally produce partial output and should not be used for completeness
  comparisons.

  ## Validation

  - `python3 -m py_compile examples/benchmark/benchmark_effective_distance.py examples/benchmark/benchmark_common.py`
  - `prolog-accumulated` vs `wam-rust-accumulated` at scale `300`: outputs match.
  - `WAM_SEED_LIMIT=5 wam-rust-accumulated-no-kernels` runs and reports non-zero fallback work metrics:
    - `total_steps=90`
    - `total_backtracks=10`