### PR TITLE
feat(wam-clojure): add intern scaffold

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -258,7 +258,8 @@ emit_one(put_value(Xn, Ai), I) :-
 
 emit_one(put_structure(F, Ai), I) :-
     format("~w;; put-structure ~w, ~w~n", [I, F, Ai]),
-    format("~w(let [instr {:op :put-structure :functor ~q :reg ~q}]~n", [I, F, Ai]),
+    parse_functor_arity_local(F, FunctorArity),
+    format("~w(let [instr {:op :put-structure :functor ~q :reg ~q :arity ~w}]~n", [I, F, Ai, FunctorArity]),
     format("~w  (runtime/step (assoc state :instr instr)))~n", [I]).
 
 emit_one(put_list(Ai), I) :-
@@ -323,3 +324,7 @@ emit_one(jump(_), _) :- !.
 
 emit_one(Instr, I) :-
     format("~w;; TODO: lowered emission for ~w~n", [I, Instr]).
+
+parse_functor_arity_local(Functor, Arity) :-
+    split_string(Functor, "/", "", [_Name, ArityStr]),
+    number_string(Arity, ArityStr).

--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -87,6 +87,14 @@ compile_predicates_for_project([], _, CoreNamespace, RuntimeNamespace, Code) :-
   (:require [clojure.edn :as edn]
             [~w :as runtime]))
 
+(def compile-time-atom-seeds [])
+(def compile-time-functor-seeds [])
+(def atom-intern-context
+  (runtime/build-intern-context compile-time-atom-seeds compile-time-functor-seeds))
+(def atom-intern-table (:atom-intern atom-intern-context))
+(def atom-deintern-table (:atom-deintern atom-intern-context))
+(def functor-arity-table (:functor-arity atom-intern-context))
+
 (def shared-wam-code-raw [])
 (def shared-wam-labels {})
 (def shared-wam-code (runtime/resolve-instructions shared-wam-code-raw shared-wam-labels))
@@ -98,10 +106,16 @@ compile_predicates_for_project([], _, CoreNamespace, RuntimeNamespace, Code) :-
   false)
 
 (defn -main [& _args]
-  (println false))
+    (println false))
 ', [CoreNamespace, CoreNamespace, RuntimeNamespace]).
 compile_predicates_for_project(Predicates, Options, CoreNamespace, RuntimeNamespace, Code) :-
-    collect_wam_entries(Predicates, Options, 0, PredicateBodies, RawEntries, LabelEntries, DispatchEntries),
+    collect_wam_entries(Predicates, Options, 0,
+                        PredicateBodies, RawEntries, LabelEntries, DispatchEntries,
+                        AtomSeedEntries0, FunctorSeedEntries0),
+    sort(AtomSeedEntries0, AtomSeedEntries),
+    sort(FunctorSeedEntries0, FunctorSeedEntries),
+    emit_clojure_string_vector(AtomSeedEntries, AtomSeedsCode),
+    emit_clojure_string_vector(FunctorSeedEntries, FunctorSeedsCode),
     clojure_foreign_handlers_code(Options, ForeignHandlersCode),
     atomic_list_concat(RawEntries, '\n  ', RawBody0),
     atomic_list_concat(LabelEntries, '\n  ', LabelBody0),
@@ -117,6 +131,14 @@ compile_predicates_for_project(Predicates, Options, CoreNamespace, RuntimeNamesp
 (ns ~w
   (:require [clojure.edn :as edn]
             [~w :as runtime]))
+
+(def compile-time-atom-seeds ~w)
+(def compile-time-functor-seeds ~w)
+(def atom-intern-context
+  (runtime/build-intern-context compile-time-atom-seeds compile-time-functor-seeds))
+(def atom-intern-table (:atom-intern atom-intern-context))
+(def atom-deintern-table (:atom-deintern atom-intern-context))
+(def functor-arity-table (:functor-arity atom-intern-context))
 
 (def shared-wam-code-raw [
 ~w
@@ -148,17 +170,24 @@ compile_predicates_for_project(Predicates, Options, CoreNamespace, RuntimeNamesp
   (let [[pred-key & pred-args] args]
     (println (invoke-predicate pred-key (mapv edn/read-string pred-args)))))
 
-', [CoreNamespace, CoreNamespace, RuntimeNamespace, RawBody, LabelBody, ForeignHandlersCode, WrapperCode, DispatchBody]).
+', [CoreNamespace, CoreNamespace, RuntimeNamespace,
+    AtomSeedsCode, FunctorSeedsCode,
+    RawBody, LabelBody, ForeignHandlersCode, WrapperCode, DispatchBody]).
 
-collect_wam_entries([], _, _, [], [], [], []).
+collect_wam_entries([], _, _, [], [], [], [], [], []).
 collect_wam_entries([PredIndicator|Rest], Options, PC,
-                    [PredicateCode|RestWrappers], AllInstrs, AllLabels, [DispatchEntry|RestDispatch]) :-
+                    [PredicateCode|RestWrappers], AllInstrs, AllLabels, [DispatchEntry|RestDispatch],
+                    AllAtomSeeds, AllFunctorSeeds) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
+    format(atom(PredKey), '~w/~w', [Pred, Arity]),
     (   clojure_foreign_predicate(Pred, Arity, Options)
     ->  clojure_foreign_stub_data(Pred, Arity, PC, GoLiterals, LabelPairs, NextPC),
         compile_wam_predicate_to_clojure_shared(Pred/Arity, PC, PredicateCode),
-        predicate_clojure_name(Pred, DispatchName)
+        predicate_clojure_name(Pred, DispatchName),
+        LocalAtomSeeds = [PredKey],
+        LocalFunctorSeeds = []
     ;   wam_target:compile_predicate_to_wam(PredIndicator, Options, WamCode),
+        wam_code_to_clojure_intern_seeds(WamCode, CodeAtomSeeds, CodeFunctorSeeds),
         (   wam_clojure_lowerable(Pred/Arity, WamCode, _Reason)
         ->  lower_predicate_to_clojure(Pred/Arity, WamCode, Options, PredicateCode),
             clojure_lowered_func_name(Pred/Arity, DispatchName),
@@ -168,14 +197,20 @@ collect_wam_entries([PredIndicator|Rest], Options, PC,
         ;   wam_code_to_clojure_data(WamCode, PC, GoLiterals, LabelPairs, NextPC),
             compile_wam_predicate_to_clojure_shared(Pred/Arity, PC, PredicateCode),
             predicate_clojure_name(Pred, DispatchName)
-        )
+        ),
+        LocalAtomSeeds = [PredKey|CodeAtomSeeds],
+        LocalFunctorSeeds = CodeFunctorSeeds
     ),
     maplist([Lit, Entry]>>format(atom(Entry), '~w', [Lit]), GoLiterals, InstrEntries),
     maplist([Label-Idx, Entry]>>format(atom(Entry), '~w ~w', [Label, Idx]), LabelPairs, LabelRows),
     format(atom(DispatchEntry), '"~w/~w" ~w', [Pred, Arity, DispatchName]),
-    collect_wam_entries(Rest, Options, NextPC, RestWrappers, RestInstrs, RestLabels, RestDispatch),
+    collect_wam_entries(Rest, Options, NextPC,
+                        RestWrappers, RestInstrs, RestLabels, RestDispatch,
+                        RestAtomSeeds, RestFunctorSeeds),
     append(InstrEntries, RestInstrs, AllInstrs),
-    append(LabelRows, RestLabels, AllLabels).
+    append(LabelRows, RestLabels, AllLabels),
+    append(LocalAtomSeeds, RestAtomSeeds, AllAtomSeeds),
+    append(LocalFunctorSeeds, RestFunctorSeeds, AllFunctorSeeds).
 
 %% clojure_foreign_predicate(+Pred, +Arity, +Options) is semidet.
 %  True when a predicate should be represented by a Clojure WAM
@@ -330,13 +365,27 @@ clojure_handler_code_text(HandlerCode, HandlerText) :-
 compile_wam_predicate_to_clojure(PredIndicator, WamCode, _Options, ClojureCode) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
     wam_code_to_clojure_data(WamCode, 0, RawEntries, LabelPairs, _),
+    wam_code_to_clojure_intern_seeds(WamCode, AtomSeedEntries0, FunctorSeedEntries0),
+    format(atom(PredKey), '~w/~w', [Pred, Arity]),
+    sort([PredKey|AtomSeedEntries0], AtomSeedEntries),
+    sort(FunctorSeedEntries0, FunctorSeedEntries),
+    emit_clojure_string_vector(AtomSeedEntries, AtomSeedsCode),
+    emit_clojure_string_vector(FunctorSeedEntries, FunctorSeedsCode),
     atomic_list_concat(RawEntries, '\n  ', RawBody0),
     atomic_list_concat(LabelPairs, '\n  ', LabelBody0),
     (RawBody0 == "" -> RawBody = "" ; format(atom(RawBody), '  ~w', [RawBody0])),
     (LabelBody0 == "" -> LabelBody = "" ; format(atom(LabelBody), '  ~w', [LabelBody0])),
     compile_wam_predicate_to_clojure_shared(Pred/Arity, 0, WrapperCode),
     format(atom(ClojureCode),
-'(def shared-wam-code-raw [
+'(def compile-time-atom-seeds ~w)
+(def compile-time-functor-seeds ~w)
+(def atom-intern-context
+  (runtime/build-intern-context compile-time-atom-seeds compile-time-functor-seeds))
+(def atom-intern-table (:atom-intern atom-intern-context))
+(def atom-deintern-table (:atom-deintern atom-intern-context))
+(def functor-arity-table (:functor-arity atom-intern-context))
+
+(def shared-wam-code-raw [
 ~w
 ])
 
@@ -350,7 +399,7 @@ compile_wam_predicate_to_clojure(PredIndicator, WamCode, _Options, ClojureCode) 
 (def foreign-handlers {})
 
 ~w
-', [RawBody, LabelBody, WrapperCode]).
+', [AtomSeedsCode, FunctorSeedsCode, RawBody, LabelBody, WrapperCode]).
 
 compile_wam_predicate_to_clojure_shared(Pred/Arity, StartPC, Code) :-
     predicate_clojure_name(Pred, CljName),
@@ -360,13 +409,58 @@ compile_wam_predicate_to_clojure_shared(Pred/Arity, StartPC, Code) :-
 '(def ~w-start-pc ~w)
 
 (defn ~w [~w]
-  (runtime/run-wam-predicate shared-wam-code shared-wam-labels ~w-start-pc ~w foreign-handlers))
+  (runtime/run-wam-predicate shared-wam-code shared-wam-labels ~w-start-pc ~w foreign-handlers atom-intern-context))
 ', [CljName, StartPC, CljName, ArgList, CljName, RegMap]).
 
 wam_code_to_clojure_data(WamCode, BasePC, Entries, LabelPairs, NextPC) :-
     atom_string(WamCode, WamStr),
     split_string(WamStr, "\n", "", Lines),
     wam_lines_to_clojure_data(Lines, BasePC, Entries, LabelPairs, NextPC).
+
+wam_code_to_clojure_intern_seeds(WamCode, AtomSeeds, FunctorSeeds) :-
+    atom_string(WamCode, WamStr),
+    split_string(WamStr, "\n", "", Lines),
+    wam_lines_intern_seeds(Lines, AtomSeeds, FunctorSeeds).
+
+wam_lines_intern_seeds([], [], []).
+wam_lines_intern_seeds([Line|Rest], AtomSeeds, FunctorSeeds) :-
+    normalize_space(string(Trimmed), Line),
+    (   Trimmed == ""
+    ->  wam_lines_intern_seeds(Rest, AtomSeeds, FunctorSeeds)
+    ;   sub_string(Trimmed, _, 1, 0, ":")
+    ->  wam_lines_intern_seeds(Rest, AtomSeeds, FunctorSeeds)
+    ;   split_string(Trimmed, " ", "", [Op|ArgParts]),
+        atomic_list_concat(ArgParts, ' ', ArgText0),
+        normalize_space(string(ArgText), ArgText0),
+        (   Op == "switch_on_constant"
+        ->  switch_case_atom_values(ArgText, LocalAtomSeeds),
+            LocalFunctorSeeds = []
+        ;   wam_args(ArgText, Args),
+            wam_op_intern_seeds(Op, Args, LocalAtomSeeds, LocalFunctorSeeds)
+        ),
+        wam_lines_intern_seeds(Rest, RestAtomSeeds, RestFunctorSeeds),
+        append(LocalAtomSeeds, RestAtomSeeds, AtomSeeds),
+        append(LocalFunctorSeeds, RestFunctorSeeds, FunctorSeeds)
+    ).
+
+switch_case_atom_values(CasesText, AtomSeeds) :-
+    split_string(CasesText, " ", " ", RawCases),
+    findall(Const,
+            ( member(RawCase, RawCases),
+              normalize_space(string(Case), RawCase),
+              split_string(Case, ":", "", [Const|_])
+            ),
+            AtomSeeds).
+
+wam_op_intern_seeds("get_constant", [Const, _], [Const], []).
+wam_op_intern_seeds("put_constant", [Const, _], [Const], []).
+wam_op_intern_seeds("set_constant", [Const], [Const], []).
+wam_op_intern_seeds("unify_constant", [Const], [Const], []).
+wam_op_intern_seeds("put_structure", [Functor, _], [Functor], [Functor]).
+wam_op_intern_seeds("get_structure", [Functor, _], [Functor], [Functor]).
+wam_op_intern_seeds("put_list", [_], ["[|]/2"], ["[|]/2"]).
+wam_op_intern_seeds("get_list", [_], ["[|]/2"], ["[|]/2"]).
+wam_op_intern_seeds(_, _, [], []).
 
 wam_lines_to_clojure_data([], PC, [], [], PC).
 wam_lines_to_clojure_data([Line|Rest], PC0, Entries, Labels, NextPC) :-
@@ -453,7 +547,8 @@ wam_op_to_clojure_literal("put_value", [Var, Reg], _, Literal) :-
 wam_op_to_clojure_literal("put_structure", [Functor, Reg], _, Literal) :-
     clj_string_literal(Functor, FunctorLit),
     clj_string_literal(Reg, RegLit),
-    format(atom(Literal), '{:op :put-structure :functor ~w :reg ~w}', [FunctorLit, RegLit]).
+    functor_arity_string(Functor, FunctorArity),
+    format(atom(Literal), '{:op :put-structure :functor ~w :reg ~w :arity ~w}', [FunctorLit, RegLit, FunctorArity]).
 wam_op_to_clojure_literal("get_structure", [Functor, Reg], _, Literal) :-
     clj_string_literal(Functor, FunctorLit),
     clj_string_literal(Reg, RegLit),
@@ -510,6 +605,10 @@ parse_switch_case(RawCase, Entry) :-
         format(atom(Entry), '{:value ~w :label ~w}', [ConstLit, LabelLit])
     ).
 
+functor_arity_string(Functor, Arity) :-
+    split_string(Functor, "/", "", [_Name, ArityStr]),
+    number_string(Arity, ArityStr).
+
 predicate_indicator_parts(Module:Pred/Arity, Module, Pred, Arity) :- !.
 predicate_indicator_parts(Pred/Arity, user, Pred, Arity).
 
@@ -530,6 +629,12 @@ build_clojure_wam_reg_map(Arity, RegMap) :-
     maplist([I, S]>>format(atom(S), '"A~w" a~w', [I, I]), Indices, Parts),
     atomic_list_concat(Parts, ', ', Body),
     format(atom(RegMap), '{~w}', [Body]).
+
+emit_clojure_string_vector([], "[]") :- !.
+emit_clojure_string_vector(Strings, Literal) :-
+    maplist(clj_string_literal, Strings, Quoted),
+    atomic_list_concat(Quoted, ' ', Body),
+    format(atom(Literal), '[~w]', [Body]).
 
 write_namespace_file(ProjectDir, Namespace, Content) :-
     namespace_relative_path(Namespace, RelativePath),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -4,6 +4,45 @@
 (ns {{runtime_namespace}}
   (:require [clojure.string :as str]))
 
+(def well-known-intern-seeds ["true" "fail" "[]" "." "" "[|]" "[|]/2"])
+
+(defn parse-functor-arity [functor]
+  (let [[_ arity-str] (str/split functor #"/")]
+    (Integer/parseInt arity-str)))
+
+(defn build-intern-context
+  ([atom-seeds]
+   (build-intern-context atom-seeds []))
+  ([atom-seeds functor-seeds]
+   (let [ordered-seeds (vec (distinct (concat well-known-intern-seeds atom-seeds functor-seeds)))
+         atom-intern (into {}
+                           (map-indexed (fn [idx value]
+                                          [value idx]))
+                           ordered-seeds)
+         functor-arity (into {}
+                            (map (fn [functor]
+                                   [functor (parse-functor-arity functor)]))
+                            (distinct functor-seeds))]
+     {:atom-intern atom-intern
+      :atom-deintern ordered-seeds
+      :functor-arity functor-arity})))
+
+(defn intern-atom [ctx atom]
+  (if-let [id (get (:atom-intern ctx) atom)]
+    [ctx id]
+    (let [id (count (:atom-deintern ctx))]
+      [(-> ctx
+           (assoc-in [:atom-intern atom] id)
+           (update :atom-deintern conj atom))
+       id])))
+
+(defn deintern-atom [ctx id]
+  (get (:atom-deintern ctx) id))
+
+(defn functor-arity [ctx functor]
+  (or (get-in ctx [:functor-arity functor])
+      (parse-functor-arity functor)))
+
 (defn resolve-instruction [labels instr]
   (case (:op instr)
     :call
@@ -70,13 +109,16 @@
 
 (defn new-state
   ([code labels start-pc regs]
-   (new-state code labels start-pc regs {}))
+   (new-state code labels start-pc regs {} nil))
   ([code labels start-pc regs foreign-handlers]
+   (new-state code labels start-pc regs foreign-handlers nil))
+  ([code labels start-pc regs foreign-handlers intern-context]
   {:code code
    :labels labels
    :pc start-pc
    :regs regs
    :foreign-handlers foreign-handlers
+   :intern-context intern-context
    :env-stack []
    :bindings {}
    :stack []
@@ -278,10 +320,6 @@
   (let [id (:next-var-id state)]
     [(var-term id) (update state :next-var-id inc)]))
 
-(defn parse-functor-arity [functor]
-  (let [[_ arity-str] (str/split functor #"/")]
-    (Integer/parseInt arity-str)))
-
 (defn push-build-frame [state target-reg functor arity]
   (update state :build-stack conj {:target-reg target-reg
                                    :functor functor
@@ -471,7 +509,8 @@
             advance)
 
         :put-structure
-        (let [arity (parse-functor-arity (:functor instr))]
+        (let [arity (or (:arity instr)
+                        (functor-arity (:intern-context state) (:functor instr)))]
           (-> state
               (push-build-frame (:reg instr) (:functor instr) arity)
               advance))
@@ -663,6 +702,8 @@
 
 (defn run-wam-predicate
   ([code labels start-pc regs]
-   (run-wam-predicate code labels start-pc regs {}))
+   (run-wam-predicate code labels start-pc regs {} nil))
   ([code labels start-pc regs foreign-handlers]
-   (run-wam (new-state code labels start-pc regs foreign-handlers))))
+   (run-wam-predicate code labels start-pc regs foreign-handlers nil))
+  ([code labels start-pc regs foreign-handlers intern-context]
+   (run-wam (new-state code labels start-pc regs foreign-handlers intern-context))))

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -47,7 +47,7 @@ user:wam_parent_lookup(X, Y) :- user:category_parent(X, Y).
 user:max_depth(_) :- fail.
 user:wam_ancestor_lookup(A, B, C, D) :- user:category_ancestor(A, B, C, D).
 
-test(project_uses_shared_wam_table_for_cross_predicate_calls) :-
+test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
     once((
         unique_tmp_dir('tmp_wam_clojure_shared', TmpDir),
         write_wam_clojure_project([user:wam_execute_caller/1,
@@ -62,19 +62,30 @@ test(project_uses_shared_wam_table_for_cross_predicate_calls) :-
         read_file_to_string(RuntimePath, RuntimeCode, []),
         read_file_to_string(DepsPath, DepsCode, []),
         read_file_to_string(ProjectPath, ProjectCode, []),
+        assertion(sub_string(CoreCode, _, _, _, '(def compile-time-atom-seeds [')),
+        assertion(sub_string(CoreCode, _, _, _, '(def compile-time-functor-seeds [')),
+        assertion(sub_string(CoreCode, _, _, _, '(def atom-intern-context')),
+        assertion(sub_string(CoreCode, _, _, _, '(def atom-intern-table (:atom-intern atom-intern-context))')),
+        assertion(sub_string(CoreCode, _, _, _, '(def atom-deintern-table (:atom-deintern atom-intern-context))')),
+        assertion(sub_string(CoreCode, _, _, _, '(def functor-arity-table (:functor-arity atom-intern-context))')),
         assertion(sub_string(CoreCode, _, _, _, '(def shared-wam-code-raw [')),
         assertion(sub_string(CoreCode, _, _, _, '(def shared-wam-labels {')),
         assertion(sub_string(CoreCode, _, _, _, '(def shared-wam-code')),
         assertion(sub_string(CoreCode, _, _, _, 'runtime/resolve-instructions shared-wam-code-raw shared-wam-labels')),
-        assertion(sub_string(CoreCode, _, _, _, '(def wam-execute-caller-start-pc ')),
-        assertion(sub_string(CoreCode, _, _, _, '(defn wam-execute-caller [a1]')),
-        assertion(sub_string(CoreCode, _, _, _, '(defn wam-call-caller [a1]')),
-        assertion(sub_string(CoreCode, _, _, _, 'runtime/run-wam-predicate shared-wam-code shared-wam-labels wam-execute-caller-start-pc')),
+        assertion(sub_string(CoreCode, _, _, _, '(defn lowered-wam-execute-caller-1 [state]')),
+        assertion(sub_string(CoreCode, _, _, _, '(defn lowered-wam-call-caller-1 [state]')),
+        assertion(sub_string(CoreCode, _, _, _, '(defn lowered-wam-fact-1 [state]')),
         assertion(sub_string(CoreCode, _, _, _, 'foreign-handlers')),
         assertion(sub_string(CoreCode, _, _, _, '(def predicate-dispatch {')),
-        assertion(sub_string(CoreCode, _, _, _, '"wam_execute_caller/1" wam-execute-caller')),
-        assertion(sub_string(CoreCode, _, _, _, '"wam_call_caller/1" wam-call-caller')),
+        assertion(sub_string(CoreCode, _, _, _, '"wam_execute_caller/1" lowered-wam-execute-caller-1')),
+        assertion(sub_string(CoreCode, _, _, _, '"wam_call_caller/1" lowered-wam-call-caller-1')),
+        assertion(sub_string(CoreCode, _, _, _, '"wam_fact/1" lowered-wam-fact-1')),
         assertion(sub_string(CoreCode, _, _, _, '(defn -main [& args]')),
+        assertion(sub_string(RuntimeCode, _, _, _, '(def well-known-intern-seeds [')),
+        assertion(sub_string(RuntimeCode, _, _, _, '(defn build-intern-context')),
+        assertion(sub_string(RuntimeCode, _, _, _, '(defn intern-atom [ctx atom]')),
+        assertion(sub_string(RuntimeCode, _, _, _, '(defn deintern-atom [ctx id]')),
+        assertion(sub_string(RuntimeCode, _, _, _, '(defn functor-arity [ctx functor]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn resolve-instructions [code labels]')),
         assertion(sub_string(RuntimeCode, _, _, _, ':try-me-else-pc')),
         assertion(sub_string(RuntimeCode, _, _, _, ':switch-on-constant')),
@@ -102,11 +113,27 @@ test(project_uses_shared_wam_table_for_cross_predicate_calls) :-
         assertion(sub_string(RuntimeCode, _, _, _, ':unify-variable')),
         assertion(sub_string(RuntimeCode, _, _, _, ':retry-me-else-pc')),
         assertion(sub_string(RuntimeCode, _, _, _, ':trust-me')),
+        assertion(sub_string(RuntimeCode, _, _, _, ':intern-context intern-context')),
         assertion(sub_string(RuntimeCode, _, _, _, ':regs (:regs state)')),
         assertion(\+ sub_string(RuntimeCode, _, _, _, 'snapshot-choice-regs')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn step [state]')),
         assertion(sub_string(DepsCode, _, _, _, '"-m" "generated.wam_test.core"')),
         assertion(sub_string(ProjectCode, _, _, _, ':main generated.wam_test.core')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+test(compile_time_intern_tables_are_emitted_and_deduplicated) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_intern_tables', TmpDir),
+        write_wam_clojure_project([user:wam_fact/1,
+                                   user:wam_struct_fact/1,
+                                   user:wam_list_fact/1],
+                                  [namespace('generated.wam_intern_test')], TmpDir),
+        directory_file_path(TmpDir, 'src/generated/wam_intern_test/core.clj', CorePath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(sub_string(CoreCode, _, _, _, '(def compile-time-atom-seeds ["[]" "[|]/2" "a" "b" "f/1" "wam_fact/1" "wam_list_fact/1" "wam_struct_fact/1"])')),
+        assertion(sub_string(CoreCode, _, _, _, '(def compile-time-functor-seeds ["[|]/2" "f/1"])')),
+        assertion(sub_string(CoreCode, _, _, _, '(runtime/build-intern-context compile-time-atom-seeds compile-time-functor-seeds)')),
         delete_directory_and_contents(TmpDir)
     )).
 
@@ -142,7 +169,7 @@ test(clojure_foreign_handlers_emit_handler_map) :-
         read_file_to_string(CorePath, CoreCode, []),
         assertion(sub_string(CoreCode, _, _, _, '(def foreign-handlers {')),
         assertion(sub_string(CoreCode, _, _, _, '"wam_fact/1" (fn [args] (= (first args) "a"))')),
-        assertion(sub_string(CoreCode, _, _, _, 'foreign-handlers)')),
+        assertion(sub_string(CoreCode, _, _, _, 'foreign-handlers atom-intern-context)')),
         delete_directory_and_contents(TmpDir)
     )).
 
@@ -221,7 +248,7 @@ test(clojure_lmdb_target_foreign_relation_auto_handler,
         assertion(sub_string(CoreCode, _, _, _, '"category_parent/2" (let [reader-delay (delay (generated.lmdb.LmdbArtifactReader/openSharedCached')),
         assertion(sub_string(CoreCode, _, _, _, 'data/generated/test/category_parent_lmdb')),
         assertion(sub_string(CoreCode, _, _, _, 'lmdb_cache_stats category_parent/2')),
-        assertion(sub_string(CoreCode, _, _, _, '"wam_parent_lookup/2" wam-parent-lookup')),
+        assertion(sub_string(CoreCode, _, _, _, '"wam_parent_lookup/2" lowered-wam-parent-lookup-2')),
         delete_directory_and_contents(TmpDir)
     )).
 
@@ -255,7 +282,7 @@ test(clojure_lmdb_target_ancestor_foreign_relation_auto_handler,
         assertion(sub_string(CoreCode, _, _, _, 'lmdb_cache_stats category_ancestor/4')),
         assertion(sub_string(CoreCode, _, _, _, '{:solutions (vec solutions)}')),
         assertion(sub_string(CoreCode, _, _, _, '{:bindings {2 ancestor 3 hops}}')),
-        assertion(sub_string(CoreCode, _, _, _, '"wam_ancestor_lookup/4" wam-ancestor-lookup')),
+        assertion(sub_string(CoreCode, _, _, _, '"wam_ancestor_lookup/4" lowered-wam-ancestor-lookup-4')),
         delete_directory_and_contents(TmpDir)
     )).
 


### PR DESCRIPTION
# Summary

Add the first atom/functor interning scaffold for the hybrid Clojure WAM target.

This does **not** rewrite the Clojure runtime around interned integer values yet. It establishes the metadata seam needed for that later work:

- compile-time atom/functor seed emission
- runtime intern/deintern helpers
- intern-context threading through generated WAM wrappers
- functor arity lookup through the intern context

# What Changed

- updated `src/unifyweaver/targets/wam_clojure_target.pl`
  - emit `compile-time-atom-seeds`
  - emit `compile-time-functor-seeds`
  - emit `atom-intern-context`, `atom-intern-table`, `atom-deintern-table`, and `functor-arity-table`
  - collect atom/functor seeds from generated WAM code:
    - constants
    - structure functors
    - list functor
    - switch constants
    - predicate dispatch keys
  - thread `atom-intern-context` into generated WAM wrapper calls
  - carry precomputed `:arity` on generated `:put-structure` instructions

- updated `templates/targets/clojure_wam/runtime.clj.mustache`
  - added:
    - `well-known-intern-seeds`
    - `build-intern-context`
    - `intern-atom`
    - `deintern-atom`
    - `functor-arity`
  - extended runtime state with `:intern-context`
  - used intern-context functor arity as the fallback for `:put-structure`

- updated `src/unifyweaver/targets/wam_clojure_lowered_emitter.pl`
  - lowered `put-structure` instructions now also emit precomputed `:arity`

- updated `tests/test_wam_clojure_generator.pl`
  - adapted existing assertions to the routed lowered-tier shape
  - added explicit compile-time interning coverage
  - kept LMDB/foreign/lowered/shared-WAM mixed coverage intact

# Why

The lowered-tier and LMDB work made the remaining Clojure hot-path issue clearer: the target still relies heavily on string-based lookup and reparsing.

This PR sets up the first reusable interning seam without taking on the larger risk of a full runtime representation rewrite. That keeps the implementation incremental:

1. emit compile-time interning metadata
2. thread intern context through generated code
3. use it in selected hot-path lookups
4. later push interned IDs deeper into the runtime

# Verification

Passed:

```sh
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
```

```sh
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
```

```sh
git diff --check
```

# Scope Boundary

This PR does not yet:

- replace string-based atoms/functors with interned IDs throughout the runtime
- retune benchmark or LMDB behavior
- expand lowered instruction coverage beyond the current scaffold direction
- rewrite foreign handlers around interned IDs

Those remain follow-up steps after the interning seam is in place.
