### PR TITLE
feat(wam-elixir): cost-aware Tier-2 gate via opt-in forkMinCost option

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -1150,6 +1150,19 @@ par_wrap_segment(Pred/Arity, Segments, Options, Code) :-
     \+ option(intra_query_parallel(false), Options),
     tier2_purity_eligible(Pred, Arity, _Cert),
     length(Segments, N), N >= 3,
+    % Cost-aware gate: opt-in via `forkMinCost(N)` Option. The
+    % per-clause body is statically scored (1 unit baseline, 5 for
+    % calls/builtin_calls, 10 for begin_aggregate, etc.); only the
+    % MAX clause cost has to clear the threshold (worst-case branch
+    % cost dominates the parallel-overhead amortisation). Default
+    % MinCost=0 keeps behaviour unchanged — anything passes — so
+    % existing Tier-2 tests that exercise the parallel arm with
+    % low-cost bodies still fire. Setting `forkMinCost(15)` (or
+    % similar) per the benchmark crossover blocks the parallel-loses
+    % regime documented in benchmarks/wam_elixir_tier2_findall.md.
+    option(forkMinCost(MinCost), Options, 0),
+    predicate_cost(Segments, EstCost),
+    EstCost >= MinCost,
     !,
     Segments = [FirstName-_|_],
     segment_func_name(FirstName, "", EntryFunc),
@@ -1164,6 +1177,45 @@ par_wrap_segment(Pred/Arity, Segments, Options, Code) :-
             Segments, BranchFuncs),
     emit_par_tier2_wrapper(EntryFunc, EntryImplFunc, BranchFuncs, Code).
 par_wrap_segment(_Pred, _Segments, _Options, "").
+
+%% predicate_cost(+Segments, -Cost)
+%  Static per-execution cost estimate for a Tier-2 candidates worst-
+%  case branch. Segments are Name-Instrs pairs; we sum the per-
+%  instruction weights for each clause and take the max — parallel
+%  speedup is bounded by the slowest branch, so the heaviest clause
+%  body is what determines whether parallel-overhead amortises.
+predicate_cost(Segments, Cost) :-
+    maplist([_-Instrs, C]>>clause_cost(Instrs, C), Segments, ClauseCosts),
+    (   ClauseCosts == []
+    ->  Cost = 0
+    ;   max_list(ClauseCosts, Cost)
+    ).
+
+clause_cost(Instrs, Cost) :-
+    % Segments hold PC-Instr pairs (the PC is the source-line index
+    % attached during parsing); strip the PC tag before scoring.
+    maplist([Pair, C]>>(Pair = _-Instr, instr_cost(Instr, C)), Instrs, Costs),
+    sum_list(Costs, Cost).
+
+%% instr_cost(+Instr, -Weight)
+%  Rough static weights for WAM instructions in BEAM-interpreted
+%  Elixir. Calibrated against benchmarks/wam_elixir_tier2_findall.md
+%  crossover data: a fact-only predicate (just `proceed`) scores ~1,
+%  a rule body with one call scores ~7-10, an inline-findall body
+%  scores ~17. forkMinCost values around 10-15 separate the parallel-
+%  loses regime from the parallel-wins regime for typical workloads.
+instr_cost(builtin_call(_, _),    5) :- !.
+instr_cost(call(_, _),            5) :- !.
+instr_cost(execute(_),            5) :- !.
+instr_cost(begin_aggregate(_, _, _), 10) :- !.
+instr_cost(end_aggregate(_),      5) :- !.
+instr_cost(put_structure(_, _),   3) :- !.
+instr_cost(get_structure(_, _),   3) :- !.
+instr_cost(put_list(_),           3) :- !.
+instr_cost(get_list(_),           3) :- !.
+instr_cost(switch_on_constant(_), 2) :- !.
+instr_cost(switch_on_constant_a2(_), 2) :- !.
+instr_cost(_,                     1).
 
 %% emit_par_tier2_wrapper(+EntryFunc, +EntryImplFunc, +BranchImplFuncs, -Code)
 %  Formats the `cond`-based super-wrapper per the template in

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -1502,6 +1502,70 @@ test_par_wrap_segment_kill_switch :-
         retract(clause_body_analysis:order_independent(user:tier2_pure3/2))
     ).
 
+%% Cost-aware gate (audit-driven follow-up to PRs #1774 / #1778).
+%  par_wrap_segment/4 now consults a `forkMinCost(N)` Option: if the
+%  predicates worst-case clause body scores below N on the static
+%  instruction-weighted cost model, the super-wrapper is suppressed
+%  (Code = "") and the clauses run sequentially. Default MinCost=0
+%  preserves prior behaviour.
+
+%% A high-cost fixture: each clause body has begin_aggregate (10) +
+%  call (5) + put_constant (1) + end_aggregate (5) + proceed (1) +
+%  control (try_me_else / retry_me_else / trust_me, 1 each) → ~22-23
+%  per clause. Above any reasonable forkMinCost threshold.
+heavy_segment_fixture([
+    'clause_start'-[1-try_me_else(l_b), 2-put_constant("x", "A1"),
+                    3-begin_aggregate(":collect", "X2", "X1"),
+                    4-call("inner/1", 1), 5-end_aggregate("X2"), 6-proceed],
+    'l_b'-[7-retry_me_else(l_c), 8-put_constant("y", "A1"),
+           9-begin_aggregate(":collect", "X2", "X1"),
+           10-call("inner/1", 1), 11-end_aggregate("X2"), 12-proceed],
+    'l_c'-[13-trust_me, 14-put_constant("z", "A1"),
+           15-begin_aggregate(":collect", "X2", "X1"),
+           16-call("inner/1", 1), 17-end_aggregate("X2"), 18-proceed]
+]).
+
+test_par_wrap_segment_cost_gate_rejects_low_cost :-
+    Test = 'Tier-2 cost gate: forkMinCost above clause cost forces fall-through',
+    setup_call_cleanup(
+        assertz(clause_body_analysis:order_independent(user:tier2_pure3/2)),
+        (   three_segment_fixture(Segs),  % cost ~3-4 per clause
+            par_wrap_segment(tier2_pure3/2, Segs, [forkMinCost(20)], Code),
+            Code == ""
+        ->  pass(Test)
+        ;   fail_test(Test, 'cost gate did not suppress wrapper for low-cost predicate')
+        ),
+        retract(clause_body_analysis:order_independent(user:tier2_pure3/2))
+    ).
+
+test_par_wrap_segment_cost_gate_passes_high_cost :-
+    Test = 'Tier-2 cost gate: forkMinCost below clause cost still emits wrapper',
+    setup_call_cleanup(
+        assertz(clause_body_analysis:order_independent(user:tier2_pure3/2)),
+        (   heavy_segment_fixture(Segs),  % cost ~22-23 per clause
+            par_wrap_segment(tier2_pure3/2, Segs, [forkMinCost(20)], Code),
+            Code \== "",
+            % Sanity: the emitted wrapper still has the cond/Task.async_stream shape.
+            sub_string(Code, _, _, _, "Task.async_stream")
+        ->  pass(Test)
+        ;   fail_test(Test, 'cost gate wrongly suppressed wrapper for high-cost predicate')
+        ),
+        retract(clause_body_analysis:order_independent(user:tier2_pure3/2))
+    ).
+
+test_par_wrap_segment_cost_gate_default_zero :-
+    Test = 'Tier-2 cost gate: default MinCost=0 preserves prior behaviour (low-cost still wraps)',
+    setup_call_cleanup(
+        assertz(clause_body_analysis:order_independent(user:tier2_pure3/2)),
+        (   three_segment_fixture(Segs),
+            par_wrap_segment(tier2_pure3/2, Segs, [], Code),
+            Code \== ""
+        ->  pass(Test)
+        ;   fail_test(Test, 'default MinCost=0 incorrectly suppressed wrapper')
+        ),
+        retract(clause_body_analysis:order_independent(user:tier2_pure3/2))
+    ).
+
 maybe_abolish_test_predicate(Name/Arity) :-
     (   current_predicate(user:Name/Arity)
     ->  abolish(user:Name/Arity)
@@ -1667,6 +1731,9 @@ run_tests :-
     test_switch_arm_targets_are_segments,
     test_par_wrap_segment_covers_switch_targets,
     test_par_wrap_segment_kill_switch,
+    test_par_wrap_segment_cost_gate_rejects_low_cost,
+    test_par_wrap_segment_cost_gate_passes_high_cost,
+    test_par_wrap_segment_cost_gate_default_zero,
     test_wiring_emits_tier2_eligible_attr,
     test_wiring_clause_main_is_super_wrapper_on_gate_pass,
     test_wiring_gate_reject_preserves_naming,


### PR DESCRIPTION
## Summary

The Tier-2 super-wrapper gate in `par_wrap_segment/4` used to fire on purity + clause-count alone, with no per-branch cost consideration. Per `benchmarks/wam_elixir_tier2_findall.md`, that means a 3+ clause Tier-2-eligible predicate with near-trivial bodies pays full `Task.async_stream` spawn overhead and ends up **slower** than sequential (~0.3–0.9× in the parallel-loses regime documented in PR #1774 / #1778).

This adds an opt-in cost gate. `par_wrap_segment/4` now consults `forkMinCost(N)` from `Options`: if the predicate's worst-case clause body scores below `N` on a static instruction-weighted cost model, the super-wrapper is suppressed (`Code = ""`) and the predicate runs sequentially.

## Cost model

```
builtin_call    5    end_aggregate  5
call            5    put/get_struct 3
execute         5    put/get_list   3
begin_aggregate 10   switch_on_*    2
                     everything else 1
```

Calibrated against the benchmark crossover data:

| Body shape                                  | Score |
| ------------------------------------------- | ----- |
| fact-only (just `proceed`)                  | ~1    |
| rule body with one call                     | ~7-10 |
| inline-findall body (begin + call + end)    | ~17-23|

A `forkMinCost` around **10–20** separates the parallel-loses regime from the parallel-wins regime for typical workloads.

## Default behavior preserved

Default `MinCost=0` keeps behavior unchanged: anything passes the cost gate, so existing Tier-2 tests (which exercise the parallel arm with low-cost bodies for correctness coverage, not perf) continue to fire the wrapper. Users opt in by setting `forkMinCost(N)` in project options.

## Worst-case-across-clauses semantics

Parallel speedup is bounded by the slowest branch, so the heaviest clause body determines whether parallel-overhead amortises. `predicate_cost/2` returns `max(clause_cost)` across segments.

## Tests

- `test_par_wrap_segment_cost_gate_rejects_low_cost`: low-cost fixture (cost 2) with `forkMinCost(20)` → `Code = ""`.
- `test_par_wrap_segment_cost_gate_passes_high_cost`: heavy fixture with `begin_aggregate` / `call` / `end_aggregate` per clause (cost 23) with `forkMinCost(20)` → `Code` contains `"Task.async_stream"`.
- `test_par_wrap_segment_cost_gate_default_zero`: low-cost fixture with no `forkMinCost` option → wrapper still emitted (regression guard for default-preservation invariant).

## Test plan

- [x] Phase 3 (16/16)
- [x] Phase 4c (5/5)
- [x] Phase 4d (1/1)
- [x] `test_wam_elixir_target.pl` (all + 3 new tests)
- [x] `test_wam_target.pl` (all)

## Out-of-scope follow-ups

- **Runtime-probe variant**: run sequential first time, switch to parallel on subsequent calls if measured cost is above threshold. Handles workload shapes where static cost can't predict inner-iteration count (e.g., findall over a predicate whose result-set size depends on input). Discussed in §10 of the Phase 4 proposal; needs dispatcher state + invocation accounting.
- **Calibration**: current weights are rough rules of thumb. A more principled fit against the full benchmark grid would update the recommended `forkMinCost` defaults — currently the user sets it manually per workload.

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_