### PR TITLE
feat(wam-elixir): TransitiveStepParentDistance kernel + dispatch (5 of 7 kernels)

### DIFF
--- a/docs/WAM_TARGET_ROADMAP.md
+++ b/docs/WAM_TARGET_ROADMAP.md
@@ -238,16 +238,16 @@ In rough order of expected payoff:
    | `category_ancestor` | ✓ | ✓ | ✓ (PR #1803, optimised through #1817) |
    | `transitive_distance3` | ✓ | ✓ | ✓ (PR #1822) |
    | `transitive_parent_distance4` | ✓ | ✓ | ✓ (PR #1823) |
+   | `transitive_step_parent_distance5` | ✓ | ✓ | ✓ (PR #1824) |
    | `weighted_shortest_path3` | ✓ | ✓ | — |
    | `astar_shortest_path4` | ✓ | ✓ | — |
-   | `transitive_step_parent_distance5` | ✓ | ✓ | — |
 
-   Remaining 3 kernels in rough order of implementation difficulty:
-   `transitive_step_parent_distance5` (DFS + first-step tracking —
-   small extension of `transitive_parent_distance4`);
+   Remaining 2 kernels (both weighted-graph) in order of difficulty:
    `weighted_shortest_path3` (Dijkstra over weighted edges — needs
-   priority queue); `astar_shortest_path4` (A* with heuristic — most
-   complex, goal-directed instead of full enumeration).
+   priority queue, and the detector + dispatch wrapper need the
+   weight argument plumbed through); `astar_shortest_path4` (A*
+   with heuristic — most complex; goal-directed search instead of
+   full enumeration, optional direct-distance heuristic predicate).
 
 3. **Tier-2 outer-loop parallelism, but emitter-driven.** The
    parallel-fanout numbers in `benchmarks/wam_effective_distance_cross_target.md`

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -2827,6 +2827,72 @@ defmodule WamRuntime.GraphKernel.TransitiveParentDistance do
   end
 end
 
+defmodule WamRuntime.GraphKernel.TransitiveStepParentDistance do
+  @moduledoc """
+  Native transitive-step-parent-distance kernel — bypasses WAM dispatch
+  for the canonical pattern:
+
+      tspd(X, Y, Y, X, 1) :- edge(X, Y).
+      tspd(X, Y, Mid, P, D) :-
+          edge(X, Mid),
+          tspd(Mid, Y, _IgnoredStep, P, D1),
+          D is D1 + 1.
+
+  Returns `[{target, step, parent, distance}, ...]` quadruples where:
+    - target: the reachable node
+    - step: the FIRST hop taken from `start` (the immediate child of
+      `start` on the recorded path)
+    - parent: the immediate predecessor of `target`
+    - distance: total path length from `start` to `target`
+
+  Note that `step` and `parent` differ in general — `step` is anchored
+  to the start, `parent` to the target. They coincide only on direct
+  edges (depth 1).
+
+  Ported from the Rust kernel
+  `collect_native_transitive_step_parent_distance_results` in
+  src/unifyweaver/targets/wam_rust_target.pl. Identical algorithm:
+  for each direct edge from `start`, emit the depth-1 quadruple, then
+  delegate to `TransitiveParentDistance.collect_triples/2` for the
+  deeper walk and decorate every returned `(target, parent, dist)`
+  triple with the current first-hop and `dist + 1`.
+
+  WARNING: NO cycle detection (inherited from TransitiveParentDistance).
+  Cyclic inputs loop indefinitely — use only on DAGs (typical
+  category-parent / ontology shapes are fine).
+  """
+
+  @doc """
+  Returns `[{target, step, parent, distance}, ...]` for every edge in
+  the DFS expansion from `start`, decorated with the FIRST hop taken.
+  Reuses `WamRuntime.GraphKernel.TransitiveParentDistance.collect_triples/2`
+  for the inner walk; the step is fixed at the first hop per outer
+  iteration.
+  """
+  def collect_quads(neighbors_fn, start) when is_function(neighbors_fn, 1) do
+    edges = neighbors_fn.(start)
+    Enum.flat_map(edges, fn {_from, next} ->
+      direct = [{next, next, start, 1}]
+      nested =
+        WamRuntime.GraphKernel.TransitiveParentDistance.collect_triples(
+          neighbors_fn, next)
+      bumped =
+        Enum.map(nested, fn {target, parent, dist} ->
+          {target, next, parent, dist + 1}
+        end)
+      direct ++ bumped
+    end)
+  end
+
+  @doc """
+  Convenience for FactSource-backed graphs.
+  """
+  def collect_quads_from_source(source_module, source_handle, start, state \\\\ nil) do
+    fun = fn node -> source_module.lookup_by_arg1(source_handle, node, state) end
+    collect_quads(fun, start)
+  end
+end
+
 defmodule WamRuntime.GraphKernel.CategoryAncestor do
   @moduledoc """
   Native bounded-ancestor kernel — path-enumeration variant of TC
@@ -3477,6 +3543,11 @@ emit_kernel_dispatch_module(ModuleName, Pred, _Arity,
                             Code) :-
     member(edge_pred(EdgePred/_), ConfigOps),
     compile_transitive_parent_distance_dispatch_module(ModuleName, Pred, EdgePred, Code).
+emit_kernel_dispatch_module(ModuleName, Pred, _Arity,
+                            recursive_kernel(transitive_step_parent_distance5, _, ConfigOps),
+                            Code) :-
+    member(edge_pred(EdgePred/_), ConfigOps),
+    compile_transitive_step_parent_distance_dispatch_module(ModuleName, Pred, EdgePred, Code).
 
 %% compile_tc_kernel_dispatch_module(+ModuleName, +Pred, +EdgePred, -Code)
 %
@@ -3989,6 +4060,149 @@ compile_transitive_parent_distance_dispatch_module(ModuleName, Pred, EdgePred, C
          {:ok, s2} <- bind_one(s1, 3, parent),
          {:ok, s3} <- bind_one(s2, 4, distance) do
       s3
+    else
+      _ -> nil
+    end
+  end
+
+  defp bind_one(state, reg_idx, value) do
+    case Map.get(state.regs, reg_idx) do
+      {:unbound, id} ->
+        {:ok,
+         state
+         |> WamRuntime.trail_binding(id)
+         |> WamRuntime.put_reg(id, value)}
+      ^value -> {:ok, state}
+      _ -> :error
+    end
+  end
+end
+',
+    [CamelMod, CamelPred,
+     PredStr, EdgePredStr,
+     EdgeKey,
+     EdgeKey,
+     CamelPred]).
+
+%% compile_transitive_step_parent_distance_dispatch_module(+ModuleName, +Pred, +EdgePred, -Code)
+%
+%  Dispatch module for the transitive_step_parent_distance5 pattern
+%  (5-ary; detected by detect_transitive_step_parent_distance/4 in
+%  recursive_kernel_detection.pl). Routes calls through
+%  WamRuntime.GraphKernel.TransitiveStepParentDistance.collect_quads.
+%
+%  FOUR enumerated registers per solution: A2 (target), A3 (step —
+%  the FIRST hop from start), A4 (parent — immediate predecessor of
+%  target), A5 (distance). The wrapper inspects the active aggregate
+%  frames :agg_value_reg at runtime to slice quads:
+%    - val_reg == 2 -> push targets
+%    - val_reg == 3 -> push first-hop steps
+%    - val_reg == 4 -> push parents
+%    - val_reg == 5 -> push distances
+%    - otherwise    -> push quad tuples
+%
+%  Driver-direct call: bind_four_regs/5 binds A2, A3, A4, A5 to the
+%  first solution.
+%
+%  WARNING (inherited from the kernel): NO cycle detection. Use on
+%  acyclic graphs only.
+compile_transitive_step_parent_distance_dispatch_module(ModuleName, Pred, EdgePred, Code) :-
+    atom_string(ModuleName, ModName),
+    camel_case(ModName, CamelMod),
+    atom_string(Pred, PredStr),
+    camel_case(PredStr, CamelPred),
+    atom_string(EdgePred, EdgePredStr),
+    format(string(EdgeKey), "~w/2", [EdgePredStr]),
+    format(string(Code),
+'defmodule ~w.~w do
+  @moduledoc """
+  Kernel-dispatched ~w/5 (auto-recognised transitive_step_parent_distance5
+  pattern over ~w/2). Routes calls through
+  WamRuntime.GraphKernel.TransitiveStepParentDistance.
+
+  Edge source must be registered via WamRuntime.FactSourceRegistry
+  under the indicator "~w" before calling.
+
+  WARNING: the underlying kernel has NO cycle detection. Use this
+  only on acyclic graphs (DAGs) or wrap calls with a depth-bound
+  consumer.
+  """
+
+  def run(%WamRuntime.WamState{} = state) do
+    start_val = WamRuntime.deref_var(state, WamRuntime.get_reg(state, 1))
+    edge_handle = WamRuntime.FactSourceRegistry.lookup!("~w")
+    neighbors_fn = fn node ->
+      WamRuntime.FactSource.lookup_by_arg1(edge_handle, node, state)
+    end
+    quads =
+      WamRuntime.GraphKernel.TransitiveStepParentDistance.collect_quads(
+        neighbors_fn, start_val)
+
+    if WamRuntime.in_forkable_aggregate_frame?(state) do
+      # Slice quads on which register the active aggregate captures.
+      # split_at_aggregate_cp/1 walks cp stack ONCE (PR #1814 amortisation).
+      {above, agg_cp, below} = WamRuntime.split_at_aggregate_cp(state)
+      contributions =
+        case agg_cp.agg_value_reg do
+          2 -> Enum.map(quads, fn {t, _s, _p, _d} -> t end)
+          3 -> Enum.map(quads, fn {_t, s, _p, _d} -> s end)
+          4 -> Enum.map(quads, fn {_t, _s, p, _d} -> p end)
+          5 -> Enum.map(quads, fn {_t, _s, _p, d} -> d end)
+          _ -> quads
+        end
+      new_accum = agg_cp.agg_accum ++ contributions
+      new_agg_cp = %{agg_cp | agg_accum: new_accum}
+      new_state = %{state | choice_points: above ++ [new_agg_cp | below]}
+      throw({:fail, new_state})
+    else
+      case quads do
+        [{first_target, first_step, first_parent, first_dist} | _] ->
+          case bind_four_regs(state, first_target, first_step, first_parent, first_dist) do
+            nil -> throw({:fail, state})
+            bound -> {:ok, bound}
+          end
+        [] -> throw({:fail, state})
+      end
+    end
+  end
+
+  def run(args) when is_list(args) do
+    state = %WamRuntime.WamState{code: {}, labels: %{}, pc: 1}
+    {state, arg_vars} =
+      Enum.with_index(args, 1)
+      |> Enum.reduce({state, []}, fn {arg, i}, {s, vars} ->
+        case arg do
+          {:unbound, _} ->
+            v = {:unbound, make_ref()}
+            {%{s | regs: Map.put(s.regs, i, v)}, [{i, v} | vars]}
+          other ->
+            {%{s | regs: Map.put(s.regs, i, other)}, vars}
+        end
+      end)
+    state = %{state | arg_vars: arg_vars, cp: &WamRuntime.terminal_cp/1}
+    try do
+      case run(state) do
+        {:ok, final} -> {:ok, WamRuntime.materialise_args(final)}
+        other -> other
+      end
+    catch
+      {:fail, _} -> :fail
+      {:return, result} -> result
+      error ->
+        IO.puts("Predicate ~w CRASHED: #{inspect(error)}")
+        :fail
+    end
+  end
+
+  # Bind A2 (target), A3 (step), A4 (parent), A5 (distance) for
+  # driver-direct single-solution mode. Any binding failure aborts
+  # with nil so the caller throws fail.
+  defp bind_four_regs(state, target, step, parent, distance) do
+    with {:ok, s1} <- bind_one(state, 2, target),
+         {:ok, s2} <- bind_one(s1, 3, step),
+         {:ok, s3} <- bind_one(s2, 4, parent),
+         {:ok, s4} <- bind_one(s3, 5, distance) do
+      s4
     else
       _ -> nil
     end

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -995,6 +995,15 @@ setup_kernel_fixtures :-
     assertz((user:kdpd(X, Y, P, N) :-
                 user:kdedge(X, Mid),
                 user:kdpd(Mid, Y, P, N1),
+                N is N1 + 1)),
+    % transitive_step_parent_distance5 fixture: matches the canonical shape
+    %   sp(X, Y, Y, X, 1) :- edge(X, Y).                       % step==target==Y, parent==start, dist==1
+    %   sp(X, Y, Mid, P, N) :- edge(X, Mid), sp(Mid, Y, _, P, N1), N is N1 + 1.
+    retractall(user:kdsp(_, _, _, _, _)),
+    assertz((user:kdsp(X, Y, Y, X, 1) :- user:kdedge(X, Y))),
+    assertz((user:kdsp(X, Y, Mid, P, N) :-
+                user:kdedge(X, Mid),
+                user:kdsp(Mid, Y, _IgnoredStep, P, N1),
                 N is N1 + 1)).
 
 test_shared_detector_finds_tc :-
@@ -1290,6 +1299,85 @@ test_shared_detector_finds_transitive_parent_distance :-
         member(edge_pred(kdedge/2), ConfigOps)
     ->  pass(Test)
     ;   fail_test(Test, 'kdpd/4 not detected as transitive_parent_distance4 by shared detector')
+    ).
+
+test_graph_kernel_transitive_step_parent_distance_emitted_in_runtime :-
+    % Third missing kernel after PRs #1822/#1823. Reuses
+    % TransitiveParentDistance for the inner walk; tags every result
+    % with the FIRST hop taken from start. Same no-cycle-detection
+    % contract as transitive_parent_distance4.
+    Test = 'GraphKernel TransitiveStepParentDistance: runtime emits WamRuntime.GraphKernel.TransitiveStepParentDistance',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    (   sub_string(RuntimeCode, _, _, _, 'defmodule WamRuntime.GraphKernel.TransitiveStepParentDistance do'),
+        sub_string(RuntimeCode, _, _, _, 'def collect_quads('),
+        sub_string(RuntimeCode, _, _, _, 'def collect_quads_from_source(')
+    ->  pass(Test)
+    ;   fail_test(Test, 'GraphKernel.TransitiveStepParentDistance module missing expected API')
+    ).
+
+test_graph_kernel_tspd_reuses_parent_distance_walker :-
+    % Documents the implementation strategy: instead of writing a
+    % third walker, this kernel reuses TransitiveParentDistance's
+    % collect_triples and decorates results with the first-hop step.
+    % Negative invariant: there should NOT be a separate `walk` defp
+    % inside TSPD module body — it shouldnt have its own DFS walker.
+    Test = 'GraphKernel TransitiveStepParentDistance: reuses TransitiveParentDistance.collect_triples',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    Pattern = "defmodule WamRuntime.GraphKernel.TransitiveStepParentDistance do",
+    EndPattern = "defmodule WamRuntime.GraphKernel.CategoryAncestor do",
+    (   sub_string(RuntimeCode, Start, _, _, Pattern),
+        sub_string(RuntimeCode, End, _, _, EndPattern),
+        End > Start,
+        BodyLen is End - Start,
+        sub_string(RuntimeCode, Start, BodyLen, _, Body),
+        % Calls TransitiveParentDistance.collect_triples for the inner walk.
+        sub_string(Body, _, _, _, "WamRuntime.GraphKernel.TransitiveParentDistance.collect_triples"),
+        % Emits the depth-1 base case: {next, next, start, 1}.
+        sub_string(Body, _, _, _, "{next, next, start, 1}"),
+        % Bumps inner triples by 1 (dist + 1).
+        sub_string(Body, _, _, _, "dist + 1"),
+        % Documents the cycle caveat (inherited from
+        % TransitiveParentDistance).
+        sub_string(Body, _, _, _, "NO cycle detection")
+    ->  pass(Test)
+    ;   fail_test(Test, 'TransitiveStepParentDistance does not reuse the parent_distance walker correctly')
+    ).
+
+test_kernel_dispatch_emits_transitive_step_parent_distance_module :-
+    % End-to-end: detector recognises kdsp/5 as
+    % transitive_step_parent_distance5, dispatch wrapper emits
+    % FOUR-register binding (target, step, parent, distance).
+    Test = 'Kernel dispatch: transitive_step_parent_distance5 kernel emits Probe.Kdsp dispatch module',
+    setup_kernel_fixtures,
+    wam_target:compile_predicate_to_wam(user:kdsp/5, [], SpWam),
+    write_wam_elixir_project([kdsp/5-SpWam],
+        [module_name(probe), emit_mode(lowered),
+         intra_query_parallel(false),
+         kernel_dispatch(true), source_module(user)],
+        '/tmp/test_kernel_disp_sp'),
+    read_file_to_string('/tmp/test_kernel_disp_sp/lib/kdsp.ex', S, []),
+    (   sub_string(S, _, _, _, "WamRuntime.GraphKernel.TransitiveStepParentDistance"),
+        sub_string(S, _, _, _, "collect_quads("),
+        % Aggregate-frame slicing for FOUR registers (2/3/4/5).
+        sub_string(S, _, _, _, "agg_cp.agg_value_reg"),
+        sub_string(S, _, _, _, "in_forkable_aggregate_frame?"),
+        % Driver-direct binding of all four (target, step, parent, distance).
+        sub_string(S, _, _, _, "bind_four_regs(state, "),
+        sub_string(S, _, _, _, "split_at_aggregate_cp(state)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'transitive_step_parent_distance5 dispatch module missing expected shape')
+    ).
+
+test_shared_detector_finds_transitive_step_parent_distance :-
+    Test = 'Shared detector: kdsp/5 with canonical transitive_step_parent_distance shape detected',
+    setup_kernel_fixtures,
+    functor(Head, kdsp, 5),
+    findall(Head-Body, user:clause(Head, Body), Clauses),
+    (   detect_recursive_kernel(kdsp, 5, Clauses,
+            recursive_kernel(transitive_step_parent_distance5, kdsp/5, ConfigOps)),
+        member(edge_pred(kdedge/2), ConfigOps)
+    ->  pass(Test)
+    ;   fail_test(Test, 'kdsp/5 not detected as transitive_step_parent_distance5 by shared detector')
     ).
 
 test_graph_kernel_tc_uses_visited_tracking :-
@@ -2466,6 +2554,10 @@ run_tests :-
     test_graph_kernel_transitive_parent_distance_no_visited_set,
     test_kernel_dispatch_emits_transitive_parent_distance_module,
     test_shared_detector_finds_transitive_parent_distance,
+    test_graph_kernel_transitive_step_parent_distance_emitted_in_runtime,
+    test_graph_kernel_tspd_reuses_parent_distance_walker,
+    test_kernel_dispatch_emits_transitive_step_parent_distance_module,
+    test_shared_detector_finds_transitive_step_parent_distance,
     test_graph_kernel_tc_uses_visited_tracking,
     test_graph_kernel_tc_factsource_bridge,
     test_intern_atoms_default_off,


### PR DESCRIPTION
## Summary

Closes the third of the five missing kernels (after #1822 / #1823). DFS with **first-hop tracking** — each result quadruple records both the immediate predecessor of the target AND the step that started the traversal from `start`.

## Coverage progress

| Kernel kind | Rust | Haskell | Elixir |
|---|:-:|:-:|:-:|
| `transitive_closure2` | ✓ | ✓ | ✓ |
| `category_ancestor` | ✓ | ✓ | ✓ |
| `transitive_distance3` | ✓ | ✓ | ✓ |
| `transitive_parent_distance4` | ✓ | ✓ | ✓ |
| **`transitive_step_parent_distance5`** | ✓ | ✓ | **✓ this PR** |
| `weighted_shortest_path3` | ✓ | ✓ | — |
| `astar_shortest_path4` | ✓ | ✓ | — |

**5 of 7 → done.** Remaining 2 are both weighted-graph kernels.

## Implementation note: walker reuse

The kernel **reuses `TransitiveParentDistance.collect_triples/2`** (PR #1823) for the inner walk — no third DFS walker added. The new kernel just:

1. Emits the depth-1 base case `{next, next, start, 1}` for each direct edge from `start`.
2. Calls `TransitiveParentDistance.collect_triples/2` starting from each `next` and decorates every returned `(target, parent, dist)` triple with `{target, next, parent, dist + 1}` — overriding `step` to `next` (the first hop) and bumping dist.

Matches Rust's `collect_native_transitive_step_parent_distance_results` exactly (which itself calls `collect_native_transitive_parent_distance_results` internally — same structural reuse).

## What this PR ships

**`WamRuntime.GraphKernel.TransitiveStepParentDistance`** module:
- `collect_quads/2`: returns `[{target, step, parent, distance}, ...]`.
- `collect_quads_from_source/4`: FactSource convenience.

⚠️ **NO cycle detection** (inherited from `TransitiveParentDistance`). Documented in moduledoc.

**`compile_transitive_step_parent_distance_dispatch_module/4`** emits the per-predicate dispatch wrapper. **FOUR enumerated registers per solution** (A2 target, A3 step, A4 parent, A5 distance). The wrapper inspects `:agg_value_reg`:

| `agg_value_reg` | Slice |
|---|---|
| 2 | targets |
| 3 | first-hop steps |
| 4 | parents |
| 5 | distances |
| other | full quad tuples |

Driver-direct call: `bind_four_regs/5` binds all four registers.

## Test plan

- [x] **137 wam-elixir tests pass** (was 133; +4 new).
- [x] Tests assert the no-third-walker design: walker reuses `TransitiveParentDistance.collect_triples`, emits the depth-1 base case, bumps inner triples by `dist + 1`, documents the cycle caveat.
- [x] Smoke-tested end-to-end on DAG `a->b, a->c, b->d, c->d` → 4 quads with correct first-hop decoration. Both paths to "d" yielded as `{d, b, b, 2}` (via b) and `{d, c, c, 2}` (via c). Step == parent at depth 2 (immediate predecessor IS the first hop on a 2-hop path); step ≠ parent only at deeper depths.

## What's left

Two weighted-graph kernels:
1. `weighted_shortest_path3` — Dijkstra over weighted edges. Needs a priority queue (`:gb_trees` or sorted list of `{cost, node}` keyed entries). Detector + dispatch wrapper need the weight argument plumbed through (it's a `weighted_edge/3` not `edge/2`).
2. `astar_shortest_path4` — A* with heuristic. Most complex; goal-directed search instead of full enumeration. Optional `direct_dist_pred` for the heuristic.

Each is structurally bigger than the unweighted DFS kernels (1.5-2× the code) but follows the same pattern: kernel module + dispatch wrapper + tests + roadmap update.

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_