### PR TITLE
perf(wam-haskell): cache cost model + Phase M microbench

### DIFF
--- a/docs/design/CACHE_COST_MODEL_PHILOSOPHY.md
+++ b/docs/design/CACHE_COST_MODEL_PHILOSOPHY.md
@@ -1,0 +1,204 @@
+# Cache Cost Model — Philosophy
+
+## What this is
+
+A small, opt-in cost model that lets UnifyWeaver targets choose between
+sorted-seek and sequential-scan access patterns (and decide whether
+cache warming will pay off) based on first-principles estimates of
+cache regime, working-set size, and query count.
+
+This is *not* a runtime ML model. It's a closed-form formula with a
+handful of hardware constants that fit on one screen. The whole point
+is that it should be auditable: a human can read the numbers and
+predict what the model will recommend.
+
+## When the model matters
+
+The cache cost model is **groundwork**, not an immediate optimization.
+Most current UnifyWeaver workloads (Wikipedia categories at simplewiki
+or enwiki scale) fit comfortably in modern free RAM:
+
+- simplewiki categories: ~15 MB
+- enwiki categories: ~500 MB
+
+At this scale, the page cache holds the entire working set, every
+read pattern reduces to memory bandwidth, and "always use sorted
+seeks" is the right answer.
+
+The regime starts to bite when:
+
+1. **Article-level data** is ingested. Full enwiki article texts are
+   ~80 GB compressed, ~250 GB uncompressed — well past consumer RAM.
+2. **Multi-fixture aggregation** combines categories with page
+   metadata, revision counts, link tables, etc.
+3. **Memory-pressured environments** — WSL2 on Windows is a notable
+   case where the host dynamically reclaims VM pages.
+4. **Spinning-disk targets** — random seek latency jumps 100× over
+   SSD, shifting the scan-vs-seek crossover left aggressively.
+
+## What "free RAM" means (and why it's tricky)
+
+The cost model uses *free* RAM, not total. On Linux this is read from
+`/proc/meminfo:MemAvailable` — the kernel's own estimate of how much
+can be allocated without swapping. This subsumes:
+
+- The page cache (which the kernel will evict if a process needs RAM).
+- Reclaimable slab.
+- Memory currently backing inactive anonymous pages.
+
+`MemAvailable` is *not* the same as `MemFree`. A system with 0 KB
+"free" but 12 GB of page cache has 12 GB available — and that's
+exactly the RAM that the cost model can spend on warmed working set
+or rely on for memory-bandwidth-speed reads.
+
+On WSL2 the picture is more dynamic: the Linux VM's RAM ceiling is
+set in `.wslconfig` but the Windows host reclaims unused pages when
+under pressure. The cost model should re-read `MemAvailable` each
+time it makes a regime decision, not cache it across long-running
+processes.
+
+## The formula
+
+Variables:
+
+| symbol | meaning |
+|---|---|
+| `W` | bytes a full scan would touch (≈ DB size) |
+| `X` | working-set fraction the workload actually uses |
+| `R_free` | free RAM (`MemAvailable`) |
+| `S_mem_seq` | sequential bandwidth from page cache (~5 GB/s) |
+| `S_disk_seq` | sequential bandwidth from cold storage (~500 MB/s SSD) |
+| `t_mem_seek` | one cached B-tree seek (~1 µs) |
+| `t_disk_seek` | one uncached B-tree seek (~100 µs SSD, ~10 ms HDD) |
+| `K` | distinct keys looked up |
+
+Cache regime weight:
+
+```
+W_working = X * W
+f_hot     = min(1, R_free / W_working)
+```
+
+Effective costs:
+
+```
+T_scan = W_working * [f_hot / S_mem_seq + (1 - f_hot) / S_disk_seq]
+T_sort = K         * [f_hot * t_mem_seek + (1 - f_hot) * t_disk_seek]
+```
+
+Crossover K (sort = scan):
+
+```
+K_cross = W_working / [bandwidth_eff * latency_eff]
+
+where  bandwidth_eff = f_hot * S_mem_seq    + (1 - f_hot) * S_disk_seq
+       latency_eff   = f_hot * t_mem_seek   + (1 - f_hot) * t_disk_seek
+```
+
+Warming-pays-off threshold:
+
+```
+M_warm ≥ T_warm_load / (T_query_cold - T_query_hot)
+```
+
+The denominator collapses to ≈ 0 when `R_free ≫ W_warm`, matching the
+empirical Phase M result that warming is pointless when everything
+already fits. The numerator is small because warming is one sequential
+scan. Warming pays off when `R_free ≪ W_warm` and `M ≥ small`.
+
+## Hardware constants and calibration
+
+The four hardware constants (`S_mem_seq`, `S_disk_seq`, `t_mem_seek`,
+`t_disk_seek`) need to be set correctly for the running machine. Three
+options, in increasing accuracy:
+
+1. **Defaults**. SSD-typical numbers are within an order of magnitude
+   on most consumer hardware; the cost model uses these for regime
+   selection, not for second-decimal optimization. This is the default
+   and good enough for groundwork.
+2. **User override**. The Prolog predicates accept a `constants/1`
+   option list so callers can plug machine-specific numbers (e.g.
+   from `dd if=/dev/zero of=test bs=1M count=1024` measurements).
+3. **Calibration probe**. A future enhancement: at startup, time a
+   small synthetic scan + seek workload and write the resulting
+   constants to a per-machine cache file. This isn't built yet because
+   we're not at a scale where second-decimal accuracy matters.
+
+What does matter is that the *order of magnitude* is right. Mixing up
+SSD-typical seek latency (100 µs) with HDD-typical (10 ms) shifts the
+crossover by 100×. Knowing whether the storage is rotational or solid-
+state is the single most important calibration input.
+
+## Why first-principles, not measured
+
+We could pre-compute K_cross by running M1.b on every fixture every
+time. We don't, because:
+
+1. **Generality**: a measured number describes the fixture you measured,
+   not the next fixture. The formula generalises across DB sizes.
+2. **Composability**: when the workload changes (different X, different
+   M, different access pattern), measured numbers are stale. The
+   formula tracks.
+3. **Auditability**: a reader can trace why the model picks a given
+   strategy. With a measured table, "the table said so" is the only
+   explanation.
+4. **Speed**: the formula evaluates in microseconds. Repeated
+   measurement-driven recalibration is overkill at typical query
+   rates.
+
+Measurements still play a role — they're how we *validate* the formula's
+predictions and how we *calibrate* the constants. But the day-to-day
+regime decisions come from the closed form.
+
+## Connection to other resolvers
+
+UnifyWeaver already has two cost-style resolvers in production:
+
+- `resolve_auto_use_lmdb/2` in `wam_haskell_target.pl` — picks LMDB
+  vs IntMap from a `fact_count` threshold.
+- `resolve_auto_demand_bfs_mode/2` — picks cursor BFS vs in-memory
+  IntMap from the same threshold (50,000 facts).
+- The C# query target's `source_mode` resolver in
+  `docs/design/CSHARP_QUERY_SOURCE_MODE_*.md` follows a similar
+  pattern.
+
+The cache cost model is the third in this family. The pattern they
+share:
+
+- **Inputs are workload metadata + cheap system probes**. Not running
+  the workload to find out.
+- **Output is a structural choice**, not a tunable knob. Pick `cursor`
+  or `in_memory`, not "set cache size to 9.7 MB".
+- **Defaults are conservative**. When the model can't tell, fall back
+  to the safest of the candidate strategies.
+- **User override is always available**. The model is a default
+  picker, not a gatekeeper.
+
+Phase 2c will add a fourth resolver, `resolve_auto_cache_strategy/2`,
+that uses `cost_model.pl` as its decision engine. That resolver is
+not built yet — it needs the workload-metadata channel (`K_query`,
+`M`, `X_query`) plumbed through the codegen pipeline first.
+
+## What this isn't
+
+- **A runtime tuner**. The model picks one strategy at codegen time
+  and sticks with it. Adaptive runtime switching (e.g. "scan first,
+  detect that cache is filling, switch to seeks") is a different
+  problem class.
+- **A workload predictor**. The model takes workload metadata as
+  input. It doesn't predict, from past queries, what the next query
+  will look like. That's what cache warming with query-history
+  policies is for, which is downstream of this groundwork.
+- **A correctness device**. Both sort and scan return the same
+  answer; the model is purely a performance hint. Pick the wrong
+  one and you get a slow query, never a wrong one.
+
+## See also
+
+- `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` — Phase M appendix #10
+  (measurements that motivate the formula).
+- `examples/benchmark/cache_warming_microbench/` — the M1/M1.b/M2/M3
+  microbench that produced those measurements.
+- `src/unifyweaver/core/cost_model.pl` — the formula implementation.
+- `tests/core/test_cost_model.pl` — unit tests for the predicates
+  with the simplewiki/enwiki crossover values from this document.

--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -3268,3 +3268,198 @@ swipl -q -s examples/benchmark/generate_wam_haskell_matrix_benchmark.pl -- \
 (cd /tmp/wam_enwiki_cursor && cabal new-build)
 .../wam-haskell-matrix-bench data/benchmark/enwiki_cats/lmdb_proj_resident +RTS -N4
 ```
+
+## Phase M appendix #10: cache-warming microbench (Phase 2c prerequisites) (2026-05-09)
+
+### Why
+
+Before building a cost-model auto-resolver for the cache layer, we
+need empirical inputs the resolver can consume. The hand-wavy version
+"warm hot edges" hides three independent cost classes:
+
+1. *Read-pattern cost*: how much do we save by batching/sequencing
+   reads vs doing them one at a time on demand?
+2. *Ranker cost*: what does it actually cost to compute the score
+   used to pick "hot" edges? Different rankers (PPR, hop distance,
+   semantic similarity) have very different cost classes.
+3. *Crossover M*: how many queries does a workload need before
+   warming amortises its cost?
+
+The Hadoop folklore "scans beat seeks" is real but conditional on
+selection ratio, hardware, and data size. Phase M measures these on
+our actual fixtures so any "warming pays off / doesn't pay off"
+claim downstream is grounded in numbers, not intuition.
+
+### Setup
+
+`examples/benchmark/cache_warming_microbench/` — standalone cabal
+project that opens a Phase 1 LMDB fixture (`category_child` dupsort
+sub-db) and runs three sub-benches:
+
+- **M1**: same workload (resolve dupsort values for N keys) under
+  five access patterns: `PerLookupCursor`, `SharedInOrder`,
+  `SharedSorted`, `SharedShuffled`, `FullScan`.
+- **M1.b**: scan-vs-seek crossover sweep — sorted-seek time vs
+  full-scan time at six selection ratios on the same N=10k key set.
+- **M2**: ranker overhead — PPR/Flux one iteration, streaming-hop
+  one pass (B-tree frontier propagation, per the algorithm sketched
+  in this conversation), stub semantic similarity (D=128 dot
+  products on K=1000 candidates).
+- **M3**: warming-vs-JIT crossover — M random 3-hop BFS queries
+  against (a) cold cursor path, (b) IntMap pre-warmed with top-5000
+  source nodes by out-degree.
+
+Hardware: same WSL2 machine as Phase L appendices. GHC 8.6.5,
+single-threaded, GHC `-O1` (cabal default for `new-build`).
+
+### M1: read patterns at simplewiki scale (10k keys → 78,751 edges)
+
+| pattern            | wall_ms | edges_collected |
+|---|---|---|
+| PerLookupCursor    |   275   | 78,751 |
+| SharedInOrder      |     5.4 | 78,751 |
+| SharedSorted       |     4.0 | 78,751 |
+| SharedShuffled     |    14.4 | 78,751 |
+| FullScan           |    13.4 | 78,751 |
+
+**Headline numbers**:
+
+- **65× penalty** for opening a fresh cursor per key vs reusing one.
+  This is already addressed in the runtime (cursor BFS shares cursors
+  via `DupsortCursorCache`), but the magnitude is worth recording —
+  any future change that breaks cursor reuse would be catastrophic.
+- **3.5× penalty** for shuffled-key seeks vs sorted seeks. LMDB pages
+  are mmap'd; sequential key access is page-friendly, random access
+  trips through the page table.
+- At ~3.4% selection (10k of 297k edges touched), full scan is **3.3×
+  slower** than sorted seeks. Scan is *not* universally faster.
+
+### M1.b: selectivity sweep (sorted seeks vs full scan)
+
+Same N=10k key sample, time both patterns on progressively-smaller
+subsets:
+
+| key_fraction | n_keys | sorted_ms | scan_ms | scan / sorted |
+|---|---|---|---|---|
+| 0.01 |   100 |  0.077 |  5.8 | **76.1×** |
+| 0.05 |   500 |  0.238 |  6.1 | 25.7× |
+| 0.10 | 1,000 |  0.513 |  6.5 | 12.6× |
+| 0.25 | 2,500 |  1.1   |  6.6 |  5.9× |
+| 0.50 | 5,000 |  2.2   | 10.1 |  4.6× |
+| 1.00 |10,000 |  4.7   | 13.2 |  2.8× |
+
+Sorted seeks beat scan at every measured ratio. Linear-extrapolating
+the sorted-seek cost (~0.47 ms per 1k keys) and treating scan as
+fixed cost (~6 ms intercept + small slope), the projected scan-vs-
+seek crossover lands somewhere around **N ≈ 13k–25k keys** of the
+~144k true source population — i.e. **~10–18% true selection**.
+
+The Hadoop "scans beat seeks" framing is correct but applies at a
+specific operating regime: workloads that touch a high fraction of
+the data per query, hardware where random page access is much
+slower than sequential (spinning disks; or memory-pressured VMs
+where mmap pages aren't resident), and queries that don't benefit
+from caching across calls. None of those apply to category-graph
+demand BFS at simplewiki scale on this hardware. They might apply
+on different hardware or at different selection ratios — *the cost
+model needs the workload's selection ratio as an input*.
+
+### M2: ranker overhead (simplewiki, 297,283 edges, 144k sources)
+
+| ranker                       | wall_ms | output_size |
+|---|---|---|
+| PPR/Flux 1 iter              | 80.1   | 43,974 |
+| streaming-hop 1 pass         |  2.7   |    144 |
+| semantic-sim K=1000 D=128    |  2.8   |  1,000 |
+
+**Cost classes confirmed**:
+
+- **PPR is heavyweight** — 80 ms for one iteration over the full
+  edge list. PPR is only viable as a warming-decision input if its
+  cost amortises over many queries. Treating one query as ~0.5–1 ms
+  of cold-cursor work, **PPR pays for itself only at M ≥ ~80–160
+  queries**, and only if warming itself produces a measurable speedup.
+- **Streaming-hop is essentially free** — 2.7 ms because the
+  frontier-propagation loop only does work proportional to the
+  frontier size (here seeded with 10 sources, 1-hop expansion =
+  144 outputs). Multi-pass convergence would cost N × this. The
+  user's algorithmic intuition was right: this is the right shape
+  for a per-query-affordable ranker.
+- **Stub semantic similarity** is K-bound: 2.8 ms for K=1000, D=128.
+  Production embeddings would be more expensive (real vector loads,
+  not synthetic `sin(c*i)`), but the cost class is still O(K·D),
+  not O(E).
+
+### M3: warming-vs-JIT crossover (3-hop BFS from random roots)
+
+| M (queries) | cold_ms | warm_ms | speedup |
+|---|---|---|---|
+|   1 | 0.016 | 0.008 | 2.1× |
+|   5 | 0.055 | 0.040 | 1.4× |
+|  10 | 0.107 | 0.109 | 0.98× |
+|  25 | 2.2   | 0.293 | 7.6× *(noise outlier — cold path stalled)* |
+|  50 | 0.343 | 0.378 | 0.91× |
+| 100 | 0.458 | 0.461 | 0.99× |
+| 250 | 0.841 | 0.883 | 0.95× |
+
+**Warming with top-K-by-out-degree does not pay off** for random-BFS
+queries on simplewiki. Speedups hover at 1× ± measurement noise.
+
+This is workload-specific, not a general result. The warming policy
+("top-K source nodes by out-degree") doesn't match the query traffic
+("BFS from random roots"). High out-degree nodes aren't necessarily
+the nodes the queries visit. To make warming pay, the policy needs a
+signal correlated with query traffic — query-history-driven warming,
+or a ranker informed by query endpoints (streaming-hop seeded from
+recent query roots), not a static graph metric.
+
+### Cost-model takeaways
+
+The auto-resolver's input vector should include at least:
+
+1. **`selection_ratio_estimate`** — selection ratio of the typical
+   query against the full edge set. Below ~10–15%, prefer sorted
+   seeks; above, consider full scan. Below 1%, scans are 76× too
+   expensive.
+2. **`expected_query_count`** — M, the number of queries amortising
+   any warming work. PPR-class rankers pay off only at M ≥ ~80–160.
+   Streaming-hop is cheap enough to run per-query.
+3. **`workload_locality`** — proxy for how many queries hit the
+   same hot region. Without this signal, default to no warming
+   (M3 result).
+4. **`available_ram`** — already in the proposed input vector.
+   Caps the warm-set size.
+
+The resolver itself should be small (cost-class tables + thresholds),
+not a runtime ML model. Streaming-hop is cheap enough to be a default
+*per-query* ranker if a warm cache exists; PPR should be opt-in.
+
+### Caveats
+
+- **Hardware**: WSL2, mmap-backed; results would shift on cold-disk-
+  pressured systems where random-page access dominates. The
+  "scans beat seeks" regime is reachable, just not on this setup.
+- **Workload**: random-BFS from random roots is one shape. Repeated
+  queries from a small hot root set would change M3's verdict.
+- **Warming policy**: only top-K-by-out-degree was measured. A
+  query-history-driven policy is the natural follow-up; not
+  measured here.
+- **Single-pass streaming-hop**: M2 measures *one* pass. Multi-pass
+  convergence would multiply the cost; for warming purposes one
+  pass is usually enough (per the user's algorithm sketch).
+- **Sample-key bias**: `sampleDistinctKeys` returns ascending-order
+  keys, so `SharedInOrder` is approximately `SharedSorted` in
+  practice. The shuffle vs sort comparison is the meaningful one.
+
+### Reproducer
+
+```bash
+(cd examples/benchmark/cache_warming_microbench && cabal new-build)
+.../cache-warming-microbench \
+    data/benchmark/simplewiki_cats/lmdb_proj_resident/lmdb 10000 42
+# Or 1k_resident_run, or enwiki_cats/lmdb_proj_resident.
+```
+
+Phase M is measurement-only; no production codegen change. The
+cost-model resolver itself remains deferred to Phase 2c, but it now
+has empirical inputs to consume.

--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -3463,3 +3463,116 @@ not a runtime ML model. Streaming-hop is cheap enough to be a default
 Phase M is measurement-only; no production codegen change. The
 cost-model resolver itself remains deferred to Phase 2c, but it now
 has empirical inputs to consume.
+
+### Cost-model formula (cache-regime aware)
+
+The "10–18% selection crossover" reported above is conditional on the
+working set fitting in the page cache. On databases that exceed
+**free** RAM (note: on WSL, this swings dynamically as the host
+reclaims pages — `/proc/meminfo:MemAvailable`, not `MemTotal`), the
+crossover shifts left dramatically because random seeks become real
+disk operations.
+
+**Variables**:
+
+| symbol | meaning |
+|---|---|
+| `W` | bytes a full scan would touch (≈ DB size on disk) |
+| `X` | working-set fraction the workload actually uses (BFS reachability fraction; cumulative across M queries: union of working sets) |
+| `R_free` | **free** RAM available to the process (`/proc/meminfo:MemAvailable`) |
+| `S_mem_seq` | sequential read throughput when data is page-cached (~5 GB/s mmap memcpy) |
+| `S_disk_seq` | sequential read throughput from cold storage (~500 MB/s SSD, ~100 MB/s HDD) |
+| `t_mem_seek` | one B-tree-walk seek with leaves cached (~1 µs) |
+| `t_disk_seek` | one B-tree-walk seek with the leaf not cached (~100 µs SSD, ~10 ms HDD) |
+| `K` | number of distinct keys the query looks up |
+
+**Cache-regime weight**:
+
+```
+W_working = X * W
+f_hot     = min(1, R_free / W_working)
+```
+
+`f_hot = 1` is the all-RAM regime we measured. `f_hot = 0` is the
+cold-disk regime Hadoop was designed for.
+
+**Effective costs**:
+
+```
+T_scan = W_working * [f_hot / S_mem_seq + (1 - f_hot) / S_disk_seq]
+T_sort = K         * [f_hot * t_mem_seek + (1 - f_hot) * t_disk_seek]
+```
+
+**Crossover K** (sort = scan):
+
+```
+K_cross = W_working / [bandwidth_eff * latency_eff]
+        where
+          bandwidth_eff = f_hot * S_mem_seq    + (1 - f_hot) * S_disk_seq
+          latency_eff   = f_hot * t_mem_seek   + (1 - f_hot) * t_disk_seek
+```
+
+If `K_query < K_cross` → sorted seeks. Otherwise → scan.
+
+**Plugged in**:
+
+| regime | W_working | bw_eff | lat_eff | K_cross | as % keys |
+|---|---|---|---|---|---|
+| simplewiki, hot (R_free ≫ W) | 15 MB | 5 GB/s | 1 µs | ~3,000 | ~2% |
+| simplewiki, cold (R_free ≪ W) | 15 MB | 500 MB/s | 100 µs | ~300 | ~0.2% |
+| enwiki, hot (R_free ≫ W) | 500 MB | 5 GB/s | 1 µs | ~100,000 | ~10% |
+| enwiki, cold (R_free ≪ W) | 500 MB | 500 MB/s | 100 µs | ~10,000 | ~1% |
+
+The hot-regime simplewiki value (~2%) is consistent with M1.b: sort
+beats scan at all measured ratios up to 7% true selection.
+
+**Warming-pays-off threshold** — for M queries each touching `K_q`
+keys, warming a working set of `W_warm` bytes pays off at:
+
+```
+M_warm ≥ T_warm_load / (T_query_cold - T_query_hot)
+```
+
+The denominator collapses to ≈ 0 when `R_free ≫ W_warm` (matches our
+M3 simplewiki result — warming is pointless when everything's already
+cached). The numerator stays small because warming is one sequential
+scan. So warming pays off when `R_free ≪ W_warm` and `M ≥ small`.
+
+**What the resolver should read**:
+
+- `R_free` from `/proc/meminfo:MemAvailable` (recheck per-bench, since
+  WSL claims/releases pages dynamically).
+- `W` from `mdb_env_info.me_mapsize` or `stat()` of the data file.
+- `X_query`, `K_query`, `M` from workload metadata; defaults derivable
+  from BFS-depth heuristics + declared workload type.
+
+The hardware constants (`S_mem_seq`, `S_disk_seq`, `t_mem_seek`,
+`t_disk_seek`) need a one-time per-machine calibration probe. SSD-
+typical defaults are within an order of magnitude on commodity
+hardware; the order of magnitude is what matters for the regime
+selection, not the second decimal place.
+
+### When this matters
+
+Categories-only fixtures (simplewiki ≈ 15 MB, enwiki ≈ 500 MB) fit
+in any modern machine's free RAM. The cost model is groundwork, not
+an immediate optimization — at this scale, all regimes are `f_hot ≈ 1`
+and the formula reduces to "sorted seeks always".
+
+The regime starts to matter at:
+
+- **Article-level Wikipedia ingest** — full enwiki article texts are
+  ~80 GB compressed, ~250 GB uncompressed. Past free RAM on any
+  consumer machine.
+- **Multi-fixture aggregation** (e.g. enwiki categories + page
+  metadata + revision counts joined into one LMDB).
+- **Memory-pressured environments** — WSL2 in particular, where the
+  Windows host can reclaim large fractions of the VM's RAM.
+- **Spinning-disk targets** — `t_disk_seek` jumps 100×, shifting the
+  crossover left aggressively.
+
+The Prolog predicates in `src/unifyweaver/core/cost_model.pl`
+implement these formulas. They're opt-in: callers pass `cost_model`
+options to enable, otherwise targets fall back to the existing
+fact-count-threshold heuristic.
+

--- a/examples/benchmark/cache_warming_microbench/.gitignore
+++ b/examples/benchmark/cache_warming_microbench/.gitignore
@@ -1,0 +1,5 @@
+dist/
+dist-newstyle/
+*.hi
+*.o
+.ghc.environment.*

--- a/examples/benchmark/cache_warming_microbench/cache-warming-microbench.cabal
+++ b/examples/benchmark/cache_warming_microbench/cache-warming-microbench.cabal
@@ -1,0 +1,21 @@
+cabal-version: 2.4
+name:          cache-warming-microbench
+version:       0.1.0.0
+synopsis:      Phase M measurement spike — read patterns, ranker overhead, warming-vs-JIT crossover
+license:       MIT
+build-type:    Simple
+
+executable cache-warming-microbench
+  main-is:          Main.hs
+  hs-source-dirs:   src
+  other-modules:    Patterns, Rankers, Crossover
+  build-depends:    base >= 4.12,
+                    containers >= 0.6,
+                    bytestring,
+                    time >= 1.8,
+                    deepseq >= 1.4,
+                    mtl,
+                    lmdb >= 0.2.5,
+                    random >= 1.2
+  default-language: Haskell2010
+  ghc-options:      -O2 -rtsopts -threaded

--- a/examples/benchmark/cache_warming_microbench/src/Crossover.hs
+++ b/examples/benchmark/cache_warming_microbench/src/Crossover.hs
@@ -1,0 +1,92 @@
+-- SPDX-License-Identifier: MIT
+-- M3: warming-vs-JIT crossover.
+--
+-- Run M random queries against:
+--   (a) cold path: per-query LMDB cursor seeks for the keys it touches
+--   (b) warmed:    pre-load top-K keys into an IntMap; fall through to
+--                  cursor only on miss.
+--
+-- Find the break-even M (queries-per-warmup) where (b) beats (a) by
+-- a margin worth a cost-model decision. The "K" budget we choose is
+-- arbitrary for Phase M — we just want the crossover shape.
+
+{-# LANGUAGE BangPatterns #-}
+
+module Crossover
+  ( runCrossover
+  , RunResult(..)
+  ) where
+
+import Control.Monad (forM, forM_)
+import Data.Int (Int32)
+import qualified Data.IntMap.Strict as IM
+import qualified Data.IntSet as IS
+import Data.List (foldl')
+import Data.Time.Clock (diffUTCTime, getCurrentTime)
+import Foreign.Marshal.Alloc (alloca, allocaBytes)
+import Foreign.Ptr (Ptr, castPtr, nullPtr)
+import Foreign.Storable (peek, poke, peekElemOff)
+import Database.LMDB.Raw
+import System.Random (mkStdGen, randoms)
+
+data RunResult = RunResult
+  { rrTotalMs   :: !Double
+  , rrEdgeReads :: !Int
+  , rrCacheHits :: !Int
+  } deriving Show
+
+-- | Run M BFS-shaped queries from random roots, max-hops=3.
+runCrossover :: MDB_env -> String -> [Int] -> Int -> Maybe (IM.IntMap [Int]) -> IO RunResult
+runCrossover env dbName roots maxHops mWarm = do
+    txn <- mdb_txn_begin env Nothing True
+    dbi <- mdb_dbi_open' txn (Just dbName) [MDB_DUPSORT]
+    cursor <- mdb_cursor_open' txn dbi
+    t0 <- getCurrentTime
+    (!totalReads, !totalHits) <- foldQueries cursor mWarm roots
+    t1 <- getCurrentTime
+    mdb_txn_abort txn
+    let !ms = realToFrac (diffUTCTime t1 t0) * 1000.0
+    return $ RunResult ms totalReads totalHits
+  where
+    foldQueries _ _ [] = return (0, 0)
+    foldQueries cur warm (r:rs) = do
+      (rd, hi) <- bfs cur warm r maxHops
+      (rd', hi') <- foldQueries cur warm rs
+      return (rd + rd', hi + hi')
+
+    bfs cur warm root hops = go IS.empty (IS.singleton root) 0 0 0
+      where
+        go _ frontier !depth !reads !hits
+          | IS.null frontier || depth >= hops = return (reads, hits)
+          | otherwise = do
+              let nodes = IS.toList frontier
+              (!newEdges, !rd, !hi) <- expand cur warm nodes
+              let nextFrontier = IS.fromList newEdges `IS.difference` frontier
+              go (frontier `IS.union` nextFrontier) nextFrontier (depth+1) (reads + rd) (hits + hi)
+
+    expand _ _ []     = return ([], 0, 0)
+    expand cur warm (n:ns) = do
+      (xs, !rd, !hi) <- lookupOne cur warm n
+      (ys, !rd', !hi') <- expand cur warm ns
+      return (xs ++ ys, rd + rd', hi + hi')
+
+    lookupOne cur warm n = case warm of
+      Just m | Just vs <- IM.lookup n m -> return (vs, 0, 1)
+      _                                 -> do
+        vs <- countDupsCollect cur n
+        return (vs, length vs, 0)
+
+countDupsCollect :: MDB_cursor' -> Int -> IO [Int]
+countDupsCollect cursor key =
+    allocaBytes 4 $ \kp -> do
+      poke (castPtr kp :: Ptr Int32) (fromIntegral key)
+      alloca $ \kvPtr -> alloca $ \dvPtr -> do
+        poke kvPtr (MDB_val 4 kp)
+        found <- mdb_cursor_get' MDB_SET cursor kvPtr dvPtr
+        if not found then return [] else walk kvPtr dvPtr []
+  where
+    walk kvPtr dvPtr acc = do
+      MDB_val vsz vp <- peek dvPtr
+      v <- if vsz >= 4 then fromIntegral <$> peekElemOff (castPtr vp :: Ptr Int32) 0 else return 0
+      more <- mdb_cursor_get' MDB_NEXT_DUP cursor kvPtr dvPtr
+      if more then walk kvPtr dvPtr (v : acc) else return (v : acc)

--- a/examples/benchmark/cache_warming_microbench/src/Main.hs
+++ b/examples/benchmark/cache_warming_microbench/src/Main.hs
@@ -1,0 +1,217 @@
+-- SPDX-License-Identifier: MIT
+-- Phase M (Measurement) — cache warming microbench driver.
+--
+-- Usage:
+--   cache-warming-microbench <lmdb_dir> [N=10000] [seed=42]
+--
+-- Reads from a Phase 1 LMDB directory (containing category_child
+-- as the dupsort sub-db). Runs M1, M2, M3 and prints a markdown
+-- summary table to stdout.
+
+{-# LANGUAGE BangPatterns #-}
+
+module Main where
+
+import Control.DeepSeq (deepseq, force)
+import Control.Exception (evaluate)
+import Control.Monad (forM_, when)
+import Data.Int (Int32)
+import qualified Data.IntMap.Strict as IM
+import qualified Data.IntSet as IS
+import Data.List (sort, sortBy)
+import Data.Ord (comparing, Down(..))
+import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
+import Foreign.Marshal.Alloc (alloca)
+import Foreign.Ptr (Ptr, castPtr, nullPtr)
+import Foreign.Storable (peek, poke, peekElemOff)
+import System.Environment (getArgs)
+import System.IO (hFlush, stdout)
+import System.Random (mkStdGen, randoms)
+import Database.LMDB.Raw
+
+import Patterns (Pattern(..), runPatternBench)
+import Rankers (collectAllEdges, pprIteration, streamingHop, semanticSim)
+import Crossover (runCrossover, RunResult(..))
+
+main :: IO ()
+main = do
+    args <- getArgs
+    let (lmdbDir, nKeys, seed) = case args of
+          [d]       -> (d, 10000 :: Int, 42 :: Int)
+          [d, n]    -> (d, read n, 42)
+          [d, n, s] -> (d, read n, read s)
+          _         -> error "usage: cache-warming-microbench <lmdb_dir> [N] [seed]"
+
+    putStrLn $ "# Phase M microbench"
+    putStrLn $ ""
+    putStrLn $ "- LMDB: " ++ lmdbDir
+    putStrLn $ "- N (keys): " ++ show nKeys
+    putStrLn $ "- seed: " ++ show seed
+    putStrLn $ ""
+
+    env <- mdb_env_create
+    mdb_env_set_mapsize env (16 * 1024 * 1024 * 1024)  -- 16 GB ceiling
+    mdb_env_set_maxdbs env 8
+    mdb_env_set_maxreaders env 126
+    mdb_env_open env lmdbDir [MDB_RDONLY]
+
+    -- Sample N distinct keys from category_child
+    sampleKeys <- sampleDistinctKeys env "category_child" nKeys seed
+    let nActual = length sampleKeys
+    putStrLn $ "Sampled " ++ show nActual ++ " distinct keys from category_child"
+    putStrLn ""
+
+    -- =====================================================================
+    -- M1: read patterns
+    -- =====================================================================
+    putStrLn "## M1: read patterns"
+    putStrLn ""
+    putStrLn "| pattern | wall_ms | edges_collected |"
+    putStrLn "|---|---|---|"
+    forM_ [PerLookupCursor, SharedInOrder, SharedSorted, SharedShuffled, FullScan] $ \pat -> do
+      (ms, n) <- runPatternBench env "category_child" sampleKeys pat
+      putStrLn $ "| " ++ show pat ++ " | " ++ fmt ms ++ " | " ++ show n ++ " |"
+      hFlush stdout
+    putStrLn ""
+
+    -- M1.b: selectivity sweep — scan vs sorted seeks crossover.
+    -- Take a fraction of the sampled keys and time both patterns.
+    putStrLn "## M1.b: selectivity sweep (sorted seeks vs full scan)"
+    putStrLn ""
+    putStrLn "| key_fraction | n_keys | sorted_ms | scan_ms | scan/sorted |"
+    putStrLn "|---|---|---|---|---|"
+    forM_ [0.01, 0.05, 0.1, 0.25, 0.5, 1.0 :: Double] $ \frac -> do
+      let k = max 1 $ round (frac * fromIntegral nActual)
+          subset = take k sampleKeys
+      (ms_sorted, _) <- runPatternBench env "category_child" subset SharedSorted
+      (ms_scan, _)   <- runPatternBench env "category_child" subset FullScan
+      let ratio = if ms_sorted > 0 then ms_scan / ms_sorted else 0
+      putStrLn $ "| " ++ fmt frac ++ " | " ++ show k
+              ++ " | " ++ fmt ms_sorted ++ " | " ++ fmt ms_scan
+              ++ " | " ++ fmt ratio ++ "× |"
+      hFlush stdout
+    putStrLn ""
+
+    -- =====================================================================
+    -- M2: ranker overhead
+    -- =====================================================================
+    putStrLn "## M2: ranker overhead"
+    putStrLn ""
+    putStrLn "Loading full edge list once for shared-input rankers..."
+    t0 <- getCurrentTime
+    edges <- collectAllEdges env "category_child"
+    let !edgeCount = length edges
+    edges `deepseq` return ()
+    t1 <- getCurrentTime
+    putStrLn $ "  edges loaded: " ++ show edgeCount ++ " in " ++ fmt (diffMs t0 t1) ++ " ms"
+    putStrLn ""
+
+    -- Initial scores: uniform 1.0 over all source nodes.
+    let !sources = IS.fromList [u | (u, _) <- edges]
+        !initScores = IM.fromList [(s, 1.0 :: Double) | s <- IS.toList sources]
+        !outdeg = IM.fromListWith (+) [(u, 1 :: Int) | (u, _) <- edges]
+
+    putStrLn "| ranker | wall_ms | output_size |"
+    putStrLn "|---|---|---|"
+
+    -- PPR one iteration
+    tA <- getCurrentTime
+    let !ppr = pprIteration initScores outdeg edges
+    evaluate (force ppr) >>= \_ -> return ()
+    tB <- getCurrentTime
+    putStrLn $ "| PPR/Flux 1 iter | " ++ fmt (diffMs tA tB) ++ " | " ++ show (IM.size ppr) ++ " |"
+    hFlush stdout
+
+    -- Streaming hop, frontier seeded from first 10 sources
+    let !seedFrontier = IM.fromList [(s, 0) | s <- take 10 (IS.toList sources)]
+    tC <- getCurrentTime
+    let !hops = streamingHop seedFrontier edges
+    evaluate (force hops) >>= \_ -> return ()
+    tD <- getCurrentTime
+    putStrLn $ "| streaming-hop 1 pass | " ++ fmt (diffMs tC tD) ++ " | " ++ show (IM.size hops) ++ " |"
+    hFlush stdout
+
+    -- Semantic similarity stub on K=1000 candidates
+    let !candidates = take 1000 (IS.toList sources)
+    tE <- getCurrentTime
+    let !sims = semanticSim candidates
+    evaluate (force sims) >>= \_ -> return ()
+    tF <- getCurrentTime
+    putStrLn $ "| semantic-sim K=1000 D=128 | " ++ fmt (diffMs tE tF) ++ " | " ++ show (length sims) ++ " |"
+    putStrLn ""
+
+    -- =====================================================================
+    -- M3: warming-vs-JIT crossover
+    -- =====================================================================
+    putStrLn "## M3: warming-vs-JIT crossover"
+    putStrLn ""
+    putStrLn $ "BFS-shaped queries (max_hops=3) from random roots."
+    putStrLn ""
+
+    -- Warm cache: top-K source nodes by out-degree (a proxy for "hot" edges).
+    let warmK = min 5000 (IM.size outdeg)
+        topK = take warmK $ sortBy (comparing (Down . snd)) $ IM.toList outdeg
+        !warmKeys = IS.fromList (map fst topK)
+    -- Pre-load their edges into IntMap.
+    let !warmMap = IM.fromListWith (++) [(u, [v]) | (u, v) <- edges, u `IS.member` warmKeys]
+    evaluate (force warmMap) >>= \_ -> return ()
+    putStrLn $ "Warmed top-" ++ show warmK ++ " source nodes into IntMap."
+    putStrLn ""
+
+    putStrLn "| M (queries) | cold_ms | warm_ms | cold_per_q | warm_per_q | speedup |"
+    putStrLn "|---|---|---|---|---|---|"
+    forM_ [1, 5, 10, 25, 50, 100, 250] $ \m -> do
+      let roots = take m (sampleKeys ++ cycle sampleKeys)
+      cold <- runCrossover env "category_child" roots 3 Nothing
+      warm <- runCrossover env "category_child" roots 3 (Just warmMap)
+      let cms = rrTotalMs cold
+          wms = rrTotalMs warm
+          cpq = cms / fromIntegral m
+          wpq = wms / fromIntegral m
+          sp  = if wms > 0 then cms / wms else 0
+      putStrLn $ "| " ++ show m ++ " | " ++ fmt cms ++ " | " ++ fmt wms
+              ++ " | " ++ fmt cpq ++ " | " ++ fmt wpq
+              ++ " | " ++ fmt sp ++ "× |"
+      hFlush stdout
+    putStrLn ""
+
+    mdb_env_close env
+    putStrLn "## End"
+
+fmt :: Double -> String
+fmt x
+  | x >= 100   = show (round x :: Int)
+  | x >= 1     = show (fromIntegral (round (x * 10) :: Int) / 10 :: Double)
+  | otherwise  = show (fromIntegral (round (x * 1000) :: Int) / 1000 :: Double)
+
+-- | Difference between two UTCTimes in milliseconds.
+diffMs :: UTCTime -> UTCTime -> Double
+diffMs t0 t1 = realToFrac (diffUTCTime t1 t0) * 1000.0
+
+-- | Sample N distinct keys from a dupsort sub-db using MDB_FIRST + skip stride.
+-- Deterministic for a given (seed, N, db_size).
+sampleDistinctKeys :: MDB_env -> String -> Int -> Int -> IO [Int]
+sampleDistinctKeys env dbName n seed = do
+    txn <- mdb_txn_begin env Nothing True
+    dbi <- mdb_dbi_open' txn (Just dbName) [MDB_DUPSORT]
+    cursor <- mdb_cursor_open' txn dbi
+    !allKeys <- alloca $ \kvPtr -> alloca $ \dvPtr -> do
+                  poke kvPtr (MDB_val 0 nullPtr)
+                  poke dvPtr (MDB_val 0 nullPtr)
+                  found <- mdb_cursor_get' MDB_FIRST cursor kvPtr dvPtr
+                  collectKeys cursor kvPtr dvPtr found IS.empty
+    mdb_txn_abort txn
+    let allList = IS.toAscList allKeys
+        size = length allList
+        gen  = mkStdGen seed
+        idxs = take n . IS.toAscList . IS.fromList . map (`mod` size) . take (n * 2) $ randoms gen
+        chosen = [ allList !! i | i <- idxs ]
+    return (take n chosen)
+  where
+    collectKeys _ _ _ False acc = return acc
+    collectKeys cur kvPtr dvPtr True acc = do
+      MDB_val ksz kp <- peek kvPtr
+      k <- if ksz >= 4 then fromIntegral <$> peekElemOff (castPtr kp :: Ptr Int32) 0 else return 0
+      -- Skip duplicate keys: jump to next *distinct* key via MDB_NEXT_NODUP.
+      more <- mdb_cursor_get' MDB_NEXT_NODUP cur kvPtr dvPtr
+      collectKeys cur kvPtr dvPtr more (IS.insert k acc)

--- a/examples/benchmark/cache_warming_microbench/src/Patterns.hs
+++ b/examples/benchmark/cache_warming_microbench/src/Patterns.hs
@@ -1,0 +1,124 @@
+-- SPDX-License-Identifier: MIT
+-- M1: LMDB read-pattern microbench.
+--
+-- Same workload (resolve dupsort values for N keys) under five access
+-- patterns. The comparison the cost model needs is "scan time vs
+-- cumulative seek time" — i.e. when does E (full-table sequential scan)
+-- beat C (sorted-key seeks) for a given N?
+
+{-# LANGUAGE BangPatterns #-}
+
+module Patterns
+  ( runPatternBench
+  , Pattern(..)
+  ) where
+
+import Control.DeepSeq (deepseq)
+import Control.Monad (forM_, when)
+import Data.Int (Int32)
+import qualified Data.IntMap.Strict as IM
+import qualified Data.IntSet as IS
+import Data.List (sort)
+import Data.Time.Clock (diffUTCTime, getCurrentTime)
+import Foreign.Marshal.Alloc (alloca, allocaBytes)
+import Foreign.Ptr (Ptr, castPtr, nullPtr)
+import Foreign.Storable (peek, poke, peekElemOff)
+import Database.LMDB.Raw
+
+data Pattern = PerLookupCursor | SharedInOrder | SharedSorted | SharedShuffled | FullScan
+  deriving (Eq, Show)
+
+-- | Run one read pattern against a dupsort sub-db, return (wall_ms, edges_collected).
+runPatternBench :: MDB_env -> String -> [Int] -> Pattern -> IO (Double, Int)
+runPatternBench env dbName keys pat = do
+    t0 <- getCurrentTime
+    !edgeCount <- case pat of
+      PerLookupCursor -> perLookup env dbName keys
+      SharedInOrder   -> sharedCursor env dbName keys
+      SharedSorted    -> sharedCursor env dbName (sort keys)
+      SharedShuffled  -> sharedCursor env dbName (shuffleDeterministic keys)
+      FullScan        -> fullScan env dbName (IS.fromList keys)
+    t1 <- getCurrentTime
+    let !ms = realToFrac (diffUTCTime t1 t0) * 1000.0
+    return (ms, edgeCount)
+
+-- Pattern A: open and close a fresh cursor per key (worst case for setup overhead).
+perLookup :: MDB_env -> String -> [Int] -> IO Int
+perLookup env dbName keys = go 0 keys
+  where
+    go !acc []     = return acc
+    go !acc (k:ks) = do
+      txn <- mdb_txn_begin env Nothing True
+      dbi <- mdb_dbi_open' txn (Just dbName) [MDB_DUPSORT]
+      cursor <- mdb_cursor_open' txn dbi
+      n <- countDups cursor k
+      mdb_txn_abort txn
+      go (acc + n) ks
+
+-- Patterns B/C/D: open one cursor up front, MDB_SET + MDB_NEXT_DUP per key.
+sharedCursor :: MDB_env -> String -> [Int] -> IO Int
+sharedCursor env dbName keys = do
+    txn <- mdb_txn_begin env Nothing True
+    dbi <- mdb_dbi_open' txn (Just dbName) [MDB_DUPSORT]
+    cursor <- mdb_cursor_open' txn dbi
+    !n <- foldKeys cursor 0 keys
+    mdb_txn_abort txn
+    return n
+  where
+    foldKeys _ !acc []     = return acc
+    foldKeys cur !acc (k:ks) = do
+      m <- countDups cur k
+      foldKeys cur (acc + m) ks
+
+-- Count dups for one key (MDB_SET + MDB_NEXT_DUP walk).
+countDups :: MDB_cursor' -> Int -> IO Int
+countDups cursor key =
+    allocaBytes 4 $ \kp -> do
+      poke (castPtr kp :: Ptr Int32) (fromIntegral key)
+      alloca $ \kvPtr -> alloca $ \dvPtr -> do
+        poke kvPtr (MDB_val 4 kp)
+        found <- mdb_cursor_get' MDB_SET cursor kvPtr dvPtr
+        if not found then return 0 else walk kvPtr dvPtr 1
+  where
+    walk kvPtr dvPtr !n = do
+      more <- mdb_cursor_get' MDB_NEXT_DUP cursor kvPtr dvPtr
+      if more then walk kvPtr dvPtr (n+1) else return n
+
+-- Pattern E: full-table sequential scan via MDB_FIRST + MDB_NEXT, only count
+-- entries whose key is in the wanted set.
+fullScan :: MDB_env -> String -> IS.IntSet -> IO Int
+fullScan env dbName wantedKeys = do
+    txn <- mdb_txn_begin env Nothing True
+    dbi <- mdb_dbi_open' txn (Just dbName) [MDB_DUPSORT]
+    cursor <- mdb_cursor_open' txn dbi
+    !n <- alloca $ \kvPtr -> alloca $ \dvPtr -> do
+            poke kvPtr (MDB_val 0 nullPtr)
+            poke dvPtr (MDB_val 0 nullPtr)
+            found0 <- mdb_cursor_get' MDB_FIRST cursor kvPtr dvPtr
+            walkAll cursor kvPtr dvPtr found0 0
+    mdb_txn_abort txn
+    return n
+  where
+    walkAll _ _ _ False !acc = return acc
+    walkAll cur kvPtr dvPtr True !acc = do
+      MDB_val ksz kp <- peek kvPtr
+      kVal <- if ksz >= 4
+              then fromIntegral <$> peekElemOff (castPtr kp :: Ptr Int32) 0
+              else return (0 :: Int)
+      let !acc' = if IS.member kVal wantedKeys then acc + 1 else acc
+      more <- mdb_cursor_get' MDB_NEXT cur kvPtr dvPtr
+      walkAll cur kvPtr dvPtr more acc'
+
+-- Deterministic shuffle for reproducibility (Fisher-Yates with a fixed seed-ish swap).
+shuffleDeterministic :: [Int] -> [Int]
+shuffleDeterministic xs =
+    let arr = IM.fromList (zip [0..] xs)
+        n   = IM.size arr
+        swaps = [(i, ((i * 2654435761) `mod` n)) | i <- [0 .. n-1]]
+        go !m [] = m
+        go !m ((i,j):rest) =
+          let a = m IM.! i
+              b = m IM.! j
+              !m' = IM.insert i b (IM.insert j a m)
+          in go m' rest
+    in IM.elems (go arr swaps)

--- a/examples/benchmark/cache_warming_microbench/src/Rankers.hs
+++ b/examples/benchmark/cache_warming_microbench/src/Rankers.hs
@@ -1,0 +1,102 @@
+-- SPDX-License-Identifier: MIT
+-- M2: ranker overhead microbench.
+--
+-- Three rankers, all consuming the same edge list. The cost classes
+-- are very different even though all three feed into "pick top-K
+-- edges to warm":
+--
+--   - PPR/Flux iteration:   O(E) per iter (sequential pass + score update).
+--   - Streaming hop:        O(E log F) one pass, multi-pass optional.
+--                           Frontier in IntMap; relax each (u,v) seen.
+--   - Stub semantic sim:    O(K * D) — dot product per candidate against
+--                           a fixed query embedding (D=128 floats here).
+--
+-- We're not fighting over correctness here — these are cost-class
+-- microbenches. The ranker's *quality* is a separate question.
+
+{-# LANGUAGE BangPatterns #-}
+
+module Rankers
+  ( pprIteration
+  , streamingHop
+  , semanticSim
+  , collectAllEdges
+  ) where
+
+import Control.DeepSeq (deepseq)
+import Control.Monad (forM_, when)
+import Data.Int (Int32)
+import qualified Data.IntMap.Strict as IM
+import qualified Data.IntSet as IS
+import Data.List (foldl')
+import Data.Time.Clock (diffUTCTime, getCurrentTime)
+import Foreign.Marshal.Alloc (alloca)
+import Foreign.Ptr (Ptr, castPtr, nullPtr)
+import Foreign.Storable (peek, poke, peekElemOff)
+import Database.LMDB.Raw
+
+-- | Pull all (u, v) edges from a dupsort sub-db via MDB_FIRST + MDB_NEXT.
+-- This is the Phase M baseline scan — used by all three rankers.
+collectAllEdges :: MDB_env -> String -> IO [(Int, Int)]
+collectAllEdges env dbName = do
+    txn <- mdb_txn_begin env Nothing True
+    dbi <- mdb_dbi_open' txn (Just dbName) [MDB_DUPSORT]
+    cursor <- mdb_cursor_open' txn dbi
+    edges <- alloca $ \kvPtr -> alloca $ \dvPtr -> do
+              poke kvPtr (MDB_val 0 nullPtr)
+              poke dvPtr (MDB_val 0 nullPtr)
+              found <- mdb_cursor_get' MDB_FIRST cursor kvPtr dvPtr
+              walk cursor kvPtr dvPtr found []
+    mdb_txn_abort txn
+    return (reverse edges)
+  where
+    walk _ _ _ False acc = return acc
+    walk cur kvPtr dvPtr True acc = do
+      MDB_val ksz kp <- peek kvPtr
+      MDB_val vsz vp <- peek dvPtr
+      k <- if ksz >= 4 then fromIntegral <$> peekElemOff (castPtr kp :: Ptr Int32) 0 else return 0
+      v <- if vsz >= 4 then fromIntegral <$> peekElemOff (castPtr vp :: Ptr Int32) 0 else return 0
+      more <- mdb_cursor_get' MDB_NEXT cur kvPtr dvPtr
+      walk cur kvPtr dvPtr more ((k,v) : acc)
+
+-- | One PPR-style iteration: for each edge (u, v), accumulate score[u] += score[v] / outdeg[v].
+-- Returns updated score map. Pure / no IO.
+pprIteration :: IM.IntMap Double -> IM.IntMap Int -> [(Int, Int)] -> IM.IntMap Double
+pprIteration scores outdeg edges =
+    foldl' relax IM.empty edges
+  where
+    relax !acc (u, v) =
+      let sv = IM.findWithDefault 0.0 v scores
+          dv = IM.findWithDefault 1 v outdeg
+          contrib = sv / fromIntegral dv
+      in IM.insertWith (+) u contrib acc
+
+-- | Streaming hop-distance: one pass over edges, propagate (id, hop) via IntMap frontier.
+-- Per the user's algorithm: if u is in frontier at hop h and v isn't (or has higher hop),
+-- record v at h+1.  Single pass; multi-pass convergence not implemented here (Phase M
+-- measures the cost of ONE pass, which is what matters for the resolver decision).
+streamingHop :: IM.IntMap Int -> [(Int, Int)] -> IM.IntMap Int
+streamingHop initialFrontier edges =
+    foldl' relax initialFrontier edges
+  where
+    relax !frontier (u, v) =
+      case IM.lookup u frontier of
+        Nothing -> frontier
+        Just hu ->
+          let hv = hu + 1
+          in case IM.lookup v frontier of
+               Just hv' | hv' <= hv -> frontier
+               _                    -> IM.insert v hv frontier
+
+-- | Stub semantic similarity: dot product of each candidate's embedding
+-- against a fixed query embedding. We don't have real embeddings — we
+-- simulate by treating each Int as a deterministic 128-d vector.
+-- Cost is what we measure; quality is irrelevant for Phase M.
+semanticSim :: [Int] -> [Double]
+semanticSim candidates =
+    [ dotProduct (embedding c) queryEmbedding | c <- candidates ]
+  where
+    !queryEmbedding = [ sin (fromIntegral i * 0.7) | i <- [0 .. 127 :: Int] ]
+    embedding :: Int -> [Double]
+    embedding c = [ sin (fromIntegral (c * (i + 1))) | i <- [0 .. 127 :: Int] ]
+    dotProduct as bs = sum (zipWith (*) as bs)

--- a/src/unifyweaver/core/cost_model.pl
+++ b/src/unifyweaver/core/cost_model.pl
@@ -1,0 +1,246 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% cost_model.pl — Cache-regime-aware access-pattern cost model
+%
+% First-principles cost estimates for choosing between sorted-seek and
+% sequential-scan patterns over LMDB-backed (or similar) data sources,
+% and for deciding whether cache warming will pay off.
+%
+% This module is opt-in: targets that want regime-aware decisions call
+% these predicates with workload metadata + a few hardware constants
+% (or default constants) and get back a recommended access pattern or
+% a warming threshold. Targets that don't opt in keep their existing
+% behaviour.
+%
+% See docs/design/CACHE_COST_MODEL_PHILOSOPHY.md for the full theory.
+% See docs/design/WAM_PERF_OPTIMIZATION_LOG.md Phase M appendix #10
+% for the empirical measurements that motivate the formulas.
+%
+% The model deliberately stays a closed-form formula with constants
+% within an order of magnitude of any commodity hardware. It's
+% groundwork for Phase 2c, when article-level (rather than category-
+% level) workloads start to push past free RAM.
+
+:- module(cost_model, [
+    %% Regime estimation
+    cache_regime/3,             % +RFreeBytes, +WBytes, -FHot
+
+    %% Cost estimates (returns milliseconds)
+    scan_time_ms/4,             % +WBytes, +FHot, +Constants, -ScanMs
+    seek_time_ms/4,             % +KKeys, +FHot, +Constants, -SortMs
+
+    %% Crossover and recommendations
+    crossover_k/4,              % +WBytes, +FHot, +Constants, -KCross
+    warming_payoff_m/5,         % +WWarmBytes, +KPerQuery, +FHot, +Constants, -MMin
+    recommend_access_pattern/5, % +KKeys, +WBytes, +RFreeBytes, +Constants, -Pattern
+
+    %% Hardware constants
+    default_constants/1,        % -Constants
+    constant/3,                 % +Name, +Constants, -Value
+
+    %% System probes (impure)
+    read_mem_available_bytes/1  % -Bytes
+]).
+
+%% =====================================================================
+%% Hardware constants
+%% =====================================================================
+
+%! default_constants(-Constants) is det.
+%
+%  SSD-typical defaults for commodity Linux/WSL hardware. Values are
+%  within an order of magnitude of any modern consumer machine.
+%
+%  Constants is an option list of:
+%    - s_mem_seq_bps(BytesPerSec) — sequential bandwidth from page cache
+%    - s_disk_seq_bps(BytesPerSec) — sequential bandwidth from cold storage
+%    - t_mem_seek_us(Microseconds) — one cached B-tree-walk seek
+%    - t_disk_seek_us(Microseconds) — one uncached B-tree-walk seek
+%
+%  Override per-machine by passing a custom list to the cost predicates.
+default_constants([
+    s_mem_seq_bps(5_000_000_000),   % 5 GB/s mmap memcpy
+    s_disk_seq_bps(500_000_000),    % 500 MB/s sequential SSD
+    t_mem_seek_us(1.0),             % 1 µs cached B-tree walk
+    t_disk_seek_us(100.0)           % 100 µs SSD random read
+]).
+
+%! constant(+Name, +Constants, -Value) is det.
+%
+%  Look up a named constant from a constants list, falling back to
+%  default_constants/1 if not present.
+constant(Name, Constants, Value) :-
+    Term =.. [Name, V],
+    (   member(Term, Constants)
+    ->  Value = V
+    ;   default_constants(Defaults),
+        member(Term, Defaults)
+    ->  Value = V
+    ;   throw(error(domain_error(cost_model_constant, Name), _))
+    ).
+
+%% =====================================================================
+%% Regime
+%% =====================================================================
+
+%! cache_regime(+RFreeBytes, +WBytes, -FHot) is det.
+%
+%  FHot is the fraction of working set W that fits in available RAM.
+%  Returns 1.0 (all hot) when working set fits entirely; drops toward
+%  0.0 as W exceeds R_free. Returns 1.0 for empty/zero working sets.
+cache_regime(_RFreeBytes, WBytes, 1.0) :-
+    WBytes =< 0, !.
+cache_regime(RFreeBytes, WBytes, FHot) :-
+    Ratio is RFreeBytes / WBytes,
+    FHot is min(1.0, max(0.0, Ratio)).
+
+%% =====================================================================
+%% Effective bandwidth and latency
+%% =====================================================================
+
+bandwidth_eff(FHot, Constants, BwBps) :-
+    constant(s_mem_seq_bps, Constants, SMem),
+    constant(s_disk_seq_bps, Constants, SDisk),
+    BwBps is FHot * SMem + (1.0 - FHot) * SDisk.
+
+latency_eff(FHot, Constants, LatUs) :-
+    constant(t_mem_seek_us, Constants, TMem),
+    constant(t_disk_seek_us, Constants, TDisk),
+    LatUs is FHot * TMem + (1.0 - FHot) * TDisk.
+
+%% =====================================================================
+%% Cost estimates
+%% =====================================================================
+
+%! scan_time_ms(+WBytes, +FHot, +Constants, -ScanMs) is det.
+%
+%  Estimated time to sequentially scan WBytes given cache regime FHot.
+scan_time_ms(WBytes, FHot, Constants, ScanMs) :-
+    bandwidth_eff(FHot, Constants, BwBps),
+    Seconds is WBytes / BwBps,
+    ScanMs is Seconds * 1000.0.
+
+%! seek_time_ms(+KKeys, +FHot, +Constants, -SortMs) is det.
+%
+%  Estimated time to do K well-distributed sorted seeks given cache
+%  regime FHot. Uses the *amortised* seek cost — for tightly-clustered
+%  keys the actual cost will be lower because consecutive keys often
+%  hit the same B-tree leaf. The model is therefore conservative
+%  (slightly overestimates seek cost), which biases toward scan when
+%  the choice is borderline.
+seek_time_ms(KKeys, FHot, Constants, SortMs) :-
+    latency_eff(FHot, Constants, LatUs),
+    Microseconds is KKeys * LatUs,
+    SortMs is Microseconds / 1000.0.
+
+%% =====================================================================
+%% Crossover
+%% =====================================================================
+
+%! crossover_k(+WBytes, +FHot, +Constants, -KCross) is det.
+%
+%  KCross is the number of distinct-key seeks at which sorted-seek time
+%  equals full-scan time. If K_query < KCross use sorted seeks; if
+%  K_query > KCross use a full scan. The crossover shifts left
+%  dramatically in the cold regime (FHot small) because random seeks
+%  become real disk operations.
+crossover_k(WBytes, FHot, Constants, KCross) :-
+    bandwidth_eff(FHot, Constants, BwBps),
+    latency_eff(FHot, Constants, LatUs),
+    %% K * LatUs/1e6 = WBytes/BwBps  →  K = (WBytes * 1e6) / (BwBps * LatUs)
+    KCross is (WBytes * 1.0e6) / (BwBps * LatUs).
+
+%% =====================================================================
+%% Warming-pays-off threshold
+%% =====================================================================
+
+%! warming_payoff_m(+WWarmBytes, +KPerQuery, +FHot, +Constants, -MMin) is det.
+%
+%  MMin is the minimum number of queries (M) at which pre-warming
+%  WWarmBytes pays off, given each query touches KPerQuery keys and
+%  the current cache regime is FHot.
+%
+%  In the all-hot regime (FHot ≈ 1) the cold/hot per-query times are
+%  nearly identical, so the denominator is tiny and MMin is huge —
+%  warming doesn't help. As FHot drops, the denominator grows and
+%  MMin shrinks. The exact zero of the denominator is suppressed via
+%  a small epsilon to avoid division by zero; callers that get
+%  MMin = positive_infinity should treat it as "warming pointless."
+%
+%  Returns positive_infinity when FHot ≈ 1 (warming pointless).
+warming_payoff_m(WWarmBytes, _KPerQuery, FHot, _Constants, positive_infinity) :-
+    FHot >= 1.0 - 1.0e-6, !,
+    WWarmBytes >= 0.
+warming_payoff_m(WWarmBytes, KPerQuery, FHot, Constants, MMin) :-
+    %% Cost to warm: scan WWarmBytes once at the current regime's
+    %% bandwidth (we have to actually load the bytes from disk to
+    %% warm the cache, so use the cold-path bandwidth fraction).
+    scan_time_ms(WWarmBytes, FHot, Constants, TWarmMs),
+    %% Per-query cost cold (working set not in cache) vs hot (in cache):
+    %% the difference is the cold-cache penalty per query.
+    seek_time_ms(KPerQuery, 0.0, Constants, TQueryColdMs),
+    seek_time_ms(KPerQuery, 1.0, Constants, TQueryHotMs),
+    Delta is TQueryColdMs - TQueryHotMs,
+    (   Delta =< 1.0e-9
+    ->  MMin = positive_infinity
+    ;   MMinReal is TWarmMs / Delta,
+        MMin is ceiling(MMinReal)
+    ).
+
+%% =====================================================================
+%% Recommendation
+%% =====================================================================
+
+%! recommend_access_pattern(+KKeys, +WBytes, +RFreeBytes, +Constants, -Pattern) is det.
+%
+%  Pattern is `sort` if K < K_cross, else `scan`. RFreeBytes is the
+%  free RAM available to the process (use read_mem_available_bytes/1
+%  on Linux to obtain it).
+%
+%  Border behaviour: when K = K_cross, prefer sort (the formula
+%  slightly overestimates seek cost so a tied result is more likely
+%  scan than the math implies).
+recommend_access_pattern(KKeys, WBytes, RFreeBytes, Constants, Pattern) :-
+    cache_regime(RFreeBytes, WBytes, FHot),
+    crossover_k(WBytes, FHot, Constants, KCross),
+    (   KKeys =< KCross
+    ->  Pattern = sort
+    ;   Pattern = scan
+    ).
+
+%% =====================================================================
+%% System probe
+%% =====================================================================
+
+%! read_mem_available_bytes(-Bytes) is det.
+%
+%  Read MemAvailable from /proc/meminfo. Returns the kernel's own
+%  estimate of how much RAM can be allocated without swapping —
+%  i.e. MemFree + reclaimable page cache + slab. This is the right
+%  number for "how much free RAM does the process effectively have",
+%  not MemFree, which underestimates by the size of the cache.
+%
+%  Throws if /proc/meminfo isn't readable (non-Linux platforms).
+%  Callers should catch and fall back to a sensible default (or
+%  pass a configured value through workload metadata).
+read_mem_available_bytes(Bytes) :-
+    setup_call_cleanup(
+        open('/proc/meminfo', read, Stream),
+        read_meminfo_field(Stream, "MemAvailable", KiB),
+        close(Stream)
+    ),
+    Bytes is KiB * 1024.
+
+read_meminfo_field(Stream, Field, Value) :-
+    read_line_to_string(Stream, Line),
+    (   Line == end_of_file
+    ->  throw(error(domain_error(meminfo_field, Field), _))
+    ;   split_string(Line, ":", "", [FieldStr, RestStr]),
+        FieldStr == Field
+    ->  split_string(RestStr, " ", " kKB", Parts),
+        once((member(NumStr, Parts), NumStr \= "")),
+        number_string(Value, NumStr)
+    ;   read_meminfo_field(Stream, Field, Value)
+    ).

--- a/tests/core/test_cost_model.pl
+++ b/tests/core/test_cost_model.pl
@@ -1,0 +1,328 @@
+:- encoding(utf8).
+%% Test suite for cost_model.pl
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_cost_model.pl
+
+:- use_module('../../src/unifyweaver/core/cost_model').
+:- use_module(library(lists)).
+
+%% ========================================================================
+%% Test runner
+%% ========================================================================
+
+run_tests :-
+    format("~n========================================~n"),
+    format("Cache Cost Model Tests~n"),
+    format("========================================~n~n"),
+    findall(Test, test(Test), Tests),
+    length(Tests, Total),
+    run_all(Tests, 0, Passed),
+    format("~n========================================~n"),
+    (   Passed =:= Total
+    ->  format("All ~w tests passed~n", [Total])
+    ;   Failed is Total - Passed,
+        format("~w of ~w tests FAILED~n", [Failed, Total]),
+        format("Tests FAILED~n"),
+        halt(1)
+    ),
+    format("========================================~n").
+
+run_all([], Passed, Passed).
+run_all([Test|Rest], Acc, Passed) :-
+    (   catch(call(Test), Error,
+            (format("[FAIL] ~w: ~w~n", [Test, Error]), fail))
+    ->  Acc1 is Acc + 1,
+        run_all(Rest, Acc1, Passed)
+    ;   run_all(Rest, Acc, Passed)
+    ).
+
+pass(Name) :- format("[PASS] ~w~n", [Name]).
+fail_test(Name, Reason) :- format("[FAIL] ~w: ~w~n", [Name, Reason]), fail.
+
+%% Approximate equality for floating-point comparisons.
+approx_eq(A, B, Tol) :-
+    Diff is abs(A - B),
+    Diff =< Tol.
+
+%% Within an order of magnitude (factor of 10) — used for estimates
+%% where the formula's exact constant doesn't matter, only the regime.
+within_factor(A, B, Factor) :-
+    A =< B * Factor,
+    B =< A * Factor.
+
+%% ========================================================================
+%% Test declarations
+%% ========================================================================
+
+test(test_default_constants_present).
+test(test_constant_lookup_default).
+test(test_constant_lookup_override).
+
+test(test_cache_regime_all_hot).
+test(test_cache_regime_all_cold).
+test(test_cache_regime_mixed).
+test(test_cache_regime_zero_w).
+test(test_cache_regime_clamps_at_one).
+
+test(test_scan_time_hot_simplewiki).
+test(test_scan_time_cold_enwiki).
+
+test(test_seek_time_hot).
+test(test_seek_time_cold).
+
+test(test_crossover_simplewiki_hot_matches_doc).
+test(test_crossover_simplewiki_cold_shifts_left).
+test(test_crossover_enwiki_hot_matches_doc).
+test(test_crossover_enwiki_cold_shifts_left).
+
+test(test_warming_pointless_when_all_hot).
+test(test_warming_pays_off_when_all_cold).
+
+test(test_recommend_sort_at_low_k).
+test(test_recommend_scan_at_high_k).
+
+test(test_read_mem_available_returns_positive).
+
+%% ========================================================================
+%% Default constants
+%% ========================================================================
+
+test_default_constants_present :-
+    Test = 'default_constants/1 lists the four expected keys',
+    (   default_constants(C),
+        member(s_mem_seq_bps(_), C),
+        member(s_disk_seq_bps(_), C),
+        member(t_mem_seek_us(_), C),
+        member(t_disk_seek_us(_), C)
+    ->  pass(Test)
+    ;   fail_test(Test, 'default_constants missing one of the four required keys')
+    ).
+
+test_constant_lookup_default :-
+    Test = 'constant/3 returns default when not in custom list',
+    (   constant(s_mem_seq_bps, [], V),
+        V > 0
+    ->  pass(Test)
+    ;   fail_test(Test, 'default lookup failed for s_mem_seq_bps')
+    ).
+
+test_constant_lookup_override :-
+    Test = 'constant/3 prefers custom value over default',
+    (   constant(t_disk_seek_us, [t_disk_seek_us(10000.0)], V),
+        approx_eq(V, 10000.0, 0.001)
+    ->  pass(Test)
+    ;   fail_test(Test, 'override lookup failed for t_disk_seek_us')
+    ).
+
+%% ========================================================================
+%% Cache regime
+%% ========================================================================
+
+test_cache_regime_all_hot :-
+    Test = 'cache_regime returns 1.0 when R_free >> W',
+    %% 16 GB free, 100 MB working set — clearly all hot
+    cache_regime(16_000_000_000, 100_000_000, F),
+    (   approx_eq(F, 1.0, 0.001)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got F=~w (expected ~~1.0)", [F]))
+    ).
+
+test_cache_regime_all_cold :-
+    Test = 'cache_regime drops near 0 when R_free << W',
+    %% 100 MB free, 100 GB working set — clearly all cold
+    cache_regime(100_000_000, 100_000_000_000, F),
+    (   F < 0.01
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got F=~w (expected near 0)", [F]))
+    ).
+
+test_cache_regime_mixed :-
+    Test = 'cache_regime returns ~0.5 when R_free = W/2',
+    cache_regime(500_000_000, 1_000_000_000, F),
+    (   approx_eq(F, 0.5, 0.001)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got F=~w (expected ~~0.5)", [F]))
+    ).
+
+test_cache_regime_zero_w :-
+    Test = 'cache_regime returns 1.0 when W=0',
+    cache_regime(1_000_000, 0, F),
+    (   approx_eq(F, 1.0, 0.001)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got F=~w (expected 1.0)", [F]))
+    ).
+
+test_cache_regime_clamps_at_one :-
+    Test = 'cache_regime never exceeds 1.0',
+    cache_regime(100_000_000_000, 1_000_000, F),
+    (   F =< 1.0
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got F=~w (exceeds 1.0)", [F]))
+    ).
+
+%% ========================================================================
+%% Scan time
+%% ========================================================================
+
+test_scan_time_hot_simplewiki :-
+    Test = 'scan_time_ms hot regime ~3 ms for simplewiki (15 MB at 5 GB/s)',
+    default_constants(C),
+    scan_time_ms(15_000_000, 1.0, C, Ms),
+    %% 15e6 / 5e9 = 3e-3 s = 3 ms
+    (   approx_eq(Ms, 3.0, 0.5)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got ~w ms (expected ~~3 ms)", [Ms]))
+    ).
+
+test_scan_time_cold_enwiki :-
+    Test = 'scan_time_ms cold regime ~1000 ms for enwiki (500 MB at 500 MB/s)',
+    default_constants(C),
+    scan_time_ms(500_000_000, 0.0, C, Ms),
+    %% 500e6 / 500e6 = 1 s = 1000 ms
+    (   approx_eq(Ms, 1000.0, 50.0)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got ~w ms (expected ~~1000 ms)", [Ms]))
+    ).
+
+%% ========================================================================
+%% Seek time
+%% ========================================================================
+
+test_seek_time_hot :-
+    Test = 'seek_time_ms hot regime ~10 ms for 10000 keys (10000 * 1 µs)',
+    default_constants(C),
+    seek_time_ms(10_000, 1.0, C, Ms),
+    %% 10000 * 1 µs = 10 ms
+    (   approx_eq(Ms, 10.0, 0.5)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got ~w ms (expected ~~10 ms)", [Ms]))
+    ).
+
+test_seek_time_cold :-
+    Test = 'seek_time_ms cold regime ~1000 ms for 10000 keys (10000 * 100 µs)',
+    default_constants(C),
+    seek_time_ms(10_000, 0.0, C, Ms),
+    %% 10000 * 100 µs = 1 s = 1000 ms
+    (   approx_eq(Ms, 1000.0, 50.0)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got ~w ms (expected ~~1000 ms)", [Ms]))
+    ).
+
+%% ========================================================================
+%% Crossover K — these are the headline numbers from the philosophy doc
+%% ========================================================================
+
+test_crossover_simplewiki_hot_matches_doc :-
+    Test = 'crossover_k simplewiki hot ~3000 keys (matches doc)',
+    default_constants(C),
+    crossover_k(15_000_000, 1.0, C, K),
+    %% Doc says ~3000. Within an order of magnitude is the bar; we get
+    %% 15e6 / (5e9 * 1e-6) = 15e6/5000 = 3000 exactly.
+    (   within_factor(K, 3000.0, 2.0)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got K=~w (expected ~~3000)", [K]))
+    ).
+
+test_crossover_simplewiki_cold_shifts_left :-
+    Test = 'crossover_k simplewiki cold ~300 keys (10x shift left)',
+    default_constants(C),
+    crossover_k(15_000_000, 0.0, C, K),
+    %% 15e6 / (500e6 * 100e-6) = 15e6 / 50000 = 300
+    (   within_factor(K, 300.0, 2.0)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got K=~w (expected ~~300)", [K]))
+    ).
+
+test_crossover_enwiki_hot_matches_doc :-
+    Test = 'crossover_k enwiki hot ~100000 keys (matches doc)',
+    default_constants(C),
+    crossover_k(500_000_000, 1.0, C, K),
+    %% 500e6 / (5e9 * 1e-6) = 500e6 / 5000 = 100000
+    (   within_factor(K, 100000.0, 2.0)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got K=~w (expected ~~100000)", [K]))
+    ).
+
+test_crossover_enwiki_cold_shifts_left :-
+    Test = 'crossover_k enwiki cold ~10000 keys (10x shift left)',
+    default_constants(C),
+    crossover_k(500_000_000, 0.0, C, K),
+    %% 500e6 / (500e6 * 100e-6) = 500e6 / 50000 = 10000
+    (   within_factor(K, 10000.0, 2.0)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got K=~w (expected ~~10000)", [K]))
+    ).
+
+%% ========================================================================
+%% Warming threshold
+%% ========================================================================
+
+test_warming_pointless_when_all_hot :-
+    Test = 'warming_payoff_m returns positive_infinity when FHot=1 (no payoff)',
+    default_constants(C),
+    warming_payoff_m(100_000_000, 1000, 1.0, C, M),
+    (   M = positive_infinity
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got M=~w (expected positive_infinity)", [M]))
+    ).
+
+test_warming_pays_off_when_all_cold :-
+    Test = 'warming_payoff_m returns finite small M when FHot=0',
+    default_constants(C),
+    warming_payoff_m(100_000_000, 1000, 0.0, C, M),
+    (   integer(M),
+        M > 0,
+        M < 100_000  %% Some finite, plausibly small number
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got M=~w (expected small finite)", [M]))
+    ).
+
+%% ========================================================================
+%% Recommendation
+%% ========================================================================
+
+test_recommend_sort_at_low_k :-
+    Test = 'recommend_access_pattern picks sort at low K (hot regime)',
+    default_constants(C),
+    %% 16 GB free, 15 MB DB, 100 keys → all hot, K << K_cross(~3000)
+    recommend_access_pattern(100, 15_000_000, 16_000_000_000, C, Pattern),
+    (   Pattern = sort
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got pattern=~w (expected sort)", [Pattern]))
+    ).
+
+test_recommend_scan_at_high_k :-
+    Test = 'recommend_access_pattern picks scan at high K',
+    default_constants(C),
+    %% 16 GB free, 15 MB DB, 100000 keys (way past K_cross ~ 3000)
+    recommend_access_pattern(100_000, 15_000_000, 16_000_000_000, C, Pattern),
+    (   Pattern = scan
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got pattern=~w (expected scan)", [Pattern]))
+    ).
+
+%% ========================================================================
+%% System probe
+%% ========================================================================
+
+test_read_mem_available_returns_positive :-
+    Test = 'read_mem_available_bytes returns positive integer on Linux',
+    (   catch(read_mem_available_bytes(B), _, fail),
+        integer(B),
+        B > 0
+    ->  pass(Test)
+    ;   %% Skip on non-Linux platforms
+        format("[SKIP] ~w (no /proc/meminfo)~n", [Test])
+    ).
+
+%% ========================================================================
+%% Helper: format an atom for fail_test reasons
+%% ========================================================================
+
+format_atom(Format, Args, Atom) :-
+    format(string(S), Format, Args),
+    atom_string(Atom, S).
+format_atom(Format, Args) :-
+    format_atom(Format, Args, A),
+    A == A.  % Just to enforce binding; only used inside fail_test/2.


### PR DESCRIPTION
  ## Summary

  Phase 2c prerequisite. Two commits, one branch:

  1. **Phase M microbench** — empirical measurements of read patterns,
     ranker overhead, and warming-vs-JIT crossover at simplewiki scale.
  2. **Cache cost model groundwork** — closed-form theory document,
     opt-in Prolog predicates, and 21 unit tests. Ships nothing into
     production codegen yet; gives Phase 2c a decision engine to use.

  This is measurement + theory, not an optimization. Categories-only
  fixtures fit in free RAM and don't need the model; article-level
  data and memory-pressured environments are where it'll start to
  matter.

  ## Phase M microbench (commit 1)

  Three sub-benches in a standalone cabal project under
  `examples/benchmark/cache_warming_microbench/`:

  - **M1** — read patterns: same workload, five access patterns
    (`PerLookupCursor`, `SharedInOrder`, `SharedSorted`,
    `SharedShuffled`, `FullScan`).
  - **M1.b** — selectivity sweep: sorted seeks vs full scan at six
    selection ratios on the same key set.
  - **M2** — ranker overhead: PPR/Flux iteration, streaming-hop pass
    (B-tree frontier propagation), stub semantic similarity.
  - **M3** — warming-vs-JIT: M random 3-hop BFS queries against cold
    vs top-K-warmed cache.

  ### Headline numbers (simplewiki, 297k edges)

  **M1 read patterns** (10k keys → 78,751 edges):

  | pattern | wall_ms |
  |---|---|
  | PerLookupCursor | 275 |
  | SharedSorted | 4.0 |
  | SharedShuffled | 14.4 |
  | FullScan | 13.4 |

  Cursor reuse is **65×** vs per-lookup. Random-shuffle penalty is
  **3.5×** over sorted. At 3.4% selection, scan is **3.3× slower**
  than sorted seeks.

  **M1.b selectivity sweep** — sorted seeks beat scan at every
  measured ratio (76× at 1%, 2.8× at 100%). Projected scan-vs-seek
  crossover at ~10–18% true selection on this hardware. The Hadoop
  "scans beat seeks" framing applies at higher selection regimes
  than typical demand-BFS hits.

  **M2 ranker overhead**:

  | ranker | wall_ms |
  |---|---|
  | PPR/Flux 1 iter | 80 |
  | streaming-hop 1 pass | 2.7 |
  | semantic-sim K=1000 D=128 | 2.8 |

  PPR amortises only at M ≥ ~80 queries. Streaming-hop is
  essentially free — viable as a per-query default.

  **M3 warming-vs-JIT** — top-K-by-out-degree warming **does not
  pay off** for random-BFS queries on simplewiki. Speedups hover
  at 1× ± noise. Workload-specific result; warming policy must
  match query traffic, and a static graph metric (out-degree) doesn't.

  ## Cost-model groundwork (commit 2)

  Following the measurements, formalised the cache-regime cost model
  and shipped opt-in Prolog predicates that targets can use to drive
  regime-aware decisions.

  ### Theory

  `docs/design/CACHE_COST_MODEL_PHILOSOPHY.md` is the durable theory
  document. Covers why first-principles instead of measurement tables,
  the page-cache regime, `MemAvailable` vs `MemFree` (especially under
  WSL where free RAM swings dynamically as the host reclaims pages),
  hardware constants, calibration story, and connection to the
  existing C# source-mode resolver.

  ### Formula

  `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` Phase M appendix #10 is
  extended with:

  W_working = X * W
  f_hot     = min(1, R_free / W_working)

  T_scan = W_working * [f_hot / S_mem_seq + (1 - f_hot) / S_disk_seq]
  T_sort = K         * [f_hot * t_mem_seek + (1 - f_hot) * t_disk_seek]

  K_cross = W_working / [bandwidth_eff * latency_eff]

  | regime | W | K_cross | as % keys |
  |---|---|---|---|
  | simplewiki, hot | 15 MB | ~3,000 | ~2% |
  | simplewiki, cold | 15 MB | ~300 | ~0.2% |
  | enwiki, hot | 500 MB | ~100,000 | ~10% |
  | enwiki, cold | 500 MB | ~10,000 | ~1% |

  The 10–18% selection threshold from M1.b is conditional on the
  working set fitting in the page cache. On databases that exceed
  free RAM, the crossover shifts left dramatically because random
  seeks become real disk operations.

  ### Prolog implementation

  `src/unifyweaver/core/cost_model.pl` — opt-in API:

  - `cache_regime/3` — fraction-hot from R_free vs W
  - `scan_time_ms/4`, `seek_time_ms/4` — closed-form estimates
  - `crossover_k/4` — K below which sort beats scan
  - `warming_payoff_m/5` — minimum M for warming to amortise
  - `recommend_access_pattern/5` — `sort` vs `scan` from K, W, R_free
  - `default_constants/1` + `constant/3` — hardware constants with
    per-machine override
  - `read_mem_available_bytes/1` — `/proc/meminfo:MemAvailable` probe

  ### Tests

  `tests/core/test_cost_model.pl` — 21 tests covering hot/cold/mixed
  regimes, the philosophy doc's headline crossover numbers, warming
  threshold, recommendation boundaries, and the Linux meminfo probe.
  All pass.

  The model is opt-in: targets that don't use it keep their existing
  `fact_count`-threshold heuristic. Phase 2c (deferred) will add
  `resolve_auto_cache_strategy/2` that uses this module as its
  decision engine, once the workload-metadata channel
  (`K_query`, `M`, `X_query`) is plumbed through codegen.

  ## When this matters

  Categories-only fixtures (simplewiki ≈ 15 MB, enwiki ≈ 500 MB)
  fit in any modern free RAM. The model is genuinely groundwork.
  The regime starts to bite when:

  - **Article-level Wikipedia** — full enwiki article texts are
    ~80 GB compressed, ~250 GB uncompressed.
  - **Multi-fixture aggregation** — categories + page metadata +
    revision counts + link tables.
  - **Memory-pressured WSL** — the Windows host can reclaim large
    fractions of the VM's RAM.
  - **Spinning-disk targets** — `t_disk_seek` jumps 100×, shifting
    the crossover left aggressively.

  ## Caveats (workload + hardware conditional)

  - **Hardware**: WSL2 + mmap. The "scans beat seeks" regime is
    reachable on cold-disk-pressured systems; not on this setup.
  - **Workload**: random-BFS from random roots. Repeated queries
    from a hot root subset would change M3's verdict.
  - **Warming policy**: only top-K-by-out-degree measured. Query-
    history-driven warming is the natural follow-up.
  - **Constants**: SSD-typical defaults are within an order of
    magnitude on commodity hardware. A per-machine calibration
    probe is a future enhancement.

  ## Files

  **Microbench** (commit 1):
  - `examples/benchmark/cache_warming_microbench/` — new cabal
    project (`Patterns.hs`, `Rankers.hs`, `Crossover.hs`, `Main.hs`)
  - `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` — Phase M appendix #10

  **Cost model** (commit 2):
  - `docs/design/CACHE_COST_MODEL_PHILOSOPHY.md` — new theory doc
  - `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` — formula extension
  - `src/unifyweaver/core/cost_model.pl` — Prolog predicates
  - `tests/core/test_cost_model.pl` — 21 unit tests

  ## Note on pre-existing test failures

  `tests/test_wam_haskell_target.pl` shows 36/147 failures on this
  branch. Verified by checking out `main` directly: same 36 fail
  there. The regressions appear to come from PRs #1962/#1963 (Lua
  WAM and R WAM bagof/setof) merged after the UTF-8 fix; unrelated
  to this work and pre-existing on `main`. Not investigated in this
  PR.

  The new `tests/core/test_cost_model.pl` (21/21) is clean.

  ## Test plan

  - [x] Microbench builds clean under cabal new-build
  - [x] Microbench smoke run on 1k_resident_run (sub-ms scale)
  - [x] Microbench full run on simplewiki (numbers above)
  - [x] `tests/core/test_cost_model.pl` — all 21 pass
  - [x] `tests/test_wam_haskell_target.pl` — same 111/147 pass as
        on `main` (no new regressions)
  - [ ] (Optional) enwiki run for at-scale microbench validation —
        deferred; simplewiki already shows the cost-class shapes
        clearly