### PR TITLE
feat(wam-r): transitive_closure2 kernel + lowered_dispatch tier

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -183,6 +183,38 @@ tries handlers in order and stops at the first hit:
 
 If none match, the call fails and triggers backtracking.
 
+### Recursive-kernel detection
+
+Predicates that match a registered graph-traversal pattern are
+classified at codegen time and emitted as a native R fast path
+that bypasses the WAM stepping engine entirely. The classifier
+lives in
+[`src/unifyweaver/core/recursive_kernel_detection.pl`](../src/unifyweaver/core/recursive_kernel_detection.pl)
+and is shared with the Haskell / Rust / Elixir targets; this
+target wires up `transitive_closure2` so far. The canonical
+shape is
+
+```prolog
+ancestor(X, Y) :- parent(X, Y).
+ancestor(X, Y) :- parent(X, Z), ancestor(Z, Y).
+```
+
+The runtime helper `WamRuntime$transitive_closure2` does a BFS
+from a ground source over the underlying edge predicate
+(invoked via `iterate_goal`, so the edges can be a fact-table,
+a dynamic store, a WAM-compiled predicate, or any other
+registered dispatch path) and streams reached nodes via
+iter-CPs. Source must be ground; target may be ground (check)
+or unground (enumerate).
+
+The lowered function is registered in `program$lowered_dispatch`,
+so `Call` and `Execute` instructions for kernel-detected
+predicates pick up the fast path before the WAM array tier --
+not just direct R-API calls through the per-pred wrapper.
+
+Disable per-call with `kernel_layout(off)` in Options or
+globally via `user:wam_r_kernel_layout(off)`.
+
 ### Fact-table lowering
 
 Predicates whose every clause is just `get_constant + proceed` are
@@ -484,7 +516,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 46 tests covering both structural assertions on the
+and contains 47 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -524,6 +556,7 @@ Coverage map (e2e tests, by feature group):
 | `dcg_e2e_rscript` | DCG `-->` rules + `phrase/2,3` (recursive grammars, prefix-with-rest) |
 | `streams_e2e_rscript` | `open/3`, `close/1`, `read/2`, `write/2`, `writeln/2`, `format/3` round-trip |
 | `fact_table_e2e_rscript` | fact-table lowering: hash-indexed dispatch, multi-solution backtracking, atoms + integers |
+| `kernel_tc2_e2e_rscript` | recursive-kernel detection: `transitive_closure2` BFS over a fact-table edge predicate |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -58,6 +58,8 @@
     wam_r_lowerable/3,
     lower_predicate_to_r/4
 ]).
+:- use_module('../core/recursive_kernel_detection',
+             [detect_recursive_kernel/4, kernel_config/2]).
 
 % ============================================================================
 % EMIT MODE
@@ -535,7 +537,8 @@ compile_wam_predicate_to_r(_Pred, _WamCode, _Options, "").
 %%                                -AllLabels, -WrapperCode)
 compile_predicates_for_project(Predicates, Options,
                                AllInstrs, TopLevelLabelEntries,
-                               AllLabelEntries, WrapperCode, LoweredCode) :-
+                               AllLabelEntries, WrapperCode, LoweredCode,
+                               LoweredDispatchCode) :-
     init_r_atom_intern_table,
     option(intern_atoms(ExtraAtoms), Options, []),
     forall(member(A, ExtraAtoms),
@@ -545,11 +548,13 @@ compile_predicates_for_project(Predicates, Options,
                                       CompilePredicates),
     wam_r_resolve_emit_mode(Options, Mode),
     compile_all_predicates(CompilePredicates, Options, Mode, 1,
-                           [], [], [], [], [],
+                           [], [], [], [], [], [],
                            AllInstrs, TopLevelLabelEntries,
-                           AllLabelEntries, Wrappers, LoweredEntries),
+                           AllLabelEntries, Wrappers, LoweredEntries,
+                           LoweredDispatchEntries),
     atomic_list_concat(Wrappers, '\n', WrapperCode),
-    atomic_list_concat(LoweredEntries, '\n', LoweredCode).
+    atomic_list_concat(LoweredEntries, '\n', LoweredCode),
+    atomic_list_concat(LoweredDispatchEntries, '\n', LoweredDispatchCode).
 
 append_missing_foreign_predicates(Predicates, ForeignPredicates,
                                   CompilePredicates) :-
@@ -569,12 +574,15 @@ same_predicate_indicator(P0, P1) :-
 predicate_indicator_key(_:Pred/Arity, Pred/Arity) :- !.
 predicate_indicator_key(Pred/Arity, Pred/Arity).
 
-compile_all_predicates([], _, _, _, Instrs, TopLabels, AllLabels, Wrappers, Lowered,
-                       Instrs, TopLabels, AllLabels, Wrappers, Lowered).
+compile_all_predicates([], _, _, _, Instrs, TopLabels, AllLabels, Wrappers,
+                       Lowered, Dispatch,
+                       Instrs, TopLabels, AllLabels, Wrappers, Lowered, Dispatch).
 compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
                        InstrAcc, TopLabelAcc, AllLabelAcc, WrapperAcc, LoweredAcc,
+                       LoweredDispAcc,
                        AllInstrs, TopLevelLabelEntries,
-                       AllLabelEntries, AllWrappers, AllLowered) :-
+                       AllLabelEntries, AllWrappers, AllLowered,
+                       AllLoweredDispatch) :-
     (   Pred = _Module:P/Arity -> true ; Pred = P/Arity ),
     (   r_foreign_predicate(P, Arity, Options)
     ->  format(string(FLit), 'CallForeign("~w", ~w)', [P, Arity]),
@@ -602,18 +610,30 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
         NewTopLabels = [MainEntry | TopLabelAcc],
         append([MainEntry | PredSubLabelEntries], AllLabelAcc, NewAllLabels)
     ),
-    % Decide whether this predicate should be lowered. The fact-
-    % table path is preferred when applicable; otherwise we try the
-    % regular Phase-3 lowered emitter; otherwise we fall back to the
-    % WAM array dispatch.
-    (   WamCodeForLower \= "",
+    % Decide whether this predicate should be lowered. The kernel
+    % detector wins first (a recognised graph pattern dispatches to
+    % a native R fast path); then the fact-table path; then the
+    % regular Phase-3 lowered emitter; otherwise the WAM array.
+    (   kernel_layout_enabled(Options),
+        catch(wam_r_kernel_detect(Pred, Kernel), _, fail),
+        catch(emit_kernel(P, Kernel, KData, KFunc, KFuncName), _, fail)
+    ->  (   KData == ""
+        ->  NewLoweredAcc = [KFunc | LoweredAcc]
+        ;   NewLoweredAcc = [KData, KFunc | LoweredAcc]
+        ),
+        emit_r_lowered_wrapper(P, Arity, KFuncName, WrapperCode),
+        emit_lowered_dispatch_entry(P, Arity, KFuncName, DispEntry),
+        NewLoweredDispAcc = [DispEntry | LoweredDispAcc]
+    ;   WamCodeForLower \= "",
         catch(wam_r_fact_classify(WamCodeForLower,
                                    fact_info(NCls, _FArity, FTuples)),
               _, fail),
         fact_layout_enabled(P, Arity, NCls, Options)
     ->  emit_fact_table(P, Arity, FTuples, FactData, FactFunc, FactFuncName),
         NewLoweredAcc = [FactData, FactFunc | LoweredAcc],
-        emit_r_lowered_wrapper(P, Arity, FactFuncName, WrapperCode)
+        emit_r_lowered_wrapper(P, Arity, FactFuncName, WrapperCode),
+        emit_lowered_dispatch_entry(P, Arity, FactFuncName, DispEntry),
+        NewLoweredDispAcc = [DispEntry | LoweredDispAcc]
     ;   should_try_lower(Mode, P, Arity),
         WamCodeForLower \= "",
         catch(wam_r_lowerable(Pred, WamCodeForLower, _Reason), _, fail),
@@ -621,15 +641,34 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
                                    lowered(_PName, FuncName, LoweredR)),
               _, fail)
     ->  NewLoweredAcc = [LoweredR | LoweredAcc],
-        emit_r_lowered_wrapper(P, Arity, FuncName, WrapperCode)
+        emit_r_lowered_wrapper(P, Arity, FuncName, WrapperCode),
+        % Phase-3 lowered functions are NOT registered for internal
+        % dispatch -- they expect their own pre-set state via the
+        % per-pred wrapper. Internal calls keep going through the
+        % WAM array, matching the pre-PR behaviour.
+        NewLoweredDispAcc = LoweredDispAcc
     ;   NewLoweredAcc = LoweredAcc,
+        NewLoweredDispAcc = LoweredDispAcc,
         emit_r_wrapper(P, Arity, BasePC, WrapperCode)
     ),
     compile_all_predicates(Rest, Options, Mode, NewPC,
                            NewInstrs, NewTopLabels, NewAllLabels,
                            [WrapperCode|WrapperAcc], NewLoweredAcc,
+                           NewLoweredDispAcc,
                            AllInstrs, TopLevelLabelEntries,
-                           AllLabelEntries, AllWrappers, AllLowered).
+                           AllLabelEntries, AllWrappers, AllLowered,
+                           AllLoweredDispatch).
+
+%% emit_lowered_dispatch_entry(+Pred, +Arity, +FuncName, -Entry)
+%  Generates an `assign("Pred/Arity", FuncName, envir = ...)` line
+%  that's stitched into the program template. The runtime tier
+%  dispatch_call consults program$lowered_dispatch first, so kernel
+%  / fact-table fast paths fire for both top-level R-API calls and
+%  internal Call/Execute instructions.
+emit_lowered_dispatch_entry(Pred, Arity, FuncName, Entry) :-
+    format(string(Entry),
+           'assign("~w/~w", ~w, envir = shared_program$lowered_dispatch)',
+           [Pred, Arity, FuncName]).
 
 offset_label_entry(Offset, Entry0, Entry) :-
     atom_string(Entry0, S),
@@ -709,6 +748,88 @@ r_safe_ident_char(C, C) :-
 r_safe_ident_char('.', '.') :- !.
 r_safe_ident_char('_', '_') :- !.
 r_safe_ident_char(_, '_').
+
+% ============================================================================
+% RECURSIVE KERNEL DETECTION + EMISSION
+% ============================================================================
+%
+% Detects predicates that match a registered kernel pattern (so far:
+% transitive_closure2 -- ancestor(X,Y) :- edge(X,Y). ancestor(X,Y) :-
+% edge(X,Z), ancestor(Z,Y).) and emits a native R BFS that runs the
+% reachability set in one pass, streaming hits via iter-CP. The
+% detector lives in src/unifyweaver/core/recursive_kernel_detection.pl
+% and is shared with the Haskell/Rust targets.
+%
+% Per-call: kernel_layout(off) in Options or
+% user:wam_r_kernel_layout(off) globally disables detection.
+
+:- multifile user:wam_r_kernel_layout/1.
+
+kernel_layout_enabled(Options) :-
+    option(kernel_layout(Setting), Options, auto),
+    kernel_layout_setting_ok(Setting).
+
+kernel_layout_setting_ok(auto) :-
+    (   catch(user:wam_r_kernel_layout(Override), _, fail)
+    ->  Override \== off
+    ;   true
+    ).
+kernel_layout_setting_ok(on).
+
+%% wam_r_kernel_detect(+PredIndicator, -Kernel) is semidet.
+%  Pulls the user clauses for PredIndicator and asks the shared
+%  detector to classify them. Fails silently when the predicate
+%  doesn't match any registered kernel pattern.
+wam_r_kernel_detect(PI, Kernel) :-
+    (   PI = _Mod:Pred/Arity -> true ; PI = Pred/Arity ),
+    functor(Head, Pred, Arity),
+    catch(findall(Head-StrippedBody,
+                  ( user:clause(Head, RawBody),
+                    strip_module_qualifiers(RawBody, StrippedBody) ),
+                  Clauses), _, fail),
+    Clauses \= [],
+    detect_recursive_kernel(Pred, Arity, Clauses, Kernel).
+
+% Recursively peel `Mod:Goal` wrappers and walk through the goal
+% structure (conjunction, disjunction, if-then) so the recursive-
+% kernel detector sees the underlying predicate calls. This is
+% needed because plunit wraps test-asserted clause bodies in its
+% own `plunit_<test>:user:Goal` -- bare `clause/2` returns the
+% wrapped form, which `detect_recursive_kernel` doesn't recognise.
+strip_module_qualifiers(Var, Var) :-
+    var(Var), !.
+strip_module_qualifiers(_:G, Stripped) :-
+    !, strip_module_qualifiers(G, Stripped).
+strip_module_qualifiers((A, B), (As, Bs)) :-
+    !, strip_module_qualifiers(A, As),
+       strip_module_qualifiers(B, Bs).
+strip_module_qualifiers((A ; B), (As ; Bs)) :-
+    !, strip_module_qualifiers(A, As),
+       strip_module_qualifiers(B, Bs).
+strip_module_qualifiers((A -> B), (As -> Bs)) :-
+    !, strip_module_qualifiers(A, As),
+       strip_module_qualifiers(B, Bs).
+strip_module_qualifiers(Goal, Goal).
+
+%% emit_kernel(+Pred, +Kernel, -DataDecl, -LoweredFunc, -FuncName)
+%  Emits the lowered R function for a detected kernel. Currently
+%  handles transitive_closure2 only; other kinds fall through (the
+%  caller falls back to the fact-table or compiled path).
+emit_kernel(Pred, recursive_kernel(transitive_closure2, _, ConfigOps),
+            DataDecl, LoweredFunc, FuncName) :-
+    member(edge_pred(EdgePred/EdgeArity), ConfigOps),
+    EdgeArity =:= 2,
+    r_pred_name(Pred, RName),
+    format(atom(FuncName), '~w_kernel_tc2', [RName]),
+    DataDecl = "",  % no per-pred data; the kernel just dispatches.
+    format(string(LoweredFunc),
+'~w <- function(program, state) {
+  source <- WamRuntime$get_reg(state, 1L)
+  target <- WamRuntime$get_reg(state, 2L)
+  WamRuntime$transitive_closure2(program, state, "~w/2", "~w", "~w/2",
+                                  source, target, state$pc + 1L)
+}',
+           [FuncName, Pred, EdgePred, EdgePred]).
 
 % ============================================================================
 % FACT-TABLE CLASSIFICATION + EMISSION
@@ -975,7 +1096,7 @@ write_wam_r_project(Predicates, Options, ProjectDir) :-
     write_description(ProjectDir, ModName),
     compile_predicates_for_project(Predicates, Options,
         AllInstrs, TopLevelLabelEntries, AllLabelEntries,
-        WrapperCode, LoweredFunctionsCode),
+        WrapperCode, LoweredFunctionsCode, LoweredDispatchCode),
     emit_r_intern_table(IdToStringStr),
     maplist([I, Line]>>(format(string(Line), '    ~w', [I])), AllInstrs,
             InstrLines),
@@ -986,7 +1107,7 @@ write_wam_r_project(Predicates, Options, ProjectDir) :-
     write_runtime_source(RDir),
     write_program_source(RDir, InstrBody, LabelBody, DispatchBody,
                          WrapperCode, IdToStringStr, ForeignHandlersBody,
-                         LoweredFunctionsCode).
+                         LoweredFunctionsCode, LoweredDispatchCode).
 
 write_description(ProjectDir, ModName) :-
     find_template('templates/targets/r_wam/DESCRIPTION.mustache', Template),
@@ -1005,7 +1126,7 @@ write_runtime_source(RDir) :-
 
 write_program_source(RDir, InstrBody, LabelBody, DispatchBody,
                      WrapperCode, IdToStringStr, ForeignHandlersBody,
-                     LoweredFunctionsCode) :-
+                     LoweredFunctionsCode, LoweredDispatchCode) :-
     find_template('templates/targets/r_wam/program.R.mustache', Template),
     get_time(T), format_time(string(DateStr), "%Y-%m-%d", T),
     render_template(Template,
@@ -1015,6 +1136,7 @@ write_program_source(RDir, InstrBody, LabelBody, DispatchBody,
           'dispatch'=DispatchBody,
           'wrappers'=WrapperCode,
           'intern_id_to_string'=IdToStringStr,
+          'lowered_dispatch_assignments'=LoweredDispatchCode,
           'foreign_handlers'=ForeignHandlersBody,
           'lowered_functions'=LoweredFunctionsCode
         ], Content),

--- a/templates/targets/r_wam/program.R.mustache
+++ b/templates/targets/r_wam/program.R.mustache
@@ -69,7 +69,14 @@ shared_program <- list(
   # Stream registry for open/3, read/2, write/2, etc. Keyed by the
   # stringified integer id stored inside `stream(<id>)` terms; the
   # special key "__next_id__" holds the next-id counter.
-  streams          = new.env(parent = emptyenv())
+  streams          = new.env(parent = emptyenv()),
+  # Lowered-dispatch registry for predicates that have a native R
+  # fast path (kernels, fact-tables). Keyed by "pred/arity"; value
+  # is the lowered R function. dispatch_call consults this before
+  # falling through to label/foreign/dynamic/library/builtin tiers,
+  # so internal Call/Execute instructions also reach the fast path
+  # (not just direct R-API calls through the per-pred wrapper).
+  lowered_dispatch = new.env(parent = emptyenv())
 )
 
 # ----------------------------------------------------------
@@ -77,6 +84,13 @@ shared_program <- list(
 # Empty when emit_mode is interpreter.
 # ----------------------------------------------------------
 {{lowered_functions}}
+
+# ----------------------------------------------------------
+# Lowered-dispatch registrations. Must come AFTER the lowered
+# function definitions above so the assignments can reference
+# the functions by name.
+# ----------------------------------------------------------
+{{lowered_dispatch_assignments}}
 
 # ----------------------------------------------------------
 # Per-predicate wrapper functions

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -1019,6 +1019,16 @@ WamRuntime$step <- function(program, state, instr) {
     },
     "Call" = {
       key <- paste0(instr$pred, "/", instr$arity)
+      # Lowered fast path (kernel / fact-table) wins over the WAM
+      # array. The lowered fn pushes any iter CPs it needs and
+      # returns TRUE/FALSE, so we just advance PC on success.
+      if (!is.null(program$lowered_dispatch) &&
+          exists(key, envir = program$lowered_dispatch, inherits = FALSE)) {
+        fn <- get(key, envir = program$lowered_dispatch, inherits = FALSE)
+        ok <- isTRUE(fn(program, state))
+        if (!ok) return(FALSE)
+        state$pc <- state$pc + 1L; return(TRUE)
+      }
       tgt <- program$labels[[key]]
       if (!is.null(tgt)) {
         state$cp <- state$pc + 1L
@@ -1039,6 +1049,17 @@ WamRuntime$step <- function(program, state, instr) {
     },
     "Execute" = {
       key <- paste0(instr$pred, "/", instr$arity)
+      # Lowered fast path (kernel / fact-table) wins over the WAM
+      # array. Tail-call: hand control back to the caller's CP via
+      # the same path the dynamic-store branch uses on success.
+      if (!is.null(program$lowered_dispatch) &&
+          exists(key, envir = program$lowered_dispatch, inherits = FALSE)) {
+        fn <- get(key, envir = program$lowered_dispatch, inherits = FALSE)
+        ok <- isTRUE(fn(program, state))
+        if (!ok) return(FALSE)
+        if (state$cp == 0L) { state$halt <- TRUE; return(TRUE) }
+        state$pc <- state$cp; state$cp <- 0L; return(TRUE)
+      }
       tgt <- program$labels[[key]]
       if (!is.null(tgt)) {
         state$pc <- as.integer(tgt)
@@ -1814,6 +1835,143 @@ WamRuntime$clause_iter <- function(program, state, head_args, body, arity,
 }
 
 # ----------------------------------------------------------
+# Recursive-kernel: transitive_closure2
+# ----------------------------------------------------------
+# Native BFS over the source's reachability set, given an "edge"
+# binary predicate. The detector in
+# src/unifyweaver/core/recursive_kernel_detection.pl recognises the
+# canonical shape
+#   closure(X,Y) :- edge(X,Y).
+#   closure(X,Y) :- edge(X,Z), closure(Z,Y).
+# and the wam_r_target codegen emits a one-line dispatch fn that
+# calls this helper. Edges are enumerated by driving call_goal on
+# `edge(<cur>, Y)` -- so the underlying edge predicate can be a
+# fact-table, a dynamic store, a WAM-compiled predicate, or any
+# other registered dispatch path.
+#
+# Mode support: source must be ground; target may be ground (check)
+# or unground (enumerate). Unground source falls back to FALSE for
+# now; the proper enumeration would BFS from every node, which
+# this scope leaves to a follow-up.
+WamRuntime$transitive_closure2 <- function(program, state, key, edge_pred,
+                                            edge_key, source, target,
+                                            resume_pc) {
+  table <- program$intern_table
+  src_v <- WamRuntime$deref(state, source)
+  if (is.null(src_v) || is.null(src_v$tag) || src_v$tag != "atom") {
+    return(FALSE)
+  }
+  # Snapshot state so the iterate_goal calls below don't leak
+  # bindings or CPs into the caller.
+  snap_cps   <- length(state$cps)
+  snap_regs  <- as.list.environment(state$regs2)
+  snap_trail <- length(state$trail)
+  snap_pc    <- state$pc
+  snap_cp    <- state$cp
+  snap_halt  <- state$halt
+  snap_vc    <- state$var_counter
+  snap_mode  <- state$mode
+  snap_build <- state$build_stack
+
+  edge_atom_id <- WamRuntime$intern(table, edge_pred)
+  visited <- new.env(parent = emptyenv())
+  queue   <- list(src_v)
+  reached <- list()
+  assign(as.character(src_v$id), TRUE, envir = visited)
+
+  while (length(queue) > 0L) {
+    cur <- queue[[1L]]
+    queue <- queue[-1L]
+    y_var <- Unbound(paste0("V_kt_", state$var_counter))
+    state$var_counter <- state$var_counter + 1L
+    edge_goal <- StructTerm(edge_atom_id, list(cur, y_var))
+    WamRuntime$iterate_goal(program, state, edge_goal, function() {
+      y_v <- WamRuntime$deref(state, y_var)
+      if (!is.null(y_v) && !is.null(y_v$tag) && y_v$tag == "atom") {
+        k <- as.character(y_v$id)
+        if (!exists(k, envir = visited, inherits = FALSE)) {
+          assign(k, TRUE, envir = visited)
+          queue   <<- c(queue, list(y_v))
+          reached <<- c(reached, list(y_v))
+        }
+      }
+      TRUE
+    })
+  }
+
+  # Restore state.
+  if (length(state$cps) > snap_cps) {
+    state$cps <- state$cps[seq_len(snap_cps)]
+  }
+  e <- new.env(parent = emptyenv(), hash = TRUE)
+  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
+  state$regs2 <- e
+  if (length(state$trail) > snap_trail) {
+    to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
+    for (name in to_undo) {
+      if (exists(name, envir = state$bindings, inherits = FALSE)) {
+        rm(list = name, envir = state$bindings)
+      }
+    }
+    state$trail <- state$trail[seq_len(snap_trail)]
+  }
+  state$pc          <- snap_pc
+  state$cp          <- snap_cp
+  state$halt        <- snap_halt
+  state$var_counter <- snap_vc
+  state$mode        <- snap_mode
+  state$build_stack <- snap_build
+
+  # Iterate the reached set, unifying each with target. Multi-
+  # solution: push iter CP after the first match.
+  WamRuntime$kernel_stream_iter(program, state, key, reached, target, 1L,
+                                 resume_pc)
+}
+
+# Iterate a precomputed result list, unifying each entry with the
+# target reg. Mirrors fact_table_iter_subset's iter-CP shape but
+# unifies a single-arg target instead of an arg tuple.
+WamRuntime$kernel_stream_iter <- function(program, state, key, results, target,
+                                           start_idx, resume_pc) {
+  if (start_idx > length(results)) return(FALSE)
+  for (idx in seq.int(start_idx, length(results))) {
+    snap_trail <- length(state$trail)
+    snap_vc    <- state$var_counter
+    if (WamRuntime$unify(state, target, results[[idx]])) {
+      if (idx < length(results)) {
+        captured_results <- results
+        captured_target  <- target
+        captured_next    <- idx + 1L
+        captured_resume  <- resume_pc
+        captured_program <- program
+        captured_key     <- key
+        cp <- list(
+          kind        = "iter",
+          regs        = as.list.environment(state$regs2),
+          trail_len   = snap_trail,
+          cp          = state$cp,
+          var_counter = snap_vc,
+          mode        = state$mode,
+          build_stack = state$build_stack,
+          resume_pc   = resume_pc,
+          retry       = function(state) {
+            WamRuntime$kernel_stream_iter(captured_program, state,
+                                           captured_key, captured_results,
+                                           captured_target, captured_next,
+                                           captured_resume)
+          }
+        )
+        state$cps <- c(state$cps, list(cp))
+      }
+      return(TRUE)
+    }
+    WamRuntime$undo_trail_to(state, snap_trail)
+    state$var_counter <- snap_vc
+  }
+  FALSE
+}
+
+# ----------------------------------------------------------
 # Fact-table iterator for lowered fact predicates
 # ----------------------------------------------------------
 # Predicates that are pure fact tables (all clauses are
@@ -2169,6 +2327,14 @@ WamRuntime$call_goal <- function(program, state, goal_term) {
 
 WamRuntime$dispatch_call <- function(program, state, pred, arity) {
   key <- paste0(pred, "/", arity)
+  # Lowered fast path (kernel / fact-table) wins over the WAM
+  # array; the lowered fn manages its own iter CPs and returns
+  # TRUE/FALSE.
+  if (!is.null(program$lowered_dispatch) &&
+      exists(key, envir = program$lowered_dispatch, inherits = FALSE)) {
+    fn <- get(key, envir = program$lowered_dispatch, inherits = FALSE)
+    return(isTRUE(fn(program, state)))
+  }
   tgt <- program$labels[[key]]
   if (!is.null(tgt)) {
     # User predicate (or foreign-stub label). Run as a sub-call:
@@ -2336,6 +2502,37 @@ WamRuntime$iterate_goal <- function(program, state, goal_term, on_each) {
           } else {
             WamRuntime$undo_trail_to(state, snap_t)
           }
+        }
+        return(invisible(NULL))
+      }
+    }
+  }
+
+  # Lowered fast-path predicate (kernel / fact-table): the goal's
+  # iter CPs aren't tied to the WAM stepping engine, so we drive
+  # backtracking by calling backtrack() directly and skip run().
+  # The backtrack handler restores state and invokes the iter CP's
+  # retry; on TRUE we just hand control to on_each.
+  if (!is.null(goal_v) && !is.null(goal_v$tag) &&
+      !is.null(program$lowered_dispatch)) {
+    if (goal_v$tag == "atom") {
+      ld_pred <- WamRuntime$string_of(table, goal_v$id); ld_arity <- 0L
+    } else if (goal_v$tag == "struct") {
+      ld_pred <- WamRuntime$string_of(table, goal_v$fid); ld_arity <- length(goal_v$args)
+    } else {
+      ld_pred <- NULL
+    }
+    if (!is.null(ld_pred)) {
+      ld_key <- paste0(ld_pred, "/", ld_arity)
+      if (exists(ld_key, envir = program$lowered_dispatch, inherits = FALSE)) {
+        snap_cps_len <- length(state$cps)
+        ok <- WamRuntime$call_goal(program, state, goal_term)
+        while (isTRUE(ok)) {
+          cont <- on_each()
+          if (!isTRUE(cont)) break
+          if (length(state$cps) <= snap_cps_len) break
+          if (!WamRuntime$backtrack(state)) break
+          ok <- TRUE  # backtrack already invoked retry; keep iterating
         }
         return(invisible(NULL))
       }

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2359,6 +2359,71 @@ e2e_fact_table_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for the recursive-kernel detector. The
+% ancestor/2 predicate matches the transitive_closure2 pattern from
+% recursive_kernel_detection.pl, so the codegen swaps its WAM body
+% for a native R BFS over the underlying parent/2 fact-table. Tests
+% direct hit, multi-hop reach, branch traversal, no-path failure,
+% and findall-style enumeration through the new lowered_dispatch
+% tier in dispatch_call / Call / Execute.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(kernel_tc2_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_kernel_tc2_via_rscript
+    ;   true
+    )).
+
+e2e_kernel_tc2_via_rscript :-
+    retractall(user:parent_of(_, _)),
+    retractall(user:anc(_, _)),
+    assertz(user:parent_of(alice, bob)),
+    assertz(user:parent_of(bob, carol)),
+    assertz(user:parent_of(carol, dan)),
+    assertz(user:parent_of(alice, eve)),
+    assertz(user:parent_of(eve, frank)),
+    assertz((user:anc(X, Y) :- user:parent_of(X, Y))),
+    assertz((user:anc(X, Y) :- user:parent_of(X, Z), user:anc(Z, Y))),
+    assertz((user:tc_direct  :- anc(alice, bob))),
+    assertz((user:tc_deep    :- anc(alice, dan))),
+    assertz((user:tc_branch  :- anc(alice, frank))),
+    assertz((user:tc_no_back :- anc(bob, alice))),
+    assertz((user:tc_disjoint :- anc(eve, carol))),
+    assertz((user:tc_findall :-
+        findall(Y, anc(alice, Y), L),
+        msort(L, S),
+        S == [bob, carol, dan, eve, frank])),
+    unique_r_tmp_dir('tmp_r_kernel_tc2_e2e', TmpDir),
+    write_wam_r_project(
+        [user:parent_of/2, user:anc/2,
+         user:tc_direct/0, user:tc_deep/0, user:tc_branch/0,
+         user:tc_no_back/0, user:tc_disjoint/0, user:tc_findall/0],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [tc_direct, tc_deep, tc_branch, tc_findall],
+    No  = [tc_no_back, tc_disjoint],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    % The generator should emit the kernel function and register it
+    % in the lowered-dispatch env.
+    directory_file_path(TmpDir, 'R/generated_program.R', ProgPath),
+    read_file_to_string(ProgPath, Code, []),
+    assertion(sub_string(Code, _, _, _, 'pred_anc_kernel_tc2 <- function(')),
+    assertion(sub_string(Code, _, _, _,
+        'assign("anc/2", pred_anc_kernel_tc2, envir = shared_program$lowered_dispatch)')),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
## Summary

First parity step on top of the `recursive_kernel_detection.pl` infrastructure shared with the Haskell / Rust / Elixir targets. Predicates that match the canonical transitive-closure pattern

```prolog
closure(X, Y) :- edge(X, Y).
closure(X, Y) :- edge(X, Z), closure(Z, Y).
```

are detected at codegen time and emitted as a one-line lowered function that calls a new `WamRuntime$transitive_closure2` helper. The helper does a BFS from the (ground) source over the underlying edge predicate -- driven via `iterate_goal`, so edges can be a fact-table, a dynamic store, a WAM-compiled predicate, or any other registered dispatch path. Reachable nodes stream out via iter-CPs.

## The lowered_dispatch tier (the piece that makes this matter)

The piece that makes this useful for real workloads is the new `lowered_dispatch` registry: a program-level R env mapping `"pred/arity"` to the lowered fn. Both the WAM step handlers (`Call` / `Execute`) and `dispatch_call` consult it before the WAM array, so internal Prolog-to-Prolog calls also reach the fast path -- not just direct R-API invocations through the per-pred wrapper. (Phase-3 lowered fns deliberately stay out of the registry; their wrappers manage their own state.) Both fact-table preds (PR #1921) and the new kernel preds register here.

## Cross-cutting fixes

- `iterate_goal` now special-cases `lowered_dispatch` preds: the default fallback drives the run loop, but lowered iter CPs use `resume_pc` that's only meaningful inside the WAM stepper. Direct `backtrack()` calls drive the iteration without re-entering `run()`.
- `wam_r_kernel_detect` strips module qualifiers from clause bodies via a recursive walk; plunit wraps test-asserted bodies in `plunit_<test>:user:Goal`, which the bare detector pattern can't match. The strip walks through `,/2`, `;/2`, `->/2` so kernel detection works for nested-call bodies regardless of how module-aware the test harness is.

## Test plan

- [x] `kernel_tc2_e2e_rscript` (new): direct hit, multi-hop reach, branch traversal, no-path failure, disjoint subgraph, `findall/3` enumeration through the new lowered_dispatch tier in `dispatch_call` / `Call` / `Execute`.
- [x] Full suite: 47 tests pass.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_