### PR TITLE
feat(wam-elixir): runtime cost probe for Tier-2 super-wrapper (opt-in)

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -1175,7 +1175,20 @@ par_wrap_segment(Pred/Arity, Segments, Options, Code) :-
     % duplicates from Phase 4bs runtime probe.
     maplist([Name-_Instrs, BranchFunc]>>segment_func_name(Name, "_branch", BranchFunc),
             Segments, BranchFuncs),
-    emit_par_tier2_wrapper(EntryFunc, EntryImplFunc, BranchFuncs, Code).
+    % Companion to forkMinCost (static codegen-time gate): if the
+    % user passes runtime_cost_probe(ThresholdUs), emit a probe-
+    % wrapped super-wrapper that measures the first sequential call
+    % and switches subsequent calls to parallel only when measured
+    % us > ThresholdUs. State persists across calls via an ETS table
+    % managed in WamRuntime. Without the option, emit the existing
+    % unconditional-parallel template (default behaviour preserved).
+    format(atom(PredKey), '~w/~w', [Pred, Arity]),
+    (   option(runtime_cost_probe(ThresholdUs), Options),
+        integer(ThresholdUs)
+    ->  emit_par_tier2_wrapper_with_probe(EntryFunc, EntryImplFunc,
+            BranchFuncs, PredKey, ThresholdUs, Code)
+    ;   emit_par_tier2_wrapper(EntryFunc, EntryImplFunc, BranchFuncs, Code)
+    ).
 par_wrap_segment(_Pred, _Segments, _Options, "").
 
 %% predicate_cost(+Segments, -Cost)
@@ -1342,6 +1355,92 @@ emit_par_tier2_wrapper(EntryFunc, EntryImplFunc, BranchImplFuncs, Code) :-
     end
   end',
     [EntryFunc, EntryImplFunc, EntryImplFunc, BranchListInner]).
+
+%% emit_par_tier2_wrapper_with_probe(+EntryFunc, +EntryImplFunc,
+%%   +BranchImplFuncs, +PredKey, +ThresholdUs, -Code)
+%
+%  Probe-wrapped variant of the super-wrapper. The `true ->` arm of
+%  the cond block dispatches to one of three behaviours based on a
+%  per-predicate decision in the WamRuntime ETS table:
+%
+%    :go_parallel    — fan out via Task.async_stream (existing
+%                      parallel-arm code, inlined verbatim).
+%    :go_sequential  — call the sequential _impl directly.
+%    :probe          — measure the sequential call via :timer.tc/1,
+%                      then update the decision table with the
+%                      measured us vs ThresholdUs.
+%
+%  First call is always sequential (probe). Subsequent calls follow
+%  the recorded decision. Decision is sticky.
+emit_par_tier2_wrapper_with_probe(EntryFunc, EntryImplFunc, BranchImplFuncs,
+                                  PredKey, ThresholdUs, Code) :-
+    maplist([F, Ref]>>format(string(Ref), '&~w/1', [F]),
+            BranchImplFuncs, BranchRefs),
+    atomic_list_concat(BranchRefs, ', ', BranchListInner),
+    format(string(Code),
+'  defp ~w(state) do
+    cond do
+      not WamRuntime.in_forkable_aggregate_frame?(state) ->
+        ~w(state)
+
+      Map.get(state, :parallel_depth, 0) > 0 ->
+        ~w(state)
+
+      true ->
+        # Runtime cost probe (PR follow-up to forkMinCost static gate).
+        # Per-predicate decision lives in :tier2_cost_probe ETS table;
+        # see WamRuntime.tier2_probe_decision/1 + tier2_probe_update/3.
+        case WamRuntime.tier2_probe_decision("~w") do
+          :go_sequential ->
+            ~w(state)
+
+          :probe ->
+            {us, result} = :timer.tc(fn -> ~w(state) end)
+            WamRuntime.tier2_probe_update("~w", us, ~w)
+            result
+
+          :go_parallel ->
+            [parent_agg_cp | rest_cps] = state.choice_points
+            stamped_parent = Map.put(parent_agg_cp, :branch_sentinel, true)
+
+            branch_state = %{state |
+              branch_mode: true,
+              cut_point: state.choice_points,
+              parallel_depth: Map.get(state, :parallel_depth, 0) + 1,
+              choice_points: [stamped_parent | rest_cps]
+            }
+
+            branches = [~w]
+
+            branch_results =
+              branches
+              |> Task.async_stream(fn branch ->
+                   try do
+                     case branch.(branch_state) do
+                       {:branch_exhausted, accum} when is_list(accum) -> accum
+                       _ -> []
+                     end
+                   catch
+                     {:fail, _s} -> []
+                     {:return, {:branch_exhausted, accum}} when is_list(accum) -> accum
+                     {:return, _} -> []
+                   end
+                 end,
+                 on_timeout: :kill_task,
+                 ordered: false,
+                 max_concurrency: System.schedulers_online())
+              |> Enum.flat_map(fn
+                {:ok, solutions} when is_list(solutions) -> solutions
+                _ -> []
+              end)
+
+            merged = WamRuntime.merge_into_aggregate(state, branch_results)
+            throw({:fail, merged})
+        end
+    end
+  end',
+    [EntryFunc, EntryImplFunc, EntryImplFunc, PredKey,
+     EntryImplFunc, EntryImplFunc, PredKey, ThresholdUs, BranchListInner]).
 
 % ============================================================================
 % INSTRUCTION PARSING

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -1478,6 +1478,55 @@ compile_aggregate_helpers_to_elixir(Code) :-
   end
 
   @doc """
+  Tier-2 runtime cost probe — companion to the static forkMinCost
+  gate. The static gate (par_wrap_segment/4) decides at codegen
+  time whether a predicates worst-case clause body is heavy enough
+  to amortise Task.async_stream overhead. The runtime probe takes a
+  measurement on the FIRST invocation of each Tier-2-eligible
+  predicate, then sticks with that decision for subsequent calls.
+
+  Decision is keyed by predicate-name string and stored in an ETS
+  table created lazily on first call. Three states:
+
+    :probe          — no measurement yet; caller must run sequential
+                      and report elapsed time via tier2_probe_update/3.
+    :go_sequential  — sequential beat or matched threshold; stay
+                      sequential.
+    :go_parallel    — sequential exceeded threshold; fan out
+                      via Task.async_stream from now on.
+
+  See benchmarks/wam_elixir_tier2_findall.md for the crossover data
+  that motivates the threshold default. Recommended threshold is in
+  the 500-2000us range for typical workloads on a 4-core box.
+  """
+  def tier2_probe_decision(pred_key) do
+    ensure_tier2_probe_table()
+    case :ets.lookup(:tier2_cost_probe, pred_key) do
+      [{_, decision}] -> decision
+      [] -> :probe
+    end
+  end
+
+  def tier2_probe_update(pred_key, us, threshold_us) do
+    ensure_tier2_probe_table()
+    decision = if us > threshold_us, do: :go_parallel, else: :go_sequential
+    :ets.insert(:tier2_cost_probe, {pred_key, decision})
+    :ok
+  end
+
+  defp ensure_tier2_probe_table do
+    if :ets.whereis(:tier2_cost_probe) == :undefined do
+      try do
+        :ets.new(:tier2_cost_probe, [:set, :public, :named_table])
+        :ok
+      rescue
+        ArgumentError -> :ok
+      end
+    end
+    :ok
+  end
+
+  @doc """
   Update the topmost aggregate frames :cp field to a new continuation.
   Called by end_aggregate-terminated sub-segments to point the agg
   frame at the post-end_aggregate sub-segment, so finalise tail-calls

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -1582,6 +1582,58 @@ test_par_wrap_segment_cost_gate_default_zero :-
         retract(clause_body_analysis:order_independent(user:tier2_pure3/2))
     ).
 
+%% Runtime cost probe (companion to forkMinCost static gate).
+%  par_wrap_segment/4 reads `runtime_cost_probe(ThresholdUs)` from
+%  Options. When present, the super-wrappers `true ->` arm is wrapped
+%  in a case statement that dispatches via WamRuntime.tier2_probe_*
+%  helpers — first call goes sequential and measures, subsequent
+%  calls follow the recorded decision.
+test_par_wrap_segment_runtime_probe_emits_dispatch :-
+    Test = 'Tier-2 runtime probe: super-wrapper emits ETS-backed dispatch when option set',
+    setup_call_cleanup(
+        assertz(clause_body_analysis:order_independent(user:tier2_pure3/2)),
+        (   three_segment_fixture(Segs),
+            par_wrap_segment(tier2_pure3/2, Segs,
+                             [runtime_cost_probe(1000)], Code),
+            sub_string(Code, _, _, _, "tier2_probe_decision"),
+            sub_string(Code, _, _, _, "tier2_probe_update"),
+            sub_string(Code, _, _, _, ":timer.tc"),
+            sub_string(Code, _, _, _, ":probe ->"),
+            sub_string(Code, _, _, _, ":go_sequential ->"),
+            sub_string(Code, _, _, _, ":go_parallel ->")
+        ->  pass(Test)
+        ;   fail_test(Test, 'probe-dispatch arm not emitted when runtime_cost_probe set')
+        ),
+        retract(clause_body_analysis:order_independent(user:tier2_pure3/2))
+    ).
+
+test_par_wrap_segment_runtime_probe_default_unwired :-
+    Test = 'Tier-2 runtime probe: default (no option) keeps the unconditional-parallel template',
+    setup_call_cleanup(
+        assertz(clause_body_analysis:order_independent(user:tier2_pure3/2)),
+        (   three_segment_fixture(Segs),
+            par_wrap_segment(tier2_pure3/2, Segs, [], Code),
+            % Probe markers must NOT appear when option absent.
+            \+ sub_string(Code, _, _, _, "tier2_probe_decision"),
+            \+ sub_string(Code, _, _, _, ":probe ->")
+        ->  pass(Test)
+        ;   fail_test(Test, 'probe-dispatch arm leaked into default code path')
+        ),
+        retract(clause_body_analysis:order_independent(user:tier2_pure3/2))
+    ).
+
+test_runtime_emits_tier2_probe_helpers :-
+    Test = 'Runtime: tier2_probe_decision/1 + tier2_probe_update/3 + ensure_tier2_probe_table available',
+    wam_elixir_target:compile_wam_runtime_to_elixir([], Code),
+    atom_string(Code, S),
+    (   sub_string(S, _, _, _, 'def tier2_probe_decision('),
+        sub_string(S, _, _, _, 'def tier2_probe_update('),
+        sub_string(S, _, _, _, 'defp ensure_tier2_probe_table'),
+        sub_string(S, _, _, _, ':tier2_cost_probe')
+    ->  pass(Test)
+    ;   fail_test(Test, 'one or more tier2 probe helpers missing from runtime')
+    ).
+
 maybe_abolish_test_predicate(Name/Arity) :-
     (   current_predicate(user:Name/Arity)
     ->  abolish(user:Name/Arity)
@@ -1751,6 +1803,9 @@ run_tests :-
     test_par_wrap_segment_cost_gate_rejects_low_cost,
     test_par_wrap_segment_cost_gate_passes_high_cost,
     test_par_wrap_segment_cost_gate_default_zero,
+    test_par_wrap_segment_runtime_probe_emits_dispatch,
+    test_par_wrap_segment_runtime_probe_default_unwired,
+    test_runtime_emits_tier2_probe_helpers,
     test_wiring_emits_tier2_eligible_attr,
     test_wiring_clause_main_is_super_wrapper_on_gate_pass,
     test_wiring_gate_reject_preserves_naming,


### PR DESCRIPTION
## Summary

Companion to PR #1783's static `forkMinCost` gate. The static gate decides at codegen time based on instruction-weighted cost; this adds an opt-in **runtime** probe that takes a measurement on the first sequential call and switches subsequent calls to parallel only when the measured wall-clock exceeds a user-supplied threshold.

Useful for workload shapes where static cost can't predict the inner-iteration count — e.g., a Tier-2-eligible predicate whose body is a `findall` over an external fact source whose cardinality varies at runtime. Static cost would score the body the same regardless of input size; the runtime probe sees the actual cost of one call and adapts.

## How it works

Opt-in via `runtime_cost_probe(ThresholdUs)` Option to `write_wam_elixir_project/3`. When present, `par_wrap_segment/4` calls the new `emit_par_tier2_wrapper_with_probe/6` instead of the existing `emit_par_tier2_wrapper/4`. The probe-wrapped super-wrapper's `true ->` arm dispatches three ways via `WamRuntime.tier2_probe_decision/1`:

| Decision | Behaviour |
| --- | --- |
| `:probe` | Run sequential `_impl`, measure via `:timer.tc/1`, update decision. |
| `:go_sequential` | Call `_impl` directly (skip overhead). |
| `:go_parallel` | Fan out via `Task.async_stream`. |

Decision is per-predicate (keyed by `"name/arity"` string) and **sticky** after the first measurement. Default (option absent) keeps the unconditional-parallel template — no behavioural change for existing projects.

## State storage

ETS table `:tier2_cost_probe`, created lazily on first call via `ensure_tier2_probe_table/0`. `:public` + `:named_table` so any process spawned via `Task.async_stream` sees the same decisions. `ArgumentError` on table-create races (two processes simultaneously creating) is rescued — the second one just uses the table the first created.

## End-to-end smoke test

```
Decision before any call: :probe
Call 1 (probe) elapsed=37us              # sequential, measured
Decision after probe: :go_sequential    # 37 < 500us threshold
Call 2 elapsed=17us                      # subsequent calls stay sequential
Call 3 elapsed=15us
…

# Manual override via :ets.insert
Forced :go_parallel; running 3 more times
Call 7 elapsed=3557us                    # JIT + spawn warmup
Call 8 elapsed=71us                      # parallel from now on
Call 9 elapsed=88us
```

## Tests

- `test_par_wrap_segment_runtime_probe_emits_dispatch`: emit-and-grep asserts the probe-dispatch arm contains `tier2_probe_decision`, `tier2_probe_update`, `:timer.tc`, and the three case branches.
- `test_par_wrap_segment_runtime_probe_default_unwired`: regression guard — without the option, probe markers MUST NOT appear (default behaviour preserved).
- `test_runtime_emits_tier2_probe_helpers`: emit-and-grep on `wam_runtime.ex` confirming `tier2_probe_decision` / `tier2_probe_update` + the ETS table name are present.

## Test plan

- [x] Phase 3 (16/16)
- [x] Phase 4c (5/5)
- [x] Phase 4d (1/1)
- [x] `test_wam_elixir_target.pl` (all + 3 new tests)
- [x] `test_wam_target.pl` (all)
- [x] Manual end-to-end smoke probe with decision stickiness verified

## Static + runtime gates

Combined with PR #1783, users can now mix-and-match:

| Gate | Trade-off |
| --- | --- |
| `forkMinCost(N)` | Static codegen-time gate; cheap, no runtime overhead, blind to per-invocation context. |
| `runtime_cost_probe(Us)` | Runtime measurement; one-call cost for the probe call, sticky decision thereafter; adapts to actual workload. |

Both can coexist (static gate runs first; if the wrapper is emitted, the runtime probe wraps the parallel arm).

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_