### PR TITLE
feat(wam-elixir): =/2, \\=/2, fail/0, append/3, write/nl/format + default-arm hardening

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -780,13 +780,49 @@ compile_utility_helpers_to_elixir(Code) :-
         cond do
           match?({:unbound, _}, lhs) ->
             id = case lhs do {:unbound, i} -> i end
-            state 
+            state
             |> trail_binding(id)
             |> put_reg(id, result)
             |> Map.put(:pc, new_pc)
           lhs == result -> %{state | pc: new_pc}
           true -> :fail
         end
+      {"=/2", 2} ->
+        # Body unification: X = Y. Reuses unify/3 — the same machinery
+        # the WAM head-unification instructions call into. On success,
+        # advance pc and keep the bindings; on failure, return :fail
+        # so the surrounding catch can backtrack.
+        v1 = get_reg(state, 1)
+        v2 = get_reg(state, 2)
+        case unify(state, v1, v2) do
+          {:ok, new_state} ->
+            new_pc = if is_integer(new_state.pc), do: new_state.pc + 1, else: new_state.pc
+            %{new_state | pc: new_pc}
+          :fail -> :fail
+        end
+      {"\\\\=/2", 2} ->
+        # Body negation-of-unify (the \\=/2 op). Tests unify without
+        # committing — Elixirs immutability means we just discard the
+        # post-unify state on the success path. If unify succeeds the
+        # two args *would* unify, so the goal fails; if unify fails,
+        # the goal holds and we advance pc with the original
+        # (untouched) state.
+        v1 = get_reg(state, 1)
+        v2 = get_reg(state, 2)
+        case unify(state, v1, v2) do
+          {:ok, _discarded} -> :fail
+          :fail ->
+            new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+            %{state | pc: new_pc}
+        end
+      {"fail/0", 0} ->
+        # Explicit Prolog fail. The default-arm hardening below throws
+        # {:unknown_builtin, ...} for un-handled ops; without an
+        # explicit arm here, fail/0 would have hit the throw arm and
+        # surface as a crash instead of an ordinary backtrack-driving
+        # failure. (Pre-hardening, fail/0 worked accidentally because
+        # the default arm returned :fail — same semantic, wrong reason.)
+        :fail
       {"</2", 2} ->
         v1 = eval_arith(state, get_reg(state, 1))
         v2 = eval_arith(state, get_reg(state, 2))
@@ -881,6 +917,57 @@ compile_utility_helpers_to_elixir(Code) :-
         else
           :fail
         end
+      {"append/3", 3} ->
+        # Deterministic append: walk arg1 + arg2 into a native list,
+        # unify with arg3. Native-list output works against unbound
+        # arg3 (the common case) and against an arg3 that is itself
+        # a native list of the same shape. Doesnt work against arg3
+        # being a heap-built ./2 chain — unify/3 only does shallow
+        # comparison and the structural equality check fails. Filed
+        # as an audit-known limitation; covers the typical usage.
+        l1 = deref_var(state, get_reg(state, 1))
+        l2 = deref_var(state, get_reg(state, 2))
+        case wam_list_to_native(state, l1) do
+          {:ok, n1} ->
+            case wam_list_to_native(state, l2) do
+              {:ok, n2} ->
+                appended = n1 ++ n2
+                case unify(state, get_reg(state, 3), appended) do
+                  {:ok, new_state} ->
+                    new_pc = if is_integer(new_state.pc), do: new_state.pc + 1, else: new_state.pc
+                    %{new_state | pc: new_pc}
+                  :fail -> :fail
+                end
+              :fail -> :fail
+            end
+          :fail -> :fail
+        end
+      {"write/1", 1} ->
+        v = deref_var(state, get_reg(state, 1))
+        IO.write(format_term_for_write(v))
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        %{state | pc: new_pc}
+      {"nl/0", 0} ->
+        IO.puts("")
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        %{state | pc: new_pc}
+      {"format/1", 1} ->
+        # format(Atom) — atom is the format string, no args.
+        fstr = deref_var(state, get_reg(state, 1))
+        IO.write(prolog_format(state, fstr, []))
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        %{state | pc: new_pc}
+      {"format/2", 2} ->
+        # format(Atom, Args) — atom is the format string, Args is a list.
+        fstr = deref_var(state, get_reg(state, 1))
+        args = deref_var(state, get_reg(state, 2))
+        case wam_list_to_native(state, args) do
+          {:ok, native_args} ->
+            IO.write(prolog_format(state, fstr, native_args))
+            new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+            %{state | pc: new_pc}
+          :fail -> :fail
+        end
       {"!/0", 0} ->
         # Cut: truncate choice_points back to the barrier set at
         # predicate entry (saved by `allocate` into state.cut_point).
@@ -907,8 +994,78 @@ compile_utility_helpers_to_elixir(Code) :-
             preserved_aggs ++ state.cut_point
           end
         %{state | choice_points: new_cps, pc: new_pc}
+      _ ->
+        # Hardening: surface unimplemented builtins instead of silently
+        # returning :fail. The pre-hardening default arm masked
+        # missing-builtin bugs as ordinary clause failures (see
+        # benchmarks/wam_elixir_builtin_coverage.md). Throw a tagged
+        # tuple so the error catch-all in run/1 reports it clearly
+        # rather than collapsing to :fail. Real Prolog `fail` has its
+        # own explicit `{"fail/0", 0}` arm above; new builtins should
+        # be added rather than relying on the silent-:fail accident.
+        throw({:unknown_builtin, op, arity})
+    end
+  end
+
+  defp wam_list_to_native(_state, []), do: {:ok, []}
+  defp wam_list_to_native(_state, "[]"), do: {:ok, []}
+  defp wam_list_to_native(_state, list) when is_list(list), do: {:ok, list}
+  defp wam_list_to_native(state, {:ref, addr}) do
+    # Cons cells get tagged either `./2` (early put_list emit) or
+    # `[|]/2` (later set_value emit) depending on which lowering arm
+    # produced them. Both shapes appear in lists built inline in a
+    # clause body — the existing wam_list_length/wam_list_member?
+    # check only `./2`, which is a separate audit-noted limitation.
+    # We accept both to make append/3 work end-to-end on inline lists.
+    case Map.get(state.heap, addr) do
+      {:str, cons} when cons in ["./2", "[|]/2"] ->
+        [h, tail] = heap_slice(state, addr + 1, 2)
+        head_val = deref_var(state, h)
+        case wam_list_to_native(state, deref_var(state, tail)) do
+          {:ok, rest} -> {:ok, [head_val | rest]}
+          :fail -> :fail
+        end
       _ -> :fail
     end
+  end
+  defp wam_list_to_native(_state, _), do: :fail
+
+  defp format_term_for_write({:str, name}), do: name
+  defp format_term_for_write({:ref, _} = ref), do: inspect(ref)
+  defp format_term_for_write({:unbound, _}), do: "_"
+  defp format_term_for_write(v) when is_binary(v), do: v
+  defp format_term_for_write(v) when is_number(v), do: to_string(v)
+  defp format_term_for_write(v) when is_atom(v), do: Atom.to_string(v)
+  defp format_term_for_write(v) when is_list(v) do
+    "[" <> Enum.map_join(v, ",", &format_term_for_write/1) <> "]"
+  end
+  defp format_term_for_write(v), do: inspect(v)
+
+  # Minimal Prolog format/2 implementation. Supports `~~w` (write next
+  # arg), `~~a` (atom), `~~d` (integer), `~~s` (string), `~~n` (newline).
+  # Unknown directives pass through verbatim — better to print weird
+  # output than to crash a debug-line.
+  defp prolog_format(state, fmt, args) when is_binary(fmt) do
+    do_format(state, String.graphemes(fmt), args, [])
+    |> Enum.reverse()
+    |> Enum.join("")
+  end
+  defp prolog_format(state, fmt, args) when is_list(fmt) do
+    prolog_format(state, IO.iodata_to_binary(fmt), args)
+  end
+  defp prolog_format(state, fmt, args) do
+    prolog_format(state, format_term_for_write(fmt), args)
+  end
+  defp do_format(_state, [], _args, acc), do: acc
+  defp do_format(state, ["~~", "n" | rest], args, acc) do
+    do_format(state, rest, args, ["\n" | acc])
+  end
+  defp do_format(state, ["~~", d | rest], [arg | args_rest], acc)
+       when d in ["w", "a", "d", "s", "p"] do
+    do_format(state, rest, args_rest, [format_term_for_write(deref_var(state, arg)) | acc])
+  end
+  defp do_format(state, [c | rest], args, acc) do
+    do_format(state, rest, args, [c | acc])
   end
 
   defp wam_list_length(_state, []), do: 0

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -1156,6 +1156,35 @@ test_runtime_emits_full_comparison_family :-
     ;   fail_test(Test, 'one or more comparison ops missing from execute_builtin')
     ).
 
+%% Audit follow-up (benchmarks/wam_elixir_builtin_coverage.md): the
+%  runtime now also implements =/2, \\=/2, fail/0, append/3, write/1,
+%  nl/0, format/1, format/2, and hardens the default arm to throw
+%  {:unknown_builtin, op, arity} instead of silently :fail-ing.
+test_runtime_emits_extended_builtin_set :-
+    Test = 'Runtime: execute_builtin covers =/2, \\=/2, fail/0, append/3, write/nl/format',
+    wam_elixir_target:compile_wam_runtime_to_elixir([], Code),
+    atom_string(Code, S),
+    (   sub_string(S, _, _, _, '{"=/2", 2}'),
+        sub_string(S, _, _, _, '{"\\\\=/2", 2}'),
+        sub_string(S, _, _, _, '{"fail/0", 0}'),
+        sub_string(S, _, _, _, '{"append/3", 3}'),
+        sub_string(S, _, _, _, '{"write/1", 1}'),
+        sub_string(S, _, _, _, '{"nl/0", 0}'),
+        sub_string(S, _, _, _, '{"format/1", 1}'),
+        sub_string(S, _, _, _, '{"format/2", 2}')
+    ->  pass(Test)
+    ;   fail_test(Test, 'one or more extended builtins missing from execute_builtin')
+    ).
+
+test_runtime_default_arm_throws_unknown_builtin :-
+    Test = 'Runtime: execute_builtin default arm throws {:unknown_builtin, ...} (hardening)',
+    wam_elixir_target:compile_wam_runtime_to_elixir([], Code),
+    atom_string(Code, S),
+    (   sub_string(S, _, _, _, 'throw({:unknown_builtin, op, arity})')
+    ->  pass(Test)
+    ;   fail_test(Test, 'default arm not hardened — throw not emitted')
+    ).
+
 %% Backslash-escape regression: `=\=/2` op name must be emitted as
 %  `"=\\=/2"` in the lowered call site so Elixir parses it as the
 %  runtime string `=\=/2` (5 chars). Without escaping, Elixir 1.14+
@@ -1566,6 +1595,8 @@ run_tests :-
     test_findall_module_qualified_unwrap,
     test_lowered_emits_integer_literals,
     test_runtime_emits_full_comparison_family,
+    test_runtime_emits_extended_builtin_set,
+    test_runtime_default_arm_throws_unknown_builtin,
     test_lowered_escapes_backslash_in_builtin_call,
     test_tier2_purity_gate_rejects_unknown,
     test_tier2_purity_gate_accepts_declared,


### PR DESCRIPTION
## Summary

Closes the high-priority gaps identified in the audit doc (PR #1778, `benchmarks/wam_elixir_builtin_coverage.md`). Pre-this-PR, any predicate body using `=/2`, `\=/2`, `append/3`, `write/1`, `nl/0`, or `format/1`/`format/2` silently returned `:fail` because `execute_builtin` had no matching arm and the default `_ -> :fail` arm masked the miss as ordinary clause failure.

## Implementation

`execute_builtin` arms added (`wam_elixir_target.pl`):

- **`=/2`** — body unification. Reuses existing `unify/3`. Bindings commit on success; `:fail` on mismatch lets the catch backtrack.
- **`\=/2`** — negation-of-unify. Tests unify without committing — Elixir's immutability means the post-unify state is simply discarded on the success path.
- **`fail/0`** — explicit Prolog fail. Without this, the new hardening throw would have made `fail/0` surface as a crash instead of an ordinary backtrack-driving failure.
- **`append/3`** — deterministic mode: walk arg1 + arg2 into a native list, unify with arg3.
- **`write/1`, `nl/0`** — output via a `format_term_for_write/1` helper that handles `{:str, _}`, `{:ref, _}`, `{:unbound, _}`, integers, atoms, native lists.
- **`format/1`, `format/2`** — minimal Prolog-style format. Supports `~w`, `~a`, `~d`, `~s`, `~p` (write next arg) and `~n` (newline). Unknown directives pass through verbatim.

Helpers added: `wam_list_to_native/2` (handles native Elixir lists, the `"[]"` atom-rep, and heap-built `./2` OR `[|]/2` cons chains).

## Hardening

The default arm changes from `_ -> :fail` to `throw({:unknown_builtin, op, arity})`. Surfaced via the `run/1` catch-all as a CRASHED message rather than collapsing to `:fail`. **This alone would have caught the `>/2` and `=\=/2` misses in PR #1777 the moment they were exercised**, instead of waiting for a benchmark to notice "iterate runs in microseconds at all sizes".

## Tests

- `test_runtime_emits_extended_builtin_set`: emit-and-grep asserting all eight new arms are in the generated `wam_runtime.ex`.
- `test_runtime_default_arm_throws_unknown_builtin`: emit-and-grep asserting the throw is present.
- Manual smoke probe confirming end-to-end:
  - `eq_p(5)=true, eq_p(6)=false`
  - `neq_p(6)=true, neq_p(5)=false`
  - `app_drv([1,2,3], [4,5], L) → L = [1, 2, 3, 4, 5]`
  - `write_p(hello)= hello`
  - `fmt_p= hi: 42`

## Test plan

- [x] Phase 3 (16/16)
- [x] Phase 4c (5/5)
- [x] Phase 4d (1/1)
- [x] `test_wam_elixir_target.pl` (all + 2 new tests)
- [x] `test_wam_target.pl` (all)
- [x] Manual end-to-end probe of all eight new arms

## Out-of-scope follow-ups

- `functor/3`, `arg/3`, `=../2`, `copy_term/2` — term meta-programming (audit medium-priority).
- **Inline-list-build heap chain bug** — `append/3` (and `length/2`) works on driver-passed native lists but fails on inline `[1,2,3]` literals because the WAM compiler's `put_list`/`set_value` emission doesn't link cons-cell tails to the next cons. Pre-existing bug affecting any list builtin on inline lists; out of scope here. Filing this for a separate PR.

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_