### PR TITLE
perf(wam-haskell): L1 cache wins — IOArray, capability index, IO-direct fallback

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2898,7 +2898,7 @@ compile_wam_runtime_to_haskell(Options, DetectedKernels, Code) :-
                     BacktrackCode),
     % Phase B1: conditional LMDB imports and functions
     (   option(use_lmdb(true), Options)
-    ->  LmdbImports = "import Database.LMDB.Raw\nimport Foreign.Ptr (Ptr, castPtr)\nimport Foreign.Storable (peek, poke, peekElemOff)\nimport Foreign.Marshal.Alloc (alloca, allocaBytes)\nimport Foreign.Marshal.Array (withArray)\nimport Foreign.C.String (withCStringLen, peekCStringLen)\nimport Foreign.C.Types (CSize(..))\nimport Data.Int (Int32)\nimport Data.Word (Word8)\nimport Data.IORef (IORef, newIORef, readIORef, writeIORef, atomicModifyIORef')\nimport Control.Monad (forM_)\nimport Control.Concurrent (runInBoundThread, myThreadId, ThreadId)",
+    ->  LmdbImports = "import Database.LMDB.Raw\nimport Foreign.Ptr (Ptr, castPtr)\nimport Foreign.Storable (peek, poke, peekElemOff)\nimport Foreign.Marshal.Alloc (alloca, allocaBytes)\nimport Foreign.Marshal.Array (withArray)\nimport Foreign.C.String (withCStringLen, peekCStringLen)\nimport Foreign.C.Types (CSize(..))\nimport Data.Int (Int32)\nimport Data.Word (Word8)\nimport Data.Bits ((.&.))\nimport Data.IORef (IORef, newIORef, readIORef, writeIORef, atomicModifyIORef')\nimport qualified Data.Array as A\nimport qualified Data.Array.IO as IOA\nimport Control.Monad (forM_)\nimport Control.Concurrent (runInBoundThread, myThreadId, ThreadId, threadCapability, getNumCapabilities)",
         generate_lmdb_functions(Options, LmdbFunctions)
     ;   LmdbImports = "",
         LmdbFunctions = ""

--- a/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
+++ b/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
@@ -223,75 +223,99 @@ lmdbCachedEdgeLookup env dbi cursorCache resultCache key = unsafePerformIO $ do
 -- reuse (most DFS-style workloads).  If your workload has heavy
 -- cross-thread overlap, the future L2 / two_level modes will
 -- recover those hits.
+-- Each L1Cache is a fixed-size mutable IOArray indexed by
+-- (key .&. (capacity - 1)) — overwrite-on-collision semantics.  We
+-- store (key, vs) so a hit can verify the stored key matches the
+-- looked-up key (different keys can map to the same slot).  This
+-- replaces a persistent IntMap because profiling on the 1000-seed
+-- enwiki workload showed `IM.insert` consuming 42% of total time —
+-- copy-on-write tree updates allocate ~10 nodes per call.  IOArray
+-- writes are O(1) with no allocation; we trade some hits for far
+-- cheaper writes.
 data L1Cache = L1Cache
-    { l1Map      :: {-# UNPACK #-} !(IORef (IM.IntMap [Int]))
-    , l1Capacity :: {-# UNPACK #-} !Int
+    { l1Arr      :: {-# UNPACK #-} !(IOA.IOArray Int L1Entry)
+    , l1Capacity :: {-# UNPACK #-} !Int  -- must be a power of two
     }
 
--- | Registry mapping each Haskell ThreadId to its own L1Cache.
--- Same Map ThreadId pattern as DupsortCursorCache (PR #1632) — IORef
--- + atomicModifyIORef' rather than MVar so we don't need a new
--- concurrency primitive.  Each thread only ever modifies its own
--- ThreadId entry, so the CAS is uncontended in the steady state.
-type L1Registry = IORef (Map.Map ThreadId L1Cache)
+data L1Entry
+    = L1Empty
+    | L1Entry {-# UNPACK #-} !Int [Int]   -- stored key + values
 
--- | Default L1 capacity per HEC.  At ~80 bytes per IntMap entry
--- this is ~80 KiB per HEC, ~320 KiB at -N4 — negligible vs the
--- LMDB working set.  The user can override via
+-- | Registry of one L1Cache per Haskell capability (HEC).  Indexed
+-- 0..numCapabilities-1.  Pre-allocated at startup via
+-- getNumCapabilities, so the hot-path lookup is a single O(1) array
+-- index — no Map.lookup, no IORef-on-the-registry indirection.
+-- threadCapability tells us which slot is "ours" without any ThreadId
+-- ↔ slot mapping table.
+type L1Registry = A.Array Int L1Cache
+
+-- | Default L1 capacity per HEC.  Must be a power of two so we can
+-- use bit-and instead of mod for the slot index.  4096 entries × ~24
+-- bytes per L1Entry = ~96 KiB per HEC, ~384 KiB at -N4 — negligible
+-- vs the LMDB working set.  The user can override via
 -- lmdb_cache_l1_capacity(N) in the Prolog options if needed.
 defaultL1Capacity :: Int
-defaultL1Capacity = 1024
+defaultL1Capacity = 4096
 
-newL1Registry :: IO L1Registry
-newL1Registry = newIORef Map.empty
+-- | Allocate one L1Cache per capability.  Each cache is a fresh
+-- IOArray of L1Empty entries.  Different capabilities get
+-- independent arrays so per-capability writes never touch each
+-- other's cache lines.
+newL1Registry :: Int -> IO L1Registry
+newL1Registry cap = do
+    n <- getNumCapabilities
+    caches <- mapM (\_ -> do
+                       arr <- IOA.newArray (0, cap - 1) L1Empty
+                       return (L1Cache arr cap))
+                   [0 .. n - 1]
+    return $! A.listArray (0, n - 1) caches
 
--- | Look up or lazily allocate this thread's L1 cache.  First call
--- per thread does an atomicModifyIORef' insert; subsequent calls
--- read lock-free (we never overwrite our own slot once initialised).
-getOrAllocL1 :: L1Registry -> Int -> IO L1Cache
-getOrAllocL1 reg cap = do
+-- | Look up this thread's L1 cache.  Hot-path cost: one myThreadId
+-- + one threadCapability + one array index.  No Map.lookup, no
+-- IORef on the registry, no atomic ops.
+{-# INLINE getL1ForCap #-}
+getL1ForCap :: L1Registry -> IO L1Cache
+getL1ForCap reg = do
     tid <- myThreadId
-    m   <- readIORef reg
-    case Map.lookup tid m of
-      Just c  -> return c
-      Nothing -> do
-        ref <- newIORef IM.empty
-        let c = L1Cache ref cap
-        atomicModifyIORef' reg (\m' -> (Map.insert tid c m', ()))
-        return c
+    (capId, _bound) <- threadCapability tid
+    return $! reg A.! capId
 
--- | L1 lookup: thread-local IORef read, no synchronisation.
+-- | L1 lookup: O(1) array read with collision check.  Different
+-- keys can map to the same slot (key .&. mask); a hit requires the
+-- stored key to match.  Returns Nothing on empty slot or key mismatch.
+{-# INLINE l1Lookup #-}
 l1Lookup :: L1Cache -> Int -> IO (Maybe [Int])
-l1Lookup (L1Cache ref _) key = do
-    m <- readIORef ref
-    return $! IM.lookup key m
+l1Lookup (L1Cache arr cap) key = do
+    let !idx = key .&. (cap - 1)
+    e <- IOA.readArray arr idx
+    case e of
+      L1Entry k vs | k == key -> return (Just vs)
+      _                       -> return Nothing
 
--- | L1 insert with capacity-based overwrite.  When the cache is at
--- capacity we drop one entry (the smallest key — cheap, deterministic
--- per-thread; LRU is overkill at this scale and harder under a
--- non-atomic IORef).  This bounds memory at l1Capacity entries.
+-- | L1 insert: O(1) array write with overwrite-on-collision.  No
+-- allocation per write (just slot overwrite); replaces the previous
+-- IntMap.insert which allocated ~10 tree nodes per call (42% of
+-- total runtime in the original profile).
+{-# INLINE l1Insert #-}
 l1Insert :: L1Cache -> Int -> [Int] -> IO ()
-l1Insert (L1Cache ref cap) key vs = do
-    m <- readIORef ref
-    let !m' | IM.size m >= cap = IM.insert key vs (evictOneL1 m)
-            | otherwise        = IM.insert key vs m
-    writeIORef ref m'
-
--- | Evict one entry.  Drop the smallest key — IM.deleteMin is O(log n)
--- and avoids the hot-path cost of tracking access order for LRU.
-evictOneL1 :: IM.IntMap [Int] -> IM.IntMap [Int]
-evictOneL1 m = case IM.minViewWithKey m of
-    Just (_, m') -> m'
-    Nothing      -> m  -- impossible if size >= cap >= 1
+l1Insert (L1Cache arr cap) key vs = do
+    let !idx = key .&. (cap - 1)
+    IOA.writeArray arr idx (L1Entry key vs)
 
 -- | L1-wrapped EdgeLookup.  On hit, returns the cached neighbours
 -- with no FFI or synchronisation.  On miss, falls through to the
 -- per-thread-cursor dupsort lookup and populates the L1 entry.
+--
+-- Hot-path cost: getL1ForCap (myThreadId + threadCapability + array
+-- index) + l1Lookup (readIORef + IM.lookup).  No Map.lookup, no
+-- atomicModifyIORef on the registry.  The per-capability cache is
+-- mutated only by its own HEC thread, so writeIORef is safe.
+{-# INLINE lmdbL1EdgeLookup #-}
 lmdbL1EdgeLookup
-    :: MDB_env -> MDB_dbi' -> DupsortCursorCache -> L1Registry -> Int
+    :: MDB_env -> MDB_dbi' -> DupsortCursorCache -> L1Registry
     -> EdgeLookup
-lmdbL1EdgeLookup env dbi cursorCache l1reg cap key = unsafePerformIO $ do
-    l1 <- getOrAllocL1 l1reg cap
+lmdbL1EdgeLookup env dbi cursorCache l1reg key = unsafePerformIO $ do
+    l1 <- getL1ForCap l1reg
     h  <- l1Lookup l1 key
     case h of
       Just vs -> return vs
@@ -320,10 +344,11 @@ openLmdbEdgeLookup dbPath _dbName = do
 {{/lmdb_cache_memoize}}
 {{^lmdb_cache_memoize}}
 {{#lmdb_cache_l1}}
-    -- Per-HEC L1 cache; each Haskell thread owns its own IntMap
-    -- with no synchronisation on the hot path.
-    l1reg <- newL1Registry
-    return (lmdbL1EdgeLookup env dbi cursorCache l1reg defaultL1Capacity)
+    -- Per-HEC L1 cache; each capability owns its own IntMap with
+    -- no synchronisation on the hot path.  Pre-allocated for
+    -- numCapabilities slots so the lookup is O(1) array indexing.
+    l1reg <- newL1Registry defaultL1Capacity
+    return (lmdbL1EdgeLookup env dbi cursorCache l1reg)
 {{/lmdb_cache_l1}}
 {{^lmdb_cache_l1}}
     return (lmdbRawEdgeLookup env dbi cursorCache)
@@ -376,9 +401,9 @@ lmdbFactSource dbPath _dbName = do
 {{/lmdb_cache_memoize}}
 {{^lmdb_cache_memoize}}
 {{#lmdb_cache_l1}}
-    -- Per-HEC L1 cache; thread-local IORefs, no synchronisation.
-    l1reg <- newL1Registry
-    let lookup' = lmdbL1EdgeLookup env dbi cursorCache l1reg defaultL1Capacity
+    -- Per-capability L1 cache; one IORef per HEC, no synchronisation.
+    l1reg <- newL1Registry defaultL1Capacity
+    let lookup' = lmdbL1EdgeLookup env dbi cursorCache l1reg
 {{/lmdb_cache_l1}}
 {{^lmdb_cache_l1}}
     let lookup' = lmdbRawEdgeLookup env dbi cursorCache

--- a/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
+++ b/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
@@ -124,12 +124,13 @@ getOrOpenDupsortCursor env dbi cache = do
           (\m' -> (Map.insert tid (txn, c) m', ()))
         return c
 
--- | Dupsort EdgeLookup: cursor-based iteration over duplicate values.
--- Thread-safe: each calling thread gets its own (txn, cursor) from
--- the per-thread cache.  parMap workloads see no shared mutable state
--- and run without the shared-cursor assertion failure.
-lmdbRawEdgeLookup :: MDB_env -> MDB_dbi' -> DupsortCursorCache -> EdgeLookup
-lmdbRawEdgeLookup env dbi cache key = unsafePerformIO $ do
+-- | Dupsort EdgeLookup IO body.  The pure EdgeLookup variant wraps
+-- this in unsafePerformIO; callers like the L1 cache that are
+-- already in IO can call this directly to avoid the nested
+-- unsafePerformIO unwrap on the hot path.
+{-# INLINE lmdbRawEdgeLookupIO #-}
+lmdbRawEdgeLookupIO :: MDB_env -> MDB_dbi' -> DupsortCursorCache -> Int -> IO [Int]
+lmdbRawEdgeLookupIO env dbi cache key = do
     cursor <- getOrOpenDupsortCursor env dbi cache
     allocaBytes 4 $ \kp -> do
       poke (castPtr kp :: Ptr Int32) (fromIntegral key :: Int32)
@@ -153,6 +154,14 @@ lmdbRawEdgeLookup env dbi cache key = unsafePerformIO $ do
       if sz >= 4
         then fromIntegral <$> peekElemOff (castPtr dataPtr :: Ptr Int32) 0
         else return 0
+
+-- | Dupsort EdgeLookup: cursor-based iteration over duplicate values.
+-- Thread-safe: each calling thread gets its own (txn, cursor) from
+-- the per-thread cache.  parMap workloads see no shared mutable state
+-- and run without the shared-cursor assertion failure.
+lmdbRawEdgeLookup :: MDB_env -> MDB_dbi' -> DupsortCursorCache -> EdgeLookup
+lmdbRawEdgeLookup env dbi cache key =
+    unsafePerformIO (lmdbRawEdgeLookupIO env dbi cache key)
 {{/lmdb_dupsort}}
 
 {{#lmdb_cache_memoize}}
@@ -320,7 +329,10 @@ lmdbL1EdgeLookup env dbi cursorCache l1reg key = unsafePerformIO $ do
     case h of
       Just vs -> return vs
       Nothing -> do
-        let !vs = lmdbRawEdgeLookup env dbi cursorCache key
+        -- Call the IO-direct fallback rather than the unsafePerformIO-
+        -- wrapped lmdbRawEdgeLookup; we're already inside an IO action,
+        -- and avoiding the nested unwrap saves overhead per miss.
+        !vs <- lmdbRawEdgeLookupIO env dbi cursorCache key
         l1Insert l1 key vs
         return vs
 {{/lmdb_cache_l1}}


### PR DESCRIPTION
  ## Summary

  Three compounding optimisations turn the per-HEC L1 LMDB cache (PR #1639) from a regression on the 1000-seed enwiki
  workload into a clear win. **At -N4 with the workload's 34% measured hit rate, L1 is now ~13% faster than the bare
  dupsort path** — meeting the Phase 1 acceptance criterion from `docs/proposals/WAM_HASKELL_LMDB_CACHE_TIERS.md`.

  ## What changed (in commit order)

  1. **`IORef (IntMap)` → `IOArray L1Entry` with key-modulo-cap slot indexing** (commit `1db9dc36`).
     Profile showed `IM.insert` consuming **42% of total time** — copy-on-write tree allocation per call. Replacing with
   a fixed-size mutable array (overwrite-on-collision, the bounded-hashtable design) drops insert cost to a single
  `writeArray`. No tree-building, no per-write allocation.

  2. **`IORef (Map ThreadId)` registry → `Array Int` indexed by capability** (same commit).
     Lookup chain becomes `myThreadId` + `threadCapability` + O(1) array index. No `Map.lookup`, no IORef on the
  registry path.

  3. **Split `lmdbRawEdgeLookup` into IO + pure wrappers** (commit `ac9e0963`).
     The L1 wrapper is itself inside `unsafePerformIO`. On miss, calling the *also-`unsafePerformIO`-wrapped*
  `lmdbRawEdgeLookup` paid two unwraps per call. Adding `lmdbRawEdgeLookupIO :: ... -> IO [Int]` lets the L1 miss path
  stay in IO and avoid the nested unwrap.

  ## Measured impact (1000-seed enwiki, warm cache, +RTS -A32M, alternating order)

  | Config | -N1 | -N4 |
  |--------|-----|-----|
  | BASE (no cache) | ~62ms | ~31ms |
  | L1 IntMap (PR #1639 baseline) | ~145ms | ~46ms |
  | L1 IOArray + capability index | ~62ms | ~32ms |
  | **L1 IOArray + IO-direct (this PR)** | **~62ms** | **~27ms** |

  Total: **~2.3× faster L1 path at -N1**, **~1.7× faster at -N4 vs the original implementation**, and **L1 now beats
  BASE at -N4** despite the workload's modest 34% hit rate.

  ## Profiling evidence

  The original profile attributed 42% of total time to `l1Insert.m'` (the `IM.insert` line). After this PR, none of the
  L1 helpers register in the profile at all — the IOArray reads/writes are below sampling resolution. Top costs are now
  genuine LMDB FFI work (~38%) and WAM machinery (`executeForeign`, `nativeKernel_category_ancestor`, ~15%).

  ## Why the cache works at modest hit rate

  Wikipedia category graphs have heavy ancestor sharing — root 97688913 alone is touched by ~all 860 successful seeds.
  With the per-call infrastructure now near-free, even 34% hits are enough to overcome the negligible miss overhead.
  Workloads with deeper paths or denser subgraph sharing (e.g. simplewiki full-categories — see Phase 2 acceptance)
  should see hit rate climb to 60-80%+ and proportional speedup.

  ## Test plan
  - [x] `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl` (all pass; existing L1 tests cover the option
  emission)
  - [x] Generate enwiki int-atom benchmark with `--cache-l1`, build with cabal — clean
  - [x] Apples-to-apples comparison BASE vs L1 across 6 alternating iterations at -N1 and -N4 — L1 beats BASE at -N4
  - [x] Re-profile post-IOArray — L1 helpers no longer dominate; FFI is now the headline cost

  ## What's next

  Phase 1 is done. Phase 2 (sharded L2 + two_level composition) per the proposal — and the simplewiki full-categories
  test you suggested would be the natural validation that scales the hit rate higher.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)