### PR TITLE
fix(wam-rust): complete no-kernel category ancestor fallback

### DIFF
--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -125,7 +125,9 @@ def scale_sort_key(scale: str) -> tuple[int, str]:
 def available_targets(requested: list[str]) -> list[str]:
     targets: list[str] = []
     rust_matrix_targets = {
+        "rust-pure-interp",
         "rust-interp-ffi",
+        "rust-lowered-only",
         "rust-lowered-ffi",
     }
     for target in requested:

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -618,8 +618,12 @@ def build_scale_independent_commands(root: Path, targets: list[str]) -> dict[str
             commands[target] = build_haskell_effective_distance(root, "functions", "kernels_off")
         elif target == "haskell-lowered-ffi":
             commands[target] = build_haskell_effective_distance(root, "functions", "kernels_on")
+        elif target == "rust-pure-interp":
+            commands[target] = build_rust_matrix_effective_distance(root, "interpreter", "kernels_off")
         elif target == "rust-interp-ffi":
             commands[target] = build_rust_matrix_effective_distance(root, "interpreter", "kernels_on")
+        elif target == "rust-lowered-only":
+            commands[target] = build_rust_matrix_effective_distance(root, "functions", "kernels_off")
         elif target == "rust-lowered-ffi":
             commands[target] = build_rust_matrix_effective_distance(root, "functions", "kernels_on")
     return commands

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -142,10 +142,20 @@ TARGETS: dict[str, TargetInfo] = {
         "optimized-prolog",
         "Optimized Prolog -> lowered Haskell functions with kernels enabled",
     ),
+    "rust-pure-interp": TargetInfo(
+        "rust-pure-interp",
+        "hybrid-wam",
+        "Optimized Prolog -> WAM Rust interpreter with no_kernels(true)",
+    ),
     "rust-interp-ffi": TargetInfo(
         "rust-interp-ffi",
         "hybrid-wam",
         "Optimized Prolog -> WAM Rust interpreter with kernels enabled",
+    ),
+    "rust-lowered-only": TargetInfo(
+        "rust-lowered-only",
+        "optimized-prolog",
+        "Optimized Prolog -> lowered Rust functions with no_kernels(true)",
     ),
     "rust-lowered-ffi": TargetInfo(
         "rust-lowered-ffi",
@@ -212,6 +222,7 @@ TARGET_SETS: dict[str, list[str]] = {
         "prolog-accumulated",
         "haskell-lowered-only",
         "haskell-lowered-ffi",
+        "rust-lowered-only",
         "rust-lowered-ffi",
     ],
     "hybrid-wam": [
@@ -229,7 +240,9 @@ TARGET_SETS: dict[str, list[str]] = {
         "haskell-interp-ffi",
         "haskell-lowered-only",
         "haskell-lowered-ffi",
+        "rust-pure-interp",
         "rust-interp-ffi",
+        "rust-lowered-only",
         "rust-lowered-ffi",
     ],
     "clojure-wam-scaffold": [],

--- a/examples/benchmark/generate_wam_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_effective_distance_benchmark.pl
@@ -584,6 +584,56 @@ fn optimize_benchmark_code(code: &mut Vec<Instruction>) {
                 continue;
             }
         }
+        if i + 10 < code.len() {
+            let replacement = match (
+                &code[i],
+                &code[i + 1],
+                &code[i + 2],
+                &code[i + 3],
+                &code[i + 4],
+                &code[i + 5],
+                &code[i + 6],
+                &code[i + 7],
+                &code[i + 8],
+                &code[i + 9],
+                &code[i + 10],
+            ) {
+                (
+                    Instruction::GetConstant(Value::Atom(raw), hops_reg),
+                    Instruction::GetVariable(visited_reg, visited_arg),
+                    Instruction::PutValue(cat_reg, a1),
+                    Instruction::PutValue(target_reg, a2),
+                    Instruction::Call(pred, 2),
+                    Instruction::Deallocate,
+                    Instruction::PutStructure(functor, a1b),
+                    Instruction::SetValue(target_reg2),
+                    Instruction::SetValue(visited_reg2),
+                    Instruction::BuiltinCall(op, 1),
+                    Instruction::Proceed,
+                ) if raw == "1"
+                    && visited_arg == "A4"
+                    && a1 == "A1"
+                    && a2 == "A2"
+                    && pred == "category_parent/2"
+                    && functor == "member/2"
+                    && a1b == "A1"
+                    && target_reg == target_reg2
+                    && visited_reg == visited_reg2
+                    && op == r"\\+/1" =>
+                    Some(Instruction::BaseCategoryAncestorBind(
+                        cat_reg.clone(),
+                        target_reg.clone(),
+                        hops_reg.clone(),
+                        visited_arg.clone(),
+                    )),
+                _ => None,
+            };
+            if let Some(instr) = replacement {
+                code[i] = instr;
+                i += 11;
+                continue;
+            }
+        }
         if i + 8 < code.len() {
             let replacement = match (
                 &code[i],
@@ -734,6 +784,15 @@ fn main() {
     let category_parents = load_tsv_pairs(&format!("{}/category_parent.tsv", facts_dir));
     let article_categories = load_tsv_pairs(&format!("{}/article_category.tsv", facts_dir));
     let roots = load_single_column(&format!("{}/root_categories.tsv", facts_dir));
+    let root = roots[0].clone();
+    let max_depth_limit = 10usize;
+    let reverse_category_parents = build_reverse_fact2(&category_parents);
+    let reachable_to_root = compute_reachable_to_root(&root, &reverse_category_parents, max_depth_limit);
+    let runtime_category_parents: Vec<(String, String)> = category_parents
+        .iter()
+        .filter(|(_, parent)| reachable_to_root.contains(parent))
+        .cloned()
+        .collect();
 
     let load_ms = start.elapsed().as_millis();
 
@@ -749,14 +808,14 @@ fn main() {
 ~w
 
     // --- Runtime fact predicates ---
-    append_fact2(&mut all_code, &mut all_labels, "category_parent", &category_parents);
+    append_fact2(&mut all_code, &mut all_labels, "category_parent", &runtime_category_parents);
     append_fact2(&mut all_code, &mut all_labels, "article_category", &article_categories);
     append_fact1(&mut all_code, &mut all_labels, "root_category", &roots);
     resolve_benchmark_targets(&mut all_code, &all_labels);
 
     // Create VM with merged code
     let mut vm = WamState::new(all_code, all_labels);
-    vm.register_indexed_atom_fact2("category_parent/2", build_indexed_fact2(&category_parents));
+    vm.register_indexed_atom_fact2("category_parent/2", build_indexed_fact2(&runtime_category_parents));
 
     // Build atom intern table and interned ffi_facts from indexed_atom_fact2
     for (_pred, table) in &vm.indexed_atom_fact2.clone() {
@@ -810,11 +869,7 @@ fn main() {
     }
     let seed_count = seed_cats.len();
 
-    let root = roots[0].clone();
-    let max_depth_limit = 10usize;
     setup_foreign_predicates(&mut vm);
-    let reverse_category_parents = build_reverse_fact2(&category_parents);
-    let reachable_to_root = compute_reachable_to_root(&root, &reverse_category_parents, max_depth_limit);
     let n: f64 = 5.0;
     let neg_n: f64 = -n;
     let mut hop_weights: Vec<f64> = Vec::with_capacity(max_depth_limit + 2);
@@ -901,7 +956,7 @@ fn main() {
                         false
                     }
                 } else {
-                    vm.backtrack()
+                    vm.backtrack() && vm.run()
                 };
                 if !succeeded {
                     break;

--- a/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
+++ b/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
@@ -158,6 +158,39 @@ fn build_indexed_fact2(pairs: &[(String, String)]) -> HashMap<String, Vec<String
     grouped
 }
 
+fn build_reverse_fact2(pairs: &[(String, String)]) -> HashMap<String, Vec<String>> {
+    let mut grouped: HashMap<String, Vec<String>> = HashMap::new();
+    for (child, parent) in pairs {
+        grouped.entry(parent.clone()).or_default().push(child.clone());
+    }
+    grouped
+}
+
+fn compute_reachable_to_root(root: &str, reverse_index: &HashMap<String, Vec<String>>, max_depth: usize) -> HashSet<String> {
+    use std::collections::VecDeque;
+    let mut reachable = HashSet::new();
+    let mut best_depth: HashMap<String, usize> = HashMap::new();
+    let mut queue: VecDeque<(String, usize)> = VecDeque::from([(root.to_string(), 0)]);
+    while let Some((current, depth)) = queue.pop_front() {
+        if let Some(prev) = best_depth.get(&current) {
+            if depth >= *prev {
+                continue;
+            }
+        }
+        best_depth.insert(current.clone(), depth);
+        reachable.insert(current.clone());
+        if depth >= max_depth {
+            continue;
+        }
+        if let Some(children) = reverse_index.get(&current) {
+            for child in children {
+                queue.push_back((child.clone(), depth + 1));
+            }
+        }
+    }
+    reachable
+}
+
 fn append_fact2(code: &mut Vec<Instruction>, labels: &mut HashMap<String, usize>, pred_name: &str, pairs: &[(String, String)]) {
     use std::collections::BTreeMap;
     if pairs.is_empty() {
@@ -232,6 +265,44 @@ fn optimize_benchmark_code(code: &mut Vec<Instruction>) {
             if let Some(instr) = replacement {
                 code[i] = instr;
                 i += 2;
+                continue;
+            }
+        }
+        if i + 10 < code.len() {
+            let replacement = match (&code[i], &code[i + 1], &code[i + 2], &code[i + 3], &code[i + 4], &code[i + 5], &code[i + 6], &code[i + 7], &code[i + 8], &code[i + 9], &code[i + 10]) {
+                (
+                    Instruction::GetConstant(Value::Atom(raw), hops_reg),
+                    Instruction::GetVariable(visited_reg, visited_arg),
+                    Instruction::PutValue(cat_reg, a1),
+                    Instruction::PutValue(target_reg, a2),
+                    Instruction::Call(pred, 2),
+                    Instruction::Deallocate,
+                    Instruction::PutStructure(functor, a1b),
+                    Instruction::SetValue(target_reg2),
+                    Instruction::SetValue(visited_reg2),
+                    Instruction::BuiltinCall(op, 1),
+                    Instruction::Proceed,
+                ) if raw == "1"
+                    && visited_arg == "A4"
+                    && a1 == "A1"
+                    && a2 == "A2"
+                    && pred == "category_parent/2"
+                    && functor == "member/2"
+                    && a1b == "A1"
+                    && target_reg == target_reg2
+                    && visited_reg == visited_reg2
+                    && op == r"\\+/1" =>
+                    Some(Instruction::BaseCategoryAncestorBind(
+                        cat_reg.clone(),
+                        target_reg.clone(),
+                        hops_reg.clone(),
+                        visited_arg.clone(),
+                    )),
+                _ => None,
+            };
+            if let Some(instr) = replacement {
+                code[i] = instr;
+                i += 11;
                 continue;
             }
         }
@@ -448,14 +519,23 @@ fn main() {
     let category_parents = load_tsv_pairs(edge_path);
     let article_categories = load_tsv_pairs(article_path);
     let roots = load_single_column(&root_path);
+    let root = roots.first().cloned().unwrap_or_default();
+    let max_depth_limit = 10usize;
+    let reverse_category_parents = build_reverse_fact2(&category_parents);
+    let reachable_to_root = compute_reachable_to_root(&root, &reverse_category_parents, max_depth_limit);
+    let runtime_category_parents: Vec<(String, String)> = category_parents
+        .iter()
+        .filter(|(_, parent)| reachable_to_root.contains(parent))
+        .cloned()
+        .collect();
     let load_ms = started.elapsed().as_millis();
 
     let (mut code, mut labels) = shared_wam_program();
-    append_fact2(&mut code, &mut labels, "category_parent", &category_parents);
+    append_fact2(&mut code, &mut labels, "category_parent", &runtime_category_parents);
     resolve_targets(&mut code, &labels);
 
     let mut vm = WamState::new(code, labels);
-    vm.register_indexed_atom_fact2("category_parent/2", build_indexed_fact2(&category_parents));
+    vm.register_indexed_atom_fact2("category_parent/2", build_indexed_fact2(&runtime_category_parents));
     for (_pred, table) in &vm.indexed_atom_fact2.clone() {
         for (key, vals) in table {
             vm.intern_atom(key);
@@ -499,7 +579,6 @@ fn main() {
     }
 
     let query_start = Instant::now();
-    let root = roots.first().cloned().unwrap_or_default();
     let n = 5.0f64;
     let inv_n = -1.0 / n;
     let step_limit = std::env::var("WAM_STEP_LIMIT")
@@ -523,7 +602,7 @@ fn main() {
                 cat_id,
                 root_id,
                 &visited_ids,
-                10,
+                max_depth_limit,
                 "category_parent",
                 &mut hops,
             );
@@ -549,7 +628,7 @@ fn main() {
                         false
                     }
                 } else {
-                    vm.backtrack()
+                    vm.backtrack() && vm.run()
                 };
                 if !succeeded {
                     break;

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -429,6 +429,62 @@ wam_instruction_arm('Instruction::BaseCategoryAncestor(cat_reg, target_reg, visi
                     false
                 }'.
 
+wam_instruction_arm('Instruction::BaseCategoryAncestorBind(cat_reg, target_reg, hops_reg, visited_reg)', Body) :-
+    Body = '                let cat = match self.get_reg(cat_reg) {
+                    Some(Value::Atom(s)) => s,
+                    Some(val) => match self.deref_var(&val) {
+                        Value::Atom(s) => s,
+                        _ => return false,
+                    },
+                    None => return false,
+                };
+                let target = match self.get_reg(target_reg) {
+                    Some(val) => self.deref_var(&val),
+                    None => return false,
+                };
+                let target_atom = match &target {
+                    Value::Atom(s) => s.clone(),
+                    _ => return false,
+                };
+                let visited = match self.get_reg(visited_reg) {
+                    Some(val) => self.deref_var(&val),
+                    None => return false,
+                };
+                let already_visited = match &visited {
+                    Value::List(items) => items.iter().any(|item| self.deref_var(item) == target),
+                    _ => false,
+                };
+                if already_visited {
+                    return false;
+                }
+                let parent_matches = self.indexed_atom_fact2
+                    .get("category_parent/2")
+                    .and_then(|table| table.get(&cat))
+                    .map(|values| values.iter().any(|parent| parent == &target_atom))
+                    .unwrap_or(false);
+                if !parent_matches {
+                    return false;
+                }
+                let hops_val = match self.get_reg(hops_reg) {
+                    Some(val) => val,
+                    None => return false,
+                };
+                match hops_val {
+                    Value::Unbound(var_name) => self.bind_var(&var_name, Value::Integer(1)),
+                    Value::Integer(1) => {},
+                    Value::Atom(ref raw) if raw == "1" => {},
+                    _ => return false,
+                }
+                if let Some(StackEntry::Env(old_cp, _)) = self.smut().pop() {
+                    self.cp = old_cp;
+                    let ret = self.cp;
+                    self.cp = 0;
+                    self.pc = ret;
+                    true
+                } else {
+                    false
+                }'.
+
 wam_instruction_arm('Instruction::RecurseCategoryAncestor(mid_reg, root_reg, child_hops_reg, visited_reg, pred, skip)', Body) :-
     Body = '                let Some(&target_pc) = self.labels.get(pred) else { return false; };
                 let instr = Instruction::RecurseCategoryAncestorPc(
@@ -509,8 +565,16 @@ wam_instruction_arm('Instruction::ReturnAdd1(out_reg, in_reg)', Body) :-
                     Some(val) => val,
                     None => return false,
                 };
-                if !self.unify(&out_val, &result) {
-                    return false;
+                match out_val {
+                    Value::Unbound(var_name) => self.bind_var(&var_name, result),
+                    Value::Integer(n) if result == Value::Integer(n) => {},
+                    Value::Float(f) if result == Value::Float(f) => {},
+                    Value::Atom(ref raw) if result == Value::Atom(raw.clone()) => {},
+                    other => {
+                        if !self.unify(&other, &result) {
+                            return false;
+                        }
+                    }
                 }
                 if let Some(StackEntry::Env(old_cp, _)) = self.smut().pop() {
                     self.cp = old_cp;

--- a/templates/targets/rust_wam/instructions.rs.mustache
+++ b/templates/targets/rust_wam/instructions.rs.mustache
@@ -52,6 +52,8 @@ pub enum Instruction {
     ListLengthLt(String, String, usize),
     /// Fused base clause for category_ancestor/4 using indexed parent existence.
     BaseCategoryAncestor(String, String, String),
+    /// Fused category_ancestor/4 base clause that also binds the hop register.
+    BaseCategoryAncestorBind(String, String, String, String),
     /// Fused benchmark recursive self-call setup for category_ancestor/4.
     RecurseCategoryAncestor(String, String, String, String, String, usize),
     /// Fused benchmark recursive self-call setup with a resolved target PC.

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -549,11 +549,8 @@ impl WamState {
     pub fn deref_heap(&self, val: &Value) -> Value {
         match val {
             Value::Unbound(name) => {
-                if let Some(v) = self.get_reg(name) {
-                    if let Value::Unbound(name2) = &v {
-                        if name2 == name { return val.clone(); }
-                    }
-                    return self.deref_heap(&v);
+                if let Some(v) = self.bindings.get(name) {
+                    return self.deref_heap(v);
                 }
                 val.clone()
             }
@@ -749,6 +746,13 @@ impl WamState {
                     args[0].clone(),
                     args[1].clone(),
                     args[2].clone(),
+                )),
+            "base_category_ancestor_bind" if args.len() == 4 =>
+                Some(Instruction::BaseCategoryAncestorBind(
+                    args[0].clone(),
+                    args[1].clone(),
+                    args[2].clone(),
+                    args[3].clone(),
                 )),
             "recurse_category_ancestor" if args.len() == 6 => {
                 let skip = args[5].parse::<usize>().ok()?;


### PR DESCRIPTION
  ## Summary

  Adds the missing Rust matrix no-kernel benchmark targets and fixes the WAM-Rust fallback path for
  `category_ancestor/4` so pure interpreter and lowered-without-kernels modes produce complete results.

  ## Changes

  - Expose `rust-pure-interp` and `rust-lowered-only` in the effective-distance matrix harness.
  - Fix WAM-Rust logical variable dereferencing so unbound Prolog variables are resolved through WAM bindings, not
  mistaken for registers.
  - Add a fused `BaseCategoryAncestorBind` instruction for the benchmark base clause path.
  - Fix no-kernel benchmark enumeration so restored alternatives are executed with `vm.run()`.
  - Apply reachable-to-root filtering to runtime category-parent facts in generated Rust benchmark code.

  ## Validation

  - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/
  benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
  - `swipl -q -s tests/test_wam_rust_target.pl`
  - `git diff --check`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 300 --targets prolog-accumulated,rust-
  pure-interp,rust-interp-ffi,rust-lowered-only,rust-lowered-ffi --repetitions 1`

  Scale `300` output matched across all targets with digest `70bbc9ffa4cf`.