### PR TITLE
bench(scala): Add Scala effective-distance benchmark data modes

### DIFF
--- a/docs/proposals/WAM_SCALA_HYBRID_SPEC.md
+++ b/docs/proposals/WAM_SCALA_HYBRID_SPEC.md
@@ -458,6 +458,11 @@ registered in the benchmark matrix as `scala-wam-seeded`,
 Scala project with `scalac` and run the common TSV-emitting
 `EffectiveDistanceRunner`, giving the matrix the same seeded/accumulated
 kernel/no-kernel comparison surface used by the other WAM families.
+The generator also accepts `sidecar`, `inline`, `artifact`, and `auto`
+benchmark data modes. The first matrix artifact targets are registered
+separately as `scala-wam-seeded-artifact` and
+`scala-wam-accumulated-artifact`; they currently exercise a file-backed
+category-parent artifact, not a memory-mapped or LMDB artifact backend.
 
 ## 13. Example Target-Level Declarations
 

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -132,8 +132,10 @@ def available_targets(requested: list[str]) -> list[str]:
     }
     scala_matrix_targets = {
         "scala-wam-seeded",
+        "scala-wam-seeded-artifact",
         "scala-wam-seeded-no-kernels",
         "scala-wam-accumulated",
+        "scala-wam-accumulated-artifact",
         "scala-wam-accumulated-no-kernels",
     }
     for target in requested:

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -257,9 +257,11 @@ def scala_sources(project_dir: Path) -> list[str]:
     return sorted(str(path) for path in (project_dir / "src" / "main" / "scala").rglob("*.scala"))
 
 
-def build_wam_scala_effective_distance(root: Path, scale: str, variant: str, kernel_mode: str) -> list[str]:
+def build_wam_scala_effective_distance(
+    root: Path, scale: str, variant: str, kernel_mode: str, data_mode: str = "auto"
+) -> list[str]:
     facts_path = require_file(BENCH_DIR / scale / "facts.pl")
-    project_dir = root / f"wam_scala_{variant}_{kernel_mode}" / scale
+    project_dir = root / f"wam_scala_{variant}_{kernel_mode}_{data_mode}" / scale
     project_dir.mkdir(parents=True, exist_ok=True)
     run_command(
         [
@@ -272,6 +274,7 @@ def build_wam_scala_effective_distance(root: Path, scale: str, variant: str, ker
             str(project_dir),
             variant,
             kernel_mode,
+            data_mode,
         ],
         cwd=ROOT,
     )
@@ -823,10 +826,18 @@ def main() -> int:
                     command = build_wam_go_effective_distance(temp_root, scale, "kernels_off")
                 elif target == "scala-wam-seeded":
                     command = build_wam_scala_effective_distance(temp_root, scale, "seeded", "kernels_on")
+                elif target == "scala-wam-seeded-artifact":
+                    command = build_wam_scala_effective_distance(
+                        temp_root, scale, "seeded", "kernels_on", "artifact"
+                    )
                 elif target == "scala-wam-seeded-no-kernels":
                     command = build_wam_scala_effective_distance(temp_root, scale, "seeded", "kernels_off")
                 elif target == "scala-wam-accumulated":
                     command = build_wam_scala_effective_distance(temp_root, scale, "accumulated", "kernels_on")
+                elif target == "scala-wam-accumulated-artifact":
+                    command = build_wam_scala_effective_distance(
+                        temp_root, scale, "accumulated", "kernels_on", "artifact"
+                    )
                 elif target == "scala-wam-accumulated-no-kernels":
                     command = build_wam_scala_effective_distance(temp_root, scale, "accumulated", "kernels_off")
                 elif target == "clojure-wam-accumulated":

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -87,6 +87,11 @@ TARGETS: dict[str, TargetInfo] = {
         "hybrid-wam",
         "Hybrid WAM Scala effective-distance runner with seeded helpers and kernels enabled",
     ),
+    "scala-wam-seeded-artifact": TargetInfo(
+        "scala-wam-seeded-artifact",
+        "hybrid-wam",
+        "Hybrid WAM Scala effective-distance runner with seeded helpers, kernels enabled, and file-backed artifact data",
+    ),
     "scala-wam-seeded-no-kernels": TargetInfo(
         "scala-wam-seeded-no-kernels",
         "hybrid-wam",
@@ -96,6 +101,11 @@ TARGETS: dict[str, TargetInfo] = {
         "scala-wam-accumulated",
         "hybrid-wam",
         "Hybrid WAM Scala effective-distance runner with optimized accumulated helpers and kernels enabled",
+    ),
+    "scala-wam-accumulated-artifact": TargetInfo(
+        "scala-wam-accumulated-artifact",
+        "hybrid-wam",
+        "Hybrid WAM Scala effective-distance runner with optimized accumulated helpers, kernels enabled, and file-backed artifact data",
     ),
     "scala-wam-accumulated-no-kernels": TargetInfo(
         "scala-wam-accumulated-no-kernels",
@@ -299,6 +309,12 @@ TARGET_SETS: dict[str, list[str]] = {
         "scala-wam-seeded-no-kernels",
         "scala-wam-accumulated",
         "scala-wam-accumulated-no-kernels",
+    ],
+    "scala-wam-artifact": [
+        "scala-wam-seeded",
+        "scala-wam-seeded-artifact",
+        "scala-wam-accumulated",
+        "scala-wam-accumulated-artifact",
     ],
     "clojure-wam": [
         "clojure-wam-accumulated",

--- a/examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl
@@ -1,6 +1,9 @@
 :- module(generate_wam_scala_effective_distance_benchmark,
           [ main/0,
             generate/4,
+            generate/5,
+            parse_benchmark_data_mode/2,
+            benchmark_effective_data_mode/3,
             collect_wam_predicates/2,
             scala_effective_distance_runner_code/2
           ]).
@@ -19,7 +22,7 @@
 %%
 %% Usage:
 %%   swipl -q -s generate_wam_scala_effective_distance_benchmark.pl -- \
-%%       <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off]
+%%       <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off] [sidecar|inline|artifact|auto]
 
 benchmark_workload_path(Path) :-
     source_file(benchmark_workload_path(_), ThisFile),
@@ -30,21 +33,25 @@ main :-
     current_prolog_flag(argv, Argv),
     (   Argv == []
     ->  true
-    ;   Argv = [FactsPath, OutputDir, VariantAtom, KernelModeAtom]
+    ;   Argv = [FactsPath, OutputDir, VariantAtom, KernelModeAtom, DataModeAtom]
     ->  true
+    ;   Argv = [FactsPath, OutputDir, VariantAtom, KernelModeAtom]
+    ->  DataModeAtom = auto
     ;   Argv = [FactsPath, OutputDir, VariantAtom]
-    ->  KernelModeAtom = kernels_on
+    ->  KernelModeAtom = kernels_on,
+        DataModeAtom = auto
     ;   Argv = [FactsPath, OutputDir]
     ->  VariantAtom = accumulated,
-        KernelModeAtom = kernels_on
+        KernelModeAtom = kernels_on,
+        DataModeAtom = auto
     ;   format(user_error,
-            'Usage: ... -- <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off]~n',
+            'Usage: ... -- <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off] [sidecar|inline|artifact|auto]~n',
             []),
         halt(1)
     ),
     (   Argv == []
     ->  true
-    ;   generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom),
+    ;   generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom, DataModeAtom),
         halt(0)
     ).
 
@@ -53,6 +60,9 @@ main :-
     halt(1).
 
 generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom) :-
+    generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom, auto).
+
+generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom, DataModeAtom) :-
     must_exist_file(FactsPath),
     benchmark_workload_path(WorkloadPath),
     reset_benchmark_predicates,
@@ -66,12 +76,13 @@ generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom) :-
     maybe_load_optimized_predicates(VariantAtom, ScriptCode),
     maybe_assert_seeded_helper(VariantAtom),
     collect_wam_predicates(KernelModeAtom, Predicates),
-    scala_options(OutputDir, KernelModeAtom, Options),
+    parse_benchmark_data_mode(DataModeAtom, DataMode),
+    scala_options(OutputDir, KernelModeAtom, DataMode, Options),
     write_wam_scala_project(Predicates, Options, OutputDir),
     append_effective_distance_runner(OutputDir),
     format(user_error,
-           '[WAM-Scala-EffectiveDistance] facts=~w variant=~w kernels=~w output=~w~n',
-           [FactsPath, VariantAtom, KernelModeAtom, OutputDir]).
+           '[WAM-Scala-EffectiveDistance] facts=~w variant=~w kernels=~w data_mode=~w output=~w~n',
+           [FactsPath, VariantAtom, KernelModeAtom, DataMode, OutputDir]).
 
 reset_benchmark_predicates :-
     forall(member(Name/Arity,
@@ -107,18 +118,72 @@ parse_variant(accumulated, [
     seeded_accumulation(auto)
 ]).
 
-scala_options(OutputDir, kernels_on, Options) :-
-    category_parent_csv_path(OutputDir, CsvPath),
-    write_category_parent_csv(CsvPath),
+parse_benchmark_data_mode(sidecar, sidecar).
+parse_benchmark_data_mode(inline, inline).
+parse_benchmark_data_mode(artifact, artifact).
+parse_benchmark_data_mode(auto, Mode) :-
+    (   benchmark_declared_data_mode(DeclaredMode),
+        DeclaredMode \== auto
+    ->  parse_benchmark_data_mode(DeclaredMode, Mode)
+    ;   benchmark_fact_volume(RowCount),
+        (   RowCount >= 128
+        ->  Mode = sidecar
+        ;   Mode = inline
+        )
+    ).
+
+benchmark_declared_data_mode(Mode) :-
+    member(Name,
+           [ wam_scala_benchmark_data_mode,
+             benchmark_data_mode
+           ]),
+    current_predicate(user:Name/1),
+    Goal =.. [Name, DeclaredMode],
+    once(call(user:Goal)),
+    memberchk(DeclaredMode, [auto, sidecar, inline, artifact]),
+    Mode = DeclaredMode.
+
+benchmark_relation_declared_data_mode(Relation, Mode) :-
+    member(Name,
+           [ wam_scala_benchmark_relation_data_mode,
+             benchmark_relation_data_mode
+           ]),
+    current_predicate(user:Name/2),
+    Goal =.. [Name, Relation, DeclaredMode],
+    once(call(user:Goal)),
+    memberchk(DeclaredMode, [auto, sidecar, inline, artifact]),
+    Mode = DeclaredMode.
+
+benchmark_effective_data_mode(Relation, DataMode, RelationMode) :-
+    (   benchmark_relation_declared_data_mode(Relation, DeclaredMode),
+        DeclaredMode \== auto
+    ->  parse_benchmark_data_mode(DeclaredMode, RelationMode)
+    ;   RelationMode = DataMode
+    ).
+
+benchmark_fact_volume(RowCount) :-
+    benchmark_fact_count(user:category_parent/2, ParentCount),
+    benchmark_fact_count(user:article_category/2, ArticleCount),
+    benchmark_fact_count(user:root_category/1, RootCount),
+    RowCount is ParentCount + ArticleCount + RootCount.
+
+benchmark_fact_count(Module:Name/Arity, Count) :-
+    functor(Goal, Name, Arity),
+    findall(Goal, Module:Goal, Goals),
+    length(Goals, Count).
+
+scala_options(OutputDir, kernels_on, DataMode, Options) :-
+    benchmark_effective_data_mode(category_parent, DataMode, ParentMode),
     benchmark_atoms(Atoms),
+    scala_fact_source_for_category_parent(OutputDir, ParentMode, FactSource),
     Options = [
         package('generated.wam_scala_effective_distance.core'),
         runtime_package('generated.wam_scala_effective_distance.core'),
         module_name('wam-scala-effective-distance'),
         intern_atoms(Atoms),
-        scala_fact_sources([source(category_parent/2, file(CsvPath))])
+        scala_fact_sources([FactSource])
     ].
-scala_options(_OutputDir, kernels_off, Options) :-
+scala_options(_OutputDir, kernels_off, _DataMode, Options) :-
     benchmark_atoms(Atoms),
     Options = [
         package('generated.wam_scala_effective_distance.core'),
@@ -126,6 +191,16 @@ scala_options(_OutputDir, kernels_off, Options) :-
         module_name('wam-scala-effective-distance'),
         intern_atoms(Atoms)
     ].
+
+scala_fact_source_for_category_parent(_OutputDir, inline, source(category_parent/2, Tuples)) :-
+    findall([Child, Parent], current_category_parent_fact(Child, Parent), Tuples0),
+    sort(Tuples0, Tuples).
+scala_fact_source_for_category_parent(OutputDir, sidecar, source(category_parent/2, file(CsvPath))) :-
+    category_parent_csv_path(OutputDir, sidecar, CsvPath),
+    write_category_parent_csv(CsvPath).
+scala_fact_source_for_category_parent(OutputDir, artifact, source(category_parent/2, file(CsvPath))) :-
+    category_parent_csv_path(OutputDir, artifact, CsvPath),
+    write_category_parent_csv(CsvPath).
 
 collect_wam_predicates(kernels_on, [
     user:dimension_n/1,
@@ -139,10 +214,14 @@ collect_wam_predicates(kernels_off, [
     user:category_ancestor/4
 ]).
 
-category_parent_csv_path(OutputDir, CsvPath) :-
+category_parent_csv_path(OutputDir, sidecar, CsvPath) :-
     directory_file_path(OutputDir, 'data', DataDir),
     make_directory_path(DataDir),
     directory_file_path(DataDir, 'category_parent.csv', CsvPath).
+category_parent_csv_path(OutputDir, artifact, CsvPath) :-
+    directory_file_path(OutputDir, 'data', DataDir),
+    make_directory_path(DataDir),
+    directory_file_path(DataDir, 'category_parent_artifact.csv', CsvPath).
 
 write_category_parent_csv(CsvPath) :-
     findall(Child-Parent, current_category_parent_fact(Child, Parent), Pairs0),

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -85,6 +85,24 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         self.assertEqual(TARGETS["scala-wam-accumulated"].category, "hybrid-wam")
         self.assertEqual(TARGETS["scala-wam-accumulated-no-kernels"].category, "hybrid-wam")
 
+    def test_scala_artifact_targets_are_registered_separately(self) -> None:
+        targets = resolve_targets(
+            explicit_targets=None,
+            target_set_names=["scala-wam-artifact"],
+        )
+
+        self.assertEqual(
+            targets,
+            [
+                "scala-wam-seeded",
+                "scala-wam-seeded-artifact",
+                "scala-wam-accumulated",
+                "scala-wam-accumulated-artifact",
+            ],
+        )
+        self.assertEqual(TARGETS["scala-wam-seeded-artifact"].category, "hybrid-wam")
+        self.assertEqual(TARGETS["scala-wam-accumulated-artifact"].category, "hybrid-wam")
+
     def test_list_targets_includes_clojure_scaffold_set(self) -> None:
         text = list_targets_text()
 
@@ -100,6 +118,11 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         self.assertIn(
             "scala-wam\tscala-wam-seeded,scala-wam-seeded-no-kernels,"
             "scala-wam-accumulated,scala-wam-accumulated-no-kernels",
+            text,
+        )
+        self.assertIn(
+            "scala-wam-artifact\tscala-wam-seeded,scala-wam-seeded-artifact,"
+            "scala-wam-accumulated,scala-wam-accumulated-artifact",
             text,
         )
         self.assertIn("clojure-wam-scaffold\t", text)

--- a/tests/test_wam_scala_effective_distance_generator.pl
+++ b/tests/test_wam_scala_effective_distance_generator.pl
@@ -36,6 +36,76 @@ test(generate_kernels_off_project_omits_fact_sidecar) :-
         ),
         cleanup_tmp_dir(TmpDir)).
 
+test(data_mode_options) :-
+    parse_benchmark_data_mode(sidecar, sidecar),
+    parse_benchmark_data_mode(inline, inline),
+    parse_benchmark_data_mode(artifact, artifact),
+    setup_call_cleanup(
+        load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
+        assertion(parse_benchmark_data_mode(auto, sidecar)),
+        true
+    ).
+
+test(data_mode_predicate_override) :-
+    setup_call_cleanup(
+        ( load_files(user:'data/benchmark/dev/facts.pl', [silent(true)]),
+          assertz(user:wam_scala_benchmark_data_mode(sidecar))
+        ),
+        assertion(parse_benchmark_data_mode(auto, sidecar)),
+        maybe_abolish_test_predicate(wam_scala_benchmark_data_mode/1)
+    ).
+
+test(relation_data_mode_override_parent_inline) :-
+    setup_call_cleanup(
+        assertz(user:wam_scala_benchmark_relation_data_mode(category_parent, inline)),
+        setup_call_cleanup(
+            unique_tmp_dir('tmp_wam_scala_effective_distance_rel_inline', TmpDir),
+            (   generate('data/benchmark/dev/facts.pl', TmpDir, accumulated, kernels_on, sidecar),
+                directory_file_path(TmpDir, 'data/category_parent.csv', CsvPath),
+                \+ exists_file(CsvPath),
+                directory_file_path(TmpDir,
+                                    'src/main/scala/generated/wam_scala_effective_distance/core/GeneratedProgram.scala',
+                                    GeneratedPath),
+                read_file_to_string(GeneratedPath, Generated, []),
+                sub_string(Generated, _, _, _, 'private val sols: Seq[Map[Int, WamTerm]] = Seq('),
+                !
+            ),
+            cleanup_tmp_dir(TmpDir)),
+        maybe_abolish_test_predicate(wam_scala_benchmark_relation_data_mode/2)
+    ).
+
+test(generate_inline_project_omits_fact_sidecar) :-
+    setup_call_cleanup(
+        unique_tmp_dir('tmp_wam_scala_effective_distance_inline', TmpDir),
+        (   generate('data/benchmark/dev/facts.pl', TmpDir, accumulated, kernels_on, inline),
+            directory_file_path(TmpDir, 'data/category_parent.csv', CsvPath),
+            \+ exists_file(CsvPath),
+            directory_file_path(TmpDir,
+                                'src/main/scala/generated/wam_scala_effective_distance/core/GeneratedProgram.scala',
+                                GeneratedPath),
+            read_file_to_string(GeneratedPath, Generated, []),
+            sub_string(Generated, _, _, _, 'private val sols: Seq[Map[Int, WamTerm]] = Seq('),
+            !
+        ),
+        cleanup_tmp_dir(TmpDir)).
+
+test(generate_artifact_project_emits_distinct_file_backend) :-
+    setup_call_cleanup(
+        unique_tmp_dir('tmp_wam_scala_effective_distance_artifact', TmpDir),
+        (   generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, artifact),
+            directory_file_path(TmpDir, 'data/category_parent_artifact.csv', ArtifactPath),
+            directory_file_path(TmpDir, 'data/category_parent.csv', SidecarPath),
+            exists_file(ArtifactPath),
+            \+ exists_file(SidecarPath),
+            directory_file_path(TmpDir,
+                                'src/main/scala/generated/wam_scala_effective_distance/core/GeneratedProgram.scala',
+                                GeneratedPath),
+            read_file_to_string(GeneratedPath, Generated, []),
+            sub_string(Generated, _, _, _, 'category_parent_artifact.csv'),
+            !
+        ),
+        cleanup_tmp_dir(TmpDir)).
+
 unique_tmp_dir(Prefix, TmpDir) :-
     tmp_file(Prefix, TmpDir),
     catch(delete_directory_and_contents(TmpDir), _, true),
@@ -43,5 +113,11 @@ unique_tmp_dir(Prefix, TmpDir) :-
 
 cleanup_tmp_dir(TmpDir) :-
     catch(delete_directory_and_contents(TmpDir), _, true).
+
+maybe_abolish_test_predicate(Name/Arity) :-
+    (   current_predicate(user:Name/Arity)
+    ->  abolish(user:Name/Arity)
+    ;   true
+    ).
 
 :- end_tests(wam_scala_effective_distance_generator).


### PR DESCRIPTION
  ## Summary
  - Add `sidecar`, `inline`, `artifact`, and `auto` data-mode support to the Scala WAM effective-distance generator.
  - Add global and relation-level data-mode override predicates for Scala benchmark generation.
  - Register opt-in `scala-wam-artifact` matrix targets for seeded and accumulated kernel-on Scala runs.
  - Wire Scala artifact targets through the effective-distance matrix harness.
  - Extend generator and matrix tests for data-mode parsing, overrides, artifact file emission, and target registration.
  - Document the current artifact boundary as file-backed category-parent data, not LMDB or memory-mapped storage.

  ## Validation
  - `swipl -q -f init.pl -s tests/test_wam_scala_effective_distance_generator.pl -g run_tests -t halt`
  - `python3 -m py_compile examples/benchmark/benchmark_common.py examples/benchmark/benchmark_target_matrix.py
  examples/benchmark/benchmark_effective_distance_matrix.py`
  - `python3 -m unittest tests/test_benchmark_target_matrix.py`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --list-targets`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --list-kernel-pairs`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets scala-wam-artifact
  --repetitions 1`
  - `git diff --check`