### PR TITLE
fix(wam, core): nested if-then-else recognition + clause_body_analysis nonvar guard

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -623,15 +623,6 @@ WamRuntime$run(shared_program, state)
   strictly less than the operator precedence. Symmetric with the
   existing prefix simplification. Documented; not a real-world
   blocker.
-- **WAM compiler's `clause_body_analysis` stack overflow on deeply
-  nested disjunctions**. Triple-nested `( A -> B ; C -> D ; E )`
-  shapes blow the analyser's stack at compile time, even though
-  `compile_if_then_else` itself handles them correctly. Workaround
-  for now: factor the chain into a separate predicate's clauses
-  and dispatch by head pattern (see `list_elem_continue`,
-  `op_loop_step` in `src/unifyweaver/core/prolog_term_parser.pl`).
-  Lives in `src/unifyweaver/core/clause_body_analysis.pl`'s
-  `disjunction_alternatives/2` and is independent of the runtime.
 - **WAM-text quoting collision**. The atom `'42'` and the integer
   `42` both serialise as `set_constant 42` in SWI's WAM emitter,
   so the codegen can't distinguish them. The runtime's `atom_*`
@@ -726,6 +717,7 @@ Coverage map (e2e tests, by feature group):
 | `stack_frame_cleanup_on_backtrack_e2e_rscript` | failed clauses' env frames get popped on backtrack via the CP's `stack_len` snapshot, so the outer predicate's `Deallocate` doesn't pop a stale frame and re-enter post-call code |
 | `cut_ite_barrier_after_helper_e2e_rscript` | `( A -> B ; C )` soft-cut commits past CPs that A's evaluation left alive (the codegen marks the if-then-else's `try_me_else` as `try_me_else_ite`, the runtime tags the CP `kind="ite"`, and `CutIte` truncates `state$cps` back to that CP's pre-push depth) |
 | `nested_if_then_else_e2e_rscript` | chained `( A -> B ; C -> D ; E )` compiles as nested cut_ite/try_me_else_ite pairs (each `->` in Else position is recognised recursively rather than emitted as a stub `Call("->", 2)`) |
+| `deeply_nested_ite_compiles` | clause_body_analysis no longer stack-overflows on triple-nested if-then-else bodies (the `nonvar` guard on `disjunction_alternatives/2` keeps it from infinitely-expanding an unbound goal that passes through the analyser) |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -623,23 +623,14 @@ WamRuntime$run(shared_program, state)
   strictly less than the operator precedence. Symmetric with the
   existing prefix simplification. Documented; not a real-world
   blocker.
-- **Nested if-then-else (`A -> B ; C -> D`)**. The WAM compiler's
-  `compile_if_then_else` only recognises the outermost `(Cond ->
-  Then ; Else)` and compiles the Else recursively as an opaque goal
-  list, which means a second `->` in Else position emits as
-  `Call("->", 2)` -- a builtin we don't implement, so the call just
-  fails. Workaround: factor a chain of `(A -> B ; C -> D ; ...)`
-  into a separate predicate's clauses and dispatch by head pattern
-  (see `parse_args_continue`, `list_elem_continue`, `op_loop_step`
-  in `src/unifyweaver/core/prolog_term_parser.pl`). The proper
-  fix is making `compile_if_then_else` recognise that an Else of
-  shape `(Cond2 -> Then2)` is itself an if-then-else (with `fail`
-  as the implicit deepest else).
 - **WAM compiler's `clause_body_analysis` stack overflow on deeply
   nested disjunctions**. Triple-nested `( A -> B ; C -> D ; E )`
-  shapes blow the analyser's stack. Rewrite as clause-level
-  dispatch (same workaround as nested if-then-else above). Lives
-  in `src/unifyweaver/core/clause_body_analysis.pl`'s
+  shapes blow the analyser's stack at compile time, even though
+  `compile_if_then_else` itself handles them correctly. Workaround
+  for now: factor the chain into a separate predicate's clauses
+  and dispatch by head pattern (see `list_elem_continue`,
+  `op_loop_step` in `src/unifyweaver/core/prolog_term_parser.pl`).
+  Lives in `src/unifyweaver/core/clause_body_analysis.pl`'s
   `disjunction_alternatives/2` and is independent of the runtime.
 - **WAM-text quoting collision**. The atom `'42'` and the integer
   `42` both serialise as `set_constant 42` in SWI's WAM emitter,
@@ -734,6 +725,7 @@ Coverage map (e2e tests, by feature group):
 | `cut_barrier_after_helper_e2e_rscript` | `!/0` truncates `state$cps` to the predicate's call-site depth, dropping leftover CPs from multi-clause helpers and the predicate's own try-chain CP in one shot |
 | `stack_frame_cleanup_on_backtrack_e2e_rscript` | failed clauses' env frames get popped on backtrack via the CP's `stack_len` snapshot, so the outer predicate's `Deallocate` doesn't pop a stale frame and re-enter post-call code |
 | `cut_ite_barrier_after_helper_e2e_rscript` | `( A -> B ; C )` soft-cut commits past CPs that A's evaluation left alive (the codegen marks the if-then-else's `try_me_else` as `try_me_else_ite`, the runtime tags the CP `kind="ite"`, and `CutIte` truncates `state$cps` back to that CP's pre-push depth) |
+| `nested_if_then_else_e2e_rscript` | chained `( A -> B ; C -> D ; E )` compiles as nested cut_ite/try_me_else_ite pairs (each `->` in Else position is recognised recursively rather than emitted as a stub `Call("->", 2)`) |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/docs/handoff/wam_r_session_handoff.md
+++ b/docs/handoff/wam_r_session_handoff.md
@@ -161,47 +161,36 @@ roughly priority order:
    keeping the inline path for the CLI arg parser if startup latency
    regresses too far.
 
-4. **Nested if-then-else (`A -> B ; C -> D`)**. `compile_if_then_else`
-   in `src/unifyweaver/targets/wam_target.pl` only matches the
-   outermost `(Cond -> Then ; Else)` and compiles Else as an opaque
-   goal sequence, so a second `->` in Else position emits as
-   `Call("->", 2)` -- which has no runtime implementation, so it
-   just fails. Workaround in the cross-target parser today is
-   factoring chains into clause-level dispatch
-   (`parse_args_continue`, `list_elem_continue`,
-   `op_loop_step`). Proper fix: make `compile_if_then_else`
-   recognise that an Else of shape `(Cond2 -> Then2)` is itself an
-   if-then-else with `fail` as the implicit innermost Else, and
-   recursively emit nested CutIte/TryMeElseIte. Should be a small
-   compiler change.
-5. **WAM compiler `clause_body_analysis` stack overflow** on triple-
-   nested `( A -> B ; C -> D ; E )` disjunctions. Independent of
-   the nested-if-then-else point above (this is the analyser, not
-   the emitter). Lives in
+4. **WAM compiler `clause_body_analysis` stack overflow** on triple-
+   nested `( A -> B ; C -> D ; E )` disjunctions at compile time
+   (the emitter handles them correctly post-PR #1966; this is a
+   separate bug in the analyser). Lives in
    `src/unifyweaver/core/clause_body_analysis.pl`'s
    `disjunction_alternatives/2`. Rewrite the recursion as
    tail-recursive accumulator (or memoise) so the call depth doesn't
-   scale with disjunction nesting.
-6. **Strict `xf` precedence rule** (small). Threading the precedence
+   scale with disjunction nesting. Removes the last in-the-source
+   workarounds in the cross-target Prolog parser
+   (`list_elem_continue`, `op_loop_step`).
+5. **Strict `xf` precedence rule** (small). Threading the precedence
    of the current `left` expression through `wam_parse_expr` so `xf`
    and `yf` differ correctly at chained-postfix sites. Fixes the
    simplification documented as a known limitation. Same fix would
    let `fx` / `fy` differ correctly in the prefix path.
-7. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
+6. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
    mode info per predicate (in/out per arg); Phase 2 wires it to
    specialised emission (skip unifications when the mode says the slot
    is unbound, etc.). Look at the Haskell target's
    `WAM_HASKELL_MODE_ANALYSIS_*.md` design docs for the precedent.
-9. **Multi-line `read/2`.** Read until a `.` terminator across lines.
+7. **Multi-line `read/2`.** Read until a `.` terminator across lines.
    Niche but completes the streams story.
-10. **Multi-solution `retract/1` ignoring snapshot.** I.e. re-read the
-    live clause list on each backtrack. Trickier semantics; document
-    carefully if pursued.
-11. **Phase-3 lowered emitter expansion.** Currently handles only
-    `deterministic` and `multi_clause_1` shapes. Could grow N-clause
-    general lowering; would compete with the kernel / fact-table paths
-    so the value is unclear.
-12. **Range / interval indexes** on fact tables. Per-arg hash indexes
+8. **Multi-solution `retract/1` ignoring snapshot.** I.e. re-read the
+   live clause list on each backtrack. Trickier semantics; document
+   carefully if pursued.
+9. **Phase-3 lowered emitter expansion.** Currently handles only
+   `deterministic` and `multi_clause_1` shapes. Could grow N-clause
+   general lowering; would compete with the kernel / fact-table paths
+   so the value is unclear.
+10. **Range / interval indexes** on fact tables. Per-arg hash indexes
     land queries with ground atom/int args; range queries (`X > 5`,
     `X between A B`) still go through the per-tuple scan. A sorted-
     per-arg index would route these. Niche but a natural extension.

--- a/docs/handoff/wam_r_session_handoff.md
+++ b/docs/handoff/wam_r_session_handoff.md
@@ -161,36 +161,26 @@ roughly priority order:
    keeping the inline path for the CLI arg parser if startup latency
    regresses too far.
 
-4. **WAM compiler `clause_body_analysis` stack overflow** on triple-
-   nested `( A -> B ; C -> D ; E )` disjunctions at compile time
-   (the emitter handles them correctly post-PR #1966; this is a
-   separate bug in the analyser). Lives in
-   `src/unifyweaver/core/clause_body_analysis.pl`'s
-   `disjunction_alternatives/2`. Rewrite the recursion as
-   tail-recursive accumulator (or memoise) so the call depth doesn't
-   scale with disjunction nesting. Removes the last in-the-source
-   workarounds in the cross-target Prolog parser
-   (`list_elem_continue`, `op_loop_step`).
-5. **Strict `xf` precedence rule** (small). Threading the precedence
+4. **Strict `xf` precedence rule** (small). Threading the precedence
    of the current `left` expression through `wam_parse_expr` so `xf`
    and `yf` differ correctly at chained-postfix sites. Fixes the
    simplification documented as a known limitation. Same fix would
    let `fx` / `fy` differ correctly in the prefix path.
-6. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
+5. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
    mode info per predicate (in/out per arg); Phase 2 wires it to
    specialised emission (skip unifications when the mode says the slot
    is unbound, etc.). Look at the Haskell target's
    `WAM_HASKELL_MODE_ANALYSIS_*.md` design docs for the precedent.
-7. **Multi-line `read/2`.** Read until a `.` terminator across lines.
+6. **Multi-line `read/2`.** Read until a `.` terminator across lines.
    Niche but completes the streams story.
-8. **Multi-solution `retract/1` ignoring snapshot.** I.e. re-read the
+7. **Multi-solution `retract/1` ignoring snapshot.** I.e. re-read the
    live clause list on each backtrack. Trickier semantics; document
    carefully if pursued.
-9. **Phase-3 lowered emitter expansion.** Currently handles only
+8. **Phase-3 lowered emitter expansion.** Currently handles only
    `deterministic` and `multi_clause_1` shapes. Could grow N-clause
    general lowering; would compete with the kernel / fact-table paths
    so the value is unclear.
-10. **Range / interval indexes** on fact tables. Per-arg hash indexes
+9. **Range / interval indexes** on fact tables. Per-arg hash indexes
     land queries with ground atom/int args; range queries (`X > 5`,
     `X between A B`) still go through the per-tuple scan. A sorted-
     per-arg index would route these. Niche but a natural extension.

--- a/src/unifyweaver/core/clause_body_analysis.pl
+++ b/src/unifyweaver/core/clause_body_analysis.pl
@@ -137,7 +137,17 @@ if_then_goal(->(IfGoal, ThenGoal), IfGoal, ThenGoal) :- !.
 
 %% disjunction_alternatives(+Goal, -Alternatives)
 %  Flatten a Prolog disjunction (A ; B ; C) into a list [A, B, C].
-disjunction_alternatives((Left ; Right), Alternatives) :-
+%  The `nonvar(Goal)` guard is load-bearing: without it, an unbound
+%  Goal unifies with `(L ; R)` against fresh unbound L and R, the
+%  recursion then walks those fresh unbounds, each call manufactures
+%  more unbounds, and the recursion never terminates. Some callers
+%  (most notably the WAM compiler's analysis pass on bodies whose
+%  if-then-else trees temporarily expose unbound subterms) hit this
+%  shape easily; the guard makes the whole module safe to call with
+%  any term.
+disjunction_alternatives(Goal, Alternatives) :-
+    nonvar(Goal),
+    Goal = (Left ; Right),
     !,
     disjunction_alternatives(Left, LeftAlts),
     disjunction_alternatives(Right, RightAlts),

--- a/src/unifyweaver/core/prolog_term_parser.pl
+++ b/src/unifyweaver/core/prolog_term_parser.pl
@@ -278,33 +278,21 @@ parse_expr(Tokens0, OpTable, MaxPrec, Term, Env0, Env, Rest) :-
 
 parse_op_loop([], _, _, Left, Left, Env, Env, []).
 parse_op_loop([T|Toks], OpTable, MaxPrec, Left, Term, Env0, Env, Rest) :-
-    op_loop_step(T, Toks, OpTable, MaxPrec, Left, Term, Env0, Env, Rest).
-
-% op_loop_step: factored out of parse_op_loop to keep the disjunction
-% depth shallow -- the WAM compiler's clause_body_analysis pass
-% stack-overflows on deeply nested ( A -> B ; C -> D ; E ).
-op_loop_step(T, Toks, OpTable, MaxPrec, Left, Term, Env0, Env, Rest) :-
-    token_op_name(T, Name),
-    op_loop_with_op(Name, Toks, OpTable, MaxPrec, Left, Term, Env0, Env, Rest),
-    !.
-op_loop_step(T, Toks, _, _, Left, Left, Env, Env, [T|Toks]).
-
-% Tries infix first (matches SWI), falls through to postfix. Fails if
-% neither resolution applies, letting op_loop_step backtrack to the
-% no-op clause.
-op_loop_with_op(Name, Toks, OpTable, MaxPrec, Left, Term, Env0, Env, Rest) :-
-    resolve_infix(Name, OpTable, Prec, Type),
-    Prec =< MaxPrec,
-    !,
-    rhs_max_prec(Type, Prec, RhsMax),
-    parse_expr(Toks, OpTable, RhsMax, Right, Env0, Env1, Toks1),
-    T2 =.. [Name, Left, Right],
-    parse_op_loop(Toks1, OpTable, MaxPrec, T2, Term, Env1, Env, Rest).
-op_loop_with_op(Name, Toks, OpTable, MaxPrec, Left, Term, Env0, Env, Rest) :-
-    resolve_postfix(Name, OpTable, Prec, _Type),
-    Prec =< MaxPrec,
-    T2 =.. [Name, Left],
-    parse_op_loop(Toks, OpTable, MaxPrec, T2, Term, Env0, Env, Rest).
+    (   token_op_name(T, Name)
+    ->  (   resolve_infix(Name, OpTable, Prec, Type),
+            Prec =< MaxPrec
+        ->  rhs_max_prec(Type, Prec, RhsMax),
+            parse_expr(Toks, OpTable, RhsMax, Right, Env0, Env1, Toks1),
+            T2 =.. [Name, Left, Right],
+            parse_op_loop(Toks1, OpTable, MaxPrec, T2, Term, Env1, Env, Rest)
+        ;   resolve_postfix(Name, OpTable, Prec, _PType),
+            Prec =< MaxPrec
+        ->  T2 =.. [Name, Left],
+            parse_op_loop(Toks, OpTable, MaxPrec, T2, Term, Env0, Env, Rest)
+        ;   Term = Left, Env = Env0, Rest = [T|Toks]
+        )
+    ;   Term = Left, Env = Env0, Rest = [T|Toks]
+    ).
 
 % parse_primary: the leading token of an expression. Number / var / atom /
 % list / parenthesised / prefix-op application.
@@ -361,21 +349,15 @@ parse_list_body(Tokens, OpTable, List, Env0, Env, Rest) :-
 
 parse_list_elems(Tokens, OpTable, [E|Rest], Tail, Env0, Env, RestOut) :-
     parse_expr(Tokens, OpTable, 999, E, Env0, Env1, Tokens1),
-    list_elem_continue(Tokens1, OpTable, Rest, Tail, Env1, Env, RestOut).
-
-% Three-way clause-level dispatch instead of nested
-% `( A -> B ; C -> D ; E )`. The WAM compiler's clause_body_analysis
-% pass stack-overflows on the deeply nested disjunction shape (a
-% bug separate from the CutIte semantics that motivated the
-% other workarounds). Until that's fixed, keep this factored.
-list_elem_continue([tk_comma|Toks], OpTable, Rest, Tail, Env0, Env, RestOut) :-
-    !,
-    parse_list_elems(Toks, OpTable, Rest, Tail, Env0, Env, RestOut).
-list_elem_continue([tk_pipe|Toks], OpTable, [], Tail, Env0, Env, RestOut) :-
-    !,
-    parse_expr(Toks, OpTable, 999, Tail, Env0, Env, Tokens3),
-    Tokens3 = [tk_rbracket|RestOut].
-list_elem_continue([tk_rbracket|RestOut], _, [], [], Env, Env, RestOut).
+    (   Tokens1 = [tk_comma|Tokens2]
+    ->  parse_list_elems(Tokens2, OpTable, Rest, Tail, Env1, Env, RestOut)
+    ;   Tokens1 = [tk_pipe|Tokens2]
+    ->  parse_expr(Tokens2, OpTable, 999, Tail, Env1, Env, Tokens3),
+        Tokens3 = [tk_rbracket|RestOut],
+        Rest = []
+    ;   Tokens1 = [tk_rbracket|RestOut]
+    ->  Rest = [], Tail = [], Env = Env1
+    ).
 
 list_build([], Tail, Tail).
 list_build([E|Es], Tail, [E|Rest]) :- list_build(Es, Tail, Rest).

--- a/src/unifyweaver/core/prolog_term_parser.pl
+++ b/src/unifyweaver/core/prolog_term_parser.pl
@@ -343,21 +343,14 @@ parse_atom_head(Name, R, OpTable, MaxPrec, Term, Env0, Env, Rest) :-
 parse_atom_head(Name, R, _, _, Name, Env, Env, R).
 
 % parse_args: comma-separated arg list inside `(...)`, max_prec 999 so the
-% top-level comma operator (1000) doesn't get folded in. Like
-% parse_op_loop and list_elem_continue, the post-arg dispatch uses
-% clause-level pattern matching rather than nested
-% `( A -> B ; C -> D )` -- the WAM compiler doesn't recursively
-% recognize Else as another if-then-else and emits the second ->/2
-% as a regular Call, which has no runtime implementation. Filed as
-% a separate compiler enhancement.
+% top-level comma operator (1000) doesn't get folded in.
 parse_args(Tokens, OpTable, [Arg|Rest], Env0, Env, RestOut) :-
     parse_expr(Tokens, OpTable, 999, Arg, Env0, Env1, Tokens1),
-    parse_args_continue(Tokens1, OpTable, Rest, Env1, Env, RestOut).
-
-parse_args_continue([tk_comma|Toks], OpTable, Rest, Env0, Env, RestOut) :-
-    !,
-    parse_args(Toks, OpTable, Rest, Env0, Env, RestOut).
-parse_args_continue([tk_rparen|RestOut], _, [], Env, Env, RestOut).
+    (   Tokens1 = [tk_comma|Tokens2]
+    ->  parse_args(Tokens2, OpTable, Rest, Env1, Env, RestOut)
+    ;   Tokens1 = [tk_rparen|RestOut]
+    ->  Rest = [], Env = Env1
+    ).
 
 % parse_list_body: handles `[]`, `[a, b, c]`, `[H|T]`. Element max_prec 999
 % (matches parse_args).

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -905,19 +905,26 @@ flatten_conjunction(Goal, [Goal]).
 %  Compile (Cond -> Then ; Else) to WAM try/cut/trust + jump pattern.
 %  The condition runs in a temporary choice point; if it succeeds, cut
 %  commits to Then. If it fails, backtrack to Else.
+%
+%  When Else is itself another if-then-else (`(C2 -> T2 ; E2)`) or a
+%  bare `(C2 -> T2)` (implicit `; fail`), we recurse so a chain like
+%  `(A -> B ; C -> D ; E)` compiles to nested cut_ite/try_me_else
+%  pairs. Without this, the second `->` in Else position would emit
+%  as a regular `Call("->", 2)` -- which has no runtime
+%  implementation and just fails.
 compile_if_then_else(CondGoal, ThenGoal, ElseGoal, V0, Vf, _HasEnv, Code) :-
     next_ite_label(ElseLabel, ContLabel),
-    % Flatten condition and branch bodies into goal lists
+    % Flatten condition and then-branch into goal lists
     flatten_conjunction(CondGoal, CondGoals),
     flatten_conjunction(ThenGoal, ThenGoals),
-    flatten_conjunction(ElseGoal, ElseGoals),
     % Compile condition goals as calls (never TCO)
     compile_inner_call_goals(CondGoals, V0, V1, CondCode),
     % Compile then-branch goals as calls
     compile_inner_call_goals(ThenGoals, V1, V2, ThenCode),
-    % Compile else-branch goals as calls (start from V0 since backtrack
-    % restores to before the condition)
-    compile_inner_call_goals(ElseGoals, V0, V3, ElseCode),
+    % Compile else-branch -- if it's a nested if-then-else recurse,
+    % otherwise treat it as a flat goal list. Start from V0 since
+    % backtrack restores to before the condition.
+    compile_else_branch(ElseGoal, V0, V3, ElseCode),
     % Use the wider variable map as output
     (   V2 = V3 -> Vf = V2
     ;   Vf = V2  % prefer then-branch vars (else-branch is alternative)
@@ -930,6 +937,21 @@ compile_if_then_else(CondGoal, ThenGoal, ElseGoal, V0, Vf, _HasEnv, Code) :-
     format(string(Code),
         "    try_me_else ~w~n~w~n    cut_ite~n~w~n    jump ~w~n~w:~n    trust_me~n~w~n~w:",
         [ElseLabel, CondCode, ThenCode, ContLabel, ElseLabel, ElseCode, ContLabel]).
+
+%% compile_else_branch(+Else, +V0, -Vf, -Code) is det.
+%  The Else position of `(Cond -> Then ; Else)`. If Else is itself
+%  another if-then-else, recurse; otherwise compile as a flat goal
+%  sequence. A bare `(C -> T)` in Else position is interpreted as
+%  `(C -> T ; fail)` -- the branch fails when C fails, matching SWI.
+compile_else_branch((Cond2 -> Then2 ; Else2), V0, Vf, Code) :-
+    !,
+    compile_if_then_else(Cond2, Then2, Else2, V0, Vf, no, Code).
+compile_else_branch((Cond2 -> Then2), V0, Vf, Code) :-
+    !,
+    compile_if_then_else(Cond2, Then2, fail, V0, Vf, no, Code).
+compile_else_branch(ElseGoal, V0, Vf, Code) :-
+    flatten_conjunction(ElseGoal, ElseGoals),
+    compile_inner_call_goals(ElseGoals, V0, Vf, Code).
 
 %% compile_disjunction(+Left, +Right, +V0, -Vf, +HasEnv, -Code)
 %  Compile (A ; B) to WAM try/trust + jump pattern (no cut).

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -914,17 +914,14 @@ flatten_conjunction(Goal, [Goal]).
 %  implementation and just fails.
 compile_if_then_else(CondGoal, ThenGoal, ElseGoal, V0, Vf, _HasEnv, Code) :-
     next_ite_label(ElseLabel, ContLabel),
-    % Flatten condition and then-branch into goal lists
+    % Flatten condition into a goal list
     flatten_conjunction(CondGoal, CondGoals),
-    flatten_conjunction(ThenGoal, ThenGoals),
-    % Compile condition goals as calls (never TCO)
     compile_inner_call_goals(CondGoals, V0, V1, CondCode),
-    % Compile then-branch goals as calls
-    compile_inner_call_goals(ThenGoals, V1, V2, ThenCode),
-    % Compile else-branch -- if it's a nested if-then-else recurse,
-    % otherwise treat it as a flat goal list. Start from V0 since
-    % backtrack restores to before the condition.
-    compile_else_branch(ElseGoal, V0, V3, ElseCode),
+    % Then and Else can each be themselves a nested if-then-else --
+    % compile_ite_branch recurses on those forms. Else starts from
+    % V0 since backtrack restores to before the condition.
+    compile_ite_branch(ThenGoal, V1, V2, ThenCode),
+    compile_ite_branch(ElseGoal, V0, V3, ElseCode),
     % Use the wider variable map as output
     (   V2 = V3 -> Vf = V2
     ;   Vf = V2  % prefer then-branch vars (else-branch is alternative)
@@ -938,20 +935,20 @@ compile_if_then_else(CondGoal, ThenGoal, ElseGoal, V0, Vf, _HasEnv, Code) :-
         "    try_me_else ~w~n~w~n    cut_ite~n~w~n    jump ~w~n~w:~n    trust_me~n~w~n~w:",
         [ElseLabel, CondCode, ThenCode, ContLabel, ElseLabel, ElseCode, ContLabel]).
 
-%% compile_else_branch(+Else, +V0, -Vf, -Code) is det.
-%  The Else position of `(Cond -> Then ; Else)`. If Else is itself
-%  another if-then-else, recurse; otherwise compile as a flat goal
-%  sequence. A bare `(C -> T)` in Else position is interpreted as
-%  `(C -> T ; fail)` -- the branch fails when C fails, matching SWI.
-compile_else_branch((Cond2 -> Then2 ; Else2), V0, Vf, Code) :-
+%% compile_ite_branch(+Branch, +V0, -Vf, -Code) is det.
+%  Compile a Then- or Else-branch of an if-then-else. If the branch
+%  is itself another if-then-else (`(C -> T ; E)` or bare `(C -> T)`,
+%  the latter treated as `(C -> T ; fail)` to match SWI), recurse;
+%  otherwise compile as a flat goal sequence.
+compile_ite_branch((Cond2 -> Then2 ; Else2), V0, Vf, Code) :-
     !,
     compile_if_then_else(Cond2, Then2, Else2, V0, Vf, no, Code).
-compile_else_branch((Cond2 -> Then2), V0, Vf, Code) :-
+compile_ite_branch((Cond2 -> Then2), V0, Vf, Code) :-
     !,
     compile_if_then_else(Cond2, Then2, fail, V0, Vf, no, Code).
-compile_else_branch(ElseGoal, V0, Vf, Code) :-
-    flatten_conjunction(ElseGoal, ElseGoals),
-    compile_inner_call_goals(ElseGoals, V0, Vf, Code).
+compile_ite_branch(Branch, V0, Vf, Code) :-
+    flatten_conjunction(Branch, BranchGoals),
+    compile_inner_call_goals(BranchGoals, V0, Vf, Code).
 
 %% compile_disjunction(+Left, +Right, +V0, -Vf, +HasEnv, -Code)
 %  Compile (A ; B) to WAM try/trust + jump pattern (no cut).

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -3578,6 +3578,53 @@ e2e_cut_ite_barrier_after_helper_via_rscript :-
     assertion(sub_string(Out, _, _, _, "true")),
     delete_directory_and_contents(TmpDir).
 
+% End-to-end: chained `(A -> B ; C -> D ; E)` if-then-else compiles
+% as nested cut_ite/try_me_else_ite pairs, so each branch dispatches
+% on its own Cond. Pre-fix, only the outermost `(A -> B ; rest)` was
+% recognised as an if-then-else; the inner `(C -> D ; E)` in Else
+% position emitted as `Call("->", 2)` (no runtime implementation),
+% so any input that should land on a non-first branch silently
+% failed.
+test(nested_if_then_else_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_nested_if_then_else_via_rscript
+    ;   true
+    )).
+
+e2e_nested_if_then_else_via_rscript :-
+    retractall(user:nite_classify/2),
+    retractall(user:nite_drv_one/0),
+    retractall(user:nite_drv_two/0),
+    retractall(user:nite_drv_three/0),
+    retractall(user:nite_drv_other/0),
+    % Three-way chain: matches arg 1 against 1, 2, 3 in order; falls
+    % through to "other". Each branch sets a distinct atom in arg 2.
+    assertz((user:nite_classify(X, Tag) :-
+        ( X =:= 1 -> Tag = one
+        ; X =:= 2 -> Tag = two
+        ; X =:= 3 -> Tag = three
+        ; Tag = other ))),
+    assertz((user:nite_drv_one   :- nite_classify(1, T), write(T), nl)),
+    assertz((user:nite_drv_two   :- nite_classify(2, T), write(T), nl)),
+    assertz((user:nite_drv_three :- nite_classify(3, T), write(T), nl)),
+    assertz((user:nite_drv_other :- nite_classify(7, T), write(T), nl)),
+    unique_r_tmp_dir('tmp_r_nested_ite_e2e', TmpDir),
+    write_wam_r_project([user:nite_classify/2,
+                         user:nite_drv_one/0, user:nite_drv_two/0,
+                         user:nite_drv_three/0, user:nite_drv_other/0],
+                        [], TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    run_rscript_query(RDir, 'nite_drv_one/0', Out1),
+    assertion(sub_string(Out1, _, _, _, "one")),
+    run_rscript_query(RDir, 'nite_drv_two/0', Out2),
+    assertion(sub_string(Out2, _, _, _, "two")),
+    run_rscript_query(RDir, 'nite_drv_three/0', Out3),
+    assertion(sub_string(Out3, _, _, _, "three")),
+    run_rscript_query(RDir, 'nite_drv_other/0', Out4),
+    assertion(sub_string(Out4, _, _, _, "other")),
+    delete_directory_and_contents(TmpDir).
+
 % ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -3625,6 +3625,33 @@ e2e_nested_if_then_else_via_rscript :-
     assertion(sub_string(Out4, _, _, _, "other")),
     delete_directory_and_contents(TmpDir).
 
+% Compile-time: deeply-nested if-then-else bodies don't blow the
+% clause_body_analysis stack. Pre-fix `disjunction_alternatives/2`
+% unified an unbound goal with `(Left ; Right)`, binding Left and
+% Right to fresh unbounds and recursing into them indefinitely.
+% The nonvar guard makes the function safe to call with any term;
+% as a side benefit the parser's natural-form `parse_op_loop` /
+% `parse_list_elems` bodies (triple-nested ITE) compile cleanly.
+test(deeply_nested_ite_compiles) :-
+    retractall(user:dni_chain/1),
+    % Triple-nested if-then-else. The exact shape that previously
+    % stack-overflowed clause_body_analysis at compile time.
+    assertz((user:dni_chain(X) :-
+        ( integer(X), X > 0
+        -> Y = pos_int
+        ; integer(X), X < 0
+        -> Y = neg_int
+        ; atom(X)
+        -> Y = atom
+        ; Y = other
+        ),
+        write(Y), nl)),
+    set_prolog_flag(stack_limit, 67_108_864),
+    wam_target:compile_predicate_to_wam(user:dni_chain/1, [], Code),
+    string_length(Code, CodeLen),
+    assertion(CodeLen > 0),
+    retractall(user:dni_chain/1).
+
 % ------------------------------------------------------------------
 % Test 8: r_wam bindings module loads
 % ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related compiler-side fixes that close the cross-target Prolog parser story by removing the last in-the-source workarounds. The parser at `src/unifyweaver/core/prolog_term_parser.pl` is now plain natural Prolog throughout — no compiler-quirk dance.

### 1. Nested if-then-else recognition in `compile_if_then_else`

`compile_if_then_else` previously matched only the outermost `(Cond -> Then ; Else)` and compiled both branches as flat goal sequences, so a chain like `(A -> B ; C -> D ; E)` saw the second `->` in Else position emitted as a regular `Call(";", 2)` or `Call("->", 2)`. Neither has a runtime implementation, so the chain silently failed for any input that should have landed on a non-first branch.

Fix: a single `compile_ite_branch/4` helper that recognises three shapes for **both Then and Else** positions:

```prolog
(Cond2 -> Then2 ; Else2)   % recurse with full ITE
(Cond2 -> Then2)           % recurse with `fail` as implicit innermost else (matches SWI)
<anything else>            % flat goal sequence
```

Each level of nesting emits its own `cut_ite` / `try_me_else_ite` pair, so each branch dispatches on its own Cond and the soft-cut barriers stay correctly scoped per-construct.

### 2. `clause_body_analysis:disjunction_alternatives/2` `nonvar` guard

The function had a head pattern `(Left ; Right)` that happily unified with an unbound goal, binding Left and Right to fresh unbounds and recursing into them — each recursion manufactured more unbounds, producing infinite expansion. The WAM compiler's analysis pass on bodies whose if-then-else trees temporarily expose unbound subterms hit this shape and stack-overflowed at compile time (depth 424,468 frames before SWI killed the process).

Fix: guard with `nonvar(Goal)` before the head pattern. Unbound goals fall through to the second clause and return `[Goal]` — a single-alternative result that callers handle correctly.

This is a shared module — affects all five targets that use `clause_body_analysis` (jython, powershell, fsharp, krakatau, rust) plus the WAM target's `is_guard_goal` path. The history note: `clause_body_analysis` was originally for mutual-recursion detection. It became much more widely adopted across targets after rust started using its multifile API (`render_output_goal` / `render_guard_condition` / `render_branch_value` / `render_ite_block`) for native kernel lowering. So this fix benefits all of them.

(`typr_target` has its own forked `typr_disjunction_alternatives` with the same shape; out of scope here but worth noting.)

## Parser cleanup

- `parse_args` restored to natural 2-way ITE (was clause-level `parse_args_continue` workaround for the nested-ITE bug).
- `parse_op_loop` and `parse_list_elems` restored to natural deeply-nested ITE (was clause-level `op_loop_step` / `list_elem_continue` workarounds for the stack-overflow bug).

The cross-target parser source has **zero** in-the-source workarounds for compiler quirks.

## Test plan

- [x] New `nested_if_then_else_e2e_rscript`: 4-way classifier `( X =:= 1 -> one ; X =:= 2 -> two ; X =:= 3 -> three ; other )` exercised on inputs 1, 2, 3, and 7 — each lands on the expected branch.
- [x] New `deeply_nested_ite_compiles`: triple-nested if-then-else body compiles cleanly via `wam_target:compile_predicate_to_wam`. Pre-fix this stack-overflowed at depth 424k frames.
- [x] Full WAM-R suite: **70/70** (was 68, +2 new).
- [x] `prolog_term_parser` SWI suite: 25/25.
- [x] `prolog_term_parser_wam_r_compile`: 3/3.

## Where the loop stands now

The cross-target Prolog parser story is **structurally complete on the compiler/runtime side**. Remaining handoff items:

- **#3 Inline `WamRuntime$parse_term` swap-in** (medium-large; needs benchmarks first).
- **#4 Strict `xf` precedence rule** (small; semantic refinement).
- **#5+** Mode analysis, multi-line `read/2`, multi-solution `retract/1`, Phase-3 expansion, range indexes.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd