### PR TITLE
feat(wam-r): backtrack bagof setof witness groups

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -430,7 +430,8 @@ paths:
   `WamRuntime$collect_bag_groups`, which snapshot state, drive the
   goal via `iterate_goal`, and restore state fully before returning.
   `bagof/3` and `setof/3` honor `^/2` existential scope and group
-  non-existential free variables for the selected witness group.
+  non-existential free variables; additional witness groups are
+  exposed through normal backtracking.
 
 `iterate_goal` has R-level fast paths for `member/2`, `between/3`,
 `,/2` conjunctions over the above, and dynamic predicates -- so
@@ -635,12 +636,10 @@ WamRuntime$run(shared_program, state)
   Removed clauses are matched against the live store by object
   identity, so concurrent retracts/asserts of unrelated clauses
   don't disturb the iteration order.
-- **`bagof/3` / `setof/3` group enumeration on backtracking**.
-  Non-existential free variables are grouped and the first witness
-  group is bound, so `bagof(X, p(X,Y), L)` can bind `Y` and `L`
-  consistently. Backtracking across additional witness groups is a
-  follow-up; the current library path does not yet push a group
-  choice point.
+- **Full ISO/SWI compatibility for every `bagof/3` / `setof/3` edge**.
+  The runtime now groups non-existential free variables and enumerates
+  additional witness groups on backtracking, but unusual attributed-var
+  or cyclic-term cases still need broader compatibility coverage.
 - **`length/2` (-, -)** generative mode is not supported (would
   need a CP-driving generator).
 - **`between/3` (+, +, -)** in compiled-goal context produces an

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -3277,6 +3277,7 @@ WamRuntime$member_iter <- function(state, target, elems, start_idx, resume_pc) {
     snap_vc    <- state$var_counter
     snap_mode  <- state$mode
     snap_build <- state$build_stack
+    snap_read  <- state$read_stack
     if (WamRuntime$unify(state, target, elems[[idx]])) {
       if (idx < length(elems)) {
         next_idx <- idx + 1L
@@ -3291,6 +3292,7 @@ WamRuntime$member_iter <- function(state, target, elems, start_idx, resume_pc) {
           var_counter = snap_vc,
           mode        = snap_mode,
           build_stack = snap_build,
+          read_stack  = snap_read,
           resume_pc   = resume_pc,
           retry       = function(state) {
             WamRuntime$member_iter(state, captured_target, captured_elems, next_idx, captured_resume)
@@ -3317,6 +3319,7 @@ WamRuntime$member_iter <- function(state, target, elems, start_idx, resume_pc) {
     state$var_counter <- snap_vc
     state$mode        <- snap_mode
     state$build_stack <- snap_build
+    state$read_stack  <- snap_read
   }
   FALSE
 }
@@ -3331,6 +3334,7 @@ WamRuntime$between_iter <- function(state, target, current, hi, resume_pc) {
   snap_vc    <- state$var_counter
   snap_mode  <- state$mode
   snap_build <- state$build_stack
+  snap_read  <- state$read_stack
   if (WamRuntime$unify(state, target, IntTerm(current))) {
     if (current < hi) {
       next_val <- current + 1L
@@ -3345,6 +3349,7 @@ WamRuntime$between_iter <- function(state, target, current, hi, resume_pc) {
         var_counter = snap_vc,
         mode        = snap_mode,
         build_stack = snap_build,
+        read_stack  = snap_read,
         resume_pc   = resume_pc,
         retry       = function(state) {
           WamRuntime$between_iter(state, captured_target, next_val, captured_hi, captured_resume)
@@ -3560,7 +3565,9 @@ WamRuntime$dispatch_call <- function(program, state, pred, arity) {
 # choice-point machinery. Other goals -- including multi-clause user
 # predicates and dynamic-store predicates -- go through the default
 # fallback, which uses call_goal + backtrack + run to drive the
-# standard try_me_else / dynamic CP iteration.
+# standard try_me_else / dynamic CP iteration. Library predicates that
+# push iter CPs but do not need the WAM stepping loop are handled as
+# explicit fast paths below.
 #
 # The callback `on_each` is invoked while the iteration's bindings
 # are still in scope. It returns TRUE to continue iterating, FALSE to
@@ -3601,6 +3608,26 @@ WamRuntime$iterate_goal <- function(program, state, goal_term, on_each) {
       cont
     })
     return(invisible(NULL))
+  }
+
+  # bagof/3 and setof/3 are library-level enumerators: once their
+  # grouped solutions are collected, later witness groups are exposed
+  # by iter CP retry closures. Backtrack directly between groups; the
+  # WAM stepping loop is not involved for this runtime-only path.
+  if (v$tag == "struct" && length(v$args) == 3L) {
+    pred_name <- WamRuntime$string_of(table, v$fid)
+    if (pred_name %in% c("bagof", "setof")) {
+      snap_cps_len <- length(state$cps)
+      ok <- WamRuntime$call_goal(program, state, goal_term)
+      while (isTRUE(ok)) {
+        cont <- on_each()
+        if (!isTRUE(cont)) break
+        if (length(state$cps) <= snap_cps_len) break
+        if (!WamRuntime$backtrack(state)) break
+        ok <- TRUE
+      }
+      return(invisible(NULL))
+    }
   }
 
   # member/2: iterate list elements directly (no CP machinery).
@@ -3877,6 +3904,85 @@ WamRuntime$bind_bag_group_witnesses <- function(state, group) {
     }
   }
   TRUE
+}
+
+WamRuntime$bag_group_values <- function(state, group, table, sort_dedup = FALSE) {
+  if (!isTRUE(sort_dedup)) return(group$values)
+  sorted <- WamRuntime$wam_sort_terms(state, group$values, table)
+  deduped <- list()
+  for (i in seq_along(sorted)) {
+    if (i == 1L ||
+        WamRuntime$compare_terms(state, sorted[[i - 1L]], sorted[[i]], table) != 0L) {
+      deduped <- c(deduped, list(sorted[[i]]))
+    }
+  }
+  deduped
+}
+
+WamRuntime$bag_group_iter <- function(state, groups, start_idx, bag_target, table, sort_dedup, resume_pc) {
+  if (start_idx > length(groups)) return(FALSE)
+  for (idx in seq.int(start_idx, length(groups))) {
+    snap_regs  <- as.list.environment(state$regs2)
+    snap_trail <- length(state$trail)
+    snap_cp    <- state$cp
+    snap_vc    <- state$var_counter
+    snap_mode  <- state$mode
+    snap_build <- state$build_stack
+    snap_read  <- state$read_stack
+
+    group <- groups[[idx]]
+    bag <- WamRuntime$wam_list_build(
+      WamRuntime$bag_group_values(state, group, table, sort_dedup),
+      table
+    )
+    ok <- WamRuntime$bind_bag_group_witnesses(state, group)
+    if (isTRUE(ok)) ok <- WamRuntime$unify(state, bag_target, bag)
+    if (isTRUE(ok)) {
+      if (idx < length(groups)) {
+        next_idx <- idx + 1L
+        captured_groups <- groups
+        captured_target <- bag_target
+        captured_table <- table
+        captured_sort <- sort_dedup
+        captured_resume <- resume_pc
+        cp <- list(
+          kind        = "iter",
+          regs        = snap_regs,
+          trail_len   = snap_trail,
+          cp          = snap_cp,
+          var_counter = snap_vc,
+          mode        = snap_mode,
+          build_stack = snap_build,
+          read_stack  = snap_read,
+          resume_pc   = resume_pc,
+          retry       = function(state) {
+            WamRuntime$bag_group_iter(
+              state,
+              captured_groups,
+              next_idx,
+              captured_target,
+              captured_table,
+              captured_sort,
+              captured_resume
+            )
+          }
+        )
+        state$cps <- c(state$cps, list(cp))
+      }
+      return(TRUE)
+    }
+
+    e <- new.env(parent = emptyenv(), hash = TRUE)
+    for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
+    state$regs2 <- e
+    WamRuntime$undo_trail_to(state, snap_trail)
+    state$cp          <- snap_cp
+    state$var_counter <- snap_vc
+    state$mode        <- snap_mode
+    state$build_stack <- snap_build
+    state$read_stack  <- snap_read
+  }
+  FALSE
 }
 
 WamRuntime$call_builtin <- function(program, state, pred, arity) {
@@ -4451,21 +4557,13 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     goal     <- WamRuntime$get_reg(state, 2L)
     groups <- WamRuntime$collect_bag_groups(program, state, template, goal)
     if (length(groups) == 0L) return(FALSE)
-    group <- groups[[1L]]
-    bag <- WamRuntime$wam_list_build(group$values, table)
-    trail0 <- length(state$trail)
-    if (!WamRuntime$bind_bag_group_witnesses(state, group)) {
-      WamRuntime$undo_trail_to(state, trail0)
-      return(FALSE)
-    }
     cur <- WamRuntime$get_reg(state, 3L)
     if (is.null(cur)) {
-      WamRuntime$put_reg(state, 3L, bag)
-      return(TRUE)
+      cur <- Unbound(paste0("__bagof_", state$var_counter))
+      state$var_counter <- state$var_counter + 1L
+      WamRuntime$put_reg(state, 3L, cur)
     }
-    ok <- WamRuntime$unify(state, cur, bag)
-    if (!isTRUE(ok)) WamRuntime$undo_trail_to(state, trail0)
-    return(ok)
+    return(WamRuntime$bag_group_iter(state, groups, 1L, cur, table, FALSE, state$pc + 1L))
   }
 
   # ----- setof/3: bagof + sort + dedup (standard order of terms) -----
@@ -4474,29 +4572,13 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     goal     <- WamRuntime$get_reg(state, 2L)
     groups <- WamRuntime$collect_bag_groups(program, state, template, goal)
     if (length(groups) == 0L) return(FALSE)
-    group <- groups[[1L]]
-    sorted <- WamRuntime$wam_sort_terms(state, group$values, table)
-    deduped <- list()
-    for (i in seq_along(sorted)) {
-      if (i == 1L ||
-          WamRuntime$compare_terms(state, sorted[[i - 1L]], sorted[[i]], table) != 0L) {
-        deduped <- c(deduped, list(sorted[[i]]))
-      }
-    }
-    bag <- WamRuntime$wam_list_build(deduped, table)
-    trail0 <- length(state$trail)
-    if (!WamRuntime$bind_bag_group_witnesses(state, group)) {
-      WamRuntime$undo_trail_to(state, trail0)
-      return(FALSE)
-    }
     cur <- WamRuntime$get_reg(state, 3L)
     if (is.null(cur)) {
-      WamRuntime$put_reg(state, 3L, bag)
-      return(TRUE)
+      cur <- Unbound(paste0("__setof_", state$var_counter))
+      state$var_counter <- state$var_counter + 1L
+      WamRuntime$put_reg(state, 3L, cur)
     }
-    ok <- WamRuntime$unify(state, cur, bag)
-    if (!isTRUE(ok)) WamRuntime$undo_trail_to(state, trail0)
-    return(ok)
+    return(WamRuntime$bag_group_iter(state, groups, 1L, cur, table, TRUE, state$pc + 1L))
   }
 
   # ----- once/1: run goal, commit to first solution -----
@@ -5304,6 +5386,7 @@ WamRuntime$backtrack <- function(state) {
     state$var_counter <- cp$var_counter
     state$mode        <- cp$mode
     state$build_stack <- cp$build_stack
+    if (!is.null(cp$read_stack)) state$read_stack <- cp$read_stack
     if (cp$retry(state)) {
       state$pc <- as.integer(cp$resume_pc)
       return(TRUE)

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2168,23 +2168,33 @@ e2e_bagof_setof_existential_via_rscript :-
         setof(X, hh(X, Y), L),
         Y == a,
         L == [1, 3])),
-    % Boundary for this partial implementation: additional witness
-    % groups are not enumerated on backtracking yet.
-    assertz((user:be_bagof_no_second_group :-
+    % Additional witness groups are enumerated on backtracking.
+    assertz((user:be_bagof_group_backtrack :-
         assertz(ii(1, a)), assertz(ii(2, b)),
-        \+ (bagof(X, ii(X, Y), L), Y == b, L == [2]))),
+        bagof(X, ii(X, Y), L),
+        Y == b,
+        L == [2])),
+    assertz((user:be_setof_group_backtrack :-
+        assertz(jj(3, a)), assertz(jj(1, a)), assertz(jj(3, a)),
+        assertz(jj(2, b)),
+        setof(X, jj(X, Y), L),
+        Y == b,
+        L == [2])),
     unique_r_tmp_dir('tmp_r_caret_e2e', TmpDir),
     write_wam_r_project(
         [ user:be_bagof_basic/0, user:be_setof_basic/0,
           user:be_nested_caret/0, user:be_findall_caret/0,
           user:be_bagof_empty_no/0, user:be_bagof_group_first/0,
-          user:be_setof_group_first/0, user:be_bagof_no_second_group/0 ],
+          user:be_setof_group_first/0,
+          user:be_bagof_group_backtrack/0,
+          user:be_setof_group_backtrack/0 ],
         [],
         TmpDir),
     directory_file_path(TmpDir, 'R', RDir),
     Yes = [be_bagof_basic, be_setof_basic, be_nested_caret,
            be_findall_caret, be_bagof_group_first,
-           be_setof_group_first, be_bagof_no_second_group],
+           be_setof_group_first, be_bagof_group_backtrack,
+           be_setof_group_backtrack],
     No  = [be_bagof_empty_no],
     forall(member(P, Yes), (
         format(string(Q), '~w/0', [P]),


### PR DESCRIPTION
## Summary

- Adds WAM-R runtime iteration across additional `bagof/3` and `setof/3` witness groups.
- Preserves `read_stack` in iterator choice-point snapshots used by enumerable runtime paths.
- Updates WAM-R docs and Rscript e2e coverage for second witness-group backtracking.

## Notes

- `bagof/3` and `setof/3` already grouped non-existential free variables for the selected group; this extends that support so later groups can be reached by ordinary backtracking.
- `setof/3` continues to sort and deduplicate within each witness group.
- `Var^Goal` existential handling remains covered by the existing aggregate tests.

## Verification

- `swipl -g "run_tests([wam_r_generator:bagof_setof_existential_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
- `swipl -g "run_tests([wam_r_generator:findall_e2e_rscript,wam_r_generator:bagof_setof_once_forall_e2e_rscript,wam_r_generator:enumerable_builtins_e2e_rscript,wam_r_generator:bagof_setof_existential_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
