### PR TITLE
feat(wam-scala): arithmetic builtins + S6 cut/foreign discriminator

### DIFF
--- a/src/unifyweaver/targets/wam_scala_target.pl
+++ b/src/unifyweaver/targets/wam_scala_target.pl
@@ -158,8 +158,8 @@ wam_parts_to_scala(["deallocate"], 'Deallocate').
 % --- Register: get ---
 wam_parts_to_scala(["get_constant", C, Reg], Lit) :-
     reg_to_int(Reg, RegIdx),
-    intern_scala_atom(C, AtomId),
-    format(string(Lit), 'GetConstant(Atom(~w), ~w)', [AtomId, RegIdx]).
+    constant_to_scala_term(C, TermLit),
+    format(string(Lit), 'GetConstant(~w, ~w)', [TermLit, RegIdx]).
 
 wam_parts_to_scala(["get_variable", VarReg, ArgReg], Lit) :-
     reg_to_int(VarReg, VIdx), reg_to_int(ArgReg, AIdx),
@@ -172,8 +172,8 @@ wam_parts_to_scala(["get_value", VarReg, ArgReg], Lit) :-
 % --- Register: put ---
 wam_parts_to_scala(["put_constant", C, Reg], Lit) :-
     reg_to_int(Reg, RegIdx),
-    intern_scala_atom(C, AtomId),
-    format(string(Lit), 'PutConstant(Atom(~w), ~w)', [AtomId, RegIdx]).
+    constant_to_scala_term(C, TermLit),
+    format(string(Lit), 'PutConstant(~w, ~w)', [TermLit, RegIdx]).
 
 wam_parts_to_scala(["put_variable", VarReg, ArgReg], Lit) :-
     reg_to_int(VarReg, VIdx), reg_to_int(ArgReg, AIdx),
@@ -215,8 +215,8 @@ wam_parts_to_scala(["set_value", Reg], Lit) :-
     format(string(Lit), 'SetValue(~w)', [Idx]).
 
 wam_parts_to_scala(["set_constant", C], Lit) :-
-    intern_scala_atom(C, AtomId),
-    format(string(Lit), 'SetConstant(Atom(~w))', [AtomId]).
+    constant_to_scala_term(C, TermLit),
+    format(string(Lit), 'SetConstant(~w)', [TermLit]).
 
 wam_parts_to_scala(["unify_variable", Reg], Lit) :-
     reg_to_int(Reg, Idx),
@@ -227,13 +227,14 @@ wam_parts_to_scala(["unify_value", Reg], Lit) :-
     format(string(Lit), 'UnifyValue(~w)', [Idx]).
 
 wam_parts_to_scala(["unify_constant", C], Lit) :-
-    intern_scala_atom(C, AtomId),
-    format(string(Lit), 'UnifyConstant(Atom(~w))', [AtomId]).
+    constant_to_scala_term(C, TermLit),
+    format(string(Lit), 'UnifyConstant(~w)', [TermLit]).
 
 % --- Builtins ---
 wam_parts_to_scala(["builtin_call", Pred, ArityStr], Lit) :-
     number_string(Arity, ArityStr),
-    format(string(Lit), 'BuiltinCall("~w", ~w)', [Pred, Arity]).
+    scala_string_literal(Pred, PredLit),
+    format(string(Lit), 'BuiltinCall(~w, ~w)', [PredLit, Arity]).
 
 % --- Foreign call ---
 wam_parts_to_scala(["call_foreign", Pred, ArityStr], Lit) :-
@@ -271,6 +272,34 @@ strip_arity_suffix(Pred, Name) :-
     ->  sub_string(Pred, 0, B, _, Name)
     ;   Name = Pred
     ).
+
+%% constant_to_scala_term(+ConstStr, -ScalaTermLit) is det.
+%  Converts a WAM constant token to its Scala-source-literal form. Numeric
+%  tokens become IntTerm(N) so arithmetic builtins (is/2, =:=/2, ...) can
+%  evaluate them; non-numeric tokens are interned as atoms.
+constant_to_scala_term(C, Lit) :-
+    (   number_string(N, C),
+        integer(N)
+    ->  format(string(Lit), 'IntTerm(~w)', [N])
+    ;   intern_scala_atom(C, AtomId),
+        format(string(Lit), 'Atom(~w)', [AtomId])
+    ).
+
+%% scala_string_literal(+Raw, -Quoted) is det.
+%  Wraps Raw in double quotes and escapes backslashes and double quotes
+%  so it is a valid Scala string literal. Used for builtin predicate
+%  names like `=\=/2` that contain backslashes.
+scala_string_literal(Raw, Quoted) :-
+    atom_string(Raw, S),
+    string_chars(S, Chars),
+    maplist(scala_string_escape_char, Chars, EscapedLists),
+    append(EscapedLists, EscChars),
+    string_chars(EscBody, EscChars),
+    format(string(Quoted), '"~w"', [EscBody]).
+
+scala_string_escape_char('\\', ['\\', '\\']) :- !.
+scala_string_escape_char('"',  ['\\', '"'])  :- !.
+scala_string_escape_char(C, [C]).
 
 %% parse_functor_arity(+FunctorStr, -Name, -Arity)
 parse_functor_arity(FStr, Name, Arity) :-

--- a/templates/targets/scala_wam/program.scala.mustache
+++ b/templates/targets/scala_wam/program.scala.mustache
@@ -92,22 +92,29 @@ object GeneratedProgram {
   }
 
   // Parse a CLI argument into a WamTerm.
-  // Supports atoms ("a"), structures ("f(a,b)"), and lists ("[a,b]").
-  // Unknown atom strings get id -1 so they fail unification with known atoms.
+  // Supports integers ("42", "-3"), atoms ("a"), structures ("f(a,b)"),
+  // and lists ("[a,b]"). Unknown atom strings get id -1 so they fail
+  // unification with known atoms.
   private def parseArg(s: String): WamTerm = {
     val t = s.trim
-    if (t.startsWith("[") && t.endsWith("]"))
-      parseList(t.substring(1, t.length - 1))
-    else {
-      val open = t.indexOf('(')
-      if (open > 0 && t.endsWith(")")) {
-        val functor = t.substring(0, open)
-        val inner = t.substring(open + 1, t.length - 1)
-        val argTerms = splitTopLevelCommas(inner).map(parseArg).toArray
-        Struct(internAtomId(functor), argTerms.length, argTerms)
-      } else {
-        Atom(internAtomId(t))
-      }
+    // Integers first — covers signed ints; falls through to atom on parse error.
+    val intOpt = try Some(t.toInt) catch { case _: NumberFormatException => None }
+    intOpt match {
+      case Some(n) => IntTerm(n)
+      case None =>
+        if (t.startsWith("[") && t.endsWith("]"))
+          parseList(t.substring(1, t.length - 1))
+        else {
+          val open = t.indexOf('(')
+          if (open > 0 && t.endsWith(")")) {
+            val functor = t.substring(0, open)
+            val inner = t.substring(open + 1, t.length - 1)
+            val argTerms = splitTopLevelCommas(inner).map(parseArg).toArray
+            Struct(internAtomId(functor), argTerms.length, argTerms)
+          } else {
+            Atom(internAtomId(t))
+          }
+        }
     }
   }
 

--- a/templates/targets/scala_wam/runtime.scala.mustache
+++ b/templates/targets/scala_wam/runtime.scala.mustache
@@ -386,11 +386,23 @@ object WamRuntime {
     case top :: rest =>
       s.buildStack = rest
       val built = Struct(top.functorId, top.sArity, top.args.toArray)
+      // Write-mode WAM PutStructure / PutList semantics. The target
+      // register is *always* set to the new struct, so callers see it
+      // there. In addition, if the target currently holds an unbound
+      // Ref (typical of the `set_variable X; put_structure F, X`
+      // threading idiom that compiles `+(_, *(_, _))`-style nested
+      // arithmetic), bind that Ref so any other build frame that
+      // captured the same Ref as one of its args sees the new struct
+      // through deref.
       val current = s.regs(top.targetReg)
-      val ok = if (current == null) { setReg(s, top.targetReg, built); true }
-               else unify(s, deref(s.bindings, current), built)
-      if (!ok) backtrack(s)
-      else if (s.buildStack.nonEmpty && s.buildStack.head.args.length == s.buildStack.head.sArity)
+      val derefedRef = if (current == null) None
+                       else deref(s.bindings, current) match {
+                         case r: Ref => Some(r)
+                         case _      => None
+                       }
+      derefedRef.foreach(r => bindVar(s, r, built))
+      setReg(s, top.targetReg, built)
+      if (s.buildStack.nonEmpty && s.buildStack.head.args.length == s.buildStack.head.sArity)
         finalizeBuild(s)
   }
 
@@ -663,6 +675,24 @@ object WamRuntime {
         case "!/0" =>
           s.choicePoints = s.choicePoints.drop(s.choicePoints.length - s.cutBar)
           s.pc += 1
+
+        // Arithmetic: A1 is target (assignment) or left operand (comparison),
+        // A2 is the expression / right operand. The expression term is built
+        // by put_structure +/2 etc. and evaluated recursively.
+        case "is/2" =>
+          evalArith(s, program, s.regs(2)) match {
+            case Some(n) =>
+              if (unify(s, s.regs(1), IntTerm(n))) s.pc += 1 else backtrack(s)
+            case None =>
+              backtrack(s)
+          }
+        case "=:=/2" => arithCmp(s, program, _ == _)
+        case "=\\=/2" => arithCmp(s, program, _ != _)
+        case "</2"   => arithCmp(s, program, _ < _)
+        case ">/2"   => arithCmp(s, program, _ > _)
+        case "=</2"  => arithCmp(s, program, _ <= _)
+        case ">=/2"  => arithCmp(s, program, _ >= _)
+
         case _ =>
           backtrack(s)
       }
@@ -686,6 +716,63 @@ object WamRuntime {
 
       case _ =>
         backtrack(s)
+    }
+  }
+
+  // ----------------------------------------------------------
+  // Arithmetic evaluation
+  // ----------------------------------------------------------
+  // Recursively evaluates an arithmetic expression term. Operator
+  // functors (+, -, *, /, mod) are looked up by name via the program's
+  // intern table, so the runtime is independent of the well-known atom
+  // ID assignment. Returns None on type errors / unbound vars / div-by-0.
+
+  def evalArith(s: WamState, program: WamProgram, t: WamTerm): Option[Int] = {
+    val v = deref(s.bindings, t)
+    v match {
+      case IntTerm(n) => Some(n)
+      case Struct(f, 2, args) =>
+        val name =
+          if (f >= 0 && f < program.internTable.idToString.length)
+            program.internTable.idToString(f)
+          else ""
+        val a = evalArith(s, program, args(0))
+        val b = evalArith(s, program, args(1))
+        (a, b) match {
+          case (Some(x), Some(y)) =>
+            name match {
+              case "+" => Some(x + y)
+              case "-" => Some(x - y)
+              case "*" => Some(x * y)
+              case "/"   if y != 0 => Some(x / y)
+              case "mod" if y != 0 => Some(x % y)
+              case _   => None
+            }
+          case _ => None
+        }
+      case Struct(f, 1, args) =>
+        val name =
+          if (f >= 0 && f < program.internTable.idToString.length)
+            program.internTable.idToString(f)
+          else ""
+        evalArith(s, program, args(0)).flatMap { x =>
+          name match {
+            case "-" => Some(-x)
+            case "+" => Some(x)
+            case _   => None
+          }
+        }
+      case _ => None
+    }
+  }
+
+  /** Helper for arithmetic comparison builtins: evaluate A1 and A2 then
+   *  apply `op` to the integer results. Advances pc on true; backtracks on
+   *  false or on any evaluation failure. */
+  def arithCmp(s: WamState, program: WamProgram, op: (Int, Int) => Boolean): Unit = {
+    (evalArith(s, program, s.regs(1)), evalArith(s, program, s.regs(2))) match {
+      case (Some(a), Some(b)) if op(a, b) => s.pc += 1
+      case _                              => backtrack(s)
     }
   }
 

--- a/tests/test_wam_scala_runtime_smoke.pl
+++ b/tests/test_wam_scala_runtime_smoke.pl
@@ -48,6 +48,17 @@
 :- dynamic user:wam_foreign_pair_query/1.
 :- dynamic user:wam_foreign_multi/2.
 :- dynamic user:wam_foreign_multi_query/1.
+:- dynamic user:wam_inc/2.
+:- dynamic user:wam_double/2.
+:- dynamic user:wam_combo/3.
+:- dynamic user:wam_neg/2.
+:- dynamic user:wam_lt/2.
+:- dynamic user:wam_gt/2.
+:- dynamic user:wam_geq/2.
+:- dynamic user:wam_leq/2.
+:- dynamic user:wam_eq_arith/2.
+:- dynamic user:wam_neq_arith/2.
+:- dynamic user:wam_cut_obs/1.
 
 user:wam_fact(a).
 user:wam_execute_caller(X)    :- user:wam_fact(X).
@@ -92,6 +103,24 @@ user:wam_foreign_pair(_, _).
 user:wam_foreign_pair_query(Y)  :- user:wam_foreign_pair(a, Y).
 user:wam_foreign_multi(_, _).
 user:wam_foreign_multi_query(Y) :- user:wam_foreign_multi(a, Y).
+% wam_cut_obs: Y is fresh in the body; foreign yields Y=a then Y=b on
+% backtrack. The cut after the foreign call must drop the foreign CP so
+% that a later unify failure cannot redo the foreign and try the second
+% solution. With correct cut: wam_cut_obs(b) → false. Without: would be true.
+user:wam_cut_obs(X) :- user:wam_foreign_multi(a, Y), !, Y = X.
+
+% Arithmetic: WAM emits builtin_call is/2, =:=/2, </2, >/2, =</2, >=/2,
+% =\=/2 and builds expression terms via put_structure +/-/*/'/' .
+user:wam_inc(N, M)        :- M is N + 1.
+user:wam_double(N, M)     :- M is N * 2.
+user:wam_combo(A, B, R)   :- R is A + B * 2.
+user:wam_neg(N, M)        :- M is -N.
+user:wam_lt(X, Y)         :- X < Y.
+user:wam_gt(X, Y)         :- X > Y.
+user:wam_geq(X, Y)        :- X >= Y.
+user:wam_leq(X, Y)        :- X =< Y.
+user:wam_eq_arith(X, Y)   :- X =:= Y.
+user:wam_neq_arith(X, Y)  :- X =\= Y.
 
 % ============================================================
 % Condition: only run if scalac is available
@@ -301,6 +330,63 @@ test(foreign_multi) :-
             verify_scala(TmpDir, 'wam_foreign_multi_query/1', 'c', "false")
         )).
 
+% S6: cut after a multi-solution foreign must drop the foreign choice
+% point so a later unify failure cannot redo the foreign.
+% Discriminating case: wam_cut_obs(b) with cut → false; without cut → true.
+test(cut_after_foreign_multi) :-
+    foreign_multi_handler(MultiHandler),
+    with_scala_project(
+        [user:wam_foreign_multi/2, user:wam_cut_obs/1],
+        [ foreign_predicates([wam_foreign_multi/2]),
+          intern_atoms([a, b, c]),
+          scala_foreign_handlers([handler(wam_foreign_multi/2, MultiHandler)]) ],
+        TmpDir,
+        (
+            verify_scala(TmpDir, 'wam_cut_obs/1', 'a', "true"),
+            verify_scala(TmpDir, 'wam_cut_obs/1', 'b', "false"),
+            verify_scala(TmpDir, 'wam_cut_obs/1', 'c', "false")
+        )).
+
+% --- Arithmetic builtins ---
+
+test(arith_is) :-
+    with_scala_project(
+        [user:wam_inc/2, user:wam_double/2, user:wam_combo/3, user:wam_neg/2],
+        _Opts,
+        TmpDir,
+        (
+            verify_scala_args(TmpDir, 'wam_inc/2',    ['5', '6'],     "true"),
+            verify_scala_args(TmpDir, 'wam_inc/2',    ['5', '7'],     "false"),
+            verify_scala_args(TmpDir, 'wam_double/2', ['7', '14'],    "true"),
+            verify_scala_args(TmpDir, 'wam_double/2', ['7', '15'],    "false"),
+            verify_scala_args(TmpDir, 'wam_combo/3',  ['3','4','11'], "true"),
+            verify_scala_args(TmpDir, 'wam_combo/3',  ['3','4','12'], "false"),
+            verify_scala_args(TmpDir, 'wam_neg/2',    ['5', '-5'],    "true"),
+            verify_scala_args(TmpDir, 'wam_neg/2',    ['5', '5'],     "false")
+        )).
+
+test(arith_compare) :-
+    with_scala_project(
+        [user:wam_lt/2, user:wam_gt/2, user:wam_geq/2, user:wam_leq/2,
+         user:wam_eq_arith/2, user:wam_neq_arith/2],
+        _Opts,
+        TmpDir,
+        (
+            verify_scala_args(TmpDir, 'wam_lt/2',        ['1', '2'], "true"),
+            verify_scala_args(TmpDir, 'wam_lt/2',        ['2', '1'], "false"),
+            verify_scala_args(TmpDir, 'wam_lt/2',        ['2', '2'], "false"),
+            verify_scala_args(TmpDir, 'wam_gt/2',        ['2', '1'], "true"),
+            verify_scala_args(TmpDir, 'wam_gt/2',        ['1', '2'], "false"),
+            verify_scala_args(TmpDir, 'wam_geq/2',       ['2', '2'], "true"),
+            verify_scala_args(TmpDir, 'wam_geq/2',       ['1', '2'], "false"),
+            verify_scala_args(TmpDir, 'wam_leq/2',       ['2', '2'], "true"),
+            verify_scala_args(TmpDir, 'wam_leq/2',       ['3', '2'], "false"),
+            verify_scala_args(TmpDir, 'wam_eq_arith/2',  ['3', '3'], "true"),
+            verify_scala_args(TmpDir, 'wam_eq_arith/2',  ['3', '4'], "false"),
+            verify_scala_args(TmpDir, 'wam_neq_arith/2', ['3', '4'], "true"),
+            verify_scala_args(TmpDir, 'wam_neq_arith/2', ['3', '3'], "false")
+        )).
+
 :- end_tests(wam_scala_runtime_smoke).
 
 % ============================================================
@@ -359,24 +445,28 @@ find_scala_sources(AbsProjectDir, Sources) :-
         Sources).
 
 %% verify_scala(+ProjectDir, +PredKey, +Arg, +Expected)
-%  Runs the predicate via `scala` and checks stdout matches Expected.
+%  Single-arg form for predicates of arity 1.
 verify_scala(ProjectDir, PredKey, Arg, Expected) :-
-    run_scala_predicate(ProjectDir, PredKey, Arg, Actual),
+    verify_scala_args(ProjectDir, PredKey, [Arg], Expected).
+
+%% verify_scala_args(+ProjectDir, +PredKey, +Args, +Expected)
+%  Multi-arg form: Args is a list of atoms/strings to pass on the CLI.
+verify_scala_args(ProjectDir, PredKey, Args, Expected) :-
+    run_scala_predicate_args(ProjectDir, PredKey, Args, Actual),
     (   Actual == Expected
     ->  true
-    ;   throw(error(assertion_error(PredKey, Arg, Expected, Actual), _))
+    ;   throw(error(assertion_error(PredKey, Args, Expected, Actual), _))
     ).
 
-%% run_scala_predicate(+ProjectDir, +PredKey, +Arg, -Output)
-run_scala_predicate(ProjectDir, PredKey, Arg, Output) :-
+run_scala_predicate_args(ProjectDir, PredKey, Args, Output) :-
     absolute_file_name(ProjectDir, AbsProjectDir),
     directory_file_path(AbsProjectDir, 'classes', ClassDir),
-    atom_string(Arg, ArgStr),
     atom_string(PredKey, PredStr),
-    process_create(path(scala),
-                   ['-classpath', ClassDir,
-                    'generated.wam_scala_smoke.core.GeneratedProgram',
-                    PredStr, ArgStr],
+    maplist([A, S]>>atom_string(A, S), Args, ArgStrs),
+    append(['-classpath', ClassDir,
+            'generated.wam_scala_smoke.core.GeneratedProgram',
+            PredStr], ArgStrs, ProcArgs),
+    process_create(path(scala), ProcArgs,
                    [cwd(AbsProjectDir),
                     stdout(pipe(Out)), stderr(pipe(Err)),
                     process(Pid)]),
@@ -388,7 +478,7 @@ run_scala_predicate(ProjectDir, PredKey, Arg, Output) :-
     normalize_space(string(Output), OutStr0),
     (   ExitCode =:= 0
     ->  true
-    ;   throw(error(scala_run_failed(ExitCode, PredKey, Arg, ErrStr), _))
+    ;   throw(error(scala_run_failed(ExitCode, PredKey, Args, ErrStr), _))
     ).
 
 unique_scala_tmp_dir(Prefix, TmpDir) :-


### PR DESCRIPTION
## Summary

Three new smoke tests close two long-standing gaps in the WAM Scala
target's runtime: **arithmetic** (`is/2` plus the comparison family),
and **cut interaction with foreign choice points** (S6). Several
latent runtime bugs in the build-stack semantics surfaced once
arithmetic was wired end-to-end and are fixed here.

Test counts after this PR: 10 generator tests, 18 e2e smoke tests
(was 10 + 15). All pass under `scalac` + `scala`.

## What's in the diff

### Arithmetic — two new smoke tests in `tests/test_wam_scala_runtime_smoke.pl`

| Test | Exercises |
|---|---|
| `arith_is` | `M is N + 1`, `M is N * 2`, **nested** `R is A + B * 2` (the put_structure / set_variable threading idiom), and unary `M is -N`. |
| `arith_compare` | `</2`, `>/2`, `=</2`, `>=/2`, `=:=/2`, `=\=/2` across true/false/equal cases. |

Wiring:

- New `constant_to_scala_term/2` codegen helper recognises numeric
  tokens in `get_constant` / `put_constant` / `set_constant` /
  `unify_constant` and emits `IntTerm(N)` instead of `Atom(intern(N))`.
  Without this, `set_constant 1` was being interned as the atom `"1"`,
  leaving the runtime no integer to evaluate against.
- New runtime `evalArith(s, program, t)` recursively evaluates an
  expression term. Operator functors (`+`, `-`, `*`, `/`, `mod`, plus
  unary `+` / `-`) are resolved by name via
  `program.internTable.idToString` so the runtime is independent of any
  well-known atom-id assignment.
- New runtime `arithCmp(s, program, op)` helper for the comparison
  family.
- CLI parser now recognises signed integers (`42`, `-3`) and emits
  `IntTerm`, falling through to the existing atom / structure / list
  parser on parse error.
- New `scala_string_literal/2` helper escapes backslashes and double
  quotes when emitting Scala string literals — fixes `=\=/2` being
  written as a malformed `"=\=/2"` literal.

### Bug fixes exposed by arithmetic

`finalizeBuild` was calling `unify(current, built)` against whatever
was already in the target register at the time of `put_structure` /
`put_list`. That matches Clojure's `assign-or-unify-reg` but is wrong:
standard WAM `put_*` operations are write-mode and unconditionally
place the new term in the target register. Symptom: `wam_inc(5, 6)`
returned `false` because `A2` still held the input `IntTerm(6)` from
`get_variable X2, A2`, and unifying that with the freshly built
`+(N, 1)` struct trivially fails.

Fix preserves the `set_variable X; put_structure F, X` idiom that
threads nested arithmetic — when the target register holds an unbound
`Ref` (the freshvar from `set_variable`), we additionally `bindVar`
that Ref to the built struct, so any other build frame that captured
the same Ref via its args list sees the new struct through `deref`.
The target register is set unconditionally regardless.

### S6 cut+foreign — one new smoke test

| Test | Exercises |
|---|---|
| `cut_after_foreign_multi` | Body `wam_foreign_multi(a, Y), !, Y = X` binds a fresh logic variable `Y` from a multi-solution foreign and commits via cut. |

The cut must drop the foreign choice point so a later unify failure
cannot redo the foreign and try the second solution. Discriminating
case: `wam_cut_obs(b)` returns `false` with correct cut semantics,
would return `true` without (since the second foreign solution `Y=b`
would unify with `X=b` on backtrack).

The runtime's existing `!/0` handler — which drops choice points back
to `cutBar` — already handles `ForeignCP`s on the choice-point list
the same way it handles `WamCP`s, so no runtime change was needed
beyond the test itself confirming the behaviour.

### Test harness

New `verify_scala_args/4` and `run_scala_predicate_args/4` helpers
pass a list of args to the generated CLI runner, so multi-arg
predicates (`wam_inc/2`, `wam_combo/3`, etc.) can be exercised.
Single-arg `verify_scala/4` now wraps the multi-arg form for back
compat with the existing 16 tests — no other test file changed.

## Test plan

- [ ] `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_generator.pl"),run_tests,halt' -t 'halt(1)'` → 10/10 pass.
- [ ] With `scalac` on PATH or `SCALA_SMOKE_TESTS=1`:
      `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_runtime_smoke.pl"),run_tests,halt' -t 'halt(1)'` → 18/18 pass.
- [ ] Without `scalac`: smoke unit reports "No tests to run" (gated by `scala_available/0`).

## Out of scope

- Float/rational arithmetic. The runtime evaluator is `Int` only.
- The "true streaming" / iterator-based `ForeignSolutions` protocol
  mentioned in the S6 plan. The eager `ForeignMulti(Seq)` form already
  delivers correct multi-solution backtracking; lazy iteration buys
  nothing for any current test and stays for later if a real workload
  needs it.
- Phases S7 (fact backend seam), S8 (LMDB), S9 (benchmarks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)