### PR TITLE
feat(wam-clojure): route lowered emitter predicates

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -28,6 +28,11 @@
 :- use_module(library(process), [process_create/3, process_wait/2]).
 :- use_module('../core/template_system', [render_template/3]).
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../targets/wam_clojure_lowered_emitter', [
+    wam_clojure_lowerable/3,
+    lower_predicate_to_clojure/4,
+    clojure_lowered_func_name/2
+]).
 
 %% write_wam_clojure_project(+Predicates, +Options, +ProjectDir)
 %  Generate a minimal hybrid/WAM Clojure project with:
@@ -96,11 +101,11 @@ compile_predicates_for_project([], _, CoreNamespace, RuntimeNamespace, Code) :-
   (println false))
 ', [CoreNamespace, CoreNamespace, RuntimeNamespace]).
 compile_predicates_for_project(Predicates, Options, CoreNamespace, RuntimeNamespace, Code) :-
-    collect_wam_entries(Predicates, Options, 0, WamEntries, RawEntries, LabelEntries, DispatchEntries),
+    collect_wam_entries(Predicates, Options, 0, PredicateBodies, RawEntries, LabelEntries, DispatchEntries),
     clojure_foreign_handlers_code(Options, ForeignHandlersCode),
     atomic_list_concat(RawEntries, '\n  ', RawBody0),
     atomic_list_concat(LabelEntries, '\n  ', LabelBody0),
-    atomic_list_concat(WamEntries, '\n\n', WrapperCode),
+    atomic_list_concat(PredicateBodies, '\n\n', WrapperCode),
     atomic_list_concat(DispatchEntries, '\n  ', DispatchBody0),
     (RawBody0 == "" -> RawBody = "" ; format(atom(RawBody), '  ~w', [RawBody0])),
     (LabelBody0 == "" -> LabelBody = "" ; format(atom(LabelBody), '  ~w', [LabelBody0])),
@@ -147,18 +152,27 @@ compile_predicates_for_project(Predicates, Options, CoreNamespace, RuntimeNamesp
 
 collect_wam_entries([], _, _, [], [], [], []).
 collect_wam_entries([PredIndicator|Rest], Options, PC,
-                    [WrapperCode|RestWrappers], AllInstrs, AllLabels, [DispatchEntry|RestDispatch]) :-
+                    [PredicateCode|RestWrappers], AllInstrs, AllLabels, [DispatchEntry|RestDispatch]) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
     (   clojure_foreign_predicate(Pred, Arity, Options)
-    ->  clojure_foreign_stub_data(Pred, Arity, PC, GoLiterals, LabelPairs, NextPC)
+    ->  clojure_foreign_stub_data(Pred, Arity, PC, GoLiterals, LabelPairs, NextPC),
+        compile_wam_predicate_to_clojure_shared(Pred/Arity, PC, PredicateCode),
+        predicate_clojure_name(Pred, DispatchName)
     ;   wam_target:compile_predicate_to_wam(PredIndicator, Options, WamCode),
-        wam_code_to_clojure_data(WamCode, PC, GoLiterals, LabelPairs, NextPC)
+        (   wam_clojure_lowerable(Pred/Arity, WamCode, _Reason)
+        ->  lower_predicate_to_clojure(Pred/Arity, WamCode, Options, PredicateCode),
+            clojure_lowered_func_name(Pred/Arity, DispatchName),
+            GoLiterals = [],
+            LabelPairs = [],
+            NextPC = PC
+        ;   wam_code_to_clojure_data(WamCode, PC, GoLiterals, LabelPairs, NextPC),
+            compile_wam_predicate_to_clojure_shared(Pred/Arity, PC, PredicateCode),
+            predicate_clojure_name(Pred, DispatchName)
+        )
     ),
     maplist([Lit, Entry]>>format(atom(Entry), '~w', [Lit]), GoLiterals, InstrEntries),
     maplist([Label-Idx, Entry]>>format(atom(Entry), '~w ~w', [Label, Idx]), LabelPairs, LabelRows),
-    compile_wam_predicate_to_clojure_shared(Pred/Arity, PC, WrapperCode),
-    predicate_clojure_name(Pred, CljName),
-    format(atom(DispatchEntry), '"~w/~w" ~w', [Pred, Arity, CljName]),
+    format(atom(DispatchEntry), '"~w/~w" ~w', [Pred, Arity, DispatchName]),
     collect_wam_entries(Rest, Options, NextPC, RestWrappers, RestInstrs, RestLabels, RestDispatch),
     append(InstrEntries, RestInstrs, AllInstrs),
     append(LabelRows, RestLabels, AllLabels).
@@ -482,7 +496,7 @@ wam_op_to_clojure_literal(_Op, _Args, Line, Literal) :-
     format(atom(Literal), '{:op :raw :text ~w}', [LineLit]).
 
 parse_switch_cases(CasesText, CaseEntries) :-
-    split_string(CasesText, ",", " ", RawCases),
+    split_string(CasesText, " ", " ", RawCases),
     maplist(parse_switch_case, RawCases, CaseEntries).
 
 parse_switch_case(RawCase, Entry) :-

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -293,6 +293,40 @@ test(foreign_lowering_false_suppresses_clojure_foreign_stub) :-
         delete_directory_and_contents(TmpDir)
     )).
 
+test(lowered_wam_predicate_routes_into_dispatch) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_lowered_route', TmpDir),
+        write_wam_clojure_project([user:wam_fact/1],
+                                  [namespace('generated.wam_lowered_route_test')], TmpDir),
+        directory_file_path(TmpDir, 'src/generated/wam_lowered_route_test/core.clj', CorePath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(sub_string(CoreCode, _, _, _, '(defn lowered-wam-fact-1 [state]')),
+        assertion(sub_string(CoreCode, _, _, _, '"wam_fact/1" lowered-wam-fact-1')),
+        assertion(\+ sub_string(CoreCode, _, _, _, '(def wam-fact-start-pc ')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+test(mixed_project_supports_lowered_foreign_and_shared_wam) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_mixed_route', TmpDir),
+        write_wam_clojure_project([user:wam_fact/1,
+                                   user:wam_parent_lookup/2,
+                                   user:wam_choice_fact/1],
+                                  [ namespace('generated.wam_mixed_route_test'),
+                                    foreign_predicates([wam_parent_lookup/2])
+                                  ], TmpDir),
+        directory_file_path(TmpDir, 'src/generated/wam_mixed_route_test/core.clj', CorePath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(sub_string(CoreCode, _, _, _, '(defn lowered-wam-fact-1 [state]')),
+        assertion(sub_string(CoreCode, _, _, _, '"wam_fact/1" lowered-wam-fact-1')),
+        assertion(sub_string(CoreCode, _, _, _, '{:op :call-foreign :pred "wam_parent_lookup" :arity 2}')),
+        assertion(sub_string(CoreCode, _, _, _, '"wam_parent_lookup/2" wam-parent-lookup')),
+        assertion(sub_string(CoreCode, _, _, _, '(def wam-choice-fact-start-pc ')),
+        assertion(sub_string(CoreCode, _, _, _, '"wam_choice_fact/1" wam-choice-fact')),
+        assertion(sub_string(CoreCode, _, _, _, '{:op :switch-on-constant :cases [')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
 test(switch_on_constant_preserves_default_fallthrough) :-
     once((
         unique_tmp_dir('tmp_wam_clojure_switch', TmpDir),


### PR DESCRIPTION
# Summary

Wire the new Clojure lowered-emitter scaffold into the hybrid Clojure WAM target so generated projects can mix:

- lowered WAM predicates
- `call-foreign` predicates
- ordinary shared-WAM fallback predicates

This is the first implementation PR that makes the lowered tier active in generated Clojure hybrid WAM output instead of leaving it as an unused library module.

# What Changed

- updated `src/unifyweaver/targets/wam_clojure_target.pl`
  - import the lowered-emitter module
  - classify predicates during project generation
  - route lowerable predicates to generated lowered function bodies
  - keep foreign predicates on the existing `call-foreign` stub path
  - keep unsupported or non-lowerable predicates on the shared-WAM fallback path
  - fix dispatch naming so lowered predicates point at the generated lowered function name
- fixed `switch_on_constant` case parsing in the Clojure target to match the actual space-separated WAM case format
- extended `tests/test_wam_clojure_generator.pl`
  - verify lowered predicates dispatch through the lowered function
  - verify a mixed project can contain lowered, foreign, and shared-WAM predicates together

# Why

The Clojure hybrid target had the lowered-emitter scaffold, but generated projects still did not use it. That left a gap versus the intended tiered-lowering design:

- classic native lowering
- lowered WAM
- foreign/kernel lowering
- full WAM fallback

This PR activates the lowered WAM tier conservatively without changing the interpreter path for unsupported predicates.

# Verification

Passed:

```sh
swipl -q -g "run_tests(wam_clojure_generator:lowered_wam_predicate_routes_into_dispatch), run_tests(wam_clojure_generator:mixed_project_supports_lowered_foreign_and_shared_wam), run_tests(wam_clojure_generator:foreign_predicates_emit_call_foreign_stub), run_tests(wam_clojure_generator:switch_on_constant_preserves_default_fallthrough)" -t halt tests/test_wam_clojure_generator.pl
```

```sh
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
```

```sh
git diff --check
```

# Scope Boundary

This PR does not yet:

- add atom/functor interning
- broaden lowered instruction coverage beyond the current conservative scaffold
- change benchmark or LMDB behavior
- rewrite the full interpreter path

Those remain follow-up steps after routing is in place.
