### PR TITLE
feat(wam-r): term inspection, list/atom library, and extended arithmetic

### DIFF
--- a/src/unifyweaver/targets/wam_r_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_r_lowered_emitter.pl
@@ -151,6 +151,7 @@ parts_supported(["execute", _]).
 parts_supported(["execute", _, _]).
 parts_supported(["call_foreign", _, _]).
 parts_supported(["builtin_call", _, _]).
+parts_supported(["arg", _, _, _]).
 
 % =====================================================================
 % Function-name generation

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -345,6 +345,16 @@ wam_parts_to_r(["call_foreign", Pred, ArityStr], Lit) :-
     number_string(Arity, ArityStr),
     format(string(Lit), 'CallForeign("~w", ~w)', [Pred, Arity]).
 
+% --- arg N, Reg, OutReg ---
+% The WAM compiler optimises arg/3 into a dedicated opcode (faster
+% than builtin_call when N is a literal and the source term is already
+% in a register). Format: "arg <N> <Reg> <OutReg>".
+wam_parts_to_r(["arg", NStr, RegStr, OutRegStr], Lit) :-
+    number_string(N, NStr),
+    reg_to_int(RegStr, RegIdx),
+    reg_to_int(OutRegStr, OutIdx),
+    format(string(Lit), 'ArgInstr(~w, ~w, ~w)', [N, RegIdx, OutIdx]).
+
 % --- Switch on constant ---
 wam_parts_to_r(["switch_on_constant" | Cases], Lit) :-
     normalize_switch_case_tokens(Cases, NormalizedCases),

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -154,6 +154,7 @@ Jump           <- function(label)      list(op = "Jump",          label = label)
 CutIte         <- function()           list(op = "CutIte")
 
 BuiltinCall    <- function(p, n)       list(op = "BuiltinCall",   pred = p, arity = n)
+ArgInstr       <- function(n, ai, out) list(op = "ArgInstr",      n = as.integer(n), ai = as.integer(ai), out = as.integer(out))
 
 SwitchOnConstant  <- function(cases)    list(op = "SwitchOnConstant",  cases = cases)
 SwitchCase        <- function(val, label) list(value = val, label = label)
@@ -420,6 +421,42 @@ wam_compare_nums <- function(a, b) {
   if (a < b) -1L else if (a > b) 1L else 0L
 }
 
+# Build a Prolog-style cons-list term from a list of WAM terms.
+# []      -> Atom("[]")
+# [a]     -> StructTerm("[|]", list(a, Atom("[]")))
+# [a, b]  -> StructTerm("[|]", list(a, StructTerm("[|]", list(b, Atom("[]")))))
+WamRuntime$wam_list_build <- function(elements, table) {
+  cons_id <- WamRuntime$intern(table, "[|]")
+  nil_id  <- WamRuntime$intern(table, "[]")
+  result <- Atom(nil_id)
+  if (length(elements) > 0L) {
+    for (i in seq.int(length(elements), 1L, by = -1L)) {
+      result <- StructTerm(cons_id, list(elements[[i]], result))
+    }
+  }
+  result
+}
+
+# Walk a cons-list term and return its elements as an R list of WAM
+# terms. Returns NULL on a malformed (non-proper) list. Used by =../2
+# in construct mode to read the [Functor | Args] specification.
+WamRuntime$wam_list_decompose <- function(state, term, table) {
+  cons_id <- WamRuntime$intern(table, "[|]")
+  nil_id  <- WamRuntime$intern(table, "[]")
+  out <- list()
+  v <- WamRuntime$deref(state, term)
+  while (!is.null(v) && is.list(v) && !is.null(v$tag)) {
+    if (v$tag == "atom" && identical(v$id, nil_id)) return(out)
+    if (v$tag == "struct" && identical(v$fid, cons_id) && length(v$args) == 2L) {
+      out <- c(out, list(WamRuntime$deref(state, v$args[[1]])))
+      v <- WamRuntime$deref(state, v$args[[2]])
+    } else {
+      return(NULL)
+    }
+  }
+  NULL
+}
+
 WamRuntime$unify <- function(state, a, b) {
   a <- WamRuntime$deref(state, a)
   b <- WamRuntime$deref(state, b)
@@ -615,6 +652,23 @@ WamRuntime$step <- function(program, state, instr) {
     "BuiltinCall" = {
       ok <- WamRuntime$call_builtin(program, state, instr$pred, instr$arity)
       if (!ok) return(FALSE)
+      state$pc <- state$pc + 1L; TRUE
+    },
+    "ArgInstr" = {
+      # WAM-optimised arg/3 with literal index. Read from register
+      # instr$ai (must deref to a struct), grab the n-th 1-based arg,
+      # unify it with the OutReg target. Same semantics as the
+      # builtin_call arg/3 dispatch in call_builtin.
+      v <- WamRuntime$deref(state, WamRuntime$get_reg(state, instr$ai))
+      if (is.null(v) || is.null(v$tag) || v$tag != "struct") return(FALSE)
+      i <- instr$n
+      if (i < 1L || i > length(v$args)) return(FALSE)
+      cur <- WamRuntime$get_reg(state, instr$out)
+      if (is.null(cur)) {
+        WamRuntime$put_reg(state, instr$out, v$args[[i]])
+      } else if (!WamRuntime$unify(state, cur, v$args[[i]])) {
+        return(FALSE)
+      }
       state$pc <- state$pc + 1L; TRUE
     },
     # ----- Compound terms -----
@@ -930,6 +984,98 @@ WamRuntime$call_builtin <- function(program, state, pred, arity) {
         FALSE
       ))
     }
+    # =../2 (univ): bidirectional struct <-> list conversion.
+    #   Decompose: f(a,b) =.. L  -> L = [f, a, b]
+    #              a      =.. L  -> L = [a]
+    #              7      =.. L  -> L = [7]
+    #   Construct: T =.. [f, a, b]  -> T = f(a,b)
+    #              T =.. [a]        -> T = a
+    if (pred == "=../2") {
+      raw_t <- a
+      v <- WamRuntime$deref(state, raw_t)
+      if (is.null(v) || is.null(v$tag)) return(FALSE)
+      if (v$tag == "unbound") {
+        elems <- WamRuntime$wam_list_decompose(state, b, table)
+        if (is.null(elems) || length(elems) == 0L) return(FALSE)
+        head <- elems[[1]]
+        rest <- elems[-1]
+        if (length(rest) == 0L) {
+          # arity 0: bind T to head (atom or number).
+          return(WamRuntime$unify(state, raw_t, head))
+        }
+        if (is.null(head$tag) || head$tag != "atom") return(FALSE)
+        new_t <- StructTerm(head$id, rest)
+        return(WamRuntime$unify(state, raw_t, new_t))
+      }
+      # Decompose: build [Functor | Args].
+      if (v$tag == "struct") {
+        elems <- c(list(Atom(v$fid)), v$args)
+      } else if (v$tag %in% c("atom", "int", "float")) {
+        elems <- list(v)
+      } else {
+        return(FALSE)
+      }
+      list_term <- WamRuntime$wam_list_build(elems, table)
+      return(WamRuntime$unify(state, b, list_term))
+    }
+  }
+
+  # functor/3: bidirectional name/arity inspection.
+  #   Decompose: functor(f(a,b), F, A)  -> F=f, A=2
+  #              functor(a,      F, A)  -> F=a, A=0
+  #              functor(7,      F, A)  -> F=7, A=0
+  #   Construct: functor(T, f, 2)       -> T = f(_V, _V)  (fresh vars)
+  #              functor(T, a, 0)       -> T = a
+  #              functor(T, 7, 0)       -> T = 7
+  if (pred == "functor/3" && arity == 3L) {
+    raw_t <- WamRuntime$get_reg(state, 1L)
+    v <- WamRuntime$deref(state, raw_t)
+    if (is.null(v) || is.null(v$tag)) return(FALSE)
+    if (v$tag == "unbound") {
+      name_v  <- WamRuntime$deref(state, WamRuntime$get_reg(state, 2L))
+      arity_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 3L))
+      if (is.null(name_v) || is.null(arity_v)) return(FALSE)
+      if (is.null(arity_v$tag) || arity_v$tag != "int") return(FALSE)
+      n <- arity_v$val
+      if (n == 0L) {
+        # arity 0: T must be the atom/number itself.
+        return(WamRuntime$unify(state, raw_t, name_v))
+      }
+      if (n < 0L) return(FALSE)
+      if (is.null(name_v$tag) || name_v$tag != "atom") return(FALSE)
+      args <- vector("list", n)
+      for (i in seq_len(n)) {
+        args[[i]] <- Unbound(paste0("V", state$var_counter))
+        state$var_counter <- state$var_counter + 1L
+      }
+      new_t <- StructTerm(name_v$id, args)
+      return(WamRuntime$unify(state, raw_t, new_t))
+    }
+    # Decompose mode.
+    if (v$tag == "struct") {
+      name_term  <- Atom(v$fid)
+      arity_term <- IntTerm(length(v$args))
+    } else if (v$tag %in% c("atom", "int", "float")) {
+      name_term  <- v
+      arity_term <- IntTerm(0L)
+    } else {
+      return(FALSE)
+    }
+    if (!WamRuntime$unify(state, WamRuntime$get_reg(state, 2L), name_term))  return(FALSE)
+    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 3L), arity_term))
+  }
+
+  # arg/3: 1-based argument extraction. Always called with N and T
+  # ground; A may be any term (we unify with the extracted arg).
+  if (pred == "arg/3" && arity == 3L) {
+    n_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+    t_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 2L))
+    if (is.null(n_v) || is.null(t_v)) return(FALSE)
+    if (is.null(n_v$tag) || n_v$tag != "int") return(FALSE)
+    if (is.null(t_v$tag) || t_v$tag != "struct") return(FALSE)
+    i <- n_v$val
+    if (i < 1L || i > length(t_v$args)) return(FALSE)
+    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 3L), t_v$args[[i]]))
   }
 
   # Unknown builtin -> failure (matches WAM convention).

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -543,17 +543,31 @@ WamRuntime$step <- function(program, state, instr) {
     "Call" = {
       key <- paste0(instr$pred, "/", instr$arity)
       tgt <- program$labels[[key]]
-      if (is.null(tgt)) return(FALSE)
-      state$cp <- state$pc + 1L
-      state$pc <- as.integer(tgt)
-      TRUE
+      if (!is.null(tgt)) {
+        state$cp <- state$pc + 1L
+        state$pc <- as.integer(tgt)
+        return(TRUE)
+      }
+      # No label match. Try the runtime library (e.g. atom_codes/2,
+      # reverse/2 etc. that the WAM compiler emits as a plain Execute).
+      lib <- WamRuntime$call_library(program, state, instr$pred, instr$arity)
+      if (is.null(lib)) return(FALSE)
+      if (!isTRUE(lib)) return(FALSE)
+      state$pc <- state$pc + 1L; TRUE
     },
     "Execute" = {
       key <- paste0(instr$pred, "/", instr$arity)
       tgt <- program$labels[[key]]
-      if (is.null(tgt)) return(FALSE)
-      state$pc <- as.integer(tgt)
-      TRUE
+      if (!is.null(tgt)) {
+        state$pc <- as.integer(tgt)
+        return(TRUE)
+      }
+      lib <- WamRuntime$call_library(program, state, instr$pred, instr$arity)
+      if (is.null(lib)) return(FALSE)
+      if (!isTRUE(lib)) return(FALSE)
+      # Tail-call return: same protocol as Proceed.
+      if (state$cp == 0L) { state$halt <- TRUE; return(TRUE) }
+      state$pc <- state$cp; state$cp <- 0L; TRUE
     },
     "CallForeign" = {
       ok <- WamRuntime$call_foreign(program, state, instr$pred, instr$arity, tail_call = FALSE)
@@ -959,6 +973,47 @@ WamRuntime$call_builtin <- function(program, state, pred, arity) {
     ))
   }
 
+  # length/2: deterministic modes only.
+  #   (+, -): traverse the list, count cells, unify N with the count.
+  #   (-, +): build a list of N fresh unbound vars, unify with L.
+  # The (-, -) enumerable mode is intentionally not supported -- it
+  # requires choice-point machinery this scaffold doesn't provide for
+  # generated solutions.
+  if (pred == "length/2" && arity == 2L) {
+    raw_list <- WamRuntime$get_reg(state, 1L)
+    raw_n    <- WamRuntime$get_reg(state, 2L)
+    list_v <- WamRuntime$deref(state, raw_list)
+    n_v    <- WamRuntime$deref(state, raw_n)
+    if (!is.null(list_v) && !is.null(list_v$tag) && list_v$tag != "unbound") {
+      elems <- WamRuntime$wam_list_decompose(state, raw_list, table)
+      if (is.null(elems)) return(FALSE)
+      return(WamRuntime$unify(state, raw_n, IntTerm(length(elems))))
+    }
+    if (!is.null(n_v) && !is.null(n_v$tag) && n_v$tag == "int") {
+      n <- n_v$val
+      if (n < 0L) return(FALSE)
+      args <- vector("list", n)
+      for (i in seq_len(n)) {
+        args[[i]] <- Unbound(paste0("V", state$var_counter))
+        state$var_counter <- state$var_counter + 1L
+      }
+      return(WamRuntime$unify(state, raw_list, WamRuntime$wam_list_build(args, table)))
+    }
+    return(FALSE)
+  }
+
+  # append/3: deterministic (+, +, -) mode.
+  #   append([1,2], [3,4], C) -> C = [1,2,3,4]
+  # The other modes (split-on-third-arg etc.) are non-deterministic
+  # and are intentionally skipped.
+  if (pred == "append/3" && arity == 3L) {
+    a_elems <- WamRuntime$wam_list_decompose(state, WamRuntime$get_reg(state, 1L), table)
+    b_elems <- WamRuntime$wam_list_decompose(state, WamRuntime$get_reg(state, 2L), table)
+    if (is.null(a_elems) || is.null(b_elems)) return(FALSE)
+    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 3L),
+                            WamRuntime$wam_list_build(c(a_elems, b_elems), table)))
+  }
+
   # Term equality / identity / standard order. =/2 may bind; the others
   # never do (and \=/2 specifically rolls back any transient bindings
   # via undo_trail_to).
@@ -1080,6 +1135,136 @@ WamRuntime$call_builtin <- function(program, state, pred, arity) {
 
   # Unknown builtin -> failure (matches WAM convention).
   FALSE
+}
+
+# ----------------------------------------------------------
+# Library predicates (WAM Execute / Call fallback)
+# ----------------------------------------------------------
+# The WAM compiler emits many useful Prolog library predicates as
+# plain Execute / Call rather than builtin_call (atom_codes/2,
+# atom_chars/2, atom_length/2, atom_concat/3, reverse/2, last/2 etc.).
+# When the dispatcher can't find a label for one of these, it
+# delegates here. Returns:
+#   TRUE  -- handled, succeeded
+#   FALSE -- handled, failed (proper WAM failure)
+#   NULL  -- not a known library pred (caller should propagate failure)
+#
+# All implementations are deterministic. Modes that require multi-
+# solution backtracking (e.g. atom_concat split mode) are skipped.
+
+WamRuntime$call_library <- function(program, state, pred, arity) {
+  table <- program$intern_table
+  key <- paste0(pred, "/", arity)
+
+  # ----- atom_codes/2: atom <-> list of code points -----
+  if (key == "atom_codes/2") {
+    raw_a <- WamRuntime$get_reg(state, 1L)
+    raw_c <- WamRuntime$get_reg(state, 2L)
+    a_v <- WamRuntime$deref(state, raw_a)
+    if (!is.null(a_v) && !is.null(a_v$tag) && a_v$tag != "unbound") {
+      s <- if (a_v$tag == "atom")        WamRuntime$string_of(table, a_v$id)
+           else if (a_v$tag == "int")    as.character(a_v$val)
+           else if (a_v$tag == "float")  as.character(a_v$val)
+           else return(FALSE)
+      codes <- utf8ToInt(s)
+      if (length(s) == 0L) codes <- integer(0)
+      elems <- lapply(codes, IntTerm)
+      return(WamRuntime$unify(state, raw_c, WamRuntime$wam_list_build(elems, table)))
+    }
+    # Construct mode: A unbound, Codes bound.
+    elems <- WamRuntime$wam_list_decompose(state, raw_c, table)
+    if (is.null(elems)) return(FALSE)
+    codes <- vapply(elems, function(e) {
+      if (is.null(e) || is.null(e$tag) || e$tag != "int") NA_integer_
+      else as.integer(e$val)
+    }, integer(1))
+    if (any(is.na(codes))) return(FALSE)
+    s <- if (length(codes) == 0L) "" else intToUtf8(codes)
+    new_id <- WamRuntime$intern(table, s)
+    return(WamRuntime$unify(state, raw_a, Atom(new_id)))
+  }
+
+  # ----- atom_chars/2: atom <-> list of single-char atoms -----
+  if (key == "atom_chars/2") {
+    raw_a <- WamRuntime$get_reg(state, 1L)
+    raw_l <- WamRuntime$get_reg(state, 2L)
+    a_v <- WamRuntime$deref(state, raw_a)
+    if (!is.null(a_v) && !is.null(a_v$tag) && a_v$tag != "unbound") {
+      s <- if (a_v$tag == "atom")       WamRuntime$string_of(table, a_v$id)
+           else if (a_v$tag == "int")   as.character(a_v$val)
+           else if (a_v$tag == "float") as.character(a_v$val)
+           else return(FALSE)
+      chars <- if (nchar(s) == 0L) character(0)
+               else strsplit(s, "", fixed = TRUE)[[1]]
+      elems <- lapply(chars, function(ch) Atom(WamRuntime$intern(table, ch)))
+      return(WamRuntime$unify(state, raw_l, WamRuntime$wam_list_build(elems, table)))
+    }
+    elems <- WamRuntime$wam_list_decompose(state, raw_l, table)
+    if (is.null(elems)) return(FALSE)
+    chars <- vapply(elems, function(e) {
+      if (is.null(e) || is.null(e$tag) || e$tag != "atom") NA_character_
+      else WamRuntime$string_of(table, e$id)
+    }, character(1))
+    if (any(is.na(chars))) return(FALSE)
+    s <- paste0(chars, collapse = "")
+    new_id <- WamRuntime$intern(table, s)
+    return(WamRuntime$unify(state, raw_a, Atom(new_id)))
+  }
+
+  # ----- atom_length/2 -----
+  if (key == "atom_length/2") {
+    a_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+    if (is.null(a_v) || is.null(a_v$tag) || a_v$tag != "atom") return(FALSE)
+    s <- WamRuntime$string_of(table, a_v$id)
+    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 2L), IntTerm(nchar(s))))
+  }
+
+  # ----- atom_concat/3 (deterministic mode: A and B both bound) -----
+  if (key == "atom_concat/3") {
+    a_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+    b_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 2L))
+    if (is.null(a_v) || is.null(b_v)) return(FALSE)
+    sa <- if (a_v$tag == "atom")       WamRuntime$string_of(table, a_v$id)
+          else if (a_v$tag == "int")   as.character(a_v$val)
+          else if (a_v$tag == "float") as.character(a_v$val)
+          else return(FALSE)
+    sb <- if (b_v$tag == "atom")       WamRuntime$string_of(table, b_v$id)
+          else if (b_v$tag == "int")   as.character(b_v$val)
+          else if (b_v$tag == "float") as.character(b_v$val)
+          else return(FALSE)
+    new_id <- WamRuntime$intern(table, paste0(sa, sb))
+    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 3L), Atom(new_id)))
+  }
+
+  # ----- reverse/2 (deterministic if either side is bound) -----
+  if (key == "reverse/2") {
+    a_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+    b_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 2L))
+    if (!is.null(a_v) && !is.null(a_v$tag) && a_v$tag != "unbound") {
+      elems <- WamRuntime$wam_list_decompose(state, WamRuntime$get_reg(state, 1L), table)
+      if (is.null(elems)) return(FALSE)
+      return(WamRuntime$unify(state, WamRuntime$get_reg(state, 2L),
+                              WamRuntime$wam_list_build(rev(elems), table)))
+    }
+    if (!is.null(b_v) && !is.null(b_v$tag) && b_v$tag != "unbound") {
+      elems <- WamRuntime$wam_list_decompose(state, WamRuntime$get_reg(state, 2L), table)
+      if (is.null(elems)) return(FALSE)
+      return(WamRuntime$unify(state, WamRuntime$get_reg(state, 1L),
+                              WamRuntime$wam_list_build(rev(elems), table)))
+    }
+    return(FALSE)
+  }
+
+  # ----- last/2 -----
+  if (key == "last/2") {
+    elems <- WamRuntime$wam_list_decompose(state, WamRuntime$get_reg(state, 1L), table)
+    if (is.null(elems) || length(elems) == 0L) return(FALSE)
+    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 2L),
+                            elems[[length(elems)]]))
+  }
+
+  # Unknown library predicate.
+  NULL
 }
 
 # ----------------------------------------------------------

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -856,14 +856,29 @@ WamRuntime$call_foreign <- function(program, state, pred, arity, tail_call) {
 # Recursively evaluate an arithmetic term against the current bindings.
 # Returns a numeric scalar on success or NULL on failure (unbound var,
 # unknown operator, type mismatch). Tagged-list constants resolve to
-# their $val; structures resolve to op(eval(arg1), eval(arg2)). Atoms
-# can be added later (pi, e, ...) but are not supported here.
+# their $val; structures resolve to op(eval(arg1), eval(arg2)). Bare
+# atoms resolve to standard arithmetic constants (pi, e, inf, nan,
+# epsilon, max_tagged_integer).
 WamRuntime$eval_arith <- function(state, term, table) {
   v <- WamRuntime$deref(state, term)
   if (is.null(v) || !is.list(v) || is.null(v$tag)) return(NULL)
   if (v$tag == "int")   return(v$val)
   if (v$tag == "float") return(v$val)
   if (v$tag == "unbound") return(NULL)
+  if (v$tag == "atom") {
+    name <- WamRuntime$string_of(table, v$id)
+    return(switch(name,
+      "pi"                  = pi,
+      "e"                   = exp(1),
+      "inf"                 = Inf,
+      "infinite"            = Inf,
+      "nan"                 = NaN,
+      "epsilon"             = .Machine$double.eps,
+      "max_tagged_integer"  =  .Machine$integer.max,
+      "min_tagged_integer"  = -.Machine$integer.max,
+      NULL
+    ))
+  }
   if (v$tag == "struct") {
     op <- WamRuntime$string_of(table, v$fid)
     args <- v$args
@@ -871,9 +886,27 @@ WamRuntime$eval_arith <- function(state, term, table) {
       a <- WamRuntime$eval_arith(state, args[[1]], table)
       if (is.null(a)) return(NULL)
       return(switch(op,
-        "-"   = -a,
-        "+"   = +a,
-        "abs" = abs(a),
+        "-"        = -a,
+        "+"        = +a,
+        "abs"      = abs(a),
+        "sign"     = sign(a),
+        "sqrt"     = sqrt(a),
+        "exp"      = exp(a),
+        "log"      = log(a),
+        "log2"     = log2(a),
+        "sin"      = sin(a),
+        "cos"      = cos(a),
+        "tan"      = tan(a),
+        "asin"     = asin(a),
+        "acos"     = acos(a),
+        "atan"     = atan(a),
+        "sinh"     = sinh(a),
+        "cosh"     = cosh(a),
+        "tanh"     = tanh(a),
+        "floor"    = floor(a),
+        "ceiling"  = ceiling(a),
+        "truncate" = trunc(a),
+        "round"    = round(a),
         NULL
       ))
     }
@@ -882,20 +915,33 @@ WamRuntime$eval_arith <- function(state, term, table) {
       b <- WamRuntime$eval_arith(state, args[[2]], table)
       if (is.null(a) || is.null(b)) return(NULL)
       return(switch(op,
-        "+"   = a + b,
-        "-"   = a - b,
-        "*"   = a * b,
-        "/"   = a / b,
-        "//"  = a %/% b,
-        "mod" = a %% b,
-        "rem" = a - (a %/% b) * b,
-        "min" = min(a, b),
-        "max" = max(a, b),
+        "+"     = a + b,
+        "-"     = a - b,
+        "*"     = a * b,
+        "/"     = a / b,
+        "//"    = a %/% b,
+        "mod"   = a %% b,
+        "rem"   = a - (a %/% b) * b,
+        "min"   = min(a, b),
+        "max"   = max(a, b),
+        "^"     = a ^ b,
+        "**"    = a ^ b,
+        "atan2" = atan2(a, b),
+        "gcd"   = wam_gcd(as.integer(a), as.integer(b)),
         NULL
       ))
     }
   }
   NULL
+}
+
+# Standard Euclidean GCD; both args coerced to non-negative integers.
+wam_gcd <- function(a, b) {
+  a <- abs(as.integer(a)); b <- abs(as.integer(b))
+  while (b != 0L) {
+    t <- b; b <- a %% b; a <- t
+  }
+  a
 }
 
 # Wrap an R numeric back into a WAM term, keeping integer-ness when the

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -795,6 +795,81 @@ e2e_list_atom_builtins_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for extended arithmetic in is/2.
+% Covers atom constants (pi, e), unary transcendentals (sqrt, exp, log,
+% sin, cos), rounding family (floor, ceiling, truncate, round, sign),
+% and binary ops (^, **, atan2, gcd). Auto-skips when Rscript is not
+% on PATH.
+% ------------------------------------------------------------------
+test(extended_arith_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_extended_arith_via_rscript
+    ;   true
+    )).
+
+e2e_extended_arith_via_rscript :-
+    % Atom constants.
+    assertz((user:ar_pi      :- X is pi,         X > 3.14, X < 3.15)),
+    assertz((user:ar_e       :- X is e,          X > 2.71, X < 2.72)),
+    % Unary transcendentals.
+    assertz((user:ar_sqrt    :- X is sqrt(16),   X =:= 4)),
+    assertz((user:ar_sqrt_f  :- X is sqrt(2),    X > 1.4, X < 1.5)),
+    assertz((user:ar_exp     :- X is exp(0),     X =:= 1)),
+    assertz((user:ar_log     :- X is log(1),     X =:= 0)),
+    assertz((user:ar_sin     :- X is sin(0),     X =:= 0)),
+    assertz((user:ar_cos     :- X is cos(0),     X =:= 1)),
+    % Rounding family.
+    assertz((user:ar_floor   :- X is floor(3.7),    X =:= 3)),
+    assertz((user:ar_ceil    :- X is ceiling(3.2),  X =:= 4)),
+    assertz((user:ar_trunc   :- X is truncate(3.9), X =:= 3)),
+    assertz((user:ar_round_d :- X is round(3.5),    X =:= 4)),
+    assertz((user:ar_round_u :- X is round(3.4),    X =:= 3)),
+    assertz((user:ar_sign_p  :- X is sign(7),       X =:= 1)),
+    assertz((user:ar_sign_n  :- X is sign(-7),      X =:= -1)),
+    assertz((user:ar_sign_z  :- X is sign(0),       X =:= 0)),
+    assertz((user:ar_abs     :- X is abs(-12),      X =:= 12)),
+    % Binary.
+    assertz((user:ar_pow     :- X is 2^10,           X =:= 1024)),
+    assertz((user:ar_starpow :- X is 2**10,          X =:= 1024)),
+    assertz((user:ar_atan2   :- X is atan2(1, 1),    X > 0.78, X < 0.79)),
+    assertz((user:ar_gcd     :- X is gcd(12, 8),     X =:= 4)),
+    assertz((user:ar_gcd2    :- X is gcd(100, 75),   X =:= 25)),
+    % Failure cases.
+    assertz((user:ar_unknown :- X is bogus(1))),
+    unique_r_tmp_dir('tmp_r_extarith_e2e', TmpDir),
+    write_wam_r_project(
+        [ user:ar_pi/0, user:ar_e/0,
+          user:ar_sqrt/0, user:ar_sqrt_f/0, user:ar_exp/0, user:ar_log/0,
+          user:ar_sin/0, user:ar_cos/0,
+          user:ar_floor/0, user:ar_ceil/0, user:ar_trunc/0,
+          user:ar_round_d/0, user:ar_round_u/0,
+          user:ar_sign_p/0, user:ar_sign_n/0, user:ar_sign_z/0, user:ar_abs/0,
+          user:ar_pow/0, user:ar_starpow/0, user:ar_atan2/0,
+          user:ar_gcd/0, user:ar_gcd2/0,
+          user:ar_unknown/0 ],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [ar_pi, ar_e,
+           ar_sqrt, ar_sqrt_f, ar_exp, ar_log, ar_sin, ar_cos,
+           ar_floor, ar_ceil, ar_trunc, ar_round_d, ar_round_u,
+           ar_sign_p, ar_sign_n, ar_sign_z, ar_abs,
+           ar_pow, ar_starpow, ar_atan2, ar_gcd, ar_gcd2],
+    No  = [ar_unknown],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -640,6 +640,92 @@ e2e_extended_builtins_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% Term inspection: functor/3, arg/3, =../2 emit BuiltinCall literals.
+% ------------------------------------------------------------------
+test(term_inspection_emitted) :-
+    once((
+        unique_r_tmp_dir('tmp_r_terminsp', TmpDir),
+        assertz((user:ti_funct(T, F, A) :- functor(T, F, A))),
+        assertz((user:ti_arg(N, T, A)   :- arg(N, T, A))),
+        assertz((user:ti_univ(T, L)     :- T =.. L)),
+        write_wam_r_project(
+            [user:ti_funct/3, user:ti_arg/3, user:ti_univ/2],
+            [],
+            TmpDir),
+        directory_file_path(TmpDir, 'R/generated_program.R', Program),
+        read_file_to_string(Program, Code, []),
+        assertion(sub_string(Code, _, _, _, 'BuiltinCall("functor/3", 3)')),
+        assertion(sub_string(Code, _, _, _, 'BuiltinCall("arg/3", 3)')),
+        assertion(sub_string(Code, _, _, _, 'BuiltinCall("=../2", 2)')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+% ------------------------------------------------------------------
+% End-to-end Rscript run for term inspection. Covers:
+%   - functor/3 decompose for struct, atom, integer
+%   - functor/3 construct (fresh var args)
+%   - arg/3 extraction
+%   - =../2 decompose for struct, atom
+%   - =../2 construct from a list
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(term_inspection_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_term_inspection_via_rscript
+    ;   true
+    )).
+
+e2e_term_inspection_via_rscript :-
+    % Decompose: pull functor name + arity out of a struct.
+    assertz((user:ti_dec_struct  :- functor(f(a, b), f, 2))),
+    assertz((user:ti_dec_struct_n :- functor(f(a, b), g, 2))),
+    assertz((user:ti_dec_atom    :- functor(hello, hello, 0))),
+    assertz((user:ti_dec_int     :- functor(7, 7, 0))),
+    % Construct: build a fresh struct from name + arity.
+    assertz((user:ti_con_struct :- functor(T, f, 2), arg(1, T, _), arg(2, T, _))),
+    assertz((user:ti_con_atom   :- functor(T, hello, 0), T == hello)),
+    % arg/3 indexing (1-based).
+    assertz((user:ti_arg_first  :- arg(1, f(a, b, c), a))),
+    assertz((user:ti_arg_third  :- arg(3, f(a, b, c), c))),
+    assertz((user:ti_arg_oob    :- arg(4, f(a, b, c), _))),
+    % =../2 decompose: f(a,b) =.. [f, a, b].
+    assertz((user:ti_univ_dec   :- f(a, b) =.. [f, a, b])),
+    assertz((user:ti_univ_dec_n :- f(a, b) =.. [g, a, b])),
+    assertz((user:ti_univ_atom  :- hello =.. [hello])),
+    % =../2 construct: T =.. [f, a, b]  ->  T = f(a, b).
+    assertz((user:ti_univ_con   :- T =.. [f, a, b], T == f(a, b))),
+    assertz((user:ti_univ_con_a :- T =.. [hello],   T == hello)),
+    unique_r_tmp_dir('tmp_r_terminsp_e2e', TmpDir),
+    write_wam_r_project(
+        [ user:ti_dec_struct/0, user:ti_dec_struct_n/0,
+          user:ti_dec_atom/0, user:ti_dec_int/0,
+          user:ti_con_struct/0, user:ti_con_atom/0,
+          user:ti_arg_first/0, user:ti_arg_third/0, user:ti_arg_oob/0,
+          user:ti_univ_dec/0, user:ti_univ_dec_n/0, user:ti_univ_atom/0,
+          user:ti_univ_con/0, user:ti_univ_con_a/0 ],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [ti_dec_struct, ti_dec_atom, ti_dec_int,
+           ti_con_struct, ti_con_atom,
+           ti_arg_first, ti_arg_third,
+           ti_univ_dec, ti_univ_atom,
+           ti_univ_con, ti_univ_con_a],
+    No  = [ti_dec_struct_n, ti_arg_oob, ti_univ_dec_n],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -726,6 +726,75 @@ e2e_term_inspection_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end: list / atom library builtins.
+% length/2 and append/3 dispatch via builtin_call; atom_codes/2,
+% atom_chars/2, atom_length/2, atom_concat/3, reverse/2 and last/2
+% dispatch via the runtime's call_library fallback when the WAM-emitted
+% Execute / Call hits a missing label. Auto-skips when Rscript is not
+% on PATH.
+% ------------------------------------------------------------------
+test(list_atom_builtins_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_list_atom_builtins_via_rscript
+    ;   true
+    )).
+
+e2e_list_atom_builtins_via_rscript :-
+    % length/2 (both deterministic modes).
+    assertz((user:lb_len_count :- length([a, b, c], 3))),
+    assertz((user:lb_len_zero  :- length([], 0))),
+    assertz((user:lb_len_wrong :- length([a, b, c], 4))),
+    assertz((user:lb_len_build :- length(L, 3), is_list(L))),
+    % append/3 deterministic mode.
+    assertz((user:lb_app_ok    :- append([1, 2], [3, 4], [1, 2, 3, 4]))),
+    assertz((user:lb_app_empty :- append([], [a, b], [a, b]))),
+    assertz((user:lb_app_no    :- append([1, 2], [3, 4], [1, 2, 3, 5]))),
+    % reverse/2.
+    assertz((user:lb_rev_ok :- reverse([a, b, c], [c, b, a]))),
+    assertz((user:lb_rev_no :- reverse([a, b, c], [a, b, c]))),
+    % last/2.
+    assertz((user:lb_last_ok  :- last([a, b, c], c))),
+    assertz((user:lb_last_no  :- last([a, b, c], a))),
+    % atom_length/2 / atom_codes/2 / atom_chars/2 / atom_concat/3.
+    assertz((user:lb_alen_ok    :- atom_length(hello, 5))),
+    assertz((user:lb_alen_no    :- atom_length(hello, 4))),
+    assertz((user:lb_acodes_ok  :- atom_codes(hi, [104, 105]))),
+    assertz((user:lb_achars_ok  :- atom_chars(hi, [h, i]))),
+    assertz((user:lb_aconcat_ok :- atom_concat(hello, world, helloworld))),
+    assertz((user:lb_aconcat_no :- atom_concat(hello, world, hellounlikely))),
+    unique_r_tmp_dir('tmp_r_listatom_e2e', TmpDir),
+    write_wam_r_project(
+        [ user:lb_len_count/0, user:lb_len_zero/0, user:lb_len_wrong/0,
+          user:lb_len_build/0,
+          user:lb_app_ok/0, user:lb_app_empty/0, user:lb_app_no/0,
+          user:lb_rev_ok/0, user:lb_rev_no/0,
+          user:lb_last_ok/0, user:lb_last_no/0,
+          user:lb_alen_ok/0, user:lb_alen_no/0,
+          user:lb_acodes_ok/0, user:lb_achars_ok/0,
+          user:lb_aconcat_ok/0, user:lb_aconcat_no/0 ],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [lb_len_count, lb_len_zero, lb_len_build,
+           lb_app_ok, lb_app_empty,
+           lb_rev_ok, lb_last_ok,
+           lb_alen_ok, lb_acodes_ok, lb_achars_ok, lb_aconcat_ok],
+    No  = [lb_len_wrong, lb_app_no, lb_rev_no, lb_last_no,
+           lb_alen_no, lb_aconcat_no],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
Builds on the just-merged Phase-3 + extended-builtins PR (#1872) with
three more rounds of builtin coverage on the WAM-R target.

## Summary

- **Term inspection** (e9261cb) — `functor/3` (decompose + construct), `arg/3` (1-based extraction), `=../2` (bidirectional struct ↔ list). Two new runtime helpers (`wam_list_build`, `wam_list_decompose`) and a new `ArgInstr` opcode for the WAM-optimised dedicated `arg N, Reg, OutReg` op.

- **List + atom library builtins** (e369892) — `length/2`, `append/3` (deterministic modes) added to `call_builtin`. Plus a runtime-level `call_library` fallback hook used by `Execute`/`Call` when no label matches; it covers `atom_codes/2`, `atom_chars/2`, `atom_length/2`, `atom_concat/3`, `reverse/2`, `last/2`. Multi-solution / split modes are intentionally skipped.

- **Extended is/2 evaluators** (a6f6921) — `eval_arith` grows atom constants (`pi`, `e`, `inf`, `nan`, `epsilon`, `max_tagged_integer`), unary math ops (`sqrt`, `exp`, `log`, `log2`, full trig family, `sinh`/`cosh`/`tanh`, `floor`, `ceiling`, `truncate`, `round`, `sign`), and binary ops (`^`, `**`, `atan2`, `gcd`).

Behaviour under `emit_mode(interpreter)` is unchanged for any predicate that does not touch the new builtins, so this lands without disturbing existing project behaviour.

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_r_generator.pl` — 26/26 plunit tests pass.
- [x] End-to-end Rscript runs cover: `functor/3` decompose+construct, `arg/3` indexing, `=../2` both directions, full list/atom library family (11 yes + 6 no), extended arithmetic (22 yes + 1 unknown-op no), and four manual integration scenarios (Pythagorean via `sqrt`, circle area with `pi`/`**`, chained `gcd`, `sin²+cos²=1`).
- [x] Rscript-driven tests auto-skip when Rscript is not on PATH.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_