### PR TITLE
perf(wam-haskell): pre-filter demand seeds before parMap — restore parallel scaling

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -2595,3 +2595,105 @@ The Phase L appendix #2 follow-ups #1, #2, #4 remain — ST-monad arc,
 optional firewall hook for the resolver, and the larger scale 5k/10k
 sweeps. Cross-target audit found one Clojure bug; no other target
 needed fixes.
+
+## Phase L appendix #4: pre-filter demand seeds before parMap (2026-04-28)
+
+PR #1876 (codex) added a per-seed `IS.member` gate inside the parMap
+closure so seeds outside the structural demand set returned `(cat,
+0.0)` immediately. The gate was correct but introduced a parallel
+scaling regression at high seed counts: the spark count still equalled
+`length seedCats`, so on `100k_cats` (84,136 seeds, ~84,125 outside
+the demand set) GHC scheduled ~84k sparks of trivial work and paid
+synchronization cost on each. The handoff doc captured the regression
+— at `-N1` total was 9.66 s and at `-N4` it was 7.02 s, with `-N2`
+the only setting that beat `-N1`.
+
+### The fix
+
+Move the filter from inside the parMap closure to a separate let
+binding executed *before* `parMap`:
+
+```haskell
+-- Before (PR #1876):
+let !seedResultsForced = parMap rdeepseq (\cat ->
+        if not (IS.member (iAtom cat) demandSet)
+          then (cat, 0.0)
+          else <full seed query>
+        ) seedCats
+    !demandSkippedSeeds = length [cat | cat <- seedCats, not (IS.member (iAtom cat) demandSet)]
+
+-- After (this PR):
+    !filteredSeedCats = filter (\cat -> IS.member (iAtom cat) demandSet) seedCats
+    !demandSkippedSeeds = length seedCats - length filteredSeedCats
+...
+let !seedResultsForced = parMap rdeepseq (\cat ->
+        <full seed query>
+        ) filteredSeedCats
+```
+
+Semantically equivalent: the post-aggregation step
+`Map.fromList [(cat, ws) | (cat, ws) <- seedResultsForced, ws > 0]`
+already discards zero-weight entries, so removing them upstream
+is observationally identical. Verified by output sha
+`70bbc9ffa4cf` matching at scale-300 (271 rows) before and after.
+
+### Codegen touch points
+
+`src/unifyweaver/targets/wam_haskell_target.pl`:
+- `generate_demand_filter/4` now emits the `!filteredSeedCats` binding
+  and computes `demandSkippedSeeds` as a length subtraction (cheaper
+  than a list-comprehension count).
+- `generate_demand_gated_query_body/3` is now an identity passthrough.
+  The historical wrapper is preserved as a comment in case anyone
+  needs to rebuild the in-body gate variant.
+- `generate_main_hs/4` selects `parmap_seed_source = filteredSeedCats`
+  when the demand filter is active and `seedCats` otherwise.
+
+`templates/targets/haskell_wam/main.hs.mustache`:
+- The parMap line iterates over `{{parmap_seed_source}}` instead of
+  hardcoded `seedCats`.
+
+`tests/test_wam_haskell_target.pl`:
+- `test_demand_filter_gates_seed_query_body` rewritten: now asserts
+  `!filteredSeedCats = filter ...` is present, that the inline
+  `if not (IS.member ...) then (cat, 0.0)` gate is *absent*, and
+  that parMap closes over `filteredSeedCats`.
+- `test_demand_filter_false_leaves_query_ungated` extended: also
+  asserts no pre-filter binding and that parMap still closes over
+  `seedCats`.
+
+### Measurements (`100k_cats`, default root `0s_beginnings`,
+`demand_skipped_seeds=84125`, 11 effective seeds, 3 trials each)
+
+| RTS | codex baseline (#1876) | this fix | delta |
+|---|---|---|---|
+| `-N1` | total 9.66 s, query 240 ms | total 3.23 s, query 0 ms | **3.0× faster** |
+| `-N2` | total 6.25 s, query 172 ms | total 3.32 s, query ≤4 ms | 1.9× faster |
+| `-N4` | total 7.02 s, query 220 ms | total 6.15 s, query 0 ms | 1.1× faster |
+
+Wall-clock is dominated by the sequential pre-query phase (TSV load,
+atom interning, demand-set BFS) once the spark fanout is removed.
+That sequential floor is the next target — not the parallel section.
+
+### Honest reading
+
+The parMap path is now correctly proportional to effective demand
+(11 sparks at `-N1`, not 84,136). `query_ms` collapsing to ~0 ms
+shows the spark scheduling overhead was real and is gone. `-N4`
+hurting the *total* — even with the fix — reflects the GC / RTS
+pressure of more capabilities on a workload where the parallelizable
+section is now small. That is a separate problem (parallelize the
+load / atom-intern / BFS phases, or drop into single-thread mode for
+small effective-demand workloads); the spark-fanout regression PR
+#1876 introduced is closed.
+
+### Open follow-ups
+
+- Codex's handoff doc lists Rust accumulated at 0.6 s and Elixir LMDB
+  at 1.6 s on the same fixture. Even after this fix Haskell at 3.2 s
+  is the slowest of the three because the sequential pre-query work
+  dominates. Parallelizing or amortizing TSV load and atom interning
+  is the next lever.
+- The historical in-body gate code path is documented in
+  `generate_demand_gated_query_body/3` but unreachable. Drop it once
+  there's no plausible reason to A/B against the gate variant.

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2797,6 +2797,15 @@ generate_main_hs(_Predicates, DetectedKernels, InlineDefs, Options, Code) :-
     generate_demand_filter(DetectedKernels, Options, DemandFilter, FactsSource),
     generate_query_body(QueryOptions, RawQueryBody),
     generate_demand_gated_query_body(DemandFilter, RawQueryBody, QueryBody),
+    %% When the demand filter is active, parMap iterates over the
+    %% pre-filtered seed list (so skipped seeds don't pay spark
+    %% synchronization cost). Otherwise it iterates over seedCats as
+    %% before. See generate_demand_filter for the filteredSeedCats
+    %% binding.
+    (   DemandFilter \= ''
+    ->  ParmapSeedSource = 'filteredSeedCats'
+    ;   ParmapSeedSource = 'seedCats'
+    ),
     (   DemandFilter \= ''
     ->  DemandMetrics =
 '    hPutStrLn stderr $ "demand_set_size=" ++ show demandSize
@@ -2843,6 +2852,7 @@ generate_main_hs(_Predicates, DetectedKernels, InlineDefs, Options, Code) :-
         , int_atom_seeds=IntAtomSeeds
         , max_depth=MaxDepth
         , dimension_n=DimN
+        , parmap_seed_source=ParmapSeedSource
         ], Code).
 
 %% resolve_max_depth(+Options, -MaxDepth)
@@ -2973,20 +2983,30 @@ generate_demand_filter(DetectedKernels, Options, FilterCode, FactsSource) :-
         !totalNodes = IM.size parentsIndexInterned
         !filteredParents = filterByDemand demandSet parentsIndexInterned
         !filteredSize = IM.size filteredParents
-        !demandSkippedSeeds = length [cat | cat <- seedCats, not (IS.member (iAtom cat) demandSet)]',
+        -- Pre-filter seedCats so parMap below only sparks seeds that can
+        -- actually reach root. Without this, every skipped seed pays
+        -- spark synchronization overhead even though its work is trivial,
+        -- which kills parallel speedup at -N>1 on workloads where most
+        -- seeds are gated out (e.g. 50k_cats: 49989/50000 skipped).
+        !filteredSeedCats = filter (\\cat -> IS.member (iAtom cat) demandSet) seedCats
+        !demandSkippedSeeds = length seedCats - length filteredSeedCats',
         FactsSource = 'filteredParents'
     ;   FilterCode = '',
         FactsSource = 'parentsIndexInterned'
     ).
 
 %% generate_demand_gated_query_body(+DemandFilter, +RawQueryBody, -QueryBody)
-%  If a structural demand set is available, avoid constructing WAM state or
-%  calling the FFI kernel for seeds that cannot reach the bound root.
-generate_demand_gated_query_body('', QueryBody, QueryBody) :- !.
-generate_demand_gated_query_body(_, RawQueryBody, QueryBody) :-
-    format(string(QueryBody),
-'if not (IS.member (iAtom cat) demandSet) then (cat, 0.0) else ~w',
-           [RawQueryBody]).
+%
+%  Historical: PR #1876 wrapped the parMap closure with an inline
+%  IS.member check. That kept the spark count equal to seedCats (50k+
+%  on enwiki-style fixtures), so 49989/50000 sparks paid synchronization
+%  cost while doing trivial work — total parallel scaling broke at -N>1.
+%
+%  Current: the filter happens BEFORE parMap (in
+%  generate_demand_filter via filteredSeedCats), so the closure here
+%  no longer needs an inline gate. This predicate is kept as an
+%  identity wrapper for backwards compat with the codegen call site.
+generate_demand_gated_query_body(_, QueryBody, QueryBody).
 
 %% generate_merged_code_build(+DetectedKernels, +Options, -Code)
 %  Emit the merged-code construction block for Main.hs.

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -244,9 +244,15 @@ main = do
     -- rdeepseq forces each (cat, weightSum) fully in parallel. Without
     -- deepseq, the tuple constructor would be WHNF but the Double inside
     -- could remain a thunk, deferring the actual work to later.
+    -- parMap iterates over `{{parmap_seed_source}}`. With demand
+    -- filtering active, that's `filteredSeedCats` (defined in the
+    -- demand-filter block above) — seeds outside the root-bound demand
+    -- set are removed BEFORE we spawn sparks, so we don't pay
+    -- synchronization overhead for trivial work. With demand filtering
+    -- off, this is `seedCats` and behaviour matches the pre-#1876 path.
     let !seedResultsForced = parMap rdeepseq (\cat ->
             {{query_body}}
-            ) seedCats
+            ) {{parmap_seed_source}}
         -- Force the spine so parMap sparks all run before the timing
         -- endpoint. deepseq on the list forces every element too.
         !_ = seedResultsForced `deepseq` ()

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1399,7 +1399,7 @@ test_b1_lmdb_manifest_wiring_option_present :-
     ).
 
 test_demand_filter_gates_seed_query_body :-
-    Test = 'WAM-Haskell: demand filter gates seeds before FFI query body',
+    Test = 'WAM-Haskell: demand filter pre-filters seeds before parMap',
     Kernel = recursive_kernel(category_ancestor, 'category_ancestor'/4,
                               [max_depth(10), edge_pred(category_parent/2)]),
     (   wam_haskell_target:generate_main_hs(
@@ -1413,12 +1413,14 @@ test_demand_filter_gates_seed_query_body :-
         sub_string(S, _, _, _, "!demandSet = computeDemandSet parentsIndexInterned rootId"),
         sub_string(S, _, _, _, "!reverseAdj = IM.fromListWith (++)"),
         sub_string(S, _, _, _, "filterByDemand demandSet parents = IS.foldl' addChild IM.empty demandSet"),
-        sub_string(S, _, _, _, "!demandSkippedSeeds = length [cat | cat <- seedCats, not (IS.member (iAtom cat) demandSet)]"),
-        sub_string(S, _, _, _, "if not (IS.member (iAtom cat) demandSet) then (cat, 0.0) else let { hopsVarId"),
+        sub_string(S, _, _, _, "!filteredSeedCats = filter (\\cat -> IS.member (iAtom cat) demandSet) seedCats"),
+        sub_string(S, _, _, _, "!demandSkippedSeeds = length seedCats - length filteredSeedCats"),
+        sub_string(S, _, _, _, ") filteredSeedCats"),
+        \+ sub_string(S, _, _, _, "if not (IS.member (iAtom cat) demandSet) then (cat, 0.0) else"),
         sub_string(S, _, _, _, "collectForeignSolutions ctx \"category_ancestor/4\""),
         sub_string(S, _, _, _, "demand_skipped_seeds=")
     ->  pass(Test)
-    ;   fail_test(Test, 'Demand-filtered Main.hs should skip non-demand seeds before FFI')
+    ;   fail_test(Test, 'Demand-filtered Main.hs should pre-filter seeds before parMap')
     ).
 
 test_demand_filter_false_leaves_query_ungated :-
@@ -1434,9 +1436,11 @@ test_demand_filter_false_leaves_query_ungated :-
         atom_string(Code, S),
         sub_string(S, _, _, _, "collectForeignSolutions ctx \"category_ancestor/4\""),
         \+ sub_string(S, _, _, _, "if not (IS.member (iAtom cat) demandSet)"),
+        \+ sub_string(S, _, _, _, "filteredSeedCats = filter"),
+        sub_string(S, _, _, _, ") seedCats"),
         \+ sub_string(S, _, _, _, "demand_skipped_seeds=")
     ->  pass(Test)
-    ;   fail_test(Test, 'demand_filter(false) should not emit the seed gate')
+    ;   fail_test(Test, 'demand_filter(false) should not emit pre-filter or seed gate')
     ).
 
 %% Regression test for the linear-chain-zero-results bug: the FFI kernel's


### PR DESCRIPTION
  ## Summary

  PR #1876 added a per-seed `IS.member` demand-set gate inside the `parMap` closure. The gate was correct but kept spark
   count equal to `length seedCats`. On `100k_cats` (84,136 seeds, ~84,125 outside the demand set) GHC scheduled ~84k
  sparks of trivial work and paid synchronization cost on each — `-N1` total was 9.66 s and `-N4` was 7.02 s, with no
  useful speedup beyond `-N2`.

  This PR moves the filter from inside the parMap closure to a separate let binding executed *before* `parMap`. Spark
  count now equals effective demand (11 sparks at the default root, not 84,136). The post-aggregation step already
  discards zero-weight entries, so removing them upstream is observationally identical.

  ```haskell
  -- Before (PR #1876):
  let !seedResultsForced = parMap rdeepseq (\cat ->
          if not (IS.member (iAtom cat) demandSet)
            then (cat, 0.0)
            else <full seed query>
          ) seedCats

  -- After:
      !filteredSeedCats = filter (\cat -> IS.member (iAtom cat) demandSet) seedCats
  ...
  let !seedResultsForced = parMap rdeepseq (\cat ->
          <full seed query>
          ) filteredSeedCats
  ```

  ## Measurements

  `100k_cats`, default root `0s_beginnings`, `demand_skipped_seeds=84125`, 11 effective seeds, 3 trials each:

  | RTS | codex baseline (#1876) | this PR | speedup |
  |---|---|---|---|
  | `-N1` | total 9.66 s, query 240 ms | total 3.23 s, query 0 ms | **3.0×** |
  | `-N2` | total 6.25 s, query 172 ms | total 3.32 s, query ≤4 ms | 1.9× |
  | `-N4` | total 7.02 s, query 220 ms | total 6.15 s, query 0 ms | 1.1× |

  `query_ms` collapsing from ~240 ms to ~0 ms is the spark scheduling overhead disappearing. The remaining wall-clock
  floor (~3 s at any `-N`) is now the sequential pre-query phase (TSV load, atom interning, demand-set BFS), which is
  the next lever.

  `-N4` still hurts the *total* even with the fix — that reflects GC / RTS pressure of more capabilities on a workload
  where the parallelizable section is now small. Separate problem from the spark-fanout regression closed here.

  ## Correctness

  Output sha `70bbc9ffa4cf` matches at scale-300 (271 rows) before and after. The pre-filter and the in-body gate
  produce semantically identical results because the post-aggregation `Map.fromList [(cat, ws) | ..., ws > 0]` discards
  zero-weight entries either way.

  ## Codegen touch points

  - `src/unifyweaver/targets/wam_haskell_target.pl`
    - `generate_demand_filter/4` emits `!filteredSeedCats = filter ...` and computes `demandSkippedSeeds` as a length
  subtraction.
    - `generate_demand_gated_query_body/3` is now an identity passthrough (the historical wrapper is preserved as a
  comment).
    - `generate_main_hs/4` selects `parmap_seed_source = filteredSeedCats` when demand is active, else `seedCats`.
  - `templates/targets/haskell_wam/main.hs.mustache`
    - `parMap` line iterates over `{{parmap_seed_source}}`.
  - `tests/test_wam_haskell_target.pl`
    - `test_demand_filter_gates_seed_query_body` rewritten for the pre-filter shape; asserts the inline gate is absent.
    - `test_demand_filter_false_leaves_query_ungated` extended to also assert no pre-filter binding when demand off.
  - `docs/design/WAM_PERF_OPTIMIZATION_LOG.md`
    - Phase L appendix #4 with full context.

  ## Test plan

  - [x] `swipl -q -g run_tests -t halt tests/test_wam_haskell_target.pl` — green
  - [x] Scale-300 matrix bench — output sha `70bbc9ffa4cf` unchanged
  - [x] `100k_cats` default root with `+RTS -N1/-N2/-N4` — see measurements
  - [ ] Re-run codex's full handoff matrix (50k_cats + 100k_cats with Rust/Elixir comparators) — expected sha
  `9ada853b4403`

  You can paste straight into gh pr create --title ... --body ... or the GitHub UI. Want me to run gh pr create once the
   SSH push is confirmed?