### PR TITLE
fix(wam-elixir): trail-bind result in finalise_aggregate (Phase 3c)

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -1111,8 +1111,33 @@ compile_aggregate_helpers_to_elixir(Code) :-
         :min ->
           if accum_rev == [], do: throw({:fail, state}), else: Enum.min(accum_rev)
       end
+    # Bind the result through the trail when result_reg holds an
+    # unbound ref. Direct slot overwrite (the pre-#1659 behaviour)
+    # writes to agg_cp.regs[result_reg_idx] but leaves the underlying
+    # ref unbound — fine for the simple case where the result_reg
+    # slot IS the binding target, but breaks for nested findall: the
+    # inner findalls result_reg shares its unbound ref with the
+    # outer callers reg via the calls get_variable, and the inner
+    # predicates deallocate merge restores the outers Y-reg
+    # snapshot — overwriting the inners reg-slot binding. Trail-style
+    # binding (Map.put under the ref id, not the integer reg-slot)
+    # propagates through deref_var across frame boundaries and
+    # survives deallocate. Proposal section 6 risk 7 (nested findall)
+    # fix surfaced by Phase 3c.
+    bound_regs =
+      case Map.get(agg_cp.regs, agg_cp.agg_result_reg) do
+        {:unbound, id} ->
+          # Trail the binding under the unbound refs id so any
+          # aliased copy sees it via deref_var.
+          agg_cp.regs
+          |> Map.put(id, result)
+          |> Map.put(agg_cp.agg_result_reg, result)
+        _ ->
+          # Slot was bound or empty — preserve legacy direct overwrite.
+          Map.put(agg_cp.regs, agg_cp.agg_result_reg, result)
+      end
     restored = %{state |
-      regs: Map.put(agg_cp.regs, agg_cp.agg_result_reg, result),
+      regs: bound_regs,
       heap: agg_cp.heap,
       heap_len: agg_cp.heap_len,
       trail: agg_cp.trail,

--- a/tests/test_wam_elixir_lowered_phase3.pl
+++ b/tests/test_wam_elixir_lowered_phase3.pl
@@ -131,7 +131,7 @@ user:phase3_min(M) :- aggregate_all(min(X), phase3_smoke_p(X), M).
 
 % Scenario 9: module-qualified findall, end-to-end — closes Finding 1
 % from #1647. The static-module-qualifier unwrap in compile_goal_call/4
-% (this PR) emits a regular `call phase3_smoke_p/1` for the inner
+% (#1658) emits a regular `call phase3_smoke_p/1` for the inner
 % goal instead of routing through the `:/2` builtin path, so the
 % Elixir runtime never sees `:/2` and never hits its catch-all
 % `_ -> :fail`. Functionally equivalent to scenario 1 once the
@@ -139,6 +139,50 @@ user:phase3_min(M) :- aggregate_all(min(X), phase3_smoke_p(X), M).
 % still hit `:/2` and remain a known limitation — see
 % WAM_ELIXIR_TIER2_FINDALL.md for the forward reference.
 user:phase3_findall_qualified(L) :- findall(X, user:phase3_smoke_p(X), L).
+
+% Scenario 10: single-clause findall — degenerate case. Inner predicate
+% has exactly one solution (no try_me_else / retry_me_else CPs).
+% Validates the path where the inner enumeration exhausts immediately
+% after one solution: aggregate_collect captures the value, throw fail
+% drives backtrack, the topmost CP IS the agg frame (no inner CPs to
+% pop first), and finalise binds the 1-element list.
+user:phase3_one_solution(only).
+user:phase3_findall_one(L) :- findall(X, phase3_one_solution(X), L).
+
+% Nested findall — proposal §6 risk #7 — surfaced a deeper
+% architectural issue during this PR's investigation, deferred to a
+% focused follow-up:
+%
+%   When end_aggregate throws {:fail, state}, wrap_segment's catch
+%   calls backtrack/1, which routes to finalise_aggregate/4.
+%   finalise tail-calls the saved continuation (agg_cp.cp = the
+%   outer caller's post-call continuation) DIRECTLY, bypassing the
+%   inner predicate's deallocate instruction. The outer continuation
+%   then runs with the inner's stack frame still active — Y-reg
+%   accesses see the inner's Y-regs, not the outer's. For
+%   single-level findall this works because there's no outer
+%   "Y-reg consumer" after the call (the post-call continuation only
+%   touches X-regs and the result_reg via aggregate_collect). For
+%   nested findall, the outer's end_aggregate Y1 reads the wrong Y1.
+%
+%   The trail-bind fix in this PR (finalise binds the result through
+%   the underlying unbound ref's id, not just the integer reg slot)
+%   makes single-level findall correctly bind L at the parameter
+%   slot instead of incidentally leaving the value at the X-reg
+%   only. This is necessary but not sufficient for nested.
+%
+%   Follow-up options for the architectural fix:
+%   (a) Have finalise simulate deallocate when state.stack has an
+%       env frame above the saved snapshot — pop frames until the
+%       agg_cp.stack snapshot matches.
+%   (b) Restructure end_aggregate's lowering to fall through to the
+%       inner's deallocate before throwing fail.
+%   (c) Push the agg frame BEFORE allocate, so agg_cp.stack
+%       captures the pre-allocate state and finalise's restore
+%       naturally pops the inner env.
+%
+%   Each option needs careful design — that's its own PR after
+%   Phase 3c lands.
 
 %% tmp_root — try TMPDIR / TMP / TEMP / $PREFIX/tmp / ./output in
 %% order. Same fallback chain as the existing benchmark harness.
@@ -180,7 +224,9 @@ phase3_predicates([
     user:phase3_set/1,
     user:phase3_max/1,
     user:phase3_min/1,
-    user:phase3_findall_qualified/1
+    user:phase3_findall_qualified/1,
+    user:phase3_one_solution/1,
+    user:phase3_findall_one/1
 ]).
 
 %% phase3_driver_invocations(-Lines)
@@ -205,7 +251,9 @@ phase3_driver_invocations([
     'r8 = Phase3Smoke.Phase3Min.run([{:unbound, make_ref()}])',
     'IO.inspect(r8, label: "SCENARIO_AGG_MIN", charlists: :as_lists)',
     'r9 = Phase3Smoke.Phase3FindallQualified.run([{:unbound, make_ref()}])',
-    'IO.inspect(r9, label: "SCENARIO_FINDALL_QUALIFIED", charlists: :as_lists)'
+    'IO.inspect(r9, label: "SCENARIO_FINDALL_QUALIFIED", charlists: :as_lists)',
+    'r10 = Phase3Smoke.Phase3FindallOne.run([{:unbound, make_ref()}])',
+    'IO.inspect(r10, label: "SCENARIO_FINDALL_ONE_CLAUSE", charlists: :as_lists)'
 ]).
 
 %% Generate the test project. Predicates and driver invocations are
@@ -344,6 +392,13 @@ assert_scenario_findall_qualified(StdOut) :-
     sub_string(W, _, _, _, "\"b\""),
     sub_string(W, _, _, _, "\"c\"").
 
+assert_scenario_findall_one_clause(StdOut) :-
+    scope_after_label(StdOut, "SCENARIO_FINDALL_ONE_CLAUSE", W),
+    % One-element list — the single fact's value `only` is captured
+    % once. No try_me_else CPs to backtrack through; finalise is
+    % reached on the very first throw-fail after aggregate_collect.
+    sub_string(W, _, _, _, "\"only\"").
+
 %% Per-scenario test wrappers that share captured StdOut/StdErr/ExitCode.
 
 run_scenario(Test, Assertion, StdOut, StdErr, ExitCode) :-
@@ -383,6 +438,9 @@ run_all_scenarios(StdOut, StdErr, ExitCode) :-
                  StdOut, StdErr, ExitCode),
     run_scenario('Phase 3: findall(X, user:phase3_smoke_p(X), L) → [a, b, c] (module-qualified, closes #1647 Finding 1)',
                  assert_scenario_findall_qualified,
+                 StdOut, StdErr, ExitCode),
+    run_scenario('Phase 3c: findall(X, phase3_one_solution(X), L) → ["only"] (single-clause, no try_me_else CPs)',
+                 assert_scenario_findall_one_clause,
                  StdOut, StdErr, ExitCode).
 
 %% Test runner — single project, single elixir invocation, all


### PR DESCRIPTION
## Summary

- **Substrate fix** in `finalise_aggregate/4`: when the aggregate frame's result_reg slot holds an unbound ref, finalise now binds the result through the underlying ref id (trail-style), not just the integer reg slot. Single-level findall is now *correctly* materialised at the L parameter slot — previously the bound list lived only at the X-reg slot and the parameter slot stayed unbound, with substring-match tests passing by accident.
- **Phase 3c scenario 10** added: single-clause findall (`findall(X, phase3_one_solution(X), L)` → `["only"]`). Validates the path where finalise is reached on the very first throw-fail (no try_me_else CPs to backtrack through).
- **Deferred finding**: nested findall surfaced a deeper architectural issue beyond the trail-bind. Investigated, characterised, three follow-up fix options documented inline in the test file. Skipped from this PR's scenarios; needs its own focused follow-up.
- 80/80 target tests + 10/10 Phase 3 runtime scenarios passing on Termux (Elixir 1.19, OTP 28).

## What changes

### `src/unifyweaver/targets/wam_elixir_target.pl` (+27 / -2)

The `finalise_aggregate/4` body in `compile_aggregate_helpers_to_elixir/1` now does:

```elixir
bound_regs =
  case Map.get(agg_cp.regs, agg_cp.agg_result_reg) do
    {:unbound, id} ->
      # Trail the binding under the unbound refs id so any
      # aliased copy sees it via deref_var.
      agg_cp.regs
      |> Map.put(id, result)
      |> Map.put(agg_cp.agg_result_reg, result)
    _ ->
      # Slot was bound or empty — preserve legacy direct overwrite.
      Map.put(agg_cp.regs, agg_cp.agg_result_reg, result)
  end
```

…replacing the unconditional `Map.put(agg_cp.regs, agg_cp.agg_result_reg, result)`.

**Why this matters even for cases that "already passed":** for a trivial findall like `phase3_smoke_findall(L) :- findall(X, phase3_smoke_p(X), L).`, the WAM compiles to `get_variable X2, A1; ... begin_aggregate collect, Y1, X2; ...; end_aggregate Y1`. After finalise, the bound list `["a","b","c"]` was at `state.regs[102]` (X2's slot), but `state.regs[1]` (the L parameter slot) and `state.regs[<L's unbound ref id>]` were both unbound. `materialise_args` derefs through the parameter ref → finds nothing → returns the original unbound. The IO.inspect-based substring-match tests passed because the values were *somewhere* in the dump (at slot 102), just not where they should be.

The trail-bind fix puts the result under the underlying ref id, so `deref_var` resolves it correctly and `materialise_args` returns the bound list. Single-level findall now works for the *right* reasons.

### `tests/test_wam_elixir_lowered_phase3.pl` (+62 / -2)

- New scenario 10: single-clause findall fixture (`phase3_one_solution(only).`) and `phase3_findall_one(L) :- findall(X, phase3_one_solution(X), L).`. Driver invocation, assertion (`L` contains `"only"`), runner registration.
- ~30-line deferred-scenario comment block where the nested findall scenario was originally drafted, explaining the architectural issue surfaced and the three follow-up fix options.

## Reviewer notes

**Why I wrote the trail-bind fix even though no existing test was failing for it.** The investigation into nested findall (proposal §6 risk #7) revealed that single-level findall was passing by accident — the substring-match assertions were finding the bound values at the wrong reg slot. The trail-bind fix doesn't *enable* anything new to pass at the substring level, but it makes the runtime behaviour structurally correct in a way that downstream uses of `materialise_args` (or any future code that resolves the parameter through `arg_vars`) actually depend on. Without the fix, any caller that consumed the L parameter via the conventional deref path would see an unbound variable. The fix is necessary scaffolding for any further work that touches result-slot binding.

**Why nested findall couldn't be activated in this PR.** The smoke ran cleanly with the trail-bind fix — the inner findall correctly bound L through the shared ref. But the outer findall's `end_aggregate Y1` then read from the wrong Y1: when inner finalise tail-calls the saved continuation (= outer's post-call k1), it bypasses the inner predicate's `deallocate`, so `state.stack` still has the inner's env on top. The outer's k1 starts running with the inner's Y-regs active, reading from `state.regs[201]` which is the inner's Y1 (unbound for X), not the outer's Y1 (which should now hold the bound L from the inner's findall). aggregate_collect captures the inner's unbound, accum gets a list of unbound refs, finalise binds the outer LL to that.

This is an end_aggregate-finalise control-flow issue, not a binding issue. The trail-bind fix is necessary but not sufficient for nested findall.

**Three follow-up options for the architectural fix** are documented in the test file's deferred-scenario comment block (`tests/test_wam_elixir_lowered_phase3.pl`, search for "nested findall — proposal §6 risk #7"):

1. **Finalise simulates deallocate.** Pop env frames from `state.stack` until `agg_cp.stack`'s snapshot matches. Y-regs get restored from each popped env. Cleanest at the runtime layer.
2. **Restructure end_aggregate's lowering.** Have it fall through to `deallocate` before throwing fail. Lowering-level change; touches the per-instruction emit pipeline.
3. **Push agg frame before allocate.** Then `agg_cp.stack` captures the pre-allocate state and finalise's restore naturally pops the inner env. WAM-compiler-level change; affects every target's begin_aggregate emission.

Each needs careful design and its own PR.

**Why the substring-match assertion strategy stays.** The Phase 3 test harness uses `IO.inspect`-then-grep because actual term equality across the swipl/elixir boundary would require a result-encoding protocol that doesn't yet exist. The substring approach is sensitive to *presence* of expected values but blind to *which slot* they're at — which is why the trail-bind fix needs explanation in the commit message and PR body rather than appearing as a test that started passing.

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_target.pl` — 80/80 passing (substrate fix doesn't change byte shape or interface, just the bound regs map at finalise time)
- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_lowered_phase3.pl` — 10/10 passing on Termux (9 prior + new single-clause scenario)
- [x] WAM byte-shape direct probe — confirmed `begin_aggregate collect, Y1, X2` and trail-bind path exercised correctly
- [x] Pre-existing `test_wam_e2e.pl atom/1` failure exists on `main`, unrelated to this PR

## Phase plan (post-merge)

- **Nested findall architectural fix (next)**: Pick one of the three options documented in the test file. Closes proposal §6 risk #7 end-to-end. Probably option (a) — finalise simulates deallocate — as the smallest, most localised change.
- **Phase 3c continuation**: Y-register Template deep-copy probe (§6 risk #1) and cut in inner goal (§6 risk #3) remain. Single-clause was the cheap warmup that surfaced the trail-bind issue and the nested-findall finding; the riskier probes are still ahead.
- **`:sum` numeric encoding**: Substrate-level fix in `put_constant` lowering (integers as Elixir strings).
- **Phase 4**: Tier-2 × findall — branch-local-accum protocol from Haskell.

## Related

- Findall track: proposal #1626 → substrate #1627 → lowering #1643 → harness #1647 → coverage #1649 → Y-reg fix #1650 → static-unwrap #1658 → trail-bind + Phase 3c (this PR)
- Nested findall reference: `wam_haskell_target.pl:1502-1516` (Haskell's branch-local-accum pattern, which addresses a similar but distinct frame-cleanup problem in the parallel case)
