### PR TITLE
docs(wam): demand-filter design package — philosophy, spec, plan

### DIFF
--- a/docs/design/WAM_DEMAND_FILTER_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_DEMAND_FILTER_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,244 @@
+# Demand Filter: Implementation Plan
+
+For *why*, see `WAM_DEMAND_FILTER_PHILOSOPHY.md`. For *what*, see
+`WAM_DEMAND_FILTER_SPECIFICATION.md`. This document records the
+ordered rollout.
+
+This plan composes with the LMDB-resident interning rollout — see:
+
+- `WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md`
+- `WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md`
+- `WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md`
+
+The two work streams interleave because the demand BFS walks edge
+sub-dbs defined in the LMDB-resident plan. Phase 2 of the LMDB plan
+is renamed Phase 2 here for symmetry.
+
+## 0. Starting point
+
+Current state on `main` after PR #1905:
+
+- `data/benchmark/100k_cats/intmap/src/Main.hs` lines ~144-201
+  build `demandSet` via plain reverse BFS over `parentsIndexInterned`,
+  then derive `filteredSeedCats` via `IS.member`. The filter is
+  always-on when demand filtering is selected; there is no user
+  knob for filter strategy.
+- `templates/targets/haskell_wam/main.hs.mustache` emits the
+  `IntSet` build inline; no dispatch shape.
+- Cache infrastructure (`lmdb_cache_mode = per_hec / sharded /
+  two_level / auto`) is implemented in
+  `templates/targets/haskell_wam/lmdb_fact_source.hs.mustache:218+`
+  but not coupled to the demand BFS — it caches kernel queries
+  reactively.
+- LMDB-resident Phase 1 (PR #1905) shipped the producer side:
+  ingester writes `s2i` / `i2s` / `meta` / `category_parent` /
+  `article_category` sub-dbs.
+
+The plan below adds dispatch on the runtime side, ships the simple
+sound default, and stubs the more advanced strategies for follow-up
+PRs.
+
+## 1. Phase 2 — `HopLimit` filter + dispatch shape
+
+**Branch:** `feat/wam-haskell-demand-filter-dispatch`
+
+### 1.1 Codegen support
+
+Edit `src/unifyweaver/targets/wam_haskell_target.pl`:
+
+- Parse `:- declare_demand_filter(Strategy, Opts).` directives at
+  predicate-declaration time. Default is
+  `declare_demand_filter(hop_limit, [max_hops(MaxDepth)])` where
+  `MaxDepth` comes from the existing `max_depth/1` resolution.
+- Emit a `DemandFilterSpec` literal in the generated `Main.hs`.
+- Validate Strategy ∈ {`hop_limit`, `flux`, `none`}; reject unknown
+  with a clear error.
+- For `flux`, emit a panic stub: the spec compiles but the runtime
+  errors out at startup with "Flux strategy not yet implemented;
+  see Phase 2.5". Phase 2.5 fills this in.
+
+### 1.2 Runtime dispatch in `main.hs.mustache`
+
+- Add the `DemandFilterSpec` data declaration to `WamTypes` (or
+  inline in `Main.hs` — Phase 2 chooses inline for simplicity, can
+  promote later).
+- Replace the inline `demandSet` build with a call to
+  `runDemandBFS spec ctx rootId`, returning `DemandFilterResult`.
+- Implement `runDemandBFS` for `HopLimit` (depth-bounded reverse
+  BFS, no priority queue).
+- Implement `runDemandBFS` for `None` (returns `dfrInSet =
+  IS.fromList (IM.keys parents)`, sorted seeds = `Nothing`).
+- Implement `runDemandBFS` for `Flux` as `error "..."` panic stub.
+
+### 1.3 LMDB-cursor BFS
+
+When `int_atom_seeds(lmdb)` mode (LMDB-resident Phase 2) is active,
+the BFS walks LMDB cursors. Otherwise, it walks the in-memory
+`IntMap` exactly as today. Same `runDemandBFS` interface either way;
+just a different `EdgeLookup` argument.
+
+The reverse-edge handling defaults to "build `reverseAdj` in memory
+at startup" (LMDB-resident plan §6, option 1). If a reverse sub-db
+is later added to the ingester (LMDB-resident Phase 1.x follow-up),
+`runDemandBFS` reads from it directly without any change here.
+
+### 1.4 Cache warming hook
+
+When an `lmdb_cache_mode` is configured, the BFS visits each edge
+once and writes it through the cache write path. Behind a feature
+flag `dfWarmCache :: Bool` on the Spec (default `True` when a cache
+mode is set, `False` otherwise). Trivial implementation — just an
+extra `IORef`/`IOArray` write per visited edge.
+
+For `Flux`, warming order honours flux scores (highest first). For
+`HopLimit` and `None`, warming order is the BFS order (no priority).
+
+### 1.5 Tests
+
+`tests/test_wam_haskell_target.pl` extensions:
+
+- `test_demand_filter_hop_limit_emits_dispatch` — generated `Main.hs`
+  contains `runDemandBFS (HopLimit { dfMaxHops = 10 })`.
+- `test_demand_filter_none_skips_filter` — generated `Main.hs`
+  contains `runDemandBFS None` and `dfrInSet = IS.fromList`-style
+  expression for the universe.
+- `test_demand_filter_flux_emits_panic_stub` — generated `Main.hs`
+  contains the `error "Flux strategy not yet implemented"` panic.
+- `test_demand_filter_directive_validation` — invalid strategy
+  rejected with diagnostic.
+- `test_demand_filter_max_hops_overrides_max_depth` — explicit
+  `max_hops(N)` in the directive overrides kernel's `max_depth`.
+
+End-to-end: scale-300 matrix bench should produce sha
+`70bbc9ffa4cf` unchanged, since `HopLimit` with `max_hops = max_depth`
+is equivalent to today's behaviour.
+
+### 1.6 Acceptance
+
+- Tests green.
+- Scale-300 stdout sha matches.
+- `100k_cats` default root: `demand_set_size` and
+  `demand_skipped_seeds` numbers unchanged from PR #1905 baseline.
+- Stderr contains the new `demand_filter:` diagnostic line.
+
+## 2. Phase 2.5 — `Flux` filter
+
+**Branch:** `feat/wam-haskell-demand-flux`
+
+### 2.1 Priority-queue BFS
+
+Replace the panic stub with a real implementation:
+
+- Use `Data.Heap` (or `Data.Heap.Internal.MaxHeap`) keyed by flux
+  descending, ties broken by node ID ascending (for determinism).
+- Walk reverse edges; on each pop, record `flux(n)` and update
+  `flux(child)` for each reverse-edge child.
+- Stop when `IS.size dfrInSet >= dfCacheTopK` or queue is empty.
+- Compute `dfrSortedSeeds` as `sortBy (Down . flux)
+  filteredSeedCats` if `dfSortSparks=True`.
+
+### 2.2 Codegen: target_fraction → target_count
+
+When the directive specifies `target_fraction(f)`:
+
+- Codegen emits an expression like `Flux { dfCacheTopK = ceiling
+  (f * fromIntegral universeSize), dfSortSparks = True }`.
+- `universeSize` resolves to `meta.next_id` (LMDB) or
+  `IM.size parentsIndexInterned` (in-memory IntMap).
+
+When the directive specifies `target_count(K)`, the literal K is
+emitted directly.
+
+### 2.3 Cabal dep
+
+Conditional on any kernel emitting `Flux`, add `heap >= 1.0` to the
+generated cabal file. Existing `lmdb >= 0.2.5` conditional logic
+serves as the pattern.
+
+### 2.4 Tests
+
+- Unit test on a small synthetic graph: known flux values, verify
+  `runDemandBFS Flux` returns expected top-K.
+- Sorted-sparks test: `dfrSortedSeeds` is in flux-descending order.
+- Determinism test: two runs of the BFS produce the same set and the
+  same sort order.
+- Cap behaviour: `dfCacheTopK = 0` returns empty set; `dfCacheTopK >
+  reachable count` returns full reachable set.
+- E2E: scale-300 with `flux` strategy produces the same sha as the
+  same workload with `hop_limit` (only the order changes, not the
+  result; the kernel still runs all reachable seeds).
+
+### 2.5 Acceptance
+
+- Phase 2 tests still green.
+- New flux-specific tests green.
+- `100k_cats` `Deaths_by_year` root: `query_ms` with `flux` ≤
+  `query_ms` with `hop_limit` (priority order should help cache
+  hit rate at the very least; we'd accept flat as proof of
+  no-regression).
+
+## 3. Phase 2.6 — `Hybrid` and adaptive
+
+**Branch:** `feat/wam-haskell-demand-hybrid`
+
+Optional. Only worth implementing if Phase 2.5 measurements show
+neither pure strategy dominates.
+
+- Add `Hybrid { dfHopLimit :: !Int, dfFluxTopK :: !Int }`
+  constructor: BFS bounded by hops AND flux-priority.
+- Adaptive variant: measure hit-rate during the first few queries
+  and adjust the floor / target_fraction. Probably gated behind an
+  env flag rather than always-on.
+
+## 4. Phase 5 — cross-target reuse (joint with LMDB-resident plan)
+
+The demand-filter dispatch is target-agnostic in its semantics. The
+WAM-Rust and WAM-Elixir backends could adopt the same strategy
+sum-type. The implementation is per-target (each backend has its own
+runtime), but the codegen directive (`declare_demand_filter`) and
+the validation logic in `wam_haskell_target.pl` can be lifted to a
+shared module under `src/unifyweaver/core/`.
+
+This phase is exploratory; deliverable is a memo on whether to
+unify, plus issues for the rollout to other targets.
+
+## 5. Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| `Flux` BFS is slow on broad roots | The `dfCacheTopK` cap bounds the BFS; once the priority queue has emitted `dfCacheTopK` nodes, expansion stops. Worst case is O(K log K). |
+| Priority queue cost dominates for small `K` | For `K < 10000`, a sorted-array-based priority queue is faster than a heap. Phase 2.5 ships the heap version; if measurements show cost matters, swap implementations. |
+| `target_fraction(f)` underspecifies behaviour when `meta.next_id` is unset (small fixtures, in-memory path) | Fall back to `IM.size parentsIndexInterned` as the universe estimate. Document this in the spec; warn at codegen if neither is present. |
+| Sorted parMap input changes parallelism characteristics | The matrix bench should detect any regression in `query_ms`. If sorted input degrades parallelism (e.g. all high-flux work piles on HEC 0), investigate work-stealing tuning before reverting. |
+| `Hybrid` adds complexity without proven value | Don't ship until measurements show it's needed. Phase 2.5 is the gate. |
+| Reverse-edge in-memory build is itself expensive | Tracked in LMDB-resident plan §6; reverse sub-db follow-up at the ingester layer if measured to matter. |
+
+## 6. Verification
+
+End-to-end at every phase boundary:
+
+1. Phase 2: scale-300 sha unchanged; `100k_cats` numbers match
+   PR #1905; `demand_filter:` stderr line emitted.
+2. Phase 2.5: small-graph unit test for known flux values; scale-300
+   sha unchanged across `hop_limit` / `flux` / `none` strategies.
+3. Phase 2.6: only if measurements warrant.
+
+If any phase regresses scale-300 sha `70bbc9ffa4cf`, that is the
+phase to debug before moving on. The strategy is "kernel-result
+identical, performance characteristics differ" — anything else is a
+bug.
+
+## 7. Out of scope
+
+These appear in the philosophy doc as future ideas but are not in
+this implementation arc:
+
+- Pre-computed demand sets per known root, written to a sub-db at
+  ingest time (filed as ingester follow-up).
+- Information-theoretic floors (entropy-based cutoffs).
+- Adaptive memory budget with frontier trimming.
+- Cross-root flux LRU cache.
+- Parallel BFS workers.
+
+Each of these is additive — they fit the dispatch shape Phase 2
+establishes. Filed for measurement-driven future work.

--- a/docs/design/WAM_DEMAND_FILTER_PHILOSOPHY.md
+++ b/docs/design/WAM_DEMAND_FILTER_PHILOSOPHY.md
@@ -1,0 +1,334 @@
+# Demand Filter: Philosophy
+
+This doc captures the design exploration around how the WAM-Haskell
+runtime decides which seeds to spark, which edges to cache, and which
+work to deprioritise. It walks through alternatives we considered,
+explains why we landed where we did, and flags the questions that
+should drive future revisions.
+
+Companion docs:
+- `WAM_DEMAND_FILTER_SPECIFICATION.md` — the technical shape we ship.
+- `WAM_DEMAND_FILTER_IMPLEMENTATION_PLAN.md` — phased rollout.
+- `WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md` — the storage layer this
+  composes with; demand BFS walks LMDB cursors.
+
+## What the demand set actually is
+
+For the canonical workload (`category_ancestor` style: each seed
+walks `category_parent` edges UP toward a `root`), a seed S can reach
+root iff root is in S's ancestors — equivalently, S is in root's
+**descendants** in tree terms. The demand set is built by **reverse**
+BFS from root, and is therefore "everything below root in the
+hierarchy."
+
+Common confusion worth nailing here:
+
+- *Ancestors of root* = the few super-categories above root (e.g.
+  "Knowledge", "Things"). Tiny. Not what we want.
+- *Descendants of root* = the categories that sit under root (e.g.
+  for root=Physics: "Quantum_Mechanics", "Optics", "Lenses", ...).
+  Potentially huge. **This is the demand set.**
+
+The size of the demand set is therefore determined by root
+generality, not by the size of the universe directly:
+
+| Root example | Approx descendants on enwiki |
+|---|---:|
+| `0s_beginnings` (very specific) | ~10 |
+| `Deaths_by_year` (mid) | ~1,000 |
+| `Physics` (broad) | ~50k–500k |
+| `Science` (very broad) | ~1M–3M |
+| `Things` (top-of-tree) | ~7M ≈ universe |
+
+So "the demand set is small" is workload-dependent, not a property of
+the algorithm. A correct design has to handle the full range.
+
+## Two artifacts that the current TSV path collapses together
+
+The current code computes:
+
+```haskell
+!demandSet         = computeDemandSet parentsIndexInterned rootId
+!filteredParents   = filterByDemand demandSet parentsIndexInterned
+!filteredSeedCats  = filter (\c -> IS.member (iAtom c) demandSet) seedCats
+```
+
+These are **two different artifacts** that the existing path
+implicitly couples:
+
+| Artifact | Type | Role | Memory cost |
+|---|---|---|---|
+| `demandSet` | `IntSet` | Pre-filter `seedCats` before parMap | O(\|descendants\|), small Patricia trie |
+| `filteredParents` | `IntMap [Int]` | Edge map the kernel walks | O(\|descendant edges\|), big when descendants are big |
+
+These have different roles and different costs. Keeping them coupled
+forces "if filtering is on, both are built; if off, neither is." In
+the LMDB-resident world they decouple naturally:
+
+- `demandSet` stays — small set, used for seed pre-filter, prevents
+  the spark-fanout regression PR #1882 just fixed.
+- `filteredParents` goes away — the kernel reads edges via LMDB
+  cursors, optionally backed by a configured cache layer
+  (`per_hec` / `sharded` / `two_level`). The cache *is* the
+  in-memory edge tier, sized by mode rather than by the demand set.
+
+## Hop-limit: the simple sound filter
+
+The kernel already has `max_depth=10` (or whatever the user sets). A
+seed more than 10 forward-hops from root **cannot** succeed
+regardless of any filter. So bounding the demand BFS to `max_depth`
+hops gives a **provably complete filter** — no false negatives, no
+approximation:
+
+```
+demand set = { n : reverse-BFS distance from root to n ≤ max_depth }
+```
+
+Properties:
+
+- Sound: every seed reachable within the kernel's actual reach is in
+  the set.
+- Cheap: the BFS only walks `max_depth` levels, naturally bounded.
+- Aligned: it uses the kernel's existing depth knob, no new tuning.
+
+The downside: **it doesn't account for routing density**. In a
+small-world graph like Wikipedia categories, a 5-hop path through
+high-degree hubs is fundamentally different from a 5-hop path
+through a thin chain. Hop-limit treats them the same.
+
+## The small-world wrinkle
+
+Wikipedia's category graph is small-world: average shortest path is
+~4-5 hops, dominated by a handful of high-degree hubs that
+short-circuit otherwise distant subtrees. Statistical character:
+
+- Average reachability distance L* ~ log(N), not Θ(\|tree\|).
+- A node with 10,000 children is a routing hub: any path through it
+  fans out into 10,000 alternatives.
+- Two nodes at the same hop-distance from root can have very
+  different "effective connectedness" — one funneling through hubs,
+  the other walking thin chains.
+
+For a filter that wants to capture "the part of the graph
+meaningfully connected to root," hop-limit conflates these regimes.
+We need something that compensates for routing density.
+
+## Flux density as the principled alternative
+
+Treat the BFS as a random walk from root, choosing reverse edges
+uniformly at each step. The probability of landing at node n after
+some hops is the **flux** at n:
+
+```
+flux(root) = 1
+flux(n)    = sum over reverse-edges (n, parent_of_n) of
+                 flux(parent_of_n) / out_degree(parent_of_n)
+```
+
+This is personalized PageRank from root without teleport. Properties:
+
+- A node reachable by many short, low-branching paths has high flux.
+- A node reachable by one long high-branching path has low flux.
+- Flux is **intrinsic** to network structure — it captures
+  "closeness to root" weighted by routing density.
+- It's bounded: total flux mass sums to 1 by construction.
+
+Flux gives us a *gradient* over nodes rather than a binary in/out
+classification. That gradient is what makes the design compose well
+with parallel scheduling (see "Top-K plus sorting" below).
+
+## What "size" knob makes sense for the user
+
+We considered two parametrisations of "how big should the demand
+set be":
+
+- **Target flux mass** — capture nodes whose cumulative flux ≥ M
+  (e.g. M = 1−1/e ≈ 0.632, by analogy with EE characteristic time
+  / network-science mixing time).
+- **Target network fraction** — capture top-K nodes by flux where
+  K = f × N (e.g. f = 0.05).
+
+We considered the 1/e mass cutoff because it's parameter-free and
+falls out of the natural scale of an exponential decay. But:
+
+- The user can't predict the resulting **count** without knowing the
+  flux distribution, which depends on the workload.
+- Memory budgets are denominated in "elements" or "bytes," not
+  "mass."
+- "Capture 5% of N" maps directly to a known cache footprint.
+
+So the user-facing knob is **target network fraction**, with flux
+ordering as the *priority* (which K to keep), not the *budget* (how
+many). The 1/e idea was a useful theoretical anchor but the wrong
+shape for the API.
+
+## Top-K plus sorted sparks: the cleanest formulation
+
+The realisation that simplifies the whole design: there are
+**two different K's** with two different meanings.
+
+| Mechanism | Cap | Purpose |
+|---|---|---|
+| **Cache top-K** | Bounded by RAM (`f × N` or absolute byte budget) | Holds highest-flux edges; warmed during BFS |
+| **Spark ordering** | Unbounded — sort *all* reachable seeds by flux | parMap creates high-flux sparks first; low-flux fill idle capacity |
+
+The cache K is hard-capped by hardware. The spark K is unbounded —
+every seed with `flux > 0` still runs, just in priority order. No
+false negatives, no quality cliff, graceful degradation under any
+configuration.
+
+Implementation is trivial:
+
+```haskell
+let !filteredSeedCats   = filter (\c -> flux c > 0) seedCats
+    !sortedFilteredSeeds = sortBy (comparing (Down . flux)) filteredSeedCats
+let !seedResultsForced   = parMap rdeepseq queryBody sortedFilteredSeeds
+```
+
+Two-line change vs. the current code. `parMap rdeepseq` is lazy in
+its input; sparks fire as the spine is forced; sorted-by-flux input
+means high-priority sparks reach idle workers first. GHC's
+work-stealing then pulls low-flux sparks onto idle threads. No
+custom scheduler, no priority queue.
+
+The `flux > 0` filter remains the **hard sound filter** (a seed with
+flux 0 cannot reach root, definitionally). Sorting is the **soft
+priority** within the surviving set.
+
+## What about "ancestors are smaller than descendants"
+
+A reasonable hope: per-node ancestor sets are tiny (depth × branching
+≈ 5-50 nodes) while descendant sets can be enormous. Why not compute
+the demand filter as the **union of seed ancestors** instead of root
+descendants?
+
+The math:
+
+| Approach | BFSes computed | Per-set size | Total work |
+|---|---:|---:|---:|
+| Descendants of root (current) | **1** | O(\|root subtree\|) | O(\|subtree\|) |
+| Ancestors of each seed | **N seeds** | O(depth × branching) | O(N × depth) |
+
+For a single shared filter, **one BFS from root** is cheaper than
+**N small BFSes from seeds**, even though each individual seed's
+ancestor walk is tiny. The filter inherently considers all seeds at
+once, so the shared computation wins.
+
+Bidirectional BFS (walk forward from seeds AND backward from root,
+intersect) is a classic √N speedup for shortest-path queries, but
+for our filter — a binary "can-reach?" predicate shared across many
+seeds — the one-shot reverse BFS is already the bidirectional
+algorithm's cheap half.
+
+So the demand set stays as descendants of root, and we manage size
+via flux-priority + cap, not via a different BFS direction.
+
+## Statistical anchors
+
+Useful fixed points from network science / EE:
+
+- **Logarithmic complexity**: small-world networks have characteristic
+  path length L* ~ log(N). On enwiki, that's ~14-16 (natural log) or
+  empirically ~4-5 because hubs short-circuit chains.
+- **Mixing time**: O(log N) random-walk steps to come within 1/e of
+  the stationary distribution. Same scale as L*.
+- **1/e (≈ 0.632) characteristic decay**: the "natural scale" of an
+  exponential. The cumulative flux mass after one mixing time is
+  ≈ 1 − 1/e ≈ 63%.
+- **Effective diameter** (Leskovec et al.): 90th-percentile shortest
+  path. Convention from network-science papers but the percentile
+  is arbitrary.
+
+These don't directly drive the user-facing knob (we settled on
+network fraction), but they inform sensible defaults and explain why
+the runtime should *expect* the demand set to be reachable with very
+few hops on real workloads — and why the worst case is the entire
+universe when `root` is the tree root.
+
+## Configurable, not hard-coded
+
+The right framing is "the demand filter is a strategy, not a
+mechanism." Different workloads want different filters:
+
+- A query asking "which categories strongly connect to Physics"
+  wants flux-weighted reachability — most-central first, prune the
+  tail.
+- A query asking "which categories can reach Physics in any way"
+  wants strict hop-bounded reachability — no false negatives.
+- A small-fixture dev workflow wants no filter — everything runs,
+  cache absorbs the overhead.
+
+So the surface is declarative:
+
+```prolog
+:- declare_demand_filter(hop_limit, [max_hops(10)]).
+:- declare_demand_filter(flux, [target_fraction(0.05), sort_sparks(true)]).
+:- declare_demand_filter(none).
+```
+
+The runtime's job is to honour the declared strategy. No magic
+defaults that vary by workload size; deployments pick what they
+want.
+
+## What we think is best
+
+For Phase 2 (the immediate next implementation step):
+
+1. Ship `hop_limit` as the default — it's sound, cheap, and aligned
+   with the kernel's existing `max_depth`.
+2. Build the dispatch machinery so adding strategies is purely
+   additive (`DemandFilterSpec` sum type, `runDemandBFS` consumer).
+3. Stub the `Flux` constructor so the codegen can emit it; runtime
+   panics if used until Phase 2.5 implements it.
+
+For Phase 2.5:
+
+4. Implement `Flux` properly — priority-queue BFS, top-K cache
+   warming, sorted-by-flux parMap input.
+5. Default `target_fraction(0.05)` and `sort_sparks(true)` when
+   `Flux` is selected. These are pragmatic, not principled — we
+   revise after measurements.
+
+For later phases:
+
+6. Hybrid (`HopLimit` AND `Flux`) for users who want both bounds.
+7. Adaptive: measure hit-rate during the first few queries and tune
+   the floor / target_fraction. Worth doing only if measurements
+   show the hand-tuned defaults need adjusting.
+
+## Open questions and future inspiration
+
+- **Pre-computed demand sets per known root** — for production
+  deployments where the same root is queried repeatedly, the
+  ingester could write per-root demand sets to disk. Trades disk for
+  startup time. Not Phase 2 scope.
+- **Parallel BFS** — workers fan out by frontier slice, each owning
+  a thread-local LMDB cursor. ~Ncores speedup on broad roots.
+- **Reverse-edge sub-db** — option in the ingester to write a
+  pre-computed reverse adjacency, avoiding the in-memory build at
+  startup. Small additive change to the Phase 1 ingester.
+- **Information-theoretic floors** — replace the network-fraction
+  heuristic with an entropy-based cutoff (capture the K nodes that
+  contribute most to the flux distribution's entropy). More
+  principled but heavier math.
+- **Adaptive memory budget** — measure RSS during BFS, trim
+  lowest-flux frontier when the budget is exceeded. No user knob
+  needed, just a cap.
+- **Cross-root flux caching** — flux for root R₁ partially overlaps
+  with flux for root R₂ if R₁ and R₂ share descendants. A flux LRU
+  across root queries could amortise the BFS.
+
+These are filed for future exploration. Phase 2 ships the simple
+sound default and the dispatch shape; everything above is additive.
+
+## Refs
+
+- `WAM_DEMAND_FILTER_SPECIFICATION.md` — the chosen API, types, knob surface.
+- `WAM_DEMAND_FILTER_IMPLEMENTATION_PLAN.md` — phased rollout.
+- `WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md` — composes with demand
+  filtering at the BFS layer (cursors over LMDB).
+- `WAM_PERF_OPTIMIZATION_LOG.md` Phase L appendix #4 — the
+  parallelisation regression that motivated keeping the seed pre-filter
+  no matter what.
+- `templates/targets/haskell_wam/lmdb_fact_source.hs.mustache` — the
+  cache mode infrastructure (`per_hec`, `sharded`, `two_level`).

--- a/docs/design/WAM_DEMAND_FILTER_SPECIFICATION.md
+++ b/docs/design/WAM_DEMAND_FILTER_SPECIFICATION.md
@@ -1,0 +1,217 @@
+# Demand Filter: Specification
+
+The technical shape of the demand-filter dispatch we're implementing.
+For *why* each decision, see `WAM_DEMAND_FILTER_PHILOSOPHY.md`. For
+the rollout sequence, see `WAM_DEMAND_FILTER_IMPLEMENTATION_PLAN.md`.
+
+This design composes with the LMDB-resident interning work — see:
+
+- `WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md`
+- `WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md`
+- `WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md`
+
+The demand BFS walks edge sub-dbs defined there; the filter strategies
+defined here are independent of the storage layer (they work the same
+way for in-memory `IntMap` edges or LMDB-cursor edges).
+
+## 1. The DemandFilterSpec sum type
+
+Carried from the codegen layer to the runtime; selected at compile
+time per-predicate.
+
+```haskell
+data DemandFilterSpec
+  -- Provably complete filter using the kernel's natural depth.
+  = HopLimit
+      { dfMaxHops :: !Int
+      }
+  -- Flux-weighted top-K with optional spark ordering.
+  | Flux
+      { dfCacheTopK   :: !Int   -- nodes to retain in cache (RAM-bounded)
+      , dfSortSparks  :: !Bool  -- order parMap input by flux descending
+      }
+  -- No filter; rely on cache + kernel's own pruning.
+  | None
+  deriving (Eq, Show)
+```
+
+Three constructors cover the regimes the philosophy doc identifies.
+The runtime dispatches once at startup (`runDemandBFS spec ctx
+rootId`) and produces an `IntSet` of in-set node IDs, plus optionally
+a sorted seed list for the spark stage.
+
+## 2. Runtime contract
+
+Every strategy honours the same shape:
+
+```haskell
+-- The output of a demand-filter run.
+data DemandFilterResult = DemandFilterResult
+  { dfrInSet        :: !IS.IntSet
+    -- Nodes considered "in." Used for seed pre-filter and as the
+    -- universe for cache warming.
+  , dfrSortedSeeds  :: !(Maybe [Int])
+    -- Seeds in descending priority order. Nothing for HopLimit/None.
+  , dfrFluxScores   :: !(Maybe (IM.IntMap Double))
+    -- Per-node flux. Populated by Flux only; consumed by cache
+    -- warming when configured.
+  }
+```
+
+The runtime then:
+
+1. Filters seed list: `seedCats' = filter (`IS.member` dfrInSet) seedCats`.
+2. If `dfrSortedSeeds` is `Just sorted`, replaces `seedCats'` with
+   `take (length seedCats') sorted` (preserving sort order).
+3. If a cache mode is active, warms the cache with edges to nodes in
+   `dfrInSet` (highest-flux first when scores are present).
+4. Hands `seedCats'` to `parMap`.
+
+The seed pre-filter (step 1) is **always applied** when a filter is
+declared — that's the spark-fanout fix from PR #1882, and it's
+load-bearing regardless of strategy.
+
+## 3. Strategy semantics
+
+### 3.1 HopLimit
+
+```
+demand set = { n : reverse-BFS distance from root to n ≤ dfMaxHops }
+sorted seeds = Nothing
+flux scores = Nothing
+```
+
+Plain reverse BFS bounded by depth. Sound (no false negatives) when
+`dfMaxHops` ≥ kernel's `max_depth`. Default `dfMaxHops = max_depth`
+unless the user overrides.
+
+### 3.2 Flux
+
+```
+1. Reverse-BFS from root with priority queue keyed by flux descending.
+2. flux(root) = 1; flux(n) = sum over reverse-edges (n, parent) of
+   flux(parent) / out_degree(parent).
+3. Stop when |inSet| ≥ dfCacheTopK or queue exhausts (subtree smaller
+   than target).
+4. The flux of the last popped node is the implicit floor — emitted
+   to stderr for diagnostics.
+```
+
+`dfSortSparks=True` returns the surviving seed list sorted by flux
+descending; `False` skips the sort cost when the deployment doesn't
+care about spark ordering.
+
+A seed with `flux = 0` is by definition unreachable from root (in
+reverse-BFS terms), so it's always excluded — that's the sound part.
+A seed with `flux > 0` but rank > `dfCacheTopK` is excluded as an
+**approximation**: in real workloads it has a path to root but the
+path is "too diluted" by routing density to be worth scheduling.
+
+### 3.3 None
+
+```
+demand set = full universe of node IDs (all keys in the edge sub-db)
+sorted seeds = Nothing
+flux scores = Nothing
+```
+
+The seed pre-filter degenerates to "always pass." All seeds get
+sparked. Useful when:
+
+- The cache mode is sufficient to bound work without filtering.
+- Debugging / measuring filter overhead (vs. running with no filter).
+- Small fixtures where filter setup costs more than the kernel work.
+
+## 4. Codegen surface
+
+The Prolog codegen emits a directive per kernel that uses demand
+filtering:
+
+```prolog
+%% Default — sound, kernel-aligned:
+:- declare_demand_filter(hop_limit, [max_hops(10)]).
+
+%% Flux-weighted with sensible defaults (Phase 2.5):
+:- declare_demand_filter(flux, [target_fraction(0.05), sort_sparks(true)]).
+
+%% Flux with absolute cap:
+:- declare_demand_filter(flux, [target_count(50000), sort_sparks(true)]).
+
+%% No filter — cache-only mode:
+:- declare_demand_filter(none).
+```
+
+The codegen reads this directive and emits a `DemandFilterSpec`
+literal in `Main.hs`. Per-kernel option, not per-target option.
+
+`target_fraction(f)` is resolved to `target_count = ceil(f *
+meta.next_id)` at runtime, after the LMDB env is opened (see
+`WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md` §1.1 for the `next_id`
+meta key). For the in-memory IntMap path, `next_id` is replaced by
+`IM.size parentsIndexInterned`.
+
+## 5. Cache integration
+
+The demand filter and the cache layer (`lmdb_cache_mode`, see
+`templates/targets/haskell_wam/lmdb_fact_source.hs.mustache:218+`)
+compose:
+
+| Filter | Cache mode | Behaviour |
+|---|---|---|
+| `None` | `unset` | All seeds spark; LMDB cursors for every lookup. |
+| `None` | `per_hec` / `sharded` / `two_level` | All seeds spark; cache absorbs hot lookups; cold falls through to LMDB. |
+| `HopLimit` / `Flux` | `unset` | Seed pre-filter applied; LMDB cursors directly. |
+| `HopLimit` / `Flux` | `per_hec` / `sharded` / `two_level` | Seed pre-filter applied; **cache warmed during BFS** with edges in `dfrInSet`. Kernel hits cache for in-set, cache misses fall through to LMDB. |
+
+Cache warming during BFS is one extra `IORef` write per visited edge
+— effectively free. With `Flux`, the warming order honours
+`dfrFluxScores`: highest-flux edges go in first so eviction (when
+the cache is smaller than the demand set) drops lowest-flux first.
+
+## 6. Cabal/feature dependencies
+
+No new Haskell packages required for `HopLimit` (uses only
+`containers` for `IntSet` / `IntMap`).
+
+`Flux` requires `Data.Heap` (or equivalent priority queue) for the
+BFS frontier. Adds `heap >= 1.0` as a conditional dep when any
+generated kernel emits a `Flux` filter.
+
+## 7. Error handling and degenerate cases
+
+| Condition | Behaviour |
+|---|---|
+| `HopLimit` with `dfMaxHops <= 0` | Demand set is `{rootId}` only; spark filter excludes everything. Logged as warning. |
+| `Flux` with `dfCacheTopK = 0` | Demand set is empty; all seeds excluded. Logged as warning. |
+| `Flux` with `dfCacheTopK > N` | All reachable nodes included; equivalent to unbounded reverse BFS. |
+| Root not in LMDB / `IntMap` | Demand set is empty; warning emitted; all seeds excluded. |
+| Edge sub-db empty | Demand set is `{rootId}` only. |
+
+Warnings go to `stderr` via `hPutStrLn stderr "demand_filter: ..."`,
+matching the existing `demand_set_size=` etc. convention.
+
+## 8. Determinism
+
+- `HopLimit` is fully deterministic given root and max_hops.
+- `Flux` is deterministic given the input edges (priority queue ties
+  broken by node ID ascending). Same LMDB → same demand set → same
+  output sha.
+- `None` is deterministic.
+
+This matches the project-wide invariant that the same fixture should
+produce the same `stdout_sha256` regardless of how many cores or
+which strategy variant is selected.
+
+## 9. Diagnostics
+
+Every strategy emits a one-line summary on stderr after BFS:
+
+```
+demand_filter: strategy=hop_limit max_hops=10 in_set=1151 universe=84136
+demand_filter: strategy=flux cache_top_k=4207 in_set=4207 implicit_floor=2.4e-5
+demand_filter: strategy=none in_set=84136 universe=84136
+```
+
+The matrix bench harness already grep's `demand_set_size=` and
+`demand_skipped_seeds=`; the new line follows the same pattern so
+existing tooling sees both keys.

--- a/docs/design/WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md
@@ -4,6 +4,9 @@ For the *why*, see `WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md`. For the
 *what*, see `WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md`. This
 document records the ordered rollout.
 
+The demand-filter rollout interleaves with this plan; its phases are
+defined in `WAM_DEMAND_FILTER_IMPLEMENTATION_PLAN.md`.
+
 ## 0. Starting point
 
 Current state on `main` after PR #1882 / #1901:

--- a/docs/design/WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md
+++ b/docs/design/WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md
@@ -320,6 +320,13 @@ up front.
 
 - `WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md` — schema, CLI, runtime contract.
 - `WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md` — phased steps.
+- `WAM_DEMAND_FILTER_PHILOSOPHY.md` — the demand-filter dispatch
+  (HopLimit / Flux / None) that walks LMDB cursors emitted here.
+  Read alongside this doc for the full runtime picture.
+- `WAM_DEMAND_FILTER_SPECIFICATION.md` — `DemandFilterSpec` API and
+  cache-warming integration.
+- `WAM_DEMAND_FILTER_IMPLEMENTATION_PLAN.md` — the demand-filter
+  rollout that interleaves with the LMDB-resident phases.
 - `WAM_PERF_OPTIMIZATION_LOG.md` — measurements that motivated this work,
   especially Phase L appendix #4.
 - `src/unifyweaver/runtime/rust/mysql_stream/` — Rust parser (canonical

--- a/docs/design/WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md
+++ b/docs/design/WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md
@@ -5,6 +5,12 @@ interning design. For *why* each decision, see
 `WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md`. For the rollout sequence,
 see `WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md`.
 
+The demand-filter dispatch (`HopLimit` / `Flux` / `None`) walks the
+edge sub-dbs defined here. For its design, see the companion triad:
+`WAM_DEMAND_FILTER_PHILOSOPHY.md`,
+`WAM_DEMAND_FILTER_SPECIFICATION.md`,
+`WAM_DEMAND_FILTER_IMPLEMENTATION_PLAN.md`.
+
 ## 1. LMDB layout
 
 A single `data.mdb` file (LMDB environment) with the following


### PR DESCRIPTION
  ## Summary

  Three new design docs capturing the dialectical exploration around how the WAM-Haskell runtime decides which seeds to
  spark, which edges to cache, and which work to deprioritise. Companion triad to the LMDB-resident interning docs in
  #1901 / #1904 — the BFS the new docs describe walks the LMDB cursors defined there.

  No code changes. Design package only.

  ## Why preserve the dialectic

  The conversation that produced these docs walked through several alternatives that we considered seriously and then
  rejected or revised:

  1. **What the demand set actually is** — *descendants* of root in the category hierarchy (not ancestors).
  Confusion-prone because "ancestors are smaller per node," which is true but not what the demand-filter inherently
  needs.
  2. **Two artifacts the current path conflates** — `IntSet` (small, for seed pre-filter) vs. `IntMap` edge filter
  (large, replaceable by cache).
  3. **Scale concerns** — at full enwiki (~7M categories) demand sets can reach 1M+ for broad roots; "the demand set is
  small" is workload-dependent.
  4. **Hop-limit as the simple sound filter** — kernel-aligned, no false negatives, but conflates "5 hops through hubs"
  with "5 hops through chains."
  5. **Small-world structure** breaking the hop-distance assumption — average L* ~ log(N) on real Wikipedia, dominated
  by hubs.
  6. **Flux density as routing-aware reachability** — personalized PageRank from root without teleport.
  7. **Statistical anchors** — log(N) characteristic distance, 1/e (EE characteristic time / network-science mixing time
   / Cheeger conductance) as a parameter-free decay scale.
  8. **Target-mass vs target-fraction** — I conflated these in conversation; resolution: user-facing knob is
  fraction-of-network (predictable count), flux is the *priority order* within that budget.
  9. **Top-K + sorted-sparks formulation** — the cleanest framing: two independent K's. Cache-K is RAM-bounded; spark-K
  is unbounded — every reachable seed runs, just in priority order. No false negatives, graceful degradation.
  10. **Configurable strategy via `declare_demand_filter`** — not a fixed mechanism; user picks the semantics for their
  workload.

  Each of these is a real fork in the design space. Recording the reasoning means future-you (or any other contributor)
  can follow the breadcrumbs — including the rejected alternatives — and adapt as the workload picture sharpens.

  ## What's in each doc

  ### `WAM_DEMAND_FILTER_PHILOSOPHY.md` (334 lines)

  The why. Walks through:

  - What the demand set actually is (descendants of root, with the size-by-root-generality table).
  - Two-artifact decoupling (`IntSet` survives, `IntMap` becomes optional with cache).
  - Hop-limit baseline and the small-world wrinkle.
  - Flux density as principled alternative, with the recursive flux equation.
  - Statistical anchors from EE and network science.
  - Top-K + sorted-sparks formulation.
  - The "ancestors are smaller per node" detour and why descendants-of-root still wins (multiplicity flip: 1 BFS vs. N).
  - Configurable strategy.
  - "What we think is best" section anchoring the chosen path.
  - Open questions and future inspiration: per-root precomputed demand sets, parallel BFS, reverse-edge sub-db at ingest
   time, information-theoretic floors, adaptive memory budgets, cross-root flux LRU.

  ### `WAM_DEMAND_FILTER_SPECIFICATION.md` (217 lines)

  The what. Defines:

  - `DemandFilterSpec` sum type (`HopLimit` / `Flux` / `None`).
  - `DemandFilterResult` shape (`inSet`, `sortedSeeds`, `fluxScores`).
  - Strategy semantics for each variant — what BFS walks, what gets returned, what the cache sees.
  - Codegen surface — `declare_demand_filter` Prolog directive with options.
  - Cache integration table — every (filter × cache_mode) combination.
  - Cabal/feature dependencies (`heap` conditional on `Flux`).
  - Error handling, determinism, diagnostics (`demand_filter:` stderr line).

  ### `WAM_DEMAND_FILTER_IMPLEMENTATION_PLAN.md` (244 lines)

  The how. Phased rollout:

  - **Phase 2**: `HopLimit` + dispatch shape. `Flux` shipped as a panic stub so the codegen accepts it but runtime
  errors with a clear message until Phase 2.5.
  - **Phase 2.5**: `Flux` filter — priority-queue BFS, top-K, `sort_sparks`. Sensible defaults (`target_fraction(0.05)`,
   `sort_sparks(true)`).
  - **Phase 2.6**: `Hybrid` and adaptive — only if measurements warrant.
  - **Phase 5**: cross-target reuse with WAM-Rust / WAM-Elixir.

  Plus risks (BFS cost, priority-queue overhead, fraction-vs-count fallback, sorted parMap parallelism), verification
  gates per phase, and explicitly-out-of-scope items filed for future measurement-driven work.

  ## Cross-references

  The new triad references the existing LMDB-resident triad as companion docs at the top, and in the refs section. The
  existing LMDB-resident triad now back-references the new demand-filter triad — same change applied to all three of
  those files so navigation is symmetric. A reader landing on either triad's philosophy can follow the breadcrumb to the
   other.

  ## Test plan

  - [x] Docs render correctly in GitHub's markdown view
  - [x] Cross-references between the six docs (3 new + 3 amended) resolve
  - [x] Existing references (`WAM_PERF_OPTIMIZATION_LOG.md`, `lmdb_fact_source.hs.mustache`, `main.hs.mustache`) resolve
  - [ ] Phase 2 implementation (`HopLimit` + dispatch shape) lands in a follow-up PR
  - [ ] Phase 2.5 implementation (`Flux` filter) lands after Phase 2
  - [ ] Scale-300 stdout sha `70bbc9ffa4cf` preserved at every phase boundary

  ## Notes for reviewers

  The doc structure deliberately mirrors the LMDB-resident triad (philosophy / specification / implementation plan) so
  the two work streams have the same shape. They interleave at the implementation layer (Phase 2 of either plan composes
   with Phase 2 of the other), but they're separable concerns: LMDB-resident is about *where* the data lives;
  demand-filter is about *which* nodes get prioritised. Either can ship without the other.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)