### PR TITLE
bench(csharp-query): skip unsupported source-mode sweep scales

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -125,6 +125,11 @@ summarize stable winners. Values above `1` report majority winners, winner
 counts, stable resolved `auto` modes, and per-mode median timings across the
 independent runs.
 
+Mixed-scale sweeps are filtered per workload. File-backed graph workloads can
+use `dev`, `300`, `1k`, `5k`, and `10k`; generated dependency-depth workloads
+use `300`, `1k`, `5k`, and `10k`. Unsupported workload/scale pairs are skipped
+with warnings instead of aborting the full sweep.
+
 ### WAM-Rust and WAM-Haskell Benchmark Variants
 
 The effective-distance harness also includes hybrid WAM benchmark targets:
@@ -1133,7 +1138,8 @@ Comparison note:
 - use `benchmark_csharp_query_source_mode_sweep.py` when you want a compact
   cross-workload TSV or Markdown summary of best source mode, auto-vs-best
   ratio, output agreement, per-mode medians, and source-registration storage
-  families
+  families; mixed requests such as `--scales dev,300` skip unsupported
+  workload/scale pairs with warnings
 - cache reuse remains disabled for these one-shot generated benchmark
   programs, and trace creation is now opt-in rather than always-on
 - the hand-written C# DFS baseline is still cheaper after its lighter

--- a/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
+++ b/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
@@ -34,6 +34,17 @@ WORKLOAD_SCRIPTS = {
     "weighted-shortest-path": BENCHMARK_DIR / "benchmark_weighted_shortest_path_cross_target.py",
 }
 
+FILE_BACKED_GRAPH_SCALES = ("dev", "300", "1k", "5k", "10k")
+GENERATED_GRAPH_SCALES = ("300", "1k", "5k", "10k")
+WORKLOAD_SUPPORTED_SCALES = {
+    "category-influence": FILE_BACKED_GRAPH_SCALES,
+    "dependency-depth": GENERATED_GRAPH_SCALES,
+    "dependency-longest-depth": GENERATED_GRAPH_SCALES,
+    "effective-distance": FILE_BACKED_GRAPH_SCALES,
+    "shortest-path": FILE_BACKED_GRAPH_SCALES,
+    "weighted-shortest-path": FILE_BACKED_GRAPH_SCALES,
+}
+
 DEFAULT_WORKLOADS = "all"
 CALIBRATION_ARTIFACT = BENCHMARK_DIR / "csharp_query_graph_source_mode_calibration.tsv"
 
@@ -164,6 +175,23 @@ def parse_workloads(value: str) -> list[str]:
     if not workloads:
         raise SystemExit("expected at least one workload")
     return workloads
+
+
+def supported_scales_for_workload(workload: str) -> tuple[str, ...]:
+    try:
+        return WORKLOAD_SUPPORTED_SCALES[workload]
+    except KeyError as exc:
+        raise SystemExit(
+            f"unknown workload {workload!r}; expected one of {', '.join(WORKLOAD_SCRIPTS)}"
+        ) from exc
+
+
+def filter_workload_scales(workload: str, scales: str) -> tuple[str, list[str]]:
+    requested = split_csv(scales)
+    supported = set(supported_scales_for_workload(workload))
+    selected = [scale for scale in requested if scale in supported]
+    skipped = [scale for scale in requested if scale not in supported]
+    return ",".join(selected), skipped
 
 
 def load_calibration_artifact(path: Path = CALIBRATION_ARTIFACT) -> list[CalibrationArtifactRow]:
@@ -596,10 +624,22 @@ def main() -> int:
     for _ in range(args.stability_runs):
         run_summaries: list[SourceModeSummary] = []
         for workload in workloads:
+            selected_scales, skipped_scales = filter_workload_scales(workload, args.scales)
+            for scale in skipped_scales:
+                supported = ", ".join(supported_scales_for_workload(workload))
+                print(
+                    (
+                        f"WARNING: skipping unsupported scale {scale!r} "
+                        f"for {workload}; supported scales: {supported}"
+                    ),
+                    file=sys.stderr,
+                )
+            if not selected_scales:
+                continue
             run_summaries.extend(
                 run_workload(
                     workload,
-                    scales=args.scales,
+                    scales=selected_scales,
                     source_modes=args.source_modes,
                     repetitions=args.repetitions,
                     trace=args.trace,
@@ -611,6 +651,8 @@ def main() -> int:
         for run_summaries in sweep_runs
         for summary in run_summaries
     ]
+    if not summaries:
+        raise SystemExit("no supported workload/scale combinations selected")
 
     if args.stability_runs > 1:
         stability_summaries = summarize_stability(sweep_runs)

--- a/tests/test_csharp_query_source_mode_sweep.py
+++ b/tests/test_csharp_query_source_mode_sweep.py
@@ -17,6 +17,7 @@ from benchmark_csharp_query_source_mode_sweep import (  # noqa: E402
     WORKLOAD_SCRIPTS,
     calibration_failures,
     compare_calibration,
+    filter_workload_scales,
     load_calibration_artifact,
     parse_args,
     parse_mode_summary,
@@ -24,6 +25,7 @@ from benchmark_csharp_query_source_mode_sweep import (  # noqa: E402
     parse_runner_output,
     parse_workloads,
     summarize_stability,
+    supported_scales_for_workload,
 )
 from benchmark_common import csharp_query_source_mode_choices  # noqa: E402
 
@@ -47,6 +49,26 @@ class CSharpQuerySourceModeSweepTests(unittest.TestCase):
     def test_parse_workloads_rejects_unknown_workloads(self) -> None:
         with self.assertRaisesRegex(SystemExit, "unknown workload"):
             parse_workloads("category-influence,not-a-workload")
+
+    def test_filter_workload_scales_skips_unsupported_generated_graph_scales(self) -> None:
+        self.assertEqual(
+            supported_scales_for_workload("dependency-depth"),
+            ("300", "1k", "5k", "10k"),
+        )
+        self.assertEqual(
+            filter_workload_scales("dependency-depth", "dev,300"),
+            ("300", ["dev"]),
+        )
+
+    def test_filter_workload_scales_keeps_dev_for_file_backed_graph_scales(self) -> None:
+        self.assertEqual(
+            filter_workload_scales("effective-distance", "dev,300"),
+            ("dev,300", []),
+        )
+        self.assertEqual(
+            filter_workload_scales("shortest-path", "dev"),
+            ("dev", []),
+        )
 
     def test_calibration_artifact_covers_registered_graph_workloads(self) -> None:
         rows = load_calibration_artifact(CALIBRATION_ARTIFACT)


### PR DESCRIPTION
  ## Summary

  - Adds per-workload scale filtering to the C# query source-mode sweep wrapper.
  - Skips unsupported workload/scale pairs with warnings instead of aborting the whole mixed-scale sweep.
  - Documents mixed-scale behavior for `dev` plus numeric benchmark scales.
  - Adds unit coverage for generated dependency-depth workloads versus file-backed graph workloads.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_source_mode_sweep.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_source_mode_sweep.py tests/
  test_csharp_query_source_mode_sweep.py`
  - `python3 examples/benchmark/benchmark_csharp_query_source_mode_sweep.py --workloads dependency-depth,effective-
  distance --scales dev,300 --source-modes auto,preload --repetitions 1 --stability-runs 2 --format tsv`
  - `git diff --check`

  Working tree has no tracked changes after the commit. Untracked generated/data artifacts are still present and were
  not included.