### PR TITLE
bench(csharp-query): report pipeline bucket join strategies

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -1009,6 +1009,10 @@ Comparison note:
 - set `UNIFYWEAVER_BENCH_TRACE=1` when you want the generated
   `csharp-query` longest-depth benchmark to print both per-phase DAG
   timings and DAG retention strategy buckets to `stderr`
+- generated `csharp-query` DAG, weight-sum, and path-min workloads also
+  print concrete artifact bucket join choices as
+  `bucket_strategy_<node>_<strategy>=<count>` when trace data contains
+  `KeyJoinIndexedRelationProviderBucket*` strategies
 - cache reuse remains disabled for these one-shot generated benchmark
   programs, and trace creation is now opt-in rather than always-on
 - the hand-written C# DFS baseline is still cheaper after its lighter

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -39,6 +39,30 @@ CSHARP_BENCHMARK_PROJECT = """\
 </Project>
 """
 
+CSHARP_QUERY_BUCKET_STRATEGY_HELPERS = r"""
+    static bool IsConcreteBucketStrategy(string strategy)
+    {
+        return strategy.StartsWith("KeyJoinIndexedRelationProviderBucket", StringComparison.Ordinal)
+            && !string.Equals(strategy, "KeyJoinIndexedRelationProviderBuckets", StringComparison.Ordinal);
+    }
+
+    static void PrintBucketStrategies(QueryExecutionTrace? trace)
+    {
+        if (trace is null)
+        {
+            return;
+        }
+
+        foreach (var strategy in trace.SnapshotStrategies()
+            .Where(s => IsConcreteBucketStrategy(s.Strategy))
+            .OrderBy(s => s.NodeType, StringComparer.Ordinal)
+            .ThenBy(s => s.Strategy, StringComparer.Ordinal))
+        {
+            Console.Error.WriteLine($"bucket_strategy_{strategy.NodeType}_{strategy.Strategy}={strategy.Count}");
+        }
+    }
+"""
+
 
 def load_facts(facts_path):
     """Load facts from Prolog file."""
@@ -1475,6 +1499,7 @@ class Program
             Console.Error.WriteLine($"phase_{{phase.Phase}}_ms={{phase.Elapsed.TotalMilliseconds:F3}}");
         }}
     }}
+{CSHARP_QUERY_BUCKET_STRATEGY_HELPERS}
 
     static void Main(string[] args)
     {{
@@ -1564,6 +1589,7 @@ class Program
         Console.Error.WriteLine($"project_count={{results.Count}}");
         Console.Error.WriteLine($"dag_retention_strategy_setting={{dagRetentionStrategy}}");
         PrintDagStrategies(trace);
+        PrintBucketStrategies(trace);
         PrintDagPhases(trace);
     }}
 }}
@@ -1984,6 +2010,7 @@ class Program
             Console.Error.WriteLine($"phase_{{phase.Phase}}_ms={{phase.Elapsed.TotalMilliseconds.ToString(\"F3\", CultureInfo.InvariantCulture)}}");
         }}
     }}
+{CSHARP_QUERY_BUCKET_STRATEGY_HELPERS}
 
     static void Main(string[] args)
     {{
@@ -2084,6 +2111,7 @@ class Program
         Console.Error.WriteLine($"project_count={{results.Count}}");
         Console.Error.WriteLine($"dag_retention_strategy_setting={{dagRetentionStrategy}}");
         PrintDagStrategies(trace);
+        PrintBucketStrategies(trace);
         PrintDagPhases(trace);
     }}
 }}
@@ -2645,6 +2673,7 @@ class Program
             Console.Error.WriteLine($"phase_{{phase.Phase}}_ms={{phase.Elapsed.TotalMilliseconds.ToString(\"F3\", CultureInfo.InvariantCulture)}}");
         }}
     }}
+{CSHARP_QUERY_BUCKET_STRATEGY_HELPERS}
 
     static void Main(string[] args)
     {{
@@ -2742,6 +2771,7 @@ class Program
         Console.Error.WriteLine($"edge_retention_strategy_setting={{edgeRetentionStrategy}}");
         Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintWeightSumStrategies(trace);
+        PrintBucketStrategies(trace);
         PrintWeightSumPhases(trace);
     }}
 }}
@@ -2829,6 +2859,7 @@ class Program
             Console.Error.WriteLine($"phase_{{phase.Phase}}_ms={{phase.Elapsed.TotalMilliseconds.ToString(\"F3\", CultureInfo.InvariantCulture)}}");
         }}
     }}
+{CSHARP_QUERY_BUCKET_STRATEGY_HELPERS}
 
     static void Main(string[] args)
     {{
@@ -2915,6 +2946,7 @@ class Program
         Console.Error.WriteLine($"edge_retention_strategy_setting={{edgeRetentionStrategy}}");
         Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintWeightSumStrategies(trace);
+        PrintBucketStrategies(trace);
         PrintWeightSumPhases(trace);
     }}
 
@@ -3005,6 +3037,7 @@ class Program
             Console.Error.WriteLine($"phase_{{phase.Phase}}_ms={{phase.Elapsed.TotalMilliseconds.ToString(\"F3\", CultureInfo.InvariantCulture)}}");
         }}
     }}
+{CSHARP_QUERY_BUCKET_STRATEGY_HELPERS}
 
     static void Main(string[] args)
     {{
@@ -3090,6 +3123,7 @@ class Program
         Console.Error.WriteLine($"edge_retention_strategy_setting={{edgeRetentionStrategy}}");
         Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintPathMinStrategies(trace);
+        PrintBucketStrategies(trace);
         PrintPathMinPhases(trace);
     }}
 }}
@@ -3192,6 +3226,7 @@ class Program
             Console.Error.WriteLine($"metric_{{metric.Metric}}={{metric.Value.ToString(\"G17\", CultureInfo.InvariantCulture)}}");
         }}
     }}
+{CSHARP_QUERY_BUCKET_STRATEGY_HELPERS}
 
     static void Main(string[] args)
     {{
@@ -3317,6 +3352,7 @@ class Program
         Console.Error.WriteLine($"edge_retention_strategy_setting={{edgeRetentionStrategy}}");
         Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintPathMinStrategies(trace);
+        PrintBucketStrategies(trace);
         PrintPathMinPhases(trace);
         PrintPathMinMetrics(trace);
     }}


### PR DESCRIPTION
  ## Summary

  - Add generated C# query benchmark helpers that report concrete artifact bucket join strategies from
  `QueryExecutionTrace`.
  - Emit bucket strategy metrics as `bucket_strategy_<node>_<strategy>=<count>` for DAG, weight-sum, and path-min
  generated workloads.
  - Filter out the legacy aggregate `KeyJoinIndexedRelationProviderBuckets` marker so the output only shows concrete
  choices like bucket merge or hash-build direction.
  - Document the new trace output in the benchmark README.

  ## Validation

  - `python3 -m py_compile examples/benchmark/generate_pipeline.py`
  - `git diff --check`
  - Generated all six `csharp_query` pipeline workloads from `data/benchmark/300/facts.pl`
  - Built all six generated C# projects with 0 errors
  - Ran a traced generated `category_influence` benchmark