### PR TITLE
feat(wam-r): string operations family

### DIFF
--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -177,19 +177,19 @@ wam_line_to_r_literal(Line, Lit) :-
 %  Same single-quote-aware tokenizer as the Scala target.
 tokenize_wam_line(Line, Tokens) :-
     string_chars(Line, Chars),
-    tokenize_wam_chars(Chars, [], [], outside, Tokens0),
-    % Drop empty tokens. These appear when a single-quoted atom is
-    % followed by a `,` separator; strip_operand_comma turns the bare
-    % comma into "" which would otherwise confuse pattern-matching in
-    % wam_parts_to_r.
-    exclude(=(""), Tokens0, Tokens).
+    tokenize_wam_chars(Chars, [], [], outside, Tokens).
 
 tokenize_wam_chars([], [], Acc, _, Tokens) :- !,
     reverse(Acc, Tokens).
 tokenize_wam_chars([], CurR, Acc, outside, Tokens) :- !,
     reverse(CurR, CurC), string_chars(T0, CurC),
     strip_operand_comma(T0, T),
-    reverse([T|Acc], Tokens).
+    % Bare comma at end-of-input: skip rather than emit "". Quoted-empty
+    % atoms come through the inside-mode branch below and are kept.
+    (   T == ""
+    ->  reverse(Acc, Tokens)
+    ;   reverse([T|Acc], Tokens)
+    ).
 tokenize_wam_chars([], CurR, Acc, inside, Tokens) :- !,
     reverse(CurR, CurC), string_chars(T, CurC),
     reverse([T|Acc], Tokens).
@@ -199,7 +199,11 @@ tokenize_wam_chars([C|Rest], CurR, Acc, outside, Tokens) :-
         ->  tokenize_wam_chars(Rest, [], Acc, outside, Tokens)
         ;   reverse(CurR, CurC), string_chars(T0, CurC),
             strip_operand_comma(T0, T),
-            tokenize_wam_chars(Rest, [], [T|Acc], outside, Tokens)
+            (   T == ""
+            ->  NewAcc = Acc
+            ;   NewAcc = [T|Acc]
+            ),
+            tokenize_wam_chars(Rest, [], NewAcc, outside, Tokens)
         )
     ;   C == '\''
     ->  (   CurR == []

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -1690,8 +1690,10 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     return(WamRuntime$call_goal(program, state, WamRuntime$get_reg(state, 1L)))
   }
 
-  # ----- atom_codes/2: atom <-> list of code points -----
-  if (key == "atom_codes/2") {
+  # ----- atom_codes/2 (also string_codes/2): atom <-> list of code points -----
+  # Strings and atoms are not distinguished at the WAM-text level, so
+  # the string_* family aliases onto its atom_* counterpart.
+  if (key == "atom_codes/2" || key == "string_codes/2") {
     raw_a <- WamRuntime$get_reg(state, 1L)
     raw_c <- WamRuntime$get_reg(state, 2L)
     a_v <- WamRuntime$deref(state, raw_a)
@@ -1718,13 +1720,13 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     return(WamRuntime$unify(state, raw_a, Atom(new_id)))
   }
 
-  # ----- atom_chars/2: atom <-> list of single-char atoms -----
+  # ----- atom_chars/2 (also string_chars/2): atom <-> list of single-char atoms -----
   # Char-list elements are accepted as atoms or as ints/floats with
   # their decimal name. The leniency exists because WAM-text loses the
   # atom-vs-number quoting distinction: the literal `'1'` and the
   # integer `1` both serialise as `set_constant 1`, so the codegen
   # can't tell them apart and emits IntTerm for both.
-  if (key == "atom_chars/2") {
+  if (key == "atom_chars/2" || key == "string_chars/2") {
     raw_a <- WamRuntime$get_reg(state, 1L)
     raw_l <- WamRuntime$get_reg(state, 2L)
     a_v <- WamRuntime$deref(state, raw_a)
@@ -1747,17 +1749,17 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     return(WamRuntime$unify(state, raw_a, Atom(new_id)))
   }
 
-  # ----- atom_length/2 -----
+  # ----- atom_length/2 (also string_length/2) -----
   # Same atom-or-numeric leniency as atom_chars (see note above).
-  if (key == "atom_length/2") {
+  if (key == "atom_length/2" || key == "string_length/2") {
     a_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
     s <- wam_term_name_string(a_v, table)
     if (is.null(s)) return(FALSE)
     return(WamRuntime$unify(state, WamRuntime$get_reg(state, 2L), IntTerm(nchar(s))))
   }
 
-  # ----- atom_concat/3 (deterministic mode: A and B both bound) -----
-  if (key == "atom_concat/3") {
+  # ----- atom_concat/3 (also string_concat/3, deterministic mode) -----
+  if (key == "atom_concat/3" || key == "string_concat/3") {
     a_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
     b_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 2L))
     sa <- wam_term_name_string(a_v, table)
@@ -1864,6 +1866,88 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     if (is.null(n_v) || is.null(n_v$tag) || !(n_v$tag %in% c("int", "float"))) return(FALSE)
     new_id <- WamRuntime$intern(table, as.character(n_v$val))
     return(WamRuntime$unify(state, raw_a, Atom(new_id)))
+  }
+
+  # ----- atom_string/2 and string_to_atom/2 -----
+  # Bidirectional atom <-> string conversion. Since this scaffold
+  # collapses strings into atoms (the WAM-text serialisation doesn't
+  # distinguish them), both predicates reduce to a unification of
+  # whichever side is bound with the other side as an atom of the
+  # same name string.
+  if (key == "atom_string/2" || key == "string_to_atom/2") {
+    # atom_string(?Atom, ?String); string_to_atom(?String, ?Atom).
+    if (key == "atom_string/2") {
+      atom_reg <- 1L; str_reg <- 2L
+    } else {
+      atom_reg <- 2L; str_reg <- 1L
+    }
+    a_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, atom_reg))
+    s_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, str_reg))
+    if (!is.null(a_v) && !is.null(a_v$tag) && a_v$tag != "unbound") {
+      s <- wam_term_name_string(a_v, table)
+      if (is.null(s)) return(FALSE)
+      return(WamRuntime$unify(state, WamRuntime$get_reg(state, str_reg),
+                              Atom(WamRuntime$intern(table, s))))
+    }
+    if (!is.null(s_v) && !is.null(s_v$tag) && s_v$tag != "unbound") {
+      s <- wam_term_name_string(s_v, table)
+      if (is.null(s)) return(FALSE)
+      return(WamRuntime$unify(state, WamRuntime$get_reg(state, atom_reg),
+                              Atom(WamRuntime$intern(table, s))))
+    }
+    return(FALSE)
+  }
+
+  # ----- string_upper/2 and string_lower/2 -----
+  # Case conversion. The first arg must be bound (atom or numeric);
+  # the result is interned as an Atom with the case-converted name.
+  if (key == "string_upper/2" || key == "string_lower/2") {
+    in_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+    s <- wam_term_name_string(in_v, table)
+    if (is.null(s)) return(FALSE)
+    converted <- if (key == "string_upper/2") toupper(s) else tolower(s)
+    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 2L),
+                            Atom(WamRuntime$intern(table, converted))))
+  }
+
+  # ----- string_code/3: 1-based code at index -----
+  # string_code(+Index, +String, ?Code).
+  if (key == "string_code/3") {
+    n_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+    s_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 2L))
+    if (is.null(n_v) || is.null(n_v$tag) || n_v$tag != "int") return(FALSE)
+    s <- wam_term_name_string(s_v, table)
+    if (is.null(s)) return(FALSE)
+    i <- n_v$val
+    if (i < 1L || i > nchar(s)) return(FALSE)
+    code <- utf8ToInt(s)[i]
+    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 3L), IntTerm(code)))
+  }
+
+  # ----- split_string/4 -----
+  # split_string(+String, +Separators, +Pad, -SubStrings).
+  # Each char in Separators is a split delimiter; each char in Pad is
+  # trimmed from both ends of every substring. Returns a list of
+  # atom-strings.
+  if (key == "split_string/4") {
+    s_v   <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+    sep_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 2L))
+    pad_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 3L))
+    s   <- wam_term_name_string(s_v,   table)
+    sep <- wam_term_name_string(sep_v, table)
+    pad <- wam_term_name_string(pad_v, table)
+    if (is.null(s) || is.null(sep) || is.null(pad)) return(FALSE)
+    parts <- if (nchar(sep) == 0L) list(s)
+             else strsplit(s, paste0("[", gsub("([\\^\\\\\\]\\-])", "\\\\\\1", sep), "]"),
+                           perl = TRUE)[[1]]
+    if (nchar(pad) > 0L) {
+      pad_re <- paste0("[", gsub("([\\^\\\\\\]\\-])", "\\\\\\1", pad), "]")
+      parts <- gsub(paste0("^", pad_re, "+|", pad_re, "+$"), "", parts, perl = TRUE)
+    }
+    elems <- lapply(as.character(parts), function(p)
+      Atom(WamRuntime$intern(table, p)))
+    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 4L),
+                            WamRuntime$wam_list_build(elems, table)))
   }
 
   # ----- msort/2: sort, keep duplicates -----

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -1195,6 +1195,72 @@ e2e_io_between_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for the string family (string_concat,
+% string_length, atom_string, string_to_atom, string_chars,
+% string_codes, string_upper, string_lower, string_code,
+% split_string). The codegen collapses strings into atoms (the
+% WAM-text serialisation doesn't distinguish them), so the string_*
+% predicates either alias onto their atom_* counterpart or are
+% implemented fresh.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(string_ops_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_string_ops_via_rscript
+    ;   true
+    )).
+
+e2e_string_ops_via_rscript :-
+    assertz((user:str_concat   :- string_concat("foo", "bar", "foobar"))),
+    assertz((user:str_concat_n :- string_concat("foo", "bar", "fooXbar"))),
+    assertz((user:str_length   :- string_length("hello", 5))),
+    assertz((user:str_length_n :- string_length("hello", 4))),
+    assertz((user:str_atom     :- atom_string(hello, "hello"))),
+    assertz((user:str_to_atom  :- string_to_atom("hello", hello))),
+    assertz((user:str_chars    :- string_chars("hi", [h, i]))),
+    assertz((user:str_codes    :- string_codes("AB", [65, 66]))),
+    assertz((user:str_upper    :- string_upper("abc", "ABC"))),
+    assertz((user:str_lower    :- string_lower("ABC", "abc"))),
+    assertz((user:str_code     :- string_code(2, "abc", 98))),
+    assertz((user:str_code_n   :- string_code(2, "abc", 99))),
+    assertz((user:str_code_oob :- string_code(99, "abc", _))),
+    assertz((user:str_split    :- split_string("a,b,c", ",", "", ["a", "b", "c"]))),
+    assertz((user:str_split_p  :- split_string(" a , b , c ", ",", " ", ["a", "b", "c"]))),
+    assertz((user:str_split_e  :- split_string("abc", "", "", ["abc"]))),
+    unique_r_tmp_dir('tmp_r_strops_e2e', TmpDir),
+    write_wam_r_project(
+        [ user:str_concat/0, user:str_concat_n/0,
+          user:str_length/0, user:str_length_n/0,
+          user:str_atom/0, user:str_to_atom/0,
+          user:str_chars/0, user:str_codes/0,
+          user:str_upper/0, user:str_lower/0,
+          user:str_code/0, user:str_code_n/0, user:str_code_oob/0,
+          user:str_split/0, user:str_split_p/0, user:str_split_e/0 ],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [str_concat, str_length,
+           str_atom, str_to_atom,
+           str_chars, str_codes,
+           str_upper, str_lower,
+           str_code,
+           str_split, str_split_p, str_split_e],
+    No  = [str_concat_n, str_length_n,
+           str_code_n, str_code_oob],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
Adds the `string_*` family of standard-library predicates. Since the
WAM-text serialisation doesn't distinguish atoms from strings (both
come through as `set_constant 'atom-or-string'`), the scaffold
collapses strings into atoms: `string_*` predicates whose semantics
match an `atom_*` counterpart alias onto the existing handler; the
rest are implemented fresh.

## Summary

Aliased onto existing `atom_*` arms (`call_library`):
- `string_concat/3` → `atom_concat/3`
- `string_length/2` → `atom_length/2`
- `string_chars/2` → `atom_chars/2`
- `string_codes/2` → `atom_codes/2`

New (`call_library`):
- `atom_string/2`, `string_to_atom/2` — bidirectional, just unify under the shared representation
- `string_upper/2`, `string_lower/2` — via R's `toupper` / `tolower`
- `string_code/3` — 1-based code-at-index
- `split_string/4` — `(+S, +Seps, +Pad, -Parts)` with character-class regex (special chars escaped)

Codegen fix: tokenizer now drops bare-comma artefacts (`,` reduced by `strip_operand_comma` to `""`) at the source instead of via a global empty-token filter. The previous global filter also ate legitimate quoted-empty atoms (`set_constant '', An`), which broke `split_string` with an empty `Pad` argument.

## Test plan

- [x] 31/31 plunit tests pass.
- [x] `string_ops_e2e_rscript`: 12 yes-cases + 4 no-cases covering all new and aliased predicates, including `split_string` with both empty and non-empty `Pad` sets and `string_code`'s out-of-range handling. Auto-skips when Rscript is not on PATH.
- [x] Manual sweep across 11 string predicates (concat, length, atom↔string, chars/codes, upper/lower, code, three split variants) all produce expected truth values.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_