### PR TITLE
bench(wam): report kernel pair deltas

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -295,6 +295,12 @@ The report is TSV with `family`, `mode`, `kernels_target`, and
 `no_kernels_target` columns. It currently covers registered Rust, Go, Clojure,
 and Haskell effective-distance WAM pairings.
 
+When both sides of a registered pair run for the same scale, the benchmark
+summary also emits a paired delta table with median timings, a
+`kernels_speedup_vs_no_kernels` ratio, and output/row-count match flags. A
+ratio above `1.0` means the kernel-enabled target was faster than its
+no-kernel counterpart for that pair.
+
 Artifact-vs-sidecar Clojure comparisons are available through the
 `clojure-wam-artifact` target set, which adds:
 

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -49,6 +49,7 @@ from benchmark_common import (
     run_command,
 )
 from benchmark_target_matrix import (
+    KERNEL_TARGET_PAIRS,
     TARGETS,
     default_target_set_name,
     list_kernel_pairs_text,
@@ -648,6 +649,40 @@ def print_summary(results: list[RunResult], baseline_target: str) -> None:
                 if result.target == baseline_target:
                     continue
                 print_speedup(scale, f"speedup_vs_{baseline_target}_{result.target}", baseline, result)
+    print_kernel_pair_deltas(results)
+
+
+def kernel_pair_delta_rows(scale: str, entries: list[RunResult]) -> list[str]:
+    by_target = {entry.target: entry for entry in entries}
+    rows: list[str] = []
+    for pair in KERNEL_TARGET_PAIRS:
+        kernels = by_target.get(pair.kernels_target)
+        no_kernels = by_target.get(pair.no_kernels_target)
+        if kernels is None or no_kernels is None:
+            continue
+        speedup = no_kernels.median / kernels.median if kernels.median > 0 else float("inf")
+        output_match = kernels.stdout_sha256 == no_kernels.stdout_sha256
+        rows_match = kernels.row_count == no_kernels.row_count
+        rows.append(
+            f"{scale}\t{pair.family}\t{pair.mode}\t{pair.kernels_target}\t"
+            f"{pair.no_kernels_target}\t{kernels.median:.3f}\t{no_kernels.median:.3f}\t"
+            f"{speedup:.3f}\t{str(output_match).lower()}\t{str(rows_match).lower()}"
+        )
+    return rows
+
+
+def print_kernel_pair_deltas(results: list[RunResult]) -> None:
+    rows: list[str] = []
+    for scale, entries in group_results_by_scale(results):
+        rows.extend(kernel_pair_delta_rows(scale, entries))
+    if not rows:
+        return
+    print(
+        "scale\tfamily\tmode\tkernels_target\tno_kernels_target\tkernels_median_s\t"
+        "no_kernels_median_s\tkernels_speedup_vs_no_kernels\toutput_match\trows_match"
+    )
+    for row in rows:
+        print(row)
 
 
 def resolve_requested_targets(args: argparse.Namespace) -> list[str]:

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -3,13 +3,21 @@ from __future__ import annotations
 
 import sys
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
 
-from benchmark_effective_distance_matrix import parse_args, resolve_requested_targets  # noqa: E402
+from benchmark_effective_distance_matrix import (  # noqa: E402
+    RunResult,
+    kernel_pair_delta_rows,
+    parse_args,
+    print_kernel_pair_deltas,
+    resolve_requested_targets,
+)
 from benchmark_target_matrix import (  # noqa: E402
     KERNEL_TARGET_PAIRS,
     TARGETS,
@@ -122,6 +130,76 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
             self.assertTrue(args.list_kernel_pairs)
         finally:
             sys.argv = original_argv
+
+    def test_kernel_pair_delta_rows_report_matching_pair(self) -> None:
+        rows = kernel_pair_delta_rows(
+            "dev",
+            [
+                RunResult(
+                    "wam-rust-accumulated",
+                    "dev",
+                    [1.0, 1.2, 1.1],
+                    "same",
+                    42,
+                    "",
+                ),
+                RunResult(
+                    "wam-rust-accumulated-no-kernels",
+                    "dev",
+                    [2.0, 2.2, 2.1],
+                    "same",
+                    42,
+                    "",
+                ),
+            ],
+        )
+
+        self.assertEqual(
+            rows,
+            [
+                "dev\trust\taccumulated\twam-rust-accumulated\t"
+                "wam-rust-accumulated-no-kernels\t1.100\t2.100\t1.909\ttrue\ttrue"
+            ],
+        )
+
+    def test_kernel_pair_delta_rows_skip_incomplete_pair(self) -> None:
+        rows = kernel_pair_delta_rows(
+            "dev",
+            [
+                RunResult(
+                    "wam-rust-accumulated",
+                    "dev",
+                    [1.0],
+                    "digest",
+                    42,
+                    "",
+                )
+            ],
+        )
+
+        self.assertEqual(rows, [])
+
+    def test_print_kernel_pair_deltas_emits_one_table_for_all_scales(self) -> None:
+        output = StringIO()
+        with redirect_stdout(output):
+            print_kernel_pair_deltas(
+                [
+                    RunResult("wam-rust-seeded", "dev", [1.0], "a", 10, ""),
+                    RunResult("wam-rust-seeded-no-kernels", "dev", [2.0], "a", 10, ""),
+                    RunResult("wam-rust-seeded", "10x", [3.0], "b", 20, ""),
+                    RunResult("wam-rust-seeded-no-kernels", "10x", [6.0], "c", 20, ""),
+                ]
+            )
+
+        lines = output.getvalue().strip().splitlines()
+        self.assertEqual(
+            lines[0],
+            "scale\tfamily\tmode\tkernels_target\tno_kernels_target\tkernels_median_s\t"
+            "no_kernels_median_s\tkernels_speedup_vs_no_kernels\toutput_match\trows_match",
+        )
+        self.assertEqual(len(lines), 3)
+        self.assertIn("dev\trust\tseeded\twam-rust-seeded\twam-rust-seeded-no-kernels", lines[1])
+        self.assertIn("10x\trust\tseeded\twam-rust-seeded\twam-rust-seeded-no-kernels", lines[2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary
  Add paired kernel/no-kernel delta reporting to the effective-distance benchmark matrix summary.

  ## What changed
  - Emits a paired delta table when both sides of a registered WAM kernel pair run for the same scale.
  - Reports kernel median time, no-kernel median time, speedup ratio, output digest match, and row-count match.
  - Adds synthetic unit coverage for complete pairs, incomplete pairs, and multi-scale table output.
  - Documents the new paired delta rows in the benchmark README.

  ## Verification
  - `python3 -m unittest tests/test_benchmark_target_matrix.py`
  - `git diff --check`

  ## Notes
  - A `kernels_speedup_vs_no_kernels` value above `1.0` means the kernel-enabled target was faster.
  - Untracked local benchmark/data artifacts were left out of the commit.