### PR TITLE
bench(wam-rust): add effective-distance matrix FFI targets

### DIFF
--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -124,6 +124,10 @@ def scale_sort_key(scale: str) -> tuple[int, str]:
 
 def available_targets(requested: list[str]) -> list[str]:
     targets: list[str] = []
+    rust_matrix_targets = {
+        "rust-interp-ffi",
+        "rust-lowered-ffi",
+    }
     for target in requested:
         if target.startswith("csharp-") and shutil.which("dotnet") is None:
             print(f"skip {target}: dotnet not found", file=sys.stderr)
@@ -135,6 +139,11 @@ def available_targets(requested: list[str]) -> list[str]:
             continue
         if target.startswith("haskell-") and (shutil.which("cabal") is None or shutil.which("ghc") is None):
             print(f"skip {target}: cabal or ghc not found", file=sys.stderr)
+            continue
+        if target in rust_matrix_targets and (
+            shutil.which("swipl") is None or shutil.which("cargo") is None or shutil.which("rustc") is None
+        ):
+            print(f"skip {target}: swipl, cargo, or rustc not found", file=sys.stderr)
             continue
         if target.startswith("rust-") and shutil.which("rustc") is None:
             print(f"skip {target}: rustc not found", file=sys.stderr)

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -62,11 +62,13 @@ BENCH_DIR = ROOT / "data" / "benchmark"
 GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
 PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_effective_distance_benchmark.pl"
 WAM_RUST_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_effective_distance_benchmark.pl"
+WAM_RUST_MATRIX_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_rust_matrix_benchmark.pl"
 WAM_HASKELL_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_haskell_matrix_benchmark.pl"
 WAM_GO_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_go_effective_distance_benchmark.pl"
 WAM_CLOJURE_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_clojure_optimized_benchmark.pl"
 DEFAULT_FACTS = BENCH_DIR / "10k" / "facts.pl"
 HASKELL_EXE = "wam-haskell-matrix-bench"
+RUST_MATRIX_EXE = "wam_rust_matrix_bench"
 
 
 def default_scales_csv() -> str:
@@ -569,6 +571,28 @@ def build_haskell_effective_distance(root: Path, mode: str, kernel_mode: str) ->
     return build_haskell_project(project_dir, HASKELL_EXE)
 
 
+def build_rust_matrix_effective_distance(root: Path, mode: str, kernel_mode: str) -> list[str]:
+    project_dir = root / f"rust_{mode}_{kernel_mode}"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(WAM_RUST_MATRIX_GENERATOR),
+            "--",
+            str(DEFAULT_FACTS),
+            str(project_dir),
+            "accumulated",
+            mode,
+            kernel_mode,
+        ],
+        cwd=ROOT,
+    )
+    run_command(["cargo", "build", "--release"], cwd=project_dir)
+    return [str(project_dir / "target" / "release" / RUST_MATRIX_EXE)]
+
+
 def build_scale_independent_commands(root: Path, targets: list[str]) -> dict[str, list[str]]:
     commands: dict[str, list[str]] = {}
     for target in targets:
@@ -588,6 +612,10 @@ def build_scale_independent_commands(root: Path, targets: list[str]) -> dict[str
             commands[target] = build_haskell_effective_distance(root, "functions", "kernels_off")
         elif target == "haskell-lowered-ffi":
             commands[target] = build_haskell_effective_distance(root, "functions", "kernels_on")
+        elif target == "rust-interp-ffi":
+            commands[target] = build_rust_matrix_effective_distance(root, "interpreter", "kernels_on")
+        elif target == "rust-lowered-ffi":
+            commands[target] = build_rust_matrix_effective_distance(root, "functions", "kernels_on")
     return commands
 
 

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -134,6 +134,16 @@ TARGETS: dict[str, TargetInfo] = {
         "optimized-prolog",
         "Optimized Prolog -> lowered Haskell functions with kernels enabled",
     ),
+    "rust-interp-ffi": TargetInfo(
+        "rust-interp-ffi",
+        "hybrid-wam",
+        "Optimized Prolog -> WAM Rust interpreter with kernels enabled",
+    ),
+    "rust-lowered-ffi": TargetInfo(
+        "rust-lowered-ffi",
+        "optimized-prolog",
+        "Optimized Prolog -> lowered Rust functions with kernels enabled",
+    ),
 }
 
 
@@ -148,6 +158,7 @@ TARGET_SETS: dict[str, list[str]] = {
         "prolog-accumulated",
         "haskell-lowered-only",
         "haskell-lowered-ffi",
+        "rust-lowered-ffi",
     ],
     "hybrid-wam": [
         "wam-rust-seeded",
@@ -164,6 +175,8 @@ TARGET_SETS: dict[str, list[str]] = {
         "haskell-interp-ffi",
         "haskell-lowered-only",
         "haskell-lowered-ffi",
+        "rust-interp-ffi",
+        "rust-lowered-ffi",
     ],
     "clojure-wam-scaffold": [],
     "clojure-wam": [

--- a/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
+++ b/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
@@ -1,0 +1,620 @@
+:- initialization(main, main).
+
+:- use_module('../../src/unifyweaver/targets/wam_rust_target').
+:- use_module('../../src/unifyweaver/targets/prolog_target').
+
+%% generate_wam_rust_matrix_benchmark.pl
+%%
+%% Generates a result-producing effective-distance Rust benchmark through the
+%% generic WAM-Rust target. This mirrors the Haskell matrix modes:
+%%
+%%   interpreter + kernels_off => pure WAM interpreter
+%%   interpreter + kernels_on  => WAM interpreter with FFI kernels
+%%   functions   + kernels_off => lowered Rust helpers with WAM fallback
+%%   functions   + kernels_on  => lowered Rust helpers with FFI kernels
+
+benchmark_workload_path(Path) :-
+    source_file(benchmark_workload_path(_), ThisFile),
+    file_directory_name(ThisFile, Here),
+    directory_file_path(Here, 'effective_distance.pl', Path).
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv = [_FactsPath, OutputDir, VariantAtom, EmitModeAtom, KernelModeAtom]
+    ->  true
+    ;   format(user_error,
+            'Usage: ... -- <facts.pl> <output-dir> <seeded|accumulated> <interpreter|functions> <kernels_on|kernels_off>~n',
+            []),
+        halt(1)
+    ),
+    generate(VariantAtom, EmitModeAtom, KernelModeAtom, OutputDir),
+    halt(0).
+
+main :-
+    format(user_error, 'Error: generation failed~n', []),
+    halt(1).
+
+generate(VariantAtom, EmitModeAtom, KernelModeAtom, OutputDir) :-
+    benchmark_workload_path(WorkloadPath),
+    load_files(WorkloadPath, [silent(true)]),
+    retractall(user:mode(category_ancestor(_, _, _, _))),
+    assertz(user:mode(category_ancestor(-, +, -, +))),
+    parse_variant(VariantAtom, OptimizationOptions),
+    parse_emit_mode(EmitModeAtom, EmitMode),
+    parse_kernel_mode(KernelModeAtom, KernelOptions),
+    BasePreds = [dimension_n/1, max_depth/1, category_ancestor/4],
+    prolog_target:generate_prolog_script(BasePreds, OptimizationOptions, ScriptCode),
+    tmp_file_stream(text, TmpPath, TmpStream),
+    write(TmpStream, ScriptCode),
+    close(TmpStream),
+    load_files(TmpPath, [silent(true)]),
+    delete_file(TmpPath),
+    collect_wam_predicates(VariantAtom, Predicates),
+    append([[module_name(wam_rust_matrix_bench), wam_fallback(true), emit_mode(EmitMode), parallel(true)],
+            KernelOptions], Options),
+    write_wam_rust_project(Predicates, Options, OutputDir),
+    write_matrix_main(OutputDir, EmitModeAtom, KernelModeAtom),
+    format(user_error,
+           '[WAM-Rust-Matrix] variant=~w emit_mode=~w kernels=~w output=~w~n',
+           [VariantAtom, EmitMode, KernelModeAtom, OutputDir]).
+
+parse_variant(seeded, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false)
+]).
+parse_variant(accumulated, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false),
+    seeded_accumulation(auto)
+]).
+
+parse_emit_mode(interpreter, interpreter).
+parse_emit_mode(functions, functions).
+
+parse_kernel_mode(kernels_on, []).
+parse_kernel_mode(kernels_off, [no_kernels(true)]).
+
+collect_wam_predicates(seeded, [
+    user:dimension_n/1,
+    user:max_depth/1,
+    user:category_ancestor/4,
+    user:power_sum_bound/4
+]).
+collect_wam_predicates(accumulated, [
+    user:dimension_n/1,
+    user:max_depth/1,
+    user:category_ancestor/4,
+    user:'category_ancestor$power_sum_bound'/3,
+    user:'category_ancestor$power_sum_selected'/3,
+    user:'category_ancestor$power_sum_grouped'/3,
+    user:'category_ancestor$power_sum_grouped$grouped'/2,
+    user:'category_ancestor$power_sum_grouped$grouped$sum_pairs'/2,
+    user:'category_ancestor$effective_distance_sum_selected'/3,
+    user:'category_ancestor$effective_distance_sum_bound'/3
+]).
+
+write_matrix_main(OutputDir, EmitModeAtom, KernelModeAtom) :-
+    directory_file_path(OutputDir, 'src', SrcDir),
+    directory_file_path(SrcDir, 'main.rs', MainPath),
+    format(string(ModeMetric), 'wam_rust_matrix_~w_~w', [EmitModeAtom, KernelModeAtom]),
+    rust_main_template(Template),
+    format(string(Code), Template, [ModeMetric]),
+    setup_call_cleanup(
+        open(MainPath, write, Stream, [encoding(utf8)]),
+        format(Stream, '~w', [Code]),
+        close(Stream)
+    ).
+
+rust_main_template('use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::time::Instant;
+
+use wam_rust_matrix_bench::foreign_pred_keys;
+use wam_rust_matrix_bench::setup_foreign_predicates;
+use wam_rust_matrix_bench::shared_wam_program;
+use wam_rust_matrix_bench::instructions::Instruction;
+use wam_rust_matrix_bench::state::WamState;
+use wam_rust_matrix_bench::value::Value;
+
+fn load_tsv_pairs(path: &Path) -> Vec<(String, String)> {
+    let file = File::open(path).unwrap_or_else(|e| panic!("cannot open {}: {}", path.display(), e));
+    let reader = BufReader::new(file);
+    let mut pairs = Vec::new();
+    for line in reader.lines().skip(1) {
+        let line = line.unwrap();
+        let line = line.trim();
+        if line.is_empty() || line.starts_with(''#'') {
+            continue;
+        }
+        let parts: Vec<&str> = line.split(''\\t'').collect();
+        if parts.len() >= 2 {
+            pairs.push((parts[0].to_string(), parts[1].to_string()));
+        }
+    }
+    pairs
+}
+
+fn load_single_column(path: &Path) -> Vec<String> {
+    let file = File::open(path).unwrap_or_else(|e| panic!("cannot open {}: {}", path.display(), e));
+    let reader = BufReader::new(file);
+    reader
+        .lines()
+        .skip(1)
+        .filter_map(Result::ok)
+        .map(|line| line.trim().to_string())
+        .filter(|line| !line.is_empty() && !line.starts_with(''#''))
+        .collect()
+}
+
+fn build_indexed_fact2(pairs: &[(String, String)]) -> HashMap<String, Vec<String>> {
+    let mut grouped: HashMap<String, Vec<String>> = HashMap::new();
+    for (a, b) in pairs {
+        grouped.entry(a.clone()).or_default().push(b.clone());
+    }
+    grouped
+}
+
+fn append_fact2(code: &mut Vec<Instruction>, labels: &mut HashMap<String, usize>, pred_name: &str, pairs: &[(String, String)]) {
+    use std::collections::BTreeMap;
+    if pairs.is_empty() {
+        return;
+    }
+    let mut groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (a, b) in pairs {
+        groups.entry(a.clone()).or_default().push(b.clone());
+    }
+    labels.insert(format!("{}/2", pred_name), code.len() + 1);
+    let switch_idx = code.len();
+    code.push(Instruction::Proceed);
+    let mut dispatch = Vec::new();
+    for (key, values) in groups {
+        let group_label = format!("{}_g_{}", pred_name, key);
+        dispatch.push((Value::Atom(key.clone()), group_label.clone()));
+        labels.insert(group_label, code.len() + 1);
+        for (i, b) in values.iter().enumerate() {
+            labels.insert(format!("{}_g_{}_{}", pred_name, key, i), code.len() + 1);
+            if values.len() > 1 {
+                if i == 0 {
+                    code.push(Instruction::TryMeElse(format!("{}_g_{}_{}", pred_name, key, i + 1)));
+                } else if i == values.len() - 1 {
+                    code.push(Instruction::TrustMe);
+                } else {
+                    code.push(Instruction::RetryMeElse(format!("{}_g_{}_{}", pred_name, key, i + 1)));
+                }
+            }
+            code.push(Instruction::GetConstant(Value::Atom(key.clone()), "A1".to_string()));
+            code.push(Instruction::GetConstant(Value::Atom(b.clone()), "A2".to_string()));
+            code.push(Instruction::Proceed);
+        }
+    }
+    code[switch_idx] = Instruction::SwitchOnConstant(dispatch);
+}
+
+fn optimize_benchmark_code(code: &mut Vec<Instruction>) {
+    let mut i = 0usize;
+    while i < code.len() {
+        if i + 5 < code.len() {
+            let replacement = match (&code[i], &code[i + 1], &code[i + 2], &code[i + 3], &code[i + 4], &code[i + 5]) {
+                (
+                    Instruction::PutValue(list_reg, a1),
+                    Instruction::PutVariable(tmp_reg, a2),
+                    Instruction::BuiltinCall(op_len, 2),
+                    Instruction::PutValue(tmp_reg2, a1b),
+                    Instruction::PutValue(limit_reg, a2b),
+                    Instruction::BuiltinCall(op_lt, 2),
+                ) if a1 == "A1"
+                    && a2 == "A2"
+                    && op_len == "length/2"
+                    && tmp_reg == tmp_reg2
+                    && a1b == "A1"
+                    && a2b == "A2"
+                    && op_lt == "</2" =>
+                    Some(Instruction::ListLengthLt(list_reg.clone(), limit_reg.clone(), 6)),
+                _ => None,
+            };
+            if let Some(instr) = replacement {
+                code[i] = instr;
+                i += 6;
+                continue;
+            }
+        }
+        if i + 1 < code.len() {
+            let replacement = match (&code[i], &code[i + 1]) {
+                (Instruction::PutVariable(limit_reg, a1), Instruction::Call(pred, 1))
+                    if a1 == "A1" && pred == "max_depth/1" =>
+                    Some(Instruction::LoadRegisterConstant(Value::Integer(10), limit_reg.clone(), 2)),
+                _ => None,
+            };
+            if let Some(instr) = replacement {
+                code[i] = instr;
+                i += 2;
+                continue;
+            }
+        }
+        if i + 8 < code.len() {
+            let replacement = match (&code[i], &code[i + 1], &code[i + 2], &code[i + 3], &code[i + 4], &code[i + 5], &code[i + 6], &code[i + 7], &code[i + 8]) {
+                (
+                    Instruction::PutValue(cat_reg, a1),
+                    Instruction::PutValue(target_reg, a2),
+                    Instruction::Call(pred, 2),
+                    Instruction::PutStructure(functor, a1b),
+                    Instruction::SetValue(target_reg2),
+                    Instruction::SetValue(visited_reg),
+                    Instruction::Deallocate,
+                    Instruction::BuiltinCall(op, 1),
+                    Instruction::Proceed,
+                ) if a1 == "A1"
+                    && a2 == "A2"
+                    && pred == "category_parent/2"
+                    && functor == "member/2"
+                    && a1b == "A1"
+                    && target_reg == target_reg2
+                    && op == r"\\+/1" =>
+                    Some(Instruction::BaseCategoryAncestor(cat_reg.clone(), target_reg.clone(), visited_reg.clone())),
+                _ => None,
+            };
+            if let Some(instr) = replacement {
+                code[i] = instr;
+                i += 9;
+                continue;
+            }
+        }
+        if i + 8 < code.len() {
+            let replacement = match (&code[i], &code[i + 1], &code[i + 2], &code[i + 3], &code[i + 4], &code[i + 5], &code[i + 6], &code[i + 7], &code[i + 8]) {
+                (
+                    Instruction::PutValue(cat_reg, a1),
+                    Instruction::PutValue(target_reg, a2),
+                    Instruction::Call(pred, 2),
+                    Instruction::Deallocate,
+                    Instruction::PutStructure(functor, a1b),
+                    Instruction::SetValue(target_reg2),
+                    Instruction::SetValue(visited_reg),
+                    Instruction::BuiltinCall(op, 1),
+                    Instruction::Proceed,
+                ) if a1 == "A1"
+                    && a2 == "A2"
+                    && pred == "category_parent/2"
+                    && functor == "member/2"
+                    && a1b == "A1"
+                    && target_reg == target_reg2
+                    && op == r"\\+/1" =>
+                    Some(Instruction::BaseCategoryAncestor(
+                        cat_reg.clone(),
+                        target_reg.clone(),
+                        visited_reg.clone(),
+                    )),
+                _ => None,
+            };
+            if let Some(instr) = replacement {
+                code[i] = instr;
+                i += 9;
+                continue;
+            }
+        }
+        if i + 3 < code.len() {
+            let replacement = match (&code[i], &code[i + 1], &code[i + 2], &code[i + 3]) {
+                (
+                    Instruction::PutStructure(functor, a1),
+                    Instruction::SetValue(elem_reg),
+                    Instruction::SetValue(list_reg),
+                    Instruction::BuiltinCall(op, 1),
+                ) if functor == "member/2" && a1 == "A1" && op == r"\\+/1" =>
+                    Some(Instruction::NotMember(elem_reg.clone(), list_reg.clone(), 4)),
+                _ => None,
+            };
+            if let Some(instr) = replacement {
+                code[i] = instr;
+                i += 4;
+                continue;
+            }
+        }
+        if i + 6 < code.len() {
+            let replacement = match (&code[i], &code[i + 1], &code[i + 2], &code[i + 3], &code[i + 4], &code[i + 5], &code[i + 6]) {
+                (
+                    Instruction::PutValue(mid_reg, a1),
+                    Instruction::PutValue(root_reg, a2),
+                    Instruction::PutVariable(child_hops_reg, a3),
+                    Instruction::PutList(a4),
+                    Instruction::SetValue(mid_reg2),
+                    Instruction::SetValue(visited_reg),
+                    Instruction::Call(pred, 4),
+                ) if a1 == "A1"
+                    && a2 == "A2"
+                    && a3 == "A3"
+                    && a4 == "A4"
+                    && mid_reg == mid_reg2
+                    && pred == "category_ancestor/4" =>
+                    Some(Instruction::RecurseCategoryAncestor(
+                        mid_reg.clone(),
+                        root_reg.clone(),
+                        child_hops_reg.clone(),
+                        visited_reg.clone(),
+                        pred.clone(),
+                        7,
+                    )),
+                _ => None,
+            };
+            if let Some(instr) = replacement {
+                code[i] = instr;
+                i += 7;
+                continue;
+            }
+        }
+        if i + 6 < code.len() {
+            let replacement = match (&code[i], &code[i + 1], &code[i + 2], &code[i + 3], &code[i + 4], &code[i + 5], &code[i + 6]) {
+                (
+                    Instruction::PutValue(out_reg, a1),
+                    Instruction::PutStructure(functor, a2),
+                    Instruction::SetValue(in_reg),
+                    Instruction::SetConstant(Value::Integer(1)),
+                    Instruction::Deallocate,
+                    Instruction::BuiltinCall(op, 2),
+                    Instruction::Proceed,
+                ) if a1 == "A1" && a2 == "A2" && functor == "+/2" && op == "is/2" =>
+                    Some(Instruction::ReturnAdd1(out_reg.clone(), in_reg.clone())),
+                _ => None,
+            };
+            if let Some(instr) = replacement {
+                code[i] = instr;
+                i += 7;
+                continue;
+            }
+        }
+        i += 1;
+    }
+}
+
+fn resolve_targets(code: &mut Vec<Instruction>, labels: &HashMap<String, usize>) {
+    let foreign_preds = foreign_pred_keys();
+    optimize_benchmark_code(code);
+    for instr in code.iter_mut() {
+        let replacement = match instr {
+            Instruction::Call(pred, arity) if foreign_preds.contains(pred) => {
+                Some(Instruction::CallForeign(pred.clone(), *arity))
+            }
+            Instruction::Call(pred, arity) if pred == "category_parent/2" && *arity == 2 => {
+                Some(Instruction::CallIndexedAtomFact2(pred.clone()))
+            }
+            Instruction::Call(pred, arity) => {
+                labels.get(pred).copied().map(|pc| Instruction::CallPc(pc, *arity))
+            }
+            Instruction::Execute(pred) => {
+                labels.get(pred).copied().map(Instruction::ExecutePc)
+            }
+            Instruction::RecurseCategoryAncestor(mid_reg, root_reg, child_hops_reg, visited_reg, pred, skip) => {
+                labels.get(pred).copied().map(|pc| {
+                    Instruction::RecurseCategoryAncestorPc(
+                        mid_reg.clone(),
+                        root_reg.clone(),
+                        child_hops_reg.clone(),
+                        visited_reg.clone(),
+                        pc,
+                        *skip,
+                    )
+                })
+            }
+            Instruction::TryMeElse(label) => {
+                labels.get(label).copied().map(Instruction::TryMeElsePc)
+            }
+            Instruction::RetryMeElse(label) => {
+                labels.get(label).copied().map(Instruction::RetryMeElsePc)
+            }
+            Instruction::SwitchOnConstant(table) => {
+                let mut resolved = Vec::with_capacity(table.len());
+                let mut ok = true;
+                for (value, label) in table.iter() {
+                    if let Some(&pc) = labels.get(label) {
+                        resolved.push((value.clone(), pc));
+                    } else {
+                        ok = false;
+                        break;
+                    }
+                }
+                ok.then_some(Instruction::SwitchOnConstantPc(resolved))
+            }
+            _ => None,
+        };
+        if let Some(new_instr) = replacement {
+            *instr = new_instr;
+        }
+    }
+}
+
+fn value_to_f64(value: &Value) -> Option<f64> {
+    match value {
+        Value::Integer(v) => Some(*v as f64),
+        Value::Float(v) => Some(*v),
+        Value::Atom(raw) => raw.parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Usage: wam_rust_matrix_bench <category_parent.tsv> <article_category.tsv>");
+        std::process::exit(1);
+    }
+    let edge_path = Path::new(&args[1]);
+    let article_path = Path::new(&args[2]);
+    let facts_dir = edge_path.parent().unwrap_or_else(|| Path::new("."));
+    let root_path = facts_dir.join("root_categories.tsv");
+
+    let started = Instant::now();
+    let category_parents = load_tsv_pairs(edge_path);
+    let article_categories = load_tsv_pairs(article_path);
+    let roots = load_single_column(&root_path);
+    let load_ms = started.elapsed().as_millis();
+
+    let (mut code, mut labels) = shared_wam_program();
+    append_fact2(&mut code, &mut labels, "category_parent", &category_parents);
+    resolve_targets(&mut code, &labels);
+
+    let mut vm = WamState::new(code, labels);
+    vm.register_indexed_atom_fact2("category_parent/2", build_indexed_fact2(&category_parents));
+    for (_pred, table) in &vm.indexed_atom_fact2.clone() {
+        for (key, vals) in table {
+            vm.intern_atom(key);
+            for val in vals {
+                vm.intern_atom(val);
+            }
+        }
+    }
+    for (pred, table) in &vm.indexed_atom_fact2.clone() {
+        let pred_name = pred.split(''/'').next().unwrap_or(pred);
+        let mut interned_table: HashMap<u32, Vec<u32>> = HashMap::new();
+        for (key, vals) in table {
+            let kid = vm.intern_atom(key);
+            let vids: Vec<u32> = vals.iter().map(|v| vm.intern_atom(v)).collect();
+            interned_table.insert(kid, vids);
+        }
+        vm.ffi_facts.insert(pred_name.to_string(), interned_table);
+    }
+    setup_foreign_predicates(&mut vm);
+
+    let mut seed_cats: Vec<String> = article_categories.iter().map(|(_, cat)| cat.clone()).collect();
+    seed_cats.sort();
+    seed_cats.dedup();
+    if let Ok(filter_raw) = std::env::var("WAM_SEED_FILTER") {
+        let wanted: HashSet<String> = filter_raw
+            .split("|")
+            .map(str::trim)
+            .filter(|part| !part.is_empty())
+            .map(str::to_string)
+            .collect();
+        if !wanted.is_empty() {
+            seed_cats.retain(|cat| wanted.contains(cat));
+        }
+    }
+    if let Ok(limit_raw) = std::env::var("WAM_SEED_LIMIT") {
+        match limit_raw.parse::<usize>() {
+            Ok(limit) if limit > 0 && seed_cats.len() > limit => seed_cats.truncate(limit),
+            Ok(_) => {}
+            Err(_) => eprintln!("[WAM-Rust-Matrix] WARNING: WAM_SEED_LIMIT={} is not a valid usize, ignoring", limit_raw),
+        }
+    }
+
+    let query_start = Instant::now();
+    let root = roots.first().cloned().unwrap_or_default();
+    let n = 5.0f64;
+    let inv_n = -1.0 / n;
+    let step_limit = std::env::var("WAM_STEP_LIMIT")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .unwrap_or(1_000_000);
+    let mut total_steps = 0u64;
+    let mut total_backtracks = 0u64;
+    let mut seed_weight_sums: HashMap<String, f64> = HashMap::new();
+
+    for cat in &seed_cats {
+        vm.reset_query();
+        vm.step_limit = step_limit;
+        let mut weight_sum = 0.0f64;
+        if vm.foreign_predicates.contains("category_ancestor/4") {
+            let cat_id = vm.intern_atom(cat);
+            let root_id = vm.intern_atom(&root);
+            let visited_ids = vec![cat_id];
+            let mut hops = Vec::new();
+            vm.collect_native_category_ancestor_hops(
+                cat_id,
+                root_id,
+                &visited_ids,
+                10,
+                "category_parent",
+                &mut hops,
+            );
+            for hop in hops.iter().take(10001) {
+                let distance = (*hop as f64) + 1.0;
+                weight_sum += distance.powf(-n);
+            }
+        } else {
+            vm.set_reg("A1", Value::Atom(cat.clone()));
+            vm.set_reg("A2", Value::Atom(root.clone()));
+            vm.set_reg("A3", Value::Unbound("Hops".to_string()));
+            vm.set_reg("A4", Value::List(vec![Value::Atom(cat.clone())]));
+            let mut first = true;
+            let mut solutions = 0usize;
+            loop {
+                let succeeded = if first {
+                    first = false;
+                    if let Some(&pc) = vm.labels.get("category_ancestor/4") {
+                        vm.pc = pc;
+                        vm.cp = 0;
+                        vm.run()
+                    } else {
+                        false
+                    }
+                } else {
+                    vm.backtrack()
+                };
+                if !succeeded {
+                    break;
+                }
+                if let Some(hops) = vm.bindings
+                    .get("Hops")
+                    .cloned()
+                    .or_else(|| vm.regs.get(3).cloned().map(|v| vm.deref_var(&v)))
+                    .and_then(|value| value_to_f64(&value)) {
+                    let distance = hops + 1.0;
+                    weight_sum += distance.powf(-n);
+                    solutions += 1;
+                }
+                if solutions > 10000 {
+                    break;
+                }
+            }
+        }
+        total_steps += vm.step_count;
+        total_backtracks += vm.backtrack_count;
+        if weight_sum > 0.0 {
+            seed_weight_sums.insert(cat.clone(), weight_sum);
+        }
+    }
+    let query_ms = query_start.elapsed().as_millis();
+
+    let agg_start = Instant::now();
+    let mut article_sums: HashMap<String, f64> = HashMap::new();
+    for (article, cat) in &article_categories {
+        let entry = article_sums.entry(article.clone()).or_insert(0.0);
+        if *cat == root {
+            *entry += 1.0;
+        }
+        if let Some(weight_sum) = seed_weight_sums.get(cat) {
+            *entry += *weight_sum;
+        }
+    }
+    let mut rows: Vec<(f64, String)> = article_sums
+        .into_iter()
+        .filter_map(|(article, weight_sum)| {
+            (weight_sum > 0.0).then(|| (weight_sum.powf(inv_n), article))
+        })
+        .collect();
+    rows.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap().then(a.1.cmp(&b.1)));
+    let aggregation_ms = agg_start.elapsed().as_millis();
+
+    println!("article\\troot_category\\teffective_distance");
+    for (distance, article) in rows {
+        println!("{}\\t{}\\t{:.6}", article, root, distance);
+    }
+
+    eprintln!("mode=~w");
+    eprintln!("load_ms={}", load_ms);
+    eprintln!("query_ms={}", query_ms);
+    eprintln!("aggregation_ms={}", aggregation_ms);
+    eprintln!("total_ms={}", started.elapsed().as_millis());
+    eprintln!("seed_count={}", seed_cats.len());
+    if let Ok(seed_limit) = std::env::var("WAM_SEED_LIMIT") {
+        eprintln!("seed_limit={}", seed_limit);
+    }
+    if let Ok(seed_filter) = std::env::var("WAM_SEED_FILTER") {
+        eprintln!("seed_filter={}", seed_filter);
+    }
+    eprintln!("tuple_count={}", seed_weight_sums.len());
+    eprintln!("total_steps={}", total_steps);
+    eprintln!("total_backtracks={}", total_backtracks);
+}
+').

--- a/src/unifyweaver/core/template_system.pl
+++ b/src/unifyweaver/core/template_system.pl
@@ -450,7 +450,7 @@ pub mod value;
 pub mod instructions;
 pub mod state;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use value::Value;
 use instructions::Instruction;
 use state::WamState;

--- a/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
@@ -180,26 +180,52 @@ rust_safe_code(_, 0'_).
 
 %% lower_predicate_to_rust(+Pred/Arity, +WamCode, +Options, -RustLines)
 %  Emit a Rust function for the predicate.
-lower_predicate_to_rust(PI, WamCode, _Options, RustLines) :-
+lower_predicate_to_rust(PI, WamCode, Options, RustLines) :-
     ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     rust_lowered_func_name(Pred/Arity, FuncName),
     (   is_list(WamCode) -> Instrs = WamCode
     ;   parse_wam_text(WamCode, Instrs)
     ),
     clause1_instrs(Instrs, C1Instrs),
-    with_output_to(string(Body), emit_instrs(C1Instrs, "    ")),
+    (   member(foreign_pred_keys(ForeignPreds0), Options)
+    ->  maplist(foreign_key_string, ForeignPreds0, ForeignPreds)
+    ;   ForeignPreds = []
+    ),
+    with_output_to(string(Body), emit_instrs(C1Instrs, "    ", ForeignPreds)),
     format(string(Header),
 '// ~w — lowered from ~w/~w
 pub fn ~w(vm: &mut WamState) -> bool {', [FuncName, Pred, Arity, FuncName]),
     format(string(Footer), '}', []),
     RustLines = [Header, Body, Footer].
 
-%% emit_instrs(+Instrs, +Indent)
+%% emit_instrs(+Instrs, +Indent, +ForeignPreds)
 %  Emit Rust code for a list of instructions.
-emit_instrs([], _).
-emit_instrs([Instr|Rest], Ind) :-
-    emit_one(Instr, Ind),
-    emit_instrs(Rest, Ind).
+emit_instrs([], _, _).
+emit_instrs([Instr|Rest], Ind, ForeignPreds) :-
+    emit_one(Instr, Ind, ForeignPreds),
+    emit_instrs(Rest, Ind, ForeignPreds).
+
+emit_one(call(PredStr, NStr), I, ForeignPreds) :-
+    member(PredStr, ForeignPreds), !,
+    format("~w// call ~w via foreign kernel~n", [I, PredStr]),
+    format("~wif !vm.step(&Instruction::CallForeign(\"~w\".to_string(), ~w)) { return false; }~n",
+           [I, PredStr, NStr]).
+emit_one(execute(PredStr), I, ForeignPreds) :-
+    member(PredStr, ForeignPreds),
+    sub_atom(PredStr, _, 1, ArityLen, '/'),
+    sub_atom(PredStr, _, ArityLen, 0, ArityAtom),
+    atom_number(ArityAtom, Arity), !,
+    format("~w// execute ~w via foreign kernel~n", [I, PredStr]),
+    format("~wreturn vm.step(&Instruction::CallForeign(\"~w\".to_string(), ~w));~n",
+           [I, PredStr, Arity]).
+emit_one(Instr, I, _) :-
+    emit_one(Instr, I).
+
+foreign_key_string(Key, String) :-
+    (   string(Key)
+    ->  String = Key
+    ;   atom_string(Key, String)
+    ).
 
 % --- Terminal instructions ---
 

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -39,6 +39,22 @@
     kernel_native_call/2
 ]).
 
+rust_safe_function_name(Pred, FuncName) :-
+    atom_string(Pred, PredStr),
+    string_codes(PredStr, Codes),
+    maplist(rust_safe_identifier_code, Codes, SafeCodes),
+    string_codes(FuncStr, SafeCodes),
+    atom_string(FuncName, FuncStr).
+
+rust_safe_identifier_code(C, C) :-
+    (   C >= 0'a, C =< 0'z
+    ;   C >= 0'A, C =< 0'Z
+    ;   C >= 0'0, C =< 0'9
+    ;   C =:= 0'_
+    ),
+    !.
+rust_safe_identifier_code(_, 0'_).
+
 % ============================================================================
 % PHASE 2: step_wam/3 → Rust match arms
 % ============================================================================
@@ -2414,6 +2430,7 @@ compile_wam_runtime_to_rust(Options, RustCode) :-
 %  that creates instruction data and executes it via the WAM runtime.
 compile_wam_predicate_to_rust(Pred/Arity, WamCode, Options, RustCode) :-
     atom_string(Pred, PredStr),
+    rust_safe_function_name(Pred, FuncName),
     build_rust_wam_arg_list(Arity, ArgList),
     build_rust_wam_arg_setup(Arity, ArgSetup),
     foreign_wrapper_setup(Pred/Arity, WamCode, Options, InstrSetup, ForeignSetup, RunExpr),
@@ -2426,7 +2443,7 @@ pub fn ~w(~w) -> bool {
 ~w
 ~w
     ~w
-}', [PredStr, Arity, PredStr, ArgList, InstrSetup, ForeignSetup, ArgSetup, RunExpr]).
+}', [PredStr, Arity, FuncName, ArgList, InstrSetup, ForeignSetup, ArgSetup, RunExpr]).
 
 foreign_wrapper_setup(Pred/Arity, WamCode, Options, InstrSetup, Setup, RunExpr) :-
     (   option(foreign_lowering(ForeignSpec), Options),
@@ -2968,6 +2985,11 @@ fn get_shared_wam() -> &\'static (Vec<Instruction>, HashMap<String, usize>) {
         ];
         (code, labels)
     })
+}
+
+pub fn shared_wam_program() -> (Vec<Instruction>, HashMap<String, usize>) {
+    let (code, labels) = get_shared_wam();
+    (code.clone(), labels.clone())
 }', [AllLabels, AllInstrs])
     ;   SharedCode = ""
     ),
@@ -3100,6 +3122,7 @@ generate_predicate_codes([classified(_, _Pred, _Arity, failed, PredCode)|Rest],
 %  Generates a thin WAM predicate wrapper that references the shared code table.
 compile_wam_predicate_to_rust_shared(Pred/Arity, StartPC, RustCode) :-
     atom_string(Pred, PredStr),
+    rust_safe_function_name(Pred, FuncName),
     build_rust_wam_arg_list(Arity, ArgList),
     build_rust_wam_arg_setup(Arity, ArgSetup),
     format(string(RustCode),
@@ -3113,7 +3136,7 @@ pub fn ~w(~w) -> bool {
     vm.pc = ~w;
 ~w
     vm.run()
-}', [PredStr, Arity, StartPC, PredStr, ArgList, StartPC, ArgSetup]).
+}', [PredStr, Arity, StartPC, FuncName, ArgList, StartPC, ArgSetup]).
 
 %% write_file(+Path, +Content)
 write_file(Path, Content) :-

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -2929,7 +2929,8 @@ write_wam_rust_project(Predicates, Options, ProjectDir) :-
     generate_setup_foreign_predicates_rust(DetectedKernels, SetupForeignCode),
 
     % Compile predicates and generate lib.rs
-    compile_predicates_for_project(Predicates, Options, PredicatesCode),
+    pairs_keys(DetectedKernels, DetectedKeys),
+    compile_predicates_for_project(Predicates, [foreign_pred_keys(DetectedKeys)|Options], PredicatesCode),
     format(string(FullPredicatesCode), "~w\n\n~w", [SetupForeignCode, PredicatesCode]),
     render_named_template(rust_wam_lib,
         [module_name=ModuleName, date=Date, predicates_code=FullPredicatesCode],
@@ -3018,7 +3019,7 @@ classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
         ->  lower_predicate_to_rust(Pred/Arity, WamCode, Options, RustLines),
             atomic_list_concat(RustLines, '\n', PredCode),
             format(user_error, '  ~w/~w: lowered (~w)~n', [Pred, Arity, Reason]),
-            Entry = classified(Module, Pred, Arity, lowered, PredCode)
+            Entry = classified(Module, Pred, Arity, lowered, lowered_code(PredCode, WamCode))
         ;   % Standard WAM fallback: will use shared table
             format(user_error, '  ~w/~w: WAM fallback~n', [Pred, Arity]),
             Entry = classified(Module, Pred, Arity, wam, WamCode)
@@ -3041,6 +3042,17 @@ collect_wam_entries([classified(_, Pred, Arity, wam, WamCode)|Rest], PC,
     split_string(WamStr, "\n", "", Lines),
     wam_lines_to_rust(Lines, PC, Pred/Arity, [], InstrParts, LabelParts),
     % Count instructions to compute next PC
+    length(InstrParts, InstrCount),
+    NextPC is PC + InstrCount,
+    collect_wam_entries(Rest, NextPC, RestEntries, RestInstrs, RestLabels),
+    append(InstrParts, RestInstrs, AllInstrs),
+    append(LabelParts, RestLabels, AllLabels).
+collect_wam_entries([classified(_, Pred, Arity, lowered, lowered_code(_, WamCode))|Rest], PC,
+                    [wam_entry(Pred, Arity, PC)|RestEntries],
+                    AllInstrs, AllLabels) :-
+    atom_string(WamCode, WamStr),
+    split_string(WamStr, "\n", "", Lines),
+    wam_lines_to_rust(Lines, PC, Pred/Arity, [], InstrParts, LabelParts),
     length(InstrParts, InstrCount),
     NextPC is PC + InstrCount,
     collect_wam_entries(Rest, NextPC, RestEntries, RestInstrs, RestLabels),
@@ -3069,7 +3081,7 @@ generate_predicate_codes([classified(_, _Pred, _Arity, wam_foreign, PredCode)|Re
                          WamEntries, [Code|RestCodes]) :-
     format(string(Code), "// Strategy: wam\n~w", [PredCode]),
     generate_predicate_codes(Rest, WamEntries, RestCodes).
-generate_predicate_codes([classified(_, _Pred, _Arity, lowered, PredCode)|Rest],
+generate_predicate_codes([classified(_, _Pred, _Arity, lowered, lowered_code(PredCode, _))|Rest],
                          WamEntries, [Code|RestCodes]) :-
     format(string(Code), "// Strategy: lowered\n~w", [PredCode]),
     generate_predicate_codes(Rest, WamEntries, RestCodes).

--- a/templates/targets/rust_wam/lib.rs.mustache
+++ b/templates/targets/rust_wam/lib.rs.mustache
@@ -6,7 +6,7 @@ pub mod value;
 pub mod instructions;
 pub mod state;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use value::Value;
 use instructions::Instruction;
 use state::WamState;

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -3,6 +3,8 @@
 % Usage: swipl -g run_tests -t halt tests/test_wam_rust_target.pl
 
 :- use_module('../src/unifyweaver/targets/wam_rust_target').
+:- use_module('../src/unifyweaver/targets/wam_rust_lowered_emitter',
+              [lower_predicate_to_rust/4]).
 :- use_module('../src/unifyweaver/targets/rust_target').
 :- use_module('../src/unifyweaver/targets/wam_target').
 :- use_module('../src/unifyweaver/core/template_system', [render_named_template/3]).
@@ -1671,6 +1673,27 @@ test_native_wam_mixed_project :-
         fail_test(Test, 'Mixed native+WAM project not generated correctly')
     ).
 
+test_rust_wam_lib_imports_hashset :-
+    Test = 'WAM-Rust: lib template imports HashSet for foreign_pred_keys',
+    (   render_named_template(rust_wam_lib,
+            [module_name='hashset_test', date='test', predicates_code=''],
+            LibStr),
+        sub_string(LibStr, _, _, _, 'use std::collections::{HashMap, HashSet};')
+    ->  pass(Test)
+    ;   fail_test(Test, 'rust_wam_lib template does not import HashSet')
+    ).
+
+test_lowered_calls_detected_kernel_via_callforeign :-
+    Test = 'WAM-Rust: lowered helper calls detected kernel via CallForeign',
+    WamCode = 'put_value X1 A1\ncall category_ancestor/4 4\nproceed\n',
+    (   lower_predicate_to_rust(test_foreign_call/1, WamCode,
+            [foreign_pred_keys(['category_ancestor/4'])], Lines),
+        atomic_list_concat(Lines, '\n', RustCode),
+        sub_string(RustCode, _, _, _, 'CallForeign("category_ancestor/4".to_string(), 4)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'Lowered helper did not emit CallForeign for detected kernel')
+    ).
+
 %% Run all tests
 run_tests :-
     format('~n========================================~n'),
@@ -1741,6 +1764,8 @@ run_tests :-
     test_cross_predicate_distinct_pcs,
     test_shared_wam_labels_contain_all_preds,
     test_native_wam_mixed_project,
+    test_rust_wam_lib_imports_hashset,
+    test_lowered_calls_detected_kernel_via_callforeign,
 
     format('~n========================================~n'),
     (   test_failed

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -1648,6 +1648,28 @@ test_shared_wam_labels_contain_all_preds :-
         fail_test(Test, 'Shared WAM table missing labels for some predicates')
     ).
 
+test_shared_wam_program_exported :-
+    Test = 'WAM-Rust: shared WAM program is exported for generated runners',
+    TmpDir = 'output/test_wam_rust_shared_program',
+    (   exists_directory(TmpDir)
+    ->  catch(delete_directory_and_contents(TmpDir), _, true)
+    ;   true
+    ),
+    (   once(write_wam_rust_project(
+            [user:test_resistant/3, user:test_caller/2],
+            [module_name('shared_program_test'), wam_fallback(true)],
+            TmpDir)),
+        directory_file_path(TmpDir, 'src', SrcDir),
+        directory_file_path(SrcDir, 'lib.rs', LibPath),
+        read_file_to_string(LibPath, LibStr, []),
+        sub_string(LibStr, _, _, _, 'pub fn shared_wam_program()'),
+        sub_string(LibStr, _, _, _, '(code.clone(), labels.clone())')
+    ->  catch(delete_directory_and_contents(TmpDir), _, true),
+        pass(Test)
+    ;   catch(delete_directory_and_contents(TmpDir), _, true),
+        fail_test(Test, 'shared_wam_program export missing')
+    ).
+
 test_native_wam_mixed_project :-
     Test = 'WAM-Rust: mixed native+WAM project only shares WAM predicates',
     TmpDir = 'output/test_wam_rust_mixed',
@@ -1763,6 +1785,7 @@ run_tests :-
     test_cross_predicate_shared_wam,
     test_cross_predicate_distinct_pcs,
     test_shared_wam_labels_contain_all_preds,
+    test_shared_wam_program_exported,
     test_native_wam_mixed_project,
     test_rust_wam_lib_imports_hashset,
     test_lowered_calls_detected_kernel_via_callforeign,


### PR DESCRIPTION
  ## Summary

  Adds Rust hybrid-WAM effective-distance matrix targets for the validated FFI-backed modes:

  - `rust-interp-ffi`: optimized Prolog compiled to WAM Rust interpreter with native kernels enabled
  - `rust-lowered-ffi`: optimized Prolog compiled to lowered Rust helpers with WAM fallback and native kernels enabled

  This also exposes the generated Rust shared WAM program for benchmark runners and sanitizes generated Rust wrapper
  function names for Prolog predicate names containing characters like `$`.

  ## Validation

  - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/
  benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
  - `swipl -q -s tests/test_wam_rust_target.pl`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 300 --targets prolog-accumulated,rust-
  interp-ffi,rust-lowered-ffi --repetitions 1`

  Scale `300` result: all outputs matched Prolog accumulated output. Observed smoke-run speedups were about `6.59x` for
  `rust-interp-ffi` and `8.30x` for `rust-lowered-ffi`.

  ## Notes

  Pure no-kernel Rust matrix targets are intentionally not advertised in this PR. Local probing showed the generic WAM
  fallback path still needs separate correctness/performance work before it is suitable for routine matrix benchmarking.