### PR TITLE
Feature/lua wam external fact source parity

### DIFF
--- a/PR_lua_wam_external_fact_source_parity.md
+++ b/PR_lua_wam_external_fact_source_parity.md
@@ -1,0 +1,23 @@
+# PR Title
+
+Add Lua WAM external fact sources
+
+# PR Description
+
+## Summary
+
+- Add `lua_fact_sources([source(P/A, file(Path))])` support for Lua WAM binary fact streams.
+- Generate `fact_sources` metadata for configured external `P/2` fact predicates.
+- Extend `CallFactStream` to fall back from inline facts to file-backed CSV/TSV fact sources.
+- Add Lua runtime file loading, atom interning, row caching, and streaming through the existing fact-stream backtracking path.
+- Add e2e coverage for direct and caller predicates backed by an external CSV file.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`
+
+## Notes
+
+This closes the first Lua external fact-source parity gap against Haskell/R-style file-backed fact streaming. The slice intentionally stays dependency-free and limited to binary CSV/TSV facts; LMDB or richer fact-source adapters can follow separately.

--- a/src/unifyweaver/targets/wam_lua_target.pl
+++ b/src/unifyweaver/targets/wam_lua_target.pl
@@ -410,7 +410,7 @@ compile_wam_predicate_to_lua(_Pred, _WamCode, _Options, "").
 
 compile_predicates_for_project(Predicates, Options,
                                AllInstrs, TopLabels, AllLabels,
-                               WrapperCode, LoweredCode, InlineFactsCode) :-
+                               WrapperCode, LoweredCode, InlineFactsCode, FactSourcesCode) :-
     init_lua_atom_intern_table,
     option(intern_atoms(ExtraAtoms), Options, []),
     forall(member(A, ExtraAtoms), (atom_string(A, S), intern_lua_atom(S, _))),
@@ -418,11 +418,12 @@ compile_predicates_for_project(Predicates, Options,
     append_missing_foreign_predicates(Predicates, ForeignPredicates, CompilePreds),
     wam_lua_resolve_emit_mode(Options, Mode),
     compile_all_predicates(CompilePreds, Options, Mode, 1,
-        [], [], [], [], [], [],
-        AllInstrs, TopLabels, AllLabels, Wrappers, LoweredEntries, InlineFacts),
+        [], [], [], [], [], [], [],
+        AllInstrs, TopLabels, AllLabels, Wrappers, LoweredEntries, InlineFacts, FactSources),
     atomic_list_concat(Wrappers, '\n', WrapperCode),
     atomic_list_concat(LoweredEntries, '\n', LoweredCode),
-    atomic_list_concat(InlineFacts, ',\n', InlineFactsCode).
+    atomic_list_concat(InlineFacts, ',\n', InlineFactsCode),
+    atomic_list_concat(FactSources, ',\n', FactSourcesCode).
 
 append_missing_foreign_predicates(Predicates, ForeignPredicates, CompilePredicates) :-
     findall(F, (member(F, ForeignPredicates), \+ (member(P, Predicates), same_pi(P, F))), Missing),
@@ -432,19 +433,29 @@ same_pi(P0, P1) :- pi_key(P0, K), pi_key(P1, K).
 pi_key(_:P/A, P/A) :- !.
 pi_key(P/A, P/A).
 
-compile_all_predicates([], _, _, _, Instrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts,
-                       Instrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts).
+compile_all_predicates([], _, _, _, Instrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts, FactSources,
+                       Instrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts, FactSources).
 compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
-                       InstrAcc, TopLabelAcc, AllLabelAcc, WrapperAcc, LoweredAcc, InlineFactAcc,
-                       AllInstrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts) :-
+                       InstrAcc, TopLabelAcc, AllLabelAcc, WrapperAcc, LoweredAcc, InlineFactAcc, FactSourceAcc,
+                       AllInstrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts, FactSources) :-
     (Pred = _M:P/Arity -> true ; Pred = P/Arity),
-    (   lua_foreign_predicate(P, Arity, Options)
+    (   lua_fact_source_spec(P, Arity, Options, SourceSpec)
+    ->  format(string(Key), '~w/~w', [P, Arity]),
+        lua_string_literal(Key, KeyQ),
+        format(string(FLit), 'I.CallFactStream(~w, ~w)', [KeyQ, Arity]),
+        PredInstrs = [FLit, 'I.Proceed()'],
+        WamForLower = "",
+        PredSubLabelEntries0 = [],
+        InlineFactEntry = none,
+        lua_fact_source_entry(Key, SourceSpec, FactSourceEntry)
+    ;   lua_foreign_predicate(P, Arity, Options)
     ->  lua_string_literal(P, PQ),
         format(string(FLit), 'I.CallForeign(~w, ~w)', [PQ, Arity]),
         PredInstrs = [FLit, 'I.Proceed()'],
         WamForLower = "",
         PredSubLabelEntries0 = [],
-        InlineFactEntry = none
+        InlineFactEntry = none,
+        FactSourceEntry = none
     ;   compile_predicate_to_wam(P/Arity, [], WamForLower),
         (   Arity == 2,
             lua_inline_fact_tuples(WamForLower, Tuples),
@@ -454,9 +465,11 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
             format(string(FLit), 'I.CallFactStream(~w, ~w)', [KeyQ, Arity]),
             PredInstrs = [FLit, 'I.Proceed()'],
             PredSubLabelEntries0 = [],
-            lua_inline_fact_entry(Key, Tuples, InlineFactEntry)
+            lua_inline_fact_entry(Key, Tuples, InlineFactEntry),
+            FactSourceEntry = none
         ;   wam_code_to_lua_data(WamForLower, Options, PredInstrs, PredSubLabelEntries0),
-            InlineFactEntry = none
+            InlineFactEntry = none,
+            FactSourceEntry = none
         )
     ),
     length(PredInstrs, PredLen),
@@ -486,9 +499,31 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
         emit_lua_wrapper(P, Arity, BasePC, Wrapper)
     ),
     (InlineFactEntry == none -> NewInlineFactAcc = InlineFactAcc ; NewInlineFactAcc = [InlineFactEntry|InlineFactAcc]),
+    (FactSourceEntry == none -> NewFactSourceAcc = FactSourceAcc ; NewFactSourceAcc = [FactSourceEntry|FactSourceAcc]),
     compile_all_predicates(Rest, Options, Mode, NewPC,
-        NewInstrs, NewTopLabels, NewAllLabels, [Wrapper|WrapperAcc], NewLoweredAcc, NewInlineFactAcc,
-        AllInstrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts).
+        NewInstrs, NewTopLabels, NewAllLabels, [Wrapper|WrapperAcc], NewLoweredAcc, NewInlineFactAcc, NewFactSourceAcc,
+        AllInstrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts, FactSources).
+
+lua_fact_source_spec(P, Arity, Options, Spec) :-
+    Arity =:= 2,
+    option(lua_fact_sources(Sources), Options, []),
+    member(source(PI, Spec), Sources),
+    fact_source_pi_match(PI, P, Arity).
+
+fact_source_pi_match(_:Name/Ar, P, Arity) :- !,
+    Name == P, Ar =:= Arity.
+fact_source_pi_match(Name/Ar, P, Arity) :-
+    Name == P, Ar =:= Arity.
+
+lua_fact_source_entry(Key, file(Path), Entry) :-
+    atom_string(Path, PathStr),
+    (   absolute_file_name(PathStr, AbsPath, [access(read), file_errors(fail)])
+    ->  SourcePath = AbsPath
+    ;   SourcePath = PathStr
+    ),
+    lua_string_literal(Key, KeyQ),
+    lua_string_literal(SourcePath, PathQ),
+    format(string(Entry), '  [~w] = { path = ~w }', [KeyQ, PathQ]).
 
 lua_inline_fact_tuples(WamCode, Tuples) :-
     atom_string(WamCode, Str),
@@ -624,7 +659,7 @@ write_wam_lua_project(Predicates, Options, ProjectDir) :-
     directory_file_path(ProjectDir, 'lua', LuaDir),
     make_directory_path(LuaDir),
     compile_predicates_for_project(Predicates, Options,
-        AllInstrs, TopLabels, AllLabels, WrapperCode, LoweredCode, InlineFactsCode),
+        AllInstrs, TopLabels, AllLabels, WrapperCode, LoweredCode, InlineFactsCode, FactSourcesCode),
     emit_lua_intern_table(InternSeed),
     maplist([I, Line]>>(format(string(Line), '  ~w', [I])), AllInstrs, InstrLines),
     atomic_list_concat(InstrLines, ',\n', InstrBody),
@@ -633,7 +668,7 @@ write_wam_lua_project(Predicates, Options, ProjectDir) :-
     lua_foreign_handlers_code(Options, ForeignHandlers),
     write_runtime_source(LuaDir),
     write_program_source(LuaDir, InstrBody, LabelBody, DispatchBody,
-                         WrapperCode, InternSeed, ForeignHandlers, LoweredCode, InlineFactsCode).
+                         WrapperCode, InternSeed, ForeignHandlers, LoweredCode, InlineFactsCode, FactSourcesCode).
 
 write_runtime_source(LuaDir) :-
     find_template('templates/targets/lua_wam/runtime.lua.mustache', Template),
@@ -643,7 +678,7 @@ write_runtime_source(LuaDir) :-
     write_file(Path, Content).
 
 write_program_source(LuaDir, InstrBody, LabelBody, DispatchBody,
-                     WrapperCode, InternSeed, ForeignHandlers, LoweredCode, InlineFactsCode) :-
+                     WrapperCode, InternSeed, ForeignHandlers, LoweredCode, InlineFactsCode, FactSourcesCode) :-
     find_template('templates/targets/lua_wam/program.lua.mustache', Template),
     get_time(T), format_time(string(Date), "%Y-%m-%d", T),
     render_template(Template,
@@ -655,7 +690,8 @@ write_program_source(LuaDir, InstrBody, LabelBody, DispatchBody,
          'intern_id_to_string'=InternSeed,
          'foreign_handlers'=ForeignHandlers,
          'lowered_functions'=LoweredCode,
-         'inline_facts'=InlineFactsCode], Content),
+         'inline_facts'=InlineFactsCode,
+         'fact_sources'=FactSourcesCode], Content),
     directory_file_path(LuaDir, 'generated_program.lua', Path),
     write_file(Path, Content).
 

--- a/templates/targets/lua_wam/program.lua.mustache
+++ b/templates/targets/lua_wam/program.lua.mustache
@@ -33,12 +33,17 @@ local inline_facts = {
 {{inline_facts}}
 }
 
+local fact_sources = {
+{{fact_sources}}
+}
+
 local shared_program = {
   instructions = shared_instructions,
   labels = shared_labels,
   dispatch = dispatch,
   foreign_handlers = foreign_handlers,
   inline_facts = inline_facts,
+  fact_sources = fact_sources,
   indexed_atom_fact2 = {},
   intern_table = intern_table
 }

--- a/templates/targets/lua_wam/runtime.lua.mustache
+++ b/templates/targets/lua_wam/runtime.lua.mustache
@@ -471,8 +471,51 @@ local function call_indexed_atom_fact2(program, state, instr)
   return true
 end
 
+local function trim(s)
+  return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+local function parse_fact_source_value(program, text)
+  text = trim(text)
+  local n = tonumber(text)
+  if n and tostring(math.tointeger(n) or n) == text then return V.Int(n) end
+  return V.Atom(Runtime.intern(program.intern_table, text))
+end
+
+function Runtime.read_facts_file(program, path)
+  local rows = {}
+  local fh = io.open(path, "r")
+  if fh == nil then return rows end
+  for line in fh:lines() do
+    local cleaned = trim(line)
+    if cleaned ~= "" and cleaned:sub(1, 1) ~= "#" then
+      local sep = cleaned:find("\t", 1, true) and "\t" or ","
+      local parts = {}
+      for part in cleaned:gmatch("([^" .. sep .. "]+)") do
+        parts[#parts + 1] = part
+      end
+      if #parts >= 2 then
+        rows[#rows + 1] = {
+          parse_fact_source_value(program, parts[1]),
+          parse_fact_source_value(program, parts[2])
+        }
+      end
+    end
+  end
+  fh:close()
+  return rows
+end
+
+local function fact_source_rows(program, pred)
+  local source = program.fact_sources and program.fact_sources[pred] or nil
+  if source == nil then return nil end
+  if source.rows == nil then source.rows = Runtime.read_facts_file(program, source.path) end
+  return source.rows
+end
+
 local function call_fact_stream(program, state, instr)
   local rows = program.inline_facts and program.inline_facts[instr.pred] or nil
+  if rows == nil or #rows == 0 then rows = fact_source_rows(program, instr.pred) end
   if rows == nil or #rows == 0 then return false end
   if #rows > 1 then
     local rest = {}

--- a/tests/test_wam_lua_generator.pl
+++ b/tests/test_wam_lua_generator.pl
@@ -26,6 +26,8 @@
 :- dynamic user:wam_lua_agg_set/0.
 :- dynamic user:wam_lua_stream_fact/2.
 :- dynamic user:wam_lua_stream_caller/2.
+:- dynamic user:wam_lua_ext_fact/2.
+:- dynamic user:wam_lua_ext_caller/2.
 
 user:wam_lua_fact(a).
 user:wam_lua_choice(a).
@@ -63,6 +65,7 @@ user:wam_lua_agg_set :-
 user:wam_lua_stream_fact(a, b).
 user:wam_lua_stream_fact(a, c).
 user:wam_lua_stream_caller(X, Y) :- user:wam_lua_stream_fact(X, Y).
+user:wam_lua_ext_caller(X, Y) :- user:wam_lua_ext_fact(X, Y).
 
 test(exports) :-
     assertion(current_predicate(wam_lua_target:write_wam_lua_project/3)),
@@ -181,6 +184,35 @@ test(lua_fact_stream_e2e, [condition(lua_available)]) :-
           run_lua_query(LuaDir, 'wam_lua_stream_fact/2', [a, c], true),
           run_lua_query(LuaDir, 'wam_lua_stream_fact/2', [a, d], false),
           run_lua_query(LuaDir, 'wam_lua_stream_caller/2', [a, c], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(lua_external_fact_source_e2e, [condition(lua_available)]) :-
+    unique_lua_tmp_dir('tmp_lua_ext_fact_e2e', TmpDir),
+    setup_call_cleanup(
+        ( make_directory_path(TmpDir),
+          directory_file_path(TmpDir, 'ext_facts.csv', CsvPath),
+          setup_call_cleanup(
+              open(CsvPath, write, Stream),
+              ( writeln(Stream, 'a,b'),
+                writeln(Stream, 'a,c')
+              ),
+              close(Stream)),
+          write_wam_lua_project(
+              [user:wam_lua_ext_fact/2, user:wam_lua_ext_caller/2],
+              [lua_fact_sources([source(wam_lua_ext_fact/2, file(CsvPath))])],
+              TmpDir)
+        ),
+        ( directory_file_path(TmpDir, 'lua/generated_program.lua', Program),
+          read_file_to_string(Program, Code, []),
+          assertion(sub_string(Code, _, _, _, 'local fact_sources = {')),
+          assertion(sub_string(Code, _, _, _, '["wam_lua_ext_fact/2"] = { path = ')),
+          directory_file_path(TmpDir, 'lua', LuaDir),
+          run_lua_query(LuaDir, 'wam_lua_ext_fact/2', [a, b], true),
+          run_lua_query(LuaDir, 'wam_lua_ext_fact/2', [a, c], true),
+          run_lua_query(LuaDir, 'wam_lua_ext_fact/2', [a, d], false),
+          run_lua_query(LuaDir, 'wam_lua_ext_caller/2', [a, c], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

- Add `lua_fact_sources([source(P/A, file(Path))])` support for Lua WAM binary fact streams.
- Generate `fact_sources` metadata for configured external `P/2` fact predicates.
- Extend `CallFactStream` to fall back from inline facts to file-backed CSV/TSV fact sources.
- Add Lua runtime file loading, atom interning, row caching, and streaming through the existing fact-stream backtracking path.
- Add e2e coverage for direct and caller predicates backed by an external CSV file.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`

## Notes

This closes the first Lua external fact-source parity gap against Haskell/R-style file-backed fact streaming. The slice intentionally stays dependency-free and limited to binary CSV/TSV facts; LMDB or richer fact-source adapters can follow separately.
