### PR TITLE
feat(csharp-query): Centralize C# query graph benchmark source-mode auto policy

### DIFF
--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1536,7 +1536,7 @@ class Program
             Environment.Exit(1);
         }}
 
-        var sourceMode = configuredSourceMode == RelationSourceMode.Auto ? RelationSourceMode.Preload : configuredSourceMode;
+        var sourceMode = RelationSourceModePolicy.ResolveGraphBenchmarkMode(configuredSourceMode, "dependency-depth");
         var configuredProvider = new ConfiguredDelimitedRelationProvider(
             sourceMode,
             Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_ARTIFACT_DIR"));
@@ -2055,7 +2055,7 @@ class Program
             Environment.Exit(1);
         }}
 
-        var sourceMode = configuredSourceMode == RelationSourceMode.Auto ? RelationSourceMode.Preload : configuredSourceMode;
+        var sourceMode = RelationSourceModePolicy.ResolveGraphBenchmarkMode(configuredSourceMode, "dependency-longest-depth");
         var configuredProvider = new ConfiguredDelimitedRelationProvider(
             sourceMode,
             Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_ARTIFACT_DIR"));
@@ -2712,7 +2712,7 @@ class Program
             Environment.Exit(1);
         }}
 
-        var sourceMode = configuredSourceMode == RelationSourceMode.Auto ? RelationSourceMode.Preload : configuredSourceMode;
+        var sourceMode = RelationSourceModePolicy.ResolveGraphBenchmarkMode(configuredSourceMode, "category-influence");
         var configuredProvider = new ConfiguredDelimitedRelationProvider(
             sourceMode,
             Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_ARTIFACT_DIR"));
@@ -2899,7 +2899,7 @@ class Program
             Environment.Exit(1);
         }}
 
-        var sourceMode = configuredSourceMode == RelationSourceMode.Auto ? RelationSourceMode.Preload : configuredSourceMode;
+        var sourceMode = RelationSourceModePolicy.ResolveGraphBenchmarkMode(configuredSourceMode, "effective-distance");
         var configuredProvider = new ConfiguredDelimitedRelationProvider(
             sourceMode,
             Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_ARTIFACT_DIR"));
@@ -3078,7 +3078,7 @@ class Program
             Environment.Exit(1);
         }}
 
-        var sourceMode = configuredSourceMode == RelationSourceMode.Auto ? RelationSourceMode.Preload : configuredSourceMode;
+        var sourceMode = RelationSourceModePolicy.ResolveGraphBenchmarkMode(configuredSourceMode, "shortest-path");
         var configuredProvider = new ConfiguredDelimitedRelationProvider(
             sourceMode,
             Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_ARTIFACT_DIR"));
@@ -3268,7 +3268,7 @@ class Program
             Environment.Exit(1);
         }}
 
-        var sourceMode = configuredSourceMode == RelationSourceMode.Auto ? RelationSourceMode.Preload : configuredSourceMode;
+        var sourceMode = RelationSourceModePolicy.ResolveGraphBenchmarkMode(configuredSourceMode, "weighted-shortest-path");
         var configuredProvider = new ConfiguredDelimitedRelationProvider(
             sourceMode,
             Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_ARTIFACT_DIR"));

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -173,6 +173,27 @@ namespace UnifyWeaver.QueryRuntime
                 _ => RelationSourceMode.Preload,
             };
         }
+
+        public static RelationSourceMode ResolveGraphBenchmarkMode(
+            RelationSourceMode configuredMode,
+            string workload)
+        {
+            if (configuredMode != RelationSourceMode.Auto)
+            {
+                return configuredMode;
+            }
+
+            return workload switch
+            {
+                "category-influence" => RelationSourceMode.Preload,
+                "dependency-depth" => RelationSourceMode.Preload,
+                "dependency-longest-depth" => RelationSourceMode.Preload,
+                "effective-distance" => RelationSourceMode.Preload,
+                "shortest-path" => RelationSourceMode.Preload,
+                "weighted-shortest-path" => RelationSourceMode.Preload,
+                _ => RelationSourceMode.Preload,
+            };
+        }
     }
 
     public sealed class BinaryRelationArtifactManifest

--- a/tests/test_csharp_query_graph_source_mode_policy.py
+++ b/tests/test_csharp_query_graph_source_mode_policy.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
+
+from generate_pipeline import (  # noqa: E402
+    generate_csharp_query_category_influence,
+    generate_csharp_query_dependency_depth,
+    generate_csharp_query_dependency_longest_depth,
+    generate_csharp_query_effective_distance,
+    generate_csharp_query_shortest_path,
+    generate_csharp_query_weighted_shortest_path,
+)
+
+
+class CSharpQueryGraphSourceModePolicyTests(unittest.TestCase):
+    def test_graph_benchmark_generators_use_source_mode_policy_helper(self) -> None:
+        article_cats = [("Article", "Physics")]
+        category_parents = [("Physics", "Science")]
+        root_cats = ["Science"]
+        cases = [
+            (
+                "dependency-depth",
+                generate_csharp_query_dependency_depth(article_cats, category_parents, root_cats),
+            ),
+            (
+                "dependency-longest-depth",
+                generate_csharp_query_dependency_longest_depth(article_cats, category_parents, root_cats),
+            ),
+            (
+                "category-influence",
+                generate_csharp_query_category_influence(article_cats, category_parents, root_cats),
+            ),
+            (
+                "effective-distance",
+                generate_csharp_query_effective_distance(article_cats, category_parents, root_cats),
+            ),
+            (
+                "shortest-path",
+                generate_csharp_query_shortest_path(article_cats, category_parents, root_cats),
+            ),
+            (
+                "weighted-shortest-path",
+                generate_csharp_query_weighted_shortest_path(article_cats, category_parents, root_cats),
+            ),
+        ]
+
+        for workload, source in cases:
+            with self.subTest(workload=workload):
+                self.assertIn(
+                    f'RelationSourceModePolicy.ResolveGraphBenchmarkMode(configuredSourceMode, "{workload}")',
+                    source,
+                )
+                self.assertNotIn(
+                    "configuredSourceMode == RelationSourceMode.Auto ? RelationSourceMode.Preload : configuredSourceMode",
+                    source,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  Centralizes C# query graph benchmark `auto` source-mode resolution in `RelationSourceModePolicy`.

  Generated graph benchmark runners previously duplicated `auto -> preload` logic inline. This moves that decision
  behind a workload-aware runtime helper so future tuning can happen in one place while preserving current behavior.

  ## Changes

  - Add `RelationSourceModePolicy.ResolveGraphBenchmarkMode(configuredMode, workload)`.
  - Update six generated C# query graph benchmark runners to call the centralized helper.
  - Add generator tests covering all graph workloads.
  - Assert the old inline `configuredSourceMode == Auto ? Preload : configuredSourceMode` pattern does not return.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_graph_source_mode_policy.py tests/
  test_csharp_query_source_mode_sweep.py`
  - `python3 -m py_compile examples/benchmark/generate_pipeline.py tests/test_csharp_query_graph_source_mode_policy.py`
  - Live gated source-mode sweep for `category-influence,dependency-depth` at scale `300`
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
  - `git diff --check`