### PR TITLE
test(wam-clojure): document call execute boundary

### DIFF
--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -150,6 +150,31 @@ test(env_framed_equality_reaches_direct_builtin_prefix) :-
         has(Code, "runtime/succeed-state")
     )).
 
+test(execute_stays_runtime_mediated_after_lowered_prefix) :-
+    once((
+        WamCode = "test_exec/1:\nallocate\ndeallocate\nexecute test_fact/1\n",
+        wam_clojure_lowerable(test_exec/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_exec/1, WamCode, [], Code),
+        has(Code, "update :env-stack conj {}"),
+        has(Code, "update :env-stack #(if (seq %) (pop %) %)"),
+        assertion(\+ has(Code, "execute test_fact/1")),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
+test(call_stays_runtime_mediated_after_lowered_prefix) :-
+    once((
+        WamCode = "test_call/1:\nallocate\nget_variable Y1, A1\nput_value Y1, A1\ncall test_fact/1, 1\ndeallocate\nproceed\n",
+        wam_clojure_lowerable(test_call/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_call/1, WamCode, [], Code),
+        has(Code, "update :env-stack conj {}"),
+        has(Code, "get-variable Y1, A1"),
+        has(Code, "put-value Y1, A1"),
+        assertion(\+ has(Code, "call test_fact/1")),
+        assertion(\+ has(Code, "update :env-stack #(if (seq %) (pop %) %)")),
+        assertion(\+ has(Code, "runtime/succeed-state")),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(structure_build_ops_are_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_build/1:\nput_structure f/2, A1\nset_constant a\nset_variable X1\nset_value X1\nproceed\n",


### PR DESCRIPTION
## Summary

Adds focused lowered-emitter tests that document the current Clojure lowered-WAM boundary for `call/2` and `execute/1`.

The tests assert that safe prefix instructions before control transfer are directly lowered, while `call/2` and `execute/1` themselves remain runtime-mediated for now.

## Why

The Clojure lowered emitter now directly lowers a broad prefix of safe WAM instructions, including register moves, structure/list read and write paths, simple builtins, and env-frame setup/teardown. Control transfer is the next important boundary.

Before implementing direct lowering for `execute/1` or `call/2`, this PR records the current contract:

- Prefix instructions before control transfer may be lowered.
- The control-transfer instruction itself is not emitted directly yet.
- Instructions after a `call/2` are not accidentally pulled into the pre-call lowered prefix.
- The lowered function should stop cleanly at the boundary rather than emitting a generic `runtime/step`.

## Changes

- Adds `execute_stays_runtime_mediated_after_lowered_prefix`.
- Adds `call_stays_runtime_mediated_after_lowered_prefix`.
- Keeps the PR test-only; no emitter semantics are changed.

## Validation

Passed locally on Termux:

```sh
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
git diff --check
```

## Follow-Up

The next implementation PR should lower `execute/1` first, if the generated wrapper can safely hand off to the target lowered function or preserve the existing `runtime/run-wam` PC semantics. Full `call/2` lowering should remain separate because it has continuation and post-call suffix semantics.
