### PR TITLE
feat(wam-clojure): lower compound builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -304,6 +304,10 @@ clojure_direct_builtin("var/1", "1").
 clojure_direct_builtin("var/1", 1).
 clojure_direct_builtin('var/1', "1").
 clojure_direct_builtin('var/1', 1).
+clojure_direct_builtin("compound/1", "1").
+clojure_direct_builtin("compound/1", 1).
+clojure_direct_builtin('compound/1', "1").
+clojure_direct_builtin('compound/1', 1).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
@@ -455,6 +459,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     !,
     format(atom(Expr),
            '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (or (= value ::lowered-unbound) (runtime/logic-var? value)) (runtime/advance ~w) (runtime/backtrack ~w)))',
+           [S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "compound/1" ; Op == 'compound/1'),
+    !,
+    format(atom(Expr),
+           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (runtime/structure-term? value) (runtime/advance ~w) (runtime/backtrack ~w)))',
            [S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -847,6 +847,13 @@
               (advance state)
               (backtrack state)))
 
+          "compound/1"
+          (let [value (deref-value (:bindings state)
+                                   (or (reg-get-raw state "A1") ::unbound))]
+            (if (structure-term? value)
+              (advance state)
+              (backtrack state)))
+
           "!/0"
           (-> state
               (update :choice-points #(vec (take (:cut-bar state) %)))

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -114,6 +114,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, '"atomic/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"nonvar/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"var/1"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"compound/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-bindings [state bindings]')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -277,6 +277,28 @@ test(terminal_execute_var_is_direct_lowered_as_succeeding_builtin) :-
         assertion(\+ has(Code, ":pc target-pc"))
     )).
 
+test(simple_builtin_compound_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_compound/1:\nbuiltin_call compound/1, 1\nproceed\n",
+        wam_clojure_lowerable(test_compound/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_compound/1, WamCode, [], Code),
+        has(Code, "runtime/deref-value"),
+        has(Code, "runtime/structure-term? value"),
+        has(Code, "runtime/advance"),
+        has(Code, "runtime/backtrack")
+    )).
+
+test(terminal_execute_compound_is_direct_lowered_as_succeeding_builtin) :-
+    once((
+        WamCode = "test_execute_compound/1:\nallocate\ndeallocate\nexecute compound/1\n",
+        wam_clojure_lowerable(test_execute_compound/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_execute_compound/1, WamCode, [], Code),
+        has(Code, "runtime/structure-term? value"),
+        has(Code, "runtime/succeed-state next-state"),
+        assertion(\+ has(Code, "\"compound/1\"")),
+        assertion(\+ has(Code, ":pc target-pc"))
+    )).
+
 test(env_framed_equality_reaches_direct_builtin_prefix) :-
     once((
         WamCode = "test_env_eq/2:\nallocate\nput_value X1, A1\nput_value X2, A2\nbuiltin_call =/2, 2\ndeallocate\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -47,6 +47,8 @@
 :- dynamic user:wam_nonvar_unbound/1.
 :- dynamic user:wam_var_guard/1.
 :- dynamic user:wam_var_unbound/1.
+:- dynamic user:wam_compound_guard/1.
+:- dynamic user:wam_compound_unbound/1.
 
 has(Code, Substr) :-
     once(sub_string(Code, _, _, _, Substr)).
@@ -96,6 +98,8 @@ user:wam_unbound_arg(_).
 user:wam_nonvar_unbound(_) :- user:wam_unbound_arg(Y), nonvar(Y).
 user:wam_var_guard(X) :- var(X).
 user:wam_var_unbound(_) :- user:wam_unbound_arg(Y), var(Y).
+user:wam_compound_guard(X) :- compound(X).
+user:wam_compound_unbound(_) :- user:wam_unbound_arg(Y), compound(Y).
 
 :- initialization(main, main).
 
@@ -149,7 +153,9 @@ run_smoke :-
           user:wam_unbound_arg/1,
           user:wam_nonvar_unbound/1,
           user:wam_var_guard/1,
-          user:wam_var_unbound/1
+          user:wam_var_unbound/1,
+          user:wam_compound_guard/1,
+          user:wam_compound_unbound/1
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
@@ -174,6 +180,7 @@ run_smoke :-
     assert_lowered_atomic_builtin_emitted(TmpDir),
     assert_lowered_nonvar_builtin_emitted(TmpDir),
     assert_lowered_var_builtin_emitted(TmpDir),
+    assert_lowered_compound_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
@@ -248,6 +255,11 @@ run_smoke :-
     verify_output(TmpDir, 'wam_var_guard/1', 42, "false"),
     verify_output(TmpDir, 'wam_var_guard/1', 'f(a)', "false"),
     verify_output(TmpDir, 'wam_var_unbound/1', a, "true"),
+    verify_output(TmpDir, 'wam_compound_guard/1', a, "false"),
+    verify_output(TmpDir, 'wam_compound_guard/1', 42, "false"),
+    verify_output(TmpDir, 'wam_compound_guard/1', 'f(a)', "true"),
+    verify_output(TmpDir, 'wam_compound_guard/1', '[a,b]', "true"),
+    verify_output(TmpDir, 'wam_compound_unbound/1', a, "false"),
     delete_directory_and_contents(TmpDir),
     writeln('wam_clojure_runtime_smoke: ok').
 
@@ -348,6 +360,13 @@ assert_lowered_var_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-var-unbound-1"),
     has(CoreCode, "= value ::lowered-unbound"),
     has(CoreCode, "runtime/logic-var? value").
+
+assert_lowered_compound_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-compound-guard-1"),
+    has(CoreCode, "defn lowered-wam-compound-unbound-1"),
+    has(CoreCode, "runtime/structure-term? value").
 
 assert_multiclause_wrappers_runtime_mediated(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM runtime support for `builtin_call compound/1`.
- Adds direct lowered-prefix support for deterministic `compound/1` builtin calls.
- Reuses the terminal direct-builtin path for compiler-emitted `execute compound/1`.
- Treats normalized structure/list terms as compound values.
- Adds generator, lowered-emitter, and runtime smoke coverage for structure, list, atom, number, and unbound cases.

## Why

`compound/1` complements the existing lowered `atomic/1` support. It is a pure dereference check: normalized compound terms succeed, while atoms, numbers, and unbound variables fail.

This keeps simple compound guard predicates on the Clojure lowered path without introducing new binding behavior or changing WAM-visible semantics.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
