### PR TITLE
feat(wam-c): cover classic recursive programs

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -1,15 +1,15 @@
 # WAM C Target - Status And Next Steps
 
-Status date: 2026-05-05
+Status date: 2026-05-06
 
 Base verified locally:
 
-- `main` at `74d14fd5` (`Merge pull request #1858 from s243a/feat/wam-c-effective-distance-matrix`)
+- `main` at `6b6b8613` (`Merge pull request #1861 from s243a/feat/csharp-query-source-mode-sweep-all-graph-default`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 
 Active branch:
 
-- `feat/wam-c-lmdb-effective-distance-wiring`
+- `feat/wam-c-classic-program-e2e`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -32,7 +32,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | LMDB-backed FactSource foundation | Done | Optional `WAM_C_ENABLE_LMDB`, `wam_fact_source_load_lmdb`, duplicate-key LMDB smoke, existing lookup/kernel registration reuse |
 | Shared kernel detector setup | Done | `detect_kernels/2`, `generate_setup_detected_kernels_c/2`, detected `category_ancestor/4` foreign trampoline project smoke |
 | Effective-distance matrix wiring | Done | `c-wam-accumulated`, `c-wam-accumulated-no-kernels`, C kernel-pair delta, `dev` parity smoke against Prolog |
-| Effective-distance LMDB fact-storage wiring | In progress | `facts_lmdb` generator mode, LMDB seeder/validator, `c-wam-accumulated-lmdb` matrix targets, `dev` parity smoke against Prolog |
+| Effective-distance LMDB fact-storage wiring | Done | `facts_lmdb` generator mode, LMDB seeder/validator, `c-wam-accumulated-lmdb` matrix targets, `dev` parity smoke against Prolog |
+| Classic recursive program e2e | In progress | Generated Prolog-to-WAM-C Fibonacci smoke, `set_*` instruction support, dereferenced constants/results, call-base choicepoint pruning |
 
 ## Current C Target Baseline
 
@@ -41,6 +42,8 @@ The C target is now a credible small WAM backend:
 - Emits a C runtime and predicate setup functions.
 - Supports core head/body WAM instructions for constants, variables,
   structures, lists, and unification.
+- Supports `set_variable`, `set_value`, and `set_constant` for generated body
+  term construction.
 - Supports `call`, `execute`, `proceed`, `allocate`, `deallocate`, and
   choice-point instructions.
 - Supports `switch_on_constant`, `switch_on_structure`, `switch_on_term`,
@@ -69,6 +72,8 @@ The C target is now a credible small WAM backend:
   foreign calls, native category ancestor, file-backed facts, streaming native
   results, real multi-clause predicates, structure indexing, `is_list/1`, and
   `=/2`.
+- Has an executable smoke for a generated multi-recursive Fibonacci-style
+  arithmetic program.
 
 The main limitation is not core WAM execution anymore. It is hybrid-WAM
 infrastructure: C lacks lowered/native helper integration and full benchmark
@@ -98,7 +103,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
 | Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB `kernels_on`/`kernels_off`; next gap is larger artifact layouts. |
-| Classic-program e2e suite | Partial | Partial/Done | Partial/Done | C has targeted smokes; add Fibonacci/Ackermann-style suite like Scala/Elixir. |
+| Classic-program e2e suite | Partial/Done | Partial/Done | Partial/Done | C now covers generated Fibonacci-style recursion with arithmetic; add Ackermann-style depth only if routine runtime stays acceptable. |
 | Memory lifecycle | Partial | Runtime-managed | Runtime-managed | C has init/free; needs ASAN/Valgrind CI-style coverage for larger programs. |
 | Instruction layout efficiency | TODO | N/A | N/A | Pack `Instruction` fields into a tagged union if runtime footprint matters. |
 
@@ -110,8 +115,11 @@ Goal: broaden C executable coverage with classic recursive programs.
 
 Scope:
 
-- Add Fibonacci/Ackermann-style generated executable smokes.
-- Stress retry/trust, arithmetic comparisons, and recursive calls.
+- Add generated executable smokes for classic recursive programs.
+- Stress retry/trust, arithmetic comparisons, recursive calls, and generated
+  body term construction.
+- Cover Fibonacci-style multi-recursive calls; add Ackermann-style depth only if
+  routine runtime stays acceptable.
 - Keep the suite small enough for routine local runs.
 
 ### 2. `perf/wam-c-pack-instruction`
@@ -130,10 +138,9 @@ or cache behavior becomes a real bottleneck.
 
 ## Suggested Immediate Next Step
 
-Finish `feat/wam-c-lmdb-effective-distance-wiring`, then start
-`feat/wam-c-classic-program-e2e`.
+Continue validating `feat/wam-c-classic-program-e2e`.
 
 The C target is now visible in the shared effective-distance matrix using TSV
-and LMDB facts. The next parity gap is broader classic recursive program
-coverage, which should stress retry/trust, arithmetic comparisons, and
-recursive calls outside the effective-distance benchmark shape.
+and LMDB facts. The current classic-program branch adds Fibonacci-style
+recursive arithmetic coverage and fixes the `set_*`, dereference, and
+first-solution call-pruning gaps it exposed.

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -18,6 +18,7 @@
 #define WAM_PRED_HASH_SIZE 256
 #define WAM_ATOM_HASH_SIZE 512
 #define WAM_FOREIGN_HASH_SIZE 256
+#define WAM_CALL_STACK_SIZE 1024
 
 typedef struct WamState WamState;
 typedef bool (*WamForeignHandler)(WamState *state, const char *pred, int arity);
@@ -51,6 +52,7 @@ typedef struct {
     int heap_size;
     int trail_size;
     int stack_size;
+    int call_base_top;
     int arity;
     WamValue a_regs[32]; // Reduced from MAX_REGS to save memory (typical max arity)
 } ChoicePoint;
@@ -187,6 +189,10 @@ struct WamState {
 
     /* Foreign predicate handlers */
     ForeignEntry foreign_hash[WAM_FOREIGN_HASH_SIZE];
+
+    /* First-solution call pruning */
+    int call_bases[WAM_CALL_STACK_SIZE];
+    int call_base_top;
 
     /* Native category_ancestor kernel data */
     CategoryEdge *category_edges;
@@ -386,7 +392,7 @@ static inline void trail_binding(WamState *state, WamValue *cell) {
 static inline WamValue* wam_deref_ptr(WamState *state, WamValue *v) {
     while (v->tag == VAL_REF) {
         WamValue *next = &state->H_array[v->data.ref_addr];
-        if (next->tag == VAL_UNBOUND) break;
+        if (next->tag == VAL_UNBOUND) return next;
         if (next->tag == VAL_REF && next->data.ref_addr == v->data.ref_addr) break;
         v = next;
     }
@@ -462,6 +468,7 @@ static inline void push_choice_point(WamState *state, int next_pc, int arity) {
     cp->heap_size = state->H;
     cp->trail_size = state->TR;
     cp->stack_size = state->E;
+    cp->call_base_top = state->call_base_top;
     
     int save_arity = arity < 32 ? arity : 32;
     cp->arity = save_arity;
@@ -480,6 +487,7 @@ static inline void restore_choice_point(WamState *state, ChoicePoint *cp) {
     state->H = cp->heap_size;
     state->E = cp->stack_size;
     state->CP = cp->cp;
+    state->call_base_top = cp->call_base_top;
     unwind_trail(state, cp->trail_size);
     memcpy(state->A, cp->a_regs, sizeof(WamValue) * cp->arity);
 }
@@ -491,6 +499,11 @@ static inline void pop_choice_point(WamState *state) {
         } else {
             state->HB = 0;
         }
+    }
+}
+static inline void wam_prune_choice_points(WamState *state, int target_b) {
+    while (state->B > target_b) {
+        pop_choice_point(state);
     }
 }
 static inline void update_choice_point(WamState *state, int next_pc) {

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -181,6 +181,15 @@ wam_instruction_to_c_literal(get_list(Ai), Code) :-
 wam_instruction_to_c_literal(put_list(Xn), Code) :-
     c_reg_index(Xn, IsY_Xn, XIdx),
     format(atom(Code), '{ .tag = INSTR_PUT_LIST, .reg_xn = ~w, .is_y_xn = ~w }', [XIdx, IsY_Xn]).
+wam_instruction_to_c_literal(set_variable(Xn), Code) :-
+    c_reg_index(Xn, IsY_Xn, XIdx),
+    format(atom(Code), '{ .tag = INSTR_SET_VARIABLE, .reg_xn = ~w, .is_y_xn = ~w }', [XIdx, IsY_Xn]).
+wam_instruction_to_c_literal(set_value(Xn), Code) :-
+    c_reg_index(Xn, IsY_Xn, XIdx),
+    format(atom(Code), '{ .tag = INSTR_SET_VALUE, .reg_xn = ~w, .is_y_xn = ~w }', [XIdx, IsY_Xn]).
+wam_instruction_to_c_literal(set_constant(C), Code) :-
+    c_value_literal(C, Val),
+    format(atom(Code), '{ .tag = INSTR_SET_CONSTANT, .val = ~w }', [Val]).
 wam_instruction_to_c_literal(unify_variable(Xn), Code) :-
     c_reg_index(Xn, IsY_Xn, XIdx),
     format(atom(Code), '{ .tag = INSTR_UNIFY_VARIABLE, .reg_xn = ~w, .is_y_xn = ~w }', [XIdx, IsY_Xn]).
@@ -303,6 +312,18 @@ wam_line_to_c_instr(["put_list", Xn], Instr) :-
     clean_comma(Xn, CXn),
     c_reg_index(CXn, IsY, Idx),
     format(atom(Instr), '{ .tag = INSTR_PUT_LIST, .reg_xn = ~w, .is_y_xn = ~w }', [Idx, IsY]).
+wam_line_to_c_instr(["set_variable", Xn], Instr) :-
+    clean_comma(Xn, CXn),
+    c_reg_index(CXn, IsY, Idx),
+    format(atom(Instr), '{ .tag = INSTR_SET_VARIABLE, .reg_xn = ~w, .is_y_xn = ~w }', [Idx, IsY]).
+wam_line_to_c_instr(["set_value", Xn], Instr) :-
+    clean_comma(Xn, CXn),
+    c_reg_index(CXn, IsY, Idx),
+    format(atom(Instr), '{ .tag = INSTR_SET_VALUE, .reg_xn = ~w, .is_y_xn = ~w }', [Idx, IsY]).
+wam_line_to_c_instr(["set_constant", C], Instr) :-
+    clean_comma(C, CC),
+    c_value_literal(CC, Val),
+    format(atom(Instr), '{ .tag = INSTR_SET_CONSTANT, .val = ~w }', [Val]).
 wam_line_to_c_instr(["unify_variable", Xn], Instr) :-
     clean_comma(Xn, CXn),
     c_reg_index(CXn, IsY, Idx),
@@ -497,7 +518,7 @@ compile_step_wam_to_c(_Options, CCode) :-
 '    bool step_wam(WamState* state, Instruction* instr) {
         switch (instr->tag) {
             case INSTR_GET_CONSTANT: {
-                WamValue *cell = resolve_reg(state, instr->reg, instr->is_y_reg);
+                WamValue *cell = wam_deref_ptr(state, resolve_reg(state, instr->reg, instr->is_y_reg));
                 if (val_is_unbound(*cell)) {
                     trail_binding(state, cell);
                     *cell = instr->val;
@@ -568,13 +589,21 @@ compile_step_wam_to_c(_Options, CCode) :-
                 return true;
             }
             case INSTR_PROCEED: {
-                state->P = state->CP;
+                int continuation = state->CP;
+                if (continuation != WAM_HALT && state->call_base_top > 0) {
+                    int target_b = state->call_bases[--state->call_base_top];
+                    wam_prune_choice_points(state, target_b);
+                }
+                state->P = continuation;
                 return true;
             }
             case INSTR_CALL: {
+                if (state->call_base_top >= WAM_CALL_STACK_SIZE) return false;
+                state->call_bases[state->call_base_top++] = state->B;
                 state->CP = state->P + 1;
                 int target = resolve_predicate_hash(state, instr->pred);
                 if (target >= 0) { state->P = target; return true; }
+                state->call_base_top--;
                 return false;
             }
             case INSTR_EXECUTE: {
@@ -776,6 +805,34 @@ compile_step_wam_to_c(_Options, CCode) :-
                     state->H_array = realloc(state->H_array, sizeof(WamValue) * state->H_cap);
                 }
                 state->mode = MODE_WRITE;
+                state->P++;
+                return true;
+            }
+            case INSTR_SET_VARIABLE: {
+                WamValue *cell = resolve_reg(state, instr->reg_xn, instr->is_y_xn);
+                WamValue ref = wam_make_ref(state);
+                *cell = ref;
+                state->P++;
+                return true;
+            }
+            case INSTR_SET_VALUE: {
+                WamValue *cell = resolve_reg(state, instr->reg_xn, instr->is_y_xn);
+                if (state->H >= state->H_cap) {
+                    state->H_cap = state->H_cap ? state->H_cap * 2 : WAM_INITIAL_CAP;
+                    state->H_array = realloc(state->H_array, sizeof(WamValue) * state->H_cap);
+                }
+                state->H_array[state->H] = *cell;
+                state->H++;
+                state->P++;
+                return true;
+            }
+            case INSTR_SET_CONSTANT: {
+                if (state->H >= state->H_cap) {
+                    state->H_cap = state->H_cap ? state->H_cap * 2 : WAM_INITIAL_CAP;
+                    state->H_array = realloc(state->H_array, sizeof(WamValue) * state->H_cap);
+                }
+                state->H_array[state->H] = instr->val;
+                state->H++;
                 state->P++;
                 return true;
             }

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -84,7 +84,10 @@ test_body_construction_instructions :-
         member(put_variable, Cases),
         member(put_value, Cases),
         member(put_structure, Cases),
-        member(put_list, Cases)
+        member(put_list, Cases),
+        member(set_variable, Cases),
+        member(set_value, Cases),
+        member(set_constant, Cases)
     ->  pass(Test)
     ;   fail_test(Test, 'missing body construction instruction arms')
     ).
@@ -491,6 +494,16 @@ test_real_prolog_unify_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_real_prolog_classic_recursive_executable_smoke :-
+    Test = 'WAM-C: real Prolog classic recursive executable smoke',
+    (   gcc_available
+    ->  (   run_real_prolog_classic_recursive_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'real Prolog classic recursive executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 gcc_available :-
     catch(process_create(path(gcc), ['--version'],
                          [stdout(null), stderr(null), process(Pid)]),
@@ -807,6 +820,43 @@ run_real_prolog_unify_executable_smoke :-
         run_c_smoke_plain(ExePath)
     ->  retractall(user:wam_c_real_unify(_, _))
     ;   retractall(user:wam_c_real_unify(_, _)),
+        fail
+    ).
+
+run_real_prolog_classic_recursive_executable_smoke :-
+    assertz((user:wam_c_classic_fib(0, 0) :- true)),
+    assertz((user:wam_c_classic_fib(1, 1) :- true)),
+    assertz((user:wam_c_classic_fib(N, F) :-
+        N > 1,
+        N1 is N - 1,
+        N2 is N - 2,
+        wam_c_classic_fib(N1, F1),
+        wam_c_classic_fib(N2, F2),
+        F is F1 + F2)),
+    (   compile_predicate_to_wam(user:wam_c_classic_fib/2, [], WamCode),
+        sub_string(WamCode, _, _, _, 'retry_me_else'),
+        sub_string(WamCode, _, _, _, 'trust_me'),
+        sub_string(WamCode, _, _, _, 'builtin_call >/2, 2'),
+        sub_string(WamCode, _, _, _, 'builtin_call is/2, 2'),
+        sub_string(WamCode, _, _, _, 'call wam_c_classic_fib/2, 2'),
+        compile_wam_predicate_to_c(user:wam_c_classic_fib/2, WamCode, [], PredCode),
+        compile_wam_runtime_to_c([], RuntimeCode),
+        get_time(Now),
+        Stamp is round(Now * 1000000),
+        format(atom(TmpBase), '/tmp/unifyweaver_wam_c_classic_fib_smoke_~w', [Stamp]),
+        format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+        format(atom(PredPath), '~w_pred.c', [TmpBase]),
+        format(atom(MainPath), '~w_main.c', [TmpBase]),
+        format(atom(ExePath), '~w_bin', [TmpBase]),
+        write_text_file(RuntimePath, RuntimeCode),
+        format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+        write_text_file(PredPath, PredTranslationUnit),
+        wam_c_classic_fib_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  retractall(user:wam_c_classic_fib(_, _))
+    ;   retractall(user:wam_c_classic_fib(_, _)),
         fail
     ).
 
@@ -1586,6 +1636,57 @@ int main(void) {
 }
 ').
 
+wam_c_classic_fib_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_classic_fib_2(WamState* state);
+
+static int expect_fib(WamState *state, int n, int expected) {
+    (void)state;
+    WamState local;
+    wam_state_init(&local);
+    setup_wam_c_classic_fib_2(&local);
+    WamValue args[2] = { val_int(n), val_unbound("F") };
+    int rc = wam_run_predicate(&local, "wam_c_classic_fib/2", args, 2);
+    WamValue *result = wam_deref_ptr(&local, &local.A[0]);
+    int ok = rc == 0 &&
+             local.P == WAM_HALT &&
+             result->tag == VAL_INT &&
+             result->data.integer == expected;
+    wam_free_state(&local);
+    return ok;
+}
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_classic_fib_2(&state);
+
+    if (!expect_fib(&state, 0, 0)) {
+        wam_free_state(&state);
+        return 10;
+    }
+    if (!expect_fib(&state, 1, 1)) {
+        wam_free_state(&state);
+        return 20;
+    }
+    if (!expect_fib(&state, 6, 8)) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    WamValue fail_args[2] = { val_int(6), val_int(7) };
+    int fail_rc = wam_run_predicate(&state, "wam_c_classic_fib/2", fail_args, 2);
+    if (fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 implemented_wam_c_cases(Cases) :-
     compile_step_wam_to_c([], Code),
     atom_string(Code, S),
@@ -1618,6 +1719,9 @@ implemented_case(get_structure, 'case INSTR_GET_STRUCTURE').
 implemented_case(put_structure, 'case INSTR_PUT_STRUCTURE').
 implemented_case(get_list, 'case INSTR_GET_LIST').
 implemented_case(put_list, 'case INSTR_PUT_LIST').
+implemented_case(set_variable, 'case INSTR_SET_VARIABLE').
+implemented_case(set_value, 'case INSTR_SET_VALUE').
+implemented_case(set_constant, 'case INSTR_SET_CONSTANT').
 implemented_case(unify_variable, 'case INSTR_UNIFY_VARIABLE').
 implemented_case(unify_value, 'case INSTR_UNIFY_VALUE').
 implemented_case(unify_constant, 'case INSTR_UNIFY_CONSTANT').
@@ -1673,6 +1777,7 @@ run_tests_once :-
     test_real_prolog_structure_index_executable_smoke,
     test_real_prolog_is_list_executable_smoke,
     test_real_prolog_unify_executable_smoke,
+    test_real_prolog_classic_recursive_executable_smoke,
     format('~n=== WAM-C Target Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).
 


### PR DESCRIPTION
## Summary

This PR broadens WAM-C executable coverage with a generated Fibonacci-style recursive program. The new smoke compiles real Prolog clauses through the WAM frontend, emits C, builds the generated executable, and verifies recursive arithmetic results end to end.

## What Changed

- Adds WAM-C parser and runtime support for `set_variable`, `set_value`, and `set_constant`.
- Dereferences `GET_CONSTANT` targets before binding or comparison.
- Fixes heap reference dereferencing so references to unbound heap cells bind through the heap cell.
- Adds a small call-base stack and first-solution choicepoint pruning for nested deterministic calls.
- Adds a generated Prolog-to-WAM-C Fibonacci executable smoke covering retry/trust, arithmetic comparison, `is/2`, nested recursive calls, and failure behavior.
- Updates `WAM_C_TARGET_NEXT_STEPS.md` to mark LMDB effective-distance wiring done and record the classic recursive program coverage.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `git diff --check`

## Follow-Up

The next recommended WAM-C branch remains `perf/wam-c-pack-instruction` unless runtime depth or generated program size points to a higher-priority correctness or memory-lifecycle issue.