### PR TITLE
feat(wam-haskell): demand-filter dispatch refactor (Phase 2a)

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2969,16 +2969,27 @@ generate_lmdb_wiring(Options, SetupCode, ContextCode, ImportCode) :-
 
 %% generate_demand_filter(+DetectedKernels, +Options, -FilterCode, -FactsSource)
 %  When demand filtering is enabled (kernels detected with an edge predicate),
-%  emit code to compute the demand set via backward BFS and filter the parents
-%  index. Otherwise emit nothing and use the unfiltered index.
+%  emit code that builds a DemandFilterSpec, dispatches via runDemandBFS, and
+%  filters the parents index. Otherwise emit nothing and use the unfiltered
+%  index.
+%
+%  The DemandFilterSpec is selected by:
+%    - declare_demand_filter/2 directive in user code (preferred)
+%    - declare_demand_filter(Strategy, Opts) option (override)
+%    - default `HopLimit Nothing` (unbounded — matches pre-Phase-2 behaviour)
+%
+%  See docs/design/WAM_DEMAND_FILTER_SPECIFICATION.md for the type.
 generate_demand_filter(DetectedKernels, Options, FilterCode, FactsSource) :-
     (   option(demand_filter(false), Options)
     ->  FilterCode = '',
         FactsSource = 'parentsIndexInterned'
     ;   DetectedKernels \= []
-    ->  FilterCode =
+    ->  resolve_demand_filter_spec(Options, SpecHs),
+        format(string(FilterCode),
 '    let !rootId = iAtom root
-        !demandSet = computeDemandSet parentsIndexInterned rootId
+        !demandFilterSpec = ~w
+        !demandFilterResult = runDemandBFS demandFilterSpec parentsIndexInterned rootId
+        !demandSet = dfrInSet demandFilterResult
         !demandSize = IS.size demandSet
         !totalNodes = IM.size parentsIndexInterned
         !filteredParents = filterByDemand demandSet parentsIndexInterned
@@ -2990,10 +3001,56 @@ generate_demand_filter(DetectedKernels, Options, FilterCode, FactsSource) :-
         -- seeds are gated out (e.g. 50k_cats: 49989/50000 skipped).
         !filteredSeedCats = filter (\\cat -> IS.member (iAtom cat) demandSet) seedCats
         !demandSkippedSeeds = length seedCats - length filteredSeedCats',
+            [SpecHs]),
         FactsSource = 'filteredParents'
     ;   FilterCode = '',
         FactsSource = 'parentsIndexInterned'
     ).
+
+%% resolve_demand_filter_spec(+Options, -SpecHs)
+%  Pick the DemandFilterSpec literal to emit into Main.hs.
+%  Precedence:
+%    1. demand_filter_spec(Strategy, Opts) in Options.
+%    2. user:demand_filter_spec(Strategy, Opts) declared in workload.
+%    3. Default: HopLimit Nothing (unbounded — legacy behaviour).
+resolve_demand_filter_spec(Options, SpecHs) :-
+    (   option(demand_filter_spec(Strategy, FilterOpts), Options)
+    ->  emit_demand_filter_spec(Strategy, FilterOpts, SpecHs)
+    ;   catch(user:demand_filter_spec(Strategy, FilterOpts), _, fail)
+    ->  emit_demand_filter_spec(Strategy, FilterOpts, SpecHs)
+    ;   SpecHs = '(HopLimit Nothing)'
+    ).
+
+%% emit_demand_filter_spec(+Strategy, +FilterOpts, -SpecHs)
+%  Translate a (Strategy, Options) Prolog term into a Haskell
+%  DemandFilterSpec literal. Validates strategy + options.
+emit_demand_filter_spec(hop_limit, FilterOpts, SpecHs) :- !,
+    (   memberchk(max_hops(N), FilterOpts), integer(N), N >= 0
+    ->  format(string(SpecHs), '(HopLimit (Just ~d))', [N])
+    ;   memberchk(unbounded, FilterOpts)
+    ->  SpecHs = '(HopLimit Nothing)'
+    ;   SpecHs = '(HopLimit Nothing)'
+    ).
+emit_demand_filter_spec(flux, FilterOpts, SpecHs) :- !,
+    %% Flux is accepted at codegen but panics at runtime until Phase 2.5.
+    (   memberchk(target_count(K), FilterOpts), integer(K), K >= 0
+    ->  CacheTopK = K
+    ;   memberchk(target_fraction(_F), FilterOpts)
+    ->  %% target_fraction needs runtime knowledge of universe size; emit
+        %% a placeholder K that the Phase 2.5 implementation will replace.
+        CacheTopK = 0
+    ;   CacheTopK = 0
+    ),
+    (   memberchk(sort_sparks(false), FilterOpts)
+    ->  SortSparks = 'False'
+    ;   SortSparks = 'True'
+    ),
+    format(string(SpecHs), '(Flux ~d ~w)', [CacheTopK, SortSparks]).
+emit_demand_filter_spec(none, _FilterOpts, 'DfNone') :- !.
+emit_demand_filter_spec(Strategy, _FilterOpts, _) :-
+    format(user_error,
+        '[wam_haskell] unknown demand filter strategy: ~w~n', [Strategy]),
+    throw(error(domain_error(demand_filter_strategy, Strategy), _)).
 
 %% generate_demand_gated_query_body(+DemandFilter, +RawQueryBody, -QueryBody)
 %

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -378,23 +378,80 @@ extractDouble _ (Float h) = Just h
 extractDouble tbl (Atom aid) = case reads (lookupAtom tbl aid) of [(h, "")] -> Just h; _ -> Nothing
 extractDouble _ _ = Nothing
 
--- | Compute the backward-reachable demand set from a root node.
--- Given a child→[parents] adjacency map, returns all nodes that can
--- reach rootId via the edge relation (backward BFS fixpoint).
-computeDemandSet :: IM.IntMap [Int] -> Int -> IS.IntSet
-computeDemandSet parents rootId = bfs (IS.singleton rootId) (IS.singleton rootId)
+-- | DemandFilterSpec selects which demand-filter strategy the runtime
+-- runs. See docs/design/WAM_DEMAND_FILTER_SPECIFICATION.md.
+--   HopLimit Nothing  — unbounded reverse BFS (legacy default, matches
+--                       today's behaviour when no directive is declared).
+--   HopLimit (Just n) — depth-bounded reverse BFS (sound when n ≥ kernel
+--                       max_depth; misses unreachable seeds otherwise).
+--   Flux _ _          — flux-weighted top-K with optional spark sort.
+--                       Phase 2.5; emits panic at runtime in Phase 2.
+--   DfNone            — no filter; demand set is the full universe of
+--                       node IDs in the edge map.
+data DemandFilterSpec
+  = HopLimit { dfMaxHops :: !(Maybe Int) }
+  | Flux     { dfCacheTopK :: !Int, dfSortSparks :: !Bool }
+  | DfNone
+  deriving (Show)
+
+-- | Output of a single runDemandBFS call. The seed pre-filter consumes
+-- dfrInSet; cache warming consumes dfrFluxScores when present;
+-- spark scheduling consumes dfrSortedSeeds when present.
+data DemandFilterResult = DemandFilterResult
+  { dfrInSet       :: !IS.IntSet
+  , dfrSortedSeeds :: !(Maybe [Int])
+  , dfrFluxScores  :: !(Maybe (IM.IntMap Double))
+  } deriving (Show)
+
+-- | Dispatch on DemandFilterSpec and produce a DemandFilterResult.
+-- HopLimit and DfNone are implemented in Phase 2; Flux is a panic stub
+-- until Phase 2.5.
+runDemandBFS :: DemandFilterSpec -> IM.IntMap [Int] -> Int -> DemandFilterResult
+runDemandBFS spec parents rootId = case spec of
+  HopLimit maxHops ->
+    DemandFilterResult
+      { dfrInSet       = computeDemandSetHopLimited parents rootId maxHops
+      , dfrSortedSeeds = Nothing
+      , dfrFluxScores  = Nothing
+      }
+  Flux {} ->
+    error "runDemandBFS: Flux strategy not yet implemented (Phase 2.5). \
+          \Use HopLimit or DfNone."
+  DfNone ->
+    DemandFilterResult
+      { dfrInSet       = IS.fromList (IM.keys parents)
+      , dfrSortedSeeds = Nothing
+      , dfrFluxScores  = Nothing
+      }
+
+-- | Compute the backward-reachable demand set from a root node, with an
+-- optional hop limit. Nothing = unbounded (legacy behaviour). The bound
+-- counts edges traversed, so HopLimit (Just 0) returns just {rootId}.
+computeDemandSetHopLimited :: IM.IntMap [Int] -> Int -> Maybe Int -> IS.IntSet
+computeDemandSetHopLimited parents rootId maxHops =
+    bfs 0 (IS.singleton rootId) (IS.singleton rootId)
   where
     -- Build reverse adjacency: parent → [children]
     !reverseAdj = IM.fromListWith (++)
         [(p, [child]) | (child, ps) <- IM.toList parents, p <- ps]
-    bfs frontier visited
+    bfs !depth !frontier !visited
       | IS.null frontier = visited
+      | exceededHopLimit depth = visited
       | otherwise =
           let newNodes = IS.fromList
                 [ c | node <- IS.toList frontier
                     , c <- IM.findWithDefault [] node reverseAdj
                     , not (IS.member c visited) ]
-          in bfs newNodes (IS.union visited newNodes)
+          in bfs (depth + 1) newNodes (IS.union visited newNodes)
+    exceededHopLimit !d = case maxHops of
+      Nothing -> False
+      Just n  -> d >= n
+
+-- | Backward-compat alias for unbounded demand BFS. Pre-Phase-2 callers
+-- and any test asserting this name keep working unchanged.
+computeDemandSet :: IM.IntMap [Int] -> Int -> IS.IntSet
+computeDemandSet parents rootId =
+    computeDemandSetHopLimited parents rootId Nothing
 
 -- | Filter a child→[parents] map to the structural demand set.
 -- Iterates the usually-small demand set instead of scanning every graph node.

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1410,7 +1410,9 @@ test_demand_filter_gates_seed_query_body :-
             Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, "let seedCatsAll = map head $ group $ sort $ map snd articleCategories"),
-        sub_string(S, _, _, _, "!demandSet = computeDemandSet parentsIndexInterned rootId"),
+        sub_string(S, _, _, _, "!demandFilterSpec = (HopLimit Nothing)"),
+        sub_string(S, _, _, _, "!demandFilterResult = runDemandBFS demandFilterSpec parentsIndexInterned rootId"),
+        sub_string(S, _, _, _, "!demandSet = dfrInSet demandFilterResult"),
         sub_string(S, _, _, _, "!reverseAdj = IM.fromListWith (++)"),
         sub_string(S, _, _, _, "filterByDemand demandSet parents = IS.foldl' addChild IM.empty demandSet"),
         sub_string(S, _, _, _, "!filteredSeedCats = filter (\\cat -> IS.member (iAtom cat) demandSet) seedCats"),
@@ -1421,6 +1423,76 @@ test_demand_filter_gates_seed_query_body :-
         sub_string(S, _, _, _, "demand_skipped_seeds=")
     ->  pass(Test)
     ;   fail_test(Test, 'Demand-filtered Main.hs should pre-filter seeds before parMap')
+    ).
+
+test_demand_filter_hop_limit_with_max_hops :-
+    Test = 'WAM-Haskell: demand_filter_spec(hop_limit, [max_hops(N)]) emits HopLimit (Just N)',
+    Kernel = recursive_kernel(category_ancestor, 'category_ancestor'/4,
+                              [max_depth(10), edge_pred(category_parent/2)]),
+    (   wam_haskell_target:generate_main_hs(
+            [],
+            ['category_ancestor/4'-Kernel],
+            [],
+            [demand_filter_spec(hop_limit, [max_hops(7)])],
+            Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "!demandFilterSpec = (HopLimit (Just 7))"),
+        sub_string(S, _, _, _, "runDemandBFS demandFilterSpec parentsIndexInterned rootId")
+    ->  pass(Test)
+    ;   fail_test(Test, 'demand_filter_spec(hop_limit, [max_hops(7)]) should emit HopLimit (Just 7)')
+    ).
+
+test_demand_filter_none_emits_dfnone :-
+    Test = 'WAM-Haskell: demand_filter_spec(none, []) emits DfNone',
+    Kernel = recursive_kernel(category_ancestor, 'category_ancestor'/4,
+                              [max_depth(10), edge_pred(category_parent/2)]),
+    (   wam_haskell_target:generate_main_hs(
+            [],
+            ['category_ancestor/4'-Kernel],
+            [],
+            [demand_filter_spec(none, [])],
+            Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "!demandFilterSpec = DfNone"),
+        sub_string(S, _, _, _, "runDemandBFS demandFilterSpec parentsIndexInterned rootId")
+    ->  pass(Test)
+    ;   fail_test(Test, 'demand_filter_spec(none, []) should emit DfNone')
+    ).
+
+test_demand_filter_flux_emits_panic_stub_compatible :-
+    Test = 'WAM-Haskell: demand_filter_spec(flux, [...]) emits Flux constructor (panics at runtime in Phase 2)',
+    Kernel = recursive_kernel(category_ancestor, 'category_ancestor'/4,
+                              [max_depth(10), edge_pred(category_parent/2)]),
+    (   wam_haskell_target:generate_main_hs(
+            [],
+            ['category_ancestor/4'-Kernel],
+            [],
+            [demand_filter_spec(flux, [target_count(5000), sort_sparks(true)])],
+            Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "!demandFilterSpec = (Flux 5000 True)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'demand_filter_spec(flux, [...]) should emit Flux constructor for runtime to panic on')
+    ).
+
+test_demand_filter_invalid_strategy_rejected :-
+    Test = 'WAM-Haskell: demand_filter_spec with unknown strategy throws domain_error',
+    Kernel = recursive_kernel(category_ancestor, 'category_ancestor'/4,
+                              [max_depth(10), edge_pred(category_parent/2)]),
+    (   catch(
+            wam_haskell_target:generate_main_hs(
+                [],
+                ['category_ancestor/4'-Kernel],
+                [],
+                [demand_filter_spec(bogus_strategy, [])],
+                _Code),
+            error(domain_error(demand_filter_strategy, bogus_strategy), _),
+            (true, ThrewDomainError = true))
+    ->  (   ThrewDomainError == true
+        ->  pass(Test)
+        ;   fail_test(Test, 'unknown strategy should throw domain_error')
+        )
+    ;   fail_test(Test, 'unknown strategy should throw domain_error')
     ).
 
 test_demand_filter_false_leaves_query_ungated :-
@@ -1979,6 +2051,10 @@ run_tests :-
     test_b1_external_source_default_allow_list,
     test_b1_external_source_off_without_use_lmdb,
     test_demand_filter_gates_seed_query_body,
+    test_demand_filter_hop_limit_with_max_hops,
+    test_demand_filter_none_emits_dfnone,
+    test_demand_filter_flux_emits_panic_stub_compatible,
+    test_demand_filter_invalid_strategy_rejected,
     test_demand_filter_false_leaves_query_ungated,
     %% max_depth substitution (regression for linear-chain-zero-results)
     test_max_depth_default_10_when_no_user_fact,


### PR DESCRIPTION
  ## Summary

  Lifts the inline demand BFS in generated `Main.hs` into a `DemandFilterSpec` sum type + `runDemandBFS` dispatch
  function. **Pure refactor**: scale-300 stdout sha `70bbc9ffa4cf` (271 rows) matches exactly. Lays the structural
  groundwork for Phase 2b (LMDB-resident interning + LMDB-cursor BFS) and Phase 2.5 (Flux strategy implementation).

  This is the first concrete code landing the design package from PR #1907.

  ## Why split this from Phase 2b

  Combined Phase 2 (dispatch refactor + LMDB-resident) was originally scoped as one PR but broke down into two cleanly
  verifiable halves:

  - **Phase 2a (this PR)**: dispatch refactor on the in-memory `IntMap` path. Pure refactor — sha must be
  byte-identical, which is a clean gate.
  - **Phase 2b (next PR)**: `int_atom_seeds(lmdb)` mode + LMDB-cursor BFS. Where the actual perf win lands; sha
  unchanged is still the gate, plus `total_ms` floor on `100k_cats` should drop.

  Splitting attribution: if 2a regresses sha, it's the dispatch refactor; if 2b regresses, it's the LMDB part. Each half
   is small enough to review without bisecting inside the diff.

  ## What changed

  ### `templates/targets/haskell_wam/main.hs.mustache`

  - New `DemandFilterSpec` sum type:
    ```haskell
    data DemandFilterSpec
      = HopLimit { dfMaxHops :: !(Maybe Int) }   -- Nothing = unbounded (today's default)
      | Flux     { dfCacheTopK :: !Int, dfSortSparks :: !Bool }
      | DfNone
    ```
  - New `DemandFilterResult` record carrying `inSet`, optional `sortedSeeds`, optional `fluxScores`.
  - New `runDemandBFS :: DemandFilterSpec -> IM.IntMap [Int] -> Int -> DemandFilterResult` dispatcher. `HopLimit` and
  `DfNone` are implemented; `Flux` panics at runtime with a clear "Phase 2.5 — not yet implemented" message until 2.5
  lands.
  - New `computeDemandSetHopLimited` with `Maybe Int` hop bound (`Nothing` = unbounded). The default emission `HopLimit
  Nothing` is byte-equivalent to today's unbounded reverse BFS.
  - Existing `computeDemandSet` kept as a backward-compat alias around the new hop-limited implementation.

  ### `src/unifyweaver/targets/wam_haskell_target.pl`

  - `generate_demand_filter/4` now emits a `DemandFilterSpec` literal and a `runDemandBFS` call instead of the inline
  `computeDemandSet` call.
  - New `resolve_demand_filter_spec/2` picks the spec from `demand_filter_spec(...)` Options or
  `user:demand_filter_spec/2` declared in the workload, defaulting to `(HopLimit Nothing)` for pre-Phase-2 backward
  compatibility.
  - New `emit_demand_filter_spec/3` translates Prolog spec terms to Haskell `DemandFilterSpec` literals, validates
  strategy name (`hop_limit` / `flux` / `none`), and rejects unknown strategies with `domain_error`.
  - `Flux` codegen accepts `target_count(K)` directly; `target_fraction(F)` is reserved for Phase 2.5 (needs runtime
  knowledge of universe size).

  ### `tests/test_wam_haskell_target.pl`

  - Updated `test_demand_filter_gates_seed_query_body` to assert the new dispatch shape (`demandFilterSpec`,
  `runDemandBFS`, `dfrInSet`).
  - Added `test_demand_filter_hop_limit_with_max_hops` — explicit `max_hops(N)` emits `HopLimit (Just N)`.
  - Added `test_demand_filter_none_emits_dfnone` — `none` strategy emits `DfNone`.
  - Added `test_demand_filter_flux_emits_panic_stub_compatible` — `flux` strategy emits the constructor (runtime panics
  until 2.5).
  - Added `test_demand_filter_invalid_strategy_rejected` — unknown strategy throws `domain_error` at codegen time.

  ## Verification

  - [x] `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl` — all green, including the four new tests
  - [x] `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 300 --include-targets
  haskell-interp-ffi --repetitions 1` — `haskell-interp-ffi` produces sha `70bbc9ffa4cf` (271 rows), unchanged from
  pre-refactor

  ## What this does NOT do

  - Does **not** wire LMDB-cursor BFS — that's Phase 2b.
  - Does **not** implement `Flux` — the constructor compiles, runtime panics with a clear message. Phase 2.5.
  - Does **not** change any defaults visible to existing workloads — `HopLimit Nothing` is byte-equivalent to today's
  `computeDemandSet`. Workloads that don't set `demand_filter_spec` see no change.

  ## Refs

  - `docs/design/WAM_DEMAND_FILTER_PHILOSOPHY.md` (#1907)
  - `docs/design/WAM_DEMAND_FILTER_SPECIFICATION.md` (#1907) — `DemandFilterSpec` shape, codegen surface, runtime
  contract
  - `docs/design/WAM_DEMAND_FILTER_IMPLEMENTATION_PLAN.md` (#1907) — Phase 2a is this PR; 2b and 2.5 are follow-ups
  - `docs/design/WAM_LMDB_RESIDENT_INTERNING_*.md` (#1901, #1904) — the storage-layer companion design

  ## Test plan

  - [x] All existing `test_wam_haskell_target.pl` tests pass
  - [x] Four new dispatch tests pass
  - [x] Scale-300 sha unchanged
  - [ ] Phase 2b lands on a follow-up branch and ships the LMDB-cursor BFS
  - [ ] Phase 2.5 replaces the `Flux` panic stub with the real implementation

  🤖 Generated with [Claude Code](https://claude.com/claude-code)