### PR TITLE
feat(wam-r): DCG support via phrase/2,3

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -248,7 +248,8 @@ keep duplicates), `maplist/2..3`.
 ### Higher-order / meta
 
 `call/1..N`, `\+/1`, `once/1`, `forall/2`, `findall/3`, `bagof/3`,
-`setof/3`. Aggregators back-end via two paths:
+`setof/3`, `phrase/2`, `phrase/3`. Aggregators back-end via two
+paths:
 
 - Compiled goals push an `aggregate` CP at `BeginAggregate`,
   collect on every backtrack, and finalise at `EndAggregate`.
@@ -296,6 +297,24 @@ table; non-standard user-defined operators are not recognised.
 Format control sequences supported: `~w`, `~a`, `~d`, `~p`, `~s`,
 `~n`, `~~`. Output goes to standard `cat()` -- no stream
 abstraction.
+
+### DCG (`-->`)
+
+DCG rules are translated at SWI's term-expansion time (or at
+runtime via `dcg_translate_rule/2`) into ordinary clauses with
+two extra difference-list args, so by the time the WAM compiler
+reads them they look like normal predicates and need no special
+handling. The runtime supports `phrase/2` and `phrase/3` to
+bridge the user-level call into the translated `<head>/N+2` form.
+
+```prolog
+:- use_module(library(dcg/basics)).
+dcg_translate_rule((seq(0) --> []), C0), assertz(user:C0),
+dcg_translate_rule(
+    (seq(N) --> {N > 0}, [N], {N1 is N - 1}, seq(N1)), Cn),
+assertz(user:Cn),
+% phrase(seq(3), [3, 2, 1]) succeeds via seq/3.
+```
 
 ### Dynamic predicates
 
@@ -430,7 +449,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 43 tests covering both structural assertions on the
+and contains 44 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -467,6 +486,7 @@ Coverage map (e2e tests, by feature group):
 | `cli_arg_parser_e2e_rscript` | structured CLI args (lists, structs, expressions) parse via the runtime parser |
 | `base_name_clash_e2e_rscript` | predicates named after base R functions (`c`, `t`, `q`, `cat`) don't shadow them |
 | `read_term_clause_e2e_rscript` | `read_term_from_atom/2,3` and multi-solution `clause/2` |
+| `dcg_e2e_rscript` | DCG `-->` rules + `phrase/2,3` (recursive grammars, prefix-with-rest) |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -2976,6 +2976,33 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     return(WamRuntime$call_goal(program, state, WamRuntime$get_reg(state, 1L)))
   }
 
+  # ----- phrase/2 and phrase/3 -----
+  # phrase(?Body, ?List)         is call(Body, List, []).
+  # phrase(?Body, ?List, ?Rest)  is call(Body, List, Rest).
+  # Used to invoke DCG-translated nonterminals (rule head + 2 extra
+  # difference-list args). The translation itself happens at SWI's
+  # consult time (term_expansion) or via dcg_translate_rule/2 at
+  # runtime; by the time clauses reach the WAM compiler they are
+  # ordinary Prolog with the difference-list args already in place.
+  if (key == "phrase/2") {
+    goal <- WamRuntime$get_reg(state, 1L)
+    list_in <- WamRuntime$get_reg(state, 2L)
+    empty_list <- Atom(WamRuntime$intern(table, "[]"))
+    ext <- WamRuntime$wam_extend_goal(state, goal,
+                                       list(list_in, empty_list), table)
+    if (is.null(ext)) return(FALSE)
+    return(isTRUE(WamRuntime$call_goal(program, state, ext)))
+  }
+  if (key == "phrase/3") {
+    goal <- WamRuntime$get_reg(state, 1L)
+    list_in <- WamRuntime$get_reg(state, 2L)
+    list_out <- WamRuntime$get_reg(state, 3L)
+    ext <- WamRuntime$wam_extend_goal(state, goal,
+                                       list(list_in, list_out), table)
+    if (is.null(ext)) return(FALSE)
+    return(isTRUE(WamRuntime$call_goal(program, state, ext)))
+  }
+
   # ----- atom_codes/2 (also string_codes/2): atom <-> list of code points -----
   # Strings and atoms are not distinguished at the WAM-text level, so
   # the string_* family aliases onto its atom_* counterpart.

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2150,6 +2150,71 @@ e2e_read_term_clause_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for DCG (--> notation). DCG rules are
+% translated at SWI's term-expansion time (or via
+% dcg_translate_rule/2 at runtime) into ordinary clauses with two
+% extra difference-list args, so by the time the WAM compiler
+% reads them they look like normal predicates and need no special
+% handling. The runtime side just needs phrase/2 and phrase/3 to
+% bridge the user-level call into the translated /N+2 form.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(dcg_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_dcg_via_rscript
+    ;   true
+    )).
+
+e2e_dcg_via_rscript :-
+    use_module(library(dcg/basics)),
+    % Translate a handful of DCG rules at runtime via
+    % dcg_translate_rule/2, then assertz the resulting clauses.
+    % This proves the WAM target handles the translated form
+    % regardless of whether SWI did the translation at consult
+    % time or asynchronously.
+    dcg_translate_rule((g_greet --> [hello]), Cg),  assertz(user:Cg),
+    dcg_translate_rule((g_pair  --> [a], [b]), Cp), assertz(user:Cp),
+    % Recursive grammar that emits N..1 down to 0.
+    dcg_translate_rule((g_seq(0) --> []), Cs0),     assertz(user:Cs0),
+    dcg_translate_rule(
+        (g_seq(N) --> {N > 0}, [N], {N1 is N - 1}, g_seq(N1)), Csn),
+    assertz(user:Csn),
+    % Test predicates that exercise phrase/2 and phrase/3.
+    assertz((user:dcg_simple :- phrase(g_greet, [hello]))),
+    assertz((user:dcg_pair   :- phrase(g_pair, [a, b]))),
+    assertz((user:dcg_seq3   :- phrase(g_seq(3), [3, 2, 1]))),
+    assertz((user:dcg_seq0   :- phrase(g_seq(0), []))),
+    % phrase/3 with a non-empty rest: parse a prefix, leave the rest.
+    assertz((user:dcg_phrase3 :-
+        phrase(g_pair, [a, b, x, y], [x, y]))),
+    % Negative cases.
+    assertz((user:dcg_no   :- phrase(g_pair, [a, c]))),
+    assertz((user:dcg_no2  :- phrase(g_seq(2), [2, 1, 0]))),
+    unique_r_tmp_dir('tmp_r_dcg_e2e', TmpDir),
+    write_wam_r_project(
+        [user:g_greet/2, user:g_pair/2, user:g_seq/3,
+         user:dcg_simple/0, user:dcg_pair/0, user:dcg_seq3/0,
+         user:dcg_seq0/0, user:dcg_phrase3/0,
+         user:dcg_no/0, user:dcg_no2/0],
+        [intern_atoms([hello, a, b, c, x, y])],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [dcg_simple, dcg_pair, dcg_seq3, dcg_seq0, dcg_phrase3],
+    No  = [dcg_no, dcg_no2],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
## Summary

DCG (Definite Clause Grammar) support via `phrase/2,3`. As suspected during the planning step, SWI's term-expansion machinery handles the `-->` rewrite -- it translates each DCG rule into an ordinary clause with two extra difference-list args at consult time (or via `dcg_translate_rule/2` at runtime). By the time the WAM compiler reads the translated clauses they look like normal predicates and need no special handling.

What was missing: the runtime didn't have the `phrase/N` bridges that turn a user-level `phrase(Body, List)` call into the translated `<head>/N+2` invocation. This PR adds them.

## What's in the PR

- `phrase/2`: `phrase(Body, List)` -> `call(Body, List, [])`. Implemented in `call_library`; reuses `wam_extend_goal` to handle both atom (arity-0 NTs) and struct (parameterised NTs) forms.
- `phrase/3`: `phrase(Body, List, Rest)` -> `call(Body, List, Rest)`.

## Test plan

- [x] `dcg_e2e_rscript` (new): covers
  - Atom DCG (`g_greet --> [hello]`).
  - Multi-token DCG (`g_pair --> [a], [b]`).
  - Recursive DCG with arithmetic guards (`g_seq(N) --> {N > 0}, [N], {N1 is N - 1}, g_seq(N1).`).
  - `phrase/2` over arity-0 and arity-1 NTs.
  - `phrase/3` with a non-empty rest (prefix parsing).
  - Negative cases (mismatched tokens, wrong count).
- [x] Full suite: 44 tests pass.

## Doc

New DCG section in `docs/WAM_R_TARGET.md` with a worked `dcg_translate_rule + phrase` idiom; the supported-features table grows a `phrase/2,3` entry under higher-order/meta.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_