### PR TITLE
feat(wam-clojure): lower var builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -300,6 +300,10 @@ clojure_direct_builtin("nonvar/1", "1").
 clojure_direct_builtin("nonvar/1", 1).
 clojure_direct_builtin('nonvar/1', "1").
 clojure_direct_builtin('nonvar/1', 1).
+clojure_direct_builtin("var/1", "1").
+clojure_direct_builtin("var/1", 1).
+clojure_direct_builtin('var/1', "1").
+clojure_direct_builtin('var/1', 1).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
@@ -444,6 +448,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     !,
     format(atom(Expr),
            '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (and (not= value ::lowered-unbound) (not (runtime/logic-var? value))) (runtime/advance ~w) (runtime/backtrack ~w)))',
+           [S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "var/1" ; Op == 'var/1'),
+    !,
+    format(atom(Expr),
+           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (or (= value ::lowered-unbound) (runtime/logic-var? value)) (runtime/advance ~w) (runtime/backtrack ~w)))',
            [S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -840,6 +840,13 @@
               (advance state)
               (backtrack state)))
 
+          "var/1"
+          (let [value (deref-value (:bindings state)
+                                   (or (reg-get-raw state "A1") ::unbound))]
+            (if (or (= value ::unbound) (logic-var? value))
+              (advance state)
+              (backtrack state)))
+
           "!/0"
           (-> state
               (update :choice-points #(vec (take (:cut-bar state) %)))

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -113,6 +113,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, '"number/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"atomic/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"nonvar/1"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"var/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-bindings [state bindings]')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -253,6 +253,30 @@ test(terminal_execute_nonvar_is_direct_lowered_as_succeeding_builtin) :-
         assertion(\+ has(Code, ":pc target-pc"))
     )).
 
+test(simple_builtin_var_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_var/1:\nbuiltin_call var/1, 1\nproceed\n",
+        wam_clojure_lowerable(test_var/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_var/1, WamCode, [], Code),
+        has(Code, "runtime/deref-value"),
+        has(Code, "= value ::lowered-unbound"),
+        has(Code, "runtime/logic-var? value"),
+        has(Code, "runtime/advance"),
+        has(Code, "runtime/backtrack")
+    )).
+
+test(terminal_execute_var_is_direct_lowered_as_succeeding_builtin) :-
+    once((
+        WamCode = "test_execute_var/1:\nallocate\ndeallocate\nexecute var/1\n",
+        wam_clojure_lowerable(test_execute_var/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_execute_var/1, WamCode, [], Code),
+        has(Code, "= value ::lowered-unbound"),
+        has(Code, "runtime/logic-var? value"),
+        has(Code, "runtime/succeed-state next-state"),
+        assertion(\+ has(Code, "\"var/1\"")),
+        assertion(\+ has(Code, ":pc target-pc"))
+    )).
+
 test(env_framed_equality_reaches_direct_builtin_prefix) :-
     once((
         WamCode = "test_env_eq/2:\nallocate\nput_value X1, A1\nput_value X2, A2\nbuiltin_call =/2, 2\ndeallocate\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -45,6 +45,8 @@
 :- dynamic user:wam_nonvar_guard/1.
 :- dynamic user:wam_unbound_arg/1.
 :- dynamic user:wam_nonvar_unbound/1.
+:- dynamic user:wam_var_guard/1.
+:- dynamic user:wam_var_unbound/1.
 
 has(Code, Substr) :-
     once(sub_string(Code, _, _, _, Substr)).
@@ -92,6 +94,8 @@ user:wam_atomic_guard(X) :- atomic(X).
 user:wam_nonvar_guard(X) :- nonvar(X).
 user:wam_unbound_arg(_).
 user:wam_nonvar_unbound(_) :- user:wam_unbound_arg(Y), nonvar(Y).
+user:wam_var_guard(X) :- var(X).
+user:wam_var_unbound(_) :- user:wam_unbound_arg(Y), var(Y).
 
 :- initialization(main, main).
 
@@ -143,7 +147,9 @@ run_smoke :-
           user:wam_atomic_guard/1,
           user:wam_nonvar_guard/1,
           user:wam_unbound_arg/1,
-          user:wam_nonvar_unbound/1
+          user:wam_nonvar_unbound/1,
+          user:wam_var_guard/1,
+          user:wam_var_unbound/1
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
@@ -167,6 +173,7 @@ run_smoke :-
     assert_lowered_number_builtin_emitted(TmpDir),
     assert_lowered_atomic_builtin_emitted(TmpDir),
     assert_lowered_nonvar_builtin_emitted(TmpDir),
+    assert_lowered_var_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
@@ -237,6 +244,10 @@ run_smoke :-
     verify_output(TmpDir, 'wam_nonvar_guard/1', 42, "true"),
     verify_output(TmpDir, 'wam_nonvar_guard/1', 'f(a)', "true"),
     verify_output(TmpDir, 'wam_nonvar_unbound/1', a, "false"),
+    verify_output(TmpDir, 'wam_var_guard/1', a, "false"),
+    verify_output(TmpDir, 'wam_var_guard/1', 42, "false"),
+    verify_output(TmpDir, 'wam_var_guard/1', 'f(a)', "false"),
+    verify_output(TmpDir, 'wam_var_unbound/1', a, "true"),
     delete_directory_and_contents(TmpDir),
     writeln('wam_clojure_runtime_smoke: ok').
 
@@ -329,6 +340,14 @@ assert_lowered_nonvar_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-nonvar-unbound-1"),
     has(CoreCode, "not= value ::lowered-unbound"),
     has(CoreCode, "not (runtime/logic-var? value)").
+
+assert_lowered_var_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-var-guard-1"),
+    has(CoreCode, "defn lowered-wam-var-unbound-1"),
+    has(CoreCode, "= value ::lowered-unbound"),
+    has(CoreCode, "runtime/logic-var? value").
 
 assert_multiclause_wrappers_runtime_mediated(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM runtime support for `builtin_call var/1`.
- Adds direct lowered-prefix support for deterministic `var/1` builtin calls.
- Reuses the terminal direct-builtin path for compiler-emitted `execute var/1`.
- Treats a dereferenced value as variable when it is the unbound sentinel or a runtime logic variable.
- Adds generator, lowered-emitter, and runtime smoke coverage for bound and unbound cases.

## Why

`var/1` is the natural complement to the existing lowered `nonvar/1` support. It is a pure dereference check and does not introduce new binding behavior: unbound arguments succeed, while atoms, numbers, and compound terms fail.

This keeps simple variable-state guard predicates on the Clojure lowered path while preserving WAM-visible semantics.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
