### PR TITLE
feat(wam-haskell): demand-driven LMDB result-cache backend (opt-in fourth option)

### DIFF
--- a/examples/benchmark/enwiki_dfs_benchmark/enwiki-dfs-benchmark.cabal
+++ b/examples/benchmark/enwiki_dfs_benchmark/enwiki-dfs-benchmark.cabal
@@ -8,12 +8,13 @@ build-type:    Simple
 executable enwiki-dfs
   main-is:          Main.hs
   hs-source-dirs:   src
-  other-modules:    Common, IntMapBackend, LmdbBackend
+  other-modules:    Common, IntMapBackend, LmdbBackend, LmdbCachedBackend
   build-depends:    base >= 4.12,
                     containers >= 0.6,
                     bytestring,
                     time >= 1.8,
                     deepseq >= 1.4,
+                    parallel >= 3.2,
                     mtl,
                     lmdb >= 0.2.5,
                     random >= 1.2

--- a/examples/benchmark/enwiki_dfs_benchmark/src/Common.hs
+++ b/examples/benchmark/enwiki_dfs_benchmark/src/Common.hs
@@ -15,6 +15,7 @@ module Common
 import qualified Data.IntSet as IS
 import Data.List (sort)
 import Data.Time.Clock (getCurrentTime, diffUTCTime)
+import Control.DeepSeq (NFData(..))
 
 -- | The universal node-lookup contract.  Each backend implements this.
 --   Given a node id, returns the list of its parent node ids.
@@ -26,6 +27,9 @@ data BenchResult = BenchResult
   { brVisited :: {-# UNPACK #-} !Int
   , brMaxDepth :: {-# UNPACK #-} !Int
   } deriving (Show)
+
+instance NFData BenchResult where
+    rnf (BenchResult v d) = rnf v `seq` rnf d
 
 -- | Depth-limited DFS from a seed, collecting a running count of
 --   visited nodes and the maximum depth reached.  Deduplicates via

--- a/examples/benchmark/enwiki_dfs_benchmark/src/LmdbCachedBackend.hs
+++ b/examples/benchmark/enwiki_dfs_benchmark/src/LmdbCachedBackend.hs
@@ -1,0 +1,185 @@
+-- SPDX-License-Identifier: MIT
+-- LmdbCachedBackend: demand-driven memoising wrapper around LMDB dupsort.
+--
+-- Motivation
+-- ----------
+-- Naive upfront prefetch doesn't work for this workload: the DFS in
+-- dfsFromSeed drives which nodes are visited — you cannot know the
+-- reachable set without first running the traversal you are trying to
+-- prefetch for.  See NOTE [Prefetch bootstrapping problem] below.
+--
+-- Instead we use demand-driven memoisation: each node's dupsort values
+-- are fetched from LMDB exactly once (on first access, by whichever
+-- thread gets there first), then stored in a shared pure IntMap.  All
+-- subsequent accesses — by the same seed or any other parallel seed
+-- that shares the node — read the pure IntMap with no FFI and no IORef
+-- contention.
+--
+-- This gives the IntMap parallelism profile on the hot path while
+-- keeping LMDB as the authoritative data source.
+--
+-- NOTE [Prefetch bootstrapping problem]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-- The DFS in Common.dfsFromSeed calls `edges node` only on nodes it
+-- actually visits.  Which nodes get visited depends on the edge data
+-- returned by `edges`.  So the reachable working set is not known until
+-- the traversal is complete — making upfront prefetch a chicken-and-egg
+-- problem.  Demand-driven caching resolves this naturally.
+--
+-- NOTE [Thread-local cursors]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-- LMDB cursors are NOT thread-safe; a cursor must only be used by the
+-- thread that created it.  We keep a Map ThreadId MDB_cursor' under a
+-- MVar so that each thread opens its own cursor once and reuses it for
+-- all its cache-miss FFI calls.
+--
+-- NOTE [Main.hs wiring]
+-- ~~~~~~~~~~~~~~~~~~~~~
+-- To activate this backend, add to Main.hs:
+--
+--   import qualified LmdbCachedBackend as LC
+--   ...
+--   "lmdb_cached" -> LC.openLmdbCachedBackend dbPath
+--
+-- No changes to the parallel harness or Common.hs are needed.
+
+{-# LANGUAGE BangPatterns #-}
+
+module LmdbCachedBackend
+  ( openLmdbCachedBackend
+  ) where
+
+import Control.Concurrent (myThreadId, ThreadId)
+import Control.Concurrent.MVar
+import Control.Monad (when)
+import Data.Int (Int32)
+import Data.IORef
+import qualified Data.IntMap.Strict as IM
+import qualified Data.Map.Strict as Map
+import Foreign.Marshal.Alloc (alloca, allocaBytes)
+import Foreign.Ptr (Ptr, castPtr)
+import Foreign.Storable (peek, poke, peekElemOff)
+import System.IO.Unsafe (unsafePerformIO)
+import Database.LMDB.Raw
+
+import Common (EdgeLookup)
+
+-- ---------------------------------------------------------------------------
+-- Public API
+-- ---------------------------------------------------------------------------
+
+-- | Open the LMDB database read-only.  Returns an EdgeLookup that
+--   memoises each node's dupsort neighbours on first access and serves
+--   all subsequent accesses from a pure IntMap cache.
+--
+--   Thread-safe: multiple Haskell threads (sparks) may call the
+--   returned EdgeLookup concurrently.  Cache hits are pure IntMap
+--   lookups (no synchronisation); cache misses use a per-thread cursor
+--   and atomicModifyIORef' to update the shared cache.
+openLmdbCachedBackend :: FilePath -> IO EdgeLookup
+openLmdbCachedBackend path = do
+    -- Shared LMDB environment + dbi (read-only; safe to share across txns).
+    env <- mdb_env_create
+    mdb_env_set_mapsize env (2 * 1024 * 1024 * 1024)
+    mdb_env_set_maxdbs env 4
+    mdb_env_set_maxreaders env 126
+    mdb_env_open env path [MDB_RDONLY]
+
+    -- Shared memoisation cache: IntMap [Int], starts empty.
+    -- IORef: reads are cheap; writes (cache misses) are rare once warm.
+    cacheRef <- newIORef (IM.empty :: IM.IntMap [Int])
+
+    -- Per-thread cursor registry: Map ThreadId (MDB_txn', MDB_cursor').
+    -- Wrapped in MVar for thread-safe insertion of new entries.
+    -- Reads after insertion are lock-free (Map is persistent; we only
+    -- read our own entry after inserting it).
+    cursorMapVar <- newMVar (Map.empty :: Map.Map ThreadId (MDB_txn', MDB_cursor'))
+
+    let dbi_ref = unsafePerformIO $ do
+          -- Open a throw-away txn just to get the dbi handle.
+          -- dbi values are stable for the lifetime of the env.
+          txn <- mdb_txn_begin env Nothing True
+          dbi <- mdb_dbi_open' txn (Just "main") [MDB_DUPSORT]
+          mdb_txn_abort txn
+          newIORef dbi
+        {-# NOINLINE dbi_ref #-}
+
+    return $ cachedLookup env dbi_ref cacheRef cursorMapVar
+
+-- ---------------------------------------------------------------------------
+-- Internal implementation
+-- ---------------------------------------------------------------------------
+
+-- | The EdgeLookup closure.
+cachedLookup
+    :: MDB_env
+    -> IORef MDB_dbi'
+    -> IORef (IM.IntMap [Int])
+    -> MVar (Map.Map ThreadId (MDB_txn', MDB_cursor'))
+    -> EdgeLookup
+cachedLookup env dbiRef cacheRef cursorMapVar key = unsafePerformIO $ do
+    -- Fast path: pure cache hit (no synchronisation).
+    cache <- readIORef cacheRef
+    case IM.lookup key cache of
+      Just vs -> return vs
+      Nothing -> do
+        -- Slow path: cache miss.  Fetch from LMDB, populate cache.
+        vs <- fetchFromLmdb env dbiRef cursorMapVar key
+        -- Atomically insert into cache.  If another thread raced us,
+        -- we just overwrite with the same value (dupsort data is
+        -- immutable).  The double-write is harmless and cheaper than
+        -- a check-then-set loop.
+        atomicModifyIORef' cacheRef $ \m -> (IM.insert key vs m, ())
+        return vs
+
+-- | Fetch dupsort values for `key` from LMDB using this thread's cursor.
+--   Opens a new read txn + cursor on first call per thread; reuses on
+--   subsequent calls.
+fetchFromLmdb
+    :: MDB_env
+    -> IORef MDB_dbi'
+    -> MVar (Map.Map ThreadId (MDB_txn', MDB_cursor'))
+    -> Int
+    -> IO [Int]
+fetchFromLmdb env dbiRef cursorMapVar key = do
+    tid <- myThreadId
+    -- Look up this thread's cursor without holding the MVar.
+    cursorMap <- readMVar cursorMapVar
+    (_, cursor) <- case Map.lookup tid cursorMap of
+      Just entry -> return entry
+      Nothing    -> do
+        -- First cache-miss for this thread: open a dedicated cursor.
+        dbi <- readIORef dbiRef
+        txn <- mdb_txn_begin env Nothing True
+        cur <- mdb_cursor_open' txn dbi
+        let entry = (txn, cur)
+        modifyMVar_ cursorMapVar $ \m -> return (Map.insert tid entry m)
+        return entry
+    lookupDupsSafe cursor key
+
+-- | Dupsort lookup using an already-positioned cursor.  Same logic as
+--   LmdbBackend.lookupDups but safe to call with any thread-local cursor.
+lookupDupsSafe :: MDB_cursor' -> Int -> IO [Int]
+lookupDupsSafe cursor key =
+    allocaBytes 4 $ \kp -> do
+      poke (castPtr kp :: Ptr Int32) (fromIntegral key :: Int32)
+      alloca $ \kvPtr -> alloca $ \dvPtr -> do
+        poke kvPtr (MDB_val 4 kp)
+        found <- mdb_cursor_get' MDB_SET cursor kvPtr dvPtr
+        if not found
+          then return []
+          else collectDups kvPtr dvPtr
+  where
+    collectDups kvPtr dvPtr = do
+      v <- readInt32Val dvPtr
+      more <- mdb_cursor_get' MDB_NEXT_DUP cursor kvPtr dvPtr
+      if more
+        then (v :) <$> collectDups kvPtr dvPtr
+        else return [v]
+
+    readInt32Val :: Ptr MDB_val -> IO Int
+    readInt32Val ptr = do
+      MDB_val sz dataPtr <- peek ptr
+      if sz >= 4
+        then fromIntegral <$> peekElemOff (castPtr dataPtr :: Ptr Int32) 0
+        else return 0

--- a/examples/benchmark/enwiki_dfs_benchmark/src/LmdbCachedBackend.hs
+++ b/examples/benchmark/enwiki_dfs_benchmark/src/LmdbCachedBackend.hs
@@ -51,7 +51,6 @@ module LmdbCachedBackend
 
 import Control.Concurrent (myThreadId, ThreadId)
 import Control.Concurrent.MVar
-import Control.Monad (when)
 import Data.Int (Int32)
 import Data.IORef
 import qualified Data.IntMap.Strict as IM
@@ -85,26 +84,26 @@ openLmdbCachedBackend path = do
     mdb_env_set_maxreaders env 126
     mdb_env_open env path [MDB_RDONLY]
 
+    -- Bootstrap the dbi handle.  IMPORTANT: the txn must be COMMITTED
+    -- (not aborted) so the dbi handle persists across subsequent
+    -- transactions.  Per LMDB docs, "if the transaction is aborted the
+    -- handle will be closed automatically", which would invalidate
+    -- every per-thread cursor opened later.
+    bootstrapTxn <- mdb_txn_begin env Nothing True
+    dbi <- mdb_dbi_open' bootstrapTxn (Just "main") [MDB_DUPSORT]
+    mdb_txn_commit bootstrapTxn
+
     -- Shared memoisation cache: IntMap [Int], starts empty.
     -- IORef: reads are cheap; writes (cache misses) are rare once warm.
     cacheRef <- newIORef (IM.empty :: IM.IntMap [Int])
 
-    -- Per-thread cursor registry: Map ThreadId (MDB_txn', MDB_cursor').
-    -- Wrapped in MVar for thread-safe insertion of new entries.
-    -- Reads after insertion are lock-free (Map is persistent; we only
-    -- read our own entry after inserting it).
-    cursorMapVar <- newMVar (Map.empty :: Map.Map ThreadId (MDB_txn', MDB_cursor'))
+    -- Per-thread cursor registry.  Wrapped in MVar for thread-safe
+    -- insertion of new entries.  Each thread only reads/writes its own
+    -- ThreadId key so contention is limited to the rare first-miss
+    -- per thread.
+    cursorMapVar <- newMVar (Map.empty :: Map.Map ThreadId MDB_cursor')
 
-    let dbi_ref = unsafePerformIO $ do
-          -- Open a throw-away txn just to get the dbi handle.
-          -- dbi values are stable for the lifetime of the env.
-          txn <- mdb_txn_begin env Nothing True
-          dbi <- mdb_dbi_open' txn (Just "main") [MDB_DUPSORT]
-          mdb_txn_abort txn
-          newIORef dbi
-        {-# NOINLINE dbi_ref #-}
-
-    return $ cachedLookup env dbi_ref cacheRef cursorMapVar
+    return $ cachedLookup env dbi cacheRef cursorMapVar
 
 -- ---------------------------------------------------------------------------
 -- Internal implementation
@@ -113,18 +112,18 @@ openLmdbCachedBackend path = do
 -- | The EdgeLookup closure.
 cachedLookup
     :: MDB_env
-    -> IORef MDB_dbi'
+    -> MDB_dbi'
     -> IORef (IM.IntMap [Int])
-    -> MVar (Map.Map ThreadId (MDB_txn', MDB_cursor'))
+    -> MVar (Map.Map ThreadId MDB_cursor')
     -> EdgeLookup
-cachedLookup env dbiRef cacheRef cursorMapVar key = unsafePerformIO $ do
+cachedLookup env dbi cacheRef cursorMapVar key = unsafePerformIO $ do
     -- Fast path: pure cache hit (no synchronisation).
     cache <- readIORef cacheRef
     case IM.lookup key cache of
       Just vs -> return vs
       Nothing -> do
         -- Slow path: cache miss.  Fetch from LMDB, populate cache.
-        vs <- fetchFromLmdb env dbiRef cursorMapVar key
+        vs <- fetchFromLmdb env dbi cursorMapVar key
         -- Atomically insert into cache.  If another thread raced us,
         -- we just overwrite with the same value (dupsort data is
         -- immutable).  The double-write is harmless and cheaper than
@@ -137,24 +136,23 @@ cachedLookup env dbiRef cacheRef cursorMapVar key = unsafePerformIO $ do
 --   subsequent calls.
 fetchFromLmdb
     :: MDB_env
-    -> IORef MDB_dbi'
-    -> MVar (Map.Map ThreadId (MDB_txn', MDB_cursor'))
+    -> MDB_dbi'
+    -> MVar (Map.Map ThreadId MDB_cursor')
     -> Int
     -> IO [Int]
-fetchFromLmdb env dbiRef cursorMapVar key = do
+fetchFromLmdb env dbi cursorMapVar key = do
     tid <- myThreadId
-    -- Look up this thread's cursor without holding the MVar.
     cursorMap <- readMVar cursorMapVar
-    (_, cursor) <- case Map.lookup tid cursorMap of
-      Just entry -> return entry
-      Nothing    -> do
-        -- First cache-miss for this thread: open a dedicated cursor.
-        dbi <- readIORef dbiRef
+    cursor <- case Map.lookup tid cursorMap of
+      Just c  -> return c
+      Nothing -> do
+        -- First cache-miss for this thread: open a dedicated read txn
+        -- and cursor.  Both stay alive for the life of the thread (no
+        -- explicit cleanup; acceptable for batch jobs).
         txn <- mdb_txn_begin env Nothing True
         cur <- mdb_cursor_open' txn dbi
-        let entry = (txn, cur)
-        modifyMVar_ cursorMapVar $ \m -> return (Map.insert tid entry m)
-        return entry
+        modifyMVar_ cursorMapVar $ \m -> return (Map.insert tid cur m)
+        return cur
     lookupDupsSafe cursor key
 
 -- | Dupsort lookup using an already-positioned cursor.  Same logic as

--- a/examples/benchmark/enwiki_dfs_benchmark/src/Main.hs
+++ b/examples/benchmark/enwiki_dfs_benchmark/src/Main.hs
@@ -3,7 +3,7 @@
 --
 -- Usage:
 --   enwiki-dfs <lmdb-path> <backend> <n-seeds>
---   backend = intmap | lmdb
+--   backend = intmap | lmdb | lmdb_cached
 --
 -- Samples N random seeds (from a list of valid keys in the LMDB,
 -- using a fixed RNG seed for reproducibility), runs a depth-limited
@@ -14,6 +14,8 @@
 module Main where
 
 import Control.Monad (forM, forM_, when)
+import Control.Parallel.Strategies (parMap, rdeepseq)
+import Control.DeepSeq (NFData(..), deepseq)
 import Data.IORef
 import Data.Int (Int32)
 import qualified Data.IntSet as IS
@@ -29,6 +31,7 @@ import Database.LMDB.Raw
 import Common
 import qualified IntMapBackend as IM
 import qualified LmdbBackend as L
+import qualified LmdbCachedBackend as LC
 
 maxDfsDepth :: Int
 maxDfsDepth = 12
@@ -51,8 +54,9 @@ main = do
 
         -- Open the selected backend and run DFS for each seed.
         edges <- case backend of
-          "intmap" -> IM.openIntMapFromLmdb dbPath
-          "lmdb"   -> L.openLmdbBackend dbPath
+          "intmap"      -> IM.openIntMapFromLmdb dbPath
+          "lmdb"        -> L.openLmdbBackend dbPath
+          "lmdb_cached" -> LC.openLmdbCachedBackend dbPath
           _ -> do
             putStrLn $ "unknown backend: " ++ backend
             exitFailure
@@ -65,12 +69,13 @@ main = do
         putStrLn "[main] measuring..."
         -- Time the whole sweep.  Individual per-seed timings are below
         -- clock resolution for fast queries and produce garbage stats.
-        -- The reliable number is total-time ÷ seed-count.
+        -- The reliable number is total-time ÷ seed-count.  parMap with
+        -- rdeepseq forces each BenchResult fully so sparks complete
+        -- before the timing endpoint.  Run with +RTS -N to exercise
+        -- multiple cores; +RTS -N1 stays sequential.
         (brs, elapsed) <- timeIt $ do
-          rs <- forM keys $ \k -> do
-                  let !br = dfsFromSeed edges maxDfsDepth k
-                  return br
-          return rs
+          let !rs = parMap rdeepseq (dfsFromSeed edges maxDfsDepth) keys
+          rs `deepseq` return rs
 
         let !totalVisited = foldl' (\a br -> a + brVisited br) 0 brs
             !maxDepthSeen = foldl' (\a br -> max a (brMaxDepth br)) 0 brs
@@ -89,7 +94,7 @@ main = do
         putStrLn $ "  max_depth_observed:    " ++ show maxDepthSeen
 
       _ -> do
-        putStrLn "usage: enwiki-dfs <lmdb-path> <intmap|lmdb> <n-seeds>"
+        putStrLn "usage: enwiki-dfs <lmdb-path> <intmap|lmdb|lmdb_cached> <n-seeds>"
         exitFailure
 
 -- | Sample N distinct keys from an LMDB database via reservoir sampling.

--- a/examples/benchmark/generate_wam_haskell_enwiki_lmdb_benchmark.pl
+++ b/examples/benchmark/generate_wam_haskell_enwiki_lmdb_benchmark.pl
@@ -10,13 +10,18 @@
 %%
 %% Usage:
 %%   swipl -q -s generate_wam_haskell_enwiki_lmdb_benchmark.pl -- \
-%%       <facts.pl> <output-dir>
+%%       <facts.pl> <output-dir> [--cache]
 %%
 %% facts.pl is the seeded benchmark workload (effective_distance.pl shape
 %% with dimension_n/1, max_depth/1, category_ancestor/4, power_sum_bound/4).
 %% category_parent/2 facts come from LMDB at runtime; the predicate is
 %% in the lmdb_backed_facts allow-list and skipped from WAM compilation
 %% via the external_source path.
+%%
+%% Optional --cache flag adds lmdb_cache_mode(memoize) so each LMDB key
+%% is fetched at most once and shared across all parMap worker threads.
+%% Helps on workloads with subgraph overlap; can hurt on random shallow
+%% seeds where the IORef cache infrastructure overhead exceeds savings.
 %%
 %% The generated project expects two extra files alongside the LMDB at
 %% the runtime factsDir:
@@ -31,12 +36,14 @@ benchmark_workload_path(Path) :-
 main :-
     current_prolog_flag(argv, Argv),
     (   Argv = [FactsPath, OutputDir]
-    ->  true
+    ->  CacheMode = no
+    ;   Argv = [FactsPath, OutputDir, '--cache']
+    ->  CacheMode = memoize
     ;   format(user_error,
-               'Usage: ... -- <facts.pl> <output-dir>~n', []),
+               'Usage: ... -- <facts.pl> <output-dir> [--cache]~n', []),
         halt(1)
     ),
-    generate(FactsPath, OutputDir),
+    generate(FactsPath, OutputDir, CacheMode),
     halt(0).
 
 main :-
@@ -51,7 +58,7 @@ power_sum_bound(Cat, Root, NegN, WeightSum) :-
          W is H ** NegN),
         WeightSum).
 
-generate(FactsPath, OutputDir) :-
+generate(FactsPath, OutputDir, CacheMode) :-
     benchmark_workload_path(WorkloadPath),
     load_files(WorkloadPath, [silent(true)]),
     load_files(FactsPath, [silent(true)]),
@@ -69,7 +76,7 @@ generate(FactsPath, OutputDir) :-
         user:power_sum_bound/4
     ],
 
-    Options = [
+    BaseOptions = [
         module_name('wam-haskell-enwiki'),
         use_lmdb(true),
         % Streaming-pipeline ingest format: named "main" subdb with
@@ -82,8 +89,17 @@ generate(FactsPath, OutputDir) :-
         % Disable so the FFI kernel falls back to LMDB lookups directly.
         demand_filter(false)
     ],
+    (   CacheMode == memoize
+    ->  Options = [lmdb_cache_mode(memoize) | BaseOptions]
+    ;   Options = BaseOptions
+    ),
 
     write_wam_haskell_project(Predicates, Options, OutputDir),
-    format(user_error,
-           '[WAM-Haskell] enwiki int-atom benchmark generated at ~w~n',
-           [OutputDir]).
+    (   CacheMode == memoize
+    ->  format(user_error,
+               '[WAM-Haskell] enwiki int-atom benchmark (cached) generated at ~w~n',
+               [OutputDir])
+    ;   format(user_error,
+               '[WAM-Haskell] enwiki int-atom benchmark generated at ~w~n',
+               [OutputDir])
+    ).

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -3679,6 +3679,19 @@ emit_inline_fact_literal(ListName, Tuples, Code) :-
 %                           overhead can exceed the FFI savings.
 %                           Only meaningful when lmdb_layout(dupsort);
 %                           ignored otherwise.
+%
+%                           PARALLELISM CAVEAT: under +RTS -N>1 the
+%                           shared atomicModifyIORef' write per miss
+%                           serialises across cores.  On low-hit-rate
+%                           workloads this produces a net regression
+%                           vs the bare dupsort path (measured 7x
+%                           slowdown at -N4 on a random-seed enwiki
+%                           workload).  Recommended only when the
+%                           expected cache hit rate justifies the
+%                           contention — generally workloads where
+%                           many seeds share substantial subgraph
+%                           overlap.  A future per-HEC L1 + sharded
+%                           L2 design would mitigate the contention.
 generate_lmdb_functions(Options, Code) :-
     read_kernel_template('lmdb_fact_source.hs.mustache', Template),
     (   option(lmdb_layout(dupsort), Options)

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -3668,13 +3668,32 @@ emit_inline_fact_literal(ListName, Tuples, Code) :-
 %    lmdb_layout(dupsort) — named "main" subdb with MDB_DUPSORT, one
 %                           entry per (key, value) pair (streaming-
 %                           pipeline ingest)
+%    lmdb_cache_mode(memoize) — opt-in: wrap the dupsort EdgeLookup with
+%                           a demand-driven IntMap memoisation layer.
+%                           Each (key, [neighbours]) pair is fetched
+%                           from LMDB at most once and shared across
+%                           all parMap worker threads.  Pays off on
+%                           workloads with subgraph overlap (deeper
+%                           paths, shared root regions); on random
+%                           shallow seeds the cache infrastructure
+%                           overhead can exceed the FFI savings.
+%                           Only meaningful when lmdb_layout(dupsort);
+%                           ignored otherwise.
 generate_lmdb_functions(Options, Code) :-
     read_kernel_template('lmdb_fact_source.hs.mustache', Template),
     (   option(lmdb_layout(dupsort), Options)
     ->  Dupsort = true
     ;   Dupsort = false
     ),
-    render_template(Template, [lmdb_dupsort=Dupsort], Code).
+    (   option(lmdb_cache_mode(memoize), Options),
+        Dupsort == true
+    ->  CacheMemoize = true
+    ;   CacheMemoize = false
+    ),
+    render_template(Template,
+                    [lmdb_dupsort=Dupsort,
+                     lmdb_cache_memoize=CacheMemoize],
+                    Code).
 
 %% maybe_parallelize_instrs(+PredIndicator, +Options, +InstrExprs0, -InstrExprs)
 %  Rewrite TryMeElse → ParTryMeElse etc. when the predicate certifies

--- a/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
+++ b/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
@@ -170,6 +170,17 @@ lmdbRawEdgeLookup env dbi cache key = unsafePerformIO $ do
 -- per miss) costs a few hundred ns per lookup, so on workloads with
 -- minimal subgraph overlap (random shallow seeds) this can be slower
 -- than the bare dupsort path.  Use only when you expect cache reuse.
+--
+-- WARNING — parallelism interaction: under +RTS -N>1 the shared
+-- atomicModifyIORef' on every miss serialises writes across cores.
+-- On workloads with low hit rate this produces a NET REGRESSION vs
+-- the bare dupsort path (measured: 7x slowdown at -N4 on the 1000-
+-- seed enwiki benchmark, where there is essentially no subgraph
+-- overlap).  This option targets workloads with substantial overlap
+-- (deeper paths, more seeds sharing root regions, repeated queries).
+-- A two-level cache (per-HEC L1 + sharded L2) would mitigate the
+-- contention; see the WAM Haskell benchmark notes for the planned
+-- follow-up.
 type LmdbResultCache = IORef (IM.IntMap [Int])
 
 newLmdbResultCache :: IO LmdbResultCache

--- a/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
+++ b/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
@@ -59,7 +59,12 @@ openLmdbRawReadonlyStore dbPath dbName = do
     env <- mdb_env_create
     mdb_env_set_mapsize env (1024 * 1024 * 1024)
     mdb_env_set_maxdbs env 4
-    mdb_env_set_maxreaders env 126
+    -- Maxreaders: each parMap-driven Haskell thread that does a
+    -- cache miss opens a new read txn (one slot).  GHC's spark
+    -- scheduler under -N>1 with rdeepseq can produce many distinct
+    -- ThreadIds per spark batch (well above the OS thread count),
+    -- so we size generously.  LMDB hard cap is 32767.
+    mdb_env_set_maxreaders env 4096
     mdb_env_open env dbPath [MDB_RDONLY]
     txn <- mdb_txn_begin env Nothing True
 {{#lmdb_dupsort}}
@@ -150,6 +155,45 @@ lmdbRawEdgeLookup env dbi cache key = unsafePerformIO $ do
         else return 0
 {{/lmdb_dupsort}}
 
+{{#lmdb_cache_memoize}}
+-- | Demand-driven memoising wrapper around the dupsort EdgeLookup.
+-- Each (key, [neighbours]) pair is fetched from LMDB at most once.
+-- Subsequent lookups for the same key — by the same seed or any
+-- parallel seed that shares an ancestor — read the pure IntMap with
+-- no FFI and no IORef contention.  This recovers most of the
+-- pure-IntMap parallelism profile on workloads with subgraph overlap
+-- (deeper paths, more seeds, queries that share root regions) while
+-- keeping LMDB as the authoritative data source for datasets too
+-- large to load fully.
+--
+-- The cache infrastructure (one IORef read per call + atomic write
+-- per miss) costs a few hundred ns per lookup, so on workloads with
+-- minimal subgraph overlap (random shallow seeds) this can be slower
+-- than the bare dupsort path.  Use only when you expect cache reuse.
+type LmdbResultCache = IORef (IM.IntMap [Int])
+
+newLmdbResultCache :: IO LmdbResultCache
+newLmdbResultCache = newIORef IM.empty
+
+lmdbCachedEdgeLookup
+    :: MDB_env -> MDB_dbi' -> DupsortCursorCache -> LmdbResultCache
+    -> EdgeLookup
+lmdbCachedEdgeLookup env dbi cursorCache resultCache key = unsafePerformIO $ do
+    -- Fast path: pure IntMap hit.  No FFI, no synchronisation.
+    cache <- readIORef resultCache
+    case IM.lookup key cache of
+      Just vs -> return vs
+      Nothing -> do
+        -- Slow path: cache miss.  Use the underlying dupsort lookup
+        -- (which itself uses a per-thread cursor) and memoise the
+        -- result.  If two threads race on the same key, the second
+        -- write overwrites with identical immutable dupsort data —
+        -- harmless and cheaper than a check-then-set.
+        let !vs = lmdbRawEdgeLookup env dbi cursorCache key
+        atomicModifyIORef' resultCache (\m -> (IM.insert key vs m, ()))
+        return vs
+{{/lmdb_cache_memoize}}
+
 -- | Convenience: open LMDB and return an EdgeLookup with a long-lived
 -- read transaction. The transaction (and thus the mmap snapshot) stays
 -- open for the process lifetime. This is correct because the fact
@@ -160,8 +204,16 @@ openLmdbEdgeLookup dbPath _dbName = do
 {{#lmdb_dupsort}}
     -- Per-thread (txn, cursor) cache; entries are populated lazily
     -- on the first lookup from each parMap worker thread.
-    cache <- newDupsortCursorCache
-    return (lmdbRawEdgeLookup env dbi cache)
+    cursorCache <- newDupsortCursorCache
+{{#lmdb_cache_memoize}}
+    -- Result memoisation cache (demand-driven): each key's neighbours
+    -- are fetched from LMDB at most once and shared across all threads.
+    resultCache <- newLmdbResultCache
+    return (lmdbCachedEdgeLookup env dbi cursorCache resultCache)
+{{/lmdb_cache_memoize}}
+{{^lmdb_cache_memoize}}
+    return (lmdbRawEdgeLookup env dbi cursorCache)
+{{/lmdb_cache_memoize}}
 {{/lmdb_dupsort}}
 {{^lmdb_dupsort}}
     txn <- mdb_txn_begin env Nothing True  -- read-only, held for process lifetime
@@ -201,8 +253,15 @@ lmdbFactSource dbPath _dbName = do
 {{#lmdb_dupsort}}
     -- Lookups go through a per-thread cursor cache (independent of
     -- the scan txn above so parMap workers can run in parallel).
-    cache <- newDupsortCursorCache
-    let lookup' = lmdbRawEdgeLookup env dbi cache
+    cursorCache <- newDupsortCursorCache
+{{#lmdb_cache_memoize}}
+    -- Result memoisation cache; each key fetched from LMDB at most once.
+    resultCache <- newLmdbResultCache
+    let lookup' = lmdbCachedEdgeLookup env dbi cursorCache resultCache
+{{/lmdb_cache_memoize}}
+{{^lmdb_cache_memoize}}
+    let lookup' = lmdbRawEdgeLookup env dbi cursorCache
+{{/lmdb_cache_memoize}}
 {{/lmdb_dupsort}}
 {{^lmdb_dupsort}}
     let lookup' = lmdbRawEdgeLookup txn dbi

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1373,6 +1373,43 @@ test_b1_lmdb_default_layout_no_cursor_cache :-
     ;   fail_test(Test, 'Default layout unexpectedly emitted dupsort cache code')
     ).
 
+test_b1_lmdb_cache_memoize_emitted :-
+    Test = 'B1: lmdb_cache_mode(memoize) emits memoising EdgeLookup',
+    (   compile_wam_runtime_to_haskell(
+            [use_lmdb(true),
+             lmdb_layout(dupsort),
+             lmdb_cache_mode(memoize)], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "LmdbResultCache"),
+        sub_string(S, _, _, _, "lmdbCachedEdgeLookup")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Memoising EdgeLookup not emitted')
+    ).
+
+test_b1_lmdb_cache_memoize_not_emitted_without_dupsort :-
+    Test = 'B1: lmdb_cache_mode(memoize) ignored without dupsort layout',
+    (   compile_wam_runtime_to_haskell(
+            [use_lmdb(true), lmdb_cache_mode(memoize)], [], Code),
+        atom_string(Code, S),
+        \+ sub_string(S, _, _, _, "LmdbResultCache"),
+        \+ sub_string(S, _, _, _, "lmdbCachedEdgeLookup")
+    ->  pass(Test)
+    ;   fail_test(Test,
+            'Memoising EdgeLookup unexpectedly emitted without dupsort')
+    ).
+
+test_b1_lmdb_dupsort_alone_no_memoize :-
+    Test = 'B1: dupsort without lmdb_cache_mode does not emit memoising lookup',
+    (   compile_wam_runtime_to_haskell(
+            [use_lmdb(true), lmdb_layout(dupsort)], [], Code),
+        atom_string(Code, S),
+        \+ sub_string(S, _, _, _, "LmdbResultCache"),
+        \+ sub_string(S, _, _, _, "lmdbCachedEdgeLookup")
+    ->  pass(Test)
+    ;   fail_test(Test,
+            'Memoising EdgeLookup unexpectedly emitted without cache_mode')
+    ).
+
 run_tests :-
     format('~n========================================~n'),
     format('WAM-Haskell target: Phase 5+6+7+8+F1-F4+E2E+B1 codegen tests~n'),
@@ -1482,6 +1519,9 @@ run_tests :-
     test_b1_lmdb_manifest_wiring_option_present,
     test_b1_lmdb_dupsort_per_thread_cursor,
     test_b1_lmdb_default_layout_no_cursor_cache,
+    test_b1_lmdb_cache_memoize_emitted,
+    test_b1_lmdb_cache_memoize_not_emitted_without_dupsort,
+    test_b1_lmdb_dupsort_alone_no_memoize,
     test_b1_external_source_skips_wam_compilation,
     test_b1_external_source_default_allow_list,
     test_b1_external_source_off_without_use_lmdb,


### PR DESCRIPTION
  ## Summary

  Adds a demand-driven memoising EdgeLookup as a fourth fact-source strategy in the WAM Haskell target. Each LMDB key's
  neighbours are fetched from the dupsort backend at most once and shared across all parMap worker threads via an `IORef
   (IntMap [Int])`.

  Co-designed with Perplexity (initial prototype in `LmdbCachedBackend.hs`), with bug fixes, integration, and
  parallel-scaling benchmarking added on top.

  ## The four fact-source strategies, in order

  | # | Strategy | When to use |
  |---|----------|-------------|
  | 1 | `inline_data` (compiled facts) | Tiny scale (≤1k facts) |
  | 2 | Default IntMap (in-memory load) | Medium scale, dataset fits in RAM |
  | 3 | `lmdb_layout(dupsort)` | Large scale, mmap'd LMDB, per-thread cursor |
  | 4 | `lmdb_layout(dupsort) + lmdb_cache_mode(memoize)` (this PR) | Workloads with substantial subgraph overlap |

  ## What changed

  ### Bug fixes vs the original prototype (commit `2a31a8a9`)
  - **`mdb_txn_abort` → `mdb_txn_commit`** on the bootstrap txn. Aborting a txn closes any dbi handles opened in it,
  invalidating every per-thread cursor opened later. Same bug we hit and fixed in PR #1631.
  - **`MDB_txn'` → `MDB_txn`** — `Database.LMDB.Raw` exposes the apostrophe-suffixed types only for `dbi`/`cursor`, not
  transactions. As written the file would not compile.
  - **Drop unnecessary `unsafePerformIO` + IORef indirection** for the `dbi` handle — the function already runs in IO;
  one `let` binding suffices.

  ### Integration
  - Wired the cached backend as a fourth mode in the standalone `enwiki-dfs` benchmark binary alongside `intmap`,
  `lmdb`, plus added `parMap rdeepseq` to the standalone Main so `+RTS -N` actually exercises parallelism (was
  sequential `forM`).
  - Added `NFData BenchResult` so `rdeepseq` can force per-seed results.
  - Bumped LMDB `maxreaders` from 126 to 4096 — GHC's spark scheduler under `-N>1` with `parMap+rdeepseq` produces many
  distinct `ThreadId`s per spark batch, each opening a read txn keyed by `myThreadId`. The 126 default ran out at 1000
  seeds.

  ### WAM target wiring (commit `125e2710`)
  - New Prolog option `lmdb_cache_mode(memoize)` in `generate_lmdb_functions/2`. Gated by `lmdb_layout(dupsort)`;
  ignored otherwise.
  - New mustache section `{{#lmdb_cache_memoize}}` emitting `LmdbResultCache` and `lmdbCachedEdgeLookup`.
  - New `--cache` CLI flag on `generate_wam_haskell_enwiki_lmdb_benchmark.pl` for easy A/B comparison.
  - Three new B1 tests: option emits the cache code, ignored without dupsort, dupsort-alone doesn't accidentally emit
  it.

  ### Inline documentation (commit `bf847d7d`)
  - The parallelism caveat lives next to the option at both the Prolog API layer and the mustache template — anyone
  evaluating the option sees the trade-off at the point of decision, not buried in commit history.

  ## Honest perf findings

  Three-way comparison on 1000-seed enwiki dupsort, warm cache, `+RTS -A32M`:

  | Backend | -N1 | -N4 | -N4 vs -N1 |
  |---------|-----|-----|------------|
  | `intmap` (in-memory) | ~10ms | ~10ms | (workload too small to scale) |
  | `lmdb` direct | ~28ms | **crashes** | shared-cursor `mdb_cursor_set` assertion |
  | `lmdb_cached` (this PR) | ~36ms | ~23ms | 1.5× faster |

  End-to-end through the WAM target binary, also 1000 seeds:

  | Config | -N1 | -N4 | -N4 vs -N1 |
  |--------|-----|-----|------------|
  | dupsort (per-thread cursor only) | ~60ms | ~32ms | **1.9× faster** |
  | dupsort + `lmdb_cache_mode(memoize)` | ~65ms | **~236ms** | **3.6× SLOWER** |

  The result-cache path is dramatically slower under `-N4` because `atomicModifyIORef'` on every miss serialises writes
  across cores. At 1000 random seeds reaching depth ~3 (~5200 distinct nodes, ~0% subgraph overlap) there are no cache
  hits to compensate.

  **The cache is the right tool for the right workload.** It targets cases where many seeds share substantial subgraph
  overlap (deeper paths, more seeds sharing root regions, repeated queries). Quantifying the crossover point — where
  overlap-driven hits outweigh contention cost — is future work.

  ## Why ship it now

  - The bug fixes alone are worth landing (would-be compile error + would-be runtime crash on first cursor open).
  - The option is **opt-in** and clearly gated behind `lmdb_cache_mode(memoize)`. The default and dupsort paths are
  unchanged.
  - The trade-off is documented in three places: option doc, template comment, commit message.
  - Future iterations (per-HEC L1 cache, sharded L2) live cleanly on top — the option spelling can grow to
  `none|memoize|per_hec|two_level` without breaking compatibility.

  ## Test plan
  - [x] `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl` — all pass, three new B1 tests added
  - [x] Standalone enwiki-dfs binary builds with all three backends; correctness verified (5200 nodes visited at depth 3
   across 1000 seeds, identical across `intmap` / `lmdb` / `lmdb_cached`)
  - [x] WAM target generator builds with `--cache` flag; binary produces 860 tuples (matches non-cached baseline)
  - [x] `+RTS -N4` no longer crashes for the cached path (after `maxreaders` bump)

  ## Future follow-ups (separate PRs)
  1. **Per-HEC L1 cache** — ~30 lines, no contention, scales naturally. Best when intra-HEC overlap dominates.
  2. **L1 + sharded L2** — ~80 lines, low contention via 16 shards. Best when cross-HEC overlap matters.
  3. **Workload that exercises overlap** — find or construct a benchmark with high subgraph reuse so the cache's value
  can be quantified honestly (current benchmark can't distinguish these designs).

  🤖 Generated with [Claude Code](https://claude.com/claude-code)