### PR TITLE
bench(wam-haskell): Gate WAM-Haskell category seeds with structural demand filtering

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2793,14 +2793,16 @@ generate_main_hs(_Predicates, DetectedKernels, InlineDefs, Options, Code) :-
     ->  QueryOptions = [use_ffi(true)|Options]
     ;   QueryOptions = Options
     ),
-    generate_query_body(QueryOptions, QueryBody),
     generate_merged_code_build(DetectedKernels, Options, MergedCodeBuild),
     generate_demand_filter(DetectedKernels, Options, DemandFilter, FactsSource),
+    generate_query_body(QueryOptions, RawQueryBody),
+    generate_demand_gated_query_body(DemandFilter, RawQueryBody, QueryBody),
     (   DemandFilter \= ''
     ->  DemandMetrics =
 '    hPutStrLn stderr $ "demand_set_size=" ++ show demandSize
     hPutStrLn stderr $ "demand_total_nodes=" ++ show totalNodes
-    hPutStrLn stderr $ "demand_filtered_nodes=" ++ show filteredSize'
+    hPutStrLn stderr $ "demand_filtered_nodes=" ++ show filteredSize
+    hPutStrLn stderr $ "demand_skipped_seeds=" ++ show demandSkippedSeeds'
     ;   DemandMetrics = ''
     ),
     % Phase F3/F4: generate wcInlineFacts wiring from InlineDefs
@@ -2970,11 +2972,21 @@ generate_demand_filter(DetectedKernels, Options, FilterCode, FactsSource) :-
         !demandSize = IS.size demandSet
         !totalNodes = IM.size parentsIndexInterned
         !filteredParents = filterByDemand demandSet parentsIndexInterned
-        !filteredSize = IM.size filteredParents',
+        !filteredSize = IM.size filteredParents
+        !demandSkippedSeeds = length [cat | cat <- seedCats, not (IS.member (iAtom cat) demandSet)]',
         FactsSource = 'filteredParents'
     ;   FilterCode = '',
         FactsSource = 'parentsIndexInterned'
     ).
+
+%% generate_demand_gated_query_body(+DemandFilter, +RawQueryBody, -QueryBody)
+%  If a structural demand set is available, avoid constructing WAM state or
+%  calling the FFI kernel for seeds that cannot reach the bound root.
+generate_demand_gated_query_body('', QueryBody, QueryBody) :- !.
+generate_demand_gated_query_body(_, RawQueryBody, QueryBody) :-
+    format(string(QueryBody),
+'if not (IS.member (iAtom cat) demandSet) then (cat, 0.0) else ~w',
+           [RawQueryBody]).
 
 %% generate_merged_code_build(+DetectedKernels, +Options, -Code)
 %  Emit the merged-code construction block for Main.hs.

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -4,7 +4,7 @@ module Main where
 import qualified Data.Map.Strict as Map
 import qualified Data.IntMap.Strict as IM
 import qualified Data.IntSet as IS
-import Data.List (nub, sort, isPrefixOf, intercalate, foldl')
+import Data.List (group, sort, isPrefixOf, intercalate, foldl')
 import qualified Numeric
 import Data.Maybe (fromMaybe, mapMaybe)
 import System.Environment (getArgs, lookupEnv)
@@ -186,7 +186,7 @@ main = do
 
 {{^int_atom_seeds}}
     -- Collect seed categories from article_category and TSV roots
-    let seedCatsAll = nub $ sort $ map snd articleCategories
+    let seedCatsAll = map head $ group $ sort $ map snd articleCategories
         root = head roots
         n = fromIntegral ({{dimension_n}} :: Int) :: Double
         negN = -n
@@ -379,9 +379,8 @@ computeDemandSet :: IM.IntMap [Int] -> Int -> IS.IntSet
 computeDemandSet parents rootId = bfs (IS.singleton rootId) (IS.singleton rootId)
   where
     -- Build reverse adjacency: parent → [children]
-    !reverseAdj = IM.foldlWithKey' (\m child ps ->
-        foldl' (\m' p -> IM.insertWith (++) p [child] m') m ps
-      ) IM.empty parents
+    !reverseAdj = IM.fromListWith (++)
+        [(p, [child]) | (child, ps) <- IM.toList parents, p <- ps]
     bfs frontier visited
       | IS.null frontier = visited
       | otherwise =
@@ -391,10 +390,15 @@ computeDemandSet parents rootId = bfs (IS.singleton rootId) (IS.singleton rootId
                     , not (IS.member c visited) ]
           in bfs newNodes (IS.union visited newNodes)
 
--- | Filter a child→[parents] map to only include parents in the demand set.
--- Removes edges to unreachable parents, and drops entries with no remaining parents.
+-- | Filter a child→[parents] map to the structural demand set.
+-- Iterates the usually-small demand set instead of scanning every graph node.
 filterByDemand :: IS.IntSet -> IM.IntMap [Int] -> IM.IntMap [Int]
-filterByDemand demandSet = IM.mapMaybe $ \ps ->
-    case filter (`IS.member` demandSet) ps of
-      [] -> Nothing
-      ps' -> Just ps'
+filterByDemand demandSet parents = IS.foldl' addChild IM.empty demandSet
+  where
+    addChild acc child =
+      case IM.lookup child parents of
+        Nothing -> acc
+        Just ps ->
+          case filter (`IS.member` demandSet) ps of
+            [] -> acc
+            ps' -> IM.insert child ps' acc

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1398,6 +1398,47 @@ test_b1_lmdb_manifest_wiring_option_present :-
     ;   fail_test(Test, 'Manifest-backed FactSource wiring option not found')
     ).
 
+test_demand_filter_gates_seed_query_body :-
+    Test = 'WAM-Haskell: demand filter gates seeds before FFI query body',
+    Kernel = recursive_kernel(category_ancestor, 'category_ancestor'/4,
+                              [max_depth(10), edge_pred(category_parent/2)]),
+    (   wam_haskell_target:generate_main_hs(
+            [],
+            ['category_ancestor/4'-Kernel],
+            [],
+            [],
+            Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "let seedCatsAll = map head $ group $ sort $ map snd articleCategories"),
+        sub_string(S, _, _, _, "!demandSet = computeDemandSet parentsIndexInterned rootId"),
+        sub_string(S, _, _, _, "!reverseAdj = IM.fromListWith (++)"),
+        sub_string(S, _, _, _, "filterByDemand demandSet parents = IS.foldl' addChild IM.empty demandSet"),
+        sub_string(S, _, _, _, "!demandSkippedSeeds = length [cat | cat <- seedCats, not (IS.member (iAtom cat) demandSet)]"),
+        sub_string(S, _, _, _, "if not (IS.member (iAtom cat) demandSet) then (cat, 0.0) else let { hopsVarId"),
+        sub_string(S, _, _, _, "collectForeignSolutions ctx \"category_ancestor/4\""),
+        sub_string(S, _, _, _, "demand_skipped_seeds=")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Demand-filtered Main.hs should skip non-demand seeds before FFI')
+    ).
+
+test_demand_filter_false_leaves_query_ungated :-
+    Test = 'WAM-Haskell: demand_filter(false) leaves seed query ungated',
+    Kernel = recursive_kernel(category_ancestor, 'category_ancestor'/4,
+                              [max_depth(10), edge_pred(category_parent/2)]),
+    (   wam_haskell_target:generate_main_hs(
+            [],
+            ['category_ancestor/4'-Kernel],
+            [],
+            [demand_filter(false)],
+            Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "collectForeignSolutions ctx \"category_ancestor/4\""),
+        \+ sub_string(S, _, _, _, "if not (IS.member (iAtom cat) demandSet)"),
+        \+ sub_string(S, _, _, _, "demand_skipped_seeds=")
+    ->  pass(Test)
+    ;   fail_test(Test, 'demand_filter(false) should not emit the seed gate')
+    ).
+
 %% Regression test for the linear-chain-zero-results bug: the FFI kernel's
 %% max_depth must be substituted from user:max_depth/1 (or an option) at
 %% codegen time. Hardcoding 10 in the Main.hs template caused chain-shaped
@@ -1933,6 +1974,8 @@ run_tests :-
     test_b1_external_source_skips_wam_compilation,
     test_b1_external_source_default_allow_list,
     test_b1_external_source_off_without_use_lmdb,
+    test_demand_filter_gates_seed_query_body,
+    test_demand_filter_false_leaves_query_ungated,
     %% max_depth substitution (regression for linear-chain-zero-results)
     test_max_depth_default_10_when_no_user_fact,
     test_max_depth_from_user_fact,


### PR DESCRIPTION
## Summary

- Skip Haskell WAM/FFI query construction for seeds outside the root-bound structural demand set.
- Emit `demand_skipped_seeds` so large category runs show how much seed work was avoided.
- Replace quadratic sorted seed de-duplication with `group . sort`.
- Build demand-filtered parent maps by iterating the demand set instead of scanning every graph node.
- Bulk-build reverse adjacency with `IntMap.fromListWith`.

## Benchmark Results

All rows are one local repetition on this branch.

| scale | target | time | rows | hash |
|---|---:|---:|---:|---|
| `10k` | `haskell-wam-accumulated` | `1.081s` | 5192 | `4f569fa28e25` |
| `50k_cats` | `haskell-wam-accumulated` | `3.492s` | 11 | `9ada853b4403` |
| `100k_cats` | `haskell-wam-accumulated` | `9.657s` | 11 | `9ada853b4403` |

For `50k_cats`, the previous run before fixing quadratic seed de-duplication
and demand setup was `21.161s`; the earlier merged-main baseline was about
`40.454s`. The new `50k_cats` metrics report:

```text
query_ms=155
demand_set_size=11
demand_total_nodes=80082
demand_filtered_nodes=10
demand_skipped_seeds=49989
```

For `100k_cats`, the run reports:

```text
query_ms=240
demand_set_size=11
demand_total_nodes=80082
demand_filtered_nodes=10
demand_skipped_seeds=84125
```

## Verification

- `swipl -q -s tests/test_wam_haskell_target.pl -t halt`
- `git diff --check`
- `python3 examples/benchmark/benchmark_effective_distance.py --scales 50k_cats --repetitions 1 --targets haskell-wam-accumulated --build-root /tmp/uw-haskell-demand-gate5`
- `python3 examples/benchmark/benchmark_effective_distance.py --scales 10k,100k_cats --repetitions 1 --targets haskell-wam-accumulated --build-root /tmp/uw-haskell-demand-gate5`