### PR TITLE
bench(csharp-query): Expose C# query source-mode control in generated benchmark runners

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -437,7 +437,7 @@ Tables:
 | `benchmark_dependency_depth_cross_target.py` | Compare synthetic dependency reach-count across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_longest_depth_cross_target.py` | Compare true DAG longest dependency-chain depth across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
-| `benchmark_scan_materialization.py` | Exercise relation scan, pattern scan, join, negation, and aggregate under the scan materialization planner |
+| `benchmark_scan_materialization.py` | Exercise relation scan, pattern scan, join, negation, and aggregate under the scan materialization planner; use the `join` mode when you need concrete artifact bucket join strategy rows |
 | `benchmark_closure_materialization.py` | Exercise generic seeded closure and streamed auxiliary accumulation under the closure materialization planner |
 | `benchmark_closure_pair_planning.py` | Exercise seeded and grouped closure-pair workloads under the closure-pair strategy planner |
 | `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive, non-negative, and fallback weighted paths |
@@ -1016,6 +1016,14 @@ Comparison note:
 - cross-target runners summarize those generated metrics as
   `csharp-query-bucket-strategies` rows when `UNIFYWEAVER_BENCH_TRACE=1`
   captures any concrete bucket strategies
+- most generated cross-target workloads use specialized DAG, weight-sum,
+  or path-min runtime nodes rather than direct `KeyJoinNode` plans; forcing
+  `--csharp-query-source-mode artifact-prebuilt` enables artifact-backed
+  relation access but does not by itself guarantee a bucket-join trace row
+- generated `csharp-query` cross-target runners accept
+  `--csharp-query-source-mode auto|preload|delimited|artifact|artifact-prebuilt`;
+  non-`auto` runs include `csharp_query_source_mode=<mode>` in the
+  `csharp-query-metrics` row and use a runner-managed artifact directory
 - cache reuse remains disabled for these one-shot generated benchmark
   programs, and trace creation is now opt-in rather than always-on
 - the hand-written C# DFS baseline is still cheaper after its lighter

--- a/examples/benchmark/benchmark_category_influence_cross_target.py
+++ b/examples/benchmark/benchmark_category_influence_cross_target.py
@@ -19,6 +19,9 @@ from benchmark_common import (
     build_csharp_package,
     build_go_binary,
     build_rust_binary,
+    add_csharp_query_source_mode_arg,
+    append_csharp_query_source_mode_metric,
+    csharp_query_env,
     digest_normalized_output,
     find_result,
     group_results_by_scale,
@@ -64,6 +67,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--keep-temp", action="store_true")
+    add_csharp_query_source_mode_arg(parser)
     return parser.parse_args()
 
 
@@ -109,7 +113,14 @@ def normalize_output(output: str) -> str:
     return normalize_two_column_float_rows(output, decimals=9, descending_numeric=True)
 
 
-def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
+def benchmark_target(
+    command: list[str],
+    scale: str,
+    repetitions: int,
+    target: str,
+    csharp_query_source_mode: str = "auto",
+    artifact_dir: Path | None = None,
+) -> RunResult:
     scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
     edge_path = scale_dir / "category_parent.tsv"
     article_path = scale_dir / "article_category.tsv"
@@ -121,11 +132,18 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
         started = time.perf_counter()
         if target == "prolog-accumulated":
             result = run_command(command, cwd=ROOT)
+        elif target == "csharp-query":
+            result = run_command(
+                command + [str(edge_path), str(article_path)],
+                env=csharp_query_env(csharp_query_source_mode, artifact_dir),
+            )
         else:
             result = run_command(command + [str(edge_path), str(article_path)])
         times.append(time.perf_counter() - started)
         stdout = result.stdout
         stderr = result.stderr
+        if target == "csharp-query":
+            stderr = append_csharp_query_source_mode_metric(stderr, csharp_query_source_mode)
 
     normalized = normalize_output(stdout)
     digest, row_count = digest_normalized_output(normalized)
@@ -191,7 +209,17 @@ def main() -> int:
                 commands["prolog-accumulated"] = build_prolog_accumulated(temp_root, scale)
 
             for target in targets:
-                results.append(benchmark_target(commands[target], scale, args.repetitions, target))
+                artifact_dir = temp_root / "artifacts" / target / scale if target == "csharp-query" else None
+                results.append(
+                    benchmark_target(
+                        commands[target],
+                        scale,
+                        args.repetitions,
+                        target,
+                        args.csharp_query_source_mode,
+                        artifact_dir,
+                    )
+                )
 
         print_summary(results)
         return 0

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -27,6 +27,37 @@ def run_command(
     )
 
 
+def csharp_query_env(source_mode: str | None = None, artifact_dir: Path | None = None) -> dict[str, str]:
+    env = dict(os.environ)
+    selected_source_mode = source_mode or "auto"
+    env["UNIFYWEAVER_RELATION_SOURCE_MODE"] = selected_source_mode
+    if selected_source_mode in {"artifact", "artifact-prebuilt"} and artifact_dir is not None:
+        env["UNIFYWEAVER_RELATION_ARTIFACT_DIR"] = str(artifact_dir)
+    else:
+        env.pop("UNIFYWEAVER_RELATION_ARTIFACT_DIR", None)
+    return env
+
+
+def csharp_query_source_mode_choices() -> list[str]:
+    return ["auto", "preload", "delimited", "artifact", "artifact-prebuilt"]
+
+
+def add_csharp_query_source_mode_arg(parser) -> None:
+    parser.add_argument(
+        "--csharp-query-source-mode",
+        default="auto",
+        choices=csharp_query_source_mode_choices(),
+        help="Relation source mode for csharp-query runs.",
+    )
+
+
+def append_csharp_query_source_mode_metric(stderr: str, source_mode: str | None) -> str:
+    selected_source_mode = source_mode or "auto"
+    if selected_source_mode == "auto":
+        return stderr
+    return stderr.rstrip() + f"\ncsharp_query_source_mode={selected_source_mode}\n"
+
+
 def require_file(path: Path) -> Path:
     if not path.exists():
         raise FileNotFoundError(path)

--- a/examples/benchmark/benchmark_dependency_depth_cross_target.py
+++ b/examples/benchmark/benchmark_dependency_depth_cross_target.py
@@ -19,6 +19,9 @@ from benchmark_common import (
     build_csharp_package,
     build_go_binary,
     build_rust_binary,
+    add_csharp_query_source_mode_arg,
+    append_csharp_query_source_mode_metric,
+    csharp_query_env,
     digest_normalized_output,
     find_result,
     group_results_by_scale,
@@ -63,6 +66,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--keep-temp", action="store_true")
+    add_csharp_query_source_mode_arg(parser)
     return parser.parse_args()
 
 
@@ -105,7 +109,15 @@ def build_go_dfs(root: Path, facts_path: Path) -> list[str]:
     )
 
 
-def benchmark_target(command: list[str], dataset_dir: Path, repetitions: int, target: str, scale: str) -> RunResult:
+def benchmark_target(
+    command: list[str],
+    dataset_dir: Path,
+    repetitions: int,
+    target: str,
+    scale: str,
+    csharp_query_source_mode: str = "auto",
+    artifact_dir: Path | None = None,
+) -> RunResult:
     edge_path = require_file(dataset_dir / "category_parent.tsv")
     article_path = require_file(dataset_dir / "article_category.tsv")
 
@@ -114,10 +126,13 @@ def benchmark_target(command: list[str], dataset_dir: Path, repetitions: int, ta
     stderr = ""
     for _ in range(repetitions):
         started = time.perf_counter()
-        result = run_command(command + [str(edge_path), str(article_path)])
+        env = csharp_query_env(csharp_query_source_mode, artifact_dir) if target == "csharp-query" else None
+        result = run_command(command + [str(edge_path), str(article_path)], env=env)
         times.append(time.perf_counter() - started)
         stdout = result.stdout
         stderr = result.stderr
+        if target == "csharp-query":
+            stderr = append_csharp_query_source_mode_metric(stderr, csharp_query_source_mode)
 
     digest, row_count = digest_normalized_output(normalize_sorted_lines(stdout))
     return RunResult(target, scale, times, digest, row_count, stderr)
@@ -180,7 +195,18 @@ def main() -> int:
         for scale in scales:
             dataset_dir = build_dataset(temp_root, scale)
             for target in targets:
-                results.append(benchmark_target(commands[target], dataset_dir, args.repetitions, target, scale))
+                artifact_dir = temp_root / "artifacts" / target / scale if target == "csharp-query" else None
+                results.append(
+                    benchmark_target(
+                        commands[target],
+                        dataset_dir,
+                        args.repetitions,
+                        target,
+                        scale,
+                        args.csharp_query_source_mode,
+                        artifact_dir,
+                    )
+                )
 
         print_summary(results)
         return 0

--- a/examples/benchmark/benchmark_dependency_longest_depth_cross_target.py
+++ b/examples/benchmark/benchmark_dependency_longest_depth_cross_target.py
@@ -19,6 +19,9 @@ from benchmark_common import (
     build_csharp_package,
     build_go_binary,
     build_rust_binary,
+    add_csharp_query_source_mode_arg,
+    append_csharp_query_source_mode_metric,
+    csharp_query_env,
     digest_normalized_output,
     find_result,
     group_results_by_scale,
@@ -63,6 +66,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--keep-temp", action="store_true")
+    add_csharp_query_source_mode_arg(parser)
     return parser.parse_args()
 
 
@@ -105,7 +109,15 @@ def build_go_dfs(root: Path, facts_path: Path) -> list[str]:
     )
 
 
-def benchmark_target(command: list[str], dataset_dir: Path, repetitions: int, target: str, scale: str) -> RunResult:
+def benchmark_target(
+    command: list[str],
+    dataset_dir: Path,
+    repetitions: int,
+    target: str,
+    scale: str,
+    csharp_query_source_mode: str = "auto",
+    artifact_dir: Path | None = None,
+) -> RunResult:
     edge_path = require_file(dataset_dir / "category_parent.tsv")
     article_path = require_file(dataset_dir / "article_category.tsv")
 
@@ -114,10 +126,13 @@ def benchmark_target(command: list[str], dataset_dir: Path, repetitions: int, ta
     stderr = ""
     for _ in range(repetitions):
         started = time.perf_counter()
-        result = run_command(command + [str(edge_path), str(article_path)])
+        env = csharp_query_env(csharp_query_source_mode, artifact_dir) if target == "csharp-query" else None
+        result = run_command(command + [str(edge_path), str(article_path)], env=env)
         times.append(time.perf_counter() - started)
         stdout = result.stdout
         stderr = result.stderr
+        if target == "csharp-query":
+            stderr = append_csharp_query_source_mode_metric(stderr, csharp_query_source_mode)
 
     digest, row_count = digest_normalized_output(normalize_sorted_lines(stdout))
     return RunResult(target, scale, times, digest, row_count, stderr)
@@ -183,7 +198,18 @@ def main() -> int:
         for scale in scales:
             dataset_dir = build_dataset(temp_root, scale)
             for target in targets:
-                results.append(benchmark_target(commands[target], dataset_dir, args.repetitions, target, scale))
+                artifact_dir = temp_root / "artifacts" / target / scale if target == "csharp-query" else None
+                results.append(
+                    benchmark_target(
+                        commands[target],
+                        dataset_dir,
+                        args.repetitions,
+                        target,
+                        scale,
+                        args.csharp_query_source_mode,
+                        artifact_dir,
+                    )
+                )
 
         print_summary(results)
         return 0

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -32,6 +32,9 @@ from benchmark_common import (
     build_go_binary,
     build_haskell_project,
     build_rust_binary,
+    add_csharp_query_source_mode_arg,
+    append_csharp_query_source_mode_metric,
+    csharp_query_env,
     digest_normalized_output,
     find_result,
     group_results_by_scale,
@@ -97,6 +100,7 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Keep the temporary build directory for inspection",
     )
+    add_csharp_query_source_mode_arg(parser)
     return parser.parse_args()
 
 
@@ -278,7 +282,14 @@ def build_haskell_wam_effective_distance(root: Path, scale: str, variant: str) -
     return command
 
 
-def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
+def benchmark_target(
+    command: list[str],
+    scale: str,
+    repetitions: int,
+    target: str,
+    csharp_query_source_mode: str = "auto",
+    artifact_dir: Path | None = None,
+) -> RunResult:
     times: list[float] = []
     last_stdout = ""
     last_stderr = ""
@@ -290,11 +301,14 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
             scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
             edge_path = scale_dir / "category_parent.tsv"
             article_path = scale_dir / "article_category.tsv"
-            result = run_command(command + [str(edge_path), str(article_path)])
+            env = csharp_query_env(csharp_query_source_mode, artifact_dir) if target == "csharp-query" else None
+            result = run_command(command + [str(edge_path), str(article_path)], env=env)
         elapsed = time.perf_counter() - started
         times.append(elapsed)
         last_stdout = result.stdout
         last_stderr = result.stderr
+        if target == "csharp-query":
+            last_stderr = append_csharp_query_source_mode_metric(last_stderr, csharp_query_source_mode)
 
     normalized = normalize_three_column_float_rows(last_stdout, decimals=6)
     digest, rows = digest_normalized_output(normalized)
@@ -537,7 +551,17 @@ def main() -> int:
                     command = build_prolog_effective_semantic(temp_root, scale)
                 else:
                     command = commands[target]
-                results.append(benchmark_target(command, scale, args.repetitions, target))
+                artifact_dir = temp_root / "artifacts" / target / scale if target == "csharp-query" else None
+                results.append(
+                    benchmark_target(
+                        command,
+                        scale,
+                        args.repetitions,
+                        target,
+                        args.csharp_query_source_mode,
+                        artifact_dir,
+                    )
+                )
 
         print_summary(results)
         if args.keep_temp:

--- a/examples/benchmark/benchmark_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_shortest_path_cross_target.py
@@ -19,6 +19,9 @@ from benchmark_common import (
     build_csharp_package,
     build_go_binary,
     build_rust_binary,
+    add_csharp_query_source_mode_arg,
+    append_csharp_query_source_mode_metric,
+    csharp_query_env,
     digest_normalized_output,
     find_result,
     group_results_by_scale,
@@ -65,6 +68,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--keep-temp", action="store_true")
+    add_csharp_query_source_mode_arg(parser)
     return parser.parse_args()
 
 
@@ -124,7 +128,14 @@ def print_head_to_head(scale: str, left: RunResult | None, right: RunResult | No
         print(f"{scale}\t{label}_speedup\t{slower.median / faster.median:.2f}x")
 
 
-def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
+def benchmark_target(
+    command: list[str],
+    scale: str,
+    repetitions: int,
+    target: str,
+    csharp_query_source_mode: str = "auto",
+    artifact_dir: Path | None = None,
+) -> RunResult:
     times: list[float] = []
     stdout = ""
     stderr = ""
@@ -136,10 +147,13 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
             scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
             edge_path = scale_dir / "category_parent.tsv"
             article_path = scale_dir / "article_category.tsv"
-            result = run_command(command + [str(edge_path), str(article_path)])
+            env = csharp_query_env(csharp_query_source_mode, artifact_dir) if target == "csharp-query" else None
+            result = run_command(command + [str(edge_path), str(article_path)], env=env)
         times.append(time.perf_counter() - started)
         stdout = result.stdout
         stderr = result.stderr
+        if target == "csharp-query":
+            stderr = append_csharp_query_source_mode_metric(stderr, csharp_query_source_mode)
 
     normalized = normalize_output(stdout)
     digest, row_count = digest_normalized_output(normalized)
@@ -207,7 +221,17 @@ def main() -> int:
                     command = build_prolog_min(temp_root, scale)
                 else:
                     command = commands[target]
-                results.append(benchmark_target(command, scale, args.repetitions, target))
+                artifact_dir = temp_root / "artifacts" / target / scale if target == "csharp-query" else None
+                results.append(
+                    benchmark_target(
+                        command,
+                        scale,
+                        args.repetitions,
+                        target,
+                        args.csharp_query_source_mode,
+                        artifact_dir,
+                    )
+                )
 
         print_summary(results)
         return 0

--- a/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
@@ -19,6 +19,9 @@ from benchmark_common import (
     build_csharp_package,
     build_go_binary,
     build_rust_binary,
+    add_csharp_query_source_mode_arg,
+    append_csharp_query_source_mode_metric,
+    csharp_query_env,
     digest_normalized_output,
     find_result,
     group_results_by_scale,
@@ -65,6 +68,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--keep-temp", action="store_true")
+    add_csharp_query_source_mode_arg(parser)
     return parser.parse_args()
 
 
@@ -124,7 +128,14 @@ def print_head_to_head(scale: str, left: RunResult | None, right: RunResult | No
         print(f"{scale}\t{label}_speedup\t{slower.median / faster.median:.2f}x")
 
 
-def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
+def benchmark_target(
+    command: list[str],
+    scale: str,
+    repetitions: int,
+    target: str,
+    csharp_query_source_mode: str = "auto",
+    artifact_dir: Path | None = None,
+) -> RunResult:
     times: list[float] = []
     stdout = ""
     stderr = ""
@@ -136,10 +147,13 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
             scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
             edge_path = scale_dir / "category_parent.tsv"
             article_path = scale_dir / "article_category.tsv"
-            result = run_command(command + [str(edge_path), str(article_path)])
+            env = csharp_query_env(csharp_query_source_mode, artifact_dir) if target == "csharp-query" else None
+            result = run_command(command + [str(edge_path), str(article_path)], env=env)
         times.append(time.perf_counter() - started)
         stdout = result.stdout
         stderr = result.stderr
+        if target == "csharp-query":
+            stderr = append_csharp_query_source_mode_metric(stderr, csharp_query_source_mode)
 
     normalized = normalize_output(stdout)
     digest, row_count = digest_normalized_output(normalized)
@@ -207,7 +221,17 @@ def main() -> int:
                     command = build_prolog_min(temp_root, scale)
                 else:
                     command = commands[target]
-                results.append(benchmark_target(command, scale, args.repetitions, target))
+                artifact_dir = temp_root / "artifacts" / target / scale if target == "csharp-query" else None
+                results.append(
+                    benchmark_target(
+                        command,
+                        scale,
+                        args.repetitions,
+                        target,
+                        args.csharp_query_source_mode,
+                        artifact_dir,
+                    )
+                )
 
         print_summary(results)
         return 0


### PR DESCRIPTION
  ## Summary

  - add shared C# query benchmark helpers for `UNIFYWEAVER_RELATION_SOURCE_MODE` and artifact-dir env setup
  - expose `--csharp-query-source-mode auto|preload|delimited|artifact|artifact-prebuilt` across generated cross-target
  benchmark runners
  - report non-`auto` source modes in `csharp-query-metrics`
  - document that specialized generated workloads may use artifact-backed access without emitting `KeyJoinNode` bucket-
  strategy rows

  ## Validation

  - `python3 -m py_compile` for touched benchmark runners
  - `git diff --check`
  - helper assertions for `auto`, `preload`, and `artifact-prebuilt`
  - traced `benchmark_category_influence_cross_target.py` C# query smoke with `artifact-prebuilt`
  - `benchmark_scan_materialization.py --modes join --source-modes artifact-prebuilt`
  - `--help` sweep across generated cross-target runners