### PR TITLE
feat(wam-clojure): lower is arithmetic builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -280,6 +280,10 @@ clojure_direct_builtin("=\\=/2", "2").
 clojure_direct_builtin("=\\=/2", 2).
 clojure_direct_builtin('=\\=/2', "2").
 clojure_direct_builtin('=\\=/2', 2).
+clojure_direct_builtin("is/2", "2").
+clojure_direct_builtin("is/2", 2).
+clojure_direct_builtin('is/2', "2").
+clojure_direct_builtin('is/2', 2).
 clojure_direct_builtin("</2", "2").
 clojure_direct_builtin("</2", 2).
 clojure_direct_builtin('</2', "2").
@@ -495,6 +499,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr),
            '(let [left (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) right (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound))] (if (runtime/arithmetic-not-equal? ~w left right) (runtime/advance ~w) (runtime/backtrack ~w)))',
            [S, S, S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "is/2" ; Op == 'is/2'),
+    !,
+    format(atom(Expr),
+           '(let [left (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) expr (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound)) result (runtime/eval-arithmetic-term ~w expr)] (if (some? result) (let [[ok next-state] (runtime/unify-values ~w left result)] (if ok (runtime/advance next-state) (runtime/backtrack ~w))) (runtime/backtrack ~w)))',
+           [S, S, S, S, S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     clojure_arithmetic_order_builtin(Op, RuntimePred),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -7,7 +7,8 @@
 (def well-known-intern-seeds ["true" "fail" "[]" "." "" "[|]" "[|]/2"])
 
 (defn parse-functor-arity [functor]
-  (let [[_ arity-str] (str/split functor #"/")]
+  (let [slash (.lastIndexOf ^String functor "/")
+        arity-str (when (pos? slash) (subs functor (inc slash)))]
     (Integer/parseInt arity-str)))
 
 (defn build-intern-context
@@ -404,6 +405,50 @@
 
 (defn arithmetic-greater-or-equal? [state left right]
   (arithmetic-compare? state >= left right))
+
+(defn arithmetic-result-term [value]
+  (cond
+    (integer? value) value
+    (number? value)
+    (let [as-double (double value)]
+      (if (== as-double (Math/rint as-double))
+        (long as-double)
+        as-double))
+    :else nil))
+
+(defn eval-arithmetic-term [state term]
+  (letfn [(binary [args f]
+            (when (= 2 (count args))
+              (when-let [left (eval* (first args))]
+                (when-let [right (eval* (second args))]
+                  (f left right)))))
+          (safe-div [left right]
+            (when-not (zero? right) (/ (double left) (double right))))
+          (safe-int-div [left right]
+            (when-not (zero? right) (quot (long left) (long right))))
+          (safe-mod [left right]
+            (when-not (zero? right) (mod left right)))
+          (eval* [value]
+            (let [cur (deref-value (:bindings state) value)]
+              (cond
+                (number? cur) cur
+                (atom-term? cur)
+                (parse-numeric-atom (deintern-atom (:intern-context state) (:id cur)))
+                (structure-term? cur)
+                (let [op (functor-key (:intern-context state) (:functor cur))
+                      args (:args cur)]
+                  (case op
+                    "+/1" (when (= 1 (count args)) (eval* (first args)))
+                    "-/1" (when-let [v (and (= 1 (count args)) (eval* (first args)))] (- v))
+                    "+/2" (binary args +)
+                    "-/2" (binary args -)
+                    "*/2" (binary args *)
+                    "//2" (binary args safe-div)
+                    "///2" (binary args safe-int-div)
+                    "mod/2" (binary args safe-mod)
+                    nil))
+                :else nil)))]
+    (arithmetic-result-term (eval* term))))
 
 (defn structure-term [functor args]
   {:tag :struct :functor functor :args (vec args)})
@@ -884,6 +929,19 @@
                                    (or (reg-get-raw state "A2") ::unbound))]
             (if (arithmetic-not-equal? state left right)
               (advance state)
+              (backtrack state)))
+
+          "is/2"
+          (let [left (deref-value (:bindings state)
+                                  (or (reg-get-raw state "A1") ::unbound))
+                expr (deref-value (:bindings state)
+                                  (or (reg-get-raw state "A2") ::unbound))
+                result (eval-arithmetic-term state expr)]
+            (if (some? result)
+              (let [[ok next-state] (unify-values state left result)]
+                (if ok
+                  (advance next-state)
+                  (backtrack state)))
               (backtrack state)))
 
           "</2"

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -109,6 +109,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, '"\\\\=/2"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"=:=/2"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"=\\\\=/2"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"is/2"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"</2"')),
         assertion(sub_string(RuntimeCode, _, _, _, '">/2"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"=</2"')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -166,6 +166,17 @@ test(simple_builtin_arithmetic_not_equal_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/backtrack")
     )).
 
+test(simple_builtin_is_is_direct_lowered_in_prefix) :-
+    once((
+        lower_predicate_to_clojure(test_is/2, [builtin_call('is/2', 2), proceed], [], Code),
+        has(Code, "runtime/reg-get-raw"),
+        has(Code, "\"A1\""),
+        has(Code, "\"A2\""),
+        has(Code, "runtime/eval-arithmetic-term"),
+        has(Code, "runtime/unify-values"),
+        has(Code, "runtime/backtrack")
+    )).
+
 test(simple_builtin_arithmetic_less_is_direct_lowered_in_prefix) :-
     once((
         lower_predicate_to_clojure(test_arith_lt/2, [builtin_call('</2', 2), proceed], [], Code),

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -67,6 +67,13 @@
 :- dynamic user:wam_arith_le_42/1.
 :- dynamic user:wam_arith_ge_42/1.
 :- dynamic user:wam_arith_lt_unbound/1.
+:- dynamic user:wam_arith_is_inc_42/1.
+:- dynamic user:wam_arith_is_combo_3_4/1.
+:- dynamic user:wam_arith_is_neg_42/1.
+:- dynamic user:wam_arith_is_div_5/1.
+:- dynamic user:wam_arith_is_int_div_5/1.
+:- dynamic user:wam_arith_is_mod_5/1.
+:- dynamic user:wam_arith_is_unbound/1.
 
 has(Code, Substr) :-
     once(sub_string(Code, _, _, _, Substr)).
@@ -136,6 +143,13 @@ user:wam_arith_gt_42(X) :- X > 42.
 user:wam_arith_le_42(X) :- X =< 42.
 user:wam_arith_ge_42(X) :- X >= 42.
 user:wam_arith_lt_unbound(_) :- user:wam_unbound_arg(Y), Y < 42.
+user:wam_arith_is_inc_42(M) :- M is 42 + 1.
+user:wam_arith_is_combo_3_4(R) :- R is 3 + 4 * 2.
+user:wam_arith_is_neg_42(M) :- M is -42.
+user:wam_arith_is_div_5(M) :- M is 5 / 2.
+user:wam_arith_is_int_div_5(M) :- M is 5 // 2.
+user:wam_arith_is_mod_5(M) :- M is 5 mod 2.
+user:wam_arith_is_unbound(_) :- user:wam_unbound_arg(Y), _ is Y + 1.
 
 :- initialization(main, main).
 
@@ -209,7 +223,14 @@ run_smoke :-
           user:wam_arith_gt_42/1,
           user:wam_arith_le_42/1,
           user:wam_arith_ge_42/1,
-          user:wam_arith_lt_unbound/1
+          user:wam_arith_lt_unbound/1,
+          user:wam_arith_is_inc_42/1,
+          user:wam_arith_is_combo_3_4/1,
+          user:wam_arith_is_neg_42/1,
+          user:wam_arith_is_div_5/1,
+          user:wam_arith_is_int_div_5/1,
+          user:wam_arith_is_mod_5/1,
+          user:wam_arith_is_unbound/1
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
@@ -357,6 +378,14 @@ run_smoke :-
     verify_output(TmpDir, 'wam_arith_ge_42/1', 42, "true"),
     verify_output(TmpDir, 'wam_arith_ge_42/1', 3.5, "false"),
     verify_output(TmpDir, 'wam_arith_lt_unbound/1', a, "false"),
+    verify_output(TmpDir, 'wam_arith_is_inc_42/1', 43, "true"),
+    verify_output(TmpDir, 'wam_arith_is_inc_42/1', 42, "false"),
+    verify_output(TmpDir, 'wam_arith_is_combo_3_4/1', 11, "true"),
+    verify_output(TmpDir, 'wam_arith_is_neg_42/1', -42, "true"),
+    verify_output(TmpDir, 'wam_arith_is_div_5/1', 2.5, "true"),
+    verify_output(TmpDir, 'wam_arith_is_int_div_5/1', 2, "true"),
+    verify_output(TmpDir, 'wam_arith_is_mod_5/1', 1, "true"),
+    verify_output(TmpDir, 'wam_arith_is_unbound/1', a, "false"),
     delete_directory_and_contents(TmpDir),
     writeln('wam_clojure_runtime_smoke: ok').
 
@@ -507,8 +536,16 @@ assert_lowered_arithmetic_comparison_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-arith-le-42-1"),
     has(CoreCode, "defn lowered-wam-arith-ge-42-1"),
     has(CoreCode, "defn lowered-wam-arith-lt-unbound-1"),
+    has(CoreCode, "defn lowered-wam-arith-is-inc-42-1"),
+    has(CoreCode, "defn lowered-wam-arith-is-combo-3-4-1"),
+    has(CoreCode, "defn lowered-wam-arith-is-neg-42-1"),
+    has(CoreCode, "defn lowered-wam-arith-is-div-5-1"),
+    has(CoreCode, "defn lowered-wam-arith-is-int-div-5-1"),
+    has(CoreCode, "defn lowered-wam-arith-is-mod-5-1"),
+    has(CoreCode, "defn lowered-wam-arith-is-unbound-1"),
     has(CoreCode, "runtime/arithmetic-equal?"),
     has(CoreCode, "runtime/arithmetic-not-equal?"),
+    has(CoreCode, "runtime/eval-arithmetic-term"),
     has(CoreCode, "runtime/arithmetic-less?"),
     has(CoreCode, "runtime/arithmetic-greater?"),
     has(CoreCode, "runtime/arithmetic-less-or-equal?"),
@@ -568,7 +605,12 @@ prolog_term_string_to_edn(c, "\"c\"") :- !.
 prolog_term_string_to_edn(d, "\"d\"") :- !.
 prolog_term_string_to_edn(z, "\"z\"") :- !.
 prolog_term_string_to_edn('[]', "\"[]\"") :- !.
+prolog_term_string_to_edn(-42, "-42") :- !.
+prolog_term_string_to_edn(1, "1") :- !.
+prolog_term_string_to_edn(2, "2") :- !.
+prolog_term_string_to_edn(2.5, "2.5") :- !.
 prolog_term_string_to_edn(3.5, "3.5") :- !.
+prolog_term_string_to_edn(11, "11") :- !.
 prolog_term_string_to_edn(42, "42") :- !.
 prolog_term_string_to_edn(43, "43") :- !.
 prolog_term_string_to_edn("a", "\"a\"") :- !.


### PR DESCRIPTION
## Summary

- Adds direct lowered Clojure WAM support for `is/2`.
- Adds runtime arithmetic evaluation for generated WAM arithmetic expression terms.
- Supports numeric literals, interned numeric atoms, unary `+`/`-`, binary `+`, `-`, `*`, `/`, `//`, and `mod`.
- Fixes Clojure functor arity parsing for operator functors such as `//2` and `///2`.
- Extends lowered-emitter, generator, and runtime smoke fixtures for arithmetic evaluation.

## Why

The Clojure WAM target already directly lowers arithmetic equality and ordering comparisons. `is/2` is the next required arithmetic primitive because compiled WAM emits expression terms into `A2` and expects the runtime to evaluate them before binding or checking `A1`.

This closes the basic arithmetic assignment gap needed for predicates like:

```prolog
M is N + 1.
R is A + B * 2.
Y is X / 2.
```

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- Targeted generated Clojure runtime checks for:
  - `wam_arith_is_inc_42/1 43 -> true`
  - `wam_arith_is_inc_42/1 42 -> false`
  - `wam_arith_is_combo_3_4/1 11 -> true`
  - `wam_arith_is_neg_42/1 -42 -> true`
  - `wam_arith_is_div_5/1 2.5 -> true`
  - `wam_arith_is_int_div_5/1 2 -> true`
  - `wam_arith_is_mod_5/1 1 -> true`
  - `wam_arith_is_unbound/1 a -> false`

## Termux Note

The full `tests/test_wam_clojure_runtime_smoke.pl` run still times out in this Termux environment, consistent with the pre-existing smoke-test hang seen before this branch. The generated project was inspected and the new `is/2` runtime paths were validated directly with one JVM invocation at a time.
