### PR TITLE
feat(wam-haskell): mode analysis + =../2 PutStructureDyn lowering

### DIFF
--- a/src/unifyweaver/core/binding_state_analysis.pl
+++ b/src/unifyweaver/core/binding_state_analysis.pl
@@ -1,0 +1,536 @@
+:- encoding(utf8).
+%% binding_state_analysis.pl
+%%
+%% Forward, no-fixpoint, three-valued binding-state analysis for the
+%% WAM target's =../2 PutStructureDyn lowering.
+%%
+%% See docs/design/WAM_HASKELL_MODE_ANALYSIS_{PHILOSOPHY,SPEC,PLAN}.md
+%% for the full design. This module produces, for every goal in a
+%% normalised clause body, a `goal_binding(Idx, BeforeEnv, AfterEnv)`
+%% record that downstream code generators can consult to decide
+%% whether a builtin call can be specialised (e.g. compose-mode
+%% =../2 -> PutStructureDyn).
+%%
+%% Domain (binding_state/1):
+%%   unbound  — variable definitely unbound at the program point
+%%   bound    — variable definitely bound to a non-variable term
+%%   unknown  — analysis cannot prove either (lattice bottom)
+%%
+%% The analysis is *sound* in the sense that whenever a downstream
+%% pass acts on a `bound` or `unbound` answer, that answer must hold
+%% on every successful execution path that reaches the program
+%% point. When in doubt, the analysis answers `unknown`.
+
+:- module(binding_state_analysis, [
+    %% Public API consumed by the WAM target.
+    analyse_clause_bindings/3,        % +Head, +Body, -GoalBindings
+    binding_state_at/4,               % +GoalIdx, +Var, +GoalBindings, -State
+    binding_state_at_var/3,           % +Env, +Var, +ExpectedState
+    %% Lower-level helpers (exported for testability and for direct
+    %% callers that want to construct envs by hand).
+    binding_state/1,                  % ?State
+    empty_binding_env/1,              % -Env
+    set_binding_state/4,              % +Env0, +Var, +State, -Env1
+    get_binding_state/3,              % +Env, +Var, -State
+    initial_binding_env/3,            % +Head, +ModeDecl, -Env
+    propagate_goal/3,                 % +Goal, +BeforeEnv, -AfterEnv
+    meet_env/3                        % +EnvA, +EnvB, -EnvAB
+]).
+
+:- use_module(library(lists)).
+:- use_module(clause_body_analysis).
+:- use_module(demand_analysis).
+
+%% ========================================================================
+%% Section 1. Domain
+%% ========================================================================
+
+%% binding_state(?State)
+%  Three-valued binding state.
+binding_state(unbound).
+binding_state(bound).
+binding_state(unknown).
+
+%% Internal: lattice meet (variable-by-variable).
+%%   bound   ⊓ bound   = bound
+%%   unbound ⊓ unbound = unbound
+%%   anything else      = unknown
+state_meet(S, S, S) :- !.
+state_meet(_, _, unknown).
+
+%% ========================================================================
+%% Section 2. Environment
+%%
+%% Stored as a flat list of `var(V)-State` pairs where V is the actual
+%% Prolog variable. Lookup uses ==/2 (variable identity), so the
+%% environment correctly distinguishes fresh-var-with-same-name from
+%% the original variable.
+%% ========================================================================
+
+%% empty_binding_env(-Env)
+empty_binding_env([]).
+
+%% get_binding_state(+Env, +Var, -State)
+%  Defaults to `unknown` for variables not in the environment, and
+%  for any non-variable term.
+get_binding_state(_, Var, bound) :-
+    nonvar(Var), !.
+get_binding_state(Env, Var, State) :-
+    var(Var),
+    env_lookup(Env, Var, State0),
+    !,
+    State = State0.
+get_binding_state(_, _, unknown).
+
+%% set_binding_state(+Env0, +Var, +State, -Env1)
+%  Replaces or inserts the binding state for Var. Non-variable Var is
+%  a no-op (we only track Prolog variables).
+set_binding_state(Env0, Var, _, Env0) :-
+    nonvar(Var), !.
+set_binding_state(Env0, Var, State, Env1) :-
+    binding_state(State),
+    env_replace(Env0, Var, State, Env1).
+
+env_lookup([Var0-State|_], Var, State) :-
+    Var0 == Var, !.
+env_lookup([_|Rest], Var, State) :-
+    env_lookup(Rest, Var, State).
+
+env_replace([], Var, State, [Var-State]).
+env_replace([V0-_|Rest], Var, State, [Var-State|Rest]) :-
+    V0 == Var, !.
+env_replace([V0-S|Rest0], Var, State, [V0-S|Rest1]) :-
+    env_replace(Rest0, Var, State, Rest1).
+
+%% binding_state_at_var(+Env, +Var, +ExpectedState)
+%  Convenience predicate used by the WAM lowering: succeeds iff Var
+%  is *proven* to be in ExpectedState. `unknown` never matches a
+%  concrete expected state.
+binding_state_at_var(Env, Var, ExpectedState) :-
+    get_binding_state(Env, Var, ExpectedState),
+    ExpectedState \== unknown.
+
+%% ========================================================================
+%% Section 3. Initial environment from head + mode declaration
+%% ========================================================================
+
+%% initial_binding_env(+Head, +ModeDecl, -Env)
+%
+%  ModeDecl is one of:
+%    - `none` (no `:- mode/1` declaration found)
+%    - a list of mode atoms (input/output/any) — the same shape
+%      that `demand_analysis:read_mode_declaration/3` returns.
+%
+%  Variables in head sub-terms (e.g. inside `f(X)` when the head arg
+%  is `f(X)`) are marked `bound` because head unification will have
+%  bound them by the time the body executes.
+initial_binding_env(Head, ModeDecl, Env) :-
+    Head =.. [_|HeadArgs],
+    apply_mode_decl(HeadArgs, ModeDecl, [], Env0),
+    propagate_head_structure(HeadArgs, Env0, Env).
+
+apply_mode_decl(_HeadArgs, none, Env, Env) :- !.
+apply_mode_decl([], _, Env, Env) :- !.
+apply_mode_decl([Arg|RestArgs], [Mode|RestModes], Env0, Env) :-
+    !,
+    apply_mode_to_arg(Arg, Mode, Env0, Env1),
+    apply_mode_decl(RestArgs, RestModes, Env1, Env).
+apply_mode_decl([_|RestArgs], [], Env0, Env) :-
+    %% Mode list shorter than head — leave remaining args at default.
+    apply_mode_decl(RestArgs, [], Env0, Env).
+
+apply_mode_to_arg(Arg, input, Env0, Env1) :-
+    !,
+    %% mode + (input): caller promises the argument is bound.
+    (   var(Arg)
+    ->  set_binding_state(Env0, Arg, bound, Env1)
+    ;   Env1 = Env0
+    ).
+apply_mode_to_arg(Arg, output, Env0, Env1) :-
+    !,
+    %% mode - (output): caller promises the argument is unbound.
+    (   var(Arg)
+    ->  set_binding_state(Env0, Arg, unbound, Env1)
+    ;   %% Inconsistent: the head pattern is a non-variable but mode
+        %% says output. Fall through to `unknown` (no entry).
+        Env1 = Env0
+    ).
+apply_mode_to_arg(_Arg, any, Env, Env) :- !.
+apply_mode_to_arg(_Arg, _Other, Env, Env).
+
+%% propagate_head_structure(+HeadArgs, +Env0, -Env1)
+%  For each non-variable head argument, walk it and mark every Prolog
+%  variable contained inside as `bound` — head unification will have
+%  bound them at clause entry.
+propagate_head_structure([], Env, Env).
+propagate_head_structure([Arg|Rest], Env0, Env) :-
+    (   var(Arg)
+    ->  Env1 = Env0
+    ;   mark_subvars_bound(Arg, Env0, Env1)
+    ),
+    propagate_head_structure(Rest, Env1, Env).
+
+mark_subvars_bound(Term, Env, Env) :-
+    (   atomic(Term) ; var(Term) ),
+    \+ var(Term),  %% atomic(Term)
+    !.
+mark_subvars_bound(Var, Env0, Env1) :-
+    var(Var), !,
+    set_binding_state(Env0, Var, bound, Env1).
+mark_subvars_bound(Term, Env0, Env) :-
+    Term =.. [_|Args],
+    foldl(mark_subvars_bound, Args, Env0, Env).
+
+%% ========================================================================
+%% Section 4. Per-goal propagation
+%% ========================================================================
+
+%% propagate_goal(+Goal, +BeforeEnv, -AfterEnv)
+%  Updates the binding environment based on the success-conditional
+%  effect of Goal. The fall-through assumption is "all argument
+%  variables become unknown" — most sound, least informative.
+
+%% Module-qualified goals: strip the module wrapper and recurse.
+propagate_goal(_M:Goal, Env0, Env) :- !,
+    propagate_goal(Goal, Env0, Env).
+
+%% true/fail/cut: no effect on bindings.
+propagate_goal(true,  Env, Env) :- !.
+propagate_goal(fail,  Env, Env) :- !.
+propagate_goal(false, Env, Env) :- !.
+propagate_goal(!,     Env, Env) :- !.
+
+%% Negation: doesn't bind anything (as-failure semantics).
+propagate_goal(\+(_),  Env, Env) :- !.
+propagate_goal(not(_), Env, Env) :- !.
+
+%% Type-test guards that also prove a binding state.
+propagate_goal(var(X), Env0, Env) :- !,
+    (   var(X)
+    ->  set_binding_state(Env0, X, unbound, Env)
+    ;   Env = Env0
+    ).
+propagate_goal(nonvar(X), Env0, Env) :- !,
+    (   var(X)
+    ->  set_binding_state(Env0, X, bound, Env)
+    ;   Env = Env0
+    ).
+propagate_goal(atom(X),     Env0, Env) :- !, set_var_bound(X, Env0, Env).
+propagate_goal(atomic(X),   Env0, Env) :- !, set_var_bound(X, Env0, Env).
+propagate_goal(integer(X),  Env0, Env) :- !, set_var_bound(X, Env0, Env).
+propagate_goal(float(X),    Env0, Env) :- !, set_var_bound(X, Env0, Env).
+propagate_goal(number(X),   Env0, Env) :- !, set_var_bound(X, Env0, Env).
+propagate_goal(is_list(X),  Env0, Env) :- !, set_var_bound(X, Env0, Env).
+propagate_goal(compound(X), Env0, Env) :- !, set_var_bound(X, Env0, Env).
+
+%% Comparison guards (==, =\=, >, <, etc.): no binding effect.
+propagate_goal(Goal, Env, Env) :-
+    compound(Goal),
+    Goal =.. [Op, _, _],
+    is_pure_comparison_op(Op),
+    !.
+
+%% Arithmetic: X is Expr binds X.
+propagate_goal(X is _, Env0, Env) :- !,
+    set_var_bound(X, Env0, Env).
+
+%% Unification: X = Y.
+propagate_goal(X = Y, Env0, Env) :- !,
+    propagate_unification(X, Y, Env0, Env).
+
+%% Disequality (\= and \==): no binding effect; success-conditional
+%% but proves nothing useful for our domain.
+propagate_goal(\=(_, _),  Env, Env) :- !.
+propagate_goal(\==(_, _), Env, Env) :- !.
+
+%% Term-inspection builtins.
+propagate_goal(functor(T, Name, Arity), Env0, Env) :- !,
+    propagate_functor(T, Name, Arity, Env0, Env).
+propagate_goal(arg(_, _, A), Env0, Env) :- !,
+    %% A's runtime state depends on T's contents — we cannot prove
+    %% bound or unbound. Mark as unknown.
+    set_var_unknown(A, Env0, Env).
+propagate_goal(=..(T, L), Env0, Env) :- !,
+    propagate_univ(T, L, Env0, Env).
+propagate_goal(copy_term(_, C), Env0, Env) :- !,
+    set_var_bound(C, Env0, Env).
+
+%% Aggregate builtins: inner goal analysed in isolation; outer env
+%% only sees the result variable transition to `bound`.
+propagate_goal(findall(_T, _G, R), Env0, Env) :- !,
+    set_var_bound(R, Env0, Env).
+propagate_goal(bagof(_T, _G, R), Env0, Env) :- !,
+    set_var_bound(R, Env0, Env).
+propagate_goal(setof(_T, _G, R), Env0, Env) :- !,
+    set_var_bound(R, Env0, Env).
+propagate_goal(aggregate_all(_T, _G, R), Env0, Env) :- !,
+    set_var_bound(R, Env0, Env).
+
+%% Conjunction: sequential composition.
+propagate_goal((A, B), Env0, Env) :- !,
+    propagate_goal(A, Env0, Env1),
+    propagate_goal(B, Env1, Env).
+
+%% If-then-else: walk Then with Cond's bindings, walk Else from Env0,
+%% meet the post-states.
+propagate_goal((Cond -> Then ; Else), Env0, Env) :- !,
+    propagate_goal(Cond, Env0, EnvCond),
+    propagate_goal(Then, EnvCond, EnvThen),
+    propagate_goal(Else, Env0, EnvElse),
+    meet_env(EnvThen, EnvElse, Env).
+
+%% If-then (no else): result of the construct is taken to be the
+%% post-state of Cond+Then if matched, or Env0 otherwise. We meet to
+%% remain conservative.
+propagate_goal((Cond -> Then), Env0, Env) :- !,
+    propagate_goal(Cond, Env0, EnvCond),
+    propagate_goal(Then, EnvCond, EnvThen),
+    meet_env(EnvThen, Env0, Env).
+
+%% Bare disjunction: meet of branches.
+propagate_goal((A ; B), Env0, Env) :- !,
+    propagate_goal(A, Env0, EnvA),
+    propagate_goal(B, Env0, EnvB),
+    meet_env(EnvA, EnvB, Env).
+
+%% User predicate calls: classify by mode declaration.
+propagate_goal(Goal, Env0, Env) :-
+    compound(Goal),
+    functor(Goal, Pred, Arity),
+    Goal =.. [_|Args],
+    !,
+    (   demand_analysis:read_mode_declaration(Pred, Arity, Modes)
+    ->  apply_call_modes(Args, Modes, Env0, Env)
+    ;   set_args_unknown(Args, Env0, Env)
+    ).
+
+%% Atom or zero-arity opaque goal: nothing to update.
+propagate_goal(_Goal, Env, Env).
+
+%% ----- helpers -----
+
+set_var_bound(Var, Env0, Env) :-
+    (   var(Var)
+    ->  set_binding_state(Env0, Var, bound, Env)
+    ;   Env = Env0
+    ).
+
+set_var_unknown(Var, Env0, Env) :-
+    (   var(Var)
+    ->  set_binding_state(Env0, Var, unknown, Env)
+    ;   Env = Env0
+    ).
+
+set_args_unknown([], Env, Env).
+set_args_unknown([Arg|Rest], Env0, Env) :-
+    (   var(Arg)
+    ->  set_binding_state(Env0, Arg, unknown, Env1)
+    ;   Env1 = Env0
+    ),
+    set_args_unknown(Rest, Env1, Env).
+
+apply_call_modes([], _, Env, Env) :- !.
+apply_call_modes(_, [], Env, Env) :- !.
+apply_call_modes([Arg|Rest], [Mode|RestModes], Env0, Env) :-
+    apply_call_mode(Arg, Mode, Env0, Env1),
+    apply_call_modes(Rest, RestModes, Env1, Env).
+
+apply_call_mode(_Arg, input, Env, Env) :- !.    % caller required to supply bound
+apply_call_mode(Arg,  output, Env0, Env) :- !,  % callee promises to bind it
+    set_var_bound(Arg, Env0, Env).
+apply_call_mode(Arg,  any, Env0, Env) :- !,     % unknown post-state
+    set_var_unknown(Arg, Env0, Env).
+apply_call_mode(_Arg, _Other, Env, Env).
+
+is_pure_comparison_op(>).
+is_pure_comparison_op(<).
+is_pure_comparison_op(>=).
+is_pure_comparison_op(=<).
+is_pure_comparison_op(=:=).
+is_pure_comparison_op(=\=).
+is_pure_comparison_op(==).
+is_pure_comparison_op(@<).
+is_pure_comparison_op(@>).
+is_pure_comparison_op(@=<).
+is_pure_comparison_op(@>=).
+
+%% propagate_unification(+X, +Y, +Env0, -Env1)
+propagate_unification(X, Y, Env0, Env) :-
+    var(X), var(Y), !,
+    get_binding_state(Env0, X, SX),
+    get_binding_state(Env0, Y, SY),
+    (   ( SX == bound ; SY == bound )
+    ->  set_var_bound(X, Env0, Env1),
+        set_var_bound(Y, Env1, Env)
+    ;   %% Two unbound aliases or any other combination: collapse to
+        %% unknown — analysis does not track aliasing.
+        set_var_unknown(X, Env0, Env1),
+        set_var_unknown(Y, Env1, Env)
+    ).
+propagate_unification(X, Y, Env0, Env) :-
+    var(X), nonvar(Y), !,
+    set_var_bound(X, Env0, Env1),
+    %% Sub-vars of Y become bound iff Y is fully ground.
+    (   ground(Y)
+    ->  Env = Env1
+    ;   mark_term_vars_unknown(Y, Env1, Env)
+    ).
+propagate_unification(X, Y, Env0, Env) :-
+    nonvar(X), var(Y), !,
+    propagate_unification(Y, X, Env0, Env).
+propagate_unification(_, _, Env, Env).
+
+mark_term_vars_unknown(Term, Env, Env) :-
+    atomic(Term), !.
+mark_term_vars_unknown(Var, Env0, Env) :-
+    var(Var), !,
+    %% leave it alone — caller's unification is success-conditional
+    %% and does not bind the sub-var unless it was already bound.
+    Env = Env0.
+mark_term_vars_unknown(Term, Env0, Env) :-
+    Term =.. [_|Args],
+    foldl(mark_term_vars_unknown, Args, Env0, Env).
+
+%% propagate_functor(+T, +Name, +Arity, +Env0, -Env)
+%  functor(T, Name, Arity) — pre-cond: at least one of T, Name+Arity bound.
+propagate_functor(T, Name, Arity, Env0, Env) :-
+    get_binding_state(Env0, T, ST),
+    get_binding_state(Env0, Name, SN),
+    get_binding_state(Env0, Arity, SA),
+    (   ST == bound
+    ->  set_var_bound(Name, Env0, Env1),
+        set_var_bound(Arity, Env1, Env)
+    ;   ( SN == bound, SA == bound )
+    ->  set_var_bound(T, Env0, Env)
+    ;   %% Cannot prove direction. All become unknown.
+        set_var_unknown(T, Env0, Env1),
+        set_var_unknown(Name, Env1, Env2),
+        set_var_unknown(Arity, Env2, Env)
+    ).
+
+%% propagate_univ(+T, +L, +Env0, -Env)
+%  T =.. L. Pre-cond: at least one of T, L is bound.
+%
+%  Compose mode (T pre-unbound, L bound):
+%    L must be a list whose head is bound to an atom and whose tail
+%    is bound. We do a lightweight static check: if L is syntactically
+%    a list with head and an atom-or-bound-var first element, treat
+%    as compose. Otherwise stay conservative.
+propagate_univ(T, L, Env0, Env) :-
+    get_binding_state(Env0, T, ST),
+    (   ST == bound
+    ->  %% Decompose: T -> L list.
+        set_var_bound(L, Env0, Env)
+    ;   %% Try compose: L is a proper list literal of length ≥ 1
+        %% whose first element (the functor name) is provably bound
+        %% to an atom or to a variable proven `bound`. The rest of
+        %% the list elements are the structure arguments — they
+        %% don't need to be bound for the WAM PutStructureDyn
+        %% lowering (the emitter handles unbound args via
+        %% set_variable).
+        univ_compose_list_ok(L, Env0)
+    ->  set_var_bound(T, Env0, Env)
+    ;   %% Conservative fallback.
+        set_var_unknown(T, Env0, Env1),
+        set_var_unknown(L, Env1, Env)
+    ).
+
+%% univ_compose_list_ok(+L, +Env)
+%  L is a proper list literal of length ≥ 1, AND the head of L (the
+%  functor name) is statically bound to an atom — i.e. literally an
+%  atom, or a variable in Env with state `bound`.
+univ_compose_list_ok(L, _Env) :-
+    var(L), !, fail.
+univ_compose_list_ok([H|T], Env) :-
+    proper_list_tail(T),
+    head_bound_to_atom(H, Env).
+
+proper_list_tail(T) :- var(T), !, fail.
+proper_list_tail([]) :- !.
+proper_list_tail([_|T]) :- proper_list_tail(T).
+
+head_bound_to_atom(H, _Env) :- atom(H), !.
+head_bound_to_atom(H, Env) :-
+    var(H), !,
+    get_binding_state(Env, H, bound).
+
+%% ========================================================================
+%% Section 5. Meet of two environments
+%% ========================================================================
+
+%% meet_env(+EnvA, +EnvB, -EnvAB)
+%  Variable-by-variable meet. Variables present in only one env are
+%  treated as `unknown` in the other (since absent = default unknown).
+meet_env(EnvA, EnvB, EnvMeet) :-
+    collect_env_vars(EnvA, EnvB, Vars),
+    foldl(meet_one_var(EnvA, EnvB), Vars, [], EnvMeet).
+
+collect_env_vars(EnvA, EnvB, Vars) :-
+    pairs_vars(EnvA, VA),
+    pairs_vars(EnvB, VB),
+    append(VA, VB, All),
+    list_unique_by_identity(All, Vars).
+
+pairs_vars([], []).
+pairs_vars([V-_|Rest], [V|Vs]) :- pairs_vars(Rest, Vs).
+
+list_unique_by_identity([], []).
+list_unique_by_identity([V|Rest], [V|UniqueRest]) :-
+    \+ ( member(W, Rest), W == V ), !,
+    list_unique_by_identity(Rest, UniqueRest).
+list_unique_by_identity([_|Rest], UniqueRest) :-
+    list_unique_by_identity(Rest, UniqueRest).
+
+meet_one_var(EnvA, EnvB, V, Env0, Env1) :-
+    get_binding_state(EnvA, V, SA),
+    get_binding_state(EnvB, V, SB),
+    state_meet(SA, SB, SM),
+    (   SM == unknown
+    ->  Env1 = Env0  % default — no entry
+    ;   set_binding_state(Env0, V, SM, Env1)
+    ).
+
+%% ========================================================================
+%% Section 6. Whole-clause analysis
+%% ========================================================================
+
+%% analyse_clause_bindings(+Head, +Body, -GoalBindings)
+%
+%  Computes per-goal binding-state records for a clause body.
+%
+%  GoalBindings is a list of `goal_binding(Idx, BeforeEnv, AfterEnv)`
+%  records, one per *normalised* body goal (control-flow constructs
+%  produce a single record with a meet post-state — they are not
+%  decomposed into sub-goal records).
+analyse_clause_bindings(Head, Body, GoalBindings) :-
+    Head =.. [Pred|_],
+    functor(Head, Pred, Arity),
+    lookup_modes(Pred, Arity, Modes),
+    initial_binding_env(Head, Modes, Env0),
+    clause_body_analysis:normalize_goals(Body, Goals),
+    walk_body(Goals, 1, Env0, GoalBindings).
+
+%% lookup_modes(+Pred, +Arity, -ModesOrNone)
+lookup_modes(Pred, Arity, Modes) :-
+    catch(
+        demand_analysis:read_mode_declaration(Pred, Arity, Modes),
+        _,
+        fail
+    ),
+    !.
+lookup_modes(_, _, none).
+
+walk_body([], _, _, []).
+walk_body([Goal|Rest], Idx, EnvIn, [goal_binding(Idx, EnvIn, EnvOut)|RestBindings]) :-
+    propagate_goal(Goal, EnvIn, EnvOut),
+    Idx1 is Idx + 1,
+    walk_body(Rest, Idx1, EnvOut, RestBindings).
+
+%% binding_state_at(+GoalIdx, +Var, +GoalBindings, -State)
+%  Reads the BeforeEnv of the goal at index GoalIdx; defaults to
+%  `unknown` if the goal index is out of range.
+binding_state_at(GoalIdx, Var, GoalBindings, State) :-
+    member(goal_binding(GoalIdx, BeforeEnv, _), GoalBindings),
+    !,
+    get_binding_state(BeforeEnv, Var, State).
+binding_state_at(_, _, _, unknown).

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -23,6 +23,7 @@
 :- use_module(library(option)).
 :- use_module('../core/clause_body_analysis').
 :- use_module('../core/template_system').
+:- use_module('../core/binding_state_analysis').
 
 %% target_info(-Info)
 target_info(info{
@@ -308,6 +309,7 @@ escape_wam_char(C, [C]).
 
 %% compile_single_clause_wam(+Clause, +Options, -Code)
 compile_single_clause_wam(Head-Body, Options, Code) :-
+    set_clause_binding_context(Head, Body),
     Head =.. [_|Args],
     normalize_goals(Body, Goals),
     empty_varmap(V0),
@@ -434,6 +436,7 @@ compile_clauses_fragments([Head-Body|Rest], I, N, Pred, Arity, Options,
         format(string(Choice), "L_~w_~w_~w:~n    retry_me_else L_~w_~w_~w", [Pred, Arity, I, Pred, Arity, Next])
     ),
     % Compile clause body — pre-assign Yi for permanent vars before head
+    set_clause_binding_context(Head, Body),
     Head =.. [_|Args],
     normalize_goals(Body, Goals),
     empty_varmap(V0),
@@ -683,7 +686,18 @@ compile_goals([Goal|Rest], V0, HasEnv, Vf, Code) :-
         )
     ;   Rest == []
     ->  % Last goal: execute (Tail Call Optimization)
-        (   HasEnv == yes
+        (   %% Univ compose-mode lowering routes through compile_goal_execute
+            %% which dispatches to emit_put_structure_dyn_lowering when the
+            %% binding-state preconditions hold. We add the deallocate here
+            %% (HasEnv == yes case) so the resulting tail-call stays
+            %% TCO-correct.
+            Goal = (_ =.. _),
+            HasEnv == yes
+        ->  compile_goal_execute(Goal, V0, Vf, ExecCode),
+            format(string(Code), "    deallocate~n~w", [ExecCode])
+        ;   Goal = (_ =.. _)
+        ->  compile_goal_execute(Goal, V0, Vf, Code)
+        ;   HasEnv == yes
         ->  Goal =.. [Pred|Args],
             length(Args, Arity),
             compile_put_arguments(Args, 1, V0, Vf, PutCode),
@@ -699,6 +713,7 @@ compile_goals([Goal|Rest], V0, HasEnv, Vf, Code) :-
         )
     ;   % Non-last goal: call
         compile_goal_call(Goal, V0, V1, GoalCode),
+        advance_clause_goal_idx,
         compile_goals(Rest, V1, HasEnv, Vf, RestCode),
         format(string(Code), "~w~n~w", [GoalCode, RestCode])
     ).
@@ -939,6 +954,17 @@ compile_goal_call(M:InnerGoal, V0, Vf, Code) :-
     (atom(M) ; string(M)),
     !,
     compile_goal_call(InnerGoal, V0, Vf, Code).
+%% =../2 compose-mode lowering: T =.. [Name | FixedArgs] where T is
+%% provably unbound and Name is provably bound. Emits PutStructureDyn
+%% rather than the generic =../2 builtin call. Falls through to the
+%% builtin path if the binding-state preconditions cannot be proved.
+compile_goal_call(T =.. L, V0, Vf, Code) :-
+    parse_univ_list_pattern(L, NameVar, FixedArgs),
+    current_clause_binding_env(BeforeEnv),
+    binding_state_analysis:binding_state_at_var(BeforeEnv, T, unbound),
+    binding_state_analysis:binding_state_at_var(BeforeEnv, NameVar, bound),
+    !,
+    emit_put_structure_dyn_lowering(T, NameVar, FixedArgs, V0, Vf, Code).
 compile_goal_call(Goal, V0, Vf, Code) :-
     Goal =.. [Pred|Args],
     length(Args, Arity),
@@ -956,6 +982,16 @@ compile_goal_execute(M:InnerGoal, V0, Vf, Code) :-
     (atom(M) ; string(M)),
     !,
     compile_goal_execute(InnerGoal, V0, Vf, Code).
+%% =../2 compose-mode lowering, tail-call form. Produces the same
+%% PutStructureDyn lowering followed by `proceed`.
+compile_goal_execute(T =.. L, V0, Vf, Code) :-
+    parse_univ_list_pattern(L, NameVar, FixedArgs),
+    current_clause_binding_env(BeforeEnv),
+    binding_state_analysis:binding_state_at_var(BeforeEnv, T, unbound),
+    binding_state_analysis:binding_state_at_var(BeforeEnv, NameVar, bound),
+    !,
+    emit_put_structure_dyn_lowering(T, NameVar, FixedArgs, V0, Vf, BodyCode),
+    format(string(Code), "~w~n    proceed", [BodyCode]).
 compile_goal_execute(Goal, V0, Vf, Code) :-
     Goal =.. [Pred|Args],
     length(Args, Arity),
@@ -1217,3 +1253,127 @@ write_wam_program(Code, Filename) :-
         format(Stream, "~w~n", [Code]),
         close(Stream)
     ).
+
+%% ========================================================================
+%% Binding-state analysis plumbing for =../2 compose-mode lowering.
+%%
+%% The binding analyser produces a list of `goal_binding(Idx, Before,
+%% After)` records per clause. We stash that list in a non-backtrackable
+%% global before invoking the body walk, and the new `compile_goal_call`
+%% / `compile_goal_execute` clauses for `T =.. L` consult it.
+%%
+%% The analysis is *additive* — if the global is unset (e.g. when a
+%% target invokes `compile_goal_call/4` directly without going through
+%% `compile_single_clause_wam`), the lowering simply falls through to
+%% the existing builtin path. No regression for any non-WAM-Haskell
+%% caller.
+%% ========================================================================
+
+%% set_clause_binding_context(+Head, +Body)
+%  Run the binding analyser on the clause and stash the resulting list
+%  of `goal_binding/3` records in `wam_clause_binding_records`. Also
+%  resets the per-goal index counter to 1.
+set_clause_binding_context(Head, Body) :-
+    catch(
+        binding_state_analysis:analyse_clause_bindings(Head, Body, Bindings),
+        _Err,
+        Bindings = []
+    ),
+    b_setval(wam_clause_binding_records, Bindings),
+    b_setval(wam_clause_goal_idx, 1).
+
+%% current_clause_binding_env(-BeforeEnv)
+%  Returns the BeforeEnv of the goal currently being compiled. Defaults
+%  to the empty env when no analysis is in scope.
+current_clause_binding_env(BeforeEnv) :-
+    (   catch(b_getval(wam_clause_binding_records, Bindings), _, fail)
+    ->  true
+    ;   Bindings = []
+    ),
+    (   catch(b_getval(wam_clause_goal_idx, Idx), _, fail)
+    ->  true
+    ;   Idx = 1
+    ),
+    (   member(goal_binding(Idx, Env, _), Bindings)
+    ->  BeforeEnv = Env
+    ;   binding_state_analysis:empty_binding_env(BeforeEnv)
+    ).
+
+%% advance_clause_goal_idx
+%  Step the per-clause goal index forward by one. Called from the body
+%  walk between goals so the binding lookup sees the right BeforeEnv.
+advance_clause_goal_idx :-
+    (   catch(b_getval(wam_clause_goal_idx, Idx), _, fail)
+    ->  Idx1 is Idx + 1,
+        b_setval(wam_clause_goal_idx, Idx1)
+    ;   true
+    ).
+
+%% parse_univ_list_pattern(+List, -NameVar, -FixedArgs)
+%
+%  Recognises the list literal `[NameVar | FixedArgs]` where NameVar is
+%  a Prolog variable and FixedArgs is a fixed-length proper list
+%  (length ≥ 0, no tail variables). Used by the =../2 compose-mode
+%  lowering to extract the dynamic functor name and the fixed
+%  argument list.
+parse_univ_list_pattern(List, _NameVar, _FixedArgs) :-
+    var(List), !, fail.
+parse_univ_list_pattern([NameVar|Rest], NameVar, FixedArgs) :-
+    var(NameVar),
+    proper_fixed_list(Rest, FixedArgs).
+
+proper_fixed_list(L, _) :- var(L), !, fail.
+proper_fixed_list([], []) :- !.
+proper_fixed_list([H|T], [H|FixedT]) :-
+    proper_fixed_list(T, FixedT).
+
+%% emit_put_structure_dyn_lowering(+T, +NameVar, +FixedArgs, +V0, -Vf, -Code)
+%
+%  Emit the WAM instruction sequence that constructs a structure whose
+%  functor name comes from a register (`NameVar`) and whose arity is
+%  the literal length of FixedArgs.
+%
+%  Sequence:
+%      put_value Reg(NameVar), A1     # nameReg
+%      put_constant N, A2             # arityReg (literal int)
+%      put_structure_dyn A1, A2, A3   # construct Str at A3
+%      <set_value/set_variable for each FixedArg>
+%      get_value Reg(T), A3           # unify with T
+%
+%  Pre-condition: the caller has verified that NameVar is `bound` and
+%  T is `unbound` in the BeforeEnv.
+emit_put_structure_dyn_lowering(T, NameVar, FixedArgs, V0, Vf, Code) :-
+    %% A1 = NameVar's register (must already exist; if not, allocate).
+    (   get_var_reg(NameVar, V0, NameReg)
+    ->  V1 = V0,
+        format(string(NameCode), "    put_value ~w, A1", [NameReg])
+    ;   next_x_reg(V0, NameReg, V_temp1),
+        bind_var(NameVar, NameReg, V_temp1, V1),
+        format(string(NameCode), "    put_variable ~w, A1", [NameReg])
+    ),
+    %% A2 = literal arity.
+    length(FixedArgs, Arity),
+    format(string(ArityCode), "    put_constant ~w, A2", [Arity]),
+    %% A3 = constructed term register.
+    next_x_reg(V1, TermReg, V2),
+    format(string(StructCode), "    put_structure_dyn A1, A2, ~w", [TermReg]),
+    %% Emit set_value/set_variable for each FixedArg.
+    compile_set_arguments(FixedArgs, V2, V3, SetCode),
+    %% Bind T to the result. If T already has a reg, emit get_value;
+    %% otherwise bind T to TermReg directly (T is now aliased to the
+    %% constructed term).
+    (   get_var_reg(T, V3, TReg)
+    ->  Vf = V3,
+        format(string(GetCode), "    get_value ~w, ~w", [TReg, TermReg])
+    ;   bind_var(T, TermReg, V3, Vf),
+        GetCode = ""
+    ),
+    %% Stitch together, dropping empty pieces.
+    join_nonempty(
+        [NameCode, ArityCode, StructCode, SetCode, GetCode],
+        Code).
+
+join_nonempty(Pieces, Code) :-
+    exclude(=(""), Pieces, NonEmpty),
+    atomic_list_concat(NonEmpty, '\n', CodeAtom),
+    atom_string(CodeAtom, Code).

--- a/tests/core/test_binding_state_analysis.pl
+++ b/tests/core/test_binding_state_analysis.pl
@@ -1,0 +1,378 @@
+:- encoding(utf8).
+%% Test suite for binding_state_analysis.pl
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_binding_state_analysis.pl
+
+:- use_module('../../src/unifyweaver/core/binding_state_analysis').
+:- use_module(library(lists)).
+
+%% ========================================================================
+%% Test runner
+%% ========================================================================
+
+run_tests :-
+    format("~n========================================~n"),
+    format("Binding State Analysis Tests~n"),
+    format("========================================~n~n"),
+    findall(Test, test(Test), Tests),
+    length(Tests, Total),
+    run_all(Tests, 0, Passed),
+    format("~n========================================~n"),
+    (   Passed =:= Total
+    ->  format("All ~w tests passed~n", [Total])
+    ;   Failed is Total - Passed,
+        format("~w of ~w tests FAILED~n", [Failed, Total]),
+        format("Tests FAILED~n"),
+        halt(1)
+    ),
+    format("========================================~n").
+
+run_all([], Passed, Passed).
+run_all([Test|Rest], Acc, Passed) :-
+    (   catch(call(Test), Error,
+            (format("[FAIL] ~w: ~w~n", [Test, Error]), fail))
+    ->  Acc1 is Acc + 1,
+        run_all(Rest, Acc1, Passed)
+    ;   run_all(Rest, Acc, Passed)
+    ).
+
+pass(Name) :- format("[PASS] ~w~n", [Name]).
+fail_test(Name, Reason) :- format("[FAIL] ~w: ~w~n", [Name, Reason]), fail.
+
+%% ========================================================================
+%% Test declarations
+%% ========================================================================
+
+test(test_initial_env_no_mode).
+test(test_initial_env_input_mode).
+test(test_initial_env_output_mode).
+test(test_initial_env_any_mode).
+test(test_initial_env_structured_head).
+test(test_get_default_unknown).
+test(test_propagate_unify_var_term).
+test(test_propagate_unify_two_vars_one_bound).
+test(test_propagate_is).
+test(test_propagate_nonvar_guard).
+test(test_propagate_var_guard).
+test(test_propagate_atom_guard).
+test(test_propagate_functor_compose).
+test(test_propagate_functor_decompose).
+test(test_propagate_univ_compose).
+test(test_propagate_univ_decompose).
+test(test_propagate_univ_unbound_unbound).
+test(test_propagate_negation_noop).
+test(test_propagate_cut_noop).
+test(test_propagate_arg_unknown).
+test(test_propagate_copy_term_bound).
+test(test_ite_meet_disagree).
+test(test_ite_meet_agree).
+test(test_disjunction_meet).
+test(test_findall_result_bound).
+test(test_call_unknown_pred_opacity).
+test(test_walk_body_indices).
+test(test_binding_state_at_lookup).
+test(test_binding_state_at_var_negative).
+test(test_meet_unbound_unbound).
+test(test_meet_bound_unbound).
+
+%% ========================================================================
+%% Section 1 — initial_binding_env
+%% ========================================================================
+
+test_initial_env_no_mode :-
+    Test = test_initial_env_no_mode,
+    initial_binding_env(foo(X, Y), none, Env),
+    get_binding_state(Env, X, SX),
+    get_binding_state(Env, Y, SY),
+    (   SX == unknown, SY == unknown
+    ->  pass(Test)
+    ;   fail_test(Test, sx_or_sy_not_unknown(SX, SY))
+    ).
+
+test_initial_env_input_mode :-
+    Test = test_initial_env_input_mode,
+    initial_binding_env(foo(X), [input], Env),
+    get_binding_state(Env, X, SX),
+    (   SX == bound
+    ->  pass(Test)
+    ;   fail_test(Test, expected_bound_got(SX))
+    ).
+
+test_initial_env_output_mode :-
+    Test = test_initial_env_output_mode,
+    initial_binding_env(foo(X), [output], Env),
+    get_binding_state(Env, X, SX),
+    (   SX == unbound
+    ->  pass(Test)
+    ;   fail_test(Test, expected_unbound_got(SX))
+    ).
+
+test_initial_env_any_mode :-
+    Test = test_initial_env_any_mode,
+    initial_binding_env(foo(X), [any], Env),
+    get_binding_state(Env, X, SX),
+    (   SX == unknown
+    ->  pass(Test)
+    ;   fail_test(Test, expected_unknown_got(SX))
+    ).
+
+test_initial_env_structured_head :-
+    Test = test_initial_env_structured_head,
+    %% Head foo(f(X)) — X is bound by head unification.
+    initial_binding_env(foo(f(X)), [any], Env),
+    get_binding_state(Env, X, SX),
+    (   SX == bound
+    ->  pass(Test)
+    ;   fail_test(Test, expected_bound_got(SX))
+    ).
+
+test_get_default_unknown :-
+    Test = test_get_default_unknown,
+    empty_binding_env(Env),
+    get_binding_state(Env, _Z, SZ),
+    (   SZ == unknown
+    ->  pass(Test)
+    ;   fail_test(Test, expected_unknown_got(SZ))
+    ).
+
+%% ========================================================================
+%% Section 2 — per-goal propagation
+%% ========================================================================
+
+test_propagate_unify_var_term :-
+    Test = test_propagate_unify_var_term,
+    empty_binding_env(Env0),
+    propagate_goal(X = foo(a), Env0, Env1),
+    get_binding_state(Env1, X, S),
+    (   S == bound -> pass(Test) ; fail_test(Test, S) ).
+
+test_propagate_unify_two_vars_one_bound :-
+    Test = test_propagate_unify_two_vars_one_bound,
+    empty_binding_env(Env0),
+    set_binding_state(Env0, X, bound, Env1),
+    propagate_goal(X = Y, Env1, Env2),
+    get_binding_state(Env2, X, SX),
+    get_binding_state(Env2, Y, SY),
+    (   SX == bound, SY == bound
+    ->  pass(Test)
+    ;   fail_test(Test, sx_sy(SX, SY))
+    ).
+
+test_propagate_is :-
+    Test = test_propagate_is,
+    empty_binding_env(Env0),
+    set_binding_state(Env0, X, bound, Env1),
+    propagate_goal(Y is X + 1, Env1, Env2),
+    get_binding_state(Env2, Y, S),
+    (   S == bound -> pass(Test) ; fail_test(Test, S) ).
+
+test_propagate_nonvar_guard :-
+    Test = test_propagate_nonvar_guard,
+    empty_binding_env(Env0),
+    propagate_goal(nonvar(X), Env0, Env1),
+    get_binding_state(Env1, X, S),
+    (   S == bound -> pass(Test) ; fail_test(Test, S) ).
+
+test_propagate_var_guard :-
+    Test = test_propagate_var_guard,
+    empty_binding_env(Env0),
+    propagate_goal(var(X), Env0, Env1),
+    get_binding_state(Env1, X, S),
+    (   S == unbound -> pass(Test) ; fail_test(Test, S) ).
+
+test_propagate_atom_guard :-
+    Test = test_propagate_atom_guard,
+    empty_binding_env(Env0),
+    propagate_goal(atom(X), Env0, Env1),
+    get_binding_state(Env1, X, S),
+    (   S == bound -> pass(Test) ; fail_test(Test, S) ).
+
+test_propagate_functor_compose :-
+    %% functor(T, foo, 2) with T unbound — analysis can prove T bound after.
+    Test = test_propagate_functor_compose,
+    empty_binding_env(Env0),
+    set_binding_state(Env0, T, unbound, Env1),
+    propagate_goal(functor(T, foo, 2), Env1, Env2),
+    get_binding_state(Env2, T, S),
+    (   S == bound -> pass(Test) ; fail_test(Test, S) ).
+
+test_propagate_functor_decompose :-
+    %% functor(T, N, A) with T bound — N and A become bound.
+    Test = test_propagate_functor_decompose,
+    empty_binding_env(Env0),
+    set_binding_state(Env0, T, bound, Env1),
+    propagate_goal(functor(T, N, A), Env1, Env2),
+    get_binding_state(Env2, N, SN),
+    get_binding_state(Env2, A, SA),
+    (   SN == bound, SA == bound
+    ->  pass(Test)
+    ;   fail_test(Test, sn_sa(SN, SA))
+    ).
+
+test_propagate_univ_compose :-
+    %% T =.. [foo, X, Y] — list literally bound (atom head, ground tail).
+    Test = test_propagate_univ_compose,
+    empty_binding_env(Env0),
+    set_binding_state(Env0, T, unbound, Env1),
+    propagate_goal(T =.. [foo, _, _], Env1, Env2),
+    get_binding_state(Env2, T, S),
+    (   S == bound -> pass(Test) ; fail_test(Test, S) ).
+
+test_propagate_univ_decompose :-
+    Test = test_propagate_univ_decompose,
+    empty_binding_env(Env0),
+    set_binding_state(Env0, T, bound, Env1),
+    propagate_goal(T =.. L, Env1, Env2),
+    get_binding_state(Env2, L, S),
+    (   S == bound -> pass(Test) ; fail_test(Test, S) ).
+
+test_propagate_univ_unbound_unbound :-
+    %% Both sides unknown ⇒ both stay unknown.
+    Test = test_propagate_univ_unbound_unbound,
+    empty_binding_env(Env0),
+    propagate_goal(T =.. L, Env0, Env1),
+    get_binding_state(Env1, T, ST),
+    get_binding_state(Env1, L, SL),
+    (   ST == unknown, SL == unknown
+    ->  pass(Test)
+    ;   fail_test(Test, st_sl(ST, SL))
+    ).
+
+test_propagate_negation_noop :-
+    Test = test_propagate_negation_noop,
+    empty_binding_env(Env0),
+    set_binding_state(Env0, X, unbound, Env1),
+    propagate_goal(\+(some_pred(X)), Env1, Env2),
+    get_binding_state(Env2, X, S),
+    (   S == unbound -> pass(Test) ; fail_test(Test, S) ).
+
+test_propagate_cut_noop :-
+    Test = test_propagate_cut_noop,
+    empty_binding_env(Env0),
+    set_binding_state(Env0, X, bound, Env1),
+    propagate_goal(!, Env1, Env2),
+    get_binding_state(Env2, X, S),
+    (   S == bound -> pass(Test) ; fail_test(Test, S) ).
+
+test_propagate_arg_unknown :-
+    Test = test_propagate_arg_unknown,
+    empty_binding_env(Env0),
+    set_binding_state(Env0, T, bound, Env1),
+    propagate_goal(arg(1, T, A), Env1, Env2),
+    get_binding_state(Env2, A, S),
+    (   S == unknown -> pass(Test) ; fail_test(Test, S) ).
+
+test_propagate_copy_term_bound :-
+    Test = test_propagate_copy_term_bound,
+    empty_binding_env(Env0),
+    set_binding_state(Env0, T, bound, Env1),
+    propagate_goal(copy_term(T, C), Env1, Env2),
+    get_binding_state(Env2, C, S),
+    (   S == bound -> pass(Test) ; fail_test(Test, S) ).
+
+%% ========================================================================
+%% Section 3 — control constructs and meet
+%% ========================================================================
+
+test_ite_meet_disagree :-
+    %% Then sets X bound, Else does nothing — meet ⇒ unknown.
+    Test = test_ite_meet_disagree,
+    empty_binding_env(Env0),
+    propagate_goal(
+        (true -> X = foo ; true),
+        Env0, Env),
+    get_binding_state(Env, X, S),
+    (   S == unknown -> pass(Test) ; fail_test(Test, S) ).
+
+test_ite_meet_agree :-
+    %% Both branches set X bound — meet ⇒ bound.
+    Test = test_ite_meet_agree,
+    empty_binding_env(Env0),
+    propagate_goal(
+        (true -> X = foo ; X = bar),
+        Env0, Env),
+    get_binding_state(Env, X, S),
+    (   S == bound -> pass(Test) ; fail_test(Test, S) ).
+
+test_disjunction_meet :-
+    Test = test_disjunction_meet,
+    empty_binding_env(Env0),
+    propagate_goal(
+        (X = a ; X = b),
+        Env0, Env),
+    get_binding_state(Env, X, S),
+    (   S == bound -> pass(Test) ; fail_test(Test, S) ).
+
+test_findall_result_bound :-
+    Test = test_findall_result_bound,
+    empty_binding_env(Env0),
+    propagate_goal(findall(_, member(_, [1,2,3]), R), Env0, Env),
+    get_binding_state(Env, R, S),
+    (   S == bound -> pass(Test) ; fail_test(Test, S) ).
+
+%% ========================================================================
+%% Section 4 — user calls
+%% ========================================================================
+
+test_call_unknown_pred_opacity :-
+    %% Calling some_user_pred(X) without mode declaration:
+    %% X transitions to unknown (was unset, default unknown — still unknown).
+    Test = test_call_unknown_pred_opacity,
+    empty_binding_env(Env0),
+    set_binding_state(Env0, X, bound, Env1),
+    propagate_goal(some_user_pred(X), Env1, Env2),
+    get_binding_state(Env2, X, S),
+    (   S == unknown -> pass(Test) ; fail_test(Test, S) ).
+
+%% ========================================================================
+%% Section 5 — full clause walks
+%% ========================================================================
+
+test_walk_body_indices :-
+    %% A 3-goal body produces 3 records with indices 1,2,3.
+    Test = test_walk_body_indices,
+    Head = p(_X, _Y),
+    Body = (_A = a, _B = b, _C = c),
+    analyse_clause_bindings(Head, Body, Bindings),
+    length(Bindings, 3),
+    Bindings = [goal_binding(1, _, _), goal_binding(2, _, _), goal_binding(3, _, _)],
+    pass(Test).
+
+test_binding_state_at_lookup :-
+    Test = test_binding_state_at_lookup,
+    Head = p(X),
+    Body = (Y = foo, X = Y),
+    analyse_clause_bindings(Head, Body, Bindings),
+    %% At goal 2 (`X = Y`), Y should already be bound from goal 1.
+    binding_state_at(2, Y, Bindings, SY),
+    (   SY == bound -> pass(Test) ; fail_test(Test, SY) ).
+
+test_binding_state_at_var_negative :-
+    %% binding_state_at_var with `unknown` expected fails (it never matches).
+    Test = test_binding_state_at_var_negative,
+    empty_binding_env(Env),
+    (   binding_state_at_var(Env, _Z, unknown)
+    ->  fail_test(Test, unknown_should_not_match)
+    ;   pass(Test)
+    ).
+
+test_meet_unbound_unbound :-
+    Test = test_meet_unbound_unbound,
+    empty_binding_env(E),
+    set_binding_state(E, X, unbound, EA),
+    set_binding_state(E, X, unbound, EB),
+    meet_env(EA, EB, EM),
+    get_binding_state(EM, X, S),
+    (   S == unbound -> pass(Test) ; fail_test(Test, S) ).
+
+test_meet_bound_unbound :-
+    Test = test_meet_bound_unbound,
+    empty_binding_env(E),
+    set_binding_state(E, X, bound, EA),
+    set_binding_state(E, X, unbound, EB),
+    meet_env(EA, EB, EM),
+    get_binding_state(EM, X, S),
+    (   S == unknown -> pass(Test) ; fail_test(Test, S) ).
+
+:- initialization(run_tests, main).

--- a/tests/core/test_wam_univ_lowering.pl
+++ b/tests/core/test_wam_univ_lowering.pl
@@ -1,0 +1,208 @@
+:- encoding(utf8).
+%% Test suite for the =../2 compose-mode lowering wired into wam_target.pl.
+%%
+%% Verifies the M6 lowering decision:
+%%   * With a `:- mode/1` declaration that proves T unbound and Name
+%%     bound at the program point of T =.. [Name | Args], the generated
+%%     WAM text contains `put_structure_dyn`.
+%%   * Without a mode declaration (T's binding state is unknown), the
+%%     generator falls through to `builtin_call =../2`.
+%%   * With a mode declaration that proves T bound (decompose), the
+%%     generator falls through to `builtin_call =../2`.
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_wam_univ_lowering.pl
+
+:- use_module('../../src/unifyweaver/targets/wam_target').
+:- use_module(library(lists)).
+
+%% ========================================================================
+%% Test runner
+%% ========================================================================
+
+run_tests :-
+    format("~n========================================~n"),
+    format("WAM =../2 compose-mode lowering tests~n"),
+    format("========================================~n~n"),
+    findall(T, test(T), Tests),
+    length(Tests, Total),
+    run_all(Tests, 0, Passed),
+    format("~n========================================~n"),
+    (   Passed =:= Total
+    ->  format("All ~w tests passed~n", [Total])
+    ;   Failed is Total - Passed,
+        format("~w of ~w tests FAILED~n", [Failed, Total]),
+        format("Tests FAILED~n"),
+        halt(1)
+    ),
+    format("========================================~n").
+
+run_all([], P, P).
+run_all([T|Rest], Acc, P) :-
+    (   catch(call(T), E, (format("[FAIL] ~w: ~w~n", [T, E]), fail))
+    ->  Acc1 is Acc + 1, run_all(Rest, Acc1, P)
+    ;   run_all(Rest, Acc, P)
+    ).
+
+pass(N) :- format("[PASS] ~w~n", [N]).
+fail_test(N, R) :- format("[FAIL] ~w: ~w~n", [N, R]), fail.
+
+%% ========================================================================
+%% Test declarations
+%% ========================================================================
+
+test(test_compose_mode_emits_put_structure_dyn).
+test(test_no_mode_falls_through_to_builtin).
+test(test_decompose_mode_falls_through_to_builtin).
+test(test_compose_mode_arity_matches_list_length).
+test(test_compose_mode_with_zero_arity).
+
+%% ========================================================================
+%% Fixtures
+%% ========================================================================
+
+%% A predicate where the LAST argument is the term to be built and the
+%% functor name is given as an input. With mode (+, ?, -), the analyser
+%% should prove Name bound and T unbound at the =../2 site, triggering
+%% the lowering.
+setup_compose_fixture :-
+    retractall(user:build_term(_, _, _)),
+    retractall(user:mode(build_term(_, _, _))),
+    assert(user:mode(build_term(+, ?, -))),
+    assert(user:(build_term(Name, Arg, T) :-
+        T =.. [Name, Arg])).
+
+teardown_compose_fixture :-
+    retractall(user:build_term(_, _, _)),
+    retractall(user:mode(build_term(_, _, _))).
+
+%% Same predicate body but with no mode declaration — analysis cannot
+%% prove the preconditions, so the lowering must NOT fire.
+setup_no_mode_fixture :-
+    retractall(user:build_term_nomode(_, _, _)),
+    retractall(user:mode(build_term_nomode(_, _, _))),
+    assert(user:(build_term_nomode(Name, Arg, T) :-
+        T =.. [Name, Arg])).
+
+teardown_no_mode_fixture :-
+    retractall(user:build_term_nomode(_, _, _)).
+
+%% Decompose: term in, name+arg out. With T bound (input mode +) the
+%% analyser proves T bound and the lowering does NOT fire.
+setup_decompose_fixture :-
+    retractall(user:split_term(_, _, _)),
+    retractall(user:mode(split_term(_, _, _))),
+    assert(user:mode(split_term(+, -, -))),
+    assert(user:(split_term(T, Name, Arg) :-
+        T =.. [Name, Arg])).
+
+teardown_decompose_fixture :-
+    retractall(user:split_term(_, _, _)),
+    retractall(user:mode(split_term(_, _, _))).
+
+%% ========================================================================
+%% Tests
+%% ========================================================================
+
+test_compose_mode_emits_put_structure_dyn :-
+    Test = test_compose_mode_emits_put_structure_dyn,
+    setup_compose_fixture,
+    (   catch(
+            wam_target:compile_predicate_to_wam(build_term/3, [], WamCode),
+            _, fail)
+    ->  atom_string(WamCode, S),
+        teardown_compose_fixture,
+        (   sub_string(S, _, _, _, "put_structure_dyn")
+        ->  pass(Test)
+        ;   fail_test(Test, no_put_structure_dyn(S))
+        )
+    ;   teardown_compose_fixture,
+        fail_test(Test, compile_failed)
+    ).
+
+test_no_mode_falls_through_to_builtin :-
+    Test = test_no_mode_falls_through_to_builtin,
+    setup_no_mode_fixture,
+    (   catch(
+            wam_target:compile_predicate_to_wam(build_term_nomode/3, [], WamCode),
+            _, fail)
+    ->  atom_string(WamCode, S),
+        teardown_no_mode_fixture,
+        (   sub_string(S, _, _, _, "builtin_call =../2"),
+            \+ sub_string(S, _, _, _, "put_structure_dyn")
+        ->  pass(Test)
+        ;   fail_test(Test, expected_builtin_path(S))
+        )
+    ;   teardown_no_mode_fixture,
+        fail_test(Test, compile_failed)
+    ).
+
+test_decompose_mode_falls_through_to_builtin :-
+    Test = test_decompose_mode_falls_through_to_builtin,
+    setup_decompose_fixture,
+    (   catch(
+            wam_target:compile_predicate_to_wam(split_term/3, [], WamCode),
+            _, fail)
+    ->  atom_string(WamCode, S),
+        teardown_decompose_fixture,
+        (   sub_string(S, _, _, _, "builtin_call =../2"),
+            \+ sub_string(S, _, _, _, "put_structure_dyn")
+        ->  pass(Test)
+        ;   fail_test(Test, expected_builtin_path(S))
+        )
+    ;   teardown_decompose_fixture,
+        fail_test(Test, compile_failed)
+    ).
+
+test_compose_mode_arity_matches_list_length :-
+    Test = test_compose_mode_arity_matches_list_length,
+    %% Use a 4-arity predicate: build_pair(Name, A, B, T) :- T =.. [Name, A, B].
+    %% With mode (+, ?, ?, -) the lowering should fire and put_constant 2
+    %% should appear (the literal arity).
+    retractall(user:build_pair(_, _, _, _)),
+    retractall(user:mode(build_pair(_, _, _, _))),
+    assert(user:mode(build_pair(+, ?, ?, -))),
+    assert(user:(build_pair(Name, A, B, T) :-
+        T =.. [Name, A, B])),
+    (   catch(
+            wam_target:compile_predicate_to_wam(build_pair/4, [], WamCode),
+            _, fail)
+    ->  atom_string(WamCode, S),
+        retractall(user:build_pair(_, _, _, _)),
+        retractall(user:mode(build_pair(_, _, _, _))),
+        (   sub_string(S, _, _, _, "put_structure_dyn"),
+            sub_string(S, _, _, _, "put_constant 2, A2")
+        ->  pass(Test)
+        ;   fail_test(Test, missing_arity_or_dyn(S))
+        )
+    ;   retractall(user:build_pair(_, _, _, _)),
+        retractall(user:mode(build_pair(_, _, _, _))),
+        fail_test(Test, compile_failed)
+    ).
+
+test_compose_mode_with_zero_arity :-
+    Test = test_compose_mode_with_zero_arity,
+    %% Build a zero-arity term (atom-as-functor): t(Name, T) :- T =.. [Name].
+    %% With mode (+, -) the lowering fires and arity is 0.
+    retractall(user:build_atom(_, _)),
+    retractall(user:mode(build_atom(_, _))),
+    assert(user:mode(build_atom(+, -))),
+    assert(user:(build_atom(Name, T) :-
+        T =.. [Name])),
+    (   catch(
+            wam_target:compile_predicate_to_wam(build_atom/2, [], WamCode),
+            _, fail)
+    ->  atom_string(WamCode, S),
+        retractall(user:build_atom(_, _)),
+        retractall(user:mode(build_atom(_, _))),
+        (   sub_string(S, _, _, _, "put_structure_dyn"),
+            sub_string(S, _, _, _, "put_constant 0, A2")
+        ->  pass(Test)
+        ;   fail_test(Test, missing_zero_arity(S))
+        )
+    ;   retractall(user:build_atom(_, _)),
+        retractall(user:mode(build_atom(_, _))),
+        fail_test(Test, compile_failed)
+    ).
+
+:- initialization(run_tests, main).


### PR DESCRIPTION
## Summary

Implements the WAM-Haskell mode-analysis design from merged docs PR #1664.

This adds a forward binding-state analyser and wires it into WAM lowering so eligible `T =.. List` compose-mode cases emit `put_structure_dyn` instead of falling back to generic `builtin_call =../2`.

## Changes

- Add `src/unifyweaver/core/binding_state_analysis.pl` with clause-level binding-state analysis APIs.
- Wire binding context into `src/unifyweaver/targets/wam_target.pl`.
- Lower eligible compose-mode `=../2` calls to `put_structure_dyn`.
- Preserve fallback behavior for no-mode and decompose-mode cases.
- Add analyser unit tests and WAM codegen tests.

## Tests

- `swipl -g run_tests -t halt tests/core/test_binding_state_analysis.pl`
- `swipl -g run_tests -t halt tests/core/test_wam_univ_lowering.pl`
- `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl`
- `swipl -g run_tests -t halt tests/core/test_demand_analysis.pl`
- `swipl -g run_tests -t halt tests/core/test_purity_certificate.pl`

## Notes

Follow-up work remains for a full Cabal end-to-end smoke test and docs/log updates.
