### PR TITLE
feat(wam-clojure): lower env prefix

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -215,6 +215,8 @@ lowered_direct_prefix([Instr|Rest], [Instr|PrefixRest]) :-
     lowered_direct_prefix(Rest, PrefixRest).
 lowered_direct_prefix(_, []).
 
+lowered_direct_instr(allocate).
+lowered_direct_instr(deallocate).
 lowered_direct_instr(proceed).
 lowered_direct_instr(fail).
 lowered_direct_instr(get_constant(_, _)).
@@ -252,6 +254,14 @@ emit_lowered_expr(proceed, S, Expr) :-
     format(atom(Expr), '(runtime/succeed-state ~w)', [S]).
 emit_lowered_expr(fail, S, Expr) :-
     format(atom(Expr), '(runtime/fail-state ~w)', [S]).
+emit_lowered_expr(allocate, S, Expr) :-
+    format(atom(Expr),
+           '(-> ~w (update :env-stack conj {}) (assoc :cut-bar (count (:choice-points ~w))) runtime/advance)',
+           [S, S]).
+emit_lowered_expr(deallocate, S, Expr) :-
+    format(atom(Expr),
+           '(-> ~w (update :env-stack #(if (seq %) (pop %) %)) runtime/advance)',
+           [S]).
 emit_lowered_expr(get_constant(C, Ai), S, Expr) :-
     clj_lowered_literal(C, Lit),
     format(atom(Expr),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -139,6 +139,17 @@ test(unsupported_builtin_stays_runtime_mediated) :-
         has(Code, "state")
     )).
 
+test(env_framed_equality_reaches_direct_builtin_prefix) :-
+    once((
+        WamCode = "test_env_eq/2:\nallocate\nput_value X1, A1\nput_value X2, A2\nbuiltin_call =/2, 2\ndeallocate\nproceed\n",
+        wam_clojure_lowerable(test_env_eq/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_env_eq/2, WamCode, [], Code),
+        has(Code, "update :env-stack conj {}"),
+        has(Code, "update :env-stack #(if (seq %) (pop %) %)"),
+        has(Code, "runtime/unify-values"),
+        has(Code, "runtime/succeed-state")
+    )).
+
 test(structure_build_ops_are_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_build/1:\nput_structure f/2, A1\nset_constant a\nset_variable X1\nset_value X1\nproceed\n",


### PR DESCRIPTION
## Summary

Adds direct-prefix lowering for Clojure WAM environment frame setup:

- lowers `allocate`
- lowers `deallocate`
- mirrors existing runtime state updates for `:env-stack` and `:cut-bar`
- adds lowered-emitter coverage proving env-framed equality can continue into direct `=/2` builtin lowering

## Why

Recent Clojure lowered-emitter PRs added direct lowering for structure/list read/write prefixes, simple unify queue consumption, and the safest builtins. However, realistic generated WAM predicates often begin with `allocate`, which stopped the direct prefix before reaching the newly lowered instructions.

This PR unblocks those deterministic env-framed prefixes without taking on calls, branching, cuts, or choice-point control flow.

## Safety Boundary

This remains intentionally narrow:

- `allocate` only pushes an empty env frame, sets `:cut-bar`, and advances
- `deallocate` only pops an env frame when present and advances
- `!/0`, choice points, calls, jumps, switches, and foreign calls remain runtime-mediated

## Validation

Passed locally:

```sh
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
git diff --check
```

