### PR TITLE
bench(scala): Add Scala seeded effective-distance matrix targets

### DIFF
--- a/docs/proposals/WAM_SCALA_HYBRID_SPEC.md
+++ b/docs/proposals/WAM_SCALA_HYBRID_SPEC.md
@@ -452,11 +452,12 @@ The benchmark generator should not become the only place where Scala
 LMDB or artifact behavior exists.
 
 The first result-producing Scala effective-distance generator is now
-registered in the benchmark matrix as `scala-wam-accumulated` and
-`scala-wam-accumulated-no-kernels`. Both targets compile the generated
+registered in the benchmark matrix as `scala-wam-seeded`,
+`scala-wam-seeded-no-kernels`, `scala-wam-accumulated`, and
+`scala-wam-accumulated-no-kernels`. These targets compile the generated
 Scala project with `scalac` and run the common TSV-emitting
-`EffectiveDistanceRunner`, giving the matrix the same kernel/no-kernel
-comparison surface used by the other WAM families.
+`EffectiveDistanceRunner`, giving the matrix the same seeded/accumulated
+kernel/no-kernel comparison surface used by the other WAM families.
 
 ## 13. Example Target-Level Declarations
 

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -131,6 +131,8 @@ def available_targets(requested: list[str]) -> list[str]:
         "rust-lowered-ffi",
     }
     scala_matrix_targets = {
+        "scala-wam-seeded",
+        "scala-wam-seeded-no-kernels",
         "scala-wam-accumulated",
         "scala-wam-accumulated-no-kernels",
     }

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -257,9 +257,9 @@ def scala_sources(project_dir: Path) -> list[str]:
     return sorted(str(path) for path in (project_dir / "src" / "main" / "scala").rglob("*.scala"))
 
 
-def build_wam_scala_effective_distance(root: Path, scale: str, kernel_mode: str) -> list[str]:
+def build_wam_scala_effective_distance(root: Path, scale: str, variant: str, kernel_mode: str) -> list[str]:
     facts_path = require_file(BENCH_DIR / scale / "facts.pl")
-    project_dir = root / f"wam_scala_accumulated_{kernel_mode}" / scale
+    project_dir = root / f"wam_scala_{variant}_{kernel_mode}" / scale
     project_dir.mkdir(parents=True, exist_ok=True)
     run_command(
         [
@@ -270,7 +270,7 @@ def build_wam_scala_effective_distance(root: Path, scale: str, kernel_mode: str)
             "--",
             str(facts_path),
             str(project_dir),
-            "accumulated",
+            variant,
             kernel_mode,
         ],
         cwd=ROOT,
@@ -821,10 +821,14 @@ def main() -> int:
                     command = build_wam_go_effective_distance(temp_root, scale, "kernels_on")
                 elif target == "go-wam-accumulated-no-kernels":
                     command = build_wam_go_effective_distance(temp_root, scale, "kernels_off")
+                elif target == "scala-wam-seeded":
+                    command = build_wam_scala_effective_distance(temp_root, scale, "seeded", "kernels_on")
+                elif target == "scala-wam-seeded-no-kernels":
+                    command = build_wam_scala_effective_distance(temp_root, scale, "seeded", "kernels_off")
                 elif target == "scala-wam-accumulated":
-                    command = build_wam_scala_effective_distance(temp_root, scale, "kernels_on")
+                    command = build_wam_scala_effective_distance(temp_root, scale, "accumulated", "kernels_on")
                 elif target == "scala-wam-accumulated-no-kernels":
-                    command = build_wam_scala_effective_distance(temp_root, scale, "kernels_off")
+                    command = build_wam_scala_effective_distance(temp_root, scale, "accumulated", "kernels_off")
                 elif target == "clojure-wam-accumulated":
                     command = build_wam_clojure_effective_distance(temp_root, scale, "accumulated", "kernels_on")
                 elif target == "clojure-wam-accumulated-no-kernels":

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -82,6 +82,16 @@ TARGETS: dict[str, TargetInfo] = {
         "hybrid-wam",
         "Hybrid WAM Go benchmark with optimized accumulated helpers and no_kernels(true)",
     ),
+    "scala-wam-seeded": TargetInfo(
+        "scala-wam-seeded",
+        "hybrid-wam",
+        "Hybrid WAM Scala effective-distance runner with seeded helpers and kernels enabled",
+    ),
+    "scala-wam-seeded-no-kernels": TargetInfo(
+        "scala-wam-seeded-no-kernels",
+        "hybrid-wam",
+        "Hybrid WAM Scala effective-distance runner with seeded helpers and no_kernels(true)",
+    ),
     "scala-wam-accumulated": TargetInfo(
         "scala-wam-accumulated",
         "hybrid-wam",
@@ -208,6 +218,12 @@ KERNEL_TARGET_PAIRS: tuple[KernelPairInfo, ...] = (
     ),
     KernelPairInfo(
         "scala",
+        "seeded",
+        "scala-wam-seeded",
+        "scala-wam-seeded-no-kernels",
+    ),
+    KernelPairInfo(
+        "scala",
         "accumulated",
         "scala-wam-accumulated",
         "scala-wam-accumulated-no-kernels",
@@ -260,6 +276,8 @@ TARGET_SETS: dict[str, list[str]] = {
         "wam-rust-accumulated-no-kernels",
         "go-wam-accumulated",
         "go-wam-accumulated-no-kernels",
+        "scala-wam-seeded",
+        "scala-wam-seeded-no-kernels",
         "scala-wam-accumulated",
         "scala-wam-accumulated-no-kernels",
         "clojure-wam-accumulated",
@@ -277,6 +295,8 @@ TARGET_SETS: dict[str, list[str]] = {
     ],
     "clojure-wam-scaffold": [],
     "scala-wam": [
+        "scala-wam-seeded",
+        "scala-wam-seeded-no-kernels",
         "scala-wam-accumulated",
         "scala-wam-accumulated-no-kernels",
     ],

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -56,6 +56,8 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
 
         self.assertIn("go-wam-accumulated", targets)
         self.assertIn("haskell-interp-ffi", targets)
+        self.assertIn("scala-wam-seeded", targets)
+        self.assertIn("scala-wam-seeded-no-kernels", targets)
         self.assertIn("scala-wam-accumulated", targets)
         self.assertIn("scala-wam-accumulated-no-kernels", targets)
         self.assertIn("clojure-wam-accumulated", targets)
@@ -72,10 +74,14 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         self.assertEqual(
             targets,
             [
+                "scala-wam-seeded",
+                "scala-wam-seeded-no-kernels",
                 "scala-wam-accumulated",
                 "scala-wam-accumulated-no-kernels",
             ],
         )
+        self.assertEqual(TARGETS["scala-wam-seeded"].category, "hybrid-wam")
+        self.assertEqual(TARGETS["scala-wam-seeded-no-kernels"].category, "hybrid-wam")
         self.assertEqual(TARGETS["scala-wam-accumulated"].category, "hybrid-wam")
         self.assertEqual(TARGETS["scala-wam-accumulated-no-kernels"].category, "hybrid-wam")
 
@@ -91,7 +97,11 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
             "clojure-wam-seeded-no-kernels,clojure-wam-accumulated-no-kernels",
             text,
         )
-        self.assertIn("scala-wam\tscala-wam-accumulated,scala-wam-accumulated-no-kernels", text)
+        self.assertIn(
+            "scala-wam\tscala-wam-seeded,scala-wam-seeded-no-kernels,"
+            "scala-wam-accumulated,scala-wam-accumulated-no-kernels",
+            text,
+        )
         self.assertIn("clojure-wam-scaffold\t", text)
 
     def test_effective_distance_runner_resolves_seeded_clojure_targets(self) -> None:
@@ -116,6 +126,7 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
             ("rust", "interpreter"),
             ("rust", "lowered"),
             ("go", "accumulated"),
+            ("scala", "seeded"),
             ("scala", "accumulated"),
             ("clojure", "seeded"),
             ("clojure", "accumulated"),
@@ -146,6 +157,10 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         )
         self.assertIn(
             "scala\taccumulated\tscala-wam-accumulated\tscala-wam-accumulated-no-kernels",
+            text,
+        )
+        self.assertIn(
+            "scala\tseeded\tscala-wam-seeded\tscala-wam-seeded-no-kernels",
             text,
         )
 


### PR DESCRIPTION
  ## Summary
  - Add `scala-wam-seeded` and `scala-wam-seeded-no-kernels` to the benchmark target matrix.
  - Register the Scala seeded kernel/no-kernel pair in `--list-kernel-pairs`.
  - Generalize the Scala effective-distance matrix build helper so it supports both `seeded` and `accumulated` generator
  variants.
  - Extend target-matrix tests for the expanded Scala target set and pair registry.
  - Update the Scala hybrid WAM spec to document seeded and accumulated matrix coverage.

  ## Validation
  - `python3 -m py_compile examples/benchmark/benchmark_common.py examples/benchmark/benchmark_target_matrix.py
  examples/benchmark/benchmark_effective_distance_matrix.py`
  - `python3 -m unittest tests/test_benchmark_target_matrix.py`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --list-kernel-pairs`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets scala-wam-seeded,scala-
  wam-seeded-no-kernels --repetitions 1`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets scala-wam
  --repetitions 1`
  - `git diff --check`