### PR TITLE
  docs(wam): LMDB-resident interning — philosophy, specification, implementation plan

### DIFF
--- a/docs/design/WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,212 @@
+# LMDB-Resident Interning: Implementation Plan
+
+For the *why*, see `WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md`. For the
+*what*, see `WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md`. This
+document records the ordered rollout.
+
+## 0. Starting point
+
+Current state on `main` after PR #1882:
+
+- `data/benchmark/100k_cats/lmdb_proj/src/Main.hs:131-180` parses two
+  TSVs (~280k pairs) and rebuilds the intern table on every run, even
+  when `data.mdb` exists. Sequential setup floor: ~3.2 s wall-time
+  out of ~3.2 s total at `-N1` on `100k_cats`.
+- `templates/targets/haskell_wam/main.hs.mustache` already has an
+  `int_atom_seeds(true)` mode that skips TSV loading and reads
+  pre-interned int-id files. Used by the enwiki path; not used by the
+  matrix bench fixtures.
+- `src/unifyweaver/runtime/rust/mysql_stream/` parses MySQL INSERT
+  dumps and emits TSV to stdout. ~555 lines, well-tested.
+- `examples/benchmark/prepare_effective_distance_large_scales.py` builds
+  the `100k_cats` fixture by extracting from a SimpleWiki SQLite db.
+
+## 1. Phase 1 — Rust ingester (`mysql_stream` extension)
+
+**Branch:** `feat/mysql-stream-lmdb-sink`
+
+### 1.1 Add `heed` dependency
+
+Edit `src/unifyweaver/runtime/rust/mysql_stream/Cargo.toml` to add
+`heed = "0.20"` (or current stable). Keep it behind a feature flag
+`lmdb-sink` so the existing TSV-stdout path has no new compile-time
+dependency by default.
+
+### 1.2 `IngestSink` trait
+
+Refactor `iter_mysql_rows` consumers behind a small trait:
+
+```rust
+pub trait IngestSink {
+    fn on_row(&mut self, row: &[Field]) -> Result<()>;
+    fn finalize(self) -> Result<()>;
+}
+```
+
+The existing TSV-stdout writer becomes `TsvSink`; the new sink is
+`LmdbSink`. The streaming loop is unchanged.
+
+### 1.3 `LmdbSink` implementation
+
+New module `src/lmdb_sink.rs` (gated by `lmdb-sink` feature):
+
+- Holds a `heed::Env`, the four named databases, an
+  `IndexMap<String, u32>` for the in-memory intern map, and a write
+  txn that is committed in `finalize`.
+- `on_row` extracts (child, parent) per the configured column indices,
+  applies any filters, interns both strings, writes the edge with
+  `MDB_APPENDDUP`, and writes any new `i2s` entries with `MDB_APPEND`.
+- `finalize` sorts the intern map by string and bulk-loads `s2i` with
+  `MDB_APPEND`. Computes / writes `meta` keys. Commits the txn.
+
+### 1.4 New binary `mysql_stream_lmdb`
+
+Adds `[[bin]]` entry in `Cargo.toml`. CLI per
+`SPECIFICATION §3`. Wraps `iter_mysql_rows` + `LmdbSink`.
+
+### 1.5 Tests
+
+- Unit tests on `LmdbSink`: small fixture (10 rows), check `s2i`,
+  `i2s`, edges, `meta` keys.
+- Round-trip test: run `mysql_stream_lmdb` on a synthetic dump, then a
+  Rust reader iterates the LMDB and reproduces the input edges.
+- Reserved-ID collision test: input dump containing the literal
+  string `"true"`, verify it gets the reserved low ID.
+
+### 1.6 Acceptance
+
+`cargo test --features lmdb-sink` green. Spike measurement: ingest
+SimpleWiki categorylinks (~280k pairs) end-to-end in well under the
+3.2 s the current Haskell setup phase takes.
+
+## 2. Phase 2 — Haskell runtime support (`int_atom_seeds(lmdb)`)
+
+**Branch:** `feat/wam-haskell-int-atom-seeds-lmdb`
+
+### 2.1 Extend `InternTable` type
+
+In `templates/targets/haskell_wam/wam_types.hs.mustache` (or wherever
+`InternTable` lives) add the `LmdbBacked` constructor per
+`SPECIFICATION §5`. Add `internAtom` / `lookupAtom` cases.
+
+### 2.2 New mustache section in `main.hs.mustache`
+
+Add `{{#int_atom_seeds_lmdb}} ... {{/int_atom_seeds_lmdb}}` blocks that
+parallel the existing `{{#int_atom_seeds}}` blocks (template lines
+129-212), but:
+
+- Open the LMDB env once at startup.
+- Read `meta` and validate `schema_version`.
+- Build `fullInternTable = LmdbBacked ...`.
+- Compute `seedCats` from a `roots` sub-db scan (or `category_parent`
+  key set if the workload's seeds are "all children").
+- Compute `articleCategories` by iterating the `article_category`
+  sub-db.
+- Compute `demandSet` via the LMDB-backed `computeDemandSetLmdb` from
+  `SPECIFICATION §6`.
+
+### 2.3 `wam_haskell_target.pl` option
+
+Add an `int_atom_seeds(lmdb)` option that activates the new mustache
+sections and emits the `lmdb` cabal dep (already conditional via
+`use_lmdb(true)`).
+
+### 2.4 Tests
+
+Extend `tests/test_wam_haskell_target.pl`:
+
+- `test_int_atom_seeds_lmdb_emits_env_open` — generated Main.hs opens
+  the LMDB at startup.
+- `test_int_atom_seeds_lmdb_skips_tsv_load` — generated code does **not**
+  call `loadTsvPairs` when `int_atom_seeds(lmdb)` is set.
+- `test_int_atom_seeds_lmdb_reads_meta` — generated code reads
+  `meta.schema_version`.
+- `test_int_atom_seeds_lmdb_demand_uses_lmdb` — generated demand BFS
+  walks LMDB cursors (asserts the source string).
+
+### 2.5 Acceptance
+
+Tests green. Generated project for a small fixture builds and runs
+end-to-end against a Phase 1 ingester output, with stdout sha matching
+the existing TSV path.
+
+## 3. Phase 3 — wire into matrix bench
+
+**Branch:** `bench/wam-haskell-lmdb-resident`
+
+### 3.1 Extend `prepare_effective_distance_large_scales.py`
+
+After the existing fixture build, call `mysql_stream_lmdb` (or a
+SQLite-input adapter for the SimpleWiki path) to produce
+`data/benchmark/100k_cats/data.mdb`. Verify the LMDB matches the TSVs
+by spot-checking a few edges.
+
+### 3.2 Update `generate_wam_haskell_matrix_benchmark.pl`
+
+When `fact_count >= 50000` and a `data.mdb` exists in the fixture,
+emit `int_atom_seeds(lmdb)` instead of the default TSV path.
+
+### 3.3 Validation
+
+- Scale-300 matrix bench: output sha `70bbc9ffa4cf` (current).
+- 100k_cats default root: output sha matches the current path.
+- 100k_cats `Deaths_by_year` root: output rows count matches.
+
+### 3.4 Acceptance
+
+All matrix bench scales green. New baseline numbers recorded in
+`WAM_PERF_OPTIMIZATION_LOG.md`.
+
+## 4. Phase 4 — measurements
+
+Single sweep at 100k_cats with default and `Deaths_by_year` roots,
+`+RTS -N1/-N2/-N4`, 5 trials each. Compare:
+
+| Metric | TSV path (now) | LMDB-resident |
+|---|---|---|
+| `loadMs` | ? | ? |
+| `setupMs` (intern + parents index) | ? | ? |
+| `query_ms` | 0–17 | should match |
+| `total_ms` | 3.2 s (-N1) | target: < 1 s |
+| Peak RSS | ~600 MB | should drop |
+
+Append the table and a short reading to `WAM_PERF_OPTIMIZATION_LOG.md`
+as Phase L appendix #5.
+
+## 5. Phase 5 — cross-target reuse
+
+Audit WAM-Rust and WAM-Elixir runtimes against the same LMDB layout.
+The Rust target already uses LMDB for its FFI kernel; the Elixir
+target's "lmdb int IDs" path is the closest analogue. If both can
+adopt the same `s2i` / `i2s` / `meta` schema, the ingester serves all
+three without per-target schema branches.
+
+This phase is exploratory; the deliverable is a memo on whether the
+schema needs adjustment to be cross-target, and an issue tracking the
+follow-up rollouts.
+
+## 6. Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| `heed` API changes between minor versions | Pin a specific `heed` version in `Cargo.toml`. |
+| `MDB_INTEGERKEY` incompat with BE bytes | Already chose **not** to use it (`SPECIFICATION §1.7`). |
+| Reserved ID drift between codegen and ingester | Single source of truth: a sidecar text file consumed by both, asserted at runtime via `meta.compile_time_atoms_count`. |
+| Demand-set BFS over LMDB is slow without reverse edges | Phase 1 ships option 1 (build reverse adjacency in memory at startup); option 2 (`--with-reverse-edges` writing a reverse sub-db) is a follow-up if the in-memory build dominates. |
+| Disk size: full enwiki LMDB might not fit a CI cache | Document the size, run small fixtures in CI, run enwiki only locally. |
+| TSV path drift: the kept TSV fallback rots from disuse | Matrix bench keeps a small-scale TSV run alongside the LMDB run; if the TSV path breaks the bench fails. |
+
+## 7. Verification
+
+End-to-end verification at every phase boundary:
+
+1. Phase 1 alone: ingester produces an LMDB whose contents the existing
+   `lmdbRawEdgeLookup` reader can iterate without error.
+2. Phase 2 alone: a hand-built minimal LMDB (no real ingester) drives a
+   generated Haskell binary to correct output on a 10-edge fixture.
+3. Phase 3 alone: the fixture-build pipeline produces a real LMDB at
+   100k_cats and the matrix bench passes.
+4. Phase 4: numbers tighten or hold; no scale-300 sha drift.
+
+If any phase regresses scale-300 sha `70bbc9ffa4cf`, that is the
+phase to debug before moving on.

--- a/docs/design/WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md
+++ b/docs/design/WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md
@@ -1,0 +1,134 @@
+# LMDB-Resident Interning: Philosophy
+
+## Context
+
+After the demand-filter and pre-filter parallelisation work landed (Phase L
+appendix #4 in `WAM_PERF_OPTIMIZATION_LOG.md`), `query_ms` on the
+`100k_cats` fixture collapsed to ~0 ms but `total_ms` plateaued at ~3.2 s.
+That floor is not the WAM interpreter, not the FFI kernel, and not the
+parallel section — it is the sequential **setup** phase: TSV parsing,
+string atom interning, and `IntMap` construction over ~280k pairs.
+
+The current LMDB-backed Main.hs compounds the cost: it parses the TSV
+*and* checks whether `data.mdb` exists. If LMDB is present it skips only
+the LMDB *write*, not the parse and intern-table rebuild. The Int IDs in
+the LMDB file are deterministic only because the input order is
+deterministic — the mapping itself is rebuilt every run.
+
+This document explains why the answer is to make the LMDB **the** intern
+table, not a second copy of data that lives next to it.
+
+## Core principle: the database is the intern table
+
+A persistent integer ID space is exactly the kind of thing a key-value
+store is good at. LMDB already gives us:
+
+- Memory-mapped reads (zero-copy lookups in the hot path).
+- Atomic single-writer transactions (correctness during ingestion).
+- Sub-databases (multiple namespaces in one file).
+- `MDB_APPEND` / `MDB_APPENDDUP` flags (skip B-tree balance for sorted writes).
+
+The previous design treated LMDB as a *cache* of edges that a separate
+Python script populated, with the intern table reconstructed in-process
+on every run. That was not wrong — it was a phase. The lesson is that
+once the consumer trusts the IDs, the intern table belongs in the
+database too.
+
+After this change, the only string ↔ int translation that remains at
+runtime is at the **boundary**: a CLI argument naming a root, and the
+output formatting that turns result IDs back into category names. Both
+are O(rows-of-output), not O(graph-size).
+
+## Why streaming preprocessing
+
+The Wikipedia categorylinks dump is sorted by `cl_from` (it is the
+clustered primary index in MySQL). The existing
+`src/unifyweaver/runtime/rust/mysql_stream/` crate already streams the
+gzipped dump and yields parsed rows. We can intern strings on the fly
+and write Int↔Int edges to LMDB *as they arrive*, with `MDB_APPENDDUP`
+because the keys are already sorted.
+
+That gives us:
+
+- One read of the input dump.
+- No intermediate TSV materialisation.
+- O(unique-strings) memory for the intern map; no edge buffer.
+- Sequential B-tree page writes for both edges and `i2s` (which is also
+  monotonic by construction).
+
+The approach scales from `100k_cats` (~5 MB intern map) to full enwiki
+(~350 MB intern map, ~28 M edges) on a commodity dev box. The
+constraint we are designing against is "preprocessing should not need
+a different machine than the benchmark itself."
+
+## Why Rust, not Haskell, for the ingester
+
+The Haskell side already has a working LMDB binding (`lmdb >= 0.2.5`) and
+could in principle do its own ingestion. We are not extending the
+Haskell binary because:
+
+1. The Rust crate **already exists** and parses the MySQL dump format
+   correctly. Reusing it is one new sink trait and one new Cargo
+   dependency.
+2. Lazy I/O in Haskell makes streaming an attentive engineering exercise
+   (`bytestring`, careful seq, watch for retainers). Rust's eager-by-default
+   model reaches the same answer with less ceremony.
+3. The same preprocessor will eventually feed the WAM-Rust and WAM-Elixir
+   targets. Putting it in Rust gives us a single shared tool. Putting it
+   in Haskell would either fork the logic or force the other targets to
+   call into a Haskell binary.
+
+Doing it in Rust is not a statement that Haskell is bad at this; it is
+a statement that a one-time, single-process preprocessor sits naturally
+in a single-purpose tool.
+
+## Why we keep the TSV path
+
+The string-keyed TSV path stays as a fallback for:
+
+- Small fixtures where ingestion overhead is irrelevant
+  (`benchmark_target_matrix` at scale-300, dev workflows).
+- Tests that need to construct fixtures without LMDB tooling.
+- Targets that have not adopted the LMDB layout yet.
+
+The matrix bench will pick the LMDB-resident path automatically when
+`fact_count` exceeds the existing `use_lmdb(auto)` threshold (50k).
+Below that, the in-process intern-table build is faster than opening a
+file and the difference doesn't matter anyway.
+
+## Demand set: why this design doesn't address it
+
+The demand set is computed at startup by a backward BFS from the root.
+With LMDB-resident edges, that BFS becomes a sequence of LMDB cursor
+walks instead of `IM.lookup` calls. On a memory-mapped LMDB the lookups
+are roughly the same cost as in-memory `IntMap` lookups once the OS
+page cache is warm — and for warm runs (the common case) it is warm by
+construction.
+
+So the demand set stays in memory as a small `IntSet` (typically <100k
+Ints), built at startup by walking the LMDB. No precomputation of
+demand sets per root, no caching strategy. If profiling later shows
+demand-set construction is itself a bottleneck, the right answer is
+either to walk in parallel or to memoise it next to the LMDB — but
+neither is needed up front.
+
+## What this rules out
+
+- **A separate manifest file** living next to the LMDB. The intern map
+  is in the database; there is one file.
+- **An in-process atom intern table that grows at runtime.** The
+  database is read-only after preprocessing. The runtime opens it and
+  performs lookups; it does not mutate the ID space.
+- **Implicit ID assignment by the runtime.** Two binaries reading the
+  same LMDB see exactly the same IDs because the IDs are *in* the LMDB,
+  not derived from input order at runtime.
+
+## Refs
+
+- `WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md` — schema, CLI, runtime contract.
+- `WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md` — phased steps.
+- `WAM_PERF_OPTIMIZATION_LOG.md` — measurements that motivated this work,
+  especially Phase L appendix #4.
+- `src/unifyweaver/runtime/rust/mysql_stream/` — existing Rust parser.
+- `templates/targets/haskell_wam/main.hs.mustache` — existing
+  `int_atom_seeds(true)` mode that this work generalises.

--- a/docs/design/WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md
+++ b/docs/design/WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md
@@ -1,0 +1,259 @@
+# LMDB-Resident Interning: Specification
+
+This document describes the technical shape of the LMDB-resident
+interning design. For *why* each decision, see
+`WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md`. For the rollout sequence,
+see `WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md`.
+
+## 1. LMDB layout
+
+A single `data.mdb` file (LMDB environment) with the following
+sub-databases. All Int IDs are unsigned 32-bit, big-endian on disk
+(matches the existing `lmdbRawEdgeLookup` packed-binary convention in
+`templates/targets/haskell_wam/lmdb_fact_source.hs.mustache`).
+
+### 1.1 `meta` (named sub-db)
+
+Plain key-value, no `MDB_DUPSORT`. ASCII keys, fixed-shape values.
+
+| Key | Value | Purpose |
+|---|---|---|
+| `schema_version` | uint32 BE | Currently `1`. Bumped on incompatible layout change. |
+| `next_id` | uint32 BE | The next ID the ingester will allocate. Read-only at runtime. |
+| `compile_time_atoms_count` | uint32 BE | Number of reserved well-known IDs at the low end. |
+| `source_dump_sha256` | 64 ASCII hex bytes | SHA-256 of the input dump. Detects "did the input change?" |
+| `build_timestamp` | ASCII ISO-8601 | When the file was created. Diagnostic only. |
+| `cli_args` | ASCII | The exact CLI invocation. Diagnostic only. |
+
+### 1.2 `s2i` (named sub-db)
+
+String → Int.
+
+- Key: UTF-8 bytes of the atom string.
+- Value: uint32 BE.
+- No dupsort.
+- Sorted by string lexicographically (LMDB default `MDB_NOOVERWRITE` ordering).
+
+The ingester writes this sub-db **after** the streaming pass, by
+sorting the in-memory `HashMap<String, u32>` by string and bulk-loading
+with `MDB_APPEND`. Before the bulk load the sub-db must be empty.
+
+### 1.3 `i2s` (named sub-db)
+
+Int → String.
+
+- Key: uint32 BE.
+- Value: UTF-8 bytes.
+- No dupsort.
+- Sorted by Int (monotonically by construction during ingestion).
+
+The ingester writes this sub-db **during** the streaming pass with
+`MDB_APPEND` because IDs are allocated monotonically.
+
+### 1.4 `category_parent` (named sub-db, dupsort)
+
+Int → Int (one-to-many).
+
+- Key: uint32 BE (child ID).
+- Value: uint32 BE (parent ID).
+- `MDB_DUPSORT` + `MDB_INTEGERKEY` + `MDB_INTEGERDUP` (or fixed-size
+  surrogates if `MDB_INTEGERKEY` proves incompatible with packed BE; see
+  §1.7).
+- Sorted by (child, parent).
+
+The ingester writes this with `MDB_APPEND` + `MDB_APPENDDUP` because
+the categorylinks dump is sorted by `cl_from` and the parser yields
+rows in input order.
+
+### 1.5 `article_category` (named sub-db, dupsort)
+
+Int → Int (one-to-many).
+
+- Same shape as `category_parent`.
+- Required for the per-article aggregation step in
+  `effective_distance` style queries.
+- Optional in deployments that only need pure category-graph queries;
+  ingester accepts a `--no-articles` flag.
+
+### 1.6 `roots` (named sub-db)
+
+Int set, stored as keys with empty values.
+
+- Key: uint32 BE.
+- Value: empty bytes.
+- Sorted by Int.
+
+Carries the set of "true root" categories that the runtime may use
+when no root is specified on the CLI. Optional; the runtime still
+accepts a `--root <name>` argument that is resolved via `s2i`.
+
+### 1.7 Endianness and `MDB_INTEGERKEY`
+
+LMDB's `MDB_INTEGERKEY` requires native-endian integer keys. The
+existing Haskell `lmdbRawEdgeLookup` already uses **big-endian** packed
+binary so cross-platform reads work. We keep that convention and do
+**not** set `MDB_INTEGERKEY` on integer-keyed sub-dbs; LMDB sorts BE
+integers correctly via byte-wise comparison. This loses a small
+optimisation in LMDB's key comparator but keeps the existing Haskell
+reader unchanged.
+
+## 2. Reserved ID range
+
+IDs `0`..`compile_time_atoms_count - 1` are reserved for compile-time
+well-known atoms (`[]`, `.`, `true`, `fail`, etc.). The Prolog codegen
+emits `compileTimeAtomTable` with these IDs at fixed positions. The
+ingester:
+
+1. Reads `compile_time_atoms_count` from a sidecar file or CLI flag
+   (must match the codegen).
+2. Pre-populates `s2i` and `i2s` with the well-known atoms at those IDs.
+3. Sets `next_id` to `compile_time_atoms_count`.
+4. Streams the dump, allocating IDs from `next_id` upward.
+
+If a runtime atom string collides with a reserved well-known atom (e.g.
+a category literally named `"true"`), the existing well-known ID is
+returned; no new ID is allocated. This is the same contract
+`internAtom` already enforces in-process.
+
+## 3. CLI contract
+
+A new binary in the existing `mysql_stream` crate (or a sibling crate
+re-exporting the parser):
+
+```
+mysql_stream_lmdb \
+  --output PATH \
+  [--cols CHILD,PARENT] \
+  [--filter COL=VALUE] \
+  [--articles-cols COL,COL --articles-filter COL=VALUE] \
+  [--articles] \
+  [--compile-time-atoms FILE.txt] \
+  [--map-size BYTES] \
+  [--no-articles] \
+  [--source-sha PRECOMPUTED_SHA] \
+  INPUT.sql.gz
+```
+
+- `--cols 0,1` selects (child, parent) column indices in the categorylinks
+  rows. Defaults are tuned for the SimpleWiki / enwiki categorylinks
+  schema: `cl_from` and `cl_to`.
+- `--filter 2=subcat` keeps only rows where column index 2 (i.e.
+  `cl_type`) equals `subcat`. Multiple `--filter` flags AND together.
+- `--compile-time-atoms` is a one-line-per-atom text file aligned with
+  the codegen's compile-time table.
+- `--map-size` is the LMDB env max size in bytes. The default is large
+  enough for full enwiki; the user can shrink it for small fixtures.
+- `--source-sha`, if provided, is written to `meta.source_dump_sha256`
+  verbatim. If omitted the binary computes it while streaming.
+
+The binary writes the LMDB at `--output`. If the directory exists and
+`meta.schema_version` matches, the binary is idempotent: it exits
+non-zero with a diagnostic unless `--force` is given.
+
+## 4. Runtime contract
+
+A new emit-mode in `wam_haskell_target.pl` — call it
+`int_atom_seeds(lmdb)` (extending the existing `int_atom_seeds(true)`).
+The generated `Main.hs`:
+
+1. Opens the LMDB env at `factsDir ++ "/data.mdb"`. Reads
+   `meta.schema_version`; bails if it doesn't match the codegen.
+2. Reads `meta.compile_time_atoms_count`. Asserts it equals the codegen's
+   compile-time atom count.
+3. Builds `fullInternTable` directly from the `i2s` sub-db. The
+   resulting `InternTable` is a thin wrapper: `iAtom` becomes a wrapper
+   around `mdb_get s2i`, and the reverse lookup is `mdb_get i2s`. Both
+   are O(log n) page walks on a memory-mapped file.
+4. Resolves the root from the CLI argument via `s2i`.
+5. Computes `seedCats` and `articleCategories` by scanning the
+   `roots` sub-db (or the LMDB key set of `category_parent` if the
+   workload's seeds are "all categories that are children").
+6. Computes `demandSet` by backward BFS from `rootId` over LMDB cursor
+   walks of `category_parent`.
+7. Filters seeds via `filteredSeedCats = filter (IS.member . iAtom) seedCats`
+   exactly as today.
+8. Runs `parMap rdeepseq` over `filteredSeedCats`.
+9. At output time, looks up each result Int via `i2s`.
+
+The hot path performs LMDB lookups, not in-memory `IntMap` lookups. On
+warm runs the OS page cache absorbs the lookups; on cold runs the
+mmap'd page faults pull pages on demand. Both are faster than parsing
+TSV strings.
+
+## 5. Atom intern table representation
+
+```haskell
+data InternTable
+  = InMemory { itForward :: !(Map.Map String Int)
+             , itReverse :: !(IM.IntMap String)
+             , itSize    :: !Int
+             }
+  | LmdbBacked { itEnv :: !MDB.Environment
+               , itS2i :: !MDB.Database
+               , itI2s :: !MDB.Database
+               , itSize :: !Int  -- read once from meta.next_id
+               }
+```
+
+`internAtom :: InternTable -> String -> Int`,
+`lookupAtom :: InternTable -> Int -> String`, and
+`displayValue` continue to work without callers caring which constructor
+they are using. The compile-time atoms (IDs 0..N-1) are still in
+`compileTimeAtomTable` and are checked first; only a miss falls through
+to the LMDB lookup.
+
+## 6. Demand set construction protocol
+
+Given a memory-mapped LMDB `category_parent` and a target `rootId`, the
+demand set is the backward-reachable set:
+
+```haskell
+computeDemandSetLmdb :: EdgeLookup -> Int -> IO IS.IntSet
+computeDemandSetLmdb edges rootId = bfs (IS.singleton rootId) (IS.singleton rootId)
+  where
+    bfs visited frontier
+      | IS.null frontier = return visited
+      | otherwise = do
+          children <- forM (IS.toList frontier) $ \nodeId ->
+            edgesReverseLookup edges nodeId  -- list of children pointing here
+          let newFrontier = IS.fromList (concat children) `IS.difference` visited
+          bfs (IS.union visited newFrontier) newFrontier
+```
+
+The implementation requires a *reverse* edge lookup. Two options:
+
+1. **Walk forward edges**: for each `(child, parent)` in the LMDB,
+   accumulate `parent → [child]` in memory. O(edges) once at startup,
+   matches the current `reverseAdj` IntMap construction. Acceptable for
+   ≤ 1 M edges.
+2. **Add a reverse sub-db** `parent_category` during ingestion. Pure
+   space cost on disk (~2× the forward edge size). Removes the startup
+   cost.
+
+Option 1 is the default for v1; option 2 is gated behind a
+`--with-reverse-edges` flag on the ingester. Either way the runtime
+sees the same `EdgeLookup` interface.
+
+## 7. Compatibility with existing `int_atom_seeds(true)`
+
+The current `int_atom_seeds(true)` mode reads `seed_ids.txt` and
+`root_ids.txt` from disk. It stays as-is. The new
+`int_atom_seeds(lmdb)` mode supersedes it for fixtures that come with a
+preprocessed LMDB; the old mode remains for hand-prepared int-id
+files.
+
+The two modes share the same downstream code (everything from
+`fullInternTable` onward in `Main.hs`); they differ only in how they
+populate it.
+
+## 8. Output sha equivalence
+
+The ingester is a deterministic function of the input dump (modulo
+`build_timestamp` and `cli_args` which only live in `meta`). Two runs
+of the ingester on the same input produce byte-identical edge,
+`s2i`, and `i2s` sub-dbs.
+
+The Haskell binary's stdout is a deterministic function of the LMDB it
+reads. We require that scale-300 (and any covered scale) produces the
+same `stdout_sha256` as the current TSV-resident path. Any divergence
+is a bug.


### PR DESCRIPTION
  ## Summary

  Three-doc design package for moving atom interning into the LMDB preprocessing artifact, so warm runs skip TSV
  parsing, intern-table rebuild, and IntMap construction entirely. No code changes — design only.

  ## Motivation

  Phase L appendix #4 in `WAM_PERF_OPTIMIZATION_LOG.md` (PR #1882) showed `query_ms` collapse to ~0 ms on `100k_cats`
  after the demand pre-filter, but `total_ms` plateaued at ~3.2 s. That floor is sequential setup: TSV parsing, atom
  interning, and `IntMap` construction over ~280k pairs. None of that should happen on a warm run.

  The existing LMDB-backed Main.hs only skips the LMDB *write* when `data.mdb` exists — it still parses TSV and rebuilds
   the intern table on every run. The Int IDs in LMDB stay deterministic only by accident of input ordering. The fix is
  to put the intern table *in* LMDB and treat the database as the single source of truth.

  ## What's in the package

  - **`WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md`** (134 lines) — why LMDB *is* the intern table (no separate manifest),
   why streaming preprocessing in Rust (categorylinks dump is sorted by `cl_from` so `MDB_APPENDDUP` works in one pass),
   why the demand set stays in memory and is rebuilt at startup via LMDB cursor walks, why we keep the TSV path as a
  small-fixture fallback.
  - **`WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md`** (259 lines) — sub-db schema (`meta`, `s2i`, `i2s`,
  `category_parent`, `article_category`, `roots`), endianness convention (BE bytes, no `MDB_INTEGERKEY` — keeps the
  existing Haskell `lmdbRawEdgeLookup` reader unchanged), reserved-ID range for compile-time atoms, CLI for
  `mysql_stream_lmdb`, runtime contract for the new `int_atom_seeds(lmdb)` mode, demand-set construction protocol with
  the reverse-edge tradeoff explicitly called out.
  - **`WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md`** (212 lines) — five phases (Rust ingester extending the
  existing `mysql_stream` crate via an `IngestSink` trait + `heed`; Haskell template support; matrix-bench wiring;
  measurements; cross-target reuse audit for WAM-Rust and WAM-Elixir), risks table, per-phase verification.

  ## Key design choices documented

  - The new ingester reuses the existing `src/unifyweaver/runtime/rust/mysql_stream/` parser. New work: `IngestSink`
  trait + `LmdbSink` impl + `mysql_stream_lmdb` binary, gated behind a `lmdb-sink` Cargo feature so the existing
  TSV-stdout path keeps zero new compile-time deps by default.
  - Single LMDB file with all sub-dbs (no separate manifest, no on-disk `.tsv` artifacts at runtime). The boundary
  between strings and Ints stays at preprocessing time and at output formatting — never in the hot loop.
  - Reserved ID range `0..compile_time_atoms_count - 1` for compile-time well-known atoms keeps the codegen's
  `compileTimeAtomTable` aligned with the LMDB without runtime synchronization.
  - Demand set remains an in-memory `IntSet` rebuilt at startup. Backward BFS over LMDB cursor walks; on warm runs the
  OS page cache absorbs the lookups. v1 builds reverse adjacency in memory (matching today's `reverseAdj`); a
  `--with-reverse-edges` flag on the ingester is filed as a follow-up if construction itself becomes the bottleneck.
  - The existing `int_atom_seeds(true)` mode is preserved; the new `int_atom_seeds(lmdb)` mode supersedes it for
  fixtures that ship with a preprocessed LMDB.

  ## Test plan

  - [x] Docs render correctly in GitHub's markdown view
  - [x] Cross-references between the three docs and to `WAM_PERF_OPTIMIZATION_LOG.md`, `mysql_stream/`, and
  `main.hs.mustache` resolve
  - [ ] Phase 1 implementation (Rust ingester) lands in a follow-up PR
  - [ ] Phase 2 implementation (Haskell `int_atom_seeds(lmdb)` mode) lands after Phase 1
  - [ ] Scale-300 stdout sha `70bbc9ffa4cf` preserved at every phase boundary

  🤖 Generated with [Claude Code](https://claude.com/claude-code)