### PR TITLE
bench(scala): Register Scala WAM effective-distance matrix targets

### DIFF
--- a/docs/proposals/WAM_SCALA_HYBRID_SPEC.md
+++ b/docs/proposals/WAM_SCALA_HYBRID_SPEC.md
@@ -451,6 +451,13 @@ Clojure/Haskell/Rust strategy:
 The benchmark generator should not become the only place where Scala
 LMDB or artifact behavior exists.
 
+The first result-producing Scala effective-distance generator is now
+registered in the benchmark matrix as `scala-wam-accumulated` and
+`scala-wam-accumulated-no-kernels`. Both targets compile the generated
+Scala project with `scalac` and run the common TSV-emitting
+`EffectiveDistanceRunner`, giving the matrix the same kernel/no-kernel
+comparison surface used by the other WAM families.
+
 ## 13. Example Target-Level Declarations
 
 Illustrative examples only:

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -130,6 +130,10 @@ def available_targets(requested: list[str]) -> list[str]:
         "rust-lowered-only",
         "rust-lowered-ffi",
     }
+    scala_matrix_targets = {
+        "scala-wam-accumulated",
+        "scala-wam-accumulated-no-kernels",
+    }
     for target in requested:
         if target.startswith("csharp-") and shutil.which("dotnet") is None:
             print(f"skip {target}: dotnet not found", file=sys.stderr)
@@ -146,6 +150,11 @@ def available_targets(requested: list[str]) -> list[str]:
             shutil.which("swipl") is None or shutil.which("cargo") is None or shutil.which("rustc") is None
         ):
             print(f"skip {target}: swipl, cargo, or rustc not found", file=sys.stderr)
+            continue
+        if target in scala_matrix_targets and (
+            shutil.which("swipl") is None or shutil.which("scalac") is None or shutil.which("scala") is None
+        ):
+            print(f"skip {target}: swipl, scalac, or scala not found", file=sys.stderr)
             continue
         if target.startswith("rust-") and shutil.which("rustc") is None:
             print(f"skip {target}: rustc not found", file=sys.stderr)

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -68,9 +68,11 @@ WAM_RUST_MATRIX_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_rust
 WAM_HASKELL_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_haskell_matrix_benchmark.pl"
 WAM_GO_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_go_effective_distance_benchmark.pl"
 WAM_CLOJURE_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_clojure_optimized_benchmark.pl"
+WAM_SCALA_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_scala_effective_distance_benchmark.pl"
 DEFAULT_FACTS = BENCH_DIR / "10k" / "facts.pl"
 HASKELL_EXE = "wam-haskell-matrix-bench"
 RUST_MATRIX_EXE = "wam_rust_matrix_bench"
+SCALA_EFFECTIVE_DISTANCE_MAIN = "generated.wam_scala_effective_distance.core.EffectiveDistanceRunner"
 
 
 def default_scales_csv() -> str:
@@ -249,6 +251,37 @@ def build_wam_go_effective_distance(root: Path, scale: str, kernel_mode: str) ->
     env = dict(os.environ, GOCACHE=str(go_cache))
     run_command(["go", "build", "-o", str(project_dir / "hybrid_ed_bench_go")], cwd=project_dir, env=env)
     return [str(project_dir / "hybrid_ed_bench_go")]
+
+
+def scala_sources(project_dir: Path) -> list[str]:
+    return sorted(str(path) for path in (project_dir / "src" / "main" / "scala").rglob("*.scala"))
+
+
+def build_wam_scala_effective_distance(root: Path, scale: str, kernel_mode: str) -> list[str]:
+    facts_path = require_file(BENCH_DIR / scale / "facts.pl")
+    project_dir = root / f"wam_scala_accumulated_{kernel_mode}" / scale
+    project_dir.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(WAM_SCALA_GENERATOR),
+            "--",
+            str(facts_path),
+            str(project_dir),
+            "accumulated",
+            kernel_mode,
+        ],
+        cwd=ROOT,
+    )
+    classes_dir = project_dir / "classes"
+    classes_dir.mkdir(exist_ok=True)
+    sources = scala_sources(project_dir)
+    if not sources:
+        raise RuntimeError(f"no Scala sources generated under {project_dir}")
+    run_command(["scalac", "-d", str(classes_dir), *sources], cwd=project_dir)
+    return ["scala", "-classpath", str(classes_dir), SCALA_EFFECTIVE_DISTANCE_MAIN]
 
 
 def clojure_classpath(project_dir: Path) -> str:
@@ -788,6 +821,10 @@ def main() -> int:
                     command = build_wam_go_effective_distance(temp_root, scale, "kernels_on")
                 elif target == "go-wam-accumulated-no-kernels":
                     command = build_wam_go_effective_distance(temp_root, scale, "kernels_off")
+                elif target == "scala-wam-accumulated":
+                    command = build_wam_scala_effective_distance(temp_root, scale, "kernels_on")
+                elif target == "scala-wam-accumulated-no-kernels":
+                    command = build_wam_scala_effective_distance(temp_root, scale, "kernels_off")
                 elif target == "clojure-wam-accumulated":
                     command = build_wam_clojure_effective_distance(temp_root, scale, "accumulated", "kernels_on")
                 elif target == "clojure-wam-accumulated-no-kernels":

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -82,6 +82,16 @@ TARGETS: dict[str, TargetInfo] = {
         "hybrid-wam",
         "Hybrid WAM Go benchmark with optimized accumulated helpers and no_kernels(true)",
     ),
+    "scala-wam-accumulated": TargetInfo(
+        "scala-wam-accumulated",
+        "hybrid-wam",
+        "Hybrid WAM Scala effective-distance runner with optimized accumulated helpers and kernels enabled",
+    ),
+    "scala-wam-accumulated-no-kernels": TargetInfo(
+        "scala-wam-accumulated-no-kernels",
+        "hybrid-wam",
+        "Hybrid WAM Scala effective-distance runner with optimized accumulated helpers and no_kernels(true)",
+    ),
     "clojure-wam-seeded": TargetInfo(
         "clojure-wam-seeded",
         "hybrid-wam",
@@ -197,6 +207,12 @@ KERNEL_TARGET_PAIRS: tuple[KernelPairInfo, ...] = (
         "go-wam-accumulated-no-kernels",
     ),
     KernelPairInfo(
+        "scala",
+        "accumulated",
+        "scala-wam-accumulated",
+        "scala-wam-accumulated-no-kernels",
+    ),
+    KernelPairInfo(
         "clojure",
         "seeded",
         "clojure-wam-seeded",
@@ -244,6 +260,8 @@ TARGET_SETS: dict[str, list[str]] = {
         "wam-rust-accumulated-no-kernels",
         "go-wam-accumulated",
         "go-wam-accumulated-no-kernels",
+        "scala-wam-accumulated",
+        "scala-wam-accumulated-no-kernels",
         "clojure-wam-accumulated",
         "clojure-wam-accumulated-no-kernels",
         "clojure-wam-seeded",
@@ -258,6 +276,10 @@ TARGET_SETS: dict[str, list[str]] = {
         "rust-lowered-ffi",
     ],
     "clojure-wam-scaffold": [],
+    "scala-wam": [
+        "scala-wam-accumulated",
+        "scala-wam-accumulated-no-kernels",
+    ],
     "clojure-wam": [
         "clojure-wam-accumulated",
         "clojure-wam-seeded",

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -56,10 +56,28 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
 
         self.assertIn("go-wam-accumulated", targets)
         self.assertIn("haskell-interp-ffi", targets)
+        self.assertIn("scala-wam-accumulated", targets)
+        self.assertIn("scala-wam-accumulated-no-kernels", targets)
         self.assertIn("clojure-wam-accumulated", targets)
         self.assertIn("clojure-wam-accumulated-no-kernels", targets)
         self.assertIn("clojure-wam-seeded", targets)
         self.assertIn("clojure-wam-seeded-no-kernels", targets)
+
+    def test_scala_targets_are_registered(self) -> None:
+        targets = resolve_targets(
+            explicit_targets=None,
+            target_set_names=["scala-wam"],
+        )
+
+        self.assertEqual(
+            targets,
+            [
+                "scala-wam-accumulated",
+                "scala-wam-accumulated-no-kernels",
+            ],
+        )
+        self.assertEqual(TARGETS["scala-wam-accumulated"].category, "hybrid-wam")
+        self.assertEqual(TARGETS["scala-wam-accumulated-no-kernels"].category, "hybrid-wam")
 
     def test_list_targets_includes_clojure_scaffold_set(self) -> None:
         text = list_targets_text()
@@ -73,6 +91,7 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
             "clojure-wam-seeded-no-kernels,clojure-wam-accumulated-no-kernels",
             text,
         )
+        self.assertIn("scala-wam\tscala-wam-accumulated,scala-wam-accumulated-no-kernels", text)
         self.assertIn("clojure-wam-scaffold\t", text)
 
     def test_effective_distance_runner_resolves_seeded_clojure_targets(self) -> None:
@@ -97,6 +116,7 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
             ("rust", "interpreter"),
             ("rust", "lowered"),
             ("go", "accumulated"),
+            ("scala", "accumulated"),
             ("clojure", "seeded"),
             ("clojure", "accumulated"),
             ("haskell", "interpreter"),
@@ -122,6 +142,10 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         )
         self.assertIn(
             "haskell\tlowered\thaskell-lowered-ffi\thaskell-lowered-only",
+            text,
+        )
+        self.assertIn(
+            "scala\taccumulated\tscala-wam-accumulated\tscala-wam-accumulated-no-kernels",
             text,
         )
 


### PR DESCRIPTION
  ## Summary
  - Add `scala-wam-accumulated` and `scala-wam-accumulated-no-kernels` to the benchmark target matrix.
  - Register the Scala accumulated kernel/no-kernel pair for `--list-kernel-pairs` reporting.
  - Wire the effective-distance matrix harness to generate, compile with `scalac`, and run the Scala WAM benchmark
  runner per scale.
  - Add target-matrix tests covering Scala target registration and pair listing.
  - Update the Scala hybrid WAM spec to document the new benchmark-matrix integration boundary.

  ## Validation
  - `python3 -m py_compile examples/benchmark/benchmark_common.py examples/benchmark/benchmark_target_matrix.py
  examples/benchmark/benchmark_effective_distance_matrix.py`
  - `python3 -m unittest tests/test_benchmark_target_matrix.py`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --list-kernel-pairs`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets scala-wam-
  accumulated,scala-wam-accumulated-no-kernels --repetitions 1`
  - `git diff --check`