### PR TITLE
refactor(wam-clojure): centralize unary guard lowering

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -327,6 +327,26 @@ clojure_pred_key_direct_builtin(Pred, Op, Arity) :-
     format(string(Op), "~w/~w", [Name, Arity]),
     clojure_direct_builtin(Op, Arity).
 
+clojure_unary_guard_test("atom/1", "(runtime/atom-term? value)").
+clojure_unary_guard_test('atom/1', "(runtime/atom-term? value)").
+clojure_unary_guard_test("integer/1", "(integer? value)").
+clojure_unary_guard_test('integer/1', "(integer? value)").
+clojure_unary_guard_test("number/1", "(number? value)").
+clojure_unary_guard_test('number/1', "(number? value)").
+clojure_unary_guard_test("atomic/1", "(or (runtime/atom-term? value) (number? value))").
+clojure_unary_guard_test('atomic/1', "(or (runtime/atom-term? value) (number? value))").
+clojure_unary_guard_test("nonvar/1", "(and (not= value ::lowered-unbound) (not (runtime/logic-var? value)))").
+clojure_unary_guard_test('nonvar/1', "(and (not= value ::lowered-unbound) (not (runtime/logic-var? value)))").
+clojure_unary_guard_test("var/1", "(or (= value ::lowered-unbound) (runtime/logic-var? value))").
+clojure_unary_guard_test('var/1', "(or (= value ::lowered-unbound) (runtime/logic-var? value))").
+clojure_unary_guard_test("compound/1", "(runtime/structure-term? value)").
+clojure_unary_guard_test('compound/1', "(runtime/structure-term? value)").
+
+emit_lowered_unary_guard(TestExpr, S, Expr) :-
+    format(atom(Expr),
+           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if ~w (runtime/advance ~w) (runtime/backtrack ~w)))',
+           [S, S, TestExpr, S, S]).
+
 emit_lowered_expr(proceed, S, Expr) :-
     format(atom(Expr), '(runtime/succeed-state ~w)', [S]).
 emit_lowered_expr(fail, S, Expr) :-
@@ -420,53 +440,9 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr), '(runtime/backtrack ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
-    (Op == "atom/1" ; Op == 'atom/1'),
+    clojure_unary_guard_test(Op, TestExpr),
     !,
-    format(atom(Expr),
-           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (runtime/atom-term? value) (runtime/advance ~w) (runtime/backtrack ~w)))',
-           [S, S, S, S]).
-emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
-    clojure_direct_builtin(Op, Arity),
-    (Op == "integer/1" ; Op == 'integer/1'),
-    !,
-    format(atom(Expr),
-           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (integer? value) (runtime/advance ~w) (runtime/backtrack ~w)))',
-           [S, S, S, S]).
-emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
-    clojure_direct_builtin(Op, Arity),
-    (Op == "number/1" ; Op == 'number/1'),
-    !,
-    format(atom(Expr),
-           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (number? value) (runtime/advance ~w) (runtime/backtrack ~w)))',
-           [S, S, S, S]).
-emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
-    clojure_direct_builtin(Op, Arity),
-    (Op == "atomic/1" ; Op == 'atomic/1'),
-    !,
-    format(atom(Expr),
-           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (or (runtime/atom-term? value) (number? value)) (runtime/advance ~w) (runtime/backtrack ~w)))',
-           [S, S, S, S]).
-emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
-    clojure_direct_builtin(Op, Arity),
-    (Op == "nonvar/1" ; Op == 'nonvar/1'),
-    !,
-    format(atom(Expr),
-           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (and (not= value ::lowered-unbound) (not (runtime/logic-var? value))) (runtime/advance ~w) (runtime/backtrack ~w)))',
-           [S, S, S, S]).
-emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
-    clojure_direct_builtin(Op, Arity),
-    (Op == "var/1" ; Op == 'var/1'),
-    !,
-    format(atom(Expr),
-           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (or (= value ::lowered-unbound) (runtime/logic-var? value)) (runtime/advance ~w) (runtime/backtrack ~w)))',
-           [S, S, S, S]).
-emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
-    clojure_direct_builtin(Op, Arity),
-    (Op == "compound/1" ; Op == 'compound/1'),
-    !,
-    format(atom(Expr),
-           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (runtime/structure-term? value) (runtime/advance ~w) (runtime/backtrack ~w)))',
-           [S, S, S, S]).
+    emit_lowered_unary_guard(TestExpr, S, Expr).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "!/0" ; Op == '!/0'),


### PR DESCRIPTION
## Summary

- Replaces repeated Clojure lowered-emitter clauses for unary guard builtins with a shared lowering path.
- Adds `clojure_unary_guard_test/2` as the predicate-to-test-expression table.
- Adds `emit_lowered_unary_guard/3` for the common dereference, test, advance, and backtrack shape.
- Preserves generated semantics for `atom/1`, `integer/1`, `number/1`, `atomic/1`, `nonvar/1`, `var/1`, and `compound/1`.

## Why

The Clojure lowered emitter accumulated a near-identical clause per unary type guard. Centralizing this pattern reduces copy/paste risk before adding more guard builtins, while keeping each predicate-specific semantic check explicit in one table.

This is a refactor-only change to the emitter path; the runtime template remains explicit.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
