### PR TITLE
fix: Clean up Prolog warning noise across target modules

### DIFF
--- a/src/unifyweaver/core/advanced/advanced_recursive_compiler.pl
+++ b/src/unifyweaver/core/advanced/advanced_recursive_compiler.pl
@@ -26,7 +26,7 @@
 ]).
 :- use_module('purity_analysis', [is_associative_op/1]).
 :- use_module('tail_recursion').
-:- use_module('linear_recursion').
+:- use_module('linear_recursion', except([is_recursive_clause/2])).
 :- use_module('multicall_linear_recursion').
 :- use_module('tree_recursion').
 :- use_module('mutual_recursion').

--- a/src/unifyweaver/core/jvm_bytecode.pl
+++ b/src/unifyweaver/core/jvm_bytecode.pl
@@ -574,9 +574,9 @@ jvm_println_bytecode(Expr, VarMap, Instructions) :-
 
 %% jvm_resolve_string_operand(+Expr, +VarMap, -Instructions)
 %%   Resolve an expression to bytecode that leaves a String/Object on stack.
-jvm_resolve_string_operand(Expr, _VarMap, [Instr]) :-
+jvm_resolve_string_operand(Expr, VarMap, [Instr]) :-
     atom(Expr),
-    \+ lookup_var(Expr, _VarMap, _),
+    \+ lookup_var(Expr, VarMap, _),
     !,
     jvm_load_string(Expr, Instr).
 jvm_resolve_string_operand(Expr, VarMap, [Instr]) :-

--- a/src/unifyweaver/core/recursive_compiler.pl
+++ b/src/unifyweaver/core/recursive_compiler.pl
@@ -9,6 +9,7 @@
 :- module(recursive_compiler, [
     compile_recursive/3,
     compile_recursive/2,
+    is_transitive_closure/5,
     test_recursive_compiler/0
 ]).
 
@@ -18,7 +19,7 @@
 :- use_module('advanced/advanced_recursive_compiler').
 :- use_module('advanced/call_graph').
 :- use_module('advanced/tail_recursion').
-:- use_module('advanced/linear_recursion').
+:- use_module('advanced/linear_recursion', except([is_recursive_clause/2])).
 :- use_module(stream_compiler).
 :- use_module('../targets/awk_target').
 :- use_module('../targets/csharp_query_target').

--- a/src/unifyweaver/targets/awk_target.pl
+++ b/src/unifyweaver/targets/awk_target.pl
@@ -158,14 +158,6 @@ compile_general_recursive_to_awk(Pred, Arity, Clauses, Options, AwkCode) :-
     ;   StepRelStr = "step",
         StepFacts = []
     ),
-    % Build BEGIN block with step data
-    findall(InitLine,
-        (   member(K-V, StepFacts),
-            format(string(InitLine),
-                '    ~w["~w"] = ~w["~w"] " ~w"',
-                [StepRelStr, K, StepRelStr, K, V])
-        ),
-        InitLines),
     % Also build individual edge lines for the fixpoint
     findall(EdgeLine,
         (   member(K-V, StepFacts),
@@ -174,7 +166,6 @@ compile_general_recursive_to_awk(Pred, Arity, Clauses, Options, AwkCode) :-
                 [K, FieldSep, V])
         ),
         EdgeLines),
-    atomic_list_concat(InitLines, '\n', InitBlock),
     atomic_list_concat(EdgeLines, '\n', EdgeBlock),
     length(StepFacts, NEdges),
     (   Arity =:= 3
@@ -2947,7 +2938,7 @@ awk_classified_output_goal(Goal, VarMap0, Line, VarMapOut) :-
     ->  ensure_var(VarMap0, Var, VarName, VarMapOut),
         awk_expr(ArithExpr, VarMap0, ExprStr),
         format(string(Line), '    ~w = ~w', [VarName, ExprStr])
-    ;   VarName = "_", VarMapOut = VarMap0,
+    ;   VarMapOut = VarMap0,
         Line = "    # unsupported output goal"
     ).
 

--- a/src/unifyweaver/targets/csharp_runtime/custom_csharp.pl
+++ b/src/unifyweaver/targets/csharp_runtime/custom_csharp.pl
@@ -24,7 +24,7 @@
     compile_component/4
 ]).
 
-:- use_module('../../core/component_registry').
+:- use_module('../../core/component_registry', [register_component_type/4]).
 
 %% type_info(-Info)
 %

--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -42,7 +42,7 @@
 :- use_module('../bindings/csharp_bindings').
 :- use_module('../core/pipeline_validation').
 :- use_module(common_generator).
-:- use_module(csharp_native_target).
+:- use_module(csharp_native_target, except([compile_predicate_to_csharp/3])).
 
 % Component system integration (ported from Go target)
 :- use_module('../core/component_registry').

--- a/src/unifyweaver/targets/fsharp_target.pl
+++ b/src/unifyweaver/targets/fsharp_target.pl
@@ -860,7 +860,6 @@ generate_fsharp_fields(Arity, Fields) :-
     atomic_list_concat(FieldList, '\n    ', Fields).
 
 generate_fsharp_fact_entry(Args, Entry) :-
-    length(Args, Arity),
     findall(FieldVal, (
         nth1(N, Args, Arg),
         format(string(FieldVal), 'Arg~w = "~w"', [N, Arg])

--- a/src/unifyweaver/targets/ilasm_target.pl
+++ b/src/unifyweaver/targets/ilasm_target.pl
@@ -180,7 +180,7 @@ ilasm_locals_from_body(Body, LocalDecls) :-
 % ============================================================================
 
 %% native_ilasm_clause_body(+PredSpec, +Clauses, -Code)
-native_ilasm_clause_body(PredStr/Arity, Clauses, Code) :-
+native_ilasm_clause_body(_PredStr/Arity, Clauses, Code) :-
     Arity1 is Arity - 1,
     ilasm_clauses_to_branches(Clauses, Arity1, Branches),
     Branches \= [],

--- a/src/unifyweaver/targets/jamaica_target.pl
+++ b/src/unifyweaver/targets/jamaica_target.pl
@@ -18,6 +18,7 @@
     compile_tree_recursion_jamaica/3,
     compile_multicall_recursion_jamaica/3,
     compile_direct_multicall_jamaica/3,
+    compile_mutual_recursion_jamaica/2,
     compile_mutual_recursion_jamaica/3,
     % Component system
     jamaica_type_info/1,
@@ -245,6 +246,9 @@ compile_direct_multicall_jamaica(Pred/Arity, _Options, Code) :-
 mutual_recursion:compile_mutual_pattern(jamaica, Predicates, _MemoEnabled, _MemoStrategy, Code) :-
     compile_mutual_recursion_jamaica(Predicates, [], Code).
 
+compile_mutual_recursion_jamaica(Predicates, Code) :-
+    compile_mutual_recursion_jamaica(Predicates, [], Code).
+
 compile_mutual_recursion_jamaica(Predicates, _Options, Code) :-
     (   Predicates = [Pred1|_]
     ->  atom_string(Pred1, P1Str),
@@ -319,9 +323,6 @@ public class ~w {
   }
 }
 ', [ClassName, PredStr, CoreParams, CoreBody, EntryName, EntryParams, EntryBody]).
-
-ensure_string(S, S) :- string(S), !.
-ensure_string(A, S) :- atom_string(A, S).
 
 %% write_jamaica_program(+Code, +Filename)
 write_jamaica_program(Code, Filename) :-

--- a/src/unifyweaver/targets/krakatau_target.pl
+++ b/src/unifyweaver/targets/krakatau_target.pl
@@ -18,6 +18,7 @@
     compile_tree_recursion_krakatau/3,
     compile_multicall_recursion_krakatau/3,
     compile_direct_multicall_krakatau/3,
+    compile_mutual_recursion_krakatau/2,
     compile_mutual_recursion_krakatau/3,
     krakatau_type_info/1,
     krakatau_validate_config/1,
@@ -217,6 +218,9 @@ compile_direct_multicall_krakatau(Pred/Arity, _Options, Code) :-
 
 %% Mutual recursion
 mutual_recursion:compile_mutual_pattern(krakatau, Predicates, _MemoEnabled, _MemoStrategy, Code) :-
+    compile_mutual_recursion_krakatau(Predicates, [], Code).
+
+compile_mutual_recursion_krakatau(Predicates, Code) :-
     compile_mutual_recursion_krakatau(Predicates, [], Code).
 
 compile_mutual_recursion_krakatau(Predicates, _Options, Code) :-

--- a/src/unifyweaver/targets/llvm_target.pl
+++ b/src/unifyweaver/targets/llvm_target.pl
@@ -675,7 +675,7 @@ recurse:
 %  Generate C header file for the exported functions.
 generate_c_header(Functions, HeaderCode) :-
     findall(Decl, (
-        member(func(Name, _Arity, _Type), Functions),
+        member(func(Name, _, _), Functions),
         atom_string(Name, NameStr),
         format(string(Decl), 'int64_t ~w(int64_t n);', [NameStr])
     ), Decls),
@@ -705,7 +705,7 @@ extern "C" {
 %  Generate Go code with cgo bindings.
 generate_cgo_bindings(Functions, GoCode) :-
     findall(GoFunc, (
-        member(func(Name, _Arity, _Type), Functions),
+        member(func(Name, _, _), Functions),
         atom_string(Name, NameStr),
         format(string(GoFunc),
 '// ~w calls the LLVM-compiled ~w function
@@ -732,14 +732,14 @@ import "C"
 %  Generate Rust FFI bindings.
 generate_rust_ffi(Functions, RustCode) :-
     findall(RustDecl, (
-        member(func(Name, _Arity, _Type), Functions),
+        member(func(Name, _, _), Functions),
         atom_string(Name, NameStr),
         format(string(RustDecl), '    fn ~w(n: i64) -> i64;', [NameStr])
     ), RustDecls),
     atomic_list_concat(RustDecls, '\n', RustDeclSection),
     
     findall(RustWrapper, (
-        member(func(Name, _Arity, _Type), Functions),
+        member(func(Name, _, _), Functions),
         atom_string(Name, NameStr),
         format(string(RustWrapper),
 '/// Calls the LLVM-compiled ~w function
@@ -881,7 +881,7 @@ recurse:
 %  Generate JavaScript bindings for Node.js and browser.
 generate_js_bindings(Functions, JSCode) :-
     findall(JSFunc, (
-        member(func(Name, _Arity, _Type), Functions),
+        member(func(Name, _, _), Functions),
         atom_string(Name, NameStr),
         format(string(JSFunc),
 '  ~w: (n) => instance.exports.~w(n)', [NameStr, NameStr])
@@ -920,14 +920,14 @@ module.exports = { loadPrologMath, loadPrologMathNode };
 %  Generate TypeScript bindings with type definitions.
 generate_ts_bindings(Functions, TSCode) :-
     findall(TSDecl, (
-        member(func(Name, _Arity, _Type), Functions),
+        member(func(Name, _, _), Functions),
         atom_string(Name, NameStr),
         format(string(TSDecl), '  ~w(n: number): number;', [NameStr])
     ), TSDecls),
     atomic_list_concat(TSDecls, '\n', TSDeclSection),
     
     findall(TSFunc, (
-        member(func(Name, _Arity, _Type), Functions),
+        member(func(Name, _, _), Functions),
         atom_string(Name, NameStr),
         format(string(TSFunc),
 '  ~w: (n: number): number => instance.exports.~w(n)', [NameStr, NameStr])
@@ -1571,7 +1571,7 @@ llvm_value(Expr, VarMap, Value) :-
     expr_op(Op, _),
     !,
     llvm_value(Left, VarMap, LVal),
-    llvm_value(Right, VarMap, RVal),
+    llvm_value(Right, VarMap, _),
     % For compound expressions used as values, just use left operand
     % (proper setup code handles the computation)
     Value = LVal.

--- a/src/unifyweaver/targets/lua_target.pl
+++ b/src/unifyweaver/targets/lua_target.pl
@@ -1301,7 +1301,28 @@ lua_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
     lua_output_goal_last(Goal, VarMap, Lines).
 lua_render_classified_last(_, _, [], []).
 
-%% lua_output_goal_last(+Goal, +VarMap, -Lines)
+%% lua_guard_condition(+VarMap, +Goal, -Condition)
+lua_guard_condition(VarMap, _Module:Goal, Condition) :-
+    !, lua_guard_condition(VarMap, Goal, Condition).
+lua_guard_condition(VarMap, Goal, Condition) :-
+    compound(Goal),
+    Goal =.. [Op, Left, Right],
+    expr_op(Op, StdOp),
+    !,
+    lua_expr(Left, VarMap, LLeft),
+    lua_expr(Right, VarMap, LRight),
+    lua_op(StdOp, LOp),
+    format(string(Condition), '~w ~w ~w', [LLeft, LOp, LRight]).
+
+%% lua_output_goals(+Goals, +VarMap, -Code)
+lua_output_goals([], _VarMap, '"error"') :- !.
+lua_output_goals([Goal], VarMap, Code) :-
+    !, lua_output_goal_last(Goal, VarMap, Code).
+lua_output_goals([Goal|Rest], VarMap0, Code) :-
+    lua_output_goal(Goal, VarMap0, _Line, VarMap1),
+    lua_output_goals(Rest, VarMap1, Code).
+
+%% lua_output_goal_last — produce the return expression
 lua_output_goal_last(Goal, VarMap, [Line]) :-
     lua_output_goal(Goal, VarMap, AssignLine, VarMapOut),
     (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMapOut, OutName)
@@ -1311,6 +1332,18 @@ lua_output_goal_last(Goal, VarMap, [Line]) :-
 lua_output_goal_last(Goal, VarMap, [Line]) :-
     lua_branch_value(Goal, VarMap, Expr),
     format(string(Line), '    return ~w', [Expr]).
+lua_output_goal_last(_Module:Goal, VarMap, Code) :-
+    !, lua_output_goal_last(Goal, VarMap, Code).
+lua_output_goal_last(Goal, VarMap, Code) :-
+    if_then_else_goal(Goal, IfGoal, ThenGoal, ElseGoal),
+    !,
+    lua_if_then_else_output(IfGoal, ThenGoal, ElseGoal, VarMap, Code).
+lua_output_goal_last(=(Var, Expr), VarMap, Code) :-
+    var(Var), !,
+    lua_expr(Expr, VarMap, Code).
+lua_output_goal_last(is(Var, Expr), VarMap, Code) :-
+    var(Var), !,
+    lua_expr(Expr, VarMap, Code).
 
 %% lua_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
 lua_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
@@ -1357,41 +1390,6 @@ lua_disj_elseif_chain([Alt|Rest], VarMap, [ElifLine, RetLine|RestLines]) :-
     format(string(ElifLine), '    elseif ~w then', [CondExpr]),
     format(string(RetLine), '        return ~w', [ValExpr]),
     lua_disj_elseif_chain(Rest, VarMap, RestLines).
-
-%% lua_guard_condition(+VarMap, +Goal, -Condition)
-lua_guard_condition(VarMap, _Module:Goal, Condition) :-
-    !, lua_guard_condition(VarMap, Goal, Condition).
-lua_guard_condition(VarMap, Goal, Condition) :-
-    compound(Goal),
-    Goal =.. [Op, Left, Right],
-    expr_op(Op, StdOp),
-    !,
-    lua_expr(Left, VarMap, LLeft),
-    lua_expr(Right, VarMap, LRight),
-    lua_op(StdOp, LOp),
-    format(string(Condition), '~w ~w ~w', [LLeft, LOp, LRight]).
-
-%% lua_output_goals(+Goals, +VarMap, -Code)
-lua_output_goals([], _VarMap, '"error"') :- !.
-lua_output_goals([Goal], VarMap, Code) :-
-    !, lua_output_goal_last(Goal, VarMap, Code).
-lua_output_goals([Goal|Rest], VarMap0, Code) :-
-    lua_output_goal(Goal, VarMap0, _Line, VarMap1),
-    lua_output_goals(Rest, VarMap1, Code).
-
-%% lua_output_goal_last — produce the return expression
-lua_output_goal_last(_Module:Goal, VarMap, Code) :-
-    !, lua_output_goal_last(Goal, VarMap, Code).
-lua_output_goal_last(Goal, VarMap, Code) :-
-    if_then_else_goal(Goal, IfGoal, ThenGoal, ElseGoal),
-    !,
-    lua_if_then_else_output(IfGoal, ThenGoal, ElseGoal, VarMap, Code).
-lua_output_goal_last(=(Var, Expr), VarMap, Code) :-
-    var(Var), !,
-    lua_expr(Expr, VarMap, Code).
-lua_output_goal_last(is(Var, Expr), VarMap, Code) :-
-    var(Var), !,
-    lua_expr(Expr, VarMap, Code).
 
 %% lua_output_goal — produce a local assignment (not used as return)
 lua_output_goal(_Module:Goal, VarMap0, Line, VarMapOut) :-
@@ -1700,7 +1698,7 @@ function ~w_worker(arg1, visited)\n\c
 end\n',
     [PredStr, PredStr, PredStr, PredStr, BaseCheck, RecCallExpr]).
 
-extract_rec_call_lua((A, B), PredStr, Expr) :-
+extract_rec_call_lua((A, _), PredStr, Expr) :-
     nonvar(A),
     functor(A, Pred, _),
     atom_string(Pred, PredStr), !,

--- a/src/unifyweaver/targets/perl_target.pl
+++ b/src/unifyweaver/targets/perl_target.pl
@@ -2157,7 +2157,7 @@ sub ~w {\n\c
 }\n',
     [PredStr, PredStr, WorkerStr, WorkerStr, BaseCheck, RecCallExpr]).
 
-extract_rec_call_perl((A, B), PredStr, WorkerStr, Expr) :-
+extract_rec_call_perl((A, _), PredStr, WorkerStr, Expr) :-
     nonvar(A),
     functor(A, Pred, _),
     atom_string(Pred, PredStr), !,

--- a/src/unifyweaver/targets/python_runtime/custom_python.pl
+++ b/src/unifyweaver/targets/python_runtime/custom_python.pl
@@ -24,7 +24,7 @@
     compile_component/4
 ]).
 
-:- use_module('../../core/component_registry').
+:- use_module('../../core/component_registry', [register_component_type/4]).
 
 %% type_info(-Info)
 %

--- a/src/unifyweaver/targets/python_target.pl
+++ b/src/unifyweaver/targets/python_target.pl
@@ -83,7 +83,10 @@
 % Conditional import of call_graph for mutual recursion detection
 % Falls back gracefully if module not available
 :- catch(use_module('../core/advanced/call_graph'), _, true).
-:- use_module(common_generator).
+:- use_module(common_generator, [
+    translate_builtin_common/4,
+    prepare_negation_data/4
+]).
 
 % Binding system integration (ported from PowerShell target)
 :- use_module('../core/binding_registry').
@@ -1373,22 +1376,14 @@ compile_service_mesh_python(service(Name, Options, HandlerSpec), PythonCode) :-
         CBTimeout = 30000
     ),
     % Retry with backoff
-    ( ( member(retry(RetryN, RetryStrategy, RetryOpts), Options) ->
-          ( member(delay(RetryDelay), RetryOpts) -> true ; RetryDelay = 100 ),
-          ( member(max_delay(RetryMaxDelay), RetryOpts) -> true ; RetryMaxDelay = 30000 )
-      ; member(retry(RetryN, RetryStrategy), Options) ->
-          RetryDelay = 100,
-          RetryMaxDelay = 30000
-      ) ->
+    ( service_mesh_retry_options(Options, RetryN, RetryStrategy, RetryDelay, RetryMaxDelay) ->
         generate_retry_python(config(RetryN, RetryStrategy, RetryDelay, RetryMaxDelay), RetryCode),
         atom_string(RetryStrategy, RetryStrategyStr),
         format(string(RetryConfig), "RetryConfig(~w, '~w', ~w, ~w)", [RetryN, RetryStrategyStr, RetryDelay, RetryMaxDelay])
     ;
         RetryCode = "",
         RetryConfig = "None",
-        RetryN = 0,
-        RetryDelay = 100,
-        RetryMaxDelay = 30000
+        RetryN = 0
     ),
     % Backends
     ( member(backends(Backends), Options) ->
@@ -1534,10 +1529,18 @@ class ~wService(Service):
 
 # Register service
 register_service('~w', ~wService())
-", [LoadBalancerCode, CircuitBreakerCode, RetryCode,
-    ClassNameAtom, Name, LBStrategyStr, CBThreshold, CBTimeout, RetryN,
-    Name, Stateful, BackendsCode, LBStrategyStr, CBConfig, RetryConfig,
-    HandlerCode, Name, ClassNameAtom]).
+	", [LoadBalancerCode, CircuitBreakerCode, RetryCode,
+	    ClassNameAtom, Name, LBStrategyStr, CBThreshold, CBTimeout, RetryN,
+	    Name, Stateful, BackendsCode, LBStrategyStr, CBConfig, RetryConfig,
+	    HandlerCode, Name, ClassNameAtom]).
+
+service_mesh_retry_options(Options, RetryN, RetryStrategy, RetryDelay, RetryMaxDelay) :-
+    member(retry(RetryN, RetryStrategy, RetryOpts), Options),
+    !,
+    ( member(delay(RetryDelay), RetryOpts) -> true ; RetryDelay = 100 ),
+    ( member(max_delay(RetryMaxDelay), RetryOpts) -> true ; RetryMaxDelay = 30000 ).
+service_mesh_retry_options(Options, RetryN, RetryStrategy, 100, 30000) :-
+    member(retry(RetryN, RetryStrategy), Options).
 
 %% generate_load_balancer_python(+Strategy, -Code)
 %  Generate Python load balancer infrastructure.
@@ -3053,6 +3056,39 @@ compile_non_recursive_predicate(Name, Arity, Clauses, Options, PythonCode) :-
     generate_python_main(Options, Main),
     format(string(PythonCode), "~s~s\n~s\n~s", [Header, Helpers, FuncCode, Main]).
 
+compile_non_recursive_predicate(_Name, Arity, Clauses, Options, PythonCode) :-
+    % Fallback: per-clause functions with yield
+    % Generate clause functions
+    findall(ClauseCode, (
+        nth0(Index, Clauses, (ClauseHead, ClauseBody)),
+        translate_clause(ClauseHead, ClauseBody, Index, Arity, ClauseCode)
+    ), ClauseCodes),
+    atomic_list_concat(ClauseCodes, "\n", AllClausesCode),
+
+    % Generate process_stream calls
+    findall(Call, (
+        nth0(Index, Clauses, _),
+        format(string(Call), "        yield from _clause_~d(record)", [Index])
+    ), Calls),
+    atomic_list_concat(Calls, "\n", CallsCode),
+
+    header(Header),
+    helpers(Helpers),
+
+    generate_python_main(Options, Main),
+
+    format(string(Logic),
+"
+~s
+
+def process_stream(records: Iterator[Dict]) -> Iterator[Dict]:
+    \"\"\"Generated predicate logic.\"\"\"
+    for record in records:
+~s
+\n", [AllClausesCode, CallsCode]),
+
+    format(string(PythonCode), "~s~s~s~s", [Header, Helpers, Logic, Main]).
+
 %% python_arg_split(+Arity, +ClausePairs, -InputArity)
 %  Determine how many args are inputs vs outputs.
 %  Arity 1: all args are inputs (boolean predicate — guard-only)
@@ -3085,6 +3121,8 @@ python_arg_split(Arity, ClausePairs, InputArity) :-
     ),
     InputArity >= 1,
     !.
+python_arg_split(Arity, _, InputArity) :-
+    InputArity is max(1, Arity - 1).
 
 %% python_fact_input_count(+HeadArgs, -InputCount)
 %  For pure facts, count the number of distinct first-occurrence variables.
@@ -3144,7 +3182,6 @@ python_typed_arg_list(Name/Arity, InputArity, ArgList) :-
     ).
 
 has_python_type_annotations(Name/Arity) :-
-    functor(Head, Name, Arity),
     (   clause(type_declarations:uw_type(Name/Arity, _, _), true)
     ;   clause(user:uw_type(Name/Arity, _, _), true)
     ), !.
@@ -3196,9 +3233,6 @@ python_count_first_occurrences([Arg|Rest], Seen, Acc, Count) :-
         Acc1 is Acc + 1,
         python_count_first_occurrences(Rest, Seen, Acc1, Count)
     ).
-python_arg_split(Arity, _, InputArity) :-
-    InputArity is max(1, Arity - 1).
-
 %% count_output_vars(+ClassifiedGoals, +HeadArgs, -Count)
 %  Count how many head args are assigned as outputs in the body.
 count_output_vars(ClassifiedGoals, HeadArgs, Count) :-
@@ -3214,38 +3248,6 @@ classified_output_var(output(_, Var, _), Var).
 classified_output_var(output_ite(_, _, _, Vars), Var) :- member(Var, Vars).
 classified_output_var(output_disj(_, Vars), Var) :- member(Var, Vars).
 classified_output_var(output_if_then(_, _, Vars), Var) :- member(Var, Vars).
-compile_non_recursive_predicate(_Name, Arity, Clauses, Options, PythonCode) :-
-    % Fallback: per-clause functions with yield
-    % Generate clause functions
-    findall(ClauseCode, (
-        nth0(Index, Clauses, (ClauseHead, ClauseBody)),
-        translate_clause(ClauseHead, ClauseBody, Index, Arity, ClauseCode)
-    ), ClauseCodes),
-    atomic_list_concat(ClauseCodes, "\n", AllClausesCode),
-
-    % Generate process_stream calls
-    findall(Call, (
-        nth0(Index, Clauses, _),
-        format(string(Call), "        yield from _clause_~d(record)", [Index])
-    ), Calls),
-    atomic_list_concat(Calls, "\n", CallsCode),
-
-    header(Header),
-    helpers(Helpers),
-
-    generate_python_main(Options, Main),
-
-    format(string(Logic),
-"
-~s
-
-def process_stream(records: Iterator[Dict]) -> Iterator[Dict]:
-    \"\"\"Generated predicate logic.\"\"\"
-    for record in records:
-~s
-\n", [AllClausesCode, CallsCode]),
-
-    format(string(PythonCode), "~s~s~s~s", [Header, Helpers, Logic, Main]).
 
 % ============================================================================
 % NATIVE CLAUSE BODY LOWERING
@@ -3510,7 +3512,7 @@ python_render_classified_goals([Classified], VarMap, Conds, Lines) :-
     !,
     python_render_classified_last(Classified, VarMap, Conds, Lines).
 %% Guarded tail: output followed by guard(s) — assign first, then conditional return
-python_render_classified_goals([output(Goal, Var, _Expr)|Rest], VarMap, [], Lines) :-
+python_render_classified_goals([output(Goal, _Var, _Expr)|Rest], VarMap, [], Lines) :-
     Rest = [guard(_, _)|_],
     !,
     python_output_goal(Goal, VarMap, AssignLine, VarMap1),
@@ -3566,39 +3568,6 @@ python_render_classified_last(guard(Goal, _Expr), VarMap, [Cond], []) :-
     python_guard_condition(VarMap, Goal, Cond).
 python_render_classified_last(output(Goal, _Var, _Expr), VarMap, [], Lines) :-
     python_output_goal_last(Goal, VarMap, Lines, _).
-
-%% Multi-output: when there are previous output assignments, return tuple
-python_render_classified_goals_multi_return(ClassifiedGoals, VarMap, Conds, Lines) :-
-    %% Collect all output var names
-    collect_output_var_names(ClassifiedGoals, VarMap, OutputNames),
-    OutputNames = [_,_|_],  %% at least 2 outputs
-    !,
-    %% Render all goals as mid (assignments), then add tuple return
-    python_render_all_as_mid(ClassifiedGoals, VarMap, Conds, MidLines, _),
-    format(string(TupleStr), '~w', [OutputNames]),
-    atomic_list_concat(OutputNames, ', ', TupleInner),
-    format(string(ReturnLine), '    return (~w)', [TupleInner]),
-    append(MidLines, [ReturnLine], Lines).
-
-python_render_all_as_mid([], _VarMap, [], [], _VarMap).
-python_render_all_as_mid([C|Rest], VarMap, Conds, Lines, VarMapOut) :-
-    python_render_classified_mid(C, VarMap, MConds, MLines, VarMap1),
-    python_render_all_as_mid(Rest, VarMap1, RConds, RLines, VarMapOut),
-    append(MConds, RConds, Conds),
-    append(MLines, RLines, Lines).
-
-collect_output_var_names([], _, []).
-collect_output_var_names([output(Goal, _Var, _)|Rest], VarMap, [Name|Names]) :-
-    goal_output_var(Goal, OutVar),
-    lookup_var(OutVar, VarMap, Name), !,
-    collect_output_var_names(Rest, VarMap, Names).
-collect_output_var_names([output(Goal, _Var, _)|Rest], VarMap, [Name|Names]) :-
-    %% Fallback: ensure the var gets a name
-    goal_output_var(Goal, OutVar),
-    ensure_var(VarMap, OutVar, Name, VarMap1), !,
-    collect_output_var_names(Rest, VarMap1, Names).
-collect_output_var_names([_|Rest], VarMap, Names) :-
-    collect_output_var_names(Rest, VarMap, Names).
 python_render_classified_last(output_ite(If, Then, Else, SharedVars), VarMap, [], Lines) :-
     python_guard_condition(VarMap, If, Cond),
     length(SharedVars, SharedCount),
@@ -3618,6 +3587,44 @@ python_render_classified_last(output_ite(If, Then, Else, SharedVars), VarMap, []
         python_branch_return_lines(ElseLines, ElseVars, SharedCount, IndentedElse),
         append([IfLine|IndentedThen], [ElseLine|IndentedElse], Lines)
     ).
+python_render_classified_last(output_disj(Alternatives, SharedVars), VarMap, [], Lines) :-
+    python_classified_disj_return(Alternatives, SharedVars, VarMap, Lines).
+python_render_classified_last(output_if_then(If, Then, OutputVars), VarMap, [], Lines) :-
+    python_classified_if_then_return(If, Then, OutputVars, VarMap, Lines).
+python_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
+    python_output_goal_last(Goal, VarMap, Lines, _).
+
+%% Multi-output: when there are previous output assignments, return tuple
+python_render_classified_goals_multi_return(ClassifiedGoals, VarMap, Conds, Lines) :-
+    %% Collect all output var names
+    collect_output_var_names(ClassifiedGoals, VarMap, OutputNames),
+    OutputNames = [_,_|_],  %% at least 2 outputs
+    !,
+    %% Render all goals as mid (assignments), then add tuple return
+    python_render_all_as_mid(ClassifiedGoals, VarMap, Conds, MidLines, _),
+    atomic_list_concat(OutputNames, ', ', TupleInner),
+    format(string(ReturnLine), '    return (~w)', [TupleInner]),
+    append(MidLines, [ReturnLine], Lines).
+
+python_render_all_as_mid([], VarMap, [], [], VarMap).
+python_render_all_as_mid([C|Rest], VarMap, Conds, Lines, VarMapOut) :-
+    python_render_classified_mid(C, VarMap, MConds, MLines, VarMap1),
+    python_render_all_as_mid(Rest, VarMap1, RConds, RLines, VarMapOut),
+    append(MConds, RConds, Conds),
+    append(MLines, RLines, Lines).
+
+collect_output_var_names([], _, []).
+collect_output_var_names([output(Goal, _Var, _)|Rest], VarMap, [Name|Names]) :-
+    goal_output_var(Goal, OutVar),
+    lookup_var(OutVar, VarMap, Name), !,
+    collect_output_var_names(Rest, VarMap, Names).
+collect_output_var_names([output(Goal, _Var, _)|Rest], VarMap, [Name|Names]) :-
+    %% Fallback: ensure the var gets a name
+    goal_output_var(Goal, OutVar),
+    ensure_var(VarMap, OutVar, Name, VarMap1), !,
+    collect_output_var_names(Rest, VarMap1, Names).
+collect_output_var_names([_|Rest], VarMap, Names) :-
+    collect_output_var_names(Rest, VarMap, Names).
 
 %% python_branch_return_lines(+BranchLines, +VarNames, +OutputCount, -IndentedLines)
 %  Indent branch lines and add return statement.
@@ -3634,12 +3641,6 @@ python_branch_return_lines(BranchLines, VarNames, OutputCount, IndentedLines) :-
     ;   RetLine = '        return None'
     ),
     append(Indented, [RetLine], IndentedLines).
-python_render_classified_last(output_disj(Alternatives, SharedVars), VarMap, [], Lines) :-
-    python_classified_disj_return(Alternatives, SharedVars, VarMap, Lines).
-python_render_classified_last(output_if_then(If, Then, OutputVars), VarMap, [], Lines) :-
-    python_classified_if_then_return(If, Then, OutputVars, VarMap, Lines).
-python_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
-    python_output_goal_last(Goal, VarMap, Lines, _).
 
 %% === If-then-else output (assignment, not return) ===
 python_classified_ite_assign(If, Then, Else, SharedVars, VarMap0, Lines, VarMapOut) :-
@@ -3691,18 +3692,6 @@ python_classified_if_then_return(If, Then, _OutputVars, VarMap, Lines) :-
     format(string(L1), '    if ~w:', [Cond]),
     format(string(L2), '        return ~w', [ThenExpr]),
     Lines = [L1, L2].
-
-%% python_branch_value(+Branch, +VarMap, -PyExpr)
-%  Extract the output value from a branch (Then or Else) as a single expression.
-%  For simple branches (single assignment/is), returns the expression directly.
-%  Falls back to python_expr for atomic values.
-python_branch_value(Branch, VarMap, PyExpr) :-
-    normalize_goals(Branch, Goals),
-    reverse(Goals, [LastGoal|_]),
-    python_goal_value(LastGoal, VarMap, PyExpr),
-    !.
-python_branch_value(Branch, VarMap, PyExpr) :-
-    python_expr(Branch, VarMap, PyExpr).
 
 %% python_goal_value(+Goal, +VarMap, -PyExpr)
 python_goal_value(_Module:Goal, VarMap, Expr) :- !, python_goal_value(Goal, VarMap, Expr).
@@ -3882,7 +3871,6 @@ python_disj_if_elif_lines([Alt|Rest], VarName, VarMap, [CondLine, AssignLine|Res
     ->  true
     ;   ValExpr = "None"
     ),
-    (   Rest == [] -> Kw = "else" ; python_disj_if_elif_lines([], _, _, _) -> Kw = "if" ; Kw = "if"  ),
     %% First alt uses "if", rest use "elif"
     format(string(CondLine), '    if ~w:', [CondExpr]),
     format(string(AssignLine), '        ~w = ~w', [VarName, ValExpr]),
@@ -5083,11 +5071,6 @@ select_best_runtime(ScoredCandidates, Preferences, Runtime) :-
         )
     ).
 
-%% get_collected_imports(-Imports)
-%  Get the list of imports collected during compilation
-get_collected_imports(Imports) :-
-    findall(I, required_import(I), Imports).
-
 %% compile_recursive_predicate(+Name, +Arity, +Clauses, +Options, -PythonCode)
 compile_recursive_predicate(Name, Arity, Clauses, Options, PythonCode) :-
     % Separate base and recursive clauses
@@ -5152,12 +5135,6 @@ compile_visited_recursive_generic(Name, Arity, VisitedPos, BaseClauses, RecClaus
     atomic_list_concat(ExternalArgs, ', ', ExternalArgStr),
     %% Build worker arg list (all args + visited)
     format(string(WorkerArgStr), '~w, visited=None', [ExternalArgStr]),
-    %% Build output tuple args (non-input, non-visited)
-    findall(ArgName, (
-        between(2, Arity, I),
-        I \= VisitedPos,
-        format(string(ArgName), 'arg~w', [I])
-    ), OutputArgs),
     %% Base case
     (   BaseClauses = [(BaseHead, BaseBody)|_]
     ->  BaseHead =.. [_|BaseHeadArgs],
@@ -11860,16 +11837,6 @@ collect_stage_names([Pred/_|Rest], [Pred|RestNames]) :-
 collect_stage_names([_|Rest], RestNames) :-
     collect_stage_names(Rest, RestNames).
 
-%% format_stage_list(+Names, -Str)
-%  Format stage names as Python function references.
-format_stage_list([], '').
-format_stage_list([Name], Str) :-
-    format(string(Str), '~w', [Name]).
-format_stage_list([Name|Rest], Str) :-
-    Rest \= [],
-    format_stage_list(Rest, RestStr),
-    format(string(Str), '~w, ~w', [Name, RestStr]).
-
 %% format_python_route_map(+Routes, -Code)
 %  Format routing map as Python dict literal.
 format_python_route_map([], '').
@@ -12981,15 +12948,15 @@ translate_fold_expr_python(A + B, InputVar, AccVar, PyExpr) :-
     A == InputVar, B == AccVar, !, PyExpr = 'current + result'.
 translate_fold_expr_python(A + B, InputVar, AccVar, PyExpr) :-
     A == AccVar, B == InputVar, !, PyExpr = 'result + current'.
-translate_fold_expr_python(A + B, _InputVar, AccVar, PyExpr) :-
+translate_fold_expr_python(A + B, _, AccVar, PyExpr) :-
     A == AccVar, integer(B), !, format(string(PyExpr), 'result + ~w', [B]).
-translate_fold_expr_python(A + B, _InputVar, AccVar, PyExpr) :-
+translate_fold_expr_python(A + B, _, AccVar, PyExpr) :-
     B == AccVar, integer(A), !, format(string(PyExpr), '~w + result', [A]).
 translate_fold_expr_python(A * B, InputVar, AccVar, PyExpr) :-
     A == InputVar, B == AccVar, !, PyExpr = 'current * result'.
 translate_fold_expr_python(A * B, InputVar, AccVar, PyExpr) :-
     A == AccVar, B == InputVar, !, PyExpr = 'result * current'.
-translate_fold_expr_python(A * B, _InputVar, AccVar, PyExpr) :-
+translate_fold_expr_python(A * B, _, AccVar, PyExpr) :-
     A == AccVar, integer(B), !, format(string(PyExpr), 'result * ~w', [B]).
 translate_fold_expr_python(A - B, InputVar, AccVar, PyExpr) :-
     A == InputVar, B == AccVar, !, PyExpr = 'current - result'.
@@ -13018,9 +12985,9 @@ tree_recursion:compile_tree_pattern(python, _Pattern, Pred, _Arity, UseMemo, Cod
     %% Extract recursive expression from a single clause copy
     (   clause(user:Head, RBody),
         RBody \= true,
-        Head =.. [Pred, _InputVar, ResultVar],
+        Head =.. [Pred, InputVar, ResultVar],
         %% Find all recursive calls and their arg expressions
-        extract_tree_rec_calls(RBody, Pred, _InputVar, RecCalls),
+        extract_tree_rec_calls(RBody, Pred, InputVar, RecCalls),
         RecCalls = [_|_],
         %% Find the fold expression (Result is ...)
         linear_recursion:find_last_is_expression(RBody, ResultVar is FoldExpr),
@@ -13121,9 +13088,9 @@ resolve_is_operand(N, _, N) :- number(N), !.
 resolve_is_operand(-(N), _, -(N)) :- number(N), !.
 resolve_is_operand(X, _, X).
 
-simplify_arg_expr(Var, _InputVar, Var) :- var(Var), !.
-simplify_arg_expr(Expr, _InputVar, Expr) :- number(Expr), !.
-simplify_arg_expr(Expr, _InputVar, Expr) :- atom(Expr), !.
+simplify_arg_expr(Var, _, Var) :- var(Var), !.
+simplify_arg_expr(Expr, _, Expr) :- number(Expr), !.
+simplify_arg_expr(Expr, _, Expr) :- atom(Expr), !.
 simplify_arg_expr(Expr, _, Expr).
 
 %% build_tree_python_expr(+FoldExpr, +RecCalls, +Pred, +PredStr, -PyExpr)
@@ -13192,7 +13159,7 @@ tree_call_python(Call, Pred, PredStr, PyExpr) :-
 tree_call_python(Expr, _, _, PyExpr) :-
     format(string(PyExpr), '~w', [Expr]).
 
-tree_arg_python(N - K, PyArg) :-
+tree_arg_python(_N - K, PyArg) :-
     integer(K), !,
     format(string(PyArg), 'n - ~w', [K]).
 tree_arg_python(Expr, PyExpr) :-
@@ -13274,7 +13241,7 @@ mutual_function_arity2_python(PredStr, BaseClauses, RecClauses, AllPreds, MemoEn
     atomic_list_concat(BaseLines, '\n', BaseCode),
     %% Recursive case
     (   RecClauses = [clause(RHead, RBody)|_]
-    ->  RHead =.. [_, _InputVar, _OutputVar],
+    ->  RHead =.. [_, _InputVar, _],
         extract_mutual_rec_info2_python(RBody, AllPreds, Guard, CalledPred, Step, FoldExpr),
         atom_string(CalledPred, CalledStr),
         (   Guard = (N > Threshold), var(N)
@@ -13325,7 +13292,7 @@ extract_mutual_rec_info2_python(Body, AllPreds, Guard, CalledPred, Step, FoldExp
     %% Find mutual call (arity 2)
     member(Call, Goals),
     compound(Call),
-    Call =.. [CalledPred, CalledArg, _ResultVar],
+    Call =.. [CalledPred, CalledArg, ResultVar],
     member(CalledPred/_A, AllPreds),
     !,
     %% Extract step — trace through is-bindings
@@ -13333,7 +13300,7 @@ extract_mutual_rec_info2_python(Body, AllPreds, Guard, CalledPred, Step, FoldExp
     %% Find fold expression — use the LAST is/2 (the fold, not the step)
     (   reverse(Goals, RevGoals),
         member(IsGoal, RevGoals), IsGoal = (_ is FoldArith)
-    ->  translate_fold_expr_mutual_python(FoldArith, _ResultVar, FoldExpr)
+    ->  translate_fold_expr_mutual_python(FoldArith, ResultVar, FoldExpr)
     ;   FoldExpr = "rec_result"
     ).
 

--- a/src/unifyweaver/targets/r_target.pl
+++ b/src/unifyweaver/targets/r_target.pl
@@ -24,7 +24,7 @@
 :- use_module('../bindings/r_bindings').
 :- use_module('../core/template_system').
 :- use_module('type_declarations').
-:- use_module('../core/clause_body_analysis').
+:- use_module('../core/clause_body_analysis', []).
 :- multifile prolog:message//1.
 
 % Track required packages/libraries

--- a/src/unifyweaver/targets/ruby_target.pl
+++ b/src/unifyweaver/targets/ruby_target.pl
@@ -1981,7 +1981,7 @@ def ~w(arg1, visited)\n\c
 end\n',
     [PredStr, PredStr, WorkerStr, WorkerStr, BaseCheck, RecCallExpr]).
 
-extract_rec_call_ruby((A, B), PredStr, WorkerStr, Expr) :-
+extract_rec_call_ruby((A, _), PredStr, WorkerStr, Expr) :-
     nonvar(A),
     functor(A, Pred, _),
     atom_string(Pred, PredStr), !,

--- a/src/unifyweaver/targets/typescript_runtime/custom_typescript.pl
+++ b/src/unifyweaver/targets/typescript_runtime/custom_typescript.pl
@@ -39,7 +39,7 @@
     compile_component/4
 ]).
 
-:- use_module('../../core/component_registry').
+:- use_module('../../core/component_registry', [register_component_type/4]).
 
 %% type_info(-Info)
 %

--- a/src/unifyweaver/targets/typescript_target.pl
+++ b/src/unifyweaver/targets/typescript_target.pl
@@ -1603,7 +1603,7 @@ function ~w(arg1: string, visited: Set<string>): string[] {\n\c
 }\n',
     [PredStr, PredStr, WorkerStr, WorkerStr, BaseCheck, RecCallExpr]).
 
-extract_rec_call_typescript((A, B), PredStr, WorkerStr, Expr) :-
+extract_rec_call_typescript((A, _), PredStr, WorkerStr, Expr) :-
     nonvar(A),
     functor(A, Pred, _),
     atom_string(Pred, PredStr), !,

--- a/src/unifyweaver/targets/vbnet_target.pl
+++ b/src/unifyweaver/targets/vbnet_target.pl
@@ -576,7 +576,7 @@ vbnet_classified_output_goal(Goal, VarMap0, Line, VarMapOut) :-
     ->  ensure_var(VarMap0, Var, VarName, VarMapOut),
         vbnet_arith_expr(ArithExpr, VarMap0, ExprStr),
         format(string(Line), '        Dim ~w = ~w', [VarName, ExprStr])
-    ;   VarName = "_", VarMapOut = VarMap0,
+    ;   VarMapOut = VarMap0,
         Line = "        ' unsupported output goal"
     ).
 

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -18,7 +18,8 @@
     write_wam_rust_project/3,            % +Predicates, +Options, +ProjectDir
     cargo_check_project/2,               % +ProjectDir, -Result
     detect_kernels/2,                    % +Predicates, -DetectedKernels
-    generate_setup_foreign_predicates_rust/2  % +DetectedKernels, -RustCode
+    generate_setup_foreign_predicates_rust/2, % +DetectedKernels, -RustCode
+    escape_rust_string/2
 ]).
 
 :- use_module(library(lists)).


### PR DESCRIPTION
## Summary

- Reordered discontiguous predicate clauses instead of relying on broad `discontiguous` directives.
- Removed low-risk singleton and singleton-marked variable warnings across target generators.
- Tightened import lists to avoid weak-import override warnings where modules intentionally define local implementations.
- Exported helper predicates already imported by tests or target lowerers.

## Verification

- `swipl -q -g "['tests/core/test_lua_native_lowering.pl'], test_lua_native_lowering:test_lua_native_lowering, halt"`
- `swipl -q -g "['tests/core/test_python_native_lowering.pl'], test_python_native_lowering:test_python_native_lowering, halt"`
- `swipl -q -g "['tests/core/test_jvm_asm_native_lowering.pl'], test_jvm_asm_native_lowering:test_jvm_asm_native_lowering, halt"`
- `swipl -q -g "['src/unifyweaver/core/advanced/test_regressions.pl'], test_regressions:test_regressions, halt"`
- `git diff --check`

## Notes

- The Python native lowering suite still reports the existing `fallback_for_recursive` choicepoint warning.
- Registry initialization messages such as `Registered type: ...` are still printed, but the warning cleanup paths verified above are clean.
