### PR TITLE
feat(wam-scala): float arithmetic, more builtins, and Phase S7 fact seam

### DIFF
--- a/src/unifyweaver/targets/wam_scala_target.pl
+++ b/src/unifyweaver/targets/wam_scala_target.pl
@@ -274,13 +274,16 @@ strip_arity_suffix(Pred, Name) :-
     ).
 
 %% constant_to_scala_term(+ConstStr, -ScalaTermLit) is det.
-%  Converts a WAM constant token to its Scala-source-literal form. Numeric
-%  tokens become IntTerm(N) so arithmetic builtins (is/2, =:=/2, ...) can
-%  evaluate them; non-numeric tokens are interned as atoms.
+%  Converts a WAM constant token to its Scala-source-literal form.
+%  Integer tokens become IntTerm(N); float tokens become FloatTerm(N);
+%  everything else is interned as an atom.
 constant_to_scala_term(C, Lit) :-
     (   number_string(N, C),
         integer(N)
     ->  format(string(Lit), 'IntTerm(~w)', [N])
+    ;   number_string(F, C),
+        float(F)
+    ->  format(string(Lit), 'FloatTerm(~w)', [F])
     ;   intern_scala_atom(C, AtomId),
         format(string(Lit), 'Atom(~w)', [AtomId])
     ).
@@ -302,15 +305,26 @@ scala_string_escape_char('"',  ['\\', '"'])  :- !.
 scala_string_escape_char(C, [C]).
 
 %% parse_functor_arity(+FunctorStr, -Name, -Arity)
+%  Splits a WAM functor token of the form "name/arity" into Name and Arity.
+%  Uses the *last* "/" as the separator so functor names that themselves
+%  contain a slash (e.g. the division operator "/" rendered as "//2") are
+%  parsed correctly.
 parse_functor_arity(FStr, Name, Arity) :-
     atom_string(FA, FStr),
-    (   sub_atom(FA, B, 1, _, '/')
+    (   last_slash_index(FA, B)
     ->  sub_atom(FA, 0, B, _, Name),
         B1 is B + 1,
         sub_atom(FA, B1, _, 0, AS),
         atom_number(AS, Arity)
     ;   Name = FA, Arity = 0
     ).
+
+%% last_slash_index(+Atom, -Index)
+%  Index of the last "/" in Atom, or fails if none.
+last_slash_index(Atom, Index) :-
+    findall(B, sub_atom(Atom, B, 1, _, '/'), Bs),
+    Bs \= [],
+    last(Bs, Index).
 
 % ============================================================================
 % WAM TEXT → SCALA INSTRUCTION ARRAY
@@ -506,12 +520,115 @@ scala_foreign_handler_entry(handler(Pred/Arity, HandlerCode), Entry) :-
     format(string(Entry), '    "~w/~w" -> ~w', [Pred, Arity, HandlerCode]).
 
 % ============================================================================
+% FACT BACKEND SEAM (Phase S7)
+% ============================================================================
+% A FactSource is a declarative way to provide fact-shaped data to a
+% predicate at codegen time without writing a full Scala ForeignHandler.
+% The user supplies `scala_fact_sources([source(P/A, Tuples), ...])` where
+% each Tuple is a list of Arity atoms. The codegen synthesises:
+%   - a ForeignHandler that enumerates all tuples as ForeignMulti solutions
+%     (the runtime's existing applyBindings + backtracking machinery filters
+%     them against the input args);
+%   - a foreign_predicates entry so the WAM body is replaced by a
+%     CallForeign stub;
+%   - intern_atoms entries for every atom used in any tuple.
+% This is the "inline" implementation; sidecar (file/LMDB) backends will
+% slot into the same option in later phases.
+
+%% expand_fact_sources_in_options(+Options0, -Options) is det.
+%  Replaces scala_fact_sources(...) entries with equivalent
+%  foreign_predicates + scala_foreign_handlers + intern_atoms entries,
+%  preserving any user-supplied entries in those lists by union.
+expand_fact_sources_in_options(Options0, Options) :-
+    (   option(scala_fact_sources(Sources), Options0, []),
+        Sources \= []
+    ->  findall(P/A, member(source(P/A, _), Sources), SourcePreds),
+        findall(handler(P/A, Code),
+                (   member(source(P/A, Tuples), Sources),
+                    fact_source_to_handler_code(A, Tuples, Code)
+                ),
+                SourceHandlers),
+        findall(Atom,
+                (   member(source(_/_, Tuples), Sources),
+                    member(Tuple, Tuples),
+                    member(Atom, Tuple)
+                ),
+                FactAtomsBag),
+        list_to_set(FactAtomsBag, FactAtoms),
+        % Union with any user-supplied lists. option/3 picks the first
+        % occurrence; we replace it with the unioned form below.
+        option(foreign_predicates(FPs0), Options0, []),
+        option(scala_foreign_handlers(FHs0), Options0, []),
+        option(intern_atoms(IA0), Options0, []),
+        list_union(FPs0, SourcePreds, FPsAll),
+        list_union(FHs0, SourceHandlers, FHsAll),
+        list_union(IA0, FactAtoms, IAAll),
+        replace_option(foreign_predicates, FPsAll, Options0, O1),
+        replace_option(scala_foreign_handlers, FHsAll, O1, O2),
+        replace_option(intern_atoms, IAAll, O2, Options)
+    ;   Options = Options0
+    ).
+
+%% fact_source_to_handler_code(+Arity, +Tuples, -ScalaCode) is det.
+fact_source_to_handler_code(Arity, Tuples, Code) :-
+    maplist(tuple_to_solution_map_lit(Arity), Tuples, SolLits),
+    atomic_list_concat(SolLits, ',\n        ', SolBody),
+    format(string(Code),
+           "new ForeignHandler {\n      def apply(args: Array[WamTerm]): ForeignResult = {\n        val sols: Seq[Map[Int, WamTerm]] = Seq(\n        ~w\n        )\n        if (sols.isEmpty) ForeignFail else ForeignMulti(sols)\n      }\n    }",
+           [SolBody]).
+
+tuple_to_solution_map_lit(Arity, Tuple, Lit) :-
+    is_list(Tuple),
+    length(Tuple, Arity),
+    map_args_to_pairs(Tuple, 1, Pairs),
+    atomic_list_concat(Pairs, ', ', PairsStr),
+    format(string(Lit), 'Map(~w)', [PairsStr]).
+
+map_args_to_pairs([], _, []).
+map_args_to_pairs([A|Rest], N, [Pair|More]) :-
+    fact_arg_to_scala_term(A, TermLit),
+    format(string(Pair), '~w -> ~w', [N, TermLit]),
+    N1 is N + 1,
+    map_args_to_pairs(Rest, N1, More).
+
+%% fact_arg_to_scala_term(+Arg, -ScalaTermLit)
+%  Same numeric/atom split as constant_to_scala_term/2 but operating
+%  on Prolog terms (not WAM-text strings).
+fact_arg_to_scala_term(N, Lit) :-
+    integer(N), !,
+    format(string(Lit), 'IntTerm(~w)', [N]).
+fact_arg_to_scala_term(F, Lit) :-
+    float(F), !,
+    format(string(Lit), 'FloatTerm(~w)', [F]).
+fact_arg_to_scala_term(A, Lit) :-
+    atom_string(A, S),
+    intern_scala_atom(S, AtomId),
+    format(string(Lit), 'Atom(~w)', [AtomId]).
+
+%% list_union(+L1, +L2, -Union) — preserves order of L1, then appends new of L2.
+list_union(L1, L2, Union) :-
+    findall(X, (member(X, L2), \+ member(X, L1)), New),
+    append(L1, New, Union).
+
+%% replace_option(+Key, +Value, +Options0, -Options)
+%  Removes any existing Key(...) entry from Options0 and prepends
+%  Key(Value).
+replace_option(Key, Value, Options0, [NewEntry | Cleaned]) :-
+    exclude([X]>>( compound(X), X =.. [Key, _] ), Options0, Cleaned),
+    NewEntry =.. [Key, Value].
+
+% ============================================================================
 % PROJECT WRITER
 % ============================================================================
 
-%% write_wam_scala_project(+Predicates, +Options, +ProjectDir) is det.
-%  Creates a complete Scala WAM project in ProjectDir.
-write_wam_scala_project(Predicates, Options, ProjectDir) :-
+%% write_wam_scala_project(+Predicates, +Options0, +ProjectDir) is det.
+%  Creates a complete Scala WAM project in ProjectDir. The S7 fact-backend
+%  seam is processed before anything else: scala_fact_sources(...) entries
+%  expand into equivalent foreign_predicates + scala_foreign_handlers +
+%  intern_atoms entries, so the rest of the pipeline doesn't need to know
+%  about fact sources as a distinct concept.
+write_wam_scala_project(Predicates, Options0, ProjectDir) :-
+    expand_fact_sources_in_options(Options0, Options),
     make_directory_path(ProjectDir),
     % --- build.sbt ---
     option(module_name(ModName), Options, 'wam-scala-generated'),

--- a/templates/targets/scala_wam/program.scala.mustache
+++ b/templates/targets/scala_wam/program.scala.mustache
@@ -92,29 +92,34 @@ object GeneratedProgram {
   }
 
   // Parse a CLI argument into a WamTerm.
-  // Supports integers ("42", "-3"), atoms ("a"), structures ("f(a,b)"),
-  // and lists ("[a,b]"). Unknown atom strings get id -1 so they fail
-  // unification with known atoms.
+  // Supports integers ("42", "-3"), floats ("3.14", "-1.5"), atoms ("a"),
+  // structures ("f(a,b)"), and lists ("[a,b]"). Unknown atom strings get
+  // id -1 so they fail unification with known atoms.
   private def parseArg(s: String): WamTerm = {
     val t = s.trim
-    // Integers first — covers signed ints; falls through to atom on parse error.
+    // Integers first, then floats; both fall through to atom/list/struct
+    // on parse error so that things like "f(3,4)" still parse correctly.
     val intOpt = try Some(t.toInt) catch { case _: NumberFormatException => None }
-    intOpt match {
-      case Some(n) => IntTerm(n)
-      case None =>
-        if (t.startsWith("[") && t.endsWith("]"))
-          parseList(t.substring(1, t.length - 1))
-        else {
-          val open = t.indexOf('(')
-          if (open > 0 && t.endsWith(")")) {
-            val functor = t.substring(0, open)
-            val inner = t.substring(open + 1, t.length - 1)
-            val argTerms = splitTopLevelCommas(inner).map(parseArg).toArray
-            Struct(internAtomId(functor), argTerms.length, argTerms)
-          } else {
-            Atom(internAtomId(t))
-          }
-        }
+    if (intOpt.isDefined) return IntTerm(intOpt.get)
+    // Only parse as float if there's a decimal point or exponent — avoids
+    // accidentally turning identifiers like "1e" into floats and lets us
+    // pass through to the atom path otherwise.
+    if (t.exists(c => c == '.' || c == 'e' || c == 'E')) {
+      val dblOpt = try Some(t.toDouble) catch { case _: NumberFormatException => None }
+      if (dblOpt.isDefined) return FloatTerm(dblOpt.get)
+    }
+    if (t.startsWith("[") && t.endsWith("]"))
+      parseList(t.substring(1, t.length - 1))
+    else {
+      val open = t.indexOf('(')
+      if (open > 0 && t.endsWith(")")) {
+        val functor = t.substring(0, open)
+        val inner = t.substring(open + 1, t.length - 1)
+        val argTerms = splitTopLevelCommas(inner).map(parseArg).toArray
+        Struct(internAtomId(functor), argTerms.length, argTerms)
+      } else {
+        Atom(internAtomId(t))
+      }
     }
   }
 

--- a/templates/targets/scala_wam/runtime.scala.mustache
+++ b/templates/targets/scala_wam/runtime.scala.mustache
@@ -672,26 +672,39 @@ object WamRuntime {
           if (ok) s.pc += 1 else backtrack(s)
         case "true/0" =>
           s.pc += 1
+        case "fail/0" =>
+          backtrack(s)
         case "!/0" =>
           s.choicePoints = s.choicePoints.drop(s.choicePoints.length - s.cutBar)
           s.pc += 1
 
         // Arithmetic: A1 is target (assignment) or left operand (comparison),
         // A2 is the expression / right operand. The expression term is built
-        // by put_structure +/2 etc. and evaluated recursively.
+        // by put_structure +/2 etc. and evaluated recursively. Result type
+        // is Int or Double depending on operands and operator.
         case "is/2" =>
           evalArith(s, program, s.regs(2)) match {
             case Some(n) =>
-              if (unify(s, s.regs(1), IntTerm(n))) s.pc += 1 else backtrack(s)
+              if (unify(s, s.regs(1), numToTerm(n))) s.pc += 1 else backtrack(s)
             case None =>
               backtrack(s)
           }
-        case "=:=/2" => arithCmp(s, program, _ == _)
-        case "=\\=/2" => arithCmp(s, program, _ != _)
-        case "</2"   => arithCmp(s, program, _ < _)
-        case ">/2"   => arithCmp(s, program, _ > _)
-        case "=</2"  => arithCmp(s, program, _ <= _)
-        case ">=/2"  => arithCmp(s, program, _ >= _)
+        case "=:=/2" => arithCmp(s, program, numEq)
+        case "=\\=/2" => arithCmp(s, program, (a, b) => !numEq(a, b))
+        case "</2"   => arithCmp(s, program, numLt)
+        case ">/2"   => arithCmp(s, program, (a, b) => numLt(b, a))
+        case "=</2"  => arithCmp(s, program, (a, b) => !numLt(b, a))
+        case ">=/2"  => arithCmp(s, program, (a, b) => !numLt(a, b))
+
+        // Negation as failure. Reflects the goal term back into a predicate
+        // call, runs it in a saved sub-state, and inverts the result.
+        case "\\+/1" =>
+          val goal = deref(s.bindings, s.regs(1))
+          metaCallSucceeds(s, program, goal) match {
+            case Some(true)  => backtrack(s)        // goal succeeded → \+ fails
+            case Some(false) => s.pc += 1            // goal failed   → \+ succeeds
+            case None        => backtrack(s)        // unresolvable goal → fail
+          }
 
         case _ =>
           backtrack(s)
@@ -726,53 +739,174 @@ object WamRuntime {
   // functors (+, -, *, /, mod) are looked up by name via the program's
   // intern table, so the runtime is independent of the well-known atom
   // ID assignment. Returns None on type errors / unbound vars / div-by-0.
+  //
+  // Mixed Int/Double: the result type promotes to NDouble whenever any
+  // sub-expression is a Double or when the operator is `/` (true division).
+  // Integer division uses `//`. This mirrors SWI-Prolog's is/2 semantics
+  // closely enough for typical numeric workloads.
 
-  def evalArith(s: WamState, program: WamProgram, t: WamTerm): Option[Int] = {
+  sealed trait Num {
+    def toDouble: Double = this match {
+      case NInt(n)    => n.toDouble
+      case NDouble(d) => d
+    }
+  }
+  final case class NInt(value: Int) extends Num
+  final case class NDouble(value: Double) extends Num
+
+  def numOf(t: WamTerm): Option[Num] = t match {
+    case IntTerm(n)   => Some(NInt(n))
+    case FloatTerm(d) => Some(NDouble(d))
+    case _            => None
+  }
+
+  def numToTerm(n: Num): WamTerm = n match {
+    case NInt(v)    => IntTerm(v)
+    case NDouble(v) => FloatTerm(v)
+  }
+
+  def numEq(a: Num, b: Num): Boolean = (a, b) match {
+    case (NInt(x), NInt(y)) => x == y
+    case _                  => a.toDouble == b.toDouble
+  }
+  def numLt(a: Num, b: Num): Boolean = (a, b) match {
+    case (NInt(x), NInt(y)) => x < y
+    case _                  => a.toDouble < b.toDouble
+  }
+
+  private def numBinop(name: String, a: Num, b: Num): Option[Num] = (a, b) match {
+    case (NInt(x), NInt(y)) =>
+      name match {
+        case "+"   => Some(NInt(x + y))
+        case "-"   => Some(NInt(x - y))
+        case "*"   => Some(NInt(x * y))
+        case "/"   => Some(NDouble(x.toDouble / y.toDouble))   // true division
+        case "//"  if y != 0 => Some(NInt(x / y))               // integer division
+        case "mod" if y != 0 => Some(NInt(x % y))
+        case _     => None
+      }
+    case _ =>
+      val x = a.toDouble; val y = b.toDouble
+      name match {
+        case "+" => Some(NDouble(x + y))
+        case "-" => Some(NDouble(x - y))
+        case "*" => Some(NDouble(x * y))
+        case "/" => Some(NDouble(x / y))
+        case _   => None
+      }
+  }
+
+  def evalArith(s: WamState, program: WamProgram, t: WamTerm): Option[Num] = {
     val v = deref(s.bindings, t)
-    v match {
-      case IntTerm(n) => Some(n)
-      case Struct(f, 2, args) =>
-        val name =
-          if (f >= 0 && f < program.internTable.idToString.length)
-            program.internTable.idToString(f)
-          else ""
-        val a = evalArith(s, program, args(0))
-        val b = evalArith(s, program, args(1))
-        (a, b) match {
-          case (Some(x), Some(y)) =>
+    numOf(v) match {
+      case Some(n) => Some(n)
+      case None => v match {
+        case Struct(f, 2, args) =>
+          val name =
+            if (f >= 0 && f < program.internTable.idToString.length)
+              program.internTable.idToString(f)
+            else ""
+          for {
+            a <- evalArith(s, program, args(0))
+            b <- evalArith(s, program, args(1))
+            r <- numBinop(name, a, b)
+          } yield r
+        case Struct(f, 1, args) =>
+          val name =
+            if (f >= 0 && f < program.internTable.idToString.length)
+              program.internTable.idToString(f)
+            else ""
+          evalArith(s, program, args(0)).flatMap { x =>
             name match {
-              case "+" => Some(x + y)
-              case "-" => Some(x - y)
-              case "*" => Some(x * y)
-              case "/"   if y != 0 => Some(x / y)
-              case "mod" if y != 0 => Some(x % y)
+              case "-" => Some(x match { case NInt(n) => NInt(-n); case NDouble(d) => NDouble(-d) })
+              case "+" => Some(x)
               case _   => None
             }
-          case _ => None
-        }
-      case Struct(f, 1, args) =>
-        val name =
-          if (f >= 0 && f < program.internTable.idToString.length)
-            program.internTable.idToString(f)
-          else ""
-        evalArith(s, program, args(0)).flatMap { x =>
-          name match {
-            case "-" => Some(-x)
-            case "+" => Some(x)
-            case _   => None
           }
-        }
-      case _ => None
+        case _ => None
+      }
     }
   }
 
   /** Helper for arithmetic comparison builtins: evaluate A1 and A2 then
-   *  apply `op` to the integer results. Advances pc on true; backtracks on
-   *  false or on any evaluation failure. */
-  def arithCmp(s: WamState, program: WamProgram, op: (Int, Int) => Boolean): Unit = {
+   *  apply `op` to the (Int|Double) results. Advances pc on true;
+   *  backtracks on false or any evaluation failure. */
+  def arithCmp(s: WamState, program: WamProgram, op: (Num, Num) => Boolean): Unit = {
     (evalArith(s, program, s.regs(1)), evalArith(s, program, s.regs(2))) match {
       case (Some(a), Some(b)) if op(a, b) => s.pc += 1
       case _                              => backtrack(s)
+    }
+  }
+
+  // ----------------------------------------------------------
+  // Meta-call: invoke a predicate from a goal term
+  // ----------------------------------------------------------
+  // Used by \+/1 and (eventually) call/1. Saves the relevant outer
+  // state, runs the goal until completion in the same WamState, then
+  // restores. Returns Some(true) if the goal succeeded, Some(false) if
+  // it failed deterministically, or None if the goal could not be
+  // resolved to a known predicate. Bindings made during the goal are
+  // unwound on exit so \+ does not leak partial bindings.
+
+  def metaCallSucceeds(s: WamState, program: WamProgram, goal: WamTerm): Option[Boolean] = {
+    val (key, args) = goal match {
+      case Atom(f) =>
+        val n = if (f >= 0 && f < program.internTable.idToString.length)
+                  program.internTable.idToString(f) else ""
+        (s"$n/0", Array.empty[WamTerm])
+      case Struct(f, arity, sargs) =>
+        val n = if (f >= 0 && f < program.internTable.idToString.length)
+                  program.internTable.idToString(f) else ""
+        (s"$n/$arity", sargs)
+      case _ => return None
+    }
+    program.dispatch.get(key) match {
+      case None => None
+      case Some(startPc) =>
+        // Snapshot outer state.
+        val savedPc        = s.pc
+        val savedCallStack = s.callStack
+        val savedTrailLen  = s.trail.length
+        val savedCPs       = s.choicePoints
+        val savedRegs      = s.regs.clone()
+        val savedEnvStack  = s.envStack
+        val savedNextVarId = s.nextVarId
+        val savedCutBar    = s.cutBar
+        val savedStatus    = s.status
+        val savedUnifyQ    = s.unifyQueue
+        val savedBuildStk  = s.buildStack
+
+        // Set up the goal's call frame. callStack is empty so Proceed
+        // will mark the sub-run as Succeeded rather than try to return
+        // to the outer caller.
+        java.util.Arrays.fill(s.regs.asInstanceOf[Array[AnyRef]], null)
+        args.zipWithIndex.foreach { case (v, i) => s.regs(i + 1) = v }
+        s.callStack    = Nil
+        s.choicePoints = Nil
+        s.envStack     = Nil
+        s.unifyQueue   = Nil
+        s.buildStack   = Nil
+        s.cutBar       = 0
+        s.pc           = startPc
+        s.status       = Running
+
+        while (s.status == Running) step(s, program)
+        val ok = s.status == Succeeded
+
+        // Restore — \+ does not propagate any bindings from the goal.
+        unwindTrail(s, savedTrailLen)
+        System.arraycopy(savedRegs, 0, s.regs, 0, REG_ARRAY_SIZE)
+        s.callStack    = savedCallStack
+        s.choicePoints = savedCPs
+        s.envStack     = savedEnvStack
+        s.nextVarId    = savedNextVarId
+        s.cutBar       = savedCutBar
+        s.unifyQueue   = savedUnifyQ
+        s.buildStack   = savedBuildStk
+        s.pc           = savedPc
+        s.status       = savedStatus
+
+        Some(ok)
     }
   }
 

--- a/tests/test_wam_scala_runtime_smoke.pl
+++ b/tests/test_wam_scala_runtime_smoke.pl
@@ -59,6 +59,16 @@
 :- dynamic user:wam_eq_arith/2.
 :- dynamic user:wam_neq_arith/2.
 :- dynamic user:wam_cut_obs/1.
+:- dynamic user:wam_always_fail/1.
+:- dynamic user:wam_dummy_a/1.
+:- dynamic user:wam_neg_dummy/1.
+:- dynamic user:wam_float_mul/2.
+:- dynamic user:wam_float_div/2.
+:- dynamic user:wam_float_lit/1.
+:- dynamic user:wam_float_cmp_lt/2.
+:- dynamic user:wam_int_div_true/2.
+:- dynamic user:wam_pair_inline/2.
+:- dynamic user:wam_pair_sidecar/2.
 
 user:wam_fact(a).
 user:wam_execute_caller(X)    :- user:wam_fact(X).
@@ -121,6 +131,30 @@ user:wam_geq(X, Y)        :- X >= Y.
 user:wam_leq(X, Y)        :- X =< Y.
 user:wam_eq_arith(X, Y)   :- X =:= Y.
 user:wam_neq_arith(X, Y)  :- X =\= Y.
+
+% --- fail/0 and \+/1 ---
+user:wam_always_fail(_X) :- fail.
+user:wam_dummy_a(a).
+% Negation-as-failure: succeeds only when the inner goal fails.
+user:wam_neg_dummy(X) :- \+ user:wam_dummy_a(X).
+
+% --- Float arithmetic ---
+user:wam_float_mul(X, Y)    :- Y is X * 2.5.
+user:wam_float_div(X, Y)    :- Y is X / 2.0.
+user:wam_float_lit(Y)       :- Y is 3.14.
+user:wam_float_cmp_lt(X, Y) :- X < Y.
+% True division of two integers: 5/2 -> 2.5, not 2 (per SWI semantics).
+user:wam_int_div_true(X, Y) :- Y is X / 2.
+
+% --- S7 fact backend seam ---
+% Same relation under two backends. The inline form has WAM-compiled
+% facts; the sidecar form passes the same tuples via scala_fact_sources
+% so the codegen synthesises a ForeignHandler that enumerates them.
+% Both forms must give identical answers for every query.
+user:wam_pair_inline(a, b).
+user:wam_pair_inline(b, c).
+user:wam_pair_inline(c, d).
+user:wam_pair_sidecar(_, _).
 
 % ============================================================
 % Condition: only run if scalac is available
@@ -386,6 +420,82 @@ test(arith_compare) :-
             verify_scala_args(TmpDir, 'wam_neq_arith/2', ['3', '4'], "true"),
             verify_scala_args(TmpDir, 'wam_neq_arith/2', ['3', '3'], "false")
         )).
+
+% --- fail/0 builtin ---
+test(builtin_fail) :-
+    with_scala_project(
+        [user:wam_always_fail/1],
+        _Opts,
+        TmpDir,
+        (
+            verify_scala(TmpDir, 'wam_always_fail/1', 'a', "false"),
+            verify_scala(TmpDir, 'wam_always_fail/1', 'b', "false")
+        )).
+
+% --- \+/1 negation-as-failure ---
+% wam_neg_dummy(a) → false (wam_dummy_a(a) succeeds, so \+ fails)
+% wam_neg_dummy(b) → true  (wam_dummy_a(b) fails,    so \+ succeeds)
+test(builtin_negation) :-
+    with_scala_project(
+        [user:wam_dummy_a/1, user:wam_neg_dummy/1],
+        _Opts,
+        TmpDir,
+        (
+            verify_scala(TmpDir, 'wam_neg_dummy/1', 'a', "false"),
+            verify_scala(TmpDir, 'wam_neg_dummy/1', 'b', "true"),
+            verify_scala(TmpDir, 'wam_neg_dummy/1', 'c', "true")
+        )).
+
+% --- Float arithmetic ---
+test(arith_float) :-
+    with_scala_project(
+        [user:wam_float_mul/2, user:wam_float_div/2,
+         user:wam_float_lit/1, user:wam_float_cmp_lt/2,
+         user:wam_int_div_true/2],
+        _Opts,
+        TmpDir,
+        (
+            verify_scala_args(TmpDir, 'wam_float_mul/2',    ['4', '10.0'],   "true"),
+            verify_scala_args(TmpDir, 'wam_float_mul/2',    ['4', '11.0'],   "false"),
+            verify_scala_args(TmpDir, 'wam_float_div/2',    ['9', '4.5'],    "true"),
+            verify_scala_args(TmpDir, 'wam_float_div/2',    ['9', '4.0'],    "false"),
+            verify_scala_args(TmpDir, 'wam_float_lit/1',    ['3.14'],        "true"),
+            verify_scala_args(TmpDir, 'wam_float_lit/1',    ['3.15'],        "false"),
+            verify_scala_args(TmpDir, 'wam_float_cmp_lt/2', ['1.5', '2.5'],  "true"),
+            verify_scala_args(TmpDir, 'wam_float_cmp_lt/2', ['2.5', '1.5'],  "false"),
+            % Mixed Int/Float comparison should promote.
+            verify_scala_args(TmpDir, 'wam_float_cmp_lt/2', ['1', '2.5'],    "true"),
+            verify_scala_args(TmpDir, 'wam_float_cmp_lt/2', ['2.5', '3'],    "true"),
+            % True division of integers yields a Float.
+            verify_scala_args(TmpDir, 'wam_int_div_true/2', ['5', '2.5'],    "true"),
+            verify_scala_args(TmpDir, 'wam_int_div_true/2', ['5', '2'],      "false")
+        )).
+
+% --- S7 fact backend seam: parity inline-vs-sidecar ---
+% Both versions answer the same set of queries identically.
+test(fact_source_inline_vs_sidecar) :-
+    InlineQueries =
+        [['a','b']-true, ['a','c']-false, ['b','c']-true,
+         ['c','d']-true, ['x','y']-false],
+    % Inline backend: WAM-compiled facts.
+    with_scala_project(
+        [user:wam_pair_inline/2],
+        _OptsInline,
+        TmpDir1,
+        forall(member(Args-Expected, InlineQueries),
+               ( (Expected == true -> S = "true" ; S = "false"),
+                 verify_scala_args(TmpDir1, 'wam_pair_inline/2', Args, S)
+               ))),
+    % Sidecar backend: same tuples, declared via scala_fact_sources.
+    with_scala_project(
+        [user:wam_pair_sidecar/2],
+        [ scala_fact_sources(
+              [source(wam_pair_sidecar/2, [[a,b], [b,c], [c,d]])]) ],
+        TmpDir2,
+        forall(member(Args-Expected, InlineQueries),
+               ( (Expected == true -> S = "true" ; S = "false"),
+                 verify_scala_args(TmpDir2, 'wam_pair_sidecar/2', Args, S)
+               ))).
 
 :- end_tests(wam_scala_runtime_smoke).
 


### PR DESCRIPTION
## Summary

Three thematic additions in one PR. All four new smoke tests pass under
`scalac` + `scala`.

| | Before | After |
|---|---|---|
| Generator tests | 10 | 10 |
| Smoke tests | 18 | **22** |

This PR closes the bottom three open items on the WAM Scala plan list
that didn't depend on external infra: float arithmetic, the `fail`/`\+`
builtin gap-fill, and the start of Phase S7 — the fact-backend seam
that lets relations be supplied as declarative tuples instead of WAM
clauses.

## What's in the diff

### Float arithmetic — `arith_float` smoke test

- `evalArith` now returns a `Num` ADT (`NInt | NDouble`) instead of a
  raw `Int`. Mixed Int/Double operations promote to Double; true
  division `/` always returns Double (matching SWI-Prolog); integer
  division is reachable via `//` and `mod` if a future emitter needs
  them.
- Codegen detects float literals in `get_constant` / `put_constant` /
  `set_constant` / `unify_constant` via `constant_to_scala_term/2` and
  emits `FloatTerm(N)` instead of treating them as atoms.
- The CLI parser recognises floats (anything with `.` / `e` / `E` that
  Java parses as a `Double`) and emits `FloatTerm`; otherwise it falls
  through to the existing int / atom / list / struct logic.
- The comparison family (`=:=`, `=\=`, `<`, `>`, `=<`, `>=`) takes a
  `(Num, Num) => Boolean` operator and uses Double-promoted comparison
  whenever either operand is Double.

### Bug fix uncovered by float arithmetic

`parse_functor_arity/3` was finding the *first* `/` in the functor
token, which broke for the division operator (rendered as `//2` in WAM
text — functor `/` of arity 2). The compiled output was emitting
`Raw("put_structure //2 A2")` instead of a real `PutStructure`, so
`Y is X / 2.0` silently failed. Fixed to use the *last* slash as the
arity separator. Other functors that use `/` would have hit this too;
this is a real fix, not just a float-specific patch.

### Builtin gap-fill — `builtin_fail`, `builtin_negation` smoke tests

- `fail/0` — single-line backtrack handler.
- `\+/1` (negation-as-failure) — implemented via a meta-call helper
  `metaCallSucceeds` that snapshots the relevant outer state, runs
  the goal in the same `WamState` until completion (`callStack` starts
  empty so `Proceed` marks success), then restores everything.
  Bindings made during the goal are unwound on exit so `\+` never
  propagates partial bindings to the outer scope.

### Phase S7 fact backend seam — `fact_source_inline_vs_sidecar` test

- New option `scala_fact_sources([source(P/A, Tuples), ...])` where
  each `Tuple` is a list of `Arity` atoms (or numbers). The codegen
  expands each source into:
    1. a `foreign_predicates` entry (so the WAM body becomes a
       `CallForeign` stub);
    2. a synthesised `ForeignHandler` that returns `ForeignMulti` with
       one solution per tuple — the runtime's existing `applyBindings`
       + backtracking machinery filters tuples against the input args;
    3. `intern_atoms` entries for every atom appearing in any tuple.
- Expansion happens via `expand_fact_sources_in_options/2` at the top
  of `write_wam_scala_project/3`, so the rest of the pipeline never
  needs to know about fact sources as a distinct concept. User-supplied
  `foreign_predicates` / `scala_foreign_handlers` / `intern_atoms` are
  preserved by union with the synthesised entries.
- The parity test runs the same query set against:
    1. `wam_pair_inline/2` — WAM-compiled facts (3 ground clauses);
    2. `wam_pair_sidecar/2` — same tuples passed through
       `scala_fact_sources`.
  Both return identical answers across positive and negative cases.

## Test plan

- [ ] `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_generator.pl"),run_tests,halt' -t 'halt(1)'` → 10/10 pass.
- [ ] With `scalac` on PATH or `SCALA_SMOKE_TESTS=1`:
      `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_runtime_smoke.pl"),run_tests,halt' -t 'halt(1)'` → 22/22 pass.
- [ ] Without `scalac`: smoke unit reports "No tests to run" (gated by `scala_available/0`).

## Out of scope

- Sidecar fact sources backed by external storage — the current `source(...)`
  form is inline tuples only. File / LMDB backends slot into the same
  `scala_fact_sources` option in S8.
- `call/1`, `call/2+`, `findall/3`, `bagof/3` — the meta-call
  scaffolding from `\+/1` makes `call/1` straightforward to add later
  but it isn't included here.
- Floating-point trig / log / pow — only `+`, `-`, `*`, `/`, `mod`, and
  unary `+`/`-` are supported in `evalArith`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)