### PR TITLE
feat(wam-r): astar_shortest_path4 kernel (A* w/ heuristic) — 7/7 done

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -191,11 +191,11 @@ that bypasses the WAM stepping engine entirely. The classifier
 lives in
 [`src/unifyweaver/core/recursive_kernel_detection.pl`](../src/unifyweaver/core/recursive_kernel_detection.pl)
 and is shared with the Haskell / Rust / Elixir targets; this
-target wires up `transitive_closure2`, `transitive_distance3`,
+target wires up all seven registered kernel patterns:
+`transitive_closure2`, `transitive_distance3`,
 `weighted_shortest_path3`, `transitive_parent_distance4`,
-`transitive_step_parent_distance5`, and `category_ancestor` so far
-(6/7 of the registered kernel patterns; only `astar_shortest_path4`
-remains). Canonical shapes:
+`transitive_step_parent_distance5`, `category_ancestor`, and
+`astar_shortest_path4`. Canonical shapes:
 
 ```prolog
 % transitive_closure2 -- streams reachable nodes
@@ -229,6 +229,18 @@ ca(Cat, Anc, Visited, 0) :- \+ member(Cat, Visited), edge(Cat, Anc).
 ca(Cat, Anc, Visited, Hops) :- \+ member(Cat, Visited),
     edge(Cat, Mid), ca(Mid, Anc, [Cat | Visited], Hops0),
     Hops is Hops0 + 1.
+
+% astar_shortest_path4 -- goal-directed shortest-path search.
+% direct_dist_pred/1 names the heuristic predicate (arity 3:
+% h(N, Goal, H)); the detector falls back to the edge predicate
+% when not set. Dim is a passthrough arg the native impl ignores.
+% Result is the single shortest distance source->target.
+% Admissibility of the heuristic is the user's responsibility;
+% non-admissible heuristics may produce non-optimal results.
+:- assertz(user:direct_dist_pred(h_dist/3)).
+astar(X, Y, _, W) :- edge(X, Y, W).
+astar(X, Y, D, W) :- edge(X, Z, W1), astar(Z, Y, D, RestW),
+    W is W1 + RestW.
 ```
 
 The runtime helpers BFS (`transitive_closure2`,
@@ -553,7 +565,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 52 tests covering both structural assertions on the
+and contains 53 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -599,6 +611,7 @@ Coverage map (e2e tests, by feature group):
 | `kernel_tpd4_e2e_rscript` | recursive-kernel detection: `transitive_parent_distance4` BFS with parent tracking |
 | `kernel_tspd5_e2e_rscript` | recursive-kernel detection: `transitive_step_parent_distance5` BFS with step + parent + distance |
 | `kernel_ca_e2e_rscript` | recursive-kernel detection: `category_ancestor` BFS with depth-cap + visited-set cycle detection |
+| `kernel_astar4_e2e_rscript` | recursive-kernel detection: `astar_shortest_path4` goal-directed search with user heuristic |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -918,6 +918,33 @@ emit_kernel(Pred, recursive_kernel(category_ancestor, _, ConfigOps),
                                 ~wL, source, ancestor, state$pc + 1L)
 }',
            [FuncName, Pred, EdgePred, EdgePred, MaxDepth]).
+emit_kernel(Pred, recursive_kernel(astar_shortest_path4, _, ConfigOps),
+            DataDecl, LoweredFunc, FuncName) :-
+    member(edge_pred(EdgePred/EdgeArity), ConfigOps),
+    EdgeArity =:= 3,
+    % direct_dist_pred(Spec) -- Spec may be a `Name/Arity` pair or
+    % a bare atom. Normalize to a name + arity for the codegen.
+    member(direct_dist_pred(DistSpec), ConfigOps),
+    astar_dist_pred_name(DistSpec, DistPred),
+    r_pred_name(Pred, RName),
+    format(atom(FuncName), '~w_kernel_astar4', [RName]),
+    DataDecl = "",
+    format(string(LoweredFunc),
+'~w <- function(program, state) {
+  source <- WamRuntime$get_reg(state, 1L)
+  target <- WamRuntime$get_reg(state, 2L)
+  dim    <- WamRuntime$get_reg(state, 3L)
+  dist   <- WamRuntime$get_reg(state, 4L)
+  WamRuntime$astar_shortest_path4(program, state, "~w/4",
+                                    "~w", "~w/3",
+                                    "~w", "~w/3",
+                                    source, target, dim, dist,
+                                    state$pc + 1L)
+}',
+           [FuncName, Pred, EdgePred, EdgePred, DistPred, DistPred]).
+
+astar_dist_pred_name(Name/_Arity, Name) :- atom(Name), !.
+astar_dist_pred_name(Name, Name) :- atom(Name).
 
 % ============================================================================
 % FACT-TABLE CLASSIFICATION + EMISSION

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -2442,6 +2442,155 @@ WamRuntime$category_ancestor <- function(program, state, key, edge_pred,
                                   1L, resume_pc)
 }
 
+# ----------------------------------------------------------
+# Recursive-kernel: astar_shortest_path4
+# ----------------------------------------------------------
+# A* from a ground source to a ground target over a weighted edge
+# predicate of arity 3. Pattern detected:
+#   astar(X, Y, _, W) :- edge(X, Y, W).
+#   astar(X, Y, D, W) :- edge(X, Z, W1), astar(Z, Y, D, W2), W is W1 + W2.
+# (the 3rd arg is a Dim passthrough that the native impl ignores).
+# The heuristic is queried via a user-configurable predicate of
+# arity 3: dist_pred(Node, Target, H) yields H. If the user didn't
+# set `direct_dist_pred/1`, the detector falls back to the edge
+# predicate -- which gives h=0 for nodes with no direct edge to
+# the goal (degenerating A* to Dijkstra) and h = direct-edge-cost
+# otherwise. Admissibility of the heuristic is the user's
+# responsibility; non-admissible heuristics may produce non-
+# optimal results.
+#
+# Result layout is tuple(1) -- the single shortest-path distance.
+# Mode: source and target both ground; dim ignored; dist unground
+# (output). Failure when no path exists.
+WamRuntime$astar_shortest_path4 <- function(program, state, key, edge_pred,
+                                              edge_key, dist_pred, dist_key,
+                                              source, target_node, dim, dist,
+                                              resume_pc) {
+  table <- program$intern_table
+  src_v <- WamRuntime$deref(state, source)
+  tgt_v <- WamRuntime$deref(state, target_node)
+  if (is.null(src_v) || is.null(src_v$tag) || src_v$tag != "atom" ||
+      is.null(tgt_v) || is.null(tgt_v$tag) || tgt_v$tag != "atom") {
+    return(FALSE)
+  }
+  snap_cps   <- length(state$cps)
+  snap_regs  <- as.list.environment(state$regs2)
+  snap_trail <- length(state$trail)
+  snap_pc    <- state$pc
+  snap_cp    <- state$cp
+  snap_halt  <- state$halt
+  snap_vc    <- state$var_counter
+  snap_mode  <- state$mode
+  snap_build <- state$build_stack
+
+  edge_atom_id <- WamRuntime$intern(table, edge_pred)
+  dist_atom_id <- WamRuntime$intern(table, dist_pred)
+
+  # Heuristic estimate: h(node, target). Returns 0 when the dist
+  # pred fails (no direct distance available -- safe / admissible).
+  heuristic_at <- function(node) {
+    if (identical(node$id, tgt_v$id)) return(0)
+    h_var <- Unbound(paste0("V_astar_h_", state$var_counter))
+    state$var_counter <- state$var_counter + 1L
+    h_goal <- StructTerm(dist_atom_id, list(node, tgt_v, h_var))
+    h_val <- 0
+    WamRuntime$iterate_goal(program, state, h_goal, function() {
+      v <- WamRuntime$deref(state, h_var)
+      if (!is.null(v) && !is.null(v$tag) &&
+          (v$tag == "int" || v$tag == "float")) {
+        h_val <<- v$val
+      }
+      FALSE  # one solution is enough
+    })
+    h_val
+  }
+
+  visited <- new.env(parent = emptyenv())
+  # PQ entry: list(f = priority, g = cost-so-far, node).
+  pq <- list(list(f = heuristic_at(src_v), g = 0, node = src_v))
+  found_dist <- NULL
+
+  while (length(pq) > 0L) {
+    entry <- pq[[1L]]
+    pq    <- pq[-1L]
+    cur   <- entry$node
+    g     <- entry$g
+    k     <- as.character(cur$id)
+    if (exists(k, envir = visited, inherits = FALSE)) next
+    assign(k, TRUE, envir = visited)
+    if (identical(cur$id, tgt_v$id)) {
+      found_dist <- g
+      break
+    }
+    captured_g <- g
+    y_var <- Unbound(paste0("V_astar_y_", state$var_counter))
+    state$var_counter <- state$var_counter + 1L
+    w_var <- Unbound(paste0("V_astar_w_", state$var_counter))
+    state$var_counter <- state$var_counter + 1L
+    edge_goal <- StructTerm(edge_atom_id, list(cur, y_var, w_var))
+    WamRuntime$iterate_goal(program, state, edge_goal, function() {
+      y_v <- WamRuntime$deref(state, y_var)
+      w_v <- WamRuntime$deref(state, w_var)
+      if (!is.null(y_v) && !is.null(y_v$tag) && y_v$tag == "atom" &&
+          !is.null(w_v) && !is.null(w_v$tag) &&
+          (w_v$tag == "int" || w_v$tag == "float")) {
+        nk <- as.character(y_v$id)
+        if (!exists(nk, envir = visited, inherits = FALSE)) {
+          new_g <- captured_g + w_v$val
+          new_f <- new_g + heuristic_at(y_v)
+          if (length(pq) == 0L) {
+            pq <<- list(list(f = new_f, g = new_g, node = y_v))
+          } else {
+            placed <- FALSE
+            for (i in seq_along(pq)) {
+              if (pq[[i]]$f > new_f) {
+                pq <<- append(pq, list(list(f = new_f, g = new_g, node = y_v)),
+                              after = i - 1L)
+                placed <- TRUE; break
+              }
+            }
+            if (!placed) {
+              pq <<- c(pq, list(list(f = new_f, g = new_g, node = y_v)))
+            }
+          }
+        }
+      }
+      TRUE
+    })
+  }
+
+  if (length(state$cps) > snap_cps) {
+    state$cps <- state$cps[seq_len(snap_cps)]
+  }
+  e <- new.env(parent = emptyenv(), hash = TRUE)
+  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
+  state$regs2 <- e
+  if (length(state$trail) > snap_trail) {
+    to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
+    for (name in to_undo) {
+      if (exists(name, envir = state$bindings, inherits = FALSE)) {
+        rm(list = name, envir = state$bindings)
+      }
+    }
+    state$trail <- state$trail[seq_len(snap_trail)]
+  }
+  state$pc          <- snap_pc
+  state$cp          <- snap_cp
+  state$halt        <- snap_halt
+  state$var_counter <- snap_vc
+  state$mode        <- snap_mode
+  state$build_stack <- snap_build
+
+  if (is.null(found_dist)) return(FALSE)
+  dt <- if (is.finite(found_dist) && found_dist == as.integer(found_dist) &&
+            abs(found_dist) < .Machine$integer.max) {
+          IntTerm(as.integer(found_dist))
+        } else {
+          FloatTerm(as.numeric(found_dist))
+        }
+  WamRuntime$unify(state, dist, dt)
+}
+
 # Iterate a precomputed list of result pairs, unifying each pair
 # with the (target, second) reg pair. Each entry is
 # `list(node = <WAM term>, second = <pre-built WAM term>)` so the

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2785,6 +2785,78 @@ e2e_kernel_ca_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for the astar_shortest_path4 kernel.
+% Goal-directed shortest-path search with a user-supplied heuristic
+% (read from user:direct_dist_pred/1 at codegen time). Result
+% layout is tuple(1) -- single shortest distance. Admissibility of
+% the heuristic is the user's responsibility; this test uses
+% under-estimates so the path returned is optimal.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(kernel_astar4_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_kernel_astar4_via_rscript
+    ;   true
+    )).
+
+e2e_kernel_astar4_via_rscript :-
+    retractall(user:wedge2(_, _, _)),
+    retractall(user:h_dist2(_, _, _)),
+    retractall(user:astar(_, _, _, _)),
+    retractall(user:direct_dist_pred(_)),
+    % a -1-> b -2-> c -3-> d, plus a heavy direct a -5-> c.
+    assertz(user:wedge2(a, b, 1)),
+    assertz(user:wedge2(b, c, 2)),
+    assertz(user:wedge2(c, d, 3)),
+    assertz(user:wedge2(a, c, 5)),
+    % Heuristic to goal d (admissible: each value <= true cost).
+    assertz(user:h_dist2(a, d, 5)),  % true cost is 6
+    assertz(user:h_dist2(b, d, 4)),  % true cost is 5
+    assertz(user:h_dist2(c, d, 3)),  % exact
+    assertz(user:h_dist2(d, d, 0)),
+    assertz(user:direct_dist_pred(h_dist2/3)),
+    % Canonical astar shape: 4-arity with Dim passthrough.
+    assertz((user:astar(X, Y, _, W) :- user:wedge2(X, Y, W))),
+    assertz((user:astar(X, Y, D, W) :-
+        user:wedge2(X, Z, W1),
+        user:astar(Z, Y, D, RestW),
+        W is W1 + RestW)),
+    assertz((user:astar_direct  :- astar(a, b, 5, 1))),
+    assertz((user:astar_shorter :- astar(a, c, 5, 3))),     % via b, not 5
+    assertz((user:astar_three   :- astar(a, d, 5, 6))),
+    assertz((user:astar_no_heavy :- astar(a, c, 5, 5))),     % wrong cost
+    assertz((user:astar_no_back :- astar(d, a, 5, _))),
+    unique_r_tmp_dir('tmp_r_kernel_astar4_e2e', TmpDir),
+    write_wam_r_project(
+        [user:wedge2/3, user:h_dist2/3, user:astar/4,
+         user:astar_direct/0, user:astar_shorter/0, user:astar_three/0,
+         user:astar_no_heavy/0, user:astar_no_back/0],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [astar_direct, astar_shorter, astar_three],
+    No  = [astar_no_heavy, astar_no_back],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    directory_file_path(TmpDir, 'R/generated_program.R', ProgPath),
+    read_file_to_string(ProgPath, Code, []),
+    assertion(sub_string(Code, _, _, _, 'pred_astar_kernel_astar4 <- function(')),
+    assertion(sub_string(Code, _, _, _,
+        'assign("astar/4", pred_astar_kernel_astar4, envir = shared_program$lowered_dispatch)')),
+    % Heuristic-pred name should appear in the generated dispatch call.
+    assertion(sub_string(Code, _, _, _, '"h_dist2", "h_dist2/3"')),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
## Summary

Final kernel from the shared `recursive_kernel_detection.pl` classifier — **completing 7/7 kernel parity** with the Haskell / Rust targets. Pattern:

```prolog
astar(X, Y, _, W) :- edge(X, Y, W).
astar(X, Y, D, W) :- edge(X, Z, W1), astar(Z, Y, D, RestW), W is W1 + RestW.
```

Goal-directed shortest-path search. Reuses the `wsp3` PQ scaffold but the priority is `f(n) = g(n) + h(n)`, where `h` is a user-configurable heuristic queried via `direct_dist_pred/1`. The detector falls back to the edge predicate itself when `direct_dist_pred` isn't set; in practice that gives `h=0` for nodes without a direct edge to the goal (degenerating A* to Dijkstra) and `h = direct-edge-cost` otherwise.

Result layout is `tuple(1)` — a single shortest distance, no iter-CP needed. Source and target both ground; `Dim` is a passthrough that the native impl ignores.

## Admissibility caveat

A* is optimal only when the heuristic is admissible (`h(n) ≤ true cost from n to goal`). When the user supplies a custom `direct_dist_pred`, that's their responsibility; the fallback (edge_pred) may be inadmissible if a shorter path exists through other nodes. Both behaviours are documented in the new kernel section of `docs/WAM_R_TARGET.md`.

## Codegen note

`emit_kernel` grows a clause for `astar_shortest_path4`. The kernel config carries `direct_dist_pred(Spec)` where Spec can be either a `Name/Arity` pair or a bare atom; `astar_dist_pred_name` normalises to a name string for the codegen.

## Kernel landscape after this PR (7/7 ✓)

| Kind | Status |
|---|---|
| `transitive_closure2` | #1922 |
| `transitive_distance3` | #1923 |
| `weighted_shortest_path3` | #1925 |
| `transitive_parent_distance4` | #1928 |
| `transitive_step_parent_distance5` | #1930 |
| `category_ancestor` | #1934 |
| `astar_shortest_path4` | **this PR** ✓ |

The R target now reaches feature parity with the Haskell / Rust targets on the kernel-detector front. The remaining parity gaps (mode analysis, external fact sources, multi-arg fact-table indexing) are all *outside* the kernel work.

## Test plan

- [x] `kernel_astar4_e2e_rscript` (new): direct hit, shorter detour beating heavy direct edge, multi-hop sum, wrong-distance / no-path failures, generated-source assertions on the heuristic pred name embedding.
- [x] Full suite: 53 tests pass.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_