### PR TITLE
feat(wam-clojure): lower integer builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -284,6 +284,10 @@ clojure_direct_builtin("atom/1", "1").
 clojure_direct_builtin("atom/1", 1).
 clojure_direct_builtin('atom/1', "1").
 clojure_direct_builtin('atom/1', 1).
+clojure_direct_builtin("integer/1", "1").
+clojure_direct_builtin("integer/1", 1).
+clojure_direct_builtin('integer/1', "1").
+clojure_direct_builtin('integer/1', 1).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
@@ -384,6 +388,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     !,
     format(atom(Expr),
            '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (runtime/atom-term? value) (runtime/advance ~w) (runtime/backtrack ~w)))',
+           [S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "integer/1" ; Op == 'integer/1'),
+    !,
+    format(atom(Expr),
+           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (integer? value) (runtime/advance ~w) (runtime/backtrack ~w)))',
            [S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -812,6 +812,13 @@
               (advance state)
               (backtrack state)))
 
+          "integer/1"
+          (let [value (deref-value (:bindings state)
+                                   (or (reg-get-raw state "A1") ::unbound))]
+            (if (integer? value)
+              (advance state)
+              (backtrack state)))
+
           "!/0"
           (-> state
               (update :choice-points #(vec (take (:cut-bar state) %)))

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -109,6 +109,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, '"\\\\=/2"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"fail/0"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"atom/1"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"integer/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-bindings [state bindings]')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -183,6 +183,17 @@ test(simple_builtin_atom_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/backtrack")
     )).
 
+test(simple_builtin_integer_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_integer/1:\nbuiltin_call integer/1, 1\nproceed\n",
+        wam_clojure_lowerable(test_integer/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_integer/1, WamCode, [], Code),
+        has(Code, "runtime/deref-value"),
+        has(Code, "integer? value"),
+        has(Code, "runtime/advance"),
+        has(Code, "runtime/backtrack")
+    )).
+
 test(env_framed_equality_reaches_direct_builtin_prefix) :-
     once((
         WamCode = "test_env_eq/2:\nallocate\nput_value X1, A1\nput_value X2, A2\nbuiltin_call =/2, 2\ndeallocate\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -39,6 +39,7 @@
 :- dynamic user:wam_not_b/1.
 :- dynamic user:wam_fail_after_bind/1.
 :- dynamic user:wam_atom_guard/1.
+:- dynamic user:wam_integer_guard/1.
 
 has(Code, Substr) :-
     once(sub_string(Code, _, _, _, Substr)).
@@ -80,6 +81,7 @@ user:wam_hard_cut_outer_ok(X) :- (user:wam_cut_helper(Y), X = Y ; X = b).
 user:wam_not_b(X) :- X \= b.
 user:wam_fail_after_bind(X) :- X = a, fail.
 user:wam_atom_guard(X) :- atom(X).
+user:wam_integer_guard(X) :- integer(X).
 
 :- initialization(main, main).
 
@@ -125,7 +127,8 @@ run_smoke :-
           user:wam_hard_cut_outer_ok/1,
           user:wam_not_b/1,
           user:wam_fail_after_bind/1,
-          user:wam_atom_guard/1
+          user:wam_atom_guard/1,
+          user:wam_integer_guard/1
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
@@ -145,6 +148,7 @@ run_smoke :-
     assert_lowered_not_unify_builtin_emitted(TmpDir),
     assert_lowered_fail_builtin_emitted(TmpDir),
     assert_lowered_atom_builtin_emitted(TmpDir),
+    assert_lowered_integer_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
@@ -204,6 +208,8 @@ run_smoke :-
     verify_output(TmpDir, 'wam_fail_after_bind/1', b, "false"),
     verify_output(TmpDir, 'wam_atom_guard/1', a, "true"),
     verify_output(TmpDir, 'wam_atom_guard/1', 'f(a)', "false"),
+    verify_output(TmpDir, 'wam_integer_guard/1', 42, "true"),
+    verify_output(TmpDir, 'wam_integer_guard/1', a, "false"),
     delete_directory_and_contents(TmpDir),
     writeln('wam_clojure_runtime_smoke: ok').
 
@@ -270,6 +276,12 @@ assert_lowered_atom_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-atom-guard-1"),
     has(CoreCode, "runtime/atom-term?").
 
+assert_lowered_integer_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-integer-guard-1"),
+    has(CoreCode, "integer? value").
+
 assert_multiclause_wrappers_runtime_mediated(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
@@ -323,6 +335,7 @@ prolog_term_string_to_edn(b, "\"b\"") :- !.
 prolog_term_string_to_edn(c, "\"c\"") :- !.
 prolog_term_string_to_edn(d, "\"d\"") :- !.
 prolog_term_string_to_edn(z, "\"z\"") :- !.
+prolog_term_string_to_edn(42, "42") :- !.
 prolog_term_string_to_edn("a", "\"a\"") :- !.
 prolog_term_string_to_edn("b", "\"b\"") :- !.
 prolog_term_string_to_edn("c", "\"c\"") :- !.


### PR DESCRIPTION
## Summary

- Adds Clojure WAM runtime support for `builtin_call integer/1`.
- Adds direct lowered-prefix support for deterministic `integer/1` builtin calls.
- Uses host integer values in the existing runtime representation after dereferencing the argument.
- Adds generator, lowered-emitter, and runtime smoke coverage for integer guard behavior.

## Why

The Clojure hybrid WAM target already lowers simple deterministic builtins and type-test guards like `atom/1`. `integer/1` is the corresponding low-risk numeric type test because numeric EDN inputs remain host integers in the runtime while atoms and structures are normalized into map-based terms.

This reduces interpreter fallback for deterministic guard predicates while preserving runtime semantics by dereferencing the argument before applying `integer?`.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
