### PR TITLE
fix(bench,wam-c): report matrix target errors and fix C heap overflow

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -343,9 +343,12 @@ When both sides of a registered pair run for the same scale, the benchmark
 summary also emits a paired delta table with median timings, a
 `kernels_speedup_vs_no_kernels` ratio, and output/row-count match flags. A
 ratio above `1.0` means the kernel-enabled target was faster than its
-no-kernel counterpart for that pair. Targets reported as `timeout` or
-`compile_only` are listed in the primary table but excluded from output
-matching, baseline speedups, and kernel-pair deltas.
+no-kernel counterpart for that pair. Targets reported as `timeout`, `error`,
+or `compile_only` are listed in the primary table but excluded from output
+matching, baseline speedups, and kernel-pair deltas. Error rows preserve any
+normalized stdout digest and row count that were produced before the process
+failed, which is useful for diagnosing partial-output crashes without aborting
+the rest of the matrix.
 
 Artifact-vs-sidecar Clojure comparisons are available through the
 `clojure-wam-artifact` target set, which adds:

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -789,6 +789,28 @@ def compile_only_result(target: str, scale: str, build_seconds: float) -> RunRes
     )
 
 
+def failed_result(
+    target: str,
+    scale: str,
+    elapsed: float,
+    stdout: str | bytes | None,
+    stderr: str | bytes | None,
+    returncode: int,
+) -> RunResult:
+    normalized = normalize_output(completed_output_text(stdout))
+    digest, row_count = digest_normalized_output(normalized)
+    return RunResult(
+        target=target,
+        scale=scale,
+        times=[elapsed],
+        stdout_sha256=digest,
+        row_count=row_count,
+        stderr=completed_output_text(stderr),
+        status="error",
+        message=f"exited with status {returncode}",
+    )
+
+
 def benchmark_target(
     command: list[str],
     scale: str,
@@ -827,6 +849,9 @@ def benchmark_target(
                 status="timeout",
                 message=f"timed out after {timeout:.3f}s",
             )
+        except subprocess.CalledProcessError as exc:
+            elapsed = time.perf_counter() - started
+            return failed_result(target, scale, elapsed, exc.stdout, exc.stderr, exc.returncode)
         times.append(time.perf_counter() - started)
         stdout = result.stdout
         stderr = result.stderr

--- a/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
@@ -363,6 +363,12 @@ void setup_category_ancestor_4(WamState* state);
 
 static WamValue make_visited_singleton(WamState *state, const char *atom) {
     WamValue list;
+    int required = state->H + 2;
+    if (required > state->H_cap) {
+        if (state->H_cap == 0) state->H_cap = WAM_INITIAL_CAP;
+        while (required > state->H_cap) state->H_cap *= 2;
+        state->H_array = realloc(state->H_array, sizeof(WamValue) * state->H_cap);
+    }
     list.tag = VAL_LIST;
     list.data.ref_addr = state->H;
     state->H_array[state->H++] = val_atom(atom);
@@ -417,11 +423,13 @@ static void collect_hops(WamState *state,
                          int kernels_on,
                          WamIntResults *results) {
     if (kernels_on) {
+        int heap_mark = state->H;
         state->A[0] = val_atom(cat);
         state->A[1] = val_atom(root);
         state->A[2] = val_unbound("Hops");
         state->A[3] = make_visited_singleton(state, cat);
         (void)wam_collect_category_ancestor_hops(state, results);
+        state->H = heap_mark;
     } else {
         const char *visited[64];
         visited[0] = cat;

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -307,6 +307,16 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
                     status="timeout",
                     message="timed out after 10.000s",
                 ),
+                RunResult(
+                    "c-wam-accumulated",
+                    "dev",
+                    [0.5],
+                    "digest",
+                    10,
+                    "",
+                    status="error",
+                    message="exited with status 134",
+                ),
             ],
         )
 
@@ -338,6 +348,16 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
                         status="compile_only",
                         message="generated/built but not executed",
                     ),
+                    RunResult(
+                        "c-wam-accumulated",
+                        "dev",
+                        [0.5],
+                        "b",
+                        19,
+                        "",
+                        status="error",
+                        message="exited with status 134",
+                    ),
                 ],
                 "prolog-accumulated",
             )
@@ -346,6 +366,7 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         self.assertIn("scale\ttarget\tcategory\tstatus\tmedian_s", text)
         self.assertIn("dev\tscala-wam-accumulated-no-kernels\thybrid-wam\ttimeout", text)
         self.assertIn("dev\tc-wam-accumulated-no-kernels\thybrid-wam\tcompile_only", text)
+        self.assertIn("dev\tc-wam-accumulated\thybrid-wam\terror", text)
         self.assertNotIn("all_outputs", text)
         self.assertNotIn("speedup_vs_prolog-accumulated", text)
 

--- a/tests/test_wam_c_effective_distance_benchmark.pl
+++ b/tests/test_wam_c_effective_distance_benchmark.pl
@@ -54,6 +54,20 @@ test_generate_lmdb_mode_files :-
     ;   fail_test(Test, 'facts_lmdb generated files mismatch')
     ).
 
+test_generated_runner_bounds_kernel_heap :-
+    Test = 'WAM-C effective-distance: generated runner bounds temporary kernel heap cells',
+    (   unique_tmp_dir(heap_bounds, OutputDir),
+        write_test_facts(OutputDir, FactsPath),
+        generate_wam_c_effective_distance_benchmark:generate(FactsPath, OutputDir, kernels_on, facts_tsv),
+        directory_file_path(OutputDir, 'main.c', MainPath),
+        read_file_to_string(MainPath, Main, []),
+        sub_string(Main, _, _, _, 'while (required > state->H_cap) state->H_cap *= 2;'),
+        sub_string(Main, _, _, _, 'int heap_mark = state->H;'),
+        sub_string(Main, _, _, _, 'state->H = heap_mark;')
+    ->  pass(Test)
+    ;   fail_test(Test, 'generated runner does not bound/reset kernel heap cells')
+    ).
+
 test_generate_and_run_lmdb_if_available :-
     Test = 'WAM-C effective-distance: facts_lmdb generated runner emits expected result',
     (   lmdb_toolchain_available
@@ -190,6 +204,7 @@ run_tests_once :-
     test_generate_and_run_kernels_on,
     test_generate_and_run_kernels_off,
     test_generate_lmdb_mode_files,
+    test_generated_runner_bounds_kernel_heap,
     test_generate_and_run_lmdb_if_available,
     format('~n=== WAM-C Effective Distance Benchmark Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).


### PR DESCRIPTION
  ## Summary

  Make the effective-distance matrix robust to crashing targets, and fix the WAM-C scale-300 crash found during the
  benchmark sweep.

  ## Changes

  - Report non-zero benchmark target exits as `error` rows instead of aborting the whole matrix.
  - Preserve partial stdout digest and row count for failed targets to aid diagnosis.
  - Exclude `error` rows from output matching, baseline speedups, and kernel/no-kernel deltas.
  - Fix generated WAM-C effective-distance runners so temporary kernel visited-list cells reserve heap capacity before
  writing.
  - Reset the temporary heap mark after each native `category_ancestor/4` kernel call.
  - Add regression coverage for matrix error rows and generated WAM-C heap bounds.

  ## Validation

  - `python3 tests/test_benchmark_target_matrix.py`
  - `swipl -q -s tests/test_wam_c_effective_distance_benchmark.pl`
  - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py tests/
  test_benchmark_target_matrix.py`
  - `git diff --check`
  - Scale-300 C TSV/LMDB smoke: both exit `ok`, produce 271 rows, and match digest `70bbc9ffa4cf`