### PR TITLE
feat(wam-clojure): lower simple instruction prefix

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -179,7 +179,8 @@ lower_predicate_to_clojure(PI, WamCode, _Options, ClojureCode) :-
     (   is_list(WamCode) -> Instrs = WamCode
     ;   parse_wam_text(WamCode, Instrs)
     ),
-    clause1_instrs(Instrs, C1Instrs),
+    clause1_instrs(Instrs, C1Instrs0),
+    lowered_direct_prefix(C1Instrs0, C1Instrs),
     with_output_to(string(Body), emit_instrs(C1Instrs, "  ")),
     format(string(ClojureCode),
 ';; ~w — lowered from ~w/~w
@@ -190,14 +191,88 @@ lower_predicate_to_clojure(PI, WamCode, _Options, ClojureCode) :-
 emit_instrs([], Indent) :-
     format("~wstate~n", [Indent]).
 emit_instrs(Instrs, Indent) :-
-    format("~w(-> state~n", [Indent]),
-    forall(member(Instr, Instrs), emit_one(Instr, Indent)),
-    format("~w    )~n", [Indent]).
+    length(Instrs, Len),
+    format("~w(let [s0 state~n", [Indent]),
+    emit_instr_bindings(Instrs, 0, Indent),
+    format("~w      ]~n", [Indent]),
+    format("~w  s~w)~n", [Indent, Len]).
 
-emit_one(Instr, Indent) :-
+emit_instr_bindings([], _, _).
+emit_instr_bindings([Instr|Rest], Index, Indent) :-
+    NextIndex is Index + 1,
+    format(atom(InState), 's~w', [Index]),
+    emit_lowered_expr(Instr, InState, Expr),
     instr_comment(Instr, Comment),
-    format("~w    ;; ~w~n", [Indent, Comment]),
-    format("~w    runtime/step~n", [Indent]).
+    format("~w      ;; ~w~n", [Indent, Comment]),
+    format("~w      s~w (if (= :running (:status ~w)) ~w ~w)~n",
+           [Indent, NextIndex, InState, Expr, InState]),
+    emit_instr_bindings(Rest, NextIndex, Indent).
+
+lowered_direct_prefix([], []).
+lowered_direct_prefix([Instr|Rest], [Instr|PrefixRest]) :-
+    lowered_direct_instr(Instr),
+    !,
+    lowered_direct_prefix(Rest, PrefixRest).
+lowered_direct_prefix(_, []).
+
+lowered_direct_instr(proceed).
+lowered_direct_instr(fail).
+lowered_direct_instr(get_constant(_, _)).
+lowered_direct_instr(get_integer(_, _)).
+lowered_direct_instr(get_nil(_)).
+lowered_direct_instr(put_constant(_, _)).
+lowered_direct_instr(put_nil(_)).
+lowered_direct_instr(get_variable(_, _)).
+lowered_direct_instr(put_variable(_, _)).
+lowered_direct_instr(get_value(_, _)).
+lowered_direct_instr(put_value(_, _)).
+
+emit_lowered_expr(proceed, S, Expr) :-
+    format(atom(Expr), '(runtime/succeed-state ~w)', [S]).
+emit_lowered_expr(fail, S, Expr) :-
+    format(atom(Expr), '(runtime/fail-state ~w)', [S]).
+emit_lowered_expr(get_constant(C, Ai), S, Expr) :-
+    clj_lowered_literal(C, Lit),
+    format(atom(Expr),
+           '(let [constant (runtime/normalize-literal-term (:intern-context ~w) ~w) current (or (runtime/reg-get-raw ~w ~q) ::lowered-unbound) current* (if (= current ::lowered-unbound) current (runtime/deref-value (:bindings ~w) current))] (cond (= current* ::lowered-unbound) (-> ~w (runtime/reg-set-raw ~q constant) runtime/advance) (runtime/logic-var? current*) (-> (runtime/bind-var ~w current* constant) runtime/advance) (runtime/interned-equal? current* constant) (runtime/advance ~w) :else (runtime/backtrack ~w)))',
+           [S, Lit, S, Ai, S, S, Ai, S, S, S]).
+emit_lowered_expr(get_integer(N, Ai), S, Expr) :-
+    format(atom(Expr),
+           '(let [constant ~w current (or (runtime/reg-get-raw ~w ~q) ::lowered-unbound) current* (if (= current ::lowered-unbound) current (runtime/deref-value (:bindings ~w) current))] (cond (= current* ::lowered-unbound) (-> ~w (runtime/reg-set-raw ~q constant) runtime/advance) (runtime/logic-var? current*) (-> (runtime/bind-var ~w current* constant) runtime/advance) (runtime/interned-equal? current* constant) (runtime/advance ~w) :else (runtime/backtrack ~w)))',
+           [N, S, Ai, S, S, Ai, S, S, S]).
+emit_lowered_expr(get_nil(Ai), S, Expr) :-
+    emit_lowered_expr(get_constant("[]", Ai), S, Expr).
+emit_lowered_expr(put_constant(C, Ai), S, Expr) :-
+    clj_lowered_literal(C, Lit),
+    format(atom(Expr),
+           '(let [constant (runtime/normalize-literal-term (:intern-context ~w) ~w)] (-> ~w (runtime/reg-set-raw ~q constant) runtime/advance))',
+           [S, Lit, S, Ai]).
+emit_lowered_expr(put_nil(Ai), S, Expr) :-
+    emit_lowered_expr(put_constant("[]", Ai), S, Expr).
+emit_lowered_expr(get_variable(Xn, Ai), S, Expr) :-
+    format(atom(Expr),
+           '(-> ~w (runtime/reg-set-raw ~q (runtime/reg-get-raw ~w ~q)) runtime/advance)',
+           [S, Xn, S, Ai]).
+emit_lowered_expr(put_variable(Xn, Ai), S, Expr) :-
+    format(atom(Expr),
+           '(let [[fresh next-state] (runtime/fresh-var ~w)] (-> next-state (runtime/reg-set-raw ~q fresh) (runtime/reg-set-raw ~q fresh) runtime/advance))',
+           [S, Xn, Ai]).
+emit_lowered_expr(get_value(Xn, Ai), S, Expr) :-
+    format(atom(Expr),
+           '(let [left (or (runtime/reg-get-raw ~w ~q) ::lowered-unbound) right (or (runtime/reg-get-raw ~w ~q) ::lowered-unbound) [ok next-state] (runtime/unify-values ~w left right)] (if ok (runtime/advance next-state) (runtime/backtrack ~w)))',
+           [S, Xn, S, Ai, S, S]).
+emit_lowered_expr(put_value(Xn, Ai), S, Expr) :-
+    format(atom(Expr),
+           '(let [val (runtime/deref-value (:bindings ~w) (runtime/reg-get-raw ~w ~q))] (-> ~w (runtime/reg-set-raw ~q val) runtime/advance))',
+           [S, S, Xn, S, Ai]).
+emit_lowered_expr(_Instr, S, Expr) :-
+    format(atom(Expr), '(runtime/step ~w)', [S]).
+
+clj_lowered_literal(Value, Literal) :-
+    (   number(Value)
+    ->  format(atom(Literal), '~w', [Value])
+    ;   format(atom(Literal), '~q', [Value])
+    ).
 
 instr_comment(proceed, "proceed").
 instr_comment(fail, "fail").

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -41,24 +41,41 @@ test(function_name_generation) :-
     assertion(Name == 'lowered-my-pred-3').
 
 test(lower_predicate_to_clojure_emits_function) :-
-    simple_fact_wam(WamCode),
-    lower_predicate_to_clojure(test_fact/1, WamCode, [], Code),
-    has(Code, "defn lowered-test-fact-1 [state]"),
-    has(Code, "get-constant a, A1"),
-    has(Code, "runtime/step").
+    once((
+        simple_fact_wam(WamCode),
+        lower_predicate_to_clojure(test_fact/1, WamCode, [], Code),
+        has(Code, "defn lowered-test-fact-1 [state]"),
+        has(Code, "get-constant a, A1"),
+        has(Code, "runtime/normalize-literal-term"),
+        has(Code, "runtime/reg-get-raw"),
+        has(Code, "runtime/interned-equal?")
+    )).
 
 test(lowered_multi_clause_keeps_clause1_shape) :-
-    multi_clause_wam(WamCode),
-    lower_predicate_to_clojure(test_choice/1, WamCode, [], Code),
-    has(Code, "defn lowered-test-choice-1 [state]"),
-    has(Code, "get-constant a, A1"),
-    \+ has(Code, "get-constant b, A1").
+    once((
+        multi_clause_wam(WamCode),
+        lower_predicate_to_clojure(test_choice/1, WamCode, [], Code),
+        has(Code, "defn lowered-test-choice-1 [state]"),
+        has(Code, "get-constant a, A1"),
+        \+ has(Code, "get-constant b, A1")
+    )).
 
 test(call_foreign_is_part_of_scaffold) :-
     WamCode = "test_foreign/2:\ncall_foreign category_parent/2, 2\nproceed\n",
     wam_clojure_lowerable(test_foreign/2, WamCode, deterministic),
     lower_predicate_to_clojure(test_foreign/2, WamCode, [], Code),
-    has(Code, "call-foreign category_parent/2"),
-    has(Code, "runtime/step").
+    has(Code, "defn lowered-test-foreign-2 [state]"),
+    has(Code, "state").
+
+test(simple_register_ops_are_direct_lowered) :-
+    once((
+        WamCode = "test_regs/2:\nget_variable X1, A1\nput_variable X2, A2\nget_value X1, A2\nput_value X1, A1\nproceed\n",
+        wam_clojure_lowerable(test_regs/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_regs/2, WamCode, [], Code),
+        has(Code, "runtime/fresh-var"),
+        has(Code, "runtime/unify-values"),
+        has(Code, "runtime/deref-value"),
+        has(Code, "runtime/reg-set-raw")
+    )).
 
 :- end_tests(wam_clojure_lowered_emitter).


### PR DESCRIPTION
# Summary

Add the first real direct lowered-instruction coverage for the Clojure hybrid WAM target.

The lowered emitter now directly emits a safe initial prefix of simple deterministic WAM instructions, then hands control back to the shared runtime at the first complex or control-flow instruction.

# What Changed

- replaced the old all-`runtime/step` lowered body with explicit state threading
- direct-lowered the initial prefix for simple instructions:
  - `get_constant`
  - `get_integer`
  - `get_nil`
  - `put_constant`
  - `put_nil`
  - `get_variable`
  - `put_variable`
  - `get_value`
  - `put_value`
  - `proceed`
  - `fail`
- kept complex/control-flow instructions runtime-mediated:
  - calls and execute
  - foreign calls
  - structures and lists
  - choice points
  - cuts
  - builtin calls
- added lowered-emitter tests for direct constant/register lowering

# Correctness Note

This PR deliberately lowers only the initial direct-safe prefix.

During implementation, lowering past a runtime-mediated `call` broke foreign stream backtracking. The emitter now stops direct lowering at the first unsupported instruction and lets `runtime/run-wam` continue from the shared instruction stream.

# Files

- `src/unifyweaver/targets/wam_clojure_lowered_emitter.pl`
- `tests/test_wam_clojure_lowered_emitter.pl`

# Verification

- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
- `git diff --check`

# Follow-ups

- add direct lowered support for selected structure/list instructions
- add targeted runtime smoke cases for direct lowered prefixes before calls
- evaluate whether `builtin-call =/2` can be direct-lowered safely without breaking backtracking
