### PR TITLE
feat(wam-clojure): lower deterministic jump

### DIFF
--- a/scripts/ci/install_swi_prolog.sh
+++ b/scripts/ci/install_swi_prolog.sh
@@ -22,11 +22,13 @@ retry() {
 
   local attempt=1
   while true; do
+    local exit_code
     if "$@"; then
       return 0
+    else
+      exit_code=$?
     fi
 
-    local exit_code=$?
     if [ "$attempt" -ge "$attempts" ]; then
       return "$exit_code"
     fi
@@ -70,6 +72,12 @@ remove_ppa_and_refresh() {
   retry 3 5 sudo apt-get update -qq
 }
 
+ppa_source_present() {
+  find /etc/apt/sources.list /etc/apt/sources.list.d \
+    -type f \( -name '*.list' -o -name '*.sources' \) \
+    -exec grep -q 'ppa.launchpadcontent.net/swi-prolog/stable' {} + 2>/dev/null
+}
+
 print_runner_diagnostics
 retry 3 5 sudo apt-get update -qq
 retry 3 5 sudo apt-get install -y --no-install-recommends software-properties-common
@@ -80,6 +88,10 @@ if retry 3 5 timeout 120 sudo apt-add-repository "$PPA" -y; then
   log "Added ${PPA}."
 else
   warn "Could not add ${PPA}; installing SWI-Prolog from default Ubuntu repo."
+  if ppa_source_present; then
+    warn "${PPA} appears to be partially configured; removing it before fallback."
+    remove_ppa_and_refresh
+  fi
 fi
 
 if ! retry 3 5 sudo apt-get update -qq; then

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -227,11 +227,13 @@ lowered_direct_prefix(_, _, []).
 
 lowered_terminal_direct_instr(call(_, _), allow_control).
 lowered_terminal_direct_instr(execute(_), allow_control).
+lowered_terminal_direct_instr(jump(_), allow_control).
 lowered_terminal_direct_instr(proceed, _).
 lowered_terminal_direct_instr(fail, _).
 
 lowered_direct_instr(call(_, _), allow_control).
 lowered_direct_instr(execute(_), allow_control).
+lowered_direct_instr(jump(_), allow_control).
 lowered_direct_instr(Instr, _) :-
     lowered_data_instr(Instr).
 
@@ -284,6 +286,11 @@ emit_lowered_expr(execute(Pred), S, Expr) :-
     format(atom(Expr),
            '(if-let [target-pc (get (:labels ~w) ~w)] (assoc ~w :pc target-pc) (runtime/backtrack ~w))',
            [S, PredLit, S, S]).
+emit_lowered_expr(jump(Label), S, Expr) :-
+    clj_lowered_string_literal(Label, LabelLit),
+    format(atom(Expr),
+           '(if-let [target-pc (get (:labels ~w) ~w)] (assoc ~w :pc target-pc) (runtime/backtrack ~w))',
+           [S, LabelLit, S, S]).
 emit_lowered_expr(allocate, S, Expr) :-
     format(atom(Expr),
            '(-> ~w (update :env-stack conj {}) (assoc :cut-bar (count (:choice-points ~w))) runtime/advance)',

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -217,6 +217,43 @@ test(multi_clause_call_stays_runtime_mediated) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(jump_is_direct_lowered_after_lowered_prefix) :-
+    once((
+        WamCode = "test_jump/1:\nallocate\njump test_jump_done\ntest_jump_done:\ndeallocate\nproceed\n",
+        wam_clojure_lowerable(test_jump/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_jump/1, WamCode, [], Code),
+        has(Code, "update :env-stack conj {}"),
+        has(Code, "if-let [target-pc"),
+        has(Code, "(get (:labels"),
+        has(Code, "\"test_jump_done\""),
+        has(Code, ":pc target-pc"),
+        has(Code, "runtime/backtrack"),
+        assertion(\+ has(Code, "update :env-stack #(if (seq %) (pop %) %)")),
+        assertion(\+ has(Code, "runtime/succeed-state")),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
+test(jump_terminal_stops_lowered_suffix) :-
+    once((
+        WamCode = "test_jump_suffix/1:\njump test_jump_done\ndeallocate\nproceed\ntest_jump_done:\nproceed\n",
+        wam_clojure_lowerable(test_jump_suffix/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_jump_suffix/1, WamCode, [], Code),
+        has(Code, "\"test_jump_done\""),
+        assertion(\+ has(Code, "update :env-stack #(if (seq %) (pop %) %)")),
+        assertion(\+ has(Code, "runtime/succeed-state")),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
+test(multi_clause_jump_stays_runtime_mediated) :-
+    once((
+        WamCode = "test_choice_jump/1:\ntry_me_else test_choice_jump_alt\njump test_choice_jump_done\ntest_choice_jump_done:\nproceed\ntest_choice_jump_alt:\ntrust_me\nget_constant z, A1\nproceed\n",
+        wam_clojure_lowerable(test_choice_jump/1, WamCode, multi_clause_1),
+        lower_predicate_to_clojure(test_choice_jump/1, WamCode, [], Code),
+        assertion(\+ has(Code, "\"test_choice_jump_done\"")),
+        assertion(\+ has(Code, ":pc target-pc")),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(structure_build_ops_are_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_build/1:\nput_structure f/2, A1\nset_constant a\nset_variable X1\nset_value X1\nproceed\n",


### PR DESCRIPTION
## Summary

Adds direct lowered emission for deterministic Clojure WAM `jump/1` instructions and fixes the SWI-Prolog CI installer retry path exposed by Launchpad PPA timeouts.

## Why

After deterministic `execute/1` and `call/2` lowering, `jump/1` is the next smallest safe control-transfer instruction. Runtime `:jump-pc` semantics are equivalent to setting `:pc` to a resolved target label, so deterministic lowered predicates can emit this directly.

The CI failure was unrelated to the Clojure emitter logic. `scripts/ci/install_swi_prolog.sh` had a retry helper bug that could report failed commands with exit `0`, preventing reliable fallback from the SWI-Prolog PPA to Ubuntu's default repository after Launchpad timeouts.

## Changes

- Lowers deterministic `jump(Label)` directly.
- Treats `jump/1` as a terminal lowered-prefix instruction.
- Keeps multi-clause `jump/1` runtime-mediated through the existing control-lowering gate.
- Adds lowered-emitter tests for:
  - direct deterministic `jump/1`
  - suffix stopping after terminal `jump/1`
  - multi-clause `jump/1` remaining runtime-mediated
- Fixes the CI retry helper to preserve the actual failing exit code.
- Removes partially configured SWI-Prolog PPA sources before falling back to Ubuntu packages.

## Validation

Passed locally on Termux:

```sh
bash -n scripts/ci/install_swi_prolog.sh
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
git diff --check
```

## Notes

The CI installer fix targets transient Launchpad failures like HTTP 504, connection timeout, and partial PPA source configuration. It should allow CI to continue with the Ubuntu repository package when the PPA is unavailable.
