### PR TITLE
feat(wam-elixir): functor/3, arg/3, =../2, copy_term/2 (meta-programming primitives)

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -968,6 +968,99 @@ compile_utility_helpers_to_elixir(Code) :-
             %{state | pc: new_pc}
           :fail -> :fail
         end
+      {"functor/3", 3} ->
+        # functor(Term, Name, Arity). Decompose mode: Term is bound,
+        # extract Name and Arity. Build mode (Term unbound, Name +
+        # Arity bound) is not yet implemented — falls through to :fail.
+        # Atomic terms have arity 0; compound terms unpack from their
+        # heap-side `{:str, "F/N"}` cell.
+        term = deref_var(state, get_reg(state, 1))
+        case term_functor_arity(state, term) do
+          {:ok, fname, farity} ->
+            case unify(state, get_reg(state, 2), fname) do
+              {:ok, s1} ->
+                case unify(s1, get_reg(s1, 3), farity) do
+                  {:ok, s2} ->
+                    new_pc = if is_integer(s2.pc), do: s2.pc + 1, else: s2.pc
+                    %{s2 | pc: new_pc}
+                  :fail -> :fail
+                end
+              :fail -> :fail
+            end
+          :fail -> :fail
+        end
+      {"arg/3", 3} ->
+        # arg(N, Term, Arg). Read mode: N must be a bound positive
+        # integer, Term must be a bound compound. heap[Term-addr + N]
+        # is the Nth arg slot; deref + unify with Arg.
+        n = deref_var(state, get_reg(state, 1))
+        term = deref_var(state, get_reg(state, 2))
+        case {n, term} do
+          {n, {:ref, addr}} when is_integer(n) and n >= 1 ->
+            case Map.get(state.heap, addr) do
+              {:str, _fn} ->
+                arg_val = deref_var(state, Map.get(state.heap, addr + n))
+                case unify(state, get_reg(state, 3), arg_val) do
+                  {:ok, s} ->
+                    new_pc = if is_integer(s.pc), do: s.pc + 1, else: s.pc
+                    %{s | pc: new_pc}
+                  :fail -> :fail
+                end
+              _ -> :fail
+            end
+          _ -> :fail
+        end
+      {"=../2", 2} ->
+        # Univ. Decompose mode: Term =.. List builds [Functor | Args]
+        # as a native list. Compose mode (Term unbound, List bound)
+        # is not yet implemented — falls through to :fail.
+        # Atomic Term decomposes to a singleton list [Term].
+        term = deref_var(state, get_reg(state, 1))
+        result =
+          case term do
+            {:ref, addr} ->
+              case Map.get(state.heap, addr) do
+                {:str, fn_name} ->
+                  fname = parse_functor_name(fn_name)
+                  farity = parse_functor_arity(fn_name)
+                  args = if farity > 0 do
+                    Enum.map(heap_slice(state, addr + 1, farity),
+                             &deref_var(state, &1))
+                  else
+                    []
+                  end
+                  [fname | args]
+                _ -> :fail
+              end
+            v when is_number(v) or is_binary(v) or is_atom(v) -> [v]
+            _ -> :fail
+          end
+        case result do
+          :fail -> :fail
+          list ->
+            case unify(state, get_reg(state, 2), list) do
+              {:ok, s} ->
+                new_pc = if is_integer(s.pc), do: s.pc + 1, else: s.pc
+                %{s | pc: new_pc}
+              :fail -> :fail
+            end
+        end
+      {"copy_term/2", 2} ->
+        # copy_term(Original, Copy). Initial impl handles the common
+        # case where Original is fully ground (no unbound vars) — Copy
+        # gets unified with Original directly, which is semantically
+        # equivalent (ground terms are their own copy). Non-ground
+        # terms alias rather than copy — fresh-var renaming is not yet
+        # implemented. Documented as a known limitation; covers the
+        # bulk of meta-programming usage (assert/retract patterns,
+        # ground term comparison).
+        original = deref_var(state, get_reg(state, 1))
+        case unify(state, get_reg(state, 2), original) do
+          {:ok, s} ->
+            new_pc = if is_integer(s.pc), do: s.pc + 1, else: s.pc
+            %{s | pc: new_pc}
+          :fail -> :fail
+        end
       {"!/0", 0} ->
         # Cut: truncate choice_points back to the barrier set at
         # predicate entry (saved by `allocate` into state.cut_point).
@@ -1006,6 +1099,31 @@ compile_utility_helpers_to_elixir(Code) :-
         throw({:unknown_builtin, op, arity})
     end
   end
+
+  # Extract the functor-name part from a "name/arity" string.
+  defp parse_functor_name(fn_name) do
+    case String.split(fn_name, "/") do
+      [name, _arity_str] -> name
+      _ -> fn_name
+    end
+  end
+
+  # Compute (Name, Arity) for a derefd term — used by functor/3.
+  # Atomic values (numbers, strings/atoms) report themselves as the
+  # name with arity 0. Compound terms unpack from the {:str, F/N}
+  # heap cell. Unbound and unrecognised shapes return :fail (build
+  # mode is not yet supported).
+  defp term_functor_arity(state, {:ref, addr}) do
+    case Map.get(state.heap, addr) do
+      {:str, fn_name} ->
+        {:ok, parse_functor_name(fn_name), parse_functor_arity(fn_name)}
+      _ -> :fail
+    end
+  end
+  defp term_functor_arity(_state, v) when is_number(v), do: {:ok, v, 0}
+  defp term_functor_arity(_state, v) when is_binary(v), do: {:ok, v, 0}
+  defp term_functor_arity(_state, v) when is_atom(v) and not is_nil(v), do: {:ok, v, 0}
+  defp term_functor_arity(_state, _), do: :fail
 
   defp wam_list_to_native(_state, []), do: {:ok, []}
   defp wam_list_to_native(_state, "[]"), do: {:ok, []}

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -1177,6 +1177,21 @@ test_runtime_emits_extended_builtin_set :-
     ;   fail_test(Test, 'one or more extended builtins missing from execute_builtin')
     ).
 
+%% Audit follow-up (benchmarks/wam_elixir_builtin_coverage.md
+%  medium-priority): the runtime now also implements the term meta-
+%  programming primitives functor/3, arg/3, =../2, copy_term/2.
+test_runtime_emits_meta_builtin_set :-
+    Test = 'Runtime: execute_builtin covers functor/3, arg/3, =../2, copy_term/2',
+    wam_elixir_target:compile_wam_runtime_to_elixir([], Code),
+    atom_string(Code, S),
+    (   sub_string(S, _, _, _, '{"functor/3", 3}'),
+        sub_string(S, _, _, _, '{"arg/3", 3}'),
+        sub_string(S, _, _, _, '{"=../2", 2}'),
+        sub_string(S, _, _, _, '{"copy_term/2", 2}')
+    ->  pass(Test)
+    ;   fail_test(Test, 'one or more meta-builtins missing from execute_builtin')
+    ).
+
 test_runtime_default_arm_throws_unknown_builtin :-
     Test = 'Runtime: execute_builtin default arm throws {:unknown_builtin, ...} (hardening)',
     wam_elixir_target:compile_wam_runtime_to_elixir([], Code),
@@ -1638,6 +1653,7 @@ run_tests :-
     test_lowered_emits_integer_literals,
     test_runtime_emits_full_comparison_family,
     test_runtime_emits_extended_builtin_set,
+    test_runtime_emits_meta_builtin_set,
     test_runtime_default_arm_throws_unknown_builtin,
     test_lowered_put_structure_links_unbound_heap_ref,
     test_runtime_list_walkers_accept_both_cons_tags,


### PR DESCRIPTION
## Summary

Closes the medium-priority audit gap from `benchmarks/wam_elixir_builtin_coverage.md` (PR #1778). Pre-this-PR, any predicate body using term meta-programming primitives surfaced the new `{:unknown_builtin, ...}` hardening throw — now they all run.

## Implementation

Four new arms in `execute_builtin`:

- **`functor/3`** — decompose mode. Atomic terms have arity 0 and report themselves as the name. Compound terms unpack from `{:str, "F/N"}` heap cell via the new `term_functor_arity/2` helper. Build mode (Term unbound, Name+Arity bound) is not yet implemented.
- **`arg/3`** — read mode. Reads `heap[Term-addr + N]`, derefs, unifies with `Arg`. N must be a bound positive integer; Term must be a bound compound.
- **`=../2`** — univ, decompose mode. `Term =.. List` builds `[Functor | Args]` as a native list. Atomic Term decomposes to `[Term]`. Compose mode is not yet implemented.
- **`copy_term/2`** — initial impl handles ground terms by direct unify (semantically equivalent: ground terms are their own copy). Non-ground terms alias rather than copy — fresh-var renaming is not yet implemented. Documented as a known limitation; covers the bulk of meta-programming usage (assert/retract, ground term comparison).

Helpers added: `parse_functor_name/1` (sibling of `parse_functor_arity/1`) and `term_functor_arity/2`.

## End-to-end verification

```prolog
functor(foo(a,b,c), N, A)    →  N="foo", A=3
arg(2, p(red,blue,green), X) →  X="blue"
foo(a,b,c) =.. L              →  L=["foo", "a", "b", "c"]
copy_term(hello, Y)          →  Y="hello"
```

## Tests

- `test_runtime_emits_meta_builtin_set`: emit-and-grep on the generated `wam_runtime.ex` confirming all four arms appear.
- Manual smoke probe of all four end-to-end.

## Test plan

- [x] Phase 3 (16/16)
- [x] Phase 4c (5/5)
- [x] Phase 4d (1/1)
- [x] `test_wam_elixir_target.pl` (all + new test)
- [x] `test_wam_target.pl` (all)
- [x] Manual end-to-end probes for all four meta-builtins

## Out-of-scope follow-ups

- `functor/3` build mode (Term unbound, Name+Arity bound → fresh compound on heap).
- `=../2` compose mode (Term unbound, List bound → new compound).
- `copy_term/2` with proper fresh-var renaming for non-ground terms — needs a walker similar to `deep_copy_value` but emitting heap cells with fresh-var ids.

This closes the medium-priority audit gaps. Combined with PRs #1777 (comparison ops), #1780 (`=/2`/`\=/2`/`fail`/`append`/`write`/`nl`/`format` + hardening), and #1781 (inline-list-build heap link), the WAM-Elixir runtime now covers the broad set of Prolog builtins the compiler accepts.

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_