### PR TITLE
feat(wam-scala): mutable intern + atom_concat/sub_atom reverse modes

### DIFF
--- a/examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl
@@ -369,11 +369,11 @@ object EffectiveDistanceRunner {
   }
 
   private def atom(raw: String): WamTerm =
-    Atom(GeneratedProgram.internTable.stringToId.getOrElse(raw, -1))
+    Atom(GeneratedProgram.internTable.intern(raw))
 
   private def listOf(items: WamTerm*): WamTerm = {
-    val cons = GeneratedProgram.internTable.stringToId("[|]")
-    val empty = GeneratedProgram.internTable.stringToId("[]")
+    val cons = GeneratedProgram.internTable.lookupId("[|]")
+    val empty = GeneratedProgram.internTable.lookupId("[]")
     items.foldRight[WamTerm](Atom(empty)) { (head, tail) =>
       Struct(cons, 2, Array(head, tail))
     }

--- a/examples/wam_scala_demo/genealogy.pl
+++ b/examples/wam_scala_demo/genealogy.pl
@@ -69,7 +69,7 @@ age_handler_code(C) :-
 \n  )\
 \n  args(0) match {\
 \n    case Atom(id) =>\
-\n      val name = if (id >= 0 && id < internTable.idToString.length) internTable.idToString(id) else \"\"\
+\n      val name = internTable.stringAt(id)\
 \n      ages.get(name) match {\
 \n        case Some(n) => ForeignBindings(Map(2 -> IntTerm(n)))\
 \n        case None    => ForeignFail\

--- a/src/unifyweaver/targets/wam_scala_target.pl
+++ b/src/unifyweaver/targets/wam_scala_target.pl
@@ -64,18 +64,14 @@ intern_scala_atom(AtomStr, Id) :-
         assertz(scala_atom_intern_next(Next1))
     ).
 
-%% emit_scala_intern_table(-StringToIdEntries, -IdToStringEntries) is det.
-%  Generates Mustache-substitutable strings for the intern table sections.
-emit_scala_intern_table(StringToIdEntries, IdToStringEntries) :-
+%% emit_scala_intern_table(-IdToStringEntries) is det.
+%  Generates the Mustache-substitutable string for the intern table seed
+%  array. The runtime InternTable is mutable and seeds itself from this
+%  array; ids are positional (index 0 -> id 0, etc.) so the order matters.
+emit_scala_intern_table(IdToStringEntries) :-
     findall(Id-Str, scala_atom_intern_id(Str, Id), Pairs),
     sort(Pairs, Sorted),
-    % stringToId map entries: "atom" -> id
-    maplist([Id-Str, Entry]>>(
-        format(string(Entry), '      "~w" -> ~w', [Str, Id])
-    ), Sorted, SEntries),
-    atomic_list_concat(SEntries, ',\n', StringToIdEntries),
-    % idToString array entries: "atom" (ordered by id)
-    maplist([_Id-Str, E]>>(format(string(E), '      "~w"', [Str])), Sorted, IEntries),
+    maplist([_Id-Str, E]>>(format(string(E), '    "~w"', [Str])), Sorted, IEntries),
     atomic_list_concat(IEntries, ',\n', IdToStringEntries).
 
 % ============================================================================
@@ -783,7 +779,7 @@ write_wam_scala_project(Predicates, Options0, ProjectDir) :-
     compile_predicates_for_project(Predicates, Options,
         AllInstrs, TopLevelLabelEntries, AllLabelEntries, WrapperCode),
     % --- Intern table ---
-    emit_scala_intern_table(StringToIdStr, IdToStringStr),
+    emit_scala_intern_table(IdToStringStr),
     % --- Format instruction array body ---
     maplist([I, Line]>>(format(string(Line), '    ~w', [I])), AllInstrs, InstrLines),
     atomic_list_concat(InstrLines, ',\n', InstrBody),
@@ -801,7 +797,7 @@ write_wam_scala_project(Predicates, Options0, ProjectDir) :-
     % --- Render program template ---
     write_program_source(ProjectDir, Pkg, RPkg,
                          InstrBody, LabelBody, DispatchBody,
-                         WrapperCode, StringToIdStr, IdToStringStr,
+                         WrapperCode, IdToStringStr,
                          ForeignHandlersBody).
 
 write_build_sbt(ProjectDir, ModName) :-
@@ -828,7 +824,7 @@ write_runtime_source(ProjectDir, Package, _RuntimePkg) :-
 
 write_program_source(ProjectDir, Package, RuntimePkg,
                      InstrBody, LabelBody, DispatchBody,
-                     WrapperCode, StringToIdStr, IdToStringStr,
+                     WrapperCode, IdToStringStr,
                      ForeignHandlersBody) :-
     find_template('templates/targets/scala_wam/program.scala.mustache', Template),
     get_time(T), format_time(string(DateStr), "%Y-%m-%d", T),
@@ -840,7 +836,6 @@ write_program_source(ProjectDir, Package, RuntimePkg,
           'labels'=LabelBody,
           'dispatch'=DispatchBody,
           'wrappers'=WrapperCode,
-          'intern_string_to_id'=StringToIdStr,
           'intern_id_to_string'=IdToStringStr,
           'foreign_handlers'=ForeignHandlersBody
         ], Content),

--- a/templates/targets/scala_wam/program.scala.mustache
+++ b/templates/targets/scala_wam/program.scala.mustache
@@ -10,19 +10,16 @@ import {{runtime_package}}._
 object GeneratedProgram {
 
   // ----------------------------------------------------------
-  // Compile-time atom intern table
+  // Atom intern table
   // ----------------------------------------------------------
-  // Maps atom strings <-> integer IDs. Built at code-generation time.
-  // Well-known atoms: true=0, fail=1, []=2
+  // Seeded with the atoms the codegen discovered while compiling the
+  // program. The runtime appends new atoms on demand (CLI parser for
+  // unknown args, atom_codes reverse mode, atom_concat split mode,
+  // sub_atom multi-solution). Well-known atoms: true=0, fail=1, []=2.
 
-  val internTable: InternTable = InternTable(
-    stringToId = Map(
-{{intern_string_to_id}}
-    ),
-    idToString = Array(
+  val internTable: InternTable = InternTable(Array(
 {{intern_id_to_string}}
-    )
-  )
+  ))
 
   // ----------------------------------------------------------
   // Shared WAM instruction array (all predicates)
@@ -167,8 +164,9 @@ object GeneratedProgram {
 
   // Parse a CLI argument into a WamTerm.
   // Supports integers ("42", "-3"), floats ("3.14", "-1.5"), atoms ("a"),
-  // structures ("f(a,b)"), and lists ("[a,b]"). Unknown atom strings get
-  // id -1 so they fail unification with known atoms.
+  // structures ("f(a,b)"), and lists ("[a,b]"). Unknown atom strings are
+  // interned at runtime and get a real id, so they unify properly with
+  // atoms that are themselves discovered at runtime (e.g. via atom_codes).
   private def parseArg(s: String): WamTerm = {
     val t = s.trim
     // Integers first, then floats; both fall through to atom/list/struct
@@ -220,7 +218,7 @@ object GeneratedProgram {
   }
 
   private def internAtomId(s: String): Int =
-    internTable.stringToId.getOrElse(s, -1)
+    internTable.intern(s)
 
   /** Parse one CSV-cell string into a WamTerm. Used by file-backed
    *  fact-source handlers. Same numeric/atom split as parseArg but

--- a/templates/targets/scala_wam/runtime.scala.mustache
+++ b/templates/targets/scala_wam/runtime.scala.mustache
@@ -9,13 +9,74 @@ import scala.collection.mutable
 // ============================================================
 // Atom Intern Table
 // ============================================================
+// Mutable, append-only. The codegen seeds the table with the atoms
+// it discovered while compiling predicate bodies; the runtime adds
+// new atoms on demand (CLI parser for unknown args, atom_codes
+// reverse mode, atom_concat split mode, sub_atom multi-solution).
+// Once an atom is interned its id never changes — atoms are only
+// ever added at the end. Single-threaded execution assumed.
 
-final case class InternTable(
-  stringToId: Map[String, Int],
-  idToString: Array[String]
+final class InternTable private (
+  private val map: scala.collection.mutable.HashMap[String, Int],
+  private val arr: scala.collection.mutable.ArrayBuffer[String]
 ) {
-  def resolve(id: Int): String =
-    if (id >= 0 && id < idToString.length) idToString(id) else s"<atom:$id>"
+  /** Returns the existing id for s, or -1 if not present. */
+  def lookupId(s: String): Int = map.getOrElse(s, -1)
+
+  /** Returns Some(id) if interned, None otherwise. */
+  def lookupOpt(s: String): Option[Int] = map.get(s)
+
+  /** Returns the string for an id, or a placeholder for out-of-range ids. */
+  def stringOf(id: Int): String =
+    if (id >= 0 && id < arr.length) arr(id) else s"<atom:$id>"
+
+  /** Returns the string for an id, or "" for out-of-range. Used in
+   *  the runtime's hot paths where the empty fallback was the existing
+   *  semantics before this refactor. */
+  def stringAt(id: Int): String =
+    if (id >= 0 && id < arr.length) arr(id) else ""
+
+  /** Bounds check for the array-indexed form. */
+  def isInRange(id: Int): Boolean = id >= 0 && id < arr.length
+
+  /** Looks up s; if not present, appends it and returns the new id.
+   *  This is the runtime-mutable side of the table — used wherever
+   *  an atom value is created from data not seen at codegen time. */
+  def intern(s: String): Int = {
+    val existing = map.get(s)
+    if (existing.isDefined) existing.get
+    else {
+      val id = arr.length
+      arr += s
+      map.put(s, id)
+      id
+    }
+  }
+
+  /** Number of currently-interned atoms. */
+  def size: Int = arr.length
+}
+
+object InternTable {
+  /** Build an InternTable from an initial sequence of well-known
+   *  atoms. The order in `initial` defines the ids: index 0 → id 0
+   *  etc. Used by the codegen to seed the table at construction. */
+  def apply(initial: Array[String]): InternTable = {
+    val m = scala.collection.mutable.HashMap.empty[String, Int]
+    val b = scala.collection.mutable.ArrayBuffer.empty[String]
+    var i = 0
+    while (i < initial.length) {
+      val s = initial(i)
+      // If the seed has duplicates, keep the first id (no-op on later
+      // collision so the array index stays in sync).
+      if (!m.contains(s)) {
+        m.put(s, b.length)
+        b += s
+      }
+      i += 1
+    }
+    new InternTable(m, b)
+  }
 }
 
 // ============================================================
@@ -25,7 +86,7 @@ final case class InternTable(
 sealed trait WamTerm
 /** Unbound logic variable — id is a unique integer per query. */
 final case class Ref(id: Int)                               extends WamTerm
-/** Interned atom — id indexes into InternTable.idToString. */
+/** Interned atom — id indexes into InternTable. */
 final case class Atom(id: Int)                              extends WamTerm
 final case class IntTerm(value: Int)                        extends WamTerm
 final case class FloatTerm(value: Double)                   extends WamTerm
@@ -429,6 +490,12 @@ object WamRuntime {
           s.choicePoints(s.choicePoints.length - 1) =
             cp.copy(kind = ForeignCP(remaining))
           if (!applyBindings(s, sol)) backtrack(s)
+          else if (s.pc < 0) {
+            // Tail-call multi-solution dispatched with empty callStack:
+            // pc is a sentinel signalling "Succeeded after applyBindings"
+            // (see dispatchForeignMulti). step() must not fetch from -1.
+            s.status = Succeeded
+          }
         case WamCP =>
           popCP(s)
         case AggregateCP(resumePc, _, bagReg, results, consId, emptyId) =>
@@ -898,7 +965,7 @@ object WamRuntime {
               case _                                => s.pc += 1
             }
           case Struct(f, arity, _) =>
-            val consId = program.internTable.stringToId.getOrElse("[|]", -1)
+            val consId = program.internTable.lookupId("[|]")
             if (f == consId && arity == 2) {
               if (listPc >= 0) s.pc = listPc else s.pc += 1
             } else {
@@ -1121,8 +1188,8 @@ object WamRuntime {
             templateReg = templateReg,
             bagReg      = bagReg,
             results     = Nil,
-            consId      = program.internTable.stringToId.getOrElse("[|]", 5),
-            emptyId     = program.internTable.stringToId.getOrElse("[]", 2)
+            consId      = program.internTable.lookupId("[|]"),
+            emptyId     = program.internTable.lookupId("[]")
           )
         )
         s.choicePoints += cp
@@ -1227,20 +1294,14 @@ object WamRuntime {
       case Some(n) => Some(n)
       case None => v match {
         case Struct(f, 2, args) =>
-          val name =
-            if (f >= 0 && f < program.internTable.idToString.length)
-              program.internTable.idToString(f)
-            else ""
+          val name = program.internTable.stringAt(f)
           for {
             a <- evalArith(s, program, args(0))
             b <- evalArith(s, program, args(1))
             r <- numBinop(name, a, b)
           } yield r
         case Struct(f, 1, args) =>
-          val name =
-            if (f >= 0 && f < program.internTable.idToString.length)
-              program.internTable.idToString(f)
-            else ""
+          val name = program.internTable.stringAt(f)
           evalArith(s, program, args(0)).flatMap { x =>
             name match {
               case "-" => Some(x match { case NInt(n) => NInt(-n); case NDouble(d) => NDouble(-d) })
@@ -1275,8 +1336,7 @@ object WamRuntime {
     val v = deref(s.bindings, t)
     v match {
       case Struct(f, 2, args) =>
-        val name = if (f >= 0 && f < program.internTable.idToString.length)
-                     program.internTable.idToString(f) else ""
+        val name = program.internTable.stringAt(f)
         if (name == ":") unwrapModuleQualification(s, program, args(1))
         else v
       case _ => v
@@ -1288,12 +1348,10 @@ object WamRuntime {
   def goalToPredCall(s: WamState, program: WamProgram, goal: WamTerm): Option[(String, Array[WamTerm])] = {
     unwrapModuleQualification(s, program, goal) match {
       case Atom(f) =>
-        val n = if (f >= 0 && f < program.internTable.idToString.length)
-                  program.internTable.idToString(f) else ""
+        val n = program.internTable.stringAt(f)
         Some((s"$n/0", Array.empty[WamTerm]))
       case Struct(f, arity, args) =>
-        val n = if (f >= 0 && f < program.internTable.idToString.length)
-                  program.internTable.idToString(f) else ""
+        val n = program.internTable.stringAt(f)
         Some((s"$n/$arity", args))
       case _ => None
     }
@@ -1348,13 +1406,9 @@ object WamRuntime {
         // Re-extract the predicate name; arity is the new total.
         val unwrapped = unwrapModuleQualification(s, program, goal)
         val name = unwrapped match {
-          case Atom(f) =>
-            if (f >= 0 && f < program.internTable.idToString.length)
-              program.internTable.idToString(f) else ""
-          case Struct(f, _, _) =>
-            if (f >= 0 && f < program.internTable.idToString.length)
-              program.internTable.idToString(f) else ""
-          case _ => ""
+          case Atom(f)         => program.internTable.stringAt(f)
+          case Struct(f, _, _) => program.internTable.stringAt(f)
+          case _               => ""
         }
         val key = s"$name/${allArgs.length}"
         program.dispatch.get(key) match {
@@ -1382,16 +1436,17 @@ object WamRuntime {
 
   /** atom_codes(A, Cs). Mode (+, ?): A is a bound atom; build Cs as a list
    *  of integer codes. Mode (?, +): Cs is a bound list of codes; build A
-   *  as the atom whose string is those chars. Mixed mode unifies. Numeric
-   *  terms are also stringified for SWI-Prolog compatibility. */
+   *  as the atom whose string is those chars (interning at runtime if it
+   *  doesn't already exist). Numeric terms are also stringified for
+   *  SWI-Prolog compatibility. */
   def atomCodes2(s: WamState, program: WamProgram, withReturn: Boolean): Unit = {
     val a = deref(s.bindings, s.regs(1))
     val cs = deref(s.bindings, s.regs(2))
     def advance(ok: Boolean): Unit =
       if (ok) builtinAdvance(s, withReturn) else backtrack(s)
     a match {
-      case Atom(id) if id >= 0 && id < program.internTable.idToString.length =>
-        val str = program.internTable.idToString(id)
+      case Atom(id) if program.internTable.isInRange(id) =>
+        val str = program.internTable.stringOf(id)
         val codes = str.toCharArray.map(c => IntTerm(c.toInt): WamTerm).toSeq
         advance(unify(s, s.regs(2), seqToList(program, codes)))
       case IntTerm(n) =>
@@ -1407,7 +1462,9 @@ object WamRuntime {
               case IntTerm(c) => c.toChar
               case _          => '?'
             }.mkString
-            val id = program.internTable.stringToId.getOrElse(chars, -1)
+            // intern (mutable side of the table) so the atom always has
+            // a real id even if codegen never saw this string.
+            val id = program.internTable.intern(chars)
             advance(unify(s, s.regs(1), Atom(id)))
           case None => backtrack(s)
         }
@@ -1419,8 +1476,8 @@ object WamRuntime {
   def atomLength2(s: WamState, program: WamProgram, withReturn: Boolean): Unit = {
     val a = deref(s.bindings, s.regs(1))
     a match {
-      case Atom(id) if id >= 0 && id < program.internTable.idToString.length =>
-        val len = program.internTable.idToString(id).length
+      case Atom(id) if program.internTable.isInRange(id) =>
+        val len = program.internTable.stringOf(id).length
         if (unify(s, s.regs(2), IntTerm(len))) builtinAdvance(s, withReturn)
         else backtrack(s)
       case _ => backtrack(s)
@@ -1445,24 +1502,22 @@ object WamRuntime {
    *  `f(a, b)`, cons cells as `[a, b, ...]`, vars as `_<id>`. */
   def termToString(program: WamProgram, t: WamTerm): String = t match {
     case Ref(id)       => s"_$id"
-    case Atom(id)      =>
-      if (id >= 0 && id < program.internTable.idToString.length)
-        program.internTable.idToString(id) else s"<atom:$id>"
+    case Atom(id)      => program.internTable.stringOf(id)
     case IntTerm(n)    => n.toString
     case FloatTerm(d)  => d.toString
     case st @ Struct(_, _, _) =>
-      val consId = program.internTable.stringToId.getOrElse("[|]", -1)
+      val consId = program.internTable.lookupId("[|]")
       if (st.functor == consId && st.arity == 2) listToString(program, st)
       else {
-        val name = program.internTable.idToString.lift(st.functor).getOrElse(s"<atom:${st.functor}>")
+        val name = program.internTable.stringOf(st.functor)
         val args = st.args.map(termToString(program, _)).mkString(",")
         s"$name($args)"
       }
   }
 
   private def listToString(program: WamProgram, head: WamTerm): String = {
-    val emptyId = program.internTable.stringToId.getOrElse("[]", -1)
-    val consId  = program.internTable.stringToId.getOrElse("[|]", -1)
+    val emptyId = program.internTable.lookupId("[]")
+    val consId  = program.internTable.lookupId("[|]")
     val sb = new StringBuilder("[")
     var cur: WamTerm = head
     var first = true
@@ -1495,8 +1550,8 @@ object WamRuntime {
    */
   def format2(s: WamState, program: WamProgram, withReturn: Boolean): Unit = {
     val fmt = deref(s.bindings, s.regs(1)) match {
-      case Atom(id) if id >= 0 && id < program.internTable.idToString.length =>
-        program.internTable.idToString(id)
+      case Atom(id) if program.internTable.isInRange(id) =>
+        program.internTable.stringAt(id)
       case other => termToString(program, other)
     }
     val args = listToSeq(s, program, s.regs(2)).getOrElse(Seq.empty)
@@ -1520,8 +1575,8 @@ object WamRuntime {
           case 'a' =>
             if (argIdx < argArr.length) {
               argArr(argIdx) match {
-                case Atom(id) if id >= 0 && id < program.internTable.idToString.length =>
-                  sb.append(program.internTable.idToString(id))
+                case Atom(id) if program.internTable.isInRange(id) =>
+                  sb.append(program.internTable.stringAt(id))
                 case other => sb.append(termToString(program, other))
               }
             }
@@ -1562,60 +1617,131 @@ object WamRuntime {
     }
   }
 
-  /** atom_concat(+A, +B, ?C): C is the concatenation of A and B as
-   *  strings. Forward mode only (A and B both ground). The reverse
-   *  mode would need to enumerate all (A, B) splits of C and inject
-   *  each substring as an atom in the intern table — which is
-   *  immutable in this runtime — so it's not supported.
+  /** atom_concat(+A, +B, ?C): forward mode — C is the concatenation
+   *  of A and B as their interned strings.
    *
-   *  Numeric A or B are rendered via their toString form.
+   *  atom_concat(?A, ?B, +C): reverse mode — enumerate all
+   *  (prefix, suffix) splits of C as a multi-solution choice point.
+   *  Each split's prefix/suffix is interned at runtime if not already
+   *  present, so unification produces real atoms.
+   *
+   *  Numeric A or B in forward mode are rendered via their toString
+   *  form. Reverse mode requires C to be ground; an unbound C with
+   *  unbound A and B fails (no instantiation).
    */
   def atomConcat3(s: WamState, program: WamProgram, withReturn: Boolean): Unit = {
     def stringOf(t: WamTerm): Option[String] = t match {
-      case Atom(id) if id >= 0 && id < program.internTable.idToString.length =>
-        Some(program.internTable.idToString(id))
+      case Atom(id) if program.internTable.isInRange(id) =>
+        Some(program.internTable.stringAt(id))
       case IntTerm(n)   => Some(n.toString)
       case FloatTerm(d) => Some(d.toString)
       case _            => None
     }
     val a = deref(s.bindings, s.regs(1))
     val b = deref(s.bindings, s.regs(2))
-    (stringOf(a), stringOf(b)) match {
-      case (Some(sa), Some(sb)) =>
-        val concat = sa + sb
-        // Look up the concatenation in the intern table; if the user
-        // didn't pre-intern it (via intern_atoms), the resulting atom
-        // gets id -1 and unification will fail unless arg3 is unbound.
-        val id = program.internTable.stringToId.getOrElse(concat, -1)
+    val c = deref(s.bindings, s.regs(3))
+    (stringOf(a), stringOf(b), stringOf(c)) match {
+      case (Some(sa), Some(sb), _) =>
+        // Forward mode: A and B both ground; intern the concat.
+        val id = program.internTable.intern(sa + sb)
         if (unify(s, s.regs(3), Atom(id))) builtinAdvance(s, withReturn)
         else backtrack(s)
+      case (_, _, Some(sc)) =>
+        // Reverse mode: enumerate splits 0..sc.length of sc.
+        val sols: Seq[Map[Int, WamTerm]] =
+          (0 to sc.length).map { i =>
+            val prefix = sc.substring(0, i)
+            val suffix = sc.substring(i)
+            val pid = program.internTable.intern(prefix)
+            val sid = program.internTable.intern(suffix)
+            Map(1 -> (Atom(pid): WamTerm), 2 -> (Atom(sid): WamTerm))
+          }.toSeq
+        dispatchForeignMulti(s, sols, withReturn)
       case _ => backtrack(s)
     }
   }
 
-  /** sub_atom(+Atom, +Before, +Length, ?After, ?SubAtom): extracts a
-   *  substring. Atom, Before, Length must all be ground; After and
-   *  SubAtom are derived. Multi-solution modes (any of B/L/A unbound)
-   *  are not supported in this implementation. */
+  /** sub_atom(+Atom, ?Before, ?Length, ?After, ?SubAtom): extracts a
+   *  substring. Atom must be ground.
+   *
+   *  - Forward mode (Before, Length both ground): single deterministic
+   *    binding for After and SubAtom.
+   *  - Multi-solution mode (any of Before, Length, After unbound):
+   *    enumerates all (B, L, A) triples with B + L + A = |Atom| via
+   *    ForeignCP, interning each substring on demand.
+   *
+   *  SubAtom can be ground or unbound; ground SubAtom acts as a filter
+   *  on the enumeration.
+   */
   def subAtom5(s: WamState, program: WamProgram, withReturn: Boolean): Unit = {
     val atom   = deref(s.bindings, s.regs(1))
     val before = deref(s.bindings, s.regs(2))
     val length = deref(s.bindings, s.regs(3))
+    val after  = deref(s.bindings, s.regs(4))
+    val sub    = deref(s.bindings, s.regs(5))
     val str = atom match {
-      case Atom(id) if id >= 0 && id < program.internTable.idToString.length =>
-        program.internTable.idToString(id)
+      case Atom(id) if program.internTable.isInRange(id) =>
+        program.internTable.stringAt(id)
       case _ => return backtrack(s)
     }
-    (numOf(before), numOf(length)) match {
-      case (Some(NInt(b)), Some(NInt(l)))
-          if b >= 0 && l >= 0 && b + l <= str.length =>
+    val n = str.length
+    val subStrOpt: Option[String] = sub match {
+      case Atom(id) if program.internTable.isInRange(id) =>
+        Some(program.internTable.stringAt(id))
+      case _ => None
+    }
+    (numOf(before), numOf(length), numOf(after)) match {
+      case (Some(NInt(b)), Some(NInt(l)), _)
+          if b >= 0 && l >= 0 && b + l <= n =>
+        // Forward mode: B and L bound. Single deterministic solution.
         val subStr = str.substring(b, b + l)
-        val after  = str.length - b - l
-        val subId  = program.internTable.stringToId.getOrElse(subStr, -1)
-        val ok = unify(s, s.regs(5), Atom(subId)) &&
-                 unify(s, s.regs(4), IntTerm(after))
+        if (subStrOpt.isDefined && subStrOpt.get != subStr) return backtrack(s)
+        val a = n - b - l
+        val subId = program.internTable.intern(subStr)
+        val ok = unify(s, s.regs(4), IntTerm(a)) &&
+                 unify(s, s.regs(5), Atom(subId))
         if (ok) builtinAdvance(s, withReturn) else backtrack(s)
-      case _ => backtrack(s)
+      case _ =>
+        // Multi-solution: enumerate all (b, l, a) triples respecting
+        // any ground bindings, plus the SubAtom filter when present.
+        val bRange: Range = numOf(before) match {
+          case Some(NInt(bv)) if bv >= 0 && bv <= n => bv to bv
+          case Some(_) => return backtrack(s)
+          case None    => 0 to n
+        }
+        val lFixed: Option[Int] = numOf(length) match {
+          case Some(NInt(lv)) if lv >= 0 => Some(lv)
+          case Some(_) => return backtrack(s)
+          case None    => None
+        }
+        val aFixed: Option[Int] = numOf(after) match {
+          case Some(NInt(av)) if av >= 0 => Some(av)
+          case Some(_) => return backtrack(s)
+          case None    => None
+        }
+        val buf = scala.collection.mutable.ListBuffer.empty[Map[Int, WamTerm]]
+        for (b <- bRange) {
+          val lRange: Range = lFixed match {
+            case Some(lv) => lv to lv
+            case None     => 0 to (n - b)
+          }
+          for (l <- lRange if b + l <= n) {
+            val a = n - b - l
+            if (aFixed.forall(_ == a)) {
+              val subStr = str.substring(b, b + l)
+              if (subStrOpt.forall(_ == subStr)) {
+                val subId = program.internTable.intern(subStr)
+                buf.append(Map(
+                  2 -> (IntTerm(b): WamTerm),
+                  3 -> (IntTerm(l): WamTerm),
+                  4 -> (IntTerm(a): WamTerm),
+                  5 -> (Atom(subId): WamTerm)
+                ))
+              }
+            }
+          }
+        }
+        dispatchForeignMulti(s, buf.toSeq, withReturn)
     }
   }
 
@@ -1635,30 +1761,58 @@ object WamRuntime {
             // Enumerate. Reuse ForeignMulti machinery for backtracking.
             val sols: Seq[Map[Int, WamTerm]] =
               (lo to hi).map(n => Map(3 -> (IntTerm(n): WamTerm))).toSeq
-            val resumePc = s.pc + 1
-            sols match {
-              case Nil => backtrack(s)
-              case sol +: rest =>
-                if (rest.nonEmpty) {
-                  val cp = ChoicePoint(
-                    pc        = resumePc,
-                    regs      = snapshotRegs(s),
-                    envStack  = s.envStack,
-                    callStack = s.callStack,
-                    trailLen  = s.trail.length,
-                    cutBar    = s.cutBar,
-                    nextVarId = s.nextVarId,
-                    kind      = ForeignCP(rest)
-                  )
-                  s.choicePoints += cp
-                }
-                if (applyBindings(s, sol)) {
-                  if (withReturn) s.pc = resumePc else builtinAdvance(s, withReturn)
-                } else backtrack(s)
-            }
+            dispatchForeignMulti(s, sols, withReturn)
           case _ => backtrack(s)
         }
       case _ => backtrack(s)
+    }
+  }
+
+  /** Apply the first of `sols` to `s` and stash the rest as a ForeignCP
+   *  choice point. Used by between/3, atom_concat/3 reverse mode,
+   *  sub_atom/5 multi-solution modes.
+   *
+   *  withReturn=true (called from `Call`): the resume point is the
+   *  instruction after the Call. The CP saves that pc and the unchanged
+   *  callStack.
+   *
+   *  withReturn=false (called from `Execute`, i.e. tail call): there is
+   *  no instruction after the call to resume to. The resume point is
+   *  whatever Proceed would target — top of callStack, or Succeeded if
+   *  the stack is empty. We snapshot the post-Proceed state into the CP
+   *  so backtracking lands on the right pc/stack.
+   */
+  private def dispatchForeignMulti(s: WamState, sols: Seq[Map[Int, WamTerm]],
+                                   withReturn: Boolean): Unit = {
+    // Sentinel: any negative pc on a CP signals "Succeeded after the
+    // next applyBindings"; we check for it at the resume site rather
+    // than letting step() fetch program.instructions(-1).
+    val (resumePc, resumeCallStack) =
+      if (withReturn) (s.pc + 1, s.callStack)
+      else s.callStack match {
+        case Nil       => (-1, Nil)
+        case ret :: rs => (ret, rs)
+      }
+    sols match {
+      case Nil => backtrack(s)
+      case sol +: rest =>
+        if (rest.nonEmpty) {
+          val cp = ChoicePoint(
+            pc        = resumePc,
+            regs      = snapshotRegs(s),
+            envStack  = s.envStack,
+            callStack = resumeCallStack,
+            trailLen  = s.trail.length,
+            cutBar    = s.cutBar,
+            nextVarId = s.nextVarId,
+            kind      = ForeignCP(rest)
+          )
+          s.choicePoints += cp
+        }
+        if (applyBindings(s, sol)) {
+          if (withReturn) s.pc = resumePc
+          else builtinAdvance(s, withReturn)
+        } else backtrack(s)
     }
   }
 
@@ -1736,8 +1890,7 @@ object WamRuntime {
     }
   }
   private def atomString(program: WamProgram, id: Int): String =
-    if (id >= 0 && id < program.internTable.idToString.length)
-      program.internTable.idToString(id) else s"<atom:$id>"
+    program.internTable.stringOf(id)
   private def lexLess(program: WamProgram, xs: Array[WamTerm], ys: Array[WamTerm]): Boolean = {
     val n = math.min(xs.length, ys.length)
     var i = 0
@@ -1884,8 +2037,8 @@ object WamRuntime {
   // intern table; the empty list is the atom `[]`.
 
   def listToSeq(s: WamState, program: WamProgram, list: WamTerm): Option[Seq[WamTerm]] = {
-    val emptyId = program.internTable.stringToId.getOrElse("[]",  -1)
-    val consId  = program.internTable.stringToId.getOrElse("[|]", -1)
+    val emptyId = program.internTable.lookupId("[]")
+    val consId  = program.internTable.lookupId("[|]")
     val buf = scala.collection.mutable.ListBuffer.empty[WamTerm]
     var cur = deref(s.bindings, list)
     while (true) {
@@ -1904,8 +2057,8 @@ object WamRuntime {
 
   /** Build a Prolog list term from a Scala Seq. */
   def seqToList(program: WamProgram, items: Seq[WamTerm]): WamTerm = {
-    val emptyId = program.internTable.stringToId.getOrElse("[]",  -1)
-    val consId  = program.internTable.stringToId.getOrElse("[|]", -1)
+    val emptyId = program.internTable.lookupId("[]")
+    val consId  = program.internTable.lookupId("[|]")
     items.foldRight[WamTerm](Atom(emptyId)) { (h, t) =>
       Struct(consId, 2, Array(h, t))
     }
@@ -1924,12 +2077,10 @@ object WamRuntime {
   def metaCallSucceeds(s: WamState, program: WamProgram, goal: WamTerm): Option[Boolean] = {
     val (key, args) = goal match {
       case Atom(f) =>
-        val n = if (f >= 0 && f < program.internTable.idToString.length)
-                  program.internTable.idToString(f) else ""
+        val n = program.internTable.stringAt(f)
         (s"$n/0", Array.empty[WamTerm])
       case Struct(f, arity, sargs) =>
-        val n = if (f >= 0 && f < program.internTable.idToString.length)
-                  program.internTable.idToString(f) else ""
+        val n = program.internTable.stringAt(f)
         (s"$n/$arity", sargs)
       case _ => return None
     }

--- a/tests/test_wam_scala_generator.pl
+++ b/tests/test_wam_scala_generator.pl
@@ -196,12 +196,13 @@ test(atom_intern_table) :-
             ProgramPath),
         read_file_to_string(ProgramPath, Code, []),
         assertion(sub_string(Code, _, _, _, 'val internTable: InternTable')),
-        assertion(sub_string(Code, _, _, _, 'stringToId = Map(')),
-        assertion(sub_string(Code, _, _, _, 'idToString = Array(')),
-        % Well-known atoms should be present
-        assertion(sub_string(Code, _, _, _, '"true" -> 0')),
-        assertion(sub_string(Code, _, _, _, '"fail" -> 1')),
-        assertion(sub_string(Code, _, _, _, '"[]" -> 2')),
+        assertion(sub_string(Code, _, _, _, 'InternTable(Array(')),
+        % Well-known atoms must appear at fixed positions in the seed array.
+        % InternTable's apply de-duplicates, so order = id; codegen emits
+        % true=0, fail=1, []=2 first.
+        assertion(sub_string(Code, _, _, _, '"true"')),
+        assertion(sub_string(Code, _, _, _, '"fail"')),
+        assertion(sub_string(Code, _, _, _, '"[]"')),
         delete_directory_and_contents(TmpDir)
     )).
 

--- a/tests/test_wam_scala_runtime_smoke.pl
+++ b/tests/test_wam_scala_runtime_smoke.pl
@@ -112,6 +112,8 @@
 :- dynamic user:wam_succ_q/2.
 :- dynamic user:wam_atom_concat_q/3.
 :- dynamic user:wam_sub_atom_q/5.
+:- dynamic user:wam_atom_concat_split_q/2.
+:- dynamic user:wam_sub_atom_find_q/2.
 
 user:wam_fact(a).
 user:wam_execute_caller(X)    :- user:wam_fact(X).
@@ -288,6 +290,11 @@ user:wam_format_dn(X)           :- format("n=~d~n", [X]).
 user:wam_succ_q(X, Y)              :- succ(X, Y).
 user:wam_atom_concat_q(A, B, C)    :- atom_concat(A, B, C).
 user:wam_sub_atom_q(A, B, L, At, S):- sub_atom(A, B, L, At, S).
+% Reverse-mode harnesses: known prefix / known substring against a
+% bound whole atom. Drives atom_concat/3's split enumeration and
+% sub_atom/5's multi-solution path through the runtime intern table.
+user:wam_atom_concat_split_q(P, C) :- atom_concat(P, _, C).
+user:wam_sub_atom_find_q(A, S)     :- sub_atom(A, _, _, _, S).
 
 % ============================================================
 % Condition: only run if scalac is available
@@ -1012,10 +1019,10 @@ test(builtin_succ) :-
 test(builtin_atom_concat) :-
     with_scala_project(
         [user:wam_atom_concat_q/3],
-        % Pre-intern both operands and the expected concat results so
-        % the runtime intern table can match the synthesised "ab" / "hi"
-        % strings against arg3.
-        [ intern_atoms([a, b, ab, hello, world, helloworld]) ],
+        % No intern_atoms needed — atom_concat forward mode interns the
+        % concatenation at runtime, parseArg interns CLI args, and the
+        % shared intern table makes them collide on the same id.
+        _Opts,
         TmpDir,
         (
             verify_scala_args(TmpDir, 'wam_atom_concat_q/3',
@@ -1026,10 +1033,34 @@ test(builtin_atom_concat) :-
                               ['hello', 'world', 'helloworlds'], "false")
         )).
 
+% atom_concat/3 reverse mode: prefix unbound, suffix unbound, whole
+% atom ground. Driver predicate fixes the prefix to match a known
+% atom; the runtime enumerates every (prefix, suffix) split until
+% one matches.
+test(builtin_atom_concat_split) :-
+    with_scala_project(
+        [user:wam_atom_concat_split_q/2],
+        _Opts,
+        TmpDir,
+        (
+            % "he" is a valid prefix of "hello"
+            verify_scala_args(TmpDir, 'wam_atom_concat_split_q/2',
+                              ['he', 'hello'], "true"),
+            % "hello" itself is a valid prefix (suffix = "")
+            verify_scala_args(TmpDir, 'wam_atom_concat_split_q/2',
+                              ['hello', 'hello'], "true"),
+            % empty prefix is also valid
+            verify_scala_args(TmpDir, 'wam_atom_concat_split_q/2',
+                              ['', 'hello'], "true"),
+            % "xyz" is not a prefix
+            verify_scala_args(TmpDir, 'wam_atom_concat_split_q/2',
+                              ['xyz', 'hello'], "false")
+        )).
+
 test(builtin_sub_atom) :-
     with_scala_project(
         [user:wam_sub_atom_q/5],
-        [ intern_atoms([hello, hel, ell, llo, '']) ],
+        _Opts,
         TmpDir,
         (
             % sub_atom(hello, 0, 3, After, Sub) → After=2, Sub=hel
@@ -1043,6 +1074,25 @@ test(builtin_sub_atom) :-
                               ['hello', '0', '5', '0', 'hello'], "true"),
             verify_scala_args(TmpDir, 'wam_sub_atom_q/5',
                               ['hello', '0', '3', '2', 'wrong'], "false")
+        )).
+
+% sub_atom/5 multi-solution mode: Before, Length, After all unbound;
+% Atom and SubAtom ground. Runtime enumerates all (B, L, A) triples
+% until SubAtom matches the substring at (B, L).
+test(builtin_sub_atom_find) :-
+    with_scala_project(
+        [user:wam_sub_atom_find_q/2],
+        _Opts,
+        TmpDir,
+        (
+            verify_scala_args(TmpDir, 'wam_sub_atom_find_q/2',
+                              ['hello', 'ell'], "true"),
+            verify_scala_args(TmpDir, 'wam_sub_atom_find_q/2',
+                              ['hello', 'hello'], "true"),
+            verify_scala_args(TmpDir, 'wam_sub_atom_find_q/2',
+                              ['hello', ''], "true"),
+            verify_scala_args(TmpDir, 'wam_sub_atom_find_q/2',
+                              ['hello', 'xyz'], "false")
         )).
 
 % Multi-query stream mode: run a batch of queries in a single JVM
@@ -1213,10 +1263,10 @@ write_facts_csv(Path, Tuples) :-
 % reference `internTable` directly.
 
 foreign_yes_handler(Code) :-
-    Code = "new ForeignHandler {\n      def apply(args: Array[WamTerm]): ForeignResult = {\n        val aId = internTable.stringToId.getOrElse(\"a\", -1)\n        args(0) match {\n          case Atom(id) if id == aId => ForeignSucceed\n          case _                     => ForeignFail\n        }\n      }\n    }".
+    Code = "new ForeignHandler {\n      def apply(args: Array[WamTerm]): ForeignResult = {\n        val aId = internTable.lookupId(\"a\")\n        args(0) match {\n          case Atom(id) if id == aId => ForeignSucceed\n          case _                     => ForeignFail\n        }\n      }\n    }".
 
 foreign_pair_handler(Code) :-
-    Code = "new ForeignHandler {\n      def apply(args: Array[WamTerm]): ForeignResult = {\n        val aId = internTable.stringToId.getOrElse(\"a\", -1)\n        val bId = internTable.stringToId.getOrElse(\"b\", -1)\n        args(0) match {\n          case Atom(id) if id == aId => ForeignBindings(Map(2 -> Atom(bId)))\n          case _                     => ForeignFail\n        }\n      }\n    }".
+    Code = "new ForeignHandler {\n      def apply(args: Array[WamTerm]): ForeignResult = {\n        val aId = internTable.lookupId(\"a\")\n        val bId = internTable.lookupId(\"b\")\n        args(0) match {\n          case Atom(id) if id == aId => ForeignBindings(Map(2 -> Atom(bId)))\n          case _                     => ForeignFail\n        }\n      }\n    }".
 
 foreign_multi_handler(Code) :-
-    Code = "new ForeignHandler {\n      def apply(args: Array[WamTerm]): ForeignResult = {\n        val aId = internTable.stringToId.getOrElse(\"a\", -1)\n        val bId = internTable.stringToId.getOrElse(\"b\", -1)\n        args(0) match {\n          case Atom(id) if id == aId =>\n            ForeignMulti(Seq(\n              Map(2 -> Atom(aId)),\n              Map(2 -> Atom(bId))\n            ))\n          case _ => ForeignFail\n        }\n      }\n    }".
+    Code = "new ForeignHandler {\n      def apply(args: Array[WamTerm]): ForeignResult = {\n        val aId = internTable.lookupId(\"a\")\n        val bId = internTable.lookupId(\"b\")\n        args(0) match {\n          case Atom(id) if id == aId =>\n            ForeignMulti(Seq(\n              Map(2 -> Atom(aId)),\n              Map(2 -> Atom(bId))\n            ))\n          case _ => ForeignFail\n        }\n      }\n    }".


### PR DESCRIPTION
## Summary

`WamProgram.internTable` was an immutable case class wrapping a
`Map[String, Int]` and an `Array[String]`. The "no inverse mode" notes
on `atom_codes/2`, `atom_concat/3`, and `sub_atom/5` all traced back
to that immutability — synthesised substrings collapsed to `Atom(-1)`
because the runtime had no way to add a new atom id.

This PR makes the table append-only mutable and closes the three
inverse modes. It also drops the `intern_atoms([...])` boilerplate
that several tests had been carrying as a workaround, and fixes a
latent tail-call bug in the multi-solution-builtin dispatch path that
the new tests are the first to exercise.

| | Before | After |
|---|---|---|
| Generator tests | 10 | 10 |
| Smoke tests | 49 | **51** |
| Classic-programs tests | 6 | 6 |

## What's in the diff

### `InternTable` is now mutable, append-only

[runtime.scala.mustache](templates/targets/scala_wam/runtime.scala.mustache):

```scala
final class InternTable private (
  private val map: mutable.HashMap[String, Int],
  private val arr: mutable.ArrayBuffer[String]
) {
  def lookupId(s: String): Int = map.getOrElse(s, -1)
  def lookupOpt(s: String): Option[Int] = map.get(s)
  def stringOf(id: Int): String =
    if (id >= 0 && id < arr.length) arr(id) else s"<atom:$id>"
  def stringAt(id: Int): String =
    if (id >= 0 && id < arr.length) arr(id) else ""
  def isInRange(id: Int): Boolean = id >= 0 && id < arr.length
  def intern(s: String): Int = { /* append if missing */ }
}
```

Once an atom is interned its id never changes — atoms are only ever
added at the end of `arr`, and the parallel `map` is kept in sync.
Single-threaded execution is assumed (the only invariant the runtime
already relied on).

The codegen seeds the table from a single positional `Array[String]`:

```scala
val internTable: InternTable = InternTable(Array(
  "true",
  "fail",
  "[]",
  ...
))
```

Index → id (so `true=0`, `fail=1`, `[]=2`, then the codegen-discovered
atoms in collection order). The old separate `Map(... -> ...)` and
`Array(...)` emission is gone.

### Three reverse modes that previously fell through to `not supported`

**`atom_codes/2`** reverse mode (Cs ground, A unbound) interns the
character-string of `Cs` at runtime.

**`atom_concat/3`** reverse mode (C ground, A and/or B unbound)
enumerates every (prefix, suffix) split of C and interns each
substring on the fly. Driven through the existing `ForeignCP`
choice-point machinery via a small new helper `dispatchForeignMulti`.

**`sub_atom/5`** multi-solution modes (any of `Before`, `Length`,
`After` unbound) enumerate every (B, L, A) triple satisfying
`B + L + A = |Atom|` and respecting any ground filters on B/L/A and on
SubAtom.

### `parseArg` / `parseFactArg` auto-intern at runtime

[program.scala.mustache](templates/targets/scala_wam/program.scala.mustache):
the CLI parser used to do
`internTable.stringToId.getOrElse(s, -1)`, leaving unknown atoms with
id -1. They now go through `internTable.intern(s)`, which means a CSV
cell or a CLI arg that the codegen never saw can still match an atom
that the runtime built from `atom_codes/2` reverse mode (or any other
runtime-construction path) — they collide on the same id.

This is what lets the new tests drop their `intern_atoms([...])`
boilerplate. `intern_atoms` is still supported (and still useful for
foreign handlers that reference atoms not visible in any WAM body),
but it's no longer mandatory for the common cases.

### Tail-call multi-solution bug (latent — uncovered by the new tests)

`dispatchForeignMulti` (the helper extracted from `between/3`'s
enumeration path and now shared with `atom_concat/3` reverse and
`sub_atom/5` multi-solution) was setting the resume pc on its
ChoicePoint to `s.pc + 1` unconditionally. That works for `Call`
instructions (where +1 is the next instruction) but is out of bounds
for `Execute` instructions in tail position — there's nothing after
an `Execute`, so `program.instructions(pc+1)` faulted.

`between/3`'s existing test never tripped this because it was always
called with `X` already bound (no enumeration → no CP), and findall's
metaCollectAll path runs the inner goal under controlled stepping,
not as a top-level tail call.

Fixed by capturing the post-`Proceed` (pc, callStack) at CP push time
when `withReturn=false`:

```scala
val (resumePc, resumeCallStack) =
  if (withReturn) (s.pc + 1, s.callStack)
  else s.callStack match {
    case Nil       => (-1, Nil)        // sentinel for Succeeded
    case ret :: rs => (ret, rs)
  }
```

`backtrack` honors the `pc < 0` sentinel by setting `s.status =
Succeeded` after `applyBindings` instead of letting `step()` fetch
`program.instructions(-1)`.

### Smoke-test coverage

Two new smoke tests:

- `builtin_atom_concat_split` — `atom_concat(P, _, hello)` driven
  with a prefix CLI arg, exercising the split-enumeration path.
- `builtin_sub_atom_find` — `sub_atom(hello, _, _, _, S)` driven
  with a substring CLI arg, exercising the (B, L, A) enumeration.

Both run without `intern_atoms`, so they also act as regression
coverage that the runtime intern table works end-to-end with `parseArg`'s
auto-interning.

`builtin_atom_concat` and `builtin_sub_atom` (forward-mode) had their
`intern_atoms([...])` options dropped — auto-interning makes them
unnecessary.

### Test fixtures and examples updated to the new API

- [tests/test_wam_scala_runtime_smoke.pl](tests/test_wam_scala_runtime_smoke.pl):
  the three foreign-handler Scala fixtures now call
  `internTable.lookupId("a")` instead of the removed
  `internTable.stringToId.getOrElse(...)`.
- [tests/test_wam_scala_generator.pl](tests/test_wam_scala_generator.pl):
  the `atom_intern_table` assertion was checking the old `stringToId =
  Map(...)` / `idToString = Array(...)` shape; updated to assert the
  new `InternTable(Array(...))` form and that the well-known atoms
  appear in it.
- [examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl](examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl)
  and
  [examples/wam_scala_demo/genealogy.pl](examples/wam_scala_demo/genealogy.pl):
  switched to `intern(...)` / `lookupId(...)` / `stringAt(...)`.

## Test plan

- [ ] `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_generator.pl"),run_tests,halt' -t 'halt(1)'` → 10/10 pass.
- [ ] With `scalac` on PATH or `SCALA_SMOKE_TESTS=1`:
      `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_runtime_smoke.pl"),run_tests,halt' -t 'halt(1)'` → 51/51 pass.
- [ ] With same env: `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_classic_programs.pl"),run_tests,halt' -t 'halt(1)'` → 6/6 pass.

## Out of scope

- Cleaning up `intern_atoms` calls from existing tests that still pass
  it. The option is still useful for foreign handlers and remains
  supported; aggressively scrubbing it from every test would dilute
  this PR's diff with churn.
- Phase S8 LMDB seam, dynamic clauses (`assert/retract`). Both remain
  the headline open items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
