### PR TITLE
perf(wam-scala): ArrayBuffer CP stack + tightened unify args loop

### DIFF
--- a/templates/targets/scala_wam/runtime.scala.mustache
+++ b/templates/targets/scala_wam/runtime.scala.mustache
@@ -200,7 +200,10 @@ case class AggregateCP(
 final class WamState(
   val regs:      Array[WamTerm],       // REG_ARRAY_SIZE slots; index via reg_to_int
   var envStack:  List[EnvFrame],       // environment frames (Y-registers)
-  var choicePoints: List[ChoicePoint],
+  // ArrayBuffer (LIFO; last = top) instead of List for O(1) push/pop
+  // with no per-op cons-cell allocation. The ChoicePoint instances
+  // themselves are still the same; only the container changed.
+  var choicePoints: mutable.ArrayBuffer[ChoicePoint],
   var trail:     List[TrailEntry],
   var callStack: List[Int],
   var unifyQueue: List[WamTerm],
@@ -282,7 +285,7 @@ object WamRuntime {
     new WamState(
       regs       = regs,
       envStack   = Nil,
-      choicePoints = Nil,
+      choicePoints = mutable.ArrayBuffer.empty[ChoicePoint],
       trail      = Nil,
       callStack  = Nil,
       unifyQueue = Nil,
@@ -340,16 +343,25 @@ object WamRuntime {
     s.trail = s.trail.drop(toUndo.length)
   }
 
+  /** Unification. Recursive on Struct args (JIT-friendly for typical
+   *  shallow terms) but uses an explicit while loop instead of
+   *  args1.zip(args2).forall(...) so the per-Struct case doesn't
+   *  allocate a Tuple2 array. */
   def unify(s: WamState, a: WamTerm, b: WamTerm): Boolean = {
     val da = deref(s.bindings, a)
     val db = deref(s.bindings, b)
+    if (da == db) return true
     (da, db) match {
-      case _ if da == db => true
       case (r @ Ref(_), _) => bindVar(s, r, db); true
       case (_, r @ Ref(_)) => bindVar(s, r, da); true
-      case (Struct(f1, a1, args1), Struct(f2, a2, args2))
-          if f1 == f2 && a1 == a2 =>
-        args1.zip(args2).forall { case (x, y) => unify(s, x, y) }
+      case (Struct(f1, ar1, args1), Struct(f2, ar2, args2))
+          if f1 == f2 && ar1 == ar2 =>
+        var i = 0
+        while (i < ar1) {
+          if (!unify(s, args1(i), args2(i))) return false
+          i += 1
+        }
+        true
       case _ => false
     }
   }
@@ -377,13 +389,25 @@ object WamRuntime {
       nextVarId = s.nextVarId,
       kind      = WamCP
     )
-    s.choicePoints = cp :: s.choicePoints
+    s.choicePoints += cp
   }
 
-  def backtrack(s: WamState): Unit = s.choicePoints match {
-    case Nil =>
+  /** Remove and return the top CP (last element). */
+  private def popCP(s: WamState): ChoicePoint = {
+    val i = s.choicePoints.length - 1
+    val cp = s.choicePoints(i)
+    s.choicePoints.remove(i)
+    cp
+  }
+
+  def backtrack(s: WamState): Unit = {
+    if (s.choicePoints.isEmpty) {
       s.status = Failed
-    case cp :: rest =>
+    } else {
+      val cp = s.choicePoints.last
+      // Restore the saved snapshot. The CP itself is left on the stack
+      // for ForeignCP(non-empty) / AggregateCP cases that mutate it in
+      // place; the WamCP / ForeignCP(Nil) paths pop it below.
       unwindTrail(s, cp.trailLen)
       System.arraycopy(cp.regs, 0, s.regs, 0, REG_ARRAY_SIZE)
       s.envStack   = cp.envStack
@@ -396,13 +420,17 @@ object WamRuntime {
       s.status     = Running
       cp.kind match {
         case ForeignCP(Nil) =>
-          s.choicePoints = rest
+          popCP(s)
           backtrack(s)
         case ForeignCP(sol +: remaining) =>
-          s.choicePoints = cp.copy(kind = ForeignCP(remaining)) :: rest
+          // Replace the top CP's kind in place with the remaining
+          // solutions. ArrayBuffer doesn't have a copy-on-update like
+          // List did; we mutate the slot directly.
+          s.choicePoints(s.choicePoints.length - 1) =
+            cp.copy(kind = ForeignCP(remaining))
           if (!applyBindings(s, sol)) backtrack(s)
         case WamCP =>
-          s.choicePoints = rest
+          popCP(s)
         case AggregateCP(resumePc, _, bagReg, results, consId, emptyId) =>
           // No more body solutions — finalize. Restore was already done
           // above; build the bag and unify with bagReg, then continue
@@ -412,7 +440,7 @@ object WamRuntime {
           // instruction; that case is degenerate (empty bag with no
           // EndAggregate ever reached) so we use cp.pc as a safe stop
           // — see comment below.
-          s.choicePoints = rest
+          popCP(s)
           val bagList = results.foldLeft[WamTerm](Atom(emptyId)) { (tl, hd) =>
             Struct(consId, 2, Array(hd, tl))
           }
@@ -426,6 +454,7 @@ object WamRuntime {
           // first cut — the WAM compiler always emits matching pairs.
           if (!unify(s, s.regs(bagReg), bagList)) backtrack(s)
       }
+    }
   }
 
   /** Recursively dereferences a term, replacing every Ref-on-Ref chain
@@ -569,7 +598,7 @@ object WamRuntime {
                 nextVarId = s.nextVarId,
                 kind      = ForeignCP(rest)
               )
-              s.choicePoints = cp :: s.choicePoints
+              s.choicePoints += cp
             }
             if (applyBindings(s, sol)) s.pc = resumePc else backtrack(s)
         }
@@ -895,7 +924,10 @@ object WamRuntime {
         case "fail/0" =>
           backtrack(s)
         case "!/0" =>
-          s.choicePoints = s.choicePoints.drop(s.choicePoints.length - s.cutBar)
+          // Trim back to cutBar (drop CPs above the cut frontier).
+          // ArrayBuffer.remove(idx, count) removes a contiguous range.
+          val len = s.choicePoints.length
+          if (len > s.cutBar) s.choicePoints.remove(s.cutBar, len - s.cutBar)
           s.pc += 1
 
         // Arithmetic: A1 is target (assignment) or left operand (comparison),
@@ -947,7 +979,7 @@ object WamRuntime {
                   nextVarId = s.nextVarId,
                   kind      = ForeignCP(rest)
                 )
-                s.choicePoints = cp :: s.choicePoints
+                s.choicePoints += cp
               }
               if (applyBindings(s, sols.head)) s.pc = resumePc
               else backtrack(s)
@@ -1042,7 +1074,7 @@ object WamRuntime {
                         nextVarId = s.nextVarId,
                         kind      = ForeignCP(rest)
                       )
-                      s.choicePoints = cp :: s.choicePoints
+                      s.choicePoints += cp
                     }
                     if (applyBindings(s, splits.head)) s.pc = resumePc
                     else backtrack(s)
@@ -1063,7 +1095,7 @@ object WamRuntime {
 
       case CutIte =>
         if (s.choicePoints.nonEmpty)
-          s.choicePoints = s.choicePoints.tail
+          s.choicePoints.remove(s.choicePoints.length - 1)
         s.pc += 1
 
       // --- Aggregation (findall/3) ---
@@ -1093,7 +1125,7 @@ object WamRuntime {
             emptyId     = program.internTable.stringToId.getOrElse("[]", 2)
           )
         )
-        s.choicePoints = cp :: s.choicePoints
+        s.choicePoints += cp
         s.pc += 1
 
       case EndAggregate(templateReg) =>
@@ -1103,12 +1135,15 @@ object WamRuntime {
         // eventually reaches the AggregateCP itself (no more solutions
         // above it), it finalizes and resumes after this EndAggregate.
         val captured = deepDeref(s, s.regs(templateReg))
-        s.choicePoints = s.choicePoints.map { cp =>
-          cp.kind match {
+        var i = 0
+        while (i < s.choicePoints.length) {
+          s.choicePoints(i).kind match {
             case agg: AggregateCP if agg.templateReg == templateReg =>
-              cp.copy(kind = agg.copy(results = captured :: agg.results))
-            case _ => cp
+              s.choicePoints(i) = s.choicePoints(i).copy(
+                kind = agg.copy(results = captured :: agg.results))
+            case _ =>
           }
+          i += 1
         }
         backtrack(s)
 
@@ -1539,7 +1574,7 @@ object WamRuntime {
                     nextVarId = s.nextVarId,
                     kind      = ForeignCP(rest)
                   )
-                  s.choicePoints = cp :: s.choicePoints
+                  s.choicePoints += cp
                 }
                 if (applyBindings(s, sol)) {
                   if (withReturn) s.pc = resumePc else builtinAdvance(s, withReturn)
@@ -1706,7 +1741,8 @@ object WamRuntime {
     program.dispatch.get(key) match {
       case None => Some(Seq.empty)   // unknown predicate → no solutions
       case Some(startPc) =>
-        // Snapshot outer state.
+        // Snapshot outer state. The choicePoints buffer is swapped out
+        // for a fresh empty buffer (O(1)) and restored by reassignment.
         val savedPc        = s.pc
         val savedCallStack = s.callStack
         val savedTrailLen  = s.trail.length
@@ -1724,7 +1760,7 @@ object WamRuntime {
         java.util.Arrays.fill(s.regs.asInstanceOf[Array[AnyRef]], null)
         args.zipWithIndex.foreach { case (v, i) => s.regs(i + 1) = v }
         s.callStack    = Nil
-        s.choicePoints = Nil
+        s.choicePoints = mutable.ArrayBuffer.empty[ChoicePoint]
         s.envStack     = Nil
         s.unifyQueue   = Nil
         s.buildStack   = Nil
@@ -1843,7 +1879,7 @@ object WamRuntime {
         java.util.Arrays.fill(s.regs.asInstanceOf[Array[AnyRef]], null)
         args.zipWithIndex.foreach { case (v, i) => s.regs(i + 1) = v }
         s.callStack    = Nil
-        s.choicePoints = Nil
+        s.choicePoints = mutable.ArrayBuffer.empty[ChoicePoint]
         s.envStack     = Nil
         s.unifyQueue   = Nil
         s.buildStack   = Nil


### PR DESCRIPTION
## Summary

Two structural runtime optimizations:

1. **`ChoicePoint` stack: `List` → `mutable.ArrayBuffer`** — push/pop
   no longer allocates a cons cell per op; cut now uses
   `ArrayBuffer.remove(idx, count)` for an O(1)-with-shrink trim
   instead of `List.drop`'s O(n) re-traversal.
2. **`unify` args loop tightened** — replaced
   `args1.zip(args2).forall { case (x, y) => unify(s, x, y) }` with an
   explicit `while` loop. The `.zip` was building a `Tuple2` array per
   call; the `.forall` was allocating a closure. Both gone.

The recursive form for unify on Struct args is preserved — JIT
handles shallow recursion well, and switching to an iterative
worklist (initial attempt) made shallow unifications *slower*
because of per-call ArrayBuffer allocation. The current form pays
nothing on the hot path (Atom/Ref equality) and only pays a
function-call frame per Struct level.

Test counts unchanged: 10 generator + 46 smoke + 5 classics.

## What's in the diff

### `WamState.choicePoints: mutable.ArrayBuffer[ChoicePoint]`

The previous `List[ChoicePoint]` allocated a cons cell on every push
(`cp :: cps`). On the bench's inner loop, push/pop happens at the
rate of try_me_else / retry_me_else / trust_me — once per clause
attempt — so the cons-cell allocation showed up as background GC
pressure.

ArrayBuffer with `+=` and `remove(length-1)` is O(1) amortised with
no per-op allocation (after the underlying array stops resizing).

Touch points:

| Site | Old | New |
|---|---|---|
| Push (try_me_else / ForeignMulti / AggregateCP) | `cps = cp :: cps` | `cps += cp` |
| Pop (WamCP / ForeignCP(Nil)) | pattern match `cp :: rest` | new `popCP` helper |
| Cut `!/0` | `cps.drop(cps.length - cutBar)` | `cps.remove(cutBar, len - cutBar)` |
| ITE soft cut | `cps.tail` | `cps.remove(cps.length - 1)` |
| EndAggregate accumulate | `cps.map { ... }` (rebuild) | in-place `while` loop |
| Save/restore in `metaCallSucceeds` / `metaCollectAll` | reassign `var` | reassign `var` (same pattern, allocates a fresh `ArrayBuffer.empty` for the sub-call scope) |

### Tightened `unify` args loop

```scala
// Before
case (Struct(f1, a1, args1), Struct(f2, a2, args2)) if f1 == f2 && a1 == a2 =>
  args1.zip(args2).forall { case (x, y) => unify(s, x, y) }

// After
case (Struct(f1, ar1, args1), Struct(f2, ar2, args2)) if f1 == f2 && ar1 == ar2 =>
  var i = 0
  while (i < ar1) {
    if (!unify(s, args1(i), args2(i))) return false
    i += 1
  }
  true
```

Saves a `Tuple2[]` allocation, a closure for `forall`, and an
iterator allocation per Struct unification. For the hot path
(Atom/Ref) the case never fires and the change is invisible.

### Bug fix — missed brace in `backtrack`

The Scala `if/else` rewrite of `backtrack`'s top-level structure
needed three closing braces (`match`, `else`, `def`) but only had
two. Caught immediately by the smoke compile-step.

## What was tried but reverted

- **Iterative unify with a worklist `ArrayBuffer[(WamTerm, WamTerm)]`.**
  The intent was to eliminate JVM stack risk on deep terms and to
  skip method-call frames per Struct level. Measured worse on the
  bench because every `unify` call (including Atom-vs-Atom — the hot
  path) now allocates a new ArrayBuffer. Reverted to recursive +
  while-loop tightening, which preserves the JIT-friendly hot path.

## Bench

Numbers on a loaded host (system load 20+) are too noisy for a
clean before/after comparison — variance between runs swamps the
expected per-iter delta on these microbenchmarks. The structural
wins (no per-push cons-cell allocation, no per-Struct tuple/closure
allocation) compound across longer-running workloads where GC
pressure shows up.

The 46 smoke tests + 5 classic-program regressions all pass, so the
changes are correctness-preserving.

## Test plan

- [ ] `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_generator.pl"),run_tests,halt' -t 'halt(1)'` → 10/10 pass.
- [ ] With `scalac` on PATH or `SCALA_SMOKE_TESTS=1`:
      `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_runtime_smoke.pl"),run_tests,halt' -t 'halt(1)'` → 46/46 pass.
- [ ] With same env: `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_classic_programs.pl"),run_tests,halt' -t 'halt(1)'` → 5/5 pass.

## Out of scope

- Other potential perf wins not yet tried:
  - `bindings` Map → array-keyed by var id (Refs have integer ids).
  - `unifyQueue` and `buildStack` similarly converted to ArrayBuffer.
  - Pre-allocating a worklist on `WamState` for nested unify cases.
- These need a quieter host to measure properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
