### PR TITLE
feat(wam-clojure): lower arithmetic equality builtins

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -272,6 +272,14 @@ clojure_direct_builtin("\\=/2", "2").
 clojure_direct_builtin("\\=/2", 2).
 clojure_direct_builtin('\\=/2', "2").
 clojure_direct_builtin('\\=/2', 2).
+clojure_direct_builtin("=:=/2", "2").
+clojure_direct_builtin("=:=/2", 2).
+clojure_direct_builtin('=:=/2', "2").
+clojure_direct_builtin('=:=/2', 2).
+clojure_direct_builtin("=\\=/2", "2").
+clojure_direct_builtin("=\\=/2", 2).
+clojure_direct_builtin('=\\=/2', "2").
+clojure_direct_builtin('=\\=/2', 2).
 clojure_direct_builtin("true/0", "0").
 clojure_direct_builtin("true/0", 0).
 clojure_direct_builtin('true/0', "0").
@@ -448,6 +456,20 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr),
            '(let [left (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound) right (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound)] (if (runtime/unifiable? ~w left right) (runtime/backtrack ~w) (runtime/advance ~w)))',
            [S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "=:=/2" ; Op == '=:=/2'),
+    !,
+    format(atom(Expr),
+           '(let [left (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) right (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound))] (if (runtime/arithmetic-equal? ~w left right) (runtime/advance ~w) (runtime/backtrack ~w)))',
+           [S, S, S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "=\\=/2" ; Op == '=\\=/2'),
+    !,
+    format(atom(Expr),
+           '(let [left (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) right (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound))] (if (runtime/arithmetic-not-equal? ~w left right) (runtime/advance ~w) (runtime/backtrack ~w)))',
+           [S, S, S, S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "true/0" ; Op == 'true/0'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -364,6 +364,30 @@
 (defn unifiable? [state left right]
   (first (unify-values state left right)))
 
+(defn parse-numeric-atom [text]
+  (when (and (string? text)
+             (re-matches #"[+-]?(?:\d+(?:\.\d*)?|\.\d+)" text))
+    (if (str/includes? text ".")
+      (Double/parseDouble text)
+      (Long/parseLong text))))
+
+(defn arithmetic-value [state value]
+  (let [cur (deref-value (:bindings state) value)]
+    (cond
+      (number? cur) cur
+      (atom-term? cur) (parse-numeric-atom (deintern-atom (:intern-context state) (:id cur)))
+      :else nil)))
+
+(defn arithmetic-equal? [state left right]
+  (let [left* (arithmetic-value state left)
+        right* (arithmetic-value state right)]
+    (and (some? left*) (some? right*) (== left* right*))))
+
+(defn arithmetic-not-equal? [state left right]
+  (let [left* (arithmetic-value state left)
+        right* (arithmetic-value state right)]
+    (and (some? left*) (some? right*) (not (== left* right*)))))
+
 (defn structure-term [functor args]
   {:tag :struct :functor functor :args (vec args)})
 
@@ -826,6 +850,24 @@
             (if (unifiable? state left right)
               (backtrack state)
               (advance state)))
+
+          "=:=/2"
+          (let [left (deref-value (:bindings state)
+                                  (or (reg-get-raw state "A1") ::unbound))
+                right (deref-value (:bindings state)
+                                   (or (reg-get-raw state "A2") ::unbound))]
+            (if (arithmetic-equal? state left right)
+              (advance state)
+              (backtrack state)))
+
+          "=\\=/2"
+          (let [left (deref-value (:bindings state)
+                                  (or (reg-get-raw state "A1") ::unbound))
+                right (deref-value (:bindings state)
+                                   (or (reg-get-raw state "A2") ::unbound))]
+            (if (arithmetic-not-equal? state left right)
+              (advance state)
+              (backtrack state)))
 
           "true/0"
           (advance state)

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -107,6 +107,8 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, ':jump-pc')),
         assertion(sub_string(RuntimeCode, _, _, _, ':builtin-call')),
         assertion(sub_string(RuntimeCode, _, _, _, '"\\\\=/2"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"=:=/2"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"=\\\\=/2"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"fail/0"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"atom/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"integer/1"')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -146,6 +146,26 @@ test(simple_builtin_not_unify_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/backtrack")
     )).
 
+test(simple_builtin_arithmetic_equal_is_direct_lowered_in_prefix) :-
+    once((
+        lower_predicate_to_clojure(test_arith_eq/2, [builtin_call('=:=/2', 2), proceed], [], Code),
+        has(Code, "runtime/reg-get-raw"),
+        has(Code, "\"A1\""),
+        has(Code, "\"A2\""),
+        has(Code, "runtime/arithmetic-equal?"),
+        has(Code, "runtime/backtrack")
+    )).
+
+test(simple_builtin_arithmetic_not_equal_is_direct_lowered_in_prefix) :-
+    once((
+        lower_predicate_to_clojure(test_arith_neq/2, [builtin_call('=\\=/2', 2), proceed], [], Code),
+        has(Code, "runtime/reg-get-raw"),
+        has(Code, "\"A1\""),
+        has(Code, "\"A2\""),
+        has(Code, "runtime/arithmetic-not-equal?"),
+        has(Code, "runtime/backtrack")
+    )).
+
 test(simple_builtin_true_is_direct_lowered_in_prefix) :-
     once((
         lower_predicate_to_clojure(test_true/0, [builtin_call('true/0', 0), proceed], [], Code),

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -58,6 +58,10 @@
 :- dynamic user:wam_ground_guard/1.
 :- dynamic user:wam_ground_unbound/1.
 :- dynamic user:wam_ground_nested_unbound/1.
+:- dynamic user:wam_arith_eq_42/1.
+:- dynamic user:wam_arith_eq_float/1.
+:- dynamic user:wam_arith_neq_42/1.
+:- dynamic user:wam_arith_eq_unbound/1.
 
 has(Code, Substr) :-
     once(sub_string(Code, _, _, _, Substr)).
@@ -118,6 +122,10 @@ user:wam_is_list_unbound(_) :- user:wam_unbound_arg(Y), is_list(Y).
 user:wam_ground_guard(X) :- ground(X).
 user:wam_ground_unbound(_) :- user:wam_unbound_arg(Y), ground(Y).
 user:wam_ground_nested_unbound(_) :- user:wam_unbound_arg(Y), ground(f(Y)).
+user:wam_arith_eq_42(X) :- X =:= 42.
+user:wam_arith_eq_float(X) :- X =:= 3.5.
+user:wam_arith_neq_42(X) :- X =\= 42.
+user:wam_arith_eq_unbound(_) :- user:wam_unbound_arg(Y), Y =:= 42.
 
 :- initialization(main, main).
 
@@ -182,7 +190,11 @@ run_smoke :-
           user:wam_is_list_unbound/1,
           user:wam_ground_guard/1,
           user:wam_ground_unbound/1,
-          user:wam_ground_nested_unbound/1
+          user:wam_ground_nested_unbound/1,
+          user:wam_arith_eq_42/1,
+          user:wam_arith_eq_float/1,
+          user:wam_arith_neq_42/1,
+          user:wam_arith_eq_unbound/1
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
@@ -212,6 +224,7 @@ run_smoke :-
     assert_lowered_float_builtin_emitted(TmpDir),
     assert_lowered_is_list_builtin_emitted(TmpDir),
     assert_lowered_ground_builtin_emitted(TmpDir),
+    assert_lowered_arithmetic_comparison_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
     verify_output(TmpDir, 'wam_execute_caller/1', 'a', "true"),
     verify_output(TmpDir, 'wam_execute_caller/1', 'b', "false"),
@@ -314,6 +327,12 @@ run_smoke :-
     verify_output(TmpDir, 'wam_ground_guard/1', '[a,b]', "true"),
     verify_output(TmpDir, 'wam_ground_unbound/1', a, "false"),
     verify_output(TmpDir, 'wam_ground_nested_unbound/1', a, "false"),
+    verify_output(TmpDir, 'wam_arith_eq_42/1', 42, "true"),
+    verify_output(TmpDir, 'wam_arith_eq_42/1', 3.5, "false"),
+    verify_output(TmpDir, 'wam_arith_eq_float/1', 3.5, "true"),
+    verify_output(TmpDir, 'wam_arith_neq_42/1', 3.5, "true"),
+    verify_output(TmpDir, 'wam_arith_neq_42/1', 42, "false"),
+    verify_output(TmpDir, 'wam_arith_eq_unbound/1', a, "false"),
     delete_directory_and_contents(TmpDir),
     writeln('wam_clojure_runtime_smoke: ok').
 
@@ -451,6 +470,16 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-ground-unbound-1"),
     has(CoreCode, "defn lowered-wam-ground-nested-unbound-1"),
     has(CoreCode, "runtime/ground-term?").
+
+assert_lowered_arithmetic_comparison_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-arith-eq-42-1"),
+    has(CoreCode, "defn lowered-wam-arith-eq-float-1"),
+    has(CoreCode, "defn lowered-wam-arith-neq-42-1"),
+    has(CoreCode, "defn lowered-wam-arith-eq-unbound-1"),
+    has(CoreCode, "runtime/arithmetic-equal?"),
+    has(CoreCode, "runtime/arithmetic-not-equal?").
 
 assert_multiclause_wrappers_runtime_mediated(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds direct Clojure WAM lowered support for `=:=/2` and `=\=/2`.
- Adds runtime dispatch fallback for both arithmetic equality builtins.
- Adds arithmetic coercion for generated WAM numeric constants represented as interned atom literals, such as `"42"` and `"3.5"`.
- Supports raw EDN numeric inputs and generated numeric constants through shared runtime helpers.
- Adds lowered-emitter, generator, and runtime smoke coverage for equality, inequality, floats, unequal numeric values, and unbound-variable failure.

## Why

The Clojure WAM target now has broad direct lowering for unary guards. Arithmetic equality and inequality are the next low-risk comparison builtins to lower because they only require numeric evaluation of the two argument registers and do not introduce ordering semantics yet.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
