### PR TITLE
fix(wam-r): prefix predicate wrappers with pred_ to avoid base shadows

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -101,7 +101,11 @@ The program prints `true` or `false` and exits with status 0 / 1.
 
 For richer drivers, source the generated program from another R
 script and call `WamRuntime$run_predicate(shared_program, start_pc,
-args)` directly.
+args)` directly. Each predicate also gets a `pred_<name>(...)`
+wrapper at top level (e.g. a Prolog `ancestor/2` exposes
+`pred_ancestor(x, y)`); the `pred_` prefix avoids clashes with
+base R functions when the user's predicate name is `c`, `t`, `q`,
+`cat`, etc.
 
 ## Architecture
 
@@ -422,7 +426,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 41 tests covering both structural assertions on the
+and contains 42 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -457,6 +461,7 @@ Coverage map (e2e tests, by feature group):
 | `multi_solution_retract_e2e_rscript` | multi-solution `retract/1` via iter-CP |
 | `bagof_setof_existential_e2e_rscript` | `^/2` existential scope in `bagof`/`setof`/`findall` |
 | `cli_arg_parser_e2e_rscript` | structured CLI args (lists, structs, expressions) parse via the runtime parser |
+| `base_name_clash_e2e_rscript` | predicates named after base R functions (`c`, `t`, `q`, `cat`) don't shadow them |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -679,19 +679,18 @@ pred_arg_strings(Arity, ArgDeclStr, ArgListStr) :-
     format(string(ArgListStr), 'list(~w)', [ArgDeclStr]).
 
 %% r_pred_name(+PrologName, -RName)
-%  R uses snake_case by convention; identifiers are looser than Scala
-%  so we keep the Prolog name verbatim, with safety substitutions.
+%  Generates the R identifier for a per-predicate wrapper. We
+%  always prefix with `pred_` so the wrapper can never collide
+%  with a base R function (e.g. `c`, `t`, `q`, `cat`, `paste`,
+%  `tryCatch`); without the prefix, asserting a Prolog predicate
+%  literally named `c/2` would shadow `base::c` and crash the
+%  runtime's own use of `c(...)` for vector construction.
 r_pred_name(Pred, RName) :-
     atom_string(Pred, PStr),
     string_chars(PStr, Chars),
     maplist(r_safe_ident_char, Chars, SafeChars),
     string_chars(SafeStr, SafeChars),
-    % R identifiers can't start with a digit
-    (   string_chars(SafeStr, [First|_]),
-        char_type(First, digit)
-    ->  string_concat("p_", SafeStr, RName0)
-    ;   RName0 = SafeStr
-    ),
+    string_concat("pred_", SafeStr, RName0),
     atom_string(RName, RName0).
 
 r_safe_ident_char(C, C) :-

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -589,12 +589,9 @@ WamRuntime$tokenize_term <- function(text) {
   is_digit <- function(ch) grepl("^[0-9]$", ch)
   # Symbol chars used in Prolog operators. `,`, `;`, `|` get their
   # own token types so the parser can switch behaviour at separator
-  # vs operator positions. We qualify `c` and other base helpers
-  # below as `base::*` because the generated program may contain a
-  # per-predicate wrapper that shadows `c`/`t`/`q` etc. when the
-  # user has a predicate of the same name.
-  sym_chars <- base::c("+", "-", "*", "/", "\\", "^", "<", ">",
-                       "=", ":", "@", ".", "?", "~", "#", "$", "&")
+  # vs operator positions.
+  sym_chars <- c("+", "-", "*", "/", "\\", "^", "<", ">",
+                 "=", ":", "@", ".", "?", "~", "#", "$", "&")
   is_sym <- function(ch) ch %in% sym_chars
   while (i <= n) {
     c <- chars[i]

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -117,8 +117,8 @@ test(predicate_wrappers) :-
             TmpDir),
         directory_file_path(TmpDir, 'R/generated_program.R', Program),
         read_file_to_string(Program, Code, []),
-        assertion(sub_string(Code, _, _, _, 'wam_r_caller <- function(')),
-        assertion(sub_string(Code, _, _, _, 'wam_r_fact <- function(')),
+        assertion(sub_string(Code, _, _, _, 'pred_wam_r_caller <- function(')),
+        assertion(sub_string(Code, _, _, _, 'pred_wam_r_fact <- function(')),
         assertion(sub_string(Code, _, _, _, 'WamRuntime$run_predicate(shared_program,')),
         delete_directory_and_contents(TmpDir)
     )).
@@ -202,7 +202,7 @@ test(foreign_handler_wiring) :-
         % The supplied handler body is verbatim in the file.
         assertion(sub_string(Code, _, _, _, 'list(ok = TRUE, bindings = list(list(idx = 2L,')),
         % Top-level wrapper exists too.
-        assertion(sub_string(Code, _, _, _, 'r_double <- function(')),
+        assertion(sub_string(Code, _, _, _, 'pred_r_double <- function(')),
         delete_directory_and_contents(TmpDir)
     )).
 
@@ -2008,6 +2008,58 @@ e2e_cli_arg_parser_via_rscript :-
                    [Pred, Args, Expected, Out]),
             assertion(false)
         )
+    )),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
+% End-to-end Rscript run for predicates whose names collide with
+% base R functions. The wrapper-name generator prefixes every
+% per-predicate wrapper with `pred_` so user predicates named `c`,
+% `t`, `q`, `cat`, `paste`, ... don't shadow the runtime's own
+% calls to those base functions. Without the prefix, asserting
+% `c/2` would replace `base::c` at the top level and the runtime's
+% tokenizer (and other paths that build vectors via `c(...)`) would
+% crash.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(base_name_clash_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_base_name_clash_via_rscript
+    ;   true
+    )).
+
+e2e_base_name_clash_via_rscript :-
+    assertz((user:c(1, 2))),
+    assertz((user:c(2, 3))),
+    assertz((user:t(hello))),
+    assertz((user:q(forty_two, 42))),
+    assertz((user:cat(meow))),
+    assertz((user:check_c   :- c(1, 2))),
+    assertz((user:check_t   :- t(hello))),
+    assertz((user:check_q   :- q(forty_two, X), X =:= 42)),
+    assertz((user:check_cat :- cat(meow))),
+    % Also invoke the parser path directly (term_to_atom reverse
+    % mode walks tokenize_term, which builds vectors via c(...) --
+    % this would have crashed with the old wrapper naming when c/2
+    % was asserted above).
+    assertz((user:check_parser :-
+        atom_codes(A, [102, 40, 49, 41]),  % "f(1)"
+        term_to_atom(T, A),
+        T == f(1))),
+    unique_r_tmp_dir('tmp_r_baseclash_e2e', TmpDir),
+    write_wam_r_project(
+        [user:c/2, user:t/1, user:q/2, user:cat/1,
+         user:check_c/0, user:check_t/0, user:check_q/0,
+         user:check_cat/0, user:check_parser/0],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [check_c, check_t, check_q, check_cat, check_parser],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
     )),
     delete_directory_and_contents(TmpDir).
 


### PR DESCRIPTION
## Summary

Closes the wrapper-name footgun called out in PR #1909. The per-predicate wrapper functions emitted at the top level of the generated R program used to take the predicate's name verbatim (with safe-identifier substitutions), so a Prolog predicate literally named `c/2` generated:

```r
c <- function(a1, a2) { WamRuntime$run_predicate(...) }
```

That shadows `base::c` at the top level and breaks every runtime path that builds a vector via `c(...)` (the tokenizer's symbol-char list, the build-arg helper, the trail unwinder, and so on). Other base names -- `t`, `q`, `cat`, `paste`, `tryCatch` -- had the same problem.

`r_pred_name` now unconditionally prepends `pred_`, so the `c/2` predicate exposes `pred_c(...)` and the shadow is impossible by construction. The targeted `base::c` patch added in #1909's tokenizer is reverted -- the structural fix here makes the band-aid unnecessary.

## Test plan

- [x] Tests that asserted exact wrapper names (`predicate_wrappers`, `foreign_handler_e2e_rscript`, two lowered-emitter tests) updated to assert the new `pred_` prefix.
- [x] New `base_name_clash_e2e_rscript`: asserts Prolog predicates literally named `c/2`, `t/1`, `q/2`, `cat/1` and exercises both direct calls and the tokenizer's `c(...)`-using parser path. Without the prefix this would have crashed; with it, all five sub-predicates pass.
- [x] Full suite: 42 tests pass.

## Caller-visible change

Code that sources the generated program from R and calls the wrapper directly needs to update from `<name>(...)` to `pred_<name>(...)`. The CLI invocation `Rscript R/generated_program.R '<name>/<arity>' ...` is unaffected; doc updated to document the prefix.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_