### PR TITLE
feat(wam-clojure): add LMDB ancestor target option

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -705,17 +705,22 @@ The immediate stats surface is intentionally small:
 
 That LMDB wiring is no longer benchmark-only either. The Clojure target
 itself now accepts declarative LMDB foreign relations for
-`category_parent/2`, together with the existing cache-policy and debug
-options:
+`category_parent/2`, and now also for `category_ancestor/4`, together
+with the existing cache-policy and debug options:
 
 - `clojure_lmdb_foreign_relations([category_parent/2-"..."])`
+- `clojure_lmdb_foreign_relations([category_ancestor/4-"..."])`
 - `clojure_lmdb_cache_policy(none|memoize|shared|two_level)`
 - `clojure_lmdb_cache_debug(true|false)`
+- `clojure_lmdb_ancestor_max_depth(N)` for `category_ancestor/4`
 
 Generated non-benchmark Clojure WAM projects can therefore package the
 JVM/JNI LMDB helper seam and emit a `call-foreign` handler directly
 through `wam_clojure_target.pl`, rather than relying on
-benchmark-generator-local helper code.
+benchmark-generator-local helper code. The target-level
+`category_ancestor/4` handler reuses the LMDB-backed parent lookup seam
+and emits streamed `{:solutions ...}` results using the same recursive
+ancestor traversal contract as the benchmark path.
 
 One Termux-specific stabilization also landed while lifting that seam:
 repeated LMDB-backed benchmark generation was corrupting or racing on

--- a/docs/proposals/WAM_CLOJURE_LMDB_FACT_ACCESS_PLAN.md
+++ b/docs/proposals/WAM_CLOJURE_LMDB_FACT_ACCESS_PLAN.md
@@ -60,9 +60,10 @@ What is implemented today:
   - `benchmark_relation_data_mode/2`
 - non-benchmark generated Clojure WAM projects may also declare an LMDB
   foreign relation directly through:
-  - `clojure_lmdb_foreign_relations([category_parent/2-"path/to/artifact"])`
+  - `clojure_lmdb_foreign_relations([...])`
   - `clojure_lmdb_cache_policy(none|memoize|shared|two_level)`
   - `clojure_lmdb_cache_debug(true|false)`
+  - `clojure_lmdb_ancestor_max_depth(N)` for `category_ancestor/4`
 - generation writes:
   - `category_parent.tsv`
   - `category_parent_lmdb/manifest.json`
@@ -73,6 +74,9 @@ What is implemented today:
 - target-level LMDB foreign relations auto-enable helper packaging, so
   generated projects do not need a separate benchmark-only hook just to
   get the JVM/JNI reader seam
+- target-level LMDB foreign relations currently support:
+  - `category_parent/2`
+  - `category_ancestor/4`
 - the benchmark launcher can place the helper jar on the Java classpath
   and the JNI library directory on `java.library.path`
 - the JVM helper now keeps one native LMDB store per thread through a
@@ -153,11 +157,14 @@ For non-benchmark target generation, the corresponding declarative
 surface is:
 
 - `clojure_lmdb_foreign_relations([category_parent/2-"relative/or/absolute/artifact-dir"])`
+- `clojure_lmdb_foreign_relations([category_ancestor/4-"relative/or/absolute/artifact-dir"])`
 - `clojure_lmdb_cache_policy(none|memoize|shared|two_level)`
 - `clojure_lmdb_cache_debug(true|false)`
+- `clojure_lmdb_ancestor_max_depth(N)` for `category_ancestor/4`
 
-This currently supports `category_parent/2` only. Other LMDB-backed
-foreign predicates should be added one relation contract at a time.
+This currently supports `category_parent/2` and `category_ancestor/4`
+only. Other LMDB-backed foreign predicates should be added one relation
+contract at a time.
 
 ### 3. Correctness Rules
 
@@ -232,7 +239,7 @@ Remaining gap:
 - the reader seam is still embedded in the JVM helper package rather
   than exposed as a more explicit “reader pool” type
 - target-level declarative LMDB foreign relations are now wired for
-  `category_parent/2`, so the next gap is not wiring but broader
+  `category_parent/2` and `category_ancestor/4`, so the next gap is not wiring but broader
   relation coverage and desktop measurement
 
 ### Phase C3: Optional L1 memoization

--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -214,6 +214,14 @@ clojure_lmdb_foreign_handler_code(category_parent/2, ArtifactPath, Options, Hand
     format(string(HandlerCode),
            "(let [reader-delay (delay ~w)] (fn [args] (let [child (nth args 0) parent (nth args 1) rows (.lookupArg1 ^generated.lmdb.LmdbArtifactReader @reader-delay child) result (boolean (some (fn [^generated.lmdb.LmdbRow row] (= parent (.value row))) rows))] (do ~w result))))",
            [ReaderOpenExpr, LogSnippet]).
+clojure_lmdb_foreign_handler_code(category_ancestor/4, ArtifactPath, Options, HandlerCode) :-
+    clojure_lmdb_path_literal(ArtifactPath, PathLiteral),
+    clojure_lmdb_reader_open_expr(PathLiteral, Options, ReaderOpenExpr),
+    clojure_lmdb_cache_log_snippet('category_ancestor/4', Options, LogSnippet),
+    option(clojure_lmdb_ancestor_max_depth(MaxDepth), Options, 10),
+    format(string(HandlerCode),
+           "(let [reader-delay (delay ~w) max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) parent-values (fn [category] (mapv (fn [^generated.lmdb.LmdbRow row] (.value row)) (.lookupArg1 ^generated.lmdb.LmdbArtifactReader @reader-delay category))) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (parent-values category)] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] (do ~w {:solutions (vec solutions)}))))",
+           [ReaderOpenExpr, MaxDepth, LogSnippet]).
 clojure_lmdb_foreign_handler_code(Pred/Arity, _ArtifactPath, _Options, _HandlerCode) :-
     throw(error(unsupported_clojure_lmdb_foreign_relation(Pred/Arity), _)).
 

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -22,6 +22,8 @@
 :- dynamic user:wam_use_list/1.
 :- dynamic user:category_parent/2.
 :- dynamic user:wam_parent_lookup/2.
+:- dynamic user:max_depth/1.
+:- dynamic user:wam_ancestor_lookup/4.
 
 user:wam_fact(a).
 user:wam_execute_caller(X) :- user:wam_fact(X).
@@ -42,6 +44,8 @@ user:wam_use_struct(X) :- user:wam_struct_fact(X).
 user:wam_use_list(X) :- user:wam_list_fact(X).
 user:category_parent(_, _) :- fail.
 user:wam_parent_lookup(X, Y) :- user:category_parent(X, Y).
+user:max_depth(_) :- fail.
+user:wam_ancestor_lookup(A, B, C, D) :- user:category_ancestor(A, B, C, D).
 
 test(project_uses_shared_wam_table_for_cross_predicate_calls) :-
     once((
@@ -218,6 +222,40 @@ test(clojure_lmdb_target_foreign_relation_auto_handler,
         assertion(sub_string(CoreCode, _, _, _, 'data/generated/test/category_parent_lmdb')),
         assertion(sub_string(CoreCode, _, _, _, 'lmdb_cache_stats category_parent/2')),
         assertion(sub_string(CoreCode, _, _, _, '"wam_parent_lookup/2" wam-parent-lookup')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+test(clojure_lmdb_target_ancestor_foreign_relation_auto_handler,
+     [condition(lmdb_helper_toolchain_available)]) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_lmdb_foreign_ancestor_target', TmpDir),
+        write_wam_clojure_project([user:wam_ancestor_lookup/4,
+                                   user:category_ancestor/4],
+                                  [ namespace('generated.wam_lmdb_ancestor_foreign_test'),
+                                    clojure_lmdb_foreign_relations([
+                                        category_ancestor/4-'data/generated/test/category_parent_lmdb'
+                                    ]),
+                                    clojure_lmdb_cache_policy(two_level),
+                                    clojure_lmdb_cache_debug(true),
+                                    clojure_lmdb_ancestor_max_depth(7)
+                                  ], TmpDir),
+        directory_file_path(TmpDir, 'src/generated/wam_lmdb_ancestor_foreign_test/core.clj', CorePath),
+        directory_file_path(TmpDir, 'lib/lmdb-artifact-reader.jar', ReaderJarPath),
+        directory_file_path(TmpDir, 'lib/liblmdb_artifact_jni.so', NativeLibPath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(wam_clojure_target:clojure_foreign_predicate(category_ancestor, 4,
+                   [clojure_lmdb_foreign_relations([
+                       category_ancestor/4-'data/generated/test/category_parent_lmdb'
+                   ])])),
+        assertion(exists_file(ReaderJarPath)),
+        assertion(exists_file(NativeLibPath)),
+        assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "category_ancestor" :arity 4}')),
+        assertion(sub_string(CoreCode, _, _, _, 'LmdbArtifactReader/openTwoLevel')),
+        assertion(sub_string(CoreCode, _, _, _, 'max-depth 7')),
+        assertion(sub_string(CoreCode, _, _, _, 'lmdb_cache_stats category_ancestor/4')),
+        assertion(sub_string(CoreCode, _, _, _, '{:solutions (vec solutions)}')),
+        assertion(sub_string(CoreCode, _, _, _, '{:bindings {2 ancestor 3 hops}}')),
+        assertion(sub_string(CoreCode, _, _, _, '"wam_ancestor_lookup/4" wam-ancestor-lookup')),
         delete_directory_and_contents(TmpDir)
     )).
 


### PR DESCRIPTION
## Summary

Extends the target-level LMDB foreign-relation seam in the Clojure
hybrid WAM target from `category_parent/2` to `category_ancestor/4`.

This keeps the relation contract explicit and narrow while making one
more real traversal predicate available through the reusable target
surface rather than benchmark-only wiring.

## What Changed

- extended `src/unifyweaver/targets/wam_clojure_target.pl` so
  `clojure_lmdb_foreign_relations([...])` now supports:
  - `category_parent/2`
  - `category_ancestor/4`
- added target-level option:
  - `clojure_lmdb_ancestor_max_depth(N)`
- the generated LMDB-backed `category_ancestor/4` handler:
  - uses the existing LMDB `category_parent` reader seam
  - performs recursive ancestor traversal
  - emits streamed `{:solutions ...}` results
  - binds output args `2` and `3` as `{ancestor, hops}`
- added direct generated-project coverage in
  `tests/test_wam_clojure_generator.pl` for:
  - emitted `call-foreign` stub for `category_ancestor/4`
  - `openTwoLevel` cache-policy wiring
  - max-depth propagation
  - debug stats hook presence
  - generated dispatch entry
- updated the Clojure LMDB design docs and perf log to mark
  `category_ancestor/4` as a supported target-level LMDB foreign
  relation

## Why

Before this change:

- the target-level LMDB foreign relation seam only covered
  `category_parent/2`
- `category_ancestor/4` was still effectively a benchmark-side pattern
  even though the underlying LMDB reader and traversal semantics already
  existed there

After this change:

- the target-level seam covers both the base parent relation and the
  recursive ancestor traversal relation
- generated non-benchmark Clojure WAM projects can opt into the same
  LMDB-backed traversal path directly

## Scope

This PR stays intentionally narrow:

- no new LMDB cache tiers
- no desktop benchmark measurement
- no attempt to generalize arbitrary LMDB-backed predicates

It only adds the next concrete relation contract:

- `category_ancestor/4`

## Verification

- `swipl -q -g "run_tests(wam_clojure_generator:clojure_lmdb_target_runtime_support_packages_helpers), run_tests(wam_clojure_generator:clojure_lmdb_target_reader_open_expr_policies), run_tests(wam_clojure_generator:clojure_lmdb_target_cache_log_snippet), run_tests(wam_clojure_generator:clojure_lmdb_target_foreign_relation_auto_handler), run_tests(wam_clojure_generator:clojure_lmdb_target_ancestor_foreign_relation_auto_handler)" -t halt tests/test_wam_clojure_generator.pl`
- `git diff --check`

## Notes

- the unrelated pre-existing
  `switch_on_constant_preserves_default_fallthrough` failure in the full
  Clojure generator suite is unchanged by this PR
- the next major step after this is desktop measurement of
  `none|memoize|shared|two_level` on the now-stable Clojure LMDB path
