### PR TITLE
feat(wam-r): postfix operator support (xf/yf) in term parser

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -467,11 +467,17 @@ User-defined operators are supported via the runtime `op/3` builtin
 and the codegen `r_op_decls(...)` option. `op(+Priority, +Type,
 +Name)` mutates the parser's operator table at runtime; subsequent
 `read_term_from_atom/2,3` and CLI arg parses see the new operator.
-Type is one of `xfx`, `xfy`, `yfx`, `fx`, `fy` (binary infix and
-prefix); postfix `xf` / `yf` are recognised but raise an error in
-this scaffold. Priority `0` removes the operator. Name may be an
-atom or a proper list of atoms. `current_op/3` enumerates the
-table with backtracking.
+Type is one of `xfx`, `xfy`, `yfx`, `fx`, `fy`, `xf`, `yf` (binary
+infix, prefix, and postfix). Priority `0` removes the operator.
+Name may be an atom or a proper list of atoms. `current_op/3`
+enumerates the table with backtracking. When a name is registered
+as both infix and postfix, the parser tries infix first and only
+falls through to postfix when no infix entry fits the current
+precedence ceiling -- matches SWI behaviour. The parser does not
+distinguish `xf` from `yf` at chained-postfix sites: both accept
+`5!!` rather than the ISO-strict `xf` rejecting it. Real code rarely
+relies on that distinction; the existing prefix path makes the same
+simplification (`fx` and `fy` are treated identically).
 
 For compile-time declarations (so the operator is known before any
 runtime call), pass `r_op_decls([op(P, T, N), ...])` to
@@ -608,10 +614,12 @@ WamRuntime$run(shared_program, state)
 
 ## Limitations
 
-- **Postfix operators**. `op/3` recognises `xf` and `yf` types but
-  raises an error -- the parser doesn't have a postfix operator
-  path yet. Workaround: supply postfix terms in canonical
-  structural form. Infix and prefix custom operators work.
+- **Postfix `xf` vs `yf` chaining**. Single postfix application is
+  correct; chained applications (`5!!`) accept either type without
+  enforcing the ISO `xf` rule that the operand precedence be
+  strictly less than the operator precedence. Symmetric with the
+  existing prefix simplification. Documented; not a real-world
+  blocker.
 - **WAM-text quoting collision**. The atom `'42'` and the integer
   `42` both serialise as `set_constant 42` in SWI's WAM emitter,
   so the codegen can't distinguish them. The runtime's `atom_*`
@@ -704,6 +712,7 @@ Coverage map (e2e tests, by feature group):
 | `kernel_astar4_e2e_rscript` | recursive-kernel detection: `astar_shortest_path4` goal-directed search with user heuristic |
 | `external_fact_source_e2e_rscript` | external CSV fact sources via `r_fact_sources([source(P/A, file(...))])` |
 | `external_fact_source_grouped_tsv_e2e_rscript` | external grouped-by-first TSV fact sources (arity-2): `r_fact_sources([source(P/2, grouped_by_first(...))])` |
+| `op_3_postfix_e2e_rscript` | runtime postfix-operator support: `op(P, xf|yf, N)`, parser wraps primary as postfix struct, mixed infix+postfix, yf chaining, `current_op/3` enumeration, `op(0, ...)` removal |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/docs/handoff/wam_r_session_handoff.md
+++ b/docs/handoff/wam_r_session_handoff.md
@@ -103,11 +103,13 @@ relevant feature sections. Not bugs -- intentional scope boundaries.
 - **`length/2` (-,-)** generative mode unsupported.
 - **`retract/1` snapshot semantics.** The snapshot is taken at the
   original call; clauses asserted during the iteration are not seen.
-- **Postfix operators in the term parser.** `op/3` recognises `xf` /
-  `yf` types but raises an error -- the parser doesn't have a
-  postfix path yet. Infix and prefix custom operators work, both at
-  runtime via `op/3` and at codegen time via the `r_op_decls`
-  option.
+- **Postfix `xf` vs `yf` chaining.** Single postfix application is
+  correct (e.g. `5!` parses to `'!'(5)`). Chained postfix accepts
+  either type without enforcing the ISO `xf` rule that the operand
+  precedence be strictly less than the operator precedence. Same
+  simplification the existing prefix path already makes (`fx` and
+  `fy` are treated identically). Infix/prefix/postfix operators
+  work at runtime via `op/3` and at codegen time via `r_op_decls`.
 - **`astar_shortest_path4`** is correct only when the user-supplied
   heuristic is admissible. Documented; the fallback (using the edge
   pred itself) is not generally admissible.
@@ -137,9 +139,11 @@ roughly priority order:
    identify a single hot path; subsequent PRs each fix one bottleneck.
    Tagged-list `$tag` access and env-based register lookups are likely
    suspects.
-3. **Postfix operator parser path.** Add `WamRuntime$op_postfix` and
-   the parser case so `op(P, xf, ...)` / `op(P, yf, ...)` work. Small
-   bounded follow-up to the `op/3` PR.
+3. **Strict `xf` precedence rule** (small). Threading the precedence
+   of the current `left` expression through `wam_parse_expr` so `xf`
+   and `yf` differ correctly at chained-postfix sites. Fixes the
+   simplification documented as a known limitation. Same fix would
+   let `fx` / `fy` differ correctly in the prefix path.
 4. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
    mode info per predicate (in/out per arg); Phase 2 wires it to
    specialised emission (skip unifications when the mode says the slot

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -603,6 +603,14 @@ WamRuntime$tokenize_term <- function(text) {
     if (c == ",") { push(list(type = "comma"));    i <- i + 1L; next }
     if (c == ";") { push(list(type = "semicolon")); i <- i + 1L; next }
     if (c == "|") { push(list(type = "pipe"));     i <- i + 1L; next }
+    # ISO solo atom: `!` (the cut, also usable as a postfix-op name).
+    # Doesn't combine with the symbol-run chars; emitted as a single-
+    # char atom token so the parser can treat it like any other atom.
+    if (c == "!") {
+      push(list(type = "atom", value = "!", is_symbol = TRUE))
+      i <- i + 1L
+      next
+    }
     # Quoted atom: 'foo bar' with backslash escapes for ' and \.
     if (c == "'") {
       i <- i + 1L
@@ -725,6 +733,14 @@ WamRuntime$op_prefix <- list(
   "\\"  = list(prec = 200L)
 )
 
+# Postfix operator table. Empty by default -- canonical Prolog
+# defines no postfix operators. Users introduce them via op/3 or
+# the codegen-time r_op_decls option (e.g. `op(100, yf, '!')` for
+# factorial-style notation `5!`). Format mirrors op_prefix:
+# name -> list(prec, assoc) where assoc is "xf" (operand prec <
+# op prec) or "yf" (operand prec <= op prec).
+WamRuntime$op_postfix <- list()
+
 # ----------------------------------------------------------
 # Operator-table mutation helpers (used by op/3, current_op/3,
 # and the codegen-emitted r_op_decls block).
@@ -753,18 +769,21 @@ WamRuntime$op_resolve_names <- function(state, name_v, table) {
   NULL
 }
 
-# Insert / replace / remove an entry in op_infix or op_prefix based on
-# the fixity type. Priority 0 removes; non-zero inserts. The type's
-# table choice is implicit: xfx/xfy/yfx -> infix, fx/fy -> prefix.
-# Note: assigning to `WamRuntime$op_infix[[name]]` reads the list,
-# updates the named element, and assigns the modified list back; the
-# parser sees the new entry on its next read of the table.
+# Insert / replace / remove an entry in op_infix, op_prefix, or
+# op_postfix based on the fixity type. Priority 0 removes; non-zero
+# inserts. The type's table choice is implicit: xfx/xfy/yfx -> infix,
+# fx/fy -> prefix, xf/yf -> postfix. Note: assigning to
+# `WamRuntime$op_infix[[name]]` reads the list, updates the named
+# element, and assigns the modified list back; the parser sees the
+# new entry on its next read of the table.
 WamRuntime$op_set <- function(name, prec, type_str) {
-  is_infix  <- type_str %in% c("xfx", "xfy", "yfx")
-  is_prefix <- type_str %in% c("fx", "fy")
+  is_infix   <- type_str %in% c("xfx", "xfy", "yfx")
+  is_prefix  <- type_str %in% c("fx", "fy")
+  is_postfix <- type_str %in% c("xf", "yf")
   if (prec == 0L) {
-    if (is_infix) WamRuntime$op_infix[[name]]   <- NULL
-    if (is_prefix) WamRuntime$op_prefix[[name]] <- NULL
+    if (is_infix)   WamRuntime$op_infix[[name]]   <- NULL
+    if (is_prefix)  WamRuntime$op_prefix[[name]]  <- NULL
+    if (is_postfix) WamRuntime$op_postfix[[name]] <- NULL
     return(invisible(NULL))
   }
   if (is_infix) {
@@ -773,6 +792,9 @@ WamRuntime$op_set <- function(name, prec, type_str) {
   } else if (is_prefix) {
     WamRuntime$op_prefix[[name]] <- list(prec = as.integer(prec),
                                           assoc = type_str)
+  } else if (is_postfix) {
+    WamRuntime$op_postfix[[name]] <- list(prec = as.integer(prec),
+                                           assoc = type_str)
   }
   invisible(NULL)
 }
@@ -789,6 +811,11 @@ WamRuntime$op_snapshot <- function(table) {
   for (nm in names(WamRuntime$op_prefix)) {
     entry <- WamRuntime$op_prefix[[nm]]
     type <- if (!is.null(entry$assoc)) entry$assoc else "fx"
+    out <- c(out, list(list(prec = entry$prec, type = type, name = nm)))
+  }
+  for (nm in names(WamRuntime$op_postfix)) {
+    entry <- WamRuntime$op_postfix[[nm]]
+    type <- if (!is.null(entry$assoc)) entry$assoc else "xf"
     out <- c(out, list(list(prec = entry$prec, type = type, name = nm)))
   }
   out
@@ -874,13 +901,30 @@ WamRuntime$wam_parse_expr <- function(p, max_prec) {
                else if (tok$type == "semicolon") ";"
                else NULL
     if (is.null(op_name)) return(left)
-    op <- WamRuntime$op_infix[[op_name]]
-    if (is.null(op) || op$prec > max_prec) return(left)
-    p$pos <- p$pos + 1L
-    rhs_max <- if (op$assoc == "xfy") op$prec else op$prec - 1L
-    rhs <- WamRuntime$wam_parse_expr(p, rhs_max)
-    if (is.null(rhs)) return(NULL)
-    left <- StructTerm(WamRuntime$intern(p$table, op_name), list(left, rhs))
+    iop <- WamRuntime$op_infix[[op_name]]
+    if (!is.null(iop) && iop$prec <= max_prec) {
+      p$pos <- p$pos + 1L
+      rhs_max <- if (iop$assoc == "xfy") iop$prec else iop$prec - 1L
+      rhs <- WamRuntime$wam_parse_expr(p, rhs_max)
+      if (is.null(rhs)) return(NULL)
+      left <- StructTerm(WamRuntime$intern(p$table, op_name),
+                         list(left, rhs))
+      next
+    }
+    # Postfix: prefer infix when both are defined and applicable
+    # (matches SWI). Fires only when no infix entry fits the
+    # current precedence ceiling. yf accepts left at op$prec; xf
+    # requires left at op$prec - 1, but the operand precedence is
+    # already bounded by the recursive call and the outer loop's
+    # max_prec; we defer to max_prec here.
+    pop <- WamRuntime$op_postfix[[op_name]]
+    if (!is.null(pop) && pop$prec <= max_prec) {
+      p$pos <- p$pos + 1L
+      left <- StructTerm(WamRuntime$intern(p$table, op_name),
+                         list(left))
+      next
+    }
+    return(left)
   }
 }
 
@@ -4838,10 +4882,7 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     prec <- as.integer(prec_v$val)
     if (prec < 0L || prec > 1200L) return(FALSE)
     type_str <- WamRuntime$string_of(table, type_v$id)
-    if (type_str %in% c("xf", "yf")) {
-      stop(sprintf("op/3: postfix operators (%s) not yet supported in WAM-R", type_str))
-    }
-    if (!(type_str %in% c("xfx", "xfy", "yfx", "fx", "fy"))) return(FALSE)
+    if (!(type_str %in% c("xfx", "xfy", "yfx", "fx", "fy", "xf", "yf"))) return(FALSE)
     names_vec <- WamRuntime$op_resolve_names(state, name_v, table)
     if (is.null(names_vec)) return(FALSE)
     for (nm in names_vec) {

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -3269,6 +3269,80 @@ e2e_external_fact_source_via_rscript :-
         'assign("cpedge/2", pred_cpedge_fact_iter, envir = shared_program$lowered_dispatch)')),
     delete_directory_and_contents(TmpDir).
 
+% End-to-end Rscript run for runtime postfix-operator support. Covers
+% op/3 accepting xf/yf without throwing, the parser wrapping a primary
+% as a postfix struct, mixed infix+postfix in one expression, yf
+% chaining, current_op/3 enumeration, and op(0, ...) removal. Uses
+% =.. to decompose terms so SWI doesn't need the operator declared.
+test(op_3_postfix_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_op_3_postfix_via_rscript
+    ;   true
+    )).
+
+e2e_op_3_postfix_via_rscript :-
+    retractall(user:op_postfix_yf/0),
+    retractall(user:op_postfix_xf/0),
+    retractall(user:op_postfix_yf_chain/0),
+    retractall(user:op_postfix_with_infix/0),
+    retractall(user:op_postfix_current/0),
+    retractall(user:op_postfix_remove/0),
+    assertz((user:op_postfix_yf :-
+        op(100, yf, '!'),
+        read_term_from_atom('5!', T),
+        T =.. [F, A],
+        F == '!', A == 5)),
+    assertz((user:op_postfix_xf :-
+        op(100, xf, '!'),
+        read_term_from_atom('5!', T),
+        T =.. [F, A],
+        F == '!', A == 5)),
+    % yf permits the operand at the op's own precedence, so `5!!`
+    % parses as `'!'('!'(5))`. The parser keeps wrapping while the
+    % postfix entry matches.
+    assertz((user:op_postfix_yf_chain :-
+        op(100, yf, '!'),
+        read_term_from_atom('5!!', T),
+        T =.. [F, Inner],
+        F == '!',
+        Inner =.. [F, A],
+        A == 5)),
+    % Mixed: postfix binds tighter than the surrounding infix, so
+    % `5! + 3` parses as `+('!'(5), 3)`.
+    assertz((user:op_postfix_with_infix :-
+        op(100, yf, '!'),
+        read_term_from_atom('5! + 3', T),
+        T =.. ['+', L, R],
+        L =.. [F, A],
+        F == '!', A == 5, R == 3)),
+    assertz((user:op_postfix_current :-
+        op(100, yf, '!'),
+        findall(Type, current_op(100, Type, '!'), Types),
+        Types == [yf])),
+    % op(0, yf, ...) removes the postfix entry; subsequent parse fails.
+    assertz((user:op_postfix_remove :-
+        op(100, yf, '!'),
+        op(0, yf, '!'),
+        \+ read_term_from_atom('5!', _))),
+    unique_r_tmp_dir('tmp_r_op_3_postfix_e2e', TmpDir),
+    write_wam_r_project(
+        [user:op_postfix_yf/0, user:op_postfix_xf/0,
+         user:op_postfix_yf_chain/0, user:op_postfix_with_infix/0,
+         user:op_postfix_current/0, user:op_postfix_remove/0],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [op_postfix_yf, op_postfix_xf, op_postfix_yf_chain,
+           op_postfix_with_infix, op_postfix_current,
+           op_postfix_remove],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    delete_directory_and_contents(TmpDir).
+
 test(external_fact_source_grouped_tsv_e2e_rscript) :-
     once((
         rscript_available


### PR DESCRIPTION
## Summary

Closes the long-standing gap where `op/3` accepted `xf`/`yf` in its type whitelist but threw at apply time, with no postfix branch in the term parser. End-to-end now: `op(100, yf, '!')` + `read_term_from_atom('5!', T)` produces `'!'(5)`, `current_op/3` enumerates the entry, `op(0, yf, '!')` removes it.

## Why this is WAM-R-specific

Among WAM targets, **only WAM-R implements `read/2`, `term_to_atom/2`, `read_term_from_atom/2`** — the only callers of the runtime parser. The Rust, Haskell, and Scala WAM runtimes don't carry a parser at all (verified). The Prolog → target transpile path doesn't need one; the parser fires only when target-language runtime code needs to turn a string back into a WAM term. So this fix lives in `runtime.R.mustache` and doesn't propagate horizontally.

## Implementation

- `WamRuntime$op_postfix` table; `op_set` routes `xf`/`yf` and handles prec=0 removal.
- `op_snapshot` enumerates postfix entries (so `current_op/3` sees them).
- `wam_parse_expr` postfix branch fires when infix doesn't fit; infix wins ties (matches SWI).
- `op/3` dispatcher's `stop("postfix not yet supported")` guard removed; whitelist extended.
- Tokenizer learns `!` as an ISO solo atom (was unrecognised entirely).

## Known simplification (documented)

Chained postfix (`5!!`) parses successfully under both `xf` and `yf` — does **not** enforce the ISO `xf` rule that operand precedence be strictly less than operator precedence. Symmetric with the existing prefix path, which also treats `fx` and `fy` identically. The principled fix in both cases is to thread the current left-expression's precedence through `wam_parse_expr`; filed as new follow-up #3 in the WAM-R handoff.

## Test plan

- [x] New `op_3_postfix_e2e_rscript` covers single `yf`, single `xf`, `yf` chaining, mixed infix + postfix (`5! + 3` → `+('!'(5), 3)`), `current_op/3` enumeration, and `op(0, ...)` removal. Auto-skips when `Rscript` isn't on `PATH`.
- [x] Full WAM-R suite: **65/65 pass** (was 64).

## Docs

- `WAM_R_TARGET.md` operator section lists `xf`/`yf` as supported; chaining simplification noted.
- Limitations entry rewritten: was "postfix unsupported", now narrower xf/yf-chaining caveat.
- Test catalogue gets the new entry.
- WAM-R handoff item #3 retasked from "implement postfix" to "make xf/yf differ correctly under chaining".

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_