### PR TITLE
docs(wam-scala): add hybrid WAM design

### DIFF
--- a/docs/proposals/WAM_SCALA_HYBRID_IMPL_PLAN.md
+++ b/docs/proposals/WAM_SCALA_HYBRID_IMPL_PLAN.md
@@ -1,0 +1,367 @@
+# WAM Scala Hybrid Implementation Plan
+
+## Purpose
+
+This document breaks the Scala hybrid WAM target into staged
+implementation phases.
+
+It assumes the philosophy and specification docs are accepted.
+
+The plan is optimized for:
+
+- incremental correctness
+- reuse of existing hybrid-WAM lessons
+- minimizing speculative implementation
+
+## Overview
+
+The Scala hybrid WAM target should be implemented in nine phases:
+
+1. target scaffold
+2. runtime baseline
+3. core instruction execution
+4. backtracking and choice points
+5. foreign predicate integration
+6. streamed foreign solutions
+7. artifact/fact backend seam
+8. LMDB/JVM seam integration
+9. benchmark integration and measurement prep
+
+## Phase S1: Target Scaffold
+
+### Goal
+
+Create the minimum Scala hybrid WAM target structure without full
+runtime semantics.
+
+### Deliverables
+
+- `src/unifyweaver/targets/wam_scala_target.pl`
+- `templates/targets/scala_wam/`
+- generator for:
+  - `build.sbt`
+  - runtime source
+  - generated program source
+
+### Tests
+
+- generator test proves file layout exists
+- emitted Scala compiles structurally if the toolchain is present
+
+### Notes
+
+Do not pull in LMDB, foreign streaming, or cache logic yet.
+
+## Phase S2: Runtime Baseline
+
+### Goal
+
+Introduce immutable program context and mutable execution state.
+
+### Deliverables
+
+- `WamProgram`
+- `WamState`
+- baseline term model
+- instruction ADT
+
+### Tests
+
+- runtime smoke tests for project creation
+- generated code contains shared instruction table and predicate wrappers
+
+### Design constraint
+
+At this phase, choose mutability deliberately:
+
+- immutable compiled context
+- mutable per-run state
+
+Do not mirror Haskell’s “mostly immutable except cache” runtime shape.
+
+## Phase S3: Core Instruction Execution
+
+### Goal
+
+Execute a basic subset of WAM instructions correctly.
+
+### Minimum instruction set
+
+- `call`
+- `execute`
+- `proceed`
+- `jump`
+- `allocate`
+- `deallocate`
+- `get_*`
+- `put_*`
+- `set_*`
+- `unify_*`
+
+### Tests
+
+- direct fact lookup
+- simple caller predicates
+- structure/list round-trips
+- basic arithmetic/builtin calls where already standardized
+
+## Phase S4: Choice Points and Backtracking
+
+### Goal
+
+Add full ordinary WAM backtracking behavior.
+
+### Minimum instruction set
+
+- `try-me-else`
+- `retry-me-else`
+- `trust-me`
+- `switch-on-constant`
+- cut-related behavior
+
+### Tests
+
+- multi-clause predicates
+- failure fallback
+- default-fallthrough in `switch-on-constant`
+- cut / if-then-else coverage
+
+### Warning
+
+This phase should not be postponed. A hybrid WAM target without robust
+backtracking is not “baseline complete”.
+
+## Phase S5: Foreign Predicate Integration
+
+### Goal
+
+Support target-level `call-foreign` for boolean and deterministic
+binding-returning handlers.
+
+### Deliverables
+
+- foreign handler registry
+- wrapper generation for foreign predicates
+- runtime application of binding maps
+
+### Tests
+
+- foreign success/failure
+- foreign output binding
+- mixed WAM/foreign calls
+
+## Phase S6: Streamed Foreign Solutions
+
+### Goal
+
+Support streamed multi-solution foreign predicates with backtracking.
+
+### Deliverables
+
+- `ForeignSolutions` protocol
+- foreign choice-point snapshots
+- restoration logic on failure
+
+### Tests
+
+- two-solution foreign stream
+- first-solution failure then backtrack to second
+- cut interactions
+
+### Reference
+
+Use the Clojure hybrid WAM streamed foreign semantics as the reference
+behavior, not necessarily the same representation.
+
+## Phase S7: Fact Backend Seam
+
+### Goal
+
+Introduce a target-level fact backend abstraction without tying the
+runtime to one storage technology.
+
+### Deliverables
+
+- `FactSource`-like interface
+- inline and sidecar implementations
+- declaration/manifest hooks
+
+### Tests
+
+- same relation through inline vs sidecar backend
+- identical predicate answers
+
+### Constraint
+
+This layer must remain separate from cache policy.
+
+## Phase S8: LMDB/JVM Seam Integration
+
+### Goal
+
+Consume the shared JVM LMDB seam from Scala rather than inventing a
+separate JNI integration.
+
+### Deliverables
+
+- packaging of helper jar and `.so`
+- Scala adapter over `LmdbArtifactReader`
+- one relation contract proven end to end
+
+### Initial relation
+
+Start with:
+
+- `category_parent/2`
+
+Later:
+
+- `category_ancestor/4`
+
+### Tests
+
+- generated project packages helper artifacts
+- LMDB-backed lookup path works
+- stats can be queried
+
+### Constraint
+
+Do not implement a Scala-specific native LMDB seam first.
+
+## Phase S9: Benchmark Integration and Measurement Prep
+
+### Goal
+
+Make the Scala hybrid WAM target benchmarkable without burying runtime
+decisions in benchmark-only code.
+
+### Deliverables
+
+- benchmark generator for Scala hybrid WAM
+- target-level option plumbing for backend/cache choices
+- machine-readable stats output
+
+### Tests
+
+- generated benchmark project shape
+- correctness parity with existing targets on small scale
+
+### Important boundary
+
+This phase prepares measurement. It does not decide policy defaults.
+
+## Cross-Phase Reuse Strategy
+
+### Reuse from Clojure
+
+Reuse conceptually:
+
+- hybrid WAM project shape
+- instruction-table + wrapper generation
+- foreign predicate semantics
+- JVM LMDB helper seam
+
+Do not copy directly:
+
+- Clojure map/vector runtime representation
+- Clojure-specific dynamic state transitions
+
+### Reuse from Haskell
+
+Reuse conceptually:
+
+- artifact/fact layering
+- separation of raw reader from cache policy
+- staged LMDB progression
+
+Do not copy directly:
+
+- Haskell’s immutability boundary for hot-path runtime state
+
+### Reuse from Rust
+
+Reuse conceptually:
+
+- willingness to optimize mutable execution state
+- explicit runtime structures
+- directness in hot paths
+
+## Suggested File Plan
+
+### Prolog
+
+- `src/unifyweaver/targets/wam_scala_target.pl`
+- optional helper extraction modules later if the target grows
+
+### Templates
+
+- `templates/targets/scala_wam/build.sbt.mustache`
+- `templates/targets/scala_wam/runtime.scala.mustache`
+- `templates/targets/scala_wam/program.scala.mustache`
+
+### Tests
+
+- `tests/test_wam_scala_generator.pl`
+- `tests/test_wam_scala_runtime_smoke.pl`
+- benchmark-specific tests later
+
+## Risks
+
+### Risk 1: Over-copying Clojure
+
+If the Scala target copies the Clojure runtime representation too
+closely, it will inherit dynamic-runtime costs without gaining Clojure’s
+simplicity benefits.
+
+Mitigation:
+
+- keep Scala mutable in hot-path state
+- use types and arrays where they help
+
+### Risk 2: Over-engineering early
+
+If the initial runtime tries to solve generic backend abstraction,
+parallelism, and benchmarking all at once, the target will stall.
+
+Mitigation:
+
+- phase strictly
+- prove one layer at a time
+
+### Risk 3: Scala-specific JNI duplication
+
+If Scala invents a second LMDB/JNI stack, the JVM-family targets will
+diverge unnecessarily.
+
+Mitigation:
+
+- require reuse of the shared JVM LMDB seam
+
+## Exit Criteria by Milestone
+
+### Milestone A: baseline hybrid WAM
+
+Complete when phases S1-S4 are done.
+
+### Milestone B: foreign-capable hybrid WAM
+
+Complete when phases S5-S6 are done.
+
+### Milestone C: artifact-aware hybrid WAM
+
+Complete when phases S7-S8 are done.
+
+### Milestone D: benchmarkable hybrid WAM
+
+Complete when phase S9 is done.
+
+## Recommended Immediate Start
+
+The first implementation PR after these docs should do only:
+
+1. `wam_scala_target.pl`
+2. template scaffold
+3. generator tests
+
+That is enough to establish the target’s shape without prematurely
+committing to runtime internals in code.

--- a/docs/proposals/WAM_SCALA_HYBRID_PHILOSOPHY.md
+++ b/docs/proposals/WAM_SCALA_HYBRID_PHILOSOPHY.md
@@ -1,0 +1,418 @@
+# WAM Scala Hybrid Philosophy
+
+## Purpose
+
+This document defines the architectural philosophy for a future hybrid
+WAM Scala target.
+
+It is intentionally design-heavy. The expected implementation flow is:
+
+1. settle the architecture here
+2. use the specification and implementation plan to constrain later code
+3. let faster implementation agents execute against a stable design
+
+The Scala hybrid WAM target should not be treated as “Clojure, but in
+Scala syntax.” It should reuse the same successful abstractions where
+that helps, but it should also exploit the fact that Scala gives us a
+different part of the JVM design space:
+
+- stronger static typing
+- better control over data representation
+- both functional and imperative runtime styles
+- easier packaging of reusable JVM helper layers
+
+## Why Scala Is Worth a Hybrid WAM Target
+
+Scala is useful here for three reasons:
+
+1. it is already a supported non-WAM target in the codebase
+2. it sits on the same JVM family as the newer Clojure LMDB/JNI work
+3. it can express high-level generated code while still hosting a
+   low-level runtime with explicit arrays, stacks, and caches
+
+That mix makes Scala a good candidate for a hybrid WAM target that is:
+
+- more statically constrained than Clojure
+- less FFI-hostile than a pure scripting target
+- easier to evolve into a library-grade runtime than a benchmark-only
+  code generator
+
+## Core Position
+
+### 1. Share the architecture, not the syntax
+
+The Scala hybrid WAM target should share the **architectural layers**
+already proven in Clojure, Haskell, and Rust:
+
+1. generated program surface
+2. immutable compiled code/context
+3. per-query execution state
+4. foreign predicate seam
+5. external fact/materialization seam
+6. optional cache/policy layers
+
+But it should not share implementation style mechanically.
+
+For example:
+
+- Clojure uses maps/vectors and a dynamic runtime core
+- Haskell leans hard on immutable structures and pure wrappers
+- Scala can deliberately choose mutable arrays and mutable stacks in the
+  hot path while keeping compiled code/context immutable
+
+### 2. Scala does not need Haskell’s mutability boundary
+
+This is the most important design choice.
+
+Haskell kept almost all state immutable except cache layers because that
+was the right tradeoff for Haskell’s semantics and optimizer story.
+Scala does **not** need to follow that boundary.
+
+For Scala, the better split is:
+
+- immutable `WamProgram` / `WamContext`
+- mutable per-run `WamState`
+- mutable hot-path structures inside `WamState`
+- optional caches outside or beside `WamState`, depending on sharing
+  requirements
+
+That means Scala should be comfortable with:
+
+- `Array[AnyRef]` registers
+- mutable choice-point stacks
+- mutable trail buffers
+- imperative program-counter stepping
+- specialized value representations where useful
+
+The philosophical rule is:
+
+> Keep shared compiled context immutable. Keep per-query execution state
+> cheap and mutable.
+
+This is closer to the existing Rust/C#/Go performance posture than to
+the Haskell posture.
+
+### 3. Reuse the JVM LMDB seam rather than inventing a second one
+
+The recent Clojure work already produced a usable JVM LMDB seam:
+
+- manifest-backed artifact contract
+- JNI bridge over native LMDB
+- row-oriented JVM API
+- target-local packaging conventions
+
+Scala should consume that seam, not replace it.
+
+That does **not** mean Scala should depend on Clojure-specific code.
+It means Scala should depend on the same JVM helper layer that Clojure
+already proved:
+
+- `LmdbArtifactReader`
+- `LmdbRow`
+- cache-policy wrappers
+- JNI `liblmdb_artifact_jni.so`
+
+The philosophy here is:
+
+- one JVM LMDB substrate
+- multiple JVM-family targets using it
+- target-specific adapters on top
+
+### 4. Generated Scala should remain inspectable
+
+The generated Scala project should be understandable by a human reading
+the emitted files.
+
+That argues for:
+
+- a small set of runtime classes
+- generated instruction tables as ordinary Scala values
+- explicit wrapper methods per predicate
+- minimal macro or metaprogramming magic
+
+The target should prefer explicit generated code over “clever” code
+generation that is difficult to debug.
+
+### 5. Separate mechanism from policy
+
+This lesson has repeated across targets.
+
+The Scala design must keep these separate:
+
+- how to read facts
+- whether to cache
+- how to choose a backend
+- how to report stats
+
+The target must not hard-code “LMDB implies cache mode X” or “artifact
+implies representation Y”.
+
+Instead:
+
+- the runtime supports several policies
+- the generated project chooses one
+- measurement determines the default
+
+## Architectural Layers
+
+The Scala hybrid WAM target should be built around six layers.
+
+### Layer A: Generated wrappers
+
+Generated wrapper methods are the public predicate entry points.
+
+Example:
+
+```scala
+def categoryAncestor(a1: WamTerm, a2: WamTerm, a3: WamTerm, a4: WamTerm): Boolean =
+  runtime.runPredicate(sharedCode, sharedLabels, categoryAncestorStartPc, Array(a1, a2, a3, a4), foreignHandlers)
+```
+
+These wrappers should stay thin. They are not where optimization logic
+belongs.
+
+### Layer B: Immutable program context
+
+This layer contains everything that can be shared safely across runs:
+
+- resolved instruction table
+- label index map
+- predicate dispatch
+- foreign handler registry
+- optional artifact manifests
+- optional intern tables or literal pools
+
+Example sketch:
+
+```scala
+final case class WamProgram(
+  instructions: Array[Instruction],
+  labels: Map[String, Int],
+  dispatch: Map[String, PredicateEntry],
+  foreignHandlers: Map[String, ForeignHandler]
+)
+```
+
+This layer should be immutable and reusable.
+
+### Layer C: Mutable execution state
+
+This is the hot path.
+
+Example sketch:
+
+```scala
+final class WamState(
+  val regs: Array[WamTerm],
+  val envStack: IntStack,
+  val choiceStack: ChoicePointStack,
+  val trail: TrailBuffer,
+  var pc: Int,
+  var failed: Boolean,
+  var halted: Boolean
+)
+```
+
+This layer should use mutation deliberately. The goal is cheap stepping,
+cheap backtracking, and low allocation.
+
+### Layer D: Foreign predicate adapter layer
+
+Scala should support the same broad foreign contract categories as the
+newer Clojure runtime:
+
+1. boolean success/failure
+2. deterministic binding maps
+3. streamed/multi-solution results
+
+Example protocol:
+
+```scala
+sealed trait ForeignResult
+case object ForeignFail extends ForeignResult
+case object ForeignTrue extends ForeignResult
+final case class ForeignBindings(bindings: Map[Int, WamTerm]) extends ForeignResult
+final case class ForeignSolutions(solutions: Vector[Map[Int, WamTerm]]) extends ForeignResult
+```
+
+The important philosophy is that `call-foreign` should be semantically
+integrated with WAM backtracking, not bolted on as a side effect.
+
+### Layer E: Fact backend adapter layer
+
+Scala must support multiple fact access shapes without rewriting the WAM
+runtime:
+
+- inline literals
+- sidecar TSV/EDN/JSON-like inputs
+- preprocessed artifacts
+- LMDB-backed exact lookup
+
+This adapter layer should expose a narrow capability-oriented interface.
+
+Example:
+
+```scala
+trait FactSource[K, V] {
+  def lookup(key: K): Vector[V]
+  def scan(): Iterator[(K, V)]
+}
+```
+
+The exact runtime representation can be optimized later, but the design
+should start from capabilities, not storage technology.
+
+### Layer F: Cache and stats layer
+
+Caching should sit above raw fact access.
+
+Possible modes:
+
+- `none`
+- `memoize`
+- `shared`
+- `two_level`
+
+And stats should be reported by the same layer, not buried in JNI code.
+
+## Runtime Representation Philosophy
+
+### Terms
+
+A Scala hybrid WAM target should not start with a maximally abstract
+term representation.
+
+The initial design should distinguish only what the WAM runtime needs:
+
+- variable/reference
+- atom/string
+- integer/number
+- structure
+- list / list-as-structure
+
+Example baseline:
+
+```scala
+sealed trait WamTerm
+final case class Ref(id: Int) extends WamTerm
+final case class Atom(value: String) extends WamTerm
+final case class IntTerm(value: Int) extends WamTerm
+final case class Struct(functor: String, args: Array[WamTerm]) extends WamTerm
+```
+
+This is not the final word. It is the right baseline for correctness and
+inspectability.
+
+### Instructions
+
+Instructions should be pre-resolved into a Scala representation before
+execution begins.
+
+Bad:
+
+- parse strings during stepping
+- store unresolved labels in the hot loop
+
+Good:
+
+```scala
+sealed trait Instruction
+final case class Call(pc: Int, pred: String, arity: Int) extends Instruction
+final case class TryMeElse(targetPc: Int) extends Instruction
+final case object Proceed extends Instruction
+```
+
+This follows the same core idea already used in the Clojure WAM target:
+resolve control-flow metadata once, not on every step.
+
+## Foreign Predicate Philosophy
+
+The Scala target should support the same semantic categories as the
+Clojure path, but it does not need the same representation choices.
+
+It should treat foreign predicates as:
+
+- part of normal predicate dispatch
+- allowed to backtrack
+- allowed to bind outputs
+- allowed to consume external fact backends
+
+For example, `category_ancestor/4` should be allowed to produce
+streamed solutions from an LMDB-backed parent store without requiring a
+second query engine.
+
+## Materialization and Externalization Philosophy
+
+Scala should follow the C# and shared preprocess direction:
+
+- declarations describe the storage intent
+- manifests describe the artifact contract
+- targets choose adapters against that contract
+
+Scala should not hide materialization decisions inside ad hoc codegen.
+
+Instead:
+
+- declarations say what relation shape is desired
+- generator emits metadata and bindings
+- runtime consumes that metadata
+
+This keeps Scala aligned with broader cross-target artifact work.
+
+## Example End-State
+
+At a mature stage, a generated Scala hybrid WAM project should be able
+to express:
+
+```scala
+object GeneratedProgram {
+  val program: WamProgram = ...
+
+  def categoryParent(a1: WamTerm, a2: WamTerm): Boolean =
+    WamRuntime.run(program, categoryParentStartPc, Array(a1, a2))
+
+  def categoryAncestor(a1: WamTerm, a2: WamTerm, a3: WamTerm, a4: WamTerm): Boolean =
+    WamRuntime.run(program, categoryAncestorStartPc, Array(a1, a2, a3, a4))
+}
+```
+
+with a runtime that:
+
+- uses mutable execution state
+- shares immutable compiled code
+- optionally consumes LMDB through the shared JVM seam
+- supports streamed foreign solutions
+- can emit benchmark or debug stats without changing semantics
+
+## Non-Goals
+
+The initial Scala hybrid WAM design should **not** try to solve all of
+these at once:
+
+- advanced parallel query execution
+- broad Spark/Hadoop integration
+- deep Scala macro generation
+- higher-kinded effect systems for the runtime
+- every possible external source backend
+
+The right philosophy is staged maturity:
+
+1. correct baseline hybrid WAM
+2. target-specific runtime quality
+3. shared artifact/backend seams
+4. measured optimization
+
+## Summary
+
+The Scala hybrid WAM target should be:
+
+- architecturally aligned with Clojure/Haskell/Rust
+- operationally closer to Rust/C#/Go in hot-path mutability
+- explicitly integrated with the shared JVM LMDB seam
+- generated as readable, inspectable Scala code
+- policy-driven rather than hard-coded
+
+The most important philosophical decision is this:
+
+> Scala should keep shared compiled context immutable, but it should be
+> unapologetically mutable in the per-run WAM execution state.

--- a/docs/proposals/WAM_SCALA_HYBRID_SPEC.md
+++ b/docs/proposals/WAM_SCALA_HYBRID_SPEC.md
@@ -1,0 +1,428 @@
+# WAM Scala Hybrid Specification
+
+## Scope
+
+This document specifies the structure of a future hybrid WAM Scala
+target.
+
+It assumes:
+
+- the existing non-WAM Scala target remains intact
+- the Scala hybrid WAM target is a separate target module
+- the target can reuse existing shared lowering logic where appropriate
+- the target may reuse the shared JVM LMDB seam established for Clojure
+
+## 1. Target Identity
+
+### Prolog module
+
+The target should live in:
+
+- `src/unifyweaver/targets/wam_scala_target.pl`
+
+### Template root
+
+Templates should live under:
+
+- `templates/targets/scala_wam/`
+
+### Tests
+
+At minimum:
+
+- `tests/test_wam_scala_generator.pl`
+- `tests/test_wam_scala_runtime_smoke.pl`
+- optionally benchmark-oriented tests later
+
+## 2. Generated Project Layout
+
+The generated Scala hybrid WAM project should use a simple SBT layout.
+
+### Required files
+
+```text
+<project>/
+  build.sbt
+  project/
+    build.properties
+  src/main/scala/generated/wam_scala/runtime/WamRuntime.scala
+  src/main/scala/generated/wam_scala/core/GeneratedProgram.scala
+```
+
+### Optional runtime support
+
+When LMDB or other JVM helpers are used:
+
+```text
+<project>/
+  lib/
+    lmdb-artifact-reader.jar
+    liblmdb_artifact_jni.so
+```
+
+The generated project must not assume ambient installation of helper
+artifacts.
+
+## 3. Runtime Model
+
+### 3.1 Shared immutable program
+
+The generated code must create one immutable program value.
+
+Example:
+
+```scala
+final case class WamProgram(
+  instructions: Array[Instruction],
+  labels: Map[String, Int],
+  foreignHandlers: Map[String, ForeignHandler],
+  dispatch: Map[String, PredicateEntry]
+)
+```
+
+This structure is shared across runs.
+
+### 3.2 Mutable per-query state
+
+The runtime must use mutable per-query execution state.
+
+Baseline shape:
+
+```scala
+final class WamState(
+  val regs: Array[WamTerm],
+  val envStack: IntStack,
+  val choiceStack: ChoicePointStack,
+  val trail: TrailBuffer,
+  var pc: Int,
+  var halted: Boolean,
+  var failed: Boolean
+)
+```
+
+This is a baseline; exact helper types may evolve.
+
+### 3.3 Execution contract
+
+The runtime entry point should look conceptually like:
+
+```scala
+object WamRuntime {
+  def runPredicate(
+    program: WamProgram,
+    startPc: Int,
+    regs: Array[WamTerm]
+  ): Boolean = ???
+}
+```
+
+This contract is intentionally close to the Clojure target’s generated
+wrapper shape, but Scala may use richer static types internally.
+
+## 4. Instruction Representation
+
+Instructions must be pre-resolved before stepping begins.
+
+### 4.1 Required categories
+
+The runtime must support at least:
+
+- `call`
+- `execute`
+- `call-foreign`
+- `try-me-else`
+- `retry-me-else`
+- `trust-me`
+- `jump`
+- `proceed`
+- `allocate`
+- `deallocate`
+- term-building and unification ops
+- `switch-on-constant`
+- arithmetic/builtin call nodes
+- cut / if-then-else support
+
+### 4.2 Example representation
+
+```scala
+sealed trait Instruction
+
+final case class Call(pred: String, arity: Int) extends Instruction
+final case class Execute(pred: String, arity: Int) extends Instruction
+final case class CallForeign(pred: String, arity: Int) extends Instruction
+final case class TryMeElse(targetPc: Int) extends Instruction
+final case class RetryMeElse(targetPc: Int) extends Instruction
+final case object TrustMe extends Instruction
+final case object Proceed extends Instruction
+```
+
+The exact hierarchy may be compressed for performance later, but the
+first implementation should optimize for clarity.
+
+## 5. Term Representation
+
+### 5.1 Baseline
+
+The target must support:
+
+- references/variables
+- atoms
+- integers
+- structures
+- list encoding
+
+Baseline:
+
+```scala
+sealed trait WamTerm
+final case class Ref(id: Int) extends WamTerm
+final case class Atom(value: String) extends WamTerm
+final case class IntTerm(value: Int) extends WamTerm
+final case class Struct(functor: String, args: Array[WamTerm]) extends WamTerm
+```
+
+### 5.2 Term operations
+
+The runtime must expose:
+
+- dereference
+- unify
+- read/write structure/list helpers
+- trail on variable binding
+
+## 6. Foreign Predicate Contract
+
+### 6.1 Supported result categories
+
+Foreign predicates must support:
+
+1. boolean success/failure
+2. deterministic output bindings
+3. streamed/multi-solution results
+
+### 6.2 Result protocol
+
+Suggested baseline:
+
+```scala
+sealed trait ForeignResult
+case object ForeignFail extends ForeignResult
+case object ForeignTrue extends ForeignResult
+final case class ForeignBindings(bindings: Map[Int, WamTerm]) extends ForeignResult
+final case class ForeignSolutions(solutions: Vector[Map[Int, WamTerm]]) extends ForeignResult
+```
+
+### 6.3 WAM integration requirements
+
+`call-foreign` must:
+
+- participate in backtracking
+- apply bindings to registers/terms correctly
+- preserve cut semantics
+- support foreign choice-point snapshots for streamed results
+
+This should follow the same semantic contract as the Clojure hybrid WAM
+path, even if Scala uses different data structures.
+
+## 7. Choice Points and Backtracking
+
+### 7.1 Ordinary choice points
+
+The runtime must preserve:
+
+- `pc`
+- trail length
+- environment stack position
+- register state needed for restoration
+- any additional execution metadata required for correctness
+
+### 7.2 Foreign choice points
+
+Foreign streamed solutions should use a narrower snapshot if possible.
+
+Suggested baseline:
+
+```scala
+final case class ForeignChoicePoint(
+  resumePc: Int,
+  trailLen: Int,
+  regsSnapshot: Array[WamTerm],
+  remainingSolutions: Vector[Map[Int, WamTerm]]
+)
+```
+
+The exact snapshot can be refined later, but it must remain separate
+from ordinary WAM choice points conceptually.
+
+## 8. Fact Backend Seam
+
+### 8.1 Capability contract
+
+The runtime should define a small capability-oriented fact-source
+interface.
+
+Example:
+
+```scala
+trait FactSource[K, V] {
+  def lookup(key: K): Vector[V]
+  def scan(): Iterator[(K, V)]
+}
+```
+
+This interface is intentionally simple. The initial Scala hybrid WAM
+target does not need a full generic query engine backend.
+
+### 8.2 Initial backends
+
+Initial backends should include:
+
+- inline literals
+- sidecar file materialization
+- LMDB-backed exact lookup through the shared JVM reader seam
+
+### 8.3 LMDB reuse
+
+Scala should reuse the existing JVM helper seam:
+
+- `generated.lmdb.LmdbArtifactReader`
+- `generated.lmdb.LmdbRow`
+- JNI shared library
+
+It should not define a second JNI protocol.
+
+## 9. Cache Policy Surface
+
+### 9.1 Supported policies
+
+The Scala design should reserve the same basic surface as the current
+Clojure LMDB path:
+
+- `none`
+- `memoize`
+- `shared`
+- `two_level`
+
+### 9.2 Placement
+
+These policies live above raw fact access.
+
+They are not part of the LMDB JNI contract.
+
+### 9.3 Stats
+
+The cache layer should expose machine-readable stats:
+
+- local hits
+- shared hits
+- misses
+
+This should be represented as data, not just stderr logs.
+
+## 10. Scala-Specific Runtime Policy
+
+This is the most important target-specific specification choice.
+
+### 10.1 Shared immutable context
+
+Must be immutable.
+
+### 10.2 Per-query execution state
+
+May and should be mutable.
+
+This is a required design choice, not an implementation accident.
+
+### 10.3 Caches
+
+Caches may be:
+
+- thread-local mutable
+- shared mutable with synchronization or lock-free discipline
+
+The initial target should not over-specify the exact shared-cache
+mechanism until measurement warrants it.
+
+## 11. Target Option Surface
+
+The Scala hybrid WAM target should eventually support options in these
+areas:
+
+### 11.1 Core generation
+
+- namespace / package
+- module name
+- emitted main wrapper toggle
+
+### 11.2 Foreign lowering
+
+- `foreign_predicates([...])`
+- explicit foreign handlers
+- foreign lowering enable/disable
+
+### 11.3 Artifact/fact access
+
+- sidecar vs artifact
+- preprocess declaration consumption
+- LMDB relation declarations
+
+### 11.4 Cache/reporting
+
+- cache mode
+- stats mode
+- debug logging
+
+## 12. Benchmark Integration Contract
+
+The benchmark path for Scala hybrid WAM should mirror the current
+Clojure/Haskell/Rust strategy:
+
+1. benchmark generator emits a generated project
+2. project uses target-level runtime features
+3. backends are chosen by declarations/options, not hard-coded logic
+
+The benchmark generator should not become the only place where Scala
+LMDB or artifact behavior exists.
+
+## 13. Example Target-Level Declarations
+
+Illustrative examples only:
+
+```prolog
+write_wam_scala_project(
+    [user:category_parent/2, user:category_ancestor/4],
+    [ package('generated.wam_scala'),
+      wam_scala_lmdb_foreign_relations([
+          category_parent/2-'data/generated/category_parent_lmdb',
+          category_ancestor/4-'data/generated/category_parent_lmdb'
+      ]),
+      wam_scala_lmdb_cache_policy(two_level),
+      wam_scala_lmdb_ancestor_max_depth(10)
+    ],
+    ProjectDir).
+```
+
+## 14. Non-Requirements for Phase 1
+
+The first Scala hybrid WAM implementation does not need:
+
+- parallel query execution
+- Spark or Hadoop integration
+- advanced JIT specialization
+- full generic materialization planners
+- every relation backend type
+
+It needs a correct hybrid WAM baseline with room to grow.
+
+## 15. Success Criteria
+
+The Scala hybrid WAM target reaches an acceptable first milestone when:
+
+1. it can generate a runnable Scala project
+2. simple WAM predicate execution works
+3. backtracking works
+4. `call-foreign` works for boolean and binding-returning handlers
+5. streamed foreign solutions work
+6. one LMDB-backed relation path is proven through the shared JVM seam
+7. benchmark-target integration is possible without special-casing the
+   runtime architecture


### PR DESCRIPTION
## Summary

Adds a detailed design package for a future hybrid WAM Scala target:

- philosophy
- specification
- implementation plan

The docs are intentionally architecture-heavy so later implementation
work can move quickly against a stable target design.

## What Changed

Added:

- `docs/proposals/WAM_SCALA_HYBRID_PHILOSOPHY.md`
- `docs/proposals/WAM_SCALA_HYBRID_SPEC.md`
- `docs/proposals/WAM_SCALA_HYBRID_IMPL_PLAN.md`

## Design Position

The most important architectural stance in these docs is:

- Scala should **not** copy Haskell’s mutability boundary mechanically
- shared compiled context should be immutable
- per-query WAM execution state should be mutable

That puts Scala’s hot-path runtime closer to Rust/C#/Go style than to
Haskell style, while still reusing the proven hybrid-WAM layering and
the shared JVM LMDB seam established by the recent Clojure work.

## Topics Covered

The docs cover:

- why Scala is worth a hybrid WAM target
- how it should relate to the existing Scala target
- project layout and generated files
- runtime state shape
- instruction representation
- foreign predicate semantics
- streamed foreign solutions
- fact backend and artifact seams
- LMDB/JNI reuse strategy
- cache-policy surface
- benchmark integration expectations
- a staged implementation plan from scaffold to runtime to LMDB-backed
  execution

## Why

This is the right point to invest in design because:

- the Clojure JVM-family LMDB work has clarified what should be shared
- Scala hybrid WAM does not appear to have been started yet
- the main risk now is implementation drift, not lack of ideas

These docs are meant to let later implementation agents move faster
without making target-shape decisions ad hoc in code.

## Scope

This PR is documentation-only.

It does not:

- add `wam_scala_target.pl`
- add Scala WAM templates
- add Scala WAM tests
- change any runtime behavior

## Intended Follow-up

The recommended first implementation PR after these docs is deliberately
narrow:

1. add `wam_scala_target.pl`
2. add template scaffold
3. add generator tests

The runtime and LMDB work should come later, phase by phase, using these
docs as the contract.
