### PR TITLE
emit(wam-elixir): kernel-dispatch wrapper uses fold-form in aggregate frames

### DIFF
--- a/benchmarks/wam_effective_distance_cross_target.md
+++ b/benchmarks/wam_effective_distance_cross_target.md
@@ -180,6 +180,50 @@ fold INTO the producer.
     `(article, root)` groups by `Map.update`. No per-pair list ever
     exists.
 
+**Emitter dispatch-fold integration** (this PR — first emitter-side
+step toward the producer-consumer fusion that Rust + Haskell get for
+free from monomorphisation / GHC deforestation). The kernel-dispatch
+wrapper that the WAM-Elixir target generates for kernel-recognised
+predicates (`compile_category_ancestor_dispatch_module/5`) used to
+build a hop list via `collect_hops/4` and then iterate it through
+`merge_into_aggregate` whenever the call site was inside an
+aggregate frame. The new path uses fold-form directly:
+
+12. Add `fold_hops/6` (tuple-input variant of `fold_hops_with_dests/6`)
+    that pairs with `collect_hops/4`. Same semantics as
+    `fold_hops_with_dests/6` but the neighbours come back as
+    `{from, to}` tuples — the contract `WamRuntime.FactSource.lookup_by_arg1`
+    returns and the kernel-dispatch wrapper sees. Implementation is
+    parallel `fold_n` / `fold_n_recurse` / `fold_n_leaf` mirroring
+    the existing `fold_d_*` walkers.
+13. Add `WamRuntime.aggregate_push_one/2` runtime helper. Same role
+    as `aggregate_collect/2` but takes the value directly instead of
+    reading from a register. Convention matches `aggregate_collect/2`
+    (prepend, O(1)) — the existing `Enum.reverse` in
+    `finalise_aggregate/4` restores encounter order.
+14. Modify the dispatch wrapper template: when
+    `in_forkable_aggregate_frame?(state)` is true, fold each hop
+    directly into the aggregate frame via
+    `fold_hops(neighbors_fn, ..., state, fn hop, st -> aggregate_push_one(st, hop) end)`.
+    No intermediate hop list is built. The non-aggregate (backtracking)
+    branch keeps `collect_hops/4` since it needs to bind individual
+    solutions into the hops register one at a time.
+
+**Scope of the dispatch-fold change.** Equivalent semantics to the
+legacy collect+merge path for `findall`, `bag`, `set`, `count`,
+`sum`, `max`, `min` aggregates whose value register IS the kernel's
+hop output — the most common shapes. **NOT yet handled**:
+transform-aware aggregates such as
+`aggregate_all(sum(W), (Goal, W is Hops ** -n), R)` from
+`effective_distance/3` — the wrapper does not see the `W is f(Hops)`
+arithmetic step, so it would push raw hops where `f(hops)` values
+are expected. Those queries currently bypass kernel dispatch and run
+on plain WAM bytecode; lifting them into fold-form requires the WAM
+IR pattern-recognition pass that compiles the per-solution
+arithmetic into a closure passed as `hop_fn`. That is the natural
+next emitter step — same architectural shape as this PR but with
+Prolog-arithmetic-to-Elixir compilation added.
+
 **Output cross-validation**: at every scale (dev/300/1k/10k) the
 patched kernel produces identical row counts AND identical
 effective_distance values (max delta < 1e-4) to

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -1481,6 +1481,33 @@ compile_aggregate_helpers_to_elixir(Code) :-
   end
 
   @doc """
+  Per-value aggregator entry point — same role as `aggregate_collect/2`
+  but takes the value directly instead of reading from a register.
+  Used by kernel-dispatch wrappers running in fold-form, where the
+  kernel emits each solution value via a callback instead of building
+  a list and calling `merge_into_aggregate/2`.
+
+  Convention matches `aggregate_collect/2`: prepend (O(1)); the final
+  `Enum.reverse` in `finalise_aggregate/4` restores encounter order.
+  This is *different* from `merge_into_aggregate/2`, which appends a
+  pre-built list. If the same kernel run uses both helpers in the
+  same call, ordering will be inconsistent — pick one path per call.
+  """
+  def aggregate_push_one(state, value) do
+    {updated_cps, _pushed} =
+      Enum.map_reduce(state.choice_points, false, fn cp, pushed ->
+        cond do
+          pushed -> {cp, pushed}
+          Map.has_key?(cp, :agg_type) ->
+            prior = Map.get(cp, :agg_accum, [])
+            {Map.put(cp, :agg_accum, [value | prior]), true}
+          true -> {cp, pushed}
+        end
+      end)
+    %{state | choice_points: updated_cps}
+  end
+
+  @doc """
   Tier-2 runtime cost probe — companion to the static forkMinCost
   gate. The static gate (par_wrap_segment/4) decides at codegen
   time whether a predicates worst-case clause body is heavy enough
@@ -2346,6 +2373,19 @@ defmodule WamRuntime.GraphKernel.CategoryAncestor do
   end
 
   @doc """
+  Tuple-input fold variant — same as `fold_hops_with_dests/6` but
+  pairs with `collect_hops/4` (neighbors_fn returning `{from, to}`
+  tuples instead of bare destinations). Used by the kernel-dispatch
+  wrapper that sits behind `WamRuntime.FactSource.lookup_by_arg1`,
+  whose contract returns tuples.
+  """
+  def fold_hops(neighbors_fn, cat, root, max_depth, init_acc, hop_fn)
+      when is_function(neighbors_fn, 1) and is_integer(max_depth)
+       and is_function(hop_fn, 2) do
+    fold_n(neighbors_fn, cat, root, [], max_depth, init_acc, 0, hop_fn)
+  end
+
+  @doc """
   Same semantics as `collect_hops/4` but `dests_fn` returns a bare list
   of destination nodes (no `{from, to}` tuple wrapping). Use this when
   the underlying FactSource can produce destinations directly.
@@ -2474,6 +2514,43 @@ defmodule WamRuntime.GraphKernel.CategoryAncestor do
   defp walk_n_leaf([{_from, to} | rest], root, nd, acc) do
     ac = if to == root, do: [nd | acc], else: acc
     walk_n_leaf(rest, root, nd, ac)
+  end
+
+  # Tuple-input fold walkers — same shape as fold_d/fold_d_recurse/fold_d_leaf
+  # but the input neighbor list is `[{from, to} | rest]` (FactSource
+  # `lookup_by_arg1` contract) so the from-side is unpacked at pattern-match
+  # time. Keep in sync with walk_n_recurse / walk_n_leaf and with the
+  # dests-side fold_d_* below.
+  defp fold_n(neighbors_fn, cat, root, visited, max_depth, acc, depth, hop_fn) do
+    next_depth = depth + 1
+    if next_depth < max_depth do
+      fold_n_recurse(neighbors_fn.(cat), neighbors_fn, root, visited, max_depth, next_depth, acc, hop_fn)
+    else
+      fold_n_leaf(neighbors_fn.(cat), root, next_depth, acc, hop_fn)
+    end
+  end
+
+  defp fold_n_recurse([], _, _, _, _, _, acc, _), do: acc
+  defp fold_n_recurse([{_from, to} | rest], nf, root, vis, mx, nd, acc, hop_fn) do
+    ac =
+      cond do
+        to == root -> hop_fn.(nd, acc)
+        :lists.member(to, vis) -> acc
+        true ->
+          new_nd = nd + 1
+          if new_nd < mx do
+            fold_n_recurse(nf.(to), nf, root, [to | vis], mx, new_nd, acc, hop_fn)
+          else
+            fold_n_leaf(nf.(to), root, new_nd, acc, hop_fn)
+          end
+      end
+    fold_n_recurse(rest, nf, root, vis, mx, nd, ac, hop_fn)
+  end
+
+  defp fold_n_leaf([], _, _, acc, _), do: acc
+  defp fold_n_leaf([{_from, to} | rest], root, nd, acc, hop_fn) do
+    ac = if to == root, do: hop_fn.(nd, acc), else: acc
+    fold_n_leaf(rest, root, nd, ac, hop_fn)
   end
 
   defp collect_d(dests_fn, cat, root, visited, max_depth, acc, depth) do
@@ -3013,14 +3090,29 @@ compile_category_ancestor_dispatch_module(ModuleName, Pred, EdgePred, MaxDepth, 
     neighbors_fn = fn node ->
       WamRuntime.FactSource.lookup_by_arg1(edge_handle, node, state)
     end
-    hops_list =
-      WamRuntime.GraphKernel.CategoryAncestor.collect_hops(
-        neighbors_fn, cat_val, root_val, @max_depth)
 
     if WamRuntime.in_forkable_aggregate_frame?(state) do
-      merged = WamRuntime.merge_into_aggregate(state, hops_list)
-      throw({:fail, merged})
+      # Fold-form path: stream each hop directly into the aggregate
+      # frame. Skips the intermediate hops list and the subsequent
+      # merge_into_aggregate iteration. Equivalent semantics to the
+      # legacy collect+merge path for findall/sum/count/max aggregates
+      # whose value register IS the kernel hop output. Transform-aware
+      # shapes — `aggregate_all(sum(W), (Goal, W is f(Hops)), R)` —
+      # are NOT yet handled here: the dispatch wrapper does not see
+      # `f`, so it would push raw hops where Hops^(-N) values are
+      # expected. Those queries currently bypass kernel dispatch and
+      # run on plain WAM; the follow-up emitter pass will recognise
+      # them at compile time.
+      new_state =
+        WamRuntime.GraphKernel.CategoryAncestor.fold_hops(
+          neighbors_fn, cat_val, root_val, @max_depth, state,
+          fn hop, st -> WamRuntime.aggregate_push_one(st, hop) end
+        )
+      throw({:fail, new_state})
     else
+      hops_list =
+        WamRuntime.GraphKernel.CategoryAncestor.collect_hops(
+          neighbors_fn, cat_val, root_val, @max_depth)
       case hops_list do
         [first | _] ->
           case bind_hops_reg(state, 3, first) do

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -849,6 +849,44 @@ test_kernel_dispatch_emits_category_ancestor_module :-
     ;   fail_test(Test, 'category_ancestor kernel dispatch module not emitted as expected')
     ).
 
+test_kernel_dispatch_uses_fold_form_in_aggregate_frame :-
+    Test = 'Kernel dispatch: category_ancestor wrapper uses fold_hops + aggregate_push_one when in aggregate frame',
+    setup_kernel_fixtures,
+    wam_target:compile_predicate_to_wam(user:kdca/4, [], CaWam),
+    write_wam_elixir_project([kdca/4-CaWam],
+        [module_name(probe), emit_mode(lowered),
+         intra_query_parallel(false),
+         kernel_dispatch(true), source_module(user)],
+        '/tmp/test_kernel_disp_ca_fold'),
+    read_file_to_string('/tmp/test_kernel_disp_ca_fold/lib/kdca.ex', S, []),
+    (   sub_string(S, _, _, _, "in_forkable_aggregate_frame?"),
+        sub_string(S, _, _, _, "fold_hops("),
+        sub_string(S, _, _, _, "aggregate_push_one(st, hop)"),
+        % Fall-through (backtracking) path still uses collect_hops.
+        sub_string(S, _, _, _, "collect_hops(")
+    ->  pass(Test)
+    ;   fail_test(Test, 'dispatch wrapper does not branch into fold-form for aggregate frames')
+    ).
+
+test_runtime_emits_fold_hops :-
+    Test = 'GraphKernel CategoryAncestor: runtime emits fold_hops + fold_hops_with_dests',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    (   sub_string(RuntimeCode, _, _, _, 'def fold_hops(neighbors_fn'),
+        sub_string(RuntimeCode, _, _, _, 'def fold_hops_with_dests(dests_fn'),
+        sub_string(RuntimeCode, _, _, _, 'defp fold_n_recurse('),
+        sub_string(RuntimeCode, _, _, _, 'defp fold_d_recurse(')
+    ->  pass(Test)
+    ;   fail_test(Test, 'fold_hops/6 (tuple variant) or its walkers missing from runtime')
+    ).
+
+test_runtime_emits_aggregate_push_one :-
+    Test = 'WamRuntime: runtime emits aggregate_push_one/2 helper',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    (   sub_string(RuntimeCode, _, _, _, 'def aggregate_push_one(state, value)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'aggregate_push_one/2 helper missing from runtime')
+    ).
+
 test_graph_kernel_tc_emitted_in_runtime :-
     Test = 'GraphKernel TC: runtime assembly emits WamRuntime.GraphKernel.TransitiveClosure',
     compile_wam_runtime_to_elixir([], RuntimeCode),
@@ -2013,6 +2051,9 @@ run_tests :-
     test_shared_detector_finds_category_ancestor,
     test_kernel_dispatch_emits_tc_module,
     test_kernel_dispatch_emits_category_ancestor_module,
+    test_kernel_dispatch_uses_fold_form_in_aggregate_frame,
+    test_runtime_emits_fold_hops,
+    test_runtime_emits_aggregate_push_one,
     test_graph_kernel_tc_emitted_in_runtime,
     test_graph_kernel_tc_uses_visited_tracking,
     test_graph_kernel_tc_factsource_bridge,


### PR DESCRIPTION
## Summary

First emitter-side step toward the producer-consumer fusion that #1812 delivered as a kernel API. The Prolog kernel-dispatch wrapper that the WAM-Elixir target generates for kernel-recognised predicates (today: `category_ancestor`) used to allocate a hop list via `collect_hops/4` and then iterate it through `merge_into_aggregate` whenever the call site was inside an aggregate frame. The new path uses fold-form directly — no intermediate list.

## Changes

`src/unifyweaver/targets/wam_elixir_target.pl`:

1. **`fold_hops/6`** — tuple-input fold variant of `fold_hops_with_dests/6`. Pairs with `collect_hops/4` (neighbours_fn returning `{from, to}` tuples — the `WamRuntime.FactSource.lookup_by_arg1` contract). Implementation is parallel `fold_n` / `fold_n_recurse` / `fold_n_leaf` mirroring the existing `fold_d_*` walkers. Now the dispatch wrapper can fold directly without stripping tuples in a closure.
2. **`WamRuntime.aggregate_push_one/2`** — per-value aggregator entry point. Same role as `aggregate_collect/2` but takes the value directly instead of reading from a register. Convention matches `aggregate_collect/2` (prepend, O(1)) — the existing `Enum.reverse` in `finalise_aggregate/4` restores encounter order.
3. **`compile_category_ancestor_dispatch_module/5` template change**: when `in_forkable_aggregate_frame?(state)` is true, emit `fold_hops(..., state, fn hop, st -> aggregate_push_one(st, hop) end)` instead of `collect_hops` + `merge_into_aggregate`. The non-aggregate (backtracking) branch keeps `collect_hops/4`.

## Scope

**Equivalent semantics** to the legacy path for `findall` / `bag` / `set` / `count` / `sum` / `max` / `min` aggregates whose value register IS the kernel's hop output.

**NOT yet handled**: transform-aware aggregates such as `aggregate_all(sum(W), (Goal, W is Hops ** -n), R)` from `effective_distance/3` — the wrapper does not see the `W is f(Hops)` arithmetic step, so it would push raw hops where `f(hops)` values are expected. Those queries currently bypass kernel dispatch and run on plain WAM bytecode; lifting them into fold-form needs the IR pattern-recognition pass that compiles the per-solution arithmetic into a closure passed as `hop_fn`. Same architectural shape as this PR plus arithmetic-to-Elixir compilation — **the natural next emitter step**.

## Tests

- 117 wam-elixir tests pass (114 prior + 3 new):
  - `test_kernel_dispatch_uses_fold_form_in_aggregate_frame`
  - `test_runtime_emits_fold_hops`
  - `test_runtime_emits_aggregate_push_one`
- Smoke test verifies `fold_hops/6` (tuple variant) sums match `collect_hops/4` + `Enum.sum` across 100 (cat, root) pairs at dev scale.
- Smoke test verifies `aggregate_push_one/2` prepends correctly to a fake aggregate frame.

## Note on benchmark numbers

Cross-target benchmark numbers do not move because the bench harness (`bench_fold.exs`) calls the kernel API directly and does not go through the dispatch wrapper — this PR is structural integration work for queries compiled through `wam_elixir_target` with `kernel_dispatch(true)`. To exercise the dispatch path end-to-end, a Prolog query like `aggregate_all(sum(H), category_ancestor(Cat, Root, H, [Cat]), S)` could be compiled and timed; that's a useful follow-up benchmark to add.

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_