### PR TITLE
fix(wam): findall allocates Y-reg for value (Finding 1 from #1647)

### DIFF
--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -715,7 +715,17 @@ compile_aggregate_all(Template, InnerGoal, Result, V0, Vf, Code) :-
     ;   Template = min(ValueVar) -> AggType = min
     ;   Template = bag(ValueVar) -> AggType = bag
     ;   Template = set(ValueVar) -> AggType = set
-    ;   AggType = collect, ValueVar = Template  % default: collect all values
+    % findall/3 → compile_findall/5 wraps Template as `collect-Template`.
+    % Unwrap to expose the real ValueVar so the var(ValueVar) branch
+    % below allocates a Y-register and emits put_variable Y_n, A1.
+    % Without this, ValueReg defaults to A1 and survives the inner
+    % call only when no instruction along the inner-goal path
+    % overwrites A1 — false in the module-qualified case where the
+    % `:/2` builtin lowering puts the module-name string into A1
+    % (Phase 3 finding from #1647). Y-reg version is preserved
+    % across any inner-call register churn.
+    ;   Template = collect-CollectVar -> AggType = collect, ValueVar = CollectVar
+    ;   AggType = collect, ValueVar = Template  % default: direct callers
     ),
     % Find or allocate the Result register (where output goes)
     (   var(Result), get_var_reg(Result, V0, ResultReg0)

--- a/tests/test_wam_elixir_lowered_phase3.pl
+++ b/tests/test_wam_elixir_lowered_phase3.pl
@@ -129,6 +129,16 @@ user:phase3_set(S) :- aggregate_all(set(X), phase3_smoke_p(X), S).
 user:phase3_max(M) :- aggregate_all(max(X), phase3_smoke_p(X), M).
 user:phase3_min(M) :- aggregate_all(min(X), phase3_smoke_p(X), M).
 
+% Module-qualified findall — `findall(X, user:p(X), L)` — would test
+% the Finding 1 fix from #1647 end-to-end, but is currently blocked
+% by a separate Elixir-runtime gap: WamRuntime.execute_builtin/3
+% doesn't implement `:/2` (the meta-call dispatcher). The WAM-side
+% fix in compile_aggregate_all/5 IS correct (Y-reg now used for
+% findall regardless of inner-goal shape — verified at the WAM
+% byte-shape level in tests/test_wam_elixir_target.pl). End-to-end
+% runtime validation deferred until `:/2` is implemented in the
+% Elixir runtime — separate Phase 3c follow-up.
+
 %% tmp_root — try TMPDIR / TMP / TEMP / $PREFIX/tmp / ./output in
 %% order. Same fallback chain as the existing benchmark harness.
 tmp_root_candidate(Root) :-

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -921,6 +921,53 @@ test_findall_instr_end_to_end_lowering :-
     ;   fail_test(Test, 'end-to-end findall lowering missing push/collect/throw shape')
     ).
 
+%% Module-qualified findall regression test for the wam_target.pl fix
+%% (Finding 1 from #1647). Before the fix, `findall(X, M:p(X), L)`
+%% emitted `begin_aggregate collect, A1, X_n` — value_reg=A1 — which
+%% got clobbered by the `:/2` builtin's put_constant of the module
+%% name string. After the fix, compile_aggregate_all/5 unwraps
+%% compile_findall's `collect-Template` wrapper to expose the
+%% Template variable, so the var(ValueVar) branch fires and a Y-reg
+%% is allocated. End_aggregate then reads from a slot that survives
+%% any inner-call register churn.
+%%
+%% Target-agnostic at the WAM byte-shape level: this test asserts
+%% the emitted WAM uses Y... not A1 for findall's value_reg, which
+%% is the contract every target's lowering depends on.
+
+:- dynamic phase_a_test:findall_qualified_target/1.
+
+test_findall_module_qualified_uses_y_reg :-
+    Test = 'WAM compiler: findall/3 with module-qualified inner goal uses Y-reg in begin_aggregate (fix for #1647 Finding 1)',
+    setup_call_cleanup(
+        (   retractall(phase_a_test:findall_qualified_target(_)),
+            assertz(phase_a_test:findall_qualified_target('a')),
+            assertz(phase_a_test:findall_qualified_target('b')),
+            assertz((phase_a_test:findall_qualified_caller(L) :-
+                findall(X, phase_a_test:findall_qualified_target(X), L)))
+        ),
+        (   wam_target:compile_predicate_to_wam(
+                phase_a_test:findall_qualified_caller/1, [], WamCode),
+            atom_string(WamCode, S),
+            % The fix: findall's value_reg should be a Y-register
+            % (Y1, Y2, ...). Pre-fix, A1 was used and would have been
+            % clobbered by the `:/2` builtin's put_constant.
+            sub_string(S, _, _, _, 'begin_aggregate collect, Y'),
+            sub_string(S, _, _, _, 'end_aggregate Y'),
+            % And the inner-call lowering should use the `:/2` builtin
+            % path — the very thing that exposed the bug. Confirms we
+            % are still going through the module-qualified compilation,
+            % not silently unwrapping it elsewhere.
+            sub_string(S, _, _, _, 'builtin_call :/2'),
+            \+ sub_string(S, _, _, _, 'begin_aggregate collect, A1')
+        ->  pass(Test)
+        ;   fail_test(Test, 'module-qualified findall did not emit Y-reg in begin_aggregate (fix regressed?)')
+        ),
+        (   retractall(phase_a_test:findall_qualified_target(_)),
+            retractall(phase_a_test:findall_qualified_caller(_))
+        )
+    ).
+
 test_findall_substrate_backtrack_routes_aggregate_frames :-
     Test = 'Findall substrate: backtrack/1 dispatches aggregate frames to finalise_aggregate',
     (   compile_wam_runtime_to_elixir([], Code),
@@ -1257,6 +1304,7 @@ run_tests :-
     test_findall_instr_translates_collect_to_findall,
     test_findall_instr_lowers_end_aggregate,
     test_findall_instr_end_to_end_lowering,
+    test_findall_module_qualified_uses_y_reg,
     test_tier2_purity_gate_rejects_unknown,
     test_tier2_purity_gate_accepts_declared,
     test_par_wrap_segment_emits_super_wrapper,


### PR DESCRIPTION
## Summary

- **One-clause WAM-compiler fix**, cross-target benefit. Resolves Finding 1 from #1647 — `findall(X, M:p(X), L)` produced broken WAM where the `:/2` builtin's `put_constant` of the module-name string clobbered the value register before `end_aggregate` read it.
- 12 lines added to `src/unifyweaver/targets/wam_target.pl`'s `compile_aggregate_all/5` (one match clause + rationale comment), 48 lines of new test, 10 lines of comment in the Elixir Phase 3 file.
- Suite: **80/80** Elixir target tests passing (79 prior + 1 new target-agnostic Y-reg assertion); **8/8** Phase 3 runtime scenarios still passing; LLVM aggregate test still passing.

## The bug

`findall(X, p(X), L)` and `findall(X, M:p(X), L)` both go through `compile_findall/5`, which wraps the Template:

```prolog
compile_findall(Template, InnerGoal, Result, V0, Vf, Code) :-
    compile_aggregate_all(collect-Template, InnerGoal, Result, V0, Vf, Code).
```

`compile_aggregate_all/5`'s AggType cascade had no clause matching the `collect-Template` wrapper, so it fell through to:

```prolog
;   AggType = collect, ValueVar = Template  % default: collect all values
```

…leaving `ValueVar = collect-X` (a compound). Because `var(collect-X)` is `false`, the ValueReg-allocation branch took the constant-default path:

```prolog
;   % Constant value (e.g., count uses 1) — use A1 as placeholder
    ValueReg = 'A1', V2 = V1, InitValueCode = ""
```

So `begin_aggregate collect, A1, ...` and `end_aggregate A1` were emitted with `value_reg = A1`. For non-module-qualified inner goals, A1 *happened to* still hold the Template binding when `end_aggregate` ran — the inner call's argument passing left it there. For **module-qualified** inner goals, the `:/2` builtin's `put_constant` of the module-name string into A1 clobbered the binding. `end_aggregate` then captured `"user"` (or whatever the module name was) instead of the Template's actual binding for every solution.

Surfaced by the Phase 3 runtime smoke (#1647) — see [#1647 Finding 1](https://github.com/s243a/UnifyWeaver/pull/1647) for the original diagnosis.

## The fix

Add a clause matching the wrapper that unwraps to expose the actual Template variable, so the `var(ValueVar)` branch fires and a Y-register is allocated:

```prolog
;   Template = collect-CollectVar -> AggType = collect, ValueVar = CollectVar
```

This puts the value into a register that survives any inner-call register churn — `put_variable Y_n, A1` initialises both Y_n and A1 with the same fresh unbound ref, the inner call may bind through A1 (with the binding flowing through deref), and `end_aggregate Y_n` reads the deref-able value cleanly.

## Byte-shape change (verified via direct probe)

```
Before:                          After:
  allocate                          allocate
  get_variable X2, A1               get_variable X2, A1
  put_variable Y1, A1               put_variable Y1, A1
  begin_aggregate collect, A1, X2   begin_aggregate collect, Y1, X2
  [inner goal lowering]             [inner goal lowering]
  end_aggregate A1                  end_aggregate Y1
  deallocate                        deallocate
  proceed                           proceed
```

Non-findall aggregate paths (`sum`/`count`/`max`/`min`/`bag`/`set`) are **unaffected** — they already extract ValueVar correctly from their structured Template forms (e.g. `sum(X)`, `max(X)`).

## Impact

| Target | Status |
|---|---|
| Rust, Go, LLVM, Haskell | ✅ Immediate benefit — they already implement `:/2` natively |
| Elixir (WAM compiler side) | ✅ This PR |
| Elixir (runtime side) | ⏳ Still gated on `WamRuntime.execute_builtin/3` implementing `:/2` (separate Phase 3c follow-up) |

**Tests that don't regress** (verified):

- `test_wam_llvm_aggregate.pl` — its `aggregate_all(min(X), ...)` test goes through the structured-aggregator path which already worked, byte-shape contains `begin_aggregate` / `end_aggregate` substrings (still does).
- `test_wam_rust_target.pl` — its aggregate test uses a hand-written WAM string (`"begin_aggregate sum, Y1, A1\n..."`) and doesn't go through `compile_findall`.
- `test_wam_e2e.pl` — its `findall_wam` test uses a Prolog-side `findall` helper, not the body-goal `findall/3`. The pre-existing `atom/1` failure exists on `main` and is unrelated.

## What changes

### `src/unifyweaver/targets/wam_target.pl` (+10 / -1)

One new clause in the AggType cascade in `compile_aggregate_all/5`, with a comment block explaining the rationale. The fall-through default `AggType = collect, ValueVar = Template` is preserved as a safety net for any direct callers that pass a non-wrapped Template.

### `tests/test_wam_elixir_target.pl` (+48)

New test `test_findall_module_qualified_uses_y_reg`:

- Asserts `begin_aggregate collect, Y...` and `end_aggregate Y...` for findall with a module-qualified inner goal.
- Asserts the inner-call lowering still uses `builtin_call :/2` — confirms we're exercising the bug-triggering path, not silently unwrapping module qualification elsewhere.
- Asserts `\+ sub_string(_, 'begin_aggregate collect, A1')` — explicit regression guard against the pre-fix shape.

Target-agnostic: tests the WAM byte-shape contract that every downstream target's lowering depends on.

### `tests/test_wam_elixir_lowered_phase3.pl` (+10 / -1)

Comment block explaining why the natural runtime scenario (`findall(X, user:phase3_smoke_p(X), L)` with the kill-switched super-wrapper) is **not** added in this PR — it would need `WamRuntime.execute_builtin/3` to implement `:/2`, which is an Elixir-runtime gap separate from this WAM-compiler fix. The comment points the next implementer at the right place to pick it up.

## Reviewer notes

**Why no end-to-end runtime test on Elixir.** Adding the obvious scenario (`findall(X, user:p(X), L)` through the lowered Elixir runtime) would test two bugs at once and only fix one — the test would still fail because Elixir's `execute_builtin/3` returns `:fail` from its catch-all when handed `:/2`. Better to validate the WAM-side fix at the WAM byte-shape level (target-agnostic, runs everywhere) and leave the Elixir-runtime `:/2` implementation as a focused follow-up.

**Why the safety-net catch-all stays.** Direct callers of `compile_aggregate_all/5` (not via `compile_findall/5`) might pass a non-wrapped Template — the existing fallback `AggType = collect, ValueVar = Template` keeps them working, even though it has the same A1-clobbering vulnerability the wrapper case had. Auditing every caller and removing the fallback is out of scope for a focused fix; the wrapper match handles the only known caller (`compile_findall/5`).

**Comment block in `compile_aggregate_all/5`.** Inline comment explains *why* the wrapper exists (artifact of `compile_findall`'s delegation) and *why* the unwrap is needed (Y-reg survives the `:/2` register churn, A1 doesn't). Future readers will see the trap before stepping into it.

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_target.pl` — 80/80 passing (79 prior + new Y-reg assertion)
- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_lowered_phase3.pl` — 8/8 passing on Termux (Elixir 1.19, OTP 28)
- [x] `swipl -t halt -g test_aggregate_compiles tests/core/test_wam_llvm_aggregate.pl` — passes (byte-shape unchanged for `aggregate_all(min(X), ...)`)
- [x] WAM byte-shape direct probe — verified `begin_aggregate collect, Y1, X2` and `end_aggregate Y1` for both qualified and unqualified findall
- [x] Pre-existing `test_wam_e2e.pl` `atom/1` failure exists on `main` and is unrelated to this PR

## Related

- The bug's original surfacing: #1647 Finding 1 (Phase 3a runtime smoke)
- Findall track: proposal #1626 → substrate #1627 → lowering #1643 → harness #1647 → coverage #1649
- LLVM precedent for fail-driven enumeration: `wam_llvm_target.pl:2417-2496`

## Phase plan (post-merge)

- **Phase 3c (next)**: Edge cases on the Elixir runtime track — single-clause findall, Y-register Template deep-copy probe (§6 risk #1), cut in inner goal (§6 risk #3), nested findall (§6 risk #7).
- **Elixir `:/2` runtime support** (parallel track): Implement meta-call dispatcher in `WamRuntime.execute_builtin/3`. Once landed, the runtime scenario this PR is sketched as a comment can be activated.
- **`:sum` over numeric facts** (parallel track): Substrate-level fix in `put_constant` lowering (currently emits integers as Elixir strings).
- **Phase 4** (later): Tier-2 × findall — branch-local-accum protocol from Haskell `wam_haskell_target.pl:1502-1516`.
