### PR TITLE
feat(wam-elixir): LmdbIntIds ingest + migration helpers

### DIFF
--- a/docs/proposals/wam_elixir_lmdb_int_id_factsource.md
+++ b/docs/proposals/wam_elixir_lmdb_int_id_factsource.md
@@ -196,13 +196,71 @@ for the original Lmdb adaptor.
 ## Status
 
 - [x] Doc fix (the inaccurate "Haskell uses LMDB IDs" claim
-  removed from kernel docstring + benchmark doc + roadmap).
-- [x] Design proposal (this doc).
+  removed from kernel docstring + benchmark doc + roadmap)
+  — PR #1819.
+- [x] Design proposal (this doc) — PR #1819.
 - [x] Code stub: `WamRuntime.FactSource.LmdbIntIds` emitted by
-  `wam_elixir_target.pl`. Compiles, doesn't run without `:elmdb`.
-- [x] Emit-and-grep tests asserting the API surface emits.
+  `wam_elixir_target.pl`. Compiles, doesn't run without `:elmdb`
+  — PR #1819.
+- [x] Emit-and-grep tests asserting the API surface emits — PR #1819.
+- [x] **Driver ingestion helper**: `ingest_pairs/3` populates all
+  three sub-databases consistently with insert-time ID assignment.
+  Idempotent for previously-seen strings. Returns `{:ok, %{pairs_seen,
+  new_ids, next_id}}` for batched ingestion. — this PR.
+- [x] **Migration helper**: `migrate_from_string_keyed/3` cursor-walks
+  an existing PR #1792 `Lmdb` env, batches into `ingest_pairs/3` calls,
+  populates the destination's three sub-databases with sequential
+  IDs in encounter order. — this PR.
 - [ ] `:elmdb`-backed integration test (requires Hex.pm reachability).
 - [ ] Cross-target benchmark with the int-id LMDB FactSource against
-  the in-memory int-tuple recipe (requires #6).
-- [ ] Migration helper: `migrate_to_int_ids/1` from existing
-  PR #1792 `Lmdb` env to `LmdbIntIds` env.
+  the in-memory int-tuple recipe (requires the integration test).
+- [ ] Mock-`Elmdb` end-to-end test that exercises the adaptor's logic
+  (id encoding/decoding, dupsort cursor walk, round-trip) without
+  requiring real `:elmdb`. ~300 lines of Elixir for a fake module
+  backed by an in-memory map; would catch the kinds of bugs
+  emit-and-grep can't (encoding off-by-ones, dupsort comparator
+  ordering, txn lifecycle). Deferred.
+
+## Driver-side recipe
+
+With the helpers shipped, a driver looks like:
+
+```elixir
+# 1. Open env + three sub-DBs (driver responsibility).
+{:ok, env} = :elmdb.env_open("/path/to/db.lmdb", maxdbs: 3, ...)
+{:ok, facts}    = :elmdb.db_open(env, "facts",    [:create, :dupsort])
+{:ok, k_to_id}  = :elmdb.db_open(env, "key_to_id",  [:create])
+{:ok, id_to_k}  = :elmdb.db_open(env, "id_to_key",  [:create])
+
+handle = WamRuntime.FactSource.LmdbIntIds.open(
+  %{env: env, facts_dbi: facts, key_to_id_dbi: k_to_id,
+    id_to_key_dbi: id_to_k, arity: 2, dupsort: true},
+  2, nil)
+
+# 2. Ingest data (insert-time ID assignment).
+{:ok, %{next_id: nid}} =
+  WamRuntime.FactSource.LmdbIntIds.ingest_pairs(
+    handle,
+    [{"alpha", "beta"}, {"alpha", "gamma"}, {"delta", "epsilon"}],
+    start_id: 0)
+
+# 3. Persist next_id somewhere (sentinel key, separate metadata DB,
+#    application config) for the next ingest batch.
+
+# 4. Register with the kernel-dispatch FactSourceRegistry.
+WamRuntime.FactSourceRegistry.register("category_parent/2", handle)
+
+# 5. Now the kernel sees integer IDs end-to-end:
+#    dispatch_wrapper.run/1 calls handle.lookup_by_arg1_id/3 which
+#    returns [{cat_id, parent_id}, ...] -- no atom-table pressure,
+#    no per-call hashing, fact data on disk via LMDB.
+```
+
+For migration from an existing PR #1792 string-keyed env:
+
+```elixir
+{:ok, %{pairs_migrated: n, ids_assigned: m}} =
+  WamRuntime.FactSource.LmdbIntIds.migrate_from_string_keyed(
+    old_string_handle, new_int_id_handle,
+    start_id: 0, batch_size: 10_000)
+```

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -2434,6 +2434,130 @@ defmodule WamRuntime.FactSource.LmdbIntIds do
     end
   end
 
+  @doc """
+  Driver-side ingestion helper. Populates all three sub-databases
+  consistently for a list of `{arg1_str, arg2_str}` pairs:
+
+  - `key_to_id_dbi`: assigns sequential integer IDs (starting at
+    `:start_id`, default 0) to each unique string in encounter order.
+  - `id_to_key_dbi`: reverse map, written atomically alongside.
+  - `facts_dbi`: writes the `(arg1_id, arg2_id)` pair as 8-byte BE
+    u64 keys/values.
+
+  Idempotent for previously-seen strings — looks up the existing ID
+  before allocating a new one.
+
+  Options:
+    `:start_id` (integer, default 0) — ID to assign to the first
+      unseen string. For batch ingestion across multiple calls,
+      pass the previous calls returned `:next_id`.
+    `:txn` (LMDB rw_txn handle, default nil) — if set, run all
+      writes inside the caller-supplied transaction. If nil, this
+      function opens its own rw_txn and commits at the end.
+
+  Returns `{:ok, %{pairs_seen: integer, new_ids: integer, next_id: integer}}`
+  on success. The `next_id` is `start_id + new_ids` and should be
+  persisted (e.g. via the callers metadata DB or a sentinel key in
+  `id_to_key_dbi`) for the next batch.
+
+  Stub status: bodies wired through Module.concat; runtime exercise
+  requires `:elmdb`.
+  """
+  def ingest_pairs(%__MODULE__{} = handle, pairs, opts \\\\ [])
+      when is_list(pairs) do
+    start_id = Keyword.get(opts, :start_id, 0)
+    user_txn = Keyword.get(opts, :txn, nil)
+    mod = lmdb_module()
+
+    {txn, owns_txn} =
+      if user_txn do
+        {user_txn, false}
+      else
+        {:ok, t} = apply(mod, :rw_txn_begin, [handle.env])
+        {t, true}
+      end
+
+    try do
+      {next_id, pairs_seen, new_ids} =
+        Enum.reduce(pairs, {start_id, 0, 0}, fn {a1, a2}, {nid, seen, allocated} ->
+          {a1_id, nid, allocated} = intern_one(handle, mod, txn, a1, nid, allocated)
+          {a2_id, nid, allocated} = intern_one(handle, mod, txn, a2, nid, allocated)
+          :ok = apply(mod, :txn_put, [txn, handle.facts_dbi,
+                                      encode_id(a1_id), encode_id(a2_id)])
+          {nid, seen + 1, allocated}
+        end)
+
+      if owns_txn, do: :ok = apply(mod, :txn_commit, [txn])
+      {:ok, %{pairs_seen: pairs_seen, new_ids: new_ids, next_id: next_id}}
+    catch
+      kind, reason ->
+        if owns_txn, do: apply(mod, :txn_abort, [txn])
+        {:error, {kind, reason}}
+    end
+  end
+
+  # Look up or allocate an ID for one string.
+  # Returns {id, updated_next_id, updated_allocated_count}.
+  defp intern_one(handle, mod, txn, str, next_id, allocated) when is_binary(str) do
+    case apply(mod, :txn_get, [txn, handle.key_to_id_dbi, str]) do
+      {:ok, bin_id} ->
+        {decode_id(bin_id), next_id, allocated}
+      :not_found ->
+        bin_id = encode_id(next_id)
+        :ok = apply(mod, :txn_put, [txn, handle.key_to_id_dbi, str, bin_id])
+        :ok = apply(mod, :txn_put, [txn, handle.id_to_key_dbi, bin_id, str])
+        {next_id, next_id + 1, allocated + 1}
+    end
+  end
+
+  @doc """
+  Migration helper: convert an existing PR #1792 string-keyed `Lmdb`
+  env to an int-id-keyed `LmdbIntIds` env. Cursor-walks the source
+  envs facts DB, assigns sequential IDs to unique strings in
+  encounter order, and populates the destination envs three
+  sub-databases consistently.
+
+  Arguments:
+    `source_handle` — `%WamRuntime.FactSource.Lmdb{}` pointing at the
+      existing string-keyed env (PR #1792 shape).
+    `dest_handle` — freshly opened `%WamRuntime.FactSource.LmdbIntIds{}`
+      with empty `facts_dbi` / `key_to_id_dbi` / `id_to_key_dbi`.
+
+  Options:
+    `:start_id` (default 0) — first ID to assign.
+    `:batch_size` (default 10_000) — commit per-batch to bound the
+      rw_txns dirty-page memory at large scale.
+
+  Returns `{:ok, %{pairs_migrated: integer, ids_assigned: integer,
+  next_id: integer}}`.
+
+  Stub status: bodies wired through Module.concat; runtime exercise
+  requires `:elmdb`.
+  """
+  def migrate_from_string_keyed(source_handle, %__MODULE__{} = dest_handle, opts \\\\ []) do
+    start_id = Keyword.get(opts, :start_id, 0)
+    batch_size = Keyword.get(opts, :batch_size, 10_000)
+
+    # Stream the source envs (key, value) pairs (binaries from PR #1792)
+    # then batch into ingest_pairs/3 calls.
+    all_pairs = WamRuntime.FactSource.Lmdb.stream_all(source_handle, nil)
+
+    {final_next_id, total_pairs, total_new_ids} =
+      all_pairs
+      |> Enum.chunk_every(batch_size)
+      |> Enum.reduce({start_id, 0, 0}, fn batch, {nid, total_p, total_n} ->
+        case ingest_pairs(dest_handle, batch, start_id: nid) do
+          {:ok, %{pairs_seen: p, new_ids: n, next_id: new_nid}} ->
+            {new_nid, total_p + p, total_n + n}
+          {:error, reason} ->
+            throw({:migrate_failed, reason})
+        end
+      end)
+
+    {:ok, %{pairs_migrated: total_pairs, ids_assigned: total_new_ids,
+            next_id: final_next_id}}
+  end
+
   @impl true
   def stream_all(%__MODULE__{env: env, facts_dbi: dbi}, _state) do
     mod = lmdb_module()

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -816,6 +816,51 @@ test_lmdb_int_ids_design_proposal_referenced :-
     ;   fail_test(Test, 'kernel docstring still has the old LMDB-IDs claim or doesnt reference the proposal')
     ).
 
+test_lmdb_int_ids_ingest_pairs_emitted :-
+    % Driver-side ingestion helper. Without this, the proposal
+    % documents a contract no driver can fulfill (insert-time
+    % ID assignment requires a coordinated write to all three
+    % sub-DBs; a one-off helper is the natural shape).
+    Test = 'LmdbIntIds: ingest_pairs/3 driver helper emitted with three-DB write surface',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    (   sub_string(RuntimeCode, _, _, _, 'def ingest_pairs(%__MODULE__{}'),
+        % Idempotent string-interning: txn_get on key_to_id_dbi
+        % before allocating a new ID.
+        sub_string(RuntimeCode, _, _, _, 'defp intern_one('),
+        % Sequential ID allocation: increment next_id when
+        % :not_found in key_to_id_dbi.
+        sub_string(RuntimeCode, _, _, _, ':not_found ->'),
+        % Writes all three sub-DBs: key_to_id_dbi, id_to_key_dbi,
+        % facts_dbi (each via txn_put through Module.concat).
+        sub_string(RuntimeCode, _, _, _, 'handle.key_to_id_dbi'),
+        sub_string(RuntimeCode, _, _, _, 'handle.id_to_key_dbi'),
+        sub_string(RuntimeCode, _, _, _, 'handle.facts_dbi'),
+        % Returns a status map with the next_id sentinel for
+        % batched calls.
+        sub_string(RuntimeCode, _, _, _, ':next_id')
+    ->  pass(Test)
+    ;   fail_test(Test, 'ingest_pairs/3 missing or has wrong API surface')
+    ).
+
+test_lmdb_int_ids_migrate_from_string_keyed_emitted :-
+    % Migration helper: existing PR #1792 string-keyed Lmdb env
+    % -> int-id-keyed LmdbIntIds env. Without this, deployments
+    % that already use the original Lmdb adaptor have no path to
+    % the int-id win.
+    Test = 'LmdbIntIds: migrate_from_string_keyed/3 helper emitted, batches via ingest_pairs/3',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    (   sub_string(RuntimeCode, _, _, _, 'def migrate_from_string_keyed('),
+        % Reads from the existing PR #1792 Lmdb adaptor.
+        sub_string(RuntimeCode, _, _, _, 'WamRuntime.FactSource.Lmdb.stream_all'),
+        % Batches via Enum.chunk_every for memory safety at scale.
+        sub_string(RuntimeCode, _, _, _, 'Enum.chunk_every(batch_size)'),
+        % Delegates to ingest_pairs/3 (so insert-time ID assignment
+        % logic lives in one place).
+        sub_string(RuntimeCode, _, _, _, 'ingest_pairs(dest_handle, batch')
+    ->  pass(Test)
+    ;   fail_test(Test, 'migrate_from_string_keyed/3 missing or has wrong shape')
+    ).
+
 %% Atom-interning experiment (opt-in via intern_atoms(true) Option):
 %  identifier-shape constants emit as Elixir atom literals (`:foo`)
 %  instead of binaries (`"foo"`). BEAM atoms compare via pointer
@@ -2140,6 +2185,8 @@ run_tests :-
     test_lmdb_int_ids_adaptor_emitted_in_runtime,
     test_lmdb_int_ids_adaptor_uses_indirect_module_resolution,
     test_lmdb_int_ids_design_proposal_referenced,
+    test_lmdb_int_ids_ingest_pairs_emitted,
+    test_lmdb_int_ids_migrate_from_string_keyed_emitted,
     test_shared_detector_finds_tc,
     test_shared_detector_finds_category_ancestor,
     test_kernel_dispatch_emits_tc_module,


### PR DESCRIPTION
## Summary

Continuing the LMDB int-id FactSource work from #1819. The proposal's status checklist had three open items; this PR closes two of them.

The driver-side ingestion contract (insert-time ID assignment with consistent writes to all three sub-databases) is non-trivial enough that not shipping a helper would mean every driver re-implements it, likely with subtle bugs — forgetting to update `id_to_key_dbi` when allocating a new ID, or breaking idempotency on previously-seen strings. Same reasoning for the migration path: deployments already on #1792's string-keyed `Lmdb` need a way forward.

## Two helpers added

### `ingest_pairs/3`
Driver-side population. Takes `[{arg1_str, arg2_str}, ...]` and:
- Looks up each string in `key_to_id_dbi` via `txn_get`; if found, reuses the existing ID (idempotent).
- If `:not_found`, allocates the next ID and writes both `key_to_id_dbi` (string → 8-byte BE u64) and `id_to_key_dbi` (8-byte BE u64 → string) atomically.
- Writes the pair as `(a1_id, a2_id)` into `facts_dbi`.
- Returns `{:ok, %{pairs_seen, new_ids, next_id}}` for batched calls.
- Optional `:txn` opt for a caller-owned transaction (so multiple ingests can share one rw_txn).

### `migrate_from_string_keyed/3`
Migration from a #1792 string-keyed `%Lmdb{}` to a fresh `%LmdbIntIds{}`. Cursor-walks the source, batches via `Enum.chunk_every` (default 10_000 to bound dirty-page memory), delegates each batch to `ingest_pairs/3`. Sequential ID assignment in encounter order.

Plus a private `intern_one/6` that handles the lookup-or-allocate logic shared between the two args of each pair.

Both functions go through `Module.concat([Elmdb])` like the rest of `LmdbIntIds`, so the runtime emits without `:elmdb` installed. **Runtime exercise still requires Hex.pm reachability.**

## Test plan

- [x] **124 wam-elixir tests pass** (was 122 in #1819; +2 new):
  - `test_lmdb_int_ids_ingest_pairs_emitted` — function emits, `intern_one/6` helper exists, `:not_found` branch present (allocate-on-miss semantics), all three sub-DB fields referenced.
  - `test_lmdb_int_ids_migrate_from_string_keyed_emitted` — function emits, reads from #1792's `stream_all`, batches via `Enum.chunk_every`, delegates to `ingest_pairs`.
- [ ] `:elmdb`-backed integration test — still blocked on Hex.pm reachability.

## Proposal updates

`docs/proposals/wam_elixir_lmdb_int_id_factsource.md`:
- Status checklist: two items moved `[ ]` → `[x]` with PR refs.
- New "Driver-side recipe" section showing end-to-end usage: open env + three sub-DBs, `ingest_pairs/3` for new data, `migrate_from_string_keyed/3` for #1792 migration, register with `FactSourceRegistry`.

## What's still open

Per the updated proposal status:
- `:elmdb`-backed integration test (sandbox can't install Hex deps).
- Cross-target benchmark of int-id LMDB vs in-memory int-tuple (depends on integration test).
- Mock-`Elmdb` end-to-end test as a deferrable alternative — ~300 lines for an in-memory fake of the `Elmdb` API; would catch encoding off-by-ones and dupsort cursor logic without real Hex deps. Flagged in the status section but deferred from this PR's scope.

The mock-Elmdb test is the natural next step if you want to push further without `:elmdb` access — it'd validate the encoding/decoding correctness, dupsort handling, and round-trip semantics that emit-and-grep can't reach.

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_