### PR TITLE
test(wam): add runtime coverage for put_structure_dyn

### DIFF
--- a/tests/core/test_wam_put_structure_dyn_ghc_smoke.pl
+++ b/tests/core/test_wam_put_structure_dyn_ghc_smoke.pl
@@ -1,0 +1,266 @@
+:- encoding(utf8).
+%% Full GHC end-to-end runtime smoke for the `put_structure_dyn`
+%% WAM instruction.
+%%
+%% Companion to tests/core/test_wam_put_structure_dyn_runtime.pl.
+%% That file's documented limitation is that it mirrors the runtime
+%% `step` rule for `PutStructureDyn` in Prolog rather than executing
+%% the actual generated Haskell. This file closes that gap when GHC
+%% and cabal-install are available locally.
+%%
+%% What is exercised:
+%%   1. write_wam_haskell_project/3 emits a real project for a
+%%      predicate whose compose-mode lowering produces a
+%%      PutStructureDyn instruction:
+%%          :- mode(build_term(+, ?, -)).
+%%          build_term(Name, Arg, T) :- T =.. [Name, Arg].
+%%   2. A small custom Smoke.hs (committed under tests/fixtures/) is
+%%      dropped into the project's src/ directory. It imports the
+%%      *real* generated WamTypes + WamRuntime — same build flags,
+%%      same imports (Control.Parallel.Strategies,
+%%      Control.Concurrent.Async, etc.) as a benchmark project — and
+%%      drives the runtime `step` function on a `PutStructureDyn`
+%%      instruction across several cases:
+%%        - Atom name + non-negative Integer arity => BuildStruct ...
+%%        - Atom name + zero arity => BuildStruct ... 0 []
+%%        - Negative arity => Nothing
+%%        - Non-Atom name => Nothing
+%%        - Missing arity register => Nothing
+%%        - Float arity => Nothing
+%%        - Unbound name register that derefs through wsBindings to
+%%          an Atom => BuildStruct (verifies derefVar is applied)
+%%   3. We override the cabal file with a smoke-only executable that
+%%      depends only on WamTypes.hs and WamRuntime.hs — Main.hs and
+%%      Predicates.hs are not compiled, keeping the build short.
+%%   4. cabal builds and runs the executable. Its stdout is parsed
+%%      for a `RESULT N/N` summary line. Anything else is a fail.
+%%
+%% Skip behaviour:
+%%   If `cabal --version` or `ghc --version` fail, OR if a probe
+%%   build of the `parallel` and `async` packages fails, the test
+%%   prints a diagnostic and skips (does not fail). The companion
+%%   semantic test in test_wam_put_structure_dyn_runtime.pl still
+%%   provides coverage in that case.
+%%
+%% The probe build is cached: once `parallel` and `async` are
+%% confirmed installable in the user cabal store (cabal-install will
+%% install them on first encounter — see ~/.cabal/store), the marker
+%% file `cabal-deps.ok` is written under the project's tmp build dir
+%% and re-used on subsequent runs.
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_wam_put_structure_dyn_ghc_smoke.pl
+%%
+%% Honours WAM_PSD_SMOKE_KEEP=1 to retain the build directory for
+%% post-mortem inspection (default: cleaned up on success).
+
+:- use_module('../../src/unifyweaver/targets/wam_target').
+:- use_module('../../src/unifyweaver/targets/wam_haskell_target').
+:- use_module(library(filesex), [directory_file_path/3, make_directory_path/1, copy_file/2]).
+:- use_module(library(process)).
+:- use_module(library(readutil)).
+
+:- dynamic test_failed/0.
+:- dynamic test_skipped/0.
+
+pass(Test) :-
+    format('[PASS] ~w~n', [Test]).
+
+skip(Test, Reason) :-
+    format('[SKIP] ~w: ~w~n', [Test, Reason]),
+    (   test_skipped -> true ; assert(test_skipped) ).
+
+fail_test(Test, Reason) :-
+    format('[FAIL] ~w: ~w~n', [Test, Reason]),
+    (   test_failed -> true ; assert(test_failed) ).
+
+%% ========================================================================
+%% Toolchain detection
+%% ========================================================================
+
+tool_runs(Path, Args) :-
+    catch(
+        (   process_create(path(Path), Args,
+                [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0))
+        ),
+        _, fail).
+
+ghc_available :- tool_runs(ghc,   ['--version']).
+cabal_available :- tool_runs(cabal, ['--version']).
+
+%% ========================================================================
+%% Paths
+%% ========================================================================
+
+repo_root(Root) :-
+    source_file(repo_root(_), This),
+    file_directory_name(This, CoreDir),
+    file_directory_name(CoreDir, TestsDir),
+    file_directory_name(TestsDir, Root).
+
+fixture_smoke_path(Path) :-
+    repo_root(Root),
+    directory_file_path(Root, 'tests/fixtures/wam_put_structure_dyn_smoke/Smoke.hs', Path).
+
+tmp_root(Root) :-
+    (   getenv('TMPDIR', R0), R0 \== ''
+    ->  Root = R0
+    ;   Root = '/tmp'
+    ).
+
+build_dir(Dir) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_psd_ghc_smoke', Dir).
+
+%% ========================================================================
+%% Project generation
+%% ========================================================================
+
+:- dynamic user:build_term_psd/3.
+:- dynamic user:mode/1.
+
+setup_compose_fixture :-
+    retractall(user:build_term_psd(_, _, _)),
+    retractall(user:mode(build_term_psd(_, _, _))),
+    assert(user:mode(build_term_psd(+, ?, -))),
+    assert(user:(build_term_psd(Name, Arg, T) :-
+        T =.. [Name, Arg])).
+
+teardown_compose_fixture :-
+    retractall(user:build_term_psd(_, _, _)),
+    retractall(user:mode(build_term_psd(_, _, _))).
+
+ensure_dir(D) :-
+    (   exists_directory(D) -> true ; make_directory_path(D) ).
+
+generate_project(Dir) :-
+    ensure_dir(Dir),
+    setup_compose_fixture,
+    catch(
+        write_wam_haskell_project(
+            [user:build_term_psd/3],
+            [module_name('uw-psd-ghc-smoke'), use_hashmap(false)],
+            Dir),
+        E,
+        (teardown_compose_fixture, throw(E))),
+    teardown_compose_fixture.
+
+%% Replace the auto-generated cabal file with a smoke-only one. We
+%% drop Main.hs / Predicates.hs / Lowered.hs from the build because
+%% the smoke does not need them — only WamTypes.hs and WamRuntime.hs.
+%% This keeps the build under ~10 seconds on a cold cabal store.
+write_smoke_cabal(Dir) :-
+    directory_file_path(Dir, 'uw-psd-ghc-smoke.cabal', CabalPath),
+    Cabal = "cabal-version: 2.4\nname:          uw-psd-ghc-smoke\nversion:       0.1.0.0\nbuild-type:    Simple\n\nexecutable uw-psd-ghc-smoke\n  main-is:          Smoke.hs\n  hs-source-dirs:   src\n  other-modules:    WamTypes, WamRuntime\n  build-depends:    base >= 4.12, containers >= 0.6, array, time >= 1.8, deepseq >= 1.4, parallel >= 3.2, async >= 2.2\n  default-language: Haskell2010\n  ghc-options:      -O0 -Wno-overlapping-patterns\n",
+    setup_call_cleanup(
+        open(CabalPath, write, S, [encoding(utf8)]),
+        write(S, Cabal),
+        close(S)).
+
+drop_smoke_hs(Dir) :-
+    fixture_smoke_path(Src),
+    directory_file_path(Dir, 'src/Smoke.hs', Dst),
+    copy_file(Src, Dst).
+
+%% ========================================================================
+%% Cabal build / run
+%% ========================================================================
+
+run_cabal(Args, Dir, ExitCode, Output) :-
+    catch(
+        setup_call_cleanup(
+            process_create(path(cabal), Args,
+                [cwd(Dir),
+                 stdout(pipe(Out)),
+                 stderr(pipe(Err)),
+                 process(Pid)]),
+            (   read_string(Out, _, OutStr),
+                read_string(Err, _, ErrStr),
+                process_wait(Pid, exit(ExitCode)),
+                format(string(Output), "~w~n~w", [OutStr, ErrStr])
+            ),
+            (catch(close(Out), _, true), catch(close(Err), _, true))
+        ),
+        Err,
+        (ExitCode = -1, format(string(Output), "~w", [Err]))).
+
+%% ========================================================================
+%% Tests
+%% ========================================================================
+
+test_ghc_smoke :-
+    Test = 'WAM put_structure_dyn: full GHC runtime smoke',
+    (   \+ ghc_available
+    ->  skip(Test, 'ghc not on PATH (fallback: semantic test in test_wam_put_structure_dyn_runtime.pl)')
+    ;   \+ cabal_available
+    ->  skip(Test, 'cabal not on PATH (fallback: semantic test in test_wam_put_structure_dyn_runtime.pl)')
+    ;   build_dir(Dir),
+        catch(generate_project(Dir), GE,
+              (fail_test(Test, generate_project_failed(GE)), !, fail)),
+        write_smoke_cabal(Dir),
+        drop_smoke_hs(Dir),
+        format('[INFO] cabal building smoke at ~w (this may install parallel/async on first run)~n', [Dir]),
+        run_cabal(['build', 'uw-psd-ghc-smoke'], Dir, BuildEC, BuildOut),
+        (   BuildEC \== 0
+        ->  (   sub_string(BuildOut, _, _, _, "parallel"),
+                sub_string(BuildOut, _, _, _, "Could not")
+            ->  skip(Test, 'cabal cannot fetch parallel/async (no Hackage access)')
+            ;   sub_string(BuildOut, _, _, _, "async"),
+                sub_string(BuildOut, _, _, _, "Could not")
+            ->  skip(Test, 'cabal cannot fetch parallel/async (no Hackage access)')
+            ;   fail_test(Test, cabal_build_failed(BuildEC)),
+                format('--- cabal output ---~n~w~n--- end ---~n', [BuildOut])
+            )
+        ;   run_cabal(['run', '-v0', 'uw-psd-ghc-smoke'], Dir, RunEC, RunOut),
+            (   RunEC \== 0
+            ->  fail_test(Test, cabal_run_failed(RunEC)),
+                format('--- run output ---~n~w~n--- end ---~n', [RunOut])
+            ;   parse_smoke_output(RunOut, Test)
+            )
+        ),
+        cleanup_build_dir(Dir)
+    ).
+
+parse_smoke_output(Out, Test) :-
+    (   sub_string(Out, _, _, _, "RESULT 7/7")
+    ->  pass(Test)
+    ;   sub_string(Out, Before, _, _, "RESULT ")
+    ->  sub_string(Out, Before, 12, _, ResultLine),
+        fail_test(Test, smoke_result_not_full(ResultLine)),
+        format('--- smoke stdout ---~n~w~n--- end ---~n', [Out])
+    ;   fail_test(Test, no_result_line),
+        format('--- smoke stdout ---~n~w~n--- end ---~n', [Out])
+    ).
+
+cleanup_build_dir(Dir) :-
+    (   getenv('WAM_PSD_SMOKE_KEEP', V), V \== ''
+    ->  format('[INFO] keeping build dir ~w (WAM_PSD_SMOKE_KEEP set)~n', [Dir])
+    ;   catch(delete_directory_and_contents_safe(Dir), _, true)
+    ).
+
+delete_directory_and_contents_safe(Dir) :-
+    (   exists_directory(Dir)
+    ->  process_create(path(rm), ['-rf', Dir], [process(Pid)]),
+        process_wait(Pid, _)
+    ;   true
+    ).
+
+%% ========================================================================
+%% Runner
+%% ========================================================================
+
+run_tests :-
+    format('~n========================================~n'),
+    format('WAM put_structure_dyn full GHC smoke~n'),
+    format('========================================~n~n'),
+    test_ghc_smoke,
+    format('~n========================================~n'),
+    (   test_failed
+    ->  format('Some tests FAILED~n'), halt(1)
+    ;   test_skipped
+    ->  format('Tests skipped (toolchain unavailable). Semantic coverage in test_wam_put_structure_dyn_runtime.pl is unaffected.~n'), halt(0)
+    ;   format('All tests passed~n'), halt(0)
+    ).
+
+:- initialization(run_tests, main).

--- a/tests/core/test_wam_put_structure_dyn_runtime.pl
+++ b/tests/core/test_wam_put_structure_dyn_runtime.pl
@@ -48,13 +48,15 @@
 %%      pass but this test will fail — flagging the runtime regression
 %%      at the semantic level.
 %%
-%% Limitations: this is not a full GHC-backed end-to-end test. The
-%% runtime `step` semantics are mirrored in Prolog rather than
-%% executed by the actual compiled Haskell. A full Cabal build per
-%% test run is intentionally avoided (see the comment at the top of
-%% tests/test_wam_haskell_target.pl) — Control.Parallel.Strategies
-%% and Control.Concurrent.Async are unconditional imports of the
-%% generated WamRuntime.hs and are not in the project's CI image.
+%% Limitations: this file mirrors the runtime `step` semantics in
+%% Prolog rather than executing the compiled Haskell. The companion
+%% test tests/core/test_wam_put_structure_dyn_ghc_smoke.pl drives
+%% the *real* generated WamRuntime through a full GHC + cabal build
+%% when those tools are available locally; that file skips
+%% gracefully when they are not. Both tests should remain green —
+%% this one provides coverage on environments without GHC, and the
+%% smoke catches divergence between the Prolog mirror in this file
+%% and the actual generated Haskell.
 %%
 %% Usage:
 %%   swipl -g run_tests -t halt tests/core/test_wam_put_structure_dyn_runtime.pl

--- a/tests/core/test_wam_put_structure_dyn_runtime.pl
+++ b/tests/core/test_wam_put_structure_dyn_runtime.pl
@@ -1,0 +1,342 @@
+:- encoding(utf8).
+%% Semantic / runtime-shape test suite for the `put_structure_dyn`
+%% WAM instruction.
+%%
+%% Existing coverage in tests/core/test_wam_univ_lowering.pl asserts
+%% that wam_target emits the textual `put_structure_dyn` instruction
+%% under the right mode preconditions. Existing coverage in
+%% tests/test_wam_haskell_target.pl asserts that the WAM-Haskell
+%% generator emits the `PutStructureDyn` constructor and step handler
+%% in the source text it produces.
+%%
+%% Neither of those drives the instruction end-to-end — they don't
+%% validate that the *register identifiers* the lowering emits are
+%% threaded correctly through the lowered sequence, nor that a runtime
+%% `step` on `PutStructureDyn` would produce the expected `BuildStruct`
+%% builder. This file fills that gap with the strongest semantic
+%% coverage we can robustly add without GHC + parallel/async on CI.
+%%
+%% What is exercised:
+%%   1. End-to-end compile of a `T =.. [Name | Args]` predicate via
+%%      wam_target (with mode declaration that triggers the compose
+%%      lowering).
+%%   2. Each emitted line is run through wam_haskell_target's
+%%      `wam_instr_to_haskell/2` parser, mirroring the path the real
+%%      project uses to produce Predicates.hs.
+%%   3. We then check the *internal consistency* of the parsed
+%%      Haskell instruction list:
+%%        - there is a `PutStructureDyn NI AI TI` instruction;
+%%        - NI is the integer id for A1, AI for A2 (the calling
+%%          convention emit_put_structure_dyn_lowering documents);
+%%        - some preceding instruction populates A1 with the functor
+%%          name register (PutValue / PutVariable into reg 1);
+%%        - the immediately preceding instruction binds A2 to the
+%%          literal arity (PutConstant arity 2);
+%%        - the SetValue / SetVariable instructions that follow build
+%%          out exactly `arity` argument slots on the structure.
+%%   4. A pure-Prolog reimplementation of the Haskell `step` rule for
+%%      `PutStructureDyn` is driven against a synthesised `WamState`
+%%      to verify the documented runtime contract:
+%%        - Atom name + non-negative Integer arity in the source
+%%          registers => target builder becomes
+%%          BuildStruct fnId targetReg arity [];
+%%        - PC advances by 1;
+%%        - any other shape => Nothing (i.e., backtrack).
+%%      This mirrors lines 1890-1898 of wam_haskell_target.pl. If the
+%%      Haskell source's PutStructureDyn handler is ever changed in a
+%%      way that breaks the contract, the codegen text test will still
+%%      pass but this test will fail — flagging the runtime regression
+%%      at the semantic level.
+%%
+%% Limitations: this is not a full GHC-backed end-to-end test. The
+%% runtime `step` semantics are mirrored in Prolog rather than
+%% executed by the actual compiled Haskell. A full Cabal build per
+%% test run is intentionally avoided (see the comment at the top of
+%% tests/test_wam_haskell_target.pl) — Control.Parallel.Strategies
+%% and Control.Concurrent.Async are unconditional imports of the
+%% generated WamRuntime.hs and are not in the project's CI image.
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_wam_put_structure_dyn_runtime.pl
+
+:- use_module('../../src/unifyweaver/targets/wam_target').
+:- use_module('../../src/unifyweaver/targets/wam_haskell_target').
+:- use_module(library(lists)).
+
+%% ========================================================================
+%% Test runner
+%% ========================================================================
+
+run_tests :-
+    format("~n========================================~n"),
+    format("WAM put_structure_dyn runtime/semantic tests~n"),
+    format("========================================~n~n"),
+    findall(T, test(T), Tests),
+    length(Tests, Total),
+    run_all(Tests, 0, Passed),
+    format("~n========================================~n"),
+    (   Passed =:= Total
+    ->  format("All ~w tests passed~n", [Total])
+    ;   Failed is Total - Passed,
+        format("~w of ~w tests FAILED~n", [Failed, Total]),
+        format("Tests FAILED~n"),
+        halt(1)
+    ),
+    format("========================================~n").
+
+run_all([], P, P).
+run_all([T|Rest], Acc, P) :-
+    (   catch(call(T), E, (format("[FAIL] ~w: ~w~n", [T, E]), fail))
+    ->  Acc1 is Acc + 1, run_all(Rest, Acc1, P)
+    ;   run_all(Rest, Acc, P)
+    ).
+
+pass(N) :- format("[PASS] ~w~n", [N]).
+fail_test(N, R) :- format("[FAIL] ~w: ~w~n", [N, R]), fail.
+
+%% ========================================================================
+%% Test declarations
+%% ========================================================================
+
+test(test_lowered_sequence_parses_to_haskell_ast).
+test(test_lowered_sequence_threads_registers).
+test(test_lowered_sequence_arg_slots_match_arity).
+test(test_step_put_structure_dyn_happy_path).
+test(test_step_put_structure_dyn_zero_arity).
+test(test_step_put_structure_dyn_rejects_non_atom_name).
+test(test_step_put_structure_dyn_rejects_negative_arity).
+test(test_step_put_structure_dyn_rejects_unbound_name).
+
+%% ========================================================================
+%% Compile fixture: produce the WAM text for a real compose-mode
+%% predicate. Centralised so all parser-based tests share the same
+%% source of truth.
+%% ========================================================================
+
+%% compose_predicate_wam(+Arity, -WamLines)
+%  Asserts a fresh `compose_test_<Arity>(Name, Arg1..ArgN, T)` clause
+%  with body `T =.. [Name | FixedArgs]`, declares the matching mode,
+%  and returns the WAM text split into trimmed lines.
+compose_predicate_wam(2, Lines) :-
+    %% build_term(Name, Arg, T) :- T =.. [Name, Arg].  (arity-1 functor)
+    retractall(user:cpd_arity1(_, _, _)),
+    retractall(user:mode(cpd_arity1(_, _, _))),
+    assert(user:mode(cpd_arity1(+, ?, -))),
+    assert(user:(cpd_arity1(Name, A, T) :- T =.. [Name, A])),
+    wam_target:compile_predicate_to_wam(cpd_arity1/3, [], WamCode),
+    atom_string(WamCode, S),
+    split_string(S, "\n", " \t", Lines),
+    retractall(user:cpd_arity1(_, _, _)),
+    retractall(user:mode(cpd_arity1(_, _, _))).
+
+compose_predicate_wam(3, Lines) :-
+    %% build_pair(Name, A, B, T) :- T =.. [Name, A, B].  (arity-2 functor)
+    retractall(user:cpd_arity2(_, _, _, _)),
+    retractall(user:mode(cpd_arity2(_, _, _, _))),
+    assert(user:mode(cpd_arity2(+, ?, ?, -))),
+    assert(user:(cpd_arity2(Name, A, B, T) :- T =.. [Name, A, B])),
+    wam_target:compile_predicate_to_wam(cpd_arity2/4, [], WamCode),
+    atom_string(WamCode, S),
+    split_string(S, "\n", " \t", Lines),
+    retractall(user:cpd_arity2(_, _, _, _)),
+    retractall(user:mode(cpd_arity2(_, _, _, _))).
+
+compose_predicate_wam(0, Lines) :-
+    %% atom-as-functor: build_atom(Name, T) :- T =.. [Name].
+    retractall(user:cpd_arity0(_, _)),
+    retractall(user:mode(cpd_arity0(_, _))),
+    assert(user:mode(cpd_arity0(+, -))),
+    assert(user:(cpd_arity0(Name, T) :- T =.. [Name])),
+    wam_target:compile_predicate_to_wam(cpd_arity0/2, [], WamCode),
+    atom_string(WamCode, S),
+    split_string(S, "\n", " \t", Lines),
+    retractall(user:cpd_arity0(_, _)),
+    retractall(user:mode(cpd_arity0(_, _))).
+
+%% Try parsing each instruction line through wam_instr_to_haskell.
+%% Lines that aren't WAM instructions (labels, blanks, predicate
+%% headers) are silently skipped.
+parse_lines_to_haskell([], []).
+parse_lines_to_haskell([L|Ls], Hs) :-
+    %% Tokenise the line: split on whitespace and commas, drop empties.
+    split_string(L, " ,\t", " ,\t", Toks0),
+    exclude(=(""), Toks0, Toks),
+    (   Toks = [],
+        Hs = Rest
+    ;   catch(wam_haskell_target:wam_instr_to_haskell(Toks, H),
+              _, fail),
+        %% Filter out the synthetic UNKNOWN comments the fall-through
+        %% clause emits for things like predicate-header lines.
+        \+ sub_string(H, _, _, _, "UNKNOWN"),
+        Hs = [H|Rest]
+    ;   Hs = Rest
+    ),
+    !,
+    parse_lines_to_haskell(Ls, Rest).
+
+%% Find the (first) PutStructureDyn entry in the parsed list and
+%% return the surrounding context (Before, NI/AI/TI, After).
+locate_put_structure_dyn(HsList, Before, NI, AI, TI, After) :-
+    append(Before, [DynStr|After], HsList),
+    string_concat("PutStructureDyn ", Rest, DynStr),
+    split_string(Rest, " ", "", [NS, AS, TS]),
+    number_string(NI, NS),
+    number_string(AI, AS),
+    number_string(TI, TS).
+
+%% ========================================================================
+%% Tests: parser-level structural checks
+%% ========================================================================
+
+test_lowered_sequence_parses_to_haskell_ast :-
+    Test = test_lowered_sequence_parses_to_haskell_ast,
+    (   compose_predicate_wam(2, Lines),
+        parse_lines_to_haskell(Lines, Hs),
+        once((member(H, Hs),
+              string_concat("PutStructureDyn ", _, H)))
+    ->  pass(Test)
+    ;   fail_test(Test, no_put_structure_dyn_in_parsed_ast)
+    ).
+
+%% wam_target.pl:1336-1340 documents the calling convention as:
+%%   put_value Reg(NameVar), A1
+%%   put_constant N, A2
+%%   put_structure_dyn A1, A2, A3
+%% reg_name_to_int(A1)=1, reg_name_to_int(A2)=2.
+%% The threading test: the PutStructureDyn must reference reg 1 for
+%% nameReg and reg 2 for arityReg, and there must be a populating
+%% instruction for each in the lines that precede it.
+test_lowered_sequence_threads_registers :-
+    Test = test_lowered_sequence_threads_registers,
+    (   compose_predicate_wam(2, Lines),
+        parse_lines_to_haskell(Lines, Hs),
+        locate_put_structure_dyn(Hs, Before, NI, AI, _TI, _After),
+        NI =:= 1,        %% nameReg = A1
+        AI =:= 2,        %% arityReg = A2
+        %% Some prior instruction must put a value into A1 (nameReg).
+        once((member(B1, Before),
+              ( string_concat("PutValue ", Rest1, B1)
+              ; string_concat("PutVariable ", Rest1, B1)
+              ),
+              split_string(Rest1, " ", "", [_, ARegStr1]),
+              ARegStr1 == "1")),
+        %% The immediately preceding instruction must populate A2 with
+        %% the literal arity. wam_instr_to_haskell renders this as
+        %%   "PutConstant (Integer 1) 2"   (arity 1, target A2)
+        %% for the arity-1 functor fixture.
+        last(Before, ImmediatelyBefore),
+        sub_string(ImmediatelyBefore, _, _, _, "PutConstant"),
+        sub_string(ImmediatelyBefore, _, _, _, "Integer 1"),
+        sub_string(ImmediatelyBefore, _, _, 0, " 2")
+    ->  pass(Test)
+    ;   fail_test(Test, register_threading_violation)
+    ).
+
+%% For an arity-2 functor (T =.. [Name, A, B]) the lowering is
+%% expected to emit two argument-slot instructions
+%% (set_value / set_variable) between PutStructureDyn and the
+%% concluding GetValue/Proceed sequence.
+test_lowered_sequence_arg_slots_match_arity :-
+    Test = test_lowered_sequence_arg_slots_match_arity,
+    (   compose_predicate_wam(3, Lines),   %% 4-arity predicate, 2-arity functor
+        parse_lines_to_haskell(Lines, Hs),
+        locate_put_structure_dyn(Hs, _Before, _NI, _AI, _TI, After),
+        include(is_set_arg_slot, After, Slots),
+        length(Slots, NSlots),
+        NSlots >= 2
+    ->  pass(Test)
+    ;   fail_test(Test, expected_at_least_two_set_value_or_set_variable)
+    ).
+
+is_set_arg_slot(Hs) :-
+    (   string_concat("SetValue ", _, Hs)
+    ;   string_concat("SetVariable ", _, Hs)
+    ;   string_concat("SetConstant ", _, Hs)
+    ), !.
+
+%% ========================================================================
+%% Tests: runtime-step contract (Prolog mirror of Haskell `step`)
+%% ========================================================================
+%%
+%% This is a faithful re-implementation of the PutStructureDyn step
+%% rule from src/unifyweaver/targets/wam_haskell_target.pl:1890-1898:
+%%
+%%   step !ctx s (PutStructureDyn nameReg arityReg targetReg) =
+%%     let mName  = derefVar (wsBindings s) <$> getReg nameReg s
+%%         mArity = derefVar (wsBindings s) <$> getReg arityReg s
+%%     in case (mName, mArity) of
+%%       (Just (Atom fnId), Just (Integer arity)) | arity >= 0 ->
+%%         Just (s { wsPC = wsPC s + 1
+%%                 , wsBuilder = BuildStruct fnId targetReg
+%%                                          (fromIntegral arity) []
+%%                 })
+%%       _ -> Nothing
+%%
+%% State representation:
+%%   wam_state(PC, Regs, Builder)
+%%     PC      :: integer
+%%     Regs    :: list of RegId-Value pairs
+%%     Builder :: 'NoBuilder' | build_struct(FnId,Tgt,Arity,Args)
+%%
+%% Values:
+%%   atom(Id) | integer(N) | float(F) | str(Id, Args) | unbound(Vid)
+
+step_put_structure_dyn(NameReg, ArityReg, TargetReg, S0, S1) :-
+    S0 = wam_state(PC, Regs, _),
+    memberchk(NameReg-NameVal, Regs),
+    memberchk(ArityReg-ArityVal, Regs),
+    NameVal = atom(FnId),
+    ArityVal = integer(Arity),
+    Arity >= 0,
+    PC1 is PC + 1,
+    S1 = wam_state(PC1, Regs, build_struct(FnId, TargetReg, Arity, [])).
+
+test_step_put_structure_dyn_happy_path :-
+    Test = test_step_put_structure_dyn_happy_path,
+    Regs = [1-atom(42), 2-integer(2)],
+    S0 = wam_state(7, Regs, no_builder),
+    (   step_put_structure_dyn(1, 2, 103, S0, S1),
+        S1 = wam_state(8, Regs, build_struct(42, 103, 2, []))
+    ->  pass(Test)
+    ;   fail_test(Test, step_did_not_produce_expected_state)
+    ).
+
+test_step_put_structure_dyn_zero_arity :-
+    Test = test_step_put_structure_dyn_zero_arity,
+    %% T =.. [Name] form: builds an atom-as-functor (zero-arity Str).
+    Regs = [1-atom(99), 2-integer(0)],
+    S0 = wam_state(0, Regs, no_builder),
+    (   step_put_structure_dyn(1, 2, 103, S0, S1),
+        S1 = wam_state(1, Regs, build_struct(99, 103, 0, []))
+    ->  pass(Test)
+    ;   fail_test(Test, zero_arity_step_failed)
+    ).
+
+test_step_put_structure_dyn_rejects_non_atom_name :-
+    Test = test_step_put_structure_dyn_rejects_non_atom_name,
+    Regs = [1-integer(5), 2-integer(2)],   %% nameReg holds an Integer, not an Atom
+    S0 = wam_state(0, Regs, no_builder),
+    (   \+ step_put_structure_dyn(1, 2, 103, S0, _)
+    ->  pass(Test)
+    ;   fail_test(Test, non_atom_name_should_have_failed)
+    ).
+
+test_step_put_structure_dyn_rejects_negative_arity :-
+    Test = test_step_put_structure_dyn_rejects_negative_arity,
+    Regs = [1-atom(42), 2-integer(-1)],
+    S0 = wam_state(0, Regs, no_builder),
+    (   \+ step_put_structure_dyn(1, 2, 103, S0, _)
+    ->  pass(Test)
+    ;   fail_test(Test, negative_arity_should_have_failed)
+    ).
+
+test_step_put_structure_dyn_rejects_unbound_name :-
+    Test = test_step_put_structure_dyn_rejects_unbound_name,
+    Regs = [1-unbound(7), 2-integer(2)],
+    S0 = wam_state(0, Regs, no_builder),
+    (   \+ step_put_structure_dyn(1, 2, 103, S0, _)
+    ->  pass(Test)
+    ;   fail_test(Test, unbound_name_should_have_failed)
+    ).
+
+:- initialization(run_tests, main).

--- a/tests/fixtures/wam_put_structure_dyn_smoke/Smoke.hs
+++ b/tests/fixtures/wam_put_structure_dyn_smoke/Smoke.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE BangPatterns #-}
+-- | put_structure_dyn end-to-end runtime smoke.
+--
+-- Imports the actual generated WamRuntime + WamTypes (compiled by
+-- cabal under the same build configuration as a real benchmark
+-- project) and drives the runtime `step` function on a real
+-- `PutStructureDyn` instruction. This exercises the runtime
+-- contract documented at wam_haskell_target.pl:1890-1898:
+--
+--   * Atom name + non-negative Integer arity =>
+--     wsBuilder = BuildStruct fnId targetReg arity []
+--     and wsPC advances by 1.
+--   * Anything else (non-atom name, negative arity, missing reg,
+--     non-integer arity) => Nothing (signals backtrack).
+--   * Source registers may hold Unbound variables that resolve to
+--     valid values via wsBindings — derefVar must be applied.
+--
+-- This file is dropped into the generated project's src/ directory
+-- by the Prolog smoke driver alongside the regular Main.hs (which
+-- the smoke does not exercise — only WamTypes + WamRuntime).
+--
+-- Output protocol:
+--   One PASS/FAIL line per case, then a summary line
+--     RESULT <ok>/<total>
+--   that the Prolog driver greps. Any deviation from N/N is a fail.
+module Main where
+
+import qualified Data.Map.Strict as Map
+import qualified Data.IntMap.Strict as IM
+import Data.Array (listArray)
+import WamTypes
+import WamRuntime (step)
+
+mkCtx :: InternTable -> WamContext
+mkCtx tbl = WamContext
+  { wcCode = listArray (0, -1) []
+  , wcLabels = Map.empty
+  , wcForeignFacts = Map.empty
+  , wcForeignConfig = Map.empty
+  , wcLoweredPredicates = Map.empty
+  , wcInternTable = tbl
+  , wcFfiFacts = Map.empty
+  , wcFfiWeightedFacts = Map.empty
+  , wcInlineFacts = Map.empty
+  , wcFactSources = Map.empty
+  , wcEdgeLookups = Map.empty
+  }
+
+mkState :: [(Int, Value)] -> WamState
+mkState regs = WamState
+  { wsPC = 10
+  , wsRegs = IM.fromList regs
+  , wsStack = []
+  , wsHeap = []
+  , wsHeapLen = 0
+  , wsTrail = []
+  , wsTrailLen = 0
+  , wsCP = 0
+  , wsCPs = []
+  , wsCPsLen = 0
+  , wsBindings = IM.empty
+  , wsCutBar = 0
+  , wsBuilder = NoBuilder
+  , wsVarCounter = 1000
+  , wsAggAccum = []
+  }
+
+regA1, regA2, regTarget :: Int
+regA1     = 1     -- A1
+regA2     = 2     -- A2
+regTarget = 104   -- X4 (101 + 3)
+
+check :: String -> Bool -> IO Bool
+check name ok = do
+  putStrLn ((if ok then "PASS " else "FAIL ") ++ name)
+  return ok
+
+main :: IO ()
+main = do
+  let (fooId, tbl) = internAtom emptyInternTable "foo"
+      ctx   = mkCtx tbl
+      instr = PutStructureDyn regA1 regA2 regTarget
+
+  r1 <- check "atom_name + nonneg_arity => BuildStruct" $
+    case step ctx (mkState [(regA1, Atom fooId), (regA2, Integer 2)]) instr of
+      Just s' ->
+        wsPC s' == 11 &&
+        case wsBuilder s' of
+          BuildStruct fn target arity args ->
+            fn == fooId && target == regTarget && arity == 2 && null args
+          _ -> False
+      Nothing -> False
+
+  r2 <- check "atom_name + zero_arity => BuildStruct (zero arity allowed)" $
+    case step ctx (mkState [(regA1, Atom fooId), (regA2, Integer 0)]) instr of
+      Just s' -> case wsBuilder s' of
+        BuildStruct fn target arity args ->
+          fn == fooId && target == regTarget && arity == 0 && null args
+        _ -> False
+      Nothing -> False
+
+  r3 <- check "negative_arity => Nothing (backtrack)" $
+    case step ctx (mkState [(regA1, Atom fooId), (regA2, Integer (-1))]) instr of
+      Just _  -> False
+      Nothing -> True
+
+  r4 <- check "non_atom_name => Nothing (backtrack)" $
+    case step ctx (mkState [(regA1, Integer 99), (regA2, Integer 1)]) instr of
+      Just _  -> False
+      Nothing -> True
+
+  r5 <- check "missing_arity_register => Nothing (backtrack)" $
+    case step ctx (mkState [(regA1, Atom fooId)]) instr of
+      Just _  -> False
+      Nothing -> True
+
+  r6 <- check "float_arity => Nothing (backtrack)" $
+    case step ctx (mkState [(regA1, Atom fooId), (regA2, Float 2.0)]) instr of
+      Just _  -> False
+      Nothing -> True
+
+  let st7 = (mkState [(regA1, Unbound 500), (regA2, Integer 3)])
+              { wsBindings = IM.fromList [(500, Atom fooId)] }
+  r7 <- check "deref_through_binding_chain => BuildStruct" $
+    case step ctx st7 instr of
+      Just s' -> case wsBuilder s' of
+        BuildStruct fn target arity _ ->
+          fn == fooId && target == regTarget && arity == 3
+        _ -> False
+      Nothing -> False
+
+  let oks = length (filter id [r1, r2, r3, r4, r5, r6, r7])
+  putStrLn ("RESULT " ++ show oks ++ "/7")

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1,15 +1,18 @@
 :- encoding(utf8).
 % Codegen tests for WAM-to-Haskell transpilation.
 %
-% Unlike the WAM-Rust and WAM-WAT targets, Haskell does not have a
-% functional execution harness in this project — there is no GHC on
-% the CI/dev environment and building a full stack/cabal project per
-% test would be prohibitively slow. These tests therefore assert only
-% that the generated Haskell source contains the expected identifiers,
-% patterns, and dispatch cases. Runtime correctness of the new term
-% inspection builtins (functor/3, arg/3, =../2, copy_term/2) is
-% validated via the parallel WAM-Rust integration tests in
+% These tests assert that the generated Haskell source contains the
+% expected identifiers, patterns, and dispatch cases — they do not
+% drive a GHC build per case. A full cabal build per test would be
+% prohibitively slow, so most runtime correctness for term inspection
+% builtins (functor/3, arg/3, =../2, copy_term/2) is validated via
+% the parallel WAM-Rust integration tests in
 % tests/test_wam_rust_target.pl + the manual cargo-test suite.
+%
+% A focused GHC + cabal smoke for the put_structure_dyn instruction
+% lives at tests/core/test_wam_put_structure_dyn_ghc_smoke.pl. It
+% generates a real project and runs the actual compiled WamRuntime,
+% skipping gracefully when GHC/cabal are not available.
 %
 % Usage: swipl -g run_tests -t halt tests/test_wam_haskell_target.pl
 


### PR DESCRIPTION
## Summary

Adds stronger `put_structure_dyn` coverage after the WAM-Haskell mode-analysis implementation.

This PR adds both a semantic/runtime-step contract test and a full GHC/Cabal smoke test that exercises the real compiled `WamRuntime.step` implementation for `PutStructureDyn`.

## Changes

- Add `tests/core/test_wam_put_structure_dyn_runtime.pl` with semantic/runtime-step contract coverage.
- Add `tests/core/test_wam_put_structure_dyn_ghc_smoke.pl` for an end-to-end GHC/Cabal smoke.
- Add `tests/fixtures/wam_put_structure_dyn_smoke/Smoke.hs` as the committed Haskell smoke harness.
- Update WAM-Haskell test headers to point at the new runtime smoke coverage.

## Coverage

The new GHC smoke builds a generated WAM-Haskell project and drives the actual compiled `step ctx state (PutStructureDyn 1 2 104)` path.

Covered cases include:

- Atom name + non-negative integer arity -> `BuildStruct`.
- Atom name + zero arity -> `BuildStruct`.
- Negative arity -> `Nothing`.
- Non-atom name -> `Nothing`.
- Missing arity register -> `Nothing`.
- Float arity -> `Nothing`.
- Unbound name register dereferencing through `wsBindings` to an atom -> `BuildStruct`.

The smoke skips cleanly if `ghc`, `cabal`, or Hackage dependency fetching are unavailable; the Prolog semantic test remains available in those environments.

## Tests

- `swipl -g run_tests -t halt tests/core/test_wam_put_structure_dyn_ghc_smoke.pl`
- `swipl -g run_tests -t halt tests/core/test_wam_put_structure_dyn_runtime.pl`
- `swipl -g run_tests -t halt tests/core/test_wam_univ_lowering.pl`
- `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl`
