### PR TITLE
feat(wam-elixir): compile-time pattern recognition auto-routes tc/2 to graph kernel

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_kernel_dispatch.pl
+++ b/src/unifyweaver/targets/wam_elixir_kernel_dispatch.pl
@@ -1,0 +1,71 @@
+% wam_elixir_kernel_dispatch.pl
+%
+% Pattern recognition for graph-kernel dispatch in the WAM-Elixir
+% target. When a predicate matches a recognised pattern AND the
+% project Options include `kernel_dispatch(true)`, write_wam_elixir_-
+% project/3 emits a dispatch module that delegates to a hand-tuned
+% WamRuntime.GraphKernel.* module instead of the WAM-bytecode lower
+% chain. See docs/WAM_TARGET_ROADMAP.md for the architectural story
+% and benchmarks/wam_elixir_tier2_findall.md for the measured impact
+% (PR #1799 reported 218x-1564x for transitive closure).
+%
+% First pattern shipped: transitive closure.
+%
+%   tc(X, Z) :- edge(X, Z).
+%   tc(X, Z) :- edge(X, Y), tc(Y, Z).
+%
+% Variants out of scope for this PR (future patterns will extend the
+% matcher table):
+%   - clause-order swap (recursive case before base case)
+%   - right-recursive form `tc(X, Z) :- tc(Y, Z), edge(X, Y)`
+%   - other-arity edges, n-ary recursion, etc.
+
+:- module(wam_elixir_kernel_dispatch, [
+    match_transitive_closure_pattern/3
+]).
+
+%% match_transitive_closure_pattern(+Module, +Pred/+Arity, -EdgePred/+EdgeArity)
+%
+%  True if Module:Pred/Arity has exactly the canonical 2-clause TC
+%  shape over some EdgePred/EdgeArity (where EdgePred is recovered
+%  from the clause bodies). Pred and EdgePred must both be 2-ary.
+%
+%  Alpha-equivalent: variable names in source dont matter — only
+%  structural identity.
+match_transitive_closure_pattern(Module, Pred/2, EdgePred/2) :-
+    atom(Pred),
+    functor(QHead, Pred, 2),
+    findall(QHead-Body, clause(Module:QHead, Body), Clauses),
+    Clauses = [BaseHead-BaseBody, RecHead-RecBody],
+    %
+    % Base case: pred(A, B) :- edge(A, B).
+    %
+    BaseHead =.. [Pred, BA, BB],
+    var(BA), var(BB), BA \== BB,
+    strip_module_call(BaseBody, BaseGoal),
+    BaseGoal =.. [EdgePred, EBA, EBB],
+    atom(EdgePred), EdgePred \== Pred,
+    BA == EBA, BB == EBB,
+    %
+    % Recursive case: pred(C, D) :- edge(C, E), pred(E, D).
+    %
+    RecHead =.. [Pred, RC, RD],
+    var(RC), var(RD), RC \== RD,
+    strip_module_call(RecBody, RecBodyPlain),
+    RecBodyPlain = (G1Raw, G2Raw),
+    strip_module_call(G1Raw, G1),
+    strip_module_call(G2Raw, G2),
+    G1 =.. [EdgePred, RG1A, RG1B],
+    RG1A == RC,
+    var(RG1B), RG1B \== RC, RG1B \== RD,
+    G2 =.. [Pred, RG2A, RG2B],
+    RG2A == RG1B,
+    RG2B == RD.
+
+%% strip_module_call(+Goal, -PlainGoal)
+%  Body goals can be module-qualified (`mod:goal(args)`) — sometimes
+%  with nested qualifiers (`user:kernel_test:goal`) and sometimes
+%  wrapping a conjunction (`user:(g1, g2)`). Strip recursively so
+%  the matcher sees bare goal shapes.
+strip_module_call(_M:G, Plain) :- !, strip_module_call(G, Plain).
+strip_module_call(G, G).

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -28,6 +28,9 @@
 :- use_module('../core/template_system').
 :- use_module('../bindings/elixir_wam_bindings').
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../targets/wam_elixir_utils', [camel_case/2]).
+:- use_module('../targets/wam_elixir_kernel_dispatch',
+              [match_transitive_closure_pattern/3]).
 :- use_module('wam_elixir_lowered_emitter', [lower_predicate_to_elixir/4]).
 :- use_module('wam_elixir_utils', [reg_id/2, clean_comma/2, is_label_part/1, camel_case/2, parse_arity/2]).
 
@@ -2545,6 +2548,133 @@ atom_interning_setup(Options) :-
     ;   true
     ).
 
+%% compile_tc_kernel_dispatch_module(+ModuleName, +Pred, +EdgePred, -Code)
+%
+%  Emit a per-predicate dispatch module that routes calls through
+%  WamRuntime.GraphKernel.TransitiveClosure.reachable_from instead
+%  of the WAM-bytecode lower chain. Replaces what lower_predicate_to_-
+%  elixir would have emitted for predicates matching the canonical
+%  TC pattern.
+%
+%  Driver responsibility: register the edge predicate as a FactSource
+%  so the kernel can fetch neighbours. The dispatch module looks the
+%  source up by indicator string (e.g., "edge/2") at call time.
+%
+%  Findall integration: when called from inside a `findall(Z, tc(X, Z),
+%  L)` aggregate frame, the surrounding state.cp does aggregate_collect
+%  + throw fail per result. We iterate the kernels reachable list,
+%  trail-bind reg 2, call state.cp, catch the fail, unwind trail, try
+%  the next. After exhaustion, throw fail to terminate the predicate.
+%
+%  Driver-direct call (state.cp = terminal_cp): the FIRST iteration
+%  returns {:ok, state} without throwing; we halt and propagate.
+compile_tc_kernel_dispatch_module(ModuleName, Pred, EdgePred, Code) :-
+    atom_string(ModuleName, ModName),
+    camel_case(ModName, CamelMod),
+    atom_string(Pred, PredStr),
+    camel_case(PredStr, CamelPred),
+    atom_string(EdgePred, EdgePredStr),
+    format(string(EdgeKey), "~w/2", [EdgePredStr]),
+    format(string(Code),
+'defmodule ~w.~w do
+  @moduledoc """
+  Kernel-dispatched ~w/2 (auto-recognised TC pattern over ~w/2).
+  Replaces the WAM-bytecode lowering for this predicate; routes
+  calls through WamRuntime.GraphKernel.TransitiveClosure.
+
+  Edge source must be registered via WamRuntime.FactSourceRegistry
+  under the indicator "~w" before calling. The registered handle
+  must implement the WamRuntime.FactSource behaviour (any of
+  FactSource.Lmdb, FactSource.Sqlite, FactSource.Ets, FactSource.Tsv,
+  or a driver-supplied module).
+  """
+
+  def run(%WamRuntime.WamState{} = state) do
+    start_val = WamRuntime.deref_var(state, WamRuntime.get_reg(state, 1))
+    edge_handle = WamRuntime.FactSourceRegistry.lookup!("~w")
+    neighbors_fn = fn node ->
+      WamRuntime.FactSource.lookup_by_arg1(edge_handle, node, state)
+    end
+    reachable =
+      WamRuntime.GraphKernel.TransitiveClosure.reachable_from(
+        neighbors_fn, start_val)
+
+    # Two-mode dispatch:
+    #
+    # (a) Findall / aggregate context — an aggregate frame is on the
+    #     CP stack (gated by in_forkable_aggregate_frame?/1, the same
+    #     check the Tier-2 super-wrapper uses). Dump ALL kernel
+    #     results into the agg_accum in one go via merge_into_-
+    #     aggregate, then throw fail to drive the standard
+    #     backtrack -> finalise_aggregate flow. Avoids iterating
+    #     state.cp per result, which would let the calling clauses
+    #     k1 catch its own fail and finalise after one solution.
+    #
+    # (b) Driver-direct call — no agg frame; return the FIRST
+    #     reachable node bound into result reg 2 as a single solution.
+    #     Subsequent solutions are not enumerable in this mode (no
+    #     choice point to drive backtracking), but the typical
+    #     driver-direct call shape is `findall(Z, tc(X, Z), L)` which
+    #     hits path (a).
+    if WamRuntime.in_forkable_aggregate_frame?(state) do
+      merged = WamRuntime.merge_into_aggregate(state, reachable)
+      throw({:fail, merged})
+    else
+      case reachable do
+        [first | _] ->
+          case bind_result_reg(state, 2, first) do
+            nil -> throw({:fail, state})
+            bound -> {:ok, bound}
+          end
+        [] -> throw({:fail, state})
+      end
+    end
+  end
+
+  def run(args) when is_list(args) do
+    state = %WamRuntime.WamState{code: {}, labels: %{}, pc: 1}
+    {state, arg_vars} =
+      Enum.with_index(args, 1)
+      |> Enum.reduce({state, []}, fn {arg, i}, {s, vars} ->
+        case arg do
+          {:unbound, _} ->
+            v = {:unbound, make_ref()}
+            {%{s | regs: Map.put(s.regs, i, v)}, [{i, v} | vars]}
+          other ->
+            {%{s | regs: Map.put(s.regs, i, other)}, vars}
+        end
+      end)
+    state = %{state | arg_vars: arg_vars, cp: &WamRuntime.terminal_cp/1}
+    try do
+      case run(state) do
+        {:ok, final} -> {:ok, WamRuntime.materialise_args(final)}
+        other -> other
+      end
+    catch
+      {:fail, _} -> :fail
+      {:return, result} -> result
+      error ->
+        IO.puts("Predicate ~w CRASHED: #{inspect(error)}")
+        :fail
+    end
+  end
+
+  defp bind_result_reg(state, reg_idx, value) do
+    case Map.get(state.regs, reg_idx) do
+      {:unbound, id} ->
+        state |> WamRuntime.trail_binding(id) |> WamRuntime.put_reg(id, value)
+      ^value -> state
+      _ -> nil
+    end
+  end
+end
+',
+    [CamelMod, CamelPred,
+     PredStr, EdgePredStr,
+     EdgeKey,
+     EdgeKey,
+     CamelPred]).
+
 atom_interning_cleanup(Options) :-
     (   option(intern_atoms(true), Options)
     ->  retractall(wam_elixir_lowered_emitter:intern_atoms_enabled)
@@ -2568,12 +2698,21 @@ do_write_wam_elixir_project(Predicates, Options, ProjectDir,
         close(DS)
     ;   true
     ),
-    % Generate predicate modules
+    % Generate predicate modules. When kernel_dispatch(true) is set
+    % AND a predicate matches a recognised graph-kernel pattern, route
+    % its emit through the kernel-dispatch path instead of the WAM
+    % lower chain. See wam_elixir_kernel_dispatch.pl for matchers.
+    option(source_module(SourceModule), Options, user),
     forall(
         member(Pred/Arity-WamCode, Predicates),
-        (   (   Mode == lowered
-            ->  lower_predicate_to_elixir(Pred/Arity, WamCode, Options, PredCode)
-            ;   compile_wam_predicate_to_elixir(Pred/Arity, WamCode, Options, PredCode)
+        (   (   option(kernel_dispatch(true), Options),
+                Mode == lowered,
+                match_transitive_closure_pattern(SourceModule, Pred/Arity, EdgeP/_)
+            ->  compile_tc_kernel_dispatch_module(ModuleName, Pred, EdgeP, PredCode)
+            ;   (   Mode == lowered
+                ->  lower_predicate_to_elixir(Pred/Arity, WamCode, Options, PredCode)
+                ;   compile_wam_predicate_to_elixir(Pred/Arity, WamCode, Options, PredCode)
+                )
             ),
             atom_string(Pred, PredStr),
             format(atom(PredFile), '~w.ex', [PredStr]),

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -8,6 +8,8 @@
               [lower_predicate_to_elixir/4, classify_predicate/4,
                extract_facts/3, extract_arg1_index/3,
                tier2_purity_eligible/3, par_wrap_segment/4]).
+:- use_module('../src/unifyweaver/targets/wam_elixir_kernel_dispatch',
+              [match_transitive_closure_pattern/3]).
 % For Tier-2 purity-gate tests — user-annotation producer reads
 % clause_body_analysis:order_independent/1 dynamic facts.
 :- use_module('../src/unifyweaver/core/clause_body_analysis').
@@ -763,6 +765,64 @@ test_lmdb_adaptor_uses_indirect_module_resolution :-
 %  WamRuntime.GraphKernel.TransitiveClosure and is callable directly
 %  from driver code; future work adds compile-time pattern recognition
 %  to route source-Prolog tc/2 calls through the kernel automatically.
+%% Pattern recognition for kernel dispatch (PR #1799 added the kernel
+%  module; this PR adds compile-time pattern detection + auto-routing).
+:- dynamic kernel_test:tc/2.
+:- dynamic kernel_test:edge/2.
+:- dynamic kernel_test:single_clause/2.
+:- dynamic kernel_test:wrong_arity/3.
+:- dynamic kernel_test:right_rec/2.
+
+setup_kernel_fixtures :-
+    retractall(kernel_test:tc(_, _)),
+    retractall(kernel_test:edge(_, _)),
+    retractall(kernel_test:single_clause(_, _)),
+    retractall(kernel_test:wrong_arity(_, _, _)),
+    retractall(kernel_test:right_rec(_, _)),
+    assertz((kernel_test:tc(X, Z) :- kernel_test:edge(X, Z))),
+    assertz((kernel_test:tc(X, Z) :- kernel_test:edge(X, Y), kernel_test:tc(Y, Z))),
+    assertz((kernel_test:single_clause(X, Z) :- kernel_test:edge(X, Z))),
+    assertz((kernel_test:wrong_arity(X, _, Z) :- kernel_test:edge(X, Z))),
+    assertz((kernel_test:wrong_arity(X, Y, Z) :- kernel_test:edge(X, A), kernel_test:wrong_arity(A, Y, Z))),
+    assertz((kernel_test:right_rec(X, Z) :- kernel_test:edge(X, Z))),
+    assertz((kernel_test:right_rec(X, Z) :- kernel_test:right_rec(Y, Z), kernel_test:edge(X, Y))).
+
+test_kernel_pattern_matches_canonical_tc :-
+    Test = 'Kernel pattern: matches canonical tc/2 shape',
+    setup_kernel_fixtures,
+    (   wam_elixir_kernel_dispatch:match_transitive_closure_pattern(
+            kernel_test, tc/2, edge/2)
+    ->  pass(Test)
+    ;   fail_test(Test, 'matcher failed to recognise canonical tc/2 shape')
+    ).
+
+test_kernel_pattern_rejects_single_clause :-
+    Test = 'Kernel pattern: rejects single-clause predicate',
+    setup_kernel_fixtures,
+    (   wam_elixir_kernel_dispatch:match_transitive_closure_pattern(
+            kernel_test, single_clause/2, _)
+    ->  fail_test(Test, 'matcher wrongly accepted single-clause predicate')
+    ;   pass(Test)
+    ).
+
+test_kernel_pattern_rejects_wrong_arity :-
+    Test = 'Kernel pattern: rejects 3-ary predicate',
+    setup_kernel_fixtures,
+    (   wam_elixir_kernel_dispatch:match_transitive_closure_pattern(
+            kernel_test, wrong_arity/3, _)
+    ->  fail_test(Test, 'matcher wrongly accepted 3-ary predicate')
+    ;   pass(Test)
+    ).
+
+test_kernel_pattern_rejects_right_recursion :-
+    Test = 'Kernel pattern: rejects right-recursive form (out of scope)',
+    setup_kernel_fixtures,
+    (   wam_elixir_kernel_dispatch:match_transitive_closure_pattern(
+            kernel_test, right_rec/2, _)
+    ->  fail_test(Test, 'matcher wrongly accepted right-recursive form')
+    ;   pass(Test)
+    ).
+
 test_graph_kernel_tc_emitted_in_runtime :-
     Test = 'GraphKernel TC: runtime assembly emits WamRuntime.GraphKernel.TransitiveClosure',
     compile_wam_runtime_to_elixir([], RuntimeCode),
@@ -1923,6 +1983,10 @@ run_tests :-
     test_lmdb_adaptor_emitted_in_runtime,
     test_lmdb_adaptor_uses_indirect_module_resolution,
     test_lmdb_adaptor_targets_safe_keyvalue_api,
+    test_kernel_pattern_matches_canonical_tc,
+    test_kernel_pattern_rejects_single_clause,
+    test_kernel_pattern_rejects_wrong_arity,
+    test_kernel_pattern_rejects_right_recursion,
     test_graph_kernel_tc_emitted_in_runtime,
     test_graph_kernel_tc_uses_visited_tracking,
     test_graph_kernel_tc_factsource_bridge,


### PR DESCRIPTION
## Summary

Closes the loop on PR #1799 (graph kernel) by adding **source-Prolog pattern recognition** that auto-routes matching predicates through `WamRuntime.GraphKernel.TransitiveClosure` instead of WAM-bytecode lowering. Users no longer need to call the kernel manually — they write the canonical `tc/2` shape and the codegen recognises it.

## Pattern matcher

New module `wam_elixir_kernel_dispatch.pl` exports:

```prolog
match_transitive_closure_pattern(+Module, +Pred/+Arity, -EdgePred/+EdgeArity)
```

Detects the canonical 2-clause TC shape:

```prolog
tc(X, Z) :- edge(X, Z).
tc(X, Z) :- edge(X, Y), tc(Y, Z).
```

Alpha-equivalent (variable names don't matter); strips arbitrarily-nested module qualifiers (`user:kernel_test:edge(...)`); recovers the edge predicate name from the bodies.

**Out of scope for this PR** (future matcher entries):
- clause-order swap (recursive case before base case)
- right-recursive form `tc(X, Z) :- tc(Y, Z), edge(X, Y)`
- non-2-ary edges, n-ary recursion

## Auto-routing

In `write_wam_elixir_project/3`: when `Options` include `kernel_dispatch(true)` AND a predicate matches the pattern, emit a kernel-dispatch module instead of the WAM lower chain. Source module defaults to `user`; override via `source_module(M)` Option.

## Emitted dispatch module

The emitted `Tc` module has two-mode `run(state)`:

| Context | Behavior |
| --- | --- |
| Findall (`in_forkable_aggregate_frame? = true`) | Dump all reachable nodes into the agg frame via `merge_into_aggregate`, throw fail to drive standard `finalise_aggregate`. Same trick the Tier-2 super-wrapper uses. |
| Driver-direct (no agg frame) | Bind result reg to FIRST reachable node, return `:ok`. (Subsequent solutions aren't enumerable in this mode — typical use is findall.) |

Edge source must be registered with `WamRuntime.FactSourceRegistry` under the indicator string (`"edge/2"`). **Composes with any FactSource adaptor — ETS / SQLite / TSV / LMDB.**

## End-to-end verified

Chain graph `a → b → c → d`:

```elixir
WamRuntime.FactSourceRegistry.register("edge/2", ets_handle)
Probe.TcFindall.run(["a", {:unbound, make_ref()}])
# => {:ok, %WamRuntime.WamState{regs: %{2 => ["b", "c", "d"], ...}}}
```

via kernel dispatch (no WAM bytecode for `tc/2` emitted).

## Tests

- `test_kernel_pattern_matches_canonical_tc` — positive case.
- `test_kernel_pattern_rejects_single_clause` — 1-clause negative.
- `test_kernel_pattern_rejects_wrong_arity` — 3-ary negative.
- `test_kernel_pattern_rejects_right_recursion` — out-of-scope variant.

## Test plan

- [x] Phase 3 (16/16)
- [x] Phase 4c (5/5)
- [x] Phase 4d (1/1)
- [x] `test_wam_elixir_target.pl` (114/114, includes 4 new pattern tests)
- [x] `test_wam_target.pl` (16/16)
- [x] Manual end-to-end probe — `findall(Z, tc(a, Z), L)` returns `["b", "c", "d"]` via auto-routed kernel dispatch

## Implementation gotchas (recorded for future contributors)

1. **Nested module qualifiers**: `clause/2` returns body terms wrapped in module qualifiers (`user:kernel_test:edge(...)`) and the conjunction itself can be wrapped (`user:(g1, g2)`). The matcher needs **recursive** `strip_module_call` before structurally decomposing.

2. **Iteration vs aggregate-frame merge**: the first dispatch attempt iterated `state.cp` per result — looked correct in theory, but in practice the calling clause's `k1` catches its OWN `throw fail`, calls backtrack, finalises after just one result. Switching to `merge_into_aggregate` + single `throw fail` fixed it. Same pattern as the parallel super-wrapper — the aggregate frame is a one-shot accumulator, not an iterator.

## Out-of-scope follow-ups

- More patterns: `shortest_path`, `strongly_connected_components`, `effective_distance` — each gets its own `match_*_pattern` + emitter.
- Kernel-vs-WAM benchmark with `kernel_dispatch` enabled (PR #1799 had to use direct-call to the kernel; this PR enables the auto path).
- Cross-target: bring the same pattern recognition to Haskell / Go / Clojure (where the kernels exist via FFI).

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_