### PR TITLE
test(wam-c): cover real structure-index executable path

### DIFF
--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -280,6 +280,16 @@ test_real_prolog_multiclause_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_real_prolog_structure_index_executable_smoke :-
+    Test = 'WAM-C: real Prolog structure-index executable smoke',
+    (   gcc_available
+    ->  (   run_real_prolog_structure_index_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'real Prolog structure-index executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 gcc_available :-
     catch(process_create(path(gcc), ['--version'],
                          [stdout(null), stderr(null), process(Pid)]),
@@ -395,6 +405,34 @@ run_real_prolog_multiclause_executable_smoke :-
         run_c_smoke_plain(ExePath)
     ->  retractall(user:wam_c_real_multi(_, _))
     ;   retractall(user:wam_c_real_multi(_, _)),
+        fail
+    ).
+
+run_real_prolog_structure_index_executable_smoke :-
+    assertz((user:wam_c_real_struct(foo(_), foo) :- true)),
+    assertz((user:wam_c_real_struct(bar(_), bar) :- true)),
+    (   compile_predicate_to_wam(user:wam_c_real_struct/2, [], WamCode),
+        sub_string(WamCode, _, _, _, 'switch_on_structure'),
+        sub_string(WamCode, _, _, _, 'foo/1:default'),
+        sub_string(WamCode, _, _, _, 'bar/1:'),
+        compile_wam_predicate_to_c(user:wam_c_real_struct/2, WamCode, [], PredCode),
+        compile_wam_runtime_to_c([], RuntimeCode),
+        get_time(Now),
+        Stamp is round(Now * 1000000),
+        format(atom(TmpBase), '/tmp/unifyweaver_wam_c_real_struct_smoke_~w', [Stamp]),
+        format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+        format(atom(PredPath), '~w_pred.c', [TmpBase]),
+        format(atom(MainPath), '~w_main.c', [TmpBase]),
+        format(atom(ExePath), '~w_bin', [TmpBase]),
+        write_text_file(RuntimePath, RuntimeCode),
+        format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+        write_text_file(PredPath, PredTranslationUnit),
+        wam_c_real_struct_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  retractall(user:wam_c_real_struct(_, _))
+    ;   retractall(user:wam_c_real_struct(_, _)),
         fail
     ).
 
@@ -633,6 +671,54 @@ int main(void) {
 }
 ').
 
+wam_c_real_struct_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_real_struct_2(WamState* state);
+
+static WamValue make_test_structure_1(WamState *state, const char *functor, WamValue arg) {
+    WamValue structure;
+    structure.tag = VAL_STR;
+    structure.data.ref_addr = state->H;
+    state->H_array[state->H++] = val_atom(functor);
+    state->H_array[state->H++] = arg;
+    return structure;
+}
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_real_struct_2(&state);
+
+    WamValue foo_term = make_test_structure_1(&state, "foo/1", val_int(1));
+    WamValue foo_args[2] = { foo_term, val_atom("foo") };
+    int foo_rc = wam_run_predicate(&state, "wam_c_real_struct/2", foo_args, 2);
+    if (foo_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue bar_term = make_test_structure_1(&state, "bar/1", val_atom("x"));
+    WamValue bar_args[2] = { bar_term, val_atom("bar") };
+    int bar_rc = wam_run_predicate(&state, "wam_c_real_struct/2", bar_args, 2);
+    if (bar_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue baz_term = make_test_structure_1(&state, "baz/1", val_int(3));
+    WamValue fail_args[2] = { baz_term, val_atom("baz") };
+    int fail_rc = wam_run_predicate(&state, "wam_c_real_struct/2", fail_args, 2);
+    if (fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 implemented_wam_c_cases(Cases) :-
     compile_step_wam_to_c([], Code),
     atom_string(Code, S),
@@ -702,6 +788,7 @@ run_tests_once :-
     test_builtin_call_executable_smoke,
     test_real_prolog_builtin_executable_smoke,
     test_real_prolog_multiclause_executable_smoke,
+    test_real_prolog_structure_index_executable_smoke,
     format('~n=== WAM-C Target Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).
 


### PR DESCRIPTION
## Summary

- Add a WAM-C executable smoke that starts from a real Prolog predicate with compound first-argument clauses.
- Verify generated `switch_on_structure` output through WAM-C code generation and native executable execution.
- Cover successful `foo/1` and `bar/1` structure dispatch plus a failure case for unmatched `baz/1`.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
