### PR TITLE
Feature/lua wam external fact source index parity

### DIFF
--- a/PR_lua_wam_external_fact_source_index_parity.md
+++ b/PR_lua_wam_external_fact_source_index_parity.md
@@ -1,0 +1,22 @@
+# PR Title
+
+Index Lua WAM external fact sources
+
+# PR Description
+
+## Summary
+
+- Add first-argument indexing for loaded Lua WAM external `P/2` fact sources.
+- Cache external fact source loads as `{ rows, arg1_index }` instead of a flat row list.
+- Teach `CallFactStream` to use the external source `arg1_index` when `A1` is already bound, falling back to the full row scan only when needed.
+- Expand external fact source tests to cover multiple first-argument groups and assert the cached index shape.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`
+
+## Notes
+
+This aligns Lua external fact-source behavior with Haskell's `fsLookupArg1` path and the R grouped-by-first fact-source backend, while keeping the Lua implementation dependency-free.

--- a/templates/targets/lua_wam/runtime.lua.mustache
+++ b/templates/targets/lua_wam/runtime.lua.mustache
@@ -484,8 +484,9 @@ end
 
 function Runtime.read_facts_file(program, path)
   local rows = {}
+  local arg1_index = {}
   local fh = io.open(path, "r")
-  if fh == nil then return rows end
+  if fh == nil then return { rows = rows, arg1_index = arg1_index } end
   for line in fh:lines() do
     local cleaned = trim(line)
     if cleaned ~= "" and cleaned:sub(1, 1) ~= "#" then
@@ -495,27 +496,38 @@ function Runtime.read_facts_file(program, path)
         parts[#parts + 1] = part
       end
       if #parts >= 2 then
-        rows[#rows + 1] = {
+        local row = {
           parse_fact_source_value(program, parts[1]),
           parse_fact_source_value(program, parts[2])
         }
+        rows[#rows + 1] = row
+        local key = term_key(row[1])
+        local bucket = arg1_index[key] or {}
+        arg1_index[key] = bucket
+        bucket[#bucket + 1] = row
       end
     end
   end
   fh:close()
-  return rows
+  return { rows = rows, arg1_index = arg1_index }
 end
 
-local function fact_source_rows(program, pred)
+local function fact_source_rows(program, pred, state)
   local source = program.fact_sources and program.fact_sources[pred] or nil
   if source == nil then return nil end
-  if source.rows == nil then source.rows = Runtime.read_facts_file(program, source.path) end
-  return source.rows
+  if source.cache == nil then source.cache = Runtime.read_facts_file(program, source.path) end
+  local a1 = Runtime.deref(state, Runtime.get_reg(state, 1))
+  if type(a1) == "table" and a1.tag ~= "unbound" then
+    return source.cache.arg1_index[term_key(a1)] or {}
+  end
+  return source.cache.rows
 end
 
 local function call_fact_stream(program, state, instr)
   local rows = program.inline_facts and program.inline_facts[instr.pred] or nil
-  if rows == nil or #rows == 0 then rows = fact_source_rows(program, instr.pred) end
+  if rows == nil or #rows == 0 then
+    rows = fact_source_rows(program, instr.pred, state)
+  end
   if rows == nil or #rows == 0 then return false end
   if #rows > 1 then
     local rest = {}

--- a/tests/test_wam_lua_generator.pl
+++ b/tests/test_wam_lua_generator.pl
@@ -196,7 +196,8 @@ test(lua_external_fact_source_e2e, [condition(lua_available)]) :-
           setup_call_cleanup(
               open(CsvPath, write, Stream),
               ( writeln(Stream, 'a,b'),
-                writeln(Stream, 'a,c')
+                writeln(Stream, 'a,c'),
+                writeln(Stream, 'x,z')
               ),
               close(Stream)),
           write_wam_lua_project(
@@ -212,7 +213,15 @@ test(lua_external_fact_source_e2e, [condition(lua_available)]) :-
           run_lua_query(LuaDir, 'wam_lua_ext_fact/2', [a, b], true),
           run_lua_query(LuaDir, 'wam_lua_ext_fact/2', [a, c], true),
           run_lua_query(LuaDir, 'wam_lua_ext_fact/2', [a, d], false),
-          run_lua_query(LuaDir, 'wam_lua_ext_caller/2', [a, c], true)
+          run_lua_query(LuaDir, 'wam_lua_ext_fact/2', [x, z], true),
+          run_lua_query(LuaDir, 'wam_lua_ext_fact/2', [a, z], false),
+          run_lua_query(LuaDir, 'wam_lua_ext_caller/2', [a, c], true),
+          run_lua_script(
+              LuaDir,
+              'local m=require("generated_program"); local R=m.Runtime; local V=m.V; local function atom(s) return V.Atom(R.intern(m.program.intern_table,s)) end; print(m.wam_lua_ext_fact(atom("a"), atom("b"))); local src=m.program.fact_sources["wam_lua_ext_fact/2"]; local aid=R.intern(m.program.intern_table,"a"); print(#src.cache.rows, #src.cache.arg1_index["a:"..aid])',
+              Output),
+          normalize_space(string(CacheInfo), Output),
+          assertion(CacheInfo == "true 3 2")
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
# Index Lua WAM external fact sources

## Summary

- Add first-argument indexing for loaded Lua WAM external `P/2` fact sources.
- Cache external fact source loads as `{ rows, arg1_index }` instead of a flat row list.
- Teach `CallFactStream` to use the external source `arg1_index` when `A1` is already bound, falling back to the full row scan only when needed.
- Expand external fact source tests to cover multiple first-argument groups and assert the cached index shape.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`

## Notes

This aligns Lua external fact-source behavior with Haskell's `fsLookupArg1` path and the R grouped-by-first fact-source backend, while keeping the Lua implementation dependency-free.
