### PR TITLE
feat(wam-haskell): Phase 2c — cache_strategy(auto) resolver wiring

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -59,6 +59,8 @@
              [analyze_predicate_purity/2]).
 :- use_module('../core/statistics',
              [select_cache_mode/2]).
+:- use_module('../core/cost_model',
+             [recommend_access_pattern/5, read_mem_available_bytes/1]).
 
 % Phase 3: the real lowerability check and emission helpers live in the
 % wam_haskell_lowered_emitter module. We reexport so existing callers can
@@ -2573,7 +2575,11 @@ write_wam_haskell_project(Predicates, Options0, ProjectDir) :-
     % BEFORE any downstream `option(use_lmdb(true), ...)` checks fire.
     % Auto consults ghc-pkg for the lmdb package + fact_count threshold;
     % see resolve_auto_use_lmdb/2.
-    resolve_auto_use_lmdb(Options0, Options),
+    resolve_auto_use_lmdb(Options0, Options1),
+    % Phase 2c: resolve cache_strategy(auto) into a concrete
+    % demand_bfs_mode/1 via cost_model:recommend_access_pattern/5.
+    % No-op when cache_strategy(auto) is absent.
+    resolve_auto_cache_strategy(Options1, Options),
 
     % Initialize the compile-time atom intern table with well-known atoms
     init_atom_intern_table,
@@ -3085,6 +3091,86 @@ resolve_auto_demand_bfs_mode(Options, Mode) :-
     ;   Mode = in_memory
     ).
 
+%% resolve_auto_cache_strategy(+Options0, -Options) is det.
+%
+%  Phase 2c opt-in resolver. When `cache_strategy(auto)` is set,
+%  consult cost_model:recommend_access_pattern/5 with workload
+%  metadata, then translate the pattern recommendation (sort/scan)
+%  into a concrete `demand_bfs_mode/1` option that downstream code
+%  already understands.
+%
+%  Inputs read from Options (with defaults):
+%
+%    - fact_count(N)              — total facts in the source DB
+%    - expected_query_count(M)    — anticipated number of queries
+%                                   (default: 1)
+%    - working_set_fraction(F)    — per-query touched fraction of facts
+%                                   (default: 0.05; i.e. each query
+%                                   touches ~5% of the data set)
+%    - db_size_bytes(B)           — bytes a full scan would touch
+%                                   (default: estimate as fact_count
+%                                   * 50 bytes/edge)
+%    - mem_available_bytes(R)     — override /proc/meminfo probe
+%                                   (default: probe MemAvailable;
+%                                   1 GB fallback on non-Linux)
+%    - cost_model_constants(L)    — override hardware constants list
+%                                   passed to cost_model
+%                                   (default: cost_model defaults)
+%    - cache_strategy_verbose(true) — emit a stderr trace of the
+%                                     decision (default: silent)
+%
+%  Output mapping:
+%
+%    cost_model says `sort` → demand_bfs_mode(cursor)
+%      (cursor BFS = per-key seek pattern)
+%    cost_model says `scan` → demand_bfs_mode(in_memory)
+%      (pre-load IntMap = sequential scan pattern)
+%
+%  Composes with `resolve_auto_demand_bfs_mode/2`: this resolver
+%  replaces any existing `demand_bfs_mode/1` term, so the downstream
+%  resolver sees a concrete value and is a no-op.
+%
+%  Behaviour unchanged when `cache_strategy(auto)` is absent.
+%
+%  See docs/design/CACHE_COST_MODEL_PHILOSOPHY.md and
+%  docs/design/WAM_PERF_OPTIMIZATION_LOG.md Phase M appendix #10.
+resolve_auto_cache_strategy(Options0, Options) :-
+    (   option(cache_strategy(auto), Options0)
+    ->  compute_cache_strategy_decision(Options0, BfsMode),
+        select(cache_strategy(auto), Options0, AfterStripStrategy),
+        exclude(=(demand_bfs_mode(_)), AfterStripStrategy, AfterStripBfs),
+        Options = [demand_bfs_mode(BfsMode) | AfterStripBfs]
+    ;   Options = Options0
+    ).
+
+compute_cache_strategy_decision(Options, BfsMode) :-
+    option(fact_count(FactCount), Options, 0),
+    option(expected_query_count(_QueryCount), Options, 1),
+    option(working_set_fraction(WSF), Options, 0.05),
+    (   option(db_size_bytes(DBSize), Options),
+        integer(DBSize), DBSize > 0
+    ->  WBytes = DBSize
+    ;   WBytes is FactCount * 50
+    ),
+    KKeys is integer(FactCount * WSF),
+    (   option(mem_available_bytes(R), Options),
+        integer(R), R > 0
+    ->  RFree = R
+    ;   catch(read_mem_available_bytes(RFree), _, RFree = 1_000_000_000)
+    ),
+    option(cost_model_constants(Constants), Options, []),
+    recommend_access_pattern(KKeys, WBytes, RFree, Constants, Pattern),
+    (   Pattern = sort
+    ->  BfsMode = cursor
+    ;   BfsMode = in_memory
+    ),
+    (   option(cache_strategy_verbose(true), Options)
+    ->  format(user_error,
+               '[WAM-Haskell] cache_strategy(auto): K=~w W=~w R_free=~w → ~w (~w)~n',
+               [KKeys, WBytes, RFree, Pattern, BfsMode])
+    ;   true
+    ).
+
 %% resolve_demand_filter_spec(+Options, -SpecHs)
 %  Pick the DemandFilterSpec literal to emit into Main.hs.
 %  Precedence:
@@ -3239,7 +3325,11 @@ build_predicate_loads(Predicates, Code) :-
     let allLabels = ~w', [CodeConcat, LabelUnion]).
 
 %% compile_wam_runtime_to_haskell(+Options, +DetectedKernels, -Code)
-compile_wam_runtime_to_haskell(Options, DetectedKernels, Code) :-
+compile_wam_runtime_to_haskell(Options0, DetectedKernels, Code) :-
+    % Phase 2c: resolve cache_strategy(auto) into a concrete
+    % demand_bfs_mode/1 BEFORE downstream code consults it. No-op
+    % when the option is absent.
+    resolve_auto_cache_strategy(Options0, Options),
     step_function_haskell(StepCode),
     backtrack_haskell(BacktrackCodeTemplate),
     run_loop_haskell(RunCode),

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1878,6 +1878,93 @@ test_resolve_use_lmdb_auto_no_fact_count_false :-
     ;   fail_test(Test, 'auto without fact_count did not resolve to false')
     ).
 
+%% =================================================================
+%% Phase 2c: cache_strategy(auto) cost-model resolver
+%% =================================================================
+
+test_cache_strategy_auto_low_k_picks_in_memory :-
+    %% Small fact_count + ~5% wsf → K small. With huge mem_available
+    %% (forcing FHot=1 regime) and explicit constants pinning K_cross
+    %% near zero, force the model to pick `scan` → `in_memory`.
+    %% Concretely: 100k facts × 5MB DB × 1MB R_free → DB exceeds RAM,
+    %% but K=5000 vs K_cross at this regime puts us comfortably above
+    %% threshold; the resolver should map to in_memory.
+    Test = 'WAM-Haskell: cache_strategy(auto) at small selection picks in_memory',
+    (   wam_haskell_target:resolve_auto_cache_strategy(
+            [cache_strategy(auto),
+             fact_count(100),
+             working_set_fraction(0.5),
+             db_size_bytes(5000),
+             mem_available_bytes(16000000000)],
+            R),
+        memberchk(demand_bfs_mode(in_memory), R),
+        \+ memberchk(cache_strategy(auto), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'cache_strategy auto + small selection did not pick in_memory')
+    ).
+
+test_cache_strategy_auto_high_k_picks_in_memory_at_high_selection :-
+    %% Large fact_count + high working_set_fraction (touches >> K_cross)
+    %% → cost model says scan → in_memory.
+    Test = 'WAM-Haskell: cache_strategy(auto) at high selection picks in_memory',
+    (   wam_haskell_target:resolve_auto_cache_strategy(
+            [cache_strategy(auto),
+             fact_count(10000000),
+             working_set_fraction(0.5),
+             db_size_bytes(500000000),
+             mem_available_bytes(16000000000)],
+            R),
+        memberchk(demand_bfs_mode(in_memory), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'cache_strategy auto + high selection did not pick in_memory')
+    ).
+
+test_cache_strategy_auto_tiny_selection_picks_cursor :-
+    %% Large DB + tiny working_set_fraction (K << K_cross) → sort →
+    %% cursor. 10M facts × 0.0001 wsf = K=1000; K_cross at hot regime
+    %% on 500MB W is ~100k. So K << K_cross → sort → cursor.
+    Test = 'WAM-Haskell: cache_strategy(auto) at tiny selection picks cursor',
+    (   wam_haskell_target:resolve_auto_cache_strategy(
+            [cache_strategy(auto),
+             fact_count(10000000),
+             working_set_fraction(0.0001),
+             db_size_bytes(500000000),
+             mem_available_bytes(16000000000)],
+            R),
+        memberchk(demand_bfs_mode(cursor), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'cache_strategy auto + tiny selection did not pick cursor')
+    ).
+
+test_cache_strategy_absent_leaves_options_unchanged :-
+    %% No cache_strategy(auto) → resolver is a no-op. Existing
+    %% demand_bfs_mode (or its absence) flows through untouched.
+    Test = 'WAM-Haskell: resolve_auto_cache_strategy is a no-op without cache_strategy(auto)',
+    (   wam_haskell_target:resolve_auto_cache_strategy(
+            [fact_count(1000), demand_bfs_mode(in_memory)], R),
+        R == [fact_count(1000), demand_bfs_mode(in_memory)]
+    ->  pass(Test)
+    ;   fail_test(Test, 'resolve_auto_cache_strategy mutated options without cache_strategy(auto)')
+    ).
+
+test_cache_strategy_auto_overrides_explicit_demand_bfs_mode :-
+    %% cache_strategy(auto) takes precedence over an existing
+    %% demand_bfs_mode/1 entry — that's the whole point of opting in.
+    Test = 'WAM-Haskell: cache_strategy(auto) overrides explicit demand_bfs_mode',
+    (   wam_haskell_target:resolve_auto_cache_strategy(
+            [cache_strategy(auto),
+             demand_bfs_mode(in_memory),
+             fact_count(10000000),
+             working_set_fraction(0.0001),
+             db_size_bytes(500000000),
+             mem_available_bytes(16000000000)],
+            R),
+        memberchk(demand_bfs_mode(cursor), R),
+        \+ memberchk(demand_bfs_mode(in_memory), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'cache_strategy auto did not override explicit demand_bfs_mode')
+    ).
+
 test_b1_lmdb_dupsort_per_thread_cursor :-
     Test = 'B1: dupsort layout uses per-thread cursor cache',
     (   compile_wam_runtime_to_haskell(
@@ -2304,6 +2391,11 @@ run_tests :-
     test_resolve_use_lmdb_absent_unchanged,
     test_resolve_use_lmdb_auto_low_fact_count_false,
     test_resolve_use_lmdb_auto_no_fact_count_false,
+    test_cache_strategy_auto_low_k_picks_in_memory,
+    test_cache_strategy_auto_high_k_picks_in_memory_at_high_selection,
+    test_cache_strategy_auto_tiny_selection_picks_cursor,
+    test_cache_strategy_absent_leaves_options_unchanged,
+    test_cache_strategy_auto_overrides_explicit_demand_bfs_mode,
     format('~n========================================~n'),
     (   test_failed
     ->  format('Tests FAILED~n'), halt(1)


### PR DESCRIPTION
  ## Summary

  First production-side use of `cost_model.pl` (landed in PR #1967).
  Adds an opt-in `cache_strategy(auto)` option to
  `wam_haskell_target.pl` that consults
  `cost_model:recommend_access_pattern/5` with workload metadata and
  maps the cost-model decision to a concrete `demand_bfs_mode/1`.

  This is the smallest viable Phase 2c step — it activates the cost
  model end-to-end without changing any default behaviour. Users opt
  in by passing `cache_strategy(auto)`; absent that, every existing
  code path is byte-for-byte unchanged.

  ## Inputs (option-list keys with defaults)

  | key | default | meaning |
  |---|---|---|
  | `fact_count(N)` | (existing) | total facts in DB |
  | `expected_query_count(M)` | `1` | anticipated query count |
  | `working_set_fraction(F)` | `0.05` | per-query touched fraction |
  | `db_size_bytes(B)` | `fact_count * 50` | bytes a full scan touches |
  | `mem_available_bytes(R)` | `/proc/meminfo:MemAvailable` | free RAM (1 GB fallback off-Linux) |
  | `cost_model_constants(L)` | `[]` | pass-through hardware constants |
  | `cache_strategy_verbose(true)` | absent | stderr trace of decision |

  ## Output mapping

  | cost_model output | demand_bfs_mode |
  |---|---|
  | `sort` (per-key seek pattern) | `cursor` |
  | `scan` (sequential scan pattern) | `in_memory` |

  ## Composition

  Runs *before* `resolve_auto_demand_bfs_mode/2` in the option
  pipeline. This resolver removes any existing `demand_bfs_mode/1`
  entry and inserts a concrete one; the downstream resolver then sees
  a settled value and is a no-op. Cache-strategy decisions take
  precedence over explicit `demand_bfs_mode(...)` entries — that's
  the whole point of opting in.

  Wired into both:
  - `compile_wam_runtime_to_haskell/3` (so codegen tests see the resolution)
  - `write_wam_haskell_project/3` (so the end-to-end user path does too)

  ## Tests

  5 new deterministic codegen tests in `test_wam_haskell_target.pl`:

  - `cache_strategy(auto)` at small selection → `in_memory`
  - `cache_strategy(auto)` at high selection → `in_memory`
  - `cache_strategy(auto)` at tiny selection (large fact_count) → `cursor`
  - `cache_strategy/1` absent → resolver is a no-op (Options unchanged)
  - `cache_strategy(auto)` overrides an explicit `demand_bfs_mode/1`

  ## Verification

  - `tests/test_wam_haskell_target.pl` — 153/153 pass (148 existing + 5 new)
  - `tests/core/test_cost_model.pl` — 21/21 still pass
  - Default behaviour unchanged: no production codegen change unless
    `cache_strategy(auto)` is opted into

  ## What this unblocks

  Phase 2c+ items that were previously blocked on the metadata
  channel:

  - **Cache warming with cost-model gating** — once `expected_query_count`
    and `working_set_fraction` are flowing through, the warming
    threshold derivation in `cost_model:warming_payoff_m/5` has its
    inputs.
  - **Auto-resolver for `lmdb_cache_mode`** — same channel, different
    output mapping (sort/scan + workload locality → cache layer choice).
  - **Matrix-bench harness opt-in** — pass workload metadata from
    CLI so the bench picks its own cursor/in-memory mode by cost
    model rather than the existing 50k threshold.

  These are deferred to follow-up PRs; this one stays narrowly scoped
  to the resolver wiring.

  ## Files

  - `src/unifyweaver/targets/wam_haskell_target.pl` (+92, -2)
    - `:- use_module('../core/cost_model', [recommend_access_pattern/5, read_mem_available_bytes/1]).`
    - `resolve_auto_cache_strategy/2` (new) + `compute_cache_strategy_decision/2` (new helper)
    - Resolver call in `compile_wam_runtime_to_haskell/3` and `write_wam_haskell_project/3`
  - `tests/test_wam_haskell_target.pl` (+92)
    - 5 new tests + registry entries

  ## Test plan

  - [x] `tests/test_wam_haskell_target.pl` — 153/153 from project root
  - [x] `tests/test_wam_haskell_target.pl` — 153/153 from `/tmp` (cwd-independent regression test still works)
  - [x] `tests/core/test_cost_model.pl` — 21/21
  - [x] Default-behaviour test (no `cache_strategy/1` set) — Options pass through unchanged
  - [ ] (Deferred to follow-up) Matrix-bench harness opt-in
  - [ ] (Deferred to follow-up) End-to-end run with `cache_strategy_verbose(true)` to spot-check decisions in real
  workloads