### PR TITLE
feat(wam-clojure): lower ground builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -320,6 +320,10 @@ clojure_direct_builtin("is_list/1", "1").
 clojure_direct_builtin("is_list/1", 1).
 clojure_direct_builtin('is_list/1', "1").
 clojure_direct_builtin('is_list/1', 1).
+clojure_direct_builtin("ground/1", "1").
+clojure_direct_builtin("ground/1", 1).
+clojure_direct_builtin('ground/1', "1").
+clojure_direct_builtin('ground/1', 1).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
@@ -460,6 +464,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     !,
     format(atom(Expr),
            '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (runtime/proper-list-term? ~w value) (runtime/advance ~w) (runtime/backtrack ~w)))',
+           [S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "ground/1" ; Op == 'ground/1'),
+    !,
+    format(atom(Expr),
+           '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (runtime/ground-term? ~w value) (runtime/advance ~w) (runtime/backtrack ~w)))',
            [S, S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -389,6 +389,18 @@
         (recur (deref-value bindings (second (:args cur))) (conj seen cur))
         :else false))))
 
+(defn ground-term? [state value]
+  (let [bindings (:bindings state)]
+    (letfn [(ground* [term seen]
+              (let [cur (deref-value bindings term)]
+                (cond
+                  (or (= cur ::unbound) (logic-var? cur)) false
+                  (contains? seen cur) true
+                  (structure-term? cur)
+                  (every? #(ground* % (conj seen cur)) (:args cur))
+                  :else true)))]
+      (ground* value #{}))))
+
 (defn normalize-term* [ctx term]
   (cond
     (atom-term? term) [ctx term]
@@ -888,6 +900,13 @@
           (let [value (deref-value (:bindings state)
                                    (or (reg-get-raw state "A1") ::unbound))]
             (if (proper-list-term? state value)
+              (advance state)
+              (backtrack state)))
+
+          "ground/1"
+          (let [value (deref-value (:bindings state)
+                                   (or (reg-get-raw state "A1") ::unbound))]
+            (if (ground-term? state value)
               (advance state)
               (backtrack state)))
 

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -118,6 +118,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, '"callable/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"float/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"is_list/1"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"ground/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-bindings [state bindings]')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -367,6 +367,28 @@ test(terminal_execute_is_list_is_direct_lowered_as_succeeding_builtin) :-
         assertion(\+ has(Code, ":pc target-pc"))
     )).
 
+test(simple_builtin_ground_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_ground/1:\nbuiltin_call ground/1, 1\nproceed\n",
+        wam_clojure_lowerable(test_ground/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_ground/1, WamCode, [], Code),
+        has(Code, "runtime/deref-value"),
+        has(Code, "runtime/ground-term?"),
+        has(Code, "runtime/advance"),
+        has(Code, "runtime/backtrack")
+    )).
+
+test(terminal_execute_ground_is_direct_lowered_as_succeeding_builtin) :-
+    once((
+        WamCode = "test_execute_ground/1:\nallocate\ndeallocate\nexecute ground/1\n",
+        wam_clojure_lowerable(test_execute_ground/1, WamCode, deterministic),
+        lower_predicate_to_clojure(test_execute_ground/1, WamCode, [], Code),
+        has(Code, "runtime/ground-term?"),
+        has(Code, "runtime/succeed-state next-state"),
+        assertion(\+ has(Code, "\"ground/1\"")),
+        assertion(\+ has(Code, ":pc target-pc"))
+    )).
+
 test(env_framed_equality_reaches_direct_builtin_prefix) :-
     once((
         WamCode = "test_env_eq/2:\nallocate\nput_value X1, A1\nput_value X2, A2\nbuiltin_call =/2, 2\ndeallocate\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -55,6 +55,9 @@
 :- dynamic user:wam_float_unbound/1.
 :- dynamic user:wam_is_list_guard/1.
 :- dynamic user:wam_is_list_unbound/1.
+:- dynamic user:wam_ground_guard/1.
+:- dynamic user:wam_ground_unbound/1.
+:- dynamic user:wam_ground_nested_unbound/1.
 
 has(Code, Substr) :-
     once(sub_string(Code, _, _, _, Substr)).
@@ -112,6 +115,9 @@ user:wam_float_guard(X) :- float(X).
 user:wam_float_unbound(_) :- user:wam_unbound_arg(Y), float(Y).
 user:wam_is_list_guard(X) :- is_list(X).
 user:wam_is_list_unbound(_) :- user:wam_unbound_arg(Y), is_list(Y).
+user:wam_ground_guard(X) :- ground(X).
+user:wam_ground_unbound(_) :- user:wam_unbound_arg(Y), ground(Y).
+user:wam_ground_nested_unbound(_) :- user:wam_unbound_arg(Y), ground(f(Y)).
 
 :- initialization(main, main).
 
@@ -173,7 +179,10 @@ run_smoke :-
           user:wam_float_guard/1,
           user:wam_float_unbound/1,
           user:wam_is_list_guard/1,
-          user:wam_is_list_unbound/1
+          user:wam_is_list_unbound/1,
+          user:wam_ground_guard/1,
+          user:wam_ground_unbound/1,
+          user:wam_ground_nested_unbound/1
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
@@ -202,6 +211,7 @@ run_smoke :-
     assert_lowered_callable_builtin_emitted(TmpDir),
     assert_lowered_float_builtin_emitted(TmpDir),
     assert_lowered_is_list_builtin_emitted(TmpDir),
+    assert_lowered_ground_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
@@ -297,6 +307,13 @@ run_smoke :-
     verify_output(TmpDir, 'wam_is_list_guard/1', a, "false"),
     verify_output(TmpDir, 'wam_is_list_guard/1', 'f(a)', "false"),
     verify_output(TmpDir, 'wam_is_list_unbound/1', a, "false"),
+    verify_output(TmpDir, 'wam_ground_guard/1', a, "true"),
+    verify_output(TmpDir, 'wam_ground_guard/1', 42, "true"),
+    verify_output(TmpDir, 'wam_ground_guard/1', 3.5, "true"),
+    verify_output(TmpDir, 'wam_ground_guard/1', 'f(a)', "true"),
+    verify_output(TmpDir, 'wam_ground_guard/1', '[a,b]', "true"),
+    verify_output(TmpDir, 'wam_ground_unbound/1', a, "false"),
+    verify_output(TmpDir, 'wam_ground_nested_unbound/1', a, "false"),
     delete_directory_and_contents(TmpDir),
     writeln('wam_clojure_runtime_smoke: ok').
 
@@ -426,6 +443,14 @@ assert_lowered_is_list_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-is-list-guard-1"),
     has(CoreCode, "defn lowered-wam-is-list-unbound-1"),
     has(CoreCode, "runtime/proper-list-term?").
+
+assert_lowered_ground_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-ground-guard-1"),
+    has(CoreCode, "defn lowered-wam-ground-unbound-1"),
+    has(CoreCode, "defn lowered-wam-ground-nested-unbound-1"),
+    has(CoreCode, "runtime/ground-term?").
 
 assert_multiclause_wrappers_runtime_mediated(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM runtime support for `builtin_call ground/1`.
- Adds direct lowered-prefix support for deterministic `ground/1` calls.
- Reuses terminal direct-builtin lowering for compiler-emitted `execute ground/1`.
- Adds `ground-term?` to recursively inspect Clojure WAM terms with dereferencing and cycle safety.
- Rejects unbound variables both at the top level and inside nested structures.
- Adds generator, lowered-emitter, and runtime smoke coverage for atoms, integers, floats, compounds, lists, top-level unbound variables, and nested unbound variables.

## Why

`ground/1` is already treated as a pure builtin by the analysis layer, and Clojure now has enough lowered guard infrastructure to handle it directly. Unlike simple unary type checks, `ground/1` needs a state-aware recursive traversal so nested WAM terms can be dereferenced correctly before deciding whether a term is ground.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
