### PR TITLE
bench(csharp-query): compare graph source-mode calibration drift

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -115,6 +115,11 @@ The checked-in scale-300 calibration snapshot is
 baseline for the current graph `auto` policy, not a permanent benchmark
 claim: use a fresh sweep before changing `RelationSourceModePolicy`.
 
+Add `--compare-calibration` to compare a fresh sweep with that snapshot. The
+comparison fails on output, resolved-policy, coverage, or relation-registration
+drift, while reporting best-mode and median changes as timing warnings because
+single-repetition benchmark winners can move with local noise.
+
 ### WAM-Rust and WAM-Haskell Benchmark Variants
 
 The effective-distance harness also includes hybrid WAM benchmark targets:

--- a/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
+++ b/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
@@ -61,6 +61,12 @@ class CalibrationArtifactRow:
     source_registration_summary: str
 
 
+@dataclass
+class CalibrationDrift:
+    critical: list[str]
+    timing: list[str]
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -94,6 +100,26 @@ def parse_args() -> argparse.Namespace:
         "--fail-on-output-mismatch",
         action="store_true",
         help="Fail when any swept C# query source mode produces a different output hash.",
+    )
+    parser.add_argument(
+        "--compare-calibration",
+        action="store_true",
+        help=(
+            "Compare the fresh sweep with the checked-in calibration artifact. "
+            "Policy/output drift fails; timing drift is reported as warnings."
+        ),
+    )
+    parser.add_argument(
+        "--calibration-artifact",
+        type=Path,
+        default=CALIBRATION_ARTIFACT,
+        help="TSV calibration artifact used by --compare-calibration.",
+    )
+    parser.add_argument(
+        "--timing-drift-ratio",
+        type=float,
+        default=1.50,
+        help="Warn when a per-mode median or auto-vs-best ratio changes by more than this ratio.",
     )
     return parser.parse_args()
 
@@ -231,6 +257,116 @@ def parse_ratio(value: str) -> float | None:
         return None
 
 
+def parse_mode_summary(value: str) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for part in split_csv(value):
+        if ":" not in part:
+            continue
+        mode, mode_value = part.split(":", 1)
+        parsed[mode] = mode_value
+    return parsed
+
+
+def compare_calibration(
+    summaries: list[SourceModeSummary],
+    baseline_rows: list[CalibrationArtifactRow],
+    *,
+    timing_drift_ratio: float = 1.50,
+) -> CalibrationDrift:
+    critical: list[str] = []
+    timing: list[str] = []
+    fresh_by_key = {
+        (summary.workload, summary.scale): summary
+        for summary in summaries
+    }
+    baseline_by_key = {
+        (row.workload, row.scale): row
+        for row in baseline_rows
+    }
+
+    for key in sorted(set(baseline_by_key) - set(fresh_by_key), key=_calibration_key_sort_key):
+        critical.append(f"{key[0]}/{key[1]}: missing fresh sweep row")
+    for key in sorted(set(fresh_by_key) - set(baseline_by_key), key=_calibration_key_sort_key):
+        critical.append(f"{key[0]}/{key[1]}: no calibration baseline row")
+
+    for key in sorted(set(fresh_by_key) & set(baseline_by_key), key=_calibration_key_sort_key):
+        fresh = fresh_by_key[key]
+        baseline = baseline_by_key[key]
+        label = f"{fresh.workload}/{fresh.scale}"
+        fresh_resolved = parse_mode_summary(fresh.resolved_source_mode_summary)
+        if fresh.output_agreement != "match":
+            critical.append(f"{label}: fresh source-mode outputs {fresh.output_agreement}")
+        if baseline.output_agreement != "match":
+            critical.append(f"{label}: calibration baseline records output {baseline.output_agreement}")
+        if fresh_resolved.get("auto") != baseline.current_auto_resolved_source_mode:
+            critical.append(
+                f"{label}: auto resolved source mode changed from "
+                f"{baseline.current_auto_resolved_source_mode} to {fresh_resolved.get('auto', '<missing>')}"
+            )
+        if fresh.source_registration_summary != baseline.source_registration_summary:
+            critical.append(f"{label}: source registration shape changed")
+
+        if fresh.best_source_mode != baseline.observed_best_source_mode:
+            timing.append(
+                f"{label}: best source mode changed from "
+                f"{baseline.observed_best_source_mode} to {fresh.best_source_mode}"
+            )
+        _append_ratio_drift(
+            timing,
+            label,
+            "auto_vs_best",
+            baseline.observed_auto_vs_best,
+            fresh.auto_vs_best,
+            timing_drift_ratio,
+        )
+        baseline_medians = parse_mode_summary(baseline.median_summary)
+        fresh_medians = parse_mode_summary(fresh.median_summary)
+        for mode in sorted(set(baseline_medians) | set(fresh_medians)):
+            _append_ratio_drift(
+                timing,
+                label,
+                f"median[{mode}]",
+                baseline_medians.get(mode, ""),
+                fresh_medians.get(mode, ""),
+                timing_drift_ratio,
+            )
+
+    return CalibrationDrift(critical=critical, timing=timing)
+
+
+def _calibration_key_sort_key(key: tuple[str, str]) -> tuple[str, tuple[int, object]]:
+    return (key[0], scale_sort_key(key[1]))
+
+
+def _append_ratio_drift(
+    drift: list[str],
+    label: str,
+    field: str,
+    baseline_value: str,
+    fresh_value: str,
+    threshold: float,
+) -> None:
+    baseline = parse_ratio(baseline_value)
+    fresh = parse_ratio(fresh_value)
+    if baseline is None or fresh is None:
+        if baseline_value != fresh_value:
+            drift.append(
+                f"{label}: {field} changed from "
+                f"{baseline_value or '<missing>'} to {fresh_value or '<missing>'}"
+            )
+        return
+    if baseline == 0.0 or fresh == 0.0:
+        if baseline != fresh:
+            drift.append(f"{label}: {field} changed from {baseline_value} to {fresh_value}")
+        return
+    ratio = max(baseline, fresh) / min(baseline, fresh)
+    if ratio > threshold:
+        drift.append(
+            f"{label}: {field} changed from {baseline_value} to {fresh_value} "
+            f"({ratio:.2f}x)"
+        )
+
+
 def calibration_failures(
     summaries: list[SourceModeSummary],
     *,
@@ -342,6 +478,16 @@ def main() -> int:
         max_auto_vs_best_ratio=args.max_auto_vs_best_ratio,
         fail_on_output_mismatch=args.fail_on_output_mismatch,
     )
+    if args.compare_calibration:
+        drift = compare_calibration(
+            summaries,
+            load_calibration_artifact(args.calibration_artifact),
+            timing_drift_ratio=args.timing_drift_ratio,
+        )
+        for warning in drift.timing:
+            print(f"WARNING: calibration timing drift: {warning}", file=sys.stderr)
+        for failure in drift.critical:
+            failures.append(f"calibration drift: {failure}")
     if failures:
         for failure in failures:
             print(f"ERROR: {failure}", file=sys.stderr)

--- a/tests/test_csharp_query_source_mode_sweep.py
+++ b/tests/test_csharp_query_source_mode_sweep.py
@@ -11,11 +11,15 @@ sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
 
 from benchmark_csharp_query_source_mode_sweep import (  # noqa: E402
     CALIBRATION_ARTIFACT,
+    CalibrationArtifactRow,
     DEFAULT_WORKLOADS,
+    SourceModeSummary,
     WORKLOAD_SCRIPTS,
     calibration_failures,
+    compare_calibration,
     load_calibration_artifact,
     parse_args,
+    parse_mode_summary,
     parse_ratio,
     parse_runner_output,
     parse_workloads,
@@ -60,6 +64,80 @@ class CSharpQuerySourceModeSweepTests(unittest.TestCase):
                 self.assertEqual(row.output_agreement, "match")
                 self.assertLessEqual(parse_ratio(row.observed_auto_vs_best) or 0.0, 2.0)
                 self.assertIn("auto:preload", row.resolved_source_mode_summary)
+
+    def test_parse_mode_summary(self) -> None:
+        self.assertEqual(
+            parse_mode_summary("artifact-prebuilt:0.904,auto:0.467,preload:0.360"),
+            {
+                "artifact-prebuilt": "0.904",
+                "auto": "0.467",
+                "preload": "0.360",
+            },
+        )
+
+    def test_compare_calibration_flags_policy_drift_as_critical(self) -> None:
+        drift = compare_calibration(
+            [
+                self._summary(
+                    resolved_source_mode_summary="auto:artifact-prebuilt,preload:preload",
+                )
+            ],
+            [self._baseline()],
+        )
+
+        self.assertEqual(drift.timing, [])
+        self.assertEqual(
+            drift.critical,
+            [
+                (
+                    "category-influence/300: auto resolved source mode changed "
+                    "from preload to artifact-prebuilt"
+                )
+            ],
+        )
+
+    def test_compare_calibration_flags_output_and_registration_drift_as_critical(self) -> None:
+        drift = compare_calibration(
+            [
+                self._summary(
+                    output_agreement="MISMATCH",
+                    source_registration_summary="auto:binary_artifact_artifact-prebuilt_arity2=2",
+                )
+            ],
+            [self._baseline()],
+        )
+
+        self.assertEqual(
+            drift.critical,
+            [
+                "category-influence/300: fresh source-mode outputs MISMATCH",
+                "category-influence/300: source registration shape changed",
+            ],
+        )
+
+    def test_compare_calibration_keeps_best_mode_and_median_changes_as_timing(self) -> None:
+        drift = compare_calibration(
+            [
+                self._summary(
+                    best_source_mode="auto",
+                    auto_vs_best="1.00x",
+                    median_summary="artifact-prebuilt:0.904,auto:0.100,preload:0.900",
+                )
+            ],
+            [self._baseline()],
+            timing_drift_ratio=1.20,
+        )
+
+        self.assertEqual(drift.critical, [])
+        self.assertEqual(
+            drift.timing,
+            [
+                "category-influence/300: best source mode changed from preload to auto",
+                "category-influence/300: auto_vs_best changed from 1.30x to 1.00x (1.30x)",
+                "category-influence/300: median[auto] changed from 0.467 to 0.100 (4.67x)",
+                "category-influence/300: median[preload] changed from 0.360 to 0.900 (2.50x)",
+            ],
+        )
 
     def test_parse_runner_output_summarizes_modes_and_registrations(self) -> None:
         output = "\n".join(
@@ -171,6 +249,35 @@ class CSharpQuerySourceModeSweepTests(unittest.TestCase):
         self.assertEqual(parse_ratio("1.00"), 1.0)
         self.assertIsNone(parse_ratio(""))
         self.assertIsNone(parse_ratio("not-a-ratio"))
+
+    def _baseline(self, **overrides: str) -> CalibrationArtifactRow:
+        values = {
+            "workload": "category-influence",
+            "scale": "300",
+            "observed_best_source_mode": "preload",
+            "current_auto_resolved_source_mode": "preload",
+            "observed_auto_vs_best": "1.30x",
+            "output_agreement": "match",
+            "median_summary": "artifact-prebuilt:0.904,auto:0.467,preload:0.360",
+            "resolved_source_mode_summary": "artifact-prebuilt:artifact-prebuilt,auto:preload,preload:preload",
+            "source_registration_summary": "auto:preloaded_preload_arity2=2",
+        }
+        values.update(overrides)
+        return CalibrationArtifactRow(**values)
+
+    def _summary(self, **overrides: str) -> SourceModeSummary:
+        values = {
+            "workload": "category-influence",
+            "scale": "300",
+            "best_source_mode": "preload",
+            "auto_vs_best": "1.30x",
+            "output_agreement": "match",
+            "median_summary": "artifact-prebuilt:0.904,auto:0.467,preload:0.360",
+            "resolved_source_mode_summary": "artifact-prebuilt:artifact-prebuilt,auto:preload,preload:preload",
+            "source_registration_summary": "auto:preloaded_preload_arity2=2",
+        }
+        values.update(overrides)
+        return SourceModeSummary(**values)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary

  - Adds `--compare-calibration` to the C# query source-mode sweep.
  - Compares fresh sweep output against the checked-in graph calibration TSV.
  - Fails on coverage, output, resolved-policy, or relation-registration drift.
  - Reports best-mode and median changes as timing warnings so benchmark noise does not block the gate.
  - Documents the new comparison mode in the benchmark README.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_source_mode_sweep.py tests/
  test_csharp_query_graph_source_mode_policy.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_source_mode_sweep.py tests/
  test_csharp_query_source_mode_sweep.py tests/test_csharp_query_graph_source_mode_policy.py`
  - `python3 examples/benchmark/benchmark_csharp_query_source_mode_sweep.py --scales 300 --source-modes
  auto,preload,artifact-prebuilt --repetitions 1 --format tsv --fail-on-output-mismatch --max-auto-vs-best-ratio 2.00
  --compare-calibration`
  - `git diff --check`