### PR TITLE
fix(wam-haskell): SetVariable for user-source =../2 compose path

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -1907,6 +1907,12 @@ step !ctx s (SetValue xn) =
     Just val -> addToBuilder val s
     Nothing -> Nothing
 
+step !ctx s (SetVariable xn) =
+  let vid = wsVarCounter s
+      var = Unbound vid
+      s1 = putReg xn var (s { wsVarCounter = vid + 1 })
+  in addToBuilder var s1
+
 step !ctx s (SetConstant c) =
   addToBuilder c s
 
@@ -3367,6 +3373,7 @@ data Instruction
   | PutStructureDyn !RegId !RegId !RegId  -- nameReg, arityReg, targetReg (runtime-parsed)
   | PutList !RegId
   | SetValue !RegId
+  | SetVariable !RegId                  -- builder slot = fresh unbound; also write to register
   | SetConstant Value
   | Allocate
   | Deallocate
@@ -4020,7 +4027,8 @@ wam_instr_to_haskell(["trust_me"], "TrustMe").
 wam_instr_to_haskell(["retry_me_else", Label], Hs) :-
     format(string(Hs), 'RetryMeElse "~w"', [Label]).
 wam_instr_to_haskell(["set_variable", Xn], Hs) :-
-    format(string(Hs), 'SetVariable "~w"', [Xn]).
+    clean_comma(Xn, CXn), reg_name_to_int(CXn, XnI),
+    format(string(Hs), 'SetVariable ~w', [XnI]).
 %% switch_on_constant key1:label1, key2:label2, ...
 wam_instr_to_haskell(["switch_on_constant"|Entries], Hs) :-
     parse_switch_entries(Entries, HsPairs),

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -411,6 +411,37 @@ test_haskell_put_structure_dyn_wam_parse :-
     ;   fail_test(Test, 'put_structure_dyn WAM text not parsed')
     ).
 
+%% SetVariable: builder slot = fresh unbound (used by user-source =../2 list-build path)
+%% ------------------------------------------------------------------------------------
+
+test_haskell_set_variable_in_types :-
+    Test = 'WAM-Haskell: SetVariable constructor takes RegId (not String)',
+    (   wam_haskell_target:generate_wam_types_hs(TypesCode),
+        atom_string(TypesCode, S),
+        sub_string(S, _, _, _, "SetVariable !RegId")
+    ->  pass(Test)
+    ;   fail_test(Test, 'SetVariable !RegId missing from Instruction type')
+    ).
+
+test_haskell_set_variable_step_handler :-
+    Test = 'WAM-Haskell: SetVariable step handler present',
+    (   compile_wam_runtime_to_haskell([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "step !ctx s (SetVariable xn)"),
+        sub_string(S, _, _, _, "Unbound vid")
+    ->  pass(Test)
+    ;   fail_test(Test, 'SetVariable step handler missing or incorrect')
+    ).
+
+test_haskell_set_variable_wam_parse :-
+    Test = 'WAM-Haskell: set_variable WAM text emits Int reg id',
+    (   wam_haskell_target:wam_instr_to_haskell(["set_variable", "X6"], Hs),
+        % X6 -> 106 via reg_name_to_int
+        sub_string(Hs, _, _, _, "SetVariable 106")
+    ->  pass(Test)
+    ;   fail_test(Test, 'set_variable did not emit numeric register id')
+    ).
+
 %% Phase 4.3: findall/bag/set merge strategies
 %% --------------------------------------------
 
@@ -1644,6 +1675,10 @@ run_tests :-
     test_haskell_put_structure_dyn_in_types,
     test_haskell_put_structure_dyn_step_handler,
     test_haskell_put_structure_dyn_wam_parse,
+    %% SetVariable: list-build path used by user-source =../2 compose mode
+    test_haskell_set_variable_in_types,
+    test_haskell_set_variable_step_handler,
+    test_haskell_set_variable_wam_parse,
     %% Phase 4.3: findall/bag/set merge strategies
     test_haskell_findall_bag_set_forkable,
     test_haskell_infer_collect_maps_to_findall,


### PR DESCRIPTION
## Summary

- Adds the missing `SetVariable !RegId` constructor and step handler to the Haskell WAM target so user predicates that call `=../2` with a list literal containing a fresh variable (compose mode) actually compile and run.
- Drops the existing `SetVariable` text-keyed emission in favour of an Int register ID, matching the convention used by every other WAM-instruction parser.
- Adds three regression tests covering the constructor, the runtime step handler, and the codegen parser.

## Background

The Haskell WAM target's `Instruction` ADT had `SetValue !RegId`, `SetConstant Value`, etc., but no `SetVariable` constructor — yet the codegen rule at `wam_instr_to_haskell([\"set_variable\", Xn], …)` emitted `SetVariable \"X6\"` (a literal data-constructor application with a string argument).

Any user-source predicate whose body contained an `=../2` compose pattern such as

```prolog
build_pair(Name, X, Y, T) :- T =.. [Name, X, Y].
```

produced Haskell that GHC rejected at `Predicates.hs`:

```
Not in scope: data constructor 'SetVariable'
```

The breakage was silent in the existing test suite because no end-to-end test exercised the compose-mode list-build path through the templated runtime.

## Changes

### `src/unifyweaver/targets/wam_haskell_target.pl`

- `Instruction` ADT: add `| SetVariable !RegId  -- builder slot = fresh unbound; also write to register`.
- New step handler:
  ```haskell
  step !ctx s (SetVariable xn) =
    let vid = wsVarCounter s
        var = Unbound vid
        s1  = putReg xn var (s { wsVarCounter = vid + 1 })
    in addToBuilder var s1
  ```
  Allocates a fresh `Unbound vid`, writes it to the named register (so subsequent `SetValue`s on the same register see the bound var), and feeds it to the active builder.
- `set_variable` instruction parser: convert WAM register names (`X6`, `Y2`, …) to numeric register IDs via `reg_name_to_int`, matching `SetValue` and friends.

### `tests/test_wam_haskell_target.pl`

Three new tests, wired into the `run_tests` driver next to the existing PutStructureDyn block:

- `test_haskell_set_variable_in_types` — asserts `SetVariable !RegId` appears in the generated `WamTypes.hs`.
- `test_haskell_set_variable_step_handler` — asserts the runtime template emits the `Unbound vid` allocation handler.
- `test_haskell_set_variable_wam_parse` — asserts `set_variable X6` round-trips to `SetVariable 106` (X-bank offset).

## Why we did not also lower `=../2` to `PutStructureDyn` here

`PutStructureDyn` already exists in the WAM and is a strictly faster compose path (no intermediate list, no runtime list-walk), but emitting it eagerly for every `T =.. [Name | Args]` is not safe without mode analysis:

- `PutStructureDyn` requires `Name` to be **bound to an atom at runtime**; if `Name` is unbound, the runtime returns `Nothing` and the goal fails.
- The same Prolog source `T =.. [Name, X, Y]` is used both for **compose** (T fresh, Name bound) and **decompose** (T bound, Name fresh), and the WAM compiler has no static signal distinguishing them.
- Replacing the existing builtin `=../2` path with eager `PutStructureDyn` lowering would silently break every decompose-mode caller.

The existing builtin `=../2` step handler already handles both modes correctly **once `SetVariable` works** (which it now does). The performance lowering is left as a follow-up tied to mode-analysis work; the `PutStructureDyn` instruction stays in place so the compiler can target it later without further runtime changes.

## Validation

- Regenerated the smoke project (`build_pair/4` + `split_pair/4`, both using `T =.. [Name, X, Y]`) into `/tmp/dyn-struct-smoke` and confirmed `cabal v2-build` succeeds end-to-end. Prior to this PR the same regeneration crashed at the `Predicates.hs` compile step.
- `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl` — full suite green, including the three new SetVariable tests and the existing PutStructureDyn block.

## Test plan

- [ ] CI: `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl` passes.
- [ ] Spot-check: regenerate any project whose source uses `=../2` in compose mode and confirm `cabal v2-build` is clean.
- [ ] No regression in `tests/core/test_purity_certificate.pl` (touch points are runtime-only, but worth confirming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)