### PR TITLE
feat(wam-clojure): lower structure read prefix

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -218,6 +218,8 @@ lowered_direct_prefix(_, []).
 lowered_direct_instr(proceed).
 lowered_direct_instr(fail).
 lowered_direct_instr(get_constant(_, _)).
+lowered_direct_instr(get_structure(_, _)).
+lowered_direct_instr(get_list(_)).
 lowered_direct_instr(get_integer(_, _)).
 lowered_direct_instr(get_nil(_)).
 lowered_direct_instr(put_constant(_, _)).
@@ -247,6 +249,15 @@ emit_lowered_expr(get_integer(N, Ai), S, Expr) :-
            [N, S, Ai, S, S, Ai, S, S, S]).
 emit_lowered_expr(get_nil(Ai), S, Expr) :-
     emit_lowered_expr(get_constant("[]", Ai), S, Expr).
+emit_lowered_expr(get_structure(F, Ai), S, Expr) :-
+    clj_lowered_literal(F, Lit),
+    format(atom(Expr),
+           '(let [functor (runtime/normalize-literal-term (:intern-context ~w) ~w) reg-val (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w ~q) ::lowered-unbound))] (cond (and (runtime/structure-term? reg-val) (runtime/interned-equal? (:functor reg-val) functor)) (-> ~w (runtime/enter-unify-mode (:args reg-val)) runtime/advance) :else (runtime/backtrack ~w)))',
+           [S, Lit, S, S, Ai, S, S]).
+emit_lowered_expr(get_list(Ai), S, Expr) :-
+    format(atom(Expr),
+           '(let [reg-val (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w ~q) ::lowered-unbound)) list-functor (runtime/list-functor-term (:intern-context ~w))] (cond (and (runtime/structure-term? reg-val) (runtime/interned-equal? (:functor reg-val) list-functor)) (-> ~w (runtime/enter-unify-mode (:args reg-val)) runtime/advance) :else (runtime/backtrack ~w)))',
+           [S, S, Ai, S, S, S]).
 emit_lowered_expr(put_constant(C, Ai), S, Expr) :-
     clj_lowered_literal(C, Lit),
     format(atom(Expr),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -78,6 +78,28 @@ test(simple_register_ops_are_direct_lowered) :-
         has(Code, "runtime/reg-set-raw")
     )).
 
+test(structure_read_entry_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_read_struct/1:\nget_structure f/2, A1\nunify_constant a\nunify_variable X1\nproceed\n",
+        wam_clojure_lowerable(test_read_struct/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_read_struct/1, WamCode, [], Code),
+        has(Code, "runtime/enter-unify-mode"),
+        has(Code, "runtime/structure-term?"),
+        has(Code, "runtime/interned-equal?"),
+        assertion(\+ has(Code, "unify-constant a"))
+    )).
+
+test(list_read_entry_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_read_list/1:\nget_list A1\nunify_constant head\nunify_constant []\nproceed\n",
+        wam_clojure_lowerable(test_read_list/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_read_list/1, WamCode, [], Code),
+        has(Code, "runtime/enter-unify-mode"),
+        has(Code, "runtime/list-functor-term"),
+        has(Code, "runtime/structure-term?"),
+        assertion(\+ has(Code, "unify-constant head"))
+    )).
+
 test(structure_build_ops_are_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_build/1:\nput_structure f/2, A1\nset_constant a\nset_variable X1\nset_value X1\nproceed\n",


### PR DESCRIPTION
## Summary

Adds conservative direct-prefix lowering for Clojure WAM read-mode structure/list entry:

- lowers `get_structure/2` in the initial lowered prefix
- lowers `get_list/1` in the initial lowered prefix
- enters runtime unify mode with `runtime/enter-unify-mode`
- keeps `unify_*` instructions runtime-mediated for now
- adds focused lowered-emitter tests for structure and list read entry

## Why

The Clojure lowered emitter can now lower write-mode structure/list construction setup and build arguments. The next matching gap was read-mode structure/list entry: predicates beginning with `get_structure` or `get_list` still stopped before any useful lowered work.

This PR lowers only the safe entry step and deliberately leaves the actual `unify_*` queue processing to the existing runtime. That gives better lowered coverage without taking on direct unify-mode lowering in the same change.

## Safety Boundary

This remains intentionally narrow:

- only the initial direct prefix is lowered
- `get_structure/2` succeeds only for already-bound matching structure terms
- `get_list/1` succeeds only for already-bound cons/list structure terms
- `unify_constant`, `unify_variable`, and `unify_value` are not directly lowered in this PR
- calls, choice points, foreign calls, cuts, and other backtracking-sensitive instructions remain runtime-mediated

## Validation

Passed locally:

```sh
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
git diff --check
```

