### PR TITLE
feat(wam-elixir): TransitiveParentDistance kernel + dispatch (4 of 7 kernels)

### DIFF
--- a/docs/WAM_TARGET_ROADMAP.md
+++ b/docs/WAM_TARGET_ROADMAP.md
@@ -237,18 +237,17 @@ In rough order of expected payoff:
    | `transitive_closure2` | ✓ | ✓ | ✓ (PR #1799) |
    | `category_ancestor` | ✓ | ✓ | ✓ (PR #1803, optimised through #1817) |
    | `transitive_distance3` | ✓ | ✓ | ✓ (PR #1822) |
+   | `transitive_parent_distance4` | ✓ | ✓ | ✓ (PR #1823) |
    | `weighted_shortest_path3` | ✓ | ✓ | — |
-   | `transitive_parent_distance4` | ✓ | ✓ | — |
    | `astar_shortest_path4` | ✓ | ✓ | — |
    | `transitive_step_parent_distance5` | ✓ | ✓ | — |
 
-   Remaining 4 kernels in rough order of implementation difficulty:
-   `transitive_parent_distance4` (DFS, no cycle check, 3-tuple output —
-   simplest); `transitive_step_parent_distance5` (DFS + first-step
-   tracking — small extension of #1822); `weighted_shortest_path3`
-   (Dijkstra over weighted edges — needs priority queue); 
-   `astar_shortest_path4` (A* with heuristic — most complex, goal-
-   directed instead of full enumeration).
+   Remaining 3 kernels in rough order of implementation difficulty:
+   `transitive_step_parent_distance5` (DFS + first-step tracking —
+   small extension of `transitive_parent_distance4`);
+   `weighted_shortest_path3` (Dijkstra over weighted edges — needs
+   priority queue); `astar_shortest_path4` (A* with heuristic — most
+   complex, goal-directed instead of full enumeration).
 
 3. **Tier-2 outer-loop parallelism, but emitter-driven.** The
    parallel-fanout numbers in `benchmarks/wam_effective_distance_cross_target.md`

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -2752,6 +2752,81 @@ defmodule WamRuntime.GraphKernel.TransitiveDistance do
   end
 end
 
+defmodule WamRuntime.GraphKernel.TransitiveParentDistance do
+  @moduledoc """
+  Native transitive-parent-distance kernel — bypasses WAM dispatch
+  for the canonical pattern:
+
+      pd(X, Y, X, 1) :- edge(X, Y).
+      pd(X, Y, P, N) :-
+          edge(X, Mid),
+          pd(Mid, Y, P, N1),
+          N is N1 + 1.
+
+  Returns `[{target, predecessor, distance}, ...]` triples — for every
+  edge encountered during DFS from `start`, records the edge plus the
+  depth at which it was traversed. The predecessor is the immediate
+  source-side of the recorded edge (the node we stepped FROM), which
+  matches the Prolog patterns base-case binding (`pd(X, Y, X, 1)` —
+  parent equals start when one edge connects start to target).
+
+  Ported from the Rust kernel
+  `collect_native_transitive_parent_distance_results` in
+  src/unifyweaver/targets/wam_rust_target.pl. Identical algorithm:
+  iterative DFS via an explicit stack, push `(target, predecessor,
+  next_depth)` per edge.
+
+  WARNING: NO cycle detection. Matches the Rust reference impl which
+  uses a stack-based DFS without a visited list. On cyclic inputs
+  this kernel **loops indefinitely**; callers must either ensure
+  acyclic input (DAGs only — e.g. typical category-parent structures)
+  or wrap with a depth-bound consumer like
+  `findall(P-N, (pd(X, Y, P, N), N < MaxD), Triples)`. If you need
+  cycle-safe behaviour AND the predecessor, the right next step is a
+  separate `transitive_parent_distance4_safe` kernel that adds a
+  visited list — not in this PR.
+  """
+
+  @doc """
+  Returns `[{target, predecessor, distance}, ...]` for every edge
+  encountered during DFS from `start`. `neighbors_fn` follows the
+  FactSource lookup_by_arg1 contract: receives a node, returns
+  `[{from, to}, ...]` tuples.
+
+  Edge-iteration order: matches Rusts `for next in next_nodes.iter().rev()
+  + stack.push` — edges are visited in forward order. We reverse the
+  edge list before reducing onto the stack so the first edge pops
+  first. This preserves the same enumeration order across targets,
+  which matters when callers depend on it for deterministic test
+  output.
+  """
+  def collect_triples(neighbors_fn, start) when is_function(neighbors_fn, 1) do
+    walk(neighbors_fn, [{start, 0}], [])
+    |> Enum.reverse()
+  end
+
+  defp walk(_, [], acc), do: acc
+  defp walk(neighbors_fn, [{node, depth} | rest], acc) do
+    edges = neighbors_fn.(node)
+    next_depth = depth + 1
+    {new_acc, new_stack} =
+      edges
+      |> Enum.reverse()
+      |> Enum.reduce({acc, rest}, fn {_from, target}, {a, s} ->
+        {[{target, node, next_depth} | a], [{target, next_depth} | s]}
+      end)
+    walk(neighbors_fn, new_stack, new_acc)
+  end
+
+  @doc """
+  Convenience for FactSource-backed graphs.
+  """
+  def collect_triples_from_source(source_module, source_handle, start, state \\\\ nil) do
+    fun = fn node -> source_module.lookup_by_arg1(source_handle, node, state) end
+    collect_triples(fun, start)
+  end
+end
+
 defmodule WamRuntime.GraphKernel.CategoryAncestor do
   @moduledoc """
   Native bounded-ancestor kernel — path-enumeration variant of TC
@@ -3397,6 +3472,11 @@ emit_kernel_dispatch_module(ModuleName, Pred, _Arity,
                             Code) :-
     member(edge_pred(EdgePred/_), ConfigOps),
     compile_transitive_distance_dispatch_module(ModuleName, Pred, EdgePred, Code).
+emit_kernel_dispatch_module(ModuleName, Pred, _Arity,
+                            recursive_kernel(transitive_parent_distance4, _, ConfigOps),
+                            Code) :-
+    member(edge_pred(EdgePred/_), ConfigOps),
+    compile_transitive_parent_distance_dispatch_module(ModuleName, Pred, EdgePred, Code).
 
 %% compile_tc_kernel_dispatch_module(+ModuleName, +Pred, +EdgePred, -Code)
 %
@@ -3767,6 +3847,148 @@ compile_transitive_distance_dispatch_module(ModuleName, Pred, EdgePred, Code) :-
     with {:ok, s1} <- bind_one(state, 2, target),
          {:ok, s2} <- bind_one(s1, 3, distance) do
       s2
+    else
+      _ -> nil
+    end
+  end
+
+  defp bind_one(state, reg_idx, value) do
+    case Map.get(state.regs, reg_idx) do
+      {:unbound, id} ->
+        {:ok,
+         state
+         |> WamRuntime.trail_binding(id)
+         |> WamRuntime.put_reg(id, value)}
+      ^value -> {:ok, state}
+      _ -> :error
+    end
+  end
+end
+',
+    [CamelMod, CamelPred,
+     PredStr, EdgePredStr,
+     EdgeKey,
+     EdgeKey,
+     CamelPred]).
+
+%% compile_transitive_parent_distance_dispatch_module(+ModuleName, +Pred, +EdgePred, -Code)
+%
+%  Dispatch module for the transitive_parent_distance4 pattern (4-ary;
+%  detected by detect_transitive_parent_distance/4 in
+%  recursive_kernel_detection.pl). Routes calls through
+%  WamRuntime.GraphKernel.TransitiveParentDistance.collect_triples.
+%
+%  Three enumerated registers per solution: A2 (target), A3 (parent
+%  / immediate predecessor), A4 (distance). The kernel returns
+%  [{target, parent, distance}, ...]; the dispatch wrapper inspects
+%  the active aggregate frames :agg_value_reg at runtime to select
+%  which slice to push:
+%    - val_reg == 2 -> push targets
+%    - val_reg == 3 -> push parents
+%    - val_reg == 4 -> push distances
+%    - otherwise    -> push triple tuples (compound template)
+%
+%  Driver-direct call: bind_three_regs/4 binds A2, A3, A4 to the
+%  first solution.
+%
+%  WARNING (inherited from the kernel): NO cycle detection. Caller
+%  must ensure acyclic input or wrap with a depth-bounded consumer.
+compile_transitive_parent_distance_dispatch_module(ModuleName, Pred, EdgePred, Code) :-
+    atom_string(ModuleName, ModName),
+    camel_case(ModName, CamelMod),
+    atom_string(Pred, PredStr),
+    camel_case(PredStr, CamelPred),
+    atom_string(EdgePred, EdgePredStr),
+    format(string(EdgeKey), "~w/2", [EdgePredStr]),
+    format(string(Code),
+'defmodule ~w.~w do
+  @moduledoc """
+  Kernel-dispatched ~w/4 (auto-recognised transitive_parent_distance4
+  pattern over ~w/2). Routes calls through
+  WamRuntime.GraphKernel.TransitiveParentDistance.
+
+  Edge source must be registered via WamRuntime.FactSourceRegistry
+  under the indicator "~w" before calling.
+
+  WARNING: the underlying kernel has NO cycle detection. Use this
+  only on acyclic graphs (DAGs) or wrap calls with a depth-bound
+  consumer.
+  """
+
+  def run(%WamRuntime.WamState{} = state) do
+    start_val = WamRuntime.deref_var(state, WamRuntime.get_reg(state, 1))
+    edge_handle = WamRuntime.FactSourceRegistry.lookup!("~w")
+    neighbors_fn = fn node ->
+      WamRuntime.FactSource.lookup_by_arg1(edge_handle, node, state)
+    end
+    triples =
+      WamRuntime.GraphKernel.TransitiveParentDistance.collect_triples(
+        neighbors_fn, start_val)
+
+    if WamRuntime.in_forkable_aggregate_frame?(state) do
+      # Slice triples based on which register the active aggregate
+      # is capturing. split_at_aggregate_cp/1 walks the cp stack ONCE
+      # so per-pair contribution is O(1) (PR #1814 amortisation).
+      {above, agg_cp, below} = WamRuntime.split_at_aggregate_cp(state)
+      contributions =
+        case agg_cp.agg_value_reg do
+          2 -> Enum.map(triples, fn {t, _p, _d} -> t end)
+          3 -> Enum.map(triples, fn {_t, p, _d} -> p end)
+          4 -> Enum.map(triples, fn {_t, _p, d} -> d end)
+          _ -> triples
+        end
+      new_accum = agg_cp.agg_accum ++ contributions
+      new_agg_cp = %{agg_cp | agg_accum: new_accum}
+      new_state = %{state | choice_points: above ++ [new_agg_cp | below]}
+      throw({:fail, new_state})
+    else
+      case triples do
+        [{first_target, first_parent, first_dist} | _] ->
+          case bind_three_regs(state, first_target, first_parent, first_dist) do
+            nil -> throw({:fail, state})
+            bound -> {:ok, bound}
+          end
+        [] -> throw({:fail, state})
+      end
+    end
+  end
+
+  def run(args) when is_list(args) do
+    state = %WamRuntime.WamState{code: {}, labels: %{}, pc: 1}
+    {state, arg_vars} =
+      Enum.with_index(args, 1)
+      |> Enum.reduce({state, []}, fn {arg, i}, {s, vars} ->
+        case arg do
+          {:unbound, _} ->
+            v = {:unbound, make_ref()}
+            {%{s | regs: Map.put(s.regs, i, v)}, [{i, v} | vars]}
+          other ->
+            {%{s | regs: Map.put(s.regs, i, other)}, vars}
+        end
+      end)
+    state = %{state | arg_vars: arg_vars, cp: &WamRuntime.terminal_cp/1}
+    try do
+      case run(state) do
+        {:ok, final} -> {:ok, WamRuntime.materialise_args(final)}
+        other -> other
+      end
+    catch
+      {:fail, _} -> :fail
+      {:return, result} -> result
+      error ->
+        IO.puts("Predicate ~w CRASHED: #{inspect(error)}")
+        :fail
+    end
+  end
+
+  # Bind A2 (target), A3 (parent), A4 (distance) for driver-direct
+  # single-solution mode. Any binding failure (slot already bound to a
+  # different value) aborts with nil so the caller throws fail.
+  defp bind_three_regs(state, target, parent, distance) do
+    with {:ok, s1} <- bind_one(state, 2, target),
+         {:ok, s2} <- bind_one(s1, 3, parent),
+         {:ok, s3} <- bind_one(s2, 4, distance) do
+      s3
     else
       _ -> nil
     end

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -986,6 +986,15 @@ setup_kernel_fixtures :-
     assertz((user:kdtd(X, Y, N) :-
                 user:kdedge(X, Mid),
                 user:kdtd(Mid, Y, N1),
+                N is N1 + 1)),
+    % transitive_parent_distance4 fixture: matches the canonical shape
+    %   pd(X, Y, X, 1) :- edge(X, Y).                  % parent == start, dist == 1
+    %   pd(X, Y, P, N) :- edge(X, Mid), pd(Mid, Y, P, N1), N is N1 + 1.
+    retractall(user:kdpd(_, _, _, _)),
+    assertz((user:kdpd(X, Y, X, 1) :- user:kdedge(X, Y))),
+    assertz((user:kdpd(X, Y, P, N) :-
+                user:kdedge(X, Mid),
+                user:kdpd(Mid, Y, P, N1),
                 N is N1 + 1)).
 
 test_shared_detector_finds_tc :-
@@ -1200,6 +1209,87 @@ test_shared_detector_finds_transitive_distance :-
         member(edge_pred(kdedge/2), ConfigOps)
     ->  pass(Test)
     ;   fail_test(Test, 'kdtd/3 not detected as transitive_distance3 by shared detector')
+    ).
+
+test_graph_kernel_transitive_parent_distance_emitted_in_runtime :-
+    % Second of the five missing kernels (after TransitiveDistance in PR
+    % #1822). Stack-based DFS with no cycle detection — matches Rust's
+    % collect_native_transitive_parent_distance_results reference exactly.
+    Test = 'GraphKernel TransitiveParentDistance: runtime emits WamRuntime.GraphKernel.TransitiveParentDistance',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    (   sub_string(RuntimeCode, _, _, _, 'defmodule WamRuntime.GraphKernel.TransitiveParentDistance do'),
+        sub_string(RuntimeCode, _, _, _, 'def collect_triples('),
+        sub_string(RuntimeCode, _, _, _, 'def collect_triples_from_source(')
+    ->  pass(Test)
+    ;   fail_test(Test, 'GraphKernel.TransitiveParentDistance module missing expected API')
+    ).
+
+test_graph_kernel_transitive_parent_distance_no_visited_set :-
+    % Documented contract: NO cycle detection, matches Rust's
+    % stack-based DFS exactly. The walker must NOT carry a visited
+    % list — that would change the per-path enumeration semantics.
+    % Locate the TransitiveParentDistance module body and check it.
+    Test = 'GraphKernel TransitiveParentDistance: walker has no visited list (matches Rust DFS)',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    Pattern = "defmodule WamRuntime.GraphKernel.TransitiveParentDistance do",
+    EndPattern = "defmodule WamRuntime.GraphKernel.CategoryAncestor do",
+    (   sub_string(RuntimeCode, Start, _, _, Pattern),
+        sub_string(RuntimeCode, End, _, _, EndPattern),
+        End > Start,
+        BodyLen is End - Start,
+        sub_string(RuntimeCode, Start, BodyLen, _, Body),
+        % Stack-based DFS shape: explicit `[{node, depth} | rest]`
+        % stack pattern in the walker, with the records pushed as
+        % `(target, predecessor, next_depth)` triples.
+        sub_string(Body, _, _, _, "[{node, depth} | rest]"),
+        sub_string(Body, _, _, _, "{[{target, node, next_depth}"),
+        % Negative invariant: no `:lists.member` visited check (would
+        % silently change the semantics from "every edge in DFS" to
+        % "every edge with simple-path constraint").
+        \+ sub_string(Body, _, _, _, ":lists.member"),
+        % Documents the cycle caveat in the moduledoc.
+        sub_string(Body, _, _, _, "NO cycle detection")
+    ->  pass(Test)
+    ;   fail_test(Test, 'TransitiveParentDistance walker has wrong shape or missing cycle caveat')
+    ).
+
+test_kernel_dispatch_emits_transitive_parent_distance_module :-
+    % End-to-end: detector recognises kdpd/4 as
+    % transitive_parent_distance4, dispatch wrapper emits with the
+    % correct shape (calls collect_triples, branches on agg_value_reg
+    % across reg 2/3/4 for findall slicing, binds three regs in
+    % driver-direct mode).
+    Test = 'Kernel dispatch: transitive_parent_distance4 kernel emits Probe.Kdpd dispatch module',
+    setup_kernel_fixtures,
+    wam_target:compile_predicate_to_wam(user:kdpd/4, [], PdWam),
+    write_wam_elixir_project([kdpd/4-PdWam],
+        [module_name(probe), emit_mode(lowered),
+         intra_query_parallel(false),
+         kernel_dispatch(true), source_module(user)],
+        '/tmp/test_kernel_disp_pd'),
+    read_file_to_string('/tmp/test_kernel_disp_pd/lib/kdpd.ex', S, []),
+    (   sub_string(S, _, _, _, "WamRuntime.GraphKernel.TransitiveParentDistance"),
+        sub_string(S, _, _, _, "collect_triples("),
+        % Aggregate-frame slicing for three registers (2/3/4).
+        sub_string(S, _, _, _, "agg_cp.agg_value_reg"),
+        sub_string(S, _, _, _, "in_forkable_aggregate_frame?"),
+        % Driver-direct binding of all three (target, parent, distance).
+        sub_string(S, _, _, _, "bind_three_regs(state, "),
+        sub_string(S, _, _, _, "split_at_aggregate_cp(state)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'transitive_parent_distance4 dispatch module missing expected shape')
+    ).
+
+test_shared_detector_finds_transitive_parent_distance :-
+    Test = 'Shared detector: kdpd/4 with canonical transitive_parent_distance shape detected',
+    setup_kernel_fixtures,
+    functor(Head, kdpd, 4),
+    findall(Head-Body, user:clause(Head, Body), Clauses),
+    (   detect_recursive_kernel(kdpd, 4, Clauses,
+            recursive_kernel(transitive_parent_distance4, kdpd/4, ConfigOps)),
+        member(edge_pred(kdedge/2), ConfigOps)
+    ->  pass(Test)
+    ;   fail_test(Test, 'kdpd/4 not detected as transitive_parent_distance4 by shared detector')
     ).
 
 test_graph_kernel_tc_uses_visited_tracking :-
@@ -2372,6 +2462,10 @@ run_tests :-
     test_graph_kernel_transitive_distance_uses_per_path_visited,
     test_kernel_dispatch_emits_transitive_distance_module,
     test_shared_detector_finds_transitive_distance,
+    test_graph_kernel_transitive_parent_distance_emitted_in_runtime,
+    test_graph_kernel_transitive_parent_distance_no_visited_set,
+    test_kernel_dispatch_emits_transitive_parent_distance_module,
+    test_shared_detector_finds_transitive_parent_distance,
     test_graph_kernel_tc_uses_visited_tracking,
     test_graph_kernel_tc_factsource_bridge,
     test_intern_atoms_default_off,


### PR DESCRIPTION
## Summary

Closes the second of the 5 missing kernel kinds (after #1822's `TransitiveDistance`). Stack-based iterative DFS, output `(target, predecessor, distance)` triples — matches Rust's `collect_native_transitive_parent_distance_results` reference exactly, **including the absence of cycle detection.**

## Coverage progress

| Kernel kind | Rust | Haskell | Elixir |
|---|:-:|:-:|:-:|
| `transitive_closure2` | ✓ | ✓ | ✓ |
| `category_ancestor` | ✓ | ✓ | ✓ |
| `transitive_distance3` | ✓ | ✓ | ✓ |
| **`transitive_parent_distance4`** | ✓ | ✓ | **✓ this PR** |
| `weighted_shortest_path3` | ✓ | ✓ | — |
| `astar_shortest_path4` | ✓ | ✓ | — |
| `transitive_step_parent_distance5` | ✓ | ✓ | — |

**4 of 7 → done.** Remaining 3 by difficulty: `transitive_step_parent_distance5` (small extension of this PR), `weighted_shortest_path3` (needs priority queue), `astar_shortest_path4` (A* with heuristic, goal-directed).

## What this PR ships

**`WamRuntime.GraphKernel.TransitiveParentDistance`** module:
- `collect_triples/2`: returns `[{target, predecessor, distance}, ...]` for every edge encountered during DFS from `start`. Predecessor is the immediate source-side of each recorded edge.
- `collect_triples_from_source/4`: FactSource convenience.

⚠️ **NO cycle detection** (matches Rust). Documented in moduledoc. On cyclic input the kernel loops indefinitely — callers must use DAGs or wrap with a depth-bounded consumer.

**`compile_transitive_parent_distance_dispatch_module/4`** emits the per-predicate dispatch wrapper. **THREE enumerated registers per solution** (A2 target, A3 parent, A4 distance). The wrapper inspects `:agg_value_reg`:

| `agg_value_reg` | Findall pattern | Contributes |
|---|---|---|
| 2 | `findall(T, pd(s, T, _, _), Ts)` | targets |
| 3 | `findall(P, pd(s, _, P, _), Ps)` | parents |
| 4 | `findall(D, pd(s, _, _, D), Ds)` | distances |
| other | `findall(P-D, pd(s, _, P, D), Pairs)` | triple tuples |

Driver-direct call: `bind_three_regs/4` binds all three registers to the first solution.

## Test plan

- [x] **133 wam-elixir tests pass** (was 129; +4 new):
  - Runtime emits the module with expected API.
  - Walker has stack-based shape `[{node, depth} | rest]`, pushes `(target, predecessor, depth)`, has **no** `:lists.member` visited check (negative invariant — would change semantics from per-edge DFS to per-simple-path), documents cycle caveat.
  - Dispatch wrapper end-to-end via new `kdpd/4` fixture.
  - Shared detector recognises `kdpd/4` as `transitive_parent_distance4`.
- [x] **Smoke-tested end-to-end** on DAG `a->b, a->c, b->d, c->d` → 4 triples with correct predecessors. Both paths to "d" yielded as `{d, b, 2}` and `{d, c, 2}`, confirming per-edge enumeration matches Rust's reference.

## Note on the no-cycle-detection design

The Rust reference impl explicitly uses stack-based DFS without a visited list. The canonical Prolog pattern `pd(X, Y, P, N) :- edge(X, Mid), pd(Mid, Y, P, N1), N is N1 + 1` likewise has no cycle check — Prolog typically relies on the consumer (depth-bound `findall`, tabling, or known-acyclic input) to terminate. This Elixir port preserves that contract for cross-target consistency.

If a future caller needs cycle-safe behaviour AND predecessor tracking, the right next step is a separate `transitive_parent_distance4_safe` kernel that adds a visited list — that's a meaningful semantic difference (per-simple-path enumeration instead of per-edge), not just an optimisation, so it warrants its own kernel kind in the shared detector.

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_