### PR TITLE
feat(wam-elixir): findall instruction lowering (Phase 2 of 3)

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -1431,6 +1431,15 @@ wam_elixir_lower_instr(begin_aggregate(AggTypeStr, ValueReg, ResultReg),
 '    state = WamRuntime.push_aggregate_frame(state, :~w, ~w, ~w)',
         [AggType, ValReg, ResReg]).
 
+% Control flow note: the throw({:fail, state}) here is caught by the
+% enclosing wrap_segment\'s try/catch, which calls WamRuntime.backtrack
+% on the thrown state. backtrack/1 sees the aggregate CP at the top of
+% choice_points (pushed by the matching begin_aggregate), checks
+% Map.get(cp, :agg_type), and routes to finalise_aggregate/4 — which
+% binds the aggregated result and tail-calls the saved continuation.
+% The control flow is non-obvious from the emitted Elixir alone: throw →
+% segment catch → backtrack → finalise. See WAM_ELIXIR_TIER2_FINDALL.md
+% §3.3 (LLVM precedent) and §4.4 (backtrack extension).
 wam_elixir_lower_instr(end_aggregate(ValueReg), _PC, _Labels, _FuncName, _Suffix, Code) :-
     reg_id(ValueReg, ValReg),
     format(string(Code),

--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -1160,6 +1160,8 @@ instr_from_parts(["set_constant", C], set_constant(C)).
 instr_from_parts(["switch_on_constant"|Entries], switch_on_constant(Entries)).
 instr_from_parts(["switch_on_constant_a2"|Entries], switch_on_constant_a2(Entries)).
 instr_from_parts(["proceed"], proceed).
+instr_from_parts(["begin_aggregate", Type, ValReg, ResReg], begin_aggregate(Type, ValReg, ResReg)).
+instr_from_parts(["end_aggregate", ValReg], end_aggregate(ValReg)).
 instr_from_parts(Parts, raw(Combined)) :-
     atomic_list_concat(Parts, ' ', Combined).
 
@@ -1415,6 +1417,41 @@ wam_elixir_lower_instr(proceed, _PC, _Labels, _FuncName, _Suffix, Code) :-
     % state.cp — this tail call invokes it. BEAM TCO collapses the stack
     % so deep recursion doesn\'t grow it.
     Code = '    state.cp.(state)'.
+
+% begin_aggregate / end_aggregate lowering — Phase 2 of the findall
+% implementation per docs/proposals/WAM_ELIXIR_TIER2_FINDALL.md §4.2/§4.3.
+% Substrate helpers live in WamRuntime (PR #1627).
+
+wam_elixir_lower_instr(begin_aggregate(AggTypeStr, ValueReg, ResultReg),
+                       _PC, _Labels, _FuncName, _Suffix, Code) :-
+    agg_type_atom(AggTypeStr, AggType),
+    reg_id(ValueReg, ValReg),
+    reg_id(ResultReg, ResReg),
+    format(string(Code),
+'    state = WamRuntime.push_aggregate_frame(state, :~w, ~w, ~w)',
+        [AggType, ValReg, ResReg]).
+
+wam_elixir_lower_instr(end_aggregate(ValueReg), _PC, _Labels, _FuncName, _Suffix, Code) :-
+    reg_id(ValueReg, ValReg),
+    format(string(Code),
+'    state = WamRuntime.aggregate_collect(state, ~w)
+    throw({:fail, state})', [ValReg]).
+
+%% agg_type_atom(+Str, -Atom)
+%  Translates the WAM-text aggregator name to the Elixir runtime atom.
+%
+%  The WAM compiler emits `:collect` for findall/3 (via the
+%  `collect-Template` wrapper in compile_findall/5). The Tier-2 gate
+%  `in_forkable_aggregate_frame?/1` (PR #1586) only recognises
+%  `:findall` and `:aggregate_all` as forkable, so we translate
+%  `collect → findall` at the emission site rather than broadening the
+%  substrate. Decision per WAM_ELIXIR_TIER2_FINDALL.md §6.4 and §9 Q5.
+%
+%  All other aggregator atoms (sum/count/max/min/bag/set/aggregate_all)
+%  pass through unchanged — finalise_aggregate/4 (PR #1627) handles the
+%  full alphabet.
+agg_type_atom("collect", findall) :- !.
+agg_type_atom(Str, Atom) :- atom_string(Atom, Str).
 
 wam_elixir_lower_instr(raw(Combined), _PC, _Labels, _FuncName, _Suffix, Code) :-
     format(string(Code), '    # raw: ~w\n    raise "TODO: ~w"', [Combined, Combined]).

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -947,9 +947,19 @@ compile_aggregate_helpers_to_elixir(Code) :-
   for bagof/setof (witness-variable dependency) and for an empty or
   non-aggregate-bearing CP stack.
 
-  Consumed by the Tier-2 wrapper (`par_wrap_segment/3`, PR2) as a
-  correctness gate: outside a forkable aggregate, parallel fan-out
-  would strand solutions that the sequential `next_solution/1`
+  Note on the alphabet: the WAM compiler\'s compile_aggregate_all/5
+  emits `:collect` for findall/3 (via the collect-Template wrapper
+  in compile_findall/5), but the Elixir target translates
+  `collect → findall` at the begin_aggregate emission site
+  (agg_type_atom/2 in wam_elixir_lowered_emitter.pl, per
+  WAM_ELIXIR_TIER2_FINDALL.md §6.4). Consequently the only
+  forkable atoms this function ever sees in emitted modules are
+  `:findall` and `:aggregate_all` — `:collect` never reaches the
+  runtime substrate.
+
+  Consumed by the Tier-2 wrapper (`par_wrap_segment/4`, PR #1608)
+  as a correctness gate: outside a forkable aggregate, parallel
+  fan-out would strand solutions that the sequential
   enumeration path would otherwise surface.
   """
   def in_forkable_aggregate_frame?(state) do

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -827,6 +827,96 @@ test_findall_substrate_emits_finalise_aggregate :-
 %% deferred to Phase 3 runtime tests, where a fixture state with an
 %% empty CP stack can exercise the contract end-to-end.
 
+%% Findall instructions (Phase 2) — exercises the parser entries and
+%% wam_elixir_lower_instr/6 clauses for begin_aggregate / end_aggregate
+%% per docs/proposals/WAM_ELIXIR_TIER2_FINDALL.md §4.2 + §4.3.
+
+test_findall_instr_parser_begin_aggregate :-
+    Test = 'Findall instr: instr_from_parts parses `begin_aggregate sum, A1, A3`',
+    (   wam_elixir_lowered_emitter:instr_from_parts(
+            ["begin_aggregate", "sum", "A1", "A3"],
+            begin_aggregate("sum", "A1", "A3"))
+    ->  pass(Test)
+    ;   fail_test(Test, 'parser did not match begin_aggregate 4-element form')
+    ).
+
+test_findall_instr_parser_end_aggregate :-
+    Test = 'Findall instr: instr_from_parts parses `end_aggregate A1`',
+    (   wam_elixir_lowered_emitter:instr_from_parts(
+            ["end_aggregate", "A1"],
+            end_aggregate("A1"))
+    ->  pass(Test)
+    ;   fail_test(Test, 'parser did not match end_aggregate 2-element form')
+    ).
+
+test_findall_instr_lowers_begin_aggregate_sum :-
+    Test = 'Findall instr: begin_aggregate(sum, A1, A3) lowers to push_aggregate_frame call with :sum',
+    (   wam_elixir_lowered_emitter:wam_elixir_lower_instr(
+            begin_aggregate("sum", "A1", "A3"),
+            1, [], "clause_main", "", Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'WamRuntime.push_aggregate_frame(state, :sum, 1, 3)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'sum aggregator did not lower to push_aggregate_frame call')
+    ).
+
+test_findall_instr_translates_collect_to_findall :-
+    Test = 'Findall instr: begin_aggregate(collect, ...) translates to :findall (proposal §6.4)',
+    (   wam_elixir_lowered_emitter:wam_elixir_lower_instr(
+            begin_aggregate("collect", "A1", "A3"),
+            1, [], "clause_main", "", Code),
+        atom_string(Code, S),
+        % Translation is at the emission site so the substrate's
+        % in_forkable_aggregate_frame?/1 (which only recognises
+        % :findall and :aggregate_all) sees a forkable frame.
+        sub_string(S, _, _, _, ':findall'),
+        \+ sub_string(S, _, _, _, ':collect')
+    ->  pass(Test)
+    ;   fail_test(Test, 'collect aggregator was not translated to :findall at emission')
+    ).
+
+test_findall_instr_lowers_end_aggregate :-
+    Test = 'Findall instr: end_aggregate(A1) lowers to aggregate_collect + throw({:fail, state})',
+    (   wam_elixir_lowered_emitter:wam_elixir_lower_instr(
+            end_aggregate("A1"),
+            1, [], "clause_main", "", Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'WamRuntime.aggregate_collect(state, 1)'),
+        % Throw drives backtrack into finalise_aggregate per the
+        % fail-driven enumeration model (proposal §3.3 / §4.4).
+        sub_string(S, _, _, _, 'throw({:fail, state})')
+    ->  pass(Test)
+    ;   fail_test(Test, 'end_aggregate did not emit collect + throw shape')
+    ).
+
+%% End-to-end bridge: a predicate whose body uses findall/3 should now
+%% lower through the full pipeline (WAM compile → parse → lower) and
+%% produce a module containing both runtime calls. This is the first
+%% test that exercises the full Phase 2 chain. Phase 3 will add actual
+%% Elixir-execution tests.
+
+:- dynamic phase_a_test:has_findall/1.
+
+phase_a_findall_fixture_setup :-
+    phase_a_fixture_setup,
+    retractall(phase_a_test:has_findall(_)),
+    assertz((phase_a_test:has_findall(L) :-
+        findall(X, phase_a_test:small_fact(X, _), L))).
+
+test_findall_instr_end_to_end_lowering :-
+    Test = 'Findall instr: predicate body using findall/3 lowers to push_aggregate_frame + aggregate_collect',
+    phase_a_findall_fixture_setup,
+    wam_target:compile_predicate_to_wam(phase_a_test:has_findall/1, [], WamCode),
+    lower_predicate_to_elixir(has_findall/1, WamCode,
+                              [module_name('TestMod')], Code),
+    atom_string(Code, S),
+    (   sub_string(S, _, _, _, 'WamRuntime.push_aggregate_frame(state, :findall'),
+        sub_string(S, _, _, _, 'WamRuntime.aggregate_collect(state'),
+        sub_string(S, _, _, _, 'throw({:fail, state})')
+    ->  pass(Test)
+    ;   fail_test(Test, 'end-to-end findall lowering missing push/collect/throw shape')
+    ).
+
 test_findall_substrate_backtrack_routes_aggregate_frames :-
     Test = 'Findall substrate: backtrack/1 dispatches aggregate frames to finalise_aggregate',
     (   compile_wam_runtime_to_elixir([], Code),
@@ -1157,6 +1247,12 @@ run_tests :-
     test_findall_substrate_emits_aggregate_collect,
     test_findall_substrate_emits_finalise_aggregate,
     test_findall_substrate_backtrack_routes_aggregate_frames,
+    test_findall_instr_parser_begin_aggregate,
+    test_findall_instr_parser_end_aggregate,
+    test_findall_instr_lowers_begin_aggregate_sum,
+    test_findall_instr_translates_collect_to_findall,
+    test_findall_instr_lowers_end_aggregate,
+    test_findall_instr_end_to_end_lowering,
     test_tier2_purity_gate_rejects_unknown,
     test_tier2_purity_gate_accepts_declared,
     test_par_wrap_segment_emits_super_wrapper,

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -910,7 +910,11 @@ test_findall_instr_end_to_end_lowering :-
     lower_predicate_to_elixir(has_findall/1, WamCode,
                               [module_name('TestMod')], Code),
     atom_string(Code, S),
-    (   sub_string(S, _, _, _, 'WamRuntime.push_aggregate_frame(state, :findall'),
+    (   % :findall (translated from WAM-emitted :collect) must appear
+        % in the push call — confirms the collect→findall translation
+        % survives the full WAM compile → parse → lower pipeline, not
+        % just the unit-level lowering test above.
+        sub_string(S, _, _, _, 'WamRuntime.push_aggregate_frame(state, :findall'),
         sub_string(S, _, _, _, 'WamRuntime.aggregate_collect(state'),
         sub_string(S, _, _, _, 'throw({:fail, state})')
     ->  pass(Test)


### PR DESCRIPTION
## Summary

- Phase 2 of the three-phase findall implementation per `docs/proposals/WAM_ELIXIR_TIER2_FINDALL.md` §4.2 + §4.3. Lowers the `begin_aggregate` and `end_aggregate` WAM instructions emitted by `compile_aggregate_all/5` (`wam_target.pl:710`) into calls into the Phase 1 substrate (#1627).
- Two new `wam_elixir_lower_instr/6` clauses, two parser entries, one translation helper (`agg_type_atom/2`), and the canonical `:collect → :findall` translation per proposal §6.4 / §9 Q5.
- 79/79 tests passing (73 prior + 6 new). End-to-end findall execution waits on Phase 3 (runtime integration tests).

## Why this is split out

Following the same multi-PR pattern that the Tier-2 wiring used (#1586 substrate → #1607 probe → #1608 emitter → #1611 proposal → #1624 activation), this PR lands the instruction lowering alone so the emission shape and the `:collect → :findall` translation can be reviewed in isolation before Phase 3 starts exercising end-to-end execution.

## What changes

### `src/unifyweaver/targets/wam_elixir_lowered_emitter.pl`

**Parser entries** in `instr_from_parts/2`:

- `["begin_aggregate", Type, ValReg, ResReg]` → `begin_aggregate(Type, ValReg, ResReg)`
- `["end_aggregate", ValReg]` → `end_aggregate(ValReg)`

Both ride on the existing tokenizer that strips commas as separators (`wam_separator_char/1`), so `begin_aggregate sum, A1, A3` tokenises cleanly without new parsing machinery.

**Lowering** in `wam_elixir_lower_instr/6`:

- `begin_aggregate(Type, ValReg, ResReg)` →
  ```elixir
  state = WamRuntime.push_aggregate_frame(state, :type, vreg, rreg)
  ```
- `end_aggregate(ValReg)` →
  ```elixir
  state = WamRuntime.aggregate_collect(state, vreg)
  throw({:fail, state})
  ```
  The throw drives backtrack into `finalise_aggregate/4` per the fail-driven enumeration model (LLVM precedent at `wam_llvm_target.pl:2417`, proposal §3.3 / §4.4). A control-flow comment near the lowering documents the non-obvious chain `throw → wrap_segment catch → backtrack → finalise`.

**Aggregator-name translation** (`agg_type_atom/2`):

- `:collect → :findall` at the emission site, per proposal §6.4 / §9 Q5. The WAM compiler emits `:collect` for findall/3 (via the `collect-Template` wrapper in `compile_findall/5`), but the Tier-2 gate `in_forkable_aggregate_frame?/1` (#1586) only recognises `:findall` and `:aggregate_all` as forkable. Translating at emission keeps the substrate's existing alphabet authoritative rather than broadening it.
- All other aggregator atoms (`sum/count/max/min/bag/set/aggregate_all`) pass through unchanged — `finalise_aggregate/4` (#1627) handles the full alphabet uniformly.

### `src/unifyweaver/targets/wam_elixir_target.pl`

Cross-reference added to `in_forkable_aggregate_frame?/1`'s `@doc`: notes that `:collect` never reaches the runtime substrate (translated at emission) so the gate only ever sees `:findall` / `:aggregate_all`. The gate is the canonical reader of forkable atoms, so its docstring is the right place to document the alphabet contract.

### `tests/test_wam_elixir_target.pl`

Six new tests:

- **Parser:** `begin_aggregate sum, A1, A3` → 4-arg term.
- **Parser:** `end_aggregate A1` → 2-arg term.
- **Lowering:** sum aggregator emits `:sum` (no translation).
- **Lowering:** collect aggregator emits `:findall` (translation applied).
- **Lowering:** `end_aggregate` emits `aggregate_collect` call + `throw({:fail, state})`.
- **End-to-end pipeline:** a predicate body using `findall/3` compiles through the full `compile_predicate_to_wam → parse → lower_predicate_to_elixir` chain and the lowered module contains `push_aggregate_frame(state, :findall, ...)`, `aggregate_collect(state, ...)`, and the failing throw. This is the strongest new test — validates the WAM compiler, parser, and lowering all connect.

## Reviewer notes

**`:collect → :findall` translation is a deliberate one-way bridge.** The WAM compiler's intermediate representation uses `:collect` as the findall aggregator; the Elixir runtime's substrate alphabet uses `:findall` because `in_forkable_aggregate_frame?/1` predates this PR. Translating at the emission site (rather than broadening the substrate to recognise `:collect`) keeps the substrate's existing contract stable and was the design choice in proposal §9 Q5. The translation is unit-tested AND asserted in the end-to-end pipeline test — both sites verified.

**The `throw({:fail, state})` in `end_aggregate`'s lowering is intentional, not an error.** It is caught by the enclosing `wrap_segment`'s `try/catch`, which calls `WamRuntime.backtrack/1`, which (per Phase 1 — #1627) dispatches on `:agg_type` and routes aggregate-frame CPs to `finalise_aggregate/4`. The control flow is documented as an inline comment near the lowering.

## Review history (Perplexity)

Initial review confirmed Phase 2 was correct and well-scoped, with three documentation-level recommendations (no blockers); all addressed in the follow-up commit:

| Severity | Issue | Resolution |
|---|---|---|
| 🟡 Recommend | `:findall` substring not asserted in end-to-end test | Test already had it (review missed it); added a clarifying comment so intent is explicit |
| 🟡 Recommend | `collect → findall` translation not cross-referenced in the substrate `@doc` | Added a paragraph to `in_forkable_aggregate_frame?/1`'s `@doc` documenting the alphabet contract and pointing at proposal §6.4 |
| 🟢 Nit | Control flow `throw → catch → backtrack → finalise` is non-obvious from the emitted code | Added an inline comment near the `end_aggregate` lowering explaining the chain |

## Phase plan

- **Phase 1 (#1627, merged):** runtime substrate.
- **Phase 2 (this PR):** instruction lowering.
- **Phase 3 (next):** runtime integration tests. Spin up a `mix` project, drop in the lowered runtime, and run representative findall queries (`findall(X, member(X, [a,b,c]), L)`, `findall(X, fail, L)`, `aggregate_all(count, ..., N)`, etc.) — asserting result lists with actual Elixir execution. The §6 risks (trail-unwind safety of compound values, cut-barrier interaction, nested findalls, Tier-2 finalise trigger) need real execution to probe.

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_target.pl` — 79/79 passing
- [x] All 73 pre-Phase-2 tests pass unchanged (lowering is additive — new instruction handlers, no changes to existing emission)
- [x] 6 new tests cover parser (2), unit-level lowering by aggregator type (3), and end-to-end pipeline (1)
- [x] Translation `:collect → :findall` covered at both unit-level (`test_findall_instr_translates_collect_to_findall`) and end-to-end (`test_findall_instr_end_to_end_lowering` asserts `:findall` substring)
- [ ] Elixir-side `mix compile` of a generated module containing the new instruction emissions — recommend before merge as a syntax-correctness check, will be properly exercised in Phase 3

## Related

- Proposal: `docs/proposals/WAM_ELIXIR_TIER2_FINDALL.md` (#1626)
- Phase 1 substrate: #1627 (`push_aggregate_frame/4`, `aggregate_collect/2`, `finalise_aggregate/4`, `backtrack/1` dispatch)
- Tier-2 substrate this builds on: #1586 (`in_forkable_aggregate_frame?/1`, `merge_into_aggregate/2`)
- LLVM precedent for fail-driven enumeration: `wam_llvm_target.pl:2417-2496`
- WAM compiler's findall entry: `wam_target.pl:755`
