### PR TITLE
feat(wam-elixir): LmdbIntIds FactSource stub + design proposal; doc fix

### DIFF
--- a/benchmarks/wam_effective_distance_cross_target.md
+++ b/benchmarks/wam_effective_distance_cross_target.md
@@ -107,10 +107,15 @@ Atom-Map and int-Map are within 10-15% of each other (atom-table
 hash precomputation gives atoms a small per-call edge that
 disappears as Map lookups dominate). Int-tuple wins ~2× over both
 because `elem(cp_tuple, id)` is O(1) without hashing — the
-contiguous integer IDs from a one-shot intern pass (or from an
-LMDB-backed FactSource that already keys nodes by integer ID, the
-shape the Haskell target uses) let us replace the HAMT with a flat
-indexed structure.
+contiguous integer IDs from a one-shot intern pass at TSV-load
+time let us replace the HAMT with a flat indexed structure.
+(Earlier versions of this doc claimed Haskell gets the same shape
+"for free" from LMDB — that's incorrect. Haskell maintains a
+compile-time atom-intern table; LMDB stores binary keys. The same
+holds for Scala. The
+`docs/proposals/wam_elixir_lmdb_int_id_factsource.md` proposal
+describes the LMDB-native design that would actually use storage
+record IDs as the interning key.)
 
 Why this matters beyond perf: BEAM's atom table is bounded
 (~1M default, shared with the rest of the VM). Production-scale
@@ -539,9 +544,11 @@ What the kernel DOES achieve:
    composition: `fold_hops_with_dests/6` is the BEAM analogue of
    Rust iterator monomorphization and Haskell GHC deforestation.
 7. Production-scale viability: integer-keyed FactSource path
-   matches the architecture the Haskell target uses (LMDB-derived
-   integer IDs as comparison keys). Scales to ~1M unique nodes
-   without atom-table cap concerns.
+   scales to ~1M unique nodes without atom-table cap concerns. The
+   LMDB-native design that would push interning into the storage
+   layer (rather than a separate codegen/runtime pass, as Haskell
+   and Scala do today) is captured in
+   `docs/proposals/wam_elixir_lmdb_int_id_factsource.md`.
 8. BEAM-native paradigm fit: outer-loop parallelism via
    `Task.async_stream` (with chunking) is the angle where BEAM is
    genuinely the right tool. The single-process kernel walk will

--- a/docs/WAM_TARGET_ROADMAP.md
+++ b/docs/WAM_TARGET_ROADMAP.md
@@ -212,10 +212,20 @@ In rough order of expected payoff:
    facts; Haskell and C# both have it shipping. This is the highest-
    value next step. Pattern to follow: Haskell's safe key/value API
    (the raw-pointer interface caused crashes — design doc note).
-   Bonus: LMDB-derived integer keys for free, matching the int-tuple
-   FactSource pattern (PR #1815) that turned out to be the single
-   biggest perf lever. The Haskell target uses LMDB IDs directly as
-   comparison keys; Elixir can do the same.
+
+   Note: an earlier version of this doc claimed Haskell uses LMDB's
+   storage IDs directly as the interning key. That's not what the
+   Haskell target actually does — it maintains a compile-time
+   `atom_intern_id` table (see `wam_haskell_target.pl` ~line 75) and
+   stores facts in LMDB with binary keys. Scala uses a runtime
+   `InternTable` per FactSource lookup. **Neither pushes interning
+   into LMDB itself.** The LMDB-native design — three sub-databases
+   (facts, key→id, id→key) within one env, with insert-time ID
+   assignment — is captured in
+   `docs/proposals/wam_elixir_lmdb_int_id_factsource.md` and a code
+   stub of `WamRuntime.FactSource.LmdbIntIds` is shipped alongside
+   it for emit-and-grep validation. Real runtime testing requires
+   `:elmdb`, which the sandbox cannot install.
 
 2. **Hot-path graph kernels.** Pick one or two graph operations
    (transitive closure, effective-distance) and emit them as Elixir

--- a/docs/proposals/wam_elixir_lmdb_int_id_factsource.md
+++ b/docs/proposals/wam_elixir_lmdb_int_id_factsource.md
@@ -1,0 +1,208 @@
+# WAM-Elixir LMDB int-id FactSource
+
+**Status**: design proposal + emit-and-grep code stub. Runtime
+validation deferred until `:elmdb` is installable.
+
+**Companion to**: PR #1792 (initial `WamRuntime.FactSource.Lmdb`
+adaptor) and PR #1815 (int-tuple FactSource pattern, the single
+largest perf lever in the cross-target benchmark sequence).
+
+## What this proposal addresses
+
+PR #1815 found that for the WAM-Elixir CategoryAncestor kernel,
+storing the FactSource as a tuple-as-array indexed by contiguous
+integer IDs is ~2× faster than an atom-keyed `Map` at 10k scale.
+The win came from `elem/2` being O(1) without hashing.
+
+That recipe assumed an upstream **interning pass** — at TSV-load
+time the bench harness builds a string→int map and then a tuple
+of dest-lists indexed by the int ID. The cross-target benchmark
+doc documents this as "the recommended scale-up recipe."
+
+But: at production scale (~1M unique categories — the full
+Wikipedia data) two things break:
+
+1. The intern pass + tuple build is in-memory only. No
+   persistence; restart the BEAM and you re-intern from scratch.
+2. The int-tuple holds the entire fact set in BEAM's heap.
+   For 1M categories with ~10M edges, that's ~160-1600 MB,
+   uncomfortable on small machines.
+
+LMDB is the existing answer to (2) for the other targets: a
+memory-mapped K/V store that lets the OS page hot data while keeping
+the cold majority on disk. The PR #1792 Elixir LMDB adaptor stores
+binary keys (UTF-8 category names) and binary values. That solves
+(2) but loses the integer-key win from PR #1815: every kernel
+neighbor lookup pays the binary-string `Map.get` hash cost.
+
+The earlier kernel docstring claimed Haskell already solved this by
+using LMDB record IDs directly as comparison keys. Investigation
+found that's **incorrect**. Haskell's intern table
+(`atom_intern_id/2`, `wam_haskell_target.pl` ~line 75) is built at
+codegen, the integer IDs come from emission order, and LMDB itself
+stores binary keys. Scala's `InternTable` runs at runtime per
+FactSource lookup. Neither pushes interning into the storage layer.
+The architecture this proposal describes is genuinely new for the
+LMDB-using targets.
+
+## Goal
+
+Produce an LMDB FactSource adaptor for WAM-Elixir that:
+
+- Stores facts as integer-id pairs (so neighbor lookups return
+  bare integers, ready for the int-tuple kernel path).
+- Persists the string↔id mapping in the same LMDB env, surviving
+  process restart.
+- Is consistent across multiple readers / cross-process (LMDB
+  is multi-reader-safe).
+- Scales to arbitrary fact-set size — only hot pages live in RAM,
+  cold pages stay on disk.
+- Reuses the safe Elmdb API surface that PR #1792's existing
+  `WamRuntime.FactSource.Lmdb` already targets.
+
+## Architecture
+
+Three LMDB sub-databases inside one env:
+
+| Sub-DB | Key | Value | Notes |
+|---|---|---|---|
+| `facts_dbi` | 8-byte BE u64 (arg1 id) | 8-byte BE u64 (arg2 id) | `MDB_DUPSORT` if a single arg1 maps to multiple arg2s. Both key and value are integer IDs. |
+| `key_to_id_dbi` | binary (UTF-8 string) | 8-byte BE u64 | Input translation: caller has a node name, gets the ID. Unique. |
+| `id_to_key_dbi` | 8-byte BE u64 | binary | Output translation: caller has an ID, wants the original string for display. Unique. |
+
+A sentinel key `"__next_id__"` in `id_to_key_dbi` (or in a separate
+metadata sub-DB) tracks the next unassigned ID. The ingestion
+routine reads it, assigns IDs sequentially, writes back.
+
+ID assignment is **insert-time** (driver responsibility). The
+ingestion routine takes raw `(arg1_str, arg2_str)` pairs and
+populates all three sub-databases consistently. This is more
+efficient than open-time enumeration because:
+
+- Open is now O(1) — just opening LMDB handles. No cursor walk to
+  rebuild the id map.
+- Ingestion already needs to walk the input data once anyway, so
+  building the maps adds no extra pass.
+
+For migration of an existing string-keyed LMDB (PR #1792's shape)
+to int-id form, a one-time `migrate_to_int_ids/1` helper would
+cursor-walk the existing fact DB and emit the three sub-DBs.
+
+## Public API surface
+
+```elixir
+defmodule WamRuntime.FactSource.LmdbIntIds do
+  @behaviour WamRuntime.FactSource
+
+  defstruct [:env, :facts_dbi, :key_to_id_dbi, :id_to_key_dbi, :arity, :dupsort]
+
+  # Open the FactSource against a pre-opened LMDB env + the three
+  # sub-DBs. Driver is responsible for creating the env and DBs and
+  # populating them via insert-time ID assignment.
+  @impl true
+  def open(spec, pred_arity, state)
+
+  # Returns [{key_id :: integer, value_id :: integer}, ...].
+  # The fast path — bypasses both string keys AND the existing
+  # PR #1792 `lookup_by_arg1` adapter. Pair this with the int-tuple
+  # kernel path: `dests_fn = fn id -> for {_, v_id} <- lookup_by_arg1_id(...), do: v_id end`.
+  def lookup_by_arg1_id(handle, key_id, state) when is_integer(key_id)
+
+  # Backwards-compatible binary-key entry. Translates key → id,
+  # delegates to lookup_by_arg1_id, translates value ids → strings
+  # on the way out. Two extra LMDB reads per lookup, useful for
+  # gradual migration but slower than the int-id path.
+  @impl true
+  def lookup_by_arg1(handle, key, state) when is_binary(key)
+
+  # Boundary translators. Caller usually invokes these once at the
+  # query boundary (input: parse user-supplied article name to id;
+  # output: format result ids back to display names).
+  def lookup_id(handle, key) :: integer | nil
+  def lookup_key(handle, id) :: binary | nil
+
+  # Cursor-walk all (key_id, value_id) pairs in facts_dbi.
+  @impl true
+  def stream_all(handle, state)
+
+  @impl true
+  def close(handle, state)
+end
+```
+
+The kernel-dispatch path uses `lookup_by_arg1_id`. The string-key
+entry exists only for callers that haven't migrated to int IDs yet.
+
+## Comparison with existing FactSource adapters
+
+| FactSource | Storage | Key type | Cap | Scale-up |
+|---|---|---|---|---|
+| `Tsv` | in-memory list-of-tuples | binary | RAM | not for production |
+| `Ets` | ETS bag | binary | RAM | up to ~RAM/2 |
+| `Sqlite` | sqlite3 file | binary | disk | scales but slow |
+| `Lmdb` (PR #1792) | LMDB env | binary | disk | scales, but pays binary-key cost on every kernel lookup |
+| **`LmdbIntIds`** | LMDB env (3 sub-DBs) | **integer** | disk | **scales AND keeps the PR #1815 int-tuple perf** |
+
+## What the code stub ships
+
+A new module `WamRuntime.FactSource.LmdbIntIds` emitted by
+`wam_elixir_target.pl` with:
+
+- The full public API surface above.
+- Bodies that call `Module.concat([Elmdb])` for the actual LMDB
+  primitives (`txn_get`, `ro_txn_cursor_get`, etc.) — same indirect
+  resolution pattern as the existing `Lmdb` adaptor, so the runtime
+  emits and compiles without `:elmdb` installed.
+- Big-endian 8-byte u64 encoding helpers (`encode_id/1`, `decode_id/1`)
+  for the integer-key marshalling.
+
+## What still needs runtime validation
+
+Without `:elmdb` we can't actually exercise:
+- The three-sub-DB ingestion path.
+- The cursor walk in `lookup_by_arg1_id` for `MDB_DUPSORT`.
+- The id↔key translation latency vs the binary-key adapter.
+- End-to-end perf parity with the in-memory int-tuple recipe.
+
+The emit-and-grep tests in
+`tests/test_wam_elixir_target.pl` validate the structural shape:
+the module emits, the API functions are present, the moduledoc
+documents the architecture. Same test discipline as PR #1792 used
+for the original Lmdb adaptor.
+
+## Open questions for runtime validation
+
+1. **Cost of integer encoding/decoding per lookup.** Each
+   `lookup_by_arg1_id` produces N `<<id::64-big-unsigned>>` decodes
+   for the value list. Maybe negligible, maybe dominant — only
+   measurement will tell.
+
+2. **Whether dupsort comparator order matches integer order.** LMDB
+   uses memcmp by default; for big-endian u64 that *should* match
+   integer order but we need to verify (especially for cursor-based
+   range scans).
+
+3. **Per-transaction vs per-call txn lifecycle.** The PR #1792
+   adapter opens a fresh ro_txn per `lookup_by_arg1` call. For the
+   kernel walk that does many lookups in tight succession, batching
+   into a single txn (e.g., a `with_txn/2` wrapper) could matter.
+
+4. **Whether LMDB's page cache + memcmp on 8-byte keys actually
+   matches the in-memory int-tuple `elem/2` win at scale.** This is
+   the big empirical question. The hypothesis is yes (memcmp on a
+   fixed-width 8-byte key + a B+tree lookup ≈ HAMT lookup, but with
+   disk-backing for free); the proof requires measurement.
+
+## Status
+
+- [x] Doc fix (the inaccurate "Haskell uses LMDB IDs" claim
+  removed from kernel docstring + benchmark doc + roadmap).
+- [x] Design proposal (this doc).
+- [x] Code stub: `WamRuntime.FactSource.LmdbIntIds` emitted by
+  `wam_elixir_target.pl`. Compiles, doesn't run without `:elmdb`.
+- [x] Emit-and-grep tests asserting the API surface emits.
+- [ ] `:elmdb`-backed integration test (requires Hex.pm reachability).
+- [ ] Cross-target benchmark with the int-id LMDB FactSource against
+  the in-memory int-tuple recipe (requires #6).
+- [ ] Migration helper: `migrate_to_int_ids/1` from existing
+  PR #1792 `Lmdb` env to `LmdbIntIds` env.

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -2287,6 +2287,212 @@ defmodule WamRuntime.FactSource.Lmdb do
   end
 end
 
+defmodule WamRuntime.FactSource.LmdbIntIds do
+  @moduledoc """
+  LMDB FactSource variant that exposes integer IDs end-to-end. Designed
+  for production-scale workloads (>50k unique nodes) where atom-interning
+  is not viable due to BEAMs atom-table cap (~~1M default), and where the
+  in-memory int-tuple FactSource recipe from PR #1815 wouldnt fit RAM
+  (~~1M categories at full Wikipedia scale).
+
+  See `docs/proposals/wam_elixir_lmdb_int_id_factsource.md` for the full
+  architecture rationale; this moduledoc is the API summary only.
+
+  Status: emit-and-grep stub. The function bodies are wired but runtime
+  validation requires `:elmdb` (not reachable from the sandbox where this
+  was developed). Same testing posture as PR #1792s original
+  `WamRuntime.FactSource.Lmdb`.
+
+  Architecture: three LMDB sub-databases inside one env.
+
+  | Sub-DB       | Key                       | Value                     | Notes                                  |
+  | ------------ | ------------------------- | ------------------------- | -------------------------------------- |
+  | facts_dbi    | 8-byte BE u64 (arg1 id)   | 8-byte BE u64 (arg2 id)   | MDB_DUPSORT for arg1 -> many arg2s.    |
+  | key_to_id    | binary (UTF-8 string)     | 8-byte BE u64             | Input translation (string -> id).      |
+  | id_to_key    | 8-byte BE u64             | binary                    | Output translation (id -> string).     |
+
+  ID assignment is INSERT-time (driver responsibility). Driver populates
+  all three sub-databases consistently when ingesting facts.
+
+  Driver responsibility (mirrors PR #1792s `Lmdb`):
+    1. Add `:elmdb` to mix deps. The module is referenced indirectly via
+       `Module.concat([Elmdb])` so this runtime emits without it.
+    2. Open the LMDB env, create the three sub-databases.
+    3. Ingest facts: for each `(arg1_str, arg2_str)` row, look up or
+       allocate the integer ID for each side and write to all three DBs.
+    4. Pass env + the three dbi handles to this adaptors `open/3`.
+
+  Pair this with the int-tuple kernel path: the dispatch wrappers
+  `dests_fn` reads ids directly from `lookup_by_arg1_id/3` and feeds them
+  to `WamRuntime.GraphKernel.CategoryAncestor.fold_hops_with_dests/6`.
+  No string interning at lookup time; the kernel sees integers throughout.
+  """
+  @behaviour WamRuntime.FactSource
+  defstruct [:env, :facts_dbi, :key_to_id_dbi, :id_to_key_dbi, :arity, :dupsort]
+
+  defp lmdb_module, do: Module.concat([Elmdb])
+
+  defp encode_id(id) when is_integer(id) and id >= 0, do: <<id::64-big-unsigned>>
+  defp decode_id(<<id::64-big-unsigned>>), do: id
+
+  @impl true
+  def open(%{env: env, facts_dbi: facts, key_to_id_dbi: k2i,
+             id_to_key_dbi: i2k, arity: arity} = spec, _pred_arity, _state)
+      when arity == 2 do
+    %__MODULE__{
+      env: env,
+      facts_dbi: facts,
+      key_to_id_dbi: k2i,
+      id_to_key_dbi: i2k,
+      arity: arity,
+      dupsort: Map.get(spec, :dupsort, true)
+    }
+  end
+
+  @doc """
+  Fast-path lookup. Returns `[{key_id, value_id}, ...]` where both
+  components are integers — no string translation. This is the API the
+  kernel-dispatch wrapper should call when the FactSource is int-id
+  backed.
+  """
+  def lookup_by_arg1_id(%__MODULE__{env: env, facts_dbi: dbi, dupsort: dupsort},
+                        key_id, _state) when is_integer(key_id) do
+    mod = lmdb_module()
+    bin_key = encode_id(key_id)
+    {:ok, txn} = apply(mod, :ro_txn_begin, [env])
+    try do
+      if dupsort do
+        {:ok, cur} = apply(mod, :ro_txn_cursor_open, [txn, dbi])
+        try do
+          collect_dupsort_ids(mod, cur, bin_key, key_id)
+        after
+          apply(mod, :ro_txn_cursor_close, [cur])
+        end
+      else
+        case apply(mod, :txn_get, [txn, dbi, bin_key]) do
+          {:ok, bin_val} -> [{key_id, decode_id(bin_val)}]
+          :not_found -> []
+          _ -> []
+        end
+      end
+    after
+      apply(mod, :ro_txn_commit, [txn])
+    end
+  end
+
+  @impl true
+  def lookup_by_arg1(%__MODULE__{} = handle, key, state) when is_binary(key) do
+    # Backwards-compatible binary-key entry. Translates key -> id,
+    # delegates to the int-id fast path, translates value ids -> binaries
+    # on the way out. Two extra LMDB reads per lookup vs the fast path —
+    # use lookup_by_arg1_id/3 directly when possible.
+    case lookup_id(handle, key) do
+      nil -> []
+      key_id ->
+        for {k_id, v_id} <- lookup_by_arg1_id(handle, key_id, state) do
+          {lookup_key(handle, k_id), lookup_key(handle, v_id)}
+        end
+    end
+  end
+
+  @doc """
+  Boundary translator: binary node name -> integer ID. Returns `nil` if
+  the key has no entry. Caller usually invokes this once at the input
+  boundary (parse user-supplied article name).
+  """
+  def lookup_id(%__MODULE__{env: env, key_to_id_dbi: dbi}, key) when is_binary(key) do
+    mod = lmdb_module()
+    {:ok, txn} = apply(mod, :ro_txn_begin, [env])
+    try do
+      case apply(mod, :txn_get, [txn, dbi, key]) do
+        {:ok, bin_id} -> decode_id(bin_id)
+        :not_found -> nil
+        _ -> nil
+      end
+    after
+      apply(mod, :ro_txn_commit, [txn])
+    end
+  end
+
+  @doc """
+  Boundary translator: integer ID -> binary node name. Returns `nil` if
+  the ID has no entry. Caller usually invokes this once at the output
+  boundary (format result IDs back to display names).
+  """
+  def lookup_key(%__MODULE__{env: env, id_to_key_dbi: dbi}, id) when is_integer(id) do
+    mod = lmdb_module()
+    bin_id = encode_id(id)
+    {:ok, txn} = apply(mod, :ro_txn_begin, [env])
+    try do
+      case apply(mod, :txn_get, [txn, dbi, bin_id]) do
+        {:ok, key} -> key
+        :not_found -> nil
+        _ -> nil
+      end
+    after
+      apply(mod, :ro_txn_commit, [txn])
+    end
+  end
+
+  @impl true
+  def stream_all(%__MODULE__{env: env, facts_dbi: dbi}, _state) do
+    mod = lmdb_module()
+    {:ok, txn} = apply(mod, :ro_txn_begin, [env])
+    try do
+      {:ok, cur} = apply(mod, :ro_txn_cursor_open, [txn, dbi])
+      try do
+        scan_int_pairs_all(mod, cur, [])
+      after
+        apply(mod, :ro_txn_cursor_close, [cur])
+      end
+    after
+      apply(mod, :ro_txn_commit, [txn])
+    end
+  end
+
+  @impl true
+  def close(%__MODULE__{env: _env}, _state) do
+    # Env lifecycle belongs to the driver — multiple FactSources may share
+    # one env. The driver calls env_close when its done with all of them.
+    :ok
+  end
+
+  defp collect_dupsort_ids(mod, cur, bin_key, key_id) do
+    case apply(mod, :ro_txn_cursor_get, [cur, :set, bin_key]) do
+      {:ok, ^bin_key, bin_v} ->
+        collect_dupsort_ids_next(mod, cur, bin_key, key_id,
+                                  [{key_id, decode_id(bin_v)}])
+      :not_found -> []
+      _ -> []
+    end
+  end
+
+  defp collect_dupsort_ids_next(mod, cur, bin_key, key_id, acc) do
+    case apply(mod, :ro_txn_cursor_get, [cur, :next_dup, nil]) do
+      {:ok, ^bin_key, bin_v} ->
+        collect_dupsort_ids_next(mod, cur, bin_key, key_id,
+                                  [{key_id, decode_id(bin_v)} | acc])
+      _ -> Enum.reverse(acc)
+    end
+  end
+
+  defp scan_int_pairs_all(mod, cur, acc) do
+    case apply(mod, :ro_txn_cursor_get, [cur, :first, nil]) do
+      {:ok, k, v} -> scan_int_pairs_next(mod, cur, [{decode_id(k), decode_id(v)} | acc])
+      :not_found -> Enum.reverse(acc)
+      _ -> Enum.reverse(acc)
+    end
+  end
+
+  defp scan_int_pairs_next(mod, cur, acc) do
+    case apply(mod, :ro_txn_cursor_get, [cur, :next, nil]) do
+      {:ok, k, v} -> scan_int_pairs_next(mod, cur, [{decode_id(k), decode_id(v)} | acc])
+      :not_found -> Enum.reverse(acc)
+      _ -> Enum.reverse(acc)
+    end
+  end
+end
+
 defmodule WamRuntime.GraphKernel.TransitiveClosure do
   @moduledoc """
   Native transitive-closure kernel — bypasses WAM dispatch for the
@@ -2405,8 +2611,12 @@ defmodule WamRuntime.GraphKernel.CategoryAncestor do
     `cat -> [parent_id, ...]` as a tuple of length N+1. `dests_fn` is
     `fn n -> elem(cp_tuple, n) end` — O(1) read, no hashing. About
     2x faster than atom-Map and 2.2x faster than int-Map at 10k.
-    Same architectural shape the Haskell target uses: LMDB-derived
-    integer IDs as the comparison key, no separate intern step.
+    Note: contrary to an earlier claim in this doc, no shipping
+    target currently uses LMDBs internal record positions as the
+    interning key — Haskell, Rust, and Scala all maintain a separate
+    string -> int table at codegen or runtime. See
+    docs/proposals/wam_elixir_lmdb_int_id_factsource.md for the
+    LMDB-native design that would actually achieve the integration.
   """
 
   @doc """

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -753,6 +753,69 @@ test_lmdb_adaptor_uses_indirect_module_resolution :-
     ;   fail_test(Test, 'LMDB adaptor has literal Elmdb references — will warn without dep')
     ).
 
+test_lmdb_int_ids_adaptor_emitted_in_runtime :-
+    % LmdbIntIds is the int-id-keyed sibling of FactSource.Lmdb,
+    % designed for production-scale workloads where atom-interning
+    % isn't viable (>50k unique nodes). Same emit-and-grep posture
+    % as the original Lmdb adaptor — runtime validation requires
+    % :elmdb which the sandbox can't install. See the design proposal
+    % at docs/proposals/wam_elixir_lmdb_int_id_factsource.md.
+    Test = 'LmdbIntIds adaptor: runtime emits FactSource.LmdbIntIds with three-sub-DB shape',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    (   sub_string(RuntimeCode, _, _, _, 'defmodule WamRuntime.FactSource.LmdbIntIds do'),
+        sub_string(RuntimeCode, _, _, _, '@behaviour WamRuntime.FactSource'),
+        % Three sub-DB handles in the struct: facts, key→id, id→key.
+        sub_string(RuntimeCode, _, _, _, ':facts_dbi'),
+        sub_string(RuntimeCode, _, _, _, ':key_to_id_dbi'),
+        sub_string(RuntimeCode, _, _, _, ':id_to_key_dbi'),
+        % Fast-path int-id API (the whole point of this adaptor).
+        sub_string(RuntimeCode, _, _, _, 'def lookup_by_arg1_id('),
+        % Boundary translators for input/output id↔string conversion.
+        sub_string(RuntimeCode, _, _, _, 'def lookup_id('),
+        sub_string(RuntimeCode, _, _, _, 'def lookup_key('),
+        % Backwards-compat binary-key entry (delegates to int-id path).
+        sub_string(RuntimeCode, _, _, _, 'def lookup_by_arg1(%__MODULE__'),
+        % 8-byte BE u64 id encoding (the on-disk wire format).
+        sub_string(RuntimeCode, _, _, _, '<<id::64-big-unsigned>>')
+    ->  pass(Test)
+    ;   fail_test(Test, 'LmdbIntIds adaptor missing expected structure')
+    ).
+
+test_lmdb_int_ids_adaptor_uses_indirect_module_resolution :-
+    Test = 'LmdbIntIds adaptor: uses Module.concat so runtime compiles without an LMDB binding dep',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    % Verify the LmdbIntIds-specific block (not the original Lmdb)
+    % uses the same indirect-resolution pattern. Pull out the
+    % LmdbIntIds module body and check it doesn't contain literal
+    % Elmdb.X calls.
+    Pattern = "defmodule WamRuntime.FactSource.LmdbIntIds do",
+    EndPattern = "defmodule WamRuntime.GraphKernel.TransitiveClosure do",
+    (   sub_string(RuntimeCode, Start, _, _, Pattern),
+        sub_string(RuntimeCode, End, _, _, EndPattern),
+        End > Start,
+        BodyLen is End - Start,
+        sub_string(RuntimeCode, Start, BodyLen, _, Body),
+        sub_string(Body, _, _, _, "Module.concat([Elmdb])"),
+        sub_string(Body, _, _, _, "apply(mod,"),
+        \+ sub_string(Body, _, _, _, "Elmdb.ro_txn_begin"),
+        \+ sub_string(Body, _, _, _, "Elmdb.txn_get(")
+    ->  pass(Test)
+    ;   fail_test(Test, 'LmdbIntIds adaptor has literal Elmdb references — will warn without dep')
+    ).
+
+test_lmdb_int_ids_design_proposal_referenced :-
+    % Doc-fix invariant: the kernel docstring no longer claims
+    % "Haskell uses LMDB IDs as interning". Instead it points at
+    % the proposal that describes the actual LMDB-native design.
+    Test = 'LmdbIntIds: kernel docstring points at the design proposal',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    (   sub_string(RuntimeCode, _, _, _, 'wam_elixir_lmdb_int_id_factsource.md'),
+        % Negative invariant: the old (false) claim is gone.
+        \+ sub_string(RuntimeCode, _, _, _, 'no separate intern step')
+    ->  pass(Test)
+    ;   fail_test(Test, 'kernel docstring still has the old LMDB-IDs claim or doesnt reference the proposal')
+    ).
+
 %% Atom-interning experiment (opt-in via intern_atoms(true) Option):
 %  identifier-shape constants emit as Elixir atom literals (`:foo`)
 %  instead of binaries (`"foo"`). BEAM atoms compare via pointer
@@ -906,7 +969,10 @@ test_kernel_docstring_documents_integer_id_path :-
     compile_wam_runtime_to_elixir([], RuntimeCode),
     (   sub_string(RuntimeCode, _, _, _, 'kernel is term-agnostic'),
         sub_string(RuntimeCode, _, _, _, 'Integers with tuple-as-array'),
-        sub_string(RuntimeCode, _, _, _, 'no separate intern step')
+        % After the int-id LMDB FactSource doc fix, the old "no separate
+        % intern step" claim was removed. The replacement points readers
+        % at the proposal doc that describes the LMDB-native design.
+        sub_string(RuntimeCode, _, _, _, 'wam_elixir_lmdb_int_id_factsource.md')
     ->  pass(Test)
     ;   fail_test(Test, 'CategoryAncestor moduledoc missing the integer-id scale-up note')
     ).
@@ -2071,6 +2137,9 @@ run_tests :-
     test_lmdb_adaptor_emitted_in_runtime,
     test_lmdb_adaptor_uses_indirect_module_resolution,
     test_lmdb_adaptor_targets_safe_keyvalue_api,
+    test_lmdb_int_ids_adaptor_emitted_in_runtime,
+    test_lmdb_int_ids_adaptor_uses_indirect_module_resolution,
+    test_lmdb_int_ids_design_proposal_referenced,
     test_shared_detector_finds_tc,
     test_shared_detector_finds_category_ancestor,
     test_kernel_dispatch_emits_tc_module,


### PR DESCRIPTION
## Summary

Your question — *"for the LMDB cases, do we use the database IDs for interning?"* — surfaced an inaccuracy in the kernel docstring shipped in PR #1815. The doc claimed Haskell uses LMDB record IDs directly as the comparison key, "no separate intern step." Investigation showed that's wrong: **every LMDB-using target** (Haskell, Scala, plus PR #1792's Elixir `Lmdb` adaptor) maintains a separate string→int interning table at codegen or runtime, and stores binary keys in LMDB.

This PR addresses the gap with three deliverables (full scope of option 3 from the prior message): doc fix + design proposal + emit-and-grep code stub.

## What this PR ships

### 1. Doc fix (three places)

- `wam_elixir_target.pl`: kernel `CategoryAncestor` moduledoc.
- `benchmarks/wam_effective_distance_cross_target.md`: footnote ⁶.
- `docs/WAM_TARGET_ROADMAP.md`: "Implications for Elixir's next work" item 1.

Each retraction points readers at the proposal doc for the LMDB-native architecture that *would* push interning into the storage layer.

### 2. Design proposal

`docs/proposals/wam_elixir_lmdb_int_id_factsource.md` covers:
- Three-sub-DB architecture (`facts_dbi`, `key_to_id_dbi`, `id_to_key_dbi`) inside one LMDB env.
- 8-byte BE u64 wire format for IDs.
- Insert-time ID assignment (driver responsibility).
- Public API surface.
- Comparison with existing FactSource adapters.
- Open questions for runtime validation (txn lifecycle, dupsort comparator order, perf parity with in-memory int-tuple).

### 3. `WamRuntime.FactSource.LmdbIntIds` module stub

Emitted by `wam_elixir_target.pl`. Same testing posture as PR #1792's original `Lmdb` adaptor: bodies wired through `Module.concat([Elmdb])` indirection so the runtime emits and compiles without `:elmdb` installed; **runtime validation deferred until Hex.pm is reachable.**

Public API:
- `lookup_by_arg1_id/3` — int-id fast path returning `[{key_id, value_id}, ...]` integers, no string translation.
- `lookup_by_arg1/3` — backwards-compat binary-key entry that delegates through the int-id path with id↔string boundary translation on either side.
- `lookup_id/2`, `lookup_key/2` — boundary translators for parsing user input / formatting display output.
- `stream_all/2` — cursor-walk all `(key_id, value_id)` pairs.

## Pairs with PR #1815's int-tuple kernel path

The dispatch wrapper's `dests_fn` closure reads ids directly from `lookup_by_arg1_id/3` and feeds them to `fold_hops_with_dests/6`. No interning at lookup time — the kernel sees integers throughout AND the fact data lives on disk via LMDB. Scales to ~1M unique nodes (full Wikipedia category data) without atom-table pressure or the in-memory tuple-as-array's RAM footprint.

## Test plan

- [x] **122 wam-elixir tests pass** (was 119; +3 new `LmdbIntIds` tests):
  - `test_lmdb_int_ids_adaptor_emitted_in_runtime` — struct fields, API surface, BE u64 encoding present.
  - `test_lmdb_int_ids_adaptor_uses_indirect_module_resolution` — no literal `Elmdb.X` calls in the LmdbIntIds block.
  - `test_lmdb_int_ids_design_proposal_referenced` — kernel docstring points at the proposal AND no longer contains the retracted "no separate intern step" claim.
- [x] One existing test (`test_kernel_docstring_documents_integer_id_path`) updated to match the new accurate phrasing.
- [ ] `:elmdb`-backed integration test — deferred until Hex.pm is reachable.
- [ ] Cross-target benchmark of the int-id LMDB FactSource against the in-memory int-tuple recipe — depends on the integration test.

## What this PR does NOT include

Per the proposal's status section:
- `:elmdb`-backed integration test (sandbox can't install Hex deps).
- Cross-target benchmark of int-id LMDB vs in-memory int-tuple.
- Migration helper from existing PR #1792 `Lmdb` env to `LmdbIntIds` env (would do an open-time cursor walk + sequential ID assignment for a one-time conversion of a string-keyed LMDB).

These are flagged in the proposal's Status checklist as open work.

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_