### PR TITLE
fix(wam-r): per-frame Y registers + dispatch_call sub-call cleanup

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -634,18 +634,14 @@ WamRuntime$run(shared_program, state)
   into clause-level patterns (see `parse_op_loop`,
   `parse_args_continue`, etc. in
   `src/unifyweaver/core/prolog_term_parser.pl`).
-- **Y-register frame locality**. `state$regs2` is a single flat env
-  shared across all call frames, so a callee's `Y_n` writes to the
-  same slot as the caller's `Y_n`. `Allocate` saves the caller's
-  Y values and `Deallocate` restores them, which keeps register
-  state correct across the full caller-callee-caller path -- but
-  the WAM emit can read a Y register *after* `Deallocate` (e.g.
-  the `Term =.. [...]` after a `Call parse_args` in
-  `parse_atom_head`), expecting to see the body's value, not the
-  caller's restored value. That pattern silently reads the wrong
-  register. Real WAM emits use per-frame Y storage (each frame
-  has its own slot for Y_n); WAM-R will need the same. Documented
-  as the new follow-up gating the cross-target parser swap-in.
+- **`CutIte` (soft-cut) barrier scope**. `!/0` truncates `state$cps`
+  back to the predicate's call-site depth (correct cut barrier);
+  `CutIte` -- emitted for `( A -> B ; C )` -- still drops only the
+  most-recent CP. Predicates that depend on if-then-else commit
+  semantics need to be written with clause-level dispatch (see
+  `parse_op_loop`, `parse_args_continue`, `tokenize_loop_step` in
+  `src/unifyweaver/core/prolog_term_parser.pl`) until the same
+  Allocate-stamps-barrier model is wired up for soft cut.
 - **WAM-text quoting collision**. The atom `'42'` and the integer
   `42` both serialise as `set_constant 42` in SWI's WAM emitter,
   so the codegen can't distinguish them. The runtime's `atom_*`

--- a/docs/handoff/wam_r_session_handoff.md
+++ b/docs/handoff/wam_r_session_handoff.md
@@ -139,26 +139,30 @@ roughly priority order:
    identify a single hot path; subsequent PRs each fix one bottleneck.
    Tagged-list `$tag` access and env-based register lookups are likely
    suspects.
-3. **Per-frame Y-register storage.** `state$regs2` is one flat env
-   shared across all call frames, so a callee's `Y_n` writes to the
-   same slot as the caller's. `Allocate`/`Deallocate` save+restore
-   keeps state correct on the boundary, but the WAM emit can read
-   a Y register *after* `Deallocate` (the SWI emitter's normal
-   shape, e.g. `Call parse_args; Deallocate; PutValue Y6, A1; ...
-   =../2`) expecting to see the body's value. Today that read
-   silently picks up the caller's restored value. The cross-target
-   Prolog parser at `src/unifyweaver/core/prolog_term_parser.pl`
-   compiles cleanly and now executes much further than before
-   (cut-barrier and stack-cleanup fixes both shipped, see #1948),
-   but `parse_atom_head`'s post-`Call` `=..` hits this register
-   conflict and the swap-in of `WamRuntime$parse_term` is gated on
-   the fix. Real WAM impls give each frame its own Y slot vector;
-   the easiest version here is a per-frame env (`frame$ys`) that
-   `GetVariable`/`PutValue`/etc. dispatch into when the index is
-   `>= 201`, leaving X registers in the shared env.
+3. **Inline `WamRuntime$parse_term` swap-in.** The cross-target Prolog
+   term parser at `src/unifyweaver/core/prolog_term_parser.pl` now
+   runs end-to-end through the WAM-R compiled path -- atoms, integers,
+   simple compounds, multi-arg compounds, lists, infix operators with
+   correct precedence, postfix, var sharing, nested. Coverage proven
+   by `tests/test_prolog_term_parser_wam_r_compile.pl:full_parser_e2e_via_rscript`.
+   Per-frame Y storage and the `dispatch_call` sub-call cleanup landed
+   alongside the cut-barrier work; nothing in the parser source needs
+   to change. The remaining work is wiring `WamRuntime$parse_term`
+   (and `term_to_atom/2`, `read_term_from_atom/2,3`, `read/2`, the
+   CLI arg parser) to dispatch into the compiled predicate instead of
+   the inline R parser. Important: existing op-related tests
+   (`op_3_runtime_e2e_rscript`, `op_3_decl_e2e_rscript`,
+   `op_3_postfix_e2e_rscript`, `term_to_atom*`) all exercise the
+   inline parser today; the swap needs to keep them green. Performance
+   Performance is unmeasured but the compiled parser will be slower
+   than the inline R version (WAM stepping engine vs. native R
+   control flow); the swap is a correctness / cross-target win, not
+   a speed win, so benchmark before pulling the trigger and consider
+   keeping the inline path for the CLI arg parser if startup latency
+   regresses too far.
 
 4. **`CutIte` (soft cut) barrier scope.** `!/0` now uses a proper
-   cut barrier (PR #1948); `CutIte` -- emitted for
+   cut barrier (PR #1960); `CutIte` -- emitted for
    `( A -> B ; C )` -- still drops only the most-recent CP. The
    same Allocate-stamps-barrier model would work for soft cut, with
    the barrier saved at the start of A so CutIte truncates back to

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -259,11 +259,45 @@ WamRuntime$new_state <- function() {
   # "commit globally" -- correct, since there's no outer caller
   # whose alternatives need preserving.
   s$pending_call_barrier <- 0L
+  # Per-frame Y storage. Y registers (idx >= 201) live in the topmost
+  # frame's `ys` env, not in s$regs2. Deallocate pops the frame but
+  # parks its ys env on s$shadow_frame so the SWI WAM emit's typical
+  # post-Deallocate Y reads still resolve. Allocate clears it; the
+  # next body's Y writes don't leak in. Also initialise the regs2
+  # env so X / A access works before the first Allocate.
+  s$shadow_frame <- NULL
   s
 }
 
 WamRuntime$get_reg <- function(state, idx) {
   key <- as.character(idx)
+  # Y registers live in the topmost frame's `ys` env, not in regs2.
+  # When state$shadow_frame is set (a Deallocate has just popped a
+  # frame and we're in the post-Deallocate code section of THAT
+  # predicate), Y reads route through the shadow first -- the SWI
+  # WAM emit reads Y_n between Deallocate and the predicate's
+  # Proceed/Execute, expecting the body's value, and the just-
+  # popped frame is the only place that holds it. Shadow is cleared
+  # at every Allocate / Proceed / Execute / backtrack, so any time
+  # we're inside a normal pre-Deallocate body Y reads bypass shadow
+  # and hit the topmost frame's ys directly.
+  if (idx >= 201L) {
+    sf <- state$shadow_frame
+    if (!is.null(sf)) {
+      ys <- sf$ys
+      if (!is.null(ys) && exists(key, envir = ys, inherits = FALSE)) {
+        return(get(key, envir = ys, inherits = FALSE))
+      }
+    }
+    sn <- length(state$stack)
+    if (sn > 0L) {
+      ys <- state$stack[[sn]]$ys
+      if (!is.null(ys) && exists(key, envir = ys, inherits = FALSE)) {
+        return(get(key, envir = ys, inherits = FALSE))
+      }
+    }
+    return(NULL)
+  }
   if (exists(key, envir = state$regs2, inherits = FALSE)) {
     get(key, envir = state$regs2, inherits = FALSE)
   } else {
@@ -273,6 +307,16 @@ WamRuntime$get_reg <- function(state, idx) {
 
 WamRuntime$put_reg <- function(state, idx, val) {
   key <- as.character(idx)
+  # Y writes go to the topmost frame's ys env. Outside any Allocate'd
+  # frame (top-level pre-Allocate, builtin handlers without their own
+  # frame) Y writes fall back to regs2 so we keep something accessible.
+  if (idx >= 201L) {
+    sn <- length(state$stack)
+    if (sn > 0L) {
+      assign(key, val, envir = state$stack[[sn]]$ys)
+      return(invisible(NULL))
+    }
+  }
   assign(key, val, envir = state$regs2)
   invisible(NULL)
 }
@@ -1208,18 +1252,12 @@ WamRuntime$step <- function(program, state, instr) {
       state$pc <- state$pc + 1L; TRUE
     },
     "Allocate" = {
-      # Save the caller's Y registers (idx >= 201) so the callee's
-      # Y writes don't stomp them. Without this, nested calls
-      # `rt(F) :- do_write(F), do_read(F).` lose F when do_write's
-      # Y201 (= S) overwrites rt's Y201 (= F) in the flat regs2
-      # env. Deallocate restores the saved Y values.
-      saved_ys <- list()
-      for (k in ls(state$regs2)) {
-        ki <- suppressWarnings(as.integer(k))
-        if (!is.na(ki) && ki >= 201L) {
-          saved_ys[[k]] <- get(k, envir = state$regs2, inherits = FALSE)
-        }
-      }
+      # Push a new env frame with its OWN Y-register storage. Y writes
+      # in this clause body live in `frame$ys` (idx >= 201); X and A
+      # registers stay in the shared state$regs2. This matches real
+      # WAM semantics where each frame has its own Y slot vector,
+      # so a callee's Y_n cannot stomp the caller's Y_n.
+      ys <- new.env(parent = emptyenv(), hash = TRUE)
       # state$pending_call_barrier was set by the Call/Execute that
       # routed us to this predicate's first instruction (or left at
       # its initial 0 for a top-level run_predicate entry). Capture
@@ -1228,27 +1266,27 @@ WamRuntime$step <- function(program, state, instr) {
       # predicate has created (including its own TryMeElse CP).
       state$stack <- c(state$stack,
                        list(list(cp = state$cp,
-                                 saved_ys = saved_ys,
+                                 ys = ys,
                                  cps_barrier = state$pending_call_barrier)))
+      # The previous frame's `ys` is no longer reachable as a "shadow"
+      # for post-Deallocate Y reads -- a fresh body starts here.
+      state$shadow_frame <- NULL
       state$pc <- state$pc + 1L; TRUE
     },
     "Deallocate" = {
-      # Pop the call frame and restore the caller's Y registers.
-      # Note: we *only* overwrite the slots that were live in the
-      # caller (frame$saved_ys); any Y the callee added beyond
-      # those is left in place because SWI's WAM emit can read a
-      # Y register *after* Deallocate (e.g. an ArgInstr that
-      # follows the trim), and removing the value would break it.
+      # Pop the call frame. Y registers were stored in `frame$ys`,
+      # which is now retained on `state$shadow_frame` so the next
+      # few instructions -- the SWI WAM emit routinely reads Y
+      # registers after Deallocate (e.g. `Call X; Deallocate;
+      # PutValue Y_n; ...; BuiltinCall =.. ; Proceed`) -- still see
+      # the body's writes. The shadow is invalidated by the next
+      # Allocate (a fresh body cannot leak into stale slots) and by
+      # backtrack (truncates state$stack and clears shadow).
       n <- length(state$stack)
       if (n > 0L) {
         frame <- state$stack[[n]]
         state$cp <- frame$cp
-        saved <- frame$saved_ys
-        if (!is.null(saved)) {
-          for (k in names(saved)) {
-            assign(k, saved[[k]], envir = state$regs2)
-          }
-        }
+        state$shadow_frame <- frame
         state$stack <- state$stack[-n]
       }
       state$pc <- state$pc + 1L; TRUE
@@ -1297,6 +1335,7 @@ WamRuntime$step <- function(program, state, instr) {
         fn <- get(key, envir = program$lowered_dispatch, inherits = FALSE)
         ok <- isTRUE(fn(program, state))
         if (!ok) return(FALSE)
+        state$shadow_frame <- NULL
         if (state$cp == 0L) { state$halt <- TRUE; return(TRUE) }
         state$pc <- state$cp; state$cp <- 0L; return(TRUE)
       }
@@ -1307,21 +1346,28 @@ WamRuntime$step <- function(program, state, instr) {
         # barrier the same way Call does -- any CP the callee pushes
         # is its own; everything currently on state$cps belongs to
         # outer frames whose alternatives the callee's `!/0` must
-        # leave alone.
+        # leave alone. Also clear the shadow_frame the caller's
+        # Deallocate left -- the callee shouldn't see the caller's
+        # Y values via shadow fallthrough.
         state$pending_call_barrier <- length(state$cps)
+        state$shadow_frame <- NULL
         state$pc <- as.integer(tgt)
         return(TRUE)
       }
       dyn <- WamRuntime$try_dynamic(program, state, instr$pred, instr$arity)
       if (!is.null(dyn)) {
         if (!isTRUE(dyn)) return(FALSE)
+        state$shadow_frame <- NULL
         if (state$cp == 0L) { state$halt <- TRUE; return(TRUE) }
         state$pc <- state$cp; state$cp <- 0L; return(TRUE)
       }
       lib <- WamRuntime$call_library(program, state, instr$pred, instr$arity)
       if (is.null(lib)) return(FALSE)
       if (!isTRUE(lib)) return(FALSE)
-      # Tail-call return: same protocol as Proceed.
+      # Tail-call return: same protocol as Proceed -- clear shadow so
+      # the caller's body's Y reads don't pick up our just-popped
+      # frame's ys.
+      state$shadow_frame <- NULL
       if (state$cp == 0L) { state$halt <- TRUE; return(TRUE) }
       state$pc <- state$cp; state$cp <- 0L; TRUE
     },
@@ -1333,11 +1379,18 @@ WamRuntime$step <- function(program, state, instr) {
     "ExecuteForeign" = {
       ok <- WamRuntime$call_foreign(program, state, instr$pred, instr$arity, tail_call = TRUE)
       if (!ok) return(FALSE)
-      # tail-call returns to caller's CP
+      # tail-call returns to caller's CP; clear shadow so the
+      # caller's Y reads don't pick up our just-popped frame.
+      state$shadow_frame <- NULL
       if (state$cp == 0L) { state$halt <- TRUE; return(TRUE) }
       state$pc <- state$cp; state$cp <- 0L; TRUE
     },
     "Proceed" = {
+      # Returning to caller. Any post-Deallocate shadow that this
+      # predicate left for its own post-Deallocate Y reads has done
+      # its job; the caller's frame is the next live env, so clear
+      # shadow to keep its ys from leaking into caller's Y access.
+      state$shadow_frame <- NULL
       if (state$cp == 0L) { state$halt <- TRUE; return(TRUE) }
       state$pc <- state$cp; state$cp <- 0L; TRUE
     },
@@ -3583,10 +3636,20 @@ WamRuntime$dispatch_call <- function(program, state, pred, arity) {
   tgt <- program$labels[[key]]
   if (!is.null(tgt)) {
     # User predicate (or foreign-stub label). Run as a sub-call:
-    # save the outer pc / cp / halt, run to Proceed, restore.
-    saved_pc   <- state$pc
-    saved_cp   <- state$cp
-    saved_halt <- state$halt
+    # save the outer pc / cp / halt + env stack depth + shadow frame,
+    # run to Proceed, restore. The stack/shadow restore is critical:
+    # if the sub-call fails without a choice point to backtrack to,
+    # `run` returns FALSE leaving the callee's Allocated frame still
+    # on state$stack -- subsequent Y register reads in the OUTER
+    # body would then land in the stale callee frame instead of the
+    # caller's. Same logic for shadow_frame, since the sub-call's
+    # Deallocates can leave it pointing at a popped callee frame
+    # that the outer body's Y reads must not see.
+    saved_pc       <- state$pc
+    saved_cp       <- state$cp
+    saved_halt     <- state$halt
+    saved_stack_n  <- length(state$stack)
+    saved_shadow   <- state$shadow_frame
     state$pc   <- as.integer(tgt)
     state$cp   <- 0L
     state$halt <- FALSE
@@ -3594,6 +3657,10 @@ WamRuntime$dispatch_call <- function(program, state, pred, arity) {
     state$pc   <- saved_pc
     state$cp   <- saved_cp
     state$halt <- saved_halt
+    if (length(state$stack) > saved_stack_n) {
+      state$stack <- state$stack[seq_len(saved_stack_n)]
+    }
+    state$shadow_frame <- saved_shadow
     return(isTRUE(ok))
   }
   if (!is.null(program$foreign_handlers[[key]])) {
@@ -5450,6 +5517,10 @@ WamRuntime$backtrack <- function(state) {
       length(state$stack) > cp$stack_len) {
     state$stack <- state$stack[seq_len(cp$stack_len)]
   }
+  # The shadow frame held the most-recently popped frame's ys env so
+  # post-Deallocate Y reads still resolved. Backtracking past that
+  # boundary makes the shadow stale -- clear it.
+  state$shadow_frame <- NULL
   state$pc <- as.integer(cp$next_pc)
   TRUE
 }

--- a/tests/test_prolog_term_parser_wam_r_compile.pl
+++ b/tests/test_prolog_term_parser_wam_r_compile.pl
@@ -32,7 +32,18 @@ parser_predicates(Preds) :-
     findall(prolog_term_parser:N/A,
             (   current_predicate(prolog_term_parser:N/A),
                 functor(H, N, A),
-                once(clause(prolog_term_parser:H, _))
+                once(clause(prolog_term_parser:H, _)),
+                % Exclude imported predicates (member/2, append/3,
+                % reverse/2 from the lists library) -- clause/2 finds
+                % them through the module qualifier, but they aren't
+                % defined here and shouldn't be compiled as if they
+                % were. Without this filter, the SWI tests' calls
+                % autoload list helpers into prolog_term_parser, the
+                % filter sees them as "predicates with clauses", and
+                % the compiled R project ends up with conflicting
+                % shadow definitions of the runtime's library calls.
+                \+ predicate_property(prolog_term_parser:H,
+                                       imported_from(_))
             ),
             Raw),
     sort(Raw, Preds).
@@ -143,6 +154,90 @@ cut_free_subset_runs_body :-
     assertion(sub_string(RhsYfxOut, _, _, _, "499")),
     run_rscript_query(RDir, 'drv_starts/0', StartsOut),
     assertion(sub_string(StartsOut, _, _, _, "ok")),
+    delete_directory_and_contents(TmpDir).
+
+% ---------------------------------------------------------------------------
+% Test: the full compiled parser produces the same terms under Rscript as
+% it does under SWI. End-to-end proof that the cross-target loop works.
+% Auto-skips when Rscript isn't on PATH.
+% ---------------------------------------------------------------------------
+
+test(full_parser_e2e_via_rscript) :-
+    once((
+        rscript_available
+    ->  full_parser_e2e_body
+    ;   true
+    )).
+
+full_parser_e2e_body :-
+    parser_predicates(ParserPreds),
+    fresh_tmp_dir(TmpDir),
+    % Drivers cover the parser surface: bare atom, integer, simple
+    % compound, multi-arg compound, list, infix operator with
+    % precedence, postfix operator, repeated variable (var sharing
+    % within one parse), nested compound + list. Each prints the
+    % parsed term so we can sub-string match the expected output.
+    retractall(user:dpe_atom/0),
+    retractall(user:dpe_num/0),
+    retractall(user:dpe_compound/0),
+    retractall(user:dpe_arith/0),
+    retractall(user:dpe_list/0),
+    retractall(user:dpe_postfix/0),
+    retractall(user:dpe_var/0),
+    retractall(user:dpe_nested/0),
+    assertz((user:dpe_atom :-
+        canonical_op_table(O), parse_term_from_atom('foo', O, T),
+        write(T), nl)),
+    assertz((user:dpe_num :-
+        canonical_op_table(O), parse_term_from_atom('42', O, T),
+        write(T), nl)),
+    assertz((user:dpe_compound :-
+        canonical_op_table(O), parse_term_from_atom('foo(a, b)', O, T),
+        write(T), nl)),
+    assertz((user:dpe_arith :-
+        canonical_op_table(O), parse_term_from_atom('1 + 2 * 3', O, T),
+        write(T), nl)),
+    assertz((user:dpe_list :-
+        canonical_op_table(O), parse_term_from_atom('[a, b]', O, T),
+        write(T), nl)),
+    assertz((user:dpe_postfix :-
+        canonical_op_table(B), Ops = [op('!', 100, yf) | B],
+        parse_term_from_atom('5!', Ops, T),
+        write(T), nl)),
+    assertz((user:dpe_var :-
+        canonical_op_table(O), parse_term_from_atom('f(X, X)', O, T),
+        ( T = f(A, B), var(A), A == B
+        -> write(shared_var) ; write(not_shared) ),
+        nl)),
+    assertz((user:dpe_nested :-
+        canonical_op_table(O),
+        parse_term_from_atom('foo(bar(1), [a, b])', O, T),
+        write(T), nl)),
+    Drivers = [user:dpe_atom/0, user:dpe_num/0, user:dpe_compound/0,
+               user:dpe_arith/0, user:dpe_list/0, user:dpe_postfix/0,
+               user:dpe_var/0, user:dpe_nested/0],
+    append(Drivers, ParserPreds, Compile),
+    write_wam_r_project(Compile, [intern_atoms(['!'])], TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    run_rscript_query(RDir, 'dpe_atom/0', AtomOut),
+    assertion(sub_string(AtomOut, _, _, _, "foo")),
+    run_rscript_query(RDir, 'dpe_num/0', NumOut),
+    assertion(sub_string(NumOut, _, _, _, "42")),
+    run_rscript_query(RDir, 'dpe_compound/0', CompOut),
+    assertion(sub_string(CompOut, _, _, _, "foo(a,b)")),
+    run_rscript_query(RDir, 'dpe_arith/0', ArithOut),
+    % WAM-R's write/1 prints structs in canonical-functor form; the
+    % Pratt parser produced `+(1, *(2, 3))` so precedence is right
+    % (mult binds tighter than add).
+    assertion(sub_string(ArithOut, _, _, _, "+(1,*(2,3))")),
+    run_rscript_query(RDir, 'dpe_list/0', ListOut),
+    assertion(sub_string(ListOut, _, _, _, "[a,b]")),
+    run_rscript_query(RDir, 'dpe_postfix/0', PostfixOut),
+    assertion(sub_string(PostfixOut, _, _, _, "!(5)")),
+    run_rscript_query(RDir, 'dpe_var/0', VarOut),
+    assertion(sub_string(VarOut, _, _, _, "shared_var")),
+    run_rscript_query(RDir, 'dpe_nested/0', NestedOut),
+    assertion(sub_string(NestedOut, _, _, _, "foo(bar(1),[a,b])")),
     delete_directory_and_contents(TmpDir).
 
 run_rscript_query(RDir, Query, Out) :-


### PR DESCRIPTION
## Summary

Closes the cross-target Prolog parser loop. The compiled-from-Prolog parser at `src/unifyweaver/core/prolog_term_parser.pl` now executes correctly end-to-end through the WAM-R compiled path — atoms, integers, simple compounds, multi-arg compounds, lists, infix operators with correct precedence, postfix, var sharing, and nested compounds all round-trip via `Rscript`.

Two related runtime fixes:

### 1. Per-frame Y register storage

`state$regs2` was a single flat env shared across every call frame, so a callee's `Y_n` write to the same slot as the caller's `Y_n` would clobber it. The previous `Allocate` / `Deallocate` `saved_ys` mechanism restored the caller's value at `Deallocate` — which was wrong for the SWI WAM emit's standard pattern where Y registers are read **after** `Deallocate` (the trim optimisation: `Call X; Deallocate; PutValue Y_n; ...; BuiltinCall Y_n =.. ...; Proceed`). Real WAM impls give each frame its own Y vector.

Now each `Allocate` frame carries its own `ys` env, accessed by `get_reg` / `put_reg` when `idx >= 201`. The just-popped frame's `ys` is parked on `state$shadow_frame` so post-`Deallocate` Y reads still resolve. Shadow is invalidated by the next `Allocate`, by `Proceed`, by `Execute` (and its dynamic / library / lowered-dispatch return paths), by `ExecuteForeign`, and by backtrack — so it doesn't leak stale values into a different predicate's body or into the caller after we return.

### 2. `dispatch_call` sub-call cleanup

The sub-call mechanism used by `call_goal` (and therefore by `\+/1`, `not/1`, ...) saved `pc` / `cp` / `halt` across the inner run, but not `state$stack` or `state$shadow_frame`. When the inner goal failed without a choice point to backtrack to, `run` returned `FALSE` leaving the callee's `Allocate` frame on `state$stack` — subsequent Y reads in the outer body then landed in the stale callee's `ys`. Now both stack length and shadow are saved and restored on sub-call exit, regardless of the inner outcome.

## Test plan

- [x] Full WAM-R suite: **67/67** pass (no regressions).
- [x] `prolog_term_parser` SWI suite: **25/25** pass.
- [x] `prolog_term_parser_wam_r_compile` extended with new `full_parser_e2e_via_rscript` test that round-trips eight inputs through the compiled parser via `Rscript` and asserts on stdout (atoms, integers, compounds, arithmetic with `+(1,*(2,3))` precedence, lists, postfix `5! -> !(5)`, var sharing, nested). **3/3** pass.
- [x] `parser_predicates/1` helper hardened: filters out imported predicates (`member/2`, `append/3`, `reverse/2` autoloaded into the parser module by the SWI tests). Without this, the dynamic enumeration leaked list-library imports into the compile list and the generated R project shadowed the runtime library implementations with stub clauses.

## What's deliberately NOT in this PR

The actual swap of `WamRuntime$parse_term` (and the `term_to_atom` / `read_term_from_atom` / `read/2` / CLI arg-parser call sites) to dispatch into the compiled parser. The compiled parser is now correct, but performance is unmeasured and likely slower than the inline R version. Per the directive "only swap if equivalent or better", deferred to a separate PR with benchmarks in hand. Filed as the new follow-up **#3** in the WAM-R handoff; follow-up **#4** (CutIte soft-cut barrier) renumbered accordingly.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_