### PR TITLE
feat(bench): add bounded effective-distance WAM probes

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -284,9 +284,38 @@ swipl -q -s examples/benchmark/generate_wam_scala_effective_distance_benchmark.p
 It emits a Scala WAM project plus an `EffectiveDistanceRunner` companion that
 prints the standard `article	root_category	effective_distance` table from
 `category_parent.tsv` and `article_category.tsv`. The generator supports
-`kernels_on` via the Scala fact-source handler and `kernels_off` via compiled
-WAM facts, but the targets are not registered in the Python matrix until the
-runner wiring has a dedicated smoke gate.
+`kernels_on` via the Scala fact-source handler and `kernels_off` via WAM
+`category_ancestor/4` recursion over the same fact-source seam. The registered
+matrix targets are:
+
+- `scala-wam-seeded`
+- `scala-wam-seeded-no-kernels`
+- `scala-wam-accumulated`
+- `scala-wam-accumulated-no-kernels`
+
+Slow fallback probes can be bounded from the matrix harness instead of relying
+on an external watchdog. For example, to validate that a large no-kernel Scala
+project still generates and compiles without running the slow fallback:
+
+```bash
+python3 examples/benchmark/benchmark_effective_distance_matrix.py \
+  --scales 300 \
+  --targets scala-wam-accumulated-no-kernels \
+  --compile-only-targets scala-wam-accumulated-no-kernels \
+  --repetitions 1
+```
+
+To run a bounded kernel/no-kernel comparison and report a timeout row rather
+than hanging the benchmark process:
+
+```bash
+python3 examples/benchmark/benchmark_effective_distance_matrix.py \
+  --scales dev \
+  --targets scala-wam-accumulated,scala-wam-accumulated-no-kernels \
+  --timeout-targets scala-wam-accumulated-no-kernels \
+  --run-timeout-seconds 10 \
+  --repetitions 1
+```
 
 The configurable benchmark matrix now treats all Clojure WAM effective-distance
 modes as result-producing `hybrid-wam` targets:
@@ -307,14 +336,16 @@ python3 examples/benchmark/benchmark_effective_distance_matrix.py --list-kernel-
 
 The report is TSV with `family`, `mode`, `kernels_target`, and
 `no_kernels_target` columns. It currently covers registered Rust
-seeded/accumulated and Rust interpreter/lowered pairings, plus Go, Clojure,
-and Haskell effective-distance WAM pairings.
+seeded/accumulated and Rust interpreter/lowered pairings, plus Go, C, Scala,
+Clojure, and Haskell effective-distance WAM pairings.
 
 When both sides of a registered pair run for the same scale, the benchmark
 summary also emits a paired delta table with median timings, a
 `kernels_speedup_vs_no_kernels` ratio, and output/row-count match flags. A
 ratio above `1.0` means the kernel-enabled target was faster than its
-no-kernel counterpart for that pair.
+no-kernel counterpart for that pair. Targets reported as `timeout` or
+`compile_only` are listed in the primary table but excluded from output
+matching, baseline speedups, and kernel-pair deltas.
 
 Artifact-vs-sidecar Clojure comparisons are available through the
 `clojure-wam-artifact` target set, which adds:

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -16,6 +16,7 @@ def run_command(
     env: dict[str, str] | None = None,
     check: bool = True,
     capture_output: bool = True,
+    timeout: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         cmd,
@@ -24,6 +25,7 @@ def run_command(
         check=check,
         capture_output=capture_output,
         text=True,
+        timeout=timeout,
     )
 
 

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -26,6 +26,7 @@ import os
 import re
 import shlex
 import statistics
+import subprocess
 import sys
 import tempfile
 import time
@@ -89,10 +90,16 @@ class RunResult:
     stdout_sha256: str
     row_count: int
     stderr: str
+    status: str = "ok"
+    message: str = ""
 
     @property
     def median(self) -> float:
-        return statistics.median(self.times)
+        return statistics.median(self.times) if self.times else float("nan")
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "ok"
 
 
 def parse_args() -> argparse.Namespace:
@@ -112,6 +119,22 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--exclude-targets", default="")
     parser.add_argument("--baseline-target", default="prolog-accumulated")
     parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument(
+        "--run-timeout-seconds",
+        type=float,
+        default=0,
+        help="Optional per-invocation runtime timeout. Timed-out targets are reported, not compared.",
+    )
+    parser.add_argument(
+        "--timeout-targets",
+        default="",
+        help="Comma-separated targets that receive --run-timeout-seconds. Defaults to all targets.",
+    )
+    parser.add_argument(
+        "--compile-only-targets",
+        default="",
+        help="Comma-separated targets to generate/build but not execute. Useful for slow WAM fallback validation.",
+    )
     parser.add_argument("--keep-temp", action="store_true")
     parser.add_argument("--list-targets", action="store_true")
     parser.add_argument(
@@ -719,22 +742,69 @@ def normalize_output(output: str) -> str:
     return normalize_three_column_float_rows(output, decimals=9)
 
 
-def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
+def completed_output_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def should_timeout_target(target: str, timeout_targets: set[str]) -> bool:
+    return not timeout_targets or target in timeout_targets
+
+
+def compile_only_result(target: str, scale: str, build_seconds: float) -> RunResult:
+    return RunResult(
+        target=target,
+        scale=scale,
+        times=[build_seconds],
+        stdout_sha256="",
+        row_count=0,
+        stderr="",
+        status="compile_only",
+        message="generated/built but not executed",
+    )
+
+
+def benchmark_target(
+    command: list[str],
+    scale: str,
+    repetitions: int,
+    target: str,
+    run_timeout_seconds: float = 0,
+    timeout_targets: set[str] | None = None,
+) -> RunResult:
     times: list[float] = []
     stdout = ""
     stderr = ""
+    timeout_targets = timeout_targets or set()
+    timeout = run_timeout_seconds if run_timeout_seconds > 0 and should_timeout_target(target, timeout_targets) else None
     for _ in range(repetitions):
         started = time.perf_counter()
-        if target.startswith("prolog-") or target.startswith("wam-") or target.startswith("clojure-wam-"):
-            result = run_command(command, cwd=ROOT)
-        elif target.startswith("haskell-"):
-            scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
-            result = run_command(command + [str(scale_dir)], cwd=ROOT)
-        else:
-            scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
-            edge_path = scale_dir / "category_parent.tsv"
-            article_path = scale_dir / "article_category.tsv"
-            result = run_command(command + [str(edge_path), str(article_path)], cwd=ROOT)
+        try:
+            if target.startswith("prolog-") or target.startswith("wam-") or target.startswith("clojure-wam-"):
+                result = run_command(command, cwd=ROOT, timeout=timeout)
+            elif target.startswith("haskell-"):
+                scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
+                result = run_command(command + [str(scale_dir)], cwd=ROOT, timeout=timeout)
+            else:
+                scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
+                edge_path = scale_dir / "category_parent.tsv"
+                article_path = scale_dir / "article_category.tsv"
+                result = run_command(command + [str(edge_path), str(article_path)], cwd=ROOT, timeout=timeout)
+        except subprocess.TimeoutExpired as exc:
+            elapsed = time.perf_counter() - started
+            return RunResult(
+                target=target,
+                scale=scale,
+                times=[elapsed],
+                stdout_sha256="",
+                row_count=0,
+                stderr=completed_output_text(exc.stderr),
+                status="timeout",
+                message=f"timed out after {timeout:.3f}s",
+            )
         times.append(time.perf_counter() - started)
         stdout = result.stdout
         stderr = result.stderr
@@ -745,27 +815,31 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
 
 
 def print_summary(results: list[RunResult], baseline_target: str) -> None:
-    print("scale\ttarget\tcategory\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
+    print("scale\ttarget\tcategory\tstatus\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256\tmessage")
     for scale, entries in group_results_by_scale(results):
         for result in sorted(entries, key=lambda item: item.target):
             category = TARGETS[result.target].category
+            min_s = f"{min(result.times):.3f}" if result.times else "NA"
+            max_s = f"{max(result.times):.3f}" if result.times else "NA"
+            median_s = f"{result.median:.3f}" if result.times else "NA"
             print(
-                f"{scale}\t{result.target}\t{category}\t{result.median:.3f}\t"
-                f"{min(result.times):.3f}\t{max(result.times):.3f}\t"
-                f"{result.row_count}\t{result.stdout_sha256[:12]}"
+                f"{scale}\t{result.target}\t{category}\t{result.status}\t{median_s}\t"
+                f"{min_s}\t{max_s}\t{result.row_count}\t{result.stdout_sha256[:12]}\t{result.message}"
             )
 
-        if len(entries) > 1:
-            print_match_status(scale, "all_outputs", entries)
+        ok_entries = [entry for entry in entries if entry.ok]
 
-        for category in sorted({TARGETS[item.target].category for item in entries}):
-            category_entries = [item for item in entries if TARGETS[item.target].category == category]
+        if len(ok_entries) > 1:
+            print_match_status(scale, "all_outputs", ok_entries)
+
+        for category in sorted({TARGETS[item.target].category for item in ok_entries}):
+            category_entries = [item for item in ok_entries if TARGETS[item.target].category == category]
             if len(category_entries) > 1:
                 print_match_status(scale, f"{category}_outputs", category_entries)
 
-        baseline = find_result(entries, baseline_target)
+        baseline = find_result(ok_entries, baseline_target)
         if baseline:
-            for result in sorted(entries, key=lambda item: item.target):
+            for result in sorted(ok_entries, key=lambda item: item.target):
                 if result.target == baseline_target:
                     continue
                 print_speedup(scale, f"speedup_vs_{baseline_target}_{result.target}", baseline, result)
@@ -773,7 +847,7 @@ def print_summary(results: list[RunResult], baseline_target: str) -> None:
 
 
 def kernel_pair_delta_rows(scale: str, entries: list[RunResult]) -> list[str]:
-    by_target = {entry.target: entry for entry in entries}
+    by_target = {entry.target: entry for entry in entries if entry.ok}
     rows: list[str] = []
     for pair in KERNEL_TARGET_PAIRS:
         kernels = by_target.get(pair.kernels_target)
@@ -840,6 +914,20 @@ def main() -> int:
     scales = [part.strip() for part in args.scales.split(",") if part.strip()]
     validate_termux_scales(scales, args.allow_large_termux_scales)
     targets = resolve_requested_targets(args)
+    compile_only_targets = set(parse_csv(args.compile_only_targets))
+    timeout_targets = set(parse_csv(args.timeout_targets))
+    unknown_compile_only = sorted(compile_only_targets.difference(TARGETS))
+    if unknown_compile_only:
+        raise ValueError(f"unknown --compile-only-targets: {','.join(unknown_compile_only)}")
+    unknown_timeout_targets = sorted(timeout_targets.difference(TARGETS))
+    if unknown_timeout_targets:
+        raise ValueError(f"unknown --timeout-targets: {','.join(unknown_timeout_targets)}")
+    inactive_compile_only = sorted(compile_only_targets.difference(targets))
+    for target in inactive_compile_only:
+        print(f"warning: compile-only target was not selected and will be ignored: {target}", file=sys.stderr)
+    inactive_timeout_targets = sorted(timeout_targets.difference(targets))
+    for target in inactive_timeout_targets:
+        print(f"warning: timeout target was not selected and will be ignored: {target}", file=sys.stderr)
     if not targets:
         print("no benchmark targets available", file=sys.stderr)
         return 1
@@ -857,6 +945,7 @@ def main() -> int:
         results: list[RunResult] = []
         for scale in scales:
             for target in targets:
+                build_started = time.perf_counter()
                 if target == "prolog-seeded":
                     command = build_prolog_effective_distance(temp_root, scale, "seeded")
                 elif target == "prolog-accumulated":
@@ -919,7 +1008,20 @@ def main() -> int:
                     )
                 else:
                     command = commands[target]
-                results.append(benchmark_target(command, scale, args.repetitions, target))
+                build_seconds = time.perf_counter() - build_started
+                if target in compile_only_targets:
+                    results.append(compile_only_result(target, scale, build_seconds))
+                    continue
+                results.append(
+                    benchmark_target(
+                        command,
+                        scale,
+                        args.repetitions,
+                        target,
+                        args.run_timeout_seconds,
+                        timeout_targets,
+                    )
+                )
 
         print_summary(results, args.baseline_target)
         return 0

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -16,6 +16,7 @@ from benchmark_effective_distance_matrix import (  # noqa: E402
     kernel_pair_delta_rows,
     parse_args,
     print_kernel_pair_deltas,
+    print_summary,
     resolve_requested_targets,
 )
 from benchmark_target_matrix import (  # noqa: E402
@@ -173,6 +174,7 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
             ("rust", "interpreter"),
             ("rust", "lowered"),
             ("go", "accumulated"),
+            ("c", "accumulated"),
             ("scala", "seeded"),
             ("scala", "accumulated"),
             ("clojure", "seeded"),
@@ -280,6 +282,63 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         )
 
         self.assertEqual(rows, [])
+
+    def test_kernel_pair_delta_rows_skip_non_ok_pair_member(self) -> None:
+        rows = kernel_pair_delta_rows(
+            "dev",
+            [
+                RunResult("scala-wam-accumulated", "dev", [1.0], "digest", 42, ""),
+                RunResult(
+                    "scala-wam-accumulated-no-kernels",
+                    "dev",
+                    [10.0],
+                    "",
+                    0,
+                    "",
+                    status="timeout",
+                    message="timed out after 10.000s",
+                ),
+            ],
+        )
+
+        self.assertEqual(rows, [])
+
+    def test_print_summary_reports_bounded_statuses_without_comparisons(self) -> None:
+        output = StringIO()
+        with redirect_stdout(output):
+            print_summary(
+                [
+                    RunResult("prolog-accumulated", "dev", [0.1], "a", 10, ""),
+                    RunResult(
+                        "scala-wam-accumulated-no-kernels",
+                        "dev",
+                        [10.0],
+                        "",
+                        0,
+                        "",
+                        status="timeout",
+                        message="timed out after 10.000s",
+                    ),
+                    RunResult(
+                        "c-wam-accumulated-no-kernels",
+                        "dev",
+                        [0.5],
+                        "",
+                        0,
+                        "",
+                        status="compile_only",
+                        message="generated/built but not executed",
+                    ),
+                ],
+                "prolog-accumulated",
+            )
+
+        text = output.getvalue()
+        self.assertIn("scale\ttarget\tcategory\tstatus\tmedian_s", text)
+        self.assertIn("dev\tscala-wam-accumulated-no-kernels\thybrid-wam\ttimeout", text)
+        self.assertIn("dev\tc-wam-accumulated-no-kernels\thybrid-wam\tcompile_only", text)
+        self.assertNotIn("all_outputs", text)
+        self.assertNotIn("speedup_vs_prolog-accumulated", text)
 
     def test_print_kernel_pair_deltas_emits_one_table_for_all_scales(self) -> None:
         output = StringIO()


### PR DESCRIPTION
  ## Summary

  Add bounded execution controls to the effective-distance benchmark matrix so slow WAM fallback targets can be
  generated, compiled, or time-limited without hanging local validation runs.

  ## Changes

  - Add `--compile-only-targets` to generate/build selected targets without executing them.
  - Add `--run-timeout-seconds` and `--timeout-targets` for bounded per-target runtime probes.
  - Extend matrix results with explicit `ok`, `timeout`, and `compile_only` statuses.
  - Exclude non-OK rows from output matching, baseline speedups, and kernel/no-kernel delta comparisons.
  - Document bounded Scala WAM fallback probe workflows.
  - Add tests for bounded-status summary and pair-delta behavior.

  ## Validation

  - `python3 tests/test_benchmark_target_matrix.py`
  - `python3 -m py_compile examples/benchmark/benchmark_common.py examples/benchmark/
  benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py tests/
  test_benchmark_target_matrix.py`
  - Compile-only smoke for `prolog-accumulated`
  - Timeout smoke for `prolog-accumulated`
  - Normal dev smoke for `prolog-accumulated`
  - `git diff --check`