### PR TITLE
Add Lua WAM fact stream parity

### DIFF
--- a/PR_lua_wam_fact_stream_parity.md
+++ b/PR_lua_wam_fact_stream_parity.md
@@ -1,0 +1,23 @@
+# PR Title
+
+Add Lua WAM fact stream parity
+
+# PR Description
+
+## Summary
+
+- Add Lua WAM `CallFactStream` instruction/runtime support for inline binary fact streams.
+- Add generated-program `inline_facts` storage for simple binary ground fact-only predicates.
+- Teach the Lua WAM generator to detect eligible `P/2` fact-only WAM and emit `CallFactStream` instead of full clause WAM.
+- Stream inline fact rows at runtime, unifying `A1`/`A2` and backtracking over remaining rows.
+- Add focused emission and e2e tests, including a normal caller predicate that returns through a fact-stream predicate.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`
+
+## Notes
+
+This closes the first Lua parity gap against Haskell's `CallFactStream` path for in-memory binary facts. External `FactSource`/file/LMDB-backed fact streaming remains a larger follow-up.

--- a/src/unifyweaver/targets/wam_lua_target.pl
+++ b/src/unifyweaver/targets/wam_lua_target.pl
@@ -410,7 +410,7 @@ compile_wam_predicate_to_lua(_Pred, _WamCode, _Options, "").
 
 compile_predicates_for_project(Predicates, Options,
                                AllInstrs, TopLabels, AllLabels,
-                               WrapperCode, LoweredCode) :-
+                               WrapperCode, LoweredCode, InlineFactsCode) :-
     init_lua_atom_intern_table,
     option(intern_atoms(ExtraAtoms), Options, []),
     forall(member(A, ExtraAtoms), (atom_string(A, S), intern_lua_atom(S, _))),
@@ -418,10 +418,11 @@ compile_predicates_for_project(Predicates, Options,
     append_missing_foreign_predicates(Predicates, ForeignPredicates, CompilePreds),
     wam_lua_resolve_emit_mode(Options, Mode),
     compile_all_predicates(CompilePreds, Options, Mode, 1,
-        [], [], [], [], [],
-        AllInstrs, TopLabels, AllLabels, Wrappers, LoweredEntries),
+        [], [], [], [], [], [],
+        AllInstrs, TopLabels, AllLabels, Wrappers, LoweredEntries, InlineFacts),
     atomic_list_concat(Wrappers, '\n', WrapperCode),
-    atomic_list_concat(LoweredEntries, '\n', LoweredCode).
+    atomic_list_concat(LoweredEntries, '\n', LoweredCode),
+    atomic_list_concat(InlineFacts, ',\n', InlineFactsCode).
 
 append_missing_foreign_predicates(Predicates, ForeignPredicates, CompilePredicates) :-
     findall(F, (member(F, ForeignPredicates), \+ (member(P, Predicates), same_pi(P, F))), Missing),
@@ -431,19 +432,32 @@ same_pi(P0, P1) :- pi_key(P0, K), pi_key(P1, K).
 pi_key(_:P/A, P/A) :- !.
 pi_key(P/A, P/A).
 
-compile_all_predicates([], _, _, _, Instrs, TopLabels, AllLabels, Wrappers, Lowered,
-                       Instrs, TopLabels, AllLabels, Wrappers, Lowered).
+compile_all_predicates([], _, _, _, Instrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts,
+                       Instrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts).
 compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
-                       InstrAcc, TopLabelAcc, AllLabelAcc, WrapperAcc, LoweredAcc,
-                       AllInstrs, TopLabels, AllLabels, Wrappers, Lowered) :-
+                       InstrAcc, TopLabelAcc, AllLabelAcc, WrapperAcc, LoweredAcc, InlineFactAcc,
+                       AllInstrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts) :-
     (Pred = _M:P/Arity -> true ; Pred = P/Arity),
     (   lua_foreign_predicate(P, Arity, Options)
     ->  lua_string_literal(P, PQ),
         format(string(FLit), 'I.CallForeign(~w, ~w)', [PQ, Arity]),
         PredInstrs = [FLit, 'I.Proceed()'],
-        WamForLower = ""
+        WamForLower = "",
+        PredSubLabelEntries0 = [],
+        InlineFactEntry = none
     ;   compile_predicate_to_wam(P/Arity, [], WamForLower),
-        wam_code_to_lua_data(WamForLower, Options, PredInstrs, PredSubLabelEntries0)
+        (   Arity == 2,
+            lua_inline_fact_tuples(WamForLower, Tuples),
+            Tuples \= []
+        ->  format(string(Key), '~w/~w', [P, Arity]),
+            lua_string_literal(Key, KeyQ),
+            format(string(FLit), 'I.CallFactStream(~w, ~w)', [KeyQ, Arity]),
+            PredInstrs = [FLit, 'I.Proceed()'],
+            PredSubLabelEntries0 = [],
+            lua_inline_fact_entry(Key, Tuples, InlineFactEntry)
+        ;   wam_code_to_lua_data(WamForLower, Options, PredInstrs, PredSubLabelEntries0),
+            InlineFactEntry = none
+        )
     ),
     length(PredInstrs, PredLen),
     append(InstrAcc, PredInstrs, NewInstrs),
@@ -462,6 +476,7 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
     append([MainEntry|PredSubLabelEntries], AllLabelAcc, NewAllLabels),
     (   should_try_lower(Mode, P, Arity),
         WamForLower \= "",
+        InlineFactEntry == none,
         catch(wam_lua_lowerable(Pred, WamForLower, _), _, fail),
         catch(lower_predicate_to_lua(Pred, WamForLower, [],
                                      lowered(_, FuncName, LoweredLua)), _, fail)
@@ -470,9 +485,64 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
     ;   NewLoweredAcc = LoweredAcc,
         emit_lua_wrapper(P, Arity, BasePC, Wrapper)
     ),
+    (InlineFactEntry == none -> NewInlineFactAcc = InlineFactAcc ; NewInlineFactAcc = [InlineFactEntry|InlineFactAcc]),
     compile_all_predicates(Rest, Options, Mode, NewPC,
-        NewInstrs, NewTopLabels, NewAllLabels, [Wrapper|WrapperAcc], NewLoweredAcc,
-        AllInstrs, TopLabels, AllLabels, Wrappers, Lowered).
+        NewInstrs, NewTopLabels, NewAllLabels, [Wrapper|WrapperAcc], NewLoweredAcc, NewInlineFactAcc,
+        AllInstrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts).
+
+lua_inline_fact_tuples(WamCode, Tuples) :-
+    atom_string(WamCode, Str),
+    split_string(Str, "\n", "", Lines),
+    lua_wam_segments(Lines, Segments),
+    Segments \= [],
+    lua_fact_only_segments(Segments),
+    findall(A1-A2, (
+        member(Instrs, Segments),
+        member(["get_constant", A1, "A1"], Instrs),
+        member(["get_constant", A2, "A2"], Instrs)
+    ), Tuples).
+
+lua_wam_segments([], []).
+lua_wam_segments([Line|Rest], Segments) :-
+    tokenize_wam_line(Line, Parts),
+    (   Parts == []
+    ->  lua_wam_segments(Rest, Segments)
+    ;   Parts = [First|_], sub_string(First, _, 1, 0, ":")
+    ->  lua_segment_instrs(Rest, Instrs, Remaining),
+        Segments = [Instrs|More],
+        lua_wam_segments(Remaining, More)
+    ;   lua_wam_segments(Rest, Segments)
+    ).
+
+lua_segment_instrs([], [], []).
+lua_segment_instrs([Line|Rest], Instrs, Remaining) :-
+    tokenize_wam_line(Line, Parts),
+    (   Parts == []
+    ->  lua_segment_instrs(Rest, Instrs, Remaining)
+    ;   Parts = [First|_], sub_string(First, _, 1, 0, ":")
+    ->  Instrs = [], Remaining = [Line|Rest]
+    ;   Instrs = [Parts|More],
+        lua_segment_instrs(Rest, More, Remaining)
+    ).
+
+lua_fact_only_segments(Segments) :-
+    forall(member(Instrs, Segments),
+           forall(member(Parts, Instrs), \+ lua_body_call_instr(Parts))).
+
+lua_body_call_instr(["call"|_]).
+lua_body_call_instr(["execute"|_]).
+lua_body_call_instr(["builtin_call"|_]).
+
+lua_inline_fact_entry(Key, Tuples, Entry) :-
+    lua_string_literal(Key, KeyQ),
+    maplist(lua_inline_fact_tuple_lit, Tuples, TupleLits),
+    atomic_list_concat(TupleLits, ', ', TuplesText),
+    format(string(Entry), '  [~w] = {~w}', [KeyQ, TuplesText]).
+
+lua_inline_fact_tuple_lit(A1-A2, Lit) :-
+    intern_lua_atom(A1, I1),
+    intern_lua_atom(A2, I2),
+    format(string(Lit), '{V.Atom(~w), V.Atom(~w)}', [I1, I2]).
 
 offset_label_entry(Offset, Entry0, Entry) :-
     atom_string(Entry0, S),
@@ -554,7 +624,7 @@ write_wam_lua_project(Predicates, Options, ProjectDir) :-
     directory_file_path(ProjectDir, 'lua', LuaDir),
     make_directory_path(LuaDir),
     compile_predicates_for_project(Predicates, Options,
-        AllInstrs, TopLabels, AllLabels, WrapperCode, LoweredCode),
+        AllInstrs, TopLabels, AllLabels, WrapperCode, LoweredCode, InlineFactsCode),
     emit_lua_intern_table(InternSeed),
     maplist([I, Line]>>(format(string(Line), '  ~w', [I])), AllInstrs, InstrLines),
     atomic_list_concat(InstrLines, ',\n', InstrBody),
@@ -563,7 +633,7 @@ write_wam_lua_project(Predicates, Options, ProjectDir) :-
     lua_foreign_handlers_code(Options, ForeignHandlers),
     write_runtime_source(LuaDir),
     write_program_source(LuaDir, InstrBody, LabelBody, DispatchBody,
-                         WrapperCode, InternSeed, ForeignHandlers, LoweredCode).
+                         WrapperCode, InternSeed, ForeignHandlers, LoweredCode, InlineFactsCode).
 
 write_runtime_source(LuaDir) :-
     find_template('templates/targets/lua_wam/runtime.lua.mustache', Template),
@@ -573,7 +643,7 @@ write_runtime_source(LuaDir) :-
     write_file(Path, Content).
 
 write_program_source(LuaDir, InstrBody, LabelBody, DispatchBody,
-                     WrapperCode, InternSeed, ForeignHandlers, LoweredCode) :-
+                     WrapperCode, InternSeed, ForeignHandlers, LoweredCode, InlineFactsCode) :-
     find_template('templates/targets/lua_wam/program.lua.mustache', Template),
     get_time(T), format_time(string(Date), "%Y-%m-%d", T),
     render_template(Template,
@@ -584,7 +654,8 @@ write_program_source(LuaDir, InstrBody, LabelBody, DispatchBody,
          'wrappers'=WrapperCode,
          'intern_id_to_string'=InternSeed,
          'foreign_handlers'=ForeignHandlers,
-         'lowered_functions'=LoweredCode], Content),
+         'lowered_functions'=LoweredCode,
+         'inline_facts'=InlineFactsCode], Content),
     directory_file_path(LuaDir, 'generated_program.lua', Path),
     write_file(Path, Content).
 

--- a/templates/targets/lua_wam/program.lua.mustache
+++ b/templates/targets/lua_wam/program.lua.mustache
@@ -29,11 +29,16 @@ local foreign_handlers = {
 {{foreign_handlers}}
 }
 
+local inline_facts = {
+{{inline_facts}}
+}
+
 local shared_program = {
   instructions = shared_instructions,
   labels = shared_labels,
   dispatch = dispatch,
   foreign_handlers = foreign_handlers,
+  inline_facts = inline_facts,
   indexed_atom_fact2 = {},
   intern_table = intern_table
 }

--- a/templates/targets/lua_wam/runtime.lua.mustache
+++ b/templates/targets/lua_wam/runtime.lua.mustache
@@ -36,6 +36,7 @@ function I.SetConstant(c) return instr("SetConstant", { c = c }) end
 function I.Call(p, n) return instr("Call", { pred = p, arity = n }) end
 function I.CallPc(pc, n) return instr("CallPc", { pc = pc, arity = n }) end
 function I.CallIndexedAtomFact2(p) return instr("CallIndexedAtomFact2", { pred = p }) end
+function I.CallFactStream(p, n) return instr("CallFactStream", { pred = p, arity = n }) end
 function I.Execute(p, n) return instr("Execute", { pred = p, arity = n }) end
 function I.ExecutePc(pc) return instr("ExecutePc", { pc = pc }) end
 function I.CallForeign(p, n) return instr("CallForeign", { pred = p, arity = n }) end
@@ -258,6 +259,28 @@ function Runtime.backtrack(state)
     state.halt = false
     return true
   end
+  if cp.kind == "fact_stream" then
+    while #state.trail > cp.trail_len do
+      local name = table.remove(state.trail)
+      state.bindings[name] = nil
+    end
+    state.regs = Runtime.copy_table(cp.regs)
+    state.cp = cp.cp
+    state.var_counter = cp.var_counter
+    state.mode = cp.mode
+    state.build_stack = cp.build_stack or {}
+    local row = table.remove(cp.rows, 1)
+    if #cp.rows == 0 then table.remove(state.cps) end
+    if Runtime.unify(state, Runtime.get_reg(state, 1), row[1]) ~= true then
+      return Runtime.backtrack(state)
+    end
+    if Runtime.unify(state, Runtime.get_reg(state, 2), row[2]) ~= true then
+      return Runtime.backtrack(state)
+    end
+    state.pc = cp.next_pc
+    state.halt = false
+    return true
+  end
   if cp.kind == "aggregate" then
     table.remove(state.cps)
     while #state.trail > cp.trail_len do
@@ -444,6 +467,30 @@ local function call_indexed_atom_fact2(program, state, instr)
   end
   local atom = V.Atom(Runtime.intern(program.intern_table, values[1]))
   if Runtime.unify(state, Runtime.get_reg(state, 2), atom) ~= true then return false end
+  state.pc = state.pc + 1
+  return true
+end
+
+local function call_fact_stream(program, state, instr)
+  local rows = program.inline_facts and program.inline_facts[instr.pred] or nil
+  if rows == nil or #rows == 0 then return false end
+  if #rows > 1 then
+    local rest = {}
+    for i = 2, #rows do rest[#rest + 1] = rows[i] end
+    table.insert(state.cps, {
+      kind = "fact_stream",
+      next_pc = state.pc + 1,
+      regs = Runtime.copy_table(state.regs),
+      cp = state.cp,
+      trail_len = #state.trail,
+      var_counter = state.var_counter,
+      mode = state.mode,
+      build_stack = state.build_stack,
+      rows = rest
+    })
+  end
+  if Runtime.unify(state, Runtime.get_reg(state, 1), rows[1][1]) ~= true then return false end
+  if Runtime.unify(state, Runtime.get_reg(state, 2), rows[1][2]) ~= true then return false end
   state.pc = state.pc + 1
   return true
 end
@@ -648,6 +695,7 @@ function Runtime.step(program, state, instr)
     return true
   end
   if op == "CallIndexedAtomFact2" then return call_indexed_atom_fact2(program, state, instr) end
+  if op == "CallFactStream" then return call_fact_stream(program, state, instr) end
   if op == "CallPc" then
     state.cp = state.pc + 1
     state.pc = instr.pc

--- a/tests/test_wam_lua_generator.pl
+++ b/tests/test_wam_lua_generator.pl
@@ -24,6 +24,8 @@
 :- dynamic user:wam_lua_agg_min/0.
 :- dynamic user:wam_lua_agg_max/0.
 :- dynamic user:wam_lua_agg_set/0.
+:- dynamic user:wam_lua_stream_fact/2.
+:- dynamic user:wam_lua_stream_caller/2.
 
 user:wam_lua_fact(a).
 user:wam_lua_choice(a).
@@ -58,6 +60,9 @@ user:wam_lua_agg_max :-
 user:wam_lua_agg_set :-
     aggregate_all(set(X), user:wam_lua_num(X), S),
     S = [1, 2, 3].
+user:wam_lua_stream_fact(a, b).
+user:wam_lua_stream_fact(a, c).
+user:wam_lua_stream_caller(X, Y) :- user:wam_lua_stream_fact(X, Y).
 
 test(exports) :-
     assertion(current_predicate(wam_lua_target:write_wam_lua_project/3)),
@@ -132,6 +137,19 @@ test(call_indexed_atom_fact2_literal) :-
     once(wam_parts_to_lua(["call_indexed_atom_fact2", "edge/2"], [], Lit)),
     assertion(Lit == "I.CallIndexedAtomFact2(\"edge/2\")").
 
+test(fact_stream_emitted) :-
+    unique_lua_tmp_dir('tmp_lua_fact_stream_emit', TmpDir),
+    setup_call_cleanup(
+        write_wam_lua_project([user:wam_lua_stream_fact/2], [], TmpDir),
+        ( directory_file_path(TmpDir, 'lua/generated_program.lua', Program),
+          read_file_to_string(Program, Code, []),
+          assertion(sub_string(Code, _, _, _, 'I.CallFactStream("wam_lua_stream_fact/2", 2)')),
+          assertion(sub_string(Code, _, _, _, 'local inline_facts = {')),
+          assertion(sub_string(Code, _, _, _, '["wam_lua_stream_fact/2"] = {{V.Atom('))
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
 test(lua_indexed_atom_fact2_e2e, [condition(lua_available)]) :-
     unique_lua_tmp_dir('tmp_lua_indexed_fact2_e2e', TmpDir),
     setup_call_cleanup(
@@ -150,6 +168,19 @@ test(lua_indexed_atom_fact2_e2e, [condition(lua_available)]) :-
           run_lua_script(LuaDir, Script, Output),
           normalize_space(string(Trimmed), Output),
           assertion(Trimmed == "true true false")
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(lua_fact_stream_e2e, [condition(lua_available)]) :-
+    unique_lua_tmp_dir('tmp_lua_fact_stream_e2e', TmpDir),
+    setup_call_cleanup(
+        write_wam_lua_project([user:wam_lua_stream_fact/2, user:wam_lua_stream_caller/2], [], TmpDir),
+        ( directory_file_path(TmpDir, 'lua', LuaDir),
+          run_lua_query(LuaDir, 'wam_lua_stream_fact/2', [a, b], true),
+          run_lua_query(LuaDir, 'wam_lua_stream_fact/2', [a, c], true),
+          run_lua_query(LuaDir, 'wam_lua_stream_fact/2', [a, d], false),
+          run_lua_query(LuaDir, 'wam_lua_stream_caller/2', [a, c], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

- Add Lua WAM `CallFactStream` instruction/runtime support for inline binary fact streams.
- Add generated-program `inline_facts` storage for simple binary ground fact-only predicates.
- Teach the Lua WAM generator to detect eligible `P/2` fact-only WAM and emit `CallFactStream` instead of full clause WAM.
- Stream inline fact rows at runtime, unifying `A1`/`A2` and backtracking over remaining rows.
- Add focused emission and e2e tests, including a normal caller predicate that returns through a fact-stream predicate.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`

## Notes

This closes the first Lua parity gap against Haskell's `CallFactStream` path for in-memory binary facts. External `FactSource`/file/LMDB-backed fact streaming remains a larger follow-up.
