### PR TITLE
feat(wam-clojure): lower atomic builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -292,6 +292,10 @@ clojure_direct_builtin("number/1", "1").
 clojure_direct_builtin("number/1", 1).
 clojure_direct_builtin('number/1', "1").
 clojure_direct_builtin('number/1', 1).
+clojure_direct_builtin("atomic/1", "1").
+clojure_direct_builtin("atomic/1", 1).
+clojure_direct_builtin('atomic/1', "1").
+clojure_direct_builtin('atomic/1', 1).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
@@ -302,6 +306,15 @@ clojure_terminal_builtin("fail/0", 0).
 clojure_terminal_builtin('fail/0', "0").
 clojure_terminal_builtin('fail/0', 0).
 
+clojure_pred_key_direct_builtin(Pred, Op, Arity) :-
+    (   string(Pred) -> PredString = Pred
+    ;   atom(Pred) -> atom_string(Pred, PredString)
+    ),
+    split_string(PredString, "/", "", [Name, ArityString]),
+    number_string(Arity, ArityString),
+    format(string(Op), "~w/~w", [Name, Arity]),
+    clojure_direct_builtin(Op, Arity).
+
 emit_lowered_expr(proceed, S, Expr) :-
     format(atom(Expr), '(runtime/succeed-state ~w)', [S]).
 emit_lowered_expr(fail, S, Expr) :-
@@ -311,6 +324,13 @@ emit_lowered_expr(call(Pred, _Arity), S, Expr) :-
     format(atom(Expr),
            '(if-let [target-pc (get (:labels ~w) ~w)] (-> ~w (update :stack conj (inc (:pc ~w))) (assoc :pc target-pc)) (runtime/backtrack ~w))',
            [S, PredLit, S, S, S]).
+emit_lowered_expr(execute(Pred), S, Expr) :-
+    clojure_pred_key_direct_builtin(Pred, Op, Arity),
+    !,
+    emit_lowered_expr(builtin_call(Op, Arity), S, BuiltinExpr),
+    format(atom(Expr),
+           '(let [next-state ~w] (if (= :running (:status next-state)) (runtime/succeed-state next-state) next-state))',
+           [BuiltinExpr]).
 emit_lowered_expr(execute(Pred), S, Expr) :-
     clj_lowered_string_literal(Pred, PredLit),
     format(atom(Expr),
@@ -406,6 +426,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     !,
     format(atom(Expr),
            '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (number? value) (runtime/advance ~w) (runtime/backtrack ~w)))',
+           [S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "atomic/1" ; Op == 'atomic/1'),
+    !,
+    format(atom(Expr),
+           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (or (runtime/atom-term? value) (number? value)) (runtime/advance ~w) (runtime/backtrack ~w)))',
            [S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -826,6 +826,13 @@
               (advance state)
               (backtrack state)))
 
+          "atomic/1"
+          (let [value (deref-value (:bindings state)
+                                   (or (reg-get-raw state "A1") ::unbound))]
+            (if (or (atom-term? value) (number? value))
+              (advance state)
+              (backtrack state)))
+
           "!/0"
           (-> state
               (update :choice-points #(vec (take (:cut-bar state) %)))

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -111,6 +111,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, '"atom/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"integer/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"number/1"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"atomic/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-bindings [state bindings]')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -205,6 +205,30 @@ test(simple_builtin_number_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/backtrack")
     )).
 
+test(simple_builtin_atomic_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_atomic/1:\nbuiltin_call atomic/1, 1\nproceed\n",
+        wam_clojure_lowerable(test_atomic/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_atomic/1, WamCode, [], Code),
+        has(Code, "runtime/deref-value"),
+        has(Code, "runtime/atom-term? value"),
+        has(Code, "number? value"),
+        has(Code, "runtime/advance"),
+        has(Code, "runtime/backtrack")
+    )).
+
+test(terminal_execute_atomic_is_direct_lowered_as_succeeding_builtin) :-
+    once((
+        WamCode = "test_execute_atomic/1:\nallocate\ndeallocate\nexecute atomic/1\n",
+        wam_clojure_lowerable(test_execute_atomic/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_execute_atomic/1, WamCode, [], Code),
+        has(Code, "runtime/atom-term? value"),
+        has(Code, "number? value"),
+        has(Code, "runtime/succeed-state next-state"),
+        assertion(\+ has(Code, "\"atomic/1\"")),
+        assertion(\+ has(Code, ":pc target-pc"))
+    )).
+
 test(env_framed_equality_reaches_direct_builtin_prefix) :-
     once((
         WamCode = "test_env_eq/2:\nallocate\nput_value X1, A1\nput_value X2, A2\nbuiltin_call =/2, 2\ndeallocate\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -41,6 +41,7 @@
 :- dynamic user:wam_atom_guard/1.
 :- dynamic user:wam_integer_guard/1.
 :- dynamic user:wam_number_guard/1.
+:- dynamic user:wam_atomic_guard/1.
 
 has(Code, Substr) :-
     once(sub_string(Code, _, _, _, Substr)).
@@ -84,6 +85,7 @@ user:wam_fail_after_bind(X) :- X = a, fail.
 user:wam_atom_guard(X) :- atom(X).
 user:wam_integer_guard(X) :- integer(X).
 user:wam_number_guard(X) :- number(X).
+user:wam_atomic_guard(X) :- atomic(X).
 
 :- initialization(main, main).
 
@@ -131,7 +133,8 @@ run_smoke :-
           user:wam_fail_after_bind/1,
           user:wam_atom_guard/1,
           user:wam_integer_guard/1,
-          user:wam_number_guard/1
+          user:wam_number_guard/1,
+          user:wam_atomic_guard/1
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
@@ -153,6 +156,7 @@ run_smoke :-
     assert_lowered_atom_builtin_emitted(TmpDir),
     assert_lowered_integer_builtin_emitted(TmpDir),
     assert_lowered_number_builtin_emitted(TmpDir),
+    assert_lowered_atomic_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
@@ -216,6 +220,9 @@ run_smoke :-
     verify_output(TmpDir, 'wam_integer_guard/1', a, "false"),
     verify_output(TmpDir, 'wam_number_guard/1', 42, "true"),
     verify_output(TmpDir, 'wam_number_guard/1', a, "false"),
+    verify_output(TmpDir, 'wam_atomic_guard/1', a, "true"),
+    verify_output(TmpDir, 'wam_atomic_guard/1', 42, "true"),
+    verify_output(TmpDir, 'wam_atomic_guard/1', 'f(a)', "false"),
     delete_directory_and_contents(TmpDir),
     writeln('wam_clojure_runtime_smoke: ok').
 
@@ -292,6 +299,13 @@ assert_lowered_number_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
     has(CoreCode, "defn lowered-wam-number-guard-1"),
+    has(CoreCode, "number? value").
+
+assert_lowered_atomic_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-atomic-guard-1"),
+    has(CoreCode, "runtime/atom-term? value"),
     has(CoreCode, "number? value").
 
 assert_multiclause_wrappers_runtime_mediated(ProjectDir) :-


### PR DESCRIPTION
## Summary

- Adds Clojure WAM runtime support for `builtin_call atomic/1`.
- Adds direct lowered-prefix support for deterministic `atomic/1` builtin calls.
- Treats normalized atom terms and host numeric values as atomic values.
- Lowers terminal `execute atomic/1` as a direct builtin success/failure path instead of attempting a label jump.
- Adds generator, lowered-emitter, and runtime smoke coverage for atomic guard behavior.

## Why

The Clojure hybrid WAM target now directly lowers `atom/1`, `integer/1`, and `number/1`. `atomic/1` is the natural next guard because the runtime represents atoms as normalized atom terms and numbers as host numeric values, while structures and lists remain non-atomic compound terms.

The runtime smoke exposed that the compiler can emit `execute atomic/1` rather than `builtin_call atomic/1` for `atomic(X)`. This PR handles that terminal builtin shape directly so generated lowered wrappers do not backtrack through a missing `atomic/1` label.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
