### PR TITLE
feat(wam-c): add file-backed fact source

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,7 +4,7 @@ Status date: 2026-05-04
 
 Base verified locally:
 
-- `main` at `1e2bb5d6` (`Merge pull request #1832 from s243a/feat/wam-c-call-foreign`)
+- `main` at `d7611dc9` (`Merge pull request #1834 from s243a/feat/wam-c-category-ancestor-kernel`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 
 This file replaces the older implementation plan. The four original C follow-up
@@ -22,6 +22,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Unsupported instruction fail-fast | Done | `unsupported_instruction`, `unsupported_instruction_tokens`, no `(Instruction){0}` fallback |
 | Foreign predicate dispatch foundation | Done | `INSTR_CALL_FOREIGN`, `WamForeignHandler`, `wam_register_foreign_predicate`, `wam_execute_foreign_predicate`, executable smoke |
 | Native category ancestor kernel foundation | Done | `wam_register_category_parent`, `wam_register_category_ancestor_kernel`, `wam_category_ancestor_handler`, direct and recursive executable smoke |
+| File-backed FactSource foundation | Done | `WamFactSource`, `wam_fact_source_load_tsv`, `wam_fact_source_lookup_arg1`, `wam_register_category_parent_fact_source`, executable smoke |
 
 ## Current C Target Baseline
 
@@ -39,13 +40,15 @@ The C target is now a credible small WAM backend:
 - Supports deterministic `call_foreign` dispatch through a C handler registry.
 - Supports a deterministic native `category_ancestor/4` handler over an
   in-memory category-parent edge table.
+- Supports loading category-parent facts from TSV through a small
+  `WamFactSource` interface.
 - Has executable smokes for generated runtime, cross-predicate calls,
-  foreign calls, native category ancestor, real multi-clause predicates,
-  structure indexing, `is_list/1`, and `=/2`.
+  foreign calls, native category ancestor, file-backed facts, real
+  multi-clause predicates, structure indexing, `is_list/1`, and `=/2`.
 
 The main limitation is not core WAM execution anymore. It is hybrid-WAM
-infrastructure: C lacks FactSource, lowered/native helper, streaming foreign
-results, and benchmark wiring that Haskell and Rust already have.
+infrastructure: C lacks streaming foreign results, lowered/native helper,
+LMDB, and benchmark wiring that Haskell and Rust already have.
 
 ## Feature Parity Matrix
 
@@ -68,40 +71,16 @@ missing important target features; `Missing` = no comparable C path yet.
 | Native recursive kernels | Partial | Done | Done | C has deterministic `category_ancestor/4`; add streaming results and detector-driven setup later. |
 | Shared kernel detector integration | Missing | Done | Done | Reuse `recursive_kernel_detection.pl`; generate C registration stubs. |
 | Lowered/native helper functions | Missing | Done | Done | Consider after foreign kernels; C can lower simple fact-only or deterministic predicates. |
-| FactSource abstraction | Missing | Partial/less central | Done | Add simple file-backed FactSource before LMDB. |
-| LMDB-backed facts | Missing | Not primary | Done | Haskell is the reference. C should first define FactSource API and ownership model. |
-| Effective-distance benchmark harness | Missing | Done | Done | Add after foreign kernels and external fact sources. |
+| FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
+| LMDB-backed facts | Missing | Not primary | Done | Haskell is the reference. C now has an ownership model to extend. |
+| Effective-distance benchmark harness | Missing | Done | Done | Add after streaming foreign results so all paths can be counted. |
 | Classic-program e2e suite | Partial | Partial/Done | Partial/Done | C has targeted smokes; add Fibonacci/Ackermann-style suite like Scala/Elixir. |
 | Memory lifecycle | Partial | Runtime-managed | Runtime-managed | C has init/free; needs ASAN/Valgrind CI-style coverage for larger programs. |
 | Instruction layout efficiency | TODO | N/A | N/A | Pack `Instruction` fields into a tagged union if runtime footprint matters. |
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-file-fact-source`
-
-Goal: add the first C FactSource abstraction.
-
-Scope:
-
-- Define a small C interface for `scan`, `lookup_arg1`, and `close`.
-- Implement TSV or grouped-by-first file loading.
-- Wire a C foreign predicate to a FactSource lookup.
-- Add tests that mirror the Scala/Haskell grouped fact-source behavior.
-
-Why before LMDB: ownership, row encoding, and cursor semantics are easier to
-settle with a file-backed source.
-
-### 2. `feat/wam-c-effective-distance-bench`
-
-Goal: make C visible in the benchmark matrix once kernels/facts exist.
-
-Scope:
-
-- Add a C effective-distance generator under `examples/benchmark/`.
-- Support `kernels_on` / `kernels_off`.
-- Start with small TSV/fact-source mode; add LMDB later.
-
-### 3. `feat/wam-c-streaming-foreign-results`
+### 1. `feat/wam-c-streaming-foreign-results`
 
 Goal: support multiple foreign results instead of only deterministic success.
 
@@ -113,6 +92,27 @@ Scope:
 
 Why before larger benchmark work: effective-distance needs all paths, not just
 the first successful path.
+
+### 2. `feat/wam-c-effective-distance-bench`
+
+Goal: make C visible in the benchmark matrix once kernels/facts exist.
+
+Scope:
+
+- Add a C effective-distance generator under `examples/benchmark/`.
+- Support `kernels_on` / `kernels_off`.
+- Start with small TSV/fact-source mode; add LMDB later.
+
+### 3. `feat/wam-c-lmdb-fact-source`
+
+Goal: add LMDB-backed category-parent facts once the file FactSource and
+streaming result contracts are stable.
+
+Scope:
+
+- Mirror the TSV FactSource ownership model.
+- Load/cursor category-parent pairs from LMDB.
+- Keep this behind an optional build/runtime path.
 
 ### 4. `perf/wam-c-pack-instruction`
 
@@ -130,15 +130,16 @@ or cache behavior becomes a real bottleneck.
 
 ## Suggested Immediate Next Step
 
-Start with `feat/wam-c-file-fact-source`.
+Start with `feat/wam-c-streaming-foreign-results`.
 
-It is now the smallest feature that moves the native kernel from hand-seeded
-test data toward benchmark-usable external facts. The work should be split
-into two commits:
+It is now the smallest feature that unlocks real effective-distance semantics:
+the native category-ancestor kernel currently binds the first successful hop
+count, while the benchmark needs all hop counts for a query. The work should
+be split into two commits:
 
-1. Runtime FactSource interface plus TSV/grouped-by-first loader.
-2. Category-parent wiring and an executable smoke that feeds the native
-   `category_ancestor/4` kernel from the loaded source.
+1. Runtime result-buffer API and deterministic compatibility path.
+2. Category-ancestor all-hop collection plus an executable smoke with multiple
+   paths.
 
-Keep LMDB and effective-distance out of that branch; they depend on a stable
-external fact-source shape.
+Keep LMDB and effective-distance out of that branch; they depend on the
+streaming result shape.

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -107,6 +107,12 @@ typedef struct {
     const char *parent;
 } CategoryEdge;
 
+typedef struct {
+    CategoryEdge *edges;
+    int edge_count;
+    int edge_cap;
+} WamFactSource;
+
 /* Instruction */
 // TODO: Pack these fields into a union keyed on `tag` to reduce memory footprint
 typedef struct {
@@ -190,6 +196,12 @@ bool wam_execute_foreign_predicate(WamState *state, const char *pred, int arity)
 void wam_register_category_parent(WamState *state, const char *child, const char *parent);
 void wam_register_category_ancestor_kernel(WamState *state, const char *pred, int max_depth);
 bool wam_category_ancestor_handler(WamState *state, const char *pred, int arity);
+void wam_fact_source_init(WamFactSource *source);
+void wam_fact_source_close(WamFactSource *source);
+bool wam_fact_source_load_tsv(WamState *state, WamFactSource *source, const char *path);
+int wam_fact_source_lookup_arg1(WamFactSource *source, const char *arg1,
+                                CategoryEdge *out_edges, int max_edges);
+bool wam_register_category_parent_fact_source(WamState *state, WamFactSource *source);
 
 /* Helpers */
 static inline WamValue val_atom(const char *s) {

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -927,6 +927,84 @@ void wam_register_category_parent(WamState *state, const char *child, const char
     state->category_edge_count++;
 }
 
+void wam_fact_source_init(WamFactSource *source) {
+    memset(source, 0, sizeof(WamFactSource));
+}
+
+void wam_fact_source_close(WamFactSource *source) {
+    free(source->edges);
+    memset(source, 0, sizeof(WamFactSource));
+}
+
+static void wam_fact_source_add_edge(WamState *state,
+                                     WamFactSource *source,
+                                     const char *child,
+                                     const char *parent) {
+    if (source->edge_count >= source->edge_cap) {
+        source->edge_cap = source->edge_cap ? source->edge_cap * 2 : WAM_INITIAL_CAP;
+        source->edges = realloc(source->edges, sizeof(CategoryEdge) * source->edge_cap);
+    }
+    source->edges[source->edge_count].child = wam_intern_atom(state, child);
+    source->edges[source->edge_count].parent = wam_intern_atom(state, parent);
+    source->edge_count++;
+}
+
+bool wam_fact_source_load_tsv(WamState *state, WamFactSource *source, const char *path) {
+    FILE *file = fopen(path, "r");
+    if (!file) return false;
+
+    char line[1024];
+    while (fgets(line, sizeof(line), file)) {
+        char *start = line;
+        while (*start == 32 || *start == 9) start++;
+        if (*start == 0 || *start == 10 || *start == 35) continue;
+
+        char *sep = strchr(start, 9);
+        if (!sep) sep = strchr(start, 32);
+        if (!sep) {
+            fclose(file);
+            return false;
+        }
+
+        *sep = 0;
+        char *parent = sep + 1;
+        while (*parent == 32 || *parent == 9) parent++;
+
+        char *end = parent + strlen(parent);
+        while (end > parent && (end[-1] == 10 || end[-1] == 13 ||
+                                end[-1] == 32 || end[-1] == 9)) {
+            *--end = 0;
+        }
+
+        if (*start == 0 || *parent == 0) {
+            fclose(file);
+            return false;
+        }
+        wam_fact_source_add_edge(state, source, start, parent);
+    }
+
+    fclose(file);
+    return true;
+}
+
+int wam_fact_source_lookup_arg1(WamFactSource *source, const char *arg1,
+                                CategoryEdge *out_edges, int max_edges) {
+    int count = 0;
+    for (int i = 0; i < source->edge_count; i++) {
+        if (strcmp(source->edges[i].child, arg1) != 0) continue;
+        if (count < max_edges) out_edges[count] = source->edges[i];
+        count++;
+    }
+    return count;
+}
+
+bool wam_register_category_parent_fact_source(WamState *state, WamFactSource *source) {
+    for (int i = 0; i < source->edge_count; i++) {
+        wam_register_category_parent(state, source->edges[i].child, source->edges[i].parent);
+    }
+    return true;
+}
+
 void wam_register_category_ancestor_kernel(WamState *state, const char *pred, int max_depth) {
     state->category_max_depth = max_depth > 0 ? max_depth : 10;
     wam_register_foreign_predicate(state, pred, 4, wam_category_ancestor_handler);

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -247,6 +247,18 @@ test_category_ancestor_kernel_generation :-
     ;   fail_test(Test, 'category_ancestor native kernel helpers missing')
     ).
 
+test_fact_source_generation :-
+    Test = 'WAM-C: file FactSource helpers generated',
+    (   compile_wam_runtime_to_c([], RuntimeCode),
+        atom_string(RuntimeCode, S),
+        sub_string(S, _, _, _, 'void wam_fact_source_init'),
+        sub_string(S, _, _, _, 'bool wam_fact_source_load_tsv'),
+        sub_string(S, _, _, _, 'int wam_fact_source_lookup_arg1'),
+        sub_string(S, _, _, _, 'bool wam_register_category_parent_fact_source')
+    ->  pass(Test)
+    ;   fail_test(Test, 'file FactSource helpers missing')
+    ).
+
 test_unsupported_instruction_fails_loudly :-
     Test = 'WAM-C: unsupported instructions fail loudly',
     BadWamCode = 'foo/1:\n    unknown_opcode A1\n    proceed',
@@ -336,6 +348,16 @@ test_category_ancestor_kernel_executable_smoke :-
     ->  (   run_category_ancestor_kernel_executable_smoke
         ->  pass(Test)
         ;   fail_test(Test, 'category_ancestor native kernel executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
+test_fact_source_executable_smoke :-
+    Test = 'WAM-C: file FactSource executable smoke',
+    (   gcc_available
+    ->  (   run_fact_source_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'file FactSource executable failed')
         )
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
@@ -487,6 +509,27 @@ run_category_ancestor_kernel_executable_smoke :-
     format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
     write_text_file(PredPath, PredTranslationUnit),
     wam_c_category_ancestor_smoke_main(MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
+run_fact_source_executable_smoke :-
+    WamCode = 'category_ancestor/4:\n    call_foreign category_ancestor/4, 4\n    proceed',
+    compile_wam_predicate_to_c(user:category_ancestor/4, WamCode, [], PredCode),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(TmpBase), '/tmp/unifyweaver_wam_c_fact_source_smoke_~w', [Stamp]),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(DataPath), '~w_edges.tsv', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(RuntimePath, RuntimeCode),
+    format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+    write_text_file(PredPath, PredTranslationUnit),
+    write_text_file(DataPath, 'leaf\tmid\nmid\troot\nleaf\tother\n'),
+    wam_c_fact_source_smoke_main(DataPath, MainCode),
     write_text_file(MainPath, MainCode),
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
@@ -884,6 +927,67 @@ int main(void) {
 }
 ').
 
+wam_c_fact_source_smoke_main(DataPath, MainCode) :-
+    format(atom(MainCode),
+'#include "wam_runtime.h"
+
+void setup_category_ancestor_4(WamState* state);
+
+static WamValue make_visited_singleton(WamState *state, const char *atom) {
+    WamValue list;
+    list.tag = VAL_LIST;
+    list.data.ref_addr = state->H;
+    state->H_array[state->H++] = val_atom(atom);
+    state->H_array[state->H++] = val_atom("[]");
+    return list;
+}
+
+int main(void) {
+    WamState state;
+    WamFactSource source;
+    CategoryEdge matches[4];
+    wam_state_init(&state);
+    wam_fact_source_init(&source);
+    setup_category_ancestor_4(&state);
+
+    if (!wam_fact_source_load_tsv(&state, &source, "~w")) {
+        wam_free_state(&state);
+        wam_fact_source_close(&source);
+        return 10;
+    }
+
+    int match_count = wam_fact_source_lookup_arg1(&source, "leaf", matches, 4);
+    if (match_count != 2 ||
+        strcmp(matches[0].child, "leaf") != 0 ||
+        strcmp(matches[0].parent, "mid") != 0) {
+        wam_free_state(&state);
+        wam_fact_source_close(&source);
+        return 20;
+    }
+
+    wam_register_category_parent_fact_source(&state, &source);
+    wam_register_category_ancestor_kernel(&state, "category_ancestor/4", 10);
+
+    WamValue args[4] = {
+        val_atom("leaf"),
+        val_atom("root"),
+        val_unbound("Hops"),
+        make_visited_singleton(&state, "leaf")
+    };
+    int rc = wam_run_predicate(&state, "category_ancestor/4", args, 4);
+    if (rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 2) {
+        wam_free_state(&state);
+        wam_fact_source_close(&source);
+        return 30;
+    }
+
+    wam_free_state(&state);
+    wam_fact_source_close(&source);
+    return 0;
+}
+', [DataPath]).
+
 wam_c_real_builtin_smoke_main(
 '#include "wam_runtime.h"
 
@@ -1157,6 +1261,7 @@ run_tests_once :-
     test_builtin_call_generation,
     test_call_foreign_generation,
     test_category_ancestor_kernel_generation,
+    test_fact_source_generation,
     test_unsupported_instruction_fails_loudly,
     test_no_zero_instruction_fallback,
     test_list_target_pc_emission,
@@ -1165,6 +1270,7 @@ run_tests_once :-
     test_builtin_call_executable_smoke,
     test_call_foreign_executable_smoke,
     test_category_ancestor_kernel_executable_smoke,
+    test_fact_source_executable_smoke,
     test_real_prolog_builtin_executable_smoke,
     test_real_prolog_multiclause_executable_smoke,
     test_real_prolog_structure_index_executable_smoke,


### PR DESCRIPTION
## Summary

This PR adds the first file-backed FactSource foundation for the WAM C target. It lets generated C runtimes load category-parent facts from TSV, look them up by first argument, and feed them into the native `category_ancestor/4` kernel.

## What Changed

- Adds `WamFactSource` to the WAM C runtime.
- Adds TSV loading with `wam_fact_source_load_tsv`.
- Adds first-argument lookup with `wam_fact_source_lookup_arg1`.
- Adds `wam_register_category_parent_fact_source` to register loaded rows into the existing category-parent edge table.
- Adds an executable smoke test proving TSV-loaded facts drive the native `category_ancestor/4` handler.
- Updates `WAM_C_TARGET_NEXT_STEPS.md` to mark the file-backed FactSource foundation complete and move the next recommended branch to `feat/wam-c-streaming-foreign-results`.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --cached --check`

## Follow-Up

The next parity step is streaming foreign results. The current C foreign-call contract is deterministic, so `category_ancestor/4` still returns the first matching hop count rather than all hop counts needed for full effective-distance semantics.