### PR TITLE
bench: add Rust WAM no-kernel matrix targets

### DIFF
--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -701,6 +701,10 @@ def main() -> int:
                     command = build_wam_rust_effective_distance(temp_root, scale, "seeded")
                 elif target == "wam-rust-accumulated":
                     command = build_wam_rust_effective_distance(temp_root, scale, "accumulated")
+                elif target == "wam-rust-seeded-no-kernels":
+                    command = build_wam_rust_effective_distance(temp_root, scale, "seeded_no_kernels")
+                elif target == "wam-rust-accumulated-no-kernels":
+                    command = build_wam_rust_effective_distance(temp_root, scale, "accumulated_no_kernels")
                 elif target == "go-wam-accumulated":
                     command = build_wam_go_effective_distance(temp_root, scale, "kernels_on")
                 elif target == "go-wam-accumulated-no-kernels":

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -54,6 +54,16 @@ TARGETS: dict[str, TargetInfo] = {
         "hybrid-wam",
         "Hybrid WAM Rust benchmark with optimized accumulated helpers",
     ),
+    "wam-rust-seeded-no-kernels": TargetInfo(
+        "wam-rust-seeded-no-kernels",
+        "hybrid-wam",
+        "Hybrid WAM Rust benchmark with seeded host accumulation and no_kernels(true)",
+    ),
+    "wam-rust-accumulated-no-kernels": TargetInfo(
+        "wam-rust-accumulated-no-kernels",
+        "hybrid-wam",
+        "Hybrid WAM Rust benchmark with optimized accumulated helpers and no_kernels(true)",
+    ),
     "go-wam-accumulated": TargetInfo(
         "go-wam-accumulated",
         "hybrid-wam",
@@ -142,6 +152,8 @@ TARGET_SETS: dict[str, list[str]] = {
     "hybrid-wam": [
         "wam-rust-seeded",
         "wam-rust-accumulated",
+        "wam-rust-seeded-no-kernels",
+        "wam-rust-accumulated-no-kernels",
         "go-wam-accumulated",
         "go-wam-accumulated-no-kernels",
         "clojure-wam-accumulated",


### PR DESCRIPTION
  ## Summary

  Adds Rust WAM no-kernel variants to the newer effective-distance matrix benchmark harness:

  - `wam-rust-seeded-no-kernels`
  - `wam-rust-accumulated-no-kernels`

  These mirror the existing Rust no-kernel variants from the older effective-distance harness and make them available
  through:

  - `--list-targets`
  - `--target-sets hybrid-wam`
  - explicit `--targets ...` matrix runs

  The targets reuse the existing Rust effective-distance generator variants:

  - `seeded_no_kernels`
  - `accumulated_no_kernels`

  ## Validation

  - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/
  benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --list-targets`
  - `WAM_SEED_FILTER=Physics python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 300 --targets
  wam-rust-accumulated,wam-rust-accumulated-no-kernels --repetitions 1`