### PR TITLE
feat(wam-clojure): lower deterministic call

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -225,10 +225,12 @@ lowered_direct_prefix([Instr|Rest], ControlLowering, [Instr|PrefixRest]) :-
     lowered_direct_prefix(Rest, ControlLowering, PrefixRest).
 lowered_direct_prefix(_, _, []).
 
+lowered_terminal_direct_instr(call(_, _), allow_control).
 lowered_terminal_direct_instr(execute(_), allow_control).
 lowered_terminal_direct_instr(proceed, _).
 lowered_terminal_direct_instr(fail, _).
 
+lowered_direct_instr(call(_, _), allow_control).
 lowered_direct_instr(execute(_), allow_control).
 lowered_direct_instr(Instr, _) :-
     lowered_data_instr(Instr).
@@ -272,6 +274,11 @@ emit_lowered_expr(proceed, S, Expr) :-
     format(atom(Expr), '(runtime/succeed-state ~w)', [S]).
 emit_lowered_expr(fail, S, Expr) :-
     format(atom(Expr), '(runtime/fail-state ~w)', [S]).
+emit_lowered_expr(call(Pred, _Arity), S, Expr) :-
+    clj_lowered_string_literal(Pred, PredLit),
+    format(atom(Expr),
+           '(if-let [target-pc (get (:labels ~w) ~w)] (-> ~w (update :stack conj (inc (:pc ~w))) (assoc :pc target-pc)) (runtime/backtrack ~w))',
+           [S, PredLit, S, S, S]).
 emit_lowered_expr(execute(Pred), S, Expr) :-
     clj_lowered_string_literal(Pred, PredLit),
     format(atom(Expr),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -187,7 +187,7 @@ test(multi_clause_execute_stays_runtime_mediated) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
-test(call_stays_runtime_mediated_after_lowered_prefix) :-
+test(call_is_direct_lowered_after_lowered_prefix) :-
     once((
         WamCode = "test_call/1:\nallocate\nget_variable Y1, A1\nput_value Y1, A1\ncall test_fact/1, 1\ndeallocate\nproceed\n",
         wam_clojure_lowerable(test_call/1, WamCode, deterministic),
@@ -195,9 +195,25 @@ test(call_stays_runtime_mediated_after_lowered_prefix) :-
         has(Code, "update :env-stack conj {}"),
         has(Code, "get-variable Y1, A1"),
         has(Code, "put-value Y1, A1"),
-        assertion(\+ has(Code, "call test_fact/1")),
+        has(Code, "if-let [target-pc"),
+        has(Code, "(get (:labels"),
+        has(Code, "\"test_fact/1\""),
+        has(Code, "update :stack conj (inc (:pc"),
+        has(Code, ":pc target-pc"),
+        has(Code, "runtime/backtrack"),
         assertion(\+ has(Code, "update :env-stack #(if (seq %) (pop %) %)")),
         assertion(\+ has(Code, "runtime/succeed-state")),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
+test(multi_clause_call_stays_runtime_mediated) :-
+    once((
+        WamCode = "test_choice_call/1:\ntry_me_else test_choice_call_alt\ncall test_fact/1, 1\nproceed\ntest_choice_call_alt:\ntrust_me\nget_constant z, A1\nproceed\n",
+        wam_clojure_lowerable(test_choice_call/1, WamCode, multi_clause_1),
+        lower_predicate_to_clojure(test_choice_call/1, WamCode, [], Code),
+        assertion(\+ has(Code, "\"test_fact/1\"")),
+        assertion(\+ has(Code, ":pc target-pc")),
+        assertion(\+ has(Code, "update :stack conj")),
         assertion(\+ has(Code, "runtime/step"))
     )).
 

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -131,6 +131,7 @@ run_smoke :-
     assert_lowered_read_unify_prefix_emitted(TmpDir),
     assert_lowered_env_prefix_emitted(TmpDir),
     assert_lowered_execute_emitted(TmpDir),
+    assert_lowered_call_emitted(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
     verify_output(TmpDir, 'wam_call_caller/1', 'a', "true"),
@@ -212,6 +213,16 @@ assert_lowered_execute_emitted(ProjectDir) :-
     has(CoreCode, "if-let [target-pc"),
     has(CoreCode, "(get (:labels"),
     has(CoreCode, "\"wam_fact/1\""),
+    has(CoreCode, ":pc target-pc").
+
+assert_lowered_call_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-call-caller-1"),
+    has(CoreCode, "if-let [target-pc"),
+    has(CoreCode, "(get (:labels"),
+    has(CoreCode, "\"wam_fact/1\""),
+    has(CoreCode, "update :stack conj (inc (:pc"),
     has(CoreCode, ":pc target-pc").
 
 verify_output(ProjectDir, PredKey, Arg, Expected) :-


### PR DESCRIPTION
## Summary

Adds direct lowered emission for deterministic Clojure WAM `call/2` instructions.

The lowered emitter now treats deterministic `call(Pred, Arity)` as a terminal control-transfer instruction. It mirrors the runtime `:call-pc` behavior by pushing the return PC onto `:stack` and jumping to the target predicate PC.

## Why

After deterministic `execute/1` lowering, `call/2` is the next control-transfer boundary. The runtime semantics are still small enough to lower safely for deterministic predicates:

- return to the instruction after the call with `(inc (:pc state))`
- push that return PC onto `:stack`
- set `:pc` to the callee target PC

This removes another runtime instruction-dispatch step from deterministic lowered predicates while keeping multi-clause predicates protected by the existing runtime-mediated control path.

## Changes

- Lowers deterministic `call/2` directly in `wam_clojure_lowered_emitter.pl`.
- Keeps `call/2` terminal in the lowered prefix so post-call suffix instructions are not incorrectly pulled forward.
- Keeps multi-clause `call/2` runtime-mediated.
- Updates lowered-emitter tests for:
  - direct deterministic `call/2`
  - return-PC stack push
  - target-PC transfer
  - multi-clause `call/2` remaining runtime-mediated
- Adds generated-runtime smoke coverage for direct `wam_call_caller/1` call lowering.

## Validation

Passed locally on Termux:

```sh
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
git diff --check
```

## Notes

This PR intentionally does not lower multi-clause `call/2`. Multi-clause predicates still require runtime-mediated choice setup before direct control lowering can be safely generalized.
