### PR TITLE
feat(wam-r): bagof/3, setof/3, once/1, forall/2

### DIFF
--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -1405,6 +1405,68 @@ WamRuntime$dispatch_call <- function(program, state, pred, arity) {
   isTRUE(WamRuntime$call_builtin(program, state, key, arity))
 }
 
+# Collect all solutions of a goal, returning their copy_term'd
+# template values as an R list. Used by bagof/3, setof/3, and forall/2
+# (when implemented as a "no Action failures" check). Restores state
+# completely on return -- bindings produced by the goal don't leak to
+# the caller.
+#
+# The iteration drives the run loop manually:
+#   1. call_goal dispatches the goal once.
+#   2. After each success, copy_term the template and snapshot it.
+#   3. Trigger backtrack to find the next goal solution; if backtrack
+#      pops past the snapshot's cps_len, the goal has exhausted its
+#      choice points and we stop.
+#   4. Re-enter the run loop with state$halt = FALSE so the alt body
+#      can execute. Loop until the goal stops succeeding.
+WamRuntime$collect_solutions <- function(program, state, template_term, goal_term) {
+  snap_cps_len   <- length(state$cps)
+  snap_regs      <- as.list.environment(state$regs2)
+  snap_trail     <- length(state$trail)
+  snap_pc        <- state$pc
+  snap_cp        <- state$cp
+  snap_halt      <- state$halt
+  snap_vc        <- state$var_counter
+  snap_mode      <- state$mode
+  snap_build     <- state$build_stack
+
+  collected <- list()
+  ok <- WamRuntime$call_goal(program, state, goal_term)
+  while (isTRUE(ok)) {
+    v <- WamRuntime$deref(state, template_term)
+    collected <- c(collected, list(WamRuntime$copy_term(state, v)))
+    if (length(state$cps) <= snap_cps_len) break
+    if (!WamRuntime$backtrack(state)) break
+    state$halt <- FALSE
+    ok <- WamRuntime$run(program, state)
+  }
+
+  # Restore: pop any extra CPs and roll back regs / trail / state.
+  if (length(state$cps) > snap_cps_len) {
+    state$cps <- state$cps[seq_len(snap_cps_len)]
+  }
+  e <- new.env(parent = emptyenv(), hash = TRUE)
+  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
+  state$regs2 <- e
+  if (length(state$trail) > snap_trail) {
+    to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
+    for (name in to_undo) {
+      if (exists(name, envir = state$bindings, inherits = FALSE)) {
+        rm(list = name, envir = state$bindings)
+      }
+    }
+    state$trail <- state$trail[seq_len(snap_trail)]
+  }
+  state$pc          <- snap_pc
+  state$cp          <- snap_cp
+  state$halt        <- snap_halt
+  state$var_counter <- snap_vc
+  state$mode        <- snap_mode
+  state$build_stack <- snap_build
+
+  collected
+}
+
 WamRuntime$call_builtin <- function(program, state, pred, arity) {
   table <- program$intern_table
   # Pred uses the with-/N convention here (matches BuiltinCall instr$pred).
@@ -1859,6 +1921,115 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
       return(x_v$val >= lo && x_v$val <= hi)
     }
     return(WamRuntime$unify(state, WamRuntime$get_reg(state, 3L), IntTerm(lo)))
+  }
+
+  # ----- bagof/3: like findall but fails on empty bag -----
+  # Note: this scaffold does NOT support free-variable witnesses.
+  # bagof(T, G, B) here is equivalent to findall(T, G, B) with the
+  # extra rule "fail if no solutions". Common idiom: existentially
+  # quantify any non-template variables with `^/2` (e.g.
+  # bagof(X, Y^p(X,Y), L)). Without `^`, witness variables are
+  # silently aggregated rather than producing one bag per witness.
+  if (key == "bagof/3") {
+    template <- WamRuntime$get_reg(state, 1L)
+    goal     <- WamRuntime$get_reg(state, 2L)
+    collected <- WamRuntime$collect_solutions(program, state, template, goal)
+    if (length(collected) == 0L) return(FALSE)
+    bag <- WamRuntime$wam_list_build(collected, table)
+    cur <- WamRuntime$get_reg(state, 3L)
+    if (is.null(cur)) {
+      WamRuntime$put_reg(state, 3L, bag)
+      return(TRUE)
+    }
+    return(WamRuntime$unify(state, cur, bag))
+  }
+
+  # ----- setof/3: bagof + sort + dedup (standard order of terms) -----
+  if (key == "setof/3") {
+    template <- WamRuntime$get_reg(state, 1L)
+    goal     <- WamRuntime$get_reg(state, 2L)
+    collected <- WamRuntime$collect_solutions(program, state, template, goal)
+    if (length(collected) == 0L) return(FALSE)
+    sorted <- WamRuntime$wam_sort_terms(state, collected, table)
+    deduped <- list()
+    for (i in seq_along(sorted)) {
+      if (i == 1L ||
+          WamRuntime$compare_terms(state, sorted[[i - 1L]], sorted[[i]], table) != 0L) {
+        deduped <- c(deduped, list(sorted[[i]]))
+      }
+    }
+    bag <- WamRuntime$wam_list_build(deduped, table)
+    cur <- WamRuntime$get_reg(state, 3L)
+    if (is.null(cur)) {
+      WamRuntime$put_reg(state, 3L, bag)
+      return(TRUE)
+    }
+    return(WamRuntime$unify(state, cur, bag))
+  }
+
+  # ----- once/1: run goal, commit to first solution -----
+  # Drops any choice points the goal pushed, so backtracking outside
+  # once/1 won't re-enter the goal body.
+  if (key == "once/1") {
+    cps_before <- length(state$cps)
+    ok <- WamRuntime$call_goal(program, state, WamRuntime$get_reg(state, 1L))
+    if (!isTRUE(ok)) return(FALSE)
+    if (length(state$cps) > cps_before) {
+      state$cps <- state$cps[seq_len(cps_before)]
+    }
+    return(TRUE)
+  }
+
+  # ----- forall/2: forall(Cond, Action) succeeds iff Action succeeds
+  # for every Cond binding -----
+  # Implemented by enumerating Cond and checking Action at each step.
+  # State is fully restored at the end (forall doesn't bind anything
+  # through to the surrounding query).
+  if (key == "forall/2") {
+    cond   <- WamRuntime$get_reg(state, 1L)
+    action <- WamRuntime$get_reg(state, 2L)
+    snap_cps_len <- length(state$cps)
+    snap_regs    <- as.list.environment(state$regs2)
+    snap_trail   <- length(state$trail)
+    snap_pc      <- state$pc
+    snap_cp      <- state$cp
+    snap_halt    <- state$halt
+    snap_vc      <- state$var_counter
+    snap_mode    <- state$mode
+    snap_build   <- state$build_stack
+    ok <- WamRuntime$call_goal(program, state, cond)
+    result <- TRUE
+    while (isTRUE(ok)) {
+      action_ok <- WamRuntime$call_goal(program, state, action)
+      if (!isTRUE(action_ok)) { result <- FALSE; break }
+      if (length(state$cps) <= snap_cps_len) break
+      if (!WamRuntime$backtrack(state)) break
+      state$halt <- FALSE
+      ok <- WamRuntime$run(program, state)
+    }
+    # Restore (forall does not produce bindings on success).
+    if (length(state$cps) > snap_cps_len) {
+      state$cps <- state$cps[seq_len(snap_cps_len)]
+    }
+    e <- new.env(parent = emptyenv(), hash = TRUE)
+    for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
+    state$regs2 <- e
+    if (length(state$trail) > snap_trail) {
+      to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
+      for (name in to_undo) {
+        if (exists(name, envir = state$bindings, inherits = FALSE)) {
+          rm(list = name, envir = state$bindings)
+        }
+      }
+      state$trail <- state$trail[seq_len(snap_trail)]
+    }
+    state$pc          <- snap_pc
+    state$cp          <- snap_cp
+    state$halt        <- snap_halt
+    state$var_counter <- snap_vc
+    state$mode        <- snap_mode
+    state$build_stack <- snap_build
+    return(result)
   }
 
   # ----- I/O: writeln/1, print/1, format/1, format/2 -----

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -1389,6 +1389,75 @@ e2e_findall_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for bagof/3, setof/3, once/1, forall/2.
+% These build on the multi-solution machinery and require the goal
+% argument to push choice points for enumeration; that means a
+% multi-clause user predicate or dynamic-store predicate. Builtin
+% goals like member/2 currently dispatch deterministically (first-
+% match only) and are NOT enumerable from these aggregators -- a
+% separate follow-up that adds CPs to those builtins is needed.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(bagof_setof_once_forall_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_bagof_setof_once_forall_via_rscript
+    ;   true
+    )).
+
+e2e_bagof_setof_once_forall_via_rscript :-
+    % Multi-clause sources for enumeration.
+    assertz(user:bso_letter(a)),
+    assertz(user:bso_letter(b)),
+    assertz(user:bso_letter(c)),
+    assertz(user:bso_num(3)),
+    assertz(user:bso_num(1)),
+    assertz(user:bso_num(2)),
+    assertz(user:bso_num(1)),
+    % bagof/3: same as findall but fails on empty.
+    assertz((user:bg_basic    :- bagof(X, user:bso_letter(X), L), L == [a, b, c])),
+    assertz((user:bg_empty_no :- bagof(X, user:nope(X), _))),
+    % setof/3: bag + sort + dedup.
+    assertz((user:so_basic    :- setof(X, user:bso_num(X), L), L == [1, 2, 3])),
+    assertz((user:so_atoms    :- setof(X, user:bso_letter(X), L), L == [a, b, c])),
+    assertz((user:so_empty_no :- setof(X, user:nope(X), _))),
+    % once/1: commits to first solution; outer backtracking can't
+    % re-enter the goal.
+    assertz((user:on_basic    :- once(user:bso_letter(X)), X == a)),
+    assertz((user:on_inner_no :- once(user:nope(_)))),
+    % forall/2 over a user predicate. fa_pos and fa_atom both succeed
+    % because every element of the source matches Action.
+    assertz((user:fa_atom     :- forall(user:bso_letter(X), atom(X)))),
+    assertz((user:fa_atom_no  :- forall(user:bso_letter(X), integer(X)))),
+    unique_r_tmp_dir('tmp_r_bso_e2e', TmpDir),
+    write_wam_r_project(
+        [ user:bso_letter/1, user:bso_num/1,
+          user:bg_basic/0, user:bg_empty_no/0,
+          user:so_basic/0, user:so_atoms/0, user:so_empty_no/0,
+          user:on_basic/0, user:on_inner_no/0,
+          user:fa_atom/0, user:fa_atom_no/0 ],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [bg_basic, so_basic, so_atoms,
+           on_basic,
+           fa_atom],
+    No  = [bg_empty_no, so_empty_no,
+           on_inner_no,
+           fa_atom_no],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
Completes the aggregation/control family on top of the multi-solution
machinery introduced with `findall/3` (#1886).

## Summary

New runtime helper:
- `WamRuntime$collect_solutions(program, state, template, goal)` — drives the goal repeatedly via `call_goal` → `backtrack` → `run`, collecting `copy_term`'d template values. Restores state fully on return.

New library predicates (`call_library`):
- **`bagof/3`** — findall semantics + fail-on-empty. Free-variable witness preservation is not implemented; the common idiom of explicit `^/2` quantification is supported transparently since `collect_solutions` sees the same bag `findall` would.
- **`setof/3`** — `bagof` + sort + dedup via the existing `compare_terms` / `wam_sort_terms` helpers.
- **`once/1`** — runs the goal, returns its truth, then drops any choice points the goal pushed (commit-to-first-solution).
- **`forall/2`** — `forall(Cond, Action)` iterates `Cond` solutions and checks `Action` at each. Fully restores state on exit.

## Scope and limitations

All four aggregators rely on the goal pushing choice points for enumeration. **Multi-clause user predicates** and **dynamic-store predicates** work; deterministic builtins like `member/2`, `between/3`, and `append/3` are not yet enumerable from these aggregators (this pre-existing limitation also affects `findall/3`). A follow-up that adds CP-pushing variants to those builtins is needed to unlock the full standard usage; this PR keeps the test surface tightly scoped to what works correctly.

## Test plan

- [x] 34/34 plunit tests pass.
- [x] `bagof_setof_once_forall_e2e_rscript`: 5 yes-cases + 4 no-cases using multi-clause user predicates as the iteration source. Exercises bag-on-empty failure, sort+dedup, commit-to-first, and universal quantification with both passing and failing Action. Auto-skips when Rscript is not on PATH.
- [x] Manual cross-check across nine scenarios all match SWI-Prolog semantics.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_