### PR TITLE
feat(wam-clojure): lower callable builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -308,6 +308,10 @@ clojure_direct_builtin("compound/1", "1").
 clojure_direct_builtin("compound/1", 1).
 clojure_direct_builtin('compound/1', "1").
 clojure_direct_builtin('compound/1', 1).
+clojure_direct_builtin("callable/1", "1").
+clojure_direct_builtin("callable/1", 1).
+clojure_direct_builtin('callable/1', "1").
+clojure_direct_builtin('callable/1', 1).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
@@ -341,6 +345,8 @@ clojure_unary_guard_test("var/1", "(or (= value ::lowered-unbound) (runtime/logi
 clojure_unary_guard_test('var/1', "(or (= value ::lowered-unbound) (runtime/logic-var? value))").
 clojure_unary_guard_test("compound/1", "(runtime/structure-term? value)").
 clojure_unary_guard_test('compound/1', "(runtime/structure-term? value)").
+clojure_unary_guard_test("callable/1", "(or (runtime/atom-term? value) (runtime/structure-term? value))").
+clojure_unary_guard_test('callable/1', "(or (runtime/atom-term? value) (runtime/structure-term? value))").
 
 emit_lowered_unary_guard(TestExpr, S, Expr) :-
     format(atom(Expr),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -854,6 +854,13 @@
               (advance state)
               (backtrack state)))
 
+          "callable/1"
+          (let [value (deref-value (:bindings state)
+                                   (or (reg-get-raw state "A1") ::unbound))]
+            (if (or (atom-term? value) (structure-term? value))
+              (advance state)
+              (backtrack state)))
+
           "!/0"
           (-> state
               (update :choice-points #(vec (take (:cut-bar state) %)))

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -115,6 +115,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, '"nonvar/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"var/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"compound/1"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"callable/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-bindings [state bindings]')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -299,6 +299,30 @@ test(terminal_execute_compound_is_direct_lowered_as_succeeding_builtin) :-
         assertion(\+ has(Code, ":pc target-pc"))
     )).
 
+test(simple_builtin_callable_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_callable/1:\nbuiltin_call callable/1, 1\nproceed\n",
+        wam_clojure_lowerable(test_callable/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_callable/1, WamCode, [], Code),
+        has(Code, "runtime/deref-value"),
+        has(Code, "runtime/atom-term? value"),
+        has(Code, "runtime/structure-term? value"),
+        has(Code, "runtime/advance"),
+        has(Code, "runtime/backtrack")
+    )).
+
+test(terminal_execute_callable_is_direct_lowered_as_succeeding_builtin) :-
+    once((
+        WamCode = "test_execute_callable/1:\nallocate\ndeallocate\nexecute callable/1\n",
+        wam_clojure_lowerable(test_execute_callable/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_execute_callable/1, WamCode, [], Code),
+        has(Code, "runtime/atom-term? value"),
+        has(Code, "runtime/structure-term? value"),
+        has(Code, "runtime/succeed-state next-state"),
+        assertion(\+ has(Code, "\"callable/1\"")),
+        assertion(\+ has(Code, ":pc target-pc"))
+    )).
+
 test(env_framed_equality_reaches_direct_builtin_prefix) :-
     once((
         WamCode = "test_env_eq/2:\nallocate\nput_value X1, A1\nput_value X2, A2\nbuiltin_call =/2, 2\ndeallocate\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -49,6 +49,8 @@
 :- dynamic user:wam_var_unbound/1.
 :- dynamic user:wam_compound_guard/1.
 :- dynamic user:wam_compound_unbound/1.
+:- dynamic user:wam_callable_guard/1.
+:- dynamic user:wam_callable_unbound/1.
 
 has(Code, Substr) :-
     once(sub_string(Code, _, _, _, Substr)).
@@ -100,6 +102,8 @@ user:wam_var_guard(X) :- var(X).
 user:wam_var_unbound(_) :- user:wam_unbound_arg(Y), var(Y).
 user:wam_compound_guard(X) :- compound(X).
 user:wam_compound_unbound(_) :- user:wam_unbound_arg(Y), compound(Y).
+user:wam_callable_guard(X) :- callable(X).
+user:wam_callable_unbound(_) :- user:wam_unbound_arg(Y), callable(Y).
 
 :- initialization(main, main).
 
@@ -155,7 +159,9 @@ run_smoke :-
           user:wam_var_guard/1,
           user:wam_var_unbound/1,
           user:wam_compound_guard/1,
-          user:wam_compound_unbound/1
+          user:wam_compound_unbound/1,
+          user:wam_callable_guard/1,
+          user:wam_callable_unbound/1
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
@@ -181,6 +187,7 @@ run_smoke :-
     assert_lowered_nonvar_builtin_emitted(TmpDir),
     assert_lowered_var_builtin_emitted(TmpDir),
     assert_lowered_compound_builtin_emitted(TmpDir),
+    assert_lowered_callable_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
@@ -260,6 +267,11 @@ run_smoke :-
     verify_output(TmpDir, 'wam_compound_guard/1', 'f(a)', "true"),
     verify_output(TmpDir, 'wam_compound_guard/1', '[a,b]', "true"),
     verify_output(TmpDir, 'wam_compound_unbound/1', a, "false"),
+    verify_output(TmpDir, 'wam_callable_guard/1', a, "true"),
+    verify_output(TmpDir, 'wam_callable_guard/1', 42, "false"),
+    verify_output(TmpDir, 'wam_callable_guard/1', 'f(a)', "true"),
+    verify_output(TmpDir, 'wam_callable_guard/1', '[a,b]', "true"),
+    verify_output(TmpDir, 'wam_callable_unbound/1', a, "false"),
     delete_directory_and_contents(TmpDir),
     writeln('wam_clojure_runtime_smoke: ok').
 
@@ -366,6 +378,14 @@ assert_lowered_compound_builtin_emitted(ProjectDir) :-
     read_file_to_string(CorePath, CoreCode, []),
     has(CoreCode, "defn lowered-wam-compound-guard-1"),
     has(CoreCode, "defn lowered-wam-compound-unbound-1"),
+    has(CoreCode, "runtime/structure-term? value").
+
+assert_lowered_callable_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-callable-guard-1"),
+    has(CoreCode, "defn lowered-wam-callable-unbound-1"),
+    has(CoreCode, "runtime/atom-term? value"),
     has(CoreCode, "runtime/structure-term? value").
 
 assert_multiclause_wrappers_runtime_mediated(ProjectDir) :-


### PR DESCRIPTION
## Summary

- Adds Clojure WAM runtime support for `builtin_call callable/1`.
- Adds direct lowered-prefix support for deterministic `callable/1` builtin calls through the centralized unary guard table.
- Reuses terminal direct-builtin lowering for compiler-emitted `execute callable/1`.
- Treats normalized atom terms and normalized structure/list terms as callable values.
- Adds generator, lowered-emitter, and runtime smoke coverage for atom, number, structure, list, and unbound cases.

## Why

`callable/1` is a natural follow-up to the unary guard refactor. It is a pure dereference check and fits the existing Clojure runtime representation: atoms and compound terms are callable, while numbers and unbound variables are not.

This keeps simple callable guard predicates on the Clojure lowered path without adding new binding behavior or changing WAM-visible semantics.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
