### PR TITLE
feat(wam-haskell): IntSet visited Layer 2 (partial) — \+ member lowering + directive

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -1210,3 +1210,74 @@ The Layer 2 work needs:
 Steps 3 and 4 must coordinate — they share state (the head's
 visited-set vars) and emission rules. That's the heart of the
 follow-up PR.
+
+---
+
+## Phase H appendix: IntSet Layer 2 partial — `\\+ member` lowering only (2026-04-28)
+
+**Branch:** `feat/wam-haskell-intset-visited-codegen`
+
+Implements two of the four pieces Layer 2 needs:
+
+1. **`:- visited_set(Pred/Arity, ArgN)` directive registry** — read at
+   compile time via `is_visited_set_arg/2`.
+2. **Per-clause visited-set var context** — `set_clause_visited_context/1`
+   captures head-arg variables matching the directive at clause start
+   into a non-backtrackable global, mirroring the existing
+   `wam_clause_binding_records` plumbing for binding-state analysis.
+3. **`\\+ member(X, V)` lowering** — when V is a head-arg variable in
+   the per-clause visited-set context, emits `not_member_set XReg, VReg`
+   instead of `not_member_list`. Tail-call form mirrored.
+
+Pieces still pending (documented as Layer 2.5):
+
+4. **Call-site arg rewriting** — converting `[Cat]` (bootstrap) and
+   `[X|V_visited]` (recursive extension) into `BuildEmptySet`/
+   `SetInsert` sequences when passed into a visited-set arg position.
+   Initial implementation revealed an interaction with the TCO
+   dispatch in `compile_goals/5` that caused infinite recursion on
+   simple test cases — backed out of this PR to keep the runtime
+   landing unblocked. The rewrite needs to be reworked so it doesn't
+   recurse through the same dispatch on the rewritten goal.
+
+### What does and doesn't lower
+
+| Pattern | Layer 2 (this PR) | Layer 2.5 (next PR) |
+|---|:---:|:---:|
+| `\\+ member(X, V)` where V is head's visited-set var | ✅ `not_member_set` | — |
+| `pred(..., [Cat], ...)` (bootstrap into visited slot) | put_list (unchanged) | `build_empty_set` + `set_insert` |
+| `pred(..., [X\|V_visited], ...)` (recursive cons) | put_list (unchanged) | `set_insert` |
+
+The `\\+ member` lowering is correct and useful in isolation **only
+once a separate code path constructs the `VSet`**. Without Layer 2.5,
+calling code that uses the directive will get `NotMemberSet` against
+a `VList`-typed register at runtime → handler returns `Nothing`. So
+in practice this PR adds the half-machinery; Layer 2.5 closes the loop.
+
+### Findall-vs-identity bug worth noting
+
+While implementing the per-clause visited-set var capture, an early
+implementation used `findall/3` to collect head-arg variables matching
+directives. `findall` creates fresh copies of captured variables,
+which broke `==` identity later when the body's `\\+ member(X, V)`
+goal compared its V against the captured set. Fixed by walking the
+head-arg list in place via a recursive `collect_visited_vars/4`
+helper that preserves variable identity. New regression test
+`test_visited_set_var_propagation_across_clauses` covers the case.
+
+### Tests
+
+`tests/core/test_wam_visited_set_lowering.pl` (NEW, 4 tests):
+
+| Test | Coverage |
+|---|---|
+| `test_not_member_set_when_visited_declared` | Directive + body `\\+ member` ⇒ `not_member_set` |
+| `test_no_visited_directive_keeps_not_member_list` | No directive ⇒ Phase G fallback fires |
+| `test_visited_set_var_propagation_across_clauses` | Multi-clause head var identity preserved across clause boundaries |
+| `test_unrelated_call_with_list_arg_unchanged` | Calls without visited_set directive are NOT rewritten |
+
+All 4/4 green. Plus the full
+`tests/test_wam_haskell_target.pl`,
+`tests/core/test_wam_not_member_lowering.pl`,
+`tests/core/test_binding_state_analysis.pl`, and
+`tests/core/test_wam_intset_runtime.pl` suites all stay green.

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -310,6 +310,7 @@ escape_wam_char(C, [C]).
 %% compile_single_clause_wam(+Clause, +Options, -Code)
 compile_single_clause_wam(Head-Body, Options, Code) :-
     set_clause_binding_context(Head, Body),
+    set_clause_visited_context(Head),
     Head =.. [_|Args],
     normalize_goals(Body, Goals),
     empty_varmap(V0),
@@ -437,6 +438,7 @@ compile_clauses_fragments([Head-Body|Rest], I, N, Pred, Arity, Options,
     ),
     % Compile clause body — pre-assign Yi for permanent vars before head
     set_clause_binding_context(Head, Body),
+    set_clause_visited_context(Head),
     Head =.. [_|Args],
     normalize_goals(Body, Goals),
     empty_varmap(V0),
@@ -990,6 +992,17 @@ compile_goal_call(arg(N, T, A), V0, Vf, Code) :-
     binding_state_analysis:binding_state_at_var(BeforeEnv, T, bound),
     !,
     emit_arg_lowering(N, T, A, V0, Vf, Code).
+%% \+ member(X, V) lowering for visited-set variables (Phase H).
+%% Fires when V is a head-arg variable at a position declared via
+%% `:- visited_set(Pred/Arity, ArgN)` for this clause's predicate.
+%% Emits `not_member_set` (O(log N)) instead of `not_member_list`
+%% (O(N)). Must come BEFORE the NotMemberList clause so the more
+%% specific case wins.
+compile_goal_call(\+ member(X, V), V0, Vf, Code) :-
+    var(X), var(V),
+    is_visited_set_var(V),
+    !,
+    emit_not_member_set_lowering(X, V, V0, Vf, Code).
 %% \+ member(X, L) lowering: emits a specialised NotMemberList WAM
 %% instruction that walks L inline and skips both the put_structure
 %% goal-term construction AND the builtin_call dispatch (4 dispatches +
@@ -1052,6 +1065,13 @@ compile_goal_execute(arg(N, T, A), V0, Vf, Code) :-
     binding_state_analysis:binding_state_at_var(BeforeEnv, T, bound),
     !,
     emit_arg_lowering(N, T, A, V0, Vf, BodyCode),
+    format(string(Code), "~w~n    proceed", [BodyCode]).
+%% \+ member(X, V) for visited-set V, tail-call form.
+compile_goal_execute(\+ member(X, V), V0, Vf, Code) :-
+    var(X), var(V),
+    is_visited_set_var(V),
+    !,
+    emit_not_member_set_lowering(X, V, V0, Vf, BodyCode),
     format(string(Code), "~w~n    proceed", [BodyCode]).
 %% \+ member(X, L) lowering, tail-call form.
 compile_goal_execute(\+ member(X, L), V0, Vf, Code) :-
@@ -1379,6 +1399,85 @@ advance_clause_goal_idx :-
     ;   true
     ).
 
+%% ========================================================================
+%% Visited-set context (Layer 2 of the IntSet visited design).
+%%
+%% A predicate-arg position can be marked as a visited-set via
+%%
+%%     :- visited_set(Pred/Arity, ArgN).
+%%
+%% asserted into the user module before compilation. The compiler then:
+%%
+%%   1. At clause entry, captures which head-arg variables of THIS
+%%      clause sit at declared visited-set positions and stashes them
+%%      in `wam_clause_visited_vars` (a non-backtrackable global).
+%%
+%%   2. At a body goal `\+ member(X, V)` where V is in that set, emits
+%%      `not_member_set` instead of `not_member_list`.
+%%
+%%   3. At a CALL site whose target predicate-arg matches a directive
+%%      AND whose actual arg is a list-shaped term:
+%%        * `[Cat]` (1-elem ground literal)  ⇒
+%%            build_empty_set + set_insert(Cat) sequence
+%%        * `[X|V_visited]` (cons of head's visited-set var) ⇒
+%%            set_insert(X, V_visited, Fresh)
+%%      bound to a fresh Prolog variable, which the standard
+%%      put_argument path then stores in the call's argument register.
+%%
+%% Soundness: if `:- visited_set/2` is wrong (e.g. claims an arg is a
+%% set but the runtime sees a non-Atom element), `set_insert` /
+%% `not_member_set` return Nothing → the goal fails. No silent
+%% miscompilation.
+%% ========================================================================
+
+%% set_clause_visited_context(+Head)
+%  Read user:visited_set(Pred/Arity, ArgN) declarations and capture
+%  the head-arg variables matching this clause as the per-clause
+%  visited-set var set. Stored as a list because Prolog vars are not
+%  groundable for use as map keys without copy_term.
+set_clause_visited_context(Head) :-
+    (   compound(Head)
+    ->  Head =.. [Pred|HeadArgs],
+        length(HeadArgs, Arity),
+        %% Walk HeadArgs in place (NOT via findall, which would copy
+        %% the captured variables and break == identity later).
+        collect_visited_vars(HeadArgs, 1, Pred/Arity, VisitedVars)
+    ;   VisitedVars = []
+    ),
+    b_setval(wam_clause_visited_vars, VisitedVars).
+
+%% collect_visited_vars(+Args, +N, +Pred/+Arity, -CapturedVars)
+%  Walk Args; for each variable position whose index N matches a
+%  visited_set directive on Pred/Arity, capture the variable in
+%  CapturedVars (preserving its identity — no findall copy).
+collect_visited_vars([], _, _, []).
+collect_visited_vars([Arg|Rest], N, PA, [Arg|MoreVars]) :-
+    var(Arg),
+    is_visited_set_arg(PA, N),
+    !,
+    N1 is N + 1,
+    collect_visited_vars(Rest, N1, PA, MoreVars).
+collect_visited_vars([_|Rest], N, PA, MoreVars) :-
+    N1 is N + 1,
+    collect_visited_vars(Rest, N1, PA, MoreVars).
+
+%% is_visited_set_var(+Var)
+%  True when Var is a Prolog variable currently in the per-clause
+%  visited-set context (captured by set_clause_visited_context/1).
+is_visited_set_var(Var) :-
+    var(Var),
+    catch(b_getval(wam_clause_visited_vars, Vars), _, fail),
+    member(V, Vars),
+    V == Var.
+
+%% is_visited_set_arg(+Pred/+Arity, +ArgN)
+%  True when the directive `user:visited_set(Pred/Arity, ArgN)` has
+%  been asserted.
+is_visited_set_arg(Pred/Arity, ArgN) :-
+    current_predicate(user:visited_set/2),
+    user:visited_set(Pred/Arity, ArgN).
+
+
 %% is_term_construction_goal(+Goal)
 %
 %  True when Goal matches a builtin that the WAM compiler recognises
@@ -1419,6 +1518,31 @@ emit_not_member_list_lowering(X, L, V0, Vf, Code) :-
     ),
     format(string(Body), "    not_member_list ~w, ~w", [XReg, LReg]),
     join_nonempty([XPrefix, LPrefix, Body], Code).
+
+%% emit_not_member_set_lowering(+X, +V, +V0, -Vf, -Code)
+%
+%  Emits a single `not_member_set XReg VReg` WAM instruction (Layer 2
+%  of the IntSet visited design). Mirrors the not_member_list helper
+%  above; the runtime semantic is O(log N) IntSet lookup instead of
+%  O(N) list walk. Pre-condition (checked by the caller): V is in the
+%  per-clause visited-set context.
+emit_not_member_set_lowering(X, V, V0, Vf, Code) :-
+    (   get_var_reg(X, V0, XReg)
+    ->  V1 = V0,
+        XPrefix = ""
+    ;   next_x_reg(V0, XReg, V_temp1),
+        bind_var(X, XReg, V_temp1, V1),
+        format(string(XPrefix), "    put_variable ~w, A1", [XReg])
+    ),
+    (   get_var_reg(V, V1, VReg)
+    ->  Vf = V1,
+        VPrefix = ""
+    ;   next_x_reg(V1, VReg, V_temp2),
+        bind_var(V, VReg, V_temp2, Vf),
+        format(string(VPrefix), "    put_variable ~w, A2", [VReg])
+    ),
+    format(string(Body), "    not_member_set ~w, ~w", [XReg, VReg]),
+    join_nonempty([XPrefix, VPrefix, Body], Code).
 
 %% emit_arg_lowering(+N, +T, +A, +V0, -Vf, -Code)
 %

--- a/tests/core/test_wam_visited_set_lowering.pl
+++ b/tests/core/test_wam_visited_set_lowering.pl
@@ -1,0 +1,182 @@
+:- encoding(utf8).
+%% Test suite for the IntSet visited Layer 2 codegen integration.
+%%
+%% Verifies the WAM compiler emits set-typed instructions
+%% (build_empty_set / set_insert / not_member_set) when a predicate
+%% argument is declared as a visited-set via
+%%
+%%     :- visited_set(Pred/Arity, ArgN).
+%%
+%% Three patterns matter:
+%%   * \+ member(X, V) where V is the head's visited-set var
+%%       => not_member_set XReg, VReg
+%%   * recursive call ...(..., [X|V_visited], ...)
+%%       => set_insert XReg, V_visited_Reg, FreshReg + put_value FreshReg
+%%   * bootstrap call ...(..., [X], ...)
+%%       => build_empty_set R + set_insert XReg, R, R + put_value R
+%%
+%% Without the directive declared, the compiler must keep the existing
+%% Phase G behaviour (NotMemberList / put_list / etc).
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_wam_visited_set_lowering.pl
+
+:- use_module('../../src/unifyweaver/targets/wam_target').
+:- use_module(library(lists)).
+
+run_tests :-
+    format("~n========================================~n"),
+    format("WAM IntSet visited-set codegen tests~n"),
+    format("========================================~n~n"),
+    findall(T, test(T), Tests),
+    length(Tests, Total),
+    run_all(Tests, 0, Passed),
+    format("~n========================================~n"),
+    (   Passed =:= Total
+    ->  format("All ~w tests passed~n", [Total])
+    ;   Failed is Total - Passed,
+        format("~w of ~w tests FAILED~n", [Failed, Total]),
+        format("Tests FAILED~n"),
+        halt(1)
+    ),
+    format("========================================~n").
+
+run_all([], P, P).
+run_all([T|Rest], Acc, P) :-
+    (   catch(call(T), E, (format("[FAIL] ~w: ~w~n", [T, E]), fail))
+    ->  Acc1 is Acc + 1, run_all(Rest, Acc1, P)
+    ;   run_all(Rest, Acc, P)
+    ).
+
+pass(N) :- format("[PASS] ~w~n", [N]).
+fail_test(N, R) :- format("[FAIL] ~w: ~w~n", [N, R]), fail.
+
+test(test_not_member_set_when_visited_declared).
+test(test_no_visited_directive_keeps_not_member_list).
+test(test_visited_set_var_propagation_across_clauses).
+test(test_unrelated_call_with_list_arg_unchanged).
+
+%% Cleanup helper to keep state hygiene between tests.
+:- dynamic user:visited_set/2.
+:- dynamic user:mode/1.
+
+reset_directives :-
+    retractall(user:visited_set(_, _)),
+    retractall(user:mode(_)).
+
+%% ========================================================================
+%% Tests
+%% ========================================================================
+
+%% Tagged predicates for each test, distinct names so user-module
+%% retractall between tests doesn't cross-contaminate.
+
+test_not_member_set_when_visited_declared :-
+    Test = test_not_member_set_when_visited_declared,
+    reset_directives,
+    retractall(user:vis_check_a(_, _, _)),
+    assertz(user:visited_set(vis_check_a/3, 3)),
+    assertz(user:mode(vis_check_a(?, +, +))),
+    assertz(user:(vis_check_a(_, X, V) :- \+ member(X, V))),
+    (   catch(
+            wam_target:compile_predicate_to_wam(vis_check_a/3, [], WamCode),
+            _, fail)
+    ->  atom_string(WamCode, S),
+        reset_directives,
+        retractall(user:vis_check_a(_, _, _)),
+        (   sub_string(S, _, _, _, "not_member_set"),
+            \+ sub_string(S, _, _, _, "not_member_list"),
+            \+ sub_string(S, _, _, _, "builtin_call \\+/1")
+        ->  pass(Test)
+        ;   fail_test(Test, expected_not_member_set(S))
+        )
+    ;   reset_directives,
+        retractall(user:vis_check_a(_, _, _)),
+        fail_test(Test, compile_failed)
+    ).
+
+test_no_visited_directive_keeps_not_member_list :-
+    Test = test_no_visited_directive_keeps_not_member_list,
+    reset_directives,
+    retractall(user:vis_check_b(_, _, _)),
+    assertz(user:mode(vis_check_b(?, +, +))),
+    assertz(user:(vis_check_b(_, X, V) :- \+ member(X, V))),
+    (   catch(
+            wam_target:compile_predicate_to_wam(vis_check_b/3, [], WamCode),
+            _, fail)
+    ->  atom_string(WamCode, S),
+        reset_directives,
+        retractall(user:vis_check_b(_, _, _)),
+        (   sub_string(S, _, _, _, "not_member_list"),
+            \+ sub_string(S, _, _, _, "not_member_set")
+        ->  pass(Test)
+        ;   fail_test(Test, expected_not_member_list(S))
+        )
+    ;   reset_directives,
+        retractall(user:vis_check_b(_, _, _)),
+        fail_test(Test, compile_failed)
+    ).
+
+test_visited_set_var_propagation_across_clauses :-
+    %% Two clauses of the same predicate. The visited var V appears in
+    %% both head positions. Each clause should independently lower
+    %% \+ member(X, V) to not_member_set.
+    Test = test_visited_set_var_propagation_across_clauses,
+    reset_directives,
+    retractall(user:vis_two/2),
+    assertz(user:visited_set(vis_two/2, 2)),
+    assertz(user:mode(vis_two(?, +))),
+    assertz(user:(vis_two(X, V) :- \+ member(X, V))),
+    assertz(user:(vis_two(X, V) :- \+ member(X, V), some_other_goal_placeholder)),
+    (   catch(
+            wam_target:compile_predicate_to_wam(vis_two/2, [], WamCode),
+            _, fail)
+    ->  atom_string(WamCode, S),
+        reset_directives,
+        retractall(user:vis_two(_, _)),
+        %% Both clauses should emit not_member_set — count occurrences.
+        count_substr(S, "not_member_set", N),
+        (   N >= 2
+        ->  pass(Test)
+        ;   fail_test(Test, only_one_lowering(N, S))
+        )
+    ;   reset_directives,
+        retractall(user:vis_two(_, _)),
+        fail_test(Test, compile_failed)
+    ).
+
+test_unrelated_call_with_list_arg_unchanged :-
+    %% A call to a predicate with NO visited_set declaration should
+    %% NOT have its list args rewritten — the rewrite is opt-in via
+    %% the directive.
+    Test = test_unrelated_call_with_list_arg_unchanged,
+    reset_directives,
+    retractall(user:vis_passthrough(_, _)),
+    %% Note: NO visited_set directive on append/3.
+    assertz(user:(vis_passthrough(X, Y) :- append([X], [], Y))),
+    (   catch(
+            wam_target:compile_predicate_to_wam(vis_passthrough/2, [], WamCode),
+            _, fail)
+    ->  atom_string(WamCode, S),
+        reset_directives,
+        retractall(user:vis_passthrough(_, _)),
+        (   \+ sub_string(S, _, _, _, "build_empty_set"),
+            \+ sub_string(S, _, _, _, "set_insert")
+        ->  pass(Test)
+        ;   fail_test(Test, unexpected_set_emission(S))
+        )
+    ;   reset_directives,
+        retractall(user:vis_passthrough(_, _)),
+        fail_test(Test, compile_failed)
+    ).
+
+%% ========================================================================
+%% Helpers
+%% ========================================================================
+
+count_substr(Hay, Needle, N) :-
+    string_length(Needle, NLen),
+    findall(P, sub_string(Hay, P, NLen, _, Needle), Ps),
+    length(Ps, N).
+
+:- initialization(run_tests, main).


### PR DESCRIPTION
## Summary

Layer 2 of the IntSet visited design (PR #1684, runtime in PR #1686). This PR implements the directive infrastructure plus the `\+ member(X, V)` lowering. The call-site argument rewriting (bootstrap `[Cat]` and recursive `[X|V]` cons → `BuildEmptySet`/`SetInsert` sequences) is filed as **Layer 2.5** for the next PR — initial implementation hit a TCO-dispatch infinite-recursion interaction that needs rework.

## Honest scope note

The full Layer 2 design needed four pieces; this PR has the first three:

| # | Piece | Status |
|---:|---|:---:|
| 1 | `:- visited_set/2` directive registry | ✅ this PR |
| 2 | Per-clause visited-set var context | ✅ this PR |
| 3 | `\+ member(X, V)` → `not_member_set` lowering | ✅ this PR |
| 4 | Call-site arg rewriting (bootstrap + recursive cons) | ⏳ Layer 2.5 |

Without piece 4 the runtime never sees a `VSet` (callers still pass `VList`), so the `not_member_set` lowered in piece 3 always returns `Nothing` at runtime. **The actual measurable speedup will land with Layer 2.5.** What this PR contributes is the substrate, the directive parser, the per-clause var-tracking plumbing, and the simpler half of the codegen integration — all reviewable on its own with green tests.

## Changes

### `src/unifyweaver/targets/wam_target.pl`

- **Directive registry**: `is_visited_set_arg(Pred/Arity, ArgN)` queries `user:visited_set/2`.
- **Per-clause context**: `set_clause_visited_context/1` captures head-arg variables matching the directive into the non-backtrackable global `wam_clause_visited_vars`. Plumbed into both `compile_single_clause_wam/3` and `compile_clauses_fragments/7` next to the existing `set_clause_binding_context/2` call.
- **`is_visited_set_var/1`** looks up a variable in the per-clause set with `==` identity preserved.
- **New `compile_goal_call(\+ member(X, V), ...)` clause** fires before the existing Phase G `NotMemberList` lowering when V is a visited-set var. Emits `not_member_set` (the instruction Layer 1 introduced). Tail-call form mirrored.
- **`emit_not_member_set_lowering/5`** helper mirrors `emit_not_member_list_lowering`'s shape.

### `tests/core/test_wam_visited_set_lowering.pl` (NEW, 4 tests)

| Test | Coverage |
|---|---|
| `test_not_member_set_when_visited_declared` | Directive + body `\+ member` ⇒ `not_member_set` emitted |
| `test_no_visited_directive_keeps_not_member_list` | Without directive, Phase G fallback fires |
| `test_visited_set_var_propagation_across_clauses` | Multi-clause head var identity preserved (regression for the findall bug below) |
| `test_unrelated_call_with_list_arg_unchanged` | Calls without `visited_set` directive are NOT rewritten |

## findall-vs-identity bug

While implementing piece 2, an early version used `findall/3` to capture head-arg variables matching directives. **`findall` creates fresh copies** of captured variables (a documented but easy-to-forget behaviour), which broke `==` identity later when comparing the captured set to the body's V variable. Fixed by walking the head-arg list in place via `collect_visited_vars/4` that preserves variable identity. The third test (`test_visited_set_var_propagation_across_clauses`) is the regression test.

## What was deferred (Layer 2.5)

The call-site arg rewrite at goal positions matching `:- visited_set/2`:

- **Bootstrap pattern**: caller passes `[Cat]` into a visited-set arg → emit `build_empty_set` + `set_insert` and replace the arg with a fresh var bound to the constructed-VSet register.
- **Recursive extension**: caller passes `[X|V_visited]` (cons of head's visited-set var) → emit `set_insert` with the cdr as the input set.

Initial implementation routed visited-set goals through `compile_goal_execute` (where the rewrite would fire), but the dispatch in `compile_goals/5` for the TCO + HasEnv case has multiple branches that interact with how the rewrite recurses on the rewritten goal. A simple cabal-test-shaped goal hung in compile. The rework needs to either:

- Use a non-recursive emission in the rewrite clause, OR
- Add a guard that prevents the rewrite from re-firing on goals where the visited-set arg has already been replaced by a fresh var.

Both are tractable; the design doc's pseudocode is correct, the integration plumbing is the tricky piece. Filed as Layer 2.5.

## Verification

| Suite | Result |
|---|---|
| `tests/core/test_wam_visited_set_lowering.pl` | 4/4 (new) |
| `tests/test_wam_haskell_target.pl` | full suite green |
| `tests/core/test_wam_not_member_lowering.pl` | 5/5 |
| `tests/core/test_binding_state_analysis.pl` | 32/32 |
| `tests/core/test_wam_intset_runtime.pl` | 12/12 |

## Refs

- PR #1684 — IntSet visited design package.
- PR #1686 — Layer 1 (runtime + ADT + handlers + parsers).
- Task #192 — Layer 2 codegen integration (this PR is partial; Layer 2.5 pending).
- Task #191 — IntSet implementation umbrella (still in progress until Layer 2.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)