### PR TITLE
docs(wam-haskell): mode analysis design for =../2 PutStructureDyn lowering

### DIFF
--- a/docs/design/WAM_HASKELL_MODE_ANALYSIS_PHILOSOPHY.md
+++ b/docs/design/WAM_HASKELL_MODE_ANALYSIS_PHILOSOPHY.md
@@ -1,0 +1,218 @@
+# WAM Mode Analysis: Philosophy
+
+> **Scope:** This doc covers the design-level *why* of the binding-state
+> analysis pass that will unlock the deferred `PutStructureDyn`
+> lowering for `=../2`. The companion docs are
+> `WAM_HASKELL_MODE_ANALYSIS_SPEC.md` (the contract) and
+> `WAM_HASKELL_MODE_ANALYSIS_PLAN.md` (the work breakdown).
+
+## What we have today
+
+The Haskell WAM target supports `T =.. [Name | Args]` (Prolog univ) via
+a single `BuiltinCall "=../2" 2` instruction whose runtime handler
+covers both modes:
+
+- **Compose** (T unbound, Name bound to atom): build a `Str fid args`
+  term from the list and bind T.
+- **Decompose** (T bound to a structure): walk the term, build the
+  list `[Atom name, arg1, ..., argN]`, bind it to A2.
+
+This works correctly as of PR #1657 (the `SetVariable` constructor
+fix). It is also slow on the compose path: the compiler emits a
+`put_list`/`set_value`/`set_constant` cascade to *materialise* the list
+on the heap, then the runtime walks the list to extract the functor
+name and argument vector before constructing the `Str` term. For a
+predicate that constructs terms in a tight loop, that allocation +
+walk dominates.
+
+A faster instruction already exists: `PutStructureDyn nameReg arityReg
+targetReg`. It is the runtime-parsed variant of `PutStructure` —
+it reads the functor name (an atom) and the arity (an integer) from
+registers and pre-allocates a `BuildStruct` builder that subsequent
+`SetValue`/`SetConstant` instructions can populate, exactly like
+static `PutStructure`. No intermediate list. No runtime list walk.
+
+The instruction has been in the WAM since the original
+`PutStructureDyn` work. Nothing emits it yet.
+
+## Why we have not lowered to `PutStructureDyn` yet
+
+`PutStructureDyn` is unsafe in decompose mode. The runtime expects
+`Name` to dereference to an `Atom fid`; if it dereferences to an
+`Unbound`, the step returns `Nothing` and the goal fails. The same
+Prolog source
+
+```prolog
+T =.. [Name, X, Y].
+```
+
+is used both ways — it composes when called with `T` fresh and `Name`
+bound, decomposes when `T` is bound and `Name` is fresh. The compiler
+cannot tell from local syntax alone which mode applies at any given
+call site. Eagerly emitting `PutStructureDyn` for every `=../2`
+would silently break decompose-mode callers.
+
+The fix is to give the compiler enough static knowledge to *prove*
+compose mode at the program point of the `=..` goal. That is what a
+binding-state analysis pass provides.
+
+## What we are willing to spend
+
+We are explicitly **not** building Mercury-style mode analysis.
+
+- We do not need every-mode-of-every-predicate inference.
+- We do not need uniqueness or determinism analysis.
+- We do not need the analysis to be sound across module boundaries
+  in the absence of declarations.
+
+We need a small, conservative pass that answers a single question for
+each variable at each program point in a clause body:
+
+> *Is this variable definitely unbound here? Is it definitely bound to
+> a non-variable? Otherwise: don't know.*
+
+Three-valued, monotonic, propagated forwards. No fixpoint. No
+backwards inference. No abstract domain richer than
+`{ unbound, bound, unknown }`.
+
+That suffices for the `=../2` lowering decision: emit
+`PutStructureDyn` when `T` is `unbound` *and* `Name` is `bound` at the
+goal's program point; fall back to the existing builtin
+otherwise. Anything we cannot prove stays on the existing path —
+correctness is preserved by construction.
+
+## Why this is the right shape of analysis for us now
+
+Three reasons.
+
+**It pays off on the hot predicates we already care about.** The
+canonical compose pattern is
+
+```prolog
+build_term(Functor, Args, T) :- T =.. [Functor | Args].
+```
+
+where `T` is a head argument with mode `-` (output). That is the
+shape used by code-generation utilities in user programs and by
+Prolog-meta interpreters. Those are exactly the predicates that
+benefit from the O(1) `PutStructureDyn` path because they construct
+many terms.
+
+**It opens the door for further small lowerings.** Once we have
+binding state at each program point, several other optimizations
+become trivial:
+
+- `functor/3` in compose mode (functor name + arity → fresh term)
+  can lower to `PutStructureDyn` plus `SetVariable` ×N.
+- `arg/3` on a known-bound term can fuse into a `GetValue` against a
+  pre-projected register, skipping the runtime structure traversal.
+- `\+ member(X, L)` where `L` is ground at the call site can skip
+  the unification machinery and use `IS.notMember` directly.
+
+We are not doing those in this arc, but the analysis we write now is
+the substrate they would all build on. The cost is paid once.
+
+**It composes with the analyses we already have.** The Haskell target
+already runs `purity_certificate`, `clause_body_analysis`, and
+`demand_analysis` per clause. Adding a `binding_state_analysis` pass
+slots in next to them — same input shape (head + body), same output
+shape (a per-goal record list), same consumption pattern (the WAM
+compiler reads it before emitting each goal).
+
+## What we are choosing not to do
+
+- **No backwards propagation.** We do not infer "Y must be bound
+  before this goal because the goal binds it" — only forward
+  reachability.
+- **No interprocedural analysis.** Calls to user predicates are
+  treated as opaque: outputs of a call are `unknown` unless the
+  callee has a `:- mode` declaration that says otherwise.
+- **No groundness lattice.** `bound` means "not unbound" — it does
+  not distinguish "fully ground" from "bound to a structure with
+  unbound holes". For `=..`, that is all we need: `Name` must be
+  bound to an atom (which is automatically ground), and `T` must be
+  unbound. The analysis answer for `T` is what the lowering
+  predicate keys on.
+- **No mode-driven specialisation.** We are not generating multiple
+  WAM bodies per call mode. One body, with the lowering decision
+  made at compile time based on what the analysis can prove.
+
+## Soundness contract
+
+This is the only safety property the analysis must preserve:
+
+> If the analysis says "variable V is `unbound` at program point P",
+> then in every execution that reaches P with V's binding state
+> resolved, V is in fact unbound.
+>
+> If the analysis says "variable V is `bound` at program point P",
+> then in every such execution V is bound to a non-variable term.
+>
+> Otherwise the analysis says `unknown`, and the compiler emits the
+> conservative path.
+
+The lowering decision is gated on the analysis returning a
+*positive* answer for both `T` (unbound) and `Name` (bound). Any
+`unknown` keeps the existing builtin path. There is no scenario in
+which a wrong analysis result silently produces incorrect runtime
+behaviour — at worst, an over-conservative analysis leaves
+performance on the table.
+
+## Relationship to `:- mode` declarations
+
+Mercury-style `:- mode` declarations on user predicates are an
+optional input to the analysis, not a requirement. When present,
+they let us:
+
+- Initialise the binding state of head arguments at the start of
+  body propagation.
+- Annotate predicate calls so output positions become `bound` after
+  the call and input positions are required to be `bound` going in.
+
+When absent, head arguments start at `unknown` and predicate calls
+return `unknown` for all output positions. This is the conservative
+default and is what existing un-annotated code in the repo will get.
+
+The `demand_analysis` module already reads `:- mode/1` declarations
+(see `core/demand_analysis.pl:133-149`). We will reuse that reader
+verbatim — no new directive grammar.
+
+## Non-goals worth naming
+
+- **We are not stabilising a public API for the analysis result.**
+  The output records are an internal detail of the WAM compiler.
+  Other targets (Rust, Go, ILAsm) may grow their own analysers or
+  share this one — that decision is out of scope for this arc.
+- **We are not adding mode polymorphism to user code.** A predicate
+  declared `:- mode pred(+, -)` cannot also be called as
+  `:- mode pred(-, +)` and have both compiled correctly. If you
+  need both, write two predicates. Mercury's mode polymorphism is
+  an entire compiler architecture and we are not building one.
+- **We are not running the analysis on lowered/native predicates.**
+  Predicates that bypass the WAM (the lowered Haskell path,
+  CallForeign FFI predicates, external_source LMDB-backed
+  predicates) are already opaque to the WAM compiler; the
+  analysis treats their outputs the same as it would a call to any
+  user predicate without a mode declaration: `unknown`.
+
+## Success metrics for this arc
+
+The arc is done when:
+
+1. `T =.. [Name | Args]` in compose mode (T proven unbound, Name
+   proven bound) emits `PutStructureDyn` plus `SetValue`/`SetVariable`
+   ×N + a `GetValue` to unify with T, instead of the list-build path.
+2. The same source in decompose mode (T proven bound) keeps the
+   existing builtin path. (Or, when we are not sure, also keeps it.)
+3. The full `tests/test_wam_haskell_target.pl` suite remains green,
+   including the existing `=../2` tests that exercise the builtin
+   path.
+4. A new unit test exercises a compose-mode predicate and asserts
+   the generated `Predicates.hs` contains `PutStructureDyn`, and
+   that the resulting cabal project builds and produces correct
+   results when invoked.
+
+We will *not* benchmark in this arc — the optimisation enables
+follow-up work, but the immediate measurable win is correctness
+of emitted code on the new path. Performance numbers come when a
+real compose-heavy workload exists to measure against.

--- a/docs/design/WAM_HASKELL_MODE_ANALYSIS_PLAN.md
+++ b/docs/design/WAM_HASKELL_MODE_ANALYSIS_PLAN.md
@@ -1,0 +1,373 @@
+# WAM Mode Analysis: Implementation Plan
+
+> **Companion docs:** `WAM_HASKELL_MODE_ANALYSIS_PHILOSOPHY.md`
+> (the *why*) and `WAM_HASKELL_MODE_ANALYSIS_SPEC.md` (the *what*).
+> This doc is the *how*: ordered phases, file-by-file edits, test
+> gates between phases, and rollback advice.
+
+## Phases at a glance
+
+| Phase | Goal | Lines (rough) | Test gate |
+|------:|------|---------------|-----------|
+| **M1** | Skeleton analyser module + initial-env construction from `:- mode/1` | ~150 LOC | unit tests for initial env |
+| **M2** | Per-goal propagation table for guards, `=/2`, `is/2`, term-inspection builtins | ~250 LOC | unit tests for propagation on synthetic goal lists |
+| **M3** | Control-construct handling (if-then-else, disjunction, aggregates) | ~100 LOC | unit tests for meet semantics |
+| **M4** | User-call handling (mode-declared and opaque) | ~80 LOC | unit tests for input/output mode propagation |
+| **M5** | Wire `analyse_clause_bindings` into `wam_target.pl` body walk | ~50 LOC threading change | existing test suite stays green |
+| **M6** | `=../2` lowering decision in `compile_goal_call/5` | ~80 LOC for new clause + emit helper | new codegen unit tests |
+| **M7** | End-to-end: regenerate `dyn-struct-smoke` with mode declarations, build, run, verify `PutStructureDyn` is in the output | ~30 LOC test fixture | smoke fixture builds and produces correct results |
+| **M8** | Documentation: update `MEMORY.md`, `WAM_PERF_OPTIMIZATION_LOG.md`, the project status memory file | docs only | no test impact |
+
+Total estimated LOC: ~700 production, ~400 test, ~150 docs.
+
+## Phase M1 — Skeleton analyser
+
+### Files
+- **New**: `src/unifyweaver/core/binding_state_analysis.pl`
+- **New**: `tests/core/test_binding_state_analysis.pl`
+- **Read-only reference**: `src/unifyweaver/core/clause_body_analysis.pl`
+  (for `variable_key/2` and `normalise_body/2`).
+- **Read-only reference**: `src/unifyweaver/core/demand_analysis.pl`
+  (for `read_mode_declaration/3`, lines 133–149).
+
+### Tasks
+
+1. Create the module skeleton:
+   ```prolog
+   :- module(binding_state_analysis, [
+       analyse_clause_bindings/3,
+       binding_state_at/4,
+       binding_state_at_var/3
+   ]).
+   ```
+2. Implement `binding_state/1` validator and three constructors.
+3. Implement `binding_env/1` as `assoc/1`-wrapped, with helpers:
+   - `empty_binding_env(-Env)`
+   - `set_binding_state(+Env0, +Var, +State, -Env1)`
+   - `get_binding_state(+Env, +Var, -State)` — defaults to `unknown`.
+4. Implement `initial_binding_env/3`:
+   ```prolog
+   initial_binding_env(+Head, +ModeDecl, -Env)
+   ```
+   Reads `Head =.. [_|HeadArgs]`, walks them in lockstep with the
+   mode list (or uses `?` for every position when no mode), and
+   builds an env with appropriate states.
+5. Add a stub `analyse_clause_bindings/3` that returns
+   `goal_binding(1, InitEnv, InitEnv)` for every body goal — no
+   propagation yet. This lets us land the integration test gate in
+   M5 without blocking on M2–M4.
+
+### Test gate (M1)
+
+Add `tests/core/test_binding_state_analysis.pl` with:
+- `test_initial_env_no_mode` — every head arg → `unknown`.
+- `test_initial_env_input_mode` — `+` head var → `bound`.
+- `test_initial_env_output_mode` — `-` head var → `unbound`.
+- `test_initial_env_any_mode` — `?` head var → `unknown`.
+- `test_initial_env_structured_head` — head `foo(f(X))` → X is
+  `bound` regardless of mode.
+- `test_get_default_unknown` — un-set var reads as `unknown`.
+
+Wire the test file into the project test runner (likely the
+`run_all_core_tests` predicate, mirror what
+`tests/core/test_demand_analysis.pl` does).
+
+## Phase M2 — Propagation table for guards, =, is, term inspection
+
+### Files
+- **Edit**: `src/unifyweaver/core/binding_state_analysis.pl`
+- **Edit**: `tests/core/test_binding_state_analysis.pl`
+
+### Tasks
+
+1. Implement `propagate_goal/3` with the rule table from spec §2.3:
+   - Guards (delegate to `clause_body_analysis:is_guard_goal/2`)
+     including the `var/1`, `nonvar/1`, type-test exceptions.
+   - `X = Y` unification with the four sub-cases.
+   - `X is Expr` → X bound.
+   - `functor/3`, `arg/3`, `=../2`, `copy_term/2` per the table.
+   - `\\+/1`, `!/0` → no-op.
+2. Make `analyse_clause_bindings/3` actually walk the body:
+   ```prolog
+   analyse_clause_bindings(Head, Body, GoalBindings) :-
+       lookup_mode_decl(Head, ModeDecl),
+       initial_binding_env(Head, ModeDecl, Env0),
+       clause_body_analysis:normalise_body(Body, NormBody),
+       walk_body(NormBody, 1, Env0, GoalBindings).
+   ```
+3. Implement `walk_body/4` as a fold that emits a `goal_binding/3`
+   per goal and threads the env forward.
+
+### Test gate (M2)
+
+- `test_propagate_unify_var_term` — `X = foo(a)` ⇒ X bound.
+- `test_propagate_unify_two_vars_one_bound` — bound flag propagates.
+- `test_propagate_is` — `Y is X + 1` ⇒ Y bound.
+- `test_propagate_nonvar_guard` — `nonvar(X)` ⇒ X bound.
+- `test_propagate_var_guard` — `var(X)` ⇒ X unbound.
+- `test_propagate_functor_compose` — `functor(T, foo, 2)` with T
+  unbound ⇒ T bound.
+- `test_propagate_functor_decompose` — `functor(T, N, A)` with T
+  bound ⇒ N and A bound.
+- `test_propagate_univ_compose` — `T =.. [foo, X, Y]` ⇒ T bound
+  (since list is statically bound).
+- `test_propagate_negation_noop` — env unchanged through `\\+ G`.
+
+## Phase M3 — Control constructs
+
+### Files
+- **Edit**: `src/unifyweaver/core/binding_state_analysis.pl`
+- **Edit**: `tests/core/test_binding_state_analysis.pl`
+
+### Tasks
+
+1. Add an env-meet operator:
+   ```prolog
+   meet_env(+EnvA, +EnvB, -EnvAB)
+   %% Variable-by-variable meet:
+   %%   bound  ⊓ bound   = bound
+   %%   unbound ⊓ unbound = unbound
+   %%   anything else      = unknown
+   ```
+2. Handle if-then-else and disjunction in `walk_body/4` by
+   recursively analysing each branch from the same `Env0` and
+   meeting the post-states.
+3. Handle aggregates (`findall/3`, `bagof/3`, `setof/3`,
+   `aggregate_all/3`): inner goal analysed in isolation; outer
+   env gains `bound` for the result variable; template variables
+   get `unknown`.
+
+### Test gate (M3)
+
+- `test_ite_meet_disagree` — Then sets X bound, Else doesn't ⇒
+  post-state X is unknown.
+- `test_ite_meet_agree` — both branches set X bound ⇒ X bound.
+- `test_disjunction_meet` — same shape via `(A ; B)`.
+- `test_findall_result_bound` — `findall(_, _, R)` ⇒ R bound,
+  inner template var unaffected.
+
+## Phase M4 — User-call handling
+
+### Files
+- **Edit**: `src/unifyweaver/core/binding_state_analysis.pl`
+- **Edit**: `tests/core/test_binding_state_analysis.pl`
+
+### Tasks
+
+1. In `propagate_goal/3` fallback, classify the goal:
+   - Foreign / external_source / unknown predicate ⇒ all arg
+     vars become `unknown`.
+   - User predicate with `:- mode/1` declaration ⇒ apply mode
+     pattern: `+` args required `bound` (warning if not), `-`
+     args become `bound` after, `?` args unchanged.
+2. Reuse `demand_analysis:read_mode_declaration/3` verbatim;
+   do not re-implement the directive parser.
+3. Add an optional warning emission helper
+   `emit_mode_violation/2` that prints to stderr only when a
+   debug flag is set.
+
+### Test gate (M4)
+
+- `test_call_unknown_pred_opacity` — args become unknown.
+- `test_call_mode_decl_input_propagation` — `+` arg required
+  bound (analyser does not block, just notes).
+- `test_call_mode_decl_output_propagation` — `-` arg becomes
+  bound after the call.
+- `test_call_mode_decl_any` — `?` args unchanged.
+
+## Phase M5 — Wire into wam_target.pl
+
+### Files
+- **Edit**: `src/unifyweaver/targets/wam_target.pl`
+  (`compile_clause/3` and the body walk).
+- **Edit**: `src/unifyweaver/targets/wam_target.pl` to add an
+  arity-5 `compile_goal_call/5` and `compile_goal_execute/5`
+  that take a `BeforeEnv`. Existing arity-4 wrappers default to
+  empty env.
+
+### Tasks
+
+1. Add `:- use_module('../core/binding_state_analysis')` at the
+   top of `wam_target.pl`.
+2. In `compile_clause/3` (or wherever the body sequence is built):
+   ```prolog
+   binding_state_analysis:analyse_clause_bindings(
+       Head, Body, GoalBindings),
+   ```
+3. Replace the existing `compile_goals/5` with
+   `compile_goals_with_bindings/7` that threads
+   `(Idx, GoalBindings)` alongside the existing `(V0, HasEnv, Vf)`.
+4. New arity:
+   ```prolog
+   compile_goal_call(Goal, BeforeEnv, V0, Vf, Code).
+   compile_goal_execute(Goal, BeforeEnv, V0, Vf, Code).
+   ```
+   Default `BeforeEnv = empty_binding_env` clause kept for any
+   non-WAM-Haskell target that may eventually call these.
+5. **Critical**: keep the existing arity-4 versions intact and
+   delegate to the arity-5 with empty env. The Rust, Go, ILAsm,
+   LLVM, Elixir targets all share `wam_target.pl` — we cannot
+   force them to thread a new state.
+
+### Test gate (M5)
+
+- Run the **full existing test suite** (`run_tests` in
+  `tests/test_wam_haskell_target.pl` plus the core test runner).
+  No regressions.
+- Generate `/tmp/dyn-struct-smoke` from the existing fixture
+  (no mode declarations) — the generated `Predicates.hs` is
+  byte-for-byte identical to current main. Confirms the wiring
+  is a no-op without mode declarations.
+
+## Phase M6 — `=../2` lowering decision
+
+### Files
+- **Edit**: `src/unifyweaver/targets/wam_target.pl`
+- **Edit**: `tests/test_wam_haskell_target.pl`
+
+### Tasks
+
+1. In `compile_goal_call/5`, add an early clause matching
+   `Goal = (T =.. L)`:
+   ```prolog
+   compile_goal_call(T =.. L, BeforeEnv, V0, Vf, Code) :-
+       parse_univ_list_pattern(L, Name, FixedArgs),
+       binding_state_analysis:binding_state_at_var(BeforeEnv, T, unbound),
+       binding_state_analysis:binding_state_at_var(BeforeEnv, Name, bound),
+       !,
+       emit_put_structure_dyn_lowering(T, Name, FixedArgs, V0, Vf, Code).
+   ```
+2. Implement `parse_univ_list_pattern(+List, -NameVar, -FixedArgs)`:
+   - Accepts `[NameVar | RestArgs]` where `NameVar` is unbound
+     (a Prolog variable) and `RestArgs` is a fixed-length proper
+     list.
+   - Fails (no lowering) if list is partial, contains a tail
+     variable, or NameVar is not a variable.
+3. Implement `emit_put_structure_dyn_lowering/6` per spec §3.3:
+   - Allocate or look up reg for Name, emit `put_value` (or
+     `put_variable` if not yet bound to a reg — defensive).
+   - Allocate a fresh X-reg for arity, emit `put_constant N`.
+   - Allocate a fresh X-reg for the constructed term, emit
+     `put_structure_dyn`.
+   - For each `Arg_i` in `FixedArgs`, emit the appropriate
+     `set_value` / `set_variable` / `set_constant` /
+     nested `put_structure` (reuse `compile_set_arguments/4`).
+   - For T: if already bound to a reg, emit `get_value`; else
+     bind T to the constructed-term reg via `bind_var/4` and
+     emit nothing (T is now aliased to the term reg).
+4. Mirror the change in `compile_goal_execute/5` for the
+   tail-call form, ending with `proceed` instead of falling
+   through to the next goal.
+
+### Test gate (M6)
+
+- `test_haskell_univ_compose_lowered_to_put_structure_dyn` —
+  given a clause body that the analyser proves is compose-mode,
+  the generated WAM text contains `put_structure_dyn` instead
+  of `builtin_call =../2`.
+- `test_haskell_univ_unknown_keeps_builtin` — without mode
+  declaration, the generated WAM text contains
+  `builtin_call =../2`.
+- `test_haskell_univ_decompose_keeps_builtin` — with `:- mode`
+  marking T as `+`, the generated WAM text contains
+  `builtin_call =../2`.
+
+## Phase M7 — End-to-end smoke
+
+### Files
+- **Edit (or new)**: `tests/test_wam_haskell_target.pl` —
+  add an integration test that:
+  1. Asserts the existing `dyn-struct-smoke` fixture predicates
+     into a clean db.
+  2. Asserts a `:- mode build_pair(?, ?, ?, -).` directive.
+  3. Calls `write_wam_haskell_project/3` to a temp dir.
+  4. `cabal v2-build`s the project, asserts exit code 0.
+  5. Greps the generated `Predicates.hs` for
+     `PutStructureDyn`, asserts present in `build_pair`'s
+     instruction list.
+  6. Greps the same file for `BuiltinCall "=../2"`, asserts
+     present in `split_pair`'s instruction list (since it has
+     no mode declaration).
+
+### Test gate (M7)
+
+The integration test passes. The smoke binary (built via
+`cabal v2-run dyn-struct-smoke`) produces the same output as
+before, confirming end-to-end runtime correctness.
+
+## Phase M8 — Docs
+
+### Files
+- **Edit**: `MEMORY.md` (the user's auto-memory). Add an entry
+  pointing at a new project-memory file
+  `project_wam_haskell_mode_analysis.md` summarising what was
+  built and what is now possible.
+- **Edit**: `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` — append
+  an entry for the lowering, with the analysis pass as the
+  prerequisite.
+- **Edit**: `docs/design/HASKELL_TARGET_ROADMAP.md` (if
+  present) — mark `=../2` lowering as done.
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Mode propagation rule table grows unboundedly as we add builtins | medium | Cap at the spec's table; new builtins fall through to "all unknown". Adding rules later is additive. |
+| `clause_body_analysis:variable_key/2` doesn't exist or has a different shape | low | Confirm in M1; if missing, write a local helper using `term_to_atom/2` over a copy_term. |
+| `wam_target.pl` body walk is shared with non-WAM-Haskell targets and a thread-through breaks them | medium | M5 test gate explicitly verifies the no-op default-env path. |
+| `:- mode` declarations are scoped per-module and the analyser misses the user's module | medium | Reuse `demand_analysis`'s lookup verbatim; if it works for demand, it works here. |
+| Analyser silently produces wrong `bound`/`unbound` answer | low (but high impact) | Test gate at M2 covers the canonical builtins; M6 tests verify the lowering only fires when both pre-conditions are present. |
+| Existing tests that exercise `=../2` regress because the analyser now sees `unknown` everywhere | low | M5 test gate confirms byte-identical codegen for un-annotated code. |
+
+## Rollback plan
+
+The analysis pass is additive: it produces records but the
+existing compiler ignores them unless a new
+`compile_goal_call/5` clause matches. To roll back:
+
+1. Comment out the M6 `compile_goal_call(T =.. L, ...)`
+   clause — falls through to existing builtin path.
+2. Optionally comment out the M5 thread-through — the
+   analyser still runs but its output is unused.
+3. Optionally comment out the M5 `analyse_clause_bindings/3`
+   call — the analyser becomes dead code.
+
+No data structures change. No public APIs change. No existing
+tests rely on the new module. Rollback is a single-clause
+deletion away.
+
+## Acceptance for the arc
+
+Arc complete when:
+
+1. `tests/core/test_binding_state_analysis.pl` runs and is green.
+2. `tests/test_wam_haskell_target.pl` runs and is green
+   (existing tests + new M6 codegen tests + M7 integration).
+3. The `dyn-struct-smoke` smoke fixture, with a mode
+   declaration on `build_pair`, generates and builds a Haskell
+   project containing `PutStructureDyn` in the compiled instruction
+   list, and the project runs to completion.
+4. The `MEMORY.md` index points at a new
+   `project_wam_haskell_mode_analysis.md` summary with status,
+   benchmarks (if any), and follow-up arcs.
+5. No regression on `tests/core/test_purity_certificate.pl`,
+   `tests/core/test_demand_analysis.pl`, or any other existing
+   core test.
+
+## Suggested branch / PR strategy
+
+Single feature branch:
+`feat/wam-haskell-mode-analysis`.
+
+One PR is acceptable for the whole arc — phases M1–M4 are
+self-contained (analyser + tests, no compiler integration), M5
+is a no-op wiring change, and M6–M7 are the actual
+optimisation. Reviewers can step through phase-by-phase via
+the commits if they want.
+
+If preferred, split into two PRs:
+- PR 1: M1–M5 (analyser module + wiring + green test suite).
+- PR 2: M6–M7 (lowering + integration smoke).
+
+PR 1 is risk-free (no behavioural change). PR 2 is where the
+actual lowering lands and where any regression would manifest.

--- a/docs/design/WAM_HASKELL_MODE_ANALYSIS_SPEC.md
+++ b/docs/design/WAM_HASKELL_MODE_ANALYSIS_SPEC.md
@@ -1,0 +1,389 @@
+# WAM Mode Analysis: Specification
+
+> **Companion docs:** `WAM_HASKELL_MODE_ANALYSIS_PHILOSOPHY.md`
+> (the *why*) and `WAM_HASKELL_MODE_ANALYSIS_PLAN.md` (the work
+> breakdown). This doc fixes the contracts: data structures,
+> propagation rules, public API, and integration sites.
+
+## 1. Data structures
+
+### 1.1 `binding_state/1`
+
+Three-valued domain. Strict bottom-of-lattice = `unknown`; `bound`
+and `unbound` are incomparable peaks. There is no merge below
+`unknown` in this analysis (we never join paths).
+
+```prolog
+%% binding_state(?State)
+%  State is one of:
+%    unbound  — variable definitely unbound at this program point
+%    bound    — variable definitely bound to a non-variable term
+%    unknown  — analysis cannot prove either
+binding_state(unbound).
+binding_state(bound).
+binding_state(unknown).
+```
+
+### 1.2 `binding_env/1`
+
+Per-variable map keyed by Prolog variable identity. Stored as an
+association list (`assoc/1` from SWI-Prolog's `library(assoc)`)
+keyed by the variable's stable address — same approach
+`clause_body_analysis.pl` uses for its `VarMap`.
+
+```prolog
+%% binding_env(BindingEnv)
+%  Opaque association: VarKey -> binding_state.
+%  VarKey is a stable identifier obtained via variable_key/2 (see
+%  clause_body_analysis for the existing helper).
+```
+
+Variables not present in the map are treated as `unknown`. The map
+only holds non-default entries to keep printing useful in tests.
+
+### 1.3 `goal_binding/3`
+
+The output record per goal in a clause body.
+
+```prolog
+%% goal_binding(GoalIdx, BeforeEnv, AfterEnv)
+%  GoalIdx    — 1-based index of the goal in the clause body
+%               (after normalisation, see §2.1).
+%  BeforeEnv  — binding_env at the program point immediately before
+%               this goal executes.
+%  AfterEnv   — binding_env at the program point immediately after
+%               this goal completes successfully.
+```
+
+A clause body of N goals produces N records. A consumer asking
+"what is the binding state of T at the `=..` goal" reads
+`BeforeEnv` of the record whose `GoalIdx` matches the `=..` goal's
+position.
+
+## 2. Algorithm
+
+### 2.1 Body normalisation
+
+Reuse `clause_body_analysis:normalise_body/2`. After normalisation
+the body is a flat list of goals; control constructs (if-then-else,
+disjunction, conjunction nesting) have been flattened or wrapped.
+The analysis treats every flattened goal as one program point.
+
+For if-then-else `(Cond -> Then ; Else)` the analysis is conservative:
+it walks the *Then* branch with `Cond` having executed (to capture
+guard-induced bindings), but the post-state `AfterEnv` of the entire
+construct is the **meet** of the Then-branch and Else-branch
+post-states — variables only marked `bound`/`unbound` in *both*
+branches retain that state. Anything else collapses to `unknown`.
+
+For disjunction `(A ; B)`, same meet rule: post-state is the meet
+of the per-branch post-states.
+
+For findall/bag/set aggregates, the inner goal is analysed in
+isolation; the outer call sees only the result variable transitioning
+to `bound` after the aggregate completes.
+
+### 2.2 Initial environment
+
+`initial_binding_env(+Head, +ModeDecl, -Env)` constructs the
+binding state at the start of the body:
+
+- If `ModeDecl` is `mode(Pred(M1, ..., Mn))` from
+  `demand_analysis:read_mode_declaration/3`, then for each head
+  argument `H_i` with mode `M_i`:
+  - `M_i = +` → if `H_i` is a variable, set state to `bound`;
+    otherwise (atom/structure/list literal) leave at default
+    `unknown` (the head match itself binds the variable, see §2.3
+    for unification handling).
+  - `M_i = -` → if `H_i` is a variable, set state to `unbound`;
+    otherwise inconsistent declaration, emit a warning and treat
+    as `unknown`.
+  - `M_i = ?` → leave at `unknown`.
+- If no mode declaration is present, every head argument variable
+  starts at `unknown`. (Head match still propagates structural
+  bindings; see §2.3.)
+
+After mode-driven initialisation, walk the head pattern itself and
+mark any variable that appears as a sub-term inside a literal head
+argument as `bound` — those are bound by the head unification at
+clause entry. Atomic head args don't introduce variables.
+
+### 2.3 Per-goal propagation
+
+`propagate_goal(+Goal, +BeforeEnv, -AfterEnv)` is the workhorse.
+The rule table is hardcoded, indexed on goal head + arity. Order:
+guards first (don't bind anything, only consume), then explicit
+table, then fallback.
+
+#### 2.3.1 Guard goals
+
+For any goal classified as a guard by
+`clause_body_analysis:is_guard_goal/2` — comparisons (`>/2`, `<`,
+`==/2`, `=\\=`, `@</2`, etc.), type tests (`var/1`, `nonvar/1`,
+`is_list/1`, `atom/1`, `integer/1`, `compound/1`), and arithmetic
+predicates that don't bind:
+
+- `AfterEnv = BeforeEnv`.
+- **Exception**: `nonvar(X)` ⇒ `X` becomes `bound`.
+  `var(X)` ⇒ `X` becomes `unbound`.
+  These are guards but they prove a binding state.
+- **Exception**: `is_list(X)` ⇒ `X` becomes `bound` (a proper list
+  is bound). `atom(X)` ⇒ `bound`. `integer(X)` ⇒ `bound`. Etc.
+
+#### 2.3.2 Unification
+
+`X = Y`:
+- If `X` is a variable and `Y` is a variable:
+  - If `state(X) == bound` or `state(Y) == bound`, both become
+    `bound` (one ground side propagates).
+  - If `state(X) == unbound` and `state(Y) == unbound`, both
+    become `unknown` (aliased fresh vars — analysis does not
+    track aliasing).
+  - Otherwise both become `unknown`.
+- If `X` is a variable and `Y` is a non-variable term:
+  - `X` becomes `bound`. Sub-variables of `Y` retain their state
+    (or become `bound` if `Y` is fully ground at compile time).
+  - Symmetric for `Y` variable, `X` non-variable.
+- If neither side is a variable: `AfterEnv = BeforeEnv` (the
+  unification either succeeds without binding new variables, or
+  fails — analysis is success-conditional).
+
+#### 2.3.3 Arithmetic: `X is Expr`
+
+`X` becomes `bound` (regardless of prior state). Variables in
+`Expr` must be `bound` for the goal to succeed; if any are not
+proven `bound`, the analysis still proceeds (success-conditional)
+but optionally emits a soft diagnostic in verbose mode.
+
+#### 2.3.4 Term-inspection builtins
+
+| Goal | Pre-condition for success | Post-state effect |
+|------|---------------------------|-------------------|
+| `functor(T, Name, Arity)` | At least one of T, Name+Arity is bound | If T pre-bound: Name and Arity → `bound`. If T pre-unbound and Name+Arity bound: T → `bound`. Else all → `unknown`. |
+| `arg(N, T, A)` | N bound, T bound | A → `unknown` (could be unbound or bound depending on T's contents) |
+| `T =.. L` | At least one of T, L is bound | If T pre-bound: L → `bound`. If T pre-unbound and L bound to list of length ≥1 with first element bound to atom: T → `bound`. Else all → `unknown`. |
+| `copy_term(T, C)` | T bound (for meaningful semantics) | C → `bound` |
+
+#### 2.3.5 Negation: `\\+ Goal`
+
+`\\+ Goal` does not bind anything — `AfterEnv = BeforeEnv`.
+
+#### 2.3.6 Cut: `!`
+
+Cut does not bind anything — `AfterEnv = BeforeEnv`.
+
+#### 2.3.7 User predicate calls
+
+Two paths:
+
+- **Foreign-classified or external_source predicates**: opaque,
+  all argument variables become `unknown` after the call.
+- **User predicates with `:- mode/1` declaration**: the input
+  positions (modes `+`) require their argument to be `bound`
+  before the call (analysis emits a `mode_violation` warning if
+  not, but does not fail compilation); output positions (modes
+  `-`) make their argument `bound` after the call. `?` modes
+  leave the argument at its pre-call state.
+- **User predicates without mode declaration**: conservative —
+  every argument variable becomes `unknown` after the call.
+
+#### 2.3.8 Control constructs
+
+- `(A, B)`: sequential, `propagate_goal(A, …) ∘ propagate_goal(B, …)`.
+- `(A ; B)`: meet of post-states, see §2.1.
+- `(Cond -> Then ; Else)`: meet of post-states, see §2.1.
+- `aggregate_all(Tmpl, Goal, Result)` /
+  `findall/3` / `bagof/3` / `setof/3`: inner goal analysed in
+  isolation with no effect on outer env except `Result` →
+  `bound`.
+
+#### 2.3.9 Fallback
+
+Any goal not matched by the above table is treated like an
+opaque user predicate call: all argument variables become
+`unknown`.
+
+### 2.4 Analyser entry point
+
+```prolog
+%% analyse_clause_bindings(+Head, +Body, -GoalBindings)
+%
+%% Computes per-goal binding-state records for a clause body.
+%%
+%% Head — the clause head, e.g. `build_term(F, A, T)`.
+%% Body — the clause body, may contain control constructs.
+%% GoalBindings — list of `goal_binding/3` records, one per
+%%   normalised goal in the body, in source order.
+%%
+%% Side-effect-free. Reads `:- mode/1` declarations via
+%% demand_analysis:read_mode_declaration/3 if available.
+analyse_clause_bindings(+Head, +Body, -GoalBindings).
+```
+
+Public API. Lives in `src/unifyweaver/core/binding_state_analysis.pl`.
+
+A second entry point provides the lookup the WAM compiler will use:
+
+```prolog
+%% binding_state_at(+GoalIdx, +Var, +GoalBindings, -State)
+%% Reads the BeforeEnv of the goal at index GoalIdx and returns
+%% the binding_state of Var in that environment. Defaults to
+%% `unknown` if the variable is not in the env.
+binding_state_at(+GoalIdx, +Var, +GoalBindings, -State).
+```
+
+## 3. Integration with `wam_target.pl`
+
+### 3.1 Plumbing
+
+`compile_clause/3` (or whichever predicate currently sequences
+head-pattern compilation, body normalisation, and goal-by-goal
+emission) gains a one-line call:
+
+```prolog
+analyse_clause_bindings(Head, Body, GoalBindings),
+```
+
+The resulting `GoalBindings` list is threaded into the body walk
+alongside the existing `V0` register-allocator state. The walk
+becomes:
+
+```prolog
+compile_goals_with_bindings([], _Idx, _GB, V, _, V, "").
+compile_goals_with_bindings([Goal|Rest], Idx, GoalBindings, V0, HasEnv, Vf, Code) :-
+    compile_goal_call_with_bindings(Goal, Idx, GoalBindings, V0, V1, GoalCode),
+    NIdx is Idx + 1,
+    compile_goals_with_bindings(Rest, NIdx, GoalBindings, V1, HasEnv, Vf, RestCode),
+    format(string(Code), "~w~n~w", [GoalCode, RestCode]).
+```
+
+`compile_goal_call_with_bindings/6` is a thin wrapper that pulls
+`BeforeEnv` from `GoalBindings` for the current `Idx` and passes
+it to a new `compile_goal_call/5` arity. Existing `compile_goal_call/4`
+becomes a default-`unknown`-env wrapper for backwards compatibility
+with non-WAM-Haskell callers.
+
+### 3.2 The `=../2` lowering decision
+
+In `compile_goal_call/5` (the new arity), add an early clause:
+
+```prolog
+compile_goal_call(Goal, BeforeEnv, V0, Vf, Code) :-
+    Goal = (T =.. L),
+    is_list_with_var_head_and_fixed_tail(L, Name, FixedArgs),
+    binding_state_at_var(BeforeEnv, T, unbound),
+    binding_state_at_var(BeforeEnv, Name, bound),
+    !,
+    emit_put_structure_dyn_lowering(T, Name, FixedArgs, V0, Vf, Code).
+```
+
+`is_list_with_var_head_and_fixed_tail/3` recognises the pattern
+`[NameVar, Arg1, Arg2, ..., ArgN]` where:
+- `NameVar` is a variable.
+- The list literal has a fixed length N ≥ 0.
+- Each `Arg_i` is a term (var, atom, structure, list literal — the
+  existing `compile_put_argument` machinery handles all of these).
+
+### 3.3 The lowering itself
+
+`emit_put_structure_dyn_lowering(T, Name, FixedArgs, V0, Vf, Code)`
+emits:
+
+```
+    put_value Reg(Name), A1                  # nameReg
+    put_constant N, A2                       # arityReg (literal int)
+    put_structure_dyn A1, A2, A3             # construct Str at A3
+    set_value/set_variable for FixedArgs[1..N]
+    get_value Reg(T), A3                     # unify constructed term with T
+```
+
+A few details:
+- If `Name` does not yet have a register, allocate one via
+  `next_x_reg/3` and emit `put_variable` in its place. The
+  binding-state precondition (`bound`) is structural — Name
+  *must* be reachable from a register at runtime — so the
+  fallback should be unreachable in practice but we handle it
+  for safety.
+- The arity register slot does need a real `put_constant`
+  emission; `PutStructureDyn` reads an `Integer` value from
+  `arityReg`, not a literal in the instruction.
+- `T` may or may not have a register. If it does, emit
+  `get_value`; if not (T is a fresh variable here, which is
+  precisely the precondition), allocate a register, bind the
+  Prolog variable to it via `bind_var/4`, and emit
+  `get_variable`.
+
+### 3.4 Falling through to the existing path
+
+If any of the precondition predicates fail (pattern mismatch,
+binding state not provable, list shape too dynamic), the
+compile_goal_call clause matches no head and falls through to
+the existing `Goal =.. [Pred|Args]` general builtin path. No
+behavioural change for any unmatched call.
+
+## 4. Test surface
+
+The implementation plan covers the test-by-test list, but the
+spec fixes what we test *for*:
+
+- **Unit-level, analyser**:
+  - Fresh variable in head with mode `-` is `unbound` at goal 1.
+  - Fresh variable bound by `is/2` becomes `bound` after the goal.
+  - Variable bound by head pattern unification (e.g. head
+    `foo(f(X))` ⇒ X is `bound` at start of body).
+  - Meet at if-then-else collapses to `unknown` when branches
+    disagree.
+  - Opaque user call without mode declaration yields `unknown`
+    for every argument.
+- **Unit-level, lowering**:
+  - `T =.. [Name | Args]` with T proven `unbound` and Name
+    proven `bound` emits `PutStructureDyn` in generated WAM
+    text.
+  - `T =.. [Name | Args]` with T `unknown` falls through to
+    `builtin_call =../2`.
+  - `T =.. [Name | Args]` with T `bound` falls through.
+- **Integration**:
+  - `build_pair/4` from the existing smoke fixture, given
+    `:- mode build_pair(?, ?, ?, -).`, generates a
+    `Predicates.hs` containing `PutStructureDyn` and the
+    project builds and runs.
+  - `split_pair/4` from the same fixture, given
+    `:- mode split_pair(+, ?, ?, ?).`, keeps the existing
+    `BuiltinCall "=../2"` path and the project builds and runs.
+  - Without any mode declaration, both predicates compile via
+    the existing builtin path (no regressions on un-annotated
+    code).
+
+## 5. Failure modes and diagnostics
+
+The analysis must never crash. Three specific failure modes:
+
+- **Mode declaration parse error**: warn and proceed as if no
+  declaration was present.
+- **Unhandled goal shape** (e.g. a meta-call `call(F, X)`):
+  treat all arg variables as `unknown` after the goal, emit
+  no warning (silent fallback).
+- **Mode violation** (a goal requires a `+` argument bound, but
+  analysis cannot prove it): emit a warning at compile time
+  but proceed. The runtime `=../2` builtin handles the actual
+  failure semantics.
+
+In verbose mode (controlled by an existing
+`unifyweaver_debug` flag if there is one — to be confirmed in
+the implementation plan), print the per-goal binding env to
+stderr alongside the existing WAM text dump for the predicate.
+
+## 6. Out-of-scope for this spec
+
+Explicitly deferred to follow-up arcs:
+
+- `functor/3` lowering to `PutStructureDyn` + `SetVariable` ×N.
+- `arg/3` lowering to indexed `GetValue`.
+- `\\+ member(X, L)` lowering to native set lookup.
+- Sharing analysis (alias tracking).
+- Multi-mode predicates compiled as separate WAM bodies.
+- Backwards/demand-driven mode propagation.
+
+The analysis API (§2.4) is shaped to accommodate those follow-ups
+without further changes — they would add new propagation rule
+table entries and new lowering clauses, not alter the contract.


### PR DESCRIPTION
## Summary

- Adds a three-doc design package (philosophy / spec / plan) for a binding-state analysis pass that will unlock the deferred `PutStructureDyn` lowering for `=../2` in compose mode.
- No code changes. The point of this PR is to land a fixed, reviewable design that a follow-up implementation PR (or a handoff to another agent) can execute against without re-deriving the rationale from conversation context.

## Background

PR #1657 fixed the `SetVariable` constructor bug so user-source `=../2` compiles end-to-end through the Haskell WAM target. It deliberately did **not** add the `PutStructureDyn` lowering that task #16 originally proposed, for one reason: `PutStructureDyn` is unsafe in decompose mode. The runtime expects the functor name register to dereference to `Atom fid`; if it dereferences to `Unbound`, the step returns `Nothing` and the goal fails.

The same Prolog source

```prolog
T =.. [Name, X, Y].
```

is used both ways — composing when called with `T` fresh and `Name` bound, decomposing when `T` is bound. The WAM compiler has no static signal to disambiguate them. Eagerly emitting `PutStructureDyn` would silently break decompose-mode callers.

The fix is a small, conservative binding-state analysis pass that proves at the program point of each `=..` goal whether the lowering is safe. This PR is the design for that pass.

## Docs added

Three docs in `docs/design/`, mirroring the naming and structure of the existing `WAM_HASKELL_INTRA_QUERY_*` series:

### `WAM_HASKELL_MODE_ANALYSIS_PHILOSOPHY.md` — the *why* (218 lines)

- What the WAM target has today (single `BuiltinCall "=../2" 2` instruction handling both modes).
- Why we have not lowered to `PutStructureDyn` yet (decompose-mode safety).
- What we are **explicitly not** building: Mercury-style mode polymorphism, fixpoint iteration, aliasing analysis, backwards/demand-driven inference, multi-mode predicate specialisation.
- The three-valued `{unbound, bound, unknown}` lattice and the soundness contract: every positive answer is a runtime guarantee; `unknown` keeps the existing path. Wrong analysis can only leave performance on the table — never produce incorrect runtime behaviour.
- Why the analysis pays off beyond `=../2`: it's the substrate for future `functor/3`, `arg/3`, `\\+ member` lowerings.

### `WAM_HASKELL_MODE_ANALYSIS_SPEC.md` — the *what* (389 lines)

- Data structures: `binding_state/1` (3-valued domain), `binding_env/1` (assoc-list, per-variable map), `goal_binding/3` (the per-goal output record with `BeforeEnv` / `AfterEnv`).
- Per-builtin propagation rule table covering: guards (with `var/1`/`nonvar/1`/type-test exceptions), `=/2` unification (4 sub-cases), `is/2`, `functor/3`, `arg/3`, `=../2`, `copy_term/2`, `\\+/1`, `!/0`, control constructs (sequence / disjunction / if-then-else / aggregates), user predicate calls (mode-declared and opaque).
- Initial-environment construction from `:- mode/1` declarations (reusing `demand_analysis:read_mode_declaration/3` verbatim — no new directive grammar).
- Public API: `analyse_clause_bindings/3`, `binding_state_at/4`, `binding_state_at_var/3`.
- Integration sites in `wam_target.pl`: a new `compile_goal_call/5` arity that takes `BeforeEnv` alongside `V0`, with the existing arity-4 kept as a default-empty-env wrapper so non-WAM-Haskell targets (Rust, Go, ILAsm, LLVM, Elixir) are unaffected.
- The `=../2` lowering decision and the `emit_put_structure_dyn_lowering/6` codegen helper.
- Failure modes and diagnostic policy. Out-of-scope follow-ups (the spec is shaped to admit them additively).

### `WAM_HASKELL_MODE_ANALYSIS_PLAN.md` — the *how* (373 lines)

8 phases with explicit test gates between each:

| Phase | Goal | LOC | Gate |
|------:|------|----:|------|
| M1 | Skeleton analyser + initial-env from `:- mode/1` | ~150 | unit tests for env construction |
| M2 | Propagation table for guards, `=`, `is`, term inspection | ~250 | unit tests for per-builtin propagation |
| M3 | Control constructs (if-then-else, disjunction, aggregates) | ~100 | unit tests for meet semantics |
| M4 | User-call handling (mode-declared and opaque) | ~80 | unit tests for input/output mode propagation |
| M5 | Wire into `wam_target.pl` body walk | ~50 | full existing suite stays green; un-annotated codegen byte-identical |
| M6 | `=../2` lowering decision + emit helper | ~80 | new codegen unit tests |
| M7 | End-to-end smoke (regenerate `dyn-struct-smoke` with mode decls, build, run, grep) | ~30 | integration test passes |
| M8 | Docs + memory updates | docs only | n/a |

Plus a risk register and a rollback plan: M1–M5 are no-op additive wiring (analyser runs, output unused), so the optimisation can be reverted by deleting one `compile_goal_call/5` clause.

The plan suggests two reasonable PR strategies — single PR for the whole arc, or split at the M5/M6 boundary so the risk-free wiring lands ahead of the actual lowering.

## Why doc-only

Mode analysis is the kind of work where the cost of mid-implementation discovery is high. Writing the spec now forces three decisions upfront:

1. **The lattice depth.** Three-valued, no aliasing, no groundness sublattice. Anything richer is out of scope.
2. **The `:- mode` policy.** Declarations are an *optional* input that improves precision; the analysis must work without them. We reuse the existing reader in `demand_analysis.pl`.
3. **The integration shape.** Arity-5 `compile_goal_call` with the arity-4 wrapper preserved. No other targets get touched.

Locking those decisions in writing makes the implementation either trivially executable by a follow-up agent or directly handoff-able to a contributor.

## Verification

- All three files render as valid Markdown.
- Naming and section structure mirror the existing `docs/design/WAM_HASKELL_INTRA_QUERY_PHILOSOPHY.md` / `_SPEC.md` / `_IMPLEMENTATION_PLAN.md` series.
- No source files modified; no test impact.

## Test plan

- [ ] Skim each doc for internal consistency (data-structure names match across all three; rule table in spec matches phase ordering in plan).
- [ ] Confirm the three docs land in `docs/design/` next to the existing WAM Haskell design series.
- [ ] (Follow-up PR) Execute phase M1 against the spec; confirm test gate passes before moving on.

## Refs

- Task #16 — Add PutStructureDyn for runtime-parsed functors (now blocked on this analysis).
- Task #185 — PutStructureDyn end-to-end + WAM compiler lowering (the umbrella task this design serves).
- PR #1657 — `SetVariable` correctness fix that unblocked user-source `=../2` and made the deferred lowering decision explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)