### PR TITLE
bench: allow Haskell WAM RTS options

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -135,6 +135,10 @@ python examples/benchmark/benchmark_effective_distance.py \
   --repetitions 1
 ```
 
+Set `HASKELL_RTS` to pass runtime-system options to generated Haskell WAM
+executables, for example `HASKELL_RTS="+RTS -N2 -RTS"` to allow two GHC
+capabilities. Leaving it unset preserves the default single-capability run.
+
 On Termux, the harness chooses a writable temporary parent from `TMPDIR`,
 `TMP`, `TEMP`, `$PREFIX/tmp`, or `output` instead of assuming `/tmp`.
 

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -268,9 +268,13 @@ def build_haskell_wam_effective_distance(root: Path, scale: str, variant: str) -
         ],
         cwd=ROOT,
     )
-    return build_haskell_project(project_dir, "wam-haskell-bench") + [
+    command = build_haskell_project(project_dir, "wam-haskell-bench") + [
         str(require_file(BENCH_DIR / scale / "category_parent.tsv").parent)
     ]
+    haskell_rts = os.environ.get("HASKELL_RTS", "").strip()
+    if haskell_rts:
+        command.extend(haskell_rts.split())
+    return command
 
 
 def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:


### PR DESCRIPTION
  ## Summary

  Adds an opt-in `HASKELL_RTS` environment variable for generated Haskell WAM effective-distance benchmark executables.

  This lets benchmark runs pass GHC RTS flags such as:

  `HASKELL_RTS="+RTS -N2 -RTS"`

  Leaving `HASKELL_RTS` unset preserves the existing default single-capability behavior.

  ## Validation

  - `python3 -m py_compile examples/benchmark/benchmark_effective_distance.py examples/benchmark/benchmark_common.py`
  - `git diff --check -- examples/benchmark/benchmark_effective_distance.py examples/benchmark/README.md`
  - Smoke-tested `haskell-wam-accumulated` at scale `300` with `WAM_SEED_FILTER=Physics`
  - Smoke-tested the same run with `HASKELL_RTS="+RTS -N2 -RTS"`
  - Compared `1k` `haskell-wam-accumulated` with and without `HASKELL_RTS`

  Both RTS and non-RTS runs produced matching output hashes. The `+RTS -N2` runs were slower at the tested small scales, so
  parallel RTS remains an explicit benchmark knob rather than a default.