### PR TITLE
feat(wam-haskell): Phase 3 scaffold — lmdb_cache_mode(auto) hook

### DIFF
--- a/src/unifyweaver/core/statistics.pl
+++ b/src/unifyweaver/core/statistics.pl
@@ -12,8 +12,18 @@
     get_stats/2,            % get_stats(+Pred, -Stats)
     clear_stats/1,          % clear_stats(+Pred)
     load_stats/1,           % load_stats(+Path)
-    
-    estimate_cost/4         % estimate_cost(+Goal, +BoundVars, +Pred, -Cost)
+
+    estimate_cost/4,        % estimate_cost(+Goal, +BoundVars, +Pred, -Cost)
+
+    % --- Phase 3 scaffolding: cache mode auto-select ---
+    % Optional hints for choosing an LMDB cache mode in the WAM
+    % Haskell target.  The hints describe a workload's reuse
+    % pattern; the selector maps that to a cache mode.  See
+    % docs/proposals/WAM_HASKELL_LMDB_CACHE_TIERS.md Phase 3.
+    declare_cache_hints/1,  % declare_cache_hints(+Hints)
+    get_cache_hints/1,      % get_cache_hints(-Hints)
+    clear_cache_hints/0,    % clear_cache_hints
+    select_cache_mode/2     % select_cache_mode(+DefaultMode, -Mode)
 ]).
 
 :- use_module(library(lists)).
@@ -160,3 +170,84 @@ count_bound_fields(Fields, BoundVars, Count) :-
 
 var_member(V, [H|_]) :- V == H, !.
 var_member(V, [_|T]) :- var_member(V, T).
+
+% ============================================================================
+% PHASE 3 SCAFFOLDING: CACHE MODE AUTO-SELECT
+% ============================================================================
+%
+% Workload-level hints that describe the *shape* of cache reuse,
+% not its quantity.  Used by the WAM Haskell target to pick an
+% lmdb_cache_mode automatically when the user passes
+% lmdb_cache_mode(auto).  This is infrastructure: the hints must
+% currently be supplied by the user (or a future analyzer tool);
+% the codegen does not compute them itself.
+%
+% Hints schema (all fields optional except reuse_axis):
+%
+%   cache_hints{
+%       reuse_axis: none | intra_thread | cross_thread | mixed,
+%       overlap_factor: Float in [0.0, 1.0]   % approx fraction of
+%                                             % accesses that are
+%                                             % cache hits when warm
+%       expected_unique_keys: Int             % helps L2 sizing
+%   }
+%
+% reuse_axis → mode mapping (per the workload-shape table in the
+% cache-tiers proposal, validated by enwiki-10k measurement):
+%
+%   none          → none      (cache infrastructure costs more
+%                              than it saves)
+%   intra_thread  → per_hec   (each spark re-touches its own
+%                              keys; per-HEC L1 catches them
+%                              with zero synchronisation)
+%   cross_thread  → sharded   (threads converge on shared keys;
+%                              the lock-free L2 catches every
+%                              cross-thread hit, and L1 would
+%                              just add overhead)
+%   mixed         → two_level (both axes present; L1 absorbs
+%                              hot intra-thread reuse, L2 picks
+%                              up the cross-thread hits)
+
+% stored as a single workload-level entry; cache mode is a
+% process-wide decision, not per-predicate.
+:- dynamic stored_cache_hints/1.
+
+%% declare_cache_hints(+Hints)
+%  Set workload-level cache hints.  Replaces any previous hints.
+%  Hints is the cache_hints dict described above.
+declare_cache_hints(Hints) :-
+    retractall(stored_cache_hints(_)),
+    assertz(stored_cache_hints(Hints)).
+
+%% get_cache_hints(-Hints)
+%  Retrieve the current workload-level cache hints.  Fails if none
+%  have been declared.
+get_cache_hints(Hints) :-
+    stored_cache_hints(Hints).
+
+%% clear_cache_hints
+%  Remove any workload-level cache hints.
+clear_cache_hints :-
+    retractall(stored_cache_hints(_)).
+
+%% select_cache_mode(+DefaultMode, -Mode)
+%  Pick an lmdb_cache_mode based on the current cache hints.  If
+%  no hints have been declared, returns DefaultMode.  Otherwise
+%  maps hints.reuse_axis to a mode per the table above.
+%
+%  DefaultMode is one of: none, per_hec, sharded, two_level.
+%  The fallback exists so callers can ship a sensible default
+%  when no hints are available (typically `none` or `sharded`
+%  depending on the broader workload class).
+select_cache_mode(DefaultMode, Mode) :-
+    (   stored_cache_hints(Hints),
+        get_dict(reuse_axis, Hints, Axis),
+        reuse_axis_to_mode(Axis, Mode)
+    ->  true
+    ;   Mode = DefaultMode
+    ).
+
+reuse_axis_to_mode(none,         none).
+reuse_axis_to_mode(intra_thread, per_hec).
+reuse_axis_to_mode(cross_thread, sharded).
+reuse_axis_to_mode(mixed,        two_level).

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -57,6 +57,8 @@
 :- use_module('../core/template_system', [render_template/3]).
 :- use_module('../core/purity_certificate',
              [analyze_predicate_purity/2]).
+:- use_module('../core/statistics',
+             [select_cache_mode/2]).
 
 % Phase 3: the real lowerability check and emission helpers live in the
 % wam_haskell_lowered_emitter module. We reexport so existing callers can
@@ -3714,6 +3716,19 @@ emit_inline_fact_literal(ListName, Tuples, Code) :-
 %                           1M entries) or too large (memory-tight
 %                           container).
 %
+%    lmdb_cache_mode(auto) — Phase 3 hook: defer the choice of
+%                           cache mode to statistics:select_cache_mode/2.
+%                           Users populate workload-level hints via
+%                           statistics:declare_cache_hints/1 (see
+%                           reuse_axis → mode mapping in
+%                           src/unifyweaver/core/statistics.pl).
+%                           When no hints are declared, falls back
+%                           to `none` (no cache).  Infrastructure-
+%                           only: codegen does not currently compute
+%                           the hints; future work will add an
+%                           analyzer that derives them from a
+%                           sample run.
+%
 %    All cache modes are gated by lmdb_layout(dupsort); ignored
 %    otherwise.  Modes are mutually exclusive; precedence when
 %    multiple flags are set is two_level > sharded > memoize >
@@ -3726,6 +3741,20 @@ emit_inline_fact_literal(ListName, Tuples, Code) :-
 %    uses a lock-free IOArray and does not have this problem.  The
 %    PARALLELISM CAVEAT applies only if you explicitly want the
 %    legacy behaviour.
+%% resolve_auto_cache_mode(-Mode)
+%  Phase 3 hook: consult statistics:select_cache_mode/2 with the
+%  default fallback `none`.  Users populate workload-level hints via
+%  statistics:declare_cache_hints/1 before invoking the codegen;
+%  when no hints are declared, this returns `none` and the user
+%  effectively gets the bare dupsort path.
+%
+%  Kept as a thin wrapper here (rather than inlined) so the
+%  default fallback policy is documented in one place and easy to
+%  change later (e.g. flip the default from `none` to `sharded`
+%  once auto-detection of workload class is added).
+resolve_auto_cache_mode(Mode) :-
+    select_cache_mode(none, Mode).
+
 generate_lmdb_functions(Options, Code) :-
     read_kernel_template('lmdb_fact_source.hs.mustache', Template),
     (   option(lmdb_layout(dupsort), Options)
@@ -3735,8 +3764,16 @@ generate_lmdb_functions(Options, Code) :-
     % Two-level wins over all single-tier modes; sharded next; then
     % per_hec; the deprecated memoize is treated like sharded for
     % the new IOArray implementation (older IntMap is gone).
-    (   option(lmdb_cache_mode(Mode), Options),
-        member(Mode, [two_level, sharded, per_hec, memoize]),
+    %
+    % `auto` consults statistics:select_cache_mode/2 with default
+    % `none`; users can populate workload hints via
+    % statistics:declare_cache_hints/1.  See Phase 3 in
+    % docs/proposals/WAM_HASKELL_LMDB_CACHE_TIERS.md.
+    (   option(lmdb_cache_mode(auto), Options),
+        Dupsort == true
+    ->  resolve_auto_cache_mode(ChosenMode)
+    ;   option(lmdb_cache_mode(Mode), Options),
+        member(Mode, [two_level, sharded, per_hec, memoize, none]),
         Dupsort == true
     ->  ChosenMode = Mode
     ;   ChosenMode = none

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1486,6 +1486,72 @@ test_b1_lmdb_cache_l2_capacity_ignored_without_l2 :-
     ;   fail_test(Test, 'L2 override unexpectedly emitted without L2')
     ).
 
+test_b1_lmdb_cache_auto_no_hints_falls_back_to_none :-
+    Test = 'B1: lmdb_cache_mode(auto) with no hints emits no cache',
+    (   statistics:clear_cache_hints,
+        compile_wam_runtime_to_haskell(
+            [use_lmdb(true),
+             lmdb_layout(dupsort),
+             lmdb_cache_mode(auto)], [], Code),
+        atom_string(Code, S),
+        \+ sub_string(S, _, _, _, "L1Cache"),
+        \+ sub_string(S, _, _, _, "L2Cache"),
+        \+ sub_string(S, _, _, _, "lmdbL1EdgeLookup"),
+        \+ sub_string(S, _, _, _, "lmdbL2EdgeLookup")
+    ->  pass(Test)
+    ;   fail_test(Test,
+            'auto with no hints unexpectedly emitted cache code')
+    ).
+
+test_b1_lmdb_cache_auto_intra_thread_picks_per_hec :-
+    Test = 'B1: lmdb_cache_mode(auto) + intra_thread hint → per_hec (L1)',
+    (   statistics:clear_cache_hints,
+        statistics:declare_cache_hints(_{reuse_axis: intra_thread}),
+        compile_wam_runtime_to_haskell(
+            [use_lmdb(true),
+             lmdb_layout(dupsort),
+             lmdb_cache_mode(auto)], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "L1Cache"),
+        sub_string(S, _, _, _, "lmdbL1EdgeLookup"),
+        \+ sub_string(S, _, _, _, "L2Cache")
+    ->  pass(Test)
+    ;   fail_test(Test, 'auto + intra_thread did not emit L1-only')
+    ),
+    statistics:clear_cache_hints.
+
+test_b1_lmdb_cache_auto_cross_thread_picks_sharded :-
+    Test = 'B1: lmdb_cache_mode(auto) + cross_thread hint → sharded (L2)',
+    (   statistics:clear_cache_hints,
+        statistics:declare_cache_hints(_{reuse_axis: cross_thread}),
+        compile_wam_runtime_to_haskell(
+            [use_lmdb(true),
+             lmdb_layout(dupsort),
+             lmdb_cache_mode(auto)], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "L2Cache"),
+        sub_string(S, _, _, _, "lmdbL2EdgeLookup"),
+        \+ sub_string(S, _, _, _, "lmdbL1EdgeLookup")
+    ->  pass(Test)
+    ;   fail_test(Test, 'auto + cross_thread did not emit L2-only')
+    ),
+    statistics:clear_cache_hints.
+
+test_b1_lmdb_cache_auto_mixed_picks_two_level :-
+    Test = 'B1: lmdb_cache_mode(auto) + mixed hint → two_level',
+    (   statistics:clear_cache_hints,
+        statistics:declare_cache_hints(_{reuse_axis: mixed}),
+        compile_wam_runtime_to_haskell(
+            [use_lmdb(true),
+             lmdb_layout(dupsort),
+             lmdb_cache_mode(auto)], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "lmdbTwoLevelEdgeLookup")
+    ->  pass(Test)
+    ;   fail_test(Test, 'auto + mixed did not emit two_level')
+    ),
+    statistics:clear_cache_hints.
+
 test_b1_lmdb_dupsort_alone_no_memoize :-
     Test = 'B1: dupsort without lmdb_cache_mode does not emit memoising lookup',
     (   compile_wam_runtime_to_haskell(
@@ -1665,6 +1731,10 @@ run_tests :-
     test_b1_lmdb_cache_l2_capacity_override,
     test_b1_lmdb_cache_l2_capacity_default_when_unset,
     test_b1_lmdb_cache_l2_capacity_ignored_without_l2,
+    test_b1_lmdb_cache_auto_no_hints_falls_back_to_none,
+    test_b1_lmdb_cache_auto_intra_thread_picks_per_hec,
+    test_b1_lmdb_cache_auto_cross_thread_picks_sharded,
+    test_b1_lmdb_cache_auto_mixed_picks_two_level,
     test_b1_external_source_skips_wam_compilation,
     test_b1_external_source_default_allow_list,
     test_b1_external_source_off_without_use_lmdb,


### PR DESCRIPTION
  ## Summary

  Lays the cost-analysis-hook infrastructure for Phase 3 of
  [`WAM_HASKELL_LMDB_CACHE_TIERS.md`](docs/proposals/WAM_HASKELL_LMDB_CACHE_TIERS.md). The eventual reuse-pattern
  analyzer hasn't been built yet — doing this now means cache-mode auto-select is wired and tested when downstream work
  (a sample-based analyzer; the C# target's cost-driven plan selection) needs it. **Less to do later when both targets
  need the same hook.**

  ## What lands

  ### `src/unifyweaver/core/statistics.pl` — new exports
  - `declare_cache_hints/1` — workload-level hint storage
  - `get_cache_hints/1` — retrieve current hints
  - `clear_cache_hints/0` — drop hints
  - `select_cache_mode/2` — `hints → mode` mapping with default fallback

  ### `src/unifyweaver/targets/wam_haskell_target.pl`
  - New option `lmdb_cache_mode(auto)`
  - `resolve_auto_cache_mode/1` helper consults `statistics:select_cache_mode/2`

  ### `tests/test_wam_haskell_target.pl` — four new B1 tests
  - auto with no hints → no cache emitted (fallback to `none`)
  - auto + `intra_thread` → L1 emitted
  - auto + `cross_thread` → L2 emitted
  - auto + `mixed` → two_level emitted

  ## Hint schema

  ```prolog
  cache_hints{
      reuse_axis: none | intra_thread | cross_thread | mixed,
      overlap_factor: Float in [0.0, 1.0],   % optional, reserved
      expected_unique_keys: Int              % optional, reserved
  }
  ```

  ## reuse_axis → mode mapping

  Implements the workload-shape table from [PR #1654](../pull/1654) (the proposal-doc update), grounded in the
  enwiki-10k measurement:

  | reuse_axis | mode | rationale |
  |------------|------|-----------|
  | `none` | `none` | cache infrastructure costs more than it saves |
  | `intra_thread` | `per_hec` | each spark re-touches its own keys |
  | **`cross_thread`** | **`sharded`** | **threads converge on shared keys** — this beat `two_level` at enwiki-10k |
  | `mixed` | `two_level` | both axes present; rare in practice |

  Default fallback when no hints declared: `none`.

  ## Usage

  ```prolog
  :- use_module(library(statistics)).

  :- statistics:declare_cache_hints(_{reuse_axis: cross_thread}).

  % codegen with auto picks `sharded`:
  write_wam_haskell_project(Predicates,
      [use_lmdb(true),
       lmdb_layout(dupsort),
       lmdb_cache_mode(auto)],
      OutputDir).
  ```

  ## What is NOT in this PR

  - **No automated stats computation.** The analyzer that derives `reuse_axis` from a sample run is future work. Users
  must currently call `statistics:declare_cache_hints/1` explicitly.
  - **No C# target consumption yet.** The hook is at `core/statistics` so any target can read it; only the WAM Haskell
  target wires it today.
  - `overlap_factor` and `expected_unique_keys` are accepted in the hint schema but not yet consumed by the selector.
  Reserved for future fine-grained decisions (e.g. don't cache if `overlap_factor < 0.1`; size L2 from
  `expected_unique_keys`).

  ## Test plan
  - [x] `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl` — all pass; four new auto tests fire correctly
  - [x] No regressions in pre-existing tests
  - [x] Hook is opt-in via `lmdb_cache_mode(auto)`; default codegen behaviour unchanged

  🤖 Generated with [Claude Code](https://claude.com/claude-code)