### PR TITLE
feat(wam-r): I/O builtins (write, format, ...) + between/3

### DIFF
--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -177,7 +177,12 @@ wam_line_to_r_literal(Line, Lit) :-
 %  Same single-quote-aware tokenizer as the Scala target.
 tokenize_wam_line(Line, Tokens) :-
     string_chars(Line, Chars),
-    tokenize_wam_chars(Chars, [], [], outside, Tokens).
+    tokenize_wam_chars(Chars, [], [], outside, Tokens0),
+    % Drop empty tokens. These appear when a single-quoted atom is
+    % followed by a `,` separator; strip_operand_comma turns the bare
+    % comma into "" which would otherwise confuse pattern-matching in
+    % wam_parts_to_r.
+    exclude(=(""), Tokens0, Tokens).
 
 tokenize_wam_chars([], [], Acc, _, Tokens) :- !,
     reverse(Acc, Tokens).

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -82,6 +82,47 @@ wam_term_to_string <- function(v, table = NULL) {
   )
 }
 
+# Stateful pretty printer used by I/O builtins. Derefs every node and
+# renders cons cells (`[|]`/2 chains terminated by `[]`) as native list
+# notation. Improper lists fall back to the `[h1, ..., hn | tail]` form.
+WamRuntime$term_to_string <- function(state, term, table) {
+  v <- WamRuntime$deref(state, term)
+  if (is.null(v) || is.null(v$tag)) return("<null>")
+  switch(v$tag,
+    "atom"    = WamRuntime$string_of(table, v$id),
+    "int"     = as.character(v$val),
+    "float"   = as.character(v$val),
+    "unbound" = paste0("_", v$name),
+    "struct"  = {
+      head <- WamRuntime$string_of(table, v$fid)
+      if (head == "[|]" && length(v$args) == 2L) {
+        elems <- character(0)
+        cur <- v
+        while (TRUE) {
+          cur <- WamRuntime$deref(state, cur)
+          if (is.null(cur) || is.null(cur$tag)) break
+          if (cur$tag == "atom" && WamRuntime$string_of(table, cur$id) == "[]") {
+            return(paste0("[", paste(elems, collapse = ","), "]"))
+          }
+          if (cur$tag == "struct" && length(cur$args) == 2L &&
+              WamRuntime$string_of(table, cur$fid) == "[|]") {
+            elems <- c(elems, WamRuntime$term_to_string(state, cur$args[[1]], table))
+            cur <- cur$args[[2]]
+          } else {
+            return(paste0("[", paste(elems, collapse = ","), "|",
+                          WamRuntime$term_to_string(state, cur, table), "]"))
+          }
+        }
+        return(paste0("[", paste(elems, collapse = ","), "...]"))
+      }
+      args_str <- vapply(v$args, function(a)
+        WamRuntime$term_to_string(state, a, table), character(1))
+      paste0(head, "(", paste(args_str, collapse = ","), ")")
+    },
+    "<unknown>"
+  )
+}
+
 wam_member <- function(elem, lst) {
   for (x in lst) {
     if (identical(x, elem)) return(TRUE)
@@ -428,6 +469,42 @@ wam_term_name_string <- function(v, table) {
     "float" = as.character(v$val),
     NULL
   )
+}
+
+# Format-template processor used by format/1 and format/2. Supports the
+# common SWI control-sequence subset:
+#   ~w, ~a, ~p, ~q, ~d  -> consume one arg and write its string form
+#   ~n                  -> newline
+#   ~~                  -> literal '~'
+# Unknown directives are emitted verbatim. Returns NULL on missing args.
+WamRuntime$wam_format <- function(state, template, args, table) {
+  result <- ""
+  i <- 1L
+  arg_idx <- 1L
+  chars <- if (nchar(template) == 0L) character(0)
+           else strsplit(template, "", fixed = TRUE)[[1]]
+  n <- length(chars)
+  while (i <= n) {
+    c <- chars[i]
+    if (c == "~" && i < n) {
+      d <- chars[i + 1L]
+      if (d == "n") {
+        result <- paste0(result, "\n"); i <- i + 2L
+      } else if (d == "~") {
+        result <- paste0(result, "~");  i <- i + 2L
+      } else if (d %in% c("w", "a", "d", "p", "q")) {
+        if (arg_idx > length(args)) return(NULL)
+        result <- paste0(result, WamRuntime$term_to_string(state, args[[arg_idx]], table))
+        arg_idx <- arg_idx + 1L
+        i <- i + 2L
+      } else {
+        result <- paste0(result, c, d); i <- i + 2L
+      }
+    } else {
+      result <- paste0(result, c); i <- i + 1L
+    }
+  }
+  result
 }
 
 wam_compare_nums <- function(a, b) {
@@ -1129,6 +1206,18 @@ WamRuntime$call_builtin <- function(program, state, pred, arity) {
     return(TRUE)
   }
 
+  # write/1 and nl/0: side-effecting I/O. Atoms / numbers print as
+  # their name string; structs render with the term_to_string pretty
+  # printer (cons cells become list notation).
+  if (pred == "write/1" && arity == 1L) {
+    cat(WamRuntime$term_to_string(state, WamRuntime$get_reg(state, 1L), table))
+    return(TRUE)
+  }
+  if (pred == "nl/0" && arity == 0L) {
+    cat("\n")
+    return(TRUE)
+  }
+
   # \+/1, not/1: negation as failure. Run the goal in a snapshot --
   # rolling back the trail, build state and choice points after --
   # then invert the outcome. Note: the WAM compiler emits not/1 as
@@ -1534,6 +1623,64 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
                               IntTerm(y_v$val - 1L)))
     }
     return(FALSE)
+  }
+
+  # ----- between/3: deterministic mode (test only) -----
+  # between(+Low, +High, +X) succeeds iff Low <= X <= High.
+  # The (+,+,-) enumerable mode unifies X with Low (the smallest valid
+  # value). Iterating across the range needs choice-point machinery
+  # this scaffold doesn't drive from inside library dispatches.
+  if (key == "between/3") {
+    lo_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+    hi_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 2L))
+    x_v  <- WamRuntime$deref(state, WamRuntime$get_reg(state, 3L))
+    if (is.null(lo_v) || is.null(lo_v$tag) || lo_v$tag != "int") return(FALSE)
+    if (is.null(hi_v) || is.null(hi_v$tag) || hi_v$tag != "int") return(FALSE)
+    lo <- lo_v$val
+    hi <- hi_v$val
+    if (lo > hi) return(FALSE)
+    if (!is.null(x_v) && !is.null(x_v$tag) && x_v$tag == "int") {
+      return(x_v$val >= lo && x_v$val <= hi)
+    }
+    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 3L), IntTerm(lo)))
+  }
+
+  # ----- I/O: writeln/1, print/1, format/1, format/2 -----
+  # writeln/1 == write/1 + newline. print/1 is the same as write/1 in
+  # this scaffold (no portray/1 hook). format/N processes the template
+  # via WamRuntime$wam_format -- see that helper for supported
+  # control sequences.
+  if (key == "writeln/1") {
+    cat(WamRuntime$term_to_string(state, WamRuntime$get_reg(state, 1L), table), "\n", sep = "")
+    return(TRUE)
+  }
+  if (key == "print/1") {
+    cat(WamRuntime$term_to_string(state, WamRuntime$get_reg(state, 1L), table))
+    return(TRUE)
+  }
+  if (key == "format/1") {
+    t_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+    s <- wam_term_name_string(t_v, table)
+    if (is.null(s)) return(FALSE)
+    out <- WamRuntime$wam_format(state, s, list(), table)
+    if (is.null(out)) return(FALSE)
+    cat(out)
+    return(TRUE)
+  }
+  if (key == "format/2") {
+    t_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+    s <- wam_term_name_string(t_v, table)
+    if (is.null(s)) return(FALSE)
+    raw_args <- WamRuntime$get_reg(state, 2L)
+    args <- WamRuntime$wam_list_decompose(state, raw_args, table)
+    if (is.null(args)) {
+      # Non-list arg: treat as singleton ([Arg]).
+      args <- list(WamRuntime$deref(state, raw_args))
+    }
+    out <- WamRuntime$wam_format(state, s, args, table)
+    if (is.null(out)) return(FALSE)
+    cat(out)
+    return(TRUE)
   }
 
   # call/1: meta-call. Just delegate the goal to the goal evaluator;

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -1125,6 +1125,76 @@ e2e_higherorder_listutil_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for I/O builtins (write/1, nl/0, writeln/1,
+% print/1, format/1, format/2) and between/3 (deterministic mode).
+% Asserts both the truth result AND the captured stdout.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(io_between_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_io_between_via_rscript
+    ;   true
+    )).
+
+e2e_io_between_via_rscript :-
+    assertz((user:io_w_basic   :- write(hello), nl)),
+    assertz((user:io_w_int     :- write(42), nl)),
+    assertz((user:io_writeln_a :- writeln(world))),
+    assertz((user:io_print_x   :- print(x), nl)),
+    assertz((user:io_format1   :- format("plain~n"))),
+    assertz((user:io_format2   :- format("~w + ~w = ~w~n", [2, 3, 5]))),
+    assertz((user:io_format_list :- format("list = ~w~n", [[a, b, c]]))),
+    assertz((user:io_format_struct :- format("term = ~w~n", [f(1, two)]))),
+    assertz((user:io_format_tilde  :- format("100~~ done~n"))),
+    % between/3
+    assertz((user:bt_in    :- between(1, 10, 5))),
+    assertz((user:bt_lo    :- between(5, 5, 5))),
+    assertz((user:bt_oob_h :- between(1, 10, 99))),
+    assertz((user:bt_oob_l :- between(1, 10, 0))),
+    assertz((user:bt_bad   :- between(10, 1, 5))),
+    assertz((user:bt_gen   :- between(3, 7, X), X =:= 3)),
+    unique_r_tmp_dir('tmp_r_io_e2e', TmpDir),
+    write_wam_r_project(
+        [ user:io_w_basic/0, user:io_w_int/0, user:io_writeln_a/0,
+          user:io_print_x/0, user:io_format1/0, user:io_format2/0,
+          user:io_format_list/0, user:io_format_struct/0,
+          user:io_format_tilde/0,
+          user:bt_in/0, user:bt_lo/0, user:bt_oob_h/0, user:bt_oob_l/0,
+          user:bt_bad/0, user:bt_gen/0 ],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    % Truth-only checks (output content irrelevant for these).
+    Yes = [io_w_basic, io_w_int, io_writeln_a, io_print_x,
+           io_format1, io_format2, io_format_list, io_format_struct,
+           io_format_tilde,
+           bt_in, bt_lo, bt_gen],
+    No  = [bt_oob_h, bt_oob_l, bt_bad],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    % Output-content checks for the I/O family.
+    run_rscript_query(RDir, 'io_w_basic/0',       OB),
+    assertion(sub_string(OB, _, _, _, "hello\n")),
+    run_rscript_query(RDir, 'io_format2/0',       OF2),
+    assertion(sub_string(OF2, _, _, _, "2 + 3 = 5\n")),
+    run_rscript_query(RDir, 'io_format_list/0',   OFL),
+    assertion(sub_string(OFL, _, _, _, "list = [a,b,c]\n")),
+    run_rscript_query(RDir, 'io_format_struct/0', OFS),
+    assertion(sub_string(OFS, _, _, _, "term = f(1,two)\n")),
+    run_rscript_query(RDir, 'io_format_tilde/0',  OFT),
+    assertion(sub_string(OFT, _, _, _, "100~ done\n")),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
Generated programs can now actually print their output. Adds the I/O
family plus `between/3` (deterministic mode) and a tokenizer fix that
unblocks `format` with multi-word templates.

## Summary

- **I/O**:
  - `write/1`, `nl/0` in `call_builtin` (matches WAM-emitted dispatch)
  - `writeln/1`, `print/1`, `format/1`, `format/2` in `call_library`
  - `format` supports the SWI control-sequence subset `~w`/`~a`/`~d`/`~p`/`~q` (write next arg), `~n` (newline), `~~` (literal `~`)
- **`between/3`** (deterministic mode): test-mode `(+, +, +)` succeeds iff `Low ≤ X ≤ High`; gen-mode `(+, +, -)` unifies `X` with `Low`. Iterating across the range needs choice-point machinery this scaffold doesn't drive from library dispatches yet.
- **New runtime helpers**: `WamRuntime$term_to_string` (the stateful pretty printer — derefs every node and renders cons-cell chains as native list notation `[a,b,c]`); `WamRuntime$wam_format` (template processor).
- **Codegen fix**: `tokenize_wam_line/2` now filters empty tokens. The single-quoted-atom + comma sequence WAM emits for multi-word `format` templates (`'~w + ~w~n', A1`) used to produce an `""` token after `strip_operand_comma` ate the bare comma, breaking the pattern match in `wam_parts_to_r` and dropping the line through to `Raw`.

## Test plan

- [x] 30/30 plunit tests pass.
- [x] `io_between_e2e_rscript`: 12 yes-cases + 3 no-cases for truth, plus five output-content assertions verifying `write`/`format` produce the expected strings (including pretty-printed list notation, struct rendering, and the literal-tilde escape). Auto-skips when Rscript is not on PATH.
- [x] Manual cross-check: `format("~w + ~w = ~w~n", [2, 3, 5])` → `"2 + 3 = 5"`, `format("list = ~w~n", [[a,b,c]])` → `"list = [a,b,c]"`.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_