### PR TITLE
bench(csharp-query): prebuild nary scan auto artifacts

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -113,7 +113,7 @@ namespace UnifyWeaver.QueryRuntime
 
     public static class RelationSourceModePolicy
     {
-        private const long SmallJoinPrebuiltArtifactRowThreshold = 7_500L;
+        private const long SmallPrebuiltArtifactRowThreshold = 7_500L;
 
         public static bool TryParse(string? value, out RelationSourceMode mode)
         {
@@ -166,8 +166,9 @@ namespace UnifyWeaver.QueryRuntime
             {
                 "bound_scan" => RelationSourceMode.Artifact,
                 "selective_join" => RelationSourceMode.Artifact,
-                "join" when totalRows <= SmallJoinPrebuiltArtifactRowThreshold => RelationSourceMode.ArtifactPrebuilt,
+                "join" when totalRows <= SmallPrebuiltArtifactRowThreshold => RelationSourceMode.ArtifactPrebuilt,
                 "join" => RelationSourceMode.Artifact,
+                "nary_join" => RelationSourceMode.ArtifactPrebuilt,
                 _ => RelationSourceMode.Preload,
             };
         }


### PR DESCRIPTION
  ## Summary

  - Updates scan benchmark auto source-mode policy so `nary_join` resolves to `artifact-prebuilt`.
  - Renames the small join threshold constant to `SmallPrebuiltArtifactRowThreshold` because the policy is no longer
  join-only.
  - Keeps binary `join` threshold behavior unchanged.

  ## Verification

  - `git diff --check`
  - `python3 examples/benchmark/benchmark_scan_materialization.py --scales 300,1k,5k --modes nary_join --source-modes
  auto,preload,artifact-prebuilt --strategies auto --repetitions 3 --format calibration-tsv`
  - `python3 examples/benchmark/benchmark_scan_materialization.py --scales 300 --modes nary_join --source-modes auto
  --strategies auto --repetitions 1`