### PR TITLE
fix(wam-haskell): resolve dimension_n from user:dimension_n/1 at codegen

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2813,6 +2813,11 @@ generate_main_hs(_Predicates, DetectedKernels, InlineDefs, Options, Code) :-
     % the historical hardcoded value when no max_depth/1 fact is present.
     % See effective_distance.pl line 43 for the workload's default.
     resolve_max_depth(Options, MaxDepth),
+    % Resolve dimension_n at codegen time. Same instrumentation-bug class
+    % as max_depth: a user-asserted user:dimension_n/1 must reach the
+    % aggregation formula (n in Hops^(-N) and the inverse exponent), not
+    % be silently overridden by a hardcoded 5.0 in the template.
+    resolve_dimension_n(Options, DimN),
     render_template(Template,
         [ foreign_preds=ForeignPredsStr
         , benchmark_mode=Mode
@@ -2827,6 +2832,7 @@ generate_main_hs(_Predicates, DetectedKernels, InlineDefs, Options, Code) :-
         , lmdb_import=LmdbImport
         , int_atom_seeds=IntAtomSeeds
         , max_depth=MaxDepth
+        , dimension_n=DimN
         ], Code).
 
 %% resolve_max_depth(+Options, -MaxDepth)
@@ -2846,6 +2852,26 @@ resolve_max_depth(Options, MaxDepth) :-
         M >= 1
     ->  MaxDepth = M
     ;   MaxDepth = 10
+    ).
+
+%% resolve_dimension_n(+Options, -DimN)
+%  Determine the aggregation formula's dimensionality (the N in
+%  d_eff = (sum Hops^(-N))^(-1/N)). Priority order:
+%   1. Options list: dimension_n(N)
+%   2. user:dimension_n/1 fact (asserted by the workload)
+%   3. Default: 5
+%  Always returns a positive integer.
+resolve_dimension_n(Options, DimN) :-
+    (   option(dimension_n(N), Options),
+        integer(N),
+        N >= 1
+    ->  DimN = N
+    ;   current_predicate(user:dimension_n/1),
+        user:dimension_n(N),
+        integer(N),
+        N >= 1
+    ->  DimN = N
+    ;   DimN = 5
     ).
 
 %% generate_inline_facts_wiring(+InlineDefs, -Code)

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -188,7 +188,7 @@ main = do
     -- Collect seed categories from article_category and TSV roots
     let seedCatsAll = nub $ sort $ map snd articleCategories
         root = head roots
-        n = 5.0 :: Double
+        n = fromIntegral ({{dimension_n}} :: Int) :: Double
         negN = -n
     (seedCats, seedLimitMetric, seedFilterMetric) <- applySeedControls seedCatsAll
 
@@ -204,7 +204,7 @@ main = do
         !root = case rootIds of
                   []      -> 0
                   (r:_)   -> r
-        n = 5.0 :: Double
+        n = fromIntegral ({{dimension_n}} :: Int) :: Double
         negN = -n
         seedLimitMetric  = Nothing :: Maybe String
         seedFilterMetric = Nothing :: Maybe String

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1430,6 +1430,51 @@ test_max_depth_option_overrides_user_fact :-
     ),
     retractall(user:max_depth(_)).
 
+%% =========================================================================
+%% dimension_n substitution (same instrumentation-bug class as max_depth).
+%%
+%% The aggregation formula d_eff = (sum Hops^(-N))^(-1/N) needs N at
+%% codegen — `n` in Main.hs was historically hardcoded to 5.0. A user
+%% asserting `dimension_n(7).` in the workload would silently still get
+%% N=5 in the FFI aggregation while the WAM-compiled `dimension_n/1`
+%% predicate returned 7. Fix: read `user:dimension_n/1` (or
+%% `dimension_n(N)` option) at codegen and substitute `{{dimension_n}}`.
+test_dimension_n_default_5_when_no_user_fact :-
+    Test = 'WAM-Haskell: Main.hs dimension_n defaults to 5 when no user:dimension_n/1',
+    retractall(user:dimension_n(_)),
+    (   wam_haskell_target:generate_main_hs([], [], [], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "fromIntegral (5 :: Int) :: Double")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Default dimension_n=5 not present in Main.hs')
+    ).
+
+test_dimension_n_from_user_fact :-
+    Test = 'WAM-Haskell: Main.hs dimension_n picks up user:dimension_n/1',
+    retractall(user:dimension_n(_)),
+    assertz(user:dimension_n(7)),
+    (   wam_haskell_target:generate_main_hs([], [], [], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "fromIntegral (7 :: Int) :: Double"),
+        \+ sub_string(S, _, _, _, "fromIntegral (5 :: Int) :: Double")
+    ->  pass(Test)
+    ;   fail_test(Test, 'user:dimension_n(7) not propagated into Main.hs')
+    ),
+    retractall(user:dimension_n(_)).
+
+test_dimension_n_option_overrides_user_fact :-
+    Test = 'WAM-Haskell: dimension_n(N) option overrides user:dimension_n/1',
+    retractall(user:dimension_n(_)),
+    assertz(user:dimension_n(7)),
+    (   wam_haskell_target:generate_main_hs([], [], [], [dimension_n(11)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "fromIntegral (11 :: Int) :: Double"),
+        \+ sub_string(S, _, _, _, "fromIntegral (7 :: Int) :: Double")
+    ->  pass(Test)
+    ;   fail_test(Test, 'dimension_n(11) option did not override user:dimension_n(7)')
+    ),
+    retractall(user:dimension_n(_)).
+
 test_b1_lmdb_dupsort_per_thread_cursor :-
     Test = 'B1: dupsort layout uses per-thread cursor cache',
     (   compile_wam_runtime_to_haskell(
@@ -1825,6 +1870,10 @@ run_tests :-
     test_max_depth_default_10_when_no_user_fact,
     test_max_depth_from_user_fact,
     test_max_depth_option_overrides_user_fact,
+    %% dimension_n substitution (same instrumentation-bug class as max_depth)
+    test_dimension_n_default_5_when_no_user_fact,
+    test_dimension_n_from_user_fact,
+    test_dimension_n_option_overrides_user_fact,
     format('~n========================================~n'),
     (   test_failed
     ->  format('Tests FAILED~n'), halt(1)


### PR DESCRIPTION
## Summary

Same instrumentation-bug class as the `max_depth` fix in PR #1721. Found by a defensive audit triggered by that fix.

`templates/targets/haskell_wam/main.hs.mustache` had `n = 5.0 :: Double` hardcoded in both the regular and `int_atom_seeds` branches. The aggregation formula `d_eff = (sum Hops^(-N))^(-1/N)` reads `n` for the dimensionality, but a user asserting `dimension_n(7).` in the workload (e.g. for a different Minkowski dimension) would silently get N=5 in the FFI aggregation while the WAM-compiled `dimension_n/1` predicate returned 7. The two would diverge — no crash, just wrong `d_eff` values.

## Audit scope

After the max_depth bug — which survived three PRs because every measurement was internally consistent at the broken value — I grepped the Haskell WAM mustache templates and codegen for the same pattern:

1. **Hardcoded numeric literals in templates** that look like they should come from user code. Found exactly one: `n = 5.0 :: Double` (lines 191 and 207 of main.hs.mustache).
2. **`current_predicate(user:...)` lookups in codegen.** Only `user:max_depth/1` was being resolved; `user:dimension_n/1` was missing.
3. **`wcForeignConfig` entries in templates.** Already templated as `Map.singleton "max_depth" {{max_depth}}` post the fix — no others lurking.
4. **Kernel templates with hardcoded thresholds.** All take parameters (e.g. `nativeKernel_category_ancestor` takes `maxDepth`). The bug class doesn't reach into the kernels themselves; it's only the call-site in Main.hs.

The audit terminated cleanly — only the one bug surfaced.

## The fix

Mirrors the agent's max_depth fix:

```prolog
%% resolve_dimension_n(+Options, -DimN)
%  Determine the aggregation formula's dimensionality (the N in
%  d_eff = (sum Hops^(-N))^(-1/N)). Priority order:
%   1. Options list: dimension_n(N)
%   2. user:dimension_n/1 fact (asserted by the workload)
%   3. Default: 5
resolve_dimension_n(Options, DimN) :- ...
```

Plus the substitution in `main.hs.mustache`:

```haskell
n = fromIntegral ({{dimension_n}} :: Int) :: Double
```

`fromIntegral` keeps the substitution simple (integer in, Double out), allowing the template to handle integer dimensionality values without per-call format conversion in Prolog.

Three new tests in `tests/test_wam_haskell_target.pl` (default / user-fact / option-override) mirror the max_depth tests.

## Why this matters

In practice, the canonical workload uses `dimension_n(5)`, which matches the old hardcoded 5.0 — so no existing behavior changes. But:

- A user trying to tune dimensionality for a different graph / domain (e.g. higher Minkowski dimension on dense graphs) would have hit silent divergence.
- The class of bug — "user code asserts a value, template silently uses a different one" — is exactly what bit us three PRs in a row with max_depth. The defensive coverage prevents the next round.
- The 3 new tests *fail* against the broken template, like the max_depth tests do, closing the loophole on the same class.

## Changes

### `templates/targets/haskell_wam/main.hs.mustache`

- Line 191 (regular branch): `n = 5.0 :: Double` → `n = fromIntegral ({{dimension_n}} :: Int) :: Double`
- Line 207 (int_atom_seeds branch): same replacement

### `src/unifyweaver/targets/wam_haskell_target.pl`

- New `resolve_dimension_n/2` after `resolve_max_depth/2` (Options first, user:dimension_n/1 second, default 5)
- New `dimension_n=DimN` parameter threaded through `render_template`
- Comment block explaining this is the same instrumentation-bug class as max_depth

### `tests/test_wam_haskell_target.pl`

Three new tests after the max_depth tests:
- `test_dimension_n_default_5_when_no_user_fact`
- `test_dimension_n_from_user_fact`
- `test_dimension_n_option_overrides_user_fact`

Registered in `run_tests/0`.

## Verification

- `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl` — all tests pass, including the 3 new dimension_n tests
- No existing behavior changes for the canonical workload (`dimension_n(5)` matches the old hardcoded 5.0)
- The 3 new tests would have failed against the pre-fix template — verified by inspection of the substitution shape (`fromIntegral (N :: Int)`)

## Test plan

- [ ] (Future) Audit the corresponding mustache templates / codegen for the other WAM targets (Rust, Elixir, Scala, Clojure) for the same pattern. Each likely has its own version of "user-asserted constant ignored by the kernel/main."

## Refs

- PR #1721 — landed the original `max_depth` fix; this PR is the defensive follow-up that covers the rest of the bug class for the Haskell target.
- PR #1714 — the bug originally surfaced as "synth_chain_30 returns tuple_count=0"; root cause was max_depth, but the audit finds dimension_n as the next-instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)