### PR TITLE
feat(benchmark): add WAM kernel pair report

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -284,6 +284,17 @@ modes as result-producing `hybrid-wam` targets:
 
 These targets provide both seeded/accumulated and kernel-on/off comparisons.
 
+The matrix CLI can print the currently registered kernel/no-kernel pairings
+without running benchmarks:
+
+```bash
+python3 examples/benchmark/benchmark_effective_distance_matrix.py --list-kernel-pairs
+```
+
+The report is TSV with `family`, `mode`, `kernels_target`, and
+`no_kernels_target` columns. It currently covers registered Rust, Go, Clojure,
+and Haskell effective-distance WAM pairings.
+
 Artifact-vs-sidecar Clojure comparisons are available through the
 `clojure-wam-artifact` target set, which adds:
 

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -51,6 +51,7 @@ from benchmark_common import (
 from benchmark_target_matrix import (
     TARGETS,
     default_target_set_name,
+    list_kernel_pairs_text,
     list_targets_text,
     parse_csv,
     resolve_targets,
@@ -106,6 +107,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--keep-temp", action="store_true")
     parser.add_argument("--list-targets", action="store_true")
+    parser.add_argument(
+        "--list-kernel-pairs",
+        action="store_true",
+        help="Print registered kernel/no-kernel WAM target pairings and exit.",
+    )
     parser.add_argument(
         "--allow-large-termux-scales",
         action="store_true",
@@ -671,6 +677,9 @@ def main() -> int:
     args = parse_args()
     if args.list_targets:
         print(list_targets_text())
+        return 0
+    if args.list_kernel_pairs:
+        print(list_kernel_pairs_text())
         return 0
 
     scales = [part.strip() for part in args.scales.split(",") if part.strip()]

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -13,6 +13,14 @@ class TargetInfo:
     description: str
 
 
+@dataclass(frozen=True)
+class KernelPairInfo:
+    family: str
+    mode: str
+    kernels_target: str
+    no_kernels_target: str
+
+
 TARGETS: dict[str, TargetInfo] = {
     "csharp-query": TargetInfo(
         "csharp-query",
@@ -137,6 +145,52 @@ TARGETS: dict[str, TargetInfo] = {
 }
 
 
+KERNEL_TARGET_PAIRS: tuple[KernelPairInfo, ...] = (
+    KernelPairInfo(
+        "rust",
+        "seeded",
+        "wam-rust-seeded",
+        "wam-rust-seeded-no-kernels",
+    ),
+    KernelPairInfo(
+        "rust",
+        "accumulated",
+        "wam-rust-accumulated",
+        "wam-rust-accumulated-no-kernels",
+    ),
+    KernelPairInfo(
+        "go",
+        "accumulated",
+        "go-wam-accumulated",
+        "go-wam-accumulated-no-kernels",
+    ),
+    KernelPairInfo(
+        "clojure",
+        "seeded",
+        "clojure-wam-seeded",
+        "clojure-wam-seeded-no-kernels",
+    ),
+    KernelPairInfo(
+        "clojure",
+        "accumulated",
+        "clojure-wam-accumulated",
+        "clojure-wam-accumulated-no-kernels",
+    ),
+    KernelPairInfo(
+        "haskell",
+        "interpreter",
+        "haskell-interp-ffi",
+        "haskell-pure-interp",
+    ),
+    KernelPairInfo(
+        "haskell",
+        "lowered",
+        "haskell-lowered-ffi",
+        "haskell-lowered-only",
+    ),
+)
+
+
 TARGET_SETS: dict[str, list[str]] = {
     "termux-smoke": [
         "prolog-accumulated",
@@ -230,6 +284,15 @@ def list_targets_text() -> str:
     lines.append("target_set\ttargets")
     for set_name in sorted(TARGET_SETS):
         lines.append(f"{set_name}\t{','.join(TARGET_SETS[set_name])}")
+    return "\n".join(lines)
+
+
+def list_kernel_pairs_text() -> str:
+    lines = ["family\tmode\tkernels_target\tno_kernels_target"]
+    for pair in KERNEL_TARGET_PAIRS:
+        lines.append(
+            f"{pair.family}\t{pair.mode}\t{pair.kernels_target}\t{pair.no_kernels_target}"
+        )
     return "\n".join(lines)
 
 

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -10,7 +10,13 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
 
 from benchmark_effective_distance_matrix import parse_args, resolve_requested_targets  # noqa: E402
-from benchmark_target_matrix import TARGETS, list_targets_text, resolve_targets  # noqa: E402
+from benchmark_target_matrix import (  # noqa: E402
+    KERNEL_TARGET_PAIRS,
+    TARGETS,
+    list_kernel_pairs_text,
+    list_targets_text,
+    resolve_targets,
+)
 
 
 class BenchmarkTargetMatrixTests(unittest.TestCase):
@@ -71,6 +77,49 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
             ]
             args = parse_args()
             self.assertEqual(resolve_requested_targets(args), ["clojure-wam-seeded", "prolog-accumulated"])
+        finally:
+            sys.argv = original_argv
+
+    def test_kernel_pair_registry_covers_registered_wam_pairs(self) -> None:
+        pairs = {(pair.family, pair.mode): pair for pair in KERNEL_TARGET_PAIRS}
+
+        expected = {
+            ("rust", "seeded"),
+            ("rust", "accumulated"),
+            ("go", "accumulated"),
+            ("clojure", "seeded"),
+            ("clojure", "accumulated"),
+            ("haskell", "interpreter"),
+            ("haskell", "lowered"),
+        }
+        self.assertEqual(set(pairs), expected)
+
+        for pair in KERNEL_TARGET_PAIRS:
+            self.assertIn(pair.kernels_target, TARGETS)
+            self.assertIn(pair.no_kernels_target, TARGETS)
+
+    def test_list_kernel_pairs_text_is_tsv(self) -> None:
+        text = list_kernel_pairs_text()
+
+        self.assertTrue(text.startswith("family\tmode\tkernels_target\tno_kernels_target\n"))
+        self.assertIn(
+            "rust\taccumulated\twam-rust-accumulated\twam-rust-accumulated-no-kernels",
+            text,
+        )
+        self.assertIn(
+            "haskell\tlowered\thaskell-lowered-ffi\thaskell-lowered-only",
+            text,
+        )
+
+    def test_effective_distance_runner_accepts_kernel_pair_listing(self) -> None:
+        original_argv = sys.argv
+        try:
+            sys.argv = [
+                "benchmark_effective_distance_matrix.py",
+                "--list-kernel-pairs",
+            ]
+            args = parse_args()
+            self.assertTrue(args.list_kernel_pairs)
         finally:
             sys.argv = original_argv
 


### PR DESCRIPTION
  ## Summary
  Add a compact WAM matrix report that lists registered kernel/no-kernel target pairs without running benchmarks.

  ## What changed
  - Added a shared kernel-pair registry for the benchmark target matrix.
  - Added `--list-kernel-pairs` to `benchmark_effective_distance_matrix.py`.
  - Covered the new registry and CLI flag with unit tests.
  - Documented the new report in the benchmark README.

  - `python3 -m py_compile examples/benchmark/benchmark_target_matrix.py examples/benchmark/
  benchmark_effective_distance_matrix.py`
  - `python3 -m unittest tests/test_benchmark_target_matrix.py`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --list-kernel-pairs`
  ## Notes
  - The report currently covers registered Rust, Go, Clojure, and Haskell pairings.
  - Untracked local benchmark artifacts are left out of the commit.