### PR TITLE
feat(wam-clojure): lower nonvar builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -296,6 +296,10 @@ clojure_direct_builtin("atomic/1", "1").
 clojure_direct_builtin("atomic/1", 1).
 clojure_direct_builtin('atomic/1', "1").
 clojure_direct_builtin('atomic/1', 1).
+clojure_direct_builtin("nonvar/1", "1").
+clojure_direct_builtin("nonvar/1", 1).
+clojure_direct_builtin('nonvar/1', "1").
+clojure_direct_builtin('nonvar/1', 1).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
@@ -433,6 +437,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     !,
     format(atom(Expr),
            '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (or (runtime/atom-term? value) (number? value)) (runtime/advance ~w) (runtime/backtrack ~w)))',
+           [S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "nonvar/1" ; Op == 'nonvar/1'),
+    !,
+    format(atom(Expr),
+           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (and (not= value ::lowered-unbound) (not (runtime/logic-var? value))) (runtime/advance ~w) (runtime/backtrack ~w)))',
            [S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -833,6 +833,13 @@
               (advance state)
               (backtrack state)))
 
+          "nonvar/1"
+          (let [value (deref-value (:bindings state)
+                                   (or (reg-get-raw state "A1") ::unbound))]
+            (if (and (not= value ::unbound) (not (logic-var? value)))
+              (advance state)
+              (backtrack state)))
+
           "!/0"
           (-> state
               (update :choice-points #(vec (take (:cut-bar state) %)))

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -112,6 +112,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, '"integer/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"number/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"atomic/1"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"nonvar/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-bindings [state bindings]')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -229,6 +229,30 @@ test(terminal_execute_atomic_is_direct_lowered_as_succeeding_builtin) :-
         assertion(\+ has(Code, ":pc target-pc"))
     )).
 
+test(simple_builtin_nonvar_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_nonvar/1:\nbuiltin_call nonvar/1, 1\nproceed\n",
+        wam_clojure_lowerable(test_nonvar/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_nonvar/1, WamCode, [], Code),
+        has(Code, "runtime/deref-value"),
+        has(Code, "not= value ::lowered-unbound"),
+        has(Code, "not (runtime/logic-var? value)"),
+        has(Code, "runtime/advance"),
+        has(Code, "runtime/backtrack")
+    )).
+
+test(terminal_execute_nonvar_is_direct_lowered_as_succeeding_builtin) :-
+    once((
+        WamCode = "test_execute_nonvar/1:\nallocate\ndeallocate\nexecute nonvar/1\n",
+        wam_clojure_lowerable(test_execute_nonvar/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_execute_nonvar/1, WamCode, [], Code),
+        has(Code, "not= value ::lowered-unbound"),
+        has(Code, "not (runtime/logic-var? value)"),
+        has(Code, "runtime/succeed-state next-state"),
+        assertion(\+ has(Code, "\"nonvar/1\"")),
+        assertion(\+ has(Code, ":pc target-pc"))
+    )).
+
 test(env_framed_equality_reaches_direct_builtin_prefix) :-
     once((
         WamCode = "test_env_eq/2:\nallocate\nput_value X1, A1\nput_value X2, A2\nbuiltin_call =/2, 2\ndeallocate\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -42,6 +42,9 @@
 :- dynamic user:wam_integer_guard/1.
 :- dynamic user:wam_number_guard/1.
 :- dynamic user:wam_atomic_guard/1.
+:- dynamic user:wam_nonvar_guard/1.
+:- dynamic user:wam_unbound_arg/1.
+:- dynamic user:wam_nonvar_unbound/1.
 
 has(Code, Substr) :-
     once(sub_string(Code, _, _, _, Substr)).
@@ -86,6 +89,9 @@ user:wam_atom_guard(X) :- atom(X).
 user:wam_integer_guard(X) :- integer(X).
 user:wam_number_guard(X) :- number(X).
 user:wam_atomic_guard(X) :- atomic(X).
+user:wam_nonvar_guard(X) :- nonvar(X).
+user:wam_unbound_arg(_).
+user:wam_nonvar_unbound(_) :- user:wam_unbound_arg(Y), nonvar(Y).
 
 :- initialization(main, main).
 
@@ -134,7 +140,10 @@ run_smoke :-
           user:wam_atom_guard/1,
           user:wam_integer_guard/1,
           user:wam_number_guard/1,
-          user:wam_atomic_guard/1
+          user:wam_atomic_guard/1,
+          user:wam_nonvar_guard/1,
+          user:wam_unbound_arg/1,
+          user:wam_nonvar_unbound/1
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
@@ -157,6 +166,7 @@ run_smoke :-
     assert_lowered_integer_builtin_emitted(TmpDir),
     assert_lowered_number_builtin_emitted(TmpDir),
     assert_lowered_atomic_builtin_emitted(TmpDir),
+    assert_lowered_nonvar_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
@@ -223,6 +233,10 @@ run_smoke :-
     verify_output(TmpDir, 'wam_atomic_guard/1', a, "true"),
     verify_output(TmpDir, 'wam_atomic_guard/1', 42, "true"),
     verify_output(TmpDir, 'wam_atomic_guard/1', 'f(a)', "false"),
+    verify_output(TmpDir, 'wam_nonvar_guard/1', a, "true"),
+    verify_output(TmpDir, 'wam_nonvar_guard/1', 42, "true"),
+    verify_output(TmpDir, 'wam_nonvar_guard/1', 'f(a)', "true"),
+    verify_output(TmpDir, 'wam_nonvar_unbound/1', a, "false"),
     delete_directory_and_contents(TmpDir),
     writeln('wam_clojure_runtime_smoke: ok').
 
@@ -307,6 +321,14 @@ assert_lowered_atomic_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-atomic-guard-1"),
     has(CoreCode, "runtime/atom-term? value"),
     has(CoreCode, "number? value").
+
+assert_lowered_nonvar_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-nonvar-guard-1"),
+    has(CoreCode, "defn lowered-wam-nonvar-unbound-1"),
+    has(CoreCode, "not= value ::lowered-unbound"),
+    has(CoreCode, "not (runtime/logic-var? value)").
 
 assert_multiclause_wrappers_runtime_mediated(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM runtime support for `builtin_call nonvar/1`.
- Adds direct lowered-prefix support for deterministic `nonvar/1` builtin calls.
- Reuses the terminal direct-builtin path for compiler-emitted `execute nonvar/1`.
- Treats a dereferenced value as nonvar when it is neither the unbound sentinel nor a runtime logic variable.
- Adds generator, lowered-emitter, and runtime smoke coverage for bound and unbound cases.

## Why

The Clojure hybrid WAM target now directly lowers atom and numeric type guards. `nonvar/1` is the next safe variable-state guard because it is a pure dereference check: bound atoms, numbers, and compound terms succeed, while unbound logic variables fail.

This keeps simple guard predicates on the lowered path without adding new binding behavior or changing WAM-visible semantics.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
