### PR TITLE
feat(wam-r): transitive_parent_distance4 kernel (BFS + parent)

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -192,7 +192,8 @@ lives in
 [`src/unifyweaver/core/recursive_kernel_detection.pl`](../src/unifyweaver/core/recursive_kernel_detection.pl)
 and is shared with the Haskell / Rust / Elixir targets; this
 target wires up `transitive_closure2`, `transitive_distance3`,
-and `weighted_shortest_path3` so far. Canonical shapes:
+`weighted_shortest_path3`, and `transitive_parent_distance4` so
+far. Canonical shapes:
 
 ```prolog
 % transitive_closure2 -- streams reachable nodes
@@ -206,6 +207,10 @@ tdist(X, Y, D) :- edge(X, Z), tdist(Z, Y, D1), D is D1 + 1.
 % weighted_shortest_path3 -- streams (target, shortest-weight)
 wsp(X, Y, W) :- edge(X, Y, W).
 wsp(X, Y, W) :- edge(X, Z, W1), wsp(Z, Y, RestW), W is RestW + W1.
+
+% transitive_parent_distance4 -- streams (target, parent, distance)
+pd(X, Y, X, 1) :- edge(X, Y).
+pd(X, Y, P, D) :- edge(X, Z), pd(Z, Y, P, D1), D is D1 + 1.
 ```
 
 The runtime helpers BFS (`transitive_closure2`,
@@ -530,7 +535,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 49 tests covering both structural assertions on the
+and contains 50 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -573,6 +578,7 @@ Coverage map (e2e tests, by feature group):
 | `kernel_tc2_e2e_rscript` | recursive-kernel detection: `transitive_closure2` BFS over a fact-table edge predicate |
 | `kernel_td3_e2e_rscript` | recursive-kernel detection: `transitive_distance3` BFS-with-depth over a fact-table edge predicate |
 | `kernel_wsp3_e2e_rscript` | recursive-kernel detection: `weighted_shortest_path3` Dijkstra over a weighted fact-table edge predicate |
+| `kernel_tpd4_e2e_rscript` | recursive-kernel detection: `transitive_parent_distance4` BFS with parent tracking |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -863,6 +863,24 @@ emit_kernel(Pred, recursive_kernel(weighted_shortest_path3, _, ConfigOps),
                                       source, target, weight, state$pc + 1L)
 }',
            [FuncName, Pred, EdgePred, EdgePred]).
+emit_kernel(Pred, recursive_kernel(transitive_parent_distance4, _, ConfigOps),
+            DataDecl, LoweredFunc, FuncName) :-
+    member(edge_pred(EdgePred/EdgeArity), ConfigOps),
+    EdgeArity =:= 2,
+    r_pred_name(Pred, RName),
+    format(atom(FuncName), '~w_kernel_tpd4', [RName]),
+    DataDecl = "",
+    format(string(LoweredFunc),
+'~w <- function(program, state) {
+  source <- WamRuntime$get_reg(state, 1L)
+  target <- WamRuntime$get_reg(state, 2L)
+  parent <- WamRuntime$get_reg(state, 3L)
+  dist   <- WamRuntime$get_reg(state, 4L)
+  WamRuntime$transitive_parent_distance4(program, state, "~w/4", "~w", "~w/2",
+                                          source, target, parent, dist,
+                                          state$pc + 1L)
+}',
+           [FuncName, Pred, EdgePred, EdgePred]).
 
 % ============================================================================
 % FACT-TABLE CLASSIFICATION + EMISSION

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -2141,6 +2141,104 @@ WamRuntime$weighted_shortest_path3 <- function(program, state, key, edge_pred,
                                1L, resume_pc)
 }
 
+# ----------------------------------------------------------
+# Recursive-kernel: transitive_parent_distance4
+# ----------------------------------------------------------
+# BFS variant that tracks the immediate predecessor of each node
+# in the search tree, yielding (target, parent, distance) triples.
+# Pattern detected:
+#   pd(X, Y, X, 1) :- edge(X, Y).
+#   pd(X, Y, P, D) :- edge(X, Z), pd(Z, Y, P, D1), D is D1 + 1.
+# The `parent` slot is the node that immediately preceded `target`
+# in the BFS path from `source` (i.e. for direct neighbours it's
+# `source` itself; for two-hop reach it's the intermediate node).
+# Source itself is *not* yielded -- the recursion always takes at
+# least one edge step.
+WamRuntime$transitive_parent_distance4 <- function(program, state, key,
+                                                     edge_pred, edge_key,
+                                                     source, target, parent,
+                                                     dist, resume_pc) {
+  table <- program$intern_table
+  src_v <- WamRuntime$deref(state, source)
+  if (is.null(src_v) || is.null(src_v$tag) || src_v$tag != "atom") {
+    return(FALSE)
+  }
+  snap_cps   <- length(state$cps)
+  snap_regs  <- as.list.environment(state$regs2)
+  snap_trail <- length(state$trail)
+  snap_pc    <- state$pc
+  snap_cp    <- state$cp
+  snap_halt  <- state$halt
+  snap_vc    <- state$var_counter
+  snap_mode  <- state$mode
+  snap_build <- state$build_stack
+
+  edge_atom_id <- WamRuntime$intern(table, edge_pred)
+  visited <- new.env(parent = emptyenv())
+  # Parallel queues: nodes, parents (immediate predecessor), depth.
+  q_nodes   <- list(src_v)
+  q_parents <- list(NULL)   # source has no parent in the BFS tree
+  q_depths  <- list(0L)
+  reached   <- list()       # (node, parent, distance) triples
+  assign(as.character(src_v$id), TRUE, envir = visited)
+
+  while (length(q_nodes) > 0L) {
+    cur     <- q_nodes[[1L]]
+    cur_par <- q_parents[[1L]]
+    depth   <- q_depths[[1L]]
+    q_nodes   <- q_nodes[-1L]
+    q_parents <- q_parents[-1L]
+    q_depths  <- q_depths[-1L]
+    next_depth <- depth + 1L
+    captured_cur <- cur
+    y_var <- Unbound(paste0("V_pd_", state$var_counter))
+    state$var_counter <- state$var_counter + 1L
+    edge_goal <- StructTerm(edge_atom_id, list(cur, y_var))
+    WamRuntime$iterate_goal(program, state, edge_goal, function() {
+      y_v <- WamRuntime$deref(state, y_var)
+      if (!is.null(y_v) && !is.null(y_v$tag) && y_v$tag == "atom") {
+        k <- as.character(y_v$id)
+        if (!exists(k, envir = visited, inherits = FALSE)) {
+          assign(k, TRUE, envir = visited)
+          q_nodes   <<- c(q_nodes,   list(y_v))
+          q_parents <<- c(q_parents, list(captured_cur))
+          q_depths  <<- c(q_depths,  list(next_depth))
+          reached   <<- c(reached,
+                          list(list(node   = y_v,
+                                    second = captured_cur,
+                                    third  = IntTerm(next_depth))))
+        }
+      }
+      TRUE
+    })
+  }
+
+  if (length(state$cps) > snap_cps) {
+    state$cps <- state$cps[seq_len(snap_cps)]
+  }
+  e <- new.env(parent = emptyenv(), hash = TRUE)
+  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
+  state$regs2 <- e
+  if (length(state$trail) > snap_trail) {
+    to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
+    for (name in to_undo) {
+      if (exists(name, envir = state$bindings, inherits = FALSE)) {
+        rm(list = name, envir = state$bindings)
+      }
+    }
+    state$trail <- state$trail[seq_len(snap_trail)]
+  }
+  state$pc          <- snap_pc
+  state$cp          <- snap_cp
+  state$halt        <- snap_halt
+  state$var_counter <- snap_vc
+  state$mode        <- snap_mode
+  state$build_stack <- snap_build
+
+  WamRuntime$kernel_triple_iter(program, state, key, reached, target,
+                                  parent, dist, 1L, resume_pc)
+}
+
 # Iterate a precomputed list of result pairs, unifying each pair
 # with the (target, second) reg pair. Each entry is
 # `list(node = <WAM term>, second = <pre-built WAM term>)` so the
@@ -2180,6 +2278,59 @@ WamRuntime$kernel_pair_iter <- function(program, state, key, results, target,
                                          captured_results, captured_target,
                                          captured_second, captured_next,
                                          captured_resume)
+          }
+        )
+        state$cps <- c(state$cps, list(cp))
+      }
+      return(TRUE)
+    }
+    WamRuntime$undo_trail_to(state, snap_trail)
+    state$var_counter <- snap_vc
+  }
+  FALSE
+}
+
+# Iterate a precomputed list of 3-tuple results, unifying each
+# entry with the (target, second, third) reg triple. Each entry is
+# `list(node, second, third)` where `second` and `third` are pre-
+# built WAM terms. Used by transitive_parent_distance4 (target,
+# parent, distance) and other 4-arg kernels.
+WamRuntime$kernel_triple_iter <- function(program, state, key, results, target,
+                                            second, third, start_idx,
+                                            resume_pc) {
+  if (start_idx > length(results)) return(FALSE)
+  for (idx in seq.int(start_idx, length(results))) {
+    snap_trail <- length(state$trail)
+    snap_vc    <- state$var_counter
+    entry <- results[[idx]]
+    ok_t <- WamRuntime$unify(state, target, entry$node)
+    ok_s <- ok_t && WamRuntime$unify(state, second, entry$second)
+    ok_h <- ok_s && WamRuntime$unify(state, third,  entry$third)
+    if (ok_h) {
+      if (idx < length(results)) {
+        captured_results <- results
+        captured_target  <- target
+        captured_second  <- second
+        captured_third   <- third
+        captured_next    <- idx + 1L
+        captured_resume  <- resume_pc
+        captured_program <- program
+        captured_key     <- key
+        cp <- list(
+          kind        = "iter",
+          regs        = as.list.environment(state$regs2),
+          trail_len   = snap_trail,
+          cp          = state$cp,
+          var_counter = snap_vc,
+          mode        = state$mode,
+          build_stack = state$build_stack,
+          resume_pc   = resume_pc,
+          retry       = function(state) {
+            WamRuntime$kernel_triple_iter(captured_program, state,
+                                            captured_key, captured_results,
+                                            captured_target, captured_second,
+                                            captured_third, captured_next,
+                                            captured_resume)
           }
         )
         state$cps <- c(state$cps, list(cp))

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2556,6 +2556,76 @@ e2e_kernel_wsp3_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for the transitive_parent_distance4
+% kernel. BFS that tracks the immediate predecessor of each
+% reachable node alongside its distance, yielding (target, parent,
+% distance) triples. Direct/multi-hop checks, branch traversal,
+% wrong-parent failure, and a findall over the reachable set
+% (using a struct template t(Y,P,D) since the WAM compiler doesn't
+% accept pair templates like Y-P-D).
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(kernel_tpd4_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_kernel_tpd4_via_rscript
+    ;   true
+    )).
+
+e2e_kernel_tpd4_via_rscript :-
+    retractall(user:pedge(_, _)),
+    retractall(user:pd(_, _, _, _)),
+    % a -> b -> c -> d, plus branch a -> e -> f.
+    assertz(user:pedge(a, b)),
+    assertz(user:pedge(b, c)),
+    assertz(user:pedge(c, d)),
+    assertz(user:pedge(a, e)),
+    assertz(user:pedge(e, f)),
+    assertz((user:pd(X, Y, X, 1) :- user:pedge(X, Y))),
+    assertz((user:pd(X, Y, P, D) :- user:pedge(X, Z),
+                                     user:pd(Z, Y, P, D1),
+                                     D is D1 + 1)),
+    assertz((user:tpd_direct  :- pd(a, b, a, 1))),
+    assertz((user:tpd_two     :- pd(a, c, b, 2))),
+    assertz((user:tpd_three   :- pd(a, d, c, 3))),
+    assertz((user:tpd_branch  :- pd(a, e, a, 1))),
+    assertz((user:tpd_branch2 :- pd(a, f, e, 2))),
+    assertz((user:tpd_wrong   :- pd(a, c, a, 2))),
+    assertz((user:tpd_no_back :- pd(b, a, _, _))),
+    assertz((user:tpd_findall :-
+        findall(t(Y, P, D), pd(a, Y, P, D), L),
+        msort(L, S),
+        S == [t(b, a, 1), t(c, b, 2), t(d, c, 3), t(e, a, 1), t(f, e, 2)])),
+    unique_r_tmp_dir('tmp_r_kernel_tpd4_e2e', TmpDir),
+    write_wam_r_project(
+        [user:pedge/2, user:pd/4,
+         user:tpd_direct/0, user:tpd_two/0, user:tpd_three/0,
+         user:tpd_branch/0, user:tpd_branch2/0,
+         user:tpd_wrong/0, user:tpd_no_back/0, user:tpd_findall/0],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [tpd_direct, tpd_two, tpd_three, tpd_branch, tpd_branch2,
+           tpd_findall],
+    No  = [tpd_wrong, tpd_no_back],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    directory_file_path(TmpDir, 'R/generated_program.R', ProgPath),
+    read_file_to_string(ProgPath, Code, []),
+    assertion(sub_string(Code, _, _, _, 'pred_pd_kernel_tpd4 <- function(')),
+    assertion(sub_string(Code, _, _, _,
+        'assign("pd/4", pred_pd_kernel_tpd4, envir = shared_program$lowered_dispatch)')),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
## Summary

Fourth of the seven kernels from the shared `recursive_kernel_detection.pl` classifier. Pattern:

```prolog
pd(X, Y, X, 1) :- edge(X, Y).
pd(X, Y, P, D) :- edge(X, Z), pd(Z, Y, P, D1), D is D1 + 1.
```

BFS from a ground source over a 2-arg edge predicate, tracking both the search depth and the immediate predecessor of each reachable node, yielding `(target, parent, distance)` triples. The parent is the node **just before** target in the BFS path from source -- so for direct neighbours it's `source` itself; for two-hop reach it's the intermediate node. Useful for path reconstruction.

## Implementation

`WamRuntime$transitive_parent_distance4`:

- Parallel queues (nodes, parents, depths) drive the BFS.
- `captured_cur` (the current frontier node) becomes the parent for any newly-enqueued neighbour.
- Edge enumeration via `iterate_goal` -- same as the other BFS kernels -- so the underlying edge predicate can be a fact-table, dynamic store, WAM-compiled, etc.

New `kernel_triple_iter` helper for 3-tuple results, mirroring `kernel_pair_iter` but with three unify slots. Used here for tpd4; likely picked up by `transitive_step_parent_distance5` (when that lands) for its first three slots.

## Note for tests

SWI's WAM compiler doesn't accept `-/2`-style chained pair templates in `findall` (`Y-P-D`), so the e2e test uses a struct template `t(Y, P, D)` instead. This is independent of the kernel itself -- the kernel emits standard `(target, parent, distance)` regs that any aggregate can consume.

## Kernel landscape after this PR (4/7)

| Kind | Status |
|---|---|
| `transitive_closure2` | #1922 |
| `transitive_distance3` | #1923 |
| `weighted_shortest_path3` | #1925 |
| `transitive_parent_distance4` | **this PR** |
| `category_ancestor` | pending |
| `astar_shortest_path4` | pending |
| `transitive_step_parent_distance5` | pending |

## Test plan

- [x] `kernel_tpd4_e2e_rscript` (new): direct hit at depth 1 (parent = source), two-hop with parent = intermediate, three-hop chain, branch traversal, wrong-parent failure, no-path failure, findall over the reachable triples.
- [x] Full suite: 50 tests pass.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_