### PR TITLE
feat(wam-r): grouped-by-first TSV backend for r_fact_sources

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -301,10 +301,17 @@ successive hashing, bitmap intersection), and how this aligns
 with the parameterized C# query runtime -- see
 [`design/WAM_R_FACT_INDEXING.md`](design/WAM_R_FACT_INDEXING.md).
 
-### External fact sources (CSV)
+### External fact sources
 
 Mirrors the Scala target's `scala_fact_sources` option. Users can
-declare a predicate's facts as a separate CSV file:
+declare a predicate's facts as a separate file. Two backends are
+supported today:
+
+- `file('data.csv')` -- comma-separated rows, one fact per row.
+  Any arity.
+- `grouped_by_first('data.tsv')` -- tab-separated rows shaped as
+  `key<TAB>v1<TAB>v2<TAB>...`; the loader explodes each row into
+  separate `(key, vK)` tuples. Arity-2 only.
 
 ```prolog
 :- write_wam_r_project(
@@ -312,21 +319,29 @@ declare a predicate's facts as a separate CSV file:
        [intern_atoms([alice, bob, carol]),
         r_fact_sources([source(cp/2, file('data.csv'))])],
        '/tmp/proj').
+
+:- write_wam_r_project(
+       [user:parent/2, user:test/0],
+       [intern_atoms([alice, bob, carol]),
+        r_fact_sources([source(parent/2,
+                                grouped_by_first('parents.tsv'))])],
+       '/tmp/proj').
 ```
 
 The predicate has **no Prolog clauses** -- the codegen emits a
-runtime CSV loader that reads the file at program-init time and
+runtime loader that reads the file at program-init time and
 populates the standard fact-table data structures
 (`<pred>_facts` / `<pred>_indexes`). The predicate then dispatches
 via the same `fact_table_dispatch` path used by inline-clause
 fact tables (PR #1921), so per-arg hash indexing, multi-
 solution backtracking, and `iterate_goal` integration all work
-the same way.
+the same way regardless of backend.
 
-CSV format: one row per fact, comma-separated; lines starting
-with `#` and blank lines are skipped. Fields that parse as a
-finite numeric become `IntTerm` / `FloatTerm`; everything else
-interns as an atom.
+For both formats: lines starting with `#` and blank lines are
+skipped. Fields that parse as a finite numeric become `IntTerm` /
+`FloatTerm`; everything else interns as an atom. CSV trims each
+field; grouped-by-first additionally drops empty fields and
+silently skips rows with no values (just a key).
 
 For atoms that don't appear in any compiled WAM body but are
 needed by the loaded facts, declare them via `intern_atoms(...)`
@@ -336,7 +351,9 @@ get IDs outside the codegen-known range.
 
 The CLI path works the same as inline fact tables: the
 predicate's body is a single `Execute("P", A)` instruction that
-falls through to the lowered_dispatch tier.
+falls through to the lowered_dispatch tier. To add a new backend,
+add a `fact_source_loader_call/4` clause for the Spec shape and a
+`WamRuntime$read_facts_<shape>(...)` runtime helper.
 
 ### Emit modes
 
@@ -686,6 +703,7 @@ Coverage map (e2e tests, by feature group):
 | `kernel_ca_e2e_rscript` | recursive-kernel detection: `category_ancestor` BFS with depth-cap + visited-set cycle detection |
 | `kernel_astar4_e2e_rscript` | recursive-kernel detection: `astar_shortest_path4` goal-directed search with user heuristic |
 | `external_fact_source_e2e_rscript` | external CSV fact sources via `r_fact_sources([source(P/A, file(...))])` |
+| `external_fact_source_grouped_tsv_e2e_rscript` | external grouped-by-first TSV fact sources (arity-2): `r_fact_sources([source(P/2, grouped_by_first(...))])` |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/docs/handoff/wam_r_session_handoff.md
+++ b/docs/handoff/wam_r_session_handoff.md
@@ -120,9 +120,18 @@ relevant feature sections. Not bugs -- intentional scope boundaries.
 If you're picking up this campaign, these are the obvious next steps in
 roughly priority order:
 
-1. **LMDB / grouped-by-first TSV backends** for `r_fact_sources`. Mirrors
-   the Scala precedent; the `fact_source_spec_to_*` clauses in
-   `wam_scala_target.pl` are templates.
+1. **LMDB backend** for `r_fact_sources`. Grouped-by-first TSV landed
+   alongside this entry (`grouped_by_first('path.tsv')` Spec; arity-2;
+   exploded into per-value tuples by `WamRuntime$read_facts_grouped_tsv`,
+   then through the same `build_fact_indexes` + `fact_table_dispatch`
+   pipeline as the CSV backend). LMDB is harder: needs an R LMDB binding
+   (e.g. `thor` / `lmdbr`, both system-LMDB-dependent) and a different
+   dispatch path -- the Scala impl deliberately bypasses the
+   load-everything `fact_table_dispatch` and probes by `lookupByArg1`
+   for ground arg1, `streamAll` otherwise. To extend: add a
+   `fact_source_loader_call/4` clause for the new Spec shape **plus** a
+   parallel `WamRuntime$lmdb_fact_dispatch` to skip the in-memory tuple
+   list, since materialising every key defeats the point.
 2. **Performance profiling + targeted optimization.** First PR should
    add `Rprof` instrumentation around `wam_r_fact_source_bench.pl` and
    identify a single hot path; subsequent PRs each fix one bottleneck.

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -1182,23 +1182,24 @@ fact_source_pi_match(Name/Ar, P, Arity) :-
 
 %% emit_external_fact_source(+P, +Arity, +Spec,
 %%                            -DataDecl, -LoweredFunc, -FuncName)
-%  Emits the CSV loader + fact-iter dispatch fn. Spec must be
-%  file('path') for now; future shapes (LMDB, gzipped tables, ...)
-%  can branch here.
-emit_external_fact_source(Pred, Arity, file(Path),
+%  Emits the loader + fact-iter dispatch fn. Spec dispatches to a
+%  per-shape loader call (CSV, grouped-by-first TSV, ...); the
+%  generated loader output feeds the same build_fact_indexes +
+%  fact_table_dispatch pipeline used by inline fact tables, so
+%  per-arg indexing and dispatch are unchanged across backends.
+emit_external_fact_source(Pred, Arity, Spec,
                           DataDecl, LoweredFunc, FuncName) :-
     r_pred_name(Pred, RName),
     format(atom(DataName), '~w_facts', [RName]),
     format(atom(IndexesName), '~w_indexes', [RName]),
     format(atom(FuncName), '~w_fact_iter', [RName]),
-    atom_string(Path, PathStr),
-    r_string_literal(PathStr, PathLit),
+    fact_source_loader_call(Spec, Arity, LoaderCall, SpecComment),
     format(string(DataDecl),
-'# External fact source for ~w/~w (file: ~w)
-~w <- WamRuntime$read_facts_csv(~w, intern_table)
+'# External fact source for ~w/~w (~w)
+~w <- ~w
 ~w <- WamRuntime$build_fact_indexes(~w, ~wL)',
-        [Pred, Arity, PathStr, DataName, PathLit, IndexesName, DataName,
-         Arity]),
+        [Pred, Arity, SpecComment, DataName, LoaderCall, IndexesName,
+         DataName, Arity]),
     fact_args_collect(Arity, ArgsCollect),
     format(string(LoweredFunc),
 '~w <- function(program, state) {
@@ -1207,6 +1208,29 @@ emit_external_fact_source(Pred, Arity, file(Path),
                                   args, state$pc + 1L)
 }',
         [FuncName, ArgsCollect, Pred, Arity, DataName, IndexesName]).
+
+%% fact_source_loader_call(+Spec, +Arity, -LoaderCallSrc, -CommentTag)
+%  Maps a Spec to the R source that loads the table, plus a short
+%  human-readable tag for the comment header. New backends slot in
+%  by adding a clause here.
+fact_source_loader_call(file(Path), _Arity, LoaderCall, Comment) :-
+    atom_string(Path, PathStr),
+    r_string_literal(PathStr, PathLit),
+    format(string(LoaderCall),
+           'WamRuntime$read_facts_csv(~w, intern_table)',
+           [PathLit]),
+    format(string(Comment), 'csv file: ~w', [PathStr]).
+fact_source_loader_call(grouped_by_first(Path), Arity, LoaderCall, Comment) :-
+    (   Arity =:= 2
+    ->  true
+    ;   throw(error(domain_error(arity_2_for_grouped_by_first, Arity), _))
+    ),
+    atom_string(Path, PathStr),
+    r_string_literal(PathStr, PathLit),
+    format(string(LoaderCall),
+           'WamRuntime$read_facts_grouped_tsv(~w, intern_table)',
+           [PathLit]),
+    format(string(Comment), 'grouped-by-first tsv file: ~w', [PathStr]).
 
 % ============================================================================
 % FACT-TABLE CLASSIFICATION + EMISSION

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -3083,6 +3083,50 @@ WamRuntime$read_facts_csv <- function(path, intern_table) {
   out
 }
 
+# Reads a "grouped-by-first" TSV file and explodes each row into
+# separate arity-2 tuples. Each non-comment, non-blank line has the
+# shape `key<TAB>v1<TAB>v2<TAB>...`; the loader emits one tuple per
+# value `(key, vK)`. Lines with no values (just a key) are skipped.
+# Field parsing matches read_facts_csv: numeric -> Int/FloatTerm,
+# otherwise interned as an Atom.
+#
+# Mirrors the Scala target's grouped_by_first(Path) backend (see
+# wam_scala_target.pl). Arity-2 only -- the codegen layer is
+# responsible for refusing other arities at codegen time.
+WamRuntime$read_facts_grouped_tsv <- function(path, intern_table) {
+  if (!file.exists(path)) return(list())
+  lines <- tryCatch(readLines(path, warn = FALSE),
+                    error = function(e) character(0))
+  parse_field <- function(p) {
+    n <- suppressWarnings(as.numeric(p))
+    if (!is.na(n) && is.finite(n)) {
+      if (n == as.integer(n) && abs(n) < .Machine$integer.max) {
+        IntTerm(as.integer(n))
+      } else {
+        FloatTerm(as.numeric(n))
+      }
+    } else {
+      Atom(WamRuntime$intern(intern_table, p))
+    }
+  }
+  out <- list()
+  for (raw in lines) {
+    line <- gsub("^\\s+|\\s+$", "", raw)
+    if (nchar(line) == 0L) next
+    if (substr(line, 1L, 1L) == "#") next
+    parts <- strsplit(line, "\t", fixed = TRUE)[[1]]
+    parts <- trimws(parts)
+    parts <- parts[nchar(parts) > 0L]
+    if (length(parts) < 2L) next
+    key_term <- parse_field(parts[[1]])
+    for (k in seq.int(2L, length(parts))) {
+      val_term <- parse_field(parts[[k]])
+      out <- c(out, list(list(key_term, val_term)))
+    }
+  }
+  out
+}
+
 # Build per-arg hash indexes for a runtime-loaded fact table.
 # Returns a list of N envs (one per arg position, where N = arity).
 # Each env follows the same shape as the codegen-emitted

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -3269,6 +3269,73 @@ e2e_external_fact_source_via_rscript :-
         'assign("cpedge/2", pred_cpedge_fact_iter, envir = shared_program$lowered_dispatch)')),
     delete_directory_and_contents(TmpDir).
 
+test(external_fact_source_grouped_tsv_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_external_fact_source_grouped_tsv_via_rscript
+    ;   true
+    )).
+
+e2e_external_fact_source_grouped_tsv_via_rscript :-
+    retractall(user:gpedge(_, _)),
+    unique_r_tmp_dir('tmp_r_grouped_tsv_fact_e2e', TmpDir),
+    make_directory_path(TmpDir),
+    directory_file_path(TmpDir, 'gpedge.tsv', TsvPath),
+    atom_string(TsvPath, TsvPathStr),
+    % grouped-by-first shape: <key>\t<v1>\t<v2>...; the loader explodes
+    % each row into multiple (key, vK) tuples. The 'alice' row tests
+    % multi-value rows; the 'eve' row tests a single-value row;
+    % '# comment' and the blank line test the skip rules.
+    setup_call_cleanup(
+        open(TsvPath, write, Stream),
+        ( write(Stream, '# Auto-generated for the grouped-by-first TSV test.'),
+          nl(Stream),
+          write(Stream, 'alice\tbob\tcarol\teve'), nl(Stream),
+          write(Stream, ''), nl(Stream),
+          write(Stream, 'bob\tdan'), nl(Stream),
+          write(Stream, 'eve\tfrank'), nl(Stream) ),
+        close(Stream)),
+    assertz((user:gs_direct  :- gpedge(alice, bob))),
+    assertz((user:gs_third   :- gpedge(alice, eve))),
+    assertz((user:gs_no_back :- gpedge(bob, alice))),
+    assertz((user:gs_findall :-
+        findall(Y, gpedge(alice, Y), L),
+        msort(L, S),
+        S == [bob, carol, eve])),
+    assertz((user:gs_findall_all :-
+        findall(X-Y, gpedge(X, Y), L),
+        length(L, N),
+        N == 5)),
+    write_wam_r_project(
+        [user:gpedge/2, user:gs_direct/0, user:gs_third/0,
+         user:gs_no_back/0, user:gs_findall/0, user:gs_findall_all/0],
+        [intern_atoms([alice, bob, carol, dan, eve, frank]),
+         r_fact_sources([source(gpedge/2,
+                                grouped_by_first(TsvPathStr))])],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [gs_direct, gs_third, gs_findall, gs_findall_all],
+    No  = [gs_no_back],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    forall(member(P, No), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "false"))
+    )),
+    directory_file_path(TmpDir, 'R/generated_program.R', ProgPath),
+    read_file_to_string(ProgPath, Code, []),
+    assertion(sub_string(Code, _, _, _,
+        '# External fact source for gpedge/2 (grouped-by-first tsv file:')),
+    assertion(sub_string(Code, _, _, _,
+        'pred_gpedge_facts <- WamRuntime$read_facts_grouped_tsv(')),
+    assertion(sub_string(Code, _, _, _,
+        'assign("gpedge/2", pred_gpedge_fact_iter, envir = shared_program$lowered_dispatch)')),
+    delete_directory_and_contents(TmpDir).
+
 % ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the first half of WAM-R follow-up #1 (handoff `docs/handoff/wam_r_session_handoff.md:118`): a second `r_fact_sources` backend mirroring the Scala target's `grouped_by_first(Path)` Spec.

Users can now declare:

```prolog
r_fact_sources([source(parent/2, grouped_by_first('parents.tsv'))])
```

The TSV is row-shaped as `key<TAB>v1<TAB>v2<TAB>...`; the runtime explodes each row into separate `(key, vK)` tuples and feeds the same `build_fact_indexes` + `fact_table_dispatch` pipeline as the existing `file(...)` CSV backend, so per-arg hash indexing and multi-solution backtracking work unchanged.

## Why split LMDB into a follow-up

The Scala precedent has three Specs: `file(CSV)`, `grouped_by_first(TSV)`, and `lmdb(...)`. CSV was already done, TSV is here. LMDB is harder because it requires (a) an R LMDB binding (`thor` / `lmdbr`, both system-LMDB-dependent — adds e2e test setup pain) and (b) a different runtime dispatch path: the Scala impl deliberately bypasses the load-everything `fact_table_dispatch` and probes by `lookupByArg1` for ground arg1, `streamAll` otherwise. Materialising every key into memory defeats the point of LMDB. That's a separate, more involved change — kept out of this PR for reviewability. Handoff item #1 has been updated with the design notes.

## Implementation

- Splits `emit_external_fact_source/6` into a thin emitter + a `fact_source_loader_call/4` dispatch table keyed on Spec shape. New backends slot in by adding one clause + one runtime helper.
- Adds `WamRuntime$read_facts_grouped_tsv(path, intern_table)` to the runtime template. Skips blank/comment lines, drops empty fields, silently skips key-only rows, parses fields the same way as `read_facts_csv`.
- Refuses `arity != 2` at codegen time with `domain_error(arity_2_for_grouped_by_first, _)` — matches the Scala-side contract.

## Test plan

- [x] New `external_fact_source_grouped_tsv_e2e_rscript` covers multi-value rows, single-value rows, comment + blank skipping, ground-arg dispatch, free-arg `findall`, and absence of false positives. Auto-skips when `Rscript` isn't on `PATH`.
- [x] Full WAM-R suite: 64/64 pass.

## Docs

- `docs/WAM_R_TARGET.md` "External fact sources" section rewritten to cover both backends with a one-line note on how to add more.
- Test catalogue gets the new entry.
- `docs/handoff/wam_r_session_handoff.md` follow-up #1 narrowed to "LMDB backend" with the design split called out.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_