### PR TITLE
docs(wam): revise LMDB-resident interning design — match existing pipeline + pluggable sinks

### DIFF
--- a/docs/design/WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md
@@ -6,7 +6,7 @@ document records the ordered rollout.
 
 ## 0. Starting point
 
-Current state on `main` after PR #1882:
+Current state on `main` after PR #1882 / #1901:
 
 - `data/benchmark/100k_cats/lmdb_proj/src/Main.hs:131-180` parses two
   TSVs (~280k pairs) and rebuilds the intern table on every run, even
@@ -16,68 +16,104 @@ Current state on `main` after PR #1882:
   `int_atom_seeds(true)` mode that skips TSV loading and reads
   pre-interned int-id files. Used by the enwiki path; not used by the
   matrix bench fixtures.
-- `src/unifyweaver/runtime/rust/mysql_stream/` parses MySQL INSERT
-  dumps and emits TSV to stdout. ~555 lines, well-tested.
+- **`src/unifyweaver/runtime/rust/mysql_stream/`** — Rust parser for
+  MySQL INSERT dumps. ~555 lines, validated against simplewiki (2.2 M
+  rows, byte-exact match to SQLite ground truth, ~28 MB/s gzipped on
+  one core). Schema-agnostic, emits TSV to stdout.
+- **`src/unifyweaver/runtime/python/lmdb_ingest/ingest_to_lmdb.py`** —
+  Python LMDB consumer. ~206 lines. Reads TSV from stdin, writes LMDB
+  with filtering, projection, encoding (`int32_le`), and dupsort. Already
+  in production for the integer-keyed enwiki ingest.
+- **`examples/streaming/enwiki_category_ingest.pl`** — Prolog glue
+  composing the Rust producer and Python consumer.
+- **`examples/streaming/enwiki_category_ingest_awk.pl`** — AWK variant
+  of the parser, demonstrating the one-line `declare_target` swap.
+- **`examples/streaming/enwiki_category_ingest_csharp.pl`** — C#
+  consumer variant.
+- `src/unifyweaver/glue/streaming_glue.pl` — the producer/consumer
+  composer.
 - `examples/benchmark/prepare_effective_distance_large_scales.py` builds
   the `100k_cats` fixture by extracting from a SimpleWiki SQLite db.
 
-## 1. Phase 1 — Rust ingester (`mysql_stream` extension)
+The plan below **extends the existing Python consumer** with text-keyed
+intern support. It does **not** add a new Rust crate or a new LMDB
+binding; the parser stays untouched, and the consumer's existing
+codepath stays the default for the integer-keyed enwiki regime.
 
-**Branch:** `feat/mysql-stream-lmdb-sink`
+## 1. Phase 1 — extend Python consumer with text-keyed intern support
 
-### 1.1 Add `heed` dependency
+**Branch:** `feat/lmdb-ingest-text-keyed-intern`
 
-Edit `src/unifyweaver/runtime/rust/mysql_stream/Cargo.toml` to add
-`heed = "0.20"` (or current stable). Keep it behind a feature flag
-`lmdb-sink` so the existing TSV-stdout path has no new compile-time
-dependency by default.
+The Rust parser stays unchanged. All work in this phase is in
+`src/unifyweaver/runtime/python/lmdb_ingest/ingest_to_lmdb.py` and a
+new Prolog example.
 
-### 1.2 `IngestSink` trait
+### 1.1 New env-var surface
 
-Refactor `iter_mysql_rows` consumers behind a small trait:
+Per `SPECIFICATION §3.2`, add the env vars `UW_INTERN_KEY`,
+`UW_INTERN_VAL`, `UW_LMDB_S2I_DB`, `UW_LMDB_I2S_DB`, `UW_LMDB_META_DB`,
+`UW_LMDB_APPEND`, `UW_COMPILE_TIME_ATOMS`, `UW_SOURCE_SHA`,
+`UW_SCHEMA_VERSION`, `UW_FORCE_REINGEST`. All default off; existing
+behaviour is preserved exactly.
 
-```rust
-pub trait IngestSink {
-    fn on_row(&mut self, row: &[Field]) -> Result<()>;
-    fn finalize(self) -> Result<()>;
-}
-```
+### 1.2 Intern map + sub-db writes
 
-The existing TSV-stdout writer becomes `TsvSink`; the new sink is
-`LmdbSink`. The streaming loop is unchanged.
+When `UW_INTERN_KEY=1` (and/or `UW_INTERN_VAL=1`):
 
-### 1.3 `LmdbSink` implementation
+- Maintain a Python `dict[str, int]` for the in-memory intern map.
+- On each row: look up the string in the dict; if absent, allocate the
+  next ID (starting from `compile_time_atoms_count`), append to `i2s`
+  with `append=True` (IDs are monotonic by construction), and record
+  in the dict.
+- On finalize: sort the dict by key, bulk-load `s2i` with
+  `append=True`. Write `meta` keys. Commit.
 
-New module `src/lmdb_sink.rs` (gated by `lmdb-sink` feature):
+When `UW_LMDB_APPEND=1` and the input is sorted, edge writes use
+`append=True` for the corresponding sub-db.
 
-- Holds a `heed::Env`, the four named databases, an
-  `IndexMap<String, u32>` for the in-memory intern map, and a write
-  txn that is committed in `finalize`.
-- `on_row` extracts (child, parent) per the configured column indices,
-  applies any filters, interns both strings, writes the edge with
-  `MDB_APPENDDUP`, and writes any new `i2s` entries with `MDB_APPEND`.
-- `finalize` sorts the intern map by string and bulk-loads `s2i` with
-  `MDB_APPEND`. Computes / writes `meta` keys. Commits the txn.
+### 1.3 Compile-time atoms sidecar
 
-### 1.4 New binary `mysql_stream_lmdb`
+Read the optional one-atom-per-line file at `UW_COMPILE_TIME_ATOMS`.
+Pre-populate `s2i` and `i2s` at the low IDs (0 .. N-1). Set
+`meta.compile_time_atoms_count = N`. Subsequent runtime atoms get IDs
+starting at N.
 
-Adds `[[bin]]` entry in `Cargo.toml`. CLI per
-`SPECIFICATION §3`. Wraps `iter_mysql_rows` + `LmdbSink`.
+If the input contains a string that collides with a reserved
+compile-time atom (e.g. literal `"true"`), it returns the existing
+reserved ID — no new ID is allocated.
 
-### 1.5 Tests
+### 1.4 Idempotence + reingestion guard
 
-- Unit tests on `LmdbSink`: small fixture (10 rows), check `s2i`,
-  `i2s`, edges, `meta` keys.
-- Round-trip test: run `mysql_stream_lmdb` on a synthetic dump, then a
-  Rust reader iterates the LMDB and reproduces the input edges.
-- Reserved-ID collision test: input dump containing the literal
-  string `"true"`, verify it gets the reserved low ID.
+On startup, if the LMDB exists and has `meta.schema_version` matching
+`UW_SCHEMA_VERSION`, exit with a diagnostic unless
+`UW_FORCE_REINGEST=1`. This prevents accidental double-ingestion
+into a populated database.
 
-### 1.6 Acceptance
+### 1.5 New Prolog example
 
-`cargo test --features lmdb-sink` green. Spike measurement: ingest
-SimpleWiki categorylinks (~280k pairs) end-to-end in well under the
-3.2 s the current Haskell setup phase takes.
+`examples/streaming/simplewiki_category_ingest_text.pl` — same shape
+as `enwiki_category_ingest.pl` but configured for text-keyed input
+(string columns, `UW_INTERN_KEY=1 UW_INTERN_VAL=1`, sub-db names per
+the spec). Producer declaration is unchanged from the enwiki example.
+
+### 1.6 Tests
+
+- Unit test on the consumer with a small synthetic TSV:
+  - Text-keyed input → check `s2i`, `i2s`, edges, `meta` keys.
+  - Reserved-ID collision: input containing the literal string
+    `"true"` → returns the reserved low ID, not a fresh one.
+  - Idempotence: rerun without `UW_FORCE_REINGEST` → exits non-zero
+    with a clear diagnostic.
+- Round-trip test driven by the existing Prolog harness:
+  produce → consume → read back → reconstruct edges → byte-equal.
+
+### 1.7 Acceptance
+
+Tests green. Spike measurement: ingest SimpleWiki categorylinks
+(~280k pairs) end-to-end in well under the 3.2 s the current Haskell
+setup phase takes. The integer-keyed enwiki path keeps producing
+byte-identical LMDB output (no behaviour change when the new env
+vars are unset).
 
 ## 2. Phase 2 — Haskell runtime support (`int_atom_seeds(lmdb)`)
 
@@ -178,23 +214,34 @@ as Phase L appendix #5.
 Audit WAM-Rust and WAM-Elixir runtimes against the same LMDB layout.
 The Rust target already uses LMDB for its FFI kernel; the Elixir
 target's "lmdb int IDs" path is the closest analogue. If both can
-adopt the same `s2i` / `i2s` / `meta` schema, the ingester serves all
+adopt the same `s2i` / `i2s` / `meta` schema, the consumer serves all
 three without per-target schema branches.
 
-This phase is exploratory; the deliverable is a memo on whether the
-schema needs adjustment to be cross-target, and an issue tracking the
-follow-up rollouts.
+The Python consumer is already shared across the C# and AWK pipeline
+variants (via the streaming-glue layer), so cross-target reuse is the
+default rather than the exception. This phase is exploratory: the
+deliverable is a memo confirming the schema needs no per-target
+adjustment, plus issues tracking the rollout to WAM-Rust and
+WAM-Elixir.
+
+### 5.1 Optional follow-up: parser-language extension
+
+The current parser variants are Rust (canonical for benchmarks) and
+AWK. If a deployment ever needs a Haskell-language parser (e.g. for
+single-binary distribution), it slots into the same `declare_target`
+shape. This is **not** in scope for this implementation arc; it is
+documented here so the option is preserved if the need arises.
 
 ## 6. Risks
 
 | Risk | Mitigation |
 |------|-----------|
-| `heed` API changes between minor versions | Pin a specific `heed` version in `Cargo.toml`. |
-| `MDB_INTEGERKEY` incompat with BE bytes | Already chose **not** to use it (`SPECIFICATION §1.7`). |
-| Reserved ID drift between codegen and ingester | Single source of truth: a sidecar text file consumed by both, asserted at runtime via `meta.compile_time_atoms_count`. |
-| Demand-set BFS over LMDB is slow without reverse edges | Phase 1 ships option 1 (build reverse adjacency in memory at startup); option 2 (`--with-reverse-edges` writing a reverse sub-db) is a follow-up if the in-memory build dominates. |
+| Reserved ID drift between codegen and consumer | Single source of truth: the `UW_COMPILE_TIME_ATOMS` sidecar file consumed by the Python consumer, asserted at runtime via `meta.compile_time_atoms_count`. |
+| Demand-set BFS over LMDB is slow without reverse edges | Phase 2 ships option 1 (build reverse adjacency in memory at startup); option 2 (write a reverse sub-db at ingestion time) is a follow-up if the in-memory build dominates. |
 | Disk size: full enwiki LMDB might not fit a CI cache | Document the size, run small fixtures in CI, run enwiki only locally. |
 | TSV path drift: the kept TSV fallback rots from disuse | Matrix bench keeps a small-scale TSV run alongside the LMDB run; if the TSV path breaks the bench fails. |
+| Python `lmdb` package's `append=True` rejects unsorted keys | The streaming pass writes `i2s` in monotonic ID order (always sorted) and writes edges in input-order (sorted by `cl_from` for categorylinks); `s2i` is bulk-loaded after sort at finalize. |
+| Parser-cost variation contaminating benchmarks | Benchmark harness fixes the parser to Rust via `declare_target`; pluggable-parser property exists but is not exercised in the perf path. |
 
 ## 7. Verification
 

--- a/docs/design/WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md
+++ b/docs/design/WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md
@@ -39,19 +39,41 @@ runtime is at the **boundary**: a CLI argument naming a root, and the
 output formatting that turns result IDs back into category names. Both
 are O(rows-of-output), not O(graph-size).
 
+## Two regimes: integer-keyed vs text-keyed
+
+The MySQL dumps we consume have two distinct shapes, and they motivate
+different handling:
+
+- **Integer-keyed (enwiki categorylinks)**: the relevant columns are
+  `cl_from` (the source page's MediaWiki `page_id`, an int32) and
+  `cl_target_id` (the target category's `page_id`, also int32).
+  *MediaWiki has already done the interning.* The pipeline writes
+  Int → Int edges directly. No `s2i` / `i2s` intern table is needed at
+  this layer; the upstream identifier *is* the canonical ID.
+- **Text-keyed (SimpleWiki-derived `100k_cats` / `50k_cats`)**: the
+  fixture build extracts category names as strings, with no
+  pre-assigned integer IDs. The pipeline must intern as it ingests.
+  The intern table belongs in the same LMDB file as the edges.
+
+The current production path covers the integer-keyed regime correctly
+(see "What already exists" below). The work this document motivates is
+adding text-keyed support without disturbing the existing path.
+
 ## Why streaming preprocessing
 
 The Wikipedia categorylinks dump is sorted by `cl_from` (it is the
 clustered primary index in MySQL). The existing
 `src/unifyweaver/runtime/rust/mysql_stream/` crate already streams the
-gzipped dump and yields parsed rows. We can intern strings on the fly
-and write Int↔Int edges to LMDB *as they arrive*, with `MDB_APPENDDUP`
-because the keys are already sorted.
+gzipped dump and yields parsed rows. The existing Python consumer
+already writes Int → Int edges with `MDB_DUPSORT`. The text-keyed
+extension reuses the same streaming pattern: intern strings on the fly
+and write Int↔Int edges *as they arrive*, with `MDB_APPENDDUP` because
+the keys are already sorted.
 
 That gives us:
 
 - One read of the input dump.
-- No intermediate TSV materialisation.
+- No intermediate TSV materialisation beyond the existing producer→consumer pipe.
 - O(unique-strings) memory for the intern map; no edge buffer.
 - Sequential B-tree page writes for both edges and `i2s` (which is also
   monotonic by construction).
@@ -61,26 +83,118 @@ The approach scales from `100k_cats` (~5 MB intern map) to full enwiki
 constraint we are designing against is "preprocessing should not need
 a different machine than the benchmark itself."
 
-## Why Rust, not Haskell, for the ingester
+## What already exists
 
-The Haskell side already has a working LMDB binding (`lmdb >= 0.2.5`) and
-could in principle do its own ingestion. We are not extending the
-Haskell binary because:
+This is **not** a green-field project. The streaming pipeline is in
+production for the integer-keyed enwiki path:
 
-1. The Rust crate **already exists** and parses the MySQL dump format
-   correctly. Reusing it is one new sink trait and one new Cargo
-   dependency.
-2. Lazy I/O in Haskell makes streaming an attentive engineering exercise
-   (`bytestring`, careful seq, watch for retainers). Rust's eager-by-default
-   model reaches the same answer with less ceremony.
-3. The same preprocessor will eventually feed the WAM-Rust and WAM-Elixir
-   targets. Putting it in Rust gives us a single shared tool. Putting it
-   in Haskell would either fork the logic or force the other targets to
-   call into a Haskell binary.
+- `src/unifyweaver/runtime/rust/mysql_stream/` — the Rust parser. ~555
+  lines, validated against simplewiki (2.2 M rows, byte-exact match to
+  the SQLite ground truth, ~28 MB/s gzipped on one core).
+- `src/unifyweaver/runtime/python/lmdb_ingest/ingest_to_lmdb.py` — the
+  Python consumer. ~206 lines. Reads TSV from stdin, writes LMDB.
+  Already handles filtering (`UW_FILTER_COL=4 UW_FILTER_VAL=subcat`),
+  column projection (`UW_KEY_COL=0 UW_VAL_COL=6`), encoding
+  (`int32_le`), and dupsort (`UW_LMDB_DUPSORT=1`).
+- `examples/streaming/enwiki_category_ingest.pl` — the Prolog glue
+  composing producer + consumer.
+- AWK and C# consumer variants live alongside (`enwiki_category_ingest_awk.pl`,
+  `enwiki_category_ingest_csharp.pl`), demonstrating the pluggable
+  shape — see "Pluggable parsers" below.
 
-Doing it in Rust is not a statement that Haskell is bad at this; it is
-a statement that a one-time, single-process preprocessor sits naturally
-in a single-purpose tool.
+The text-keyed extension is small relative to this surface: extend the
+Python consumer to optionally write `s2i` / `i2s` / `meta` sub-dbs when
+the producer is configured for text-keyed input, plus add `MDB_APPEND`
+flags when the input is sorted. No new Rust crate, no new dependency
+on `heed`; the Python `lmdb` package already supports both `append=True`
+and named sub-dbs.
+
+## Pluggable parsers — but Rust is canonical for benchmarks
+
+The streaming-glue layer (`src/unifyweaver/glue/streaming_glue.pl`)
+treats the parser as a declaratively-selected target. The same Prolog
+pipeline runs unchanged whether the producer is the Rust crate or an
+AWK script:
+
+```prolog
+% Rust:
+:- declare_target(parse_mysql_rows/2, rust,
+                  [leaf(true), native_crate(mysql_stream)]).
+
+% AWK (one-line swap):
+:- declare_target(parse_mysql_rows/2, awk,
+                  [leaf(true),
+                   script_path('src/.../parse_inserts.awk'),
+                   input_filter(zcat),
+                   awk_exec(gawk)]).
+```
+
+The AWK and C# variants already exist; a Haskell variant would slot
+into the same pattern. **For performance benchmarking we deliberately
+fix the parser to Rust** so the preprocessing cost is constant across
+query targets. The query target is what we are measuring; the parser
+is upstream of the measurement and any variation in its cost would
+contaminate the comparison.
+
+The pluggable-parser property is preserved in the design, but it is
+not exercised in the perf path. Other deployments (a developer
+sketching a new ingest with AWK; a customer who can't ship a Rust
+binary) keep the option without paying for it.
+
+## Why Python (not Rust) for the LMDB sink — for now
+
+The existing consumer is `ingest_to_lmdb.py`, and that is where the new
+intern-table writing belongs **for the current arc**. The Haskell side
+already has a working LMDB binding (`lmdb >= 0.2.5`), and we could in
+principle have written the LMDB sink in Rust or extended the Haskell
+binary. We are not, today, because:
+
+1. The Python sink **already exists** and already handles the writing
+   side correctly (filter, project, dupsort, batched txns). Extending
+   it adds named sub-dbs and `MDB_APPEND` — both supported by the
+   Python `lmdb` package. No new language and no new dependency.
+2. Lazy I/O in Haskell makes streaming an attentive engineering
+   exercise (`bytestring`, careful seq, watch for retainers). The
+   Python `lmdb` package's eager-by-default model reaches the same
+   answer with less ceremony.
+3. The same consumer feeds the WAM-Rust and WAM-Elixir backends today.
+   Keeping the sink in Python means one shared tool, not three.
+
+This is not a statement that Haskell is bad at this; it is a statement
+that the one-time, single-process consumer sits naturally where it
+already lives.
+
+### Pluggable sinks mirror pluggable parsers
+
+The pluggable-parser property has a symmetric pluggable-sink property
+that we explicitly preserve. The `streaming_glue` layer treats both
+endpoints the same way:
+
+```prolog
+% Today (Python sink — fast enough):
+:- declare_target(ingest_to_lmdb/3, python,
+                  [leaf(true),
+                   script_path('src/.../ingest_to_lmdb.py'),
+                   pip_packages([lmdb])]).
+
+% Future (one-line swap to a Rust-direct-LMDB sink, no Python in the loop):
+:- declare_target(ingest_to_lmdb/3, rust,
+                  [leaf(true),
+                   native_crate(lmdb_sink)]).
+```
+
+A Rust-native sink would skip the producer→consumer pipe entirely
+(linking the parser and writer in-process) and avoid TSV serialisation
+between the two stages. We are choosing not to build it now because
+the current bottleneck is in the Haskell *runtime*, not in
+preprocessing throughput — but the door is left open as a one-line
+Prolog change. Same pattern, same guarantees.
+
+The directional principle is: **language choice for any pipeline stage
+is a declarative concern, not an architectural one.** This is true
+today for the parser (Rust canonical, AWK alternate, Haskell
+hypothetical) and remains true for the sink (Python today, Rust later
+if and only if we measure the producer→consumer pipe as a real cost).
 
 ## Why we keep the TSV path
 
@@ -129,6 +243,17 @@ neither is needed up front.
 - `WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md` — phased steps.
 - `WAM_PERF_OPTIMIZATION_LOG.md` — measurements that motivated this work,
   especially Phase L appendix #4.
-- `src/unifyweaver/runtime/rust/mysql_stream/` — existing Rust parser.
+- `src/unifyweaver/runtime/rust/mysql_stream/` — Rust parser (canonical
+  for benchmarks).
+- `src/unifyweaver/runtime/python/lmdb_ingest/ingest_to_lmdb.py` —
+  Python LMDB consumer that the text-keyed extension lives in.
+- `examples/streaming/enwiki_category_ingest.pl` — production Prolog
+  glue using the Rust parser.
+- `examples/streaming/enwiki_category_ingest_awk.pl` — AWK variant,
+  demonstrating the one-line parser swap.
+- `examples/streaming/enwiki_category_ingest_csharp.pl` — C# consumer
+  variant.
+- `src/unifyweaver/glue/streaming_glue.pl` — the declarative
+  producer/consumer composer.
 - `templates/targets/haskell_wam/main.hs.mustache` — existing
   `int_atom_seeds(true)` mode that this work generalises.

--- a/docs/design/WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md
+++ b/docs/design/WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md
@@ -115,40 +115,101 @@ a category literally named `"true"`), the existing well-known ID is
 returned; no new ID is allocated. This is the same contract
 `internAtom` already enforces in-process.
 
-## 3. CLI contract
+## 3. Pipeline composition contract
 
-A new binary in the existing `mysql_stream` crate (or a sibling crate
-re-exporting the parser):
+The pipeline is **already in production** for integer-keyed enwiki
+ingestion. The text-keyed extension reuses the same composition; only
+the consumer's environment changes.
 
-```
-mysql_stream_lmdb \
-  --output PATH \
-  [--cols CHILD,PARENT] \
-  [--filter COL=VALUE] \
-  [--articles-cols COL,COL --articles-filter COL=VALUE] \
-  [--articles] \
-  [--compile-time-atoms FILE.txt] \
-  [--map-size BYTES] \
-  [--no-articles] \
-  [--source-sha PRECOMPUTED_SHA] \
-  INPUT.sql.gz
+### 3.1 Producer (parser) — pluggable, Rust is canonical
+
+The streaming-glue layer (`src/unifyweaver/glue/streaming_glue.pl`)
+selects the parser declaratively:
+
+```prolog
+:- declare_target(parse_mysql_rows/2, rust,
+                  [leaf(true), native_crate(mysql_stream)]).
 ```
 
-- `--cols 0,1` selects (child, parent) column indices in the categorylinks
-  rows. Defaults are tuned for the SimpleWiki / enwiki categorylinks
-  schema: `cl_from` and `cl_to`.
-- `--filter 2=subcat` keeps only rows where column index 2 (i.e.
-  `cl_type`) equals `subcat`. Multiple `--filter` flags AND together.
-- `--compile-time-atoms` is a one-line-per-atom text file aligned with
-  the codegen's compile-time table.
-- `--map-size` is the LMDB env max size in bytes. The default is large
-  enough for full enwiki; the user can shrink it for small fixtures.
-- `--source-sha`, if provided, is written to `meta.source_dump_sha256`
-  verbatim. If omitted the binary computes it while streaming.
+Swapping to AWK is a one-line change to `declare_target`. A Haskell
+variant would slot in identically; it has not been written yet.
 
-The binary writes the LMDB at `--output`. If the directory exists and
-`meta.schema_version` matches, the binary is idempotent: it exits
-non-zero with a diagnostic unless `--force` is given.
+**For benchmarking we fix the parser to Rust.** Preprocessing cost
+must be constant across query-target measurements; varying the parser
+contaminates the comparison. The pluggable-parser property exists for
+deployments and one-off experiments; it does not appear in the
+benchmark harness.
+
+### 3.2 Consumer (LMDB sink) — pluggable, Python is canonical for now
+
+The consumer is also selected via `declare_target`. The current
+production sink is `ingest_to_lmdb.py`; an alternate Rust-native sink
+that links the parser and writer in-process would be a one-line
+Prolog swap:
+
+```prolog
+% Today:
+:- declare_target(ingest_to_lmdb/3, python,
+                  [leaf(true),
+                   script_path('src/.../ingest_to_lmdb.py'),
+                   pip_packages([lmdb])]).
+
+% Future (Rust-native, no producer→consumer pipe):
+:- declare_target(ingest_to_lmdb/3, rust,
+                  [leaf(true),
+                   native_crate(lmdb_sink)]).
+```
+
+This implementation arc extends the Python sink only. Building a
+Rust-native sink is deferred until profiling shows the producer→consumer
+pipe is itself a meaningful cost. The contract below describes the
+Python extension; the Rust alternative would honour the same env-var
+semantics and produce byte-identical LMDB output.
+
+### 3.2.1 Python sink env-var surface
+
+The existing consumer at
+`src/unifyweaver/runtime/python/lmdb_ingest/ingest_to_lmdb.py` already
+handles the integer-keyed regime via env vars:
+
+```
+UW_LMDB_PATH=/path/to/data.mdb
+UW_FILTER_COL=4 UW_FILTER_VAL=subcat
+UW_KEY_COL=0 UW_VAL_COL=6
+UW_KEY_ENCODING=int32_le UW_VAL_ENCODING=int32_le
+UW_LMDB_DUPSORT=1
+UW_BATCH_SIZE=50000
+```
+
+The text-keyed regime adds the following env vars on top of the
+existing set; behaviour is fully backward-compatible (when these are
+unset the consumer behaves exactly as today):
+
+| Env var | Purpose |
+|---|---|
+| `UW_INTERN_KEY=1` | Intern key column; write to `s2i` / `i2s` sub-dbs; output is the assigned Int. |
+| `UW_INTERN_VAL=1` | Intern value column; same. |
+| `UW_LMDB_EDGES_DB=category_parent` | Named sub-db for edge writes (default `category_parent`). |
+| `UW_LMDB_S2I_DB=s2i` | Named sub-db for forward intern map. |
+| `UW_LMDB_I2S_DB=i2s` | Named sub-db for reverse intern map. |
+| `UW_LMDB_META_DB=meta` | Named sub-db for metadata keys. |
+| `UW_LMDB_APPEND=1` | Use `append=True` on edge writes (only when input is sorted). |
+| `UW_COMPILE_TIME_ATOMS=PATH` | Sidecar file pre-populating low IDs (see §2). |
+| `UW_SOURCE_SHA=...` | Recorded in `meta.source_dump_sha256`. |
+| `UW_SCHEMA_VERSION=1` | Recorded in `meta.schema_version`. |
+
+The consumer is idempotent: if `meta.schema_version` matches the env
+and the LMDB is non-empty, it exits with a diagnostic unless
+`UW_FORCE_REINGEST=1`.
+
+### 3.3 Prolog glue surface
+
+A new example
+`examples/streaming/simplewiki_category_ingest_text.pl` mirrors the
+existing `enwiki_category_ingest.pl` but sets `UW_INTERN_KEY=1`,
+`UW_INTERN_VAL=1`, and the appropriate sub-db names. The producer
+declaration is unchanged. The consumer declaration is unchanged
+(same script path; only env differs).
 
 ## 4. Runtime contract
 
@@ -237,14 +298,26 @@ sees the same `EdgeLookup` interface.
 ## 7. Compatibility with existing `int_atom_seeds(true)`
 
 The current `int_atom_seeds(true)` mode reads `seed_ids.txt` and
-`root_ids.txt` from disk. It stays as-is. The new
-`int_atom_seeds(lmdb)` mode supersedes it for fixtures that come with a
-preprocessed LMDB; the old mode remains for hand-prepared int-id
-files.
+`root_ids.txt` from disk and is used by the enwiki integer-keyed
+pipeline. It stays as-is. The new `int_atom_seeds(lmdb)` mode
+supersedes it for fixtures that come with a preprocessed LMDB; the
+old mode remains for hand-prepared int-id files.
 
 The two modes share the same downstream code (everything from
 `fullInternTable` onward in `Main.hs`); they differ only in how they
 populate it.
+
+### 7.1 Regime selection
+
+| Fixture shape | Producer | Consumer env | Runtime mode |
+|---|---|---|---|
+| Integer-keyed (enwiki) | `mysql_stream` (Rust) | int32_le keys, no intern | `int_atom_seeds(true)` reading `seed_ids.txt` |
+| Text-keyed (100k_cats) | `mysql_stream` (Rust) | `UW_INTERN_KEY=1 UW_INTERN_VAL=1` | `int_atom_seeds(lmdb)` reading from `s2i`/`i2s` |
+| Small TSV (dev / scale-300) | n/a (TSV is the input) | n/a | TSV path (current default) |
+
+The matrix bench picks the regime based on input shape and
+`fact_count`. The TSV path stays as a fallback for small fixtures
+where preprocessing overhead is irrelevant.
 
 ## 8. Output sha equivalence
 


### PR DESCRIPTION
  ## Summary

  Revises the design package landed in #1901 to match the production streaming pipeline that already exists, and to make
   the pluggable-sink property symmetric with the pluggable-parser one. No code changes — design revisions only.

  ## Why

  The original design package (#1901) described Phase 1 as a new Rust LMDB sink built on `mysql_stream` + `heed`. That
  over-scoped the work: the production pipeline already pairs the Rust parser
  (`src/unifyweaver/runtime/rust/mysql_stream/`) with a Python LMDB consumer
  (`src/unifyweaver/runtime/python/lmdb_ingest/ingest_to_lmdb.py`) that already handles filtering, projection,
  `int32_le` encoding, dupsort, and batched txns. The text-keyed extension is a small addition to the existing Python
  sink, not a new Rust crate.

  There are also AWK and C# pipeline variants alongside the Rust one, demonstrating the existing
  declarative-language-choice pattern via `declare_target` in the streaming-glue layer. The original docs glossed over
  this; the revision makes it first-class.

  ## What changed

  ### `WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md`

  - **New "Two regimes" section** — integer-keyed (enwiki: MediaWiki `page_id` is already the canonical ID, no intern
  table needed) vs. text-keyed (`100k_cats`: SimpleWiki-derived strings need interning). The new work targets the
  text-keyed regime; the integer-keyed path stays exactly as-is.
  - **New "What already exists" inventory** — Rust parser, Python consumer, Prolog glue, AWK + C# variants, with line
  counts and the validated throughput number (28 MB/s gzipped, byte-exact match to SQLite ground truth on simplewiki's
  2.2M rows).
  - **New "Pluggable parsers — but Rust is canonical for benchmarks"** — parser language is declaratively selected via
  `declare_target` (one-line swap between Rust and AWK already exists in `enwiki_category_ingest_awk.pl`). Benchmarks
  deliberately pin the parser to Rust so preprocessing cost is constant across query-target measurements.
  - **New "Pluggable sinks mirror pluggable parsers"** — Python sink today (fast enough), Rust-direct-LMDB sink is a
  one-line `declare_target` swap if/when profiling shows the producer→consumer pipe is a real cost. Includes the
  directional principle: *language choice for any pipeline stage is a declarative concern, not an architectural one.*
  - **"Why Rust, not Haskell, for the ingester"** → **"Why Python (not Rust) for the LMDB sink — for now"** — reflects
  current pipeline reality, frames the choice as deferred-not-rejected.

  ### `WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md`

  - **Replaces §3 "CLI contract"** with **"Pipeline composition contract"** — describes the producer/consumer
  declarative split, the canonical-parser-for-benchmarks convention, the pluggable-sink property, and the env-var
  surface for extending `ingest_to_lmdb.py` rather than a fictional new Rust binary.
  - **§3.2 documents the new env vars** — `UW_INTERN_KEY`, `UW_INTERN_VAL`, `UW_LMDB_S2I_DB`, `UW_LMDB_I2S_DB`,
  `UW_LMDB_META_DB`, `UW_LMDB_APPEND`, `UW_COMPILE_TIME_ATOMS`, `UW_SOURCE_SHA`, `UW_SCHEMA_VERSION`,
  `UW_FORCE_REINGEST`. All default off; existing behaviour preserved exactly.
  - **New §7.1 "Regime selection" table** — maps fixture shape (integer-keyed / text-keyed / small TSV) to producer +
  consumer config + runtime mode (`int_atom_seeds(true)` / `int_atom_seeds(lmdb)` / TSV).

  ### `WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md`

  - **§0 "Starting point"** expanded to inventory all existing pieces with bold pointers to file paths.
  - **Phase 1 retitled** "extend Python consumer with text-keyed intern support" — new env-var surface, intern map +
  sub-db writes, idempotence guard, new Prolog example (`simplewiki_category_ingest_text.pl`), tests including a
  reserved-ID-collision test for inputs that contain literal `"true"` / `"fail"`.
  - **Phase 5 "cross-target reuse"** updated — Python consumer is already shared across the C# and AWK variants via
  streaming-glue, so cross-target reuse is the default, not an exception. Adds §5.1 noting a Haskell-parser variant as a
   preserved option, not in scope.
  - **Risks table updated** — drops `heed`-specific risks, adds Python-`lmdb` `append=True` ordering risk, adds
  parser-cost-variation risk (mitigated by pinning Rust as canonical for benchmarks).

  ## Test plan

  - [x] Docs render correctly in GitHub's markdown view
  - [x] Cross-references between the three docs and to existing files (`mysql_stream/`, `ingest_to_lmdb.py`,
  `enwiki_category_ingest*.pl`, `streaming_glue.pl`, `main.hs.mustache`, `WAM_PERF_OPTIMIZATION_LOG.md`) resolve
  - [ ] Phase 1 implementation (Python consumer extension) lands in a follow-up PR
  - [ ] Phase 2 implementation (Haskell `int_atom_seeds(lmdb)` mode) lands after Phase 1
  - [ ] Scale-300 stdout sha `70bbc9ffa4cf` preserved at every phase boundary

  ## Notes for reviewers

  The substantive design choice — *put the intern table inside LMDB so warm runs skip TSV parsing and intern-table
  rebuild* — is unchanged from #1901. What's revised is the *path* to get there: extend an existing Python script, not
  build a new Rust binary. The schema (sub-dbs `meta`, `s2i`, `i2s`, `category_parent`, `article_category`, `roots`,
  big-endian byte keys, reserved ID range for compile-time atoms) is also unchanged.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)