### PR TITLE
test(wam-clojure): assert lowered env smoke

### DIFF
--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -129,6 +129,7 @@ run_smoke :-
         ],
         TmpDir),
     assert_lowered_read_unify_prefix_emitted(TmpDir),
+    assert_lowered_env_prefix_emitted(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
     verify_output(TmpDir, 'wam_call_caller/1', 'a', "true"),
@@ -192,6 +193,16 @@ assert_lowered_read_unify_prefix_emitted(ProjectDir) :-
     has(CoreCode, "runtime/enter-unify-mode"),
     has(CoreCode, "runtime/pop-unify-item"),
     has(CoreCode, "runtime/unify-values").
+
+assert_lowered_env_prefix_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-env1-1"),
+    has(CoreCode, "update :env-stack conj {}"),
+    has(CoreCode, "assoc :cut-bar"),
+    has(CoreCode, "update :env-stack #(if (seq %) (pop %) %)"),
+    has(CoreCode, "runtime/unify-values"),
+    has(CoreCode, "runtime/succeed-state").
 
 verify_output(ProjectDir, PredKey, Arg, Expected) :-
     run_clojure_predicate(ProjectDir, PredKey, Arg, Actual),


### PR DESCRIPTION
## Summary

Adds generated-runtime smoke coverage for the Clojure lowered WAM env-prefix path.

The smoke test now verifies that `wam_env1/1` emits the lowered `lowered-wam-env1-1` function and includes direct env-frame setup/teardown plus equality unification in the generated Clojure runtime.

## Why

Recent Clojure lowered-WAM work added direct lowering for env-frame instructions such as `allocate` and `deallocate`, alongside direct equality handling. The existing runtime smoke exercised behavior, but did not explicitly assert that the generated code was using the lowered env path rather than silently falling back to runtime-mediated instruction dispatch.

This PR locks in that generated-code contract.

## Changes

- Extends `tests/test_wam_clojure_runtime_smoke.pl` with a lowered env-prefix assertion.
- Checks generated `core.clj` for:
  - `defn lowered-wam-env1-1`
  - env stack push via `update :env-stack conj {}`
  - `:cut-bar` setup
  - env stack pop on deallocate
  - direct `runtime/unify-values`
  - direct `runtime/succeed-state`

## Validation

Passed locally on Termux:

```sh
swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
git diff --check
```

## Notes

This is a focused test-only PR. It does not change Clojure WAM generation semantics.
