### PR TITLE
feat(wam-clojure): lower unify prefix

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -222,6 +222,9 @@ lowered_direct_instr(get_structure(_, _)).
 lowered_direct_instr(get_list(_)).
 lowered_direct_instr(get_integer(_, _)).
 lowered_direct_instr(get_nil(_)).
+lowered_direct_instr(unify_constant(_)).
+lowered_direct_instr(unify_variable(_)).
+lowered_direct_instr(unify_value(_)).
 lowered_direct_instr(put_constant(_, _)).
 lowered_direct_instr(put_nil(_)).
 lowered_direct_instr(get_variable(_, _)).
@@ -258,6 +261,19 @@ emit_lowered_expr(get_list(Ai), S, Expr) :-
     format(atom(Expr),
            '(let [reg-val (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w ~q) ::lowered-unbound)) list-functor (runtime/list-functor-term (:intern-context ~w))] (cond (and (runtime/structure-term? reg-val) (runtime/interned-equal? (:functor reg-val) list-functor)) (-> ~w (runtime/enter-unify-mode (:args reg-val)) runtime/advance) :else (runtime/backtrack ~w)))',
            [S, S, Ai, S, S, S]).
+emit_lowered_expr(unify_constant(C), S, Expr) :-
+    clj_lowered_literal(C, Lit),
+    format(atom(Expr),
+           '(let [constant (runtime/normalize-literal-term (:intern-context ~w) ~w) [item next-state] (runtime/pop-unify-item ~w) [ok bound-state] (runtime/unify-values next-state item constant)] (if ok (runtime/advance bound-state) (runtime/backtrack ~w)))',
+           [S, Lit, S, S]).
+emit_lowered_expr(unify_variable(Xn), S, Expr) :-
+    format(atom(Expr),
+           '(let [[item next-state] (runtime/pop-unify-item ~w)] (-> next-state (runtime/reg-set-raw ~q item) runtime/advance))',
+           [S, Xn]).
+emit_lowered_expr(unify_value(Xn), S, Expr) :-
+    format(atom(Expr),
+           '(let [[item next-state] (runtime/pop-unify-item ~w) reg-val (or (runtime/reg-get-raw next-state ~q) ::lowered-unbound) [ok bound-state] (runtime/unify-values next-state reg-val item)] (if ok (runtime/advance bound-state) (runtime/backtrack ~w)))',
+           [S, Xn, S]).
 emit_lowered_expr(put_constant(C, Ai), S, Expr) :-
     clj_lowered_literal(C, Lit),
     format(atom(Expr),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -84,9 +84,10 @@ test(structure_read_entry_is_direct_lowered_in_prefix) :-
         wam_clojure_lowerable(test_read_struct/1, WamCode, deterministic),
         lower_predicate_to_clojure(test_read_struct/1, WamCode, [], Code),
         has(Code, "runtime/enter-unify-mode"),
+        has(Code, "runtime/pop-unify-item"),
         has(Code, "runtime/structure-term?"),
         has(Code, "runtime/interned-equal?"),
-        assertion(\+ has(Code, "unify-constant a"))
+        has(Code, "runtime/unify-values")
     )).
 
 test(list_read_entry_is_direct_lowered_in_prefix) :-
@@ -97,7 +98,18 @@ test(list_read_entry_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/enter-unify-mode"),
         has(Code, "runtime/list-functor-term"),
         has(Code, "runtime/structure-term?"),
-        assertion(\+ has(Code, "unify-constant head"))
+        has(Code, "runtime/pop-unify-item"),
+        has(Code, "runtime/unify-values")
+    )).
+
+test(unify_value_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_unify_value/2:\nget_variable X1, A2\nget_structure f/1, A1\nunify_value X1\nproceed\n",
+        wam_clojure_lowerable(test_unify_value/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_unify_value/2, WamCode, [], Code),
+        has(Code, "runtime/pop-unify-item"),
+        has(Code, "runtime/reg-get-raw"),
+        has(Code, "runtime/unify-values")
     )).
 
 test(structure_build_ops_are_direct_lowered_in_prefix) :-


### PR DESCRIPTION
## Summary

Adds direct-prefix lowering for simple Clojure WAM unify-mode queue consumption:

- lowers `unify_constant/1`
- lowers `unify_variable/1`
- lowers `unify_value/1`
- mirrors existing runtime behavior using `pop-unify-item`, `unify-values`, and `reg-set-raw`
- extends lowered-emitter tests for structure/list read prefixes and `unify_value/1`

## Why

The previous Clojure lowered-emitter slices added direct handling for structure/list read entry through `get_structure/2` and `get_list/1`. Those instructions entered runtime unify mode, but immediately handed `unify_*` processing back to the interpreter.

This PR completes the next narrow step by directly lowering the simple queue-consumption instructions that follow read-mode entry. It improves coverage for real matching predicates while preserving the existing prefix-only safety boundary.

## Safety Boundary

This remains intentionally conservative:

- only the initial direct prefix is lowered
- `unify_*` lowering uses the same runtime helpers as the interpreter path
- calls, choice points, foreign calls, cuts, jumps, and other control-flow-sensitive instructions remain runtime-mediated
- no attempt is made to lower full multi-clause control flow or backtracking paths in this PR

## Validation

Passed locally:

```sh
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
git diff --check
```

