### PR TITLE
feat(wam-elixir): AstarShortestPath kernel + dispatch (7 of 7 — COMPLETE)

### DIFF
--- a/docs/WAM_TARGET_ROADMAP.md
+++ b/docs/WAM_TARGET_ROADMAP.md
@@ -240,15 +240,12 @@ In rough order of expected payoff:
    | `transitive_parent_distance4` | ✓ | ✓ | ✓ (PR #1823) |
    | `transitive_step_parent_distance5` | ✓ | ✓ | ✓ (PR #1824) |
    | `weighted_shortest_path3` | ✓ | ✓ | ✓ (PR #1825) |
-   | `astar_shortest_path4` | ✓ | ✓ | — |
+   | `astar_shortest_path4` | ✓ | ✓ | ✓ (PR #1826) |
 
-   Remaining: `astar_shortest_path4` (A* with heuristic — most
-   complex; goal-directed search instead of full enumeration,
-   optional direct-distance heuristic predicate). Builds on the
-   Dijkstra primitives shipped with `weighted_shortest_path3` —
-   `:gb_sets` priority queue, dist map with stale-entry skip — but
-   adds a heuristic estimate on every push and stops when the goal
-   pops from the heap.
+   **Coverage complete.** All 7 kernel kinds the shared detector
+   (`recursive_kernel_detection.pl`) recognises now have native
+   Elixir kernel + dispatch-wrapper implementations, matching the
+   coverage Rust and Haskell already had.
 
 3. **Tier-2 outer-loop parallelism, but emitter-driven.** The
    parallel-fanout numbers in `benchmarks/wam_effective_distance_cross_target.md`

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -2999,6 +2999,156 @@ defmodule WamRuntime.GraphKernel.WeightedShortestPath do
   end
 end
 
+defmodule WamRuntime.GraphKernel.AstarShortestPath do
+  @moduledoc """
+  Native A* shortest-path kernel — bypasses WAM dispatch for the
+  canonical pattern:
+
+      astar(X, Y, _Dim, W) :- weighted_edge(X, Y, W).
+      astar(X, Y, Dim, TotalW) :-
+          weighted_edge(X, Mid, W1),
+          astar(Mid, Y, Dim, RestW),
+          TotalW is RestW + W1.
+
+  Goal-directed shortest-path search with a dimensionality-aware
+  heuristic. Priority: f(n) = g(n)^D + h(n)^D where D is graph
+  dimensionality. h(n) = direct semantic distance from n to target
+  (via the configured `direct_dist_fn`). Minkowski-style f-cost
+  (NOT standard Euclidean f = g + h) — by Minkowski inequality this
+  is admissible and tighter than L1 A*.
+
+  Ported from the Rust kernel
+  `collect_native_astar_shortest_path_results` in
+  src/unifyweaver/targets/wam_rust_target.pl. Identical algorithm:
+  min-heap keyed by f-cost, dist map for stale-entry skip, early
+  termination when target pops, post-filter dist map.
+
+  Dijkstra fallback: if `target` is `nil`, the heuristic returns 0
+  for every node, f-cost reduces to g(n)^D, and the search behaves
+  like Dijkstra (no early termination — explores all reachable).
+  This matches Rusts `target.is_empty()` branch.
+
+  Two edge predicates per call:
+    - `weighted_edges_fn(node)` -> [{from, to, weight}, ...]
+      Forward weighted edges. Same contract as
+      WeightedShortestPath.collect_path_costs/2.
+    - `direct_dist_fn(node)` -> [{from, to, weight}, ...]
+      Heuristic edges from `node`. The kernel filters for the entry
+      where `to == target`; if none, defaults to 1.0 (Rusts
+      "conservative default"). When no separate `direct_dist_pred`
+      is configured, callers pass `weighted_edges_fn` here too —
+      using forward edges as the heuristic is admissible (any direct
+      edge weight is a lower bound on shortest path through it).
+
+  Result shape: same as WeightedShortestPath — `[{node, g_cost}, ...]`
+  for every node whose dist was finalised before target popped, plus
+  target itself. With early termination, result size depends on
+  search depth, not graph size. Caller post-filters to target if
+  only that single result is wanted (the dispatch wrapper does this
+  when target is bound on entry).
+
+  Cycle handling: same as Dijkstra (PR #1825) — naturally bounded
+  via the dist map. No explicit visited list needed.
+  """
+
+  @doc """
+  Returns `[{node, g_cost}, ...]` — finalised shortest-path costs
+  from `start` to nodes explored by A* search. With `target` bound,
+  search terminates as soon as target pops from the heap; result
+  contains target plus all nodes finalised along the way. With
+  `target == nil`, behaves like Dijkstra (full reachable set).
+
+  `dim` is the Minkowski exponent for f-cost. Use 5 by default
+  (matches Rusts foreign_usize_config fallback for `dimensionality`).
+  """
+  def collect_path_costs(weighted_edges_fn, direct_dist_fn, start, target, dim)
+      when is_function(weighted_edges_fn, 1) and is_function(direct_dist_fn, 1)
+       and is_number(dim) do
+    h_start = heuristic(direct_dist_fn, start, target)
+    initial_f = f_cost(0, h_start, dim)
+    initial_dist = %{start => 0}
+    initial_heap = :gb_sets.singleton({initial_f, 0, start})
+    final_dist = astar_loop(weighted_edges_fn, direct_dist_fn, target, dim,
+                            initial_heap, initial_dist)
+    final_dist
+    |> Enum.flat_map(fn
+      {^start, _} -> []
+      {node, cost} -> [{node, cost}]
+    end)
+  end
+
+  defp astar_loop(weighted_edges_fn, direct_dist_fn, target, dim, heap, dist) do
+    case :gb_sets.is_empty(heap) do
+      true -> dist
+      false ->
+        {{_f_cost, g_cost, node}, heap1} = :gb_sets.take_smallest(heap)
+        best = Map.fetch!(dist, node)
+        cond do
+          # Stale-entry skip: better path was found AFTER pushing this entry.
+          g_cost > best ->
+            astar_loop(weighted_edges_fn, direct_dist_fn, target, dim, heap1, dist)
+
+          # Early termination: target popped from heap. With an admissible
+          # heuristic this is guaranteed to be the shortest path to target.
+          target != nil and node == target ->
+            dist
+
+          # Expand neighbours.
+          true ->
+            edges = weighted_edges_fn.(node)
+            {new_heap, new_dist} =
+              edges
+              |> Enum.reduce({heap1, dist}, fn {_from, next, weight}, {h, d} ->
+                next_g = g_cost + weight
+                case Map.fetch(d, next) do
+                  {:ok, prev} when prev <= next_g ->
+                    {h, d}
+                  _ ->
+                    h_next = heuristic(direct_dist_fn, next, target)
+                    f_next = f_cost(next_g, h_next, dim)
+                    {:gb_sets.add({f_next, next_g, next}, h),
+                     Map.put(d, next, next_g)}
+                end
+              end)
+            astar_loop(weighted_edges_fn, direct_dist_fn, target, dim,
+                       new_heap, new_dist)
+        end
+    end
+  end
+
+  # h(n) = direct distance from `node` to `target`. nil target means
+  # Dijkstra mode (no goal). Default 1.0 if no direct edge recorded
+  # (matches Rusts conservative default).
+  defp heuristic(_direct_dist_fn, _node, nil), do: 0
+  defp heuristic(direct_dist_fn, node, target) do
+    edges = direct_dist_fn.(node)
+    Enum.find_value(edges, 1.0, fn
+      {_from, to, w} when to == target -> w
+      _ -> false
+    end)
+  end
+
+  # f(n) = g(n)^D + h(n)^D — Minkowski-style. NOT standard A*s g + h.
+  defp f_cost(g, h, dim), do: :math.pow(g, dim) + :math.pow(h, dim)
+
+  @doc """
+  Convenience for FactSource-backed graphs. Both `weighted_source` and
+  `direct_source` may be the same handle if no separate
+  direct_dist_pred is configured (the detectors fallback shape).
+  """
+  def collect_path_costs_from_source(weighted_source_module, weighted_source_handle,
+                                     direct_source_module, direct_source_handle,
+                                     start, target, dim, state \\\\ nil) do
+    weighted_fn = fn node ->
+      weighted_source_module.lookup_by_arg1(weighted_source_handle, node, state)
+    end
+    direct_fn = fn node ->
+      direct_source_module.lookup_by_arg1(direct_source_handle, node, state)
+    end
+    collect_path_costs(weighted_fn, direct_fn, start, target, dim)
+  end
+end
+
 defmodule WamRuntime.GraphKernel.CategoryAncestor do
   @moduledoc """
   Native bounded-ancestor kernel — path-enumeration variant of TC
@@ -3659,6 +3809,13 @@ emit_kernel_dispatch_module(ModuleName, Pred, _Arity,
                             Code) :-
     member(edge_pred(EdgePred/_), ConfigOps),
     compile_weighted_shortest_path_dispatch_module(ModuleName, Pred, EdgePred, Code).
+emit_kernel_dispatch_module(ModuleName, Pred, _Arity,
+                            recursive_kernel(astar_shortest_path4, _, ConfigOps),
+                            Code) :-
+    member(edge_pred(EdgePred/_), ConfigOps),
+    member(direct_dist_pred(DirectPred/_), ConfigOps),
+    member(dimensionality(Dim), ConfigOps),
+    compile_astar_shortest_path_dispatch_module(ModuleName, Pred, EdgePred, DirectPred, Dim, Code).
 
 %% compile_tc_kernel_dispatch_module(+ModuleName, +Pred, +EdgePred, -Code)
 %
@@ -4474,6 +4631,185 @@ end
      PredStr, EdgePredStr,
      EdgeKey,
      EdgeKey,
+     CamelPred]).
+
+%% compile_astar_shortest_path_dispatch_module(+ModuleName, +Pred, +EdgePred, +DirectPred, +Dim, -Code)
+%
+%  Dispatch module for the astar_shortest_path4 pattern. Routes
+%  calls through WamRuntime.GraphKernel.AstarShortestPath. Reads
+%  TWO FactSources at runtime (weighted_edge + direct_dist edges)
+%  via the registry, plus three argument registers:
+%    - A1: start (must be bound to an atom)
+%    - A2: target (atom for goal-directed mode; unbound for Dijkstra
+%      fallback)
+%    - A3: dim (number on entry overrides default; unbound uses
+%      compile-time Dim from kernel config)
+%    - A4: cost (typically unbound; gets bound on success)
+%
+%  TWO enumerated registers per solution: A2 (target, only if it
+%  was unbound on entry) and A4 (cost). When target is bound on
+%  entry, the kernel returns AT MOST ONE solution (the goal cost).
+%
+%  Driver-direct call: bind_two_regs/4 binds A2 and A4 (skipping
+%  A2 if already bound) to the first solution.
+compile_astar_shortest_path_dispatch_module(ModuleName, Pred, EdgePred, DirectPred, Dim, Code) :-
+    atom_string(ModuleName, ModName),
+    camel_case(ModName, CamelMod),
+    atom_string(Pred, PredStr),
+    camel_case(PredStr, CamelPred),
+    atom_string(EdgePred, EdgePredStr),
+    atom_string(DirectPred, DirectPredStr),
+    format(string(EdgeKey), "~w/3", [EdgePredStr]),
+    format(string(DirectKey), "~w/3", [DirectPredStr]),
+    format(string(Code),
+'defmodule ~w.~w do
+  @moduledoc """
+  Kernel-dispatched ~w/4 (auto-recognised astar_shortest_path4 pattern
+  over ~w/3 with ~w/3 as the heuristic source). Routes calls through
+  WamRuntime.GraphKernel.AstarShortestPath.
+
+  Both edge sources must be registered via WamRuntime.FactSourceRegistry:
+    - "~w" — forward weighted edges
+    - "~w" — direct heuristic distances (may be the same indicator
+      if no separate direct_dist_pred was configured at compile time)
+  """
+
+  @default_dim ~w
+
+  def run(%WamRuntime.WamState{} = state) do
+    start_val = WamRuntime.deref_var(state, WamRuntime.get_reg(state, 1))
+    target_raw = WamRuntime.deref_var(state, WamRuntime.get_reg(state, 2))
+    dim_raw = WamRuntime.deref_var(state, WamRuntime.get_reg(state, 3))
+
+    # target: nil = unbound (Dijkstra mode); else the atom/binary.
+    target_val =
+      case target_raw do
+        {:unbound, _} -> nil
+        v -> v
+      end
+
+    # dim: numeric override on entry; else the compile-time default.
+    dim_val =
+      case dim_raw do
+        {:unbound, _} -> @default_dim
+        n when is_number(n) -> n
+        _ -> @default_dim
+      end
+
+    weighted_handle = WamRuntime.FactSourceRegistry.lookup!("~w")
+    direct_handle = WamRuntime.FactSourceRegistry.lookup!("~w")
+    weighted_fn = fn node ->
+      WamRuntime.FactSource.lookup_by_arg1(weighted_handle, node, state)
+    end
+    direct_fn = fn node ->
+      WamRuntime.FactSource.lookup_by_arg1(direct_handle, node, state)
+    end
+
+    pairs =
+      WamRuntime.GraphKernel.AstarShortestPath.collect_path_costs(
+        weighted_fn, direct_fn, start_val, target_val, dim_val)
+
+    # Post-filter: when target was bound on entry, surface only its
+    # entry from the dist map (matches Rust dispatchs `results.retain`
+    # behaviour). When target was unbound, return the full set
+    # (Dijkstra mode).
+    pairs =
+      case target_val do
+        nil -> pairs
+        t -> Enum.filter(pairs, fn {n, _} -> n == t end)
+      end
+
+    if WamRuntime.in_forkable_aggregate_frame?(state) do
+      {above, agg_cp, below} = WamRuntime.split_at_aggregate_cp(state)
+      contributions =
+        case agg_cp.agg_value_reg do
+          2 -> Enum.map(pairs, fn {t, _w} -> t end)
+          4 -> Enum.map(pairs, fn {_t, w} -> w end)
+          _ -> pairs
+        end
+      new_accum = agg_cp.agg_accum ++ contributions
+      new_agg_cp = %{agg_cp | agg_accum: new_accum}
+      new_state = %{state | choice_points: above ++ [new_agg_cp | below]}
+      throw({:fail, new_state})
+    else
+      case pairs do
+        [{first_target, first_cost} | _] ->
+          case bind_target_and_cost(state, target_val, first_target, first_cost) do
+            nil -> throw({:fail, state})
+            bound -> {:ok, bound}
+          end
+        [] -> throw({:fail, state})
+      end
+    end
+  end
+
+  def run(args) when is_list(args) do
+    state = %WamRuntime.WamState{code: {}, labels: %{}, pc: 1}
+    {state, arg_vars} =
+      Enum.with_index(args, 1)
+      |> Enum.reduce({state, []}, fn {arg, i}, {s, vars} ->
+        case arg do
+          {:unbound, _} ->
+            v = {:unbound, make_ref()}
+            {%{s | regs: Map.put(s.regs, i, v)}, [{i, v} | vars]}
+          other ->
+            {%{s | regs: Map.put(s.regs, i, other)}, vars}
+        end
+      end)
+    state = %{state | arg_vars: arg_vars, cp: &WamRuntime.terminal_cp/1}
+    try do
+      case run(state) do
+        {:ok, final} -> {:ok, WamRuntime.materialise_args(final)}
+        other -> other
+      end
+    catch
+      {:fail, _} -> :fail
+      {:return, result} -> result
+      error ->
+        IO.puts("Predicate ~w CRASHED: #{inspect(error)}")
+        :fail
+    end
+  end
+
+  # If target was bound on entry, A2 is already set — skip rebinding.
+  # Always bind A4 (cost).
+  defp bind_target_and_cost(state, nil, first_target, first_cost) do
+    # Target was unbound on entry — bind both A2 and A4.
+    with {:ok, s1} <- bind_one(state, 2, first_target),
+         {:ok, s2} <- bind_one(s1, 4, first_cost) do
+      s2
+    else
+      _ -> nil
+    end
+  end
+  defp bind_target_and_cost(state, _bound_target, _first_target, first_cost) do
+    # Target was bound on entry — only bind A4.
+    case bind_one(state, 4, first_cost) do
+      {:ok, s} -> s
+      _ -> nil
+    end
+  end
+
+  defp bind_one(state, reg_idx, value) do
+    case Map.get(state.regs, reg_idx) do
+      {:unbound, id} ->
+        {:ok,
+         state
+         |> WamRuntime.trail_binding(id)
+         |> WamRuntime.put_reg(id, value)}
+      ^value -> {:ok, state}
+      _ -> :error
+    end
+  end
+end
+',
+    [CamelMod, CamelPred,
+     PredStr, EdgePredStr, DirectPredStr,
+     EdgeKey,
+     DirectKey,
+     Dim,
+     EdgeKey,
+     DirectKey,
      CamelPred]).
 
 atom_interning_cleanup(Options) :-

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -1015,7 +1015,29 @@ setup_kernel_fixtures :-
     assertz((user:kdwsp(X, Y, TotalW) :-
                 user:kdweighted_edge(X, Mid, W1),
                 user:kdwsp(Mid, Y, RestW),
-                TotalW is RestW + W1)).
+                TotalW is RestW + W1)),
+    % astar_shortest_path4 fixture: 4-ary canonical shape with Dim
+    % passthrough. Reuses kdweighted_edge/3 as the forward edge source;
+    % a separate kddirect/3 is asserted as the heuristic source via
+    % the optional direct_dist_pred/1 user fact (detector falls back
+    % to the same edge predicate if no direct_dist_pred is asserted).
+    %   astar(X, Y, _Dim, W) :- weighted_edge(X, Y, W).
+    %   astar(X, Y, Dim, TotalW) :- weighted_edge(X, Mid, W1),
+    %                              astar(Mid, Y, Dim, RestW),
+    %                              TotalW is RestW + W1.
+    retractall(user:kdastar(_, _, _, _)),
+    retractall(user:direct_dist_pred(_)),
+    retractall(user:dimensionality(_)),
+    assertz((user:kdastar(X, Y, _Dim, W) :- user:kdweighted_edge(X, Y, W))),
+    assertz((user:kdastar(X, Y, Dim, TotalW) :-
+                user:kdweighted_edge(X, Mid, W1),
+                user:kdastar(Mid, Y, Dim, RestW),
+                TotalW is RestW + W1)),
+    % Optional config the detector reads: tells it to use kdweighted_edge/3
+    % as the heuristic source (same as forward edges — admissible because
+    % a direct edges weight is a lower bound on shortest path through it).
+    assertz(user:direct_dist_pred(kdweighted_edge/3)),
+    assertz(user:dimensionality(5)).
 
 test_shared_detector_finds_tc :-
     Test = 'Shared detector: kdtc/2 with canonical TC shape detected as transitive_closure2',
@@ -1469,6 +1491,95 @@ test_shared_detector_finds_weighted_shortest_path :-
         member(edge_pred(kdweighted_edge/3), ConfigOps)
     ->  pass(Test)
     ;   fail_test(Test, 'kdwsp/3 not detected as weighted_shortest_path3 by shared detector')
+    ).
+
+test_graph_kernel_astar_shortest_path_emitted_in_runtime :-
+    % Final kernel — closes the 7-of-7 coverage table. Builds on
+    % WSPs Dijkstra primitives (:gb_sets priority queue + dist map)
+    % adding a heuristic estimate and early termination.
+    Test = 'GraphKernel AstarShortestPath: runtime emits WamRuntime.GraphKernel.AstarShortestPath',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    (   sub_string(RuntimeCode, _, _, _, 'defmodule WamRuntime.GraphKernel.AstarShortestPath do'),
+        sub_string(RuntimeCode, _, _, _, 'def collect_path_costs('),
+        sub_string(RuntimeCode, _, _, _, 'def collect_path_costs_from_source(')
+    ->  pass(Test)
+    ;   fail_test(Test, 'GraphKernel.AstarShortestPath module missing expected API')
+    ).
+
+test_graph_kernel_astar_uses_minkowski_f_cost :-
+    % UnifyWeavers A* uses Minkowski-style f(n) = g^D + h^D, NOT the
+    % standard f = g + h. Per Rusts reference impl which documents
+    % "By Minkowski inequality this is admissible and tighter than L1
+    % A*". The kernel must use :math.pow for both g and h to preserve
+    % this contract.
+    Test = 'GraphKernel AstarShortestPath: f-cost uses Minkowski g^D + h^D (NOT g + h)',
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    Pattern = "defmodule WamRuntime.GraphKernel.AstarShortestPath do",
+    EndPattern = "defmodule WamRuntime.GraphKernel.CategoryAncestor do",
+    (   sub_string(RuntimeCode, Start, _, _, Pattern),
+        sub_string(RuntimeCode, End, _, _, EndPattern),
+        End > Start,
+        BodyLen is End - Start,
+        sub_string(RuntimeCode, Start, BodyLen, _, Body),
+        % Minkowski f-cost helper.
+        sub_string(Body, _, _, _, ":math.pow(g, dim) + :math.pow(h, dim)"),
+        % Stale-entry skip + early termination on target.
+        sub_string(Body, _, _, _, "g_cost > best"),
+        sub_string(Body, _, _, _, "target != nil and node == target"),
+        % Documents the Minkowski narrowing.
+        sub_string(Body, _, _, _, "Minkowski-style f-cost"),
+        % :gb_sets primitives reused from WSP.
+        sub_string(Body, _, _, _, ":gb_sets.take_smallest(heap)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'AstarShortestPath kernel missing Minkowski f-cost or A* primitives')
+    ).
+
+test_kernel_dispatch_emits_astar_shortest_path_module :-
+    % End-to-end: detector recognises kdastar/4 as
+    % astar_shortest_path4 (with the user-asserted direct_dist_pred
+    % and dimensionality facts), dispatch wrapper emits with TWO
+    % FactSource lookups + two-register binding (target=2, cost=4),
+    % skipping target rebinding when bound on entry.
+    Test = 'Kernel dispatch: astar_shortest_path4 kernel emits Probe.Kdastar dispatch module',
+    setup_kernel_fixtures,
+    wam_target:compile_predicate_to_wam(user:kdastar/4, [], AstarWam),
+    write_wam_elixir_project([kdastar/4-AstarWam],
+        [module_name(probe), emit_mode(lowered),
+         intra_query_parallel(false),
+         kernel_dispatch(true), source_module(user)],
+        '/tmp/test_kernel_disp_astar'),
+    read_file_to_string('/tmp/test_kernel_disp_astar/lib/kdastar.ex', S, []),
+    (   sub_string(S, _, _, _, "WamRuntime.GraphKernel.AstarShortestPath"),
+        sub_string(S, _, _, _, "collect_path_costs("),
+        % TWO FactSource lookups (forward + heuristic).
+        sub_string(S, _, _, _, "weighted_handle = WamRuntime.FactSourceRegistry.lookup!"),
+        sub_string(S, _, _, _, "direct_handle = WamRuntime.FactSourceRegistry.lookup!"),
+        % Edge indicator is /3.
+        sub_string(S, _, _, _, "kdweighted_edge/3"),
+        % Compile-time dim default attribute.
+        sub_string(S, _, _, _, "@default_dim 5"),
+        % Aggregate-frame slicing for two regs (target=2, cost=4).
+        sub_string(S, _, _, _, "agg_cp.agg_value_reg"),
+        sub_string(S, _, _, _, "in_forkable_aggregate_frame?"),
+        % Driver-direct binding: target may be already bound on entry.
+        sub_string(S, _, _, _, "bind_target_and_cost(state, "),
+        sub_string(S, _, _, _, "split_at_aggregate_cp(state)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'astar_shortest_path4 dispatch module missing expected shape')
+    ).
+
+test_shared_detector_finds_astar_shortest_path :-
+    Test = 'Shared detector: kdastar/4 with canonical astar_shortest_path shape detected',
+    setup_kernel_fixtures,
+    functor(Head, kdastar, 4),
+    findall(Head-Body, user:clause(Head, Body), Clauses),
+    (   detect_recursive_kernel(kdastar, 4, Clauses,
+            recursive_kernel(astar_shortest_path4, kdastar/4, ConfigOps)),
+        member(edge_pred(kdweighted_edge/3), ConfigOps),
+        member(direct_dist_pred(kdweighted_edge/3), ConfigOps),
+        member(dimensionality(5), ConfigOps)
+    ->  pass(Test)
+    ;   fail_test(Test, 'kdastar/4 not detected as astar_shortest_path4 by shared detector')
     ).
 
 test_graph_kernel_tc_uses_visited_tracking :-
@@ -2653,6 +2764,10 @@ run_tests :-
     test_graph_kernel_wsp_uses_gb_sets_priority_queue,
     test_kernel_dispatch_emits_weighted_shortest_path_module,
     test_shared_detector_finds_weighted_shortest_path,
+    test_graph_kernel_astar_shortest_path_emitted_in_runtime,
+    test_graph_kernel_astar_uses_minkowski_f_cost,
+    test_kernel_dispatch_emits_astar_shortest_path_module,
+    test_shared_detector_finds_astar_shortest_path,
     test_graph_kernel_tc_uses_visited_tracking,
     test_graph_kernel_tc_factsource_bridge,
     test_intern_atoms_default_off,


### PR DESCRIPTION
## Summary

**Final kernel — closes the 7-of-7 coverage table.** All graph kernels recognised by the shared detector (`recursive_kernel_detection.pl`) now have native Elixir implementations matching Rust + Haskell.

| Kernel kind | Rust | Haskell | Elixir |
|---|:-:|:-:|:-:|
| `transitive_closure2` | ✓ | ✓ | ✓ |
| `category_ancestor` | ✓ | ✓ | ✓ |
| `transitive_distance3` | ✓ | ✓ | ✓ |
| `transitive_parent_distance4` | ✓ | ✓ | ✓ |
| `transitive_step_parent_distance5` | ✓ | ✓ | ✓ |
| `weighted_shortest_path3` | ✓ | ✓ | ✓ |
| **`astar_shortest_path4`** | ✓ | ✓ | **✓ this PR** |

**7 of 7 complete.** 🎉

## Implementation

A* shortest-path with **Minkowski-style** f-cost (NOT standard `f = g + h`). Builds directly on PR #1825's Dijkstra primitives (`:gb_sets` priority queue + dist map with stale-entry skip) and adds:
- A heuristic estimate on every push: `h(n) = direct_distance(n, target)` or `1.0` default.
- f-cost: `f(n) = g(n)^D + h(n)^D` (Minkowski; admissible by Minkowski inequality, tighter than L1 A*).
- Early termination when target pops from the heap.
- Dijkstra fallback when `target` is `nil`.

Ports Rust's `collect_native_astar_shortest_path_results` exactly.

**`WamRuntime.GraphKernel.AstarShortestPath`** module:
- `collect_path_costs/5(weighted_edges_fn, direct_dist_fn, start, target, dim)`
- `collect_path_costs_from_source/8` (FactSource convenience for both source modules + handles).

Two edge predicates: `weighted_edges_fn` (forward) and `direct_dist_fn` (heuristic — may be the same fn when no separate `direct_dist_pred` is configured; using forward edges as the heuristic is admissible because a direct edge's weight is a lower bound on shortest path through that edge).

**`compile_astar_shortest_path_dispatch_module/6`** emits the per-predicate dispatch wrapper. Reads BOTH FactSources at runtime (weighted + direct), plus four argument registers:
- A1: start (bound)
- A2: target (atom for goal-directed; unbound for Dijkstra fallback)
- A3: dim (numeric override; unbound uses compile-time `@default_dim` from kernel config)
- A4: cost (typically unbound)

Post-filter: when target was bound on entry, surface only its entry from the dist map (matches Rust dispatch's `results.retain`). Driver-direct call: `bind_target_and_cost/4` binds A2 + A4 if A2 was unbound; only A4 otherwise.

Wired into `emit_kernel_dispatch_module/5` with **three** ConfigOps reads: `edge_pred` + `direct_dist_pred` + `dimensionality`.

## Test plan

- [x] **145 wam-elixir tests pass** (was 141; +4 new).
- [x] Tests assert Minkowski f-cost (`:math.pow(g, dim) + :math.pow(h, dim)` — NOT `g + h`), canonical A* primitives (stale-entry skip + early termination), reuses `:gb_sets.take_smallest` from WSP, documents the Minkowski narrowing in moduledoc.
- [x] **Smoke-tested end-to-end with three cases:**
  1. **Bound target (goal-directed)**: `a→d` picks shortest path 3.0 via b, NOT direct 5.0 edge. A* early-terminates correctly.
  2. **Unbound target (Dijkstra fallback)**: explores all reachable with correct shortest costs (a→b: 1.0, a→c: 2.5, a→d: 3.0).
  3. **Cyclic graph terminates**: `a→b→a→b→...` plus `b→c` yields `a→c` cost 6.0 without infinite loop.

## Conclusion

The Elixir kernel coverage table is **closed**. Across PRs #1799 → #1826, the WAM-Elixir target now ships native, dispatch-wrapper-routed implementations of all 7 graph kernels in the shared detector. Each kernel:

- Mirrors the corresponding Rust reference impl in algorithm and contract.
- Has emit-and-grep tests for the runtime + dispatch wrapper.
- Has a `kdN`-prefixed Prolog fixture in `setup_kernel_fixtures` exercising the shared detector.
- Has at least one end-to-end smoke test confirming correctness on a small graph.

The kernel-coverage gap with Rust+Haskell on Wikipedia-scale graph workloads is closed at the shared-detector level. Remaining perf headroom is in the workload-shape orthogonal optimisations from earlier PRs (int-tuple FactSource scaling, fold-form aggregation, chunked outer-loop parallelism).

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_