### PR TITLE
feat(wam-haskell): L2 capacity user override + enwiki-10k validation

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -3702,6 +3702,18 @@ emit_inline_fact_literal(ListName, Tuples, Code) :-
 %                           L1, high-overlap workloads benefit from
 %                           cross-HEC sharing via L2.
 %
+%    lmdb_cache_l2_capacity_bytes(N) — override the auto-detected
+%                           L2 capacity.  N is the desired byte
+%                           budget; the runtime divides by ~32
+%                           bytes per entry and rounds down to a
+%                           power of two.  Only meaningful when L2
+%                           is active (sharded or two_level);
+%                           ignored otherwise.  Useful when the
+%                           /proc/meminfo-based default is too small
+%                           (server with 64 GB RAM but auto caps at
+%                           1M entries) or too large (memory-tight
+%                           container).
+%
 %    All cache modes are gated by lmdb_layout(dupsort); ignored
 %    otherwise.  Modes are mutually exclusive; precedence when
 %    multiple flags are set is two_level > sharded > memoize >
@@ -3750,12 +3762,23 @@ generate_lmdb_functions(Options, Code) :-
     % Legacy memoize section in the template is not used in Phase 2;
     % the sharded IOArray implementation lives under lmdb_cache_l2.
     CacheMemoize   = false,
+    % L2 capacity user override (bytes).  0 means "use the
+    % memory-aware default"; any positive integer overrides it.
+    % Mustache treats 0 as falsy so the {{#lmdb_l2_capacity_bytes}}
+    % section only fires for the override case.
+    (   option(lmdb_cache_l2_capacity_bytes(Bytes), Options),
+        integer(Bytes), Bytes > 0,
+        CacheL2 == true
+    ->  L2CapacityBytes = Bytes
+    ;   L2CapacityBytes = 0
+    ),
     render_template(Template,
                     [lmdb_dupsort=Dupsort,
                      lmdb_cache_memoize=CacheMemoize,
                      lmdb_cache_l1=CacheL1,
                      lmdb_cache_l2=CacheL2,
-                     lmdb_cache_two_level=CacheTwoLevel],
+                     lmdb_cache_two_level=CacheTwoLevel,
+                     lmdb_l2_capacity_bytes=L2CapacityBytes],
                     Code).
 
 %% maybe_parallelize_instrs(+PredIndicator, +Options, +InstrExprs0, -InstrExprs)

--- a/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
+++ b/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
@@ -362,6 +362,7 @@ data L2Entry
     = L2Empty
     | L2Entry {-# UNPACK #-} !Int [Int]   -- stored key + values
 
+{{^lmdb_l2_capacity_bytes}}
 -- | Read /proc/meminfo MemAvailable on Linux.  Falls back to 1 GB if
 -- the file is unreadable (non-Linux or sandboxed environment).  This
 -- is best-effort sizing; the user can override via
@@ -393,7 +394,27 @@ l2MemoryBudgetBytes = do
         halfBytes   = available `div` 2
         budget      = min halfBytes (available - bufferBytes)
     return $! max 0 budget
+{{/lmdb_l2_capacity_bytes}}
 
+-- | Round @n@ down to the nearest power of two (≥ 1).
+roundDownPow2 :: Int -> Int
+roundDownPow2 n
+  | n <= 1    = 1
+  | otherwise = go 1
+  where
+    go x | x * 2 > n = x
+         | otherwise = go (x * 2)
+
+{{#lmdb_l2_capacity_bytes}}
+-- | L2 capacity (entries): user-specified via the Prolog option
+-- lmdb_cache_l2_capacity_bytes/1.  Bytes are converted to entries
+-- using the same ~32-byte-per-L2Entry estimate the auto-detect
+-- path uses, then rounded down to a power of two so the
+-- @key .&. (cap-1)@ slot index works.  Auto-detect is bypassed.
+defaultL2Capacity :: IO Int
+defaultL2Capacity = return $! roundDownPow2 ({{lmdb_l2_capacity_bytes}} `div` 32)
+{{/lmdb_l2_capacity_bytes}}
+{{^lmdb_l2_capacity_bytes}}
 -- | Default L2 capacity in entries: derived from the memory budget,
 -- ~32 bytes per L2Entry, rounded down to a power of two, bounded
 -- [1024, 1M] entries.  Can be overridden by the Prolog option
@@ -405,13 +426,7 @@ defaultL2Capacity = do
         rawEntries    = budget `div` bytesPerEntry
         bounded       = max 1024 (min 1048576 rawEntries)
     return $! roundDownPow2 bounded
-  where
-    roundDownPow2 n
-      | n <= 1    = 1
-      | otherwise = go 1
-      where
-        go x | x * 2 > n = x
-             | otherwise = go (x * 2)
+{{/lmdb_l2_capacity_bytes}}
 
 -- | Allocate the shared L2 cache.  Capacity must be a power of two
 -- (caller's responsibility; defaultL2Capacity guarantees this, and

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1441,6 +1441,51 @@ test_b1_lmdb_cache_default_no_l2 :-
     ;   fail_test(Test, 'L2 unexpectedly emitted in default mode')
     ).
 
+test_b1_lmdb_cache_l2_capacity_override :-
+    Test = 'B1: lmdb_cache_l2_capacity_bytes overrides auto-detect',
+    (   compile_wam_runtime_to_haskell(
+            [use_lmdb(true),
+             lmdb_layout(dupsort),
+             lmdb_cache_mode(sharded),
+             lmdb_cache_l2_capacity_bytes(67108864)], [], Code),  % 64 MB
+        atom_string(Code, S),
+        % override branch emits a constant-return defaultL2Capacity
+        sub_string(S, _, _, _, "user-specified"),
+        sub_string(S, _, _, _, "67108864 `div` 32"),
+        % the auto-detect branch should NOT be emitted
+        \+ sub_string(S, _, _, _, "l2MemoryBudgetBytes")
+    ->  pass(Test)
+    ;   fail_test(Test, 'L2 capacity override not emitted as expected')
+    ).
+
+test_b1_lmdb_cache_l2_capacity_default_when_unset :-
+    Test = 'B1: L2 capacity falls back to auto-detect when not specified',
+    (   compile_wam_runtime_to_haskell(
+            [use_lmdb(true),
+             lmdb_layout(dupsort),
+             lmdb_cache_mode(sharded)], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "l2MemoryBudgetBytes"),
+        \+ sub_string(S, _, _, _, "user-specified")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Auto-detect path not emitted by default')
+    ).
+
+test_b1_lmdb_cache_l2_capacity_ignored_without_l2 :-
+    Test = 'B1: lmdb_cache_l2_capacity_bytes ignored when L2 not active',
+    (   compile_wam_runtime_to_haskell(
+            [use_lmdb(true),
+             lmdb_layout(dupsort),
+             lmdb_cache_mode(per_hec),
+             lmdb_cache_l2_capacity_bytes(67108864)], [], Code),
+        atom_string(Code, S),
+        % L2 is not active (per_hec only) so override should not fire
+        \+ sub_string(S, _, _, _, "user-specified"),
+        \+ sub_string(S, _, _, _, "67108864")
+    ->  pass(Test)
+    ;   fail_test(Test, 'L2 override unexpectedly emitted without L2')
+    ).
+
 test_b1_lmdb_dupsort_alone_no_memoize :-
     Test = 'B1: dupsort without lmdb_cache_mode does not emit memoising lookup',
     (   compile_wam_runtime_to_haskell(
@@ -1617,6 +1662,9 @@ run_tests :-
     test_b1_lmdb_cache_sharded_emitted,
     test_b1_lmdb_cache_two_level_emitted,
     test_b1_lmdb_cache_default_no_l2,
+    test_b1_lmdb_cache_l2_capacity_override,
+    test_b1_lmdb_cache_l2_capacity_default_when_unset,
+    test_b1_lmdb_cache_l2_capacity_ignored_without_l2,
     test_b1_external_source_skips_wam_compilation,
     test_b1_external_source_default_allow_list,
     test_b1_external_source_off_without_use_lmdb,


### PR DESCRIPTION
  ## Summary

  Two related items on one branch:

  1. **`lmdb_cache_l2_capacity_bytes/1` user override** — closes the L2-capacity-override commitment from the
  cache-tiers proposal. Users can now opt up (server with 64 GB RAM) or down (memory-tight container) from the
  auto-detected default.

  2. **enwiki-10k four-way benchmark** — bumps the Phase 2 validation from 1000 seeds to 10000, where the cache modes'
  relative advantages become visible above noise.

  ## The override

  ```prolog
  % Use 64 MB regardless of /proc/meminfo
  [lmdb_layout(dupsort), lmdb_cache_mode(sharded),
   lmdb_cache_l2_capacity_bytes(67108864)]
  ```

  Bytes are divided by ~32 bytes/entry and rounded down to a power of two. Gated by L2 being active (`sharded` or
  `two_level`); ignored for `per_hec` or no-cache modes.

  Implementation: a `{{#lmdb_l2_capacity_bytes}}` mustache section emits a constant-return `defaultL2Capacity` when set;
   the auto-detect helpers (`readMemAvailableBytes`, `l2MemoryBudgetBytes`) live inside the inverse section and aren't
  emitted when the override is in effect.

  Three new B1 tests verify all three states (override active, auto-detect, override ignored without L2).

  ## Enwiki-10k benchmark — surprising finding

  10000 seeds reaching root 97688913, warm cache, alternating order, +RTS -N4 -A32M, 3 rounds:

  | Mode | Avg query_ms | vs BASE |
  |------|--------------|---------|
  | BASE | ~137 | 1.00× |
  | L1 (per_hec) | ~130 | 1.05× |
  | **L2 (sharded)** | **~124** | **1.10×** |
  | two_level | ~130 | 1.05× |

  **L2 wins consistently** across all three rounds (124, 119, 129 — all below the others' 130-140 range).

  **Surprise**: `two_level` does NOT pull ahead at this scale; it ties L1. The proposal's hypothesis was that
  `two_level` would dominate at scale. The likely explanation: Wikipedia category traversal has heavy *cross-thread*
  reuse (all threads converge on the same ancestor chain through a shared root), so the per-HEC L1 layer adds overhead
  without catching FFI savings — those savings live at L2. On this DFS-with-common-root workload the sweet spot is plain
   `sharded`.

  This is workload-dependent. Workloads with intra-thread reuse patterns (each thread re-touching its own keys without
  other threads needing them) would still favour `two_level`. The principled answer is the cost-analysis hook in the
  proposal's Phase 3 — for now, document the finding and let users pick.

  ## Recommendation update

  Default cache choice for DFS-style queries with shared-ancestor structure: **`sharded`** (not `two_level` as the
  proposal initially suggested).
  - `per_hec` for workloads where intra-thread reuse dominates
  - `two_level` only when both intra- and inter-thread reuse are present (rare in practice)
  - `sharded` for the common case

  Will fold this into the proposal doc as a follow-up.

  ## Test plan
  - [x] `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl` — all pass (3 new override tests)
  - [x] Generate enwiki-10k seeds reaching root 97688913 (10000/10000 successful)
  - [x] Build all four binaries (BASE/L1/L2/two_level)
  - [x] Four-way alternating-order benchmark at -N4: all produce 10000 correct tuples; L2 consistently fastest

  🤖 Generated with [Claude Code](https://claude.com/claude-code)