### PR TITLE
WAM-R: per-arg fact-table indexes + design doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,7 @@ training-data/
 # Sandbox folders
 sandbox/
 CLAUDE.md
+memory.md
 
 # Local tools and subprojects (optional, not in repo)
 .local/

--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -295,6 +295,12 @@ selective dispatch on any ground arg (not just the first).
 Disable per-call with `fact_table_layout(off)` in Options, or
 globally via the multifile `user:wam_r_fact_layout(off)` fact.
 
+For the design rationale -- per-arg vs. composite indexes,
+smallest-bucket selection, alternatives ruled out (composite,
+successive hashing, bitmap intersection), and how this aligns
+with the parameterized C# query runtime -- see
+[`design/WAM_R_FACT_INDEXING.md`](design/WAM_R_FACT_INDEXING.md).
+
 ### External fact sources (CSV)
 
 Mirrors the Scala target's `scala_fact_sources` option. Users can

--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -269,16 +269,28 @@ globally via `user:wam_r_kernel_layout(off)`.
 Predicates whose every clause is just `get_constant + proceed` are
 classified as pure fact tables and lowered to a flat R list of arg
 tuples plus a one-line dispatch function -- the WAM stepping
-engine isn't entered at all. A first-arg hash index (an R env
-keyed by `"a<atom-id>"` / `"i<int-val>"`) routes ground-arg
-queries to a bucket lookup; unground first args fall back to a
-linear scan over the full tuple list.
+engine isn't entered at all. **Per-arg hash indexes** (one R env
+per arg position, each keyed by `"a<atom-id>"` / `"i<int-val>"`)
+route any ground arg to a bucket lookup; the dispatcher picks the
+smallest matching bucket among bound atom/int args (most
+selective) and iterates just that bucket, with per-tuple unify
+filtering the rest of the conditions. A query with all args
+unbound (or all bound to floats / structs) falls back to a linear
+scan over the full tuple list.
+
+Memory: O(N · F) for F facts and arity N -- per-arg, not per-arg-
+*combination*, so no `2^N` composite-key blowup. Each fact
+contributes at most one entry per arg position. The codegen emits
+`<pred>_index_arg<K>` envs (K = 1..N) bundled into
+`<pred>_indexes <- list(...)`; the runtime equivalent for
+externally-loaded facts is `WamRuntime$build_fact_indexes(facts,
+arity)`.
 
 The bench (`tests/benchmarks/wam_r_fact_source_bench.pl`) shows
 modest per-query wins (~10% at N=100 chains, querying the deepest
 element) over the WAM `switch_on_constant` path. The bigger wins
-are structural: codegen-time savings, simpler emitted R, and the
-infrastructure to build richer indexes (multi-arg, range) on top.
+are structural: codegen-time savings, simpler emitted R, and now
+selective dispatch on any ground arg (not just the first).
 
 Disable per-call with `fact_table_layout(off)` in Options, or
 globally via the multifile `user:wam_r_fact_layout(off)` fact.
@@ -299,9 +311,9 @@ declare a predicate's facts as a separate CSV file:
 The predicate has **no Prolog clauses** -- the codegen emits a
 runtime CSV loader that reads the file at program-init time and
 populates the standard fact-table data structures
-(`<pred>_facts` / `<pred>_index`). The predicate then dispatches
+(`<pred>_facts` / `<pred>_indexes`). The predicate then dispatches
 via the same `fact_table_dispatch` path used by inline-clause
-fact tables (PR #1921), so first-arg hash indexing, multi-
+fact tables (PR #1921), so per-arg hash indexing, multi-
 solution backtracking, and `iterate_goal` integration all work
 the same way.
 
@@ -602,7 +614,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 54 tests covering both structural assertions on the
+and contains 55 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -642,6 +654,7 @@ Coverage map (e2e tests, by feature group):
 | `dcg_e2e_rscript` | DCG `-->` rules + `phrase/2,3` (recursive grammars, prefix-with-rest) |
 | `streams_e2e_rscript` | `open/3`, `close/1`, `read/2`, `write/2`, `writeln/2`, `format/3` round-trip |
 | `fact_table_e2e_rscript` | fact-table lowering: hash-indexed dispatch, multi-solution backtracking, atoms + integers |
+| `fact_table_multi_arg_index_e2e_rscript` | per-arg fact-table indexes: dispatch picks smallest matching bucket among bound atom/int args (arg2-only, arg3-only, multi-arg-bound queries) |
 | `kernel_tc2_e2e_rscript` | recursive-kernel detection: `transitive_closure2` BFS over a fact-table edge predicate |
 | `kernel_td3_e2e_rscript` | recursive-kernel detection: `transitive_distance3` BFS-with-depth over a fact-table edge predicate |
 | `kernel_wsp3_e2e_rscript` | recursive-kernel detection: `weighted_shortest_path3` Dijkstra over a weighted fact-table edge predicate |

--- a/docs/design/WAM_R_FACT_INDEXING.md
+++ b/docs/design/WAM_R_FACT_INDEXING.md
@@ -1,0 +1,435 @@
+# WAM-R Fact Table Indexing
+
+## Status
+
+**Implemented.** Per-arg hash indexes landed on the `claude/r-hybrid-wam-target-cMqaZ`
+branch (commit `907d979`). Generalises the first-arg-only hash index that
+shipped with PR #1921. Memory: O(N · F) for F facts, arity N. No composite-key
+indexes.
+
+This document records the design discussion: what we built, what alternatives we
+considered and ruled out, the theoretical context this slots into, and how it
+relates to the parameterized C# query runtime
+(`src/unifyweaver/targets/csharp_query_runtime/`), which has the most
+sophisticated query-engine-style code in the repo.
+
+> **Why a design doc for one PR?** The decision space here -- per-attribute
+> hashing, composite keys, successive hashing, bitmap intersection, smallest-
+> bucket selection -- is the same decision space mature query engines work in.
+> WAM-R is the second target (after the C# parameterized runtime) where the
+> engine has to make these choices, and it would be nice to keep the reasoning
+> in one place rather than re-deriving it the next time another target hits it.
+
+## TL;DR
+
+For each fact-table predicate `p/N`, the codegen now emits **N independent hash
+indexes**, one per arg position. Each index maps `(value -> integer-vector of
+matching tuple indices)`. At dispatch time, the runtime walks the bound atom/int
+args, looks each one up in its own index, **picks the smallest matching bucket**
+(the most selective bound arg), and iterates just that bucket. Per-tuple
+unification then filters on all the other args.
+
+The position of an arg is encoded **structurally** by which env you look in, not
+as part of the key. So `"aa"` in `arg1_env` and `"aa"` in `arg2_env` mean two
+totally different things, and there are no hash collisions between positions.
+
+Memory grows linearly in arity (`N × F` entries vs. `F` for first-arg only). It
+does **not** grow exponentially, because we only index single-arg keys -- not
+combinations of args.
+
+## What we built
+
+### Storage
+
+For a fact table with arity N and F ground tuples:
+
+- `<pred>_facts <- list( list(arg1, arg2, ..., argN), ... )` -- master tuple
+  list (unchanged).
+- `<pred>_index_arg<K> <- new.env(...)` for K = 1..N -- one R env per arg
+  position. Keys: `"a<atom-id>"` for atom-tag args, `"i<int-value>"` for
+  integer-tag args. Value: an R integer vector of 1-based tuple indices into
+  `<pred>_facts`.
+- `<pred>_indexes <- list(<pred>_index_arg1, ..., <pred>_index_argN)` -- the
+  bundle passed to `WamRuntime$fact_table_dispatch`.
+
+For runtime-loaded fact sources (CSV today, future LMDB / TSV), the equivalent
+runtime helper is `WamRuntime$build_fact_indexes(facts, arity)` which returns
+the same list-of-envs shape.
+
+Total entries across all indexes: at most `N × F`. Each fact contributes at
+most one entry per arg position (skipped at positions whose value isn't atom or
+int, e.g. floats, structs, unbounds at build time). Memory cost vs. the
+first-arg-only baseline: `N×` more entries.
+
+### Dispatch (`WamRuntime$fact_table_dispatch`)
+
+Pseudocode:
+
+```
+function dispatch(args, indexes, tuples):
+  best_bucket = NULL; best_size = +inf
+  for j in 1..arity:
+    if indexes[j] is NULL: continue
+    v = deref(args[j])
+    if v is unbound or struct: continue
+    bk = key_for(v)                # "a<id>" or "i<val>"; NULL for floats
+    if bk is NULL: continue
+    if not exists(bk in indexes[j]): return FALSE   # short-circuit
+    bucket = indexes[j][bk]
+    if size(bucket) < best_size:
+      best_bucket = bucket; best_size = size(bucket)
+  if best_bucket is not NULL:
+    return iter_subset(tuples, best_bucket, args)   # per-tuple unify
+  return iter_full(tuples, args)                    # no usable bound arg
+```
+
+Two important properties:
+
+1. **Short-circuit on miss.** If any bound atom/int arg's bucket is missing
+   from its index, no fact can possibly match the conjunction, so we return
+   FALSE without iterating. This is sound because: (a) the index contains
+   *every* fact whose arg has that tag at that position; (b) a missing bucket
+   means no fact has the queried value at that position; (c) the conjunction
+   "all bound args must match" is therefore unsatisfiable.
+
+2. **Smallest-bucket pick.** Any matching tuple must appear in *every* bound
+   arg's bucket (each bucket contains exactly the tuples matching that one
+   arg). So picking *any* bound arg's bucket is sound -- we just iterate fewer
+   tuples by picking the smallest one. This is the runtime equivalent of the
+   classic "build hash on smaller relation" hash-join heuristic.
+
+### Soundness sketch
+
+Let `B_j(v) = { i | tuples[i][j] = v }` be the set of tuple indices in arg `j`'s
+bucket for value `v`. For a query that binds args `j1, ..., jk` to values
+`v1, ..., vk`, the set of matching tuples is `B_{j1}(v1) ∩ ... ∩ B_{jk}(vk)`.
+
+Key observation: the matching set is a **subset** of every `B_{ji}(vi)`. So
+iterating any single `B_{ji}(vi)` and applying per-tuple unify (which checks
+all args) yields exactly the matching set. Picking the smallest `B` minimizes
+work. Q.E.D.
+
+## Alternatives considered
+
+### A. Composite-key indexes
+
+Keep a separate index for each subset of bound positions: `(arg1)`, `(arg2)`,
+`(arg1, arg2)`, `(arg1, arg3)`, ..., `(arg1, ..., argN)`. Lookup becomes O(1)
+hash for any binding pattern.
+
+**Why not:** `2^N - 1` indexes per fact table. Storage is exponential in arity.
+Build time is exponential in arity. Even at N = 6 you have 63 indexes per
+table. The "n-tuple problem" -- this is what the user flagged.
+
+**When it would be worth it:** if a workload heavily exercises *one* specific
+multi-arg binding pattern and per-arg buckets aren't selective enough. Then
+emit only the indexes for that pattern (workload-driven, opt-in). Mentioned in
+the future-directions section below; not the default.
+
+### B. Successive / rolling hash chain
+
+Hash incrementally over the args of a fact: `h0 = init; h1 = mix(h0, arg1);
+h2 = mix(h1, arg2); ...; hN`. Store `hN -> tuple_index` for exact-tuple
+lookup.
+
+**Why not:** breaks under partial bindings. A query with `arg2` unbound can't
+compute `h2 = mix(h1, arg2)`. You'd have to either (a) skip arg2 in the chain
+(producing a different hash sequence than facts that included it -- so they
+don't match), or (b) precompute every possible `h2`, which collapses back to
+the exponential case. Successive hashing works for primary-key style lookups
+where every arg is always bound, but doesn't generalize to "any subset bound."
+
+### C. Single env with composite (position, value) keys
+
+One R env keyed by strings like `"1:a"`, `"2:b"`, where the position is part
+of the key string instead of being implicit in env identity.
+
+**Why not chosen:** functionally equivalent to per-arg envs, but with longer
+keys (one extra string concat per lookup, slightly worse hash distribution
+because keys share a position-prefix). Per-arg envs avoid both. Same memory.
+
+### D. Bitmap intersection
+
+Maintain per-(position, value) bitmaps over tuple indices; for each query,
+AND-together the bitmaps for all bound args, then iterate the result.
+
+**Why not:** at F facts, each bitmap is ~F bits, so each AND is O(F)
+regardless of how selective the args are. The smallest-bucket pick is O(smallest
+bucket), which is strictly better when at least one arg is selective. Bitmaps
+win only when *all* bound args have very high cardinality buckets that need to
+be intersected -- an uncommon case for fact tables.
+
+### E. Sorted per-arg indexes (range-aware)
+
+Same as our approach but with sorted vectors per bucket, supporting range
+queries (`X > 5`, `X between A B`). Strict superset of what we did.
+
+**Why not yet:** range queries aren't a current pattern in WAM-R workloads,
+and the per-tuple-scan path handles them correctly (just slowly). Listed as
+a future direction.
+
+## Theoretical context
+
+### RDBMS indexing tradition
+
+What we did fits squarely in the **secondary-index** family from RDBMS theory:
+- One index per column (~ B-tree on a single column in PostgreSQL/SQLite).
+- Bucket-per-key shape (hash index, not sorted).
+- Pre-filter via index, post-filter via per-row predicate evaluation.
+
+Mature systems extend this with:
+- **Range / sorted indexes** (B+ tree) for `>`, `<`, `BETWEEN`. (Our future #8.)
+- **Composite / covering indexes** (`CREATE INDEX ON t(a, b)`) for high-
+  selectivity multi-column queries. Not exponential in practice because users
+  declare them per workload, not exhaustively.
+- **Cost-based index selection** during query planning. Picks the right index
+  before execution, using statistics. Our smallest-bucket pick is a runtime
+  shortcut: we can't pre-plan because the WAM emits a single dispatch
+  instruction per call without knowing arg cardinalities.
+- **Index intersection** for queries that can use multiple indexes (related to
+  bitmap intersection above; PostgreSQL's "BitmapAnd" plan node).
+
+The RDBMS tradition tells us: per-column indexes are the well-trodden default,
+composite indexes are workload-driven extras, and intersection/cost-based
+planning are the more elaborate add-ons. Our design lands at the well-trodden
+default.
+
+### Datalog evaluation tradition
+
+Datalog engines (Soufflé, LogicBlox, Coral, DLV, ...) typically:
+- Index every relation on every column where it appears as a join key
+  (roughly: per-attribute, like us).
+- Use **semi-naive evaluation** for recursive predicates, so each round only
+  scans newly-derived facts. Not applicable here -- WAM-R's recursive
+  predicates go through the kernel detector (BFS / Dijkstra / A*) which
+  bypasses the WAM stepper entirely; non-kernel recursion uses the WAM
+  interpreter loop with no semi-naive optimization.
+- Apply **magic-set transformation** to push selections through recursion,
+  effectively doing demand-driven evaluation. Not applicable here for the
+  same reason -- we don't have a Datalog query planner; WAM-R is interpreting
+  WAM bytecode that was emitted from Prolog clauses with their evaluation
+  order baked in.
+- Maintain **delta relations** for incremental view maintenance. Not
+  applicable -- our facts are static once loaded.
+
+The piece of Datalog tradition we directly use: per-attribute hash indexes
+to make the join probing fast. WAM-R doesn't have a join planner, but the
+WAM's choice-point machinery effectively does nested-loop joins, and per-arg
+indexes accelerate the inner loop.
+
+### Where this design sits
+
+On a spectrum from "no indexing" to "full cost-based query optimizer":
+
+```
+no indexing                                              Soufflé / Postgres
+| full table scan                                        | per-attribute index +
+                                                         | composite index +
+                                                         | range index +
+                                                         | cost-based join planning +
+                                                         | semi-naive eval +
+                                                         | magic-set transformation
+|                                                        |
+|              [WAM-R, after this PR]                    |
+|              per-attribute hash index                  |
+|              + smallest-bucket runtime pick            |
+|              + per-tuple unify post-filter             |
+|                                                        |
+v                                                        v
+0%                                                       100%
+```
+
+WAM-R is at "minimum viable per-attribute indexing" + a runtime selectivity
+heuristic. Each step further (range, composite, cardinality estimation,
+semi-naive, magic sets) is a future direction listed below.
+
+## Connection to the C# query runtimes
+
+The repo has three layers of C# code targeting different abstraction levels:
+
+| Layer | Path | What it does |
+|---|---|---|
+| Parameterized query runtime (current) | `src/unifyweaver/targets/csharp_query_runtime/` | Plan-execution runtime: takes IR plans (param_seed, materialize, KeyJoinNode, NegationNode, AggregateNode, ...), executes them over relation providers. Has indexing, cardinality, and join-planning hooks. |
+| Older non-parameterized native runtime | `src/unifyweaver/targets/csharp_native_runtime/` (`LinqRecursive.cs`) | Recursive-pattern helpers using LINQ. Predates the plan-based runtime. |
+| Generator-side bridge | `src/unifyweaver/targets/csharp_runtime/` (`custom_csharp.pl`) | Prolog-side custom-handler integration. Predates the structured query target. |
+
+The **parameterized query runtime** is the relevant comparison for WAM-R fact
+indexing -- it's the one place in the repo with a real query-engine-style
+indexing model.
+
+### Direct alignment
+
+The parameterized C# runtime implements essentially the same per-column
+indexing design we just landed:
+
+- **`IIndexedRelationProvider.TryLookupFacts(predicate, columnIndex, keys, ...)`**
+  (`QueryRuntime.cs:351`) -- single-column lookup, the C# analogue of
+  `WamRuntime$fact_table_dispatch`'s per-arg env lookup.
+- **`IIndexedRelationBucketProvider.TryReadIndexedBuckets(predicate, columnIndex, ...)`**
+  (`QueryRuntime.cs:362`) -- streams whole buckets for one column, the C#
+  analogue of "iterate this arg's bucket."
+- **Per-predicate per-column fact-index cache** (per the parameterized-queries
+  status doc): "uses cached per-predicate/per-column fact indices to pick a
+  selective bound pattern slot." That is *exactly* our smallest-bucket-pick
+  policy, in a runtime that also has joins and aggregates.
+
+### Where the C# runtime goes further
+
+Things the C# parameterized runtime does that we do not (yet) do in WAM-R:
+
+- **Manifest-level support for composite indexes.**
+  `DelimitedRelationArtifactIndexManifest.Columns` is `List<int>`, so the
+  artifact format can describe `(col1, col2)` indexes. The current writers
+  only emit single-column indexes, but the format is ready. (`QueryRuntime.cs:294`.)
+- **Two physical index kinds per column:** `offset_directory` (key -> file
+  offsets, on-disk) and `covering_bucket` (key -> the rows themselves,
+  amortizes I/O). WAM-R has only one in-memory shape (key -> integer vector
+  of indices into a master list).
+- **Cardinality-aware join build-side selection.**
+  `KeyJoinNode` (`QueryRuntime.cs:11748-11754`) chooses build-vs-probe side
+  based on `IRelationCardinalityProvider.TryGetRelationCardinality`. WAM-R
+  has no joins (the WAM does nested-loop joins via choice points) and no
+  cardinality estimation -- our runtime smallest-bucket pick is a poor man's
+  cardinality oracle that uses the actual bucket size as a proxy.
+- **Mode declarations** drive which indexes are needed. With `mode(p(+, -))`,
+  only arg1 is ever used as a query input, so only arg1's index is needed.
+  WAM-R doesn't yet do mode analysis, so we eagerly build indexes for all
+  args. Mode analysis is follow-up #4 in the WAM-R handoff.
+- **A real plan IR** (`param_seed`, `materialize`, `KeyJoinNode`,
+  `NegationNode`, `AggregateNode`, `AggregateSubplanNode`). WAM-R has no
+  plan layer -- the WAM bytecode *is* the plan, emitted directly by the
+  Prolog compiler, with whatever evaluation order the source clauses imply.
+
+### Where WAM-R goes further
+
+Things WAM-R does that the C# runtime does not:
+
+- **Full Prolog operational semantics**: choice points, backtracking,
+  cut, negation-as-failure on first-class WAM terms, dynamic predicates
+  (assertz/retract), exception handling. The C# runtime is a
+  declarative-Datalog evaluator extended with parameterized inputs; it
+  doesn't carry the full Prolog runtime weight. Different design point.
+
+- **Native R kernels** for graph traversal (BFS, Dijkstra, A*) that bypass
+  the WAM dispatch entirely. The C# runtime has the `KeyJoinNode` /
+  `AggregateNode` plan nodes for similar specialisation but does it through
+  the plan IR, not via runtime fast-path detection.
+
+These are different design axes; the indexing subsystem is one of the few
+places where the two converge on the same design.
+
+## Limitations and worst case
+
+### Things we explicitly accept
+
+1. **No composite indexes.** Queries that bind multiple args still iterate the
+   smallest single-arg bucket and post-filter. If two args are *individually*
+   non-selective but their conjunction is highly selective, we don't capture
+   that gain.
+
+2. **Floats not indexed.** Float-valued args are skipped at index-build time
+   (no bucket key), and float-valued query args fall through to the unbound
+   path (no bucket lookup, full scan). Acceptable because: (a) float equality
+   is fragile in general; (b) Prolog facts rarely use float keys.
+
+3. **Structs not indexed.** Compound terms (`f(a, b)`) at fact-arg positions
+   fall through to the unbound path. Indexing structs would require either
+   structural hashing or recursive decomposition; not justified by current
+   workloads.
+
+4. **No cardinality estimation at codegen time.** We could pre-compute and
+   emit `<pred>_index_arg1_size`, `<pred>_index_arg2_size`, ... at codegen
+   time and let dispatch pick by these statistics. Probably not worth it --
+   the runtime `length(bucket)` call is cheap.
+
+### Worst case
+
+When *all* bound atom/int args are non-selective (every fact has the same value
+at the queried positions), the smallest bucket is still O(F), so we scan
+everything. There's no win over the old first-arg-only design (which would
+have scanned for the same reason). The fundamental tradeoff: composite indexes
+could intersect multiple non-selective buckets to find selective subsets, at
+exponential storage cost. We prefer the linear-storage worst case.
+
+In practice, on the WAM-R workloads we care about (genealogy, graph traversal,
+benchmark fact lookups), at least one bound arg is highly selective and the
+smallest-bucket pick wins.
+
+## Future directions
+
+In rough priority order, with the most useful first:
+
+1. **Range / interval indexes (sorted per-arg).** Sort each per-arg bucket
+   key list at codegen time (or use a balanced BST at build time for runtime-
+   loaded sources). Adds support for `X > 5`, `X between A B` queries which
+   currently fall through to the per-tuple scan. Modest perf win on
+   range-heavy workloads. Listed as follow-up #8 in the WAM-R handoff.
+
+2. **Mode-driven index pruning.** When mode analysis arrives (handoff
+   follow-up #4), use the mode info to skip building indexes for positions
+   that will only ever be outputs. Saves O(F) memory per never-input
+   position. The C# parameterized runtime already does this via mode
+   declarations.
+
+3. **Workload-driven composite indexes.** A `r_fact_composite_index([p/3,
+   [1,2]])` directive would emit one extra `(arg1, arg2)` index for queries
+   that bind both. Opt-in, declared per-workload, so no exponential blowup
+   in the default case. Would need codegen for composite-key buckets and a
+   dispatch hook to use them when the right binding pattern shows up.
+
+4. **Codegen-time cardinality stats.** Emit `<pred>_arg<K>_max_bucket_size`
+   constants alongside the indexes. Dispatch could prefer args with smaller
+   *known* max-bucket size when bucket sizes tie at runtime. Marginal win;
+   useful if profiling shows the runtime `length()` is ever a hot path.
+
+5. **Bitmap representation for high-cardinality buckets.** When a bucket
+   exceeds some threshold (e.g. 50% of F), switch from `c(1L, 2L, 3L, ...)`
+   to a logical bitmap. Allows efficient AND-with-other-buckets fallback for
+   the worst-case scenario above. Adds complexity for an edge case.
+
+6. **Cross-target indexing IR.** Both the C# parameterized runtime and WAM-R
+   now emit per-column hash indexes. A shared Prolog-side description (e.g.
+   `index_spec(Pred, [hash(1), hash(2), hash(3)])`) consumed by both
+   targets would let workload-specific index choices be declared once and
+   honoured everywhere. Requires aligning the two indexing models more
+   carefully than they're aligned today.
+
+## Glossary
+
+- **Fact table** -- a Prolog predicate whose every clause is `get_constant +
+  proceed` only (no body, no compound args). The WAM-R classifier identifies
+  these and the codegen emits a flat tuple list + indexes instead of WAM
+  bytecode.
+- **Bucket** -- the integer vector under one key in one per-arg index; the
+  set of tuple indices that match that (position, value) pair.
+- **Selective** -- a bound arg whose bucket is small relative to the total
+  fact count. The runtime picks the most selective bound arg by bucket size.
+- **Per-tuple unify** -- the inner loop of `fact_table_iter_subset`: for each
+  candidate tuple from a bucket, run unification on every arg of the query
+  vs. every arg of the tuple. This is the post-filter that makes per-arg
+  indexes work without composite keys.
+- **Lowered dispatch** -- the WAM-R `program$lowered_dispatch` env consulted
+  by `Call` / `Execute` / `dispatch_call` before label dispatch. Fact tables
+  register here so internal Prolog-to-Prolog calls reach the indexed fast
+  path, not just direct R-API calls.
+
+## References
+
+- `WAM_R_TARGET.md` -- user-facing reference for the WAM-R target. See
+  the **Fact-table lowering** section.
+- `docs/handoff/wam_r_session_handoff.md` -- session handoff for the
+  WAM-R campaign. See the **Follow-up ideas** section for context on
+  where this fits.
+- `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs` -- the
+  parameterized C# query runtime. See `IIndexedRelationProvider`,
+  `IIndexedRelationBucketProvider`, `IRelationCardinalityProvider`,
+  `KeyJoinNode`.
+- `docs/development/proposals/PARAMETERIZED_QUERIES_PROPOSAL.md` and
+  `PARAMETERIZED_QUERIES_STATUS.md` -- design and status of the C#
+  parameterized queries work, including the per-predicate / per-column
+  fact-index cache that aligns with WAM-R's per-arg indexes.
+- Standard query-engine references for further reading: Garcia-Molina /
+  Ullman / Widom *Database Systems*; Abiteboul / Hull / Vianu
+  *Foundations of Databases* (chapters on Datalog evaluation, magic sets,
+  semi-naive); Soufflé documentation (compile-time Datalog with rich
+  per-attribute indexing).

--- a/docs/design/WAM_R_FACT_INDEXING.md
+++ b/docs/design/WAM_R_FACT_INDEXING.md
@@ -34,8 +34,13 @@ as part of the key. So `"aa"` in `arg1_env` and `"aa"` in `arg2_env` mean two
 totally different things, and there are no hash collisions between positions.
 
 Memory grows linearly in arity (`N × F` entries vs. `F` for first-arg only). It
-does **not** grow exponentially, because we only index single-arg keys -- not
-combinations of args.
+does **not** grow exponentially, because we build indexes for the N singleton
+arg-position subsets only -- not for combinations of args. (Note: the
+"exponential" cost of composite indexing comes from building all `2^N - 1`
+subsets, not from the key-space size of any single composite index. Each
+individual hash table only stores entries for keys that appear in the data.
+So a workload-driven *small* set of composite indexes would also be linear.
+We just don't have any today.)
 
 ## What we built
 
@@ -111,22 +116,44 @@ work. Q.E.D.
 
 ## Alternatives considered
 
-### A. Composite-key indexes
+### A. Composite-key indexes (exhaustive)
 
 Keep a separate index for each subset of bound positions: `(arg1)`, `(arg2)`,
 `(arg1, arg2)`, `(arg1, arg3)`, ..., `(arg1, ..., argN)`. Lookup becomes O(1)
 hash for any binding pattern.
 
-**Why not:** `2^N - 1` indexes per fact table. Storage is exponential in arity.
-Build time is exponential in arity. Even at N = 6 you have 63 indexes per
-table. The "n-tuple problem" -- this is what the user flagged.
+**Why not:** building all `2^N - 1` subsets means each fact contributes one
+entry per subset, so total storage is `O(F × 2^N)` -- exponential in arity,
+even though *each individual index* is just O(F) and the hash buckets only
+ever materialize for keys that actually appear in the data. Build time is
+exponential too. Even at N = 6 you have 63 indexes per table. This is the
+"n-tuple problem" -- and it's only a problem when the index choice is
+exhaustive.
 
-**When it would be worth it:** if a workload heavily exercises *one* specific
-multi-arg binding pattern and per-arg buckets aren't selective enough. Then
-emit only the indexes for that pattern (workload-driven, opt-in). Mentioned in
-the future-directions section below; not the default.
+> **Note on what's actually exponential.** The *key space* for composite
+> indexing is exponential in arity (`2^N - 1` binding patterns, each with a
+> potentially large value-space). Hash tables only store entries for keys that
+> actually appear in the data, so a *single* composite index is O(F) regardless
+> of key-space size. The exponential storage cost only appears when you build
+> indexes for *every* subset of bound positions; the alternative -- workload-
+> driven composite indexing on a chosen few subsets -- is O(F × k) for a small
+> constant k. See option B below and the future-directions section.
 
-### B. Successive / rolling hash chain
+### B. Composite-key indexes (workload-driven, opt-in)
+
+Same as A, but the user declares which composite indexes to build per
+workload, e.g. `r_fact_composite_index(p/3, [1, 2])` to build only the
+`(arg1, arg2)` index. Storage is O(F × k) for k declared indexes -- linear,
+not exponential.
+
+**Why not (yet):** no infrastructure for declaring or maintaining these in
+WAM-R today. Worth adding when a real workload shows that per-arg buckets
+aren't selective enough on a specific multi-arg binding pattern. Listed in
+future directions below. The parameterized C# query runtime already supports
+this in its manifest format (`DelimitedRelationArtifactIndexManifest.Columns`
+is `List<int>`) but currently emits only single-column indexes.
+
+### C. Successive / rolling hash chain
 
 Hash incrementally over the args of a fact: `h0 = init; h1 = mix(h0, arg1);
 h2 = mix(h1, arg2); ...; hN`. Store `hN -> tuple_index` for exact-tuple
@@ -139,7 +166,7 @@ don't match), or (b) precompute every possible `h2`, which collapses back to
 the exponential case. Successive hashing works for primary-key style lookups
 where every arg is always bound, but doesn't generalize to "any subset bound."
 
-### C. Single env with composite (position, value) keys
+### D. Single env with composite (position, value) keys
 
 One R env keyed by strings like `"1:a"`, `"2:b"`, where the position is part
 of the key string instead of being implicit in env identity.
@@ -148,7 +175,7 @@ of the key string instead of being implicit in env identity.
 keys (one extra string concat per lookup, slightly worse hash distribution
 because keys share a position-prefix). Per-arg envs avoid both. Same memory.
 
-### D. Bitmap intersection
+### E. Bitmap intersection
 
 Maintain per-(position, value) bitmaps over tuple indices; for each query,
 AND-together the bitmaps for all bound args, then iterate the result.
@@ -159,7 +186,7 @@ bucket), which is strictly better when at least one arg is selective. Bitmaps
 win only when *all* bound args have very high cardinality buckets that need to
 be intersected -- an uncommon case for fact tables.
 
-### E. Sorted per-arg indexes (range-aware)
+### F. Sorted per-arg indexes (range-aware)
 
 Same as our approach but with sorted vectors per bucket, supporting range
 queries (`X > 5`, `X between A B`). Strict superset of what we did.
@@ -347,9 +374,12 @@ places where the two converge on the same design.
 When *all* bound atom/int args are non-selective (every fact has the same value
 at the queried positions), the smallest bucket is still O(F), so we scan
 everything. There's no win over the old first-arg-only design (which would
-have scanned for the same reason). The fundamental tradeoff: composite indexes
-could intersect multiple non-selective buckets to find selective subsets, at
-exponential storage cost. We prefer the linear-storage worst case.
+have scanned for the same reason). A targeted composite index on the actual
+binding pattern (option B above) would solve the specific case at O(F)
+additional storage; an exhaustive composite-index scheme (option A) would
+solve every binding pattern at O(F × 2^N) storage. We prefer to keep the
+default linear in arity, with workload-driven composite indexes available as
+opt-in future work.
 
 In practice, on the WAM-R workloads we care about (genealogy, graph traversal,
 benchmark fact lookups), at least one bound arg is highly selective and the

--- a/docs/handoff/wam_r_session_handoff.md
+++ b/docs/handoff/wam_r_session_handoff.md
@@ -94,7 +94,9 @@ relevant feature sections. Not bugs -- intentional scope boundaries.
   indexes (one env per arg, dispatcher picks smallest bound
   bucket). Storage is O(N · F) -- linear in arity, no `2^N`
   composite-key blowup. Range / interval indexes are still future
-  work.
+  work. Design rationale + alternatives + connection to the
+  parameterized C# query runtime are documented in
+  [`docs/design/WAM_R_FACT_INDEXING.md`](../design/WAM_R_FACT_INDEXING.md).
 - **`bagof` / `setof` per-witness grouping.** `^/2` existential scope
   works; non-quantified free vars are silently aggregated rather than
   producing one bag per witness binding.

--- a/docs/handoff/wam_r_session_handoff.md
+++ b/docs/handoff/wam_r_session_handoff.md
@@ -15,8 +15,8 @@ then read `docs/WAM_R_TARGET.md` for the user-facing reference.
 
 ### Numbers
 
-- **54 tests** in `tests/test_wam_r_generator.pl` (37 e2e via Rscript,
-  the rest structural). Full suite runs in ~5-7 minutes; bottleneck is
+- **55 tests** in `tests/test_wam_r_generator.pl` (38 e2e via Rscript,
+  the rest structural). Full suite runs in ~5-9 minutes; bottleneck is
   Rscript startup, not the runtime.
 - **3 main source files**:
   - `src/unifyweaver/targets/wam_r_target.pl` -- codegen + project writer.
@@ -48,7 +48,7 @@ then read `docs/WAM_R_TARGET.md` for the user-facing reference.
 | **DCG** | `-->` via SWI's term-expansion + `phrase/2,3`. |
 | **Parser** | Operator-precedence parser for the standard Prolog operator table; lists, structs, integers, floats, vars. |
 | **Streams** | File I/O via R `file()` connections; line-buffered `read/2` parses through the term parser. |
-| **Fact-table lowering** | Pure-fact predicates (only `get_constant + proceed`) emit a flat R tuple list + first-arg hash index, dispatched via `WamRuntime$fact_table_dispatch`. |
+| **Fact-table lowering** | Pure-fact predicates (only `get_constant + proceed`) emit a flat R tuple list + per-arg hash indexes (one env per arg position), dispatched via `WamRuntime$fact_table_dispatch`. Smallest matching bound-arg bucket wins; O(N · F) memory. |
 | **External fact sources (CSV)** | `r_fact_sources([source(P/A, file('data.csv'))])` -- predicate has no Prolog clauses; loader runs at program init. |
 | **Kernels (7/7)** | All seven patterns from `recursive_kernel_detection.pl`: `transitive_closure2`, `transitive_distance3`, `weighted_shortest_path3`, `transitive_parent_distance4`, `transitive_step_parent_distance5`, `category_ancestor`, `astar_shortest_path4`. Native R BFS / Dijkstra / A* implementations that bypass the WAM stepper. |
 | **Lowered dispatch** | `program$lowered_dispatch` env consulted by `Call` / `Execute` / `dispatch_call` before label dispatch, so internal Prolog-to-Prolog calls reach the fast path (not just direct R-API). |
@@ -90,8 +90,11 @@ relevant feature sections. Not bugs -- intentional scope boundaries.
 - **No multi-line term reads.** `read/2` is line-buffered.
 - **No streams beyond file I/O.** No `current_input/1`, `current_output/1`,
   `set_input/1`, character I/O, binary streams.
-- **Fact-table indexing is first-arg only.** Multi-arg indexing is
-  feasible but not yet wired.
+- **Fact-table indexing covers any arg position.** Per-arg hash
+  indexes (one env per arg, dispatcher picks smallest bound
+  bucket). Storage is O(N · F) -- linear in arity, no `2^N`
+  composite-key blowup. Range / interval indexes are still future
+  work.
 - **`bagof` / `setof` per-witness grouping.** `^/2` existential scope
   works; non-quantified free vars are silently aggregated rather than
   producing one bag per witness binding.
@@ -112,34 +115,35 @@ relevant feature sections. Not bugs -- intentional scope boundaries.
 If you're picking up this campaign, these are the obvious next steps in
 roughly priority order:
 
-1. **Multi-arg fact-table indexing.** Extend the first-arg index to
-   second/third args. Modest perf gain on non-leading-ground queries.
-   Bounded scope; reuses the existing `fact_table_dispatch` machinery.
-2. **Operator declarations (`op/3`)** in the term parser. Quality-of-life
+1. **Operator declarations (`op/3`)** in the term parser. Quality-of-life
    for `read_term_from_atom/2,3` and any user code that ports Prolog
    source between targets.
-3. **LMDB / grouped-by-first TSV backends** for `r_fact_sources`. Mirrors
+2. **LMDB / grouped-by-first TSV backends** for `r_fact_sources`. Mirrors
    the Scala precedent; the `fact_source_spec_to_*` clauses in
    `wam_scala_target.pl` are templates.
-4. **Performance profiling + targeted optimization.** First PR should
+3. **Performance profiling + targeted optimization.** First PR should
    add `Rprof` instrumentation around `wam_r_fact_source_bench.pl` and
    identify a single hot path; subsequent PRs each fix one bottleneck.
    Tagged-list `$tag` access and env-based register lookups are likely
    suspects.
-5. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
+4. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
    mode info per predicate (in/out per arg); Phase 2 wires it to
    specialised emission (skip unifications when the mode says the slot
    is unbound, etc.). Look at the Haskell target's
    `WAM_HASKELL_MODE_ANALYSIS_*.md` design docs for the precedent.
-6. **Multi-line `read/2`.** Read until a `.` terminator across lines.
+5. **Multi-line `read/2`.** Read until a `.` terminator across lines.
    Niche but completes the streams story.
-7. **Multi-solution `retract/1` ignoring snapshot.** I.e. re-read the
+6. **Multi-solution `retract/1` ignoring snapshot.** I.e. re-read the
    live clause list on each backtrack. Trickier semantics; document
    carefully if pursued.
-8. **Phase-3 lowered emitter expansion.** Currently handles only
+7. **Phase-3 lowered emitter expansion.** Currently handles only
    `deterministic` and `multi_clause_1` shapes. Could grow N-clause
    general lowering; would compete with the kernel / fact-table paths
    so the value is unclear.
+8. **Range / interval indexes** on fact tables. Per-arg hash indexes
+   land queries with ground atom/int args; range queries (`X > 5`,
+   `X between A B`) still go through the per-tuple scan. A sorted-
+   per-arg index would route these. Niche but a natural extension.
 
 ## Things to know before you start a follow-up
 

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -1182,11 +1182,18 @@ emit_fact_table(Pred, Arity, Tuples, DataDecl, LoweredFunc, FuncName) :-
 % 1..Arity, emit a `<RName>_index_arg<K> <- new.env(...)` plus one
 % `assign("a<id>"/"i<val>", c(...), envir = ...)` line per bucket.
 % Finally bundle all per-arg envs into `<IndexesName> <- list(...)`.
-fact_indexes_block(_Tuples, 0, _RName, IndexesName, Body) :- !,
-    format(string(Body), '~w <- list()', [IndexesName]).
+%
+% Arity must be a positive integer: the fact-table classifier requires
+% `get_constant + proceed`, which implies arity >= 1. An arity-0 fact
+% table would emit `<IndexesName> <- list()`, which fact_table_dispatch
+% would reject loudly via its own arity-vs-indexes check, but it's
+% still better to fail at codegen time with a clear domain error.
 fact_indexes_block(Tuples, Arity, RName, IndexesName, Body) :-
-    Arity > 0,
+    must_be(positive_integer, Arity),
     numlist(1, Arity, ArgPositions),
+    % maplist/4 with two output lists: each call to fact_index_per_arg/5
+    % produces one block of R code (Block) and the matching env name
+    % (IndexName), zipped over ArgPositions.
     maplist(fact_index_per_arg(Tuples, RName), ArgPositions, PerArgBlocks,
             PerArgNames),
     atomic_list_concat(PerArgBlocks, '\n', Joined),

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -1006,15 +1006,16 @@ emit_external_fact_source(Pred, Arity, file(Path),
                           DataDecl, LoweredFunc, FuncName) :-
     r_pred_name(Pred, RName),
     format(atom(DataName), '~w_facts', [RName]),
-    format(atom(IndexName), '~w_index', [RName]),
+    format(atom(IndexesName), '~w_indexes', [RName]),
     format(atom(FuncName), '~w_fact_iter', [RName]),
     atom_string(Path, PathStr),
     r_string_literal(PathStr, PathLit),
     format(string(DataDecl),
 '# External fact source for ~w/~w (file: ~w)
 ~w <- WamRuntime$read_facts_csv(~w, intern_table)
-~w <- WamRuntime$build_fact_index(~w)',
-        [Pred, Arity, PathStr, DataName, PathLit, IndexName, DataName]),
+~w <- WamRuntime$build_fact_indexes(~w, ~wL)',
+        [Pred, Arity, PathStr, DataName, PathLit, IndexesName, DataName,
+         Arity]),
     fact_args_collect(Arity, ArgsCollect),
     format(string(LoweredFunc),
 '~w <- function(program, state) {
@@ -1022,7 +1023,7 @@ emit_external_fact_source(Pred, Arity, file(Path),
   WamRuntime$fact_table_dispatch(program, state, "~w/~w", ~w, ~w,
                                   args, state$pc + 1L)
 }',
-        [FuncName, ArgsCollect, Pred, Arity, DataName, IndexName]).
+        [FuncName, ArgsCollect, Pred, Arity, DataName, IndexesName]).
 
 % ============================================================================
 % FACT-TABLE CLASSIFICATION + EMISSION
@@ -1149,53 +1150,73 @@ fact_seg_arg_lit(SegParts, Idx, Lit) :-
 %% emit_fact_table(+Pred, +Arity, +Tuples, -DataDecl, -LoweredFunc, -FuncName)
 %  Renders the per-predicate fact-data declaration and a lowered
 %  function that delegates to WamRuntime$fact_table_dispatch.
-%  Emits a first-arg index (an R env mapping "a<id>" / "i<val>" to
-%  the integer-vector of tuple indices) so ground first-arg queries
-%  hit a hash bucket instead of a full linear scan -- the speed-up
-%  vs the WAM `switch_on_constant` path comes from skipping the
-%  stepping engine and the get_constant unify chain.
+%  Emits N per-arg indexes (one R env per arg position, each mapping
+%  "a<id>" / "i<val>" -> integer vector of matching tuple indices),
+%  bundled into an `<RName>_indexes <- list(...)` list. Dispatch picks
+%  the smallest matching bucket among bound atom/int args and iterates
+%  just that bucket; a non-leading-ground query is no longer a full
+%  scan. Memory: O(N * F); per-arg, no composite keys.
 emit_fact_table(Pred, Arity, Tuples, DataDecl, LoweredFunc, FuncName) :-
     r_pred_name(Pred, RName),
     format(atom(DataName), '~w_facts', [RName]),
-    format(atom(IndexName), '~w_index', [RName]),
+    format(atom(IndexesName), '~w_indexes', [RName]),
     format(atom(FuncName), '~w_fact_iter', [RName]),
     length(Tuples, NTuples),
     fact_tuples_to_r_list(Tuples, ListBody),
-    fact_index_assignments(Tuples, IndexName, IndexBody),
+    fact_indexes_block(Tuples, Arity, RName, IndexesName, IndexBody),
     format(string(DataDecl),
 '# Fact table for ~w/~w (~w tuples)
 ~w <- list(
 ~w
 )
-~w <- new.env(parent = emptyenv())
-~w', [Pred, Arity, NTuples, DataName, ListBody, IndexName, IndexBody]),
+~w', [Pred, Arity, NTuples, DataName, ListBody, IndexBody]),
     fact_args_collect(Arity, ArgsCollect),
     format(string(LoweredFunc),
 '~w <- function(program, state) {
   args <- ~w
   WamRuntime$fact_table_dispatch(program, state, "~w/~w", ~w, ~w,
                                   args, state$pc + 1L)
-}', [FuncName, ArgsCollect, Pred, Arity, DataName, IndexName]).
+}', [FuncName, ArgsCollect, Pred, Arity, DataName, IndexesName]).
 
-% Build the R-side index population block. Each tuple's first arg
-% (which our classifier guarantees is a ground IntTerm/Atom literal)
-% maps to a bucket key "a<id>" or "i<val>"; the bucket value is the
-% list of 1-based tuple indices that share that key, in source order.
-fact_index_assignments(Tuples, IndexName, Body) :-
-    fact_index_pairs(Tuples, 1, Pairs),
+% Build the per-arg index population block. For each arg position
+% 1..Arity, emit a `<RName>_index_arg<K> <- new.env(...)` plus one
+% `assign("a<id>"/"i<val>", c(...), envir = ...)` line per bucket.
+% Finally bundle all per-arg envs into `<IndexesName> <- list(...)`.
+fact_indexes_block(_Tuples, 0, _RName, IndexesName, Body) :- !,
+    format(string(Body), '~w <- list()', [IndexesName]).
+fact_indexes_block(Tuples, Arity, RName, IndexesName, Body) :-
+    Arity > 0,
+    numlist(1, Arity, ArgPositions),
+    maplist(fact_index_per_arg(Tuples, RName), ArgPositions, PerArgBlocks,
+            PerArgNames),
+    atomic_list_concat(PerArgBlocks, '\n', Joined),
+    atomic_list_concat(PerArgNames, ', ', NamesList),
+    format(string(Body), '~w\n~w <- list(~w)',
+           [Joined, IndexesName, NamesList]).
+
+% Emit the new.env + bucket assigns for a single arg position.
+fact_index_per_arg(Tuples, RName, ArgPos, Block, IndexName) :-
+    format(atom(IndexName), '~w_index_arg~w', [RName, ArgPos]),
+    fact_index_pairs_at(Tuples, ArgPos, 1, Pairs),
     fact_index_group(Pairs, [], Buckets),
-    maplist(fact_index_emit_assign(IndexName), Buckets, Lines),
-    atomic_list_concat(Lines, '\n', Body).
+    maplist(fact_index_emit_assign(IndexName), Buckets, AssignLines),
+    atomic_list_concat(AssignLines, '\n', AssignsBody),
+    (   AssignsBody == ''
+    ->  format(string(Block), '~w <- new.env(parent = emptyenv())',
+               [IndexName])
+    ;   format(string(Block), '~w <- new.env(parent = emptyenv())\n~w',
+               [IndexName, AssignsBody])
+    ).
 
-fact_index_pairs([], _, []).
-fact_index_pairs([Tuple | Rest], Idx, [Key-Idx | RestPairs]) :-
-    Tuple = [First | _],
-    fact_index_key(First, Key), !,
+fact_index_pairs_at([], _ArgPos, _Idx, []).
+fact_index_pairs_at([Tuple | Rest], ArgPos, Idx, [Key-Idx | RestPairs]) :-
+    nth1(ArgPos, Tuple, Lit),
+    fact_index_key(Lit, Key), !,
     Idx1 is Idx + 1,
-    fact_index_pairs(Rest, Idx1, RestPairs).
-fact_index_pairs([_ | Rest], Idx, RestPairs) :-
+    fact_index_pairs_at(Rest, ArgPos, Idx1, RestPairs).
+fact_index_pairs_at([_ | Rest], ArgPos, Idx, RestPairs) :-
     Idx1 is Idx + 1,
-    fact_index_pairs(Rest, Idx1, RestPairs).
+    fact_index_pairs_at(Rest, ArgPos, Idx1, RestPairs).
 
 % Source literals are produced by constant_to_r_term: "Atom(<id>)"
 % or "IntTerm(<val>)" / "FloatTerm(<val>)". We pull the prefix to

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -2876,22 +2876,27 @@ WamRuntime$fact_table_iter_subset <- function(program, state, key, tuples,
 # out the rest of the conditions.
 #
 # A bound atom/int arg whose bucket is missing means no fact has that
-# value at that position -> short-circuit FALSE. A float / unbound /
-# struct query value doesn't hit the index path at all (`bk` stays NULL)
-# and is filtered during the per-tuple scan instead. If no bound arg
-# yields a usable bucket (all unbound, or all floats), we fall back to
-# a full-table scan.
+# value at that position -> short-circuit FALSE. (The short-circuit
+# fires on the first miss encountered in left-to-right arg order; any
+# later miss would also produce FALSE, so the order-dependent early
+# return is sound.) A float / unbound / struct query value doesn't
+# hit the index path at all (`bk` stays NULL) and is filtered during
+# the per-tuple scan instead. If no bound arg yields a usable bucket
+# (all unbound, or all floats), we fall back to a full-table scan.
 #
 # Memory: O(N * F) for F facts; each fact contributes at most one entry
 # per arg position. No composite-key indexes -- avoids the 2^N blowup.
 WamRuntime$fact_table_dispatch <- function(program, state, key, tuples, indexes,
                                             args, resume_pc) {
   arity <- length(args)
-  best_bucket <- NULL
-  best_size   <- NA_integer_
   n_idx <- length(indexes)
+  if (n_idx != arity) {
+    stop(sprintf("fact_table_dispatch: indexes length (%d) != arity (%d) for %s",
+                 n_idx, arity, key))
+  }
+  best_bucket <- NULL
+  best_size   <- .Machine$integer.max
   for (j in seq_len(arity)) {
-    if (j > n_idx) break
     idx_env <- indexes[[j]]
     if (is.null(idx_env)) next
     v <- WamRuntime$deref(state, args[[j]])
@@ -2905,7 +2910,7 @@ WamRuntime$fact_table_dispatch <- function(program, state, key, tuples, indexes,
     }
     bucket <- get(bk, envir = idx_env, inherits = FALSE)
     sz <- length(bucket)
-    if (is.na(best_size) || sz < best_size) {
+    if (sz < best_size) {
       best_bucket <- bucket
       best_size   <- sz
     }

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -2868,32 +2868,52 @@ WamRuntime$fact_table_iter_subset <- function(program, state, key, tuples,
   FALSE
 }
 
-# Indexed dispatch for fact tables: if the caller's first arg derefs
-# to a ground atom or integer, we look its bucket up in the index
-# (an env mapping "atom-id" / "int-value" to the integer-vector of
-# matching tuple indices). On a hit we iterate just that bucket; on
-# a miss we fail outright (the index already enumerated every value
-# present in the table). For an unground first arg or any other tag,
-# we fall back to a full-table scan.
-WamRuntime$fact_table_dispatch <- function(program, state, key, tuples, index,
+# Indexed dispatch for fact tables. `indexes` is a list of N envs (one
+# per arg position); each env maps "a<atom-id>" / "i<int-value>" to
+# an integer vector of matching tuple indices. We scan all bound atom/int
+# args, look each one up, and iterate just the smallest matching bucket
+# (most selective). Per-tuple unify in fact_table_iter_subset filters
+# out the rest of the conditions.
+#
+# A bound atom/int arg whose bucket is missing means no fact has that
+# value at that position -> short-circuit FALSE. A float / unbound /
+# struct query value doesn't hit the index path at all (`bk` stays NULL)
+# and is filtered during the per-tuple scan instead. If no bound arg
+# yields a usable bucket (all unbound, or all floats), we fall back to
+# a full-table scan.
+#
+# Memory: O(N * F) for F facts; each fact contributes at most one entry
+# per arg position. No composite-key indexes -- avoids the 2^N blowup.
+WamRuntime$fact_table_dispatch <- function(program, state, key, tuples, indexes,
                                             args, resume_pc) {
   arity <- length(args)
-  if (arity >= 1L) {
-    v <- WamRuntime$deref(state, args[[1]])
-    if (!is.null(v) && !is.null(v$tag)) {
-      bk <- NULL
-      if (v$tag == "atom") bk <- paste0("a", v$id)
-      else if (v$tag == "int") bk <- paste0("i", v$val)
-      if (!is.null(bk)) {
-        if (exists(bk, envir = index, inherits = FALSE)) {
-          bucket <- get(bk, envir = index, inherits = FALSE)
-          return(WamRuntime$fact_table_iter_subset(program, state, key,
-                                                    tuples, bucket, args, 1L,
-                                                    resume_pc))
-        }
-        return(FALSE)
-      }
+  best_bucket <- NULL
+  best_size   <- NA_integer_
+  n_idx <- length(indexes)
+  for (j in seq_len(arity)) {
+    if (j > n_idx) break
+    idx_env <- indexes[[j]]
+    if (is.null(idx_env)) next
+    v <- WamRuntime$deref(state, args[[j]])
+    if (is.null(v) || is.null(v$tag)) next
+    bk <- if (v$tag == "atom") paste0("a", v$id)
+          else if (v$tag == "int") paste0("i", v$val)
+          else NULL
+    if (is.null(bk)) next
+    if (!exists(bk, envir = idx_env, inherits = FALSE)) {
+      return(FALSE)
     }
+    bucket <- get(bk, envir = idx_env, inherits = FALSE)
+    sz <- length(bucket)
+    if (is.na(best_size) || sz < best_size) {
+      best_bucket <- bucket
+      best_size   <- sz
+    }
+  }
+  if (!is.null(best_bucket)) {
+    return(WamRuntime$fact_table_iter_subset(program, state, key, tuples,
+                                              best_bucket, args, 1L,
+                                              resume_pc))
   }
   WamRuntime$fact_table_iter(program, state, key, tuples, args, 1L, resume_pc)
 }
@@ -2940,28 +2960,43 @@ WamRuntime$read_facts_csv <- function(path, intern_table) {
   out
 }
 
-# Build the first-arg hash index for a runtime-loaded fact table.
-# Same index shape as the codegen-emitted `<pred>_index <-
-# new.env(...); assign("a<id>", c(...))` blocks for inline fact
-# tables: keys are "a<atom-id>" / "i<int-value>", values are
-# integer vectors of 1-based tuple indices.
-WamRuntime$build_fact_index <- function(facts) {
-  idx <- new.env(parent = emptyenv())
+# Build per-arg hash indexes for a runtime-loaded fact table.
+# Returns a list of N envs (one per arg position, where N = arity).
+# Each env follows the same shape as the codegen-emitted
+# `<pred>_index_argK <- new.env(...); assign("a<id>", c(...))` blocks
+# for inline fact tables: keys are "a<atom-id>" / "i<int-value>",
+# values are integer vectors of 1-based tuple indices. Floats /
+# unbounds / structs at a given position are skipped for that
+# position's index but still appear in the master tuple list.
+#
+# Memory: O(N * F) for F facts; each fact contributes at most one
+# entry per arg position. Per-arg, not per-arg-combination -- no
+# 2^N composite indexes.
+WamRuntime$build_fact_indexes <- function(facts, arity) {
+  if (arity < 1L) return(list())
+  idxs <- vector("list", arity)
+  for (j in seq_len(arity)) {
+    idxs[[j]] <- new.env(parent = emptyenv())
+  }
   for (i in seq_along(facts)) {
     tuple <- facts[[i]]
     if (length(tuple) < 1L) next
-    first <- tuple[[1L]]
-    if (is.null(first) || !is.list(first) || is.null(first$tag)) next
-    bk <- if (first$tag == "atom") paste0("a", first$id)
-          else if (first$tag == "int") paste0("i", first$val)
-          else NULL
-    if (is.null(bk)) next
-    existing <- if (exists(bk, envir = idx, inherits = FALSE)) {
-      get(bk, envir = idx, inherits = FALSE)
-    } else integer(0)
-    assign(bk, c(existing, as.integer(i)), envir = idx)
+    for (j in seq_len(arity)) {
+      if (j > length(tuple)) break
+      v <- tuple[[j]]
+      if (is.null(v) || !is.list(v) || is.null(v$tag)) next
+      bk <- if (v$tag == "atom") paste0("a", v$id)
+            else if (v$tag == "int") paste0("i", v$val)
+            else NULL
+      if (is.null(bk)) next
+      env_j <- idxs[[j]]
+      existing <- if (exists(bk, envir = env_j, inherits = FALSE)) {
+        get(bk, envir = env_j, inherits = FALSE)
+      } else integer(0)
+      assign(bk, c(existing, as.integer(i)), envir = env_j)
+    }
   }
-  idx
+  idxs
 }
 
 # Enumerable iteration over a list of WAM terms, used by member/2 (and

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2345,7 +2345,10 @@ e2e_fact_table_via_rscript :-
     read_file_to_string(ProgPath, Code, []),
     assertion(sub_string(Code, _, _, _, '# Fact table for edge/2')),
     assertion(sub_string(Code, _, _, _, 'pred_edge_facts <- list(')),
-    assertion(sub_string(Code, _, _, _, 'pred_edge_index <- new.env')),
+    % Per-arg indexes (one env per arg position) bundled into a list.
+    assertion(sub_string(Code, _, _, _, 'pred_edge_index_arg1 <- new.env')),
+    assertion(sub_string(Code, _, _, _, 'pred_edge_index_arg2 <- new.env')),
+    assertion(sub_string(Code, _, _, _, 'pred_edge_indexes <- list(pred_edge_index_arg1, pred_edge_index_arg2)')),
     % The hash-index covers every distinct first-arg value.
     forall(member(K, ['a', 'b', 'c', 'd']), (
         format(string(Pat), 'assign("a~w", c(', [K]),
@@ -2356,6 +2359,76 @@ e2e_fact_table_via_rscript :-
         % Sanity: an `a<id>` index entry exists.
         ignore(sub_string(Code, _, _, _, Pat))
     )),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
+% End-to-end Rscript run for multi-arg fact-table indexing.
+% A 3-arg edge_w/3 table with deliberately skewed buckets exercises
+% the smallest-bucket pick: arg1 has 5 values for one of them and
+% just 1 for another, while arg2 / arg3 have different selectivities.
+% Drivers query with just arg2 bound, just arg3 bound, and (arg2, arg3)
+% bound -- all three should hit the per-arg indexes rather than fall
+% back to a full scan. We assert on the answers (correctness) and on
+% the emitted index code (the indexes list contains 3 envs).
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(fact_table_multi_arg_index_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_multi_arg_index_via_rscript
+    ;   true
+    )).
+
+e2e_multi_arg_index_via_rscript :-
+    % edge_w(Src, Dst, Weight) -- 6 facts. Skew arg1: `a` has 4 outgoing,
+    % everyone else has 1. So a query with arg2=z bound reaches 1 fact;
+    % a query with arg1=a bound reaches 4. Smallest-bucket pick should
+    % use arg2 in those cases.
+    assertz(user:edge_w(a, x, 1)),
+    assertz(user:edge_w(a, y, 2)),
+    assertz(user:edge_w(a, z, 3)),
+    assertz(user:edge_w(a, w, 4)),
+    assertz(user:edge_w(b, x, 5)),
+    assertz(user:edge_w(c, x, 6)),
+    % q_arg2_only:  edge_w(_, z, _) -- 1 match (a, z, 3).
+    % q_arg3_only:  edge_w(_, _, 5) -- 1 match (b, x, 5).
+    % q_arg23:      edge_w(_, x, 6) -- 1 match (c, x, 6).
+    % q_arg2_no:    edge_w(_, q, _) -- 0 matches (atom q absent at arg2).
+    % q_arg3_no:    edge_w(_, _, 99) -- 0 matches.
+    assertz((user:q_arg2_only :- edge_w(_, z, W), W == 3)),
+    assertz((user:q_arg3_only :- edge_w(S, _, 5), S == b)),
+    assertz((user:q_arg23     :- edge_w(S, x, 6), S == c)),
+    assertz((user:q_arg2_no   :- edge_w(_, q, _))),
+    assertz((user:q_arg3_no   :- edge_w(_, _, 99))),
+    unique_r_tmp_dir('tmp_r_multi_arg_index_e2e', TmpDir),
+    write_wam_r_project(
+        [user:edge_w/3,
+         user:q_arg2_only/0, user:q_arg3_only/0,
+         user:q_arg23/0,
+         user:q_arg2_no/0, user:q_arg3_no/0],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [q_arg2_only, q_arg3_only, q_arg23],
+    No  = [q_arg2_no, q_arg3_no],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    % Structural: 3 per-arg index envs are emitted and bundled.
+    directory_file_path(TmpDir, 'R/generated_program.R', ProgPath),
+    read_file_to_string(ProgPath, Code, []),
+    assertion(sub_string(Code, _, _, _, 'pred_edge_w_index_arg1 <- new.env')),
+    assertion(sub_string(Code, _, _, _, 'pred_edge_w_index_arg2 <- new.env')),
+    assertion(sub_string(Code, _, _, _, 'pred_edge_w_index_arg3 <- new.env')),
+    assertion(sub_string(Code, _, _, _,
+        'pred_edge_w_indexes <- list(pred_edge_w_index_arg1, pred_edge_w_index_arg2, pred_edge_w_index_arg3)')),
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2301,6 +2301,12 @@ test(fact_table_e2e_rscript) :-
     )).
 
 e2e_fact_table_via_rscript :-
+    setup_call_cleanup(
+        e2e_fact_table_setup(TmpDir),
+        e2e_fact_table_body(TmpDir),
+        e2e_fact_table_cleanup(TmpDir)).
+
+e2e_fact_table_setup(TmpDir) :-
     assertz(user:edge(a, b)),
     assertz(user:edge(b, c)),
     assertz(user:edge(c, d)),
@@ -2319,7 +2325,9 @@ e2e_fact_table_via_rscript :-
     assertz(user:ival(3, three)),
     assertz((user:ft_int  :- ival(2, two))),
     assertz((user:ft_int_no :- ival(2, three))),
-    unique_r_tmp_dir('tmp_r_facttable_e2e', TmpDir),
+    unique_r_tmp_dir('tmp_r_facttable_e2e', TmpDir).
+
+e2e_fact_table_body(TmpDir) :-
     write_wam_r_project(
         [user:edge/2, user:ival/2,
          user:ft_first/0, user:ft_third/0, user:ft_no/0,
@@ -2349,17 +2357,31 @@ e2e_fact_table_via_rscript :-
     assertion(sub_string(Code, _, _, _, 'pred_edge_index_arg1 <- new.env')),
     assertion(sub_string(Code, _, _, _, 'pred_edge_index_arg2 <- new.env')),
     assertion(sub_string(Code, _, _, _, 'pred_edge_indexes <- list(pred_edge_index_arg1, pred_edge_index_arg2)')),
-    % The hash-index covers every distinct first-arg value.
-    forall(member(K, ['a', 'b', 'c', 'd']), (
-        format(string(Pat), 'assign("a~w", c(', [K]),
-        % Some atoms map to the same id only if interning collapses,
-        % which won't happen for distinct names. We just check the
-        % presence of an `assign("a<digit>"`-style line per atom.
-        true,
-        % Sanity: an `a<id>` index entry exists.
-        ignore(sub_string(Code, _, _, _, Pat))
-    )),
-    delete_directory_and_contents(TmpDir).
+    % Both arg envs should be populated: each fact contributes one
+    % entry to each arg position's index. 4 facts, 4 distinct atoms
+    % at arg1 (a, b, c, d) and 4 distinct atoms at arg2 (b, c, d, a)
+    % -> 4 `assign(..., envir = <env>)` lines per env. We don't bind
+    % to specific atom-ids since interning order is not stable.
+    aggregate_all(count,
+        sub_string(Code, _, _, _, ', envir = pred_edge_index_arg1)'),
+        Arg1Count),
+    aggregate_all(count,
+        sub_string(Code, _, _, _, ', envir = pred_edge_index_arg2)'),
+        Arg2Count),
+    assertion(Arg1Count =:= 4),
+    assertion(Arg2Count =:= 4).
+
+e2e_fact_table_cleanup(TmpDir) :-
+    retractall(user:edge(_, _)),
+    retractall(user:ival(_, _)),
+    retractall(user:ft_first),
+    retractall(user:ft_third),
+    retractall(user:ft_no),
+    retractall(user:ft_findall),
+    retractall(user:ft_succ),
+    retractall(user:ft_int),
+    retractall(user:ft_int_no),
+    ignore(catch(delete_directory_and_contents(TmpDir), _, true)).
 
 % ------------------------------------------------------------------
 % End-to-end Rscript run for multi-arg fact-table indexing.
@@ -2380,6 +2402,12 @@ test(fact_table_multi_arg_index_e2e_rscript) :-
     )).
 
 e2e_multi_arg_index_via_rscript :-
+    setup_call_cleanup(
+        e2e_multi_arg_index_setup(TmpDir),
+        e2e_multi_arg_index_body(TmpDir),
+        e2e_multi_arg_index_cleanup(TmpDir)).
+
+e2e_multi_arg_index_setup(TmpDir) :-
     % edge_w(Src, Dst, Weight) -- 6 facts. Skew arg1: `a` has 4 outgoing,
     % everyone else has 1. So a query with arg2=z bound reaches 1 fact;
     % a query with arg1=a bound reaches 4. Smallest-bucket pick should
@@ -2400,7 +2428,9 @@ e2e_multi_arg_index_via_rscript :-
     assertz((user:q_arg23     :- edge_w(S, x, 6), S == c)),
     assertz((user:q_arg2_no   :- edge_w(_, q, _))),
     assertz((user:q_arg3_no   :- edge_w(_, _, 99))),
-    unique_r_tmp_dir('tmp_r_multi_arg_index_e2e', TmpDir),
+    unique_r_tmp_dir('tmp_r_multi_arg_index_e2e', TmpDir).
+
+e2e_multi_arg_index_body(TmpDir) :-
     write_wam_r_project(
         [user:edge_w/3,
          user:q_arg2_only/0, user:q_arg3_only/0,
@@ -2428,8 +2458,16 @@ e2e_multi_arg_index_via_rscript :-
     assertion(sub_string(Code, _, _, _, 'pred_edge_w_index_arg2 <- new.env')),
     assertion(sub_string(Code, _, _, _, 'pred_edge_w_index_arg3 <- new.env')),
     assertion(sub_string(Code, _, _, _,
-        'pred_edge_w_indexes <- list(pred_edge_w_index_arg1, pred_edge_w_index_arg2, pred_edge_w_index_arg3)')),
-    delete_directory_and_contents(TmpDir).
+        'pred_edge_w_indexes <- list(pred_edge_w_index_arg1, pred_edge_w_index_arg2, pred_edge_w_index_arg3)')).
+
+e2e_multi_arg_index_cleanup(TmpDir) :-
+    retractall(user:edge_w(_, _, _)),
+    retractall(user:q_arg2_only),
+    retractall(user:q_arg3_only),
+    retractall(user:q_arg23),
+    retractall(user:q_arg2_no),
+    retractall(user:q_arg3_no),
+    ignore(catch(delete_directory_and_contents(TmpDir), _, true)).
 
 % ------------------------------------------------------------------
 % End-to-end Rscript run for the recursive-kernel detector. The


### PR DESCRIPTION
## Summary

- **Per-arg fact-table indexes** (commit `907d979`). Replaces the first-arg-only hash index with one hash env per arg position. `WamRuntime$fact_table_dispatch` walks every bound atom/int arg, picks the smallest matching bucket (most selective), and iterates just that bucket; per-tuple unify filters the rest. Memory is O(N · F) for F facts and arity N -- per-arg, not per-arg-combination, so no `2^N` composite-key blowup. Codegen emits `<pred>_index_arg<K>` envs (K = 1..N) bundled into `<pred>_indexes <- list(...)`. Runtime equivalent for CSV-loaded sources is `WamRuntime$build_fact_indexes(facts, arity)`.

- **Design doc** at [`docs/design/WAM_R_FACT_INDEXING.md`](docs/design/WAM_R_FACT_INDEXING.md) (commit `47cd715`). Records the design discussion: what we built, alternatives ruled out (composite-key indexes, successive/rolling hash chains, single composite-key envs, bitmap intersection, sorted per-arg), RDBMS / Datalog theoretical context, direct alignment with the parameterized C# query runtime (`csharp_query_runtime/`), and future directions. Cross-referenced from `WAM_R_TARGET.md` and the WAM-R session handoff.

- **Doc correction** (commit `488ef58`). Distinguishes exponential *key space* from *storage* (which is bounded by actual data + number of indexes built). Adds option B for workload-driven composite indexes, which would also be linear-storage if declared per workload.

Highest-ranked follow-up from `docs/handoff/wam_r_session_handoff.md` is now done. New top-ranked follow-up is `op/3` operator declarations.

## Test plan

- [x] `fact_table_e2e_rscript` updated to assert on the new index shape (`pred_edge_index_arg1`, `pred_edge_index_arg2`, `pred_edge_indexes`)
- [x] New `fact_table_multi_arg_index_e2e_rscript` exercises arg2-only, arg3-only, and (arg2, arg3) bound queries on a 6-fact / arity-3 table; asserts on answers and emitted indexes shape
- [x] Full WAM-R suite: 55/55 pass (was 54)
- [x] Existing `external_fact_source_e2e_rscript` still passes through the new dispatch shape (CSV-loaded indexes use `WamRuntime$build_fact_indexes`)
- [x] All 7 kernel e2e tests still pass (kernels reach fact tables via `lowered_dispatch` which now uses the multi-arg dispatch path)

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_