### PR TITLE
feat(wam-haskell): LMDB-resident loader helpers — Phase 2b.2a

### DIFF
--- a/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
+++ b/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
@@ -776,3 +776,161 @@ ingestTsvToLmdb :: InternTable -> FilePath -> FilePath -> String -> IO ()
 ingestTsvToLmdb _ _ _ _ = error
     "ingestTsvToLmdb: not supported for dupsort layout (LMDB built externally)"
 {{/lmdb_dupsort}}
+
+-- ===========================================================================
+-- Phase 2b.2 LMDB-resident loaders (called from int_atom_seeds(lmdb) mode)
+-- ===========================================================================
+--
+-- These functions populate runtime state directly from the LMDB sub-dbs
+-- written by the Phase 1 ingester (PR #1905):
+--
+--   s2i              : UTF-8 string  -> int32_le      (forward intern map)
+--   i2s              : int32_le      -> UTF-8 string  (reverse intern map)
+--   article_category : int32_le      -> int32_le      (dupsort)
+--   category_parent  : int32_le      -> int32_le      (dupsort)
+--
+-- ASCII / UTF-8 caveat
+-- --------------------
+-- These loaders treat byte-for-byte equality as the equality semantics for
+-- atoms. For ASCII-only inputs (English Wikipedia category names, which
+-- are URL-encoded ASCII) the resulting Haskell `String` is byte-identical
+-- to what `decodeUtf8 . readFile` would produce, so atom equality is
+-- preserved across TSV and LMDB regimes.
+--
+-- For inputs containing multi-byte UTF-8 sequences (e.g. simplewiki's
+-- "Geografía"), the byte-by-byte conversion produces the Latin-1
+-- interpretation, NOT the Unicode codepoint. This will cause atom
+-- inequality with the TSV path's `decodeUtf8` reader. If/when we
+-- exercise an internationalized fixture, the fix is to add `bytestring`
+-- + `text` deps and use `Data.Text.Encoding.decodeUtf8`. Filed as a
+-- follow-up; documented here so a future failure mode is recoverable.
+
+-- | Decode bytes pointed to by a CChar pointer as a Haskell String,
+-- byte-by-byte (ASCII-correct, Latin-1 fallback for non-ASCII).
+peekStringBytes :: Ptr CChar -> Int -> IO String
+peekStringBytes p len
+    | len <= 0  = return []
+    | otherwise = do
+        bytes <- mapM (\i -> peekElemOff (castPtr p :: Ptr Word8) i)
+                      [0 .. len - 1]
+        return (map (toEnum . fromIntegral) bytes)
+
+-- | Iterate every (key, value) pair in a sub-db with a single read txn,
+-- applying a decoder to each pair. Returns results in iteration order.
+-- The cursor is opened on the supplied txn and discarded when the txn
+-- aborts at the end. Caller is responsible for managing the txn lifetime
+-- (typically: bracket with mdb_txn_begin/mdb_txn_abort).
+iterateAllPairs :: MDB_txn -> MDB_dbi'
+                -> (MDB_val -> MDB_val -> IO a)
+                -> IO [a]
+iterateAllPairs txn dbi decode = do
+    cursor <- mdb_cursor_open' txn dbi
+    alloca $ \kvPtr -> alloca $ \dvPtr -> do
+      poke kvPtr (MDB_val 0 nullPtr)
+      poke dvPtr (MDB_val 0 nullPtr)
+      found0 <- mdb_cursor_get' MDB_FIRST cursor kvPtr dvPtr
+      go cursor kvPtr dvPtr found0 []
+  where
+    go _ _ _ False acc = return (Prelude.reverse acc)
+    go cursor kvPtr dvPtr True acc = do
+      kv <- peek kvPtr
+      dv <- peek dvPtr
+      x <- decode kv dv
+      more <- mdb_cursor_get' MDB_NEXT cursor kvPtr dvPtr
+      go cursor kvPtr dvPtr more (x : acc)
+
+-- | Read s2i and i2s sub-dbs into the existing InternTable record shape.
+-- Skips TSV parsing + intern rebuild on warm runs of the LMDB-resident
+-- pipeline. Memory cost: O(unique strings * average length) — same as
+-- today, just loaded faster from binary instead of from text TSV.
+loadInternTableFromLmdb :: MDB_env -> String -> String -> IO InternTable
+loadInternTableFromLmdb env s2iName i2sName = do
+    txn <- mdb_txn_begin env Nothing True
+    s2iDb <- mdb_dbi_open' txn (Just s2iName) []
+    i2sDb <- mdb_dbi_open' txn (Just i2sName) []
+    forwardPairs <- iterateAllPairs txn s2iDb decodeStrInt
+    reversePairs <- iterateAllPairs txn i2sDb decodeIntStr
+    mdb_txn_abort txn
+    let !forward = Map.fromList forwardPairs
+        !reverse_ = IM.fromList reversePairs
+        !sz = if null reversePairs then 0 else 1 + maximum (map fst reversePairs)
+    return $! InternTable forward reverse_ sz
+  where
+    decodeStrInt (MDB_val ksz kp) (MDB_val vsz vp) = do
+      keyStr <- peekStringBytes (castPtr kp) (fromIntegral ksz)
+      val <- if vsz >= 4
+              then fromIntegral <$> peekElemOff (castPtr vp :: Ptr Int32) 0
+              else return 0
+      return (keyStr, val)
+    decodeIntStr (MDB_val ksz kp) (MDB_val vsz vp) = do
+      key <- if ksz >= 4
+              then fromIntegral <$> peekElemOff (castPtr kp :: Ptr Int32) 0
+              else return 0
+      valStr <- peekStringBytes (castPtr vp) (fromIntegral vsz)
+      return (key, valStr)
+
+-- | Read the article_category dupsort sub-db into a [(article_id,
+-- category_id)] list. Used in place of TSV-derived `articleCategories`
+-- when int_atom_seeds(lmdb) is active.
+loadArticleCategoriesFromLmdb :: MDB_env -> String -> IO [(Int, Int)]
+loadArticleCategoriesFromLmdb env dbName = do
+    txn <- mdb_txn_begin env Nothing True
+    db <- mdb_dbi_open' txn (Just dbName) [MDB_DUPSORT]
+    pairs <- iterateAllPairs txn db decodeIntIntPair
+    mdb_txn_abort txn
+    return pairs
+  where
+    decodeIntIntPair (MDB_val ksz kp) (MDB_val vsz vp) = do
+      k <- if ksz >= 4
+            then fromIntegral <$> peekElemOff (castPtr kp :: Ptr Int32) 0
+            else return 0
+      v <- if vsz >= 4
+            then fromIntegral <$> peekElemOff (castPtr vp :: Ptr Int32) 0
+            else return 0
+      return (k, v)
+
+-- | Read the category_parent dupsort sub-db into an in-memory IntMap
+-- (child_id -> [parent_ids]). This builds the same shape as today's
+-- `parentsIndexInterned` but populated from LMDB binary instead of
+-- parsed TSV. The size threshold guards against materialising an
+-- enwiki-scale (~28M edge) graph in memory: callers above the
+-- threshold should switch to LMDB-cursor BFS (Phase 2b.3 follow-up)
+-- or pass --with-reverse-edges to the ingester.
+--
+-- Threshold convention: 0 means unlimited (returns whatever fits in
+-- RAM); a positive number panics with a clear message above that
+-- count of edges loaded so far.
+loadForwardEdgesFromLmdb :: MDB_env -> String -> Int -> IO (IM.IntMap [Int])
+loadForwardEdgesFromLmdb env dbName threshold = do
+    txn <- mdb_txn_begin env Nothing True
+    db <- mdb_dbi_open' txn (Just dbName) [MDB_DUPSORT]
+    !edges <- iterateAndAccumulate txn db threshold IM.empty 0
+    mdb_txn_abort txn
+    return edges
+  where
+    iterateAndAccumulate txn db lim acc count = do
+      cursor <- mdb_cursor_open' txn db
+      alloca $ \kvPtr -> alloca $ \dvPtr -> do
+        poke kvPtr (MDB_val 0 nullPtr)
+        poke dvPtr (MDB_val 0 nullPtr)
+        found0 <- mdb_cursor_get' MDB_FIRST cursor kvPtr dvPtr
+        go cursor kvPtr dvPtr found0 acc count
+      where
+        go _ _ _ False a _ = return a
+        go cursor kvPtr dvPtr True a c = do
+          when (lim > 0 && c >= lim) $
+            error $ "loadForwardEdgesFromLmdb: edge count exceeded threshold "
+                 ++ show lim ++ " (loaded " ++ show c ++ " so far). "
+                 ++ "Switch to LMDB-cursor BFS (Phase 2b.3) or use the "
+                 ++ "ingester's --with-reverse-edges follow-up."
+          MDB_val ksz kp <- peek kvPtr
+          MDB_val vsz vp <- peek dvPtr
+          k <- if ksz >= 4
+                then fromIntegral <$> peekElemOff (castPtr kp :: Ptr Int32) 0
+                else return 0
+          v <- if vsz >= 4
+                then fromIntegral <$> peekElemOff (castPtr vp :: Ptr Int32) 0
+                else return 0
+          let !a' = IM.insertWith (++) k [v] a
+          more <- mdb_cursor_get' MDB_NEXT cursor kvPtr dvPtr
+          go cursor kvPtr dvPtr more a' (c + 1)

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1360,6 +1360,19 @@ test_b1_lmdb_raw_zero_copy_reads :-
     ;   fail_test(Test, 'Raw LMDB zero-copy read patterns not found')
     ).
 
+test_b1_phase2b2_loaders_emitted :-
+    Test = 'B1: Phase 2b.2 loaders (loadInternTableFromLmdb / loadArticleCategoriesFromLmdb / loadForwardEdgesFromLmdb) emitted',
+    (   compile_wam_runtime_to_haskell([use_lmdb(true)], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "loadInternTableFromLmdb :: MDB_env -> String -> String -> IO InternTable"),
+        sub_string(S, _, _, _, "loadArticleCategoriesFromLmdb :: MDB_env -> String -> IO [(Int, Int)]"),
+        sub_string(S, _, _, _, "loadForwardEdgesFromLmdb :: MDB_env -> String -> Int -> IO (IM.IntMap [Int])"),
+        sub_string(S, _, _, _, "iterateAllPairs txn dbi decode = do"),
+        sub_string(S, _, _, _, "peekStringBytes p len")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Phase 2b.2 LMDB-resident loaders should be emitted when use_lmdb(true)')
+    ).
+
 test_b1_lmdb_scan_support_present :-
     Test = 'B1: raw LMDB FactSource emits scan support',
     (   compile_wam_runtime_to_haskell([use_lmdb(true)], [], Code),
@@ -2078,6 +2091,7 @@ run_tests :-
     test_b1_lmdb_cabal_dependency,
     test_b1_no_lmdb_cabal_default,
     test_b1_lmdb_raw_zero_copy_reads,
+    test_b1_phase2b2_loaders_emitted,
     test_b1_lmdb_scan_support_present,
     test_b1_lmdb_manifest_fact_source_present,
     test_b1_lmdb_manifest_wiring_option_present,


### PR DESCRIPTION
  ## Summary

  Adds three LMDB-resident loader helper functions to `lmdb_fact_source.hs.mustache`, building directly on Phase 2b.1
  (PR #1913) which established the codegen surface with a runtime panic stub. **Pure surface addition**: scale-300
  stdout sha `70bbc9ffa4cf` unchanged because no caller invokes the new helpers yet — Phase 2b.2b will replace the panic
   stub with calls into them.

  ## Why a separate phase for the loader helpers

  Phase 2b was always going to be larger than the recent commits. Splitting the loader implementations from the wiring
  keeps each PR small and individually verifiable:

  - **Phase 2b.2a (this PR)**: loaders defined and emitted; codegen test asserts signatures. Sha gate: byte-identical to
   main.
  - **Phase 2b.2b** (next): replace panic stub, mustache section restructure for three-way mode. Sha gate:
  byte-identical on TSV / int_ids modes; new sha for LMDB mode.
  - **Phase 2b.2c** (next+1): end-to-end build + perf measurement. New numbers in `WAM_PERF_OPTIMIZATION_LOG.md`.

  This split also gave Perplexity a clean review boundary — the loader logic in isolation, separate from the wiring
  concerns.

  ## What changed

  ### `templates/targets/haskell_wam/lmdb_fact_source.hs.mustache` (+170 lines)

  Five new functions, all emitted when `use_lmdb(true)` is set:

  | Function | Purpose |
  |---|---|
  | `loadInternTableFromLmdb :: MDB_env -> String -> String -> IO InternTable` | Reads `s2i` + `i2s` sub-dbs into the
  existing `InternTable` record. Skips TSV parse + intern rebuild on warm runs. |
  | `loadArticleCategoriesFromLmdb :: MDB_env -> String -> IO [(Int, Int)]` | Iterates the `article_category` dupsort
  sub-db. |
  | `loadForwardEdgesFromLmdb :: MDB_env -> String -> Int -> IO (IM.IntMap [Int])` | Iterates `category_parent` dupsort
  sub-db into in-memory `IntMap`. Optional edge-count threshold (`0 = unlimited`) panics with a clear message above the
  limit, pointing at the LMDB-cursor BFS / reverse-edge sub-db follow-ups for enwiki-scale graphs. |
  | `iterateAllPairs` | Generic full-db iteration via `MDB_FIRST` + `MDB_NEXT`. |
  | `peekStringBytes` | Byte-by-byte decode of an `MDB_val` for string columns. |

  ### `tests/test_wam_haskell_target.pl` (+15 lines)

  `test_b1_phase2b2_loaders_emitted` asserts all five function signatures appear when `use_lmdb(true)`. Runs alongside
  the existing `test_b1_lmdb_raw_zero_copy_reads` peer test.

  ## Verification

  - [x] `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl` — all green, including the new
  `test_b1_phase2b2_loaders_emitted`
  - [x] `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 300 --include-targets
  haskell-interp-ffi --repetitions 1` — `haskell-interp-ffi` produces sha `70bbc9ffa4cf` (271 rows), unchanged from main

  ## Perplexity review summary

  External review of this branch ([conversation excerpt in commit context]) confirmed:

  - Strengths: incremental staging with sha gate, good test coverage, clear follow-up scope.
  - Caveats noted (all documented in code or filed as follow-ups):
    - **UTF-8 / ASCII** — tracked in #1915. Byte-by-byte decode is correct for English Wikipedia (URL-encoded ASCII),
  wrong for multi-byte UTF-8. Fix is a small cabal-deps + 3-line code change once a non-ASCII fixture exercises it.
    - **Edge-count threshold calibration** — defaults to `0 = unlimited`; will be calibrated during Phase 2b.2c
  end-to-end measurement.
    - **No runtime wiring yet** — intentional split; loader logic exercised against real LMDB output in 2b.2b/2b.2c.

  ## Follow-up tracking

  - **Issue #1915**: replace `peekStringBytes` byte-by-byte decode with `bytestring + text`-backed `decodeUtf8`. Closing
   criteria spelled out in the issue.

  ## What this does NOT do

  - Does **not** call the new loaders — they're emitted but unreferenced. Phase 2b.2b wires them in.
  - Does **not** add new Haskell or Python dependencies. Uses the existing `Database.LMDB.Raw` import set already
  established in `lmdb_fact_source.hs.mustache`.
  - Does **not** change behavior for `int_atom_seeds(false)` (TSV) or `int_atom_seeds(true)` (int_ids files) modes —
  both remain byte-identical.

  ## Refs

  - `docs/design/WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md` (#1901)
  - `docs/design/WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md` (#1904)
  - `docs/design/WAM_LMDB_RESIDENT_INTERNING_IMPLEMENTATION_PLAN.md` (#1904)
  - `docs/design/WAM_DEMAND_FILTER_*.md` (#1907)
  - Phase 1 ingester (PR #1905) — produces the LMDB sub-dbs that these loaders read
  - Phase 2a (PR #1910) — `DemandFilterSpec` dispatch refactor
  - Phase 2b.1 (PR #1913) — `int_atom_seeds(lmdb)` codegen surface + panic stub

  🤖 Generated with [Claude Code](https://claude.com/claude-code)