### PR TITLE
fix(wam-r): bind NewFactCommentAcc in external-fact-source branch

### DIFF
--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -768,7 +768,12 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
         format(string(MainEntry), '    "~w/~w" = ~wL', [P, Arity, BasePC]),
         NewTopLabels = [MainEntry | TopLabelAcc],
         NewAllLabels = [MainEntry | AllLabelAcc],
-        WamCodeForLower = ""
+        WamCodeForLower = "",
+        % External fact sources have no clause body to classify, so
+        % no fact-shape comment is emitted. Without this binding the
+        % accumulator carries an unbound tail, blowing up the
+        % atomic_list_concat in compile_predicates_for_project.
+        NewFactCommentAcc = FactCommentAcc
     ;   r_foreign_predicate(P, Arity, Options)
     ->  format(string(FLit), 'CallForeign("~w", ~w)', [P, Arity]),
         ForeignSeq = [FLit, 'Proceed()'],


### PR DESCRIPTION
## Summary

Fixes the `external_fact_source_e2e_rscript` test, which was failing on main with `atomic_list_concat/3: Arguments are not sufficiently instantiated`.

**Root cause.** In `compile_all_predicates`, the `r_fact_source_spec` branch was missing the `NewFactCommentAcc = FactCommentAcc` binding that the other two branches (foreign predicate, regular WAM compilation) had. The unbound accumulator propagated through the recursion and surfaced when `compile_predicates_for_project` tried to fold `FactComments` into the rendered `fact_shape_comments` block via `atomic_list_concat/3`.

**Why it slipped past CI.** The bug was introduced in `873dc76` (the original external-fact-sources PR), and the matching e2e test was added in the same commit. The test auto-skips when `Rscript` isn't on `PATH`, which masked the regression. With `Rscript` available the failure is deterministic.

**Fix.** One-line addition: bind `NewFactCommentAcc = FactCommentAcc` in the `r_fact_source_spec` branch (external fact sources have no Prolog clause body to classify, so no fact-shape comment is emitted — same shape as the foreign-predicate branch).

## Test plan

- [x] `external_fact_source_e2e_rscript` now passes (was failing on bare main with `atomic_list_concat/3: instantiation_error`)
- [x] Full WAM-R suite: 63/63 pass

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_