### PR TITLE
fix(wam-scala): keep large no-kernel benchmarks compilable

### DIFF
--- a/examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_scala_effective_distance_benchmark.pl
@@ -194,13 +194,16 @@ scala_options(OutputDir, kernels_on, DataMode, Options) :-
         intern_atoms(Atoms),
         scala_fact_sources([FactSource])
     ].
-scala_options(_OutputDir, kernels_off, _DataMode, Options) :-
+scala_options(OutputDir, kernels_off, DataMode, Options) :-
+    benchmark_effective_data_mode(category_parent, DataMode, ParentMode),
     benchmark_atoms(Atoms),
+    scala_fact_source_for_category_parent(OutputDir, ParentMode, FactSource),
     Options = [
         package('generated.wam_scala_effective_distance.core'),
         runtime_package('generated.wam_scala_effective_distance.core'),
         module_name('wam-scala-effective-distance'),
-        intern_atoms(Atoms)
+        intern_atoms(Atoms),
+        scala_fact_sources([FactSource])
     ].
 
 scala_fact_source_for_category_parent(_OutputDir, inline, source(category_parent/2, Tuples)) :-

--- a/src/unifyweaver/targets/wam_scala_target.pl
+++ b/src/unifyweaver/targets/wam_scala_target.pl
@@ -122,14 +122,19 @@ tokenize_wam_line(Line, Tokens) :-
 % tokenize_wam_chars(+Chars, +CurReversed, +TokensReversedAcc, +State, -Tokens)
 tokenize_wam_chars([], [], Acc, _, Tokens) :- !,
     reverse(Acc, Tokens).
-tokenize_wam_chars([], CurR, Acc, _, Tokens) :- !,
+tokenize_wam_chars([], CurR, Acc, outside, Tokens) :- !,
+    reverse(CurR, CurC), string_chars(T0, CurC),
+    strip_operand_comma(T0, T),
+    reverse([T|Acc], Tokens).
+tokenize_wam_chars([], CurR, Acc, inside, Tokens) :- !,
     reverse(CurR, CurC), string_chars(T, CurC),
     reverse([T|Acc], Tokens).
 tokenize_wam_chars([C|Rest], CurR, Acc, outside, Tokens) :-
-    (   (C == ' ' ; C == '\t' ; C == ',')
+    (   (C == ' ' ; C == '\t')
     ->  (   CurR == []
         ->  tokenize_wam_chars(Rest, [], Acc, outside, Tokens)
-        ;   reverse(CurR, CurC), string_chars(T, CurC),
+        ;   reverse(CurR, CurC), string_chars(T0, CurC),
+            strip_operand_comma(T0, T),
             tokenize_wam_chars(Rest, [], [T|Acc], outside, Tokens)
         )
     ;   C == '\''
@@ -141,11 +146,20 @@ tokenize_wam_chars([C|Rest], CurR, Acc, outside, Tokens) :-
     ;   tokenize_wam_chars(Rest, [C|CurR], Acc, outside, Tokens)
     ).
 tokenize_wam_chars([C|Rest], CurR, Acc, inside, Tokens) :-
-    (   C == '\''
+    (   C == '\\',
+        Rest = [Escaped|More]
+    ->  tokenize_wam_chars(More, [Escaped|CurR], Acc, inside, Tokens)
+    ;   C == '\''
     ->  reverse(CurR, CurC), string_chars(T, CurC),
         tokenize_wam_chars(Rest, [], [T|Acc], outside, Tokens)
     ;   tokenize_wam_chars(Rest, [C|CurR], Acc, inside, Tokens)
     ).
+
+strip_operand_comma(Token0, Token) :-
+    sub_string(Token0, _, 1, 0, ","),
+    !,
+    sub_string(Token0, 0, _, 1, Token).
+strip_operand_comma(Token, Token).
 
 % --- Control instructions ---
 % The WAM emitter produces both:
@@ -291,7 +305,8 @@ wam_parts_to_scala(["call_foreign", Pred, ArityStr], Lit) :-
 
 % --- Switch on constant ---
 wam_parts_to_scala(["switch_on_constant" | Cases], Lit) :-
-    parse_switch_cases(Cases, CaseLits),
+    normalize_switch_case_tokens(Cases, NormalizedCases),
+    parse_switch_cases(NormalizedCases, CaseLits),
     atomic_list_concat(CaseLits, ', ', CasesStr),
     format(string(Lit), 'SwitchOnConstant(Array(~w))', [CasesStr]).
 
@@ -327,17 +342,30 @@ wam_parts_to_scala(["end_aggregate", TemplateReg], Lit) :-
 % --- Fallback ---
 wam_parts_to_scala(Parts, Lit) :-
     atomic_list_concat(Parts, ' ', Text),
-    format(string(Lit), 'Raw("~w")', [Text]).
+    scala_string_literal(Text, TextLit),
+    format(string(Lit), 'Raw(~w)', [TextLit]).
 
 %% parse_switch_cases(+Tokens, -CaseLiterals)
 %  Parses switch_on_constant case list into SwitchCase constructor calls.
 %  Each token has the form "value:label" (e.g. "a:default", "b:L_x_2").
 parse_switch_cases([], []).
 parse_switch_cases([Token | Rest], [Lit | More]) :-
-    split_string(Token, ":", "", [ValStr, LabelStr | _]),
+    split_at_first_colon(Token, ValStr, LabelStr),
     intern_scala_atom(ValStr, AtomId),
     format(string(Lit), 'SwitchCase(Atom(~w), "~w")', [AtomId, LabelStr]),
     parse_switch_cases(Rest, More).
+
+normalize_switch_case_tokens([], []).
+normalize_switch_case_tokens([Value, Label0 | Rest], [Token | More]) :-
+    \+ sub_string(Value, _, 1, _, ":"),
+    sub_string(Label0, 0, 1, _, ":"),
+    !,
+    sub_string(Label0, 1, _, 0, Label),
+    string_concat(Value, ":", Prefix),
+    string_concat(Prefix, Label, Token),
+    normalize_switch_case_tokens(Rest, More).
+normalize_switch_case_tokens([Token | Rest], [Token | More]) :-
+    normalize_switch_case_tokens(Rest, More).
 
 %% strip_arity_suffix(+Pred, -Name)
 %  If Pred has the form "name/N", returns "name"; otherwise returns Pred unchanged.

--- a/tests/test_wam_scala_effective_distance_generator.pl
+++ b/tests/test_wam_scala_effective_distance_generator.pl
@@ -25,7 +25,7 @@ test(generate_kernels_on_project_emits_runner_and_fact_sidecar) :-
         ),
         cleanup_tmp_dir(TmpDir)).
 
-test(generate_kernels_off_project_omits_fact_sidecar) :-
+test(generate_kernels_off_project_uses_fact_sidecar_with_wam_runner) :-
     setup_call_cleanup(
         unique_tmp_dir('tmp_wam_scala_effective_distance_off', TmpDir),
         (   generate('data/benchmark/dev/facts.pl', TmpDir, accumulated, kernels_off),
@@ -34,7 +34,7 @@ test(generate_kernels_off_project_omits_fact_sidecar) :-
                                 RunnerPath),
             directory_file_path(TmpDir, 'data/category_parent.csv', CsvPath),
             exists_file(RunnerPath),
-            \+ exists_file(CsvPath),
+            exists_file(CsvPath),
             read_file_to_string(RunnerPath, Runner, []),
             sub_string(Runner, _, _, _, 'kernel_mode=kernels_off'),
             sub_string(Runner, _, _, _, 'categoryRootHopsWam(category, root)'),

--- a/tests/test_wam_scala_generator.pl
+++ b/tests/test_wam_scala_generator.pl
@@ -363,6 +363,31 @@ test(build_sbt_module_name) :-
         delete_directory_and_contents(TmpDir)
     )).
 
+test(escaped_quoted_atom_tokenizes_as_constant) :-
+    wam_scala_target:wam_line_to_scala_literal(
+        "get_constant 'People\\'s_Republic_of_China' A1",
+        Literal),
+    assertion(sub_string(Literal, _, _, _, 'GetConstant(Atom(')),
+    assertion(\+ sub_string(Literal, _, _, _, 'Raw(')).
+
+test(raw_fallback_escapes_scala_string) :-
+    wam_scala_target:wam_parts_to_scala(["unsupported", "People\\", "s"], Literal),
+    assertion(sub_string(Literal, _, _, _, 'Raw("unsupported People\\\\ s")')).
+
+test(switch_on_constant_preserves_comma_atoms) :-
+    wam_scala_target:wam_line_to_scala_literal(
+        "switch_on_constant 'Washington,_D.C. ':L_one plain:L_two",
+        Literal),
+    assertion(sub_string(Literal, _, _, _, 'SwitchOnConstant(Array(')),
+    assertion(\+ sub_string(Literal, _, _, _, 'Raw(')).
+
+test(switch_on_constant_rejoins_space_before_colon) :-
+    wam_scala_target:wam_line_to_scala_literal(
+        "switch_on_constant 'Academics_from_Washington,_D.C. ' :L_one plain:L_two",
+        Literal),
+    assertion(sub_string(Literal, _, _, _, 'SwitchOnConstant(Array(')),
+    assertion(\+ sub_string(Literal, _, _, _, 'Raw(')).
+
 % ------------------------------------------------------------------
 % Helpers
 % ------------------------------------------------------------------


### PR DESCRIPTION
  ## Summary

  Fix Scala WAM code generation so large fact-heavy no-kernel effective-distance benchmarks compile, while keeping the
  no-kernel path as WAM recursion over the existing fact-source seam.

  ## Changes

  - Preserve comma-containing atoms during WAM tokenization, such as `Washington,_D.C.`.
  - Handle escaped quotes inside quoted WAM atoms.
  - Rejoin split `switch_on_constant` cases where tokenization separates `Value` from `:Label`.
  - Escape fallback `Raw(...)` Scala string literals.
  - Route Scala effective-distance `kernels_off` through the same `category_parent/2` fact-source seam as `kernels_on`,
  avoiding huge inline fact bytecode while preserving WAM `category_ancestor/4` recursion.
  - Add focused tokenizer, switch parsing, and kernels-off generator regression tests.

  ## Validation

  - `swipl -q -s tests/test_wam_scala_generator.pl`
  - `swipl -q -s tests/test_wam_scala_effective_distance_generator.pl`
  - `git diff --check`
  - Scale-300 no-kernels generated Scala project compiles with `scalac`
  - Dev matrix matches Prolog for `scala-wam-accumulated` and `scala-wam-accumulated-no-kernels`

  ## Notes

  The full scale-300 no-kernels runtime remains too slow for a routine validation gate; this PR fixes the codegen/
  compile blocker rather than claiming scale-300 runtime parity.