### PR TITLE
feat(wam-c): Add WAM C foreign predicate dispatch

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,7 +4,7 @@ Status date: 2026-05-04
 
 Base verified locally:
 
-- `main` at `00c2cd4e` (`Merge pull request #1829 from s243a/fix/wam-c-remove-zero-instruction-fallback`)
+- `main` at `21258826` (`Merge pull request #1831 from s243a/docs/wam-c-next-steps-refresh`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 
 This file replaces the older implementation plan. The four original C follow-up
@@ -20,6 +20,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Dynamic atom interning | Done | `AtomEntry`, `wam_intern_atom`, `wam_free_state`, executable smoke interns duplicate runtime atom |
 | Runtime helpers | Done | `wam_state_init`, `wam_free_state`, `wam_run_predicate`, `test_helpers_generation` |
 | Unsupported instruction fail-fast | Done | `unsupported_instruction`, `unsupported_instruction_tokens`, no `(Instruction){0}` fallback |
+| Foreign predicate dispatch foundation | Done | `INSTR_CALL_FOREIGN`, `WamForeignHandler`, `wam_register_foreign_predicate`, `wam_execute_foreign_predicate`, executable smoke |
 
 ## Current C Target Baseline
 
@@ -34,8 +35,10 @@ The C target is now a credible small WAM backend:
   second-argument constant dispatch, and direct list dispatch.
 - Supports basic `builtin_call` delegation for tested builtins:
   `atom/1`, `integer/1`, `is_list/1`, `=/2`, and `is/2`.
+- Supports deterministic `call_foreign` dispatch through a C handler registry.
 - Has executable smokes for generated runtime, cross-predicate calls,
-  real multi-clause predicates, structure indexing, `is_list/1`, and `=/2`.
+  foreign calls, real multi-clause predicates, structure indexing, `is_list/1`,
+  and `=/2`.
 
 The main limitation is not core WAM execution anymore. It is hybrid-WAM
 infrastructure: C lacks the native kernel, FactSource, lowered/native helper,
@@ -58,8 +61,8 @@ missing important target features; `Missing` = no comparable C path yet.
 | Builtin calls | Partial | Broader | Broader | C has a small builtin set. Add `functor/3`, `arg/3`, `atom_concat/3`, arithmetic comparisons as needed. |
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
 | Negation / control builtins | Partial | Broader | Broader | C likely needs explicit tests for `\+/1`, cut interactions, and if-then-else lowering. |
-| Foreign predicate instruction (`CallForeign`) | Missing | Done | Done | Highest-value parity gap: add C `INSTR_CALL_FOREIGN` plus registration/dispatch hooks. |
-| Native recursive kernels | Missing | Done | Done | Start with one kernel, probably `category_ancestor/4` or `transitive_closure2`, after `CallForeign` exists. |
+| Foreign predicate instruction (`CallForeign`) | Done | Done | Done | C has deterministic handler dispatch; later branches can add streaming result conventions. |
+| Native recursive kernels | Missing | Done | Done | Start with one kernel, probably `category_ancestor/4` or `transitive_closure2`. |
 | Shared kernel detector integration | Missing | Done | Done | Reuse `recursive_kernel_detection.pl`; generate C registration stubs. |
 | Lowered/native helper functions | Missing | Done | Done | Consider after foreign kernels; C can lower simple fact-only or deterministic predicates. |
 | FactSource abstraction | Missing | Partial/less central | Done | Add simple file-backed FactSource before LMDB. |
@@ -71,25 +74,9 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-call-foreign`
+### 1. `feat/wam-c-category-ancestor-kernel`
 
-Goal: add the minimum foreign predicate abstraction to the C target.
-
-Scope:
-
-- Add `INSTR_CALL_FOREIGN` or reuse an equivalent C instruction shape for
-  compile-time-resolved foreign predicates.
-- Add a C registry type for foreign handlers keyed by `pred/arity`.
-- Add setup emission for a hand-registered foreign predicate.
-- Add an executable smoke where a C foreign handler returns one or more
-  solutions and the WAM runtime binds output registers.
-
-Why first: Rust and Haskell hybrid WAMs both hinge on `CallForeign`; without it,
-C cannot participate in native-kernel or external-source benchmarks.
-
-### 2. `feat/wam-c-category-ancestor-kernel`
-
-Goal: wire one shared recursive kernel into C after `CallForeign` exists.
+Goal: wire one shared recursive kernel into C now that `CallForeign` exists.
 
 Candidate kernel:
 
@@ -103,7 +90,7 @@ Scope:
 - Keep facts in a simple in-memory edge table initially.
 - Add a small executable smoke with a tiny category graph.
 
-### 3. `feat/wam-c-file-fact-source`
+### 2. `feat/wam-c-file-fact-source`
 
 Goal: add the first C FactSource abstraction.
 
@@ -117,7 +104,7 @@ Scope:
 Why before LMDB: ownership, row encoding, and cursor semantics are easier to
 settle with a file-backed source.
 
-### 4. `feat/wam-c-effective-distance-bench`
+### 3. `feat/wam-c-effective-distance-bench`
 
 Goal: make C visible in the benchmark matrix once kernels/facts exist.
 
@@ -127,7 +114,7 @@ Scope:
 - Support `kernels_on` / `kernels_off`.
 - Start with small TSV/fact-source mode; add LMDB later.
 
-### 5. `perf/wam-c-pack-instruction`
+### 4. `perf/wam-c-pack-instruction`
 
 Goal: reduce `Instruction` memory footprint.
 
@@ -143,13 +130,15 @@ or cache behavior becomes a real bottleneck.
 
 ## Suggested Immediate Next Step
 
-Start with `feat/wam-c-call-foreign`.
+Start with `feat/wam-c-category-ancestor-kernel`.
 
-It is the smallest feature that moves C toward Rust/Haskell parity. The work
-should be split into two commits:
+It is now the smallest feature that exercises the new C foreign-call
+foundation against the same class of hybrid WAM work that Rust and Haskell
+already handle. The work should be split into two commits:
 
-1. Runtime API and instruction support for C foreign handlers.
-2. Transpiler emission plus one executable smoke.
+1. C native handler skeleton and registration path for one detected kernel.
+2. Tiny category graph executable smoke that proves the handler can bind output
+   registers through `CallForeign`.
 
-Keep LMDB and effective-distance out of that first branch; they depend on this
-foreign-call foundation.
+Keep LMDB and effective-distance out of that branch; they depend on a stable
+native-kernel shape.

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -14,6 +14,10 @@
 #define WAM_INITIAL_CAP 64
 #define WAM_PRED_HASH_SIZE 256
 #define WAM_ATOM_HASH_SIZE 512
+#define WAM_FOREIGN_HASH_SIZE 256
+
+typedef struct WamState WamState;
+typedef bool (*WamForeignHandler)(WamState *state, const char *pred, int arity);
 
 /* Value tag enum */
 typedef enum {
@@ -73,7 +77,7 @@ typedef enum {
     INSTR_ALLOCATE, INSTR_DEALLOCATE,
     INSTR_TRY_ME_ELSE, INSTR_RETRY_ME_ELSE, INSTR_TRUST_ME,
     INSTR_SWITCH_ON_CONSTANT, INSTR_SWITCH_ON_STRUCTURE, INSTR_SWITCH_ON_TERM,
-    INSTR_BUILTIN_CALL
+    INSTR_BUILTIN_CALL, INSTR_CALL_FOREIGN
 } WamInstrTag;
 
 /* Hash Entry for Indexing */
@@ -91,6 +95,12 @@ typedef struct AtomEntry {
     char *str;
     struct AtomEntry *next;
 } AtomEntry;
+
+typedef struct {
+    const char *name;
+    int arity;
+    WamForeignHandler handler;
+} ForeignEntry;
 
 /* Instruction */
 // TODO: Pack these fields into a union keyed on `tag` to reduce memory footprint
@@ -114,7 +124,7 @@ typedef struct {
 } Instruction;
 
 /* WAM state */
-typedef struct {
+struct WamState {
     int P;    // Program Counter
     int CP;   // Continuation Pointer
     int S;    // Structure Pointer
@@ -154,7 +164,10 @@ typedef struct {
 
     /* Interned dynamic atoms */
     AtomEntry *atom_table[WAM_ATOM_HASH_SIZE];
-} WamState;
+
+    /* Foreign predicate handlers */
+    ForeignEntry foreign_hash[WAM_FOREIGN_HASH_SIZE];
+};
 
 bool step_wam(WamState* state, Instruction* instr);
 int wam_run(WamState* state);
@@ -162,6 +175,7 @@ void wam_state_init(WamState *state);
 void wam_free_state(WamState *state);
 int wam_run_predicate(WamState *state, const char *pred, WamValue *args, int arity);
 bool wam_execute_builtin(WamState *state, const char *op, int arity);
+bool wam_execute_foreign_predicate(WamState *state, const char *pred, int arity);
 
 /* Helpers */
 static inline WamValue val_atom(const char *s) {
@@ -219,6 +233,46 @@ static inline void wam_register_predicate(WamState *state, const char *pred, int
 
 static inline int resolve_predicate(WamState *state, const char *pred) {
     return resolve_predicate_hash(state, pred);
+}
+
+static inline unsigned int wam_foreign_hash(const char *name, int arity) {
+    unsigned int h = wam_hash_string(name);
+    h = ((h << 5) + h) ^ (unsigned int)arity;
+    return h & (WAM_FOREIGN_HASH_SIZE - 1);
+}
+
+static inline void wam_register_foreign_predicate(WamState *state,
+                                                  const char *name,
+                                                  int arity,
+                                                  WamForeignHandler handler) {
+    unsigned int idx = wam_foreign_hash(name, arity);
+    unsigned int probes = 0;
+    while (state->foreign_hash[idx].name != NULL &&
+           (strcmp(state->foreign_hash[idx].name, name) != 0 ||
+            state->foreign_hash[idx].arity != arity) &&
+           probes < WAM_FOREIGN_HASH_SIZE) {
+        idx = (idx + 1) & (WAM_FOREIGN_HASH_SIZE - 1);
+        probes++;
+    }
+    if (probes == WAM_FOREIGN_HASH_SIZE) return;
+    state->foreign_hash[idx].name = name;
+    state->foreign_hash[idx].arity = arity;
+    state->foreign_hash[idx].handler = handler;
+}
+
+static inline WamForeignHandler resolve_foreign_predicate(WamState *state,
+                                                          const char *name,
+                                                          int arity) {
+    unsigned int idx = wam_foreign_hash(name, arity);
+    unsigned int probes = 0;
+    while (state->foreign_hash[idx].name != NULL && probes < WAM_FOREIGN_HASH_SIZE) {
+        if (strcmp(state->foreign_hash[idx].name, name) == 0 &&
+            state->foreign_hash[idx].arity == arity)
+            return state->foreign_hash[idx].handler;
+        idx = (idx + 1) & (WAM_FOREIGN_HASH_SIZE - 1);
+        probes++;
+    }
+    return NULL;
 }
 
 static inline char *wam_strdup(const char *str) {

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -122,6 +122,8 @@ wam_instruction_to_c_literal(execute(P), Code) :-
     format(atom(Code), '{ .tag = INSTR_EXECUTE, .pred = "~w" }', [P]).
 wam_instruction_to_c_literal(builtin_call(Op, N), Code) :-
     format(atom(Code), '{ .tag = INSTR_BUILTIN_CALL, .pred = "~w", .arity = ~w }', [Op, N]).
+wam_instruction_to_c_literal(call_foreign(P, N), Code) :-
+    format(atom(Code), '{ .tag = INSTR_CALL_FOREIGN, .pred = "~w", .arity = ~w }', [P, N]).
 wam_instruction_to_c_literal(try_me_else(_Label), _) :-
     throw(error(context_error(missing_label_map, "try_me_else/1 requires LabelMap for target_pc resolution. Use wam_instruction_to_c_literal/3 instead."), _)).
 wam_instruction_to_c_literal(retry_me_else(_Label), _) :-
@@ -248,6 +250,9 @@ wam_line_to_c_instr(["execute", P], Instr) :-
 wam_line_to_c_instr(["builtin_call", Op, N], Instr) :-
     clean_comma(Op, COp), clean_comma(N, CN),
     format(atom(Instr), '{ .tag = INSTR_BUILTIN_CALL, .pred = "~w", .arity = ~w }', [COp, CN]).
+wam_line_to_c_instr(["call_foreign", P, N], Instr) :-
+    clean_comma(P, CP), clean_comma(N, CN),
+    format(atom(Instr), '{ .tag = INSTR_CALL_FOREIGN, .pred = "~w", .arity = ~w }', [CP, CN]).
 wam_line_to_c_instr(["try_me_else", L], LabelMap, Arity, Instr) :-
     clean_comma(L, CL),
     ( member(CL-TargetPC, LabelMap) -> true ; TargetPC = -1 ),
@@ -505,6 +510,13 @@ compile_step_wam_to_c(_Options, CCode) :-
             }
             case INSTR_BUILTIN_CALL: {
                 if (wam_execute_builtin(state, instr->pred, instr->arity)) {
+                    state->P++;
+                    return true;
+                }
+                return false;
+            }
+            case INSTR_CALL_FOREIGN: {
+                if (wam_execute_foreign_predicate(state, instr->pred, instr->arity)) {
                     state->P++;
                     return true;
                 }
@@ -896,6 +908,12 @@ bool wam_execute_builtin(WamState *state, const char *op, int arity) {
     }
 
     return false;
+}
+
+bool wam_execute_foreign_predicate(WamState *state, const char *pred, int arity) {
+    WamForeignHandler handler = resolve_foreign_predicate(state, pred, arity);
+    if (!handler) return false;
+    return handler(state, pred, arity);
 }
 '.
 

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -103,6 +103,7 @@ test_control_flow_instructions :-
         member(call, Cases),
         member(execute, Cases),
         member(builtin_call, Cases),
+        member(call_foreign, Cases),
         member(proceed, Cases),
         member(allocate, Cases),
         member(deallocate, Cases)
@@ -217,6 +218,23 @@ test_builtin_call_generation :-
     ;   fail_test(Test, 'builtin_call parser/runtime delegation missing')
     ).
 
+test_call_foreign_generation :-
+    Test = 'WAM-C: call_foreign parses and dispatches registered handlers',
+    WamCode = 'foo/1:\n    call_foreign foo/1, 1\n    proceed',
+    (   compile_wam_predicate_to_c(user:foo/1, WamCode, [], PredCode),
+        atom_string(PredCode, PredS),
+        compile_step_wam_to_c([], StepCode),
+        atom_string(StepCode, StepS),
+        compile_wam_helpers_to_c([], HelpersCode),
+        atom_string(HelpersCode, HelpersS),
+        sub_string(PredS, _, _, _, 'INSTR_CALL_FOREIGN'),
+        sub_string(PredS, _, _, _, '.pred = "foo/1"'),
+        sub_string(StepS, _, _, _, 'wam_execute_foreign_predicate'),
+        sub_string(HelpersS, _, _, _, 'bool wam_execute_foreign_predicate')
+    ->  pass(Test)
+    ;   fail_test(Test, 'call_foreign parser/runtime delegation missing')
+    ).
+
 test_unsupported_instruction_fails_loudly :-
     Test = 'WAM-C: unsupported instructions fail loudly',
     BadWamCode = 'foo/1:\n    unknown_opcode A1\n    proceed',
@@ -286,6 +304,16 @@ test_builtin_call_executable_smoke :-
     ->  (   run_builtin_call_executable_smoke
         ->  pass(Test)
         ;   fail_test(Test, 'builtin_call executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
+test_call_foreign_executable_smoke :-
+    Test = 'WAM-C: call_foreign executable smoke',
+    (   gcc_available
+    ->  (   run_call_foreign_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'call_foreign executable failed')
         )
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
@@ -399,6 +427,25 @@ run_builtin_call_executable_smoke :-
     format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
     write_text_file(PredPath, PredTranslationUnit),
     wam_c_builtin_smoke_main(MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
+run_call_foreign_executable_smoke :-
+    WamCode = 'wam_c_foreign_emit/1:\n    call_foreign wam_c_foreign_emit/1, 1\n    proceed',
+    compile_wam_predicate_to_c(user:wam_c_foreign_emit/1, WamCode, [], PredCode),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(TmpBase), '/tmp/unifyweaver_wam_c_foreign_smoke_~w', [Stamp]),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(RuntimePath, RuntimeCode),
+    format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+    write_text_file(PredPath, PredTranslationUnit),
+    wam_c_foreign_smoke_main(MainCode),
     write_text_file(MainPath, MainCode),
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
@@ -688,6 +735,48 @@ int main(void) {
 }
 ').
 
+wam_c_foreign_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_foreign_emit_1(WamState* state);
+
+static bool foreign_emit_ok(WamState *state, const char *pred, int arity) {
+    if (strcmp(pred, "wam_c_foreign_emit/1") != 0 || arity != 1) return false;
+    WamValue out = val_atom("foreign_ok");
+    return wam_unify(state, &state->A[0], &out);
+}
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_foreign_emit_1(&state);
+    wam_register_foreign_predicate(&state, "wam_c_foreign_emit/1", 1, foreign_emit_ok);
+
+    WamValue ok_args[1] = { val_unbound("Out") };
+    int ok_rc = wam_run_predicate(&state, "wam_c_foreign_emit/1", ok_args, 1);
+    if (ok_rc != 0 || state.P != WAM_HALT ||
+        state.A[0].tag != VAL_ATOM || strcmp(state.A[0].data.atom, "foreign_ok") != 0) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamState missing;
+    wam_state_init(&missing);
+    setup_wam_c_foreign_emit_1(&missing);
+    WamValue fail_args[1] = { val_unbound("Out") };
+    int fail_rc = wam_run_predicate(&missing, "wam_c_foreign_emit/1", fail_args, 1);
+    if (fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        wam_free_state(&missing);
+        return 20;
+    }
+
+    wam_free_state(&state);
+    wam_free_state(&missing);
+    return 0;
+}
+').
+
 wam_c_real_builtin_smoke_main(
 '#include "wam_runtime.h"
 
@@ -916,6 +1005,7 @@ implemented_case(proceed, 'case INSTR_PROCEED').
 implemented_case(call, 'case INSTR_CALL').
 implemented_case(execute, 'case INSTR_EXECUTE').
 implemented_case(builtin_call, 'case INSTR_BUILTIN_CALL').
+implemented_case(call_foreign, 'case INSTR_CALL_FOREIGN').
 implemented_case(try_me_else, 'case INSTR_TRY_ME_ELSE').
 implemented_case(retry_me_else, 'case INSTR_RETRY_ME_ELSE').
 implemented_case(trust_me, 'case INSTR_TRUST_ME').
@@ -958,12 +1048,14 @@ run_tests_once :-
     test_c_while_loop,
     test_predicate_hash_registration,
     test_builtin_call_generation,
+    test_call_foreign_generation,
     test_unsupported_instruction_fails_loudly,
     test_no_zero_instruction_fallback,
     test_list_target_pc_emission,
     test_generated_runtime_executable_smoke,
     test_cross_predicate_executable_smoke,
     test_builtin_call_executable_smoke,
+    test_call_foreign_executable_smoke,
     test_real_prolog_builtin_executable_smoke,
     test_real_prolog_multiclause_executable_smoke,
     test_real_prolog_structure_index_executable_smoke,


### PR DESCRIPTION
## Summary

This PR adds the first C-side `CallForeign` foundation for the WAM C target, matching the next roadmap step toward Rust/Haskell hybrid WAM parity.

## What Changed

- Adds `INSTR_CALL_FOREIGN` to the C WAM instruction set.
- Adds deterministic foreign handler support in the C runtime:
  - `WamForeignHandler`
  - `wam_register_foreign_predicate`
  - `resolve_foreign_predicate`
  - `wam_execute_foreign_predicate`
- Adds parser/emitter support for WAM text instructions of the form:
  - `call_foreign pred/arity, arity`
- Wires `INSTR_CALL_FOREIGN` into `step_wam`.
- Adds a compiled executable smoke test where a registered C handler binds a WAM output register.
- Updates `WAM_C_TARGET_NEXT_STEPS.md` to mark the foreign dispatch foundation complete and move the recommended next branch to `feat/wam-c-category-ancestor-kernel`.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --cached --check`
