### PR TITLE
fix(wam-haskell): decode LMDB intern strings as UTF-8 (#1915)

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -3247,7 +3247,7 @@ compile_wam_runtime_to_haskell(Options, DetectedKernels, Code) :-
                     BacktrackCode),
     % Phase B1: conditional LMDB imports and functions
     (   option(use_lmdb(true), Options)
-    ->  LmdbImports = "import Database.LMDB.Raw\nimport Foreign.Ptr (Ptr, castPtr, nullPtr)\nimport Foreign.Storable (peek, poke, peekElemOff)\nimport Foreign.Marshal.Alloc (alloca, allocaBytes)\nimport Foreign.Marshal.Array (withArray)\nimport Foreign.C.String (withCStringLen, peekCStringLen)\nimport Foreign.C.Types (CSize(..), CChar)\nimport Data.Int (Int32)\nimport Data.Word (Word8)\nimport Data.Bits ((.&.))\nimport Data.IORef (IORef, newIORef, readIORef, writeIORef, atomicModifyIORef')\nimport qualified Data.Array as A\nimport qualified Data.Array.IO as IOA\nimport qualified Control.Exception as E\nimport Control.Monad (forM_, when, foldM)\nimport Control.Concurrent (runInBoundThread, myThreadId, ThreadId, threadCapability, getNumCapabilities)\nimport Control.Concurrent.Async (mapConcurrently)",
+    ->  LmdbImports = "import Database.LMDB.Raw\nimport Foreign.Ptr (Ptr, castPtr, nullPtr)\nimport Foreign.Storable (peek, poke, peekElemOff)\nimport Foreign.Marshal.Alloc (alloca, allocaBytes)\nimport Foreign.Marshal.Array (withArray)\nimport Foreign.C.String (withCStringLen, peekCStringLen)\nimport Foreign.C.Types (CSize(..), CChar)\nimport Data.Int (Int32)\nimport Data.Word (Word8)\nimport Data.Bits ((.&.))\nimport Data.IORef (IORef, newIORef, readIORef, writeIORef, atomicModifyIORef')\nimport qualified Data.Array as A\nimport qualified Data.Array.IO as IOA\nimport qualified Data.ByteString as BS\nimport qualified Data.Text as T\nimport qualified Data.Text.Encoding as TE\nimport qualified Data.Text.Encoding.Error as TEE\nimport qualified Control.Exception as E\nimport Control.Monad (forM_, when, foldM)\nimport Control.Concurrent (runInBoundThread, myThreadId, ThreadId, threadCapability, getNumCapabilities)\nimport Control.Concurrent.Async (mapConcurrently)",
         generate_lmdb_functions(Options, LmdbFunctions)
     ;   LmdbImports = "",
         LmdbFunctions = ""
@@ -3812,9 +3812,12 @@ generate_cabal_file(Name, UseHM, Options, Code) :-
     ->  BaseDeps = "base >= 4.12, containers >= 0.6, array, time >= 1.8, unordered-containers >= 0.2, hashable >= 1.2, deepseq >= 1.4, parallel >= 3.2, async >= 2.2"
     ;   BaseDeps = "base >= 4.12, containers >= 0.6, array, time >= 1.8, deepseq >= 1.4, parallel >= 3.2, async >= 2.2"
     ),
-    % Phase B1: conditional LMDB dependency
+    % Phase B1: conditional LMDB dependency.
+    % bytestring + text are added with use_lmdb(true) so peekStringBytes
+    % can decode UTF-8 — the byte loop got mojibake on non-ASCII fixtures
+    % (e.g. accented Wikipedia categorylinks).
     (   option(use_lmdb(true), Options)
-    ->  format(string(Deps), "~w, lmdb >= 0.2.5, directory >= 1.3", [BaseDeps])
+    ->  format(string(Deps), "~w, lmdb >= 0.2.5, directory >= 1.3, bytestring >= 0.10, text >= 1.2", [BaseDeps])
     ;   Deps = BaseDeps
     ),
     % -threaded enables multi-core runtime (+RTS -N to use cores).

--- a/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
+++ b/templates/targets/haskell_wam/lmdb_fact_source.hs.mustache
@@ -837,15 +837,18 @@ openLmdbInternEnvReadonly dbPath = do
     mdb_env_open env dbPath [MDB_RDONLY]
     return env
 
--- | Decode bytes pointed to by a CChar pointer as a Haskell String,
--- byte-by-byte (ASCII-correct, Latin-1 fallback for non-ASCII).
+-- | Decode bytes pointed to by a CChar pointer as a Haskell String.
+-- Treats the bytes as UTF-8, so non-ASCII (e.g. accented categorylinks
+-- like "Caf\xc3\xa9s") round-trips correctly. Invalid byte sequences
+-- get U+FFFD via lenientDecode rather than throwing — the LMDB store
+-- is upstream-controlled (Phase 1 ingester), so a decode failure means
+-- the ingester wrote bad bytes, not a runtime fault to abort on.
 peekStringBytes :: Ptr CChar -> Int -> IO String
 peekStringBytes p len
     | len <= 0  = return []
     | otherwise = do
-        bytes <- mapM (\i -> peekElemOff (castPtr p :: Ptr Word8) i)
-                      [0 .. len - 1]
-        return (map (toEnum . fromIntegral) bytes)
+        bs <- BS.packCStringLen (p, len)
+        return $! T.unpack (TE.decodeUtf8With TEE.lenientDecode bs)
 
 -- | Iterate every (key, value) pair in a sub-db with a single read txn,
 -- applying a decoder to each pair. Returns results in iteration order.

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1392,6 +1392,39 @@ test_b1_phase2b2_loaders_emitted :-
     ;   fail_test(Test, 'Phase 2b.2 LMDB-resident loaders should be emitted when use_lmdb(true)')
     ).
 
+test_b1_peekstringbytes_decodes_utf8 :-
+    Test = 'B1: peekStringBytes decodes UTF-8 via TE.decodeUtf8With',
+    (   compile_wam_runtime_to_haskell([use_lmdb(true)], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BS.packCStringLen (p, len)"),
+        sub_string(S, _, _, _, "TE.decodeUtf8With TEE.lenientDecode"),
+        \+ sub_string(S, _, _, _, "map (toEnum . fromIntegral) bytes")
+    ->  pass(Test)
+    ;   fail_test(Test, 'peekStringBytes should decode UTF-8 via Data.Text.Encoding')
+    ).
+
+test_b1_lmdb_text_imports_present :-
+    Test = 'B1: bytestring + text imports emitted with use_lmdb(true)',
+    (   compile_wam_runtime_to_haskell([use_lmdb(true)], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "import qualified Data.ByteString as BS"),
+        sub_string(S, _, _, _, "import qualified Data.Text as T"),
+        sub_string(S, _, _, _, "import qualified Data.Text.Encoding as TE"),
+        sub_string(S, _, _, _, "import qualified Data.Text.Encoding.Error as TEE")
+    ->  pass(Test)
+    ;   fail_test(Test, 'bytestring/text imports missing under use_lmdb(true)')
+    ).
+
+test_b1_lmdb_cabal_text_dependencies :-
+    Test = 'B1: cabal includes bytestring + text when use_lmdb(true)',
+    (   wam_haskell_target:generate_cabal_file('test', false, [use_lmdb(true)], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "bytestring >= 0.10"),
+        sub_string(S, _, _, _, "text >= 1.2")
+    ->  pass(Test)
+    ;   fail_test(Test, 'bytestring/text not in cabal deps when use_lmdb(true)')
+    ).
+
 test_b1_lmdb_scan_support_present :-
     Test = 'B1: raw LMDB FactSource emits scan support',
     (   compile_wam_runtime_to_haskell([use_lmdb(true)], [], Code),
@@ -2187,6 +2220,9 @@ run_tests :-
     test_with_rtsopts_absent_by_default,
     test_b1_lmdb_raw_zero_copy_reads,
     test_b1_phase2b2_loaders_emitted,
+    test_b1_peekstringbytes_decodes_utf8,
+    test_b1_lmdb_text_imports_present,
+    test_b1_lmdb_cabal_text_dependencies,
     test_b1_lmdb_scan_support_present,
     test_b1_lmdb_manifest_fact_source_present,
     test_b1_lmdb_manifest_wiring_option_present,


### PR DESCRIPTION
  ## Summary

  Closes #1915. `peekStringBytes` in the LMDB-resident loader was reading
  bytes one at a time and mapping each via `toEnum . fromIntegral` — that's
  Latin-1 semantics, not UTF-8. Non-ASCII strings ingested via the Phase 1
  pipeline (e.g. accented Wikipedia categorylinks like `"Cafés"`) came out
  as mojibake (`"CafÃ©s"`) on read.

  Replace the byte loop with `BS.packCStringLen` + `TE.decodeUtf8With
  TEE.lenientDecode`. Lenient (not strict) because the LMDB store is
  upstream-controlled — a decode failure means the ingester wrote bad
  bytes, not something the runtime should abort over. Lenient substitutes
  U+FFFD for invalid sequences.

  ## What changed

  - `templates/targets/haskell_wam/lmdb_fact_source.hs.mustache` — new
    three-line `peekStringBytes` body using `decodeUtf8With lenientDecode`
  - `src/unifyweaver/targets/wam_haskell_target.pl`
    - Add `Data.ByteString as BS`, `Data.Text as T`, `Data.Text.Encoding as
      TE`, `Data.Text.Encoding.Error as TEE` to the `use_lmdb(true)` import
      block
    - Add `bytestring >= 0.10` and `text >= 1.2` to conditional cabal deps
  - `tests/test_wam_haskell_target.pl` — three new B1 tests:
    - `test_b1_peekstringbytes_decodes_utf8` — body uses `decodeUtf8With`,
      no `toEnum` byte loop
    - `test_b1_lmdb_text_imports_present` — all four new imports present
    - `test_b1_lmdb_cabal_text_dependencies` — both new deps in cabal

  ## Verification

  - Full `tests/test_wam_haskell_target.pl` suite green (added tests pass,
    no regressions).
  - Generated a `seeded interpreter kernels_on resident` bench at 1k scale
    and ran `cabal new-build` — clean compile (only pre-existing
    pattern-match completeness warnings, unrelated).
  - Functional run on `data/benchmark/1k_resident_run`: `total_ms=65`,
    `demand_set_size=2011`, `tuple_count=48` — identical to prior baseline.
    ASCII fixtures unaffected; the change is purely for the non-ASCII path.

  ## Why now

  Trivial follow-up surfaced during the Phase 2b/L arc. Untriggered by any
  of the existing fixtures (1k_cats / 100k_cats / simplewiki / enwiki
  converter output all happen to be ASCII for the chosen roots), but would
  silently corrupt category names the moment a non-Latin alphabet fixture
  is fed through. Fixing now keeps the lurking-bug count at zero before
  the cost-model / Phase 2c arc starts.

  ## Test plan

  - [x] All codegen tests pass
  - [x] Smoke-build at 1k scale (cabal new-build clean)
  - [x] Functional run matches prior baseline (no regression)
  - [ ] (Manual, not in CI) round-trip a non-ASCII string through
        `ingest_resident_lmdb_fixture.py` and confirm read-back equality —
        can be done if/when a non-ASCII fixture lands in the repo