### PR TITLE
test(wam-haskell): regression test for read_kernel_template cwd-independence

### DIFF
--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -171,6 +171,35 @@ test_parameterized_render_kernel_function :-
     ;   fail_test(Test, 'render_kernel_function failed for category_ancestor')
     ).
 
+%% Regression test for the read_kernel_template/2 cwd-independence fix.
+%% Prior to the fix, the predicate fell through to a cwd-relative path
+%% when the source_file/2 lookup silently failed; codegen worked from
+%% the project root but emitted "Template not found" stubs elsewhere.
+%% This test pins the fix down by running codegen from /tmp.
+test_render_kernel_function_cwd_independent :-
+    Test = 'WAM-Haskell: render_kernel_function works from any cwd (regression)',
+    Kernel = recursive_kernel(category_ancestor, 'category_ancestor'/4, [max_depth(10), edge_pred(category_parent/2)]),
+    working_directory(SavedCwd, '/tmp'),
+    catch(
+        (   wam_haskell_target:render_kernel_function('category_ancestor/4'-Kernel, Code),
+            atom_string(Code, S),
+            \+ sub_string(S, _, _, _, "Template not found"),
+            sub_string(S, _, _, _, "nativeKernel_category_ancestor")
+        ->  Result = pass
+        ;   Result = fail
+        ),
+        E,
+        Result = error(E)
+    ),
+    working_directory(_, SavedCwd),
+    (   Result == pass
+    ->  pass(Test)
+    ;   Result = error(Err)
+    ->  format(string(Reason), 'codegen from /tmp threw: ~w', [Err]),
+        fail_test(Test, Reason)
+    ;   fail_test(Test, 'codegen from /tmp produced "Template not found"')
+    ).
+
 test_transitive_closure_kernel_function :-
     Test = 'WAM-Haskell: transitive_closure2 kernel template renders',
     Kernel = recursive_kernel(transitive_closure2, closure/2, [edge_pred(edge/2)]),
@@ -2121,6 +2150,7 @@ run_tests :-
     test_parameterized_execute_foreign_category_ancestor,
     test_parameterized_execute_foreign_empty,
     test_parameterized_render_kernel_function,
+    test_render_kernel_function_cwd_independent,
     test_transitive_closure_kernel_function,
     test_transitive_closure_execute_foreign,
     test_multi_kernel_execute_foreign,


### PR DESCRIPTION
  ## Summary

  Locks in the fix from PR #1970 with an explicit regression test.

  `render_kernel_function/2` is exercised from `/tmp` (rather than the
  project root), and we assert the result does not contain
  "Template not found". The pre-fix code path produced exactly that
  stub whenever cwd ≠ project root, and 36 cascaded test failures
  showed up because every downstream substring assertion was looking
  in a "Template not found:" placeholder string.

  ## Why

  The original bug was silent: `source_file(wam_haskell_target, _)`
  (bare-atom form) failed without error, so `read_kernel_template/2`
  fell through to a cwd-relative path. Tests passed when run from the
  project root (the standard invocation) and didn't from anywhere else.
  A regression test that pins cwd to `/tmp` makes any future
  reintroduction of the bug visible immediately, instead of waiting
  for someone to run tests from a non-standard directory.

  ## What changed

  `tests/test_wam_haskell_target.pl` (+30):

  - `test_render_kernel_function_cwd_independent` — calls
    `working_directory/2` to set cwd to `/tmp`, runs
    `render_kernel_function/2`, asserts the output isn't a
    "Template not found" stub. Restores cwd in the cleanup branch.
  - Added to the test list above the existing
    `test_transitive_closure_kernel_function`.

  ## Test plan

  - [x] All 148 tests pass from project root
  - [x] All 148 tests pass from `/tmp`
  - [x] The new test specifically reads `[PASS] ... works from any cwd`