### PR TITLE
feat(wam-clojure): lower structure build prefix

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -226,6 +226,8 @@ lowered_direct_instr(get_variable(_, _)).
 lowered_direct_instr(put_variable(_, _)).
 lowered_direct_instr(get_value(_, _)).
 lowered_direct_instr(put_value(_, _)).
+lowered_direct_instr(put_structure(_, _)).
+lowered_direct_instr(put_list(_)).
 lowered_direct_instr(set_constant(_)).
 lowered_direct_instr(set_variable(_)).
 lowered_direct_instr(set_value(_)).
@@ -268,6 +270,15 @@ emit_lowered_expr(put_value(Xn, Ai), S, Expr) :-
     format(atom(Expr),
            '(let [val (runtime/deref-value (:bindings ~w) (runtime/reg-get-raw ~w ~q))] (-> ~w (runtime/reg-set-raw ~q val) runtime/advance))',
            [S, S, Xn, S, Ai]).
+emit_lowered_expr(put_structure(F, Ai), S, Expr) :-
+    clj_lowered_literal(F, Lit),
+    format(atom(Expr),
+           '(let [functor (runtime/normalize-literal-term (:intern-context ~w) ~w) arity (runtime/functor-arity (:intern-context ~w) functor)] (-> ~w (runtime/push-build-frame ~q functor arity) runtime/advance))',
+           [S, Lit, S, S, Ai]).
+emit_lowered_expr(put_list(Ai), S, Expr) :-
+    format(atom(Expr),
+           '(-> ~w (runtime/push-build-frame ~q (runtime/list-functor-term (:intern-context ~w)) 2) runtime/advance)',
+           [S, Ai, S]).
 emit_lowered_expr(set_constant(C), S, Expr) :-
     clj_lowered_literal(C, Lit),
     format(atom(Expr),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -78,13 +78,26 @@ test(simple_register_ops_are_direct_lowered) :-
         has(Code, "runtime/reg-set-raw")
     )).
 
-test(build_arg_ops_are_direct_lowered_after_delegated_put_structure) :-
+test(structure_build_ops_are_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_build/1:\nput_structure f/2, A1\nset_constant a\nset_variable X1\nset_value X1\nproceed\n",
         wam_clojure_lowerable(test_build/1, WamCode, deterministic),
         lower_predicate_to_clojure(test_build/1, WamCode, [], Code),
-        assertion(\+ has(Code, "runtime/append-build-arg")),
-        has(Code, "state")
+        has(Code, "runtime/push-build-frame"),
+        has(Code, "runtime/functor-arity"),
+        has(Code, "runtime/append-build-arg"),
+        has(Code, "runtime/finalize-complete-builds")
+    )).
+
+test(list_build_ops_are_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_list_build/1:\nput_list A1\nset_constant head\nset_constant []\nproceed\n",
+        wam_clojure_lowerable(test_list_build/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_list_build/1, WamCode, [], Code),
+        has(Code, "runtime/push-build-frame"),
+        has(Code, "runtime/list-functor-term"),
+        has(Code, "runtime/append-build-arg"),
+        has(Code, "runtime/finalize-complete-builds")
     )).
 
 test(build_arg_ops_are_direct_lowered_in_prefix) :-


### PR DESCRIPTION
## Summary

Adds direct-prefix lowering for Clojure WAM structure/list build setup:

- lowers `put_structure/2` in the safe initial lowered prefix
- lowers `put_list/1` in the safe initial lowered prefix
- reuses the existing runtime build-frame helpers: `push-build-frame`, `functor-arity`, `list-functor-term`, `append-build-arg`, and `finalize-complete-builds`
- extends lowered-emitter tests for structure and list construction paths

## Why

The previous Clojure lowered-emitter slice could directly lower `set_*` build-argument instructions, but structure and list construction still stopped at `put_structure` or `put_list`. That meant real write-mode construction paths often fell back before the lowered `set_*` logic could help.

This PR completes the next conservative step by lowering the build-frame setup instructions while preserving the existing prefix-only safety boundary.

## Safety Boundary

This remains intentionally narrow:

- only the initial direct prefix is lowered
- calls, choice points, foreign calls, cuts, and other backtracking-sensitive instructions remain runtime-mediated
- `get_structure` and `get_list` remain outside this PR because they require read/unify-mode handling

## Validation

Passed locally:

```sh
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
git diff --check
```

