### PR TITLE
fix(wam-r): isolate compound aggregate template vars

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -719,7 +719,7 @@ Coverage map (e2e tests, by feature group):
 | `op_3_runtime_e2e_rscript` | runtime `op/3` builtin: add infix / prefix custom ops, xfy right-associativity, `op(0, ...)` removal, `current_op/3` enumeration |
 | `op_3_decl_e2e_rscript` | codegen `r_op_decls([op(P, T, N), ...])` option seeds the operator table at program init; covers atom-name and list-of-names forms |
 | `multi_solution_retract_e2e_rscript` | multi-solution `retract/1` via iter-CP |
-| `bagof_setof_existential_e2e_rscript` | `^/2` existential scope and first witness grouping in `bagof`/`setof`; `findall` caret transparency |
+| `bagof_setof_existential_e2e_rscript` | `^/2` existential scope, witness grouping/backtracking in `bagof`/`setof`, and compiled `findall` over runtime grouped aggregators |
 | `cli_arg_parser_e2e_rscript` | structured CLI args (lists, structs, expressions) parse via the runtime parser |
 | `base_name_clash_e2e_rscript` | predicates named after base R functions (`c`, `t`, `q`, `cat`) don't shadow them |
 | `read_term_clause_e2e_rscript` | `read_term_from_atom/2,3` and multi-solution `clause/2` |

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -828,10 +828,12 @@ compile_aggregate_all(Template, InnerGoal, Result, V0, Vf, Code) :-
 %% compile_compound_template(+Template, +V0, -Vf, -InitCode, -ConstructionCode)
 %  For findall(Functor(Arg1, Arg2, ...), Goal, L) with compound Template:
 %  - Each Arg is either a variable or a constant
-%  - Variables get Y-regs allocated (via allocate_var) so they have
-%    stable slots across the inner-goal call
-%  - InitCode emits put_variable Y_n, A_n for variables and
-%    put_constant for constants — fresh refs each iteration
+%  - Variables get Y-regs allocated (via allocate_var) and initialized
+%    directly so they have stable slots across the inner-goal call.
+%    Do not initialize through A-registers: those are scratch argument
+%    registers for the inner goal, and aliasing a template variable
+%    through A2 can bind it when the inner goal builds its own A2 term
+%    (for example findall(Y-L, bagof(X, p(X,Y), L), Groups)).
 %  - ConstructionCode emits put_structure + set_value/set_constant
 %    after the inner goal returns; A1 holds the heap ref to the
 %    constructed Template
@@ -853,13 +855,11 @@ compile_template_arg_init([], _, V, V, []).
 compile_template_arg_init([Arg | Rest], I, V0, Vf, Lines) :-
     (   var(Arg)
     ->  allocate_var(Arg, V0, V1, Reg),
-        format(string(Line), "    put_variable ~w, A~w", [Reg, I]),
+        format(string(Line), "    put_variable ~w, ~w", [Reg, Reg]),
         Lines = [Line | RestLines]
     ;   atomic(Arg)
     ->  V1 = V0,
-        quote_wam_constant(Arg, ArgStr),
-        format(string(Line), "    put_constant ~w, A~w", [ArgStr, I]),
-        Lines = [Line | RestLines]
+        Lines = RestLines
     ;   % Compound or other — not yet supported
         throw(error(unsupported_template_arg(Arg), compile_compound_template/5))
     ),

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2180,6 +2180,18 @@ e2e_bagof_setof_existential_via_rscript :-
         setof(X, jj(X, Y), L),
         Y == b,
         L == [2])),
+    % Nested compiled findall around runtime bagof/setof: compound
+    % findall template vars must not alias the inner call's A-register
+    % temporaries.
+    assertz((user:be_findall_bagof_groups :-
+        assertz(kk(1, a)), assertz(kk(2, b)),
+        findall(Y-L, bagof(X, kk(X, Y), L), Groups),
+        Groups == [a-[1], b-[2]])),
+    assertz((user:be_findall_setof_groups :-
+        assertz(ll(3, a)), assertz(ll(1, a)), assertz(ll(3, a)),
+        assertz(ll(2, b)),
+        findall(Y-L, setof(X, ll(X, Y), L), Groups),
+        Groups == [a-[1, 3], b-[2]])),
     unique_r_tmp_dir('tmp_r_caret_e2e', TmpDir),
     write_wam_r_project(
         [ user:be_bagof_basic/0, user:be_setof_basic/0,
@@ -2187,14 +2199,17 @@ e2e_bagof_setof_existential_via_rscript :-
           user:be_bagof_empty_no/0, user:be_bagof_group_first/0,
           user:be_setof_group_first/0,
           user:be_bagof_group_backtrack/0,
-          user:be_setof_group_backtrack/0 ],
+          user:be_setof_group_backtrack/0,
+          user:be_findall_bagof_groups/0,
+          user:be_findall_setof_groups/0 ],
         [],
         TmpDir),
     directory_file_path(TmpDir, 'R', RDir),
     Yes = [be_bagof_basic, be_setof_basic, be_nested_caret,
            be_findall_caret, be_bagof_group_first,
            be_setof_group_first, be_bagof_group_backtrack,
-           be_setof_group_backtrack],
+           be_setof_group_backtrack, be_findall_bagof_groups,
+           be_findall_setof_groups],
     No  = [be_bagof_empty_no],
     forall(member(P, Yes), (
         format(string(Q), '~w/0', [P]),


### PR DESCRIPTION
## Summary

- Fixes WAM aggregate lowering for compound `findall/3` templates so template variables are initialized directly in their Y registers instead of aliasing through scratch A registers.
- Adds WAM-R e2e coverage for compiled `findall/3` collecting over runtime `bagof/3` and `setof/3` grouped witness results.
- Updates the WAM-R docs coverage table to reflect witness grouping/backtracking and nested grouped aggregator coverage.

## Details

The previous lowering for compound templates like `Y-L` emitted `put_variable Yn, An`. In nested aggregate cases such as:

```prolog
findall(Y-L, bagof(X, p(X, Y), L), Groups)
```

the inner `bagof/3` call reused A registers while constructing its own goal term, which could accidentally alias and bind the outer compound template variables. This patch initializes compound-template variables in their Y slots directly, keeping them stable across the inner call.

## Verification

- `swipl -g "run_tests([wam_r_generator:bagof_setof_existential_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
- `swipl -g "run_tests([wam_r_generator:findall_e2e_rscript,wam_r_generator:bagof_setof_once_forall_e2e_rscript,wam_r_generator:enumerable_builtins_e2e_rscript,wam_r_generator:bagof_setof_existential_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
