### PR TITLE
feat(wam-r): external fact sources via CSV files

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -283,6 +283,43 @@ infrastructure to build richer indexes (multi-arg, range) on top.
 Disable per-call with `fact_table_layout(off)` in Options, or
 globally via the multifile `user:wam_r_fact_layout(off)` fact.
 
+### External fact sources (CSV)
+
+Mirrors the Scala target's `scala_fact_sources` option. Users can
+declare a predicate's facts as a separate CSV file:
+
+```prolog
+:- write_wam_r_project(
+       [user:cp/2, user:test/0],
+       [intern_atoms([alice, bob, carol]),
+        r_fact_sources([source(cp/2, file('data.csv'))])],
+       '/tmp/proj').
+```
+
+The predicate has **no Prolog clauses** -- the codegen emits a
+runtime CSV loader that reads the file at program-init time and
+populates the standard fact-table data structures
+(`<pred>_facts` / `<pred>_index`). The predicate then dispatches
+via the same `fact_table_dispatch` path used by inline-clause
+fact tables (PR #1921), so first-arg hash indexing, multi-
+solution backtracking, and `iterate_goal` integration all work
+the same way.
+
+CSV format: one row per fact, comma-separated; lines starting
+with `#` and blank lines are skipped. Fields that parse as a
+finite numeric become `IntTerm` / `FloatTerm`; everything else
+interns as an atom.
+
+For atoms that don't appear in any compiled WAM body but are
+needed by the loaded facts, declare them via `intern_atoms(...)`
+so the intern table includes them at startup -- otherwise the
+loader interns them lazily, which is fine but means some atoms
+get IDs outside the codegen-known range.
+
+The CLI path works the same as inline fact tables: the
+predicate's body is a single `Execute("P", A)` instruction that
+falls through to the lowered_dispatch tier.
+
 ### Emit modes
 
 The Phase-3 lowered emitter can replace the instruction-array body
@@ -565,7 +602,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 53 tests covering both structural assertions on the
+and contains 54 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -612,6 +649,7 @@ Coverage map (e2e tests, by feature group):
 | `kernel_tspd5_e2e_rscript` | recursive-kernel detection: `transitive_step_parent_distance5` BFS with step + parent + distance |
 | `kernel_ca_e2e_rscript` | recursive-kernel detection: `category_ancestor` BFS with depth-cap + visited-set cycle detection |
 | `kernel_astar4_e2e_rscript` | recursive-kernel detection: `astar_shortest_path4` goal-directed search with user heuristic |
+| `external_fact_source_e2e_rscript` | external CSV fact sources via `r_fact_sources([source(P/A, file(...))])` |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -584,7 +584,21 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
                        AllLabelEntries, AllWrappers, AllLowered,
                        AllLoweredDispatch) :-
     (   Pred = _Module:P/Arity -> true ; Pred = P/Arity ),
-    (   r_foreign_predicate(P, Arity, Options)
+    (   r_fact_source_spec(P, Arity, Options, _FactSourceSpec)
+    ->  % External fact source -- skip Prolog clause extraction.
+        % The body is a single Execute("P", A) which falls through
+        % to lowered_dispatch (set up below), and the lowered fn
+        % loads the file at program-init time and dispatches via
+        % WamRuntime$fact_table_dispatch.
+        format(string(EFLit), 'Execute("~w", ~w)', [P, Arity]),
+        ExternalSeq = [EFLit],
+        append(InstrAcc, ExternalSeq, NewInstrs),
+        NewPC is BasePC + 1,
+        format(string(MainEntry), '    "~w/~w" = ~wL', [P, Arity, BasePC]),
+        NewTopLabels = [MainEntry | TopLabelAcc],
+        NewAllLabels = [MainEntry | AllLabelAcc],
+        WamCodeForLower = ""
+    ;   r_foreign_predicate(P, Arity, Options)
     ->  format(string(FLit), 'CallForeign("~w", ~w)', [P, Arity]),
         ForeignSeq = [FLit, 'Proceed()'],
         append(InstrAcc, ForeignSeq, NewInstrs),
@@ -610,11 +624,20 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
         NewTopLabels = [MainEntry | TopLabelAcc],
         append([MainEntry | PredSubLabelEntries], AllLabelAcc, NewAllLabels)
     ),
-    % Decide whether this predicate should be lowered. The kernel
-    % detector wins first (a recognised graph pattern dispatches to
-    % a native R fast path); then the fact-table path; then the
-    % regular Phase-3 lowered emitter; otherwise the WAM array.
-    (   kernel_layout_enabled(Options),
+    % Decide whether this predicate should be lowered. External
+    % fact sources (r_fact_sources option) win first -- they have
+    % no Prolog clauses, just a file-loader; then the kernel
+    % detector (recognised graph pattern -> native R fast path);
+    % then the fact-table path; then the regular Phase-3 lowered
+    % emitter; otherwise the WAM array.
+    (   r_fact_source_spec(P, Arity, Options, ExternalFactSpec)
+    ->  emit_external_fact_source(P, Arity, ExternalFactSpec,
+                                   ExtData, ExtFunc, ExtFuncName),
+        NewLoweredAcc = [ExtData, ExtFunc | LoweredAcc],
+        emit_r_lowered_wrapper(P, Arity, ExtFuncName, WrapperCode),
+        emit_lowered_dispatch_entry(P, Arity, ExtFuncName, DispEntry),
+        NewLoweredDispAcc = [DispEntry | LoweredDispAcc]
+    ;   kernel_layout_enabled(Options),
         catch(wam_r_kernel_detect(Pred, Kernel), _, fail),
         catch(emit_kernel(P, Kernel, KData, KFunc, KFuncName), _, fail)
     ->  (   KData == ""
@@ -945,6 +968,61 @@ emit_kernel(Pred, recursive_kernel(astar_shortest_path4, _, ConfigOps),
 
 astar_dist_pred_name(Name/_Arity, Name) :- atom(Name), !.
 astar_dist_pred_name(Name, Name) :- atom(Name).
+
+% ============================================================================
+% EXTERNAL FACT SOURCES
+% ============================================================================
+%
+% Mirrors the Scala target's scala_fact_sources option: users
+% declare `r_fact_sources([source(P/A, file('data.csv')), ...])`
+% and the codegen wires up a runtime CSV loader that populates the
+% standard fact-table data structures (`<pred>_facts` /
+% `<pred>_index`) at program-load time. The predicate then
+% dispatches via the same fact_table_dispatch path used by
+% inline-clause fact tables (PR #1921).
+%
+% The external-source path WINS over Prolog clause compilation:
+% the predicate's body is replaced by a single
+% `Execute("P", A)` instruction that falls through to the
+% lowered_dispatch tier (which the codegen registers below). No
+% Prolog clauses are required for the predicate.
+
+r_fact_source_spec(P, Arity, Options, Spec) :-
+    option(r_fact_sources(Sources), Options, []),
+    member(source(PI, Spec), Sources),
+    fact_source_pi_match(PI, P, Arity).
+
+fact_source_pi_match(_:Name/Ar, P, Arity) :- !,
+    Name == P, Ar =:= Arity.
+fact_source_pi_match(Name/Ar, P, Arity) :-
+    Name == P, Ar =:= Arity.
+
+%% emit_external_fact_source(+P, +Arity, +Spec,
+%%                            -DataDecl, -LoweredFunc, -FuncName)
+%  Emits the CSV loader + fact-iter dispatch fn. Spec must be
+%  file('path') for now; future shapes (LMDB, gzipped tables, ...)
+%  can branch here.
+emit_external_fact_source(Pred, Arity, file(Path),
+                          DataDecl, LoweredFunc, FuncName) :-
+    r_pred_name(Pred, RName),
+    format(atom(DataName), '~w_facts', [RName]),
+    format(atom(IndexName), '~w_index', [RName]),
+    format(atom(FuncName), '~w_fact_iter', [RName]),
+    atom_string(Path, PathStr),
+    r_string_literal(PathStr, PathLit),
+    format(string(DataDecl),
+'# External fact source for ~w/~w (file: ~w)
+~w <- WamRuntime$read_facts_csv(~w, intern_table)
+~w <- WamRuntime$build_fact_index(~w)',
+        [Pred, Arity, PathStr, DataName, PathLit, IndexName, DataName]),
+    fact_args_collect(Arity, ArgsCollect),
+    format(string(LoweredFunc),
+'~w <- function(program, state) {
+  args <- ~w
+  WamRuntime$fact_table_dispatch(program, state, "~w/~w", ~w, ~w,
+                                  args, state$pc + 1L)
+}',
+        [FuncName, ArgsCollect, Pred, Arity, DataName, IndexName]).
 
 % ============================================================================
 % FACT-TABLE CLASSIFICATION + EMISSION

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -2898,6 +2898,72 @@ WamRuntime$fact_table_dispatch <- function(program, state, key, tuples, index,
   WamRuntime$fact_table_iter(program, state, key, tuples, args, 1L, resume_pc)
 }
 
+# ----------------------------------------------------------
+# External fact-source loaders
+# ----------------------------------------------------------
+# Reads a CSV file and parses each line into a fact tuple. Each
+# field is trimmed; if it parses as a finite numeric and lands on
+# an integer it becomes IntTerm, on a non-integer FloatTerm,
+# otherwise it interns as an atom. Lines that are blank or start
+# with `#` are skipped. Returns a list of tuple-lists matching
+# the shape consumed by fact_table_dispatch.
+#
+# Used by the codegen-emitted `<pred>_facts <-
+# WamRuntime$read_facts_csv(...)` block when a predicate has an
+# r_fact_sources([source(P/A, file(...))]) declaration. The
+# parsing happens at program-load time, not per-query.
+WamRuntime$read_facts_csv <- function(path, intern_table) {
+  if (!file.exists(path)) return(list())
+  lines <- tryCatch(readLines(path, warn = FALSE),
+                    error = function(e) character(0))
+  out <- list()
+  for (raw in lines) {
+    line <- gsub("^\\s+|\\s+$", "", raw)
+    if (nchar(line) == 0L) next
+    if (substr(line, 1L, 1L) == "#") next
+    parts <- strsplit(line, ",", fixed = TRUE)[[1]]
+    parts <- trimws(parts)
+    tuple <- lapply(parts, function(p) {
+      n <- suppressWarnings(as.numeric(p))
+      if (!is.na(n) && is.finite(n)) {
+        if (n == as.integer(n) && abs(n) < .Machine$integer.max) {
+          IntTerm(as.integer(n))
+        } else {
+          FloatTerm(as.numeric(n))
+        }
+      } else {
+        Atom(WamRuntime$intern(intern_table, p))
+      }
+    })
+    out <- c(out, list(tuple))
+  }
+  out
+}
+
+# Build the first-arg hash index for a runtime-loaded fact table.
+# Same index shape as the codegen-emitted `<pred>_index <-
+# new.env(...); assign("a<id>", c(...))` blocks for inline fact
+# tables: keys are "a<atom-id>" / "i<int-value>", values are
+# integer vectors of 1-based tuple indices.
+WamRuntime$build_fact_index <- function(facts) {
+  idx <- new.env(parent = emptyenv())
+  for (i in seq_along(facts)) {
+    tuple <- facts[[i]]
+    if (length(tuple) < 1L) next
+    first <- tuple[[1L]]
+    if (is.null(first) || !is.list(first) || is.null(first$tag)) next
+    bk <- if (first$tag == "atom") paste0("a", first$id)
+          else if (first$tag == "int") paste0("i", first$val)
+          else NULL
+    if (is.null(bk)) next
+    existing <- if (exists(bk, envir = idx, inherits = FALSE)) {
+      get(bk, envir = idx, inherits = FALSE)
+    } else integer(0)
+    assign(bk, c(existing, as.integer(i)), envir = idx)
+  }
+  idx
+}
+
 # Enumerable iteration over a list of WAM terms, used by member/2 (and
 # any future enumerator with the same shape). Tries to unify `target`
 # with each element starting at `start_idx`. On success, pushes an iter

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2857,6 +2857,79 @@ e2e_kernel_astar4_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for external fact sources via CSV. The
+% predicate has no Prolog clauses; the codegen emits a runtime
+% loader that reads the file at program-init time and dispatches
+% via the same fact_table_dispatch path used by inline fact tables
+% (PR #1921). The CLI hits the loader through a 1-instruction
+% Execute body that falls into lowered_dispatch.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(external_fact_source_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_external_fact_source_via_rscript
+    ;   true
+    )).
+
+e2e_external_fact_source_via_rscript :-
+    retractall(user:cpedge(_, _)),
+    retractall(user:fs_check/0),
+    unique_r_tmp_dir('tmp_r_csv_fact_e2e', TmpDir),
+    make_directory_path(TmpDir),
+    directory_file_path(TmpDir, 'cpedge.csv', CsvPath),
+    atom_string(CsvPath, CsvPathStr),
+    setup_call_cleanup(
+        open(CsvPath, write, Stream),
+        ( write(Stream, '# Auto-generated for the CSV fact-source test.'),
+          nl(Stream),
+          write(Stream, 'alice,bob'), nl(Stream),
+          write(Stream, 'bob,carol'), nl(Stream),
+          write(Stream, 'carol,dan'), nl(Stream),
+          write(Stream, 'alice,eve'), nl(Stream),
+          write(Stream, 'eve,frank'), nl(Stream) ),
+        close(Stream)),
+    % cpedge/2 has no clauses; the loader populates pred_cpedge_facts.
+    assertz((user:fs_direct  :- cpedge(alice, bob))),
+    assertz((user:fs_branch  :- cpedge(alice, eve))),
+    assertz((user:fs_no_back :- cpedge(bob, alice))),
+    assertz((user:fs_findall :-
+        findall(Y, cpedge(alice, Y), L),
+        msort(L, S),
+        S == [bob, eve])),
+    assertz((user:fs_findall_all :-
+        findall(X-Y, cpedge(X, Y), L),
+        length(L, N),
+        N == 5)),
+    write_wam_r_project(
+        [user:cpedge/2, user:fs_direct/0, user:fs_branch/0,
+         user:fs_no_back/0, user:fs_findall/0, user:fs_findall_all/0],
+        [intern_atoms([alice, bob, carol, dan, eve, frank]),
+         r_fact_sources([source(cpedge/2, file(CsvPathStr))])],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [fs_direct, fs_branch, fs_findall, fs_findall_all],
+    No  = [fs_no_back],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    directory_file_path(TmpDir, 'R/generated_program.R', ProgPath),
+    read_file_to_string(ProgPath, Code, []),
+    assertion(sub_string(Code, _, _, _, '# External fact source for cpedge/2')),
+    assertion(sub_string(Code, _, _, _,
+        'pred_cpedge_facts <- WamRuntime$read_facts_csv(')),
+    assertion(sub_string(Code, _, _, _,
+        'assign("cpedge/2", pred_cpedge_fact_iter, envir = shared_program$lowered_dispatch)')),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
## Summary

Mirrors the Scala target's `scala_fact_sources` option. Users can now declare a predicate's facts as a separate CSV file:

```prolog
write_wam_r_project(
    [user:cp/2, ...],
    [intern_atoms([alice, bob, ...]),
     r_fact_sources([source(cp/2, file('data.csv'))])],
    ProjectDir).
```

The predicate has **no Prolog clauses** -- the codegen emits a runtime CSV loader that reads the file at program-init time and populates the standard fact-table data structures (`<pred>_facts` / `<pred>_index`). The predicate then dispatches via the same `fact_table_dispatch` path used by inline-clause fact tables (PR #1921), so first-arg hash indexing, multi-solution backtracking, and `iterate_goal` integration all work the same way.

## Pieces

| Layer | What's new |
|---|---|
| `runtime.R.mustache` | `WamRuntime$read_facts_csv` parses each line with comma-split + numeric-vs-atom detection (`#`-comment / blank-line skip); `build_fact_index` builds the same first-arg `"a<id>"` / `"i<val>"` hash the inline path uses. |
| `wam_r_target.pl` | `r_fact_source_spec/4` looks up a predicate in the `r_fact_sources` option; `emit_external_fact_source/6` renders the loader + index + dispatch fn. `compile_all_predicates` wires the external-source path **before WAM compilation** so the predicate can have no Prolog clauses; the body is a single `Execute("P", A)` instruction that falls through to `lowered_dispatch`. |
| `docs/WAM_R_TARGET.md` | New section under fact-table lowering with the API shape, CSV format rules, `intern_atoms` guidance, CLI dispatch path. |

## CSV format

- One row per fact, comma-separated.
- Lines starting with `#` and blank lines are skipped.
- Fields that parse as a finite numeric become `IntTerm` / `FloatTerm`.
- Everything else interns as an atom.

For atoms that don't appear in any compiled WAM body but are needed by the loaded facts, declare them via `intern_atoms(...)` so the intern table includes them at startup.

## Test plan

- [x] `external_fact_source_e2e_rscript` (new): round trip -- write a CSV at test setup, generate the project, run direct queries (positive + negative), `findall` enumeration over selected source, full-table `findall`, assertions on the generated loader / dispatch lines.
- [x] Full suite: 54 tests pass.

## Not yet ported

The Scala target also has sidecar backends for LMDB and grouped-by-first TSV files. Those are all `fact_source_spec_to_*` clauses in `wam_scala_target.pl` and can be ported in follow-up PRs if the workload justifies them.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_