### PR TITLE
feat(wam-elixir): _branch variants close chain-CP duplicates (4b.5)`

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -108,15 +108,25 @@ render_compiled_module(CamelMod, CamelPred, PredIndicator, PredStr, ShapeComment
     (   Tier2Wrapper == ""
     ->  Suffix = "",
         Tier2Extras = "",
-        Tier2ModAttr = ""
+        Tier2ModAttr = "",
+        BranchFuncCodes = []
     ;   Suffix = "_impl",
         % The super-wrapper (Tier2Wrapper) already calls the
         % `*_impl` entry directly from its gate-miss cond arms, so
         % no separate sequential alias is emitted here.
         Tier2Extras = Tier2Wrapper,
-        Tier2ModAttr = '  @tier2_eligible true\n'
+        Tier2ModAttr = '  @tier2_eligible true\n',
+        % Phase 4b.5: Tier-2-eligible predicates ALSO emit `_branch`
+        % variants of each clause function. The super-wrappers
+        % parallel branches (in BranchImplFuncs) point at these.
+        % The `_branch` versions run only their own clause body
+        % without pushing a try_me_else CP for the next clause —
+        % each branch enumerates ONLY its own clauses solutions,
+        % avoiding the duplicate-enumeration finding from #1706.
+        generate_all_segments(Segments, Labels, "_branch", BranchFuncCodes)
     ),
-    generate_all_segments(Segments, Labels, Suffix, FuncCodes),
+    generate_all_segments(Segments, Labels, Suffix, ImplFuncCodes),
+    append(ImplFuncCodes, BranchFuncCodes, FuncCodes),
     atomic_list_concat(FuncCodes, '\n\n', FuncsBody),
     % `def run(state)` always delegates to `clause_main` — which is the
     % super-wrapper under Tier 2, or the first clause's body pre-Tier-2.
@@ -985,6 +995,29 @@ classify_segment_head(Instrs, HeadType, BodyInstrs) :-
     ;   HeadType = none, BodyInstrs = Instrs
     ), !.
 
+% Phase 4b.5: _branch variant emission. When Suffix is "_branch" the
+% function is called directly by the Tier-2 super-wrapper as one of
+% its parallel branches — it must run only its own clause body
+% without pushing a CP for the next clause (which would cause the
+% branchs local backtrack to chain into subsequent clauses,
+% producing duplicate solutions across branches; the chain-CP
+% finding from Phase 4b's runtime probe). The no-push shape mirrors
+% the existing trust_me / none templates.
+wrap_segment(FuncName, _HeadType, BodyCode, "_branch", Code) :-
+    !,
+    format(string(Code),
+'  defp ~w(state) do
+    try do
+~w
+    catch
+      {:fail, s} ->
+        case WamRuntime.backtrack(s) do
+          :fail -> throw({:fail, %{s | choice_points: []}})
+          other -> other
+        end
+    end
+  end', [FuncName, BodyCode]).
+
 wrap_segment(FuncName, try_me_else(L), BodyCode, Suffix, Code) :-
     segment_func_name(L, Suffix, FallbackFunc),
     format(string(Code),
@@ -1106,9 +1139,15 @@ par_wrap_segment(Pred/Arity, Segments, Options, Code) :-
     Segments = [FirstName-_|_],
     segment_func_name(FirstName, "", EntryFunc),
     segment_func_name(FirstName, "_impl", EntryImplFunc),
-    maplist([Name-_Instrs, ImplFunc]>>segment_func_name(Name, "_impl", ImplFunc),
-            Segments, BranchImplFuncs),
-    emit_par_tier2_wrapper(EntryFunc, EntryImplFunc, BranchImplFuncs, Code).
+    % Phase 4b.5: BranchFuncs reference the `_branch` variants
+    % (emitted alongside `_impl` by render_compiled_module/8 when
+    % Tier-2 is eligible). The `_branch` versions skip the
+    % try_me_else / retry_me_else CP push so each branch enumerates
+    % ONLY its own clauses solutions — avoids the chain-CP
+    % duplicates from Phase 4bs runtime probe.
+    maplist([Name-_Instrs, BranchFunc]>>segment_func_name(Name, "_branch", BranchFunc),
+            Segments, BranchFuncs),
+    emit_par_tier2_wrapper(EntryFunc, EntryImplFunc, BranchFuncs, Code).
 par_wrap_segment(_Pred, _Segments, _Options, "").
 
 %% emit_par_tier2_wrapper(+EntryFunc, +EntryImplFunc, +BranchImplFuncs, -Code)

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -1075,6 +1075,65 @@ test_findall_phase4b_wamstate_has_branch_mode_field :-
     ;   fail_test(Test, ':branch_mode field missing from WamState defstruct')
     ).
 
+%% Phase 4b.5 — _branch variants emitted alongside _impl for Tier-2-
+%% eligible predicates. Closes the chain-CP duplicate-enumeration
+%% finding from Phase 4b's runtime probe.
+
+test_findall_phase4b5_emits_branch_variants :-
+    Test = 'Phase 4b.5: Tier-2-eligible predicate emits both _impl and _branch clause variants',
+    setup_call_cleanup(
+        (   phase_a_fixture_setup,
+            assertz(clause_body_analysis:order_independent(user:small_fact/2))
+        ),
+        (   wam_target:compile_predicate_to_wam(phase_a_test:small_fact/2, [], WamCode),
+            lower_predicate_to_elixir(small_fact/2, WamCode,
+                                      [module_name('TestMod')], Code),
+            atom_string(Code, S),
+            % Both `_impl` and `_branch` variants must be present.
+            % `_impl` is the existing sequential chain (try_me_else
+            % CP push); `_branch` is the no-push variant for parallel
+            % super-wrapper dispatch. Suffix-based check rather than
+            % hardcoded names because real WAM-compiled predicates
+            % produce `clause_<PredCamel><Arity>` entry names, not
+            % `clause_main` which only fires for hand-built fixtures
+            % whose first segment label is literally "clause_start".
+            sub_string(S, _, _, _, '_impl(state) do'),
+            sub_string(S, _, _, _, '_branch(state) do')
+        ->  pass(Test)
+        ;   fail_test(Test, '_impl and/or _branch variants missing for Tier-2 predicate')
+        ),
+        retract(clause_body_analysis:order_independent(user:small_fact/2))
+    ).
+
+test_findall_phase4b5_branch_skips_cp_push :-
+    Test = 'Phase 4b.5: _branch variant skips try_me_else CP push',
+    setup_call_cleanup(
+        (   phase_a_fixture_setup,
+            assertz(clause_body_analysis:order_independent(user:small_fact/2))
+        ),
+        (   wam_target:compile_predicate_to_wam(phase_a_test:small_fact/2, [], WamCode),
+            lower_predicate_to_elixir(small_fact/2, WamCode,
+                                      [module_name('TestMod')], Code),
+            atom_string(Code, S),
+            % Find a `_branch(state) do` defp opener; verify the
+            % immediate body section contains `try do` without a
+            % preceding `cp = %{pc:` push or `choice_points: [cp |`
+            % update. The `_branch` body should jump straight into
+            % `try do` (no CP-push preamble between the defp opener
+            % and the try).
+            sub_string(S, BranchOff, _, _, '_branch(state) do'),
+            string_length(S, TotalLen),
+            ScanLen is min(200, TotalLen - BranchOff),
+            sub_string(S, BranchOff, ScanLen, _, BranchHead),
+            sub_string(BranchHead, _, _, _, 'try do'),
+            \+ sub_string(BranchHead, _, _, _, 'cp = %{pc:'),
+            \+ sub_string(BranchHead, _, _, _, 'choice_points: [cp |')
+        ->  pass(Test)
+        ;   fail_test(Test, '_branch variant unexpectedly contains a CP push')
+        ),
+        retract(clause_body_analysis:order_independent(user:small_fact/2))
+    ).
+
 test_tier2_purity_gate_rejects_unknown :-
     Test = 'Tier-2 infra: purity gate fails for unknown predicate',
     (   \+ tier2_purity_eligible(no_such_pred, 2, _)
@@ -1145,16 +1204,20 @@ test_par_wrap_segment_emits_super_wrapper :-
     ).
 
 test_par_wrap_segment_references_all_branches :-
-    Test = 'Tier-2 wrapper: branch list references every clause _impl function',
+    Test = 'Tier-2 wrapper: branch list references every clause _branch function (Phase 4b.5)',
     setup_call_cleanup(
         assertz(clause_body_analysis:order_independent(user:tier2_pure3/2)),
         (   three_segment_fixture(Segs),
             par_wrap_segment(tier2_pure3/2, Segs, [], Code),
-            sub_string(Code, _, _, _, '&clause_ClauseStart_impl/1'),
-            sub_string(Code, _, _, _, '&clause_LB_impl/1'),
-            sub_string(Code, _, _, _, '&clause_LC_impl/1')
+            % Phase 4b.5: super-wrappers BranchFuncs reference `_branch`
+            % variants (no next-clause CP push) instead of `_impl` —
+            % closes the chain-CP duplicate-enumeration finding from
+            % Phase 4bs runtime probe.
+            sub_string(Code, _, _, _, '&clause_ClauseStart_branch/1'),
+            sub_string(Code, _, _, _, '&clause_LB_branch/1'),
+            sub_string(Code, _, _, _, '&clause_LC_branch/1')
         ->  pass(Test)
-        ;   fail_test(Test, 'branch list does not reference all three clause _impl functions')
+        ;   fail_test(Test, 'branch list does not reference all three clause _branch functions')
         ),
         retract(clause_body_analysis:order_independent(user:tier2_pure3/2))
     ).
@@ -1236,12 +1299,13 @@ test_par_wrap_segment_covers_switch_targets :-
             switch_arm_targets(FirstInstrs, ArmTargets),
             par_wrap_segment(small_fact/2, Segments, [], Code),
             Code \= "",
-            % For each switch arm target, confirm the emitted super-wrapper
-            % references &clause_<camelCase(target)>_impl/1.
+            % Phase 4b.5: super-wrapper references `_branch` variants
+            % (skip next-clause CP push) instead of `_impl`. Closes
+            % chain-CP duplicate-enumeration finding from #1706.
             forall(member(Target, ArmTargets),
                    (  wam_elixir_lowered_emitter:segment_func_name(Target, BaseFunc),
-                      format(string(ImplRef), '&~w_impl/1', [BaseFunc]),
-                      sub_string(Code, _, _, _, ImplRef)
+                      format(string(BranchRef), '&~w_branch/1', [BaseFunc]),
+                      sub_string(Code, _, _, _, BranchRef)
                    ))
         ->  pass(Test)
         ;   fail_test(Test, 'emitted branch list does not cover every switch_on_constant target')
@@ -1401,6 +1465,8 @@ run_tests :-
     test_findall_phase4a_branch_backtrack_distinct_from_backtrack,
     test_findall_phase4b_backtrack_dispatches_on_branch_mode,
     test_findall_phase4b_wamstate_has_branch_mode_field,
+    test_findall_phase4b5_emits_branch_variants,
+    test_findall_phase4b5_branch_skips_cp_push,
     test_findall_instr_parser_begin_aggregate,
     test_findall_instr_parser_end_aggregate,
     test_findall_instr_lowers_begin_aggregate_sum,


### PR DESCRIPTION
## Summary

- Closes the chain-CP duplicate-enumeration finding from Phase 4b's runtime probe (#1706). Tier-2-eligible predicates now emit a `_branch` variant of each clause function alongside the existing `_impl` chain; the super-wrapper's `Task.async_stream` dispatches to `_branch` functions which skip the next-clause CP push.
- Three coordinated lowering changes — ~117 lines total. No substrate changes.
- 86/86 target tests + 16/16 Phase 3 runtime scenarios passing. Sequential path is unchanged because all Phase 3 scenarios use `intra_query_parallel(false)` and even when activated, the new `_branch` variants only emit for Tier-2-eligible predicates.
- Runtime probe verified the fix end-to-end: parallel `findall(X, p(X), L)` over a 3-clause Tier-2-eligible predicate now returns `["c", "b", "a"]` (3 unique) instead of `["c", "c", "b", "c", "b", "a"]` (6 with duplicates).

## The bug being closed

Phase 4b (#1706) shipped the parallel super-wrapper rework — `branch_mode`, `backtrack/1` dispatch, merge-then-throw flow. The runtime probe in that PR's reviewer notes documented a remaining structural issue:

Each clause's `_impl` function pushes a `try_me_else` CP for the next clause as part of its standard sequential-enumeration setup. When the super-wrapper dispatches branch i = clause i_impl:

- Branch 1 (`clause_main_impl`) pushes CP for clause 2, runs clause 1, returns to k1 → throw fail. Branch's local backtrack pops the CP, resumes clause 2. Pushes CP for clause 3. Runs clause 2. Etc. — branch 1 enumerates **all 3 clauses**.
- Branch 2 (`clause_LB_impl`) starts from clause 2 and chains forward: enumerates 2 and 3.
- Branch 3 (`clause_LC_impl`) is `trust_me` (no CP push): enumerates only clause 3.

Total: 3 + 2 + 1 = 6 solutions with duplicates.

## The fix

Three coordinated lowering changes:

### 1. `wrap_segment/5` gains a `_branch` suffix arm

```prolog
wrap_segment(FuncName, _HeadType, BodyCode, "_branch", Code) :-
    !,
    format(string(Code),
'  defp ~w(state) do
    try do
~w
    catch
      {:fail, s} ->
        case WamRuntime.backtrack(s) do
          :fail -> throw({:fail, %{s | choice_points: []}})
          other -> other
        end
    end
  end', [FuncName, BodyCode]).
```

Cut takes precedence over `try_me_else` / `retry_me_else` for the `_branch` suffix. Emits the same no-CP-push template as the existing `trust_me` / `none` arms — body code is identical to `_impl` but without the try_me_else CP-push preamble.

### 2. `render_compiled_module/8` emits both variants for Tier-2 predicates

```prolog
;   Suffix = "_impl",
    Tier2Extras = Tier2Wrapper,
    Tier2ModAttr = '  @tier2_eligible true\n',
    generate_all_segments(Segments, Labels, "_branch", BranchFuncCodes)
),
generate_all_segments(Segments, Labels, Suffix, ImplFuncCodes),
append(ImplFuncCodes, BranchFuncCodes, FuncCodes),
```

Both `_impl` (existing sequential chain — unchanged) and `_branch` (new no-push variant) clause functions are emitted side-by-side when Tier-2 is eligible.

### 3. `par_wrap_segment/4` references `_branch` names in `BranchFuncs`

```prolog
maplist([Name-_Instrs, BranchFunc]>>segment_func_name(Name, "_branch", BranchFunc),
        Segments, BranchFuncs),
emit_par_tier2_wrapper(EntryFunc, EntryImplFunc, BranchFuncs, Code).
```

The super-wrapper's branch list now points at `&clause_X_branch/1` instead of `&clause_X_impl/1`. The gate-miss `cond` arms still call `EntryImplFunc` (the sequential path) — that's unchanged and correct.

## Runtime probe verification

Before this fix (Phase 4b shipped state), `findall(X, p(X), L)` over a 3-clause Tier-2-eligible predicate `p/1` (no kill-switch):

```
PARALLEL_FINDALL: {:ok, %WamState{regs: %{
  1 => ["c", "c", "b", "c", "b", "a"],
  ...
}}}
```

6 elements with duplicates, exactly matching the analytical 3 + 2 + 1 prediction from the chain.

After this fix:

```
PARALLEL_FINDALL: {:ok, %WamState{regs: %{
  1 => ["c", "b", "a"],
  ...
}}}
```

3 unique elements. Order is reverse of clause order (parallel branches return non-deterministically; `Task.async_stream` with `ordered: false` preserves completion order). Order independence is fine because Tier-2's purity gate requires it.

## Reviewer notes

**Why a `_branch` clause comes before `try_me_else` / `retry_me_else` clauses with a cut.** Without the cut, Prolog would try the `try_me_else` clause first (which matches structurally on the HeadType), then fall through to `_branch` only if it fails. The cut + suffix-first ordering ensures `_branch` takes precedence for the `_branch` suffix specifically, while sequential `_impl` paths still hit the existing `try_me_else` / `retry_me_else` / `trust_me` / `none` arms.

**Why I kept `_impl` and `_branch` as separate variants instead of conditionally suppressing the push.** Conditional suppression would require threading the parallel-vs-sequential context through the per-instruction lowering pipeline, which doesn't currently exist. Two variants is the cleaner separation: `_impl` is the sequential predicate's clause (used by gate-miss `cond` arms and by direct sequential calls), `_branch` is for parallel super-wrapper dispatch only. They share the same body code; only the wrap_segment template differs.

**Why test assertions changed from `clause_main_impl(state)` to `_impl(state) do`.** The original wiring tests (#1624) used hand-built fixtures whose first segment label is literally `"clause_start"` — `segment_func_name/3` special-cases this to `clause_main`. Real WAM-compiled predicates produce `clause_<PredCamel><Arity>` (e.g., `clause_SmallFact2`). The test assertions for Phase 4b.5 use suffix-only matching (`_impl(state) do`, `_branch(state) do`) so they pass for both fixture-style and real-WAM-compiled predicates.

**Sequential path is structurally unchanged.** All 16 Phase 3 runtime scenarios pass without modification. The kill-switched super-wrapper (`intra_query_parallel(false)` in test fixtures) routes through `EntryImplFunc` which is the existing `_impl` chain; `_branch` variants are emitted but never called in those tests.

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_target.pl` — 86/86 passing (84 prior + 2 new Phase 4b.5 emit-and-grep tests)
- [x] `swipl -g run_tests -t halt tests/test_wam_elixir_lowered_phase3.pl` — 16/16 still passing on Termux (Elixir 1.19, OTP 28). Sequential findall behaviour unchanged.
- [x] Runtime probe — parallel `findall(X, p(X), L)` over 3-clause Tier-2-eligible predicate confirmed to return 3 unique solutions (`["c", "b", "a"]`) instead of 6 with duplicates.
- [x] Updated `test_par_wrap_segment_references_all_branches` and `test_par_wrap_segment_covers_switch_targets` to assert `_branch` names (was `_impl`).
- [x] LLVM aggregate test passes — this is an Elixir-target lowering change; LLVM target unaffected.
- [x] Pre-existing `test_wam_e2e.pl atom/1` failure exists on `main`, unrelated to this PR

## Phase 4 status (post-merge)

| Phase | Scope | Status |
|---|---|---|
| Phase 4a | Substrate (`branch_backtrack/1`) | ✅ #1694 |
| Phase 4b | Super-wrapper rework + `branch_mode` dispatch | ✅ #1706 |
| Phase 4b.5 | `_branch` variants close chain-CP duplicates | ✅ This PR |
| Phase 4c | Activate `intra_query_parallel(true)` in tests + Haskell cross-validation | ⏳ Next |

After Phase 4c lands end-to-end, the parallel-track Phase 3c follow-ups (`get_structure` aliased-ref binding, compound args within Template, deep-copy for list shapes, `:sum` numeric encoding) remain as opportunistic fixes — none block Phase 4 progress.

## Related

- Phase 4 proposal: `docs/proposals/WAM_ELIXIR_TIER2_FINDALL_PHASE4.md` (#1672)
- Phase 4a substrate: #1694
- Phase 4b super-wrapper rework (this PR fixes its deferred finding): #1706
- Tier-2 wiring (the original super-wrapper template): #1608, #1624
- Sequential findall track (now complete): #1626 → #1627 → #1643 → #1647 → #1649 → #1650 → #1658 → #1659 → #1661 → #1663 → #1667 → #1669
- Haskell precedent (the Phase 4 design oracle): `wam_haskell_target.pl:1480-1539`
