### PR TITLE
fix(wam-c): reject unsupported instruction emission

### DIFF
--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -132,8 +132,8 @@ wam_instruction_to_c_literal(trust_me, '{ .tag = INSTR_TRUST_ME }').
 wam_instruction_to_c_literal(proceed, '{ .tag = INSTR_PROCEED }').
 wam_instruction_to_c_literal(allocate, '{ .tag = INSTR_ALLOCATE }').
 wam_instruction_to_c_literal(deallocate, '{ .tag = INSTR_DEALLOCATE }').
-wam_instruction_to_c_literal(Instr, Code) :-
-    format(atom(Code), '// TODO: ~w', [Instr]).
+wam_instruction_to_c_literal(Instr, _) :-
+    throw(error(wam_c_target_error(unsupported_instruction(Instr)), _)).
 
 wam_instruction_to_c_literal(try_me_else(Label), LabelMap, Code) :-
     ( member(Label-TargetPC, LabelMap) -> true ; TargetPC = -1 ),
@@ -260,9 +260,8 @@ wam_line_to_c_instr(["trust_me"], _, '{ .tag = INSTR_TRUST_ME }').
 wam_line_to_c_instr(["proceed"], _, '{ .tag = INSTR_PROCEED }').
 wam_line_to_c_instr(["allocate"], _, '{ .tag = INSTR_ALLOCATE }').
 wam_line_to_c_instr(["deallocate"], _, '{ .tag = INSTR_DEALLOCATE }').
-wam_line_to_c_instr(Parts, _, Instr) :-
-    atomic_list_concat(Parts, ' ', Combined),
-    format(atom(Instr), '/* TODO: ~w */ {0}', [Combined]).
+wam_line_to_c_instr(Parts, _, _) :-
+    throw(error(wam_c_target_error(unsupported_instruction_tokens(Parts)), _)).
 
 clean_comma(S, Clean) :-
     (   sub_string(S, _, 1, 0, ",")

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -217,6 +217,21 @@ test_builtin_call_generation :-
     ;   fail_test(Test, 'builtin_call parser/runtime delegation missing')
     ).
 
+test_unsupported_instruction_fails_loudly :-
+    Test = 'WAM-C: unsupported instructions fail loudly',
+    BadWamCode = 'foo/1:\n    unknown_opcode A1\n    proceed',
+    (   catch(wam_instruction_to_c_literal(unknown_opcode('A1'), _),
+              error(wam_c_target_error(unsupported_instruction(unknown_opcode('A1'))), _),
+              TermThrows = true),
+        catch(compile_wam_predicate_to_c(user:foo/1, BadWamCode, [], _),
+              error(wam_c_target_error(unsupported_instruction_tokens(["unknown_opcode", "A1"])), _),
+              LineThrows = true),
+        TermThrows == true,
+        LineThrows == true
+    ->  pass(Test)
+    ;   fail_test(Test, 'unsupported instruction was silently emitted')
+    ).
+
 test_list_target_pc_emission :-
     Test = 'WAM-C: list-headed clauses emit list_target_pc',
     assertz((user:wam_c_list_case([_|_]) :- true)),
@@ -928,6 +943,7 @@ run_tests_once :-
     test_c_while_loop,
     test_predicate_hash_registration,
     test_builtin_call_generation,
+    test_unsupported_instruction_fails_loudly,
     test_list_target_pc_emission,
     test_generated_runtime_executable_smoke,
     test_cross_predicate_executable_smoke,


### PR DESCRIPTION
## Summary

- Replace silent WAM-C fallback emission for unsupported term instructions with `wam_c_target_error(unsupported_instruction(...))`.
- Replace tokenized WAM-line fallback emission from `/* TODO */ {0}` with `wam_c_target_error(unsupported_instruction_tokens(...))`.
- Add a regression test covering both unsupported instruction paths.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
