### PR TITLE
feat(wam-python): route lowered project predicates

### DIFF
--- a/src/unifyweaver/targets/wam_python_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_python_lowered_emitter.pl
@@ -24,6 +24,7 @@
 	emit_lowered_python/4,           % +FunctorArity, +Instrs, +Options, -Lines
 	is_deterministic_pred_py/1,      % +Instrs
 	python_func_name/2,              % +Functor/Arity, -PythonName
+	parse_wam_text_py/2,             % +WamText, -Instrs
 	is_match_instr_py/1,             % +Instr
 	is_ite_block_py/2,               % +Instrs, -Blocks
 	emit_ite_block_py/5              % +FuncName, +Blocks, +Indent, +Opts, -Lines
@@ -142,6 +143,12 @@ instr_from_parts_py(["fail"], fail).
 instr_from_parts_py(["halt"], halt).
 instr_from_parts_py(["allocate"], allocate).
 instr_from_parts_py(["deallocate"], deallocate).
+instr_from_parts_py(["try_me_else", Label], try_me_else(Label)).
+instr_from_parts_py(["retry_me_else", Label], retry_me_else(Label)).
+instr_from_parts_py(["trust_me"], trust_me).
+instr_from_parts_py(["try", Label], try(Label)).
+instr_from_parts_py(["retry", Label], retry(Label)).
+instr_from_parts_py(["trust", Label], trust(Label)).
 instr_from_parts_py(["is", Target, Expr], is(Target, Expr)).
 instr_from_parts_py(["builtin_call", Op, Ar], builtin_call(Op, Ar)).
 instr_from_parts_py(["call_foreign", Pred, Ar], call_foreign(Pred, Ar)).

--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -1107,6 +1107,17 @@ def run_wam(code: list, labels: dict, entry: str, state: WamState) -> bool:
                 if not fail(): return False
                 continue
 
+        elif op == 'call_lowered':
+            _, fn, _arity = instr
+            try:
+                ok = fn(state)
+            except WAMError:
+                ok = False
+            if not ok:
+                if not fail(): return False
+                continue
+            arg_snapshot = list(state.regs)
+
         elif op == 'proceed':
             if state.cp is None:
                 return True
@@ -1873,6 +1884,17 @@ def _run_aggregate_body(code: list, labels: dict, body_start: int, end_pc: int,
                 if not sub_fail(): break
                 sub_arg_snap = list(sub.regs)
                 continue
+        elif op == 'call_lowered':
+            _, fn, _arity = instr
+            try:
+                ok = fn(sub)
+            except WAMError:
+                ok = False
+            if not ok:
+                if not sub_fail(): break
+                sub_arg_snap = list(sub.regs)
+                continue
+            sub_arg_snap = list(sub.regs)
         elif op == 'proceed':
             if sub.cp is None:
                 break  # done

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -39,6 +39,7 @@
 :- use_module('../targets/wam_python_lowered_emitter', [
 	emit_lowered_python/4,
 	is_deterministic_pred_py/1,
+	parse_wam_text_py/2,
 	python_func_name/2
 ]).
 
@@ -1210,9 +1211,11 @@ sub_string_replace(Str, From, To, Result) :-
 %  Converts WAM instruction output for a predicate to Python code.
 %  Emits a register_predicate(raw_program) call so the flat program can be
 %  built by load_program in main.py.
-compile_wam_predicate_to_python(Pred/Arity, WamCode, _Options, PythonCode) :-
+compile_wam_predicate_to_python(Pred/Arity, WamCode, Options, PythonCode) :-
 	atom_string(Pred, PredStr),
 	python_func_name(Pred/Arity, FuncName),
+	option(registrar_prefix(RegistrarPrefix), Options, ''),
+	atom_concat(RegistrarPrefix, FuncName, RegistrarName),
 	% Build the label key: "Pred/Arity"
 	format(atom(LabelKey), '~w/~w', [PredStr, Arity]),
 	wam_code_to_python_instructions(WamCode, Pred/Arity, InstrLiterals, _LabelLiterals),
@@ -1222,7 +1225,29 @@ compile_wam_predicate_to_python(Pred/Arity, WamCode, _Options, PythonCode) :-
     raw_program["~w"] = (
 ~w
     )
-', [FuncName, PredStr, Arity, LabelKey, InstrLiterals]).
+', [RegistrarName, PredStr, Arity, LabelKey, InstrLiterals]).
+
+%% compile_lowered_wam_predicate_to_python(+Pred/Arity, +WamCode, +Options, -PythonCode)
+%  Emits a direct lowered Python predicate plus a separate registrar that
+%  inserts a call_lowered stub into raw_program. The separate registrar avoids
+%  a name collision with the pred_* lowered function itself.
+compile_lowered_wam_predicate_to_python(Pred/Arity, WamCode, Options, PythonCode) :-
+	parse_wam_text_py(WamCode, Instrs),
+	is_deterministic_pred_py(Instrs),
+	emit_lowered_python(Pred/Arity, Instrs, Options, LoweredFn),
+	atom_string(Pred, PredStr),
+	python_func_name(Pred/Arity, FuncName),
+	atom_concat(register_, FuncName, RegistrarName),
+	format(atom(LabelKey), '~w/~w', [PredStr, Arity]),
+	format(string(Registrar),
+'def ~w(raw_program):
+    """Register lowered WAM code for ~w/~w into raw_program dict."""
+    raw_program["~w"] = (
+        ("call_lowered", ~w, ~w),
+        ("proceed",),
+    )
+', [RegistrarName, PredStr, Arity, LabelKey, FuncName, Arity]),
+	atomic_list_concat([LoweredFn, '\n\n', Registrar], PythonCode).
 
 %% build_python_wam_arg_list(+Arity, -ArgList)
 %  Build the Python function argument list.
@@ -1401,14 +1426,21 @@ compile_all_predicates(Predicates, Options, Code) :-
 
 %% pred_func_name(+Options, +PredSpec, -FuncName)
 %  Get the Python function name for a predicate (for build_program registry).
-pred_func_name(_Options, _Module:Pred/Arity, FuncName) :- !,
-	python_func_name(Pred/Arity, FuncName).
-pred_func_name(_Options, _Module:Pred/Arity-_, FuncName) :- !,
-	python_func_name(Pred/Arity, FuncName).
-pred_func_name(_Options, Pred/Arity-_, FuncName) :- !,
-	python_func_name(Pred/Arity, FuncName).
-pred_func_name(_Options, Pred/Arity, FuncName) :-
-	python_func_name(Pred/Arity, FuncName).
+pred_func_name(Options, _Module:Pred/Arity, FuncName) :- !,
+	pred_registrar_func_name(Options, Pred/Arity, FuncName).
+pred_func_name(Options, _Module:Pred/Arity-_, FuncName) :- !,
+	pred_registrar_func_name(Options, Pred/Arity, FuncName).
+pred_func_name(Options, Pred/Arity-_, FuncName) :- !,
+	pred_registrar_func_name(Options, Pred/Arity, FuncName).
+pred_func_name(Options, Pred/Arity, FuncName) :-
+	pred_registrar_func_name(Options, Pred/Arity, FuncName).
+
+pred_registrar_func_name(Options, Pred/Arity, RegistrarName) :-
+	python_func_name(Pred/Arity, FuncName),
+	(   option(emit_mode(lowered), Options)
+	->  atom_concat(register_, FuncName, RegistrarName)
+	;   RegistrarName = FuncName
+	).
 
 %% build_program_func(+FuncNames, -Code)
 %  Emit a build_program(raw_program) function that calls all pred_* registrars.
@@ -1425,14 +1457,19 @@ compile_one_predicate(Options, _Module:PredSpec, PredCode) :-
 	compile_one_predicate(Options, PredSpec, PredCode).
 compile_one_predicate(Options, Pred/Arity-WamCode, PredCode) :-
 	(   is_ffi_predicate(Pred, Arity, Options)
-	->  compile_ffi_stub_predicate(Pred, Arity, PredCode)
+	->  compile_ffi_stub_predicate(Pred, Arity, Options, PredCode)
+	;   option(emit_mode(lowered), Options),
+	    compile_lowered_wam_predicate_to_python(Pred/Arity, WamCode, Options, PredCode)
+	->  true
+	;   option(emit_mode(lowered), Options)
+	->  compile_wam_predicate_to_python(Pred/Arity, WamCode, [registrar_prefix(register_)|Options], PredCode)
 	;   compile_wam_predicate_to_python(Pred/Arity, WamCode, Options, PredCode)
 	).
 compile_one_predicate(Options, Pred/Arity, PredCode) :-
 	(   is_ffi_predicate(Pred, Arity, Options)
 	->  compile_ffi_stub_predicate(Pred, Arity, PredCode)
 	;   (   compile_predicate_to_wam(Pred/Arity, [], WamCode)
-		->  compile_wam_predicate_to_python(Pred/Arity, WamCode, Options, PredCode)
+		->  compile_one_predicate(Options, Pred/Arity-WamCode, PredCode)
 		;   atom_string(Pred, PredStr),
 			format(string(PredCode),
 				'# Could not compile ~w/~w to WAM\n', [PredStr, Arity])
@@ -1442,8 +1479,15 @@ compile_one_predicate(Options, Pred/Arity, PredCode) :-
 %% compile_ffi_stub_predicate(+Pred, +Arity, -Code)
 %  Emit a registration function that inserts a call_foreign stub into raw_program.
 compile_ffi_stub_predicate(Pred, Arity, PredCode) :-
+	compile_ffi_stub_predicate(Pred, Arity, [], PredCode).
+
+compile_ffi_stub_predicate(Pred, Arity, Options, PredCode) :-
 	atom_string(Pred, PredStr),
 	python_func_name(Pred/Arity, FuncName),
+	(   option(emit_mode(lowered), Options)
+	->  atom_concat(register_, FuncName, RegistrarName)
+	;   RegistrarName = FuncName
+	),
 	format(atom(LabelKey), '~w/~w', [PredStr, Arity]),
 	format(string(PredCode),
 'def ~w(raw_program):
@@ -1452,7 +1496,7 @@ compile_ffi_stub_predicate(Pred, Arity, PredCode) :-
         ("call_foreign", "~w", ~w),
         ("proceed",),
     )
-', [FuncName, PredStr, Arity, LabelKey, PredStr, Arity]).
+', [RegistrarName, PredStr, Arity, LabelKey, PredStr, Arity]).
 
 %% generate_main_py(+Predicates, +ModuleName, -Code)
 %  Generate a main.py entry point.
@@ -1463,15 +1507,25 @@ import sys
 from wam_runtime import *
 from predicates import *
 
+def _init_query_args(query, state):
+    try:
+        arity = int(query.rsplit("/", 1)[1])
+    except (IndexError, ValueError):
+        return
+    for i in range(1, arity + 1):
+        if get_reg(state, i) is None:
+            set_reg(state, i, state.fresh_var())
+
 def main():
     state = WamState()
     # Build a raw program dict from predicates, then flatten + pre-resolve
-    raw_program = {}  # populated by predicate modules
+    raw_program = build_program()
     code, labels = load_program(raw_program)
     # Run a user-specified query
     if len(sys.argv) > 1:
         query = sys.argv[1]
         if query in labels:
+            _init_query_args(query, state)
             if run_wam(code, labels, query, state):
                 results = []
                 for i in range(1, 11):
@@ -1479,7 +1533,7 @@ def main():
                     if val is not None:
                         results.append((i, val))
                 for i, r in results:
-                    print(f"A{i} = {_format_value(r)}")
+                    print(f"A{i} = {repr(r)}")
             else:
                 print("false.")
         else:
@@ -1504,7 +1558,7 @@ from predicates import *
 
 def main():
     # Build a raw program dict from predicates, then flatten + pre-resolve
-    raw_program = {}  # populated by predicate modules
+    raw_program = build_program()
     code, labels = load_program(raw_program)
 
     # Define seeds — each seed is a list of initial register values

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -180,6 +180,29 @@ test(compile_arg_setup) :-
 	assertion(sub_string(S, _, _, _, 'raw_program["qux/2"]')),
 	assertion(sub_string(S, _, _, _, '("proceed",)')).
 
+test(compile_lowered_mode_direct_predicate) :-
+	WamCode = 'foo/1:\n  get_constant a, 1\n  proceed',
+	wam_python_target:compile_one_predicate([emit_mode(lowered)], foo/1-WamCode, PythonCode),
+	atom_string(PythonCode, S),
+	assertion(sub_string(S, _, _, _, "def pred_foo_1(state)")),
+	assertion(sub_string(S, _, _, _, "def register_pred_foo_1(raw_program)")),
+	assertion(sub_string(S, _, _, _, '("call_lowered", pred_foo_1, 1)')).
+
+test(compile_lowered_mode_falls_back_for_nondet) :-
+	WamCode = 'choice/1:\n  try_me_else choice_2\n  get_constant a, 1\n  proceed\nchoice_2:\n  trust_me\n  get_constant b, 1\n  proceed',
+	wam_python_target:compile_one_predicate([emit_mode(lowered)], choice/1-WamCode, PythonCode),
+	atom_string(PythonCode, S),
+	assertion(sub_string(S, _, _, _, "def register_pred_choice_1(raw_program)")),
+	assertion(sub_string(S, _, _, _, '("try_me_else", "choice_2")')),
+	assertion(\+ sub_string(S, _, _, _, "def pred_choice_1(state)")).
+
+test(compile_all_lowered_mode_build_program_uses_registrars) :-
+	WamCode = 'foo/1:\n  get_constant a, 1\n  proceed',
+	wam_python_target:compile_all_predicates([foo/1-WamCode], [emit_mode(lowered)], PythonCode),
+	atom_string(PythonCode, S),
+	assertion(sub_string(S, _, _, _, "register_pred_foo_1(raw_program)")),
+	assertion(sub_string(S, _, _, _, '("call_lowered", pred_foo_1, 1)')).
+
 :- end_tests(wam_python_compile).
 
 % ============================================================================
@@ -259,10 +282,26 @@ test(load_program_in_main, [nondet]) :-
 	wam_python_target:generate_main_py([], test_mod, Code),
 	sub_string(Code, _, _, _, "load_program").
 
+test(build_program_in_main, [nondet]) :-
+	% generate_main_py populates raw_program through predicates.build_program().
+	wam_python_target:generate_main_py([], test_mod, Code),
+	sub_string(Code, _, _, _, "raw_program = build_program()").
+
+test(init_query_args_in_main, [nondet]) :-
+	% main.py initialises A-register query variables from the predicate arity.
+	wam_python_target:generate_main_py([], test_mod, Code),
+	sub_string(Code, _, _, _, "def _init_query_args"),
+	sub_string(Code, _, _, _, "_init_query_args(query, state)").
+
 test(run_wam_four_arg_in_main, [nondet]) :-
 	% main.py calls run_wam(code, labels, query, state)
 	wam_python_target:generate_main_py([], test_mod, Code),
 	sub_string(Code, _, _, _, "run_wam(code, labels").
+
+test(main_prints_results_with_repr, [nondet]) :-
+	% Static runtime does not export underscored helpers through import *.
+	wam_python_target:generate_main_py([], test_mod, Code),
+	sub_string(Code, _, _, _, "repr(r)").
 
 test(static_runtime_has_load_program, [nondet]) :-
 	% The static WamRuntime.py defines the load_program function
@@ -287,6 +326,14 @@ test(static_runtime_has_call_pc, [nondet]) :-
 	directory_file_path(ThisDir, 'wam_python_runtime/WamRuntime.py', SrcPath),
 	read_file_to_string(SrcPath, Content, []),
 	sub_string(Content, _, _, _, "call_pc").
+
+test(static_runtime_has_call_lowered, [nondet]) :-
+	% The static WamRuntime.py handles lowered predicate stubs.
+	source_file(wam_python_target:compile_step_wam_to_python(_,_), ThisFile),
+	file_directory_name(ThisFile, ThisDir),
+	directory_file_path(ThisDir, 'wam_python_runtime/WamRuntime.py', SrcPath),
+	read_file_to_string(SrcPath, Content, []),
+	sub_string(Content, _, _, _, "'call_lowered'").
 
 test(static_runtime_run_wam_four_args, [nondet]) :-
 	% run_wam takes (code, labels, entry, state)


### PR DESCRIPTION
## Summary

Wires Python `emit_mode(lowered)` into generated WAM Python projects so eligible predicates are actually routed through direct lowered Python functions, while unsupported or nondeterministic predicates continue to use the interpreter path.

## Changes

- Emit direct `pred_*` lowered Python functions for deterministic WAM predicates when `emit_mode(lowered)` is selected
- Add separate `register_pred_*` functions so lowered functions do not collide with `raw_program` registrar names
- Register lowered predicates as `("call_lowered", pred_fn, arity)` stubs in `raw_program`
- Add `call_lowered` dispatch support to the Python WAM runtime
- Preserve choice-point opcodes in the lowered parser so nondeterministic WAM text falls back instead of being misclassified as deterministic
- Keep interpreter fallback for nondeterministic lowered-mode predicates
- Update generated `main.py` to call `build_program()` before `load_program()`
- Initialize query A-registers from predicate arity in generated `main.py`
- Print generated CLI results with `repr(r)` instead of relying on underscored runtime helpers that are not imported by `from wam_runtime import *`
- Add regression coverage for lowered routing, fallback behavior, generated main wiring, and runtime `call_lowered`

## Test Plan

- `swipl -g run_tests -t halt tests/test_wam_python_target.pl`
  - 108 tests passed
- Generated lowered project smoke:
  - generated a lowered `foo/1` project
  - ran `python main.py foo/1`
  - observed `A1 = a`
