### PR TITLE
feat(wam-r): file streams + Y-register save/restore on call frames

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -293,10 +293,23 @@ table; non-standard user-defined operators are not recognised.
 
 ### I/O
 
-`write/1`, `writeln/1`, `print/1`, `nl/0`, `format/1`, `format/2`.
-Format control sequences supported: `~w`, `~a`, `~d`, `~p`, `~s`,
-`~n`, `~~`. Output goes to standard `cat()` -- no stream
-abstraction.
+Stdout family: `write/1`, `writeln/1`, `print/1`, `nl/0`,
+`format/1`, `format/2`. Stream-aware variants: `write/2`,
+`writeln/2`, `nl/1`, `format/3`. Format control sequences
+supported: `~w`, `~a`, `~d`, `~p`, `~s`, `~n`, `~~`.
+
+### Streams (file I/O)
+
+`open/3`, `close/1`, `read/2`. Streams are opaque `stream(<id>)`
+structs whose integer id keys into `program$streams`, an R env
+that maps id -> R connection. `open/3` accepts modes `read`,
+`write`, `append` and returns a `stream(<id>)` term; `close/1`
+closes the connection and removes the entry. `read/2` is
+line-buffered: it consumes one line, strips a trailing `.` (with
+optional whitespace), parses the rest via the operator-precedence
+parser, and unifies with the second arg. EOF binds the term to
+the atom `end_of_file` (matches SWI semantics). Multi-line terms
+are not supported in this scaffold.
 
 ### DCG (`-->`)
 
@@ -439,8 +452,11 @@ WamRuntime$run(shared_program, state)
   the R-level fast path enumerates directly. Mixed contexts that
   need iter-CP-driven generation from inside library dispatch are
   not exhaustively covered.
-- **No streams**. All I/O goes to `cat()`. There is no `open/3`,
-  no `read/1`, no `current_output`.
+- **Stream-aware predicate set is partial**. `open/3`, `close/1`,
+  `read/2`, `write/2`, `writeln/2`, `nl/1`, and `format/3` are
+  supported, but multi-line term reads, `current_input/1` /
+  `current_output/1`, `set_input/1` / `set_output/1`, character
+  I/O (`get_char/1,2`, `put_char/1,2`), and binary streams are not.
 - **Float arithmetic is `double` only**; bigints and rationals are
   not supported. Integer overflow follows R's normal `integer`
   semantics.
@@ -449,7 +465,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 44 tests covering both structural assertions on the
+and contains 45 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -487,6 +503,7 @@ Coverage map (e2e tests, by feature group):
 | `base_name_clash_e2e_rscript` | predicates named after base R functions (`c`, `t`, `q`, `cat`) don't shadow them |
 | `read_term_clause_e2e_rscript` | `read_term_from_atom/2,3` and multi-solution `clause/2` |
 | `dcg_e2e_rscript` | DCG `-->` rules + `phrase/2,3` (recursive grammars, prefix-with-rest) |
+| `streams_e2e_rscript` | `open/3`, `close/1`, `read/2`, `write/2`, `writeln/2`, `format/3` round-trip |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/templates/targets/r_wam/program.R.mustache
+++ b/templates/targets/r_wam/program.R.mustache
@@ -65,7 +65,11 @@ shared_program <- list(
   # Keyed by "pred/arity"; each value is a list of clause records
   # of shape list(head_args, body). An env (rather than a list) so
   # mutations propagate across query invocations.
-  dynamic          = new.env(parent = emptyenv())
+  dynamic          = new.env(parent = emptyenv()),
+  # Stream registry for open/3, read/2, write/2, etc. Keyed by the
+  # stringified integer id stored inside `stream(<id>)` terms; the
+  # special key "__next_id__" holds the next-id counter.
+  streams          = new.env(parent = emptyenv())
 )
 
 # ----------------------------------------------------------

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -980,13 +980,39 @@ WamRuntime$step <- function(program, state, instr) {
       state$pc <- state$pc + 1L; TRUE
     },
     "Allocate" = {
-      state$stack <- c(state$stack, list(list(cp = state$cp, locals = new.env(parent = emptyenv()))))
+      # Save the caller's Y registers (idx >= 201) so the callee's
+      # Y writes don't stomp them. Without this, nested calls
+      # `rt(F) :- do_write(F), do_read(F).` lose F when do_write's
+      # Y201 (= S) overwrites rt's Y201 (= F) in the flat regs2
+      # env. Deallocate restores the saved Y values.
+      saved_ys <- list()
+      for (k in ls(state$regs2)) {
+        ki <- suppressWarnings(as.integer(k))
+        if (!is.na(ki) && ki >= 201L) {
+          saved_ys[[k]] <- get(k, envir = state$regs2, inherits = FALSE)
+        }
+      }
+      state$stack <- c(state$stack,
+                       list(list(cp = state$cp, saved_ys = saved_ys)))
       state$pc <- state$pc + 1L; TRUE
     },
     "Deallocate" = {
+      # Pop the call frame and restore the caller's Y registers.
+      # Note: we *only* overwrite the slots that were live in the
+      # caller (frame$saved_ys); any Y the callee added beyond
+      # those is left in place because SWI's WAM emit can read a
+      # Y register *after* Deallocate (e.g. an ArgInstr that
+      # follows the trim), and removing the value would break it.
       n <- length(state$stack)
       if (n > 0L) {
-        state$cp    <- state$stack[[n]]$cp
+        frame <- state$stack[[n]]
+        state$cp <- frame$cp
+        saved <- frame$saved_ys
+        if (!is.null(saved)) {
+          for (k in names(saved)) {
+            assign(k, saved[[k]], envir = state$regs2)
+          }
+        }
         state$stack <- state$stack[-n]
       }
       state$pc <- state$pc + 1L; TRUE
@@ -1924,6 +1950,63 @@ WamRuntime$arith_to_term <- function(n) {
 # and dispatch it through the standard pipeline. The dispatch order
 # is labels -> foreign handlers -> library -> builtin, matching what
 # a directly-compiled call would have hit.
+
+# ----------------------------------------------------------
+# Stream registry helpers
+# ----------------------------------------------------------
+# Streams are opaque `stream(<int>)` structs whose integer id keys
+# into program$streams (an R env). open/3 allocates a fresh id and
+# stores the underlying R connection; close/1 closes the connection
+# and removes the entry; read/2 / write/2 / writeln/2 / nl/1 /
+# format/3 look up the connection by id.
+WamRuntime$stream_alloc <- function(program) {
+  next_id <- if (exists("__next_id__", envir = program$streams, inherits = FALSE)) {
+    get("__next_id__", envir = program$streams, inherits = FALSE)
+  } else {
+    1L
+  }
+  assign("__next_id__", as.integer(next_id + 1L), envir = program$streams)
+  as.integer(next_id)
+}
+
+WamRuntime$stream_register <- function(program, conn) {
+  id <- WamRuntime$stream_alloc(program)
+  assign(as.character(id), conn, envir = program$streams)
+  id
+}
+
+WamRuntime$stream_get <- function(program, id) {
+  k <- as.character(id)
+  if (!exists(k, envir = program$streams, inherits = FALSE)) return(NULL)
+  get(k, envir = program$streams, inherits = FALSE)
+}
+
+WamRuntime$stream_close <- function(program, id) {
+  k <- as.character(id)
+  if (!exists(k, envir = program$streams, inherits = FALSE)) return(FALSE)
+  conn <- get(k, envir = program$streams, inherits = FALSE)
+  # Explicit flush before close: R's close() should flush, but
+  # in practice cat(..., file=conn, sep="") doesn't always push
+  # buffered output through before the file handle goes away when
+  # the program immediately reopens the same path for reading.
+  tryCatch(flush(conn), error = function(e) NULL)
+  tryCatch(close(conn), error = function(e) NULL)
+  rm(list = k, envir = program$streams)
+  TRUE
+}
+
+# Extract the integer stream id from a `stream(<int>)` struct, or
+# NULL if the term doesn't have that shape. Used by every stream
+# builtin to validate its first arg.
+WamRuntime$stream_id_of <- function(state, term, table) {
+  v <- WamRuntime$deref(state, term)
+  if (is.null(v) || is.null(v$tag) || v$tag != "struct") return(NULL)
+  if (length(v$args) != 1L) return(NULL)
+  if (!identical(WamRuntime$string_of(table, v$fid), "stream")) return(NULL)
+  id_v <- WamRuntime$deref(state, v$args[[1]])
+  if (is.null(id_v) || is.null(id_v$tag) || id_v$tag != "int") return(NULL)
+  id_v$val
+}
 
 # Extend a goal term with extra args (call/N+1 semantics). An atom G
 # becomes the struct G(extra_args...); a struct F(...) becomes
@@ -2966,6 +3049,113 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     out <- WamRuntime$wam_format(state, s, args, table)
     if (is.null(out)) return(FALSE)
     cat(out)
+    return(TRUE)
+  }
+
+  # ----- Stream I/O builtins -----
+  # All stream-aware variants take a `stream(<id>)` struct as their
+  # first arg. Stream lookups go through stream_id_of -- a non-stream
+  # arg or a stale id (after close/1) makes the call fail rather
+  # than throw, matching the WAM convention.
+  if (key == "open/3") {
+    path_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+    mode_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 2L))
+    path <- wam_term_name_string(path_v, table)
+    mode_name <- wam_term_name_string(mode_v, table)
+    if (is.null(path) || is.null(mode_name)) return(FALSE)
+    r_mode <- switch(mode_name,
+      "read"   = "r",
+      "write"  = "w",
+      "append" = "a",
+      NULL
+    )
+    if (is.null(r_mode)) return(FALSE)
+    conn <- tryCatch(file(path, open = r_mode), error = function(e) NULL,
+                                                warning = function(w) NULL)
+    if (is.null(conn)) return(FALSE)
+    id <- WamRuntime$stream_register(program, conn)
+    stream_term <- StructTerm(WamRuntime$intern(table, "stream"),
+                               list(IntTerm(id)))
+    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 3L), stream_term))
+  }
+
+  if (key == "close/1") {
+    sid <- WamRuntime$stream_id_of(state, WamRuntime$get_reg(state, 1L), table)
+    if (is.null(sid)) return(FALSE)
+    return(isTRUE(WamRuntime$stream_close(program, sid)))
+  }
+
+  # read/2 is line-buffered: each call consumes one line, strips a
+  # trailing `.` (with optional whitespace), and parses the rest via
+  # the operator-precedence parser. Multi-line terms are not
+  # supported in this scaffold. EOF binds the term to the atom
+  # `end_of_file` (matches SWI semantics).
+  if (key == "read/2") {
+    sid <- WamRuntime$stream_id_of(state, WamRuntime$get_reg(state, 1L), table)
+    if (is.null(sid)) return(FALSE)
+    conn <- WamRuntime$stream_get(program, sid)
+    if (is.null(conn)) return(FALSE)
+    txt <- ""
+    repeat {
+      line <- tryCatch(readLines(conn, n = 1L, warn = FALSE),
+                       error = function(e) NULL)
+      if (is.null(line) || length(line) == 0L) {
+        return(WamRuntime$unify(state, WamRuntime$get_reg(state, 2L),
+                                Atom(WamRuntime$intern(table, "end_of_file"))))
+      }
+      candidate <- sub("\\s*\\.\\s*$", "", line)
+      if (nchar(candidate) > 0L) { txt <- candidate; break }
+    }
+    parsed <- WamRuntime$parse_term(txt, table, state)
+    if (is.null(parsed)) return(FALSE)
+    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 2L), parsed))
+  }
+
+  if (key == "write/2") {
+    sid <- WamRuntime$stream_id_of(state, WamRuntime$get_reg(state, 1L), table)
+    if (is.null(sid)) return(FALSE)
+    conn <- WamRuntime$stream_get(program, sid)
+    if (is.null(conn)) return(FALSE)
+    text <- WamRuntime$term_to_string(state, WamRuntime$get_reg(state, 2L), table)
+    cat(text, file = conn, sep = "")
+    return(TRUE)
+  }
+
+  if (key == "writeln/2") {
+    sid <- WamRuntime$stream_id_of(state, WamRuntime$get_reg(state, 1L), table)
+    if (is.null(sid)) return(FALSE)
+    conn <- WamRuntime$stream_get(program, sid)
+    if (is.null(conn)) return(FALSE)
+    text <- WamRuntime$term_to_string(state, WamRuntime$get_reg(state, 2L), table)
+    cat(text, "\n", file = conn, sep = "")
+    return(TRUE)
+  }
+
+  if (key == "nl/1") {
+    sid <- WamRuntime$stream_id_of(state, WamRuntime$get_reg(state, 1L), table)
+    if (is.null(sid)) return(FALSE)
+    conn <- WamRuntime$stream_get(program, sid)
+    if (is.null(conn)) return(FALSE)
+    cat("\n", file = conn, sep = "")
+    return(TRUE)
+  }
+
+  if (key == "format/3") {
+    sid <- WamRuntime$stream_id_of(state, WamRuntime$get_reg(state, 1L), table)
+    if (is.null(sid)) return(FALSE)
+    conn <- WamRuntime$stream_get(program, sid)
+    if (is.null(conn)) return(FALSE)
+    t_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 2L))
+    s <- wam_term_name_string(t_v, table)
+    if (is.null(s)) return(FALSE)
+    raw_args <- WamRuntime$get_reg(state, 3L)
+    args <- WamRuntime$wam_list_decompose(state, raw_args, table)
+    if (is.null(args)) {
+      args <- list(WamRuntime$deref(state, raw_args))
+    }
+    out <- WamRuntime$wam_format(state, s, args, table)
+    if (is.null(out)) return(FALSE)
+    cat(out, file = conn, sep = "")
     return(TRUE)
   }
 

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2215,6 +2215,66 @@ e2e_dcg_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for stream I/O. Drives a write-then-read
+% round trip through a real file: open/3 + writeln/2 + format/3 +
+% close/1, then re-open the file for reading and read/2 each term
+% back, verifying the parser handles operator notation and EOF
+% returns the `end_of_file` atom.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(streams_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_streams_via_rscript
+    ;   true
+    )).
+
+e2e_streams_via_rscript :-
+    unique_r_tmp_dir('tmp_r_streams_e2e', TmpDir),
+    directory_file_path(TmpDir, 'stream_data.txt', DataFile),
+    atom_string(DataFile, DataFileStr),
+    % Driver predicates. write_round writes a few terms (each
+    % terminated by a `.` so read/2 can re-parse them); read_round
+    % opens for read, pulls terms back, and asserts they unify with
+    % the expected forms.
+    assertz((user:s_write(File) :-
+        open(File, write, S),
+        writeln(S, 'fact(1).'),
+        writeln(S, 'fact(2).'),
+        format(S, 'sum(~w).~n', [42]),
+        format(S, 'expr(~w).~n', [1+2*3]),
+        close(S))),
+    assertz((user:s_read_back(File) :-
+        open(File, read, S),
+        read(S, T1), T1 == fact(1),
+        read(S, T2), T2 == fact(2),
+        read(S, T3), T3 == sum(42),
+        read(S, T4), T4 == expr(1+2*3),
+        read(S, T5), T5 == end_of_file,
+        close(S))),
+    assertz((user:s_round_trip(File) :- s_write(File), s_read_back(File))),
+    % open/3 on a non-existent file with mode=read fails.
+    assertz((user:s_open_no(File) :- open(File, read, _))),
+    % close/1 on a non-stream arg fails.
+    assertz((user:s_close_no :- close(not_a_stream))),
+    write_wam_r_project(
+        [user:s_write/1, user:s_read_back/1, user:s_round_trip/1,
+         user:s_open_no/1, user:s_close_no/0],
+        [intern_atoms([fact, sum, expr, end_of_file, '+', '*'])],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    % Path is passed bare; the CLI parser falls back to atom when
+    % the slash-tokenised string fails to parse as a Prolog term.
+    run_rscript_with_args(RDir, 's_round_trip/1', [DataFileStr], OutOk),
+    assertion(sub_string(OutOk, _, _, _, "true")),
+    % Bogus path fails the read-mode open.
+    run_rscript_with_args(RDir, 's_open_no/1', ["/no/such/path.txt"], OutNo),
+    assertion(sub_string(OutNo, _, _, _, "false")),
+    run_rscript_query(RDir, 's_close_no/0', OutCloseNo),
+    assertion(sub_string(OutCloseNo, _, _, _, "false")),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
## Summary

Adds basic file-stream I/O to the WAM R target. While writing the e2e test I surfaced a long-standing latent bug in the call-frame handling and fixed it as part of this PR.

### Streams

New library builtins:

| Builtin | Notes |
|---|---|
| `open/3` | modes `read` / `write` / `append`; returns a `stream(<id>)` struct. |
| `close/1` | closes the underlying R connection (with explicit `flush`) and removes the registry entry. |
| `read/2` | line-buffered; strips a trailing `.` and parses the rest via the operator-precedence parser. EOF binds to the atom `end_of_file` (SWI semantics). |
| `write/2`, `writeln/2`, `nl/1`, `format/3` | stream-aware variants of the existing stdout I/O. |

Streams are opaque `stream(<id>)` structs whose integer id keys into a new `program$streams` env. A small `stream_id_of` helper extracts the id so every builtin can validate its first arg uniformly.

Multi-line terms, `current_input/1` / `current_output/1`, `set_input/1` / `set_output/1`, character I/O, and binary streams are not supported -- doc updated to enumerate the gap.

### Y-register save/restore on Allocate / Deallocate

The flat `state$regs2` env stored A, X, *and* Y registers under the same keyspace. With nested calls like

```prolog
rt(F) :- do_write(F), do_read(F).
```

that's a real bug: `do_write`'s `Y201` (for its local stream var) overwrites `rt`'s `Y201` (for `File`), so `do_read` sees a stream struct where it expected a path. The 44 pre-existing tests never happened to nest two predicates that both used `Y201` as a permanent var, so the bug stayed latent.

Fix: `Allocate` snapshots the caller's Y vars (`idx >= 201`) into the new frame; `Deallocate` overwrites those slots with the saved values when the frame pops. Y vars the callee added beyond the caller's set are **left in place**, because SWI's WAM emit can read a Y register *after* `Deallocate` (e.g. an `ArgInstr` that follows environment trimming) -- removing them would break that case. The first attempt at this fix was too aggressive (it also dropped callee-added Ys) and broke `term_inspection_e2e_rscript`; the final shape leaves callee-added Ys alone and only restores the saved ones.

## Test plan

- [x] `streams_e2e_rscript` (new): write a sequence of terms via `writeln/2` + `format/3`, re-open the file, read each term back via `read/2`, verify EOF binds to `end_of_file`, and check that `open/3` on a missing path and `close/1` on a non-stream both fail.
- [x] `term_inspection_e2e_rscript` (regression check): `functor + arg + arg` after `Deallocate` still works.
- [x] Full suite: 45 tests pass (run time 259s).

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_