### PR TITLE
feat(wam-r): catch/3, throw/1, and runtime aggregators over dynamic preds

### DIFF
--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -1577,10 +1577,60 @@ WamRuntime$iterate_goal <- function(program, state, goal_term, on_each) {
     return(invisible(NULL))
   }
 
+  # Dynamic-store predicate: enumerate clauses at the R level. The
+  # default fallback would push dynamic CPs whose resume_pc points
+  # past the surrounding library dispatch (no good in this context).
+  # Detection: deref the goal struct, look up its key in the dynamic
+  # env. Module qualification (M:G) is unwrapped first.
+  goal_v <- v
+  if (goal_v$tag == "struct" && length(goal_v$args) == 2L &&
+      identical(WamRuntime$string_of(table, goal_v$fid), ":")) {
+    goal_v <- WamRuntime$deref(state, goal_v$args[[2]])
+  }
+  if (!is.null(goal_v) && !is.null(goal_v$tag) && !is.null(program$dynamic)) {
+    if (goal_v$tag == "atom") {
+      dyn_pred <- WamRuntime$string_of(table, goal_v$id); dyn_arity <- 0L
+    } else if (goal_v$tag == "struct") {
+      dyn_pred <- WamRuntime$string_of(table, goal_v$fid); dyn_arity <- length(goal_v$args)
+    } else {
+      dyn_pred <- NULL
+    }
+    if (!is.null(dyn_pred)) {
+      dyn_key <- paste0(dyn_pred, "/", dyn_arity)
+      if (exists(dyn_key, envir = program$dynamic, inherits = FALSE)) {
+        clauses <- get(dyn_key, envir = program$dynamic, inherits = FALSE)
+        head_args <- if (goal_v$tag == "struct") goal_v$args else list()
+        for (clause in clauses) {
+          if (length(clause$head_args) != dyn_arity) next
+          snap_t <- length(state$trail)
+          fresh  <- WamRuntime$copy_term_clause(state, clause)
+          ok <- TRUE
+          if (dyn_arity > 0L) {
+            for (i in seq_len(dyn_arity)) {
+              if (!WamRuntime$unify(state, head_args[[i]], fresh$head_args[[i]])) {
+                ok <- FALSE; break
+              }
+            }
+          }
+          if (ok && !is.null(fresh$body)) {
+            ok <- isTRUE(WamRuntime$call_goal(program, state, fresh$body))
+          }
+          if (ok) {
+            cont <- on_each()
+            WamRuntime$undo_trail_to(state, snap_t)
+            if (!isTRUE(cont)) return(invisible(NULL))
+          } else {
+            WamRuntime$undo_trail_to(state, snap_t)
+          }
+        }
+        return(invisible(NULL))
+      }
+    }
+  }
+
   # Default: call_goal-driven iteration. Works for multi-clause user
-  # predicates (try_me_else CPs) and dynamic-store predicates (dynamic
-  # CPs). After backtrack, run() drives the alt clause body until it
-  # proceeds back through the call boundary.
+  # predicates (try_me_else CPs). After backtrack, run() drives the
+  # alt clause body until it proceeds back through the call boundary.
   snap_cps_len <- length(state$cps)
   ok <- WamRuntime$call_goal(program, state, goal_term)
   while (isTRUE(ok)) {
@@ -2201,6 +2251,50 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     return(result)
   }
 
+  # ----- throw/1 and catch/3: exception handling -----
+  # throw/1 raises an R condition whose `error_term` field carries a
+  # copy_term'd snapshot of the thrown Prolog term (so the thrown term
+  # is independent of post-throw bindings). catch/3 wraps call_goal in
+  # an R tryCatch and, on prolog_throw, unifies the thrown term with
+  # the Catcher; if it unifies, the Recovery is run; otherwise the
+  # condition is rethrown for an outer catch to handle. CPs and trail
+  # made by Goal are unwound to the catch's snapshot before Recovery
+  # runs, matching SWI semantics.
+  if (key == "throw/1") {
+    raw <- WamRuntime$get_reg(state, 1L)
+    err_copy <- WamRuntime$copy_term(state, WamRuntime$deref(state, raw))
+    cond <- structure(
+      list(message = "prolog_throw", error_term = err_copy),
+      class = c("prolog_throw", "condition")
+    )
+    stop(cond)
+  }
+  if (key == "catch/3") {
+    goal     <- WamRuntime$get_reg(state, 1L)
+    catcher  <- WamRuntime$get_reg(state, 2L)
+    recovery <- WamRuntime$get_reg(state, 3L)
+    cps_snap   <- length(state$cps)
+    trail_snap <- length(state$trail)
+    handler <- function(cond) {
+      # Restore: drop CPs the goal pushed and unwind the trail, so
+      # the recovery sees the catch's pre-call state.
+      if (length(state$cps) > cps_snap) {
+        state$cps <- state$cps[seq_len(cps_snap)]
+      }
+      WamRuntime$undo_trail_to(state, trail_snap)
+      if (WamRuntime$unify(state, catcher, cond$error_term)) {
+        WamRuntime$call_goal(program, state, recovery)
+      } else {
+        # Rethrow for an outer catch.
+        stop(cond)
+      }
+    }
+    return(isTRUE(tryCatch(
+      WamRuntime$call_goal(program, state, goal),
+      prolog_throw = handler
+    )))
+  }
+
   # ----- I/O: writeln/1, print/1, format/1, format/2 -----
   # writeln/1 == write/1 + newline. print/1 is the same as write/1 in
   # this scaffold (no portray/1 hook). format/N processes the template
@@ -2764,5 +2858,8 @@ WamRuntime$run_predicate <- function(program, start_pc, args) {
   }
   state$pc <- as.integer(start_pc)
   state$cp <- 0L
-  WamRuntime$run(program, state)
+  # Top-level prolog_throw catcher: an uncaught throw becomes a query
+  # failure (matches Prolog top-level "error" handling, scaled down).
+  tryCatch(WamRuntime$run(program, state),
+           prolog_throw = function(cond) FALSE)
 }

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -1543,6 +1543,70 @@ e2e_enumerable_builtins_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for catch/3 + throw/1 (exception handling)
+% and runtime aggregator support for dynamic predicates (the small
+% gap noted in the previous PR).
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(catch_throw_dyn_aggregator_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_catch_throw_dyn_via_rscript
+    ;   true
+    )).
+
+e2e_catch_throw_dyn_via_rscript :-
+    % catch/throw basics.
+    assertz((user:ct_basic     :- catch(throw(boom), boom, true))),
+    % Throw a structured term; recovery sees the unified Catcher var.
+    assertz((user:ct_unify     :- catch(throw(error(my_err, ctx)),
+                                         error(E, _), E == my_err))),
+    % Goal succeeds with no throw -- catch just succeeds, no recovery.
+    assertz((user:ct_no_throw  :- catch(true, _, fail))),
+    % Catcher doesn't unify -> rethrown -> top-level returns FALSE.
+    assertz((user:ct_uncaught  :- catch(throw(boom), other, true))),
+    % Nested catch: outer catches what inner rethrows.
+    assertz((user:ct_nested    :- catch(catch(throw(inner), other, fail),
+                                         inner, true))),
+    % Bare throw without any catch -> top-level returns FALSE.
+    assertz((user:ct_bare_throw :- throw(uncaught))),
+    % Runtime aggregators over dynamic-store predicates.
+    assertz((user:dyn_bg :- assertz(dynbg(a)), assertz(dynbg(b)),
+                            assertz(dynbg(c)),
+                            bagof(X, dynbg(X), L), L == [a, b, c])),
+    assertz((user:dyn_so :- assertz(dynso(c)), assertz(dynso(a)),
+                            assertz(dynso(b)), assertz(dynso(a)),
+                            setof(X, dynso(X), L), L == [a, b, c])),
+    assertz((user:dyn_fa :- assertz(dynfa(1)), assertz(dynfa(2)),
+                            assertz(dynfa(3)),
+                            forall(dynfa(X), integer(X)))),
+    assertz((user:dyn_fa_no :- assertz(dynfan(1)), assertz(dynfan(foo)),
+                                assertz(dynfan(3)),
+                                forall(dynfan(X), integer(X)))),
+    unique_r_tmp_dir('tmp_r_catch_dyn_e2e', TmpDir),
+    write_wam_r_project(
+        [ user:ct_basic/0, user:ct_unify/0, user:ct_no_throw/0,
+          user:ct_uncaught/0, user:ct_nested/0, user:ct_bare_throw/0,
+          user:dyn_bg/0, user:dyn_so/0, user:dyn_fa/0, user:dyn_fa_no/0 ],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [ct_basic, ct_unify, ct_no_throw, ct_nested,
+           dyn_bg, dyn_so, dyn_fa],
+    No  = [ct_uncaught, ct_bare_throw, dyn_fa_no],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
Two complementary additions on top of the multi-solution work.

## 1. Exception handling: `catch/3` and `throw/1`

- **`throw/1`** raises an R condition whose `error_term` field carries a `copy_term`'d snapshot of the thrown term, so handlers see a fresh value independent of post-throw bindings.
- **`catch/3`** wraps `call_goal` in `tryCatch`. On a `prolog_throw` condition it unwinds CPs and the trail to the catch's pre-call snapshot, then unifies the thrown term with `Catcher`; on success it runs `Recovery`, on failure it rethrows for an outer catch to handle.
- `run_predicate` is wrapped in a top-level `tryCatch` so a bare throw with no enclosing catch becomes a clean query failure rather than a fatal R error.

## 2. Runtime aggregators over dynamic-store predicates

`bagof/3`, `setof/3`, and `forall/2` now enumerate clauses in the dynamic store at the R level (in `iterate_goal`), closing the small remaining gap from the previous PR. Module qualification (`M:G`) is unwrapped before the dynamic lookup. The default `call_goal`-based fallback is unchanged for everything else.

## Test plan

- [x] 36/36 plunit tests pass.
- [x] `catch_throw_dyn_aggregator_e2e_rscript`: 7 yes-cases + 3 no-cases covering: basic catch + matching throw, structured-term unify in `Catcher`, no-throw passthrough, uncaught throw → top-level failure, nested catch with rethrow, bare-throw top-level failure, plus `bagof` / `setof` / `forall` over runtime-asserted predicates including the failing-Action case.
- [x] Manual sweep across 8 catch/throw scenarios and 4 dynamic-aggregator scenarios all match SWI-Prolog semantics.

I also confirmed disjunction `(A ; B)` and if-then-else `(Cond -> Then ; Else)` already work via the existing `try_me_else` / `cut_ite` / `jump` machinery — no new work needed.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_