### PR TITLE
feat(wam-r): group bagof/setof by selected witnesses

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -426,9 +426,11 @@ paths:
 - Compiled goals push an `aggregate` CP at `BeginAggregate`,
   collect on every backtrack, and finalise at `EndAggregate`.
 - Library-level aggregators (`bagof`, `setof`, runtime-only
-  predicates) call `WamRuntime$collect_solutions`, which snapshots
-  state, drives the goal via `iterate_goal`, and restores state
-  fully before returning.
+  predicates) call `WamRuntime$collect_solutions` or
+  `WamRuntime$collect_bag_groups`, which snapshot state, drive the
+  goal via `iterate_goal`, and restore state fully before returning.
+  `bagof/3` and `setof/3` honor `^/2` existential scope and group
+  non-existential free variables for the selected witness group.
 
 `iterate_goal` has R-level fast paths for `member/2`, `between/3`,
 `,/2` conjunctions over the above, and dynamic predicates -- so
@@ -625,13 +627,12 @@ WamRuntime$run(shared_program, state)
   Removed clauses are matched against the live store by object
   identity, so concurrent retracts/asserts of unrelated clauses
   don't disturb the iteration order.
-- **`bagof/3` / `setof/3` per-witness grouping**. The `^/2`
-  existential scoping operator is supported (the wrapper is
-  transparent in `call_goal` / `iterate_goal` / `call_library`,
-  so `bagof(X, Y^p(X,Y), L)` runs `p(X,Y)` and aggregates X). What
-  isn't supported is the per-witness grouping for non-quantified
-  free vars: `bagof(X, p(X,Y), L)` produces one bag containing
-  every X (regardless of Y) rather than one bag per Y binding.
+- **`bagof/3` / `setof/3` group enumeration on backtracking**.
+  Non-existential free variables are grouped and the first witness
+  group is bound, so `bagof(X, p(X,Y), L)` can bind `Y` and `L`
+  consistently. Backtracking across additional witness groups is a
+  follow-up; the current library path does not yet push a group
+  choice point.
 - **`length/2` (-, -)** generative mode is not supported (would
   need a CP-driving generator).
 - **`between/3` (+, +, -)** in compiled-goal context produces an
@@ -687,7 +688,7 @@ Coverage map (e2e tests, by feature group):
 | `op_3_runtime_e2e_rscript` | runtime `op/3` builtin: add infix / prefix custom ops, xfy right-associativity, `op(0, ...)` removal, `current_op/3` enumeration |
 | `op_3_decl_e2e_rscript` | codegen `r_op_decls([op(P, T, N), ...])` option seeds the operator table at program init; covers atom-name and list-of-names forms |
 | `multi_solution_retract_e2e_rscript` | multi-solution `retract/1` via iter-CP |
-| `bagof_setof_existential_e2e_rscript` | `^/2` existential scope in `bagof`/`setof`/`findall` |
+| `bagof_setof_existential_e2e_rscript` | `^/2` existential scope and first witness grouping in `bagof`/`setof`; `findall` caret transparency |
 | `cli_arg_parser_e2e_rscript` | structured CLI args (lists, structs, expressions) parse via the runtime parser |
 | `base_name_clash_e2e_rscript` | predicates named after base R functions (`c`, `t`, `q`, `cat`) don't shadow them |
 | `read_term_clause_e2e_rscript` | `read_term_from_atom/2,3` and multi-solution `clause/2` |

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -1375,7 +1375,9 @@ WamRuntime$step <- function(program, state, instr) {
       # frame has a valid continuation even when the goal has zero
       # solutions (and thus EndAggregate never fires). We scan from
       # the current PC forward; a depth counter handles nested
-      # aggregates. The next_pc is end+1.
+      # aggregates. Nested aggregates are represented by the same
+      # instruction pair; ordinary Raw or library calls do not affect
+      # this structural scan. The next_pc is end+1.
       end_pc <- 0L
       depth <- 1L
       for (j in seq.int(state$pc + 1L, length(program$instructions))) {
@@ -1399,6 +1401,7 @@ WamRuntime$step <- function(program, state, instr) {
         var_counter  = state$var_counter,
         mode         = state$mode,
         build_stack  = state$build_stack,
+        read_stack   = state$read_stack,
         table        = program$intern_table,
         collected    = list()
       )
@@ -1422,7 +1425,10 @@ WamRuntime$step <- function(program, state, instr) {
       agg <- state$cps[[agg_idx]]
       v <- WamRuntime$deref(state, WamRuntime$get_reg(state, instr$template))
       # copy_term so the collected value is independent of subsequent
-      # binding rewrites during backtracking.
+      # binding rewrites during backtracking. EndAggregate runs while
+      # the goal solution bindings are still live; the forced backtrack
+      # immediately after this will undo them before trying the next
+      # solution or finalizing the aggregate frame.
       collected_v <- WamRuntime$copy_term(state, v)
       agg$collected <- c(agg$collected, list(collected_v))
       state$cps[[agg_idx]] <- agg
@@ -3705,6 +3711,7 @@ WamRuntime$collect_solutions <- function(program, state, template_term, goal_ter
   snap_vc        <- state$var_counter
   snap_mode      <- state$mode
   snap_build     <- state$build_stack
+  snap_read      <- state$read_stack
 
   collected <- list()
   WamRuntime$iterate_goal(program, state, goal_term, function() {
@@ -3735,6 +3742,7 @@ WamRuntime$collect_solutions <- function(program, state, template_term, goal_ter
   state$var_counter <- snap_vc
   state$mode        <- snap_mode
   state$build_stack <- snap_build
+  state$read_stack  <- snap_read
 
   collected
 }
@@ -3757,6 +3765,7 @@ WamRuntime$collect_bag_groups <- function(program, state, template_term, goal_te
   snap_vc        <- state$var_counter
   snap_mode      <- state$mode
   snap_build     <- state$build_stack
+  snap_read      <- state$read_stack
 
   groups <- list()
   group_index <- new.env(parent = emptyenv(), hash = TRUE)
@@ -3806,6 +3815,7 @@ WamRuntime$collect_bag_groups <- function(program, state, template_term, goal_te
   state$var_counter <- snap_vc
   state$mode        <- snap_mode
   state$build_stack <- snap_build
+  state$read_stack  <- snap_read
 
   groups
 }
@@ -5277,6 +5287,7 @@ WamRuntime$backtrack <- function(state) {
     state$var_counter <- cp$var_counter
     state$mode        <- cp$mode
     state$build_stack <- cp$build_stack
+    state$read_stack  <- cp$read_stack
     bag <- WamRuntime$wam_list_build(cp$collected, cp$table)
     cur <- WamRuntime$get_reg(state, cp$bag_reg)
     if (is.null(cur)) {

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -3446,9 +3446,9 @@ WamRuntime$call_goal <- function(program, state, goal_term) {
     return(WamRuntime$call_goal(program, state, v$args[[2]]))
   }
   # Unwrap `^/2` existential scope: in `bagof(X, Y^Goal, B)` the
-  # `Y^` is a hint that Y is locally scoped (no per-witness
-  # grouping). Since this scaffold doesn't do per-witness grouping
-  # anyway, the wrapper is transparent for call purposes.
+  # `Y^` is a hint that Y is locally scoped. Witness grouping is
+  # handled by collect_bag_groups; direct goal calls treat the
+  # wrapper as transparent.
   if (v$tag == "struct" && length(v$args) == 2L &&
       identical(WamRuntime$string_of(table, v$fid), "^")) {
     return(WamRuntime$call_goal(program, state, v$args[[2]]))
@@ -3528,9 +3528,9 @@ WamRuntime$iterate_goal <- function(program, state, goal_term, on_each) {
   if (is.null(v) || is.null(v$tag)) return(invisible(NULL))
 
   # Unwrap `Y^Goal` existential scope (and module-qualified
-  # `Module:Goal`) so the inner goal drives iteration directly. The
-  # outer wrapper has no semantic effect on enumeration in this
-  # scaffold (no per-witness grouping for bagof/setof).
+  # `Module:Goal`) so the inner goal drives iteration directly.
+  # collect_bag_groups separately records existential vars before
+  # calling into this iterator.
   if (v$tag == "struct" && length(v$args) == 2L &&
       identical(WamRuntime$string_of(table, v$fid), "^")) {
     return(WamRuntime$iterate_goal(program, state, v$args[[2]], on_each))
@@ -3775,6 +3775,11 @@ WamRuntime$collect_bag_groups <- function(program, state, template_term, goal_te
     witness_terms <- lapply(witness_names, function(n) {
       WamRuntime$copy_term(state, WamRuntime$deref(state, Unbound(n)))
     })
+    # Group keys are computed at collection time from copy_term'd
+    # witness values, while the solution bindings are still live.
+    # This avoids depending on deref chains after iterate_goal has
+    # moved on to later solutions or collect_bag_groups has restored
+    # the caller snapshot.
     key <- if (length(witness_terms) == 0L) {
       "__all__"
     } else {
@@ -4138,8 +4143,8 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
   # ----- ^/2 existential scope -----
   # When the WAM compiler emits `Y^Goal` as a Call("^", 2), treat
   # the wrapper as transparent and run Goal. Y is locally scoped
-  # (matches the bagof/setof idiom); we don't do per-witness
-  # grouping, so the wrapper has no further effect.
+  # (matches the bagof/setof idiom); collect_bag_groups handles the
+  # witness/existential split for library bagof/setof.
   if (key == "^/2") {
     return(WamRuntime$call_goal(program, state, WamRuntime$get_reg(state, 2L)))
   }

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -527,6 +527,53 @@ wam_term_name_string <- function(v, table) {
   )
 }
 
+WamRuntime$term_key <- function(state, term, table) {
+  v <- WamRuntime$deref(state, term)
+  if (is.null(v) || is.null(v$tag)) return("null")
+  switch(v$tag,
+    "unbound" = paste0("var:", v$name),
+    "int"     = paste0("int:", v$val),
+    "float"   = paste0("float:", format(v$val, scientific = FALSE)),
+    "atom"    = paste0("atom:", WamRuntime$string_of(table, v$id)),
+    "struct"  = {
+      args <- vapply(v$args, function(a)
+        WamRuntime$term_key(state, a, table), character(1))
+      paste0("struct:", WamRuntime$string_of(table, v$fid), "/",
+             length(v$args), "(", paste(args, collapse = ","), ")")
+    },
+    "unknown"
+  )
+}
+
+WamRuntime$term_var_names <- function(state, term) {
+  v <- WamRuntime$deref(state, term)
+  if (is.null(v) || is.null(v$tag)) return(character(0))
+  if (v$tag == "unbound") return(v$name)
+  if (v$tag != "struct") return(character(0))
+  unique(unlist(lapply(v$args, function(a)
+    WamRuntime$term_var_names(state, a)), use.names = FALSE))
+}
+
+WamRuntime$strip_existentials <- function(state, goal_term, table) {
+  v <- WamRuntime$deref(state, goal_term)
+  if (is.null(v) || is.null(v$tag)) {
+    return(list(goal = goal_term, vars = character(0)))
+  }
+  if (v$tag == "struct" && length(v$args) == 2L) {
+    fun <- WamRuntime$string_of(table, v$fid)
+    if (fun == ":") {
+      inner <- WamRuntime$strip_existentials(state, v$args[[2]], table)
+      return(list(goal = inner$goal, vars = inner$vars))
+    }
+    if (fun == "^") {
+      inner <- WamRuntime$strip_existentials(state, v$args[[2]], table)
+      scoped <- WamRuntime$term_var_names(state, v$args[[1]])
+      return(list(goal = inner$goal, vars = unique(c(scoped, inner$vars))))
+    }
+  }
+  list(goal = goal_term, vars = character(0))
+}
+
 # Format-template processor used by format/1 and format/2. Supports the
 # common SWI control-sequence subset:
 #   ~w, ~a, ~p, ~q, ~d  -> consume one arg and write its string form
@@ -3692,6 +3739,87 @@ WamRuntime$collect_solutions <- function(program, state, template_term, goal_ter
   collected
 }
 
+WamRuntime$collect_bag_groups <- function(program, state, template_term, goal_term) {
+  table <- program$intern_table
+  stripped <- WamRuntime$strip_existentials(state, goal_term, table)
+  goal_inner <- stripped$goal
+  existential_vars <- stripped$vars
+  template_vars <- WamRuntime$term_var_names(state, template_term)
+  goal_vars <- WamRuntime$term_var_names(state, goal_inner)
+  witness_names <- setdiff(goal_vars, unique(c(template_vars, existential_vars)))
+
+  snap_cps_len   <- length(state$cps)
+  snap_regs      <- as.list.environment(state$regs2)
+  snap_trail     <- length(state$trail)
+  snap_pc        <- state$pc
+  snap_cp        <- state$cp
+  snap_halt      <- state$halt
+  snap_vc        <- state$var_counter
+  snap_mode      <- state$mode
+  snap_build     <- state$build_stack
+
+  groups <- list()
+  group_index <- new.env(parent = emptyenv(), hash = TRUE)
+  WamRuntime$iterate_goal(program, state, goal_inner, function() {
+    val <- WamRuntime$deref(state, template_term)
+    copied_val <- WamRuntime$copy_term(state, val)
+    witness_terms <- lapply(witness_names, function(n) {
+      WamRuntime$copy_term(state, WamRuntime$deref(state, Unbound(n)))
+    })
+    key <- if (length(witness_terms) == 0L) {
+      "__all__"
+    } else {
+      paste(vapply(witness_terms, function(w)
+        WamRuntime$term_key(state, w, table), character(1)), collapse = "\001")
+    }
+    if (!exists(key, envir = group_index, inherits = FALSE)) {
+      groups[[length(groups) + 1L]] <<- list(
+        names = witness_names,
+        witnesses = witness_terms,
+        values = list()
+      )
+      assign(key, length(groups), envir = group_index)
+    }
+    idx <- get(key, envir = group_index, inherits = FALSE)
+    groups[[idx]]$values[[length(groups[[idx]]$values) + 1L]] <<- copied_val
+    TRUE
+  })
+
+  if (length(state$cps) > snap_cps_len) {
+    state$cps <- state$cps[seq_len(snap_cps_len)]
+  }
+  e <- new.env(parent = emptyenv(), hash = TRUE)
+  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
+  state$regs2 <- e
+  if (length(state$trail) > snap_trail) {
+    to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
+    for (name in to_undo) {
+      if (exists(name, envir = state$bindings, inherits = FALSE)) {
+        rm(list = name, envir = state$bindings)
+      }
+    }
+    state$trail <- state$trail[seq_len(snap_trail)]
+  }
+  state$pc          <- snap_pc
+  state$cp          <- snap_cp
+  state$halt        <- snap_halt
+  state$var_counter <- snap_vc
+  state$mode        <- snap_mode
+  state$build_stack <- snap_build
+
+  groups
+}
+
+WamRuntime$bind_bag_group_witnesses <- function(state, group) {
+  if (length(group$names) == 0L) return(TRUE)
+  for (i in seq_along(group$names)) {
+    if (!WamRuntime$unify(state, Unbound(group$names[[i]]), group$witnesses[[i]])) {
+      return(FALSE)
+    }
+  }
+  TRUE
+}
+
 WamRuntime$call_builtin <- function(program, state, pred, arity) {
   table <- program$intern_table
   # Pred uses the with-/N convention here (matches BuiltinCall instr$pred).
@@ -4258,34 +4386,37 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     return(isTRUE(res))
   }
 
-  # ----- bagof/3: like findall but fails on empty bag -----
-  # Note: this scaffold does NOT support free-variable witnesses.
-  # bagof(T, G, B) here is equivalent to findall(T, G, B) with the
-  # extra rule "fail if no solutions". Common idiom: existentially
-  # quantify any non-template variables with `^/2` (e.g.
-  # bagof(X, Y^p(X,Y), L)). Without `^`, witness variables are
-  # silently aggregated rather than producing one bag per witness.
+  # ----- bagof/3: findall plus non-empty, grouped by free witnesses -----
   if (key == "bagof/3") {
     template <- WamRuntime$get_reg(state, 1L)
     goal     <- WamRuntime$get_reg(state, 2L)
-    collected <- WamRuntime$collect_solutions(program, state, template, goal)
-    if (length(collected) == 0L) return(FALSE)
-    bag <- WamRuntime$wam_list_build(collected, table)
+    groups <- WamRuntime$collect_bag_groups(program, state, template, goal)
+    if (length(groups) == 0L) return(FALSE)
+    group <- groups[[1L]]
+    bag <- WamRuntime$wam_list_build(group$values, table)
+    trail0 <- length(state$trail)
+    if (!WamRuntime$bind_bag_group_witnesses(state, group)) {
+      WamRuntime$undo_trail_to(state, trail0)
+      return(FALSE)
+    }
     cur <- WamRuntime$get_reg(state, 3L)
     if (is.null(cur)) {
       WamRuntime$put_reg(state, 3L, bag)
       return(TRUE)
     }
-    return(WamRuntime$unify(state, cur, bag))
+    ok <- WamRuntime$unify(state, cur, bag)
+    if (!isTRUE(ok)) WamRuntime$undo_trail_to(state, trail0)
+    return(ok)
   }
 
   # ----- setof/3: bagof + sort + dedup (standard order of terms) -----
   if (key == "setof/3") {
     template <- WamRuntime$get_reg(state, 1L)
     goal     <- WamRuntime$get_reg(state, 2L)
-    collected <- WamRuntime$collect_solutions(program, state, template, goal)
-    if (length(collected) == 0L) return(FALSE)
-    sorted <- WamRuntime$wam_sort_terms(state, collected, table)
+    groups <- WamRuntime$collect_bag_groups(program, state, template, goal)
+    if (length(groups) == 0L) return(FALSE)
+    group <- groups[[1L]]
+    sorted <- WamRuntime$wam_sort_terms(state, group$values, table)
     deduped <- list()
     for (i in seq_along(sorted)) {
       if (i == 1L ||
@@ -4294,12 +4425,19 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
       }
     }
     bag <- WamRuntime$wam_list_build(deduped, table)
+    trail0 <- length(state$trail)
+    if (!WamRuntime$bind_bag_group_witnesses(state, group)) {
+      WamRuntime$undo_trail_to(state, trail0)
+      return(FALSE)
+    }
     cur <- WamRuntime$get_reg(state, 3L)
     if (is.null(cur)) {
       WamRuntime$put_reg(state, 3L, bag)
       return(TRUE)
     }
-    return(WamRuntime$unify(state, cur, bag))
+    ok <- WamRuntime$unify(state, cur, bag)
+    if (!isTRUE(ok)) WamRuntime$undo_trail_to(state, trail0)
+    return(ok)
   }
 
   # ----- once/1: run goal, commit to first solution -----

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2111,13 +2111,11 @@ e2e_multi_solution_retract_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
-% End-to-end Rscript run for `^/2` existential scope in
-% bagof/setof/findall. Asserts a 2-arg dynamic predicate, then
-% drives bagof(X, Y^p(X,Y), L) etc. The `^/2` wrapper should be
-% transparent: all X bindings get aggregated regardless of Y's
-% value. This scaffold doesn't do per-witness grouping, so non-
-% existentially-quantified free vars are also aggregated -- the
-% test only covers the `^`-wrapped case.
+% End-to-end Rscript run for `^/2` existential scope and first
+% free-variable grouping in bagof/setof. Asserts 2-arg dynamic
+% predicates, then drives bagof(X, Y^p(X,Y), L) and
+% bagof(X, p(X,Y), L). The `^/2` wrapper keeps Y existential;
+% without it, Y is bound to the selected witness group.
 % Auto-skips when Rscript is not on PATH.
 % ------------------------------------------------------------------
 test(bagof_setof_existential_e2e_rscript) :-
@@ -2155,16 +2153,33 @@ e2e_bagof_setof_existential_via_rscript :-
     % Empty bag fails (bagof semantics).
     assertz((user:be_bagof_empty_no :-
         bagof(X, Y^nonexistent(X, Y), _))),
+    % Non-existential free witness: first group binds Y and collects
+    % only matching X values.
+    assertz((user:be_bagof_group_first :-
+        assertz(gg(1, a)), assertz(gg(2, a)), assertz(gg(3, b)),
+        bagof(X, gg(X, Y), L),
+        Y == a,
+        L == [1, 2])),
+    % setof does the same grouping, then sorts and dedups the selected
+    % group's template values.
+    assertz((user:be_setof_group_first :-
+        assertz(hh(3, a)), assertz(hh(1, a)), assertz(hh(3, a)),
+        assertz(hh(2, b)),
+        setof(X, hh(X, Y), L),
+        Y == a,
+        L == [1, 3])),
     unique_r_tmp_dir('tmp_r_caret_e2e', TmpDir),
     write_wam_r_project(
         [ user:be_bagof_basic/0, user:be_setof_basic/0,
           user:be_nested_caret/0, user:be_findall_caret/0,
-          user:be_bagof_empty_no/0 ],
+          user:be_bagof_empty_no/0, user:be_bagof_group_first/0,
+          user:be_setof_group_first/0 ],
         [],
         TmpDir),
     directory_file_path(TmpDir, 'R', RDir),
     Yes = [be_bagof_basic, be_setof_basic, be_nested_caret,
-           be_findall_caret],
+           be_findall_caret, be_bagof_group_first,
+           be_setof_group_first],
     No  = [be_bagof_empty_no],
     forall(member(P, Yes), (
         format(string(Q), '~w/0', [P]),

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2168,18 +2168,23 @@ e2e_bagof_setof_existential_via_rscript :-
         setof(X, hh(X, Y), L),
         Y == a,
         L == [1, 3])),
+    % Boundary for this partial implementation: additional witness
+    % groups are not enumerated on backtracking yet.
+    assertz((user:be_bagof_no_second_group :-
+        assertz(ii(1, a)), assertz(ii(2, b)),
+        \+ (bagof(X, ii(X, Y), L), Y == b, L == [2]))),
     unique_r_tmp_dir('tmp_r_caret_e2e', TmpDir),
     write_wam_r_project(
         [ user:be_bagof_basic/0, user:be_setof_basic/0,
           user:be_nested_caret/0, user:be_findall_caret/0,
           user:be_bagof_empty_no/0, user:be_bagof_group_first/0,
-          user:be_setof_group_first/0 ],
+          user:be_setof_group_first/0, user:be_bagof_no_second_group/0 ],
         [],
         TmpDir),
     directory_file_path(TmpDir, 'R', RDir),
     Yes = [be_bagof_basic, be_setof_basic, be_nested_caret,
            be_findall_caret, be_bagof_group_first,
-           be_setof_group_first],
+           be_setof_group_first, be_bagof_no_second_group],
     No  = [be_bagof_empty_no],
     forall(member(P, Yes), (
         format(string(Q), '~w/0', [P]),


### PR DESCRIPTION
## Summary

- Add WAM-R witness grouping for library-level `bagof/3` and `setof/3`.
- Preserve `^/2` existential behavior so existentially scoped variables are excluded from witness grouping.
- Bind the selected first witness group consistently, so calls like `bagof(X, p(X, Y), L)` can bind `Y` and `L` for that group.
- Preserve `read_stack` in aggregate snapshots and restoration, matching the existing `build_stack` handling.
- Add a regression test that documents the current boundary: additional witness groups are not enumerated on backtracking yet.
- Update WAM-R docs to state this is not full ISO/SWI-equivalent `bagof/3` / `setof/3` behavior.

## Important Scope Note

This PR is a partial semantic improvement, not full `bagof/3` / `setof/3` parity.

Supported now:

- selected first witness group is respected
- `Var^Goal` existential scoping remains transparent and excludes existential variables from grouping
- `setof/3` sorts and deduplicates within the selected group
- no-solution `bagof/3` still fails

Still deferred:

- backtracking across additional witness groups

## Verification

- `swipl -g "run_tests([wam_r_generator:bagof_setof_once_forall_e2e_rscript,wam_r_generator:enumerable_builtins_e2e_rscript,wam_r_generator:bagof_setof_existential_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
  - All 3 targeted aggregator tests passed after rebasing/merging local `origin/main`.
- `swipl -g "run_tests([wam_r_generator:findall_e2e_rscript,wam_r_generator:bagof_setof_once_forall_e2e_rscript,wam_r_generator:bagof_setof_existential_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
  - All 3 targeted aggregate/read-stack tests passed after the aggregate snapshot fix.
- `swipl -g "run_tests([wam_r_generator:bagof_setof_existential_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
  - Passed after adding the explicit first-group boundary test.
- `git diff --check`
  - Clean.

## Commits

- `0ddcc013 feat(wam-r): group bagof setof by witnesses`
- `0e3ab852 fix(wam-r): preserve read stack in aggregate snapshots`
- `e24e9c7a test(wam-r): document bagof grouping boundary`
