### PR TITLE
feat(wam-clojure): add LMDB foreign target options

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -702,3 +702,23 @@ The immediate stats surface is intentionally small:
 - `localHits`
 - `sharedHits`
 - `misses`
+
+That LMDB wiring is no longer benchmark-only either. The Clojure target
+itself now accepts declarative LMDB foreign relations for
+`category_parent/2`, together with the existing cache-policy and debug
+options:
+
+- `clojure_lmdb_foreign_relations([category_parent/2-"..."])`
+- `clojure_lmdb_cache_policy(none|memoize|shared|two_level)`
+- `clojure_lmdb_cache_debug(true|false)`
+
+Generated non-benchmark Clojure WAM projects can therefore package the
+JVM/JNI LMDB helper seam and emit a `call-foreign` handler directly
+through `wam_clojure_target.pl`, rather than relying on
+benchmark-generator-local helper code.
+
+One Termux-specific stabilization also landed while lifting that seam:
+repeated LMDB-backed benchmark generation was corrupting or racing on
+the shared Rust helper under `examples/lmdb_relation_artifact/target`.
+The benchmark generator now uses a workspace-local isolated Cargo target
+directory per SWI process instead of the shared repo `target/` path.

--- a/docs/proposals/WAM_CLOJURE_LMDB_FACT_ACCESS_PLAN.md
+++ b/docs/proposals/WAM_CLOJURE_LMDB_FACT_ACCESS_PLAN.md
@@ -58,6 +58,11 @@ What is implemented today:
 - `category_parent` may resolve to `lmdb` through:
   - `wam_clojure_benchmark_relation_data_mode/2`
   - `benchmark_relation_data_mode/2`
+- non-benchmark generated Clojure WAM projects may also declare an LMDB
+  foreign relation directly through:
+  - `clojure_lmdb_foreign_relations([category_parent/2-"path/to/artifact"])`
+  - `clojure_lmdb_cache_policy(none|memoize|shared|two_level)`
+  - `clojure_lmdb_cache_debug(true|false)`
 - generation writes:
   - `category_parent.tsv`
   - `category_parent_lmdb/manifest.json`
@@ -65,6 +70,9 @@ What is implemented today:
   - `lib/liblmdb_artifact_jni.so`
 - generated Clojure `category_parent/2` and `category_ancestor/4`
   handlers can consume `generated.lmdb.LmdbArtifactReader`
+- target-level LMDB foreign relations auto-enable helper packaging, so
+  generated projects do not need a separate benchmark-only hook just to
+  get the JVM/JNI reader seam
 - the benchmark launcher can place the helper jar on the Java classpath
   and the JNI library directory on `java.library.path`
 - the JVM helper now keeps one native LMDB store per thread through a
@@ -83,6 +91,10 @@ This is intentionally narrow:
 - only `category_parent` uses LMDB today
 - the existing EDN and grouped-TSV paths remain the stable defaults
 - there is no shared L2 cache policy yet
+- repeated Rust helper builds in Termux should avoid the shared
+  `examples/lmdb_relation_artifact/target` directory; the benchmark
+  generator now uses a workspace-local isolated Cargo target directory
+  per SWI process to keep repeated LMDB-backed runs stable
 
 ## Specification
 
@@ -136,6 +148,16 @@ The current Clojure-specific extension is:
 - `category_parent -> lmdb`
 
 This is intentionally relation-local, not a new top-level benchmark mode.
+
+For non-benchmark target generation, the corresponding declarative
+surface is:
+
+- `clojure_lmdb_foreign_relations([category_parent/2-"relative/or/absolute/artifact-dir"])`
+- `clojure_lmdb_cache_policy(none|memoize|shared|two_level)`
+- `clojure_lmdb_cache_debug(true|false)`
+
+This currently supports `category_parent/2` only. Other LMDB-backed
+foreign predicates should be added one relation contract at a time.
 
 ### 3. Correctness Rules
 
@@ -209,6 +231,9 @@ Remaining gap:
 
 - the reader seam is still embedded in the JVM helper package rather
   than exposed as a more explicit “reader pool” type
+- target-level declarative LMDB foreign relations are now wired for
+  `category_parent/2`, so the next gap is not wiring but broader
+  relation coverage and desktop measurement
 
 ### Phase C3: Optional L1 memoization
 
@@ -218,6 +243,9 @@ Goal:
 
 - allow repeated `category_parent` lookups to avoid duplicate JNI and
   LMDB traversal work on overlap-heavy workloads
+
+The same cache policy surface is now available from the target-level
+LMDB foreign relation option, not only from the benchmark generator.
 
 Important constraint:
 

--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -174,8 +174,14 @@ collect_wam_entries([PredIndicator|Rest], Options, PC,
 clojure_foreign_predicate(Pred, Arity, Options) :-
     \+ option(no_kernels(true), Options),
     \+ option(foreign_lowering(false), Options),
+    clojure_foreign_relation_selected(Pred/Arity, Options).
+
+clojure_foreign_relation_selected(Pred/Arity, Options) :-
     option(foreign_predicates(ForeignPreds), Options, []),
     member(Pred/Arity, ForeignPreds).
+clojure_foreign_relation_selected(Pred/Arity, Options) :-
+    option(clojure_lmdb_foreign_relations(Relations), Options, []),
+    member(Pred/Arity-_, Relations).
 
 clojure_foreign_stub_data(Pred, Arity, PC, Literals, LabelPairs, NextPC) :-
     format(atom(PredKey), '~w/~w', [Pred, Arity]),
@@ -187,10 +193,29 @@ clojure_foreign_stub_data(Pred, Arity, PC, Literals, LabelPairs, NextPC) :-
     NextPC is PC + 2.
 
 clojure_foreign_handlers_code(Options, Code) :-
-    option(clojure_foreign_handlers(Handlers), Options, []),
+    option(clojure_foreign_handlers(ExplicitHandlers), Options, []),
+    clojure_lmdb_foreign_handlers(Options, LmdbHandlers),
+    append(LmdbHandlers, ExplicitHandlers, Handlers),
     maplist(clojure_foreign_handler_entry, Handlers, Entries),
     atomic_list_concat(Entries, '\n  ', Body),
     (Body == "" -> Code = "" ; format(atom(Code), '  ~w', [Body])).
+
+clojure_lmdb_foreign_handlers(Options, Handlers) :-
+    option(clojure_lmdb_foreign_relations(Relations), Options, []),
+    maplist(clojure_lmdb_foreign_handler(Options), Relations, Handlers).
+
+clojure_lmdb_foreign_handler(Options, Pred/Arity-ArtifactPath, handler(Pred/Arity, HandlerCode)) :-
+    clojure_lmdb_foreign_handler_code(Pred/Arity, ArtifactPath, Options, HandlerCode).
+
+clojure_lmdb_foreign_handler_code(category_parent/2, ArtifactPath, Options, HandlerCode) :-
+    clojure_lmdb_path_literal(ArtifactPath, PathLiteral),
+    clojure_lmdb_reader_open_expr(PathLiteral, Options, ReaderOpenExpr),
+    clojure_lmdb_cache_log_snippet('category_parent/2', Options, LogSnippet),
+    format(string(HandlerCode),
+           "(let [reader-delay (delay ~w)] (fn [args] (let [child (nth args 0) parent (nth args 1) rows (.lookupArg1 ^generated.lmdb.LmdbArtifactReader @reader-delay child) result (boolean (some (fn [^generated.lmdb.LmdbRow row] (= parent (.value row))) rows))] (do ~w result))))",
+           [ReaderOpenExpr, LogSnippet]).
+clojure_lmdb_foreign_handler_code(Pred/Arity, _ArtifactPath, _Options, _HandlerCode) :-
+    throw(error(unsupported_clojure_lmdb_foreign_relation(Pred/Arity), _)).
 
 clojure_foreign_handler_entry(handler(Pred/Arity, HandlerCode), Entry) :- !,
     clojure_foreign_handler_entry(Pred/Arity-HandlerCode, Entry).
@@ -201,10 +226,17 @@ clojure_foreign_handler_entry(Pred/Arity-HandlerCode, Entry) :-
     format(atom(Entry), '~w ~s', [PredKeyLit, HandlerText]).
 
 maybe_prepare_wam_clojure_lmdb_runtime_support(ProjectDir, Options) :-
-    option(clojure_lmdb_runtime_support(true), Options),
+    clojure_lmdb_runtime_needed(Options),
     !,
     prepare_wam_clojure_lmdb_runtime_support(ProjectDir, Options).
 maybe_prepare_wam_clojure_lmdb_runtime_support(_, _).
+
+clojure_lmdb_runtime_needed(Options) :-
+    option(clojure_lmdb_runtime_support(true), Options),
+    !.
+clojure_lmdb_runtime_needed(Options) :-
+    option(clojure_lmdb_foreign_relations(Relations), Options, []),
+    Relations \= [].
 
 prepare_wam_clojure_lmdb_runtime_support(ProjectDir, _Options) :-
     absolute_file_name(ProjectDir, AbsoluteProjectDir),
@@ -256,6 +288,16 @@ clojure_lmdb_reader_open_expr_for_policy(PathLiteral, none, Expr) :-
     format(string(Expr),
            "(generated.lmdb.LmdbArtifactReader/open (java.nio.file.Paths/get ~w (make-array String 0)))",
            [PathLiteral]).
+
+clojure_lmdb_path_literal(ArtifactPath, PathLiteral) :-
+    string(ArtifactPath),
+    !,
+    clj_string_literal(ArtifactPath, PathLiteral).
+clojure_lmdb_path_literal(ArtifactPath, PathLiteral) :-
+    atom(ArtifactPath),
+    !,
+    clj_string_literal(ArtifactPath, PathLiteral).
+clojure_lmdb_path_literal(path_literal(PathLiteral), PathLiteral).
 
 clojure_handler_code_text(HandlerCode, HandlerCode) :-
     string(HandlerCode), !.

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -20,6 +20,8 @@
 :- dynamic user:wam_list_fact/1.
 :- dynamic user:wam_use_struct/1.
 :- dynamic user:wam_use_list/1.
+:- dynamic user:category_parent/2.
+:- dynamic user:wam_parent_lookup/2.
 
 user:wam_fact(a).
 user:wam_execute_caller(X) :- user:wam_fact(X).
@@ -38,6 +40,8 @@ user:wam_struct_fact(f(a)).
 user:wam_list_fact([a,b]).
 user:wam_use_struct(X) :- user:wam_struct_fact(X).
 user:wam_use_list(X) :- user:wam_list_fact(X).
+user:category_parent(_, _) :- fail.
+user:wam_parent_lookup(X, Y) :- user:category_parent(X, Y).
 
 test(project_uses_shared_wam_table_for_cross_predicate_calls) :-
     once((
@@ -185,6 +189,37 @@ test(clojure_lmdb_target_cache_log_snippet) :-
     assertion(DisabledSnippet == "nil"),
     assertion(sub_string(EnabledSnippet, _, _, _, 'lmdb_cache_stats category_parent/2')),
     assertion(sub_string(EnabledSnippet, _, _, _, '.cacheStats')).
+
+test(clojure_lmdb_target_foreign_relation_auto_handler,
+     [condition(lmdb_helper_toolchain_available)]) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_lmdb_foreign_target', TmpDir),
+        write_wam_clojure_project([user:wam_parent_lookup/2,
+                                   user:category_parent/2],
+                                  [ namespace('generated.wam_lmdb_foreign_test'),
+                                    clojure_lmdb_foreign_relations([
+                                        category_parent/2-'data/generated/test/category_parent_lmdb'
+                                    ]),
+                                    clojure_lmdb_cache_policy(shared),
+                                    clojure_lmdb_cache_debug(true)
+                                  ], TmpDir),
+        directory_file_path(TmpDir, 'src/generated/wam_lmdb_foreign_test/core.clj', CorePath),
+        directory_file_path(TmpDir, 'lib/lmdb-artifact-reader.jar', ReaderJarPath),
+        directory_file_path(TmpDir, 'lib/liblmdb_artifact_jni.so', NativeLibPath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(wam_clojure_target:clojure_foreign_predicate(category_parent, 2,
+                   [clojure_lmdb_foreign_relations([
+                       category_parent/2-'data/generated/test/category_parent_lmdb'
+                   ])])),
+        assertion(exists_file(ReaderJarPath)),
+        assertion(exists_file(NativeLibPath)),
+        assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_parent" :arity 2}')),
+        assertion(sub_string(CoreCode, _, _, _, '"category_parent/2" (let [reader-delay (delay (generated.lmdb.LmdbArtifactReader/openSharedCached')),
+        assertion(sub_string(CoreCode, _, _, _, 'data/generated/test/category_parent_lmdb')),
+        assertion(sub_string(CoreCode, _, _, _, 'lmdb_cache_stats category_parent/2')),
+        assertion(sub_string(CoreCode, _, _, _, '"wam_parent_lookup/2" wam-parent-lookup')),
+        delete_directory_and_contents(TmpDir)
+    )).
 
 test(no_kernels_suppresses_clojure_foreign_stub) :-
     once((


### PR DESCRIPTION
## Summary

Adds a target-level declarative LMDB foreign-relation surface to the
Clojure hybrid WAM target.

This moves the LMDB path one step further away from benchmark-only
scaffolding by allowing a generated non-benchmark Clojure WAM project
to declare `category_parent/2` as an LMDB-backed `call-foreign`
predicate directly through `wam_clojure_target.pl`.

## What Changed

- added target-level declarative LMDB foreign relation support in
  `src/unifyweaver/targets/wam_clojure_target.pl`
  - `clojure_lmdb_foreign_relations([category_parent/2-"path"])`
  - existing `clojure_lmdb_cache_policy/1`
  - existing `clojure_lmdb_cache_debug/1`
- `clojure_foreign_predicate/3` now treats declared LMDB foreign
  relations as real `call-foreign` stubs
- `clojure_foreign_handlers_code/2` now auto-generates the LMDB foreign
  handler for `category_parent/2`
- LMDB helper packaging is now auto-enabled when a target declares LMDB
  foreign relations, so generated projects do not need a separate
  runtime-support hook just to use the reader seam
- added a direct generated-project test in
  `tests/test_wam_clojure_generator.pl` that verifies:
  - helper packaging
  - emitted `call-foreign` stub
  - emitted LMDB-backed handler body
  - cache-policy and debug-log wiring
- updated the Clojure LMDB design/docs to reflect:
  - the new target-level declarative surface
  - the current supported relation scope
  - the Termux workspace-local Cargo target stabilization note

## Why

Before this change:

- LMDB cache-policy and debug options were reusable
- but actual LMDB-backed foreign relation declaration still lived
  effectively in benchmark-specific generation code

After this change:

- the Clojure target can declare LMDB-backed foreign relations directly
- generated projects can consume the same JVM/JNI reader seam outside
  the benchmark generator
- the target-level surface is explicit enough to extend one relation
  contract at a time

## Scope

Current supported LMDB-backed target relation:

- `category_parent/2`

This PR does **not** generalize arbitrary LMDB-backed relations yet.
That remains intentionally narrow until we have another concrete
relation contract to support.

## Verification

- `swipl -q -g "run_tests(wam_clojure_generator:clojure_lmdb_target_runtime_support_packages_helpers), run_tests(wam_clojure_generator:clojure_lmdb_target_reader_open_expr_policies), run_tests(wam_clojure_generator:clojure_lmdb_target_cache_log_snippet), run_tests(wam_clojure_generator:clojure_lmdb_target_foreign_relation_auto_handler)" -t halt tests/test_wam_clojure_generator.pl`
- `git diff --check`

## Notes

- the unrelated pre-existing
  `switch_on_constant_preserves_default_fallthrough` failure in the full
  Clojure generator suite is unchanged by this PR
- this PR is about target-level LMDB foreign relation plumbing, not new
  cache tiers or desktop performance measurement
