### PR TITLE
bench(csharp-query): guard calibration sweeps by resources

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -120,6 +120,12 @@ comparison fails on output, resolved-policy, coverage, or relation-registration
 drift, while reporting best-mode and median changes as timing warnings because
 single-repetition benchmark winners can move with local noise.
 
+Add `--require-idle` for timing-sensitive calibration refreshes. It fails
+before running child benchmarks if `MemAvailable` is below
+`--min-free-memory-mib` (default `1024`) or if another process is already above
+`--max-competing-cpu-percent` (default `50.0`), preventing known-noisy timing
+rows from being captured accidentally.
+
 Use `--stability-runs <n>` to run the wrapper-level sweep repeatedly and
 summarize stable winners. Values above `1` report majority winners, winner
 counts, stable resolved `auto` modes, and per-mode median timings across the

--- a/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
+++ b/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
@@ -14,6 +14,7 @@ import argparse
 import csv
 import os
 import statistics
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -94,6 +95,13 @@ class SourceModeStabilitySummary:
     median_summary: str
 
 
+@dataclass
+class CompetingProcess:
+    pid: int
+    cpu_percent: float
+    command: str
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -157,6 +165,26 @@ def parse_args() -> argparse.Namespace:
         default=1.50,
         help="Warn when a per-mode median or auto-vs-best ratio changes by more than this ratio.",
     )
+    parser.add_argument(
+        "--require-idle",
+        action="store_true",
+        help=(
+            "Before timing-sensitive runs, fail fast if competing high-CPU processes "
+            "are active or available memory is below --min-free-memory-mib."
+        ),
+    )
+    parser.add_argument(
+        "--max-competing-cpu-percent",
+        type=float,
+        default=50.0,
+        help="CPU-percent threshold for --require-idle competing-process detection.",
+    )
+    parser.add_argument(
+        "--min-free-memory-mib",
+        type=int,
+        default=1024,
+        help="Minimum MemAvailable MiB required by --require-idle.",
+    )
     return parser.parse_args()
 
 
@@ -192,6 +220,110 @@ def filter_workload_scales(workload: str, scales: str) -> tuple[str, list[str]]:
     selected = [scale for scale in requested if scale in supported]
     skipped = [scale for scale in requested if scale not in supported]
     return ",".join(selected), skipped
+
+
+def parse_mem_available_mib(meminfo_text: str) -> int | None:
+    for line in meminfo_text.splitlines():
+        if not line.startswith("MemAvailable:"):
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            return None
+        try:
+            return int(parts[1]) // 1024
+        except ValueError:
+            return None
+    return None
+
+
+def read_mem_available_mib(meminfo_path: Path = Path("/proc/meminfo")) -> int | None:
+    try:
+        return parse_mem_available_mib(meminfo_path.read_text(encoding="utf-8"))
+    except OSError:
+        return None
+
+
+def parse_competing_processes(
+    ps_output: str,
+    *,
+    current_pid: int,
+    cpu_threshold: float,
+) -> list[CompetingProcess]:
+    processes: list[CompetingProcess] = []
+    for line in ps_output.splitlines()[1:]:
+        parts = line.strip().split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            cpu_percent = float(parts[1])
+        except ValueError:
+            continue
+        if pid == current_pid or cpu_percent < cpu_threshold:
+            continue
+        processes.append(
+            CompetingProcess(
+                pid=pid,
+                cpu_percent=cpu_percent,
+                command=parts[2],
+            )
+        )
+    return processes
+
+
+def collect_competing_processes(
+    *,
+    cpu_threshold: float,
+    current_pid: int | None = None,
+) -> list[CompetingProcess]:
+    try:
+        result = subprocess.run(
+            ["ps", "-eo", "pid=,%cpu=,args="],
+            check=True,
+            cwd=ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return []
+    header = "PID %CPU COMMAND\n"
+    return parse_competing_processes(
+        header + result.stdout,
+        current_pid=current_pid or os.getpid(),
+        cpu_threshold=cpu_threshold,
+    )
+
+
+def resource_preflight_failures(
+    *,
+    min_free_memory_mib: int,
+    max_competing_cpu_percent: float,
+    available_memory_mib: int | None = None,
+    competing_processes: list[CompetingProcess] | None = None,
+) -> list[str]:
+    failures: list[str] = []
+    memory_mib = read_mem_available_mib() if available_memory_mib is None else available_memory_mib
+    if memory_mib is None:
+        failures.append("could not determine available memory from /proc/meminfo")
+    elif memory_mib < min_free_memory_mib:
+        failures.append(
+            f"available memory {memory_mib} MiB is below required {min_free_memory_mib} MiB"
+        )
+
+    processes = (
+        collect_competing_processes(cpu_threshold=max_competing_cpu_percent)
+        if competing_processes is None
+        else competing_processes
+    )
+    for process in processes:
+        failures.append(
+            (
+                f"competing process {process.pid} uses {process.cpu_percent:.1f}% CPU "
+                f"(threshold {max_competing_cpu_percent:.1f}%): {process.command}"
+            )
+        )
+    return failures
 
 
 def load_calibration_artifact(path: Path = CALIBRATION_ARTIFACT) -> list[CalibrationArtifactRow]:
@@ -619,6 +751,15 @@ def main() -> int:
         validate_csharp_query_source_modes(args.source_modes)
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
+    if args.require_idle:
+        preflight_failures = resource_preflight_failures(
+            min_free_memory_mib=args.min_free_memory_mib,
+            max_competing_cpu_percent=args.max_competing_cpu_percent,
+        )
+        if preflight_failures:
+            for failure in preflight_failures:
+                print(f"ERROR: resource preflight: {failure}", file=sys.stderr)
+            return 1
 
     sweep_runs: list[list[SourceModeSummary]] = []
     for _ in range(args.stability_runs):

--- a/tests/test_csharp_query_source_mode_sweep.py
+++ b/tests/test_csharp_query_source_mode_sweep.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
 from benchmark_csharp_query_source_mode_sweep import (  # noqa: E402
     CALIBRATION_ARTIFACT,
     CalibrationArtifactRow,
+    CompetingProcess,
     DEFAULT_WORKLOADS,
     SourceModeSummary,
     WORKLOAD_SCRIPTS,
@@ -20,10 +21,13 @@ from benchmark_csharp_query_source_mode_sweep import (  # noqa: E402
     filter_workload_scales,
     load_calibration_artifact,
     parse_args,
+    parse_competing_processes,
+    parse_mem_available_mib,
     parse_mode_summary,
     parse_ratio,
     parse_runner_output,
     parse_workloads,
+    resource_preflight_failures,
     summarize_stability,
     supported_scales_for_workload,
 )
@@ -68,6 +72,50 @@ class CSharpQuerySourceModeSweepTests(unittest.TestCase):
         self.assertEqual(
             filter_workload_scales("shortest-path", "dev"),
             ("dev", []),
+        )
+
+    def test_parse_mem_available_mib(self) -> None:
+        self.assertEqual(
+            parse_mem_available_mib("MemTotal:       4096000 kB\nMemAvailable:   2097152 kB\n"),
+            2048,
+        )
+        self.assertIsNone(parse_mem_available_mib("MemTotal:       4096000 kB\n"))
+
+    def test_parse_competing_processes_filters_current_pid_and_threshold(self) -> None:
+        processes = parse_competing_processes(
+            "\n".join(
+                [
+                    "PID %CPU COMMAND",
+                    "100 75.0 swipl -q benchmark.pl",
+                    "101 10.0 idle-process",
+                    "102 99.0 current-python",
+                ]
+            ),
+            current_pid=102,
+            cpu_threshold=50.0,
+        )
+
+        self.assertEqual(
+            processes,
+            [CompetingProcess(pid=100, cpu_percent=75.0, command="swipl -q benchmark.pl")],
+        )
+
+    def test_resource_preflight_failures_checks_memory_and_cpu(self) -> None:
+        failures = resource_preflight_failures(
+            min_free_memory_mib=1024,
+            max_competing_cpu_percent=50.0,
+            available_memory_mib=512,
+            competing_processes=[
+                CompetingProcess(pid=100, cpu_percent=75.0, command="swipl -q benchmark.pl")
+            ],
+        )
+
+        self.assertEqual(
+            failures,
+            [
+                "available memory 512 MiB is below required 1024 MiB",
+                "competing process 100 uses 75.0% CPU (threshold 50.0%): swipl -q benchmark.pl",
+            ],
         )
 
     def test_calibration_artifact_covers_registered_graph_workloads(self) -> None:


### PR DESCRIPTION
  ## Summary

  - Adds opt-in `--require-idle` preflight checks to the C# query source-mode sweep wrapper.
  - Blocks timing-sensitive calibration runs when available memory is below `--min-free-memory-mib` (default `1024`
  MiB).
  - Blocks runs when competing processes exceed `--max-competing-cpu-percent` (default `50.0`).
  - Documents the guard for calibration refresh workflows.
  - Adds unit coverage for memory parsing, competing-process parsing, and combined resource preflight failures.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_source_mode_sweep.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_source_mode_sweep.py tests/
  test_csharp_query_source_mode_sweep.py`
  - `git diff --check`
  - Forced `--require-idle` failure smoke exited before benchmark execution.