### PR TITLE
perf(wam-go): env trimming + StackLen choicepoints + save-A+Y-skip-X

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -224,6 +224,125 @@ re-doing the fusion.
 
 ---
 
+## Go WAM — optimization timeline
+
+Started from a working but slow runtime (effective-distance bench at
+scale-300 took ~340s after the late-April correctness fixes landed).
+Three rounds of perf brought it to ~53s — a **6.4x cumulative
+speedup** — and aligned the runtime with the Rust target's choicepoint
+and environment-trimming design.
+
+### Phase A: Correctness work (April 2026)
+
+Six runtime bugs found and fixed in sequence; collectively the
+difference between `tuple_count=0` and `tuple_count=211 article_count=271`
+matching the reference output. Documented in
+`benchmarks/go_wam_runtime_findings.md`. Most relevant for future perf
+work:
+
+| Bug | Fix |
+|---|---|
+| `bindUnbound` corrupting A1 when `Idx=0` | Drop unconditional `putReg(u.Idx, val)` |
+| `pushChoicePoint` saving only A-regs, leaving stale heap-Refs | Snapshot full register file (constraint that Phase D would later loosen via env trimming) |
+| `PutVariable` Idx collision across recursive activations | Globally-unique Idx via `allocVarId/0` |
+| `extract_shared_start_pc` taking the wrong digits | Fixed-length `sub_string` |
+| `Atom.Equals` always doing string compare | Pointer-identity short-circuit |
+| Y-regs colliding across nested predicate calls | Save/restore in `EnvFrame.SavedYRegs` at Allocate/Deallocate |
+
+### Phase B: First constant-factor wins (May 2026, `86f6febb`)
+
+| Commit | What | Why it matters |
+|---|---|---|
+| `4d0dd53e` | Include `category_parent/2` in `kernels_on` predicate list | Without it the kernel's recursion had nothing to call, every weight query returned 0 |
+| `86f6febb` | `Regs[512]` → `Regs[320]` + `resolveInstructions` handles `default` label sentinel | The `default` label kept SwitchOnConstant on the linear-scan runtime path even though SwitchOnConstantPc binary search was available; resolution lets the indexed dispatch fire. Combined with the smaller register file these brought scale-300 from ~340s to ~178s (1.91x) |
+
+### Phase C: Constant-factor attempts that didn't pan out (May 2026)
+
+Tracked here so they don't get re-tried; the underlying lessons match
+the Haskell/Rust patterns but the constant-factor reductions aren't
+distinguishable from variance noise (~±10%) at scale-300.
+
+| Attempt | Outcome |
+|---|---|
+| `Ctx.SaveRegBound` (compute max-used reg, snapshot only `Regs[:208]`) | Within variance |
+| `SavedRegs` pool with `truncateChoicePoints` recycle helper + `Clone()` deep-copy | +3% at 50-seed scale, **−6% at full scale-300** — Clone deep-copy + pool bookkeeping exceed alloc savings on the longer run |
+| Pre-sized `Bindings` map (`make(map[int]Value, 4096)`) | Consistent ~3-5% regression |
+| `Bindings []Value` slice indexed by Idx (`perf/wam-go-bindings-slice-and-stack-share`) | Performance-neutral at scale (theoretical 6x speedup on per-binding ops, but Bindings ops are ≤10% of total CPU; real bottleneck was elsewhere). Kept as structural cleanup |
+| Save only A-regs at CP push (Rust's `fea72426`-equivalent, attempted before env trimming) | **Broke correctness** (tuple_count dropped from 16 to 4 at dev): without env trimming, Y-regs at backtrack-time can't be recovered from the env frame because the SavedYRegs there hold *outer* values, not the current Y-regs at TryMeElse time. Re-enabled in Phase D as save-A+Y-skip-X once env trimming was in place |
+
+### Phase D: Structural refactor (May 2026, `perf/wam-go-env-trimming`)
+
+The two patches that delivered most of the Phase B → Phase D
+improvement (178s → 53s = 3.4x at full scale-300; cumulative 6.4x
+from the original 340s baseline):
+
+| Change | What | Why it matters |
+|---|---|---|
+| Environment trimming | Add `WamState.E` (current env-frame stack index) and `EnvFrame.PrevE`. Allocate links via PrevE and updates `vm.E`. Deallocate walks the PrevE chain *logically* (updates vm.E) and only physically pops the frame when both (a) it's at the top of the stack and (b) `env.B0 >= len(ChoicePoints)` (no younger CP references it). Otherwise the frame stays on the stack, dead but harmless, until backtrack truncation sweeps it. `peekEnvFrame` becomes O(1) via vm.E instead of an O(stack) reverse scan. | Prerequisite for the next change — without it, env frames could be physically popped while a younger CP needed them, so `pushChoicePoint` had to deep-copy the stack to capture the frames. With env trimming, the live frames are guaranteed to still be on the stack at backtrack time. |
+| Stack-mark choicepoints | `ChoicePoint.Stack []StackEntry` → `ChoicePoint.StackLen int`. `pushChoicePoint` records `len(vm.Stack)` instead of calling `copyStack`. `backtrack` truncates via `vm.Stack = vm.Stack[:cp.StackLen]`. The `Stack` field on ChoicePoint is gone; `copyStack` is unused. | Eliminates the per-CP `make([]StackEntry, ...)` + memcpy that was ~19% of CPU. Combined with env trimming this brought scale-300/50 from ~20s to ~8.5s (2.4x). |
+| Save-A+Y-skip-X register snapshot | `snapshotAllRegs` now saves 108 elements: `Regs[0..7]` (A-regs) + `Regs[200..299]` (Y-regs). `restoreSavedRegs` reverses the layout. The X-reg range (Regs[8..199]) is intentionally skipped — X-regs are clause-local in the codegen, the next clause's head writes whatever X-regs it needs (PutVariable / GetVariable Xn always writes before the X-reg is read), and stale leftovers from the failed clause never get touched. Y-regs *do* need saving because env trimming stores Y-regs at *Allocate* time; the *current* Y-regs at TryMeElse time only exist in the CP snapshot. | Cuts the per-CP snapshot copy from 320 elements to 108 (≈3x). Combined with the above, scale-300/50 went from ~8.5s to ~5.1s (1.7x more); scale-300/full went from 88.7s to 53s (1.7x more). |
+
+Cross-target precedent: the Rust target's Phase B (`6bec8b7e`,
+`fcc88aca`, `6815f9a3`, `fea72426`, `4a6e374e`) landed the equivalent
+sequence — lightweight choicepoints + Rc-shared stack + save only
+argument regs. The Go runtime can't use `Rc<Vec>` for stack sharing,
+but the `len(vm.Stack)` mark gives the same effect because env
+trimming guarantees the live frames stay reachable until backtrack
+truncates them.
+
+### Cumulative measurement (scale-300, kernels_off, single-thread)
+
+All medians of 5 alternating trials on the 50-seed sub-bench. Full
+386-seed bench measured once.
+
+| Stage | scale-300/50 median | scale-300/full | speedup vs prior | speedup vs original |
+|---|---|---|---|---|
+| Pre-Phase-A (broken — tuple_count=0) | n/a | n/a | n/a | n/a |
+| Phase A (correctness; full-Regs snapshot) | n/a | ~340s | — | 1.0x |
+| Phase B (`Regs[320]` + default-label resolve) | n/a | ~178s | 1.91x | 1.91x |
+| Phase D env trimming + StackLen | 8594ms | 88.7s | 2.0x | 3.83x |
+| Phase D + save-A+Y-skip-X | 5084ms | 53.0s | 1.67x | 6.42x |
+
+Output identical to prior at every stage except for the documented
+`max_depth(10)` drift on Brownian_motion / Hermann_von_Helmholtz
+tie-break (the workload uses `max_depth(10)` while the reference TSV
+was generated with `max_depth >= 50`; tracked in
+`benchmarks/go_wam_runtime_findings.md`).
+
+### Remaining headroom
+
+- **`bindUnbound`'s alias-rewrite loop** (`for idx, reg := range vm.Regs { if reg == u { vm.Regs[idx] = val } }`) is O(320) per binding. With the snapshot/restore work largely defanged, this is the next visible bandwidth cost. Could be replaced by deref-on-read (every reader that takes an `Unbound` derefs through `vm.getBinding`), at the cost of auditing every `vm.Regs[N]` read in the codegen.
+- **`Bindings map[int]Value` → `[]Value`** (the `perf/wam-go-bindings-slice-and-stack-share` branch). Performance-neutral at the moment because it was committed before Phase D and the dominant cost was elsewhere; with the per-CP work now small, the map's per-access cost may show up. Worth re-measuring on top of Phase D.
+- **Heap-trim on backtrack.** `vm.Heap = vm.Heap[:cp.HeapTop]` is fast but allocations to `vm.Heap` still happen via `append`. A pool / arena could eliminate the steady GC churn.
+
+### Lessons unique to the Go runtime
+
+1. **Variance bands stayed wide right up until Phase D.** Phase C's
+   constant-factor attempts couldn't be distinguished from noise;
+   Phase D's structural change shows up as a clean 4x with no overlap
+   between baseline and post-fix trial bands. The lesson isn't "don't
+   profile" — it's "if your patch only moves things by less than the
+   variance, the patch is too small."
+
+2. **Save-only-A-regs is correct in Go too — but only after env
+   trimming.** The Rust precedent (`fea72426`) wasn't directly
+   portable because the Go target had no equivalent of Rust's
+   per-clause register liveness analysis. What made the Rust
+   optimization safe was the same thing that made env trimming work:
+   Y-regs live in the env frame, not in a global register file
+   shared across activations. Once the Go runtime had that property,
+   the same observation applied.
+
+3. **Cumulative speedup ≠ sum of individual speedups.** Phase B was
+   1.91x. Phase D env-trim was 2.0x. Phase D save-A+Y was 1.67x.
+   Multiplied: 6.4x. The structural changes compose because they
+   each remove a different bottleneck — the constant-factor attempts
+   in Phase C didn't compose because they all targeted the same cost
+   (the SavedRegs copy) and the underlying issue was the design, not
+   the constants.
+
+---
+
 ## Clojure WAM — current implementation status
 
 The Clojure hybrid/WAM target is not yet in the same maturity class as

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -1531,7 +1531,11 @@ wam_go_case('SetConstant', '        vm.heapPush(i.C)
 
 % --- Control Instructions ---
 
-wam_go_case('Allocate', '        env := &EnvFrame{CP: vm.CP, B0: len(vm.ChoicePoints)}
+wam_go_case('Allocate', '        // Env trimming: PrevE links the new frame back to the previously
+        // active env frame. vm.E moves to the index of the just-pushed
+        // frame so peekEnvFrame is O(1) and Deallocate can walk the
+        // PrevE chain without scanning the stack.
+        env := &EnvFrame{CP: vm.CP, B0: len(vm.ChoicePoints), PrevE: vm.E}
         // Snapshot the Y-reg range (200..299) into the env frame so a
         // nested predicate that uses the same slot numbers via
         // PutVariable doesn''t silently clobber the caller''s Y-regs.
@@ -1541,12 +1545,30 @@ wam_go_case('Allocate', '        env := &EnvFrame{CP: vm.CP, B0: len(vm.ChoicePo
         // lose genuine results, only spurious leftover state.
         copy(env.SavedYRegs[:], vm.Regs[200:300])
         vm.Stack = append(vm.Stack, env)
+        vm.E = len(vm.Stack) - 1
         vm.PC++
         return true').
 
-wam_go_case('Deallocate', '        if env := vm.popEnvFrame(); env != nil {
-            vm.CP = env.CP
-            copy(vm.Regs[200:300], env.SavedYRegs[:])
+wam_go_case('Deallocate', '        if vm.E >= 0 && vm.E < len(vm.Stack) {
+            if env, ok := vm.Stack[vm.E].(*EnvFrame); ok {
+                vm.CP = env.CP
+                copy(vm.Regs[200:300], env.SavedYRegs[:])
+                prevE := env.PrevE
+                // Physical-pop only if it''s safe: the frame must be at
+                // the top of the stack AND no younger choicepoint
+                // references it (env.B0 == current CP count means the
+                // frame was Allocated AFTER the youngest live CP, so
+                // nothing depends on it staying around). Otherwise the
+                // frame stays on the stack — backtrack truncation will
+                // sweep it away when the referencing CPs are
+                // exhausted, and a future Allocate can push above it
+                // because vm.E now points at prevE, not at the dead
+                // frame''s slot.
+                if env.B0 >= len(vm.ChoicePoints) && vm.E == len(vm.Stack)-1 {
+                    vm.Stack = vm.Stack[:vm.E]
+                }
+                vm.E = prevE
+            }
         }
         vm.PC++
         return true').
@@ -2216,13 +2238,20 @@ func (vm *WamState) finishForeignResults(predKey string, resultRegs []int, resul
     case "stream":
         var baseRegs [320]Value
         baseRegs = vm.Regs
-        baseStack := copyStack(vm.Stack)
+        // Capture stack length and the env-pointer instead of cloning
+        // the stack — backtrack truncates to baseStackLen and restores
+        // baseE the same way the regular CP path does.
+        baseStackLen := len(vm.Stack)
+        baseE := vm.E
         trailMark := vm.TrailLen
         heapTop := vm.HeapLen
         for idx, result := range results {
             vm.unwindTrailTo(trailMark)
             vm.Regs = baseRegs
-            vm.Stack = copyStack(baseStack)
+            if baseStackLen <= len(vm.Stack) {
+                vm.Stack = vm.Stack[:baseStackLen]
+            }
+            vm.E = baseE
             if heapTop >= 0 && heapTop <= vm.HeapLen {
                 vm.heapTrimTo(heapTop)
             }
@@ -2234,14 +2263,19 @@ func (vm *WamState) finishForeignResults(predKey string, resultRegs []int, resul
             }
             if idx+1 < len(results) {
                 remaining := append([]Value(nil), results[idx+1:]...)
-                savedRegs := make([]Value, 100)
-                copy(savedRegs, baseRegs[:100])
+                // Match the regular CP snapshot layout that
+                // restoreSavedRegs() expects: 8 A-regs + 100 Y-regs,
+                // skipping the clause-local X-reg range.
+                savedRegs := make([]Value, 108)
+                copy(savedRegs[:8], baseRegs[:8])
+                copy(savedRegs[8:], baseRegs[200:300])
                 vm.ChoicePoints = append(vm.ChoicePoints, ChoicePoint{
                     NextPC: resumePC,
                     ResumePC: resumePC,
                     CP: vm.CP,
+                    E: baseE,
+                    StackLen: baseStackLen,
                     SavedRegs: savedRegs,
-                    Stack: baseStack,
                     HeapTop: heapTop,
                     TrailMark: trailMark,
                     ForeignPredKey: predKey,

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -30,8 +30,22 @@ type ChoicePoint struct {
 	NextPC    int
 	ResumePC  int
 	CP        int
+	// E captures vm.E (env-frame stack index) at choicepoint push.
+	// Restored at backtrack so the env-trimming-aware Deallocate
+	// continues from the right frame after the failed branch's
+	// changes are undone.
+	E         int
+	// StackLen captures len(vm.Stack) at choicepoint push. Backtrack
+	// truncates the stack to this length; everything pushed during
+	// the failed attempt is dropped. With env trimming in place the
+	// truncation is safe — env frames pushed after the CP are dead
+	// (their PrevE chain has already been walked back), and frames
+	// alive at CP push time are guaranteed to be at indices < StackLen
+	// because Deallocate doesn't physically pop frames whose B0 < the
+	// youngest live CP. Replaces the prior `Stack: copyStack(vm.Stack)`
+	// per-push allocation, which was ~19% of CPU at scale-300.
+	StackLen  int
 	SavedRegs []Value
-	Stack     []StackEntry
 	HeapTop   int
 	TrailMark int
 	IndexedClausePCs []int
@@ -43,6 +57,16 @@ type ChoicePoint struct {
 type EnvFrame struct {
 	CP int
 	B0 int
+	// PrevE is the WamState.E (env-frame stack index) at the moment
+	// this frame was Allocated. Deallocate restores vm.E to PrevE
+	// for the LIFO walk back through nested activations. The "logical
+	// pop only" discipline lets env frames stay physically on the
+	// stack while a younger choicepoint still references them, so
+	// `pushChoicePoint` no longer has to deep-copy the stack — it
+	// just records `len(vm.Stack)` as a mark, and backtrack truncates
+	// to that mark. Stack frames whose B0 makes them "dead" stay
+	// inert until the truncation rolls past them.
+	PrevE int
 	// SavedYRegs is a snapshot of Regs[200..299] (the Y-register range)
 	// taken at Allocate time and restored at Deallocate. Y-regs are
 	// global slots in this runtime, so without per-call save/restore
@@ -139,6 +163,15 @@ type WamState struct {
 	// `1 is 2`. Start above 1000 so the counter never collides with
 	// the register-slot range that was used pre-fix.
 	NextVarId    int
+	// E is the stack index of the currently-active EnvFrame, or -1
+	// when no frame is allocated (e.g., right after NewWamState before
+	// any Allocate). With env trimming, Deallocate moves E back along
+	// the EnvFrame.PrevE chain rather than physically popping; the
+	// frame stays on the stack until either (a) physical pop is safe
+	// (no younger CP referencing it) or (b) backtrack truncates the
+	// stack down past it. peekEnvFrame is now O(1) via this index
+	// instead of an O(stack) reverse scan.
+	E int
 }
 
 // allocVarId returns a fresh, globally-unique Idx for a new logical
@@ -173,11 +206,11 @@ func NewWamContext(code []Instruction, labels map[string]int) *WamContext {
 
 func NewWamState(code []Instruction, labels map[string]int) *WamState {
 	ctx := NewWamContext(code, labels)
-	return &WamState{Ctx: ctx, Bindings: make(map[int]Value)}
+	return &WamState{Ctx: ctx, Bindings: make(map[int]Value), E: -1}
 }
 
 func NewWamStateFromCtx(ctx *WamContext) *WamState {
-	return &WamState{Ctx: ctx, Bindings: make(map[int]Value)}
+	return &WamState{Ctx: ctx, Bindings: make(map[int]Value), E: -1}
 }
 
 // RunParallel executes multiple seeds in parallel, each with their own
@@ -270,31 +303,41 @@ func (vm *WamState) trailTrimTo(mark int) {
 	vm.TrailLen = mark
 }
 
-// snapshotAllRegs captures the FULL register file for a choice point.
+// snapshotAllRegs captures only the A-register range (Regs[0..7]) and
+// the Y-register range (Regs[200..299]). The middle X-register range
+// (Regs[8..199]) is intentionally skipped — X-regs are clause-local
+// in the codegen, so the next clause's head writes whatever X-regs
+// it needs (PutVariable / GetVariable Xn always writes BEFORE the
+// X-reg is read), and stale leftovers from the failed clause never
+// get touched. The Rust target's `fea72426` ("Save only argument
+// regs in choice points") landed the same observation; in the Go
+// runtime the equivalent has to keep Y-regs because env trimming
+// stores Y-regs at *Allocate* time (caller's outer Y-regs) — at
+// TryMeElse time the caller's *current* Y-regs are already in
+// vm.Regs[200..299] and only the CP's snapshot can recover them
+// across backtrack.
 //
-// The original implementation saved only the first `arity` slots — the
-// arity of the predicate that triggered the CP. That was a real
-// correctness bug for any predicate that allocates X-regs (Regs[100..])
-// or Y-regs (Regs[200..]) holding heap-Refs: backtrack would restore
-// A1..An but leave the higher slots untouched, even though heapTrimTo
-// just shrunk the heap past their referent. The next deref of one of
-// those Refs would read off the end of the heap and crash, or — worse —
-// silently resolve to whatever cell a later allocation happened to put
-// in the same slot.
+// Layout in the returned slice:
+//   - SavedRegs[0..7]   := vm.Regs[0..7]    (A1..A8)
+//   - SavedRegs[8..107] := vm.Regs[200..299] (Y200..Y299)
 //
-// Symptom that uncovered this: `category_ancestor("Branches_of_chemistry",
-// "Physics", H, [BoC])` panicked with `index out of range [21] with
-// length 21` from inside `member/2`'s listToSlice. Snapshotting the
-// full register file makes the panic go away and 1-hop and 2-hop
-// ancestor queries return the right number of solutions.
-//
-// The fixed cost (copying a [320]Value array per CP) is small compared
-// to the pre-existing cost of copyStack(vm.Stack) per CP, and is much
-// smaller than the bug it prevents.
+// restoreSavedRegs() at backtrack reverses the copy. 108-element
+// snapshot vs the prior 320-element one cuts the per-CP memmove
+// roughly 3x and the matching mallocgc by the same factor.
 func (vm *WamState) snapshotAllRegs() []Value {
-	saved := make([]Value, len(vm.Regs))
-	copy(saved, vm.Regs[:])
+	saved := make([]Value, 108)
+	copy(saved[:8], vm.Regs[:8])
+	copy(saved[8:], vm.Regs[200:300])
 	return saved
+}
+
+func (vm *WamState) restoreSavedRegs(saved []Value) {
+	if len(saved) >= 8 {
+		copy(vm.Regs[:8], saved[:8])
+	}
+	if len(saved) >= 108 {
+		copy(vm.Regs[200:300], saved[8:108])
+	}
 }
 
 func (vm *WamState) pushChoicePoint(nextPC int, arity int) {
@@ -302,8 +345,9 @@ func (vm *WamState) pushChoicePoint(nextPC int, arity int) {
 	vm.ChoicePoints = append(vm.ChoicePoints, ChoicePoint{
 		NextPC:    nextPC,
 		CP:        vm.CP,
+		E:         vm.E,
+		StackLen:  len(vm.Stack),
 		SavedRegs: vm.snapshotAllRegs(),
-		Stack:     copyStack(vm.Stack),
 		HeapTop:   vm.HeapLen,
 		TrailMark: vm.TrailLen,
 	})
@@ -313,8 +357,9 @@ func (vm *WamState) pushIndexedChoicePoint(pcs []int, arity int) {
 	_ = arity
 	vm.ChoicePoints = append(vm.ChoicePoints, ChoicePoint{
 		CP:        vm.CP,
+		E:         vm.E,
+		StackLen:  len(vm.Stack),
 		SavedRegs: vm.snapshotAllRegs(),
-		Stack:     copyStack(vm.Stack),
 		HeapTop:   vm.HeapLen,
 		TrailMark: vm.TrailLen,
 		IndexedClausePCs: append([]int(nil), pcs...),
@@ -348,10 +393,11 @@ func (vm *WamState) peekWriteCtx() *WriteCtx {
 }
 
 func (vm *WamState) peekEnvFrame() *EnvFrame {
-	for i := len(vm.Stack) - 1; i >= 0; i-- {
-		if f, ok := vm.Stack[i].(*EnvFrame); ok {
-			return f
-		}
+	if vm.E < 0 || vm.E >= len(vm.Stack) {
+		return nil
+	}
+	if f, ok := vm.Stack[vm.E].(*EnvFrame); ok {
+		return f
 	}
 	return nil
 }
@@ -389,6 +435,7 @@ func (vm *WamState) Clone() *WamState {
 		// then deref through the parent's bindings and silently drop
 		// every solution.
 		NextVarId:    vm.NextVarId,
+		E:            vm.E,
 	}
 	newState.Regs = vm.Regs
 	for k, v := range vm.Bindings {
@@ -818,8 +865,11 @@ func (vm *WamState) backtrack() bool {
     cp := vm.ChoicePoints[topIdx]
     if len(cp.IndexedClausePCs) > 0 {
         vm.unwindTrailTo(cp.TrailMark)
-        copy(vm.Regs[:len(cp.SavedRegs)], cp.SavedRegs)
-        vm.Stack = copyStack(cp.Stack)
+        vm.restoreSavedRegs(cp.SavedRegs)
+        if cp.StackLen <= len(vm.Stack) {
+            vm.Stack = vm.Stack[:cp.StackLen]
+        }
+        vm.E = cp.E
         if cp.HeapTop >= 0 && cp.HeapTop <= vm.HeapLen {
             vm.heapTrimTo(cp.HeapTop)
         }
@@ -840,8 +890,11 @@ func (vm *WamState) backtrack() bool {
     if len(cp.ForeignResults) > 0 {
         for len(cp.ForeignResults) > 0 {
             vm.unwindTrailTo(cp.TrailMark)
-            copy(vm.Regs[:len(cp.SavedRegs)], cp.SavedRegs)
-            vm.Stack = copyStack(cp.Stack)
+            vm.restoreSavedRegs(cp.SavedRegs)
+            if cp.StackLen <= len(vm.Stack) {
+                vm.Stack = vm.Stack[:cp.StackLen]
+            }
+            vm.E = cp.E
             if cp.HeapTop >= 0 && cp.HeapTop <= vm.HeapLen {
                 vm.heapTrimTo(cp.HeapTop)
             }
@@ -865,8 +918,11 @@ func (vm *WamState) backtrack() bool {
         return false
     }
     vm.unwindTrailTo(cp.TrailMark)
-    copy(vm.Regs[:len(cp.SavedRegs)], cp.SavedRegs)
-    vm.Stack = copyStack(cp.Stack)
+    vm.restoreSavedRegs(cp.SavedRegs)
+    if cp.StackLen <= len(vm.Stack) {
+        vm.Stack = vm.Stack[:cp.StackLen]
+    }
+    vm.E = cp.E
     if cp.HeapTop >= 0 && cp.HeapTop <= vm.HeapLen {
         vm.heapTrimTo(cp.HeapTop)
     }


### PR DESCRIPTION
Three structural changes that compose to a 3.4x speedup at full scale-300 (178s → 53s) and a 6.4x cumulative win from the original pre-Phase-A ~340s baseline. Output is identical to the prior implementation modulo the documented `max_depth(10)` drift on the Brownian_motion / Hermann_von_Helmholtz tie-break.

1. **Environment trimming.** New `WamState.E` (current env-frame stack index, -1 = none) and `EnvFrame.PrevE` (env at Allocate time). `Allocate` links via PrevE and updates vm.E. `Deallocate` walks the PrevE chain *logically* (just updates vm.E) and only physically pops the frame when both (a) it's at the top of the stack and (b) `env.B0 >= len(ChoicePoints)` (no younger CP references it). Otherwise the frame stays on the stack — dead but harmless — until backtrack truncation sweeps it. `peekEnvFrame` is now O(1) via vm.E instead of a reverse stack scan. `popEnvFrame` is no longer called by Deallocate (kept for binary compatibility but unused).

2. **Stack-mark choicepoints.** Replace `ChoicePoint.Stack []StackEntry` with `ChoicePoint.StackLen int`. `pushChoicePoint` records `len(vm.Stack)` instead of calling `copyStack`. `backtrack` truncates via `vm.Stack = vm.Stack[:cp.StackLen]`. This is only safe because env trimming guarantees frames live at CP push time are still on the stack at backtrack time (younger Deallocates leave them physically alone). Also adds `ChoicePoint.E int` so backtrack restores `vm.E` to the env- frame index that was active at CP-push.

3. **Save-A+Y-skip-X register snapshot.** `snapshotAllRegs` now saves 108 elements: `Regs[0..7]` (A-regs) + `Regs[200..299]` (Y-regs). New `restoreSavedRegs` reverses the layout. The X-reg range (Regs[8..199]) is intentionally skipped — X-regs are clause-local, the next clause's head writes whatever X-regs it needs (PutVariable / GetVariable Xn always writes before the X-reg is read), and stale leftovers from the failed clause never get touched. Y-regs *do* need saving because env trimming stores Y-regs at *Allocate* time (caller's outer values); the *current* Y-regs at TryMeElse time only exist in the CP snapshot. The same observation made Rust's `fea72426` ("Save only argument regs") work — see the perf log for the cross-target comparison. Earlier attempt without env trimming broke correctness because Y-regs couldn't be recovered from the env frame on backtrack.

Measurements (scale-300, kernels_off, single-thread):

| Stage | scale-300/50 median (5 trials) | scale-300/full | speedup vs prior | |---|---|---|---|
| Baseline (current main) | 20576ms | 178s | — |
| + env-trimming + StackLen | 8594ms | 88.7s | 2.4x / 2.0x | | + save-A+Y-skip-X | 5084ms | 53.0s | 1.69x / 1.67x | | Cumulative | — | — | **4.05x / 3.4x** |

Cumulative from the original pre-Phase-A ~340s = **6.4x**.

The foreign-result CP construction in `wam_go_target.pl` (streaming foreign predicates' continuation CP) was also updated to match the new SavedRegs layout (8 + 100 element layout). No known foreign predicate currently uses streaming mode, so the runtime-correctness path was exercised only via the regular TryMeElse / RetryMeElse / TrustMe pushes, but the layout has to match for safety.

Doc: `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` gains a Go WAM section parallel to the existing Haskell / Rust / Clojure timelines, covering Phases A-D, the constant-factor attempts in Phase C that didn't pan out (SaveRegBound, SavedRegs pool, map pre-size, Bindings slice, save-only-A-regs without env trimming), the cumulative measurement table, the remaining headroom (alias- rewrite loop in bindUnbound, Bindings as slice on top of Phase D, heap-trim arena), and Go-specific lessons.