### PR TITLE
test(wam-scala): add LMDB smoke and benchmark recipe

### DIFF
--- a/examples/benchmark/README_lmdb.md
+++ b/examples/benchmark/README_lmdb.md
@@ -1,0 +1,109 @@
+# LMDB benchmark recipe - Scala / Haskell / Elixir cross-target
+
+This document explains how to run the effective-distance benchmark
+with an LMDB-backed `category_parent/2` against the three WAM
+targets that ship an LMDB FactSource adaptor: Scala (PR #1804),
+Haskell (`generate_wam_haskell_enwiki_lmdb_benchmark.pl`), and Elixir
+(PR #1792).
+
+The point is to compare materialisation cost: above ~100k facts the
+JVM/BEAM/GHC heap pressure of holding all rows in memory dominates
+runtime. LMDB's memory-mapped file lets each target read straight
+from the page cache.
+
+> **Status:** infrastructure-only. The three targets use *different
+> key encodings* on disk - Haskell uses int32 IDs, Scala/Elixir use
+> UTF-8 strings. Reconciling those is out of scope for this PR; see
+> *Caveats* at the bottom. The recipe below produces three separate
+> envs and three separate benchmarks. Treat the timings as
+> indicative, not apples-to-apples, until the encoding is unified.
+
+## Workload
+
+`effective_distance.pl` driving `category_ancestor(Cat, Root, Hops,
+Visited)` over Wikipedia category hierarchy facts. The bottleneck
+predicate is `category_parent(Child, Parent)`: the WAM body queries
+it with `Child` ground (single-key probe) and the multi-parent shape
+naturally maps to LMDB `MDB_DUPSORT`.
+
+## Setup
+
+You need the LMDB env populated before any of the three targets can
+read it. The simplest loader is a small program that reads the
+`category_parent/2` facts from the workload `.pl` and writes them as
+`Child -> Parent` rows under `MDB_DUPSORT`.
+
+There isn't a single canonical loader in this repo; each target's
+existing benchmark has its own. For a single-string-key env that
+both Scala and Elixir can read, a one-liner with the `mdb_dump`
+companion tooling works; for the int32-key env the Haskell pipeline
+expects, see `examples/benchmark/generate_wam_haskell_enwiki_lmdb_benchmark.pl`'s
+docstring (it documents `seed_ids.txt` / `root_ids.txt`
+companion files).
+
+## Running each target
+
+### Scala (this PR)
+
+```sh
+# 1. Generate the project with lmdb data mode.
+WAM_SCALA_LMDB_ENV=/path/to/lmdb_env \
+  swipl -q -s examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl -- \
+    data/benchmark/dev/facts.pl /tmp/scala-bench-lmdb \
+    accumulated kernels_on lmdb
+
+# 2. Build with lmdbjava on the classpath.
+cd /tmp/scala-bench-lmdb
+sbt 'set libraryDependencies += "org.lmdbjava" % "lmdbjava" % "0.9.0"' compile
+
+# 3. Run with the same classpath.
+sbt 'run --bench 100 wam_effective_distance_q/4 ...'
+```
+
+### Haskell
+
+See `examples/benchmark/generate_wam_haskell_enwiki_lmdb_benchmark.pl`.
+The Haskell pipeline targets int32 IDs and the LMDB layout matches
+that - `seed_ids.txt` + `root_ids.txt` companion files are required.
+
+### Elixir
+
+See PR #1792 (`feat/wam-elixir-lmdb-fact-source`). Same
+single-string-key shape as Scala. Driver responsibility: open env +
+dbi via `:elmdb`, populate, pass handles to
+`WamRuntime.FactSource.Lmdb.open/3` via the spec map.
+
+## Comparing the timings
+
+Each target's bench mode emits a `BENCH n=<N> elapsed=<sec>` line.
+Capture three runs of equal `N` against the same workload and
+compare. Beware: the encoding mismatch means each target is reading
+*its own* LMDB, not the same bytes - so the comparison is bound by
+loader cost, not just runtime cost. A fair side-by-side requires the
+encoding reconciliation in *Caveats*.
+
+## Caveats
+
+- **Key encoding mismatch.** Scala/Elixir use UTF-8 strings; Haskell
+  uses int32 IDs. To make all three read the *same* env you'd
+  either: (a) teach Scala/Elixir an int32-key mode, or (b) teach
+  Haskell a string-key mode. Either is a separate PR.
+- **MDB_DUPSORT byte order.** Lmdbjava and `:elmdb` both expose the
+  `MDB_DUPSORT` flag, but their default key/value comparator
+  functions may differ from the C `lmdb` library Haskell uses
+  through `lmdb-bindings`. Verify before drawing conclusions about
+  per-key fanout.
+- **Cache modes.** The Haskell pipeline has multiple `lmdb_cache_mode`
+  options (`memoize` / `per_hec` / `sharded`); Scala/Elixir don't yet.
+  Disable Haskell caching (or pick the no-cache default) for an
+  apples-to-apples comparison.
+
+## See also
+
+- `PR_DESCRIPTION_WAM_SCALA_LMDB_FACT_SOURCE.md` - the Scala
+  adaptor's design contract.
+- `tests/test_wam_scala_lmdb_runtime_smoke.pl` - runtime smoke for
+  the Scala adaptor (gated on `SCALA_LMDB_TESTS=1` and
+  `LMDBJAVA_CLASSPATH`).
+- `docs/WAM_TARGET_ROADMAP.md` - the original materialisation-cost
+  bottleneck writeup that motivated all three LMDB adaptors.

--- a/examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl
@@ -23,7 +23,13 @@
 %%
 %% Usage:
 %%   swipl -q -s generate_wam_scala_effective_distance_benchmark.pl -- \
-%%       <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off] [sidecar|inline|artifact|auto]
+%%       <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off] [sidecar|inline|artifact|lmdb|auto]
+%%
+%% lmdb mode requires the LMDB env to be pre-populated (the harness
+%% does not write data files for it the way sidecar/artifact do).
+%% Set $WAM_SCALA_LMDB_ENV to point at the env directory, or it
+%% defaults to <output-dir>/data/lmdb. See examples/benchmark/README_lmdb.md
+%% for the loader recipe and cross-target comparison instructions.
 
 benchmark_workload_path(Path) :-
     source_file(benchmark_workload_path(_), ThisFile),
@@ -46,7 +52,7 @@ main :-
         KernelModeAtom = kernels_on,
         DataModeAtom = auto
     ;   format(user_error,
-            'Usage: ... -- <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off] [sidecar|inline|artifact|auto]~n',
+            'Usage: ... -- <facts.pl> <output-dir> [accumulated|seeded] [kernels_on|kernels_off] [sidecar|inline|artifact|lmdb|auto]~n',
             []),
         halt(1)
     ),
@@ -124,6 +130,7 @@ parse_variant(accumulated, [
 parse_benchmark_data_mode(sidecar, sidecar).
 parse_benchmark_data_mode(inline, inline).
 parse_benchmark_data_mode(artifact, artifact).
+parse_benchmark_data_mode(lmdb,     lmdb).
 parse_benchmark_data_mode(auto, Mode) :-
     (   benchmark_declared_data_mode(DeclaredMode),
         DeclaredMode \== auto
@@ -143,7 +150,7 @@ benchmark_declared_data_mode(Mode) :-
     current_predicate(user:Name/1),
     Goal =.. [Name, DeclaredMode],
     once(call(user:Goal)),
-    memberchk(DeclaredMode, [auto, sidecar, inline, artifact]),
+    memberchk(DeclaredMode, [auto, sidecar, inline, artifact, lmdb]),
     Mode = DeclaredMode.
 
 benchmark_relation_declared_data_mode(Relation, Mode) :-
@@ -154,7 +161,7 @@ benchmark_relation_declared_data_mode(Relation, Mode) :-
     current_predicate(user:Name/2),
     Goal =.. [Name, Relation, DeclaredMode],
     once(call(user:Goal)),
-    memberchk(DeclaredMode, [auto, sidecar, inline, artifact]),
+    memberchk(DeclaredMode, [auto, sidecar, inline, artifact, lmdb]),
     Mode = DeclaredMode.
 
 benchmark_effective_data_mode(Relation, DataMode, RelationMode) :-
@@ -204,6 +211,17 @@ scala_fact_source_for_category_parent(OutputDir, sidecar, source(category_parent
 scala_fact_source_for_category_parent(OutputDir, artifact, source(category_parent/2, grouped_by_first(GroupedPath))) :-
     category_parent_grouped_path(OutputDir, GroupedPath),
     write_category_parent_grouped_tsv(GroupedPath).
+%% LMDB data mode: the env is populated separately (the bench harness
+%% does not write the data file the way sidecar/artifact do). The path
+%% is taken from $WAM_SCALA_LMDB_ENV (or defaults to <OutputDir>/data/lmdb,
+%% in which case the harness expects it to be pre-populated by a loader
+%% companion). dupsort=true matches the multi-parent shape of the
+%% category_parent relation.
+scala_fact_source_for_category_parent(OutputDir, lmdb, source(category_parent/2, lmdb([env_path(EnvPath), dbi(''), dupsort(true)]))) :-
+    (   getenv('WAM_SCALA_LMDB_ENV', EnvPath0)
+    ->  atom_string(EnvPath, EnvPath0)
+    ;   directory_file_path(OutputDir, 'data/lmdb', EnvPath)
+    ).
 
 collect_wam_predicates(kernels_on, [
     user:dimension_n/1,

--- a/tests/test_wam_scala_lmdb_runtime_smoke.pl
+++ b/tests/test_wam_scala_lmdb_runtime_smoke.pl
@@ -1,0 +1,230 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (@s243a)
+%
+% test_wam_scala_lmdb_runtime_smoke.pl
+%
+% Runtime smoke test for the Scala LmdbFactSource adaptor introduced
+% in PR #1804. Exercises the adaptor end-to-end: generates a Scala
+% project with an `lmdb(...)` fact source, compiles with lmdbjava on
+% the classpath, populates a temp LMDB env, runs a query, and
+% verifies the result.
+%
+% The emit-and-grep tests in test_wam_scala_generator.pl cover
+% codegen regressions; this test catches protocol-level regressions
+% (method signatures, ByteBuffer encoding, dupsort cursor walking).
+%
+% Triple gating - the test is skipped unless ALL of:
+%   1. SCALA_LMDB_TESTS=1                         (opt in)
+%   2. scalac and scala on PATH                   (existing smoke gate)
+%   3. LMDBJAVA_CLASSPATH points to a colon-     (driver responsibility:
+%      separated list of JARs containing          provide lmdbjava +
+%      lmdbjava + its native deps                 transitive deps)
+%
+% Setup recipe (a one-time setup the developer runs locally):
+%   1. Download lmdbjava + jnr-ffi + jffi + asm transitive deps
+%      (e.g. via `coursier fetch org.lmdbjava:lmdbjava:0.9.0`).
+%   2. export LMDBJAVA_CLASSPATH=/path/to/jar1.jar:/path/to/jar2.jar:...
+%   3. export SCALA_LMDB_TESTS=1
+%   4. swipl -g 'use_module(library(plunit)),consult("tests/test_wam_scala_lmdb_runtime_smoke.pl"),run_tests,halt' -t 'halt(1)'
+%
+% Expected to be skipped in default CI; the developer running it
+% locally validates the protocol contract before benchmarking.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module(library(process)).
+:- use_module('../src/unifyweaver/targets/wam_scala_target').
+
+:- dynamic user:wam_pair_lmdb/2.
+
+% Body is irrelevant - the predicate is replaced by a CallForeign stub
+% that delegates to the LmdbFactSource. Listed here so write_wam_scala_project
+% finds it.
+user:wam_pair_lmdb(_, _).
+
+% ============================================================
+% Gating
+% ============================================================
+
+%% scala_lmdb_available/0 - true if all preconditions hold.
+scala_lmdb_available :-
+    getenv('SCALA_LMDB_TESTS', "1"),
+    scalac_on_path,
+    getenv('LMDBJAVA_CLASSPATH', _).
+
+scalac_on_path :-
+    catch(
+        process_create(path(scalac), ['--version'],
+                       [stdout(null), stderr(null), process(Pid)]),
+        _,
+        fail
+    ),
+    process_wait(Pid, exit(0)).
+
+% ============================================================
+% Tests
+% ============================================================
+
+:- begin_tests(wam_scala_lmdb_runtime_smoke,
+               [ condition(scala_lmdb_available) ]).
+
+% Single end-to-end smoke: seed an LMDB env with three (key, value)
+% pairs, compile a Scala project that reads via LmdbFactSource,
+% query it, verify the output matches the seeded data.
+%
+% The seeder is a small Scala main compiled alongside the WAM
+% project. It uses lmdbjava DIRECTLY (no FactSource indirection) so
+% the seeder's own bytes-on-disk shape matches what the FactSource
+% will read back.
+test(lmdb_fact_source_end_to_end) :-
+    once((
+        unique_lmdb_tmp_dir('tmp_scala_lmdb_smoke', TmpDir),
+        directory_file_path(TmpDir, 'lmdb_env', LmdbEnv),
+        make_directory_path(LmdbEnv),
+        absolute_file_name(LmdbEnv, AbsLmdbEnv),
+        % Generate the WAM project with an LMDB FactSource pointing at
+        % AbsLmdbEnv. dupsort=false (one value per key in this test).
+        write_wam_scala_project(
+            [user:wam_pair_lmdb/2],
+            [package('generated.wam_scala_lmdb_smoke.core'),
+             runtime_package('generated.wam_scala_lmdb_smoke.runtime'),
+             scala_fact_sources([
+                source(wam_pair_lmdb/2,
+                       lmdb([env_path(AbsLmdbEnv),
+                             dbi(''),
+                             dupsort(false)]))
+             ])],
+            TmpDir),
+        % Drop the seeder source alongside the generated sources so
+        % scalac sees them all as one compilation unit.
+        write_lmdb_seeder_source(TmpDir),
+        compile_lmdb_project(TmpDir),
+        seed_lmdb_env(TmpDir, AbsLmdbEnv),
+        % Query: wam_pair_lmdb(alpha, X) should return true (alpha is
+        % a seeded key whose value is bravo). wam_pair_lmdb(missing, _)
+        % should return false.
+        verify_lmdb(TmpDir, 'wam_pair_lmdb/2', ['alpha', 'bravo'], "true"),
+        verify_lmdb(TmpDir, 'wam_pair_lmdb/2', ['alpha', 'wrong'], "false"),
+        verify_lmdb(TmpDir, 'wam_pair_lmdb/2', ['missing', 'bravo'], "false"),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+:- end_tests(wam_scala_lmdb_runtime_smoke).
+
+% ============================================================
+% Helpers
+% ============================================================
+
+unique_lmdb_tmp_dir(Prefix, TmpDir) :-
+    get_time(T),
+    Stamp is floor(T * 1000),
+    format(atom(TmpDir), '~w_~w', [Prefix, Stamp]),
+    make_directory_path(TmpDir).
+
+%% write_lmdb_seeder_source(+ProjectDir)
+%  Drops a small Scala main that uses lmdbjava DIRECTLY to populate a
+%  test LMDB env. Compiled alongside the generated WAM runtime so the
+%  same JVM classpath is used for both seed and read.
+write_lmdb_seeder_source(ProjectDir) :-
+    directory_file_path(ProjectDir,
+        'src/main/scala/generated/wam_scala_lmdb_smoke/core/LmdbSeeder.scala',
+        Path),
+    file_directory_name(Path, Dir),
+    make_directory_path(Dir),
+    SeederSrc = "package generated.wam_scala_lmdb_smoke.core\n\nimport java.io.File\nimport java.nio.ByteBuffer\nimport java.nio.charset.StandardCharsets\n\n// Standalone seeder - uses lmdbjava directly (no FactSource\n// indirection) to populate a small LMDB env with three known\n// (key, value) pairs. Run once before the WAM project queries.\nobject LmdbSeeder {\n  def main(args: Array[String]): Unit = {\n    val envPath = args(0)\n    val envDir = new File(envPath)\n    envDir.mkdirs()\n    val envClass = Class.forName(\"org.lmdbjava.Env\")\n    val builder = envClass.getMethod(\"create\").invoke(null)\n    // setMapSize(1L << 20) - 1 MiB, ample for three rows.\n    val setMapSize = builder.getClass.getMethod(\"setMapSize\", java.lang.Long.TYPE)\n    setMapSize.invoke(builder, java.lang.Long.valueOf(1L << 20))\n    val openMethod = builder.getClass.getMethod(\"open\", classOf[File])\n    val env = openMethod.invoke(builder, envDir)\n    val flagsClass = Class.forName(\"org.lmdbjava.DbiFlags\")\n    val mdbCreate = flagsClass.getField(\"MDB_CREATE\").get(null)\n    val flagArr = java.lang.reflect.Array.newInstance(flagsClass, 1)\n    java.lang.reflect.Array.set(flagArr, 0, mdbCreate)\n    val openDbi = envClass.getMethod(\"openDbi\", classOf[String], flagArr.getClass)\n    val dbi = openDbi.invoke(env, \"\", flagArr)\n    val txnWrite = envClass.getMethod(\"txnWrite\")\n    val txn = txnWrite.invoke(env)\n    try {\n      val putMethod = dbi.getClass.getMethod(\"put\",\n        Class.forName(\"org.lmdbjava.Txn\"),\n        classOf[ByteBuffer], classOf[ByteBuffer])\n      def put(k: String, v: String): Unit = {\n        val kb = utf8(k); val vb = utf8(v)\n        putMethod.invoke(dbi, txn, kb, vb)\n      }\n      put(\"alpha\",   \"bravo\")\n      put(\"charlie\", \"delta\")\n      put(\"echo\",    \"foxtrot\")\n      val commit = txn.getClass.getMethod(\"commit\")\n      commit.invoke(txn)\n    } finally {\n      val close = txn.getClass.getMethod(\"close\")\n      close.invoke(txn)\n    }\n    val envClose = envClass.getMethod(\"close\")\n    envClose.invoke(env)\n  }\n  private def utf8(s: String): ByteBuffer = {\n    val bytes = s.getBytes(StandardCharsets.UTF_8)\n    val buf = ByteBuffer.allocateDirect(bytes.length)\n    buf.put(bytes)\n    buf.flip()\n    buf\n  }\n}\n",
+    setup_call_cleanup(
+        open(Path, write, Stream),
+        write(Stream, SeederSrc),
+        close(Stream)).
+
+%% compile_lmdb_project(+ProjectDir)
+%  Same shape as the regular smoke harness's compile_scala_project,
+%  but with lmdbjava JARs prepended to scalac's classpath.
+compile_lmdb_project(ProjectDir) :-
+    absolute_file_name(ProjectDir, AbsProjectDir),
+    directory_file_path(AbsProjectDir, 'classes', ClassDir),
+    make_directory_path(ClassDir),
+    find_scala_sources_lmdb(AbsProjectDir, Sources),
+    Sources \= [],
+    getenv('LMDBJAVA_CLASSPATH', LmdbCp),
+    process_create(path(scalac),
+                   ['-classpath', LmdbCp, '-d', ClassDir | Sources],
+                   [cwd(AbsProjectDir),
+                    stdout(pipe(Out)), stderr(pipe(Err)),
+                    process(Pid)]),
+    read_string(Out, _, _OutStr),
+    read_string(Err, _, ErrStr),
+    close(Out),
+    close(Err),
+    process_wait(Pid, exit(ExitCode)),
+    (   ExitCode =:= 0
+    ->  true
+    ;   throw(error(scala_compile_failed(ExitCode, ErrStr), _))
+    ).
+
+find_scala_sources_lmdb(AbsProjectDir, Sources) :-
+    directory_file_path(AbsProjectDir, 'src', SrcDir),
+    findall(F,
+        ( directory_member(SrcDir, RelF,
+              [extensions([scala]), recursive(true)]),
+          directory_file_path(SrcDir, RelF, F)
+        ),
+        Sources).
+
+%% seed_lmdb_env(+ProjectDir, +EnvPath)
+%  Invokes the LmdbSeeder main against the temp env path. Must run
+%  AFTER compile but BEFORE the WAM main is queried, so the data is
+%  in place when LmdbFactSource opens the env.
+seed_lmdb_env(ProjectDir, EnvPath) :-
+    absolute_file_name(ProjectDir, AbsProjectDir),
+    directory_file_path(AbsProjectDir, 'classes', ClassDir),
+    getenv('LMDBJAVA_CLASSPATH', LmdbCp),
+    format(atom(FullCp), '~w:~w', [ClassDir, LmdbCp]),
+    process_create(path(scala),
+                   ['-classpath', FullCp,
+                    'generated.wam_scala_lmdb_smoke.core.LmdbSeeder',
+                    EnvPath],
+                   [cwd(AbsProjectDir),
+                    stdout(pipe(Out)), stderr(pipe(Err)),
+                    process(Pid)]),
+    read_string(Out, _, _OutStr),
+    read_string(Err, _, ErrStr),
+    close(Out),
+    close(Err),
+    process_wait(Pid, exit(ExitCode)),
+    (   ExitCode =:= 0
+    ->  true
+    ;   throw(error(lmdb_seed_failed(ExitCode, ErrStr), _))
+    ).
+
+%% verify_lmdb(+ProjectDir, +PredKey, +Args, +Expected)
+%  Same as verify_scala_args from the regular smoke harness, but
+%  with lmdbjava JARs on the runtime classpath so LmdbFactSource can
+%  resolve its lmdbjava classes via Class.forName.
+verify_lmdb(ProjectDir, PredKey, Args, Expected) :-
+    absolute_file_name(ProjectDir, AbsProjectDir),
+    directory_file_path(AbsProjectDir, 'classes', ClassDir),
+    atom_string(PredKey, PredStr),
+    maplist([A, S]>>atom_string(A, S), Args, ArgStrs),
+    getenv('LMDBJAVA_CLASSPATH', LmdbCp),
+    format(atom(FullCp), '~w:~w', [ClassDir, LmdbCp]),
+    append(['-classpath', FullCp,
+            'generated.wam_scala_lmdb_smoke.core.GeneratedProgram',
+            PredStr], ArgStrs, ProcArgs),
+    process_create(path(scala), ProcArgs,
+                   [cwd(AbsProjectDir),
+                    stdout(pipe(Out)), stderr(pipe(Err)),
+                    process(Pid)]),
+    read_string(Out, _, OutStr0),
+    read_string(Err, _, ErrStr),
+    close(Out),
+    close(Err),
+    process_wait(Pid, exit(ExitCode)),
+    normalize_space(string(Actual), OutStr0),
+    (   ExitCode =:= 0,
+        Actual == Expected
+    ->  true
+    ;   throw(error(lmdb_run_failed(ExitCode, PredKey, Args,
+                                     Expected, Actual, ErrStr), _))
+    ).


### PR DESCRIPTION
## Summary

- Add an opt-in Scala LMDB runtime smoke that generates a WAM Scala project with an `lmdb(...)` FactSource, seeds a temporary LMDB env through lmdbjava, and verifies true/false queries through the generated executable.
- Add `lmdb` as an effective-distance benchmark data mode for Scala, using `WAM_SCALA_LMDB_ENV` or `<output-dir>/data/lmdb`.
- Document the Scala/Haskell/Elixir LMDB benchmark recipe and caveats around cross-target key encoding differences.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_scala_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_scala_effective_distance_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_scala_lmdb_runtime_smoke.pl` (default-gated; requires `SCALA_LMDB_TESTS=1` and `LMDBJAVA_CLASSPATH` to exercise lmdbjava end-to-end)
