### PR TITLE
feat(wam-clojure): lower build instructions

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -226,6 +226,9 @@ lowered_direct_instr(get_variable(_, _)).
 lowered_direct_instr(put_variable(_, _)).
 lowered_direct_instr(get_value(_, _)).
 lowered_direct_instr(put_value(_, _)).
+lowered_direct_instr(set_constant(_)).
+lowered_direct_instr(set_variable(_)).
+lowered_direct_instr(set_value(_)).
 
 emit_lowered_expr(proceed, S, Expr) :-
     format(atom(Expr), '(runtime/succeed-state ~w)', [S]).
@@ -265,6 +268,19 @@ emit_lowered_expr(put_value(Xn, Ai), S, Expr) :-
     format(atom(Expr),
            '(let [val (runtime/deref-value (:bindings ~w) (runtime/reg-get-raw ~w ~q))] (-> ~w (runtime/reg-set-raw ~q val) runtime/advance))',
            [S, S, Xn, S, Ai]).
+emit_lowered_expr(set_constant(C), S, Expr) :-
+    clj_lowered_literal(C, Lit),
+    format(atom(Expr),
+           '(let [constant (runtime/normalize-literal-term (:intern-context ~w) ~w)] (-> ~w (runtime/append-build-arg constant) runtime/finalize-complete-builds runtime/advance))',
+           [S, Lit, S]).
+emit_lowered_expr(set_variable(Xn), S, Expr) :-
+    format(atom(Expr),
+           '(let [[fresh next-state] (runtime/fresh-var ~w)] (-> next-state (runtime/reg-set-raw ~q fresh) (runtime/append-build-arg fresh) runtime/finalize-complete-builds runtime/advance))',
+           [S, Xn]).
+emit_lowered_expr(set_value(Xn), S, Expr) :-
+    format(atom(Expr),
+           '(let [val (runtime/deref-value (:bindings ~w) (runtime/reg-get-raw ~w ~q))] (-> ~w (runtime/append-build-arg val) runtime/finalize-complete-builds runtime/advance))',
+           [S, S, Xn, S]).
 emit_lowered_expr(_Instr, S, Expr) :-
     format(atom(Expr), '(runtime/step ~w)', [S]).
 

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -78,4 +78,22 @@ test(simple_register_ops_are_direct_lowered) :-
         has(Code, "runtime/reg-set-raw")
     )).
 
+test(build_arg_ops_are_direct_lowered_after_delegated_put_structure) :-
+    once((
+        WamCode = "test_build/1:\nput_structure f/2, A1\nset_constant a\nset_variable X1\nset_value X1\nproceed\n",
+        wam_clojure_lowerable(test_build/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_build/1, WamCode, [], Code),
+        assertion(\+ has(Code, "runtime/append-build-arg")),
+        has(Code, "state")
+    )).
+
+test(build_arg_ops_are_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_build_prefix/0:\nset_constant a\nset_variable X1\nset_value X1\nproceed\n",
+        wam_clojure_lowerable(test_build_prefix/0, WamCode, deterministic),
+        lower_predicate_to_clojure(test_build_prefix/0, WamCode, [], Code),
+        has(Code, "runtime/append-build-arg"),
+        has(Code, "runtime/finalize-complete-builds")
+    )).
+
 :- end_tests(wam_clojure_lowered_emitter).


### PR DESCRIPTION
# Summary

Extend the Clojure WAM lowered emitter with direct lowering for build-argument instructions in the safe initial prefix.

This builds on the simple instruction prefix work by adding direct emitted forms for `set_constant`, `set_variable`, and `set_value`, while preserving the existing rule that direct lowering stops before complex or control-flow instructions.

# What Changed

- direct-lowered additional write-mode build instructions:
  - `set_constant`
  - `set_variable`
  - `set_value`
- kept direct lowering limited to the initial prefix
- continued to delegate complex instructions to the shared runtime path, including:
  - `put_structure`
  - `put_list`
  - calls and execute
  - foreign calls
  - choice points
  - cuts
  - builtin calls
- added lowered-emitter tests proving:
  - `set_*` instructions lower when they appear in the direct prefix
  - `set_*` instructions do not lower after a delegated `put_structure`

# Why

`set_*` instructions are local build-stack operations. They do not introduce new control flow, and they already have straightforward runtime behavior.

Lowering them directly improves the Clojure lowered tier incrementally without reopening the backtracking and foreign-stream issues that occur if lowering continues past calls or other delegated instructions.

# Files

- `src/unifyweaver/targets/wam_clojure_lowered_emitter.pl`
- `tests/test_wam_clojure_lowered_emitter.pl`

# Verification

- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
- `git diff --check`

# Follow-ups

- evaluate direct lowering for selected `put_structure` / `put_list` setup once build-stack behavior is better isolated
- consider direct lowering for `builtin-call =/2` only after adding targeted backtracking tests
