### PR TITLE
fix(wam-haskell): make read_kernel_template/2 cwd-independent

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -482,7 +482,12 @@ config_ops_to_template_vars([Op|Rest], [Key=Value|RestVars]) :-
 
 read_kernel_template(FileName, Template) :-
     atom_concat('templates/targets/haskell_wam/', FileName, RelPath),
-    (   source_file(wam_haskell_target, SrcFile)
+    %% Resolve the project root from this module's source file rather than
+    %% trusting the caller's cwd. Walks up: targets/ → unifyweaver/ → src/
+    %% → project root. Uses a callable head (`read_kernel_template/2`) so
+    %% source_file/2 actually matches; the bare-atom form was a no-op and
+    %% silently fell through to a cwd-relative path.
+    (   source_file(read_kernel_template(_,_), SrcFile)
     ->  file_directory_name(SrcFile, SrcDir),
         file_directory_name(SrcDir, TargetsDir),
         file_directory_name(TargetsDir, UnifyWeaverDir),


### PR DESCRIPTION
  ## Summary

  `read_kernel_template/2` calls `source_file(wam_haskell_target, SrcFile)`
  to find this module's source path and walk up to the project root. But
  `source_file/2` expects a *callable head* (e.g. `foo(_,_)`), not a bare
  module-name atom — so the lookup silently failed and the predicate fell
  through to a cwd-relative `RelPath`.

  That accidentally worked when tests were run from the project root
  (every standard invocation does this), but broke completely from any
  other cwd, producing "Template not found" errors and cascading test
  failures throughout `test_wam_haskell_target.pl`.

  The fix is a one-character conceptual change: pass `read_kernel_template(_,_)`
  instead of `wam_haskell_target` to `source_file/2`. Now the absolute
  path resolves correctly regardless of cwd.

  ## Why this matters

  This was a long-standing latent bug, not a recent regression. It
  became visible during the cache-warming microbench work because
  `cd`-ing into a sub-project to run `cabal new-build` left the shell
  in a non-root cwd, and subsequent `swipl` invocations against the
  template-loading code path silently produced "Template not found"
  strings instead of real templates. Tests then asserted on substrings
  that weren't present.

  With the fix:

  - All 147 tests in `test_wam_haskell_target.pl` pass from the project
    root (as before).
  - All 147 also pass from `/tmp`, from
    `examples/benchmark/cache_warming_microbench/`, or any other cwd.
  - All 21 tests in `tests/core/test_cost_model.pl` continue to pass.

  ## What changed

  `src/unifyweaver/targets/wam_haskell_target.pl` (6+, 1−) — the
  `source_file/2` call now uses a callable head. Comment added explaining
  why the bare-atom form was a no-op, so we don't reintroduce the bug.

  No template or codegen logic changes. Pure path-resolution fix.

  ## Test plan

  - [x] `tests/test_wam_haskell_target.pl` — 147/147 from project root
  - [x] `tests/test_wam_haskell_target.pl` — 147/147 from `/tmp`
  - [x] `tests/core/test_cost_model.pl` — 21/21 from any cwd