### PR TITLE
Feature/lua wam fact stream filter parity

### DIFF
--- a/PR_lua_wam_fact_stream_filter_parity.md
+++ b/PR_lua_wam_fact_stream_filter_parity.md
@@ -1,0 +1,23 @@
+# PR Title
+
+Filter Lua WAM fact stream rows
+
+# PR Description
+
+## Summary
+
+- Add bound-argument filtering to Lua WAM `CallFactStream`.
+- Filter candidate rows against already-bound `A1` and/or `A2` before unification.
+- Apply the same filtering path to inline facts and external fact-source rows.
+- Preserve external `A1` indexing as the candidate source optimization, then filter by bound `A2`.
+- Add regression assertions for mismatched bound-argument cases.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`
+
+## Notes
+
+This aligns Lua fact-stream behavior with Haskell's `streamFactRows` filtering semantics while keeping the existing inline and external fact-source paths intact.

--- a/templates/targets/lua_wam/runtime.lua.mustache
+++ b/templates/targets/lua_wam/runtime.lua.mustache
@@ -523,11 +523,28 @@ local function fact_source_rows(program, pred, state)
   return source.cache.rows
 end
 
+local function fact_row_matches(state, row)
+  local a1 = Runtime.deref(state, Runtime.get_reg(state, 1))
+  local a2 = Runtime.deref(state, Runtime.get_reg(state, 2))
+  if type(a1) == "table" and a1.tag ~= "unbound" and same_atomic(a1, row[1]) ~= true then return false end
+  if type(a2) == "table" and a2.tag ~= "unbound" and same_atomic(a2, row[2]) ~= true then return false end
+  return true
+end
+
+local function filter_fact_rows(state, rows)
+  local out = {}
+  for _, row in ipairs(rows or {}) do
+    if fact_row_matches(state, row) then out[#out + 1] = row end
+  end
+  return out
+end
+
 local function call_fact_stream(program, state, instr)
   local rows = program.inline_facts and program.inline_facts[instr.pred] or nil
   if rows == nil or #rows == 0 then
     rows = fact_source_rows(program, instr.pred, state)
   end
+  rows = filter_fact_rows(state, rows)
   if rows == nil or #rows == 0 then return false end
   if #rows > 1 then
     local rest = {}

--- a/tests/test_wam_lua_generator.pl
+++ b/tests/test_wam_lua_generator.pl
@@ -183,6 +183,7 @@ test(lua_fact_stream_e2e, [condition(lua_available)]) :-
           run_lua_query(LuaDir, 'wam_lua_stream_fact/2', [a, b], true),
           run_lua_query(LuaDir, 'wam_lua_stream_fact/2', [a, c], true),
           run_lua_query(LuaDir, 'wam_lua_stream_fact/2', [a, d], false),
+          run_lua_query(LuaDir, 'wam_lua_stream_fact/2', [x, c], false),
           run_lua_query(LuaDir, 'wam_lua_stream_caller/2', [a, c], true)
         ),
         delete_directory_and_contents(TmpDir)
@@ -215,6 +216,7 @@ test(lua_external_fact_source_e2e, [condition(lua_available)]) :-
           run_lua_query(LuaDir, 'wam_lua_ext_fact/2', [a, d], false),
           run_lua_query(LuaDir, 'wam_lua_ext_fact/2', [x, z], true),
           run_lua_query(LuaDir, 'wam_lua_ext_fact/2', [a, z], false),
+          run_lua_query(LuaDir, 'wam_lua_ext_fact/2', [x, c], false),
           run_lua_query(LuaDir, 'wam_lua_ext_caller/2', [a, c], true),
           run_lua_script(
               LuaDir,


### PR DESCRIPTION
## Summary

- Add bound-argument filtering to Lua WAM `CallFactStream`.
- Filter candidate rows against already-bound `A1` and/or `A2` before unification.
- Apply the same filtering path to inline facts and external fact-source rows.
- Preserve external `A1` indexing as the candidate source optimization, then filter by bound `A2`.
- Add regression assertions for mismatched bound-argument cases.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`

## Notes

This aligns Lua fact-stream behavior with Haskell's `streamFactRows` filtering semantics while keeping the existing inline and external fact-source paths intact.
