### PR TITLE
feat(wam-elixir): WeightedShortestPath kernel + dispatch (6 of 7 kernels)

### DIFF
--- a/docs/WAM_TARGET_ROADMAP.md
+++ b/docs/WAM_TARGET_ROADMAP.md
@@ -239,15 +239,16 @@ In rough order of expected payoff:
    | `transitive_distance3` | ✓ | ✓ | ✓ (PR #1822) |
    | `transitive_parent_distance4` | ✓ | ✓ | ✓ (PR #1823) |
    | `transitive_step_parent_distance5` | ✓ | ✓ | ✓ (PR #1824) |
-   | `weighted_shortest_path3` | ✓ | ✓ | — |
+   | `weighted_shortest_path3` | ✓ | ✓ | ✓ (PR #1825) |
    | `astar_shortest_path4` | ✓ | ✓ | — |
 
-   Remaining 2 kernels (both weighted-graph) in order of difficulty:
-   `weighted_shortest_path3` (Dijkstra over weighted edges — needs
-   priority queue, and the detector + dispatch wrapper need the
-   weight argument plumbed through); `astar_shortest_path4` (A*
-   with heuristic — most complex; goal-directed search instead of
-   full enumeration, optional direct-distance heuristic predicate).
+   Remaining: `astar_shortest_path4` (A* with heuristic — most
+   complex; goal-directed search instead of full enumeration,
+   optional direct-distance heuristic predicate). Builds on the
+   Dijkstra primitives shipped with `weighted_shortest_path3` —
+   `:gb_sets` priority queue, dist map with stale-entry skip — but
+   adds a heuristic estimate on every push and stops when the goal
+   pops from the heap.
 
 3. **Tier-2 outer-loop parallelism, but emitter-driven.** The
    parallel-fanout numbers in `benchmarks/wam_effective_distance_cross_target.md`

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -2893,6 +2893,112 @@ defmodule WamRuntime.GraphKernel.TransitiveStepParentDistance do
   end
 end
 
+defmodule WamRuntime.GraphKernel.WeightedShortestPath do
+  @moduledoc """
+  Native Dijkstra shortest-path kernel — bypasses WAM dispatch for
+  the canonical pattern:
+
+      wsp(X, Y, W) :- weighted_edge(X, Y, W).
+      wsp(X, Y, TotalW) :-
+          weighted_edge(X, Mid, W1),
+          wsp(Mid, Y, RestW),
+          TotalW is RestW + W1.
+
+  Returns `[{target, cost}, ...]` — the SHORTEST-path cost from
+  `start` to each reachable node (excluding start itself).
+
+  Important semantic narrowing: the canonical Prolog pattern above
+  enumerates ALL paths from start to target with their summed
+  weights. This kernel computes only the SHORTEST. So:
+
+      findall(W, wsp(s, t, W), Ws)
+      ;; Prolog source: yields all path weights to t.
+      ;; Kernel:        yields a 1-element list — only the shortest.
+
+      findall(T-W, wsp(s, T, W), Pairs)
+      ;; Prolog source: yields one pair per (path, weight); same
+      ;;                target may appear multiple times.
+      ;; Kernel:        yields one pair per reachable target with
+      ;;                its shortest-path cost.
+
+      aggregate_all(min, wsp(s, t, W), MinW)
+      ;; Both produce the same answer — the kernel just computes it
+      ;; in O(E log V) instead of exponential path enumeration.
+
+  Ported from the Rust kernel
+  `collect_native_weighted_shortest_path_results` in
+  src/unifyweaver/targets/wam_rust_target.pl (which uses BinaryHeap
+  with reversed Ordering for min-heap behaviour). Elixir uses
+  `:gb_sets` of `{cost, node}` tuples — Erlang term ordering puts
+  numerically-smaller cost first, then ties broken by node ordering,
+  giving min-first via `:gb_sets.take_smallest/1`.
+
+  Edge predicate is 3-ary: `weighted_edges_fn(node)` receives a node
+  and returns `[{from, to, weight}, ...]` triples (the weight at
+  position 3, matching the FactSource lookup_by_arg1 contract for
+  arity-3 predicates). Weights must be non-negative for Dijkstras
+  correctness — the kernel does not validate this; caller responsibility.
+
+  Cycle handling: Dijkstra naturally bounds termination via the dist
+  map. Cycles do not loop indefinitely (a nodes dist gets updated
+  only on improvement, eventually no improvement possible).
+  """
+
+  @doc """
+  Returns `[{target, cost}, ...]` — shortest path cost from `start`
+  to every reachable node. `weighted_edges_fn` is a 1-arity function
+  receiving a node, returns `[{from, to, weight}, ...]` triples.
+  """
+  def collect_path_costs(weighted_edges_fn, start)
+      when is_function(weighted_edges_fn, 1) do
+    initial_dist = %{start => 0}
+    initial_heap = :gb_sets.singleton({0, start})
+    final_dist = dijkstra(weighted_edges_fn, initial_heap, initial_dist)
+    final_dist
+    |> Enum.flat_map(fn
+      {^start, _} -> []
+      {node, cost} -> [{node, cost}]
+    end)
+  end
+
+  defp dijkstra(weighted_edges_fn, heap, dist) do
+    case :gb_sets.is_empty(heap) do
+      true -> dist
+      false ->
+        {{cost, node}, heap1} = :gb_sets.take_smallest(heap)
+        # Skip stale entries: if dist[node] is already lower than
+        # `cost`, we found a better path AFTER pushing this entry.
+        best = Map.fetch!(dist, node)
+        if cost > best do
+          dijkstra(weighted_edges_fn, heap1, dist)
+        else
+          {new_heap, new_dist} =
+            weighted_edges_fn.(node)
+            |> Enum.reduce({heap1, dist}, fn {_from, next, weight}, {h, d} ->
+              next_cost = cost + weight
+              case Map.fetch(d, next) do
+                {:ok, prev} when prev <= next_cost ->
+                  {h, d}
+                _ ->
+                  {:gb_sets.add({next_cost, next}, h), Map.put(d, next, next_cost)}
+              end
+            end)
+          dijkstra(weighted_edges_fn, new_heap, new_dist)
+        end
+    end
+  end
+
+  @doc """
+  Convenience for FactSource-backed graphs (3-arity weighted_edge
+  predicate). The FactSource adaptor must support `arity == 3` and
+  return `[{from, to, weight}, ...]` from `lookup_by_arg1`.
+  """
+  def collect_path_costs_from_source(source_module, source_handle, start, state \\\\ nil) do
+    fun = fn node -> source_module.lookup_by_arg1(source_handle, node, state) end
+    collect_path_costs(fun, start)
+  end
+end
+
 defmodule WamRuntime.GraphKernel.CategoryAncestor do
   @moduledoc """
   Native bounded-ancestor kernel — path-enumeration variant of TC
@@ -3548,6 +3654,11 @@ emit_kernel_dispatch_module(ModuleName, Pred, _Arity,
                             Code) :-
     member(edge_pred(EdgePred/_), ConfigOps),
     compile_transitive_step_parent_distance_dispatch_module(ModuleName, Pred, EdgePred, Code).
+emit_kernel_dispatch_module(ModuleName, Pred, _Arity,
+                            recursive_kernel(weighted_shortest_path3, _, ConfigOps),
+                            Code) :-
+    member(edge_pred(EdgePred/_), ConfigOps),
+    compile_weighted_shortest_path_dispatch_module(ModuleName, Pred, EdgePred, Code).
 
 %% compile_tc_kernel_dispatch_module(+ModuleName, +Pred, +EdgePred, -Code)
 %
@@ -4203,6 +4314,144 @@ compile_transitive_step_parent_distance_dispatch_module(ModuleName, Pred, EdgePr
          {:ok, s3} <- bind_one(s2, 4, parent),
          {:ok, s4} <- bind_one(s3, 5, distance) do
       s4
+    else
+      _ -> nil
+    end
+  end
+
+  defp bind_one(state, reg_idx, value) do
+    case Map.get(state.regs, reg_idx) do
+      {:unbound, id} ->
+        {:ok,
+         state
+         |> WamRuntime.trail_binding(id)
+         |> WamRuntime.put_reg(id, value)}
+      ^value -> {:ok, state}
+      _ -> :error
+    end
+  end
+end
+',
+    [CamelMod, CamelPred,
+     PredStr, EdgePredStr,
+     EdgeKey,
+     EdgeKey,
+     CamelPred]).
+
+%% compile_weighted_shortest_path_dispatch_module(+ModuleName, +Pred, +EdgePred, -Code)
+%
+%  Dispatch module for the weighted_shortest_path3 pattern (3-ary
+%  predicate over a 3-ary weighted_edge/3 source). Routes calls
+%  through WamRuntime.GraphKernel.WeightedShortestPath.collect_path_costs.
+%
+%  TWO enumerated registers per solution: A2 (target), A3 (cost). The
+%  wrapper inspects the active aggregate frames :agg_value_reg at
+%  runtime to slice the (target, cost) pair:
+%    - val_reg == 2 -> push targets
+%    - val_reg == 3 -> push costs
+%    - otherwise    -> push pair tuples
+%
+%  Driver-direct call: bind_two_regs/3 binds A2, A3 to the first
+%  shortest-path solution.
+%
+%  Semantic narrowing (documented in the runtime kernels moduledoc):
+%  the canonical Prolog pattern enumerates ALL paths; the kernel
+%  computes only the SHORTEST. Match the Rust reference impl.
+compile_weighted_shortest_path_dispatch_module(ModuleName, Pred, EdgePred, Code) :-
+    atom_string(ModuleName, ModName),
+    camel_case(ModName, CamelMod),
+    atom_string(Pred, PredStr),
+    camel_case(PredStr, CamelPred),
+    atom_string(EdgePred, EdgePredStr),
+    format(string(EdgeKey), "~w/3", [EdgePredStr]),
+    format(string(Code),
+'defmodule ~w.~w do
+  @moduledoc """
+  Kernel-dispatched ~w/3 (auto-recognised weighted_shortest_path3
+  pattern over ~w/3). Routes calls through
+  WamRuntime.GraphKernel.WeightedShortestPath (Dijkstra).
+
+  Edge source must be registered via WamRuntime.FactSourceRegistry
+  under the indicator "~w" before calling. The registered handle
+  must support arity 3 and return `[{from, to, weight}, ...]` from
+  lookup_by_arg1.
+
+  Semantic narrowing: the canonical Prolog pattern enumerates all
+  paths from start to target with their summed weights; this kernel
+  computes only the SHORTEST path cost (one result per reachable
+  target). Match the Rust reference impl. See the kernel moduledoc
+  in WamRuntime.GraphKernel.WeightedShortestPath for the full
+  contract.
+  """
+
+  def run(%WamRuntime.WamState{} = state) do
+    start_val = WamRuntime.deref_var(state, WamRuntime.get_reg(state, 1))
+    edge_handle = WamRuntime.FactSourceRegistry.lookup!("~w")
+    weighted_edges_fn = fn node ->
+      WamRuntime.FactSource.lookup_by_arg1(edge_handle, node, state)
+    end
+    pairs =
+      WamRuntime.GraphKernel.WeightedShortestPath.collect_path_costs(
+        weighted_edges_fn, start_val)
+
+    if WamRuntime.in_forkable_aggregate_frame?(state) do
+      # Slice (target, cost) on which register the aggregate captures.
+      # split_at_aggregate_cp/1 walks cp stack ONCE (PR #1814 fix).
+      {above, agg_cp, below} = WamRuntime.split_at_aggregate_cp(state)
+      contributions =
+        case agg_cp.agg_value_reg do
+          2 -> Enum.map(pairs, fn {t, _w} -> t end)
+          3 -> Enum.map(pairs, fn {_t, w} -> w end)
+          _ -> pairs
+        end
+      new_accum = agg_cp.agg_accum ++ contributions
+      new_agg_cp = %{agg_cp | agg_accum: new_accum}
+      new_state = %{state | choice_points: above ++ [new_agg_cp | below]}
+      throw({:fail, new_state})
+    else
+      case pairs do
+        [{first_target, first_cost} | _] ->
+          case bind_two_regs(state, first_target, first_cost) do
+            nil -> throw({:fail, state})
+            bound -> {:ok, bound}
+          end
+        [] -> throw({:fail, state})
+      end
+    end
+  end
+
+  def run(args) when is_list(args) do
+    state = %WamRuntime.WamState{code: {}, labels: %{}, pc: 1}
+    {state, arg_vars} =
+      Enum.with_index(args, 1)
+      |> Enum.reduce({state, []}, fn {arg, i}, {s, vars} ->
+        case arg do
+          {:unbound, _} ->
+            v = {:unbound, make_ref()}
+            {%{s | regs: Map.put(s.regs, i, v)}, [{i, v} | vars]}
+          other ->
+            {%{s | regs: Map.put(s.regs, i, other)}, vars}
+        end
+      end)
+    state = %{state | arg_vars: arg_vars, cp: &WamRuntime.terminal_cp/1}
+    try do
+      case run(state) do
+        {:ok, final} -> {:ok, WamRuntime.materialise_args(final)}
+        other -> other
+      end
+    catch
+      {:fail, _} -> :fail
+      {:return, result} -> result
+      error ->
+        IO.puts("Predicate ~w CRASHED: #{inspect(error)}")
+        :fail
+    end
+  end
+
+  defp bind_two_regs(state, target, cost) do
+    with {:ok, s1} <- bind_one(state, 2, target),
+         {:ok, s2} <- bind_one(s1, 3, cost) do
+      s2
     else
       _ -> nil
     end

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -1004,7 +1004,18 @@ setup_kernel_fixtures :-
     assertz((user:kdsp(X, Y, Mid, P, N) :-
                 user:kdedge(X, Mid),
                 user:kdsp(Mid, Y, _IgnoredStep, P, N1),
-                N is N1 + 1)).
+                N is N1 + 1)),
+    % weighted_shortest_path3 fixture: matches the canonical shape over
+    % a 3-arity weighted_edge predicate (kdweighted_edge in this fixture).
+    %   wsp(X, Y, W) :- weighted_edge(X, Y, W).
+    %   wsp(X, Y, TotalW) :- weighted_edge(X, Mid, W1), wsp(Mid, Y, RestW), TotalW is RestW + W1.
+    retractall(user:kdweighted_edge(_, _, _)),
+    retractall(user:kdwsp(_, _, _)),
+    assertz((user:kdwsp(X, Y, W) :- user:kdweighted_edge(X, Y, W))),
+    assertz((user:kdwsp(X, Y, TotalW) :-
+                user:kdweighted_edge(X, Mid, W1),
+                user:kdwsp(Mid, Y, RestW),
+                TotalW is RestW + W1)).
 
 test_shared_detector_finds_tc :-
     Test = 'Shared detector: kdtc/2 with canonical TC shape detected as transitive_closure2',
@@ -1378,6 +1389,86 @@ test_shared_detector_finds_transitive_step_parent_distance :-
         member(edge_pred(kdedge/2), ConfigOps)
     ->  pass(Test)
     ;   fail_test(Test, 'kdsp/5 not detected as transitive_step_parent_distance5 by shared detector')
+    ).
+
+test_graph_kernel_weighted_shortest_path_emitted_in_runtime :-
+    % First weighted-graph kernel (after the four unweighted DFS
+    % kernels in PRs #1799/#1803/#1822/#1823/#1824). Dijkstra via
+    % :gb_sets priority queue. Same testing posture as the
+    % unweighted kernels: emit-and-grep on the runtime + dispatch
+    % wrapper, then end-to-end smoke test against the runtime.
+    Test = 'GraphKernel WeightedShortestPath: runtime emits WamRuntime.GraphKernel.WeightedShortestPath',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    (   sub_string(RuntimeCode, _, _, _, 'defmodule WamRuntime.GraphKernel.WeightedShortestPath do'),
+        sub_string(RuntimeCode, _, _, _, 'def collect_path_costs('),
+        sub_string(RuntimeCode, _, _, _, 'def collect_path_costs_from_source(')
+    ->  pass(Test)
+    ;   fail_test(Test, 'GraphKernel.WeightedShortestPath module missing expected API')
+    ).
+
+test_graph_kernel_wsp_uses_gb_sets_priority_queue :-
+    % BEAMs natural min-heap is :gb_sets ordered by Erlang term
+    % comparison ({cost, node} tuples sort by cost first, then node).
+    % :gb_sets.take_smallest/1 is the pop primitive. Without a real
+    % priority queue Dijkstra is O(V^2); with it we get O((V+E) log V).
+    Test = 'GraphKernel WeightedShortestPath: uses :gb_sets priority queue for Dijkstra',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    Pattern = "defmodule WamRuntime.GraphKernel.WeightedShortestPath do",
+    EndPattern = "defmodule WamRuntime.GraphKernel.CategoryAncestor do",
+    (   sub_string(RuntimeCode, Start, _, _, Pattern),
+        sub_string(RuntimeCode, End, _, _, EndPattern),
+        End > Start,
+        BodyLen is End - Start,
+        sub_string(RuntimeCode, Start, BodyLen, _, Body),
+        % Min-heap construction + pop.
+        sub_string(Body, _, _, _, ":gb_sets.singleton({0, start})"),
+        sub_string(Body, _, _, _, ":gb_sets.take_smallest(heap)"),
+        % Stale-entry skip (the canonical Dijkstra optimisation).
+        sub_string(Body, _, _, _, "if cost > best do"),
+        % Documents the semantic narrowing (all-paths -> shortest).
+        sub_string(Body, _, _, _, "semantic narrowing"),
+        sub_string(Body, _, _, _, "computes only the SHORTEST")
+    ->  pass(Test)
+    ;   fail_test(Test, 'WeightedShortestPath kernel missing :gb_sets primitives or semantic-narrowing note')
+    ).
+
+test_kernel_dispatch_emits_weighted_shortest_path_module :-
+    % End-to-end: detector recognises kdwsp/3 as
+    % weighted_shortest_path3, dispatch wrapper emits with two-register
+    % binding (target, cost) and 3-arity edge predicate ("kdweighted_edge/3").
+    Test = 'Kernel dispatch: weighted_shortest_path3 kernel emits Probe.Kdwsp dispatch module',
+    setup_kernel_fixtures,
+    wam_target:compile_predicate_to_wam(user:kdwsp/3, [], WspWam),
+    write_wam_elixir_project([kdwsp/3-WspWam],
+        [module_name(probe), emit_mode(lowered),
+         intra_query_parallel(false),
+         kernel_dispatch(true), source_module(user)],
+        '/tmp/test_kernel_disp_wsp'),
+    read_file_to_string('/tmp/test_kernel_disp_wsp/lib/kdwsp.ex', S, []),
+    (   sub_string(S, _, _, _, "WamRuntime.GraphKernel.WeightedShortestPath"),
+        sub_string(S, _, _, _, "collect_path_costs("),
+        % 3-arity edge predicate indicator: weighted_edge/3
+        sub_string(S, _, _, _, "kdweighted_edge/3"),
+        % Aggregate-frame slicing for two regs (target=2, cost=3).
+        sub_string(S, _, _, _, "agg_cp.agg_value_reg"),
+        sub_string(S, _, _, _, "in_forkable_aggregate_frame?"),
+        % Driver-direct binding of both regs.
+        sub_string(S, _, _, _, "bind_two_regs(state, "),
+        sub_string(S, _, _, _, "split_at_aggregate_cp(state)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'weighted_shortest_path3 dispatch module missing expected shape')
+    ).
+
+test_shared_detector_finds_weighted_shortest_path :-
+    Test = 'Shared detector: kdwsp/3 with canonical weighted_shortest_path shape detected',
+    setup_kernel_fixtures,
+    functor(Head, kdwsp, 3),
+    findall(Head-Body, user:clause(Head, Body), Clauses),
+    (   detect_recursive_kernel(kdwsp, 3, Clauses,
+            recursive_kernel(weighted_shortest_path3, kdwsp/3, ConfigOps)),
+        member(edge_pred(kdweighted_edge/3), ConfigOps)
+    ->  pass(Test)
+    ;   fail_test(Test, 'kdwsp/3 not detected as weighted_shortest_path3 by shared detector')
     ).
 
 test_graph_kernel_tc_uses_visited_tracking :-
@@ -2558,6 +2649,10 @@ run_tests :-
     test_graph_kernel_tspd_reuses_parent_distance_walker,
     test_kernel_dispatch_emits_transitive_step_parent_distance_module,
     test_shared_detector_finds_transitive_step_parent_distance,
+    test_graph_kernel_weighted_shortest_path_emitted_in_runtime,
+    test_graph_kernel_wsp_uses_gb_sets_priority_queue,
+    test_kernel_dispatch_emits_weighted_shortest_path_module,
+    test_shared_detector_finds_weighted_shortest_path,
     test_graph_kernel_tc_uses_visited_tracking,
     test_graph_kernel_tc_factsource_bridge,
     test_intern_atoms_default_off,


### PR DESCRIPTION
## Summary

First weighted-graph kernel — Dijkstra shortest-path. **6 of 7 kernels in Elixir now match Rust+Haskell.** The remaining one (`astar_shortest_path4`) builds on this Dijkstra primitive plus a heuristic.

| Kernel kind | Rust | Haskell | Elixir |
|---|:-:|:-:|:-:|
| `transitive_closure2` | ✓ | ✓ | ✓ |
| `category_ancestor` | ✓ | ✓ | ✓ |
| `transitive_distance3` | ✓ | ✓ | ✓ |
| `transitive_parent_distance4` | ✓ | ✓ | ✓ |
| `transitive_step_parent_distance5` | ✓ | ✓ | ✓ |
| **`weighted_shortest_path3`** | ✓ | ✓ | **✓ this PR** |
| `astar_shortest_path4` | ✓ | ✓ | — |

## Semantic narrowing (documented prominently)

The canonical Prolog pattern enumerates ALL paths from start to target with their summed weights; this kernel computes only the SHORTEST. Match Rust's `collect_native_weighted_shortest_path_results` reference exactly.

```
findall(W, wsp(s, t, W), Ws)
;; Prolog source: yields ALL path weights to t.
;; Kernel:        yields a 1-element list — only the shortest.

aggregate_all(min, wsp(s, t, W), MinW)
;; Both produce same answer; kernel runs in O(E log V) instead
;; of exponential path enumeration.
```

## Implementation

`WamRuntime.GraphKernel.WeightedShortestPath`:
- `collect_path_costs/2`: returns `[{target, cost}, ...]` for shortest-path cost from `start`.
- `collect_path_costs_from_source/4`: FactSource convenience (3-arity `weighted_edge` predicate).

**Priority queue: `:gb_sets`**
- `:gb_sets` of `{cost, node}` tuples — Erlang term ordering puts numerically-smaller cost first, ties broken by node ordering. Min-first via `:gb_sets.take_smallest/1`.
- `dist` map (`node -> shortest-known-cost`) with the canonical stale-entry skip: when popping `{cost, node}`, if `dist[node]` is already lower, skip without expanding.
- **Naturally cycle-safe** — cyclic graphs terminate because `dist` updates only on improvement. No explicit visited list needed (unlike PRs #1823 / #1824 which inherit Rust's no-cycle-detection contract).

Caller responsibility: weights must be non-negative for Dijkstra's correctness. Kernel does not validate this.

**Dispatch wrapper** (`compile_weighted_shortest_path_dispatch_module/4`): TWO enumerated registers per solution (A2 target, A3 cost). Wrapper slices on `:agg_value_reg`. Edge predicate is 3-ary — emitted indicator is `<pred>/3` (vs `/2` for unweighted kernels). FactSource adaptors that back this kernel must support `arity == 3` and return `[{from, to, weight}, ...]` from `lookup_by_arg1`.

## Test plan

- [x] **141 wam-elixir tests pass** (was 137; +4 new).
- [x] Tests assert `:gb_sets` priority-queue primitives, canonical Dijkstra stale-entry skip, and the documented semantic narrowing in the moduledoc.
- [x] **Smoke-tested correctness** on a weighted graph with a longer-but-direct edge:
  ```
  a --1.0--> b --2.0--> d   (cost via b: 3.0)
  a --5.0--> d              (direct: 5.0; longer)
  a --2.5--> c --1.0--> d   (cost via c: 3.5; longer)
  ```
  Output: `a→b: 1.0, a→c: 2.5, a→d: 3.0` — correctly picks via b over the direct edge.
- [x] **Smoke-tested cycle handling**: `a→b→a→b→...` plus `b→c`. Dijkstra terminates correctly via the dist-map bound; `a→c` yields cost 6.0 as expected. No infinite loop on cycles (unlike the no-visited DFS kernels in PRs #1823/#1824).

## What's left

One more: `astar_shortest_path4` — A* with heuristic. Builds on this PR's Dijkstra primitives (`:gb_sets` priority queue, dist map with stale-entry skip) but adds a heuristic estimate on every push and stops when the goal pops from the heap. Optional `direct_dist_pred` for the heuristic; if absent the kernel degenerates to Dijkstra.

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_