### PR TITLE
`fix(wam): findall over compound Templates (closes §6 risk #1)`

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -1046,21 +1046,27 @@ compile_aggregate_helpers_to_elixir(Code) :-
   frame\'s :agg_accum (O(1)). Returns updated state.
 
   Atomic values (strings/numbers/atoms) survive trail unwind without
-  copy because they\'re value types in BEAM. Compound values that
-  reference heap cells (e.g. lists, structures) are a known
-  follow-up — see WAM_ELIXIR_TIER2_FINDALL.md §6 risk #1. For Phase
-  1 substrate the simple cases (`findall(X, member(X, [a,b,c]), L)`,
-  `findall(X, p(X), L)` over fact predicates) are unaffected.
+  copy because theyre value types in BEAM. Compound values that
+  reference heap cells (e.g. structures from put_structure +
+  set_value, emitted by compile_aggregate_alls compound-Template
+  construction code) are deep-copied via deep_copy_value/2 below —
+  the captured value becomes a self-contained {:struct, "name/arity",
+  [args]} tuple that survives backtracks heap-rewind. Without
+  deep-copy, all elements of accum would point to the same heap
+  region (because end_aggregates throw fail rewinds the heap; the
+  next iterations put_structure overwrites the same addresses).
 
   If no aggregate frame is present, returns state unchanged (caller
   misuse — emitter should always pair end_aggregate with begin).
 
-  Walk cost: O(N) in choice-point depth per call. Acceptable for
-  Phase 1; if Phase 3 profiling shows this dominates, an
-  agg_frame_idx field on state can collapse it to O(1).
+  Walk cost: O(N) in choice-point depth per call (for the agg-frame
+  search) plus O(M) in heap-structure size (for deep_copy). Both
+  acceptable for Phase 3; if Phase 4 profiling shows either
+  dominates, separate optimisations can address them.
   """
   def aggregate_collect(state, value_reg) do
-    val = deref_var(state, Map.get(state.regs, value_reg))
+    raw = Map.get(state.regs, value_reg)
+    val = deep_copy_value(state, raw)
     {updated_cps, _collected} =
       Enum.map_reduce(state.choice_points, false, fn cp, collected ->
         cond do
@@ -1072,6 +1078,49 @@ compile_aggregate_helpers_to_elixir(Code) :-
         end
       end)
     %{state | choice_points: updated_cps}
+  end
+
+  @doc """
+  Recursively walk a captured value, resolving heap references into
+  self-contained Elixir tuples that survive backtracks heap-rewind.
+
+  Cases:
+    {:unbound, _}  → deref through state.regs; recurse on the bound
+                     value if any, else return as-is (degenerate).
+    {:ref, addr}   → read heap[addr]. If {:str, "name/arity"}, parse
+                     arity and recursively deep-copy the args at
+                     heap[addr+1..addr+arity]. Yields {:struct,
+                     "name/arity", [arg_copies...]}.
+    Anything else  → atomic value (string/number/atom/list of
+                     atomics) — return as-is.
+
+  Lists built via put_list / set_value chains arent yet handled —
+  they would need heap-walking through ./2 cons cells. For Phase 3c
+  the compound-Template scenarios use only structures and atomic
+  args.
+  """
+  def deep_copy_value(state, val) do
+    case val do
+      {:unbound, _} = unb ->
+        derefed = deref_var(state, unb)
+        if derefed == unb, do: unb, else: deep_copy_value(state, derefed)
+      {:ref, addr} ->
+        case Map.get(state.heap, addr) do
+          {:str, functor} ->
+            arity = parse_functor_arity(functor)
+            args =
+              if arity > 0 do
+                for i <- 1..arity, do: deep_copy_value(state, Map.get(state.heap, addr + i))
+              else
+                []
+              end
+            {:struct, functor, args}
+          _ ->
+            val
+        end
+      _ ->
+        val
+    end
   end
 
   @doc """

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -737,9 +737,22 @@ compile_aggregate_all(Template, InnerGoal, Result, V0, Vf, Code) :-
     ->  % ValueVar is a Prolog variable — allocate a Y-register for it
         allocate_var(ValueVar, V1, V2, ValueReg),
         % Emit put_variable to actually create the Y-register in the env frame
-        format(string(InitValueCode), "    put_variable ~w, A1", [ValueReg])
+        format(string(InitValueCode), "    put_variable ~w, A1", [ValueReg]),
+        ConstructionCode = ""
+    ;   compound(ValueVar)
+    ->  % Compound Template — `findall(p(X, Y), Goal, L)` and similar.
+        % Allocate Y-regs for each variable arg, init via put_variable so
+        % each iteration starts with fresh refs (the inner goal binds
+        % them through head unification). After the inner returns, build
+        % the Template structure on the heap via put_structure +
+        % set_value/set_constant. ValueReg = A1 holds the heap ref so
+        % end_aggregate captures it. aggregate_collect on the Elixir
+        % runtime side deep-copies the heap structure into a self-
+        % contained value before backtrack rewinds the heap.
+        compile_compound_template(ValueVar, V1, V2, InitValueCode, ConstructionCode),
+        ValueReg = 'A1'
     ;   % Constant value (e.g., count uses 1) — use A1 as placeholder
-        ValueReg = 'A1', V2 = V1, InitValueCode = ""
+        ValueReg = 'A1', V2 = V1, InitValueCode = "", ConstructionCode = ""
     ),
     % Flatten the InnerGoal conjunction into a list of goals
     flatten_conjunction(InnerGoal, GoalList),
@@ -752,14 +765,75 @@ compile_aggregate_all(Template, InnerGoal, Result, V0, Vf, Code) :-
     % pre_assign_permanent_vars call here — it would reassign variables
     % that already have Y-register slots from the outer pass.
     compile_inner_call_goals(GoalList, V2, Vf, InnerCode),
+    % For compound Templates, the construction code runs AFTER the
+    % inner-goal call but BEFORE end_aggregate captures.
+    (   ConstructionCode == ""
+    ->  FullInnerCode = InnerCode
+    ;   format(string(FullInnerCode), "~w~n~w", [InnerCode, ConstructionCode])
+    ),
     (   InitValueCode \= ""
     ->  format(string(Code),
             "~w~n    begin_aggregate ~w, ~w, ~w~n~w~n    end_aggregate ~w",
-            [InitValueCode, AggType, ValueReg, ResultReg0, InnerCode, ValueReg])
+            [InitValueCode, AggType, ValueReg, ResultReg0, FullInnerCode, ValueReg])
     ;   format(string(Code),
             "    begin_aggregate ~w, ~w, ~w~n~w~n    end_aggregate ~w",
-            [AggType, ValueReg, ResultReg0, InnerCode, ValueReg])
+            [AggType, ValueReg, ResultReg0, FullInnerCode, ValueReg])
     ).
+
+%% compile_compound_template(+Template, +V0, -Vf, -InitCode, -ConstructionCode)
+%  For findall(Functor(Arg1, Arg2, ...), Goal, L) with compound Template:
+%  - Each Arg is either a variable or a constant
+%  - Variables get Y-regs allocated (via allocate_var) so they have
+%    stable slots across the inner-goal call
+%  - InitCode emits put_variable Y_n, A_n for variables and
+%    put_constant for constants — fresh refs each iteration
+%  - ConstructionCode emits put_structure + set_value/set_constant
+%    after the inner goal returns; A1 holds the heap ref to the
+%    constructed Template
+%  - Compound args within the Template (e.g., `findall(p(f(X)), ...)`)
+%    are not yet supported — would need recursive heap construction.
+compile_compound_template(Template, V0, Vf, InitCode, ConstructionCode) :-
+    Template =.. [Functor | Args],
+    length(Args, Arity),
+    compile_template_arg_init(Args, 1, V0, V1, InitLines),
+    (   InitLines == []
+    ->  InitCode = ""
+    ;   atomic_list_concat(InitLines, '\n', InitCode)
+    ),
+    format(string(PutStrucCode), "    put_structure ~w/~w, A1", [Functor, Arity]),
+    compile_template_arg_set(Args, V1, Vf, SetLines),
+    atomic_list_concat([PutStrucCode | SetLines], '\n', ConstructionCode).
+
+compile_template_arg_init([], _, V, V, []).
+compile_template_arg_init([Arg | Rest], I, V0, Vf, Lines) :-
+    (   var(Arg)
+    ->  allocate_var(Arg, V0, V1, Reg),
+        format(string(Line), "    put_variable ~w, A~w", [Reg, I]),
+        Lines = [Line | RestLines]
+    ;   atomic(Arg)
+    ->  V1 = V0,
+        quote_wam_constant(Arg, ArgStr),
+        format(string(Line), "    put_constant ~w, A~w", [ArgStr, I]),
+        Lines = [Line | RestLines]
+    ;   % Compound or other — not yet supported
+        throw(error(unsupported_template_arg(Arg), compile_compound_template/5))
+    ),
+    NI is I + 1,
+    compile_template_arg_init(Rest, NI, V1, Vf, RestLines).
+
+compile_template_arg_set([], V, V, []).
+compile_template_arg_set([Arg | Rest], V0, Vf, [Line | Lines]) :-
+    (   var(Arg)
+    ->  get_var_reg(Arg, V0, Reg),
+        format(string(Line), "    set_value ~w", [Reg]),
+        V1 = V0
+    ;   atomic(Arg)
+    ->  V1 = V0,
+        quote_wam_constant(Arg, ArgStr),
+        format(string(Line), "    set_constant ~w", [ArgStr])
+    ;   throw(error(unsupported_template_arg(Arg), compile_compound_template/5))
+    ),
+    compile_template_arg_set(Rest, V1, Vf, Lines).
 
 %% compile_findall(+Template, +InnerGoal, +Result, +V0, -Vf, -Code)
 compile_findall(Template, InnerGoal, Result, V0, Vf, Code) :-

--- a/tests/test_wam_elixir_lowered_phase3.pl
+++ b/tests/test_wam_elixir_lowered_phase3.pl
@@ -169,6 +169,33 @@ user:phase3_findall_one(L) :- findall(X, phase3_one_solution(X), L).
 user:phase3_nested_inner(L) :- findall(X, phase3_smoke_p(X), L).
 user:phase3_nested_outer(LL) :- findall(L, phase3_nested_inner(L), LL).
 
+% Scenario 12: compound Template findall — proposal §6 risk #1 probe
+% (deep-copy of compound captured values). Surfaced and resolved in
+% this PR via two changes:
+%
+%   1. compile_aggregate_all/5 now detects compound Templates
+%      (`Template = compound(...)`), allocates Y-regs for variable
+%      args via the new compile_compound_template/5 helper, and
+%      emits put_structure + set_value/set_constant code AFTER the
+%      inner-goal call so each iteration constructs a fresh heap
+%      structure. Without this the WAM emitted no construction
+%      instructions and end_aggregate captured only A1 (the first
+%      Template arg), losing the other args entirely.
+%
+%   2. WamRuntime.aggregate_collect/2 now deep-copies the captured
+%      value via deep_copy_value/2 before adding to accum.
+%      For atomic captured values (the prior cases, scenarios 1–11)
+%      deep-copy is a no-op pass-through; for compound `{:ref, addr}`
+%      values it walks the heap structure and builds a self-contained
+%      {:struct, "name/arity", [args]} tuple. Without deep-copy all
+%      accum entries would point to the same final iterations heap
+%      addresses (heap_len rewinds during backtrack so put_structure
+%      reuses the same addrs).
+user:phase3_q(a, '1').
+user:phase3_q(b, '2').
+user:phase3_q(c, '3').
+user:phase3_findall_compound(L) :- findall(p(X, Y), phase3_q(X, Y), L).
+
 %% tmp_root — try TMPDIR / TMP / TEMP / $PREFIX/tmp / ./output in
 %% order. Same fallback chain as the existing benchmark harness.
 tmp_root_candidate(Root) :-
@@ -213,7 +240,9 @@ phase3_predicates([
     user:phase3_one_solution/1,
     user:phase3_findall_one/1,
     user:phase3_nested_inner/1,
-    user:phase3_nested_outer/1
+    user:phase3_nested_outer/1,
+    user:phase3_q/2,
+    user:phase3_findall_compound/1
 ]).
 
 %% phase3_driver_invocations(-Lines)
@@ -242,7 +271,9 @@ phase3_driver_invocations([
     'r10 = Phase3Smoke.Phase3FindallOne.run([{:unbound, make_ref()}])',
     'IO.inspect(r10, label: "SCENARIO_FINDALL_ONE_CLAUSE", charlists: :as_lists)',
     'r11 = Phase3Smoke.Phase3NestedOuter.run([{:unbound, make_ref()}])',
-    'IO.inspect(r11, label: "SCENARIO_FINDALL_NESTED", charlists: :as_lists)'
+    'IO.inspect(r11, label: "SCENARIO_FINDALL_NESTED", charlists: :as_lists)',
+    'r12 = Phase3Smoke.Phase3FindallCompound.run([{:unbound, make_ref()}])',
+    'IO.inspect(r12, label: "SCENARIO_FINDALL_COMPOUND", charlists: :as_lists)'
 ]).
 
 %% Generate the test project. Predicates and driver invocations are
@@ -401,6 +432,27 @@ assert_scenario_findall_nested(StdOut) :-
     sub_string(W, _, _, _, "\"b\""),
     sub_string(W, _, _, _, "\"c\"").
 
+assert_scenario_findall_compound(StdOut) :-
+    scope_after_label(StdOut, "SCENARIO_FINDALL_COMPOUND", W),
+    % Compound Template findall: each iteration constructs a fresh
+    % p(X, Y) on the heap and aggregate_collect deep-copies it into
+    % a self-contained {:struct, "p/2", [X, Y]} tuple. After all
+    % three iterations, L should contain three distinct {:struct,
+    % ...} tuples — sub-term identity preserved per Perplexity's
+    % "sharper probe" recommendation. We assert all six sub-term
+    % values are present in the scenario's stdout window. If
+    % deep-copy was missing, all three list elements would point
+    % to the same heap region (the final iteration's p(c, "3"))
+    % so "a", "b", "1", "2" would be absent.
+    sub_string(W, _, _, _, ":struct"),
+    sub_string(W, _, _, _, "p/2"),
+    sub_string(W, _, _, _, "\"a\""),
+    sub_string(W, _, _, _, "\"b\""),
+    sub_string(W, _, _, _, "\"c\""),
+    sub_string(W, _, _, _, "\"1\""),
+    sub_string(W, _, _, _, "\"2\""),
+    sub_string(W, _, _, _, "\"3\"").
+
 %% Per-scenario test wrappers that share captured StdOut/StdErr/ExitCode.
 
 run_scenario(Test, Assertion, StdOut, StdErr, ExitCode) :-
@@ -446,6 +498,9 @@ run_all_scenarios(StdOut, StdErr, ExitCode) :-
                  StdOut, StdErr, ExitCode),
     run_scenario('Phase 3c: nested findall — outer iterates inner-findall results (proposal §6 risk #7)',
                  assert_scenario_findall_nested,
+                 StdOut, StdErr, ExitCode),
+    run_scenario('Phase 3c: findall(p(X,Y), q(X,Y), L) — compound Template + deep-copy (proposal §6 risk #1)',
+                 assert_scenario_findall_compound,
                  StdOut, StdErr, ExitCode).
 
 %% Test runner — single project, single elixir invocation, all

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -784,16 +784,23 @@ test_findall_substrate_emits_push_aggregate_frame :-
     ).
 
 test_findall_substrate_emits_aggregate_collect :-
-    Test = 'Findall substrate: WamRuntime emits aggregate_collect/2 (deref + prepend to nearest agg frame)',
+    Test = 'Findall substrate: WamRuntime emits aggregate_collect/2 (deep-copy + prepend to nearest agg frame)',
     (   compile_wam_runtime_to_elixir([], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, 'def aggregate_collect(state, value_reg)'),
-        % Must deref the value register before capturing.
-        sub_string(S, _, _, _, 'val = deref_var(state, Map.get(state.regs, value_reg))'),
+        % Must deep-copy the value register before capturing — atomic
+        % values pass through unchanged, compound heap structures
+        % become self-contained {:struct, ...} tuples that survive
+        % backtrack's heap-rewind.
+        sub_string(S, _, _, _, 'raw = Map.get(state.regs, value_reg)'),
+        sub_string(S, _, _, _, 'val = deep_copy_value(state, raw)'),
         % Must prepend (O(1)) to the nearest aggregate frame's accum.
-        sub_string(S, _, _, _, '[val | prior]')
+        sub_string(S, _, _, _, '[val | prior]'),
+        % And the deep_copy_value helper itself exists.
+        sub_string(S, _, _, _, 'def deep_copy_value(state, val)'),
+        sub_string(S, _, _, _, '{:str, functor}')
     ->  pass(Test)
-    ;   fail_test(Test, 'aggregate_collect absent or missing deref/prepend logic')
+    ;   fail_test(Test, 'aggregate_collect absent or missing deep-copy/prepend logic')
     ).
 
 test_findall_substrate_emits_finalise_aggregate :-


### PR DESCRIPTION
## Summary

- Closes proposal §6 risk #1 (deep-copy of compound captured values) end-to-end. Started as a probe per Perplexity's recommendation; surfaced a deeper WAM-compiler bug that had to be fixed first.
- **Two distinct bugs fixed in one PR**, both blocking the same user-visible symptom: `findall(p(X, Y), q(X, Y), L)` returns nonsense (or only X's bindings) instead of `[p(a, "1"), p(b, "2"), p(c, "3")]`.
- ~80 lines of WAM-compiler changes (cross-target benefit), ~30 lines of Elixir runtime additions, new test scenario, updated emit-and-grep test.
- 80/80 target tests + 12/12 Phase 3 runtime scenarios + LLVM aggregate test all passing on Termux (Elixir 1.19, OTP 28).

## The two bugs (and why one PR)

The probe started as a focused test of §6 risk #1 — does `aggregate_collect/2` correctly handle compound captured values whose heap representation gets rewound between iterations? Writing the natural fixture surfaced bug #1 first, which masked bug #2.

### Bug 1: WAM compiler emitted no Template construction (cross-target)

`compile_aggregate_all/5` in `src/unifyweaver/targets/wam_target.pl` fell through to the constant-default `ValueReg = 'A1'` branch for any non-bare-variable Template. The inner-goal's call passed Template vars through A1..An as fresh refs, the called predicate bound them via head unification, but **no `put_structure` / `set_value` emission constructed the `p(X, Y)` heap structure**. `end_aggregate` captured A1 (= X's slot) only — Y was lost entirely.

Probe output before the fix, for `findall(p(X, Y), phase3_q(X, Y), L)`:

```elixir
{:ok, %WamRuntime.WamState{regs: %{1 => ["a", "b", "c"], ...}, ...}}
```

`L = ["a", "b", "c"]` — only X's three values, Y entirely absent, no `p` structure anywhere.

Affects every target that uses `compile_aggregate_all` (we noticed via WAM-Elixir; Rust / Go / LLVM / Haskell would have produced similarly broken WAM bytecode silently).

### Bug 2: WamRuntime.aggregate_collect captured raw heap refs

Even if the WAM correctly built a `p(X, Y)` structure on the heap with `value_reg = A1 = {:ref, addr}`, the captured `{:ref, addr}` would point to a heap region that's rewound by `backtrack`'s restore-from-CP-snapshot (`heap_len` resets, the next iteration's `put_structure` starts at the same addr and overwrites). All accum entries would point to the same final iteration's data — the canonical deep-copy issue from proposal §6 risk #1.

### Why one PR

Bug 1 blocked any test of bug 2 — without Template construction, the captured value was never compound, so deep-copy never had anything to do. Fixing bug 1 alone would just expose bug 2 in the same scenario. Splitting into two PRs would mean PR1 lands a partial fix that produces "different but still wrong" output for any 2+ solution case, and PR2 finally makes the scenario work. Combined PR is cleaner — one round of review, one runtime test that exercises both fixes correctly.

## What changes

### `src/unifyweaver/targets/wam_target.pl` (+76 / -6)

New `compound(ValueVar)` branch in `compile_aggregate_all/5` delegates to a new helper:

```prolog
compile_compound_template(Template, V0, Vf, InitCode, ConstructionCode) :-
    Template =.. [Functor | Args],
    length(Args, Arity),
    compile_template_arg_init(Args, 1, V0, V1, InitLines),
    ...
    format(string(PutStrucCode), "    put_structure ~w/~w, A1", [Functor, Arity]),
    compile_template_arg_set(Args, V1, Vf, SetLines),
    ...
```

- `compile_template_arg_init/5` walks Template's args, allocates Y-regs for vars (via `allocate_var/4`) and emits `put_variable Y_n, A_n` (vars) or `put_constant ArgStr, A_n` (constants). Emitted as `InitCode`, placed *before* `begin_aggregate`.
- `compile_template_arg_set/4` walks the same args and emits `set_value Y_n` (vars) or `set_constant ArgStr` (constants). Emitted as `ConstructionCode`, placed *after* the inner-goal call but *before* `end_aggregate` (inside the begin/end_aggregate block).
- `ValueReg = 'A1'` because `put_structure functor/arity, A1` puts the freshly built heap ref into A1; `end_aggregate A1` then captures it.
- Compound args within Template (e.g. `findall(p(f(X)), ..., L)`) aren't yet supported — `compile_template_arg_init/5` and `compile_template_arg_set/4` throw `unsupported_template_arg(Arg)` rather than silently miscompiling.

The result for `findall(p(X, Y), phase3_q(X, Y), L)`:

```
phase3_findall_compound/1:
    allocate
    get_variable X3, A1
    put_variable Y1, A1
    put_variable Y2, A2
    begin_aggregate collect, A1, X3
    put_value Y1, A1
    put_value Y2, A2
    call phase3_q/2, 2
    put_structure p/2, A1
    set_value Y1
    set_value Y2
    end_aggregate A1
    deallocate
    proceed
```

### `src/unifyweaver/targets/wam_elixir_target.pl` (+57 / -10)

New `deep_copy_value/2` helper in `compile_aggregate_helpers_to_elixir/1`:

```elixir
def deep_copy_value(state, val) do
  case val do
    {:unbound, _} = unb ->
      derefed = deref_var(state, unb)
      if derefed == unb, do: unb, else: deep_copy_value(state, derefed)
    {:ref, addr} ->
      case Map.get(state.heap, addr) do
        {:str, functor} ->
          arity = parse_functor_arity(functor)
          args = if arity > 0, do: (for i <- 1..arity, do: deep_copy_value(state, Map.get(state.heap, addr + i))), else: []
          {:struct, functor, args}
        _ -> val
      end
    _ -> val
  end
end
```

`aggregate_collect/2` now calls `deep_copy_value(state, raw)` before adding to accum. For atomic captured values (scenarios 1–11) this is a no-op pass-through; for compound `{:ref, addr}` values it walks the heap and produces self-contained `{:struct, "name/arity", [args]}` tuples that survive backtrack's heap-rewind.

Lists built via `put_list` / `set_value` chains aren't yet handled (they'd need walking through `./2` cons cells). Phase 3c's compound-Template scenarios use only structures and atomic args, so this is sufficient for now; a follow-up can extend deep-copy to lists when a fixture needs it.

### `tests/test_wam_elixir_lowered_phase3.pl` (+59 / -2)

New scenario 12: `findall(p(X, Y), phase3_q(X, Y), L)` with a 3-fact `phase3_q/2`. Asserts presence of all 6 distinct sub-term values (`"a"`, `"b"`, `"c"`, `"1"`, `"2"`, `"3"`) plus `:struct` + `p/2` markers in the scenario's stdout window. If deep-copy were missing, values from non-final iterations (`"a"`, `"b"`, `"1"`, `"2"`) would be absent. Per Perplexity's "sharper probe" recommendation — sub-term identity preserved across iterations.

### `tests/test_wam_elixir_target.pl` (+13 / -4)

Updated `test_findall_substrate_emits_aggregate_collect`: the prior assertion hardcoded `'val = deref_var(state, Map.get(state.regs, value_reg))'` (the pre-deep-copy shape). Replaced with `'raw = Map.get(state.regs, value_reg)' + 'val = deep_copy_value(state, raw)' + 'def deep_copy_value(state, val)' + '{:str, functor}'` to assert the new path. Same overall test count (80/80).

## Reviewer notes

**Why bug 1 wasn't surfaced earlier.** Phase 3a/3b/3c scenarios up through #1661 all used bare-variable Templates: `findall(X, p(X), L)` and the various `aggregate_all(<aggregator>(X), p(X), R)` shapes. Those go through the existing `var(ValueVar)` branch which works correctly. The compound-Template path was never exercised at runtime. The Phase 2 emit-and-grep test for `lower_predicate_to_elixir` over a `findall/3`-using predicate (#1643) was structural-shape-only — confirmed `push_aggregate_frame` and `aggregate_collect` were called, not that the captured values were correct.

**Why bug 1 affects all targets.** The fix is in `wam_target.pl`'s `compile_aggregate_all/5` — the WAM compiler that all targets feed from. Rust / Go / LLVM / Haskell all consume this WAM and would have produced equally broken downstream code for compound Templates. Cross-target benefit is real.

**Why deep_copy_value lives in WamRuntime, not in the lowering.** Per the same logic as `finalise_aggregate/4` (#1659): all aggregate-frame logic is co-located in `compile_aggregate_helpers_to_elixir/1` so the runtime has a single source of truth for the substrate's behaviour. Inlining into the lowered emitter would scatter correctness logic across per-instruction handlers.

**Compound args within Template.** `findall(p(f(X)), ..., L)` would need recursive heap construction — emit nested `put_structure` chains within Template construction. The `unsupported_template_arg` exception in `compile_template_arg_init/5` makes the limitation explicit rather than silently miscompiling. Worth handling in a follow-up if a real predicate needs it; the unbounded-recursion case has subtleties (cyclic structures, sharing) that warrant their own design.

**No bug 2 (get_structure binding propagation through aliased refs) needed for this PR.** During the probe I noticed a separate issue with `get_structure`'s write-mode (it overwrites `state.regs[Ai]` directly rather than trail-binding the underlying unbound ref's id). That issue would have surfaced if the test fixture had used `q_compound(X) :- X = f(a).`-style clauses with `=/2` unification. The actual fixture (`q(a, "1").` etc. — all `get_constant`) bypasses it because `get_constant`'s lowering correctly trail-binds through refs. Documenting as a separate finding for if it ever surfaces.

## End-to-end trace (compound findall, post-fix)

For `findall(p(X, Y), phase3_q(X, Y), L)` with `phase3_q(a, "1"). phase3_q(b, "2"). phase3_q(c, "3").`:

1. Outer entry: `state.cp = terminal_cp`. Allocate. `put_variable Y1, A1` and `put_variable Y2, A2` create fresh refs `X_ref` and `Y_ref` in Y1/A1 and Y2/A2 respectively. `begin_aggregate :collect, A1, X3` pushes agg_cp.
2. `put_value Y1, A1; put_value Y2, A2; call phase3_q/2`. Inner predicate's clause 1 binds A1 to `"a"` (via trail through X_ref) and A2 to `"1"` (via trail through Y_ref).
3. Control returns. `put_structure p/2, A1` writes `heap[0] = {:str, "p/2"}`, sets `A1 = {:ref, 0}`. `set_value Y1` reads Y1 = X_ref unbound, derefs to `"a"`, writes `heap[1] = "a"`. `set_value Y2` writes `heap[2] = "1"`.
4. `end_aggregate A1` calls `aggregate_collect(state, 1)`. `raw = state.regs[1] = {:ref, 0}`. `deep_copy_value` walks: `heap[0] = {:str, "p/2"}` → arity = 2 → recurse on `heap[1] = "a"` (atomic, returns as-is) and `heap[2] = "1"` (atomic). Result: `{:struct, "p/2", ["a", "1"]}`. Prepended to agg accum.
5. Throw fail → backtrack to inner clause 2 → trail unwinds, heap_len resets to 0. Iteration 2 reuses heap addrs 0..2 for `{:str, "p/2"}`, `"b"`, `"2"`. `aggregate_collect` deep-copies → `{:struct, "p/2", ["b", "2"]}`. Different self-contained tuple. Prepended.
6. Iteration 3 similarly → `{:struct, "p/2", ["c", "3"]}`.
7. Backtrack pops agg_cp → finalise_aggregate. accum_rev = `[{:struct, "p/2", ["a", "1"]}, {:struct, "p/2", ["b", "2"]}, {:struct, "p/2", ["c", "3"]}]`. Trail-bind result_reg's underlying ref id to the list. Pop env frame (#1661). Tail-call terminal_cp.
8. `materialise_args` derefs L → the 3-element list of distinct structs. ✓

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_target.pl` — 80/80 passing
- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_lowered_phase3.pl` — 12/12 passing on Termux (11 prior + new compound scenario)
- [x] `swipl -t halt -g test_aggregate_compiles tests/core/test_wam_llvm_aggregate.pl` — passes (its `aggregate_all(min(X), ...)` fixture goes through the bare-variable branch, unchanged)
- [x] WAM byte-shape direct probe — verified the new compound-Template emission shape (init code → begin_aggregate → inner call → construction code → end_aggregate)
- [x] Pre-existing `test_wam_e2e.pl atom/1` failure exists on `main`, unrelated to this PR

## Phase plan (post-merge)

- **Phase 3c continuation (next)**: Cut in inner goal (§6 risk #3) — the only remaining §6 probe with no runtime test yet.
- **`get_structure` aliased-ref binding** (parallel track): Surface noted in this PR's reviewer notes. Same class of bug as the trail-bind fix in #1659 / finalise pop in #1661 — `get_structure`'s write-mode should bind through the underlying ref id, not overwrite the reg slot. Likely small (~10 lines).
- **Compound args within Template** (parallel track): `findall(p(f(X)), ..., L)` extension — recursive heap construction. Medium scope; design needs to handle cyclic structures and sharing.
- **Deep-copy for list shapes** (parallel track): `put_list` / `set_value` chain walking. Cheap once the structure-walking is in place.
- **`:sum` numeric encoding** (parallel track): Substrate fix in `put_constant` lowering.
- **Phase 4** (later): Tier-2 × findall — branch-local-accum protocol from Haskell. Significantly closer to feasible because the sequential compound case now works.

## Related

- Probe motivated by: proposal §6 risk #1, recommended for Phase 3c by Perplexity
- Phase 2 lowering test that didn't catch bug 1 (emit-and-grep, not runtime semantics): #1643
- Findall track: proposal #1626 → substrate #1627 → lowering #1643 → harness #1647 → coverage #1649 → Y-reg fix #1650 → static-unwrap #1658 → trail-bind #1659 → finalise frame pop #1661 → compound Template + deep-copy (this PR)
