### PR TITLE
feat(wam-clojure): add LMDB relation adaptor

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -623,3 +623,22 @@ relation's resolved mode came from the shared `preprocess/2` layer. That
 brings the current Clojure path closer to the C# provider/materializer
 shape: generated artifacts now carry both the chosen storage mode and
 the declaration intent that selected it.
+
+The next Clojure step is no longer just metadata. The benchmark
+generator now supports an opt-in per-relation `lmdb` mode for
+`category_parent`. When that override is selected, generation:
+
+- writes a flat `category_parent.tsv` source file
+- builds a real LMDB dupsort artifact for `category_parent/2`
+- packages the shared JVM LMDB reader into
+  `lib/lmdb-artifact-reader.jar`
+- builds `lib/liblmdb_artifact_jni.so`
+- switches the generated Clojure `category_parent/2` and
+  `category_ancestor/4` foreign handlers to use
+  `generated.lmdb.LmdbArtifactReader`
+
+The generated benchmark runner also knows how to put that helper jar on
+the Java classpath and expose the JNI library path when the project is
+launched. The current integration is deliberately narrow: only
+`category_parent` can opt into LMDB, and the existing EDN / grouped-TSV
+paths remain the stable defaults and fallbacks.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -186,6 +186,21 @@ These are applied on top of `artifact` mode so a workload can, for
 example, keep `category_parent` on the grouped artifact path while
 forcing `article_category` back to row sidecars, or vice versa.
 
+`category_parent` also now accepts an opt-in `lmdb` override. In that
+mode the generator:
+
+- writes a `category_parent/2` LMDB dupsort artifact under
+  `data/generated/wam_clojure_optimized_bench/category_parent_lmdb/`
+- packages the JVM reader helper as
+  `lib/lmdb-artifact-reader.jar`
+- builds the JNI shim as `lib/liblmdb_artifact_jni.so`
+- places that helper jar on the runtime classpath when the benchmark
+  harness launches the generated Clojure project
+
+This keeps the public benchmark target names stable while letting a
+workload compare grouped TSV against LMDB-backed exact arg1 lookups for
+the hottest traversal relation.
+
 The generator also now honors the shared predicate-preprocessing
 declaration surface from
 `src/unifyweaver/core/predicate_preprocessing.pl`. For the current

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -244,8 +244,13 @@ def build_wam_go_effective_distance(root: Path, scale: str, kernel_mode: str) ->
 
 def clojure_classpath(project_dir: Path) -> str:
     env_classpath = os.environ.get("CLASSPATH", "")
+    helper_jar = project_dir / "lib" / "lmdb-artifact-reader.jar"
     if env_classpath:
-        return ":".join([str(project_dir / "src"), env_classpath])
+        parts = [str(project_dir / "src")]
+        if helper_jar.exists():
+            parts.append(str(helper_jar))
+        parts.append(env_classpath)
+        return ":".join(parts)
     jar_paths = [
         Path.home() / ".m2" / "repository" / "org" / "clojure" / "clojure" / "1.11.1" / "clojure-1.11.1.jar",
         Path.home() / ".m2" / "repository" / "org" / "clojure" / "spec.alpha" / "0.3.218" / "spec.alpha-0.3.218.jar",
@@ -264,7 +269,11 @@ def clojure_classpath(project_dir: Path) -> str:
     existing_jars = [path for path in jar_paths if path.exists()]
     if not existing_jars:
         raise RuntimeError("Clojure jars not found; cannot run clojure-wam target")
-    return ":".join([str(project_dir / "src"), *(str(path) for path in existing_jars)])
+    parts = [str(project_dir / "src")]
+    if helper_jar.exists():
+        parts.append(str(helper_jar))
+    parts.extend(str(path) for path in existing_jars)
+    return ":".join(parts)
 
 
 def build_wam_clojure_effective_distance(
@@ -288,14 +297,20 @@ def build_wam_clojure_effective_distance(
         ],
         cwd=ROOT,
     )
-    return [
-        "java",
-        "-cp",
-        clojure_classpath(project_dir),
-        "clojure.main",
-        "-m",
-        "generated.wam_clojure_optimized_bench.core",
-    ]
+    command = ["java"]
+    native_lib_dir = project_dir / "lib"
+    if native_lib_dir.exists():
+        command.append(f"-Djava.library.path={native_lib_dir}")
+    command.extend(
+        [
+            "-cp",
+            clojure_classpath(project_dir),
+            "clojure.main",
+            "-m",
+            "generated.wam_clojure_optimized_bench.core",
+        ]
+    )
+    return command
 
 
 def parse_effective_distance_facts(facts_path: Path) -> tuple[list[tuple[str, str]], list[str]]:

--- a/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
@@ -18,6 +18,7 @@
               [declared_preprocess/3,
                declared_preprocess_metadata/4]).
 :- use_module(library(filesex), [directory_file_path/3, make_directory_path/1]).
+:- use_module(library(process), [process_create/3, process_wait/2]).
 :- discontiguous benchmark_article_category_by_article_artifact/1.
 :- discontiguous benchmark_category_parent_by_child_artifact/1.
 
@@ -41,6 +42,16 @@ benchmark_workload_path(Path) :-
     source_file(benchmark_workload_path(_), ThisFile),
     file_directory_name(ThisFile, Here),
     directory_file_path(Here, 'effective_distance.pl', Path).
+
+benchmark_repo_root(Root) :-
+    source_file(benchmark_repo_root(_), ThisFile),
+    file_directory_name(ThisFile, BenchDir),
+    file_directory_name(BenchDir, ExamplesDir),
+    file_directory_name(ExamplesDir, Root).
+
+benchmark_repo_path(RelativePath, AbsolutePath) :-
+    benchmark_repo_root(Root),
+    directory_file_path(Root, RelativePath, AbsolutePath).
 
 main :-
     current_prolog_flag(argv, Argv),
@@ -211,7 +222,7 @@ benchmark_declared_data_mode(Mode) :-
     current_predicate(user:Name/1),
     Goal =.. [Name, DeclaredMode],
     once(call(user:Goal)),
-    memberchk(DeclaredMode, [auto, sidecar, artifact, inline]),
+    memberchk(DeclaredMode, [auto, sidecar, artifact, inline, lmdb]),
     Mode = DeclaredMode.
 
 benchmark_relation_declared_data_mode(Relation, Mode) :-
@@ -222,7 +233,7 @@ benchmark_relation_declared_data_mode(Relation, Mode) :-
     current_predicate(user:Name/2),
     Goal =.. [Name, Relation, DeclaredMode],
     once(call(user:Goal)),
-    memberchk(DeclaredMode, [auto, sidecar, artifact, inline]),
+    memberchk(DeclaredMode, [auto, sidecar, artifact, inline, lmdb]),
     Mode = DeclaredMode.
 
 benchmark_fact_volume(RowCount) :-
@@ -250,6 +261,11 @@ category_parent_handler_code(OutputDir, artifact, HandlerCode) :-
     format(string(HandlerCode),
            "(let [parents-by-child-delay (delay (into {} (keep (fn [line] (when-not (.isEmpty ^String line) (let [parts (vec (.split ^String line \"\\\\t\")) child (first parts) parents (subvec parts 1)] [child parents]))) (.split ^String (slurp ~w) \"\\\\r?\\\\n\"))))] (fn [args] (let [child (nth args 0) parent (nth args 1)] (boolean (some #(= parent %) (get @parents-by-child-delay child []))))))",
            [CategoryParentMapPath]).
+category_parent_handler_code(OutputDir, lmdb, HandlerCode) :-
+    benchmark_sidecar_subdir_literal(OutputDir, 'category_parent_lmdb', ArtifactDirPath),
+    format(string(HandlerCode),
+           "(let [reader-delay (delay (generated.lmdb.LmdbArtifactReader/open (java.nio.file.Paths/get ~w (make-array String 0))))] (fn [args] (let [child (nth args 0) parent (nth args 1) rows (.lookupArg1 ^generated.lmdb.LmdbArtifactReader @reader-delay child)] (boolean (some (fn [^generated.lmdb.LmdbRow row] (= parent (.value row))) rows)))))",
+           [ArtifactDirPath]).
 category_parent_handler_code(_OutputDir, inline, HandlerCode) :-
     category_parent_handler_code(inline, HandlerCode).
 category_parent_handler_code(sidecar, HandlerCode) :-
@@ -287,6 +303,12 @@ category_ancestor_handler_code(OutputDir, artifact, HandlerCode) :-
     format(string(HandlerCode),
            "(let [parents-by-child-delay (delay (into {} (keep (fn [line] (when-not (.isEmpty ^String line) (let [parts (vec (.split ^String line \"\\\\t\")) child (first parts) parents (subvec parts 1)] [child parents]))) (.split ^String (slurp ~w) \"\\\\r?\\\\n\")))) max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (get @parents-by-child-delay category [])] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] {:solutions (vec solutions)})))",
            [CategoryParentMapPath, MaxDepth]).
+category_ancestor_handler_code(OutputDir, lmdb, HandlerCode) :-
+    benchmark_max_depth_literal(MaxDepth),
+    benchmark_sidecar_subdir_literal(OutputDir, 'category_parent_lmdb', ArtifactDirPath),
+    format(string(HandlerCode),
+           "(let [reader-delay (delay (generated.lmdb.LmdbArtifactReader/open (java.nio.file.Paths/get ~w (make-array String 0)))) max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) parent-values (fn [category] (mapv (fn [^generated.lmdb.LmdbRow row] (.value row)) (.lookupArg1 ^generated.lmdb.LmdbArtifactReader @reader-delay category))) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (parent-values category)] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] {:solutions (vec solutions)})))",
+           [ArtifactDirPath, MaxDepth]).
 category_ancestor_handler_code(_OutputDir, inline, HandlerCode) :-
     category_ancestor_handler_code(inline, HandlerCode).
 category_ancestor_handler_code(sidecar, HandlerCode) :-
@@ -480,6 +502,8 @@ benchmark_relation_predicate(category_parent, category_parent/2).
 benchmark_derived_state_code(artifact, artifact, Code) :-
     Code = '(def benchmark-seed-categories-delay
   (delay (sort (set (mapcat identity (vals @benchmark-article-categories-by-article-delay))))))'.
+benchmark_derived_state_code(artifact, lmdb, Code) :-
+    benchmark_derived_state_code(artifact, artifact, Code).
 benchmark_derived_state_code(sidecar, artifact, Code) :-
     Code = '(def benchmark-article-categories-by-article-delay
   (delay
@@ -490,6 +514,8 @@ benchmark_derived_state_code(sidecar, artifact, Code) :-
 
 (def benchmark-seed-categories-delay
   (delay (sort (set (map second @benchmark-article-categories-delay)))))'.
+benchmark_derived_state_code(sidecar, lmdb, Code) :-
+    benchmark_derived_state_code(sidecar, artifact, Code).
 benchmark_derived_state_code(_ArticleMode, _ParentMode, Code) :-
     Code = '(def benchmark-parents-by-child-delay
   (delay
@@ -541,6 +567,17 @@ benchmark_category_parents_code(artifact, _DataDirLiteral, _BenchmarkData, Code)
                       parents (subvec parts 1)]
                   [child parents]))))
       (.split ^String (slurp (str benchmark-data-dir "/category_parent_by_child.tsv")) "\\r?\\n"))))'.
+benchmark_category_parents_code(lmdb, _DataDirLiteral, _BenchmarkData, Code) :-
+    Code = '(def benchmark-parents-by-child-delay
+  (delay
+    (let [reader (generated.lmdb.LmdbArtifactReader/open
+                   (java.nio.file.Paths/get
+                     (str benchmark-data-dir "/category_parent_lmdb")
+                     (make-array String 0)))]
+      (reduce (fn [acc ^generated.lmdb.LmdbRow row]
+                (update acc (.key row) (fnil conj []) (.value row)))
+              {}
+              (.scan ^generated.lmdb.LmdbArtifactReader reader)))))'.
 benchmark_category_parents_code(inline, _DataDirLiteral, benchmark_data(_, CategoryParents, _, _, _, _, _, _), Code) :-
     format(string(Code),
            "(def benchmark-category-parents-delay (delay [~s]))",
@@ -566,15 +603,19 @@ maybe_write_benchmark_sidecar_files(OutputDir, FactsPath, VariantAtom, KernelMod
 maybe_write_benchmark_sidecar_files(_, _, _, _, inline, _).
 
 write_benchmark_sidecar_files(OutputDir, FactsPath, VariantAtom, KernelModeAtom, DataMode, BenchmarkData) :-
+    benchmark_effective_data_modes(VariantAtom, DataMode, _ArticleMode, ParentMode),
     benchmark_sidecar_dir(OutputDir, DataDir),
     make_directory_path(DataDir),
     write_benchmark_sidecar_file(DataDir, 'article_category.edn', BenchmarkData, benchmark_article_category_edn),
     write_benchmark_sidecar_file(DataDir, 'article_category_by_article.tsv', BenchmarkData, benchmark_article_category_by_article_artifact),
     write_benchmark_sidecar_file(DataDir, 'category_parent.edn', BenchmarkData, benchmark_category_parent_edn),
     write_benchmark_sidecar_file(DataDir, 'category_parent_by_child.tsv', BenchmarkData, benchmark_category_parent_by_child_artifact),
+    write_benchmark_sidecar_file(DataDir, 'category_parent.tsv', BenchmarkData, benchmark_category_parent_rows_tsv),
     write_benchmark_sidecar_file(DataDir, 'root_category.edn', BenchmarkData, benchmark_root_category_edn),
+    maybe_write_category_parent_lmdb_artifact(DataDir, ParentMode),
     benchmark_artifact_manifest(FactsPath, VariantAtom, KernelModeAtom, DataMode, Manifest),
-    write_benchmark_sidecar_content(DataDir, 'manifest.edn', Manifest).
+    write_benchmark_sidecar_content(DataDir, 'manifest.edn', Manifest),
+    maybe_prepare_clojure_lmdb_runtime_support(OutputDir, ParentMode).
 
 benchmark_sidecar_dir(OutputDir, DataDir) :-
     directory_file_path(OutputDir, 'data', DataRoot),
@@ -590,6 +631,12 @@ benchmark_sidecar_file_path_literal(OutputDir, FileName, Literal) :-
     benchmark_sidecar_dir(OutputDir, DataDir),
     directory_file_path(DataDir, FileName, FilePath),
     absolute_file_name(FilePath, AbsolutePath),
+    clj_string_literal_local(AbsolutePath, Literal).
+
+benchmark_sidecar_subdir_literal(OutputDir, DirName, Literal) :-
+    benchmark_sidecar_dir(OutputDir, DataDir),
+    directory_file_path(DataDir, DirName, DirPath),
+    absolute_file_name(DirPath, AbsolutePath),
     clj_string_literal_local(AbsolutePath, Literal).
 
 write_benchmark_sidecar_file(DataDir, FileName, BenchmarkData, Builder) :-
@@ -693,6 +740,10 @@ relation_manifest_shape(category_parent, artifact,
                         'category_parent_by_child.tsv',
                         'grouped_tsv_arg1',
                         'arg1_lookup,scan_grouped') :- !.
+relation_manifest_shape(category_parent, lmdb,
+                        'category_parent_lmdb/manifest.json',
+                        'lmdb_dupsort_btree',
+                        'arg1_lookup,arg1_multi_lookup,scan') :- !.
 relation_manifest_shape(category_parent, _,
                         'category_parent.edn',
                         'edn_rows',
@@ -788,6 +839,19 @@ category_parent_bucket_artifact_line(Child, Line) :-
             Parents0),
     sort(Parents0, Parents),
     atomic_list_concat([Child|Parents], '\t', Line).
+
+benchmark_category_parent_rows_tsv(Content) :-
+    findall(Child-Parent,
+            current_category_parent_fact(Child, Parent),
+            Pairs0),
+    sort(Pairs0, Pairs),
+    maplist(category_parent_row_tsv_line, Pairs, Lines),
+    atomic_list_concat(Lines, '\n', Content).
+benchmark_category_parent_rows_tsv(_, Content) :-
+    benchmark_category_parent_rows_tsv(Content).
+
+category_parent_row_tsv_line(Child-Parent, Line) :-
+    atomic_list_concat([Child, Parent], '\t', Line).
 
 benchmark_root_category_edn(benchmark_data(_, _, _, _, _, Content, _, _), Content).
 
@@ -904,3 +968,73 @@ power_sum_bound(Cat, Root, NegN, WeightSum) :-
          H is Hops + 1,
          W is H ** NegN),
         WeightSum).
+
+maybe_write_category_parent_lmdb_artifact(_DataDir, ParentMode) :-
+    ParentMode \== lmdb,
+    !.
+maybe_write_category_parent_lmdb_artifact(DataDir, lmdb) :-
+    directory_file_path(DataDir, 'category_parent.tsv', TsvPath),
+    directory_file_path(DataDir, 'category_parent_lmdb', ArtifactDir),
+    make_directory_path(ArtifactDir),
+    benchmark_repo_path('examples/lmdb_relation_artifact/Cargo.toml', CargoManifest),
+    process_create(path(cargo),
+                   ['run', '--quiet',
+                    '--manifest-path', CargoManifest,
+                    '--', 'build', 'category_parent/2',
+                    TsvPath, ArtifactDir, '--dupsort'],
+                   [process(PID)]),
+    process_wait(PID, Status),
+    (   Status == exit(0)
+    ->  true
+    ;   throw(error(cargo_lmdb_artifact_build_failed(Status, TsvPath, ArtifactDir), _))
+    ).
+
+maybe_prepare_clojure_lmdb_runtime_support(_OutputDir, ParentMode) :-
+    ParentMode \== lmdb,
+    !.
+maybe_prepare_clojure_lmdb_runtime_support(OutputDir, lmdb) :-
+    absolute_file_name(OutputDir, AbsoluteOutputDir),
+    directory_file_path(AbsoluteOutputDir, 'classes', ClassesDir),
+    directory_file_path(AbsoluteOutputDir, 'lib', LibDir),
+    directory_file_path(AbsoluteOutputDir, '.jni', JniDir),
+    make_directory_path(ClassesDir),
+    make_directory_path(LibDir),
+    make_directory_path(JniDir),
+    lmdb_helper_java_sources(JavaSources),
+    atomic_list_concat(JavaSources, ' ', JavaSourceArgs),
+    format(atom(JavacCmd),
+           'javac -d "~w" -h "~w" ~w',
+           [ClassesDir, JniDir, JavaSourceArgs]),
+    run_shell_command_or_throw(AbsoluteOutputDir, JavacCmd, javac_lmdb_helper_failed),
+    format(atom(JarCmd),
+           'jar --create --file "~w/lmdb-artifact-reader.jar" -C "~w" generated/lmdb',
+           [LibDir, ClassesDir]),
+    run_shell_command_or_throw(AbsoluteOutputDir, JarCmd, jar_lmdb_helper_failed),
+    benchmark_repo_path('examples/scala_lmdb_jni_probe/native/lmdb_artifact_jni.c', NativeSource),
+    format(atom(GccCmd),
+           'JAVAC_REAL=$(readlink -f "$(command -v javac)") && JAVA_HOME_DIR=$(CDPATH= cd -- "$(dirname "$JAVAC_REAL")/.." && pwd) && cat "~w" | gcc -x c -shared -fPIC -include stddef.h -I"$JAVA_HOME_DIR/include" -I"$JAVA_HOME_DIR/include/linux" -I/data/data/com.termux/files/usr/include -L/data/data/com.termux/files/usr/lib -o "~w/liblmdb_artifact_jni.so" - -llmdb',
+           [NativeSource, LibDir]),
+    run_shell_command_or_throw(AbsoluteOutputDir, GccCmd, gcc_lmdb_helper_failed).
+
+lmdb_helper_java_sources(JavaSources) :-
+    maplist(lmdb_helper_java_source_path,
+            [ 'LmdbRow.java',
+              'LmdbArtifactManifest.java',
+              'LmdbArtifactReader.java',
+              'LmdbArtifactJNI.java'
+            ],
+            JavaSources).
+
+lmdb_helper_java_source_path(FileName, QuotedPath) :-
+    benchmark_repo_path('examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb', JavaDir),
+    directory_file_path(JavaDir, FileName, SourcePath),
+    format(atom(QuotedPath), '"~w"', [SourcePath]).
+
+run_shell_command_or_throw(Cwd, Command, ErrorFunctor) :-
+    process_create(path(sh), ['-c', Command], [cwd(Cwd), process(PID)]),
+    process_wait(PID, Status),
+    (   Status == exit(0)
+    ->  true
+    ;   Error =.. [ErrorFunctor, Status, Command],
+        throw(error(Error, _))
+    ).

--- a/examples/lmdb_relation_artifact/src/main.rs
+++ b/examples/lmdb_relation_artifact/src/main.rs
@@ -8,7 +8,7 @@ use std::env;
 use std::error::Error;
 use std::fmt::Write as _;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 type DynError = Box<dyn Error>;
 
@@ -302,6 +302,7 @@ fn file_sha256(path: &Path) -> Result<String, DynError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]

--- a/tests/test_wam_clojure_benchmark_generator.pl
+++ b/tests/test_wam_clojure_benchmark_generator.pl
@@ -76,6 +76,33 @@ test(relation_data_mode_override_accumulated_parent_sidecar) :-
         maybe_abolish_test_predicate(wam_clojure_benchmark_relation_data_mode/2)
     ).
 
+test(relation_data_mode_override_seeded_parent_lmdb, [condition(lmdb_helper_toolchain_available)]) :-
+    setup_call_cleanup(
+        ( load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
+          assertz(user:wam_clojure_benchmark_relation_data_mode(category_parent, lmdb))
+        ),
+        once((
+            unique_tmp_dir('tmp_wam_clojure_bench_rel_parent_lmdb', TmpDir),
+            generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, artifact),
+            directory_file_path(TmpDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
+            directory_file_path(TmpDir, 'data/generated/wam_clojure_optimized_bench/manifest.edn', ManifestPath),
+            directory_file_path(TmpDir, 'data/generated/wam_clojure_optimized_bench/category_parent_lmdb/manifest.json', LmdbManifestPath),
+            directory_file_path(TmpDir, 'lib/lmdb-artifact-reader.jar', ReaderJarPath),
+            directory_file_path(TmpDir, 'lib/liblmdb_artifact_jni.so', NativeLibPath),
+            read_file_to_string(CorePath, CoreCode, []),
+            read_file_to_string(ManifestPath, Manifest, []),
+            assertion(exists_file(LmdbManifestPath)),
+            assertion(exists_file(ReaderJarPath)),
+            assertion(exists_file(NativeLibPath)),
+            assertion(sub_string(CoreCode, _, _, _, 'generated.lmdb.LmdbArtifactReader/open')),
+            assertion(sub_string(CoreCode, _, _, _, 'category_parent_lmdb')),
+            assertion(sub_string(Manifest, _, _, _, '"category_parent" {:mode "lmdb"')),
+            assertion(sub_string(Manifest, _, _, _, ':file "category_parent_lmdb/manifest.json"')),
+            delete_directory_and_contents(TmpDir)
+        )),
+        maybe_abolish_test_predicate(wam_clojure_benchmark_relation_data_mode/2)
+    ).
+
 test(shared_preprocess_override_seeded_article_artifact) :-
     setup_call_cleanup(
         ( load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
@@ -247,6 +274,27 @@ test(generated_category_parent_handler_executes, [condition(clojure_available)])
         delete_directory_and_contents(TmpDir)
     )).
 
+test(generated_category_parent_lmdb_handler_executes,
+     [condition((clojure_available, lmdb_helper_toolchain_available))]) :-
+    setup_call_cleanup(
+        ( load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
+          assertz(user:wam_clojure_benchmark_relation_data_mode(category_parent, lmdb))
+        ),
+        once((
+            unique_tmp_dir('tmp_wam_clojure_bench_exec_lmdb', TmpDir),
+            generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, artifact),
+            run_clojure_predicate(TmpDir, 'category_parent/2',
+                                  ['Abstraction', 'Thought'], "true"),
+            run_clojure_predicate(TmpDir, 'category_parent/2',
+                                  ['Abstraction', 'NotAParent'], "false"),
+            run_clojure_predicate(TmpDir, 'category_ancestor/4',
+                                  ['Abstraction', 'Cognition', raw('{:var 1000}'), visited(['Abstraction'])],
+                                  "true"),
+            delete_directory_and_contents(TmpDir)
+        )),
+        maybe_abolish_test_predicate(wam_clojure_benchmark_relation_data_mode/2)
+    ).
+
 :- end_tests(wam_clojure_benchmark_generator).
 
 unique_tmp_dir(Prefix, TmpDir) :-
@@ -255,11 +303,15 @@ unique_tmp_dir(Prefix, TmpDir) :-
     format(atom(TmpDir), '~w_~w', [Prefix, Stamp]).
 
 run_clojure_predicate(ProjectDir, PredKey, Args, Output) :-
-    find_clojure_classpath(ClassPath),
+    project_clojure_classpath(ProjectDir, ClassPath),
+    project_java_library_path_args(ProjectDir, JavaLibArgs),
     maplist(clojure_edn_arg, Args, EdnArgs),
+    append(JavaLibArgs,
+           ['-cp', ClassPath, 'clojure.main', '-m',
+            'generated.wam_clojure_optimized_bench.core', PredKey|EdnArgs],
+           JavaArgs),
     process_create(path(java),
-                   ['-cp', ClassPath, 'clojure.main', '-m',
-                    'generated.wam_clojure_optimized_bench.core', PredKey|EdnArgs],
+                   JavaArgs,
                    [ cwd(ProjectDir),
                      stdout(pipe(Out)),
                      stderr(pipe(Err)),
@@ -299,6 +351,30 @@ visited_list_edn([Atom|Rest], Edn) :-
 
 clojure_available :-
     find_clojure_classpath(_).
+
+lmdb_helper_toolchain_available :-
+    absolute_file_name(path(cargo), _, [access(execute)]),
+    absolute_file_name(path(javac), _, [access(execute)]),
+    absolute_file_name(path(jar), _, [access(execute)]),
+    absolute_file_name(path(gcc), _, [access(execute)]).
+
+project_clojure_classpath(ProjectDir, ClassPath) :-
+    find_clojure_classpath(BaseClassPath),
+    absolute_file_name(ProjectDir, AbsoluteProjectDir),
+    directory_file_path(AbsoluteProjectDir, 'lib/lmdb-artifact-reader.jar', ReaderJarPath),
+    (   exists_file(ReaderJarPath)
+    ->  atomic_list_concat([ReaderJarPath, BaseClassPath], :, ClassPath)
+    ;   ClassPath = BaseClassPath
+    ).
+
+project_java_library_path_args(ProjectDir, Args) :-
+    absolute_file_name(ProjectDir, AbsoluteProjectDir),
+    directory_file_path(AbsoluteProjectDir, 'lib', LibDir),
+    (   exists_directory(LibDir)
+    ->  format(atom(Arg), '-Djava.library.path=~w', [LibDir]),
+        Args = [Arg]
+    ;   Args = []
+    ).
 
 find_clojure_classpath(ClassPath) :-
     findall(Path,


### PR DESCRIPTION
# Summary

This PR adds the first narrow LMDB-backed runtime path to the Clojure hybrid WAM benchmark generator.

It keeps the existing benchmark target names and default data modes stable, but allows `category_parent` to opt into an LMDB-backed exact arg1 lookup path through the existing per-relation benchmark override surface.

# What Changed

- added an opt-in `lmdb` relation mode for Clojure benchmark generation:
  - `wam_clojure_benchmark_relation_data_mode(category_parent, lmdb).`
  - `benchmark_relation_data_mode(category_parent, lmdb).`
- extended the Clojure benchmark generator to:
  - write `category_parent.tsv`
  - build a dupsort LMDB artifact for `category_parent/2`
  - package the JVM helper as `lib/lmdb-artifact-reader.jar`
  - build `lib/liblmdb_artifact_jni.so`
- switched generated Clojure `category_parent/2` and `category_ancestor/4` foreign handlers to use `generated.lmdb.LmdbArtifactReader` when `category_parent` resolves to `lmdb`
- added LMDB-aware runtime launch wiring in the benchmark matrix so generated projects get:
  - the helper jar on the Java classpath
  - the JNI library directory on `java.library.path`
- added focused generator/runtime tests for the LMDB override path
- cleaned up the LMDB artifact builder test import noise
- updated benchmark docs and the WAM perf optimization log

# Why

The existing Clojure target already had:

- sidecar externalization
- grouped artifact mode
- per-relation artifact policy
- shared preprocess metadata
- a reusable JVM LMDB reader seam

The missing step was to use that JVM seam in the actual Clojure benchmark/runtime path. This PR does that conservatively for one hot relation, `category_parent/2`, without replacing the existing EDN or grouped-TSV paths.

# Verification

- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`
- `cargo test` in `examples/lmdb_relation_artifact`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --targets clojure-wam-seeded-artifact,prolog-accumulated --scales dev --repetitions 1`
- manual LMDB-override generated-project benchmark run on `dev`
- `git diff --check`

# Notes

- this is intentionally single-threaded integration work
- the JNI seam copies LMDB rows into owned JVM objects before returning them
- the default benchmark data modes remain unchanged
- LMDB is currently only wired for `category_parent` in the Clojure benchmark path

# Follow-up

- add an explicit benchmark comparison path for grouped TSV vs LMDB on `category_parent`
- evaluate whether `article_category` or other exact relations should gain an LMDB-backed option
- defer any threaded LMDB read design until after broader correctness and measurement work
