### PR TITLE
fix: make Python recursive pattern detection deterministic

### DIFF
--- a/src/unifyweaver/targets/python_target.pl
+++ b/src/unifyweaver/targets/python_target.pl
@@ -6417,9 +6417,11 @@ extract_recursive_pattern(Body, Name, Pattern) :-
     (   Exprs \= [],
         last(Exprs, RecExpr),
         functor(RecExpr, Op, 2),
-        member(Op, ['*', '+', '-', '/'])
-    ->  member(RecCall, Goals),
-        functor(RecCall, Name, _),
+        memberchk(Op, ['*', '+', '-', '/'])
+    ->  once((
+            member(RecCall, Goals),
+            functor(RecCall, Name, _)
+        )),
         Pattern = arithmetic(RecExpr, RecCall)
     ;   Pattern = unknown
     ).

--- a/tests/core/test_python_native_lowering.pl
+++ b/tests/core/test_python_native_lowering.pl
@@ -127,7 +127,8 @@ test(guard_with_computation) :-
 test(fallback_for_recursive) :-
     assert(user:factorial(0, 1)),
     assert(user:(factorial(N, F) :- N > 0, N1 is N - 1, factorial(N1, F1), F is N * F1)),
-    compile_py(factorial/2, Code),
+    call_cleanup(compile_py(factorial/2, Code), Deterministic = true),
+    assertion(Deterministic == true),
     % Recursive predicates go through compile_recursive_predicate
     % so native lowering doesn't apply — should not produce def factorial(arg1)
     \+ once(sub_string(Code, _, _, _, "def factorial(arg1)")),


### PR DESCRIPTION
# Fix Python recursive pattern detection choicepoint

## Summary

- Make Python recursive arithmetic pattern detection deterministic instead of leaving a residual Prolog choicepoint.
- Use `memberchk/2` for operator matching and `once/1` for selecting the intended recursive call.
- Add a regression assertion to the Python native lowering fallback test so the recursive compile path must remain deterministic.

## Verification

- `swipl -q -g "['tests/core/test_python_native_lowering.pl'], test_python_native_lowering:test_python_native_lowering, halt"`
- `swipl -q -g "['tests/core/test_lua_native_lowering.pl'], test_lua_native_lowering:test_lua_native_lowering, halt"`
- `swipl -q -g "['tests/core/test_jvm_asm_native_lowering.pl'], test_jvm_asm_native_lowering:test_jvm_asm_native_lowering, halt"`
- `swipl -q -g "['src/unifyweaver/core/advanced/test_regressions.pl'], test_regressions:test_regressions, halt"`
- `git diff --check`

## Notes

- This fixes the warning source directly; it does not suppress the test warning.
- The branch is clean at `f89d27e0`.
