### PR TITLE
Add Lua WAM indexed atom fact dispatch

### DIFF
--- a/src/unifyweaver/targets/wam_lua_target.pl
+++ b/src/unifyweaver/targets/wam_lua_target.pl
@@ -261,6 +261,10 @@ wam_parts_to_lua(["builtin_call", Pred, ArityStr], Lit) :-
 wam_parts_to_lua(["call_foreign", Pred, ArityStr], Lit) :-
     number_string(Arity, ArityStr), lua_string_literal(Pred, P),
     format(string(Lit), 'I.CallForeign(~w, ~w)', [P, Arity]).
+wam_parts_to_lua(["call_indexed_atom_fact2", Pred], Lit) :-
+    strip_operand_comma(Pred, CleanPred),
+    lua_string_literal(CleanPred, P),
+    format(string(Lit), 'I.CallIndexedAtomFact2(~w)', [P]).
 wam_parts_to_lua(["arg", NStr, RegStr, OutRegStr], Lit) :-
     number_string(N, NStr), reg_to_int(RegStr, R), reg_to_int(OutRegStr, O),
     format(string(Lit), 'I.ArgInstr(~w, ~w, ~w)', [N, R, O]).

--- a/templates/targets/lua_wam/program.lua.mustache
+++ b/templates/targets/lua_wam/program.lua.mustache
@@ -34,6 +34,7 @@ local shared_program = {
   labels = shared_labels,
   dispatch = dispatch,
   foreign_handlers = foreign_handlers,
+  indexed_atom_fact2 = {},
   intern_table = intern_table
 }
 Runtime.resolve_program(shared_program)

--- a/templates/targets/lua_wam/runtime.lua.mustache
+++ b/templates/targets/lua_wam/runtime.lua.mustache
@@ -35,6 +35,7 @@ function I.SetValue(xn) return instr("SetValue", { xn = xn }) end
 function I.SetConstant(c) return instr("SetConstant", { c = c }) end
 function I.Call(p, n) return instr("Call", { pred = p, arity = n }) end
 function I.CallPc(pc, n) return instr("CallPc", { pc = pc, arity = n }) end
+function I.CallIndexedAtomFact2(p) return instr("CallIndexedAtomFact2", { pred = p }) end
 function I.Execute(p, n) return instr("Execute", { pred = p, arity = n }) end
 function I.ExecutePc(pc) return instr("ExecutePc", { pc = pc }) end
 function I.CallForeign(p, n) return instr("CallForeign", { pred = p, arity = n }) end
@@ -112,6 +113,21 @@ function Runtime.copy_term(state, v, seen)
   if v.tag == "float" then return V.Float(v.val) end
   if v.tag == "unbound" then return V.Unbound(v.name) end
   return v
+end
+
+function Runtime.register_indexed_atom_fact2_pairs(program, pred, pairs)
+  program.indexed_atom_fact2 = program.indexed_atom_fact2 or {}
+  local table_for_pred = program.indexed_atom_fact2[pred] or {}
+  program.indexed_atom_fact2[pred] = table_for_pred
+  for _, pair in ipairs(pairs or {}) do
+    local left = tostring(pair[1])
+    local right = tostring(pair[2])
+    Runtime.intern(program.intern_table, left)
+    Runtime.intern(program.intern_table, right)
+    local values = table_for_pred[left] or {}
+    table_for_pred[left] = values
+    table.insert(values, right)
+  end
 end
 
 function Runtime.new_state()
@@ -222,6 +238,26 @@ function Runtime.backtrack(state)
   if n == 0 then return false end
   local cp = state.cps[n]
   if cp == nil then return false end
+  if cp.kind == "indexed_atom_fact2" then
+    while #state.trail > cp.trail_len do
+      local name = table.remove(state.trail)
+      state.bindings[name] = nil
+    end
+    state.regs = Runtime.copy_table(cp.regs)
+    state.cp = cp.cp
+    state.var_counter = cp.var_counter
+    state.mode = cp.mode
+    state.build_stack = cp.build_stack or {}
+    local value = table.remove(cp.values, 1)
+    if #cp.values == 0 then table.remove(state.cps) end
+    local atom = V.Atom(Runtime.intern(cp.table, value))
+    if Runtime.unify(state, Runtime.get_reg(state, 2), atom) ~= true then
+      return Runtime.backtrack(state)
+    end
+    state.pc = cp.next_pc
+    state.halt = false
+    return true
+  end
   if cp.kind == "aggregate" then
     table.remove(state.cps)
     while #state.trail > cp.trail_len do
@@ -380,6 +416,36 @@ end
 
 local function call_key(instr)
   return instr.pred .. "/" .. tostring(instr.arity)
+end
+
+local function call_indexed_atom_fact2(program, state, instr)
+  local key_term = Runtime.deref(state, Runtime.get_reg(state, 1))
+  if type(key_term) ~= "table" or key_term.tag ~= "atom" then return false end
+  local key = Runtime.string_of(program.intern_table, key_term.id)
+  local values = program.indexed_atom_fact2
+      and program.indexed_atom_fact2[instr.pred]
+      and program.indexed_atom_fact2[instr.pred][key]
+  if values == nil or #values == 0 then return false end
+  if #values > 1 then
+    local rest = {}
+    for i = 2, #values do rest[#rest + 1] = values[i] end
+    table.insert(state.cps, {
+      kind = "indexed_atom_fact2",
+      next_pc = state.pc + 1,
+      regs = Runtime.copy_table(state.regs),
+      cp = state.cp,
+      trail_len = #state.trail,
+      var_counter = state.var_counter,
+      mode = state.mode,
+      build_stack = state.build_stack,
+      table = program.intern_table,
+      values = rest
+    })
+  end
+  local atom = V.Atom(Runtime.intern(program.intern_table, values[1]))
+  if Runtime.unify(state, Runtime.get_reg(state, 2), atom) ~= true then return false end
+  state.pc = state.pc + 1
+  return true
 end
 
 local function resolve_switch_cases(labels, cases)
@@ -581,6 +647,7 @@ function Runtime.step(program, state, instr)
     state.pc = target
     return true
   end
+  if op == "CallIndexedAtomFact2" then return call_indexed_atom_fact2(program, state, instr) end
   if op == "CallPc" then
     state.cp = state.pc + 1
     state.pc = instr.pc

--- a/tests/test_wam_lua_generator.pl
+++ b/tests/test_wam_lua_generator.pl
@@ -92,6 +92,7 @@ test(instructions_and_labels) :-
           assertion(sub_string(Code, _, _, _, 'local intern_seed = {')),
           assertion(sub_string(Code, _, _, _, 'local shared_instructions = {')),
           assertion(sub_string(Code, _, _, _, 'Runtime.resolve_program(shared_program)')),
+          assertion(sub_string(Code, _, _, _, 'indexed_atom_fact2 = {}')),
           assertion(sub_string(Code, _, _, _, 'I.GetConstant(V.Atom(')),
           assertion(sub_string(Code, _, _, _, '["wam_lua_fact/1"] = 1'))
         ),
@@ -123,6 +124,32 @@ test(aggregate_and_second_arg_switch_emitted) :-
           assertion(sub_string(Code, _, _, _, 'I.BeginAggregate("collect"')),
           assertion(sub_string(Code, _, _, _, 'I.EndAggregate(')),
           assertion(sub_string(Code, _, _, _, 'I.SwitchOnConstantA2('))
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(call_indexed_atom_fact2_literal) :-
+    once(wam_parts_to_lua(["call_indexed_atom_fact2", "edge/2"], [], Lit)),
+    assertion(Lit == "I.CallIndexedAtomFact2(\"edge/2\")").
+
+test(lua_indexed_atom_fact2_e2e, [condition(lua_available)]) :-
+    unique_lua_tmp_dir('tmp_lua_indexed_fact2_e2e', TmpDir),
+    setup_call_cleanup(
+        write_wam_lua_project([user:wam_lua_fact/1], [], TmpDir),
+        ( directory_file_path(TmpDir, 'lua', LuaDir),
+          atomic_list_concat([
+              'local rt=require("wam_runtime"); ',
+              'local R=rt.Runtime; local V=rt.V; local I=rt.I; ',
+              'local p={instructions={I.CallIndexedAtomFact2("edge/2"),I.Proceed()}, labels={["idx/2"]=1}, indexed_atom_fact2={}, intern_table=R.new_intern_table({"true","fail","[]",".","","[|]"})}; ',
+              'R.register_indexed_atom_fact2_pairs(p, "edge/2", {{"a","b"},{"a","c"}}); ',
+              'local function atom(s) return V.Atom(R.intern(p.intern_table,s)) end; ',
+              'print(R.run_predicate(p,1,{atom("a"),atom("b")})); ',
+              'print(R.run_predicate(p,1,{atom("a"),atom("c")})); ',
+              'print(R.run_predicate(p,1,{atom("a"),atom("d")}))'
+          ], Script),
+          run_lua_script(LuaDir, Script, Output),
+          normalize_space(string(Trimmed), Output),
+          assertion(Trimmed == "true true false")
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

- Add Lua WAM codegen support for the `call_indexed_atom_fact2` instruction.
- Add `I.CallIndexedAtomFact2(pred)` and Lua runtime handling that indexes on atom `A1`, unifies `A2`, and backtracks over alternate indexed values.
- Add `indexed_atom_fact2` storage to generated Lua programs plus `Runtime.register_indexed_atom_fact2_pairs` for Rust/Python-style pair registration.
- Add focused Lua generator/runtime tests for literal emission, generated index storage, and multi-solution indexed fact dispatch.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`

## Notes

This closes the Lua indexed binary atom fact dispatch gap against the Rust/Python WAM runtimes. Haskell-style `CallFactStream`/external `FactSource` support remains a broader follow-up.
