### PR TITLE
perf(wam-haskell): default -A64M for matrix bench — parMap regression diagnosis (Phase L appendix #6)

### DIFF
--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -2824,3 +2824,105 @@ swipl -q -s examples/benchmark/generate_wam_haskell_matrix_benchmark.pl -- \
 
 # 4. Run with /usr/bin/time -v for peak RSS; loop -N1/-N2/-N4 × 5 trials.
 ```
+
+## Phase L appendix #6: parMap regression at -N>=2 is GC pressure (2026-05-08)
+
+### Why this landed
+
+Appendix #5 left this open: "both modes get slower at -N4 vs -N1
+(TSV: 3535→5831 = 1.65× slower; resident: 980→2090 = 2.13× slower)".
+The hypothesis was first-page faults paid concurrently across worker
+threads on the LMDB load. This appendix tests it.
+
+### Diagnosis
+
+Resident binary, 100k_cats, +RTS -N4 -s, three trials per config:
+
+| config       | total_ms | GC time |  RSS_MB |
+|--------------|---------:|--------:|--------:|
+| default      |     3327 |  5.66 s |     397 |
+| -A64M        |     1146 |  1.36 s |     619 |
+| -A256M       |     1031 |  0.65 s |    1244 |
+| -A1G         |      892 |   ~0  s |    1318 |
+| -A64M -qg    |     1286 |  0.66 s |     619 |
+
+The regression is **GC pressure**, not LMDB or thread contention. At
+-N4 the default 1 MB nursery triggers a parallel GC pass roughly
+every 1 MB of allocation; with 4 threads competing for the GC's stop-
+the-world phase, GC time blows up to 5.7 s out of 3.3 s wall (because
+parallel GC accounts wall time across each capability separately).
+
+`-A64M` lifts the nursery to 64 MB so collections happen ~64× less
+often. `-A1G` is even better (near-zero GC) but uses 1.3 GB RSS.
+`-A64M -qg` (use sequential GC) is comparable to `-A64M` alone — the
+nursery size is the dominant lever, not the parallelism mode of GC
+itself.
+
+### Validation across -N
+
+5 trials per cell, medians:
+
+| cell           | total_ms | GC time | RSS_MB |
+|----------------|---------:|--------:|-------:|
+| default -N1    |     1016 |  0.68 s |    394 |
+| **A64M    -N1**|   **1260**| **0.89 s** |**521** |
+| default -N2    |     1079 |  1.19 s |    394 |
+| **A64M    -N2**|    **801**| **0.71 s** |**504** |
+| default -N4    |     2126 |  3.85 s |    397 |
+| **A64M    -N4**|   **1062**| **1.10 s** |**619** |
+
+`-A64M` is **only correct at -N≥2**. At -N1 it costs ~24% (1016 →
+1260 ms): the small default nursery's frequent minor GCs beat one
+big nursery + occasional major GC, when there's no parallel GC
+synchronisation cost. Crossover is between -N1 and -N2.
+
+### What landed
+
+The matrix bench's primary use case is `+RTS -N>=2`, so we accept
+the -N1 cost in exchange for halving total_ms at -N4. New
+`with_rtsopts(Flags)` codegen option in `generate_cabal_file/4` bakes
+`-with-rtsopts="..."` into the executable's `ghc-options`. The
+matrix bench generator passes `with_rtsopts('-A64M')`. Per GHC's
+"last flag wins" rule, callers can override at runtime with
+`+RTS -A1M -RTS`.
+
+| Codegen surface               | Default       | Override |
+|-------------------------------|---------------|---------|
+| `generate_cabal_file/4`       | no rtsopts    | `with_rtsopts(Flags)` |
+| matrix bench generator        | `-A64M`       | `+RTS -A1M -RTS` |
+| other WAM-Haskell projects    | unchanged     | n/a    |
+
+Only the matrix bench opts in. Other generated projects (typical
+user code, single-target benches, etc.) get the original GHC defaults
+because the right -A varies with workload + intended -N.
+
+### What's still open
+
+A workload-aware nursery size is the proper fix, à la the C# target's
+source-mode cost-model resolver
+(`docs/design/CSHARP_QUERY_SOURCE_MODE_*.md`). For the WAM-Haskell
+target the inputs are: number of seeds, number of edges, intended
+-N, available RAM. Output: an -A choice that optimises total_ms
+without exceeding budget. Not done in this iteration; the static
+`-A64M` is a reasonable point on the curve for the matrix bench.
+
+The TSV setup-growth observation from appendix #5 (TSV setup_ms
+3.5→5.8 s going N1→N4) is the same phenomenon — a sequential
+allocation-heavy phase running while the GC scales with -N. -A64M
+helps there too; the matrix bench's resident mode is the canonical
+test, but TSV mode benefits as a side effect.
+
+### Reproducer
+
+```bash
+# Generate the matrix bench (resident or none — both inherit -A64M).
+swipl -q -s examples/benchmark/generate_wam_haskell_matrix_benchmark.pl -- \
+    data/benchmark/100k_cats_resident_run/facts.pl /tmp/wam_resident \
+    seeded interpreter kernels_on resident
+grep ghc-options /tmp/wam_resident/wam-haskell-matrix-bench.cabal
+# -> ghc-options:      -O2 -threaded -rtsopts "-with-rtsopts=-A64M"
+
+# Build and run; -A64M is now the runtime default at every -N.
+(cd /tmp/wam_resident && cabal new-build)
+.../wam-haskell-matrix-bench .../100k_cats_resident_run +RTS -N4 -s
+```

--- a/examples/benchmark/generate_wam_haskell_matrix_benchmark.pl
+++ b/examples/benchmark/generate_wam_haskell_matrix_benchmark.pl
@@ -66,9 +66,16 @@ generate(FactsPath, VariantAtom, EmitModeAtom, KernelModeAtom, LmdbModeAtom, Out
     delete_file(TmpPath),
     collect_wam_predicates(VariantAtom, Predicates),
     query_pred_for_variant(VariantAtom, QueryPredOpts),
+    %% Default -A64M nursery for the matrix bench: at -N>=2 it cuts
+    %% GC time from ~3.9s to ~1.1s on 100k_cats and roughly halves
+    %% total_ms; the -N1 regression is ~24% (1.0 -> 1.3s) which we
+    %% accept as the bench's typical run is parallel.  Documented in
+    %% WAM_PERF_OPTIMIZATION_LOG.md Phase L appendix #6.  Override by
+    %% passing +RTS -A1M -RTS at run time.
     append([[module_name('wam-haskell-matrix-bench'),
              emit_mode(EmitMode),
-             fact_count(FactCount)],
+             fact_count(FactCount),
+             with_rtsopts('-A64M')],
             KernelOptions, LmdbOptions, QueryPredOpts], Options),
     write_wam_haskell_project(Predicates, Options, OutputDir),
     format(user_error,

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -3761,8 +3761,21 @@ generate_cabal_file(Name, UseHM, Options, Code) :-
     % -threaded enables multi-core runtime (+RTS -N to use cores).
     % -rtsopts is needed so +RTS flags are accepted at runtime.
     (   option(profiling(true), Options)
-    ->  GhcOpts = "-O2 -threaded -rtsopts -prof -fprof-auto"
-    ;   GhcOpts = "-O2 -threaded -rtsopts"
+    ->  BaseGhcOpts = "-O2 -threaded -rtsopts -prof -fprof-auto"
+    ;   BaseGhcOpts = "-O2 -threaded -rtsopts"
+    ),
+    %% with_rtsopts(Flags): bake default RTS flags into the executable
+    %% so +RTS args don't need to be passed every run. Caller-supplied
+    %% +RTS flags still override (per GHC's "last flag wins" rule).
+    %% Used by the matrix bench to default -A64M (Phase L appendix #6
+    %% in WAM_PERF_OPTIMIZATION_LOG.md): the GC-pressure win at -N>=2
+    %% is large enough that we'd rather pay the small -N1 regression
+    %% than make every bench user pass +RTS flags. Cost-model-driven
+    %% selection (à la C# target's source-mode resolver) is deferred.
+    (   option(with_rtsopts(RtsFlags), Options),
+        RtsFlags \= ''
+    ->  format(string(GhcOpts), '~w "-with-rtsopts=~w"', [BaseGhcOpts, RtsFlags])
+    ;   GhcOpts = BaseGhcOpts
     ),
     format(string(Code),
 'cabal-version: 2.4

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1281,6 +1281,25 @@ test_b1_no_lmdb_cabal_default :-
     ;   fail_test(Test, 'lmdb-simple should not appear in default cabal deps')
     ).
 
+test_with_rtsopts_emits_in_cabal :-
+    Test = 'WAM-Haskell: with_rtsopts(Flags) bakes -with-rtsopts into ghc-options',
+    (   wam_haskell_target:generate_cabal_file('test', false,
+            [with_rtsopts('-A64M')], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "\"-with-rtsopts=-A64M\"")
+    ->  pass(Test)
+    ;   fail_test(Test, 'with_rtsopts(-A64M) should add -with-rtsopts=-A64M to ghc-options')
+    ).
+
+test_with_rtsopts_absent_by_default :-
+    Test = 'WAM-Haskell: cabal omits -with-rtsopts when option not set',
+    (   wam_haskell_target:generate_cabal_file('test', false, [], Code),
+        atom_string(Code, S),
+        \+ sub_string(S, _, _, _, "-with-rtsopts")
+    ->  pass(Test)
+    ;   fail_test(Test, 'cabal should not contain -with-rtsopts when option absent')
+    ).
+
 test_b1_external_source_skips_wam_compilation :-
     Test = 'B1: external_source fact predicate skips WAM compilation',
     (   retractall(user:b1_ext(_, _)),
@@ -2096,6 +2115,8 @@ run_tests :-
     test_b1_lmdb_absent_when_disabled,
     test_b1_lmdb_cabal_dependency,
     test_b1_no_lmdb_cabal_default,
+    test_with_rtsopts_emits_in_cabal,
+    test_with_rtsopts_absent_by_default,
     test_b1_lmdb_raw_zero_copy_reads,
     test_b1_phase2b2_loaders_emitted,
     test_b1_lmdb_scan_support_present,


### PR DESCRIPTION
  ## Summary

  Diagnoses the parMap regression at `-N>=2` flagged as an open
  follow-up in Phase L appendices #4 and #5. The slowdown is **GC
  pressure on the sequential intern/load phase**, not LMDB or thread
  contention. Lifting the nursery to 64 MB roughly halves total_ms at
  -N4 and is the only change required.

  ## Root cause

  At `+RTS -N4 -s` on 100k_cats, the default RTS spends GC time
  disproportionate to the work:

  | config       | total_ms | GC time |  RSS_MB |
  |--------------|---------:|--------:|--------:|
  | default      |     3327 |  5.66 s |     397 |
  | -A64M        |     1146 |  1.36 s |     619 |
  | -A256M       |     1031 |  0.65 s |    1244 |
  | -A1G         |      892 |   ~0  s |    1318 |
  | -A64M -qg    |     1286 |  0.66 s |     619 |

  The default 1 MB nursery triggers a parallel GC pass roughly every
  1 MB of allocation; with 4 capabilities competing for the
  stop-the-world phase, GC accounting blows up to 5.7 s of charged
  time on a 3.3 s wall (parallel GC charges each capability separately).
  `-A64M` lifts the nursery so collections happen ~64× less often.
  `-A1G` is even better (near-zero GC) but uses 1.3 GB RSS — the wrong
  default for a benchmark that runs on developer laptops.

  `-A64M -qg` (sequential GC under -N>=2) is comparable to `-A64M`
  alone, confirming **the nursery size is the dominant lever**, not the
  parallelism mode of GC itself.

  ## Validation across -N

  5 trials per cell, medians, 100k_cats resident mode:

  | cell        | total_ms | GC time | RSS_MB |
  |-------------|---------:|--------:|-------:|
  | default -N1 |    1016  |  0.68 s |    394 |
  | **A64M -N1**|    **1260**|  **0.89 s** |   **521** |
  | default -N2 |    1079  |  1.19 s |    394 |
  | **A64M -N2**|     **801**|  **0.71 s** |   **504** |
  | default -N4 |    2126  |  3.85 s |    397 |
  | **A64M -N4**|    **1062**|  **1.10 s** |   **619** |

  `-A64M` is **only correct at -N>=2**. At -N1 the small default
  nursery's frequent minor GCs beat one big nursery + occasional major
  GC, when there's no parallel-GC synchronisation cost. The crossover
  is between -N1 and -N2; at -N1 we accept ~24% slower in exchange for
  ~50% faster at -N4.

  The matrix bench's primary use case is `+RTS -N>=2` (it's the
  parallelism harness), so the trade is sensible. Per GHC's "last flag
  wins" rule, callers can override at runtime with `+RTS -A1M -RTS`.

  ## What changed

  ### `src/unifyweaver/targets/wam_haskell_target.pl`
  - `generate_cabal_file/4` honors `with_rtsopts(Flags)` by emitting
    `-with-rtsopts="..."` in the executable's `ghc-options`. Optional
    — when absent, no rtsopts are baked, preserving the previous
    behavior for all other callers.

  ### `examples/benchmark/generate_wam_haskell_matrix_benchmark.pl`
  - Passes `with_rtsopts('-A64M')` to `write_wam_haskell_project`.
    Other generated WAM-Haskell projects are unaffected (default GHC
    nursery).

  ### `tests/test_wam_haskell_target.pl`
  - `test_with_rtsopts_emits_in_cabal` — option is plumbed.
  - `test_with_rtsopts_absent_by_default` — cabal omits the flag when
    the option is not set (no surprise behavior change).

  ### `docs/design/WAM_PERF_OPTIMIZATION_LOG.md`
  - Phase L appendix #6 with the diagnosis, validation table, and the
    open follow-up.

  ## Scope

  | Codegen surface               | Default       | Override |
  |-------------------------------|---------------|---------|
  | `generate_cabal_file/4`       | no rtsopts    | `with_rtsopts(Flags)` |
  | matrix bench generator        | `-A64M`       | `+RTS -A1M -RTS` |
  | other WAM-Haskell projects    | unchanged     | n/a     |

  Only the matrix bench opts in. The right `-A` varies with workload
  + intended `-N` + available RAM; one-size defaults are wrong for
  non-bench workloads.

  ## What's still open

  A workload-aware nursery size is the proper fix, à la the C# target's
  source-mode cost-model resolver
  (`docs/design/CSHARP_QUERY_SOURCE_MODE_*.md`). For the WAM-Haskell
  target the inputs are: number of seeds, number of edges, intended
  `-N`, available RAM. Output: an `-A` choice that optimises total_ms
  without exceeding RSS budget. The static `-A64M` is a reasonable
  point on the curve for the matrix bench at 100k_cats; cost-model
  integration is deferred.

  ## Test plan

  - [x] `swipl -g run_tests -t halt tests/test_wam_haskell_target.pl` — all green
  - [x] Two new codegen tests added
  - [x] Smoke build of matrix bench `resident` mode against 100k_cats
    fixture: cabal output contains
    `ghc-options: -O2 -threaded -rtsopts "-with-rtsopts=-A64M"`
  - [x] Runtime check: `+RTS -N1/-N2/-N4` with baked-in default
    reproduces validation-table numbers within trial noise

  🤖 Generated with [Claude Code](https://claude.com/claude-code)