### PR TITLE
feat(wam-r): read_term_from_atom/2,3 and multi-solution clause/2

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -273,7 +273,9 @@ WAM stepping loop.
 Before and Length given), `char_type/2` (forward mode: char given;
 types `alpha`, `alnum`, `digit`, `space`, `upper`, `lower`,
 `punct`, `ascii`, `csym`, `csymf`, `newline`, `white`),
-`term_to_atom/2`, `tab/1`.
+`term_to_atom/2`, `read_term_from_atom/2`,
+`read_term_from_atom/3` (the options arg is accepted but ignored
+in this scaffold), `tab/1`.
 
 The `atom`/`string` distinction is collapsed at the WAM-text level
 (SWI's WAM emitter doesn't preserve it), so `string_*` predicates
@@ -299,11 +301,13 @@ abstraction.
 
 `assertz/1`, `asserta/1`, `retract/1` (multi-solution: iter-CP
 walks the snapshot taken at the call, removing each match in turn
-on backtracking), `abolish/1` (takes `Name/Arity`). Clauses are
-stored in `program$dynamic` (an R env, so mutations propagate
-across queries). Multi-clause dynamic predicate calls are
-dispatched through a `dynamic` CP that walks the clause list on
-backtracking.
+on backtracking), `abolish/1` (takes `Name/Arity`), `clause/2`
+(multi-solution introspection: same iter-CP shape as
+`retract/1`, without the removal side-effect; facts are surfaced
+with body = `true`). Clauses are stored in `program$dynamic` (an
+R env, so mutations propagate across queries). Multi-clause
+dynamic predicate calls are dispatched through a `dynamic` CP
+that walks the clause list on backtracking.
 
 ### Exception handling
 
@@ -426,7 +430,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 42 tests covering both structural assertions on the
+and contains 43 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -462,6 +466,7 @@ Coverage map (e2e tests, by feature group):
 | `bagof_setof_existential_e2e_rscript` | `^/2` existential scope in `bagof`/`setof`/`findall` |
 | `cli_arg_parser_e2e_rscript` | structured CLI args (lists, structs, expressions) parse via the runtime parser |
 | `base_name_clash_e2e_rscript` | predicates named after base R functions (`c`, `t`, `q`, `cat`) don't shadow them |
+| `read_term_clause_e2e_rscript` | `read_term_from_atom/2,3` and multi-solution `clause/2` |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -1721,6 +1721,72 @@ WamRuntime$retract_iter <- function(program, state, head_args, body, arity,
   FALSE
 }
 
+# Multi-solution clause/2. Same shape as retract_iter except the
+# matched clauses are *not* removed from the live store -- clause/2
+# is non-destructive introspection. Walks the snapshot taken at the
+# original call, unifying the caller's Head pattern against each
+# stored clause's head args and the caller's Body against the
+# stored body (with a fact's implicit body treated as the atom
+# `true`, matching SWI semantics). On the first match an iter CP is
+# pushed so backtracking re-binds against the next snapshot entry.
+WamRuntime$clause_iter <- function(program, state, head_args, body, arity,
+                                    ck, snapshot, start_idx, resume_pc) {
+  if (start_idx > length(snapshot)) return(FALSE)
+  table <- program$intern_table
+  true_atom <- Atom(WamRuntime$intern(table, "true"))
+  for (idx in seq.int(start_idx, length(snapshot))) {
+    cl <- snapshot[[idx]]
+    if (length(cl$head_args) != arity) next
+    snap_trail <- length(state$trail)
+    snap_vc    <- state$var_counter
+    fresh <- WamRuntime$copy_term_clause(state, cl)
+    ok <- TRUE
+    for (j in seq_len(arity)) {
+      if (!WamRuntime$unify(state, head_args[[j]], fresh$head_args[[j]])) {
+        ok <- FALSE; break
+      }
+    }
+    if (ok) {
+      fresh_body <- if (is.null(fresh$body)) true_atom else fresh$body
+      ok <- WamRuntime$unify(state, body, fresh_body)
+    }
+    if (ok) {
+      if (idx < length(snapshot)) {
+        captured_head_args <- head_args
+        captured_body      <- body
+        captured_arity     <- arity
+        captured_ck        <- ck
+        captured_snapshot  <- snapshot
+        captured_next_idx  <- idx + 1L
+        captured_resume    <- resume_pc
+        captured_program   <- program
+        cp <- list(
+          kind        = "iter",
+          regs        = as.list.environment(state$regs2),
+          trail_len   = snap_trail,
+          cp          = state$cp,
+          var_counter = snap_vc,
+          mode        = state$mode,
+          build_stack = state$build_stack,
+          resume_pc   = resume_pc,
+          retry       = function(state) {
+            WamRuntime$clause_iter(captured_program, state,
+                                    captured_head_args, captured_body,
+                                    captured_arity, captured_ck,
+                                    captured_snapshot, captured_next_idx,
+                                    captured_resume)
+          }
+        )
+        state$cps <- c(state$cps, list(cp))
+      }
+      return(TRUE)
+    }
+    WamRuntime$undo_trail_to(state, snap_trail)
+    state$var_counter <- snap_vc
+  }
+  FALSE
+}
+
 # Enumerable iteration over a list of WAM terms, used by member/2 (and
 # any future enumerator with the same shape). Tries to unify `target`
 # with each element starting at `start_idx`. On success, pushes an iter
@@ -3124,8 +3190,9 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
   #   form of Term (uses term_to_string -- list notation, struct
   #   `f(a,b)`, atom names, numbers).
   #   Reverse mode (Atom bound):  parse Atom's name as a Prolog term
-  #   and unify with Term. Operator notation is *not* supported in
-  #   the parser; user terms must be in canonical structural form.
+  #   and unify with Term. The parser handles canonical structural
+  #   form *and* operator notation for the standard Prolog operator
+  #   table (see WamRuntime$op_infix / WamRuntime$op_prefix).
   if (key == "term_to_atom/2") {
     raw_t <- WamRuntime$get_reg(state, 1L)
     raw_a <- WamRuntime$get_reg(state, 2L)
@@ -3142,6 +3209,52 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     parsed <- WamRuntime$parse_term(text, table, state)
     if (is.null(parsed)) return(FALSE)
     return(WamRuntime$unify(state, raw_t, parsed))
+  }
+
+  # ----- read_term_from_atom/2 and read_term_from_atom/3 -----
+  # read_term_from_atom(+Atom, -Term[, +Options]).
+  #   Parse Atom's name as a Prolog term and unify with Term. The
+  #   /3 variant accepts an Options list (e.g. variable_names(VN));
+  #   options other than `[]` are silently ignored in this
+  #   scaffold. Same parser as term_to_atom/2 reverse mode.
+  if (key == "read_term_from_atom/2" || key == "read_term_from_atom/3") {
+    a_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+    if (is.null(a_v)) return(FALSE)
+    text <- wam_term_name_string(a_v, table)
+    if (is.null(text)) return(FALSE)
+    parsed <- WamRuntime$parse_term(text, table, state)
+    if (is.null(parsed)) return(FALSE)
+    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 2L), parsed))
+  }
+
+  # ----- clause/2: enumerate matching clauses in the dynamic store -----
+  # clause(?Head, ?Body) succeeds, and on backtracking re-succeeds,
+  # for every clause stored in program$dynamic that matches Head
+  # and Body. Facts are treated as having body = `true` (matching
+  # SWI semantics). Multi-solution: an iter CP is pushed after the
+  # first match; the snapshot is value-stable across asserts/
+  # retracts that happen during the iteration (same approach as
+  # retract_iter).
+  if (key == "clause/2") {
+    head_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+    body   <- WamRuntime$get_reg(state, 2L)
+    if (is.null(head_v) || is.null(head_v$tag)) return(FALSE)
+    if (head_v$tag == "atom") {
+      pred <- WamRuntime$string_of(table, head_v$id)
+      arity <- 0L
+      head_args <- list()
+    } else if (head_v$tag == "struct") {
+      pred <- WamRuntime$string_of(table, head_v$fid)
+      arity <- length(head_v$args)
+      head_args <- head_v$args
+    } else {
+      return(FALSE)
+    }
+    ck <- paste0(pred, "/", arity)
+    if (!exists(ck, envir = program$dynamic, inherits = FALSE)) return(FALSE)
+    snapshot <- get(ck, envir = program$dynamic, inherits = FALSE)
+    return(WamRuntime$clause_iter(program, state, head_args, body, arity, ck,
+                                   snapshot, 1L, state$pc + 1L))
   }
 
   # ----- string_upper/2 and string_lower/2 -----

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2064,6 +2064,92 @@ e2e_base_name_clash_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for read_term_from_atom/2,3 and clause/2.
+% Both build on existing infrastructure: read_term_from_atom shares
+% the parser with term_to_atom/2 reverse mode; clause/2 walks the
+% dynamic store via clause_iter (same iter-CP shape as retract_iter
+% from PR #1900, but without the removal side-effect).
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(read_term_clause_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_read_term_clause_via_rscript
+    ;   true
+    )).
+
+e2e_read_term_clause_via_rscript :-
+    % read_term_from_atom/2: parse a structural term.
+    assertz((user:rt_struct :-
+        atom_codes(A, [102, 40, 49, 44, 50, 41]),  % "f(1,2)"
+        read_term_from_atom(A, T),
+        T == f(1, 2))),
+    % read_term_from_atom/2: parse an operator expression.
+    assertz((user:rt_op :-
+        atom_codes(A, [49, 43, 50, 42, 51]),  % "1+2*3"
+        read_term_from_atom(A, T),
+        T == 1+2*3)),
+    % read_term_from_atom/3: options arg is accepted (ignored).
+    assertz((user:rt_three :-
+        atom_codes(A, [104, 105]),  % "hi"
+        read_term_from_atom(A, T, []),
+        T == hi)),
+    % Garbage input fails.
+    assertz((user:rt_fail :-
+        atom_codes(A, [102, 40]),  % "f("
+        read_term_from_atom(A, _))),
+    % clause/2: collect every fact of fact/1.
+    assertz((user:cl_collect :-
+        assertz(fact(1)), assertz(fact(2)), assertz(fact(3)),
+        findall(X, clause(fact(X), true), L),
+        L == [1, 2, 3])),
+    % clause/2: rule with body. The body in the dynamic store comes
+    % out via the second arg.
+    assertz((user:cl_body :-
+        assertz((rul(X) :- X > 0)),
+        clause(rul(_), B),
+        B = (_ > 0))),
+    % clause/2 unifies head -- selects which clauses match.
+    assertz((user:cl_filter :-
+        assertz(typed(1, odd)),
+        assertz(typed(2, even)),
+        assertz(typed(3, odd)),
+        findall(X, clause(typed(X, odd), true), Odds),
+        Odds == [1, 3])),
+    % clause/2 over an unknown predicate fails.
+    assertz((user:cl_no :- clause(nope(_), _))),
+    % clause/2 doesn't remove anything; the store survives.
+    assertz((user:cl_nondestr :-
+        assertz(persists(1)), assertz(persists(2)),
+        findall(X, clause(persists(X), _), L1),
+        L1 == [1, 2],
+        % After clause/2, the facts must still be there.
+        findall(Y, clause(persists(Y), _), L2),
+        L2 == [1, 2])),
+    unique_r_tmp_dir('tmp_r_readterm_clause_e2e', TmpDir),
+    write_wam_r_project(
+        [user:rt_struct/0, user:rt_op/0, user:rt_three/0, user:rt_fail/0,
+         user:cl_collect/0, user:cl_body/0, user:cl_filter/0,
+         user:cl_no/0, user:cl_nondestr/0],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [rt_struct, rt_op, rt_three,
+           cl_collect, cl_body, cl_filter, cl_nondestr],
+    No  = [rt_fail, cl_no],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
## Summary

Adds two new library builtins, both reusing infrastructure from earlier PRs.

### `read_term_from_atom/2` and `read_term_from_atom/3`

Parses an atom's name as a Prolog term using the operator-precedence parser introduced in PR #1897. The `/3` variant accepts an `Options` arg but ignores it -- enough for code ported from SWI that habitually passes `[]` or `[variable_names(_)]`. Both forms share the same parser as `term_to_atom/2` reverse mode.

Also fixes a stale comment on `term_to_atom/2` that still claimed operator notation wasn't supported (it has been since #1897).

### `clause/2`

Walks the dynamic store via a new `clause_iter` helper that mirrors `retract_iter`'s iter-CP shape minus the removal side-effect. Snapshot-driven iteration; head and body unified per clause; facts surfaced with body = `true` (matching SWI semantics). Multi-solution: re-enters at the next snapshot index on backtracking.

## Test plan

- [x] `read_term_clause_e2e_rscript` (new): covers
  - `read_term_from_atom/2` parsing structural and operator-notation terms.
  - `read_term_from_atom/3` accepting (and ignoring) the Options arg.
  - Parse-failure case (`f(`).
  - `clause/2` collecting all matching facts.
  - `clause/2` returning a rule's body.
  - `clause/2` filtering by head pattern (only odd-typed entries).
  - `clause/2` non-destructiveness (the store survives the iteration).
  - `clause/2` failing on unknown predicates.
- [x] Full suite: 43 tests pass.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_