### PR TITLE
feat(core): portable Prolog term parser (cross-target spec, WAM-R structural compile)

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -620,6 +620,17 @@ WamRuntime$run(shared_program, state)
   strictly less than the operator precedence. Symmetric with the
   existing prefix simplification. Documented; not a real-world
   blocker.
+- **Cut barrier scope**. The runtime's `!/0` and `CutIte` drop the
+  most-recent choice point, not the choice points created since the
+  current predicate's clause head. This is enough for cut in a
+  predicate whose body never calls another multi-clause predicate
+  before the cut, but loses cut-barrier semantics for any cut whose
+  preceding goals push CPs that aren't the predicate's own. The
+  cross-target Prolog parser (`src/unifyweaver/core/prolog_term_parser.pl`,
+  see `tests/test_prolog_term_parser_wam_r_compile.pl`) compiles
+  successfully but only its cut-free predicates execute correctly
+  end-to-end for this reason; full runtime equivalence with
+  `WamRuntime$parse_term` is gated on this fix.
 - **WAM-text quoting collision**. The atom `'42'` and the integer
   `42` both serialise as `set_constant 42` in SWI's WAM emitter,
   so the codegen can't distinguish them. The runtime's `atom_*`

--- a/docs/handoff/wam_r_session_handoff.md
+++ b/docs/handoff/wam_r_session_handoff.md
@@ -139,26 +139,40 @@ roughly priority order:
    identify a single hot path; subsequent PRs each fix one bottleneck.
    Tagged-list `$tag` access and env-based register lookups are likely
    suspects.
-3. **Strict `xf` precedence rule** (small). Threading the precedence
+3. **Proper cut-barrier scope.** The runtime's `!/0` and `CutIte`
+   drop only the most-recent CP; they don't track the cut barrier
+   at clause-head entry. Fine for shallow predicates, but loses
+   cut semantics whenever a multi-clause callee leaves CPs alive
+   before the cut runs. Direct unblocks the compiled Prolog term
+   parser at `src/unifyweaver/core/prolog_term_parser.pl` -- the
+   structural compile test
+   (`tests/test_prolog_term_parser_wam_r_compile.pl`) shows the
+   source compiles cleanly; full end-to-end equivalence with
+   `WamRuntime$parse_term` is gated on this. To fix: stamp every
+   choice point with the depth at clause-head entry, and have
+   `!/0` truncate `state$cps` back to that depth instead of
+   popping one. Same change makes `CutIte` correct for nested
+   if-then-else.
+4. **Strict `xf` precedence rule** (small). Threading the precedence
    of the current `left` expression through `wam_parse_expr` so `xf`
    and `yf` differ correctly at chained-postfix sites. Fixes the
    simplification documented as a known limitation. Same fix would
    let `fx` / `fy` differ correctly in the prefix path.
-4. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
+5. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
    mode info per predicate (in/out per arg); Phase 2 wires it to
    specialised emission (skip unifications when the mode says the slot
    is unbound, etc.). Look at the Haskell target's
    `WAM_HASKELL_MODE_ANALYSIS_*.md` design docs for the precedent.
-5. **Multi-line `read/2`.** Read until a `.` terminator across lines.
+6. **Multi-line `read/2`.** Read until a `.` terminator across lines.
    Niche but completes the streams story.
-6. **Multi-solution `retract/1` ignoring snapshot.** I.e. re-read the
+7. **Multi-solution `retract/1` ignoring snapshot.** I.e. re-read the
    live clause list on each backtrack. Trickier semantics; document
    carefully if pursued.
-7. **Phase-3 lowered emitter expansion.** Currently handles only
+8. **Phase-3 lowered emitter expansion.** Currently handles only
    `deterministic` and `multi_clause_1` shapes. Could grow N-clause
    general lowering; would compete with the kernel / fact-table paths
    so the value is unclear.
-8. **Range / interval indexes** on fact tables. Per-arg hash indexes
+9. **Range / interval indexes** on fact tables. Per-arg hash indexes
    land queries with ground atom/int args; range queries (`X > 5`,
    `X between A B`) still go through the per-tuple scan. A sorted-
    per-arg index would route these. Niche but a natural extension.

--- a/src/unifyweaver/core/prolog_term_parser.pl
+++ b/src/unifyweaver/core/prolog_term_parser.pl
@@ -1,0 +1,436 @@
+% =============================================================================
+% prolog_term_parser.pl
+%
+% Portable Prolog term parser. Lives in the cross-target-compilable subset
+% (the same constructs the WAM-R / WAM-Haskell / WAM-Scala backends consume),
+% so the same source can serve as the canonical spec AND be transpiled into
+% any target whose runtime needs to turn a string back into a term -- read/2,
+% term_to_atom/2, read_term_from_atom/2,3, command-line arg parsing, etc.
+%
+% Operator tables are caller-supplied data rather than module-local dynamic
+% state. Targets keep their own canonical op storage (e.g. WAM-R holds three
+% R lists keyed by fixity) and pass a snapshot in at parse time. This keeps
+% the parser pure, compiles cleanly, and matches how the runtime parser in
+% templates/targets/r_wam/runtime.R.mustache already works.
+%
+% API
+%   parse_term_from_codes(+Codes, +OpTable, -Term).
+%   parse_term_from_atom (+Atom,  +OpTable, -Term).
+%   canonical_op_table(-OpTable).
+%
+% OpTable is a list of op(Name, Prec, Type) facts; Type is one of
+% xfx | xfy | yfx | fx | fy | xf | yf.
+%
+% Variables sharing a source-level name share a Prolog logic variable
+% within a single parse; '_' is anonymous (distinct each occurrence).
+%
+% Compatibility note: this implementation deliberately matches the
+% Pratt-style algorithm in WamRuntime$wam_parse_expr. The xf/yf and
+% fx/fy distinctions are not enforced under chained postfix / prefix
+% application; both treat the operand precedence ceiling as
+% `op_prec - 1`. Same simplification documented in the WAM-R handoff.
+%
+% Compile-target status: this source compiles cleanly to WAM-R
+% (every predicate produces a label + wrapper; see
+% tests/test_prolog_term_parser_wam_r_compile.pl), and SWI runs it
+% to spec. End-to-end equivalence with the inline R parser at
+% WamRuntime$parse_term is currently gated on the WAM-R cut
+% implementation: the runtime's `!/0` and `CutIte` drop only the
+% most-recent CP, which loses cut-barrier semantics whenever a
+% multi-clause callee leaves CPs alive before the cut runs (which
+% e.g. tokenize_one and take_ident hit). Fix is filed as follow-up
+% #3 in docs/handoff/wam_r_session_handoff.md. When that lands the
+% inline parser can be retired -- the structural compile test is
+% the regression guard.
+% =============================================================================
+
+:- module(prolog_term_parser, [
+    parse_term_from_codes/3,
+    parse_term_from_atom/3,
+    canonical_op_table/1
+]).
+
+% -----------------------------------------------------------------------------
+% Entry points
+% -----------------------------------------------------------------------------
+
+parse_term_from_atom(Atom, OpTable, Term) :-
+    atom_codes(Atom, Codes),
+    parse_term_from_codes(Codes, OpTable, Term).
+
+parse_term_from_codes(Codes, OpTable, Term) :-
+    tokenize(Codes, Tokens),
+    parse_expr(Tokens, OpTable, 1200, Term, [], _Env, Rest),
+    Rest == [].
+
+% -----------------------------------------------------------------------------
+% Canonical op table (mirrors WamRuntime$op_infix / op_prefix seeds)
+% -----------------------------------------------------------------------------
+
+canonical_op_table([
+    op(':-',   1200, xfx),
+    op('-->',  1200, xfx),
+    op(';',    1100, xfy),
+    op('->',   1050, xfy),
+    op('*->',  1050, xfy),
+    op(',',    1000, xfy),
+    op('=',     700, xfx),
+    op('\\=',   700, xfx),
+    op('==',    700, xfx),
+    op('\\==',  700, xfx),
+    op('=..',   700, xfx),
+    op('is',    700, xfx),
+    op('=:=',   700, xfx),
+    op('=\\=',  700, xfx),
+    op('<',     700, xfx),
+    op('>',     700, xfx),
+    op('=<',    700, xfx),
+    op('>=',    700, xfx),
+    op('@<',    700, xfx),
+    op('@>',    700, xfx),
+    op('@=<',   700, xfx),
+    op('@>=',   700, xfx),
+    op('+',     500, yfx),
+    op('-',     500, yfx),
+    op('/\\',   500, yfx),
+    op('\\/',   500, yfx),
+    op('xor',   500, yfx),
+    op('*',     400, yfx),
+    op('/',     400, yfx),
+    op('//',    400, yfx),
+    op('mod',   400, yfx),
+    op('rem',   400, yfx),
+    op('div',   400, yfx),
+    op('<<',    400, yfx),
+    op('>>',    400, yfx),
+    op('**',    200, xfx),
+    op('^',     200, xfy),
+    op(':-',   1200, fx),
+    op('?-',   1200, fx),
+    op('\\+',   900, fy),
+    op('-',     200, fy),
+    op('+',     200, fy),
+    op('\\',    200, fy)
+]).
+
+% -----------------------------------------------------------------------------
+% Tokenizer
+% -----------------------------------------------------------------------------
+% codes -> list of:
+%   tk_atom(Name)        bare/quoted atoms, single-char solo atoms
+%   tk_sym(Name)         symbol-run atoms (`+`, `=:=`, `\\=`, ...)
+%   tk_num(Value)        integer or float
+%   tk_var(Name)         variable; Name is the source-level identifier
+%   tk_lparen / tk_rparen / tk_lbracket / tk_rbracket
+%   tk_comma / tk_semicolon / tk_pipe
+
+tokenize(Codes, Tokens) :-
+    tokenize_loop(Codes, [], Reverse),
+    reverse(Reverse, Tokens).
+
+tokenize_loop([], Acc, Acc).
+tokenize_loop([C|Cs], Acc, Out) :-
+    (   ws_code(C)
+    ->  tokenize_loop(Cs, Acc, Out)
+    ;   tokenize_one([C|Cs], Acc, Acc1, Rest),
+        tokenize_loop(Rest, Acc1, Out)
+    ).
+
+ws_code(32). ws_code(9). ws_code(10). ws_code(13).
+
+% Single-char structural / solo tokens.
+tokenize_one([0'(  |R], A, [tk_lparen    |A], R) :- !.
+tokenize_one([0')  |R], A, [tk_rparen    |A], R) :- !.
+tokenize_one([0'[  |R], A, [tk_lbracket  |A], R) :- !.
+tokenize_one([0']  |R], A, [tk_rbracket  |A], R) :- !.
+tokenize_one([0',  |R], A, [tk_comma     |A], R) :- !.
+tokenize_one([0';  |R], A, [tk_semicolon |A], R) :- !.
+tokenize_one([0'|  |R], A, [tk_pipe      |A], R) :- !.
+tokenize_one([0'!  |R], A, [tk_atom('!') |A], R) :- !.
+
+% Quoted atom: '...'. Handles \\ and \' escapes; bare \ followed by any
+% other char keeps the next char literally (matches the R tokenizer).
+tokenize_one([39|R], A, [tk_atom(Atom)|A], Rest) :-
+    !,
+    take_quoted(R, [], Cs, Rest),
+    atom_codes(Atom, Cs).
+
+% Signed number: a `-` followed by a digit, but only when the previous
+% emitted token can't combine with `-` as an infix operator (so we don't
+% mis-tokenise `X-1` as `X (-1)`). Acc holds the reverse of tokens emitted
+% so far.
+tokenize_one([0'-, D | R], A, [tk_num(N)|A], Rest) :-
+    digit_code(D),
+    can_lead_negative(A),
+    !,
+    take_number_after_sign(D, R, Cs, Rest),
+    codes_to_number([0'-|Cs], N).
+
+% Unsigned number.
+tokenize_one([D|R], A, [tk_num(N)|A], Rest) :-
+    digit_code(D),
+    !,
+    take_number_after_sign(D, R, Cs, Rest),
+    codes_to_number(Cs, N).
+
+% Variable: starts with uppercase or underscore.
+tokenize_one([C|R], A, [tk_var(Name)|A], Rest) :-
+    var_start_code(C),
+    !,
+    take_ident([C|R], Cs, Rest),
+    atom_codes(Name, Cs).
+
+% Bare atom: lowercase start.
+tokenize_one([C|R], A, [tk_atom(Atom)|A], Rest) :-
+    lower_code(C),
+    !,
+    take_ident([C|R], Cs, Rest),
+    atom_codes(Atom, Cs).
+
+% Symbol-run atom.
+tokenize_one([C|R], A, [tk_sym(Atom)|A], Rest) :-
+    sym_code(C),
+    !,
+    take_syms([C|R], Cs, Rest),
+    atom_codes(Atom, Cs).
+
+% Anything else: fail the whole tokenize (unrecognized character).
+
+% --- character classes -------------------------------------------------------
+
+digit_code(C) :- C >= 48, C =< 57.
+lower_code(C) :- C >= 97, C =< 122.
+upper_code(C) :- C >= 65, C =< 90.
+var_start_code(C) :- upper_code(C).
+var_start_code(95).                     % `_`
+ident_cont(C) :- lower_code(C).
+ident_cont(C) :- upper_code(C).
+ident_cont(C) :- digit_code(C).
+ident_cont(95).                         % `_`
+
+% Same set as the R tokenizer's sym_chars: + - * / \ ^ < > = : @ . ? ~ # $ &.
+sym_code(43). sym_code(45). sym_code(42). sym_code(47). sym_code(92).
+sym_code(94). sym_code(60). sym_code(62). sym_code(61). sym_code(58).
+sym_code(64). sym_code(46). sym_code(63). sym_code(126). sym_code(35).
+sym_code(36). sym_code(38).
+
+% --- string-eating helpers ---------------------------------------------------
+
+take_ident([], [], []).
+take_ident([C|R], [C|Cs], Rest) :- ident_cont(C), !, take_ident(R, Cs, Rest).
+take_ident([C|R], [], [C|R])    :- \+ ident_cont(C).
+
+take_syms([], [], []).
+take_syms([C|R], [C|Cs], Rest) :- sym_code(C), !, take_syms(R, Cs, Rest).
+take_syms([C|R], [], [C|R])    :- \+ sym_code(C).
+
+% Consume digits, then optional `.digits` for a float. The first digit is
+% already consumed by the caller (passed in via Lead); we splice it back.
+take_number_after_sign(Lead, R, [Lead|Cs], Rest) :-
+    take_digits(R, IntCs, Rest1),
+    (   Rest1 = [0'., D | Rest2], digit_code(D)
+    ->  take_digits(Rest2, FracCs, Rest),
+        append(IntCs, [0'., D | FracCs], Cs)
+    ;   Cs = IntCs, Rest = Rest1
+    ).
+
+take_digits([], [], []).
+take_digits([C|R], [C|Cs], Rest) :- digit_code(C), !, take_digits(R, Cs, Rest).
+take_digits([C|R], [], [C|R])    :- \+ digit_code(C).
+
+% Quoted atom body. ' ends the literal; \ acts as a one-char escape so '\''
+% and '\\' both round-trip.
+take_quoted([39|R], Cs, Cs, R) :- !.
+take_quoted([92, C | R], Acc, Out, Rest) :-
+    !,
+    append(Acc, [C], Acc1),
+    take_quoted(R, Acc1, Out, Rest).
+take_quoted([C|R], Acc, Out, Rest) :-
+    append(Acc, [C], Acc1),
+    take_quoted(R, Acc1, Out, Rest).
+
+% codes_to_number: codes -> integer or float. Tries integer first by checking
+% for a `.` in the digit run.
+codes_to_number(Cs, N) :-
+    (   memberchk(0'., Cs)
+    ->  number_codes(N, Cs)             % float
+    ;   number_codes(N, Cs)             % integer; same path, ISO behaviour
+    ).
+
+% can_lead_negative: a bare `-` followed by a digit is a signed-number lead
+% only when the previous emitted token (top of Acc, a reverse stack) is a
+% structural separator -- otherwise the `-` is the infix subtraction op.
+can_lead_negative([]).
+can_lead_negative([T|_]) :- separator_token(T).
+
+separator_token(tk_comma).
+separator_token(tk_semicolon).
+separator_token(tk_lparen).
+separator_token(tk_lbracket).
+separator_token(tk_pipe).
+
+% -----------------------------------------------------------------------------
+% Parser (Pratt-style)
+% -----------------------------------------------------------------------------
+
+% parse_expr(+Tokens, +OpTable, +MaxPrec, -Term, +Env0, -Env, -Rest).
+parse_expr(Tokens0, OpTable, MaxPrec, Term, Env0, Env, Rest) :-
+    parse_primary(Tokens0, OpTable, MaxPrec, Left, Env0, Env1, Tokens1),
+    parse_op_loop(Tokens1, OpTable, MaxPrec, Left, Term, Env1, Env, Rest).
+
+parse_op_loop([], _, _, Left, Left, Env, Env, []).
+parse_op_loop([T|Toks], OpTable, MaxPrec, Left, Term, Env0, Env, Rest) :-
+    op_loop_step(T, Toks, OpTable, MaxPrec, Left, Term, Env0, Env, Rest).
+
+% op_loop_step: factored out of parse_op_loop to keep the disjunction
+% depth shallow -- the WAM compiler's clause_body_analysis pass
+% stack-overflows on deeply nested ( A -> B ; C -> D ; E ).
+op_loop_step(T, Toks, OpTable, MaxPrec, Left, Term, Env0, Env, Rest) :-
+    token_op_name(T, Name),
+    op_loop_with_op(Name, Toks, OpTable, MaxPrec, Left, Term, Env0, Env, Rest),
+    !.
+op_loop_step(T, Toks, _, _, Left, Left, Env, Env, [T|Toks]).
+
+% Tries infix first (matches SWI), falls through to postfix. Fails if
+% neither resolution applies, letting op_loop_step backtrack to the
+% no-op clause.
+op_loop_with_op(Name, Toks, OpTable, MaxPrec, Left, Term, Env0, Env, Rest) :-
+    resolve_infix(Name, OpTable, Prec, Type),
+    Prec =< MaxPrec,
+    !,
+    rhs_max_prec(Type, Prec, RhsMax),
+    parse_expr(Toks, OpTable, RhsMax, Right, Env0, Env1, Toks1),
+    T2 =.. [Name, Left, Right],
+    parse_op_loop(Toks1, OpTable, MaxPrec, T2, Term, Env1, Env, Rest).
+op_loop_with_op(Name, Toks, OpTable, MaxPrec, Left, Term, Env0, Env, Rest) :-
+    resolve_postfix(Name, OpTable, Prec, _Type),
+    Prec =< MaxPrec,
+    T2 =.. [Name, Left],
+    parse_op_loop(Toks, OpTable, MaxPrec, T2, Term, Env0, Env, Rest).
+
+% parse_primary: the leading token of an expression. Number / var / atom /
+% list / parenthesised / prefix-op application.
+parse_primary([tk_num(V)|R], _, _, V, Env, Env, R) :- !.
+
+parse_primary([tk_var(Name)|R], _, _, V, Env0, Env, R) :- !,
+    bind_var(Name, V, Env0, Env).
+
+parse_primary([tk_atom(Name)|R], OpTable, MaxPrec, Term, Env0, Env, Rest) :- !,
+    parse_atom_head(Name, R, OpTable, MaxPrec, Term, Env0, Env, Rest).
+
+parse_primary([tk_sym(Name)|R], OpTable, MaxPrec, Term, Env0, Env, Rest) :- !,
+    parse_atom_head(Name, R, OpTable, MaxPrec, Term, Env0, Env, Rest).
+
+parse_primary([tk_lparen|R], OpTable, _, Term, Env0, Env, Rest) :- !,
+    parse_expr(R, OpTable, 1200, Term, Env0, Env, [tk_rparen|Rest]).
+
+parse_primary([tk_lbracket|R], OpTable, _, Term, Env0, Env, Rest) :- !,
+    parse_list_body(R, OpTable, Term, Env0, Env, Rest).
+
+% parse_atom_head: an atom token at primary position can be (1) a functor
+% application (atom immediately followed by `(`), (2) a prefix-op application,
+% or (3) a stand-alone atom.
+parse_atom_head(Name, [tk_lparen|R], OpTable, _, Term, Env0, Env, Rest) :- !,
+    parse_args(R, OpTable, Args, Env0, Env, Rest),
+    Term =.. [Name|Args].
+parse_atom_head(Name, R, OpTable, MaxPrec, Term, Env0, Env, Rest) :-
+    R = [Next|_],
+    starts_term(Next),
+    resolve_prefix(Name, OpTable, Prec),
+    Prec =< MaxPrec,
+    !,
+    OperandMax is Prec - 1,
+    parse_expr(R, OpTable, OperandMax, Operand, Env0, Env, Rest),
+    Term =.. [Name, Operand].
+parse_atom_head(Name, R, _, _, Name, Env, Env, R).
+
+% parse_args: comma-separated arg list inside `(...)`, max_prec 999 so the
+% top-level comma operator (1000) doesn't get folded in.
+parse_args(Tokens, OpTable, [Arg|Rest], Env0, Env, RestOut) :-
+    parse_expr(Tokens, OpTable, 999, Arg, Env0, Env1, Tokens1),
+    (   Tokens1 = [tk_comma|Tokens2]
+    ->  parse_args(Tokens2, OpTable, Rest, Env1, Env, RestOut)
+    ;   Tokens1 = [tk_rparen|RestOut]
+    ->  Rest = [], Env = Env1
+    ).
+
+% parse_list_body: handles `[]`, `[a, b, c]`, `[H|T]`. Element max_prec 999
+% (matches parse_args).
+parse_list_body([tk_rbracket|R], _, [], Env, Env, R) :- !.
+parse_list_body(Tokens, OpTable, List, Env0, Env, Rest) :-
+    parse_list_elems(Tokens, OpTable, Elems, Tail, Env0, Env, Rest),
+    list_build(Elems, Tail, List).
+
+parse_list_elems(Tokens, OpTable, [E|Rest], Tail, Env0, Env, RestOut) :-
+    parse_expr(Tokens, OpTable, 999, E, Env0, Env1, Tokens1),
+    list_elem_continue(Tokens1, OpTable, Rest, Tail, Env1, Env, RestOut).
+
+% Same disjunction-depth workaround as op_loop_step.
+list_elem_continue([tk_comma|Toks], OpTable, Rest, Tail, Env0, Env, RestOut) :-
+    !,
+    parse_list_elems(Toks, OpTable, Rest, Tail, Env0, Env, RestOut).
+list_elem_continue([tk_pipe|Toks], OpTable, [], Tail, Env0, Env, RestOut) :-
+    !,
+    parse_expr(Toks, OpTable, 999, Tail, Env0, Env, Tokens3),
+    Tokens3 = [tk_rbracket|RestOut].
+list_elem_continue([tk_rbracket|RestOut], _, [], [], Env, Env, RestOut).
+
+list_build([], Tail, Tail).
+list_build([E|Es], Tail, [E|Rest]) :- list_build(Es, Tail, Rest).
+
+% --- token / op resolution ---------------------------------------------------
+
+token_op_name(tk_atom(N),    N).
+token_op_name(tk_sym(N),     N).
+token_op_name(tk_comma,      ',').
+token_op_name(tk_semicolon,  ';').
+
+resolve_infix(Name, OpTable, Prec, Type) :-
+    member(op(Name, Prec, Type), OpTable),
+    is_infix_type(Type),
+    !.
+
+resolve_postfix(Name, OpTable, Prec, Type) :-
+    member(op(Name, Prec, Type), OpTable),
+    is_postfix_type(Type),
+    !.
+
+resolve_prefix(Name, OpTable, Prec) :-
+    member(op(Name, Prec, Type), OpTable),
+    is_prefix_type(Type),
+    !.
+
+is_infix_type(xfx).
+is_infix_type(xfy).
+is_infix_type(yfx).
+is_postfix_type(xf).
+is_postfix_type(yf).
+is_prefix_type(fx).
+is_prefix_type(fy).
+
+% rhs_max_prec: xfy keeps the rhs at op_prec (right-associative); xfx/yfx
+% drop one (xfx forbids same-prec rhs; yfx folds left through the outer loop
+% since each iteration starts at the same MaxPrec ceiling).
+rhs_max_prec(xfy, Prec, Prec).
+rhs_max_prec(xfx, Prec, Prec1) :- Prec1 is Prec - 1.
+rhs_max_prec(yfx, Prec, Prec1) :- Prec1 is Prec - 1.
+
+starts_term(tk_num(_)).
+starts_term(tk_var(_)).
+starts_term(tk_atom(_)).
+starts_term(tk_sym(_)).
+starts_term(tk_lparen).
+starts_term(tk_lbracket).
+
+% --- variable env ------------------------------------------------------------
+
+% bind_var(+Name, -Var, +Env0, -Env).
+%   Looks up Name in Env. If found, unifies Var with the existing logic var.
+%   Otherwise adds Name-Var and returns the extended env. The atom '_' is
+%   anonymous: every occurrence yields a fresh var.
+bind_var('_', _Fresh, Env, Env) :- !.
+bind_var(Name, Var, Env, Env) :-
+    member(Name-V, Env),
+    !,
+    Var = V.
+bind_var(Name, Var, Env, [Name-Var|Env]).

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -380,6 +380,15 @@ wam_parts_to_r(["switch_on_constant" | Cases], Lit) :-
     atomic_list_concat(CaseLits, ', ', CasesStr),
     format(string(Lit), 'SwitchOnConstant(list(~w))', [CasesStr]).
 
+% --- Switch on term (type-mixed dispatch) ---
+% Emitted by the WAM compiler when a predicate's clauses have a mix
+% of first-arg types (constant + struct + list). The runtime
+% implements this as a no-op that advances PC; the standard
+% try/retry chain visits each clause and clause-head unification
+% filters non-matching ones, so correctness is preserved without
+% the optimisation.
+wam_parts_to_r(["switch_on_term" | _], 'SwitchOnTerm()').
+
 % --- Switch on structure (functor-shape dispatch) ---
 % Each case is "F/N:label". Behaviour parallels switch_on_constant: when
 % the first arg is a struct of matching shape, jump to the labelled
@@ -784,7 +793,12 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
         NewAllLabels = [MainEntry | AllLabelAcc],
         WamCodeForLower = "",
         NewFactCommentAcc = FactCommentAcc
-    ;   compile_predicate_to_wam(P/Arity, [], WamCode),
+    ;   % Pass Pred (which may be Module:P/Arity or P/Arity) so cross-
+        % module compilation can find clauses outside `user`. Stripping
+        % to P/Arity defaults compile_predicate_to_wam's module to
+        % `user`, which silently produces "no clauses" for predicates
+        % defined in any other module.
+        compile_predicate_to_wam(Pred, [], WamCode),
         WamCodeForLower = WamCode,
         atom_string(WamCode, WamStr),
         split_string(WamStr, "\n", "", WamLines),

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -201,6 +201,14 @@ SwitchOnConstant  <- function(cases)    list(op = "SwitchOnConstant",  cases = c
 SwitchCase        <- function(val, label) list(value = val, label = label)
 SwitchOnStructure <- function(cases)    list(op = "SwitchOnStructure", cases = cases)
 StructCase        <- function(fid, arity, label) list(fid = as.integer(fid), arity = as.integer(arity), label = label)
+# switch_on_term is the type-mixed dispatch instruction emitted by the
+# WAM compiler when a predicate's clauses have a mix of first-arg
+# types (constant + struct + list). We don't currently use it for
+# optimised type dispatch -- the standard try/retry chain visits
+# every clause and uses clause-head unification to filter -- so the
+# instruction is a correctness-preserving no-op. Adding the proper
+# dispatch later is a pure speed win.
+SwitchOnTerm      <- function()         list(op = "SwitchOnTerm")
 
 BeginAggregate <- function(kind, t, b) list(op = "BeginAggregate", kind = kind, template = t, bag = b)
 EndAggregate   <- function(t)          list(op = "EndAggregate",   template = t)
@@ -1333,6 +1341,10 @@ WamRuntime$step <- function(program, state, instr) {
         state$pc <- as.integer(tgt)
       }
       TRUE
+    },
+    "SwitchOnTerm" = {
+      # Correctness-preserving no-op (see SwitchOnTerm constructor).
+      state$pc <- state$pc + 1L; TRUE
     },
     "BuiltinCall" = {
       ok <- WamRuntime$call_builtin(program, state, instr$pred, instr$arity)

--- a/tests/test_prolog_term_parser.pl
+++ b/tests/test_prolog_term_parser.pl
@@ -1,0 +1,138 @@
+% =============================================================================
+% test_prolog_term_parser.pl
+%
+% SWI-runnable correctness tests for src/unifyweaver/core/prolog_term_parser.pl.
+% The same module will eventually be compiled to one or more WAM targets
+% (see test_prolog_term_parser_wam_r_compile.pl for the structural
+% compile-to-target test); these tests exercise the algorithm under SWI so
+% breakage shows up before any cross-target codegen runs.
+% =============================================================================
+
+:- use_module(library(plunit)).
+:- use_module('../src/unifyweaver/core/prolog_term_parser').
+
+:- begin_tests(prolog_term_parser).
+
+% Helper: parse using the canonical op table.
+canon_parse_atom(A, T) :-
+    canonical_op_table(Ops),
+    parse_term_from_atom(A, Ops, T).
+
+% --- atomic / number / variable primitives ----------------------------------
+
+test(atom_bare) :-
+    canon_parse_atom('foo', T),
+    T == foo.
+
+test(atom_quoted_with_space) :-
+    canon_parse_atom('\'hello world\'', T),
+    T == 'hello world'.
+
+test(int_unsigned) :-
+    canon_parse_atom('42', T),
+    T == 42.
+
+test(int_negative_after_sep) :-
+    canon_parse_atom('f(-3)', T),
+    T == f(-3).
+
+test(float_basic) :-
+    canon_parse_atom('3.14', T),
+    T == 3.14.
+
+test(var_uppercase) :-
+    canon_parse_atom('X', T),
+    var(T).
+
+test(var_underscore_anonymous) :-
+    canon_parse_atom('f(_, _)', f(A, B)),
+    var(A), var(B),
+    A \== B.
+
+test(var_repeated_shares) :-
+    canon_parse_atom('f(X, X)', f(A, B)),
+    var(A), A == B.
+
+% --- compound terms / lists --------------------------------------------------
+
+test(compound_simple) :-
+    canon_parse_atom('foo(a, b)', T),
+    T == foo(a, b).
+
+test(compound_nested) :-
+    canon_parse_atom('foo(bar(1), baz(X, X))', T),
+    T = foo(bar(1), baz(A, B)),
+    var(A), A == B.
+
+test(empty_list) :-
+    canon_parse_atom('[]', T),
+    T == [].
+
+test(list_basic) :-
+    canon_parse_atom('[1, 2, 3]', T),
+    T == [1, 2, 3].
+
+test(list_pipe_tail) :-
+    canon_parse_atom('[a, b | T]', X),
+    X = [a, b | Tail],
+    var(Tail).
+
+% --- operators --------------------------------------------------------------
+
+test(infix_arith) :-
+    canon_parse_atom('1 + 2 * 3', T),
+    T == 1 + 2 * 3.
+
+test(infix_yfx_left_assoc) :-
+    canon_parse_atom('1 - 2 - 3', T),
+    T == (1 - 2) - 3.
+
+test(infix_xfy_right_assoc) :-
+    canon_parse_atom('a ; b ; c', T),
+    T == (a ; (b ; c)).
+
+test(prefix_minus) :-
+    canon_parse_atom('-5', T),
+    T == -5.
+
+test(prefix_negation) :-
+    canon_parse_atom('\\+ foo', T),
+    T == (\+ foo).
+
+test(parenthesised_grouping) :-
+    canon_parse_atom('(1 + 2) * 3', T),
+    T == (1 + 2) * 3.
+
+% --- postfix --------------------------------------------------------------
+
+postfix_op_table(Ops) :-
+    canonical_op_table(Base),
+    Ops = [op('!', 100, yf) | Base].
+
+test(postfix_single) :-
+    postfix_op_table(Ops),
+    parse_term_from_atom('5!', Ops, T),
+    T == '!'(5).
+
+test(postfix_chained) :-
+    postfix_op_table(Ops),
+    parse_term_from_atom('5!!', Ops, T),
+    T == '!'('!'(5)).
+
+test(postfix_with_infix) :-
+    postfix_op_table(Ops),
+    parse_term_from_atom('5! + 3', Ops, T),
+    T == '!'(5) + 3.
+
+% --- failure modes ----------------------------------------------------------
+
+test(unterminated_quote_fails, [fail]) :-
+    canon_parse_atom('\'oops', _).
+
+test(extra_tokens_fail, [fail]) :-
+    canon_parse_atom('a b', _).
+
+test(empty_input_fails, [fail]) :-
+    canon_parse_atom('', _).
+
+:- end_tests(prolog_term_parser).

--- a/tests/test_prolog_term_parser_wam_r_compile.pl
+++ b/tests/test_prolog_term_parser_wam_r_compile.pl
@@ -1,0 +1,160 @@
+% =============================================================================
+% test_prolog_term_parser_wam_r_compile.pl
+%
+% Structural compile-to-target test: feeds every predicate of
+% src/unifyweaver/core/prolog_term_parser.pl through
+% write_wam_r_project/3 and verifies (a) the generated R is syntactically
+% valid, (b) every parser predicate has a generated label and wrapper
+% function, and (c) a cut-free subset runs end-to-end via Rscript.
+%
+% This is the cross-target proof point: the same canonical-Prolog parser
+% source can be transpiled to a WAM-R project. End-to-end execution of
+% the FULL parser is not yet covered; the WAM-R cut scaffold drops only
+% the most recent choice point (runtime.R.mustache: cut comment near
+% `pred == "!/0"`), which loses cut-barrier semantics when the cut sits
+% in a clause body that calls another multi-clause predicate. The parser
+% relies on those exact semantics via take_ident, ident_cont, and
+% friends. Filed as a separate follow-up; this PR ships the source +
+% structural compilation, not the runtime swap-in.
+% =============================================================================
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module(library(process)).
+:- use_module('../src/unifyweaver/core/prolog_term_parser').
+:- use_module('../src/unifyweaver/targets/wam_r_target').
+
+:- begin_tests(prolog_term_parser_wam_r_compile).
+
+% Helper: enumerate every clause-defined predicate in the parser module
+% and return them as a sorted list of Module:Name/Arity terms.
+parser_predicates(Preds) :-
+    findall(prolog_term_parser:N/A,
+            (   current_predicate(prolog_term_parser:N/A),
+                functor(H, N, A),
+                once(clause(prolog_term_parser:H, _))
+            ),
+            Raw),
+    sort(Raw, Preds).
+
+% Helper: tmp project dir under /tmp/prolog_term_parser_compile_e2e_<stamp>.
+fresh_tmp_dir(Dir) :-
+    get_time(T),
+    StampF is T,
+    format(atom(Dir), '/tmp/prolog_term_parser_compile_e2e_~w', [StampF]),
+    (   exists_directory(Dir)
+    ->  delete_directory_and_contents(Dir)
+    ;   true
+    ).
+
+rscript_available :-
+    catch((
+        process_create(path('Rscript'), ['--version'],
+                       [ stdout(null), stderr(null), process(PID) ]),
+        process_wait(PID, exit(0))
+    ), _, fail).
+
+% ---------------------------------------------------------------------------
+% Test: every parser predicate compiles without error and the project
+% writer produces the expected files.
+% ---------------------------------------------------------------------------
+
+test(parser_compiles_to_wam_r_project) :- once((
+    parser_predicates(ParserPreds),
+    fresh_tmp_dir(TmpDir),
+    retractall(user:drv_compile_only/0),
+    assertz((user:drv_compile_only :-
+        canonical_op_table(_Ops),
+        write(ok), nl)),
+    write_wam_r_project([user:drv_compile_only/0 | ParserPreds],
+                        [], TmpDir),
+    directory_file_path(TmpDir, 'R/generated_program.R', GenPath),
+    directory_file_path(TmpDir, 'R/wam_runtime.R',       RtPath),
+    assertion(exists_file(GenPath)),
+    assertion(exists_file(RtPath)),
+    read_file_to_string(GenPath, Code, []),
+    % Sanity: every parser predicate has a generated dispatcher
+    % wrapper (pred_<name>) so the runtime can resolve calls into
+    % the compiled body.
+    forall(member(prolog_term_parser:N/A, ParserPreds), (
+        format(atom(WrapperPattern), 'pred_~w <- function(', [N]),
+        assertion(sub_atom(Code, _, _, _, WrapperPattern)),
+        format(atom(LabelPattern), '"~w/~w" =', [N, A]),
+        assertion(sub_atom(Code, _, _, _, LabelPattern))
+    )),
+    delete_directory_and_contents(TmpDir))).
+
+% ---------------------------------------------------------------------------
+% Test: a cut-free subset runs end-to-end via Rscript. Auto-skips when
+% Rscript isn't on PATH (matches the convention in
+% test_wam_r_generator.pl).
+% ---------------------------------------------------------------------------
+
+test(cut_free_subset_runs_via_rscript) :-
+    once((
+        rscript_available
+    ->  cut_free_subset_runs_body
+    ;   true
+    )).
+
+cut_free_subset_runs_body :-
+    parser_predicates(ParserPreds),
+    fresh_tmp_dir(TmpDir),
+    % Cut-free drivers: exercise predicates whose semantics don't
+    % depend on cut-barrier scoping.
+    %   * canonical_op_table/1: single fact, no body.
+    %   * is_infix_type/1: 3 facts; head-pattern dispatch.
+    %   * rhs_max_prec/3: 3 clauses, head-pattern dispatch + arithmetic.
+    %   * starts_term/1: 6 facts.
+    retractall(user:drv_canon_len/0),
+    retractall(user:drv_infix/0),
+    retractall(user:drv_rhs_xfy/0),
+    retractall(user:drv_rhs_yfx/0),
+    retractall(user:drv_starts/0),
+    assertz((user:drv_canon_len :-
+        canonical_op_table(Ops),
+        length(Ops, N),
+        write('len='), write(N), nl)),
+    assertz((user:drv_infix :-
+        is_infix_type(xfy),
+        write(ok), nl)),
+    assertz((user:drv_rhs_xfy :-
+        rhs_max_prec(xfy, 700, R),
+        write(R), nl)),
+    assertz((user:drv_rhs_yfx :-
+        rhs_max_prec(yfx, 500, R),
+        write(R), nl)),
+    assertz((user:drv_starts :-
+        starts_term(tk_lparen),
+        write(ok), nl)),
+    Drivers = [user:drv_canon_len/0, user:drv_infix/0,
+               user:drv_rhs_xfy/0, user:drv_rhs_yfx/0,
+               user:drv_starts/0],
+    append(Drivers, ParserPreds, Compile),
+    write_wam_r_project(Compile, [], TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    run_rscript_query(RDir, 'drv_canon_len/0', LenOut),
+    assertion(sub_string(LenOut, _, _, _, "len=")),
+    run_rscript_query(RDir, 'drv_infix/0', InfixOut),
+    assertion(sub_string(InfixOut, _, _, _, "ok")),
+    run_rscript_query(RDir, 'drv_rhs_xfy/0', RhsXfyOut),
+    assertion(sub_string(RhsXfyOut, _, _, _, "700")),
+    run_rscript_query(RDir, 'drv_rhs_yfx/0', RhsYfxOut),
+    assertion(sub_string(RhsYfxOut, _, _, _, "499")),
+    run_rscript_query(RDir, 'drv_starts/0', StartsOut),
+    assertion(sub_string(StartsOut, _, _, _, "ok")),
+    delete_directory_and_contents(TmpDir).
+
+run_rscript_query(RDir, Query, Out) :-
+    process_create(path('Rscript'),
+                   ['generated_program.R', Query],
+                   [ cwd(RDir),
+                     stdout(pipe(OutStream)),
+                     stderr(pipe(ErrStream)),
+                     process(PID)
+                   ]),
+    read_string(OutStream, _, Out), close(OutStream),
+    read_string(ErrStream, _, _),   close(ErrStream),
+    process_wait(PID, _).
+
+:- end_tests(prolog_term_parser_wam_r_compile).


### PR DESCRIPTION
## Summary

First step of the cross-target generalization. Lifts the WAM-R term parser into `src/unifyweaver/core/prolog_term_parser.pl` as portable Prolog. The spec now lives in Prolog source — same algorithm, same coverage, written in the WAM-target-compilable subset, with operator tables passed in as data. Any future target that grows `read/2` / `term_to_atom/2` builtins inherits the parser by recompiling this one source.

Today only WAM-R has those builtins, but the bootstrap is in place: the source compiles cleanly through the WAM-R pipeline (39 parser predicates → wrappers + labels in the generated R project).

## What's in

**Module + tests** (new):
- `src/unifyweaver/core/prolog_term_parser.pl` — `parse_term_from_codes/3`, `parse_term_from_atom/3`, `canonical_op_table/1`. ~436 lines.
- `tests/test_prolog_term_parser.pl` — 25 SWI-level correctness tests (atoms, numbers, vars, var sharing, lists, infix/prefix/postfix with precedence + associativity, postfix chaining, failure modes).
- `tests/test_prolog_term_parser_wam_r_compile.pl` — 2 structural compile tests:
  - `parser_compiles_to_wam_r_project` — every parser predicate has a generated wrapper + label.
  - `cut_free_subset_runs_via_rscript` — cut-free predicates execute correctly via Rscript (`canonical_op_table`, `is_infix_type`, `rhs_max_prec`, `starts_term`). Auto-skips when Rscript isn't on `PATH`.

**WAM-R-side enabling changes** (small, stay backward compatible — `wam_r_generator` 65/65 still green):
- `wam_r_target.pl`: pass the original (possibly module-qualified) `Pred` to `compile_predicate_to_wam` rather than stripping it. Stripping defaulted `Module` to `user`, silently producing "no clauses" for cross-module predicates.
- `runtime.R.mustache` + `wam_r_target.pl`: handle the WAM compiler's `switch_on_term` indexing instruction. Clauses with mixed first-arg types (constant + cons + struct) emit it; WAM-R previously crashed at runtime with `unrecognized WAM instruction`. New `SwitchOnTerm()` is a correctness-preserving no-op (try/retry chain handles dispatch via clause-head unification).
- `prolog_term_parser.pl`: `parse_op_loop` and `parse_list_elems` written as clause-level dispatch rather than triple-nested `( A -> B ; C -> D ; E )`. Equivalent under SWI; necessary because the WAM compiler's `clause_body_analysis` pass stack-overflows on deeply-nested if-then-else.

## What's NOT in (and why)

`WamRuntime$parse_term` is **unchanged**. Per the directive "only replace if equivalent or better," the compiled-from-Prolog parser does not yet pass full equivalence: WAM-R's `!/0` and `CutIte` drop only the most-recent choice point rather than committing at the predicate's clause-head barrier, and the parser leans on proper cut-barrier semantics via `take_ident` / `ident_cont`. Predicates compile cleanly and cut-free subsets execute correctly; full runtime equivalence with the inline parser is gated on the cut fix.

Filed as follow-up #3 in `docs/handoff/wam_r_session_handoff.md`. The fix is mechanical: stamp every choice point with the depth at clause-head entry, and have `!/0` truncate `state$cps` back to that depth. When that lands, swapping `WamRuntime$parse_term` to dispatch into the compiled parser is a one-PR follow-up.

## Test plan

- [x] `tests/test_prolog_term_parser.pl` — 25/25 pass under SWI.
- [x] `tests/test_prolog_term_parser_wam_r_compile.pl` — 2/2 pass (compile + cut-free runtime via Rscript).
- [x] `tests/test_wam_r_generator.pl` — full WAM-R suite still 65/65 (no behavioural regression to existing surface).

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_