### PR TITLE
bench(csharp-query): Add C# query source-mode sweeps to generated benchmark runners

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -1024,6 +1024,10 @@ Comparison note:
   `--csharp-query-source-mode auto|preload|delimited|artifact|artifact-prebuilt`;
   non-`auto` runs include `csharp_query_source_mode=<mode>` in the
   `csharp-query-metrics` row and use a runner-managed artifact directory
+- use `--csharp-query-source-modes auto,artifact-prebuilt,...` to sweep
+  multiple source modes in one generated cross-target run; the output labels
+  those rows as `csharp-query:<mode>` and prints a
+  `csharp_query_best_source_mode` summary
 - cache reuse remains disabled for these one-shot generated benchmark
   programs, and trace creation is now opt-in rather than always-on
 - the hand-written C# DFS baseline is still cheaper after its lighter

--- a/examples/benchmark/benchmark_category_influence_cross_target.py
+++ b/examples/benchmark/benchmark_category_influence_cross_target.py
@@ -22,11 +22,16 @@ from benchmark_common import (
     add_csharp_query_source_mode_arg,
     append_csharp_query_source_mode_metric,
     csharp_query_env,
+    csharp_query_results,
+    csharp_query_source_modes_from_args,
+    csharp_query_target_label,
     digest_normalized_output,
     find_result,
+    find_csharp_query_result,
     group_results_by_scale,
     normalize_two_column_float_rows,
     print_bucket_strategy_metrics,
+    print_csharp_query_source_mode_summary,
     print_match_status,
     print_phase_metrics,
     print_result_table,
@@ -120,6 +125,7 @@ def benchmark_target(
     target: str,
     csharp_query_source_mode: str = "auto",
     artifact_dir: Path | None = None,
+    result_target: str | None = None,
 ) -> RunResult:
     scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
     edge_path = scale_dir / "category_parent.tsv"
@@ -147,14 +153,14 @@ def benchmark_target(
 
     normalized = normalize_output(stdout)
     digest, row_count = digest_normalized_output(normalized)
-    return RunResult(target, scale, times, digest, row_count, stderr)
+    return RunResult(result_target or target, scale, times, digest, row_count, stderr)
 
 
 def print_summary(results: list[RunResult]) -> None:
     print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
     for scale, entries in group_results_by_scale(results):
         print_result_table(entries, scale)
-        csharp = find_result(entries, "csharp-query")
+        csharp = find_csharp_query_result(entries)
         if len(entries) > 1:
             print_match_status(scale, "outputs", entries)
             rust = find_result(entries, "rust-dfs")
@@ -169,13 +175,22 @@ def print_summary(results: list[RunResult]) -> None:
                 print(f"{scale}\tfaster_target\t{faster}")
                 print(f"{scale}\tspeedup\t{speedup:.2f}x")
             print_phase_metrics(scale, "prolog-accumulated-metrics", prolog)
-        print_phase_metrics(scale, "csharp-query-metrics", csharp)
-        print_bucket_strategy_metrics(scale, "csharp-query-bucket-strategies", csharp)
+        for csharp_entry in csharp_query_results(entries):
+            metric_label = f"{csharp_entry.target}-metrics" if csharp_entry.target != "csharp-query" else "csharp-query-metrics"
+            bucket_label = (
+                f"{csharp_entry.target}-bucket-strategies"
+                if csharp_entry.target != "csharp-query"
+                else "csharp-query-bucket-strategies"
+            )
+            print_phase_metrics(scale, metric_label, csharp_entry)
+            print_bucket_strategy_metrics(scale, bucket_label, csharp_entry)
+        print_csharp_query_source_mode_summary(scale, entries)
 
 
 def main() -> int:
     args = parse_args()
     scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    csharp_query_source_modes = csharp_query_source_modes_from_args(args)
     targets = available_targets([part.strip() for part in args.targets.split(",") if part.strip()])
     if not targets:
         print("no benchmark targets available", file=sys.stderr)
@@ -209,17 +224,29 @@ def main() -> int:
                 commands["prolog-accumulated"] = build_prolog_accumulated(temp_root, scale)
 
             for target in targets:
-                artifact_dir = temp_root / "artifacts" / target / scale if target == "csharp-query" else None
-                results.append(
-                    benchmark_target(
-                        commands[target],
-                        scale,
-                        args.repetitions,
-                        target,
-                        args.csharp_query_source_mode,
-                        artifact_dir,
+                if target == "csharp-query":
+                    for source_mode in csharp_query_source_modes:
+                        artifact_dir = temp_root / "artifacts" / target / source_mode / scale
+                        results.append(
+                            benchmark_target(
+                                commands[target],
+                                scale,
+                                args.repetitions,
+                                target,
+                                source_mode,
+                                artifact_dir,
+                                csharp_query_target_label(source_mode, csharp_query_source_modes),
+                            )
+                        )
+                else:
+                    results.append(
+                        benchmark_target(
+                            commands[target],
+                            scale,
+                            args.repetitions,
+                            target,
+                        )
                     )
-                )
 
         print_summary(results)
         return 0

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -42,6 +42,26 @@ def csharp_query_source_mode_choices() -> list[str]:
     return ["auto", "preload", "delimited", "artifact", "artifact-prebuilt"]
 
 
+def split_csv(value: str) -> list[str]:
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def validate_csharp_query_source_modes(value: str) -> list[str]:
+    modes = split_csv(value)
+    if not modes:
+        raise ValueError("expected at least one C# query source mode")
+    choices = set(csharp_query_source_mode_choices())
+    unknown = [mode for mode in modes if mode not in choices]
+    if unknown:
+        raise ValueError(
+            "unknown C# query source mode(s): "
+            + ", ".join(unknown)
+            + "; expected one of "
+            + ", ".join(csharp_query_source_mode_choices())
+        )
+    return modes
+
+
 def add_csharp_query_source_mode_arg(parser) -> None:
     parser.add_argument(
         "--csharp-query-source-mode",
@@ -49,6 +69,28 @@ def add_csharp_query_source_mode_arg(parser) -> None:
         choices=csharp_query_source_mode_choices(),
         help="Relation source mode for csharp-query runs.",
     )
+    parser.add_argument(
+        "--csharp-query-source-modes",
+        default=None,
+        help=(
+            "Comma-separated C# query source modes to sweep. "
+            "When set, csharp-query rows are labeled csharp-query:<mode>."
+        ),
+    )
+
+
+def csharp_query_source_modes_from_args(args) -> list[str]:
+    raw_modes = getattr(args, "csharp_query_source_modes", None)
+    if raw_modes:
+        try:
+            return validate_csharp_query_source_modes(raw_modes)
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc
+    return [getattr(args, "csharp_query_source_mode", "auto")]
+
+
+def csharp_query_target_label(source_mode: str, source_modes: list[str]) -> str:
+    return f"csharp-query:{source_mode}" if len(source_modes) > 1 else "csharp-query"
 
 
 def append_csharp_query_source_mode_metric(stderr: str, source_mode: str | None) -> str:
@@ -378,6 +420,43 @@ def print_result_table(entries: list[object], scale: str) -> None:
 
 def find_result(entries: list[object], target: str) -> object | None:
     return next((item for item in entries if item.target == target), None)
+
+
+def csharp_query_results(entries: list[object]) -> list[object]:
+    return [
+        item
+        for item in entries
+        if item.target == "csharp-query" or item.target.startswith("csharp-query:")
+    ]
+
+
+def find_csharp_query_result(entries: list[object]) -> object | None:
+    exact = find_result(entries, "csharp-query")
+    if exact is not None:
+        return exact
+    auto = find_result(entries, "csharp-query:auto")
+    if auto is not None:
+        return auto
+    candidates = csharp_query_results(entries)
+    return candidates[0] if candidates else None
+
+
+def csharp_query_source_mode_from_target(target: str) -> str:
+    if target.startswith("csharp-query:"):
+        return target.split(":", 1)[1]
+    return "auto"
+
+
+def print_csharp_query_source_mode_summary(scale: str, entries: list[object]) -> None:
+    candidates = [item for item in csharp_query_results(entries) if item.target.startswith("csharp-query:")]
+    if len(candidates) < 2:
+        return
+    best = min(candidates, key=lambda item: item.median)
+    auto = find_result(candidates, "csharp-query:auto")
+    print(f"{scale}\tcsharp_query_best_source_mode\t{csharp_query_source_mode_from_target(best.target)}")
+    if auto is not None:
+        ratio = auto.median / best.median if best.median else float("inf")
+        print(f"{scale}\tcsharp_query_auto_vs_best_source_mode\t{ratio:.2f}x")
 
 
 def print_match_status(scale: str, label: str, entries: list[object]) -> None:

--- a/examples/benchmark/benchmark_dependency_depth_cross_target.py
+++ b/examples/benchmark/benchmark_dependency_depth_cross_target.py
@@ -22,11 +22,16 @@ from benchmark_common import (
     add_csharp_query_source_mode_arg,
     append_csharp_query_source_mode_metric,
     csharp_query_env,
+    csharp_query_results,
+    csharp_query_source_modes_from_args,
+    csharp_query_target_label,
     digest_normalized_output,
     find_result,
+    find_csharp_query_result,
     group_results_by_scale,
     normalize_sorted_lines,
     print_bucket_strategy_metrics,
+    print_csharp_query_source_mode_summary,
     print_match_status,
     print_pair_match_status,
     print_result_table,
@@ -117,6 +122,7 @@ def benchmark_target(
     scale: str,
     csharp_query_source_mode: str = "auto",
     artifact_dir: Path | None = None,
+    result_target: str | None = None,
 ) -> RunResult:
     edge_path = require_file(dataset_dir / "category_parent.tsv")
     article_path = require_file(dataset_dir / "article_category.tsv")
@@ -135,30 +141,38 @@ def benchmark_target(
             stderr = append_csharp_query_source_mode_metric(stderr, csharp_query_source_mode)
 
     digest, row_count = digest_normalized_output(normalize_sorted_lines(stdout))
-    return RunResult(target, scale, times, digest, row_count, stderr)
+    return RunResult(result_target or target, scale, times, digest, row_count, stderr)
 
 
 def print_summary(results: list[RunResult]) -> None:
     print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
     for scale, entries in group_results_by_scale(results):
         print_result_table(entries, scale)
-        qe = find_result(entries, "csharp-query")
+        qe = find_csharp_query_result(entries)
         csharp_dfs = find_result(entries, "csharp-dfs")
         rust_dfs = find_result(entries, "rust-dfs")
         go_dfs = find_result(entries, "go-dfs")
-        dfs_like = [item for item in entries if item.target != "csharp-query"]
+        dfs_like = [item for item in entries if not item.target.startswith("csharp-query")]
         if len(dfs_like) > 1:
             print_match_status(scale, "dfs_outputs", dfs_like)
         print_pair_match_status(scale, "query_vs_csharp_dfs", qe, csharp_dfs)
         print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
         print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
         print_speedup(scale, "speedup_vs_go_dfs", go_dfs, qe)
-        print_bucket_strategy_metrics(scale, "csharp-query-bucket-strategies", qe)
+        for csharp_entry in csharp_query_results(entries):
+            bucket_label = (
+                f"{csharp_entry.target}-bucket-strategies"
+                if csharp_entry.target != "csharp-query"
+                else "csharp-query-bucket-strategies"
+            )
+            print_bucket_strategy_metrics(scale, bucket_label, csharp_entry)
+        print_csharp_query_source_mode_summary(scale, entries)
 
 
 def main() -> int:
     args = parse_args()
     scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    csharp_query_source_modes = csharp_query_source_modes_from_args(args)
     for scale in scales:
         if scale not in SCALES:
             raise SystemExit(f"Unsupported scale {scale!r}; expected one of {', '.join(SCALES)}")
@@ -195,18 +209,31 @@ def main() -> int:
         for scale in scales:
             dataset_dir = build_dataset(temp_root, scale)
             for target in targets:
-                artifact_dir = temp_root / "artifacts" / target / scale if target == "csharp-query" else None
-                results.append(
-                    benchmark_target(
-                        commands[target],
-                        dataset_dir,
-                        args.repetitions,
-                        target,
-                        scale,
-                        args.csharp_query_source_mode,
-                        artifact_dir,
+                if target == "csharp-query":
+                    for source_mode in csharp_query_source_modes:
+                        artifact_dir = temp_root / "artifacts" / target / source_mode / scale
+                        results.append(
+                            benchmark_target(
+                                commands[target],
+                                dataset_dir,
+                                args.repetitions,
+                                target,
+                                scale,
+                                source_mode,
+                                artifact_dir,
+                                csharp_query_target_label(source_mode, csharp_query_source_modes),
+                            )
+                        )
+                else:
+                    results.append(
+                        benchmark_target(
+                            commands[target],
+                            dataset_dir,
+                            args.repetitions,
+                            target,
+                            scale,
+                        )
                     )
-                )
 
         print_summary(results)
         return 0

--- a/examples/benchmark/benchmark_dependency_longest_depth_cross_target.py
+++ b/examples/benchmark/benchmark_dependency_longest_depth_cross_target.py
@@ -22,11 +22,16 @@ from benchmark_common import (
     add_csharp_query_source_mode_arg,
     append_csharp_query_source_mode_metric,
     csharp_query_env,
+    csharp_query_results,
+    csharp_query_source_modes_from_args,
+    csharp_query_target_label,
     digest_normalized_output,
     find_result,
+    find_csharp_query_result,
     group_results_by_scale,
     normalize_sorted_lines,
     print_bucket_strategy_metrics,
+    print_csharp_query_source_mode_summary,
     print_match_status,
     print_pair_match_status,
     print_result_table,
@@ -117,6 +122,7 @@ def benchmark_target(
     scale: str,
     csharp_query_source_mode: str = "auto",
     artifact_dir: Path | None = None,
+    result_target: str | None = None,
 ) -> RunResult:
     edge_path = require_file(dataset_dir / "category_parent.tsv")
     article_path = require_file(dataset_dir / "article_category.tsv")
@@ -135,18 +141,18 @@ def benchmark_target(
             stderr = append_csharp_query_source_mode_metric(stderr, csharp_query_source_mode)
 
     digest, row_count = digest_normalized_output(normalize_sorted_lines(stdout))
-    return RunResult(target, scale, times, digest, row_count, stderr)
+    return RunResult(result_target or target, scale, times, digest, row_count, stderr)
 
 
 def print_summary(results: list[RunResult]) -> None:
     print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
     for scale, entries in group_results_by_scale(results):
         print_result_table(entries, scale)
-        csharp_query = find_result(entries, "csharp-query")
+        csharp_query = find_csharp_query_result(entries)
         csharp_dfs = find_result(entries, "csharp-dfs")
         rust_dfs = find_result(entries, "rust-dfs")
         go_dfs = find_result(entries, "go-dfs")
-        dfs_like = [entry for entry in entries if entry.target != "csharp-query"]
+        dfs_like = [entry for entry in entries if not entry.target.startswith("csharp-query")]
         if len(dfs_like) > 1:
             print_match_status(scale, "dfs_outputs", dfs_like)
         if csharp_query and csharp_dfs:
@@ -156,12 +162,20 @@ def print_summary(results: list[RunResult]) -> None:
             print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, csharp_query)
         if csharp_query and go_dfs:
             print_speedup(scale, "speedup_vs_go_dfs", go_dfs, csharp_query)
-        print_bucket_strategy_metrics(scale, "csharp-query-bucket-strategies", csharp_query)
+        for csharp_entry in csharp_query_results(entries):
+            bucket_label = (
+                f"{csharp_entry.target}-bucket-strategies"
+                if csharp_entry.target != "csharp-query"
+                else "csharp-query-bucket-strategies"
+            )
+            print_bucket_strategy_metrics(scale, bucket_label, csharp_entry)
+        print_csharp_query_source_mode_summary(scale, entries)
 
 
 def main() -> int:
     args = parse_args()
     scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    csharp_query_source_modes = csharp_query_source_modes_from_args(args)
     for scale in scales:
         if scale not in SCALES:
             raise SystemExit(f"Unsupported scale {scale!r}; expected one of {', '.join(SCALES)}")
@@ -198,18 +212,31 @@ def main() -> int:
         for scale in scales:
             dataset_dir = build_dataset(temp_root, scale)
             for target in targets:
-                artifact_dir = temp_root / "artifacts" / target / scale if target == "csharp-query" else None
-                results.append(
-                    benchmark_target(
-                        commands[target],
-                        dataset_dir,
-                        args.repetitions,
-                        target,
-                        scale,
-                        args.csharp_query_source_mode,
-                        artifact_dir,
+                if target == "csharp-query":
+                    for source_mode in csharp_query_source_modes:
+                        artifact_dir = temp_root / "artifacts" / target / source_mode / scale
+                        results.append(
+                            benchmark_target(
+                                commands[target],
+                                dataset_dir,
+                                args.repetitions,
+                                target,
+                                scale,
+                                source_mode,
+                                artifact_dir,
+                                csharp_query_target_label(source_mode, csharp_query_source_modes),
+                            )
+                        )
+                else:
+                    results.append(
+                        benchmark_target(
+                            commands[target],
+                            dataset_dir,
+                            args.repetitions,
+                            target,
+                            scale,
+                        )
                     )
-                )
 
         print_summary(results)
         return 0

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -35,11 +35,16 @@ from benchmark_common import (
     add_csharp_query_source_mode_arg,
     append_csharp_query_source_mode_metric,
     csharp_query_env,
+    csharp_query_results,
+    csharp_query_source_modes_from_args,
+    csharp_query_target_label,
     digest_normalized_output,
     find_result,
+    find_csharp_query_result,
     group_results_by_scale,
     normalize_three_column_float_rows,
     print_bucket_strategy_metrics,
+    print_csharp_query_source_mode_summary,
     print_match_status,
     print_pair_match_status,
     print_phase_metrics,
@@ -289,6 +294,7 @@ def benchmark_target(
     target: str,
     csharp_query_source_mode: str = "auto",
     artifact_dir: Path | None = None,
+    result_target: str | None = None,
 ) -> RunResult:
     times: list[float] = []
     last_stdout = ""
@@ -312,7 +318,14 @@ def benchmark_target(
 
     normalized = normalize_three_column_float_rows(last_stdout, decimals=6)
     digest, rows = digest_normalized_output(normalized)
-    return RunResult(target=target, scale=scale, times=times, stdout_sha256=digest, row_count=rows, stderr=last_stderr)
+    return RunResult(
+        target=result_target or target,
+        scale=scale,
+        times=times,
+        stdout_sha256=digest,
+        row_count=rows,
+        stderr=last_stderr,
+    )
 
 
 def print_summary(results: list[RunResult]) -> None:
@@ -321,7 +334,7 @@ def print_summary(results: list[RunResult]) -> None:
     for scale, entries in group_results_by_scale(results, sort_key=scale_sort_key):
         print_result_table(entries, scale)
 
-        qe = find_result(entries, "csharp-query")
+        qe = find_csharp_query_result(entries)
         csharp_dfs = find_result(entries, "csharp-dfs")
         rust_dfs = find_result(entries, "rust-dfs")
         prolog_seeded = find_result(entries, "prolog-seeded")
@@ -392,8 +405,16 @@ def print_summary(results: list[RunResult]) -> None:
         print_no_kernel_speedup(scale, "wam_rust_speedup_vs_haskell_accumulated_no_kernels", haskell_wam_accumulated_no_kernels, wam_rust_accumulated_no_kernels, seed_subset_probe)
         print_speedup(scale, "speedup_vs_prolog_semantic_min", prolog_semantic_min, qe)
         print_speedup(scale, "speedup_vs_prolog_eff_semantic", prolog_eff_semantic, qe)
-        print_phase_metrics(scale, "csharp-query-metrics", qe)
-        print_bucket_strategy_metrics(scale, "csharp-query-bucket-strategies", qe)
+        for csharp_entry in csharp_query_results(entries):
+            metric_label = f"{csharp_entry.target}-metrics" if csharp_entry.target != "csharp-query" else "csharp-query-metrics"
+            bucket_label = (
+                f"{csharp_entry.target}-bucket-strategies"
+                if csharp_entry.target != "csharp-query"
+                else "csharp-query-bucket-strategies"
+            )
+            print_phase_metrics(scale, metric_label, csharp_entry)
+            print_bucket_strategy_metrics(scale, bucket_label, csharp_entry)
+        print_csharp_query_source_mode_summary(scale, entries)
         print_phase_metrics(scale, "prolog-seeded-metrics", prolog_seeded)
         print_phase_metrics(scale, "prolog-pruned-metrics", prolog_pruned)
         print_phase_metrics(scale, "prolog-accumulated-metrics", prolog_accumulated)
@@ -457,6 +478,7 @@ def scale_sort_key(scale: str) -> tuple[int, str]:
 def main() -> int:
     args = parse_args()
     scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    csharp_query_source_modes = csharp_query_source_modes_from_args(args)
     requested_targets = [part.strip() for part in args.targets.split(",") if part.strip()]
     targets = available_targets(requested_targets)
     if not targets:
@@ -551,17 +573,29 @@ def main() -> int:
                     command = build_prolog_effective_semantic(temp_root, scale)
                 else:
                     command = commands[target]
-                artifact_dir = temp_root / "artifacts" / target / scale if target == "csharp-query" else None
-                results.append(
-                    benchmark_target(
-                        command,
-                        scale,
-                        args.repetitions,
-                        target,
-                        args.csharp_query_source_mode,
-                        artifact_dir,
+                if target == "csharp-query":
+                    for source_mode in csharp_query_source_modes:
+                        artifact_dir = temp_root / "artifacts" / target / source_mode / scale
+                        results.append(
+                            benchmark_target(
+                                command,
+                                scale,
+                                args.repetitions,
+                                target,
+                                source_mode,
+                                artifact_dir,
+                                csharp_query_target_label(source_mode, csharp_query_source_modes),
+                            )
+                        )
+                else:
+                    results.append(
+                        benchmark_target(
+                            command,
+                            scale,
+                            args.repetitions,
+                            target,
+                        )
                     )
-                )
 
         print_summary(results)
         if args.keep_temp:

--- a/examples/benchmark/benchmark_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_shortest_path_cross_target.py
@@ -22,11 +22,16 @@ from benchmark_common import (
     add_csharp_query_source_mode_arg,
     append_csharp_query_source_mode_metric,
     csharp_query_env,
+    csharp_query_results,
+    csharp_query_source_modes_from_args,
+    csharp_query_target_label,
     digest_normalized_output,
     find_result,
+    find_csharp_query_result,
     group_results_by_scale,
     normalize_sorted_lines,
     print_bucket_strategy_metrics,
+    print_csharp_query_source_mode_summary,
     print_match_status,
     print_pair_match_status,
     print_phase_metrics,
@@ -135,6 +140,7 @@ def benchmark_target(
     target: str,
     csharp_query_source_mode: str = "auto",
     artifact_dir: Path | None = None,
+    result_target: str | None = None,
 ) -> RunResult:
     times: list[float] = []
     stdout = ""
@@ -157,7 +163,7 @@ def benchmark_target(
 
     normalized = normalize_output(stdout)
     digest, row_count = digest_normalized_output(normalized)
-    return RunResult(target, scale, times, digest, row_count, stderr)
+    return RunResult(result_target or target, scale, times, digest, row_count, stderr)
 
 
 def print_summary(results: list[RunResult]) -> None:
@@ -165,7 +171,7 @@ def print_summary(results: list[RunResult]) -> None:
     for scale, entries in group_results_by_scale(results):
         print_result_table(entries, scale)
 
-        qe = find_result(entries, "csharp-query")
+        qe = find_csharp_query_result(entries)
         csharp_dfs = find_result(entries, "csharp-dfs")
         rust_dfs = find_result(entries, "rust-dfs")
         go_dfs = find_result(entries, "go-dfs")
@@ -180,14 +186,23 @@ def print_summary(results: list[RunResult]) -> None:
         print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
         print_speedup(scale, "speedup_vs_go_dfs", go_dfs, qe)
         print_head_to_head(scale, qe, prolog_min, "query_vs_prolog_min")
-        print_phase_metrics(scale, "csharp-query-metrics", qe)
-        print_bucket_strategy_metrics(scale, "csharp-query-bucket-strategies", qe)
+        for csharp_entry in csharp_query_results(entries):
+            metric_label = f"{csharp_entry.target}-metrics" if csharp_entry.target != "csharp-query" else "csharp-query-metrics"
+            bucket_label = (
+                f"{csharp_entry.target}-bucket-strategies"
+                if csharp_entry.target != "csharp-query"
+                else "csharp-query-bucket-strategies"
+            )
+            print_phase_metrics(scale, metric_label, csharp_entry)
+            print_bucket_strategy_metrics(scale, bucket_label, csharp_entry)
+        print_csharp_query_source_mode_summary(scale, entries)
         print_phase_metrics(scale, "prolog-min-metrics", prolog_min)
 
 
 def main() -> int:
     args = parse_args()
     scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    csharp_query_source_modes = csharp_query_source_modes_from_args(args)
     targets = available_targets([part.strip() for part in args.targets.split(",") if part.strip()])
     if not targets:
         print("no benchmark targets available", file=sys.stderr)
@@ -221,17 +236,29 @@ def main() -> int:
                     command = build_prolog_min(temp_root, scale)
                 else:
                     command = commands[target]
-                artifact_dir = temp_root / "artifacts" / target / scale if target == "csharp-query" else None
-                results.append(
-                    benchmark_target(
-                        command,
-                        scale,
-                        args.repetitions,
-                        target,
-                        args.csharp_query_source_mode,
-                        artifact_dir,
+                if target == "csharp-query":
+                    for source_mode in csharp_query_source_modes:
+                        artifact_dir = temp_root / "artifacts" / target / source_mode / scale
+                        results.append(
+                            benchmark_target(
+                                command,
+                                scale,
+                                args.repetitions,
+                                target,
+                                source_mode,
+                                artifact_dir,
+                                csharp_query_target_label(source_mode, csharp_query_source_modes),
+                            )
+                        )
+                else:
+                    results.append(
+                        benchmark_target(
+                            command,
+                            scale,
+                            args.repetitions,
+                            target,
+                        )
                     )
-                )
 
         print_summary(results)
         return 0

--- a/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
@@ -22,11 +22,16 @@ from benchmark_common import (
     add_csharp_query_source_mode_arg,
     append_csharp_query_source_mode_metric,
     csharp_query_env,
+    csharp_query_results,
+    csharp_query_source_modes_from_args,
+    csharp_query_target_label,
     digest_normalized_output,
     find_result,
+    find_csharp_query_result,
     group_results_by_scale,
     normalize_three_column_float_rows,
     print_bucket_strategy_metrics,
+    print_csharp_query_source_mode_summary,
     print_match_status,
     print_pair_match_status,
     print_phase_metrics,
@@ -135,6 +140,7 @@ def benchmark_target(
     target: str,
     csharp_query_source_mode: str = "auto",
     artifact_dir: Path | None = None,
+    result_target: str | None = None,
 ) -> RunResult:
     times: list[float] = []
     stdout = ""
@@ -157,7 +163,7 @@ def benchmark_target(
 
     normalized = normalize_output(stdout)
     digest, row_count = digest_normalized_output(normalized)
-    return RunResult(target, scale, times, digest, row_count, stderr)
+    return RunResult(result_target or target, scale, times, digest, row_count, stderr)
 
 
 def print_summary(results: list[RunResult]) -> None:
@@ -165,7 +171,7 @@ def print_summary(results: list[RunResult]) -> None:
     for scale, entries in group_results_by_scale(results):
         print_result_table(entries, scale)
 
-        qe = find_result(entries, "csharp-query")
+        qe = find_csharp_query_result(entries)
         csharp_dfs = find_result(entries, "csharp-dfs")
         rust_dfs = find_result(entries, "rust-dfs")
         go_dfs = find_result(entries, "go-dfs")
@@ -180,14 +186,23 @@ def print_summary(results: list[RunResult]) -> None:
         print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
         print_speedup(scale, "speedup_vs_go_dfs", go_dfs, qe)
         print_head_to_head(scale, qe, prolog_min, "query_vs_prolog_min")
-        print_phase_metrics(scale, "csharp-query-metrics", qe)
-        print_bucket_strategy_metrics(scale, "csharp-query-bucket-strategies", qe)
+        for csharp_entry in csharp_query_results(entries):
+            metric_label = f"{csharp_entry.target}-metrics" if csharp_entry.target != "csharp-query" else "csharp-query-metrics"
+            bucket_label = (
+                f"{csharp_entry.target}-bucket-strategies"
+                if csharp_entry.target != "csharp-query"
+                else "csharp-query-bucket-strategies"
+            )
+            print_phase_metrics(scale, metric_label, csharp_entry)
+            print_bucket_strategy_metrics(scale, bucket_label, csharp_entry)
+        print_csharp_query_source_mode_summary(scale, entries)
         print_phase_metrics(scale, "prolog-min-metrics", prolog_min)
 
 
 def main() -> int:
     args = parse_args()
     scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    csharp_query_source_modes = csharp_query_source_modes_from_args(args)
     targets = available_targets([part.strip() for part in args.targets.split(",") if part.strip()])
     if not targets:
         print("no benchmark targets available", file=sys.stderr)
@@ -221,17 +236,29 @@ def main() -> int:
                     command = build_prolog_min(temp_root, scale)
                 else:
                     command = commands[target]
-                artifact_dir = temp_root / "artifacts" / target / scale if target == "csharp-query" else None
-                results.append(
-                    benchmark_target(
-                        command,
-                        scale,
-                        args.repetitions,
-                        target,
-                        args.csharp_query_source_mode,
-                        artifact_dir,
+                if target == "csharp-query":
+                    for source_mode in csharp_query_source_modes:
+                        artifact_dir = temp_root / "artifacts" / target / source_mode / scale
+                        results.append(
+                            benchmark_target(
+                                command,
+                                scale,
+                                args.repetitions,
+                                target,
+                                source_mode,
+                                artifact_dir,
+                                csharp_query_target_label(source_mode, csharp_query_source_modes),
+                            )
+                        )
+                else:
+                    results.append(
+                        benchmark_target(
+                            command,
+                            scale,
+                            args.repetitions,
+                            target,
+                        )
                     )
-                )
 
         print_summary(results)
         return 0


### PR DESCRIPTION
  ## Summary

  - add `--csharp-query-source-modes` for sweeping multiple C# query relation source modes in one run
  - label multi-mode rows as `csharp-query:<mode>` while preserving existing single-mode output
  - summarize the fastest C# query source mode with `csharp_query_best_source_mode`
  - keep per-mode metrics and bucket-strategy rows separated for multi-mode runs
  - document the new sweep flag in the benchmark README

  ## Validation

  - `git diff --check`
  - `python3 -m py_compile` for touched benchmark runners
  - invalid source-mode CLI checks
  - category influence smoke with `--csharp-query-source-modes auto,artifact-prebuilt`
  - dependency depth smoke with `--csharp-query-source-modes auto,preload`