### PR TITLE
bench(csharp-query): summarize bucket strategies in benchmark runners

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -1013,6 +1013,9 @@ Comparison note:
   print concrete artifact bucket join choices as
   `bucket_strategy_<node>_<strategy>=<count>` when trace data contains
   `KeyJoinIndexedRelationProviderBucket*` strategies
+- cross-target runners summarize those generated metrics as
+  `csharp-query-bucket-strategies` rows when `UNIFYWEAVER_BENCH_TRACE=1`
+  captures any concrete bucket strategies
 - cache reuse remains disabled for these one-shot generated benchmark
   programs, and trace creation is now opt-in rather than always-on
 - the hand-written C# DFS baseline is still cheaper after its lighter

--- a/examples/benchmark/benchmark_category_influence_cross_target.py
+++ b/examples/benchmark/benchmark_category_influence_cross_target.py
@@ -23,6 +23,7 @@ from benchmark_common import (
     find_result,
     group_results_by_scale,
     normalize_two_column_float_rows,
+    print_bucket_strategy_metrics,
     print_match_status,
     print_phase_metrics,
     print_result_table,
@@ -135,9 +136,9 @@ def print_summary(results: list[RunResult]) -> None:
     print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
     for scale, entries in group_results_by_scale(results):
         print_result_table(entries, scale)
+        csharp = find_result(entries, "csharp-query")
         if len(entries) > 1:
             print_match_status(scale, "outputs", entries)
-            csharp = find_result(entries, "csharp-query")
             rust = find_result(entries, "rust-dfs")
             go = find_result(entries, "go-dfs")
             prolog = find_result(entries, "prolog-accumulated")
@@ -149,8 +150,9 @@ def print_summary(results: list[RunResult]) -> None:
                 speedup = (go.median / rust.median) if faster == "rust-dfs" else (rust.median / go.median)
                 print(f"{scale}\tfaster_target\t{faster}")
                 print(f"{scale}\tspeedup\t{speedup:.2f}x")
-            print_phase_metrics(scale, "csharp-query-metrics", csharp)
             print_phase_metrics(scale, "prolog-accumulated-metrics", prolog)
+        print_phase_metrics(scale, "csharp-query-metrics", csharp)
+        print_bucket_strategy_metrics(scale, "csharp-query-bucket-strategies", csharp)
 
 
 def main() -> int:

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -366,6 +366,25 @@ def print_speedup(scale: str, label: str, faster_baseline: object | None, measur
 
 def print_phase_metrics(scale: str, label: str, result: object | None) -> None:
     if result and result.stderr:
-        phase_lines = [line.strip() for line in result.stderr.splitlines() if "=" in line]
+        phase_lines = [
+            line.strip()
+            for line in result.stderr.splitlines()
+            if "=" in line and not line.startswith("bucket_strategy_")
+        ]
         if phase_lines:
             print(f"{scale}\t{label}\t" + " ".join(phase_lines))
+
+
+def summarize_bucket_strategy_metrics(stderr: str) -> str:
+    return " ".join(
+        line.strip()
+        for line in stderr.splitlines()
+        if line.startswith("bucket_strategy_") and "=" in line
+    )
+
+
+def print_bucket_strategy_metrics(scale: str, label: str, result: object | None) -> None:
+    if result and result.stderr:
+        summary = summarize_bucket_strategy_metrics(result.stderr)
+        if summary:
+            print(f"{scale}\t{label}\t{summary}")

--- a/examples/benchmark/benchmark_dependency_depth_cross_target.py
+++ b/examples/benchmark/benchmark_dependency_depth_cross_target.py
@@ -23,6 +23,7 @@ from benchmark_common import (
     find_result,
     group_results_by_scale,
     normalize_sorted_lines,
+    print_bucket_strategy_metrics,
     print_match_status,
     print_pair_match_status,
     print_result_table,
@@ -137,6 +138,7 @@ def print_summary(results: list[RunResult]) -> None:
         print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
         print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
         print_speedup(scale, "speedup_vs_go_dfs", go_dfs, qe)
+        print_bucket_strategy_metrics(scale, "csharp-query-bucket-strategies", qe)
 
 
 def main() -> int:

--- a/examples/benchmark/benchmark_dependency_longest_depth_cross_target.py
+++ b/examples/benchmark/benchmark_dependency_longest_depth_cross_target.py
@@ -23,6 +23,7 @@ from benchmark_common import (
     find_result,
     group_results_by_scale,
     normalize_sorted_lines,
+    print_bucket_strategy_metrics,
     print_match_status,
     print_pair_match_status,
     print_result_table,
@@ -140,6 +141,7 @@ def print_summary(results: list[RunResult]) -> None:
             print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, csharp_query)
         if csharp_query and go_dfs:
             print_speedup(scale, "speedup_vs_go_dfs", go_dfs, csharp_query)
+        print_bucket_strategy_metrics(scale, "csharp-query-bucket-strategies", csharp_query)
 
 
 def main() -> int:

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -36,6 +36,7 @@ from benchmark_common import (
     find_result,
     group_results_by_scale,
     normalize_three_column_float_rows,
+    print_bucket_strategy_metrics,
     print_match_status,
     print_pair_match_status,
     print_phase_metrics,
@@ -378,6 +379,7 @@ def print_summary(results: list[RunResult]) -> None:
         print_speedup(scale, "speedup_vs_prolog_semantic_min", prolog_semantic_min, qe)
         print_speedup(scale, "speedup_vs_prolog_eff_semantic", prolog_eff_semantic, qe)
         print_phase_metrics(scale, "csharp-query-metrics", qe)
+        print_bucket_strategy_metrics(scale, "csharp-query-bucket-strategies", qe)
         print_phase_metrics(scale, "prolog-seeded-metrics", prolog_seeded)
         print_phase_metrics(scale, "prolog-pruned-metrics", prolog_pruned)
         print_phase_metrics(scale, "prolog-accumulated-metrics", prolog_accumulated)

--- a/examples/benchmark/benchmark_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_shortest_path_cross_target.py
@@ -23,6 +23,7 @@ from benchmark_common import (
     find_result,
     group_results_by_scale,
     normalize_sorted_lines,
+    print_bucket_strategy_metrics,
     print_match_status,
     print_pair_match_status,
     print_phase_metrics,
@@ -166,6 +167,7 @@ def print_summary(results: list[RunResult]) -> None:
         print_speedup(scale, "speedup_vs_go_dfs", go_dfs, qe)
         print_head_to_head(scale, qe, prolog_min, "query_vs_prolog_min")
         print_phase_metrics(scale, "csharp-query-metrics", qe)
+        print_bucket_strategy_metrics(scale, "csharp-query-bucket-strategies", qe)
         print_phase_metrics(scale, "prolog-min-metrics", prolog_min)
 
 

--- a/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
@@ -23,6 +23,7 @@ from benchmark_common import (
     find_result,
     group_results_by_scale,
     normalize_three_column_float_rows,
+    print_bucket_strategy_metrics,
     print_match_status,
     print_pair_match_status,
     print_phase_metrics,
@@ -166,6 +167,7 @@ def print_summary(results: list[RunResult]) -> None:
         print_speedup(scale, "speedup_vs_go_dfs", go_dfs, qe)
         print_head_to_head(scale, qe, prolog_min, "query_vs_prolog_min")
         print_phase_metrics(scale, "csharp-query-metrics", qe)
+        print_bucket_strategy_metrics(scale, "csharp-query-bucket-strategies", qe)
         print_phase_metrics(scale, "prolog-min-metrics", prolog_min)
 
 


### PR DESCRIPTION
  ## Summary

  - Add shared benchmark helpers to extract generated `bucket_strategy_*` stderr metrics.
  - Print dedicated `csharp-query-bucket-strategies` rows in C# query cross-target benchmark summaries.
  - Filter bucket strategy entries out of generic `*-metrics` rows to avoid duplicate reporting.
  - Wire the summary row into category influence, effective distance, shortest path, weighted shortest path, dependency
  depth, and dependency longest-depth runners.
  - Document the new benchmark summary row in the benchmark README.

  ## Validation

  - `python3 -m py_compile examples/benchmark/benchmark_common.py examples/benchmark/
  benchmark_category_influence_cross_target.py examples/benchmark/benchmark_effective_distance.py examples/benchmark/
  benchmark_shortest_path_cross_target.py examples/benchmark/benchmark_weighted_shortest_path_cross_target.py examples/
  benchmark/benchmark_dependency_depth_cross_target.py examples/benchmark/
  benchmark_dependency_longest_depth_cross_target.py`
  - `python3 -c "from examples.benchmark.benchmark_common import summarize_bucket_strategy_metrics;
  s='load_ms=1\nbucket_strategy_KeyJoinNode_KeyJoinIndexedRelationProviderBucketMerge=2\nstrategy_other=1\n'; assert
  summarize_bucket_strategy_metrics(s) == 'bucket_strategy_KeyJoinNode_KeyJoinIndexedRelationProviderBucketMerge=2'"`
  - `git diff --check`
  - `env UNIFYWEAVER_BENCH_TRACE=1 python3 examples/benchmark/benchmark_category_influence_cross_target.py --scales 300
  --targets csharp-query --repetitions 1`