### PR TITLE
fix: make recursion compiler progress opt-in

### DIFF
--- a/src/unifyweaver/core/advanced/direct_multi_call_recursion.pl
+++ b/src/unifyweaver/core/advanced/direct_multi_call_recursion.pl
@@ -16,6 +16,7 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(library(debug)).
 :- use_module('pattern_matchers').
 
 %% compile_direct_multicall_pattern/5 is multifile - targets register their own clauses.
@@ -76,7 +77,7 @@ compile_direct_binary_recursion(Pred, Options, Code) :-
     (   member(target(Target), Options) -> true
     ;   Target = bash
     ),
-    format('  Target: ~w~n', [Target]),
+    debug(recursion_compile, 'Target: ~w', [Target]),
 
     % Get clauses
     functor(Head, Pred, 2),

--- a/src/unifyweaver/core/advanced/linear_recursion.pl
+++ b/src/unifyweaver/core/advanced/linear_recursion.pl
@@ -24,6 +24,7 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(library(debug)).
 :- use_module('../template_system').
 :- use_module('../constraint_analyzer').
 :- use_module('pattern_matchers').
@@ -47,25 +48,25 @@ can_compile_linear_recursion(Pred/Arity) :-
 %  - ordered(true): Use hash-based memoization (faster lookup, preserves order)
 %  - ordered(false): Use standard memoization (default)
 compile_linear_recursion(Pred/Arity, Options, Code) :-
-    format('  Compiling linear recursion: ~w/~w~n', [Pred, Arity]),
+    debug(recursion_compile, 'Compiling linear recursion: ~w/~w', [Pred, Arity]),
 
     % Query constraints
     get_constraints(Pred/Arity, Constraints),
-    format('  Constraints: ~w~n', [Constraints]),
+    debug(recursion_compile, 'Constraints: ~w', [Constraints]),
 
     % Merge runtime options with constraints for diagnostics/template hooks.
     % Explicit caller options take precedence when we read an option below.
     append(Options, Constraints, AllOptions),
-    format('  Final options: ~w~n', [AllOptions]),
+    debug(recursion_compile, 'Final options: ~w', [AllOptions]),
 
     % Determine memoization strategy based on constraints and options
     (   option_value(memo, Options, Constraints, MemoValue),
         MemoValue == false ->
-        format('  Applying memo(false): Memo disabled~n', []),
+        debug(recursion_compile, 'Applying memo(false): Memo disabled', []),
         MemoEnabled = false
     ;   option_value(unique, Options, Constraints, UniqueValue),
         UniqueValue == false ->
-        format('  Applying unique(false): Memo disabled~n', []),
+        debug(recursion_compile, 'Applying unique(false): Memo disabled', []),
         MemoEnabled = false
     ;   MemoEnabled = true
     ),
@@ -73,7 +74,7 @@ compile_linear_recursion(Pred/Arity, Options, Code) :-
     % Determine memo lookup strategy
     (   option_value(unordered, Options, Constraints, UnorderedValue),
         UnorderedValue == false ->  % ordered = true
-        format('  Applying ordered constraint: Using hash-based memo~n', []),
+        debug(recursion_compile, 'Applying ordered constraint: Using hash-based memo', []),
         MemoStrategy = hash
     ;   MemoStrategy = standard
     ),
@@ -85,7 +86,7 @@ compile_linear_recursion(Pred/Arity, Options, Code) :-
     (   option_value(target, Options, Constraints, Target) -> true
     ;   Target = bash
     ),
-    format('  Target: ~w~n', [Target]),
+    debug(recursion_compile, 'Target: ~w', [Target]),
 
     % Get clauses - use user:clause to access predicates from any module (including test predicates)
     findall(clause(Head, Body), user:clause(Head, Body), Clauses),

--- a/src/unifyweaver/core/advanced/multicall_linear_recursion.pl
+++ b/src/unifyweaver/core/advanced/multicall_linear_recursion.pl
@@ -16,6 +16,7 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(library(debug)).
 :- use_module('pattern_matchers').
 
 %% compile_multicall_pattern/6 is multifile - targets register their own clauses.
@@ -118,7 +119,7 @@ compile_multicall_linear_recursion(Pred/Arity, Options, Code) :-
     (   member(target(Target), Options) -> true
     ;   Target = bash
     ),
-    format('  Target: ~w~n', [Target]),
+    debug(recursion_compile, 'Target: ~w', [Target]),
 
     % Generate code - delegate to multifile
     (   compile_multicall_pattern(Target, PredStr, BaseClauses, RecClauses, MemoEnabled, Code) ->

--- a/src/unifyweaver/core/advanced/mutual_recursion.pl
+++ b/src/unifyweaver/core/advanced/mutual_recursion.pl
@@ -16,6 +16,7 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(library(debug)).
 :- use_module('../template_system').
 :- use_module('../constraint_analyzer').
 :- use_module('call_graph').
@@ -96,26 +97,26 @@ merge_scc_constraints(Predicates, MergedConstraints) :-
 %  - If ANY predicate has unique(false), memoization is disabled for all
 %  - If ANY predicate requires ordered, hash-based memo is used for all
 compile_mutual_recursion(Predicates, Options, Code) :-
-    format('  Compiling mutual recursion group: ~w~n', [Predicates]),
+    debug(recursion_compile, 'Compiling mutual recursion group: ~w', [Predicates]),
 
     % Merge constraints from all predicates in the SCC
     merge_scc_constraints(Predicates, SCCConstraints),
-    format('  Merged SCC constraints: ~w~n', [SCCConstraints]),
+    debug(recursion_compile, 'Merged SCC constraints: ~w', [SCCConstraints]),
 
     % Merge runtime options with merged constraints (runtime options override)
     append(Options, SCCConstraints, AllOptions),
-    format('  Final options: ~w~n', [AllOptions]),
+    debug(recursion_compile, 'Final options: ~w', [AllOptions]),
 
     % Determine memoization strategy based on constraints
     (   member(unique(false), AllOptions) ->
-        format('  Applying unique(false): Shared memo disabled~n', []),
+        debug(recursion_compile, 'Applying unique(false): Shared memo disabled', []),
         MemoEnabled = false
     ;   MemoEnabled = true
     ),
 
     % Determine memo lookup strategy
     (   member(unordered(false), AllOptions) ->  % ordered = true
-        format('  Applying ordered constraint: Using hash-based shared memo~n', []),
+        debug(recursion_compile, 'Applying ordered constraint: Using hash-based shared memo', []),
         MemoStrategy = hash
     ;   MemoStrategy = standard
     ),
@@ -124,7 +125,7 @@ compile_mutual_recursion(Predicates, Options, Code) :-
     (   member(target(Target), AllOptions) -> true
     ;   Target = bash
     ),
-    format('  Target: ~w~n', [Target]),
+    debug(recursion_compile, 'Target: ~w', [Target]),
 
     % Generate code for the group
     (   compile_mutual_pattern(Target, Predicates, MemoEnabled, MemoStrategy, Code) ->

--- a/src/unifyweaver/core/advanced/tail_recursion.pl
+++ b/src/unifyweaver/core/advanced/tail_recursion.pl
@@ -12,6 +12,7 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(library(debug)).
 :- use_module('../template_system').
 :- use_module('../constraint_analyzer').
 :- use_module('pattern_matchers').
@@ -32,28 +33,28 @@ can_compile_tail_recursion(Pred/Arity) :-
 %  so deduplication constraints don't apply. Options are reserved for
 %  future use (e.g., output language selection).
 compile_tail_recursion(Pred/Arity, Options, Code) :-
-    format('  Compiling tail recursion: ~w/~w~n', [Pred, Arity]),
+    debug(recursion_compile, 'Compiling tail recursion: ~w/~w', [Pred, Arity]),
 
     % Query constraints (for logging and future use)
     get_constraints(Pred/Arity, Constraints),
-    format('  Constraints: ~w~n', [Constraints]),
+    debug(recursion_compile, 'Constraints: ~w', [Constraints]),
 
     % Merge runtime options with constraints for diagnostics/template hooks.
     % Explicit caller options take precedence when we read an option below.
     append(Options, Constraints, AllOptions),
-    format('  Final options: ~w~n', [AllOptions]),
+    debug(recursion_compile, 'Final options: ~w', [AllOptions]),
     
     % Determine target (default to bash)
     (   option_value(target, Options, Constraints, Target) -> true
     ;   Target = bash
     ),
-    format('  Target: ~w~n', [Target]),
+    debug(recursion_compile, 'Target: ~w', [Target]),
 
     % Apply unique constraint optimization
     % Tail recursive predicates with unique(true) can exit after first result
     (   option_value(unique, Options, Constraints, UniqueValue),
         UniqueValue == true ->
-        format('  Applying unique constraint optimization~n', []),
+        debug(recursion_compile, 'Applying unique constraint optimization', []),
         ExitAfterResult = true
     ;   ExitAfterResult = false
     ),

--- a/src/unifyweaver/core/advanced/tree_recursion.pl
+++ b/src/unifyweaver/core/advanced/tree_recursion.pl
@@ -15,6 +15,7 @@
 
 :- use_module(library(lists)).
 :- use_module(library(filesex)).
+:- use_module(library(debug)).
 :- use_module(pattern_matchers).
 :- use_module('../template_system').
 
@@ -128,7 +129,7 @@ compile_tree_recursion(Pred/Arity, Options, Code) :-
     (   member(target(Target), Options) -> true
     ;   Target = bash
     ),
-    format('  Target: ~w~n', [Target]),
+    debug(recursion_compile, 'Target: ~w', [Target]),
 
     % Detect pattern type (fibonacci checked first — more specific)
     (   is_fibonacci_pattern(Pred/Arity) ->

--- a/src/unifyweaver/core/stream_compiler.pl
+++ b/src/unifyweaver/core/stream_compiler.pl
@@ -15,6 +15,7 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(library(debug)).
 :- use_module('constraint_analyzer').
 :- use_module('template_system').
 :- use_module('optimizer').
@@ -25,11 +26,11 @@ compile_predicate(Pred/Arity, Options) :-
 
 compile_predicate(PredIndicator, Options, BashCode) :-
     PredIndicator = PredAtom/Arity,
-    format('=== Compiling ~w/~w ===~n', [PredAtom, Arity]),
+    debug(stream_compile, 'Compiling ~w/~w', [PredAtom, Arity]),
 
     % Get constraints for this predicate (from declarations or defaults)
     get_constraints(PredAtom/Arity, Constraints),
-    format('  Constraints: ~w~n', [Constraints]),
+    debug(stream_compile, 'Constraints: ~w', [Constraints]),
 
     % Merge with any runtime options (options take precedence)
     merge_options(Options, Constraints, MergedOptions),


### PR DESCRIPTION
## Summary

- Move routine recursion compiler progress messages to SWI-Prolog debug logging.
- Quiet normal regression runs by default while keeping diagnostics available through `debug(recursion_compile)` and `debug(stream_compile)`.
- Leave real errors on the normal output path.

## Verification

- `swipl -q -g "['src/unifyweaver/core/advanced/test_regressions.pl'], test_regressions:test_regressions, halt"`
- `swipl -q -g "['tests/core/test_python_native_lowering.pl'], test_python_native_lowering:test_python_native_lowering, halt"`
- `swipl -q -g "['tests/core/test_lua_native_lowering.pl'], test_lua_native_lowering:test_lua_native_lowering, halt"`
- `swipl -q -g "['tests/core/test_jvm_asm_native_lowering.pl'], test_jvm_asm_native_lowering:test_jvm_asm_native_lowering, halt"`
- `swipl -q -t halt -s src/unifyweaver/core/advanced/linear_recursion.pl`
- `swipl -q -t halt -s src/unifyweaver/core/stream_compiler.pl`
- `git diff --check`

## Notes

- This does not suppress warnings. It changes routine progress diagnostics from unconditional `format/2` calls to opt-in debug topics.
- The branch is clean at `21d0b52b`.
