### PR TITLE
fix(wam-haskell): build matrix targets with IntSet values

### DIFF
--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -641,6 +641,9 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
         started = time.perf_counter()
         if target.startswith("prolog-") or target.startswith("wam-") or target.startswith("clojure-wam-"):
             result = run_command(command, cwd=ROOT)
+        elif target.startswith("haskell-"):
+            scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
+            result = run_command(command + [str(scale_dir)], cwd=ROOT)
         else:
             scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
             edge_path = scale_dir / "category_parent.tsv"

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2670,15 +2670,17 @@ apply_hashmap_rewrite(true, Module, Code0, Code) :-
     % HashMap has no toAscList — use toList instead (loses ordering, but
     % the only use site builds a SwitchOnConstant which doesn''t need it)
     replace_substr(Code2, "Map.toAscList", "Map.toList", Code3),
-    % For WamTypes, add Hashable instance for Value (needed for HashMap keys)
+    % For WamTypes, add a Hashable instance for Value (needed for HashMap keys).
+    % IntSet does not have a Hashable instance in the older dependency set
+    % used by the local Cabal build, so hash VSet through its stable list form.
     (   Module == types
     ->  replace_substr(Code3,
             "module WamTypes where\n\nimport qualified Data.HashMap.Strict as Map",
-            "{-# LANGUAGE DeriveGeneric #-}\nmodule WamTypes where\n\nimport qualified Data.HashMap.Strict as Map\nimport Data.Hashable (Hashable)\nimport GHC.Generics (Generic)",
+            "module WamTypes where\n\nimport qualified Data.HashMap.Strict as Map\nimport Data.Hashable (Hashable(..))",
             Code4),
         replace_substr(Code4,
             "deriving (Eq, Ord, Show)",
-            "deriving (Eq, Ord, Show, Generic)\ninstance Hashable Value",
+            "deriving (Eq, Ord, Show)\n\ninstance Hashable Value where\n  hashWithSalt salt (Atom n) = hashWithSalt salt (0 :: Int, n)\n  hashWithSalt salt (Integer n) = hashWithSalt salt (1 :: Int, n)\n  hashWithSalt salt (Float f) = hashWithSalt salt (2 :: Int, f)\n  hashWithSalt salt (VList xs) = hashWithSalt salt (3 :: Int, xs)\n  hashWithSalt salt (VSet s) = hashWithSalt salt (4 :: Int, IS.toList s)\n  hashWithSalt salt (Str n args) = hashWithSalt salt (5 :: Int, n, args)\n  hashWithSalt salt (Unbound n) = hashWithSalt salt (6 :: Int, n)\n  hashWithSalt salt (Ref n) = hashWithSalt salt (7 :: Int, n)",
             Code)
     ;   Code = Code3
     ).

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -333,6 +333,19 @@ test_haskell_value_nfdata_instance :-
     ;   fail_test(Test, 'NFData Value instance missing')
     ).
 
+test_haskell_hashable_value_handles_intset :-
+    Test = 'WAM-Haskell: HashMap rewrite hashes VSet IntSet explicitly',
+    (   wam_haskell_target:generate_wam_types_hs(TypesCode),
+        wam_haskell_target:apply_hashmap_rewrite(true, types, TypesCode, HashCode),
+        atom_string(HashCode, S),
+        sub_string(S, _, _, _, "import Data.Hashable (Hashable(..))"),
+        sub_string(S, _, _, _, "instance Hashable Value where"),
+        sub_string(S, _, _, _, "hashWithSalt salt (VSet s) = hashWithSalt salt (4 :: Int, IS.toList s)"),
+        \+ sub_string(S, _, _, _, "deriving (Eq, Ord, Show, Generic)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Hashable Value still relies on derived Generic or misses VSet handling')
+    ).
+
 test_haskell_fork_min_branches_threshold :-
     Test = 'WAM-Haskell: forkMinBranches threshold emitted in runtime',
     (   compile_wam_runtime_to_haskell([], [], Code),
@@ -1760,6 +1773,7 @@ run_tests :-
     test_haskell_agg_frame_has_merge_strategy,
     test_haskell_infer_merge_strategy,
     test_haskell_value_nfdata_instance,
+    test_haskell_hashable_value_handles_intset,
     test_haskell_fork_min_branches_threshold,
     test_haskell_fork_helpers_present,
     test_haskell_partryme_else_delegates_to_fork,


### PR DESCRIPTION
  ## Summary

  Fixes the Haskell WAM effective-distance matrix targets so they build and run correctly in both kernel and no-kernel
  modes.

  ## Changes

  - Route `haskell-*` matrix targets with a scale directory argument instead of separate TSV file paths.
  - Replace derived `Hashable Value` generation with an explicit instance.
  - Hash `VSet IntSet` through `IS.toList`, avoiding dependency on a `Hashable IntSet` instance.
  - Add a regression test covering the generated `Hashable Value` instance for `VSet`.

  ## Validation

  - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/
  benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
  - `swipl -q -s tests/test_wam_haskell_target.pl`
  - `git diff --check`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 300 --targets prolog-accumulated,rust-
  pure-interp,rust-interp-ffi,rust-lowered-only,rust-lowered-ffi,haskell-pure-interp,haskell-interp-ffi,haskell-lowered-
  only,haskell-lowered-ffi --repetitions 1`

  Scale `300` matched across all targets with digest `70bbc9ffa4cf`.