### PR TITLE
bench(wam-haskell): IntSet 3-way macro — algorithmic win didn't materialise at depth=10`

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -1368,13 +1368,85 @@ SetInsert 201 203 107    -- [Mid|Visited] passed to recursive call
 The runtime instructions (Layer 1) + lowering (Layer 2) + arg
 rewrite (Layer 2.5) coordinate end-to-end.
 
-### Macro benchmark — TODO
+### Macro benchmark — measured (and the design's expected speedup did NOT materialise)
 
-A follow-up should extend
-`tests/benchmarks/wam_effective_distance_macro_bench.pl` to add a
-third variant that includes `:- visited_set(category_ancestor/4, 4)`
-and compare against the Phase G `mode`-only baseline. Expected
-improvement per the design doc: another ~1.5–3× on top of the
-~1.18× Phase G macro speedup (compounding the constant-factor and
-algorithmic wins). Filed as a small follow-up — the substrate is in
-place; the benchmark is just a copy-and-add-directive.
+`tests/benchmarks/wam_effective_distance_macro_bench.pl` extended
+to a 3-way comparison: `unlowered` / `lowered` (Phase G) /
+`intset` (Phase G + H). 6 trials with rotating order to spot
+cache-warming bias.
+
+Results at 10k scale (`data/benchmark/10k`, 462 tuples,
+~50-element visited list bounded by `max_depth=10`):
+
+| variant | mean query_ms |
+|---|---:|
+| unlowered (no directives) | 931.5 |
+| lowered (Phase G `mode` only) | 861.0 |
+| intset (Phase G + H combined) | 957.5 |
+
+Speedups:
+
+- **lowered vs unlowered: 1.082×** — Phase G's constant-factor
+  win on the macro path is consistent with the prior 1.18× at 1k.
+- **intset vs lowered: 0.899×** — the IntSet path is **~10 %
+  slower** than the list-based lowering at this scale.
+- **intset vs unlowered: 0.973×** — IntSet barely matches the
+  unlowered baseline.
+
+`tuple_count=462` matches across all three — correctness
+preserved.
+
+### Why the algorithmic O(log N) does not pay off here
+
+The design predicted ~1.5–3× speedup from O(N) → O(log N) at
+`max_depth=10`. Reality: the Patricia-trie constant factor
+(tree descent, node allocation per insert) **exceeds** the
+~10-element list walk's linear cost. Specifically:
+
+1. **Allocation per insert**: `IS.insert` allocates new tree
+   nodes on each cons-extension (purely functional). `[X|V]`
+   allocates one cons cell. For shallow visited sets, the
+   allocation cost dominates.
+2. **Cache locality**: a small contiguous cons-cell list packs
+   into one or two cache lines. A 4-element IntSet trie scatters
+   across multiple nodes that may hit different cache lines.
+3. **Node traversal overhead**: even `IS.member` on a 10-element
+   `IntSet` does ~3-4 tag-checks and comparisons in a Patricia
+   trie, vs at most 10 simple `==` checks in the list — the
+   constant factors are surprisingly close at this size.
+
+**The IntSet wins kick in at much deeper visited sets** —
+probably `max_depth ≥ 50` or unbounded depth on cyclic graphs.
+For the canonical effective-distance workload at `max_depth=10`,
+the algorithmic improvement does not amortise its constant
+factors.
+
+### Honest reading of the IntSet arc
+
+The IntSet implementation is **correct** (tests + cabal e2e green,
+`tuple_count` matches across all variants), but on the workload it
+was designed for, it does not improve performance — and slightly
+hurts it. Three takeaways:
+
+1. **Algorithmic wins are not free at small N.** The design's
+   "1.5–3× expected" was reasoning from asymptotic complexity
+   without accounting for IntSet's per-operation constant factors
+   on deeply-allocating workloads.
+2. **The infrastructure is reusable.** `VSet`, the directive,
+   and the codegen paths can host other set representations that
+   might win at small N — e.g. a sorted array or a small bitmap
+   for known-small visited sets.
+3. **Phase G is the real macro win.** The constant-factor
+   `not_member_list` lowering (skipping put_structure +
+   builtin_call dispatch + heap term allocation) is what
+   actually speeds up the workload. Phase H's algorithmic
+   pivot was the wrong move for this particular workload.
+
+The directive remains opt-in. Users who don't declare it pay
+nothing. Users who do declare it on workloads with deep visited
+sets may see the expected algorithmic win; users at typical
+`max_depth=10` should leave it off.
+
+A useful follow-up would be to test at `max_depth=50` or higher
+to find the crossover point where IntSet's algorithmic benefit
+finally dominates the constant factors.

--- a/tests/benchmarks/wam_effective_distance_macro_bench.pl
+++ b/tests/benchmarks/wam_effective_distance_macro_bench.pl
@@ -1,20 +1,27 @@
 :- encoding(utf8).
-%% Macro benchmark for the mode-analysis arc on a real workload.
+%% Macro benchmark for the mode-analysis + IntSet visited arc on a real
+%% workload.
 %%
-%% Generates two effective-distance Haskell WAM projects from the
-%% same Prolog source, distinguished only by which mode declarations
-%% are in effect when write_wam_haskell_project/3 runs:
+%% Generates THREE effective-distance Haskell WAM projects from the
+%% same Prolog source, distinguished by which directives are in effect
+%% when write_wam_haskell_project/3 runs:
 %%
+%%   variant_unlowered: no extra modes — Parent's bound state is
+%%                      destroyed by the opaque category_parent call,
+%%                      `\+ member` falls back to the slow builtin path.
 %%   variant_lowered:   mode(category_ancestor(-, +, -, +)) AND
-%%                      mode(category_parent(?, ?))     — `\+ member`
-%%                      lowering fires across the parent call.
-%%   variant_unlowered: only mode(category_ancestor(...)) — Parent's
-%%                      bound state is destroyed by the opaque
-%%                      category_parent call, lowering does not fire.
+%%                      mode(category_parent(?, ?))     — Phase G
+%%                      `not_member_list` lowering fires (constant-
+%%                      factor win over the builtin dispatch).
+%%   variant_intset:    same as `lowered` PLUS
+%%                      visited_set(category_ancestor/4, 4) — Phase H
+%%                      IntSet path: BuildEmptySet/SetInsert/
+%%                      NotMemberSet replace the list-walk entirely
+%%                      (algorithmic O(N) → O(log N) on visited check).
 %%
 %% Each project's standard Main.hs prints `query_ms` to stderr after
-%% running the effective-distance workload against the 1k benchmark
-%% data set. We compare query_ms across the two variants.
+%% running effective-distance against the 1k benchmark data set. We
+%% compare query_ms across all three variants.
 %%
 %% Skip: same as wam_term_construction_bench.pl.
 
@@ -50,7 +57,11 @@ build_dir_for(Variant, Dir) :-
 
 facts_path(Path) :-
     repo_root(Root),
-    directory_file_path(Root, 'data/benchmark/1k/facts.pl', Path).
+    (   getenv('WAM_EFF_DIST_BENCH_SCALE', Scale), Scale \== ''
+    ->  format(atom(Sub), 'data/benchmark/~w/facts.pl', [Scale])
+    ;   Sub = 'data/benchmark/1k/facts.pl'
+    ),
+    directory_file_path(Root, Sub, Path).
 
 workload_path(Path) :-
     repo_root(Root),
@@ -67,12 +78,17 @@ ensure_dir(D) :-
 generate_project(Variant, Dir) :-
     workload_path(Wp),
     load_files(Wp, [silent(true)]),
-    %% Reset relevant modes; declare per variant.
+    %% Reset everything per variant.
     retractall(user:mode(category_ancestor(_, _, _, _))),
     retractall(user:mode(category_parent(_, _))),
+    retractall(user:visited_set(_, _)),
     assertz(user:mode(category_ancestor(-, +, -, +))),
-    (   Variant == lowered
+    (   (Variant == lowered ; Variant == intset)
     ->  assertz(user:mode(category_parent(?, ?)))
+    ;   true
+    ),
+    (   Variant == intset
+    ->  assertz(user:visited_set(category_ancestor/4, 4))
     ;   true
     ),
     ensure_dir(Dir),
@@ -176,32 +192,48 @@ main :-
     ->  format("[SKIP] cabal not on PATH~n"), halt(0)
     ;   true
     ),
-    %% Run lowered first, unlowered second, lowered again, unlowered again
-    %% to spot cache-warming bias.
-    build_and_run(lowered,   L1, T1),
+    %% Run all three variants twice with rotating order to spot
+    %% cache-warming bias.
+    build_and_run(intset,    I1, T1i),
+    build_and_run(lowered,   L1, T1l),
     build_and_run(unlowered, U1, T1u),
     build_and_run(unlowered, U2, _),
     build_and_run(lowered,   L2, _),
+    build_and_run(intset,    I2, _),
     format("~n========================================~n"),
     format("Results (1k facts, query_ms)~n"),
     format("========================================~n"),
-    format("  trial 1: lowered = ~w ms,   unlowered = ~w ms~n", [L1, U1]),
-    format("  trial 2: unlowered = ~w ms, lowered = ~w ms~n",   [U2, L2]),
-    format("  tuple_count: lowered=~w  unlowered=~w (must match for correctness)~n",
-           [T1, T1u]),
-    (   integer(L1), integer(L2), integer(U1), integer(U2),
-        L1 > 0, L2 > 0, U1 > 0, U2 > 0
-    ->  Lavg is (L1 + L2) / 2,
+    format("  trial 1: intset = ~w ms, lowered = ~w ms, unlowered = ~w ms~n",
+           [I1, L1, U1]),
+    format("  trial 2: unlowered = ~w ms, lowered = ~w ms, intset = ~w ms~n",
+           [U2, L2, I2]),
+    format("  tuple_count: intset=~w  lowered=~w  unlowered=~w (must match)~n",
+           [T1i, T1l, T1u]),
+    (   integer(I1), integer(I2), integer(L1), integer(L2),
+        integer(U1), integer(U2),
+        I1 > 0, I2 > 0, L1 > 0, L2 > 0, U1 > 0, U2 > 0
+    ->  Iavg is (I1 + I2) / 2,
+        Lavg is (L1 + L2) / 2,
         Uavg is (U1 + U2) / 2,
-        Speedup is Uavg / Lavg,
-        format("~n  mean lowered:   ~3f ms~n", [Lavg]),
+        SpeedupLowered is Uavg / Lavg,
+        SpeedupIntset  is Uavg / Iavg,
+        SpeedupCompound is Lavg / Iavg,
+        format("~n  mean intset:    ~3f ms~n", [Iavg]),
+        format("  mean lowered:   ~3f ms~n", [Lavg]),
         format("  mean unlowered: ~3f ms~n", [Uavg]),
-        format("  speedup: ~3f x~n", [Speedup])
+        format("  speedup intset vs unlowered:    ~3f x  (Phase G + H combined)~n",
+               [SpeedupIntset]),
+        format("  speedup lowered vs unlowered:   ~3f x  (Phase G alone)~n",
+               [SpeedupLowered]),
+        format("  speedup intset vs lowered:      ~3f x  (Phase H IntSet alone)~n",
+               [SpeedupCompound])
     ;   format("~n[WARN] could not compute means (some runs failed)~n")
     ),
     (   getenv('WAM_EFF_DIST_BENCH_KEEP', V), V \== ''
     ->  format("[INFO] keeping build dirs (WAM_EFF_DIST_BENCH_KEEP set)~n", [])
-    ;   build_dir_for(lowered, DL), build_dir_for(unlowered, DU),
+    ;   build_dir_for(intset, DI), build_dir_for(lowered, DL),
+        build_dir_for(unlowered, DU),
+        catch(cleanup_dir(DI), _, true),
         catch(cleanup_dir(DL), _, true),
         catch(cleanup_dir(DU), _, true)
     ),


### PR DESCRIPTION
## Summary

Closes the IntSet visited arc with measured numbers — and the design's predicted speedup did **not** materialise at the workload's actual recursion depth. This is a real and worth-reporting finding.

- Extends `tests/benchmarks/wam_effective_distance_macro_bench.pl` to a 3-way comparison (`unlowered` / Phase G `lowered` / Phase H `intset`).
- Adds `WAM_EFF_DIST_BENCH_SCALE` env var so the bench can run against 1k or 10k facts.
- Updates `WAM_PERF_OPTIMIZATION_LOG.md` Phase H final entry with the measured numbers and an honest reading of why the algorithmic improvement didn't pay off.
- Memory files (outside repo) refreshed with the IntSet arc completion notes including this finding.

## Measured numbers

10k scale (462 tuples, `max_depth=10`, 6 trials with rotating order):

| variant | mean query_ms |
|---|---:|
| unlowered (no directives) | 931.5 |
| lowered (Phase G `mode` only) | 861.0 |
| intset (Phase G + Phase H) | 957.5 |

| comparison | speedup |
|---|---:|
| **lowered vs unlowered** | **1.082×** (Phase G constant-factor win, as expected) |
| **intset vs lowered** | **0.899×** (IntSet ~10 % **SLOWER** than list) |
| **intset vs unlowered** | **0.973×** (IntSet barely matches the slow path) |

`tuple_count=462` matches across all three — correctness preserved across both the Phase G lowering and the Phase H IntSet path.

## Why the algorithmic O(log N) didn't pay off

The design predicted ~1.5–3× speedup from `O(N) → O(log N)` at `max_depth=10`. Reality: the Patricia-trie constant factors exceed the linear walk cost on a ~10-element list. Specifically:

1. **Allocation per insert**: `IS.insert` allocates new tree nodes per cons-extension (purely functional). `[X|V]` allocates one cons cell. For shallow visited sets, the allocation cost dominates.
2. **Cache locality**: a small contiguous cons-cell list packs into one or two cache lines. A 4-element IntSet trie scatters across multiple nodes.
3. **Node traversal overhead**: even `IS.member` on a 10-element IntSet does ~3-4 tag-checks and comparisons in a Patricia trie, vs at most 10 simple `==` checks in the list. Constant factors are surprisingly close at this size.

The IntSet wins likely materialize at deeper visited sets (`max_depth ≥ 50`); the canonical effective-distance workload doesn't reach there. Phase G's `not_member_list` lowering (skipping the put_structure + builtin_call dispatch + heap term allocation) is the actual macro win on this workload.

## Honest takeaways

1. **Algorithmic wins aren't free at small N.** The design's "1.5-3× expected" was asymptotic reasoning that didn't account for IntSet's constant factors on deeply-allocating workloads.
2. **The infrastructure is reusable.** `VSet`, the directive, and the codegen paths can host other set representations (sorted array, small bitmap) that might beat IntSet at small N. Filed as future exploration.
3. **Phase G is the real macro win.** The constant-factor dispatch reduction is what speeds up the workload. Phase H's algorithmic pivot was the wrong move for `max_depth=10`. The implementation remains correct and opt-in: users at typical depth should leave the directive off.

## Changes

### `tests/benchmarks/wam_effective_distance_macro_bench.pl` (~90 LOC delta)

- New `intset` variant in `generate_project/2` that asserts both the mode declarations AND `:- visited_set(category_ancestor/4, 4)`.
- Reworked `main/0` to run all three variants twice with rotating order, report 3-way comparison with three speedup ratios.
- New `WAM_EFF_DIST_BENCH_SCALE` env var routes `facts_path/1` to `data/benchmark/<scale>/facts.pl`. Defaults to 1k for fast smoke runs; set `WAM_EFF_DIST_BENCH_SCALE=10k` for the macro measurement.

### `docs/design/WAM_PERF_OPTIMIZATION_LOG.md`

Phase H final entry's "Macro benchmark — TODO" replaced with the measured 10k results, the per-trial numbers, the constant-factor analysis, and the three honest takeaways.

### Memory updates (outside repo)

- `project_wam_haskell_intset_visited.md` — updated "what's not measured yet" → measured, with the honest finding.
- `project_wam_haskell_mode_analysis.md` — extended with cross-arc summary and per-arc benchmark numbers.
- `MEMORY.md` — added IntSet visited entry, updated mode-analysis description with measured speedups.
- `todo.md` — marked tasks #186/#187/#188/#191/#192/#193 as completed; new pending entry for max_depth crossover-point exploration.

## Verification

- All 5 lowering / runtime / state-analysis test suites stay green.
- Cabal e2e test still passes.
- The benchmark itself runs end-to-end at both 1k and 10k.

## Test plan

- [ ] Re-run the benchmark at multiple scales to confirm the directionality holds: `WAM_EFF_DIST_BENCH_SCALE=10k swipl -t halt tests/benchmarks/wam_effective_distance_macro_bench.pl`
- [ ] (Future) Benchmark at `max_depth=50` or higher to find the IntSet crossover point.

## Refs

- PR #1684 — IntSet visited design package (`WAM_HASKELL_INTSET_VISITED_DESIGN.md`).
- PR #1686 — Layer 1 (runtime + ADT + handlers).
- PR #1690 — Layer 2 partial (`\+ member` lowering).
- PR #1692 — Layer 2.5 (call-site arg rewrite).
- Task #194 (this PR) — closes the arc with measured numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)