### PR TITLE
feat(wam-clojure): add LMDB L2 cache policies

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -681,3 +681,10 @@ not in the native store object:
 - one thread-local L1 map caches `lookupArg1` results by key
 - scan behavior is unchanged
 - shared L2 caching is still deferred
+
+The next narrow step is now underway too: the JVM helper exposes
+`openSharedCached` and `openTwoLevel` so Clojure can opt into a shared
+`lookupArg1` cache or a composed L1+L2 policy without changing the
+native store seam again. We should not trust Termux to tell us whether
+`none` vs `memoize` is the right default; that comparison is now a
+desktop-only measurement TODO.

--- a/docs/proposals/WAM_CLOJURE_LMDB_FACT_ACCESS_PLAN.md
+++ b/docs/proposals/WAM_CLOJURE_LMDB_FACT_ACCESS_PLAN.md
@@ -75,6 +75,8 @@ What is implemented today:
   memoization for `category_parent` lookup overlap:
   - `wam_clojure_benchmark_relation_cache_policy(category_parent, memoize)`
   - `benchmark_relation_cache_policy(category_parent, memoize)`
+- desktop-only TODO: compare `none` vs `memoize` on overlap-heavy and
+  low-overlap workloads before treating L1 as a settled default
 
 This is intentionally narrow:
 
@@ -246,18 +248,32 @@ Reference:
 
 ### Phase C4: Shared cache tiers
 
-Status: **deferred**
+Status: **in progress**
 
-Do not start until:
+Before broadening this phase:
 
 1. raw reader seam is stable
 2. thread-local reuse is validated
-3. L1 policy is benchmarked and justified
+3. L1 policy should still be benchmarked and justified on desktop
+
+Narrow implementation shape:
+
+1. keep shared cache policy above the raw native store seam
+2. use copied JVM `LmdbRow` values as cache payloads
+3. scope the first L2 work to `lookupArg1`
+4. allow a composed `two_level` policy, but keep shared invalidation and
+   memory budgeting deferred
 
 Reference:
 
 - Haskell `d124e1d1` is useful here, but it is guidance for a later
-  phase, not the immediate next step for Clojure
+  phase, not a reason to merge all L2 concerns at once
+
+Desktop measurement TODO:
+
+- evaluate `none` vs `memoize` vs `shared` vs `two_level`
+- do this outside Termux, where JVM timing and memory behavior are more
+  trustworthy
 
 ### Phase C5: Broader relation coverage
 

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -213,6 +213,21 @@ reader reuse to a thread-local L1 `arg1` memoization layer on top of the
 same native store seam. Leaving the predicate unset preserves the
 default `none` policy.
 
+Additional experimental policies are available for the same relation:
+
+- `shared`
+- `two_level`
+
+These keep the same LMDB storage mode but change the JVM-side cache
+composition:
+
+- `shared`: shared `arg1` cache above the thread-local native reader
+- `two_level`: thread-local L1 plus shared L2
+
+Use these as explicit workload overrides for now. The relative value of
+`none`, `memoize`, `shared`, and `two_level` should be measured on a
+desktop JVM rather than treated as settled from Termux timings.
+
 The generator also now honors the shared predicate-preprocessing
 declaration surface from
 `src/unifyweaver/core/predicate_preprocessing.pl`. For the current

--- a/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
@@ -249,7 +249,7 @@ benchmark_relation_declared_cache_policy(Relation, Policy) :-
     current_predicate(user:Name/2),
     Goal =.. [Name, Relation, DeclaredPolicy],
     once(call(user:Goal)),
-    memberchk(DeclaredPolicy, [none, memoize]),
+    memberchk(DeclaredPolicy, [none, memoize, shared, two_level]),
     Policy = DeclaredPolicy.
 
 benchmark_relation_cache_policy(_Relation, Mode, none) :-
@@ -322,6 +322,14 @@ category_parent_handler_code(inline, HandlerCode) :-
 lmdb_reader_open_expr(ArtifactDirPath, memoize, Expr) :-
     format(string(Expr),
            "(generated.lmdb.LmdbArtifactReader/openMemoized (java.nio.file.Paths/get ~w (make-array String 0)))",
+           [ArtifactDirPath]).
+lmdb_reader_open_expr(ArtifactDirPath, shared, Expr) :-
+    format(string(Expr),
+           "(generated.lmdb.LmdbArtifactReader/openSharedCached (java.nio.file.Paths/get ~w (make-array String 0)))",
+           [ArtifactDirPath]).
+lmdb_reader_open_expr(ArtifactDirPath, two_level, Expr) :-
+    format(string(Expr),
+           "(generated.lmdb.LmdbArtifactReader/openTwoLevel (java.nio.file.Paths/get ~w (make-array String 0)))",
            [ArtifactDirPath]).
 lmdb_reader_open_expr(ArtifactDirPath, none, Expr) :-
     format(string(Expr),
@@ -628,6 +636,16 @@ benchmark_category_parents_code(inline, _ParentCachePolicy, _DataDirLiteral, ben
 
 lmdb_reader_open_expr_runtime(memoize, Expr) :-
     Expr = '(generated.lmdb.LmdbArtifactReader/openMemoized
+                   (java.nio.file.Paths/get
+                     (str benchmark-data-dir "/category_parent_lmdb")
+                     (make-array String 0)))'.
+lmdb_reader_open_expr_runtime(shared, Expr) :-
+    Expr = '(generated.lmdb.LmdbArtifactReader/openSharedCached
+                   (java.nio.file.Paths/get
+                     (str benchmark-data-dir "/category_parent_lmdb")
+                     (make-array String 0)))'.
+lmdb_reader_open_expr_runtime(two_level, Expr) :-
+    Expr = '(generated.lmdb.LmdbArtifactReader/openTwoLevel
                    (java.nio.file.Paths/get
                      (str benchmark-data-dir "/category_parent_lmdb")
                      (make-array String 0)))'.

--- a/examples/scala_lmdb_jni_probe/README.md
+++ b/examples/scala_lmdb_jni_probe/README.md
@@ -60,5 +60,7 @@ clojure_lmdb_jni_probe_ok lookup=a	1,a	2 scan_count=3 db=edge/2
 - the reader also exposes an optional `openMemoized(...)` constructor
   that adds a thread-local `arg1` memoization layer above the native
   store seam
+- the reader also exposes `openSharedCached(...)` and `openTwoLevel(...)`
+  for narrow shared-cache experiments above the same seam
 - LMDB access itself is done through JNI against the native `liblmdb`
 - this is still a probe, not yet a generated target integration

--- a/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactReader.java
+++ b/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactReader.java
@@ -2,24 +2,36 @@ package generated.lmdb;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.HashMap;
 import java.util.Map;
 
 public final class LmdbArtifactReader {
+    private enum CachePolicy {
+        NONE,
+        MEMOIZE,
+        SHARED,
+        TWO_LEVEL
+    }
+
+    private static final ConcurrentHashMap<String, LmdbRow[]> SHARED_ARG1_CACHE = new ConcurrentHashMap<>();
+
     private final LmdbArtifactManifest manifest;
     private final ThreadLocal<LmdbArtifactStore> threadLocalStore;
-    private final boolean memoizeArg1;
+    private final CachePolicy cachePolicy;
+    private final String sharedCachePrefix;
     private final ThreadLocal<Map<String, LmdbRow[]>> threadLocalArg1Cache;
 
     public LmdbArtifactReader(Path artifactDir, LmdbArtifactManifest manifest) {
-        this(artifactDir, manifest, false);
+        this(artifactDir, manifest, CachePolicy.NONE);
     }
 
-    public LmdbArtifactReader(Path artifactDir, LmdbArtifactManifest manifest, boolean memoizeArg1) {
+    private LmdbArtifactReader(Path artifactDir, LmdbArtifactManifest manifest, CachePolicy cachePolicy) {
         this.manifest = manifest;
-        this.memoizeArg1 = memoizeArg1;
+        this.cachePolicy = cachePolicy;
+        this.sharedCachePrefix = artifactDir.toAbsolutePath().normalize() + "::";
         this.threadLocalStore = ThreadLocal.withInitial(() -> LmdbArtifactStore.open(artifactDir, manifest));
-        this.threadLocalArg1Cache = memoizeArg1
+        this.threadLocalArg1Cache = usesThreadLocalCache(cachePolicy)
             ? ThreadLocal.withInitial(HashMap::new)
             : null;
     }
@@ -35,20 +47,63 @@ public final class LmdbArtifactReader {
         return new LmdbArtifactReader(
             artifactDir,
             LmdbArtifactManifest.read(artifactDir.resolve("manifest.json")),
-            true
+            CachePolicy.MEMOIZE
+        );
+    }
+
+    public static LmdbArtifactReader openSharedCached(Path artifactDir) throws IOException {
+        return new LmdbArtifactReader(
+            artifactDir,
+            LmdbArtifactManifest.read(artifactDir.resolve("manifest.json")),
+            CachePolicy.SHARED
+        );
+    }
+
+    public static LmdbArtifactReader openTwoLevel(Path artifactDir) throws IOException {
+        return new LmdbArtifactReader(
+            artifactDir,
+            LmdbArtifactManifest.read(artifactDir.resolve("manifest.json")),
+            CachePolicy.TWO_LEVEL
         );
     }
 
     public LmdbRow[] lookupArg1(String key) {
-        if (!memoizeArg1) {
-            return threadLocalStore.get().lookupArg1(key);
-        }
+        return switch (cachePolicy) {
+            case NONE -> threadLocalStore.get().lookupArg1(key);
+            case MEMOIZE -> lookupMemoized(key);
+            case SHARED -> lookupShared(key);
+            case TWO_LEVEL -> lookupTwoLevel(key);
+        };
+    }
+
+    private LmdbRow[] lookupMemoized(String key) {
         Map<String, LmdbRow[]> cache = threadLocalArg1Cache.get();
         LmdbRow[] cached = cache.get(key);
         if (cached != null) {
             return cached;
         }
         LmdbRow[] rows = threadLocalStore.get().lookupArg1(key);
+        cache.put(key, rows);
+        return rows;
+    }
+
+    private LmdbRow[] lookupShared(String key) {
+        return SHARED_ARG1_CACHE.computeIfAbsent(
+            sharedCacheKey(key),
+            ignored -> threadLocalStore.get().lookupArg1(key)
+        );
+    }
+
+    private LmdbRow[] lookupTwoLevel(String key) {
+        Map<String, LmdbRow[]> cache = threadLocalArg1Cache.get();
+        LmdbRow[] cached = cache.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        LmdbRow[] rows = SHARED_ARG1_CACHE.computeIfAbsent(
+            sharedCacheKey(key),
+            ignored -> threadLocalStore.get().lookupArg1(key)
+        );
         cache.put(key, rows);
         return rows;
     }
@@ -71,5 +126,13 @@ public final class LmdbArtifactReader {
             }
             threadLocalStore.remove();
         }
+    }
+
+    private static boolean usesThreadLocalCache(CachePolicy cachePolicy) {
+        return cachePolicy == CachePolicy.MEMOIZE || cachePolicy == CachePolicy.TWO_LEVEL;
+    }
+
+    private String sharedCacheKey(String key) {
+        return sharedCachePrefix + key;
     }
 }

--- a/tests/test_wam_clojure_benchmark_generator.pl
+++ b/tests/test_wam_clojure_benchmark_generator.pl
@@ -127,6 +127,50 @@ test(relation_cache_policy_override_seeded_parent_lmdb_memoize, [condition(lmdb_
         )
     ).
 
+test(relation_cache_policy_override_seeded_parent_lmdb_shared, [condition(lmdb_helper_toolchain_available)]) :-
+    setup_call_cleanup(
+        ( load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
+          assertz(user:wam_clojure_benchmark_relation_data_mode(category_parent, lmdb)),
+          assertz(user:wam_clojure_benchmark_relation_cache_policy(category_parent, shared))
+        ),
+        once((
+            unique_tmp_dir('tmp_wam_clojure_bench_rel_parent_lmdb_shared', TmpDir),
+            generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, artifact),
+            directory_file_path(TmpDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
+            directory_file_path(TmpDir, 'data/generated/wam_clojure_optimized_bench/manifest.edn', ManifestPath),
+            read_file_to_string(CorePath, CoreCode, []),
+            read_file_to_string(ManifestPath, Manifest, []),
+            assertion(sub_string(CoreCode, _, _, _, 'generated.lmdb.LmdbArtifactReader/openSharedCached')),
+            assertion(sub_string(Manifest, _, _, _, ':cache_policy "shared"')),
+            delete_directory_and_contents(TmpDir)
+        )),
+        ( maybe_abolish_test_predicate(wam_clojure_benchmark_relation_data_mode/2),
+          maybe_abolish_test_predicate(wam_clojure_benchmark_relation_cache_policy/2)
+        )
+    ).
+
+test(relation_cache_policy_override_seeded_parent_lmdb_two_level, [condition(lmdb_helper_toolchain_available)]) :-
+    setup_call_cleanup(
+        ( load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
+          assertz(user:wam_clojure_benchmark_relation_data_mode(category_parent, lmdb)),
+          assertz(user:wam_clojure_benchmark_relation_cache_policy(category_parent, two_level))
+        ),
+        once((
+            unique_tmp_dir('tmp_wam_clojure_bench_rel_parent_lmdb_two_level', TmpDir),
+            generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, artifact),
+            directory_file_path(TmpDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
+            directory_file_path(TmpDir, 'data/generated/wam_clojure_optimized_bench/manifest.edn', ManifestPath),
+            read_file_to_string(CorePath, CoreCode, []),
+            read_file_to_string(ManifestPath, Manifest, []),
+            assertion(sub_string(CoreCode, _, _, _, 'generated.lmdb.LmdbArtifactReader/openTwoLevel')),
+            assertion(sub_string(Manifest, _, _, _, ':cache_policy "two_level"')),
+            delete_directory_and_contents(TmpDir)
+        )),
+        ( maybe_abolish_test_predicate(wam_clojure_benchmark_relation_data_mode/2),
+          maybe_abolish_test_predicate(wam_clojure_benchmark_relation_cache_policy/2)
+        )
+    ).
+
 test(shared_preprocess_override_seeded_article_artifact) :-
     setup_call_cleanup(
         ( load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
@@ -328,6 +372,30 @@ test(generated_category_parent_lmdb_memoized_handler_executes,
         ),
         once((
             unique_tmp_dir('tmp_wam_clojure_bench_exec_lmdb_memo', TmpDir),
+            generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, artifact),
+            run_clojure_predicate(TmpDir, 'category_parent/2',
+                                  ['Abstraction', 'Thought'], "true"),
+            run_clojure_predicate(TmpDir, 'category_parent/2',
+                                  ['Abstraction', 'NotAParent'], "false"),
+            run_clojure_predicate(TmpDir, 'category_ancestor/4',
+                                  ['Abstraction', 'Cognition', raw('{:var 1000}'), visited(['Abstraction'])],
+                                  "true"),
+            delete_directory_and_contents(TmpDir)
+        )),
+        ( maybe_abolish_test_predicate(wam_clojure_benchmark_relation_data_mode/2),
+          maybe_abolish_test_predicate(wam_clojure_benchmark_relation_cache_policy/2)
+        )
+    ).
+
+test(generated_category_parent_lmdb_two_level_handler_executes,
+     [condition((clojure_available, lmdb_helper_toolchain_available))]) :-
+    setup_call_cleanup(
+        ( load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
+          assertz(user:wam_clojure_benchmark_relation_data_mode(category_parent, lmdb)),
+          assertz(user:wam_clojure_benchmark_relation_cache_policy(category_parent, two_level))
+        ),
+        once((
+            unique_tmp_dir('tmp_wam_clojure_bench_exec_lmdb_two_level', TmpDir),
             generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, artifact),
             run_clojure_predicate(TmpDir, 'category_parent/2',
                                   ['Abstraction', 'Thought'], "true"),


### PR DESCRIPTION
## Summary

Starts the narrow Phase C4 implementation from
`docs/proposals/WAM_CLOJURE_LMDB_FACT_ACCESS_PLAN.md` by adding shared
cache policy support above the existing Clojure/JVM LMDB reader seam.

This does **not** change the native LMDB store abstraction. The raw
reader lifecycle remains separate from cache policy:

- native LMDB transaction/cursor ownership stays in `LmdbArtifactStore`
- thread-local reader reuse stays in `LmdbArtifactReader`
- shared cache policy is layered above that seam

## What Changed

- extends the JVM LMDB helper reader with additional cache policies:
  - `shared`
  - `two_level`
- keeps existing policies:
  - `none`
  - `memoize`
- adds shared `lookupArg1` caching in `LmdbArtifactReader`
- adds composed L1+L2 behavior for `two_level`
- keeps scan behavior unchanged
- extends the Clojure benchmark generator to accept the broader
  relation-local cache policy surface for LMDB-backed `category_parent`
- updates generated Clojure projects so the LMDB path can select:
  - `open`
  - `openMemoized`
  - `openSharedCached`
  - `openTwoLevel`
- updates generated manifests to record the selected cache policy

## Tests

Verified locally with:

- `sh examples/scala_lmdb_jni_probe/build.sh`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`
- `git diff --check`

Coverage now includes:

- generated `openSharedCached` wiring
- generated `openTwoLevel` wiring
- manifest `:cache_policy` coverage for shared and two-level modes
- runtime execution on the two-level LMDB-backed path

## Design Notes

This PR intentionally keeps the scope narrow:

- it adds shared cache policy support
- it does **not** attempt shared invalidation policy
- it does **not** attempt memory budgeting policy
- it does **not** declare a default winner among `none`, `memoize`,
  `shared`, and `two_level`

That comparison is now explicitly documented as a desktop-only
measurement TODO. Termux is adequate for correctness and integration
checks here, but not the right place to settle cache-policy defaults.

## Follow-up

- benchmark `none` vs `memoize` vs `shared` vs `two_level` on desktop
- decide whether any cache policy should become the preferred default
- only then consider deeper shared-cache controls such as invalidation
  and memory-budget handling
