### PR TITLE
feat(wam-r): weighted_shortest_path3 kernel (Dijkstra)

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -191,8 +191,8 @@ that bypasses the WAM stepping engine entirely. The classifier
 lives in
 [`src/unifyweaver/core/recursive_kernel_detection.pl`](../src/unifyweaver/core/recursive_kernel_detection.pl)
 and is shared with the Haskell / Rust / Elixir targets; this
-target wires up `transitive_closure2` and `transitive_distance3`
-so far. Canonical shapes:
+target wires up `transitive_closure2`, `transitive_distance3`,
+and `weighted_shortest_path3` so far. Canonical shapes:
 
 ```prolog
 % transitive_closure2 -- streams reachable nodes
@@ -202,16 +202,24 @@ ancestor(X, Y) :- parent(X, Z), ancestor(Z, Y).
 % transitive_distance3 -- streams (target, distance-from-source)
 tdist(X, Y, 1) :- edge(X, Y).
 tdist(X, Y, D) :- edge(X, Z), tdist(Z, Y, D1), D is D1 + 1.
+
+% weighted_shortest_path3 -- streams (target, shortest-weight)
+wsp(X, Y, W) :- edge(X, Y, W).
+wsp(X, Y, W) :- edge(X, Z, W1), wsp(Z, Y, RestW), W is RestW + W1.
 ```
 
-The runtime helpers (`WamRuntime$transitive_closure2`,
-`WamRuntime$transitive_distance3`) BFS from a ground source over
-the underlying edge predicate (invoked via `iterate_goal`, so the
-edges can be a fact-table, a dynamic store, a WAM-compiled
-predicate, or any other registered dispatch path) and stream
-results via iter-CPs. Source must be ground; target may be ground
-(check) or unground (enumerate); for the distance variant, the
-distance arg is computed (always unground at the call).
+The runtime helpers BFS (`transitive_closure2`,
+`transitive_distance3`) or run Dijkstra (`weighted_shortest_path3`)
+from a ground source over the underlying edge predicate (invoked
+via `iterate_goal`, so the edges can be a fact-table, a dynamic
+store, a WAM-compiled predicate, or any other registered dispatch
+path) and stream results via iter-CPs. Source must be ground;
+target may be ground (check) or unground (enumerate); for the
+distance / weight variants, those args are computed (always
+unground at the call). Note that the Prolog source clauses
+enumerate *all* paths, but the native fast paths return the
+*shortest* per reachable node -- that's the labelling implied by
+the kernel name and matches the Haskell / Rust semantics.
 
 The lowered function is registered in `program$lowered_dispatch`,
 so `Call` and `Execute` instructions for kernel-detected
@@ -522,7 +530,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 48 tests covering both structural assertions on the
+and contains 49 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -564,6 +572,7 @@ Coverage map (e2e tests, by feature group):
 | `fact_table_e2e_rscript` | fact-table lowering: hash-indexed dispatch, multi-solution backtracking, atoms + integers |
 | `kernel_tc2_e2e_rscript` | recursive-kernel detection: `transitive_closure2` BFS over a fact-table edge predicate |
 | `kernel_td3_e2e_rscript` | recursive-kernel detection: `transitive_distance3` BFS-with-depth over a fact-table edge predicate |
+| `kernel_wsp3_e2e_rscript` | recursive-kernel detection: `weighted_shortest_path3` Dijkstra over a weighted fact-table edge predicate |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -847,6 +847,22 @@ emit_kernel(Pred, recursive_kernel(transitive_distance3, _, ConfigOps),
                                    source, target, dist, state$pc + 1L)
 }',
            [FuncName, Pred, EdgePred, EdgePred]).
+emit_kernel(Pred, recursive_kernel(weighted_shortest_path3, _, ConfigOps),
+            DataDecl, LoweredFunc, FuncName) :-
+    member(edge_pred(EdgePred/EdgeArity), ConfigOps),
+    EdgeArity =:= 3,
+    r_pred_name(Pred, RName),
+    format(atom(FuncName), '~w_kernel_wsp3', [RName]),
+    DataDecl = "",
+    format(string(LoweredFunc),
+'~w <- function(program, state) {
+  source <- WamRuntime$get_reg(state, 1L)
+  target <- WamRuntime$get_reg(state, 2L)
+  weight <- WamRuntime$get_reg(state, 3L)
+  WamRuntime$weighted_shortest_path3(program, state, "~w/3", "~w", "~w/3",
+                                      source, target, weight, state$pc + 1L)
+}',
+           [FuncName, Pred, EdgePred, EdgePred]).
 
 % ============================================================================
 % FACT-TABLE CLASSIFICATION + EMISSION

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -1981,7 +1981,9 @@ WamRuntime$transitive_distance3 <- function(program, state, key, edge_pred,
           assign(k, TRUE, envir = visited)
           q_nodes  <<- c(q_nodes,  list(y_v))
           q_depths <<- c(q_depths, list(next_depth))
-          reached  <<- c(reached,  list(list(node = y_v, depth = next_depth)))
+          reached  <<- c(reached,
+                         list(list(node = y_v,
+                                   second = IntTerm(next_depth))))
         }
       }
       TRUE
@@ -2015,23 +2017,151 @@ WamRuntime$transitive_distance3 <- function(program, state, key, edge_pred,
                                1L, resume_pc)
 }
 
-# Iterate a precomputed list of (node, depth) pairs, unifying each
-# pair with the (target, distance) reg pair. Same iter-CP shape as
-# kernel_stream_iter but with two unify slots per result.
+# ----------------------------------------------------------
+# Recursive-kernel: weighted_shortest_path3
+# ----------------------------------------------------------
+# Dijkstra from a ground source over a weighted edge predicate of
+# arity 3 (edge(X, Y, W)). Yields (target, total-weight) pairs --
+# the SHORTEST total weight per reachable node, not all paths.
+# Pattern detected:
+#   wsp(X, Y, W) :- edge(X, Y, W).
+#   wsp(X, Y, W) :- edge(X, Z, W1), wsp(Z, Y, RestW), W is RestW + W1.
+# Algorithm: keep a priority queue (R list sorted ascending by
+# weight via linear insert -- O(V^2) but fine for the hundreds-of-
+# nodes regime). Pop the min-weight unvisited node, mark visited,
+# yield it, then relax all outgoing edges. Source itself isn't
+# yielded unless reachable via a non-trivial path (matches the
+# "at least one edge step" semantics of the clauses above).
+WamRuntime$weighted_shortest_path3 <- function(program, state, key, edge_pred,
+                                                 edge_key, source, target,
+                                                 weight, resume_pc) {
+  table <- program$intern_table
+  src_v <- WamRuntime$deref(state, source)
+  if (is.null(src_v) || is.null(src_v$tag) || src_v$tag != "atom") {
+    return(FALSE)
+  }
+  snap_cps   <- length(state$cps)
+  snap_regs  <- as.list.environment(state$regs2)
+  snap_trail <- length(state$trail)
+  snap_pc    <- state$pc
+  snap_cp    <- state$cp
+  snap_halt  <- state$halt
+  snap_vc    <- state$var_counter
+  snap_mode  <- state$mode
+  snap_build <- state$build_stack
+
+  edge_atom_id <- WamRuntime$intern(table, edge_pred)
+  visited <- new.env(parent = emptyenv())
+  # Priority queue: list of list(weight = <num>, node = <atom>),
+  # kept sorted ascending by weight.
+  pq <- list(list(weight = 0, node = src_v))
+  reached <- list()  # list of list(node, second = pre-built term)
+
+  while (length(pq) > 0L) {
+    entry  <- pq[[1L]]
+    pq     <- pq[-1L]
+    cur    <- entry$node
+    cur_w  <- entry$weight
+    k      <- as.character(cur$id)
+    if (exists(k, envir = visited, inherits = FALSE)) next
+    assign(k, TRUE, envir = visited)
+    if (!identical(cur, src_v) || cur_w > 0) {
+      # Pre-build the weight WAM term: keep ints as IntTerm where
+      # possible so downstream `==/2` round-trips cleanly.
+      wt <- if (is.finite(cur_w) && cur_w == as.integer(cur_w) &&
+                abs(cur_w) < .Machine$integer.max) {
+              IntTerm(as.integer(cur_w))
+            } else {
+              FloatTerm(as.numeric(cur_w))
+            }
+      reached <- c(reached, list(list(node = cur, second = wt)))
+    }
+    # Relax neighbours via edge_pred(cur, Y, W).
+    y_var <- Unbound(paste0("V_wsp_y_", state$var_counter))
+    state$var_counter <- state$var_counter + 1L
+    w_var <- Unbound(paste0("V_wsp_w_", state$var_counter))
+    state$var_counter <- state$var_counter + 1L
+    edge_goal <- StructTerm(edge_atom_id, list(cur, y_var, w_var))
+    captured_w <- cur_w
+    WamRuntime$iterate_goal(program, state, edge_goal, function() {
+      y_v <- WamRuntime$deref(state, y_var)
+      w_v <- WamRuntime$deref(state, w_var)
+      if (!is.null(y_v) && !is.null(y_v$tag) && y_v$tag == "atom" &&
+          !is.null(w_v) && !is.null(w_v$tag) &&
+          (w_v$tag == "int" || w_v$tag == "float")) {
+        nk <- as.character(y_v$id)
+        if (!exists(nk, envir = visited, inherits = FALSE)) {
+          new_w <- captured_w + w_v$val
+          # Sorted insert into pq (ascending weight).
+          if (length(pq) == 0L) {
+            pq <<- list(list(weight = new_w, node = y_v))
+          } else {
+            placed <- FALSE
+            for (i in seq_along(pq)) {
+              if (pq[[i]]$weight > new_w) {
+                pq <<- append(pq, list(list(weight = new_w, node = y_v)),
+                              after = i - 1L)
+                placed <- TRUE; break
+              }
+            }
+            if (!placed) {
+              pq <<- c(pq, list(list(weight = new_w, node = y_v)))
+            }
+          }
+        }
+      }
+      TRUE
+    })
+  }
+
+  # Restore state.
+  if (length(state$cps) > snap_cps) {
+    state$cps <- state$cps[seq_len(snap_cps)]
+  }
+  e <- new.env(parent = emptyenv(), hash = TRUE)
+  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
+  state$regs2 <- e
+  if (length(state$trail) > snap_trail) {
+    to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
+    for (name in to_undo) {
+      if (exists(name, envir = state$bindings, inherits = FALSE)) {
+        rm(list = name, envir = state$bindings)
+      }
+    }
+    state$trail <- state$trail[seq_len(snap_trail)]
+  }
+  state$pc          <- snap_pc
+  state$cp          <- snap_cp
+  state$halt        <- snap_halt
+  state$var_counter <- snap_vc
+  state$mode        <- snap_mode
+  state$build_stack <- snap_build
+
+  WamRuntime$kernel_pair_iter(program, state, key, reached, target, weight,
+                               1L, resume_pc)
+}
+
+# Iterate a precomputed list of result pairs, unifying each pair
+# with the (target, second) reg pair. Each entry is
+# `list(node = <WAM term>, second = <pre-built WAM term>)` so the
+# caller controls how the second slot is constructed -- distance
+# IntTerms for transitive_distance3, weight Int/FloatTerms for
+# weighted_shortest_path3, etc. iter-CP shape mirrors
+# kernel_stream_iter with two unify slots per result.
 WamRuntime$kernel_pair_iter <- function(program, state, key, results, target,
-                                         dist, start_idx, resume_pc) {
+                                         second, start_idx, resume_pc) {
   if (start_idx > length(results)) return(FALSE)
   for (idx in seq.int(start_idx, length(results))) {
     snap_trail <- length(state$trail)
     snap_vc    <- state$var_counter
     entry <- results[[idx]]
     ok_t <- WamRuntime$unify(state, target, entry$node)
-    ok_d <- ok_t && WamRuntime$unify(state, dist, IntTerm(entry$depth))
-    if (ok_d) {
+    ok_s <- ok_t && WamRuntime$unify(state, second, entry$second)
+    if (ok_s) {
       if (idx < length(results)) {
         captured_results <- results
         captured_target  <- target
-        captured_dist    <- dist
+        captured_second  <- second
         captured_next    <- idx + 1L
         captured_resume  <- resume_pc
         captured_program <- program
@@ -2048,7 +2178,7 @@ WamRuntime$kernel_pair_iter <- function(program, state, key, results, target,
           retry       = function(state) {
             WamRuntime$kernel_pair_iter(captured_program, state, captured_key,
                                          captured_results, captured_target,
-                                         captured_dist, captured_next,
+                                         captured_second, captured_next,
                                          captured_resume)
           }
         )

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2490,6 +2490,72 @@ e2e_kernel_td3_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for the weighted_shortest_path3 kernel.
+% Dijkstra over a weighted edge predicate of arity 3 -- yields
+% (target, total-weight) for the SHORTEST path per reachable node,
+% not all paths. Tests cover:
+%   * shorter detour beating a single direct heavy edge,
+%   * multi-hop sum,
+%   * wrong-distance failure (heavy direct edge),
+%   * findall over the reachable set with shortest weights.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(kernel_wsp3_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_kernel_wsp3_via_rscript
+    ;   true
+    )).
+
+e2e_kernel_wsp3_via_rscript :-
+    retractall(user:wedge(_, _, _)),
+    retractall(user:wsp(_, _, _)),
+    % a -1-> b -2-> c -3-> d, plus a heavy direct a-5->c.
+    assertz(user:wedge(a, b, 1)),
+    assertz(user:wedge(b, c, 2)),
+    assertz(user:wedge(c, d, 3)),
+    assertz(user:wedge(a, c, 5)),
+    assertz((user:wsp(X, Y, W) :- user:wedge(X, Y, W))),
+    assertz((user:wsp(X, Y, W) :- user:wedge(X, Z, W1),
+                                   user:wsp(Z, Y, W2),
+                                   W is W1 + W2)),
+    assertz((user:wsp_direct  :- wsp(a, b, 1))),
+    assertz((user:wsp_shorter :- wsp(a, c, 3))),       % via b, not 5
+    assertz((user:wsp_threehop :- wsp(a, d, 6))),
+    assertz((user:wsp_no_heavy :- wsp(a, c, 5))),      % wrong weight
+    assertz((user:wsp_no_back  :- wsp(d, a, _))),
+    assertz((user:wsp_findall :-
+        findall(Y-W, wsp(a, Y, W), L),
+        msort(L, S),
+        S == [b-1, c-3, d-6])),
+    unique_r_tmp_dir('tmp_r_kernel_wsp3_e2e', TmpDir),
+    write_wam_r_project(
+        [user:wedge/3, user:wsp/3,
+         user:wsp_direct/0, user:wsp_shorter/0, user:wsp_threehop/0,
+         user:wsp_no_heavy/0, user:wsp_no_back/0, user:wsp_findall/0],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [wsp_direct, wsp_shorter, wsp_threehop, wsp_findall],
+    No  = [wsp_no_heavy, wsp_no_back],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    directory_file_path(TmpDir, 'R/generated_program.R', ProgPath),
+    read_file_to_string(ProgPath, Code, []),
+    assertion(sub_string(Code, _, _, _, 'pred_wsp_kernel_wsp3 <- function(')),
+    assertion(sub_string(Code, _, _, _,
+        'assign("wsp/3", pred_wsp_kernel_wsp3, envir = shared_program$lowered_dispatch)')),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
## Summary

Third of the seven kernels from the shared `recursive_kernel_detection.pl` classifier. Pattern:

```prolog
wsp(X, Y, W) :- edge(X, Y, W).
wsp(X, Y, W) :- edge(X, Z, W1), wsp(Z, Y, RestW), W is RestW + W1.
```

Different algorithmic shape from the BFS-based `tc2` / `td3` kernels: the Prolog source enumerates all paths but the native fast path runs Dijkstra and yields the **shortest** total weight per reachable node, matching the kernel's labelling and the Haskell / Rust semantics.

## Implementation

`WamRuntime$weighted_shortest_path3`:

- Priority queue is an R list kept sorted ascending by weight via a linear insert. O(V²) but fine for the hundreds-of-nodes regime; replacing it with a binary-heap structure is a follow-up if a workload demands it.
- Edge enumeration drives via `iterate_goal` -- same as tc2 / td3 -- so the underlying weighted edge predicate can be a fact-table, dynamic store, WAM-compiled, etc.
- Pre-builds an `Int`/`FloatTerm` per yield so the `==/2` round-trip in user code compares cleanly without re-coercion.

`kernel_pair_iter` is generalised: each entry now carries a pre-built `second` WAM term instead of a raw integer depth, so `transitive_distance3` (IntTerm depth) and `weighted_shortest_path3` (Int/Float weight) share one iter helper. The change is mechanical for td3.

## Kernel landscape after this PR (3/7)

| Kind | Status |
|---|---|
| `transitive_closure2` | #1922 |
| `transitive_distance3` | #1923 |
| `weighted_shortest_path3` | **this PR** |
| `category_ancestor` | pending |
| `transitive_parent_distance4` | pending |
| `astar_shortest_path4` | pending |
| `transitive_step_parent_distance5` | pending |

## Test plan

- [x] `kernel_wsp3_e2e_rscript` (new): direct hit, shorter-detour-beats-heavy-direct (`a→b→c=3` vs `a→c=5`), three-hop sum (`a→b→c→d=6`), wrong-weight failure, no-path failure, `findall` over the reachable set with shortest weights.
- [x] Full suite: 49 tests pass.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_