### PR TITLE
test(wam-elixir): exercise LmdbIntIds with real LMDB

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -2167,12 +2167,13 @@ defmodule WamRuntime.FactSource.Lmdb do
   raw-pointer dereferences.
 
   Driver responsibility:
-    1. Add an LMDB binding to its mix deps (`:elmdb` is the
-       reference shape; other bindings work if they expose the same
-       function names). To keep this runtime dep-free for drivers
-       that dont use LMDB, the module is referenced indirectly via
-       Module.concat — same trick as the SQLite adaptor uses for
-       :exqlite.
+    1. Add an LMDB binding to its mix deps. The runtime expects a
+       module named `Elmdb`; the Hex `:elmdb` package exposes an
+       Erlang module named `:elmdb`, so real drivers should provide a
+       tiny bridge module with the function names used below. To keep
+       this runtime dep-free for drivers that dont use LMDB, the module
+       is referenced indirectly via Module.concat — same trick as the
+       SQLite adaptor uses for :exqlite.
     2. Open the LMDB env + database handle (dbi). Populate facts.
     3. Pass env/dbi to this adaptors open/3 via the spec.
 
@@ -2298,10 +2299,9 @@ defmodule WamRuntime.FactSource.LmdbIntIds do
   See `docs/proposals/wam_elixir_lmdb_int_id_factsource.md` for the full
   architecture rationale; this moduledoc is the API summary only.
 
-  Status: emit-and-grep stub. The function bodies are wired but runtime
-  validation requires `:elmdb` (not reachable from the sandbox where this
-  was developed). Same testing posture as PR #1792s original
-  `WamRuntime.FactSource.Lmdb`.
+  Status: function bodies are wired and covered by a MockElmdb e2e plus
+  a real-`:elmdb` integration fixture that runs when the local NIF
+  toolchain can compile the dependency.
 
   Architecture: three LMDB sub-databases inside one env.
 
@@ -2315,8 +2315,11 @@ defmodule WamRuntime.FactSource.LmdbIntIds do
   all three sub-databases consistently when ingesting facts.
 
   Driver responsibility (mirrors PR #1792s `Lmdb`):
-    1. Add `:elmdb` to mix deps. The module is referenced indirectly via
-       `Module.concat([Elmdb])` so this runtime emits without it.
+    1. Add an LMDB binding to mix deps and provide a module named
+       `Elmdb` with this runtime shape. For the Hex `:elmdb`
+       package, that bridge delegates to the Erlang module `:elmdb`.
+       The module is referenced indirectly via `Module.concat([Elmdb])`
+       so this runtime emits without the dependency.
     2. Open the LMDB env, create the three sub-databases.
     3. Ingest facts: for each `(arg1_str, arg2_str)` row, look up or
        allocate the integer ID for each side and write to all three DBs.
@@ -2460,8 +2463,8 @@ defmodule WamRuntime.FactSource.LmdbIntIds do
   persisted (e.g. via the callers metadata DB or a sentinel key in
   `id_to_key_dbi`) for the next batch.
 
-  Stub status: bodies wired through Module.concat; runtime exercise
-  requires `:elmdb`.
+  Runtime exercise is covered by MockElmdb and by a gated real-`:elmdb`
+  fixture.
   """
   def ingest_pairs(%__MODULE__{} = handle, pairs, opts \\\\ [])
       when is_list(pairs) do
@@ -2531,8 +2534,8 @@ defmodule WamRuntime.FactSource.LmdbIntIds do
   Returns `{:ok, %{pairs_migrated: integer, ids_assigned: integer,
   next_id: integer}}`.
 
-  Stub status: bodies wired through Module.concat; runtime exercise
-  requires `:elmdb`.
+  Runtime exercise is covered by MockElmdb and by a gated real-`:elmdb`
+  fixture.
   """
   def migrate_from_string_keyed(source_handle, %__MODULE__{} = dest_handle, opts \\\\ []) do
     start_id = Keyword.get(opts, :start_id, 0)

--- a/tests/elixir_e2e/lmdb_int_ids_real_test.exs
+++ b/tests/elixir_e2e/lmdb_int_ids_real_test.exs
@@ -1,0 +1,250 @@
+# End-to-end test for WamRuntime.FactSource.LmdbIntIds against a real
+# LMDB environment via the Hex :elmdb package.
+#
+# The generated runtime intentionally resolves a module named `Elmdb`
+# indirectly so it stays dependency-free for drivers that do not use
+# LMDB. The Hex package exposes the Erlang module `:elmdb`, so this
+# test supplies the small bridge module that a real driver would own.
+#
+# If :elmdb cannot be downloaded/compiled in the local environment,
+# the script prints a [SKIP] marker and exits 0. If :elmdb is available,
+# runtime behavior failures print [FAIL] and exit non-zero.
+
+defmodule RealElmdbDependency do
+  def ensure! do
+    try do
+      Mix.install([{:elmdb, "~> 0.4.1"}], consolidate_protocols: false)
+      :ok
+    rescue
+      exception ->
+        IO.puts("[SKIP] real Elmdb dependency unavailable: #{Exception.message(exception)}")
+        System.halt(0)
+    catch
+      kind, reason ->
+        IO.puts("[SKIP] real Elmdb dependency unavailable: #{inspect({kind, reason})}")
+        System.halt(0)
+    end
+  end
+end
+
+RealElmdbDependency.ensure!()
+Code.require_file("lib/wam_runtime.ex", __DIR__)
+
+defmodule Elmdb do
+  @moduledoc false
+
+  def env_open(path, opts) when is_binary(path) do
+    :elmdb.env_open(String.to_charlist(path), opts)
+  end
+
+  def env_close(env), do: :elmdb.env_close(env)
+
+  def db_open(env, name, opts) do
+    :elmdb.db_open(env, to_db_name(name), normalize_db_opts(opts))
+  end
+
+  def rw_txn_begin(env), do: :elmdb.txn_begin(env)
+  def ro_txn_begin(env), do: :elmdb.ro_txn_begin(env)
+  def txn_commit(txn), do: :elmdb.txn_commit(txn)
+  def txn_abort(txn), do: :elmdb.txn_abort(txn)
+  def ro_txn_commit(txn), do: :elmdb.ro_txn_commit(txn)
+  def txn_get(txn, dbi, key) do
+    bin_key = to_bin(key)
+
+    try do
+      :elmdb.txn_get(txn, dbi, bin_key)
+    rescue
+      ArgumentError -> :elmdb.ro_txn_get(txn, dbi, bin_key)
+    end
+  end
+  def txn_put(txn, dbi, key, value), do: :elmdb.txn_put(txn, dbi, to_bin(key), to_bin(value))
+  def ro_txn_cursor_open(txn, dbi), do: :elmdb.ro_txn_cursor_open(txn, dbi)
+  def ro_txn_cursor_close(cur), do: :elmdb.ro_txn_cursor_close(cur)
+
+  def ro_txn_cursor_get(cur, op, arg) do
+    :elmdb.ro_txn_cursor_get(cur, normalize_cursor_op(op, arg))
+  end
+
+  defp to_db_name(name) when is_binary(name), do: name
+  defp to_db_name(name) when is_atom(name), do: Atom.to_string(name)
+
+  defp to_bin(value) when is_binary(value), do: value
+  defp to_bin(value) when is_list(value), do: :erlang.iolist_to_binary(value)
+
+  defp normalize_db_opts(opts) do
+    opts
+    |> Enum.map(fn
+      :dupsort -> :dup_sort
+      other -> other
+    end)
+    |> add_create()
+    |> Enum.uniq()
+  end
+
+  defp add_create(opts), do: [:create | opts]
+
+  defp normalize_cursor_op(:set, key), do: {:set, key}
+  defp normalize_cursor_op(op, _arg), do: op
+end
+
+defmodule LmdbIntIdsRealTest do
+  @moduledoc false
+
+  alias WamRuntime.FactSource.Lmdb
+  alias WamRuntime.FactSource.LmdbIntIds
+
+  defp pass(name), do: IO.puts("[PASS] #{name}")
+
+  defp fail(name, reason) do
+    IO.puts("[FAIL] #{name}: #{reason}")
+    System.halt(1)
+  end
+
+  defp with_envs(name, fun) do
+    root = Path.join(System.tmp_dir!(), "uw_elixir_lmdb_real_#{System.unique_integer([:positive])}")
+    File.rm_rf!(root)
+    File.mkdir_p!(root)
+
+    try do
+      fun.(root)
+    after
+      File.rm_rf!(root)
+    end
+  rescue
+    exception ->
+      fail(name, Exception.format(:error, exception, __STACKTRACE__))
+  catch
+    kind, reason ->
+      fail(name, inspect({kind, reason}))
+  end
+
+  defp open_int_handle(root, suffix, dupsort) do
+    path = Path.join(root, suffix)
+    {:ok, env} = Elmdb.env_open(path, [{:map_size, 16 * 1024 * 1024}, {:max_dbs, 8}])
+    fact_opts = if dupsort, do: [:dupsort], else: []
+    {:ok, facts} = Elmdb.db_open(env, "facts", fact_opts)
+    {:ok, k_to_id} = Elmdb.db_open(env, "key_to_id", [])
+    {:ok, id_to_k} = Elmdb.db_open(env, "id_to_key", [])
+
+    handle =
+      LmdbIntIds.open(
+        %{
+          env: env,
+          facts_dbi: facts,
+          key_to_id_dbi: k_to_id,
+          id_to_key_dbi: id_to_k,
+          arity: 2,
+          dupsort: dupsort
+        },
+        2,
+        nil
+      )
+
+    {handle, env}
+  end
+
+  defp open_string_handle(root, suffix, dupsort) do
+    path = Path.join(root, suffix)
+    {:ok, env} = Elmdb.env_open(path, [{:map_size, 16 * 1024 * 1024}, {:max_dbs, 4}])
+    fact_opts = if dupsort, do: [:dupsort], else: []
+    {:ok, facts} = Elmdb.db_open(env, "facts", fact_opts)
+    handle = Lmdb.open(%{env: env, dbi: facts, arity: 2, dupsort: dupsort}, 2, nil)
+    {handle, env, facts}
+  end
+
+  def test_unique_ingest_lookup_stream do
+    name = "real :elmdb unique-key ingest, lookup, stream_all"
+
+    with_envs(name, fn root ->
+      {handle, env} = open_int_handle(root, "unique", false)
+      {:ok, result} = LmdbIntIds.ingest_pairs(handle, [{"alpha", "beta"}, {"gamma", "delta"}])
+
+      alpha_id = LmdbIntIds.lookup_id(handle, "alpha")
+      beta_id = LmdbIntIds.lookup_id(handle, "beta")
+      alpha_rows = LmdbIntIds.lookup_by_arg1_id(handle, alpha_id, nil)
+      stream = LmdbIntIds.stream_all(handle, nil)
+      Elmdb.env_close(env)
+
+      cond do
+        result.pairs_seen != 2 -> fail(name, "expected 2 pairs, got #{inspect(result)}")
+        result.new_ids != 4 -> fail(name, "expected 4 new ids, got #{inspect(result)}")
+        alpha_rows != [{alpha_id, beta_id}] -> fail(name, "lookup mismatch: #{inspect(alpha_rows)}")
+        length(stream) != 2 -> fail(name, "stream_all length mismatch: #{inspect(stream)}")
+        true -> pass(name)
+      end
+    end)
+  end
+
+  def test_dupsort_lookup do
+    name = "real :elmdb dupsort lookup_by_arg1_id returns all values"
+
+    with_envs(name, fn root ->
+      {handle, env} = open_int_handle(root, "dupsort", true)
+
+      {:ok, _} =
+        LmdbIntIds.ingest_pairs(handle, [
+          {"alpha", "beta"},
+          {"alpha", "gamma"},
+          {"alpha", "delta"}
+        ])
+
+      alpha_id = LmdbIntIds.lookup_id(handle, "alpha")
+      expected =
+        ["beta", "gamma", "delta"]
+        |> Enum.map(&LmdbIntIds.lookup_id(handle, &1))
+        |> MapSet.new()
+
+      actual =
+        handle
+        |> LmdbIntIds.lookup_by_arg1_id(alpha_id, nil)
+        |> Enum.map(fn {^alpha_id, value_id} -> value_id end)
+        |> MapSet.new()
+
+      Elmdb.env_close(env)
+
+      if MapSet.equal?(actual, expected) do
+        pass(name)
+      else
+        fail(name, "expected #{inspect(expected)}, got #{inspect(actual)}")
+      end
+    end)
+  end
+
+  def test_migrate_from_string_keyed do
+    name = "real :elmdb migrate_from_string_keyed copies string LMDB into int-id LMDB"
+
+    with_envs(name, fn root ->
+      {source, src_env, src_dbi} = open_string_handle(root, "source", true)
+
+      {:ok, txn} = Elmdb.rw_txn_begin(src_env)
+      :ok = Elmdb.txn_put(txn, src_dbi, "alpha", "beta")
+      :ok = Elmdb.txn_put(txn, src_dbi, "alpha", "gamma")
+      :ok = Elmdb.txn_put(txn, src_dbi, "delta", "epsilon")
+      :ok = Elmdb.txn_commit(txn)
+
+      {dest, dest_env} = open_int_handle(root, "dest", true)
+      {:ok, result} = LmdbIntIds.migrate_from_string_keyed(source, dest, batch_size: 2)
+
+      migrated_alpha = LmdbIntIds.lookup_by_arg1(dest, "alpha", nil) |> MapSet.new()
+      Elmdb.env_close(src_env)
+      Elmdb.env_close(dest_env)
+
+      cond do
+        result.pairs_migrated != 3 -> fail(name, "expected 3 migrated pairs, got #{inspect(result)}")
+        result.ids_assigned != 5 -> fail(name, "expected 5 ids assigned, got #{inspect(result)}")
+        not MapSet.equal?(migrated_alpha, MapSet.new([{"alpha", "beta"}, {"alpha", "gamma"}])) ->
+          fail(name, "alpha rows mismatch: #{inspect(migrated_alpha)}")
+        true ->
+          pass(name)
+      end
+    end)
+  end
+
+  def run do
+    test_unique_ingest_lookup_stream()
+    test_dupsort_lookup()
+    test_migrate_from_string_keyed()
+  end
+end
+
+LmdbIntIdsRealTest.run()

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -922,6 +922,70 @@ run_lmdb_int_ids_mock_e2e(Test) :-
         assertz(test_failed)
     ).
 
+test_lmdb_int_ids_real_lmdb_e2e :-
+    % End-to-end exercise against an actual LMDB env through the Hex
+    % :elmdb package. The Elixir script supplies the real-driver bridge
+    % from the runtime's dependency-free `Elmdb` shape to the Erlang
+    % `:elmdb` module. It skips cleanly if the local NIF toolchain cannot
+    % compile :elmdb.
+    Test = 'LmdbIntIds: real LMDB e2e through :elmdb bridge',
+    (   catch(process_create(path(elixir), ['-v'],
+                              [stdout(null), stderr(null), process(P)]),
+              _, fail),
+        process_wait(P, _)
+    ->  run_lmdb_int_ids_real_lmdb_e2e(Test)
+    ;   format('[SKIP] ~w: elixir not installed~n', [Test])
+    ).
+
+run_lmdb_int_ids_real_lmdb_e2e(Test) :-
+    TmpDir = '/tmp/test_lmdb_int_ids_real_lmdb_e2e',
+    (   exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true ),
+    make_directory(TmpDir),
+    directory_file_path(TmpDir, 'lib', LibDir),
+    make_directory(LibDir),
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    directory_file_path(LibDir, 'wam_runtime.ex', RuntimePath),
+    open(RuntimePath, write, RS),
+    write(RS, RuntimeCode),
+    close(RS),
+    source_file(test_lmdb_int_ids_real_lmdb_e2e, SrcFile),
+    file_directory_name(SrcFile, TestsDir),
+    directory_file_path(TestsDir, 'elixir_e2e/lmdb_int_ids_real_test.exs', TestSrc),
+    directory_file_path(TmpDir, 'lmdb_int_ids_real_test.exs', TestDst),
+    copy_file(TestSrc, TestDst),
+    process_create(path(elixir),
+                   ['lmdb_int_ids_real_test.exs'],
+                   [cwd(TmpDir),
+                    stdout(pipe(Out)), stderr(pipe(Err)),
+                    process(Pid)]),
+    read_string(Out, _, StdOut),
+    read_string(Err, _, StdErr),
+    process_wait(Pid, Status),
+    close(Out),
+    close(Err),
+    split_string(StdOut, "\n", "", Lines),
+    (   member(SkipLine, Lines),
+        string_concat("[SKIP] ", _, SkipLine)
+    ->  format('[SKIP] ~w: ~s~n', [Test, SkipLine])
+    ;   findall(L, (member(L, Lines), string_concat("[PASS] ", _, L)), PassLines),
+        findall(L, (member(L, Lines), string_concat("[FAIL] ", _, L)), FailLines),
+        length(PassLines, NPass),
+        length(FailLines, NFail),
+        (   Status = exit(0), NPass >= 3, NFail = 0
+        ->  format('[PASS] ~w (~w sub-tests via real LMDB)~n', [Test, NPass])
+        ;   format('[FAIL] ~w: status=~w pass=~w fail=~w~n', [Test, Status, NPass, NFail]),
+            (   FailLines = [_|_]
+            ->  forall(member(F, FailLines), format('  ~s~n', [F]))
+            ;   true
+            ),
+            (   StdErr \= ""
+            ->  format('  stderr:~n~s~n', [StdErr])
+            ;   true
+            ),
+            assertz(test_failed)
+        )
+    ).
+
 test_lmdb_int_ids_migrate_from_string_keyed_emitted :-
     % Migration helper: existing PR #1792 string-keyed Lmdb env
     % -> int-id-keyed LmdbIntIds env. Without this, deployments
@@ -2738,6 +2802,7 @@ run_tests :-
     test_lmdb_int_ids_ingest_pairs_emitted,
     test_lmdb_int_ids_migrate_from_string_keyed_emitted,
     test_lmdb_int_ids_mock_e2e,
+    test_lmdb_int_ids_real_lmdb_e2e,
     test_shared_detector_finds_tc,
     test_shared_detector_finds_category_ancestor,
     test_kernel_dispatch_emits_tc_module,


### PR DESCRIPTION
## Summary

- add a real-`:elmdb` end-to-end fixture for `WamRuntime.FactSource.LmdbIntIds`
- cover unique-key ingest/lookup/stream, dupsort lookup, and migration from string-keyed LMDB into int-id LMDB
- document the real driver boundary: generated runtime resolves a dependency-free `Elmdb` bridge, while the Hex package exposes Erlang `:elmdb`

## Validation

- `swipl -q -s tests/test_wam_elixir_target.pl -g test_lmdb_int_ids_real_lmdb_e2e -t halt`
- `swipl -q -s tests/test_wam_elixir_target.pl -g run_tests -t halt`
- `git diff --check`

## Notes

- The fixture skips cleanly if `:elmdb` cannot be downloaded or compiled locally.
- On this OTP 28/asdf install, `:elmdb` required a local compatibility symlink from `liberl_interface.a` to `libei.a` before the NIF could link.