### PR TITLE
feat(artifacts): add JVM LMDB row API

### DIFF
--- a/examples/scala_lmdb_jni_probe/README.md
+++ b/examples/scala_lmdb_jni_probe/README.md
@@ -2,22 +2,31 @@
 
 This is a standalone JVM-side probe for consuming the LMDB relation-artifact contract through JNI.
 
-It is intentionally isolated from the current Haskell and Elixir target paths.
+It is intentionally isolated from the current Haskell and Elixir target paths, but the shape is now closer to a reusable JVM seam than to a one-off Scala demo. It now validates both Scala and Clojure consumption against the same Java/JNI reader API.
 
 ## What it does
 
 - builds a tiny LMDB relation artifact from `testdata/edge.tsv`
-- parses `manifest.json` in Scala
+- parses `manifest.json` in Java
+- exposes a small reusable JVM-side API:
+  - `LmdbArtifactManifest`
+  - `LmdbArtifactReader`
+  - `LmdbRow`
 - uses JNI-backed C code to:
   - open the named LMDB DB from the manifest
   - perform `arg1` lookup
   - perform full scan
 - asserts the returned rows match the fixture
+- proves the same JVM-side seam is consumable from both Scala and Clojure
 
 ## Files
 
-- `src/main/scala/generated/lmdb/LmdbArtifactProbe.scala`
 - `src/main/java/generated/lmdb/LmdbArtifactJNI.java`
+- `src/main/java/generated/lmdb/LmdbArtifactManifest.java`
+- `src/main/java/generated/lmdb/LmdbArtifactReader.java`
+- `src/main/java/generated/lmdb/LmdbRow.java`
+- `src/main/scala/generated/lmdb/LmdbArtifactProbe.scala`
+- `src/main/clojure/generated/lmdb/clojure_probe.clj`
 - `native/lmdb_artifact_jni.c`
 - `build.sh`
 
@@ -31,6 +40,7 @@ Expected success output:
 
 ```text
 scala_lmdb_jni_probe_ok lookup=a	1,a	2 scan_count=3 db=edge/2
+clojure_lmdb_jni_probe_ok lookup=a	1,a	2 scan_count=3 db=edge/2
 ```
 
 ## Notes
@@ -42,6 +52,6 @@ scala_lmdb_jni_probe_ok lookup=a	1,a	2 scan_count=3 db=edge/2
   - `scalac`
   - `gcc`
   - installed `liblmdb`
-- manifest parsing is kept in Scala to avoid adding a JSON dependency or JNI-side JSON parser
+- manifest parsing and reader ownership are kept in Java so JVM languages like Clojure or a future Scala hybrid WAM can reuse the same seam
 - LMDB access itself is done through JNI against the native `liblmdb`
-- this is a probe, not yet a generated Scala target integration
+- this is still a probe, not yet a generated target integration

--- a/examples/scala_lmdb_jni_probe/build.sh
+++ b/examples/scala_lmdb_jni_probe/build.sh
@@ -7,6 +7,7 @@ OUT_DIR="$PROBE_DIR/out"
 CLASSES_DIR="$OUT_DIR/classes"
 LIB_DIR="$OUT_DIR/lib"
 ARTIFACT_DIR="$OUT_DIR/artifact"
+CLOJURE_SRC_DIR="$PROBE_DIR/src/main/clojure"
 
 JAVA_BIN=${JAVA_BIN:-$(command -v java)}
 JAVAC_BIN=${JAVAC_BIN:-$(command -v javac)}
@@ -19,13 +20,16 @@ JAVA_HOME_DIR=$(CDPATH= cd -- "$(dirname "$JAVAC_REAL")/.." && pwd)
 JNI_INCLUDE="$JAVA_HOME_DIR/include"
 JNI_PLATFORM_INCLUDE="$JNI_INCLUDE/linux"
 SCALA_LIB_JAR=${SCALA_LIB_JAR:-/data/data/com.termux/files/usr/opt/scala/maven2/org/scala-lang/scala-library/3.8.3/scala-library-3.8.3.jar}
+CLOJURE_JAR=${CLOJURE_JAR:-/data/data/com.termux/files/usr/var/lib/proot-distro/installed-rootfs/debian/usr/share/java/clojure-1.11.1.jar}
+CLOJURE_SPEC_JAR=${CLOJURE_SPEC_JAR:-/data/data/com.termux/files/usr/var/lib/proot-distro/installed-rootfs/debian/usr/share/java/spec.alpha-0.3.218.jar}
+CLOJURE_CORE_SPECS_JAR=${CLOJURE_CORE_SPECS_JAR:-/data/data/com.termux/files/usr/var/lib/proot-distro/installed-rootfs/debian/usr/share/java/core.specs.alpha-0.2.62.jar}
 
 mkdir -p "$CLASSES_DIR" "$LIB_DIR" "$ARTIFACT_DIR"
 
 "$CARGO_BIN" run --manifest-path "$ROOT_DIR/examples/lmdb_relation_artifact/Cargo.toml" -- \
   build edge/2 "$PROBE_DIR/testdata/edge.tsv" "$ARTIFACT_DIR" --dupsort
 
-"$JAVAC_BIN" -d "$CLASSES_DIR" -h "$OUT_DIR" "$PROBE_DIR/src/main/java/generated/lmdb/LmdbArtifactJNI.java"
+"$JAVAC_BIN" -d "$CLASSES_DIR" -h "$OUT_DIR" "$PROBE_DIR"/src/main/java/generated/lmdb/*.java
 cat "$PROBE_DIR/native/lmdb_artifact_jni.c" | "$GCC_BIN" -x c -shared -fPIC \
   -include stddef.h \
   -I"$JNI_INCLUDE" -I"$JNI_PLATFORM_INCLUDE" \
@@ -37,4 +41,6 @@ cat "$PROBE_DIR/native/lmdb_artifact_jni.c" | "$GCC_BIN" -x c -shared -fPIC \
 "$SCALAC_BIN" -d "$CLASSES_DIR" -classpath "$CLASSES_DIR" \
   "$PROBE_DIR/src/main/scala/generated/lmdb/LmdbArtifactProbe.scala"
 
-exec "$JAVA_BIN" -Djava.library.path="$LIB_DIR" -cp "$CLASSES_DIR:$SCALA_LIB_JAR" generated.lmdb.LmdbArtifactProbe "$ARTIFACT_DIR"
+"$JAVA_BIN" -Djava.library.path="$LIB_DIR" -cp "$CLASSES_DIR:$SCALA_LIB_JAR" generated.lmdb.LmdbArtifactProbe "$ARTIFACT_DIR"
+
+exec "$JAVA_BIN" -Djava.library.path="$LIB_DIR" -cp "$CLASSES_DIR:$SCALA_LIB_JAR:$CLOJURE_JAR:$CLOJURE_SPEC_JAR:$CLOJURE_CORE_SPECS_JAR:$CLOJURE_SRC_DIR" clojure.main -m generated.lmdb.clojure-probe "$ARTIFACT_DIR"

--- a/examples/scala_lmdb_jni_probe/native/lmdb_artifact_jni.c
+++ b/examples/scala_lmdb_jni_probe/native/lmdb_artifact_jni.c
@@ -4,45 +4,60 @@
 
 #include <stdbool.h>
 #include <errno.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-static char *dup_c_string(const char *src) {
-    size_t len = strlen(src);
+typedef struct {
+    char *key;
+    char *value;
+} row_buf;
+
+static char *dup_bytes(const char *src, size_t len) {
     char *dst = (char *)malloc(len + 1);
     if (dst == NULL) {
         return NULL;
     }
-    memcpy(dst, src, len + 1);
+    memcpy(dst, src, len);
+    dst[len] = '\0';
     return dst;
 }
 
-static void append_bytes(char **buffer, size_t *len, size_t *cap, const char *src, size_t src_len) {
-    size_t needed = *len + src_len + 1;
-    if (needed > *cap) {
-        size_t new_cap = (*cap == 0) ? 256 : *cap;
-        while (new_cap < needed) {
-            new_cap *= 2;
-        }
-        char *new_buf = (char *)realloc(*buffer, new_cap);
-        if (new_buf == NULL) {
-            free(*buffer);
-            *buffer = NULL;
-            *len = 0;
-            *cap = 0;
-            return;
-        }
-        *buffer = new_buf;
-        *cap = new_cap;
+static void free_rows(row_buf *rows, size_t count) {
+    if (rows == NULL) {
+        return;
     }
-    memcpy(*buffer + *len, src, src_len);
-    *len += src_len;
-    (*buffer)[*len] = '\0';
+    for (size_t i = 0; i < count; i++) {
+        free(rows[i].key);
+        free(rows[i].value);
+    }
+    free(rows);
 }
 
-static jstring error_string(JNIEnv *env, const char *message) {
-    return (*env)->NewStringUTF(env, message);
+static int append_row(row_buf **rows, size_t *count, size_t *cap, const char *key, size_t key_len, const char *value, size_t value_len) {
+    if (*count == *cap) {
+        size_t new_cap = (*cap == 0) ? 8 : (*cap * 2);
+        row_buf *new_rows = (row_buf *)realloc(*rows, new_cap * sizeof(row_buf));
+        if (new_rows == NULL) {
+            return ENOMEM;
+        }
+        *rows = new_rows;
+        *cap = new_cap;
+    }
+
+    char *key_copy = dup_bytes(key, key_len);
+    if (key_copy == NULL) {
+        return ENOMEM;
+    }
+    char *value_copy = dup_bytes(value, value_len);
+    if (value_copy == NULL) {
+        free(key_copy);
+        return ENOMEM;
+    }
+
+    (*rows)[*count].key = key_copy;
+    (*rows)[*count].value = value_copy;
+    *count += 1;
+    return MDB_SUCCESS;
 }
 
 static int open_store(const char *artifact_dir, const char *db_name, MDB_env **env_out, MDB_txn **txn_out, MDB_dbi *dbi_out) {
@@ -89,8 +104,42 @@ static void close_store(MDB_env *env, MDB_txn *txn) {
     }
 }
 
-JNIEXPORT jstring JNICALL
-Java_generated_lmdb_LmdbArtifactJNI_lookupRaw(JNIEnv *env, jclass cls, jstring artifact_dir_j, jstring db_name_j, jstring key_j, jboolean dupsort_j) {
+static jobjectArray rows_to_java(JNIEnv *env, row_buf *rows, size_t count) {
+    jclass row_cls = (*env)->FindClass(env, "generated/lmdb/LmdbRow");
+    if (row_cls == NULL) {
+        return NULL;
+    }
+    jmethodID ctor = (*env)->GetMethodID(env, row_cls, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
+    if (ctor == NULL) {
+        return NULL;
+    }
+
+    jobjectArray result = (*env)->NewObjectArray(env, (jsize)count, row_cls, NULL);
+    if (result == NULL) {
+        return NULL;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        jstring key = (*env)->NewStringUTF(env, rows[i].key);
+        jstring value = (*env)->NewStringUTF(env, rows[i].value);
+        if (key == NULL || value == NULL) {
+            return NULL;
+        }
+        jobject row = (*env)->NewObject(env, row_cls, ctor, key, value);
+        if (row == NULL) {
+            return NULL;
+        }
+        (*env)->SetObjectArrayElement(env, result, (jsize)i, row);
+        (*env)->DeleteLocalRef(env, row);
+        (*env)->DeleteLocalRef(env, key);
+        (*env)->DeleteLocalRef(env, value);
+    }
+
+    return result;
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_generated_lmdb_LmdbArtifactJNI_lookupRows(JNIEnv *env, jclass cls, jstring artifact_dir_j, jstring db_name_j, jstring key_j, jboolean dupsort_j) {
     (void)cls;
     const char *artifact_dir = (*env)->GetStringUTFChars(env, artifact_dir_j, NULL);
     const char *db_name = (*env)->GetStringUTFChars(env, db_name_j, NULL);
@@ -101,73 +150,58 @@ Java_generated_lmdb_LmdbArtifactJNI_lookupRaw(JNIEnv *env, jclass cls, jstring a
     MDB_txn *txn = NULL;
     MDB_dbi dbi = 0;
     int rc = open_store(artifact_dir, db_name, &mdb_env, &txn, &dbi);
-    if (rc != MDB_SUCCESS) {
-        (*env)->ReleaseStringUTFChars(env, artifact_dir_j, artifact_dir);
-        (*env)->ReleaseStringUTFChars(env, db_name_j, db_name);
-        (*env)->ReleaseStringUTFChars(env, key_j, key);
-        return error_string(env, mdb_strerror(rc));
-    }
 
-    char *buffer = NULL;
-    size_t len = 0;
+    row_buf *rows = NULL;
+    size_t count = 0;
     size_t cap = 0;
 
-    if (dupsort) {
-        MDB_cursor *cursor = NULL;
-        MDB_val mdb_key;
-        MDB_val mdb_val;
+    if (rc == MDB_SUCCESS) {
+        if (dupsort) {
+            MDB_cursor *cursor = NULL;
+            MDB_val mdb_key;
+            MDB_val mdb_val;
+            mdb_key.mv_size = strlen(key);
+            mdb_key.mv_data = (void *)key;
 
-        mdb_key.mv_size = strlen(key);
-        mdb_key.mv_data = (void *)key;
-        rc = mdb_cursor_open(txn, dbi, &cursor);
-        if (rc == MDB_SUCCESS) {
-            rc = mdb_cursor_get(cursor, &mdb_key, &mdb_val, MDB_SET);
-            while (rc == MDB_SUCCESS) {
-                append_bytes(&buffer, &len, &cap, key, strlen(key));
-                append_bytes(&buffer, &len, &cap, "\t", 1);
-                append_bytes(&buffer, &len, &cap, (const char *)mdb_val.mv_data, mdb_val.mv_size);
-                append_bytes(&buffer, &len, &cap, "\n", 1);
-                if (buffer == NULL) {
-                    rc = ENOMEM;
-                    break;
+            rc = mdb_cursor_open(txn, dbi, &cursor);
+            if (rc == MDB_SUCCESS) {
+                rc = mdb_cursor_get(cursor, &mdb_key, &mdb_val, MDB_SET);
+                while (rc == MDB_SUCCESS) {
+                    rc = append_row(&rows, &count, &cap,
+                                    key, strlen(key),
+                                    (const char *)mdb_val.mv_data, mdb_val.mv_size);
+                    if (rc != MDB_SUCCESS) {
+                        break;
+                    }
+                    rc = mdb_cursor_get(cursor, &mdb_key, &mdb_val, MDB_NEXT_DUP);
                 }
-                rc = mdb_cursor_get(cursor, &mdb_key, &mdb_val, MDB_NEXT_DUP);
+                if (rc == MDB_NOTFOUND) {
+                    rc = MDB_SUCCESS;
+                }
+                mdb_cursor_close(cursor);
             }
-            if (rc == MDB_NOTFOUND) {
+        } else {
+            MDB_val mdb_key;
+            MDB_val mdb_val;
+            mdb_key.mv_size = strlen(key);
+            mdb_key.mv_data = (void *)key;
+            rc = mdb_get(txn, dbi, &mdb_key, &mdb_val);
+            if (rc == MDB_SUCCESS) {
+                rc = append_row(&rows, &count, &cap,
+                                key, strlen(key),
+                                (const char *)mdb_val.mv_data, mdb_val.mv_size);
+            } else if (rc == MDB_NOTFOUND) {
                 rc = MDB_SUCCESS;
             }
-            mdb_cursor_close(cursor);
-        }
-    } else {
-        MDB_val mdb_key;
-        MDB_val mdb_val;
-        mdb_key.mv_size = strlen(key);
-        mdb_key.mv_data = (void *)key;
-        rc = mdb_get(txn, dbi, &mdb_key, &mdb_val);
-        if (rc == MDB_SUCCESS) {
-            append_bytes(&buffer, &len, &cap, key, strlen(key));
-            append_bytes(&buffer, &len, &cap, "\t", 1);
-            append_bytes(&buffer, &len, &cap, (const char *)mdb_val.mv_data, mdb_val.mv_size);
-            append_bytes(&buffer, &len, &cap, "\n", 1);
-            if (buffer == NULL) {
-                rc = ENOMEM;
-            }
-        } else if (rc == MDB_NOTFOUND) {
-            rc = MDB_SUCCESS;
         }
     }
 
-    jstring result;
-    if (rc != MDB_SUCCESS) {
-        result = error_string(env, mdb_strerror(rc));
-    } else {
-        if (buffer == NULL) {
-            buffer = dup_c_string("");
-        }
-        result = (*env)->NewStringUTF(env, buffer);
+    jobjectArray result = NULL;
+    if (rc == MDB_SUCCESS) {
+        result = rows_to_java(env, rows, count);
     }
 
-    free(buffer);
+    free_rows(rows, count);
     close_store(mdb_env, txn);
     (*env)->ReleaseStringUTFChars(env, artifact_dir_j, artifact_dir);
     (*env)->ReleaseStringUTFChars(env, db_name_j, db_name);
@@ -175,8 +209,8 @@ Java_generated_lmdb_LmdbArtifactJNI_lookupRaw(JNIEnv *env, jclass cls, jstring a
     return result;
 }
 
-JNIEXPORT jstring JNICALL
-Java_generated_lmdb_LmdbArtifactJNI_scanRaw(JNIEnv *env, jclass cls, jstring artifact_dir_j, jstring db_name_j) {
+JNIEXPORT jobjectArray JNICALL
+Java_generated_lmdb_LmdbArtifactJNI_scanRows(JNIEnv *env, jclass cls, jstring artifact_dir_j, jstring db_name_j) {
     (void)cls;
     const char *artifact_dir = (*env)->GetStringUTFChars(env, artifact_dir_j, NULL);
     const char *db_name = (*env)->GetStringUTFChars(env, db_name_j, NULL);
@@ -185,51 +219,40 @@ Java_generated_lmdb_LmdbArtifactJNI_scanRaw(JNIEnv *env, jclass cls, jstring art
     MDB_txn *txn = NULL;
     MDB_dbi dbi = 0;
     int rc = open_store(artifact_dir, db_name, &mdb_env, &txn, &dbi);
-    if (rc != MDB_SUCCESS) {
-        (*env)->ReleaseStringUTFChars(env, artifact_dir_j, artifact_dir);
-        (*env)->ReleaseStringUTFChars(env, db_name_j, db_name);
-        return error_string(env, mdb_strerror(rc));
-    }
 
-    MDB_cursor *cursor = NULL;
-    rc = mdb_cursor_open(txn, dbi, &cursor);
-
-    char *buffer = NULL;
-    size_t len = 0;
+    row_buf *rows = NULL;
+    size_t count = 0;
     size_t cap = 0;
 
     if (rc == MDB_SUCCESS) {
-        MDB_val key;
-        MDB_val val;
-        rc = mdb_cursor_get(cursor, &key, &val, MDB_FIRST);
-        while (rc == MDB_SUCCESS) {
-            append_bytes(&buffer, &len, &cap, (const char *)key.mv_data, key.mv_size);
-            append_bytes(&buffer, &len, &cap, "\t", 1);
-            append_bytes(&buffer, &len, &cap, (const char *)val.mv_data, val.mv_size);
-            append_bytes(&buffer, &len, &cap, "\n", 1);
-            if (buffer == NULL) {
-                rc = ENOMEM;
-                break;
+        MDB_cursor *cursor = NULL;
+        rc = mdb_cursor_open(txn, dbi, &cursor);
+        if (rc == MDB_SUCCESS) {
+            MDB_val key;
+            MDB_val value;
+            rc = mdb_cursor_get(cursor, &key, &value, MDB_FIRST);
+            while (rc == MDB_SUCCESS) {
+                rc = append_row(&rows, &count, &cap,
+                                (const char *)key.mv_data, key.mv_size,
+                                (const char *)value.mv_data, value.mv_size);
+                if (rc != MDB_SUCCESS) {
+                    break;
+                }
+                rc = mdb_cursor_get(cursor, &key, &value, MDB_NEXT);
             }
-            rc = mdb_cursor_get(cursor, &key, &val, MDB_NEXT);
+            if (rc == MDB_NOTFOUND) {
+                rc = MDB_SUCCESS;
+            }
+            mdb_cursor_close(cursor);
         }
-        if (rc == MDB_NOTFOUND) {
-            rc = MDB_SUCCESS;
-        }
-        mdb_cursor_close(cursor);
     }
 
-    jstring result;
-    if (rc != MDB_SUCCESS) {
-        result = error_string(env, mdb_strerror(rc));
-    } else {
-        if (buffer == NULL) {
-            buffer = dup_c_string("");
-        }
-        result = (*env)->NewStringUTF(env, buffer);
+    jobjectArray result = NULL;
+    if (rc == MDB_SUCCESS) {
+        result = rows_to_java(env, rows, count);
     }
 
-    free(buffer);
+    free_rows(rows, count);
     close_store(mdb_env, txn);
     (*env)->ReleaseStringUTFChars(env, artifact_dir_j, artifact_dir);
     (*env)->ReleaseStringUTFChars(env, db_name_j, db_name);

--- a/examples/scala_lmdb_jni_probe/src/main/clojure/generated/lmdb/clojure_probe.clj
+++ b/examples/scala_lmdb_jni_probe/src/main/clojure/generated/lmdb/clojure_probe.clj
@@ -1,0 +1,30 @@
+(ns generated.lmdb.clojure-probe
+  (:require [clojure.string :as str])
+  (:gen-class)
+  (:import [generated.lmdb LmdbArtifactReader]))
+
+(defn -main
+  [& args]
+  (when (not= 1 (count args))
+    (binding [*out* *err*]
+      (println "usage: generated.lmdb.clojure-probe <artifact-dir>"))
+    (System/exit 1))
+  (let [artifact-dir (first args)
+        reader (LmdbArtifactReader/open (java.nio.file.Path/of artifact-dir (make-array String 0)))
+        lookup-rows (map (fn [row] (str (.key row) "\t" (.value row)))
+                         (.lookupArg1 reader "a"))
+        scan-rows (set (map (fn [row] (str (.key row) "\t" (.value row)))
+                            (.scan reader)))]
+    (when (not= ["a\t1" "a\t2"] (vec lookup-rows))
+      (throw (ex-info "unexpected lookup rows" {:rows (vec lookup-rows)})))
+    (when-not (contains? scan-rows "a\t1")
+      (throw (ex-info "scan missing a\t1" {:rows scan-rows})))
+    (when-not (contains? scan-rows "a\t2")
+      (throw (ex-info "scan missing a\t2" {:rows scan-rows})))
+    (when-not (contains? scan-rows "b\t3")
+      (throw (ex-info "scan missing b\t3" {:rows scan-rows})))
+    (println
+      (str "clojure_lmdb_jni_probe_ok lookup="
+           (str/join "," lookup-rows)
+           " scan_count=" (count scan-rows)
+           " db=" (.dbName (.manifest reader))))))

--- a/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactJNI.java
+++ b/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactJNI.java
@@ -7,7 +7,7 @@ public final class LmdbArtifactJNI {
 
     private LmdbArtifactJNI() {}
 
-    public static native String lookupRaw(String artifactDir, String dbName, String key, boolean dupsort);
+    public static native LmdbRow[] lookupRows(String artifactDir, String dbName, String key, boolean dupsort);
 
-    public static native String scanRaw(String artifactDir, String dbName);
+    public static native LmdbRow[] scanRows(String artifactDir, String dbName);
 }

--- a/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactManifest.java
+++ b/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactManifest.java
@@ -1,0 +1,25 @@
+package generated.lmdb;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public record LmdbArtifactManifest(String dbName, boolean dupsort) {
+    private static final Pattern DB_NAME_PATTERN = Pattern.compile("\"db_name\"\\s*:\\s*\"([^\"]+)\"");
+    private static final Pattern DUPSORT_PATTERN = Pattern.compile("\"dupsort\"\\s*:\\s*(true|false)");
+
+    public static LmdbArtifactManifest read(Path manifestPath) throws IOException {
+        String content = Files.readString(manifestPath, StandardCharsets.UTF_8);
+        String dbName = matchOrDefault(DB_NAME_PATTERN, content, "edge/2");
+        boolean dupsort = "true".equals(matchOrDefault(DUPSORT_PATTERN, content, "false"));
+        return new LmdbArtifactManifest(dbName, dupsort);
+    }
+
+    private static String matchOrDefault(Pattern pattern, String input, String fallback) {
+        Matcher matcher = pattern.matcher(input);
+        return matcher.find() ? matcher.group(1) : fallback;
+    }
+}

--- a/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactReader.java
+++ b/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactReader.java
@@ -1,0 +1,41 @@
+package generated.lmdb;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public final class LmdbArtifactReader {
+    private final Path artifactDir;
+    private final LmdbArtifactManifest manifest;
+
+    public LmdbArtifactReader(Path artifactDir, LmdbArtifactManifest manifest) {
+        this.artifactDir = artifactDir;
+        this.manifest = manifest;
+    }
+
+    public static LmdbArtifactReader open(Path artifactDir) throws IOException {
+        return new LmdbArtifactReader(
+            artifactDir,
+            LmdbArtifactManifest.read(artifactDir.resolve("manifest.json"))
+        );
+    }
+
+    public LmdbRow[] lookupArg1(String key) {
+        return LmdbArtifactJNI.lookupRows(
+            artifactDir.toString(),
+            manifest.dbName(),
+            key,
+            manifest.dupsort()
+        );
+    }
+
+    public LmdbRow[] scan() {
+        return LmdbArtifactJNI.scanRows(
+            artifactDir.toString(),
+            manifest.dbName()
+        );
+    }
+
+    public LmdbArtifactManifest manifest() {
+        return manifest;
+    }
+}

--- a/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbRow.java
+++ b/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbRow.java
@@ -1,0 +1,3 @@
+package generated.lmdb;
+
+public record LmdbRow(String key, String value) {}

--- a/examples/scala_lmdb_jni_probe/src/main/scala/generated/lmdb/LmdbArtifactProbe.scala
+++ b/examples/scala_lmdb_jni_probe/src/main/scala/generated/lmdb/LmdbArtifactProbe.scala
@@ -1,14 +1,6 @@
 package generated.lmdb
 
-import scala.io.Source
-import scala.util.matching.Regex
-
 object LmdbArtifactProbe {
-  final case class Manifest(dbName: String, dupsort: Boolean)
-
-  private val dbNamePattern: Regex = """"db_name"\s*:\s*"([^"]+)"""".r
-  private val dupsortPattern: Regex = """"dupsort"\s*:\s*(true|false)""".r
-
   def main(args: Array[String]): Unit = {
     if (args.length != 1) {
       System.err.println("usage: LmdbArtifactProbe <artifact-dir>")
@@ -16,28 +8,16 @@ object LmdbArtifactProbe {
     }
 
     val artifactDir = args(0)
-    val manifest = readManifest(s"$artifactDir/manifest.json")
+    val reader = LmdbArtifactReader.open(java.nio.file.Path.of(artifactDir))
 
-    val lookupRows = splitRows(LmdbArtifactJNI.lookupRaw(artifactDir, manifest.dbName, "a", manifest.dupsort))
-    val scanRows = splitRows(LmdbArtifactJNI.scanRaw(artifactDir, manifest.dbName))
+    val lookupRows = reader.lookupArg1("a").iterator.map(row => s"${row.key}\t${row.value}").toVector
+    val scanRows = reader.scan().iterator.map(row => s"${row.key}\t${row.value}").toVector
 
     require(lookupRows == Vector("a\t1", "a\t2"), s"unexpected lookup rows: $lookupRows")
     require(scanRows.contains("a\t1"), s"scan missing a\\t1: $scanRows")
     require(scanRows.contains("a\t2"), s"scan missing a\\t2: $scanRows")
     require(scanRows.contains("b\t3"), s"scan missing b\\t3: $scanRows")
 
-    println(s"scala_lmdb_jni_probe_ok lookup=${lookupRows.mkString(",")} scan_count=${scanRows.size} db=${manifest.dbName}")
-  }
-
-  private def readManifest(path: String): Manifest = {
-    val content = Source.fromFile(path, "UTF-8").mkString
-    val dbName = dbNamePattern.findFirstMatchIn(content).map(_.group(1)).getOrElse("edge/2")
-    val dupsort = dupsortPattern.findFirstMatchIn(content).exists(_.group(1) == "true")
-    Manifest(dbName, dupsort)
-  }
-
-  private def splitRows(raw: String): Vector[String] = {
-    if (raw == null || raw.isEmpty) Vector.empty
-    else raw.split("\n").iterator.filter(_.nonEmpty).toVector
+    println(s"scala_lmdb_jni_probe_ok lookup=${lookupRows.mkString(",")} scan_count=${scanRows.size} db=${reader.manifest.dbName}")
   }
 }


### PR DESCRIPTION
# Summary

This PR turns the Scala/JNI LMDB probe into a small reusable JVM-side artifact seam and proves that both Scala and Clojure can consume it.

The key change is moving from newline-delimited JNI string payloads to a row-oriented JVM API:

- `LmdbArtifactManifest`
- `LmdbArtifactReader`
- `LmdbRow`

JNI now returns structured `LmdbRow[]` values, Java owns manifest parsing and reader logic, and both Scala and Clojure consume the same API.

# What Changed

Under [examples/scala_lmdb_jni_probe](/data/data/com.termux/files/home/UnifyWeaver/examples/scala_lmdb_jni_probe):

- added reusable Java-side classes:
  - `src/main/java/generated/lmdb/LmdbArtifactManifest.java`
  - `src/main/java/generated/lmdb/LmdbArtifactReader.java`
  - `src/main/java/generated/lmdb/LmdbRow.java`
- updated `src/main/java/generated/lmdb/LmdbArtifactJNI.java` to expose:
  - `lookupRows(...)`
  - `scanRows(...)`
- rewrote `native/lmdb_artifact_jni.c` so JNI constructs `LmdbRow[]` directly instead of packing newline-delimited strings
- updated `src/main/scala/generated/lmdb/LmdbArtifactProbe.scala` to consume the Java reader API
- added a Clojure-side proof of consumption:
  - `src/main/clojure/generated/lmdb/clojure_probe.clj`
- updated `build.sh` so one serial run verifies:
  - Rust artifact generation
  - JNI library build
  - Scala consumer success
  - Clojure consumer success
- updated `README.md` to describe the new JVM seam and the dual Scala/Clojure proof

# Why

The previous Scala/JNI probe proved that JNI-backed LMDB access was possible, but it was still probe-local and string-based.

This PR makes the result more useful for existing higher-priority JVM work, especially Clojure:

- manifest parsing is now in Java rather than in Scala
- LMDB access is hidden behind a small JNI boundary
- returned data is row-oriented JVM objects
- Clojure can consume the same seam cleanly without needing a Scala-specific layer

That makes this PR more about shared JVM artifact infrastructure than about a future Scala hybrid WAM target.

# Verification

Ran:

```sh
sh examples/scala_lmdb_jni_probe/build.sh
```

Observed success output:

```text
scala_lmdb_jni_probe_ok lookup=a	1,a	2 scan_count=3 db=edge/2
clojure_lmdb_jni_probe_ok lookup=a	1,a	2 scan_count=3 db=edge/2
```

# Environment Notes

This works in the current Termux environment, but the build script captures a few environment-specific details:

1. the real JDK include path must be resolved from `readlink -f $(command -v javac)`
2. the JNI build uses the local native `liblmdb`
3. the Clojure proof needs the concrete Debian `clojure-1.11.1.jar`, `spec.alpha`, and `core.specs.alpha` jars on the runtime classpath

# Scope Boundary

This PR does **not** integrate LMDB into the Clojure hybrid WAM runtime yet.

It only provides and validates a JVM-side row-oriented artifact API that Clojure can reuse in a later integration step.

# Next Steps

1. add a tiny Clojure hybrid-WAM-side adaptor that can call `LmdbArtifactReader` for one benchmark relation
2. keep the existing Clojure runtime path intact while evaluating the artifact-backed path side-by-side
3. decide later whether Scala should get a full hybrid WAM target, rather than letting that decision drive current Clojure infrastructure work
