### PR TITLE
bench(csharp-query): Report C# query relation source registrations

### DIFF
--- a/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
+++ b/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
@@ -503,12 +503,14 @@ Prototype status:
 
 ### N-ary delimited artifact direction
 
-The current C# artifact implementation is deliberately binary. Wider
-delimited relations can now use the same runtime-configured source registration
-path, but `artifact` and `artifact-prebuilt` modes fall back to preloaded rows
-for arities other than 2. That is the correct interim behavior: it preserves
-answers and source-mode wiring without pretending the `.uwbr` sidecars support
-general row shapes.
+The original C# artifact implementation was deliberately binary. Wider
+delimited relations now use the same runtime-configured source registration
+path and can use the delimited artifact provider in `artifact` and
+`artifact-prebuilt` modes. Binary relations still use the older `.uwbr`
+provider, while wider relations use the delimited artifact path. Runtime source
+registration reporting distinguishes these paths as `binary_artifact`,
+`delimited_artifact`, `delimited`, or `preloaded`, which keeps benchmark output
+honest about the storage family used for each arity.
 
 A general delimited artifact should be a new format revision, not an implicit
 reinterpretation of the binary files. The row file should keep the existing

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -438,7 +438,7 @@ Tables:
 | `benchmark_dependency_longest_depth_cross_target.py` | Compare true DAG longest dependency-chain depth across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_csharp_query_source_mode_sweep.py` | Run generated C# query source-mode sweeps across selected workloads and emit a compact TSV/Markdown comparison |
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
-| `benchmark_scan_materialization.py` | Exercise relation scan, pattern scan, join, negation, and aggregate under the scan materialization planner; use the `join` mode when you need concrete artifact bucket join strategy rows |
+| `benchmark_scan_materialization.py` | Exercise relation scan, pattern scan, binary/n-ary join, negation, and aggregate under the scan materialization planner; use `join` or `nary_join` when you need concrete artifact bucket join strategy rows |
 | `benchmark_closure_materialization.py` | Exercise generic seeded closure and streamed auxiliary accumulation under the closure materialization planner |
 | `benchmark_closure_pair_planning.py` | Exercise seeded and grouped closure-pair workloads under the closure-pair strategy planner |
 | `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive, non-negative, and fallback weighted paths |
@@ -1025,6 +1025,9 @@ Comparison note:
   `--csharp-query-source-mode auto|preload|delimited|artifact|artifact-prebuilt`;
   non-`auto` runs include `csharp_query_source_mode=<mode>` in the
   `csharp-query-metrics` row and use a runner-managed artifact directory
+- generated `csharp-query` metrics also include `source_registration_*`
+  counters that identify the actual storage family used for registered
+  relations, for example `binary_artifact` or `delimited_artifact` by arity
 - use `--csharp-query-source-modes auto,artifact-prebuilt,...` to sweep
   multiple source modes in one generated cross-target run; the output labels
   those rows as `csharp-query:<mode>` and prints a

--- a/examples/benchmark/benchmark_scan_materialization.py
+++ b/examples/benchmark/benchmark_scan_materialization.py
@@ -10,6 +10,7 @@ relation sources inside a temporary C# project:
 - `bound_scan`: parameterized `RelationScanNode` over one bound column
 - `pattern`: `PatternScanNode` with a bound category
 - `join`: `KeyJoinNode` over article/category and category-parent scans
+- `nary_join`: `KeyJoinNode` over synthetic width-3 delimited relations
 - `selective_join`: parameter seed joined against category-parent
 - `negation`: unary negation over scanned support relations
 - `aggregate`: grouped count aggregate over a scanned relation
@@ -113,11 +114,29 @@ class Program
                 .Select(group => $"{group.Key}:{group.Sum(p => p.Elapsed.TotalMilliseconds).ToString("F3", CultureInfo.InvariantCulture)}"));
     }
 
+    static string SummarizeSourceRegistrations(ConfiguredDelimitedRelationProvider configuredProvider)
+    {
+        return string.Join(
+            "|",
+            configuredProvider.SnapshotRegistrations()
+                .GroupBy(registration => new
+                {
+                    registration.StorageKind,
+                    registration.SourceMode,
+                    registration.Arity
+                })
+                .OrderBy(group => group.Key.StorageKind, StringComparer.Ordinal)
+                .ThenBy(group => group.Key.SourceMode.ToString(), StringComparer.Ordinal)
+                .ThenBy(group => group.Key.Arity)
+                .Select(group =>
+                    $"{group.Key.StorageKind}:{RelationSourceModePolicy.ToConfigValue(group.Key.SourceMode)}:arity{group.Key.Arity}={group.Count()}"));
+    }
+
     static int Main(string[] args)
     {
         if (args.Length < 3)
         {
-            Console.Error.WriteLine("Usage: program <scan|pattern|join|negation|aggregate> <category_parent.tsv> <article_category.tsv>");
+            Console.Error.WriteLine("Usage: program <scan|pattern|join|nary_join|negation|aggregate> <category_parent.tsv> <article_category.tsv>");
             return 1;
         }
 
@@ -143,6 +162,8 @@ class Program
         var edgeId = new PredicateId("category_parent", 2);
         var articleId = new PredicateId("article_category", 2);
         var blockedId = new PredicateId("blocked_article_category", 2);
+        var naryLeftId = new PredicateId("nary_left", 3);
+        var naryRightId = new PredicateId("nary_right", 3);
 
         configuredProvider.RegisterBinaryRelation(edgeId, new DelimitedRelationSource(edgePath, '	', 1, 2), $"{edgeId.Name}_{edgeId.Arity}");
         configuredProvider.RegisterBinaryRelation(articleId, new DelimitedRelationSource(articlePath, '	', 1, 2), $"{articleId.Name}_{articleId.Arity}");
@@ -164,9 +185,32 @@ class Program
             }
         }
 
+        var naryLeftPath = Path.Combine(Path.GetTempPath(), $"uw-scan-nary-left-{Guid.NewGuid():N}.tsv");
+        var naryRightPath = Path.Combine(Path.GetTempPath(), $"uw-scan-nary-right-{Guid.NewGuid():N}.tsv");
+        using (var writer = new StreamWriter(naryLeftPath, false))
+        {
+            writer.WriteLine("key	item	rank");
+            writer.WriteLine("Keyboard	left-keyboard	1");
+            writer.WriteLine("Laptop	left-laptop	2");
+            writer.WriteLine("Mouse	left-mouse	3");
+        }
+
+        using (var writer = new StreamWriter(naryRightPath, false))
+        {
+            writer.WriteLine("key	item	score");
+            writer.WriteLine("Keyboard	right-keyboard	10");
+            writer.WriteLine("Laptop	right-laptop	20");
+            writer.WriteLine("Mouse	right-mouse	30");
+        }
+
         try
         {
             configuredProvider.RegisterBinaryRelation(blockedId, new DelimitedRelationSource(blockedPath, '	', 1, 2), $"{blockedId.Name}_{blockedId.Arity}");
+            if (mode == "nary_join")
+            {
+                configuredProvider.RegisterDelimitedRelation(naryLeftId, new DelimitedRelationSource(naryLeftPath, '	', 1, 3), $"{naryLeftId.Name}_{naryLeftId.Arity}");
+                configuredProvider.RegisterDelimitedRelation(naryRightId, new DelimitedRelationSource(naryRightPath, '	', 1, 3), $"{naryRightId.Name}_{naryRightId.Arity}");
+            }
 
             var scanOutId = new PredicateId("scan_rows", 2);
             var patternOutId = new PredicateId("pattern_rows", 2);
@@ -196,6 +240,16 @@ class Program
                         2,
                         2,
                         4)),
+                "nary_join" => new QueryPlan(
+                    joinOutId,
+                    new KeyJoinNode(
+                        new RelationScanNode(naryLeftId),
+                        new RelationScanNode(naryRightId),
+                        new int[] { 0 },
+                        new int[] { 0 },
+                        3,
+                        3,
+                        6)),
                 "selective_join" => new QueryPlan(
                     joinOutId,
                     new KeyJoinNode(
@@ -244,6 +298,7 @@ class Program
             Console.Error.WriteLine($"pattern_category={patternCategory}");
             Console.Error.WriteLine($"row_count={rows.Count}");
             Console.Error.WriteLine($"elapsed_ms={stopwatch.ElapsedMilliseconds}");
+            Console.Error.WriteLine($"source_registrations={SummarizeSourceRegistrations(configuredProvider)}");
 
             if (traceEnabled && trace is not null)
             {
@@ -272,6 +327,8 @@ class Program
         finally
         {
             try { File.Delete(blockedPath); } catch { }
+            try { File.Delete(naryLeftPath); } catch { }
+            try { File.Delete(naryRightPath); } catch { }
             if (sourceMode != RelationSourceMode.ArtifactPrebuilt)
             {
                 if (!string.IsNullOrWhiteSpace(configuredProvider.ArtifactDirectory))
@@ -427,7 +484,7 @@ def main() -> int:
                     for strategy in strategies:
                         results.append(benchmark_mode(command, scale, mode, source_mode, strategy, args.repetitions))
 
-        print("scale	mode	source_mode	resolved_source_mode	strategy	median_s	min_s	max_s	rows	planner	bucket_strategies	phases")
+        print("scale	mode	source_mode	resolved_source_mode	strategy	median_s	min_s	max_s	rows	source_registrations	planner	bucket_strategies	phases")
         grouped: dict[tuple[str, str, str], dict[str, BenchResult]] = {}
         by_source_mode: dict[tuple[str, str, str], BenchResult] = {}
         for result in sorted(results, key=lambda item: (scale_sort_key(item.scale), item.mode, item.source_mode, item.strategy)):
@@ -439,9 +496,10 @@ def main() -> int:
             bucket_strategies = metrics.get("bucket_strategies", "")
             phases = metrics.get("scan_phase_summary", "")
             rows = metrics.get("row_count", "")
+            source_registrations = metrics.get("source_registrations", "")
             print(
                 f"{result.scale}	{result.mode}	{result.source_mode}	{result.resolved_source_mode}	{result.strategy}	{result.median:.3f}	"
-                f"{min(result.times):.3f}	{max(result.times):.3f}	{rows}	{planner}	{bucket_strategies}	{phases}"
+                f"{min(result.times):.3f}	{max(result.times):.3f}	{rows}	{source_registrations}	{planner}	{bucket_strategies}	{phases}"
             )
 
         for scale, mode, source_mode in sorted(grouped.keys(), key=lambda item: (scale_sort_key(item[0]), item[1], item[2])):

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -61,6 +61,24 @@ CSHARP_QUERY_BUCKET_STRATEGY_HELPERS = r"""
             Console.Error.WriteLine($"bucket_strategy_{strategy.NodeType}_{strategy.Strategy}={strategy.Count}");
         }
     }
+
+    static void PrintSourceRegistrations(ConfiguredDelimitedRelationProvider configuredProvider)
+    {
+        foreach (var group in configuredProvider.SnapshotRegistrations()
+            .GroupBy(registration => new
+            {
+                registration.StorageKind,
+                registration.SourceMode,
+                registration.Arity
+            })
+            .OrderBy(group => group.Key.StorageKind, StringComparer.Ordinal)
+            .ThenBy(group => group.Key.SourceMode.ToString(), StringComparer.Ordinal)
+            .ThenBy(group => group.Key.Arity))
+        {
+            Console.Error.WriteLine(
+                $"source_registration_{group.Key.StorageKind}_{RelationSourceModePolicy.ToConfigValue(group.Key.SourceMode)}_arity{group.Key.Arity}={group.Count()}");
+        }
+    }
 """
 
 
@@ -1590,6 +1608,7 @@ class Program
         Console.Error.WriteLine($"dag_retention_strategy_setting={{dagRetentionStrategy}}");
         PrintDagStrategies(trace);
         PrintBucketStrategies(trace);
+        PrintSourceRegistrations(configuredProvider);
         PrintDagPhases(trace);
     }}
 }}
@@ -2112,6 +2131,7 @@ class Program
         Console.Error.WriteLine($"dag_retention_strategy_setting={{dagRetentionStrategy}}");
         PrintDagStrategies(trace);
         PrintBucketStrategies(trace);
+        PrintSourceRegistrations(configuredProvider);
         PrintDagPhases(trace);
     }}
 }}
@@ -2772,6 +2792,7 @@ class Program
         Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintWeightSumStrategies(trace);
         PrintBucketStrategies(trace);
+        PrintSourceRegistrations(configuredProvider);
         PrintWeightSumPhases(trace);
     }}
 }}
@@ -2947,6 +2968,7 @@ class Program
         Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintWeightSumStrategies(trace);
         PrintBucketStrategies(trace);
+        PrintSourceRegistrations(configuredProvider);
         PrintWeightSumPhases(trace);
     }}
 
@@ -3124,6 +3146,7 @@ class Program
         Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintPathMinStrategies(trace);
         PrintBucketStrategies(trace);
+        PrintSourceRegistrations(configuredProvider);
         PrintPathMinPhases(trace);
     }}
 }}
@@ -3353,6 +3376,7 @@ class Program
         Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintPathMinStrategies(trace);
         PrintBucketStrategies(trace);
+        PrintSourceRegistrations(configuredProvider);
         PrintPathMinPhases(trace);
         PrintPathMinMetrics(trace);
     }}

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1258,6 +1258,13 @@ namespace UnifyWeaver.QueryRuntime
         double Value
     );
 
+    public sealed record RelationSourceRegistrationTrace(
+        PredicateId Predicate,
+        RelationSourceMode SourceMode,
+        string StorageKind,
+        int Arity
+    );
+
     public sealed class QueryExecutionTrace
     {
         private sealed class NodeStats
@@ -4492,6 +4499,8 @@ namespace UnifyWeaver.QueryRuntime
 
     public sealed class ConfiguredDelimitedRelationProvider
     {
+        private readonly List<RelationSourceRegistrationTrace> _registrations = new();
+
         public RelationSourceMode SourceMode { get; }
 
         public InMemoryRelationProvider MemoryProvider { get; }
@@ -4503,6 +4512,8 @@ namespace UnifyWeaver.QueryRuntime
         public IRelationProvider Provider => (IRelationProvider?)ArtifactProvider ?? (IRelationProvider?)DelimitedArtifactProvider ?? MemoryProvider;
 
         public string? ArtifactDirectory { get; }
+
+        public IReadOnlyList<RelationSourceRegistrationTrace> SnapshotRegistrations() => _registrations.ToList();
 
         public ConfiguredDelimitedRelationProvider(
             RelationSourceMode sourceMode,
@@ -4534,9 +4545,11 @@ namespace UnifyWeaver.QueryRuntime
                 case RelationSourceMode.Preload:
                     MemoryProvider.RegisterDelimitedSource(predicate, source);
                     MemoryProvider.AddFacts(predicate, DelimitedRelationReader.ReadRows(source));
+                    RecordRegistration(predicate, "preloaded");
                     return;
                 case RelationSourceMode.Delimited:
                     MemoryProvider.RegisterDelimitedSource(predicate, source);
+                    RecordRegistration(predicate, "delimited");
                     return;
                 case RelationSourceMode.Artifact:
                 case RelationSourceMode.ArtifactPrebuilt:
@@ -4547,6 +4560,7 @@ namespace UnifyWeaver.QueryRuntime
 
                     var manifestPath = BinaryRelationArtifactBuilder.BuildFromDelimited(predicate, source, ArtifactDirectory, artifactName);
                     ArtifactProvider.RegisterArtifact(predicate, manifestPath);
+                    RecordRegistration(predicate, "binary_artifact");
                     return;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(SourceMode), SourceMode, null);
@@ -4565,10 +4579,12 @@ namespace UnifyWeaver.QueryRuntime
             {
                 case RelationSourceMode.Delimited:
                     MemoryProvider.RegisterDelimitedSource(predicate, source);
+                    RecordRegistration(predicate, "delimited");
                     return;
                 case RelationSourceMode.Preload:
                     MemoryProvider.RegisterDelimitedSource(predicate, source);
                     MemoryProvider.AddFacts(predicate, DelimitedRelationReader.ReadRows(source));
+                    RecordRegistration(predicate, "preloaded");
                     return;
                 case RelationSourceMode.Artifact:
                 case RelationSourceMode.ArtifactPrebuilt:
@@ -4579,10 +4595,20 @@ namespace UnifyWeaver.QueryRuntime
 
                     var manifestPath = DelimitedRelationArtifactBuilder.BuildFromDelimited(predicate, source, ArtifactDirectory, artifactName);
                     DelimitedArtifactProvider.RegisterArtifact(predicate, manifestPath);
+                    RecordRegistration(predicate, "delimited_artifact");
                     return;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(SourceMode), SourceMode, null);
             }
+        }
+
+        private void RecordRegistration(PredicateId predicate, string storageKind)
+        {
+            _registrations.Add(new RelationSourceRegistrationTrace(
+                predicate,
+                SourceMode,
+                storageKind,
+                predicate.Arity));
         }
     }
 


### PR DESCRIPTION
  ## Summary

  - record C# query relation source registrations with source mode, storage kind, and arity
  - emit `source_registration_*` metrics from generated C# query benchmark programs
  - add `source_registrations` output to `benchmark_scan_materialization.py`
  - add `nary_join` scan benchmark mode to exercise width-3 delimited artifact joins
  - update benchmark/proposal docs to distinguish binary and delimited artifact paths

  ## Validation

  - `git diff --check`
  - `python3 -m py_compile` for touched benchmark scripts
  - scan materialization `join` smoke with `artifact-prebuilt`
  - scan materialization `nary_join` smoke with `artifact-prebuilt`
  - generated category influence C# query smoke with `artifact-prebuilt`
  - targeted n-ary C# query test with suite setup