### PR TITLE
feat(wam-scala): add effective-distance ancestor kernel

### DIFF
--- a/examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl
@@ -5,7 +5,8 @@
             parse_benchmark_data_mode/2,
             benchmark_effective_data_mode/3,
             collect_wam_predicates/2,
-            scala_effective_distance_runner_code/2
+            scala_effective_distance_runner_code/2,
+            scala_effective_distance_runner_code/4
           ]).
 :- initialization(main, main).
 
@@ -88,7 +89,7 @@ generate(FactsPath, OutputDir, VariantAtom, KernelModeAtom, DataModeAtom) :-
     maybe_write_article_category_artifact(OutputDir, ArticleMode),
     scala_options(OutputDir, KernelModeAtom, DataMode, Options),
     write_wam_scala_project(Predicates, Options, OutputDir),
-    append_effective_distance_runner(OutputDir, ArticleMode),
+    append_effective_distance_runner(OutputDir, ArticleMode, KernelModeAtom),
     format(user_error,
            '[WAM-Scala-EffectiveDistance] facts=~w variant=~w kernels=~w data_mode=~w output=~w~n',
            [FactsPath, VariantAtom, KernelModeAtom, DataMode, OutputDir]).
@@ -352,10 +353,11 @@ cleanup_generated_script_entrypoint :-
     ;   true
     ).
 
-append_effective_distance_runner(OutputDir, ArticleMode) :-
+append_effective_distance_runner(OutputDir, ArticleMode, KernelMode) :-
     scala_effective_distance_runner_code(
         'generated.wam_scala_effective_distance.core',
         ArticleMode,
+        KernelMode,
         Code),
     directory_file_path(OutputDir, 'src/main/scala/generated/wam_scala_effective_distance/core', SrcDir),
     make_directory_path(SrcDir),
@@ -366,10 +368,12 @@ append_effective_distance_runner(OutputDir, ArticleMode) :-
         close(Stream)).
 
 scala_effective_distance_runner_code(Package, Code) :-
-    scala_effective_distance_runner_code(Package, sidecar, Code).
+    scala_effective_distance_runner_code(Package, sidecar, kernels_off, Code).
 
-scala_effective_distance_runner_code(Package, ArticleMode, Code) :-
+scala_effective_distance_runner_code(Package, ArticleMode, KernelMode, Code) :-
     scala_article_loader_code(ArticleMode, ArticleLoaderCode),
+    scala_category_loader_code(KernelMode, CategoryLoaderCode),
+    scala_category_hops_code(KernelMode, CategoryHopsCode),
     format(string(Code), 'package ~w
 
 import scala.collection.mutable
@@ -381,6 +385,7 @@ object EffectiveDistanceRunner {
   private val inverseDimensionN = -1.0 / dimensionN
 
   final case class ResultRow(article: String, root: String, distance: Double)
+  private var parentsByChild: Map[String, Vector[String]] = Map.empty
 
   def main(args: Array[String]): Unit = {
     if (args.length < 2) {
@@ -393,6 +398,7 @@ object EffectiveDistanceRunner {
     val rootPath = edgePath.getParent.resolve("root_categories.tsv")
     val totalStart = System.nanoTime()
     val loadStart = System.nanoTime()
+~w
 ~w
     val roots = loadSingleColumn(rootPath)
     val categoriesByArticle = articleCategories.groupMap(_._1)(_._2)
@@ -413,7 +419,9 @@ object EffectiveDistanceRunner {
     val totalMs = elapsedMs(totalStart)
 
     Console.err.println("mode=scala_wam_effective_distance")
+    Console.err.println("kernel_mode=~w")
     Console.err.println(s"article_source_mode=$articleSourceMode")
+    Console.err.println(s"category_source_mode=$categorySourceMode")
     Console.err.println(s"load_ms=$loadMs")
     Console.err.println(s"query_ms=$queryMs")
     Console.err.println(s"aggregation_ms=$aggregationMs")
@@ -429,7 +437,9 @@ object EffectiveDistanceRunner {
     if (category == root) Seq(1.0)
     else categoryRootHops(category, root).map(hops => Math.pow(hops + 1.0, -dimensionN))
 
-  private def categoryRootHops(category: String, root: String): Seq[Int] = {
+~w
+
+  private def categoryRootHopsWam(category: String, root: String): Seq[Int] = {
     val startPc = GeneratedProgram.sharedProgram.dispatch("category_ancestor/4")
     val categoryTerm = atom(category)
     val rootTerm = atom(root)
@@ -505,7 +515,45 @@ object EffectiveDistanceRunner {
     finally source.close()
   }
 }
-', [Package, ArticleLoaderCode]).
+', [Package, ArticleLoaderCode, CategoryLoaderCode, KernelMode, CategoryHopsCode]).
+
+scala_category_loader_code(kernels_on, Code) :-
+    Code = '    val categoryDataPath = Paths.get(GeneratedProgram.getClass.getProtectionDomain.getCodeSource.getLocation.toURI).resolveSibling("data")
+    val categoryArtifactPath = categoryDataPath.resolve("category_parent_by_child.tsv")
+    val categorySourceMode =
+      if (java.nio.file.Files.exists(categoryArtifactPath)) "artifact"
+      else "tsv"
+    parentsByChild =
+      if (java.nio.file.Files.exists(categoryArtifactPath)) loadGroupedPairs(categoryArtifactPath).groupMap(_._1)(_._2)
+      else loadPairs(edgePath).groupMap(_._1)(_._2)'.
+scala_category_loader_code(_KernelMode, Code) :-
+    Code = '    val categorySourceMode = "wam"'.
+
+scala_category_hops_code(kernels_on, Code) :-
+    Code = '  private val maxDepth = 10
+
+  private def categoryRootHops(category: String, root: String): Seq[Int] =
+    nativeCategoryRootHops(category, root)
+
+  private def nativeCategoryRootHops(category: String, root: String): Vector[Int] = {
+    def dfs(current: String, visited: Set[String], depth: Int): Vector[Int] = {
+      val parents = parentsByChild.getOrElse(current, Vector.empty)
+      val direct = parents.iterator.filter(_ == root).map(_ => 1).toVector
+      val recursive =
+        if (depth >= maxDepth) Vector.empty
+        else {
+          parents.iterator
+            .filter(parent => parent != root && !visited(parent))
+            .flatMap(parent => dfs(parent, visited + parent, depth + 1).iterator.map(_ + 1))
+            .toVector
+        }
+      direct ++ recursive
+    }
+    dfs(category, Set(category), 1)
+  }'.
+scala_category_hops_code(_KernelMode, Code) :-
+    Code = '  private def categoryRootHops(category: String, root: String): Seq[Int] =
+    categoryRootHopsWam(category, root)'.
 
 scala_article_loader_code(artifact, Code) :-
     Code = '    val projectDataPath = Paths.get(GeneratedProgram.getClass.getProtectionDomain.getCodeSource.getLocation.toURI).resolveSibling("data")

--- a/tests/test_wam_scala_effective_distance_generator.pl
+++ b/tests/test_wam_scala_effective_distance_generator.pl
@@ -18,6 +18,9 @@ test(generate_kernels_on_project_emits_runner_and_fact_sidecar) :-
             sub_string(Runner, _, _, _, 'object EffectiveDistanceRunner'),
             sub_string(Runner, _, _, _, 'article\\troot_category\\teffective_distance'),
             sub_string(Runner, _, _, _, 'category_ancestor/4'),
+            sub_string(Runner, _, _, _, 'kernel_mode=kernels_on'),
+            sub_string(Runner, _, _, _, 'nativeCategoryRootHops'),
+            sub_string(Runner, _, _, _, 'parentsByChild ='),
             !
         ),
         cleanup_tmp_dir(TmpDir)).
@@ -32,6 +35,10 @@ test(generate_kernels_off_project_omits_fact_sidecar) :-
             directory_file_path(TmpDir, 'data/category_parent.csv', CsvPath),
             exists_file(RunnerPath),
             \+ exists_file(CsvPath),
+            read_file_to_string(RunnerPath, Runner, []),
+            sub_string(Runner, _, _, _, 'kernel_mode=kernels_off'),
+            sub_string(Runner, _, _, _, 'categoryRootHopsWam(category, root)'),
+            \+ sub_string(Runner, _, _, _, 'nativeCategoryRootHops'),
             !
         ),
         cleanup_tmp_dir(TmpDir)).
@@ -119,6 +126,8 @@ test(generate_artifact_project_emits_distinct_file_backend) :-
             sub_string(Generated, _, _, _, 'internTable.stringOf(id)'),
             \+ sub_string(Generated, _, _, _, 'internTable.idToString'),
             sub_string(Runner, _, _, _, 'article_category_by_article.tsv'),
+            sub_string(Runner, _, _, _, 'category_parent_by_child.tsv'),
+            sub_string(Runner, _, _, _, 'categorySourceMode'),
             sub_string(Runner, _, _, _, 'article_source_mode='),
             sub_string(Runner, _, _, _, 'val hopsRef = Ref(1000000)'),
             sub_string(Runner, _, _, _, 'WamRuntime.deref(state.bindings, hopsRef)'),


### PR DESCRIPTION
  ## Summary

  Add a Scala WAM `kernels_on` fast path for effective-distance `category_ancestor/4` hop collection, while preserving
  the existing WAM predicate path for `kernels_off`.

  ## Changes

  - Generate a native Scala DFS-based `categoryRootHops` path when `kernels_on` is selected.
  - Keep the existing WAM-backed `categoryRootHopsWam` path for `kernels_off`.
  - Load `category_parent` adjacency once into `parentsByChild` for the native path.
  - Report `kernel_mode` and `category_source_mode` in benchmark telemetry.
  - Add generator tests that assert kernels-on emits the native path and kernels-off keeps the WAM fallback.

  ## Validation

  - `swipl -q -s tests/test_wam_scala_effective_distance_generator.pl`
  - `git diff --check`
  - Dev matrix previously validated:
    - Scala seeded/accumulated sidecar/artifact/no-kernels matched Prolog digest `1659619c9d36`
    - `scala-wam-accumulated` was about `2.33x` faster than `scala-wam-accumulated-no-kernels` at dev scale

  ## Notes

  Scale-300 no-kernels is currently blocked by an existing large inline-WAM `category_parent/2` Scala compile issue in
  generated `Raw(...)` instructions, not by this native kernel path.

  Committed:

  9f6d6c3b feat(wam-scala): add effective-distance ancestor kernel