### PR TITLE
fix(wam-elixir): add missing comparison builtins + escape backslash in builtin_call

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -1462,11 +1462,33 @@ wam_elixir_lower_instr(execute(P), _PC, _Labels, _FuncName, _Suffix, Code) :-
 '    WamDispatcher.call("~w", state)', [P]).
 
 wam_elixir_lower_instr(builtin_call(Op, Ar), _PC, _Labels, _FuncName, _Suffix, Code) :-
+    escape_backslashes_for_elixir(Op, OpEsc),
     format(string(Code),
 '    state = case WamRuntime.execute_builtin(state, "~w", ~w) do
       :fail -> throw({:fail, state})
       s -> s
-    end', [Op, Ar]).
+    end', [OpEsc, Ar]).
+
+%% escape_backslashes_for_elixir(+Token, -Escaped)
+%  Double backslashes when emitting `Token` into an Elixir double-
+%  quoted string literal. Without this, an op name like `=\=/2`
+%  becomes Elixir source `"=\=/2"` — and Elixir 1.14+ silently
+%  DROPS the unrecognised `\=` escape, producing the runtime string
+%  `==/2` instead of `=\=/2`. The execute_builtin pattern then
+%  never matches and the call falls through to the default :fail
+%  arm. Doubling the backslash gives Elixir source `"=\\=/2"`
+%  which parses as runtime `=\=/2` (5 chars including backslash).
+escape_backslashes_for_elixir(Token, Escaped) :-
+    (   atom(Token) -> atom_string(Token, S) ; S = Token ),
+    string_chars(S, Chars),
+    backslash_double(Chars, DoubledChars),
+    string_chars(Escaped, DoubledChars).
+
+backslash_double([], []).
+backslash_double(['\\' | Rest], ['\\', '\\' | More]) :- !,
+    backslash_double(Rest, More).
+backslash_double([C | Rest], [C | More]) :-
+    backslash_double(Rest, More).
 
 wam_elixir_lower_instr(put_constant(C, AiName), _PC, _Labels, _FuncName, _Suffix, Code) :-
     reg_id(AiName, Ai),

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -792,6 +792,31 @@ compile_utility_helpers_to_elixir(Code) :-
         v2 = eval_arith(state, get_reg(state, 2))
         new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
         if v1 < v2, do: %{state | pc: new_pc}, else: :fail
+      {">/2", 2} ->
+        v1 = eval_arith(state, get_reg(state, 1))
+        v2 = eval_arith(state, get_reg(state, 2))
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        if v1 > v2, do: %{state | pc: new_pc}, else: :fail
+      {"=</2", 2} ->
+        v1 = eval_arith(state, get_reg(state, 1))
+        v2 = eval_arith(state, get_reg(state, 2))
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        if v1 <= v2, do: %{state | pc: new_pc}, else: :fail
+      {">=/2", 2} ->
+        v1 = eval_arith(state, get_reg(state, 1))
+        v2 = eval_arith(state, get_reg(state, 2))
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        if v1 >= v2, do: %{state | pc: new_pc}, else: :fail
+      {"=:=/2", 2} ->
+        v1 = eval_arith(state, get_reg(state, 1))
+        v2 = eval_arith(state, get_reg(state, 2))
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        if v1 == v2, do: %{state | pc: new_pc}, else: :fail
+      {"=\\\\=/2", 2} ->
+        v1 = eval_arith(state, get_reg(state, 1))
+        v2 = eval_arith(state, get_reg(state, 2))
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        if v1 != v2, do: %{state | pc: new_pc}, else: :fail
       {"length/2", 2} ->
         # length walks the list. The list may be either a native Elixir
         # list (driver-supplied, e.g. ["Classical_mechanics"]) or a

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -1135,6 +1135,52 @@ test_findall_phase4b5_branch_skips_cp_push :-
     ).
 
 :- dynamic integer_match_test:int_p/1.
+:- dynamic arith_cmp_test:gt_p/1, arith_cmp_test:neq_p/1.
+
+%% Arithmetic-comparison regression: the runtime must implement the
+%  full comparison family (`<`, `>`, `>=`, `=<`, `=:=`, `=\=`) — pre-
+%  fix only `</2` was implemented, so any predicate body using `>`
+%  silently fell through to execute_builtin's default :fail arm.
+%  Surfaced when iterate(N) :- N > 0, ... returned :fail for any N>0.
+test_runtime_emits_full_comparison_family :-
+    Test = 'Runtime: execute_builtin covers full arithmetic-comparison family',
+    wam_elixir_target:compile_wam_runtime_to_elixir([], Code),
+    atom_string(Code, S),
+    (   sub_string(S, _, _, _, '{"</2", 2}'),
+        sub_string(S, _, _, _, '{">/2", 2}'),
+        sub_string(S, _, _, _, '{">=/2", 2}'),
+        sub_string(S, _, _, _, '{"=</2", 2}'),
+        sub_string(S, _, _, _, '{"=:=/2", 2}'),
+        sub_string(S, _, _, _, '{"=\\\\=/2", 2}')
+    ->  pass(Test)
+    ;   fail_test(Test, 'one or more comparison ops missing from execute_builtin')
+    ).
+
+%% Backslash-escape regression: `=\=/2` op name must be emitted as
+%  `"=\\=/2"` in the lowered call site so Elixir parses it as the
+%  runtime string `=\=/2` (5 chars). Without escaping, Elixir 1.14+
+%  drops the unrecognised `\=` escape and the call becomes the
+%  runtime string `==/2` (4 chars), which never matches the
+%  execute_builtin pattern.
+test_lowered_escapes_backslash_in_builtin_call :-
+    Test = 'Lowering: builtin_call escapes backslash so =\\= reaches the runtime intact',
+    setup_call_cleanup(
+        (   retractall(arith_cmp_test:neq_p(_)),
+            assertz((arith_cmp_test:neq_p(X) :- X =\= 0))
+        ),
+        (   wam_target:compile_predicate_to_wam(arith_cmp_test:neq_p/1, [], WamCode),
+            lower_predicate_to_elixir(neq_p/1, WamCode, [module_name('TestMod')], Code),
+            atom_string(Code, S),
+            % Positive: properly escaped form.
+            sub_string(S, _, _, _, 'execute_builtin(state, "=\\\\=/2"'),
+            % Negative: the buggy unescaped form would parse as ==/2
+            % at runtime; ensure it isn't emitted.
+            \+ sub_string(S, _, _, _, 'execute_builtin(state, "=\\=/2"')
+        ->  pass(Test)
+        ;   fail_test(Test, 'backslash not escaped — =\\= would be misparsed by Elixir')
+        ),
+        retractall(arith_cmp_test:neq_p(_))
+    ).
 
 %% Integer-quoting regression: the lowered emitter must emit numeric
 %  constants as bare Elixir integer literals, not as quoted strings.
@@ -1519,6 +1565,8 @@ run_tests :-
     test_findall_instr_end_to_end_lowering,
     test_findall_module_qualified_unwrap,
     test_lowered_emits_integer_literals,
+    test_runtime_emits_full_comparison_family,
+    test_lowered_escapes_backslash_in_builtin_call,
     test_tier2_purity_gate_rejects_unknown,
     test_tier2_purity_gate_accepts_declared,
     test_par_wrap_segment_emits_super_wrapper,


### PR DESCRIPTION
## Summary

Two related bugs surfaced when the integer-quoting fix (PR #1776) unblocked numeric pattern-match: arithmetic-comparison code still silently no-op'd because (1) the comparison builtins beyond `</2` and `is/2` were not implemented in `execute_builtin`, and (2) the `=\=` op name lost its backslash on the way through Elixir's string parser.

## Fix 1: Add missing arithmetic-comparison builtins

`execute_builtin` in `wam_elixir_target.pl` only had `</2` and `is/2` from the comparison family. Added five missing ops with the same `eval_arith` / PC-advance shape:

- `>/2`
- `>=/2`
- `=</2`
- `=:=/2`
- `=\=/2`

Pre-fix, any predicate body using `>` (etc.) hit the default `:fail` arm. `iterate(N) :- N > 0, N1 is N - 1, iterate(N1)` was the original surface — `iterate/1` returned `:fail` for any N>0 until this landed.

## Fix 2: Escape backslashes in builtin_call lowering

The op name `=\=/2` was being formatted with `~w` directly into Elixir source as `"=\=/2"`. Elixir 1.14+ silently drops the unrecognised `\=` escape, so the runtime string became `==/2` (4 chars) instead of `=\=/2` (5). The `execute_builtin` pattern then never matched.

Added `escape_backslashes_for_elixir/2` helper in `wam_elixir_lowered_emitter.pl` that doubles backslashes so the Elixir source preserves the literal `\` and the runtime string round-trips intact.

## End-to-end verification

A recursive `iterate(N) :- N > 0, N1 is N - 1, iterate(N1)` now actually iterates and scales O(N) wall-clock — `iterate(0)=3μs` through `iterate(1000)=197ms` — instead of returning `:fail` in microseconds. Per the "Side finding" in `benchmarks/wam_elixir_tier2_findall.md`, the parallel-vs-sequential benchmark can now use arithmetic-heavy workloads without the silent-no-op trap.

## Tests

- **`test_runtime_emits_full_comparison_family`**: emit-and-grep on the generated `wam_runtime.ex` confirming all five new ops appear.
- **`test_lowered_escapes_backslash_in_builtin_call`**: emit-and-grep on a `X =\= 0` predicate confirming the call site emits the escaped `"=\\=/2"` form (and NOT the buggy unescaped `"=\=/2"`).

## Test plan

- [x] Phase 3 (16/16)
- [x] Phase 4c (5/5)
- [x] Phase 4d (1/1)
- [x] `test_wam_elixir_target.pl` (all + 2 new tests)
- [x] `test_wam_target.pl` (all)
- [x] Direct `iterate(N)` runtime probe — scales O(N), correct results

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_