### PR TITLE
perf(wam-go-runtime): shrink Regs to 320 slots + resolve SwitchOnConstant default labels

### DIFF
--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -1839,8 +1839,26 @@ func (vm *WamState) fetch() Instruction {
 }
 
 func resolveInstructions(code []Instruction, labels map[string]int) []Instruction {
+    // resolveLabel handles the "default" sentinel that the constant-index
+    // emitter (build_constant_index/5 in wam_target.pl) puts on the
+    // first clause''s entry — at runtime that label means "fall through
+    // to the next instruction" (vm.PC+1). resolveInstructions runs over
+    // the code linearly, so the "next" PC is always idx+1 of the
+    // current SwitchOnConstant. Without this resolution, every
+    // SwitchOnConstant with a default entry stays unresolved (because
+    // labels["default"] doesn''t exist), keeping the linear-scan
+    // SwitchOnConstant runtime case alive — at scale-300 with
+    // category_parent''s 6000-clause table the O(N) scan dominates
+    // the per-call cost.
+    resolveLabel := func(label string, idx int) (int, bool) {
+        if label == "default" {
+            return idx + 1, true
+        }
+        pc, ok := labels[label]
+        return pc, ok
+    }
     resolved := make([]Instruction, 0, len(code))
-    for _, instr := range code {
+    for idx, instr := range code {
         switch i := instr.(type) {
         case *Call:
             if pc, ok := labels[i.Pred]; ok {
@@ -1878,7 +1896,7 @@ func resolveInstructions(code []Instruction, labels map[string]int) []Instructio
             cases := make([]ConstPcCase, 0, len(i.Cases))
             complete := true
             for _, c := range i.Cases {
-                pc, ok := labels[c.Label]
+                pc, ok := resolveLabel(c.Label, idx)
                 if !ok {
                     complete = false
                     break
@@ -1897,7 +1915,7 @@ func resolveInstructions(code []Instruction, labels map[string]int) []Instructio
             cases := make([]StructPcCase, 0, len(i.Cases))
             complete := true
             for _, c := range i.Cases {
-                pc, ok := labels[c.Label]
+                pc, ok := resolveLabel(c.Label, idx)
                 if !ok {
                     complete = false
                     break
@@ -1913,7 +1931,7 @@ func resolveInstructions(code []Instruction, labels map[string]int) []Instructio
             cases := make([]ConstPcCase, 0, len(i.Cases))
             complete := true
             for _, c := range i.Cases {
-                pc, ok := labels[c.Label]
+                pc, ok := resolveLabel(c.Label, idx)
                 if !ok {
                     complete = false
                     break
@@ -2196,7 +2214,7 @@ func (vm *WamState) finishForeignResults(predKey string, resultRegs []int, resul
     mode := vm.foreignResultMode(predKey)
     switch mode {
     case "stream":
-        var baseRegs [512]Value
+        var baseRegs [320]Value
         baseRegs = vm.Regs
         baseStack := copyStack(vm.Stack)
         trailMark := vm.TrailLen

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -105,7 +105,17 @@ type WamState struct {
 	Ctx          *WamContext
 	PC           int
 	CP           int
-	Regs         [512]Value
+	// Regs holds A/X/Y registers in a single flat array.
+	//   * A1..A8: indices 0..7 (argument registers)
+	//   * X-regs: 8..199  (clause-local temporaries)
+	//   * Y-regs: 200..299 (env-frame permanents; saved/restored at
+	//     Allocate/Deallocate via EnvFrame.SavedYRegs)
+	// Beyond 299 is unused space. The size used to be 512 but profiling
+	// at scale-300 showed `copy(vm.Regs[:len(cp.SavedRegs)],
+	// cp.SavedRegs)` was ~37% of CPU; trimming to 320 cuts that copy
+	// (and snapshotAllRegs's matching alloc) by ~37% per choicepoint
+	// without changing the addressable-slot range.
+	Regs         [320]Value
 	Bindings     map[int]Value
 	Heap         []Value
 	HeapLen      int
@@ -278,7 +288,7 @@ func (vm *WamState) trailTrimTo(mark int) {
 // full register file makes the panic go away and 1-hop and 2-hop
 // ancestor queries return the right number of solutions.
 //
-// The fixed cost (copying a [512]Value array per CP) is small compared
+// The fixed cost (copying a [320]Value array per CP) is small compared
 // to the pre-existing cost of copyStack(vm.Stack) per CP, and is much
 // smaller than the bug it prevents.
 func (vm *WamState) snapshotAllRegs() []Value {


### PR DESCRIPTION
Two related codegen + runtime changes that bring scale-300
effective-distance from ~340s to ~178s (1.91x faster). Targeted at
the two costliest items the CPU profile flagged at the bottom of the
prior fix series:

1. Regs trimmed from [512]Value to [320]Value.
   The codegen never references slots beyond ~210 (A1..A8, X100..X1xx,
   Y200..Y2xx). With every choicepoint snapshotting the full register
   file, the unused tail accounted for ~37% of every backtrack copy.
   Profile (scale-300, 50 seeds): runtime.memmove 27.6% → 15.4%, the
   `copy(vm.Regs[:len(cp.SavedRegs)], cp.SavedRegs)` line at
   state.go:858 dropped from 9.13s/24.23s to ~smaller fraction of
   total CPU. Other targets keep [512] — only the Go runtime template
   shrinks. The foreign-result `var baseRegs [512]Value` in
   wam_go_target.pl matches.

2. resolveInstructions handles "default" sentinel label.
   `build_constant_index/5` in wam_target.pl emits Label="default" on
   the first clause's switch entry (semantically: "fall through to
   PC+1"). resolveInstructions previously did `labels["default"]` and
   bailed out — every SwitchOnConstant with a default case stayed
   unresolved, forcing the runtime onto the linear-scan SwitchOnConstant
   path even though SwitchOnConstantPc binary-search was available. At
   scale-300 with category_parent's ~6000-clause indexing table, that
   linear scan ran on every recursive descent. The fix adds a
   resolveLabel closure that translates "default" to idx+1 of the
   current instruction, lets resolution complete, and the runtime
   binary-search SwitchOnConstantPc fires.

Measured (effective-distance bench, scale-300, kernels_off):
  Before: 340s, tuple_count=211, article_count=271
  After:  178s, tuple_count=211, article_count=271

Output is 271 rows in both cases. One row's position differs by one
(Hermann_von_Helmholtz vs Peter_Freund swap inside a 5-row tie at
distance=3.003688) — the new ordering is the correct alphabetical
tie-break and the prior was a non-stable-sort artifact. Reference
diff still shows the documented max_depth(10) vs max_depth>=50
discrepancy on Brownian_motion / 2008_in_science, unchanged.

Verified at dev too: 122ms → 73ms (1.67x), output identical to the
prior pass, SwitchOnConstantPc resolves successfully (probe shows
soc=0 socpc=1 in the resolved bytecode).

Open: snapshot/restore copy is still the dominant cost in the new
profile (~47% of total). A per-context max-reg-used field could
shrink the copy further (down from 320 to ~210), and switching
SavedRegs from `[]Value` to an inline fixed-size array could
eliminate the per-CP heap alloc; both attempted but reverted because
the inline-array variant ran slightly slower (the 5KB struct copy in
ChoicePoints' append cancels the alloc savings) and the max-reg-used
field needs codegen-side bookkeeping to stay correct across contexts.
Saved as future work in benchmarks/go_wam_runtime_findings.md (next
patch).