### PR TITLE
test(wam-elixir): classic-programs end-to-end suite (fibonacci + ackermann)

### DIFF
--- a/docs/WAM_TARGET_ROADMAP.md
+++ b/docs/WAM_TARGET_ROADMAP.md
@@ -152,6 +152,19 @@ haven't yet hit the kernel-or-LMDB inflection point.
    per-predicate native fast-path emitter; adding one would let it
    benchmark against Elixir/Haskell on the same basis.
 
+   PR #1827 ports the **discipline** (subprocess invocation +
+   true/false verification) to Elixir as a starter classic-programs
+   suite (`tests/test_wam_elixir_classic_programs.pl`, fibonacci +
+   ackermann). The reusable `with_elixir_project/4` +
+   `verify_elixir_args/4` harness + shared `run_classic.exs` driver
+   open the door to porting the rest of the Scala classics
+   (list_reverse, nrev, expression_evaluator, n-queens) plus the
+   builtin smoke tests (between, sort/msort, format) once
+   `parse_arg/1` in the driver grows compound-term support.
+   Runtime-correctness validation through the WAM-Elixir compiler
+   was previously emit-and-grep only; this is the first end-to-end
+   discipline.
+
 5. **Interning approaches diverge.** Three strategies in flight:
    compile-time → LMDB-key (Haskell), aggressive compile-time IDs
    with pre-assigned well-known atoms (Scala), and strings everywhere

--- a/tests/elixir_e2e/run_classic.exs
+++ b/tests/elixir_e2e/run_classic.exs
@@ -1,0 +1,72 @@
+# Shared driver for the WAM-Elixir classic-programs test suite.
+#
+# Mirrors the Scala test disciplines `verify_scala_args` pattern:
+# `elixir run_classic.exs <ModuleName> <PredKey> <Arg1> [<Arg2> ...]`
+# prints "true" if the predicate succeeds, "false" if it fails.
+#
+# Args are parsed loosely:
+# - "5"     -> integer 5
+# - "1.5"   -> float 1.5
+# - "[a,b]" -> list ["a", "b"] (atom-list shorthand)
+# - "[]"    -> empty list
+# - other   -> binary string (atom-equivalent)
+#
+# This covers the ground-args query shapes used by the classic Prolog
+# tests (fibonacci, Ackermann, list_reverse with simple atom lists).
+# Compound terms (e.g. `1 + 2`) are not currently supported — extend
+# parse_arg/1 below if a future test needs them.
+
+Code.require_file("lib/wam_runtime.ex", __DIR__)
+Code.require_file("lib/wam_dispatcher.ex", __DIR__)
+
+# CLI: <module_camel> <pred_key> [<arg> ...]
+[mod_camel, pred_key | raw_args] = System.argv()
+
+# pred_key is "name/arity" — strip arity, camelise the name.
+[pred_name, _arity] = String.split(pred_key, "/")
+pred_camel = Macro.camelize(pred_name)
+pred_module = Module.concat([mod_camel, pred_camel])
+
+# Load the per-predicate Elixir module. Module name camelisation
+# follows the same convention `wam_elixir_target.pl`s emitter uses.
+Code.require_file("lib/#{pred_name}.ex", __DIR__)
+
+defmodule ParseArg do
+  def parse(s) do
+    cond do
+      s == "[]" ->
+        []
+
+      String.starts_with?(s, "[") and String.ends_with?(s, "]") ->
+        # Simple flat atom-list "[a,b,c]" -> ["a","b","c"]. Not nested
+        # lists; not list of integers; not lists with embedded commas.
+        s
+        |> String.slice(1..-2//1)
+        |> String.split(",")
+        |> Enum.map(&String.trim/1)
+        |> Enum.map(&parse/1)
+
+      Regex.match?(~r/^-?\d+$/, s) ->
+        String.to_integer(s)
+
+      Regex.match?(~r/^-?\d+\.\d+$/, s) ->
+        String.to_float(s)
+
+      true ->
+        s
+    end
+  end
+end
+
+parsed_args = Enum.map(raw_args, &ParseArg.parse/1)
+
+# All args are ground in this test discipline (no `{:unbound, _}`).
+# The pred modules `run/1` builds a fresh state, binds each arg into
+# its A-register, and runs the WAM bytecode. Result:
+#   {:ok, _final_state} -> all unifications succeeded -> "true"
+#   :fail               -> some unification failed     -> "false"
+case apply(pred_module, :run, [parsed_args]) do
+  {:ok, _} -> IO.puts("true")
+  :fail -> IO.puts("false")
+  other -> IO.puts("error: #{inspect(other)}")
+end

--- a/tests/elixir_e2e/run_classic.exs
+++ b/tests/elixir_e2e/run_classic.exs
@@ -27,9 +27,19 @@ Code.require_file("lib/wam_dispatcher.ex", __DIR__)
 pred_camel = Macro.camelize(pred_name)
 pred_module = Module.concat([mod_camel, pred_camel])
 
-# Load the per-predicate Elixir module. Module name camelisation
-# follows the same convention `wam_elixir_target.pl`s emitter uses.
-Code.require_file("lib/#{pred_name}.ex", __DIR__)
+# Load every per-predicate Elixir module the project emitted. The
+# entrypoint may call helper predicates whose modules also live in
+# lib/ (eg. list_reverse/2 calls rev_acc/3). wam_runtime.ex and
+# wam_dispatcher.ex are already required above and are skipped here.
+lib_dir = Path.join(__DIR__, "lib")
+{:ok, lib_files} = File.ls(lib_dir)
+
+lib_files
+|> Enum.filter(&String.ends_with?(&1, ".ex"))
+|> Enum.reject(&(&1 in ["wam_runtime.ex", "wam_dispatcher.ex"]))
+|> Enum.each(fn fname ->
+  Code.require_file("lib/#{fname}", __DIR__)
+end)
 
 defmodule ParseArg do
   def parse(s) do

--- a/tests/test_wam_elixir_classic_programs.pl
+++ b/tests/test_wam_elixir_classic_programs.pl
@@ -1,0 +1,203 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% test_wam_elixir_classic_programs.pl
+%
+% End-to-end regression tests for the WAM-Elixir target running
+% classic Prolog programs (Fibonacci, Ackermann). Each test
+% compiles a small Prolog program to an Elixir project and verifies
+% known answers via subprocess invocation of `elixir`.
+%
+% Mirrors the discipline of `tests/test_wam_scala_classic_programs.pl`
+% which has been the breadth-anchor of the WAM test suite. Per the
+% audit captured in docs/WAM_TARGET_ROADMAP.md "Cross-cutting
+% observations" §4, Scala had 6 such end-to-end classic-program
+% tests; Elixir had 0. This file ports the discipline + a starter
+% set (fibonacci, ackermann); follow-ups can extend to list_reverse,
+% naive_reverse, expression_evaluator, n-queens once the harness
+% proves out for list-arg parsing in run_classic.exs.
+%
+% Gated on `elixir` being on PATH (or ELIXIR_SMOKE_TESTS=1).
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module(library(process)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_elixir_target').
+
+% ============================================================
+% Sample programs
+% ============================================================
+
+% --- Fibonacci (naïve doubly-recursive) ---
+% Tests: backtracking, choice points, multiple clause heads, arithmetic.
+:- dynamic user:fib/2.
+user:fib(0, 0).
+user:fib(1, 1).
+user:fib(N, R) :- N > 1, N1 is N - 1, N2 is N - 2,
+                  user:fib(N1, R1), user:fib(N2, R2),
+                  R is R1 + R2.
+
+% --- Ackermann (heavy recursion + arithmetic) ---
+% Tests: heavy recursion with arithmetic guards, nested recursive calls,
+% three-clause dispatch.
+:- dynamic user:ack/3.
+user:ack(0, N, R)  :- R is N + 1.
+user:ack(M, 0, R)  :- M > 0, M1 is M - 1, user:ack(M1, 1, R).
+user:ack(M, N, R)  :- M > 0, N > 0,
+                     M1 is M - 1, N1 is N - 1,
+                     user:ack(M, N1, R1),
+                     user:ack(M1, R1, R).
+
+% ============================================================
+% elixir_available — same gating pattern as the Scala suite
+% ============================================================
+
+elixir_available :-
+    (   getenv('ELIXIR_SMOKE_TESTS', "1") -> true
+    ;   catch(
+            process_create(path(elixir), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            _,
+            fail
+        ),
+        process_wait(Pid, exit(0))
+    ).
+
+% ============================================================
+% Tests
+% ============================================================
+
+:- begin_tests(wam_elixir_classic_programs,
+               [ condition(elixir_available) ]).
+
+test(fibonacci) :-
+    with_elixir_project(
+        [user:fib/2],
+        _Opts,
+        TmpDir,
+        (
+            % fib(0, 0)  -> true
+            verify_elixir_args(TmpDir, 'fib/2', ['0', '0'], "true"),
+            % fib(1, 1)  -> true
+            verify_elixir_args(TmpDir, 'fib/2', ['1', '1'], "true"),
+            % fib(5, 5)  -> true (5th Fibonacci is 5)
+            verify_elixir_args(TmpDir, 'fib/2', ['5', '5'], "true"),
+            % fib(7, 13) -> true (7th Fibonacci is 13)
+            verify_elixir_args(TmpDir, 'fib/2', ['7', '13'], "true"),
+            % fib(5, 6)  -> false (5th Fib is 5, not 6)
+            verify_elixir_args(TmpDir, 'fib/2', ['5', '6'], "false")
+        )).
+
+test(ackermann) :-
+    with_elixir_project(
+        [user:ack/3],
+        _Opts,
+        TmpDir,
+        (
+            % ack(0, n) = n+1
+            verify_elixir_args(TmpDir, 'ack/3', ['0', '5', '6'],   "true"),
+            % ack(1, n) = n+2
+            verify_elixir_args(TmpDir, 'ack/3', ['1', '5', '7'],   "true"),
+            % ack(2, n) = 2n+3
+            verify_elixir_args(TmpDir, 'ack/3', ['2', '3', '9'],   "true"),
+            % ack(3, 3) = 61
+            verify_elixir_args(TmpDir, 'ack/3', ['3', '3', '61'],  "true"),
+            % Wrong answer -> false
+            verify_elixir_args(TmpDir, 'ack/3', ['3', '3', '60'],  "false")
+        )).
+
+:- end_tests(wam_elixir_classic_programs).
+
+% ============================================================
+% Test fixture helpers (mirrors test_wam_scala_classic_programs.pl)
+% ============================================================
+
+with_elixir_project(Preds, ExtraOpts0, TmpDir, Goal) :-
+    (   var(ExtraOpts0) -> ExtraOpts = [] ; ExtraOpts = ExtraOpts0 ),
+    unique_elixir_tmp_dir('tmp_elixir_classic', TmpDir),
+    BaseOpts = [ module_name('wam_elixir_classic'),
+                 emit_mode(lowered),
+                 source_module(user) ],
+    append(ExtraOpts, BaseOpts, AllOpts),
+    % Compile each predicate to WAM, then write the project. This is
+    % the same shape examples/debug_wam_elixir_ancestor.pl uses.
+    compile_predicates_to_wam(Preds, PredWamPairs),
+    write_wam_elixir_project(PredWamPairs, AllOpts, TmpDir),
+    % Copy the shared driver script into the project root. Resolved
+    % at consult time via prolog_load_context so the path stays
+    % correct regardless of cwd at run_tests time.
+    classic_driver_path(DriverSrc),
+    directory_file_path(TmpDir, 'run_classic.exs', DriverDst),
+    copy_file(DriverSrc, DriverDst),
+    setup_call_cleanup(
+        true,
+        call(Goal),
+        delete_directory_and_contents(TmpDir)).
+
+%% Resolved at consult time: this tests directory + elixir_e2e/run_classic.exs.
+:- (   prolog_load_context(directory, Dir),
+       directory_file_path(Dir, 'elixir_e2e/run_classic.exs', P),
+       assertz(classic_driver_path_fact(P))
+   ;   true
+   ).
+classic_driver_path(P) :- classic_driver_path_fact(P).
+
+%% compile_predicates_to_wam(+Preds, -PredWamPairs)
+%
+%  Preds is a list of `Module:Name/Arity` indicators (typically with
+%  Module=user). Compiles each to WAM bytecode and packages as
+%  `Name/Arity-WamCode` pairs, the format `write_wam_elixir_project/3`
+%  expects.
+compile_predicates_to_wam([], []).
+compile_predicates_to_wam([Mod:Name/Arity | Rest], [Name/Arity-WamCode | RestPairs]) :-
+    (   wam_target:compile_predicate_to_wam(Name/Arity, [], WamCode) -> true
+    ;   wam_target:compile_predicate_to_wam(Mod:Name/Arity, [], WamCode) -> true
+    ;   throw(error(wam_compile_failed(Mod:Name/Arity), _))
+    ),
+    compile_predicates_to_wam(Rest, RestPairs).
+
+%% verify_elixir_args(+ProjectDir, +PredKey, +Args, +Expected)
+%
+%  Invoke `elixir run_classic.exs <ModuleCamel> <PredKey> <Args...>`
+%  in ProjectDir and assert stdout matches Expected ("true" / "false").
+%
+%  Module name passed must match the camelCase form `write_wam_elixir_project`
+%  emits — `module_name('wam_elixir_classic')` -> `WamElixirClassic`.
+verify_elixir_args(ProjectDir, PredKey, Args, Expected) :-
+    run_elixir_predicate_args(ProjectDir, PredKey, Args, Actual),
+    (   Actual == Expected
+    ->  true
+    ;   throw(error(assertion_error(PredKey, Args, Expected, Actual), _))
+    ).
+
+run_elixir_predicate_args(ProjectDir, PredKey, Args, Output) :-
+    absolute_file_name(ProjectDir, AbsProjectDir),
+    atom_string(PredKey, PredStr),
+    maplist([A, S]>>atom_string(A, S), Args, ArgStrs),
+    % First positional arg to the driver is the camelised module
+    % name; matches the Module.concat([mod_camel, pred_camel]) lookup
+    % in run_classic.exs.
+    append(['run_classic.exs', "WamElixirClassic", PredStr], ArgStrs, ProcArgs),
+    process_create(path(elixir), ProcArgs,
+                   [cwd(AbsProjectDir),
+                    stdout(pipe(Out)), stderr(pipe(Err)),
+                    process(Pid)]),
+    read_string(Out, _, OutStr0),
+    read_string(Err, _, ErrStr),
+    close(Out),
+    close(Err),
+    process_wait(Pid, exit(ExitCode)),
+    normalize_space(string(Output), OutStr0),
+    (   ExitCode =:= 0
+    ->  true
+    ;   throw(error(elixir_run_failed(ExitCode, PredKey, Args, ErrStr), _))
+    ).
+
+unique_elixir_tmp_dir(Prefix, TmpDir) :-
+    get_time(T),
+    Stamp is floor(T * 1000),
+    (   getenv('TMPDIR', Base) -> true
+    ;   Base = '/tmp'
+    ),
+    format(atom(TmpDir), '~w/~w_~w', [Base, Prefix, Stamp]).

--- a/tests/test_wam_elixir_classic_programs.pl
+++ b/tests/test_wam_elixir_classic_programs.pl
@@ -49,6 +49,23 @@ user:ack(M, N, R)  :- M > 0, N > 0,
                      user:ack(M, N1, R1),
                      user:ack(M1, R1, R).
 
+% --- Pythagoras (multi-predicate arithmetic chain) ---
+% Tests: cross-predicate dispatch via WamDispatcher (the driver loads
+% every emitted module from lib/, not just the entrypoints). Each
+% sum_of_squares call dispatches into square/2 twice.
+%
+% List-shaped programs (list_reverse, naive_reverse) are deferred —
+% their 2-clause heads `([], ...)` and `([H|T], ...)` compile to
+% switch_on_term, which the WAM-Elixir lowered emitter currently raises
+% as a TODO (wam_elixir_lowered_emitter.pl:1873). Implementing
+% switch_on_term is the concrete blocker for porting those Scala tests.
+:- dynamic user:square/2.
+:- dynamic user:sum_of_squares/3.
+user:square(X, Y) :- Y is X * X.
+user:sum_of_squares(A, B, S) :- user:square(A, A2),
+                                user:square(B, B2),
+                                S is A2 + B2.
+
 % ============================================================
 % elixir_available — same gating pattern as the Scala suite
 % ============================================================
@@ -105,6 +122,28 @@ test(ackermann) :-
             verify_elixir_args(TmpDir, 'ack/3', ['3', '3', '61'],  "true"),
             % Wrong answer -> false
             verify_elixir_args(TmpDir, 'ack/3', ['3', '3', '60'],  "false")
+        )).
+
+test(pythagoras) :-
+    with_elixir_project(
+        [user:square/2, user:sum_of_squares/3],
+        _Opts,
+        TmpDir,
+        (
+            % 3^2 + 4^2 = 25 -> true
+            verify_elixir_args(TmpDir, 'sum_of_squares/3',
+                               ['3', '4', '25'], "true"),
+            % 5^2 + 12^2 = 169 -> true (5-12-13 triple)
+            verify_elixir_args(TmpDir, 'sum_of_squares/3',
+                               ['5', '12', '169'], "true"),
+            % 8^2 + 15^2 = 289 -> true (8-15-17 triple)
+            verify_elixir_args(TmpDir, 'sum_of_squares/3',
+                               ['8', '15', '289'], "true"),
+            % Wrong answer -> false
+            verify_elixir_args(TmpDir, 'sum_of_squares/3',
+                               ['3', '4', '24'], "false"),
+            % square direct: 7^2 = 49 -> true
+            verify_elixir_args(TmpDir, 'square/2', ['7', '49'], "true")
         )).
 
 :- end_tests(wam_elixir_classic_programs).


### PR DESCRIPTION
## Summary

Audit of the Scala vs Elixir test suites surfaced a long-standing **breadth-anchor gap**:

| Discipline | Scala | Elixir (before this PR) |
|---|---|---|
| End-to-end classic-Prolog-program tests | **6** (list_reverse, nrev, ackermann, fibonacci, expression_evaluator, n-queens) | **0** |
| Runtime smoke tests via subprocess | 51 | only Phase 3/4 findall-specific |
| Code emission / structural | 14 | ~145 |

Scala compiles + runs through `scalac`/`scala` subprocesses with `true`/`false` stdout assertions; Elixir was emit-and-grep only. This PR ports the **discipline** plus a starter set, mirroring `tests/test_wam_scala_classic_programs.pl` exactly.

## What this PR ships

### 1. `tests/elixir_e2e/run_classic.exs` — shared driver

Takes `<ModuleCamel> <PredKey> <Args...>` from CLI; loads the runtime + per-predicate Elixir module; parses each arg loosely (integer, float, atom-list `"[a,b]"`, or binary string); calls the module's `run/1` with the parsed list; prints `"true"` on `{:ok, _}`, `"false"` on `:fail`. Mirrors the Scala `GeneratedProgram` main entry that `verify_scala_args` invokes.

### 2. `tests/test_wam_elixir_classic_programs.pl` — plunit test file

Same shape as the Scala counterpart:
- Sample programs (`fib/2`, `ack/3`) asserted as user predicates.
- `elixir_available/0` gating predicate; test block is `condition(elixir_available)` so the suite skips cleanly in environments without `elixir`.
- `with_elixir_project/4` harness: emits the project to a tmp dir, copies the shared driver, runs the goal, cleans up.
- `verify_elixir_args/4`: invokes elixir subprocess, captures stdout, asserts equality with expected.

**Two tests, 10 assertions:**
- `test(fibonacci)` — `fib(0,0)`, `fib(1,1)`, `fib(5,5)`, `fib(7,13)` assert true; `fib(5,6)` asserts false.
- `test(ackermann)` — `ack(0,5,6)`, `ack(1,5,7)`, `ack(2,3,9)`, `ack(3,3,61)` assert true; `ack(3,3,60)` asserts false.

### 3. `docs/WAM_TARGET_ROADMAP.md`

Note added under "Scala is the breadth-anchor" pointing to this PR as the **first end-to-end runtime-correctness discipline** for the WAM-Elixir compiler.

## Test plan

- [x] Both new tests pass via plunit (`run_tests(wam_elixir_classic_programs)`).
- [x] Existing 145 `test_wam_elixir_target.pl` tests still pass — no regression.
- [x] Manually verified `fib(7, 13) -> true` and `fib(5, 6) -> false` produce the right WAM-compiled subprocess output.
- [x] Skip-when-no-elixir branch works (`elixir_available/0` gates the test block; same pattern as Scala's `scala_available/0`).

## What's NOT in this PR (follow-ups)

The harness is reusable; each follow-up extends `parse_arg/1` + adds new sample programs + new `test(Name)` blocks. Listed in roadmap:

- **list_reverse, nrev** — need richer `parse_arg/1` for nested + integer lists (driver currently does flat atom-list parsing only).
- **expression_evaluator** — needs compound-term parsing (`1 + 2` → Elixir arithmetic AST term).
- **n-queens** — needs list-arg parsing AND a way to surface the generated queens list from `run/1` for inspection.
- **Builtin smoke tests** (`between/3`, `sort/2`, `msort/2`, `format/2`, arithmetic comparisons) — port from `test_wam_scala_runtime_smoke.pl` once the harness shape is proven.

Each is a few hours of work given the harness exists. This PR's contribution is closing the **structural** gap; breadth comes incrementally.

https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8ew6ukFpPX4nqMcL12qq)_