### PR TITLE
bench: compare WAM Rust and Haskell effective distance

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -93,9 +93,9 @@ Semantic note:
 - current runs also report `query_vs_prolog_accumulated = match` at
   `300`, `1k`, `5k`, and `10k`
 
-### WAM-Rust Benchmark Variants
+### WAM-Rust and WAM-Haskell Benchmark Variants
 
-The effective-distance harness also includes WAM-Rust benchmark targets:
+The effective-distance harness also includes hybrid WAM benchmark targets:
 
 - `wam-rust-seeded` compiles the base WAM predicates and uses the generated
   Rust benchmark driver to compute per-seed weight sums through the
@@ -116,13 +116,17 @@ The effective-distance harness also includes WAM-Rust benchmark targets:
   completeness comparisons. These environment variables apply to the entire
   benchmark invocation; when either is set, no-kernel parity and speedup lines
   are treated as seed-subset probes rather than full-output comparisons.
+- `haskell-wam-seeded` and `haskell-wam-accumulated` use the optimized
+  WAM-Haskell generator for the same effective-distance workload. They are
+  intended as a non-Rust hybrid comparison point and use Cabal new-style builds
+  so Hackage dependencies can be resolved when the local package cache is cold.
 
 Example focused run:
 
 ```bash
 python examples/benchmark/benchmark_effective_distance.py \
   --scales dev \
-  --targets prolog-accumulated,wam-rust-seeded,wam-rust-accumulated,wam-rust-accumulated-no-kernels \
+  --targets prolog-accumulated,wam-rust-accumulated,haskell-wam-accumulated,wam-rust-accumulated-no-kernels \
   --repetitions 1
 ```
 

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -210,12 +210,20 @@ def build_go_binary(
 
 
 def build_haskell_project(project_dir: Path, executable_name: str) -> list[str]:
-    run_command(["cabal", "build", f"exe:{executable_name}"], cwd=project_dir)
-    result = run_command(["cabal", "list-bin", f"exe:{executable_name}"], cwd=project_dir)
-    binary = result.stdout.strip()
-    if not binary:
+    run_command(["cabal", "v2-build", f"exe:{executable_name}"], cwd=project_dir)
+    binary = find_cabal_binary(project_dir, executable_name)
+    return [str(binary)]
+
+
+def find_cabal_binary(project_dir: Path, executable_name: str) -> Path:
+    candidates = [
+        path
+        for path in (project_dir / "dist-newstyle").rglob(executable_name)
+        if path.is_file() and os.access(path, os.X_OK)
+    ]
+    if not candidates:
         raise RuntimeError(f"could not resolve cabal binary for {executable_name}")
-    return [binary]
+    return max(candidates, key=lambda path: path.stat().st_mtime)
 
 
 def digest_normalized_output(normalized: str) -> tuple[str, int]:

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -55,6 +55,11 @@ def available_targets(requested: list[str]) -> list[str]:
         if target.startswith("csharp-") and shutil.which("dotnet") is None:
             print(f"skip {target}: dotnet not found", file=sys.stderr)
             continue
+        if target.startswith("haskell-wam-") and (
+            shutil.which("swipl") is None or shutil.which("cabal") is None or shutil.which("ghc") is None
+        ):
+            print(f"skip {target}: swipl, cabal, or ghc not found", file=sys.stderr)
+            continue
         if target.startswith("haskell-") and (shutil.which("cabal") is None or shutil.which("ghc") is None):
             print(f"skip {target}: cabal or ghc not found", file=sys.stderr)
             continue

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -51,6 +51,8 @@ BENCH_DIR = ROOT / "data" / "benchmark"
 GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
 PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_effective_distance_benchmark.pl"
 WAM_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_effective_distance_benchmark.pl"
+# Use the variant-aware optimized Haskell WAM generator so seeded and
+# accumulated targets compile the same Prolog optimization surfaces as Rust.
 WAM_HASKELL_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_haskell_optimized_benchmark.pl"
 SEMANTIC_PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_min_semantic_distance_benchmark.pl"
 EFF_SEMANTIC_PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_effective_semantic_distance_benchmark.pl"
@@ -277,7 +279,7 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
     last_stderr = ""
     for _ in range(repetitions):
         started = time.perf_counter()
-        if target.startswith("prolog-") or target.startswith("wam-"):
+        if target.startswith("prolog-") or target.startswith("wam-") or target.startswith("haskell-wam-"):
             result = run_command(command)
         else:
             scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
@@ -455,7 +457,7 @@ def main() -> int:
                 continue
             elif target == "prolog-root-accumulated":
                 continue
-            # WAM-Rust variants are generated per scale because facts and
+            # Hybrid WAM variants are generated per scale because facts and
             # optional optimized helpers are loaded into the generated project.
             elif target == "wam-rust-seeded":
                 continue

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -30,6 +30,7 @@ from benchmark_common import (
     available_targets,
     build_csharp_package,
     build_go_binary,
+    build_haskell_project,
     build_rust_binary,
     digest_normalized_output,
     find_result,
@@ -50,6 +51,7 @@ BENCH_DIR = ROOT / "data" / "benchmark"
 GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
 PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_effective_distance_benchmark.pl"
 WAM_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_effective_distance_benchmark.pl"
+WAM_HASKELL_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_haskell_optimized_benchmark.pl"
 SEMANTIC_PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_min_semantic_distance_benchmark.pl"
 EFF_SEMANTIC_PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_effective_semantic_distance_benchmark.pl"
 EDGE_WEIGHT_SCRIPT = ROOT / "examples" / "benchmark" / "precompute_edge_weights.py"
@@ -79,7 +81,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--targets",
         default="csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated",
-        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded,prolog-pruned,prolog-accumulated,prolog-article-accumulated,prolog-root-accumulated,wam-rust-seeded,wam-rust-accumulated,wam-rust-seeded-no-kernels,wam-rust-accumulated-no-kernels",
+        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded,prolog-pruned,prolog-accumulated,prolog-article-accumulated,prolog-root-accumulated,wam-rust-seeded,wam-rust-accumulated,wam-rust-seeded-no-kernels,wam-rust-accumulated-no-kernels,haskell-wam-seeded,haskell-wam-accumulated",
     )
     parser.add_argument(
         "--repetitions",
@@ -247,6 +249,28 @@ def build_wam_rust_effective_distance(root: Path, scale: str, variant: str) -> l
     return [str(binary), str(scale_dir)]
 
 
+def build_haskell_wam_effective_distance(root: Path, scale: str, variant: str) -> list[str]:
+    facts_path = require_file(BENCH_DIR / scale / "facts.pl")
+    project_dir = root / f"haskell_wam_{variant}" / scale
+    project_dir.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(WAM_HASKELL_GENERATOR),
+            "--",
+            str(facts_path),
+            str(project_dir),
+            variant,
+        ],
+        cwd=ROOT,
+    )
+    return build_haskell_project(project_dir, "wam-haskell-bench") + [
+        str(require_file(BENCH_DIR / scale / "category_parent.tsv").parent)
+    ]
+
+
 def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
     times: list[float] = []
     last_stdout = ""
@@ -288,6 +312,8 @@ def print_summary(results: list[RunResult]) -> None:
         wam_rust_accumulated = find_result(entries, "wam-rust-accumulated")
         wam_rust_seeded_no_kernels = find_result(entries, "wam-rust-seeded-no-kernels")
         wam_rust_accumulated_no_kernels = find_result(entries, "wam-rust-accumulated-no-kernels")
+        haskell_wam_seeded = find_result(entries, "haskell-wam-seeded")
+        haskell_wam_accumulated = find_result(entries, "haskell-wam-accumulated")
         prolog_semantic_min = find_result(entries, "prolog-semantic-min")
         prolog_eff_semantic = find_result(entries, "prolog-eff-semantic")
         dfs_like = [item for item in entries if item.target in {"csharp-dfs", "rust-dfs", "go-dfs"}]
@@ -304,10 +330,16 @@ def print_summary(results: list[RunResult]) -> None:
         print_pair_match_status(scale, "query_vs_wam_rust_accumulated", qe, wam_rust_accumulated)
         print_no_kernel_match_status(scale, "query_vs_wam_rust_seeded_no_kernels", qe, wam_rust_seeded_no_kernels, seed_subset_probe)
         print_no_kernel_match_status(scale, "query_vs_wam_rust_accumulated_no_kernels", qe, wam_rust_accumulated_no_kernels, seed_subset_probe)
+        print_pair_match_status(scale, "query_vs_haskell_wam_seeded", qe, haskell_wam_seeded)
+        print_pair_match_status(scale, "query_vs_haskell_wam_accumulated", qe, haskell_wam_accumulated)
         print_pair_match_status(scale, "prolog_vs_wam_rust_seeded", prolog_accumulated, wam_rust_seeded)
         print_pair_match_status(scale, "prolog_vs_wam_rust_accumulated", prolog_accumulated, wam_rust_accumulated)
         print_no_kernel_match_status(scale, "prolog_vs_wam_rust_seeded_no_kernels", prolog_accumulated, wam_rust_seeded_no_kernels, seed_subset_probe)
         print_no_kernel_match_status(scale, "prolog_vs_wam_rust_accumulated_no_kernels", prolog_accumulated, wam_rust_accumulated_no_kernels, seed_subset_probe)
+        print_pair_match_status(scale, "prolog_vs_haskell_wam_seeded", prolog_accumulated, haskell_wam_seeded)
+        print_pair_match_status(scale, "prolog_vs_haskell_wam_accumulated", prolog_accumulated, haskell_wam_accumulated)
+        print_pair_match_status(scale, "wam_rust_vs_haskell_wam_seeded", wam_rust_seeded, haskell_wam_seeded)
+        print_pair_match_status(scale, "wam_rust_vs_haskell_wam_accumulated", wam_rust_accumulated, haskell_wam_accumulated)
         print_pair_match_status(scale, "query_vs_prolog_semantic_min", qe, prolog_semantic_min)
         print_pair_match_status(scale, "query_vs_prolog_eff_semantic", qe, prolog_eff_semantic)
         print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
@@ -321,6 +353,10 @@ def print_summary(results: list[RunResult]) -> None:
         print_speedup(scale, "speedup_vs_wam_rust_accumulated", wam_rust_accumulated, qe)
         print_no_kernel_speedup(scale, "speedup_vs_wam_rust_seeded_no_kernels", wam_rust_seeded_no_kernels, qe, seed_subset_probe)
         print_no_kernel_speedup(scale, "speedup_vs_wam_rust_accumulated_no_kernels", wam_rust_accumulated_no_kernels, qe, seed_subset_probe)
+        print_speedup(scale, "speedup_vs_haskell_wam_seeded", haskell_wam_seeded, qe)
+        print_speedup(scale, "speedup_vs_haskell_wam_accumulated", haskell_wam_accumulated, qe)
+        print_speedup(scale, "wam_rust_speedup_vs_haskell_seeded", haskell_wam_seeded, wam_rust_seeded)
+        print_speedup(scale, "wam_rust_speedup_vs_haskell_accumulated", haskell_wam_accumulated, wam_rust_accumulated)
         print_speedup(scale, "speedup_vs_prolog_semantic_min", prolog_semantic_min, qe)
         print_speedup(scale, "speedup_vs_prolog_eff_semantic", prolog_eff_semantic, qe)
         print_phase_metrics(scale, "csharp-query-metrics", qe)
@@ -333,6 +369,8 @@ def print_summary(results: list[RunResult]) -> None:
         print_phase_metrics(scale, "wam-rust-accumulated-metrics", wam_rust_accumulated)
         print_phase_metrics(scale, "wam-rust-seeded-no-kernels-metrics", wam_rust_seeded_no_kernels)
         print_phase_metrics(scale, "wam-rust-accumulated-no-kernels-metrics", wam_rust_accumulated_no_kernels)
+        print_phase_metrics(scale, "haskell-wam-seeded-metrics", haskell_wam_seeded)
+        print_phase_metrics(scale, "haskell-wam-accumulated-metrics", haskell_wam_accumulated)
         print_phase_metrics(scale, "prolog-semantic-min-metrics", prolog_semantic_min)
         print_phase_metrics(scale, "prolog-eff-semantic-metrics", prolog_eff_semantic)
 
@@ -427,6 +465,10 @@ def main() -> int:
                 continue
             elif target == "wam-rust-accumulated-no-kernels":
                 continue
+            elif target == "haskell-wam-seeded":
+                continue
+            elif target == "haskell-wam-accumulated":
+                continue
             elif target == "prolog-semantic-min":
                 continue
             elif target == "prolog-eff-semantic":
@@ -455,6 +497,10 @@ def main() -> int:
                     command = build_wam_rust_effective_distance(temp_root, scale, "seeded_no_kernels")
                 elif target == "wam-rust-accumulated-no-kernels":
                     command = build_wam_rust_effective_distance(temp_root, scale, "accumulated_no_kernels")
+                elif target == "haskell-wam-seeded":
+                    command = build_haskell_wam_effective_distance(temp_root, scale, "seeded")
+                elif target == "haskell-wam-accumulated":
+                    command = build_haskell_wam_effective_distance(temp_root, scale, "accumulated")
                 elif target == "prolog-semantic-min":
                     command = build_prolog_semantic_min(temp_root, scale)
                 elif target == "prolog-eff-semantic":


### PR DESCRIPTION
  ## Summary

  Adds Haskell WAM effective-distance targets to the benchmark harness so the existing Rust hybrid WAM path can be
  compared against a non-Rust hybrid target.

  ## Changes

  - Adds `haskell-wam-seeded` and `haskell-wam-accumulated` targets.
  - Wires the targets through `generate_wam_haskell_optimized_benchmark.pl`.
  - Uses Cabal new-style builds via `cabal v2-build` so Hackage dependencies can resolve when needed.
  - Adds a Cabal 2.4-compatible executable lookup by scanning `dist-newstyle`.
  - Adds Rust-vs-Haskell parity and speedup reporting.
  - Requires `swipl`, `cabal`, and `ghc` for `haskell-wam-*` target availability.
  - Documents the Haskell WAM targets in the benchmark README.

  ## Validation

  - `python3 -m py_compile examples/benchmark/benchmark_effective_distance.py examples/benchmark/benchmark_common.py`
  - `TMPDIR=/tmp python3 examples/benchmark/benchmark_effective_distance.py --scales 300 --targets wam-rust-
  accumulated,haskell-wam-accumulated --repetitions 1`

  Scale `300` validation:
  - Rust WAM accumulated and Haskell WAM accumulated outputs match.
  - Latest local run reported Rust WAM accumulated `4.34x` faster than Haskell WAM accumulated.

  ## Note

  Future follow-up: optionally detect `swipl` in common install locations when it is not on `PATH`. That is
  intentionally left out of this PR.