### PR TITLE
bench(wam-elixir): precompile LMDB benchmark runner

### DIFF
--- a/docs/proposals/wam_elixir_lmdb_int_id_factsource.md
+++ b/docs/proposals/wam_elixir_lmdb_int_id_factsource.md
@@ -248,15 +248,18 @@ for the original Lmdb adaptor.
   CategoryAncestor kernel over the LMDB-backed int-id FactSource. The
   dev-scale smoke matches Prolog, Rust WAM accumulated, and Haskell
   WAM accumulated output.
+- [x] Move `wam-elixir-lmdb-int-ids` off `Mix.install` in the timed
+  command. The harness now patches the generated Mix project with an
+  `:elmdb` dependency, runs `mix deps.get`, `mix compile`, and LMDB
+  ingest before timing, then measures a `mix run --no-compile`
+  wrapper.
 - [ ] Fair steady-state benchmark against the in-memory int-tuple
   recipe and Rust/Haskell accumulated targets. The current Elixir
-  benchmark path is correct, but the timed command still pays BEAM
-  startup and `Mix.install` dependency-loading overhead, so it is a
-  correctness/comparison hook rather than a final performance number.
-  Haskell's `use_lmdb(auto)` currently defaults to
-  `lmdb_auto_threshold(50000)` when the `lmdb` package is available;
-  Elixir should get a comparable auto policy once the steady-state
-  runner is in place.
+  benchmark path no longer pays dependency installation or compilation
+  inside the timed command, but it still pays BEAM startup. Haskell's
+  `use_lmdb(auto)` currently defaults to `lmdb_auto_threshold(50000)`
+  when the `lmdb` package is available; Elixir should get a comparable
+  auto policy after the steady-state comparison shape is settled.
 
 ## Driver-side recipe
 

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -147,8 +147,10 @@ def available_targets(requested: list[str]) -> list[str]:
         ):
             print(f"skip {target}: swipl, cabal, or ghc not found", file=sys.stderr)
             continue
-        if target.startswith("wam-elixir-") and (shutil.which("swipl") is None or shutil.which("elixir") is None):
-            print(f"skip {target}: swipl or elixir not found", file=sys.stderr)
+        if target.startswith("wam-elixir-") and (
+            shutil.which("swipl") is None or shutil.which("elixir") is None or shutil.which("mix") is None
+        ):
+            print(f"skip {target}: swipl, elixir, or mix not found", file=sys.stderr)
             continue
         if target.startswith("haskell-") and (shutil.which("cabal") is None or shutil.which("ghc") is None):
             print(f"skip {target}: cabal or ghc not found", file=sys.stderr)

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import statistics
 import sys
 import tempfile
@@ -288,16 +289,7 @@ def build_haskell_wam_effective_distance(root: Path, scale: str, variant: str) -
     return command
 
 
-ELIXIR_LMDB_BRIDGE = r'''
-defmodule RealElmdbDependency do
-  def ensure! do
-    Mix.install([{:elmdb, "~> 0.4.1"}], consolidate_protocols: false)
-  end
-end
-
-RealElmdbDependency.ensure!()
-Code.require_file("lib/wam_runtime.ex", __DIR__)
-
+ELIXIR_LMDB_BENCH_MODULES = r'''
 defmodule Elmdb do
   @moduledoc false
 
@@ -351,10 +343,8 @@ defmodule Elmdb do
   defp normalize_cursor_op(:set, key), do: {:set, key}
   defp normalize_cursor_op(op, _arg), do: op
 end
-'''
 
 
-ELIXIR_LMDB_SETUP = ELIXIR_LMDB_BRIDGE + r'''
 defmodule LmdbSetup do
   alias WamRuntime.FactSource.LmdbIntIds
 
@@ -405,16 +395,7 @@ defmodule LmdbSetup do
   end
 end
 
-case System.argv() do
-  [facts_dir] -> LmdbSetup.run(facts_dir)
-  _ ->
-    IO.puts(:stderr, "Usage: elixir setup_lmdb_int_ids.exs <facts-dir>")
-    System.halt(1)
-end
-'''
 
-
-ELIXIR_LMDB_DRIVER = ELIXIR_LMDB_BRIDGE + r'''
 defmodule BenchDriver do
   alias WamRuntime.FactSource.LmdbIntIds
 
@@ -528,14 +509,42 @@ defmodule BenchDriver do
     |> Enum.to_list()
   end
 end
-
-case System.argv() do
-  [facts_dir] -> BenchDriver.run_all(facts_dir)
-  _ ->
-    IO.puts(:stderr, "Usage: elixir run_lmdb_int_ids.exs <facts-dir>")
-    System.halt(1)
-end
 '''
+
+
+def patch_wam_elixir_lmdb_mix(project_dir: Path) -> None:
+    mix_path = require_file(project_dir / "mix.exs")
+    mix_path.write_text(
+        '''defmodule WamElixirBench.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :wam_elixir_bench,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      deps: [{:elmdb, "~> 0.4.1"}]
+    ]
+  end
+end
+''',
+        encoding="utf-8",
+    )
+
+
+def write_wam_elixir_lmdb_runner(project_dir: Path, scale_dir: Path) -> Path:
+    runner = project_dir / "run_lmdb_int_ids"
+    runner.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"cd {shlex.quote(str(project_dir))}\n"
+        "exec mix run --no-compile -e "
+        + shlex.quote(f'BenchDriver.run_all("{scale_dir}")')
+        + "\n",
+        encoding="utf-8",
+    )
+    runner.chmod(0o755)
+    return runner
 
 
 def build_wam_elixir_lmdb_int_ids_effective_distance(root: Path, scale: str) -> list[str]:
@@ -555,12 +564,13 @@ def build_wam_elixir_lmdb_int_ids_effective_distance(root: Path, scale: str) -> 
         ],
         cwd=ROOT,
     )
-    setup_script = project_dir / "setup_lmdb_int_ids.exs"
-    driver_script = project_dir / "run_lmdb_int_ids.exs"
-    setup_script.write_text(ELIXIR_LMDB_SETUP, encoding="utf-8")
-    driver_script.write_text(ELIXIR_LMDB_DRIVER, encoding="utf-8")
-    run_command(["elixir", str(setup_script), str(scale_dir)], cwd=project_dir)
-    return ["elixir", str(driver_script), str(scale_dir)]
+    patch_wam_elixir_lmdb_mix(project_dir)
+    bench_modules = project_dir / "lib" / "lmdb_bench_modules.ex"
+    bench_modules.write_text(ELIXIR_LMDB_BENCH_MODULES, encoding="utf-8")
+    run_command(["mix", "deps.get"], cwd=project_dir)
+    run_command(["mix", "compile"], cwd=project_dir)
+    run_command(["mix", "run", "--no-compile", "-e", f'LmdbSetup.run("{scale_dir}")'], cwd=project_dir)
+    return [str(write_wam_elixir_lmdb_runner(project_dir, scale_dir))]
 
 
 def benchmark_target(


### PR DESCRIPTION
## Summary

- Move the `wam-elixir-lmdb-int-ids` effective-distance benchmark off `Mix.install` in the timed command.
- Patch the generated WAM-Elixir Mix project with an `:elmdb` dependency, then run `mix deps.get`, `mix compile`, and LMDB ingestion before timing.
- Generate a small executable wrapper that runs the benchmark with `mix run --no-compile`, so dependency installation, compilation, and ingest are outside the measured command.
- Update target availability checks to require `mix` for WAM-Elixir benchmark targets.
- Update the LMDB int-id proposal status to reflect the new precompiled runner boundary.

## Validation

- `python3 -m py_compile examples/benchmark/benchmark_common.py examples/benchmark/benchmark_effective_distance.py`
- `python3 examples/benchmark/benchmark_effective_distance.py --scales dev --repetitions 1 --targets wam-elixir-lmdb-int-ids`
- `python3 examples/benchmark/benchmark_effective_distance.py --scales dev --repetitions 1 --targets prolog-accumulated,wam-rust-accumulated,haskell-wam-accumulated,wam-elixir-lmdb-int-ids`
- `git diff --check`

The cross-target dev smoke still produces matching output across Prolog accumulated, Rust WAM accumulated, Haskell WAM accumulated, and WAM-Elixir LMDB int ids:

```text
dev     prolog_vs_wam_rust_accumulated  match
dev     prolog_vs_haskell_wam_accumulated       match
dev     prolog_vs_wam_elixir_lmdb_int_ids       match
dev     wam_rust_vs_haskell_wam_accumulated     match
dev     wam_rust_vs_wam_elixir_lmdb_int_ids     match
dev     haskell_wam_vs_wam_elixir_lmdb_int_ids  match
```

## Notes

This removes dependency installation and compilation from the timed Elixir LMDB command. The command still pays BEAM startup via `mix run --no-compile`, so this is not yet an always-on process or in-VM steady-state measurement. The next slice should compare Elixir LMDB against an Elixir in-memory int-tuple runner and add an Elixir auto LMDB policy comparable to Haskell's `lmdb_auto_threshold(50000)` behavior.