### PR TITLE
feat(wam-clojure): lower atom builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -280,6 +280,10 @@ clojure_direct_builtin("fail/0", "0").
 clojure_direct_builtin("fail/0", 0).
 clojure_direct_builtin('fail/0', "0").
 clojure_direct_builtin('fail/0', 0).
+clojure_direct_builtin("atom/1", "1").
+clojure_direct_builtin("atom/1", 1).
+clojure_direct_builtin('atom/1', "1").
+clojure_direct_builtin('atom/1', 1).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
@@ -374,6 +378,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "fail/0" ; Op == 'fail/0'),
     !,
     format(atom(Expr), '(runtime/backtrack ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "atom/1" ; Op == 'atom/1'),
+    !,
+    format(atom(Expr),
+           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (runtime/atom-term? value) (runtime/advance ~w) (runtime/backtrack ~w)))',
+           [S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "!/0" ; Op == '!/0'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -805,6 +805,13 @@
           "fail/0"
           (backtrack state)
 
+          "atom/1"
+          (let [value (deref-value (:bindings state)
+                                   (or (reg-get-raw state "A1") ::unbound))]
+            (if (atom-term? value)
+              (advance state)
+              (backtrack state)))
+
           "!/0"
           (-> state
               (update :choice-points #(vec (take (:cut-bar state) %)))

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -108,6 +108,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, ':builtin-call')),
         assertion(sub_string(RuntimeCode, _, _, _, '"\\\\=/2"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"fail/0"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"atom/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-bindings [state bindings]')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -172,13 +172,15 @@ test(cut_builtin_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/succeed-state")
     )).
 
-test(unsupported_builtin_stays_runtime_mediated) :-
+test(simple_builtin_atom_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_atom/1:\nbuiltin_call atom/1, 1\nproceed\n",
         wam_clojure_lowerable(test_atom/1, WamCode, deterministic),
         lower_predicate_to_clojure(test_atom/1, WamCode, [], Code),
-        assertion(\+ has(Code, "builtin-call atom/1")),
-        has(Code, "state")
+        has(Code, "runtime/deref-value"),
+        has(Code, "runtime/atom-term?"),
+        has(Code, "runtime/advance"),
+        has(Code, "runtime/backtrack")
     )).
 
 test(env_framed_equality_reaches_direct_builtin_prefix) :-

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -38,6 +38,7 @@
 :- dynamic user:wam_hard_cut_outer_ok/1.
 :- dynamic user:wam_not_b/1.
 :- dynamic user:wam_fail_after_bind/1.
+:- dynamic user:wam_atom_guard/1.
 
 has(Code, Substr) :-
     once(sub_string(Code, _, _, _, Substr)).
@@ -78,6 +79,7 @@ user:wam_cut_helper(X) :- X = a, !, fail.
 user:wam_hard_cut_outer_ok(X) :- (user:wam_cut_helper(Y), X = Y ; X = b).
 user:wam_not_b(X) :- X \= b.
 user:wam_fail_after_bind(X) :- X = a, fail.
+user:wam_atom_guard(X) :- atom(X).
 
 :- initialization(main, main).
 
@@ -122,7 +124,8 @@ run_smoke :-
           user:wam_cut_helper/1,
           user:wam_hard_cut_outer_ok/1,
           user:wam_not_b/1,
-          user:wam_fail_after_bind/1
+          user:wam_fail_after_bind/1,
+          user:wam_atom_guard/1
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
@@ -141,6 +144,7 @@ run_smoke :-
     assert_lowered_cut_builtin_emitted(TmpDir),
     assert_lowered_not_unify_builtin_emitted(TmpDir),
     assert_lowered_fail_builtin_emitted(TmpDir),
+    assert_lowered_atom_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
@@ -198,6 +202,8 @@ run_smoke :-
     verify_output(TmpDir, 'wam_not_b/1', b, "false"),
     verify_output(TmpDir, 'wam_fail_after_bind/1', a, "false"),
     verify_output(TmpDir, 'wam_fail_after_bind/1', b, "false"),
+    verify_output(TmpDir, 'wam_atom_guard/1', a, "true"),
+    verify_output(TmpDir, 'wam_atom_guard/1', 'f(a)', "false"),
     delete_directory_and_contents(TmpDir),
     writeln('wam_clojure_runtime_smoke: ok').
 
@@ -257,6 +263,12 @@ assert_lowered_fail_builtin_emitted(ProjectDir) :-
     read_file_to_string(CorePath, CoreCode, []),
     has(CoreCode, "defn lowered-wam-fail-after-bind-1"),
     has(CoreCode, "runtime/backtrack").
+
+assert_lowered_atom_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-atom-guard-1"),
+    has(CoreCode, "runtime/atom-term?").
 
 assert_multiclause_wrappers_runtime_mediated(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM runtime support for `builtin_call atom/1`.
- Adds direct lowered-prefix support for deterministic `atom/1` builtin calls.
- Uses the existing interned atom representation via `runtime/atom-term?`.
- Adds generator, lowered-emitter, and runtime smoke coverage for atom guard behavior.

## Why

The Clojure hybrid WAM target already lowers several deterministic builtins directly. `atom/1` is a low-risk type-test builtin because query inputs and constants are normalized into the runtime's interned atom representation.

This reduces interpreter fallback for deterministic guard predicates while preserving runtime semantics by dereferencing the argument before applying `atom-term?`.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
