### PR TITLE
fix(wam-clojure): preserve multiclause choice setup

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -181,10 +181,9 @@ lower_predicate_to_clojure(PI, WamCode, _Options, ClojureCode) :-
     ),
     clause1_instrs(Instrs, C1Instrs0),
     (   is_deterministic_pred_clojure(Instrs)
-    ->  ControlLowering = allow_control
-    ;   ControlLowering = runtime_control
+    ->  lowered_direct_prefix(C1Instrs0, allow_control, C1Instrs)
+    ;   C1Instrs = []
     ),
-    lowered_direct_prefix(C1Instrs0, ControlLowering, C1Instrs),
     with_output_to(string(Body), emit_instrs(C1Instrs, "  ")),
     format(string(ClojureCode),
 ';; ~w — lowered from ~w/~w

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -23,6 +23,18 @@ test(multi_clause_clause1_is_lowerable) :-
     wam_clojure_lowerable(test_choice/1, WamCode, Reason),
     assertion(Reason == multi_clause_1).
 
+test(multi_clause_emits_empty_lowered_prefix) :-
+    once((
+        WamCode = "test_choice/1:\nallocate\ndeallocate\nexecute test_fact/1\ntry_me_else test_choice_alt\nallocate\ndeallocate\nexecute test_fact/1\ntest_choice_alt:\ntrust_me\nget_constant z, A1\nproceed\n",
+        wam_clojure_lowerable(test_choice/1, WamCode, multi_clause_1),
+        lower_predicate_to_clojure(test_choice/1, WamCode, [], Code),
+        has(Code, "defn lowered-test-choice-1 [state]"),
+        assertion(\+ has(Code, "update :env-stack conj {}")),
+        assertion(\+ has(Code, "\"test_fact/1\"")),
+        assertion(\+ has(Code, ":pc target-pc")),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(switch_on_constant_not_yet_lowerable, [fail]) :-
     unsupported_wam(WamCode),
     wam_clojure_lowerable(test_switch/1, WamCode, _).
@@ -51,13 +63,14 @@ test(lower_predicate_to_clojure_emits_function) :-
         has(Code, "runtime/interned-equal?")
     )).
 
-test(lowered_multi_clause_keeps_clause1_shape) :-
+test(lowered_multi_clause_stays_runtime_mediated) :-
     once((
         multi_clause_wam(WamCode),
         lower_predicate_to_clojure(test_choice/1, WamCode, [], Code),
         has(Code, "defn lowered-test-choice-1 [state]"),
-        has(Code, "get-constant a, A1"),
-        \+ has(Code, "get-constant b, A1")
+        assertion(\+ has(Code, "get-constant a, A1")),
+        assertion(\+ has(Code, "get-constant b, A1")),
+        assertion(\+ has(Code, "runtime/step"))
     )).
 
 test(call_foreign_is_part_of_scaffold) :-


### PR DESCRIPTION
## Summary

Fixes a Clojure lowered-WAM regression where multi-clause predicates could skip runtime choice setup after recent allocate/deallocate wrapping.

Non-deterministic and multi-clause predicates now emit an empty lowered prefix, leaving their execution fully runtime-mediated. Deterministic predicates continue to use the direct lowered prefix path.

## Why

Local verification on merged `main` found a runtime smoke failure:

```text
wam_choice_or_z/1, input z
expected true, got false
```

The generated WAM for that predicate now includes `allocate/deallocate` before `try_me_else`. The lowered Clojure wrapper was directly executing those prefix instructions and advancing the PC before runtime had installed the choice point, so the alternate `z` clause was skipped.

## Changes

- Disables lowered-prefix emission for non-deterministic and multi-clause predicates.
- Keeps deterministic lowered-prefix emission unchanged.
- Updates the existing multi-clause lowered-emitter test to assert runtime-mediated behavior.
- Adds a regression test for the failing shape:
  - `allocate`
  - `deallocate`
  - `execute`
  - `try_me_else`
  - alternate clause

## Validation

Passed locally on Termux:

```sh
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
git diff --check
```

## Notes

This is intentionally conservative. Multi-clause direct lowering can be revisited later, but it needs explicit choice-point-aware lowering rather than prefix lowering before runtime control setup.
