### PR TITLE
feat(wam-r): compound terms, foreign handlers, builtins, Phase-2 lowering

### DIFF
--- a/src/unifyweaver/targets/wam_r_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_r_lowered_emitter.pl
@@ -2,20 +2,24 @@
 % SPDX-License-Identifier: MIT OR Apache-2.0
 % Copyright (c) 2026 John William Creighton (@s243a)
 %
-% wam_r_lowered_emitter.pl -- WAM-lowered R emission (Phase 1: stub)
+% wam_r_lowered_emitter.pl -- WAM-lowered R emission (Phase 2)
 %
 % Plan mirrors the Haskell hybrid path in
 %   docs/design/WAM_HASKELL_LOWERED_{PHILOSOPHY,SPECIFICATION,
 %                                     IMPLEMENTATION_PLAN}.md
 %
-% Phase 1 (this file): wam_r_lowerable/3 always fails, so every
-%                      predicate routes to the interpreter array path.
-%                      lower_predicate_to_r/4 is provided for symmetry
-%                      and emits a placeholder TODO function.
-% Phase 2+: replace the stub with a real whitelist over the WAM
-%           instruction stream and emit native R functions per
-%           lowerable predicate. See the Rust/Haskell/Go lowered
-%           emitters for prior art.
+% Phase 2 (this file): real lowering for deterministic single-clause
+%                      predicates whose body shape is in the supported
+%                      set. Each lowered predicate becomes one R
+%                      function that delegates per-instruction work to
+%                      WamRuntime$step (so semantics stay identical to
+%                      the array path) but handles control-flow
+%                      instructions natively (Call/Execute/Proceed).
+%
+% Phase 3+ would inline simple register ops, threaded across calls to
+% other lowered predicates; that's deferred. The Phase-2 design keeps
+% the surface area small while wiring up the emit-mode plumbing and
+% exercising the project-writer integration end-to-end.
 
 :- module(wam_r_lowered_emitter, [
     wam_r_lowerable/3,           % +Pred, +WamCode, -Reason
@@ -26,14 +30,114 @@
 :- use_module(library(lists)).
 
 % =====================================================================
-% Lowerability (Phase 1: always fails)
+% WAM-text parsing
 % =====================================================================
+% We re-parse the WAM-assembly text into a list of structured terms so
+% the lowerability check can pattern-match on instruction shape. Lines
+% that are blank or contain a label header (foo/2:) are dropped.
 
-%% wam_r_lowerable(+Pred/Arity, +WamCode, -Reason) is semidet.
-%  Phase 1 stub: always fails. Phase 2+ will return a Reason term
-%  describing why the predicate is lowerable (e.g. deterministic,
-%  multi_clause_1).
-wam_r_lowerable(_PI, _WamCode, _Reason) :- fail.
+parse_wam_text(WamText, Instrs) :-
+    atom_string(WamText, S),
+    split_string(S, "\n", "", Lines),
+    parse_lines(Lines, Instrs).
+
+parse_lines([], []).
+parse_lines([Line|Rest], Instrs) :-
+    split_string(Line, " \t,", " \t,", Parts),
+    delete(Parts, "", CleanParts),
+    (   CleanParts == []
+    ->  parse_lines(Rest, Instrs)
+    ;   CleanParts = [First|_],
+        sub_string(First, _, 1, 0, ":")
+    ->  parse_lines(Rest, Instrs)
+    ;   instr_from_parts(CleanParts, Instr)
+    ->  Instrs = [Instr|RestInstrs],
+        parse_lines(Rest, RestInstrs)
+    ;   parse_lines(Rest, Instrs)
+    ).
+
+instr_from_parts(["allocate"], allocate).
+instr_from_parts(["deallocate"], deallocate).
+instr_from_parts(["proceed"], proceed).
+instr_from_parts(["fail"], fail).
+instr_from_parts(["get_constant", C, Ai], get_constant(C, Ai)).
+instr_from_parts(["get_variable", X, Ai], get_variable(X, Ai)).
+instr_from_parts(["get_value", X, Ai], get_value(X, Ai)).
+instr_from_parts(["get_structure", F, Ai], get_structure(F, Ai)).
+instr_from_parts(["get_list", Ai], get_list(Ai)).
+instr_from_parts(["put_constant", C, Ai], put_constant(C, Ai)).
+instr_from_parts(["put_variable", X, Ai], put_variable(X, Ai)).
+instr_from_parts(["put_value", X, Ai], put_value(X, Ai)).
+instr_from_parts(["put_structure", F, Ai], put_structure(F, Ai)).
+instr_from_parts(["put_list", Ai], put_list(Ai)).
+instr_from_parts(["unify_variable", X], unify_variable(X)).
+instr_from_parts(["unify_value", X], unify_value(X)).
+instr_from_parts(["unify_constant", C], unify_constant(C)).
+instr_from_parts(["set_variable", X], set_variable(X)).
+instr_from_parts(["set_value", X], set_value(X)).
+instr_from_parts(["set_constant", C], set_constant(C)).
+instr_from_parts(["call", Pred, N], call(Pred, N)).
+instr_from_parts(["call", PredArity], call(PredArity)).
+instr_from_parts(["execute", Pred, N], execute(Pred, N)).
+instr_from_parts(["execute", PredArity], execute(PredArity)).
+instr_from_parts(["call_foreign", Pred, N], call_foreign(Pred, N)).
+instr_from_parts(["builtin_call", Op, N], builtin_call(Op, N)).
+instr_from_parts(["try_me_else", L], try_me_else(L)).
+instr_from_parts(["retry_me_else", L], retry_me_else(L)).
+instr_from_parts(["trust_me"], trust_me).
+instr_from_parts(["jump", L], jump(L)).
+instr_from_parts(["cut_ite"], cut_ite).
+instr_from_parts(["switch_on_constant" | _], switch_on_constant).
+instr_from_parts(["switch_on_structure" | _], switch_on_structure).
+
+% =====================================================================
+% Lowerability
+% =====================================================================
+%
+% A predicate is Phase-2-lowerable if:
+%   (1) all its instructions are in the supported set,
+%   (2) it has no choice-point instructions (try_me_else / retry_me_else
+%       / trust_me) -- multi-clause predicates stay on the array path
+%       so the standard backtracking machinery handles them, and
+%   (3) it contains no switch_on_* dispatch (those imply multi-clause).
+%
+% Reason is unified with `deterministic` on success; future phases can
+% add more granular reasons.
+
+wam_r_lowerable(_PI, WamCode, deterministic) :-
+    parse_wam_text(WamCode, Instrs),
+    \+ member(try_me_else(_),   Instrs),
+    \+ member(retry_me_else(_), Instrs),
+    \+ member(trust_me,         Instrs),
+    \+ member(switch_on_constant,  Instrs),
+    \+ member(switch_on_structure, Instrs),
+    forall(member(I, Instrs), supported_op(I)).
+
+supported_op(allocate).
+supported_op(deallocate).
+supported_op(proceed).
+supported_op(get_constant(_, _)).
+supported_op(get_variable(_, _)).
+supported_op(get_value(_, _)).
+supported_op(get_structure(_, _)).
+supported_op(get_list(_)).
+supported_op(put_constant(_, _)).
+supported_op(put_variable(_, _)).
+supported_op(put_value(_, _)).
+supported_op(put_structure(_, _)).
+supported_op(put_list(_)).
+supported_op(unify_variable(_)).
+supported_op(unify_value(_)).
+supported_op(unify_constant(_)).
+supported_op(set_variable(_)).
+supported_op(set_value(_)).
+supported_op(set_constant(_)).
+supported_op(call(_, _)).
+supported_op(call(_)).
+supported_op(execute(_, _)).
+supported_op(execute(_)).
+supported_op(call_foreign(_, _)).
+supported_op(builtin_call(_, _)).
 
 % =====================================================================
 % Function-name generation
@@ -41,8 +145,6 @@ wam_r_lowerable(_PI, _WamCode, _Reason) :- fail.
 
 %% r_lowered_func_name(+Functor/Arity, -RFuncName)
 %  foo/2 -> "lowered_foo_2", my_pred/3 -> "lowered_my_pred_3".
-%  R identifiers can contain "." but we use "_" to avoid clashing with
-%  R's S3 method dispatch convention (e.g. print.foo).
 r_lowered_func_name(Functor/Arity, Name) :-
     atom_string(Functor, FStr),
     sanitize_r_ident(FStr, SanStr),
@@ -64,28 +166,93 @@ r_safe_code(C, C) :-
 r_safe_code(_, 0'_).
 
 % =====================================================================
-% Emission (Phase 1 placeholder)
+% Per-instruction emission
 % =====================================================================
+%
+% The lowered function body is a sequence of R statements, one per WAM
+% instruction. Most instructions delegate to WamRuntime$step using the
+% same R Instruction-literal that the array path uses; we re-tokenize
+% and feed wam_r_target's wam_parts_to_r/3 to keep the literal shape
+% identical. Control instructions are emitted natively:
+%   proceed       -> return(TRUE)
+%   call P/N      -> save cp, set pc to label, run, restore cp
+%   execute P/N   -> tail call (set pc, return WamRuntime$run(...))
 
 %% lower_predicate_to_r(+Pred/Arity, +WamCode, +Options, -Entry)
 %  Entry = lowered(PredName, FuncName, RCode).
-%
-%  Phase 1: emits a TODO placeholder. Lowering is gated by
-%  wam_r_lowerable/3 which always fails, so this code is unreachable
-%  in practice. It's here to make the contract explicit and to give
-%  Phase 2 a starting point.
-lower_predicate_to_r(PI, _WamCode, _Opts,
+lower_predicate_to_r(PI, WamCode, _Opts,
                      lowered(PredName, FuncName, Code)) :-
     ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     format(atom(PredName), '~w/~w', [Pred, Arity]),
     r_lowered_func_name(Pred/Arity, FuncName),
+    atom_string(WamCode, Str),
+    split_string(Str, "\n", "", Lines),
+    with_output_to(string(Body), emit_lines(Lines, "  ")),
     format(string(Code),
-'# Lowered: ~w
-# Phase 1 stub -- lowering is not yet implemented for this target.
-# See wam_r_lowered_emitter.pl, modelled on
-#   wam_haskell_lowered_emitter.pl (Maybe-monad style) and
-#   wam_rust_lowered_emitter.pl   (delegate-to-step style).
-~w <- function(ctx, state) {
-  stop("R lowered emitter not yet implemented")
-}
-', [PredName, FuncName]).
+'# Lowered: ~w  (Phase-2 deterministic single-clause)
+~w <- function(program, state) {
+~w  return(TRUE)
+}', [PredName, FuncName, Body]).
+
+emit_lines([], _).
+emit_lines([Line|Rest], Ind) :-
+    wam_r_target:tokenize_wam_line(Line, Parts),
+    (   Parts == []
+    ->  true
+    ;   Parts = [First|_], sub_string(First, _, 1, 0, ":")
+    ->  true
+    ;   emit_line_parts(Parts, Ind)
+    ),
+    emit_lines(Rest, Ind).
+
+% --- Control instructions: special emission --------------------------
+
+emit_line_parts(["proceed"], I) :-
+    format("~wreturn(TRUE)~n", [I]).
+emit_line_parts(["call", PredArity], I) :-
+    emit_call(PredArity, I).
+emit_line_parts(["call", Pred, ArityStr], I) :-
+    strip_arity_local(Pred, PredName),
+    format(string(PredArity), "~w/~w", [PredName, ArityStr]),
+    emit_call(PredArity, I).
+emit_line_parts(["execute", PredArity], I) :-
+    emit_execute(PredArity, I).
+emit_line_parts(["execute", Pred, ArityStr], I) :-
+    strip_arity_local(Pred, PredName),
+    format(string(PredArity), "~w/~w", [PredName, ArityStr]),
+    emit_execute(PredArity, I).
+% --- Default: delegate to step with the same R literal the array uses
+emit_line_parts(Parts, I) :-
+    wam_r_target:wam_parts_to_r(Parts, [], Lit),
+    format("~wif (!isTRUE(WamRuntime$step(program, state, ~w))) return(FALSE)~n",
+           [I, Lit]).
+
+emit_call(PredArity, I) :-
+    format("~w{~n", [I]),
+    format("~w  saved_cp <- state$cp~n", [I]),
+    format("~w  tgt <- program$labels[[\"~w\"]]~n", [I, PredArity]),
+    format("~w  if (is.null(tgt)) return(FALSE)~n", [I]),
+    format("~w  state$cp <- 0L~n", [I]),
+    format("~w  state$pc <- as.integer(tgt)~n", [I]),
+    format("~w  if (!isTRUE(WamRuntime$run(program, state))) return(FALSE)~n", [I]),
+    format("~w  state$halt <- FALSE~n", [I]),
+    format("~w  state$cp <- saved_cp~n", [I]),
+    format("~w}~n", [I]).
+
+emit_execute(PredArity, I) :-
+    format("~w{~n", [I]),
+    format("~w  tgt <- program$labels[[\"~w\"]]~n", [I, PredArity]),
+    format("~w  if (is.null(tgt)) return(FALSE)~n", [I]),
+    format("~w  state$pc <- as.integer(tgt)~n", [I]),
+    format("~w  return(isTRUE(WamRuntime$run(program, state)))~n", [I]),
+    format("~w}~n", [I]).
+
+%% strip_arity_local(+TokenWithArity, -Name)
+%  Same convention as wam_r_target's strip_arity_suffix: drop trailing
+%  "/N" if present so we can rebuild "Name/N" from the explicit arity
+%  token that follows in the WAM line.
+strip_arity_local(Tok, Name) :-
+    (   sub_string(Tok, B, 1, _, "/")
+    ->  sub_string(Tok, 0, B, _, Name)
+    ;   Name = Tok
+    ).

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -35,7 +35,12 @@
     compile_wam_predicate_to_r/4,    % +Pred/Arity, +WamCode, +Options, -RCode
     write_wam_r_project/3,           % +Predicates, +Options, +ProjectDir
     r_foreign_predicate/3,           % +Pred, +Arity, +Options
-    init_r_atom_intern_table/0       % reinitialize atom intern table
+    init_r_atom_intern_table/0,      % reinitialize atom intern table
+    % --- Re-exported helpers used by wam_r_lowered_emitter -----
+    tokenize_wam_line/2,             % +Line, -Tokens
+    wam_parts_to_r/3,                % +Tokens, +Options, -RLiteral
+    parse_functor_arity/3,           % +Str, -Name, -Arity
+    wam_r_resolve_emit_mode/2        % +Options, -Mode
 ]).
 
 :- use_module(library(lists)).
@@ -43,6 +48,49 @@
 :- use_module(library(filesex), [make_directory_path/1, directory_file_path/3]).
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
 :- use_module('../core/template_system', [render_template/3]).
+% Lowered emitter: real Phase-2 implementation lives there. We keep the
+% module load lazy via catch/3 so the file remains usable even if the
+% emitter module is temporarily missing during refactors.
+:- use_module(wam_r_lowered_emitter, [
+    wam_r_lowerable/3,
+    lower_predicate_to_r/4
+]).
+
+% ============================================================================
+% EMIT MODE
+% ============================================================================
+% Mirror of wam_haskell_target.pl: Mode is one of
+%   - interpreter           : never lower (default, byte-identical to pre-
+%                             Phase-2 output)
+%   - functions             : try to lower every predicate; failed
+%                             lowerability falls through to the array path
+%   - mixed([Pred/Arity, ...]) : try to lower only listed preds
+%
+% Resolution order: emit_mode(M) Option -> user:wam_r_emit_mode(M)
+% multifile fact -> default interpreter.
+
+:- multifile user:wam_r_emit_mode/1.
+
+wam_r_resolve_emit_mode(Options, Mode) :-
+    (   option(emit_mode(M0), Options)
+    ->  validate_emit_mode(M0, Mode)
+    ;   catch(user:wam_r_emit_mode(M1), _, fail)
+    ->  validate_emit_mode(M1, Mode)
+    ;   Mode = interpreter
+    ).
+
+validate_emit_mode(interpreter, interpreter) :- !.
+validate_emit_mode(functions,   functions)   :- !.
+validate_emit_mode(mixed(L),    mixed(L))    :- is_list(L), !.
+validate_emit_mode(Other, _) :-
+    throw(error(domain_error(wam_r_emit_mode, Other),
+                wam_r_resolve_emit_mode/2)).
+
+%% should_try_lower(+Mode, +Pred, +Arity) is semidet.
+should_try_lower(functions,    _, _) :- !.
+should_try_lower(mixed(HotPreds), P, A) :-
+    member(P/A, HotPreds), !.
+should_try_lower(_, _, _) :- fail.
 
 % ============================================================================
 % ATOM INTERNING TABLE (compile-time)
@@ -465,7 +513,7 @@ compile_wam_predicate_to_r(_Pred, _WamCode, _Options, "").
 %%                                -AllLabels, -WrapperCode)
 compile_predicates_for_project(Predicates, Options,
                                AllInstrs, TopLevelLabelEntries,
-                               AllLabelEntries, WrapperCode) :-
+                               AllLabelEntries, WrapperCode, LoweredCode) :-
     init_r_atom_intern_table,
     option(intern_atoms(ExtraAtoms), Options, []),
     forall(member(A, ExtraAtoms),
@@ -473,11 +521,13 @@ compile_predicates_for_project(Predicates, Options,
     option(foreign_predicates(ForeignPredicates), Options, []),
     append_missing_foreign_predicates(Predicates, ForeignPredicates,
                                       CompilePredicates),
-    compile_all_predicates(CompilePredicates, Options, 1,
-                           [], [], [], [],
+    wam_r_resolve_emit_mode(Options, Mode),
+    compile_all_predicates(CompilePredicates, Options, Mode, 1,
+                           [], [], [], [], [],
                            AllInstrs, TopLevelLabelEntries,
-                           AllLabelEntries, Wrappers),
-    atomic_list_concat(Wrappers, '\n', WrapperCode).
+                           AllLabelEntries, Wrappers, LoweredEntries),
+    atomic_list_concat(Wrappers, '\n', WrapperCode),
+    atomic_list_concat(LoweredEntries, '\n', LoweredCode).
 
 append_missing_foreign_predicates(Predicates, ForeignPredicates,
                                   CompilePredicates) :-
@@ -497,12 +547,12 @@ same_predicate_indicator(P0, P1) :-
 predicate_indicator_key(_:Pred/Arity, Pred/Arity) :- !.
 predicate_indicator_key(Pred/Arity, Pred/Arity).
 
-compile_all_predicates([], _, _, Instrs, TopLabels, AllLabels, Wrappers,
-                       Instrs, TopLabels, AllLabels, Wrappers).
-compile_all_predicates([Pred|Rest], Options, BasePC,
-                       InstrAcc, TopLabelAcc, AllLabelAcc, WrapperAcc,
+compile_all_predicates([], _, _, _, Instrs, TopLabels, AllLabels, Wrappers, Lowered,
+                       Instrs, TopLabels, AllLabels, Wrappers, Lowered).
+compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
+                       InstrAcc, TopLabelAcc, AllLabelAcc, WrapperAcc, LoweredAcc,
                        AllInstrs, TopLevelLabelEntries,
-                       AllLabelEntries, AllWrappers) :-
+                       AllLabelEntries, AllWrappers, AllLowered) :-
     (   Pred = _Module:P/Arity -> true ; Pred = P/Arity ),
     (   r_foreign_predicate(P, Arity, Options)
     ->  format(string(FLit), 'CallForeign("~w", ~w)', [P, Arity]),
@@ -511,8 +561,10 @@ compile_all_predicates([Pred|Rest], Options, BasePC,
         NewPC is BasePC + 2,
         format(string(MainEntry), '    "~w/~w" = ~wL', [P, Arity, BasePC]),
         NewTopLabels = [MainEntry | TopLabelAcc],
-        NewAllLabels = [MainEntry | AllLabelAcc]
+        NewAllLabels = [MainEntry | AllLabelAcc],
+        WamCodeForLower = ""
     ;   compile_predicate_to_wam(P/Arity, [], WamCode),
+        WamCodeForLower = WamCode,
         wam_code_to_r_data(WamCode, Options, PredInstrs, _LMap,
                            PredSubLabelEntries0),
         length(PredInstrs, PredLen),
@@ -528,12 +580,23 @@ compile_all_predicates([Pred|Rest], Options, BasePC,
         NewTopLabels = [MainEntry | TopLabelAcc],
         append([MainEntry | PredSubLabelEntries], AllLabelAcc, NewAllLabels)
     ),
-    emit_r_wrapper(P, Arity, BasePC, WrapperCode),
-    compile_all_predicates(Rest, Options, NewPC,
+    % Decide whether this predicate should be lowered.
+    (   should_try_lower(Mode, P, Arity),
+        WamCodeForLower \= "",
+        catch(wam_r_lowerable(Pred, WamCodeForLower, _Reason), _, fail),
+        catch(lower_predicate_to_r(Pred, WamCodeForLower, [],
+                                   lowered(_PName, FuncName, LoweredR)),
+              _, fail)
+    ->  NewLoweredAcc = [LoweredR | LoweredAcc],
+        emit_r_lowered_wrapper(P, Arity, FuncName, WrapperCode)
+    ;   NewLoweredAcc = LoweredAcc,
+        emit_r_wrapper(P, Arity, BasePC, WrapperCode)
+    ),
+    compile_all_predicates(Rest, Options, Mode, NewPC,
                            NewInstrs, NewTopLabels, NewAllLabels,
-                           [WrapperCode|WrapperAcc],
+                           [WrapperCode|WrapperAcc], NewLoweredAcc,
                            AllInstrs, TopLevelLabelEntries,
-                           AllLabelEntries, AllWrappers).
+                           AllLabelEntries, AllWrappers, AllLowered).
 
 offset_label_entry(Offset, Entry0, Entry) :-
     atom_string(Entry0, S),
@@ -560,18 +623,38 @@ is_pred_label(PredKey, Entry) :-
 %  Emits an R top-level function: pred_name(arg1, arg2, ...).
 %  Calls run_predicate(shared_program, start_pc, list(arg1, ...)).
 emit_r_wrapper(Pred, Arity, StartPc, Code) :-
-    (   Arity =:= 0
-    ->  ArgDeclStr = '',
-        ArgListStr  = 'list()'
-    ;   numlist(1, Arity, ArgNums),
-        maplist([N, A]>>(format(string(A), 'a~w', [N])), ArgNums, ArgNames),
-        atomic_list_concat(ArgNames, ', ', ArgDeclStr),
-        format(string(ArgListStr), 'list(~w)', [ArgDeclStr])
-    ),
+    pred_arg_strings(Arity, ArgDeclStr, ArgListStr),
     r_pred_name(Pred, RName),
     format(string(Code),
            '~w <- function(~w) {\n  WamRuntime$run_predicate(shared_program, ~wL, ~w)\n}\n',
            [RName, ArgDeclStr, StartPc, ArgListStr]).
+
+%% emit_r_lowered_wrapper(+Pred, +Arity, +LoweredFuncName, -Code)
+%  Wrapper for predicates that have a lowered R function. Builds a
+%  fresh state, seeds A1..An with the call-site args, and dispatches
+%  directly to the lowered function (bypassing the instruction-array
+%  driver). Returns the boolean returned by the lowered fn.
+emit_r_lowered_wrapper(Pred, Arity, LoweredFuncName, Code) :-
+    pred_arg_strings(Arity, ArgDeclStr, ArgListStr),
+    r_pred_name(Pred, RName),
+    format(string(Code),
+'~w <- function(~w) {
+  state <- WamRuntime$new_state()
+  WamRuntime$promote_regs(state)
+  args <- ~w
+  for (i in seq_along(args)) WamRuntime$put_reg(state, i, args[[i]])
+  state$cp <- 0L
+  isTRUE(~w(shared_program, state))
+}
+', [RName, ArgDeclStr, ArgListStr, LoweredFuncName]).
+
+pred_arg_strings(0, '', 'list()') :- !.
+pred_arg_strings(Arity, ArgDeclStr, ArgListStr) :-
+    Arity > 0,
+    numlist(1, Arity, ArgNums),
+    maplist([N, A]>>(format(string(A), 'a~w', [N])), ArgNums, ArgNames),
+    atomic_list_concat(ArgNames, ', ', ArgDeclStr),
+    format(string(ArgListStr), 'list(~w)', [ArgDeclStr]).
 
 %% r_pred_name(+PrologName, -RName)
 %  R uses snake_case by convention; identifiers are looser than Scala
@@ -639,7 +722,8 @@ write_wam_r_project(Predicates, Options, ProjectDir) :-
     option(module_name(ModName), Options, 'wam.r.generated'),
     write_description(ProjectDir, ModName),
     compile_predicates_for_project(Predicates, Options,
-        AllInstrs, TopLevelLabelEntries, AllLabelEntries, WrapperCode),
+        AllInstrs, TopLevelLabelEntries, AllLabelEntries,
+        WrapperCode, LoweredFunctionsCode),
     emit_r_intern_table(IdToStringStr),
     maplist([I, Line]>>(format(string(Line), '    ~w', [I])), AllInstrs,
             InstrLines),
@@ -649,7 +733,8 @@ write_wam_r_project(Predicates, Options, ProjectDir) :-
     r_foreign_handlers_code(Options, ForeignHandlersBody),
     write_runtime_source(RDir),
     write_program_source(RDir, InstrBody, LabelBody, DispatchBody,
-                         WrapperCode, IdToStringStr, ForeignHandlersBody).
+                         WrapperCode, IdToStringStr, ForeignHandlersBody,
+                         LoweredFunctionsCode).
 
 write_description(ProjectDir, ModName) :-
     find_template('templates/targets/r_wam/DESCRIPTION.mustache', Template),
@@ -667,7 +752,8 @@ write_runtime_source(RDir) :-
     write_file(Path, Content).
 
 write_program_source(RDir, InstrBody, LabelBody, DispatchBody,
-                     WrapperCode, IdToStringStr, ForeignHandlersBody) :-
+                     WrapperCode, IdToStringStr, ForeignHandlersBody,
+                     LoweredFunctionsCode) :-
     find_template('templates/targets/r_wam/program.R.mustache', Template),
     get_time(T), format_time(string(DateStr), "%Y-%m-%d", T),
     render_template(Template,
@@ -677,7 +763,8 @@ write_program_source(RDir, InstrBody, LabelBody, DispatchBody,
           'dispatch'=DispatchBody,
           'wrappers'=WrapperCode,
           'intern_id_to_string'=IdToStringStr,
-          'foreign_handlers'=ForeignHandlersBody
+          'foreign_handlers'=ForeignHandlersBody,
+          'lowered_functions'=LoweredFunctionsCode
         ], Content),
     directory_file_path(RDir, 'generated_program.R', Path),
     write_file(Path, Content).

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -257,9 +257,9 @@ wam_parts_to_r(["put_list", Reg], Lit) :-
     format(string(Lit), 'PutList(~w, ~w)', [RegIdx, FId]).
 wam_parts_to_r(["get_structure", Functor, Reg], Lit) :-
     reg_to_int(Reg, RegIdx),
-    parse_functor_arity(Functor, FName, _),
+    parse_functor_arity(Functor, FName, FArity),
     intern_r_atom(FName, FId),
-    format(string(Lit), 'GetStructure(~w, ~w)', [FId, RegIdx]).
+    format(string(Lit), 'GetStructure(~w, ~w, ~w)', [FId, RegIdx, FArity]).
 wam_parts_to_r(["get_list", Reg], Lit) :-
     reg_to_int(Reg, RegIdx),
     intern_r_atom("[|]", FId),
@@ -301,6 +301,19 @@ wam_parts_to_r(["switch_on_constant" | Cases], Lit) :-
     atomic_list_concat(CaseLits, ', ', CasesStr),
     format(string(Lit), 'SwitchOnConstant(list(~w))', [CasesStr]).
 
+% --- Switch on structure (functor-shape dispatch) ---
+% Each case is "F/N:label". Behaviour parallels switch_on_constant: when
+% the first arg is a struct of matching shape, jump to the labelled
+% clause; otherwise (or if the label is "default") fall through to the
+% try/retry chain. The runtime treats the case list as advisory — we
+% always re-run the matching clause body afterwards, so worst case is
+% an extra try/retry traversal.
+wam_parts_to_r(["switch_on_structure" | Cases], Lit) :-
+    normalize_switch_case_tokens(Cases, NormalizedCases),
+    parse_struct_switch_cases(NormalizedCases, CaseLits),
+    atomic_list_concat(CaseLits, ', ', CasesStr),
+    format(string(Lit), 'SwitchOnStructure(list(~w))', [CasesStr]).
+
 % --- ITE soft cut ---
 wam_parts_to_r(["cut_ite"], 'CutIte()').
 
@@ -326,6 +339,16 @@ parse_switch_cases([Token | Rest], [Lit | More]) :-
     intern_r_atom(ValStr, AtomId),
     format(string(Lit), 'SwitchCase(Atom(~w), "~w")', [AtomId, LabelStr]),
     parse_switch_cases(Rest, More).
+
+%% parse_struct_switch_cases(+Tokens, -CaseLiterals)
+%  Each token is "Functor/Arity:label" — e.g. "f/2:L_pair_1_2".
+parse_struct_switch_cases([], []).
+parse_struct_switch_cases([Token | Rest], [Lit | More]) :-
+    split_at_first_colon(Token, FAStr, LabelStr),
+    parse_functor_arity(FAStr, FName, FArity),
+    intern_r_atom(FName, FId),
+    format(string(Lit), 'StructCase(~w, ~w, "~w")', [FId, FArity, LabelStr]),
+    parse_struct_switch_cases(Rest, More).
 
 normalize_switch_case_tokens([], []).
 normalize_switch_case_tokens([Value, Label0 | Rest], [Token | More]) :-

--- a/templates/targets/r_wam/program.R.mustache
+++ b/templates/targets/r_wam/program.R.mustache
@@ -64,6 +64,12 @@ shared_program <- list(
 )
 
 # ----------------------------------------------------------
+# Lowered native R functions (Phase-2 emitter output)
+# Empty when emit_mode is interpreter.
+# ----------------------------------------------------------
+{{lowered_functions}}
+
+# ----------------------------------------------------------
 # Per-predicate wrapper functions
 # ----------------------------------------------------------
 {{wrappers}}

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -155,18 +155,21 @@ WamRuntime$new_state <- function() {
   s$var_counter <- 0L
   s$halt        <- FALSE                    # set by foreign top-level wrapper
   # Structure read/write state. NULL when no build/scan is active.
-  #   write mode: build_target_reg / build_fid / build_arity / build_args
-  #               (set_*/unify_* in write mode append to build_args; on
-  #                completion the struct is finalized into the target reg).
-  #   read mode:  read_args / read_cursor (1-based)
-  #               (unify_* in read mode consume one arg per step).
-  s$mode               <- NULL
-  s$build_target_reg   <- NULL
-  s$build_fid          <- NULL
-  s$build_arity        <- 0L
-  s$build_args         <- list()
-  s$read_args          <- list()
-  s$read_cursor        <- 1L
+  #   write mode: build_stack -- LIFO of BuildFrame(target_reg, fid,
+  #               arity, args). PutStructure / PutList push; set_* /
+  #               unify_* (in write mode) append to the top frame; when
+  #               top.args reaches top.arity it pops and feeds itself as
+  #               the next arg of the parent frame (or, if no parent,
+  #               writes to top.target_reg and binds any Ref there).
+  #               Stack form is required because nested compound terms
+  #               (e.g. arithmetic like X is 3 * 4 + 1) interleave
+  #               builds of the inner and outer functors.
+  #   read mode:  read_args / read_cursor (1-based) -- unify_* in read
+  #               mode consume one arg per step.
+  s$mode        <- NULL
+  s$build_stack <- list()
+  s$read_args   <- list()
+  s$read_cursor <- 1L
   s
 }
 
@@ -199,38 +202,51 @@ WamRuntime$promote_regs <- function(state) {
 # ----------------------------------------------------------
 # Structure build helpers (write mode)
 # ----------------------------------------------------------
-# Begin a write-mode build for `arity` args of functor `fid`, targeting
-# register `target_reg`. Used by both PutStructure/PutList and the
-# write-mode branch of GetStructure/GetList (when matching against an
-# unbound variable).
+# Push a new write-mode build frame for `arity` args of functor `fid`,
+# targeting register `target_reg`. Used by both PutStructure/PutList and
+# the write-mode branch of GetStructure/GetList (when matching against
+# an unbound variable). Nested PutStructure (arithmetic, list cons,
+# etc.) just push more frames; finalization cascades up the stack.
 WamRuntime$begin_build <- function(state, fid, arity, target_reg) {
-  state$mode             <- "write"
-  state$build_fid        <- as.integer(fid)
-  state$build_arity      <- as.integer(arity)
-  state$build_target_reg <- as.integer(target_reg)
-  state$build_args       <- list()
+  state$mode <- "write"
+  frame <- list(target_reg = as.integer(target_reg),
+                fid        = as.integer(fid),
+                arity      = as.integer(arity),
+                args       = list())
+  state$build_stack <- c(state$build_stack, list(frame))
   invisible(NULL)
 }
 
-# Append an argument to the in-progress build. When the args list reaches
-# the declared arity we materialize the struct and write it to the target
-# register, binding any unbound variable that was previously there.
+# Append an arg to the top build frame. If the top frame is now full,
+# materialize it: bind any unbound var that the target register held
+# (the WAM compiler typically pre-installs a Ref via set_variable so
+# nested structures can reference each other), then write the struct
+# into the target register. The parent frame is *not* auto-fed; the
+# emitter explicitly appends the parent's remaining args via further
+# set_*/unify_* instructions, and the parent sees the inner struct
+# through the bound Ref. Cascading finalize is still required for the
+# rare case where a parent already happens to be at full arity (e.g.
+# trailing finalize after the last explicit set_constant).
 WamRuntime$append_build_arg <- function(state, val) {
-  state$build_args <- c(state$build_args, list(val))
-  if (length(state$build_args) >= state$build_arity) {
-    new_struct <- StructTerm(state$build_fid, state$build_args)
-    cur <- WamRuntime$get_reg(state, state$build_target_reg)
+  n <- length(state$build_stack)
+  if (n == 0L) return(invisible(NULL))
+  top <- state$build_stack[[n]]
+  top$args <- c(top$args, list(val))
+  state$build_stack[[n]] <- top
+  while (n > 0L) {
+    top <- state$build_stack[[n]]
+    if (length(top$args) < top$arity) break
+    state$build_stack <- state$build_stack[-n]
+    new_struct <- StructTerm(top$fid, top$args)
+    cur <- WamRuntime$get_reg(state, top$target_reg)
     cur <- WamRuntime$deref(state, cur)
     if (!is.null(cur) && is.list(cur) && !is.null(cur$tag) && cur$tag == "unbound") {
       WamRuntime$bind(state, cur$name, new_struct)
     }
-    WamRuntime$put_reg(state, state$build_target_reg, new_struct)
-    state$mode             <- NULL
-    state$build_target_reg <- NULL
-    state$build_fid        <- NULL
-    state$build_arity      <- 0L
-    state$build_args       <- list()
+    WamRuntime$put_reg(state, top$target_reg, new_struct)
+    n <- length(state$build_stack)
   }
+  if (length(state$build_stack) == 0L) state$mode <- NULL
   invisible(NULL)
 }
 
@@ -648,10 +664,92 @@ WamRuntime$call_foreign <- function(program, state, pred, arity, tail_call) {
   TRUE
 }
 
+# Recursively evaluate an arithmetic term against the current bindings.
+# Returns a numeric scalar on success or NULL on failure (unbound var,
+# unknown operator, type mismatch). Tagged-list constants resolve to
+# their $val; structures resolve to op(eval(arg1), eval(arg2)). Atoms
+# can be added later (pi, e, ...) but are not supported here.
+WamRuntime$eval_arith <- function(state, term, table) {
+  v <- WamRuntime$deref(state, term)
+  if (is.null(v) || !is.list(v) || is.null(v$tag)) return(NULL)
+  if (v$tag == "int")   return(v$val)
+  if (v$tag == "float") return(v$val)
+  if (v$tag == "unbound") return(NULL)
+  if (v$tag == "struct") {
+    op <- WamRuntime$string_of(table, v$fid)
+    args <- v$args
+    if (length(args) == 1L) {
+      a <- WamRuntime$eval_arith(state, args[[1]], table)
+      if (is.null(a)) return(NULL)
+      return(switch(op,
+        "-"   = -a,
+        "+"   = +a,
+        "abs" = abs(a),
+        NULL
+      ))
+    }
+    if (length(args) == 2L) {
+      a <- WamRuntime$eval_arith(state, args[[1]], table)
+      b <- WamRuntime$eval_arith(state, args[[2]], table)
+      if (is.null(a) || is.null(b)) return(NULL)
+      return(switch(op,
+        "+"   = a + b,
+        "-"   = a - b,
+        "*"   = a * b,
+        "/"   = a / b,
+        "//"  = a %/% b,
+        "mod" = a %% b,
+        "rem" = a - (a %/% b) * b,
+        "min" = min(a, b),
+        "max" = max(a, b),
+        NULL
+      ))
+    }
+  }
+  NULL
+}
+
+# Wrap an R numeric back into a WAM term, keeping integer-ness when the
+# value lands cleanly on an integer (so 6 stays IntTerm(6) instead of
+# FloatTerm(6.0)). This matters for downstream unify_constant matches.
+WamRuntime$arith_to_term <- function(n) {
+  if (is.null(n) || !is.numeric(n)) return(NULL)
+  if (is.finite(n) && n == as.integer(n) && abs(n) < .Machine$integer.max) {
+    IntTerm(as.integer(n))
+  } else {
+    FloatTerm(as.numeric(n))
+  }
+}
+
 WamRuntime$call_builtin <- function(program, state, pred, arity) {
-  # Stub: minimal builtins. Extend as the lowered emitter matures.
-  if (pred == "true" && arity == 0L) return(TRUE)
-  if (pred == "fail" && arity == 0L) return(FALSE)
+  table <- program$intern_table
+  if (pred == "true"  && arity == 0L) return(TRUE)
+  if (pred == "fail"  && arity == 0L) return(FALSE)
+  # is/2: eval A2, unify with A1.
+  if (pred == "is/2" && arity == 2L) {
+    target <- WamRuntime$get_reg(state, 1L)
+    expr   <- WamRuntime$get_reg(state, 2L)
+    n <- WamRuntime$eval_arith(state, expr, table)
+    if (is.null(n)) return(FALSE)
+    res <- WamRuntime$arith_to_term(n)
+    if (is.null(res)) return(FALSE)
+    return(WamRuntime$unify(state, target, res))
+  }
+  # Comparison builtins: eval both args, compare.
+  if (arity == 2L && pred %in% c("=:=/2", "=\\=/2", "</2", ">/2", "=</2", ">=/2")) {
+    a <- WamRuntime$eval_arith(state, WamRuntime$get_reg(state, 1L), table)
+    b <- WamRuntime$eval_arith(state, WamRuntime$get_reg(state, 2L), table)
+    if (is.null(a) || is.null(b)) return(FALSE)
+    return(switch(pred,
+      "=:=/2"  = a == b,
+      "=\\=/2" = a != b,
+      "</2"    = a <  b,
+      ">/2"    = a >  b,
+      "=</2"   = a <= b,
+      ">=/2"   = a >= b,
+      FALSE
+    ))
+  }
   # Unknown builtin -> failure (matches WAM convention).
   FALSE
 }

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -621,9 +621,30 @@ WamRuntime$call_foreign <- function(program, state, pred, arity, tail_call) {
     args[[i]] <- WamRuntime$get_reg(state, i)
   }
   res <- handler(state, args, program$intern_table)
-  if (is.null(res) || isTRUE(res$ok == FALSE)) return(FALSE)
-  # On success the handler may have written register bindings via the
-  # mutable state; we accept that and let the caller advance the PC.
+  # Result contract:
+  #   list(ok = TRUE,                            -- handler succeeded.
+  #        bindings = list(                      -- (optional) outputs to
+  #          list(idx = <reg>, val = <term>),    -- unify into argument
+  #          ...))                               -- registers; failure
+  #                                                 to unify makes the
+  #                                                 whole call fail.
+  #   list(ok = FALSE)                           -- handler failed.
+  # A bare TRUE / FALSE is also accepted for handlers that mutate state
+  # directly; it's equivalent to list(ok = TRUE) / list(ok = FALSE).
+  if (is.null(res)) return(FALSE)
+  if (isTRUE(res)) return(TRUE)
+  if (isFALSE(res)) return(FALSE)
+  if (!isTRUE(res$ok)) return(FALSE)
+  if (!is.null(res$bindings)) {
+    for (entry in res$bindings) {
+      cur <- WamRuntime$get_reg(state, entry$idx)
+      if (is.null(cur)) {
+        WamRuntime$put_reg(state, entry$idx, entry$val)
+      } else if (!WamRuntime$unify(state, cur, entry$val)) {
+        return(FALSE)
+      }
+    }
+  }
   TRUE
 }
 

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -97,7 +97,7 @@ wam_member <- function(elem, lst) {
 GetConstant    <- function(c, ai)      list(op = "GetConstant",    c = c,  ai = ai)
 GetVariable    <- function(xn, ai)     list(op = "GetVariable",    xn = xn, ai = ai)
 GetValue       <- function(xn, ai)     list(op = "GetValue",       xn = xn, ai = ai)
-GetStructure   <- function(fid, ai)    list(op = "GetStructure",   fid = fid, ai = ai)
+GetStructure   <- function(fid, ai, arity = NA_integer_) list(op = "GetStructure", fid = fid, ai = ai, arity = as.integer(arity))
 GetList        <- function(ai, fid)    list(op = "GetList",        ai = ai, fid = fid)
 
 PutConstant    <- function(c, ai)      list(op = "PutConstant",    c = c,  ai = ai)
@@ -130,8 +130,10 @@ CutIte         <- function()           list(op = "CutIte")
 
 BuiltinCall    <- function(p, n)       list(op = "BuiltinCall",   pred = p, arity = n)
 
-SwitchOnConstant <- function(cases)    list(op = "SwitchOnConstant", cases = cases)
-SwitchCase       <- function(val, label) list(value = val, label = label)
+SwitchOnConstant  <- function(cases)    list(op = "SwitchOnConstant",  cases = cases)
+SwitchCase        <- function(val, label) list(value = val, label = label)
+SwitchOnStructure <- function(cases)    list(op = "SwitchOnStructure", cases = cases)
+StructCase        <- function(fid, arity, label) list(fid = as.integer(fid), arity = as.integer(arity), label = label)
 
 BeginAggregate <- function(kind, t, b) list(op = "BeginAggregate", kind = kind, template = t, bag = b)
 EndAggregate   <- function(t)          list(op = "EndAggregate",   template = t)
@@ -152,6 +154,19 @@ WamRuntime$new_state <- function() {
   s$trail       <- list()
   s$var_counter <- 0L
   s$halt        <- FALSE                    # set by foreign top-level wrapper
+  # Structure read/write state. NULL when no build/scan is active.
+  #   write mode: build_target_reg / build_fid / build_arity / build_args
+  #               (set_*/unify_* in write mode append to build_args; on
+  #                completion the struct is finalized into the target reg).
+  #   read mode:  read_args / read_cursor (1-based)
+  #               (unify_* in read mode consume one arg per step).
+  s$mode               <- NULL
+  s$build_target_reg   <- NULL
+  s$build_fid          <- NULL
+  s$build_arity        <- 0L
+  s$build_args         <- list()
+  s$read_args          <- list()
+  s$read_cursor        <- 1L
   s
 }
 
@@ -179,6 +194,79 @@ WamRuntime$promote_regs <- function(state) {
     assign(k, state$regs[[k]], envir = e)
   }
   state$regs2 <- e
+}
+
+# ----------------------------------------------------------
+# Structure build helpers (write mode)
+# ----------------------------------------------------------
+# Begin a write-mode build for `arity` args of functor `fid`, targeting
+# register `target_reg`. Used by both PutStructure/PutList and the
+# write-mode branch of GetStructure/GetList (when matching against an
+# unbound variable).
+WamRuntime$begin_build <- function(state, fid, arity, target_reg) {
+  state$mode             <- "write"
+  state$build_fid        <- as.integer(fid)
+  state$build_arity      <- as.integer(arity)
+  state$build_target_reg <- as.integer(target_reg)
+  state$build_args       <- list()
+  invisible(NULL)
+}
+
+# Append an argument to the in-progress build. When the args list reaches
+# the declared arity we materialize the struct and write it to the target
+# register, binding any unbound variable that was previously there.
+WamRuntime$append_build_arg <- function(state, val) {
+  state$build_args <- c(state$build_args, list(val))
+  if (length(state$build_args) >= state$build_arity) {
+    new_struct <- StructTerm(state$build_fid, state$build_args)
+    cur <- WamRuntime$get_reg(state, state$build_target_reg)
+    cur <- WamRuntime$deref(state, cur)
+    if (!is.null(cur) && is.list(cur) && !is.null(cur$tag) && cur$tag == "unbound") {
+      WamRuntime$bind(state, cur$name, new_struct)
+    }
+    WamRuntime$put_reg(state, state$build_target_reg, new_struct)
+    state$mode             <- NULL
+    state$build_target_reg <- NULL
+    state$build_fid        <- NULL
+    state$build_arity      <- 0L
+    state$build_args       <- list()
+  }
+  invisible(NULL)
+}
+
+WamRuntime$begin_read <- function(state, args) {
+  state$mode        <- "read"
+  state$read_args   <- args
+  state$read_cursor <- 1L
+  invisible(NULL)
+}
+
+WamRuntime$next_read_arg <- function(state) {
+  i <- state$read_cursor
+  if (i > length(state$read_args)) return(NULL)
+  state$read_cursor <- i + 1L
+  state$read_args[[i]]
+}
+
+# When GetStructure / GetList lands on an unbound variable we need to know
+# how many args to build. The Prolog codegen emits arity on PutStructure
+# but historically not on GetStructure (it's implicit in the matching
+# unify_* run). This helper peeks ahead in the instruction array,
+# counting consecutive UnifyVariable / UnifyValue / UnifyConstant ops
+# starting just after `pc`, and returns that count.
+WamRuntime$count_following_unify <- function(program, pc) {
+  n <- 0L
+  i <- pc + 1L
+  while (i <= length(program$instructions)) {
+    op <- program$instructions[[i]]$op
+    if (op %in% c("UnifyVariable", "UnifyValue", "UnifyConstant")) {
+      n <- n + 1L
+      i <- i + 1L
+    } else {
+      break
+    }
+  }
+  n
 }
 
 # ----------------------------------------------------------
@@ -365,9 +453,153 @@ WamRuntime$step <- function(program, state, instr) {
       }
       TRUE
     },
+    "SwitchOnStructure" = {
+      # Same fall-through semantics as SwitchOnConstant: jump to the
+      # case whose (fid, arity) matches the dereferenced first arg,
+      # otherwise advance to the standard try/retry chain. "default"
+      # labels and unresolved labels both fall through.
+      v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+      target <- NULL
+      if (!is.null(v) && is.list(v) && !is.null(v$tag) && v$tag == "struct") {
+        for (case in instr$cases) {
+          if (identical(case$fid, v$fid) && identical(case$arity, length(v$args))) {
+            target <- case$label; break
+          }
+        }
+      }
+      tgt <- if (!is.null(target) && target != "default") program$labels[[target]] else NULL
+      if (is.null(tgt)) {
+        state$pc <- state$pc + 1L
+      } else {
+        state$pc <- as.integer(tgt)
+      }
+      TRUE
+    },
     "BuiltinCall" = {
       ok <- WamRuntime$call_builtin(program, state, instr$pred, instr$arity)
       if (!ok) return(FALSE)
+      state$pc <- state$pc + 1L; TRUE
+    },
+    # ----- Compound terms -----
+    # PutStructure / PutList both start a write-mode build; the only
+    # difference is the functor id (PutList is hard-wired to "[|]"/2).
+    # The arity is taken from the instruction so the build helper knows
+    # when to finalize.
+    "PutStructure" = {
+      WamRuntime$begin_build(state, instr$fid, instr$arity, instr$ai)
+      # Pre-seed the target reg with an unbound so internal references
+      # built before finalization can resolve to the eventual struct.
+      cur <- WamRuntime$get_reg(state, instr$ai)
+      cur <- WamRuntime$deref(state, cur)
+      if (is.null(cur) || (is.list(cur) && !is.null(cur$tag) && cur$tag != "unbound")) {
+        u <- Unbound(paste0("V", state$var_counter))
+        state$var_counter <- state$var_counter + 1L
+        WamRuntime$put_reg(state, instr$ai, u)
+      }
+      state$pc <- state$pc + 1L; TRUE
+    },
+    "PutList" = {
+      WamRuntime$begin_build(state, instr$fid, 2L, instr$ai)
+      cur <- WamRuntime$get_reg(state, instr$ai)
+      cur <- WamRuntime$deref(state, cur)
+      if (is.null(cur) || (is.list(cur) && !is.null(cur$tag) && cur$tag != "unbound")) {
+        u <- Unbound(paste0("V", state$var_counter))
+        state$var_counter <- state$var_counter + 1L
+        WamRuntime$put_reg(state, instr$ai, u)
+      }
+      state$pc <- state$pc + 1L; TRUE
+    },
+    # GetStructure / GetList: deref the register; if it's a struct of the
+    # right shape, switch to read mode; if it's unbound, switch to write
+    # mode (the unify_*/set_* sequence will build a new struct that the
+    # finalizer binds to the unbound). Anything else fails.
+    "GetStructure" = {
+      v <- WamRuntime$deref(state, WamRuntime$get_reg(state, instr$ai))
+      if (is.null(v)) return(FALSE)
+      if (v$tag == "unbound") {
+        # Read the arity from the codegen-supplied instruction. The WAM
+        # emitter doesn't carry arity on GetStructure (it's implicit in
+        # the matching unify_* sequence), so we accept either a present
+        # arity field or default to walking the unify_* sequence below.
+        arity <- if (!is.null(instr$arity)) as.integer(instr$arity) else NA_integer_
+        if (is.na(arity)) {
+          # Fallback: peek ahead in the instruction array for the run of
+          # unify_* / set_* immediately following. Acceptable for the
+          # scaffold; the codegen can be tightened to emit arity later.
+          arity <- WamRuntime$count_following_unify(program, state$pc)
+        }
+        WamRuntime$begin_build(state, instr$fid, arity, instr$ai)
+      } else if (v$tag == "struct" && identical(v$fid, as.integer(instr$fid))) {
+        WamRuntime$begin_read(state, v$args)
+      } else {
+        return(FALSE)
+      }
+      state$pc <- state$pc + 1L; TRUE
+    },
+    "GetList" = {
+      v <- WamRuntime$deref(state, WamRuntime$get_reg(state, instr$ai))
+      if (is.null(v)) return(FALSE)
+      if (v$tag == "unbound") {
+        WamRuntime$begin_build(state, instr$fid, 2L, instr$ai)
+      } else if (v$tag == "struct" && identical(v$fid, as.integer(instr$fid))
+                 && length(v$args) == 2L) {
+        WamRuntime$begin_read(state, v$args)
+      } else {
+        return(FALSE)
+      }
+      state$pc <- state$pc + 1L; TRUE
+    },
+    # ----- Unify (read mode reads next subterm; write mode appends) -----
+    "UnifyVariable" = {
+      if (identical(state$mode, "read")) {
+        v <- WamRuntime$next_read_arg(state)
+        if (is.null(v)) return(FALSE)
+        WamRuntime$put_reg(state, instr$xn, v)
+      } else {
+        u <- Unbound(paste0("V", state$var_counter))
+        state$var_counter <- state$var_counter + 1L
+        WamRuntime$put_reg(state, instr$xn, u)
+        WamRuntime$append_build_arg(state, u)
+      }
+      state$pc <- state$pc + 1L; TRUE
+    },
+    "UnifyValue" = {
+      if (identical(state$mode, "read")) {
+        v <- WamRuntime$next_read_arg(state)
+        if (is.null(v)) return(FALSE)
+        x <- WamRuntime$get_reg(state, instr$xn)
+        if (!WamRuntime$unify(state, v, x)) return(FALSE)
+      } else {
+        v <- WamRuntime$get_reg(state, instr$xn)
+        WamRuntime$append_build_arg(state, v)
+      }
+      state$pc <- state$pc + 1L; TRUE
+    },
+    "UnifyConstant" = {
+      if (identical(state$mode, "read")) {
+        v <- WamRuntime$next_read_arg(state)
+        if (is.null(v)) return(FALSE)
+        if (!WamRuntime$unify(state, v, instr$c)) return(FALSE)
+      } else {
+        WamRuntime$append_build_arg(state, instr$c)
+      }
+      state$pc <- state$pc + 1L; TRUE
+    },
+    # ----- Set (always write-mode; emitted only after Put*) -----
+    "SetVariable" = {
+      u <- Unbound(paste0("V", state$var_counter))
+      state$var_counter <- state$var_counter + 1L
+      WamRuntime$put_reg(state, instr$xn, u)
+      WamRuntime$append_build_arg(state, u)
+      state$pc <- state$pc + 1L; TRUE
+    },
+    "SetValue" = {
+      v <- WamRuntime$get_reg(state, instr$xn)
+      WamRuntime$append_build_arg(state, v)
+      state$pc <- state$pc + 1L; TRUE
+    },
+    "SetConstant" = {
+      WamRuntime$append_build_arg(state, instr$c)
       state$pc <- state$pc + 1L; TRUE
     },
     "Raw" = {

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -24,6 +24,7 @@
 :- use_module('../src/unifyweaver/targets/wam_r_target').
 :- use_module('../src/unifyweaver/targets/wam_r_lowered_emitter').
 :- use_module('../src/unifyweaver/bindings/r_wam_bindings').
+:- use_module('../src/unifyweaver/targets/wam_target').
 
 :- begin_tests(wam_r_generator).
 
@@ -324,14 +325,116 @@ e2e_builtin_arith_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
-% Test 7: lowered emitter scaffold is loadable and refuses lowering
+% Test: lowered emitter exports + lowerability semantics (Phase 2)
 % ------------------------------------------------------------------
-test(lowered_emitter_phase1_stub) :-
+test(lowered_emitter_phase2) :-
     assertion(current_predicate(wam_r_lowered_emitter:wam_r_lowerable/3)),
     assertion(current_predicate(wam_r_lowered_emitter:lower_predicate_to_r/4)),
     assertion(current_predicate(wam_r_lowered_emitter:r_lowered_func_name/2)),
-    % Phase 1 stub: must always fail.
-    \+ wam_r_lowered_emitter:wam_r_lowerable(user:wam_r_fact/1, "", _Reason).
+    % Multi-clause predicates are not lowerable (need backtracking).
+    compile_predicate_to_wam_string(user:wam_r_choice_fact/1, ChoiceWam),
+    \+ wam_r_lowered_emitter:wam_r_lowerable(user:wam_r_choice_fact/1,
+                                             ChoiceWam, _),
+    % Single-clause deterministic rule is lowerable.
+    compile_predicate_to_wam_string(user:wam_r_caller/1, CallerWam),
+    wam_r_lowered_emitter:wam_r_lowerable(user:wam_r_caller/1,
+                                          CallerWam, deterministic).
+
+compile_predicate_to_wam_string(Pred, WamStr) :-
+    wam_target:compile_predicate_to_wam(Pred, [], WamCode),
+    (   string(WamCode) -> WamStr = WamCode
+    ;   atom_string(WamCode, WamStr)
+    ).
+
+% ------------------------------------------------------------------
+% Test: emit_mode(interpreter) keeps the wrapper on the array path and
+%       emits no lowered_<...>_<n> functions.
+% ------------------------------------------------------------------
+test(emit_mode_interpreter_default) :-
+    once((
+        unique_r_tmp_dir('tmp_r_mode_interp', TmpDir),
+        write_wam_r_project(
+            [user:wam_r_caller/1],
+            [],   % default mode = interpreter
+            TmpDir),
+        directory_file_path(TmpDir, 'R/generated_program.R', Program),
+        read_file_to_string(Program, Code, []),
+        assertion(sub_string(Code, _, _, _, 'WamRuntime$run_predicate(shared_program,')),
+        assertion(\+ sub_string(Code, _, _, _, 'lowered_wam_r_caller_1')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+% ------------------------------------------------------------------
+% Test: emit_mode(functions) emits a lowered_<name>_<n> definition
+%       and points the wrapper at it.
+% ------------------------------------------------------------------
+test(emit_mode_functions_lowers_caller) :-
+    once((
+        unique_r_tmp_dir('tmp_r_mode_funcs', TmpDir),
+        write_wam_r_project(
+            [user:wam_r_caller/1, user:wam_r_fact/1],
+            [emit_mode(functions)],
+            TmpDir),
+        directory_file_path(TmpDir, 'R/generated_program.R', Program),
+        read_file_to_string(Program, Code, []),
+        assertion(sub_string(Code, _, _, _, 'lowered_wam_r_caller_1 <- function(program, state)')),
+        assertion(sub_string(Code, _, _, _, 'isTRUE(lowered_wam_r_caller_1(shared_program, state))')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+% ------------------------------------------------------------------
+% Test: multi-clause predicates fall back to interpreter even under
+%       emit_mode(functions).
+% ------------------------------------------------------------------
+test(emit_mode_functions_skips_multi_clause) :-
+    once((
+        unique_r_tmp_dir('tmp_r_mode_skip', TmpDir),
+        write_wam_r_project(
+            [user:wam_r_choice_fact/1],
+            [emit_mode(functions)],
+            TmpDir),
+        directory_file_path(TmpDir, 'R/generated_program.R', Program),
+        read_file_to_string(Program, Code, []),
+        assertion(\+ sub_string(Code, _, _, _, 'lowered_wam_r_choice_fact_1')),
+        assertion(sub_string(Code, _, _, _, 'WamRuntime$run_predicate(shared_program,')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+% ------------------------------------------------------------------
+% Test: end-to-end Rscript execution of a lowered predicate.
+% ------------------------------------------------------------------
+test(lowered_emitter_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_lowered_via_rscript
+    ;   true
+    )).
+
+e2e_lowered_via_rscript :-
+    % Multi-clause fact wam_r_e2e_fact/1 stays on the array path; the
+    % single-clause deterministic caller wam_r_e2e_caller/1 is lowered
+    % and proves through it. We assert that calling the lowered wrapper
+    % with arg = a succeeds and arg = z fails.
+    assertz(user:wam_r_e2e_fact(a)),
+    assertz(user:wam_r_e2e_fact(b)),
+    assertz((user:wam_r_e2e_caller(X) :- user:wam_r_e2e_fact(X))),
+    assertz((user:e2e_ok  :- user:wam_r_e2e_caller(a))),
+    assertz((user:e2e_bad :- user:wam_r_e2e_caller(z))),
+    unique_r_tmp_dir('tmp_r_lowered_e2e', TmpDir),
+    write_wam_r_project(
+        [ user:wam_r_e2e_fact/1, user:wam_r_e2e_caller/1,
+          user:e2e_ok/0, user:e2e_bad/0 ],
+        [emit_mode(functions)],
+        TmpDir),
+    directory_file_path(TmpDir, 'R/generated_program.R', Program),
+    read_file_to_string(Program, Code, []),
+    assertion(sub_string(Code, _, _, _, 'lowered_wam_r_e2e_caller_1 <- function')),
+    directory_file_path(TmpDir, 'R', RDir),
+    run_rscript_query(RDir, 'e2e_ok/0',  OkOut),
+    run_rscript_query(RDir, 'e2e_bad/0', BadOut),
+    assertion(sub_string(OkOut,  _, _, _, "true")),
+    assertion(sub_string(BadOut, _, _, _, "false")),
+    delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -261,6 +261,69 @@ rscript_available :-
     ), _, fail).
 
 % ------------------------------------------------------------------
+% Test: codegen emits BuiltinCall for arithmetic guards (is/2, >/2)
+% ------------------------------------------------------------------
+test(builtin_call_emitted) :-
+    once((
+        unique_r_tmp_dir('tmp_r_builtin', TmpDir),
+        assertz((user:wam_r_double(X, Y) :- Y is X * 2)),
+        assertz((user:wam_r_positive(X) :- X > 0)),
+        write_wam_r_project(
+            [user:wam_r_double/2, user:wam_r_positive/1],
+            [],
+            TmpDir),
+        directory_file_path(TmpDir, 'R/generated_program.R', Program),
+        read_file_to_string(Program, Code, []),
+        assertion(sub_string(Code, _, _, _, 'BuiltinCall("is/2", 2)')),
+        assertion(sub_string(Code, _, _, _, 'BuiltinCall(">/2", 2)')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+% ------------------------------------------------------------------
+% Test: end-to-end Rscript run for arithmetic builtins.
+% Skipped when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(builtin_arith_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_builtin_arith_via_rscript
+    ;   true
+    )).
+
+e2e_builtin_arith_via_rscript :-
+    assertz((user:wam_r_double(X, Y)   :- Y is X * 2)),
+    assertz((user:wam_r_positive(X)    :- X > 0)),
+    assertz((user:wam_r_eq(X, Y)       :- X =:= Y)),
+    assertz((user:wam_r_complex_ok     :- X is 3 * 4 + 1, X =:= 13)),
+    assertz((user:wam_r_complex_bad    :- X is 3 * 4 + 1, X =:= 14)),
+    assertz((user:wam_r_double_ok      :- wam_r_double(7, 14))),
+    assertz((user:wam_r_double_bad     :- wam_r_double(7, 99))),
+    assertz((user:wam_r_pos_ok         :- wam_r_positive(5))),
+    assertz((user:wam_r_pos_bad        :- wam_r_positive(-3))),
+    unique_r_tmp_dir('tmp_r_builtin_e2e', TmpDir),
+    write_wam_r_project(
+        [ user:wam_r_double/2, user:wam_r_positive/1, user:wam_r_eq/2,
+          user:wam_r_complex_ok/0, user:wam_r_complex_bad/0,
+          user:wam_r_double_ok/0, user:wam_r_double_bad/0,
+          user:wam_r_pos_ok/0,    user:wam_r_pos_bad/0 ],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    run_rscript_query(RDir, 'wam_r_complex_ok/0',  C1),
+    run_rscript_query(RDir, 'wam_r_complex_bad/0', C2),
+    run_rscript_query(RDir, 'wam_r_double_ok/0',   D1),
+    run_rscript_query(RDir, 'wam_r_double_bad/0',  D2),
+    run_rscript_query(RDir, 'wam_r_pos_ok/0',      P1),
+    run_rscript_query(RDir, 'wam_r_pos_bad/0',     P2),
+    assertion(sub_string(C1, _, _, _, "true")),
+    assertion(sub_string(C2, _, _, _, "false")),
+    assertion(sub_string(D1, _, _, _, "true")),
+    assertion(sub_string(D2, _, _, _, "false")),
+    assertion(sub_string(P1, _, _, _, "true")),
+    assertion(sub_string(P2, _, _, _, "false")),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 7: lowered emitter scaffold is loadable and refuses lowering
 % ------------------------------------------------------------------
 test(lowered_emitter_phase1_stub) :-

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -28,12 +28,16 @@
 :- dynamic user:wam_r_fact/1.
 :- dynamic user:wam_r_choice_fact/1.
 :- dynamic user:wam_r_caller/1.
+:- dynamic user:wam_r_pair/1.
+:- dynamic user:wam_r_list/1.
 
 user:wam_r_fact(a).
 user:wam_r_choice_fact(a).
 user:wam_r_choice_fact(b).
 user:wam_r_choice_fact(c).
 user:wam_r_caller(X) :- user:wam_r_fact(X).
+user:wam_r_pair(f(a, b)).
+user:wam_r_list([a, b, c]).
 
 % ------------------------------------------------------------------
 % Test 1: module exports the documented entry points
@@ -130,6 +134,42 @@ test(choice_points_emitted) :-
         read_file_to_string(Program, Code, []),
         assertion(sub_string(Code, _, _, _, 'TryMeElse(')),
         assertion(sub_string(Code, _, _, _, 'TrustMe()')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+% ------------------------------------------------------------------
+% Test: structure-bearing fact emits GetStructure with arity + Unify*
+% ------------------------------------------------------------------
+test(structure_instructions_emitted) :-
+    once((
+        unique_r_tmp_dir('tmp_r_struct', TmpDir),
+        write_wam_r_project(
+            [user:wam_r_pair/1],
+            [],
+            TmpDir),
+        directory_file_path(TmpDir, 'R/generated_program.R', Program),
+        read_file_to_string(Program, Code, []),
+        % Codegen carries arity on GetStructure (3-argument constructor).
+        assertion(sub_string(Code, _, _, _, 'GetStructure(')),
+        assertion(sub_string(Code, _, _, _, ', 1, 2)')),
+        assertion(sub_string(Code, _, _, _, 'UnifyConstant(')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+% ------------------------------------------------------------------
+% Test: list fact emits GetList + UnifyConstant chain
+% ------------------------------------------------------------------
+test(list_instructions_emitted) :-
+    once((
+        unique_r_tmp_dir('tmp_r_list', TmpDir),
+        write_wam_r_project(
+            [user:wam_r_list/1],
+            [],
+            TmpDir),
+        directory_file_path(TmpDir, 'R/generated_program.R', Program),
+        read_file_to_string(Program, Code, []),
+        assertion(sub_string(Code, _, _, _, 'GetList(')),
+        assertion(sub_string(Code, _, _, _, 'UnifyVariable(')),
         delete_directory_and_contents(TmpDir)
     )).
 

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -19,6 +19,8 @@
 
 :- use_module(library(plunit)).
 :- use_module(library(filesex)).
+:- use_module(library(process)).
+:- use_module(library(readutil)).
 :- use_module('../src/unifyweaver/targets/wam_r_target').
 :- use_module('../src/unifyweaver/targets/wam_r_lowered_emitter').
 :- use_module('../src/unifyweaver/bindings/r_wam_bindings').
@@ -172,6 +174,91 @@ test(list_instructions_emitted) :-
         assertion(sub_string(Code, _, _, _, 'UnifyVariable(')),
         delete_directory_and_contents(TmpDir)
     )).
+
+% ------------------------------------------------------------------
+% Test: foreign-predicate body is replaced by CallForeign + Proceed
+%       and the handler shows up in foreign_handlers
+% ------------------------------------------------------------------
+test(foreign_handler_wiring) :-
+    once((
+        unique_r_tmp_dir('tmp_r_foreign', TmpDir),
+        % r_double/2 is foreign; it is not defined in user: at all.
+        write_wam_r_project(
+            [],
+            [ foreign_predicates([r_double/2]),
+              r_foreign_handlers([
+                handler(r_double/2,
+                  'function(state, args, table) {\n  n <- args[[1]]\n  if (is.null(n) || is.null(n$tag) || n$tag != "int") return(FALSE)\n  list(ok = TRUE, bindings = list(list(idx = 2L, val = IntTerm(2L * n$val))))\n}')
+              ])
+            ],
+            TmpDir),
+        directory_file_path(TmpDir, 'R/generated_program.R', Program),
+        read_file_to_string(Program, Code, []),
+        % Foreign body is the two-instruction stub: CallForeign + Proceed.
+        assertion(sub_string(Code, _, _, _, 'CallForeign("r_double", 2)')),
+        % Handler is registered against the "pred/arity" key.
+        assertion(sub_string(Code, _, _, _, '"r_double/2" = function(')),
+        % The supplied handler body is verbatim in the file.
+        assertion(sub_string(Code, _, _, _, 'list(ok = TRUE, bindings = list(list(idx = 2L,')),
+        % Top-level wrapper exists too.
+        assertion(sub_string(Code, _, _, _, 'r_double <- function(')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+% ------------------------------------------------------------------
+% Test: end-to-end Rscript dispatch through a foreign handler.
+% Skipped automatically when Rscript is not on PATH, so the suite
+% still passes in environments without R.
+% ------------------------------------------------------------------
+test(foreign_handler_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_foreign_handler_via_rscript
+    ;   true
+    )).
+
+e2e_foreign_handler_via_rscript :-
+    HandlerSrc =
+        'function(state, args, table) {\n  n <- args[[1]]\n  if (is.null(n) || is.null(n$tag) || n$tag != "int") return(FALSE)\n  list(ok = TRUE, bindings = list(list(idx = 2L, val = IntTerm(2L * n$val))))\n}',
+    % Caller predicates ground both args at the call site, so the
+    % foreign handler's output binding must unify with the literal
+    % second arg. check_ok passes 14 (matches 2*7); check_bad passes 99
+    % (does not match) -- this exercises the bindings + unify path
+    % without dragging in arithmetic builtins.
+    assertz((user:check_ok  :- user:r_double(7, 14))),
+    assertz((user:check_bad :- user:r_double(7, 99))),
+    unique_r_tmp_dir('tmp_r_foreign_e2e', TmpDir),
+    write_wam_r_project(
+        [user:check_ok/0, user:check_bad/0],
+        [ foreign_predicates([r_double/2]),
+          r_foreign_handlers([handler(r_double/2, HandlerSrc)])
+        ],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    run_rscript_query(RDir, 'check_ok/0',  OkOut),
+    run_rscript_query(RDir, 'check_bad/0', BadOut),
+    assertion(sub_string(OkOut,  _, _, _, "true")),
+    assertion(sub_string(BadOut, _, _, _, "false")),
+    delete_directory_and_contents(TmpDir).
+
+run_rscript_query(RDir, Query, Out) :-
+    process_create(path('Rscript'),
+                   ['generated_program.R', Query],
+                   [ cwd(RDir),
+                     stdout(pipe(OutStream)),
+                     stderr(pipe(ErrStream)),
+                     process(PID)
+                   ]),
+    read_string(OutStream, _, Out), close(OutStream),
+    read_string(ErrStream, _, _),   close(ErrStream),
+    process_wait(PID, _).
+
+rscript_available :-
+    catch((
+        process_create(path('Rscript'), ['--version'],
+                       [ stdout(null), stderr(null), process(PID) ]),
+        process_wait(PID, exit(0))
+    ), _, fail).
 
 % ------------------------------------------------------------------
 % Test 7: lowered emitter scaffold is loadable and refuses lowering


### PR DESCRIPTION
Follow-up PR to #1867 (the R hybrid WAM scaffold). Builds out four
self-contained increments on top of that scaffold.

## Summary

- **Compound terms & lists** (0f04d7f) — read/write-mode build state, structure/list construction & deconstruction, `switch_on_structure` dispatch. Recursive list predicates like `my_member/2` run end-to-end.
- **Foreign-handler bindings + e2e** (d00653a) — handler result contract `list(ok, bindings = list(list(idx, val), ...))`; new e2e Rscript test exercises the full FFI path.
- **Builtin dispatch + nested-build stack** (1476c45) — `is/2` with recursive arithmetic eval, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`. Build state generalised from a single frame to a stack so nested compounds (`(3*4)+1`) build correctly. Modelled on the Scala runtime.
- **Phase-2 lowered emitter** (5327e6d) — replaces the always-fail Phase-1 stub with real per-predicate native R emission for deterministic single-clause predicates. `emit_mode(interpreter|functions|mixed([...]))` plumbing mirrors the Haskell target. Lowered preds get a wrapper that dispatches directly to the lowered fn; non-lowered preds keep the array path.

Output is byte-identical to the pre-PR state under default `emit_mode(interpreter)`, so this lands without changing existing project behaviour.

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_r_generator.pl` — 18/18 plunit tests pass.
- [x] End-to-end Rscript runs cover: structure facts (`pair(f(a,b))`), recursive list traversal (`my_member/2`), foreign-handler dispatch (`r_double/2` with output bindings), arithmetic precedence (`(10+5)*2`, `100 mod 7`), comparison families, and a lowered caller predicate compiled with `emit_mode(functions)`.
- [x] e2e Rscript tests auto-skip when Rscript is not on PATH so the suite stays green in environments without R.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_