### PR TITLE
Add C# query source-mode calibration gates

### DIFF
--- a/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
+++ b/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
@@ -63,6 +63,20 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Set UNIFYWEAVER_BENCH_TRACE=1 for the child benchmark runners.",
     )
+    parser.add_argument(
+        "--max-auto-vs-best-ratio",
+        type=float,
+        default=None,
+        help=(
+            "Fail when any output-matching summary reports auto_vs_best above this ratio. "
+            "Omit to report only."
+        ),
+    )
+    parser.add_argument(
+        "--fail-on-output-mismatch",
+        action="store_true",
+        help="Fail when any swept C# query source mode produces a different output hash.",
+    )
     return parser.parse_args()
 
 
@@ -147,6 +161,43 @@ def summarize_source_registration_tokens(metrics: str) -> str:
     return "|".join(sorted(registrations))
 
 
+def parse_ratio(value: str) -> float | None:
+    text = value.strip()
+    if not text:
+        return None
+    if text.endswith("x"):
+        text = text[:-1]
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def calibration_failures(
+    summaries: list[SourceModeSummary],
+    *,
+    max_auto_vs_best_ratio: float | None = None,
+    fail_on_output_mismatch: bool = False,
+) -> list[str]:
+    failures: list[str] = []
+    for summary in summaries:
+        label = f"{summary.workload}/{summary.scale}"
+        if fail_on_output_mismatch and summary.output_agreement != "match":
+            failures.append(f"{label}: source-mode outputs {summary.output_agreement}")
+        ratio = parse_ratio(summary.auto_vs_best)
+        if (
+            max_auto_vs_best_ratio is not None
+            and ratio is not None
+            and summary.output_agreement == "match"
+            and ratio > max_auto_vs_best_ratio
+        ):
+            failures.append(
+                f"{label}: auto_vs_best {summary.auto_vs_best} exceeds "
+                f"{max_auto_vs_best_ratio:.2f}x"
+            )
+    return failures
+
+
 def run_workload(
     workload: str,
     *,
@@ -225,6 +276,16 @@ def main() -> int:
         print_markdown(summaries)
     else:
         print_tsv(summaries)
+
+    failures = calibration_failures(
+        summaries,
+        max_auto_vs_best_ratio=args.max_auto_vs_best_ratio,
+        fail_on_output_mismatch=args.fail_on_output_mismatch,
+    )
+    if failures:
+        for failure in failures:
+            print(f"ERROR: {failure}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/tests/test_csharp_query_source_mode_sweep.py
+++ b/tests/test_csharp_query_source_mode_sweep.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
+
+from benchmark_csharp_query_source_mode_sweep import parse_runner_output  # noqa: E402
+
+
+class CSharpQuerySourceModeSweepTests(unittest.TestCase):
+    def test_parse_runner_output_summarizes_modes_and_registrations(self) -> None:
+        output = "\n".join(
+            [
+                "scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256",
+                "300\tcsharp-query:auto\t0.467\t0.467\t0.467\t42\tsamehash",
+                "300\tcsharp-query:preload\t0.360\t0.360\t0.360\t42\tsamehash",
+                "300\tcsharp-query:artifact-prebuilt\t0.904\t0.904\t0.904\t42\tsamehash",
+                "300\tcsharp-query:auto-metrics\tsource_registration_preloaded_preload_arity2=2 other=ignored",
+                "300\tcsharp-query:preload-metrics\tsource_registration_preloaded_preload_arity2=2",
+                (
+                    "300\tcsharp-query:artifact-prebuilt-metrics\t"
+                    "source_registration_binary_artifact_artifact-prebuilt_arity2=2"
+                ),
+                "300\tcsharp_query_best_source_mode\tpreload",
+                "300\tcsharp_query_auto_vs_best_source_mode\t1.30x",
+            ]
+        )
+
+        summaries = parse_runner_output("category-influence", output)
+
+        self.assertEqual(len(summaries), 1)
+        summary = summaries[0]
+        self.assertEqual(summary.workload, "category-influence")
+        self.assertEqual(summary.scale, "300")
+        self.assertEqual(summary.best_source_mode, "preload")
+        self.assertEqual(summary.auto_vs_best, "1.30x")
+        self.assertEqual(summary.output_agreement, "match")
+        self.assertEqual(
+            summary.median_summary,
+            "artifact-prebuilt:0.904,auto:0.467,preload:0.360",
+        )
+        self.assertEqual(
+            summary.source_registration_summary,
+            (
+                "artifact-prebuilt:binary_artifact_artifact-prebuilt_arity2=2,"
+                "auto:preloaded_preload_arity2=2,"
+                "preload:preloaded_preload_arity2=2"
+            ),
+        )
+
+    def test_parse_runner_output_flags_hash_mismatch(self) -> None:
+        output = "\n".join(
+            [
+                "scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256",
+                "300\tcsharp-query:auto\t0.200\t0.200\t0.200\t42\thash-a",
+                "300\tcsharp-query:preload\t0.180\t0.180\t0.180\t42\thash-b",
+                "300\tcsharp_query_best_source_mode\tpreload",
+            ]
+        )
+
+        summaries = parse_runner_output("dependency-depth", output)
+
+        self.assertEqual(len(summaries), 1)
+        self.assertEqual(summaries[0].output_agreement, "MISMATCH")
+        self.assertEqual(summaries[0].auto_vs_best, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_csharp_query_source_mode_sweep.py
+++ b/tests/test_csharp_query_source_mode_sweep.py
@@ -9,7 +9,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
 
-from benchmark_csharp_query_source_mode_sweep import parse_runner_output  # noqa: E402
+from benchmark_csharp_query_source_mode_sweep import (  # noqa: E402
+    calibration_failures,
+    parse_ratio,
+    parse_runner_output,
+)
 
 
 class CSharpQuerySourceModeSweepTests(unittest.TestCase):
@@ -68,6 +72,48 @@ class CSharpQuerySourceModeSweepTests(unittest.TestCase):
         self.assertEqual(len(summaries), 1)
         self.assertEqual(summaries[0].output_agreement, "MISMATCH")
         self.assertEqual(summaries[0].auto_vs_best, "")
+
+    def test_calibration_failures_detect_slow_auto(self) -> None:
+        output = "\n".join(
+            [
+                "scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256",
+                "300\tcsharp-query:auto\t0.300\t0.300\t0.300\t42\tsamehash",
+                "300\tcsharp-query:preload\t0.200\t0.200\t0.200\t42\tsamehash",
+                "300\tcsharp_query_best_source_mode\tpreload",
+                "300\tcsharp_query_auto_vs_best_source_mode\t1.50x",
+            ]
+        )
+        summaries = parse_runner_output("dependency-depth", output)
+
+        failures = calibration_failures(summaries, max_auto_vs_best_ratio=1.25)
+
+        self.assertEqual(
+            failures,
+            ["dependency-depth/300: auto_vs_best 1.50x exceeds 1.25x"],
+        )
+
+    def test_calibration_failures_can_detect_output_mismatch(self) -> None:
+        output = "\n".join(
+            [
+                "scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256",
+                "300\tcsharp-query:auto\t0.200\t0.200\t0.200\t42\thash-a",
+                "300\tcsharp-query:preload\t0.180\t0.180\t0.180\t42\thash-b",
+            ]
+        )
+        summaries = parse_runner_output("category-influence", output)
+
+        failures = calibration_failures(summaries, fail_on_output_mismatch=True)
+
+        self.assertEqual(
+            failures,
+            ["category-influence/300: source-mode outputs MISMATCH"],
+        )
+
+    def test_parse_ratio_accepts_x_suffix_and_empty_values(self) -> None:
+        self.assertEqual(parse_ratio("1.25x"), 1.25)
+        self.assertEqual(parse_ratio("1.00"), 1.0)
+        self.assertIsNone(parse_ratio(""))
+        self.assertIsNone(parse_ratio("not-a-ratio"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary

  Adds regression coverage and opt-in failure gates for the C# query source-mode sweep harness.

  The sweep script can now fail when source modes produce mismatched outputs or when `auto` exceeds a configured
  `auto_vs_best` ratio. By default it still reports only, so existing benchmark behavior is unchanged unless the new
  gates are explicitly enabled.

  ## Changes

  - Add unit coverage for C# query source-mode sweep parsing.
  - Cover best-mode extraction, `auto_vs_best`, output agreement, median summaries, and source registration summaries.
  - Add `--fail-on-output-mismatch`.
  - Add `--max-auto-vs-best-ratio`.
  - Cover slow-auto and output-mismatch failure detection.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_source_mode_sweep.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_source_mode_sweep.py tests/
  test_csharp_query_source_mode_sweep.py`
  - Live sweep with `--fail-on-output-mismatch --max-auto-vs-best-ratio 2.00`
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
  - `git diff --check`