### PR TITLE
feat(wam-r): transitive_step_parent_distance5 kernel (BFS + step + parent)

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -192,8 +192,8 @@ lives in
 [`src/unifyweaver/core/recursive_kernel_detection.pl`](../src/unifyweaver/core/recursive_kernel_detection.pl)
 and is shared with the Haskell / Rust / Elixir targets; this
 target wires up `transitive_closure2`, `transitive_distance3`,
-`weighted_shortest_path3`, and `transitive_parent_distance4` so
-far. Canonical shapes:
+`weighted_shortest_path3`, `transitive_parent_distance4`, and
+`transitive_step_parent_distance5` so far. Canonical shapes:
 
 ```prolog
 % transitive_closure2 -- streams reachable nodes
@@ -211,6 +211,11 @@ wsp(X, Y, W) :- edge(X, Z, W1), wsp(Z, Y, RestW), W is RestW + W1.
 % transitive_parent_distance4 -- streams (target, parent, distance)
 pd(X, Y, X, 1) :- edge(X, Y).
 pd(X, Y, P, D) :- edge(X, Z), pd(Z, Y, P, D1), D is D1 + 1.
+
+% transitive_step_parent_distance5 -- streams (target, step, parent, distance)
+% step is the FIRST hop neighbour of source on the path X -> ... -> Y.
+tspd(X, Y, Y, X, 1) :- edge(X, Y).
+tspd(X, Y, M, P, D) :- edge(X, M), tspd(M, Y, _, P, D1), D is D1 + 1.
 ```
 
 The runtime helpers BFS (`transitive_closure2`,
@@ -535,7 +540,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 50 tests covering both structural assertions on the
+and contains 51 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -579,6 +584,7 @@ Coverage map (e2e tests, by feature group):
 | `kernel_td3_e2e_rscript` | recursive-kernel detection: `transitive_distance3` BFS-with-depth over a fact-table edge predicate |
 | `kernel_wsp3_e2e_rscript` | recursive-kernel detection: `weighted_shortest_path3` Dijkstra over a weighted fact-table edge predicate |
 | `kernel_tpd4_e2e_rscript` | recursive-kernel detection: `transitive_parent_distance4` BFS with parent tracking |
+| `kernel_tspd5_e2e_rscript` | recursive-kernel detection: `transitive_step_parent_distance5` BFS with step + parent + distance |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -881,6 +881,25 @@ emit_kernel(Pred, recursive_kernel(transitive_parent_distance4, _, ConfigOps),
                                           state$pc + 1L)
 }',
            [FuncName, Pred, EdgePred, EdgePred]).
+emit_kernel(Pred, recursive_kernel(transitive_step_parent_distance5, _, ConfigOps),
+            DataDecl, LoweredFunc, FuncName) :-
+    member(edge_pred(EdgePred/EdgeArity), ConfigOps),
+    EdgeArity =:= 2,
+    r_pred_name(Pred, RName),
+    format(atom(FuncName), '~w_kernel_tspd5', [RName]),
+    DataDecl = "",
+    format(string(LoweredFunc),
+'~w <- function(program, state) {
+  source <- WamRuntime$get_reg(state, 1L)
+  target <- WamRuntime$get_reg(state, 2L)
+  step   <- WamRuntime$get_reg(state, 3L)
+  parent <- WamRuntime$get_reg(state, 4L)
+  dist   <- WamRuntime$get_reg(state, 5L)
+  WamRuntime$transitive_step_parent_distance5(program, state, "~w/5", "~w", "~w/2",
+                                                source, target, step, parent,
+                                                dist, state$pc + 1L)
+}',
+           [FuncName, Pred, EdgePred, EdgePred]).
 
 % ============================================================================
 % FACT-TABLE CLASSIFICATION + EMISSION

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -2239,6 +2239,115 @@ WamRuntime$transitive_parent_distance4 <- function(program, state, key,
                                   parent, dist, 1L, resume_pc)
 }
 
+# ----------------------------------------------------------
+# Recursive-kernel: transitive_step_parent_distance5
+# ----------------------------------------------------------
+# BFS that records, for each reachable node Y from source X:
+#   * step:   the FIRST hop neighbour of source on the path X -> ... -> Y
+#             (the immediate next node after source)
+#   * parent: the immediate predecessor of Y in the path
+#   * dist:   path length
+# Pattern detected:
+#   tspd(X, Y, Y, X, 1) :- edge(X, Y).
+#   tspd(X, Y, S, P, D) :- edge(X, M), tspd(M, Y, _, P, D1), D is D1 + 1.
+# When BFS visits N from frontier F: if F == source, then step[N] = N
+# (this IS the first hop); else step[N] = step[F] (inherits).
+# Yields (target, step, parent, distance) quads via kernel_quad_iter.
+WamRuntime$transitive_step_parent_distance5 <- function(program, state, key,
+                                                          edge_pred, edge_key,
+                                                          source, target, step,
+                                                          parent, dist,
+                                                          resume_pc) {
+  table <- program$intern_table
+  src_v <- WamRuntime$deref(state, source)
+  if (is.null(src_v) || is.null(src_v$tag) || src_v$tag != "atom") {
+    return(FALSE)
+  }
+  snap_cps   <- length(state$cps)
+  snap_regs  <- as.list.environment(state$regs2)
+  snap_trail <- length(state$trail)
+  snap_pc    <- state$pc
+  snap_cp    <- state$cp
+  snap_halt  <- state$halt
+  snap_vc    <- state$var_counter
+  snap_mode  <- state$mode
+  snap_build <- state$build_stack
+
+  edge_atom_id <- WamRuntime$intern(table, edge_pred)
+  visited <- new.env(parent = emptyenv())
+  q_nodes   <- list(src_v)
+  q_steps   <- list(NULL)   # source has no first-hop yet
+  q_parents <- list(NULL)
+  q_depths  <- list(0L)
+  reached   <- list()
+  assign(as.character(src_v$id), TRUE, envir = visited)
+
+  while (length(q_nodes) > 0L) {
+    cur     <- q_nodes[[1L]]
+    cur_step <- q_steps[[1L]]
+    cur_par <- q_parents[[1L]]
+    depth   <- q_depths[[1L]]
+    q_nodes   <- q_nodes[-1L]
+    q_steps   <- q_steps[-1L]
+    q_parents <- q_parents[-1L]
+    q_depths  <- q_depths[-1L]
+    next_depth <- depth + 1L
+    captured_cur     <- cur
+    captured_curstep <- cur_step
+    is_source <- identical(cur, src_v)
+    y_var <- Unbound(paste0("V_tspd_", state$var_counter))
+    state$var_counter <- state$var_counter + 1L
+    edge_goal <- StructTerm(edge_atom_id, list(cur, y_var))
+    WamRuntime$iterate_goal(program, state, edge_goal, function() {
+      y_v <- WamRuntime$deref(state, y_var)
+      if (!is.null(y_v) && !is.null(y_v$tag) && y_v$tag == "atom") {
+        k <- as.character(y_v$id)
+        if (!exists(k, envir = visited, inherits = FALSE)) {
+          assign(k, TRUE, envir = visited)
+          # If we're enumerating from source, this neighbour IS the
+          # first-hop step. Otherwise inherit the frontier's step.
+          new_step <- if (is_source) y_v else captured_curstep
+          q_nodes   <<- c(q_nodes,   list(y_v))
+          q_steps   <<- c(q_steps,   list(new_step))
+          q_parents <<- c(q_parents, list(captured_cur))
+          q_depths  <<- c(q_depths,  list(next_depth))
+          reached   <<- c(reached,
+                          list(list(node   = y_v,
+                                    second = new_step,
+                                    third  = captured_cur,
+                                    fourth = IntTerm(next_depth))))
+        }
+      }
+      TRUE
+    })
+  }
+
+  if (length(state$cps) > snap_cps) {
+    state$cps <- state$cps[seq_len(snap_cps)]
+  }
+  e <- new.env(parent = emptyenv(), hash = TRUE)
+  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
+  state$regs2 <- e
+  if (length(state$trail) > snap_trail) {
+    to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
+    for (name in to_undo) {
+      if (exists(name, envir = state$bindings, inherits = FALSE)) {
+        rm(list = name, envir = state$bindings)
+      }
+    }
+    state$trail <- state$trail[seq_len(snap_trail)]
+  }
+  state$pc          <- snap_pc
+  state$cp          <- snap_cp
+  state$halt        <- snap_halt
+  state$var_counter <- snap_vc
+  state$mode        <- snap_mode
+  state$build_stack <- snap_build
+
+  WamRuntime$kernel_quad_iter(program, state, key, reached, target,
+                                step, parent, dist, 1L, resume_pc)
+}
+
 # Iterate a precomputed list of result pairs, unifying each pair
 # with the (target, second) reg pair. Each entry is
 # `list(node = <WAM term>, second = <pre-built WAM term>)` so the
@@ -2331,6 +2440,61 @@ WamRuntime$kernel_triple_iter <- function(program, state, key, results, target,
                                             captured_target, captured_second,
                                             captured_third, captured_next,
                                             captured_resume)
+          }
+        )
+        state$cps <- c(state$cps, list(cp))
+      }
+      return(TRUE)
+    }
+    WamRuntime$undo_trail_to(state, snap_trail)
+    state$var_counter <- snap_vc
+  }
+  FALSE
+}
+
+# Iterate a precomputed list of 4-tuple results, unifying each
+# entry with the (target, second, third, fourth) reg quad. Each
+# entry is `list(node, second, third, fourth)` with all four as
+# pre-built WAM terms. Used by transitive_step_parent_distance5
+# (target, step, parent, distance).
+WamRuntime$kernel_quad_iter <- function(program, state, key, results, target,
+                                          second, third, fourth, start_idx,
+                                          resume_pc) {
+  if (start_idx > length(results)) return(FALSE)
+  for (idx in seq.int(start_idx, length(results))) {
+    snap_trail <- length(state$trail)
+    snap_vc    <- state$var_counter
+    entry <- results[[idx]]
+    ok_t <- WamRuntime$unify(state, target, entry$node)
+    ok_s <- ok_t && WamRuntime$unify(state, second, entry$second)
+    ok_h <- ok_s && WamRuntime$unify(state, third,  entry$third)
+    ok_f <- ok_h && WamRuntime$unify(state, fourth, entry$fourth)
+    if (ok_f) {
+      if (idx < length(results)) {
+        captured_results <- results
+        captured_target  <- target
+        captured_second  <- second
+        captured_third   <- third
+        captured_fourth  <- fourth
+        captured_next    <- idx + 1L
+        captured_resume  <- resume_pc
+        captured_program <- program
+        captured_key     <- key
+        cp <- list(
+          kind        = "iter",
+          regs        = as.list.environment(state$regs2),
+          trail_len   = snap_trail,
+          cp          = state$cp,
+          var_counter = snap_vc,
+          mode        = state$mode,
+          build_stack = state$build_stack,
+          resume_pc   = resume_pc,
+          retry       = function(state) {
+            WamRuntime$kernel_quad_iter(captured_program, state,
+                                          captured_key, captured_results,
+                                          captured_target, captured_second,
+                                          captured_third, captured_fourth,
+                                          captured_next, captured_resume)
           }
         )
         state$cps <- c(state$cps, list(cp))

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2626,6 +2626,89 @@ e2e_kernel_tpd4_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for the transitive_step_parent_distance5
+% kernel. BFS that records, for each reachable node, the FIRST
+% hop neighbour of source on the path (step) plus immediate
+% predecessor (parent) and distance. Yields 4-tuple results via
+% kernel_quad_iter. Direct/multi-hop checks, branch traversal,
+% wrong-step / wrong-parent failures, and findall over the full
+% reachable set with all four slots.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(kernel_tspd5_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_kernel_tspd5_via_rscript
+    ;   true
+    )).
+
+e2e_kernel_tspd5_via_rscript :-
+    retractall(user:sedge(_, _)),
+    retractall(user:tspd(_, _, _, _, _)),
+    assertz(user:sedge(a, b)),
+    assertz(user:sedge(b, c)),
+    assertz(user:sedge(c, d)),
+    assertz(user:sedge(a, e)),
+    assertz(user:sedge(e, f)),
+    % Canonical tspd5 shape -- the 3rd head arg in the recursive
+    % clause IS the second arg of the edge call (not a separate
+    % variable bound later), which is what the detector requires.
+    assertz((user:tspd(X, Y, Y, X, 1) :- user:sedge(X, Y))),
+    assertz((user:tspd(X, Y, M, P, D) :-
+        user:sedge(X, M), user:tspd(M, Y, _, P, D1), D is D1 + 1)),
+    % Direct edge: step==target, parent==source, dist=1.
+    assertz((user:tspd_direct  :- tspd(a, b, b, a, 1))),
+    % Two-hop a->b->c: step=b (first hop), parent=b (predecessor of c), dist=2.
+    assertz((user:tspd_two     :- tspd(a, c, b, b, 2))),
+    % Three-hop a->b->c->d: step=b, parent=c, dist=3.
+    assertz((user:tspd_three   :- tspd(a, d, b, c, 3))),
+    % Branch a->e direct: step=e, parent=a, dist=1.
+    assertz((user:tspd_branch  :- tspd(a, e, e, a, 1))),
+    % Branch two-hop a->e->f: step=e, parent=e, dist=2.
+    assertz((user:tspd_branch2 :- tspd(a, f, e, e, 2))),
+    % Wrong step: claims step=e for c, but actual is b.
+    assertz((user:tspd_no_step :- tspd(a, c, e, b, 2))),
+    % Wrong parent.
+    assertz((user:tspd_no_par  :- tspd(a, c, b, a, 2))),
+    % No reachable.
+    assertz((user:tspd_no_back :- tspd(d, a, _, _, _))),
+    % findall over the full reachable set.
+    assertz((user:tspd_findall :-
+        findall(t(Y, S, P, D), tspd(a, Y, S, P, D), L),
+        msort(L, Sorted),
+        Sorted == [t(b, b, a, 1), t(c, b, b, 2), t(d, b, c, 3),
+                    t(e, e, a, 1), t(f, e, e, 2)])),
+    unique_r_tmp_dir('tmp_r_kernel_tspd5_e2e', TmpDir),
+    write_wam_r_project(
+        [user:sedge/2, user:tspd/5,
+         user:tspd_direct/0, user:tspd_two/0, user:tspd_three/0,
+         user:tspd_branch/0, user:tspd_branch2/0,
+         user:tspd_no_step/0, user:tspd_no_par/0, user:tspd_no_back/0,
+         user:tspd_findall/0],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [tspd_direct, tspd_two, tspd_three,
+           tspd_branch, tspd_branch2, tspd_findall],
+    No  = [tspd_no_step, tspd_no_par, tspd_no_back],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    directory_file_path(TmpDir, 'R/generated_program.R', ProgPath),
+    read_file_to_string(ProgPath, Code, []),
+    assertion(sub_string(Code, _, _, _, 'pred_tspd_kernel_tspd5 <- function(')),
+    assertion(sub_string(Code, _, _, _,
+        'assign("tspd/5", pred_tspd_kernel_tspd5, envir = shared_program$lowered_dispatch)')),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
## Summary

Fifth of the seven kernels from the shared `recursive_kernel_detection.pl` classifier. Pattern:

```prolog
tspd(X, Y, Y, X, 1) :- edge(X, Y).
tspd(X, Y, M, P, D) :- edge(X, M), tspd(M, Y, _, P, D1), D is D1 + 1.
```

BFS that records, for each reachable node Y from source X:

- **step** — the FIRST hop neighbour of source on the path to Y
- **parent** — the immediate predecessor of Y in that path
- **dist** — path length

When BFS visits N from frontier F: if F == source, then `step[N] = N` (this IS the first hop); else `step[N] = step[F]` (inherits the frontier's step). Direct extension of the tpd4 (#1928) BFS scaffold with one extra parallel queue.

## What's new

- `WamRuntime$transitive_step_parent_distance5` — the BFS helper.
- `kernel_quad_iter` — 4-tuple iter alongside the existing pair / triple iters. Pre-built second/third/fourth slots are unified per-entry; iter-CP shape mirrors the others.
- `emit_kernel` clause for tspd5.

## Detector contract note

The detector requires the recursive clause's third head arg to be **literally the same variable** as the second arg of the edge call — i.e. canonical form

```prolog
tspd(X, Y, M, P, D) :- edge(X, M), ...
```

not

```prolog
tspd(X, Y, S, P, D) :- edge(X, M), ..., S = M.
```

The e2e test uses the canonical form; a comment in the test body flags this as part of the kernel detection contract. (This isn't specific to tspd5 — every kernel detector relies on variable-aliasing in the clause head.)

## Kernel landscape after this PR (5/7)

| Kind | Status |
|---|---|
| `transitive_closure2` | #1922 |
| `transitive_distance3` | #1923 |
| `weighted_shortest_path3` | #1925 |
| `transitive_parent_distance4` | #1928 |
| `transitive_step_parent_distance5` | **this PR** |
| `category_ancestor` | pending |
| `astar_shortest_path4` | pending |

## Test plan

- [x] `kernel_tspd5_e2e_rscript` (new): direct hit, two-hop / three-hop with correct (step, parent, dist), branch traversal, wrong-step / wrong-parent / no-path failures, findall over the full reachable quadruple set.
- [x] Full suite: 51 tests pass.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_