### PR TITLE
Feature/lua wam structural builtin parity

### DIFF
--- a/PR_lua_wam_structural_builtin_parity.md
+++ b/PR_lua_wam_structural_builtin_parity.md
@@ -1,0 +1,18 @@
+# PR Title
+
+Add Lua WAM structural and builtin parity
+
+# PR Description
+
+## Summary
+
+- add Lua WAM runtime support for `member/2` with choice-point backtracking over list alternatives
+- add Lua WAM runtime support for `length/2` over WAM cons-list terms
+- add Rust/Haskell parity builtins for Lua WAM type checks and comparisons: `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `var/1`, `nonvar/1`, `is_list/1`, `==/2`, `=:=/2`, `=\=/2`, `>/2`, `</2`, `>=/2`, and `=</2`
+- add Lua generator end-to-end coverage for structural, type, and comparison builtin behavior
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`

--- a/templates/targets/lua_wam/runtime.lua.mustache
+++ b/templates/targets/lua_wam/runtime.lua.mustache
@@ -281,6 +281,25 @@ function Runtime.backtrack(state)
     state.halt = false
     return true
   end
+  if cp.kind == "member" then
+    while #state.trail > cp.trail_len do
+      local name = table.remove(state.trail)
+      state.bindings[name] = nil
+    end
+    state.regs = Runtime.copy_table(cp.regs)
+    state.cp = cp.cp
+    state.var_counter = cp.var_counter
+    state.mode = cp.mode
+    state.build_stack = cp.build_stack or {}
+    local value = table.remove(cp.values, 1)
+    if #cp.values == 0 then table.remove(state.cps) end
+    if Runtime.unify(state, Runtime.get_reg(state, 1), value) ~= true then
+      return Runtime.backtrack(state)
+    end
+    state.pc = cp.next_pc
+    state.halt = false
+    return true
+  end
   if cp.kind == "aggregate" then
     table.remove(state.cps)
     while #state.trail > cp.trail_len do
@@ -323,6 +342,49 @@ function Runtime.list_from_terms(items, intern_table)
     out = V.Struct(cons_id, { items[i], out })
   end
   return out
+end
+
+local bind_or_compare
+
+local function list_items(program, state, list)
+  local nil_id = Runtime.intern(program.intern_table, "[]")
+  local cons_id = Runtime.intern(program.intern_table, "[|]")
+  local items = {}
+  local cur = Runtime.deref(state, list)
+  while type(cur) == "table" do
+    if cur.tag == "atom" and cur.id == nil_id then return items end
+    if cur.tag ~= "struct" or cur.fid ~= cons_id or #(cur.args or {}) ~= 2 then return nil end
+    table.insert(items, cur.args[1])
+    cur = Runtime.deref(state, cur.args[2])
+  end
+  return nil
+end
+
+local function builtin_member(program, state)
+  local items = list_items(program, state, Runtime.get_reg(state, 2))
+  if items == nil or #items == 0 then return false end
+  if #items > 1 then
+    local rest = {}
+    for i = 2, #items do rest[#rest + 1] = items[i] end
+    table.insert(state.cps, {
+      kind = "member",
+      next_pc = state.pc + 1,
+      regs = Runtime.copy_table(state.regs),
+      cp = state.cp,
+      trail_len = #state.trail,
+      var_counter = state.var_counter,
+      mode = state.mode,
+      build_stack = state.build_stack,
+      values = rest
+    })
+  end
+  return Runtime.unify(state, Runtime.get_reg(state, 1), items[1])
+end
+
+local function builtin_length(program, state)
+  local items = list_items(program, state, Runtime.get_reg(state, 1))
+  if items == nil then return false end
+  return bind_or_compare(state, 2, V.Int(#items))
 end
 
 local function numeric_value(v)
@@ -626,7 +688,7 @@ local function number_value(v)
   return nil
 end
 
-local function bind_or_compare(state, idx, val)
+bind_or_compare = function(state, idx, val)
   local cur = Runtime.get_reg(state, idx)
   if cur == nil then Runtime.put_reg(state, idx, val); return true end
   return Runtime.unify(state, cur, val)
@@ -635,6 +697,8 @@ end
 function Runtime.builtin_call(program, state, instr)
   local p = instr.pred
   if p == "=" or p == "=/2" then return Runtime.unify(state, Runtime.get_reg(state, 1), Runtime.get_reg(state, 2)) end
+  if p == "member" or p == "member/2" then return builtin_member(program, state) end
+  if p == "length" or p == "length/2" then return builtin_length(program, state) end
   if p == "is" or p == "is/2" then
     local n = number_value(Runtime.deref(state, Runtime.get_reg(state, 2)))
     if n == nil then return false end

--- a/templates/targets/lua_wam/runtime.lua.mustache
+++ b/templates/targets/lua_wam/runtime.lua.mustache
@@ -392,6 +392,48 @@ local function numeric_value(v)
   return nil
 end
 
+local function exact_equal(state, a, b)
+  a = Runtime.deref(state, a)
+  b = Runtime.deref(state, b)
+  if type(a) ~= "table" or type(b) ~= "table" then return a == b end
+  if a.tag ~= b.tag then return false end
+  if a.tag == "unbound" then return a.name == b.name end
+  if a.tag == "atom" then return a.id == b.id end
+  if a.tag == "int" or a.tag == "float" then return a.val == b.val end
+  if a.tag == "struct" then
+    if a.fid ~= b.fid or #(a.args or {}) ~= #(b.args or {}) then return false end
+    for i = 1, #a.args do
+      if exact_equal(state, a.args[i], b.args[i]) ~= true then return false end
+    end
+    return true
+  end
+  return false
+end
+
+local function type_builtin(program, state, pred)
+  if pred ~= "atom" and pred ~= "atom/1"
+      and pred ~= "integer" and pred ~= "integer/1"
+      and pred ~= "float" and pred ~= "float/1"
+      and pred ~= "number" and pred ~= "number/1"
+      and pred ~= "compound" and pred ~= "compound/1"
+      and pred ~= "var" and pred ~= "var/1"
+      and pred ~= "nonvar" and pred ~= "nonvar/1"
+      and pred ~= "is_list" and pred ~= "is_list/1" then
+    return nil
+  end
+  local val = Runtime.deref(state, Runtime.get_reg(state, 1))
+  if type(val) ~= "table" then return false end
+  if pred == "atom" or pred == "atom/1" then return val.tag == "atom" end
+  if pred == "integer" or pred == "integer/1" then return val.tag == "int" end
+  if pred == "float" or pred == "float/1" then return val.tag == "float" end
+  if pred == "number" or pred == "number/1" then return val.tag == "int" or val.tag == "float" end
+  if pred == "compound" or pred == "compound/1" then return val.tag == "struct" end
+  if pred == "var" or pred == "var/1" then return val.tag == "unbound" end
+  if pred == "nonvar" or pred == "nonvar/1" then return val.tag ~= "unbound" end
+  if pred == "is_list" or pred == "is_list/1" then return list_items(program, state, val) ~= nil end
+  return nil
+end
+
 local function term_key(v)
   if type(v) ~= "table" then return tostring(v) end
   if v.tag == "atom" then return "a:" .. tostring(v.id) end
@@ -696,7 +738,10 @@ end
 
 function Runtime.builtin_call(program, state, instr)
   local p = instr.pred
+  local type_ok = type_builtin(program, state, p)
+  if type_ok ~= nil then return type_ok end
   if p == "=" or p == "=/2" then return Runtime.unify(state, Runtime.get_reg(state, 1), Runtime.get_reg(state, 2)) end
+  if p == "==" or p == "==/2" then return exact_equal(state, Runtime.get_reg(state, 1), Runtime.get_reg(state, 2)) end
   if p == "member" or p == "member/2" then return builtin_member(program, state) end
   if p == "length" or p == "length/2" then return builtin_length(program, state) end
   if p == "is" or p == "is/2" then
@@ -704,20 +749,35 @@ function Runtime.builtin_call(program, state, instr)
     if n == nil then return false end
     return bind_or_compare(state, 1, math.type and math.type(n) == "integer" and V.Int(n) or V.Float(n))
   end
-  if p == "=:=" then
+  if p == "=:=" or p == '=:=/2' then
     local a = number_value(Runtime.deref(state, Runtime.get_reg(state, 1)))
     local b = number_value(Runtime.deref(state, Runtime.get_reg(state, 2)))
     return a ~= nil and b ~= nil and a == b
   end
-  if p == ">" then
+  if p == "=\\=" or p == "=\\=/2" then
+    local a = number_value(Runtime.deref(state, Runtime.get_reg(state, 1)))
+    local b = number_value(Runtime.deref(state, Runtime.get_reg(state, 2)))
+    return a ~= nil and b ~= nil and a ~= b
+  end
+  if p == ">" or p == ">/2" then
     local a = number_value(Runtime.deref(state, Runtime.get_reg(state, 1)))
     local b = number_value(Runtime.deref(state, Runtime.get_reg(state, 2)))
     return a ~= nil and b ~= nil and a > b
   end
-  if p == "<" then
+  if p == "<" or p == "</2" then
     local a = number_value(Runtime.deref(state, Runtime.get_reg(state, 1)))
     local b = number_value(Runtime.deref(state, Runtime.get_reg(state, 2)))
     return a ~= nil and b ~= nil and a < b
+  end
+  if p == ">=" or p == ">=/2" then
+    local a = number_value(Runtime.deref(state, Runtime.get_reg(state, 1)))
+    local b = number_value(Runtime.deref(state, Runtime.get_reg(state, 2)))
+    return a ~= nil and b ~= nil and a >= b
+  end
+  if p == "=<" or p == "=</2" then
+    local a = number_value(Runtime.deref(state, Runtime.get_reg(state, 1)))
+    local b = number_value(Runtime.deref(state, Runtime.get_reg(state, 2)))
+    return a ~= nil and b ~= nil and a <= b
   end
   return false
 end

--- a/tests/test_wam_lua_generator.pl
+++ b/tests/test_wam_lua_generator.pl
@@ -34,6 +34,10 @@
 :- dynamic user:wam_lua_length_basic/0.
 :- dynamic user:wam_lua_length_bind/0.
 :- dynamic user:wam_lua_length_no/0.
+:- dynamic user:wam_lua_type_builtins/0.
+:- dynamic user:wam_lua_type_var/0.
+:- dynamic user:wam_lua_type_no/0.
+:- dynamic user:wam_lua_compare_builtins/0.
 
 user:wam_lua_fact(a).
 user:wam_lua_choice(a).
@@ -78,6 +82,21 @@ user:wam_lua_member_no :- member(d, [a, b, c]).
 user:wam_lua_length_basic :- length([a, b, c], 3).
 user:wam_lua_length_bind :- length([a, b, c], N), N = 3.
 user:wam_lua_length_no :- length([a, b, c], 2).
+user:wam_lua_type_builtins :-
+    atom(a),
+    integer(3),
+    number(3),
+    compound(f(a)),
+    nonvar(a),
+    is_list([a, b]).
+user:wam_lua_type_var :- var(_).
+user:wam_lua_type_no :- atom(3).
+user:wam_lua_compare_builtins :-
+    3 >= 2,
+    2 =< 3,
+    3 =:= 3,
+    3 =\= 2,
+    a == a.
 
 test(exports) :-
     assertion(current_predicate(wam_lua_target:write_wam_lua_project/3)),
@@ -365,6 +384,26 @@ test(lua_structural_builtins_e2e, [condition(lua_available)]) :-
           run_lua_query(LuaDir, 'wam_lua_length_basic/0', [], true),
           run_lua_query(LuaDir, 'wam_lua_length_bind/0', [], true),
           run_lua_query(LuaDir, 'wam_lua_length_no/0', [], false)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(lua_type_and_compare_builtins_e2e, [condition(lua_available)]) :-
+    unique_lua_tmp_dir('tmp_lua_type_compare_builtins_e2e', TmpDir),
+    setup_call_cleanup(
+        write_wam_lua_project(
+            [ user:wam_lua_type_builtins/0,
+              user:wam_lua_type_var/0,
+              user:wam_lua_type_no/0,
+              user:wam_lua_compare_builtins/0
+            ],
+            [],
+            TmpDir),
+        ( directory_file_path(TmpDir, 'lua', LuaDir),
+          run_lua_query(LuaDir, 'wam_lua_type_builtins/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_type_var/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_type_no/0', [], false),
+          run_lua_query(LuaDir, 'wam_lua_compare_builtins/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).

--- a/tests/test_wam_lua_generator.pl
+++ b/tests/test_wam_lua_generator.pl
@@ -28,6 +28,12 @@
 :- dynamic user:wam_lua_stream_caller/2.
 :- dynamic user:wam_lua_ext_fact/2.
 :- dynamic user:wam_lua_ext_caller/2.
+:- dynamic user:wam_lua_member_basic/0.
+:- dynamic user:wam_lua_member_backtrack/0.
+:- dynamic user:wam_lua_member_no/0.
+:- dynamic user:wam_lua_length_basic/0.
+:- dynamic user:wam_lua_length_bind/0.
+:- dynamic user:wam_lua_length_no/0.
 
 user:wam_lua_fact(a).
 user:wam_lua_choice(a).
@@ -66,6 +72,12 @@ user:wam_lua_stream_fact(a, b).
 user:wam_lua_stream_fact(a, c).
 user:wam_lua_stream_caller(X, Y) :- user:wam_lua_stream_fact(X, Y).
 user:wam_lua_ext_caller(X, Y) :- user:wam_lua_ext_fact(X, Y).
+user:wam_lua_member_basic :- member(b, [a, b, c]).
+user:wam_lua_member_backtrack :- member(X, [a, b, c]), X = c.
+user:wam_lua_member_no :- member(d, [a, b, c]).
+user:wam_lua_length_basic :- length([a, b, c], 3).
+user:wam_lua_length_bind :- length([a, b, c], N), N = 3.
+user:wam_lua_length_no :- length([a, b, c], 2).
 
 test(exports) :-
     assertion(current_predicate(wam_lua_target:write_wam_lua_project/3)),
@@ -329,6 +341,30 @@ test(lua_aggregate_all_e2e, [condition(lua_available)]) :-
           run_lua_query(LuaDir, 'wam_lua_agg_min/0', [], true),
           run_lua_query(LuaDir, 'wam_lua_agg_max/0', [], true),
           run_lua_query(LuaDir, 'wam_lua_agg_set/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(lua_structural_builtins_e2e, [condition(lua_available)]) :-
+    unique_lua_tmp_dir('tmp_lua_structural_builtins_e2e', TmpDir),
+    setup_call_cleanup(
+        write_wam_lua_project(
+            [ user:wam_lua_member_basic/0,
+              user:wam_lua_member_backtrack/0,
+              user:wam_lua_member_no/0,
+              user:wam_lua_length_basic/0,
+              user:wam_lua_length_bind/0,
+              user:wam_lua_length_no/0
+            ],
+            [],
+            TmpDir),
+        ( directory_file_path(TmpDir, 'lua', LuaDir),
+          run_lua_query(LuaDir, 'wam_lua_member_basic/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_member_backtrack/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_member_no/0', [], false),
+          run_lua_query(LuaDir, 'wam_lua_length_basic/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_length_bind/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_length_no/0', [], false)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

- add Lua WAM runtime support for `member/2` with choice-point backtracking over list alternatives
- add Lua WAM runtime support for `length/2` over WAM cons-list terms
- add Rust/Haskell parity builtins for Lua WAM type checks and comparisons: `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `var/1`, `nonvar/1`, `is_list/1`, `==/2`, `=:=/2`, `=\=/2`, `>/2`, `</2`, `>=/2`, and `=</2`
- add Lua generator end-to-end coverage for structural, type, and comparison builtin behavior

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`
