### PR TITLE
bench(wam-elixir): add reusable large-scale LMDB preparation

### DIFF
--- a/docs/proposals/wam_elixir_lmdb_int_id_factsource.md
+++ b/docs/proposals/wam_elixir_lmdb_int_id_factsource.md
@@ -274,6 +274,19 @@ for the original Lmdb adaptor.
   checked-in fixture today (`10k`), int-tuple still wins locally
   (`4.270s` vs `14.160s`, same output hash), so the next measurement
   needs a generated or checked-in 50k-adjacent fixture.
+- [x] Add reusable large-scale preparation lifecycle. The benchmark
+  harness now accepts `--build-root` plus `--prepare-only`, and
+  `wam-elixir-lmdb-int-ids` reuses an existing `lmdb_int_ids/data.mdb`
+  instead of recreating it. The helper
+  `examples/benchmark/prepare_effective_distance_large_scales.py`
+  mirrors the Haskell `100k_cats` shape: it can generate `50k_cats`
+  and `100k_cats` from `simplewiki_categories.db`, then prebuild the
+  Elixir int-tuple and LMDB runners/artifacts.
+- [ ] Run the prepared large-scale matrix once the SimpleWiki DB or
+  generated fixtures are available locally:
+  `python3 examples/benchmark/prepare_effective_distance_large_scales.py --scales 50k_cats,100k_cats`
+  followed by
+  `python3 examples/benchmark/benchmark_effective_distance.py --scales 50k_cats,100k_cats --targets wam-elixir-int-tuple,wam-elixir-lmdb-int-ids,haskell-wam-accumulated,wam-rust-accumulated --build-root output/effective-distance-large --repetitions 3`.
 
 ## Driver-side recipe
 

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -107,6 +107,20 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Keep the temporary build directory for inspection",
     )
+    parser.add_argument(
+        "--build-root",
+        type=Path,
+        default=None,
+        help=(
+            "Persistent build/artifact directory. Use this for larger runs so "
+            "generated projects and Elixir LMDB artifacts can be reused."
+        ),
+    )
+    parser.add_argument(
+        "--prepare-only",
+        action="store_true",
+        help="Build target projects/artifacts, including reusable LMDB stores, but do not run timed benchmarks.",
+    )
     add_csharp_query_source_mode_arg(parser)
     return parser.parse_args()
 
@@ -349,26 +363,32 @@ defmodule LmdbSetup do
   alias WamRuntime.FactSource.LmdbIntIds
 
   def run(facts_dir) do
-    env_path = Path.join(__DIR__, "lmdb_int_ids")
-    File.rm_rf!(env_path)
-    {handle, env} = open_handle(env_path)
+    env_path = Path.expand("../lmdb_int_ids", __DIR__)
 
-    pairs =
-      facts_dir
-      |> Path.join("category_parent.tsv")
-      |> File.stream!()
-      |> Stream.drop(1)
-      |> Stream.map(fn line ->
-        [child, parent] = line |> String.trim() |> String.split("\t")
-        {child, parent}
-      end)
-      |> Enum.to_list()
+    if File.exists?(Path.join(env_path, "data.mdb")) do
+      IO.puts("lmdb_int_ids_reused=true")
+    else
+      File.rm_rf!(env_path)
+      {handle, env} = open_handle(env_path)
 
-    {:ok, result} = LmdbIntIds.ingest_pairs(handle, pairs)
-    Elmdb.env_close(env)
-    IO.puts("lmdb_int_ids_pairs=#{result.pairs_seen}")
-    IO.puts("lmdb_int_ids_new_ids=#{result.new_ids}")
-    IO.puts("lmdb_int_ids_next_id=#{result.next_id}")
+      pairs =
+        facts_dir
+        |> Path.join("category_parent.tsv")
+        |> File.stream!()
+        |> Stream.drop(1)
+        |> Stream.map(fn line ->
+          [child, parent] = line |> String.trim() |> String.split("\t")
+          {child, parent}
+        end)
+        |> Enum.to_list()
+
+      {:ok, result} = LmdbIntIds.ingest_pairs(handle, pairs)
+      Elmdb.env_close(env)
+      IO.puts("lmdb_int_ids_reused=false")
+      IO.puts("lmdb_int_ids_pairs=#{result.pairs_seen}")
+      IO.puts("lmdb_int_ids_new_ids=#{result.new_ids}")
+      IO.puts("lmdb_int_ids_next_id=#{result.next_id}")
+    end
   end
 
   defp open_handle(env_path) do
@@ -408,7 +428,7 @@ defmodule BenchDriver do
     article_cats = facts_dir |> Path.join("article_category.tsv") |> load_tsv()
     seed_cats = article_cats |> Enum.map(fn {_, c} -> c end) |> Enum.uniq() |> Enum.sort()
 
-    env_path = Path.join(__DIR__, "lmdb_int_ids")
+    env_path = Path.expand("../lmdb_int_ids", __DIR__)
     {handle, env} = open_handle(env_path)
     root_id = LmdbIntIds.lookup_id(handle, root)
 
@@ -919,7 +939,7 @@ def scale_sort_key(scale: str) -> tuple[int, str]:
     if not digits:
         return (10**9, scale)
     value = int(digits)
-    multiplier = 1000 if suffix.lower() == "k" else 1
+    multiplier = 1000 if suffix.lower().startswith("k") else 1
     return (value * multiplier, scale)
 
 
@@ -934,10 +954,14 @@ def main() -> int:
         return 1
 
     temp_ctx = None
-    temp_parent = benchmark_temp_parent()
-    if args.keep_temp:
+    if args.build_root is not None:
+        temp_root = args.build_root
+        temp_root.mkdir(parents=True, exist_ok=True)
+    elif args.keep_temp:
+        temp_parent = benchmark_temp_parent()
         temp_root = Path(tempfile.mkdtemp(prefix="uw-effective-distance-", dir=temp_parent))
     else:
+        temp_parent = benchmark_temp_parent()
         temp_ctx = tempfile.TemporaryDirectory(prefix="uw-effective-distance-", dir=temp_parent)
         temp_root = Path(temp_ctx.name)
     try:
@@ -1029,6 +1053,9 @@ def main() -> int:
                     command = build_prolog_effective_semantic(temp_root, scale)
                 else:
                     command = commands[target]
+                if args.prepare_only:
+                    print(f"prepared {scale}/{target}: {' '.join(command)}", file=sys.stderr)
+                    continue
                 if target == "csharp-query":
                     for source_mode in csharp_query_source_modes:
                         artifact_dir = temp_root / "artifacts" / target / source_mode / scale
@@ -1053,8 +1080,11 @@ def main() -> int:
                         )
                     )
 
-        print_summary(results)
-        if args.keep_temp:
+        if args.prepare_only:
+            print(f"prepared build directory: {temp_root}", file=sys.stderr)
+        else:
+            print_summary(results)
+        if args.keep_temp or args.build_root is not None:
             print(f"kept temp build directory: {temp_root}", file=sys.stderr)
         return 0
     finally:

--- a/examples/benchmark/prepare_effective_distance_large_scales.py
+++ b/examples/benchmark/prepare_effective_distance_large_scales.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Prepare larger effective-distance benchmark fixtures and reusable artifacts.
+
+This wrapper mirrors the Haskell scaling notes:
+
+- 50k_cats: full SimpleWiki category hierarchy, first 50k categories as seeds.
+- 100k_cats: full SimpleWiki category hierarchy, all content categories as seeds
+  (historically about 84k categories / 197k edges after filtering).
+
+It intentionally separates fixture/artifact preparation from timed benchmark
+runs. Use benchmark_effective_distance.py with --build-root and --prepare-only
+to compile runners and ingest reusable Elixir LMDB artifacts once.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+CATEGORY_ONLY_GENERATOR = ROOT / "examples" / "benchmark" / "generate_category_only_benchmark.py"
+BENCHMARK = ROOT / "examples" / "benchmark" / "benchmark_effective_distance.py"
+DEFAULT_DB_CANDIDATES = [
+    ROOT / "data" / "simplewiki" / "simplewiki_categories.db",
+    ROOT / "context" / "gemini" / "UnifyWeaver" / "data" / "simplewiki" / "simplewiki_categories.db",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scales",
+        default="50k_cats,100k_cats",
+        help="Comma-separated large fixtures to prepare: 50k_cats,100k_cats",
+    )
+    parser.add_argument("--db", type=Path, default=None, help="Path to simplewiki_categories.db")
+    parser.add_argument(
+        "--build-root",
+        type=Path,
+        default=ROOT / "output" / "effective-distance-large",
+        help="Persistent benchmark build/artifact root",
+    )
+    parser.add_argument(
+        "--targets",
+        default="wam-elixir-int-tuple,wam-elixir-lmdb-int-ids",
+        help="Targets to prepare with benchmark_effective_distance.py --prepare-only",
+    )
+    parser.add_argument(
+        "--skip-fixtures",
+        action="store_true",
+        help="Only prepare target artifacts; assume fixture directories already exist.",
+    )
+    return parser.parse_args()
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(cmd, cwd=ROOT, check=True)
+
+
+def resolve_db(path: Path | None) -> Path:
+    if path is not None:
+        if path.exists():
+            return path
+        raise FileNotFoundError(path)
+    for candidate in DEFAULT_DB_CANDIDATES:
+        if candidate.exists():
+            return candidate
+    searched = "\n".join(f"  - {candidate}" for candidate in DEFAULT_DB_CANDIDATES)
+    raise FileNotFoundError(
+        "simplewiki_categories.db not found. Run examples/benchmark/parse_simplewiki_dump.py "
+        "or pass --db.\nSearched:\n" + searched
+    )
+
+
+def scale_seed_cap(scale: str) -> int | None:
+    if scale == "50k_cats":
+        return 50_000
+    if scale == "100k_cats":
+        return None
+    raise ValueError(f"unsupported scale: {scale}")
+
+
+def prepare_fixture(scale: str, db_path: Path) -> None:
+    output_dir = BENCH_DIR / scale
+    if (output_dir / "category_parent.tsv").exists() and (output_dir / "facts.pl").exists():
+        print(f"[fixture] reuse {output_dir}", file=sys.stderr)
+        return
+    cmd = [
+        sys.executable,
+        str(CATEGORY_ONLY_GENERATOR),
+        "--output",
+        str(output_dir),
+        "--db",
+        str(db_path),
+    ]
+    cap = scale_seed_cap(scale)
+    if cap is not None:
+        cmd.extend(["--max-seeds", str(cap)])
+    print(f"[fixture] generate {scale}", file=sys.stderr)
+    run(cmd)
+
+
+def prepare_artifacts(scales: list[str], targets: str, build_root: Path) -> None:
+    run(
+        [
+            sys.executable,
+            str(BENCHMARK),
+            "--scales",
+            ",".join(scales),
+            "--targets",
+            targets,
+            "--repetitions",
+            "1",
+            "--build-root",
+            str(build_root),
+            "--prepare-only",
+        ]
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    if not scales:
+        raise SystemExit("expected at least one scale")
+    if not args.skip_fixtures:
+        db_path = resolve_db(args.db)
+        for scale in scales:
+            prepare_fixture(scale, db_path)
+    prepare_artifacts(scales, args.targets, args.build_root)
+    print(f"prepared large-scale artifacts under {args.build_root}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add `--build-root` and `--prepare-only` to `benchmark_effective_distance.py` so larger benchmark runs can reuse generated projects and artifacts instead of rebuilding from a temporary directory.
- Make the WAM-Elixir LMDB int-id setup idempotent: if `lmdb_int_ids/data.mdb` already exists, setup skips ingestion and reuses the artifact.
- Store the Elixir LMDB artifact at the generated project root instead of under `lib/`.
- Add `examples/benchmark/prepare_effective_distance_large_scales.py` to prepare Haskell-style `50k_cats` and `100k_cats` category-only fixtures from `simplewiki_categories.db`, then prebuild Elixir int-tuple and LMDB artifacts.
- Document the reusable preparation lifecycle and the next large-scale run commands in the Elixir LMDB int-id proposal.

## Validation

- `python3 -m py_compile examples/benchmark/benchmark_common.py examples/benchmark/benchmark_effective_distance.py examples/benchmark/prepare_effective_distance_large_scales.py`
- `python3 examples/benchmark/benchmark_effective_distance.py --scales dev --targets wam-elixir-lmdb-int-ids --repetitions 1 --build-root /tmp/uw-elixir-large-prep-smoke-root --prepare-only`
- Re-ran the same prepare command against the same build root to verify artifact reuse.
- `test -f /tmp/uw-elixir-large-prep-smoke-root/wam_elixir_lmdb_int_ids/dev/lmdb_int_ids/data.mdb`
- `python3 examples/benchmark/benchmark_effective_distance.py --scales dev --targets wam-elixir-lmdb-int-ids --repetitions 1 --build-root /tmp/uw-elixir-large-prep-smoke-root`
- `python3 examples/benchmark/prepare_effective_distance_large_scales.py --scales dev --skip-fixtures --targets wam-elixir-lmdb-int-ids --build-root /tmp/uw-elixir-large-wrapper-smoke`
- `git diff --check`

The persistent-root benchmark smoke produced the expected output hash:

```text
dev     wam-elixir-lmdb-int-ids 2.273   2.273   2.273   19      0213af7269e0
```

## Notes

This does not check in large generated fixtures. It adds the reproducible preparation path for `50k_cats` and `100k_cats` when `simplewiki_categories.db` is available. Full enwiki/1M-scale work remains separate because Haskell used a standalone enwiki LMDB DFS benchmark over a prebuilt streaming artifact, not the normal `data/benchmark/<scale>` effective-distance fixture shape.