### PR TITLE
perf(wam-haskell): accumulator-passing kernel + use_lmdb(auto) harness wiring

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -2460,24 +2460,71 @@ The "auto + high fact_count + lmdb installed → true" path is
 environment-gated so we don't test it directly here; the resolver's
 guard logic is fully covered by the false-paths.
 
-### Open follow-ups
+### Phase L appendix #2: accumulator-passing kernel rewrite + bench harness wiring (2026-05-03)
 
-1. **Bench harness wiring for `use_lmdb(auto)`** — the resolver is
-   in place; the matrix bench harness still passes manual
-   `use_lmdb(true)` only. A future change should pass
-   `use_lmdb(auto), fact_count(N)` and let the resolver decide,
-   ideally with a separate matrix variant for "auto-pick LMDB"
-   alongside the current explicit pair.
-2. **Accumulator-passing rewrite** — replace `map (+1) $ go ...` with
-   an explicit depth offset passed down the recursion. Should reduce
-   intermediate list allocation. Filed for a follow-up branch since
-   it's a different optimization axis from IntSet visited.
-3. **ST-monad / IORef state** for the Haskell WAM hot loop — the bigger
+Two of the Phase L open follow-ups closed on this branch:
+
+**Accumulator-passing rewrite.** The kernel previously returned
+relative hop counts and post-incremented via `map (+1) $ go ...` in
+the recursion. GHC's list fusion can in principle eliminate that
+extra pass, but `(baseHits ++ recHits)` breaks the build/foldr
+pattern fusion needs — so without fusion, the post-traversal cost
+compounds to O(N²) at depth N. Rewrite passes `acc :: Int` down,
+returning absolute hop counts directly.
+
+Validated at synth_chain_300:
+
+| variant | Phase L only (ms) | + accumulator (ms) | improvement |
+|---|---:|---:|---:|
+| intset | 18.0 | 16.0 | ~12% |
+| lowered | 22.0 | 14.5 | 1.5× |
+| unlowered | 31.0 | 10.5 | ~3.0× |
+
+The intset variant's improvement is small because IntSet visited
+already eliminated most of the inner-loop cost; the accumulator
+mostly helps the lowered/unlowered paths whose visited check is
+unchanged. The 3× on unlowered is the load-bearing measurement —
+shows the post-traversal `map` was a real cost on this shape.
+tuple_count=200 across all variants — correctness preserved.
+
+**Bench harness wiring for `use_lmdb(auto)`.** The resolver from
+Phase L appendix #1 was dormant — no bench fed it `fact_count(N)`
+or set `use_lmdb(auto)`. Wiring now in place:
+
+- `generate_wam_haskell_matrix_benchmark.pl` counts
+  `category_parent/2` clauses in the facts.pl and passes
+  `fact_count(N)` in Options. New optional 6th CLI arg
+  `<lmdb_mode>` ∈ {none, auto, true, false} translates to
+  `use_lmdb(...)` in Options.
+- `benchmark_effective_distance_matrix.py` threads `lmdb_mode`
+  through `build_haskell_effective_distance` and adds a dispatch
+  arm for the new `haskell-interp-ffi-auto` target.
+- `benchmark_target_matrix.py` registers the new target in the
+  `hybrid-wam` category.
+
+Verified at scale-300: `haskell-interp-ffi-auto` produces the same
+output sha (`70bbc9ffa4cf`, 271 rows) as the explicit
+`haskell-interp-ffi` target. In a dev environment without the
+Haskell `lmdb` package installed the resolver falls back to
+`use_lmdb(false)` per the documented contract; the `[WAM-Haskell]
+use_lmdb(auto): ghc-pkg does not list lmdb; falling back to IntMap`
+stderr line confirms the resolver fired.
+
+### Open follow-ups (post-Phase-L appendix #2)
+
+1. **ST-monad / IORef state** for the Haskell WAM hot loop — the bigger
    structural change that would close more of the residual Rust gap.
    Multi-PR architectural arc; see `project_wam_haskell_st_monad_plan.md`
    notes.
-4. **Optional firewall hook** in the auto-mode resolver — consult
+2. **Optional firewall hook** in the auto-mode resolver — consult
    `firewall_check(use_lmdb, R)` before the ghc-pkg check, so a
    strict-mode deployment can refuse LMDB even when it's installable.
    Requires extending the firewall's tool registry to know about
    Haskell library packages, not just executables.
+3. **Run the auto target with the lmdb cabal package installed** to
+   verify the "auto + high fact_count + lmdb available → true" path
+   works end-to-end. Requires environmental setup (cabal install lmdb +
+   LMDB-ingested data); the wiring itself is in place.
+4. **Scale 5k/10k matrix runs** with the kernel changes, to see how
+   the Haskell-vs-Rust gap evolves at larger wiki scales. Each run
+   is ~5-15 min wall time so deferred for budget.

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -593,8 +593,9 @@ func main() {{
     (project_dir / "main.go").write_text(main_code, encoding="utf-8")
 
 
-def build_haskell_effective_distance(root: Path, mode: str, kernel_mode: str) -> list[str]:
-    project_dir = root / f"haskell_{mode}_{kernel_mode}"
+def build_haskell_effective_distance(root: Path, mode: str, kernel_mode: str,
+                                     lmdb_mode: str = "none") -> list[str]:
+    project_dir = root / f"haskell_{mode}_{kernel_mode}_{lmdb_mode}"
     project_dir.mkdir(parents=True, exist_ok=True)
     run_command(
         [
@@ -608,6 +609,7 @@ def build_haskell_effective_distance(root: Path, mode: str, kernel_mode: str) ->
             "accumulated",
             mode,
             kernel_mode,
+            lmdb_mode,
         ],
         cwd=ROOT,
     )
@@ -651,6 +653,8 @@ def build_scale_independent_commands(root: Path, targets: list[str]) -> dict[str
             commands[target] = build_haskell_effective_distance(root, "interpreter", "kernels_off")
         elif target == "haskell-interp-ffi":
             commands[target] = build_haskell_effective_distance(root, "interpreter", "kernels_on")
+        elif target == "haskell-interp-ffi-auto":
+            commands[target] = build_haskell_effective_distance(root, "interpreter", "kernels_on", "auto")
         elif target == "haskell-lowered-only":
             commands[target] = build_haskell_effective_distance(root, "functions", "kernels_off")
         elif target == "haskell-lowered-ffi":

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -162,6 +162,13 @@ TARGETS: dict[str, TargetInfo] = {
         "hybrid-wam",
         "Optimized Prolog -> WAM Haskell interpreter with kernels enabled",
     ),
+    "haskell-interp-ffi-auto": TargetInfo(
+        "haskell-interp-ffi-auto",
+        "hybrid-wam",
+        "Optimized Prolog -> WAM Haskell interpreter, kernels enabled, "
+        "use_lmdb(auto) — resolver picks IntMap or LMDB based on fact_count "
+        "and ghc-pkg availability of the lmdb package",
+    ),
     "haskell-lowered-only": TargetInfo(
         "haskell-lowered-only",
         "optimized-prolog",

--- a/examples/benchmark/generate_wam_haskell_matrix_benchmark.pl
+++ b/examples/benchmark/generate_wam_haskell_matrix_benchmark.pl
@@ -31,21 +31,23 @@ benchmark_workload_path(Path) :-
 
 main :-
     current_prolog_flag(argv, Argv),
-    (   Argv = [_FactsPath, OutputDir, VariantAtom, EmitModeAtom, KernelModeAtom]
+    (   Argv = [FactsPath, OutputDir, VariantAtom, EmitModeAtom, KernelModeAtom, LmdbModeAtom]
     ->  true
+    ;   Argv = [FactsPath, OutputDir, VariantAtom, EmitModeAtom, KernelModeAtom]
+    ->  LmdbModeAtom = none
     ;   format(user_error,
-            'Usage: ... -- <facts.pl> <output-dir> <seeded|accumulated> <interpreter|functions> <kernels_on|kernels_off>~n',
+            'Usage: ... -- <facts.pl> <output-dir> <seeded|accumulated> <interpreter|functions> <kernels_on|kernels_off> [<none|auto|true|false>]~n',
             []),
         halt(1)
     ),
-    generate(VariantAtom, EmitModeAtom, KernelModeAtom, OutputDir),
+    generate(FactsPath, VariantAtom, EmitModeAtom, KernelModeAtom, LmdbModeAtom, OutputDir),
     halt(0).
 
 main :-
     format(user_error, 'Error: generation failed~n', []),
     halt(1).
 
-generate(VariantAtom, EmitModeAtom, KernelModeAtom, OutputDir) :-
+generate(FactsPath, VariantAtom, EmitModeAtom, KernelModeAtom, LmdbModeAtom, OutputDir) :-
     benchmark_workload_path(WorkloadPath),
     load_files(WorkloadPath, [silent(true)]),
     retractall(user:mode(category_ancestor(_, _, _, _))),
@@ -53,6 +55,8 @@ generate(VariantAtom, EmitModeAtom, KernelModeAtom, OutputDir) :-
     parse_variant(VariantAtom, OptimizationOptions),
     parse_emit_mode(EmitModeAtom, EmitMode),
     parse_kernel_mode(KernelModeAtom, KernelOptions),
+    parse_lmdb_mode(LmdbModeAtom, LmdbOptions),
+    count_facts_in_file(FactsPath, FactCount),
     BasePreds = [dimension_n/1, max_depth/1, category_ancestor/4],
     prolog_target:generate_prolog_script(BasePreds, OptimizationOptions, ScriptCode),
     tmp_file_stream(text, TmpPath, TmpStream),
@@ -62,11 +66,49 @@ generate(VariantAtom, EmitModeAtom, KernelModeAtom, OutputDir) :-
     delete_file(TmpPath),
     collect_wam_predicates(VariantAtom, Predicates),
     query_pred_for_variant(VariantAtom, QueryPredOpts),
-    append([[module_name('wam-haskell-matrix-bench'), emit_mode(EmitMode)], KernelOptions, QueryPredOpts], Options),
+    append([[module_name('wam-haskell-matrix-bench'),
+             emit_mode(EmitMode),
+             fact_count(FactCount)],
+            KernelOptions, LmdbOptions, QueryPredOpts], Options),
     write_wam_haskell_project(Predicates, Options, OutputDir),
     format(user_error,
-           '[WAM-Haskell-Matrix] variant=~w emit_mode=~w kernels=~w output=~w~n',
-           [VariantAtom, EmitMode, KernelModeAtom, OutputDir]).
+           '[WAM-Haskell-Matrix] variant=~w emit_mode=~w kernels=~w lmdb=~w fact_count=~w output=~w~n',
+           [VariantAtom, EmitMode, KernelModeAtom, LmdbModeAtom, FactCount, OutputDir]).
+
+%% count_facts_in_file(+FactsPath, -N)
+%
+%  Count `category_parent/2` clauses in the given facts.pl. Used to
+%  populate `fact_count(N)` in Options so resolve_auto_use_lmdb/2 can
+%  decide based on scale. Falls back to 0 if the file isn't readable
+%  or has no category_parent/2 clauses — the auto resolver then
+%  conservatively picks IntMap.
+count_facts_in_file(FactsPath, N) :-
+    (   exists_file(FactsPath)
+    ->  setup_call_cleanup(
+            open(FactsPath, read, Stream, [encoding(utf8)]),
+            count_category_parent_clauses(Stream, 0, N),
+            close(Stream))
+    ;   N = 0
+    ).
+
+count_category_parent_clauses(Stream, Acc, N) :-
+    catch(read_term(Stream, Term, []), _, (Term = end_of_file)),
+    (   Term == end_of_file
+    ->  N = Acc
+    ;   (   nonvar(Term),
+            (   Term = category_parent(_, _)
+            ;   Term = (category_parent(_, _) :- _)
+            )
+        ->  Acc1 is Acc + 1,
+            count_category_parent_clauses(Stream, Acc1, N)
+        ;   count_category_parent_clauses(Stream, Acc, N)
+        )
+    ).
+
+parse_lmdb_mode(none, []).
+parse_lmdb_mode(auto, [use_lmdb(auto)]).
+parse_lmdb_mode(true, [use_lmdb(true)]).
+parse_lmdb_mode(false, [use_lmdb(false)]).
 
 parse_variant(seeded, [
     dialect(swi),

--- a/templates/targets/haskell_wam/kernel_category_ancestor.hs.mustache
+++ b/templates/targets/haskell_wam/kernel_category_ancestor.hs.mustache
@@ -8,18 +8,28 @@
 -- O(log N) membership checks during the recursive descent — replaces
 -- the prior O(N) list `elem`. Bang patterns on the loop variables force
 -- strict evaluation so each recursive call commits to a concrete
--- (cat, depth, visited-set) tuple instead of building thunks.
+-- (acc, cat, depth, visited-set) tuple instead of building thunks.
+--
+-- Hop counts are accumulated by passing an `acc` argument down the
+-- recursion — each call returns absolute hop counts directly instead of
+-- relying on `map (+1)` over the result list. This eliminates one list
+-- traversal per recursion level: at deep paths the cumulative
+-- traversal cost was O(N²) without fusion, and Haskell list fusion
+-- doesn't fire reliably across `(++)` boundaries (baseHits ++ recHits
+-- breaks the build/foldr pattern). Accumulator-passing avoids that
+-- dependency on optimisation luck.
 {-# INLINE nativeKernel_category_ancestor #-}
 nativeKernel_category_ancestor :: EdgeLookup -> Int -> Int -> Int -> Int -> [Int] -> [Int]
 nativeKernel_category_ancestor parents cat root maxDepth depth visited =
-  go cat depth (IS.fromList visited)
+  go 0 cat depth (IS.fromList visited)
   where
-    go !c !d !v =
+    go !acc !c !d !v =
       let directParents = parents c
-          baseHits = [1 | p <- directParents, p == root]
+          hop = acc + 1
+          baseHits = [hop | p <- directParents, p == root]
           recHits = if d >= maxDepth then [] else
             concatMap (\mid ->
               if mid `IS.member` v then []
-              else map (+1) $ go mid (d+1) (IS.insert mid v)
+              else go hop mid (d+1) (IS.insert mid v)
             ) directParents
       in baseHits ++ recHits


### PR DESCRIPTION
## Summary

Closes two of the Phase L open follow-ups from #1787:

1. **Accumulator-passing rewrite** in the category_ancestor kernel — replaces `map (+1) $ go ...` with an explicit `acc :: Int` passed down. **1.5-3× further improvement** on lowered/unlowered variants at synth_chain_300; intset is roughly in noise because Phase L's IntSet visited already eliminated most of the inner-loop cost.

2. **Bench harness wiring for `use_lmdb(auto)`** — the resolver from #1787 was dormant because no bench fed it `fact_count(N)` or set `use_lmdb(auto)`. Now wired through `generate_wam_haskell_matrix_benchmark.pl` (counts `category_parent/2` clauses, accepts new `<lmdb_mode>` CLI arg) and exposed via a new `haskell-interp-ffi-auto` matrix target.

## 1. Accumulator-passing rewrite

The previous kernel:

```haskell
go !c !d !v =
  ...
  recHits = ... map (+1) $ go mid (d+1) (IS.insert mid v)
```

Rewrites to:

```haskell
go !acc !c !d !v =
  let hop = acc + 1
      baseHits = [hop | p == root]
      recHits = ... go hop mid (d+1) (IS.insert mid v)
```

Each call now returns absolute hop counts directly. GHC's list fusion can in principle eliminate the post-traversal `map (+1)` automatically, but `(baseHits ++ recHits)` breaks the build/foldr pattern fusion needs — so without fusion, the post-traversal cost compounds across recursion levels. Accumulator-passing eliminates the dependency on optimisation luck.

### Measured at synth_chain_300

Chain depth 300, 200 articles, max_depth=300:

| variant | Phase L only (ms) | + accumulator (ms) | improvement |
| --- | ---: | ---: | ---: |
| intset | 18.0 | 16.0 | ~12% |
| lowered | 22.0 | 14.5 | **1.5×** |
| unlowered | 31.0 | 10.5 | **~3.0×** |

`tuple_count=200` matches across all three. The intset variant's improvement is small because IntSet visited already eliminated most of the inner-loop cost; the accumulator mostly helps the lowered/unlowered paths whose visited check is unchanged. The 3× on unlowered is the load-bearing measurement — confirms the post-traversal `map` was a real cost on this shape.

## 2. Bench harness wiring

The Phase L resolver landed but no bench actually exercised it. This wiring closes the loop.

### `generate_wam_haskell_matrix_benchmark.pl`

- Take `FactsPath` as a meaningful arg (was previously ignored as `_FactsPath`); count `category_parent/2` clauses via streaming `read_term/2`.
- New optional 6th CLI arg `<lmdb_mode>` ∈ {`none`, `auto`, `true`, `false`}. Defaults to `none` so existing 5-arg callers (the Python harness's pre-existing variants) keep their behavior.
- Pass `fact_count(N)` and the `use_lmdb(...)` from `lmdb_mode` into Options. The resolver in `wam_haskell_target.pl` picks up both.
- Stderr line now includes `lmdb=` and `fact_count=` for debugging.

### `benchmark_effective_distance_matrix.py`

- `build_haskell_effective_distance` gains `lmdb_mode="none"` arg threaded through to the swipl invocation. Project dir name now includes `lmdb_mode` so auto and explicit modes don't collide.
- New dispatch arm for `haskell-interp-ffi-auto`.

### `benchmark_target_matrix.py`

- New `TargetInfo` entry `haskell-interp-ffi-auto` in the `hybrid-wam` category. Description spells out it's the resolver-driven variant.

### Verified at scale-300

| target | median (s) | rows | sha |
| --- | ---: | ---: | --- |
| haskell-interp-ffi | 0.538 | 271 | 70bbc9ffa4cf |
| haskell-interp-ffi-auto | 0.424 | 271 | 70bbc9ffa4cf |
| rust-interp-ffi | 0.062 | 271 | 70bbc9ffa4cf |

Output hashes match across all three targets — auto produces identical output. In this env (lmdb cabal package not installed) the resolver falls back to `use_lmdb(false)` per its documented contract; the `[WAM-Haskell] use_lmdb(auto): ghc-pkg does not list lmdb; falling back to IntMap` stderr confirms it fired.

The `auto + lmdb installed + high fact_count → true` path is still environment-gated. The wiring is correct; verifying end-to-end with LMDB would need `cabal install lmdb` + LMDB-ingested data, deferred as the Phase L appendix #2 follow-up.

## Verification

- `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl` — all tests pass (the 5 deterministic resolver tests still cover the false-paths)
- synth_chain_300 macro bench — 1.5-3× wins on lowered/unlowered, tuple_count=200 matches across variants
- scale-300 matrix — 271 rows, sha `70bbc9ffa4cf` matches across haskell-interp-ffi, haskell-interp-ffi-auto, rust-interp-ffi

## Refs

- PR #1787 — Phase L (IntSet visited + INLINE + bang patterns + use_lmdb(auto) resolver). This PR closes two of its open follow-ups.
- `WAM_PERF_OPTIMIZATION_LOG.md` — Phase L appendix #2 documents both pieces with measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)