### PR TITLE
feat(wam-clojure): lower float builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -312,6 +312,10 @@ clojure_direct_builtin("callable/1", "1").
 clojure_direct_builtin("callable/1", 1).
 clojure_direct_builtin('callable/1', "1").
 clojure_direct_builtin('callable/1', 1).
+clojure_direct_builtin("float/1", "1").
+clojure_direct_builtin("float/1", 1).
+clojure_direct_builtin('float/1', "1").
+clojure_direct_builtin('float/1', 1).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
@@ -347,6 +351,8 @@ clojure_unary_guard_test("compound/1", "(runtime/structure-term? value)").
 clojure_unary_guard_test('compound/1', "(runtime/structure-term? value)").
 clojure_unary_guard_test("callable/1", "(or (runtime/atom-term? value) (runtime/structure-term? value))").
 clojure_unary_guard_test('callable/1', "(or (runtime/atom-term? value) (runtime/structure-term? value))").
+clojure_unary_guard_test("float/1", "(float? value)").
+clojure_unary_guard_test('float/1', "(float? value)").
 
 emit_lowered_unary_guard(TestExpr, S, Expr) :-
     format(atom(Expr),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -861,6 +861,13 @@
               (advance state)
               (backtrack state)))
 
+          "float/1"
+          (let [value (deref-value (:bindings state)
+                                   (or (reg-get-raw state "A1") ::unbound))]
+            (if (float? value)
+              (advance state)
+              (backtrack state)))
+
           "!/0"
           (-> state
               (update :choice-points #(vec (take (:cut-bar state) %)))

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -116,6 +116,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, '"var/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"compound/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"callable/1"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"float/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-bindings [state bindings]')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -323,6 +323,28 @@ test(terminal_execute_callable_is_direct_lowered_as_succeeding_builtin) :-
         assertion(\+ has(Code, ":pc target-pc"))
     )).
 
+test(simple_builtin_float_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_float/1:\nbuiltin_call float/1, 1\nproceed\n",
+        wam_clojure_lowerable(test_float/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_float/1, WamCode, [], Code),
+        has(Code, "runtime/deref-value"),
+        has(Code, "float? value"),
+        has(Code, "runtime/advance"),
+        has(Code, "runtime/backtrack")
+    )).
+
+test(terminal_execute_float_is_direct_lowered_as_succeeding_builtin) :-
+    once((
+        WamCode = "test_execute_float/1:\nallocate\ndeallocate\nexecute float/1\n",
+        wam_clojure_lowerable(test_execute_float/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_execute_float/1, WamCode, [], Code),
+        has(Code, "float? value"),
+        has(Code, "runtime/succeed-state next-state"),
+        assertion(\+ has(Code, "\"float/1\"")),
+        assertion(\+ has(Code, ":pc target-pc"))
+    )).
+
 test(env_framed_equality_reaches_direct_builtin_prefix) :-
     once((
         WamCode = "test_env_eq/2:\nallocate\nput_value X1, A1\nput_value X2, A2\nbuiltin_call =/2, 2\ndeallocate\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -51,6 +51,8 @@
 :- dynamic user:wam_compound_unbound/1.
 :- dynamic user:wam_callable_guard/1.
 :- dynamic user:wam_callable_unbound/1.
+:- dynamic user:wam_float_guard/1.
+:- dynamic user:wam_float_unbound/1.
 
 has(Code, Substr) :-
     once(sub_string(Code, _, _, _, Substr)).
@@ -104,6 +106,8 @@ user:wam_compound_guard(X) :- compound(X).
 user:wam_compound_unbound(_) :- user:wam_unbound_arg(Y), compound(Y).
 user:wam_callable_guard(X) :- callable(X).
 user:wam_callable_unbound(_) :- user:wam_unbound_arg(Y), callable(Y).
+user:wam_float_guard(X) :- float(X).
+user:wam_float_unbound(_) :- user:wam_unbound_arg(Y), float(Y).
 
 :- initialization(main, main).
 
@@ -161,7 +165,9 @@ run_smoke :-
           user:wam_compound_guard/1,
           user:wam_compound_unbound/1,
           user:wam_callable_guard/1,
-          user:wam_callable_unbound/1
+          user:wam_callable_unbound/1,
+          user:wam_float_guard/1,
+          user:wam_float_unbound/1
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
@@ -188,6 +194,7 @@ run_smoke :-
     assert_lowered_var_builtin_emitted(TmpDir),
     assert_lowered_compound_builtin_emitted(TmpDir),
     assert_lowered_callable_builtin_emitted(TmpDir),
+    assert_lowered_float_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
@@ -272,6 +279,11 @@ run_smoke :-
     verify_output(TmpDir, 'wam_callable_guard/1', 'f(a)', "true"),
     verify_output(TmpDir, 'wam_callable_guard/1', '[a,b]', "true"),
     verify_output(TmpDir, 'wam_callable_unbound/1', a, "false"),
+    verify_output(TmpDir, 'wam_float_guard/1', 3.5, "true"),
+    verify_output(TmpDir, 'wam_float_guard/1', 42, "false"),
+    verify_output(TmpDir, 'wam_float_guard/1', a, "false"),
+    verify_output(TmpDir, 'wam_float_guard/1', 'f(a)', "false"),
+    verify_output(TmpDir, 'wam_float_unbound/1', a, "false"),
     delete_directory_and_contents(TmpDir),
     writeln('wam_clojure_runtime_smoke: ok').
 
@@ -388,6 +400,13 @@ assert_lowered_callable_builtin_emitted(ProjectDir) :-
     has(CoreCode, "runtime/atom-term? value"),
     has(CoreCode, "runtime/structure-term? value").
 
+assert_lowered_float_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-float-guard-1"),
+    has(CoreCode, "defn lowered-wam-float-unbound-1"),
+    has(CoreCode, "float? value").
+
 assert_multiclause_wrappers_runtime_mediated(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
@@ -441,6 +460,7 @@ prolog_term_string_to_edn(b, "\"b\"") :- !.
 prolog_term_string_to_edn(c, "\"c\"") :- !.
 prolog_term_string_to_edn(d, "\"d\"") :- !.
 prolog_term_string_to_edn(z, "\"z\"") :- !.
+prolog_term_string_to_edn(3.5, "3.5") :- !.
 prolog_term_string_to_edn(42, "42") :- !.
 prolog_term_string_to_edn("a", "\"a\"") :- !.
 prolog_term_string_to_edn("b", "\"b\"") :- !.


### PR DESCRIPTION
## Summary

- Adds Clojure WAM runtime support for `builtin_call float/1`.
- Adds direct lowered-prefix support for deterministic `float/1` builtin calls through the centralized unary guard table.
- Reuses terminal direct-builtin lowering for compiler-emitted `execute float/1`.
- Treats host floating-point values as floats while integers, atoms, compound terms, and unbound variables fail.
- Adds generator, lowered-emitter, and runtime smoke coverage for float, integer, atom, compound, and unbound cases.

## Why

`float/1` is a low-risk unary guard now that Clojure unary guard lowering is centralized. EDN decimal inputs remain host floating values in the Clojure runtime, so this guard can stay on the lowered path without adding new binding behavior.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
