### PR TITLE
feat(wam-clojure): lower fail builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -227,6 +227,8 @@ lowered_direct_prefix(_, _, []).
 lowered_terminal_direct_instr(call(_, _), allow_control).
 lowered_terminal_direct_instr(execute(_), allow_control).
 lowered_terminal_direct_instr(jump(_), allow_control).
+lowered_terminal_direct_instr(builtin_call(Op, Arity), _) :-
+    clojure_terminal_builtin(Op, Arity).
 lowered_terminal_direct_instr(proceed, _).
 lowered_terminal_direct_instr(fail, _).
 
@@ -274,10 +276,19 @@ clojure_direct_builtin("true/0", "0").
 clojure_direct_builtin("true/0", 0).
 clojure_direct_builtin('true/0', "0").
 clojure_direct_builtin('true/0', 0).
+clojure_direct_builtin("fail/0", "0").
+clojure_direct_builtin("fail/0", 0).
+clojure_direct_builtin('fail/0', "0").
+clojure_direct_builtin('fail/0', 0).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
 clojure_direct_builtin('!/0', 0).
+
+clojure_terminal_builtin("fail/0", "0").
+clojure_terminal_builtin("fail/0", 0).
+clojure_terminal_builtin('fail/0', "0").
+clojure_terminal_builtin('fail/0', 0).
 
 emit_lowered_expr(proceed, S, Expr) :-
     format(atom(Expr), '(runtime/succeed-state ~w)', [S]).
@@ -358,6 +369,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "true/0" ; Op == 'true/0'),
     !,
     format(atom(Expr), '(runtime/advance ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "fail/0" ; Op == 'fail/0'),
+    !,
+    format(atom(Expr), '(runtime/backtrack ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "!/0" ; Op == '!/0'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -802,6 +802,9 @@
           "true/0"
           (advance state)
 
+          "fail/0"
+          (backtrack state)
+
           "!/0"
           (-> state
               (update :choice-points #(vec (take (:cut-bar state) %)))

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -107,6 +107,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, ':jump-pc')),
         assertion(sub_string(RuntimeCode, _, _, _, ':builtin-call')),
         assertion(sub_string(RuntimeCode, _, _, _, '"\\\\=/2"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"fail/0"')),
         assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-bindings [state bindings]')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -153,6 +153,14 @@ test(simple_builtin_true_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/succeed-state")
     )).
 
+test(simple_builtin_fail_is_direct_lowered_in_prefix) :-
+    once((
+        lower_predicate_to_clojure(test_fail/0, [builtin_call('fail/0', 0), proceed], [], Code),
+        has(Code, "runtime/backtrack"),
+        assertion(\+ has(Code, "runtime/succeed-state")),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(cut_builtin_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_cut/0:\nallocate\nbuiltin_call !/0, 0\ndeallocate\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -37,6 +37,7 @@
 :- dynamic user:wam_cut_helper/1.
 :- dynamic user:wam_hard_cut_outer_ok/1.
 :- dynamic user:wam_not_b/1.
+:- dynamic user:wam_fail_after_bind/1.
 
 has(Code, Substr) :-
     once(sub_string(Code, _, _, _, Substr)).
@@ -76,6 +77,7 @@ user:wam_soft_cut_outer_ok(X) :- (user:wam_soft_cut_helper(Y), X = Y ; X = b).
 user:wam_cut_helper(X) :- X = a, !, fail.
 user:wam_hard_cut_outer_ok(X) :- (user:wam_cut_helper(Y), X = Y ; X = b).
 user:wam_not_b(X) :- X \= b.
+user:wam_fail_after_bind(X) :- X = a, fail.
 
 :- initialization(main, main).
 
@@ -119,7 +121,8 @@ run_smoke :-
           user:wam_soft_cut_outer_ok/1,
           user:wam_cut_helper/1,
           user:wam_hard_cut_outer_ok/1,
-          user:wam_not_b/1
+          user:wam_not_b/1,
+          user:wam_fail_after_bind/1
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
@@ -137,6 +140,7 @@ run_smoke :-
     assert_lowered_call_emitted(TmpDir),
     assert_lowered_cut_builtin_emitted(TmpDir),
     assert_lowered_not_unify_builtin_emitted(TmpDir),
+    assert_lowered_fail_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
@@ -192,6 +196,8 @@ run_smoke :-
     verify_output(TmpDir, 'wam_hard_cut_outer_ok/1', b, "true"),
     verify_output(TmpDir, 'wam_not_b/1', a, "true"),
     verify_output(TmpDir, 'wam_not_b/1', b, "false"),
+    verify_output(TmpDir, 'wam_fail_after_bind/1', a, "false"),
+    verify_output(TmpDir, 'wam_fail_after_bind/1', b, "false"),
     delete_directory_and_contents(TmpDir),
     writeln('wam_clojure_runtime_smoke: ok').
 
@@ -245,6 +251,12 @@ assert_lowered_not_unify_builtin_emitted(ProjectDir) :-
     read_file_to_string(CorePath, CoreCode, []),
     has(CoreCode, "defn lowered-wam-not-b-1"),
     has(CoreCode, "runtime/unifiable?").
+
+assert_lowered_fail_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-fail-after-bind-1"),
+    has(CoreCode, "runtime/backtrack").
 
 assert_multiclause_wrappers_runtime_mediated(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM runtime support for `builtin_call fail/0`.
- Adds direct lowered-prefix support for deterministic `fail/0` builtin calls.
- Marks `fail/0` as a terminal lowered builtin so the emitter stops before any following suffix such as `proceed`.
- Adds generator, lowered-emitter, and runtime smoke coverage for the new builtin path.

## Why

The Clojure hybrid WAM target already lowers several deterministic builtins directly. `fail/0` is a small, pure control builtin that can avoid interpreter fallback in deterministic lowered-prefix code.

The implementation preserves WAM choice semantics: `fail/0` calls `runtime/backtrack`, not `fail-state`, so existing choice alternatives remain available.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
