### PR TITLE
feat(wam-r): operator-precedence parser for term_to_atom/2

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -273,8 +273,13 @@ The `atom`/`string` distinction is collapsed at the WAM-text level
 alias onto their `atom_*` counterparts.
 
 `term_to_atom/2` reverse mode parses canonical structural Prolog
-(`f(a, b)`, `[1, 2, 3]`, atoms, integers, floats). **Operator
-notation is not supported** in the parser.
+(`f(a, b)`, `[1, 2, 3]`, atoms, integers, floats) **and operator
+notation**: arithmetic (`+`, `-`, `*`, `/`, `**`, `^`, ...),
+comparison (`=`, `\=`, `==`, `\==`, `=:=`, `=\=`, `<`, `>`, `=<`,
+`>=`, `@<`, `@>`, `@=<`, `@>=`, `=..`), control (`:-`, `-->`, `;`,
+`->`, `,`), and prefix (`\+`, `:-`, `?-`, `-`, `+`, `\`).
+Precedence and associativity follow the standard Prolog operator
+table; non-standard user-defined operators are not recognised.
 
 ### I/O
 
@@ -366,9 +371,11 @@ WamRuntime$run(shared_program, state)
 
 ## Limitations
 
-- **No operator notation in the term parser**. `term_to_atom/2`
-  reverse mode requires canonical structural form (`+(1, 2)` not
-  `1 + 2`).
+- **User-defined operators in the term parser**. The parser handles
+  the standard Prolog operator table (arithmetic, comparison,
+  control, common prefix forms); custom `op/3` declarations are not
+  consulted, so terms using them must be supplied in canonical
+  structural form.
 - **WAM-text quoting collision**. The atom `'42'` and the integer
   `42` both serialise as `set_constant 42` in SWI's WAM emitter,
   so the codegen can't distinguish them. The runtime's `atom_*`
@@ -400,7 +407,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 37 tests covering both structural assertions on the
+and contains 38 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -431,6 +438,7 @@ Coverage map (e2e tests, by feature group):
 | `enumerable_builtins_e2e_rscript` | enumerable `member/2` / `between/3` inside aggregators |
 | `catch_throw_dyn_aggregator_e2e_rscript` | `catch/3`, `throw/1`, dynamic-pred aggregation |
 | `stdlib_polish_e2e_rscript` | `numlist/3`, `tab/1`, `sub_atom/5`, `char_type/2`, `term_to_atom/2` |
+| `operator_parser_e2e_rscript` | operator-precedence parsing (`+`, `*`, `^`, `=:=`, `\+`, `,`, ...) |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -530,6 +530,13 @@ WamRuntime$tokenize_term <- function(text) {
   n <- length(chars)
   toks <- list()
   push <- function(t) toks[[length(toks) + 1L]] <<- t
+  is_digit <- function(ch) grepl("^[0-9]$", ch)
+  # Symbol chars used in Prolog operators. `,`, `;`, `|` get their
+  # own token types so the parser can switch behaviour at separator
+  # vs operator positions.
+  sym_chars <- c("+", "-", "*", "/", "\\", "^", "<", ">",
+                 "=", ":", "@", ".", "?", "~", "#", "$", "&")
+  is_sym <- function(ch) ch %in% sym_chars
   while (i <= n) {
     c <- chars[i]
     if (c %in% c(" ", "\t", "\n", "\r")) { i <- i + 1L; next }
@@ -538,6 +545,7 @@ WamRuntime$tokenize_term <- function(text) {
     if (c == "[") { push(list(type = "lbracket")); i <- i + 1L; next }
     if (c == "]") { push(list(type = "rbracket")); i <- i + 1L; next }
     if (c == ",") { push(list(type = "comma"));    i <- i + 1L; next }
+    if (c == ";") { push(list(type = "semicolon")); i <- i + 1L; next }
     if (c == "|") { push(list(type = "pipe"));     i <- i + 1L; next }
     # Quoted atom: 'foo bar' with backslash escapes for ' and \.
     if (c == "'") {
@@ -556,13 +564,13 @@ WamRuntime$tokenize_term <- function(text) {
       next
     }
     # Signed number: digit-start, or `-` followed by digit and not
-    # following an atom/var/closing bracket (in which case it would
-    # be a binary operator -- not supported).
-    is_digit <- function(ch) grepl("^[0-9]$", ch)
+    # following a value-producing token (in which case it would be a
+    # binary operator handled by the parser's op-loop).
     if (is_digit(c) || (c == "-" && i + 1L <= n && is_digit(chars[i + 1L]) &&
                         (length(toks) == 0L ||
-                         toks[[length(toks)]]$type %in% c("comma", "lparen",
-                                                           "lbracket", "pipe")))) {
+                         toks[[length(toks)]]$type %in% c("comma", "semicolon",
+                                                           "lparen", "lbracket",
+                                                           "pipe")))) {
       j <- if (c == "-") i + 1L else i
       saw_dot <- FALSE
       while (j <= n && (is_digit(chars[j]) ||
@@ -592,10 +600,74 @@ WamRuntime$tokenize_term <- function(text) {
       i <- j
       next
     }
+    # Symbol-run atom (operators): + - * / \ ^ < > = : @ . ? ~ # $ &.
+    # The whole maximal run becomes one atom token; the parser then
+    # consults the operator tables to decide its role.
+    if (is_sym(c)) {
+      j <- i + 1L
+      while (j <= n && is_sym(chars[j])) j <- j + 1L
+      push(list(type = "atom", value = paste(chars[i:(j - 1L)], collapse = ""),
+                is_symbol = TRUE))
+      i <- j
+      next
+    }
     return(NULL)  # unrecognized character
   }
   toks
 }
+
+# Operator tables. Format: name -> list(prec, assoc).
+# Coverage is the canonical Prolog operator set sufficient to round-
+# trip arithmetic, comparison, control, and common list/term
+# operators. Add entries here to extend.
+WamRuntime$op_infix <- list(
+  ":-"   = list(prec = 1200L, assoc = "xfx"),
+  "-->"  = list(prec = 1200L, assoc = "xfx"),
+  ";"    = list(prec = 1100L, assoc = "xfy"),
+  "->"   = list(prec = 1050L, assoc = "xfy"),
+  "*->"  = list(prec = 1050L, assoc = "xfy"),
+  ","    = list(prec = 1000L, assoc = "xfy"),
+  "="    = list(prec = 700L,  assoc = "xfx"),
+  "\\="  = list(prec = 700L,  assoc = "xfx"),
+  "=="   = list(prec = 700L,  assoc = "xfx"),
+  "\\==" = list(prec = 700L,  assoc = "xfx"),
+  "=.."  = list(prec = 700L,  assoc = "xfx"),
+  "is"   = list(prec = 700L,  assoc = "xfx"),
+  "=:="  = list(prec = 700L,  assoc = "xfx"),
+  "=\\=" = list(prec = 700L,  assoc = "xfx"),
+  "<"    = list(prec = 700L,  assoc = "xfx"),
+  ">"    = list(prec = 700L,  assoc = "xfx"),
+  "=<"   = list(prec = 700L,  assoc = "xfx"),
+  ">="   = list(prec = 700L,  assoc = "xfx"),
+  "@<"   = list(prec = 700L,  assoc = "xfx"),
+  "@>"   = list(prec = 700L,  assoc = "xfx"),
+  "@=<"  = list(prec = 700L,  assoc = "xfx"),
+  "@>="  = list(prec = 700L,  assoc = "xfx"),
+  "+"    = list(prec = 500L,  assoc = "yfx"),
+  "-"    = list(prec = 500L,  assoc = "yfx"),
+  "/\\"  = list(prec = 500L,  assoc = "yfx"),
+  "\\/"  = list(prec = 500L,  assoc = "yfx"),
+  "xor"  = list(prec = 500L,  assoc = "yfx"),
+  "*"    = list(prec = 400L,  assoc = "yfx"),
+  "/"    = list(prec = 400L,  assoc = "yfx"),
+  "//"   = list(prec = 400L,  assoc = "yfx"),
+  "mod"  = list(prec = 400L,  assoc = "yfx"),
+  "rem"  = list(prec = 400L,  assoc = "yfx"),
+  "div"  = list(prec = 400L,  assoc = "yfx"),
+  "<<"   = list(prec = 400L,  assoc = "yfx"),
+  ">>"   = list(prec = 400L,  assoc = "yfx"),
+  "**"   = list(prec = 200L,  assoc = "xfx"),
+  "^"    = list(prec = 200L,  assoc = "xfy")
+)
+
+WamRuntime$op_prefix <- list(
+  ":-"  = list(prec = 1200L),
+  "?-"  = list(prec = 1200L),
+  "\\+" = list(prec = 900L),
+  "-"   = list(prec = 200L),
+  "+"   = list(prec = 200L),
+  "\\"  = list(prec = 200L)
+)
 
 WamRuntime$parse_term <- function(text, table, state) {
   toks <- WamRuntime$tokenize_term(text)
@@ -606,41 +678,73 @@ WamRuntime$parse_term <- function(text, table, state) {
   p$table <- table
   p$state <- state
   p$vars <- new.env(parent = emptyenv())
-  result <- WamRuntime$wam_parse_expr(p)
+  result <- WamRuntime$wam_parse_expr(p, 1200L)
   if (is.null(result)) return(NULL)
   if (p$pos <= length(toks)) return(NULL)  # extra tokens
   result
 }
 
-WamRuntime$wam_parse_expr <- function(p) {
+# Operator-precedence (Pratt-style) parser. Parses a term whose top-
+# level operator has precedence <= max_prec. Recursive calls set the
+# rhs ceiling per associativity (xfy: rhs <= prec; yfx/xfx: rhs <
+# prec; left-recursion is implemented by the outer loop, so yfx
+# folds left without explicit lhs tracking).
+WamRuntime$wam_parse_expr <- function(p, max_prec) {
+  left <- WamRuntime$wam_parse_primary(p, max_prec)
+  if (is.null(left)) return(NULL)
+  repeat {
+    if (p$pos > length(p$tokens)) return(left)
+    tok <- p$tokens[[p$pos]]
+    op_name <- if (tok$type == "atom") tok$value
+               else if (tok$type == "comma") ","
+               else if (tok$type == "semicolon") ";"
+               else NULL
+    if (is.null(op_name)) return(left)
+    op <- WamRuntime$op_infix[[op_name]]
+    if (is.null(op) || op$prec > max_prec) return(left)
+    p$pos <- p$pos + 1L
+    rhs_max <- if (op$assoc == "xfy") op$prec else op$prec - 1L
+    rhs <- WamRuntime$wam_parse_expr(p, rhs_max)
+    if (is.null(rhs)) return(NULL)
+    left <- StructTerm(WamRuntime$intern(p$table, op_name), list(left, rhs))
+  }
+}
+
+WamRuntime$wam_parse_primary <- function(p, max_prec) {
   if (p$pos > length(p$tokens)) return(NULL)
   tok <- p$tokens[[p$pos]]
   if (tok$type == "number") {
     p$pos <- p$pos + 1L
-    if (tok$is_float) FloatTerm(as.numeric(tok$value))
-    else              IntTerm(as.integer(tok$value))
-  } else if (tok$type == "var") {
+    if (tok$is_float) return(FloatTerm(as.numeric(tok$value)))
+    return(IntTerm(as.integer(tok$value)))
+  }
+  if (tok$type == "var") {
     p$pos <- p$pos + 1L
     name <- tok$value
     if (name == "_") {
       v <- Unbound(paste0("V", p$state$var_counter))
       p$state$var_counter <- p$state$var_counter + 1L
-      v
-    } else if (exists(name, envir = p$vars, inherits = FALSE)) {
-      get(name, envir = p$vars, inherits = FALSE)
-    } else {
-      v <- Unbound(paste0("V", p$state$var_counter))
-      p$state$var_counter <- p$state$var_counter + 1L
-      assign(name, v, envir = p$vars)
-      v
+      return(v)
     }
-  } else if (tok$type == "atom") {
+    if (exists(name, envir = p$vars, inherits = FALSE)) {
+      return(get(name, envir = p$vars, inherits = FALSE))
+    }
+    v <- Unbound(paste0("V", p$state$var_counter))
+    p$state$var_counter <- p$state$var_counter + 1L
+    assign(name, v, envir = p$vars)
+    return(v)
+  }
+  if (tok$type == "atom") {
     p$pos <- p$pos + 1L
+    # Functor application: atom immediately followed by `(`. The
+    # tokenizer doesn't track whitespace gaps, so any lparen here is
+    # treated as functor application -- canonical Prolog rejects
+    # `foo (x)` too.
     if (p$pos <= length(p$tokens) && p$tokens[[p$pos]]$type == "lparen") {
       p$pos <- p$pos + 1L
       args <- list()
       repeat {
-        a <- WamRuntime$wam_parse_expr(p)
+        a <- WamRuntime$wam_parse_expr(p, 999L)
         if (is.null(a)) return(NULL)
         args <- c(args, list(a))
         if (p$pos > length(p$tokens)) return(NULL)
@@ -649,18 +753,34 @@ WamRuntime$wam_parse_expr <- function(p) {
         if (sep != "comma") return(NULL)
         p$pos <- p$pos + 1L
       }
-      StructTerm(WamRuntime$intern(p$table, tok$value), args)
-    } else {
-      Atom(WamRuntime$intern(p$table, tok$value))
+      return(StructTerm(WamRuntime$intern(p$table, tok$value), args))
     }
-  } else if (tok$type == "lparen") {
+    # Prefix operator: name in op_prefix, prec fits, and the next
+    # token can start a term. Otherwise stand-alone atom.
+    op <- WamRuntime$op_prefix[[tok$value]]
+    if (!is.null(op) && op$prec <= max_prec && p$pos <= length(p$tokens)) {
+      next_tok <- p$tokens[[p$pos]]
+      starts_term <- next_tok$type %in%
+        c("number", "var", "atom", "lparen", "lbracket")
+      if (starts_term) {
+        operand <- WamRuntime$wam_parse_expr(p, op$prec - 1L)
+        if (is.null(operand)) return(NULL)
+        return(StructTerm(WamRuntime$intern(p$table, tok$value),
+                          list(operand)))
+      }
+    }
+    return(Atom(WamRuntime$intern(p$table, tok$value)))
+  }
+  if (tok$type == "lparen") {
     p$pos <- p$pos + 1L
-    inner <- WamRuntime$wam_parse_expr(p)
+    inner <- WamRuntime$wam_parse_expr(p, 1200L)
     if (is.null(inner)) return(NULL)
-    if (p$pos > length(p$tokens) || p$tokens[[p$pos]]$type != "rparen") return(NULL)
+    if (p$pos > length(p$tokens) ||
+        p$tokens[[p$pos]]$type != "rparen") return(NULL)
     p$pos <- p$pos + 1L
-    inner
-  } else if (tok$type == "lbracket") {
+    return(inner)
+  }
+  if (tok$type == "lbracket") {
     p$pos <- p$pos + 1L
     if (p$pos <= length(p$tokens) && p$tokens[[p$pos]]$type == "rbracket") {
       p$pos <- p$pos + 1L
@@ -668,7 +788,7 @@ WamRuntime$wam_parse_expr <- function(p) {
     }
     elems <- list()
     repeat {
-      a <- WamRuntime$wam_parse_expr(p)
+      a <- WamRuntime$wam_parse_expr(p, 999L)
       if (is.null(a)) return(NULL)
       elems <- c(elems, list(a))
       if (p$pos > length(p$tokens)) return(NULL)
@@ -677,7 +797,7 @@ WamRuntime$wam_parse_expr <- function(p) {
       if (sep == "comma") { p$pos <- p$pos + 1L; next }
       if (sep == "pipe") {
         p$pos <- p$pos + 1L
-        tail <- WamRuntime$wam_parse_expr(p)
+        tail <- WamRuntime$wam_parse_expr(p, 999L)
         if (is.null(tail)) return(NULL)
         if (p$pos > length(p$tokens) ||
             p$tokens[[p$pos]]$type != "rbracket") return(NULL)
@@ -691,10 +811,9 @@ WamRuntime$wam_parse_expr <- function(p) {
       }
       return(NULL)
     }
-    WamRuntime$wam_list_build(elems, p$table)
-  } else {
-    NULL
+    return(WamRuntime$wam_list_build(elems, p$table))
   }
+  NULL
 }
 
 # Build a Prolog-style cons-list term from a list of WAM terms.

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -1703,6 +1703,91 @@ e2e_stdlib_polish_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for operator-precedence parsing in
+% term_to_atom/2 reverse mode. Asserts that the parser respects
+% operator associativity (yfx, xfy) and precedence ordering, and
+% that prefix operators (\+) work.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(operator_parser_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_operator_parser_via_rscript
+    ;   true
+    )).
+
+e2e_operator_parser_via_rscript :-
+    % "1+2" -> +(1, 2).
+    assertz((user:op_simple :-
+        atom_codes(A, [49, 43, 50]),
+        term_to_atom(T, A), T == 1+2)),
+    % "1+2*3" -> +(1, *(2, 3)) (mul binds tighter).
+    assertz((user:op_prec :-
+        atom_codes(A, [49, 43, 50, 42, 51]),
+        term_to_atom(T, A), T == 1+2*3)),
+    % "1+2+3" -> +(+(1, 2), 3) (yfx, left associative).
+    assertz((user:op_left_assoc :-
+        atom_codes(A, [49, 43, 50, 43, 51]),
+        term_to_atom(T, A), T == 1+2+3)),
+    % "2^3^4" -> ^(2, ^(3, 4)) (xfy, right associative).
+    assertz((user:op_right_assoc :-
+        atom_codes(A, [50, 94, 51, 94, 52]),
+        term_to_atom(T, A), T == 2^3^4)),
+    % Whitespace tolerated: "1 + 2" -> +(1, 2).
+    assertz((user:op_spaces :-
+        atom_codes(A, [49, 32, 43, 32, 50]),
+        term_to_atom(T, A), T == 1+2)),
+    % "a=b" -> =(a, b).
+    assertz((user:op_eq :-
+        atom_codes(A, [97, 61, 98]),
+        term_to_atom(T, A), T == (a=b))),
+    % "1<2" -> <(1, 2).
+    assertz((user:op_compare :-
+        atom_codes(A, [49, 60, 50]),
+        term_to_atom(T, A), T == (1<2))),
+    % Multi-char operator: "1+1 =:= 2" -> =:=(+(1, 1), 2).
+    assertz((user:op_arith_eq :-
+        atom_codes(A, [49, 43, 49, 32, 61, 58, 61, 32, 50]),
+        term_to_atom(T, A), T == (1+1 =:= 2))),
+    % Prefix operator: "\+foo" -> \+(foo).
+    assertz((user:op_prefix_neg :-
+        atom_codes(A, [92, 43, 102, 111, 111]),
+        term_to_atom(T, A), T == (\+ foo))),
+    % Comma as operator inside parens: "(a,b,c)" -> ','(a, ','(b, c)).
+    assertz((user:op_comma :-
+        atom_codes(A, [40, 97, 44, 98, 44, 99, 41]),
+        term_to_atom(T, A), T == (a,b,c))),
+    % Negative integer literal preserved: "f(-3)" -> f(-3).
+    assertz((user:op_neg_lit :-
+        atom_codes(A, [102, 40, 45, 51, 41]),
+        term_to_atom(T, A), T == f(-3))),
+    % Round-trip: render an arithmetic term and re-parse to the
+    % structurally equal term.
+    assertz((user:op_round_trip :-
+        T0 = 1+2*3,
+        term_to_atom(T0, A),
+        term_to_atom(T1, A),
+        T1 == T0)),
+    unique_r_tmp_dir('tmp_r_op_parser_e2e', TmpDir),
+    write_wam_r_project(
+        [ user:op_simple/0, user:op_prec/0, user:op_left_assoc/0,
+          user:op_right_assoc/0, user:op_spaces/0, user:op_eq/0,
+          user:op_compare/0, user:op_arith_eq/0, user:op_prefix_neg/0,
+          user:op_comma/0, user:op_neg_lit/0, user:op_round_trip/0 ],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [op_simple, op_prec, op_left_assoc, op_right_assoc,
+           op_spaces, op_eq, op_compare, op_arith_eq,
+           op_prefix_neg, op_comma, op_neg_lit, op_round_trip],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
## Summary

- Replaces the canonical-only `term_to_atom/2` parser with a Pratt-style operator-precedence parser covering the standard Prolog operator table.
- Closes the "no operator notation in the term parser" limitation called out in `docs/WAM_R_TARGET.md`.

## What's covered

Parsing now handles the full canonical Prolog operator set:
- **Arithmetic** -- `+`, `-`, `*`, `/`, `//`, `mod`, `rem`, `div`, `**`, `^`, `<<`, `>>`, `/\`, `\/`, `xor`.
- **Comparison** -- `=`, `\=`, `==`, `\==`, `=..`, `is`, `=:=`, `=\=`, `<`, `>`, `=<`, `>=`, `@<`, `@>`, `@=<`, `@>=`.
- **Control** -- `:-`, `-->`, `;`, `->`, `*->`, `,`.
- **Prefix** -- `\+`, `:-`, `?-`, `-`, `+`, `\`.

Precedence and associativity follow the standard table (e.g. `1+2*3` parses as `+(1, *(2, 3))`, `1+2+3` as `+(+(1,2), 3)`, `2^3^4` as `^(2, ^(3, 4))`).

## Implementation notes

- **Tokenizer** -- new symbol-run rule (`+ - * / \ ^ < > = : @ . ? ~ # $ &`) emits multi-char operator atoms via maximal munch. Negative integer literals (`-3`) still tokenise eagerly when in a value-starting context (after `(`, `[`, `,`, `;`, `|`, or BOF), so `f(-3)` produces `IntTerm(-3)` rather than `-(3)`. Outside those positions, `-` becomes a prefix operator handled by the parser.
- **Parser** -- split into `wam_parse_expr` (Pratt operator loop with `max_prec` ceiling) and `wam_parse_primary` (numbers, vars, atoms-or-prefix, parens, lists, functors). Args inside `f(...)` and elements of `[...]` parse at max_prec 999 so the comma operator stays a separator there.
- **Operator tables** -- two R lists, `WamRuntime$op_infix` and `WamRuntime$op_prefix`, easy to extend if more operators are needed.

## Test plan

- [x] `swipl -g 'use_module(library(plunit)),consult("tests/test_wam_r_generator.pl"),run_tests,halt' -t 'halt(1)'`
  -> all 38 tests pass (248s).
- [x] New `operator_parser_e2e_rscript` smoke test covers basic infix, precedence, both associativities, whitespace, comparison/control ops, prefix `\+`, comma operator, negative literals, and a round-trip through `term_to_atom/2`.
- [x] Existing `stdlib_polish_e2e_rscript` (which exercises the parser via `term_to_atom/2` reverse mode) continues to pass.

## Doc updates

- `docs/WAM_R_TARGET.md`: limitation section reframed -- the standard operator table is now supported; only custom `op/3` declarations remain unsupported.
- Coverage map adds the new `operator_parser_e2e_rscript` row; test count bumped from 37 to 38.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_