### PR TITLE
bench(csharp-query): Summarize C# query source registrations in sweep reports

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -1034,7 +1034,8 @@ Comparison note:
   `csharp_query_best_source_mode` summary
 - use `benchmark_csharp_query_source_mode_sweep.py` when you want a compact
   cross-workload TSV or Markdown summary of best source mode, auto-vs-best
-  ratio, output agreement, and per-mode medians
+  ratio, output agreement, per-mode medians, and source-registration storage
+  families
 - cache reuse remains disabled for these one-shot generated benchmark
   programs, and trace creation is now opt-in rather than always-on
 - the hand-written C# DFS baseline is still cheaper after its lighter

--- a/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
+++ b/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
@@ -40,6 +40,7 @@ class SourceModeSummary:
     auto_vs_best: str
     output_agreement: str
     median_summary: str
+    source_registration_summary: str
 
 
 def parse_args() -> argparse.Namespace:
@@ -85,6 +86,7 @@ def parse_workloads(value: str) -> list[str]:
 def parse_runner_output(workload: str, output: str) -> list[SourceModeSummary]:
     medians: dict[str, dict[str, str]] = {}
     hashes: dict[str, dict[str, str]] = {}
+    source_registrations: dict[str, dict[str, str]] = {}
     best_modes: dict[str, str] = {}
     auto_vs_best: dict[str, str] = {}
 
@@ -95,6 +97,13 @@ def parse_runner_output(workload: str, output: str) -> list[SourceModeSummary]:
             source_mode = parts[1].split(":", 1)[1]
             medians.setdefault(scale, {})[source_mode] = parts[2]
             hashes.setdefault(scale, {})[source_mode] = parts[6]
+        elif len(parts) >= 3 and parts[1].startswith("csharp-query:") and parts[1].endswith("-metrics"):
+            scale = parts[0]
+            target = parts[1][:-len("-metrics")]
+            source_mode = target.split(":", 1)[1]
+            registrations = summarize_source_registration_tokens(parts[2])
+            if registrations:
+                source_registrations.setdefault(scale, {})[source_mode] = registrations
         elif len(parts) >= 3 and parts[1] == "csharp_query_best_source_mode":
             best_modes[parts[0]] = parts[2]
         elif len(parts) >= 3 and parts[1] == "csharp_query_auto_vs_best_source_mode":
@@ -110,6 +119,10 @@ def parse_runner_output(workload: str, output: str) -> list[SourceModeSummary]:
             f"{mode}:{mode_medians[mode]}"
             for mode in sorted(mode_medians)
         )
+        registration_summary = ",".join(
+            f"{mode}:{registrations}"
+            for mode, registrations in sorted(source_registrations.get(scale, {}).items())
+        )
         summaries.append(
             SourceModeSummary(
                 workload=workload,
@@ -118,9 +131,20 @@ def parse_runner_output(workload: str, output: str) -> list[SourceModeSummary]:
                 auto_vs_best=auto_vs_best.get(scale, ""),
                 output_agreement=output_agreement,
                 median_summary=median_summary,
+                source_registration_summary=registration_summary,
             )
         )
     return summaries
+
+
+def summarize_source_registration_tokens(metrics: str) -> str:
+    registrations: list[str] = []
+    for token in metrics.split():
+        if not token.startswith("source_registration_") or "=" not in token:
+            continue
+        key, value = token.split("=", 1)
+        registrations.append(f"{key[len('source_registration_'):]}={value}")
+    return "|".join(sorted(registrations))
 
 
 def run_workload(
@@ -157,21 +181,23 @@ def run_workload(
 
 
 def print_tsv(summaries: list[SourceModeSummary]) -> None:
-    print("workload\tscale\tbest_source_mode\tauto_vs_best\toutput_agreement\tmedian_s_by_mode")
+    print("workload\tscale\tbest_source_mode\tauto_vs_best\toutput_agreement\tmedian_s_by_mode\tsource_registrations_by_mode")
     for summary in summaries:
         print(
             f"{summary.workload}\t{summary.scale}\t{summary.best_source_mode}\t"
-            f"{summary.auto_vs_best}\t{summary.output_agreement}\t{summary.median_summary}"
+            f"{summary.auto_vs_best}\t{summary.output_agreement}\t{summary.median_summary}\t"
+            f"{summary.source_registration_summary}"
         )
 
 
 def print_markdown(summaries: list[SourceModeSummary]) -> None:
-    print("| Workload | Scale | Best source mode | Auto vs best | Outputs | Median seconds by mode |")
-    print("| --- | --- | --- | ---: | --- | --- |")
+    print("| Workload | Scale | Best source mode | Auto vs best | Outputs | Median seconds by mode | Source registrations by mode |")
+    print("| --- | --- | --- | ---: | --- | --- | --- |")
     for summary in summaries:
         print(
             f"| {summary.workload} | {summary.scale} | {summary.best_source_mode} | "
-            f"{summary.auto_vs_best} | {summary.output_agreement} | `{summary.median_summary}` |"
+            f"{summary.auto_vs_best} | {summary.output_agreement} | `{summary.median_summary}` | "
+            f"`{summary.source_registration_summary}` |"
         )
 
 

--- a/examples/benchmark/benchmark_dependency_depth_cross_target.py
+++ b/examples/benchmark/benchmark_dependency_depth_cross_target.py
@@ -34,6 +34,7 @@ from benchmark_common import (
     print_csharp_query_source_mode_summary,
     print_match_status,
     print_pair_match_status,
+    print_phase_metrics,
     print_result_table,
     print_speedup,
     require_file,
@@ -160,11 +161,13 @@ def print_summary(results: list[RunResult]) -> None:
         print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
         print_speedup(scale, "speedup_vs_go_dfs", go_dfs, qe)
         for csharp_entry in csharp_query_results(entries):
+            metric_label = f"{csharp_entry.target}-metrics" if csharp_entry.target != "csharp-query" else "csharp-query-metrics"
             bucket_label = (
                 f"{csharp_entry.target}-bucket-strategies"
                 if csharp_entry.target != "csharp-query"
                 else "csharp-query-bucket-strategies"
             )
+            print_phase_metrics(scale, metric_label, csharp_entry)
             print_bucket_strategy_metrics(scale, bucket_label, csharp_entry)
         print_csharp_query_source_mode_summary(scale, entries)
 

--- a/examples/benchmark/benchmark_dependency_longest_depth_cross_target.py
+++ b/examples/benchmark/benchmark_dependency_longest_depth_cross_target.py
@@ -34,6 +34,7 @@ from benchmark_common import (
     print_csharp_query_source_mode_summary,
     print_match_status,
     print_pair_match_status,
+    print_phase_metrics,
     print_result_table,
     print_speedup,
     require_file,
@@ -163,11 +164,13 @@ def print_summary(results: list[RunResult]) -> None:
         if csharp_query and go_dfs:
             print_speedup(scale, "speedup_vs_go_dfs", go_dfs, csharp_query)
         for csharp_entry in csharp_query_results(entries):
+            metric_label = f"{csharp_entry.target}-metrics" if csharp_entry.target != "csharp-query" else "csharp-query-metrics"
             bucket_label = (
                 f"{csharp_entry.target}-bucket-strategies"
                 if csharp_entry.target != "csharp-query"
                 else "csharp-query-bucket-strategies"
             )
+            print_phase_metrics(scale, metric_label, csharp_entry)
             print_bucket_strategy_metrics(scale, bucket_label, csharp_entry)
         print_csharp_query_source_mode_summary(scale, entries)
 


### PR DESCRIPTION
  ## Summary

  - extend `benchmark_csharp_query_source_mode_sweep.py` to parse `source_registration_*` metrics
  - add `source_registrations_by_mode` to TSV and Markdown report output
  - make dependency depth runners emit C# query metrics rows consistently
  - update benchmark README to document source-registration storage summaries

  ## Validation

  - `git diff --check`
  - `python3 -m py_compile` for touched report/dependency runners
  - traced TSV smoke for `category-influence` with `auto,artifact-prebuilt`
  - traced Markdown smoke for `dependency-depth` with `auto,preload`
  - non-trace TSV smoke for `dependency-depth` with `auto,preload`