### PR TITLE
fix(wam-elixir): emit integer constants as numeric literals (not strings)

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -676,6 +676,20 @@ render_index_entry(Key-Tuples, Entry) :-
 % atoms like `A1` or labels like `L_parent_2_2`) as cheap as the previous
 % split_string-based code.
 
+%% elixir_constant_literal(+TokenStr, -ElixirLiteral)
+%  Format a WAM-bytecode constant token (atoms/numbers — quotes already
+%  stripped by the tokenizer) as the Elixir literal that should appear
+%  in lowered code. Numeric tokens emit as bare numbers; everything
+%  else as a double-quoted string. Without this, every constant in the
+%  lowered emitter is force-stringified, which silently breaks numeric
+%  head-match: `iterate(0) :- ...` lowers to `val == "0"` instead of
+%  `val == 0`, so iterate/1 fails for any caller passing an integer.
+elixir_constant_literal(TokenStr, ElixirLiteral) :-
+    (   number_string(_, TokenStr)
+    ->  ElixirLiteral = TokenStr
+    ;   format(string(ElixirLiteral), '"~w"', [TokenStr])
+    ).
+
 %% tokenize_wam_line(+Line, -Tokens)
 %  `Line` is any string or atom; `Tokens` is a list of strings, in order,
 %  with separators removed and quoted regions unquoted/unescaped.
@@ -956,6 +970,7 @@ build_switch_arms(Entries, Suffix, ArmsStr) :-
     atomic_list_concat(Arms, '\n          ', ArmsStr).
 
 build_switch_arm_group(Suffix, Key-Labels, Arm) :-
+    elixir_constant_literal(Key, KeyLit),
     (   Labels = [OnlyLabel],
         OnlyLabel \== "default"
     ->  segment_func_name(OnlyLabel, Suffix, LocalFunc),
@@ -965,9 +980,9 @@ build_switch_arm_group(Suffix, Key-Labels, Arm) :-
         % solution on backtracking. The inline-dispatched clause pushes
         % its own retry CP, which remains correct.
         format(string(Arm),
-               '"~w" -> throw({:return, ~w(%{state | choice_points: tl(state.choice_points)})})',
-               [Key, LocalFunc])
-    ;   format(string(Arm), '"~w" -> :ok', [Key])
+               '~w -> throw({:return, ~w(%{state | choice_points: tl(state.choice_points)})})',
+               [KeyLit, LocalFunc])
+    ;   format(string(Arm), '~w -> :ok', [KeyLit])
     ).
 
 segment_func_name("clause_start", "clause_main") :- !.
@@ -1318,15 +1333,16 @@ instr_from_parts(Parts, raw(Combined)) :-
 
 wam_elixir_lower_instr(get_constant(C, AiName), _PC, _Labels, _FuncName, _Suffix, Code) :-
     reg_id(AiName, Ai),
+    elixir_constant_literal(C, CLit),
     format(string(Code),
 '    val = Map.get(state.regs, ~w)
     state = cond do
-      val == "~w" -> state
+      val == ~w -> state
       match?({:unbound, _}, val) ->
         {:unbound, id} = val
-        state |> WamRuntime.trail_binding(id) |> WamRuntime.put_reg(id, "~w")
+        state |> WamRuntime.trail_binding(id) |> WamRuntime.put_reg(id, ~w)
       true -> throw({:fail, state})
-    end', [Ai, C, C]).
+    end', [Ai, CLit, CLit]).
 
 wam_elixir_lower_instr(get_variable(XnName, AiName), _PC, _Labels, _FuncName, _Suffix, Code) :-
     reg_id(XnName, Xn), reg_id(AiName, Ai),
@@ -1396,11 +1412,12 @@ wam_elixir_lower_instr(unify_value(XnName), _PC, _Labels, _FuncName, _Suffix, Co
     end', [Xn]).
 
 wam_elixir_lower_instr(unify_constant(C), _PC, _Labels, _FuncName, _Suffix, Code) :-
+    elixir_constant_literal(C, CLit),
     format(string(Code),
-'    state = case WamRuntime.step_unify_constant(state, "~w") do
+'    state = case WamRuntime.step_unify_constant(state, ~w) do
       :fail -> throw({:fail, state})
       s -> s
-    end', [C]).
+    end', [CLit]).
 
 wam_elixir_lower_instr(try_me_else(_L), _PC, _Labels, _FuncName, _Suffix, Code) :-
     Code = '    :ok # Handled by wrap_segment'.
@@ -1453,7 +1470,8 @@ wam_elixir_lower_instr(builtin_call(Op, Ar), _PC, _Labels, _FuncName, _Suffix, C
 
 wam_elixir_lower_instr(put_constant(C, AiName), _PC, _Labels, _FuncName, _Suffix, Code) :-
     reg_id(AiName, Ai),
-    format(string(Code), '    state = %{state | regs: Map.put(state.regs, ~w, "~w")}', [Ai, C]).
+    elixir_constant_literal(C, CLit),
+    format(string(Code), '    state = %{state | regs: Map.put(state.regs, ~w, ~w)}', [Ai, CLit]).
 
 wam_elixir_lower_instr(put_variable(XnName, AiName), _PC, _Labels, _FuncName, _Suffix, Code) :-
     reg_id(XnName, Xn), reg_id(AiName, Ai),
@@ -1528,9 +1546,10 @@ wam_elixir_lower_instr(set_value(XnName), _PC, _Labels, _FuncName, _Suffix, Code
     state = %{state | heap: Map.put(state.heap, addr, val), heap_len: addr + 1}', [Xn]).
 
 wam_elixir_lower_instr(set_constant(C), _PC, _Labels, _FuncName, _Suffix, Code) :-
+    elixir_constant_literal(C, CLit),
     format(string(Code),
 '    addr = state.heap_len
-    state = %{state | heap: Map.put(state.heap, addr, "~w"), heap_len: addr + 1}', [C]).
+    state = %{state | heap: Map.put(state.heap, addr, ~w), heap_len: addr + 1}', [CLit]).
 
 wam_elixir_lower_instr(switch_on_constant(Entries), _PC, _Labels, _FuncName, Suffix, Code) :-
     build_switch_arms(Entries, Suffix, ArmsStr),

--- a/tests/test_wam_elixir_lowered_phase3.pl
+++ b/tests/test_wam_elixir_lowered_phase3.pl
@@ -522,9 +522,12 @@ assert_scenario_findall_compound(StdOut) :-
     sub_string(W, _, _, _, "\"a\""),
     sub_string(W, _, _, _, "\"b\""),
     sub_string(W, _, _, _, "\"c\""),
-    sub_string(W, _, _, _, "\"1\""),
-    sub_string(W, _, _, _, "\"2\""),
-    sub_string(W, _, _, _, "\"3\"").
+    % Numeric pairs lower as bare integer literals, not strings.
+    % Match within compound-tuple context to avoid spurious hits in
+    % refs/heap addresses.
+    sub_string(W, _, _, _, "\"a\", 1"),
+    sub_string(W, _, _, _, "\"b\", 2"),
+    sub_string(W, _, _, _, "\"c\", 3").
 
 assert_scenario_cut_conj(StdOut) :-
     scope_after_label(StdOut, "SCENARIO_CUT_CONJ", W),
@@ -532,11 +535,14 @@ assert_scenario_cut_conj(StdOut) :-
     % stops enumeration after the first solution. The agg frame
     % must survive cut for end_aggregate's throw fail to find it
     % during backtrack and finalise correctly. Without the cut fix
-    % in this PR, the agg frame would be removed by cut and the
-    % predicate would fail entirely.
-    sub_string(W, _, _, _, "\"1\""),
-    \+ sub_string(W, _, _, _, "\"2\""),
-    \+ sub_string(W, _, _, _, "\"3\"").
+    % in PR #1659/#1661, the agg frame would be removed by cut and
+    % the predicate would fail entirely.
+    %
+    % Match the result list `=> [1]` directly. Integers lower as
+    % bare numeric literals (post integer-quoting fix); naked "1"
+    % would spuriously match ref/heap-addr digits, so anchor on
+    % the `=> [...]` shape that brackets the result list.
+    sub_string(W, _, _, _, "=> [1]").
 
 assert_scenario_cut_subpred(StdOut) :-
     scope_after_label(StdOut, "SCENARIO_CUT_SUBPRED", W),
@@ -544,9 +550,7 @@ assert_scenario_cut_subpred(StdOut) :-
     % first_r(X) :- r(X), !. Each call to first_r succeeds with
     % the first r solution and cuts. findall's enumeration sees
     % first_r as deterministic — only one solution. L = [1].
-    sub_string(W, _, _, _, "\"1\""),
-    \+ sub_string(W, _, _, _, "\"2\""),
-    \+ sub_string(W, _, _, _, "\"3\"").
+    sub_string(W, _, _, _, "=> [1]").
 
 assert_scenario_cut_barrier(StdOut) :-
     scope_after_label(StdOut, "SCENARIO_CUT_BARRIER", W),
@@ -555,25 +559,19 @@ assert_scenario_cut_barrier(StdOut) :-
     % returns L = [1], the second findall must enumerate all 3
     % r/1 solutions independently. Rest = [1, 2, 3].
     %
-    % Both 1, 2, and 3 must appear in the output (as part of Rest).
-    % This is the diagnostic test: if cut leaked through the agg
-    % frame boundary, the second findall would see the cut's
-    % effect and Rest would be missing values.
-    sub_string(W, _, _, _, "\"1\""),
-    sub_string(W, _, _, _, "\"2\""),
-    sub_string(W, _, _, _, "\"3\"").
+    % All three values 1, 2, 3 appear in Rest. With the integer-
+    % quoting fix, lists print as `[1, 2, 3]`; match the full list.
+    sub_string(W, _, _, _, "[1, 2, 3]").
 
 assert_scenario_two_findalls(StdOut) :-
     scope_after_label(StdOut, "SCENARIO_TWO_FINDALLS", W),
-    % Two inline findalls in one body. Without this PR's structural
+    % Two inline findalls in one body. Without PR #1661's structural
     % fix, the second findall's setup ended up as dead code after
     % the first end_aggregate's throw fail. With the fix, both
     % findalls enumerate independently and bind L = Rest = [1, 2, 3].
     % Both lists are present in the IO.inspect output (as separate
     % bindings on regs[1] and regs[2]).
-    sub_string(W, _, _, _, "\"1\""),
-    sub_string(W, _, _, _, "\"2\""),
-    sub_string(W, _, _, _, "\"3\"").
+    sub_string(W, _, _, _, "[1, 2, 3]").
 
 %% Per-scenario test wrappers that share captured StdOut/StdErr/ExitCode.
 

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -1134,6 +1134,41 @@ test_findall_phase4b5_branch_skips_cp_push :-
         retract(clause_body_analysis:order_independent(user:small_fact/2))
     ).
 
+:- dynamic integer_match_test:int_p/1.
+
+%% Integer-quoting regression: the lowered emitter must emit numeric
+%  constants as bare Elixir integer literals, not as quoted strings.
+%  Pre-fix, `get_constant 0, A1` lowered to `val == "0"` (string),
+%  silently breaking numeric head-match for any predicate matching
+%  on integer literals (e.g. `iterate(0).` or fact base `r(1).`).
+%  See benchmarks/wam_elixir_tier2_findall.md "Side finding" for the
+%  original surface — and the broader implication that arithmetic-
+%  heavy Prolog code was silently no-op on this target.
+test_lowered_emits_integer_literals :-
+    Test = 'Lowering: integer constants emit as bare Elixir literals (not stringified)',
+    setup_call_cleanup(
+        (   retractall(integer_match_test:int_p(_)),
+            assertz(integer_match_test:int_p(1)),
+            assertz(integer_match_test:int_p(2)),
+            assertz(integer_match_test:int_p(3))
+        ),
+        (   wam_target:compile_predicate_to_wam(integer_match_test:int_p/1, [], WamCode),
+            lower_predicate_to_elixir(int_p/1, WamCode, [module_name('TestMod')], Code),
+            atom_string(Code, S),
+            % Positive: bare integer literal in head-match comparison.
+            sub_string(S, _, _, _, 'val == 1'),
+            sub_string(S, _, _, _, 'val == 2'),
+            sub_string(S, _, _, _, 'val == 3'),
+            % Negative: stringified form must NOT appear.
+            \+ sub_string(S, _, _, _, 'val == "1"'),
+            \+ sub_string(S, _, _, _, 'val == "2"'),
+            \+ sub_string(S, _, _, _, 'val == "3"')
+        ->  pass(Test)
+        ;   fail_test(Test, 'integer constants stringified — head-match would silently fail')
+        ),
+        retractall(integer_match_test:int_p(_))
+    ).
+
 test_tier2_purity_gate_rejects_unknown :-
     Test = 'Tier-2 infra: purity gate fails for unknown predicate',
     (   \+ tier2_purity_eligible(no_such_pred, 2, _)
@@ -1483,6 +1518,7 @@ run_tests :-
     test_findall_instr_lowers_end_aggregate,
     test_findall_instr_end_to_end_lowering,
     test_findall_module_qualified_unwrap,
+    test_lowered_emits_integer_literals,
     test_tier2_purity_gate_rejects_unknown,
     test_tier2_purity_gate_accepts_declared,
     test_par_wrap_segment_emits_super_wrapper,


### PR DESCRIPTION
## Summary

The lowered emitter wraps every constant in `"~w"`, force-stringifying numeric literals from the WAM bytecode. `iterate(0).` lowered to `val == "0"` instead of `val == 0`, so any caller passing an integer hit the throw-fail branch — predicates with numeric heads silently no-op'd.

## Surface

Found during the Phase 4 perf benchmark (PR #1774). The first iteration of that benchmark used a recursive countdown `iterate(N) :- N > 0, N1 is N - 1, iterate(N1)` per branch. Every workload size completed in microseconds because `iterate/1` returned `:fail` even for `iterate(0)`. Direct probing in the lowered Elixir confirmed the integer-as-string emission.

## Fix

Add `elixir_constant_literal/2` helper in the lowered emitter that emits numeric tokens (parseable via `number_string/2`) as bare Elixir literals and everything else as quoted strings. Apply at the five constant-emission sites:

- `get_constant` (head-match comparison + binding)
- `put_constant` (register store)
- `set_constant` (heap write during structure build)
- `unify_constant` (call into runtime helper)
- `switch_on_constant` arms (case-key dispatch)

## Test coverage

- **New emit-and-grep test** in `tests/test_wam_elixir_target.pl`: asserts the lowered Elixir for an integer-fact predicate contains `val == 1`/`2`/`3` and NOT `val == "1"`/...
- **Phase 3 cut-barrier and compound-Template assertions updated**: they previously matched `"\"1\""` (the buggy stringified form). Post-fix, integers print bare in IO.inspect output, so the assertions now anchor on `=> [1]` (singleton-result list) and `[1, 2, 3]` (full enumeration) — patterns specific enough to not match incidental digits in refs/heap addresses.

## Out of scope (separate follow-up)

`execute_builtin` in `wam_elixir_target.pl` implements `</2` and `is/2` but is missing `>/2`, `>=/2`, `=</2`, `=:=/2`, `=\=/2`. So `iterate(N)` for N>0 still returns `:fail` post-this-fix because the `>/2` builtin call falls through to the default `:fail` arm. Filing the integer-as-string fix separately because it's the root issue and worth shipping standalone — the missing comparison operators are a different scope.

## Test plan

- [x] Phase 3 (16/16)
- [x] Phase 4c (5/5)
- [x] Phase 4d (1/1)
- [x] `test_wam_elixir_target.pl` (all + new test)
- [x] `test_wam_target.pl` (all)

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_