### PR TITLE
feat(wam-clojure): add LMDB L1 memoization

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -648,3 +648,36 @@ Follow-up design work for the next Clojure LMDB phases now lives in
 captures the Clojure-specific philosophy, specification, and
 implementation sequencing, and explicitly references the recent Haskell
 LMDB cache and reader commits that should guide the next Clojure steps.
+
+The first implementation step from that plan is now in place too. The
+JVM helper behind the Clojure LMDB benchmark path no longer opens LMDB
+from scratch on every lookup. `LmdbArtifactReader` now fronts a
+thread-local native store seam:
+
+- one LMDB read transaction per thread
+- one dupsort cursor per thread
+- owned `LmdbRow` objects still cross the JNI boundary
+- generated Clojure code keeps the same call surface
+
+This matches the spirit of the recent Haskell progression:
+
+- split raw reader mechanics from wrapper policy first
+- add thread-local reader reuse next
+- keep memoization as a separate later layer
+
+That later layer is now in place too, but still narrowly. The Clojure
+benchmark generator now accepts an opt-in relation-local cache policy
+for LMDB-backed `category_parent`:
+
+- `wam_clojure_benchmark_relation_cache_policy(category_parent, memoize)`
+- `benchmark_relation_cache_policy(category_parent, memoize)`
+
+When selected, generated Clojure projects keep the same `lmdb` storage
+mode and reader seam, but switch to `LmdbArtifactReader.openMemoized`.
+The memoization layer is thread-local and lives in the Java wrapper,
+not in the native store object:
+
+- one native store per thread still owns the LMDB transaction/cursor
+- one thread-local L1 map caches `lookupArg1` results by key
+- scan behavior is unchanged
+- shared L2 caching is still deferred

--- a/docs/proposals/WAM_CLOJURE_LMDB_FACT_ACCESS_PLAN.md
+++ b/docs/proposals/WAM_CLOJURE_LMDB_FACT_ACCESS_PLAN.md
@@ -67,12 +67,20 @@ What is implemented today:
   handlers can consume `generated.lmdb.LmdbArtifactReader`
 - the benchmark launcher can place the helper jar on the Java classpath
   and the JNI library directory on `java.library.path`
+- the JVM helper now keeps one native LMDB store per thread through a
+  thread-local seam, so repeated lookups on the same thread reuse the
+  same read transaction / cursor state instead of reopening LMDB on
+  every lookup
+- an optional relation-local cache policy may now enable thread-local L1
+  memoization for `category_parent` lookup overlap:
+  - `wam_clojure_benchmark_relation_cache_policy(category_parent, memoize)`
+  - `benchmark_relation_cache_policy(category_parent, memoize)`
 
 This is intentionally narrow:
 
 - only `category_parent` uses LMDB today
 - the existing EDN and grouped-TSV paths remain the stable defaults
-- there is no reader pooling, L1 cache, or shared cache policy yet
+- there is no shared L2 cache policy yet
 
 ## Specification
 
@@ -159,38 +167,35 @@ cursor state is the safe unit of reuse.
 
 ### Phase C1: Documentation and seam cleanup
 
-Status: **partly done**
+Status: **done**
 
 Done already:
 
 - shared artifact metadata seam exists
 - JVM LMDB row API exists
 - Clojure benchmark generator can consume LMDB for `category_parent`
-
-Next:
-
-1. add a dedicated JVM-side reader reuse abstraction instead of using
-   direct `LmdbArtifactReader/open` calls inline in generated Clojure
-2. describe that seam in the Clojure docs and in the artifact metadata
-   guidance
+- dedicated JVM-side reader seam is documented
+- generated projects package the helper jar and native library locally
 
 ### Phase C2: Thread-local reader reuse
 
-Status: **not started**
+Status: **done**
 
 Goal:
 
 - avoid repeated open/setup cost on hot lookup paths
 
-Implementation shape:
+Implemented shape:
 
-1. introduce a JVM helper that maintains thread-local reader state
-2. keep one read txn / cursor pair per thread
-3. expose the same logical API:
+1. `LmdbArtifactReader` now fronts a thread-local native store seam
+2. each thread owns its own LMDB read transaction / dupsort cursor
+   state
+3. the logical API stayed stable:
    - `lookupArg1`
    - `scan`
-4. switch generated Clojure `category_parent/2` and
-   `category_ancestor/4` handlers to that helper
+4. generated Clojure `category_parent/2` and `category_ancestor/4`
+   handlers still call the same reader API, but now benefit from
+   thread-local reuse underneath it
 
 Validation:
 
@@ -198,9 +203,14 @@ Validation:
 - generated-project predicate execution tests
 - no-argument benchmark digest parity
 
+Remaining gap:
+
+- the reader seam is still embedded in the JVM helper package rather
+  than exposed as a more explicit “reader pool” type
+
 ### Phase C3: Optional L1 memoization
 
-Status: **not started**
+Status: **done**
 
 Goal:
 
@@ -213,10 +223,21 @@ Important constraint:
 
 Implementation shape:
 
-1. add an explicit no-cache vs L1 policy choice
-2. prefer thread-local / per-thread memoization first
-3. keep policy local to `category_parent`
-4. benchmark overlap-heavy vs low-overlap workloads separately
+Implemented shape:
+
+1. `category_parent` now supports an explicit relation-local cache
+   policy choice while staying on the same `lmdb` storage mode
+2. the first policy is `memoize`, implemented as thread-local `arg1`
+   memoization in `LmdbArtifactReader`
+3. memoization remains outside `LmdbArtifactStore`, so raw native reader
+   lifecycle is still separate from cache behavior
+4. generated foreign handlers and the benchmark runner select
+   `openMemoized` only when the cache-policy override is present
+
+Current default:
+
+- no cache policy override means `none`
+- LMDB storage mode still works without L1 enabled
 
 Reference:
 
@@ -254,10 +275,10 @@ Possible future work:
 
 The next Clojure LMDB work should be:
 
-1. a cleaner reader seam
-2. thread-local reader reuse
-3. optional L1 memoization only after that
-4. shared caches later
+1. tighten the explicit JVM-side reader abstraction around the now
+   working thread-local native-store seam
+2. optional L1 memoization only after that
+3. shared caches later
 
 That is the clearest lesson from the recent Haskell commits, and it is
 the safest way to improve the current Clojure target without mixing up

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -201,6 +201,18 @@ This keeps the public benchmark target names stable while letting a
 workload compare grouped TSV against LMDB-backed exact arg1 lookups for
 the hottest traversal relation.
 
+LMDB-backed `category_parent` also supports an optional relation-local
+cache policy override:
+
+- `wam_clojure_benchmark_relation_cache_policy(category_parent, memoize).`
+- `benchmark_relation_cache_policy(category_parent, memoize).`
+
+This does not change the storage mode. It keeps `category_parent` on the
+LMDB path, but switches the packaged JVM helper from plain thread-local
+reader reuse to a thread-local L1 `arg1` memoization layer on top of the
+same native store seam. Leaving the predicate unset preserves the
+default `none` policy.
+
 The generator also now honors the shared predicate-preprocessing
 declaration surface from
 `src/unifyweaver/core/predicate_preprocessing.pl`. For the current

--- a/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
@@ -21,6 +21,10 @@
 :- use_module(library(process), [process_create/3, process_wait/2]).
 :- discontiguous benchmark_article_category_by_article_artifact/1.
 :- discontiguous benchmark_category_parent_by_child_artifact/1.
+:- discontiguous category_parent_handler_code/3.
+:- discontiguous category_parent_handler_code/4.
+:- discontiguous category_ancestor_handler_code/3.
+:- discontiguous category_ancestor_handler_code/4.
 
 %% generate_wam_clojure_optimized_benchmark.pl
 %%
@@ -194,8 +198,9 @@ parse_kernel_mode(OutputDir, VariantAtom, kernels_on, DataMode, [
     ])
 ]) :-
     benchmark_effective_data_modes(VariantAtom, DataMode, _ArticleMode, ParentMode),
-    category_parent_handler_code(OutputDir, ParentMode, ParentHandlerCode),
-    category_ancestor_handler_code(OutputDir, ParentMode, AncestorHandlerCode).
+    benchmark_relation_cache_policy(category_parent, ParentMode, ParentCachePolicy),
+    category_parent_handler_code(OutputDir, ParentMode, ParentCachePolicy, ParentHandlerCode),
+    category_ancestor_handler_code(OutputDir, ParentMode, ParentCachePolicy, AncestorHandlerCode).
 parse_kernel_mode(_OutputDir, _VariantAtom, kernels_off, _DataMode, [
     no_kernels(true)
 ]).
@@ -236,6 +241,26 @@ benchmark_relation_declared_data_mode(Relation, Mode) :-
     memberchk(DeclaredMode, [auto, sidecar, artifact, inline, lmdb]),
     Mode = DeclaredMode.
 
+benchmark_relation_declared_cache_policy(Relation, Policy) :-
+    member(Name,
+           [ wam_clojure_benchmark_relation_cache_policy,
+             benchmark_relation_cache_policy
+           ]),
+    current_predicate(user:Name/2),
+    Goal =.. [Name, Relation, DeclaredPolicy],
+    once(call(user:Goal)),
+    memberchk(DeclaredPolicy, [none, memoize]),
+    Policy = DeclaredPolicy.
+
+benchmark_relation_cache_policy(_Relation, Mode, none) :-
+    Mode \== lmdb,
+    !.
+benchmark_relation_cache_policy(Relation, _Mode, Policy) :-
+    (   benchmark_relation_declared_cache_policy(Relation, DeclaredPolicy)
+    ->  Policy = DeclaredPolicy
+    ;   Policy = none
+    ).
+
 benchmark_fact_volume(RowCount) :-
     benchmark_fact_count(user:category_parent/2, ParentCount),
     benchmark_fact_count(user:article_category/2, ArticleCount),
@@ -251,6 +276,12 @@ category_parent_handler_code(HandlerCode) :-
     parse_benchmark_data_mode(auto, DataMode),
     category_parent_handler_code(DataMode, HandlerCode).
 
+category_parent_handler_code(OutputDir, sidecar, _CachePolicy, HandlerCode) :-
+    category_parent_handler_code(OutputDir, sidecar, HandlerCode).
+category_parent_handler_code(OutputDir, artifact, _CachePolicy, HandlerCode) :-
+    category_parent_handler_code(OutputDir, artifact, HandlerCode).
+category_parent_handler_code(OutputDir, inline, _CachePolicy, HandlerCode) :-
+    category_parent_handler_code(OutputDir, inline, HandlerCode).
 category_parent_handler_code(OutputDir, sidecar, HandlerCode) :-
     benchmark_sidecar_file_path_literal(OutputDir, 'category_parent.edn', CategoryParentPath),
     format(string(HandlerCode),
@@ -261,11 +292,12 @@ category_parent_handler_code(OutputDir, artifact, HandlerCode) :-
     format(string(HandlerCode),
            "(let [parents-by-child-delay (delay (into {} (keep (fn [line] (when-not (.isEmpty ^String line) (let [parts (vec (.split ^String line \"\\\\t\")) child (first parts) parents (subvec parts 1)] [child parents]))) (.split ^String (slurp ~w) \"\\\\r?\\\\n\"))))] (fn [args] (let [child (nth args 0) parent (nth args 1)] (boolean (some #(= parent %) (get @parents-by-child-delay child []))))))",
            [CategoryParentMapPath]).
-category_parent_handler_code(OutputDir, lmdb, HandlerCode) :-
+category_parent_handler_code(OutputDir, lmdb, CachePolicy, HandlerCode) :-
     benchmark_sidecar_subdir_literal(OutputDir, 'category_parent_lmdb', ArtifactDirPath),
+    lmdb_reader_open_expr(ArtifactDirPath, CachePolicy, ReaderOpenExpr),
     format(string(HandlerCode),
-           "(let [reader-delay (delay (generated.lmdb.LmdbArtifactReader/open (java.nio.file.Paths/get ~w (make-array String 0))))] (fn [args] (let [child (nth args 0) parent (nth args 1) rows (.lookupArg1 ^generated.lmdb.LmdbArtifactReader @reader-delay child)] (boolean (some (fn [^generated.lmdb.LmdbRow row] (= parent (.value row))) rows)))))",
-           [ArtifactDirPath]).
+           "(let [reader-delay (delay ~w)] (fn [args] (let [child (nth args 0) parent (nth args 1) rows (.lookupArg1 ^generated.lmdb.LmdbArtifactReader @reader-delay child)] (boolean (some (fn [^generated.lmdb.LmdbRow row] (= parent (.value row))) rows)))))",
+           [ReaderOpenExpr]).
 category_parent_handler_code(_OutputDir, inline, HandlerCode) :-
     category_parent_handler_code(inline, HandlerCode).
 category_parent_handler_code(sidecar, HandlerCode) :-
@@ -287,10 +319,25 @@ category_parent_handler_code(inline, HandlerCode) :-
            "(let [edges #{~s}] (fn [args] (contains? edges [(nth args 0) (nth args 1)])))",
            [Edges]).
 
+lmdb_reader_open_expr(ArtifactDirPath, memoize, Expr) :-
+    format(string(Expr),
+           "(generated.lmdb.LmdbArtifactReader/openMemoized (java.nio.file.Paths/get ~w (make-array String 0)))",
+           [ArtifactDirPath]).
+lmdb_reader_open_expr(ArtifactDirPath, none, Expr) :-
+    format(string(Expr),
+           "(generated.lmdb.LmdbArtifactReader/open (java.nio.file.Paths/get ~w (make-array String 0)))",
+           [ArtifactDirPath]).
+
 category_ancestor_handler_code(HandlerCode) :-
     parse_benchmark_data_mode(auto, DataMode),
     category_ancestor_handler_code(DataMode, HandlerCode).
 
+category_ancestor_handler_code(OutputDir, sidecar, _CachePolicy, HandlerCode) :-
+    category_ancestor_handler_code(OutputDir, sidecar, HandlerCode).
+category_ancestor_handler_code(OutputDir, artifact, _CachePolicy, HandlerCode) :-
+    category_ancestor_handler_code(OutputDir, artifact, HandlerCode).
+category_ancestor_handler_code(OutputDir, inline, _CachePolicy, HandlerCode) :-
+    category_ancestor_handler_code(OutputDir, inline, HandlerCode).
 category_ancestor_handler_code(OutputDir, sidecar, HandlerCode) :-
     benchmark_max_depth_literal(MaxDepth),
     benchmark_sidecar_file_path_literal(OutputDir, 'category_parent.edn', CategoryParentPath),
@@ -303,12 +350,13 @@ category_ancestor_handler_code(OutputDir, artifact, HandlerCode) :-
     format(string(HandlerCode),
            "(let [parents-by-child-delay (delay (into {} (keep (fn [line] (when-not (.isEmpty ^String line) (let [parts (vec (.split ^String line \"\\\\t\")) child (first parts) parents (subvec parts 1)] [child parents]))) (.split ^String (slurp ~w) \"\\\\r?\\\\n\")))) max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (get @parents-by-child-delay category [])] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] {:solutions (vec solutions)})))",
            [CategoryParentMapPath, MaxDepth]).
-category_ancestor_handler_code(OutputDir, lmdb, HandlerCode) :-
+category_ancestor_handler_code(OutputDir, lmdb, CachePolicy, HandlerCode) :-
     benchmark_max_depth_literal(MaxDepth),
     benchmark_sidecar_subdir_literal(OutputDir, 'category_parent_lmdb', ArtifactDirPath),
+    lmdb_reader_open_expr(ArtifactDirPath, CachePolicy, ReaderOpenExpr),
     format(string(HandlerCode),
-           "(let [reader-delay (delay (generated.lmdb.LmdbArtifactReader/open (java.nio.file.Paths/get ~w (make-array String 0)))) max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) parent-values (fn [category] (mapv (fn [^generated.lmdb.LmdbRow row] (.value row)) (.lookupArg1 ^generated.lmdb.LmdbArtifactReader @reader-delay category))) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (parent-values category)] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] {:solutions (vec solutions)})))",
-           [ArtifactDirPath, MaxDepth]).
+           "(let [reader-delay (delay ~w) max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) parent-values (fn [category] (mapv (fn [^generated.lmdb.LmdbRow row] (.value row)) (.lookupArg1 ^generated.lmdb.LmdbArtifactReader @reader-delay category))) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (parent-values category)] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] {:solutions (vec solutions)})))",
+           [ReaderOpenExpr, MaxDepth]).
 category_ancestor_handler_code(_OutputDir, inline, HandlerCode) :-
     category_ancestor_handler_code(inline, HandlerCode).
 category_ancestor_handler_code(sidecar, HandlerCode) :-
@@ -382,8 +430,9 @@ effective_distance_runner_code(OutputDir, VariantAtom, KernelModeAtom, DataMode,
     benchmark_use_traversal_kernel_literal(KernelModeAtom, UseTraversalKernel),
     benchmark_sidecar_dir_literal(OutputDir, DataDirLiteral),
     benchmark_effective_data_modes(VariantAtom, DataMode, ArticleMode, ParentMode),
+    benchmark_relation_cache_policy(category_parent, ParentMode, ParentCachePolicy),
     benchmark_article_categories_code(ArticleMode, DataDirLiteral, BenchmarkData, ArticleCategoriesCode),
-    benchmark_category_parents_code(ParentMode, DataDirLiteral, BenchmarkData, CategoryParentsCode),
+    benchmark_category_parents_code(ParentMode, ParentCachePolicy, DataDirLiteral, BenchmarkData, CategoryParentsCode),
     benchmark_roots_code(DataMode, DataDirLiteral, BenchmarkData, RootsCode),
     benchmark_derived_state_code(ArticleMode, ParentMode, DerivedStateCode),
     format(string(Code),
@@ -553,10 +602,10 @@ benchmark_article_categories_code(inline, _DataDirLiteral, benchmark_data(Articl
            "(def benchmark-article-categories-delay (delay [~s]))",
            [ArticleCategories]).
 
-benchmark_category_parents_code(sidecar, _DataDirLiteral, _BenchmarkData, Code) :-
+benchmark_category_parents_code(sidecar, _ParentCachePolicy, _DataDirLiteral, _BenchmarkData, Code) :-
     Code = '(def benchmark-category-parents-delay
   (delay (vec (edn/read-string (slurp (str benchmark-data-dir "/category_parent.edn"))))))'.
-benchmark_category_parents_code(artifact, _DataDirLiteral, _BenchmarkData, Code) :-
+benchmark_category_parents_code(artifact, _ParentCachePolicy, _DataDirLiteral, _BenchmarkData, Code) :-
     Code = '(def benchmark-parents-by-child-delay
   (delay
     (into {}
@@ -567,21 +616,26 @@ benchmark_category_parents_code(artifact, _DataDirLiteral, _BenchmarkData, Code)
                       parents (subvec parts 1)]
                   [child parents]))))
       (.split ^String (slurp (str benchmark-data-dir "/category_parent_by_child.tsv")) "\\r?\\n"))))'.
-benchmark_category_parents_code(lmdb, _DataDirLiteral, _BenchmarkData, Code) :-
-    Code = '(def benchmark-parents-by-child-delay
-  (delay
-    (let [reader (generated.lmdb.LmdbArtifactReader/open
-                   (java.nio.file.Paths/get
-                     (str benchmark-data-dir "/category_parent_lmdb")
-                     (make-array String 0)))]
-      (reduce (fn [acc ^generated.lmdb.LmdbRow row]
-                (update acc (.key row) (fnil conj []) (.value row)))
-              {}
-              (.scan ^generated.lmdb.LmdbArtifactReader reader)))))'.
-benchmark_category_parents_code(inline, _DataDirLiteral, benchmark_data(_, CategoryParents, _, _, _, _, _, _), Code) :-
+benchmark_category_parents_code(lmdb, CachePolicy, _DataDirLiteral, _BenchmarkData, Code) :-
+    lmdb_reader_open_expr_runtime(CachePolicy, ReaderOpenExpr),
+    format(string(Code),
+           "(def benchmark-parents-by-child-delay\n  (delay\n    (let [reader ~w]\n      (reduce (fn [acc ^generated.lmdb.LmdbRow row]\n                (update acc (.key row) (fnil conj []) (.value row)))\n              {}\n              (.scan ^generated.lmdb.LmdbArtifactReader reader)))))",
+           [ReaderOpenExpr]).
+benchmark_category_parents_code(inline, _ParentCachePolicy, _DataDirLiteral, benchmark_data(_, CategoryParents, _, _, _, _, _, _), Code) :-
     format(string(Code),
            "(def benchmark-category-parents-delay (delay [~s]))",
            [CategoryParents]).
+
+lmdb_reader_open_expr_runtime(memoize, Expr) :-
+    Expr = '(generated.lmdb.LmdbArtifactReader/openMemoized
+                   (java.nio.file.Paths/get
+                     (str benchmark-data-dir "/category_parent_lmdb")
+                     (make-array String 0)))'.
+lmdb_reader_open_expr_runtime(none, Expr) :-
+    Expr = '(generated.lmdb.LmdbArtifactReader/open
+                   (java.nio.file.Paths/get
+                     (str benchmark-data-dir "/category_parent_lmdb")
+                     (make-array String 0)))'.
 
 benchmark_roots_code(sidecar, _DataDirLiteral, _BenchmarkData, Code) :-
     Code = '(def benchmark-roots-delay
@@ -653,6 +707,7 @@ write_benchmark_sidecar_content(DataDir, FileName, Content) :-
 
 benchmark_artifact_manifest(FactsPath, VariantAtom, KernelModeAtom, DataMode, Manifest) :-
     benchmark_effective_data_modes(VariantAtom, DataMode, ArticleMode, ParentMode),
+    benchmark_relation_cache_policy(category_parent, ParentMode, ParentCachePolicy),
     benchmark_fact_count(user:article_category/2, ArticleRows),
     benchmark_fact_count(user:category_parent/2, ParentRows),
     benchmark_fact_count(user:root_category/1, RootRows),
@@ -660,9 +715,9 @@ benchmark_artifact_manifest(FactsPath, VariantAtom, KernelModeAtom, DataMode, Ma
     clj_string_literal_local(VariantAtom, VariantLit),
     clj_string_literal_local(KernelModeAtom, KernelModeLit),
     clj_string_literal_local(DataMode, DataModeLit),
-    relation_manifest_entry(article_category, ArticleMode, ArticleRows, ArticleEntry),
-    relation_manifest_entry(category_parent, ParentMode, ParentRows, ParentEntry),
-    relation_manifest_entry(root_category, sidecar, RootRows, RootEntry),
+    relation_manifest_entry(article_category, ArticleMode, none, ArticleRows, ArticleEntry),
+    relation_manifest_entry(category_parent, ParentMode, ParentCachePolicy, ParentRows, ParentEntry),
+    relation_manifest_entry(root_category, sidecar, none, RootRows, RootEntry),
     format(atom(Manifest),
 '{:format "unifyweaver.clojure_benchmark_artifacts.v1"
  :exactness :exact
@@ -676,7 +731,7 @@ benchmark_artifact_manifest(FactsPath, VariantAtom, KernelModeAtom, DataMode, Ma
            [FactsPathLit, VariantLit, KernelModeLit, DataModeLit,
             ArticleEntry, ParentEntry, RootEntry]).
 
-relation_manifest_entry(Relation, Mode, RowCount, Entry) :-
+relation_manifest_entry(Relation, Mode, CachePolicy, RowCount, Entry) :-
     relation_manifest_shape(Relation, Mode, FileName, Format, Access),
     relation_manifest_preprocess_decl(Relation, DeclDecl),
     clj_string_literal_local(Relation, RelationLit),
@@ -685,9 +740,10 @@ relation_manifest_entry(Relation, Mode, RowCount, Entry) :-
     clj_string_literal_local(Format, FormatLit),
     clj_string_literal_local(Access, AccessLit),
     preprocess_decl_field(DeclDecl, DeclField),
+    cache_policy_field(CachePolicy, CacheField),
     format(atom(Entry),
-           '~w {:mode ~w :file ~w :format ~w :row_count ~w :access ~w~w}',
-           [RelationLit, ModeLit, FileNameLit, FormatLit, RowCount, AccessLit, DeclField]).
+           '~w {:mode ~w :file ~w :format ~w :row_count ~w :access ~w~w~w}',
+           [RelationLit, ModeLit, FileNameLit, FormatLit, RowCount, AccessLit, DeclField, CacheField]).
 
 relation_manifest_preprocess_decl(Relation, Decl) :-
     benchmark_relation_predicate(Relation, PredIndicator),
@@ -709,6 +765,11 @@ preprocess_decl_field(preprocess_decl(Mode, Kind, Options, Metadata), Field) :-
     format(atom(Field),
            ' :declaration {:source ~w :mode ~w :kind ~w :format ~w :access_contracts ~w :options ~w}',
            [SourceLit, ModeLit, KindLit, FormatLit, AccessLit, OptionsLit]).
+
+cache_policy_field(none, '').
+cache_policy_field(CachePolicy, Field) :-
+    clj_string_literal_local(CachePolicy, CacheLit),
+    format(atom(Field), ' :cache_policy ~w', [CacheLit]).
 
 metadata_format_literal(Metadata, Literal) :-
     clj_string_literal_local(Metadata.format, Literal).
@@ -1020,6 +1081,7 @@ lmdb_helper_java_sources(JavaSources) :-
     maplist(lmdb_helper_java_source_path,
             [ 'LmdbRow.java',
               'LmdbArtifactManifest.java',
+              'LmdbArtifactStore.java',
               'LmdbArtifactReader.java',
               'LmdbArtifactJNI.java'
             ],

--- a/examples/scala_lmdb_jni_probe/README.md
+++ b/examples/scala_lmdb_jni_probe/README.md
@@ -11,6 +11,7 @@ It is intentionally isolated from the current Haskell and Elixir target paths, b
 - exposes a small reusable JVM-side API:
   - `LmdbArtifactManifest`
   - `LmdbArtifactReader`
+  - `LmdbArtifactStore`
   - `LmdbRow`
 - uses JNI-backed C code to:
   - open the named LMDB DB from the manifest
@@ -24,6 +25,7 @@ It is intentionally isolated from the current Haskell and Elixir target paths, b
 - `src/main/java/generated/lmdb/LmdbArtifactJNI.java`
 - `src/main/java/generated/lmdb/LmdbArtifactManifest.java`
 - `src/main/java/generated/lmdb/LmdbArtifactReader.java`
+- `src/main/java/generated/lmdb/LmdbArtifactStore.java`
 - `src/main/java/generated/lmdb/LmdbRow.java`
 - `src/main/scala/generated/lmdb/LmdbArtifactProbe.scala`
 - `src/main/clojure/generated/lmdb/clojure_probe.clj`
@@ -53,5 +55,10 @@ clojure_lmdb_jni_probe_ok lookup=a	1,a	2 scan_count=3 db=edge/2
   - `gcc`
   - installed `liblmdb`
 - manifest parsing and reader ownership are kept in Java so JVM languages like Clojure or a future Scala hybrid WAM can reuse the same seam
+- the reader now reuses one native LMDB store per JVM thread via a
+  thread-local seam instead of reopening LMDB on every lookup
+- the reader also exposes an optional `openMemoized(...)` constructor
+  that adds a thread-local `arg1` memoization layer above the native
+  store seam
 - LMDB access itself is done through JNI against the native `liblmdb`
 - this is still a probe, not yet a generated target integration

--- a/examples/scala_lmdb_jni_probe/native/lmdb_artifact_jni.c
+++ b/examples/scala_lmdb_jni_probe/native/lmdb_artifact_jni.c
@@ -4,6 +4,8 @@
 
 #include <stdbool.h>
 #include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -11,6 +13,13 @@ typedef struct {
     char *key;
     char *value;
 } row_buf;
+
+typedef struct {
+    MDB_env *env;
+    MDB_txn *txn;
+    MDB_dbi dbi;
+    MDB_cursor *cursor;
+} store_handle;
 
 static char *dup_bytes(const char *src, size_t len) {
     char *dst = (char *)malloc(len + 1);
@@ -31,6 +40,13 @@ static void free_rows(row_buf *rows, size_t count) {
         free(rows[i].value);
     }
     free(rows);
+}
+
+static void throw_runtime_exception(JNIEnv *env, const char *message) {
+    jclass ex_cls = (*env)->FindClass(env, "java/lang/RuntimeException");
+    if (ex_cls != NULL) {
+        (*env)->ThrowNew(env, ex_cls, message);
+    }
 }
 
 static int append_row(row_buf **rows, size_t *count, size_t *cap, const char *key, size_t key_len, const char *value, size_t value_len) {
@@ -104,6 +120,17 @@ static void close_store(MDB_env *env, MDB_txn *txn) {
     }
 }
 
+static void close_store_handle(store_handle *handle) {
+    if (handle == NULL) {
+        return;
+    }
+    if (handle->cursor != NULL) {
+        mdb_cursor_close(handle->cursor);
+    }
+    close_store(handle->env, handle->txn);
+    free(handle);
+}
+
 static jobjectArray rows_to_java(JNIEnv *env, row_buf *rows, size_t count) {
     jclass row_cls = (*env)->FindClass(env, "generated/lmdb/LmdbRow");
     if (row_cls == NULL) {
@@ -135,6 +162,172 @@ static jobjectArray rows_to_java(JNIEnv *env, row_buf *rows, size_t count) {
         (*env)->DeleteLocalRef(env, value);
     }
 
+    return result;
+}
+
+static int append_lookup_rows_for_cursor(MDB_cursor *cursor, const char *key, row_buf **rows, size_t *count, size_t *cap) {
+    MDB_val mdb_key;
+    MDB_val mdb_val;
+    mdb_key.mv_size = strlen(key);
+    mdb_key.mv_data = (void *)key;
+
+    int rc = mdb_cursor_get(cursor, &mdb_key, &mdb_val, MDB_SET);
+    while (rc == MDB_SUCCESS) {
+        rc = append_row(rows, count, cap,
+                        key, strlen(key),
+                        (const char *)mdb_val.mv_data, mdb_val.mv_size);
+        if (rc != MDB_SUCCESS) {
+            return rc;
+        }
+        rc = mdb_cursor_get(cursor, &mdb_key, &mdb_val, MDB_NEXT_DUP);
+    }
+    return (rc == MDB_NOTFOUND) ? MDB_SUCCESS : rc;
+}
+
+JNIEXPORT jlong JNICALL
+Java_generated_lmdb_LmdbArtifactJNI_openStore(JNIEnv *env, jclass cls, jstring artifact_dir_j, jstring db_name_j, jboolean dupsort_j) {
+    (void)cls;
+    (void)dupsort_j;
+    const char *artifact_dir = (*env)->GetStringUTFChars(env, artifact_dir_j, NULL);
+    const char *db_name = (*env)->GetStringUTFChars(env, db_name_j, NULL);
+
+    MDB_env *mdb_env = NULL;
+    MDB_txn *txn = NULL;
+    MDB_dbi dbi = 0;
+    int rc = open_store(artifact_dir, db_name, &mdb_env, &txn, &dbi);
+    if (rc != MDB_SUCCESS) {
+        char message[256];
+        snprintf(message, sizeof(message), "LMDB openStore failed: %s", mdb_strerror(rc));
+        throw_runtime_exception(env, message);
+        (*env)->ReleaseStringUTFChars(env, artifact_dir_j, artifact_dir);
+        (*env)->ReleaseStringUTFChars(env, db_name_j, db_name);
+        return 0L;
+    }
+
+    store_handle *handle = (store_handle *)calloc(1, sizeof(store_handle));
+    if (handle == NULL) {
+        throw_runtime_exception(env, "LMDB openStore failed: out of memory");
+        close_store(mdb_env, txn);
+        (*env)->ReleaseStringUTFChars(env, artifact_dir_j, artifact_dir);
+        (*env)->ReleaseStringUTFChars(env, db_name_j, db_name);
+        return 0L;
+    }
+    handle->env = mdb_env;
+    handle->txn = txn;
+    handle->dbi = dbi;
+    handle->cursor = NULL;
+
+    (*env)->ReleaseStringUTFChars(env, artifact_dir_j, artifact_dir);
+    (*env)->ReleaseStringUTFChars(env, db_name_j, db_name);
+    return (jlong)(intptr_t)handle;
+}
+
+JNIEXPORT void JNICALL
+Java_generated_lmdb_LmdbArtifactJNI_closeStore(JNIEnv *env, jclass cls, jlong handle_j) {
+    (void)env;
+    (void)cls;
+    store_handle *handle = (store_handle *)(intptr_t)handle_j;
+    close_store_handle(handle);
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_generated_lmdb_LmdbArtifactJNI_lookupRowsForHandle(JNIEnv *env, jclass cls, jlong handle_j, jstring key_j, jboolean dupsort_j) {
+    (void)cls;
+    bool dupsort = dupsort_j == JNI_TRUE;
+    store_handle *handle = (store_handle *)(intptr_t)handle_j;
+    if (handle == NULL) {
+        throw_runtime_exception(env, "LMDB lookupRowsForHandle failed: null handle");
+        return NULL;
+    }
+
+    const char *key = (*env)->GetStringUTFChars(env, key_j, NULL);
+    row_buf *rows = NULL;
+    size_t count = 0;
+    size_t cap = 0;
+    int rc = MDB_SUCCESS;
+
+    if (dupsort) {
+        if (handle->cursor == NULL) {
+            rc = mdb_cursor_open(handle->txn, handle->dbi, &handle->cursor);
+        }
+        if (rc == MDB_SUCCESS) {
+            rc = append_lookup_rows_for_cursor(handle->cursor, key, &rows, &count, &cap);
+        }
+    } else {
+        MDB_val mdb_key;
+        MDB_val mdb_val;
+        mdb_key.mv_size = strlen(key);
+        mdb_key.mv_data = (void *)key;
+        rc = mdb_get(handle->txn, handle->dbi, &mdb_key, &mdb_val);
+        if (rc == MDB_SUCCESS) {
+            rc = append_row(&rows, &count, &cap,
+                            key, strlen(key),
+                            (const char *)mdb_val.mv_data, mdb_val.mv_size);
+        } else if (rc == MDB_NOTFOUND) {
+            rc = MDB_SUCCESS;
+        }
+    }
+
+    jobjectArray result = NULL;
+    if (rc == MDB_SUCCESS) {
+        result = rows_to_java(env, rows, count);
+    } else {
+        char message[256];
+        snprintf(message, sizeof(message), "LMDB lookupRowsForHandle failed: %s", mdb_strerror(rc));
+        throw_runtime_exception(env, message);
+    }
+
+    free_rows(rows, count);
+    (*env)->ReleaseStringUTFChars(env, key_j, key);
+    return result;
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_generated_lmdb_LmdbArtifactJNI_scanRowsForHandle(JNIEnv *env, jclass cls, jlong handle_j) {
+    (void)cls;
+    store_handle *handle = (store_handle *)(intptr_t)handle_j;
+    if (handle == NULL) {
+        throw_runtime_exception(env, "LMDB scanRowsForHandle failed: null handle");
+        return NULL;
+    }
+
+    MDB_cursor *cursor = NULL;
+    int rc = mdb_cursor_open(handle->txn, handle->dbi, &cursor);
+    row_buf *rows = NULL;
+    size_t count = 0;
+    size_t cap = 0;
+
+    if (rc == MDB_SUCCESS) {
+        MDB_val key;
+        MDB_val value;
+        rc = mdb_cursor_get(cursor, &key, &value, MDB_FIRST);
+        while (rc == MDB_SUCCESS) {
+            rc = append_row(&rows, &count, &cap,
+                            (const char *)key.mv_data, key.mv_size,
+                            (const char *)value.mv_data, value.mv_size);
+            if (rc != MDB_SUCCESS) {
+                break;
+            }
+            rc = mdb_cursor_get(cursor, &key, &value, MDB_NEXT);
+        }
+        if (rc == MDB_NOTFOUND) {
+            rc = MDB_SUCCESS;
+        }
+    }
+
+    jobjectArray result = NULL;
+    if (rc == MDB_SUCCESS) {
+        result = rows_to_java(env, rows, count);
+    } else {
+        char message[256];
+        snprintf(message, sizeof(message), "LMDB scanRowsForHandle failed: %s", mdb_strerror(rc));
+        throw_runtime_exception(env, message);
+    }
+
+    if (cursor != NULL) {
+        mdb_cursor_close(cursor);
+    }
+    free_rows(rows, count);
     return result;
 }
 

--- a/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactJNI.java
+++ b/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactJNI.java
@@ -7,6 +7,14 @@ public final class LmdbArtifactJNI {
 
     private LmdbArtifactJNI() {}
 
+    public static native long openStore(String artifactDir, String dbName, boolean dupsort);
+
+    public static native void closeStore(long handle);
+
+    public static native LmdbRow[] lookupRowsForHandle(long handle, String key, boolean dupsort);
+
+    public static native LmdbRow[] scanRowsForHandle(long handle);
+
     public static native LmdbRow[] lookupRows(String artifactDir, String dbName, String key, boolean dupsort);
 
     public static native LmdbRow[] scanRows(String artifactDir, String dbName);

--- a/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactReader.java
+++ b/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactReader.java
@@ -2,14 +2,26 @@ package generated.lmdb;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 public final class LmdbArtifactReader {
-    private final Path artifactDir;
     private final LmdbArtifactManifest manifest;
+    private final ThreadLocal<LmdbArtifactStore> threadLocalStore;
+    private final boolean memoizeArg1;
+    private final ThreadLocal<Map<String, LmdbRow[]>> threadLocalArg1Cache;
 
     public LmdbArtifactReader(Path artifactDir, LmdbArtifactManifest manifest) {
-        this.artifactDir = artifactDir;
+        this(artifactDir, manifest, false);
+    }
+
+    public LmdbArtifactReader(Path artifactDir, LmdbArtifactManifest manifest, boolean memoizeArg1) {
         this.manifest = manifest;
+        this.memoizeArg1 = memoizeArg1;
+        this.threadLocalStore = ThreadLocal.withInitial(() -> LmdbArtifactStore.open(artifactDir, manifest));
+        this.threadLocalArg1Cache = memoizeArg1
+            ? ThreadLocal.withInitial(HashMap::new)
+            : null;
     }
 
     public static LmdbArtifactReader open(Path artifactDir) throws IOException {
@@ -19,23 +31,45 @@ public final class LmdbArtifactReader {
         );
     }
 
-    public LmdbRow[] lookupArg1(String key) {
-        return LmdbArtifactJNI.lookupRows(
-            artifactDir.toString(),
-            manifest.dbName(),
-            key,
-            manifest.dupsort()
+    public static LmdbArtifactReader openMemoized(Path artifactDir) throws IOException {
+        return new LmdbArtifactReader(
+            artifactDir,
+            LmdbArtifactManifest.read(artifactDir.resolve("manifest.json")),
+            true
         );
     }
 
+    public LmdbRow[] lookupArg1(String key) {
+        if (!memoizeArg1) {
+            return threadLocalStore.get().lookupArg1(key);
+        }
+        Map<String, LmdbRow[]> cache = threadLocalArg1Cache.get();
+        LmdbRow[] cached = cache.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        LmdbRow[] rows = threadLocalStore.get().lookupArg1(key);
+        cache.put(key, rows);
+        return rows;
+    }
+
     public LmdbRow[] scan() {
-        return LmdbArtifactJNI.scanRows(
-            artifactDir.toString(),
-            manifest.dbName()
-        );
+        return threadLocalStore.get().scan();
     }
 
     public LmdbArtifactManifest manifest() {
         return manifest;
+    }
+
+    public void closeCurrentThread() {
+        LmdbArtifactStore store = threadLocalStore.get();
+        try {
+            store.close();
+        } finally {
+            if (threadLocalArg1Cache != null) {
+                threadLocalArg1Cache.remove();
+            }
+            threadLocalStore.remove();
+        }
     }
 }

--- a/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactStore.java
+++ b/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactStore.java
@@ -1,0 +1,38 @@
+package generated.lmdb;
+
+import java.nio.file.Path;
+
+final class LmdbArtifactStore implements AutoCloseable {
+    private final long handle;
+    private final boolean dupsort;
+
+    private LmdbArtifactStore(long handle, boolean dupsort) {
+        this.handle = handle;
+        this.dupsort = dupsort;
+    }
+
+    static LmdbArtifactStore open(Path artifactDir, LmdbArtifactManifest manifest) {
+        long handle = LmdbArtifactJNI.openStore(
+            artifactDir.toString(),
+            manifest.dbName(),
+            manifest.dupsort()
+        );
+        if (handle == 0L) {
+            throw new IllegalStateException("failed to open LMDB artifact store");
+        }
+        return new LmdbArtifactStore(handle, manifest.dupsort());
+    }
+
+    LmdbRow[] lookupArg1(String key) {
+        return LmdbArtifactJNI.lookupRowsForHandle(handle, key, dupsort);
+    }
+
+    LmdbRow[] scan() {
+        return LmdbArtifactJNI.scanRowsForHandle(handle);
+    }
+
+    @Override
+    public void close() {
+        LmdbArtifactJNI.closeStore(handle);
+    }
+}

--- a/tests/test_wam_clojure_benchmark_generator.pl
+++ b/tests/test_wam_clojure_benchmark_generator.pl
@@ -89,11 +89,13 @@ test(relation_data_mode_override_seeded_parent_lmdb, [condition(lmdb_helper_tool
             directory_file_path(TmpDir, 'data/generated/wam_clojure_optimized_bench/category_parent_lmdb/manifest.json', LmdbManifestPath),
             directory_file_path(TmpDir, 'lib/lmdb-artifact-reader.jar', ReaderJarPath),
             directory_file_path(TmpDir, 'lib/liblmdb_artifact_jni.so', NativeLibPath),
+            directory_file_path(TmpDir, 'classes/generated/lmdb/LmdbArtifactStore.class', StoreClassPath),
             read_file_to_string(CorePath, CoreCode, []),
             read_file_to_string(ManifestPath, Manifest, []),
             assertion(exists_file(LmdbManifestPath)),
             assertion(exists_file(ReaderJarPath)),
             assertion(exists_file(NativeLibPath)),
+            assertion(exists_file(StoreClassPath)),
             assertion(sub_string(CoreCode, _, _, _, 'generated.lmdb.LmdbArtifactReader/open')),
             assertion(sub_string(CoreCode, _, _, _, 'category_parent_lmdb')),
             assertion(sub_string(Manifest, _, _, _, '"category_parent" {:mode "lmdb"')),
@@ -101,6 +103,28 @@ test(relation_data_mode_override_seeded_parent_lmdb, [condition(lmdb_helper_tool
             delete_directory_and_contents(TmpDir)
         )),
         maybe_abolish_test_predicate(wam_clojure_benchmark_relation_data_mode/2)
+    ).
+
+test(relation_cache_policy_override_seeded_parent_lmdb_memoize, [condition(lmdb_helper_toolchain_available)]) :-
+    setup_call_cleanup(
+        ( load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
+          assertz(user:wam_clojure_benchmark_relation_data_mode(category_parent, lmdb)),
+          assertz(user:wam_clojure_benchmark_relation_cache_policy(category_parent, memoize))
+        ),
+        once((
+            unique_tmp_dir('tmp_wam_clojure_bench_rel_parent_lmdb_memo', TmpDir),
+            generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, artifact),
+            directory_file_path(TmpDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
+            directory_file_path(TmpDir, 'data/generated/wam_clojure_optimized_bench/manifest.edn', ManifestPath),
+            read_file_to_string(CorePath, CoreCode, []),
+            read_file_to_string(ManifestPath, Manifest, []),
+            assertion(sub_string(CoreCode, _, _, _, 'generated.lmdb.LmdbArtifactReader/openMemoized')),
+            assertion(sub_string(Manifest, _, _, _, ':cache_policy "memoize"')),
+            delete_directory_and_contents(TmpDir)
+        )),
+        ( maybe_abolish_test_predicate(wam_clojure_benchmark_relation_data_mode/2),
+          maybe_abolish_test_predicate(wam_clojure_benchmark_relation_cache_policy/2)
+        )
     ).
 
 test(shared_preprocess_override_seeded_article_artifact) :-
@@ -293,6 +317,30 @@ test(generated_category_parent_lmdb_handler_executes,
             delete_directory_and_contents(TmpDir)
         )),
         maybe_abolish_test_predicate(wam_clojure_benchmark_relation_data_mode/2)
+    ).
+
+test(generated_category_parent_lmdb_memoized_handler_executes,
+     [condition((clojure_available, lmdb_helper_toolchain_available))]) :-
+    setup_call_cleanup(
+        ( load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
+          assertz(user:wam_clojure_benchmark_relation_data_mode(category_parent, lmdb)),
+          assertz(user:wam_clojure_benchmark_relation_cache_policy(category_parent, memoize))
+        ),
+        once((
+            unique_tmp_dir('tmp_wam_clojure_bench_exec_lmdb_memo', TmpDir),
+            generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, artifact),
+            run_clojure_predicate(TmpDir, 'category_parent/2',
+                                  ['Abstraction', 'Thought'], "true"),
+            run_clojure_predicate(TmpDir, 'category_parent/2',
+                                  ['Abstraction', 'NotAParent'], "false"),
+            run_clojure_predicate(TmpDir, 'category_ancestor/4',
+                                  ['Abstraction', 'Cognition', raw('{:var 1000}'), visited(['Abstraction'])],
+                                  "true"),
+            delete_directory_and_contents(TmpDir)
+        )),
+        ( maybe_abolish_test_predicate(wam_clojure_benchmark_relation_data_mode/2),
+          maybe_abolish_test_predicate(wam_clojure_benchmark_relation_cache_policy/2)
+        )
     ).
 
 :- end_tests(wam_clojure_benchmark_generator).


### PR DESCRIPTION
## Summary

Implements the next Clojure LMDB fact-access phase from
`docs/proposals/WAM_CLOJURE_LMDB_FACT_ACCESS_PLAN.md` by adding an
optional thread-local L1 memoization layer on top of the existing
thread-local LMDB reader seam.

This keeps the Haskell-guided separation of concerns intact:

- raw native LMDB store lifecycle stays in `LmdbArtifactStore`
- thread-local reader reuse stays in `LmdbArtifactReader`
- memoization is an explicit higher-level policy, not part of the
  native store abstraction

## What Changed

- adds `openMemoized(...)` to the JVM LMDB helper reader
- adds thread-local `arg1` result memoization in the Java wrapper layer
- keeps native JNI handle / transaction / cursor ownership unchanged
- adds optional relation-local cache policy hooks for the Clojure
  benchmark generator:
  - `wam_clojure_benchmark_relation_cache_policy/2`
  - `benchmark_relation_cache_policy/2`
- supports `category_parent -> memoize` when `category_parent` is using
  `lmdb` storage mode
- updates generated Clojure LMDB handlers and benchmark runner to select
  `openMemoized` only when the memoization policy is declared
- records `:cache_policy "memoize"` in the generated benchmark manifest

## Tests

Verified locally with:

- `sh examples/scala_lmdb_jni_probe/build.sh`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`
- `git diff --check`

The updated Clojure benchmark generator coverage now checks:

- generated LMDB projects reference `openMemoized` when requested
- generated manifests record the cache policy
- memoized LMDB-backed `category_parent/2` execution
- memoized LMDB-backed `category_ancestor/4` execution

## Why This Boundary

This is a clean PR boundary because it completes Phase C3 from the
Clojure LMDB fact-access plan without mixing in later shared-cache work.

It advances the target in the same order that proved useful on the
Haskell LMDB path:

1. raw reader seam
2. thread-local reuse
3. optional L1 memoization
4. shared L2 deferred

## Follow-up

- add a small comparison path for LMDB `none` vs `memoize`
- evaluate overlap-heavy vs low-overlap workloads
- keep shared L2 cache work deferred until the L1 policy is justified
