### PR TITLE
feat(wam-python): add hybrid indexed fact kernels

### DIFF
--- a/src/unifyweaver/targets/wam_python_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_python_lowered_emitter.pl
@@ -52,6 +52,7 @@ choice_point_instr(trust_me).
 choice_point_instr(try(_)).
 choice_point_instr(retry(_)).
 choice_point_instr(trust(_)).
+choice_point_instr(call_indexed_atom_fact2(_)).
 
 % ============================================================================
 % Function name generation
@@ -144,6 +145,14 @@ instr_from_parts_py(["deallocate"], deallocate).
 instr_from_parts_py(["is", Target, Expr], is(Target, Expr)).
 instr_from_parts_py(["builtin_call", Op, Ar], builtin_call(Op, Ar)).
 instr_from_parts_py(["call_foreign", Pred, Ar], call_foreign(Pred, Ar)).
+instr_from_parts_py(["call_indexed_atom_fact2", Pred], call_indexed_atom_fact2(Pred)).
+instr_from_parts_py(["base_category_ancestor", CatReg, TargetReg, VisitedReg],
+	base_category_ancestor(CatReg, TargetReg, VisitedReg)).
+instr_from_parts_py(["base_category_ancestor_bind", CatReg, TargetReg, HopsReg, VisitedReg],
+	base_category_ancestor_bind(CatReg, TargetReg, HopsReg, VisitedReg)).
+instr_from_parts_py(["recurse_category_ancestor", MidReg, RootReg, ChildHopsReg, VisitedReg, Pred, Skip],
+	recurse_category_ancestor(MidReg, RootReg, ChildHopsReg, VisitedReg, Pred, Skip)).
+instr_from_parts_py(["return_add1", OutReg, InReg], return_add1(OutReg, InReg)).
 instr_from_parts_py(["neck_cut"], neck_cut).
 instr_from_parts_py(["get_level", Yn], get_level(Yn)).
 instr_from_parts_py(["cut", Yn], cut(Yn)).
@@ -724,6 +733,85 @@ emit_instr_py(call_foreign(PredStr, ArStr), Code) :-
 '    _args = [deref(state.regs[i+1], state) for i in range(~w)]
     if not execute_foreign("~w", ~w, _args, state): return False',
 		[ArStr, EP, ArStr]).
+
+emit_instr_py(call_indexed_atom_fact2(PredStr), Code) :-
+	escape_py(PredStr, EP),
+	format(string(Code),
+'    _key = deref(state.regs[1], state)
+    if not isinstance(_key, Atom): return False
+    _values = state.indexed_atom_fact2.get("~w", {}).get(_key.name, [])
+    if not _values: return False
+    if not unify(state.regs[2], Atom(_values[0]), state): return False', [EP]).
+
+emit_instr_py(base_category_ancestor(CatRegStr, TargetRegStr, VisitedRegStr), Code) :-
+	reg_int_py(CatRegStr, CatReg),
+	reg_int_py(TargetRegStr, TargetReg),
+	reg_int_py(VisitedRegStr, VisitedReg),
+	format(string(Code),
+'    _cat = deref(state.regs[~w], state)
+    _target = deref(state.regs[~w], state)
+    _visited = deref(state.regs[~w], state)
+    if not isinstance(_cat, Atom) or not isinstance(_target, Atom): return False
+    if _atom_in_cons_list(_target, _visited, state): return False
+    if _target.name not in state.indexed_atom_fact2.get("category_parent/2", {}).get(_cat.name, []): return False
+    pop_environment(state)
+    return True', [CatReg, TargetReg, VisitedReg]).
+
+emit_instr_py(base_category_ancestor_bind(CatRegStr, TargetRegStr, HopsRegStr, VisitedRegStr), Code) :-
+	reg_int_py(CatRegStr, CatReg),
+	reg_int_py(TargetRegStr, TargetReg),
+	reg_int_py(HopsRegStr, HopsReg),
+	reg_int_py(VisitedRegStr, VisitedReg),
+	format(string(Code),
+'    _cat = deref(state.regs[~w], state)
+    _target = deref(state.regs[~w], state)
+    _visited = deref(state.regs[~w], state)
+    if not isinstance(_cat, Atom) or not isinstance(_target, Atom): return False
+    if _atom_in_cons_list(_target, _visited, state): return False
+    if _target.name not in state.indexed_atom_fact2.get("category_parent/2", {}).get(_cat.name, []): return False
+    if not unify(state.regs[~w], Int(1), state): return False
+    pop_environment(state)
+    return True', [CatReg, TargetReg, VisitedReg, HopsReg]).
+
+emit_instr_py(recurse_category_ancestor(MidRegStr, RootRegStr, ChildHopsRegStr, VisitedRegStr, PredStr, _SkipStr), Code) :-
+	reg_int_py(MidRegStr, MidReg),
+	reg_int_py(RootRegStr, RootReg),
+	reg_int_py(ChildHopsRegStr, ChildHopsReg),
+	reg_int_py(VisitedRegStr, VisitedReg),
+	pred_to_func_name_py(PredStr, FN),
+	format(string(Code),
+'    _mid = deref(state.regs[~w], state)
+    _root = deref(state.regs[~w], state)
+    _visited = deref(state.regs[~w], state)
+    _child_hops = state.fresh_var()
+    state.regs[~w] = _child_hops
+    state.regs[1] = _mid
+    state.regs[2] = _root
+    state.regs[3] = _child_hops
+    state.regs[4] = Compound(".", [_mid, _visited])
+    if not ~w(state): return False', [MidReg, RootReg, VisitedReg, ChildHopsReg, FN]).
+
+emit_instr_py(return_add1(OutRegStr, InRegStr), Code) :-
+	reg_int_py(OutRegStr, OutReg),
+	reg_int_py(InRegStr, InReg),
+	format(string(Code),
+'    _in = deref(state.regs[~w], state)
+    if isinstance(_in, Int):
+        _result = Int(_in.n + 1)
+    elif isinstance(_in, Float):
+        _next = _in.f + 1.0
+        _result = Int(int(round(_next))) if abs(round(_next) - _next) < 1e-12 else Float(_next)
+    elif isinstance(_in, Atom):
+        try:
+            _next = float(_in.name) + 1.0
+            _result = Int(int(round(_next))) if abs(round(_next) - _next) < 1e-12 else Float(_next)
+        except (TypeError, ValueError):
+            return False
+    else:
+        return False
+    if not unify(state.regs[~w], _result, state): return False
+    pop_environment(state)
+    return True', [InReg, OutReg]).
 
 % --- Cut instructions ---
 

--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -104,6 +104,11 @@ class WamState:
         self.write_ctx: Any = None
         # Structure read context: (compound_ref, next_arg_idx) or None
         self.read_ctx: Any = None
+        # Indexed fact tables — Rust-parity O(1) fact lookups keyed by predicate.
+        # indexed_atom_fact2: pred_key -> { key_atom -> [value_atom, ...] }
+        self.indexed_atom_fact2: Dict[str, Dict[str, List[str]]] = {}
+        # indexed_weighted_edge: pred_key -> { key_atom -> [(value_atom, weight), ...] }
+        self.indexed_weighted_edge: Dict[str, Dict[str, List[Tuple[str, float]]]] = {}
 
     def fresh_var(self) -> Var:
         v = Var(ref=[None], id=self._var_counter)
@@ -171,6 +176,69 @@ def heap_trim(state: WamState, mark: int) -> None:
     for i in range(mark, state.heap_len):
         state.heap.pop(i, None)
     state.heap_len = mark
+
+
+# -- Indexed fact tables ----------------------------------------------------
+# Rust-parity O(1) fact lookups. Populated at program-build time, consumed by
+# the call_indexed_atom_fact2 / base_category_ancestor* instructions.
+
+def register_indexed_atom_fact2_pairs(state: WamState, pred_key: str,
+                                      pairs: List[Tuple[str, str]]) -> None:
+    """Build indexed_atom_fact2[pred_key][left] -> [right, ...] from binary atom pairs."""
+    table = state.indexed_atom_fact2.setdefault(pred_key, {})
+    for left, right in pairs:
+        table.setdefault(left, []).append(right)
+
+
+def register_indexed_weighted_edge_triples(state: WamState, pred_key: str,
+                                           triples: List[Tuple[str, str, float]]) -> None:
+    """Build indexed_weighted_edge[pred_key][left] -> [(right, weight), ...]."""
+    table = state.indexed_weighted_edge.setdefault(pred_key, {})
+    for left, right, weight in triples:
+        table.setdefault(left, []).append((right, float(weight)))
+
+
+def _atom_in_cons_list(needle: 'Term', list_term: 'Term', state: WamState) -> bool:
+    """Walk a cons-list (Compound('.', [head, tail])) and check if any head equals needle.
+    Equality compared by atom name, integer value, or float value (deref'd).
+    """
+    cur = list_term
+    while True:
+        cur = deref(cur, state)
+        if isinstance(cur, Ref):
+            cur = state.heap.get(cur.addr)
+            if cur is None:
+                return False
+            continue
+        if isinstance(cur, Atom) and cur.name == '[]':
+            return False
+        if isinstance(cur, Compound) and cur.functor == '.' and len(cur.args) == 2:
+            head = deref(cur.args[0], state)
+            if isinstance(head, Ref):
+                h2 = state.heap.get(head.addr)
+                if h2 is not None:
+                    head = deref(h2, state)
+            if _terms_equal(head, needle):
+                return True
+            cur = cur.args[1]
+            continue
+        return False
+
+
+def _terms_equal(a: 'Term', b: 'Term') -> bool:
+    """Structural equality on dereferenced terms (used for visited-list checks)."""
+    if isinstance(a, Atom) and isinstance(b, Atom):
+        return a.name == b.name
+    if isinstance(a, Int) and isinstance(b, Int):
+        return a.n == b.n
+    if isinstance(a, Float) and isinstance(b, Float):
+        return a.f == b.f
+    return False
+
+
+def _make_cons(head: 'Term', tail: 'Term') -> 'Compound':
+    """Construct a cons cell Compound('.', [head, tail])."""
+    return Compound('.', [head, tail])
 
 
 # -- Trail ------------------------------------------------------------------
@@ -486,6 +554,13 @@ def _resolve_instr(instr: tuple, labels: Dict[str, int]) -> tuple:
             pc = labels.get(lbl, -1)
             resolved_table[str(k) if not isinstance(k, str) else k] = pc
         return ('switch_on_constant_pc', resolved_table)
+    if op == 'recurse_category_ancestor':
+        # recurse_category_ancestor mid_reg, root_reg, child_hops_reg,
+        #                           visited_reg, pred_label, skip
+        _, mid_reg, root_reg, child_hops_reg, visited_reg, pred_label, skip = instr
+        pc = labels.get(pred_label, -1)
+        return ('recurse_category_ancestor_pc',
+                mid_reg, root_reg, child_hops_reg, visited_reg, pc, skip)
     return instr
 
 
@@ -1121,6 +1196,204 @@ def run_wam(code: list, labels: dict, entry: str, state: WamState) -> bool:
             if not ok:
                 if not fail(): return False
                 continue
+
+        elif op == 'call_indexed_atom_fact2':
+            # call_indexed_atom_fact2 pred_key:
+            #   Lookup state.indexed_atom_fact2[pred_key][A1] → [v0, v1, ...].
+            #   Push a choice point per extra value (closure resumes at this ip
+            #   binding A2 to that value). Unify A2 with values[0].
+            _, pred_key = instr
+            key_term = deref(get_reg(state, 1), state)
+            if not isinstance(key_term, Atom):
+                if not fail(): return False
+                continue
+            table = state.indexed_atom_fact2.get(pred_key)
+            values = table.get(key_term.name) if table is not None else None
+            if not values:
+                if not fail(): return False
+                continue
+            resume_ip = ip
+            for v in reversed(values[1:]):
+                value_atom = make_atom(v)
+                def make_cont(va, rip):
+                    def cont(s):
+                        target = deref(get_reg(s, 2), s)
+                        if unify(target, va, s):
+                            return rip
+                        return -1
+                    return cont
+                push_choice_point(state, 2, make_cont(value_atom, resume_ip))
+            if not unify(get_reg(state, 2), make_atom(values[0]), state):
+                if not fail(): return False
+                continue
+
+        elif op == 'base_category_ancestor':
+            # base_category_ancestor cat_reg, target_reg, visited_reg:
+            #   succeeds if (cat, target) is a category_parent/2 fact AND
+            #   target is not already in visited; then pops env & returns to caller.
+            _, cat_reg, target_reg, visited_reg = instr
+            cat_val = deref(get_reg(state, cat_reg), state)
+            if not isinstance(cat_val, Atom):
+                if not fail(): return False
+                continue
+            target_val = deref(get_reg(state, target_reg), state)
+            if not isinstance(target_val, Atom):
+                if not fail(): return False
+                continue
+            visited_val = deref(get_reg(state, visited_reg), state)
+            if _atom_in_cons_list(target_val, visited_val, state):
+                if not fail(): return False
+                continue
+            table = state.indexed_atom_fact2.get('category_parent/2')
+            parents = table.get(cat_val.name) if table is not None else None
+            if not parents or target_val.name not in parents:
+                if not fail(): return False
+                continue
+            if state.e < 0:
+                if not fail(): return False
+                continue
+            pop_environment(state)
+            ret = state.cp
+            state.cp = None
+            if isinstance(ret, int) and ret >= 0:
+                ip = ret
+                arg_snapshot = list(state.regs)
+            else:
+                return True
+
+        elif op == 'base_category_ancestor_bind':
+            # base_category_ancestor_bind cat_reg, target_reg, hops_reg, visited_reg:
+            #   Same as base_category_ancestor but additionally binds hops_reg to Int(1).
+            _, cat_reg, target_reg, hops_reg, visited_reg = instr
+            cat_val = deref(get_reg(state, cat_reg), state)
+            if not isinstance(cat_val, Atom):
+                if not fail(): return False
+                continue
+            target_val = deref(get_reg(state, target_reg), state)
+            if not isinstance(target_val, Atom):
+                if not fail(): return False
+                continue
+            visited_val = deref(get_reg(state, visited_reg), state)
+            if _atom_in_cons_list(target_val, visited_val, state):
+                if not fail(): return False
+                continue
+            table = state.indexed_atom_fact2.get('category_parent/2')
+            parents = table.get(cat_val.name) if table is not None else None
+            if not parents or target_val.name not in parents:
+                if not fail(): return False
+                continue
+            hops_val = deref(get_reg(state, hops_reg), state)
+            one = Int(1)
+            if isinstance(hops_val, Var):
+                bind(hops_val, one, state)
+            elif isinstance(hops_val, Int) and hops_val.n == 1:
+                pass
+            elif isinstance(hops_val, Atom) and hops_val.name == '1':
+                pass
+            elif not unify(hops_val, one, state):
+                if not fail(): return False
+                continue
+            if state.e < 0:
+                if not fail(): return False
+                continue
+            pop_environment(state)
+            ret = state.cp
+            state.cp = None
+            if isinstance(ret, int) and ret >= 0:
+                ip = ret
+                arg_snapshot = list(state.regs)
+            else:
+                return True
+
+        elif op == 'recurse_category_ancestor_pc':
+            # recurse_category_ancestor_pc mid_reg, root_reg, child_hops_reg,
+            #                              visited_reg, target_pc, skip:
+            #   Tail-call to category_ancestor with A1=mid, A2=root,
+            #   A3=fresh child_hops var, A4=[mid|visited]; cp=current+skip.
+            _, mid_reg, root_reg, child_hops_reg, visited_reg, target_pc, skip = instr
+            mid_val = deref(get_reg(state, mid_reg), state)
+            root_val = deref(get_reg(state, root_reg), state)
+            visited_val = deref(get_reg(state, visited_reg), state)
+            child_hops = state.fresh_var()
+            next_visited = _make_cons(mid_val, visited_val)
+            set_reg(state, child_hops_reg, child_hops)
+            set_reg(state, 1, mid_val)
+            set_reg(state, 2, root_val)
+            set_reg(state, 3, child_hops)
+            set_reg(state, 4, next_visited)
+            state.cp = ip - 1 + skip  # ip already advanced; -1 corrects to current pc
+            if target_pc < 0:
+                if not fail(): return False
+                continue
+            ip = target_pc
+            arg_snapshot = list(state.regs)
+
+        elif op == 'recurse_category_ancestor':
+            # Legacy unresolved label form (load_program normally rewrites to _pc).
+            _, mid_reg, root_reg, child_hops_reg, visited_reg, pred_label, skip = instr
+            target_pc = labels.get(pred_label, -1)
+            mid_val = deref(get_reg(state, mid_reg), state)
+            root_val = deref(get_reg(state, root_reg), state)
+            visited_val = deref(get_reg(state, visited_reg), state)
+            child_hops = state.fresh_var()
+            next_visited = _make_cons(mid_val, visited_val)
+            set_reg(state, child_hops_reg, child_hops)
+            set_reg(state, 1, mid_val)
+            set_reg(state, 2, root_val)
+            set_reg(state, 3, child_hops)
+            set_reg(state, 4, next_visited)
+            state.cp = ip - 1 + skip
+            if target_pc < 0:
+                if not fail(): return False
+                continue
+            ip = target_pc
+            arg_snapshot = list(state.regs)
+
+        elif op == 'return_add1':
+            # return_add1 out_reg, in_reg:
+            #   Compute in_reg+1, bind/unify into out_reg, then pop env & return.
+            _, out_reg, in_reg = instr
+            in_val = deref(get_reg(state, in_reg), state)
+            if isinstance(in_val, Int):
+                result = Int(in_val.n + 1)
+            elif isinstance(in_val, Float):
+                nxt = in_val.f + 1.0
+                result = Int(int(round(nxt))) if abs(round(nxt) - nxt) < 1e-12 else Float(nxt)
+            elif isinstance(in_val, Atom):
+                try:
+                    f = float(in_val.name)
+                except (TypeError, ValueError):
+                    if not fail(): return False
+                    continue
+                nxt = f + 1.0
+                result = Int(int(round(nxt))) if abs(round(nxt) - nxt) < 1e-12 else Float(nxt)
+            else:
+                if not fail(): return False
+                continue
+            out_val = deref(get_reg(state, out_reg), state)
+            if isinstance(out_val, Var):
+                bind(out_val, result, state)
+            elif isinstance(out_val, Int) and isinstance(result, Int) and out_val.n == result.n:
+                pass
+            elif isinstance(out_val, Float) and isinstance(result, Float) and out_val.f == result.f:
+                pass
+            elif isinstance(out_val, Atom) and isinstance(result, (Int, Float)) \
+                    and out_val.name == (str(result.n) if isinstance(result, Int) else str(result.f)):
+                pass
+            elif not unify(out_val, result, state):
+                if not fail(): return False
+                continue
+            if state.e < 0:
+                if not fail(): return False
+                continue
+            pop_environment(state)
+            ret = state.cp
+            state.cp = None
+            if isinstance(ret, int) and ret >= 0:
+                ip = ret
+                arg_snapshot = list(state.regs)
+            else:
+                return True
 
         elif op == 'switch_on_term_pc':
             _, lv_pc, lc_pc, ll_pc, ls_pc = instr

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -1151,6 +1151,36 @@ wam_line_to_python_literal(["jump", Label], Py) :-
 	clean_comma(Label, CL),
 	escape_python_string(CL, EL),
 	format(atom(Py), '("jump", "~w")', [EL]).
+% --- Indexed-fact + category-ancestor kernel instructions (Rust parity) ---
+wam_line_to_python_literal(["call_indexed_atom_fact2", Pred], Py) :-
+	clean_comma(Pred, CP),
+	escape_python_string(CP, EP),
+	format(atom(Py), '("call_indexed_atom_fact2", "~w")', [EP]).
+wam_line_to_python_literal(["base_category_ancestor", CatReg, TargetReg, VisitedReg], Py) :-
+	clean_comma(CatReg, CC),
+	clean_comma(TargetReg, CT),
+	clean_comma(VisitedReg, CV),
+	format(atom(Py), '("base_category_ancestor", ~w, ~w, ~w)', [CC, CT, CV]).
+wam_line_to_python_literal(["base_category_ancestor_bind", CatReg, TargetReg, HopsReg, VisitedReg], Py) :-
+	clean_comma(CatReg, CC),
+	clean_comma(TargetReg, CT),
+	clean_comma(HopsReg, CH),
+	clean_comma(VisitedReg, CV),
+	format(atom(Py), '("base_category_ancestor_bind", ~w, ~w, ~w, ~w)', [CC, CT, CH, CV]).
+wam_line_to_python_literal(["recurse_category_ancestor", MidReg, RootReg, ChildHopsReg, VisitedReg, Pred, Skip], Py) :-
+	clean_comma(MidReg, CM),
+	clean_comma(RootReg, CR),
+	clean_comma(ChildHopsReg, CCH),
+	clean_comma(VisitedReg, CV),
+	clean_comma(Pred, CP),
+	clean_comma(Skip, CSk),
+	escape_python_string(CP, EP),
+	format(atom(Py), '("recurse_category_ancestor", ~w, ~w, ~w, ~w, "~w", ~w)',
+		[CM, CR, CCH, CV, EP, CSk]).
+wam_line_to_python_literal(["return_add1", OutReg, InReg], Py) :-
+	clean_comma(OutReg, CO),
+	clean_comma(InReg, CI),
+	format(atom(Py), '("return_add1", ~w, ~w)', [CO, CI]).
 
 % ============================================================================
 % PHASE 5: Predicate Compilation
@@ -1582,6 +1612,11 @@ def run_benchmark(data_dir, n_reps):
     # Register foreign predicates
     register_category_parent(category_parents)
 
+    # Pre-flatten category_parent pairs once (used for indexed-table init below).
+    category_parent_pairs = [
+        (child, p) for child, parents in category_parents.items() for p in parents
+    ]
+
     # Build WAM program via predicates.build_program()
     raw_program = build_program()
     code, labels = load_program(raw_program)
@@ -1605,6 +1640,9 @@ def run_benchmark(data_dir, n_reps):
         rep_solutions = 0
         for (article, cat, rt) in seeds:
             state = WamState()
+            # Rust-parity: populate indexed fact table for O(1) category_parent/2
+            # lookups consumed by call_indexed_atom_fact2 / base_category_ancestor*.
+            register_indexed_atom_fact2_pairs(state, \'category_parent/2\', category_parent_pairs)
             set_reg(state, 1, make_atom(cat))
             set_reg(state, 2, make_atom(rt))
             set_reg(state, 3, state.fresh_var())

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -152,7 +152,7 @@ test(compile_fact) :-
 	atom_string(PythonCode, S),
 	assertion(S \== ""),
 	% Should contain a def line
-	assertion(sub_string(S, _, _, _, "def wam_foo")),
+	assertion(sub_string(S, _, _, _, "def pred_foo_1")),
 	% Should contain the get_constant instruction
 	assertion(sub_string(S, _, _, _, "get_constant")).
 
@@ -161,24 +161,24 @@ test(compile_binary_predicate) :-
 	WamCode = 'bar/2:\n  get_variable 101, 1\n  get_value 101, 2\n  proceed',
 	wam_python_target:compile_wam_predicate_to_python(bar/2, WamCode, [], PythonCode),
 	atom_string(PythonCode, S),
-	assertion(sub_string(S, _, _, _, "def wam_bar")),
+	assertion(sub_string(S, _, _, _, "def pred_bar_2")),
 	assertion(sub_string(S, _, _, _, "get_variable")),
 	assertion(sub_string(S, _, _, _, "proceed")).
 
 test(compile_generates_label_mapping) :-
-	% A label line should produce a labels[] assignment
+	% A label line should produce a __label__ marker consumed by load_program/1.
 	WamCode = 'baz/1:\n  get_constant hello, 1\n  proceed',
 	wam_python_target:compile_wam_predicate_to_python(baz/1, WamCode, [], PythonCode),
 	atom_string(PythonCode, S),
-	assertion(sub_string(S, _, _, _, "state.labels")).
+	assertion(sub_string(S, _, _, _, '"__label__", "baz/1"')).
 
 test(compile_arg_setup) :-
-	% Arity-2 predicate should set up a1, a2 arguments
+	% Arity-2 predicate should be registered under its pred/arity key.
 	WamCode = 'qux/2:\n  proceed',
 	wam_python_target:compile_wam_predicate_to_python(qux/2, WamCode, [], PythonCode),
 	atom_string(PythonCode, S),
-	assertion(sub_string(S, _, _, _, "a1")),
-	assertion(sub_string(S, _, _, _, "a2")).
+	assertion(sub_string(S, _, _, _, 'raw_program["qux/2"]')),
+	assertion(sub_string(S, _, _, _, '("proceed",)')).
 
 :- end_tests(wam_python_compile).
 
@@ -326,6 +326,11 @@ test(is_not_deterministic_with_trust_me) :-
 	Instrs = [trust_me, proceed],
 	\+ wam_python_lowered_emitter:is_deterministic_pred_py(Instrs).
 
+test(is_not_deterministic_with_indexed_fact_call) :-
+	% Indexed fact lookup may push choice points for additional values.
+	Instrs = [call_indexed_atom_fact2("category_parent/2"), proceed],
+	\+ wam_python_lowered_emitter:is_deterministic_pred_py(Instrs).
+
 test(python_func_name_basic) :-
 	wam_python_lowered_emitter:python_func_name(foo/2, Name),
 	Name = 'pred_foo_2'.
@@ -359,6 +364,42 @@ test(emit_lowered_def_line, [nondet]) :-
 test(emit_lowered_fail, [nondet]) :-
 	wam_python_lowered_emitter:emit_lowered_python('nope'/0, [fail], [], Lines),
 	sub_string(Lines, _, _, _, "return False").
+
+test(emit_lowered_call_indexed_atom_fact2, [nondet]) :-
+	wam_python_lowered_emitter:emit_lowered_python(
+		category_parent/2,
+		[call_indexed_atom_fact2("category_parent/2"), proceed],
+		[],
+		Lines),
+	sub_string(Lines, _, _, _, "indexed_atom_fact2"),
+	sub_string(Lines, _, _, _, "category_parent/2").
+
+test(emit_lowered_base_category_ancestor_bind, [nondet]) :-
+	wam_python_lowered_emitter:emit_lowered_python(
+		category_ancestor/4,
+		[base_category_ancestor_bind("A1", "A2", "A3", "A4")],
+		[],
+		Lines),
+	sub_string(Lines, _, _, _, "_atom_in_cons_list"),
+	sub_string(Lines, _, _, _, "Int(1)").
+
+test(emit_lowered_recurse_category_ancestor, [nondet]) :-
+	wam_python_lowered_emitter:emit_lowered_python(
+		category_ancestor/4,
+		[recurse_category_ancestor("X1", "A2", "X2", "A4", "category_ancestor/4", "3")],
+		[],
+		Lines),
+	sub_string(Lines, _, _, _, "pred_category_ancestor_4(state)"),
+	sub_string(Lines, _, _, _, 'Compound(".", [_mid, _visited])').
+
+test(emit_lowered_return_add1, [nondet]) :-
+	wam_python_lowered_emitter:emit_lowered_python(
+		category_ancestor/4,
+		[return_add1("A3", "X3")],
+		[],
+		Lines),
+	sub_string(Lines, _, _, _, "_result = Int"),
+	sub_string(Lines, _, _, _, "pop_environment(state)").
 
 :- end_tests(wam_python_lowered_emitter).
 
@@ -502,3 +543,87 @@ test(emit_ite_integer_condition, [nondet]) :-
 	sub_string(AllText, _, _, _, "Int").
 
 :- end_tests(wam_python_ite).
+
+% ============================================================================
+% Rust-parity: indexed-fact + category-ancestor kernel instructions
+% ============================================================================
+
+:- begin_tests(wam_python_kernel_parity).
+
+% --- Line-literal parsing for new ops ---
+
+test(line_call_indexed_atom_fact2) :-
+	wam_python_target:wam_line_to_python_literal(
+		["call_indexed_atom_fact2", "category_parent/2"], Lit),
+	assertion(Lit == '("call_indexed_atom_fact2", "category_parent/2")').
+
+test(line_base_category_ancestor) :-
+	wam_python_target:wam_line_to_python_literal(
+		["base_category_ancestor", "A1", "A2", "A4"], Lit),
+	assertion(Lit == '("base_category_ancestor", A1, A2, A4)').
+
+test(line_base_category_ancestor_bind) :-
+	wam_python_target:wam_line_to_python_literal(
+		["base_category_ancestor_bind", "A1", "A2", "A3", "A4"], Lit),
+	assertion(Lit == '("base_category_ancestor_bind", A1, A2, A3, A4)').
+
+test(line_recurse_category_ancestor) :-
+	wam_python_target:wam_line_to_python_literal(
+		["recurse_category_ancestor", "X1", "A2", "X2", "A4", "category_ancestor/4", "3"], Lit),
+	assertion(Lit == '("recurse_category_ancestor", X1, A2, X2, A4, "category_ancestor/4", 3)').
+
+test(line_return_add1) :-
+	wam_python_target:wam_line_to_python_literal(
+		["return_add1", "A3", "X3"], Lit),
+	assertion(Lit == '("return_add1", A3, X3)').
+
+% --- Runtime contains the new opcodes and registration helpers ---
+
+% Helper: get path to the static WamRuntime.py
+runtime_py_path(SrcPath) :-
+	source_file(wam_python_target:compile_step_wam_to_python(_,_), ThisFile),
+	file_directory_name(ThisFile, ThisDir),
+	directory_file_path(ThisDir, 'wam_python_runtime/WamRuntime.py', SrcPath).
+
+test(runtime_has_indexed_atom_fact2_field, [nondet]) :-
+	runtime_py_path(P), read_file_to_string(P, Content, []),
+	sub_string(Content, _, _, _, "self.indexed_atom_fact2").
+
+test(runtime_has_indexed_weighted_edge_field, [nondet]) :-
+	runtime_py_path(P), read_file_to_string(P, Content, []),
+	sub_string(Content, _, _, _, "self.indexed_weighted_edge").
+
+test(runtime_has_register_indexed_atom_fact2_pairs, [nondet]) :-
+	runtime_py_path(P), read_file_to_string(P, Content, []),
+	sub_string(Content, _, _, _, "def register_indexed_atom_fact2_pairs").
+
+test(runtime_has_register_indexed_weighted_edge_triples, [nondet]) :-
+	runtime_py_path(P), read_file_to_string(P, Content, []),
+	sub_string(Content, _, _, _, "def register_indexed_weighted_edge_triples").
+
+test(runtime_has_call_indexed_atom_fact2_handler, [nondet]) :-
+	runtime_py_path(P), read_file_to_string(P, Content, []),
+	sub_string(Content, _, _, _, "'call_indexed_atom_fact2'").
+
+test(runtime_has_base_category_ancestor_handler, [nondet]) :-
+	runtime_py_path(P), read_file_to_string(P, Content, []),
+	sub_string(Content, _, _, _, "'base_category_ancestor'").
+
+test(runtime_has_base_category_ancestor_bind_handler, [nondet]) :-
+	runtime_py_path(P), read_file_to_string(P, Content, []),
+	sub_string(Content, _, _, _, "'base_category_ancestor_bind'").
+
+test(runtime_has_recurse_category_ancestor_pc_handler, [nondet]) :-
+	runtime_py_path(P), read_file_to_string(P, Content, []),
+	sub_string(Content, _, _, _, "'recurse_category_ancestor_pc'").
+
+test(runtime_has_return_add1_handler, [nondet]) :-
+	runtime_py_path(P), read_file_to_string(P, Content, []),
+	sub_string(Content, _, _, _, "'return_add1'").
+
+test(runtime_resolves_recurse_category_ancestor_to_pc, [nondet]) :-
+	% _resolve_instr should rewrite recurse_category_ancestor → ..._pc
+	runtime_py_path(P), read_file_to_string(P, Content, []),
+	sub_string(Content, _, _, _, "recurse_category_ancestor_pc").
+
+:- end_tests(wam_python_kernel_parity).


### PR DESCRIPTION
## Summary

Adds Rust-parity indexed fact and category-ancestor kernel support to the WAM Python target.

## Changes

- Add indexed fact tables to the Python WAM runtime:
  - `indexed_atom_fact2`
  - `indexed_weighted_edge`
- Add registration helpers for indexed atom pairs and weighted edge triples
- Add interpreter support for hybrid kernel opcodes:
  - `call_indexed_atom_fact2`
  - `base_category_ancestor`
  - `base_category_ancestor_bind`
  - `recurse_category_ancestor`
  - `return_add1`
- Add Python target literal emission for the new opcodes
- Populate indexed `category_parent/2` facts in the Python benchmark driver
- Extend the Python lowered emitter to parse and emit the new kernel instructions
- Mark indexed fact calls as nondeterministic for lowered-route detection
- Update stale Python WAM compile tests to match the current `pred_*` registrar output

## Test Plan

- `swipl -g run_tests -t halt tests/test_wam_python_target.pl`
  - 101 tests passed
