### PR TITLE
feat(wam-elixir): LMDB FactSource adaptor (memory-mapped fact storage)

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -2093,6 +2093,137 @@ defmodule WamRuntime.FactSource.Sqlite do
   end
 end
 
+defmodule WamRuntime.FactSource.Lmdb do
+  @moduledoc """
+  LMDB fact source. Memory-mapped key/value store — the response to
+  the materialisation-cost bottleneck above 100k+ facts documented
+  in docs/WAM_TARGET_ROADMAP.md. Mirrors what Haskell uses, with
+  one important caveat: targets the **safe key/value API**, not the
+  raw-pointer interface that caused crashes in the Haskell pipeline.
+  Lookups go through txn_get and cursor get/get-next, never through
+  raw-pointer dereferences.
+
+  Driver responsibility:
+    1. Add an LMDB binding to its mix deps (`:elmdb` is the
+       reference shape; other bindings work if they expose the same
+       function names). To keep this runtime dep-free for drivers
+       that dont use LMDB, the module is referenced indirectly via
+       Module.concat — same trick as the SQLite adaptor uses for
+       :exqlite.
+    2. Open the LMDB env + database handle (dbi). Populate facts.
+    3. Pass env/dbi to this adaptors open/3 via the spec.
+
+  Spec fields:
+    env     — LMDB env handle (required; pre-opened by driver)
+    dbi     — LMDB database handle within env (required)
+    arity   — number of columns per tuple (required; only 2 supported)
+    dupsort — true if a single arg1 maps to multiple arg2s (default
+              false; matches the LMDB MDB_DUPSORT flag the driver
+              should have set when opening the dbi)
+
+  Keying convention: the LMDB key is arg1; the value is arg2 (or
+  one of several arg2s under MDB_DUPSORT). lookup_by_arg1 uses
+  txn_get for unique keys and cursor MDB_SET / MDB_NEXT_DUP for
+  dupsort.
+  """
+  @behaviour WamRuntime.FactSource
+  defstruct [:env, :dbi, :arity, :dupsort]
+
+  defp lmdb_module, do: Module.concat([Elmdb])
+
+  @impl true
+  def open(%{env: env, dbi: dbi, arity: arity} = spec, _pred_arity, _state)
+      when arity == 2 do
+    %__MODULE__{
+      env: env,
+      dbi: dbi,
+      arity: arity,
+      dupsort: Map.get(spec, :dupsort, false)
+    }
+  end
+
+  @impl true
+  def stream_all(%__MODULE__{env: env, dbi: dbi}, _state) do
+    mod = lmdb_module()
+    {:ok, txn} = apply(mod, :ro_txn_begin, [env])
+    try do
+      {:ok, cur} = apply(mod, :ro_txn_cursor_open, [txn, dbi])
+      try do
+        scan_cursor_all(mod, cur, [])
+      after
+        apply(mod, :ro_txn_cursor_close, [cur])
+      end
+    after
+      apply(mod, :ro_txn_commit, [txn])
+    end
+  end
+
+  @impl true
+  def lookup_by_arg1(%__MODULE__{env: env, dbi: dbi, dupsort: dupsort}, key, _state) do
+    mod = lmdb_module()
+    {:ok, txn} = apply(mod, :ro_txn_begin, [env])
+    try do
+      if dupsort do
+        {:ok, cur} = apply(mod, :ro_txn_cursor_open, [txn, dbi])
+        try do
+          collect_dupsort(mod, cur, key)
+        after
+          apply(mod, :ro_txn_cursor_close, [cur])
+        end
+      else
+        case apply(mod, :txn_get, [txn, dbi, key]) do
+          {:ok, val} -> [{key, val}]
+          :not_found -> []
+          _ -> []
+        end
+      end
+    after
+      apply(mod, :ro_txn_commit, [txn])
+    end
+  end
+
+  @impl true
+  def close(%__MODULE__{env: _env}, _state) do
+    # Env lifecycle belongs to the driver — multiple FactSources may
+    # share one env. The driver calls env_close when its done.
+    :ok
+  end
+
+  # Scan the entire database via cursor MDB_FIRST + MDB_NEXT.
+  defp scan_cursor_all(mod, cur, acc) do
+    case apply(mod, :ro_txn_cursor_get, [cur, :first, nil]) do
+      {:ok, k, v} -> scan_cursor_next(mod, cur, [{k, v} | acc])
+      :not_found -> Enum.reverse(acc)
+      _ -> Enum.reverse(acc)
+    end
+  end
+
+  defp scan_cursor_next(mod, cur, acc) do
+    case apply(mod, :ro_txn_cursor_get, [cur, :next, nil]) do
+      {:ok, k, v} -> scan_cursor_next(mod, cur, [{k, v} | acc])
+      :not_found -> Enum.reverse(acc)
+      _ -> Enum.reverse(acc)
+    end
+  end
+
+  # Dupsort scan: position cursor at MDB_SET key, then walk
+  # MDB_NEXT_DUP until exhausted.
+  defp collect_dupsort(mod, cur, key) do
+    case apply(mod, :ro_txn_cursor_get, [cur, :set, key]) do
+      {:ok, ^key, v} -> collect_dupsort_next(mod, cur, key, [{key, v}])
+      :not_found -> []
+      _ -> []
+    end
+  end
+
+  defp collect_dupsort_next(mod, cur, key, acc) do
+    case apply(mod, :ro_txn_cursor_get, [cur, :next_dup, nil]) do
+      {:ok, ^key, v} -> collect_dupsort_next(mod, cur, key, [{key, v} | acc])
+      _ -> Enum.reverse(acc)
+    end
+  end
+end
+
 defmodule WamRuntime.FactSourceRegistry do
   @moduledoc """
   Predicate-indicator → source-handle map. Uses :persistent_term so

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -720,6 +720,55 @@ test_sqlite_adaptor_uses_indirect_module_resolution :-
     ;   fail_test(Test, 'SQLite adaptor has literal Exqlite references — will warn without dep')
     ).
 
+%% LMDB adaptor (memory-mapped fact source — addresses the
+%  materialisation-cost bottleneck documented in
+%  docs/WAM_TARGET_ROADMAP.md). Mirrors the SQLite tests pattern
+%  emit-and-grep + indirect-module-resolution check.
+test_lmdb_adaptor_emitted_in_runtime :-
+    Test = 'LMDB adaptor: runtime assembly emits FactSource.Lmdb',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    (   sub_string(RuntimeCode, _, _, _, 'defmodule WamRuntime.FactSource.Lmdb do'),
+        sub_string(RuntimeCode, _, _, _, '@behaviour WamRuntime.FactSource'),
+        sub_string(RuntimeCode, _, _, _, 'defstruct [:env, :dbi, :arity, :dupsort]'),
+        % Three FactSource callbacks present.
+        sub_string(RuntimeCode, _, _, _, 'def stream_all('),
+        sub_string(RuntimeCode, _, _, _, 'def lookup_by_arg1('),
+        sub_string(RuntimeCode, _, _, _, 'def close(')
+    ->  pass(Test)
+    ;   fail_test(Test, 'LMDB adaptor missing expected structure')
+    ).
+
+test_lmdb_adaptor_uses_indirect_module_resolution :-
+    Test = 'LMDB adaptor: uses Module.concat so runtime compiles without an LMDB binding dep',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    % Same constraint as SQLite: the adaptor must NOT call Elmdb.X
+    % as a literal — that warns in drivers without the LMDB binding.
+    (   sub_string(RuntimeCode, _, _, _, 'Module.concat([Elmdb])'),
+        sub_string(RuntimeCode, _, _, _, 'apply(mod,'),
+        \+ sub_string(RuntimeCode, _, _, _, 'Elmdb.ro_txn_begin'),
+        \+ sub_string(RuntimeCode, _, _, _, 'Elmdb.txn_get(')
+    ->  pass(Test)
+    ;   fail_test(Test, 'LMDB adaptor has literal Elmdb references — will warn without dep')
+    ).
+
+test_lmdb_adaptor_targets_safe_keyvalue_api :-
+    Test = 'LMDB adaptor: uses safe key/value + cursor API (no raw-pointer ops)',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    % Contract per WAM_TARGET_ROADMAP.md: avoid the raw-pointer
+    % interface that crashed Haskell. txn_get + cursor get/next are
+    % the safe layer; reject any pointer-deref shape.
+    (   sub_string(RuntimeCode, _, _, _, 'txn_get'),
+        sub_string(RuntimeCode, _, _, _, 'ro_txn_cursor_get'),
+        % Dupsort path uses MDB_SET / MDB_NEXT_DUP cursor ops.
+        sub_string(RuntimeCode, _, _, _, ':next_dup'),
+        sub_string(RuntimeCode, _, _, _, ':set'),
+        % No raw pointer / mdb_val references (those are the unsafe layer).
+        \+ sub_string(RuntimeCode, _, _, _, 'mdb_val'),
+        \+ sub_string(RuntimeCode, _, _, _, 'raw_pointer')
+    ->  pass(Test)
+    ;   fail_test(Test, 'LMDB adaptor missing safe-API surface or includes raw-pointer ops')
+    ).
+
 %% Tier-2 infrastructure tests (see docs/design/WAM_TIERED_LOWERING.md)
 %% These exercise precondition scaffolding only — PR2 wires
 %% par_wrap_segment/3 on top of them.
@@ -1762,6 +1811,9 @@ run_tests :-
     test_ets_adaptor_emitted_in_runtime,
     test_sqlite_adaptor_emitted_in_runtime,
     test_sqlite_adaptor_uses_indirect_module_resolution,
+    test_lmdb_adaptor_emitted_in_runtime,
+    test_lmdb_adaptor_uses_indirect_module_resolution,
+    test_lmdb_adaptor_targets_safe_keyvalue_api,
     test_tier2_wamstate_has_parallel_depth,
     test_tier2_aggregate_helpers_emitted,
     test_tier2_aggregate_forkable_types,


### PR DESCRIPTION
## Summary

Highest-priority follow-up identified in `docs/WAM_TARGET_ROADMAP.md` (PR #1791): materialisation cost dominates above 100k+ facts; memory-mapped backing is the established response (Haskell uses LMDB; C# uses a memory-mapped file). This adds the LMDB option to Elixir's `FactSource` facade.

## Architecture

`defmodule WamRuntime.FactSource.Lmdb` mirrors the SQLite adaptor:

- Implements the `FactSource` behaviour (`open/3`, `stream_all/2`, `lookup_by_arg1/3`, `close/2`).
- **`Module.concat([Elmdb])` indirection** so the generated runtime compiles cleanly in driver projects that don't add an LMDB binding to their `mix deps`. Lookups go through `apply/3` — same trick the SQLite adaptor uses for `:exqlite`.

## Targets the safe key/value API

Per the roadmap doc, **avoids the raw-pointer interface that crashed in the Haskell pipeline**. All reads go through `txn_get` and cursor `get` / `get-next`; no `mdb_val` pointer dereferences.

API surface assumed (matches `:elmdb`):

```
ro_txn_begin(env)              -> {:ok, txn}
txn_get(txn, dbi, key)         -> {:ok, value} | :not_found
ro_txn_cursor_open(txn, dbi)   -> {:ok, cur}
ro_txn_cursor_get(cur, op, k)  -> {:ok, k, v} | :not_found
                                  where op in [:first, :next, :set, :next_dup]
ro_txn_cursor_close(cur)       -> :ok
ro_txn_commit(txn)             -> :ok
```

Drivers using a different binding can wrap their library to expose these function names.

## Driver responsibility

1. Add an LMDB Erlang binding to `mix deps`.
2. Open env + dbi (multiple `FactSource`s may share one env).
3. Populate facts.
4. Pass env/dbi to `FactSource.Lmdb.open/3` via spec map.

Spec fields:

| Field | Description |
| --- | --- |
| `env` | Pre-opened env (required) |
| `dbi` | Pre-opened database within env (required) |
| `arity` | Column count (required, 2 supported) |
| `dupsort` | `true` if `MDB_DUPSORT` was set when `dbi` was opened (default `false`) |

Lifecycle: `close/2` is intentionally a no-op for env. Multiple `FactSource`s may share the env; the driver owns `env_close`.

## Tests

- `test_lmdb_adaptor_emitted_in_runtime` — emit-and-grep on the defmodule, behaviour declaration, defstruct fields, and the three FactSource callbacks.
- `test_lmdb_adaptor_uses_indirect_module_resolution` — confirms `Module.concat([Elmdb])` is used and there are no literal `Elmdb.X` calls.
- `test_lmdb_adaptor_targets_safe_keyvalue_api` — confirms the `txn_get` + cursor `get`/`get-next` surface; rejects `mdb_val` / `raw_pointer` references.

## Test plan

- [x] Phase 3 (16/16)
- [x] Phase 4c (5/5)
- [x] Phase 4d (1/1)
- [x] `test_wam_elixir_target.pl` (all + 3 new LMDB tests)
- [x] `test_wam_target.pl` (all)

## What this enables

Per roadmap "Implications for Elixir's next work": graph-algorithm benchmark workloads above 100k facts can now use a memory-mapped backing store instead of holding everything in ETS.

The complete `FactSource` lineup post-this-PR:

| Adaptor | Use case |
| --- | --- |
| TSV | Boot from text file |
| ETS | In-memory, <100k facts |
| SQLite | Queryable artifact |
| **LMDB** | **High-volume memory-mapped (this PR)** |

## Out-of-scope follow-ups

- Runtime smoke test that loads `:elmdb` and exercises the adaptor end-to-end (emit-and-grep tests catch codegen regressions; a runtime smoke would catch protocol-level regressions).
- Documentation example with `mix.exs` snippet + env/dbi setup boilerplate.
- Cross-target benchmark comparing Elixir-LMDB vs Haskell-LMDB on the effective-distance pipeline. Should validate the materialisation-cost claim at scale.

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_