### PR TITLE
feat(wam-r): category_ancestor kernel (BFS + depth cap + visited)

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -192,8 +192,10 @@ lives in
 [`src/unifyweaver/core/recursive_kernel_detection.pl`](../src/unifyweaver/core/recursive_kernel_detection.pl)
 and is shared with the Haskell / Rust / Elixir targets; this
 target wires up `transitive_closure2`, `transitive_distance3`,
-`weighted_shortest_path3`, `transitive_parent_distance4`, and
-`transitive_step_parent_distance5` so far. Canonical shapes:
+`weighted_shortest_path3`, `transitive_parent_distance4`,
+`transitive_step_parent_distance5`, and `category_ancestor` so far
+(6/7 of the registered kernel patterns; only `astar_shortest_path4`
+remains). Canonical shapes:
 
 ```prolog
 % transitive_closure2 -- streams reachable nodes
@@ -216,6 +218,17 @@ pd(X, Y, P, D) :- edge(X, Z), pd(Z, Y, P, D1), D is D1 + 1.
 % step is the FIRST hop neighbour of source on the path X -> ... -> Y.
 tspd(X, Y, Y, X, 1) :- edge(X, Y).
 tspd(X, Y, M, P, D) :- edge(X, M), tspd(M, Y, _, P, D1), D is D1 + 1.
+
+% category_ancestor -- streams reachable ancestors with depth cap.
+% max_depth/1 must be asserted before write_wam_r_project/3 runs;
+% the detector reads it at codegen time and the cap is embedded
+% in the lowered function. Visited and Hops are inputs / discarded
+% outputs that the native impl doesn't touch.
+:- assertz(user:max_depth(3)).
+ca(Cat, Anc, Visited, 0) :- \+ member(Cat, Visited), edge(Cat, Anc).
+ca(Cat, Anc, Visited, Hops) :- \+ member(Cat, Visited),
+    edge(Cat, Mid), ca(Mid, Anc, [Cat | Visited], Hops0),
+    Hops is Hops0 + 1.
 ```
 
 The runtime helpers BFS (`transitive_closure2`,
@@ -540,7 +553,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 51 tests covering both structural assertions on the
+and contains 52 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -585,6 +598,7 @@ Coverage map (e2e tests, by feature group):
 | `kernel_wsp3_e2e_rscript` | recursive-kernel detection: `weighted_shortest_path3` Dijkstra over a weighted fact-table edge predicate |
 | `kernel_tpd4_e2e_rscript` | recursive-kernel detection: `transitive_parent_distance4` BFS with parent tracking |
 | `kernel_tspd5_e2e_rscript` | recursive-kernel detection: `transitive_step_parent_distance5` BFS with step + parent + distance |
+| `kernel_ca_e2e_rscript` | recursive-kernel detection: `category_ancestor` BFS with depth-cap + visited-set cycle detection |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -900,6 +900,24 @@ emit_kernel(Pred, recursive_kernel(transitive_step_parent_distance5, _, ConfigOp
                                                 dist, state$pc + 1L)
 }',
            [FuncName, Pred, EdgePred, EdgePred]).
+emit_kernel(Pred, recursive_kernel(category_ancestor, _, ConfigOps),
+            DataDecl, LoweredFunc, FuncName) :-
+    member(edge_pred(EdgePred/EdgeArity), ConfigOps),
+    EdgeArity =:= 2,
+    member(max_depth(MaxDepth), ConfigOps),
+    integer(MaxDepth),
+    MaxDepth > 0,
+    r_pred_name(Pred, RName),
+    format(atom(FuncName), '~w_kernel_ca', [RName]),
+    DataDecl = "",
+    format(string(LoweredFunc),
+'~w <- function(program, state) {
+  source   <- WamRuntime$get_reg(state, 1L)
+  ancestor <- WamRuntime$get_reg(state, 2L)
+  WamRuntime$category_ancestor(program, state, "~w/4", "~w", "~w/2",
+                                ~wL, source, ancestor, state$pc + 1L)
+}',
+           [FuncName, Pred, EdgePred, EdgePred, MaxDepth]).
 
 % ============================================================================
 % FACT-TABLE CLASSIFICATION + EMISSION

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -2348,6 +2348,100 @@ WamRuntime$transitive_step_parent_distance5 <- function(program, state, key,
                                 step, parent, dist, 1L, resume_pc)
 }
 
+# ----------------------------------------------------------
+# Recursive-kernel: category_ancestor
+# ----------------------------------------------------------
+# Hierarchical BFS with explicit depth cap and visited-set cycle
+# detection. Pattern detected:
+#   ca(Cat, Anc, Visited, Hops) :-
+#       \+ member(Cat, Visited),
+#       edge(Cat, Anc).
+#   ca(Cat, Anc, Visited, Hops) :-
+#       \+ member(Cat, Visited),
+#       edge(Cat, Mid),
+#       ca(Mid, Anc, [Cat | Visited], Hops0),
+#       Hops is Hops0 + 1.
+# The user provides `max_depth/1` at codegen time; the detector
+# embeds it in the kernel config so we know the cap. Result layout
+# is tuple(1) -- yield each reached ancestor; the Visited and Hops
+# slots in the user-side call are inputs / discarded outputs that
+# the native impl doesn't touch.
+WamRuntime$category_ancestor <- function(program, state, key, edge_pred,
+                                            edge_key, max_depth, source,
+                                            ancestor, resume_pc) {
+  table <- program$intern_table
+  src_v <- WamRuntime$deref(state, source)
+  if (is.null(src_v) || is.null(src_v$tag) || src_v$tag != "atom") {
+    return(FALSE)
+  }
+  snap_cps   <- length(state$cps)
+  snap_regs  <- as.list.environment(state$regs2)
+  snap_trail <- length(state$trail)
+  snap_pc    <- state$pc
+  snap_cp    <- state$cp
+  snap_halt  <- state$halt
+  snap_vc    <- state$var_counter
+  snap_mode  <- state$mode
+  snap_build <- state$build_stack
+
+  edge_atom_id <- WamRuntime$intern(table, edge_pred)
+  visited <- new.env(parent = emptyenv())
+  q_nodes  <- list(src_v)
+  q_depths <- list(0L)
+  reached  <- list()
+  assign(as.character(src_v$id), TRUE, envir = visited)
+
+  while (length(q_nodes) > 0L) {
+    cur   <- q_nodes[[1L]]
+    depth <- q_depths[[1L]]
+    q_nodes  <- q_nodes[-1L]
+    q_depths <- q_depths[-1L]
+    if (depth >= max_depth) next  # depth-cap pruning
+    next_depth <- depth + 1L
+    y_var <- Unbound(paste0("V_ca_", state$var_counter))
+    state$var_counter <- state$var_counter + 1L
+    edge_goal <- StructTerm(edge_atom_id, list(cur, y_var))
+    WamRuntime$iterate_goal(program, state, edge_goal, function() {
+      y_v <- WamRuntime$deref(state, y_var)
+      if (!is.null(y_v) && !is.null(y_v$tag) && y_v$tag == "atom") {
+        k <- as.character(y_v$id)
+        if (!exists(k, envir = visited, inherits = FALSE)) {
+          assign(k, TRUE, envir = visited)
+          q_nodes  <<- c(q_nodes,  list(y_v))
+          q_depths <<- c(q_depths, list(next_depth))
+          reached  <<- c(reached,  list(y_v))
+        }
+      }
+      TRUE
+    })
+  }
+
+  if (length(state$cps) > snap_cps) {
+    state$cps <- state$cps[seq_len(snap_cps)]
+  }
+  e <- new.env(parent = emptyenv(), hash = TRUE)
+  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
+  state$regs2 <- e
+  if (length(state$trail) > snap_trail) {
+    to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
+    for (name in to_undo) {
+      if (exists(name, envir = state$bindings, inherits = FALSE)) {
+        rm(list = name, envir = state$bindings)
+      }
+    }
+    state$trail <- state$trail[seq_len(snap_trail)]
+  }
+  state$pc          <- snap_pc
+  state$cp          <- snap_cp
+  state$halt        <- snap_halt
+  state$var_counter <- snap_vc
+  state$mode        <- snap_mode
+  state$build_stack <- snap_build
+
+  WamRuntime$kernel_stream_iter(program, state, key, reached, ancestor,
+                                  1L, resume_pc)
+}
+
 # Iterate a precomputed list of result pairs, unifying each pair
 # with the (target, second) reg pair. Each entry is
 # `list(node = <WAM term>, second = <pre-built WAM term>)` so the

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2709,6 +2709,82 @@ e2e_kernel_tspd5_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for the category_ancestor kernel.
+% Hierarchical BFS with explicit depth cap (read from
+% user:max_depth/1 at codegen time) and visited-set cycle
+% detection. Result layout is tuple(1) -- yields each reached
+% ancestor. The Visited and Hops slots in the user-side call are
+% inputs / discarded outputs that the native impl doesn't touch.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(kernel_ca_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_kernel_ca_via_rscript
+    ;   true
+    )).
+
+e2e_kernel_ca_via_rscript :-
+    retractall(user:cparent(_, _)),
+    retractall(user:cat_anc(_, _, _, _)),
+    retractall(user:max_depth(_)),
+    % Required by the category_ancestor detector at codegen time.
+    assertz(user:max_depth(3)),
+    % A small category tree:
+    %   animal -> mammal -> dog -> poodle
+    %   animal -> fish   -> salmon
+    assertz(user:cparent(animal, mammal)),
+    assertz(user:cparent(mammal, dog)),
+    assertz(user:cparent(dog, poodle)),
+    assertz(user:cparent(animal, fish)),
+    assertz(user:cparent(fish, salmon)),
+    assertz((user:cat_anc(Cat, Anc, Visited, 0) :-
+        \+ member(Cat, Visited),
+        user:cparent(Cat, Anc))),
+    assertz((user:cat_anc(Cat, Anc, Visited, Hops) :-
+        \+ member(Cat, Visited),
+        user:cparent(Cat, Mid),
+        user:cat_anc(Mid, Anc, [Cat | Visited], Hops0),
+        Hops is Hops0 + 1)),
+    assertz((user:ca_direct  :- cat_anc(animal, mammal, [], _))),
+    assertz((user:ca_two     :- cat_anc(animal, dog, [], _))),
+    assertz((user:ca_three   :- cat_anc(animal, poodle, [], _))),
+    assertz((user:ca_branch  :- cat_anc(animal, salmon, [], _))),
+    assertz((user:ca_no_back :- cat_anc(mammal, animal, [], _))),
+    assertz((user:ca_findall :-
+        findall(A, cat_anc(animal, A, [], _), L),
+        msort(L, S),
+        S == [dog, fish, mammal, poodle, salmon])),
+    unique_r_tmp_dir('tmp_r_kernel_ca_e2e', TmpDir),
+    write_wam_r_project(
+        [user:cparent/2, user:cat_anc/4,
+         user:ca_direct/0, user:ca_two/0, user:ca_three/0,
+         user:ca_branch/0, user:ca_no_back/0, user:ca_findall/0],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [ca_direct, ca_two, ca_three, ca_branch, ca_findall],
+    No  = [ca_no_back],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    directory_file_path(TmpDir, 'R/generated_program.R', ProgPath),
+    read_file_to_string(ProgPath, Code, []),
+    assertion(sub_string(Code, _, _, _, 'pred_cat_anc_kernel_ca <- function(')),
+    assertion(sub_string(Code, _, _, _,
+        'assign("cat_anc/4", pred_cat_anc_kernel_ca, envir = shared_program$lowered_dispatch)')),
+    % max_depth(3) should be embedded into the generated dispatch call.
+    assertion(sub_string(Code, _, _, _, '3L, source, ancestor')),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
## Summary

Sixth of the seven kernels from the shared `recursive_kernel_detection.pl` classifier. Pattern:

```prolog
ca(Cat, Anc, Visited, 0) :-
    \+ member(Cat, Visited),
    edge(Cat, Anc).
ca(Cat, Anc, Visited, Hops) :-
    \+ member(Cat, Visited),
    edge(Cat, Mid),
    ca(Mid, Anc, [Cat | Visited], Hops0),
    Hops is Hops0 + 1.
```

Hierarchical BFS with explicit depth cap and visited-set cycle detection. Reuses the BFS scaffold from earlier kernels with two additions:

- **Depth cap pruning** — frontier nodes at depth >= `max_depth` aren't expanded.
- **`max_depth/1` plumbing** — the detector reads `user:max_depth/1` at codegen time and stuffs the integer into the kernel config; `emit_kernel` embeds it into the generated dispatch call.

Result layout is `tuple(1)` — the kernel yields each reached ancestor through the existing 1-arg `kernel_stream_iter` (introduced for `transitive_closure2`). `Visited` and `Hops` in the user-side 4-arg call are inputs / discarded outputs that the native impl doesn't touch — the cycle detection happens internally via the visited env.

## Kernel landscape after this PR (6/7)

| Kind | Status |
|---|---|
| `transitive_closure2` | #1922 |
| `transitive_distance3` | #1923 |
| `weighted_shortest_path3` | #1925 |
| `transitive_parent_distance4` | #1928 |
| `transitive_step_parent_distance5` | #1930 |
| `category_ancestor` | **this PR** |
| `astar_shortest_path4` | pending |

## Test plan

- [x] `kernel_ca_e2e_rscript` (new): direct hit, two-/three-hop reach within the depth cap, branch traversal, no-path failure, findall over the reachable ancestor set. Asserts that the generated dispatch call embeds the `max_depth(3)` value.
- [x] Full suite: 52 tests pass.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_