### PR TITLE
feat(wam-clojure): add LMDB cache stats seam

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -688,3 +688,17 @@ The next narrow step is now underway too: the JVM helper exposes
 native store seam again. We should not trust Termux to tell us whether
 `none` vs `memoize` is the right default; that comparison is now a
 desktop-only measurement TODO.
+
+The cache policy logic is now being pulled into a clearer JVM seam as
+well. `LmdbArtifactReader` is no longer the only place where policy
+details live conceptually; the direction is:
+
+- explicit lookup-cache wrapper
+- lightweight stats hooks
+- opt-in generated Clojure debug output
+
+The immediate stats surface is intentionally small:
+
+- `localHits`
+- `sharedHits`
+- `misses`

--- a/docs/proposals/WAM_CLOJURE_LMDB_FACT_ACCESS_PLAN.md
+++ b/docs/proposals/WAM_CLOJURE_LMDB_FACT_ACCESS_PLAN.md
@@ -275,6 +275,25 @@ Desktop measurement TODO:
 - do this outside Termux, where JVM timing and memory behavior are more
   trustworthy
 
+### Phase C4a: Cache seam and stats hooks
+
+Status: **in progress**
+
+Current narrow implementation:
+
+1. extract cache behavior into a clearer JVM-side lookup-cache seam
+2. expose lightweight stats for:
+   - `localHits`
+   - `sharedHits`
+   - `misses`
+3. allow generated Clojure projects to emit those stats behind an
+   explicit debug predicate override, not by default
+
+Current debug surface:
+
+- `wam_clojure_benchmark_relation_cache_debug(category_parent, true)`
+- `benchmark_relation_cache_debug(category_parent, true)`
+
 ### Phase C5: Broader relation coverage
 
 Status: **deferred**

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -228,6 +228,17 @@ Use these as explicit workload overrides for now. The relative value of
 `none`, `memoize`, `shared`, and `two_level` should be measured on a
 desktop JVM rather than treated as settled from Termux timings.
 
+For focused debugging, the generator also accepts a relation-local cache
+stats flag:
+
+- `wam_clojure_benchmark_relation_cache_debug(category_parent, true).`
+- `benchmark_relation_cache_debug(category_parent, true).`
+
+When enabled on the LMDB path, generated Clojure projects emit
+`lmdb_cache_stats ...` lines to `stderr` during predicate/runner cache
+activity. This is intended for targeted probes, not normal benchmark
+runs.
+
 The generator also now honors the shared predicate-preprocessing
 declaration surface from
 `src/unifyweaver/core/predicate_preprocessing.pl`. For the current

--- a/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_clojure_optimized_benchmark.pl
@@ -261,6 +261,26 @@ benchmark_relation_cache_policy(Relation, _Mode, Policy) :-
     ;   Policy = none
     ).
 
+benchmark_relation_declared_cache_debug(Relation, Debug) :-
+    member(Name,
+           [ wam_clojure_benchmark_relation_cache_debug,
+             benchmark_relation_cache_debug
+           ]),
+    current_predicate(user:Name/2),
+    Goal =.. [Name, Relation, DeclaredDebug],
+    once(call(user:Goal)),
+    memberchk(DeclaredDebug, [true, false]),
+    Debug = DeclaredDebug.
+
+benchmark_relation_cache_debug(_Relation, Mode, false) :-
+    Mode \== lmdb,
+    !.
+benchmark_relation_cache_debug(Relation, _Mode, Debug) :-
+    (   benchmark_relation_declared_cache_debug(Relation, DeclaredDebug)
+    ->  Debug = DeclaredDebug
+    ;   Debug = false
+    ).
+
 benchmark_fact_volume(RowCount) :-
     benchmark_fact_count(user:category_parent/2, ParentCount),
     benchmark_fact_count(user:article_category/2, ArticleCount),
@@ -295,9 +315,11 @@ category_parent_handler_code(OutputDir, artifact, HandlerCode) :-
 category_parent_handler_code(OutputDir, lmdb, CachePolicy, HandlerCode) :-
     benchmark_sidecar_subdir_literal(OutputDir, 'category_parent_lmdb', ArtifactDirPath),
     lmdb_reader_open_expr(ArtifactDirPath, CachePolicy, ReaderOpenExpr),
+    benchmark_relation_cache_debug(category_parent, lmdb, CacheDebug),
+    lmdb_cache_log_snippet('category_parent/2', CacheDebug, ParentLogCode),
     format(string(HandlerCode),
-           "(let [reader-delay (delay ~w)] (fn [args] (let [child (nth args 0) parent (nth args 1) rows (.lookupArg1 ^generated.lmdb.LmdbArtifactReader @reader-delay child)] (boolean (some (fn [^generated.lmdb.LmdbRow row] (= parent (.value row))) rows)))))",
-           [ReaderOpenExpr]).
+           "(let [reader-delay (delay ~w)] (fn [args] (let [child (nth args 0) parent (nth args 1) rows (.lookupArg1 ^generated.lmdb.LmdbArtifactReader @reader-delay child) result (boolean (some (fn [^generated.lmdb.LmdbRow row] (= parent (.value row))) rows))] (do ~w result))))",
+           [ReaderOpenExpr, ParentLogCode]).
 category_parent_handler_code(_OutputDir, inline, HandlerCode) :-
     category_parent_handler_code(inline, HandlerCode).
 category_parent_handler_code(sidecar, HandlerCode) :-
@@ -336,6 +358,12 @@ lmdb_reader_open_expr(ArtifactDirPath, none, Expr) :-
            "(generated.lmdb.LmdbArtifactReader/open (java.nio.file.Paths/get ~w (make-array String 0)))",
            [ArtifactDirPath]).
 
+lmdb_cache_log_snippet(_Context, false, "nil").
+lmdb_cache_log_snippet(Context, true, Snippet) :-
+    format(string(Snippet),
+           "(binding [*out* *err*] (println (str \"lmdb_cache_stats ~w \" (pr-str (.cacheStats ^generated.lmdb.LmdbArtifactReader @reader-delay)))))",
+           [Context]).
+
 category_ancestor_handler_code(HandlerCode) :-
     parse_benchmark_data_mode(auto, DataMode),
     category_ancestor_handler_code(DataMode, HandlerCode).
@@ -362,9 +390,11 @@ category_ancestor_handler_code(OutputDir, lmdb, CachePolicy, HandlerCode) :-
     benchmark_max_depth_literal(MaxDepth),
     benchmark_sidecar_subdir_literal(OutputDir, 'category_parent_lmdb', ArtifactDirPath),
     lmdb_reader_open_expr(ArtifactDirPath, CachePolicy, ReaderOpenExpr),
+    benchmark_relation_cache_debug(category_parent, lmdb, CacheDebug),
+    lmdb_cache_log_snippet('category_ancestor/4', CacheDebug, AncestorLogCode),
     format(string(HandlerCode),
-           "(let [reader-delay (delay ~w) max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) parent-values (fn [category] (mapv (fn [^generated.lmdb.LmdbRow row] (.value row)) (.lookupArg1 ^generated.lmdb.LmdbArtifactReader @reader-delay category))) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (parent-values category)] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] {:solutions (vec solutions)})))",
-           [ReaderOpenExpr, MaxDepth]).
+           "(let [reader-delay (delay ~w) max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) parent-values (fn [category] (mapv (fn [^generated.lmdb.LmdbRow row] (.value row)) (.lookupArg1 ^generated.lmdb.LmdbArtifactReader @reader-delay category))) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (parent-values category)] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] (do ~w {:solutions (vec solutions)}))))",
+           [ReaderOpenExpr, MaxDepth, AncestorLogCode]).
 category_ancestor_handler_code(_OutputDir, inline, HandlerCode) :-
     category_ancestor_handler_code(inline, HandlerCode).
 category_ancestor_handler_code(sidecar, HandlerCode) :-
@@ -626,9 +656,11 @@ benchmark_category_parents_code(artifact, _ParentCachePolicy, _DataDirLiteral, _
       (.split ^String (slurp (str benchmark-data-dir "/category_parent_by_child.tsv")) "\\r?\\n"))))'.
 benchmark_category_parents_code(lmdb, CachePolicy, _DataDirLiteral, _BenchmarkData, Code) :-
     lmdb_reader_open_expr_runtime(CachePolicy, ReaderOpenExpr),
+    benchmark_relation_cache_debug(category_parent, lmdb, CacheDebug),
+    lmdb_runner_cache_log_snippet(CacheDebug, RunnerLogCode),
     format(string(Code),
-           "(def benchmark-parents-by-child-delay\n  (delay\n    (let [reader ~w]\n      (reduce (fn [acc ^generated.lmdb.LmdbRow row]\n                (update acc (.key row) (fnil conj []) (.value row)))\n              {}\n              (.scan ^generated.lmdb.LmdbArtifactReader reader)))))",
-           [ReaderOpenExpr]).
+           "(def benchmark-parents-by-child-delay\n  (delay\n    (let [reader ~w\n          result (reduce (fn [acc ^generated.lmdb.LmdbRow row]\n                           (update acc (.key row) (fnil conj []) (.value row)))\n                         {}\n                         (.scan ^generated.lmdb.LmdbArtifactReader reader))]\n      ~w\n      result)))",
+           [ReaderOpenExpr, RunnerLogCode]).
 benchmark_category_parents_code(inline, _ParentCachePolicy, _DataDirLiteral, benchmark_data(_, CategoryParents, _, _, _, _, _, _), Code) :-
     format(string(Code),
            "(def benchmark-category-parents-delay (delay [~s]))",
@@ -654,6 +686,13 @@ lmdb_reader_open_expr_runtime(none, Expr) :-
                    (java.nio.file.Paths/get
                      (str benchmark-data-dir "/category_parent_lmdb")
                      (make-array String 0)))'.
+
+lmdb_runner_cache_log_snippet(false, "nil").
+lmdb_runner_cache_log_snippet(true, Snippet) :-
+    Snippet = '(binding [*out* *err*]
+                 (println
+                   (str "lmdb_cache_stats benchmark-category-parents "
+                        (pr-str (.cacheStats ^generated.lmdb.LmdbArtifactReader reader)))))'.
 
 benchmark_roots_code(sidecar, _DataDirLiteral, _BenchmarkData, Code) :-
     Code = '(def benchmark-roots-delay
@@ -1098,8 +1137,10 @@ maybe_prepare_clojure_lmdb_runtime_support(OutputDir, lmdb) :-
 lmdb_helper_java_sources(JavaSources) :-
     maplist(lmdb_helper_java_source_path,
             [ 'LmdbRow.java',
+              'LmdbCacheStats.java',
               'LmdbArtifactManifest.java',
               'LmdbArtifactStore.java',
+              'LmdbLookupCache.java',
               'LmdbArtifactReader.java',
               'LmdbArtifactJNI.java'
             ],

--- a/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactReader.java
+++ b/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbArtifactReader.java
@@ -2,38 +2,23 @@ package generated.lmdb;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.HashMap;
-import java.util.Map;
 
 public final class LmdbArtifactReader {
-    private enum CachePolicy {
-        NONE,
-        MEMOIZE,
-        SHARED,
-        TWO_LEVEL
-    }
-
-    private static final ConcurrentHashMap<String, LmdbRow[]> SHARED_ARG1_CACHE = new ConcurrentHashMap<>();
-
     private final LmdbArtifactManifest manifest;
     private final ThreadLocal<LmdbArtifactStore> threadLocalStore;
-    private final CachePolicy cachePolicy;
-    private final String sharedCachePrefix;
-    private final ThreadLocal<Map<String, LmdbRow[]>> threadLocalArg1Cache;
+    private final LmdbLookupCache lookupCache;
 
     public LmdbArtifactReader(Path artifactDir, LmdbArtifactManifest manifest) {
-        this(artifactDir, manifest, CachePolicy.NONE);
+        this(artifactDir, manifest, LmdbLookupCache.Policy.NONE);
     }
 
-    private LmdbArtifactReader(Path artifactDir, LmdbArtifactManifest manifest, CachePolicy cachePolicy) {
+    private LmdbArtifactReader(Path artifactDir, LmdbArtifactManifest manifest, LmdbLookupCache.Policy cachePolicy) {
         this.manifest = manifest;
-        this.cachePolicy = cachePolicy;
-        this.sharedCachePrefix = artifactDir.toAbsolutePath().normalize() + "::";
         this.threadLocalStore = ThreadLocal.withInitial(() -> LmdbArtifactStore.open(artifactDir, manifest));
-        this.threadLocalArg1Cache = usesThreadLocalCache(cachePolicy)
-            ? ThreadLocal.withInitial(HashMap::new)
-            : null;
+        this.lookupCache = new LmdbLookupCache(
+            cachePolicy,
+            artifactDir.toAbsolutePath().normalize() + "::"
+        );
     }
 
     public static LmdbArtifactReader open(Path artifactDir) throws IOException {
@@ -47,7 +32,7 @@ public final class LmdbArtifactReader {
         return new LmdbArtifactReader(
             artifactDir,
             LmdbArtifactManifest.read(artifactDir.resolve("manifest.json")),
-            CachePolicy.MEMOIZE
+            LmdbLookupCache.Policy.MEMOIZE
         );
     }
 
@@ -55,7 +40,7 @@ public final class LmdbArtifactReader {
         return new LmdbArtifactReader(
             artifactDir,
             LmdbArtifactManifest.read(artifactDir.resolve("manifest.json")),
-            CachePolicy.SHARED
+            LmdbLookupCache.Policy.SHARED
         );
     }
 
@@ -63,49 +48,15 @@ public final class LmdbArtifactReader {
         return new LmdbArtifactReader(
             artifactDir,
             LmdbArtifactManifest.read(artifactDir.resolve("manifest.json")),
-            CachePolicy.TWO_LEVEL
+            LmdbLookupCache.Policy.TWO_LEVEL
         );
     }
 
     public LmdbRow[] lookupArg1(String key) {
-        return switch (cachePolicy) {
-            case NONE -> threadLocalStore.get().lookupArg1(key);
-            case MEMOIZE -> lookupMemoized(key);
-            case SHARED -> lookupShared(key);
-            case TWO_LEVEL -> lookupTwoLevel(key);
-        };
-    }
-
-    private LmdbRow[] lookupMemoized(String key) {
-        Map<String, LmdbRow[]> cache = threadLocalArg1Cache.get();
-        LmdbRow[] cached = cache.get(key);
-        if (cached != null) {
-            return cached;
-        }
-        LmdbRow[] rows = threadLocalStore.get().lookupArg1(key);
-        cache.put(key, rows);
-        return rows;
-    }
-
-    private LmdbRow[] lookupShared(String key) {
-        return SHARED_ARG1_CACHE.computeIfAbsent(
-            sharedCacheKey(key),
-            ignored -> threadLocalStore.get().lookupArg1(key)
+        return lookupCache.lookupArg1(
+            key,
+            () -> threadLocalStore.get().lookupArg1(key)
         );
-    }
-
-    private LmdbRow[] lookupTwoLevel(String key) {
-        Map<String, LmdbRow[]> cache = threadLocalArg1Cache.get();
-        LmdbRow[] cached = cache.get(key);
-        if (cached != null) {
-            return cached;
-        }
-        LmdbRow[] rows = SHARED_ARG1_CACHE.computeIfAbsent(
-            sharedCacheKey(key),
-            ignored -> threadLocalStore.get().lookupArg1(key)
-        );
-        cache.put(key, rows);
-        return rows;
     }
 
     public LmdbRow[] scan() {
@@ -116,23 +67,21 @@ public final class LmdbArtifactReader {
         return manifest;
     }
 
+    public LmdbCacheStats cacheStats() {
+        return lookupCache.snapshot();
+    }
+
+    public void resetCurrentThreadStats() {
+        lookupCache.resetCurrentThreadStats();
+    }
+
     public void closeCurrentThread() {
         LmdbArtifactStore store = threadLocalStore.get();
         try {
             store.close();
         } finally {
-            if (threadLocalArg1Cache != null) {
-                threadLocalArg1Cache.remove();
-            }
+            lookupCache.resetCurrentThreadStats();
             threadLocalStore.remove();
         }
-    }
-
-    private static boolean usesThreadLocalCache(CachePolicy cachePolicy) {
-        return cachePolicy == CachePolicy.MEMOIZE || cachePolicy == CachePolicy.TWO_LEVEL;
-    }
-
-    private String sharedCacheKey(String key) {
-        return sharedCachePrefix + key;
     }
 }

--- a/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbCacheStats.java
+++ b/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbCacheStats.java
@@ -1,0 +1,8 @@
+package generated.lmdb;
+
+public record LmdbCacheStats(
+    String policy,
+    long localHits,
+    long sharedHits,
+    long misses
+) {}

--- a/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbLookupCache.java
+++ b/examples/scala_lmdb_jni_probe/src/main/java/generated/lmdb/LmdbLookupCache.java
@@ -1,0 +1,123 @@
+package generated.lmdb;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
+
+final class LmdbLookupCache {
+    enum Policy {
+        NONE,
+        MEMOIZE,
+        SHARED,
+        TWO_LEVEL
+    }
+
+    private static final ConcurrentHashMap<String, LmdbRow[]> SHARED_ARG1_CACHE = new ConcurrentHashMap<>();
+
+    private final Policy policy;
+    private final String sharedCachePrefix;
+    private final ThreadLocal<Map<String, LmdbRow[]>> threadLocalArg1Cache;
+    private final LongAdder localHits;
+    private final LongAdder sharedHits;
+    private final LongAdder misses;
+
+    LmdbLookupCache(Policy policy, String sharedCachePrefix) {
+        this.policy = policy;
+        this.sharedCachePrefix = sharedCachePrefix;
+        this.threadLocalArg1Cache = usesThreadLocalCache(policy)
+            ? ThreadLocal.withInitial(HashMap::new)
+            : null;
+        this.localHits = new LongAdder();
+        this.sharedHits = new LongAdder();
+        this.misses = new LongAdder();
+    }
+
+    LmdbRow[] lookupArg1(String key, Supplier<LmdbRow[]> storeLookup) {
+        return switch (policy) {
+            case NONE -> lookupDirect(storeLookup);
+            case MEMOIZE -> lookupMemoized(key, storeLookup);
+            case SHARED -> lookupShared(key, storeLookup);
+            case TWO_LEVEL -> lookupTwoLevel(key, storeLookup);
+        };
+    }
+
+    LmdbCacheStats snapshot() {
+        return new LmdbCacheStats(
+            policy.name().toLowerCase(),
+            localHits.sum(),
+            sharedHits.sum(),
+            misses.sum()
+        );
+    }
+
+    void resetCurrentThreadStats() {
+        if (threadLocalArg1Cache != null) {
+            threadLocalArg1Cache.remove();
+        }
+        localHits.reset();
+        sharedHits.reset();
+        misses.reset();
+    }
+
+    private LmdbRow[] lookupDirect(Supplier<LmdbRow[]> storeLookup) {
+        misses.increment();
+        return storeLookup.get();
+    }
+
+    private LmdbRow[] lookupMemoized(String key, Supplier<LmdbRow[]> storeLookup) {
+        Map<String, LmdbRow[]> cache = threadLocalArg1Cache.get();
+        LmdbRow[] cached = cache.get(key);
+        if (cached != null) {
+            localHits.increment();
+            return cached;
+        }
+        misses.increment();
+        LmdbRow[] rows = storeLookup.get();
+        cache.put(key, rows);
+        return rows;
+    }
+
+    private LmdbRow[] lookupShared(String key, Supplier<LmdbRow[]> storeLookup) {
+        String sharedKey = sharedCacheKey(key);
+        LmdbRow[] cached = SHARED_ARG1_CACHE.get(sharedKey);
+        if (cached != null) {
+            sharedHits.increment();
+            return cached;
+        }
+        misses.increment();
+        LmdbRow[] rows = SHARED_ARG1_CACHE.computeIfAbsent(sharedKey, ignored -> storeLookup.get());
+        return rows;
+    }
+
+    private LmdbRow[] lookupTwoLevel(String key, Supplier<LmdbRow[]> storeLookup) {
+        Map<String, LmdbRow[]> localCache = threadLocalArg1Cache.get();
+        LmdbRow[] localRows = localCache.get(key);
+        if (localRows != null) {
+            localHits.increment();
+            return localRows;
+        }
+
+        String sharedKey = sharedCacheKey(key);
+        LmdbRow[] sharedRows = SHARED_ARG1_CACHE.get(sharedKey);
+        if (sharedRows != null) {
+            sharedHits.increment();
+            localCache.put(key, sharedRows);
+            return sharedRows;
+        }
+
+        misses.increment();
+        LmdbRow[] rows = SHARED_ARG1_CACHE.computeIfAbsent(sharedKey, ignored -> storeLookup.get());
+        localCache.put(key, rows);
+        return rows;
+    }
+
+    private static boolean usesThreadLocalCache(Policy policy) {
+        return policy == Policy.MEMOIZE || policy == Policy.TWO_LEVEL;
+    }
+
+    private String sharedCacheKey(String key) {
+        return sharedCachePrefix + key;
+    }
+}

--- a/tests/test_wam_clojure_benchmark_generator.pl
+++ b/tests/test_wam_clojure_benchmark_generator.pl
@@ -90,12 +90,16 @@ test(relation_data_mode_override_seeded_parent_lmdb, [condition(lmdb_helper_tool
             directory_file_path(TmpDir, 'lib/lmdb-artifact-reader.jar', ReaderJarPath),
             directory_file_path(TmpDir, 'lib/liblmdb_artifact_jni.so', NativeLibPath),
             directory_file_path(TmpDir, 'classes/generated/lmdb/LmdbArtifactStore.class', StoreClassPath),
+            directory_file_path(TmpDir, 'classes/generated/lmdb/LmdbLookupCache.class', LookupCacheClassPath),
+            directory_file_path(TmpDir, 'classes/generated/lmdb/LmdbCacheStats.class', CacheStatsClassPath),
             read_file_to_string(CorePath, CoreCode, []),
             read_file_to_string(ManifestPath, Manifest, []),
             assertion(exists_file(LmdbManifestPath)),
             assertion(exists_file(ReaderJarPath)),
             assertion(exists_file(NativeLibPath)),
             assertion(exists_file(StoreClassPath)),
+            assertion(exists_file(LookupCacheClassPath)),
+            assertion(exists_file(CacheStatsClassPath)),
             assertion(sub_string(CoreCode, _, _, _, 'generated.lmdb.LmdbArtifactReader/open')),
             assertion(sub_string(CoreCode, _, _, _, 'category_parent_lmdb')),
             assertion(sub_string(Manifest, _, _, _, '"category_parent" {:mode "lmdb"')),
@@ -168,6 +172,30 @@ test(relation_cache_policy_override_seeded_parent_lmdb_two_level, [condition(lmd
         )),
         ( maybe_abolish_test_predicate(wam_clojure_benchmark_relation_data_mode/2),
           maybe_abolish_test_predicate(wam_clojure_benchmark_relation_cache_policy/2)
+        )
+    ).
+
+test(relation_cache_debug_override_seeded_parent_lmdb_two_level, [condition(lmdb_helper_toolchain_available)]) :-
+    setup_call_cleanup(
+        ( load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
+          assertz(user:wam_clojure_benchmark_relation_data_mode(category_parent, lmdb)),
+          assertz(user:wam_clojure_benchmark_relation_cache_policy(category_parent, two_level)),
+          assertz(user:wam_clojure_benchmark_relation_cache_debug(category_parent, true))
+        ),
+        once((
+            unique_tmp_dir('tmp_wam_clojure_bench_rel_parent_lmdb_debug', TmpDir),
+            generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, artifact),
+            directory_file_path(TmpDir, 'src/generated/wam_clojure_optimized_bench/core.clj', CorePath),
+            read_file_to_string(CorePath, CoreCode, []),
+            assertion(sub_string(CoreCode, _, _, _, '.cacheStats')),
+            assertion(sub_string(CoreCode, _, _, _, 'lmdb_cache_stats category_parent/2')),
+            assertion(sub_string(CoreCode, _, _, _, 'lmdb_cache_stats category_ancestor/4')),
+            assertion(sub_string(CoreCode, _, _, _, 'lmdb_cache_stats benchmark-category-parents')),
+            delete_directory_and_contents(TmpDir)
+        )),
+        ( maybe_abolish_test_predicate(wam_clojure_benchmark_relation_data_mode/2),
+          maybe_abolish_test_predicate(wam_clojure_benchmark_relation_cache_policy/2),
+          maybe_abolish_test_predicate(wam_clojure_benchmark_relation_cache_debug/2)
         )
     ).
 
@@ -411,6 +439,31 @@ test(generated_category_parent_lmdb_two_level_handler_executes,
         )
     ).
 
+test(generated_category_parent_lmdb_two_level_debug_emits_stats,
+     [condition((clojure_available, lmdb_helper_toolchain_available))]) :-
+    setup_call_cleanup(
+        ( load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
+          assertz(user:wam_clojure_benchmark_relation_data_mode(category_parent, lmdb)),
+          assertz(user:wam_clojure_benchmark_relation_cache_policy(category_parent, two_level)),
+          assertz(user:wam_clojure_benchmark_relation_cache_debug(category_parent, true))
+        ),
+        once((
+            unique_tmp_dir('tmp_wam_clojure_bench_exec_lmdb_debug', TmpDir),
+            generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, artifact),
+            run_clojure_predicate_with_stderr(TmpDir, 'category_parent/2',
+                                              ['Abstraction', 'Thought'],
+                                              "true",
+                                              Stderr),
+            assertion(sub_string(Stderr, _, _, _, 'lmdb_cache_stats category_parent/2')),
+            assertion(sub_string(Stderr, _, _, _, 'localHits')),
+            delete_directory_and_contents(TmpDir)
+        )),
+        ( maybe_abolish_test_predicate(wam_clojure_benchmark_relation_data_mode/2),
+          maybe_abolish_test_predicate(wam_clojure_benchmark_relation_cache_policy/2),
+          maybe_abolish_test_predicate(wam_clojure_benchmark_relation_cache_debug/2)
+        )
+    ).
+
 :- end_tests(wam_clojure_benchmark_generator).
 
 unique_tmp_dir(Prefix, TmpDir) :-
@@ -451,6 +504,37 @@ run_clojure_predicate(ProjectDir, PredKey, Args, Output) :-
     ->  true
     ;   throw(error(java_stderr(PredKey, Args, ErrStr), _))
     ).
+
+run_clojure_predicate_with_stderr(ProjectDir, PredKey, Args, Output, Stderr) :-
+    project_clojure_classpath(ProjectDir, ClassPath),
+    project_java_library_path_args(ProjectDir, JavaLibArgs),
+    maplist(clojure_edn_arg, Args, EdnArgs),
+    append(JavaLibArgs,
+           ['-cp', ClassPath, 'clojure.main', '-m',
+            'generated.wam_clojure_optimized_bench.core', PredKey|EdnArgs],
+           JavaArgs),
+    process_create(path(java),
+                   JavaArgs,
+                   [ cwd(ProjectDir),
+                     stdout(pipe(Out)),
+                     stderr(pipe(Err)),
+                     process(PID)
+                   ]),
+    process_wait(PID, Status, [timeout(20)]),
+    (   Status == timeout
+    ->  process_kill(PID)
+    ;   true
+    ),
+    read_string(Out, _, OutStr0),
+    read_string(Err, _, ErrStr0),
+    close(Out),
+    close(Err),
+    (   Status == exit(0)
+    ->  true
+    ;   throw(error(java_exit(PredKey, Args, Status, ErrStr0), _))
+    ),
+    normalize_space(string(Output), OutStr0),
+    normalize_space(string(Stderr), ErrStr0).
 
 clojure_edn_arg(raw(Edn), Edn) :- !.
 clojure_edn_arg(visited(Atoms), Edn) :- !,


### PR DESCRIPTION
## Summary

Refactors the JVM-side LMDB cache policy logic for the Clojure hybrid
WAM path into a clearer dedicated seam and adds opt-in cache stats hooks
for generated Clojure LMDB projects.

This keeps the layering explicit:

- native LMDB transaction/cursor ownership stays in `LmdbArtifactStore`
- reader lifecycle stays in `LmdbArtifactReader`
- cache policy logic now lives in a separate `LmdbLookupCache` seam
- generated Clojure projects can emit cache stats only when explicitly
  requested

## What Changed

- adds `LmdbLookupCache` as a dedicated JVM-side cache policy layer
- adds `LmdbCacheStats` as the lightweight stats surface
- refactors `LmdbArtifactReader` to delegate `lookupArg1` policy to the
  new seam
- preserves existing cache-policy behavior:
  - `none`
  - `memoize`
  - `shared`
  - `two_level`
- exposes:
  - `cacheStats()`
  - `resetCurrentThreadStats()`

## Generated Clojure Support

The Clojure benchmark generator now:

- packages the new helper classes into generated LMDB-backed projects
- supports opt-in cache debug predicates:
  - `wam_clojure_benchmark_relation_cache_debug/2`
  - `benchmark_relation_cache_debug/2`
- emits `lmdb_cache_stats ...` lines to `stderr` for focused LMDB cache
  probes when debug is enabled
- leaves normal benchmark and predicate behavior unchanged by default

## Tests

Verified locally with:

- `sh examples/scala_lmdb_jni_probe/build.sh`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`
- `git diff --check`

Coverage includes:

- helper class packaging
- generated `.cacheStats` wiring
- LMDB cache debug code generation
- LMDB debug stderr emission from generated Clojure predicate runs

## Why This Boundary

This is a clean PR boundary because it improves observability and
structure without committing to further cache policy changes or default
selection. It prepares the Clojure LMDB path for better desktop-side
measurement while keeping Termux work focused on correctness and wiring.

## Follow-up

- use desktop runs to compare:
  - `none`
  - `memoize`
  - `shared`
  - `two_level`
- decide whether any policy deserves to become a preferred default
- only then consider invalidation or memory-budget controls
