### PR TITLE
feat(wam-clojure): lower simple builtins

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -225,6 +225,8 @@ lowered_direct_instr(get_nil(_)).
 lowered_direct_instr(unify_constant(_)).
 lowered_direct_instr(unify_variable(_)).
 lowered_direct_instr(unify_value(_)).
+lowered_direct_instr(builtin_call(Op, Arity)) :-
+    clojure_direct_builtin(Op, Arity).
 lowered_direct_instr(put_constant(_, _)).
 lowered_direct_instr(put_nil(_)).
 lowered_direct_instr(get_variable(_, _)).
@@ -236,6 +238,15 @@ lowered_direct_instr(put_list(_)).
 lowered_direct_instr(set_constant(_)).
 lowered_direct_instr(set_variable(_)).
 lowered_direct_instr(set_value(_)).
+
+clojure_direct_builtin("=/2", "2").
+clojure_direct_builtin("=/2", 2).
+clojure_direct_builtin('=/2', "2").
+clojure_direct_builtin('=/2', 2).
+clojure_direct_builtin("true/0", "0").
+clojure_direct_builtin("true/0", 0).
+clojure_direct_builtin('true/0', "0").
+clojure_direct_builtin('true/0', 0).
 
 emit_lowered_expr(proceed, S, Expr) :-
     format(atom(Expr), '(runtime/succeed-state ~w)', [S]).
@@ -274,6 +285,18 @@ emit_lowered_expr(unify_value(Xn), S, Expr) :-
     format(atom(Expr),
            '(let [[item next-state] (runtime/pop-unify-item ~w) reg-val (or (runtime/reg-get-raw next-state ~q) ::lowered-unbound) [ok bound-state] (runtime/unify-values next-state reg-val item)] (if ok (runtime/advance bound-state) (runtime/backtrack ~w)))',
            [S, Xn, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "=/2" ; Op == '=/2'),
+    !,
+    format(atom(Expr),
+           '(let [left (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound) right (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound) [ok next-state] (runtime/unify-values ~w left right)] (if ok (runtime/advance next-state) (runtime/backtrack ~w)))',
+           [S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "true/0" ; Op == 'true/0'),
+    !,
+    format(atom(Expr), '(runtime/advance ~w)', [S]).
 emit_lowered_expr(put_constant(C, Ai), S, Expr) :-
     clj_lowered_literal(C, Lit),
     format(atom(Expr),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -112,6 +112,33 @@ test(unify_value_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/unify-values")
     )).
 
+test(simple_builtin_equality_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_eq/2:\nbuiltin_call =/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_eq/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_eq/2, WamCode, [], Code),
+        has(Code, "runtime/reg-get-raw"),
+        has(Code, "\"A1\""),
+        has(Code, "\"A2\""),
+        has(Code, "runtime/unify-values")
+    )).
+
+test(simple_builtin_true_is_direct_lowered_in_prefix) :-
+    once((
+        lower_predicate_to_clojure(test_true/0, [builtin_call('true/0', 0), proceed], [], Code),
+        has(Code, "runtime/advance"),
+        has(Code, "runtime/succeed-state")
+    )).
+
+test(unsupported_builtin_stays_runtime_mediated) :-
+    once((
+        WamCode = "test_atom/1:\nbuiltin_call atom/1, 1\nproceed\n",
+        wam_clojure_lowerable(test_atom/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_atom/1, WamCode, [], Code),
+        assertion(\+ has(Code, "builtin-call atom/1")),
+        has(Code, "state")
+    )).
+
 test(structure_build_ops_are_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_build/1:\nput_structure f/2, A1\nset_constant a\nset_variable X1\nset_value X1\nproceed\n",


### PR DESCRIPTION
## Summary

Adds conservative direct-prefix lowering for the Clojure WAM lowered emitter’s simplest builtins:

- lowers `builtin_call =/2, 2`
- lowers `builtin_call true/0, 0`
- supports both parsed string IR and atom-form IR for those builtin names
- leaves `!/0` and unsupported builtins runtime-mediated
- adds focused lowered-emitter tests for supported and unsupported builtin paths

## Why

The Clojure lowered emitter now handles direct read/write structure/list prefixes and simple unify queue consumption. The next small deterministic gap is builtin handling. Clojure’s runtime currently supports only a very small builtin subset, so this PR only lowers the two safest pure/control-neutral cases:

- `=/2`, implemented through the same `runtime/unify-values` helper as the runtime interpreter path
- `true/0`, implemented as a simple `runtime/advance`

Cut (`!/0`) is intentionally not lowered here because it mutates choice-point state and should stay runtime-mediated until control-flow lowering is handled more deliberately.

## Validation

Passed locally:

```sh
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
git diff --check
```

