### PR TITLE
feat(wam-scala): contiguous clauses + succ/atom_concat/sub_atom + eval

### DIFF
--- a/src/unifyweaver/targets/wam_scala_target.pl
+++ b/src/unifyweaver/targets/wam_scala_target.pl
@@ -296,51 +296,6 @@ wam_parts_to_scala(["switch_on_term" | Rest], Lit) :-
     parse_switch_on_term_tokens(Rest, ConstCases, StructCases, ListLabel),
     format_switch_on_term_lit(ConstCases, StructCases, ListLabel, Lit).
 
-parse_switch_on_term_tokens([CLenStr | Rest0], ConstCases, StructCases, ListLabel) :-
-    number_string(CLen, CLenStr),
-    length(CTokens, CLen),
-    append(CTokens, [SLenStr | Rest1], Rest0),
-    number_string(SLen, SLenStr),
-    length(STokens, SLen),
-    append(STokens, [ListLabel], Rest1),
-    maplist(parse_const_case_token, CTokens, ConstCases),
-    maplist(parse_struct_case_token, STokens, StructCases).
-
-%% parse_const_case_token("<value>:<label>", -case(ValueLit, Label))
-parse_const_case_token(Token, case(ValueLit, Label)) :-
-    split_at_first_colon(Token, ValueStr, Label),
-    constant_to_scala_term(ValueStr, ValueLit).
-
-%% parse_struct_case_token("<functor>/<arity>:<label>", -case(FId, Arity, Label))
-parse_struct_case_token(Token, struct(FId, Arity, Label)) :-
-    split_at_first_colon(Token, FAStr, Label),
-    parse_functor_arity(FAStr, FName, Arity),
-    intern_scala_atom(FName, FId).
-
-%% split_at_first_colon(+Token, -Before, -After)
-%  Splits at the first ":" — used by switch_on_term parsers where the
-%  value half ([], 0, f/2) never contains a ":".
-split_at_first_colon(Token, Before, After) :-
-    sub_string(Token, B, 1, _, ":"),
-    !,
-    sub_string(Token, 0, B, _, Before),
-    B1 is B + 1,
-    sub_string(Token, B1, _, 0, After).
-
-format_switch_on_term_lit(ConstCases, StructCases, ListLabel, Lit) :-
-    maplist(const_case_lit, ConstCases, ConstLits),
-    atomic_list_concat(ConstLits, ', ', ConstStr),
-    maplist(struct_case_lit, StructCases, StructLits),
-    atomic_list_concat(StructLits, ', ', StructStr),
-    format(string(Lit),
-           'SwitchOnTerm(Array(~w), Array(~w), "~w")',
-           [ConstStr, StructStr, ListLabel]).
-
-const_case_lit(case(ValueLit, Label), Lit) :-
-    format(string(Lit), 'TermSwitchConst(~w, "~w")', [ValueLit, Label]).
-struct_case_lit(struct(FId, Arity, Label), Lit) :-
-    format(string(Lit), 'TermSwitchStruct(~w, ~w, "~w")', [FId, Arity, Label]).
-
 % --- ITE soft cut ---
 wam_parts_to_scala(["cut_ite"], 'CutIte').
 
@@ -433,6 +388,57 @@ last_slash_index(Atom, Index) :-
     findall(B, sub_atom(Atom, B, 1, _, '/'), Bs),
     Bs \= [],
     last(Bs, Index).
+
+% ----------------------------------------------------------
+% switch_on_term parsing helpers
+% ----------------------------------------------------------
+% Lifted out of the wam_parts_to_scala block so that block stays
+% contiguous (no `:- discontiguous` directive needed).
+
+parse_switch_on_term_tokens([CLenStr | Rest0], ConstCases, StructCases, ListLabel) :-
+    number_string(CLen, CLenStr),
+    length(CTokens, CLen),
+    append(CTokens, [SLenStr | Rest1], Rest0),
+    number_string(SLen, SLenStr),
+    length(STokens, SLen),
+    append(STokens, [ListLabel], Rest1),
+    maplist(parse_const_case_token, CTokens, ConstCases),
+    maplist(parse_struct_case_token, STokens, StructCases).
+
+%% parse_const_case_token("<value>:<label>", -case(ValueLit, Label))
+parse_const_case_token(Token, case(ValueLit, Label)) :-
+    split_at_first_colon(Token, ValueStr, Label),
+    constant_to_scala_term(ValueStr, ValueLit).
+
+%% parse_struct_case_token("<functor>/<arity>:<label>", -case(FId, Arity, Label))
+parse_struct_case_token(Token, struct(FId, Arity, Label)) :-
+    split_at_first_colon(Token, FAStr, Label),
+    parse_functor_arity(FAStr, FName, Arity),
+    intern_scala_atom(FName, FId).
+
+%% split_at_first_colon(+Token, -Before, -After)
+%  Splits at the first ":" — used by switch_on_term parsers where the
+%  value half ([], 0, f/2) never contains a ":".
+split_at_first_colon(Token, Before, After) :-
+    sub_string(Token, B, 1, _, ":"),
+    !,
+    sub_string(Token, 0, B, _, Before),
+    B1 is B + 1,
+    sub_string(Token, B1, _, 0, After).
+
+format_switch_on_term_lit(ConstCases, StructCases, ListLabel, Lit) :-
+    maplist(const_case_lit, ConstCases, ConstLits),
+    atomic_list_concat(ConstLits, ', ', ConstStr),
+    maplist(struct_case_lit, StructCases, StructLits),
+    atomic_list_concat(StructLits, ', ', StructStr),
+    format(string(Lit),
+           'SwitchOnTerm(Array(~w), Array(~w), "~w")',
+           [ConstStr, StructStr, ListLabel]).
+
+const_case_lit(case(ValueLit, Label), Lit) :-
+    format(string(Lit), 'TermSwitchConst(~w, "~w")', [ValueLit, Label]).
+struct_case_lit(struct(FId, Arity, Label), Lit) :-
+    format(string(Lit), 'TermSwitchStruct(~w, ~w, "~w")', [FId, Arity, Label]).
 
 % ============================================================================
 % WAM TEXT → SCALA INSTRUCTION ARRAY

--- a/templates/targets/scala_wam/runtime.scala.mustache
+++ b/templates/targets/scala_wam/runtime.scala.mustache
@@ -1322,6 +1322,9 @@ object WamRuntime {
     else if (pred == "nl"          && arity == 0)   { nl0(s, withReturn); true }
     else if (pred == "between"     && arity == 3)   { between3(s, program, withReturn); true }
     else if (pred == "format"      && arity == 2)   { format2(s, program, withReturn); true }
+    else if (pred == "succ"        && arity == 2)   { succ2(s, withReturn); true }
+    else if (pred == "atom_concat" && arity == 3)   { atomConcat3(s, program, withReturn); true }
+    else if (pred == "sub_atom"    && arity == 5)   { subAtom5(s, program, withReturn); true }
     else false
   }
 
@@ -1541,6 +1544,79 @@ object WamRuntime {
       }
     }
     sb.toString
+  }
+
+  /** succ(+X, ?Y) / succ(?X, +Y): Y = X + 1, with both args required to
+   *  be non-negative integers in any solution. Bidirectional. */
+  def succ2(s: WamState, withReturn: Boolean): Unit = {
+    val a = deref(s.bindings, s.regs(1))
+    val b = deref(s.bindings, s.regs(2))
+    (numOf(a), numOf(b)) match {
+      case (Some(NInt(x)), _) if x >= 0 =>
+        if (unify(s, s.regs(2), IntTerm(x + 1))) builtinAdvance(s, withReturn)
+        else backtrack(s)
+      case (_, Some(NInt(y))) if y > 0 =>
+        if (unify(s, s.regs(1), IntTerm(y - 1))) builtinAdvance(s, withReturn)
+        else backtrack(s)
+      case _ => backtrack(s)
+    }
+  }
+
+  /** atom_concat(+A, +B, ?C): C is the concatenation of A and B as
+   *  strings. Forward mode only (A and B both ground). The reverse
+   *  mode would need to enumerate all (A, B) splits of C and inject
+   *  each substring as an atom in the intern table — which is
+   *  immutable in this runtime — so it's not supported.
+   *
+   *  Numeric A or B are rendered via their toString form.
+   */
+  def atomConcat3(s: WamState, program: WamProgram, withReturn: Boolean): Unit = {
+    def stringOf(t: WamTerm): Option[String] = t match {
+      case Atom(id) if id >= 0 && id < program.internTable.idToString.length =>
+        Some(program.internTable.idToString(id))
+      case IntTerm(n)   => Some(n.toString)
+      case FloatTerm(d) => Some(d.toString)
+      case _            => None
+    }
+    val a = deref(s.bindings, s.regs(1))
+    val b = deref(s.bindings, s.regs(2))
+    (stringOf(a), stringOf(b)) match {
+      case (Some(sa), Some(sb)) =>
+        val concat = sa + sb
+        // Look up the concatenation in the intern table; if the user
+        // didn't pre-intern it (via intern_atoms), the resulting atom
+        // gets id -1 and unification will fail unless arg3 is unbound.
+        val id = program.internTable.stringToId.getOrElse(concat, -1)
+        if (unify(s, s.regs(3), Atom(id))) builtinAdvance(s, withReturn)
+        else backtrack(s)
+      case _ => backtrack(s)
+    }
+  }
+
+  /** sub_atom(+Atom, +Before, +Length, ?After, ?SubAtom): extracts a
+   *  substring. Atom, Before, Length must all be ground; After and
+   *  SubAtom are derived. Multi-solution modes (any of B/L/A unbound)
+   *  are not supported in this implementation. */
+  def subAtom5(s: WamState, program: WamProgram, withReturn: Boolean): Unit = {
+    val atom   = deref(s.bindings, s.regs(1))
+    val before = deref(s.bindings, s.regs(2))
+    val length = deref(s.bindings, s.regs(3))
+    val str = atom match {
+      case Atom(id) if id >= 0 && id < program.internTable.idToString.length =>
+        program.internTable.idToString(id)
+      case _ => return backtrack(s)
+    }
+    (numOf(before), numOf(length)) match {
+      case (Some(NInt(b)), Some(NInt(l)))
+          if b >= 0 && l >= 0 && b + l <= str.length =>
+        val subStr = str.substring(b, b + l)
+        val after  = str.length - b - l
+        val subId  = program.internTable.stringToId.getOrElse(subStr, -1)
+        val ok = unify(s, s.regs(5), Atom(subId)) &&
+                 unify(s, s.regs(4), IntTerm(after))
+        if (ok) builtinAdvance(s, withReturn) else backtrack(s)
+      case _ => backtrack(s)
+    }
   }
 
   /** between(+Low, +High, ?X): X enumerates integers in [Low, High].

--- a/tests/test_wam_scala_classic_programs.pl
+++ b/tests/test_wam_scala_classic_programs.pl
@@ -51,6 +51,22 @@ user:fib(N, R) :- N > 1, N1 is N - 1, N2 is N - 2,
                   user:fib(N1, R1), user:fib(N2, R2),
                   R is R1 + R2.
 
+% --- Small expression evaluator ---
+% Recursive evaluator for arithmetic expressions built as compound
+% terms (+, *, -). Tests structure pattern matching on heads with
+% non-list compound terms, plus arithmetic via is/2.
+:- dynamic user:wam_eval/2.
+user:wam_eval(N, R)     :- number(N), !, R = N.
+user:wam_eval(A + B, R) :- user:wam_eval(A, RA),
+                           user:wam_eval(B, RB),
+                           R is RA + RB.
+user:wam_eval(A * B, R) :- user:wam_eval(A, RA),
+                           user:wam_eval(B, RB),
+                           R is RA * RB.
+user:wam_eval(A - B, R) :- user:wam_eval(A, RA),
+                           user:wam_eval(B, RB),
+                           R is RA - RB.
+
 % --- N-queens via permutation + safe ---
 % Uses between/3 to build the row list (1..N), permutation/2 to try
 % column assignments, and safe/1 to reject conflicts. Combinatorial
@@ -172,6 +188,23 @@ test(fibonacci) :-
             verify_scala_args(TmpDir, 'fib/2', ['10', '55'],   "true"),
             verify_scala_args(TmpDir, 'fib/2', ['15', '610'],  "true"),
             verify_scala_args(TmpDir, 'fib/2', ['10', '54'],   "false")
+        )).
+
+% Expression evaluator — exercises structure pattern matching with
+% non-list compound terms, recursion, the cut from clause 1, and
+% arithmetic via is/2.
+test(expression_evaluator) :-
+    with_scala_project(
+        [user:wam_eval/2],
+        _Opts,
+        TmpDir,
+        (
+            verify_scala_args(TmpDir, 'wam_eval/2', ['5', '5'],          "true"),
+            verify_scala_args(TmpDir, 'wam_eval/2', ['+(2,3)', '5'],     "true"),
+            verify_scala_args(TmpDir, 'wam_eval/2', ['*(+(2,3),4)', '20'], "true"),
+            verify_scala_args(TmpDir, 'wam_eval/2', ['-(10,3)', '7'],    "true"),
+            verify_scala_args(TmpDir, 'wam_eval/2', ['+(2,*(3,4))', '14'], "true"),
+            verify_scala_args(TmpDir, 'wam_eval/2', ['*(+(2,3),4)', '19'], "false")
         )).
 
 % N-queens — exercises permutation, recursion, comparison, switch_on_term,

--- a/tests/test_wam_scala_runtime_smoke.pl
+++ b/tests/test_wam_scala_runtime_smoke.pl
@@ -109,6 +109,9 @@
 :- dynamic user:wam_format_w/1.
 :- dynamic user:wam_format_combo/2.
 :- dynamic user:wam_format_dn/1.
+:- dynamic user:wam_succ_q/2.
+:- dynamic user:wam_atom_concat_q/3.
+:- dynamic user:wam_sub_atom_q/5.
 
 user:wam_fact(a).
 user:wam_execute_caller(X)    :- user:wam_fact(X).
@@ -280,6 +283,11 @@ user:wam_between_collect(L, H, R)   :- findall(X, between(L, H, X), R).
 user:wam_format_w(X)            :- format("v=~w", [X]).
 user:wam_format_combo(X, Y)     :- format("~a is ~w!", [X, Y]).
 user:wam_format_dn(X)           :- format("n=~d~n", [X]).
+
+% --- succ/2, atom_concat/3, sub_atom/5 ---
+user:wam_succ_q(X, Y)              :- succ(X, Y).
+user:wam_atom_concat_q(A, B, C)    :- atom_concat(A, B, C).
+user:wam_sub_atom_q(A, B, L, At, S):- sub_atom(A, B, L, At, S).
 
 % ============================================================
 % Condition: only run if scalac is available
@@ -987,6 +995,54 @@ test(builtin_format) :-
             % ~n inserts a newline, which normalize_space turns into a
             % single space between the format output and "true".
             verify_scala(TmpDir, 'wam_format_dn/1', '42', "n=42 true")
+        )).
+
+test(builtin_succ) :-
+    with_scala_project(
+        [user:wam_succ_q/2],
+        _Opts,
+        TmpDir,
+        (
+            verify_scala_args(TmpDir, 'wam_succ_q/2', ['3', '4'], "true"),
+            verify_scala_args(TmpDir, 'wam_succ_q/2', ['0', '1'], "true"),
+            verify_scala_args(TmpDir, 'wam_succ_q/2', ['3', '5'], "false"),
+            verify_scala_args(TmpDir, 'wam_succ_q/2', ['-1', '0'], "false")
+        )).
+
+test(builtin_atom_concat) :-
+    with_scala_project(
+        [user:wam_atom_concat_q/3],
+        % Pre-intern both operands and the expected concat results so
+        % the runtime intern table can match the synthesised "ab" / "hi"
+        % strings against arg3.
+        [ intern_atoms([a, b, ab, hello, world, helloworld]) ],
+        TmpDir,
+        (
+            verify_scala_args(TmpDir, 'wam_atom_concat_q/3',
+                              ['a', 'b', 'ab'], "true"),
+            verify_scala_args(TmpDir, 'wam_atom_concat_q/3',
+                              ['hello', 'world', 'helloworld'], "true"),
+            verify_scala_args(TmpDir, 'wam_atom_concat_q/3',
+                              ['hello', 'world', 'helloworlds'], "false")
+        )).
+
+test(builtin_sub_atom) :-
+    with_scala_project(
+        [user:wam_sub_atom_q/5],
+        [ intern_atoms([hello, hel, ell, llo, '']) ],
+        TmpDir,
+        (
+            % sub_atom(hello, 0, 3, After, Sub) → After=2, Sub=hel
+            verify_scala_args(TmpDir, 'wam_sub_atom_q/5',
+                              ['hello', '0', '3', '2', 'hel'], "true"),
+            verify_scala_args(TmpDir, 'wam_sub_atom_q/5',
+                              ['hello', '1', '3', '1', 'ell'], "true"),
+            verify_scala_args(TmpDir, 'wam_sub_atom_q/5',
+                              ['hello', '2', '3', '0', 'llo'], "true"),
+            verify_scala_args(TmpDir, 'wam_sub_atom_q/5',
+                              ['hello', '0', '5', '0', 'hello'], "true"),
+            verify_scala_args(TmpDir, 'wam_sub_atom_q/5',
+                              ['hello', '0', '3', '2', 'wrong'], "false")
         )).
 
 % Multi-query stream mode: run a batch of queries in a single JVM


### PR DESCRIPTION
## Summary

Three small polish items:

1. **Fix the `discontiguous wam_parts_to_scala/2` warning** by
   re-arranging helper predicates that had been wedged between
   instruction clauses. No `:- discontiguous` directive — the user
   asked for a real fix.
2. **Three small builtins**: `succ/2`, `atom_concat/3`, `sub_atom/5`.
3. **A 6th classic regression**: a small recursive arithmetic
   expression evaluator (`+`, `-`, `*` over compound terms).

| | Before | After |
|---|---|---|
| Generator tests | 10 | 10 |
| Smoke tests | 46 | **49** |
| Classic-programs tests | 5 | **6** |

## What's in the diff

### Re-arranging the `wam_parts_to_scala/2` clauses

The accumulated `switch_on_term` parsing helpers
(`parse_switch_on_term_tokens`, `parse_const_case_token`,
`parse_struct_case_token`, `split_at_first_colon`,
`format_switch_on_term_lit`, `const_case_lit`, `struct_case_lit`)
had grown between the `switch_on_term` clause and the `cut_ite`
clause of `wam_parts_to_scala/2`, breaking contiguity and producing
the warning that's been flagging on every smoke run.

Lifted those helpers out and into the existing helpers section
(near `parse_switch_cases`, `strip_arity_suffix`,
`constant_to_scala_term`, `parse_functor_arity`, `last_slash_index`).
All `wam_parts_to_scala/2` clauses are now contiguous. No
`:- discontiguous` directive needed.

### `succ/2` — bidirectional integer successor

`succ(+X, ?Y)` → `Y = X + 1`. `succ(?X, +Y)` → `X = Y - 1` if `Y > 0`.
Both modes deterministic. Backtracks if either operand is negative
(per SWI-Prolog semantics).

### `atom_concat/3` — forward-mode string concatenation

`atom_concat(+A, +B, ?C)` → `C` is the concatenation of `A` and `B`
as their interned strings. Numeric operands get `toString`'d.
Forward mode only — the inverse mode (enumerate splits of `C`)
would need to inject substrings into the intern table, which is
immutable in this runtime, so we don't support it.

### `sub_atom/5` — forward-mode substring extraction

`sub_atom(+Atom, +Before, +Length, ?After, ?SubAtom)`. `Atom`,
`Before`, `Length` must be ground; `After` and `SubAtom` are
derived. Multi-solution modes (any of `B`/`L`/`A` unbound) are not
supported — they'd need the same intern-table injection problem
plus `ForeignCP` enumeration.

### Expression evaluator classic

```prolog
wam_eval(N, R)     :- number(N), !, R = N.
wam_eval(A + B, R) :- wam_eval(A, RA), wam_eval(B, RB), R is RA + RB.
wam_eval(A * B, R) :- wam_eval(A, RA), wam_eval(B, RB), R is RA * RB.
wam_eval(A - B, R) :- wam_eval(A, RA), wam_eval(B, RB), R is RA - RB.
```

Test queries pass arithmetic expressions in the WAM-friendly prefix
form (`+(2,3)`, `*(+(2,3),4)`) and assert their integer result.
Different from the existing list-based and combinatorial classics —
this one tests struct pattern matching on non-list compound heads,
recursion, the cut from clause 1 (commit on `number/1`), and
nested `is/2` arithmetic in one program.

## Test plan

- [ ] `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_generator.pl"),run_tests,halt' -t 'halt(1)'` → 10/10 pass; **no `discontiguous` warning** in output.
- [ ] With `scalac` on PATH or `SCALA_SMOKE_TESTS=1`:
      `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_runtime_smoke.pl"),run_tests,halt' -t 'halt(1)'` → 49/49 pass.
- [ ] With same env: `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_classic_programs.pl"),run_tests,halt' -t 'halt(1)'` → 6/6 pass.

## Out of scope

- Multi-solution / inverse modes for `atom_concat/3` and `sub_atom/5`.
  Both would need a mutable runtime intern table; the immutable
  `WamProgram.internTable` design is a deliberate architectural
  choice from the original spec and changing it touches more than
  these two builtins.
- More classics (eight queens, Tower of Hanoi, symbolic
  differentiation). Each is mechanical to add but bench/regression
  runtime grows linearly.
- Phase S8 LMDB seam, dynamic clauses (`assert/retract`). Both
  remain the headline open items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
