### PR TITLE
ix(wam): unwrap static M:Goal — closes #1647 Finding 1 end-to-end

### DIFF
--- a/docs/proposals/WAM_ELIXIR_TIER2_FINDALL.md
+++ b/docs/proposals/WAM_ELIXIR_TIER2_FINDALL.md
@@ -1,9 +1,9 @@
 # Elixir WAM findall/aggregate_all proposal
 
-**Status:** Phase 1 (substrate) + Phase 2 (instruction lowering) shipped; Phase 3 (runtime integration) in planning.
-**Target audience:** Perplexity review + Phase 3 implementer.
+**Status:** Phases 1–3 shipped (substrate, instruction lowering, runtime smoke + module-qualifier unwrap). Phase 3c edge cases and Phase 4 (parallel branch-local accum) remain.
+**Target audience:** Perplexity review + Phase 3c / Phase 4 implementer.
 **Depends on:** PR #1586 (Tier-2 substrate), PR #1608 (`par_wrap_segment/4`), PR #1624 (Tier-2 wiring activation), PR #1626 (this proposal).
-**Shipped:** PR #1627 (substrate — `push_aggregate_frame/4`, `aggregate_collect/2`, `finalise_aggregate/4`, `backtrack/1` dispatch). PR #1643 (instruction lowering — `begin_aggregate` / `end_aggregate` parser + `wam_elixir_lower_instr/6` clauses + `agg_type_atom/2` translation).
+**Shipped:** PR #1627 (substrate — `push_aggregate_frame/4`, `aggregate_collect/2`, `finalise_aggregate/4`, `backtrack/1` dispatch). PR #1643 (instruction lowering). PR #1647 / #1649 (Phase 3a/3b runtime smoke). PR #1650 (`compile_findall` Y-reg fix). The current PR (static module-qualifier unwrap in `compile_goal_call/4` + `compile_goal_execute/4`) closes Finding 1 from #1647 end-to-end.
 
 ## 0. Implementation status
 
@@ -11,7 +11,12 @@
 |---|---|---|
 | Phase 1 | Runtime substrate (4 helpers + backtrack dispatch) | ✅ Shipped #1627 |
 | Phase 2 | `begin_aggregate` / `end_aggregate` lowering + `:collect → :findall` translation | ✅ Shipped #1643 |
-| Phase 3 | Runtime integration tests; cross-validation against Haskell parity reference | ⏳ Planning |
+| Phase 3a | Runtime harness + first scenario (3-clause sequential findall) | ✅ Shipped #1647 |
+| Phase 3b | Runtime aggregator coverage (8 scenarios spanning `:findall` / `:count` / `:bag` / `:set` / `:max` / `:min`) | ✅ Shipped #1649 |
+| WAM-compiler fix | `compile_findall` Y-reg allocation (Finding 1, byte-shape) | ✅ Shipped #1650 |
+| Static module-qualifier unwrap | `compile_goal_call/4` + `compile_goal_execute/4` recognise `M:Goal` with atom/string M (Finding 1, end-to-end runtime closure) | ✅ This PR |
+| Phase 3c | Edge cases — single-clause, Y-register Template deep-copy probe (§6 risk #1), cut in inner goal (§6 risk #3), nested findall (§6 risk #7) | ⏳ Next |
+| Phase 4 | Tier-2 × findall — branch-local-accum protocol from Haskell | ⏳ Future |
 
 Deviations from the proposal as written, documented in commits and code:
 
@@ -261,6 +266,7 @@ The Tier-2 substrate from PR #1586 stays inert (as it has been) — `in_forkable
 - **Compile-time inlining of small enumerable sources** (e.g. `findall(X, member(X, [a,b,c]), L)` → directly emit `L = ["a","b","c"]`). Worthwhile peephole opt, separate proposal.
 - **Nested-parallel branch-local accumulators** (§6 risk #2 update). Phase 4 territory — needs the per-branch local-accum + parent-merge pattern from Haskell when a Tier-2 fan-out branch contains its own findall.
 - **`MergeStrategy` separation from `agg_type`.** Haskell's `inferMergeStrategy` (§11) splits "what is the aggregate" from "how do parallel branches combine results" — necessary once Phase 4 introduces parallel-under-aggregate.
+- **Dynamic `Module:Goal` meta-call on the Elixir runtime.** The static-module-qualifier unwrap in `compile_goal_call/4` / `compile_goal_execute/4` handles the common case (`findall(X, user:p(X), L)`) at compile time — `M:Goal` with atom or string `M` recursively compiles to a regular `call p/Arity, N`, identical to the unqualified case. The dynamic case (`Module = m, Module:Goal` where `M` is a Prolog variable at compile time) still routes through the `:/2` builtin, which `WamRuntime.execute_builtin/3` does not implement (catch-all returns `:fail`). When the dynamic case actually surfaces in a real predicate, the correct runtime fix is the CP-frame extension to `backtrack/1` — install a meta-call frame at `:/2` entry that backtracking knows to handle by re-entering the call site for each enumerated solution. This is workaround #2 from the design analysis Perplexity reviewed prior to this PR; it's an architectural change (meta-call as a first-class CP type, like aggregate frames are today), not a bug fix. Other targets (Rust / Go / LLVM / Haskell) have native `:/2` runtime support and handle the dynamic case directly. No existing test predicate uses dynamic meta-call.
 
 ## 11. Cross-target precedent (Haskell)
 

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -848,6 +848,23 @@ allocate_var(Var, VIn, VOut, Reg) :-
         Reg = XReg
     ).
 
+% Static module qualifier unwrap. UnifyWeaver's targets resolve
+% predicates by name only — there is no per-module dispatch table —
+% so `M:p(X)` with a static atom (or string) module name is
+% semantically identical to `p(X)`. Recursively compiling the inner
+% goal emits a regular `call p/Arity, N` instead of routing through
+% the `:/2` builtin path. Cross-target win: every target avoids the
+% meta-call overhead (heap walk for the goal structure, register
+% shuffling, dispatch table lookup) on the common static-qualifier
+% case. The dynamic case (`Module = m, Module:p(X)`) where M is a
+% Prolog variable at compile time still falls through to `:/2` —
+% that genuinely needs a module registry which no target has yet.
+% String + atom guard per #1647 follow-up review (Perplexity)
+% covers any code path that represents module names as strings.
+compile_goal_call(M:InnerGoal, V0, Vf, Code) :-
+    (atom(M) ; string(M)),
+    !,
+    compile_goal_call(InnerGoal, V0, Vf, Code).
 compile_goal_call(Goal, V0, Vf, Code) :-
     Goal =.. [Pred|Args],
     length(Args, Arity),
@@ -861,6 +878,10 @@ compile_goal_call(Goal, V0, Vf, Code) :-
     ;   format(string(Code), "~w~n~w", [PutCode, CallCode])
     ).
 
+compile_goal_execute(M:InnerGoal, V0, Vf, Code) :-
+    (atom(M) ; string(M)),
+    !,
+    compile_goal_execute(InnerGoal, V0, Vf, Code).
 compile_goal_execute(Goal, V0, Vf, Code) :-
     Goal =.. [Pred|Args],
     length(Args, Arity),

--- a/tests/test_wam_elixir_lowered_phase3.pl
+++ b/tests/test_wam_elixir_lowered_phase3.pl
@@ -129,15 +129,16 @@ user:phase3_set(S) :- aggregate_all(set(X), phase3_smoke_p(X), S).
 user:phase3_max(M) :- aggregate_all(max(X), phase3_smoke_p(X), M).
 user:phase3_min(M) :- aggregate_all(min(X), phase3_smoke_p(X), M).
 
-% Module-qualified findall — `findall(X, user:p(X), L)` — would test
-% the Finding 1 fix from #1647 end-to-end, but is currently blocked
-% by a separate Elixir-runtime gap: WamRuntime.execute_builtin/3
-% doesn't implement `:/2` (the meta-call dispatcher). The WAM-side
-% fix in compile_aggregate_all/5 IS correct (Y-reg now used for
-% findall regardless of inner-goal shape — verified at the WAM
-% byte-shape level in tests/test_wam_elixir_target.pl). End-to-end
-% runtime validation deferred until `:/2` is implemented in the
-% Elixir runtime — separate Phase 3c follow-up.
+% Scenario 9: module-qualified findall, end-to-end — closes Finding 1
+% from #1647. The static-module-qualifier unwrap in compile_goal_call/4
+% (this PR) emits a regular `call phase3_smoke_p/1` for the inner
+% goal instead of routing through the `:/2` builtin path, so the
+% Elixir runtime never sees `:/2` and never hits its catch-all
+% `_ -> :fail`. Functionally equivalent to scenario 1 once the
+% unwrap fires. Dynamic module qualifiers (Module = m, Module:p(X))
+% still hit `:/2` and remain a known limitation — see
+% WAM_ELIXIR_TIER2_FINDALL.md for the forward reference.
+user:phase3_findall_qualified(L) :- findall(X, user:phase3_smoke_p(X), L).
 
 %% tmp_root — try TMPDIR / TMP / TEMP / $PREFIX/tmp / ./output in
 %% order. Same fallback chain as the existing benchmark harness.
@@ -178,7 +179,8 @@ phase3_predicates([
     user:phase3_bag/1,
     user:phase3_set/1,
     user:phase3_max/1,
-    user:phase3_min/1
+    user:phase3_min/1,
+    user:phase3_findall_qualified/1
 ]).
 
 %% phase3_driver_invocations(-Lines)
@@ -201,7 +203,9 @@ phase3_driver_invocations([
     'r7 = Phase3Smoke.Phase3Max.run([{:unbound, make_ref()}])',
     'IO.inspect(r7, label: "SCENARIO_AGG_MAX", charlists: :as_lists)',
     'r8 = Phase3Smoke.Phase3Min.run([{:unbound, make_ref()}])',
-    'IO.inspect(r8, label: "SCENARIO_AGG_MIN", charlists: :as_lists)'
+    'IO.inspect(r8, label: "SCENARIO_AGG_MIN", charlists: :as_lists)',
+    'r9 = Phase3Smoke.Phase3FindallQualified.run([{:unbound, make_ref()}])',
+    'IO.inspect(r9, label: "SCENARIO_FINDALL_QUALIFIED", charlists: :as_lists)'
 ]).
 
 %% Generate the test project. Predicates and driver invocations are
@@ -330,6 +334,16 @@ assert_scenario_agg_min(StdOut) :-
     % Enum.min on string list — min("a","b","c") = "a".
     sub_string(W, _, _, _, "\"a\"").
 
+assert_scenario_findall_qualified(StdOut) :-
+    scope_after_label(StdOut, "SCENARIO_FINDALL_QUALIFIED", W),
+    % Module-qualified findall now works end-to-end after the static
+    % unwrap in compile_goal_call/4. Same expected shape as scenario 1
+    % since the unwrap makes the WAM byte-code identical to the
+    % unqualified case — three solution values present.
+    sub_string(W, _, _, _, "\"a\""),
+    sub_string(W, _, _, _, "\"b\""),
+    sub_string(W, _, _, _, "\"c\"").
+
 %% Per-scenario test wrappers that share captured StdOut/StdErr/ExitCode.
 
 run_scenario(Test, Assertion, StdOut, StdErr, ExitCode) :-
@@ -366,6 +380,9 @@ run_all_scenarios(StdOut, StdErr, ExitCode) :-
                  StdOut, StdErr, ExitCode),
     run_scenario('Phase 3: aggregate_all(min(X), phase3_smoke_p(X), M) → "a" (lex min)',
                  assert_scenario_agg_min,
+                 StdOut, StdErr, ExitCode),
+    run_scenario('Phase 3: findall(X, user:phase3_smoke_p(X), L) → [a, b, c] (module-qualified, closes #1647 Finding 1)',
+                 assert_scenario_findall_qualified,
                  StdOut, StdErr, ExitCode).
 
 %% Test runner — single project, single elixir invocation, all

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -937,8 +937,8 @@ test_findall_instr_end_to_end_lowering :-
 
 :- dynamic phase_a_test:findall_qualified_target/1.
 
-test_findall_module_qualified_uses_y_reg :-
-    Test = 'WAM compiler: findall/3 with module-qualified inner goal uses Y-reg in begin_aggregate (fix for #1647 Finding 1)',
+test_findall_module_qualified_unwrap :-
+    Test = 'WAM compiler: findall/3 with static module-qualified inner goal unwraps to direct call (fix for #1647 Finding 1)',
     setup_call_cleanup(
         (   retractall(phase_a_test:findall_qualified_target(_)),
             assertz(phase_a_test:findall_qualified_target('a')),
@@ -949,19 +949,25 @@ test_findall_module_qualified_uses_y_reg :-
         (   wam_target:compile_predicate_to_wam(
                 phase_a_test:findall_qualified_caller/1, [], WamCode),
             atom_string(WamCode, S),
-            % The fix: findall's value_reg should be a Y-register
-            % (Y1, Y2, ...). Pre-fix, A1 was used and would have been
-            % clobbered by the `:/2` builtin's put_constant.
+            % Y-reg-allocation portion of #1650 still applies — findall's
+            % value_reg should be a Y-register regardless of inner-goal shape.
             sub_string(S, _, _, _, 'begin_aggregate collect, Y'),
             sub_string(S, _, _, _, 'end_aggregate Y'),
-            % And the inner-call lowering should use the `:/2` builtin
-            % path — the very thing that exposed the bug. Confirms we
-            % are still going through the module-qualified compilation,
-            % not silently unwrapping it elsewhere.
-            sub_string(S, _, _, _, 'builtin_call :/2'),
-            \+ sub_string(S, _, _, _, 'begin_aggregate collect, A1')
+            \+ sub_string(S, _, _, _, 'begin_aggregate collect, A1'),
+            % Static-module-qualifier unwrap (this PR): the inner goal
+            % `phase_a_test:findall_qualified_target(X)` should compile
+            % to a regular `call findall_qualified_target/1, 1` instead
+            % of routing through the `:/2` builtin path. Cross-target
+            % win — every target avoids the meta-call overhead on the
+            % common static-qualifier case.
+            sub_string(S, _, _, _, 'call findall_qualified_target/1'),
+            \+ sub_string(S, _, _, _, 'builtin_call :/2'),
+            % And the put_constant for the module name is gone too —
+            % the unwrapped call doesn't construct a `:/2` structure
+            % on the heap.
+            \+ sub_string(S, _, _, _, 'put_constant phase_a_test')
         ->  pass(Test)
-        ;   fail_test(Test, 'module-qualified findall did not emit Y-reg in begin_aggregate (fix regressed?)')
+        ;   fail_test(Test, 'module-qualified findall did not unwrap to direct call (Option B regressed?)')
         ),
         (   retractall(phase_a_test:findall_qualified_target(_)),
             retractall(phase_a_test:findall_qualified_caller(_))
@@ -1304,7 +1310,7 @@ run_tests :-
     test_findall_instr_translates_collect_to_findall,
     test_findall_instr_lowers_end_aggregate,
     test_findall_instr_end_to_end_lowering,
-    test_findall_module_qualified_uses_y_reg,
+    test_findall_module_qualified_unwrap,
     test_tier2_purity_gate_rejects_unknown,
     test_tier2_purity_gate_accepts_declared,
     test_par_wrap_segment_emits_super_wrapper,


### PR DESCRIPTION
## Summary

- Closes Finding 1 from #1647 end-to-end. The WAM-compiler fix in #1650 made the bytecode correct (`begin_aggregate collect, Y1, ...`), but `findall(X, user:p(X), L)` still failed at runtime on the Elixir target because `WamRuntime.execute_builtin/3` didn't implement `:/2`. This PR makes the runtime gap moot: static `M:Goal` is unwrapped at compile time so the WAM emits a regular `call p/Arity, N` instead of routing through the `:/2` builtin.
- Two-clause change in `wam_target.pl` (`compile_goal_call/4` + `compile_goal_execute/4`) — ~12 lines of code, ~9 lines of comments.
- Cross-target benefit: every target avoids the meta-call overhead (heap walk for the goal structure, register shuffling, dispatch table lookup) on the common static-qualifier case.
- 80/80 target tests + 9/9 Phase 3 runtime scenarios + LLVM aggregate test all passing on Termux (Elixir 1.19, OTP 28).

## Why this approach

Two options were on the table after #1650 landed (which fixed the WAM byte-shape but left the Elixir runtime gap):

| | Option A: implement `:/2` in Elixir runtime | Option B: compile-time unwrap (this PR) |
|---|---|---|
| Scope | Elixir runtime only | WAM compiler (cross-target) |
| Diff size | ~50–80 lines (architectural change in `backtrack/1`) | ~12 lines |
| Backtracking | Material complexity — synchronous `execute_builtin` return contract is incompatible with meta-call's CPS nature; first solution captures cleanly but subsequent solutions resume with the wrong `state.cp` | None — uses existing `call` machinery |
| Static `M:Goal` | Works | Works |
| Dynamic `Module:Goal` | Works | Falls through to `:/2` (Elixir gap stays for this rare case) |
| Cross-target benefit | None | Cleaner WAM emission for every target |

Both options were written up in detail and reviewed by Perplexity (separate design analysis). Perplexity confirmed Option A's backtracking-semantics problem is a genuine architectural mismatch (not a missing trick), validated Option B's `(atom(M) ; string(M))` guard as correct for this codebase, and recommended Option B with the explicit deliverables this PR implements.

The dynamic case (`Module = m, Module:Goal` where `M` is a Prolog variable at compile time) is documented as a known limitation in `WAM_ELIXIR_TIER2_FINDALL.md` §10 with a forward reference to the CP-frame extension as the correct future implementation when it actually surfaces. No existing predicate in the codebase uses dynamic meta-call.

## What changes

### `src/unifyweaver/targets/wam_target.pl` (+21)

New leading clause for `compile_goal_call/4`:

```prolog
compile_goal_call(M:InnerGoal, V0, Vf, Code) :-
    (atom(M) ; string(M)),
    !,
    compile_goal_call(InnerGoal, V0, Vf, Code).
```

…plus the same shape on `compile_goal_execute/4` for tail-call positions, plus a comment block explaining why (UnifyWeaver's targets resolve predicates by name only, no per-module dispatch table). The recursion handles nested qualifiers (`M:N:Goal`) by repeated unwrapping. The `string(M)` guard is belt-and-suspenders per Perplexity's review — covers any code path that represents module names as strings.

### `tests/test_wam_elixir_target.pl` (+19 / -13)

Renamed `test_findall_module_qualified_uses_y_reg` → `test_findall_module_qualified_unwrap` and flipped the assertion semantics:

- **Y-reg portion still applies** — `begin_aggregate collect, Y...` and `end_aggregate Y...` (the #1650 fix is independent of the unwrap).
- **`builtin_call :/2`** assertion **flipped to negative** (`\+ sub_string`) — the unwrap should make this disappear.
- **Added positive `call findall_qualified_target/1`** assertion — the direct call after unwrap.
- **Added negative `\+ put_constant phase_a_test`** — confirms the `:/2` structure isn't being constructed on the heap either.

Target-agnostic at the WAM byte-shape level.

### `tests/test_wam_elixir_lowered_phase3.pl` (+30 / -9)

Activates scenario 9 — `findall(X, user:phase3_smoke_p(X), L)` — that was previously a TODO comment. Now passes end-to-end through the lowered Elixir runtime, same shape as scenario 1 since the unwrap makes the emitted WAM identical to the unqualified case.

### `docs/proposals/WAM_ELIXIR_TIER2_FINDALL.md` (+11 / -3)

- Status header and phase table updated to reflect the new shipped state.
- §10 (non-goals) gains a detailed entry on **dynamic `Module:Goal` on Elixir runtime** — explicit known limitation with a pointer at the CP-frame extension as the correct future fix.

## Reviewer notes

**Why scenario 9's runtime test was waiting for this PR.** When I tried to add it to #1650 (the WAM byte-shape fix), the test failed with `:fail` from the Elixir runtime — the Elixir-runtime `:/2` gap was independent of the WAM byte-shape gap. I documented it as a TODO comment pointing at the runtime gap. This PR fixes both gaps simultaneously by sidestepping the runtime path: the WAM no longer emits `:/2`, so the runtime never has to handle it.

**Renamed-not-added test.** The existing `test_findall_module_qualified_uses_y_reg` test from #1650 was specifically asserting that the `:/2` builtin path was still being exercised (its purpose was to confirm we hadn't accidentally bypassed the bug-triggering path while fixing the Y-reg allocation). With Option B, that path is now explicitly bypassed by design — the assertion needs to flip from positive to negative on `:/2`. Renamed to `_unwrap` to match the new semantic.

**`atom(M) ; string(M)` guard rationale.** Per Perplexity's review: the codebase parses module names as Prolog atoms in normal source files, but some test fixtures or alternative parsing paths might produce strings. The dual-guard costs nothing and eliminates the edge case. The `(atom(M) ; string(M))` form is a Prolog disjunction that succeeds if either holds.

**Why the cut (`!`) after the guard.** Standard Prolog committed-choice — once we've matched `M:InnerGoal` with a static qualifier, we want to commit to the unwrap path and not backtrack to the second clause (which would re-decompose the qualified goal via `=..` and emit `:/2`).

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_target.pl` — 80/80 passing
- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_lowered_phase3.pl` — 9/9 passing on Termux (Elixir 1.19, OTP 28)
- [x] `swipl -t halt -g test_aggregate_compiles tests/core/test_wam_llvm_aggregate.pl` — passes (byte-shape unchanged for `aggregate_all(min(X), ...)` which doesn't go through the module-qualifier path)
- [x] WAM byte-shape direct probe — verified `call phase3_p/1, 1` (not `builtin_call :/2, 2`) for module-qualified findall
- [x] Pre-existing `test_wam_e2e.pl atom/1` failure exists on `main`, unrelated to this PR

## Related

- Finding 1's original surfacing: #1647 (Phase 3a runtime smoke)
- Y-reg portion of the fix (WAM byte-shape only): #1650
- Findall track: proposal #1626 → substrate #1627 → lowering #1643 → harness #1647 → coverage #1649 → Y-reg fix #1650 → static-unwrap (this PR)
- Future Elixir runtime work for dynamic `Module:Goal`: CP-frame extension to `backtrack/1` (analogous to how aggregate frames are handled today). Not blocking — no current use case.

## Phase plan (post-merge)

- **Phase 3c (next)**: Edge cases — single-clause findall (cheap), Y-register Template deep-copy probe (§6 risk #1), cut in inner goal (§6 risk #3), nested findall (§6 risk #7).
- **`:sum` numeric encoding** (parallel track): Substrate-level fix in `put_constant` lowering (currently emits integers as Elixir strings, blocking `Enum.sum`).
- **Dynamic Elixir `:/2` runtime support** (parallel track, no blocker): Implement CP-frame extension to `backtrack/1` for meta-call. Architecture analogous to the aggregate-frame dispatch from #1627. Pick up only if a real predicate ever needs dynamic meta-call.
- **Phase 4** (later): Tier-2 × findall — branch-local-accum protocol from Haskell.
