### PR TITLE
perf(wam-go): MaxYReg-bounded Y-reg snapshot — 2.31x at full scale-300

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -290,6 +290,43 @@ but the `len(vm.Stack)` mark gives the same effect because env
 trimming guarantees the live frames stay reachable until backtrack
 truncates them.
 
+### Phase E: Y-reg snapshot bounded by actually-used range (May 2026, `perf/wam-go-yreg-trail`)
+
+After Phase D the per-CP profile showed `restoreSavedRegs` at ~42%
+of CPU, with the Y-reg copy (100 elements) dominating over the A-reg
+copy (8 elements). Most clauses use only ~10 Y-regs; the snapshot
+was paying for 100.
+
+Tried first: trail-based Y-reg restoration (per-write trail entries,
+no per-CP snapshot). It hung the bench — too many trail entries +
+subtle ordering issues with `bindUnbound`'s alias-rewrite loop and
+the existing `trailBinding(i.Xn)` calls in `GetVariable` /
+`UnifyVariable` (leftovers from when Idx == register slot index, now
+wrong with allocVarId starting at 1000+). Reverted.
+
+Approach that worked: track `vm.MaxYReg` as a high-water mark of the
+highest Y-reg index ever written, bumped inside `putReg`. The
+snapshot copies only `Regs[200..vm.MaxYReg]` instead of the full Y
+range. For the bench's category_ancestor (uses ~10 Y-regs), this
+shrinks the snapshot from 108 elements to ~18 and the per-CP
+memmove proportionally.
+
+Two bugs surfaced and were fixed:
+
+1. **MaxYReg is monotonic but the *failed clause* could grow it
+   past push-time.** If the snapshot was made when MaxYReg was N
+   and the failed clause wrote a higher Y-reg, restore wouldn't
+   touch the slot — it'd stay at the failed value. Fix:
+   `restoreSavedRegs` now clears `Regs[pushMaxY..vm.MaxYReg]` to
+   nil after restoring the snapshot (those slots were nil at push
+   time by construction).
+
+2. **`Clone()` didn't carry MaxYReg.** Sub-VMs in `executeAggregate`
+   started with MaxYReg=0, snapshot omitted Y-regs, backtrack
+   inside the sub-VM lost values the failed clause overwrote.
+   Symptom: `Velocity Physics 1.602159` instead of the
+   post-Phase-D `1.601079`. Fix: Clone copies MaxYReg.
+
 ### Cumulative measurement (scale-300, kernels_off, single-thread)
 
 All medians of 5 alternating trials on the 50-seed sub-bench. Full
@@ -302,6 +339,7 @@ All medians of 5 alternating trials on the 50-seed sub-bench. Full
 | Phase B (`Regs[320]` + default-label resolve) | n/a | ~178s | 1.91x | 1.91x |
 | Phase D env trimming + StackLen | 8594ms | 88.7s | 2.0x | 3.83x |
 | Phase D + save-A+Y-skip-X | 5084ms | 53.0s | 1.67x | 6.42x |
+| Phase E MaxYReg-bounded snapshot | 3624ms | 38.4s | 1.43x / 1.38x | **8.85x / 8.85x** |
 
 Output identical to prior at every stage except for the documented
 `max_depth(10)` drift on Brownian_motion / Hermann_von_Helmholtz
@@ -312,8 +350,9 @@ was generated with `max_depth >= 50`; tracked in
 ### Remaining headroom
 
 - **`bindUnbound`'s alias-rewrite loop** (`for idx, reg := range vm.Regs { if reg == u { vm.Regs[idx] = val } }`) is O(320) per binding. With the snapshot/restore work largely defanged, this is the next visible bandwidth cost. Could be replaced by deref-on-read (every reader that takes an `Unbound` derefs through `vm.getBinding`), at the cost of auditing every `vm.Regs[N]` read in the codegen.
-- **`Bindings map[int]Value` → `[]Value`** (the `perf/wam-go-bindings-slice-and-stack-share` branch). Performance-neutral at the moment because it was committed before Phase D and the dominant cost was elsewhere; with the per-CP work now small, the map's per-access cost may show up. Worth re-measuring on top of Phase D.
+- **`Bindings map[int]Value` → `[]Value`** (the `perf/wam-go-bindings-slice-and-stack-share` branch). Performance-neutral at the moment because it was committed before Phase D and the dominant cost was elsewhere; with the per-CP work now small, the map's per-access cost may show up. Worth re-measuring on top of Phase E.
 - **Heap-trim on backtrack.** `vm.Heap = vm.Heap[:cp.HeapTop]` is fast but allocations to `vm.Heap` still happen via `append`. A pool / arena could eliminate the steady GC churn.
+- **Trail-based Y-reg restoration** (proper version). The Phase-E attempt failed because `trailBinding(i.Xn)` calls in GetVariable/UnifyVariable leak Bindings entries with addresses that overlap the Y-reg range, AND `bindUnbound`'s alias-rewrite loop doesn't trail Y-reg overwrites. With both fixed, trail-based restoration could be made to work and would drop the per-CP snapshot to just A-regs (8 elements). Deferred — the MaxYReg approach captures most of the upside without the audit risk.
 
 ### Lessons unique to the Go runtime
 

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -163,6 +163,15 @@ type WamState struct {
 	// `1 is 2`. Start above 1000 so the counter never collides with
 	// the register-slot range that was used pre-fix.
 	NextVarId    int
+	// MaxYReg is the highest Y-register index ever written + 1 (i.e.,
+	// the count of slots the program actually uses in the Y range
+	// 200..299). snapshotAllRegs uses this as the upper bound on the
+	// Y-reg copy: most programs use only a handful of Y-regs (the
+	// effective-distance bench uses ~10 of the 100 available),
+	// shrinking the per-CP snapshot from 108 elements to 8 + actual.
+	// Monotonically grows; never resets. Starts at 200 so 0 means
+	// "no Y-regs used yet" via the formula `MaxYReg - 200`.
+	MaxYReg int
 	// E is the stack index of the currently-active EnvFrame, or -1
 	// when no frame is allocated (e.g., right after NewWamState before
 	// any Allocate). With env trimming, Deallocate moves E back along
@@ -247,6 +256,14 @@ func RunParallel(ctx *WamContext, seeds [][]Value, maxWorkers int) [][]Value {
 
 func (vm *WamState) putReg(idx int, val Value) {
 	vm.Regs[idx] = val
+	// Track the high-water mark of Y-reg writes so snapshotAllRegs
+	// can size its Y-range copy to actually-used slots only. The
+	// extra branch + compare is cheap relative to the snapshot
+	// shrink it enables (per-CP Y-range copy goes from 100
+	// elements to typically ~10).
+	if idx >= 200 && idx >= vm.MaxYReg {
+		vm.MaxYReg = idx + 1
+	}
 }
 
 func (vm *WamState) getReg(idx int) Value {
@@ -303,40 +320,60 @@ func (vm *WamState) trailTrimTo(mark int) {
 	vm.TrailLen = mark
 }
 
-// snapshotAllRegs captures only the A-register range (Regs[0..7]) and
-// the Y-register range (Regs[200..299]). The middle X-register range
+// snapshotAllRegs captures the A-register range (Regs[0..7]) plus
+// the actually-used portion of the Y-register range
+// (Regs[200..vm.MaxYReg]). The middle X-register range
 // (Regs[8..199]) is intentionally skipped — X-regs are clause-local
 // in the codegen, so the next clause's head writes whatever X-regs
-// it needs (PutVariable / GetVariable Xn always writes BEFORE the
-// X-reg is read), and stale leftovers from the failed clause never
-// get touched. The Rust target's `fea72426` ("Save only argument
-// regs in choice points") landed the same observation; in the Go
-// runtime the equivalent has to keep Y-regs because env trimming
-// stores Y-regs at *Allocate* time (caller's outer Y-regs) — at
-// TryMeElse time the caller's *current* Y-regs are already in
-// vm.Regs[200..299] and only the CP's snapshot can recover them
-// across backtrack.
+// it needs and stale leftovers from the failed clause never get
+// touched. Y-regs *do* need saving because env trimming stores
+// Y-regs at *Allocate* time (caller's outer Y-regs) — at TryMeElse
+// time the caller's *current* Y-regs only exist in the CP snapshot.
 //
 // Layout in the returned slice:
 //   - SavedRegs[0..7]   := vm.Regs[0..7]    (A1..A8)
-//   - SavedRegs[8..107] := vm.Regs[200..299] (Y200..Y299)
+//   - SavedRegs[8..8+ycount] := vm.Regs[200..200+ycount]  (used Y-regs)
 //
-// restoreSavedRegs() at backtrack reverses the copy. 108-element
-// snapshot vs the prior 320-element one cuts the per-CP memmove
-// roughly 3x and the matching mallocgc by the same factor.
+// where ycount := max(0, vm.MaxYReg - 200). The bench's
+// category_ancestor uses ~10 Y-regs, so the snapshot is ~18
+// elements vs the prior 108, cutting per-CP memmove ~6x.
 func (vm *WamState) snapshotAllRegs() []Value {
-	saved := make([]Value, 108)
+	ycount := vm.MaxYReg - 200
+	if ycount < 0 {
+		ycount = 0
+	}
+	saved := make([]Value, 8+ycount)
 	copy(saved[:8], vm.Regs[:8])
-	copy(saved[8:], vm.Regs[200:300])
+	if ycount > 0 {
+		copy(saved[8:], vm.Regs[200:200+ycount])
+	}
 	return saved
 }
 
+// restoreSavedRegs is the dual of snapshotAllRegs. The snapshot
+// captures up to MaxYReg-at-push-time; vm.MaxYReg may have grown
+// since (the failed clause wrote new Y-regs). Those "post-push"
+// Y-regs were nil at push time and need to be cleared back to nil
+// here, otherwise they'd leak failed-clause values into the next
+// clause's body. Without the clear, the bench had Velocity at
+// 1.602159 vs the post-Phase-D 1.601079 — a Y-reg from a longer
+// recursion path was bleeding into a shorter one. The clear loop
+// is bounded by MaxYReg-since-push (typically 0-2 slots), so it's
+// much cheaper than restoring the full 100-element Y range.
 func (vm *WamState) restoreSavedRegs(saved []Value) {
-	if len(saved) >= 8 {
-		copy(vm.Regs[:8], saved[:8])
+	if len(saved) < 8 {
+		return
 	}
-	if len(saved) >= 108 {
-		copy(vm.Regs[200:300], saved[8:108])
+	copy(vm.Regs[:8], saved[:8])
+	ycount := len(saved) - 8
+	if ycount > 0 {
+		copy(vm.Regs[200:200+ycount], saved[8:])
+	}
+	// Clear Y-regs that were written between snapshot and now but
+	// weren't captured (they were nil at push time, by definition).
+	pushMaxY := 200 + ycount
+	for i := pushMaxY; i < vm.MaxYReg; i++ {
+		vm.Regs[i] = nil
 	}
 }
 
@@ -436,6 +473,14 @@ func (vm *WamState) Clone() *WamState {
 		// every solution.
 		NextVarId:    vm.NextVarId,
 		E:            vm.E,
+		// Carry MaxYReg so the sub-VM's snapshotAllRegs sees the
+		// same Y-reg high-water mark as the parent (sub.Regs is a
+		// value-copy of parent.Regs and therefore *contains* those
+		// Y-reg values; without copying MaxYReg the sub-VM thinks
+		// it has 0 Y-regs in use, the snapshot omits them, and
+		// backtrack inside the sub-VM doesn't restore values that
+		// the failed clause overwrote).
+		MaxYReg:      vm.MaxYReg,
 	}
 	newState.Regs = vm.Regs
 	for k, v := range vm.Bindings {


### PR DESCRIPTION
Continues the Phase D structural refactor. After env trimming +
StackLen + save-A+Y-skip-X (Phase D) brought scale-300 from 178s
to 53s, the post-Phase-D profile showed `restoreSavedRegs` at
~42% of CPU with the 100-element Y-reg copy dominating over the
8-element A-reg copy. Most clauses use only ~10 Y-regs; the
snapshot was paying for 100.

This commit:

- Adds `WamState.MaxYReg int` (high-water mark of Y-reg writes,
  bumped inside `putReg` when idx is in the 200..299 range).
- `snapshotAllRegs` now copies `Regs[200..vm.MaxYReg]` instead of
  the full `Regs[200..300]`. Snapshot is `8 + (MaxYReg - 200)`
  elements; for the bench's category_ancestor that's ~18 elements
  vs the prior 108, cutting per-CP memmove ~6x.
- `restoreSavedRegs` reverses the copy AND clears
  `Regs[pushMaxY..vm.MaxYReg]` to nil — those slots were nil at
  push time by construction (MaxYReg is monotonic), so any value
  there came from the failed clause and must be undone. Without
  the clear, the failed clause's writes to "newly-touched"
  Y-regs would leak across backtrack boundaries.
- `Clone()` carries `MaxYReg` so the sub-VM in
  `executeAggregate` sees the same Y-reg high-water mark as the
  parent. Without this fix the sub-VM started at MaxYReg=0,
  snapshot omitted Y-regs, and backtrack inside the sub-VM lost
  values the failed clause overwrote — symptom was
  `Velocity Physics 1.602159` instead of the post-Phase-D
  `1.601079`.

Tried first: trail-based Y-reg restoration (per-write trail
entries, no per-CP snapshot). Hung the bench because
`trailBinding(i.Xn)` calls in GetVariable/UnifyVariable —
leftovers from when Idx==register-slot-index — leak Bindings
entries with addresses that overlap the Y-reg range, and
`bindUnbound`'s alias-rewrite loop doesn't trail Y-reg
overwrites. Reverted; the MaxYReg approach captures most of the
upside without the audit risk. The trail approach is documented
as a deferred follow-up in the perf log.

Measurements (scale-300, kernels_off, single-thread):

| Stage | scale-300/50 median (5 trials) | scale-300/full | speedup vs prior |
|---|---|---|---|
| Phase D (current main) | 5189ms | 88.7s | — |
| Phase E (this commit) | 3624ms | 38.4s | 1.43x / 2.31x |
| Cumulative (vs original ~340s) | — | — | **8.85x** |

Output identical to Phase D modulo the documented `max_depth(10)`
drift on Brownian_motion / Hermann_von_Helmholtz tie-break.

Doc: `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` gets a Phase E
entry covering the trail-based attempt that failed, the
MaxYReg-bounded approach that worked, the two bugs found and
fixed (post-push Y-reg clear, Clone-carries-MaxYReg), and the
updated cumulative measurement table.