### PR TITLE
feat(wam-c): Collect streaming WAM C foreign integer results

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,7 +4,7 @@ Status date: 2026-05-04
 
 Base verified locally:
 
-- `main` at `d7611dc9` (`Merge pull request #1834 from s243a/feat/wam-c-category-ancestor-kernel`)
+- `main` at `404c8c00` (`Merge pull request #1836 from s243a/feat/wam-c-file-fact-source`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 
 This file replaces the older implementation plan. The four original C follow-up
@@ -23,6 +23,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Foreign predicate dispatch foundation | Done | `INSTR_CALL_FOREIGN`, `WamForeignHandler`, `wam_register_foreign_predicate`, `wam_execute_foreign_predicate`, executable smoke |
 | Native category ancestor kernel foundation | Done | `wam_register_category_parent`, `wam_register_category_ancestor_kernel`, `wam_category_ancestor_handler`, direct and recursive executable smoke |
 | File-backed FactSource foundation | Done | `WamFactSource`, `wam_fact_source_load_tsv`, `wam_fact_source_lookup_arg1`, `wam_register_category_parent_fact_source`, executable smoke |
+| Streaming integer foreign-result foundation | Done | `WamIntResults`, `wam_int_results_push`, `wam_collect_category_ancestor_hops`, multi-path executable smoke |
 
 ## Current C Target Baseline
 
@@ -42,13 +43,17 @@ The C target is now a credible small WAM backend:
   in-memory category-parent edge table.
 - Supports loading category-parent facts from TSV through a small
   `WamFactSource` interface.
+- Supports collecting all integer hop results for native `category_ancestor/4`
+  through `WamIntResults`, while preserving deterministic first-result handler
+  behavior.
 - Has executable smokes for generated runtime, cross-predicate calls,
-  foreign calls, native category ancestor, file-backed facts, real
-  multi-clause predicates, structure indexing, `is_list/1`, and `=/2`.
+  foreign calls, native category ancestor, file-backed facts, streaming native
+  results, real multi-clause predicates, structure indexing, `is_list/1`, and
+  `=/2`.
 
 The main limitation is not core WAM execution anymore. It is hybrid-WAM
-infrastructure: C lacks streaming foreign results, lowered/native helper,
-LMDB, and benchmark wiring that Haskell and Rust already have.
+infrastructure: C lacks lowered/native helper integration, LMDB, and benchmark
+wiring that Haskell and Rust already have.
 
 ## Feature Parity Matrix
 
@@ -67,33 +72,20 @@ missing important target features; `Missing` = no comparable C path yet.
 | Builtin calls | Partial | Broader | Broader | C has a small builtin set. Add `functor/3`, `arg/3`, `atom_concat/3`, arithmetic comparisons as needed. |
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
 | Negation / control builtins | Partial | Broader | Broader | C likely needs explicit tests for `\+/1`, cut interactions, and if-then-else lowering. |
-| Foreign predicate instruction (`CallForeign`) | Done | Done | Done | C has deterministic handler dispatch; later branches can add streaming result conventions. |
-| Native recursive kernels | Partial | Done | Done | C has deterministic `category_ancestor/4`; add streaming results and detector-driven setup later. |
+| Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
+| Native recursive kernels | Partial | Done | Done | C has `category_ancestor/4` all-hop collection; add detector-driven setup later. |
 | Shared kernel detector integration | Missing | Done | Done | Reuse `recursive_kernel_detection.pl`; generate C registration stubs. |
 | Lowered/native helper functions | Missing | Done | Done | Consider after foreign kernels; C can lower simple fact-only or deterministic predicates. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Missing | Not primary | Done | Haskell is the reference. C now has an ownership model to extend. |
-| Effective-distance benchmark harness | Missing | Done | Done | Add after streaming foreign results so all paths can be counted. |
+| Effective-distance benchmark harness | Missing | Done | Done | Next parity step: wire TSV facts and all-hop collection into a benchmark harness. |
 | Classic-program e2e suite | Partial | Partial/Done | Partial/Done | C has targeted smokes; add Fibonacci/Ackermann-style suite like Scala/Elixir. |
 | Memory lifecycle | Partial | Runtime-managed | Runtime-managed | C has init/free; needs ASAN/Valgrind CI-style coverage for larger programs. |
 | Instruction layout efficiency | TODO | N/A | N/A | Pack `Instruction` fields into a tagged union if runtime footprint matters. |
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-streaming-foreign-results`
-
-Goal: support multiple foreign results instead of only deterministic success.
-
-Scope:
-
-- Define a small result-buffer convention for foreign handlers.
-- Use it to return all `category_ancestor/4` hop counts for a query.
-- Preserve deterministic handlers as the simple path.
-
-Why before larger benchmark work: effective-distance needs all paths, not just
-the first successful path.
-
-### 2. `feat/wam-c-effective-distance-bench`
+### 1. `feat/wam-c-effective-distance-bench`
 
 Goal: make C visible in the benchmark matrix once kernels/facts exist.
 
@@ -103,7 +95,7 @@ Scope:
 - Support `kernels_on` / `kernels_off`.
 - Start with small TSV/fact-source mode; add LMDB later.
 
-### 3. `feat/wam-c-lmdb-fact-source`
+### 2. `feat/wam-c-lmdb-fact-source`
 
 Goal: add LMDB-backed category-parent facts once the file FactSource and
 streaming result contracts are stable.
@@ -113,6 +105,16 @@ Scope:
 - Mirror the TSV FactSource ownership model.
 - Load/cursor category-parent pairs from LMDB.
 - Keep this behind an optional build/runtime path.
+
+### 3. `feat/wam-c-kernel-detector-setup`
+
+Goal: connect the C target to the shared recursive-kernel detector.
+
+Scope:
+
+- Reuse `recursive_kernel_detection.pl`.
+- Generate C registration stubs for `category_ancestor/4`.
+- Keep the hand-registration runtime helpers as the low-level API.
 
 ### 4. `perf/wam-c-pack-instruction`
 
@@ -130,16 +132,15 @@ or cache behavior becomes a real bottleneck.
 
 ## Suggested Immediate Next Step
 
-Start with `feat/wam-c-streaming-foreign-results`.
+Start with `feat/wam-c-effective-distance-bench`.
 
-It is now the smallest feature that unlocks real effective-distance semantics:
-the native category-ancestor kernel currently binds the first successful hop
-count, while the benchmark needs all hop counts for a query. The work should
-be split into two commits:
+The C runtime now has the pieces the small TSV benchmark needs: file-backed
+category-parent facts, native category ancestor traversal, and all-hop integer
+collection. The work should be split into two commits:
 
-1. Runtime result-buffer API and deterministic compatibility path.
-2. Category-ancestor all-hop collection plus an executable smoke with multiple
-   paths.
+1. Generator or smoke harness under `examples/benchmark/` for a small
+   effective-distance query.
+2. `kernels_on` / `kernels_off` comparison path, still using TSV facts.
 
-Keep LMDB and effective-distance out of that branch; they depend on the
-streaming result shape.
+Keep LMDB out of that branch; TSV is enough to validate benchmark semantics and
+avoid introducing storage-library friction too early.

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -113,6 +113,12 @@ typedef struct {
     int edge_cap;
 } WamFactSource;
 
+typedef struct {
+    int *values;
+    int count;
+    int cap;
+} WamIntResults;
+
 /* Instruction */
 // TODO: Pack these fields into a union keyed on `tag` to reduce memory footprint
 typedef struct {
@@ -202,6 +208,10 @@ bool wam_fact_source_load_tsv(WamState *state, WamFactSource *source, const char
 int wam_fact_source_lookup_arg1(WamFactSource *source, const char *arg1,
                                 CategoryEdge *out_edges, int max_edges);
 bool wam_register_category_parent_fact_source(WamState *state, WamFactSource *source);
+void wam_int_results_init(WamIntResults *results);
+void wam_int_results_close(WamIntResults *results);
+bool wam_int_results_push(WamIntResults *results, int value);
+bool wam_collect_category_ancestor_hops(WamState *state, WamIntResults *results);
 
 /* Helpers */
 static inline WamValue val_atom(const char *s) {

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -1005,6 +1005,29 @@ bool wam_register_category_parent_fact_source(WamState *state, WamFactSource *so
     return true;
 }
 
+void wam_int_results_init(WamIntResults *results) {
+    memset(results, 0, sizeof(WamIntResults));
+}
+
+void wam_int_results_close(WamIntResults *results) {
+    free(results->values);
+    memset(results, 0, sizeof(WamIntResults));
+}
+
+bool wam_int_results_push(WamIntResults *results, int value) {
+    if (results->count >= results->cap) {
+        results->cap = results->cap ? results->cap * 2 : WAM_INITIAL_CAP;
+        results->values = realloc(results->values, sizeof(int) * results->cap);
+        if (!results->values) {
+            results->count = 0;
+            results->cap = 0;
+            return false;
+        }
+    }
+    results->values[results->count++] = value;
+    return true;
+}
+
 void wam_register_category_ancestor_kernel(WamState *state, const char *pred, int max_depth) {
     state->category_max_depth = max_depth > 0 ? max_depth : 10;
     wam_register_foreign_predicate(state, pred, 4, wam_category_ancestor_handler);
@@ -1062,18 +1085,19 @@ static bool wam_category_ancestor_dfs(WamState *state,
                                       int max_depth,
                                       const char **visited,
                                       int visited_len,
-                                      int *hops_out) {
+                                      WamIntResults *results) {
+    bool found = false;
     for (int i = 0; i < state->category_edge_count; i++) {
         CategoryEdge *edge = &state->category_edges[i];
         if (strcmp(edge->child, cat) != 0) continue;
         if (wam_visited_array_contains(visited, visited_len, edge->parent)) continue;
         if (strcmp(edge->parent, root) == 0) {
-            *hops_out = depth + 1;
-            return true;
+            if (!wam_int_results_push(results, depth + 1)) return false;
+            found = true;
         }
     }
 
-    if (visited_len >= max_depth || visited_len >= 64) return false;
+    if (visited_len >= max_depth || visited_len >= 64) return found;
 
     for (int i = 0; i < state->category_edge_count; i++) {
         CategoryEdge *edge = &state->category_edges[i];
@@ -1082,38 +1106,61 @@ static bool wam_category_ancestor_dfs(WamState *state,
         visited[visited_len] = edge->parent;
         if (wam_category_ancestor_dfs(state, edge->parent, root, depth + 1,
                                       max_depth, visited, visited_len + 1,
-                                      hops_out)) {
-            return true;
+                                      results)) {
+            found = true;
         }
     }
-    return false;
+    return found;
 }
 
-bool wam_category_ancestor_handler(WamState *state, const char *pred, int arity) {
-    (void)pred;
-    if (arity != 4) return false;
-
+static bool wam_category_ancestor_inputs(WamState *state,
+                                         const char **cat_out,
+                                         const char **root_out,
+                                         const char **visited,
+                                         int *visited_len_out) {
     const char *cat = NULL;
     const char *root = NULL;
     if (!wam_value_as_atom(state, state->A[0], &cat)) return false;
     if (!wam_value_as_atom(state, state->A[1], &root)) return false;
-    const char *visited[64];
     int visited_len = 0;
     if (!wam_list_atoms_to_array(state, state->A[3], visited, &visited_len, 64)) return false;
     if (wam_list_contains_atom(state, state->A[3], root)) return false;
     if (visited_len == 0) {
         visited[visited_len++] = cat;
     }
+    *cat_out = cat;
+    *root_out = root;
+    *visited_len_out = visited_len;
+    return true;
+}
+
+bool wam_collect_category_ancestor_hops(WamState *state, WamIntResults *results) {
+    const char *cat = NULL;
+    const char *root = NULL;
+    const char *visited[64];
+    int visited_len = 0;
+    if (!wam_category_ancestor_inputs(state, &cat, &root, visited, &visited_len)) return false;
 
     int max_depth = state->category_max_depth > 0 ? state->category_max_depth : 10;
-    int hops = 0;
-    if (!wam_category_ancestor_dfs(state, cat, root, 0, max_depth,
-                                   visited, visited_len, &hops)) {
+    return wam_category_ancestor_dfs(state, cat, root, 0, max_depth,
+                                     visited, visited_len, results);
+}
+
+bool wam_category_ancestor_handler(WamState *state, const char *pred, int arity) {
+    (void)pred;
+    if (arity != 4) return false;
+
+    WamIntResults results;
+    wam_int_results_init(&results);
+    if (!wam_collect_category_ancestor_hops(state, &results) || results.count == 0) {
+        wam_int_results_close(&results);
         return false;
     }
 
-    WamValue result = val_int(hops);
-    return wam_unify(state, &state->A[2], &result);
+    WamValue result = val_int(results.values[0]);
+    bool ok = wam_unify(state, &state->A[2], &result);
+    wam_int_results_close(&results);
+    return ok;
 }
 '.
 

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -259,6 +259,18 @@ test_fact_source_generation :-
     ;   fail_test(Test, 'file FactSource helpers missing')
     ).
 
+test_streaming_foreign_results_generation :-
+    Test = 'WAM-C: streaming foreign result helpers generated',
+    (   compile_wam_runtime_to_c([], RuntimeCode),
+        atom_string(RuntimeCode, S),
+        sub_string(S, _, _, _, 'void wam_int_results_init'),
+        sub_string(S, _, _, _, 'bool wam_int_results_push'),
+        sub_string(S, _, _, _, 'bool wam_collect_category_ancestor_hops'),
+        sub_string(S, _, _, _, 'results.values[0]')
+    ->  pass(Test)
+    ;   fail_test(Test, 'streaming foreign result helpers missing')
+    ).
+
 test_unsupported_instruction_fails_loudly :-
     Test = 'WAM-C: unsupported instructions fail loudly',
     BadWamCode = 'foo/1:\n    unknown_opcode A1\n    proceed',
@@ -358,6 +370,16 @@ test_fact_source_executable_smoke :-
     ->  (   run_fact_source_executable_smoke
         ->  pass(Test)
         ;   fail_test(Test, 'file FactSource executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
+test_streaming_foreign_results_executable_smoke :-
+    Test = 'WAM-C: streaming category_ancestor result executable smoke',
+    (   gcc_available
+    ->  (   run_streaming_foreign_results_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'streaming category_ancestor result executable failed')
         )
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
@@ -530,6 +552,25 @@ run_fact_source_executable_smoke :-
     write_text_file(PredPath, PredTranslationUnit),
     write_text_file(DataPath, 'leaf\tmid\nmid\troot\nleaf\tother\n'),
     wam_c_fact_source_smoke_main(DataPath, MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
+run_streaming_foreign_results_executable_smoke :-
+    WamCode = 'category_ancestor/4:\n    call_foreign category_ancestor/4, 4\n    proceed',
+    compile_wam_predicate_to_c(user:category_ancestor/4, WamCode, [], PredCode),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(TmpBase), '/tmp/unifyweaver_wam_c_streaming_foreign_smoke_~w', [Stamp]),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(RuntimePath, RuntimeCode),
+    format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+    write_text_file(PredPath, PredTranslationUnit),
+    wam_c_streaming_foreign_smoke_main(MainCode),
     write_text_file(MainPath, MainCode),
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
@@ -988,6 +1029,73 @@ int main(void) {
 }
 ', [DataPath]).
 
+wam_c_streaming_foreign_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_category_ancestor_4(WamState* state);
+
+static WamValue make_visited_singleton(WamState *state, const char *atom) {
+    WamValue list;
+    list.tag = VAL_LIST;
+    list.data.ref_addr = state->H;
+    state->H_array[state->H++] = val_atom(atom);
+    state->H_array[state->H++] = val_atom("[]");
+    return list;
+}
+
+static bool has_value(WamIntResults *results, int value) {
+    for (int i = 0; i < results->count; i++) {
+        if (results->values[i] == value) return true;
+    }
+    return false;
+}
+
+int main(void) {
+    WamState state;
+    WamIntResults results;
+    wam_state_init(&state);
+    wam_int_results_init(&results);
+    setup_category_ancestor_4(&state);
+
+    wam_register_category_parent(&state, "leaf", "root");
+    wam_register_category_parent(&state, "leaf", "mid");
+    wam_register_category_parent(&state, "mid", "root");
+    wam_register_category_ancestor_kernel(&state, "category_ancestor/4", 10);
+
+    state.A[0] = val_atom("leaf");
+    state.A[1] = val_atom("root");
+    state.A[2] = val_unbound("Hops");
+    state.A[3] = make_visited_singleton(&state, "leaf");
+
+    if (!wam_collect_category_ancestor_hops(&state, &results) ||
+        results.count != 2 ||
+        !has_value(&results, 1) ||
+        !has_value(&results, 2)) {
+        wam_int_results_close(&results);
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue args[4] = {
+        val_atom("leaf"),
+        val_atom("root"),
+        val_unbound("Hops"),
+        make_visited_singleton(&state, "leaf")
+    };
+    int rc = wam_run_predicate(&state, "category_ancestor/4", args, 4);
+    if (rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 1) {
+        wam_int_results_close(&results);
+        wam_free_state(&state);
+        return 20;
+    }
+
+    wam_int_results_close(&results);
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_real_builtin_smoke_main(
 '#include "wam_runtime.h"
 
@@ -1262,6 +1370,7 @@ run_tests_once :-
     test_call_foreign_generation,
     test_category_ancestor_kernel_generation,
     test_fact_source_generation,
+    test_streaming_foreign_results_generation,
     test_unsupported_instruction_fails_loudly,
     test_no_zero_instruction_fallback,
     test_list_target_pc_emission,
@@ -1271,6 +1380,7 @@ run_tests_once :-
     test_call_foreign_executable_smoke,
     test_category_ancestor_kernel_executable_smoke,
     test_fact_source_executable_smoke,
+    test_streaming_foreign_results_executable_smoke,
     test_real_prolog_builtin_executable_smoke,
     test_real_prolog_multiclause_executable_smoke,
     test_real_prolog_structure_index_executable_smoke,


### PR DESCRIPTION
## Summary

This PR adds the first streaming-style foreign result foundation for the WAM C target. Native `category_ancestor/4` can now collect all matching hop counts for a query while preserving the existing deterministic `call_foreign` handler behavior.

## What Changed

- Adds `WamIntResults` as a small integer result buffer.
- Adds result-buffer helpers:
  - `wam_int_results_init`
  - `wam_int_results_push`
  - `wam_int_results_close`
- Adds `wam_collect_category_ancestor_hops`.
- Updates the native category-ancestor DFS to collect every matching hop count instead of stopping at the first path.
- Keeps `wam_category_ancestor_handler` deterministic by binding the first collected result through the existing `CallForeign` path.
- Adds an executable smoke test with two distinct paths proving both hop counts are collected.
- Updates `WAM_C_TARGET_NEXT_STEPS.md` so the next recommended branch is `feat/wam-c-effective-distance-bench`.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --cached --check`

## Follow-Up

The next C parity step is an effective-distance benchmark harness that uses TSV facts, native category-ancestor traversal, and all-hop collection.

