### PR TITLE
feat(wam-haskell): functor/3 compose lowering + cabal e2e + Phase F log

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -727,3 +727,78 @@ repeated LMDB-backed benchmark generation was corrupting or racing on
 the shared Rust helper under `examples/lmdb_relation_artifact/target`.
 The benchmark generator now uses a workspace-local isolated Cargo target
 directory per SWI process instead of the shared repo `target/` path.
+
+---
+
+## Phase F: Mode-driven term-construction lowering (2026-04-27)
+
+**Branches:**
+- `docs/wam-haskell-mode-analysis-design` — three-doc design package
+- `feat/wam-haskell-mode-analysis` — analyser + `=../2` lowering (M1–M6)
+- `feat/wam-haskell-mode-analysis-followups` — `functor/3` lowering, M7
+  cabal end-to-end smoke, this log entry
+
+Added a forward, three-valued (`unbound`/`bound`/`unknown`)
+binding-state analysis pass at
+`src/unifyweaver/core/binding_state_analysis.pl`. The pass produces, per
+clause, a list of `goal_binding(Idx, BeforeEnv, AfterEnv)` records that
+the WAM compiler consults at the program point of each `=../2` and
+`functor/3` goal. When the analysis can prove the term is unbound and
+the functor name is bound, the compiler lowers the goal to a
+`PutStructureDyn` instruction sequence; otherwise it falls through to
+the existing `BuiltinCall` path.
+
+### What lowers and what does not
+
+| Goal shape | Mode declaration | Result |
+|---|---|---|
+| `T =.. [Name | FixedArgs]` | T proven `unbound`, Name proven `bound` | `PutStructureDyn` + `set_value`/`set_variable` × N + `get_value` |
+| `T =.. [...]` | T `unknown` (no mode decl) | `BuiltinCall "=../2"` |
+| `T =.. [...]` | T proven `bound` (decompose) | `BuiltinCall "=../2"` |
+| `functor(T, Name, Arity)` | T `unbound`, Name `bound`, Arity literal int | `PutStructureDyn` + `set_variable` × Arity + `get_value` |
+| `functor(T, Name, Arity)` | Arity is a runtime variable | `BuiltinCall "functor/3"` |
+| `functor(T, Name, Arity)` | no mode declaration | `BuiltinCall "functor/3"` |
+
+The `functor/3` lowering reuses `emit_put_structure_dyn_lowering/6`
+verbatim by synthesising N fresh anonymous Prolog variables and threading
+them through `compile_set_arguments/4`, which emits one
+`set_variable` per slot. No new emit helper.
+
+### Soundness contract
+
+The analysis is forward-only, no fixpoint, no aliasing tracking, and
+collapses to `unknown` at any control-flow meet where branches
+disagree. Every positive answer is a runtime guarantee; `unknown`
+keeps the existing path. Wrong analysis can only leave performance on
+the table — never produce incorrect runtime behaviour.
+
+### Why no benchmark numbers yet
+
+Both lowerings are correctness-preserving optimisations on a path that
+is rarely the hot loop in the benchmarks we currently measure
+(category-ancestor walks, etc.). The lowerings will pay off on
+workloads that construct many terms in tight loops — code-generation
+utilities, Prolog-meta interpreters, term-rewriting passes. We will
+benchmark when a real such workload exists. The unit tests
+(`tests/core/test_binding_state_analysis.pl`,
+`test_wam_univ_lowering.pl`, `test_wam_functor3_lowering.pl`) plus the
+M7 cabal end-to-end smoke
+(`test_wam_term_construction_e2e.pl`) cover correctness.
+
+### Out-of-scope follow-ups (analysis substrate is in place)
+
+- `arg/3` on a known-bound term: fuse to indexed `GetValue`.
+- `\+ member(X, L)` on a ground L: skip unification, use `IS.notMember`.
+- `copy_term/2` on a ground source: identity (no walk needed).
+- Multi-mode predicate specialisation: separate WAM bodies per mode.
+
+These would extend the analysis with new propagation-rule entries
+(`arg/3`, `\+/1`-special-cased on `member/2`) and add new
+`compile_goal_call/4` clauses, without touching the public API.
+
+### Related documents
+
+- `WAM_HASKELL_MODE_ANALYSIS_PHILOSOPHY.md` — the *why*
+- `WAM_HASKELL_MODE_ANALYSIS_SPEC.md` — data structures, propagation
+  rules, integration sites
+- `WAM_HASKELL_MODE_ANALYSIS_PLAN.md` — phases M1–M8 with test gates

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -686,16 +686,16 @@ compile_goals([Goal|Rest], V0, HasEnv, Vf, Code) :-
         )
     ;   Rest == []
     ->  % Last goal: execute (Tail Call Optimization)
-        (   %% Univ compose-mode lowering routes through compile_goal_execute
-            %% which dispatches to emit_put_structure_dyn_lowering when the
-            %% binding-state preconditions hold. We add the deallocate here
-            %% (HasEnv == yes case) so the resulting tail-call stays
-            %% TCO-correct.
-            Goal = (_ =.. _),
+        (   %% Term-construction builtins (=../2 and functor/3) compose-mode
+            %% lowering routes through compile_goal_execute which dispatches
+            %% to emit_put_structure_dyn_lowering when the binding-state
+            %% preconditions hold. We add the deallocate here (HasEnv == yes
+            %% case) so the resulting tail-call stays TCO-correct.
+            is_term_construction_goal(Goal),
             HasEnv == yes
         ->  compile_goal_execute(Goal, V0, Vf, ExecCode),
             format(string(Code), "    deallocate~n~w", [ExecCode])
-        ;   Goal = (_ =.. _)
+        ;   is_term_construction_goal(Goal)
         ->  compile_goal_execute(Goal, V0, Vf, Code)
         ;   HasEnv == yes
         ->  Goal =.. [Pred|Args],
@@ -965,6 +965,19 @@ compile_goal_call(T =.. L, V0, Vf, Code) :-
     binding_state_analysis:binding_state_at_var(BeforeEnv, NameVar, bound),
     !,
     emit_put_structure_dyn_lowering(T, NameVar, FixedArgs, V0, Vf, Code).
+%% functor/3 compose-mode lowering: functor(T, Name, Arity) where T is
+%% provably unbound, Name is provably bound, and Arity is a literal
+%% non-negative integer. Lowers to the same PutStructureDyn shape as
+%% the =../2 case by synthesising Arity fresh unbound argument slots.
+compile_goal_call(functor(T, NameVar, Arity), V0, Vf, Code) :-
+    integer(Arity), Arity >= 0,
+    var(T), var(NameVar),
+    current_clause_binding_env(BeforeEnv),
+    binding_state_analysis:binding_state_at_var(BeforeEnv, T, unbound),
+    binding_state_analysis:binding_state_at_var(BeforeEnv, NameVar, bound),
+    !,
+    length(FreshArgs, Arity),
+    emit_put_structure_dyn_lowering(T, NameVar, FreshArgs, V0, Vf, Code).
 compile_goal_call(Goal, V0, Vf, Code) :-
     Goal =.. [Pred|Args],
     length(Args, Arity),
@@ -991,6 +1004,19 @@ compile_goal_execute(T =.. L, V0, Vf, Code) :-
     binding_state_analysis:binding_state_at_var(BeforeEnv, NameVar, bound),
     !,
     emit_put_structure_dyn_lowering(T, NameVar, FixedArgs, V0, Vf, BodyCode),
+    format(string(Code), "~w~n    proceed", [BodyCode]).
+%% functor/3 compose-mode lowering, tail-call form. Same shape as the
+%% call form: synthesise Arity fresh unbound slots and reuse the =../2
+%% emit helper.
+compile_goal_execute(functor(T, NameVar, Arity), V0, Vf, Code) :-
+    integer(Arity), Arity >= 0,
+    var(T), var(NameVar),
+    current_clause_binding_env(BeforeEnv),
+    binding_state_analysis:binding_state_at_var(BeforeEnv, T, unbound),
+    binding_state_analysis:binding_state_at_var(BeforeEnv, NameVar, bound),
+    !,
+    length(FreshArgs, Arity),
+    emit_put_structure_dyn_lowering(T, NameVar, FreshArgs, V0, Vf, BodyCode),
     format(string(Code), "~w~n    proceed", [BodyCode]).
 compile_goal_execute(Goal, V0, Vf, Code) :-
     Goal =.. [Pred|Args],
@@ -1307,6 +1333,19 @@ advance_clause_goal_idx :-
     ->  Idx1 is Idx + 1,
         b_setval(wam_clause_goal_idx, Idx1)
     ;   true
+    ).
+
+%% is_term_construction_goal(+Goal)
+%
+%  True when Goal matches one of the term-construction builtins that
+%  compose-mode lowering recognises: `T =.. L` or `functor(T, N, A)`.
+%  Used by the TCO routing in compile_goals/5 to direct these goals
+%  through compile_goal_execute so the lowering's preconditions can
+%  be checked.
+is_term_construction_goal(Goal) :-
+    nonvar(Goal),
+    (   Goal = (_ =.. _)
+    ;   Goal = functor(_, _, _)
     ).
 
 %% parse_univ_list_pattern(+List, -NameVar, -FixedArgs)

--- a/tests/core/test_wam_functor3_lowering.pl
+++ b/tests/core/test_wam_functor3_lowering.pl
@@ -1,0 +1,216 @@
+:- encoding(utf8).
+%% Test suite for the functor/3 compose-mode lowering wired into wam_target.pl.
+%%
+%% Mirrors the =../2 lowering test pattern. Verifies:
+%%   * With a `:- mode/1` declaration that proves T unbound and Name
+%%     bound at the program point of functor(T, Name, Arity), and Arity
+%%     a literal non-negative integer, the generated WAM text contains
+%%     `put_structure_dyn`.
+%%   * Without a mode declaration (T's binding state is unknown), the
+%%     generator falls through to `builtin_call functor/3`.
+%%   * With a mode declaration that proves T bound (decompose), the
+%%     generator falls through to `builtin_call functor/3`.
+%%   * A non-integer or negative Arity skips the lowering even with
+%%     mode info.
+%%   * Arity controls how many `set_variable` instructions are emitted
+%%     (one per fresh slot in the constructed term).
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_wam_functor3_lowering.pl
+
+:- use_module('../../src/unifyweaver/targets/wam_target').
+:- use_module(library(lists)).
+
+%% ========================================================================
+%% Test runner
+%% ========================================================================
+
+run_tests :-
+    format("~n========================================~n"),
+    format("WAM functor/3 compose-mode lowering tests~n"),
+    format("========================================~n~n"),
+    findall(T, test(T), Tests),
+    length(Tests, Total),
+    run_all(Tests, 0, Passed),
+    format("~n========================================~n"),
+    (   Passed =:= Total
+    ->  format("All ~w tests passed~n", [Total])
+    ;   Failed is Total - Passed,
+        format("~w of ~w tests FAILED~n", [Failed, Total]),
+        format("Tests FAILED~n"),
+        halt(1)
+    ),
+    format("========================================~n").
+
+run_all([], P, P).
+run_all([T|Rest], Acc, P) :-
+    (   catch(call(T), E, (format("[FAIL] ~w: ~w~n", [T, E]), fail))
+    ->  Acc1 is Acc + 1, run_all(Rest, Acc1, P)
+    ;   run_all(Rest, Acc, P)
+    ).
+
+pass(N) :- format("[PASS] ~w~n", [N]).
+fail_test(N, R) :- format("[FAIL] ~w: ~w~n", [N, R]), fail.
+
+%% ========================================================================
+%% Test declarations
+%% ========================================================================
+
+test(test_functor3_compose_mode_emits_put_structure_dyn).
+test(test_functor3_no_mode_falls_through_to_builtin).
+test(test_functor3_decompose_mode_falls_through_to_builtin).
+test(test_functor3_arity_matches_set_variable_count).
+test(test_functor3_zero_arity_emits_no_set_variable).
+test(test_functor3_non_integer_arity_falls_through).
+
+%% Count occurrences of a substring (cheap, used to assert N copies of
+%% set_variable in the emitted WAM text).
+count_substr(Hay, Needle, N) :-
+    string_length(Needle, NeedleLen),
+    findall(P, sub_string(Hay, P, NeedleLen, _, Needle), Ps),
+    length(Ps, N).
+
+%% ========================================================================
+%% Tests
+%% ========================================================================
+
+test_functor3_compose_mode_emits_put_structure_dyn :-
+    Test = test_functor3_compose_mode_emits_put_structure_dyn,
+    retractall(user:make_pair(_, _)),
+    retractall(user:mode(make_pair(_, _))),
+    assert(user:mode(make_pair(+, -))),
+    assert(user:(make_pair(Name, T) :- functor(T, Name, 2))),
+    (   catch(
+            wam_target:compile_predicate_to_wam(make_pair/2, [], WamCode),
+            _, fail)
+    ->  atom_string(WamCode, S),
+        retractall(user:make_pair(_, _)),
+        retractall(user:mode(make_pair(_, _))),
+        (   sub_string(S, _, _, _, "put_structure_dyn")
+        ->  pass(Test)
+        ;   fail_test(Test, no_put_structure_dyn(S))
+        )
+    ;   retractall(user:make_pair(_, _)),
+        retractall(user:mode(make_pair(_, _))),
+        fail_test(Test, compile_failed)
+    ).
+
+test_functor3_no_mode_falls_through_to_builtin :-
+    Test = test_functor3_no_mode_falls_through_to_builtin,
+    retractall(user:make_pair_nomode(_, _)),
+    retractall(user:mode(make_pair_nomode(_, _))),
+    assert(user:(make_pair_nomode(Name, T) :- functor(T, Name, 2))),
+    (   catch(
+            wam_target:compile_predicate_to_wam(make_pair_nomode/2, [], WamCode),
+            _, fail)
+    ->  atom_string(WamCode, S),
+        retractall(user:make_pair_nomode(_, _)),
+        (   sub_string(S, _, _, _, "builtin_call functor/3"),
+            \+ sub_string(S, _, _, _, "put_structure_dyn")
+        ->  pass(Test)
+        ;   fail_test(Test, expected_builtin_path(S))
+        )
+    ;   retractall(user:make_pair_nomode(_, _)),
+        fail_test(Test, compile_failed)
+    ).
+
+test_functor3_decompose_mode_falls_through_to_builtin :-
+    Test = test_functor3_decompose_mode_falls_through_to_builtin,
+    retractall(user:split_pair(_, _, _)),
+    retractall(user:mode(split_pair(_, _, _))),
+    assert(user:mode(split_pair(+, -, -))),
+    assert(user:(split_pair(T, Name, Arity) :- functor(T, Name, Arity))),
+    (   catch(
+            wam_target:compile_predicate_to_wam(split_pair/3, [], WamCode),
+            _, fail)
+    ->  atom_string(WamCode, S),
+        retractall(user:split_pair(_, _, _)),
+        retractall(user:mode(split_pair(_, _, _))),
+        (   sub_string(S, _, _, _, "builtin_call functor/3"),
+            \+ sub_string(S, _, _, _, "put_structure_dyn")
+        ->  pass(Test)
+        ;   fail_test(Test, expected_builtin_path(S))
+        )
+    ;   retractall(user:split_pair(_, _, _)),
+        retractall(user:mode(split_pair(_, _, _))),
+        fail_test(Test, compile_failed)
+    ).
+
+test_functor3_arity_matches_set_variable_count :-
+    Test = test_functor3_arity_matches_set_variable_count,
+    %% Arity 3 should produce three set_variable instructions plus
+    %% put_constant 3, A2.
+    retractall(user:make_triple(_, _)),
+    retractall(user:mode(make_triple(_, _))),
+    assert(user:mode(make_triple(+, -))),
+    assert(user:(make_triple(Name, T) :- functor(T, Name, 3))),
+    (   catch(
+            wam_target:compile_predicate_to_wam(make_triple/2, [], WamCode),
+            _, fail)
+    ->  atom_string(WamCode, S),
+        retractall(user:make_triple(_, _)),
+        retractall(user:mode(make_triple(_, _))),
+        count_substr(S, "set_variable", N),
+        (   sub_string(S, _, _, _, "put_structure_dyn"),
+            sub_string(S, _, _, _, "put_constant 3, A2"),
+            N >= 3
+        ->  pass(Test)
+        ;   fail_test(Test, missing_arity_or_set_variables(S, N))
+        )
+    ;   retractall(user:make_triple(_, _)),
+        retractall(user:mode(make_triple(_, _))),
+        fail_test(Test, compile_failed)
+    ).
+
+test_functor3_zero_arity_emits_no_set_variable :-
+    Test = test_functor3_zero_arity_emits_no_set_variable,
+    %% Arity 0 — fresh atom-as-functor. put_structure_dyn fires with
+    %% put_constant 0, A2 and no set_variable instructions for the
+    %% structure body.
+    retractall(user:make_atom(_, _)),
+    retractall(user:mode(make_atom(_, _))),
+    assert(user:mode(make_atom(+, -))),
+    assert(user:(make_atom(Name, T) :- functor(T, Name, 0))),
+    (   catch(
+            wam_target:compile_predicate_to_wam(make_atom/2, [], WamCode),
+            _, fail)
+    ->  atom_string(WamCode, S),
+        retractall(user:make_atom(_, _)),
+        retractall(user:mode(make_atom(_, _))),
+        (   sub_string(S, _, _, _, "put_structure_dyn"),
+            sub_string(S, _, _, _, "put_constant 0, A2")
+        ->  pass(Test)
+        ;   fail_test(Test, missing_zero_arity_dyn(S))
+        )
+    ;   retractall(user:make_atom(_, _)),
+        retractall(user:mode(make_atom(_, _))),
+        fail_test(Test, compile_failed)
+    ).
+
+test_functor3_non_integer_arity_falls_through :-
+    Test = test_functor3_non_integer_arity_falls_through,
+    %% Arity is a runtime variable, not a literal integer. Even with a
+    %% mode declaration that proves T unbound and Name bound, the
+    %% lowering must not fire — we cannot know how many set_variable
+    %% slots to emit at compile time.
+    retractall(user:make_dyn(_, _, _)),
+    retractall(user:mode(make_dyn(_, _, _))),
+    assert(user:mode(make_dyn(+, +, -))),
+    assert(user:(make_dyn(Name, Arity, T) :- functor(T, Name, Arity))),
+    (   catch(
+            wam_target:compile_predicate_to_wam(make_dyn/3, [], WamCode),
+            _, fail)
+    ->  atom_string(WamCode, S),
+        retractall(user:make_dyn(_, _, _)),
+        retractall(user:mode(make_dyn(_, _, _))),
+        (   sub_string(S, _, _, _, "builtin_call functor/3"),
+            \+ sub_string(S, _, _, _, "put_structure_dyn")
+        ->  pass(Test)
+        ;   fail_test(Test, dynamic_arity_must_not_lower(S))
+        )
+    ;   retractall(user:make_dyn(_, _, _)),
+        retractall(user:mode(make_dyn(_, _, _))),
+        fail_test(Test, compile_failed)
+    ).
+
+:- initialization(run_tests, main).

--- a/tests/core/test_wam_term_construction_e2e.pl
+++ b/tests/core/test_wam_term_construction_e2e.pl
@@ -1,0 +1,287 @@
+:- encoding(utf8).
+%% Phase M7 of the mode-analysis plan: full Haskell-cabal end-to-end
+%% smoke for the term-construction lowerings (=../2 and functor/3).
+%%
+%% What this test validates that the codegen unit tests do not:
+%%
+%%   1. write_wam_haskell_project/3 produces a real project on disk
+%%      whose generated Predicates.hs contains `PutStructureDyn` for
+%%      mode-annotated compose-mode predicates, AND `BuiltinCall
+%%      "=../2"` (resp. `BuiltinCall "functor/3"`) for unannotated
+%%      ones in the same project.
+%%   2. The full project (Main.hs + Predicates.hs + Lowered.hs +
+%%      WamTypes.hs + WamRuntime.hs) compiles end-to-end with cabal.
+%%      A successful build proves wam_instr_to_haskell/2's
+%%      put_structure_dyn → PutStructureDyn translation produces
+%%      well-typed Haskell when emitted from a real Prolog source.
+%%
+%% Skip behaviour:
+%%   If `cabal --version` or `ghc --version` fail, OR if cabal cannot
+%%   resolve the project's dependencies (no Hackage access, etc.),
+%%   the test prints a diagnostic and skips. Codegen unit tests in
+%%   test_wam_univ_lowering.pl and test_wam_functor3_lowering.pl
+%%   still cover the WAM-text level.
+%%
+%% Honours WAM_TERM_E2E_KEEP=1 to retain the build dir.
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_wam_term_construction_e2e.pl
+
+:- use_module('../../src/unifyweaver/targets/wam_target').
+:- use_module('../../src/unifyweaver/targets/wam_haskell_target').
+:- use_module(library(filesex), [directory_file_path/3, make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module(library(readutil)).
+
+:- dynamic test_failed/0.
+:- dynamic test_skipped/0.
+
+pass(Test) :-
+    format('[PASS] ~w~n', [Test]).
+
+skip(Test, Reason) :-
+    format('[SKIP] ~w: ~w~n', [Test, Reason]),
+    (   test_skipped -> true ; assert(test_skipped) ).
+
+fail_test(Test, Reason) :-
+    format('[FAIL] ~w: ~w~n', [Test, Reason]),
+    (   test_failed -> true ; assert(test_failed) ).
+
+%% ========================================================================
+%% Toolchain detection
+%% ========================================================================
+
+tool_runs(Path, Args) :-
+    catch(
+        (   process_create(path(Path), Args,
+                [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0))
+        ),
+        _, fail).
+
+ghc_available :- tool_runs(ghc,   ['--version']).
+cabal_available :- tool_runs(cabal, ['--version']).
+
+%% ========================================================================
+%% Paths
+%% ========================================================================
+
+tmp_root(Root) :-
+    (   getenv('TMPDIR', R0), R0 \== ''
+    ->  Root = R0
+    ;   Root = '/tmp'
+    ).
+
+build_dir(Dir) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_term_construction_e2e', Dir).
+
+%% ========================================================================
+%% Fixture
+%% ========================================================================
+%%
+%% Four predicates exercising both lowerings and both fall-through paths:
+%%
+%%   build_term_compose/3 (=../2, mode +,?,-)  → expect PutStructureDyn
+%%   build_term_nomode/3 (=../2, no mode)      → expect BuiltinCall "=../2"
+%%   make_pair_compose/2 (functor/3, mode +,-) → expect PutStructureDyn
+%%   make_pair_nomode/2  (functor/3, no mode)  → expect BuiltinCall "functor/3"
+
+:- dynamic user:build_term_compose/3.
+:- dynamic user:build_term_nomode/3.
+:- dynamic user:make_pair_compose/2.
+:- dynamic user:make_pair_nomode/2.
+:- dynamic user:mode/1.
+
+setup_fixture :-
+    retractall(user:build_term_compose(_,_,_)),
+    retractall(user:build_term_nomode(_,_,_)),
+    retractall(user:make_pair_compose(_,_)),
+    retractall(user:make_pair_nomode(_,_)),
+    retractall(user:mode(build_term_compose(_,_,_))),
+    retractall(user:mode(make_pair_compose(_,_))),
+    assert(user:mode(build_term_compose(+, ?, -))),
+    assert(user:mode(make_pair_compose(+, -))),
+    assert(user:(build_term_compose(Name, Arg, T) :-
+        T =.. [Name, Arg])),
+    assert(user:(build_term_nomode(Name, Arg, T) :-
+        T =.. [Name, Arg])),
+    assert(user:(make_pair_compose(Name, T) :-
+        functor(T, Name, 2))),
+    assert(user:(make_pair_nomode(Name, T) :-
+        functor(T, Name, 2))).
+
+teardown_fixture :-
+    retractall(user:build_term_compose(_,_,_)),
+    retractall(user:build_term_nomode(_,_,_)),
+    retractall(user:make_pair_compose(_,_)),
+    retractall(user:make_pair_nomode(_,_)),
+    retractall(user:mode(build_term_compose(_,_,_))),
+    retractall(user:mode(make_pair_compose(_,_))).
+
+ensure_dir(D) :-
+    (   exists_directory(D) -> true ; make_directory_path(D) ).
+
+generate_project(Dir) :-
+    ensure_dir(Dir),
+    setup_fixture,
+    catch(
+        write_wam_haskell_project(
+            [user:build_term_compose/3,
+             user:build_term_nomode/3,
+             user:make_pair_compose/2,
+             user:make_pair_nomode/2],
+            [module_name('uw-term-construction-e2e'), use_hashmap(false)],
+            Dir),
+        E,
+        (teardown_fixture, throw(E))),
+    teardown_fixture.
+
+%% ========================================================================
+%% Cabal build
+%% ========================================================================
+
+run_cabal(Args, Dir, ExitCode, Output) :-
+    catch(
+        setup_call_cleanup(
+            process_create(path(cabal), Args,
+                [cwd(Dir),
+                 stdout(pipe(Out)),
+                 stderr(pipe(Err)),
+                 process(Pid)]),
+            (   read_string(Out, _, OutStr),
+                read_string(Err, _, ErrStr),
+                process_wait(Pid, exit(ExitCode)),
+                format(string(Output), "~w~n~w", [OutStr, ErrStr])
+            ),
+            (catch(close(Out), _, true), catch(close(Err), _, true))
+        ),
+        Err,
+        (ExitCode = -1, format(string(Output), "~w", [Err]))).
+
+cabal_dependency_problem(BuildOut) :-
+    sub_string(BuildOut, _, _, _, "Could not"),
+    (   sub_string(BuildOut, _, _, _, "parallel")
+    ;   sub_string(BuildOut, _, _, _, "async")
+    ;   sub_string(BuildOut, _, _, _, "containers")
+    ;   sub_string(BuildOut, _, _, _, "Hackage")
+    ).
+
+%% ========================================================================
+%% Predicates.hs grep
+%% ========================================================================
+
+predicates_hs_path(Dir, Path) :-
+    directory_file_path(Dir, 'src/Predicates.hs', Path).
+
+read_predicates_hs(Dir, Content) :-
+    predicates_hs_path(Dir, Path),
+    read_file_to_string(Path, Content, []).
+
+%% Count occurrences of a needle substring in a haystack.
+count_substr(Hay, Needle, N) :-
+    string_length(Needle, NeedleLen),
+    findall(P, sub_string(Hay, P, NeedleLen, _, Needle), Ps),
+    length(Ps, N).
+
+%% ========================================================================
+%% Tests
+%% ========================================================================
+
+test_full_pipeline :-
+    Test = 'WAM term construction: full project compiles via cabal',
+    (   \+ ghc_available
+    ->  skip(Test, 'ghc not on PATH')
+    ;   \+ cabal_available
+    ->  skip(Test, 'cabal not on PATH')
+    ;   build_dir(Dir),
+        catch(cleanup_build_dir(Dir), _, true),
+        catch(generate_project(Dir), GE,
+              (fail_test(Test, generate_project_failed(GE)), !, fail)),
+        format('[INFO] cabal v2-build full project at ~w~n', [Dir]),
+        run_cabal(['v2-build', 'all'], Dir, BuildEC, BuildOut),
+        (   BuildEC \== 0
+        ->  (   cabal_dependency_problem(BuildOut)
+            ->  skip(Test, 'cabal cannot resolve dependencies (no Hackage access)')
+            ;   fail_test(Test, cabal_build_failed(BuildEC)),
+                format('--- cabal output ---~n~w~n--- end ---~n', [BuildOut])
+            )
+        ;   pass(Test)
+        ),
+        keep_or_clean(Dir)
+    ).
+
+test_compose_lowerings_in_predicates_hs :-
+    Test = 'WAM term construction: PutStructureDyn count and fallthrough builtins',
+    build_dir(Dir),
+    (   exists_directory(Dir)
+    ->  true
+    ;   skip(Test, 'project dir missing (full pipeline test must run first)'),
+        !, fail
+    ),
+    catch(read_predicates_hs(Dir, Hs), RE,
+          (fail_test(Test, read_predicates_hs_failed(RE)), !, fail)),
+    %% allCode is one merged instruction list per project. Two compose
+    %% predicates ⇒ two PutStructureDyn occurrences. Two non-mode
+    %% predicates ⇒ exactly one BuiltinCall "=../2" and one BuiltinCall
+    %% "functor/3" each.
+    count_substr(Hs, "PutStructureDyn", DynCount),
+    count_substr(Hs, "BuiltinCall \"=../2\"", UnivBuiltinCount),
+    count_substr(Hs, "BuiltinCall \"functor/3\"", FunctorBuiltinCount),
+    (   DynCount =:= 2,
+        UnivBuiltinCount =:= 1,
+        FunctorBuiltinCount =:= 1
+    ->  pass(Test)
+    ;   fail_test(Test,
+            counts(put_structure_dyn=DynCount,
+                   builtin_univ=UnivBuiltinCount,
+                   builtin_functor=FunctorBuiltinCount)),
+        format('--- Predicates.hs head ---~n', []),
+        sub_string(Hs, 0, 2048, _, Head),
+        format('~w~n--- end ---~n', [Head])
+    ).
+
+%% ========================================================================
+%% Cleanup
+%% ========================================================================
+
+keep_or_clean(Dir) :-
+    (   getenv('WAM_TERM_E2E_KEEP', V), V \== ''
+    ->  format('[INFO] keeping build dir ~w (WAM_TERM_E2E_KEEP set)~n', [Dir])
+    ;   true   % leave for the second test to read; cleanup at the end
+    ).
+
+cleanup_build_dir(Dir) :-
+    (   exists_directory(Dir)
+    ->  process_create(path(rm), ['-rf', Dir], [process(Pid)]),
+        process_wait(Pid, _)
+    ;   true
+    ).
+
+%% ========================================================================
+%% Runner
+%% ========================================================================
+
+run_tests :-
+    format('~n========================================~n'),
+    format('WAM term construction full E2E (=../2 + functor/3)~n'),
+    format('========================================~n~n'),
+    test_full_pipeline,
+    test_compose_lowerings_in_predicates_hs,
+    cleanup_at_end,
+    format('~n========================================~n'),
+    (   test_failed
+    ->  format('Some tests FAILED~n'), halt(1)
+    ;   test_skipped
+    ->  format('Tests skipped (toolchain unavailable). Codegen coverage in test_wam_univ_lowering.pl + test_wam_functor3_lowering.pl is unaffected.~n'), halt(0)
+    ;   format('All tests passed~n'), halt(0)
+    ).
+
+cleanup_at_end :-
+    build_dir(Dir),
+    (   getenv('WAM_TERM_E2E_KEEP', V), V \== ''
+    ->  format('[INFO] keeping build dir ~w (WAM_TERM_E2E_KEEP set)~n', [Dir])
+    ;   catch(cleanup_build_dir(Dir), _, true)
+    ).
+
+:- initialization(run_tests, main).


### PR DESCRIPTION
  ## Summary

  Three follow-ups to PR #1665 (mode analysis + `=../2` lowering), reusing the binding-state analyser substrate that PR
  put in place.

  - **`functor/3` compose-mode lowering.** Mirrors the `=../2` shape: when the analysis proves `T` unbound, `Name`
  bound, and `Arity` is a literal non-negative integer, lower to `PutStructureDyn` + `set_variable` × Arity +
  `get_value`. Reuses the existing `emit_put_structure_dyn_lowering/6` helper by synthesising N fresh anonymous Prolog
  variables — no new emit code.
  - **M7 cabal end-to-end smoke** — closes the gap PR #1665 explicitly left as a follow-up. Generates a project with
  both lowerings and both fall-through paths, runs `cabal v2-build all`, and asserts `Predicates.hs` contains exactly
  the right counts of `PutStructureDyn` / `BuiltinCall "=../2"` / `BuiltinCall "functor/3"`.
  - **M8 docs** — Phase F entry in `WAM_PERF_OPTIMIZATION_LOG.md` summarising the arc.

  ## What now lowers vs. falls through

  | Goal | Precondition | Result |
  |---|---|---|
  | `T =.. [Name \| FixedArgs]` | T `unbound`, Name `bound` | `PutStructureDyn` |
  | `T =.. [Name \| FixedArgs]` | T `unknown` or `bound`, or list shape too dynamic | `BuiltinCall "=../2"` |
  | `functor(T, Name, Arity)` | T `unbound`, Name `bound`, Arity literal int | `PutStructureDyn` (new in this PR) |
  | `functor(T, Name, Arity)` | Arity is a runtime variable | `BuiltinCall "functor/3"` |
  | `functor(T, Name, Arity)` | no mode declaration | `BuiltinCall "functor/3"` |

  Soundness preserved by construction: positive analysis answers are runtime guarantees; `unknown` always falls through.
   Wrong analysis can only leave performance on the table — never produce incorrect runtime behaviour.

  ## Why `functor/3` arity must be a literal integer

  `PutStructureDyn` pre-allocates a `BuildStruct` builder of a specific arity at the WAM level; subsequent `set_value` /
   `set_variable` instructions fill it. We must therefore know the arity at *compile* time to emit the right number of
  `set_variable`s. A runtime-variable arity has no static count, so even when T and Name are mode-proven, the lowering
  does not fire — the goal falls through to the `BuiltinCall` path. The `test_functor3_non_integer_arity_falls_through`
  test asserts this.

  ## Changes

  ### `src/unifyweaver/targets/wam_target.pl` (~30 LOC)

  - New `compile_goal_call/4` clause for `functor(T, NameVar, Arity)` with the precondition checks and call to
  `emit_put_structure_dyn_lowering/6` after `length(FreshArgs, Arity)`.
  - Matching `compile_goal_execute/4` clause for tail-call form.
  - New `is_term_construction_goal/1` helper used by the TCO routing block in `compile_goals/5`. The previous `Goal = (_
   =.. _)` carve-out becomes `is_term_construction_goal(Goal)` — admits both shapes.

  ### `tests/core/test_wam_functor3_lowering.pl` (NEW, 208 LOC, 6 tests)

  Mirrors the structure of `test_wam_univ_lowering.pl`. Covers:
  - `test_functor3_compose_mode_emits_put_structure_dyn`
  - `test_functor3_no_mode_falls_through_to_builtin`
  - `test_functor3_decompose_mode_falls_through_to_builtin`
  - `test_functor3_arity_matches_set_variable_count`
  - `test_functor3_zero_arity_emits_no_set_variable`
  - `test_functor3_non_integer_arity_falls_through`

  ### `tests/core/test_wam_term_construction_e2e.pl` (NEW, 220 LOC, 2 tests, M7)

  Phase M7 of the original mode-analysis plan. The existing `test_wam_put_structure_dyn_ghc_smoke.pl` exercises only the
   runtime `step` function (with a custom `Smoke.hs` and a stripped cabal file that doesn't compile `Predicates.hs` /
  `Main.hs`). This new test closes that gap: it generates a real project, builds the **whole** thing with `cabal
  v2-build`, and asserts the lowering reaches `Predicates.hs`.

  The two tests:
  - `test_full_pipeline` — `cabal v2-build all` succeeds. Skips cleanly if cabal/ghc/Hackage are unavailable.
  - `test_compose_lowerings_in_predicates_hs` — `Predicates.hs` contains exactly 2 × `PutStructureDyn`, 1 × `BuiltinCall
   "=../2"`, 1 × `BuiltinCall "functor/3"`. Reads the file directly instead of trying to slice per-predicate (the
  merged-instruction list isn't keyed by name).

  `WAM_TERM_E2E_KEEP=1` retains the build dir for post-mortem.

  ### `docs/design/WAM_PERF_OPTIMIZATION_LOG.md`

  Appended Phase F entry covering: branches involved, the lowering precondition table, the soundness contract, why no
  benchmark numbers yet (correctness optimisation on a path our current benchmarks don't exercise), and the out-of-scope
   follow-ups (`arg/3`, `\+ member`, `copy_term/2`).

  ## Verification

  All five test surfaces green locally:

  | Suite | Result |
  |---|---|
  | `tests/test_wam_haskell_target.pl` | full existing suite passes |
  | `tests/core/test_binding_state_analysis.pl` | 31/31 |
  | `tests/core/test_wam_univ_lowering.pl` | 5/5 |
  | `tests/core/test_wam_functor3_lowering.pl` | 6/6 (new) |
  | `tests/core/test_wam_term_construction_e2e.pl` | 2/2 (new, M7) |

  The cabal e2e test builds a real project end-to-end with GHC 8.6.5 and confirms the lowered `PutStructureDyn`
  instructions appear in the generated `Predicates.hs` exactly the expected number of times.

  ## Test plan

  - [ ] CI: all five suites above pass.
  - [ ] Spot-check: a real Prolog program using `:- mode foo(+, -). foo(X, T) :- T =.. [X, 1, 2].` generates a project
  where `Predicates.hs` has `PutStructureDyn` and the cabal binary builds.

  ## Refs

  - PR #1664 — design docs (`WAM_HASKELL_MODE_ANALYSIS_*.md`).
  - PR #1665 — analyser + `=../2` lowering (M1–M6).
  - Task #16 — Add PutStructureDyn for runtime-parsed functors.
  - Task #185 — PutStructureDyn end-to-end + WAM compiler lowering.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)