### PR TITLE
feat(wam-c): Detect WAM C category ancestor kernels

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,7 +4,7 @@ Status date: 2026-05-04
 
 Base verified locally:
 
-- `main` at `e2160c7e` (`Merge pull request #1840 from s243a/feat/wam-c-effective-distance-bench`)
+- `main` at `3a7bb595` (`Merge pull request #1852 from s243a/feat/wam-c-lmdb-fact-source`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 
 This file replaces the older implementation plan. The four original C follow-up
@@ -26,6 +26,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Streaming integer foreign-result foundation | Done | `WamIntResults`, `wam_int_results_push`, `wam_collect_category_ancestor_hops`, multi-path executable smoke |
 | Effective-distance benchmark generator | Done | `generate_wam_c_effective_distance_benchmark.pl`, TSV facts, `kernels_on`/`kernels_off`, generated C runner smoke |
 | LMDB-backed FactSource foundation | Done | Optional `WAM_C_ENABLE_LMDB`, `wam_fact_source_load_lmdb`, duplicate-key LMDB smoke, existing lookup/kernel registration reuse |
+| Shared kernel detector setup | Done | `detect_kernels/2`, `generate_setup_detected_kernels_c/2`, detected `category_ancestor/4` foreign trampoline project smoke |
 
 ## Current C Target Baseline
 
@@ -53,13 +54,16 @@ The C target is now a credible small WAM backend:
   facts.
 - Can eagerly load category-parent facts from LMDB into the same `WamFactSource`
   edge storage used by TSV, behind the optional `WAM_C_ENABLE_LMDB` build flag.
+- Can detect the shared `category_ancestor/4` recursive-kernel shape and emit
+  C startup registration plus a `call_foreign` trampoline for generated
+  projects.
 - Has executable smokes for generated runtime, cross-predicate calls,
   foreign calls, native category ancestor, file-backed facts, streaming native
   results, real multi-clause predicates, structure indexing, `is_list/1`, and
   `=/2`.
 
 The main limitation is not core WAM execution anymore. It is hybrid-WAM
-infrastructure: C lacks lowered/native helper integration, LMDB, and benchmark
+infrastructure: C lacks lowered/native helper integration and full benchmark
 wiring that Haskell and Rust already have.
 
 ## Feature Parity Matrix
@@ -80,8 +84,8 @@ missing important target features; `Missing` = no comparable C path yet.
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
 | Negation / control builtins | Partial | Broader | Broader | C likely needs explicit tests for `\+/1`, cut interactions, and if-then-else lowering. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
-| Native recursive kernels | Partial | Done | Done | C has `category_ancestor/4` all-hop collection; add detector-driven setup later. |
-| Shared kernel detector integration | Missing | Done | Done | Reuse `recursive_kernel_detection.pl`; generate C registration stubs. |
+| Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup and all-hop collection; add more kernel kinds only after runtime support exists. |
+| Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`; broaden as more native C kernels land. |
 | Lowered/native helper functions | Missing | Done | Done | Consider after foreign kernels; C can lower simple fact-only or deterministic predicates. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts; next gap is generated benchmark wiring and larger artifact layout support. |
@@ -92,17 +96,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-kernel-detector-setup`
-
-Goal: connect the C target to the shared recursive-kernel detector.
-
-Scope:
-
-- Reuse `recursive_kernel_detection.pl`.
-- Generate C registration stubs for `category_ancestor/4`.
-- Keep the hand-registration runtime helpers as the low-level API.
-
-### 2. `feat/wam-c-effective-distance-matrix`
+### 1. `feat/wam-c-effective-distance-matrix`
 
 Goal: make C visible in the standard effective-distance benchmark matrix.
 
@@ -113,7 +107,7 @@ Scope:
 - Compare `kernels_on` and `kernels_off` outputs on shared small datasets
   before scaling up.
 
-### 3. `feat/wam-c-lmdb-effective-distance-wiring`
+### 2. `feat/wam-c-lmdb-effective-distance-wiring`
 
 Goal: let the generated C effective-distance harness choose TSV or LMDB fact
 storage.
@@ -124,6 +118,16 @@ Scope:
 - Keep `facts_tsv` as the dependency-free default.
 - Compile LMDB mode with `-DWAM_C_ENABLE_LMDB -llmdb`.
 - Validate duplicate-key category-parent artifacts before scaling up.
+
+### 3. `feat/wam-c-classic-program-e2e`
+
+Goal: broaden C executable coverage with classic recursive programs.
+
+Scope:
+
+- Add Fibonacci/Ackermann-style generated executable smokes.
+- Stress retry/trust, arithmetic comparisons, and recursive calls.
+- Keep the suite small enough for routine local runs.
 
 ### 4. `perf/wam-c-pack-instruction`
 
@@ -141,8 +145,9 @@ or cache behavior becomes a real bottleneck.
 
 ## Suggested Immediate Next Step
 
-Start with `feat/wam-c-kernel-detector-setup`.
+Start with `feat/wam-c-effective-distance-matrix`.
 
-The C target now has hand-registered native kernels plus TSV and optional LMDB
-fact loading. The next parity gap is removing the hand-wiring by reusing the
-shared recursive-kernel detector to generate C registration stubs.
+The C target now has the pieces needed by the small benchmark path: detected
+native `category_ancestor/4`, all-hop collection, TSV facts, optional LMDB fact
+loading, and a generated effective-distance runner. The next parity gap is
+making C visible in the shared effective-distance comparison scripts.

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -19,16 +19,22 @@
     compile_wam_predicate_to_c/4,     % +Pred/Arity, +WamCode, +Options, -CCode
     wam_instruction_to_c_literal/2,   % +WamInstr, -CCode
     wam_instruction_to_c_literal/3,   % +WamInstr, +LabelMap, -CCode
+    detect_kernels/2,                 % +Predicates, -DetectedKernels
+    generate_setup_detected_kernels_c/2, % +DetectedKernels, -CCode
     write_wam_c_project/3             % +Predicates, +Options, +ProjectDir
 ]).
 
 :- use_module(library(lists)).
 :- use_module(library(option)).
+:- use_module(library(pairs), [pairs_keys/2]).
 
 :- use_module(library(filesex), [make_directory_path/1, directory_file_path/3]).
 :- use_module('../core/template_system').
 :- use_module('../bindings/c_wam_bindings').
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../core/recursive_kernel_detection', [
+    detect_recursive_kernel/4
+]).
 
 % ============================================================================
 % PHASE 4: Hybrid Module Assembly
@@ -38,15 +44,21 @@
 %  Generates a full C project for the given predicates.
 write_wam_c_project(Predicates, Options, ProjectDir) :-
     make_directory_path(ProjectDir),
+    detect_kernels_for_options(Predicates, Options, DetectedKernels),
     % Generate runtime .c and .h files
     compile_wam_runtime_to_c(Options, RuntimeCode),
     directory_file_path(ProjectDir, 'wam_runtime.c', RuntimePath),
     write_file(RuntimePath, RuntimeCode),
 
     % Compile predicates and generate lib.c
-    compile_predicates_for_project(Predicates, Options, PredicatesCode),
+    pairs_keys(DetectedKernels, DetectedKeys),
+    generate_setup_detected_kernels_c(DetectedKernels, SetupKernelCode),
+    compile_predicates_for_project(Predicates, [detected_kernel_keys(DetectedKeys)|Options],
+                                   PredicatesCode),
+    format(atom(LibCode), '#include "wam_runtime.h"~n~n~w~n~n~w',
+           [SetupKernelCode, PredicatesCode]),
     directory_file_path(ProjectDir, 'lib.c', LibPath),
-    write_file(LibPath, PredicatesCode),
+    write_file(LibPath, LibCode),
 
     format('WAM C project created at: ~w~n', [ProjectDir]).
 
@@ -62,7 +74,13 @@ write_file(Path, Content) :-
 compile_predicates_for_project([], _, "").
 compile_predicates_for_project([PredIndicator|Rest], Options, Code) :-
     predicate_indicator_parts(PredIndicator, Module, Pred, Arity),
-    (   wam_target:compile_predicate_to_wam(Module:Pred/Arity, Options, WamCode)
+    format(atom(Key), '~w/~w', [Pred, Arity]),
+    option(detected_kernel_keys(DetectedKeys), Options, []),
+    (   memberchk(Key, DetectedKeys)
+    ->  format(atom(WamCode), '~w/~w:\n    call_foreign ~w, ~w\n    proceed',
+               [Pred, Arity, Key, Arity]),
+        compile_wam_predicate_to_c(Module:Pred/Arity, WamCode, Options, PredCode)
+    ;   wam_target:compile_predicate_to_wam(Module:Pred/Arity, Options, WamCode)
     ->  compile_wam_predicate_to_c(Module:Pred/Arity, WamCode, Options, PredCode)
     ;   format(atom(PredCode), '// ~w/~w: compilation failed', [Pred, Arity])
     ),
@@ -71,6 +89,62 @@ compile_predicates_for_project([PredIndicator|Rest], Options, Code) :-
 
 predicate_indicator_parts(Module:Pred/Arity, Module, Pred, Arity) :- !.
 predicate_indicator_parts(Pred/Arity, user, Pred, Arity).
+
+detect_kernels_for_options(Predicates, Options, DetectedKernels) :-
+    (   option(no_kernels(true), Options)
+    ->  DetectedKernels = [],
+        format(user_error, '[WAM-C] kernel detection suppressed~n', [])
+    ;   detect_kernels(Predicates, DetectedKernels),
+        (   DetectedKernels \= []
+        ->  pairs_keys(DetectedKernels, DetectedKeys),
+            format(user_error, '[WAM-C] detected kernels: ~w~n', [DetectedKeys])
+        ;   true
+        )
+    ).
+
+%% detect_kernels(+Predicates, -DetectedKernels)
+%  Run the shared recursive-kernel detector over project predicates.
+detect_kernels([], []).
+detect_kernels([PI|Rest], Kernels) :-
+    predicate_indicator_parts(PI, _Module, Pred, Arity),
+    functor(Head, Pred, Arity),
+    findall(Head-Body, user:clause(Head, Body), Clauses),
+    (   Clauses \= [],
+        detect_recursive_kernel(Pred, Arity, Clauses, Kernel),
+        wam_c_supported_kernel(Kernel)
+    ->  format(atom(Key), '~w/~w', [Pred, Arity]),
+        Kernels = [Key-Kernel|RestKernels]
+    ;   Kernels = RestKernels
+    ),
+    detect_kernels(Rest, RestKernels).
+
+wam_c_supported_kernel(recursive_kernel(category_ancestor, _Pred, _ConfigOps)).
+
+%% generate_setup_detected_kernels_c(+DetectedKernels, -CCode)
+%  Emit C startup wiring for detected kernels. This function registers only
+%  native handlers; callers still decide when to load/register fact sources.
+generate_setup_detected_kernels_c([], Code) :- !,
+    Code = 'void setup_detected_wam_c_kernels(WamState* state) {\n    (void)state;\n}'.
+generate_setup_detected_kernels_c(DetectedKernels, Code) :-
+    maplist(wam_c_kernel_registration_line, DetectedKernels, Lines),
+    atomic_list_concat(Lines, '\n', Body),
+    format(atom(Code),
+           'void setup_detected_wam_c_kernels(WamState* state) {\n~w\n}',
+           [Body]).
+
+wam_c_kernel_registration_line(Key-recursive_kernel(category_ancestor, _Pred, ConfigOps), Line) :-
+    wam_c_kernel_max_depth(ConfigOps, MaxDepth),
+    format(atom(Line),
+           '    wam_register_category_ancestor_kernel(state, "~w", ~w);',
+           [Key, MaxDepth]).
+
+wam_c_kernel_max_depth(ConfigOps, MaxDepth) :-
+    (   member(max_depth(MaxDepth0), ConfigOps),
+        integer(MaxDepth0),
+        MaxDepth0 > 0
+    ->  MaxDepth = MaxDepth0
+    ;   MaxDepth = 10
+    ).
 
 % ============================================================================
 % PHASE 2: WAM instructions -> C Struct Literals

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -4,6 +4,8 @@
 
 :- use_module('../src/unifyweaver/targets/wam_c_target').
 :- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module(library(filesex), [directory_file_path/3]).
+:- use_module(library(readutil), [read_file_to_string/3]).
 
 :- dynamic test_failed/0.
 :- dynamic tests_already_ran/0.
@@ -272,6 +274,39 @@ test_streaming_foreign_results_generation :-
     ;   fail_test(Test, 'streaming foreign result helpers missing')
     ).
 
+test_kernel_detector_setup_generation :-
+    Test = 'WAM-C: shared kernel detector emits category_ancestor setup',
+    setup_wam_c_detector_category_ancestor,
+    (   detect_kernels([user:category_ancestor/4], Detected),
+        Detected = ['category_ancestor/4'-_Kernel],
+        generate_setup_detected_kernels_c(Detected, SetupCode),
+        sub_atom(SetupCode, _, _, _, 'setup_detected_wam_c_kernels'),
+        sub_atom(SetupCode, _, _, _, 'wam_register_category_ancestor_kernel(state, "category_ancestor/4", 10)')
+    ->  cleanup_wam_c_detector_category_ancestor,
+        pass(Test)
+    ;   cleanup_wam_c_detector_category_ancestor,
+        fail_test(Test, 'detected kernel setup missing')
+    ).
+
+test_kernel_detector_project_generation :-
+    Test = 'WAM-C: project generation lowers detected kernel to foreign trampoline',
+    setup_wam_c_detector_category_ancestor,
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(ProjectDir), '/tmp/unifyweaver_wam_c_kernel_detector_project_~w', [Stamp]),
+    (   write_wam_c_project([user:category_ancestor/4], [], ProjectDir),
+        directory_file_path(ProjectDir, 'lib.c', LibPath),
+        read_file_to_string(LibPath, LibCode, []),
+        sub_string(LibCode, _, _, _, '#include "wam_runtime.h"'),
+        sub_string(LibCode, _, _, _, 'setup_detected_wam_c_kernels'),
+        sub_string(LibCode, _, _, _, 'wam_register_category_ancestor_kernel(state, "category_ancestor/4", 10)'),
+        sub_string(LibCode, _, _, _, 'INSTR_CALL_FOREIGN')
+    ->  cleanup_wam_c_detector_category_ancestor,
+        pass(Test)
+    ;   cleanup_wam_c_detector_category_ancestor,
+        fail_test(Test, 'generated project did not lower detected kernel')
+    ).
+
 test_unsupported_instruction_fails_loudly :-
     Test = 'WAM-C: unsupported instructions fail loudly',
     BadWamCode = 'foo/1:\n    unknown_opcode A1\n    proceed',
@@ -392,6 +427,16 @@ test_streaming_foreign_results_executable_smoke :-
     ->  (   run_streaming_foreign_results_executable_smoke
         ->  pass(Test)
         ;   fail_test(Test, 'streaming category_ancestor result executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
+test_kernel_detector_executable_smoke :-
+    Test = 'WAM-C: detected category_ancestor executable smoke',
+    (   gcc_available
+    ->  (   run_kernel_detector_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'detected category_ancestor executable failed')
         )
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
@@ -594,6 +639,25 @@ run_lmdb_fact_source_executable_smoke :-
     compile_c_smoke_lmdb(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
 
+run_kernel_detector_executable_smoke :-
+    setup_wam_c_detector_category_ancestor,
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(ProjectDir), '/tmp/unifyweaver_wam_c_kernel_detector_smoke_~w', [Stamp]),
+    directory_file_path(ProjectDir, 'wam_runtime.c', RuntimePath),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    directory_file_path(ProjectDir, 'main.c', MainPath),
+    directory_file_path(ProjectDir, 'wam_c_kernel_detector_smoke', ExePath),
+    (   write_wam_c_project([user:category_ancestor/4], [], ProjectDir),
+        wam_c_kernel_detector_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, LibPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_detector_category_ancestor
+    ;   cleanup_wam_c_detector_category_ancestor,
+        fail
+    ).
+
 run_streaming_foreign_results_executable_smoke :-
     WamCode = 'category_ancestor/4:\n    call_foreign category_ancestor/4, 4\n    proceed',
     compile_wam_predicate_to_c(user:category_ancestor/4, WamCode, [], PredCode),
@@ -788,6 +852,26 @@ compile_c_smoke_lmdb(RuntimePath, PredPath, MainPath, ExePath) :-
     ;   format(user_error, 'gcc lmdb smoke failed with status ~w~n', [Status]),
         fail
     ).
+
+setup_wam_c_detector_category_ancestor :-
+    cleanup_wam_c_detector_category_ancestor,
+    assertz(user:max_depth(10)),
+    assertz((user:category_ancestor(Cat, Parent, 1, Visited) :-
+        category_parent(Cat, Parent),
+        \+ member(Parent, Visited))),
+    assertz((user:category_ancestor(Cat, Ancestor, Hops, Visited) :-
+        max_depth(MaxD),
+        length(Visited, D),
+        D < MaxD,
+        !,
+        category_parent(Cat, Mid),
+        \+ member(Mid, Visited),
+        category_ancestor(Mid, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1)).
+
+cleanup_wam_c_detector_category_ancestor :-
+    retractall(user:max_depth(_)),
+    retractall(user:category_ancestor(_, _, _, _)).
 
 run_c_smoke(ExePath) :-
     format(atom(Cmd),
@@ -1011,6 +1095,48 @@ int main(void) {
     if (fail_rc != WAM_HALT) {
         wam_free_state(&state);
         return 30;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
+wam_c_kernel_detector_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_category_ancestor_4(WamState* state);
+void setup_detected_wam_c_kernels(WamState* state);
+
+static WamValue make_visited_singleton(WamState *state, const char *atom) {
+    WamValue list;
+    list.tag = VAL_LIST;
+    list.data.ref_addr = state->H;
+    state->H_array[state->H++] = val_atom(atom);
+    state->H_array[state->H++] = val_atom("[]");
+    return list;
+}
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_category_ancestor_4(&state);
+    setup_detected_wam_c_kernels(&state);
+
+    wam_register_category_parent(&state, "leaf", "mid");
+    wam_register_category_parent(&state, "mid", "root");
+
+    WamValue args[4] = {
+        val_atom("leaf"),
+        val_atom("root"),
+        val_unbound("Hops"),
+        make_visited_singleton(&state, "leaf")
+    };
+    int rc = wam_run_predicate(&state, "category_ancestor/4", args, 4);
+    if (rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 2) {
+        wam_free_state(&state);
+        return 10;
     }
 
     wam_free_state(&state);
@@ -1528,6 +1654,8 @@ run_tests_once :-
     test_category_ancestor_kernel_generation,
     test_fact_source_generation,
     test_streaming_foreign_results_generation,
+    test_kernel_detector_setup_generation,
+    test_kernel_detector_project_generation,
     test_unsupported_instruction_fails_loudly,
     test_no_zero_instruction_fallback,
     test_list_target_pc_emission,
@@ -1538,6 +1666,7 @@ run_tests_once :-
     test_category_ancestor_kernel_executable_smoke,
     test_fact_source_executable_smoke,
     test_lmdb_fact_source_executable_smoke,
+    test_kernel_detector_executable_smoke,
     test_streaming_foreign_results_executable_smoke,
     test_real_prolog_builtin_executable_smoke,
     test_real_prolog_multiclause_executable_smoke,


### PR DESCRIPTION
## Summary

This PR connects the WAM-C target to the shared recursive-kernel detector for the supported `category_ancestor/4` shape. Detected predicates now generate C startup registration and are lowered to a `call_foreign` trampoline instead of compiling the recursive Prolog body directly into generic WAM instructions.

## What Changed

- Adds `detect_kernels/2` for WAM-C using `recursive_kernel_detection.pl`.
- Adds `generate_setup_detected_kernels_c/2`.
- Emits `setup_detected_wam_c_kernels` for detected native kernel registration.
- Lowers detected `category_ancestor/4` predicates to `INSTR_CALL_FOREIGN`.
- Keeps the existing low-level runtime API:
  - `wam_register_category_ancestor_kernel`
  - `wam_register_category_parent`
  - `wam_register_category_parent_fact_source`
- Adds tests for:
  - shared detector setup generation
  - generated project lowering
  - executable detected-kernel smoke
- Updates `WAM_C_TARGET_NEXT_STEPS.md` and moves the next recommended branch to `feat/wam-c-effective-distance-matrix`.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `git diff --check`

## Follow-Up

The next WAM-C parity step is `feat/wam-c-effective-distance-matrix`, wiring the generated C effective-distance runner into the shared benchmark comparison scripts.
