### PR TITLE
bench(csharp-query): emit stability calibration TSV

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -131,6 +131,12 @@ summarize stable winners. Values above `1` report majority winners, winner
 counts, stable resolved `auto` modes, and per-mode median timings across the
 independent runs.
 
+Use `--format calibration-tsv` when refreshing
+`csharp_query_graph_source_mode_calibration.tsv`. Combined with
+`--stability-runs <n>`, it emits artifact-compatible rows whose median timing
+fields come from the independent-run stability summary instead of one noisy
+single run.
+
 Mixed-scale sweeps are filtered per workload. File-backed graph workloads can
 use `dev`, `300`, `1k`, `5k`, and `10k`; generated dependency-depth workloads
 use `300`, `1k`, `5k`, and `10k`. Unsupported workload/scale pairs are skipped

--- a/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
+++ b/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
@@ -125,7 +125,7 @@ def parse_args() -> argparse.Namespace:
             "Values above 1 print a stability summary instead of the raw per-run table."
         ),
     )
-    parser.add_argument("--format", choices=["tsv", "markdown"], default="tsv")
+    parser.add_argument("--format", choices=["tsv", "markdown", "calibration-tsv"], default="tsv")
     parser.add_argument(
         "--trace",
         action="store_true",
@@ -531,6 +531,66 @@ def summarize_stability(sweep_runs: list[list[SourceModeSummary]]) -> list[Sourc
     return stability
 
 
+def calibration_rows_from_summaries(summaries: list[SourceModeSummary]) -> list[CalibrationArtifactRow]:
+    rows: list[CalibrationArtifactRow] = []
+    for summary in sorted(summaries, key=lambda item: _calibration_key_sort_key((item.workload, item.scale))):
+        rows.append(
+            CalibrationArtifactRow(
+                workload=summary.workload,
+                scale=summary.scale,
+                observed_best_source_mode=summary.best_source_mode,
+                current_auto_resolved_source_mode=parse_mode_summary(
+                    summary.resolved_source_mode_summary
+                ).get("auto", ""),
+                observed_auto_vs_best=summary.auto_vs_best,
+                output_agreement=summary.output_agreement,
+                median_summary=summary.median_summary,
+                resolved_source_mode_summary=summary.resolved_source_mode_summary,
+                source_registration_summary=summary.source_registration_summary,
+            )
+        )
+    return rows
+
+
+def calibration_rows_from_stability(
+    stability_summaries: list[SourceModeStabilitySummary],
+    sweep_runs: list[list[SourceModeSummary]],
+) -> list[CalibrationArtifactRow]:
+    summaries_by_key: dict[tuple[str, str], list[SourceModeSummary]] = {}
+    for run in sweep_runs:
+        for summary in run:
+            summaries_by_key.setdefault((summary.workload, summary.scale), []).append(summary)
+
+    rows: list[CalibrationArtifactRow] = []
+    for summary in stability_summaries:
+        key = (summary.workload, summary.scale)
+        raw_summaries = summaries_by_key.get(key, [])
+        rows.append(
+            CalibrationArtifactRow(
+                workload=summary.workload,
+                scale=summary.scale,
+                observed_best_source_mode=(
+                    summary.stable_best_source_mode
+                    or _first_count_value(summary.best_source_mode_counts)
+                ),
+                current_auto_resolved_source_mode=(
+                    summary.stable_auto_resolved_source_mode
+                    or _first_count_value(summary.auto_resolved_source_mode_counts)
+                ),
+                observed_auto_vs_best=summary.auto_vs_best_median,
+                output_agreement=summary.output_agreement,
+                median_summary=summary.median_summary,
+                resolved_source_mode_summary=_most_common_nonempty(
+                    item.resolved_source_mode_summary for item in raw_summaries
+                ),
+                source_registration_summary=_most_common_nonempty(
+                    item.source_registration_summary for item in raw_summaries
+                ),
+            )
+        )
+    return rows
+
+
 def _value_counts(values: list[str]) -> str:
     counts: dict[str, int] = {}
     for value in values:
@@ -539,6 +599,24 @@ def _value_counts(values: list[str]) -> str:
         f"{value}:{count}"
         for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
     )
+
+
+def _first_count_value(counts: str) -> str:
+    first = split_csv(counts)
+    if not first or ":" not in first[0]:
+        return ""
+    return first[0].split(":", 1)[0]
+
+
+def _most_common_nonempty(values: Iterable[str]) -> str:
+    counts: dict[str, int] = {}
+    for value in values:
+        if not value:
+            continue
+        counts[value] = counts.get(value, 0) + 1
+    if not counts:
+        return ""
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))[0][0]
 
 
 def _majority_value(values: list[str], total_count: int) -> str:
@@ -788,6 +866,17 @@ def print_stability_markdown(summaries: list[SourceModeStabilitySummary]) -> Non
         )
 
 
+def print_calibration_tsv(rows: list[CalibrationArtifactRow]) -> None:
+    print("workload\tscale\tobserved_best_source_mode\tcurrent_auto_resolved_source_mode\tobserved_auto_vs_best\toutput_agreement\tmedian_s_by_mode\tresolved_source_modes_by_mode\tsource_registrations_by_mode")
+    for row in rows:
+        print(
+            f"{row.workload}\t{row.scale}\t{row.observed_best_source_mode}\t"
+            f"{row.current_auto_resolved_source_mode}\t{row.observed_auto_vs_best}\t"
+            f"{row.output_agreement}\t{row.median_summary}\t"
+            f"{row.resolved_source_mode_summary}\t{row.source_registration_summary}"
+        )
+
+
 def main() -> int:
     args = parse_args()
     workloads = parse_workloads(args.workloads)
@@ -843,12 +932,18 @@ def main() -> int:
 
     if args.stability_runs > 1:
         stability_summaries = summarize_stability(sweep_runs)
-        if args.format == "markdown":
+        if args.format == "calibration-tsv":
+            print_calibration_tsv(
+                calibration_rows_from_stability(stability_summaries, sweep_runs)
+            )
+        elif args.format == "markdown":
             print_stability_markdown(stability_summaries)
         else:
             print_stability_tsv(stability_summaries)
     else:
-        if args.format == "markdown":
+        if args.format == "calibration-tsv":
+            print_calibration_tsv(calibration_rows_from_summaries(summaries))
+        elif args.format == "markdown":
             print_markdown(summaries)
         else:
             print_tsv(summaries)

--- a/tests/test_csharp_query_source_mode_sweep.py
+++ b/tests/test_csharp_query_source_mode_sweep.py
@@ -17,6 +17,8 @@ from benchmark_csharp_query_source_mode_sweep import (  # noqa: E402
     SourceModeSummary,
     WORKLOAD_SCRIPTS,
     calibration_failures,
+    calibration_rows_from_stability,
+    calibration_rows_from_summaries,
     compare_calibration,
     filter_workload_scales,
     load_calibration_artifact,
@@ -279,6 +281,76 @@ class CSharpQuerySourceModeSweepTests(unittest.TestCase):
 
         self.assertEqual(stability[0].stable_best_source_mode, "")
         self.assertEqual(stability[0].best_source_mode_counts, "auto:1,preload:1")
+
+    def test_calibration_rows_from_summaries_match_artifact_shape(self) -> None:
+        rows = calibration_rows_from_summaries(
+            [
+                self._summary(
+                    resolved_source_mode_summary="artifact-prebuilt:artifact-prebuilt,auto:preload",
+                    source_registration_summary="auto:preloaded_preload_arity2=2",
+                )
+            ]
+        )
+
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row.workload, "category-influence")
+        self.assertEqual(row.scale, "300")
+        self.assertEqual(row.observed_best_source_mode, "preload")
+        self.assertEqual(row.current_auto_resolved_source_mode, "preload")
+        self.assertEqual(row.observed_auto_vs_best, "1.30x")
+        self.assertEqual(row.output_agreement, "match")
+        self.assertEqual(
+            row.median_summary,
+            "artifact-prebuilt:0.904,auto:0.467,preload:0.360",
+        )
+        self.assertEqual(
+            row.resolved_source_mode_summary,
+            "artifact-prebuilt:artifact-prebuilt,auto:preload",
+        )
+        self.assertEqual(row.source_registration_summary, "auto:preloaded_preload_arity2=2")
+
+    def test_calibration_rows_from_stability_use_median_timing_fields(self) -> None:
+        run_one = self._summary(
+            best_source_mode="preload",
+            auto_vs_best="1.30x",
+            median_summary="artifact-prebuilt:0.904,auto:0.467,preload:0.360",
+            resolved_source_mode_summary="artifact-prebuilt:artifact-prebuilt,auto:preload",
+            source_registration_summary="auto:preloaded_preload_arity2=2",
+        )
+        run_two = self._summary(
+            best_source_mode="auto",
+            auto_vs_best="1.00x",
+            median_summary="artifact-prebuilt:0.800,auto:0.200,preload:0.400",
+            resolved_source_mode_summary="artifact-prebuilt:artifact-prebuilt,auto:preload",
+            source_registration_summary="auto:preloaded_preload_arity2=2",
+        )
+        run_three = self._summary(
+            best_source_mode="auto",
+            auto_vs_best="1.00x",
+            median_summary="artifact-prebuilt:1.000,auto:0.300,preload:0.500",
+            resolved_source_mode_summary="artifact-prebuilt:artifact-prebuilt,auto:preload",
+            source_registration_summary="auto:preloaded_preload_arity2=2",
+        )
+        sweep_runs = [[run_one], [run_two], [run_three]]
+        stability = summarize_stability(sweep_runs)
+
+        rows = calibration_rows_from_stability(stability, sweep_runs)
+
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row.observed_best_source_mode, "auto")
+        self.assertEqual(row.current_auto_resolved_source_mode, "preload")
+        self.assertEqual(row.observed_auto_vs_best, "1.00x")
+        self.assertEqual(
+            row.median_summary,
+            "artifact-prebuilt:0.904,auto:0.300,preload:0.400",
+        )
+        self.assertEqual(
+            row.resolved_source_mode_summary,
+            "artifact-prebuilt:artifact-prebuilt,auto:preload",
+        )
+        self.assertEqual(row.source_registration_summary, "auto:preloaded_preload_arity2=2")
 
     def test_parse_runner_output_summarizes_modes_and_registrations(self) -> None:
         output = "\n".join(


### PR DESCRIPTION
  ## Summary

  - Adds `--format calibration-tsv` to the C# query source-mode sweep wrapper.
  - Emits artifact-compatible rows for `csharp_query_graph_source_mode_calibration.tsv`.
  - Uses stability medians when combined with `--stability-runs > 1`, reducing calibration churn from single-run timing
  noise.
  - Preserves policy/output/source-registration fields from the underlying sweep rows.
  - Documents the stability-based calibration refresh workflow.
  - Adds unit coverage for raw-summary and stability-summary calibration row conversion.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_source_mode_sweep.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_source_mode_sweep.py tests/
  test_csharp_query_source_mode_sweep.py`
  - `python3 examples/benchmark/benchmark_csharp_query_source_mode_sweep.py --workloads dependency-depth --scales 300
  --source-modes auto,preload,artifact-prebuilt --repetitions 1 --stability-runs 2 --format calibration-tsv`
  - `git diff --check`