### PR TITLE
bench(csharp-query): Add C# query source-mode sweep report helper

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -436,6 +436,7 @@ Tables:
 | `benchmark_shortest_path_cross_target.py` | Compare shortest-path-to-root across C# query, seeded Prolog `min`, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_depth_cross_target.py` | Compare synthetic dependency reach-count across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_longest_depth_cross_target.py` | Compare true DAG longest dependency-chain depth across C# query, C# DFS, Rust DFS, and Go DFS |
+| `benchmark_csharp_query_source_mode_sweep.py` | Run generated C# query source-mode sweeps across selected workloads and emit a compact TSV/Markdown comparison |
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
 | `benchmark_scan_materialization.py` | Exercise relation scan, pattern scan, join, negation, and aggregate under the scan materialization planner; use the `join` mode when you need concrete artifact bucket join strategy rows |
 | `benchmark_closure_materialization.py` | Exercise generic seeded closure and streamed auxiliary accumulation under the closure materialization planner |
@@ -1028,6 +1029,9 @@ Comparison note:
   multiple source modes in one generated cross-target run; the output labels
   those rows as `csharp-query:<mode>` and prints a
   `csharp_query_best_source_mode` summary
+- use `benchmark_csharp_query_source_mode_sweep.py` when you want a compact
+  cross-workload TSV or Markdown summary of best source mode, auto-vs-best
+  ratio, output agreement, and per-mode medians
 - cache reuse remains disabled for these one-shot generated benchmark
   programs, and trace creation is now opt-in rather than always-on
 - the hand-written C# DFS baseline is still cheaper after its lighter

--- a/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
+++ b/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Run C# query source-mode sweeps across generated benchmark runners and emit a
+compact comparison table.
+
+The generated cross-target runners already support `--csharp-query-source-modes`;
+this wrapper makes the result easier to compare across workloads by extracting
+the best mode, auto-vs-best ratio, output hash agreement, and per-mode medians.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmark_common import run_command, scale_sort_key, split_csv, validate_csharp_query_source_modes
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCHMARK_DIR = ROOT / "examples" / "benchmark"
+
+WORKLOAD_SCRIPTS = {
+    "category-influence": BENCHMARK_DIR / "benchmark_category_influence_cross_target.py",
+    "dependency-depth": BENCHMARK_DIR / "benchmark_dependency_depth_cross_target.py",
+    "dependency-longest-depth": BENCHMARK_DIR / "benchmark_dependency_longest_depth_cross_target.py",
+    "effective-distance": BENCHMARK_DIR / "benchmark_effective_distance.py",
+    "shortest-path": BENCHMARK_DIR / "benchmark_shortest_path_cross_target.py",
+    "weighted-shortest-path": BENCHMARK_DIR / "benchmark_weighted_shortest_path_cross_target.py",
+}
+
+
+@dataclass
+class SourceModeSummary:
+    workload: str
+    scale: str
+    best_source_mode: str
+    auto_vs_best: str
+    output_agreement: str
+    median_summary: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workloads",
+        default="category-influence,dependency-depth",
+        help="Comma-separated workloads, or 'all'.",
+    )
+    parser.add_argument("--scales", default="300")
+    parser.add_argument(
+        "--source-modes",
+        default="auto,preload,artifact-prebuilt",
+        help="Comma-separated C# query source modes to sweep.",
+    )
+    parser.add_argument("--repetitions", type=int, default=1)
+    parser.add_argument("--format", choices=["tsv", "markdown"], default="tsv")
+    parser.add_argument(
+        "--trace",
+        action="store_true",
+        help="Set UNIFYWEAVER_BENCH_TRACE=1 for the child benchmark runners.",
+    )
+    return parser.parse_args()
+
+
+def parse_workloads(value: str) -> list[str]:
+    if value.strip().lower() == "all":
+        return list(WORKLOAD_SCRIPTS)
+    workloads = split_csv(value)
+    unknown = [workload for workload in workloads if workload not in WORKLOAD_SCRIPTS]
+    if unknown:
+        raise SystemExit(
+            "unknown workload(s): "
+            + ", ".join(unknown)
+            + "; expected one of "
+            + ", ".join(WORKLOAD_SCRIPTS)
+        )
+    if not workloads:
+        raise SystemExit("expected at least one workload")
+    return workloads
+
+
+def parse_runner_output(workload: str, output: str) -> list[SourceModeSummary]:
+    medians: dict[str, dict[str, str]] = {}
+    hashes: dict[str, dict[str, str]] = {}
+    best_modes: dict[str, str] = {}
+    auto_vs_best: dict[str, str] = {}
+
+    for line in output.splitlines():
+        parts = line.rstrip("\n").split("\t")
+        if len(parts) >= 7 and parts[0] != "scale" and parts[1].startswith("csharp-query:"):
+            scale = parts[0]
+            source_mode = parts[1].split(":", 1)[1]
+            medians.setdefault(scale, {})[source_mode] = parts[2]
+            hashes.setdefault(scale, {})[source_mode] = parts[6]
+        elif len(parts) >= 3 and parts[1] == "csharp_query_best_source_mode":
+            best_modes[parts[0]] = parts[2]
+        elif len(parts) >= 3 and parts[1] == "csharp_query_auto_vs_best_source_mode":
+            auto_vs_best[parts[0]] = parts[2]
+
+    summaries: list[SourceModeSummary] = []
+    for scale in sorted(medians, key=scale_sort_key):
+        mode_medians = medians[scale]
+        mode_hashes = hashes.get(scale, {})
+        unique_hashes = set(mode_hashes.values())
+        output_agreement = "match" if len(unique_hashes) == 1 else "MISMATCH"
+        median_summary = ",".join(
+            f"{mode}:{mode_medians[mode]}"
+            for mode in sorted(mode_medians)
+        )
+        summaries.append(
+            SourceModeSummary(
+                workload=workload,
+                scale=scale,
+                best_source_mode=best_modes.get(scale, ""),
+                auto_vs_best=auto_vs_best.get(scale, ""),
+                output_agreement=output_agreement,
+                median_summary=median_summary,
+            )
+        )
+    return summaries
+
+
+def run_workload(
+    workload: str,
+    *,
+    scales: str,
+    source_modes: str,
+    repetitions: int,
+    trace: bool,
+) -> list[SourceModeSummary]:
+    env = dict(os.environ)
+    if trace:
+        env["UNIFYWEAVER_BENCH_TRACE"] = "1"
+    else:
+        env.pop("UNIFYWEAVER_BENCH_TRACE", None)
+
+    result = run_command(
+        [
+            sys.executable,
+            str(WORKLOAD_SCRIPTS[workload]),
+            "--scales",
+            scales,
+            "--targets",
+            "csharp-query",
+            "--repetitions",
+            str(repetitions),
+            "--csharp-query-source-modes",
+            source_modes,
+        ],
+        cwd=ROOT,
+        env=env,
+    )
+    return parse_runner_output(workload, result.stdout)
+
+
+def print_tsv(summaries: list[SourceModeSummary]) -> None:
+    print("workload\tscale\tbest_source_mode\tauto_vs_best\toutput_agreement\tmedian_s_by_mode")
+    for summary in summaries:
+        print(
+            f"{summary.workload}\t{summary.scale}\t{summary.best_source_mode}\t"
+            f"{summary.auto_vs_best}\t{summary.output_agreement}\t{summary.median_summary}"
+        )
+
+
+def print_markdown(summaries: list[SourceModeSummary]) -> None:
+    print("| Workload | Scale | Best source mode | Auto vs best | Outputs | Median seconds by mode |")
+    print("| --- | --- | --- | ---: | --- | --- |")
+    for summary in summaries:
+        print(
+            f"| {summary.workload} | {summary.scale} | {summary.best_source_mode} | "
+            f"{summary.auto_vs_best} | {summary.output_agreement} | `{summary.median_summary}` |"
+        )
+
+
+def main() -> int:
+    args = parse_args()
+    workloads = parse_workloads(args.workloads)
+    try:
+        validate_csharp_query_source_modes(args.source_modes)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    summaries: list[SourceModeSummary] = []
+    for workload in workloads:
+        summaries.extend(
+            run_workload(
+                workload,
+                scales=args.scales,
+                source_modes=args.source_modes,
+                repetitions=args.repetitions,
+                trace=args.trace,
+            )
+        )
+
+    if args.format == "markdown":
+        print_markdown(summaries)
+    else:
+        print_tsv(summaries)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
  ## Summary

  - add `benchmark_csharp_query_source_mode_sweep.py` to run selected generated C# query source-mode sweeps
  - emit compact TSV or Markdown summaries with best source mode, auto-vs-best ratio, output agreement, and per-mode
  medians
  - document the helper in the benchmark README

  ## Validation

  - `git diff --check`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_source_mode_sweep.py`
  - `--help` check
  - TSV smoke for `category-influence,dependency-depth`
  - Markdown smoke for `dependency-depth`
  - invalid workload and invalid source-mode error checks