### PR TITLE
feat(wam-elixir): TransitiveDistance kernel + dispatch (3 of 7 kernels)

### DIFF
--- a/docs/WAM_TARGET_ROADMAP.md
+++ b/docs/WAM_TARGET_ROADMAP.md
@@ -230,13 +230,25 @@ In rough order of expected payoff:
 2. **Hot-path graph kernels.** Pick one or two graph operations
    (transitive closure, effective-distance) and emit them as Elixir
    modules that bypass WAM dispatch entirely, mirroring the
-   Go/Rust kernel approach. Done for `transitive_closure2` and
-   `category_ancestor`; the shared kernel detector
-   (`recursive_kernel_detection.pl`) recognises 5 more kinds Elixir
-   does not yet emit (`transitive_distance3`,
-   `weighted_shortest_path3`, `transitive_parent_distance4`,
-   `astar_shortest_path4`, `transitive_step_parent_distance5`).
-   Port the simplest first.
+   Go/Rust kernel approach. Coverage status as of this writing:
+
+   | Kernel kind | Rust | Haskell | Elixir |
+   |---|:-:|:-:|:-:|
+   | `transitive_closure2` | ✓ | ✓ | ✓ (PR #1799) |
+   | `category_ancestor` | ✓ | ✓ | ✓ (PR #1803, optimised through #1817) |
+   | `transitive_distance3` | ✓ | ✓ | ✓ (PR #1822) |
+   | `weighted_shortest_path3` | ✓ | ✓ | — |
+   | `transitive_parent_distance4` | ✓ | ✓ | — |
+   | `astar_shortest_path4` | ✓ | ✓ | — |
+   | `transitive_step_parent_distance5` | ✓ | ✓ | — |
+
+   Remaining 4 kernels in rough order of implementation difficulty:
+   `transitive_parent_distance4` (DFS, no cycle check, 3-tuple output —
+   simplest); `transitive_step_parent_distance5` (DFS + first-step
+   tracking — small extension of #1822); `weighted_shortest_path3`
+   (Dijkstra over weighted edges — needs priority queue); 
+   `astar_shortest_path4` (A* with heuristic — most complex, goal-
+   directed instead of full enumeration).
 
 3. **Tier-2 outer-loop parallelism, but emitter-driven.** The
    parallel-fanout numbers in `benchmarks/wam_effective_distance_cross_target.md`

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -2684,6 +2684,74 @@ defmodule WamRuntime.GraphKernel.TransitiveClosure do
   end
 end
 
+defmodule WamRuntime.GraphKernel.TransitiveDistance do
+  @moduledoc """
+  Native transitive-distance kernel — bypasses WAM dispatch for the
+  canonical pattern:
+
+      trans_dist(X, Y, 1) :- edge(X, Y).
+      trans_dist(X, Y, N) :-
+          edge(X, Mid),
+          trans_dist(Mid, Y, N1),
+          N is N1 + 1.
+
+  Returns all `(target, distance)` pairs reachable from `start` via
+  simple paths (per-path visited set, A->B->C and A->C are DIFFERENT
+  paths to C with distance 2 and 1, both yielded — same convention
+  CategoryAncestor uses).
+
+  Ported from the Rust kernel `collect_native_transitive_distance_results`
+  in src/unifyweaver/targets/wam_rust_target.pl. Identical algorithm:
+  recursive DFS with explicit per-path visited list, push (target,
+  next_depth) on every edge to an unvisited node, recurse with the
+  target appended to visited.
+
+  Termination: each recursive step adds the target to `visited`,
+  blocking re-entry. The recursion bottoms out when the current
+  nodes neighbours are all in visited (i.e. we have walked every
+  simple path from `start`).
+
+  Why bypass WAM: same reasoning as TransitiveClosure / CategoryAncestor.
+  Adding more kernel kinds is the second-largest perf lever after
+  walker tuning (per docs/WAM_TARGET_ROADMAP.md). This kernel was
+  the simplest of the five Rust+Haskell kinds Elixir was missing —
+  shape mirrors CategoryAncestor (per-path enumeration) but without
+  the explicit Visited-list arg or max_depth bound.
+  """
+
+  @doc """
+  Returns `[{target, distance}, ...]` for every distinct simple path
+  from `start`. `neighbors_fn` receives a node, returns a list of
+  `{from, to}` tuples (FactSource lookup_by_arg1 contract); only `to`
+  is read.
+  """
+  def collect_pairs(neighbors_fn, start) when is_function(neighbors_fn, 1) do
+    walk(neighbors_fn, start, [start], 0, [])
+    |> Enum.reverse()
+  end
+
+  defp walk(neighbors_fn, node, visited, depth, acc) do
+    edges = neighbors_fn.(node)
+    next_depth = depth + 1
+    Enum.reduce(edges, acc, fn {_from, target}, ac ->
+      if :lists.member(target, visited) do
+        ac
+      else
+        ac1 = [{target, next_depth} | ac]
+        walk(neighbors_fn, target, [target | visited], next_depth, ac1)
+      end
+    end)
+  end
+
+  @doc """
+  Convenience for FactSource-backed graphs.
+  """
+  def collect_pairs_from_source(source_module, source_handle, start, state \\\\ nil) do
+    fun = fn node -> source_module.lookup_by_arg1(source_handle, node, state) end
+    collect_pairs(fun, start)
+  end
+end
+
 defmodule WamRuntime.GraphKernel.CategoryAncestor do
   @moduledoc """
   Native bounded-ancestor kernel — path-enumeration variant of TC
@@ -3324,6 +3392,11 @@ emit_kernel_dispatch_module(ModuleName, Pred, _Arity,
     member(edge_pred(EdgePred/_), ConfigOps),
     member(max_depth(MaxDepth), ConfigOps),
     compile_category_ancestor_dispatch_module(ModuleName, Pred, EdgePred, MaxDepth, Code).
+emit_kernel_dispatch_module(ModuleName, Pred, _Arity,
+                            recursive_kernel(transitive_distance3, _, ConfigOps),
+                            Code) :-
+    member(edge_pred(EdgePred/_), ConfigOps),
+    compile_transitive_distance_dispatch_module(ModuleName, Pred, EdgePred, Code).
 
 %% compile_tc_kernel_dispatch_module(+ModuleName, +Pred, +EdgePred, -Code)
 %
@@ -3580,6 +3653,141 @@ end
      PredStr, EdgePredStr, MaxDepth,
      EdgeKey,
      MaxDepth,
+     EdgeKey,
+     CamelPred]).
+
+%% compile_transitive_distance_dispatch_module(+ModuleName, +Pred, +EdgePred, -Code)
+%
+%  Dispatch module for the transitive_distance3 pattern (3-ary; the
+%  shape detected by detect_transitive_distance/4 in
+%  recursive_kernel_detection.pl). Routes calls through
+%  WamRuntime.GraphKernel.TransitiveDistance.collect_pairs.
+%
+%  Unlike TC (where reg 2 alone is enumerated) or category_ancestor
+%  (where reg 2 is bound on entry and only reg 3 is enumerated), here
+%  BOTH reg 2 (target) and reg 3 (distance) get bound per solution.
+%  The kernel returns [{target, distance}, ...]; the dispatch wrapper
+%  inspects the active aggregate frames :agg_value_reg at runtime to
+%  decide which slice of the pair to contribute:
+%    - val_reg == 2 -> push targets       (`findall(T, td(s, T, _), Ts)`)
+%    - val_reg == 3 -> push distances     (`findall(D, td(s, _, D), Ds)`)
+%    - otherwise    -> push pair tuples   (`findall(T-D, ...)` etc.)
+%
+%  Driver-direct call (no aggregate frame): binds A2 and A3 to the
+%  first solutions target and distance.
+compile_transitive_distance_dispatch_module(ModuleName, Pred, EdgePred, Code) :-
+    atom_string(ModuleName, ModName),
+    camel_case(ModName, CamelMod),
+    atom_string(Pred, PredStr),
+    camel_case(PredStr, CamelPred),
+    atom_string(EdgePred, EdgePredStr),
+    format(string(EdgeKey), "~w/2", [EdgePredStr]),
+    format(string(Code),
+'defmodule ~w.~w do
+  @moduledoc """
+  Kernel-dispatched ~w/3 (auto-recognised transitive_distance3
+  pattern over ~w/2). Routes calls through
+  WamRuntime.GraphKernel.TransitiveDistance.
+
+  Edge source must be registered via WamRuntime.FactSourceRegistry
+  under the indicator "~w" before calling.
+  """
+
+  def run(%WamRuntime.WamState{} = state) do
+    start_val = WamRuntime.deref_var(state, WamRuntime.get_reg(state, 1))
+    edge_handle = WamRuntime.FactSourceRegistry.lookup!("~w")
+    neighbors_fn = fn node ->
+      WamRuntime.FactSource.lookup_by_arg1(edge_handle, node, state)
+    end
+    pairs =
+      WamRuntime.GraphKernel.TransitiveDistance.collect_pairs(
+        neighbors_fn, start_val)
+
+    if WamRuntime.in_forkable_aggregate_frame?(state) do
+      # Slice the pairs based on which register the active aggregate
+      # is capturing. split_at_aggregate_cp/1 walks the cp stack ONCE
+      # so the per-pair contribution is O(1) (no per-push cp walk,
+      # same fix-shape as PR #1814 used for category_ancestor).
+      {above, agg_cp, below} = WamRuntime.split_at_aggregate_cp(state)
+      contributions =
+        case agg_cp.agg_value_reg do
+          2 -> Enum.map(pairs, fn {t, _d} -> t end)
+          3 -> Enum.map(pairs, fn {_t, d} -> d end)
+          _ -> pairs
+        end
+      # merge_into_aggregate appends; preserve encounter order.
+      new_accum = agg_cp.agg_accum ++ contributions
+      new_agg_cp = %{agg_cp | agg_accum: new_accum}
+      new_state = %{state | choice_points: above ++ [new_agg_cp | below]}
+      throw({:fail, new_state})
+    else
+      case pairs do
+        [{first_target, first_dist} | _] ->
+          case bind_two_regs(state, first_target, first_dist) do
+            nil -> throw({:fail, state})
+            bound -> {:ok, bound}
+          end
+        [] -> throw({:fail, state})
+      end
+    end
+  end
+
+  def run(args) when is_list(args) do
+    state = %WamRuntime.WamState{code: {}, labels: %{}, pc: 1}
+    {state, arg_vars} =
+      Enum.with_index(args, 1)
+      |> Enum.reduce({state, []}, fn {arg, i}, {s, vars} ->
+        case arg do
+          {:unbound, _} ->
+            v = {:unbound, make_ref()}
+            {%{s | regs: Map.put(s.regs, i, v)}, [{i, v} | vars]}
+          other ->
+            {%{s | regs: Map.put(s.regs, i, other)}, vars}
+        end
+      end)
+    state = %{state | arg_vars: arg_vars, cp: &WamRuntime.terminal_cp/1}
+    try do
+      case run(state) do
+        {:ok, final} -> {:ok, WamRuntime.materialise_args(final)}
+        other -> other
+      end
+    catch
+      {:fail, _} -> :fail
+      {:return, result} -> result
+      error ->
+        IO.puts("Predicate ~w CRASHED: #{inspect(error)}")
+        :fail
+    end
+  end
+
+  # Bind both A2 (target) and A3 (distance) for the driver-direct
+  # single-solution path. Either binding failure (slot already bound
+  # to a different value) returns nil so the caller throws fail.
+  defp bind_two_regs(state, target, distance) do
+    with {:ok, s1} <- bind_one(state, 2, target),
+         {:ok, s2} <- bind_one(s1, 3, distance) do
+      s2
+    else
+      _ -> nil
+    end
+  end
+
+  defp bind_one(state, reg_idx, value) do
+    case Map.get(state.regs, reg_idx) do
+      {:unbound, id} ->
+        {:ok,
+         state
+         |> WamRuntime.trail_binding(id)
+         |> WamRuntime.put_reg(id, value)}
+      ^value -> {:ok, state}
+      _ -> :error
+    end
+  end
+end
+',
+    [CamelMod, CamelPred,
+     PredStr, EdgePredStr,
+     EdgeKey,
      EdgeKey,
      CamelPred]).
 

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -968,6 +968,7 @@ setup_kernel_fixtures :-
     retractall(user:kdedge(_, _)),
     retractall(user:kdca(_, _, _, _)),
     retractall(user:kdcparent(_, _)),
+    retractall(user:kdtd(_, _, _)),
     retractall(user:max_depth(_)),
     assertz((user:kdtc(X, Z) :- user:kdedge(X, Z))),
     assertz((user:kdtc(X, Z) :- user:kdedge(X, Y), user:kdtc(Y, Z))),
@@ -977,7 +978,15 @@ setup_kernel_fixtures :-
                 user:max_depth(MaxD), length(V, D), D < MaxD, !,
                 user:kdcparent(C, M), \+ member(M, V),
                 user:kdca(M, A, H1, [M|V]),
-                H is H1 + 1)).
+                H is H1 + 1)),
+    % transitive_distance3 fixture: matches the canonical shape
+    %   td(X, Y, 1) :- edge(X, Y).
+    %   td(X, Y, N) :- edge(X, Mid), td(Mid, Y, N1), N is N1 + 1.
+    assertz((user:kdtd(X, Y, 1) :- user:kdedge(X, Y))),
+    assertz((user:kdtd(X, Y, N) :-
+                user:kdedge(X, Mid),
+                user:kdtd(Mid, Y, N1),
+                N is N1 + 1)).
 
 test_shared_detector_finds_tc :-
     Test = 'Shared detector: kdtc/2 with canonical TC shape detected as transitive_closure2',
@@ -1110,6 +1119,87 @@ test_graph_kernel_tc_emitted_in_runtime :-
         sub_string(RuntimeCode, _, _, _, 'def reachable_from_source(')
     ->  pass(Test)
     ;   fail_test(Test, 'GraphKernel.TransitiveClosure module missing expected API')
+    ).
+
+test_graph_kernel_transitive_distance_emitted_in_runtime :-
+    % First of the five kernel kinds Rust+Haskell have but Elixir was missing
+    % (per the audit in benchmarks/wam_effective_distance_cross_target.md
+    % footnote about kernel coverage). This fills the simplest of the five —
+    % shape ports cleanly from the existing CategoryAncestor walker.
+    Test = 'GraphKernel TransitiveDistance: runtime assembly emits WamRuntime.GraphKernel.TransitiveDistance',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    (   sub_string(RuntimeCode, _, _, _, 'defmodule WamRuntime.GraphKernel.TransitiveDistance do'),
+        sub_string(RuntimeCode, _, _, _, 'def collect_pairs('),
+        sub_string(RuntimeCode, _, _, _, 'def collect_pairs_from_source(')
+    ->  pass(Test)
+    ;   fail_test(Test, 'GraphKernel.TransitiveDistance module missing expected API')
+    ).
+
+test_graph_kernel_transitive_distance_uses_per_path_visited :-
+    % Per-path visited list (matches Rust collect_native_transitive_distance_results).
+    % Without it the recursion would loop on cyclic graphs. The walker should
+    % use :lists.member for the visited check (consistent with PR #1817 where
+    % the explicit :lists.member call beats `Enum.member?` on the hot path).
+    Test = 'GraphKernel TransitiveDistance: kernel uses per-path visited list with :lists.member',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    % Locate the TransitiveDistance module body and check its walker
+    % uses :lists.member — anchored to the module to avoid matching
+    % CategoryAncestors visited check.
+    Pattern = "defmodule WamRuntime.GraphKernel.TransitiveDistance do",
+    EndPattern = "defmodule WamRuntime.GraphKernel.CategoryAncestor do",
+    (   sub_string(RuntimeCode, Start, _, _, Pattern),
+        sub_string(RuntimeCode, End, _, _, EndPattern),
+        End > Start,
+        BodyLen is End - Start,
+        sub_string(RuntimeCode, Start, BodyLen, _, Body),
+        sub_string(Body, _, _, _, ":lists.member(target, visited)"),
+        sub_string(Body, _, _, _, "[target | visited]")
+    ->  pass(Test)
+    ;   fail_test(Test, 'TransitiveDistance walker missing :lists.member visited check')
+    ).
+
+test_kernel_dispatch_emits_transitive_distance_module :-
+    % End-to-end: detector recognises kdtd/3 as transitive_distance3,
+    % the dispatch wrapper emits with the correct shape (calls
+    % collect_pairs, branches on agg_value_reg for findall slicing,
+    % binds two regs in driver-direct mode).
+    Test = 'Kernel dispatch: transitive_distance3 kernel emits Probe.Kdtd dispatch module',
+    setup_kernel_fixtures,
+    wam_target:compile_predicate_to_wam(user:kdtd/3, [], TdWam),
+    write_wam_elixir_project([kdtd/3-TdWam],
+        [module_name(probe), emit_mode(lowered),
+         intra_query_parallel(false),
+         kernel_dispatch(true), source_module(user)],
+        '/tmp/test_kernel_disp_td'),
+    read_file_to_string('/tmp/test_kernel_disp_td/lib/kdtd.ex', S, []),
+    (   sub_string(S, _, _, _, "WamRuntime.GraphKernel.TransitiveDistance"),
+        sub_string(S, _, _, _, "collect_pairs("),
+        % Aggregate-frame slicing logic: pick targets/distances/pairs
+        % based on which register the active aggregate is capturing.
+        sub_string(S, _, _, _, "agg_cp.agg_value_reg"),
+        sub_string(S, _, _, _, "in_forkable_aggregate_frame?"),
+        % Driver-direct binding of both target (reg 2) and distance (reg 3).
+        sub_string(S, _, _, _, "bind_two_regs(state, "),
+        % Falls through to collect_pairs (no separate fold variant yet —
+        % future work; for now the dispatch matches the TC shape
+        % structurally).
+        sub_string(S, _, _, _, "split_at_aggregate_cp(state)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'transitive_distance3 dispatch module missing expected shape')
+    ).
+
+test_shared_detector_finds_transitive_distance :-
+    % Sanity check that the shared detector recognises the canonical
+    % td/3 shape. Same form as test_shared_detector_finds_tc.
+    Test = 'Shared detector: kdtd/3 with canonical transitive_distance shape detected',
+    setup_kernel_fixtures,
+    functor(Head, kdtd, 3),
+    findall(Head-Body, user:clause(Head, Body), Clauses),
+    (   detect_recursive_kernel(kdtd, 3, Clauses,
+            recursive_kernel(transitive_distance3, kdtd/3, ConfigOps)),
+        member(edge_pred(kdedge/2), ConfigOps)
+    ->  pass(Test)
+    ;   fail_test(Test, 'kdtd/3 not detected as transitive_distance3 by shared detector')
     ).
 
 test_graph_kernel_tc_uses_visited_tracking :-
@@ -2278,6 +2368,10 @@ run_tests :-
     test_runtime_emits_split_at_aggregate_cp,
     test_kernel_docstring_documents_integer_id_path,
     test_graph_kernel_tc_emitted_in_runtime,
+    test_graph_kernel_transitive_distance_emitted_in_runtime,
+    test_graph_kernel_transitive_distance_uses_per_path_visited,
+    test_kernel_dispatch_emits_transitive_distance_module,
+    test_shared_detector_finds_transitive_distance,
     test_graph_kernel_tc_uses_visited_tracking,
     test_graph_kernel_tc_factsource_bridge,
     test_intern_atoms_default_off,


### PR DESCRIPTION
## Summary

Closes the simplest of the 5 kernel kinds Elixir was missing relative to Rust+Haskell. Shape ports cleanly from the existing `CategoryAncestor` walker (per-path DFS with visited list) but without the explicit `Visited`-list arg or `max_depth` bound — matching Rust's `collect_native_transitive_distance_results` reference.

## Coverage progress

| Kernel kind | Rust | Haskell | Elixir |
|---|:-:|:-:|:-:|
| `transitive_closure2` | ✓ | ✓ | ✓ |
| `category_ancestor` | ✓ | ✓ | ✓ |
| **`transitive_distance3`** | ✓ | ✓ | **✓ this PR** |
| `weighted_shortest_path3` | ✓ | ✓ | — |
| `transitive_parent_distance4` | ✓ | ✓ | — |
| `astar_shortest_path4` | ✓ | ✓ | — |
| `transitive_step_parent_distance5` | ✓ | ✓ | — |

3 of 7 → 3 of 7. Updated roadmap with a difficulty-ordered list of the remaining 4.

## What this PR ships

**`WamRuntime.GraphKernel.TransitiveDistance`** module in the runtime template:
- `collect_pairs/2`: returns `[{target, distance}, ...]` for every distinct simple path from `start`. Per-path visited semantics — `A->B->C` and `A->C` are DIFFERENT paths to C with distance 2 and 1, both yielded.
- `collect_pairs_from_source/4`: FactSource convenience wrapper.

Kept deliberately simple — no bare-dests / fold variants yet. Those are recommended scale-up paths (PRs #1815/#1812) that can be added when there's a real workload; the structure ports straight from `CategoryAncestor`.

**`compile_transitive_distance_dispatch_module/4`** emits the per-predicate dispatch wrapper. Unlike TC (reg 2 alone enumerated) or `category_ancestor` (reg 2 bound, reg 3 enumerated), here BOTH reg 2 (target) and reg 3 (distance) get bound per solution. The wrapper inspects the active aggregate frame's `:agg_value_reg` at runtime to decide which slice to push:

| `agg_value_reg` | Findall pattern | Contributes |
|---|---|---|
| 2 | `findall(T, td(s, T, _), Ts)` | targets |
| 3 | `findall(D, td(s, _, D), Ds)` | distances |
| other (compound template) | `findall(T-D, td(s, T, D), Ps)` | pair tuples |

Driver-direct call: `bind_two_regs/3` binds both A2 and A3 to the first solution.

Wired into `emit_kernel_dispatch_module/5` so `kernel_dispatch(true)` compilation auto-routes any predicate matching the `transitive_distance3` detector pattern.

## Test plan

- [x] **129 wam-elixir tests pass** (was 125; +4 new):
  - `test_graph_kernel_transitive_distance_emitted_in_runtime`: runtime emits `TransitiveDistance` module with the expected API.
  - `test_graph_kernel_transitive_distance_uses_per_path_visited`: walker uses `:lists.member` on visited and prepends target per recursion (matches Rust reference).
  - `test_kernel_dispatch_emits_transitive_distance_module`: end-to-end via the new `kdtd/3` fixture in `setup_kernel_fixtures`. Asserts dispatch module references `TransitiveDistance`, inspects `agg_value_reg`, calls `split_at_aggregate_cp` (PR #1814 cp-walk amortisation), and binds two regs in driver-direct mode.
  - `test_shared_detector_finds_transitive_distance`: detector recognises `kdtd/3` as `transitive_distance3`.
- [x] **Smoke test end-to-end** through a small-graph driver: `a->b`, `a->c`, `b->d`, `c->d`. Produces 4 pairs in DFS order — both paths to "d" yielded as distinct results, confirming per-path enumeration semantics.

## What's next (the remaining 4 kernels)

Listed in roadmap by difficulty:
1. `transitive_parent_distance4` — DFS, no cycle check, 3-tuple output. Smallest extension.
2. `transitive_step_parent_distance5` — DFS + first-step tracking. Small extension of this PR.
3. `weighted_shortest_path3` — Dijkstra over weighted edges. Needs priority queue.
4. `astar_shortest_path4` — A* with heuristic. Most complex (goal-directed).

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_