### PR TITLE
feat(artifacts): carry preprocess metadata into Elixir and add LMDB prototype

### DIFF
--- a/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
+++ b/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
@@ -493,6 +493,13 @@ Prototype status:
   programs use that helper, and pipeline programs can now take
   `UNIFYWEAVER_RELATION_SOURCE_MODE` plus `UNIFYWEAVER_RELATION_ARTIFACT_DIR`
   without re-implementing artifact registration in each generated template.
+- Termux viability is now less speculative for LMDB than before. A local probe
+  using the native `liblmdb` Termux package plus a Rust client confirmed a real
+  open/write/read round-trip in this environment. The current prototype lives
+  at `examples/lmdb_relation_artifact/` and builds a small exact two-column
+  LMDB artifact with a sidecar `manifest.json`. That does not settle the final
+  cross-target artifact format, but it does confirm that LMDB-backed exact
+  artifact experiments are feasible here without deferring all work to desktop.
 
 ### N-ary delimited artifact direction
 

--- a/docs/proposals/WAM_FACT_SHAPE_PLAN.md
+++ b/docs/proposals/WAM_FACT_SHAPE_PLAN.md
@@ -127,6 +127,29 @@ ETS, memory-mapped hash tables, and the preprocessed-artifact
 direction already in motion on the C# side without touching the
 emitter (see `PREPROCESSED_PREDICATE_ARTIFACTS.md`, PR #1548).
 
+Follow-up direction:
+
+- `external_source` should stop being only a raw `SourceSpec` carrier.
+- When a shared `preprocess/2` declaration exists, the emitted module
+  should also preserve normalized preprocess metadata:
+  - declaration source
+  - resolved mode
+  - declaration kind
+  - normalized format
+  - normalized access contracts
+  - serialized options
+- The first implementation seam is generated module metadata, not a
+  runtime behaviour change. That keeps TSV / ETS / SQLite adaptors
+  stable while making Elixir a consumer of the same declaration layer
+  used by the newer Clojure artifact manifest work.
+- Near-term storage decision: keep the Elixir runtime on the current
+  TSV / ETS / SQLite adaptor set for now. LMDB is now confirmed viable
+  in Termux via a Rust-side exact-artifact probe, but that is better
+  treated as a shared artifact/provider backend first than as an
+  Elixir-only binding commitment. The Elixir target should consume the
+  shared preprocess metadata seam now and defer a direct LMDB adaptor
+  until the artifact/provider boundary is a little more stable.
+
 Work:
 
 - Define the `FactSource` behaviour in `wam_elixir_target.pl`:

--- a/docs/proposals/WAM_FACT_SHAPE_SPEC.md
+++ b/docs/proposals/WAM_FACT_SHAPE_SPEC.md
@@ -157,6 +157,12 @@ Requirements on the emitter:
 - `SourceSpec` in `fact_layout(P/A, external_source(SourceSpec))` is
   an opaque term passed through to the runtime registration.
   Minimum: `tsv(Path, ArityHeader)`.
+- When a shared `preprocess/2` declaration exists for the predicate,
+  the emitted module should preserve normalized preprocess metadata
+  alongside that raw source spec so later runtime/provider code can
+  inspect the chosen declaration intent without reparsing Prolog.
+  The first Elixir seam for this is module metadata, not a live runtime
+  provider contract.
 - `run/1` / `run/0` bodies call `WamRuntime.FactSource.open(SourceSpec, state, P/A)`
   and then use the same `stream_facts` / `backtrack` contract as
   `inline_data`.
@@ -168,6 +174,16 @@ Requirements on the runtime:
   absent, the runtime falls back to linear scan.
 - A registration helper so drivers can bind a `SourceSpec` atom to a
   concrete implementation before calling `Mod.run/1`.
+- The runtime does not need to consume preprocess metadata yet, but the
+  generated module should surface it in a stable shape so future TSV,
+  ETS, SQLite, mmap, or manifest-backed providers can use the same
+  declaration seam.
+- Near-term backend choice: Elixir should keep using the existing
+  `FactSource` adaptors while the shared artifact/provider boundary
+  matures. A local Rust LMDB prototype now confirms that LMDB is viable
+  in Termux for exact relation artifacts, but that should land first as
+  a shared artifact/provider path rather than a direct Elixir binding
+  requirement.
 
 ## Option plumbing
 

--- a/examples/lmdb_relation_artifact/Cargo.toml
+++ b/examples/lmdb_relation_artifact/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "lmdb_relation_artifact"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+lmdb = "0.8.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sha2 = "0.10"

--- a/examples/lmdb_relation_artifact/README.md
+++ b/examples/lmdb_relation_artifact/README.md
@@ -1,0 +1,72 @@
+# LMDB Relation Artifact Prototype
+
+Small Rust prototype for exact two-column relation artifacts backed by LMDB.
+
+Current scope:
+
+- build an LMDB artifact from a two-column TSV file
+- emit a small `manifest.json` beside the LMDB environment
+- support exact `arg1` lookup
+- support full scan
+- support `dupsort` for one-to-many relations
+
+This is intentionally a prototype, not a committed cross-target artifact
+format. The purpose is to validate that LMDB works as a local exact-artifact
+backend in the current Termux environment and to give the shared
+preprocess/manifest work a concrete non-C# backend to target.
+
+## Usage
+
+Build an artifact:
+
+```sh
+cargo run -- build edge/2 ./edge.tsv ./edge_artifact
+```
+
+Build a dupsort artifact:
+
+```sh
+cargo run -- build category_parent/2 ./category_parent.tsv ./category_parent_artifact --dupsort
+```
+
+Lookup one key:
+
+```sh
+cargo run -- get ./edge_artifact edge/2 a
+```
+
+Scan all rows:
+
+```sh
+cargo run -- scan ./edge_artifact edge/2
+```
+
+## Manifest
+
+The prototype writes `manifest.json` with:
+
+- predicate
+- resolved mode
+- artifact kind
+- format version
+- physical format
+- exactness
+- source path and SHA-256
+- schema hash
+- db name
+- dupsort flag
+- key/value encoding
+- supported access contracts
+- target capabilities
+- declaration metadata
+  - source
+  - mode
+  - kind
+  - format
+  - access contracts
+  - options
+- expected LMDB files
+
+This is deliberately closer to the shared preprocess/artifact metadata seam than
+the first smoke prototype, even though the declaration block is still
+prototype-owned rather than coming from a real `preprocess/2` declaration.

--- a/examples/lmdb_relation_artifact/src/main.rs
+++ b/examples/lmdb_relation_artifact/src/main.rs
@@ -1,0 +1,382 @@
+use lmdb::{
+    Cursor, Database, DatabaseFlags, Environment, RoTransaction, RwTransaction, Transaction,
+    WriteFlags,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::env;
+use std::error::Error;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+type DynError = Box<dyn Error>;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ArtifactDeclaration {
+    source: String,
+    mode: String,
+    kind: String,
+    format: String,
+    access_contracts: Vec<String>,
+    options: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ArtifactManifest {
+    predicate: String,
+    resolved_mode: String,
+    artifact_kind: String,
+    format_version: u32,
+    physical_format: String,
+    exactness: String,
+    source_path: String,
+    source_hash: String,
+    schema_hash: String,
+    db_name: String,
+    dupsort: bool,
+    key_encoding: String,
+    value_encoding: String,
+    access: Vec<String>,
+    target_capabilities: Vec<String>,
+    declaration: ArtifactDeclaration,
+    files: Vec<String>,
+}
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("lmdb_relation_artifact: {err}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), DynError> {
+    let args: Vec<String> = env::args().collect();
+    match args.as_slice() {
+        [_prog, cmd, predicate, tsv_path, artifact_dir] if cmd == "build" => {
+            build_command(predicate, Path::new(tsv_path), Path::new(artifact_dir), false)
+        }
+        [_prog, cmd, predicate, tsv_path, artifact_dir, flag]
+            if cmd == "build" && flag == "--dupsort" =>
+        {
+            build_command(predicate, Path::new(tsv_path), Path::new(artifact_dir), true)
+        }
+        [_prog, cmd, artifact_dir, predicate, key] if cmd == "get" => {
+            get_command(Path::new(artifact_dir), predicate, key)
+        }
+        [_prog, cmd, artifact_dir, predicate] if cmd == "scan" => {
+            scan_command(Path::new(artifact_dir), predicate)
+        }
+        _ => {
+            print_usage();
+            Ok(())
+        }
+    }
+}
+
+fn print_usage() {
+    eprintln!(
+        "usage:
+  lmdb_relation_artifact build <predicate> <tsv-path> <artifact-dir> [--dupsort]
+  lmdb_relation_artifact get <artifact-dir> <predicate> <key>
+  lmdb_relation_artifact scan <artifact-dir> <predicate>"
+    );
+}
+
+fn build_command(
+    predicate: &str,
+    tsv_path: &Path,
+    artifact_dir: &Path,
+    dupsort: bool,
+) -> Result<(), DynError> {
+    let rows = read_tsv_rows(tsv_path)?;
+    fs::create_dir_all(artifact_dir)?;
+
+    let env = open_env(artifact_dir)?;
+    let flags = if dupsort {
+        DatabaseFlags::DUP_SORT
+    } else {
+        DatabaseFlags::empty()
+    };
+    let db = env.create_db(Some(predicate), flags)?;
+
+    {
+        let mut txn = env.begin_rw_txn()?;
+        write_rows(&mut txn, db, &rows)?;
+        txn.commit()?;
+    }
+
+    let manifest = ArtifactManifest {
+        predicate: predicate.to_string(),
+        resolved_mode: "artifact".to_string(),
+        artifact_kind: "lmdb_exact_relation_v1".to_string(),
+        format_version: 1,
+        physical_format: "lmdb_dupsort_btree".to_string(),
+        exactness: "exact".to_string(),
+        source_path: tsv_path.display().to_string(),
+        source_hash: file_sha256(tsv_path)?,
+        schema_hash: "sha256:two_column_utf8_relation_v1".to_string(),
+        db_name: predicate.to_string(),
+        dupsort,
+        key_encoding: "utf8".to_string(),
+        value_encoding: "utf8".to_string(),
+        access: if dupsort {
+            vec![
+                "scan".to_string(),
+                "arg1_lookup".to_string(),
+                "arg1_multi_lookup".to_string(),
+            ]
+        } else {
+            vec!["scan".to_string(), "arg1_lookup".to_string()]
+        },
+        target_capabilities: vec![
+            "mmap".to_string(),
+            "mvcc_readers".to_string(),
+            "little_endian".to_string(),
+        ],
+        declaration: ArtifactDeclaration {
+            source: "prototype".to_string(),
+            mode: "artifact".to_string(),
+            kind: if dupsort {
+                "adjacency_index".to_string()
+            } else {
+                "exact_hash_index".to_string()
+            },
+            format: "lmdb_dupsort_btree".to_string(),
+            access_contracts: if dupsort {
+                vec![
+                    "scan".to_string(),
+                    "arg_position_lookup(1)".to_string(),
+                    "grouped_values_lookup([2])".to_string(),
+                ]
+            } else {
+                vec![
+                    "scan".to_string(),
+                    "arg_position_lookup(1)".to_string(),
+                    "exact_key_lookup".to_string(),
+                ]
+            },
+            options: if dupsort {
+                vec![
+                    "key([1])".to_string(),
+                    "values([2])".to_string(),
+                    "dupsort(true)".to_string(),
+                ]
+            } else {
+                vec!["key([1])".to_string(), "values([2])".to_string()]
+            },
+        },
+        files: vec![
+            "data.mdb".to_string(),
+            "lock.mdb".to_string(),
+            "manifest.json".to_string(),
+        ],
+    };
+    write_manifest(artifact_dir, &manifest)?;
+
+    println!(
+        "built predicate={} rows={} dupsort={} artifact_dir={}",
+        predicate,
+        rows.len(),
+        dupsort,
+        artifact_dir.display()
+    );
+    Ok(())
+}
+
+fn get_command(artifact_dir: &Path, predicate: &str, key: &str) -> Result<(), DynError> {
+    let manifest = load_manifest(artifact_dir)?;
+    let env = open_env_readonly(artifact_dir)?;
+    let db = env.open_db(Some(predicate))?;
+    let txn = env.begin_ro_txn()?;
+    let values = get_values(&txn, db, key.as_bytes(), manifest.dupsort)?;
+    for value in values {
+        println!("{key}\t{}", String::from_utf8_lossy(&value));
+    }
+    Ok(())
+}
+
+fn scan_command(artifact_dir: &Path, predicate: &str) -> Result<(), DynError> {
+    let env = open_env_readonly(artifact_dir)?;
+    let db = env.open_db(Some(predicate))?;
+    let txn = env.begin_ro_txn()?;
+    let mut cursor = txn.open_ro_cursor(db)?;
+    for (key, value) in cursor.iter_start() {
+        println!(
+            "{}\t{}",
+            String::from_utf8_lossy(key),
+            String::from_utf8_lossy(value)
+        );
+    }
+    Ok(())
+}
+
+fn open_env(path: &Path) -> Result<Environment, DynError> {
+    Ok(Environment::new()
+        .set_max_dbs(16)
+        .set_map_size(64 * 1024 * 1024)
+        .open(path)?)
+}
+
+fn open_env_readonly(path: &Path) -> Result<Environment, DynError> {
+    Ok(Environment::new()
+        .set_max_dbs(16)
+        .set_map_size(64 * 1024 * 1024)
+        .open(path)?)
+}
+
+fn read_tsv_rows(path: &Path) -> Result<Vec<(String, String)>, DynError> {
+    let input = fs::read_to_string(path)?;
+    let mut rows = Vec::new();
+    for (line_no, line) in input.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let (key, value) = line.split_once('\t').ok_or_else(|| {
+            let mut msg = String::new();
+            let _ = write!(
+                &mut msg,
+                "invalid TSV row at {}:{}; expected two columns",
+                path.display(),
+                line_no + 1
+            );
+            msg
+        })?;
+        rows.push((key.to_string(), value.to_string()));
+    }
+    Ok(rows)
+}
+
+fn write_rows(
+    txn: &mut RwTransaction<'_>,
+    db: Database,
+    rows: &[(String, String)],
+) -> Result<(), DynError> {
+    for (key, value) in rows {
+        txn.put(db, key, value, WriteFlags::empty())?;
+    }
+    Ok(())
+}
+
+fn get_values(
+    txn: &RoTransaction<'_>,
+    db: Database,
+    key: &[u8],
+    dupsort: bool,
+) -> Result<Vec<Vec<u8>>, DynError> {
+    if !dupsort {
+        return match txn.get(db, &key.to_vec()) {
+            Ok(value) => Ok(vec![value.to_vec()]),
+            Err(lmdb::Error::NotFound) => Ok(Vec::new()),
+            Err(err) => Err(Box::new(err)),
+        };
+    }
+    let mut cursor = txn.open_ro_cursor(db)?;
+    let mut values = Vec::new();
+    let key_buf = key.to_vec();
+    for (_k, value) in cursor.iter_dup_of(&key_buf)? {
+        values.push(value.to_vec());
+    }
+    Ok(values)
+}
+
+fn write_manifest(artifact_dir: &Path, manifest: &ArtifactManifest) -> Result<(), DynError> {
+    let path = artifact_dir.join("manifest.json");
+    let content = serde_json::to_string_pretty(manifest)?;
+    fs::write(path, content)?;
+    Ok(())
+}
+
+fn load_manifest(artifact_dir: &Path) -> Result<ArtifactManifest, DynError> {
+    let path = artifact_dir.join("manifest.json");
+    Ok(serde_json::from_str(&fs::read_to_string(path)?)?)
+}
+
+fn file_sha256(path: &Path) -> Result<String, DynError> {
+    let bytes = fs::read(path)?;
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn build_and_get_roundtrip() -> Result<(), DynError> {
+        let temp_root = unique_temp_dir("lmdb_artifact_roundtrip");
+        let tsv_path = temp_root.join("edge.tsv");
+        let artifact_dir = temp_root.join("artifact");
+        fs::create_dir_all(&temp_root)?;
+        fs::write(&tsv_path, "a\t1\nb\t2\n")?;
+
+        build_command("edge/2", &tsv_path, &artifact_dir, false)?;
+
+        let manifest = load_manifest(&artifact_dir)?;
+        assert_eq!(manifest.predicate, "edge/2");
+        assert!(!manifest.dupsort);
+        assert_eq!(manifest.resolved_mode, "artifact");
+        assert_eq!(manifest.physical_format, "lmdb_dupsort_btree");
+        assert_eq!(manifest.declaration.kind, "exact_hash_index");
+        assert!(manifest
+            .declaration
+            .access_contracts
+            .contains(&"exact_key_lookup".to_string()));
+        assert_eq!(manifest.access, vec!["scan", "arg1_lookup"]);
+
+        let env = open_env_readonly(&artifact_dir)?;
+        let db = env.open_db(Some("edge/2"))?;
+        let txn = env.begin_ro_txn()?;
+        let values = get_values(&txn, db, b"a", manifest.dupsort)?;
+        assert_eq!(values, vec![b"1".to_vec()]);
+
+        let mut cursor = txn.open_ro_cursor(db)?;
+        let rows: Vec<(Vec<u8>, Vec<u8>)> = cursor
+            .iter_start()
+            .map(|(k, v)| (k.to_vec(), v.to_vec()))
+            .collect();
+        assert_eq!(rows.len(), 2);
+
+        fs::remove_dir_all(temp_root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn build_dupsort_roundtrip() -> Result<(), DynError> {
+        let temp_root = unique_temp_dir("lmdb_artifact_dupsort");
+        let tsv_path = temp_root.join("edge.tsv");
+        let artifact_dir = temp_root.join("artifact");
+        fs::create_dir_all(&temp_root)?;
+        fs::write(&tsv_path, "a\t1\na\t2\n")?;
+
+        build_command("edge/2", &tsv_path, &artifact_dir, true)?;
+
+        let manifest = load_manifest(&artifact_dir)?;
+        assert!(manifest.dupsort);
+        assert_eq!(manifest.declaration.kind, "adjacency_index");
+        assert!(manifest.access.contains(&"arg1_multi_lookup".to_string()));
+        assert!(manifest
+            .declaration
+            .options
+            .contains(&"dupsort(true)".to_string()));
+
+        let env = open_env_readonly(&artifact_dir)?;
+        let db = env.open_db(Some("edge/2"))?;
+        let txn = env.begin_ro_txn()?;
+        let values = get_values(&txn, db, b"a", manifest.dupsort)?;
+        assert_eq!(values, vec![b"1".to_vec(), b"2".to_vec()]);
+
+        fs::remove_dir_all(temp_root)?;
+        Ok(())
+    }
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock drift")
+            .as_nanos();
+        env::temp_dir().join(format!("{prefix}_{nanos}"))
+    }
+}

--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -37,6 +37,8 @@
 :- use_module(library(pairs), [group_pairs_by_key/2]).
 :- use_module('wam_elixir_utils', [reg_id/2, is_label_part/1, camel_case/2, parse_arity/2]).
 :- use_module('../core/purity_certificate', [analyze_predicate_purity/2]).
+:- use_module('../core/predicate_preprocessing',
+              [declared_preprocess_metadata/4]).
 
 % ============================================================================
 % MAIN ENTRY POINT
@@ -67,7 +69,10 @@ lower_predicate_to_elixir(Pred/Arity, WamCode, Options, Code) :-
     Info = fact_shape_info(_, _, _, Layout),
     (   Layout = external_source(_)
     ->  render_external_source_module(CamelMod, CamelPred, PredStr, Arity,
-                                      ShapeComment, Code)
+                                      ShapeComment, Layout, Code)
+    ;   Layout = external_source(_, _)
+    ->  render_external_source_module(CamelMod, CamelPred, PredStr, Arity,
+                                      ShapeComment, Layout, Code)
     ;   Layout = inline_data(_),
         catch(extract_facts(Segments, Arity, FactsLiteral), _, fail),
         choose_index(Segments, Arity, Options, IndexResult)
@@ -218,20 +223,25 @@ inline_data_run1_body(indexed(_), Arity, Body) :-
 ', [Arity]).
 
 %% render_external_source_module(+CamelMod, +CamelPred, +PredStr, +Arity,
-%%                               +ShapeComment, -Code)
+%%                               +ShapeComment, +Layout, -Code)
 %  Phase-D external_source layout: no inline facts. `run/1` looks the
 %  source up in the FactSourceRegistry (drivers must register before
 %  calling), then dispatches to stream_all/lookup_by_arg1 through the
 %  FactSource behaviour facade. The SourceSpec the user passed in
-%  fact_layout/2 is opaque to the emitter — it is only consulted at
-%  runtime via the registry, which decouples the generated code from
-%  the concrete source implementation (TSV today; SQLite / ETS /
-%  preprocessed artifacts tomorrow).
-render_external_source_module(CamelMod, CamelPred, PredStr, Arity, ShapeComment, Code) :-
+%  fact_layout/2 remains opaque to the runtime adaptor path, but the
+%  generated module now also exposes any shared preprocess declaration
+%  metadata that was attached to the layout so manifest- / provider-like
+%  tooling can inspect the intended access contract.
+render_external_source_module(CamelMod, CamelPred, PredStr, Arity, ShapeComment,
+                              Layout, Code) :-
     format(string(PredIndicator), '~w/~w', [PredStr, Arity]),
+    external_source_layout_parts(Layout, SourceSpec, Metadata),
+    external_source_metadata_block(SourceSpec, Metadata, MetadataBlock),
     format(string(Code),
 'defmodule ~w.~w do
   @moduledoc "Lowered WAM-compiled predicate: ~w/~w (external_source)"
+
+~w
 
 ~w
 
@@ -277,7 +287,51 @@ render_external_source_module(CamelMod, CamelPred, PredStr, Arity, ShapeComment,
         :fail
     end
   end
-end', [CamelMod, CamelPred, PredStr, Arity, ShapeComment, PredIndicator, Arity, CamelPred]).
+end', [CamelMod, CamelPred, PredStr, Arity, ShapeComment, MetadataBlock,
+       PredIndicator, Arity, CamelPred]).
+
+external_source_layout_parts(external_source(SourceSpec), SourceSpec, none).
+external_source_layout_parts(external_source(SourceSpec, Metadata), SourceSpec, Metadata).
+
+external_source_metadata_block(SourceSpec, Metadata, Block) :-
+    elixir_term_string_literal(SourceSpec, SourceSpecLit),
+    external_source_preprocess_map(Metadata, PreprocessMap),
+    format(string(Block),
+'  @external_source_spec ~w
+  @external_source_metadata %{source_spec: @external_source_spec, preprocess: ~w}
+  def external_source_metadata, do: @external_source_metadata',
+           [SourceSpecLit, PreprocessMap]).
+
+external_source_preprocess_map(none, 'nil').
+external_source_preprocess_map(preprocess_metadata(Source, Mode, Kind, Format,
+                                                   AccessContracts, Options),
+                               MapLiteral) :-
+    elixir_term_string_literal(Source, SourceLit),
+    elixir_term_string_literal(Mode, ModeLit),
+    elixir_term_string_literal(Kind, KindLit),
+    elixir_term_string_literal(Format, FormatLit),
+    elixir_string_list_literal(AccessContracts, AccessLit),
+    elixir_string_list_literal(Options, OptionsLit),
+    format(string(MapLiteral),
+           '%{source: ~w, mode: ~w, kind: ~w, format: ~w, access_contracts: ~w, options: ~w}',
+           [SourceLit, ModeLit, KindLit, FormatLit, AccessLit, OptionsLit]).
+
+elixir_string_list_literal(Terms, Literal) :-
+    maplist(elixir_term_string_literal, Terms, Literals),
+    sort(Literals, SortedLiterals),
+    atomic_list_concat(SortedLiterals, ', ', Body),
+    format(atom(Literal), '[~w]', [Body]).
+
+elixir_term_string_literal(Term, Literal) :-
+    term_string(Term, TermString),
+    escape_elixir_string(TermString, Escaped),
+    format(atom(Literal), '"~w"', [Escaped]).
+
+escape_elixir_string(In, Out) :-
+    split_string(In, "\\", "", Parts1),
+    atomic_list_concat(Parts1, "\\\\", Tmp1),
+    split_string(Tmp1, "\"", "", Parts2),
+    atomic_list_concat(Parts2, "\\\"", Out).
 
 % ============================================================================
 % PHASE A: FACT-SHAPE CLASSIFICATION
@@ -348,14 +402,30 @@ combine_groundness(_, mixed).
 %  but callers can select a different built-in or register their own
 %  via the multifile `user:wam_elixir_layout_policy/5` hook.
 pick_layout(PredIndicator, _NClauses, _FactOnly, Options, Layout) :-
-    option(fact_layout(PredIndicator, UserLayout), Options), !,
-    Layout = UserLayout.
+    option(fact_layout(PredIndicator, UserLayout0), Options), !,
+    augment_layout_metadata(PredIndicator, UserLayout0, Layout).
 pick_layout(PredIndicator, _NClauses, _FactOnly, _Options, Layout) :-
-    catch(user:fact_layout(PredIndicator, UserLayout), _, fail), !,
-    Layout = UserLayout.
+    catch(user:fact_layout(PredIndicator, UserLayout0), _, fail), !,
+    augment_layout_metadata(PredIndicator, UserLayout0, Layout).
 pick_layout(PredIndicator, NClauses, FactOnly, Options, Layout) :-
     option(fact_layout_policy(PolicyName), Options, auto),
-    layout_policy(PolicyName, PredIndicator, NClauses, FactOnly, Options, Layout).
+    layout_policy(PolicyName, PredIndicator, NClauses, FactOnly, Options, Layout0),
+    augment_layout_metadata(PredIndicator, Layout0, Layout).
+
+augment_layout_metadata(_PredIndicator, external_source(SourceSpec, Metadata),
+                        external_source(SourceSpec, Metadata)) :-
+    !.
+augment_layout_metadata(PredIndicator, external_source(SourceSpec),
+                        external_source(SourceSpec, MetadataTerm)) :-
+    declared_preprocess_metadata(PredIndicator, Mode,
+                                 preprocess_info(Kind, Options),
+                                 Metadata),
+    !,
+    MetadataTerm = preprocess_metadata(shared_preprocess, Mode, Kind,
+                                       Metadata.format,
+                                       Metadata.access_contracts,
+                                       Options).
+augment_layout_metadata(_PredIndicator, Layout, Layout).
 
 %% layout_policy(+Policy, +PredIndicator, +NClauses, +FactOnly, +Options, -Layout)
 %  Phase-E pluggable layout selector. Three built-in policies:

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -518,6 +518,30 @@ test_phase_d_emits_external_source_shape :-
     ;   fail_test(Test, 'external_source shape missing or bled through to other layouts')
     ).
 
+test_phase_d_external_source_preserves_shared_preprocess_metadata :-
+    Test = 'Phase D: external_source preserves shared preprocess metadata in generated module',
+    phase_a_fixture_setup,
+    wam_target:compile_predicate_to_wam(phase_a_test:big_fact/2, [], WamCode),
+    setup_call_cleanup(
+        assertz(user:preprocess(big_fact/2, exact_hash_index([key([1]), values([2])]))),
+        (   Opts = [module_name('TestMod'),
+                    fact_layout(big_fact/2, external_source(tsv_marker))],
+            once(lower_predicate_to_elixir(big_fact/2, WamCode, Opts, Code)),
+            contains_string(Code, '@external_source_spec "tsv_marker"'),
+            contains_string(Code, '@external_source_metadata %{source_spec: @external_source_spec, preprocess: %{'),
+            contains_string(Code, 'source: "shared_preprocess"'),
+            contains_string(Code, 'mode: "artifact"'),
+            contains_string(Code, 'kind: "exact_hash_index"'),
+            contains_string(Code, 'format: "exact_hash_index"'),
+            contains_string(Code, 'access_contracts: ["arg_position_lookup(1)", "exact_key_lookup", "grouped_values_lookup([2])", "scan"]'),
+            contains_string(Code, 'options: ["key([1])", "values([2])"]'),
+            contains_string(Code, 'def external_source_metadata, do: @external_source_metadata')
+        ->  pass(Test)
+        ;   fail_test(Test, 'shared preprocess metadata missing from external_source module')
+        ),
+        maybe_abolish_test_predicate(preprocess/2)
+    ).
+
 test_phase_d_runtime_emits_fact_source :-
     Test = 'Phase D: runtime assembly emits FactSource behaviour + Tsv adaptor + Registry',
     compile_wam_runtime_to_elixir([], RuntimeCode),
@@ -834,6 +858,15 @@ test_par_wrap_segment_kill_switch :-
         retract(clause_body_analysis:order_independent(user:tier2_pure3/2))
     ).
 
+maybe_abolish_test_predicate(Name/Arity) :-
+    (   current_predicate(user:Name/Arity)
+    ->  abolish(user:Name/Arity)
+    ;   true
+    ).
+
+contains_string(Haystack, Needle) :-
+    once(sub_string(Haystack, _, _, _, Needle)).
+
 %% Test runner
 
 run_tests :-
@@ -877,6 +910,7 @@ run_tests :-
     test_phase_c_index_policy_none,
     test_phase_c_variable_head_no_index,
     test_phase_d_emits_external_source_shape,
+    test_phase_d_external_source_preserves_shared_preprocess_metadata,
     test_phase_d_runtime_emits_fact_source,
     test_phase_d_external_beats_inline_override,
     test_phase_e_auto_matches_pre_phase_e,


### PR DESCRIPTION
## Summary

This PR does two related things:

- threads shared `preprocess/2` metadata into generated Elixir
  `external_source` modules
- adds a Rust LMDB relation-artifact prototype with a manifest shape closer to
  the shared artifact/preprocess seam

Together, these changes push the project toward a cross-target artifact
boundary without forcing a finalized artifact format yet.

## What Changed

### Elixir external_source metadata

- `external_source(SourceSpec)` layouts are now augmented with normalized shared
  preprocess metadata when a `preprocess/2` declaration exists
- generated modules now expose:
  - `@external_source_spec`
  - `@external_source_metadata`
  - `external_source_metadata/0`
- this preserves:
  - declaration source
  - resolved mode
  - declaration kind
  - normalized format
  - access contracts
  - serialized options

Files:

- `src/unifyweaver/targets/wam_elixir_lowered_emitter.pl`
- `tests/test_wam_elixir_target.pl`

### LMDB relation artifact prototype

Added a new standalone Rust example crate:

- `examples/lmdb_relation_artifact/`

Current prototype scope:

- build an exact two-column LMDB artifact from TSV
- support:
  - full scan
  - exact arg1 lookup
  - dupsort one-to-many lookup
- emit `manifest.json` beside the LMDB environment

The prototype manifest now includes:

- `predicate`
- `resolved_mode`
- `artifact_kind`
- `format_version`
- `physical_format`
- `exactness`
- `source_path`
- `source_hash`
- `schema_hash`
- `db_name`
- `dupsort`
- `key_encoding`
- `value_encoding`
- `access`
- `target_capabilities`
- `declaration`
- `files`

This is still prototype-owned metadata, but it is intentionally closer to the
shared preprocess/artifact seam than the earlier smoke version.

Files:

- `examples/lmdb_relation_artifact/Cargo.toml`
- `examples/lmdb_relation_artifact/src/main.rs`
- `examples/lmdb_relation_artifact/README.md`

### Docs

Updated docs to reflect:

- Elixir should consume shared preprocess metadata now
- LMDB is confirmed viable in Termux for exact artifact experiments
- near-term backend choice is:
  - keep Elixir on TSV / ETS / SQLite adaptors
  - use LMDB first at the shared artifact/provider layer

Files:

- `docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md`
- `docs/proposals/WAM_FACT_SHAPE_PLAN.md`
- `docs/proposals/WAM_FACT_SHAPE_SPEC.md`

## Why

The recent Clojure/shared preprocess work established a declaration and
manifest seam, but it still needed:

1. another target-facing consumer
2. a concrete exact-artifact backend experiment outside the C# path

This PR provides both:

- Elixir now preserves the same metadata shape at codegen time
- LMDB is no longer hypothetical in this Termux environment

That gives the project a more realistic path toward shared exact artifacts
without prematurely standardizing one binary format.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_elixir_target.pl`
- `cargo test` in `examples/lmdb_relation_artifact`
- `git diff --check`

## Notes

- this does not add a direct Elixir LMDB adaptor
- this does not finalize a cross-target artifact format
- it does establish a cleaner next step:
  - shared artifact/provider work can target LMDB
  - Elixir can continue consuming the shared declaration metadata seam until
    that provider boundary stabilizes
