### PR TITLE
perf(wam-elixir): bare-destinations API for CategoryAncestor; ~3x more

### DIFF
--- a/benchmarks/wam_effective_distance_cross_target.md
+++ b/benchmarks/wam_effective_distance_cross_target.md
@@ -33,21 +33,44 @@ Wall-clock for the full pipeline (read TSVs, compute all
 `(article, root, distance)` rows, output). Single-machine, 4-vCPU
 Intel Xeon @ 2.10 GHz.
 
-| Scale | Prolog (SWI, direct) | Rust (WAM + FFI kernel) | Elixir kernel (pre-fix)² | Elixir kernel (patched)² |
-| ---: | ---: | ---: | ---: | ---: |
-| dev (~200 edges) | 20 ms | 3 ms | 4 ms¹ | **2 ms¹** |
-| 300 (~6k edges) | 111 ms | 23 ms | 680 ms | **213 ms** |
-| 1k (~7k edges) | 115 ms | 28 ms | 5,078 ms | **886 ms** |
-| 10k | 567 ms | 177 ms | 60,710 ms | **9,806 ms** |
+| Scale | Prolog (SWI, direct) | Rust (WAM + FFI kernel) | Elixir kernel (original)² | Elixir + structural fix² | Elixir + bare-dests path³ |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| dev (~200 edges) | 20 ms | 3 ms | 4 ms¹ | 2 ms¹ | **0.5 ms¹** |
+| 300 (~6k edges) | 111 ms | 23 ms | 680 ms | 213 ms | **76 ms** |
+| 1k (~7k edges) | 115 ms | 28 ms | 5,078 ms | 886 ms | **258 ms** |
+| 10k | 567 ms | 177 ms | 60,710 ms | 9,806 ms | **3,089 ms** |
 
 ¹ Elixir timings exclude script startup; Prolog timings include
 SWI startup (~10 ms); Rust includes binary startup (~1 ms). At dev
 scale the startup dominates; at larger scales the work dominates.
 
-² Pre-fix and patched columns measured on the same hardware. The
-patched kernel ships in this PR.
+² All Elixir columns measured on the same hardware. "Original" is
+the kernel as initially shipped (PR #1799); "structural fix" is
+post-PR #1809 (collect/7 hot-path cleanup + bound semantics fix);
+"bare-dests path" is this PR.
 
-**Patched kernel changes** — see `WamRuntime.GraphKernel.CategoryAncestor.collect/7`
+³ The bare-dests column uses three composable wins (any one alone
+helps; together they compound to ~3× over the structural-fix kernel
+and ~16-20× over the original):
+- `collect_hops_with_dests/4` — new kernel API where `dests_fn`
+  returns bare destinations `[to1, to2, ...]` instead of
+  `{from, to}` tuples. Saves the per-neighbor tuple wrap+unwrap
+  that was ~22% of runtime under the neighbors_fn API.
+- Atom-interned keys at FactSource load time — atom-compare is
+  pointer-compare on BEAM (vs binary byte-compare). Cuts member-check
+  cost on the visited list by ~40%.
+- Direct `Map` (or `:persistent_term`) for the edge index instead of
+  `:ets.lookup` — eliminates ETS message-passing overhead per
+  neighbor query.
+
+The first is a kernel API change shipped here; the latter two are
+caller-side recommendations the bench harness now demonstrates. The
+existing `collect_hops/4` neighbors_fn API still works for callers
+that can't restructure (FactSource adaptors emitting tuples), and it
+also gained ~3-5% from a `:lists.member/2` substitution.
+
+**Structural-fix changes** (PR #1809) — see
+`WamRuntime.GraphKernel.CategoryAncestor.collect_n/7`
 in `src/unifyweaver/targets/wam_elixir_target.pl`:
 
 1. Pass an integer `depth` through the recursion and push `depth + 1`
@@ -67,6 +90,18 @@ in `src/unifyweaver/targets/wam_elixir_target.pl`:
    (e.g., 621 rows at scale-1k vs 580 in Rust/Prolog/`reference_output.tsv`).
    The fix uses `next_depth < max_depth`, restoring exact agreement.
 
+**Bare-dests path changes** (this PR):
+
+5. Add `collect_hops_with_dests/4` and `collect_d/7` — a parallel API
+   where `dests_fn` returns bare destinations. Profile-driven: at
+   scale-1k the previous neighbors_fn API spent ~19% of runtime on
+   `Enum.map` wrapping/unwrapping `{from, to}` tuples that the kernel
+   immediately discarded `from` from. The new path takes destinations
+   directly and the bench harness demonstrates the recipe.
+6. Replace `to in visited` with `:lists.member(to, visited)` directly,
+   skipping the `Enum.member?` protocol-dispatch overhead (~6-7% of
+   runtime at 1k-scale on top of the underlying `:lists.member` call).
+
 **Output cross-validation**: at every scale (dev/300/1k/10k) the
 patched kernel produces identical row counts AND identical
 effective_distance values (max delta < 1e-4) to
@@ -76,13 +111,15 @@ matches across Rust, Prolog, and patched Elixir at dev. The off-by-one
 correctness bug was masked at dev (no paths hit the boundary) and
 only became visible at scale.
 
-The eprof profile of the patched kernel at scale=300 shows the new
-hot path: `Enum.member?`/`lists:member` (visited-list scan) at ~31%,
-`ets:lookup` at ~13%, recursion-body lambda at ~12%, `Enum.reduce`
-machinery at ~18%. Member-check dominates because the visited list
-holds binary strings; switching to a `MapSet` doesn't help at
-max_depth=10 (lists win on short-N membership). String→integer
-interning at FactSource load time would help but is a larger refactor.
+eprof on the bare-dests + atoms + Map path at scale=1k shows the
+remaining hot path: `Enum.reduce/3` foldl machinery at ~22%,
+`:lists.member/2` (now without `Enum.member?` wrapper) at ~13%,
+`collect_d/7` recursion entry at ~17%, reduce-body lambda at ~14%,
+`Map.get/3` at ~6%. The kernel-side wins are largely exhausted —
+roughly 56% of runtime is now on the recursion + iteration loop
+itself. The next perf lever is BEAM-external: NIF-backed kernels
+(Rustler-bound port of `collect_native_category_ancestor_hops` from
+the Rust target).
 
 ## Reading the gap
 
@@ -96,14 +133,13 @@ interning at FactSource load time would help but is a larger refactor.
   the Elixir kernel uses. Path enumeration multiplies the per-step
   cost by `O(num_simple_paths)`, so the constant-factor difference
   blows up.
-- **Elixir kernel scales poorly on path-enumeration**. Even after
-  the patched-kernel cleanup (5-6× wins from removing per-step
-  `length/1`/`Enum.split`/`++`), BEAM-interpreted recursion with
-  per-call list copies for the visited list and per-step
-  `Enum.member?` over binary strings is much slower than either
-  Prolog's WAM or Rust's native code on the same algorithm. The
-  patched kernel narrows the gap (~50× over Rust at 10k vs ~350×
-  pre-fix), but it's still BEAM-interpreted vs native.
+- **Elixir kernel scales poorly on path-enumeration**. Stacking
+  the structural fix + bare-dests + atom interning + Map index
+  closes the gap from ~343× over Rust at 10k (original) to ~17×
+  (this PR). BEAM-interpreted recursion still loses to Rust's
+  native code on the same algorithm — final gap is dominated by
+  the recursion-and-reduce loop itself, not by member-check or
+  ETS overhead anymore.
 
 ## Why the kernel still matters for Elixir
 
@@ -113,10 +149,10 @@ measured kernel-Elixir vs **WAM-Elixir-emitted** `tc/2` and got
 implementations**, which is a different yardstick:
 
 - vs WAM-Elixir-emitted: kernel ≈ 1000× faster (chain graph, n=1000)
-- vs Prolog-direct: patched kernel ≈ 0.06× as fast (effective_distance, 1k)
-  — was ≈ 0.01× pre-fix
-- vs Rust-native-kernel: patched kernel ≈ 0.018× as fast (10k)
-  — was ≈ 0.003× pre-fix
+- vs Prolog-direct: bare-dests path ≈ 0.45× as fast (effective_distance, 1k)
+  — was ≈ 0.13× with structural-fix only, ≈ 0.02× original
+- vs Rust-native-kernel: bare-dests path ≈ 0.057× as fast (10k)
+  — was ≈ 0.018× with structural-fix only, ≈ 0.003× original
 
 Useful framing: the kernel makes the BEAM-deployed Elixir version
 competitive with itself, not with native targets. For applications
@@ -175,11 +211,17 @@ time swipl -q -g 'consult("examples/benchmark/effective_distance.pl"), \
                   findall(A-R-D, user:effective_distance(A,R,D), L), \
                   length(L, N), format("~w~n", [N]), halt'
 
-# Elixir kernel (TC + CategoryAncestor in WamRuntime; ETS-backed FactSource)
-# Generate any minimal Elixir project to get wam_runtime.ex emitted, then
-# write a driver script that loads TSVs into ETS and calls
-# WamRuntime.GraphKernel.CategoryAncestor.collect_hops per (article, root) pair.
-# (See benchmarks/wam_elixir_graph_kernels.md for the kernel API surface.)
+# Elixir kernel — bare-dests recipe (recommended fast path):
+# 1. Atom-intern category names at TSV-load time:
+#       intern = fn s -> String.to_atom(s) end
+# 2. Build a process-local Map of cat -> [parent_atoms] (no ETS):
+#       cp_map = ... |> Enum.reduce(%{}, fn ... -> Map.update(...) end)
+# 3. Use bare-destinations FactSource (returns a flat list, no tuples):
+#       dests_fn = fn n -> Map.get(cp_map, n, []) end
+# 4. Call WamRuntime.GraphKernel.CategoryAncestor.collect_hops_with_dests/4
+#    per (article_cat, root) pair.
+# Expect ~3x speedup vs the legacy collect_hops/4 + ETS path with binary
+# string keys. (See bench_dests.exs in PR #1810.)
 ```
 
 ## Conclusion + next steps
@@ -203,9 +245,12 @@ What the kernel DOES achieve:
    on chain graph).
 4. Pattern-recognition auto-routing: user writes the canonical
    shape, the kernel fires.
-5. Constant-factor cleanup: 5-6× over the original kernel by
-   eliminating `length/1`/`Enum.split`/`++` from the recursion hot
-   path and fusing the direct-edge check into the recursion reduce.
+5. Constant-factor cleanup: ~16-20× over the original kernel
+   stacking the structural fix (PR #1809 — eliminating
+   `length/1`/`Enum.split`/`++` and fusing the direct-edge check)
+   with the bare-destinations API path (PR #1810 — `collect_hops_with_dests/4`,
+   atom-interned keys, `Map`-backed FactSource, and `:lists.member/2`
+   subst). Final gap to Rust at 10k: ~17×, down from ~343×.
 
 For BEAM-targeted deployments at scale, the next perf lever is
 likely **NIF-backed kernels** (Rustler or Zigler) — port the same

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -2331,10 +2331,28 @@ defmodule WamRuntime.GraphKernel.CategoryAncestor do
   `neighbors_fn` is a 1-arity function: given a node, returns a list
   of `{from, to}` tuples (matching the FactSource.lookup_by_arg1
   contract). For each call, only `to` is read.
+
+  Performance note: the implementation pattern-matches `{_from, to}` per
+  neighbor. For workloads where the FactSource can return bare
+  destinations directly (no tuple wrapping), prefer
+  `collect_hops_with_dests/4` — at scale-1k+ on Wikipedia category data
+  it cuts ~~20-25% off the runtime by eliminating the per-neighbor
+  tuple construction.
   """
   def collect_hops(neighbors_fn, cat, root, max_depth)
       when is_function(neighbors_fn, 1) and is_integer(max_depth) do
-    collect(neighbors_fn, cat, root, [], max_depth, [], 0)
+    collect_n(neighbors_fn, cat, root, [], max_depth, [], 0)
+    |> Enum.reverse()
+  end
+
+  @doc """
+  Same semantics as `collect_hops/4` but `dests_fn` returns a bare list
+  of destination nodes (no `{from, to}` tuple wrapping). Use this when
+  the underlying FactSource can produce destinations directly.
+  """
+  def collect_hops_with_dests(dests_fn, cat, root, max_depth)
+      when is_function(dests_fn, 1) and is_integer(max_depth) do
+    collect_d(dests_fn, cat, root, [], max_depth, [], 0)
     |> Enum.reverse()
   end
 
@@ -2354,10 +2372,20 @@ defmodule WamRuntime.GraphKernel.CategoryAncestor do
   # Elixir kernel started with `visited = []` AND used `length(visited) >= max_depth`,
   # which allowed one extra level of direct check vs Rust and over-counted
   # paths near the depth boundary by ~~7% on Wikipedia category data.
-  defp collect(neighbors_fn, cat, root, visited, max_depth, acc, depth) do
+  #
+  # Two variants below — `_n` takes neighbors_fn returning {from, to} tuples
+  # (FactSource.lookup_by_arg1 contract), `_d` takes dests_fn returning bare
+  # destinations. Sharing one implementation via a normalise lambda costs
+  # ~~20% in measurement (closure dispatch per neighbor), so they are kept
+  # separate. Keep the bodies in sync.
+  # Use `:lists.member/2` directly instead of `to in visited` (which compiles
+  # to `Enum.member?` outside guards). Skips the Enum protocol dispatch — at
+  # scale-1k this is ~~6-7% of total runtime that goes to dispatch overhead
+  # before falling through to the same lists.member call.
+  defp collect_n(neighbors_fn, cat, root, visited, max_depth, acc, depth) do
     edges_at_cat = neighbors_fn.(cat)
     next_depth = depth + 1
-    root_blocked? = root in visited
+    root_blocked? = :lists.member(root, visited)
     can_recurse? = next_depth < max_depth
 
     Enum.reduce(edges_at_cat, acc, fn {_from, to}, ac ->
@@ -2371,11 +2399,34 @@ defmodule WamRuntime.GraphKernel.CategoryAncestor do
         not can_recurse? ->
           ac
 
-        to in visited ->
+        :lists.member(to, visited) ->
           ac
 
         true ->
-          collect(neighbors_fn, to, root, [to | visited], max_depth, ac, next_depth)
+          collect_n(neighbors_fn, to, root, [to | visited], max_depth, ac, next_depth)
+      end
+    end)
+  end
+
+  defp collect_d(dests_fn, cat, root, visited, max_depth, acc, depth) do
+    dests = dests_fn.(cat)
+    next_depth = depth + 1
+    root_blocked? = :lists.member(root, visited)
+    can_recurse? = next_depth < max_depth
+
+    Enum.reduce(dests, acc, fn to, ac ->
+      cond do
+        to == root ->
+          if root_blocked?, do: ac, else: [next_depth | ac]
+
+        not can_recurse? ->
+          ac
+
+        :lists.member(to, visited) ->
+          ac
+
+        true ->
+          collect_d(dests_fn, to, root, [to | visited], max_depth, ac, next_depth)
       end
     end)
   end


### PR DESCRIPTION
## Summary

Profile-driven follow-up to #1809. After the structural fix, eprof at scale=1k showed `Enum.member?` (visited-list scan, ~30%) and the neighbors_fn's per-neighbor tuple wrap+unwrap (`Enum.map`, ~19%) as the new dominant costs. Three composable wins, ~3x compounded.

## Changes

`src/unifyweaver/targets/wam_elixir_target.pl`:

1. **`collect_hops_with_dests/4` + `collect_d/7`** — parallel API where `dests_fn` returns bare destinations `[to1, to2, ...]` instead of `{from, to}` tuples. Sharing one impl via a normalise-lambda costs ~20% (closure dispatch per neighbor) so the two `collect_n` / `collect_d` defps are kept separate (~25 lines of near-duplicate; bodies tagged "keep in sync"). Existing `collect_hops/4` neighbors_fn API unchanged for FactSource adaptors emitting tuples.
2. **`:lists.member/2` directly** instead of `to in visited` — skips the `Enum.member?` protocol-dispatch overhead (~6-7% at 1k). Applies to both `collect_n/7` and `collect_d/7`.
3. **Caller-side recipe documented** — atom-intern category names at TSV-load time and use a process-local `Map` instead of `:ets.lookup`. Atom comparison is pointer-compare on BEAM (vs binary byte-compare); `Map.get` skips ETS message-passing per query.

## Numbers

Same hardware as #1809:

| Scale | structural-fix (#1809) | bare-dests + atoms + Map | ratio |
| ---: | ---: | ---: | ---: |
| dev | 1,664 μs | 531 μs | 3.13× |
| 300 | 213,000 μs | 76,000 μs | 2.80× |
| 1k | 886,470 μs | 258,000 μs | 3.44× |
| 10k | 9,805,747 μs | 3,089,000 μs | 3.17× |

Stacked over the original kernel (#1799), total improvement is ~16-20× at 10k. Gap to Rust at 10k: 343× → 17×.

The remaining hot path (eprof at 1k) is now `Enum.reduce` foldl (~22%) + `collect_d/7` recursion entry (~17%) + reduce-body lambda (~14%) — the iteration loop itself, not member-check or ETS. Further closing the gap likely needs NIFs (Rustler-bound port of the Rust kernel).

## Test plan

- [x] All 114 `tests/test_wam_elixir_target.pl` tests pass
- [x] Output cross-validated identical to prior kernel at 10k (0 diffs > 1e-6 on 5,192 rows)
- [x] Output matches `data/benchmark/*/reference_output.tsv` row-for-row at 300/1k/10k
- [x] Multi-run stability check at 1k and 10k (variance < 5%)

## Follow-up (separate PR)

Migrate the kernel-dispatch wrapper (`compile_category_ancestor_dispatch_module/5`) and FactSource adaptors (ETS, SQLite, TSV, LMDB) to the bare-dests path so the auto-routed dispatch — not just hand-written drivers — gets the win.

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_