### PR TITLE
bench(wam-c): Wire WAM C effective-distance LMDB facts

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -1,11 +1,15 @@
 # WAM C Target - Status And Next Steps
 
-Status date: 2026-05-04
+Status date: 2026-05-05
 
 Base verified locally:
 
-- `main` at `bb42243e` (`Merge pull request #1856 from s243a/feat/wam-c-kernel-detector-setup`)
+- `main` at `74d14fd5` (`Merge pull request #1858 from s243a/feat/wam-c-effective-distance-matrix`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
+
+Active branch:
+
+- `feat/wam-c-lmdb-effective-distance-wiring`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -28,6 +32,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | LMDB-backed FactSource foundation | Done | Optional `WAM_C_ENABLE_LMDB`, `wam_fact_source_load_lmdb`, duplicate-key LMDB smoke, existing lookup/kernel registration reuse |
 | Shared kernel detector setup | Done | `detect_kernels/2`, `generate_setup_detected_kernels_c/2`, detected `category_ancestor/4` foreign trampoline project smoke |
 | Effective-distance matrix wiring | Done | `c-wam-accumulated`, `c-wam-accumulated-no-kernels`, C kernel-pair delta, `dev` parity smoke against Prolog |
+| Effective-distance LMDB fact-storage wiring | In progress | `facts_lmdb` generator mode, LMDB seeder/validator, `c-wam-accumulated-lmdb` matrix targets, `dev` parity smoke against Prolog |
 
 ## Current C Target Baseline
 
@@ -58,8 +63,8 @@ The C target is now a credible small WAM backend:
 - Can detect the shared `category_ancestor/4` recursive-kernel shape and emit
   C startup registration plus a `call_foreign` trampoline for generated
   projects.
-- Is visible in the shared effective-distance benchmark matrix as a
-  `kernels_on` / `kernels_off` accumulated target pair.
+- Is visible in the shared effective-distance benchmark matrix as TSV and LMDB
+  `kernels_on` / `kernels_off` accumulated target pairs.
 - Has executable smokes for generated runtime, cross-predicate calls,
   foreign calls, native category ancestor, file-backed facts, streaming native
   results, real multi-clause predicates, structure indexing, `is_list/1`, and
@@ -91,27 +96,15 @@ missing important target features; `Missing` = no comparable C path yet.
 | Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`; broaden as more native C kernels land. |
 | Lowered/native helper functions | Missing | Done | Done | Consider after foreign kernels; C can lower simple fact-only or deterministic predicates. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
-| LMDB-backed facts | Partial | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts; next gap is generated benchmark wiring and larger artifact layout support. |
-| Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV `kernels_on`/`kernels_off`; next gap is LMDB mode and larger artifact layouts. |
+| LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
+| Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB `kernels_on`/`kernels_off`; next gap is larger artifact layouts. |
 | Classic-program e2e suite | Partial | Partial/Done | Partial/Done | C has targeted smokes; add Fibonacci/Ackermann-style suite like Scala/Elixir. |
 | Memory lifecycle | Partial | Runtime-managed | Runtime-managed | C has init/free; needs ASAN/Valgrind CI-style coverage for larger programs. |
 | Instruction layout efficiency | TODO | N/A | N/A | Pack `Instruction` fields into a tagged union if runtime footprint matters. |
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lmdb-effective-distance-wiring`
-
-Goal: let the generated C effective-distance harness choose TSV or LMDB fact
-storage.
-
-Scope:
-
-- Add generator options for `facts_tsv` / `facts_lmdb`.
-- Keep `facts_tsv` as the dependency-free default.
-- Compile LMDB mode with `-DWAM_C_ENABLE_LMDB -llmdb`.
-- Validate duplicate-key category-parent artifacts before scaling up.
-
-### 2. `feat/wam-c-classic-program-e2e`
+### 1. `feat/wam-c-classic-program-e2e`
 
 Goal: broaden C executable coverage with classic recursive programs.
 
@@ -121,7 +114,7 @@ Scope:
 - Stress retry/trust, arithmetic comparisons, and recursive calls.
 - Keep the suite small enough for routine local runs.
 
-### 3. `perf/wam-c-pack-instruction`
+### 2. `perf/wam-c-pack-instruction`
 
 Goal: reduce `Instruction` memory footprint.
 
@@ -137,8 +130,10 @@ or cache behavior becomes a real bottleneck.
 
 ## Suggested Immediate Next Step
 
-Start with `feat/wam-c-lmdb-effective-distance-wiring`.
+Finish `feat/wam-c-lmdb-effective-distance-wiring`, then start
+`feat/wam-c-classic-program-e2e`.
 
 The C target is now visible in the shared effective-distance matrix using TSV
-facts. The next parity gap is letting that same generated runner choose LMDB
-fact storage while keeping TSV as the dependency-free default.
+and LMDB facts. The next parity gap is broader classic recursive program
+coverage, which should stress retry/trust, arithmetic comparisons, and
+recursive calls outside the effective-distance benchmark shape.

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -111,6 +111,18 @@ def is_termux_environment() -> bool:
     return "com.termux" in prefix or "termux" in prefix.lower() or "TERMUX_VERSION" in os.environ
 
 
+def c_lmdb_toolchain_available() -> bool:
+    if shutil.which("pkg-config") is None:
+        return False
+    result = subprocess.run(
+        ["pkg-config", "--exists", "lmdb"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
 def scale_sort_key(scale: str) -> tuple[int, str]:
     digits = "".join(ch for ch in scale if ch.isdigit())
     suffix = "".join(ch for ch in scale if not ch.isdigit())
@@ -141,6 +153,10 @@ def available_targets(requested: list[str]) -> list[str]:
     c_wam_targets = {
         "c-wam-accumulated",
         "c-wam-accumulated-no-kernels",
+    }
+    c_wam_lmdb_targets = {
+        "c-wam-accumulated-lmdb",
+        "c-wam-accumulated-no-kernels-lmdb",
     }
     for target in requested:
         if target.startswith("csharp-") and shutil.which("dotnet") is None:
@@ -186,6 +202,12 @@ def available_targets(requested: list[str]) -> list[str]:
             continue
         if target in c_wam_targets and (shutil.which("swipl") is None or shutil.which("gcc") is None):
             print(f"skip {target}: swipl or gcc not found", file=sys.stderr)
+            continue
+        if target in c_wam_lmdb_targets and (shutil.which("swipl") is None or shutil.which("gcc") is None):
+            print(f"skip {target}: swipl or gcc not found", file=sys.stderr)
+            continue
+        if target in c_wam_lmdb_targets and not c_lmdb_toolchain_available():
+            print(f"skip {target}: LMDB C toolchain not found", file=sys.stderr)
             continue
         if target.startswith("clojure-wam-") and (shutil.which("swipl") is None or shutil.which("java") is None):
             print(f"skip {target}: swipl or java not found", file=sys.stderr)

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -255,9 +255,11 @@ def build_wam_go_effective_distance(root: Path, scale: str, kernel_mode: str) ->
     return [str(project_dir / "hybrid_ed_bench_go")]
 
 
-def build_wam_c_effective_distance(root: Path, scale: str, kernel_mode: str) -> list[str]:
+def build_wam_c_effective_distance(
+    root: Path, scale: str, kernel_mode: str, fact_storage: str = "facts_tsv"
+) -> list[str]:
     facts_path = require_file(BENCH_DIR / scale / "facts.pl")
-    project_dir = root / f"wam_c_{kernel_mode}" / scale
+    project_dir = root / f"wam_c_{kernel_mode}_{fact_storage}" / scale
     project_dir.mkdir(parents=True, exist_ok=True)
     run_command(
         [
@@ -269,6 +271,7 @@ def build_wam_c_effective_distance(root: Path, scale: str, kernel_mode: str) -> 
             str(facts_path),
             str(project_dir),
             kernel_mode,
+            fact_storage,
         ],
         cwd=ROOT,
     )
@@ -276,18 +279,37 @@ def build_wam_c_effective_distance(root: Path, scale: str, kernel_mode: str) -> 
     lib_path = project_dir / "lib.c"
     main_path = project_dir / "main.c"
     binary_path = project_dir / "wam_c_effective_distance"
+    compile_flags = ["-std=c11", "-Wall", "-Wextra"]
+    link_flags = ["-lm"]
+    if fact_storage == "facts_lmdb":
+        seeder_path = project_dir / "seed_category_parent_lmdb.c"
+        seeder_binary = project_dir / "seed_category_parent_lmdb"
+        run_command(
+            [
+                "gcc",
+                *compile_flags,
+                str(seeder_path),
+                "-llmdb",
+                "-o",
+                str(seeder_binary),
+            ],
+            cwd=ROOT,
+        )
+        run_command([str(seeder_binary)], cwd=project_dir)
+        compile_flags.append("-DWAM_C_ENABLE_LMDB")
+        link_flags.append("-llmdb")
+    elif fact_storage != "facts_tsv":
+        raise ValueError(f"unknown WAM-C fact storage mode: {fact_storage}")
     run_command(
         [
             "gcc",
-            "-std=c11",
-            "-Wall",
-            "-Wextra",
+            *compile_flags,
             "-I",
             str(ROOT / "src" / "unifyweaver" / "targets" / "wam_c_runtime"),
             str(runtime_path),
             str(lib_path),
             str(main_path),
-            "-lm",
+            *link_flags,
             "-o",
             str(binary_path),
         ],
@@ -877,6 +899,10 @@ def main() -> int:
                     command = build_wam_c_effective_distance(temp_root, scale, "kernels_on")
                 elif target == "c-wam-accumulated-no-kernels":
                     command = build_wam_c_effective_distance(temp_root, scale, "kernels_off")
+                elif target == "c-wam-accumulated-lmdb":
+                    command = build_wam_c_effective_distance(temp_root, scale, "kernels_on", "facts_lmdb")
+                elif target == "c-wam-accumulated-no-kernels-lmdb":
+                    command = build_wam_c_effective_distance(temp_root, scale, "kernels_off", "facts_lmdb")
                 elif target == "scala-wam-seeded":
                     command = build_wam_scala_effective_distance(temp_root, scale, "seeded", "kernels_on")
                 elif target == "scala-wam-seeded-artifact":

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -92,6 +92,16 @@ TARGETS: dict[str, TargetInfo] = {
         "hybrid-wam",
         "Hybrid WAM C effective-distance runner with reference DFS and kernels disabled",
     ),
+    "c-wam-accumulated-lmdb": TargetInfo(
+        "c-wam-accumulated-lmdb",
+        "hybrid-wam",
+        "Hybrid WAM C effective-distance runner with kernels enabled and LMDB fact storage",
+    ),
+    "c-wam-accumulated-no-kernels-lmdb": TargetInfo(
+        "c-wam-accumulated-no-kernels-lmdb",
+        "hybrid-wam",
+        "Hybrid WAM C effective-distance runner with reference DFS, kernels disabled, and LMDB fact storage",
+    ),
     "scala-wam-seeded": TargetInfo(
         "scala-wam-seeded",
         "hybrid-wam",
@@ -250,6 +260,12 @@ KERNEL_TARGET_PAIRS: tuple[KernelPairInfo, ...] = (
         "c-wam-accumulated-no-kernels",
     ),
     KernelPairInfo(
+        "c",
+        "accumulated-lmdb",
+        "c-wam-accumulated-lmdb",
+        "c-wam-accumulated-no-kernels-lmdb",
+    ),
+    KernelPairInfo(
         "scala",
         "seeded",
         "scala-wam-seeded",
@@ -323,6 +339,8 @@ TARGET_SETS: dict[str, list[str]] = {
         "go-wam-accumulated-no-kernels",
         "c-wam-accumulated",
         "c-wam-accumulated-no-kernels",
+        "c-wam-accumulated-lmdb",
+        "c-wam-accumulated-no-kernels-lmdb",
         "scala-wam-seeded",
         "scala-wam-seeded-no-kernels",
         "scala-wam-accumulated",

--- a/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
@@ -13,13 +13,13 @@
 %% generate_wam_c_effective_distance_benchmark.pl
 %%
 %% Generates a small WAM-C effective-distance benchmark project. The generated
-%% C runner loads category_parent/2 facts from TSV, executes the native
+%% C runner loads category_parent/2 facts from TSV or LMDB, executes the native
 %% category_ancestor/4 all-hop collector when kernels are enabled, and includes
 %% a C reference DFS path for kernels_off comparisons.
 %%
 %% Usage:
 %%   swipl -q -s examples/benchmark/generate_wam_c_effective_distance_benchmark.pl -- \
-%%       <facts.pl> <output-dir> [kernels_on|kernels_off]
+%%       <facts.pl> <output-dir> [kernels_on|kernels_off] [facts_tsv|facts_lmdb]
 
 benchmark_workload_path(Path) :-
     source_file(benchmark_workload_path(_), ThisFile),
@@ -30,14 +30,17 @@ main :-
     current_prolog_flag(argv, Argv),
     (   Argv == []
     ->  true
+    ;   Argv = [FactsPath, OutputDir, KernelModeAtom, FactStorageAtom]
+    ->  generate(FactsPath, OutputDir, KernelModeAtom, FactStorageAtom),
+        halt(0)
     ;   Argv = [FactsPath, OutputDir, KernelModeAtom]
-    ->  generate(FactsPath, OutputDir, KernelModeAtom),
+    ->  generate(FactsPath, OutputDir, KernelModeAtom, facts_tsv),
         halt(0)
     ;   Argv = [FactsPath, OutputDir]
     ->  generate(FactsPath, OutputDir, kernels_on),
         halt(0)
     ;   format(user_error,
-               'Usage: ... -- <facts.pl> <output-dir> [kernels_on|kernels_off]~n',
+               'Usage: ... -- <facts.pl> <output-dir> [kernels_on|kernels_off] [facts_tsv|facts_lmdb]~n',
                []),
         halt(1)
     ).
@@ -49,12 +52,13 @@ main :-
 generate(FactsPath, OutputDir, KernelMode) :-
     generate(FactsPath, OutputDir, KernelMode, []).
 
-generate(FactsPath, OutputDir, KernelMode, _Options) :-
+generate(FactsPath, OutputDir, KernelMode, OptionsOrFactStorage) :-
     (   exists_file(FactsPath)
     ->  true
     ;   throw(error(existence_error(source_sink, FactsPath), _))
     ),
     parse_kernel_mode(KernelMode, ParsedMode),
+    parse_fact_storage_option(OptionsOrFactStorage, FactStorage),
     reset_benchmark_predicates,
     benchmark_workload_path(WorkloadPath),
     load_files(user:WorkloadPath, [silent(true), if(true)]),
@@ -77,16 +81,17 @@ generate(FactsPath, OutputDir, KernelMode, _Options) :-
     category_parent_tsv(CategoryParents, CategoryTsv),
     directory_file_path(OutputDir, 'category_parent.tsv', CategoryPath),
     write_text_file(CategoryPath, CategoryTsv),
-    effective_distance_main_code(ParsedMode, Dimension, MaxDepth,
+    maybe_write_lmdb_seeder(FactStorage, OutputDir, CategoryParents),
+    effective_distance_main_code(ParsedMode, FactStorage, Dimension, MaxDepth,
                                  ArticleCategories, RootCategories, MainCode),
     directory_file_path(OutputDir, 'main.c', MainPath),
     write_text_file(MainPath, MainCode),
     directory_file_path(OutputDir, 'README.md', ReadmePath),
-    effective_distance_readme(ParsedMode, Readme),
+    effective_distance_readme(ParsedMode, FactStorage, Readme),
     write_text_file(ReadmePath, Readme),
     format(user_error,
-           '[WAM-C-EffectiveDistance] mode=~w output=~w~n',
-           [ParsedMode, OutputDir]).
+           '[WAM-C-EffectiveDistance] mode=~w fact_storage=~w output=~w~n',
+           [ParsedMode, FactStorage, OutputDir]).
 
 parse_kernel_mode(kernels_on, kernels_on).
 parse_kernel_mode(kernels_off, kernels_off).
@@ -98,6 +103,31 @@ parse_kernel_mode(Atom, Mode) :-
     parse_kernel_mode(String, Mode), !.
 parse_kernel_mode(Atom, _) :-
     throw(error(domain_error(wam_c_kernel_mode, Atom), _)).
+
+parse_fact_storage_option([], facts_tsv).
+parse_fact_storage_option(Options, FactStorage) :-
+    is_list(Options),
+    !,
+    (   memberchk(fact_storage(Raw), Options)
+    ->  parse_fact_storage(Raw, FactStorage)
+    ;   memberchk(Raw, Options),
+        parse_fact_storage(Raw, FactStorage)
+    ->  true
+    ;   FactStorage = facts_tsv
+    ).
+parse_fact_storage_option(Raw, FactStorage) :-
+    parse_fact_storage(Raw, FactStorage).
+
+parse_fact_storage(facts_tsv, facts_tsv).
+parse_fact_storage(facts_lmdb, facts_lmdb).
+parse_fact_storage("facts_tsv", facts_tsv).
+parse_fact_storage("facts_lmdb", facts_lmdb).
+parse_fact_storage(Atom, Mode) :-
+    atom(Atom),
+    atom_string(Atom, String),
+    parse_fact_storage(String, Mode), !.
+parse_fact_storage(Atom, _) :-
+    throw(error(domain_error(wam_c_fact_storage, Atom), _)).
 
 reset_benchmark_predicates :-
     forall(member(Name/Arity,
@@ -148,7 +178,169 @@ category_parent_tsv(Pairs, Tsv) :-
 category_parent_tsv_line(Child-Parent, Line) :-
     format(atom(Line), '~w\t~w\n', [Child, Parent]).
 
-effective_distance_main_code(KernelMode, Dimension, MaxDepth,
+maybe_write_lmdb_seeder(facts_tsv, _OutputDir, _CategoryParents).
+maybe_write_lmdb_seeder(facts_lmdb, OutputDir, CategoryParents) :-
+    length(CategoryParents, RowCount),
+    has_duplicate_child(CategoryParents, HasDuplicate),
+    lmdb_seeder_code(RowCount, HasDuplicate, SeederCode),
+    directory_file_path(OutputDir, 'seed_category_parent_lmdb.c', SeederPath),
+    write_text_file(SeederPath, SeederCode).
+
+has_duplicate_child(Pairs, HasDuplicate) :-
+    pairs_keys(Pairs, Children),
+    msort(Children, Sorted),
+    (   append(_, [Child, Child|_], Sorted)
+    ->  HasDuplicate = 1
+    ;   HasDuplicate = 0
+    ).
+
+lmdb_seeder_code(ExpectedRows, ExpectedDuplicate, Code) :-
+    format(atom(Code),
+'#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include "lmdb.h"
+
+static int mkdir_if_needed(const char *path) {
+    if (mkdir(path, 0775) == 0 || errno == EEXIST) return 1;
+    return 0;
+}
+
+static char *trim_right(char *s) {
+    char *end = s + strlen(s);
+    while (end > s && (end[-1] == 10 || end[-1] == 13 ||
+                       end[-1] == 32 || end[-1] == 9)) {
+        *--end = 0;
+    }
+    return s;
+}
+
+static int put_edge(MDB_txn *txn, MDB_dbi dbi, const char *child, const char *parent) {
+    MDB_val key;
+    MDB_val data;
+    key.mv_size = strlen(child);
+    key.mv_data = (void *)child;
+    data.mv_size = strlen(parent);
+    data.mv_data = (void *)parent;
+    return mdb_put(txn, dbi, &key, &data, 0);
+}
+
+static int seed_from_tsv(MDB_env *env, MDB_dbi dbi, const char *tsv_path) {
+    FILE *file = fopen(tsv_path, "r");
+    if (!file) return 0;
+    MDB_txn *txn = NULL;
+    if (mdb_txn_begin(env, NULL, 0, &txn) != MDB_SUCCESS) {
+        fclose(file);
+        return 0;
+    }
+    char line[1024];
+    int ok = 1;
+    while (fgets(line, sizeof(line), file)) {
+        char *child = line;
+        while (*child == 32 || *child == 9) child++;
+        if (*child == 0 || *child == 10 || *child == 35) continue;
+        char *sep = strchr(child, 9);
+        if (!sep) sep = strchr(child, 32);
+        if (!sep) { ok = 0; break; }
+        *sep = 0;
+        char *parent = sep + 1;
+        while (*parent == 32 || *parent == 9) parent++;
+        trim_right(parent);
+        if (*child == 0 || *parent == 0) { ok = 0; break; }
+        if (put_edge(txn, dbi, child, parent) != MDB_SUCCESS) {
+            ok = 0;
+            break;
+        }
+    }
+    fclose(file);
+    if (!ok) {
+        mdb_txn_abort(txn);
+        return 0;
+    }
+    return mdb_txn_commit(txn) == MDB_SUCCESS;
+}
+
+static int validate_lmdb(MDB_env *env, MDB_dbi dbi) {
+    MDB_txn *txn = NULL;
+    MDB_cursor *cursor = NULL;
+    MDB_val key;
+    MDB_val data;
+    int count = 0;
+    int has_duplicate_key = 0;
+    char previous_key[1024];
+    size_t previous_size = 0;
+    previous_key[0] = 0;
+
+    if (mdb_txn_begin(env, NULL, MDB_RDONLY, &txn) != MDB_SUCCESS) return 0;
+    if (mdb_cursor_open(txn, dbi, &cursor) != MDB_SUCCESS) {
+        mdb_txn_abort(txn);
+        return 0;
+    }
+    int rc = mdb_cursor_get(cursor, &key, &data, MDB_FIRST);
+    while (rc == MDB_SUCCESS) {
+        if (previous_size == key.mv_size &&
+            key.mv_size < sizeof(previous_key) &&
+            memcmp(previous_key, key.mv_data, key.mv_size) == 0) {
+            has_duplicate_key = 1;
+        }
+        if (key.mv_size < sizeof(previous_key)) {
+            memcpy(previous_key, key.mv_data, key.mv_size);
+            previous_key[key.mv_size] = 0;
+            previous_size = key.mv_size;
+        } else {
+            previous_size = 0;
+        }
+        count++;
+        rc = mdb_cursor_get(cursor, &key, &data, MDB_NEXT);
+    }
+    mdb_cursor_close(cursor);
+    mdb_txn_abort(txn);
+    return rc == MDB_NOTFOUND && count == ~w && (~w == 0 || has_duplicate_key);
+}
+
+int main(void) {
+    const char *env_path = "category_parent.lmdb";
+    if (!mkdir_if_needed(env_path)) {
+        fprintf(stderr, "failed to create %%s\\n", env_path);
+        return 1;
+    }
+
+    MDB_env *env = NULL;
+    MDB_txn *txn = NULL;
+    MDB_dbi dbi = 0;
+    int rc = mdb_env_create(&env);
+    if (rc != MDB_SUCCESS) return 2;
+    rc = mdb_env_set_mapsize(env, 10485760);
+    if (rc != MDB_SUCCESS) { mdb_env_close(env); return 3; }
+    rc = mdb_env_open(env, env_path, 0, 0664);
+    if (rc != MDB_SUCCESS) { mdb_env_close(env); return 4; }
+    rc = mdb_txn_begin(env, NULL, 0, &txn);
+    if (rc != MDB_SUCCESS) { mdb_env_close(env); return 5; }
+    rc = mdb_dbi_open(txn, NULL, MDB_CREATE | MDB_DUPSORT, &dbi);
+    if (rc == MDB_SUCCESS) rc = mdb_txn_commit(txn);
+    else mdb_txn_abort(txn);
+    if (rc != MDB_SUCCESS) { mdb_env_close(env); return 6; }
+
+    if (!seed_from_tsv(env, dbi, "category_parent.tsv")) {
+        mdb_dbi_close(env, dbi);
+        mdb_env_close(env);
+        return 7;
+    }
+    if (!validate_lmdb(env, dbi)) {
+        fprintf(stderr, "LMDB category_parent artifact validation failed\\n");
+        mdb_dbi_close(env, dbi);
+        mdb_env_close(env);
+        return 8;
+    }
+    mdb_dbi_close(env, dbi);
+    mdb_env_close(env);
+    return 0;
+}
+', [ExpectedRows, ExpectedDuplicate]).
+
+effective_distance_main_code(KernelMode, FactStorage, Dimension, MaxDepth,
                              ArticleCategories, RootCategories, Code) :-
     c_pair_arrays('ARTICLE_IDS', 'ARTICLE_CATS', ArticleCategories, ArticleArrays),
     pairs_keys(ArticleCategories, ArticleIds0),
@@ -156,6 +348,7 @@ effective_distance_main_code(KernelMode, Dimension, MaxDepth,
     c_string_array('ARTICLE_COUNT', 'ARTICLES', ArticleIds, ArticlesArray),
     c_string_array('ROOT_COUNT', 'ROOTS', RootCategories, RootArray),
     kernel_mode_flag(KernelMode, KernelFlag),
+    fact_source_load_code(FactStorage, LoadCode),
     format(atom(Code),
 '#include <math.h>
 #include <stdio.h>
@@ -243,8 +436,8 @@ int main(void) {
     wam_fact_source_init(&source);
     setup_category_ancestor_4(&state);
 
-    if (!wam_fact_source_load_tsv(&state, &source, "category_parent.tsv")) {
-        fprintf(stderr, "failed to load category_parent.tsv\\n");
+    if (!(~w)) {
+        fprintf(stderr, "failed to load category_parent facts\\n");
         wam_fact_source_close(&source);
         wam_free_state(&state);
         return 1;
@@ -284,7 +477,12 @@ int main(void) {
     wam_free_state(&state);
     return 0;
 }
-', [ArticleArrays, ArticlesArray, RootArray, MaxDepth, MaxDepth, KernelFlag, Dimension, Dimension]).
+', [ArticleArrays, ArticlesArray, RootArray, MaxDepth, LoadCode, MaxDepth, KernelFlag, Dimension, Dimension]).
+
+fact_source_load_code(facts_tsv,
+                      'wam_fact_source_load_tsv(&state, &source, "category_parent.tsv")').
+fact_source_load_code(facts_lmdb,
+                      'wam_fact_source_load_lmdb(&state, &source, "category_parent.lmdb", NULL)').
 
 kernel_mode_flag(kernels_on, 1).
 kernel_mode_flag(kernels_off, 0).
@@ -322,7 +520,8 @@ c_escaped_chars(['\\'|Rest]) --> ['\\', '\\'], c_escaped_chars(Rest).
 c_escaped_chars(['"'|Rest]) --> ['\\', '"'], c_escaped_chars(Rest).
 c_escaped_chars([C|Rest]) --> [C], c_escaped_chars(Rest).
 
-effective_distance_readme(KernelMode, Readme) :-
+effective_distance_readme(KernelMode, FactStorage, Readme) :-
+    build_notes(FactStorage, BuildNotes),
     format(atom(Readme),
 '# WAM-C Effective Distance Benchmark
 
@@ -331,7 +530,7 @@ Generated by `generate_wam_c_effective_distance_benchmark.pl`.
 Build:
 
 ```sh
-gcc -std=c11 -Wall -Wextra -I ../../src/unifyweaver/targets/wam_c_runtime wam_runtime.c lib.c main.c -lm -o wam_c_effective_distance
+~w
 ```
 
 Run:
@@ -341,7 +540,13 @@ Run:
 ```
 
 Kernel mode: `~w`.
-', [KernelMode]).
+Fact storage: `~w`.
+', [BuildNotes, KernelMode, FactStorage]).
+
+build_notes(facts_tsv,
+            'gcc -std=c11 -Wall -Wextra -I ../../src/unifyweaver/targets/wam_c_runtime wam_runtime.c lib.c main.c -lm -o wam_c_effective_distance').
+build_notes(facts_lmdb,
+            'gcc -std=c11 -Wall -Wextra seed_category_parent_lmdb.c -llmdb -o seed_category_parent_lmdb\n./seed_category_parent_lmdb\ngcc -std=c11 -Wall -Wextra -DWAM_C_ENABLE_LMDB -I ../../src/unifyweaver/targets/wam_c_runtime wam_runtime.c lib.c main.c -lm -llmdb -o wam_c_effective_distance').
 
 write_text_file(Path, Content) :-
     setup_call_cleanup(

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -84,6 +84,10 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         self.assertIn("scala-wam-seeded-no-kernels", targets)
         self.assertIn("scala-wam-accumulated", targets)
         self.assertIn("scala-wam-accumulated-no-kernels", targets)
+        self.assertIn("c-wam-accumulated", targets)
+        self.assertIn("c-wam-accumulated-no-kernels", targets)
+        self.assertIn("c-wam-accumulated-lmdb", targets)
+        self.assertIn("c-wam-accumulated-no-kernels-lmdb", targets)
         self.assertIn("clojure-wam-accumulated", targets)
         self.assertIn("clojure-wam-accumulated-no-kernels", targets)
         self.assertIn("clojure-wam-seeded", targets)
@@ -173,6 +177,8 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
             ("rust", "interpreter"),
             ("rust", "lowered"),
             ("go", "accumulated"),
+            ("c", "accumulated"),
+            ("c", "accumulated-lmdb"),
             ("scala", "seeded"),
             ("scala", "accumulated"),
             ("clojure", "seeded"),
@@ -210,6 +216,10 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         )
         self.assertIn(
             "scala\tseeded\tscala-wam-seeded\tscala-wam-seeded-no-kernels",
+            text,
+        )
+        self.assertIn(
+            "c\taccumulated-lmdb\tc-wam-accumulated-lmdb\tc-wam-accumulated-no-kernels-lmdb",
             text,
         )
         self.assertIn(

--- a/tests/test_wam_c_effective_distance_benchmark.pl
+++ b/tests/test_wam_c_effective_distance_benchmark.pl
@@ -18,7 +18,7 @@ fail_test(Test, Reason) :-
 
 test_generate_and_run_kernels_on :-
     Test = 'WAM-C effective-distance: kernels_on generated runner emits expected result',
-    (   run_generated_effective_distance(kernels_on, Output),
+    (   run_generated_effective_distance(kernels_on, facts_tsv, Output),
         sub_string(Output, _, _, _, "article\troot_category\teffective_distance"),
         sub_string(Output, _, _, _, "article_a\troot\t1.951123")
     ->  pass(Test)
@@ -27,15 +27,53 @@ test_generate_and_run_kernels_on :-
 
 test_generate_and_run_kernels_off :-
     Test = 'WAM-C effective-distance: kernels_off generated runner emits expected result',
-    (   run_generated_effective_distance(kernels_off, Output),
+    (   run_generated_effective_distance(kernels_off, facts_tsv, Output),
         sub_string(Output, _, _, _, "article\troot_category\teffective_distance"),
         sub_string(Output, _, _, _, "article_a\troot\t1.951123")
     ->  pass(Test)
     ;   fail_test(Test, 'kernels_off runner output mismatch')
     ).
 
-run_generated_effective_distance(KernelMode, Output) :-
+test_generate_lmdb_mode_files :-
+    Test = 'WAM-C effective-distance: facts_lmdb mode emits seeder and LMDB loader',
+    (   unique_tmp_dir(facts_lmdb_files, OutputDir),
+        write_test_facts(OutputDir, FactsPath),
+        generate_wam_c_effective_distance_benchmark:generate(FactsPath, OutputDir, kernels_on, facts_lmdb),
+        directory_file_path(OutputDir, 'seed_category_parent_lmdb.c', SeederPath),
+        directory_file_path(OutputDir, 'main.c', MainPath),
+        directory_file_path(OutputDir, 'README.md', ReadmePath),
+        read_file_to_string(SeederPath, Seeder, []),
+        read_file_to_string(MainPath, Main, []),
+        read_file_to_string(ReadmePath, Readme, []),
+        sub_string(Seeder, _, _, _, 'MDB_CREATE | MDB_DUPSORT'),
+        sub_string(Seeder, _, _, _, 'LMDB category_parent artifact validation failed'),
+        sub_string(Main, _, _, _, 'wam_fact_source_load_lmdb(&state, &source, "category_parent.lmdb", NULL)'),
+        sub_string(Readme, _, _, _, '-DWAM_C_ENABLE_LMDB'),
+        sub_string(Readme, _, _, _, '-llmdb')
+    ->  pass(Test)
+    ;   fail_test(Test, 'facts_lmdb generated files mismatch')
+    ).
+
+test_generate_and_run_lmdb_if_available :-
+    Test = 'WAM-C effective-distance: facts_lmdb generated runner emits expected result',
+    (   lmdb_toolchain_available
+    ->  (   run_generated_effective_distance(kernels_on, facts_lmdb, Output),
+            sub_string(Output, _, _, _, "article\troot_category\teffective_distance"),
+            sub_string(Output, _, _, _, "article_a\troot\t1.951123")
+        ->  pass(Test)
+        ;   fail_test(Test, 'facts_lmdb runner output mismatch')
+        )
+    ;   pass('WAM-C effective-distance: facts_lmdb generated runner skipped (LMDB toolchain unavailable)')
+    ).
+
+run_generated_effective_distance(KernelMode, FactStorage, Output) :-
     unique_tmp_dir(KernelMode, OutputDir),
+    write_test_facts(OutputDir, FactsPath),
+    generate_wam_c_effective_distance_benchmark:generate(FactsPath, OutputDir, KernelMode, FactStorage),
+    compile_generated_project(OutputDir, FactStorage),
+    run_generated_project(OutputDir, Output).
+
+write_test_facts(OutputDir, FactsPath) :-
     directory_file_path(OutputDir, 'facts.pl', FactsPath),
     write_text_file(FactsPath,
 'article_category(article_a, leaf).
@@ -43,10 +81,7 @@ root_category(root).
 category_parent(leaf, root).
 category_parent(leaf, mid).
 category_parent(mid, root).
-'),
-    generate_wam_c_effective_distance_benchmark:generate(FactsPath, OutputDir, KernelMode),
-    compile_generated_project(OutputDir),
-    run_generated_project(OutputDir, Output).
+').
 
 unique_tmp_dir(KernelMode, OutputDir) :-
     get_time(Now),
@@ -54,15 +89,21 @@ unique_tmp_dir(KernelMode, OutputDir) :-
     format(atom(OutputDir), '/tmp/unifyweaver_wam_c_effective_~w_~w', [KernelMode, Stamp]),
     make_directory_path(OutputDir).
 
-compile_generated_project(OutputDir) :-
+compile_generated_project(OutputDir, FactStorage) :-
+    maybe_seed_lmdb_project(OutputDir, FactStorage),
     directory_file_path(OutputDir, 'wam_runtime.c', RuntimePath),
     directory_file_path(OutputDir, 'lib.c', LibPath),
     directory_file_path(OutputDir, 'main.c', MainPath),
     directory_file_path(OutputDir, 'wam_c_effective_distance', ExePath),
     IncludeDir = 'src/unifyweaver/targets/wam_c_runtime',
+    compile_flags(FactStorage, Flags),
+    link_flags(FactStorage, Links),
+    append(['-std=c11', '-Wall', '-Wextra'|Flags],
+           ['-I', IncludeDir, RuntimePath, LibPath, MainPath, '-lm'|Links],
+           Args0),
+    append(Args0, ['-o', ExePath], Args),
     process_create(path(gcc),
-        ['-std=c11', '-Wall', '-Wextra', '-I', IncludeDir,
-         RuntimePath, LibPath, MainPath, '-lm', '-o', ExePath],
+        Args,
         [stdout(null), stderr(pipe(Err)), process(Pid)]),
     read_string(Err, _, ErrText),
     close(Err),
@@ -70,6 +111,48 @@ compile_generated_project(OutputDir) :-
     (   Status = exit(0)
     ->  true
     ;   format(user_error, 'gcc failed: ~w~n', [ErrText]),
+        fail
+    ).
+
+maybe_seed_lmdb_project(_OutputDir, facts_tsv).
+maybe_seed_lmdb_project(OutputDir, facts_lmdb) :-
+    directory_file_path(OutputDir, 'seed_category_parent_lmdb.c', SeederPath),
+    directory_file_path(OutputDir, 'seed_category_parent_lmdb', SeederExe),
+    process_create(path(gcc),
+        ['-std=c11', '-Wall', '-Wextra', SeederPath, '-llmdb', '-o', SeederExe],
+        [stdout(null), stderr(pipe(CompileErr)), process(CompilePid)]),
+    read_string(CompileErr, _, CompileErrText),
+    close(CompileErr),
+    process_wait(CompilePid, CompileStatus),
+    (   CompileStatus = exit(0)
+    ->  true
+    ;   format(user_error, 'LMDB seeder gcc failed: ~w~n', [CompileErrText]),
+        fail
+    ),
+    process_create(SeederExe, [],
+        [cwd(OutputDir), stdout(null), stderr(pipe(RunErr)), process(RunPid)]),
+    read_string(RunErr, _, RunErrText),
+    close(RunErr),
+    process_wait(RunPid, RunStatus),
+    (   RunStatus = exit(0)
+    ->  true
+    ;   format(user_error, 'LMDB seeder failed: ~w~n', [RunErrText]),
+        fail
+    ).
+
+compile_flags(facts_tsv, []).
+compile_flags(facts_lmdb, ['-DWAM_C_ENABLE_LMDB']).
+
+link_flags(facts_tsv, []).
+link_flags(facts_lmdb, ['-llmdb']).
+
+lmdb_toolchain_available :-
+    catch(
+        (   process_create(path('pkg-config'), ['--exists', 'lmdb'],
+                [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0))
+        ),
+        _,
         fail
     ).
 
@@ -106,6 +189,8 @@ run_tests_once :-
     format('~n=== WAM-C Effective Distance Benchmark Tests ===~n~n'),
     test_generate_and_run_kernels_on,
     test_generate_and_run_kernels_off,
+    test_generate_lmdb_mode_files,
+    test_generate_and_run_lmdb_if_available,
     format('~n=== WAM-C Effective Distance Benchmark Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).
 


### PR DESCRIPTION
## Summary

This PR adds LMDB fact-storage wiring to the generated WAM-C effective-distance benchmark while keeping TSV as the dependency-free default. The C runner can now be generated in `facts_tsv` or `facts_lmdb` mode, and the shared matrix exposes LMDB kernel/no-kernel C targets for parity checks against Prolog.

## What Changed

- Adds `facts_tsv` / `facts_lmdb` options to the WAM-C effective-distance generator.
- Emits an LMDB seeder/validator for `facts_lmdb` mode using `MDB_DUPSORT`.
- Compiles LMDB WAM-C benchmark runners with `-DWAM_C_ENABLE_LMDB -llmdb`.
- Adds `c-wam-accumulated-lmdb` and `c-wam-accumulated-no-kernels-lmdb` matrix targets.
- Adds the C LMDB kernel/no-kernel pair to `--list-kernel-pairs` output.
- Skips LMDB C targets cleanly when the local LMDB C toolchain is unavailable.
- Extends WAM-C generator and matrix tests for LMDB file generation and e2e execution.
- Updates `WAM_C_TARGET_NEXT_STEPS.md` to mark LMDB effective-distance wiring in progress and move the next branch recommendation to classic C program e2e coverage.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 -m unittest tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 1`
- `git diff --check`

The `dev` matrix smoke produced 19 rows for Prolog and both WAM-C LMDB targets, with matching normalized output hash `1659619c9d36`.

## Follow-Up

The next recommended WAM-C branch is `feat/wam-c-classic-program-e2e`, focused on broader recursive program coverage for retry/trust paths, arithmetic comparisons, and recursive calls outside the effective-distance benchmark shape.
