### PR TITLE
feat(csharp-query): Report resolved C# query source modes in benchmark sweeps

### DIFF
--- a/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
+++ b/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
@@ -40,6 +40,7 @@ class SourceModeSummary:
     auto_vs_best: str
     output_agreement: str
     median_summary: str
+    resolved_source_mode_summary: str
     source_registration_summary: str
 
 
@@ -100,6 +101,7 @@ def parse_workloads(value: str) -> list[str]:
 def parse_runner_output(workload: str, output: str) -> list[SourceModeSummary]:
     medians: dict[str, dict[str, str]] = {}
     hashes: dict[str, dict[str, str]] = {}
+    resolved_source_modes: dict[str, dict[str, str]] = {}
     source_registrations: dict[str, dict[str, str]] = {}
     best_modes: dict[str, str] = {}
     auto_vs_best: dict[str, str] = {}
@@ -115,6 +117,10 @@ def parse_runner_output(workload: str, output: str) -> list[SourceModeSummary]:
             scale = parts[0]
             target = parts[1][:-len("-metrics")]
             source_mode = target.split(":", 1)[1]
+            metrics = parse_metric_tokens(parts[2])
+            resolved_mode = metrics.get("resolved_source_mode")
+            if resolved_mode:
+                resolved_source_modes.setdefault(scale, {})[source_mode] = resolved_mode
             registrations = summarize_source_registration_tokens(parts[2])
             if registrations:
                 source_registrations.setdefault(scale, {})[source_mode] = registrations
@@ -137,6 +143,10 @@ def parse_runner_output(workload: str, output: str) -> list[SourceModeSummary]:
             f"{mode}:{registrations}"
             for mode, registrations in sorted(source_registrations.get(scale, {}).items())
         )
+        resolved_summary = ",".join(
+            f"{mode}:{resolved}"
+            for mode, resolved in sorted(resolved_source_modes.get(scale, {}).items())
+        )
         summaries.append(
             SourceModeSummary(
                 workload=workload,
@@ -145,18 +155,28 @@ def parse_runner_output(workload: str, output: str) -> list[SourceModeSummary]:
                 auto_vs_best=auto_vs_best.get(scale, ""),
                 output_agreement=output_agreement,
                 median_summary=median_summary,
+                resolved_source_mode_summary=resolved_summary,
                 source_registration_summary=registration_summary,
             )
         )
     return summaries
 
 
-def summarize_source_registration_tokens(metrics: str) -> str:
-    registrations: list[str] = []
+def parse_metric_tokens(metrics: str) -> dict[str, str]:
+    parsed: dict[str, str] = {}
     for token in metrics.split():
-        if not token.startswith("source_registration_") or "=" not in token:
+        if "=" not in token:
             continue
         key, value = token.split("=", 1)
+        parsed[key] = value
+    return parsed
+
+
+def summarize_source_registration_tokens(metrics: str) -> str:
+    registrations: list[str] = []
+    for key, value in parse_metric_tokens(metrics).items():
+        if not key.startswith("source_registration_"):
+            continue
         registrations.append(f"{key[len('source_registration_'):]}={value}")
     return "|".join(sorted(registrations))
 
@@ -232,22 +252,24 @@ def run_workload(
 
 
 def print_tsv(summaries: list[SourceModeSummary]) -> None:
-    print("workload\tscale\tbest_source_mode\tauto_vs_best\toutput_agreement\tmedian_s_by_mode\tsource_registrations_by_mode")
+    print("workload\tscale\tbest_source_mode\tauto_vs_best\toutput_agreement\tmedian_s_by_mode\tresolved_source_modes_by_mode\tsource_registrations_by_mode")
     for summary in summaries:
         print(
             f"{summary.workload}\t{summary.scale}\t{summary.best_source_mode}\t"
             f"{summary.auto_vs_best}\t{summary.output_agreement}\t{summary.median_summary}\t"
+            f"{summary.resolved_source_mode_summary}\t"
             f"{summary.source_registration_summary}"
         )
 
 
 def print_markdown(summaries: list[SourceModeSummary]) -> None:
-    print("| Workload | Scale | Best source mode | Auto vs best | Outputs | Median seconds by mode | Source registrations by mode |")
-    print("| --- | --- | --- | ---: | --- | --- | --- |")
+    print("| Workload | Scale | Best source mode | Auto vs best | Outputs | Median seconds by mode | Resolved source modes by mode | Source registrations by mode |")
+    print("| --- | --- | --- | ---: | --- | --- | --- | --- |")
     for summary in summaries:
         print(
             f"| {summary.workload} | {summary.scale} | {summary.best_source_mode} | "
             f"{summary.auto_vs_best} | {summary.output_agreement} | `{summary.median_summary}` | "
+            f"`{summary.resolved_source_mode_summary}` | "
             f"`{summary.source_registration_summary}` |"
         )
 

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1608,6 +1608,8 @@ class Program
         Console.Error.WriteLine($"dag_retention_strategy_setting={{dagRetentionStrategy}}");
         PrintDagStrategies(trace);
         PrintBucketStrategies(trace);
+        Console.Error.WriteLine($"source_mode={{RelationSourceModePolicy.ToConfigValue(configuredSourceMode)}}");
+        Console.Error.WriteLine($"resolved_source_mode={{RelationSourceModePolicy.ToConfigValue(sourceMode)}}");
         PrintSourceRegistrations(configuredProvider);
         PrintDagPhases(trace);
     }}
@@ -2131,6 +2133,8 @@ class Program
         Console.Error.WriteLine($"dag_retention_strategy_setting={{dagRetentionStrategy}}");
         PrintDagStrategies(trace);
         PrintBucketStrategies(trace);
+        Console.Error.WriteLine($"source_mode={{RelationSourceModePolicy.ToConfigValue(configuredSourceMode)}}");
+        Console.Error.WriteLine($"resolved_source_mode={{RelationSourceModePolicy.ToConfigValue(sourceMode)}}");
         PrintSourceRegistrations(configuredProvider);
         PrintDagPhases(trace);
     }}
@@ -2792,6 +2796,8 @@ class Program
         Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintWeightSumStrategies(trace);
         PrintBucketStrategies(trace);
+        Console.Error.WriteLine($"source_mode={{RelationSourceModePolicy.ToConfigValue(configuredSourceMode)}}");
+        Console.Error.WriteLine($"resolved_source_mode={{RelationSourceModePolicy.ToConfigValue(sourceMode)}}");
         PrintSourceRegistrations(configuredProvider);
         PrintWeightSumPhases(trace);
     }}
@@ -2968,6 +2974,8 @@ class Program
         Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintWeightSumStrategies(trace);
         PrintBucketStrategies(trace);
+        Console.Error.WriteLine($"source_mode={{RelationSourceModePolicy.ToConfigValue(configuredSourceMode)}}");
+        Console.Error.WriteLine($"resolved_source_mode={{RelationSourceModePolicy.ToConfigValue(sourceMode)}}");
         PrintSourceRegistrations(configuredProvider);
         PrintWeightSumPhases(trace);
     }}
@@ -3146,6 +3154,8 @@ class Program
         Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintPathMinStrategies(trace);
         PrintBucketStrategies(trace);
+        Console.Error.WriteLine($"source_mode={{RelationSourceModePolicy.ToConfigValue(configuredSourceMode)}}");
+        Console.Error.WriteLine($"resolved_source_mode={{RelationSourceModePolicy.ToConfigValue(sourceMode)}}");
         PrintSourceRegistrations(configuredProvider);
         PrintPathMinPhases(trace);
     }}
@@ -3376,6 +3386,8 @@ class Program
         Console.Error.WriteLine($"support_retention_strategy_setting={{supportRetentionStrategy}}");
         PrintPathMinStrategies(trace);
         PrintBucketStrategies(trace);
+        Console.Error.WriteLine($"source_mode={{RelationSourceModePolicy.ToConfigValue(configuredSourceMode)}}");
+        Console.Error.WriteLine($"resolved_source_mode={{RelationSourceModePolicy.ToConfigValue(sourceMode)}}");
         PrintSourceRegistrations(configuredProvider);
         PrintPathMinPhases(trace);
         PrintPathMinMetrics(trace);

--- a/tests/test_csharp_query_graph_source_mode_policy.py
+++ b/tests/test_csharp_query_graph_source_mode_policy.py
@@ -57,6 +57,14 @@ class CSharpQueryGraphSourceModePolicyTests(unittest.TestCase):
                     f'RelationSourceModePolicy.ResolveGraphBenchmarkMode(configuredSourceMode, "{workload}")',
                     source,
                 )
+                self.assertIn(
+                    'Console.Error.WriteLine($"source_mode={RelationSourceModePolicy.ToConfigValue(configuredSourceMode)}");',
+                    source,
+                )
+                self.assertIn(
+                    'Console.Error.WriteLine($"resolved_source_mode={RelationSourceModePolicy.ToConfigValue(sourceMode)}");',
+                    source,
+                )
                 self.assertNotIn(
                     "configuredSourceMode == RelationSourceMode.Auto ? RelationSourceMode.Preload : configuredSourceMode",
                     source,

--- a/tests/test_csharp_query_source_mode_sweep.py
+++ b/tests/test_csharp_query_source_mode_sweep.py
@@ -24,10 +24,19 @@ class CSharpQuerySourceModeSweepTests(unittest.TestCase):
                 "300\tcsharp-query:auto\t0.467\t0.467\t0.467\t42\tsamehash",
                 "300\tcsharp-query:preload\t0.360\t0.360\t0.360\t42\tsamehash",
                 "300\tcsharp-query:artifact-prebuilt\t0.904\t0.904\t0.904\t42\tsamehash",
-                "300\tcsharp-query:auto-metrics\tsource_registration_preloaded_preload_arity2=2 other=ignored",
-                "300\tcsharp-query:preload-metrics\tsource_registration_preloaded_preload_arity2=2",
+                (
+                    "300\tcsharp-query:auto-metrics\t"
+                    "source_mode=auto resolved_source_mode=preload "
+                    "source_registration_preloaded_preload_arity2=2 other=ignored"
+                ),
+                (
+                    "300\tcsharp-query:preload-metrics\t"
+                    "source_mode=preload resolved_source_mode=preload "
+                    "source_registration_preloaded_preload_arity2=2"
+                ),
                 (
                     "300\tcsharp-query:artifact-prebuilt-metrics\t"
+                    "source_mode=artifact-prebuilt resolved_source_mode=artifact-prebuilt "
                     "source_registration_binary_artifact_artifact-prebuilt_arity2=2"
                 ),
                 "300\tcsharp_query_best_source_mode\tpreload",
@@ -47,6 +56,10 @@ class CSharpQuerySourceModeSweepTests(unittest.TestCase):
         self.assertEqual(
             summary.median_summary,
             "artifact-prebuilt:0.904,auto:0.467,preload:0.360",
+        )
+        self.assertEqual(
+            summary.resolved_source_mode_summary,
+            "artifact-prebuilt:artifact-prebuilt,auto:preload,preload:preload",
         )
         self.assertEqual(
             summary.source_registration_summary,


### PR DESCRIPTION
  ## Summary

  Adds explicit configured/resolved source-mode telemetry for generated C# graph query benchmarks and surfaces it in the
  source-mode sweep summary.

  This makes `auto` policy behavior directly visible as `resolved_source_modes_by_mode`, instead of requiring inference
  from source registration tokens.

  ## Changes

  - Emit `source_mode=...` from generated C# graph query runners.
  - Emit `resolved_source_mode=...` from generated C# graph query runners.
  - Add `resolved_source_modes_by_mode` to the C# source-mode sweep TSV/Markdown output.
  - Extend tests for generated telemetry and sweep parsing.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_graph_source_mode_policy.py tests/
  test_csharp_query_source_mode_sweep.py`
  - `python3 -m py_compile examples/benchmark/generate_pipeline.py examples/benchmark/
  benchmark_csharp_query_source_mode_sweep.py tests/test_csharp_query_graph_source_mode_policy.py tests/
  test_csharp_query_source_mode_sweep.py`
  - Live gated sweep for `category-influence,dependency-depth` at scale `300`
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
  - `git diff --check`