### PR TITLE
feat(wam-clojure): lower length builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -348,6 +348,10 @@ clojure_direct_builtin("is_list/1", "1").
 clojure_direct_builtin("is_list/1", 1).
 clojure_direct_builtin('is_list/1', "1").
 clojure_direct_builtin('is_list/1', 1).
+clojure_direct_builtin("length/2", "2").
+clojure_direct_builtin("length/2", 2).
+clojure_direct_builtin('length/2', "2").
+clojure_direct_builtin('length/2', 2).
 clojure_direct_builtin("ground/1", "1").
 clojure_direct_builtin("ground/1", 1).
 clojure_direct_builtin('ground/1', "1").
@@ -530,6 +534,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr),
            '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (runtime/proper-list-term? ~w value) (runtime/advance ~w) (runtime/backtrack ~w)))',
            [S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "length/2" ; Op == 'length/2'),
+    !,
+    format(atom(Expr),
+           '(let [list-value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) len (runtime/proper-list-length ~w list-value) out (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound))] (if (some? len) (let [[ok next-state] (runtime/unify-values ~w out len)] (if ok (runtime/advance next-state) (runtime/backtrack ~w))) (runtime/backtrack ~w)))',
+           [S, S, S, S, S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "ground/1" ; Op == 'ground/1'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -475,6 +475,23 @@
         (recur (deref-value bindings (second (:args cur))) (conj seen cur))
         :else false))))
 
+(defn proper-list-length [state value]
+  (let [bindings (:bindings state)
+        empty-list (normalize-literal-atom (:intern-context state) "[]")
+        list-functor (list-functor-term (:intern-context state))]
+    (loop [cur (deref-value bindings value)
+           seen #{}
+           n 0]
+      (cond
+        (interned-equal? cur empty-list) n
+        (or (= cur ::unbound) (logic-var? cur)) nil
+        (contains? seen cur) nil
+        (and (structure-term? cur)
+             (interned-equal? (:functor cur) list-functor)
+             (= 2 (count (:args cur))))
+        (recur (deref-value bindings (second (:args cur))) (conj seen cur) (inc n))
+        :else nil))))
+
 (defn ground-term? [state value]
   (let [bindings (:bindings state)]
     (letfn [(ground* [term seen]
@@ -1054,6 +1071,19 @@
                                    (or (reg-get-raw state "A1") ::unbound))]
             (if (proper-list-term? state value)
               (advance state)
+              (backtrack state)))
+
+          "length/2"
+          (let [list-value (deref-value (:bindings state)
+                                        (or (reg-get-raw state "A1") ::unbound))
+                len (proper-list-length state list-value)
+                out (deref-value (:bindings state)
+                                 (or (reg-get-raw state "A2") ::unbound))]
+            (if (some? len)
+              (let [[ok next-state] (unify-values state out len)]
+                (if ok
+                  (advance next-state)
+                  (backtrack state)))
               (backtrack state)))
 
           "ground/1"

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -125,6 +125,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, '"callable/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"float/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"is_list/1"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"length/2"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"ground/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -438,6 +438,18 @@ test(terminal_execute_is_list_is_direct_lowered_as_succeeding_builtin) :-
         assertion(\+ has(Code, ":pc target-pc"))
     )).
 
+test(simple_builtin_length_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_length/2:\nbuiltin_call length/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_length/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_length/2, WamCode, [], Code),
+        has(Code, "runtime/deref-value"),
+        has(Code, "runtime/proper-list-length"),
+        has(Code, "runtime/unify-values"),
+        has(Code, "runtime/advance"),
+        has(Code, "runtime/backtrack")
+    )).
+
 test(simple_builtin_ground_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_ground/1:\nbuiltin_call ground/1, 1\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -55,6 +55,9 @@
 :- dynamic user:wam_float_unbound/1.
 :- dynamic user:wam_is_list_guard/1.
 :- dynamic user:wam_is_list_unbound/1.
+:- dynamic user:wam_length_guard/2.
+:- dynamic user:wam_length_bad_list/1.
+:- dynamic user:wam_length_unbound_list/1.
 :- dynamic user:wam_ground_guard/1.
 :- dynamic user:wam_ground_unbound/1.
 :- dynamic user:wam_ground_nested_unbound/1.
@@ -131,6 +134,9 @@ user:wam_float_guard(X) :- float(X).
 user:wam_float_unbound(_) :- user:wam_unbound_arg(Y), float(Y).
 user:wam_is_list_guard(X) :- is_list(X).
 user:wam_is_list_unbound(_) :- user:wam_unbound_arg(Y), is_list(Y).
+user:wam_length_guard(L, N) :- length(L, N).
+user:wam_length_bad_list(N) :- length([a|b], N).
+user:wam_length_unbound_list(N) :- user:wam_unbound_arg(Y), length(Y, N).
 user:wam_ground_guard(X) :- ground(X).
 user:wam_ground_unbound(_) :- user:wam_unbound_arg(Y), ground(Y).
 user:wam_ground_nested_unbound(_) :- user:wam_unbound_arg(Y), ground(f(Y)).
@@ -212,6 +218,9 @@ run_smoke :-
           user:wam_float_unbound/1,
           user:wam_is_list_guard/1,
           user:wam_is_list_unbound/1,
+          user:wam_length_guard/2,
+          user:wam_length_bad_list/1,
+          user:wam_length_unbound_list/1,
           user:wam_ground_guard/1,
           user:wam_ground_unbound/1,
           user:wam_ground_nested_unbound/1,
@@ -259,6 +268,7 @@ run_smoke :-
     assert_lowered_callable_builtin_emitted(TmpDir),
     assert_lowered_float_builtin_emitted(TmpDir),
     assert_lowered_is_list_builtin_emitted(TmpDir),
+    assert_lowered_length_builtin_emitted(TmpDir),
     assert_lowered_ground_builtin_emitted(TmpDir),
     assert_lowered_arithmetic_comparison_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
@@ -356,6 +366,11 @@ run_smoke :-
     verify_output(TmpDir, 'wam_is_list_guard/1', a, "false"),
     verify_output(TmpDir, 'wam_is_list_guard/1', 'f(a)', "false"),
     verify_output(TmpDir, 'wam_is_list_unbound/1', a, "false"),
+    verify_output(TmpDir, 'wam_length_guard/2', args('[a,b]', 2), "true"),
+    verify_output(TmpDir, 'wam_length_guard/2', args('[a,b]', 1), "false"),
+    verify_output(TmpDir, 'wam_length_guard/2', args('[]', 0), "true"),
+    verify_output(TmpDir, 'wam_length_bad_list/1', 1, "false"),
+    verify_output(TmpDir, 'wam_length_unbound_list/1', 0, "false"),
     verify_output(TmpDir, 'wam_ground_guard/1', a, "true"),
     verify_output(TmpDir, 'wam_ground_guard/1', 42, "true"),
     verify_output(TmpDir, 'wam_ground_guard/1', 3.5, "true"),
@@ -516,6 +531,14 @@ assert_lowered_is_list_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-is-list-unbound-1"),
     has(CoreCode, "runtime/proper-list-term?").
 
+assert_lowered_length_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-length-guard-2"),
+    has(CoreCode, "defn lowered-wam-length-bad-list-1"),
+    has(CoreCode, "defn lowered-wam-length-unbound-list-1"),
+    has(CoreCode, "runtime/proper-list-length").
+
 assert_lowered_ground_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
@@ -582,6 +605,24 @@ verify_output(ProjectDir, PredKey, Arg, Expected) :-
     ;   throw(error(assertion_error(PredKey, Arg, Expected, Actual), _))
     ).
 
+run_clojure_predicate(ProjectDir, PredKey, args(Arg1, Arg2), Output) :-
+    find_clojure_classpath(ClassPath),
+    prolog_term_string_to_edn(Arg1, EdnArg1),
+    prolog_term_string_to_edn(Arg2, EdnArg2),
+    process_create(path(java),
+                   ['-cp', ClassPath, 'clojure.main', '-m',
+                    'generated.wam_exec_test.core', PredKey, EdnArg1, EdnArg2],
+                   [cwd(ProjectDir), stdout(pipe(Out)), stderr(pipe(Err))]),
+    read_string(Out, _, OutStr0),
+    read_string(Err, _, ErrStr),
+    close(Out),
+    close(Err),
+    normalize_space(string(Output), OutStr0),
+    (   ErrStr == ""
+    ->  true
+    ;   throw(error(java_stderr(PredKey, args(Arg1, Arg2), ErrStr), _))
+    ).
+
 run_clojure_predicate(ProjectDir, PredKey, Arg, Output) :-
     find_clojure_classpath(ClassPath),
     prolog_term_string_to_edn(Arg, EdnArg),
@@ -606,6 +647,7 @@ prolog_term_string_to_edn(d, "\"d\"") :- !.
 prolog_term_string_to_edn(z, "\"z\"") :- !.
 prolog_term_string_to_edn('[]', "\"[]\"") :- !.
 prolog_term_string_to_edn(-42, "-42") :- !.
+prolog_term_string_to_edn(0, "0") :- !.
 prolog_term_string_to_edn(1, "1") :- !.
 prolog_term_string_to_edn(2, "2") :- !.
 prolog_term_string_to_edn(2.5, "2.5") :- !.


### PR DESCRIPTION
## Summary

- Adds direct lowered Clojure WAM support for `length/2`.
- Adds a `proper-list-length` runtime helper for normalized `[|]/2` list terms.
- Adds runtime `length/2` dispatch that measures `A1` and unifies/checks `A2`.
- Extends generator, lowered-emitter, and runtime smoke fixtures.

## Why

The Clojure WAM target now directly lowers arithmetic assignment and comparisons. `length/2` is a natural next builtin because it also binds or checks a numeric output, and it is a common list primitive needed by broader Prolog workloads.

The implementation is conservative: it succeeds only for proper finite lists and fails for improper lists, unbound list inputs, and length mismatches.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- Targeted generated Clojure runtime checks for:
  - `wam_length_guard/2 [a,b], 2 -> true`
  - `wam_length_guard/2 [a,b], 1 -> false`
  - `wam_length_guard/2 [], 0 -> true`
  - `wam_length_bad_list/1 1 -> false`
  - `wam_length_unbound_list/1 0 -> false`

## Termux Note

The full `tests/test_wam_clojure_runtime_smoke.pl` run still times out in this Termux environment, consistent with the pre-existing smoke-test hang. The generated project was inspected and the new `length/2` runtime paths were validated directly with one JVM invocation at a time.
