### PR TITLE
bench(csharp-query): prebuild small selective joins

### DIFF
--- a/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
+++ b/docs/proposals/PREPROCESSED_PREDICATE_ARTIFACTS.md
@@ -479,11 +479,11 @@ Prototype status:
 - `benchmark_scan_materialization.py` can now compare `preload`, `delimited`,
   `artifact`, and `artifact-prebuilt` source modes against the existing
   scan-family workloads, including `bound_scan` and `selective_join` modes for
-  indexed parameter probes. The prebuilt mode keeps artifacts in a stable
-  benchmark directory keyed by the current runtime source so runtime
-  measurements can separate query execution from preprocessing cost without
-  reusing stale artifact formats. The benchmark now resolves source-family
-  choices through runtime-owned `RelationSourceMode` and
+  indexed parameter probes. The prebuilt mode keeps artifacts in a per-run
+  benchmark directory keyed by the current runtime source and source mode, so
+  runtime measurements can separate query execution from preprocessing cost
+  without reusing stale artifact formats or colliding with concurrent runs.
+  The benchmark now resolves source-family choices through runtime-owned `RelationSourceMode` and
   `RelationSourceModePolicy` helpers instead of a benchmark-local string switch,
   which is the current seam for moving source selection out of Python-only
   configuration.

--- a/examples/benchmark/benchmark_scan_materialization.py
+++ b/examples/benchmark/benchmark_scan_materialization.py
@@ -620,6 +620,7 @@ def print_calibration_markdown(summaries: list[SourceModeSummary]) -> None:
 
 def benchmark_mode(
     command: list[str],
+    artifact_root: Path,
     scale: str,
     mode: str,
     source_mode: str,
@@ -634,7 +635,7 @@ def benchmark_mode(
     env["UNIFYWEAVER_SCAN_RETENTION_STRATEGY"] = strategy
     env["UNIFYWEAVER_SCAN_SOURCE_MODE"] = source_mode
     if source_mode in {"artifact-prebuilt", "auto"}:
-        artifact_dir = Path(tempfile.gettempdir()) / f"uw-scan-prebuilt-artifacts-{RUNTIME_CACHE_VERSION}" / scale
+        artifact_dir = artifact_root / f"prebuilt-artifacts-{RUNTIME_CACHE_VERSION}" / source_mode / scale
         artifact_dir.mkdir(parents=True, exist_ok=True)
         env["UNIFYWEAVER_SCAN_ARTIFACT_DIR"] = str(artifact_dir)
 
@@ -684,7 +685,7 @@ def main() -> int:
             for mode in modes:
                 for source_mode in source_modes:
                     for strategy in strategies:
-                        results.append(benchmark_mode(command, scale, mode, source_mode, strategy, args.repetitions))
+                        results.append(benchmark_mode(command, temp_root, scale, mode, source_mode, strategy, args.repetitions))
 
         if args.format == "detail-tsv":
             print_detail_tsv(results, scales, modes, source_modes)

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -165,6 +165,7 @@ namespace UnifyWeaver.QueryRuntime
             return mode switch
             {
                 "bound_scan" => RelationSourceMode.Artifact,
+                "selective_join" when totalRows <= SmallPrebuiltArtifactRowThreshold => RelationSourceMode.ArtifactPrebuilt,
                 "selective_join" => RelationSourceMode.Artifact,
                 "join" when totalRows <= SmallPrebuiltArtifactRowThreshold => RelationSourceMode.ArtifactPrebuilt,
                 "join" => RelationSourceMode.Artifact,


### PR DESCRIPTION
  ## Summary

  - Routes `selective_join` auto source mode to `artifact-prebuilt` for small scan benchmark inputs.
  - Keeps larger `selective_join` inputs on `artifact`.
  - Leaves `bound_scan` unchanged after calibration showed noisy/overlapping results.
  - Isolates scan benchmark prebuilt artifact directories per run and source mode to avoid concurrent cache collisions.
  - Updates the preprocessed-artifacts proposal to document per-run scan benchmark artifact directories.

  ## Verification

  - `python3 -m py_compile examples/benchmark/benchmark_scan_materialization.py`
  - `git diff --check`
  - `python3 examples/benchmark/benchmark_scan_materialization.py --scales 300,1k,5k --modes selective_join --source-
  modes auto,artifact,artifact-prebuilt,preload --strategies auto --repetitions 3 --format calibration-tsv`
  - Parallel scan benchmark smoke covering `selective_join` and `bound_scan`
  - `python3 examples/benchmark/benchmark_scan_materialization.py --scales 300 --modes selective_join --source-modes
  auto --strategies auto --repetitions 1`