### PR TITLE
bench(scala): Group Scala category-parent artifact data

### DIFF
--- a/docs/proposals/WAM_SCALA_HYBRID_SPEC.md
+++ b/docs/proposals/WAM_SCALA_HYBRID_SPEC.md
@@ -462,7 +462,9 @@ The generator also accepts `sidecar`, `inline`, `artifact`, and `auto`
 benchmark data modes. The first matrix artifact targets are registered
 separately as `scala-wam-seeded-artifact` and
 `scala-wam-accumulated-artifact`; they currently exercise a file-backed
-category-parent artifact, not a memory-mapped or LMDB artifact backend.
+grouped `category_parent_by_child.tsv` artifact with a Scala
+child-to-parents lookup handler, not a memory-mapped or LMDB artifact
+backend.
 
 ## 13. Example Target-Level Declarations
 

--- a/examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl
@@ -12,6 +12,7 @@
 :- use_module('../../src/unifyweaver/targets/prolog_target').
 :- use_module('../../src/unifyweaver/targets/wam_scala_target').
 :- use_module(library(filesex), [directory_file_path/3, make_directory_path/1]).
+:- use_module(library(pairs), [group_pairs_by_key/2]).
 
 %% generate_wam_scala_effective_distance_benchmark.pl
 %%
@@ -198,9 +199,9 @@ scala_fact_source_for_category_parent(_OutputDir, inline, source(category_parent
 scala_fact_source_for_category_parent(OutputDir, sidecar, source(category_parent/2, file(CsvPath))) :-
     category_parent_csv_path(OutputDir, sidecar, CsvPath),
     write_category_parent_csv(CsvPath).
-scala_fact_source_for_category_parent(OutputDir, artifact, source(category_parent/2, file(CsvPath))) :-
-    category_parent_csv_path(OutputDir, artifact, CsvPath),
-    write_category_parent_csv(CsvPath).
+scala_fact_source_for_category_parent(OutputDir, artifact, source(category_parent/2, grouped_by_first(GroupedPath))) :-
+    category_parent_grouped_path(OutputDir, GroupedPath),
+    write_category_parent_grouped_tsv(GroupedPath).
 
 collect_wam_predicates(kernels_on, [
     user:dimension_n/1,
@@ -218,10 +219,11 @@ category_parent_csv_path(OutputDir, sidecar, CsvPath) :-
     directory_file_path(OutputDir, 'data', DataDir),
     make_directory_path(DataDir),
     directory_file_path(DataDir, 'category_parent.csv', CsvPath).
-category_parent_csv_path(OutputDir, artifact, CsvPath) :-
+
+category_parent_grouped_path(OutputDir, Path) :-
     directory_file_path(OutputDir, 'data', DataDir),
     make_directory_path(DataDir),
-    directory_file_path(DataDir, 'category_parent_artifact.csv', CsvPath).
+    directory_file_path(DataDir, 'category_parent_by_child.tsv', Path).
 
 write_category_parent_csv(CsvPath) :-
     findall(Child-Parent, current_category_parent_fact(Child, Parent), Pairs0),
@@ -230,6 +232,20 @@ write_category_parent_csv(CsvPath) :-
         open(CsvPath, write, Stream),
         forall(member(Child-Parent, Pairs),
                format(Stream, '~w,~w~n', [Child, Parent])),
+        close(Stream)).
+
+write_category_parent_grouped_tsv(Path) :-
+    findall(Child-Parent, current_category_parent_fact(Child, Parent), Pairs0),
+    sort(Pairs0, Pairs),
+    group_pairs_by_key(Pairs, Grouped),
+    setup_call_cleanup(
+        open(Path, write, Stream),
+        forall(member(Child-Parents, Grouped),
+               (   format(Stream, '~w', [Child]),
+                   forall(member(Parent, Parents),
+                          format(Stream, '\t~w', [Parent])),
+                   nl(Stream)
+               )),
         close(Stream)).
 
 benchmark_atoms(Atoms) :-

--- a/src/unifyweaver/targets/wam_scala_target.pl
+++ b/src/unifyweaver/targets/wam_scala_target.pl
@@ -692,6 +692,8 @@ expand_fact_sources_in_options(Options0, Options) :-
 %  Dispatches on the shape of Spec:
 %    - Spec is a list of tuples → inline handler enumerating them.
 %    - Spec is file('path') → handler that reads CSV at runtime.
+%    - Spec is grouped_by_first('path') → handler that reads TSV rows
+%      shaped as Key<TAB>Value... and probes by the first argument.
 fact_source_spec_to_handler_code(Arity, Spec, Code) :-
     is_list(Spec), !,
     fact_source_to_handler_code(Arity, Spec, Code).
@@ -709,6 +711,13 @@ fact_source_spec_to_handler_code(Arity, file(Path), Code) :-
     % present); a malformed CSV will simply produce wrong-arity bindings
     % that the runtime will fail to unify.
     _ = Arity.
+fact_source_spec_to_handler_code(2, grouped_by_first(Path), Code) :-
+    !,
+    atom_string(Path, PathStr),
+    scala_string_literal(PathStr, PathLit),
+    format(string(Code),
+           "new ForeignHandler {\n      private def termKey(term: WamTerm): Option[String] = term match {\n        case Atom(id) if id >= 0 && id < internTable.idToString.length => Some(internTable.idToString(id))\n        case IntTerm(value) => Some(value.toString)\n        case FloatTerm(value) => Some(value.toString)\n        case _ => None\n      }\n      private val parentsByChild: Map[String, Vector[String]] = {\n        val src = scala.io.Source.fromFile(~w)\n        try {\n          src.getLines().toVector.flatMap { raw =>\n            val line = raw.trim\n            if (line.isEmpty || line.startsWith(\"#\")) None\n            else {\n              val parts = line.split(\"\\\\t\").map(_.trim).filter(_.nonEmpty).toVector\n              if (parts.length >= 2) Some(parts.head -> parts.tail) else None\n            }\n          }.toMap\n        } finally { src.close() }\n      }\n      private val allSols: Vector[Map[Int, WamTerm]] =\n        parentsByChild.toVector.flatMap { case (child, parents) =>\n          parents.map(parent => Map(1 -> parseFactArg(child), 2 -> parseFactArg(parent)))\n        }\n      def apply(args: Array[WamTerm]): ForeignResult = {\n        val sols = termKey(args(0)) match {\n          case Some(child) => parentsByChild.getOrElse(child, Vector.empty).map(parent => Map(1 -> parseFactArg(child), 2 -> parseFactArg(parent)))\n          case None => allSols\n        }\n        if (sols.isEmpty) ForeignFail else ForeignMulti(sols)\n      }\n    }",
+           [PathLit]).
 
 %% fact_source_to_handler_code(+Arity, +Tuples, -ScalaCode) is det.
 %  The solutions Seq is hoisted to a `val` on the anonymous class so it

--- a/tests/test_wam_scala_effective_distance_generator.pl
+++ b/tests/test_wam_scala_effective_distance_generator.pl
@@ -93,15 +93,18 @@ test(generate_artifact_project_emits_distinct_file_backend) :-
     setup_call_cleanup(
         unique_tmp_dir('tmp_wam_scala_effective_distance_artifact', TmpDir),
         (   generate('data/benchmark/dev/facts.pl', TmpDir, seeded, kernels_on, artifact),
-            directory_file_path(TmpDir, 'data/category_parent_artifact.csv', ArtifactPath),
+            directory_file_path(TmpDir, 'data/category_parent_by_child.tsv', ArtifactPath),
             directory_file_path(TmpDir, 'data/category_parent.csv', SidecarPath),
             exists_file(ArtifactPath),
             \+ exists_file(SidecarPath),
+            read_file_to_string(ArtifactPath, Artifact, []),
+            sub_string(Artifact, _, _, _, '\t'),
             directory_file_path(TmpDir,
                                 'src/main/scala/generated/wam_scala_effective_distance/core/GeneratedProgram.scala',
                                 GeneratedPath),
             read_file_to_string(GeneratedPath, Generated, []),
-            sub_string(Generated, _, _, _, 'category_parent_artifact.csv'),
+            sub_string(Generated, _, _, _, 'category_parent_by_child.tsv'),
+            sub_string(Generated, _, _, _, 'parentsByChild'),
             !
         ),
         cleanup_tmp_dir(TmpDir)).


### PR DESCRIPTION
  ## Summary
  - Change Scala effective-distance artifact mode to emit `category_parent_by_child.tsv` instead of a nominal flat CSV
  artifact.
  - Add a reusable Scala WAM `grouped_by_first(Path)` fact-source backend that loads grouped TSV data once and probes by
  the bound first argument.
  - Keep Scala artifact targets opt-in through the existing `scala-wam-artifact` target set.
  - Update generator tests and Scala hybrid WAM docs to describe the grouped child-to-parents artifact boundary.

  ## Validation
  - `swipl -q -f init.pl -s tests/test_wam_scala_effective_distance_generator.pl -g run_tests -t halt`
  - Generated, compiled, and ran a seeded Scala artifact project with `scalac` / `scala`
  - `python3 -m py_compile examples/benchmark/benchmark_common.py examples/benchmark/benchmark_target_matrix.py
  examples/benchmark/benchmark_effective_distance_matrix.py`
  - `python3 -m unittest tests/test_benchmark_target_matrix.py`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets scala-wam-artifact
  --repetitions 1`
  - `git diff --check`