### PR TITLE
feat(wam-clojure): lower is_list builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -316,6 +316,10 @@ clojure_direct_builtin("float/1", "1").
 clojure_direct_builtin("float/1", 1).
 clojure_direct_builtin('float/1', "1").
 clojure_direct_builtin('float/1', 1).
+clojure_direct_builtin("is_list/1", "1").
+clojure_direct_builtin("is_list/1", 1).
+clojure_direct_builtin('is_list/1', "1").
+clojure_direct_builtin('is_list/1', 1).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
@@ -450,6 +454,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "fail/0" ; Op == 'fail/0'),
     !,
     format(atom(Expr), '(runtime/backtrack ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "is_list/1" ; Op == 'is_list/1'),
+    !,
+    format(atom(Expr),
+           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (runtime/proper-list-term? ~w value) (runtime/advance ~w) (runtime/backtrack ~w)))',
+           [S, S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     clojure_unary_guard_test(Op, TestExpr),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -373,6 +373,22 @@
 (defn list-functor-term [ctx]
   (normalize-literal-atom ctx "[|]/2"))
 
+(defn proper-list-term? [state value]
+  (let [bindings (:bindings state)
+        empty-list (normalize-literal-atom (:intern-context state) "[]")
+        list-functor (list-functor-term (:intern-context state))]
+    (loop [cur (deref-value bindings value)
+           seen #{}]
+      (cond
+        (interned-equal? cur empty-list) true
+        (or (= cur ::unbound) (logic-var? cur)) false
+        (contains? seen cur) false
+        (and (structure-term? cur)
+             (interned-equal? (:functor cur) list-functor)
+             (= 2 (count (:args cur))))
+        (recur (deref-value bindings (second (:args cur))) (conj seen cur))
+        :else false))))
+
 (defn normalize-term* [ctx term]
   (cond
     (atom-term? term) [ctx term]
@@ -865,6 +881,13 @@
           (let [value (deref-value (:bindings state)
                                    (or (reg-get-raw state "A1") ::unbound))]
             (if (float? value)
+              (advance state)
+              (backtrack state)))
+
+          "is_list/1"
+          (let [value (deref-value (:bindings state)
+                                   (or (reg-get-raw state "A1") ::unbound))]
+            (if (proper-list-term? state value)
               (advance state)
               (backtrack state)))
 

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -117,6 +117,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, '"compound/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"callable/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"float/1"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"is_list/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-bindings [state bindings]')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -345,6 +345,28 @@ test(terminal_execute_float_is_direct_lowered_as_succeeding_builtin) :-
         assertion(\+ has(Code, ":pc target-pc"))
     )).
 
+test(simple_builtin_is_list_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_is_list/1:\nbuiltin_call is_list/1, 1\nproceed\n",
+        wam_clojure_lowerable(test_is_list/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_is_list/1, WamCode, [], Code),
+        has(Code, "runtime/deref-value"),
+        has(Code, "runtime/proper-list-term?"),
+        has(Code, "runtime/advance"),
+        has(Code, "runtime/backtrack")
+    )).
+
+test(terminal_execute_is_list_is_direct_lowered_as_succeeding_builtin) :-
+    once((
+        WamCode = "test_execute_is_list/1:\nallocate\ndeallocate\nexecute is_list/1\n",
+        wam_clojure_lowerable(test_execute_is_list/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_execute_is_list/1, WamCode, [], Code),
+        has(Code, "runtime/proper-list-term?"),
+        has(Code, "runtime/succeed-state next-state"),
+        assertion(\+ has(Code, "\"is_list/1\"")),
+        assertion(\+ has(Code, ":pc target-pc"))
+    )).
+
 test(env_framed_equality_reaches_direct_builtin_prefix) :-
     once((
         WamCode = "test_env_eq/2:\nallocate\nput_value X1, A1\nput_value X2, A2\nbuiltin_call =/2, 2\ndeallocate\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -53,6 +53,8 @@
 :- dynamic user:wam_callable_unbound/1.
 :- dynamic user:wam_float_guard/1.
 :- dynamic user:wam_float_unbound/1.
+:- dynamic user:wam_is_list_guard/1.
+:- dynamic user:wam_is_list_unbound/1.
 
 has(Code, Substr) :-
     once(sub_string(Code, _, _, _, Substr)).
@@ -108,6 +110,8 @@ user:wam_callable_guard(X) :- callable(X).
 user:wam_callable_unbound(_) :- user:wam_unbound_arg(Y), callable(Y).
 user:wam_float_guard(X) :- float(X).
 user:wam_float_unbound(_) :- user:wam_unbound_arg(Y), float(Y).
+user:wam_is_list_guard(X) :- is_list(X).
+user:wam_is_list_unbound(_) :- user:wam_unbound_arg(Y), is_list(Y).
 
 :- initialization(main, main).
 
@@ -167,7 +171,9 @@ run_smoke :-
           user:wam_callable_guard/1,
           user:wam_callable_unbound/1,
           user:wam_float_guard/1,
-          user:wam_float_unbound/1
+          user:wam_float_unbound/1,
+          user:wam_is_list_guard/1,
+          user:wam_is_list_unbound/1
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
@@ -195,6 +201,7 @@ run_smoke :-
     assert_lowered_compound_builtin_emitted(TmpDir),
     assert_lowered_callable_builtin_emitted(TmpDir),
     assert_lowered_float_builtin_emitted(TmpDir),
+    assert_lowered_is_list_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
@@ -284,6 +291,12 @@ run_smoke :-
     verify_output(TmpDir, 'wam_float_guard/1', a, "false"),
     verify_output(TmpDir, 'wam_float_guard/1', 'f(a)', "false"),
     verify_output(TmpDir, 'wam_float_unbound/1', a, "false"),
+    verify_output(TmpDir, 'wam_is_list_guard/1', '[]', "true"),
+    verify_output(TmpDir, 'wam_is_list_guard/1', '[a,b]', "true"),
+    verify_output(TmpDir, 'wam_is_list_guard/1', '[a|b]', "false"),
+    verify_output(TmpDir, 'wam_is_list_guard/1', a, "false"),
+    verify_output(TmpDir, 'wam_is_list_guard/1', 'f(a)', "false"),
+    verify_output(TmpDir, 'wam_is_list_unbound/1', a, "false"),
     delete_directory_and_contents(TmpDir),
     writeln('wam_clojure_runtime_smoke: ok').
 
@@ -407,6 +420,13 @@ assert_lowered_float_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-float-unbound-1"),
     has(CoreCode, "float? value").
 
+assert_lowered_is_list_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-is-list-guard-1"),
+    has(CoreCode, "defn lowered-wam-is-list-unbound-1"),
+    has(CoreCode, "runtime/proper-list-term?").
+
 assert_multiclause_wrappers_runtime_mediated(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
@@ -460,6 +480,7 @@ prolog_term_string_to_edn(b, "\"b\"") :- !.
 prolog_term_string_to_edn(c, "\"c\"") :- !.
 prolog_term_string_to_edn(d, "\"d\"") :- !.
 prolog_term_string_to_edn(z, "\"z\"") :- !.
+prolog_term_string_to_edn('[]', "\"[]\"") :- !.
 prolog_term_string_to_edn(3.5, "3.5") :- !.
 prolog_term_string_to_edn(42, "42") :- !.
 prolog_term_string_to_edn("a", "\"a\"") :- !.
@@ -471,6 +492,7 @@ prolog_term_string_to_edn('f(a)', "{:tag :struct :functor \"f/1\" :args [\"a\"]}
 prolog_term_string_to_edn('f(b)', "{:tag :struct :functor \"f/1\" :args [\"b\"]}") :- !.
 prolog_term_string_to_edn('[a,b]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
+prolog_term_string_to_edn('[a|b]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"b\"]}") :- !.
 prolog_term_string_to_edn("f(a)", "{:tag :struct :functor \"f/1\" :args [\"a\"]}") :- !.
 prolog_term_string_to_edn("f(b)", "{:tag :struct :functor \"f/1\" :args [\"b\"]}") :- !.
 prolog_term_string_to_edn("[a,b]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.


### PR DESCRIPTION
## Summary

- Adds Clojure WAM runtime support for `builtin_call is_list/1`.
- Adds direct lowered-prefix support for deterministic `is_list/1` calls.
- Reuses terminal direct-builtin lowering for compiler-emitted `execute is_list/1`.
- Adds `proper-list-term?` to recognize Clojure WAM proper-list terms by walking `[|]/2` tails to `[]`.
- Rejects improper lists, unbound variables, non-list atoms, and ordinary compound terms.
- Adds generator, lowered-emitter, and runtime smoke coverage for `[]`, `[a,b]`, `[a|b]`, atom, compound, and unbound cases.

## Why

`is_list/1` is the next natural unary guard after the existing Clojure lowered type checks. Unlike simple type guards, it needs runtime state so it can dereference tails while traversing Clojure WAM list terms. Keeping this as a direct lowered builtin avoids falling back to runtime dispatch for common list guards while preserving proper-list semantics.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
