### PR TITLE
test(benchmark): Report Clojure WAM artifact kernel-pair benchmark deltas

### DIFF
--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -258,6 +258,18 @@ KERNEL_TARGET_PAIRS: tuple[KernelPairInfo, ...] = (
         "clojure-wam-accumulated-no-kernels",
     ),
     KernelPairInfo(
+        "clojure",
+        "seeded-artifact",
+        "clojure-wam-seeded-artifact",
+        "clojure-wam-seeded-no-kernels-artifact",
+    ),
+    KernelPairInfo(
+        "clojure",
+        "accumulated-artifact",
+        "clojure-wam-accumulated-artifact",
+        "clojure-wam-accumulated-no-kernels-artifact",
+    ),
+    KernelPairInfo(
         "haskell",
         "interpreter",
         "haskell-interp-ffi",

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -48,6 +48,30 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         self.assertEqual(TARGETS["clojure-wam-seeded"].category, "hybrid-wam")
         self.assertEqual(TARGETS["clojure-wam-seeded-no-kernels"].category, "hybrid-wam")
 
+    def test_clojure_artifact_targets_are_registered_separately(self) -> None:
+        targets = resolve_targets(
+            explicit_targets=None,
+            target_set_names=["clojure-wam-artifact"],
+        )
+
+        self.assertEqual(
+            targets,
+            [
+                "clojure-wam-accumulated",
+                "clojure-wam-accumulated-artifact",
+                "clojure-wam-accumulated-no-kernels",
+                "clojure-wam-accumulated-no-kernels-artifact",
+                "clojure-wam-seeded",
+                "clojure-wam-seeded-artifact",
+                "clojure-wam-seeded-no-kernels",
+                "clojure-wam-seeded-no-kernels-artifact",
+            ],
+        )
+        self.assertEqual(TARGETS["clojure-wam-accumulated-artifact"].category, "hybrid-wam")
+        self.assertEqual(TARGETS["clojure-wam-accumulated-no-kernels-artifact"].category, "hybrid-wam")
+        self.assertEqual(TARGETS["clojure-wam-seeded-artifact"].category, "hybrid-wam")
+        self.assertEqual(TARGETS["clojure-wam-seeded-no-kernels-artifact"].category, "hybrid-wam")
+
     def test_default_hybrid_wam_excludes_clojure_scaffolds(self) -> None:
         targets = resolve_targets(
             explicit_targets=None,
@@ -153,6 +177,8 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
             ("scala", "accumulated"),
             ("clojure", "seeded"),
             ("clojure", "accumulated"),
+            ("clojure", "seeded-artifact"),
+            ("clojure", "accumulated-artifact"),
             ("haskell", "interpreter"),
             ("haskell", "lowered"),
         }
@@ -184,6 +210,14 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         )
         self.assertIn(
             "scala\tseeded\tscala-wam-seeded\tscala-wam-seeded-no-kernels",
+            text,
+        )
+        self.assertIn(
+            "clojure\tseeded-artifact\tclojure-wam-seeded-artifact\tclojure-wam-seeded-no-kernels-artifact",
+            text,
+        )
+        self.assertIn(
+            "clojure\taccumulated-artifact\tclojure-wam-accumulated-artifact\tclojure-wam-accumulated-no-kernels-artifact",
             text,
         )
 


### PR DESCRIPTION
Adds first-class benchmark matrix reporting for Clojure WAM artifact kernel/no-kernel pairs.

The Clojure artifact targets were already registered and runnable, but the kernel-pair summary only compared the non-artifact Clojure targets. This adds `seeded-artifact` and `accumulated-artifact` Clojure pair entries so `--list-kernel-pairs` and matrix runs report artifact-mode kernel deltas alongside the existing non-artifact deltas.

## Changes

- Register Clojure WAM artifact kernel/no-kernel pairs in the benchmark target matrix.
- Add unit coverage for the `clojure-wam-artifact` target set.
- Assert that `--list-kernel-pairs` includes the new Clojure artifact pair rows.

## Validation

- `python3 -m unittest tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_effective_distance_matrix.py`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --list-kernel-pairs`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets clojure-wam-artifact --repetitions 1`
- `git diff --check`