### PR TITLE
feat(wam-c): Add WAM C LMDB FactSource loader

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,7 +4,7 @@ Status date: 2026-05-04
 
 Base verified locally:
 
-- `main` at `83b34375` (`Merge pull request #1837 from s243a/feat/wam-c-streaming-foreign-results`)
+- `main` at `e2160c7e` (`Merge pull request #1840 from s243a/feat/wam-c-effective-distance-bench`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 
 This file replaces the older implementation plan. The four original C follow-up
@@ -25,6 +25,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | File-backed FactSource foundation | Done | `WamFactSource`, `wam_fact_source_load_tsv`, `wam_fact_source_lookup_arg1`, `wam_register_category_parent_fact_source`, executable smoke |
 | Streaming integer foreign-result foundation | Done | `WamIntResults`, `wam_int_results_push`, `wam_collect_category_ancestor_hops`, multi-path executable smoke |
 | Effective-distance benchmark generator | Done | `generate_wam_c_effective_distance_benchmark.pl`, TSV facts, `kernels_on`/`kernels_off`, generated C runner smoke |
+| LMDB-backed FactSource foundation | Done | Optional `WAM_C_ENABLE_LMDB`, `wam_fact_source_load_lmdb`, duplicate-key LMDB smoke, existing lookup/kernel registration reuse |
 
 ## Current C Target Baseline
 
@@ -50,6 +51,8 @@ The C target is now a credible small WAM backend:
 - Can generate a small effective-distance C benchmark runner from Prolog facts,
   with both native-kernel and reference DFS modes over TSV category-parent
   facts.
+- Can eagerly load category-parent facts from LMDB into the same `WamFactSource`
+  edge storage used by TSV, behind the optional `WAM_C_ENABLE_LMDB` build flag.
 - Has executable smokes for generated runtime, cross-predicate calls,
   foreign calls, native category ancestor, file-backed facts, streaming native
   results, real multi-clause predicates, structure indexing, `is_list/1`, and
@@ -81,7 +84,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Shared kernel detector integration | Missing | Done | Done | Reuse `recursive_kernel_detection.pl`; generate C registration stubs. |
 | Lowered/native helper functions | Missing | Done | Done | Consider after foreign kernels; C can lower simple fact-only or deterministic predicates. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
-| LMDB-backed facts | Missing | Not primary | Done | Haskell is the reference. C now has an ownership model to extend. |
+| LMDB-backed facts | Partial | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts; next gap is generated benchmark wiring and larger artifact layout support. |
 | Effective-distance benchmark harness | Partial | Done | Done | C has a small generated TSV harness with `kernels_on`/`kernels_off`; next gap is full benchmark matrix integration and larger datasets. |
 | Classic-program e2e suite | Partial | Partial/Done | Partial/Done | C has targeted smokes; add Fibonacci/Ackermann-style suite like Scala/Elixir. |
 | Memory lifecycle | Partial | Runtime-managed | Runtime-managed | C has init/free; needs ASAN/Valgrind CI-style coverage for larger programs. |
@@ -89,18 +92,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lmdb-fact-source`
-
-Goal: add LMDB-backed category-parent facts once the file FactSource and
-streaming result contracts are stable.
-
-Scope:
-
-- Mirror the TSV FactSource ownership model.
-- Load/cursor category-parent pairs from LMDB.
-- Keep this behind an optional build/runtime path.
-
-### 2. `feat/wam-c-kernel-detector-setup`
+### 1. `feat/wam-c-kernel-detector-setup`
 
 Goal: connect the C target to the shared recursive-kernel detector.
 
@@ -110,7 +102,7 @@ Scope:
 - Generate C registration stubs for `category_ancestor/4`.
 - Keep the hand-registration runtime helpers as the low-level API.
 
-### 3. `feat/wam-c-effective-distance-matrix`
+### 2. `feat/wam-c-effective-distance-matrix`
 
 Goal: make C visible in the standard effective-distance benchmark matrix.
 
@@ -120,6 +112,18 @@ Scope:
 - Add script wiring next to the Rust and Haskell effective-distance paths.
 - Compare `kernels_on` and `kernels_off` outputs on shared small datasets
   before scaling up.
+
+### 3. `feat/wam-c-lmdb-effective-distance-wiring`
+
+Goal: let the generated C effective-distance harness choose TSV or LMDB fact
+storage.
+
+Scope:
+
+- Add generator options for `facts_tsv` / `facts_lmdb`.
+- Keep `facts_tsv` as the dependency-free default.
+- Compile LMDB mode with `-DWAM_C_ENABLE_LMDB -llmdb`.
+- Validate duplicate-key category-parent artifacts before scaling up.
 
 ### 4. `perf/wam-c-pack-instruction`
 
@@ -137,9 +141,8 @@ or cache behavior becomes a real bottleneck.
 
 ## Suggested Immediate Next Step
 
-Start with `feat/wam-c-lmdb-fact-source`.
+Start with `feat/wam-c-kernel-detector-setup`.
 
-The C target now has a TSV-backed effective-distance harness, so the next
-highest parity gap is durable fact storage. Use the Haskell LMDB path as the
-reference design, keep the C API optional, and preserve the existing TSV
-FactSource as the dependency-free fallback.
+The C target now has hand-registered native kernels plus TSV and optional LMDB
+fact loading. The next parity gap is removing the hand-wiring by reusing the
+shared recursive-kernel detector to generate C registration stubs.

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -7,6 +7,9 @@
 #include <string.h>
 #include <stdbool.h>
 #include <assert.h>
+#ifdef WAM_C_ENABLE_LMDB
+#include <lmdb.h>
+#endif
 
 #define WAM_HALT -1
 #define WAM_ERR_OOB -2
@@ -205,6 +208,8 @@ bool wam_category_ancestor_handler(WamState *state, const char *pred, int arity)
 void wam_fact_source_init(WamFactSource *source);
 void wam_fact_source_close(WamFactSource *source);
 bool wam_fact_source_load_tsv(WamState *state, WamFactSource *source, const char *path);
+bool wam_fact_source_load_lmdb(WamState *state, WamFactSource *source,
+                               const char *env_path, const char *db_name);
 int wam_fact_source_lookup_arg1(WamFactSource *source, const char *arg1,
                                 CategoryEdge *out_edges, int max_edges);
 bool wam_register_category_parent_fact_source(WamState *state, WamFactSource *source);

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -987,6 +987,68 @@ bool wam_fact_source_load_tsv(WamState *state, WamFactSource *source, const char
     return true;
 }
 
+bool wam_fact_source_load_lmdb(WamState *state, WamFactSource *source,
+                               const char *env_path, const char *db_name) {
+#ifndef WAM_C_ENABLE_LMDB
+    (void)state;
+    (void)source;
+    (void)env_path;
+    (void)db_name;
+    return false;
+#else
+    MDB_env *env = NULL;
+    MDB_txn *txn = NULL;
+    MDB_cursor *cursor = NULL;
+    MDB_dbi dbi = 0;
+    int rc = 0;
+    bool ok = false;
+
+    rc = mdb_env_create(&env);
+    if (rc != MDB_SUCCESS) goto done;
+    rc = mdb_env_set_maxdbs(env, 16);
+    if (rc != MDB_SUCCESS) goto done;
+    rc = mdb_env_open(env, env_path, MDB_RDONLY, 0664);
+    if (rc != MDB_SUCCESS) goto done;
+    rc = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
+    if (rc != MDB_SUCCESS) goto done;
+    rc = mdb_dbi_open(txn, (db_name && db_name[0]) ? db_name : NULL, 0, &dbi);
+    if (rc != MDB_SUCCESS) goto done;
+    rc = mdb_cursor_open(txn, dbi, &cursor);
+    if (rc != MDB_SUCCESS) goto done;
+
+    MDB_val key;
+    MDB_val data;
+    rc = mdb_cursor_get(cursor, &key, &data, MDB_FIRST);
+    while (rc == MDB_SUCCESS) {
+        char *child = malloc(key.mv_size + 1);
+        char *parent = malloc(data.mv_size + 1);
+        if (!child || !parent) {
+            free(child);
+            free(parent);
+            goto done;
+        }
+        memcpy(child, key.mv_data, key.mv_size);
+        child[key.mv_size] = 0;
+        memcpy(parent, data.mv_data, data.mv_size);
+        parent[data.mv_size] = 0;
+        wam_fact_source_add_edge(state, source, child, parent);
+        free(child);
+        free(parent);
+        rc = mdb_cursor_get(cursor, &key, &data, MDB_NEXT);
+    }
+    ok = (rc == MDB_NOTFOUND);
+
+done:
+    if (cursor) mdb_cursor_close(cursor);
+    if (txn) mdb_txn_abort(txn);
+    if (env) {
+        if (dbi) mdb_dbi_close(env, dbi);
+        mdb_env_close(env);
+    }
+    return ok;
+#endif
+}
+
 int wam_fact_source_lookup_arg1(WamFactSource *source, const char *arg1,
                                 CategoryEdge *out_edges, int max_edges) {
     int count = 0;

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -253,6 +253,7 @@ test_fact_source_generation :-
         atom_string(RuntimeCode, S),
         sub_string(S, _, _, _, 'void wam_fact_source_init'),
         sub_string(S, _, _, _, 'bool wam_fact_source_load_tsv'),
+        sub_string(S, _, _, _, 'bool wam_fact_source_load_lmdb'),
         sub_string(S, _, _, _, 'int wam_fact_source_lookup_arg1'),
         sub_string(S, _, _, _, 'bool wam_register_category_parent_fact_source')
     ->  pass(Test)
@@ -374,6 +375,17 @@ test_fact_source_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_lmdb_fact_source_executable_smoke :-
+    Test = 'WAM-C: LMDB FactSource executable smoke',
+    (   gcc_available,
+        lmdb_available
+    ->  (   run_lmdb_fact_source_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'LMDB FactSource executable failed')
+        )
+    ;   format('[PASS] ~w (gcc or lmdb unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_streaming_foreign_results_executable_smoke :-
     Test = 'WAM-C: streaming category_ancestor result executable smoke',
     (   gcc_available
@@ -436,6 +448,12 @@ test_real_prolog_unify_executable_smoke :-
 
 gcc_available :-
     catch(process_create(path(gcc), ['--version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          _, fail),
+    process_wait(Pid, exit(0)).
+
+lmdb_available :-
+    catch(process_create(path('pkg-config'), ['--exists', 'lmdb'],
                          [stdout(null), stderr(null), process(Pid)]),
           _, fail),
     process_wait(Pid, exit(0)).
@@ -554,6 +572,26 @@ run_fact_source_executable_smoke :-
     wam_c_fact_source_smoke_main(DataPath, MainCode),
     write_text_file(MainPath, MainCode),
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
+run_lmdb_fact_source_executable_smoke :-
+    WamCode = 'category_ancestor/4:\n    call_foreign category_ancestor/4, 4\n    proceed',
+    compile_wam_predicate_to_c(user:category_ancestor/4, WamCode, [], PredCode),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(TmpBase), '/tmp/unifyweaver_wam_c_lmdb_fact_source_smoke_~w', [Stamp]),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(EnvPath), '~w_env', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(RuntimePath, RuntimeCode),
+    format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+    write_text_file(PredPath, PredTranslationUnit),
+    wam_c_lmdb_fact_source_smoke_main(EnvPath, MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_lmdb(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
 
 run_streaming_foreign_results_executable_smoke :-
@@ -736,6 +774,18 @@ compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath) :-
     (   Status =:= 0
     ->  true
     ;   format(user_error, 'gcc failed with status ~w~n', [Status]),
+        fail
+    ).
+
+compile_c_smoke_lmdb(RuntimePath, PredPath, MainPath, ExePath) :-
+    IncludeDir = 'src/unifyweaver/targets/wam_c_runtime',
+    format(atom(Cmd),
+           'gcc -std=c11 -Wall -Wextra -DWAM_C_ENABLE_LMDB -I ~w ~w ~w ~w -llmdb -o ~w',
+           [IncludeDir, RuntimePath, PredPath, MainPath, ExePath]),
+    shell(Cmd, Status),
+    (   Status =:= 0
+    ->  true
+    ;   format(user_error, 'gcc lmdb smoke failed with status ~w~n', [Status]),
         fail
     ).
 
@@ -1028,6 +1078,113 @@ int main(void) {
     return 0;
 }
 ', [DataPath]).
+
+wam_c_lmdb_fact_source_smoke_main(EnvPath, MainCode) :-
+    format(atom(MainCode),
+'#include "wam_runtime.h"
+#include <sys/stat.h>
+
+void setup_category_ancestor_4(WamState* state);
+
+static WamValue make_visited_singleton(WamState *state, const char *atom) {
+    WamValue list;
+    list.tag = VAL_LIST;
+    list.data.ref_addr = state->H;
+    state->H_array[state->H++] = val_atom(atom);
+    state->H_array[state->H++] = val_atom("[]");
+    return list;
+}
+
+static int put_edge(MDB_env *env, MDB_dbi dbi, const char *child, const char *parent) {
+    MDB_txn *txn = NULL;
+    MDB_val key;
+    MDB_val data;
+    int rc = mdb_txn_begin(env, NULL, 0, &txn);
+    if (rc != MDB_SUCCESS) return rc;
+    key.mv_size = strlen(child);
+    key.mv_data = (void *)child;
+    data.mv_size = strlen(parent);
+    data.mv_data = (void *)parent;
+    rc = mdb_put(txn, dbi, &key, &data, 0);
+    if (rc == MDB_SUCCESS) rc = mdb_txn_commit(txn);
+    else mdb_txn_abort(txn);
+    return rc;
+}
+
+static int seed_lmdb(const char *path) {
+    MDB_env *env = NULL;
+    MDB_txn *txn = NULL;
+    MDB_dbi dbi = 0;
+    int rc = mkdir(path, 0777);
+    (void)rc;
+    rc = mdb_env_create(&env);
+    if (rc != MDB_SUCCESS) return rc;
+    rc = mdb_env_set_maxdbs(env, 16);
+    if (rc != MDB_SUCCESS) { mdb_env_close(env); return rc; }
+    rc = mdb_env_set_mapsize(env, 1048576);
+    if (rc != MDB_SUCCESS) { mdb_env_close(env); return rc; }
+    rc = mdb_env_open(env, path, 0, 0664);
+    if (rc != MDB_SUCCESS) { mdb_env_close(env); return rc; }
+    rc = mdb_txn_begin(env, NULL, 0, &txn);
+    if (rc != MDB_SUCCESS) { mdb_env_close(env); return rc; }
+    rc = mdb_dbi_open(txn, NULL, MDB_CREATE | MDB_DUPSORT, &dbi);
+    if (rc == MDB_SUCCESS) rc = mdb_txn_commit(txn);
+    else { mdb_txn_abort(txn); mdb_env_close(env); return rc; }
+    rc = put_edge(env, dbi, "leaf", "mid");
+    if (rc == MDB_SUCCESS) rc = put_edge(env, dbi, "mid", "root");
+    if (rc == MDB_SUCCESS) rc = put_edge(env, dbi, "leaf", "other");
+    mdb_dbi_close(env, dbi);
+    mdb_env_close(env);
+    return rc;
+}
+
+int main(void) {
+    WamState state;
+    WamFactSource source;
+    CategoryEdge matches[4];
+    if (seed_lmdb("~w") != MDB_SUCCESS) return 5;
+
+    wam_state_init(&state);
+    wam_fact_source_init(&source);
+    setup_category_ancestor_4(&state);
+
+    if (!wam_fact_source_load_lmdb(&state, &source, "~w", NULL)) {
+        wam_free_state(&state);
+        wam_fact_source_close(&source);
+        return 10;
+    }
+
+    int match_count = wam_fact_source_lookup_arg1(&source, "leaf", matches, 4);
+    if (match_count != 2 ||
+        strcmp(matches[0].child, "leaf") != 0 ||
+        strcmp(matches[0].parent, "mid") != 0) {
+        wam_free_state(&state);
+        wam_fact_source_close(&source);
+        return 20;
+    }
+
+    wam_register_category_parent_fact_source(&state, &source);
+    wam_register_category_ancestor_kernel(&state, "category_ancestor/4", 10);
+
+    WamValue args[4] = {
+        val_atom("leaf"),
+        val_atom("root"),
+        val_unbound("Hops"),
+        make_visited_singleton(&state, "leaf")
+    };
+    int run_rc = wam_run_predicate(&state, "category_ancestor/4", args, 4);
+    if (run_rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 2) {
+        wam_free_state(&state);
+        wam_fact_source_close(&source);
+        return 30;
+    }
+
+    wam_free_state(&state);
+    wam_fact_source_close(&source);
+    return 0;
+}
+', [EnvPath, EnvPath]).
 
 wam_c_streaming_foreign_smoke_main(
 '#include "wam_runtime.h"
@@ -1380,6 +1537,7 @@ run_tests_once :-
     test_call_foreign_executable_smoke,
     test_category_ancestor_kernel_executable_smoke,
     test_fact_source_executable_smoke,
+    test_lmdb_fact_source_executable_smoke,
     test_streaming_foreign_results_executable_smoke,
     test_real_prolog_builtin_executable_smoke,
     test_real_prolog_multiclause_executable_smoke,


### PR DESCRIPTION
## Summary

This PR adds an optional LMDB-backed loading path for the WAM-C `WamFactSource`. It mirrors the existing TSV ownership model by eagerly loading LMDB key/value category-parent facts into the same edge storage used by TSV, so existing lookup and native-kernel registration code continues to work unchanged.

## What Changed

- Adds optional `WAM_C_ENABLE_LMDB` support in the WAM-C runtime header.
- Adds `wam_fact_source_load_lmdb`.
- Keeps LMDB disabled by default; callers opt in with `-DWAM_C_ENABLE_LMDB` and link with `-llmdb`.
- Loads UTF-8 LMDB key/value pairs into `WamFactSource`.
- Preserves the existing TSV fallback and `wam_fact_source_lookup_arg1` API.
- Adds a real LMDB executable smoke test with duplicate-key `MDB_DUPSORT` category-parent data.
- Updates `WAM_C_TARGET_NEXT_STEPS.md` to mark the LMDB FactSource foundation complete and move the next recommended branch to `feat/wam-c-kernel-detector-setup`.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `git diff --check`

## Follow-Up

The next WAM-C parity step is `feat/wam-c-kernel-detector-setup`, reusing the shared recursive-kernel detector to generate C registration stubs instead of relying on hand-wired native-kernel setup.
