### PR TITLE
feat(wam-r): transitive_distance3 kernel (BFS with depth)

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -191,21 +191,27 @@ that bypasses the WAM stepping engine entirely. The classifier
 lives in
 [`src/unifyweaver/core/recursive_kernel_detection.pl`](../src/unifyweaver/core/recursive_kernel_detection.pl)
 and is shared with the Haskell / Rust / Elixir targets; this
-target wires up `transitive_closure2` so far. The canonical
-shape is
+target wires up `transitive_closure2` and `transitive_distance3`
+so far. Canonical shapes:
 
 ```prolog
+% transitive_closure2 -- streams reachable nodes
 ancestor(X, Y) :- parent(X, Y).
 ancestor(X, Y) :- parent(X, Z), ancestor(Z, Y).
+
+% transitive_distance3 -- streams (target, distance-from-source)
+tdist(X, Y, 1) :- edge(X, Y).
+tdist(X, Y, D) :- edge(X, Z), tdist(Z, Y, D1), D is D1 + 1.
 ```
 
-The runtime helper `WamRuntime$transitive_closure2` does a BFS
-from a ground source over the underlying edge predicate
-(invoked via `iterate_goal`, so the edges can be a fact-table,
-a dynamic store, a WAM-compiled predicate, or any other
-registered dispatch path) and streams reached nodes via
-iter-CPs. Source must be ground; target may be ground (check)
-or unground (enumerate).
+The runtime helpers (`WamRuntime$transitive_closure2`,
+`WamRuntime$transitive_distance3`) BFS from a ground source over
+the underlying edge predicate (invoked via `iterate_goal`, so the
+edges can be a fact-table, a dynamic store, a WAM-compiled
+predicate, or any other registered dispatch path) and stream
+results via iter-CPs. Source must be ground; target may be ground
+(check) or unground (enumerate); for the distance variant, the
+distance arg is computed (always unground at the call).
 
 The lowered function is registered in `program$lowered_dispatch`,
 so `Call` and `Execute` instructions for kernel-detected
@@ -516,7 +522,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 47 tests covering both structural assertions on the
+and contains 48 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -557,6 +563,7 @@ Coverage map (e2e tests, by feature group):
 | `streams_e2e_rscript` | `open/3`, `close/1`, `read/2`, `write/2`, `writeln/2`, `format/3` round-trip |
 | `fact_table_e2e_rscript` | fact-table lowering: hash-indexed dispatch, multi-solution backtracking, atoms + integers |
 | `kernel_tc2_e2e_rscript` | recursive-kernel detection: `transitive_closure2` BFS over a fact-table edge predicate |
+| `kernel_td3_e2e_rscript` | recursive-kernel detection: `transitive_distance3` BFS-with-depth over a fact-table edge predicate |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -813,8 +813,9 @@ strip_module_qualifiers(Goal, Goal).
 
 %% emit_kernel(+Pred, +Kernel, -DataDecl, -LoweredFunc, -FuncName)
 %  Emits the lowered R function for a detected kernel. Currently
-%  handles transitive_closure2 only; other kinds fall through (the
-%  caller falls back to the fact-table or compiled path).
+%  handles transitive_closure2 and transitive_distance3; other
+%  kinds fall through (the caller falls back to the fact-table or
+%  compiled path).
 emit_kernel(Pred, recursive_kernel(transitive_closure2, _, ConfigOps),
             DataDecl, LoweredFunc, FuncName) :-
     member(edge_pred(EdgePred/EdgeArity), ConfigOps),
@@ -828,6 +829,22 @@ emit_kernel(Pred, recursive_kernel(transitive_closure2, _, ConfigOps),
   target <- WamRuntime$get_reg(state, 2L)
   WamRuntime$transitive_closure2(program, state, "~w/2", "~w", "~w/2",
                                   source, target, state$pc + 1L)
+}',
+           [FuncName, Pred, EdgePred, EdgePred]).
+emit_kernel(Pred, recursive_kernel(transitive_distance3, _, ConfigOps),
+            DataDecl, LoweredFunc, FuncName) :-
+    member(edge_pred(EdgePred/EdgeArity), ConfigOps),
+    EdgeArity =:= 2,
+    r_pred_name(Pred, RName),
+    format(atom(FuncName), '~w_kernel_td3', [RName]),
+    DataDecl = "",
+    format(string(LoweredFunc),
+'~w <- function(program, state) {
+  source <- WamRuntime$get_reg(state, 1L)
+  target <- WamRuntime$get_reg(state, 2L)
+  dist   <- WamRuntime$get_reg(state, 3L)
+  WamRuntime$transitive_distance3(program, state, "~w/3", "~w", "~w/2",
+                                   source, target, dist, state$pc + 1L)
 }',
            [FuncName, Pred, EdgePred, EdgePred]).
 

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -1928,6 +1928,140 @@ WamRuntime$transitive_closure2 <- function(program, state, key, edge_pred,
                                  resume_pc)
 }
 
+# ----------------------------------------------------------
+# Recursive-kernel: transitive_distance3
+# ----------------------------------------------------------
+# BFS variant that yields (target, distance) pairs. Pattern:
+#   tdist(X, Y, 1) :- edge(X, Y).
+#   tdist(X, Y, D) :- edge(X, Z), tdist(Z, Y, D1), D is D1 + 1.
+# We BFS from the (ground) source and record the depth at which
+# each node is first reached. The source itself is *not* yielded
+# unless there's a self-loop, matching the SWI semantics of the
+# clauses above (one edge step is required).
+WamRuntime$transitive_distance3 <- function(program, state, key, edge_pred,
+                                             edge_key, source, target, dist,
+                                             resume_pc) {
+  table <- program$intern_table
+  src_v <- WamRuntime$deref(state, source)
+  if (is.null(src_v) || is.null(src_v$tag) || src_v$tag != "atom") {
+    return(FALSE)
+  }
+  snap_cps   <- length(state$cps)
+  snap_regs  <- as.list.environment(state$regs2)
+  snap_trail <- length(state$trail)
+  snap_pc    <- state$pc
+  snap_cp    <- state$cp
+  snap_halt  <- state$halt
+  snap_vc    <- state$var_counter
+  snap_mode  <- state$mode
+  snap_build <- state$build_stack
+
+  edge_atom_id <- WamRuntime$intern(table, edge_pred)
+  visited <- new.env(parent = emptyenv())
+  # Queue stored as parallel lists: nodes + depths.
+  q_nodes  <- list(src_v)
+  q_depths <- list(0L)
+  reached  <- list()  # list of list(node, depth)
+  assign(as.character(src_v$id), TRUE, envir = visited)
+
+  while (length(q_nodes) > 0L) {
+    cur   <- q_nodes[[1L]]
+    depth <- q_depths[[1L]]
+    q_nodes  <- q_nodes[-1L]
+    q_depths <- q_depths[-1L]
+    y_var <- Unbound(paste0("V_kd_", state$var_counter))
+    state$var_counter <- state$var_counter + 1L
+    edge_goal <- StructTerm(edge_atom_id, list(cur, y_var))
+    next_depth <- depth + 1L
+    WamRuntime$iterate_goal(program, state, edge_goal, function() {
+      y_v <- WamRuntime$deref(state, y_var)
+      if (!is.null(y_v) && !is.null(y_v$tag) && y_v$tag == "atom") {
+        k <- as.character(y_v$id)
+        if (!exists(k, envir = visited, inherits = FALSE)) {
+          assign(k, TRUE, envir = visited)
+          q_nodes  <<- c(q_nodes,  list(y_v))
+          q_depths <<- c(q_depths, list(next_depth))
+          reached  <<- c(reached,  list(list(node = y_v, depth = next_depth)))
+        }
+      }
+      TRUE
+    })
+  }
+
+  # Restore state.
+  if (length(state$cps) > snap_cps) {
+    state$cps <- state$cps[seq_len(snap_cps)]
+  }
+  e <- new.env(parent = emptyenv(), hash = TRUE)
+  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
+  state$regs2 <- e
+  if (length(state$trail) > snap_trail) {
+    to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
+    for (name in to_undo) {
+      if (exists(name, envir = state$bindings, inherits = FALSE)) {
+        rm(list = name, envir = state$bindings)
+      }
+    }
+    state$trail <- state$trail[seq_len(snap_trail)]
+  }
+  state$pc          <- snap_pc
+  state$cp          <- snap_cp
+  state$halt        <- snap_halt
+  state$var_counter <- snap_vc
+  state$mode        <- snap_mode
+  state$build_stack <- snap_build
+
+  WamRuntime$kernel_pair_iter(program, state, key, reached, target, dist,
+                               1L, resume_pc)
+}
+
+# Iterate a precomputed list of (node, depth) pairs, unifying each
+# pair with the (target, distance) reg pair. Same iter-CP shape as
+# kernel_stream_iter but with two unify slots per result.
+WamRuntime$kernel_pair_iter <- function(program, state, key, results, target,
+                                         dist, start_idx, resume_pc) {
+  if (start_idx > length(results)) return(FALSE)
+  for (idx in seq.int(start_idx, length(results))) {
+    snap_trail <- length(state$trail)
+    snap_vc    <- state$var_counter
+    entry <- results[[idx]]
+    ok_t <- WamRuntime$unify(state, target, entry$node)
+    ok_d <- ok_t && WamRuntime$unify(state, dist, IntTerm(entry$depth))
+    if (ok_d) {
+      if (idx < length(results)) {
+        captured_results <- results
+        captured_target  <- target
+        captured_dist    <- dist
+        captured_next    <- idx + 1L
+        captured_resume  <- resume_pc
+        captured_program <- program
+        captured_key     <- key
+        cp <- list(
+          kind        = "iter",
+          regs        = as.list.environment(state$regs2),
+          trail_len   = snap_trail,
+          cp          = state$cp,
+          var_counter = snap_vc,
+          mode        = state$mode,
+          build_stack = state$build_stack,
+          resume_pc   = resume_pc,
+          retry       = function(state) {
+            WamRuntime$kernel_pair_iter(captured_program, state, captured_key,
+                                         captured_results, captured_target,
+                                         captured_dist, captured_next,
+                                         captured_resume)
+          }
+        )
+        state$cps <- c(state$cps, list(cp))
+      }
+      return(TRUE)
+    }
+    WamRuntime$undo_trail_to(state, snap_trail)
+    state$var_counter <- snap_vc
+  }
+  FALSE
+}
+
 # Iterate a precomputed result list, unifying each entry with the
 # target reg. Mirrors fact_table_iter_subset's iter-CP shape but
 # unifies a single-arg target instead of an arg tuple.

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2424,6 +2424,72 @@ e2e_kernel_tc2_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for the transitive_distance3 kernel. Same
+% BFS shape as transitive_closure2 but tracks depth-from-source and
+% yields (target, distance) pairs. Direct hits, multi-hop reach,
+% wrong-distance failure, branch traversal, and findall over the
+% reachable set. The lowered_dispatch tier means internal calls
+% (from tc_findall's body) hit the kernel just like top-level CLI.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(kernel_td3_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_kernel_td3_via_rscript
+    ;   true
+    )).
+
+e2e_kernel_td3_via_rscript :-
+    retractall(user:edge(_, _)),
+    retractall(user:tdist(_, _, _)),
+    assertz(user:edge(a, b)),
+    assertz(user:edge(b, c)),
+    assertz(user:edge(c, d)),
+    assertz(user:edge(a, e)),
+    assertz(user:edge(e, f)),
+    assertz((user:tdist(X, Y, 1) :- user:edge(X, Y))),
+    assertz((user:tdist(X, Y, D) :- user:edge(X, Z), user:tdist(Z, Y, D1),
+                                     D is D1 + 1)),
+    assertz((user:td_one  :- tdist(a, b, 1))),
+    assertz((user:td_two  :- tdist(a, c, 2))),
+    assertz((user:td_three :- tdist(a, d, 3))),
+    assertz((user:td_branch :- tdist(a, e, 1))),
+    assertz((user:td_deep_branch :- tdist(a, f, 2))),
+    assertz((user:td_wrong_dist :- tdist(a, c, 1))),
+    assertz((user:td_no_path    :- tdist(b, a, _))),
+    assertz((user:td_findall :-
+        findall(Y-D, tdist(a, Y, D), L),
+        msort(L, S),
+        S == [b-1, c-2, d-3, e-1, f-2])),
+    unique_r_tmp_dir('tmp_r_kernel_td3_e2e', TmpDir),
+    write_wam_r_project(
+        [user:edge/2, user:tdist/3,
+         user:td_one/0, user:td_two/0, user:td_three/0,
+         user:td_branch/0, user:td_deep_branch/0,
+         user:td_wrong_dist/0, user:td_no_path/0, user:td_findall/0],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [td_one, td_two, td_three, td_branch, td_deep_branch, td_findall],
+    No  = [td_wrong_dist, td_no_path],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    directory_file_path(TmpDir, 'R/generated_program.R', ProgPath),
+    read_file_to_string(ProgPath, Code, []),
+    assertion(sub_string(Code, _, _, _, 'pred_tdist_kernel_td3 <- function(')),
+    assertion(sub_string(Code, _, _, _,
+        'assign("tdist/3", pred_tdist_kernel_td3, envir = shared_program$lowered_dispatch)')),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
## Summary

Second of the seven kernels from the shared `recursive_kernel_detection.pl` classifier. Pattern:

```prolog
tdist(X, Y, 1) :- edge(X, Y).
tdist(X, Y, D) :- edge(X, Z), tdist(Z, Y, D1), D is D1 + 1.
```

Reuses the BFS scaffold from PR #1922 but tracks depth-from-source per node. The new runtime helper `WamRuntime$transitive_distance3` maintains parallel queue + depth lists during BFS and yields `(target, distance)` pairs through a new `kernel_pair_iter` that mirrors `kernel_stream_iter`'s iter-CP shape with two unify slots per result.

`emit_kernel` grows a clause for `transitive_distance3` that wires the 3-arg call into the helper; the result lands in the `lowered_dispatch` tier alongside `transitive_closure2` so internal `Call`/`Execute` instructions hit the kernel just like top-level R-API invocations.

## Test plan

- [x] `kernel_td3_e2e_rscript` (new): direct hit at depth 1, multi-hop reach with correct depth (depth 2, 3), branch traversal, wrong-distance failure (`tdist(a, c, 1)`), no-path failure, and `findall` over the full reachable set with depths.
- [x] Full suite: 48 tests pass.

## Where the kernel landscape stands now

| Kind | Status |
|---|---|
| `transitive_closure2` | Landed in #1922 |
| `transitive_distance3` | This PR |
| `category_ancestor` | Not yet (uses `\+ member` + `max_depth`) |
| `weighted_shortest_path3` | Not yet (Dijkstra) |
| `transitive_parent_distance4` | Not yet |
| `astar_shortest_path4` | Not yet (A*) |
| `transitive_step_parent_distance5` | Not yet |

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_