### PR TITLE
fix(wam): force allocate/deallocate around multi-clause body findall

### DIFF
--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -442,8 +442,18 @@ compile_clauses_fragments([Head-Body|Rest], I, N, Pred, Arity, Options,
     Head =.. [_|Args],
     normalize_goals(Body, Goals),
     empty_varmap(V0),
-    (   length(Goals, NG), NG > 1
-    ->  pre_assign_permanent_vars(Goals, V0, V0a),
+    % Force permanent variable allocation when the body contains a Call
+    % or aggregate (findall/aggregate_all), even for single-goal bodies.
+    % Without an env frame, the post-aggregate continuation has nowhere
+    % to retrieve the caller's saved cp from, so finalise_aggregate's
+    % update_topmost_agg_cp + restored.cp.(restored) chain loops back
+    % into k2 forever. The single-clause path applies the same
+    % condition at line ~327; this keeps multi-clause in sync.
+    expand_aggregate_goals_for_perm_vars(Goals, ExpandedGoals),
+    (   ( length(ExpandedGoals, NG), NG > 1
+        ; goals_contain_call_or_aggregate(Goals)
+        )
+    ->  pre_assign_permanent_vars(ExpandedGoals, V0, V0a),
         compile_head_arguments(Args, 1, V0a, V1, HeadCode0),
         compile_goals(Goals, V1, yes, _, GoalsCode),
         format(string(HeadCode), "    allocate~n~w", [HeadCode0]),

--- a/tests/test_wam_elixir_lowered_phase4d.pl
+++ b/tests/test_wam_elixir_lowered_phase4d.pl
@@ -76,7 +76,6 @@ elixir_available :-
 %% Test fixtures.
 
 :- dynamic user:phase4d_inner/1.
-:- dynamic user:phase4d_do_inner/0.
 :- dynamic user:phase4d_outer_p/1.
 :- dynamic user:phase4d_nested/1.
 
@@ -85,26 +84,20 @@ user:phase4d_inner(1).
 user:phase4d_inner(2).
 user:phase4d_inner(3).
 
-% Indirection helper: single-clause, not Tier-2-eligible itself, but
-% its body invokes findall over phase4d_inner — which routes through
-% inner's super-wrapper at parallel_depth=1, firing the gate.
+% Outer: 3-clause Tier-2-eligible predicate. Each clause body invokes
+% findall over phase4d_inner — that findall's compiled call routes
+% through inner's super-wrapper at runtime, where the parallel_depth
+% gate fires (depth = 1 from outer's fan-out).
 %
-% Why the indirection? When the inner findall is placed directly in
-% an outer_p clause body, the WAM register allocator reuses argument
-% register A1 for the inner findall's anonymous template var,
-% clobbering the outer head-bound value before the outer's
-% aggregate_collect runs. Hoisting the inner findall into a
-% zero-arity helper means each outer clause's head-bound value is
-% never live in A1 at the moment the inner findall sets up its
-% template.
-user:phase4d_do_inner :- findall(_, phase4d_inner(_), _).
-
-% Outer: 3-clause Tier-2-eligible predicate. Each clause delegates
-% to phase4d_do_inner so the inner findall doesn't share registers
-% with the outer head binding.
-user:phase4d_outer_p('a') :- phase4d_do_inner.
-user:phase4d_outer_p('b') :- phase4d_do_inner.
-user:phase4d_outer_p('c') :- phase4d_do_inner.
+% This direct-body shape originally surfaced a WAM compiler bug
+% (multi-clause + body-level findall = no env frame = caller cp lost
+% across finalise_aggregate). The fix in compile_clauses_fragments/8
+% now forces an env frame whenever the body contains a findall or
+% aggregate_all. The original-shape fixture below is the runtime
+% regression check for that fix.
+user:phase4d_outer_p('a') :- findall(_, phase4d_inner(_), _).
+user:phase4d_outer_p('b') :- findall(_, phase4d_inner(_), _).
+user:phase4d_outer_p('c') :- findall(_, phase4d_inner(_), _).
 
 % Top-level: not Tier-2-eligible (1 clause). Its findall routes to
 % outer_p's super-wrapper with parallel_depth = 0 — outer fans out.
@@ -112,7 +105,6 @@ user:phase4d_nested(L) :- findall(X, phase4d_outer_p(X), L).
 
 phase4d_predicates([
     user:phase4d_inner/1,
-    user:phase4d_do_inner/0,
     user:phase4d_outer_p/1,
     user:phase4d_nested/1
 ]).

--- a/tests/test_wam_target.pl
+++ b/tests/test_wam_target.pl
@@ -27,6 +27,21 @@ test_wrap(X) :- test_check(pair(X, done)).
 :- dynamic test_color/2.
 test_color(rgb(255, 0, 0), red).
 
+%% Multi-clause body containing a findall — regression for the bug
+%  where compile_clauses_fragments only emitted allocate/deallocate
+%  when goal-count > 1, missing the case where a single surface goal
+%  is itself a findall/aggregate that internally produces a Call.
+%  Without an env frame, the post-end_aggregate continuation has no
+%  saved caller cp to return to; finalise_aggregate's cp chain loops
+%  back into k2 forever. See compile_single_clause_wam/3 for the
+%  same logic that was previously only applied to single-clause.
+:- dynamic test_multi_findall/1, test_multi_inner/1.
+test_multi_inner(1).
+test_multi_inner(2).
+test_multi_findall('a') :- findall(_, test_multi_inner(_), _).
+test_multi_findall('b') :- findall(_, test_multi_inner(_), _).
+test_multi_findall('c') :- findall(_, test_multi_inner(_), _).
+
 %% Nested compound body arg — exercises recursive put_structure
 :- dynamic test_nested_check/1.
 test_nested_check(box(inner(_, _))).
@@ -146,6 +161,32 @@ test_wam_nested_put_structure :-
         fail_test(Test, 'Missing nested put_structure in output')
     ).
 
+%% Multi-clause findall regression: every clause must have an
+%  allocate/deallocate pair so the inner findall's post-end_aggregate
+%  continuation can retrieve the caller cp from the env frame.
+test_wam_multi_clause_findall_emits_allocate :-
+    Test = 'WAM: multi-clause body with findall emits allocate/deallocate per clause',
+    (   wam_target:compile_predicate_to_wam(user:test_multi_findall/1, [], Code),
+        atom_string(Code, S),
+        % Each of the three clause bodies should contain begin_aggregate
+        % surrounded by allocate ... deallocate. Three pairs total.
+        aggsubs_count(S, 'allocate', AllocCount),
+        aggsubs_count(S, 'deallocate', DeallocCount),
+        aggsubs_count(S, 'begin_aggregate', AggCount),
+        AllocCount >= 3,
+        DeallocCount >= 3,
+        AggCount =:= 3
+    ->  pass(Test)
+    ;   wam_target:compile_predicate_to_wam(user:test_multi_findall/1, [], Code2),
+        format(user_error, 'DEBUG: multi-clause findall output:~n~w~n', [Code2]),
+        fail_test(Test, 'Multi-clause findall body missing allocate/deallocate per clause')
+    ).
+
+%% Count non-overlapping occurrences of Sub in S.
+aggsubs_count(S, Sub, N) :-
+    findall(_, sub_string(S, _, _, _, Sub), Occurrences),
+    length(Occurrences, N).
+
 %% Run all tests
 run_tests :-
     format('~n========================================~n'),
@@ -159,6 +200,7 @@ run_tests :-
     test_wam_nested_put_structure,
     test_wam_compound_head,
     test_wam_module,
+    test_wam_multi_clause_findall_emits_allocate,
     
     format('~n========================================~n'),
     (   test_failed


### PR DESCRIPTION
## Summary

Fixes a WAM compiler bug where multi-clause predicates with body shape `findall(_, P(_), _)` (or any aggregate/call directly in a single surface goal) emit no `allocate`/`deallocate` pair. Without an env frame the post-`end_aggregate` continuation has no saved caller cp, and `finalise_aggregate`'s `update_topmost_agg_cp` + `restored.cp.(restored)` chain loops back into `k2` forever.

The single-clause compilation path (`compile_single_clause_wam/3` at `wam_target.pl:317-336`) already had the correct condition — it expands aggregates and forces an env frame when any inner goal is a Call. This change applies the same condition to `compile_clauses_fragments/8`.

## Reduction

```prolog
inner(1). inner(2). inner(3).
outer('a') :- findall(_, inner(_), _).
outer('b') :- findall(_, inner(_), _).
outer('c') :- findall(_, inner(_), _).
nested(L) :- findall(X, outer(X), L).
```

Pre-fix: `nested(L)` hangs / OOMs in sequential mode; in parallel mode `Task.async_stream` branch isolation masked the runaway and produced a clean `L = []` (silently wrong).

Single-clause `outer('a') :- findall(_, inner(_), _)` worked because Y-reg promotion forced an env frame.

Post-fix: both modes return the correct `{a, b, c}` set.

## Background

This bug was surfaced during Phase 4d post-merge investigation (PR #1767). The Phase 4d test had been worked around with an indirection helper `phase4d_do_inner/0` that hoisted the inner findall out of the multi-clause body. Now that the underlying compiler bug is fixed, the helper is unnecessary; this PR restores the original direct-body fixture as the runtime regression check.

## Tests

- **`tests/test_wam_target.pl`**: new emit-and-grep test asserts every clause of a multi-clause body containing `findall` emits `allocate`/`deallocate` — codegen-level regression.
- **`tests/test_wam_elixir_lowered_phase4d.pl`**: drops the `phase4d_do_inner/0` indirection helper; original direct-body fixture restored. End-to-end runtime regression.

Verified passing:
- [x] `tests/test_wam_target.pl` (all + new test)
- [x] `tests/test_wam_elixir_target.pl` (all)
- [x] `tests/test_wam_elixir_lowered_phase3.pl` (16/16)
- [x] `tests/test_wam_elixir_lowered_phase4c.pl` (3/3)
- [x] `tests/test_wam_elixir_lowered_phase4d.pl` (1/1, direct-body shape)
- [x] `tests/test_wam_dict.pl`, `tests/test_wam_fact_table.pl`, `tests/test_wam_cross_target_consistency.pl`

Pre-existing failures confirmed unrelated by stash-and-rerun on `main`:
- `test_wam_e2e.pl` `atom/1` failure
- `test_wam_rule_index.pl` timeout

## Test plan

- [x] Reproduce hang in sequential mode pre-fix
- [x] Confirm fix produces correct results in both sequential and parallel modes
- [x] Codegen-level regression test in `test_wam_target.pl`
- [x] Runtime regression check via simplified Phase 4d fixture
- [x] No regressions in core WAM-Elixir test suite

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_