### PR TITLE
experiment(wam-elixir): opt-in atom interning (negative result, ships option as opt-in)

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -684,11 +684,50 @@ render_index_entry(Key-Tuples, Entry) :-
 %  lowered emitter is force-stringified, which silently breaks numeric
 %  head-match: `iterate(0) :- ...` lowers to `val == "0"` instead of
 %  `val == 0`, so iterate/1 fails for any caller passing an integer.
+%
+%  When intern_atoms_enabled/0 is asserted (set by the
+%  intern_atoms(true) project Option), identifier-shape constants
+%  emit as Elixir atom literals (`:foo`) instead of binaries
+%  (`"foo"`). BEAM atoms compare via pointer equality (cheaper
+%  than binary equality on hot paths) and avoid binary copies in
+%  ETS / process-message-passing, at the cost of pressuring BEAMs
+%  atom table. Bounded by the number of distinct atoms in the
+%  source, which for typical Prolog programs is well below the
+%  default ~1M atom table limit. See the experiment writeup for
+%  measurements.
 elixir_constant_literal(TokenStr, ElixirLiteral) :-
     (   number_string(_, TokenStr)
     ->  ElixirLiteral = TokenStr
+    ;   intern_atoms_enabled,
+        valid_elixir_atom_name(TokenStr)
+    ->  format(string(ElixirLiteral), ':~w', [TokenStr])
     ;   format(string(ElixirLiteral), '"~w"', [TokenStr])
     ).
+
+%% intern_atoms_enabled is asserted by write_wam_elixir_project/3
+%  (in wam_elixir_target.pl) when the project Options include
+%  intern_atoms(true). Set/retract is wrapped in setup_call_cleanup
+%  so a failed lowering doesnt leave the flag asserted across
+%  subsequent generations.
+:- dynamic intern_atoms_enabled/0.
+
+%% valid_elixir_atom_name(+Str)
+%  True if Str matches Elixirs unquoted-atom rule: starts with a
+%  lowercase letter or underscore, rest is alphanumeric or
+%  underscore. Constants that dont match (whitespace, punctuation,
+%  uppercase-leading, etc.) emit as quoted strings even under
+%  intern_atoms — emitting `:Foo` would mean "the module Foo" in
+%  Elixir, not what we want.
+valid_elixir_atom_name(Str) :-
+    string_chars(Str, [First|Rest]),
+    valid_atom_first_char(First),
+    forall(member(C, Rest), valid_atom_rest_char(C)).
+
+valid_atom_first_char(C) :- char_type(C, lower).
+valid_atom_first_char('_').
+
+valid_atom_rest_char(C) :- char_type(C, alnum).
+valid_atom_rest_char('_').
 
 %% tokenize_wam_line(+Line, -Tokens)
 %  `Line` is any string or atom; `Tokens` is a list of strings, in order,

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -2459,6 +2459,33 @@ write_wam_elixir_project(Predicates, Options, ProjectDir) :-
     make_directory_path(ProjectDir),
     directory_file_path(ProjectDir, 'lib', LibDir),
     make_directory_path(LibDir),
+    % Atom-interning experiment: when the user passes intern_atoms(true),
+    % set a process-wide flag that elixir_constant_literal/2 in the
+    % lowered emitter consults. setup_call_cleanup/3 retracts the flag
+    % afterward so a failed lowering doesnt leak the setting into
+    % subsequent generations. Off by default (existing behaviour
+    % preserved — every constant emits as a binary).
+    setup_call_cleanup(
+        atom_interning_setup(Options),
+        do_write_wam_elixir_project(Predicates, Options, ProjectDir,
+                                     Mode, ModuleName, LibDir),
+        atom_interning_cleanup(Options)
+    ).
+
+atom_interning_setup(Options) :-
+    (   option(intern_atoms(true), Options)
+    ->  assertz(wam_elixir_lowered_emitter:intern_atoms_enabled)
+    ;   true
+    ).
+
+atom_interning_cleanup(Options) :-
+    (   option(intern_atoms(true), Options)
+    ->  retractall(wam_elixir_lowered_emitter:intern_atoms_enabled)
+    ;   true
+    ).
+
+do_write_wam_elixir_project(Predicates, Options, ProjectDir,
+                             Mode, ModuleName, LibDir) :-
     % Generate runtime module
     compile_wam_runtime_to_elixir(Options, RuntimeCode),
     directory_file_path(LibDir, 'wam_runtime.ex', RuntimePath),

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -751,6 +751,72 @@ test_lmdb_adaptor_uses_indirect_module_resolution :-
     ;   fail_test(Test, 'LMDB adaptor has literal Elmdb references — will warn without dep')
     ).
 
+%% Atom-interning experiment (opt-in via intern_atoms(true) Option):
+%  identifier-shape constants emit as Elixir atom literals (`:foo`)
+%  instead of binaries (`"foo"`). BEAM atoms compare via pointer
+%  equality and avoid binary copies on hot paths. Non-identifier
+%  constants (whitespace, leading uppercase, etc.) still emit as
+%  quoted strings — `:Foo` would mean a module reference in Elixir.
+test_intern_atoms_default_off :-
+    Test = 'Atom interning: default (no intern_atoms option) emits constants as binary literals',
+    setup_call_cleanup(
+        (   retractall(intern_test:p(_)),
+            assertz(intern_test:p('hello'))
+        ),
+        (   wam_target:compile_predicate_to_wam(intern_test:p/1, [], WamCode),
+            lower_predicate_to_elixir(p/1, WamCode, [module_name('TestMod')], Code),
+            atom_string(Code, S),
+            sub_string(S, _, _, _, 'val == "hello"'),
+            \+ sub_string(S, _, _, _, 'val == :hello')
+        ->  pass(Test)
+        ;   fail_test(Test, 'default mode wrongly emitted atom literal')
+        ),
+        retractall(intern_test:p(_))
+    ).
+
+test_intern_atoms_on_emits_atom_literals :-
+    Test = 'Atom interning: intern_atoms(true) emits identifier constants as :atom literals',
+    setup_call_cleanup(
+        (   retractall(intern_test:p(_)),
+            assertz(intern_test:p('hello')),
+            assertz(wam_elixir_lowered_emitter:intern_atoms_enabled)
+        ),
+        (   wam_target:compile_predicate_to_wam(intern_test:p/1, [], WamCode),
+            lower_predicate_to_elixir(p/1, WamCode, [module_name('TestMod')], Code),
+            atom_string(Code, S),
+            sub_string(S, _, _, _, 'val == :hello'),
+            \+ sub_string(S, _, _, _, 'val == "hello"')
+        ->  pass(Test)
+        ;   fail_test(Test, 'intern_atoms mode failed to emit atom literal')
+        ),
+        (   retractall(intern_test:p(_)),
+            retractall(wam_elixir_lowered_emitter:intern_atoms_enabled)
+        )
+    ).
+
+test_intern_atoms_keeps_non_identifiers_as_strings :-
+    Test = 'Atom interning: leading-uppercase / non-identifier constants stay as binary literals',
+    setup_call_cleanup(
+        (   retractall(intern_test:p(_)),
+            assertz(intern_test:p('Foo')),         % uppercase-leading: would mean module
+            assertz(intern_test:p('hello world')), % whitespace: not an identifier
+            assertz(wam_elixir_lowered_emitter:intern_atoms_enabled)
+        ),
+        (   wam_target:compile_predicate_to_wam(intern_test:p/1, [], WamCode),
+            lower_predicate_to_elixir(p/1, WamCode, [module_name('TestMod')], Code),
+            atom_string(Code, S),
+            sub_string(S, _, _, _, 'val == "Foo"'),
+            sub_string(S, _, _, _, 'val == "hello world"'),
+            % Sanity: did NOT emit `:Foo` (would parse as a module name).
+            \+ sub_string(S, _, _, _, 'val == :Foo')
+        ->  pass(Test)
+        ;   fail_test(Test, 'non-identifier constants wrongly emitted as atoms')
+        ),
+        (   retractall(intern_test:p(_)),
+            retractall(wam_elixir_lowered_emitter:intern_atoms_enabled)
+        )
+    ).
+
 test_lmdb_adaptor_targets_safe_keyvalue_api :-
     Test = 'LMDB adaptor: uses safe key/value + cursor API (no raw-pointer ops)',
     compile_wam_runtime_to_elixir([], RuntimeCode),
@@ -1186,6 +1252,7 @@ test_findall_phase4b5_branch_skips_cp_push :-
 :- dynamic integer_match_test:int_p/1.
 :- dynamic arith_cmp_test:gt_p/1, arith_cmp_test:neq_p/1.
 :- dynamic inline_list_test:len_p/1.
+:- dynamic intern_test:p/1.
 
 %% Arithmetic-comparison regression: the runtime must implement the
 %  full comparison family (`<`, `>`, `>=`, `=<`, `=:=`, `=\=`) — pre-
@@ -1814,6 +1881,9 @@ run_tests :-
     test_lmdb_adaptor_emitted_in_runtime,
     test_lmdb_adaptor_uses_indirect_module_resolution,
     test_lmdb_adaptor_targets_safe_keyvalue_api,
+    test_intern_atoms_default_off,
+    test_intern_atoms_on_emits_atom_literals,
+    test_intern_atoms_keeps_non_identifiers_as_strings,
     test_tier2_wamstate_has_parallel_depth,
     test_tier2_aggregate_helpers_emitted,
     test_tier2_aggregate_forkable_types,


### PR DESCRIPTION
## Summary

Adds `intern_atoms(true)` project Option that emits identifier-shape constants as Elixir atom literals (`:foo`) instead of binaries (`"foo"`). **Off by default** — zero behavior change for existing projects.

Implementation: `intern_atoms_enabled/0` dynamic flag asserted by `write_wam_elixir_project/3` around the lowering, consulted by `elixir_constant_literal/2` in the lowered emitter.

Identifier rule: starts lowercase or underscore, rest alphanumeric or underscore. Anything else (uppercase-leading like `"Foo"`, whitespace, punctuation) still emits as a quoted string — `:Foo` would parse as a module reference in Elixir, not an atom.

## Hypothesis

Per `docs/WAM_TARGET_ROADMAP.md` interning note: BEAM atom comparison is pointer-equality (cheaper than binary comparison on hot paths); ETS / message-passing avoids binary copies for atoms. Should produce a measurable win on the existing Tier-2 benchmark grid.

## Measurement

4-vCPU, BEAM `schedulers_online()=4`, atom-only `nested_findall` workload from `examples/benchmark/wam_elixir_tier2_findall_benchmark.pl`:

| K | Mode | Default (μs) | Intern (μs) | Δ |
| ---: | --- | ---: | ---: | ---: |
| 50 | seq | 1378 | 1526 | +10.7% slower |
| 50 | par | 1715 | 1578 | **-8.0% faster** |
| 200 | seq | 5007 | 5369 | +7.2% slower |
| 200 | par | 3140 | 2661 | **-15.3% faster** |
| 1000 | seq | 35270 | 38495 | +9.1% slower |
| 1000 | par | 7742 | 8416 | +8.7% slower |

## Result: roughly neutral

Dominated by noise. Sequential trends slightly slower with interning; parallel is mixed. The benchmark is **dispatch-overhead-dominated** — the per-comparison cost (atom vs binary) isn't the bottleneck, so the change doesn't move the needle.

This is the kind of negative result the roadmap doc hinted at: *"worth measuring whether the first two [interning approaches] produce meaningful wins on heap-allocation-heavy workloads."* On a heap-light, dispatch-heavy workload (this benchmark), atoms don't help. Where they likely **would** help:

- ETS tables with millions of entries (atom keys are smaller than binary keys).
- Heavy IPC across processes (atoms don't copy through message-passing).
- Hot loops that stress the binary comparator on long-prefix-shared strings.

## Why ship the option anyway

- Zero default change — no risk to existing users.
- Removing it would discard the codegen path; keeping it as opt-in lets future experiments with the right workload shape (e.g., post-LMDB integration with millions of facts) flip it on and re-measure without re-implementing.
- The negative result is itself documentation — future maintainers know this lever has been pulled and didn't move things on dispatch-bound workloads.

## Tests

- `test_intern_atoms_default_off` — default emits `val == "hello"`, no atom literal.
- `test_intern_atoms_on_emits_atom_literals` — under `intern_atoms`, identifier constants emit as `val == :hello`.
- `test_intern_atoms_keeps_non_identifiers_as_strings` — uppercase-leading and whitespace-containing constants stay as quoted strings even when interning is on.

## Test plan

- [x] Phase 3 (16/16)
- [x] Phase 4c (5/5)
- [x] Phase 4d (1/1)
- [x] `test_wam_elixir_target.pl` (all + 3 new tests)
- [x] `test_wam_target.pl` (all)
- [x] Manual measurement at K=50/200/1000 for seq+par modes — reported above

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_