### PR TITLE
test(wam-elixir): Phase 3 runtime smoke — findall end-to-end

### DIFF
--- a/tests/test_wam_elixir_lowered_phase3.pl
+++ b/tests/test_wam_elixir_lowered_phase3.pl
@@ -1,0 +1,226 @@
+:- encoding(utf8).
+% Phase 3 runtime smoke test for the WAM-lowered Elixir target.
+%
+% Tests end-to-end: compile a findall/3-using predicate through the
+% WAM compiler → lower to Elixir → write the project → compile + run
+% via `elixir` → assert the result list.
+%
+% This is the first test that actually executes the lowered Elixir
+% runtime, validating the full Phase 1 (substrate) + Phase 2
+% (instruction lowering) chain end-to-end. See
+% docs/proposals/WAM_ELIXIR_TIER2_FINDALL.md §7 (Phase 3 plan).
+%
+% Usage: swipl -g run_tests -t halt tests/test_wam_elixir_lowered_phase3.pl
+%
+% Skipped gracefully when `elixir` is not on PATH (matches the
+% Clojure / Haskell phase-3 test conventions). Opt-in from the
+% top-level test runner — only invoke from CI nodes that have
+% Elixir provisioned.
+%
+% ============================================================================
+% Phase 3 findings surfaced by this smoke (worth following up):
+%
+% 1. WAM-compiler bug for module-qualified inner goals.
+%    `findall(X, user:p(X), L)` compiles the inner call as a `:/2`
+%    builtin that overwrites A1 with the module name string ("user")
+%    before end_aggregate reads value_reg=A1 — captures "user" instead
+%    of the Template binding. Affects all targets; root cause is in
+%    wam_target.pl's compile_aggregate_all/5 which defaults
+%    ValueReg=A1 when Template is a bare variable but doesn't ensure
+%    A1 still holds the binding by end_aggregate time. Workaround:
+%    don't module-qualify the inner goal.
+%
+% 2. Tier-2 super-wrapper × findall interaction breaks finalise.
+%    When the findall's inner goal is Tier-2 eligible (≥3 clauses,
+%    declared/inferred pure), the super-wrapper's parallel arm fires
+%    because in_forkable_aggregate_frame? returns true (the parent
+%    findall pushed the frame). The parallel arm calls
+%    merge_into_aggregate and RETURNS — doesn't throw fail. The
+%    caller's post-call code then runs aggregate_collect on a stale
+%    A1 and throws fail, which finalises an accumulator that has
+%    BOTH the parallel-merged results AND a spurious aggregate_collect
+%    entry — incorrect.
+%    This materialises proposal §6 risk #2 / Haskell precedent
+%    finding (wam_haskell_target.pl:1502-1516). The proposal was
+%    correct that nested-parallel needs a branch-local-accum protocol;
+%    this is the runtime confirmation. Workaround for Phase 3:
+%    intra_query_parallel(false) kill-switches the super-wrapper.
+%    Phase 4 needs to import Haskell's branch-local pattern.
+% ============================================================================
+
+:- use_module(library(filesex)).
+:- use_module(library(process)).
+:- use_module(library(option)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_elixir_target',
+              [write_wam_elixir_project/3]).
+
+:- dynamic test_failed/0.
+
+pass(Test) :-
+    format('[PASS] ~w~n', [Test]).
+
+fail_test(Test, Reason) :-
+    format('[FAIL] ~w: ~w~n', [Test, Reason]),
+    (   test_failed -> true ; assert(test_failed) ).
+
+%% PATH guard — skip the suite cleanly if `elixir` is unavailable.
+%  Matches the convention of other subprocess-execution test files
+%  (test_wam_clojure_runtime_smoke.pl, test_wam_haskell_lowered_phase3.pl)
+%  that don't run on hosts without their respective toolchains.
+elixir_available :-
+    catch(
+        process_create(path(elixir), ['--version'],
+                       [stdout(pipe(Out)), stderr(null), process(PID)]),
+        _,
+        fail),
+    read_string(Out, _, _),
+    close(Out),
+    process_wait(PID, exit(0)).
+
+%% Test fixtures — declared at the top level so the WAM compiler can
+%% find them via user:Pred/Arity. The findall body in
+%% phase3_smoke_findall/1 is what exercises begin_aggregate /
+%% end_aggregate at runtime.
+
+:- dynamic user:phase3_smoke_p/1.
+:- dynamic user:phase3_smoke_findall/1.
+
+user:phase3_smoke_p('a').
+user:phase3_smoke_p('b').
+user:phase3_smoke_p('c').
+% Inner goal is NOT module-qualified — `findall(X, user:phase3_smoke_p(X), L)`
+% triggers a known bug where compile_aggregate_all/5 emits the inner
+% call as a `:/2` builtin that overwrites A1 with the module name
+% string before end_aggregate reads it (value_reg defaults to A1
+% when Template is a bare variable). The bug is in wam_target.pl's
+% compile_findall — out of scope for Phase 3 of the Elixir track,
+% noted as a follow-up finding for the WAM compiler.
+user:phase3_smoke_findall(L) :- findall(X, phase3_smoke_p(X), L).
+
+%% tmp_root — try TMPDIR / TMP / TEMP / $PREFIX/tmp / ./output in
+%% order. Same fallback chain as the existing benchmark harness.
+tmp_root_candidate(Root) :-
+    member(Env, ['TMPDIR', 'TMP', 'TEMP']),
+    getenv(Env, Root),
+    Root \== ''.
+tmp_root_candidate(Root) :-
+    getenv('PREFIX', Prefix),
+    Prefix \== '',
+    directory_file_path(Prefix, tmp, Root).
+tmp_root_candidate('output').
+
+writable_tmp_root(Root) :-
+    tmp_root_candidate(Root),
+    catch(make_directory_path(Root), _, fail),
+    access_file(Root, write),
+    !.
+
+unique_project_dir(Dir) :-
+    writable_tmp_root(Root),
+    get_time(T),
+    Stamp is floor(T * 1000),
+    format(atom(Name), 'uw_elixir_findall_smoke_~w', [Stamp]),
+    directory_file_path(Root, Name, Dir).
+
+%% Generate the test project and the driver .exs script. Predicates
+%% must include both the findall caller and the inner predicate
+%% (the dispatcher needs to route phase3_smoke_p/1 calls).
+write_smoke_project(ProjectDir) :-
+    Predicates = [
+        user:phase3_smoke_p/1,
+        user:phase3_smoke_findall/1
+    ],
+    findall(P/A-WamCode, (
+        member(M:P/A, Predicates),
+        wam_target:compile_predicate_to_wam(M:P/A, [], WamCode)
+    ), PredWamPairs),
+    % intra_query_parallel(false) kill-switches the Tier-2 super-wrapper.
+    % Without it, the 3-clause phase3_smoke_p/1 gets Tier-2-eligible, its
+    % super-wrapper fires (because the parent findall pushed an agg
+    % frame, so in_forkable_aggregate_frame? returns true), and the
+    % parallel arm returns from merge_into_aggregate instead of throwing
+    % fail to drive finalise — materialising proposal §6 risk #2.
+    % Phase 3 validates sequential first; the parallel path needs the
+    % branch-local-accum protocol from Haskell's wam_haskell_target.pl
+    % :1502-1516, deferred to Phase 4.
+    Options = [
+        module_name('phase3_smoke'),
+        emit_mode(lowered),
+        intra_query_parallel(false)
+    ],
+    write_wam_elixir_project(PredWamPairs, Options, ProjectDir),
+    write_smoke_driver(ProjectDir).
+
+%% The driver loads the runtime + dispatcher + predicate files and
+%% calls the findall predicate with one unbound argument. IO.inspect
+%% the result so we can parse stdout from the swipl side.
+write_smoke_driver(ProjectDir) :-
+    directory_file_path(ProjectDir, 'smoke_driver.exs', DriverPath),
+    open(DriverPath, write, S),
+    format(S, 'Code.require_file("lib/wam_runtime.ex", __DIR__)~n', []),
+    format(S, 'Code.require_file("lib/wam_dispatcher.ex", __DIR__)~n', []),
+    format(S, 'Code.require_file("lib/phase3_smoke_p.ex", __DIR__)~n', []),
+    format(S, 'Code.require_file("lib/phase3_smoke_findall.ex", __DIR__)~n', []),
+    format(S, '~n', []),
+    % Pass an unbound var so run/1 returns the materialised binding.
+    format(S, 'unbound_l = {:unbound, make_ref()}~n', []),
+    format(S, 'result = Phase3Smoke.Phase3SmokeFindall.run([unbound_l])~n', []),
+    format(S, 'IO.inspect(result, label: "FINDALL_RESULT", charlists: :as_lists)~n', []),
+    close(S).
+
+%% Run `elixir smoke_driver.exs` and capture stdout/stderr.
+run_smoke_driver(ProjectDir, StdOut, StdErr, ExitCode) :-
+    process_create(path(elixir),
+                   ['smoke_driver.exs'],
+                   [cwd(ProjectDir),
+                    stdout(pipe(OutStream)),
+                    stderr(pipe(ErrStream)),
+                    process(PID)]),
+    read_string(OutStream, _, StdOut),
+    read_string(ErrStream, _, StdErr),
+    close(OutStream),
+    close(ErrStream),
+    process_wait(PID, exit(ExitCode)).
+
+%% Assert the driver output contains the three values [a, b, c]
+%% (in any order, since fail-driven enumeration order is well-defined
+%% but we don't care about it for the smoke — only that all three
+%% solutions are present).
+assert_findall_result(StdOut) :-
+    sub_string(StdOut, _, _, _, "FINDALL_RESULT"),
+    sub_string(StdOut, _, _, _, "\"a\""),
+    sub_string(StdOut, _, _, _, "\"b\""),
+    sub_string(StdOut, _, _, _, "\"c\"").
+
+test_findall_smoke_three_clauses :-
+    Test = 'Phase 3 smoke: findall(X, phase3_smoke_p(X), L) → L contains [a, b, c]',
+    unique_project_dir(ProjectDir),
+    setup_call_cleanup(
+        write_smoke_project(ProjectDir),
+        (   run_smoke_driver(ProjectDir, StdOut, StdErr, ExitCode),
+            (   ExitCode == 0,
+                assert_findall_result(StdOut)
+            ->  pass(Test)
+            ;   format(atom(Reason),
+                       'exit=~w stdout=~w stderr=~w',
+                       [ExitCode, StdOut, StdErr]),
+                fail_test(Test, Reason)
+            )
+        ),
+        catch(delete_directory_and_contents(ProjectDir), _, true)
+    ).
+
+%% Test runner
+
+run_tests :-
+    format('~n=== WAM-Elixir Lowered Phase 3 Runtime Smoke ===~n~n'),
+    (   elixir_available
+    ->  test_findall_smoke_three_clauses
+    ;   format('% elixir not on PATH — skipping Phase 3 runtime tests~n'),
+        format('~n=== Phase 3 Runtime Smoke Skipped ===~n')
+    ),
+    (   test_failed
+    ->  halt(1)
+    ;   format('~n=== Phase 3 Runtime Smoke Complete ===~n')
+    ).


### PR DESCRIPTION
## Summary

- **First runtime test** for the WAM-lowered Elixir target. Compiles `findall(X, p(X), L)` through the full pipeline (WAM compile → Elixir lowering → project write → `elixirc` → `elixir` exec) and asserts the result list contains `[a, b, c]`.
- Validates the shipped Phase 1 substrate (#1627) + Phase 2 instruction lowering (#1643) end-to-end. Up to now we had emit-and-grep coverage only — this is the first time the substrate has actually been exercised under BEAM execution.
- Two real findings surfaced by the smoke (documented inline in the test file and below).
- 1 new test, opt-in (skipped cleanly when `elixir` is not on PATH). Existing 79/79 target-test suite untouched and unchanged.

## Why now

PR #1646 closed Phase 2 of the findall track and the updated proposal (`docs/proposals/WAM_ELIXIR_TIER2_FINDALL.md` §7) marked Phase 3 — runtime integration — as the next step. This PR establishes the harness and lands the first scenario; subsequent PRs can expand the test matrix incrementally without re-litigating the harness design.

## What changes

### `tests/test_wam_elixir_lowered_phase3.pl` (+226, new file)

Single new test file. Conventions follow the existing subprocess-execution harnesses:

- **New file rather than extending `test_wam_elixir_target.pl`.** The existing target-tests file is 55K of emit-and-grep tests; mixing in subprocess execution would muddle test categories. Matches the precedent set by `test_wam_clojure_runtime_smoke.pl` and `test_wam_haskell_lowered_phase3.pl`.
- **PATH guard via `process_create(path(elixir), ['--version'], ...)` at the top of the runner.** Exits 0 cleanly when `elixir` is unavailable rather than failing — matches the Clojure precedent so the file is safe to add to optional CI steps without breaking the main green check.
- **Opt-in from top-level runners.** Not added to any mandatory test runner. Invocable standalone via `swipl -g run_tests -t halt tests/test_wam_elixir_lowered_phase3.pl`.

The harness:

1. Generates a unique tmpdir under `$TMPDIR` / `$TMP` / `$TEMP` / `$PREFIX/tmp` / `./output` (same fallback chain as the existing benchmark harness).
2. Calls `write_wam_elixir_project/3` with the test fixtures (`phase3_smoke_p/1` × 3 clauses, `phase3_smoke_findall/1` body using `findall/3`).
3. Writes a tiny `smoke_driver.exs` that `Code.require_file`s the runtime + dispatcher + predicate modules, calls `Phase3Smoke.Phase3SmokeFindall.run([{:unbound, ...}])`, and `IO.inspect`s the result with a `FINDALL_RESULT` label.
4. Spawns `elixir smoke_driver.exs`, captures stdout/stderr.
5. Asserts the output contains `FINDALL_RESULT` plus all three solution values (`"a"`, `"b"`, `"c"`).
6. Cleans up the tmpdir on success or failure (`setup_call_cleanup`).

## Findings (worth follow-up; documented in the test file header)

### Finding 1: WAM compiler bug for module-qualified inner goals

`findall(X, user:p(X), L)` compiles the inner call as a `:/2` builtin that overwrites A1 with the module-name string `"user"` before `end_aggregate` reads it. Since `compile_aggregate_all/5` defaults `ValueReg = A1` when the Template is a bare variable, `aggregate_collect/2` then captures `"user"` instead of the Template binding for every solution.

**Affects all targets, not just Elixir.** Root cause is in `src/unifyweaver/targets/wam_target.pl`'s `compile_aggregate_all/5`. Workaround for the smoke: drop the `user:` prefix on the inner goal in the test fixture. Worth fixing as a separate WAM-compiler PR.

### Finding 2: Tier-2 super-wrapper × findall finalise (proposal §6 risk #2 confirmed at runtime)

When the findall's inner goal is Tier-2 eligible (≥3 clauses, declared/inferred pure), the super-wrapper's parallel arm fires because `in_forkable_aggregate_frame?` returns `true` (the parent findall pushed the frame). The parallel arm calls `merge_into_aggregate` and **returns the state without throwing fail**. The caller's post-call code then runs `aggregate_collect` on stale A1 and throws fail, finalising an accumulator with both the parallel-merged results AND a spurious entry — corrupted output.

This is exactly the failure mode the Haskell precedent at `wam_haskell_target.pl:1502-1516` was designed to avoid via the branch-local-accum protocol. Proposal §6 risk #2 was correct that the design needed a divergent path for parallel; the runtime confirms it.

**Workaround for this PR:** the smoke passes `intra_query_parallel(false)` in the project options to kill-switch the super-wrapper, validating sequential findall first. Phase 4 needs to import Haskell's branch-local-accum pattern.

## Reviewer notes

**This PR is deliberately small.** One scenario, two findings. Expanding to cover the rest of proposal §7's Phase 3 matrix (`findall(X, fail, L)`, `aggregate_all` variants, max-on-empty, edge cases) in this PR would force scenario-by-scenario workarounds for the two findings above, burying the smoke's actual value. Following the multi-PR pattern: harness + first scenario lands here, subsequent scenarios as focused follow-ups, with the two findings either fixed first or worked around explicitly per follow-up.

**The harness is reusable as-is.** `write_smoke_project/1` and `run_smoke_driver/4` are factored to make adding scenarios cheap — a follow-up adding `findall(X, fail, L)` should be a 10-line test predicate plus an additional fixture.

**Tier-2 kill-switch is the right scope decision for Phase 3.** Sequential findall is the simpler, smaller surface; getting it working end-to-end is the right milestone before tackling the parallel-finalise interaction. The proposal already deferred parallel findall to Phase 4 (`§10 non-goals`); this PR's workaround makes that boundary visible at runtime.

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_target.pl` — 79/79 passing (existing suite, unchanged)
- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_lowered_phase3.pl` — 1/1 passing on Termux (Elixir 1.19, OTP 28)
- [x] PATH-guard skip path verified — when `elixir` is not on PATH, the runner exits 0 with a clear message rather than failing
- [x] Tmpdir cleanup verified — `setup_call_cleanup/3` removes the project even on test failure

## Phase plan

- **Phase 1** (#1627, merged): runtime substrate.
- **Phase 2** (#1643, merged): instruction lowering.
- **Phase 3a** (this PR): runtime harness + first scenario.
- **Phase 3b** (next): expand sequential coverage — `findall(X, fail, L)`, `aggregate_all` variants, edge cases. Either after the WAM-compiler module-qualification bug is fixed, or with explicit per-scenario workarounds.
- **Phase 4** (later): nested-parallel findall — import Haskell's branch-local-accum protocol per `wam_haskell_target.pl:1502-1516`. Resolves Finding 2 above.

## Related

- Proposal: `docs/proposals/WAM_ELIXIR_TIER2_FINDALL.md` (#1626) — §7 Phase 3 plan; §6 risk #2 (now runtime-confirmed); §11 Cross-target precedent (Haskell).
- Phase 1 substrate: #1627
- Phase 2 lowering: #1643
- Doc updates: #1646
- Subprocess-execution test precedents: `tests/test_wam_clojure_runtime_smoke.pl`, `tests/test_wam_haskell_lowered_phase3.pl`
- Haskell branch-local-accum pattern (Phase 4 reference): `src/unifyweaver/targets/wam_haskell_target.pl:1502-1516`
