### PR TITLE
feat(wam-r): multi-solution retract/1 + put_structure cycle fix

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -290,11 +290,13 @@ abstraction.
 
 ### Dynamic predicates
 
-`assertz/1`, `asserta/1`, `retract/1` (deterministic first match),
-`abolish/1` (takes `Name/Arity`). Clauses are stored in
-`program$dynamic` (an R env, so mutations propagate across
-queries). Multi-clause dynamic predicates are dispatched through a
-`dynamic` CP that walks the clause list on backtracking.
+`assertz/1`, `asserta/1`, `retract/1` (multi-solution: iter-CP
+walks the snapshot taken at the call, removing each match in turn
+on backtracking), `abolish/1` (takes `Name/Arity`). Clauses are
+stored in `program$dynamic` (an R env, so mutations propagate
+across queries). Multi-clause dynamic predicate calls are
+dispatched through a `dynamic` CP that walks the clause list on
+backtracking.
 
 ### Exception handling
 
@@ -382,9 +384,13 @@ WamRuntime$run(shared_program, state)
   family is intentionally lenient (accepts ints/floats with their
   decimal name) to compensate. To round-trip an atom-of-digits
   reliably, build it via `atom_codes/2`.
-- **Multi-solution `retract/1`** is not supported -- only the first
-  match is removed. Subsequent backtracking does not retract more
-  clauses.
+- **`retract/1` snapshot semantics**. `retract/1` is multi-solution
+  via an iter-CP, but the iteration walks a snapshot of the clause
+  list captured at the original call -- so clauses asserted *during*
+  the iteration are not retracted by the same `retract/1` call.
+  Removed clauses are matched against the live store by object
+  identity, so concurrent retracts/asserts of unrelated clauses
+  don't disturb the iteration order.
 - **`bagof/3` / `setof/3`** do not support free-variable witnesses
   (`X^Goal`). Witness vars are silently aggregated rather than
   producing one bag per witness.
@@ -407,7 +413,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 38 tests covering both structural assertions on the
+and contains 39 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -439,6 +445,7 @@ Coverage map (e2e tests, by feature group):
 | `catch_throw_dyn_aggregator_e2e_rscript` | `catch/3`, `throw/1`, dynamic-pred aggregation |
 | `stdlib_polish_e2e_rscript` | `numlist/3`, `tab/1`, `sub_atom/5`, `char_type/2`, `term_to_atom/2` |
 | `operator_parser_e2e_rscript` | operator-precedence parsing (`+`, `*`, `^`, `=:=`, `\+`, `,`, ...) |
+| `multi_solution_retract_e2e_rscript` | multi-solution `retract/1` via iter-CP |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -308,13 +308,51 @@ WamRuntime$append_build_arg <- function(state, val) {
     cur <- WamRuntime$get_reg(state, top$target_reg)
     cur <- WamRuntime$deref(state, cur)
     if (!is.null(cur) && is.list(cur) && !is.null(cur$tag) && cur$tag == "unbound") {
-      WamRuntime$bind(state, cur$name, new_struct)
+      # Skip the bind if cur appears anywhere inside new_struct -- the
+      # bind would create a self-cycle. This happens when the WAM
+      # emits sequences like
+      #   put_variable Y201, A1
+      #   put_structure f/1, A1
+      #   set_value Y201
+      # where the build's lone arg is the same Unbound that's in A1,
+      # or when nested struct builds chain back to the outer target
+      # via a transitive var-binding (e.g. `:-`(rr(X), true) where
+      # rr/1's intermediate var binds to a struct containing X, and
+      # X happens to be the outer A1 unbound). Without this guard,
+      # deref(cur) eventually loops back to a struct containing cur
+      # and downstream unifications see a recursive struct instead
+      # of a fresh var.
+      if (!WamRuntime$wam_term_contains_var(state, new_struct, cur$name)) {
+        WamRuntime$bind(state, cur$name, new_struct)
+      }
     }
     WamRuntime$put_reg(state, top$target_reg, new_struct)
     n <- length(state$build_stack)
   }
   if (length(state$build_stack) == 0L) state$mode <- NULL
   invisible(NULL)
+}
+
+# Recursive structural check: does `term` reference an Unbound named
+# `name`, walking through binding chains? Used by append_build_arg's
+# cycle guard: catches both direct references (build arg is `cur`
+# itself) and transitive ones (build arg is a var that's bound to a
+# struct that ultimately contains `cur`). The depth cap is a safety
+# net for any pre-existing cycles that already pass through `name`;
+# returning FALSE in that pathological case lets the bind proceed
+# (matching the pre-guard behaviour).
+WamRuntime$wam_term_contains_var <- function(state, term, name, depth = 0L) {
+  if (depth > 256L) return(FALSE)
+  if (is.null(term) || !is.list(term) || is.null(term$tag)) return(FALSE)
+  v <- WamRuntime$deref(state, term)
+  if (is.null(v) || !is.list(v) || is.null(v$tag)) return(FALSE)
+  if (v$tag == "unbound") return(identical(v$name, name))
+  if (v$tag == "struct") {
+    for (a in v$args) {
+      if (WamRuntime$wam_term_contains_var(state, a, name, depth + 1L)) return(TRUE)
+    }
+  }
+  FALSE
 }
 
 WamRuntime$begin_read <- function(state, args) {
@@ -1583,6 +1621,84 @@ WamRuntime$dynamic_iter <- function(program, state, clauses, start_idx, arity, r
     state$var_counter <- snap_vc
     state$mode        <- snap_mode
     state$build_stack <- snap_build
+  }
+  FALSE
+}
+
+# Multi-solution retract/1. Walks `snapshot` (the clause list captured
+# at the original retract call) from `start_idx`, trying each clause
+# against the caller's pattern (head_args + optional body). On the
+# first match, the matching clause is deleted from the live store
+# (matched by object identity, since the live store may have been
+# mutated since the snapshot) and -- if more snapshot entries remain
+# -- an iter CP is pushed so backtracking re-enters the iteration at
+# `idx + 1` and re-binds the caller's pattern against that next
+# match. The captured snapshot is value-stable: asserts/retracts that
+# happen during the iteration don't perturb the order, and clauses
+# already retracted are simply skipped on subsequent identity checks.
+WamRuntime$retract_iter <- function(program, state, head_args, body, arity,
+                                     ck, snapshot, start_idx, resume_pc) {
+  if (start_idx > length(snapshot)) return(FALSE)
+  for (idx in seq.int(start_idx, length(snapshot))) {
+    cl <- snapshot[[idx]]
+    if (length(cl$head_args) != arity) next
+    snap_trail <- length(state$trail)
+    snap_vc    <- state$var_counter
+    fresh <- WamRuntime$copy_term_clause(state, cl)
+    ok <- TRUE
+    for (j in seq_len(arity)) {
+      if (!WamRuntime$unify(state, head_args[[j]], fresh$head_args[[j]])) {
+        ok <- FALSE; break
+      }
+    }
+    if (ok && !is.null(body) && !is.null(fresh$body)) {
+      ok <- WamRuntime$unify(state, body, fresh$body)
+    }
+    if (ok) {
+      # Remove the matched clause from the live store. Identity match
+      # rather than index, because the store may have been mutated.
+      if (exists(ck, envir = program$dynamic, inherits = FALSE)) {
+        live <- get(ck, envir = program$dynamic, inherits = FALSE)
+        for (li in seq_along(live)) {
+          if (identical(live[[li]], cl)) {
+            new_live <- if (length(live) == 1L) list() else live[-li]
+            assign(ck, new_live, envir = program$dynamic)
+            break
+          }
+        }
+      }
+      if (idx < length(snapshot)) {
+        captured_head_args <- head_args
+        captured_body      <- body
+        captured_arity     <- arity
+        captured_ck        <- ck
+        captured_snapshot  <- snapshot
+        captured_next_idx  <- idx + 1L
+        captured_resume    <- resume_pc
+        captured_program   <- program
+        cp <- list(
+          kind        = "iter",
+          regs        = as.list.environment(state$regs2),
+          trail_len   = snap_trail,
+          cp          = state$cp,
+          var_counter = snap_vc,
+          mode        = state$mode,
+          build_stack = state$build_stack,
+          resume_pc   = resume_pc,
+          retry       = function(state) {
+            WamRuntime$retract_iter(captured_program, state,
+                                     captured_head_args, captured_body,
+                                     captured_arity, captured_ck,
+                                     captured_snapshot, captured_next_idx,
+                                     captured_resume)
+          }
+        )
+        state$cps <- c(state$cps, list(cp))
+      }
+      return(TRUE)
+    }
+    WamRuntime$undo_trail_to(state, snap_trail)
+    state$var_counter <- snap_vc
   }
   FALSE
 }
@@ -3053,41 +3169,22 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     return(TRUE)
   }
 
-  # ----- retract/1: remove the first matching clause -----
+  # ----- retract/1: remove a matching clause; multi-solution -----
   # Bindings made by the unification persist on success (standard
-  # Prolog semantics). Multi-solution retract (backtrackable removal
-  # of subsequent matches) is not supported in this scaffold.
+  # Prolog semantics). On backtracking, retract_iter scans the rest
+  # of the snapshot taken at the original call and removes the next
+  # matching clause; when the snapshot is exhausted, backtracking
+  # continues outward as failure.
   if (key == "retract/1") {
     raw <- WamRuntime$get_reg(state, 1L)
     parts <- WamRuntime$split_clause(state, raw, table)
     if (is.null(parts)) return(FALSE)
     ck <- paste0(parts$pred, "/", parts$arity)
     if (!exists(ck, envir = program$dynamic, inherits = FALSE)) return(FALSE)
-    clauses <- get(ck, envir = program$dynamic, inherits = FALSE)
-    for (i in seq_along(clauses)) {
-      cl <- clauses[[i]]
-      if (length(cl$head_args) != parts$arity) next
-      trail0 <- length(state$trail)
-      var_counter0 <- state$var_counter
-      fresh <- WamRuntime$copy_term_clause(state, cl)
-      ok <- TRUE
-      for (j in seq_len(parts$arity)) {
-        if (!WamRuntime$unify(state, parts$head_args[[j]], fresh$head_args[[j]])) {
-          ok <- FALSE; break
-        }
-      }
-      if (ok && !is.null(parts$body) && !is.null(fresh$body)) {
-        ok <- WamRuntime$unify(state, parts$body, fresh$body)
-      }
-      if (ok) {
-        remaining <- if (length(clauses) == 1L) list() else clauses[-i]
-        assign(ck, remaining, envir = program$dynamic)
-        return(TRUE)
-      }
-      WamRuntime$undo_trail_to(state, trail0)
-      state$var_counter <- var_counter0
-    }
-    return(FALSE)
+    snapshot <- get(ck, envir = program$dynamic, inherits = FALSE)
+    return(WamRuntime$retract_iter(program, state,
+                                    parts$head_args, parts$body, parts$arity,
+                                    ck, snapshot, 1L, state$pc + 1L))
   }
 
   # ----- abolish/1: drop all clauses for Name/Arity -----

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -1788,6 +1788,77 @@ e2e_operator_parser_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for multi-solution retract/1. Asserts a
+% handful of facts, drives findall(X, retract(p(X)), L) so the
+% retract iterates across all matches via the iter-CP retry, and
+% verifies (a) the bag captures every original X and (b) the dynamic
+% store is empty afterwards.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(multi_solution_retract_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_multi_solution_retract_via_rscript
+    ;   true
+    )).
+
+e2e_multi_solution_retract_via_rscript :-
+    % Drive: assert three facts, retract them all via findall +
+    % retract, check the bag is [1,2,3] (in assertion order) and
+    % that the store is now empty (a fourth retract fails).
+    assertz((user:msr_all :-
+        assertz(p(1)), assertz(p(2)), assertz(p(3)),
+        findall(X, retract(p(X)), L),
+        L == [1, 2, 3],
+        \+ retract(p(_)))),
+    % Pattern-restricted retract: an inline filter inside the goal
+    % still iterates retract over every clause (retract's removal
+    % side-effect is permanent regardless of subsequent goal
+    % failure). Odds collects only the survivors of the filter; the
+    % store is empty afterwards.
+    assertz((user:msr_filtered :-
+        assertz(q(1)), assertz(q(2)), assertz(q(3)), assertz(q(4)),
+        findall(X, (retract(q(X)), X mod 2 =:= 1), Odds),
+        Odds == [1, 3],
+        % All q clauses retracted.
+        findall(Y, retract(q(Y)), Rest),
+        Rest == [])),
+    % Pattern-arg retract: retract clauses whose second arg matches
+    % a pattern. Survivors stay in the store.
+    assertz((user:msr_pattern :-
+        assertz(qq(1, odd)),  assertz(qq(2, even)),
+        assertz(qq(3, odd)),  assertz(qq(4, even)),
+        findall(X, retract(qq(X, even)), Evens),
+        Evens == [2, 4],
+        findall(Y, retract(qq(Y, odd)), OddsLeft),
+        OddsLeft == [1, 3])),
+    % Rule retract: retract clauses whose body matches.
+    assertz((user:msr_rule :-
+        assertz((rr(1) :- true)),
+        assertz((rr(2) :- fail)),
+        assertz((rr(3) :- true)),
+        % Retract rules whose body is `true`.
+        findall(X, retract((rr(X) :- true)), Trues),
+        Trues == [1, 3],
+        % rr(2) (with body `fail`) survives.
+        findall(Y, retract((rr(Y) :- _)), Rest),
+        Rest == [2])),
+    unique_r_tmp_dir('tmp_r_msr_e2e', TmpDir),
+    write_wam_r_project(
+        [user:msr_all/0, user:msr_filtered/0, user:msr_pattern/0,
+         user:msr_rule/0],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [msr_all, msr_filtered, msr_pattern, msr_rule],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
## Summary

- Multi-solution `retract/1` via `retract_iter` (parallels `dynamic_iter`): walks a snapshot of the clause list captured at the original call, removing each match in turn; pushes an iter-CP so backtracking re-binds against the next snapshot entry. Closes the limitation noted in `docs/WAM_R_TARGET.md`.
- Cycle guard in `append_build_arg`: when the WAM emits a `put_structure` on a register whose existing Unbound also appears (directly or transitively) in the build args, the old finalize bound the outer Unbound to the new struct and created a recursive cycle. The new `wam_term_contains_var` helper walks through binding chains so both direct and transitive cycles are caught and the bind is skipped.

## Why the cycle guard was needed

Without the guard, this fails inside `findall`:

```prolog
findall(X, retract(p(X)), L)
```

WAM emits `PutVariable(Y201, A1)` (X goes into both regs), then `PutStructure(p/1, A1)` followed by `SetValue(Y201)`. Old finalize binds `A1`'s Unbound (= X) to `p(X)` -- so `deref(X) = p(X)` and the subsequent unification of head args inside retract fails. Same shape blows up for `retract((rr(X) :- true))` via a transitive cycle through the inner `rr/1` build's intermediate var.

## Snapshot semantics

`retract_iter` works against a value-stable snapshot taken at the original call. Effects:

- Asserts during the iteration are not seen.
- Removed clauses are matched against the live store by object identity, so concurrent unrelated retracts/asserts don't perturb iteration order.
- `findall(X, (retract(q(X)), <filter>), Bag)` still retracts every clause (retract's removal is a side effect of the goal, independent of subsequent filter outcome) -- the bag just collects only the survivors of the filter. `tests/test_wam_r_generator.pl` exercises this case.

## Test plan

- [x] `multi_solution_retract_e2e_rscript` (new): 4 sub-cases -- all-retract, filter-doesn't-undo-retract, pattern-arg retract with surviving clauses, rule retract by body match.
- [x] Full suite: 39 tests pass (`swipl -g 'use_module(library(plunit)),consult("tests/test_wam_r_generator.pl"),run_tests,halt' -t 'halt(1)'`).
- [x] No regressions in the existing `findall_e2e_rscript`, `dynamic_preds_e2e_rscript`, `bagof_setof_once_forall_e2e_rscript` paths.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_