### PR TITLE
feat(wam-elixir): Phase 4a substrate — branch_backtrack/1 helper

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -1046,6 +1046,55 @@ compile_aggregate_helpers_to_elixir(Code) :-
   end
 
   @doc """
+  Phase 4a substrate — variant of backtrack/1 for parallel-branch
+  context. When the topmost CP is an aggregate frame, returns
+  {:branch_exhausted, local_accum} INSTEAD of finalising. This lets
+  a Tier-2 super-wrappers Task.async_stream branch return its local
+  contribution to the parent for merging via merge_into_aggregate/2,
+  rather than triggering a finalise that would only see the branchs
+  partial accum.
+
+  Phase 4b will wire this into the super-wrappers branch wrapper —
+  see WAM_ELIXIR_TIER2_FINDALL_PHASE4.md sections 4.2/4.3 for the
+  control flow. Phase 4c activates intra_query_parallel(true) and
+  validates end-to-end.
+
+  Behaviour by topmost-CP type:
+    - empty stack → {:branch_exhausted, []} — branch produced
+      nothing (e.g., the clauses head failed to match).
+    - :agg_type set → {:branch_exhausted, Enum.reverse(accum)} —
+      branch reached its own agg frame, enumeration is exhausted,
+      return local accum (reversed because aggregate_collect
+      prepends for O(1)).
+    - other CP type → falls through to backtrack_ordinary/3 —
+      resume the next clause-body alternative. backtrack_ordinarys
+      result (a state via cp.pc.(state), or {:ok, state}) flows
+      through; the wrap_segment catch chain may re-enter via
+      backtrack/branch_backtrack as enumeration continues.
+
+  Note on wiring: Phase 4a only adds this helper. Phase 4b decides
+  how branches route their wrap_segment catches through it (e.g.,
+  via a :branch_mode state field that backtrack/1 dispatches on,
+  or via super-wrapper-installed catch arms). The proposals
+  question 1 (section 9 Q1) asks reviewers about return-vs-throw
+  shape; for Phase 4a we use the return shape per the proposal
+  default, leaving room for Phase 4b to revisit if needed.
+  """
+  def branch_backtrack(state) do
+    case state.choice_points do
+      [] ->
+        {:branch_exhausted, []}
+      [cp | rest] ->
+        case Map.get(cp, :agg_type) do
+          nil ->
+            backtrack_ordinary(state, cp, rest)
+          _agg_type ->
+            {:branch_exhausted, Enum.reverse(Map.get(cp, :agg_accum, []))}
+        end
+    end
+  end
+
+  @doc """
   Push an aggregate-frame choice point. Captures the same snapshot
   fields as a try_me_else CP (regs, heap, heap_len, trail, trail_len,
   stack, cp) so finalise_aggregate/4 can restore the pre-aggregate

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -998,6 +998,47 @@ test_findall_substrate_backtrack_routes_aggregate_frames :-
     ;   fail_test(Test, 'backtrack/1 does not dispatch on :agg_type or backtrack_ordinary missing')
     ).
 
+%% Phase 4a substrate — branch_backtrack/1 helper for parallel-branch
+%% context. See WAM_ELIXIR_TIER2_FINDALL_PHASE4.md sections 4.2/4.3.
+%% Phase 4a only adds the helper; Phase 4b wires it into the super-
+%% wrappers branch wrapper. Tests are emit-and-grep; runtime
+%% verification (via the Phase 3-style harness) belongs to Phase 4c.
+
+test_findall_phase4a_emits_branch_backtrack :-
+    Test = 'Phase 4a: WamRuntime emits branch_backtrack/1 with required dispatch arms',
+    (   compile_wam_runtime_to_elixir([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'def branch_backtrack(state)'),
+        % Empty CP stack arm — branch produced nothing.
+        sub_string(S, _, _, _, '{:branch_exhausted, []}'),
+        % Agg frame arm — return reversed local accum (aggregate_collect
+        % prepends for O(1), branch_backtrack reverses on return so the
+        % parent sees enumeration-order values).
+        sub_string(S, _, _, _, '{:branch_exhausted, Enum.reverse'),
+        sub_string(S, _, _, _, 'Map.get(cp, :agg_accum, [])'),
+        % Fall-through arm — non-agg CP routes to backtrack_ordinary
+        % (the existing path), letting the resumed clause continue
+        % the branchs local enumeration.
+        sub_string(S, _, _, _, 'backtrack_ordinary(state, cp, rest)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'branch_backtrack/1 missing or has wrong dispatch shape')
+    ).
+
+test_findall_phase4a_branch_backtrack_distinct_from_backtrack :-
+    Test = 'Phase 4a: branch_backtrack/1 is a distinct def from backtrack/1',
+    (   compile_wam_runtime_to_elixir([], Code),
+        atom_string(Code, S),
+        % Both must exist as separate top-level defs — branch_backtrack
+        % is additive, not a replacement for backtrack. Phase 4b will
+        % decide how the super-wrapper routes between them (proposal §9
+        % Q1 — return shape vs. throw shape, branch-mode state field
+        % vs. catch-arm dispatch).
+        sub_string(S, _, _, _, 'def backtrack(state) do'),
+        sub_string(S, _, _, _, 'def branch_backtrack(state) do')
+    ->  pass(Test)
+    ;   fail_test(Test, 'branch_backtrack/1 should coexist with backtrack/1')
+    ).
+
 test_tier2_purity_gate_rejects_unknown :-
     Test = 'Tier-2 infra: purity gate fails for unknown predicate',
     (   \+ tier2_purity_eligible(no_such_pred, 2, _)
@@ -1311,6 +1352,8 @@ run_tests :-
     test_findall_substrate_emits_aggregate_collect,
     test_findall_substrate_emits_finalise_aggregate,
     test_findall_substrate_backtrack_routes_aggregate_frames,
+    test_findall_phase4a_emits_branch_backtrack,
+    test_findall_phase4a_branch_backtrack_distinct_from_backtrack,
     test_findall_instr_parser_begin_aggregate,
     test_findall_instr_parser_end_aggregate,
     test_findall_instr_lowers_begin_aggregate_sum,


### PR DESCRIPTION
## Summary

- Phase 4a of the parallel-findall implementation per `docs/proposals/WAM_ELIXIR_TIER2_FINDALL_PHASE4.md` (#1672) §4.2 / §4.3. Adds the runtime helper that Phase 4b's super-wrapper rework will use to drive parallel branch enumeration.
- Small focused PR: 49 lines of new substrate code + 43 lines of tests + comprehensive `@doc`. The helper is currently **uncalled** — Phase 4b wires it in.
- 82/82 target tests (80 prior + 2 new) and 16/16 Phase 3 runtime scenarios passing. Sequential findall behaviour unchanged because nothing actually invokes the new helper yet.

## What's added

A new top-level `def branch_backtrack(state)` in `compile_aggregate_helpers_to_elixir/1`:

```elixir
def branch_backtrack(state) do
  case state.choice_points do
    [] ->
      {:branch_exhausted, []}
    [cp | rest] ->
      case Map.get(cp, :agg_type) do
        nil ->
          backtrack_ordinary(state, cp, rest)
        _agg_type ->
          {:branch_exhausted, Enum.reverse(Map.get(cp, :agg_accum, []))}
      end
  end
end
```

Variant of `backtrack/1` specifically for parallel-branch context. When the topmost CP is an aggregate frame, returns `{:branch_exhausted, local_accum}` **instead of finalising**. This lets a Tier-2 super-wrapper's `Task.async_stream` branch return its local contribution to the parent for merging via `merge_into_aggregate/2`, rather than triggering a finalise that would only see the branch's partial accum (Finding 2 from #1647).

### Behaviour by topmost-CP type

| Topmost CP | Returns | Why |
|---|---|---|
| empty stack | `{:branch_exhausted, []}` | Branch's head failed to match — no contribution |
| has `:agg_type` | `{:branch_exhausted, Enum.reverse(accum)}` | Enumeration exhausted — return local accum (reversed because `aggregate_collect` prepends for O(1)) |
| other CP | falls through to `backtrack_ordinary(state, cp, rest)` | Resume the next clause-body alternative; the resumed clause will eventually re-enter via the wrap_segment catch chain |

## Why this is safe to land alone

The helper is currently **never called from anywhere in emitted code**. Phase 4a's PR scope is deliberately narrow: introduce the substrate, prove it compiles + works at the unit level, prepare for Phase 4b's wiring. Three lines of evidence:

1. **`backtrack/1` is unchanged** — its dispatcher still routes agg-frame CPs to `finalise_aggregate`, and the `branch_backtrack` arm is purely additive.
2. **All 16 Phase 3 runtime scenarios pass unchanged.** Sequential findall (which is what Phase 3 covers) doesn't go through the new helper.
3. **Runtime probe verified the helper works in isolation.** Direct calls confirmed:
   - Empty CP stack → `{:branch_exhausted, []}` ✓
   - Agg frame with accum `[c, b, a]` → `{:branch_exhausted, ["a", "b", "c"]}` ✓ (reversed)

## Reviewer notes

**Why `branch_backtrack` returns instead of throws.** Proposal §9 Q1 explicitly flagged this as an open design question. For Phase 4a the proposal's default (return shape) is implemented; if Phase 4b discovers the throw shape composes better with the super-wrapper's catch chain, that's a small refactor. The return shape is more amenable to direct unit testing (which is why the runtime probe could exercise it directly without setting up a try/catch context).

**Why `branch_backtrack` calls `backtrack_ordinary` for the fall-through case.** The fall-through means "this isn't an agg frame, so resume the next clause's body alternative as normal." `backtrack_ordinary` is exactly that path — it pops the CP, restores from snapshot, calls `cp.pc.(state)`. The resumed clause runs and eventually proceeds via `state.cp.(state)` or fails via `throw({:fail, _})`. Phase 4b's super-wrapper-installed catch will decide what happens at that next layer.

**Why `:agg_type` matching uses `Map.get(cp, :agg_type)` not `Map.has_key?`.** Mirrors the existing `backtrack/1` dispatcher's exact shape (added in #1627). Consistency makes the two functions read as parallel definitions.

**`@doc` flagging Phase 4b/4c next steps.** The helper's docstring explicitly notes "Phase 4a only adds this helper" and points at the proposal sections that describe wiring. Future readers (including the Phase 4b implementer) get the context inline.

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_target.pl` — 82/82 passing (80 prior + 2 new emit-and-grep substrate tests)
- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_lowered_phase3.pl` — 16/16 still passing on Termux (Elixir 1.19, OTP 28). Sequential findall unchanged because `branch_backtrack` is currently uncalled.
- [x] Runtime probe — direct invocation of `WamRuntime.branch_backtrack/1` in a tempdir Elixir script confirmed both return shapes (`{:branch_exhausted, []}` for empty stack, `{:branch_exhausted, [a, b, c]}` for agg frame with reversed accum)
- [x] `swipl -t halt -g test_aggregate_compiles tests/core/test_wam_llvm_aggregate.pl` — passes (this is an Elixir-runtime substrate change; LLVM target unaffected)
- [x] Pre-existing `test_wam_e2e.pl atom/1` failure exists on `main`, unrelated to this PR

## Phase plan (post-merge)

- **Phase 4b (next)**: Rework `par_wrap_segment/4`'s `Task.async_stream` block in `wam_elixir_lowered_emitter.pl`. Install a stub `state.cp` that returns `{:branch_exhausted, []}` and a custom catch arm that routes through `branch_backtrack` when the branch's wrap_segment chain throws fail. Per proposal §4.3. The §9 Q1 question (return vs. throw shape for `branch_backtrack`) gets resolved here based on what fits the catch chain best.
- **Phase 4c**: Activate `intra_query_parallel(true)` in the Phase 3 scenarios where the inner predicate is Tier-2-eligible. Add new scenarios that specifically exercise the parallel path. Cross-validate against the Haskell target where possible.

After Phase 4 lands end-to-end, the parallel-track Phase 3c follow-ups (`get_structure` aliased-ref binding, compound args within Template, deep-copy for list shapes, `:sum` numeric encoding) remain as opportunistic fixes — none block Phase 4 progress.

## Related

- Phase 4 proposal: `docs/proposals/WAM_ELIXIR_TIER2_FINDALL_PHASE4.md` (#1672)
- Sequential findall track (now complete): #1626 → #1627 → #1643 → #1647 → #1649 → #1650 → #1658 → #1659 → #1661 → #1663 → #1667 → #1669
- Tier-2 wiring (the super-wrapper that Phase 4b will rework): #1608, #1624
- Original Finding 2 surfaced by the Phase 3a smoke (the bug Phase 4 fixes): #1647 reviewer notes
- Haskell precedent (the Phase 4 design oracle): `wam_haskell_target.pl:1480-1539`
