### PR TITLE
feat(wam-elixir): functor/3 build mode + =../2 compose + copy_term fresh-var renaming

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -969,25 +969,47 @@ compile_utility_helpers_to_elixir(Code) :-
           :fail -> :fail
         end
       {"functor/3", 3} ->
-        # functor(Term, Name, Arity). Decompose mode: Term is bound,
-        # extract Name and Arity. Build mode (Term unbound, Name +
-        # Arity bound) is not yet implemented — falls through to :fail.
-        # Atomic terms have arity 0; compound terms unpack from their
-        # heap-side `{:str, "F/N"}` cell.
+        # functor(Term, Name, Arity). Two modes:
+        #
+        # Decompose: Term is bound — extract Name and Arity. Atomic
+        # terms have arity 0 and report themselves as the name.
+        # Compound terms unpack from their heap-side {:str, "F/N"}
+        # cell.
+        #
+        # Build: Term is unbound, Name + Arity are bound — allocate
+        # a fresh compound on the heap with `arity` unbound argument
+        # cells, bind Term to its ref. Atomic-result case (arity 0)
+        # binds Term directly to the Name value.
         term = deref_var(state, get_reg(state, 1))
-        case term_functor_arity(state, term) do
-          {:ok, fname, farity} ->
-            case unify(state, get_reg(state, 2), fname) do
-              {:ok, s1} ->
-                case unify(s1, get_reg(s1, 3), farity) do
-                  {:ok, s2} ->
-                    new_pc = if is_integer(s2.pc), do: s2.pc + 1, else: s2.pc
-                    %{s2 | pc: new_pc}
+        case term do
+          {:unbound, _} = unb ->
+            name = deref_var(state, get_reg(state, 2))
+            arity = deref_var(state, get_reg(state, 3))
+            case build_functor_term(state, name, arity) do
+              {:ok, state2, term_val} ->
+                case unify(state2, unb, term_val) do
+                  {:ok, s} ->
+                    new_pc = if is_integer(s.pc), do: s.pc + 1, else: s.pc
+                    %{s | pc: new_pc}
                   :fail -> :fail
                 end
               :fail -> :fail
             end
-          :fail -> :fail
+          _ ->
+            case term_functor_arity(state, term) do
+              {:ok, fname, farity} ->
+                case unify(state, get_reg(state, 2), fname) do
+                  {:ok, s1} ->
+                    case unify(s1, get_reg(s1, 3), farity) do
+                      {:ok, s2} ->
+                        new_pc = if is_integer(s2.pc), do: s2.pc + 1, else: s2.pc
+                        %{s2 | pc: new_pc}
+                      :fail -> :fail
+                    end
+                  :fail -> :fail
+                end
+              :fail -> :fail
+            end
         end
       {"arg/3", 3} ->
         # arg(N, Term, Arg). Read mode: N must be a bound positive
@@ -1011,51 +1033,83 @@ compile_utility_helpers_to_elixir(Code) :-
           _ -> :fail
         end
       {"=../2", 2} ->
-        # Univ. Decompose mode: Term =.. List builds [Functor | Args]
-        # as a native list. Compose mode (Term unbound, List bound)
-        # is not yet implemented — falls through to :fail.
-        # Atomic Term decomposes to a singleton list [Term].
+        # Univ. Two modes:
+        #
+        # Decompose: Term bound — Term =.. List builds [Functor | Args]
+        # as a native list. Atomic Term decomposes to [Term].
+        #
+        # Compose: Term unbound, List bound — first list element is
+        # the functor name, rest are args. Build a fresh compound
+        # on the heap and bind Term to its ref. Singleton list
+        # ([Atom]) binds Term directly to the atom.
         term = deref_var(state, get_reg(state, 1))
-        result =
-          case term do
-            {:ref, addr} ->
-              case Map.get(state.heap, addr) do
-                {:str, fn_name} ->
-                  fname = parse_functor_name(fn_name)
-                  farity = parse_functor_arity(fn_name)
-                  args = if farity > 0 do
-                    Enum.map(heap_slice(state, addr + 1, farity),
-                             &deref_var(state, &1))
-                  else
-                    []
+        case term do
+          {:unbound, _} = unb ->
+            list = deref_var(state, get_reg(state, 2))
+            case wam_list_to_native(state, list) do
+              {:ok, [name]} ->
+                # Singleton: Term = Name (atomic).
+                case unify(state, unb, name) do
+                  {:ok, s} ->
+                    new_pc = if is_integer(s.pc), do: s.pc + 1, else: s.pc
+                    %{s | pc: new_pc}
+                  :fail -> :fail
+                end
+              {:ok, [name | args]} ->
+                case build_compound_term(state, name, args) do
+                  {:ok, state2, term_val} ->
+                    case unify(state2, unb, term_val) do
+                      {:ok, s} ->
+                        new_pc = if is_integer(s.pc), do: s.pc + 1, else: s.pc
+                        %{s | pc: new_pc}
+                      :fail -> :fail
+                    end
+                  :fail -> :fail
+                end
+              _ -> :fail
+            end
+          _ ->
+            result =
+              case term do
+                {:ref, addr} ->
+                  case Map.get(state.heap, addr) do
+                    {:str, fn_name} ->
+                      fname = parse_functor_name(fn_name)
+                      farity = parse_functor_arity(fn_name)
+                      args = if farity > 0 do
+                        Enum.map(heap_slice(state, addr + 1, farity),
+                                 &deref_var(state, &1))
+                      else
+                        []
+                      end
+                      [fname | args]
+                    _ -> :fail
                   end
-                  [fname | args]
+                v when is_number(v) or is_binary(v) or is_atom(v) -> [v]
                 _ -> :fail
               end
-            v when is_number(v) or is_binary(v) or is_atom(v) -> [v]
-            _ -> :fail
-          end
-        case result do
-          :fail -> :fail
-          list ->
-            case unify(state, get_reg(state, 2), list) do
-              {:ok, s} ->
-                new_pc = if is_integer(s.pc), do: s.pc + 1, else: s.pc
-                %{s | pc: new_pc}
+            case result do
               :fail -> :fail
+              list ->
+                case unify(state, get_reg(state, 2), list) do
+                  {:ok, s} ->
+                    new_pc = if is_integer(s.pc), do: s.pc + 1, else: s.pc
+                    %{s | pc: new_pc}
+                  :fail -> :fail
+                end
             end
         end
       {"copy_term/2", 2} ->
-        # copy_term(Original, Copy). Initial impl handles the common
-        # case where Original is fully ground (no unbound vars) — Copy
-        # gets unified with Original directly, which is semantically
-        # equivalent (ground terms are their own copy). Non-ground
-        # terms alias rather than copy — fresh-var renaming is not yet
-        # implemented. Documented as a known limitation; covers the
-        # bulk of meta-programming usage (assert/retract patterns,
-        # ground term comparison).
+        # copy_term(Original, Copy). Walks Originals heap structure,
+        # allocating a fresh copy with renamed variables. Sharing is
+        # preserved: occurrences of the SAME unbound var in the input
+        # map to the SAME fresh var in the output (e.g., copy_term of
+        # p(X, X) gives p(Z, Z), not p(Z1, Z2)). Atomic values pass
+        # through unchanged — theyre immutable and have no var
+        # identity to rename.
         original = deref_var(state, get_reg(state, 1))
-        case unify(state, get_reg(state, 2), original) do
+        {state2, copy_val, _vmap} = deep_copy_with_fresh_vars(state, original, %{})
+        case unify(state2, get_reg(state2, 2), copy_val) do
           {:ok, s} ->
             new_pc = if is_integer(s.pc), do: s.pc + 1, else: s.pc
             %{s | pc: new_pc}
@@ -1124,6 +1178,92 @@ compile_utility_helpers_to_elixir(Code) :-
   defp term_functor_arity(_state, v) when is_binary(v), do: {:ok, v, 0}
   defp term_functor_arity(_state, v) when is_atom(v) and not is_nil(v), do: {:ok, v, 0}
   defp term_functor_arity(_state, _), do: :fail
+
+  # Build a fresh compound term with `arity` unbound argument cells
+  # for functor/3 in build mode. Atomic-result case (arity 0) just
+  # returns the name as the term value. Returns {:ok, state, term}
+  # on success or :fail when args are mistyped.
+  defp build_functor_term(state, name, 0)
+       when is_binary(name) or is_atom(name) or is_number(name) do
+    {:ok, state, name}
+  end
+  defp build_functor_term(state, name, arity)
+       when is_integer(arity) and arity > 0 and (is_binary(name) or is_atom(name)) do
+    name_str = if is_atom(name), do: Atom.to_string(name), else: name
+    fn_name = "#{name_str}/#{arity}"
+    addr = state.heap_len
+    heap1 = Map.put(state.heap, addr, {:str, fn_name})
+    {final_heap, _} =
+      Enum.reduce(1..arity, {heap1, addr + 1}, fn _, {h, a} ->
+        {Map.put(h, a, {:unbound, {:heap_ref, a}}), a + 1}
+      end)
+    new_state = %{state | heap: final_heap, heap_len: addr + 1 + arity}
+    {:ok, new_state, {:ref, addr}}
+  end
+  defp build_functor_term(_state, _, _), do: :fail
+
+  # Build a fresh compound term from a functor name and a list of
+  # already-evaluated argument values for =../2 in compose mode.
+  defp build_compound_term(state, name, args)
+       when (is_binary(name) or is_atom(name)) and is_list(args) do
+    arity = length(args)
+    name_str = if is_atom(name), do: Atom.to_string(name), else: name
+    fn_name = "#{name_str}/#{arity}"
+    addr = state.heap_len
+    heap1 = Map.put(state.heap, addr, {:str, fn_name})
+    {final_heap, _} =
+      Enum.reduce(args, {heap1, addr + 1}, fn arg, {h, a} ->
+        {Map.put(h, a, arg), a + 1}
+      end)
+    new_state = %{state | heap: final_heap, heap_len: addr + 1 + arity}
+    {:ok, new_state, {:ref, addr}}
+  end
+  defp build_compound_term(_state, _, _), do: :fail
+
+  # Walk a term, allocating a fresh copy with renamed variables for
+  # copy_term/2. The var_map argument carries the in-progress mapping
+  # from input-var-id to output-fresh-var so the same input var
+  # consistently maps to the same fresh output var (sharing
+  # preserved). Returns {state, copy, updated_var_map}.
+  defp deep_copy_with_fresh_vars(state, {:unbound, id}, var_map) do
+    case Map.get(var_map, id) do
+      nil ->
+        fresh = {:unbound, make_ref()}
+        {state, fresh, Map.put(var_map, id, fresh)}
+      existing ->
+        {state, existing, var_map}
+    end
+  end
+  defp deep_copy_with_fresh_vars(state, {:ref, addr}, var_map) do
+    case Map.get(state.heap, addr) do
+      {:str, fn_name} ->
+        arity = parse_functor_arity(fn_name)
+        # Recursively copy each arg, threading state and var_map.
+        {args_rev, state2, vm2} =
+          if arity > 0 do
+            Enum.reduce(1..arity, {[], state, var_map}, fn i, {acc, s, vm} ->
+              raw = Map.get(s.heap, addr + i)
+              arg_val = deref_var(s, raw)
+              {s_next, copy, vm_next} = deep_copy_with_fresh_vars(s, arg_val, vm)
+              {[copy | acc], s_next, vm_next}
+            end)
+          else
+            {[], state, var_map}
+          end
+        args = Enum.reverse(args_rev)
+        new_addr = state2.heap_len
+        heap1 = Map.put(state2.heap, new_addr, {:str, fn_name})
+        {final_heap, _} =
+          Enum.reduce(args, {heap1, new_addr + 1}, fn a_val, {h, a} ->
+            {Map.put(h, a, a_val), a + 1}
+          end)
+        new_state = %{state2 | heap: final_heap, heap_len: new_addr + 1 + arity}
+        {new_state, {:ref, new_addr}, vm2}
+      _ ->
+        {state, {:ref, addr}, var_map}
+    end
+  end
+  defp deep_copy_with_fresh_vars(state, val, var_map), do: {state, val, var_map}
 
   defp wam_list_to_native(_state, []), do: {:ok, []}
   defp wam_list_to_native(_state, "[]"), do: {:ok, []}

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -1192,6 +1192,22 @@ test_runtime_emits_meta_builtin_set :-
     ;   fail_test(Test, 'one or more meta-builtins missing from execute_builtin')
     ).
 
+%% Build-mode follow-up to PR #1782: functor/3 and =../2 now also
+%  support build mode (Term unbound, Name+Arity OR list bound),
+%  and copy_term/2 walks heap structures with fresh-var renaming
+%  (sharing preserved). Emit-and-grep on the runtime confirms the
+%  new helper defps are present.
+test_runtime_emits_meta_builtin_build_mode :-
+    Test = 'Runtime: meta-builtins emit build_functor_term/build_compound_term/deep_copy_with_fresh_vars helpers',
+    wam_elixir_target:compile_wam_runtime_to_elixir([], Code),
+    atom_string(Code, S),
+    (   sub_string(S, _, _, _, 'defp build_functor_term('),
+        sub_string(S, _, _, _, 'defp build_compound_term('),
+        sub_string(S, _, _, _, 'defp deep_copy_with_fresh_vars(')
+    ->  pass(Test)
+    ;   fail_test(Test, 'one or more meta-builtin helpers missing from runtime')
+    ).
+
 test_runtime_default_arm_throws_unknown_builtin :-
     Test = 'Runtime: execute_builtin default arm throws {:unknown_builtin, ...} (hardening)',
     wam_elixir_target:compile_wam_runtime_to_elixir([], Code),
@@ -1718,6 +1734,7 @@ run_tests :-
     test_runtime_emits_full_comparison_family,
     test_runtime_emits_extended_builtin_set,
     test_runtime_emits_meta_builtin_set,
+    test_runtime_emits_meta_builtin_build_mode,
     test_runtime_default_arm_throws_unknown_builtin,
     test_lowered_put_structure_links_unbound_heap_ref,
     test_runtime_list_walkers_accept_both_cons_tags,


### PR DESCRIPTION
## Summary

Closes the three out-of-scope items from PR #1782:

1. **`functor/3` build mode** — Term unbound, Name+Arity bound → fresh compound on heap.
2. **`=../2` compose mode** — Term unbound, List bound → new compound from list.
3. **`copy_term/2` fresh-var renaming** — non-ground terms get a fresh-var copy with sharing preserved.

## Implementation

### functor/3 build mode

When Term is unbound and Name+Arity are bound, allocate `{:str, "Name/Arity"}` + Arity unbound argument cells on heap, bind Term to its ref. Atomic-result case (arity 0) binds Term directly to Name.

### =../2 compose mode

When Term is unbound and List is bound, first list element = functor name, rest = args. Build a fresh compound on heap. Singleton list `[Atom]` binds Term directly to the atom.

### copy_term/2 fresh-var renaming

The existing impl just unified Copy with Original — correct for ground terms but **wrong for non-ground** (it aliased rather than copying). Now walks the heap structure and allocates a fresh copy with renamed variables.

**Sharing preserved** via an in-progress var_map: occurrences of the SAME unbound var in the input map to the SAME fresh var in the output. e.g., `copy_term(p(X, X), Y)` gives `Y = p(Z, Z)`, not `p(Z1, Z2)`.

## Helpers added

- `build_functor_term/3`: name + arity → fresh heap compound or atomic value.
- `build_compound_term/3`: name + arg-list → fresh heap compound. Used by `=../2` compose.
- `deep_copy_with_fresh_vars/3`: walks a term, threads state and var_map; returns `{state, copy, var_map}`. Recursive on heap-built compounds.

## End-to-end verification

```
functor(T, foo, 2)         → T = ref(addr); heap[addr] = {:str, "foo/2"};
                              heap[addr+1..2] = unbound heap_refs.

T =.. [bar, a, b, c]        → T = ref(addr); heap[addr] = {:str, "bar/3"};
                              heap[addr+1..3] = "a", "b", "c".

copy_term(pair(X, X), Y)
where X is unbound          → Y = ref(addr); heap[addr+1] == heap[addr+2]
                              (same fresh var ref; SHARING PRESERVED).
```

## Tests

- `test_runtime_emits_meta_builtin_build_mode`: emit-and-grep on `wam_runtime.ex` confirming all three new helper `defp`s appear.
- Manual smoke probes for all three modes.

## Test plan

- [x] Phase 3 (16/16)
- [x] Phase 4c (5/5)
- [x] Phase 4d (1/1)
- [x] `test_wam_elixir_target.pl` (all + new test)
- [x] `test_wam_target.pl` (all)
- [x] Manual end-to-end probes for build/compose modes and copy_term sharing

## Builtin coverage now (post this PR)

```
arithmetic + comparison:  is, <, >, =<, >=, =:=, =\=
unification:              =, \=, fail
control:                  !, \+
list ops:                 length, member, append
output:                   write, nl, format/1, format/2
meta-programming:         functor (both modes), arg, =.. (both modes),
                          copy_term (with var renaming)
hardening:                unknown-builtin throw on default arm
```

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_