### PR TITLE
feat(wam-clojure): intern dispatch equality

### DIFF
--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -45,6 +45,9 @@
 (defn atom-term? [v]
   (and (map? v) (= :atom (:tag v)) (contains? v :id)))
 
+(defn interned-equal? [left right]
+  (= left right))
+
 (defn normalize-literal-atom [ctx atom]
   (let [[_ctx id] (intern-atom ctx atom)]
     (atom-term id)))
@@ -69,6 +72,11 @@
     (structure-term? term)
     (update term :args #(mapv (fn [arg] (normalize-literal-term ctx arg)) %))
     :else term))
+
+(defn normalize-dispatch-value [ctx value]
+  (if (string? value)
+    (normalize-literal-atom ctx value)
+    value))
 
 (defn resolve-instruction [labels instr ctx]
   (case (:op instr)
@@ -468,7 +476,9 @@
       s)))
 
 (defn switch-target [state instr]
-  (let [reg-val (deref-value (:bindings state) (reg-get-raw state "A1"))
+  (let [reg-val (normalize-dispatch-value
+                 (:intern-context state)
+                 (deref-value (:bindings state) (reg-get-raw state "A1")))
         case-map (:case-map instr)
         default-target-pc (:default-target-pc instr)
         default-fallthrough? (:default-fallthrough? instr)]
@@ -601,7 +611,7 @@
             (-> (bind-var state current* constant)
                 advance)
 
-            (= current* constant)
+            (interned-equal? current* constant)
             (advance state)
 
             :else
@@ -643,7 +653,7 @@
                                    (or (reg-get-raw state (:reg instr)) ::unbound))]
           (cond
             (structure-term? reg-val)
-            (if (= (:functor reg-val) (:functor instr))
+            (if (interned-equal? (:functor reg-val) (:functor instr))
               (-> state
                   (enter-unify-mode (:args reg-val))
                   advance)
@@ -658,7 +668,7 @@
               list-functor (list-functor-term (:intern-context state))]
           (cond
             (structure-term? reg-val)
-            (if (= (:functor reg-val) list-functor)
+            (if (interned-equal? (:functor reg-val) list-functor)
               (-> state
                   (enter-unify-mode (:args reg-val))
                   advance)

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -92,6 +92,8 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, '(defn normalize-term* [ctx term]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn denormalize-term [ctx term]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn normalize-regs [ctx regs]')),
+        assertion(sub_string(RuntimeCode, _, _, _, '(defn interned-equal? [left right]')),
+        assertion(sub_string(RuntimeCode, _, _, _, '(defn normalize-dispatch-value [ctx value]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn functor-arity [ctx functor]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn resolve-instructions')),
         assertion(sub_string(RuntimeCode, _, _, _, ':try-me-else-pc')),


### PR DESCRIPTION
# Summary

Make Clojure WAM dispatch and selected hot-path equality checks explicitly use the interned representation instead of relying on incidental raw `=` comparisons.

# What Changed

- added explicit runtime helpers:
  - `interned-equal?`
  - `normalize-dispatch-value`
- updated `switch-target` to normalize the dispatch value through the intern context before `case-map` lookup
- updated hot-path equality checks to use the intern-aware seam in:
  - `:get-constant`
  - `:get-structure`
  - `:get-list`
- extended generator coverage so the emitted runtime must include the new intern-aware helpers

# Why

The previous interning work established the intern context and moved many literals into interned internal form, but dispatch and several equality sites still used direct comparisons without an explicit runtime seam.

This PR makes that boundary concrete:

- dispatch values are normalized before `switch_on_constant` lookup
- selected hot-path equality sites now consistently compare interned values

That makes the runtime behavior clearer and prepares the path for deeper interning work without changing external interfaces.

# Files

- `templates/targets/clojure_wam/runtime.clj.mustache`
- `tests/test_wam_clojure_generator.pl`

# Verification

- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
- `git diff --check`

# Follow-ups

- push interned IDs deeper into term/functor representation and equality
- expand lowered instruction coverage on top of the stabilized lowered/interpreter boundary
