### PR TITLE
feat(wam-c): Add WAM C category ancestor native kernel

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,7 +4,7 @@ Status date: 2026-05-04
 
 Base verified locally:
 
-- `main` at `21258826` (`Merge pull request #1831 from s243a/docs/wam-c-next-steps-refresh`)
+- `main` at `1e2bb5d6` (`Merge pull request #1832 from s243a/feat/wam-c-call-foreign`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 
 This file replaces the older implementation plan. The four original C follow-up
@@ -21,6 +21,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Runtime helpers | Done | `wam_state_init`, `wam_free_state`, `wam_run_predicate`, `test_helpers_generation` |
 | Unsupported instruction fail-fast | Done | `unsupported_instruction`, `unsupported_instruction_tokens`, no `(Instruction){0}` fallback |
 | Foreign predicate dispatch foundation | Done | `INSTR_CALL_FOREIGN`, `WamForeignHandler`, `wam_register_foreign_predicate`, `wam_execute_foreign_predicate`, executable smoke |
+| Native category ancestor kernel foundation | Done | `wam_register_category_parent`, `wam_register_category_ancestor_kernel`, `wam_category_ancestor_handler`, direct and recursive executable smoke |
 
 ## Current C Target Baseline
 
@@ -36,13 +37,15 @@ The C target is now a credible small WAM backend:
 - Supports basic `builtin_call` delegation for tested builtins:
   `atom/1`, `integer/1`, `is_list/1`, `=/2`, and `is/2`.
 - Supports deterministic `call_foreign` dispatch through a C handler registry.
+- Supports a deterministic native `category_ancestor/4` handler over an
+  in-memory category-parent edge table.
 - Has executable smokes for generated runtime, cross-predicate calls,
-  foreign calls, real multi-clause predicates, structure indexing, `is_list/1`,
-  and `=/2`.
+  foreign calls, native category ancestor, real multi-clause predicates,
+  structure indexing, `is_list/1`, and `=/2`.
 
 The main limitation is not core WAM execution anymore. It is hybrid-WAM
-infrastructure: C lacks the native kernel, FactSource, lowered/native helper,
-and benchmark wiring that Haskell and Rust already have.
+infrastructure: C lacks FactSource, lowered/native helper, streaming foreign
+results, and benchmark wiring that Haskell and Rust already have.
 
 ## Feature Parity Matrix
 
@@ -62,7 +65,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
 | Negation / control builtins | Partial | Broader | Broader | C likely needs explicit tests for `\+/1`, cut interactions, and if-then-else lowering. |
 | Foreign predicate instruction (`CallForeign`) | Done | Done | Done | C has deterministic handler dispatch; later branches can add streaming result conventions. |
-| Native recursive kernels | Missing | Done | Done | Start with one kernel, probably `category_ancestor/4` or `transitive_closure2`. |
+| Native recursive kernels | Partial | Done | Done | C has deterministic `category_ancestor/4`; add streaming results and detector-driven setup later. |
 | Shared kernel detector integration | Missing | Done | Done | Reuse `recursive_kernel_detection.pl`; generate C registration stubs. |
 | Lowered/native helper functions | Missing | Done | Done | Consider after foreign kernels; C can lower simple fact-only or deterministic predicates. |
 | FactSource abstraction | Missing | Partial/less central | Done | Add simple file-backed FactSource before LMDB. |
@@ -74,23 +77,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-category-ancestor-kernel`
-
-Goal: wire one shared recursive kernel into C now that `CallForeign` exists.
-
-Candidate kernel:
-
-- `category_ancestor/4`, because it is the effective-distance workload's core
-  recursive kernel and has mature Rust/Haskell examples.
-
-Scope:
-
-- Use `recursive_kernel_detection.pl` to detect the predicate.
-- Emit C registration stubs and a native handler skeleton.
-- Keep facts in a simple in-memory edge table initially.
-- Add a small executable smoke with a tiny category graph.
-
-### 2. `feat/wam-c-file-fact-source`
+### 1. `feat/wam-c-file-fact-source`
 
 Goal: add the first C FactSource abstraction.
 
@@ -104,7 +91,7 @@ Scope:
 Why before LMDB: ownership, row encoding, and cursor semantics are easier to
 settle with a file-backed source.
 
-### 3. `feat/wam-c-effective-distance-bench`
+### 2. `feat/wam-c-effective-distance-bench`
 
 Goal: make C visible in the benchmark matrix once kernels/facts exist.
 
@@ -113,6 +100,19 @@ Scope:
 - Add a C effective-distance generator under `examples/benchmark/`.
 - Support `kernels_on` / `kernels_off`.
 - Start with small TSV/fact-source mode; add LMDB later.
+
+### 3. `feat/wam-c-streaming-foreign-results`
+
+Goal: support multiple foreign results instead of only deterministic success.
+
+Scope:
+
+- Define a small result-buffer convention for foreign handlers.
+- Use it to return all `category_ancestor/4` hop counts for a query.
+- Preserve deterministic handlers as the simple path.
+
+Why before larger benchmark work: effective-distance needs all paths, not just
+the first successful path.
 
 ### 4. `perf/wam-c-pack-instruction`
 
@@ -130,15 +130,15 @@ or cache behavior becomes a real bottleneck.
 
 ## Suggested Immediate Next Step
 
-Start with `feat/wam-c-category-ancestor-kernel`.
+Start with `feat/wam-c-file-fact-source`.
 
-It is now the smallest feature that exercises the new C foreign-call
-foundation against the same class of hybrid WAM work that Rust and Haskell
-already handle. The work should be split into two commits:
+It is now the smallest feature that moves the native kernel from hand-seeded
+test data toward benchmark-usable external facts. The work should be split
+into two commits:
 
-1. C native handler skeleton and registration path for one detected kernel.
-2. Tiny category graph executable smoke that proves the handler can bind output
-   registers through `CallForeign`.
+1. Runtime FactSource interface plus TSV/grouped-by-first loader.
+2. Category-parent wiring and an executable smoke that feeds the native
+   `category_ancestor/4` kernel from the loaded source.
 
 Keep LMDB and effective-distance out of that branch; they depend on a stable
-native-kernel shape.
+external fact-source shape.

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -102,6 +102,11 @@ typedef struct {
     WamForeignHandler handler;
 } ForeignEntry;
 
+typedef struct {
+    const char *child;
+    const char *parent;
+} CategoryEdge;
+
 /* Instruction */
 // TODO: Pack these fields into a union keyed on `tag` to reduce memory footprint
 typedef struct {
@@ -167,6 +172,12 @@ struct WamState {
 
     /* Foreign predicate handlers */
     ForeignEntry foreign_hash[WAM_FOREIGN_HASH_SIZE];
+
+    /* Native category_ancestor kernel data */
+    CategoryEdge *category_edges;
+    int category_edge_count;
+    int category_edge_cap;
+    int category_max_depth;
 };
 
 bool step_wam(WamState* state, Instruction* instr);
@@ -176,6 +187,9 @@ void wam_free_state(WamState *state);
 int wam_run_predicate(WamState *state, const char *pred, WamValue *args, int arity);
 bool wam_execute_builtin(WamState *state, const char *op, int arity);
 bool wam_execute_foreign_predicate(WamState *state, const char *pred, int arity);
+void wam_register_category_parent(WamState *state, const char *child, const char *parent);
+void wam_register_category_ancestor_kernel(WamState *state, const char *pred, int max_depth);
+bool wam_category_ancestor_handler(WamState *state, const char *pred, int arity);
 
 /* Helpers */
 static inline WamValue val_atom(const char *s) {

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -812,6 +812,7 @@ void wam_free_state(WamState *state) {
     free(state->TR_array);
     free(state->B_array);
     free(state->E_array);
+    free(state->category_edges);
     memset(state, 0, sizeof(WamState));
 }
 
@@ -914,6 +915,127 @@ bool wam_execute_foreign_predicate(WamState *state, const char *pred, int arity)
     WamForeignHandler handler = resolve_foreign_predicate(state, pred, arity);
     if (!handler) return false;
     return handler(state, pred, arity);
+}
+
+void wam_register_category_parent(WamState *state, const char *child, const char *parent) {
+    if (state->category_edge_count >= state->category_edge_cap) {
+        state->category_edge_cap = state->category_edge_cap ? state->category_edge_cap * 2 : WAM_INITIAL_CAP;
+        state->category_edges = realloc(state->category_edges, sizeof(CategoryEdge) * state->category_edge_cap);
+    }
+    state->category_edges[state->category_edge_count].child = wam_intern_atom(state, child);
+    state->category_edges[state->category_edge_count].parent = wam_intern_atom(state, parent);
+    state->category_edge_count++;
+}
+
+void wam_register_category_ancestor_kernel(WamState *state, const char *pred, int max_depth) {
+    state->category_max_depth = max_depth > 0 ? max_depth : 10;
+    wam_register_foreign_predicate(state, pred, 4, wam_category_ancestor_handler);
+}
+
+static bool wam_value_as_atom(WamState *state, WamValue value, const char **out) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    if (cell->tag != VAL_ATOM) return false;
+    *out = cell->data.atom;
+    return true;
+}
+
+static bool wam_list_contains_atom(WamState *state, WamValue value, const char *atom) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    while (cell->tag == VAL_LIST) {
+        WamValue *head = wam_deref_ptr(state, &state->H_array[cell->data.ref_addr]);
+        if (head->tag == VAL_ATOM && strcmp(head->data.atom, atom) == 0) return true;
+        cell = wam_deref_ptr(state, &state->H_array[cell->data.ref_addr + 1]);
+    }
+    return cell->tag == VAL_ATOM && strcmp(cell->data.atom, atom) == 0;
+}
+
+static bool wam_list_atoms_to_array(WamState *state,
+                                    WamValue value,
+                                    const char **out,
+                                    int *out_len,
+                                    int max_len) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    int count = 0;
+    while (cell->tag == VAL_LIST) {
+        if (count >= max_len) return false;
+        WamValue *head = wam_deref_ptr(state, &state->H_array[cell->data.ref_addr]);
+        if (head->tag != VAL_ATOM) return false;
+        out[count++] = head->data.atom;
+        cell = wam_deref_ptr(state, &state->H_array[cell->data.ref_addr + 1]);
+    }
+    if (cell->tag == VAL_ATOM && strcmp(cell->data.atom, "[]") == 0) {
+        *out_len = count;
+        return true;
+    }
+    return false;
+}
+
+static bool wam_visited_array_contains(const char **visited, int visited_len, const char *atom) {
+    for (int i = 0; i < visited_len; i++) {
+        if (strcmp(visited[i], atom) == 0) return true;
+    }
+    return false;
+}
+
+static bool wam_category_ancestor_dfs(WamState *state,
+                                      const char *cat,
+                                      const char *root,
+                                      int depth,
+                                      int max_depth,
+                                      const char **visited,
+                                      int visited_len,
+                                      int *hops_out) {
+    for (int i = 0; i < state->category_edge_count; i++) {
+        CategoryEdge *edge = &state->category_edges[i];
+        if (strcmp(edge->child, cat) != 0) continue;
+        if (wam_visited_array_contains(visited, visited_len, edge->parent)) continue;
+        if (strcmp(edge->parent, root) == 0) {
+            *hops_out = depth + 1;
+            return true;
+        }
+    }
+
+    if (visited_len >= max_depth || visited_len >= 64) return false;
+
+    for (int i = 0; i < state->category_edge_count; i++) {
+        CategoryEdge *edge = &state->category_edges[i];
+        if (strcmp(edge->child, cat) != 0) continue;
+        if (wam_visited_array_contains(visited, visited_len, edge->parent)) continue;
+        visited[visited_len] = edge->parent;
+        if (wam_category_ancestor_dfs(state, edge->parent, root, depth + 1,
+                                      max_depth, visited, visited_len + 1,
+                                      hops_out)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool wam_category_ancestor_handler(WamState *state, const char *pred, int arity) {
+    (void)pred;
+    if (arity != 4) return false;
+
+    const char *cat = NULL;
+    const char *root = NULL;
+    if (!wam_value_as_atom(state, state->A[0], &cat)) return false;
+    if (!wam_value_as_atom(state, state->A[1], &root)) return false;
+    const char *visited[64];
+    int visited_len = 0;
+    if (!wam_list_atoms_to_array(state, state->A[3], visited, &visited_len, 64)) return false;
+    if (wam_list_contains_atom(state, state->A[3], root)) return false;
+    if (visited_len == 0) {
+        visited[visited_len++] = cat;
+    }
+
+    int max_depth = state->category_max_depth > 0 ? state->category_max_depth : 10;
+    int hops = 0;
+    if (!wam_category_ancestor_dfs(state, cat, root, 0, max_depth,
+                                   visited, visited_len, &hops)) {
+        return false;
+    }
+
+    WamValue result = val_int(hops);
+    return wam_unify(state, &state->A[2], &result);
 }
 '.
 

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -235,6 +235,18 @@ test_call_foreign_generation :-
     ;   fail_test(Test, 'call_foreign parser/runtime delegation missing')
     ).
 
+test_category_ancestor_kernel_generation :-
+    Test = 'WAM-C: category_ancestor native kernel helpers generated',
+    (   compile_wam_runtime_to_c([], RuntimeCode),
+        atom_string(RuntimeCode, S),
+        sub_string(S, _, _, _, 'void wam_register_category_parent'),
+        sub_string(S, _, _, _, 'void wam_register_category_ancestor_kernel'),
+        sub_string(S, _, _, _, 'bool wam_category_ancestor_handler'),
+        sub_string(S, _, _, _, 'wam_category_ancestor_dfs')
+    ->  pass(Test)
+    ;   fail_test(Test, 'category_ancestor native kernel helpers missing')
+    ).
+
 test_unsupported_instruction_fails_loudly :-
     Test = 'WAM-C: unsupported instructions fail loudly',
     BadWamCode = 'foo/1:\n    unknown_opcode A1\n    proceed',
@@ -314,6 +326,16 @@ test_call_foreign_executable_smoke :-
     ->  (   run_call_foreign_executable_smoke
         ->  pass(Test)
         ;   fail_test(Test, 'call_foreign executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
+test_category_ancestor_kernel_executable_smoke :-
+    Test = 'WAM-C: category_ancestor native kernel executable smoke',
+    (   gcc_available
+    ->  (   run_category_ancestor_kernel_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'category_ancestor native kernel executable failed')
         )
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
@@ -446,6 +468,25 @@ run_call_foreign_executable_smoke :-
     format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
     write_text_file(PredPath, PredTranslationUnit),
     wam_c_foreign_smoke_main(MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
+run_category_ancestor_kernel_executable_smoke :-
+    WamCode = 'category_ancestor/4:\n    call_foreign category_ancestor/4, 4\n    proceed',
+    compile_wam_predicate_to_c(user:category_ancestor/4, WamCode, [], PredCode),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(TmpBase), '/tmp/unifyweaver_wam_c_category_ancestor_smoke_~w', [Stamp]),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(RuntimePath, RuntimeCode),
+    format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+    write_text_file(PredPath, PredTranslationUnit),
+    wam_c_category_ancestor_smoke_main(MainCode),
     write_text_file(MainPath, MainCode),
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
@@ -777,6 +818,72 @@ int main(void) {
 }
 ').
 
+wam_c_category_ancestor_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_category_ancestor_4(WamState* state);
+
+static WamValue make_visited_singleton(WamState *state, const char *atom) {
+    WamValue list;
+    list.tag = VAL_LIST;
+    list.data.ref_addr = state->H;
+    state->H_array[state->H++] = val_atom(atom);
+    state->H_array[state->H++] = val_atom("[]");
+    return list;
+}
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_category_ancestor_4(&state);
+    wam_register_category_parent(&state, "leaf", "mid");
+    wam_register_category_parent(&state, "mid", "root");
+    wam_register_category_parent(&state, "leaf", "other");
+    wam_register_category_ancestor_kernel(&state, "category_ancestor/4", 10);
+
+    WamValue recursive_args[4] = {
+        val_atom("leaf"),
+        val_atom("root"),
+        val_unbound("Hops"),
+        make_visited_singleton(&state, "leaf")
+    };
+    int recursive_rc = wam_run_predicate(&state, "category_ancestor/4", recursive_args, 4);
+    if (recursive_rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 2) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue direct_args[4] = {
+        val_atom("leaf"),
+        val_atom("mid"),
+        val_unbound("Hops"),
+        make_visited_singleton(&state, "leaf")
+    };
+    int direct_rc = wam_run_predicate(&state, "category_ancestor/4", direct_args, 4);
+    if (direct_rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 1) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue fail_args[4] = {
+        val_atom("other"),
+        val_atom("root"),
+        val_unbound("Hops"),
+        make_visited_singleton(&state, "other")
+    };
+    int fail_rc = wam_run_predicate(&state, "category_ancestor/4", fail_args, 4);
+    if (fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_real_builtin_smoke_main(
 '#include "wam_runtime.h"
 
@@ -1049,6 +1156,7 @@ run_tests_once :-
     test_predicate_hash_registration,
     test_builtin_call_generation,
     test_call_foreign_generation,
+    test_category_ancestor_kernel_generation,
     test_unsupported_instruction_fails_loudly,
     test_no_zero_instruction_fallback,
     test_list_target_pc_emission,
@@ -1056,6 +1164,7 @@ run_tests_once :-
     test_cross_predicate_executable_smoke,
     test_builtin_call_executable_smoke,
     test_call_foreign_executable_smoke,
+    test_category_ancestor_kernel_executable_smoke,
     test_real_prolog_builtin_executable_smoke,
     test_real_prolog_multiclause_executable_smoke,
     test_real_prolog_structure_index_executable_smoke,


### PR DESCRIPTION
## Summary

This PR adds the first native recursive kernel foundation for the WAM C target: a deterministic `category_ancestor/4` handler backed by an in-memory category-parent edge table.

## What Changed

- Adds C runtime storage for category-parent edges.
- Adds runtime registration helpers:
  - `wam_register_category_parent`
  - `wam_register_category_ancestor_kernel`
- Adds `wam_category_ancestor_handler` for native `category_ancestor/4` dispatch through the existing `CallForeign` registry.
- Supports direct and recursive ancestor lookup over the registered edge table.
- Adds an executable smoke test covering:
  - direct ancestor hit
  - recursive ancestor hit
  - missing ancestor failure
- Updates `WAM_C_TARGET_NEXT_STEPS.md` to mark the native category ancestor foundation complete and move the next recommended branch to `feat/wam-c-file-fact-source`.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --cached --check`

## Follow-Up

This branch keeps the C foreign-call contract deterministic. Full effective-distance parity still needs streaming foreign results so `category_ancestor/4` can return all hop counts for a query.

