### PR TITLE
bench(csharp-query): sweep all graph workloads by default

### DIFF
--- a/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
+++ b/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
@@ -31,6 +31,8 @@ WORKLOAD_SCRIPTS = {
     "weighted-shortest-path": BENCHMARK_DIR / "benchmark_weighted_shortest_path_cross_target.py",
 }
 
+DEFAULT_WORKLOADS = "all"
+
 
 @dataclass
 class SourceModeSummary:
@@ -48,8 +50,8 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--workloads",
-        default="category-influence,dependency-depth",
-        help="Comma-separated workloads, or 'all'.",
+        default=DEFAULT_WORKLOADS,
+        help="Comma-separated workloads, or 'all' for every registered graph workload.",
     )
     parser.add_argument("--scales", default="300")
     parser.add_argument(

--- a/tests/test_csharp_query_source_mode_sweep.py
+++ b/tests/test_csharp_query_source_mode_sweep.py
@@ -10,13 +10,36 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
 
 from benchmark_csharp_query_source_mode_sweep import (  # noqa: E402
+    DEFAULT_WORKLOADS,
+    WORKLOAD_SCRIPTS,
     calibration_failures,
+    parse_args,
     parse_ratio,
     parse_runner_output,
+    parse_workloads,
 )
 
 
 class CSharpQuerySourceModeSweepTests(unittest.TestCase):
+    def test_default_workloads_cover_all_graph_workloads(self) -> None:
+        original_argv = sys.argv
+        try:
+            sys.argv = ["benchmark_csharp_query_source_mode_sweep.py"]
+            args = parse_args()
+        finally:
+            sys.argv = original_argv
+
+        self.assertEqual(args.workloads, DEFAULT_WORKLOADS)
+        self.assertEqual(parse_workloads(args.workloads), list(WORKLOAD_SCRIPTS))
+
+    def test_parse_workloads_all_expands_to_all_graph_workloads(self) -> None:
+        self.assertEqual(parse_workloads("all"), list(WORKLOAD_SCRIPTS))
+        self.assertEqual(parse_workloads(" ALL "), list(WORKLOAD_SCRIPTS))
+
+    def test_parse_workloads_rejects_unknown_workloads(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "unknown workload"):
+            parse_workloads("category-influence,not-a-workload")
+
     def test_parse_runner_output_summarizes_modes_and_registrations(self) -> None:
         output = "\n".join(
             [


### PR DESCRIPTION
  ## Summary

  - Changes the C# query source-mode sweep default workload set to `all`.
  - Keeps explicit workload selection available for narrow calibration runs.
  - Adds unit coverage for default workload expansion, `all` parsing, and unknown workload rejection.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_source_mode_sweep.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_source_mode_sweep.py tests/
  test_csharp_query_source_mode_sweep.py`
  - `python3 examples/benchmark/benchmark_csharp_query_source_mode_sweep.py --workloads category-influence,dependency-
  depth --scales 300 --source-modes auto,preload,artifact-prebuilt --repetitions 1 --format tsv --fail-on-output-
  mismatch --max-auto-vs-best-ratio 2.00`
  - `python3 examples/benchmark/benchmark_csharp_query_source_mode_sweep.py --scales 300 --source-modes
  auto,preload,artifact-prebuilt --repetitions 1 --format tsv --fail-on-output-mismatch --max-auto-vs-best-ratio 2.00`
  - `git diff --check`

  Tracked changes are committed. The remaining status entries are existing untracked generated/data artifacts.