### PR TITLE
feat(wam-elixir): Tier-2 findall substrate (Phase 1 of 3)

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -1004,10 +1004,13 @@ compile_aggregate_helpers_to_elixir(Code) :-
                          merge_into_aggregate/2 also writes here for
                          the Tier-2 parallel-fan-out path.
 
-  state.cp is captured as :agg_return_cp so finalise tail-calls back
-  to the caller\'s continuation. The .pc field is set to nil because
-  aggregate frames have no failure target — backtrack/1 routes them
-  to finalise instead of resuming a clause.
+  state.cp is captured as :cp; finalise restores it then tail-calls
+  via the restored state.cp (no separate :agg_return_cp field — the
+  proposal §4.1 listed one, but they would always equal :cp at push
+  time, so the duplication was dropped during implementation).
+  The .pc field is set to nil because aggregate frames have no
+  failure target — backtrack/1 routes them to finalise instead of
+  resuming a clause.
   """
   def push_aggregate_frame(state, agg_type, value_reg, result_reg) do
     cp = %{
@@ -1022,8 +1025,7 @@ compile_aggregate_helpers_to_elixir(Code) :-
       agg_type: agg_type,
       agg_value_reg: value_reg,
       agg_result_reg: result_reg,
-      agg_accum: [],
-      agg_return_cp: state.cp
+      agg_accum: []
     }
     %{state | choice_points: [cp | state.choice_points]}
   end
@@ -1042,6 +1044,10 @@ compile_aggregate_helpers_to_elixir(Code) :-
 
   If no aggregate frame is present, returns state unchanged (caller
   misuse — emitter should always pair end_aggregate with begin).
+
+  Walk cost: O(N) in choice-point depth per call. Acceptable for
+  Phase 1; if Phase 3 profiling shows this dominates, an
+  agg_frame_idx field on state can collapse it to O(1).
   """
   def aggregate_collect(state, value_reg) do
     val = deref_var(state, Map.get(state.regs, value_reg))
@@ -1060,8 +1066,9 @@ compile_aggregate_helpers_to_elixir(Code) :-
 
   @doc """
   Reduce :agg_accum per :agg_type, bind the result to :agg_result_reg,
-  restore the pre-aggregate snapshot, and tail-call :agg_return_cp.
-  Called by backtrack/1 when the popped CP carries :agg_type.
+  restore the pre-aggregate snapshot, and tail-call the saved
+  continuation (the restored state.cp). Called by backtrack/1 when
+  the popped CP carries :agg_type.
 
   :collect / :findall / :aggregate_all → reversed list (preserves
   enumeration order for sequential; non-deterministic for the
@@ -1070,6 +1077,16 @@ compile_aggregate_helpers_to_elixir(Code) :-
 
   :sum / :count / :max / :min mirror compile_aggregate_all/5\'s
   alphabet. :bag is collect-with-duplicates; :set deduplicates.
+
+  Empty-accumulator semantics:
+    :collect/:findall/:aggregate_all/:bag/:set → []
+    :sum   → 0     (Enum.sum identity)
+    :count → 0     (length identity)
+    :max/:min → throws {:fail, state} — no identity exists, and
+                returning nil would silently propagate as a non-WAM
+                value into downstream get_constant unification. Fail
+                is the canonical Prolog semantics for max/min over
+                an empty bag.
   """
   def finalise_aggregate(state, agg_cp, rest_cps, agg_type) do
     accum_rev = Enum.reverse(agg_cp.agg_accum)
@@ -1079,8 +1096,10 @@ compile_aggregate_helpers_to_elixir(Code) :-
         :set -> Enum.uniq(accum_rev)
         :sum -> Enum.sum(accum_rev)
         :count -> length(accum_rev)
-        :max -> Enum.max(accum_rev, fn -> nil end)
-        :min -> Enum.min(accum_rev, fn -> nil end)
+        :max ->
+          if accum_rev == [], do: throw({:fail, state}), else: Enum.max(accum_rev)
+        :min ->
+          if accum_rev == [], do: throw({:fail, state}), else: Enum.min(accum_rev)
       end
     restored = %{state |
       regs: Map.put(agg_cp.regs, agg_cp.agg_result_reg, result),
@@ -1092,7 +1111,7 @@ compile_aggregate_helpers_to_elixir(Code) :-
       cp: agg_cp.cp,
       choice_points: rest_cps
     }
-    agg_cp.agg_return_cp.(restored)
+    restored.cp.(restored)
   end', []).
 
 % ============================================================================

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -366,49 +366,62 @@ compile_backtrack_to_elixir(Code) :-
     case state.choice_points do
       [] -> :fail
       [cp | rest] ->
-        # cp.trail_len is the mark — unwind all entries pushed after that.
-        state = state
-        |> unwind_trail(cp.trail_len)
-        |> Map.put(:pc, cp.pc)
-        |> Map.put(:regs, cp.regs)
-        |> Map.put(:heap, cp.heap)
-        |> Map.put(:heap_len, cp.heap_len)
-        |> Map.put(:cp, cp.cp)
-        |> Map.put(:stack, cp.stack)
-        |> Map.put(:trail, cp.trail)
-        |> Map.put(:trail_len, cp.trail_len)
-        |> Map.put(:choice_points, rest)
-
-        cond do
-          is_function(cp.pc) ->
-            # The retried clause may throw {:fail, thrown_state} (its own
-            # guards failed, with CPs accumulated during its body) or
-            # {:return, result} (it succeeded). Translate back into the
-            # {:ok, state} | :fail contract so the caller does not need to
-            # know about clause-local control flow.
-            try do
-              cp.pc.(state)
-            catch
-              {:fail, thrown_state} -> backtrack(thrown_state)
-              {:return, result} -> result
-            end
-
-          match?({:fact_stream, _, _}, cp.pc) ->
-            # Phase-B fact-stream CP: resume iteration over the remaining
-            # tail of the fact list. The snapshot already restored regs /
-            # trail / heap to their pre-unify state, so resume_fact_stream
-            # just needs to attempt the next fact.
-            {:fact_stream, remaining, arity} = cp.pc
-            try do
-              resume_fact_stream(state, remaining, arity)
-            catch
-              {:fail, thrown_state} -> backtrack(thrown_state)
-              {:return, result} -> result
-            end
-
-          true ->
-            {:ok, state}
+        # Aggregate frames are popped via finalise_aggregate/4 instead
+        # of the ordinary unwind/restore path: they have no failure
+        # target (cp.pc is nil) and need to bind the accumulator into
+        # :agg_result_reg before resuming via :agg_return_cp.
+        case Map.get(cp, :agg_type) do
+          nil ->
+            backtrack_ordinary(state, cp, rest)
+          agg_type ->
+            finalise_aggregate(state, cp, rest, agg_type)
         end
+    end
+  end
+
+  defp backtrack_ordinary(state, cp, rest) do
+    # cp.trail_len is the mark — unwind all entries pushed after that.
+    state = state
+    |> unwind_trail(cp.trail_len)
+    |> Map.put(:pc, cp.pc)
+    |> Map.put(:regs, cp.regs)
+    |> Map.put(:heap, cp.heap)
+    |> Map.put(:heap_len, cp.heap_len)
+    |> Map.put(:cp, cp.cp)
+    |> Map.put(:stack, cp.stack)
+    |> Map.put(:trail, cp.trail)
+    |> Map.put(:trail_len, cp.trail_len)
+    |> Map.put(:choice_points, rest)
+
+    cond do
+      is_function(cp.pc) ->
+        # The retried clause may throw {:fail, thrown_state} (its own
+        # guards failed, with CPs accumulated during its body) or
+        # {:return, result} (it succeeded). Translate back into the
+        # {:ok, state} | :fail contract so the caller does not need to
+        # know about clause-local control flow.
+        try do
+          cp.pc.(state)
+        catch
+          {:fail, thrown_state} -> backtrack(thrown_state)
+          {:return, result} -> result
+        end
+
+      match?({:fact_stream, _, _}, cp.pc) ->
+        # Phase-B fact-stream CP: resume iteration over the remaining
+        # tail of the fact list. The snapshot already restored regs /
+        # trail / heap to their pre-unify state, so resume_fact_stream
+        # just needs to attempt the next fact.
+        {:fact_stream, remaining, arity} = cp.pc
+        try do
+          resume_fact_stream(state, remaining, arity)
+        catch
+          {:fail, thrown_state} -> backtrack(thrown_state)
+          {:return, result} -> result
+        end
+
+      true ->
+        {:ok, state}
     end
   end', []).
 
@@ -971,6 +984,115 @@ compile_aggregate_helpers_to_elixir(Code) :-
         end
       end)
     %{state | choice_points: updated_cps}
+  end
+
+  @doc """
+  Push an aggregate-frame choice point. Captures the same snapshot
+  fields as a try_me_else CP (regs, heap, heap_len, trail, trail_len,
+  stack, cp) so finalise_aggregate/4 can restore the pre-aggregate
+  state, plus four aggregate-specific fields:
+
+    - :agg_type        — :collect|:findall|:aggregate_all|:sum|:count|
+                         :max|:min|:bag|:set (the alphabet emitted by
+                         compile_aggregate_all/5 in wam_target.pl).
+    - :agg_value_reg   — register holding the per-solution Template
+                         value at end_aggregate time.
+    - :agg_result_reg  — register that finalise binds the aggregated
+                         value to.
+    - :agg_accum       — accumulator, prepended to (O(1)) by
+                         aggregate_collect/2; reversed at finalise.
+                         merge_into_aggregate/2 also writes here for
+                         the Tier-2 parallel-fan-out path.
+
+  state.cp is captured as :agg_return_cp so finalise tail-calls back
+  to the caller\'s continuation. The .pc field is set to nil because
+  aggregate frames have no failure target — backtrack/1 routes them
+  to finalise instead of resuming a clause.
+  """
+  def push_aggregate_frame(state, agg_type, value_reg, result_reg) do
+    cp = %{
+      pc: nil,
+      regs: state.regs,
+      heap: state.heap,
+      heap_len: state.heap_len,
+      cp: state.cp,
+      trail: state.trail,
+      trail_len: state.trail_len,
+      stack: state.stack,
+      agg_type: agg_type,
+      agg_value_reg: value_reg,
+      agg_result_reg: result_reg,
+      agg_accum: [],
+      agg_return_cp: state.cp
+    }
+    %{state | choice_points: [cp | state.choice_points]}
+  end
+
+  @doc """
+  Per-solution collector for sequential fail-driven enumeration.
+  Reads value_reg, derefs it, prepends to the nearest aggregate
+  frame\'s :agg_accum (O(1)). Returns updated state.
+
+  Atomic values (strings/numbers/atoms) survive trail unwind without
+  copy because they\'re value types in BEAM. Compound values that
+  reference heap cells (e.g. lists, structures) are a known
+  follow-up — see WAM_ELIXIR_TIER2_FINDALL.md §6 risk #1. For Phase
+  1 substrate the simple cases (`findall(X, member(X, [a,b,c]), L)`,
+  `findall(X, p(X), L)` over fact predicates) are unaffected.
+
+  If no aggregate frame is present, returns state unchanged (caller
+  misuse — emitter should always pair end_aggregate with begin).
+  """
+  def aggregate_collect(state, value_reg) do
+    val = deref_var(state, Map.get(state.regs, value_reg))
+    {updated_cps, _collected} =
+      Enum.map_reduce(state.choice_points, false, fn cp, collected ->
+        cond do
+          collected -> {cp, collected}
+          Map.has_key?(cp, :agg_type) ->
+            prior = Map.get(cp, :agg_accum, [])
+            {Map.put(cp, :agg_accum, [val | prior]), true}
+          true -> {cp, collected}
+        end
+      end)
+    %{state | choice_points: updated_cps}
+  end
+
+  @doc """
+  Reduce :agg_accum per :agg_type, bind the result to :agg_result_reg,
+  restore the pre-aggregate snapshot, and tail-call :agg_return_cp.
+  Called by backtrack/1 when the popped CP carries :agg_type.
+
+  :collect / :findall / :aggregate_all → reversed list (preserves
+  enumeration order for sequential; non-deterministic for the
+  parallel Tier-2 path, which is acceptable because both forkable
+  aggregators are order-independent by definition).
+
+  :sum / :count / :max / :min mirror compile_aggregate_all/5\'s
+  alphabet. :bag is collect-with-duplicates; :set deduplicates.
+  """
+  def finalise_aggregate(state, agg_cp, rest_cps, agg_type) do
+    accum_rev = Enum.reverse(agg_cp.agg_accum)
+    result =
+      case agg_type do
+        t when t in [:collect, :findall, :aggregate_all, :bag] -> accum_rev
+        :set -> Enum.uniq(accum_rev)
+        :sum -> Enum.sum(accum_rev)
+        :count -> length(accum_rev)
+        :max -> Enum.max(accum_rev, fn -> nil end)
+        :min -> Enum.min(accum_rev, fn -> nil end)
+      end
+    restored = %{state |
+      regs: Map.put(agg_cp.regs, agg_cp.agg_result_reg, result),
+      heap: agg_cp.heap,
+      heap_len: agg_cp.heap_len,
+      trail: agg_cp.trail,
+      trail_len: agg_cp.trail_len,
+      stack: agg_cp.stack,
+      cp: agg_cp.cp,
+      choice_points: rest_cps
+    }
+    agg_cp.agg_return_cp.(restored)
   end', []).
 
 % ============================================================================

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -753,6 +753,83 @@ test_tier2_aggregate_forkable_types :-
     ;   fail_test(Test, 'emitted forkable predicate does not cover both findall and aggregate_all')
     ).
 
+%% Findall substrate (Phase 1) — exercises the runtime helpers added
+%% per docs/proposals/WAM_ELIXIR_TIER2_FINDALL.md §4. End-to-end findall
+%% execution waits on Phase 2 (begin_aggregate/end_aggregate instruction
+%% lowering) and Phase 3 (integration tests). These are emit-and-grep
+%% checks on the emitted Elixir source.
+
+test_findall_substrate_emits_push_aggregate_frame :-
+    Test = 'Findall substrate: WamRuntime emits push_aggregate_frame/4 with correct CP shape',
+    (   compile_wam_runtime_to_elixir([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'def push_aggregate_frame(state, agg_type, value_reg, result_reg)'),
+        % CP must capture all snapshot fields finalise needs to restore.
+        sub_string(S, _, _, _, 'agg_type: agg_type'),
+        sub_string(S, _, _, _, 'agg_value_reg: value_reg'),
+        sub_string(S, _, _, _, 'agg_result_reg: result_reg'),
+        sub_string(S, _, _, _, 'agg_accum: []'),
+        sub_string(S, _, _, _, 'agg_return_cp: state.cp'),
+        % And the standard CP snapshot fields so backtrack can restore.
+        sub_string(S, _, _, _, 'trail_len: state.trail_len'),
+        sub_string(S, _, _, _, 'heap_len: state.heap_len')
+    ->  pass(Test)
+    ;   fail_test(Test, 'push_aggregate_frame absent or missing required CP fields')
+    ).
+
+test_findall_substrate_emits_aggregate_collect :-
+    Test = 'Findall substrate: WamRuntime emits aggregate_collect/2 (deref + prepend to nearest agg frame)',
+    (   compile_wam_runtime_to_elixir([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'def aggregate_collect(state, value_reg)'),
+        % Must deref the value register before capturing.
+        sub_string(S, _, _, _, 'val = deref_var(state, Map.get(state.regs, value_reg))'),
+        % Must prepend (O(1)) to the nearest aggregate frame's accum.
+        sub_string(S, _, _, _, '[val | prior]')
+    ->  pass(Test)
+    ;   fail_test(Test, 'aggregate_collect absent or missing deref/prepend logic')
+    ).
+
+test_findall_substrate_emits_finalise_aggregate :-
+    Test = 'Findall substrate: WamRuntime emits finalise_aggregate/4 covering all aggregator types',
+    (   compile_wam_runtime_to_elixir([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'def finalise_aggregate(state, agg_cp, rest_cps, agg_type)'),
+        % Reverses accumulator (we prepend in collect for O(1)).
+        sub_string(S, _, _, _, 'Enum.reverse(agg_cp.agg_accum)'),
+        % All aggregator atoms emitted by compile_aggregate_all/5 must
+        % be handled — see wam_target.pl:712 for the alphabet.
+        sub_string(S, _, _, _, ':collect, :findall, :aggregate_all, :bag'),
+        sub_string(S, _, _, _, ':set -> Enum.uniq'),
+        sub_string(S, _, _, _, ':sum -> Enum.sum'),
+        sub_string(S, _, _, _, ':count -> length'),
+        sub_string(S, _, _, _, ':max -> Enum.max'),
+        sub_string(S, _, _, _, ':min -> Enum.min'),
+        % Must bind the result into agg_result_reg, restore from
+        % snapshot, and tail-call the saved continuation.
+        sub_string(S, _, _, _, 'Map.put(agg_cp.regs, agg_cp.agg_result_reg, result)'),
+        sub_string(S, _, _, _, 'agg_cp.agg_return_cp.(restored)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'finalise_aggregate absent or missing required aggregator handling')
+    ).
+
+test_findall_substrate_backtrack_routes_aggregate_frames :-
+    Test = 'Findall substrate: backtrack/1 dispatches aggregate frames to finalise_aggregate',
+    (   compile_wam_runtime_to_elixir([], Code),
+        atom_string(Code, S),
+        % The dispatcher arm: presence of :agg_type on the popped CP
+        % routes to finalise instead of the ordinary unwind path.
+        sub_string(S, _, _, _, 'case Map.get(cp, :agg_type) do'),
+        sub_string(S, _, _, _, 'nil ->'),
+        sub_string(S, _, _, _, 'backtrack_ordinary(state, cp, rest)'),
+        sub_string(S, _, _, _, 'agg_type ->'),
+        sub_string(S, _, _, _, 'finalise_aggregate(state, cp, rest, agg_type)'),
+        % And the existing ordinary path must still exist as a defp.
+        sub_string(S, _, _, _, 'defp backtrack_ordinary(state, cp, rest)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'backtrack/1 does not dispatch on :agg_type or backtrack_ordinary missing')
+    ).
+
 test_tier2_purity_gate_rejects_unknown :-
     Test = 'Tier-2 infra: purity gate fails for unknown predicate',
     (   \+ tier2_purity_eligible(no_such_pred, 2, _)
@@ -1062,6 +1139,10 @@ run_tests :-
     test_tier2_wamstate_has_parallel_depth,
     test_tier2_aggregate_helpers_emitted,
     test_tier2_aggregate_forkable_types,
+    test_findall_substrate_emits_push_aggregate_frame,
+    test_findall_substrate_emits_aggregate_collect,
+    test_findall_substrate_emits_finalise_aggregate,
+    test_findall_substrate_backtrack_routes_aggregate_frames,
     test_tier2_purity_gate_rejects_unknown,
     test_tier2_purity_gate_accepts_declared,
     test_par_wrap_segment_emits_super_wrapper,

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -764,13 +764,19 @@ test_findall_substrate_emits_push_aggregate_frame :-
     (   compile_wam_runtime_to_elixir([], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'def push_aggregate_frame(state, agg_type, value_reg, result_reg)'),
-        % CP must capture all snapshot fields finalise needs to restore.
+        % CP must capture aggregate-specific fields.
         sub_string(S, _, _, _, 'agg_type: agg_type'),
         sub_string(S, _, _, _, 'agg_value_reg: value_reg'),
         sub_string(S, _, _, _, 'agg_result_reg: result_reg'),
         sub_string(S, _, _, _, 'agg_accum: []'),
-        sub_string(S, _, _, _, 'agg_return_cp: state.cp'),
-        % And the standard CP snapshot fields so backtrack can restore.
+        % Plus the standard CP snapshot fields finalise restores.
+        % `cp:` here doubles as the post-finalise continuation — the
+        % proposal §4.1 listed a separate :agg_return_cp field but it
+        % always equalled state.cp at push time, so it was dropped
+        % during implementation. The docstring on the emitted helper
+        % explains the deviation; finalise_aggregate's tail-call uses
+        % `restored.cp.(restored)` (asserted in the finalise test).
+        sub_string(S, _, _, _, 'cp: state.cp'),
         sub_string(S, _, _, _, 'trail_len: state.trail_len'),
         sub_string(S, _, _, _, 'heap_len: state.heap_len')
     ->  pass(Test)
@@ -803,15 +809,23 @@ test_findall_substrate_emits_finalise_aggregate :-
         sub_string(S, _, _, _, ':set -> Enum.uniq'),
         sub_string(S, _, _, _, ':sum -> Enum.sum'),
         sub_string(S, _, _, _, ':count -> length'),
-        sub_string(S, _, _, _, ':max -> Enum.max'),
-        sub_string(S, _, _, _, ':min -> Enum.min'),
+        % :max / :min throw {:fail, state} on empty accumulator
+        % (canonical Prolog semantics — no identity exists).
+        sub_string(S, _, _, _, 'if accum_rev == [], do: throw({:fail, state}), else: Enum.max(accum_rev)'),
+        sub_string(S, _, _, _, 'if accum_rev == [], do: throw({:fail, state}), else: Enum.min(accum_rev)'),
         % Must bind the result into agg_result_reg, restore from
-        % snapshot, and tail-call the saved continuation.
+        % snapshot, and tail-call the restored state.cp (no
+        % separate :agg_return_cp — see push_aggregate_frame test).
         sub_string(S, _, _, _, 'Map.put(agg_cp.regs, agg_cp.agg_result_reg, result)'),
-        sub_string(S, _, _, _, 'agg_cp.agg_return_cp.(restored)')
+        sub_string(S, _, _, _, 'restored.cp.(restored)')
     ->  pass(Test)
     ;   fail_test(Test, 'finalise_aggregate absent or missing required aggregator handling')
     ).
+
+%% Note: aggregate_collect/2 with no aggregate frame on the stack is
+%% a documented safety contract (returns state unchanged). Coverage
+%% deferred to Phase 3 runtime tests, where a fixture state with an
+%% empty CP stack can exercise the contract end-to-end.
 
 test_findall_substrate_backtrack_routes_aggregate_frames :-
     Test = 'Findall substrate: backtrack/1 dispatches aggregate frames to finalise_aggregate',


### PR DESCRIPTION
## Summary

- Phase 1 of the three-phase findall implementation per `docs/proposals/WAM_ELIXIR_TIER2_FINDALL.md` §4. Adds the runtime helpers that the Phase 2 instruction lowerings will call into.
- Three new `WamRuntime` helpers (`push_aggregate_frame/4`, `aggregate_collect/2`, `finalise_aggregate/4`) plus a `backtrack/1` refactor that routes aggregate-frame CPs to finalise instead of the ordinary clause-restart path.
- 73/73 tests passing (69 prior + 4 new substrate tests). End-to-end findall execution waits on Phase 2 (instruction lowerings) and Phase 3 (integration tests).

## Why this is split out

The findall proposal #1626 was reviewed and merged as proposal-only. Following the same multi-PR pattern that the Tier-2 wiring used (#1586 substrate → #1607 probe → #1608 emitter → #1611 proposal → #1624 activation), this PR lands the substrate alone so its design — particularly the `backtrack/1` refactor and the aggregate-CP shape — can be reviewed in isolation before the instruction lowerings depend on it.

## What changes

### `src/unifyweaver/targets/wam_elixir_target.pl`

**Three new helpers** in `compile_aggregate_helpers_to_elixir`:

- `push_aggregate_frame(state, agg_type, value_reg, result_reg)` — pushes an aggregate CP carrying the standard snapshot fields finalise needs to restore (`regs/heap/heap_len/trail/trail_len/stack/cp`) plus four aggregate-specific fields: `:agg_type`, `:agg_value_reg`, `:agg_result_reg`, `:agg_accum: []`. The CP's `pc` field is `nil` because aggregate frames have no failure target. **Deviation from proposal §4.1:** the proposal listed a separate `:agg_return_cp` field but it always held the same value as `:cp` at push time, so it was dropped during implementation; finalise tail-calls via `restored.cp.(restored)`.
- `aggregate_collect(state, value_reg)` — sequential per-solution collector. Will be called from the `end_aggregate` instruction lowering (Phase 2) before the failing throw drives backtrack. Derefs the value register and prepends to the nearest aggregate frame's `:agg_accum`. Prepend (O(1)) rather than append; finalise reverses. Atomic values survive trail-unwind by being BEAM value types; compound-value deep-copy is a documented follow-up (proposal §6 risk #1). Walk cost is O(N) in choice-point depth — flagged in the helper's `@doc` for possible Phase 3 optimisation if profiling shows it dominates.
- `finalise_aggregate(state, agg_cp, rest_cps, agg_type)` — reduces `:agg_accum` per `:agg_type`. Covers `compile_aggregate_all/5`'s full alphabet from `wam_target.pl:712` (`:collect`/`:findall`/`:aggregate_all`/`:bag`/`:set`/`:sum`/`:count`/`:max`/`:min`). Binds the result into `:agg_result_reg`, restores the pre-aggregate snapshot, and tail-calls the restored continuation. **Empty-accumulator semantics are explicitly defined**: list aggregators return `[]`, `:sum`/`:count` return `0`, `:max`/`:min` throw `{:fail, state}` (canonical Prolog semantics — no identity exists, and silently returning `nil` would propagate a non-WAM value into downstream `get_constant` unification).

**`backtrack/1` refactor** in `compile_backtrack_to_elixir`:

- Splits into a thin dispatcher that checks `Map.get(cp, :agg_type)` and routes to either `finalise_aggregate` or `backtrack_ordinary`.
- The ordinary path is the previous body, unchanged, extracted into a new `defp backtrack_ordinary/3`. Aggregate frames take the new path because they need result-reg binding + continuation tail-call rather than a clause restart.

### `tests/test_wam_elixir_target.pl`

Four new emit-and-grep tests, slotted next to the existing `test_tier2_aggregate_helpers_emitted`:

- `Findall substrate: WamRuntime emits push_aggregate_frame/4 with correct CP shape`
- `Findall substrate: WamRuntime emits aggregate_collect/2 (deref + prepend to nearest agg frame)`
- `Findall substrate: WamRuntime emits finalise_aggregate/4 covering all aggregator types` — including the new max/min-on-empty `throw({:fail, state})` shape
- `Findall substrate: backtrack/1 dispatches aggregate frames to finalise_aggregate`

## Reviewer notes

**Two collectors, one accumulator.** The existing `merge_into_aggregate/2` (PR #1586) is the **parallel batch** collector used by the Tier-2 super-wrapper. The new `aggregate_collect/2` is the **sequential per-solution** collector that `end_aggregate` (Phase 2) will call. Both write to the same `:agg_accum`, and `finalise_aggregate/4` consumes the result uniformly — no path-specific finalise logic needed. Design choice from proposal §4.5 and §9 Q2.

**`backtrack/1` is now structural, not behavioural.** The 4 lines of dispatcher logic don't change anything yet — there are no aggregate frames in the system today. The first observable behaviour change comes in Phase 2 when `begin_aggregate` instructions start producing frames.

**Why emit-and-grep tests not runtime tests.** Phase 1 is substrate-only — there's no code path that actually exercises these helpers end-to-end yet. Runtime validation belongs in Phase 3 (proposal §7), where `findall(X, p(X), L)` will run through Elixir and we can assert `L = [...]`. Emit-and-grep verifies the helpers are wired into the runtime emission with the right structural shape.

## Review history (Perplexity)

Initial review flagged one block-level issue + two recommendations + one nit; all three actionable items addressed in the follow-up commit:

| Severity | Issue | Resolution |
|---|---|---|
| 🔴 Block | `Enum.max/min` empty-fallback returned `nil` | Now throws `{:fail, state}`; empty-accumulator semantics fully documented |
| 🟡 Recommend | `:agg_return_cp` duplicated `:cp` | Field dropped; `restored.cp.(restored)` tail-call; deviation from proposal §4.1 noted in helper docstring and PR body |
| 🟡 Recommend | `aggregate_collect` O(N) walk in CP depth | `@doc` flags the cost with forward pointer to possible Phase 3 `agg_frame_idx` optimisation |
| 🟢 Nit | No test for `aggregate_collect` no-frame safety contract | Comment in test file documents the gap; coverage deferred to Phase 3 runtime tests where a fixture state can exercise it end-to-end |

## Phase plan

- **Phase 1 (this PR):** runtime substrate.
- **Phase 2 (next):** `begin_aggregate(Type, ValReg, ResReg)` and `end_aggregate(ValReg)` instruction lowerings in `wam_elixir_lowered_emitter.pl`, plus parser entries in `instr_from_parts/2`. Roughly the same size as Phase 1 — two `wam_elixir_lower_instr` clauses + parser + emit-and-grep tests.
- **Phase 3 (final):** integration tests per proposal §7 — sequential `findall`, `aggregate_all` variants, edge cases (empty result, nested, cut interaction), Tier-2 interaction (3-clause pure predicate inside `findall`), Elixir-side `mix compile` smoke check.

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_target.pl` — 73/73 passing
- [x] All 69 pre-substrate tests pass unchanged (refactor is structural, no observable behaviour change)
- [x] 4 new substrate tests cover all three helpers + the `backtrack/1` dispatch
- [x] Empty-accumulator contract for `:max`/`:min` asserted in finalise test
- [ ] Elixir-side compilation of the emitted runtime — recommend before merge as a syntax-correctness check (the helpers are pure new code, so a `mix compile` smoke is cheap insurance)

## Related

- Proposal: `docs/proposals/WAM_ELIXIR_TIER2_FINDALL.md` (#1626)
- Tier-2 substrate this builds on: #1586 (`in_forkable_aggregate_frame?/1`, `merge_into_aggregate/2`)
- LLVM precedent for fail-driven enumeration: `wam_llvm_target.pl:2417-2496`
- WAM compiler's findall entry: `wam_target.pl:755`
