### PR TITLE
feat(wam-clojure): lower cut builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -271,6 +271,10 @@ clojure_direct_builtin("true/0", "0").
 clojure_direct_builtin("true/0", 0).
 clojure_direct_builtin('true/0', "0").
 clojure_direct_builtin('true/0', 0).
+clojure_direct_builtin("!/0", "0").
+clojure_direct_builtin("!/0", 0).
+clojure_direct_builtin('!/0', "0").
+clojure_direct_builtin('!/0', 0).
 
 emit_lowered_expr(proceed, S, Expr) :-
     format(atom(Expr), '(runtime/succeed-state ~w)', [S]).
@@ -344,6 +348,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "true/0" ; Op == 'true/0'),
     !,
     format(atom(Expr), '(runtime/advance ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "!/0" ; Op == '!/0'),
+    !,
+    format(atom(Expr),
+           '(-> ~w (update :choice-points #(vec (take (:cut-bar ~w) %))) runtime/advance)',
+           [S, S]).
 emit_lowered_expr(put_constant(C, Ai), S, Expr) :-
     clj_lowered_literal(C, Lit),
     format(atom(Expr),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -130,6 +130,17 @@ test(simple_builtin_true_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/succeed-state")
     )).
 
+test(cut_builtin_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_cut/0:\nallocate\nbuiltin_call !/0, 0\ndeallocate\nproceed\n",
+        wam_clojure_lowerable(test_cut/0, WamCode, deterministic),
+        lower_predicate_to_clojure(test_cut/0, WamCode, [], Code),
+        has(Code, "update :choice-points"),
+        has(Code, "take (:cut-bar"),
+        has(Code, "runtime/advance"),
+        has(Code, "runtime/succeed-state")
+    )).
+
 test(unsupported_builtin_stays_runtime_mediated) :-
     once((
         WamCode = "test_atom/1:\nbuiltin_call atom/1, 1\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -132,6 +132,7 @@ run_smoke :-
     assert_lowered_env_prefix_emitted(TmpDir),
     assert_lowered_execute_emitted(TmpDir),
     assert_lowered_call_emitted(TmpDir),
+    assert_lowered_cut_builtin_emitted(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
     verify_output(TmpDir, 'wam_call_caller/1', 'a', "true"),
@@ -224,6 +225,13 @@ assert_lowered_call_emitted(ProjectDir) :-
     has(CoreCode, "\"wam_fact/1\""),
     has(CoreCode, "update :stack conj (inc (:pc"),
     has(CoreCode, ":pc target-pc").
+
+assert_lowered_cut_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-cut-helper-1"),
+    has(CoreCode, "update :choice-points"),
+    has(CoreCode, "take (:cut-bar").
 
 verify_output(ProjectDir, PredKey, Arg, Expected) :-
     run_clojure_predicate(ProjectDir, PredKey, Arg, Actual),


### PR DESCRIPTION
## Summary

Adds direct lowered emission for the deterministic Clojure WAM cut builtin `!/0`.

The lowered emitter now recognizes `builtin_call !/0, 0` as a direct builtin and emits the same choice-point trimming semantics used by the Clojure WAM runtime.

## Why

The Clojure lowered-WAM path now handles deterministic data movement, unification, env setup, simple builtins, and control transfers such as `execute/1`, `call/2`, and `jump/1`. The cut builtin is another small local operation:

- trim `:choice-points` to `:cut-bar`
- advance the PC

This removes one more runtime instruction-dispatch step from deterministic lowered predicates without changing multi-clause control behavior.

## Changes

- Adds `!/0` to the Clojure lowered direct-builtin allow-list.
- Emits direct choice-point trimming:
  - `update :choice-points`
  - `take (:cut-bar state)`
  - `runtime/advance`
- Adds lowered-emitter coverage for direct `!/0` lowering.
- Adds generated-runtime smoke coverage for the existing hard-cut helper path.

## Validation

Passed locally on Termux:

```sh
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
git diff --check
```

## Notes

`cut_ite` remains runtime-mediated. This PR only lowers the explicit builtin cut instruction `!/0`.
