### PR TITLE
fix(wam-elixir): finalise_aggregate pops env frame (closes §6 risk #7)

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -1146,6 +1146,35 @@ compile_aggregate_helpers_to_elixir(Code) :-
       cp: agg_cp.cp,
       choice_points: rest_cps
     }
+    # Simulate the predicates deallocate before tail-calling the
+    # saved continuation. agg_cp was pushed INSIDE the predicates
+    # body, AFTER allocate ran — so agg_cp.stack carries the
+    # current predicates env on top. agg_cp.cp was set BEFORE
+    # this predicates allocate (by the callers call instruction
+    # or by the run/1 entry), so it expects state.stack to be the
+    # callers stack, not the callees. end_aggregates throw fail
+    # bypasses the inner deallocate that would normally pop this
+    # frame — finalise has to do it itself. Without this, the
+    # saved cp runs with the wrong Y-regs active and reads stale
+    # values (proposal section 6 risk 7 — nested findall).
+    restored =
+      case restored.stack do
+        [env | rest] ->
+          {_callee_ys, base_regs} = split_y_regs(restored.regs)
+          merged = Map.merge(base_regs, Map.get(env, :y_regs_saved, %{}))
+          %{restored |
+            cp: env.cp,
+            stack: rest,
+            regs: merged,
+            cut_point: Map.get(env, :cut_point, restored.cut_point)
+          }
+        _ ->
+          # No env on top — leave the snapshot as-is. This shouldnt
+          # happen in practice because begin_aggregate is always
+          # preceded by allocate (findall uses Y-regs), but defending
+          # against it costs nothing.
+          restored
+      end
     restored.cp.(restored)
   end', []).
 

--- a/tests/test_wam_elixir_lowered_phase3.pl
+++ b/tests/test_wam_elixir_lowered_phase3.pl
@@ -149,40 +149,25 @@ user:phase3_findall_qualified(L) :- findall(X, user:phase3_smoke_p(X), L).
 user:phase3_one_solution(only).
 user:phase3_findall_one(L) :- findall(X, phase3_one_solution(X), L).
 
-% Nested findall — proposal §6 risk #7 — surfaced a deeper
-% architectural issue during this PR's investigation, deferred to a
-% focused follow-up:
+% Scenario 11: nested findall — proposal §6 risk #7. Deferred from
+% the Phase 3c trail-bind PR (#1659) and now activated by this
+% PR's finalise-pops-env-frame fix (option (a) from that PR's
+% deferred-scenario comment block).
 %
-%   When end_aggregate throws {:fail, state}, wrap_segment's catch
-%   calls backtrack/1, which routes to finalise_aggregate/4.
-%   finalise tail-calls the saved continuation (agg_cp.cp = the
-%   outer caller's post-call continuation) DIRECTLY, bypassing the
-%   inner predicate's deallocate instruction. The outer continuation
-%   then runs with the inner's stack frame still active — Y-reg
-%   accesses see the inner's Y-regs, not the outer's. For
-%   single-level findall this works because there's no outer
-%   "Y-reg consumer" after the call (the post-call continuation only
-%   touches X-regs and the result_reg via aggregate_collect). For
-%   nested findall, the outer's end_aggregate Y1 reads the wrong Y1.
-%
-%   The trail-bind fix in this PR (finalise binds the result through
-%   the underlying unbound ref's id, not just the integer reg slot)
-%   makes single-level findall correctly bind L at the parameter
-%   slot instead of incidentally leaving the value at the X-reg
-%   only. This is necessary but not sufficient for nested.
-%
-%   Follow-up options for the architectural fix:
-%   (a) Have finalise simulate deallocate when state.stack has an
-%       env frame above the saved snapshot — pop frames until the
-%       agg_cp.stack snapshot matches.
-%   (b) Restructure end_aggregate's lowering to fall through to the
-%       inner's deallocate before throwing fail.
-%   (c) Push the agg frame BEFORE allocate, so agg_cp.stack
-%       captures the pre-allocate state and finalise's restore
-%       naturally pops the inner env.
-%
-%   Each option needs careful design — that's its own PR after
-%   Phase 3c lands.
+% Outer findall iterates inner-findall results. The inner
+% phase3_nested_inner/1 is single-clause and deterministically
+% returns [a, b, c], so the outer collects exactly one solution
+% whose value is that inner list. Validates the full chain:
+%   - inner finalise binds L through the trail (PR #1659)
+%   - inner finalise pops inner_env from state.stack (this PR), so
+%     the saved cp (= outer's post-call k1) runs with the OUTER's
+%     Y-regs active
+%   - outer's end_aggregate Y1 reads the now-correctly-bound L
+%   - outer aggregate_collect captures it
+%   - outer finalise binds LL through the trail
+%   - outer finalise pops outer_env, tail-calls terminal_cp
+user:phase3_nested_inner(L) :- findall(X, phase3_smoke_p(X), L).
+user:phase3_nested_outer(LL) :- findall(L, phase3_nested_inner(L), LL).
 
 %% tmp_root — try TMPDIR / TMP / TEMP / $PREFIX/tmp / ./output in
 %% order. Same fallback chain as the existing benchmark harness.
@@ -226,7 +211,9 @@ phase3_predicates([
     user:phase3_min/1,
     user:phase3_findall_qualified/1,
     user:phase3_one_solution/1,
-    user:phase3_findall_one/1
+    user:phase3_findall_one/1,
+    user:phase3_nested_inner/1,
+    user:phase3_nested_outer/1
 ]).
 
 %% phase3_driver_invocations(-Lines)
@@ -253,7 +240,9 @@ phase3_driver_invocations([
     'r9 = Phase3Smoke.Phase3FindallQualified.run([{:unbound, make_ref()}])',
     'IO.inspect(r9, label: "SCENARIO_FINDALL_QUALIFIED", charlists: :as_lists)',
     'r10 = Phase3Smoke.Phase3FindallOne.run([{:unbound, make_ref()}])',
-    'IO.inspect(r10, label: "SCENARIO_FINDALL_ONE_CLAUSE", charlists: :as_lists)'
+    'IO.inspect(r10, label: "SCENARIO_FINDALL_ONE_CLAUSE", charlists: :as_lists)',
+    'r11 = Phase3Smoke.Phase3NestedOuter.run([{:unbound, make_ref()}])',
+    'IO.inspect(r11, label: "SCENARIO_FINDALL_NESTED", charlists: :as_lists)'
 ]).
 
 %% Generate the test project. Predicates and driver invocations are
@@ -399,6 +388,19 @@ assert_scenario_findall_one_clause(StdOut) :-
     % reached on the very first throw-fail after aggregate_collect.
     sub_string(W, _, _, _, "\"only\"").
 
+assert_scenario_findall_nested(StdOut) :-
+    scope_after_label(StdOut, "SCENARIO_FINDALL_NESTED", W),
+    % Nested findall: outer iterates inner-findall results. The
+    % inner phase3_nested_inner/1 deterministically returns
+    % [a, b, c]; outer collects exactly one solution whose value
+    % is that inner list. After the finalise-pops-env-frame fix
+    % in this PR, all three values are correctly bound through
+    % the trail across both aggregate frames and the parameter
+    % slot resolves to the nested list.
+    sub_string(W, _, _, _, "\"a\""),
+    sub_string(W, _, _, _, "\"b\""),
+    sub_string(W, _, _, _, "\"c\"").
+
 %% Per-scenario test wrappers that share captured StdOut/StdErr/ExitCode.
 
 run_scenario(Test, Assertion, StdOut, StdErr, ExitCode) :-
@@ -441,6 +443,9 @@ run_all_scenarios(StdOut, StdErr, ExitCode) :-
                  StdOut, StdErr, ExitCode),
     run_scenario('Phase 3c: findall(X, phase3_one_solution(X), L) → ["only"] (single-clause, no try_me_else CPs)',
                  assert_scenario_findall_one_clause,
+                 StdOut, StdErr, ExitCode),
+    run_scenario('Phase 3c: nested findall — outer iterates inner-findall results (proposal §6 risk #7)',
+                 assert_scenario_findall_nested,
                  StdOut, StdErr, ExitCode).
 
 %% Test runner — single project, single elixir invocation, all


### PR DESCRIPTION
## Summary

- Closes proposal §6 risk #7 — nested findall — which was deferred from #1659 with three documented architectural options. This PR ships option (a): `finalise_aggregate/4` simulates `deallocate` after restoring the snapshot, popping the predicate's own env frame and restoring the saved Y-regs / cp / cut_point so the saved continuation runs in the *caller's* frame.
- ~10 lines of new code in one runtime helper. No byte-shape change. No WAM-compiler changes.
- Activates the nested findall runtime scenario sketched as a comment in #1659's deferred-scenario block.
- 80/80 target tests + 11/11 Phase 3 runtime scenarios passing on Termux (Elixir 1.19, OTP 28).

## The bug

`agg_cp` is pushed *inside* the predicate's body, *after* the predicate's `allocate` ran. So `agg_cp.stack` carries the current predicate's env on top. But `agg_cp.cp` — the continuation finalise tail-calls — was set *before* this predicate's `allocate` (by the caller's `call` instruction or by `run/1`'s entry). It expects `state.stack` to be the *caller's* stack, not the *callee's*.

`end_aggregate`'s `throw({:fail, state})` bypasses the inner predicate's `deallocate` (the throw goes to the surrounding `wrap_segment` catch, which calls `backtrack`, which routes to `finalise`, which tail-calls saved cp directly). Without explicit cleanup, the saved continuation runs with the wrong Y-regs active and reads stale values.

**Single-level findall happened to work** because the saved cp at the top level is `terminal_cp`, which doesn't touch Y-regs — it just returns `{:ok, state}`. The trail-bind fix in #1659 made `materialise_args` resolve the parameter slot correctly through the heap-side ref binding (independent of the Y-regs).

**Nested findall failed** because the outer predicate's post-call `k1` continuation reads Y1 to feed `end_aggregate`. With the inner predicate's frame still on top of the stack, that read returns the inner's Y1 (still unbound, holding the inner's Template X) instead of the outer's Y1 (which after the inner's correct trail-bind now holds the bound L). `aggregate_collect` captures the inner's unbound, the outer's findall accumulates a list of unbound refs, and the result is `[unbound]` instead of `[["a", "b", "c"]]`.

## The fix

After restoring the snapshot in `finalise_aggregate/4`, simulate `deallocate`:

```elixir
restored =
  case restored.stack do
    [env | rest] ->
      {_callee_ys, base_regs} = split_y_regs(restored.regs)
      merged = Map.merge(base_regs, Map.get(env, :y_regs_saved, %{}))
      %{restored |
        cp: env.cp,
        stack: rest,
        regs: merged,
        cut_point: Map.get(env, :cut_point, restored.cut_point)
      }
    _ ->
      restored  # defensive — findall always allocates first
  end
restored.cp.(restored)
```

This walks the same logic as the `deallocate` instruction's lowering: split off Y-regs, merge `env.y_regs_saved` over base regs, restore `env.cp` and `env.cut_point`, drop the env from the stack. Defensive case for empty stack — shouldn't happen in practice (findall always allocates first because it uses Y-regs) but costs nothing.

## Why option (a) over (b) and (c)

| Option | Where it lives | Scope |
|---|---|---|
| **(a) finalise simulates deallocate** (this PR) | Runtime helper | ~10 lines |
| (b) restructure end_aggregate lowering to flow through deallocate first | Per-instruction emit pipeline | Cross-cutting |
| (c) push agg frame BEFORE allocate so snapshot captures pre-allocate state | WAM compiler | Affects every target's begin_aggregate |

Option (a) is the smallest, most localised fix and doesn't require coordinating any WAM-compiler or lowering changes. Options (b) and (c) remain available as future refactors if the architecture ever needs to evolve, but neither buys anything additional today.

## End-to-end trace (nested findall, post-fix)

For `phase3_nested_outer(LL) :- findall(L, phase3_nested_inner(L), LL).` where `phase3_nested_inner(L) :- findall(X, phase3_smoke_p(X), L).`:

1. Outer entry: `state.cp = terminal_cp`, `state.stack = []`. Outer's allocate pushes `outer_env` (cp=terminal_cp, y_regs_saved={}). Outer's body sets up `Y1 = L_unbound`, pushes `agg_outer_cp` (cp=terminal_cp, stack=[outer_env]).
2. Outer's `call phase3_nested_inner/1` sets `state.cp = &outer_k1` and tail-calls.
3. Inner's allocate pushes `inner_env` (cp=&outer_k1, y_regs_saved={201: L_unbound}). Inner's body sets up `Y1 = X_unbound`, pushes `agg_inner_cp` (cp=&outer_k1, stack=[inner_env, outer_env]).
4. Inner's `call phase3_smoke_p/1` enumerates 3 clauses. Each iteration: `aggregate_collect` captures the bound X, throw fail, backtrack to next clause.
5. After all 3 clauses, backtrack pops `agg_inner_cp` → `finalise_aggregate(:findall)`. accum=`["a","b","c"]`. Trail-binds `state.regs[L_unbound_id] = ["a","b","c"]`. Restores from snapshot (stack=[inner_env, outer_env]).
6. **This PR's fix:** finalise pops `inner_env`. Saved Y-regs `{201: L_unbound}` merged over base regs → `state.regs[201] = L_unbound` (the *outer*'s Y1, still pointing at the same ref). State.cp = inner_env.cp = &outer_k1. State.stack = [outer_env].
7. Tail-call `&outer_k1`. Outer's k1 runs `end_aggregate Y1` → `aggregate_collect(state, 201)`. Get reg 201 = `{:unbound, L_id}`, deref → `state.regs[L_id]` = `["a","b","c"]`. Captures `["a","b","c"]` into `agg_outer_cp.agg_accum`. Throw fail.
8. Backtrack pops `agg_outer_cp` → `finalise_aggregate(:findall)`. accum=`[["a","b","c"]]`. Trail-binds `state.regs[LL_unbound_id] = [["a","b","c"]]`. Restores snapshot (stack=[outer_env]).
9. Finalise pops `outer_env`. Saved Y-regs `{}` (top-level, no caller Y-regs). State.cp = outer_env.cp = terminal_cp. State.stack = [].
10. Tail-call terminal_cp → `{:ok, state}`. `materialise_args` derefs LL via `state.regs[LL_id]` → `[["a","b","c"]]`. ✓

## Reviewer notes

**Why no existing test was failing for option-(a)'s pop logic.** Same story as the trail-bind fix in #1659 — the substring-match assertion strategy is sensitive to *presence* of values but blind to *which slot they're at*. Single-level findall passed pre-fix because the result happened to be in `state.regs[X_reg_idx]` somewhere in the IO.inspect dump. The pop changes which slot the result lives at after finalise, but the substring-match assertions still find the values. The new value of the fix is unblocking nested findall — a scenario that was provably broken at the substring level too (the values weren't anywhere in the dump because they were lost through the inner predicate's stack frame mismatch).

**Defensive empty-stack case.** The pattern match handles `[]` by returning `restored` unchanged. This shouldn't trigger in practice because `findall`/`aggregate_all` always emit `allocate` before `begin_aggregate` (they use Y-regs). The defensive case costs nothing and avoids a runtime crash if the WAM compiler is ever extended to skip `allocate` for some narrow case.

**Why no `simulate_deallocate_for_finalise/2` helper extraction.** The pop logic is short enough (8 lines) and only used here. A separate `defp` would add indirection without reuse. Inline keeps the finalise-aggregate flow readable end-to-end.

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_target.pl` — 80/80 passing (no byte-shape change)
- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_lowered_phase3.pl` — 11/11 passing (10 prior + nested findall scenario activated)
- [x] WAM byte-shape direct probe — confirmed `agg_cp.stack` carries `[inner_env, outer_env]` for nested case, pop produces `[outer_env]` correctly
- [x] Pre-existing `test_wam_e2e.pl atom/1` failure exists on `main`, unrelated to this PR

## Phase plan (post-merge)

- **Phase 3c continuation (next)**: Y-register Template deep-copy probe (§6 risk #1) and cut in inner goal (§6 risk #3). Both still untested at runtime; each likely surfaces its own findings, hence its own focused PR.
- **`:sum` numeric encoding** (parallel track): Substrate-level fix in `put_constant` lowering (integers as Elixir strings).
- **Dynamic Elixir `:/2` runtime support** (parallel track, no blocker): CP-frame extension to `backtrack/1` for meta-call. Pick up only if a real predicate ever needs dynamic meta-call.
- **Phase 4** (later): Tier-2 × findall — branch-local-accum protocol from Haskell. Now significantly closer to feasible because the sequential nested case works correctly.

## Related

- Findall track: proposal #1626 → substrate #1627 → lowering #1643 → harness #1647 → coverage #1649 → Y-reg fix #1650 → static-unwrap #1658 → trail-bind #1659 → finalise frame pop (this PR)
- The deferred-scenario block in #1659 documented the three options that informed this PR's choice
- Haskell precedent (similar but distinct frame-cleanup problem in the parallel case): `wam_haskell_target.pl:1502-1516`
