### PR TITLE
fix(wam-c): remove zero instruction fallback

### DIFF
--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -349,7 +349,6 @@ wam_generate_c_instruction(PC, Parts, LabelMap, Arity, CodeLines) :-
         ->  CInstr = CInstr_NoMap
         ;   wam_line_to_c_instr(Parts, LabelMap, CInstr_NoArity)
         ->  CInstr = CInstr_NoArity
-        ;   CInstr = '{0}'
         ),
         format(atom(L0), '    state->code[~w] = (Instruction)~w;', [PC, CInstr]),
         CodeLines = [L0]

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -232,6 +232,21 @@ test_unsupported_instruction_fails_loudly :-
     ;   fail_test(Test, 'unsupported instruction was silently emitted')
     ).
 
+test_no_zero_instruction_fallback :-
+    Test = 'WAM-C: unsupported pass-2 instructions never emit zero fallback',
+    BadWamCode = 'foo/1:\n    definitely_unknown A1\n    proceed',
+    (   catch(compile_wam_predicate_to_c(user:foo/1, BadWamCode, [], CCode),
+              error(wam_c_target_error(unsupported_instruction_tokens(["definitely_unknown", "A1"])), _),
+              Throws = true),
+        Throws == true,
+        \+ ( nonvar(CCode),
+             atom_string(CCode, S),
+             sub_string(S, _, _, _, '(Instruction){0}')
+           )
+    ->  pass(Test)
+    ;   fail_test(Test, 'unsupported pass-2 instruction emitted {0}')
+    ).
+
 test_list_target_pc_emission :-
     Test = 'WAM-C: list-headed clauses emit list_target_pc',
     assertz((user:wam_c_list_case([_|_]) :- true)),
@@ -944,6 +959,7 @@ run_tests_once :-
     test_predicate_hash_registration,
     test_builtin_call_generation,
     test_unsupported_instruction_fails_loudly,
+    test_no_zero_instruction_fallback,
     test_list_target_pc_emission,
     test_generated_runtime_executable_smoke,
     test_cross_predicate_executable_smoke,


### PR DESCRIPTION
## Summary

- Remove the final `(Instruction){0}` fallback from WAM-C pass-2 instruction emission.
- Preserve the existing fail-fast unsupported-instruction behavior instead of silently generating a zeroed instruction.
- Add a regression test that verifies unsupported pass-2 instructions throw and cannot emit `(Instruction){0}`.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`