### PR TITLE
feat(wam-scala): call/1 + member/length/append + file fact source

### DIFF
--- a/src/unifyweaver/targets/wam_scala_target.pl
+++ b/src/unifyweaver/targets/wam_scala_target.pl
@@ -544,14 +544,20 @@ expand_fact_sources_in_options(Options0, Options) :-
         Sources \= []
     ->  findall(P/A, member(source(P/A, _), Sources), SourcePreds),
         findall(handler(P/A, Code),
-                (   member(source(P/A, Tuples), Sources),
-                    fact_source_to_handler_code(A, Tuples, Code)
+                (   member(source(P/A, Spec), Sources),
+                    fact_source_spec_to_handler_code(A, Spec, Code)
                 ),
                 SourceHandlers),
+        % Collect atoms from inline tuple sources for pre-interning. File-
+        % backed sources can't pre-intern at codegen time (the file is read
+        % at runtime), so the user must declare expected atoms via
+        % intern_atoms(...) if their handler-side code needs them.
         findall(Atom,
-                (   member(source(_/_, Tuples), Sources),
-                    member(Tuple, Tuples),
-                    member(Atom, Tuple)
+                (   member(source(_/_, Spec), Sources),
+                    is_list(Spec),
+                    member(Tuple, Spec),
+                    member(Atom, Tuple),
+                    \+ number(Atom)
                 ),
                 FactAtomsBag),
         list_to_set(FactAtomsBag, FactAtoms),
@@ -568,6 +574,25 @@ expand_fact_sources_in_options(Options0, Options) :-
         replace_option(intern_atoms, IAAll, O2, Options)
     ;   Options = Options0
     ).
+
+%% fact_source_spec_to_handler_code(+Arity, +Spec, -ScalaCode) is det.
+%  Dispatches on the shape of Spec:
+%    - Spec is a list of tuples → inline handler enumerating them.
+%    - Spec is file('path') → handler that reads CSV at runtime.
+fact_source_spec_to_handler_code(Arity, Spec, Code) :-
+    is_list(Spec), !,
+    fact_source_to_handler_code(Arity, Spec, Code).
+fact_source_spec_to_handler_code(Arity, file(Path), Code) :-
+    !,
+    atom_string(Path, PathStr),
+    scala_string_literal(PathStr, PathLit),
+    format(string(Code),
+           "new ForeignHandler {\n      def apply(args: Array[WamTerm]): ForeignResult = {\n        val src = scala.io.Source.fromFile(~w)\n        try {\n          val sols: Seq[Map[Int, WamTerm]] = src.getLines().toList.map { line =>\n            val parts = line.split(\",\").map(_.trim)\n            parts.zipWithIndex.map { case (p, i) => (i + 1) -> parseFactArg(p) }.toMap\n          }\n          if (sols.isEmpty) ForeignFail else ForeignMulti(sols)\n        } finally { src.close() }\n      }\n    }",
+           [PathLit]),
+    % Note: Arity isn't enforced here (each line uses whatever columns are
+    % present); a malformed CSV will simply produce wrong-arity bindings
+    % that the runtime will fail to unify. Acceptable for a first cut.
+    _ = Arity.
 
 %% fact_source_to_handler_code(+Arity, +Tuples, -ScalaCode) is det.
 fact_source_to_handler_code(Arity, Tuples, Code) :-

--- a/templates/targets/scala_wam/program.scala.mustache
+++ b/templates/targets/scala_wam/program.scala.mustache
@@ -147,4 +147,19 @@ object GeneratedProgram {
 
   private def internAtomId(s: String): Int =
     internTable.stringToId.getOrElse(s, -1)
+
+  /** Parse one CSV-cell string into a WamTerm. Used by file-backed
+   *  fact-source handlers. Same numeric/atom split as parseArg but
+   *  without the list / structure forms (CSV cells are expected to be
+   *  scalars). */
+  private def parseFactArg(s: String): WamTerm = {
+    val t = s.trim
+    val intOpt = try Some(t.toInt) catch { case _: NumberFormatException => None }
+    if (intOpt.isDefined) return IntTerm(intOpt.get)
+    if (t.exists(c => c == '.' || c == 'e' || c == 'E')) {
+      val dblOpt = try Some(t.toDouble) catch { case _: NumberFormatException => None }
+      if (dblOpt.isDefined) return FloatTerm(dblOpt.get)
+    }
+    Atom(internAtomId(t))
+  }
 }

--- a/templates/targets/scala_wam/runtime.scala.mustache
+++ b/templates/targets/scala_wam/runtime.scala.mustache
@@ -499,8 +499,12 @@ object WamRuntime {
         s.pc = target
 
       case Call(pred, arity) =>
-        // Unresolved — look up in dispatch table
-        program.dispatch.get(s"$pred/$arity") match {
+        // Special case call/1 as a meta-call — unwrap module qualification
+        // ":/2" if present and dispatch on the inner goal.
+        if (pred == "call" && arity == 1) {
+          metaCallInline(s, program, deref(s.bindings, s.regs(1)),
+                         resumePc = s.pc + 1, withReturn = true)
+        } else program.dispatch.get(s"$pred/$arity") match {
           case Some(pc) =>
             s.callStack = (s.pc + 1) :: s.callStack
             s.pc = pc
@@ -509,7 +513,11 @@ object WamRuntime {
         }
 
       case Execute(pred, arity) =>
-        program.dispatch.get(s"$pred/$arity") match {
+        if (pred == "call" && arity == 1) {
+          // Tail-call meta-call: don't push a return address.
+          metaCallInline(s, program, deref(s.bindings, s.regs(1)),
+                         resumePc = s.pc + 1, withReturn = false)
+        } else program.dispatch.get(s"$pred/$arity") match {
           case Some(pc) => s.pc = pc
           case None     => backtrack(s)
         }
@@ -706,6 +714,53 @@ object WamRuntime {
             case None        => backtrack(s)        // unresolvable goal → fail
           }
 
+        // member(Element, List) — multi-solution. Each list element
+        // becomes one ForeignMulti-style solution binding A1.
+        case "member/2" =>
+          listToSeq(s, program, s.regs(2)) match {
+            case None         => backtrack(s)
+            case Some(Nil)    => backtrack(s)
+            case Some(items) =>
+              val sols = items.map(item => Map(1 -> item))
+              val resumePc = s.pc + 1
+              val rest = sols.tail
+              if (rest.nonEmpty) {
+                val cp = ChoicePoint(
+                  pc        = resumePc,
+                  regs      = snapshotRegs(s),
+                  envStack  = s.envStack,
+                  callStack = s.callStack,
+                  trailLen  = s.trail.length,
+                  cutBar    = s.cutBar,
+                  nextVarId = s.nextVarId,
+                  kind      = ForeignCP(rest)
+                )
+                s.choicePoints = cp :: s.choicePoints
+              }
+              if (applyBindings(s, sols.head)) s.pc = resumePc
+              else backtrack(s)
+          }
+
+        // length(List, N) — deterministic for a ground list.
+        case "length/2" =>
+          listToSeq(s, program, s.regs(1)) match {
+            case Some(items) =>
+              if (unify(s, s.regs(2), IntTerm(items.length))) s.pc += 1
+              else backtrack(s)
+            case None => backtrack(s)
+          }
+
+        // append(A, B, C) — deterministic concat-mode: A and B ground
+        // (or at least convertible to a list), C unifies with the result.
+        case "append/3" =>
+          (listToSeq(s, program, s.regs(1)),
+           listToSeq(s, program, s.regs(2))) match {
+            case (Some(a), Some(b)) =>
+              val joined = seqToList(program, a ++ b)
+              if (unify(s, s.regs(3), joined)) s.pc += 1 else backtrack(s)
+            case _ => backtrack(s)
+          }
+
         case _ =>
           backtrack(s)
       }
@@ -835,6 +890,97 @@ object WamRuntime {
     (evalArith(s, program, s.regs(1)), evalArith(s, program, s.regs(2))) match {
       case (Some(a), Some(b)) if op(a, b) => s.pc += 1
       case _                              => backtrack(s)
+    }
+  }
+
+  // ----------------------------------------------------------
+  // Goal reflection helpers
+  // ----------------------------------------------------------
+  // call/1 and \+/1 receive the goal as a term (Atom for arity-0,
+  // Struct(f,arity,args) otherwise). The goal may be wrapped in `:/2`
+  // for module qualification (e.g. user:wam_dummy(X)) — we unwrap that
+  // recursively so the runtime sees `wam_dummy(X)`.
+
+  def unwrapModuleQualification(s: WamState, program: WamProgram, t: WamTerm): WamTerm = {
+    val v = deref(s.bindings, t)
+    v match {
+      case Struct(f, 2, args) =>
+        val name = if (f >= 0 && f < program.internTable.idToString.length)
+                     program.internTable.idToString(f) else ""
+        if (name == ":") unwrapModuleQualification(s, program, args(1))
+        else v
+      case _ => v
+    }
+  }
+
+  /** Resolve a goal term to (pred-key, arg-array). Returns None for terms
+   *  that can't be invoked (Refs, IntTerms, etc.). */
+  def goalToPredCall(s: WamState, program: WamProgram, goal: WamTerm): Option[(String, Array[WamTerm])] = {
+    unwrapModuleQualification(s, program, goal) match {
+      case Atom(f) =>
+        val n = if (f >= 0 && f < program.internTable.idToString.length)
+                  program.internTable.idToString(f) else ""
+        Some((s"$n/0", Array.empty[WamTerm]))
+      case Struct(f, arity, args) =>
+        val n = if (f >= 0 && f < program.internTable.idToString.length)
+                  program.internTable.idToString(f) else ""
+        Some((s"$n/$arity", args))
+      case _ => None
+    }
+  }
+
+  /** call/1 implementation. Reflects the goal into a real predicate call.
+   *  When `withReturn` is true, pushes resumePc onto the callStack so the
+   *  goal's Proceed returns to it; otherwise this is a tail call. */
+  def metaCallInline(s: WamState, program: WamProgram, goal: WamTerm,
+                     resumePc: Int, withReturn: Boolean): Unit = {
+    goalToPredCall(s, program, goal) match {
+      case None => backtrack(s)
+      case Some((key, args)) =>
+        program.dispatch.get(key) match {
+          case None => backtrack(s)
+          case Some(startPc) =>
+            // Place args in argument registers.
+            args.zipWithIndex.foreach { case (v, i) => s.regs(i + 1) = v }
+            if (withReturn) s.callStack = resumePc :: s.callStack
+            s.pc = startPc
+        }
+    }
+  }
+
+  // ----------------------------------------------------------
+  // List helpers
+  // ----------------------------------------------------------
+  // listToSeq deconstructs a Prolog list term into a Scala Seq. Returns
+  // None for partial / improper lists (unbound tail or non-cons cell
+  // before the closing []). Cons cells use functor `[|]` from the
+  // intern table; the empty list is the atom `[]`.
+
+  def listToSeq(s: WamState, program: WamProgram, list: WamTerm): Option[Seq[WamTerm]] = {
+    val emptyId = program.internTable.stringToId.getOrElse("[]",  -1)
+    val consId  = program.internTable.stringToId.getOrElse("[|]", -1)
+    val buf = scala.collection.mutable.ListBuffer.empty[WamTerm]
+    var cur = deref(s.bindings, list)
+    while (true) {
+      cur match {
+        case Atom(id) if id == emptyId =>
+          return Some(buf.toList)
+        case Struct(f, 2, args) if f == consId =>
+          buf.append(deref(s.bindings, args(0)))
+          cur = deref(s.bindings, args(1))
+        case _ =>
+          return None
+      }
+    }
+    None
+  }
+
+  /** Build a Prolog list term from a Scala Seq. */
+  def seqToList(program: WamProgram, items: Seq[WamTerm]): WamTerm = {
+    val emptyId = program.internTable.stringToId.getOrElse("[]",  -1)
+    val consId  = program.internTable.stringToId.getOrElse("[|]", -1)
+    items.foldRight[WamTerm](Atom(emptyId)) { (h, t) =>
+      Struct(consId, 2, Array(h, t))
     }
   }
 

--- a/tests/test_wam_scala_runtime_smoke.pl
+++ b/tests/test_wam_scala_runtime_smoke.pl
@@ -69,6 +69,13 @@
 :- dynamic user:wam_int_div_true/2.
 :- dynamic user:wam_pair_inline/2.
 :- dynamic user:wam_pair_sidecar/2.
+:- dynamic user:wam_pair_file/2.
+:- dynamic user:wam_call_dummy/1.
+:- dynamic user:wam_meta_dummy/1.
+:- dynamic user:wam_member_q/2.
+:- dynamic user:wam_member_or_abc/1.
+:- dynamic user:wam_length_q/2.
+:- dynamic user:wam_append_q/3.
 
 user:wam_fact(a).
 user:wam_execute_caller(X)    :- user:wam_fact(X).
@@ -155,6 +162,18 @@ user:wam_pair_inline(a, b).
 user:wam_pair_inline(b, c).
 user:wam_pair_inline(c, d).
 user:wam_pair_sidecar(_, _).
+user:wam_pair_file(_, _).
+
+% --- call/1 meta-call ---
+user:wam_call_dummy(a).
+user:wam_call_dummy(b).
+user:wam_meta_dummy(X) :- call(user:wam_call_dummy(X)).
+
+% --- List builtins ---
+user:wam_member_q(X, L)     :- member(X, L).
+user:wam_member_or_abc(X)   :- member(X, [a, b, c]).
+user:wam_length_q(L, N)     :- length(L, N).
+user:wam_append_q(A, B, C)  :- append(A, B, C).
 
 % ============================================================
 % Condition: only run if scalac is available
@@ -497,6 +516,90 @@ test(fact_source_inline_vs_sidecar) :-
                  verify_scala_args(TmpDir2, 'wam_pair_sidecar/2', Args, S)
                ))).
 
+% --- File-backed fact source ---
+% Same parity check, but the tuples come from a CSV file at runtime.
+test(fact_source_file_backed) :-
+    write_facts_csv('_tmp_facts.csv', [[a,b], [b,c], [c,d]]),
+    absolute_file_name('_tmp_facts.csv', AbsPath),
+    Queries =
+        [['a','b']-true, ['a','c']-false, ['b','c']-true,
+         ['c','d']-true, ['x','y']-false],
+    setup_call_cleanup(
+        true,
+        with_scala_project(
+            [user:wam_pair_file/2],
+            % Atoms in the CSV are read at runtime, so they need to be
+            % declared up-front for parseFactArg to find them in the
+            % runtime intern table. Otherwise every atom collapses to id
+            % -1 and the test can't discriminate matches from mismatches.
+            [ intern_atoms([a, b, c, d, x, y]),
+              scala_fact_sources(
+                  [source(wam_pair_file/2, file(AbsPath))]) ],
+            TmpDir,
+            forall(member(Args-Expected, Queries),
+                   ( (Expected == true -> S = "true" ; S = "false"),
+                     verify_scala_args(TmpDir, 'wam_pair_file/2', Args, S)
+                   ))),
+        catch(delete_file('_tmp_facts.csv'), _, true)).
+
+% --- call/1 meta-call ---
+test(call_meta) :-
+    with_scala_project(
+        [user:wam_call_dummy/1, user:wam_meta_dummy/1],
+        _Opts,
+        TmpDir,
+        (
+            verify_scala(TmpDir, 'wam_meta_dummy/1', 'a', "true"),
+            verify_scala(TmpDir, 'wam_meta_dummy/1', 'b', "true"),
+            verify_scala(TmpDir, 'wam_meta_dummy/1', 'c', "false")
+        )).
+
+% --- List builtins ---
+test(builtin_member) :-
+    with_scala_project(
+        [user:wam_member_q/2, user:wam_member_or_abc/1],
+        [ intern_atoms([a, b, c, d]) ],
+        TmpDir,
+        (
+            verify_scala_args(TmpDir, 'wam_member_q/2', ['a', '[a,b,c]'], "true"),
+            verify_scala_args(TmpDir, 'wam_member_q/2', ['b', '[a,b,c]'], "true"),
+            verify_scala_args(TmpDir, 'wam_member_q/2', ['c', '[a,b,c]'], "true"),
+            verify_scala_args(TmpDir, 'wam_member_q/2', ['d', '[a,b,c]'], "false"),
+            verify_scala_args(TmpDir, 'wam_member_q/2', ['a', '[]'],      "false"),
+            verify_scala(TmpDir, 'wam_member_or_abc/1', 'a', "true"),
+            verify_scala(TmpDir, 'wam_member_or_abc/1', 'b', "true"),
+            verify_scala(TmpDir, 'wam_member_or_abc/1', 'c', "true"),
+            verify_scala(TmpDir, 'wam_member_or_abc/1', 'd', "false")
+        )).
+
+test(builtin_length) :-
+    with_scala_project(
+        [user:wam_length_q/2],
+        _Opts,
+        TmpDir,
+        (
+            verify_scala_args(TmpDir, 'wam_length_q/2', ['[]',      '0'], "true"),
+            verify_scala_args(TmpDir, 'wam_length_q/2', ['[a]',     '1'], "true"),
+            verify_scala_args(TmpDir, 'wam_length_q/2', ['[a,b,c]', '3'], "true"),
+            verify_scala_args(TmpDir, 'wam_length_q/2', ['[a,b]',   '3'], "false")
+        )).
+
+test(builtin_append) :-
+    with_scala_project(
+        [user:wam_append_q/3],
+        [ intern_atoms([a, b, c]) ],
+        TmpDir,
+        (
+            verify_scala_args(TmpDir, 'wam_append_q/3',
+                              ['[a]', '[b,c]', '[a,b,c]'], "true"),
+            verify_scala_args(TmpDir, 'wam_append_q/3',
+                              ['[]', '[a,b]', '[a,b]'], "true"),
+            verify_scala_args(TmpDir, 'wam_append_q/3',
+                              ['[a,b]', '[]', '[a,b]'], "true"),
+            verify_scala_args(TmpDir, 'wam_append_q/3',
+                              ['[a]', '[b]', '[a,c]'], "false")
+        )).
+
 :- end_tests(wam_scala_runtime_smoke).
 
 % ============================================================
@@ -595,6 +698,17 @@ unique_scala_tmp_dir(Prefix, TmpDir) :-
     get_time(T),
     Stamp is floor(T * 1000),
     format(atom(TmpDir), '~w_~w', [Prefix, Stamp]).
+
+%% write_facts_csv(+Path, +Tuples) is det.
+%  Writes each tuple as a comma-separated line to Path. Used by the
+%  file-backed fact source test.
+write_facts_csv(Path, Tuples) :-
+    setup_call_cleanup(
+        open(Path, write, Stream),
+        forall(member(Tuple, Tuples),
+               ( atomic_list_concat(Tuple, ',', Line),
+                 format(Stream, '~w~n', [Line]) )),
+        close(Stream)).
 
 % ============================================================
 % Foreign handler bodies (Scala source)


### PR DESCRIPTION
## Summary

Three additive surface-area gaps closed in one PR. All five new smoke
tests pass under `scalac` + `scala`.

| | Before | After |
|---|---|---|
| Generator tests | 10 | 10 |
| Smoke tests | 22 | **27** |

## What's in the diff

### `call/1` meta-call — `call_meta` smoke test

The WAM compiler treats `call/1` as a regular predicate (`Execute` or
`Call` instruction with `pred="call"`, `arity=1`). The runtime now
intercepts those instructions when `pred=="call" && arity==1` and
reflects `regs[1]` back into a real predicate dispatch via a new
`metaCallInline` helper. Module-qualified goals (`:/2(user, foo(X))`)
are unwrapped recursively before dispatching. Both the call (with
return address) and tail-call (`Execute`) paths are handled, so
`call/1` works at any position in a body.

The existing `\+/1` implementation has its own snapshot/restore logic
and is left as-is — refactoring it isn't required and would risk
regressing the negation tests. The new goal-reflection helpers
(`unwrapModuleQualification`, `goalToPredCall`) are reusable for
future `call/N` variants.

### List builtins — `builtin_member`, `builtin_length`, `builtin_append`

| Builtin | Mode supported |
|---|---|
| `member/2` | Multi-solution. Each list element becomes one `ForeignMulti`-style solution binding `A1`. Reuses the runtime's existing `applyBindings` + `ForeignCP` backtrack machinery so cut and CP unwinding behave correctly. |
| `length/2` | Deterministic for ground lists. |
| `append/3` | Deterministic concat-mode: `A` and `B` ground, `C` unifies with the joined result. Inverse / split modes are out of scope for now. |

Two new general-purpose runtime helpers underpin all of this:

- `listToSeq(s, program, list)` — walks a Prolog list term, returning
  `None` for partial / improper lists. Looks up the cons (`[|]`) and
  empty (`[]`) functor IDs from the program intern table.
- `seqToList(program, items)` — builds a Prolog list term from a
  Scala `Seq`.

### File-backed fact source — `fact_source_file_backed`

New spec form `source(P/A, file('path.csv'))` for `scala_fact_sources`.
The codegen emits a `ForeignHandler` that opens the file at runtime,
splits each line on commas, and turns each column into a `WamTerm`
via a new `parseFactArg` helper in the program template (atom / int /
float — same numeric/atom split as `parseArg`, no nested structures
since CSV cells are scalars).

The S7 fact-seam abstraction now supports two backends in the same
`scala_fact_sources([...])` option:

```prolog
scala_fact_sources([
  source(p1/2, [[a,b], [b,c]]),               % inline tuples (S7 first cut)
  source(p2/2, file('/path/to/data.csv'))     % new in this PR
])
```

#### Limitations / notes

- Atoms in the CSV are read at runtime, after codegen has finished
  populating the intern table. Tests that care about atom identity
  must declare expected atoms via `intern_atoms(...)` so the runtime
  intern table contains them. The codegen-side comment documents this.
- The CSV reader assumes valid input — malformed lines produce
  wrong-arity bindings the runtime will fail to unify, which is
  acceptable for a first cut.
- File-backed sources don't auto-collect atoms for pre-interning
  (the file isn't read at codegen time). Inline tuple sources still do.

### Test harness

New `write_facts_csv/2` helper writes tuples to a CSV file for the
file-backed test, with cleanup via `setup_call_cleanup/3`.

## Test plan

- [ ] `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_generator.pl"),run_tests,halt' -t 'halt(1)'` → 10/10 pass.
- [ ] With `scalac` on PATH or `SCALA_SMOKE_TESTS=1`:
      `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_runtime_smoke.pl"),run_tests,halt' -t 'halt(1)'` → 27/27 pass.
- [ ] Without `scalac`: smoke unit reports "No tests to run" (gated by `scala_available/0`).

## Out of scope

- `call/N` for `N > 1` — adding the variadic forms is a small follow-up
  to the `call/1` infrastructure.
- `findall/3`, `bagof/3`, `setof/3` — collect-mode builtins. The
  `metaCallInline`/`metaCallSucceeds` scaffolding makes these
  approachable, but they need a results buffer that's cleaner to add
  in a separate PR.
- Inverse-mode `append/3` (split C into A and B) and length/2's
  generative mode (build a list of N fresh vars from N).
- LMDB-backed `source(P/A, lmdb('path'))` — the JVM seam belongs to
  Phase S8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
