### PR TITLE
fix: cross-target instrumentation-bug audit + use_lmdb(auto) true-path validation`

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -2525,6 +2525,73 @@ stderr line confirms the resolver fired.
    verify the "auto + high fact_count + lmdb available → true" path
    works end-to-end. Requires environmental setup (cabal install lmdb +
    LMDB-ingested data); the wiring itself is in place.
+   **— validated in Phase L appendix #3 (2026-05-04).**
 4. **Scale 5k/10k matrix runs** with the kernel changes, to see how
    the Haskell-vs-Rust gap evolves at larger wiki scales. Each run
    is ~5-15 min wall time so deferred for budget.
+
+---
+
+## Phase L appendix #3: cross-target audit + auto-resolver true-path validation (2026-05-04)
+
+Two Phase L follow-ups closed:
+
+**Cross-target audit** for the instrumentation-bug class (PR #1724
+fixed `dimension_n` in Haskell; the broader question was whether other
+WAM target backends had analogous hardcoded values that should come
+from user-asserted facts). Surveyed Rust, Elixir, Scala, Clojure, Go:
+
+- **Haskell** — already fixed (#1721 max_depth, #1724 dimension_n).
+- **Go** — already fine; `resolve_dimension_n_go/2` mirrors the
+  Haskell resolver, and `max_depth` flows via the shared kernel
+  registry's detector at `recursive_kernel_detection.pl:289` which
+  reads `user:max_depth/1`.
+- **Rust** — fine; FFI kernel reads `max_depth` from
+  `foreign_usize_config` at runtime, populated at codegen via
+  `register_foreign_usize_config` from the same shared registry.
+- **Elixir, Scala** — no FFI kernel with separate config that could
+  diverge from the WAM-compiled `max_depth/1` predicate; user-asserted
+  values flow via the standard predicate-compilation path.
+- **Clojure — bug found and fixed.** The LMDB foreign handler at
+  `wam_clojure_target.pl:272` read `max_depth` from
+  `option(clojure_lmdb_ancestor_max_depth(M), Options, 10)` —
+  explicit option with a hardcoded default. A user asserting
+  `user:max_depth(30)` in the workload would silently still get 10
+  unless they also passed the clojure-specific option. New
+  `resolve_clojure_lmdb_ancestor_max_depth/2` mirrors the Haskell
+  resolver pattern (option → user-fact → default 10). Regression
+  test in `tests/test_wam_clojure_generator.pl` gated on the LMDB
+  Java toolchain; verifies `user:max_depth(13)` reaches generated
+  Clojure code as `max-depth 13`.
+
+**Auto-resolver true-path validation.** Phase L appendix #1 shipped
+the resolver + 5 deterministic false-path tests; Phase L appendix #2
+wired it through the matrix harness; this appendix validates the
+true-path end-to-end.
+
+Two pieces:
+
+1. `lmdb_haskell_package_available` extended to also probe
+   `~/.cabal/store/ghc-<ver>/package.db`. The previous check only
+   consulted ghc-pkg's user/global db, but `cabal v2-build` /
+   `cabal v2-install --lib` (the cabal ≥ 2.4 norm) installs to the
+   cabal store db, which a bare `ghc-pkg list` doesn't see. With this
+   fix, the resolver finds lmdb in either location.
+
+2. Ran `haskell-interp-ffi-auto` on `100k_cats` (196,900 facts —
+   ~4× the 50,000 default threshold). Generator stderr confirms
+   `lmdb=auto fact_count=196900`; generated cabal includes
+   `lmdb >= 0.2.5` (so the resolver picked `use_lmdb(true)`); binary
+   built and ran in ~406 s, producing 11 rows of output
+   (sha `8b134f6f910e`).
+
+The five deterministic resolver tests still pass — `auto + low
+fact_count` and `auto + no fact_count` continue producing false even
+with lmdb available, because the fact_count gate (step 2) overrides.
+
+### Open follow-ups (still)
+
+The Phase L appendix #2 follow-ups #1, #2, #4 remain — ST-monad arc,
+optional firewall hook for the resolver, and the larger scale 5k/10k
+sweeps. Cross-target audit found one Clojure bug; no other target
+needed fixes.

--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -269,12 +269,32 @@ clojure_lmdb_foreign_handler_code(category_ancestor/4, ArtifactPath, Options, Ha
     clojure_lmdb_path_literal(ArtifactPath, PathLiteral),
     clojure_lmdb_reader_open_expr(PathLiteral, Options, ReaderOpenExpr),
     clojure_lmdb_cache_log_snippet('category_ancestor/4', Options, LogSnippet),
-    option(clojure_lmdb_ancestor_max_depth(MaxDepth), Options, 10),
+    resolve_clojure_lmdb_ancestor_max_depth(Options, MaxDepth),
     format(string(HandlerCode),
            "(let [reader-delay (delay ~w) max-depth ~w term-list-values (fn term-list-values [term] (if (and (map? term) (= \"[|]/2\" (:functor term))) (cons (first (:args term)) (term-list-values (second (:args term)))) [])) parent-values (fn [category] (mapv (fn [^generated.lmdb.LmdbRow row] (.value row)) (.lookupArg1 ^generated.lmdb.LmdbArtifactReader @reader-delay category))) ancestor-hops (fn ancestor-hops [category target visited] (let [parents (parent-values category)] (vec (concat (for [parent parents :when (and (not (contains? visited parent)) (or (map? target) (= parent target)))] [parent 1]) (when (< (count visited) max-depth) (apply concat (for [mid parents :when (not (contains? visited mid)) [ancestor hops] (ancestor-hops mid target (conj visited mid))] [[ancestor (inc hops)]])))))))] (fn [args] (let [category (nth args 0) target (nth args 1) visited (set (term-list-values (nth args 3))) solutions (for [[ancestor hops] (ancestor-hops category target visited)] {:bindings {2 ancestor 3 hops}})] (do ~w {:solutions (vec solutions)}))))",
            [ReaderOpenExpr, MaxDepth, LogSnippet]).
 clojure_lmdb_foreign_handler_code(Pred/Arity, _ArtifactPath, _Options, _HandlerCode) :-
     throw(error(unsupported_clojure_lmdb_foreign_relation(Pred/Arity), _)).
+
+%% resolve_clojure_lmdb_ancestor_max_depth(+Options, -MaxDepth) is det.
+%
+%  Same instrumentation-bug class as the Haskell `resolve_max_depth/2`
+%  (PR #1721) — without this resolver the LMDB ancestor handler used
+%  a hardcoded 10 as fallback, silently overriding any user-asserted
+%  `user:max_depth/1`. Priority:
+%    1. Options list: clojure_lmdb_ancestor_max_depth(N)
+%    2. user:max_depth/1 fact (asserted by the workload)
+%    3. Default: 10 (matches the prior hardcoded value)
+resolve_clojure_lmdb_ancestor_max_depth(Options, MaxDepth) :-
+    (   option(clojure_lmdb_ancestor_max_depth(M), Options),
+        integer(M), M >= 1
+    ->  MaxDepth = M
+    ;   current_predicate(user:max_depth/1),
+        user:max_depth(M),
+        integer(M), M >= 1
+    ->  MaxDepth = M
+    ;   MaxDepth = 10
+    ).
 
 clojure_foreign_handler_entry(handler(Pred/Arity, HandlerCode), Entry) :- !,
     clojure_foreign_handler_entry(Pred/Arity-HandlerCode, Entry).

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -4003,20 +4003,57 @@ resolve_auto_use_lmdb_decision(Options, Decision) :-
 
 %% lmdb_haskell_package_available
 %
-%  Probe `ghc-pkg list --simple-output lmdb`. Returns true iff the
-%  output mentions `lmdb`. Conservative: any process error or absent
-%  ghc-pkg makes this fail, which propagates through
-%  `resolve_auto_use_lmdb_decision/2` as `Decision=false` —
-%  preferable to crashing the codegen on an environmental issue.
+%  True iff the Haskell `lmdb` package is reachable from the current
+%  toolchain. Probes two sources, in order:
+%
+%  1. `ghc-pkg list --simple-output lmdb` — catches global / user
+%     package db installs (the conventional case after
+%     `cabal install --lib lmdb`).
+%
+%  2. `ghc-pkg --package-db ~/.cabal/store/ghc-<ver>/package.db list
+%     --simple-output lmdb` — catches `cabal v2-build` /
+%     `cabal v2-install --lib` installs that land in the cabal store
+%     rather than user db. Common with cabal ≥ 2.4.
+%
+%  Conservative: any process error or absent ghc-pkg makes this fail
+%  (silently), which propagates as `Decision=false` rather than
+%  crashing the codegen on an environmental issue.
 lmdb_haskell_package_available :-
+    ghc_pkg_lists_lmdb([]).
+lmdb_haskell_package_available :-
+    cabal_store_package_db(StoreDb),
+    ghc_pkg_lists_lmdb(['--package-db', StoreDb]).
+
+ghc_pkg_lists_lmdb(ExtraArgs) :-
+    append(ExtraArgs, ['list', '--simple-output', 'lmdb'], Args),
     catch(
-        (   process_create(path('ghc-pkg'),
-                ['list', '--simple-output', 'lmdb'],
+        (   process_create(path('ghc-pkg'), Args,
                 [stdout(pipe(Out)), stderr(null), process(Pid)]),
             read_string(Out, _, OutStr),
             close(Out),
             process_wait(Pid, _),
             sub_string(OutStr, _, _, _, "lmdb")
+        ),
+        _, fail).
+
+%% cabal_store_package_db(-StoreDb) is semidet.
+%
+%  Resolve the path of the cabal store's package db for the user's
+%  current GHC. Fails if `ghc --numeric-version` doesn't run or the
+%  store directory doesn't exist on disk.
+cabal_store_package_db(StoreDb) :-
+    catch(
+        (   process_create(path('ghc'), ['--numeric-version'],
+                [stdout(pipe(GhcOut)), stderr(null), process(GhcPid)]),
+            read_string(GhcOut, _, GhcVerRaw),
+            close(GhcOut),
+            process_wait(GhcPid, _),
+            split_string(GhcVerRaw, "\n", "\n\r", [GhcVer|_]),
+            GhcVer \== "",
+            expand_file_name('~/.cabal/store', [Store]),
+            format(string(StoreDb),
+                   '~w/ghc-~w/package.db', [Store, GhcVer]),
+            exists_directory(StoreDb)
         ),
         _, fail).
 

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -298,6 +298,32 @@ test(clojure_lmdb_target_ancestor_foreign_relation_auto_handler,
         delete_directory_and_contents(TmpDir)
     )).
 
+test(clojure_lmdb_ancestor_max_depth_falls_back_to_user_fact,
+     [condition(lmdb_helper_toolchain_available),
+      setup((retractall(user:max_depth(_)), assertz(user:max_depth(13)))),
+      cleanup(retractall(user:max_depth(_)))]) :-
+    %% Regression for the instrumentation-bug class fixed in PR #1724
+    %% (Haskell dimension_n/max_depth) and now extended to Clojure:
+    %% when no clojure_lmdb_ancestor_max_depth option is passed,
+    %% resolve_clojure_lmdb_ancestor_max_depth/2 reads from
+    %% user:max_depth/1 instead of silently using the hardcoded 10.
+    once((
+        unique_tmp_dir('tmp_wam_clojure_lmdb_user_max_depth', TmpDir),
+        write_wam_clojure_project([user:category_ancestor/4],
+                                  [ namespace('generated.wam_lmdb_user_max_depth_test'),
+                                    clojure_lmdb_foreign_relations([
+                                        category_ancestor/4-'data/generated/test/category_parent_lmdb'
+                                    ]),
+                                    clojure_lmdb_cache_policy(two_level)
+                                    %% NB: no clojure_lmdb_ancestor_max_depth here
+                                  ], TmpDir),
+        directory_file_path(TmpDir, 'src/generated/wam_lmdb_user_max_depth_test/core.clj', CorePath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(sub_string(CoreCode, _, _, _, 'max-depth 13')),
+        assertion(\+ sub_string(CoreCode, _, _, _, 'max-depth 10')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
 test(no_kernels_suppresses_clojure_foreign_stub) :-
     once((
         unique_tmp_dir('tmp_wam_clojure_no_kernels', TmpDir),


### PR DESCRIPTION
## Summary

Two Phase L follow-ups closed:

1. **Cross-target audit** for the instrumentation-bug class fixed in #1724 (Haskell `dimension_n`). Surveyed Rust, Elixir, Scala, Clojure, Go — found **one bug in Clojure** (`clojure_lmdb_ancestor_max_depth` defaulted to 10 without consulting `user:max_depth/1`). All other targets were already correct.

2. **End-to-end validation of the `use_lmdb(auto)` true-path.** The resolver's ghc-pkg detection extended to probe the cabal store db so `cabal v2-build` envs are recognised. Validated at scale 100k_cats (196900 facts, above 50k threshold): resolver picked `use_lmdb(true)`, generated cabal includes `lmdb >= 0.2.5`, binary ran in 406s producing 11 rows.

## 1. Cross-target audit

| target | status | notes |
| --- | --- | --- |
| Haskell | already fixed | #1721 max_depth, #1724 dimension_n |
| Go | already correct | `resolve_dimension_n_go/2` mirrors Haskell pattern; `max_depth` flows via shared kernel registry detector at `recursive_kernel_detection.pl:289` |
| Rust | already correct | FFI kernel reads `max_depth` from `foreign_usize_config` populated at codegen via the same shared registry |
| Elixir | already correct | no FFI kernel with separate config; user values flow via standard predicate compilation |
| Scala | already correct | same as Elixir |
| **Clojure** | **bug found and fixed** | `clojure_lmdb_ancestor_max_depth` defaulted to 10, never consulted `user:max_depth/1` |

### Clojure fix

`wam_clojure_target.pl:272`:

```diff
-    option(clojure_lmdb_ancestor_max_depth(MaxDepth), Options, 10),
+    resolve_clojure_lmdb_ancestor_max_depth(Options, MaxDepth),
```

New `resolve_clojure_lmdb_ancestor_max_depth/2` mirrors the Haskell resolver pattern:
1. Options list: `clojure_lmdb_ancestor_max_depth(N)` (existing explicit override)
2. `user:max_depth/1` fact (the typical workload pattern)
3. Default: 10 (matches the prior hardcoded value)

New regression test `clojure_lmdb_ancestor_max_depth_falls_back_to_user_fact` in `tests/test_wam_clojure_generator.pl`. Asserts `user:max_depth(13)`, generates a Clojure project without the explicit option, verifies `max-depth 13` reaches the generated code (not the previous hardcoded 10). Gated on `lmdb_helper_toolchain_available` like the existing ancestor handler test.

All 15 Clojure generator tests pass (existing 14 + new 1).

## 2. Auto-resolver true-path validation

### Resolver detection improvement

`lmdb_haskell_package_available` previously only probed
`ghc-pkg list --simple-output lmdb` (user/global db). But `cabal v2-build` /
`cabal v2-install --lib` (the cabal ≥ 2.4 norm) installs into the cabal store
db at `~/.cabal/store/ghc-<ver>/package.db`, which a bare `ghc-pkg list`
doesn't see. So the resolver always returned false in v2-build envs even
when lmdb was reachable for builds.

Fix: probe the user/global db first; if that misses, probe the cabal store
db using `ghc --numeric-version` to find the right path. Both probes catch
process errors and fail cleanly so the conservative fall-back-to-false
behavior holds when neither source can be probed.

### End-to-end run at scale 100k_cats

Generator log:
```
[WAM-Haskell-Matrix] variant=accumulated emit_mode=interpreter kernels=kernels_on lmdb=auto fact_count=196900 output=/tmp/probe_auto_100k
```

Generated cabal file's `build-depends`:
```
build-depends: ..., lmdb >= 0.2.5, ...
```

The `lmdb >= 0.2.5` dep confirms the resolver picked `use_lmdb(true)`. The 196900 fact count is well above the 50000 default threshold, and lmdb was detected in the cabal store via the new probe.

Matrix bench output:
```
scale       target                       category    median_s   rows  stdout_sha256
100k_cats   haskell-interp-ffi-auto      hybrid-wam  406.751    11    8b134f6f910e
```

Build + run completed end-to-end in ~6.7 minutes. 11 rows of output, sha `8b134f6f910e`.

### Tests stay green

The 5 deterministic resolver tests in `tests/test_wam_haskell_target.pl` still pass — the false-path tests rely on the `fact_count` gate (step 2 of the resolver), which produces false regardless of whether lmdb is available, when fact_count is low or absent. So the tests remain deterministic across environments where lmdb may or may not be installed.

## Verification

- `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl` — all tests pass
- `swipl -g 'consult("tests/test_wam_clojure_generator.pl"), run_tests' -t halt` — all 15 tests pass (including the new fallback test)
- Auto target end-to-end at 100k_cats — resolver picks LMDB, binary builds, runs, produces output
- Generator stderr confirms decision: `lmdb=auto fact_count=196900`

## Test plan

- [ ] (Future) Run `haskell-interp-ffi` (IntMap baseline) at 100k_cats to compare output sha against the auto run; confirms semantic equivalence between IntMap and LMDB paths at this scale (each run ~7 min)
- [ ] (Future) Optional firewall hook in the resolver — Phase L appendix #2 follow-up #2
- [ ] (Future) ST-monad arc — Phase L appendix #2 follow-up #1
- [ ] (Future) Scale 5k/10k matrix sweeps with the kernel changes

## Refs

- PR #1721 — original Haskell max_depth fix (the bug class this audit replicates)
- PR #1724 — Haskell dimension_n audit (precedent for cross-target survey)
- PR #1787 — Phase L (kernel + resolver landed)
- PR #1790 — Phase L appendix #2 (accumulator + harness wiring)
- WAM_PERF_OPTIMIZATION_LOG.md — Phase L appendix #3 documents both pieces

🤖 Generated with [Claude Code](https://claude.com/claude-code)