### PR TITLE
test(wam-c): cover real Prolog builtin executable path

### DIFF
--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -270,9 +270,12 @@ static inline bool val_equal(WamValue v1, WamValue v2) {
     return false;
 }
 static inline WamValue* resolve_reg(WamState *state, int reg_idx, int is_y) {
-    if (is_y) {
+    if (is_y == 1) {
         assert(state->E >= 0 && "Y-register accessed with empty environment stack");
         return &state->E_array[state->E].y_regs[reg_idx];
+    }
+    if (is_y == 2) {
+        return &state->X[reg_idx];
     }
     return &state->A[reg_idx];
 }

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -162,8 +162,13 @@ c_reg_index(RegStr, IsY, Idx) :-
 c_reg_index(RegAtom, IsY, Idx) :-
     atom_chars(RegAtom, Chars),
     (   Chars = [Prefix|NumChars],
-        (Prefix == 'a'; Prefix == 'x'; Prefix == 'A'; Prefix == 'X')
+        (Prefix == 'a'; Prefix == 'A')
     ->  IsY = 0,
+        catch(number_chars(RegNo, NumChars), _, fail),
+        Idx is RegNo - 1
+    ;   Chars = [Prefix|NumChars],
+        (Prefix == 'x'; Prefix == 'X')
+    ->  IsY = 2,
         catch(number_chars(RegNo, NumChars), _, fail),
         Idx is RegNo - 1
     ;   Chars = [Prefix|NumChars],
@@ -190,10 +195,22 @@ wam_line_to_c_instr(["get_variable", Xn, Ai], Instr) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
     c_reg_index(CXn, IsY_Xn, XIdx), c_reg_index(CAi, IsY_Ai, AIdx),
     format(atom(Instr), '{ .tag = INSTR_GET_VARIABLE, .reg_xn = ~w, .is_y_xn = ~w, .reg_ai = ~w, .is_y_ai = ~w }', [XIdx, IsY_Xn, AIdx, IsY_Ai]).
+wam_line_to_c_instr(["get_value", Xn, Ai], Instr) :-
+    clean_comma(Xn, CXn), clean_comma(Ai, CAi),
+    c_reg_index(CXn, IsY_Xn, XIdx), c_reg_index(CAi, IsY_Ai, AIdx),
+    format(atom(Instr), '{ .tag = INSTR_GET_VALUE, .reg_xn = ~w, .is_y_xn = ~w, .reg_ai = ~w, .is_y_ai = ~w }', [XIdx, IsY_Xn, AIdx, IsY_Ai]).
 wam_line_to_c_instr(["put_constant", C, Ai], Instr) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),
     c_value_literal(CC, Val), c_reg_index(CAi, IsY, Idx),
     format(atom(Instr), '{ .tag = INSTR_PUT_CONSTANT, .val = ~w, .reg = ~w, .is_y_reg = ~w }', [Val, Idx, IsY]).
+wam_line_to_c_instr(["put_variable", Xn, Ai], Instr) :-
+    clean_comma(Xn, CXn), clean_comma(Ai, CAi),
+    c_reg_index(CXn, IsY_Xn, XIdx), c_reg_index(CAi, IsY_Ai, AIdx),
+    format(atom(Instr), '{ .tag = INSTR_PUT_VARIABLE, .reg_xn = ~w, .is_y_xn = ~w, .reg_ai = ~w, .is_y_ai = ~w }', [XIdx, IsY_Xn, AIdx, IsY_Ai]).
+wam_line_to_c_instr(["put_value", Xn, Ai], Instr) :-
+    clean_comma(Xn, CXn), clean_comma(Ai, CAi),
+    c_reg_index(CXn, IsY_Xn, XIdx), c_reg_index(CAi, IsY_Ai, AIdx),
+    format(atom(Instr), '{ .tag = INSTR_PUT_VALUE, .reg_xn = ~w, .is_y_xn = ~w, .reg_ai = ~w, .is_y_ai = ~w }', [XIdx, IsY_Xn, AIdx, IsY_Ai]).
 wam_line_to_c_instr(["get_structure", F, Ai], Instr) :-
     clean_comma(F, CF), clean_comma(Ai, CAi),
     c_reg_index(CAi, IsY, Idx),

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -260,6 +260,16 @@ test_builtin_call_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_real_prolog_builtin_executable_smoke :-
+    Test = 'WAM-C: real Prolog builtin executable smoke',
+    (   gcc_available
+    ->  (   run_real_prolog_builtin_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'real Prolog builtin executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 gcc_available :-
     catch(process_create(path(gcc), ['--version'],
                          [stdout(null), stderr(null), process(Pid)]),
@@ -322,6 +332,32 @@ run_builtin_call_executable_smoke :-
     write_text_file(MainPath, MainCode),
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
+
+run_real_prolog_builtin_executable_smoke :-
+    assertz((user:wam_c_real_builtin(X, Y) :- atom(X), Y is 7)),
+    (   compile_predicate_to_wam(user:wam_c_real_builtin/2, [], WamCode),
+        sub_string(WamCode, _, _, _, 'builtin_call atom/1, 1'),
+        sub_string(WamCode, _, _, _, 'builtin_call is/2, 2'),
+        compile_wam_predicate_to_c(user:wam_c_real_builtin/2, WamCode, [], PredCode),
+        compile_wam_runtime_to_c([], RuntimeCode),
+        get_time(Now),
+        Stamp is round(Now * 1000000),
+        format(atom(TmpBase), '/tmp/unifyweaver_wam_c_real_builtin_smoke_~w', [Stamp]),
+        format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+        format(atom(PredPath), '~w_pred.c', [TmpBase]),
+        format(atom(MainPath), '~w_main.c', [TmpBase]),
+        format(atom(ExePath), '~w_bin', [TmpBase]),
+        write_text_file(RuntimePath, RuntimeCode),
+        format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+        write_text_file(PredPath, PredTranslationUnit),
+        wam_c_real_builtin_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  retractall(user:wam_c_real_builtin(_, _))
+    ;   retractall(user:wam_c_real_builtin(_, _)),
+        fail
+    ).
 
 write_text_file(Path, Content) :-
     setup_call_cleanup(
@@ -475,6 +511,36 @@ int main(void) {
 }
 ').
 
+wam_c_real_builtin_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_real_builtin_2(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_real_builtin_2(&state);
+
+    WamValue ok_args[2] = { val_atom("a"), val_unbound("Y") };
+    int ok_rc = wam_run_predicate(&state, "wam_c_real_builtin/2", ok_args, 2);
+    if (ok_rc != 0 || state.P != WAM_HALT ||
+        state.A[0].tag != VAL_INT || state.A[0].data.integer != 7) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue fail_args[2] = { val_int(3), val_unbound("Y") };
+    int fail_rc = wam_run_predicate(&state, "wam_c_real_builtin/2", fail_args, 2);
+    if (fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 implemented_wam_c_cases(Cases) :-
     compile_step_wam_to_c([], Code),
     atom_string(Code, S),
@@ -542,6 +608,7 @@ run_tests_once :-
     test_generated_runtime_executable_smoke,
     test_cross_predicate_executable_smoke,
     test_builtin_call_executable_smoke,
+    test_real_prolog_builtin_executable_smoke,
     format('~n=== WAM-C Target Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).
 


### PR DESCRIPTION
## Summary

- Add a WAM-C executable smoke that starts from a real Prolog predicate using `atom/1` and `is/2`.
- Verify the full path from `compile_predicate_to_wam/3` builtin emission through WAM-C generation and native executable execution.
- Add missing WAM-C parsing for `get_value`, `put_variable`, and `put_value` instructions.
- Fix C register resolution so `Xn` operands use `state->X[]` instead of aliasing `An`, while preserving `A` and `Y` register behavior.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`