### PR TITLE
feat(wam-c): add effective distance benchmark generator

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,7 +4,7 @@ Status date: 2026-05-04
 
 Base verified locally:
 
-- `main` at `404c8c00` (`Merge pull request #1836 from s243a/feat/wam-c-file-fact-source`)
+- `main` at `83b34375` (`Merge pull request #1837 from s243a/feat/wam-c-streaming-foreign-results`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 
 This file replaces the older implementation plan. The four original C follow-up
@@ -24,6 +24,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Native category ancestor kernel foundation | Done | `wam_register_category_parent`, `wam_register_category_ancestor_kernel`, `wam_category_ancestor_handler`, direct and recursive executable smoke |
 | File-backed FactSource foundation | Done | `WamFactSource`, `wam_fact_source_load_tsv`, `wam_fact_source_lookup_arg1`, `wam_register_category_parent_fact_source`, executable smoke |
 | Streaming integer foreign-result foundation | Done | `WamIntResults`, `wam_int_results_push`, `wam_collect_category_ancestor_hops`, multi-path executable smoke |
+| Effective-distance benchmark generator | Done | `generate_wam_c_effective_distance_benchmark.pl`, TSV facts, `kernels_on`/`kernels_off`, generated C runner smoke |
 
 ## Current C Target Baseline
 
@@ -46,6 +47,9 @@ The C target is now a credible small WAM backend:
 - Supports collecting all integer hop results for native `category_ancestor/4`
   through `WamIntResults`, while preserving deterministic first-result handler
   behavior.
+- Can generate a small effective-distance C benchmark runner from Prolog facts,
+  with both native-kernel and reference DFS modes over TSV category-parent
+  facts.
 - Has executable smokes for generated runtime, cross-predicate calls,
   foreign calls, native category ancestor, file-backed facts, streaming native
   results, real multi-clause predicates, structure indexing, `is_list/1`, and
@@ -78,24 +82,14 @@ missing important target features; `Missing` = no comparable C path yet.
 | Lowered/native helper functions | Missing | Done | Done | Consider after foreign kernels; C can lower simple fact-only or deterministic predicates. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Missing | Not primary | Done | Haskell is the reference. C now has an ownership model to extend. |
-| Effective-distance benchmark harness | Missing | Done | Done | Next parity step: wire TSV facts and all-hop collection into a benchmark harness. |
+| Effective-distance benchmark harness | Partial | Done | Done | C has a small generated TSV harness with `kernels_on`/`kernels_off`; next gap is full benchmark matrix integration and larger datasets. |
 | Classic-program e2e suite | Partial | Partial/Done | Partial/Done | C has targeted smokes; add Fibonacci/Ackermann-style suite like Scala/Elixir. |
 | Memory lifecycle | Partial | Runtime-managed | Runtime-managed | C has init/free; needs ASAN/Valgrind CI-style coverage for larger programs. |
 | Instruction layout efficiency | TODO | N/A | N/A | Pack `Instruction` fields into a tagged union if runtime footprint matters. |
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-effective-distance-bench`
-
-Goal: make C visible in the benchmark matrix once kernels/facts exist.
-
-Scope:
-
-- Add a C effective-distance generator under `examples/benchmark/`.
-- Support `kernels_on` / `kernels_off`.
-- Start with small TSV/fact-source mode; add LMDB later.
-
-### 2. `feat/wam-c-lmdb-fact-source`
+### 1. `feat/wam-c-lmdb-fact-source`
 
 Goal: add LMDB-backed category-parent facts once the file FactSource and
 streaming result contracts are stable.
@@ -106,7 +100,7 @@ Scope:
 - Load/cursor category-parent pairs from LMDB.
 - Keep this behind an optional build/runtime path.
 
-### 3. `feat/wam-c-kernel-detector-setup`
+### 2. `feat/wam-c-kernel-detector-setup`
 
 Goal: connect the C target to the shared recursive-kernel detector.
 
@@ -115,6 +109,17 @@ Scope:
 - Reuse `recursive_kernel_detection.pl`.
 - Generate C registration stubs for `category_ancestor/4`.
 - Keep the hand-registration runtime helpers as the low-level API.
+
+### 3. `feat/wam-c-effective-distance-matrix`
+
+Goal: make C visible in the standard effective-distance benchmark matrix.
+
+Scope:
+
+- Reuse the generated TSV harness.
+- Add script wiring next to the Rust and Haskell effective-distance paths.
+- Compare `kernels_on` and `kernels_off` outputs on shared small datasets
+  before scaling up.
 
 ### 4. `perf/wam-c-pack-instruction`
 
@@ -132,15 +137,9 @@ or cache behavior becomes a real bottleneck.
 
 ## Suggested Immediate Next Step
 
-Start with `feat/wam-c-effective-distance-bench`.
+Start with `feat/wam-c-lmdb-fact-source`.
 
-The C runtime now has the pieces the small TSV benchmark needs: file-backed
-category-parent facts, native category ancestor traversal, and all-hop integer
-collection. The work should be split into two commits:
-
-1. Generator or smoke harness under `examples/benchmark/` for a small
-   effective-distance query.
-2. `kernels_on` / `kernels_off` comparison path, still using TSV facts.
-
-Keep LMDB out of that branch; TSV is enough to validate benchmark semantics and
-avoid introducing storage-library friction too early.
+The C target now has a TSV-backed effective-distance harness, so the next
+highest parity gap is durable fact storage. Use the Haskell LMDB path as the
+reference design, keep the C API optional, and preserve the existing TSV
+FactSource as the dependency-free fallback.

--- a/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
@@ -1,0 +1,344 @@
+:- module(generate_wam_c_effective_distance_benchmark,
+          [ main/0,
+            generate/3,
+            generate/4
+          ]).
+:- initialization(main, main).
+
+:- use_module('../../src/unifyweaver/targets/wam_c_target').
+:- use_module(library(filesex), [directory_file_path/3, make_directory_path/1]).
+:- use_module(library(lists)).
+:- use_module(library(pairs), [pairs_keys/2, pairs_values/2]).
+
+%% generate_wam_c_effective_distance_benchmark.pl
+%%
+%% Generates a small WAM-C effective-distance benchmark project. The generated
+%% C runner loads category_parent/2 facts from TSV, executes the native
+%% category_ancestor/4 all-hop collector when kernels are enabled, and includes
+%% a C reference DFS path for kernels_off comparisons.
+%%
+%% Usage:
+%%   swipl -q -s examples/benchmark/generate_wam_c_effective_distance_benchmark.pl -- \
+%%       <facts.pl> <output-dir> [kernels_on|kernels_off]
+
+benchmark_workload_path(Path) :-
+    source_file(benchmark_workload_path(_), ThisFile),
+    file_directory_name(ThisFile, Here),
+    directory_file_path(Here, 'effective_distance.pl', Path).
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv == []
+    ->  true
+    ;   Argv = [FactsPath, OutputDir, KernelModeAtom]
+    ->  generate(FactsPath, OutputDir, KernelModeAtom),
+        halt(0)
+    ;   Argv = [FactsPath, OutputDir]
+    ->  generate(FactsPath, OutputDir, kernels_on),
+        halt(0)
+    ;   format(user_error,
+               'Usage: ... -- <facts.pl> <output-dir> [kernels_on|kernels_off]~n',
+               []),
+        halt(1)
+    ).
+
+main :-
+    format(user_error, 'Error: WAM-C effective-distance generation failed~n', []),
+    halt(1).
+
+generate(FactsPath, OutputDir, KernelMode) :-
+    generate(FactsPath, OutputDir, KernelMode, []).
+
+generate(FactsPath, OutputDir, KernelMode, _Options) :-
+    (   exists_file(FactsPath)
+    ->  true
+    ;   throw(error(existence_error(source_sink, FactsPath), _))
+    ),
+    parse_kernel_mode(KernelMode, ParsedMode),
+    reset_benchmark_predicates,
+    benchmark_workload_path(WorkloadPath),
+    load_files(user:WorkloadPath, [silent(true), if(true)]),
+    load_files(user:FactsPath, [silent(true), if(true)]),
+    collect_benchmark_facts(CategoryParents, ArticleCategories, RootCategories),
+    CategoryParents \= [],
+    ArticleCategories \= [],
+    RootCategories \= [],
+    benchmark_dimension(Dimension),
+    benchmark_max_depth(MaxDepth),
+    make_directory_path(OutputDir),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    directory_file_path(OutputDir, 'wam_runtime.c', RuntimePath),
+    write_text_file(RuntimePath, RuntimeCode),
+    WamCode = 'category_ancestor/4:\n    call_foreign category_ancestor/4, 4\n    proceed',
+    compile_wam_predicate_to_c(user:category_ancestor/4, WamCode, [], PredCode),
+    format(atom(LibCode), '#include "wam_runtime.h"~n~n~w~n', [PredCode]),
+    directory_file_path(OutputDir, 'lib.c', LibPath),
+    write_text_file(LibPath, LibCode),
+    category_parent_tsv(CategoryParents, CategoryTsv),
+    directory_file_path(OutputDir, 'category_parent.tsv', CategoryPath),
+    write_text_file(CategoryPath, CategoryTsv),
+    effective_distance_main_code(ParsedMode, Dimension, MaxDepth,
+                                 ArticleCategories, RootCategories, MainCode),
+    directory_file_path(OutputDir, 'main.c', MainPath),
+    write_text_file(MainPath, MainCode),
+    directory_file_path(OutputDir, 'README.md', ReadmePath),
+    effective_distance_readme(ParsedMode, Readme),
+    write_text_file(ReadmePath, Readme),
+    format(user_error,
+           '[WAM-C-EffectiveDistance] mode=~w output=~w~n',
+           [ParsedMode, OutputDir]).
+
+parse_kernel_mode(kernels_on, kernels_on).
+parse_kernel_mode(kernels_off, kernels_off).
+parse_kernel_mode("kernels_on", kernels_on).
+parse_kernel_mode("kernels_off", kernels_off).
+parse_kernel_mode(Atom, Mode) :-
+    atom(Atom),
+    atom_string(Atom, String),
+    parse_kernel_mode(String, Mode), !.
+parse_kernel_mode(Atom, _) :-
+    throw(error(domain_error(wam_c_kernel_mode, Atom), _)).
+
+reset_benchmark_predicates :-
+    forall(member(Name/Arity,
+                  [ article_category/2,
+                    category_parent/2,
+                    root_category/1,
+                    dimension_n/1,
+                    max_depth/1
+                  ]),
+           maybe_abolish_user_predicate(Name/Arity)).
+
+maybe_abolish_user_predicate(Name/Arity) :-
+    (   current_predicate(user:Name/Arity)
+    ->  abolish(user:Name/Arity)
+    ;   true
+    ).
+
+collect_benchmark_facts(CategoryParents, ArticleCategories, RootCategories) :-
+    findall(Child-Parent, user:category_parent(Child, Parent), CategoryParents0),
+    sort(CategoryParents0, CategoryParents),
+    findall(Article-Category, user:article_category(Article, Category), ArticleCategories0),
+    sort(ArticleCategories0, ArticleCategories),
+    findall(Root, user:root_category(Root), RootCategories0),
+    sort(RootCategories0, RootCategories).
+
+benchmark_dimension(Dimension) :-
+    (   current_predicate(user:dimension_n/1),
+        once(user:dimension_n(D0)),
+        integer(D0),
+        D0 > 0
+    ->  Dimension = D0
+    ;   Dimension = 5
+    ).
+
+benchmark_max_depth(MaxDepth) :-
+    (   current_predicate(user:max_depth/1),
+        once(user:max_depth(M0)),
+        integer(M0),
+        M0 > 0
+    ->  MaxDepth = M0
+    ;   MaxDepth = 10
+    ).
+
+category_parent_tsv(Pairs, Tsv) :-
+    maplist(category_parent_tsv_line, Pairs, Lines),
+    atomic_list_concat(Lines, '', Tsv).
+
+category_parent_tsv_line(Child-Parent, Line) :-
+    format(atom(Line), '~w\t~w\n', [Child, Parent]).
+
+effective_distance_main_code(KernelMode, Dimension, MaxDepth,
+                             ArticleCategories, RootCategories, Code) :-
+    c_pair_arrays('ARTICLE_IDS', 'ARTICLE_CATS', ArticleCategories, ArticleArrays),
+    c_string_array('ROOTS', RootCategories, RootArray),
+    kernel_mode_flag(KernelMode, KernelFlag),
+    format(atom(Code),
+'#include <math.h>
+#include <stdio.h>
+#include <string.h>
+#include "wam_runtime.h"
+
+void setup_category_ancestor_4(WamState* state);
+
+~w
+~w
+
+static WamValue make_visited_singleton(WamState *state, const char *atom) {
+    WamValue list;
+    list.tag = VAL_LIST;
+    list.data.ref_addr = state->H;
+    state->H_array[state->H++] = val_atom(atom);
+    state->H_array[state->H++] = val_atom("[]");
+    return list;
+}
+
+static int visited_contains(const char **visited, int visited_len, const char *atom) {
+    for (int i = 0; i < visited_len; i++) {
+        if (strcmp(visited[i], atom) == 0) return 1;
+    }
+    return 0;
+}
+
+static int collect_reference_hops(WamFactSource *source,
+                                  const char *cat,
+                                  const char *root,
+                                  int depth,
+                                  int max_depth,
+                                  const char **visited,
+                                  int visited_len,
+                                  WamIntResults *results) {
+    int found = 0;
+    for (int i = 0; i < source->edge_count; i++) {
+        CategoryEdge *edge = &source->edges[i];
+        if (strcmp(edge->child, cat) != 0) continue;
+        if (visited_contains(visited, visited_len, edge->parent)) continue;
+        if (strcmp(edge->parent, root) == 0) {
+            if (!wam_int_results_push(results, depth + 1)) return 0;
+            found = 1;
+        }
+    }
+    if (visited_len >= max_depth || visited_len >= 64) return found;
+    for (int i = 0; i < source->edge_count; i++) {
+        CategoryEdge *edge = &source->edges[i];
+        if (strcmp(edge->child, cat) != 0) continue;
+        if (visited_contains(visited, visited_len, edge->parent)) continue;
+        visited[visited_len] = edge->parent;
+        if (collect_reference_hops(source, edge->parent, root, depth + 1,
+                                   max_depth, visited, visited_len + 1,
+                                   results)) {
+            found = 1;
+        }
+    }
+    return found;
+}
+
+static void collect_hops(WamState *state,
+                         WamFactSource *source,
+                         const char *cat,
+                         const char *root,
+                         int kernels_on,
+                         WamIntResults *results) {
+    if (kernels_on) {
+        state->A[0] = val_atom(cat);
+        state->A[1] = val_atom(root);
+        state->A[2] = val_unbound("Hops");
+        state->A[3] = make_visited_singleton(state, cat);
+        (void)wam_collect_category_ancestor_hops(state, results);
+    } else {
+        const char *visited[64];
+        visited[0] = cat;
+        (void)collect_reference_hops(source, cat, root, 0, ~w, visited, 1, results);
+    }
+}
+
+int main(void) {
+    WamState state;
+    WamFactSource source;
+    wam_state_init(&state);
+    wam_fact_source_init(&source);
+    setup_category_ancestor_4(&state);
+
+    if (!wam_fact_source_load_tsv(&state, &source, "category_parent.tsv")) {
+        fprintf(stderr, "failed to load category_parent.tsv\\n");
+        wam_fact_source_close(&source);
+        wam_free_state(&state);
+        return 1;
+    }
+    wam_register_category_parent_fact_source(&state, &source);
+    wam_register_category_ancestor_kernel(&state, "category_ancestor/4", ~w);
+
+    printf("article\\troot_category\\teffective_distance\\n");
+    for (int ai = 0; ai < ARTICLE_COUNT; ai++) {
+        for (int ri = 0; ri < ROOT_COUNT; ri++) {
+            double weight_sum = 0.0;
+            WamIntResults hops;
+            wam_int_results_init(&hops);
+            if (strcmp(ARTICLE_CATS[ai], ROOTS[ri]) == 0) {
+                wam_int_results_push(&hops, 1);
+            } else {
+                collect_hops(&state, &source, ARTICLE_CATS[ai], ROOTS[ri], ~w, &hops);
+                for (int hi = 0; hi < hops.count; hi++) {
+                    hops.values[hi] += 1;
+                }
+            }
+            for (int hi = 0; hi < hops.count; hi++) {
+                weight_sum += pow((double)hops.values[hi], -~w.0);
+            }
+            if (weight_sum > 0.0) {
+                double deff = pow(weight_sum, -1.0 / ~w.0);
+                printf("%s\\t%s\\t%.9f\\n", ARTICLE_IDS[ai], ROOTS[ri], deff);
+            }
+            wam_int_results_close(&hops);
+        }
+    }
+
+    wam_fact_source_close(&source);
+    wam_free_state(&state);
+    return 0;
+}
+', [ArticleArrays, RootArray, MaxDepth, MaxDepth, KernelFlag, Dimension, Dimension]).
+
+kernel_mode_flag(kernels_on, 1).
+kernel_mode_flag(kernels_off, 0).
+
+c_pair_arrays(NamesName, ValuesName, Pairs, Code) :-
+    pairs_keys(Pairs, Keys),
+    pairs_values(Pairs, Values),
+    c_string_initializer(Keys, KeyInit),
+    c_string_initializer(Values, ValueInit),
+    length(Pairs, Count),
+    format(atom(Code),
+           'static const int ARTICLE_COUNT = ~w;\nstatic const char *~w[] = { ~w };\nstatic const char *~w[] = { ~w };',
+           [Count, NamesName, KeyInit, ValuesName, ValueInit]).
+
+c_string_array(Name, Values, Code) :-
+    c_string_initializer(Values, Init),
+    length(Values, Count),
+    format(atom(Code),
+           'static const int ROOT_COUNT = ~w;\nstatic const char *~w[] = { ~w };',
+           [Count, Name, Init]).
+
+c_string_initializer(Values, Init) :-
+    maplist(c_string_literal, Values, Literals),
+    atomic_list_concat(Literals, ', ', Init).
+
+c_string_literal(Value, Literal) :-
+    format(atom(Raw), '~w', [Value]),
+    atom_chars(Raw, Chars),
+    phrase(c_escaped_chars(Chars), Escaped),
+    atom_chars(EscapedAtom, Escaped),
+    format(atom(Literal), '"~w"', [EscapedAtom]).
+
+c_escaped_chars([]) --> [].
+c_escaped_chars(['\\'|Rest]) --> ['\\', '\\'], c_escaped_chars(Rest).
+c_escaped_chars(['"'|Rest]) --> ['\\', '"'], c_escaped_chars(Rest).
+c_escaped_chars([C|Rest]) --> [C], c_escaped_chars(Rest).
+
+effective_distance_readme(KernelMode, Readme) :-
+    format(atom(Readme),
+'# WAM-C Effective Distance Benchmark
+
+Generated by `generate_wam_c_effective_distance_benchmark.pl`.
+
+Build:
+
+```sh
+gcc -std=c11 -Wall -Wextra -I ../../src/unifyweaver/targets/wam_c_runtime wam_runtime.c lib.c main.c -lm -o wam_c_effective_distance
+```
+
+Run:
+
+```sh
+./wam_c_effective_distance
+```
+
+Kernel mode: `~w`.
+', [KernelMode]).
+
+write_text_file(Path, Content) :-
+    setup_call_cleanup(
+        open(Path, write, Stream),
+        format(Stream, '~w', [Content]),
+        close(Stream)
+    ).

--- a/tests/test_wam_c_effective_distance_benchmark.pl
+++ b/tests/test_wam_c_effective_distance_benchmark.pl
@@ -1,0 +1,112 @@
+:- encoding(utf8).
+% Test suite for the WAM-C effective-distance benchmark generator.
+% Usage: swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl
+
+:- use_module('../examples/benchmark/generate_wam_c_effective_distance_benchmark').
+:- use_module(library(filesex), [make_directory_path/1, directory_file_path/3]).
+:- use_module(library(process)).
+
+:- dynamic test_failed/0.
+:- dynamic tests_already_ran/0.
+
+pass(Test) :-
+    format('[PASS] ~w~n', [Test]).
+
+fail_test(Test, Reason) :-
+    format('[FAIL] ~w: ~w~n', [Test, Reason]),
+    (   test_failed -> true ; assert(test_failed) ).
+
+test_generate_and_run_kernels_on :-
+    Test = 'WAM-C effective-distance: kernels_on generated runner emits expected result',
+    (   run_generated_effective_distance(kernels_on, Output),
+        sub_string(Output, _, _, _, "article\troot_category\teffective_distance"),
+        sub_string(Output, _, _, _, "article_a\troot\t1.951123284")
+    ->  pass(Test)
+    ;   fail_test(Test, 'kernels_on runner output mismatch')
+    ).
+
+test_generate_and_run_kernels_off :-
+    Test = 'WAM-C effective-distance: kernels_off generated runner emits expected result',
+    (   run_generated_effective_distance(kernels_off, Output),
+        sub_string(Output, _, _, _, "article\troot_category\teffective_distance"),
+        sub_string(Output, _, _, _, "article_a\troot\t1.951123284")
+    ->  pass(Test)
+    ;   fail_test(Test, 'kernels_off runner output mismatch')
+    ).
+
+run_generated_effective_distance(KernelMode, Output) :-
+    unique_tmp_dir(KernelMode, OutputDir),
+    directory_file_path(OutputDir, 'facts.pl', FactsPath),
+    write_text_file(FactsPath,
+'article_category(article_a, leaf).
+root_category(root).
+category_parent(leaf, root).
+category_parent(leaf, mid).
+category_parent(mid, root).
+'),
+    generate_wam_c_effective_distance_benchmark:generate(FactsPath, OutputDir, KernelMode),
+    compile_generated_project(OutputDir),
+    run_generated_project(OutputDir, Output).
+
+unique_tmp_dir(KernelMode, OutputDir) :-
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(OutputDir), '/tmp/unifyweaver_wam_c_effective_~w_~w', [KernelMode, Stamp]),
+    make_directory_path(OutputDir).
+
+compile_generated_project(OutputDir) :-
+    directory_file_path(OutputDir, 'wam_runtime.c', RuntimePath),
+    directory_file_path(OutputDir, 'lib.c', LibPath),
+    directory_file_path(OutputDir, 'main.c', MainPath),
+    directory_file_path(OutputDir, 'wam_c_effective_distance', ExePath),
+    IncludeDir = 'src/unifyweaver/targets/wam_c_runtime',
+    process_create(path(gcc),
+        ['-std=c11', '-Wall', '-Wextra', '-I', IncludeDir,
+         RuntimePath, LibPath, MainPath, '-lm', '-o', ExePath],
+        [stdout(null), stderr(pipe(Err)), process(Pid)]),
+    read_string(Err, _, ErrText),
+    close(Err),
+    process_wait(Pid, Status),
+    (   Status = exit(0)
+    ->  true
+    ;   format(user_error, 'gcc failed: ~w~n', [ErrText]),
+        fail
+    ).
+
+run_generated_project(OutputDir, Output) :-
+    directory_file_path(OutputDir, 'wam_c_effective_distance', ExePath),
+    process_create(ExePath, [],
+        [cwd(OutputDir), stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+    read_string(Out, _, Output),
+    read_string(Err, _, ErrText),
+    close(Out),
+    close(Err),
+    process_wait(Pid, Status),
+    (   Status = exit(0)
+    ->  true
+    ;   format(user_error, 'generated runner failed: ~w~n', [ErrText]),
+        fail
+    ).
+
+write_text_file(Path, Content) :-
+    setup_call_cleanup(
+        open(Path, write, Stream),
+        format(Stream, '~w', [Content]),
+        close(Stream)
+    ).
+
+run_tests :-
+    (   tests_already_ran
+    ->  true
+    ;   assert(tests_already_ran),
+        run_tests_once
+    ).
+
+run_tests_once :-
+    format('~n=== WAM-C Effective Distance Benchmark Tests ===~n~n'),
+    test_generate_and_run_kernels_on,
+    test_generate_and_run_kernels_off,
+    format('~n=== WAM-C Effective Distance Benchmark Tests Complete ===~n'),
+    (   test_failed -> halt(1) ; true ).
+
+:- initialization(run_tests, main).


### PR DESCRIPTION
## Summary

This PR adds a generated WAM-C effective-distance benchmark harness. The generator emits a small standalone C project from Prolog facts, loads category-parent facts from TSV, and can compare native-kernel execution against a reference C DFS path.

## What Changed

- Adds `examples/benchmark/generate_wam_c_effective_distance_benchmark.pl`.
- Generates:
  - `wam_runtime.c`
  - `lib.c`
  - `main.c`
  - `category_parent.tsv`
  - `README.md`
- Supports `kernels_on` using `wam_collect_category_ancestor_hops`.
- Supports `kernels_off` using a generated reference DFS over `WamFactSource`.
- Emits tab-separated effective-distance output:
  - `article`
  - `root_category`
  - `effective_distance`
- Adds an executable smoke test for both kernel modes.
- Updates `WAM_C_TARGET_NEXT_STEPS.md` with the completed benchmark generator and moves the next recommended branch to `feat/wam-c-lmdb-fact-source`.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --check`

## Follow-Up

The next WAM-C parity step is `feat/wam-c-lmdb-fact-source`, using the Haskell LMDB path as the reference while preserving TSV as the dependency-free fallback.
