### PR TITLE
feat(wam-haskell): wire LMDB-resident loaders into Main.hs (Phase 2b.2b)

### DIFF
--- a/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
+++ b/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
@@ -805,6 +805,24 @@ ingestTsvToLmdb _ _ _ _ = error
 -- + `text` deps and use `Data.Text.Encoding.decodeUtf8`. Filed as a
 -- follow-up; documented here so a future failure mode is recoverable.
 
+-- | Open an LMDB env read-only for the int_atom_seeds(lmdb) loaders.
+-- Independent of {{lmdb_setup}}'s env (which is held by the FFI kernel
+-- path); opens its own handle so the loaders can run before the FFI
+-- setup block. LMDB safely supports multiple MDB_env handles per
+-- process; the OS shares the underlying mmap pages.
+--
+-- maxdbs=4 covers the four named sub-dbs the loaders touch: s2i, i2s,
+-- article_category, category_parent. mapsize matches the ingester's
+-- 4 GB ceiling (sufficient for enwiki).
+openLmdbInternEnvReadonly :: FilePath -> IO MDB_env
+openLmdbInternEnvReadonly dbPath = do
+    env <- mdb_env_create
+    mdb_env_set_mapsize env (4 * 1024 * 1024 * 1024)
+    mdb_env_set_maxdbs env 4
+    mdb_env_set_maxreaders env 126
+    mdb_env_open env dbPath [MDB_RDONLY]
+    return env
+
 -- | Decode bytes pointed to by a CChar pointer as a Haskell String,
 -- byte-by-byte (ASCII-correct, Latin-1 fallback for non-ASCII).
 peekStringBytes :: Ptr CChar -> Int -> IO String

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -127,18 +127,23 @@ main = do
     t0 <- getCurrentTime
 
 {{#int_atom_seeds_lmdb}}
-    -- Phase 2b.1: int_atom_seeds(lmdb) codegen surface is wired up,
-    -- but the runtime LMDB-resident loaders (loadInternTableFromLmdb,
-    -- loadArticleCategoriesFromLmdb, loadForwardEdgesFromLmdb) ship
-    -- in Phase 2b.2.  Until then, this mode panics at startup with a
-    -- clear message.  Falls back to int_atom_seeds(true) (seed_ids.txt)
-    -- or omitting the flag (TSV mode) for current workloads.
+    -- Phase 2b.2b: int_atom_seeds(lmdb) mode — LMDB-resident interning.
+    -- Reads the s2i / i2s / article_category / category_parent sub-dbs
+    -- written by the Phase 1 ingester
+    -- (src/unifyweaver/runtime/python/lmdb_ingest/ingest_to_lmdb.py).
+    -- Skips TSV parsing + string interning entirely; the intern table
+    -- and edge index are loaded from binary LMDB pages.
     --
-    -- See docs/design/WAM_LMDB_RESIDENT_INTERNING_*.md and
-    -- docs/design/WAM_DEMAND_FILTER_*.md for the design.
-    fail "int_atom_seeds(lmdb): runtime LMDB-resident loaders not yet \
-         \implemented (Phase 2b.2). Use int_atom_seeds(true) with \
-         \seed_ids.txt / root_ids.txt, or omit the flag for TSV mode."
+    -- The 5_000_000-edge threshold caps in-memory parentsIndex growth
+    -- at ~80 MB; enwiki-scale inputs (~28M edges) need to switch to
+    -- LMDB-cursor BFS (Phase 2b.3 follow-up). See loader docstring.
+    --
+    -- See docs/design/WAM_LMDB_RESIDENT_INTERNING_*.md.
+    let lmdbInternDir = factsDir ++ "/lmdb"
+    internEnv <- openLmdbInternEnvReadonly lmdbInternDir
+    !lmdbInternTable <- loadInternTableFromLmdb internEnv "s2i" "i2s"
+    !lmdbArticleCategories <- loadArticleCategoriesFromLmdb internEnv "article_category"
+    !lmdbParentsIndex <- loadForwardEdgesFromLmdb internEnv "category_parent" 5000000
 {{/int_atom_seeds_lmdb}}
 
 {{^int_atom_seeds}}
@@ -178,6 +183,7 @@ main = do
         iAtom s = internAtomPure fullInternTable s
 {{/int_atom_seeds}}
 {{#int_atom_seeds}}
+{{^int_atom_seeds_lmdb}}
     -- Int-atom-seeds mode: only the compile-time atom table is needed.
     -- Seed/edge IDs are raw int32 from LMDB ingest; they don't need
     -- string interning.  iAtom is identity (Int -> Int) so the rest of
@@ -185,6 +191,15 @@ main = do
     let !fullInternTable = compileTimeAtomTable
         iAtom :: Int -> Int
         iAtom = id
+{{/int_atom_seeds_lmdb}}
+{{#int_atom_seeds_lmdb}}
+    -- Int-atom-seeds(lmdb) mode: the intern table comes from LMDB
+    -- (s2i / i2s sub-dbs) — already loaded into lmdbInternTable above.
+    -- iAtom is identity since seed/edge IDs are pre-interned int32.
+    let !fullInternTable = lmdbInternTable
+        iAtom :: Int -> Int
+        iAtom = id
+{{/int_atom_seeds_lmdb}}
 {{/int_atom_seeds}}
 
     -- Build merged code: compiled predicates + runtime facts.
@@ -212,6 +227,7 @@ main = do
             [(iAtom child, [iAtom parent]) | (child, parent) <- categoryParents]
 {{/int_atom_seeds}}
 {{#int_atom_seeds}}
+{{^int_atom_seeds_lmdb}}
     -- Int-atom-seeds: seeds and root come from int-id files.  Edges
     -- live in LMDB (use_lmdb(true) is expected; the in-memory
     -- parentsIndexInterned is empty as a sentinel).
@@ -224,6 +240,22 @@ main = do
         seedLimitMetric  = Nothing :: Maybe String
         seedFilterMetric = Nothing :: Maybe String
         !parentsIndexInterned = IM.empty :: IM.IntMap [Int]
+{{/int_atom_seeds_lmdb}}
+{{#int_atom_seeds_lmdb}}
+    -- Int-atom-seeds(lmdb): seeds and root still come from int-id
+    -- config files (seed_ids.txt / root_ids.txt). Edges populate
+    -- parentsIndexInterned directly from the LMDB category_parent
+    -- sub-db (loaded above into lmdbParentsIndex).
+    let !seedCats = seedIds
+        !root = case rootIds of
+                  []      -> 0
+                  (r:_)   -> r
+        n = fromIntegral ({{dimension_n}} :: Int) :: Double
+        negN = -n
+        seedLimitMetric  = Nothing :: Maybe String
+        seedFilterMetric = Nothing :: Maybe String
+        !parentsIndexInterned = lmdbParentsIndex
+{{/int_atom_seeds_lmdb}}
 {{/int_atom_seeds}}
 
     -- Demand-driven pruning: compute the backward-reachable set from root,

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1488,8 +1488,8 @@ test_demand_filter_flux_emits_panic_stub_compatible :-
     ;   fail_test(Test, 'demand_filter_spec(flux, [...]) should emit Flux constructor for runtime to panic on')
     ).
 
-test_int_atom_seeds_lmdb_emits_panic_stub :-
-    Test = 'WAM-Haskell: int_atom_seeds(lmdb) emits Phase 2b.2 runtime panic stub',
+test_int_atom_seeds_lmdb_calls_loaders :-
+    Test = 'WAM-Haskell: int_atom_seeds(lmdb) calls Phase 2b.2 loaders (no panic stub)',
     Kernel = recursive_kernel(category_ancestor, 'category_ancestor'/4,
                               [max_depth(10), edge_pred(category_parent/2)]),
     (   wam_haskell_target:generate_main_hs(
@@ -1499,15 +1499,19 @@ test_int_atom_seeds_lmdb_emits_panic_stub :-
             [int_atom_seeds(lmdb)],
             Code),
         atom_string(Code, S),
-        sub_string(S, _, _, _, "int_atom_seeds(lmdb): runtime LMDB-resident loaders not yet"),
-        sub_string(S, _, _, _, "Phase 2b.2"),
-        sub_string(S, _, _, _, "fail \"")
+        sub_string(S, _, _, _, "openLmdbInternEnvReadonly"),
+        sub_string(S, _, _, _, "loadInternTableFromLmdb internEnv \"s2i\" \"i2s\""),
+        sub_string(S, _, _, _, "loadArticleCategoriesFromLmdb internEnv \"article_category\""),
+        sub_string(S, _, _, _, "loadForwardEdgesFromLmdb internEnv \"category_parent\""),
+        sub_string(S, _, _, _, "!fullInternTable = lmdbInternTable"),
+        sub_string(S, _, _, _, "!parentsIndexInterned = lmdbParentsIndex"),
+        \+ sub_string(S, _, _, _, "int_atom_seeds(lmdb): runtime LMDB-resident loaders not yet")
     ->  pass(Test)
-    ;   fail_test(Test, 'int_atom_seeds(lmdb) should emit a runtime panic stub')
+    ;   fail_test(Test, 'int_atom_seeds(lmdb) should call the Phase 2b.2 loaders, not emit a panic stub')
     ).
 
-test_int_atom_seeds_true_does_not_emit_lmdb_panic :-
-    Test = 'WAM-Haskell: int_atom_seeds(true) does NOT emit the LMDB panic stub',
+test_int_atom_seeds_true_does_not_call_lmdb_loaders :-
+    Test = 'WAM-Haskell: int_atom_seeds(true) does NOT call LMDB loaders',
     Kernel = recursive_kernel(category_ancestor, 'category_ancestor'/4,
                               [max_depth(10), edge_pred(category_parent/2)]),
     (   wam_haskell_target:generate_main_hs(
@@ -1517,14 +1521,15 @@ test_int_atom_seeds_true_does_not_emit_lmdb_panic :-
             [int_atom_seeds(true)],
             Code),
         atom_string(Code, S),
-        \+ sub_string(S, _, _, _, "Phase 2b.2"),
-        \+ sub_string(S, _, _, _, "int_atom_seeds(lmdb): runtime LMDB-resident")
+        \+ sub_string(S, _, _, _, "openLmdbInternEnvReadonly"),
+        \+ sub_string(S, _, _, _, "loadInternTableFromLmdb internEnv"),
+        \+ sub_string(S, _, _, _, "lmdbParentsIndex")
     ->  pass(Test)
-    ;   fail_test(Test, 'int_atom_seeds(true) should not emit the LMDB-mode panic')
+    ;   fail_test(Test, 'int_atom_seeds(true) should not call the LMDB loaders')
     ).
 
-test_int_atom_seeds_default_does_not_emit_lmdb_panic :-
-    Test = 'WAM-Haskell: default mode does NOT emit the LMDB panic stub',
+test_int_atom_seeds_default_does_not_call_lmdb_loaders :-
+    Test = 'WAM-Haskell: default mode does NOT call LMDB loaders',
     Kernel = recursive_kernel(category_ancestor, 'category_ancestor'/4,
                               [max_depth(10), edge_pred(category_parent/2)]),
     (   wam_haskell_target:generate_main_hs(
@@ -1534,10 +1539,11 @@ test_int_atom_seeds_default_does_not_emit_lmdb_panic :-
             [],
             Code),
         atom_string(Code, S),
-        \+ sub_string(S, _, _, _, "Phase 2b.2"),
-        \+ sub_string(S, _, _, _, "int_atom_seeds(lmdb): runtime LMDB-resident")
+        \+ sub_string(S, _, _, _, "openLmdbInternEnvReadonly"),
+        \+ sub_string(S, _, _, _, "loadInternTableFromLmdb internEnv"),
+        \+ sub_string(S, _, _, _, "lmdbParentsIndex")
     ->  pass(Test)
-    ;   fail_test(Test, 'default mode should not emit the LMDB-mode panic')
+    ;   fail_test(Test, 'default mode should not call the LMDB loaders')
     ).
 
 test_demand_filter_invalid_strategy_rejected :-
@@ -2120,9 +2126,9 @@ run_tests :-
     test_demand_filter_hop_limit_with_max_hops,
     test_demand_filter_none_emits_dfnone,
     test_demand_filter_flux_emits_panic_stub_compatible,
-    test_int_atom_seeds_lmdb_emits_panic_stub,
-    test_int_atom_seeds_true_does_not_emit_lmdb_panic,
-    test_int_atom_seeds_default_does_not_emit_lmdb_panic,
+    test_int_atom_seeds_lmdb_calls_loaders,
+    test_int_atom_seeds_true_does_not_call_lmdb_loaders,
+    test_int_atom_seeds_default_does_not_call_lmdb_loaders,
     test_demand_filter_invalid_strategy_rejected,
     test_demand_filter_false_leaves_query_ungated,
     %% max_depth substitution (regression for linear-chain-zero-results)


### PR DESCRIPTION
  ## Summary

  Replaces the `int_atom_seeds(lmdb)` panic stub (Phase 2b.1) with calls
  to the Phase 2b.2a loaders. The mode now opens an LMDB env at startup
  and reads the intern table, article-category index, and forward-edge
  index directly from binary sub-dbs — no TSV parsing, no string
  interning.

  This closes the codegen-surface gap that 2b.1 opened. Phase 2b.2c
  will follow with end-to-end perf measurement on `100k_cats/lmdb_proj`.

  ## What changed

  ### `main.hs.mustache`
  - **Replace panic stub** at the `{{#int_atom_seeds_lmdb}}` block (right
    after `t0 <- getCurrentTime`) with an env-open + three loader calls:
    ```haskell
    internEnv <- openLmdbInternEnvReadonly lmdbInternDir
    !lmdbInternTable <- loadInternTableFromLmdb internEnv "s2i" "i2s"
    !lmdbArticleCategories <- loadArticleCategoriesFromLmdb internEnv "article_category"
    !lmdbParentsIndex <- loadForwardEdgesFromLmdb internEnv "category_parent" 5000000
    The 5M-edge threshold caps in-memory parentsIndex growth at ~80 MB.
    Enwiki-scale (~28M edges) will trip the guard; Phase 2b.3 will switch
    to LMDB-cursor BFS to lift it.
  - Wrap the int_ids intern-table block with {{^int_atom_seeds_lmdb}}
  and add a parallel {{#int_atom_seeds_lmdb}} branch that binds
  fullInternTable = lmdbInternTable instead of compileTimeAtomTable.
  iAtom = id in both since IDs are pre-interned.
  - Wrap the int_ids parents-index block the same way: {{^int_atom_seeds_lmdb}}
  keeps the parentsIndexInterned = IM.empty sentinel for the
  int-ids-files-only mode; {{#int_atom_seeds_lmdb}} binds it to the
  loaded lmdbParentsIndex.

  lmdb_fact_source.hs.mustache

  - Add openLmdbInternEnvReadonly :: FilePath -> IO MDB_env. Independent
  handle from {{lmdb_setup}}'s FFI-kernel env; LMDB safely supports
  multiple MDB_env handles per process (the OS shares the underlying
  mmap pages). maxdbs=4 covers the four named sub-dbs the loaders
  touch (s2i, i2s, article_category, category_parent).

  tests/test_wam_haskell_target.pl

  - Invert test_int_atom_seeds_lmdb_emits_panic_stub →
  test_int_atom_seeds_lmdb_calls_loaders. Asserts loader call
  signatures appear and the panic message is absent.
  - Rename and update the two negative tests to assert loader-call
  absence in true / default modes.

  Open question (resolved)

  The memory file's Phase 2b.2b plan flagged: does {{lmdb_setup}} run
  before or after the new section needs the env?

  Resolved: {{lmdb_setup}} runs at line ~237, after the
  int_atom_seeds_lmdb load block (line ~129). Rather than restructure
  the template flow, I added a tiny independent env-opener helper. This
  keeps the FFI-kernel env (held by cpEdgeLookup/cpFactSource) and
  the loader env decoupled, so neither block has to know about the
  other's lifetime.

  Verification

| Mode | Generated Main.hs vs main |
|---|---|
| Default (TSV) | byte-identical (0-line diff) |
| int_atom_seeds(true) | 6 blank lines (mustache standalone-tag artifact, no semantic effect) |
| int_atom_seeds(lmdb) | new code path (was panic stub) |

  The scale-300 stdout sha gate (70bbc9ffa4cf, 271 rows) is for
  benchmark output not Main.hs source — preserved across TSV and
  int_atom_seeds(true) modes. Phase 2b.2c will measure LMDB-mode sha
  against the 100k_cats fixture (a new sha by design, different fixture
  path).

  Test plan

  - swipl -g run_tests -t halt tests/test_wam_haskell_target.pl — all green
  - test_int_atom_seeds_lmdb_calls_loaders — asserts loader calls present
  - test_int_atom_seeds_true_does_not_call_lmdb_loaders — asserts loaders absent
  - test_int_atom_seeds_default_does_not_call_lmdb_loaders — asserts loaders absent
  - test_b1_phase2b2_loaders_emitted (existing 2b.2a test) — unchanged, still green
  - Phase 2b.2c: build + run on 100k_cats/lmdb_proj, record loadMs/setupMs/queryMs/totalMs/RSS, append to
  WAM_PERF_OPTIMIZATION_LOG.md

  Caveats unchanged

  - UTF-8 / ASCII (issue #1915): peekStringBytes still byte-by-byte
  decodes. Correct for English Wikipedia ASCII, wrong for simplewiki
  multi-byte UTF-8. Trips on first non-ASCII fixture, likely Phase 2b.2c
  on simplewiki.
  - Edge-count threshold: 5_000_000 chosen for ~80 MB cap. Enwiki
  scale (~28M) will need either reverse-edge ingest (small ingester
  change) or LMDB-cursor BFS (Phase 2b.3).
  - No runtime wiring exercised yet: codegen tests assert string
  presence; end-to-end correctness lands in 2b.2c.

  🤖 Generated with https://claude.com/claude-code