### PR TITLE
fix(wam-elixir): cut × findall interaction (closes §6 risk #3)

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -844,8 +844,27 @@ compile_utility_helpers_to_elixir(Code) :-
         # predicate entry (saved by `allocate` into state.cut_point).
         # Preserves caller CPs while clearing CPs pushed inside this
         # clause body.
+        #
+        # Aggregate frames between the current top and cut_point are
+        # PRESERVED as additional cut barriers. Without this, cut
+        # inside a findall body (or in a sub-predicate called from
+        # findall after deallocate restores cut_point to the outer
+        # level) removes the agg frame, causing end_aggregates throw
+        # fail to propagate without finalisation. Closes proposal
+        # section 6 risk 3 — cut x findall interaction.
         new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
-        %{state | choice_points: state.cut_point, pc: new_pc}
+        cut_target_len = length(state.cut_point)
+        current_len = length(state.choice_points)
+        new_cps =
+          if current_len <= cut_target_len do
+            state.choice_points
+          else
+            above_cut_count = current_len - cut_target_len
+            above_cut = Enum.take(state.choice_points, above_cut_count)
+            preserved_aggs = Enum.filter(above_cut, &Map.has_key?(&1, :agg_type))
+            preserved_aggs ++ state.cut_point
+          end
+        %{state | choice_points: new_cps, pc: new_pc}
       _ -> :fail
     end
   end

--- a/tests/test_wam_elixir_lowered_phase3.pl
+++ b/tests/test_wam_elixir_lowered_phase3.pl
@@ -196,6 +196,47 @@ user:phase3_q(b, '2').
 user:phase3_q(c, '3').
 user:phase3_findall_compound(L) :- findall(p(X, Y), phase3_q(X, Y), L).
 
+% Scenarios 13, 14, 15: cut x findall interaction (proposal §6 risk #3).
+% Three fixtures from Perplexity's review:
+%
+%   13. Cut in conjunction — `findall(X, (r(X), !), L)`. Cut inside
+%       findall's inner goal should stop enumeration after the first
+%       solution but NOT escape findall's scope. Expected: L = [1].
+%
+%   14. Cut in sub-predicate — findall calls a sub-predicate that
+%       itself uses cut. Each call to the sub-predicate runs its
+%       cut, returns one solution; findall enumerates over those.
+%       Since first_r is deterministic (cut prunes after first
+%       success), findall captures only that one solution.
+%       Expected: L = [1].
+%
+%   15. Cut barrier — first findall uses cut, second findall right
+%       after must NOT be affected by it. Tests that the agg frame
+%       acts as a cut barrier. Restructured from Perplexity's
+%       suggestion (which had two inline findalls in one body) to
+%       use a sub-predicate for the cut-findall: that pattern works
+%       end-to-end while two-inline-findalls-in-one-body needs a
+%       lowering-level fix that's out of scope here.
+%       Expected: L = [1], Rest = [1, 2, 3].
+%
+% All three required a substrate-level cut fix in WamRuntime.execute
+% _builtin/3's `!/0` arm: cut now PRESERVES aggregate frames between
+% the current top of state.choice_points and state.cut_point. Without
+% this preservation, cut inside findall would remove the agg frame
+% (because allocate's cut_point snapshot is taken BEFORE findall
+% pushes the agg frame), leaving end_aggregate's throw fail with no
+% agg frame to dispatch to and the predicate ends up failing.
+user:phase3_r(1).
+user:phase3_r(2).
+user:phase3_r(3).
+user:phase3_cut_conj(L) :- findall(X, (phase3_r(X), !), L).
+user:phase3_first_r(X) :- phase3_r(X), !.
+user:phase3_cut_subpred(L) :- findall(X, phase3_first_r(X), L).
+user:phase3_cut_first(L) :- findall(X, (phase3_r(X), !), L).
+user:phase3_cut_barrier(L, Rest) :-
+    phase3_cut_first(L),
+    findall(Y, phase3_r(Y), Rest).
+
 %% tmp_root — try TMPDIR / TMP / TEMP / $PREFIX/tmp / ./output in
 %% order. Same fallback chain as the existing benchmark harness.
 tmp_root_candidate(Root) :-
@@ -242,7 +283,13 @@ phase3_predicates([
     user:phase3_nested_inner/1,
     user:phase3_nested_outer/1,
     user:phase3_q/2,
-    user:phase3_findall_compound/1
+    user:phase3_findall_compound/1,
+    user:phase3_r/1,
+    user:phase3_cut_conj/1,
+    user:phase3_first_r/1,
+    user:phase3_cut_subpred/1,
+    user:phase3_cut_first/1,
+    user:phase3_cut_barrier/2
 ]).
 
 %% phase3_driver_invocations(-Lines)
@@ -273,7 +320,13 @@ phase3_driver_invocations([
     'r11 = Phase3Smoke.Phase3NestedOuter.run([{:unbound, make_ref()}])',
     'IO.inspect(r11, label: "SCENARIO_FINDALL_NESTED", charlists: :as_lists)',
     'r12 = Phase3Smoke.Phase3FindallCompound.run([{:unbound, make_ref()}])',
-    'IO.inspect(r12, label: "SCENARIO_FINDALL_COMPOUND", charlists: :as_lists)'
+    'IO.inspect(r12, label: "SCENARIO_FINDALL_COMPOUND", charlists: :as_lists)',
+    'r13 = Phase3Smoke.Phase3CutConj.run([{:unbound, make_ref()}])',
+    'IO.inspect(r13, label: "SCENARIO_CUT_CONJ", charlists: :as_lists)',
+    'r14 = Phase3Smoke.Phase3CutSubpred.run([{:unbound, make_ref()}])',
+    'IO.inspect(r14, label: "SCENARIO_CUT_SUBPRED", charlists: :as_lists)',
+    'r15 = Phase3Smoke.Phase3CutBarrier.run([{:unbound, make_ref()}, {:unbound, make_ref()}])',
+    'IO.inspect(r15, label: "SCENARIO_CUT_BARRIER", charlists: :as_lists)'
 ]).
 
 %% Generate the test project. Predicates and driver invocations are
@@ -453,6 +506,43 @@ assert_scenario_findall_compound(StdOut) :-
     sub_string(W, _, _, _, "\"2\""),
     sub_string(W, _, _, _, "\"3\"").
 
+assert_scenario_cut_conj(StdOut) :-
+    scope_after_label(StdOut, "SCENARIO_CUT_CONJ", W),
+    % Cut in conjunction: findall(X, (r(X), !), L) → L = [1]. Cut
+    % stops enumeration after the first solution. The agg frame
+    % must survive cut for end_aggregate's throw fail to find it
+    % during backtrack and finalise correctly. Without the cut fix
+    % in this PR, the agg frame would be removed by cut and the
+    % predicate would fail entirely.
+    sub_string(W, _, _, _, "\"1\""),
+    \+ sub_string(W, _, _, _, "\"2\""),
+    \+ sub_string(W, _, _, _, "\"3\"").
+
+assert_scenario_cut_subpred(StdOut) :-
+    scope_after_label(StdOut, "SCENARIO_CUT_SUBPRED", W),
+    % Cut in sub-predicate: findall(X, first_r(X), L) where
+    % first_r(X) :- r(X), !. Each call to first_r succeeds with
+    % the first r solution and cuts. findall's enumeration sees
+    % first_r as deterministic — only one solution. L = [1].
+    sub_string(W, _, _, _, "\"1\""),
+    \+ sub_string(W, _, _, _, "\"2\""),
+    \+ sub_string(W, _, _, _, "\"3\"").
+
+assert_scenario_cut_barrier(StdOut) :-
+    scope_after_label(StdOut, "SCENARIO_CUT_BARRIER", W),
+    % Cut barrier: cut inside cut_first_findall must NOT escape
+    % into the second findall's enumeration. After cut_first_findall
+    % returns L = [1], the second findall must enumerate all 3
+    % r/1 solutions independently. Rest = [1, 2, 3].
+    %
+    % Both 1, 2, and 3 must appear in the output (as part of Rest).
+    % This is the diagnostic test: if cut leaked through the agg
+    % frame boundary, the second findall would see the cut's
+    % effect and Rest would be missing values.
+    sub_string(W, _, _, _, "\"1\""),
+    sub_string(W, _, _, _, "\"2\""),
+    sub_string(W, _, _, _, "\"3\"").
+
 %% Per-scenario test wrappers that share captured StdOut/StdErr/ExitCode.
 
 run_scenario(Test, Assertion, StdOut, StdErr, ExitCode) :-
@@ -501,6 +591,15 @@ run_all_scenarios(StdOut, StdErr, ExitCode) :-
                  StdOut, StdErr, ExitCode),
     run_scenario('Phase 3c: findall(p(X,Y), q(X,Y), L) — compound Template + deep-copy (proposal §6 risk #1)',
                  assert_scenario_findall_compound,
+                 StdOut, StdErr, ExitCode),
+    run_scenario('Phase 3c: findall(X, (r(X), !), L) → [1] — cut in conjunction (proposal §6 risk #3)',
+                 assert_scenario_cut_conj,
+                 StdOut, StdErr, ExitCode),
+    run_scenario('Phase 3c: findall(X, first_r(X), L) → [1] — cut in sub-predicate',
+                 assert_scenario_cut_subpred,
+                 StdOut, StdErr, ExitCode),
+    run_scenario('Phase 3c: cut barrier — agg frame protects second findall from cut',
+                 assert_scenario_cut_barrier,
                  StdOut, StdErr, ExitCode).
 
 %% Test runner — single project, single elixir invocation, all


### PR DESCRIPTION
## Summary

- Closes proposal §6 risk #3 — cut inside `findall`'s inner goal previously removed the aggregate frame, causing the predicate to fail entirely. Surfaced by the Phase 3c cut probe via Perplexity's recommended three-fixture diagnostic; all three originally returned `:fail` and now pass after a 15-line fix in `WamRuntime.execute_builtin/3`'s `!/0` handler.
- **Phase 3c §6 coverage now complete** — the three named risks (#1, #3, #7) all closed via PRs #1663, this one, and #1661 respectively.
- **One additional finding documented** for separate follow-up: multiple findalls inline in one clause body don't compose (lowering-level issue, distinct from the cut/findall question).
- 80/80 target tests + 15/15 Phase 3 runtime scenarios + LLVM aggregate test passing on Termux (Elixir 1.19, OTP 28).

## The bug

The `!/0` arm in `WamRuntime.execute_builtin/3` set:

```elixir
%{state | choice_points: state.cut_point, ...}
```

`state.cut_point` was snapshotted at the user clause's `allocate`, **before** `findall` pushed its agg frame onto `state.choice_points`. So cut blew past the agg frame, removing it entirely. `end_aggregate`'s `throw({:fail, state})` then propagated without finding an agg frame, `backtrack/1` reached an empty CP stack, and the predicate failed.

Three patterns affected:
1. Cut directly in findall body: `findall(X, (r(X), !), L)`
2. Cut in a sub-predicate called from findall: same effect via `deallocate` restoring `cut_point` to the outer (pre-findall) level before the cut fires
3. Cut leaking through the agg frame into subsequent findall code in the surrounding clause

## The fix

Cut now **preserves aggregate frames** between the current top of `state.choice_points` and `state.cut_point`. Non-agg ordinary CPs above `cut_point` are still pruned (existing cut semantics); agg frames above `cut_point` survive.

```elixir
{"!/0", 0} ->
  new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
  cut_target_len = length(state.cut_point)
  current_len = length(state.choice_points)
  new_cps =
    if current_len <= cut_target_len do
      state.choice_points  # nothing to cut
    else
      above_cut_count = current_len - cut_target_len
      above_cut = Enum.take(state.choice_points, above_cut_count)
      preserved_aggs = Enum.filter(above_cut, &Map.has_key?(&1, :agg_type))
      preserved_aggs ++ state.cut_point
    end
  %{state | choice_points: new_cps, pc: new_pc}
```

**No regression for non-findall code:** when no agg frame is in the range above `cut_point` (the common case — agg frames only appear when `findall`/`aggregate_all` is in play), `preserved_aggs` is empty and `new_cps == cut_point`, identical to the previous behaviour. The fix is invisible until findall is involved.

## Three Perplexity fixtures

### Scenario 13 — cut in conjunction

```prolog
phase3_r(1). phase3_r(2). phase3_r(3).
phase3_cut_conj(L) :- findall(X, (phase3_r(X), !), L).
```

Expected `L = ["1"]`. Cut stops enumeration after the first solution; the agg frame must survive cut so `end_aggregate` can finalise. ✓

### Scenario 14 — cut in sub-predicate

```prolog
phase3_first_r(X) :- phase3_r(X), !.
phase3_cut_subpred(L) :- findall(X, phase3_first_r(X), L).
```

Expected `L = ["1"]`. Each call to `first_r` is deterministic (cut prunes after first success); findall sees only one solution per call. The compiler emits `deallocate` before cut for tail-position builtins, so by the time cut fires `state.cut_point` has been restored to the outer (pre-findall) level — but the new logic preserves the agg frame anyway. ✓

### Scenario 15 — cut barrier (the diagnostic)

```prolog
phase3_cut_first(L) :- findall(X, (phase3_r(X), !), L).
phase3_cut_barrier(L, Rest) :-
    phase3_cut_first(L),
    findall(Y, phase3_r(Y), Rest).
```

Expected `L = ["1"]`, `Rest = ["1", "2", "3"]`. The diagnostic test: cut inside `cut_first` must **not** leak into the second findall's enumeration. After `cut_first` returns, the second findall must enumerate all three `r/1` solutions independently. ✓

**Restructured from Perplexity's original** which had the two findalls inline in one clause body (`findall(X, (r(X), !), L), findall(Y, r(Y), Rest)`). That pattern hits a separate lowering issue surfaced during the probe — see "Deferred finding" below. Putting the cut findall in a sub-predicate sidesteps that issue; the cut-barrier property is still cleanly tested.

## Reviewer notes

**Why agg frames specifically are preserved.** Cut's standard semantics is "commit to the choices made above this point." For ordinary CPs that's "remove all choice points above the barrier." Agg frames are special — they're not user-visible "choices to retry" but rather machinery that drives findall's enumeration loop. Removing them mid-enumeration corrupts the runtime state because `end_aggregate` still expects the frame to be there. Treating them as cut barriers gives the right semantics: cut prunes user-visible alternatives but not the enumeration scaffolding.

**Why this didn't surface earlier.** Phase 3a/3b/3c scenarios up through #1663 didn't use cut. Cut is a §6 risk explicitly flagged for Phase 3c probing; this PR is that probe. The bug was latent — only `findall + cut` triggered it.

**Why the deallocate-before-cut pattern in Fixture 2 doesn't matter post-fix.** When cut runs in tail position, the WAM compiler emits `deallocate` first (restoring `state.cp` and `cut_point` from the env), then `builtin_call !/0`. `cut_point` reverts to the OUTER level. Pre-fix, this made the cut even worse — it would target an even deeper level than the predicate's own allocate. Post-fix, it doesn't matter: regardless of which level `cut_point` points at, agg frames between that level and the current top are preserved.

## Deferred finding (separate PR)

**Multiple findalls inline in one clause body don't compose.** Perplexity's original Fixture 3 had:

```prolog
phase3_cut_barrier(L, Rest) :-
    findall(X, (r(X), !), L),
    findall(Y, r(Y), Rest).
```

This pattern fails because the WAM compiler splits the body into sub-segments at `call` boundaries. The second findall's setup ends up in the same sub-segment (`k1`) as the first findall's `end_aggregate`. After `aggregate_collect; throw({:fail, state})`, the rest of `k1` is dead code. The agg frame's saved cp captured `state.cp` at first push time (= `terminal_cp` for top-level calls), so when finalise tail-calls it, control jumps directly to the run/1 entry's continuation — bypassing the second findall.

This is a **lowering-level issue**, not a `cut/findall` issue. Likely fix: split sub-segments at `end_aggregate` boundaries (in addition to `call` boundaries), so each findall's post-end_aggregate code lives in its own continuation that the agg frame's saved cp can target. Documented inline in the test file's scenario-15 comment block. Sidestepped here by putting the cut-findall in a sub-predicate (which composes correctly post-#1661, the same way nested findall does).

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_target.pl` — 80/80 passing (cut fix is invisible without agg frames in scope)
- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_lowered_phase3.pl` — 15/15 passing on Termux (12 prior + 3 cut scenarios)
- [x] `swipl -t halt -g test_aggregate_compiles tests/core/test_wam_llvm_aggregate.pl` — passes (LLVM fixture doesn't use cut)
- [x] WAM byte-shape — confirmed unchanged for all three cut fixtures (this is a runtime-only fix; WAM emission identical before/after)
- [x] Pre-existing `test_wam_e2e.pl atom/1` failure exists on `main`, unrelated to this PR

## Phase 3c §6 coverage (now complete)

| Proposal §6 risk | Status | PR |
|---|---|---|
| #1 — deep-copy of compound captured values | ✅ Closed | #1663 |
| #3 — cut × findall interaction | ✅ Closed | This PR |
| #7 — nested findall | ✅ Closed | #1661 |

Phase 3c is now the natural milestone for "sequential findall + aggregate_all on the WAM-Elixir target works correctly across all the originally-flagged risks."

## Phase plan (post-merge)

- **Multiple findalls inline in one body** (next, recommended): Lowering-level fix. Likely small once the design choice is made — split sub-segments at `end_aggregate` boundaries. Removes the workaround need to wrap each findall in a sub-predicate.
- **`get_structure` aliased-ref binding** (parallel track): Surface from #1663's reviewer notes — same class as the trail-bind fixes in #1659/#1661.
- **Compound args within Template** (parallel track): `findall(p(f(X)), ..., L)` extension.
- **Deep-copy for list shapes** (parallel track): `put_list` / `set_value` chain walking.
- **`:sum` numeric encoding** (parallel track): Substrate fix in `put_constant` lowering.
- **Phase 4** (now feasible): Tier-2 × findall — branch-local-accum protocol from Haskell. Sequential is solid across all §6 risks; parallel is the next architectural milestone.

## Related

- Findall track: proposal #1626 → substrate #1627 → lowering #1643 → harness #1647 → coverage #1649 → Y-reg fix #1650 → static-unwrap #1658 → trail-bind #1659 → finalise frame pop #1661 → compound Template + deep-copy #1663 → cut x findall (this PR)
- Phase 3c §6 probes done: #1659 (trail-bind, single-clause), #1661 (nested), #1663 (compound + deep-copy), this PR (cut)
- Haskell precedent: `wam_haskell_target.pl` — equivalent cut-aggregate handling for cross-validation reference
