### PR TITLE
WAM-R: user-defined operators via op/3 and r_op_decls

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -444,7 +444,23 @@ comparison (`=`, `\=`, `==`, `\==`, `=:=`, `=\=`, `<`, `>`, `=<`,
 `>=`, `@<`, `@>`, `@=<`, `@>=`, `=..`), control (`:-`, `-->`, `;`,
 `->`, `,`), and prefix (`\+`, `:-`, `?-`, `-`, `+`, `\`).
 Precedence and associativity follow the standard Prolog operator
-table; non-standard user-defined operators are not recognised.
+table.
+
+User-defined operators are supported via the runtime `op/3` builtin
+and the codegen `r_op_decls(...)` option. `op(+Priority, +Type,
++Name)` mutates the parser's operator table at runtime; subsequent
+`read_term_from_atom/2,3` and CLI arg parses see the new operator.
+Type is one of `xfx`, `xfy`, `yfx`, `fx`, `fy` (binary infix and
+prefix); postfix `xf` / `yf` are recognised but raise an error in
+this scaffold. Priority `0` removes the operator. Name may be an
+atom or a proper list of atoms. `current_op/3` enumerates the
+table with backtracking.
+
+For compile-time declarations (so the operator is known before any
+runtime call), pass `r_op_decls([op(P, T, N), ...])` to
+`write_wam_r_project/3`. Each declaration emits a
+`WamRuntime$op_set("<N>", <P>L, "<T>")` line at program init,
+ahead of CLI parsing.
 
 ### I/O
 
@@ -575,11 +591,10 @@ WamRuntime$run(shared_program, state)
 
 ## Limitations
 
-- **User-defined operators in the term parser**. The parser handles
-  the standard Prolog operator table (arithmetic, comparison,
-  control, common prefix forms); custom `op/3` declarations are not
-  consulted, so terms using them must be supplied in canonical
-  structural form.
+- **Postfix operators**. `op/3` recognises `xf` and `yf` types but
+  raises an error -- the parser doesn't have a postfix operator
+  path yet. Workaround: supply postfix terms in canonical
+  structural form. Infix and prefix custom operators work.
 - **WAM-text quoting collision**. The atom `'42'` and the integer
   `42` both serialise as `set_constant 42` in SWI's WAM emitter,
   so the codegen can't distinguish them. The runtime's `atom_*`
@@ -620,7 +635,7 @@ WamRuntime$run(shared_program, state)
 
 The full test suite lives in
 [tests/test_wam_r_generator.pl](../tests/test_wam_r_generator.pl)
-and contains 55 tests covering both structural assertions on the
+and contains 57 tests covering both structural assertions on the
 generated source and end-to-end execution via `Rscript`. The
 `*_e2e_rscript` tests auto-skip when `Rscript` is not on `PATH`.
 
@@ -652,6 +667,8 @@ Coverage map (e2e tests, by feature group):
 | `catch_throw_dyn_aggregator_e2e_rscript` | `catch/3`, `throw/1`, dynamic-pred aggregation |
 | `stdlib_polish_e2e_rscript` | `numlist/3`, `tab/1`, `sub_atom/5`, `char_type/2`, `term_to_atom/2` |
 | `operator_parser_e2e_rscript` | operator-precedence parsing (`+`, `*`, `^`, `=:=`, `\+`, `,`, ...) |
+| `op_3_runtime_e2e_rscript` | runtime `op/3` builtin: add infix / prefix custom ops, xfy right-associativity, `op(0, ...)` removal, `current_op/3` enumeration |
+| `op_3_decl_e2e_rscript` | codegen `r_op_decls([op(P, T, N), ...])` option seeds the operator table at program init; covers atom-name and list-of-names forms |
 | `multi_solution_retract_e2e_rscript` | multi-solution `retract/1` via iter-CP |
 | `bagof_setof_existential_e2e_rscript` | `^/2` existential scope in `bagof`/`setof`/`findall` |
 | `cli_arg_parser_e2e_rscript` | structured CLI args (lists, structs, expressions) parse via the runtime parser |

--- a/docs/handoff/wam_r_session_handoff.md
+++ b/docs/handoff/wam_r_session_handoff.md
@@ -15,8 +15,8 @@ then read `docs/WAM_R_TARGET.md` for the user-facing reference.
 
 ### Numbers
 
-- **55 tests** in `tests/test_wam_r_generator.pl` (38 e2e via Rscript,
-  the rest structural). Full suite runs in ~5-9 minutes; bottleneck is
+- **57 tests** in `tests/test_wam_r_generator.pl` (40 e2e via Rscript,
+  the rest structural). Full suite runs in ~6-10 minutes; bottleneck is
   Rscript startup, not the runtime.
 - **3 main source files**:
   - `src/unifyweaver/targets/wam_r_target.pl` -- codegen + project writer.
@@ -46,7 +46,7 @@ then read `docs/WAM_R_TARGET.md` for the user-facing reference.
 | **Dynamic** | `assertz/1`, `asserta/1`, `retract/1` (multi-solution), `abolish/1`, `clause/2` (multi-solution introspection). |
 | **Exceptions** | `throw/1`, `catch/3` (on R's `tryCatch`). |
 | **DCG** | `-->` via SWI's term-expansion + `phrase/2,3`. |
-| **Parser** | Operator-precedence parser for the standard Prolog operator table; lists, structs, integers, floats, vars. |
+| **Parser** | Operator-precedence parser for the standard Prolog operator table; lists, structs, integers, floats, vars. User-defined infix and prefix operators via runtime `op/3` / `current_op/3` and codegen `r_op_decls(...)`. |
 | **Streams** | File I/O via R `file()` connections; line-buffered `read/2` parses through the term parser. |
 | **Fact-table lowering** | Pure-fact predicates (only `get_constant + proceed`) emit a flat R tuple list + per-arg hash indexes (one env per arg position), dispatched via `WamRuntime$fact_table_dispatch`. Smallest matching bound-arg bucket wins; O(N · F) memory. |
 | **External fact sources (CSV)** | `r_fact_sources([source(P/A, file('data.csv'))])` -- predicate has no Prolog clauses; loader runs at program init. |
@@ -103,8 +103,11 @@ relevant feature sections. Not bugs -- intentional scope boundaries.
 - **`length/2` (-,-)** generative mode unsupported.
 - **`retract/1` snapshot semantics.** The snapshot is taken at the
   original call; clauses asserted during the iteration are not seen.
-- **CLI argument parsing.** Goes through the operator-precedence parser,
-  which doesn't support user-defined operators (`op/3`).
+- **Postfix operators in the term parser.** `op/3` recognises `xf` /
+  `yf` types but raises an error -- the parser doesn't have a
+  postfix path yet. Infix and prefix custom operators work, both at
+  runtime via `op/3` and at codegen time via the `r_op_decls`
+  option.
 - **`astar_shortest_path4`** is correct only when the user-supplied
   heuristic is admissible. Documented; the fallback (using the edge
   pred itself) is not generally admissible.
@@ -117,17 +120,17 @@ relevant feature sections. Not bugs -- intentional scope boundaries.
 If you're picking up this campaign, these are the obvious next steps in
 roughly priority order:
 
-1. **Operator declarations (`op/3`)** in the term parser. Quality-of-life
-   for `read_term_from_atom/2,3` and any user code that ports Prolog
-   source between targets.
-2. **LMDB / grouped-by-first TSV backends** for `r_fact_sources`. Mirrors
+1. **LMDB / grouped-by-first TSV backends** for `r_fact_sources`. Mirrors
    the Scala precedent; the `fact_source_spec_to_*` clauses in
    `wam_scala_target.pl` are templates.
-3. **Performance profiling + targeted optimization.** First PR should
+2. **Performance profiling + targeted optimization.** First PR should
    add `Rprof` instrumentation around `wam_r_fact_source_bench.pl` and
    identify a single hot path; subsequent PRs each fix one bottleneck.
    Tagged-list `$tag` access and env-based register lookups are likely
    suspects.
+3. **Postfix operator parser path.** Add `WamRuntime$op_postfix` and
+   the parser case so `op(P, xf, ...)` / `op(P, yf, ...)` work. Small
+   bounded follow-up to the `op/3` PR.
 4. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
    mode info per predicate (in/out per arg); Phase 2 wires it to
    specialised emission (skip unifications when the mode says the slot

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -1478,6 +1478,54 @@ r_foreign_handlers_code(Options, Code) :-
 r_foreign_handler_entry(handler(Pred/Arity, HandlerCode), Entry) :-
     format(string(Entry), '    "~w/~w" = ~w', [Pred, Arity, HandlerCode]).
 
+%% r_op_decls_code(+Options, -Code) is det.
+%  Renders the program-init operator-declaration block. Reads
+%  r_op_decls([op(P, T, N), ...]) from Options. Each `op(P, T, N)`
+%  emits one `WamRuntime$op_set("<N>", <P>L, "<T>")` call so the
+%  parser sees the operator before any read_term_from_atom or CLI
+%  arg parsing happens. Names that collide with the built-in ops
+%  override the built-in entry.
+r_op_decls_code(Options, Code) :-
+    option(r_op_decls(Decls), Options, []),
+    maplist(r_op_decl_line, Decls, Lines),
+    atomic_list_concat(Lines, '\n', Code).
+
+r_op_decl_line(op(Prec, Type, Name), Line) :-
+    must_be(integer, Prec),
+    must_be(atom, Type),
+    Prec >= 0, Prec =< 1200,
+    memberchk(Type, [xfx, xfy, yfx, fx, fy, xf, yf]),
+    (   atom(Name)
+    ->  r_string_literal_atom(Name, NameLit),
+        format(string(Line), 'WamRuntime$op_set(~w, ~wL, "~w")',
+               [NameLit, Prec, Type])
+    ;   is_list(Name),
+        forall(member(N, Name), must_be(atom, N))
+    ->  maplist([N, NL]>>r_string_literal_atom(N, NL), Name, NameLits),
+        atomic_list_concat(NameLits, ', ', NamesJoined),
+        format(string(Line),
+               'for (nm in c(~w)) WamRuntime$op_set(nm, ~wL, "~w")',
+               [NamesJoined, Prec, Type])
+    ).
+
+% Quote an atom as a double-quoted R string literal, escaping
+% backslashes and double quotes. Used by r_op_decls_code so an op
+% name like `\\+` survives as `"\\\\+"` in emitted R source.
+r_string_literal_atom(Atom, Lit) :-
+    atom_string(Atom, S),
+    string_chars(S, Chars),
+    r_escape_chars(Chars, Escaped),
+    string_chars(EscStr, Escaped),
+    format(string(Lit), '"~w"', [EscStr]).
+
+r_escape_chars([], []).
+r_escape_chars(['\\' | T], ['\\', '\\' | RestEsc]) :- !,
+    r_escape_chars(T, RestEsc).
+r_escape_chars(['"'  | T], ['\\', '"'  | RestEsc]) :- !,
+    r_escape_chars(T, RestEsc).
+r_escape_chars([C    | T], [C | RestEsc]) :-
+    r_escape_chars(T, RestEsc).
+
 % ============================================================================
 % PROJECT WRITER
 % ============================================================================
@@ -1504,11 +1552,12 @@ write_wam_r_project(Predicates, Options, ProjectDir) :-
     atomic_list_concat(TopLevelLabelEntries, ',\n', DispatchBody),
     atomic_list_concat(AllLabelEntries, ',\n', LabelBody),
     r_foreign_handlers_code(Options, ForeignHandlersBody),
+    r_op_decls_code(Options, OpDeclsBody),
     write_runtime_source(RDir),
     write_program_source(RDir, InstrBody, LabelBody, DispatchBody,
                          WrapperCode, IdToStringStr, ForeignHandlersBody,
                          LoweredFunctionsCode, FactShapeComments,
-                         LoweredDispatchCode).
+                         LoweredDispatchCode, OpDeclsBody).
 
 write_description(ProjectDir, ModName) :-
     find_template('templates/targets/r_wam/DESCRIPTION.mustache', Template),
@@ -1528,7 +1577,7 @@ write_runtime_source(RDir) :-
 write_program_source(RDir, InstrBody, LabelBody, DispatchBody,
                      WrapperCode, IdToStringStr, ForeignHandlersBody,
                      LoweredFunctionsCode, FactShapeComments,
-                     LoweredDispatchCode) :-
+                     LoweredDispatchCode, OpDeclsBody) :-
     find_template('templates/targets/r_wam/program.R.mustache', Template),
     get_time(T), format_time(string(DateStr), "%Y-%m-%d", T),
     render_template(Template,
@@ -1541,7 +1590,8 @@ write_program_source(RDir, InstrBody, LabelBody, DispatchBody,
           'lowered_dispatch_assignments'=LoweredDispatchCode,
           'foreign_handlers'=ForeignHandlersBody,
           'lowered_functions'=LoweredFunctionsCode,
-          'fact_shape_comments'=FactShapeComments
+          'fact_shape_comments'=FactShapeComments,
+          'op_decls'=OpDeclsBody
         ], Content),
     directory_file_path(RDir, 'generated_program.R', Path),
     write_file(Path, Content).

--- a/templates/targets/r_wam/program.R.mustache
+++ b/templates/targets/r_wam/program.R.mustache
@@ -23,6 +23,14 @@ intern_seed <- c(
 intern_table <- WamRuntime$new_intern_table(intern_seed)
 
 # ----------------------------------------------------------
+# Compile-time operator declarations (from r_op_decls option)
+# Mutates WamRuntime$op_infix / WamRuntime$op_prefix before any
+# read_term_from_atom or CLI arg parsing happens. Empty when
+# r_op_decls is unspecified.
+# ----------------------------------------------------------
+{{op_decls}}
+
+# ----------------------------------------------------------
 # Shared WAM instruction array (1-based)
 # ----------------------------------------------------------
 # Fact shape classification

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -725,6 +725,124 @@ WamRuntime$op_prefix <- list(
   "\\"  = list(prec = 200L)
 )
 
+# ----------------------------------------------------------
+# Operator-table mutation helpers (used by op/3, current_op/3,
+# and the codegen-emitted r_op_decls block).
+# ----------------------------------------------------------
+
+# Resolve op/3's third arg: an atom (single name) or a proper list of
+# atoms (multiple names). Returns a character vector or NULL on bad
+# input. Bound atoms only -- unbound vars or non-atom list elements
+# fail the lookup.
+WamRuntime$op_resolve_names <- function(state, name_v, table) {
+  if (is.null(name_v) || is.null(name_v$tag)) return(NULL)
+  if (name_v$tag == "atom") {
+    return(WamRuntime$string_of(table, name_v$id))
+  }
+  if (name_v$tag == "struct") {
+    elems <- WamRuntime$wam_list_decompose(state, name_v, table)
+    if (is.null(elems)) return(NULL)
+    out <- character(length(elems))
+    for (i in seq_along(elems)) {
+      e <- WamRuntime$deref(state, elems[[i]])
+      if (is.null(e) || is.null(e$tag) || e$tag != "atom") return(NULL)
+      out[i] <- WamRuntime$string_of(table, e$id)
+    }
+    return(out)
+  }
+  NULL
+}
+
+# Insert / replace / remove an entry in op_infix or op_prefix based on
+# the fixity type. Priority 0 removes; non-zero inserts. The type's
+# table choice is implicit: xfx/xfy/yfx -> infix, fx/fy -> prefix.
+# Note: assigning to `WamRuntime$op_infix[[name]]` reads the list,
+# updates the named element, and assigns the modified list back; the
+# parser sees the new entry on its next read of the table.
+WamRuntime$op_set <- function(name, prec, type_str) {
+  is_infix  <- type_str %in% c("xfx", "xfy", "yfx")
+  is_prefix <- type_str %in% c("fx", "fy")
+  if (prec == 0L) {
+    if (is_infix) WamRuntime$op_infix[[name]]   <- NULL
+    if (is_prefix) WamRuntime$op_prefix[[name]] <- NULL
+    return(invisible(NULL))
+  }
+  if (is_infix) {
+    WamRuntime$op_infix[[name]] <- list(prec = as.integer(prec),
+                                         assoc = type_str)
+  } else if (is_prefix) {
+    WamRuntime$op_prefix[[name]] <- list(prec = as.integer(prec),
+                                          assoc = type_str)
+  }
+  invisible(NULL)
+}
+
+# Materialize a (prec, type, name) snapshot of both op tables. Used
+# by current_op/3 to enumerate ops with stable semantics under
+# concurrent table mutation.
+WamRuntime$op_snapshot <- function(table) {
+  out <- list()
+  for (nm in names(WamRuntime$op_infix)) {
+    entry <- WamRuntime$op_infix[[nm]]
+    out <- c(out, list(list(prec = entry$prec, type = entry$assoc, name = nm)))
+  }
+  for (nm in names(WamRuntime$op_prefix)) {
+    entry <- WamRuntime$op_prefix[[nm]]
+    type <- if (!is.null(entry$assoc)) entry$assoc else "fx"
+    out <- c(out, list(list(prec = entry$prec, type = type, name = nm)))
+  }
+  out
+}
+
+# current_op/3 iterator: tries each (prec, type, name) tuple in turn;
+# on success pushes an iter CP to resume at the next index. Same
+# CP shape as fact_table_iter_subset / member_iter.
+WamRuntime$current_op_iter <- function(program, state, snapshot, idx,
+                                        resume_pc) {
+  if (idx > length(snapshot)) return(FALSE)
+  table <- program$intern_table
+  for (i in seq.int(idx, length(snapshot))) {
+    entry <- snapshot[[i]]
+    snap_trail <- length(state$trail)
+    snap_vc    <- state$var_counter
+    ok <- WamRuntime$unify(state, WamRuntime$get_reg(state, 1L),
+                           IntTerm(entry$prec)) &&
+          WamRuntime$unify(state, WamRuntime$get_reg(state, 2L),
+                           Atom(WamRuntime$intern(table, entry$type))) &&
+          WamRuntime$unify(state, WamRuntime$get_reg(state, 3L),
+                           Atom(WamRuntime$intern(table, entry$name)))
+    if (ok) {
+      if (i < length(snapshot)) {
+        captured_program  <- program
+        captured_snapshot <- snapshot
+        captured_next     <- i + 1L
+        captured_resume   <- resume_pc
+        cp <- list(
+          kind        = "iter",
+          regs        = as.list.environment(state$regs2),
+          trail_len   = snap_trail,
+          cp          = state$cp,
+          var_counter = snap_vc,
+          mode        = state$mode,
+          build_stack = state$build_stack,
+          resume_pc   = resume_pc,
+          retry       = function(state) {
+            WamRuntime$current_op_iter(captured_program, state,
+                                        captured_snapshot,
+                                        captured_next,
+                                        captured_resume)
+          }
+        )
+        state$cps <- c(state$cps, list(cp))
+      }
+      return(TRUE)
+    }
+    WamRuntime$undo_trail_to(state, snap_trail)
+    state$var_counter <- snap_vc
+  }
+  FALSE
+}
+
 WamRuntime$parse_term <- function(text, table, state) {
   toks <- WamRuntime$tokenize_term(text)
   if (is.null(toks) || length(toks) == 0L) return(NULL)
@@ -4656,6 +4774,50 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     parsed <- WamRuntime$parse_term(text, table, state)
     if (is.null(parsed)) return(FALSE)
     return(WamRuntime$unify(state, raw_t, parsed))
+  }
+
+  # ----- op/3 -----
+  # op(+Priority, +Type, +Name).
+  #   Declare a custom operator. Type is one of the standard Prolog
+  #   fixities: xfx / xfy / yfx (binary) or fx / fy (prefix). Postfix
+  #   xf / yf are recognised but not yet supported -- they raise an R
+  #   error rather than silently failing, so callers know not to rely
+  #   on them. Priority 0 removes the operator from the table that
+  #   matches the type. Name is either an atom or a proper list of
+  #   atoms; the latter applies the same declaration to every name.
+  if (key == "op/3") {
+    prec_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+    type_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 2L))
+    name_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 3L))
+    if (is.null(prec_v) || is.null(prec_v$tag) || prec_v$tag != "int") return(FALSE)
+    if (is.null(type_v) || is.null(type_v$tag) || type_v$tag != "atom") return(FALSE)
+    prec <- as.integer(prec_v$val)
+    if (prec < 0L || prec > 1200L) return(FALSE)
+    type_str <- WamRuntime$string_of(table, type_v$id)
+    if (type_str %in% c("xf", "yf")) {
+      stop(sprintf("op/3: postfix operators (%s) not yet supported in WAM-R", type_str))
+    }
+    if (!(type_str %in% c("xfx", "xfy", "yfx", "fx", "fy"))) return(FALSE)
+    names_vec <- WamRuntime$op_resolve_names(state, name_v, table)
+    if (is.null(names_vec)) return(FALSE)
+    for (nm in names_vec) {
+      WamRuntime$op_set(nm, prec, type_str)
+    }
+    return(TRUE)
+  }
+
+  # ----- current_op/3 -----
+  # current_op(?Priority, ?Type, ?Name).
+  #   Backtrackable enumeration over the operator tables. We materialize
+  #   a snapshot list of all (prec, type, name) triples, then unify
+  #   against the args; an iter CP replays the next index on backtrack.
+  #   Snapshot semantics match `clause/2` / `retract/1`: ops added or
+  #   removed during the iteration are not seen.
+  if (key == "current_op/3") {
+    snapshot <- WamRuntime$op_snapshot(table)
+    if (length(snapshot) == 0L) return(FALSE)
+    return(WamRuntime$current_op_iter(program, state, snapshot, 1L,
+                                       state$pc + 1L))
   }
 
   # ----- read_term_from_atom/2 and read_term_from_atom/3 -----

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -1895,6 +1895,151 @@ e2e_operator_parser_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for the runtime op/3 builtin. The driver
+% predicates declare a custom operator at runtime and then exercise
+% read_term_from_atom and current_op/3 against the augmented parser
+% table. Covers infix add, prefix add, xfy right-associativity for a
+% custom op, op(0, ...) removal, and current_op/3 enumeration.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(op_3_runtime_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_op_3_runtime_via_rscript
+    ;   true
+    )).
+
+e2e_op_3_runtime_via_rscript :-
+    setup_call_cleanup(
+        e2e_op_3_runtime_setup(TmpDir),
+        e2e_op_3_runtime_body(TmpDir),
+        e2e_op_3_runtime_cleanup(TmpDir)).
+
+e2e_op_3_runtime_setup(TmpDir) :-
+    % op/3 adds an infix op; subsequent read_term_from_atom uses it.
+    % Decompose via =.. to avoid needing the op at SWI-Prolog level.
+    assertz((user:op_runtime_infix :-
+        op(900, xfy, '==>'),
+        read_term_from_atom('a==>b', T),
+        T =.. [F, A, B],
+        F == '==>', A == a, B == b)),
+    % xfy right-associativity: 'a ==> b ==> c' parses as (a ==> (b ==> c)).
+    assertz((user:op_runtime_xfy :-
+        op(900, xfy, '==>'),
+        read_term_from_atom('a==>b==>c', T),
+        T =.. [_, _, RHS],
+        RHS =.. [F2, B, C],
+        F2 == '==>', B == b, C == c)),
+    % Prefix op: 'neg foo' parses as neg(foo). The space matters --
+    % 'neg(foo)' would parse as a function call regardless of op decl.
+    assertz((user:op_runtime_prefix :-
+        op(200, fy, neg),
+        read_term_from_atom('neg foo', T),
+        T =.. [F, X],
+        F == neg, X == foo)),
+    % current_op/3 enumeration finds the new op.
+    assertz((user:op_runtime_current :-
+        op(900, xfy, '==>'),
+        findall(P, current_op(P, xfy, '==>'), Precs),
+        Precs == [900])),
+    % op(0, T, N) removes; subsequent parse fails.
+    assertz((user:op_runtime_remove :-
+        op(900, xfy, '==>'),
+        op(0, xfy, '==>'),
+        \+ read_term_from_atom('a==>b', _))),
+    unique_r_tmp_dir('tmp_r_op_3_runtime_e2e', TmpDir).
+
+e2e_op_3_runtime_body(TmpDir) :-
+    write_wam_r_project(
+        [user:op_runtime_infix/0, user:op_runtime_xfy/0,
+         user:op_runtime_prefix/0, user:op_runtime_current/0,
+         user:op_runtime_remove/0],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [op_runtime_infix, op_runtime_xfy, op_runtime_prefix,
+           op_runtime_current, op_runtime_remove],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )).
+
+e2e_op_3_runtime_cleanup(TmpDir) :-
+    retractall(user:op_runtime_infix),
+    retractall(user:op_runtime_xfy),
+    retractall(user:op_runtime_prefix),
+    retractall(user:op_runtime_current),
+    retractall(user:op_runtime_remove),
+    ignore(catch(delete_directory_and_contents(TmpDir), _, true)).
+
+% ------------------------------------------------------------------
+% End-to-end Rscript run for the r_op_decls codegen option. The
+% generated program seeds the operator table at init time, so no
+% runtime op/3 call is needed -- read_term_from_atom recognises
+% the custom ops out of the box.
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(op_3_decl_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_op_3_decl_via_rscript
+    ;   true
+    )).
+
+e2e_op_3_decl_via_rscript :-
+    setup_call_cleanup(
+        e2e_op_3_decl_setup(TmpDir),
+        e2e_op_3_decl_body(TmpDir),
+        e2e_op_3_decl_cleanup(TmpDir)).
+
+e2e_op_3_decl_setup(TmpDir) :-
+    assertz((user:op_decl_infix :-
+        read_term_from_atom('a==>b', T),
+        T =.. [F, A, B],
+        F == '==>', A == a, B == b)),
+    assertz((user:op_decl_prefix :-
+        read_term_from_atom('neg foo', T),
+        T =.. [F, X],
+        F == neg, X == foo)),
+    % Multi-name list form: r_op_decls accepts op(P, T, [N1, N2, ...]).
+    assertz((user:op_decl_listform :-
+        read_term_from_atom('a~b', T1),
+        T1 =.. [F1, _, _], F1 == '~',
+        read_term_from_atom('a@b', T2),
+        T2 =.. [F2, _, _], F2 == '@')),
+    unique_r_tmp_dir('tmp_r_op_3_decl_e2e', TmpDir).
+
+e2e_op_3_decl_body(TmpDir) :-
+    write_wam_r_project(
+        [user:op_decl_infix/0, user:op_decl_prefix/0,
+         user:op_decl_listform/0],
+        [r_op_decls([op(900, xfy, '==>'),
+                     op(200, fy, neg),
+                     op(700, xfx, ['~', '@'])])],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [op_decl_infix, op_decl_prefix, op_decl_listform],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    % Structural: codegen emits one op_set call per name (list-form
+    % expanded into a `for (nm in c(...))` loop).
+    directory_file_path(TmpDir, 'R/generated_program.R', ProgPath),
+    read_file_to_string(ProgPath, Code, []),
+    assertion(sub_string(Code, _, _, _, 'WamRuntime$op_set("==>", 900L, "xfy")')),
+    assertion(sub_string(Code, _, _, _, 'WamRuntime$op_set("neg", 200L, "fy")')),
+    assertion(sub_string(Code, _, _, _, 'for (nm in c("~", "@")) WamRuntime$op_set(nm, 700L, "xfx")')).
+
+e2e_op_3_decl_cleanup(TmpDir) :-
+    retractall(user:op_decl_infix),
+    retractall(user:op_decl_prefix),
+    retractall(user:op_decl_listform),
+    ignore(catch(delete_directory_and_contents(TmpDir), _, true)).
+
+% ------------------------------------------------------------------
 % End-to-end Rscript run for multi-solution retract/1. Asserts a
 % handful of facts, drives findall(X, retract(p(X)), L) so the
 % retract iterates across all matches via the iter-CP retry, and


### PR DESCRIPTION
## Summary

Adds user-defined operator support to the WAM-R term parser, closing handoff follow-up #1. Custom operators can be declared at runtime via the `op/3` builtin or at codegen time via the new `r_op_decls(...)` option to `write_wam_r_project/3`. Both paths feed into the same parser tables (`WamRuntime$op_infix` / `WamRuntime$op_prefix`), so subsequent `read_term_from_atom/2,3` and CLI arg parses recognise the new operator.

- **Runtime `op/3` builtin** validates priority (`0..1200`), type (`xfx`/`xfy`/`yfx`/`fx`/`fy`), and name (atom or proper list). Priority `0` removes. Postfix `xf`/`yf` are recognised but raise an R error — the parser doesn't have a postfix path yet (added as new follow-up #3 in the handoff).
- **`current_op/3` builtin**: backtrackable enumeration with snapshot semantics matching `clause/2` / `retract/1`.
- **Codegen `r_op_decls([op(P, T, N), ...])` option**: emits one `WamRuntime$op_set(...)` line per declaration into program init, before any CLI parsing. List-form names (`op(P, T, [N1, N2, ...])`) expand to a `for (nm in c(...))` loop.

## Test plan

- [x] `op_3_runtime_e2e_rscript`: infix add, prefix add, xfy right-associativity, `op(0, ...)` removal, `current_op/3` enumeration (5 drivers)
- [x] `op_3_decl_e2e_rscript`: codegen path with atom-name and list-of-names forms, plus structural assertion on emitted `op_set` calls (3 drivers)
- [x] Both new tests wrapped in `setup_call_cleanup/3` for test isolation
- [x] Closely-related existing tests still pass: `fact_table_e2e_rscript`, `fact_table_multi_arg_index_e2e_rscript`, `kernel_tc2_e2e_rscript`, `operator_parser_e2e_rscript`, `read_term_clause_e2e_rscript`

## Note

The pre-existing `external_fact_source_e2e_rscript` failure on main (`atomic_list_concat/3: instantiation_error`) is reproducible on bare main without this PR's changes; left unfixed in this PR. Should be tracked as a separate issue.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_