### PR TITLE
fix(wam-r): proper cut-barrier scope and stack-frame cleanup on backtrack

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -622,17 +622,30 @@ WamRuntime$run(shared_program, state)
   strictly less than the operator precedence. Symmetric with the
   existing prefix simplification. Documented; not a real-world
   blocker.
-- **Cut barrier scope**. The runtime's `!/0` and `CutIte` drop the
-  most-recent choice point, not the choice points created since the
-  current predicate's clause head. This is enough for cut in a
-  predicate whose body never calls another multi-clause predicate
-  before the cut, but loses cut-barrier semantics for any cut whose
-  preceding goals push CPs that aren't the predicate's own. The
-  cross-target Prolog parser (`src/unifyweaver/core/prolog_term_parser.pl`,
-  see `tests/test_prolog_term_parser_wam_r_compile.pl`) compiles
-  successfully but only its cut-free predicates execute correctly
-  end-to-end for this reason; full runtime equivalence with
-  `WamRuntime$parse_term` is gated on this fix.
+- **`CutIte` (soft cut) barrier scope**. `!/0` now truncates
+  `state$cps` back to the depth recorded at the predicate's call
+  site (Allocate stamps it onto the frame; backtrack restores the
+  scratch slot from the CP), so a cut in a clause body whose
+  preceding goals called multi-clause helpers commits correctly.
+  `CutIte` -- the soft-cut emitted for `( A -> B ; C )` -- still
+  drops only the most-recent choice point and would benefit from
+  the same per-construct barrier model. Predicates that need
+  if-then-else commit semantics today should factor the dispatch
+  into clause-level patterns (see `parse_op_loop`,
+  `parse_args_continue`, etc. in
+  `src/unifyweaver/core/prolog_term_parser.pl`).
+- **Y-register frame locality**. `state$regs2` is a single flat env
+  shared across all call frames, so a callee's `Y_n` writes to the
+  same slot as the caller's `Y_n`. `Allocate` saves the caller's
+  Y values and `Deallocate` restores them, which keeps register
+  state correct across the full caller-callee-caller path -- but
+  the WAM emit can read a Y register *after* `Deallocate` (e.g.
+  the `Term =.. [...]` after a `Call parse_args` in
+  `parse_atom_head`), expecting to see the body's value, not the
+  caller's restored value. That pattern silently reads the wrong
+  register. Real WAM emits use per-frame Y storage (each frame
+  has its own slot for Y_n); WAM-R will need the same. Documented
+  as the new follow-up gating the cross-target parser swap-in.
 - **WAM-text quoting collision**. The atom `'42'` and the integer
   `42` both serialise as `set_constant 42` in SWI's WAM emitter,
   so the codegen can't distinguish them. The runtime's `atom_*`
@@ -725,6 +738,8 @@ Coverage map (e2e tests, by feature group):
 | `external_fact_source_e2e_rscript` | external CSV fact sources via `r_fact_sources([source(P/A, file(...))])` |
 | `external_fact_source_grouped_tsv_e2e_rscript` | external grouped-by-first TSV fact sources (arity-2): `r_fact_sources([source(P/2, grouped_by_first(...))])` |
 | `op_3_postfix_e2e_rscript` | runtime postfix-operator support: `op(P, xf|yf, N)`, parser wraps primary as postfix struct, mixed infix+postfix, yf chaining, `current_op/3` enumeration, `op(0, ...)` removal |
+| `cut_barrier_after_helper_e2e_rscript` | `!/0` truncates `state$cps` to the predicate's call-site depth, dropping leftover CPs from multi-clause helpers and the predicate's own try-chain CP in one shot |
+| `stack_frame_cleanup_on_backtrack_e2e_rscript` | failed clauses' env frames get popped on backtrack via the CP's `stack_len` snapshot, so the outer predicate's `Deallocate` doesn't pop a stale frame and re-enter post-call code |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/docs/handoff/wam_r_session_handoff.md
+++ b/docs/handoff/wam_r_session_handoff.md
@@ -139,43 +139,56 @@ roughly priority order:
    identify a single hot path; subsequent PRs each fix one bottleneck.
    Tagged-list `$tag` access and env-based register lookups are likely
    suspects.
-3. **Proper cut-barrier scope.** The runtime's `!/0` and `CutIte`
-   drop only the most-recent CP; they don't track the cut barrier
-   at clause-head entry. Fine for shallow predicates, but loses
-   cut semantics whenever a multi-clause callee leaves CPs alive
-   before the cut runs. Direct unblocks the compiled Prolog term
-   parser at `src/unifyweaver/core/prolog_term_parser.pl` -- the
-   structural compile test
-   (`tests/test_prolog_term_parser_wam_r_compile.pl`) shows the
-   source compiles cleanly; full end-to-end equivalence with
-   `WamRuntime$parse_term` is gated on this. To fix: stamp every
-   choice point with the depth at clause-head entry, and have
-   `!/0` truncate `state$cps` back to that depth instead of
-   popping one. Same change makes `CutIte` correct for nested
-   if-then-else.
-4. **Strict `xf` precedence rule** (small). Threading the precedence
+3. **Per-frame Y-register storage.** `state$regs2` is one flat env
+   shared across all call frames, so a callee's `Y_n` writes to the
+   same slot as the caller's. `Allocate`/`Deallocate` save+restore
+   keeps state correct on the boundary, but the WAM emit can read
+   a Y register *after* `Deallocate` (the SWI emitter's normal
+   shape, e.g. `Call parse_args; Deallocate; PutValue Y6, A1; ...
+   =../2`) expecting to see the body's value. Today that read
+   silently picks up the caller's restored value. The cross-target
+   Prolog parser at `src/unifyweaver/core/prolog_term_parser.pl`
+   compiles cleanly and now executes much further than before
+   (cut-barrier and stack-cleanup fixes both shipped, see #1948),
+   but `parse_atom_head`'s post-`Call` `=..` hits this register
+   conflict and the swap-in of `WamRuntime$parse_term` is gated on
+   the fix. Real WAM impls give each frame its own Y slot vector;
+   the easiest version here is a per-frame env (`frame$ys`) that
+   `GetVariable`/`PutValue`/etc. dispatch into when the index is
+   `>= 201`, leaving X registers in the shared env.
+
+4. **`CutIte` (soft cut) barrier scope.** `!/0` now uses a proper
+   cut barrier (PR #1948); `CutIte` -- emitted for
+   `( A -> B ; C )` -- still drops only the most-recent CP. The
+   same Allocate-stamps-barrier model would work for soft cut, with
+   the barrier saved at the start of A so CutIte truncates back to
+   it on commit. Until then, predicates that depend on if-then-else
+   commit semantics need to be written with clause-level dispatch
+   (see `parse_op_loop`, `parse_args_continue`,
+   `tokenize_loop_step`, etc. in the cross-target parser).
+5. **Strict `xf` precedence rule** (small). Threading the precedence
    of the current `left` expression through `wam_parse_expr` so `xf`
    and `yf` differ correctly at chained-postfix sites. Fixes the
    simplification documented as a known limitation. Same fix would
    let `fx` / `fy` differ correctly in the prefix path.
-5. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
+6. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
    mode info per predicate (in/out per arg); Phase 2 wires it to
    specialised emission (skip unifications when the mode says the slot
    is unbound, etc.). Look at the Haskell target's
    `WAM_HASKELL_MODE_ANALYSIS_*.md` design docs for the precedent.
-6. **Multi-line `read/2`.** Read until a `.` terminator across lines.
+7. **Multi-line `read/2`.** Read until a `.` terminator across lines.
    Niche but completes the streams story.
-7. **Multi-solution `retract/1` ignoring snapshot.** I.e. re-read the
+8. **Multi-solution `retract/1` ignoring snapshot.** I.e. re-read the
    live clause list on each backtrack. Trickier semantics; document
    carefully if pursued.
-8. **Phase-3 lowered emitter expansion.** Currently handles only
+9. **Phase-3 lowered emitter expansion.** Currently handles only
    `deterministic` and `multi_clause_1` shapes. Could grow N-clause
    general lowering; would compete with the kernel / fact-table paths
    so the value is unclear.
-9. **Range / interval indexes** on fact tables. Per-arg hash indexes
-   land queries with ground atom/int args; range queries (`X > 5`,
-   `X between A B`) still go through the per-tuple scan. A sorted-
-   per-arg index would route these. Niche but a natural extension.
+10. **Range / interval indexes** on fact tables. Per-arg hash indexes
+    land queries with ground atom/int args; range queries (`X > 5`,
+    `X between A B`) still go through the per-tuple scan. A sorted-
+    per-arg index would route these. Niche but a natural extension.
 
 ## Things to know before you start a follow-up
 

--- a/src/unifyweaver/core/prolog_term_parser.pl
+++ b/src/unifyweaver/core/prolog_term_parser.pl
@@ -130,11 +130,18 @@ tokenize(Codes, Tokens) :-
 
 tokenize_loop([], Acc, Acc).
 tokenize_loop([C|Cs], Acc, Out) :-
-    (   ws_code(C)
-    ->  tokenize_loop(Cs, Acc, Out)
-    ;   tokenize_one([C|Cs], Acc, Acc1, Rest),
-        tokenize_loop(Rest, Acc1, Out)
-    ).
+    tokenize_loop_step(C, Cs, Acc, Out).
+
+% Split out so the post-classify dispatch is at the clause level,
+% not inside an if-then-else. Same workaround used elsewhere in this
+% module: keeps the WAM target's CutIte semantics out of the picture.
+tokenize_loop_step(C, Cs, Acc, Out) :-
+    ws_code(C),
+    !,
+    tokenize_loop(Cs, Acc, Out).
+tokenize_loop_step(C, Cs, Acc, Out) :-
+    tokenize_one([C|Cs], Acc, Acc1, Rest),
+    tokenize_loop(Rest, Acc1, Out).
 
 ws_code(32). ws_code(9). ws_code(10). ws_code(13).
 
@@ -228,11 +235,16 @@ take_syms([C|R], [], [C|R])    :- \+ sym_code(C).
 % already consumed by the caller (passed in via Lead); we splice it back.
 take_number_after_sign(Lead, R, [Lead|Cs], Rest) :-
     take_digits(R, IntCs, Rest1),
-    (   Rest1 = [0'., D | Rest2], digit_code(D)
-    ->  take_digits(Rest2, FracCs, Rest),
-        append(IntCs, [0'., D | FracCs], Cs)
-    ;   Cs = IntCs, Rest = Rest1
-    ).
+    take_number_frac(IntCs, Rest1, Cs, Rest).
+
+% Clause-level dispatch instead of an inner if-then-else, for the
+% same WAM CutIte avoidance reason.
+take_number_frac(IntCs, [0'., D | Rest2], Cs, Rest) :-
+    digit_code(D),
+    !,
+    take_digits(Rest2, FracCs, Rest),
+    append(IntCs, [0'., D | FracCs], Cs).
+take_number_frac(IntCs, Rest, IntCs, Rest).
 
 take_digits([], [], []).
 take_digits([C|R], [C|Cs], Rest) :- digit_code(C), !, take_digits(R, Cs, Rest).
@@ -249,13 +261,11 @@ take_quoted([C|R], Acc, Out, Rest) :-
     append(Acc, [C], Acc1),
     take_quoted(R, Acc1, Out, Rest).
 
-% codes_to_number: codes -> integer or float. Tries integer first by checking
-% for a `.` in the digit run.
+% codes_to_number: codes -> integer or float. number_codes/2 handles
+% both shapes, so the float-vs-int check the original ITE did was
+% redundant. Single-clause body avoids the WAM CutIte dependency.
 codes_to_number(Cs, N) :-
-    (   memberchk(0'., Cs)
-    ->  number_codes(N, Cs)             % float
-    ;   number_codes(N, Cs)             % integer; same path, ISO behaviour
-    ).
+    number_codes(N, Cs).
 
 % can_lead_negative: a bare `-` followed by a digit is a signed-number lead
 % only when the previous emitted token (top of Acc, a reverse stack) is a
@@ -345,14 +355,18 @@ parse_atom_head(Name, R, OpTable, MaxPrec, Term, Env0, Env, Rest) :-
 parse_atom_head(Name, R, _, _, Name, Env, Env, R).
 
 % parse_args: comma-separated arg list inside `(...)`, max_prec 999 so the
-% top-level comma operator (1000) doesn't get folded in.
+% top-level comma operator (1000) doesn't get folded in. Like parse_op_loop,
+% the post-arg dispatch is split into a separate predicate's clauses
+% (rather than nested if-then-else) so the WAM target's CutIte semantics
+% don't matter to correctness.
 parse_args(Tokens, OpTable, [Arg|Rest], Env0, Env, RestOut) :-
     parse_expr(Tokens, OpTable, 999, Arg, Env0, Env1, Tokens1),
-    (   Tokens1 = [tk_comma|Tokens2]
-    ->  parse_args(Tokens2, OpTable, Rest, Env1, Env, RestOut)
-    ;   Tokens1 = [tk_rparen|RestOut]
-    ->  Rest = [], Env = Env1
-    ).
+    parse_args_continue(Tokens1, OpTable, Rest, Env1, Env, RestOut).
+
+parse_args_continue([tk_comma|Toks], OpTable, Rest, Env0, Env, RestOut) :-
+    !,
+    parse_args(Toks, OpTable, Rest, Env0, Env, RestOut).
+parse_args_continue([tk_rparen|RestOut], _, [], Env, Env, RestOut).
 
 % parse_list_body: handles `[]`, `[a, b, c]`, `[H|T]`. Element max_prec 999
 % (matches parse_args).

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -248,6 +248,17 @@ WamRuntime$new_state <- function() {
   s$mode        <- NULL
   s$build_stack <- list()
   s$read_stack  <- list()
+  # Cut barrier scratch. Set by Call / Execute right before jumping
+  # into the callee, captured by the callee's Allocate onto the new
+  # frame as `cps_barrier`. Read by `!/0` to truncate state$cps back
+  # to the depth that was current at the predicate's call site --
+  # i.e. drop ALL choice points created since the predicate was
+  # entered, including its own TryMeElse CP. Top-level predicates
+  # (entered via run_predicate, no Call instruction) see this as 0
+  # and their cut truncates to an empty cps stack, which matches
+  # "commit globally" -- correct, since there's no outer caller
+  # whose alternatives need preserving.
+  s$pending_call_barrier <- 0L
   s
 }
 
@@ -1209,8 +1220,16 @@ WamRuntime$step <- function(program, state, instr) {
           saved_ys[[k]] <- get(k, envir = state$regs2, inherits = FALSE)
         }
       }
+      # state$pending_call_barrier was set by the Call/Execute that
+      # routed us to this predicate's first instruction (or left at
+      # its initial 0 for a top-level run_predicate entry). Capture
+      # it onto the new frame so cut can truncate state$cps back to
+      # the depth at the call site -- i.e. drop every CP this
+      # predicate has created (including its own TryMeElse CP).
       state$stack <- c(state$stack,
-                       list(list(cp = state$cp, saved_ys = saved_ys)))
+                       list(list(cp = state$cp,
+                                 saved_ys = saved_ys,
+                                 cps_barrier = state$pending_call_barrier)))
       state$pc <- state$pc + 1L; TRUE
     },
     "Deallocate" = {
@@ -1248,6 +1267,10 @@ WamRuntime$step <- function(program, state, instr) {
       }
       tgt <- program$labels[[key]]
       if (!is.null(tgt)) {
+        # Snapshot the cut barrier for the callee: any CP it pushes
+        # (TryMeElse + later) is fair game for its `!/0`, but
+        # everything pushed before this Call belongs to outer frames.
+        state$pending_call_barrier <- length(state$cps)
         state$cp <- state$pc + 1L
         state$pc <- as.integer(tgt)
         return(TRUE)
@@ -1279,6 +1302,13 @@ WamRuntime$step <- function(program, state, instr) {
       }
       tgt <- program$labels[[key]]
       if (!is.null(tgt)) {
+        # Tail call: the caller has already Deallocated, so the callee
+        # is effectively a fresh predicate entry. Snapshot its cut
+        # barrier the same way Call does -- any CP the callee pushes
+        # is its own; everything currently on state$cps belongs to
+        # outer frames whose alternatives the callee's `!/0` must
+        # leave alone.
+        state$pending_call_barrier <- length(state$cps)
         state$pc <- as.integer(tgt)
         return(TRUE)
       }
@@ -1312,12 +1342,28 @@ WamRuntime$step <- function(program, state, instr) {
       state$pc <- state$cp; state$cp <- 0L; TRUE
     },
     "TryMeElse" = {
+      # Snapshot pending_call_barrier and state$stack length onto the
+      # CP. Two reasons:
+      #   - subsequent clauses of this predicate (reached via backtrack
+      #     -> RetryMeElse) must Allocate with the right cut barrier
+      #     value, even if the failed clause's body issued Calls that
+      #     left state$pending_call_barrier stale;
+      #   - each clause's Allocate pushes a new env frame, but failed
+      #     clauses never reach Deallocate. Without a stack-length
+      #     snapshot here, those stale frames pile up and the outer
+      #     predicate's Deallocate pops the wrong one (with the
+      #     wrong saved cp), which silently re-enters post-call code
+      #     after the predicate is supposed to have committed. Save
+      #     it now; backtrack truncates state$stack back to this
+      #     depth before jumping to the next clause.
       cp <- list(
-        next_pc      = program$labels[[instr$label]],
-        regs         = as.list.environment(state$regs2),
-        cp           = state$cp,
-        trail_len    = length(state$trail),
-        var_counter  = state$var_counter
+        next_pc       = program$labels[[instr$label]],
+        regs          = as.list.environment(state$regs2),
+        cp            = state$cp,
+        trail_len     = length(state$trail),
+        var_counter   = state$var_counter,
+        call_barrier  = state$pending_call_barrier,
+        stack_len     = length(state$stack)
       )
       state$cps <- c(state$cps, list(cp))
       state$pc <- state$pc + 1L; TRUE
@@ -3897,12 +3943,26 @@ WamRuntime$call_builtin <- function(program, state, pred, arity) {
   if (pred == "true/0" && arity == 0L) return(TRUE)
   if (pred == "fail/0" && arity == 0L) return(FALSE)
 
-  # Cut (!/0): scaffold semantics drop the most recent choice point so
-  # the surrounding predicate's try-chain stops backtracking. A full
-  # cut-bar implementation tracks the depth at clause entry; a follow-up
-  # commit can replace this once the lowered emitter wants to honour it
-  # in nested-call positions.
+  # Cut (!/0): truncate state$cps back to the depth captured at the
+  # current predicate's call site (Allocate stamped this onto the
+  # topmost call frame as `cps_barrier`). This drops every CP this
+  # predicate has created -- including its own TryMeElse CP and any
+  # CPs left alive by multi-clause helpers it invoked before the
+  # cut. Falls back to the legacy "drop topmost CP" behaviour when
+  # no frame is on state$stack (rare: cut from a builtin handler
+  # called outside a Call/Allocate cycle), so existing call paths
+  # don't regress.
   if (pred == "!/0" && arity == 0L) {
+    sn <- length(state$stack)
+    if (sn > 0L) {
+      barrier <- state$stack[[sn]]$cps_barrier
+      if (!is.null(barrier)) {
+        if (length(state$cps) > barrier) {
+          state$cps <- state$cps[seq_len(barrier)]
+        }
+        return(TRUE)
+      }
+    }
     n <- length(state$cps)
     if (n > 0L) state$cps <- state$cps[-n]
     return(TRUE)
@@ -5375,6 +5435,21 @@ WamRuntime$backtrack <- function(state) {
   }
   state$cp <- cp$cp
   state$var_counter <- cp$var_counter
+  # Restore pending_call_barrier so the next clause's Allocate sees
+  # the value that was current at THIS predicate's call site, not
+  # whatever the failed-clause body's last Call left behind.
+  if (!is.null(cp$call_barrier)) {
+    state$pending_call_barrier <- cp$call_barrier
+  }
+  # Truncate state$stack to the depth recorded at the CP's TryMeElse.
+  # Drops env frames pushed by the failed clause body (and any clause
+  # bodies attempted before it via earlier RetryMeElse hops). Without
+  # this, an outer Deallocate later pops a stale frame and restores
+  # the wrong cp, silently re-running post-call code.
+  if (!is.null(cp$stack_len) &&
+      length(state$stack) > cp$stack_len) {
+    state$stack <- state$stack[seq_len(cp$stack_len)]
+  }
   state$pc <- as.integer(cp$next_pc)
   TRUE
 }

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -3431,6 +3431,99 @@ e2e_external_fact_source_grouped_tsv_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end: cut barrier truncates state$cps back to the depth at the
+% predicate's call site, so a `!` in a clause body that has just
+% returned from a multi-clause helper drops both the helper's leftover
+% CP and the predicate's own try-chain CP. Pre-fix, `!/0` only popped
+% the most-recent CP, leaving alternatives alive whenever any inner
+% multi-clause goal sat between clause-head match and the cut.
+% Auto-skips when Rscript isn't on PATH.
+test(cut_barrier_after_helper_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_cut_barrier_after_helper_via_rscript
+    ;   true
+    )).
+
+e2e_cut_barrier_after_helper_via_rscript :-
+    retractall(user:cb_helper/1),
+    retractall(user:cb_caller/1),
+    retractall(user:cb_drv/0),
+    % cb_helper has three clauses, all succeed via head match. Its
+    % TryMeElse CP stays alive after clause 1 returns, exposing the
+    % old "drop-topmost" cut bug.
+    assertz(user:cb_helper(1)),
+    assertz(user:cb_helper(2)),
+    assertz(user:cb_helper(3)),
+    % cb_caller's clause 1 cut must commit to "selected 1": with proper
+    % cut-barrier scope it drops both cb_helper's CP and cb_caller's
+    % own try-chain CP, so a downstream backtrack (`fail`) must not
+    % land on cb_caller's clause 2 (the fallback) or re-enter the
+    % helper. Pre-fix, the runtime would print "selected 1" then fall
+    % through to "fallback" (or worse).
+    assertz((user:cb_caller(X) :-
+        cb_helper(X),
+        !,
+        write('selected '), write(X), nl)),
+    assertz((user:cb_caller(_) :-
+        write('fallback'), nl)),
+    % Driver: collect every solution and assert the result is a
+    % single "selected 1" line. No fallback, no second helper value.
+    assertz((user:cb_drv :-
+        ( cb_caller(_), fail ; true ))),
+    unique_r_tmp_dir('tmp_r_cut_barrier_e2e', TmpDir),
+    write_wam_r_project([user:cb_helper/1, user:cb_caller/1, user:cb_drv/0],
+                        [], TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    run_rscript_query(RDir, 'cb_drv/0', Out),
+    assertion(sub_string(Out, _, _, _, "selected 1")),
+    assertion(\+ sub_string(Out, _, _, _, "selected 2")),
+    assertion(\+ sub_string(Out, _, _, _, "selected 3")),
+    assertion(\+ sub_string(Out, _, _, _, "fallback")),
+    assertion(sub_string(Out, _, _, _, "true")),
+    delete_directory_and_contents(TmpDir).
+
+% End-to-end: each predicate's clauses Allocate per-clause (the WAM
+% emit's standard shape). Failed clauses leave stale env frames on
+% state$stack; before the fix, an outer Deallocate later popped a
+% stale frame and restored the wrong continuation pointer, silently
+% re-running post-call code. Backtrack now truncates state$stack
+% back to the depth recorded at the CP's TryMeElse, dropping
+% stale frames before the next clause's Allocate.
+test(stack_frame_cleanup_on_backtrack_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_stack_frame_cleanup_via_rscript
+    ;   true
+    )).
+
+e2e_stack_frame_cleanup_via_rscript :-
+    retractall(user:sf_pick/2),
+    retractall(user:sf_drv/0),
+    % sf_pick has three clauses each with a body (forces Allocate
+    % per clause). Clauses 1 and 2 reject via head guard; clause 3
+    % matches. Pre-fix, clauses 1 and 2 each leave a stale frame
+    % whose saved cp later mis-targets the runner.
+    assertz((user:sf_pick(a, X) :- X is 1)),
+    assertz((user:sf_pick(b, X) :- X is 2)),
+    assertz((user:sf_pick(c, X) :- X is 3)),
+    assertz((user:sf_drv :-
+        sf_pick(c, V),
+        write('value='), write(V), nl)),
+    unique_r_tmp_dir('tmp_r_stack_cleanup_e2e', TmpDir),
+    write_wam_r_project([user:sf_pick/2, user:sf_drv/0], [], TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    run_rscript_query(RDir, 'sf_drv/0', Out),
+    assertion(sub_string(Out, _, _, _, "value=3")),
+    assertion(sub_string(Out, _, _, _, "true")),
+    % Single line (post-frame-cleanup the runtime doesn't loop into
+    % stale post-call code).
+    split_string(Out, "\n", "", Lines),
+    include([L]>>( sub_string(L, _, _, _, "value=") ), Lines, ValueLines),
+    assertion(length(ValueLines, 1)),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------
 test(r_wam_bindings_loads) :-


### PR DESCRIPTION
## Summary

Two related runtime correctness fixes that close longstanding gaps when a predicate has multi-clause helpers in its body or non-trivial multi-clause head matching. Both are local to the runtime template and the standard backtrack handler — the codegen pipeline is unchanged.

### 1. Cut barrier scope

`!/0` previously dropped only the most-recent choice point. Inside a clause body whose preceding goals called multi-clause helpers, that "topmost CP" belonged to the helper, not the predicate — the predicate's own try-chain CP stayed alive and the cut effectively did nothing.

Fix: snapshot `length(state$cps)` at every `Call` / `Execute` into `state$pending_call_barrier`; `Allocate` captures it onto the new frame as `cps_barrier`; `!/0` reads the topmost frame's barrier and truncates `state$cps` back to that depth, dropping every CP the predicate has created (including its own `TryMeElse` CP). `TryMeElse` also stashes the barrier on the CP, and standard backtrack restores the scratch slot, so retried clauses see the value that was current at the predicate's call site, not whatever a failed clause body's last `Call` left behind.

### 2. Stack-frame cleanup on backtrack

Each clause `Allocate`s a fresh env frame on `state$stack`. Failed clauses never reach `Deallocate`, so their frames piled up. The outer predicate's eventual `Deallocate` then popped the wrong frame and restored the wrong `cp`, silently re-entering post-call code (the symptom looked like the runtime "iterating" a goal that should have been deterministic).

Fix: `TryMeElse` snapshots `length(state$stack)` onto the CP; standard backtrack truncates `state$stack` back to that depth before jumping to the next clause, popping any stale frames the failed clause body `Allocate`d.

## Test plan

- [x] New `cut_barrier_after_helper_e2e_rscript`: `cb_caller`'s clause-1 cut commits after a multi-clause `cb_helper` succeeds, so a downstream `fail` doesn't backtrack into either the helper's next solution or `cb_caller`'s fallback clause.
- [x] New `stack_frame_cleanup_on_backtrack_e2e_rscript`: `sf_pick` has three body-bearing clauses; only the matching one prints, and it prints exactly once (no stale-frame-driven re-entry).
- [x] Full WAM-R suite: **67/67** (was 65). No regressions.

## Status of the cross-target parser swap-in

The cross-target Prolog term parser at `src/unifyweaver/core/prolog_term_parser.pl` now executes much further through the WAM-R compiled path — `tokenize`, `take_ident`, `parse_args`, `parse_atom_head`, etc. all run end-to-end and produce correct results in isolation.

Full equivalence with `WamRuntime$parse_term` is still gated on **two follow-ups**, filed in the WAM-R handoff:

- **#3 Per-frame Y-register storage.** SWI's WAM emit reads Y registers *after* `Deallocate`, expecting the body's value. `state$regs2` is a single flat env, so a callee's `Y_n` write to the same slot as the caller's `Y_n` gets clobbered on `Deallocate`'s saved-Y restore. Real WAM impls give each frame its own Y storage. The cleanest fix in this codebase is a per-frame env (`frame$ys`) that the register-access helpers dispatch into when index `>= 201`, leaving X registers in the shared env.
- **#4 CutIte (soft-cut) barrier scope.** Same Allocate-stamps-barrier model would work for `CutIte` (emitted for `( A -> B ; C )`); today it still uses the old "drop topmost CP" scaffold. The cross-target parser routes around it via clause-level dispatch (`parse_op_loop`, `parse_args_continue`, `tokenize_loop_step`).

Per the directive "only swap if equivalent or better", `WamRuntime$parse_term` stays untouched in this PR.

## Smaller changes alongside

- The portable parser was edited to factor a few inner if-then-else patterns into clause-level dispatch (`parse_op_loop`, `parse_args_continue`, `tokenize_loop_step`, `take_number_frac`). Same SWI semantics; works around CutIte until #4 lands. SWI suite still 25/25.
- Handoff and `WAM_R_TARGET.md` updated to describe the new state, the two new follow-ups (renumbered #3 and #4), and the catalogue entries for the new tests.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_