### PR TITLE
feat(wam-haskell): int_atom_seeds(lmdb) codegen surface (Phase 2b.1)

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2822,9 +2822,22 @@ generate_main_hs(_Predicates, DetectedKernels, InlineDefs, Options, Code) :-
     % as int32 IDs from the LMDB ingest pipeline, skip the TSV-based
     % seed loading and string interning.  Gated by section blocks in the
     % template; this just exposes the flag to the renderer.
-    (   option(int_atom_seeds(true), Options)
-    ->  IntAtomSeeds = true
-    ;   IntAtomSeeds = false
+    %
+    % Three modes:
+    %   int_atom_seeds(false) (default) — TSV mode; full string parsing.
+    %   int_atom_seeds(true)            — int_ids.txt files; iAtom = id.
+    %   int_atom_seeds(lmdb)            — Phase 2b.1: codegen surface only;
+    %                                     runtime panics with a clear
+    %                                     "not yet implemented" message
+    %                                     pending Phase 2b.2.
+    (   option(int_atom_seeds(lmdb), Options)
+    ->  IntAtomSeeds = true,
+        IntAtomSeedsLmdb = true
+    ;   option(int_atom_seeds(true), Options)
+    ->  IntAtomSeeds = true,
+        IntAtomSeedsLmdb = false
+    ;   IntAtomSeeds = false,
+        IntAtomSeedsLmdb = false
     ),
     % Resolve max_depth at codegen time. Reads user:max_depth/1 (asserted
     % by the workload or overridden by tests) so the generated FFI kernel
@@ -2850,6 +2863,7 @@ generate_main_hs(_Predicates, DetectedKernels, InlineDefs, Options, Code) :-
         , lmdb_context=LmdbContext
         , lmdb_import=LmdbImport
         , int_atom_seeds=IntAtomSeeds
+        , int_atom_seeds_lmdb=IntAtomSeedsLmdb
         , max_depth=MaxDepth
         , dimension_n=DimN
         , parmap_seed_source=ParmapSeedSource

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -126,6 +126,21 @@ main = do
 
     t0 <- getCurrentTime
 
+{{#int_atom_seeds_lmdb}}
+    -- Phase 2b.1: int_atom_seeds(lmdb) codegen surface is wired up,
+    -- but the runtime LMDB-resident loaders (loadInternTableFromLmdb,
+    -- loadArticleCategoriesFromLmdb, loadForwardEdgesFromLmdb) ship
+    -- in Phase 2b.2.  Until then, this mode panics at startup with a
+    -- clear message.  Falls back to int_atom_seeds(true) (seed_ids.txt)
+    -- or omitting the flag (TSV mode) for current workloads.
+    --
+    -- See docs/design/WAM_LMDB_RESIDENT_INTERNING_*.md and
+    -- docs/design/WAM_DEMAND_FILTER_*.md for the design.
+    fail "int_atom_seeds(lmdb): runtime LMDB-resident loaders not yet \
+         \implemented (Phase 2b.2). Use int_atom_seeds(true) with \
+         \seed_ids.txt / root_ids.txt, or omit the flag for TSV mode."
+{{/int_atom_seeds_lmdb}}
+
 {{^int_atom_seeds}}
     -- Load facts from TSV (string-keyed seeds and edges)
     categoryParents <- loadTsvPairs (factsDir ++ "/category_parent.tsv")

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1475,6 +1475,58 @@ test_demand_filter_flux_emits_panic_stub_compatible :-
     ;   fail_test(Test, 'demand_filter_spec(flux, [...]) should emit Flux constructor for runtime to panic on')
     ).
 
+test_int_atom_seeds_lmdb_emits_panic_stub :-
+    Test = 'WAM-Haskell: int_atom_seeds(lmdb) emits Phase 2b.2 runtime panic stub',
+    Kernel = recursive_kernel(category_ancestor, 'category_ancestor'/4,
+                              [max_depth(10), edge_pred(category_parent/2)]),
+    (   wam_haskell_target:generate_main_hs(
+            [],
+            ['category_ancestor/4'-Kernel],
+            [],
+            [int_atom_seeds(lmdb)],
+            Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "int_atom_seeds(lmdb): runtime LMDB-resident loaders not yet"),
+        sub_string(S, _, _, _, "Phase 2b.2"),
+        sub_string(S, _, _, _, "fail \"")
+    ->  pass(Test)
+    ;   fail_test(Test, 'int_atom_seeds(lmdb) should emit a runtime panic stub')
+    ).
+
+test_int_atom_seeds_true_does_not_emit_lmdb_panic :-
+    Test = 'WAM-Haskell: int_atom_seeds(true) does NOT emit the LMDB panic stub',
+    Kernel = recursive_kernel(category_ancestor, 'category_ancestor'/4,
+                              [max_depth(10), edge_pred(category_parent/2)]),
+    (   wam_haskell_target:generate_main_hs(
+            [],
+            ['category_ancestor/4'-Kernel],
+            [],
+            [int_atom_seeds(true)],
+            Code),
+        atom_string(Code, S),
+        \+ sub_string(S, _, _, _, "Phase 2b.2"),
+        \+ sub_string(S, _, _, _, "int_atom_seeds(lmdb): runtime LMDB-resident")
+    ->  pass(Test)
+    ;   fail_test(Test, 'int_atom_seeds(true) should not emit the LMDB-mode panic')
+    ).
+
+test_int_atom_seeds_default_does_not_emit_lmdb_panic :-
+    Test = 'WAM-Haskell: default mode does NOT emit the LMDB panic stub',
+    Kernel = recursive_kernel(category_ancestor, 'category_ancestor'/4,
+                              [max_depth(10), edge_pred(category_parent/2)]),
+    (   wam_haskell_target:generate_main_hs(
+            [],
+            ['category_ancestor/4'-Kernel],
+            [],
+            [],
+            Code),
+        atom_string(Code, S),
+        \+ sub_string(S, _, _, _, "Phase 2b.2"),
+        \+ sub_string(S, _, _, _, "int_atom_seeds(lmdb): runtime LMDB-resident")
+    ->  pass(Test)
+    ;   fail_test(Test, 'default mode should not emit the LMDB-mode panic')
+    ).
+
 test_demand_filter_invalid_strategy_rejected :-
     Test = 'WAM-Haskell: demand_filter_spec with unknown strategy throws domain_error',
     Kernel = recursive_kernel(category_ancestor, 'category_ancestor'/4,
@@ -2054,6 +2106,9 @@ run_tests :-
     test_demand_filter_hop_limit_with_max_hops,
     test_demand_filter_none_emits_dfnone,
     test_demand_filter_flux_emits_panic_stub_compatible,
+    test_int_atom_seeds_lmdb_emits_panic_stub,
+    test_int_atom_seeds_true_does_not_emit_lmdb_panic,
+    test_int_atom_seeds_default_does_not_emit_lmdb_panic,
     test_demand_filter_invalid_strategy_rejected,
     test_demand_filter_false_leaves_query_ungated,
     %% max_depth substitution (regression for linear-chain-zero-results)


### PR DESCRIPTION
  ## Summary

  Wires the `int_atom_seeds(lmdb)` option through the codegen and adds a new mustache section that emits a runtime panic
   stub. Phase 2b.2 (next PR) will replace the stub with the actual LMDB-resident loaders (`loadInternTableFromLmdb`,
  `loadArticleCategoriesFromLmdb`, `loadForwardEdgesFromLmdb`).

  **Pure surface-establishment**: scale-300 stdout sha `70bbc9ffa4cf` unchanged. The new mode is opt-in, never triggered
   by existing workloads. The runtime panic is reachable only when a user explicitly passes `int_atom_seeds(lmdb)` and
  runs the binary.

  ## Why a separate phase for codegen surface

  Phase 2b was originally scoped as one PR but the runtime LMDB-resident loaders need careful cursor-lifetime work
  against the raw `Database.LMDB.Raw` API used by `lmdb_fact_source.hs.mustache`. Splitting the codegen surface from the
   runtime loaders means:

  - This PR is a small mechanical addition — option parsing, template var, panic stub, three codegen tests. ~90 lines.
  - Phase 2b.2 can focus exclusively on cursor semantics, byte decoding, and reverse-edge memory budget without
  entangling them with codegen wiring.
  - Each phase has a clean pass/fail gate: 2b.1 verifies sha unchanged; 2b.2 verifies sha unchanged AND `total_ms` floor
   drops on `100k_cats`.

  ## What changed

  ### `src/unifyweaver/targets/wam_haskell_target.pl`

  `generate_main_hs/4` now recognises three modes:

  | Option | Behaviour |
  |---|---|
  | `int_atom_seeds(false)` (default, omitted) | TSV mode — full string parsing + intern build |
  | `int_atom_seeds(true)` | int-id files mode — reads `seed_ids.txt` / `root_ids.txt`; `iAtom = id` |
  | `int_atom_seeds(lmdb)` | **NEW** — Phase 2b.1: codegen surface only; runtime panics |

  A new `IntAtomSeedsLmdb` template variable is threaded through `render_template`. When `lmdb` mode is selected, both
  `IntAtomSeeds=true` and `IntAtomSeedsLmdb=true` are emitted; the panic fires before any int-ids-files load would
  matter at runtime.

  ### `templates/targets/haskell_wam/main.hs.mustache`

  New `{{#int_atom_seeds_lmdb}}` block emitted right after `t0 <- getCurrentTime`:

  ```haskell
  fail "int_atom_seeds(lmdb): runtime LMDB-resident loaders not yet \
       \implemented (Phase 2b.2). Use int_atom_seeds(true) with \
       \seed_ids.txt / root_ids.txt, or omit the flag for TSV mode."
  ```

  Users see a clear actionable error message pointing to existing fallback modes.

  ### `tests/test_wam_haskell_target.pl`

  Three new codegen tests, all passing:

  - `test_int_atom_seeds_lmdb_emits_panic_stub` — assert the panic message and `fail "` call are present in generated
  `Main.hs`.
  - `test_int_atom_seeds_true_does_not_emit_lmdb_panic` — defensively assert the int-ids-files mode does **not** include
   the LMDB panic (so the new section block doesn't leak into existing workloads).
  - `test_int_atom_seeds_default_does_not_emit_lmdb_panic` — same defensive check for the default TSV mode.

  ## Verification

  - [x] `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl` — all green, including the three new tests
  - [x] `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 300 --include-targets
  haskell-interp-ffi --repetitions 1` — `haskell-interp-ffi` produces sha `70bbc9ffa4cf` (271 rows), unchanged from main

  ## What this does NOT do

  - Does **not** read from LMDB at runtime — the new mode panics if invoked. Phase 2b.2.
  - Does **not** change the existing `int_atom_seeds(true)` or default TSV paths — both remain byte-identical.
  - Does **not** add new Haskell or Python dependencies.

  ## Phase 2b.2 follow-up scope

  The next PR will:

  - Implement `loadInternTableFromLmdb :: MDB_env -> IO InternTable` reading `s2i` / `i2s` sub-dbs into the existing
  `InternTable` record.
  - Implement `loadArticleCategoriesFromLmdb :: MDB_env -> IO [(Int, Int)]` iterating the `article_category` sub-db.
  - Implement `loadForwardEdgesFromLmdb :: MDB_env -> Text -> IO (IM.IntMap [Int])` iterating `category_parent`.
  - Add a configurable edge-count threshold (panic above ~5M edges with a clear "extend the ingester with reverse-edge
  sub-db" message) until the reverse-edge sub-db follow-up at the ingester layer.
  - Replace the panic stub with calls into the loaders.
  - End-to-end measurement: `100k_cats` `total_ms` floor expected to drop substantially from the current ~3.2s baseline.

  ## Refs

  - `docs/design/WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md` (#1901, #1904)
  - `docs/design/WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md` — `int_atom_seeds(lmdb)` runtime contract (§4)
  - `docs/design/WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md` — Phase 2 in the plan, split here as 2a → 2b.1 →
  2b.2
  - `docs/design/WAM_DEMAND_FILTER_*.md` (#1907)
  - Phase 1 ingester (PR #1905) — produces the LMDB sub-dbs that Phase 2b.2 will read

  🤖 Generated with [Claude Code](https://claude.com/claude-code)