### PR TITLE
Add design doc: Kernel Shape Recognition in WAM optimization

### DIFF
--- a/docs/design/KERNEL_SHAPE_RECOGNITION.md
+++ b/docs/design/KERNEL_SHAPE_RECOGNITION.md
@@ -1,0 +1,202 @@
+# Kernel Shape Recognition: Why Pattern-Matched Sub-Logic Beats Whole-Workload Optimization
+
+## The observation
+
+`effective_distance/3` is the high-level workload — given an article
+and a root category, compute a Minkowski-power aggregated distance
+over all weighted paths through the category graph. It composes a
+per-seed weight sum, an article-fanout aggregation, and a final
+exponentiation. None of those individually is a "primitive."
+
+Yet the 52× speedup at scale-300
+(`docs/design/WAM_PERF_OPTIMIZATION_LOG.md` Phase K) didn't come from
+optimizing `effective_distance` as a whole. It came from recognizing
+`category_ancestor/4` — a depth-bounded ancestor walk with a visited
+set — as a sub-shape *inside* the larger structure, and replacing
+that with native Go code. The composition above (aggregate over
+kernel-emitted hop counts) stayed in WAM bytecode. The kernel didn't
+need to know what workload it was inside; the workload didn't need to
+know what kernel it was using.
+
+This is the central design move of the WAM target's FFI-kernel
+system: pattern matching on **sub-logic inside larger structures**,
+not workload-level templates.
+
+## "High-level" and "primitive" aren't opposites
+
+Three useful parallels from neighbouring fields:
+
+- **BLAS** doesn't recognize "linear regression." It recognizes
+  matrix-matrix multiply — a sub-shape that linear regression,
+  neural-net inference, image kernels, and PDE solvers all contain.
+  Recognition is at the algebraic shape, not the application name.
+- **SQL query optimizers** don't optimize "Q1 sales report." They
+  recognize hash join, merge join, index seek — operational
+  sub-shapes that every report query composes. The rewriter chain
+  matches subtrees, not whole queries.
+- **LLVM** recognizes induction-variable patterns, not "this is
+  matrix multiply." Higher-level intent comes from libraries; the
+  compiler stays at the structural level.
+
+`category_ancestor` belongs to the same category as "matmul" or
+"hash join": a domain-named version of an underlying recurring code
+shape — depth-bounded graph traversal with a visited set. The
+bench's name is bookkeeping; what's primitive is the shape.
+
+## A note on the word *kernel*
+
+The "kernel" in our context inherits from the BLAS / GPU /
+compute-kernel tradition: a tight inner-loop primitive that larger
+workloads call many times.
+
+There's a satisfying second reading though. In algebra, the *kernel*
+of a homomorphism is what gets factored out — the elements that map
+to identity. By analogy, when we identify a kernel shape in a Prolog
+predicate, we are identifying what *can be factored out* of the WAM
+bytecode stream. What remains is the quotient: the workload-specific
+composition logic above the primitive. Both senses converge — a
+kernel is what the compiler can lift out of the dispatch path
+because the rest is structural overhead around it.
+
+## When a shape becomes worth a kernel
+
+Three properties:
+
+1. **Prolog-idiom verbosity in the WAM.** A single ancestor step
+   expands to dozens of WAM instructions: `Allocate`, `PutVar`,
+   `Call`, `\+ member` over the visited list, `is _ + 1`,
+   `Deallocate`. At depth 10 with branching parent edges, this is
+   thousands of dispatched instructions per query.
+2. **Native-algorithm density.** The same step in native code is a
+   handful of lines: a map lookup, a slice append, a recursive call.
+   The cost ratio is two orders of magnitude.
+3. **Clean boundary.** Inputs (`Cat`, `Root`, `Visited`, `MaxDepth`)
+   and outputs (one `int64` per matching path) are knowable at the
+   shape level — no escape hatches into the surrounding workload.
+
+A shape with all three pays back its implementation cost across
+every workload that contains it. A shape missing any of the three
+doesn't.
+
+## Why kernels compose where whole-workload templates don't
+
+The `effective_distance` workload looks roughly like:
+
+```prolog
+effective_distance(A, R, D) :-
+    aggregate(weight, S^(category_ancestor(A, R, _, S)), TotalW),
+    D is TotalW ** (1 / Dimensionality).
+```
+
+A whole-workload template would have to recognize this exact
+composition. A kernel system recognizes `category_ancestor` and
+lets the aggregate-and-exponentiate stay in WAM bytecode. The kernel
+returns hop counts; the WAM composes them. Both halves stay simple,
+and any other workload that happens to compose `category_ancestor`
+differently (`category_influence`, ad-hoc category queries) gets the
+same speedup for free.
+
+The WAM bytecode that *does* run is the small outer loop where
+dispatch overhead is fixed and tractable. Phases B–H of the
+performance log made *that* overhead cheap. Phase K removed the
+inner loop's overhead entirely. Both layers were necessary.
+
+## What the detector actually matches
+
+`detect_category_ancestor/4` at
+`src/unifyweaver/core/recursive_kernel_detection.pl:272` matches on
+structural tells, not on names:
+
+- At least two clauses (base + recursive).
+- A base clause whose body contains `\+ member(_, _)` and a binary
+  call sharing its first argument with the head — that binary call
+  is the edge predicate.
+- A recursive clause containing `\+ member(_, _)` and an `is _ + 1`
+  accumulator (the hop counter).
+- A `user:max_depth/1` fact in scope (the recursion bound).
+
+A predicate named `find_ancestor_within/4` with the same shape would
+match the same kernel. A predicate named `category_ancestor/4`
+written differently — say, with the visited-set encoded as a sorted
+tree, or the accumulator on a different argument — would not. The
+detector matches *shape*, not *vocabulary*.
+
+This is what "pattern matching sees sub-logic inside a larger
+structure" means concretely: the detector ignores the surrounding
+`effective_distance` framing entirely and looks only at the
+recursion-shape signature of the inner predicate.
+
+## The optimization ladder
+
+| Layer | What it removes | Phase example |
+|---|---|---|
+| Constants | Per-instruction overhead | Phases B–H — env trimming, MaxYReg, Bindings as slice. Each WAM op got cheaper. |
+| Structural runtime | Whole instruction *categories* | Phase D save-A+Y-skip-X — the X-reg snapshot disappeared. |
+| Kernel substitution | Whole instruction *streams* | Phase K — the inner ancestor walk stopped going through WAM at all. |
+
+Each layer multiplies with the layer below. The ~730× cumulative at
+Phase K isn't `52 × 12.8`; it's the product *because* the prior
+12.8× made the outer dispatch (still in WAM) cheap enough that the
+kernel boundary became the dominant remaining cost — and then the
+kernel substitution removed that too.
+
+## Tradeoffs
+
+- **Maintenance burden scales with target count.** Each new kernel
+  needs an implementation in every target's runtime (Go, Rust,
+  Haskell, Clojure, …). The shared registry at
+  `recursive_kernel_detection.pl:81-87` is what makes this
+  tractable: one detector, N back-ends, metadata-driven dispatch
+  glue.
+- **Pattern matching has false negatives.** A predicate that is
+  *semantically* equivalent to `category_ancestor` but structurally
+  different (alternate visited-set encoding, accumulator on a
+  different argument) won't match. The detector is a syntactic
+  filter, not a semantic one. This is the cost of staying in
+  decidable territory.
+- **Rare shapes don't pay.** A shape appearing in one workload only
+  pays for itself if that workload is hot. The cross-target survey
+  behind Phase K — frequency-weighted by benchmark references — was
+  the right way to prioritize.
+- **Kernel boundaries must stay clean.** A kernel that needs to call
+  back into Prolog mid-execution (e.g., for a user-defined predicate
+  inside its loop) loses most of the benefit. The cost asymmetry
+  only holds when the inner loop is fully native.
+
+## Practical takeaways
+
+For anyone building a similar layered runtime:
+
+1. Profile to find the *shape* of the dispatch cost, not just the
+   percentages. "20% in the dispatcher" can mean "the dispatcher is
+   slow" (constant-factor target) or "we're doing too much
+   dispatch" (kernel target). The right answer changes the next
+   move by orders of magnitude.
+2. Look for sub-shapes inside workloads, not at the workload
+   itself. The right primitive boundary is rarely the user's
+   outermost goal.
+3. Make detectors syntactic and registries shared. Per-target
+   ad-hoc detection drifts; one detector with N back-ends scales.
+4. Remember the ladder. Constant-factor work isn't wasted when you
+   later land a kernel — it is the prerequisite that makes the
+   kernel boundary cleanly dominate.
+
+---
+
+## References
+
+- `src/unifyweaver/core/recursive_kernel_detection.pl` — shared
+  kernel detectors and the metadata registry that all targets
+  consume.
+- `src/unifyweaver/targets/wam_rust_target.pl:1797` — Rust reference
+  implementation of `compile_collect_native_category_ancestor_to_rust`.
+- `src/unifyweaver/targets/wam_go_target.pl` — Go target's kernel
+  dispatch (`go_supported_shared_kernel/1` and the
+  `executeForeignPredicate` switch).
+- `docs/design/RECURSIVE_TEMPLATE_LOWERING.md` — the AST-recursive
+  template-then-lower architecture this builds on.
+- `docs/design/WAM_TIERED_LOWERING.md` — the routing / strategy-menu
+  framing that places kernel substitution within the broader tiered
+  system.
+- `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` Phase K — the worked
+  example: 52× speedup at scale-300 from one new kernel.

--- a/docs/design/KERNEL_SHAPE_RECOGNITION.md
+++ b/docs/design/KERNEL_SHAPE_RECOGNITION.md
@@ -43,20 +43,92 @@ Three useful parallels from neighbouring fields:
 shape — depth-bounded graph traversal with a visited set. The
 bench's name is bookkeeping; what's primitive is the shape.
 
-## A note on the word *kernel*
+## The senses of *kernel* — and why they converge here
 
-The "kernel" in our context inherits from the BLAS / GPU /
-compute-kernel tradition: a tight inner-loop primitive that larger
-workloads call many times.
+The word "kernel" carries several technical meanings across
+mathematics and computing, and a number of them line up uncannily
+well with what the detector is doing. Each lens illuminates a
+different facet of why this design works, so it is worth walking
+through them.
 
-There's a satisfying second reading though. In algebra, the *kernel*
-of a homomorphism is what gets factored out — the elements that map
-to identity. By analogy, when we identify a kernel shape in a Prolog
-predicate, we are identifying what *can be factored out* of the WAM
-bytecode stream. What remains is the quotient: the workload-specific
-composition logic above the primitive. Both senses converge — a
-kernel is what the compiler can lift out of the dispatch path
-because the rest is structural overhead around it.
+**The seed-kernel.** Etymologically, "kernel" is Old English
+*cyrnel*, the diminutive of *corn* — the inner seed of a nut or
+fruit. The metaphor distinguishes the dense, hard, valuable inner
+part from the variable surrounding shell. Different shells (apple,
+peach, walnut) wrap around structurally similar seeds. The shell is
+the part that varies between fruits; the kernel is the carrier of
+essential structure. In our case `category_ancestor` is the seed,
+and `effective_distance`, `category_influence`, and any future
+workload that traverses the category graph are different shells.
+The shell varies; the kernel is invariant.
+
+**The compute-kernel (BLAS, CUDA, OS).** In numerical computing,
+BLAS kernels are tight inner loops everything calls into — `dgemm`
+for dense matrix multiply, `dgemv` for matrix-vector. CUDA kernels
+are functions executed in parallel across thousands of threads. An
+OS kernel is the trusted core that every userspace program
+delegates to for primitive operations. The common thread is
+*inversion of control*: the kernel doesn't know about its callers;
+callers know how to invoke it. The kernel is a fixed point in the
+call graph, with everything around it variable. Our
+`category_ancestor` shares this property — once detected and
+lowered, the implementation is fixed across every workload that
+reaches it.
+
+**The algebraic kernel.** In abstract algebra, the kernel of a
+homomorphism `f: G → H` is the set of elements in `G` that map to
+the identity in `H` — the things that get "factored out." The
+First Isomorphism Theorem says `G/ker(f) ≅ image(f)`: once you
+quotient by the kernel, what remains is exactly what the map can
+see. For our purposes the WAM dispatcher is the homomorphism; the
+kernel is what the dispatcher does *not* need to see because it
+has been lifted out into native code; the quotient is the outer
+workload logic the WAM still interprets. The intuition that
+"factors have zeros" lands here directly — the kernel is what the
+structural map sends to identity, what becomes invisible to it,
+freeing the rest to focus on what varies.
+
+**The integral-transform kernel.** In `∫ K(x, y) f(y) dy`, the
+kernel function `K(x, y)` defines the transform — Fourier,
+Laplace, Hilbert. Same operator (the integral), different kernels,
+different transforms. By analogy, the WAM dispatcher is the
+operator; different kernels installed into it give us different
+specialized runtimes for different workload families. A workload
+heavy on transitive closure gets one effective runtime; a workload
+heavy on A\* gets another; the dispatcher is the same.
+
+**The kernel-method (ML) sense.** In machine learning, the kernel
+trick computes inner products in a transformed feature space
+*without materializing the transformed space*. You don't need to
+construct `φ(x)` explicitly — you just need a kernel function
+`K(x, y) = ⟨φ(x), φ(y)⟩`. Our system has the same flavour: we
+don't need to materialize a full native re-implementation of
+`effective_distance` to make it fast. We just need the kernel
+that sits inside it. The composition above the kernel can stay
+in (relatively) slow WAM bytecode because its instruction count
+is small enough that the dispatch cost is bounded. The kernel is
+the *only* place where native code is required.
+
+What unites all these senses is a single structural move: **find
+the invariant under variation, lift it out, express the rest as a
+quotient.** The compute-kernel does this in the call graph. The
+algebraic kernel does it in the homomorphism. The integral
+transform does it across families of operators. The kernel method
+does it between feature spaces. The pattern-matched kernel here
+does it across Prolog workloads.
+
+This convergence is not coincidence. Optimization, almost by
+definition, is the search for the right factorization: what can
+be hoisted, what can be shared, what is genuinely workload-
+specific. "Kernel" is the word that several traditions
+independently arrived at for naming the hoisted part. That all of
+those traditions apply simultaneously to what
+`recursive_kernel_detection.pl` is doing isn't a happy linguistic
+coincidence — it is evidence that the detector is identifying the
+right structural object. When several independent disciplines
+borrow the same name for "the thing you can factor out," and that
+name fits a fifth domain without strain, the underlying notion is
+probably real.
 
 ## When a shape becomes worth a kernel
 


### PR DESCRIPTION
## Summary

Add comprehensive design documentation explaining the kernel shape recognition approach used in the WAM target's FFI-kernel system, which achieved a 52× speedup through pattern-matching on sub-logic structures rather than whole-workload optimization.

## Changes

- **New design document** (`docs/design/KERNEL_SHAPE_RECOGNITION.md`): A 274-line guide covering:
  - The core observation: how recognizing `category_ancestor/4` as a sub-shape inside `effective_distance/3` enabled the Phase K optimization
  - Conceptual foundations: parallels to BLAS, SQL query optimizers, and LLVM
  - Five technical senses of "kernel" (seed, compute, algebraic, integral-transform, ML) and how they converge on this design
  - Criteria for when a shape becomes worth implementing as a kernel (verbosity, density, clean boundaries)
  - Why kernel composition scales better than whole-workload templates
  - Concrete pattern-matching rules the detector uses (structural tells, not name-based)
  - The optimization ladder showing how constant-factor improvements enable kernel substitution
  - Tradeoffs: maintenance burden, false negatives, rare shapes, clean boundaries
  - Practical takeaways for building similar layered runtimes

## Implementation Details

The document is structured as a design rationale rather than a reference manual, with:
- Cross-references to related design docs and source files
- A worked example showing how `category_ancestor` detection works in practice
- A comparison table showing the three layers of optimization and their cumulative effect
- Emphasis on structural pattern matching over semantic analysis

https://claude.ai/code/session_011PV3jh3d3tmL2qD3WhWaSF