### PR TITLE
feat(wam-scala): add effective-distance generator

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -274,6 +274,20 @@ The generated project supports two entry modes:
 Larger Clojure benchmark runs should stay configurable because JVM startup and
 memory behavior are noisy in constrained Termux environments.
 
+Scala has a separate effective-distance project generator:
+
+```bash
+swipl -q -s examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl -- \
+  data/benchmark/dev/facts.pl /tmp/wam-scala-effective-distance accumulated kernels_on
+```
+
+It emits a Scala WAM project plus an `EffectiveDistanceRunner` companion that
+prints the standard `article	root_category	effective_distance` table from
+`category_parent.tsv` and `article_category.tsv`. The generator supports
+`kernels_on` via the Scala fact-source handler and `kernels_off` via compiled
+WAM facts, but the targets are not registered in the Python matrix until the
+runner wiring has a dedicated smoke gate.
+
 The configurable benchmark matrix now treats all Clojure WAM effective-distance
 modes as result-producing `hybrid-wam` targets:
 

--- a/examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl
@@ -1,0 +1,340 @@
+:- module(generate_wam_scala_effective_distance_benchmark,
+          [ main/0,
+            generate/4,
+            collect_wam_predicates/2,
+            scala_effective_distance_runner_code/2
+          ]).
+:- initialization(main, main).
+
+:- use_module('../../src/unifyweaver/targets/prolog_target').
+:- use_module('../../src/unifyweaver/targets/wam_scala_target').
+:- use_module(library(filesex), [directory_file_path/3, make_directory_path/1]).
+
+%% generate_wam_scala_effective_distance_benchmark.pl
+%%
+%% Generates a result-producing Scala WAM effective-distance project. This is
+%% intentionally separate from the generic Scala target tests: it adds a
+%% benchmark companion object that emits the standard TSV result table while
+%% leaving GeneratedProgram's predicate CLI unchanged.
+%%
+%% Usage:
+%%   swipl -q -s generate_wam_scala_effective_distance_benchmark.pl -- \
+%%       <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off]
+
+benchmark_workload_path(Path) :-
+    source_file(benchmark_workload_path(_), ThisFile),
+    file_directory_name(ThisFile, Here),
+    directory_file_path(Here, 'effective_distance.pl', Path).
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv == []
+    ->  true
+    ;   Argv = [FactsPath, OutputDir, VariantAtom, KernelModeAtom]
+    ->  true
+    ;   Argv = [FactsPath, OutputDir, VariantAtom]
+    ->  KernelModeAtom = kernels_on
+    ;   Argv = [FactsPath, OutputDir]
+    ->  VariantAtom = accumulated,
+        KernelModeAtom = kernels_on
+    ;   format(user_error,
+            'Usage: ... -- <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off]~n',
+            []),
+        halt(1)
+    ),
+    (   Argv == []
+    ->  true
+    ;   generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom),
+        halt(0)
+    ).
+
+main :-
+    format(user_error, 'Error: Scala WAM effective-distance generation failed~n', []),
+    halt(1).
+
+generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom) :-
+    must_exist_file(FactsPath),
+    benchmark_workload_path(WorkloadPath),
+    reset_benchmark_predicates,
+    load_files(user:WorkloadPath, [silent(true), if(true)]),
+    load_files(user:FactsPath, [silent(true), if(true)]),
+    retractall(user:mode(category_ancestor(_, _, _, _))),
+    assertz(user:mode(category_ancestor(-, +, -, +))),
+    parse_variant(VariantAtom, OptimizationOptions),
+    BasePreds = [dimension_n/1, max_depth/1, category_ancestor/4],
+    prolog_target:generate_prolog_script(BasePreds, OptimizationOptions, ScriptCode),
+    maybe_load_optimized_predicates(VariantAtom, ScriptCode),
+    maybe_assert_seeded_helper(VariantAtom),
+    collect_wam_predicates(KernelModeAtom, Predicates),
+    scala_options(OutputDir, KernelModeAtom, Options),
+    write_wam_scala_project(Predicates, Options, OutputDir),
+    append_effective_distance_runner(OutputDir),
+    format(user_error,
+           '[WAM-Scala-EffectiveDistance] facts=~w variant=~w kernels=~w output=~w~n',
+           [FactsPath, VariantAtom, KernelModeAtom, OutputDir]).
+
+reset_benchmark_predicates :-
+    forall(member(Name/Arity,
+                  [ article_category/2,
+                    category_parent/2,
+                    root_category/1,
+                    dimension_n/1,
+                    max_depth/1,
+                    category_ancestor/4,
+                    power_sum_bound/4,
+                    'category_ancestor$power_sum_bound'/3,
+                    'category_ancestor$power_sum_selected'/3,
+                    'category_ancestor$effective_distance_sum_selected'/3,
+                    'category_ancestor$effective_distance_sum_bound'/3
+                  ]),
+           maybe_abolish_user_predicate(Name/Arity)).
+
+maybe_abolish_user_predicate(Name/Arity) :-
+    (   current_predicate(user:Name/Arity)
+    ->  abolish(user:Name/Arity)
+    ;   true
+    ).
+
+parse_variant(seeded, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false)
+]).
+parse_variant(accumulated, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false),
+    seeded_accumulation(auto)
+]).
+
+scala_options(OutputDir, kernels_on, Options) :-
+    category_parent_csv_path(OutputDir, CsvPath),
+    write_category_parent_csv(CsvPath),
+    benchmark_atoms(Atoms),
+    Options = [
+        package('generated.wam_scala_effective_distance.core'),
+        runtime_package('generated.wam_scala_effective_distance.core'),
+        module_name('wam-scala-effective-distance'),
+        intern_atoms(Atoms),
+        scala_fact_sources([source(category_parent/2, file(CsvPath))])
+    ].
+scala_options(_OutputDir, kernels_off, Options) :-
+    benchmark_atoms(Atoms),
+    Options = [
+        package('generated.wam_scala_effective_distance.core'),
+        runtime_package('generated.wam_scala_effective_distance.core'),
+        module_name('wam-scala-effective-distance'),
+        intern_atoms(Atoms)
+    ].
+
+collect_wam_predicates(kernels_on, [
+    user:dimension_n/1,
+    user:max_depth/1,
+    user:category_ancestor/4
+]).
+collect_wam_predicates(kernels_off, [
+    user:dimension_n/1,
+    user:max_depth/1,
+    user:category_parent/2,
+    user:category_ancestor/4
+]).
+
+category_parent_csv_path(OutputDir, CsvPath) :-
+    directory_file_path(OutputDir, 'data', DataDir),
+    make_directory_path(DataDir),
+    directory_file_path(DataDir, 'category_parent.csv', CsvPath).
+
+write_category_parent_csv(CsvPath) :-
+    findall(Child-Parent, current_category_parent_fact(Child, Parent), Pairs0),
+    sort(Pairs0, Pairs),
+    setup_call_cleanup(
+        open(CsvPath, write, Stream),
+        forall(member(Child-Parent, Pairs),
+               format(Stream, '~w,~w~n', [Child, Parent])),
+        close(Stream)).
+
+benchmark_atoms(Atoms) :-
+    findall(Atom, benchmark_atom(Atom), Bag),
+    sort(Bag, Atoms).
+
+benchmark_atom(Atom) :-
+    current_category_parent_fact(Child, Parent),
+    member(Atom, [Child, Parent]).
+benchmark_atom(Atom) :-
+    current_article_category_fact(Article, Category),
+    member(Atom, [Article, Category]).
+benchmark_atom(Atom) :-
+    current_root_category_fact(Atom).
+
+current_category_parent_fact(Child, Parent) :-
+    current_predicate(user:category_parent/2),
+    call(user:category_parent(Child, Parent)).
+
+current_article_category_fact(Article, Category) :-
+    current_predicate(user:article_category/2),
+    call(user:article_category(Article, Category)).
+
+current_root_category_fact(Root) :-
+    current_predicate(user:root_category/1),
+    call(user:root_category(Root)).
+
+maybe_assert_seeded_helper(seeded) :- !,
+    retractall(user:power_sum_bound(_, _, _, _)),
+    assertz((user:power_sum_bound(Cat, Root, NegN, WeightSum) :-
+        aggregate_all(sum(W),
+            (user:category_ancestor(Cat, Root, Hops, [Cat]),
+             H is Hops + 1,
+             W is H ** NegN),
+            WeightSum))).
+maybe_assert_seeded_helper(_).
+
+maybe_load_optimized_predicates(seeded, _) :- !.
+maybe_load_optimized_predicates(accumulated, ScriptCode) :-
+    strip_generated_initialization(ScriptCode, LoadableScript),
+    tmp_file_stream(text, TmpPath, TmpStream),
+    write(TmpStream, LoadableScript),
+    close(TmpStream),
+    load_files(user:TmpPath, [silent(true)]),
+    delete_file(TmpPath),
+    cleanup_generated_script_entrypoint.
+
+strip_generated_initialization(ScriptCode, LoadableScript) :-
+    split_string(ScriptCode, "\n", "", Lines0),
+    exclude(generated_initialization_line, Lines0, Lines),
+    atomic_list_concat(Lines, '\n', LoadableScript).
+
+generated_initialization_line(Line) :-
+    sub_string(Line, _, _, _, "initialization(main").
+
+cleanup_generated_script_entrypoint :-
+    (   current_predicate(user:main/0)
+    ->  abolish(user:main/0)
+    ;   true
+    ).
+
+append_effective_distance_runner(OutputDir) :-
+    scala_effective_distance_runner_code(
+        'generated.wam_scala_effective_distance.core',
+        Code),
+    directory_file_path(OutputDir, 'src/main/scala/generated/wam_scala_effective_distance/core', SrcDir),
+    make_directory_path(SrcDir),
+    directory_file_path(SrcDir, 'EffectiveDistanceRunner.scala', Path),
+    setup_call_cleanup(
+        open(Path, write, Stream),
+        write(Stream, Code),
+        close(Stream)).
+
+scala_effective_distance_runner_code(Package, Code) :-
+    format(string(Code), 'package ~w
+
+import scala.collection.mutable
+import java.nio.file.{Path, Paths}
+import scala.io.Source
+
+object EffectiveDistanceRunner {
+  private val dimensionN = 5.0
+  private val inverseDimensionN = -1.0 / dimensionN
+
+  final case class ResultRow(article: String, root: String, distance: Double)
+
+  def main(args: Array[String]): Unit = {
+    if (args.length < 2) {
+      System.err.println("Usage: EffectiveDistanceRunner <category_parent.tsv> <article_category.tsv>")
+      sys.exit(1)
+    }
+
+    val edgePath = Paths.get(args(0))
+    val articlePath = Paths.get(args(1))
+    val rootPath = edgePath.getParent.resolve("root_categories.tsv")
+    val articleCategories = loadPairs(articlePath)
+    val roots = loadSingleColumn(rootPath)
+    val categoriesByArticle = articleCategories.groupMap(_._1)(_._2)
+
+    val rows = (for {
+      root <- roots
+      article <- categoriesByArticle.keys.toSeq.sorted
+      weightSum = categoriesByArticle(article).flatMap(categoryWeights(_, root)).sum
+      if weightSum > 0.0
+    } yield ResultRow(article, root, Math.pow(weightSum, inverseDimensionN)))
+      .sortBy(row => (row.distance, row.article, row.root))
+
+    Console.err.println("mode=scala_wam_effective_distance")
+    Console.err.println(s"article_count=${rows.size}")
+    println("article\\troot_category\\teffective_distance")
+    rows.foreach { row =>
+      println(f"${row.article}\\t${row.root}\\t${row.distance}%.6f")
+    }
+  }
+
+  private def categoryWeights(category: String, root: String): Seq[Double] =
+    if (category == root) Seq(1.0)
+    else categoryRootHops(category, root).map(hops => Math.pow(hops + 1.0, -dimensionN))
+
+  private def categoryRootHops(category: String, root: String): Seq[Int] = {
+    val startPc = GeneratedProgram.sharedProgram.dispatch("category_ancestor/4")
+    val categoryTerm = atom(category)
+    val rootTerm = atom(root)
+    val hopsRef = Ref(0)
+    val visited = listOf(categoryTerm)
+    val state = WamRuntime.newState(startPc, Array(categoryTerm, rootTerm, hopsRef, visited))
+    val results = mutable.ListBuffer.empty[Int]
+    if (WamRuntime.run(state, GeneratedProgram.sharedProgram)) {
+      var keepGoing = true
+      while (keepGoing) {
+        valueToInt(WamRuntime.deref(state.bindings, state.regs(3))).foreach(results += _)
+        WamRuntime.backtrack(state)
+        keepGoing = WamRuntime.run(state, GeneratedProgram.sharedProgram)
+      }
+    }
+    results.toSeq
+  }
+
+  private def atom(raw: String): WamTerm =
+    Atom(GeneratedProgram.internTable.stringToId.getOrElse(raw, -1))
+
+  private def listOf(items: WamTerm*): WamTerm = {
+    val cons = GeneratedProgram.internTable.stringToId("[|]")
+    val empty = GeneratedProgram.internTable.stringToId("[]")
+    items.foldRight[WamTerm](Atom(empty)) { (head, tail) =>
+      Struct(cons, 2, Array(head, tail))
+    }
+  }
+
+  private def valueToInt(value: WamTerm): Option[Int] = value match {
+    case IntTerm(value) => Some(value)
+    case FloatTerm(value) => Some(value.toInt)
+    case _ => None
+  }
+
+  private def loadPairs(path: Path): Vector[(String, String)] =
+    withSource(path) { source =>
+      source.getLines().drop(1).toVector.flatMap { line =>
+        val trimmed = line.trim
+        if (trimmed.isEmpty || trimmed.startsWith("#")) None
+        else {
+          val parts = trimmed.split("\\t")
+          if (parts.length >= 2) Some(parts(0) -> parts(1)) else None
+        }
+      }
+    }
+
+  private def loadSingleColumn(path: Path): Vector[String] =
+    withSource(path) { source =>
+      source.getLines().drop(1).toVector
+        .map(_.trim)
+        .filter(line => line.nonEmpty && !line.startsWith("#"))
+    }
+
+  private def withSource[A](path: Path)(f: Source => A): A = {
+    val source = Source.fromFile(path.toFile)
+    try f(source)
+    finally source.close()
+  }
+}
+', [Package]).
+
+must_exist_file(Path) :-
+    (   exists_file(Path)
+    ->  true
+    ;   throw(error(existence_error(file, Path), _))
+    ).

--- a/tests/test_wam_scala_effective_distance_generator.pl
+++ b/tests/test_wam_scala_effective_distance_generator.pl
@@ -1,0 +1,47 @@
+:- begin_tests(wam_scala_effective_distance_generator).
+
+:- use_module('../examples/benchmark/generate_wam_scala_effective_distance_benchmark').
+:- use_module(library(filesex), [delete_directory_and_contents/1]).
+:- use_module(library(readutil), [read_file_to_string/3]).
+
+test(generate_kernels_on_project_emits_runner_and_fact_sidecar) :-
+    setup_call_cleanup(
+        unique_tmp_dir('tmp_wam_scala_effective_distance_on', TmpDir),
+        (   generate('data/benchmark/dev/facts.pl', TmpDir, accumulated, kernels_on),
+            directory_file_path(TmpDir,
+                                'src/main/scala/generated/wam_scala_effective_distance/core/EffectiveDistanceRunner.scala',
+                                RunnerPath),
+            directory_file_path(TmpDir, 'data/category_parent.csv', CsvPath),
+            exists_file(RunnerPath),
+            exists_file(CsvPath),
+            read_file_to_string(RunnerPath, Runner, []),
+            sub_string(Runner, _, _, _, 'object EffectiveDistanceRunner'),
+            sub_string(Runner, _, _, _, 'article\\troot_category\\teffective_distance'),
+            sub_string(Runner, _, _, _, 'category_ancestor/4'),
+            !
+        ),
+        cleanup_tmp_dir(TmpDir)).
+
+test(generate_kernels_off_project_omits_fact_sidecar) :-
+    setup_call_cleanup(
+        unique_tmp_dir('tmp_wam_scala_effective_distance_off', TmpDir),
+        (   generate('data/benchmark/dev/facts.pl', TmpDir, accumulated, kernels_off),
+            directory_file_path(TmpDir,
+                                'src/main/scala/generated/wam_scala_effective_distance/core/EffectiveDistanceRunner.scala',
+                                RunnerPath),
+            directory_file_path(TmpDir, 'data/category_parent.csv', CsvPath),
+            exists_file(RunnerPath),
+            \+ exists_file(CsvPath),
+            !
+        ),
+        cleanup_tmp_dir(TmpDir)).
+
+unique_tmp_dir(Prefix, TmpDir) :-
+    tmp_file(Prefix, TmpDir),
+    catch(delete_directory_and_contents(TmpDir), _, true),
+    make_directory_path(TmpDir).
+
+cleanup_tmp_dir(TmpDir) :-
+    catch(delete_directory_and_contents(TmpDir), _, true).
+
+:- end_tests(wam_scala_effective_distance_generator).


### PR DESCRIPTION
  ## Summary
  Add a standalone Scala WAM effective-distance benchmark generator that emits a result-producing Scala project without
  changing the generic Scala WAM target CLI.

  ## What changed
  - Added `generate_wam_scala_effective_distance_benchmark.pl`.
  - The generator emits a Scala WAM project plus an `EffectiveDistanceRunner` companion.
  - `EffectiveDistanceRunner` reads `category_parent.tsv` and `article_category.tsv` and prints the standard `article
  root_category effective_distance` table.
  - Supports `kernels_on` through the existing Scala fact-source handler and `kernels_off` through compiled WAM facts.
  - Added Prolog regression tests for `kernels_on` and `kernels_off` project generation.
  - Documented the Scala generator boundary in the benchmark README.

  ## Verification
  - `swipl -q -f init.pl -s tests/test_wam_scala_effective_distance_generator.pl -g run_tests -t halt`
  - `swipl -q -t halt -s examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl`
  - `git diff --check`

  ## Notes
  - Scala is not registered in the Python benchmark matrix yet.
  - The next branch should wire this generator into `benchmark_effective_distance_matrix.py` and add Scala kernel/no-
  kernel pair targets once the matrix smoke gate is in place.
  - Untracked local benchmark/data artifacts were left out of the commit.