### PR TITLE
bench(csharp-query): tune scan auto prebuilt threshold

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -113,6 +113,8 @@ namespace UnifyWeaver.QueryRuntime
 
     public static class RelationSourceModePolicy
     {
+        private const long SmallJoinPrebuiltArtifactRowThreshold = 7_500L;
+
         public static bool TryParse(string? value, out RelationSourceMode mode)
         {
             switch ((value ?? "preload").Trim().ToLowerInvariant())
@@ -164,7 +166,7 @@ namespace UnifyWeaver.QueryRuntime
             {
                 "bound_scan" => RelationSourceMode.Artifact,
                 "selective_join" => RelationSourceMode.Artifact,
-                "join" when totalRows <= 5_000L => RelationSourceMode.ArtifactPrebuilt,
+                "join" when totalRows <= SmallJoinPrebuiltArtifactRowThreshold => RelationSourceMode.ArtifactPrebuilt,
                 "join" => RelationSourceMode.Artifact,
                 _ => RelationSourceMode.Preload,
             };


### PR DESCRIPTION
  ## Summary

  - Raises the scan benchmark auto-policy cutoff for small binary `join` workloads from `5,000` to `7,500` input rows.
  - Names the cutoff as `SmallJoinPrebuiltArtifactRowThreshold`.
  - Keeps non-join and n-ary join auto-policy behavior unchanged.

  ## Verification

  - `git diff --check`
  - `python3 examples/benchmark/benchmark_scan_materialization.py --scales 300 --modes join,nary_join --source-modes
  auto,preload,artifact-prebuilt --strategies auto --repetitions 1 --format report-tsv`
  - `python3 examples/benchmark/benchmark_scan_materialization.py --scales 1k --modes join --source-modes auto,artifact-
  prebuilt,artifact --strategies auto --repetitions 1 --format report-tsv`