### PR TITLE
Feat/wam python lowered effective distance smoke

### DIFF
--- a/examples/benchmark/generate_wam_python_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_python_effective_distance_benchmark.pl
@@ -84,7 +84,7 @@ generate(FactsPath, OutputDir, KernelModeAtom) :-
         [module_name('wam-python-effective-distance-bench'),
          prefer_wam(true),
          wam_fallback(true),
-         emit_mode(functions),
+         emit_mode(lowered),
          parallel(true)],
         KernelOptions
     ], Options),

--- a/examples/benchmark/generate_wam_python_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_python_optimized_benchmark.pl
@@ -78,7 +78,7 @@ generate(VariantAtom, OutputDir) :-
     Options = [module_name('wam-python-optimized-bench'),
                prefer_wam(true),
                wam_fallback(true),
-               emit_mode(functions),
+               emit_mode(lowered),
                parallel(true),
                benchmark(true),
                foreign_predicates([category_parent/2])],

--- a/src/unifyweaver/targets/wam_python_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_python_lowered_emitter.pl
@@ -83,6 +83,42 @@ sanitize_code(C, C) :-
 	!.
 sanitize_code(_, 0'_).
 
+constant_atom_py(C, Atom) :-
+	(   atom(C)
+	->  Atom = C
+	;   string(C)
+	->  atom_string(Atom, C)
+	;   term_string(C, S),
+	    atom_string(Atom, S)
+	).
+
+constant_number_py(C, Number) :-
+	constant_atom_py(C, Atom),
+	catch(atom_number(Atom, Number), _, fail).
+
+constant_term_py(C, Term) :-
+	(   constant_number_py(C, Number)
+	->  (   integer(Number)
+	    ->  format(string(Term), "Int(~w)", [Number])
+	    ;   format(string(Term), "Float(~w)", [Number])
+	    )
+	;   escape_py(C, EC),
+	    format(string(Term), "Atom(\"~w\")", [EC])
+	).
+
+constant_match_condition_py(C, VarExpr, Cond) :-
+	(   constant_number_py(C, Number)
+	->  (   integer(Number)
+	    ->  format(string(Cond), 'isinstance(~w, Int) and ~w.n == ~w',
+	            [VarExpr, VarExpr, Number])
+	    ;   format(string(Cond), 'isinstance(~w, Float) and ~w.f == ~w',
+	            [VarExpr, VarExpr, Number])
+	    )
+	;   escape_py(C, EC),
+	    format(string(Cond), 'isinstance(~w, Atom) and ~w.name == "~w"',
+	        [VarExpr, VarExpr, EC])
+	).
+
 % ============================================================================
 % WAM text parsing (shared pattern with other emitters)
 % ============================================================================
@@ -283,10 +319,8 @@ match_instrs_to_condition_py([Instr|Rest], Cond) :-
 %  Generate a Python condition for a single match instruction.
 single_match_condition_py(get_constant(C, AiStr), Cond) :-
 	reg_int_py(AiStr, Ai),
-	escape_py(C, EC),
-	format(string(Cond),
-		'isinstance(_a~w, Var) or (isinstance(_a~w, Atom) and _a~w.name == "~w")',
-		[Ai, Ai, Ai, EC]).
+	format(string(VarExpr), "_a~w", [Ai]),
+	constant_match_condition_py(C, VarExpr, Cond).
 single_match_condition_py(get_integer(NStr, AiStr), Cond) :-
 	reg_int_py(AiStr, Ai),
 	format(string(Cond),
@@ -332,12 +366,12 @@ match_instrs_to_binding_py([Instr|Rest], Indent, Lines) :-
 %% single_match_binding_py(+Instr, +Indent, -Lines)
 single_match_binding_py(get_constant(C, AiStr), Indent, Lines) :-
 	reg_int_py(AiStr, Ai),
-	escape_py(C, EC),
+	constant_term_py(C, Term),
 	Indent1 is Indent + 4,
 	indent_str(Indent1, Pad),
 	format(string(DerefLine), "~w_a~w = deref(state.regs[~w], state)", [Pad, Ai, Ai]),
-	format(string(BindLine), "~wif isinstance(_a~w, Var): bind(_a~w, Atom(\"~w\"), state)",
-		[Pad, Ai, Ai, EC]),
+	format(string(BindLine), "~wif isinstance(_a~w, Var): bind(_a~w, ~w, state)",
+		[Pad, Ai, Ai, Term]),
 	Lines = [DerefLine, BindLine].
 single_match_binding_py(get_integer(NStr, AiStr), Indent, Lines) :-
 	reg_int_py(AiStr, Ai),
@@ -492,12 +526,14 @@ emit_lowered_python(FunctorArity, WamCode, Options, Lines) :-
 
 emit_instr_py(get_constant(C, AiStr), Code) :-
 	reg_int_py(AiStr, Ai),
-	escape_py(C, EC),
+	constant_term_py(C, Term),
+	format(string(VarExpr), "_a~w", [Ai]),
+	constant_match_condition_py(C, VarExpr, Cond),
 	format(string(Code),
 '    _a~w = deref(state.regs[~w], state)
-    if isinstance(_a~w, Var): bind(_a~w, Atom("~w"), state)
-    elif not (isinstance(_a~w, Atom) and _a~w.name == "~w"): return False',
-		[Ai, Ai, Ai, Ai, EC, Ai, Ai, EC]).
+    if isinstance(_a~w, Var): bind(_a~w, ~w, state)
+    elif not (~w): return False',
+		[Ai, Ai, Ai, Ai, Term, Cond]).
 
 emit_instr_py(get_variable(XnStr, AiStr), Code) :-
 	reg_int_py(XnStr, Xn), reg_int_py(AiStr, Ai),
@@ -599,9 +635,9 @@ emit_instr_py(put_unsafe_value(YnStr, AiStr), Code) :-
 
 emit_instr_py(put_constant(C, AiStr), Code) :-
 	reg_int_py(AiStr, Ai),
-	escape_py(C, EC),
+	constant_term_py(C, Term),
 	format(string(Code),
-'    state.regs[~w] = Atom("~w")', [Ai, EC]).
+'    state.regs[~w] = ~w', [Ai, Term]).
 
 emit_instr_py(put_nil(AiStr), Code) :-
 	reg_int_py(AiStr, Ai),
@@ -659,14 +695,15 @@ emit_instr_py(unify_value(XnStr), Code) :-
         heap_put(state, state.regs[~w])', [Xn, Xn]).
 
 emit_instr_py(unify_constant(C), Code) :-
-	escape_py(C, EC),
+	constant_term_py(C, Term),
+	constant_match_condition_py(C, "_h", Cond),
 	format(string(Code),
 '    if state.mode == "read":
         _h = deref(state.heap[state.s], state)
-        if isinstance(_h, Var): bind(_h, Atom("~w"), state)
-        elif not (isinstance(_h, Atom) and _h.name == "~w"): return False
+        if isinstance(_h, Var): bind(_h, ~w, state)
+        elif not (~w): return False
     else:
-        heap_put(state, Atom("~w"))', [EC, EC, EC]).
+        heap_put(state, ~w)', [Term, Cond, Term]).
 
 emit_instr_py(unify_nil, Code) :-
 	Code = '    if state.mode == "read":

--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -336,7 +336,8 @@ def unify(a: Term, b: Term, state: WamState) -> bool:
 
 def push_choice_point(state: WamState, n_args: int, next_clause: Any) -> None:
     """Create a new choice point, saving argument registers and trail mark."""
-    saved_regs = state.regs[:n_args].copy()
+    # Registers are 1-indexed; include index n_args so A1..An are restored.
+    saved_regs = state.regs[:n_args + 1].copy()
     cp = ChoicePoint(
         n_args=n_args,
         saved_regs=saved_regs,
@@ -352,14 +353,17 @@ def push_choice_point(state: WamState, n_args: int, next_clause: Any) -> None:
 
 def restore_choice_point(state: WamState, next_clause: Any = None) -> None:
     """Backtrack: restore state from current choice point (retry_me_else)."""
-    cp = state.stack[state.b]
+    cp_index = state.b
+    cp = state.stack[cp_index]
     assert isinstance(cp, ChoicePoint)
     # Undo trail
     undo_trail(state, cp.trail_top)
     # Trim heap (dict-based — remove entries >= mark, reset heap_len)
     heap_trim(state, cp.heap_top)
+    # Discard environments/frames younger than the restored choice point.
+    del state.stack[cp_index + 1:]
     # Restore registers
-    state.regs[:cp.n_args] = cp.saved_regs.copy()
+    state.regs[:cp.n_args + 1] = cp.saved_regs.copy()
     state.e = cp.saved_e
     state.cp = cp.saved_cp
     if next_clause is not None:
@@ -367,11 +371,12 @@ def restore_choice_point(state: WamState, next_clause: Any = None) -> None:
 
 def pop_choice_point(state: WamState) -> None:
     """Trust: restore from choice point and remove it (last clause)."""
-    cp = state.stack[state.b]
+    cp_index = state.b
+    cp = state.stack[cp_index]
     assert isinstance(cp, ChoicePoint)
     restore_choice_point(state)
-    # Remove the choice point
-    state.stack.pop()
+    # Remove the choice point and any frames above it.
+    del state.stack[cp_index:]
     state.b = cp.saved_b
 
 

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -1407,7 +1407,9 @@ is_ffi_predicate(Functor, Arity, Options) :-
 compile_all_predicates([], _Options, "# No predicates compiled\n").
 compile_all_predicates(Predicates, Options, Code) :-
 	Predicates \= [],
-	maplist(compile_one_predicate(Options), Predicates, PredCodes),
+	plan_python_predicates(Predicates, Options, Plans),
+	lowered_route_set(Plans, Options, LoweredSet),
+	maplist(compile_planned_predicate(Options, LoweredSet), Plans, PredCodes),
 	% Collect function names for build_program() registry
 	maplist(pred_func_name(Options), Predicates, FuncNames),
 	build_program_func(FuncNames, BuildProgramCode),
@@ -1423,6 +1425,100 @@ compile_all_predicates(Predicates, Options, Code) :-
 		| PredCodes
 	], '\n\n', PredSection),
 	atomic_list_concat([PredSection, '\n\n', BuildProgramCode], Code).
+
+plan_python_predicates(Predicates, Options, Plans) :-
+	maplist(plan_python_predicate(Options), Predicates, Plans).
+
+plan_python_predicate(Options, _Module:PredSpec, Plan) :- !,
+	plan_python_predicate(Options, PredSpec, Plan).
+plan_python_predicate(Options, Pred/Arity-WamCode, pred_plan(Pred, Arity, WamCode, Kind)) :- !,
+	(   is_ffi_predicate(Pred, Arity, Options)
+	->  Kind = ffi
+	;   Kind = wam
+	).
+plan_python_predicate(Options, Pred/Arity, pred_plan(Pred, Arity, WamCode, Kind)) :-
+	(   is_ffi_predicate(Pred, Arity, Options)
+	->  Kind = ffi,
+	    WamCode = ''
+	;   compile_predicate_to_wam(Pred/Arity, [], WamCode)
+	->  Kind = wam
+	;   WamCode = '',
+	    Kind = missing
+	).
+
+lowered_route_set(Plans, Options, LoweredSet) :-
+	(   option(emit_mode(lowered), Options)
+	->  findall(Pred/Arity,
+	        ( member(pred_plan(Pred, Arity, WamCode, wam), Plans),
+	          lowered_candidate_wam(WamCode)
+	        ),
+	        Candidates0),
+	    sort(Candidates0, Candidates),
+	    fix_lowered_route_set(Candidates, Plans, Options, LoweredSet)
+	;   LoweredSet = []
+	).
+
+lowered_candidate_wam(WamCode) :-
+	parse_wam_text_py(WamCode, Instrs),
+	is_deterministic_pred_py(Instrs).
+
+fix_lowered_route_set(Current, Plans, Options, Final) :-
+	include(lowered_route_supported(Plans, Options, Current), Current, Next0),
+	sort(Next0, Next),
+	(   Next == Current
+	->  Final = Next
+	;   fix_lowered_route_set(Next, Plans, Options, Final)
+	).
+
+lowered_route_supported(Plans, Options, Current, Pred/Arity) :-
+	member(pred_plan(Pred, Arity, WamCode, wam), Plans),
+	parse_wam_text_py(WamCode, Instrs),
+	findall(CalleePred/CalleeArity, direct_wam_call(Instrs, CalleePred/CalleeArity), Calls0),
+	sort(Calls0, Calls),
+	forall(member(CalleePred/CalleeArity, Calls),
+	    ( member(CalleePred/CalleeArity, Current)
+	    ; is_ffi_predicate(CalleePred, CalleeArity, Options)
+	    ; \+ planned_predicate(Plans, CalleePred/CalleeArity)
+	    )).
+
+planned_predicate(Plans, Pred/Arity) :-
+	member(pred_plan(Pred, Arity, _WamCode, Kind), Plans),
+	Kind \= missing.
+
+direct_wam_call(Instrs, Pred/Arity) :-
+	member(Instr, Instrs),
+	(   Instr = call(PredStr, ArityStr)
+	;   Instr = call_foreign(PredStr, ArityStr)
+	),
+	pred_string_indicator(PredStr, ArityStr, Pred/Arity).
+direct_wam_call(Instrs, Pred/Arity) :-
+	member(execute(PredStr), Instrs),
+	pred_string_indicator(PredStr, _ArityStr, Pred/Arity).
+
+pred_string_indicator(PredStr, ArityStr, Pred/Arity) :-
+	atom_string(PredAtom, PredStr),
+	(   sub_atom(PredAtom, B, 1, _, '/')
+	->  sub_atom(PredAtom, 0, B, _, Pred),
+	    B1 is B + 1,
+	    sub_atom(PredAtom, B1, _, 0, ArityAtom),
+	    atom_number(ArityAtom, Arity)
+	;   Pred = PredAtom,
+	    atom_string(ArityAtom0, ArityStr),
+	    atom_number(ArityAtom0, Arity)
+	).
+
+compile_planned_predicate(Options, LoweredSet, pred_plan(Pred, Arity, WamCode, Kind), PredCode) :-
+	(   Kind = ffi
+	->  compile_ffi_stub_predicate(Pred, Arity, Options, PredCode)
+	;   Kind = missing
+	->  atom_string(Pred, PredStr),
+	    format(string(PredCode), '# Could not compile ~w/~w to WAM\n', [PredStr, Arity])
+	;   member(Pred/Arity, LoweredSet)
+	->  compile_lowered_wam_predicate_to_python(Pred/Arity, WamCode, Options, PredCode)
+	;   option(emit_mode(lowered), Options)
+	->  compile_wam_predicate_to_python(Pred/Arity, WamCode, [registrar_prefix(register_)|Options], PredCode)
+	;   compile_wam_predicate_to_python(Pred/Arity, WamCode, Options, PredCode)
+	).
 
 %% pred_func_name(+Options, +PredSpec, -FuncName)
 %  Get the Python function name for a predicate (for build_program registry).
@@ -1467,7 +1563,7 @@ compile_one_predicate(Options, Pred/Arity-WamCode, PredCode) :-
 	).
 compile_one_predicate(Options, Pred/Arity, PredCode) :-
 	(   is_ffi_predicate(Pred, Arity, Options)
-	->  compile_ffi_stub_predicate(Pred, Arity, PredCode)
+	->  compile_ffi_stub_predicate(Pred, Arity, Options, PredCode)
 	;   (   compile_predicate_to_wam(Pred/Arity, [], WamCode)
 		->  compile_one_predicate(Options, Pred/Arity-WamCode, PredCode)
 		;   atom_string(Pred, PredStr),

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -424,6 +424,12 @@ test(emit_lowered_get_constant, [nondet]) :-
 	sub_string(Lines, _, _, _, "def pred_foo_1"),
 	sub_string(Lines, _, _, _, "Atom").
 
+test(emit_lowered_get_numeric_constant, [nondet]) :-
+	wam_python_lowered_emitter:emit_lowered_python('foo'/1, [get_constant("10", "1"), proceed], [], Lines),
+	Lines \= "",
+	sub_string(Lines, _, _, _, "Int(10)"),
+	assertion(\+ sub_string(Lines, _, _, _, "Atom(\"10\")")).
+
 test(emit_lowered_def_line, [nondet]) :-
 	% The emitted function starts with a proper def line
 	wam_python_lowered_emitter:emit_lowered_python('bar'/2, [proceed], [], Lines),
@@ -668,6 +674,16 @@ test(runtime_has_register_indexed_atom_fact2_pairs, [nondet]) :-
 test(runtime_has_register_indexed_weighted_edge_triples, [nondet]) :-
 	runtime_py_path(P), read_file_to_string(P, Content, []),
 	sub_string(Content, _, _, _, "def register_indexed_weighted_edge_triples").
+
+test(runtime_choicepoint_saves_one_indexed_argument_registers, [nondet]) :-
+	runtime_py_path(P), read_file_to_string(P, Content, []),
+	sub_string(Content, _, _, _, "state.regs[:n_args + 1]"),
+	sub_string(Content, _, _, _, "state.regs[:cp.n_args + 1]").
+
+test(runtime_choicepoint_discards_younger_frames, [nondet]) :-
+	runtime_py_path(P), read_file_to_string(P, Content, []),
+	sub_string(Content, _, _, _, "del state.stack[cp_index + 1:]"),
+	sub_string(Content, _, _, _, "del state.stack[cp_index:]").
 
 test(runtime_has_call_indexed_atom_fact2_handler, [nondet]) :-
 	runtime_py_path(P), read_file_to_string(P, Content, []),

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -196,12 +196,33 @@ test(compile_lowered_mode_falls_back_for_nondet) :-
 	assertion(sub_string(S, _, _, _, '("try_me_else", "choice_2")')),
 	assertion(\+ sub_string(S, _, _, _, "def pred_choice_1(state)")).
 
-test(compile_all_lowered_mode_build_program_uses_registrars) :-
+test(compile_all_lowered_mode_build_program_uses_registrars, [nondet]) :-
 	WamCode = 'foo/1:\n  get_constant a, 1\n  proceed',
 	wam_python_target:compile_all_predicates([foo/1-WamCode], [emit_mode(lowered)], PythonCode),
 	atom_string(PythonCode, S),
 	assertion(sub_string(S, _, _, _, "register_pred_foo_1(raw_program)")),
 	assertion(sub_string(S, _, _, _, '("call_lowered", pred_foo_1, 1)')).
+
+test(compile_all_lowered_mode_ffi_uses_registrar_prefix) :-
+	wam_python_target:compile_all_predicates(
+		[category_parent/2],
+		[emit_mode(lowered), foreign_predicates([category_parent/2])],
+		PythonCode),
+	atom_string(PythonCode, S),
+	assertion(sub_string(S, _, _, _, "def register_pred_category_parent_2(raw_program)")),
+	assertion(sub_string(S, _, _, _, "register_pred_category_parent_2(raw_program)")).
+
+test(compile_all_lowered_mode_keeps_direct_call_graph_consistent) :-
+	OuterWam = 'outer/1:\n  call inner/1, 1\n  proceed',
+	InnerWam = 'inner/1:\n  try_me_else inner_2\n  get_constant a, 1\n  proceed\ninner_2:\n  trust_me\n  get_constant b, 1\n  proceed',
+	wam_python_target:compile_all_predicates(
+		[outer/1-OuterWam, inner/1-InnerWam],
+		[emit_mode(lowered)],
+		PythonCode),
+	atom_string(PythonCode, S),
+	assertion(\+ sub_string(S, _, _, _, "def pred_outer_1(state)")),
+	assertion(sub_string(S, _, _, _, 'raw_program["outer/1"] = (')),
+	assertion(sub_string(S, _, _, _, '("call", "inner/1", 1)')).
 
 :- end_tests(wam_python_compile).
 


### PR DESCRIPTION
## Summary

- Switch the WAM Python effective-distance benchmark generators to lowered emission mode.
- Make lowered route planning dependency-aware so lowered Python functions only call callees that are also emitted as lowered functions.
- Fix lowered-mode FFI registrar naming for benchmark foreign predicates.
- Preserve 1-indexed WAM argument registers and discard younger frames during Python runtime choicepoint restore/trust.
- Lower numeric WAM constants as `Int`/`Float` terms instead of atoms, matching interpreter constant parsing.

## Verification

- `swipl -g run_tests -t halt tests/test_wam_python_target.pl`
- Tiny Termux smoke:
  - synthetic chain depth: `8`
  - articles: `2`
  - command: `python main.py /data/data/com.termux/files/usr/tmp/uw_synth_chain_8 1`
  - result: `query_ms=4 seeds=2 solutions=2 reps=1`
