### PR TITLE
feat(template-engine): mustache section blocks ({{#flag}}/{{^flag}}/{{/flag}})

### DIFF
--- a/docs/design/TEMPLATE_ENGINE.md
+++ b/docs/design/TEMPLATE_ENGINE.md
@@ -1,0 +1,226 @@
+# UnifyWeaver Template Engine
+
+UnifyWeaver's targets render generated source code through a small
+mustache-compatible templating engine in
+`src/unifyweaver/core/template_system.pl`. This document records what
+the engine currently supports, what it deliberately leaves out, and
+how to extend it.
+
+## Why a custom engine
+
+Every transpilation target needs to splice generated fragments into
+boilerplate scaffolds (Cargo manifests, Haskell `Main.hs`, Python
+modules, .NET project files, shell scripts). A full templating
+language (Jinja2, ERB, Liquid) would be heavy and add a runtime
+dependency. The engine in `template_system.pl` is ~200 lines of
+Prolog and supports the small subset of mustache syntax we actually
+use.
+
+## Supported syntax
+
+### Substitution
+
+```mustache
+Hello {{name}}!
+```
+
+The engine walks the dict `[Key=Value, ...]` and replaces every
+occurrence of `{{Key}}` with `Value`. Unknown keys remain in the
+output verbatim — a deliberate choice so missing-key bugs surface
+visibly in generated code rather than being silently elided.
+
+```prolog
+?- render_template('Hello {{name}}!', [name='World'], R).
+R = "Hello World!".
+```
+
+### Truthy section blocks
+
+```mustache
+{{#flag}}
+This block renders only when `flag` is truthy.
+{{/flag}}
+```
+
+The block is rendered if and only if `flag` is in the dict and its
+value is *truthy* (see Truthiness Rules below). Block contents may
+contain further substitutions and nested sections.
+
+```prolog
+?- render_template('A{{#flag}}B{{/flag}}C', [flag=true], R).
+R = "ABC".
+
+?- render_template('A{{#flag}}B{{/flag}}C', [flag=false], R).
+R = "AC".
+```
+
+### Inverted section blocks
+
+```mustache
+{{^flag}}
+This block renders only when `flag` is falsy or absent.
+{{/flag}}
+```
+
+The complement of truthy sections. Useful for "show this fallback
+when the feature isn't enabled" patterns.
+
+```prolog
+?- render_template('A{{^flag}}B{{/flag}}C', [flag=false], R).
+R = "ABC".
+
+?- render_template('A{{^flag}}B{{/flag}}C', [flag=true], R).
+R = "AC".
+```
+
+### Truthiness rules
+
+A key is *truthy* in a dict when:
+
+- The key is present in the dict (i.e. `member(Key=Value, Dict)` succeeds), AND
+- The value is not one of: `false`, `0`, `""`, `''`, `[]`.
+
+A key not in the dict is *falsy*. Any value other than the explicit
+falsy list is truthy — `true`, non-empty atoms, non-zero numbers,
+non-empty strings, non-empty lists.
+
+This matches Python/Lua/JavaScript intuitions about truthiness rather
+than strict mustache semantics (which treats only `false` and `null`
+as falsy). The wider falsy set is more useful when a "flag" can come
+from option processing where missing means off.
+
+### Nested sections
+
+Sections of *different* names nest cleanly:
+
+```prolog
+?- render_template('[{{#a}}A{{#b}}B{{/b}}{{/a}}]', [a=true, b=true], R).
+R = "[AB]".
+?- render_template('[{{#a}}A{{#b}}B{{/b}}{{/a}}]', [a=true, b=false], R).
+R = "[A]".
+?- render_template('[{{#a}}A{{#b}}B{{/b}}{{/a}}]', [a=false, b=true], R).
+R = "[]".
+```
+
+## Deliberate non-features
+
+### Same-name nesting
+
+```mustache
+{{#x}} ... {{#x}} ... {{/x}} ... {{/x}}
+```
+
+The engine does not handle nested sections with the same name — the
+first `{{/x}}` will close the outermost `{{#x}}`. If you find
+yourself wanting this, restructure with two differently-named tags.
+
+### List iteration
+
+Mustache's `{{#list}}...{{/list}}` rendered once per element of a
+list is **not** supported. The engine treats every truthy non-list
+identically: render the body once. We don't need iteration in
+practice — generated code with N similar fragments is built by
+Prolog at codegen time and substituted as a single string.
+
+If list iteration becomes useful, add it as a separate feature with a
+distinct syntax (e.g. `{{*list}}...{{/list}}`) so the existing
+truthy-section semantics stay simple.
+
+### Partials, lambdas, set delimiters
+
+Mustache's `{{> partial}}`, lambda functions, and the `{{=delim=}}`
+delimiter-changing syntax are not implemented. Composition between
+templates uses the existing `compose_templates/3` predicate. Lambdas
+aren't relevant because templates are pure data. Delimiter changes
+are a workaround for languages where `{{` is syntactically
+significant — none of UnifyWeaver's targets need that escape hatch.
+
+## Engine architecture
+
+Rendering is a two-pass process:
+
+1. **`expand_sections/3`** — walks the template, finding the earliest
+   `{{#tag}}` or `{{^tag}}` and its matching `{{/tag}}`, then either
+   keeps or strips the body based on truthiness. Recurses on the body
+   (so substitutions and nested sections inside an expanded block get
+   processed) and on the tail.
+2. **`render_template_string/3`** — pure substitution pass over the
+   already-section-expanded string. Walks the dict and replaces each
+   `{{Key}}` with `Value`.
+
+```
+render_template/3
+    │
+    ├─▶ atom_string normalize
+    ├─▶ expand_sections/3   ← handles {{#}} {{^}} {{/}}
+    └─▶ render_template_string/3   ← handles {{key}}
+```
+
+The two passes are intentionally separate: section logic only touches
+section markers, substitution logic only touches `{{key}}` placeholders.
+This makes the engine easier to reason about and keeps the
+substitution path identical to the pre-section behaviour, so any
+existing template that doesn't use the new syntax renders byte-for-byte
+identically.
+
+## Adding new features
+
+### Step-by-step
+
+1. **Add the syntax detection** in `expand_sections/3` (if it's a
+   block construct) or as a new pass between `expand_sections` and
+   `render_template_string` (if it's a transform on the substituted
+   output).
+2. **Add unit tests** at `tests/core/test_template_sections.pl` (or
+   start a new test file if the feature is a separate concern). Each
+   test should use `copy_term/2` for variable scoping — Prolog's
+   default sharing across conjuncted goals will silently break tests
+   that reuse variable names.
+3. **Document the feature** here, including the deliberate
+   non-feature edges of the new syntax.
+4. **Run the existing test suite** to confirm no regression. Templates
+   that don't use the new feature must render identically.
+
+### Sketch: list iteration (if we ever need it)
+
+```prolog
+% Pseudocode addition to expand_sections — NOT implemented:
+%   {{*list}}body{{/list}} renders body once per element of list,
+%   exposing each element under the magic name {{this}}.
+```
+
+This would require a third pass (or a recursive call structure
+inside `expand_sections`), with a distinct syntax marker (`*` rather
+than `#`/`^`) to avoid conflating with truthy-section semantics.
+
+## Tests
+
+Run the section test suite:
+
+```sh
+swipl -g run_tests -t halt tests/core/test_template_sections.pl
+```
+
+Expected: 18 passed, 0 failed. The suite covers truthy/falsy/inverted
+sections, all six falsy values (false, 0, "", '', [], missing key),
+nested sections, substitution-inside-section interaction, and
+backward compatibility with pure-substitution templates.
+
+## Related modules
+
+- `src/unifyweaver/core/template_system.pl` — the engine itself
+- `tests/core/test_template_sections.pl` — section feature tests
+- `templates/targets/*/` — actual template files used by the various
+  transpilation targets
+
+## Status
+
+| Phase | Status |
+|-------|--------|
+| `{{key}}` substitution | Complete (original feature) |
+| `{{#flag}}/{{/flag}}` truthy sections | Complete |
+| `{{^flag}}/{{/flag}}` inverted sections | Complete |
+| Same-name nesting | Not supported (deliberate) |
+| `{{> partial}}` | Not supported |
+| List iteration | Not supported |
+| Lambdas / delimiter changes | Not supported |

--- a/src/unifyweaver/core/template_system.pl
+++ b/src/unifyweaver/core/template_system.pl
@@ -250,11 +250,27 @@ render_named_template(TemplateName, Dict, Options, Result) :-
 %% ORIGINAL TEMPLATE RENDERING (unchanged)
 %% ============================================
 
-%% Named placeholder substitution
-% Replaces {{name}} with corresponding value from dictionary
+%% Named placeholder substitution + section blocks.
+%
+% Supports a small mustache subset:
+%   {{name}}              — substitution (existing behavior)
+%   {{#flag}}...{{/flag}}  — truthy section: rendered iff Dict says flag is truthy
+%   {{^flag}}...{{/flag}}  — inverted section: rendered iff Dict says flag is falsy
+%
+% Section bodies may themselves contain {{name}} substitutions and other
+% sections (with different tag names; see limitation below).
+%
+% Truthiness rules: a key is truthy when it appears in Dict and its value
+% is not one of `false`, `0`, the empty string `""` or `''`, or the empty
+% list `[]`. A key not in Dict is falsy. Any other value is truthy.
+%
+% Limitation: same-named sections cannot nest. {{#x}}{{#x}}...{{/x}}{{/x}}
+% will close the outer section at the first {{/x}}. Different-named
+% sections nest fine.
 render_template(Template, Dict, Result) :-
     atom_string(Template, TStr),
-    render_template_string(TStr, Dict, Result).
+    expand_sections(TStr, Dict, Expanded),
+    render_template_string(Expanded, Dict, Result).
 
 % Fixed version using atom_string and sub_atom for reliable replacement
 render_template_string(Template, [], Template) :- !.
@@ -278,6 +294,108 @@ replace_substring(String, Find, Replace, Result) :-
         string_concat(Part1, RestResult, Result)
     ;   Result = String
     ).
+
+%% ============================================
+%% MUSTACHE SECTION EXPANSION
+%% ============================================
+%
+% Pre-processing pass that handles {{#flag}}...{{/flag}} and
+% {{^flag}}...{{/flag}} before the substitution pass runs.
+
+%% expand_sections(+Template, +Dict, -Result)
+%  Strips or keeps section blocks based on truthiness of dict entries.
+expand_sections(Template, Dict, Result) :-
+    (   find_first_section(Template, Kind, Tag, Before, Body, After)
+    ->  (   keep_section_block(Kind, Tag, Dict)
+        ->  expand_sections(Body, Dict, BodyExpanded),
+            expand_sections(After, Dict, AfterExpanded),
+            string_concat(Before, BodyExpanded, P1),
+            string_concat(P1, AfterExpanded, Result)
+        ;   expand_sections(After, Dict, AfterExpanded),
+            string_concat(Before, AfterExpanded, Result)
+        )
+    ;   Result = Template
+    ).
+
+%% find_first_section(+Str, -Kind, -Tag, -Before, -Body, -After)
+%  Locate the first {{#Tag}} or {{^Tag}} in Str and its matching
+%  {{/Tag}}.  Body is the section's contents (markers excluded);
+%  Before/After are the parts of Str outside the section.
+find_first_section(Str, Kind, Tag, Before, Body, After) :-
+    earliest_section_open(Str, Kind, Tag, OpenIdx, BodyStart),
+    format(string(CloseMarker), "{{/~w}}", [Tag]),
+    string_length(CloseMarker, CMLen),
+    sub_string(Str, BodyStart, _, 0, BodyAndAfter),
+    sub_string(BodyAndAfter, BodyEndRel, CMLen, _, CloseMarker),
+    sub_string(BodyAndAfter, 0, BodyEndRel, _, Body),
+    AfterStart is BodyEndRel + CMLen,
+    sub_string(BodyAndAfter, AfterStart, _, 0, After),
+    sub_string(Str, 0, OpenIdx, _, Before).
+
+%% earliest_section_open(+Str, -Kind, -Tag, -OpenIdx, -BodyStart)
+%  Find the earliest {{#TAG}} or {{^TAG}} in Str.  Returns Kind in
+%  {section, inverted_section}, the absolute Index of the {{ at the
+%  opener, and BodyStart, the absolute index just after the closing
+%  }} of the open marker.
+earliest_section_open(Str, Kind, Tag, OpenIdx, BodyStart) :-
+    findall(I-K-T-B,
+            ( ( K = section,          Marker = "{{#"
+              ; K = inverted_section, Marker = "{{^"
+              ),
+              section_marker_at(Str, Marker, I, T, B)
+            ),
+            All),
+    All \= [],
+    sort(All, [OpenIdx-Kind-Tag-BodyStart|_]).
+
+%% section_marker_at(+Str, +Marker, -OpenIdx, -Tag, -BodyStart)
+%  Locate `{{#TAG}}` or `{{^TAG}}` in Str.  Marker is the 3-character
+%  opener (e.g. "{{#").  TAG must be alphanumeric/underscore.
+section_marker_at(Str, Marker, OpenIdx, Tag, BodyStart) :-
+    string_length(Marker, MLen),
+    sub_string(Str, OpenIdx, MLen, _, Marker),
+    AfterMarker is OpenIdx + MLen,
+    sub_string(Str, AfterMarker, _, 0, Tail),
+    sub_string(Tail, EndRel, 2, _, "}}"),
+    sub_string(Tail, 0, EndRel, _, TagStr),
+    TagStr \= "",
+    valid_tag_name(TagStr),
+    atom_string(Tag, TagStr),
+    BodyStart is AfterMarker + EndRel + 2.
+
+%% valid_tag_name(+TagStr)
+%  A tag is valid if every character is alnum or underscore.  This
+%  prevents `{{#one}}…{{/two}}` from masquerading as `{{#one two}}`
+%  or matching tag boundaries with whitespace.
+valid_tag_name(TagStr) :-
+    string_chars(TagStr, Chars),
+    Chars \= [],
+    forall(member(C, Chars), tag_char(C)).
+
+tag_char(C) :- char_type(C, alnum), !.
+tag_char('_').
+
+%% keep_section_block(+Kind, +Tag, +Dict)
+%  True when the section body should be rendered.  For Kind=section
+%  this means Tag is truthy in Dict.  For Kind=inverted_section it
+%  means Tag is falsy.
+keep_section_block(section, Tag, Dict) :-
+    truthy_in(Dict, Tag).
+keep_section_block(inverted_section, Tag, Dict) :-
+    \+ truthy_in(Dict, Tag).
+
+%% truthy_in(+Dict, +Tag)
+%  Tag is truthy in Dict if Dict contains `Tag=Value` and Value is
+%  not falsy.  Falsy values: false, 0, "", '', [].
+truthy_in(Dict, Tag) :-
+    member(Tag=Value, Dict),
+    \+ falsy_value(Value).
+
+falsy_value(false).
+falsy_value(0).
+falsy_value("").
+falsy_value('').
+falsy_value([]).
 
 %% Compose multiple templates into one
 compose_templates([], _, "") :- !.
@@ -746,6 +864,66 @@ test_template_system :-
     get_template_config(test_template, [source_order([file])], Config7),
     member(source_order([file]), Config7),
     writeln('PASS'),
+
+    % Test 8: Truthy section keeps body
+    write('Test 8 - Section, truthy: '),
+    render_template('A{{#flag}}B{{/flag}}C', [flag=true], R8),
+    (sub_string(R8, _, _, _, 'ABC') -> writeln('PASS') ; (format('FAIL: got ~w~n', [R8]), fail)),
+
+    % Test 9: Falsy section drops body
+    write('Test 9 - Section, falsy: '),
+    render_template('A{{#flag}}B{{/flag}}C', [flag=false], R9),
+    (sub_string(R9, _, _, _, 'AC'), \+ sub_string(R9, _, _, _, 'B')
+     -> writeln('PASS') ; (format('FAIL: got ~w~n', [R9]), fail)),
+
+    % Test 10: Missing key is falsy
+    write('Test 10 - Missing key is falsy: '),
+    render_template('A{{#absent}}B{{/absent}}C', [], R10),
+    (sub_string(R10, _, _, _, 'AC'), \+ sub_string(R10, _, _, _, 'B')
+     -> writeln('PASS') ; (format('FAIL: got ~w~n', [R10]), fail)),
+
+    % Test 11: Inverted section, falsy renders
+    write('Test 11 - Inverted section, falsy: '),
+    render_template('A{{^flag}}B{{/flag}}C', [flag=false], R11),
+    (sub_string(R11, _, _, _, 'ABC') -> writeln('PASS') ; (format('FAIL: got ~w~n', [R11]), fail)),
+
+    % Test 12: Inverted section, truthy hides
+    write('Test 12 - Inverted section, truthy: '),
+    render_template('A{{^flag}}B{{/flag}}C', [flag=true], R12),
+    (sub_string(R12, _, _, _, 'AC'), \+ sub_string(R12, _, _, _, 'B')
+     -> writeln('PASS') ; (format('FAIL: got ~w~n', [R12]), fail)),
+
+    % Test 13: Empty string is falsy
+    write('Test 13 - Empty string is falsy: '),
+    render_template('A{{#flag}}B{{/flag}}C', [flag=""], R13),
+    (sub_string(R13, _, _, _, 'AC'), \+ sub_string(R13, _, _, _, 'B')
+     -> writeln('PASS') ; (format('FAIL: got ~w~n', [R13]), fail)),
+
+    % Test 14: Substitution inside truthy section
+    write('Test 14 - Substitution inside section: '),
+    render_template('Hello {{#greet}}{{name}}{{/greet}}!', [greet=true, name='World'], R14),
+    (sub_string(R14, _, _, _, 'Hello World!') -> writeln('PASS')
+     ; (format('FAIL: got ~w~n', [R14]), fail)),
+
+    % Test 15: Nested differently-named sections
+    write('Test 15 - Nested sections: '),
+    render_template('[{{#a}}A{{#b}}B{{/b}}{{/a}}]', [a=true, b=true], R15a),
+    render_template('[{{#a}}A{{#b}}B{{/b}}{{/a}}]', [a=true, b=false], R15b),
+    render_template('[{{#a}}A{{#b}}B{{/b}}{{/a}}]', [a=false, b=true], R15c),
+    (sub_string(R15a, _, _, _, '[AB]'),
+     sub_string(R15b, _, _, _, '[A]'), \+ sub_string(R15b, _, _, _, 'B'),
+     sub_string(R15c, _, _, _, '[]'),  \+ sub_string(R15c, _, _, _, 'A'),
+     \+ sub_string(R15c, _, _, _, 'B')
+     -> writeln('PASS')
+     ; (format('FAIL: a=t b=t got ~w~n  a=t b=f got ~w~n  a=f b=t got ~w~n',
+               [R15a, R15b, R15c]), fail)),
+
+    % Test 16: Backward compatibility — existing pure-substitution
+    % templates still render identically (no { #/^/ } syntax in them).
+    write('Test 16 - No section syntax = unchanged: '),
+    render_template('plain {{x}} plain {{y}} plain', [x='X', y='Y'], R16),
+    (sub_string(R16, _, _, _, 'plain X plain Y plain')
+     -> writeln('PASS') ; (format('FAIL: got ~w~n', [R16]), fail)),
 
     % Clean up
     clear_template_cache(test_cached),

--- a/tests/core/test_template_sections.pl
+++ b/tests/core/test_template_sections.pl
@@ -1,0 +1,142 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% test_template_sections.pl - Tests for the mustache-section additions
+% to template_system.pl ({{#flag}}/{{/flag}} and {{^flag}}/{{/flag}}).
+%
+% Standalone runner: each test gets its own scope via copy_term so the
+% variables don't leak between cases.
+%
+% Usage:
+%   swipl -g run_tests -t halt tests/core/test_template_sections.pl
+
+:- use_module('../../src/unifyweaver/core/template_system').
+
+:- dynamic pass_count/1, fail_count/1.
+
+run_test(Name, Goal) :-
+    format("Test ~w: ", [Name]),
+    copy_term(Goal, FreshGoal),
+    (   catch(call(FreshGoal), E,
+              (format("ERROR ~w~n", [E]), fail))
+    ->  writeln("PASS"), bump_pass
+    ;   writeln("FAIL"), bump_fail
+    ).
+
+bump_pass :-
+    retract(pass_count(N)),
+    N1 is N + 1,
+    assertz(pass_count(N1)).
+
+bump_fail :-
+    retract(fail_count(N)),
+    N1 is N + 1,
+    assertz(fail_count(N1)).
+
+reset_counters :-
+    retractall(pass_count(_)),
+    retractall(fail_count(_)),
+    assertz(pass_count(0)),
+    assertz(fail_count(0)).
+
+run_tests :-
+    reset_counters,
+    writeln('=== Template Engine: Section Tests ==='),
+
+    % --- Section blocks (truthy) ---
+    run_test('section_truthy_keeps_body', (
+        render_template('A{{#flag}}B{{/flag}}C', [flag=true], R),
+        sub_string(R, _, _, _, 'ABC')
+    )),
+    run_test('section_falsy_strips_body', (
+        render_template('A{{#flag}}B{{/flag}}C', [flag=false], R),
+        sub_string(R, _, _, _, 'AC'),
+        \+ sub_string(R, _, _, _, 'B')
+    )),
+    run_test('section_missing_key_strips_body', (
+        render_template('A{{#absent}}B{{/absent}}C', [], R),
+        sub_string(R, _, _, _, 'AC'),
+        \+ sub_string(R, _, _, _, 'B')
+    )),
+    run_test('section_empty_string_is_falsy', (
+        render_template('A{{#flag}}B{{/flag}}C', [flag=""], R),
+        sub_string(R, _, _, _, 'AC'),
+        \+ sub_string(R, _, _, _, 'B')
+    )),
+    run_test('section_zero_is_falsy', (
+        render_template('A{{#flag}}B{{/flag}}C', [flag=0], R),
+        sub_string(R, _, _, _, 'AC'),
+        \+ sub_string(R, _, _, _, 'B')
+    )),
+    run_test('section_empty_list_is_falsy', (
+        render_template('A{{#flag}}B{{/flag}}C', [flag=[]], R),
+        sub_string(R, _, _, _, 'AC'),
+        \+ sub_string(R, _, _, _, 'B')
+    )),
+
+    % --- Inverted sections ---
+    run_test('inverted_falsy_keeps_body', (
+        render_template('A{{^flag}}B{{/flag}}C', [flag=false], R),
+        sub_string(R, _, _, _, 'ABC')
+    )),
+    run_test('inverted_truthy_strips_body', (
+        render_template('A{{^flag}}B{{/flag}}C', [flag=true], R),
+        sub_string(R, _, _, _, 'AC'),
+        \+ sub_string(R, _, _, _, 'B')
+    )),
+    run_test('inverted_missing_key_keeps_body', (
+        render_template('A{{^absent}}B{{/absent}}C', [], R),
+        sub_string(R, _, _, _, 'ABC')
+    )),
+
+    % --- Substitutions inside sections ---
+    run_test('substitution_inside_truthy_section', (
+        render_template('Hello {{#greet}}{{name}}{{/greet}}!', [greet=true, name='World'], R),
+        sub_string(R, _, _, _, 'Hello World!')
+    )),
+    run_test('substitution_inside_falsy_section_dropped', (
+        render_template('Hello {{#greet}}{{name}}{{/greet}}!', [greet=false, name='World'], R),
+        sub_string(R, _, _, _, 'Hello !'),
+        \+ sub_string(R, _, _, _, 'World')
+    )),
+
+    % --- Nested differently-named sections ---
+    run_test('nested_both_truthy', (
+        render_template('[{{#a}}A{{#b}}B{{/b}}{{/a}}]', [a=true, b=true], R),
+        sub_string(R, _, _, _, '[AB]')
+    )),
+    run_test('nested_outer_truthy_inner_falsy', (
+        render_template('[{{#a}}A{{#b}}B{{/b}}{{/a}}]', [a=true, b=false], R),
+        sub_string(R, _, _, _, '[A]'),
+        \+ sub_string(R, _, _, _, 'B')
+    )),
+    run_test('nested_outer_falsy', (
+        render_template('[{{#a}}A{{#b}}B{{/b}}{{/a}}]', [a=false, b=true], R),
+        sub_string(R, _, _, _, '[]'),
+        \+ sub_string(R, _, _, _, 'A'),
+        \+ sub_string(R, _, _, _, 'B')
+    )),
+
+    % --- Backward compatibility ---
+    run_test('plain_substitution_still_works', (
+        render_template('plain {{x}} plain {{y}} plain', [x='X', y='Y'], R),
+        sub_string(R, _, _, _, 'plain X plain Y plain')
+    )),
+    run_test('template_with_no_template_syntax_passes_through', (
+        render_template('just literal text', [unused=true], R),
+        sub_string(R, _, _, _, 'just literal text')
+    )),
+
+    % --- Edge cases ---
+    run_test('only_section_truthy', (
+        render_template('{{#k}}hi{{/k}}', [k=true], R),
+        sub_string(R, _, _, _, 'hi')
+    )),
+    run_test('only_section_falsy_yields_empty', (
+        render_template('{{#k}}hi{{/k}}', [k=false], R),
+        atom_string(R, "") ; R == ""
+    )),
+
+    pass_count(P), fail_count(F),
+    format("~n=== ~w passed, ~w failed ===~n", [P, F]),
+    (   F =:= 0 -> true ; halt(1) ).


### PR DESCRIPTION
  ## Summary

  Extends `src/unifyweaver/core/template_system.pl` with support for **mustache truthy and inverted section blocks** on
  top of the existing key-substitution mechanism. The engine remains fully backward-compatible: any template that uses
  no section markers renders byte-for-byte identically to before.

  This is the standalone engine upgrade. A follow-up PR will use the new sections to clean up the WAM Haskell
  `main.hs.mustache` template for the int-atom seed pathway (the actual motivating use case from the WAM hybrid target
  work). Doing the engine upgrade as its own commit makes review and rollback easier.

  ## What this PR adds

  ### `{{#flag}}...{{/flag}}` — truthy sections

  The block renders only when `flag` is truthy in the dict. Missing or falsy keys cause the entire block (and its
  markers) to be dropped.

  ```prolog
  ?- render_template('Hello{{#shout}}!!!{{/shout}}', [shout=true], R).
  R = "Hello!!!".
  ```
  ```
  ?- render_template('Hello{{#shout}}!!!{{/shout}}', [shout=false], R).
  R = "Hello".
  ```

  {{^flag}}...{{/flag}} — inverted sections

  The complement: renders only when flag is falsy or missing. Useful for fallback content.
  ```
  ?- render_template('Status: {{#online}}up{{/online}}{{^online}}DOWN{{/online}}',
                     [online=false], R).
  R = "Status: DOWN".
  ```

  Truthiness rules

  A flag is truthy when (a) the key is present in the dict and (b) the value is not one of: false, 0, "", '', [].
  Missing keys are falsy. This wider falsy set is more useful for code generation than strict mustache semantics — a
  missing option usually means "feature is off".

  Nested sections

  Sections of different names nest cleanly:

  ?- render_template('[{{#a}}A{{#b}}B{{/b}}{{/a}}]', [a=true, b=true], R).
  R = "[AB]".
  ?- render_template('[{{#a}}A{{#b}}B{{/b}}{{/a}}]', [a=false, b=true], R).
  R = "[]".

  If outer is falsy, the entire block — including any inner sections — is stripped without ever evaluating the inner
  condition.

  What this PR deliberately does not add

| Feature | Status | Reason |
|---|---|---|
| Same-name section nesting | Not supported | The first {{/x}} always closes the outermost {{#x}}. If you find yourself wanting same-name nesting, restructure with two differently-named tags. Documented limitation. |
| {{#list}}...{{/list}} list iteration | Not supported | For code generation, we always build repeated content as a single string in Prolog and substitute via {{key}}. If list iteration becomes useful later, it would be added with distinct syntax (e.g. {{*list}}) so truthy-section semantics stay simple. |
| {{> partial}} | Not supported | Composition between templates uses the existing compose_templates/3. |
| Lambdas | Not supported | Templates are pure data. |
| Delimiter-changing {{=delim=}} | Not supported | None of UnifyWeaver's targets need that escape hatch. |

  These are documented in docs/design/TEMPLATE_ENGINE.md so the design choices stay visible.

  Implementation

  Two-pass renderer:

  1. expand_sections/3 — walks the template, finds the earliest {{#tag}} or {{^tag}}, locates its matching {{/tag}}, and
   either keeps the body (recursing on nested constructs) or strips it.
  2. render_template_string/3 — pure {{key}} substitution on the section-expanded result. Unchanged from before.

  render_template/3
      │
      ├─▶ atom_string normalize
      ├─▶ expand_sections/3   ← handles {{#}} {{^}} {{/}}
      └─▶ render_template_string/3   ← handles {{key}}

  This separation means: any template that uses no section markers is rendered byte-for-byte identically to how it was
  rendered before sections existed. The new feature is purely additive.

  Tests

  New file: tests/core/test_template_sections.pl (standalone runner, 18 tests).

  $ swipl -g run_tests -t halt tests/core/test_template_sections.pl
  === Template Engine: Section Tests ===
  Test section_truthy_keeps_body: PASS
  Test section_falsy_strips_body: PASS
  Test section_missing_key_strips_body: PASS
  Test section_empty_string_is_falsy: PASS
  Test section_zero_is_falsy: PASS
  Test section_empty_list_is_falsy: PASS
  Test inverted_falsy_keeps_body: PASS
  Test inverted_truthy_strips_body: PASS
  Test inverted_missing_key_keeps_body: PASS
  Test substitution_inside_truthy_section: PASS
  Test substitution_inside_falsy_section_dropped: PASS
  Test nested_both_truthy: PASS
  Test nested_outer_truthy_inner_falsy: PASS
  Test nested_outer_falsy: PASS
  Test plain_substitution_still_works: PASS
  Test template_with_no_template_syntax_passes_through: PASS
  Test only_section_truthy: PASS
  Test only_section_falsy_yields_empty: PASS

  === 18 passed, 0 failed ===

  Coverage: truthy/falsy/inverted sections, all six falsy values (false, 0, "", '', [], missing), nested sections,
  substitution-inside-section interaction, backward compatibility, edge cases (only-section, missing key).

  Note for future tests: each test uses copy_term/2 for variable scoping. Without that, Prolog's default variable
  sharing across conjuncted goals silently breaks tests that reuse names like R. This was caught and fixed during
  development; documented in TEMPLATE_ENGINE.md's "Adding new features" section.

  The in-source test_template_system/0 is also extended with section tests (8–15) but has a pre-existing dependency
  issue at Test 3 (constraint_analyzer:get_dedup_strategy/2) unrelated to this work — the standalone test file is the
  cleaner runner.

  Documentation

  New: docs/design/TEMPLATE_ENGINE.md

  Covers the full surface area: what's supported, what's deliberately omitted (with reasons), truthiness rules, two-pass
   architecture, how to add new features, current status table.

  The companion education-book documentation lands separately in the education repo —
  book-02-bash-target/05_template_system.md Chapter 8 gets a new "Section Blocks: Conditional Output" subsection with
  examples and when-to-use guidance.

  Why now

  The original motivating use case is the int-atom seed pathway for the WAM Haskell target (related to the unmerged work
   toward task #157). The existing templates/targets/haskell_wam/main.hs.mustache hardcodes TSV-based seed loading;
  supporting an LMDB-int-seeds mode with the old engine would have meant either two parallel templates (maintenance
  burden) or string-concat-fragments-in-Prolog (the existing pattern for things like LmdbImports / lmdb_setup, which is
  noticeably ugly).

  With section blocks, both modes can coexist in one template file gated on a flag:
```
  {{#int_atom_seeds}}
  -- LMDB-int-seeds path
  seedIds <- loadIntSeedsFromLmdb lmdbPath
  {{/int_atom_seeds}}
  {{^int_atom_seeds}}
  -- TSV path
  articleCategories <- loadTsvPairs (factsDir ++ "/article_category.tsv")
  {{/int_atom_seeds}}
```
  Doing the engine upgrade as its own PR keeps that future work focused on the actual semantics change rather than
  mixing it with template-engine plumbing.

  Test plan

  - tests/core/test_template_sections.pl runs: 18/18 pass
  - Templates using no section syntax render identically to pre-PR behaviour (covered by plain_substitution_still_works
  and template_with_no_template_syntax_passes_through tests)
  - All six falsy values (false, 0, "", '', [], missing key) correctly trigger section stripping
  - Follow-up: use the new sections in main.hs.mustache for the int-atoms work
  - Follow-up: spot-check a few existing template files render byte-identically (probably worth a dedicated regression
  test if any future engine change touches the substitution path)

  