### PR TITLE
bench: add Haskell WAM no-kernel effective-distance targets

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -120,13 +120,18 @@ The effective-distance harness also includes hybrid WAM benchmark targets:
   WAM-Haskell generator for the same effective-distance workload. They are
   intended as a non-Rust hybrid comparison point and use Cabal new-style builds
   so Hackage dependencies can be resolved when the local package cache is cold.
+- `haskell-wam-seeded-no-kernels` and
+  `haskell-wam-accumulated-no-kernels` mirror the Rust no-kernel targets by
+  passing `no_kernels(true)` to the WAM-Haskell target. Use these for pure-WAM
+  fallback comparisons; use the non-`no-kernels` targets for native-kernel
+  hybrid comparisons.
 
 Example focused run:
 
 ```bash
 python examples/benchmark/benchmark_effective_distance.py \
   --scales dev \
-  --targets prolog-accumulated,wam-rust-accumulated,haskell-wam-accumulated,wam-rust-accumulated-no-kernels \
+  --targets prolog-accumulated,wam-rust-accumulated,haskell-wam-accumulated,wam-rust-accumulated-no-kernels,haskell-wam-accumulated-no-kernels \
   --repetitions 1
 ```
 

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -83,7 +83,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--targets",
         default="csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated",
-        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded,prolog-pruned,prolog-accumulated,prolog-article-accumulated,prolog-root-accumulated,wam-rust-seeded,wam-rust-accumulated,wam-rust-seeded-no-kernels,wam-rust-accumulated-no-kernels,haskell-wam-seeded,haskell-wam-accumulated",
+        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded,prolog-pruned,prolog-accumulated,prolog-article-accumulated,prolog-root-accumulated,wam-rust-seeded,wam-rust-accumulated,wam-rust-seeded-no-kernels,wam-rust-accumulated-no-kernels,haskell-wam-seeded,haskell-wam-accumulated,haskell-wam-seeded-no-kernels,haskell-wam-accumulated-no-kernels",
     )
     parser.add_argument(
         "--repetitions",
@@ -316,6 +316,8 @@ def print_summary(results: list[RunResult]) -> None:
         wam_rust_accumulated_no_kernels = find_result(entries, "wam-rust-accumulated-no-kernels")
         haskell_wam_seeded = find_result(entries, "haskell-wam-seeded")
         haskell_wam_accumulated = find_result(entries, "haskell-wam-accumulated")
+        haskell_wam_seeded_no_kernels = find_result(entries, "haskell-wam-seeded-no-kernels")
+        haskell_wam_accumulated_no_kernels = find_result(entries, "haskell-wam-accumulated-no-kernels")
         prolog_semantic_min = find_result(entries, "prolog-semantic-min")
         prolog_eff_semantic = find_result(entries, "prolog-eff-semantic")
         dfs_like = [item for item in entries if item.target in {"csharp-dfs", "rust-dfs", "go-dfs"}]
@@ -334,14 +336,20 @@ def print_summary(results: list[RunResult]) -> None:
         print_no_kernel_match_status(scale, "query_vs_wam_rust_accumulated_no_kernels", qe, wam_rust_accumulated_no_kernels, seed_subset_probe)
         print_pair_match_status(scale, "query_vs_haskell_wam_seeded", qe, haskell_wam_seeded)
         print_pair_match_status(scale, "query_vs_haskell_wam_accumulated", qe, haskell_wam_accumulated)
+        print_no_kernel_match_status(scale, "query_vs_haskell_wam_seeded_no_kernels", qe, haskell_wam_seeded_no_kernels, seed_subset_probe)
+        print_no_kernel_match_status(scale, "query_vs_haskell_wam_accumulated_no_kernels", qe, haskell_wam_accumulated_no_kernels, seed_subset_probe)
         print_pair_match_status(scale, "prolog_vs_wam_rust_seeded", prolog_accumulated, wam_rust_seeded)
         print_pair_match_status(scale, "prolog_vs_wam_rust_accumulated", prolog_accumulated, wam_rust_accumulated)
         print_no_kernel_match_status(scale, "prolog_vs_wam_rust_seeded_no_kernels", prolog_accumulated, wam_rust_seeded_no_kernels, seed_subset_probe)
         print_no_kernel_match_status(scale, "prolog_vs_wam_rust_accumulated_no_kernels", prolog_accumulated, wam_rust_accumulated_no_kernels, seed_subset_probe)
         print_pair_match_status(scale, "prolog_vs_haskell_wam_seeded", prolog_accumulated, haskell_wam_seeded)
         print_pair_match_status(scale, "prolog_vs_haskell_wam_accumulated", prolog_accumulated, haskell_wam_accumulated)
+        print_no_kernel_match_status(scale, "prolog_vs_haskell_wam_seeded_no_kernels", prolog_accumulated, haskell_wam_seeded_no_kernels, seed_subset_probe)
+        print_no_kernel_match_status(scale, "prolog_vs_haskell_wam_accumulated_no_kernels", prolog_accumulated, haskell_wam_accumulated_no_kernels, seed_subset_probe)
         print_pair_match_status(scale, "wam_rust_vs_haskell_wam_seeded", wam_rust_seeded, haskell_wam_seeded)
         print_pair_match_status(scale, "wam_rust_vs_haskell_wam_accumulated", wam_rust_accumulated, haskell_wam_accumulated)
+        print_no_kernel_match_status(scale, "wam_rust_vs_haskell_wam_seeded_no_kernels", wam_rust_seeded_no_kernels, haskell_wam_seeded_no_kernels, seed_subset_probe)
+        print_no_kernel_match_status(scale, "wam_rust_vs_haskell_wam_accumulated_no_kernels", wam_rust_accumulated_no_kernels, haskell_wam_accumulated_no_kernels, seed_subset_probe)
         print_pair_match_status(scale, "query_vs_prolog_semantic_min", qe, prolog_semantic_min)
         print_pair_match_status(scale, "query_vs_prolog_eff_semantic", qe, prolog_eff_semantic)
         print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
@@ -357,8 +365,12 @@ def print_summary(results: list[RunResult]) -> None:
         print_no_kernel_speedup(scale, "speedup_vs_wam_rust_accumulated_no_kernels", wam_rust_accumulated_no_kernels, qe, seed_subset_probe)
         print_speedup(scale, "speedup_vs_haskell_wam_seeded", haskell_wam_seeded, qe)
         print_speedup(scale, "speedup_vs_haskell_wam_accumulated", haskell_wam_accumulated, qe)
+        print_no_kernel_speedup(scale, "speedup_vs_haskell_wam_seeded_no_kernels", haskell_wam_seeded_no_kernels, qe, seed_subset_probe)
+        print_no_kernel_speedup(scale, "speedup_vs_haskell_wam_accumulated_no_kernels", haskell_wam_accumulated_no_kernels, qe, seed_subset_probe)
         print_speedup(scale, "wam_rust_speedup_vs_haskell_seeded", haskell_wam_seeded, wam_rust_seeded)
         print_speedup(scale, "wam_rust_speedup_vs_haskell_accumulated", haskell_wam_accumulated, wam_rust_accumulated)
+        print_no_kernel_speedup(scale, "wam_rust_speedup_vs_haskell_seeded_no_kernels", haskell_wam_seeded_no_kernels, wam_rust_seeded_no_kernels, seed_subset_probe)
+        print_no_kernel_speedup(scale, "wam_rust_speedup_vs_haskell_accumulated_no_kernels", haskell_wam_accumulated_no_kernels, wam_rust_accumulated_no_kernels, seed_subset_probe)
         print_speedup(scale, "speedup_vs_prolog_semantic_min", prolog_semantic_min, qe)
         print_speedup(scale, "speedup_vs_prolog_eff_semantic", prolog_eff_semantic, qe)
         print_phase_metrics(scale, "csharp-query-metrics", qe)
@@ -373,6 +385,8 @@ def print_summary(results: list[RunResult]) -> None:
         print_phase_metrics(scale, "wam-rust-accumulated-no-kernels-metrics", wam_rust_accumulated_no_kernels)
         print_phase_metrics(scale, "haskell-wam-seeded-metrics", haskell_wam_seeded)
         print_phase_metrics(scale, "haskell-wam-accumulated-metrics", haskell_wam_accumulated)
+        print_phase_metrics(scale, "haskell-wam-seeded-no-kernels-metrics", haskell_wam_seeded_no_kernels)
+        print_phase_metrics(scale, "haskell-wam-accumulated-no-kernels-metrics", haskell_wam_accumulated_no_kernels)
         print_phase_metrics(scale, "prolog-semantic-min-metrics", prolog_semantic_min)
         print_phase_metrics(scale, "prolog-eff-semantic-metrics", prolog_eff_semantic)
 
@@ -471,6 +485,10 @@ def main() -> int:
                 continue
             elif target == "haskell-wam-accumulated":
                 continue
+            elif target == "haskell-wam-seeded-no-kernels":
+                continue
+            elif target == "haskell-wam-accumulated-no-kernels":
+                continue
             elif target == "prolog-semantic-min":
                 continue
             elif target == "prolog-eff-semantic":
@@ -503,6 +521,10 @@ def main() -> int:
                     command = build_haskell_wam_effective_distance(temp_root, scale, "seeded")
                 elif target == "haskell-wam-accumulated":
                     command = build_haskell_wam_effective_distance(temp_root, scale, "accumulated")
+                elif target == "haskell-wam-seeded-no-kernels":
+                    command = build_haskell_wam_effective_distance(temp_root, scale, "seeded_no_kernels")
+                elif target == "haskell-wam-accumulated-no-kernels":
+                    command = build_haskell_wam_effective_distance(temp_root, scale, "accumulated_no_kernels")
                 elif target == "prolog-semantic-min":
                     command = build_prolog_semantic_min(temp_root, scale)
                 elif target == "prolog-eff-semantic":

--- a/examples/benchmark/generate_wam_haskell_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_haskell_optimized_benchmark.pl
@@ -78,7 +78,8 @@ generate(VariantAtom, OutputDir) :-
 
     % Step 5: Generate Haskell WAM project
     query_pred_for_variant(BaseVariant, QueryPredOpts),
-    append([module_name('wam-haskell-bench'), emit_mode(functions)], QueryPredOpts, Options0),
+    format(atom(ModeAtom), 'wam_haskell_~w', [VariantAtom]),
+    append([module_name('wam-haskell-bench'), emit_mode(functions), benchmark_mode(ModeAtom)], QueryPredOpts, Options0),
     append(Options0, KernelOptions, Options),
     write_wam_haskell_project(Predicates, Options, OutputDir),
     format(user_error, '[WAM-Haskell-Optimized] Generated project at ~w~n', [OutputDir]).

--- a/examples/benchmark/generate_wam_haskell_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_haskell_optimized_benchmark.pl
@@ -22,11 +22,13 @@
 %%
 %% Usage:
 %%   swipl -q -s generate_wam_haskell_optimized_benchmark.pl -- \
-%%       <facts.pl> <output-dir> [accumulated|seeded]
+%%       <facts.pl> <output-dir> [accumulated|seeded|accumulated_no_kernels|seeded_no_kernels]
 %%
 %% Variants:
-%%   seeded      — base category_ancestor + power_sum_bound (no helpers)
-%%   accumulated — full seeded accumulation with effective_distance_sum helpers
+%%   seeded                 — base category_ancestor + power_sum_bound (no helpers)
+%%   accumulated            — full seeded accumulation with effective_distance_sum helpers
+%%   seeded_no_kernels      — seeded, with native recursive kernels disabled
+%%   accumulated_no_kernels — accumulated, with native recursive kernels disabled
 
 benchmark_workload_path(Path) :-
     source_file(benchmark_workload_path(_), ThisFile),
@@ -40,7 +42,7 @@ main :-
     ;   Argv = [_FactsPath, OutputDir]
     ->  VariantAtom = accumulated  % default
     ;   format(user_error,
-            'Usage: ... -- <facts.pl> <output-dir> [accumulated|seeded]~n', []),
+            'Usage: ... -- <facts.pl> <output-dir> [accumulated|seeded|accumulated_no_kernels|seeded_no_kernels]~n', []),
         halt(1)
     ),
     generate(VariantAtom, OutputDir),
@@ -51,6 +53,7 @@ main :-
     halt(1).
 
 generate(VariantAtom, OutputDir) :-
+    parse_variant(VariantAtom, BaseVariant, KernelOptions, OptimizationOptions),
     % Step 1: Load the base workload
     benchmark_workload_path(WorkloadPath),
     load_files(WorkloadPath, [silent(true)]),
@@ -58,7 +61,6 @@ generate(VariantAtom, OutputDir) :-
     assertz(user:mode(category_ancestor(-, +, -, +))),
 
     % Step 2: Generate optimized Prolog via prolog_target
-    parse_variant(VariantAtom, OptimizationOptions),
     BasePreds = [dimension_n/1, max_depth/1, category_ancestor/4],
     prolog_target:generate_prolog_script(BasePreds, OptimizationOptions, ScriptCode),
 
@@ -70,22 +72,34 @@ generate(VariantAtom, OutputDir) :-
     delete_file(TmpPath),
 
     % Step 4: Collect all relevant predicates (base + generated helpers)
-    collect_wam_predicates(VariantAtom, Predicates),
-    format(user_error, '[WAM-Haskell-Optimized] variant=~w predicates=~w~n',
-           [VariantAtom, Predicates]),
+    collect_wam_predicates(BaseVariant, Predicates),
+    format(user_error, '[WAM-Haskell-Optimized] variant=~w base_variant=~w predicates=~w~n',
+           [VariantAtom, BaseVariant, Predicates]),
 
     % Step 5: Generate Haskell WAM project
-    query_pred_for_variant(VariantAtom, QueryPredOpts),
-    append([module_name('wam-haskell-bench'), emit_mode(functions)], QueryPredOpts, Options),
+    query_pred_for_variant(BaseVariant, QueryPredOpts),
+    append([module_name('wam-haskell-bench'), emit_mode(functions)], QueryPredOpts, Options0),
+    append(Options0, KernelOptions, Options),
     write_wam_haskell_project(Predicates, Options, OutputDir),
     format(user_error, '[WAM-Haskell-Optimized] Generated project at ~w~n', [OutputDir]).
 
-parse_variant(seeded, [
+parse_variant(seeded, seeded, [], [
     dialect(swi),
     branch_pruning(false),
     min_closure(false)
 ]).
-parse_variant(accumulated, [
+parse_variant(accumulated, accumulated, [], [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false),
+    seeded_accumulation(auto)
+]).
+parse_variant(seeded_no_kernels, seeded, [no_kernels(true)], [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false)
+]).
+parse_variant(accumulated_no_kernels, accumulated, [no_kernels(true)], [
     dialect(swi),
     branch_pruning(false),
     min_closure(false),

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2651,6 +2651,7 @@ generate_main_hs(_Predicates, DetectedKernels, InlineDefs, Options, Code) :-
     read_kernel_template('main.hs.mustache', Template),
     detected_kernel_keys(DetectedKernels, Keys),
     format_foreign_preds(Keys, ForeignPredsStr),
+    option(benchmark_mode(Mode), Options, wam_haskell_accumulated),
     % When kernels are detected, the query body should use executeForeign
     % dispatch instead of running WAM code (fact code is skipped).
     (   DetectedKernels \= []
@@ -2673,6 +2674,7 @@ generate_main_hs(_Predicates, DetectedKernels, InlineDefs, Options, Code) :-
     generate_lmdb_wiring(Options, LmdbSetup, LmdbContext, LmdbImport),
     render_template(Template,
         [ foreign_preds=ForeignPredsStr
+        , benchmark_mode=Mode
         , query_body=QueryBody
         , merged_code_build=MergedCodeBuild
         , demand_filter=DemandFilter

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -226,7 +226,7 @@ main = do
     hFlush stdout
 
     -- Metrics to stderr
-    hPutStrLn stderr $ "mode=wam_haskell_accumulated"
+    hPutStrLn stderr $ "mode={{benchmark_mode}}"
     hPutStrLn stderr $ "load_ms=" ++ show loadMs
     hPutStrLn stderr $ "query_ms=" ++ show queryMs
     hPutStrLn stderr $ "aggregation_ms=" ++ show aggMs

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -7,7 +7,7 @@ import qualified Data.IntSet as IS
 import Data.List (nub, sort, isPrefixOf, intercalate, foldl')
 import qualified Numeric
 import Data.Maybe (fromMaybe, mapMaybe)
-import System.Environment (getArgs)
+import System.Environment (getArgs, lookupEnv)
 import System.IO (hPutStrLn, stderr, hFlush, stdout)
 import Data.Time.Clock (getCurrentTime, diffUTCTime)
 import Control.Parallel.Strategies (parMap, rdeepseq)
@@ -37,6 +37,29 @@ splitOn _ [] = [""]
 splitOn d (c:cs)
   | c == d    = "" : splitOn d cs
   | otherwise = let (w:ws) = splitOn d cs in (c:w) : ws
+
+-- | Apply the same seed-subset controls as the Rust WAM benchmark driver.
+applySeedControls :: [String] -> IO ([String], Maybe String, Maybe String)
+applySeedControls seedCats0 = do
+    seedFilter <- lookupEnv "WAM_SEED_FILTER"
+    seedLimit <- lookupEnv "WAM_SEED_LIMIT"
+    let filtered = case seedFilter of
+          Nothing -> seedCats0
+          Just raw ->
+            let wanted = filter (not . null) $ map trim $ splitOn '|' raw
+            in if null wanted then seedCats0 else filter (`elem` wanted) seedCats0
+    limited <- case seedLimit of
+      Nothing -> return filtered
+      Just raw -> case reads raw :: [(Int, String)] of
+        [(limit, "")] | limit > 0 -> return (take limit filtered)
+        [(limit, "")] | limit <= 0 -> return filtered
+        _ -> do
+          hPutStrLn stderr $ "[WAM-Haskell] WARNING: WAM_SEED_LIMIT=" ++ raw ++ " is not a valid Int, ignoring"
+          return filtered
+    return (limited, seedLimit, seedFilter)
+  where
+    trim = f . f
+      where f = reverse . dropWhile (`elem` [' ', '\t', '\r', '\n'])
 
 -- | Build SwitchOnConstant dispatch table from grouped facts.
 buildFactIndex :: [(String, String)] -> Map.Map String [(String, String)]
@@ -125,10 +148,11 @@ main = do
         mergedCode = resolveCallInstrs mergedLabels foreignPreds mergedCodeRaw
 
     -- Collect seed categories
-    let seedCats = nub $ sort $ map snd articleCategories
+    let seedCatsAll = nub $ sort $ map snd articleCategories
         root = head roots
         n = 5.0 :: Double
         negN = -n
+    (seedCats, seedLimitMetric, seedFilterMetric) <- applySeedControls seedCatsAll
 
     -- Build child -> [parents] index in interned form for the FFI fast path.
     let !parentsIndexInterned = IM.fromListWith (++)
@@ -208,6 +232,8 @@ main = do
     hPutStrLn stderr $ "aggregation_ms=" ++ show aggMs
     hPutStrLn stderr $ "total_ms=" ++ show totalMs
     hPutStrLn stderr $ "seed_count=" ++ show (length seedCats)
+    maybe (return ()) (\v -> hPutStrLn stderr $ "seed_limit=" ++ v) seedLimitMetric
+    maybe (return ()) (\v -> hPutStrLn stderr $ "seed_filter=" ++ v) seedFilterMetric
     hPutStrLn stderr $ "tuple_count=" ++ show (Map.size seedWeightSums)
     hPutStrLn stderr $ "article_count=" ++ show (length results)
 {{demand_metrics}}


### PR DESCRIPTION
  ## Summary

  Adds Haskell WAM no-kernel benchmark variants so the effective-distance harness can compare both hybrid native-kernel mode
  and pure-WAM fallback mode across Rust and Haskell.

  ## Changes

  - Adds Haskell WAM no-kernel variants:
    - `haskell-wam-seeded-no-kernels`
    - `haskell-wam-accumulated-no-kernels`
  - Extends `generate_wam_haskell_optimized_benchmark.pl` with:
    - `seeded_no_kernels`
    - `accumulated_no_kernels`
  - Passes `no_kernels(true)` to the WAM-Haskell target for no-kernel variants.
  - Wires no-kernel Haskell targets into the effective-distance benchmark matrix.
  - Adds cross-target parity and speedup reporting for Rust vs Haskell no-kernel runs.
  - Adds `WAM_SEED_LIMIT` and `WAM_SEED_FILTER` support to the generated Haskell WAM driver.
  - Reports variant-specific Haskell benchmark modes such as `wam_haskell_accumulated_no_kernels`.
  - Documents native-kernel vs no-kernel Haskell WAM target usage.

  ## Validation

  - `python3 -m py_compile examples/benchmark/benchmark_effective_distance.py examples/benchmark/benchmark_common.py`
  - `TMPDIR=/tmp WAM_SEED_FILTER=Physics python3 examples/benchmark/benchmark_effective_distance.py --scales 300 --targets
  haskell-wam-accumulated,haskell-wam-accumulated-no-kernels --repetitions 1`
  - `TMPDIR=/tmp WAM_SEED_FILTER=Physics python3 examples/benchmark/benchmark_effective_distance.py --scales 300 --targets wam-
  rust-accumulated-no-kernels,haskell-wam-accumulated-no-kernels --repetitions 1`

  Validated that filtered pure-WAM Rust and Haskell outputs match for the `Physics` seed. Haskell metrics now distinguish
  kernel-enabled and no-kernel modes correctly.

  ## Follow-Up

  Haskell WAM does not currently emit `total_steps` / `total_backtracks`; adding those would require runtime instrumentation in
  `WamState` and should be handled separately.