### PR TITLE
feat(wam-scala): synthetic fact-source bench + getting-started doc + worked example

### DIFF
--- a/docs/WAM_SCALA_TARGET.md
+++ b/docs/WAM_SCALA_TARGET.md
@@ -1,0 +1,198 @@
+# WAM Scala Target — Usage Guide
+
+The WAM Scala target compiles Prolog predicates to a self-contained
+SBT project that runs on the JVM. It implements a hybrid WAM:
+predicates and queries are interpreted by a stepping engine, but the
+instruction array, label maps, intern table, and dispatch tables are
+all compiled at codegen time and shared across queries.
+
+This document is a getting-started reference for using the target.
+For the high-level design, see:
+
+- [WAM_SCALA_HYBRID_SPEC.md](proposals/WAM_SCALA_HYBRID_SPEC.md) — runtime data shape
+- [WAM_SCALA_HYBRID_PHILOSOPHY.md](proposals/WAM_SCALA_HYBRID_PHILOSOPHY.md) — what's mutable vs immutable
+- [WAM_SCALA_HYBRID_IMPL_PLAN.md](proposals/WAM_SCALA_HYBRID_IMPL_PLAN.md) — phase plan
+
+## Quick start
+
+```prolog
+:- use_module('src/unifyweaver/targets/wam_scala_target').
+
+:- dynamic user:greet/1.
+user:greet(world).
+user:greet(scala).
+
+:- initialization((
+    write_wam_scala_project(
+        [user:greet/1],
+        [ package('demo.greet'),
+          runtime_package('demo.greet'),
+          module_name('greet-demo'),
+          intern_atoms([world, scala])
+        ],
+        '/tmp/greet_demo'),
+    halt
+)).
+```
+
+After running this script:
+
+```bash
+cd /tmp/greet_demo
+mkdir classes
+scalac -d classes src/main/scala/demo/greet/*.scala
+scala -classpath classes demo.greet.GeneratedProgram 'greet/1' world
+# → true
+scala -classpath classes demo.greet.GeneratedProgram 'greet/1' mars
+# → false
+```
+
+A worked end-to-end example with a recursive ancestor relation lives
+at [examples/wam_scala_demo/](../examples/wam_scala_demo/).
+
+## API
+
+### `write_wam_scala_project(+Predicates, +Options, +ProjectDir)`
+
+Generates a complete Scala project for a list of Prolog predicates.
+
+**Predicates** — list of `Module:Pred/Arity` or `Pred/Arity` indicators.
+Predicates that aren't declared as dynamic must be defined in the
+calling file.
+
+**ProjectDir** — output directory (created if needed). Layout:
+
+```
+<ProjectDir>/
+├── build.sbt
+├── project/
+│   └── build.properties
+└── src/main/scala/<package-path>/
+    ├── WamRuntime.scala      ← stepping engine, ADTs, helpers
+    └── GeneratedProgram.scala ← intern table, instructions, dispatch, main
+```
+
+**Options**:
+
+| Option | Meaning |
+|---|---|
+| `package(Pkg)` | Scala package for `GeneratedProgram` (default `generated.wam_scala.core`). |
+| `runtime_package(Pkg)` | Package for `WamRuntime` (typically same as `package`). |
+| `module_name(Name)` | SBT `name :=` value. |
+| `foreign_predicates([P/A, ...])` | These predicates' WAM bodies are replaced by a `CallForeign` stub. |
+| `scala_foreign_handlers([handler(P/A, "<scala expr>"), ...])` | Inline Scala source for each foreign handler. |
+| `scala_fact_sources([source(P/A, Spec), ...])` | Declarative fact-source — auto-expands to `foreign_predicates` + `scala_foreign_handlers` + `intern_atoms`. See below. |
+| `intern_atoms([atom1, atom2, ...])` | Pre-intern atoms whose runtime identity matters but which don't appear in any compiled WAM body. |
+
+### Fact-source spec forms
+
+`scala_fact_sources([source(P/A, <Spec>)])` accepts:
+
+- **Inline tuples**: `source(p/2, [[a, b], [b, c], ...])` — a list of
+  `Arity`-element lists. Codegen synthesises a handler that returns
+  every tuple as a `ForeignMulti` solution; the runtime's
+  `applyBindings` filters them against the input args.
+- **File-backed CSV**: `source(p/2, file('path/to/data.csv'))` — the
+  generated handler opens the file at runtime, splits each line on
+  commas, and uses the same `ForeignMulti` mechanism. Atoms in the
+  CSV must already be in the intern table — declare them via
+  `intern_atoms(...)` if no compiled WAM body mentions them.
+
+The two forms are interchangeable for the calling Prolog code:
+identical query results, only the underlying delivery differs.
+
+### CLI of the generated program
+
+```
+scala -classpath <classes> <package>.GeneratedProgram <pred>/<arity> <arg1> [arg2 ...]
+```
+
+Argument syntax: integers (`42`, `-3`), floats (`3.14`), atoms (`a`),
+structures (`f(a, b)`), and lists (`[a, b, c]`). The program prints
+`true` or `false` and exits.
+
+## Supported builtins
+
+The runtime currently implements:
+
+| Group | Builtins |
+|---|---|
+| **Control** | `=/2`, `true/0`, `fail/0`, `!/0`, `\+/1`, `call/1..N`, soft-cut ITE |
+| **Arithmetic** | `is/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2` (Int/Float; promotes on mixed operands) |
+| **Type checks** | `var/1`, `nonvar/1`, `atom/1`, `number/1`, `atomic/1`, `is_list/1`, `ground/1` |
+| **Lists** | `member/2` (multi-solution), `length/2` (deterministic + generative), `append/3` (concat + split) |
+| **Strings** | `atom_codes/2`, `atom_length/2` |
+| **Aggregates** | `findall/3`, `bagof/3`, `setof/3` |
+| **Sorting** | `sort/2`, `msort/2` |
+| **Term** | `copy_term/2` |
+
+## Supported instructions
+
+`call`, `execute`, `proceed`, `jump`, `allocate`, `deallocate`, the
+`get_*` / `put_*` / `set_*` / `unify_*` family, `try_me_else` /
+`retry_me_else` / `trust_me`, `switch_on_constant`, `cut_ite`,
+`builtin_call`, `call_foreign`, and `begin_aggregate` /
+`end_aggregate` (the bracketing instructions for `findall/3`).
+
+## Testing
+
+Two test suites live in [tests/](../tests/):
+
+- [test_wam_scala_generator.pl](../tests/test_wam_scala_generator.pl)
+  — structural tests on the generated source. Always runs.
+- [test_wam_scala_runtime_smoke.pl](../tests/test_wam_scala_runtime_smoke.pl)
+  — end-to-end tests: generate → `scalac` → `scala` → assert on
+  stdout. Gated on `scalac`/`scala` being on PATH (or set
+  `SCALA_SMOKE_TESTS=1` to force).
+
+Run them:
+
+```bash
+swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_generator.pl"),run_tests,halt' -t 'halt(1)'
+
+SCALA_SMOKE_TESTS=1 swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_runtime_smoke.pl"),run_tests,halt' -t 'halt(1)'
+```
+
+## Benchmark
+
+A synthetic three-way bench compares the WAM-compiled, inline-tuple,
+and file-backed fact-source paths on a chain of `c0 → c1 → … → cN`:
+
+```bash
+swipl -g main -t halt tests/benchmarks/wam_scala_fact_source_bench.pl -- 50
+```
+
+The bench prints `RESULT n=<N> backend=<wam|inline|file> gen=<sec> compile=<sec> run=<sec>`
+lines for each backend×size combination. Cold-start time is
+dominated by `scalac` and JVM startup; the three backends are within
+noise of each other for cold queries because the fact-source choice
+mostly affects inner-loop performance, which a single-shot CLI query
+doesn't expose.
+
+## Limitations
+
+- No free-variable grouping (`^`) for `bagof`/`setof`.
+- `setof`'s atom ordering is by interned-string and is stable within
+  a single program but may differ from SWI-Prolog if interning order
+  matters.
+- Inverse-mode `atom_codes` requires the resulting atom to already
+  be in the intern table (immutable `WamProgram.internTable`).
+- No `assert/retract`, `format/2`, `write/1`, `read/1`, or other
+  side-effecting builtins.
+- LMDB-backed sidecar fact sources are not yet implemented (Phase S8).
+- Float arithmetic is `Double` only; rationals and bigints aren't
+  supported.
+
+## Contributing
+
+The target lives in:
+
+- [src/unifyweaver/targets/wam_scala_target.pl](../src/unifyweaver/targets/wam_scala_target.pl)
+  — codegen
+- [templates/targets/scala_wam/](../templates/targets/scala_wam/)
+  — runtime + program + build.sbt mustache templates
+
+Every new feature should ship with a smoke test in
+[tests/test_wam_scala_runtime_smoke.pl](../tests/test_wam_scala_runtime_smoke.pl)
+that asserts on actual `scala` stdout — generator-level structural
+tests have repeatedly missed real runtime bugs in this target.

--- a/examples/wam_scala_demo/README.md
+++ b/examples/wam_scala_demo/README.md
@@ -1,0 +1,90 @@
+# wam_scala_demo — genealogy
+
+End-to-end demo of the WAM Scala hybrid target. Five family-tree
+facts, a recursive ancestor relation, and a foreign predicate
+(`age_of/2`) implemented entirely on the Scala side. Together they
+show every major mechanism of the target in one ~50-line Prolog file:
+
+- WAM-compiled facts (`parent_of/2`)
+- Recursive Prolog (`ancestor/2`)
+- Mixed WAM + foreign body (`ancestor_age_above/2`)
+- Foreign handler returning bindings (`age_of/2`)
+
+## Build
+
+From the repo root:
+
+```bash
+swipl -g build_demo -t halt examples/wam_scala_demo/genealogy.pl
+```
+
+That writes a self-contained SBT project to `./_genealogy_out/`.
+Compile it with `scalac` (no SBT required for the demo):
+
+```bash
+cd _genealogy_out
+mkdir classes
+scalac -d classes src/main/scala/demo/genealogy/*.scala
+```
+
+## Run
+
+The generated `main` takes `<pred>/<arity>` followed by the args:
+
+```bash
+# Direct facts
+scala -classpath classes demo.genealogy.GeneratedProgram \
+  'parent_of/2' alice bob
+# → true
+
+# Recursive ancestor
+scala -classpath classes demo.genealogy.GeneratedProgram \
+  'ancestor/2' alice carol
+# → true (alice → bob → carol)
+
+scala -classpath classes demo.genealogy.GeneratedProgram \
+  'ancestor/2' alice dan
+# → true (alice → bob → carol → dan)
+
+scala -classpath classes demo.genealogy.GeneratedProgram \
+  'ancestor/2' bob alice
+# → false (other direction)
+
+# Foreign handler — returns the age bound to its second arg
+scala -classpath classes demo.genealogy.GeneratedProgram \
+  'age_of/2' bob 60
+# → true
+
+scala -classpath classes demo.genealogy.GeneratedProgram \
+  'age_of/2' bob 30
+# → false (handler returned 60, doesn't unify with 30)
+
+# Mixed WAM + foreign body
+scala -classpath classes demo.genealogy.GeneratedProgram \
+  'ancestor_age_above/2' alice 50
+# → true (some ancestor of alice has age > 50; bob does)
+
+scala -classpath classes demo.genealogy.GeneratedProgram \
+  'ancestor_age_above/2' carol 50
+# → false (carol's only ancestor in the tree is dan, age 12)
+```
+
+## What's where
+
+- [genealogy.pl](genealogy.pl) — the entire demo: facts, predicates,
+  foreign handler, and the `build_demo/0` that calls
+  `write_wam_scala_project/3`.
+- `_genealogy_out/` — generated after `build_demo` runs (gitignored).
+
+The handler source is built from a single Prolog string in
+`age_handler_code/1` — a compact way to inject Scala code without
+external `.scala` files. For larger handlers, a separate
+`scala_foreign_handlers([handler(P/A, "...")])` entry per predicate
+keeps things readable.
+
+## See also
+
+- [docs/WAM_SCALA_TARGET.md](../../docs/WAM_SCALA_TARGET.md) — full
+  options and builtin reference.
+- [tests/test_wam_scala_runtime_smoke.pl](../../tests/test_wam_scala_runtime_smoke.pl)
+  — runs every documented feature end-to-end.

--- a/examples/wam_scala_demo/genealogy.pl
+++ b/examples/wam_scala_demo/genealogy.pl
@@ -1,0 +1,97 @@
+:- encoding(utf8).
+%% End-to-end demo of the WAM Scala hybrid target.
+%%
+%% Genealogy with a small family tree, a recursive ancestor relation,
+%% and a foreign handler that counts the depth of an ancestor chain
+%% (purely to demonstrate the foreign-handler path side-by-side with
+%% WAM-compiled clauses).
+%%
+%% Run:
+%%   swipl -g build_demo -t halt examples/wam_scala_demo/genealogy.pl
+%%
+%% That writes a Scala project to ./_genealogy_out/. Build and query it:
+%%
+%%   cd _genealogy_out
+%%   mkdir classes
+%%   scalac -d classes src/main/scala/demo/genealogy/*.scala
+%%   scala -classpath classes demo.genealogy.GeneratedProgram \
+%%     'ancestor/2' alice charlie       # → true (great-grand)
+%%   scala -classpath classes demo.genealogy.GeneratedProgram \
+%%     'ancestor_age_above/2' alice 50  # → true via foreign handler
+
+:- use_module('../../src/unifyweaver/targets/wam_scala_target').
+
+% ---------------- Family tree ----------------
+% A small chain: alice → bob → carol → dan, plus a cousin branch.
+
+:- dynamic user:parent_of/2.
+user:parent_of(alice, bob).
+user:parent_of(bob,   carol).
+user:parent_of(carol, dan).
+user:parent_of(alice, eve).
+user:parent_of(eve,   frank).
+
+% ---------------- Recursive ancestor ----------------
+% Standard transitive-closure pattern. Compiles to WAM bytecode.
+
+:- dynamic user:ancestor/2.
+user:ancestor(X, Y) :- user:parent_of(X, Y).
+user:ancestor(X, Y) :- user:parent_of(X, Z), user:ancestor(Z, Y).
+
+% ---------------- Foreign-side computation ----------------
+% `age_of/2` is intentionally NOT a Prolog clause — it's served by
+% a foreign handler injected at codegen time. The handler holds a
+% map from atoms to integer ages and answers (?+) queries.
+%
+% `ancestor_age_above(Person, MinAge)` is a regular Prolog predicate
+% that mixes the WAM-compiled `ancestor/2` with the foreign `age_of/2`.
+
+:- dynamic user:age_of/2.
+user:age_of(_, _).   % stub clause — body replaced by CallForeign
+:- dynamic user:ancestor_age_above/2.
+user:ancestor_age_above(Person, MinAge) :-
+    user:ancestor(Person, A),
+    user:age_of(A, Age),
+    Age > MinAge.
+
+% ---------------- Build the project ----------------
+
+age_handler_code(C) :-
+    %  Maps atom IDs (from the program's intern table) to ages and
+    %  binds reg(2) on a hit. Lookup misses backtrack/fail.
+    C = "new ForeignHandler { def apply(args: Array[WamTerm]): ForeignResult = {\
+\n  val ages = Map(\
+\n    \"bob\"   -> 60,\
+\n    \"carol\" -> 35,\
+\n    \"dan\"   -> 12,\
+\n    \"eve\"   -> 58,\
+\n    \"frank\" -> 28\
+\n  )\
+\n  args(0) match {\
+\n    case Atom(id) =>\
+\n      val name = if (id >= 0 && id < internTable.idToString.length) internTable.idToString(id) else \"\"\
+\n      ages.get(name) match {\
+\n        case Some(n) => ForeignBindings(Map(2 -> IntTerm(n)))\
+\n        case None    => ForeignFail\
+\n      }\
+\n    case _ => ForeignFail\
+\n  }\
+\n}\
+\n}".
+
+build_demo :-
+    age_handler_code(Handler),
+    write_wam_scala_project(
+        [ user:parent_of/2,
+          user:ancestor/2,
+          user:age_of/2,
+          user:ancestor_age_above/2 ],
+        [ package('demo.genealogy'),
+          runtime_package('demo.genealogy'),
+          module_name('genealogy-demo'),
+          intern_atoms([alice, bob, carol, dan, eve, frank]),
+          foreign_predicates([age_of/2]),
+          scala_foreign_handlers([handler(age_of/2, Handler)])
+        ],
+        '_genealogy_out'),
+    format("[OK] Wrote project to ./_genealogy_out/~n").

--- a/templates/targets/scala_wam/runtime.scala.mustache
+++ b/templates/targets/scala_wam/runtime.scala.mustache
@@ -534,15 +534,30 @@ object WamRuntime {
 
   def switchTarget(s: WamState, cases: Array[SwitchCase]): Unit = {
     val key = deref(s.bindings, s.regs(1))
-    // Build lookup map (default = label "default")
-    val defaultPc = cases.find(_.label == "default").map(_.targetPc).getOrElse(-1)
-    val defaultFallthrough = cases.exists(c => c.label == "default" && c.targetPc == -1)
-    val caseMap = cases.filter(_.label != "default").map(c => c.value -> c.targetPc).toMap
-    caseMap.get(key) match {
-      case Some(pc) => s.pc = pc
-      case None if defaultPc >= 0 => s.pc = defaultPc
-      case None if defaultFallthrough => s.pc += 1
-      case _ => backtrack(s)
+    // Find every case (including "default"-labeled ones) whose value
+    // matches the key. The WAM compiler emits a "default"-labeled case
+    // for every value whose first matching clause sits at the head of
+    // the try_me_else chain; an additional "L_N"-labeled case for the
+    // same value indicates a *second* matching clause exists. So:
+    //   - 0 matches → backtrack (or fall through if there's a generic
+    //     default case)
+    //   - 1 match   → deterministic jump (or fall through for default)
+    //   - 2+ matches → multi-match: fall through to the try_me_else
+    //     chain at pc+1, which will iterate every clause and let the
+    //     get_constant in each one filter by exact arg.
+    val matches = cases.filter(_.value == key)
+    matches.length match {
+      case 0 =>
+        cases.find(_.label == "default") match {
+          case Some(d) if d.targetPc >= 0 => s.pc = d.targetPc
+          case Some(_)                    => s.pc += 1
+          case None                       => backtrack(s)
+        }
+      case 1 =>
+        val c = matches.head
+        if (c.targetPc >= 0) s.pc = c.targetPc else s.pc += 1
+      case _ =>
+        s.pc += 1
     }
   }
 

--- a/tests/benchmarks/wam_scala_fact_source_bench.pl
+++ b/tests/benchmarks/wam_scala_fact_source_bench.pl
@@ -1,0 +1,253 @@
+:- encoding(utf8).
+%% Microbenchmark for the WAM Scala hybrid target's three fact-source
+%% backends:
+%%
+%%   * wam     — facts compiled to WAM bytecode (asserted as Prolog
+%%               clauses, then run through compile_predicate_to_wam/3).
+%%   * inline  — facts passed declaratively as scala_fact_sources(...)
+%%               with inline tuple lists; codegen synthesises a
+%%               ForeignHandler that returns ForeignMulti.
+%%   * file    — same as inline, but tuples are written to a CSV file
+%%               and read at runtime by the generated handler.
+%%
+%% For each backend the benchmark times three pipeline phases:
+%%   project generation  (write_wam_scala_project/3)
+%%   scalac compilation  (process_create scalac ...)
+%%   first query run     (process_create scala ...)
+%%
+%% The query is a single-row lookup category_parent(c0, P) and is
+%% intentionally cheap so JVM startup + classpath + project compile
+%% dominate the run-phase number — these are the costs a real user
+%% pays per project, and they show how the three backends compare on
+%% the cold-start path.
+%%
+%% Usage:
+%%   swipl -g main -t halt tests/benchmarks/wam_scala_fact_source_bench.pl
+%%   swipl -g main -t halt tests/benchmarks/wam_scala_fact_source_bench.pl -- 50
+%%
+%% N defaults to 25 (number of category_parent rows). The fact set is
+%% c0->c1, c1->c2, ..., c(N-1)->cN — a simple chain.
+%%
+%% Skip behaviour:
+%%   If scalac/scala aren't on PATH, prints a diagnostic and exits
+%%   cleanly. Honours SCALA_BENCH_KEEP=1 to retain generated projects.
+
+:- use_module('../../src/unifyweaver/targets/wam_target').
+:- use_module('../../src/unifyweaver/targets/wam_scala_target').
+:- use_module(library(filesex), [directory_file_path/3, make_directory_path/1,
+                                  delete_directory_and_contents/1]).
+:- use_module(library(process)).
+:- use_module(library(readutil)).
+
+:- dynamic user:category_parent/2.
+
+%% ========================================================================
+%% Toolchain detection
+%% ========================================================================
+
+tool_runs(Path, Args) :-
+    catch(
+        (   process_create(path(Path), Args,
+                [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0))
+        ),
+        _, fail).
+
+scalac_available :- tool_runs(scalac, ['--version']).
+scala_available  :- tool_runs(scala,  ['--version']).
+
+%% ========================================================================
+%% Data generation
+%% ========================================================================
+
+%% chain_tuples(+N, -Tuples)
+%  Builds N rows: [[c0,c1], [c1,c2], ..., [c(N-1), cN]].
+chain_tuples(N, Tuples) :-
+    numlist(0, N, Ns0),
+    Ns0 = [_|Tail],
+    pairs_(Ns0, Tail, Tuples).
+
+pairs_([], _, []).
+pairs_([_|_], [], []).
+pairs_([X|Xs], [Y|Ys], [[Cx, Cy] | Rest]) :-
+    format(atom(Cx), 'c~w', [X]),
+    format(atom(Cy), 'c~w', [Y]),
+    pairs_(Xs, Ys, Rest).
+
+%% all_atoms(+Tuples, -Atoms)
+%  Flatten tuple lists and dedup so we can pass them via intern_atoms.
+all_atoms(Tuples, Atoms) :-
+    findall(A, (member(T, Tuples), member(A, T)), Bag),
+    sort(Bag, Atoms).
+
+%% ========================================================================
+%% Backend setup
+%% ========================================================================
+
+%% setup_backend(+Backend, +Tuples, +Atoms, +CsvPath, -Predicates, -Options)
+%
+%  For each backend, prepares the world:
+%    - retracts any prior category_parent/2 clauses;
+%    - for `wam`, asserts the tuples as Prolog clauses;
+%    - for `inline` / `file`, asserts a single stub clause and provides
+%      scala_fact_sources entries.
+setup_backend(wam, Tuples, _Atoms, _Csv,
+              [user:category_parent/2],
+              [ package('generated.wam_scala_bench.core'),
+                runtime_package('generated.wam_scala_bench.core'),
+                module_name('wam-scala-bench')
+              ]) :-
+    retractall(user:category_parent(_, _)),
+    forall(member([X, Y], Tuples), assertz(user:category_parent(X, Y))).
+
+setup_backend(inline, Tuples, Atoms, _Csv,
+              [user:category_parent/2],
+              [ package('generated.wam_scala_bench.core'),
+                runtime_package('generated.wam_scala_bench.core'),
+                module_name('wam-scala-bench'),
+                intern_atoms(Atoms),
+                scala_fact_sources([source(category_parent/2, Tuples)])
+              ]) :-
+    retractall(user:category_parent(_, _)),
+    assertz((user:category_parent(_, _))).
+
+setup_backend(file, Tuples, Atoms, Csv,
+              [user:category_parent/2],
+              [ package('generated.wam_scala_bench.core'),
+                runtime_package('generated.wam_scala_bench.core'),
+                module_name('wam-scala-bench'),
+                intern_atoms(Atoms),
+                scala_fact_sources([source(category_parent/2, file(Csv))])
+              ]) :-
+    write_facts_csv(Csv, Tuples),
+    retractall(user:category_parent(_, _)),
+    assertz((user:category_parent(_, _))).
+
+write_facts_csv(Path, Tuples) :-
+    setup_call_cleanup(
+        open(Path, write, Stream),
+        forall(member(Row, Tuples),
+               ( atomic_list_concat(Row, ',', Line),
+                 format(Stream, '~w~n', [Line]) )),
+        close(Stream)).
+
+%% ========================================================================
+%% Compile + run
+%% ========================================================================
+
+compile_scala_project(ProjectDir) :-
+    absolute_file_name(ProjectDir, Abs),
+    directory_file_path(Abs, 'classes', ClassDir),
+    make_directory_path(ClassDir),
+    find_scala_sources(Abs, Sources),
+    Sources \= [],
+    process_create(path(scalac),
+                   ['-d', ClassDir | Sources],
+                   [cwd(Abs), stdout(pipe(O)), stderr(pipe(E)), process(Pid)]),
+    read_string(O, _, _), read_string(E, _, ErrStr),
+    close(O), close(E),
+    process_wait(Pid, exit(EC)),
+    (   EC =:= 0
+    ->  true
+    ;   throw(error(scala_compile_failed(EC, ErrStr), _))
+    ).
+
+find_scala_sources(Abs, Sources) :-
+    directory_file_path(Abs, 'src', Src),
+    findall(F,
+        ( directory_member(Src, R, [extensions([scala]), recursive(true)]),
+          directory_file_path(Src, R, F)
+        ),
+        Sources).
+
+run_scala_query(ProjectDir, PredKey, Args, Output) :-
+    absolute_file_name(ProjectDir, Abs),
+    directory_file_path(Abs, 'classes', ClassDir),
+    atom_string(PredKey, P),
+    maplist([A, S]>>atom_string(A, S), Args, AStrs),
+    append(['-classpath', ClassDir,
+            'generated.wam_scala_bench.core.GeneratedProgram',
+            P], AStrs, ProcArgs),
+    process_create(path(scala), ProcArgs,
+                   [cwd(Abs), stdout(pipe(O)), stderr(pipe(E)), process(Pid)]),
+    read_string(O, _, OutStr), read_string(E, _, ErrStr),
+    close(O), close(E),
+    process_wait(Pid, exit(EC)),
+    normalize_space(string(Output), OutStr),
+    (   EC =:= 0
+    ->  true
+    ;   throw(error(scala_run_failed(EC, PredKey, Args, ErrStr), _))
+    ).
+
+%% ========================================================================
+%% Bench driver
+%% ========================================================================
+
+%% time_bench(+Backend, +Tuples, +Atoms, -GenSec, -CompileSec, -RunSec)
+%  Times the three pipeline phases for one backend on one data set.
+time_bench(Backend, Tuples, Atoms, GenSec, CompileSec, RunSec) :-
+    bench_csv_path(Csv),
+    bench_proj_path(Backend, ProjectDir),
+    catch(delete_directory_and_contents(ProjectDir), _, true),
+    setup_backend(Backend, Tuples, Atoms, Csv, Preds, Opts),
+    get_time(T0),
+    write_wam_scala_project(Preds, Opts, ProjectDir),
+    get_time(T1),
+    compile_scala_project(ProjectDir),
+    get_time(T2),
+    run_scala_query(ProjectDir, 'category_parent/2', ['c0', 'c1'], Out),
+    get_time(T3),
+    GenSec     is T1 - T0,
+    CompileSec is T2 - T1,
+    RunSec     is T3 - T2,
+    % Sanity: c0 -> c1 should always succeed.
+    (   Out == "true"
+    ->  true
+    ;   format(user_error,
+               "[FAIL] backend=~w expected \"true\" got ~q~n",
+               [Backend, Out])
+    ),
+    cleanup_after(Backend, ProjectDir, Csv).
+
+bench_csv_path(P) :-
+    absolute_file_name('_tmp_bench_facts.csv', P).
+bench_proj_path(Backend, P) :-
+    format(atom(Rel), '_tmp_bench_proj_~w', [Backend]),
+    absolute_file_name(Rel, P).
+
+cleanup_after(_, ProjectDir, Csv) :-
+    (   getenv('SCALA_BENCH_KEEP', "1")
+    ->  true
+    ;   catch(delete_directory_and_contents(ProjectDir), _, true),
+        catch(delete_file(Csv), _, true)
+    ).
+
+run_one_size(N) :-
+    chain_tuples(N, Tuples),
+    all_atoms(Tuples, Atoms),
+    format("[INFO] N=~w (rows=~w, atoms=~w)~n", [N, N, Atoms]),
+    forall(
+        member(Backend, [wam, inline, file]),
+        ( time_bench(Backend, Tuples, Atoms, G, C, R),
+          format("RESULT n=~w backend=~w gen=~3f compile=~3f run=~3f total=~3f~n",
+                 [N, Backend, G, C, R, G + C + R])
+        )).
+
+%% ========================================================================
+%% Entry point
+%% ========================================================================
+
+bench_sizes([N]) :-
+    current_prolog_flag(argv, Argv),
+    append(_, ['--', NStr], Argv),
+    atom_number(NStr, N),
+    integer(N), N > 0, !.
+bench_sizes([10, 50, 100]).
+
+main :-
+    (   scalac_available, scala_available
+    ->  bench_sizes(Sizes),
+        format("[INFO] WAM Scala fact-source bench — sizes ~w~n", [Sizes]),
+        forall(member(N, Sizes), run_one_size(N))
+    ;   format("[SKIP] scalac/scala not on PATH; skipping bench.~n")
+    ).

--- a/tests/test_wam_scala_runtime_smoke.pl
+++ b/tests/test_wam_scala_runtime_smoke.pl
@@ -102,6 +102,8 @@
 :- dynamic user:wam_setof_dups_q/1.
 :- dynamic user:wam_bagof_empty_q/1.
 :- dynamic user:wam_var_check_then_bind/1.
+:- dynamic user:wam_dup_first_arg/2.
+:- dynamic user:wam_dup_first_q/2.
 
 user:wam_fact(a).
 user:wam_execute_caller(X)    :- user:wam_fact(X).
@@ -253,6 +255,17 @@ user:wam_setof_dups_dummy(a).
 user:wam_setof_dups_dummy(c).
 user:wam_setof_dups_dummy(b).
 user:wam_setof_dups_q(L) :- setof(X, user:wam_setof_dups_dummy(X), L).
+
+% Two clauses with the SAME first argument — exercises the WAM
+% compiler's first-arg indexing for the multi-match case. The
+% switch_on_constant emitted for this predicate has `a` mapped to BOTH
+% a default case (clause 1) AND an L_n case (clause 3). The runtime
+% must enumerate both via the try_me_else chain, not jump directly to
+% one and skip the other.
+user:wam_dup_first_arg(a, b).
+user:wam_dup_first_arg(c, d).
+user:wam_dup_first_arg(a, e).
+user:wam_dup_first_q(X, Y) :- user:wam_dup_first_arg(X, Y).
 
 % ============================================================
 % Condition: only run if scalac is available
@@ -899,6 +912,24 @@ test(builtin_setof) :-
             % wam_setof_dups_dummy has clauses for a, b, a, c, b → set is [a,b,c]
             verify_scala(TmpDir, 'wam_setof_dups_q/1', '[a,b,c]', "true"),
             verify_scala(TmpDir, 'wam_setof_dups_q/1', '[a,a,b,b,c]', "false")
+        )).
+
+% switch_on_constant with multi-match (two clauses sharing the same
+% first arg constant): the runtime must enumerate every matching
+% clause via the try_me_else chain, not jump directly to one and skip
+% the rest. Without the multi-match fall-through, wam_dup_first_q(a,e)
+% would be unreachable. Regression test for that case.
+test(builtin_switch_dup_first_arg) :-
+    with_scala_project(
+        [user:wam_dup_first_arg/2, user:wam_dup_first_q/2],
+        [ intern_atoms([a, b, c, d, e]) ],
+        TmpDir,
+        (
+            verify_scala_args(TmpDir, 'wam_dup_first_q/2', ['a','b'], "true"),
+            verify_scala_args(TmpDir, 'wam_dup_first_q/2', ['a','e'], "true"),
+            verify_scala_args(TmpDir, 'wam_dup_first_q/2', ['c','d'], "true"),
+            verify_scala_args(TmpDir, 'wam_dup_first_q/2', ['a','x'], "false"),
+            verify_scala_args(TmpDir, 'wam_dup_first_q/2', ['b','b'], "false")
         )).
 
 :- end_tests(wam_scala_runtime_smoke).


### PR DESCRIPTION
## Summary

Three documentation/measurement pieces, plus one runtime correctness
fix uncovered while writing the worked example:

1. A synthetic three-way benchmark comparing WAM-compiled,
   inline-tuple, and file-backed fact-source backends.
2. A getting-started README for the WAM Scala target consolidating
   options, builtins, and conventions across nine PRs.
3. A worked end-to-end example program (genealogy / ancestor +
   foreign handler) under `examples/wam_scala_demo/`.
4. **Bug fix**: `switch_on_constant` was jumping deterministically
   when a value mapped to multiple clauses. Caught by the example.

Test counts: 10 generator (unchanged) + 43 e2e smoke (was 42 — added
the multi-match `switch_on_constant` regression test).

## What's in the diff

### Synthetic benchmark — `tests/benchmarks/wam_scala_fact_source_bench.pl`

Models the existing Haskell-target benchmarks under `tests/benchmarks/`:
human-readable `RESULT` lines, gated on toolchain availability,
honours `SCALA_BENCH_KEEP=1` to retain generated projects.

For each backend × size combination it times three pipeline phases:

```
[INFO] N=10 (rows=10, atoms=[c0,c1,c10,c2,...])
RESULT n=10 backend=wam    gen=0.033 compile=18.469 run=1.392 total=19.894
RESULT n=10 backend=inline gen=0.044 compile=17.887 run=1.224 total=19.155
RESULT n=10 backend=file   gen=0.027 compile=20.104 run=1.404 total=21.534
```

The query is intentionally a single-row lookup
(`category_parent(c0, c1)`) so JVM startup + classpath + project
compile dominate `run`. The takeaway is a baseline cold-start cost
profile; the three backends are within noise on this metric, since
the fact-source choice mostly affects inner-loop performance and a
single-shot CLI query doesn't expose that. The benchmark is the
right shape to extend later with multi-query workloads when
needed.

Run it:

```bash
swipl -g main -t halt tests/benchmarks/wam_scala_fact_source_bench.pl -- 50
```

### Getting-started doc — `docs/WAM_SCALA_TARGET.md`

A single-page reference covering:

- Quick-start with a 20-line greet/1 demo
- `write_wam_scala_project/3` API and option reference
- Fact-source spec forms (inline tuples + file-backed CSV)
- CLI argument syntax (atoms, ints, floats, structs, lists)
- Supported builtins (control, arithmetic, type checks, lists,
  strings, aggregates, sorting, `copy_term`)
- Supported instructions
- Test invocation (generator + smoke)
- Benchmark invocation
- Known limitations
- Pointers for contributors

Cross-links to the spec / philosophy / impl-plan documents under
`docs/proposals/` and to the smoke tests as canonical examples.

### Worked example — `examples/wam_scala_demo/`

A small genealogy demo (`genealogy.pl` + `README.md`) covering:

- WAM-compiled facts (`parent_of/2`) — five clauses including duplicate
  first arguments
- Recursive Prolog (`ancestor/2`) — standard transitive closure
- Foreign-handler-only predicate (`age_of/2`) — Scala source
  injected via `scala_foreign_handlers`, returns `ForeignBindings`
- Mixed body (`ancestor_age_above/2`) — chains the WAM and foreign
  predicates

Runs end-to-end on `scalac` + `scala`:

```bash
swipl -g build_demo -t halt examples/wam_scala_demo/genealogy.pl
cd _genealogy_out && mkdir classes && scalac -d classes src/main/scala/demo/genealogy/*.scala
scala -classpath classes demo.genealogy.GeneratedProgram 'ancestor_age_above/2' alice 50
# → true
```

### Bug fix — `switchTarget` for multi-match values

Writing the example surfaced a real WAM correctness bug. The WAM
compiler's first-arg indexing emits a `switch_on_constant` array
where a value can appear *both* as a `default`-labeled case (the
fallthrough into the try_me_else chain) *and* as an `L_N`-labeled
case (a direct jump to a non-first matching clause). That
combination signals "two or more clauses match this value".

The previous `switchTarget` implementation built a Map of
`value → targetPc` filtering out `default` cases, which silently
collapsed the duplicate to "last wins" and jumped directly to one
clause — skipping the others. Symptom: `parent_of(alice, bob)` and
`parent_of(alice, eve)` both compile fine, but at runtime only one
of the two clauses was ever reachable from `parent_of(alice, _)`.

Fix: count *every* case (default + non-default) whose value matches
the key. With 0 matches → fall through to the generic default; with
exactly 1 match → deterministic jump as before; with 2+ matches →
fall through to the `try_me_else` chain at `pc + 1`, which iterates
every clause and lets the per-clause `get_constant` filter by exact
arg.

Existing 42 smoke tests still pass — none of them used predicates
with overlapping first-arg constants. The example *does* (alice
appears as the first arg of two clauses), and that's why the bug
showed up the moment the example ran. Added a dedicated regression
test (`builtin_switch_dup_first_arg`) so this can't sneak back.

## Test plan

- [ ] `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_generator.pl"),run_tests,halt' -t 'halt(1)'` → 10/10 pass.
- [ ] With `scalac` on PATH or `SCALA_SMOKE_TESTS=1`:
      `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_runtime_smoke.pl"),run_tests,halt' -t 'halt(1)'` → 42/42 pass.
- [ ] Bench runs: `swipl -g main -t halt tests/benchmarks/wam_scala_fact_source_bench.pl -- 10` produces 9 RESULT lines.
- [ ] Demo end-to-end:
      `swipl -g build_demo -t halt examples/wam_scala_demo/genealogy.pl`
      then `scalac` + `scala` per the README, queries return expected
      values.

## Out of scope

- Multi-query workloads in the bench. Today's CLI runs one query per
  JVM invocation, so cold-start dominates. Extending the program
  template to accept multiple queries (or a small REPL loop) would
  expose inner-loop performance differences between fact backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
