### PR TITLE
feat(wam-r): ^/2 existential scope for bagof/setof/findall

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -391,9 +391,13 @@ WamRuntime$run(shared_program, state)
   Removed clauses are matched against the live store by object
   identity, so concurrent retracts/asserts of unrelated clauses
   don't disturb the iteration order.
-- **`bagof/3` / `setof/3`** do not support free-variable witnesses
-  (`X^Goal`). Witness vars are silently aggregated rather than
-  producing one bag per witness.
+- **`bagof/3` / `setof/3` per-witness grouping**. The `^/2`
+  existential scoping operator is supported (the wrapper is
+  transparent in `call_goal` / `iterate_goal` / `call_library`,
+  so `bagof(X, Y^p(X,Y), L)` runs `p(X,Y)` and aggregates X). What
+  isn't supported is the per-witness grouping for non-quantified
+  free vars: `bagof(X, p(X,Y), L)` produces one bag containing
+  every X (regardless of Y) rather than one bag per Y binding.
 - **`length/2` (-, -)** generative mode is not supported (would
   need a CP-driving generator).
 - **`between/3` (+, +, -)** in compiled-goal context produces an
@@ -413,7 +417,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 39 tests covering both structural assertions on the
+and contains 40 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -446,6 +450,7 @@ Coverage map (e2e tests, by feature group):
 | `stdlib_polish_e2e_rscript` | `numlist/3`, `tab/1`, `sub_atom/5`, `char_type/2`, `term_to_atom/2` |
 | `operator_parser_e2e_rscript` | operator-precedence parsing (`+`, `*`, `^`, `=:=`, `\+`, `,`, ...) |
 | `multi_solution_retract_e2e_rscript` | multi-solution `retract/1` via iter-CP |
+| `bagof_setof_existential_e2e_rscript` | `^/2` existential scope in `bagof`/`setof`/`findall` |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -1872,6 +1872,14 @@ WamRuntime$call_goal <- function(program, state, goal_term) {
       identical(WamRuntime$string_of(table, v$fid), ":")) {
     return(WamRuntime$call_goal(program, state, v$args[[2]]))
   }
+  # Unwrap `^/2` existential scope: in `bagof(X, Y^Goal, B)` the
+  # `Y^` is a hint that Y is locally scoped (no per-witness
+  # grouping). Since this scaffold doesn't do per-witness grouping
+  # anyway, the wrapper is transparent for call purposes.
+  if (v$tag == "struct" && length(v$args) == 2L &&
+      identical(WamRuntime$string_of(table, v$fid), "^")) {
+    return(WamRuntime$call_goal(program, state, v$args[[2]]))
+  }
   if (v$tag == "atom") {
     pred <- WamRuntime$string_of(table, v$id)
     return(WamRuntime$dispatch_call(program, state, pred, 0L))
@@ -1937,6 +1945,19 @@ WamRuntime$iterate_goal <- function(program, state, goal_term, on_each) {
   table <- program$intern_table
   v <- WamRuntime$deref(state, goal_term)
   if (is.null(v) || is.null(v$tag)) return(invisible(NULL))
+
+  # Unwrap `Y^Goal` existential scope (and module-qualified
+  # `Module:Goal`) so the inner goal drives iteration directly. The
+  # outer wrapper has no semantic effect on enumeration in this
+  # scaffold (no per-witness grouping for bagof/setof).
+  if (v$tag == "struct" && length(v$args) == 2L &&
+      identical(WamRuntime$string_of(table, v$fid), "^")) {
+    return(WamRuntime$iterate_goal(program, state, v$args[[2]], on_each))
+  }
+  if (v$tag == "struct" && length(v$args) == 2L &&
+      identical(WamRuntime$string_of(table, v$fid), ":")) {
+    return(WamRuntime$iterate_goal(program, state, v$args[[2]], on_each))
+  }
 
   # Conjunction `(A, B)`: iterate A; for each A binding, iterate B.
   if (v$tag == "struct" && length(v$args) == 2L &&
@@ -2416,6 +2437,15 @@ WamRuntime$call_builtin <- function(program, state, pred, arity) {
 WamRuntime$call_library <- function(program, state, pred, arity) {
   table <- program$intern_table
   key <- paste0(pred, "/", arity)
+
+  # ----- ^/2 existential scope -----
+  # When the WAM compiler emits `Y^Goal` as a Call("^", 2), treat
+  # the wrapper as transparent and run Goal. Y is locally scoped
+  # (matches the bagof/setof idiom); we don't do per-witness
+  # grouping, so the wrapper has no further effect.
+  if (key == "^/2") {
+    return(WamRuntime$call_goal(program, state, WamRuntime$get_reg(state, 2L)))
+  }
 
   # ----- maplist/2: apply Goal to each element of List -----
   # Standard semantics: maplist(_, []). maplist(G, [X|Xs]) :- call(G, X),

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -1859,6 +1859,74 @@ e2e_multi_solution_retract_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for `^/2` existential scope in
+% bagof/setof/findall. Asserts a 2-arg dynamic predicate, then
+% drives bagof(X, Y^p(X,Y), L) etc. The `^/2` wrapper should be
+% transparent: all X bindings get aggregated regardless of Y's
+% value. This scaffold doesn't do per-witness grouping, so non-
+% existentially-quantified free vars are also aggregated -- the
+% test only covers the `^`-wrapped case.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(bagof_setof_existential_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_bagof_setof_existential_via_rscript
+    ;   true
+    )).
+
+e2e_bagof_setof_existential_via_rscript :-
+    % bagof + ^/2 over a 2-arg dynamic predicate. Y is existentially
+    % scoped, so all X bindings are collected (with duplicates).
+    assertz((user:be_bagof_basic :-
+        assertz(pp(1, a)), assertz(pp(1, b)), assertz(pp(2, a)),
+        bagof(X, Y^pp(X, Y), L),
+        L == [1, 1, 2])),
+    % setof + ^/2 dedups and sorts.
+    assertz((user:be_setof_basic :-
+        assertz(qq(3, x)), assertz(qq(1, y)), assertz(qq(3, z)),
+        assertz(qq(2, x)),
+        setof(X, Y^qq(X, Y), L),
+        L == [1, 2, 3])),
+    % Nested existentials: Y^Z^Goal unwraps both layers.
+    assertz((user:be_nested_caret :-
+        assertz(rr(1, a, p)), assertz(rr(2, b, q)),
+        assertz(rr(2, c, r)), assertz(rr(1, d, s)),
+        bagof(X, Y^Z^rr(X, Y, Z), L),
+        L == [1, 2, 2, 1])),
+    % findall + ^/2 (compiled aggregate path). findall already
+    % ignores witness scoping; ^/2 must just be transparent.
+    assertz((user:be_findall_caret :-
+        assertz(ss(1, x)), assertz(ss(2, y)), assertz(ss(3, z)),
+        findall(X, Y^ss(X, Y), L),
+        L == [1, 2, 3])),
+    % Empty bag fails (bagof semantics).
+    assertz((user:be_bagof_empty_no :-
+        bagof(X, Y^nonexistent(X, Y), _))),
+    unique_r_tmp_dir('tmp_r_caret_e2e', TmpDir),
+    write_wam_r_project(
+        [ user:be_bagof_basic/0, user:be_setof_basic/0,
+          user:be_nested_caret/0, user:be_findall_caret/0,
+          user:be_bagof_empty_no/0 ],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [be_bagof_basic, be_setof_basic, be_nested_caret,
+           be_findall_caret],
+    No  = [be_bagof_empty_no],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
## Summary

Adds support for the `^/2` existential-scope operator in `bagof`/`setof`/`findall`. The standard idiom

```prolog
bagof(X, Y^p(X,Y), L)
```

used to fail because nothing recognised `^/2` as a goal wrapper -- the compiled-findall path emitted `Call("^", 2)` which fell through to unknown-predicate failure, and the runtime-aggregator path drove the goal via `call_goal` which equally didn't know `^/2`.

`^/2` is now unwrapped (treated as transparent) in three places so all paths benefit:

| Path | Where |
|---|---|
| `call/1` and other meta-calls | `WamRuntime$call_goal` |
| `bagof`/`setof`/`forall` runtime aggregator | `WamRuntime$iterate_goal` |
| compiled `findall(...)` and any other compiled `Call("^", 2)` | `WamRuntime$call_library` |

The arithmetic `^/2` (e.g. `X is 2^3`) is unaffected -- that's evaluated inside `eval_arith`, which has its own struct dispatch.

This scaffold still doesn't do per-witness grouping (`bagof(X, p(X,Y), L)` produces one bag with every X rather than one bag per Y). The doc's limitations note has been updated to reflect what's now supported and what isn't.

## Test plan

- [x] `bagof_setof_existential_e2e_rscript` (new): `bagof + ^`, `setof + ^`, nested `Y^Z^Goal`, `findall + ^`, and an empty-bag-fail case.
- [x] Full suite: 40 tests pass.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_