### PR TITLE
perf(wam-elixir): rewrite CategoryAncestor.collect/6 hot path; fix off-by-one

### DIFF
--- a/benchmarks/wam_effective_distance_cross_target.md
+++ b/benchmarks/wam_effective_distance_cross_target.md
@@ -24,8 +24,8 @@ as the single root category.
 | --- | ---: | ---: | ---: |
 | dev | 198 | 31 | 19 |
 | 300 | 6,008 | 232 | 271 |
-| 1k | 6,943 | 549 | 621 |
-| 10k | (large) | (large) | 5,193 |
+| 1k | 6,943 | 549 | 580 |
+| 10k | (large) | (large) | 5,192 |
 
 ## Results
 
@@ -33,23 +33,56 @@ Wall-clock for the full pipeline (read TSVs, compute all
 `(article, root, distance)` rows, output). Single-machine, 4-vCPU
 Intel Xeon @ 2.10 GHz.
 
-| Scale | Prolog (SWI, direct) | Rust (WAM + FFI kernel) | Elixir (kernel-dispatched) |
-| ---: | ---: | ---: | ---: |
-| dev (~200 edges) | 20 ms | 3 ms | 4 ms (kernel only)¹ |
-| 300 (~6k edges) | 111 ms | 23 ms | 667 ms |
-| 1k (~7k edges) | 115 ms | 28 ms | 4,977 ms |
-| 10k | 567 ms | 177 ms | 61,541 ms |
+| Scale | Prolog (SWI, direct) | Rust (WAM + FFI kernel) | Elixir kernel (pre-fix)² | Elixir kernel (patched)² |
+| ---: | ---: | ---: | ---: | ---: |
+| dev (~200 edges) | 20 ms | 3 ms | 4 ms¹ | **2 ms¹** |
+| 300 (~6k edges) | 111 ms | 23 ms | 680 ms | **213 ms** |
+| 1k (~7k edges) | 115 ms | 28 ms | 5,078 ms | **886 ms** |
+| 10k | 567 ms | 177 ms | 60,710 ms | **9,806 ms** |
 
 ¹ Elixir timings exclude script startup; Prolog timings include
 SWI startup (~10 ms); Rust includes binary startup (~1 ms). At dev
 scale the startup dominates; at larger scales the work dominates.
 
-**Output cross-validation**: at dev scale all three targets produce
-identical effective_distance values (e.g.
-`Bose-Einstein_statistics → Physics → 0.999179`). Confirms the
-Elixir CategoryAncestor kernel (PR #1803) faithfully implements
-the same path-enumeration semantics as Rust's
-`collect_native_category_ancestor_hops`.
+² Pre-fix and patched columns measured on the same hardware. The
+patched kernel ships in this PR.
+
+**Patched kernel changes** — see `WamRuntime.GraphKernel.CategoryAncestor.collect/7`
+in `src/unifyweaver/targets/wam_elixir_target.pl`:
+
+1. Pass an integer `depth` through the recursion and push `depth + 1`
+   directly when a direct edge to root is found. Eliminates the
+   post-recursion `length(ac)` + `length(rec_acc)` + `Enum.split` +
+   `Enum.map(&(&1+1))` + `++` pattern that was ~28% of runtime.
+2. Fuse the direct-edge `Enum.any?` check into the same `Enum.reduce`
+   that recurses, so neighbors are scanned once per step instead of twice.
+3. Skip recursion through `to == root` — those subtrees can't add new
+   entries (the next step would have `root in visited` blocking every
+   downstream direct-edge hit).
+4. Bound semantics fix: align with Rust's reference implementation
+   (`visited.len() >= max_depth` with `[cat]` seed). The previous Elixir
+   kernel started with `visited = []` AND used `length(visited) >= max_depth`,
+   which allowed one extra level of direct check vs Rust and over-counted
+   paths by ~7% near the depth boundary on Wikipedia category data
+   (e.g., 621 rows at scale-1k vs 580 in Rust/Prolog/`reference_output.tsv`).
+   The fix uses `next_depth < max_depth`, restoring exact agreement.
+
+**Output cross-validation**: at every scale (dev/300/1k/10k) the
+patched kernel produces identical row counts AND identical
+effective_distance values (max delta < 1e-4) to
+`data/benchmark/*/reference_output.tsv` and to Rust's output. The
+specific value `Bose-Einstein_statistics → Physics → 0.999179`
+matches across Rust, Prolog, and patched Elixir at dev. The off-by-one
+correctness bug was masked at dev (no paths hit the boundary) and
+only became visible at scale.
+
+The eprof profile of the patched kernel at scale=300 shows the new
+hot path: `Enum.member?`/`lists:member` (visited-list scan) at ~31%,
+`ets:lookup` at ~13%, recursion-body lambda at ~12%, `Enum.reduce`
+machinery at ~18%. Member-check dominates because the visited list
+holds binary strings; switching to a `MapSet` doesn't help at
+max_depth=10 (lists win on short-N membership). String→integer
+interning at FactSource load time would help but is a larger refactor.
 
 ## Reading the gap
 
@@ -63,11 +96,14 @@ the same path-enumeration semantics as Rust's
   the Elixir kernel uses. Path enumeration multiplies the per-step
   cost by `O(num_simple_paths)`, so the constant-factor difference
   blows up.
-- **Elixir kernel scales poorly on path-enumeration**. It IS the
-  faithful path-enumeration semantics — same algorithm Rust uses —
-  but BEAM-interpreted recursion with per-call list copies for the
-  visited list is much slower than either Prolog's WAM or Rust's
-  native code on the same algorithm.
+- **Elixir kernel scales poorly on path-enumeration**. Even after
+  the patched-kernel cleanup (5-6× wins from removing per-step
+  `length/1`/`Enum.split`/`++`), BEAM-interpreted recursion with
+  per-call list copies for the visited list and per-step
+  `Enum.member?` over binary strings is much slower than either
+  Prolog's WAM or Rust's native code on the same algorithm. The
+  patched kernel narrows the gap (~50× over Rust at 10k vs ~350×
+  pre-fix), but it's still BEAM-interpreted vs native.
 
 ## Why the kernel still matters for Elixir
 
@@ -77,8 +113,10 @@ measured kernel-Elixir vs **WAM-Elixir-emitted** `tc/2` and got
 implementations**, which is a different yardstick:
 
 - vs WAM-Elixir-emitted: kernel ≈ 1000× faster (chain graph, n=1000)
-- vs Prolog-direct: kernel ≈ 0.01× as fast (effective_distance, 1k+ nodes)
-- vs Rust-native-kernel: kernel ≈ 0.005× as fast (10k)
+- vs Prolog-direct: patched kernel ≈ 0.06× as fast (effective_distance, 1k)
+  — was ≈ 0.01× pre-fix
+- vs Rust-native-kernel: patched kernel ≈ 0.018× as fast (10k)
+  — was ≈ 0.003× pre-fix
 
 Useful framing: the kernel makes the BEAM-deployed Elixir version
 competitive with itself, not with native targets. For applications
@@ -155,13 +193,19 @@ NIF layer (Rustler-backed kernels) or accepting the JIT penalty
 relative to Rust.
 
 What the kernel DOES achieve:
-1. Correct path-enumeration semantics (cross-validated vs Rust).
+1. Correct path-enumeration semantics (cross-validated vs Rust at
+   every scale; the patched kernel matches `reference_output.tsv` to
+   < 1e-4 absolute on every (article, root) pair, fixing a previous
+   off-by-one at the depth boundary).
 2. Compositional with FactSource adaptors (ETS today, LMDB once
    `:elmdb` is installable).
 3. Massive speedup over WAM-emitted recursive Prolog (982× at N=1000
    on chain graph).
 4. Pattern-recognition auto-routing: user writes the canonical
    shape, the kernel fires.
+5. Constant-factor cleanup: 5-6× over the original kernel by
+   eliminating `length/1`/`Enum.split`/`++` from the recursion hot
+   path and fusing the direct-edge check into the recursion reduce.
 
 For BEAM-targeted deployments at scale, the next perf lever is
 likely **NIF-backed kernels** (Rustler or Zigler) — port the same

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -2334,45 +2334,50 @@ defmodule WamRuntime.GraphKernel.CategoryAncestor do
   """
   def collect_hops(neighbors_fn, cat, root, max_depth)
       when is_function(neighbors_fn, 1) and is_integer(max_depth) do
-    collect(neighbors_fn, cat, root, [], max_depth, [])
+    collect(neighbors_fn, cat, root, [], max_depth, [], 0)
     |> Enum.reverse()
   end
 
-  defp collect(neighbors_fn, cat, root, visited, max_depth, acc) do
-    # Direct edge check: only count if root not already on path.
+  # `depth` is the number of edges already taken to reach `cat`; pushed hop
+  # counts are `depth + 1` for any direct edge `cat -> root` we discover.
+  # That replaces the original post-recursion split/map/++ bump pattern
+  # (which spent ~~28% of runtime on length/1, Enum.split, and ++ at scale).
+  # The direct-edge check is also fused into the same reduce that recurses,
+  # so neighbors are scanned once per step instead of twice.
+  #
+  # Bound semantics: matches the Rust reference impl
+  # `collect_native_category_ancestor_hops` in wam_rust_target.pl. Rust seeds
+  # `visited` with `[cat]` and stops recursing when `visited.len() >= max_depth`,
+  # giving max top-level hop count = max_depth. Here `visited` is seeded with
+  # `[]`, so the equivalent gate is `next_depth < max_depth` (the deepest
+  # direct-edge check still pushes `next_depth = max_depth`). The earlier
+  # Elixir kernel started with `visited = []` AND used `length(visited) >= max_depth`,
+  # which allowed one extra level of direct check vs Rust and over-counted
+  # paths near the depth boundary by ~~7% on Wikipedia category data.
+  defp collect(neighbors_fn, cat, root, visited, max_depth, acc, depth) do
     edges_at_cat = neighbors_fn.(cat)
-    acc1 =
-      if root in visited do
-        acc
-      else
-        if Enum.any?(edges_at_cat, fn {_from, to} -> to == root end) do
-          [1 | acc]
-        else
-          acc
-        end
-      end
+    next_depth = depth + 1
+    root_blocked? = root in visited
+    can_recurse? = next_depth < max_depth
 
-    # Depth bound: stop recursing if visited length already at max.
-    if length(visited) >= max_depth do
-      acc1
-    else
-      # Recurse through each unvisited parent; increment hop counts
-      # added by the recursion. Mirrors the Rust kernels approach
-      # of bumping `out` entries after the recursive call returns.
-      Enum.reduce(edges_at_cat, acc1, fn {_from, parent}, ac ->
-        if parent in visited do
+    Enum.reduce(edges_at_cat, acc, fn {_from, to}, ac ->
+      cond do
+        to == root ->
+          # Recursing through `root` itself contributes nothing: the next
+          # step would have `root in visited`, blocking every downstream
+          # direct-edge hit. Count the path here and stop.
+          if root_blocked?, do: ac, else: [next_depth | ac]
+
+        not can_recurse? ->
           ac
-        else
-          next_visited = [parent | visited]
-          before = length(ac)
-          rec_acc = collect(neighbors_fn, parent, root, next_visited, max_depth, ac)
-          # Add 1 to each newly-pushed hop count (the entries beyond
-          # `before`). Matches the Rust impl exactly.
-          {bumped_new, kept_old} = Enum.split(rec_acc, length(rec_acc) - before)
-          Enum.map(bumped_new, &(&1 + 1)) ++ kept_old
-        end
-      end)
-    end
+
+        to in visited ->
+          ac
+
+        true ->
+          collect(neighbors_fn, to, root, [to | visited], max_depth, ac, next_depth)
+      end
+    end)
   end
 
   @doc """


### PR DESCRIPTION
eprof on Wikipedia category data (scale=300) showed the previous kernel
spending ~28% of runtime on per-step `length(visited)`, `length(rec_acc)`,
`Enum.split`, `Enum.map(&(&1+1))`, and `++` to bump hop counts after each
recursive return — and an extra ~11% on a separate `Enum.any?` pass over
neighbors for the direct-edge check that the recursion immediately
re-scanned.

Rewrite passes an integer `depth` through the recursion and pushes
`depth + 1` directly when a direct edge to root is found, fuses the
direct-edge check into the same `Enum.reduce` that recurses, and skips
recursion through `to == root` (those subtrees can't contribute new
entries because root would be in the next visited list).

Same-hardware speedups on the cross-target effective_distance workload:
- dev:  3.8 ms → 1.7 ms (2.3x)
- 300:  680 ms → 213 ms (3.2x)
- 1k:   5.1 s  → 0.89 s (5.7x)
- 10k:  60.7 s → 9.8 s  (6.2x)

Also fixes a previously-undetected correctness bug at the depth
boundary: the old kernel seeded `visited = []` AND used
`length(visited) >= max_depth`, allowing one extra level of direct-edge
check vs Rust's reference impl (which seeds `[cat]` with the same
bound). On Wikipedia data this over-counted ~7% of paths near the
boundary (e.g., 621 vs 580 rows at scale-1k). The new bound
`next_depth < max_depth` matches Rust exactly. Patched output now
agrees with `data/benchmark/*/reference_output.tsv` row-for-row at
every scale, max float delta < 1e-4.

The fix was masked at dev scale (no paths land on the boundary there)
which is why the original cross-target benchmark validation passed.