### PR TITLE
bench(wam): include rust matrix pairs

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -292,7 +292,8 @@ python3 examples/benchmark/benchmark_effective_distance_matrix.py --list-kernel-
 ```
 
 The report is TSV with `family`, `mode`, `kernels_target`, and
-`no_kernels_target` columns. It currently covers registered Rust, Go, Clojure,
+`no_kernels_target` columns. It currently covers registered Rust
+seeded/accumulated and Rust interpreter/lowered pairings, plus Go, Clojure,
 and Haskell effective-distance WAM pairings.
 
 When both sides of a registered pair run for the same scale, the benchmark

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -179,6 +179,18 @@ KERNEL_TARGET_PAIRS: tuple[KernelPairInfo, ...] = (
         "wam-rust-accumulated-no-kernels",
     ),
     KernelPairInfo(
+        "rust",
+        "interpreter",
+        "rust-interp-ffi",
+        "rust-pure-interp",
+    ),
+    KernelPairInfo(
+        "rust",
+        "lowered",
+        "rust-lowered-ffi",
+        "rust-lowered-only",
+    ),
+    KernelPairInfo(
         "go",
         "accumulated",
         "go-wam-accumulated",

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -94,6 +94,8 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         expected = {
             ("rust", "seeded"),
             ("rust", "accumulated"),
+            ("rust", "interpreter"),
+            ("rust", "lowered"),
             ("go", "accumulated"),
             ("clojure", "seeded"),
             ("clojure", "accumulated"),
@@ -112,6 +114,10 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         self.assertTrue(text.startswith("family\tmode\tkernels_target\tno_kernels_target\n"))
         self.assertIn(
             "rust\taccumulated\twam-rust-accumulated\twam-rust-accumulated-no-kernels",
+            text,
+        )
+        self.assertIn(
+            "rust\tlowered\trust-lowered-ffi\trust-lowered-only",
             text,
         )
         self.assertIn(


### PR DESCRIPTION
  ## Summary
  Complete the WAM kernel/no-kernel pair registry for already-registered Rust matrix benchmark targets.

  ## What changed
  - Added Rust interpreter pair coverage: `rust-interp-ffi` vs `rust-pure-interp`.
  - Added Rust lowered pair coverage: `rust-lowered-ffi` vs `rust-lowered-only`.
  - Updated the kernel pair listing tests to expect the new Rust matrix pair rows.
  - Clarified the README wording for Rust seeded/accumulated and interpreter/lowered pair coverage.

  ## Verification
  - `python3 -m unittest tests/test_benchmark_target_matrix.py`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --list-kernel-pairs`
  - `git diff --check`

  ## Notes
  - This does not add Scala to the matrix yet. Scala still needs a result-producing effective-distance runner before it
  can safely join the paired delta report.
  - Untracked local benchmark/data artifacts were left out of the commit.