### PR TITLE
feat(wam-scala): finish baseline (S3+S4) + foreign integration (S5)

### DIFF
--- a/src/unifyweaver/targets/wam_scala_target.pl
+++ b/src/unifyweaver/targets/wam_scala_target.pl
@@ -46,7 +46,11 @@ init_scala_atom_intern_table :-
     assertz(scala_atom_intern_id("[]",   2)),
     assertz(scala_atom_intern_id(".",    3)),
     assertz(scala_atom_intern_id("",     4)),
-    assertz(scala_atom_intern_next(5)).
+    % "[|]" is the SWI/WAM cons functor; pre-intern so it has a stable id
+    % regardless of whether the user predicate body emits put_list/get_list
+    % (which carry it implicitly) or put_structure [|]/2 (explicit).
+    assertz(scala_atom_intern_id("[|]",  5)),
+    assertz(scala_atom_intern_next(6)).
 
 %% intern_scala_atom(+AtomStr, -Id) is det.
 intern_scala_atom(AtomStr, Id) :-
@@ -188,7 +192,8 @@ wam_parts_to_scala(["put_structure", Functor, Reg], Lit) :-
 
 wam_parts_to_scala(["put_list", Reg], Lit) :-
     reg_to_int(Reg, RegIdx),
-    format(string(Lit), 'PutList(~w)', [RegIdx]).
+    intern_scala_atom("[|]", FId),
+    format(string(Lit), 'PutList(~w, ~w)', [RegIdx, FId]).
 
 wam_parts_to_scala(["get_structure", Functor, Reg], Lit) :-
     reg_to_int(Reg, RegIdx),
@@ -198,7 +203,8 @@ wam_parts_to_scala(["get_structure", Functor, Reg], Lit) :-
 
 wam_parts_to_scala(["get_list", Reg], Lit) :-
     reg_to_int(Reg, RegIdx),
-    format(string(Lit), 'GetList(~w)', [RegIdx]).
+    intern_scala_atom("[|]", FId),
+    format(string(Lit), 'GetList(~w, ~w)', [RegIdx, FId]).
 
 wam_parts_to_scala(["set_variable", Reg], Lit) :-
     reg_to_int(Reg, Idx),
@@ -325,6 +331,13 @@ compile_wam_predicate_to_scala(_Pred, _WamCode, _Options, "").
 %    AllLabelEntries: all labels including sub-clause labels (for instruction resolution)
 compile_predicates_for_project(Predicates, Options, AllInstrs, TopLevelLabelEntries, AllLabelEntries, WrapperCode) :-
     init_scala_atom_intern_table,
+    % Pre-intern atoms requested via the intern_atoms option. Useful when
+    % user-supplied foreign handlers reference atoms that don't appear in
+    % any WAM body (otherwise they collapse to the unknown-atom id -1 and
+    % can't be distinguished from each other).
+    option(intern_atoms(ExtraAtoms), Options, []),
+    forall(member(A, ExtraAtoms),
+           (atom_string(A, S), intern_scala_atom(S, _))),
     compile_all_predicates(Predicates, Options, 0, [], [], [], [], AllInstrs, TopLevelLabelEntries, AllLabelEntries, Wrappers),
     atomic_list_concat(Wrappers, '\n', WrapperCode).
 
@@ -335,10 +348,14 @@ compile_all_predicates([Pred|Rest], Options, BasePC,
                        AllInstrs, TopLevelLabelEntries, AllLabelEntries, AllWrappers) :-
     (   Pred = _Module:P/Arity -> true ; Pred = P/Arity ),
     (   scala_foreign_predicate(P, Arity, Options)
-    ->  % Foreign: emit a single CallForeign instruction
+    ->  % Foreign stub: CallForeign followed by Proceed. The trailing
+        % Proceed is what returns control to the caller after the handler
+        % succeeds; without it, pc falls through into the next predicate
+        % and re-executes its body as if continuing the foreign call.
         format(string(FLit), 'CallForeign("~w", ~w)', [P, Arity]),
-        NewInstrs = [FLit | InstrAcc],
-        NewPC is BasePC + 1,
+        ForeignSeq = [FLit, 'Proceed'],
+        append(InstrAcc, ForeignSeq, NewInstrs),
+        NewPC is BasePC + 2,
         format(string(MainEntry), '    "~w/~w" -> ~w', [P, Arity, BasePC]),
         NewTopLabels = [MainEntry | TopLabelAcc],
         NewAllLabels = [MainEntry | AllLabelAcc]
@@ -445,6 +462,20 @@ scala_foreign_predicate(Pred, Arity, Options) :-
     ;   member(_:Pred/Arity, FPs)
     ), !.
 
+%% scala_foreign_handlers_code(+Options, -Code) is det.
+%  Renders the body of the `foreignHandlers` Map in the generated
+%  program. Reads `scala_foreign_handlers([handler(P/A, "<scala>"), ...])`
+%  from Options. Each handler value is a Scala expression of type
+%  `ForeignHandler` (typically `new ForeignHandler { def apply(...) = ... }`).
+%  When no handlers are configured, returns the empty string.
+scala_foreign_handlers_code(Options, Code) :-
+    option(scala_foreign_handlers(Handlers), Options, []),
+    maplist(scala_foreign_handler_entry, Handlers, Entries),
+    atomic_list_concat(Entries, ',\n', Code).
+
+scala_foreign_handler_entry(handler(Pred/Arity, HandlerCode), Entry) :-
+    format(string(Entry), '    "~w/~w" -> ~w', [Pred, Arity, HandlerCode]).
+
 % ============================================================================
 % PROJECT WRITER
 % ============================================================================
@@ -473,12 +504,15 @@ write_wam_scala_project(Predicates, Options, ProjectDir) :-
     % --- Package and runtime package ---
     option(package(Pkg), Options, 'generated.wam_scala.core'),
     option(runtime_package(RPkg), Options, 'generated.wam_scala.runtime'),
+    % --- Foreign handler bodies ---
+    scala_foreign_handlers_code(Options, ForeignHandlersBody),
     % --- Render runtime template ---
     write_runtime_source(ProjectDir, Pkg, RPkg),
     % --- Render program template ---
     write_program_source(ProjectDir, Pkg, RPkg,
                          InstrBody, LabelBody, DispatchBody,
-                         WrapperCode, StringToIdStr, IdToStringStr).
+                         WrapperCode, StringToIdStr, IdToStringStr,
+                         ForeignHandlersBody).
 
 write_build_sbt(ProjectDir, ModName) :-
     find_template('templates/targets/scala_wam/build.sbt.mustache', Template),
@@ -504,7 +538,8 @@ write_runtime_source(ProjectDir, Package, _RuntimePkg) :-
 
 write_program_source(ProjectDir, Package, RuntimePkg,
                      InstrBody, LabelBody, DispatchBody,
-                     WrapperCode, StringToIdStr, IdToStringStr) :-
+                     WrapperCode, StringToIdStr, IdToStringStr,
+                     ForeignHandlersBody) :-
     find_template('templates/targets/scala_wam/program.scala.mustache', Template),
     get_time(T), format_time(string(DateStr), "%Y-%m-%d", T),
     render_template(Template,
@@ -517,7 +552,7 @@ write_program_source(ProjectDir, Package, RuntimePkg,
           'wrappers'=WrapperCode,
           'intern_string_to_id'=StringToIdStr,
           'intern_id_to_string'=IdToStringStr,
-          'foreign_handlers'=""
+          'foreign_handlers'=ForeignHandlersBody
         ], Content),
     scala_source_path(ProjectDir, Package, 'GeneratedProgram', Path),
     make_directory_path_for(Path),

--- a/templates/targets/scala_wam/program.scala.mustache
+++ b/templates/targets/scala_wam/program.scala.mustache
@@ -41,6 +41,17 @@ object GeneratedProgram {
   )
 
   // ----------------------------------------------------------
+  // Foreign handler registry
+  // ----------------------------------------------------------
+  // Defined before sharedProgram so the forward reference inside
+  // WamProgram(... foreignHandlers ...) resolves to a real Map at
+  // initialization time, not null.
+
+  val foreignHandlers: Map[String, ForeignHandler] = Map(
+{{foreign_handlers}}
+  )
+
+  // ----------------------------------------------------------
   // Compiled program object
   // ----------------------------------------------------------
 
@@ -52,15 +63,6 @@ object GeneratedProgram {
 {{dispatch}}
     ),
     internTable     = internTable
-  )
-
-  // ----------------------------------------------------------
-  // Foreign handler registry
-  // ----------------------------------------------------------
-  // Override entries here or pass handlers at call time.
-
-  val foreignHandlers: Map[String, ForeignHandler] = Map(
-{{foreign_handlers}}
   )
 
   // ----------------------------------------------------------
@@ -112,7 +114,7 @@ object GeneratedProgram {
   private def parseList(inner: String): WamTerm = {
     val items = splitTopLevelCommas(inner).filter(_.nonEmpty).map(parseArg)
     items.foldRight[WamTerm](Atom(internAtomId("[]"))) { (head, tail) =>
-      Struct(internAtomId("."), 2, Array(head, tail))
+      Struct(internAtomId("[|]"), 2, Array(head, tail))
     }
   }
 

--- a/templates/targets/scala_wam/runtime.scala.mustache
+++ b/templates/targets/scala_wam/runtime.scala.mustache
@@ -82,8 +82,10 @@ case class PutValue(varReg: Int, argReg: Int)           extends Instruction
 // Structure/list building
 case class PutStructure(functorId: Int, reg: Int, sArity: Int) extends Instruction
 case class GetStructure(functorId: Int, reg: Int)       extends Instruction
-case class PutList(reg: Int)                            extends Instruction
-case class GetList(reg: Int)                            extends Instruction
+// PutList/GetList carry the cons functor id explicitly so they agree
+// with PutStructure([|]/2,...)/GetStructure([|]/2,...) on the same list.
+case class PutList(reg: Int, functorId: Int)            extends Instruction
+case class GetList(reg: Int, functorId: Int)            extends Instruction
 case class SetVariable(varReg: Int)                     extends Instruction
 case class SetValue(varReg: Int)                        extends Instruction
 case class SetConstant(value: WamTerm)                  extends Instruction
@@ -347,18 +349,22 @@ object WamRuntime {
           backtrack(s)
         case ForeignCP(sol +: remaining) =>
           s.choicePoints = cp.copy(kind = ForeignCP(remaining)) :: rest
-          applyBindings(s, sol)
+          if (!applyBindings(s, sol)) backtrack(s)
         case WamCP =>
           s.choicePoints = rest
       }
   }
 
-  def applyBindings(s: WamState, binds: Map[Int, WamTerm]): Unit =
-    binds.foreach { case (reg, v) =>
+  /** Apply a foreign-handler-provided binding map to the current state.
+   *  Returns true on success; false on first unification conflict (caller
+   *  should then backtrack). Stops at the first failure rather than
+   *  continuing to bind further registers. */
+  def applyBindings(s: WamState, binds: Map[Int, WamTerm]): Boolean =
+    binds.forall { case (reg, v) =>
       val current = deref(s.bindings, s.regs(reg))
       current match {
-        case r @ Ref(_) => bindVar(s, r, v)
-        case existing   => if (!unify(s, existing, v)) s.status = Failed
+        case r @ Ref(_) => bindVar(s, r, v); true
+        case existing   => unify(s, existing, v)
       }
     }
 
@@ -412,8 +418,7 @@ object WamRuntime {
           case ForeignSucceed =>
             s.pc = resumePc
           case ForeignBindings(binds) =>
-            applyBindings(s, binds)
-            if (s.status == Running) s.pc = resumePc
+            if (applyBindings(s, binds)) s.pc = resumePc else backtrack(s)
           case ForeignMulti(Nil) =>
             backtrack(s)
           case ForeignMulti(sol +: rest) =>
@@ -430,8 +435,7 @@ object WamRuntime {
               )
               s.choicePoints = cp :: s.choicePoints
             }
-            applyBindings(s, sol)
-            if (s.status == Running) s.pc = resumePc
+            if (applyBindings(s, sol)) s.pc = resumePc else backtrack(s)
         }
     }
   }
@@ -557,8 +561,8 @@ object WamRuntime {
         s.buildStack = BuildFrame(reg, functorId, sArity, Nil) :: s.buildStack
         s.pc += 1
 
-      case PutList(reg) =>
-        s.buildStack = BuildFrame(reg, -1 /* [|]/2 */, 2, Nil) :: s.buildStack
+      case PutList(reg, functorId) =>
+        s.buildStack = BuildFrame(reg, functorId, 2, Nil) :: s.buildStack
         s.pc += 1
 
       case SetVariable(varReg) =>
@@ -584,10 +588,10 @@ object WamRuntime {
           case _ => backtrack(s)
         }
 
-      case GetList(reg) =>
+      case GetList(reg, functorId) =>
         val v = deref(s.bindings, s.regs(reg))
         v match {
-          case Struct(-1, 2, args) => // [|]/2 sentinel
+          case Struct(f, 2, args) if f == functorId =>
             s.unifyQueue = args.toList
             s.pc += 1
           case _ => backtrack(s)

--- a/tests/test_wam_scala_runtime_smoke.pl
+++ b/tests/test_wam_scala_runtime_smoke.pl
@@ -37,6 +37,17 @@
 :- dynamic user:wam_env1/1.
 :- dynamic user:wam_env2/1.
 :- dynamic user:wam_trail_choice/1.
+:- dynamic user:wam_cut_first/1.
+:- dynamic user:wam_cut_caller/1.
+:- dynamic user:wam_list_match/1.
+:- dynamic user:wam_use_list/1.
+:- dynamic user:wam_make_list/1.
+:- dynamic user:wam_foreign_yes/1.
+:- dynamic user:wam_foreign_yes_caller/1.
+:- dynamic user:wam_foreign_pair/2.
+:- dynamic user:wam_foreign_pair_query/1.
+:- dynamic user:wam_foreign_multi/2.
+:- dynamic user:wam_foreign_multi_query/1.
 
 user:wam_fact(a).
 user:wam_execute_caller(X)    :- user:wam_fact(X).
@@ -57,6 +68,30 @@ user:wam_make_struct(X)       :- X = f(a).
 user:wam_env1(X)              :- Y = X, Z = a, Y = Z.
 user:wam_env2(X)              :- user:wam_fact(X), Y = X, user:wam_fact(Y).
 user:wam_trail_choice(X)      :- (Y = a ; Y = b), X = Y.
+% Hard cut: first clause commits on a, second clause handles b.
+user:wam_cut_first(a) :- !.
+user:wam_cut_first(b).
+% Cut inside an inner predicate, then call from an outer caller, to
+% exercise the cutBar interaction across allocate/deallocate frames.
+user:wam_cut_caller(X) :- user:wam_cut_first(X).
+% List match exercises get_list / unify_constant / unify_variable
+% and the get_structure [|]/2 nested case.
+user:wam_list_match([a, b]).
+user:wam_use_list(L)   :- user:wam_list_match(L).
+% List build exercises put_list / set_constant / set_variable and
+% put_structure [|]/2.
+user:wam_make_list(X)  :- X = [a, b].
+
+% Foreign predicate stubs. When `foreign_predicates([P/A,...])` is
+% passed to the project writer, the WAM body is replaced with a single
+% CallForeign instruction; these Prolog bodies exist only so the
+% predicates are declared.
+user:wam_foreign_yes(_).
+user:wam_foreign_yes_caller(X)  :- user:wam_foreign_yes(X).
+user:wam_foreign_pair(_, _).
+user:wam_foreign_pair_query(Y)  :- user:wam_foreign_pair(a, Y).
+user:wam_foreign_multi(_, _).
+user:wam_foreign_multi_query(Y) :- user:wam_foreign_multi(a, Y).
 
 % ============================================================
 % Condition: only run if scalac is available
@@ -186,6 +221,86 @@ test(trail_and_backtrack) :-
             verify_scala(TmpDir, 'wam_trail_choice/1', 'c', "false")
         )).
 
+% --- S3+S4 lockdown coverage ---
+
+test(hard_cut) :-
+    with_scala_project(
+        [user:wam_cut_first/1, user:wam_cut_caller/1],
+        _Opts,
+        TmpDir,
+        (
+            verify_scala(TmpDir, 'wam_cut_first/1', 'a', "true"),
+            verify_scala(TmpDir, 'wam_cut_first/1', 'b', "true"),
+            verify_scala(TmpDir, 'wam_cut_first/1', 'c', "false"),
+            verify_scala(TmpDir, 'wam_cut_caller/1', 'a', "true"),
+            verify_scala(TmpDir, 'wam_cut_caller/1', 'b', "true"),
+            verify_scala(TmpDir, 'wam_cut_caller/1', 'c', "false")
+        )).
+
+test(list_match) :-
+    with_scala_project(
+        [user:wam_list_match/1, user:wam_use_list/1],
+        _Opts,
+        TmpDir,
+        (
+            verify_scala(TmpDir, 'wam_use_list/1',   '[a,b]', "true"),
+            verify_scala(TmpDir, 'wam_use_list/1',   '[a,c]', "false"),
+            verify_scala(TmpDir, 'wam_list_match/1', '[a,b]', "true"),
+            verify_scala(TmpDir, 'wam_list_match/1', '[a,b,c]', "false")
+        )).
+
+test(list_build) :-
+    with_scala_project(
+        [user:wam_make_list/1],
+        _Opts,
+        TmpDir,
+        (
+            verify_scala(TmpDir, 'wam_make_list/1', '[a,b]', "true"),
+            verify_scala(TmpDir, 'wam_make_list/1', '[a,c]', "false")
+        )).
+
+% --- Phase S5: foreign predicate integration ---
+
+test(foreign_boolean) :-
+    foreign_yes_handler(YesHandler),
+    with_scala_project(
+        [user:wam_foreign_yes/1, user:wam_foreign_yes_caller/1],
+        [ foreign_predicates([wam_foreign_yes/1]),
+          intern_atoms([a, b]),
+          scala_foreign_handlers([handler(wam_foreign_yes/1, YesHandler)]) ],
+        TmpDir,
+        (
+            verify_scala(TmpDir, 'wam_foreign_yes_caller/1', 'a', "true"),
+            verify_scala(TmpDir, 'wam_foreign_yes_caller/1', 'b', "false")
+        )).
+
+test(foreign_binding) :-
+    foreign_pair_handler(PairHandler),
+    with_scala_project(
+        [user:wam_foreign_pair/2, user:wam_foreign_pair_query/1],
+        [ foreign_predicates([wam_foreign_pair/2]),
+          intern_atoms([a, b, c]),
+          scala_foreign_handlers([handler(wam_foreign_pair/2, PairHandler)]) ],
+        TmpDir,
+        (
+            verify_scala(TmpDir, 'wam_foreign_pair_query/1', 'b', "true"),
+            verify_scala(TmpDir, 'wam_foreign_pair_query/1', 'c', "false")
+        )).
+
+test(foreign_multi) :-
+    foreign_multi_handler(MultiHandler),
+    with_scala_project(
+        [user:wam_foreign_multi/2, user:wam_foreign_multi_query/1],
+        [ foreign_predicates([wam_foreign_multi/2]),
+          intern_atoms([a, b, c]),
+          scala_foreign_handlers([handler(wam_foreign_multi/2, MultiHandler)]) ],
+        TmpDir,
+        (
+            verify_scala(TmpDir, 'wam_foreign_multi_query/1', 'a', "true"),
+            verify_scala(TmpDir, 'wam_foreign_multi_query/1', 'b', "true"),
+            verify_scala(TmpDir, 'wam_foreign_multi_query/1', 'c', "false")
+        )).
+
 :- end_tests(wam_scala_runtime_smoke).
 
 % ============================================================
@@ -195,15 +310,14 @@ test(trail_and_backtrack) :-
 %% with_scala_project(+Preds, +Opts, -TmpDir, :Goal)
 %  Generates a Scala project, compiles it, runs Goal (which may call
 %  verify_scala/4), then cleans up. TmpDir is bound for Goal's use.
-with_scala_project(Preds, _Opts, TmpDir, Goal) :-
+with_scala_project(Preds, ExtraOpts0, TmpDir, Goal) :-
+    (   var(ExtraOpts0) -> ExtraOpts = [] ; ExtraOpts = ExtraOpts0 ),
     unique_scala_tmp_dir('tmp_scala_smoke', TmpDir),
-    write_wam_scala_project(
-        Preds,
-        [ package('generated.wam_scala_smoke.core'),
-          runtime_package('generated.wam_scala_smoke.core'),
-          module_name('wam-scala-smoke')
-        ],
-        TmpDir),
+    BaseOpts = [ package('generated.wam_scala_smoke.core'),
+                 runtime_package('generated.wam_scala_smoke.core'),
+                 module_name('wam-scala-smoke') ],
+    append(ExtraOpts, BaseOpts, AllOpts),
+    write_wam_scala_project(Preds, AllOpts, TmpDir),
     compile_scala_project(TmpDir),
     setup_call_cleanup(
         true,
@@ -281,3 +395,20 @@ unique_scala_tmp_dir(Prefix, TmpDir) :-
     get_time(T),
     Stamp is floor(T * 1000),
     format(atom(TmpDir), '~w_~w', [Prefix, Stamp]).
+
+% ============================================================
+% Foreign handler bodies (Scala source)
+% ============================================================
+% Each handler is a Scala expression of type `ForeignHandler` that
+% gets injected into the generated `foreignHandlers` Map literal.
+% Handlers run inside the GeneratedProgram object so they can
+% reference `internTable` directly.
+
+foreign_yes_handler(Code) :-
+    Code = "new ForeignHandler {\n      def apply(args: Array[WamTerm]): ForeignResult = {\n        val aId = internTable.stringToId.getOrElse(\"a\", -1)\n        args(0) match {\n          case Atom(id) if id == aId => ForeignSucceed\n          case _                     => ForeignFail\n        }\n      }\n    }".
+
+foreign_pair_handler(Code) :-
+    Code = "new ForeignHandler {\n      def apply(args: Array[WamTerm]): ForeignResult = {\n        val aId = internTable.stringToId.getOrElse(\"a\", -1)\n        val bId = internTable.stringToId.getOrElse(\"b\", -1)\n        args(0) match {\n          case Atom(id) if id == aId => ForeignBindings(Map(2 -> Atom(bId)))\n          case _                     => ForeignFail\n        }\n      }\n    }".
+
+foreign_multi_handler(Code) :-
+    Code = "new ForeignHandler {\n      def apply(args: Array[WamTerm]): ForeignResult = {\n        val aId = internTable.stringToId.getOrElse(\"a\", -1)\n        val bId = internTable.stringToId.getOrElse(\"b\", -1)\n        args(0) match {\n          case Atom(id) if id == aId =>\n            ForeignMulti(Seq(\n              Map(2 -> Atom(aId)),\n              Map(2 -> Atom(bId))\n            ))\n          case _ => ForeignFail\n        }\n      }\n    }".


### PR DESCRIPTION
## Summary

Six new smoke tests bring end-to-end coverage to all of *Milestone A:
baseline hybrid WAM* (`docs/proposals/WAM_SCALA_HYBRID_IMPL_PLAN.md`,
phases S1–S4) and *Milestone B*'s first phase (S5, foreign predicates).
The new tests exposed several latent runtime bugs that this PR also
fixes. After this PR the WAM Scala target executes single-clause facts,
multi-clause backtracking, hard cut, list round-trips, and three flavors
of foreign predicate (boolean / binding / multi-solution) end-to-end via
`scalac` + `scala`.

Test counts after this PR: 10 generator tests, 15 e2e smoke tests
(was 10 + 9).

## What's in the diff

### S3+S4 lockdown — three new smoke tests in `tests/test_wam_scala_runtime_smoke.pl`

| Test | Exercises |
|---|---|
| `hard_cut` | `builtin_call !/0, 0` via both `wam_cut_first(a) :- !.` directly and `wam_cut_caller` which calls a cut-bearing inner across an allocate/deallocate frame. |
| `list_match` | `get_list`, `unify_constant`, `unify_variable`, and `get_structure [|]/2` (nested cons cell). |
| `list_build` | `put_list`, `set_constant`, `set_variable`, and `put_structure [|]/2`. |

### S5 foreign predicate integration — three new smoke tests

| Test | Handler shape |
|---|---|
| `foreign_boolean` | Returns `ForeignSucceed` / `ForeignFail` based on `args(0)`. |
| `foreign_binding` | Returns `ForeignBindings(Map(reg -> term))` to bind output reg. |
| `foreign_multi` | Returns `ForeignMulti(Seq(sol1, sol2))` and exercises the runtime backtracking from the first solution into the second on unification conflict. |

Wiring in `src/unifyweaver/targets/wam_scala_target.pl`:

- New option `scala_foreign_handlers([handler(P/A, "<scala expr>"), ...])`
  rendered into the generated `foreignHandlers` Map literal via
  `scala_foreign_handlers_code/2`.
- New option `intern_atoms([a, b, ...])` so user-supplied handler bodies
  can reference atoms by name even when no WAM body mentions them
  (otherwise unknown atoms collapse to id `-1` and become
  indistinguishable from each other).

### Bug fixes exposed by the new tests

These were latent in the prior PR — the structure of the smoke tests
just hadn't reached them yet.

**List cons functor inconsistency** (caught by `list_match`/`list_build`):

The runtime had `PutList`/`GetList` use sentinel functor id `-1` while
`PutStructure([|]/2,...)`/`GetStructure([|]/2,...)` used `intern("[|]")`.
The same WAM body for `[a,b]` mixes both opcodes — outer cons uses
`get_list`, nested cons uses `get_structure [|]/2` — so list round-trips
silently failed to unify. The program-template CLI parser also built
lists with functor `.` while the WAM builds them with `[|]`. Fixed by:
- pre-interning `[|]` at well-known id 5;
- threading the cons functor id through `PutList(reg, functorId)` and
  `GetList(reg, functorId)`, populated at codegen time;
- pointing `parseList` at `[|]` instead of `.`.

**Foreign handler forward reference** (latent NPE):

`sharedProgram` referenced `foreignHandlers` before that `val` was
defined. Resolved to `null` at init; never bit before because no smoke
test invoked a foreign handler. Reorder so `foreignHandlers` is defined
ahead of `sharedProgram`.

**Foreign stub fell through** (caught by `foreign_boolean`):

The foreign predicate stub emitted only `CallForeign`, no trailing
`Proceed`. After `ForeignSucceed`, pc advanced into the *next*
predicate's first instruction and re-executed it as if the foreign
body continued — manifesting as either infinite loops or spurious
successes. Added a trailing `Proceed`.

**Foreign-after-non-foreign mis-PC** (latent):

`compile_all_predicates`' foreign branch used `[FLit | InstrAcc]` —
prepending the foreign instruction to the running accumulator. That
worked only when the accumulator was empty (foreign was the *first*
predicate). Switched to `append/3` to match the non-foreign branch and
keep PCs aligned with labels.

**`applyBindings` failure not propagated** (caught by `foreign_multi`):

Wrote `s.status = Failed` on a unify conflict, but no caller checked
status afterward. Foreign multi-solution failures on the first solution
never backtracked into the next. Reworked `applyBindings` to return a
`Boolean` (and short-circuit on first conflict). Updated callers
(`executeForeign` and the `ForeignCP` path in `backtrack`) to call
`backtrack(s)` on `false`.

### Test harness

`with_scala_project/4`'s second arg now flows extra options
(`foreign_predicates` / `scala_foreign_handlers` / `intern_atoms`)
through to `write_wam_scala_project/3`. Existing tests pass an unbound
var there; the helper treats unbound as the empty list for back-compat.

## Test plan

- [ ] `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_generator.pl"),run_tests,halt' -t 'halt(1)'` → 10/10 pass.
- [ ] With `scalac` on PATH or `SCALA_SMOKE_TESTS=1`:
      `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_runtime_smoke.pl"),run_tests,halt' -t 'halt(1)'` → 15/15 pass.
- [ ] Without `scalac`: smoke unit reports "No tests to run" (gated by `scala_available/0`).

## Out of scope

- Phase S6 streamed foreign solutions with cut interactions (the
  multi-solution path here covers the simple two-solution backtrack
  case — the deeper cut-vs-foreign-CP cases stay for S6).
- Arithmetic builtins (`is/2`, comparisons): the WAM compiler emits
  `builtin_call is/2, 2` but the Scala runtime's `BuiltinCall` doesn't
  yet evaluate it. Out of scope for this PR — the plan defers
  arithmetic to phases that need it.
- Phases S7 (fact backend seam), S8 (LMDB/JVM seam), S9 (benchmarks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
