### PR TITLE
feat(wam-clojure): lower number builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -288,6 +288,10 @@ clojure_direct_builtin("integer/1", "1").
 clojure_direct_builtin("integer/1", 1).
 clojure_direct_builtin('integer/1', "1").
 clojure_direct_builtin('integer/1', 1).
+clojure_direct_builtin("number/1", "1").
+clojure_direct_builtin("number/1", 1).
+clojure_direct_builtin('number/1', "1").
+clojure_direct_builtin('number/1', 1).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
@@ -395,6 +399,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     !,
     format(atom(Expr),
            '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (integer? value) (runtime/advance ~w) (runtime/backtrack ~w)))',
+           [S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "number/1" ; Op == 'number/1'),
+    !,
+    format(atom(Expr),
+           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (number? value) (runtime/advance ~w) (runtime/backtrack ~w)))',
            [S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -819,6 +819,13 @@
               (advance state)
               (backtrack state)))
 
+          "number/1"
+          (let [value (deref-value (:bindings state)
+                                   (or (reg-get-raw state "A1") ::unbound))]
+            (if (number? value)
+              (advance state)
+              (backtrack state)))
+
           "!/0"
           (-> state
               (update :choice-points #(vec (take (:cut-bar state) %)))

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -110,6 +110,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, '"fail/0"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"atom/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"integer/1"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"number/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-bindings [state bindings]')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -194,6 +194,17 @@ test(simple_builtin_integer_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/backtrack")
     )).
 
+test(simple_builtin_number_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_number/1:\nbuiltin_call number/1, 1\nproceed\n",
+        wam_clojure_lowerable(test_number/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_number/1, WamCode, [], Code),
+        has(Code, "runtime/deref-value"),
+        has(Code, "number? value"),
+        has(Code, "runtime/advance"),
+        has(Code, "runtime/backtrack")
+    )).
+
 test(env_framed_equality_reaches_direct_builtin_prefix) :-
     once((
         WamCode = "test_env_eq/2:\nallocate\nput_value X1, A1\nput_value X2, A2\nbuiltin_call =/2, 2\ndeallocate\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -40,6 +40,7 @@
 :- dynamic user:wam_fail_after_bind/1.
 :- dynamic user:wam_atom_guard/1.
 :- dynamic user:wam_integer_guard/1.
+:- dynamic user:wam_number_guard/1.
 
 has(Code, Substr) :-
     once(sub_string(Code, _, _, _, Substr)).
@@ -82,6 +83,7 @@ user:wam_not_b(X) :- X \= b.
 user:wam_fail_after_bind(X) :- X = a, fail.
 user:wam_atom_guard(X) :- atom(X).
 user:wam_integer_guard(X) :- integer(X).
+user:wam_number_guard(X) :- number(X).
 
 :- initialization(main, main).
 
@@ -128,7 +130,8 @@ run_smoke :-
           user:wam_not_b/1,
           user:wam_fail_after_bind/1,
           user:wam_atom_guard/1,
-          user:wam_integer_guard/1
+          user:wam_integer_guard/1,
+          user:wam_number_guard/1
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
@@ -149,6 +152,7 @@ run_smoke :-
     assert_lowered_fail_builtin_emitted(TmpDir),
     assert_lowered_atom_builtin_emitted(TmpDir),
     assert_lowered_integer_builtin_emitted(TmpDir),
+    assert_lowered_number_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
@@ -210,6 +214,8 @@ run_smoke :-
     verify_output(TmpDir, 'wam_atom_guard/1', 'f(a)', "false"),
     verify_output(TmpDir, 'wam_integer_guard/1', 42, "true"),
     verify_output(TmpDir, 'wam_integer_guard/1', a, "false"),
+    verify_output(TmpDir, 'wam_number_guard/1', 42, "true"),
+    verify_output(TmpDir, 'wam_number_guard/1', a, "false"),
     delete_directory_and_contents(TmpDir),
     writeln('wam_clojure_runtime_smoke: ok').
 
@@ -281,6 +287,12 @@ assert_lowered_integer_builtin_emitted(ProjectDir) :-
     read_file_to_string(CorePath, CoreCode, []),
     has(CoreCode, "defn lowered-wam-integer-guard-1"),
     has(CoreCode, "integer? value").
+
+assert_lowered_number_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-number-guard-1"),
+    has(CoreCode, "number? value").
 
 assert_multiclause_wrappers_runtime_mediated(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM runtime support for `builtin_call number/1`.
- Adds direct lowered-prefix support for deterministic `number/1` builtin calls.
- Dereferences `A1` before applying the host Clojure `number?` predicate.
- Adds generator, lowered-emitter, and runtime smoke coverage for numeric guard behavior.

## Why

The Clojure hybrid WAM target already lowers deterministic type-test guards such as `atom/1` and `integer/1`. `number/1` is the next low-risk guard because numeric EDN inputs remain host numeric values in the runtime representation, while atoms and structures are normalized into non-numeric runtime terms.

Lowering this builtin keeps simple numeric guard predicates on the direct lowered path and avoids interpreter fallback without changing WAM-visible behavior.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
