### PR TITLE
perf(wam-elixir): fix dispatch-fold cp-walk regression with split_at_aggregate_cp/1

### DIFF
--- a/benchmarks/wam_effective_distance_cross_target.md
+++ b/benchmarks/wam_effective_distance_cross_target.md
@@ -203,11 +203,41 @@ aggregate frame. The new path uses fold-form directly:
     `finalise_aggregate/4` restores encounter order.
 14. Modify the dispatch wrapper template: when
     `in_forkable_aggregate_frame?(state)` is true, fold each hop
-    directly into the aggregate frame via
-    `fold_hops(neighbors_fn, ..., state, fn hop, st -> aggregate_push_one(st, hop) end)`.
-    No intermediate hop list is built. The non-aggregate (backtracking)
-    branch keeps `collect_hops/4` since it needs to bind individual
-    solutions into the hops register one at a time.
+    directly into the aggregate frame. No intermediate hop list is
+    built. The non-aggregate (backtracking) branch keeps
+    `collect_hops/4` since it needs to bind individual solutions into
+    the hops register one at a time.
+
+**Dispatch-fold regression fix** (this PR — measured by a fresh
+micro-bench that simulates the full aggregate-frame path through the
+runtime APIs at varying cp-stack depths). The first cut of the
+dispatch-fold integration used `aggregate_push_one/2` per hit, which
+walks `state.choice_points` to find the aggregate frame on every
+push. That made the per-kernel-call cost O(N×D) where the legacy
+collect+merge path was O(D + N) — a measurable regression at
+non-trivial cp-stack depth (D≥5). Numbers from
+`bench_dispatch.exs` at scale-300:
+
+| cp-stack depth | collect+merge (μs) | fold+push_one (μs) | fold+split (μs) |
+| ---: | ---: | ---: | ---: |
+| 0 | 63,041 | 68,898 | **61,083** |
+| 5 | 61,190 | 62,829 | **60,874** |
+| 20 | 62,029 | 80,314 | 67,530 |
+
+15. Add `WamRuntime.split_at_aggregate_cp/1` — one-pass cp-stack
+    walk that returns `{above_cps_in_order, agg_cp, below_cps}`.
+    Walks the cp list once instead of N times.
+16. Modify the dispatch wrapper to **extract the agg cp once via
+    `split_at_aggregate_cp/1`, fold against `agg_cp.agg_accum`
+    directly with `[hop | accum]`, then reassemble**
+    `state.choice_points` as `above ++ [updated_agg_cp | below]`.
+    Total cp work per kernel call is O(D) instead of O(N×D).
+    The fold itself stays the same; the closure no longer touches
+    the cp stack. At typical Prolog cp-stack depth (≤5) this matches
+    the legacy collect+merge path. (True O(1) would require a
+    structural separation of the active-aggregate-frames stack from
+    `choice_points`; BEAM has no equivalent of Go's compiled `switch`
+    jump table to provide constant-time dispatch for free.)
 
 **Scope of the dispatch-fold change.** Equivalent semantics to the
 legacy collect+merge path for `findall`, `bag`, `set`, `count`,

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -1492,6 +1492,13 @@ compile_aggregate_helpers_to_elixir(Code) :-
   This is *different* from `merge_into_aggregate/2`, which appends a
   pre-built list. If the same kernel run uses both helpers in the
   same call, ordering will be inconsistent — pick one path per call.
+
+  Cost note: each call walks `state.choice_points` to find the
+  aggregate frame (O(D) where D is the cp-stack depth). For folds
+  that emit many values per kernel call, prefer
+  `split_at_aggregate_cp/1` — extract the agg cp once, thread its
+  `:agg_accum` directly through the fold, reassemble at the end. The
+  dispatch wrapper does that.
   """
   def aggregate_push_one(state, value) do
     {updated_cps, _pushed} =
@@ -1505,6 +1512,32 @@ compile_aggregate_helpers_to_elixir(Code) :-
         end
       end)
     %{state | choice_points: updated_cps}
+  end
+
+  @doc """
+  One-pass cp-stack walk that extracts the topmost aggregate frame.
+  Returns `{above, agg_cp, below}` where `above` are the cps before
+  the aggregate frame (in original order) and `below` are the cps
+  after it. Returns `nil` if no aggregate frame is on the stack.
+
+  Use to amortise the cp-stack walk across many fold steps: walk once
+  to extract, fold against `agg_cp.agg_accum` directly (avoids one cp
+  walk per push), then reassemble via
+  `above ++ [updated_agg_cp | below]`. Without this, a fold that
+  emits N values into a stack of depth D would do O(N×D) cp walks via
+  `aggregate_push_one/2`; with it, the total cp work is O(D).
+  """
+  def split_at_aggregate_cp(state) do
+    split_at_aggregate_cp_loop(state.choice_points, [])
+  end
+
+  defp split_at_aggregate_cp_loop([], _above), do: nil
+  defp split_at_aggregate_cp_loop([cp | rest], above) do
+    if Map.has_key?(cp, :agg_type) do
+      {Enum.reverse(above), cp, rest}
+    else
+      split_at_aggregate_cp_loop(rest, [cp | above])
+    end
   end
 
   @doc """
@@ -3093,21 +3126,30 @@ compile_category_ancestor_dispatch_module(ModuleName, Pred, EdgePred, MaxDepth, 
 
     if WamRuntime.in_forkable_aggregate_frame?(state) do
       # Fold-form path: stream each hop directly into the aggregate
-      # frame. Skips the intermediate hops list and the subsequent
-      # merge_into_aggregate iteration. Equivalent semantics to the
-      # legacy collect+merge path for findall/sum/count/max aggregates
-      # whose value register IS the kernel hop output. Transform-aware
-      # shapes — `aggregate_all(sum(W), (Goal, W is f(Hops)), R)` —
-      # are NOT yet handled here: the dispatch wrapper does not see
-      # `f`, so it would push raw hops where Hops^(-N) values are
-      # expected. Those queries currently bypass kernel dispatch and
-      # run on plain WAM; the follow-up emitter pass will recognise
-      # them at compile time.
-      new_state =
+      # frames :agg_accum. Skips both the intermediate hops list AND
+      # the per-hit cp-stack walk that aggregate_push_one/2 would do —
+      # split_at_aggregate_cp/1 walks the cp stack ONCE and exposes
+      # :agg_accum, the fold prepends in O(1) per hit, and the
+      # reassembled state is thrown back up to finalise_aggregate.
+      # Total cp work is O(D) for the dispatch instead of O(N×D).
+      #
+      # Equivalent semantics to the legacy collect+merge path for
+      # findall/sum/count/max aggregates whose value register IS the
+      # kernel hop output. Transform-aware shapes —
+      # `aggregate_all(sum(W), (Goal, W is f(Hops)), R)` — are NOT
+      # yet handled: the dispatch wrapper does not see `f`, so it
+      # would push raw hops where f(Hops) values are expected. Those
+      # queries currently bypass kernel dispatch and run on plain
+      # WAM; the follow-up emitter pass will recognise them at
+      # compile time and compile the arithmetic into hop_fn.
+      {above, agg_cp, below} = WamRuntime.split_at_aggregate_cp(state)
+      new_accum =
         WamRuntime.GraphKernel.CategoryAncestor.fold_hops(
-          neighbors_fn, cat_val, root_val, @max_depth, state,
-          fn hop, st -> WamRuntime.aggregate_push_one(st, hop) end
+          neighbors_fn, cat_val, root_val, @max_depth, agg_cp.agg_accum,
+          fn hop, accum -> [hop | accum] end
         )
+      new_agg_cp = %{agg_cp | agg_accum: new_accum}
+      new_state = %{state | choice_points: above ++ [new_agg_cp | below]}
       throw({:fail, new_state})
     else
       hops_list =

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -850,7 +850,7 @@ test_kernel_dispatch_emits_category_ancestor_module :-
     ).
 
 test_kernel_dispatch_uses_fold_form_in_aggregate_frame :-
-    Test = 'Kernel dispatch: category_ancestor wrapper uses fold_hops + aggregate_push_one when in aggregate frame',
+    Test = 'Kernel dispatch: category_ancestor wrapper uses fold_hops + split_at_aggregate_cp when in aggregate frame',
     setup_kernel_fixtures,
     wam_target:compile_predicate_to_wam(user:kdca/4, [], CaWam),
     write_wam_elixir_project([kdca/4-CaWam],
@@ -861,7 +861,9 @@ test_kernel_dispatch_uses_fold_form_in_aggregate_frame :-
     read_file_to_string('/tmp/test_kernel_disp_ca_fold/lib/kdca.ex', S, []),
     (   sub_string(S, _, _, _, "in_forkable_aggregate_frame?"),
         sub_string(S, _, _, _, "fold_hops("),
-        sub_string(S, _, _, _, "aggregate_push_one(st, hop)"),
+        % Fix for PR #1813's per-hit cp-walk regression: extract the
+        % aggregate cp once and thread agg_accum directly through the fold.
+        sub_string(S, _, _, _, "split_at_aggregate_cp(state)"),
         % Fall-through (backtracking) path still uses collect_hops.
         sub_string(S, _, _, _, "collect_hops(")
     ->  pass(Test)
@@ -885,6 +887,14 @@ test_runtime_emits_aggregate_push_one :-
     (   sub_string(RuntimeCode, _, _, _, 'def aggregate_push_one(state, value)')
     ->  pass(Test)
     ;   fail_test(Test, 'aggregate_push_one/2 helper missing from runtime')
+    ).
+
+test_runtime_emits_split_at_aggregate_cp :-
+    Test = 'WamRuntime: runtime emits split_at_aggregate_cp/1 helper for one-pass cp-stack walk',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    (   sub_string(RuntimeCode, _, _, _, 'def split_at_aggregate_cp(state)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'split_at_aggregate_cp/1 helper missing from runtime')
     ).
 
 test_graph_kernel_tc_emitted_in_runtime :-
@@ -2054,6 +2064,7 @@ run_tests :-
     test_kernel_dispatch_uses_fold_form_in_aggregate_frame,
     test_runtime_emits_fold_hops,
     test_runtime_emits_aggregate_push_one,
+    test_runtime_emits_split_at_aggregate_cp,
     test_graph_kernel_tc_emitted_in_runtime,
     test_graph_kernel_tc_uses_visited_tracking,
     test_graph_kernel_tc_factsource_bridge,


### PR DESCRIPTION
## Summary

Option B from the prior session: write the dispatch-path benchmark we should have run BEFORE merging #1813. Result — **#1813's path was a 10-22% regression** at non-trivial cp-stack depth, not a win. This PR adds the bench, identifies the cause, and ships the fix.

## What the bench surfaced

`bench_dispatch.exs` simulates the full aggregate-frame path through the runtime APIs at varying cp-stack depths. Three paths compared at scale-300, all producing identical sums (`total=112344`):

| cp-stack depth | collect+merge (legacy) | fold+push_one (#1813) | fold+split (this PR) |
| ---: | ---: | ---: | ---: |
| 0 | 63,041 μs | 68,898 μs | **61,083 μs** |
| 5 | 61,190 μs | 62,829 μs | **60,874 μs** |
| 20 | 62,029 μs | 80,314 μs | 67,530 μs |

**Root cause**: `aggregate_push_one/2` walks `state.choice_points` looking for the agg cp on EVERY hit, so per-kernel-call cost is O(N×D) where the legacy `collect+merge` was O(D + N).

## Fix

Walk the cp stack ONCE in the dispatch wrapper, extract the agg cp, fold against its `agg_accum` directly, reassemble at the end. Per-call cp work drops from O(N×D) to O(D).

`src/unifyweaver/targets/wam_elixir_target.pl`:

1. **`WamRuntime.split_at_aggregate_cp/1`** — one-pass cp-stack walker returning `{above_cps_in_order, agg_cp, below_cps}` or `nil`. Single tail-recursive helper, no `Enum` overhead.
2. **Dispatch wrapper template** now does:
   ```elixir
   {above, agg_cp, below} = WamRuntime.split_at_aggregate_cp(state)
   new_accum = fold_hops(..., agg_cp.agg_accum, fn hop, accum -> [hop | accum] end)
   new_state = %{state | choice_points: above ++ [%{agg_cp | agg_accum: new_accum} | below]}
   ```
3. **`aggregate_push_one/2`** stays as a convenience helper for one-off pushes (tests, future kernels), with a docstring pointing fold-heavy callers at `split_at_aggregate_cp/1`.

## Why not true O(1)?

BEAM has no equivalent of Go's compiled `switch` jump table that would give us constant-time dispatch over the cp stack for free (the user's original prompt for this question). True O(1) would require structurally separating the active-aggregate-frames stack from `choice_points` — a small but non-trivial refactor of `push_aggregate_frame`/`finalise_aggregate`/backtrack interaction. Worth doing as a follow-up but not bundled here.

A background search confirmed that no current WAM target maintains a separate active-aggregates stack — all integrate into the main cp list. The split-and-thread approach in this PR is consistent with that.

## Test plan

- [x] 118 wam-elixir tests pass (114 prior + 4 in this series)
- [x] Updated `test_kernel_dispatch_uses_fold_form_in_aggregate_frame` to assert the new template uses `split_at_aggregate_cp`
- [x] Added `test_runtime_emits_split_at_aggregate_cp` for the new helper
- [x] Bench validation: sums match across all three paths (collect+merge, fold+push_one, fold+split) at every cp-stack depth — strict perf change, no semantic drift
- [x] Output across the kernel-direct cross-target benchmark unchanged (this PR only touches the dispatch path, which the bench harness doesn't exercise)

## Honest accounting

PR #1813 + this fix are at parity with the legacy collect+merge path at typical cp-stack depth (≤5), not a win. The structural fold-form story still holds — the producer-consumer fusion primitive (`fold_hops/6`) is the BEAM-native analogue of Rust iterator monomorphization and Haskell GHC deforestation, and the dispatch wrapper now uses it correctly. But the wall-clock improvement waits on either (a) the transform-aware emitter pass that handles `aggregate_all(sum(W), (Goal, W is f(H)), R)` shapes, (b) outer-loop parallelism via Tier-2 (BEAM's actual strength), or (c) NIF-backed kernels.

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_