### PR TITLE
Add category_ancestor FFI kernel for Go target

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -540,6 +540,121 @@ line at >25% of CPU after the next round of structural wins.
 Cumulative position is unchanged from Phase H; Phase J is a no-op
 on the cumulative table below.
 
+### Phase K: `category_ancestor` FFI kernel for Go (May 2026, `feat/wam-go-category-ancestor-kernel`)
+
+After Phases I and J both bottomed out at the variance floor, the
+honest read was that constant-factor work on the WAM dispatch was
+exhausted. The post-survey verdict (see the cross-target lowering
+audit in this branch's commit description) was that the next big
+multiplicative win would come from **fewer WAM dispatches entirely**,
+not making each dispatch faster — i.e. lowering more predicates to
+native Go via the FFI-kernel system that already powered
+`transitive_closure2`, `weighted_shortest_path3`, and the
+`astar_shortest_path4` family.
+
+The single missing kernel — and the one that drove the entire
+`effective_distance` benchmark family the prior 12 phases had been
+optimising for — was `category_ancestor/4`. Both Haskell and Rust
+already had it; Go fell through to full WAM bytecode for the
+inner ancestor walk on every depth-bounded recursive step.
+
+Implementation (mirrors `wam_rust_target.pl:1797`):
+
+1. **Pl-side dispatch** — three new clauses in `wam_go_target.pl`:
+   - `go_supported_shared_kernel(recursive_kernel(category_ancestor, _, _))`
+     — accept the kernel from the shared detector.
+   - `go_recursive_kernel_with_facts/3` clause that pulls
+     `max_depth(N)` and `edge_pred(EP/2)` out of the detector's
+     config and indexes the parent-edge facts via
+     `go_binary_edge_fact_pairs/3`.
+   - `go_recursive_kernel_config_ops/3` clause that emits both
+     `register_foreign_usize_config(.., max_depth, N)` and
+     `register_foreign_string_config(.., edge_pred, ..)` plus
+     `register_indexed_atom_fact2(EP/2, Pairs)`.
+   The shared `kernel_metadata/4` (`recursive_kernel_detection.pl:61`)
+   already had the right `NativeKind=category_ancestor`,
+   `ResultLayout=tuple(1)`, `ResultMode=stream` mappings; no
+   metadata work needed.
+
+2. **Generated runtime** — three new functions emitted from the
+   `compile_wam_helpers_to_go` Prolog format string:
+   - `listAsAtomStrings(vm, v)` — derefs a Prolog cons list and
+     extracts each element as an atom string. Note: uses
+     `vm.listToSlice` (the iterative cons-walker added in Phase H),
+     not `listAsSlice` — the latter returns the 2-element
+     `[head, tail]` cell of the *outer* List, which would silently
+     truncate the visited set.
+   - `collectNativeCategoryAncestorHops(cat, root, visited, maxDepth, pairs)`
+     — top-level entry that builds the parent-edge adjacency map
+     from the indexed atom-fact pairs once, then delegates to:
+   - `collectNativeCategoryAncestorHopsRec(...)` — the recursive
+     DFS, mirroring the Rust implementation byte-for-byte. Emits
+     one `int64` hop count per matching path, with the +1 increment
+     applied to the slice tail produced by each recursive call (so
+     that hop counts compose correctly on the way back up).
+
+3. **Dispatch case** — new `case "category_ancestor":` in
+   `executeForeignPredicate`. Pulls `cat`/`root` from A1/A2 as
+   atom strings, `visited` from A4 as a flattened atom-string
+   list, `maxDepth` from the foreign-usize config, edge-pred
+   adjacency from the indexed fact map. Calls the helper, packs
+   the int64 hops as `&Integer{Val: h}` Values, and finishes via
+   `finishForeignResults(predKey, []int{2}, results)` (output reg
+   is A3 = reg index 2; layout is `tuple(1)` = no tuple wrapping).
+
+#### Wall-clock impact at scale-300/full
+
+Three alternating trials (A/B; both binaries built from the
+current branch with `kernels_on`):
+
+| trial | h-fresh (Phase H baseline) | cancestor (Phase K) | speedup |
+|---|---|---|---|
+| 1 | 25219ms | 504ms | 50.0x |
+| 2 | 24171ms | 443ms | 54.6x |
+| 3 | 24139ms | 451ms | 53.5x |
+| **mean** | **24510ms** | **466ms** | **52.6x** |
+
+Cumulative vs the ~340s Phase A baseline: **~730x**. The 12.8×
+constant-factor work from Phases B–H was a prerequisite — it
+defanged everything *outside* the inner ancestor walk so that
+when the kernel removed that walk's WAM-dispatch cost, the
+remaining time is dominated by argument marshalling and result
+unification rather than by the dispatcher itself.
+
+#### Correctness — better than Phase H
+
+Output diff vs `data/benchmark/300/reference_output.tsv`: only 4
+lines, all stable-sort tie-break ordering between articles with
+identical effective-distance values (`Hermann_von_Helmholtz` /
+`Walter_Noll`-cluster). Phase H had 11+ lines of diff including
+*wrong values* (Brownian_motion 0.993865 vs reference 0.993717;
+2008_in_science 4.372980 vs reference 3.726584). The native
+kernel fixes those by computing the depth-bounded ancestor walk
+directly in Go instead of through the WAM bytecode path that had
+some subtle interaction with the bench's `\+ member(M, Visited)`
+guards. The reference tie-break ordering (where it differs from
+the kernel) is `data/benchmark/300/reference_output.tsv`-internal
+and not part of the algorithm — the kernel is correct, the diff
+is cosmetic.
+
+#### Why this worked when Phases I/J didn't
+
+- Phases I/J reshuffled dispatch *inside* the WAM interpreter
+  (where the Go compiler already did a good job) — net cost was
+  inlining loss and noise.
+- Phase K removes whole categories of WAM dispatches entirely.
+  The inner ancestor walk previously executed dozens of WAM
+  instructions per parent edge (Allocate, Get*/Put*, Call,
+  Deallocate, …); now it's a single Go function call from the
+  outer aggregator. The work that's removed isn't 10–25% of CPU
+  in any one bytecode op — it's *all of it* for the inner loop.
+
+This is the structural-vs-constant-factor lesson from the
+Lessons section made concrete: a structural change that removes
+work composes multiplicatively with prior structural wins; a
+constant-factor reshuffle inside compiler-optimised dispatch
+fights the compiler.
+
 ### Cumulative measurement (scale-300, kernels_off, single-thread)
 
 50-seed: median of 5 alternating trials. Full bench: median of 3
@@ -559,6 +674,7 @@ were outliers — this section uses re-measured medians).
 | Phase H list-builtin micro-opts | 2534ms | ~27.4s | 1.0x / ~1.0x | 13.4x / ~12.4x |
 | Phase I (reverted attempts; doc-only) | — | — | 1.0x | 13.4x / ~12.4x |
 | Phase J tag-table dispatch (reverted) | — | ~37s vs h-fresh ~33s | **0.89x** (regression) | doc-only |
+| **Phase K `category_ancestor` FFI kernel** | — | **466ms** (mean of 3) | **52.6x** | **~730x** |
 
 Output identical to prior at every stage except for the documented
 `max_depth(10)` drift on Brownian_motion / Hermann_von_Helmholtz

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -720,12 +720,24 @@ go_supported_shared_kernel(recursive_kernel(transitive_closure2, _, _)).
 go_supported_shared_kernel(recursive_kernel(transitive_distance3, _, _)).
 go_supported_shared_kernel(recursive_kernel(transitive_parent_distance4, _, _)).
 go_supported_shared_kernel(recursive_kernel(transitive_step_parent_distance5, _, _)).
+go_supported_shared_kernel(recursive_kernel(category_ancestor, _, _)).
 go_recursive_kernel_with_facts(Module,
         recursive_kernel(KernelKind, PredIndicator, KernelConfig0),
         recursive_kernel(KernelKind, PredIndicator,
             [edge_pred(EdgePred/2), fact_pairs(FactPairs)])) :-
     member(KernelKind, [transitive_closure2, transitive_distance3,
         transitive_parent_distance4, transitive_step_parent_distance5]),
+    member(edge_pred(EdgePred/2), KernelConfig0),
+    go_binary_edge_fact_pairs(Module, EdgePred/2, FactPairs),
+    FactPairs \= [].
+% category_ancestor carries a max_depth bound in addition to the
+% edge predicate; preserve it so the runtime can stop the recursion
+% at the user-specified depth.
+go_recursive_kernel_with_facts(Module,
+        recursive_kernel(category_ancestor, PredIndicator, KernelConfig0),
+        recursive_kernel(category_ancestor, PredIndicator,
+            [max_depth(MaxDepth), edge_pred(EdgePred/2), fact_pairs(FactPairs)])) :-
+    member(max_depth(MaxDepth), KernelConfig0),
     member(edge_pred(EdgePred/2), KernelConfig0),
     go_binary_edge_fact_pairs(Module, EdgePred/2, FactPairs),
     FactPairs \= [].
@@ -752,6 +764,15 @@ go_recursive_kernel_metadata(KernelKind, KernelConfig, NativeKind, ResultLayout,
 
 go_recursive_kernel_config_ops(_PredIndicator, [], []).
 go_recursive_kernel_config_ops(PredIndicator, [edge_pred(EdgePred/2), fact_pairs(FactPairs)], [
+        register_foreign_string_config(PredIndicator, edge_pred, EdgePred/2),
+        register_indexed_atom_fact2(EdgePred/2, FactPairs)
+    ]).
+% category_ancestor's depth-bounded edge walk needs both the edge-
+% pred adjacency and the user-specified max_depth so the runtime can
+% match the WAM-bytecode semantics exactly.
+go_recursive_kernel_config_ops(PredIndicator,
+        [max_depth(MaxDepth), edge_pred(EdgePred/2), fact_pairs(FactPairs)], [
+        register_foreign_usize_config(PredIndicator, max_depth, MaxDepth),
         register_foreign_string_config(PredIndicator, edge_pred, EdgePred/2),
         register_indexed_atom_fact2(EdgePred/2, FactPairs)
     ]).
@@ -2568,6 +2589,84 @@ func (vm *WamState) collectNativeAstarShortestPathResult(source string, target s
     return nil
 }
 
+// listAsAtomStrings walks a Prolog cons-list and pulls each element
+// out as an atom string. Uses vm.listToSlice rather than listAsSlice
+// because the latter returns the 2-element [head, tail] cons cell,
+// not the full flattened list — `category_ancestor`''s visited list
+// can be many cells deep, and reading just the first cons would
+// silently truncate it (causing the kernel to walk paths through
+// already-visited nodes and produce wrong hop counts).
+func listAsAtomStrings(vm *WamState, v Value) ([]string, bool) {
+    items, ok := vm.listToSlice(v)
+    if !ok {
+        return nil, false
+    }
+    out := make([]string, 0, len(items))
+    for _, item := range items {
+        s, ok := valueAsAtomString(vm, item)
+        if !ok {
+            return nil, false
+        }
+        out = append(out, s)
+    }
+    return out, true
+}
+
+// collectNativeCategoryAncestorHops walks the parent edges of `cat`
+// looking for `root`, emitting one hop count per matching path. Mirrors
+// the Rust implementation at wam_rust_target.pl:1797 — same DFS, same
+// max-depth semantics, same visited-set skip. The adjacency map is
+// built once at the top level and threaded into the recursive helper
+// to avoid rebuilding it per call.
+func (vm *WamState) collectNativeCategoryAncestorHops(cat string, root string, visited []string, maxDepth int, pairs []AtomPair) []int64 {
+    adjacency := atomAdjacency(pairs)
+    var out []int64
+    vm.collectNativeCategoryAncestorHopsRec(cat, root, visited, maxDepth, adjacency, &out)
+    return out
+}
+
+func (vm *WamState) collectNativeCategoryAncestorHopsRec(cat string, root string, visited []string, maxDepth int, adjacency map[string][]string, out *[]int64) {
+    rootSeen := false
+    for _, v := range visited {
+        if v == root {
+            rootSeen = true
+            break
+        }
+    }
+    parents := adjacency[cat]
+    if !rootSeen {
+        for _, p := range parents {
+            if p == root {
+                *out = append(*out, 1)
+                break
+            }
+        }
+    }
+    if len(visited) >= maxDepth {
+        return
+    }
+    for _, parent := range parents {
+        skip := false
+        for _, v := range visited {
+            if v == parent {
+                skip = true
+                break
+            }
+        }
+        if skip {
+            continue
+        }
+        nextVisited := make([]string, 0, len(visited)+1)
+        nextVisited = append(nextVisited, parent)
+        nextVisited = append(nextVisited, visited...)
+        before := len(*out)
+        vm.collectNativeCategoryAncestorHopsRec(parent, root, nextVisited, maxDepth, adjacency, out)
+        for i := before; i < len(*out); i++ {
+            (*out)[i] += 1
+        }
+    }
+}
+
 func (vm *WamState) executeForeignPredicate(pred string, arity int) bool {
     predKey := fmt.Sprintf("%s/%d", pred, arity)
     nativeKind, ok := vm.Ctx.ForeignNativeKinds[predKey]
@@ -2638,6 +2737,38 @@ func (vm *WamState) executeForeignPredicate(pred string, arity int) bool {
         pairs := vm.Ctx.IndexedAtomFactPairs[edgePred]
         results := vm.collectNativeTransitiveStepParentDistanceResults(source, pairs)
         return vm.finishForeignResults(predKey, []int{1, 2, 3, 4}, results)
+    case "category_ancestor":
+        // category_ancestor(Cat, Root, Hops, Visited) — output is Hops
+        // (A3, reg index 2). Cat=A1, Root=A2, Visited=A4. The WAM
+        // semantics: walk parents of Cat up to max_depth hops; emit one
+        // integer hop count per path that reaches Root, skipping any
+        // node already in Visited. See
+        // src/unifyweaver/core/recursive_kernel_detection.pl:135 for the
+        // canonical register layout and call spec.
+        cat, ok := valueAsAtomString(vm, vm.getReg(0))
+        if !ok {
+            return false
+        }
+        root, ok := valueAsAtomString(vm, vm.getReg(1))
+        if !ok {
+            return false
+        }
+        visited, ok := listAsAtomStrings(vm, vm.getReg(3))
+        if !ok {
+            return false
+        }
+        maxDepth := vm.foreignUsizeConfig(predKey, "max_depth")
+        edgePred := vm.foreignStringConfig(predKey, "edge_pred")
+        pairs := vm.Ctx.IndexedAtomFactPairs[edgePred]
+        hops := vm.collectNativeCategoryAncestorHops(cat, root, visited, maxDepth, pairs)
+        if len(hops) == 0 {
+            return false
+        }
+        results := make([]Value, len(hops))
+        for i, h := range hops {
+            results[i] = &Integer{Val: h}
+        }
+        return vm.finishForeignResults(predKey, []int{2}, results)
     case "weighted_shortest_path3":
         source, ok := valueAsAtomString(vm, vm.getReg(0))
         if !ok {


### PR DESCRIPTION
## Summary

Implements the `category_ancestor/4` foreign function interface (FFI) kernel for the Go WAM target, mirroring the existing Rust implementation. This kernel performs depth-bounded ancestor walks in native Go code rather than through WAM bytecode dispatch, delivering a 52.6x speedup on the effective_distance benchmark family.

## Key Changes

**Prolog-side kernel registration** (`wam_go_target.pl`):
- Added `go_supported_shared_kernel/1` clause to accept `category_ancestor` kernels from the shared detector
- Added `go_recursive_kernel_with_facts/3` clause that extracts `max_depth` and `edge_pred` configuration and indexes parent-edge facts
- Added `go_recursive_kernel_config_ops/3` clause that registers both the `max_depth` usize config and `edge_pred` string config with the runtime

**Go runtime implementation** (`wam_go_target.pl`):
- `listAsAtomStrings()` — converts a Prolog cons-list to a flattened Go string slice, using `vm.listToSlice` to avoid truncating deep visited lists
- `collectNativeCategoryAncestorHops()` — top-level entry point that builds the parent-edge adjacency map once and delegates to the recursive helper
- `collectNativeCategoryAncestorHopsRec()` — depth-first search that walks parent edges up to `maxDepth`, skipping visited nodes, and emits one hop count per path reaching the root
- New `case "category_ancestor":` in `executeForeignPredicate()` that marshals arguments from WAM registers, calls the helper, and returns results

## Implementation Details

- The recursive DFS mirrors the Rust implementation byte-for-byte, including the max-depth semantics and visited-set skip logic
- Hop counts are incremented on the way back up the recursion stack so they compose correctly across multiple paths
- Uses `vm.listToSlice` rather than `listAsSlice` to properly handle the full visited list (the latter would only read the outer cons cell)
- Output register is A3 (reg index 2) with `tuple(1)` layout (no tuple wrapping)

## Performance Impact

Wall-clock improvement at scale-300/full benchmark (mean of 3 trials):
- Phase H baseline: 24,510ms
- Phase K with kernel: 466ms
- **Speedup: 52.6x**
- Cumulative vs Phase A baseline: ~730x

Correctness improved over Phase H: fixes subtle WAM bytecode interactions with `\+ member(M, Visited)` guards that were producing incorrect values in some cases.

https://claude.ai/code/session_011PV3jh3d3tmL2qD3WhWaSF