### PR TITLE
fix(wam-r, core): strict xf/yf + fx/fy + xfx/xfy/yfx precedence rules

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -617,12 +617,6 @@ WamRuntime$run(shared_program, state)
 
 ## Limitations
 
-- **Postfix `xf` vs `yf` chaining**. Single postfix application is
-  correct; chained applications (`5!!`) accept either type without
-  enforcing the ISO `xf` rule that the operand precedence be
-  strictly less than the operator precedence. Symmetric with the
-  existing prefix simplification. Documented; not a real-world
-  blocker.
 - **WAM-text quoting collision**. The atom `'42'` and the integer
   `42` both serialise as `set_constant 42` in SWI's WAM emitter,
   so the codegen can't distinguish them. The runtime's `atom_*`
@@ -718,6 +712,7 @@ Coverage map (e2e tests, by feature group):
 | `cut_ite_barrier_after_helper_e2e_rscript` | `( A -> B ; C )` soft-cut commits past CPs that A's evaluation left alive (the codegen marks the if-then-else's `try_me_else` as `try_me_else_ite`, the runtime tags the CP `kind="ite"`, and `CutIte` truncates `state$cps` back to that CP's pre-push depth) |
 | `nested_if_then_else_e2e_rscript` | chained `( A -> B ; C -> D ; E )` compiles as nested cut_ite/try_me_else_ite pairs (each `->` in Else position is recognised recursively rather than emitted as a stub `Call("->", 2)`) |
 | `deeply_nested_ite_compiles` | clause_body_analysis no longer stack-overflows on triple-nested if-then-else bodies (the `nonvar` guard on `disjunction_alternatives/2` keeps it from infinitely-expanding an unbound goal that passes through the analyser) |
+| `strict_xf_chain_fails_e2e_rscript` | runtime parser enforces strict (xf / fx) vs non-strict (yf / fy) lhs-precedence rules: `5!!` parses with `op(100, yf, '!')` but fails with `op(100, xf, '!')`; `neg neg foo` parses with `op(900, fy, neg)` but fails with `op(900, fx, neg)` |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 

--- a/docs/handoff/wam_r_session_handoff.md
+++ b/docs/handoff/wam_r_session_handoff.md
@@ -161,29 +161,24 @@ roughly priority order:
    keeping the inline path for the CLI arg parser if startup latency
    regresses too far.
 
-4. **Strict `xf` precedence rule** (small). Threading the precedence
-   of the current `left` expression through `wam_parse_expr` so `xf`
-   and `yf` differ correctly at chained-postfix sites. Fixes the
-   simplification documented as a known limitation. Same fix would
-   let `fx` / `fy` differ correctly in the prefix path.
-5. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
+4. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
    mode info per predicate (in/out per arg); Phase 2 wires it to
    specialised emission (skip unifications when the mode says the slot
    is unbound, etc.). Look at the Haskell target's
    `WAM_HASKELL_MODE_ANALYSIS_*.md` design docs for the precedent.
-6. **Multi-line `read/2`.** Read until a `.` terminator across lines.
+5. **Multi-line `read/2`.** Read until a `.` terminator across lines.
    Niche but completes the streams story.
-7. **Multi-solution `retract/1` ignoring snapshot.** I.e. re-read the
+6. **Multi-solution `retract/1` ignoring snapshot.** I.e. re-read the
    live clause list on each backtrack. Trickier semantics; document
    carefully if pursued.
-8. **Phase-3 lowered emitter expansion.** Currently handles only
+7. **Phase-3 lowered emitter expansion.** Currently handles only
    `deterministic` and `multi_clause_1` shapes. Could grow N-clause
    general lowering; would compete with the kernel / fact-table paths
    so the value is unclear.
-9. **Range / interval indexes** on fact tables. Per-arg hash indexes
-    land queries with ground atom/int args; range queries (`X > 5`,
-    `X between A B`) still go through the per-tuple scan. A sorted-
-    per-arg index would route these. Niche but a natural extension.
+8. **Range / interval indexes** on fact tables. Per-arg hash indexes
+   land queries with ground atom/int args; range queries (`X > 5`,
+   `X between A B`) still go through the per-tuple scan. A sorted-
+   per-arg index would route these. Niche but a natural extension.
 
 ## Things to know before you start a follow-up
 

--- a/src/unifyweaver/core/prolog_term_parser.pl
+++ b/src/unifyweaver/core/prolog_term_parser.pl
@@ -60,7 +60,7 @@ parse_term_from_atom(Atom, OpTable, Term) :-
 
 parse_term_from_codes(Codes, OpTable, Term) :-
     tokenize(Codes, Tokens),
-    parse_expr(Tokens, OpTable, 1200, Term, [], _Env, Rest),
+    parse_expr(Tokens, OpTable, 1200, Term, _Prec, [], _Env, Rest),
     Rest == [].
 
 % -----------------------------------------------------------------------------
@@ -271,69 +271,97 @@ separator_token(tk_pipe).
 % Parser (Pratt-style)
 % -----------------------------------------------------------------------------
 
-% parse_expr(+Tokens, +OpTable, +MaxPrec, -Term, +Env0, -Env, -Rest).
-parse_expr(Tokens0, OpTable, MaxPrec, Term, Env0, Env, Rest) :-
-    parse_primary(Tokens0, OpTable, MaxPrec, Left, Env0, Env1, Tokens1),
-    parse_op_loop(Tokens1, OpTable, MaxPrec, Left, Term, Env1, Env, Rest).
+% parse_expr(+Tokens, +OpTable, +MaxPrec, -Term, -TermPrec, +Env0, -Env, -Rest).
+%   Returns the parsed term plus its precedence so the caller (the
+%   recursive parse_op_loop) can enforce strict-vs-non-strict
+%   associativity rules: xfx/xfy/xf require lhs strictly less than
+%   the op's prec; yfx/yf accept lhs at op prec (left-fold).
+parse_expr(Tokens0, OpTable, MaxPrec, Term, TermPrec, Env0, Env, Rest) :-
+    parse_primary(Tokens0, OpTable, MaxPrec, Left, LeftPrec, Env0, Env1, Tokens1),
+    parse_op_loop(Tokens1, OpTable, MaxPrec, Left, LeftPrec,
+                  Term, TermPrec, Env1, Env, Rest).
 
-parse_op_loop([], _, _, Left, Left, Env, Env, []).
-parse_op_loop([T|Toks], OpTable, MaxPrec, Left, Term, Env0, Env, Rest) :-
+parse_op_loop([], _, _, Left, LeftPrec, Left, LeftPrec, Env, Env, []).
+parse_op_loop([T|Toks], OpTable, MaxPrec, Left, LeftPrec,
+              Term, TermPrec, Env0, Env, Rest) :-
     (   token_op_name(T, Name)
     ->  (   resolve_infix(Name, OpTable, Prec, Type),
-            Prec =< MaxPrec
+            Prec =< MaxPrec,
+            infix_lhs_ok(Type, LeftPrec, Prec)
         ->  rhs_max_prec(Type, Prec, RhsMax),
-            parse_expr(Toks, OpTable, RhsMax, Right, Env0, Env1, Toks1),
+            parse_expr(Toks, OpTable, RhsMax, Right, _, Env0, Env1, Toks1),
             T2 =.. [Name, Left, Right],
-            parse_op_loop(Toks1, OpTable, MaxPrec, T2, Term, Env1, Env, Rest)
-        ;   resolve_postfix(Name, OpTable, Prec, _PType),
-            Prec =< MaxPrec
+            parse_op_loop(Toks1, OpTable, MaxPrec, T2, Prec,
+                          Term, TermPrec, Env1, Env, Rest)
+        ;   resolve_postfix(Name, OpTable, Prec, PType),
+            Prec =< MaxPrec,
+            postfix_lhs_ok(PType, LeftPrec, Prec)
         ->  T2 =.. [Name, Left],
-            parse_op_loop(Toks, OpTable, MaxPrec, T2, Term, Env0, Env, Rest)
-        ;   Term = Left, Env = Env0, Rest = [T|Toks]
+            parse_op_loop(Toks, OpTable, MaxPrec, T2, Prec,
+                          Term, TermPrec, Env0, Env, Rest)
+        ;   Term = Left, TermPrec = LeftPrec,
+            Env = Env0, Rest = [T|Toks]
         )
-    ;   Term = Left, Env = Env0, Rest = [T|Toks]
+    ;   Term = Left, TermPrec = LeftPrec,
+        Env = Env0, Rest = [T|Toks]
     ).
 
-% parse_primary: the leading token of an expression. Number / var / atom /
-% list / parenthesised / prefix-op application.
-parse_primary([tk_num(V)|R], _, _, V, Env, Env, R) :- !.
+% infix_lhs_ok / postfix_lhs_ok: enforce strict (xfx/xfy/xf) vs
+% non-strict (yfx/yf) lhs precedence.
+infix_lhs_ok(yfx, LeftPrec, OpPrec) :- !, LeftPrec =< OpPrec.
+infix_lhs_ok(_,   LeftPrec, OpPrec) :- LeftPrec < OpPrec.
 
-parse_primary([tk_var(Name)|R], _, _, V, Env0, Env, R) :- !,
+postfix_lhs_ok(yf, LeftPrec, OpPrec) :- !, LeftPrec =< OpPrec.
+postfix_lhs_ok(_,  LeftPrec, OpPrec) :- LeftPrec < OpPrec.
+
+% parse_primary: the leading token of an expression. Number / var / atom /
+% list / parenthesised / prefix-op application. Returns the parsed term
+% AND its precedence (0 for atomic / list / parens / functor, op_prec
+% for a prefix-op application) so parse_op_loop can enforce
+% strict-vs-non-strict associativity.
+parse_primary([tk_num(V)|R], _, _, V, 0, Env, Env, R) :- !.
+
+parse_primary([tk_var(Name)|R], _, _, V, 0, Env0, Env, R) :- !,
     bind_var(Name, V, Env0, Env).
 
-parse_primary([tk_atom(Name)|R], OpTable, MaxPrec, Term, Env0, Env, Rest) :- !,
-    parse_atom_head(Name, R, OpTable, MaxPrec, Term, Env0, Env, Rest).
+parse_primary([tk_atom(Name)|R], OpTable, MaxPrec, Term, TermPrec, Env0, Env, Rest) :- !,
+    parse_atom_head(Name, R, OpTable, MaxPrec, Term, TermPrec, Env0, Env, Rest).
 
-parse_primary([tk_sym(Name)|R], OpTable, MaxPrec, Term, Env0, Env, Rest) :- !,
-    parse_atom_head(Name, R, OpTable, MaxPrec, Term, Env0, Env, Rest).
+parse_primary([tk_sym(Name)|R], OpTable, MaxPrec, Term, TermPrec, Env0, Env, Rest) :- !,
+    parse_atom_head(Name, R, OpTable, MaxPrec, Term, TermPrec, Env0, Env, Rest).
 
-parse_primary([tk_lparen|R], OpTable, _, Term, Env0, Env, Rest) :- !,
-    parse_expr(R, OpTable, 1200, Term, Env0, Env, [tk_rparen|Rest]).
+parse_primary([tk_lparen|R], OpTable, _, Term, 0, Env0, Env, Rest) :- !,
+    parse_expr(R, OpTable, 1200, Term, _, Env0, Env, [tk_rparen|Rest]).
 
-parse_primary([tk_lbracket|R], OpTable, _, Term, Env0, Env, Rest) :- !,
+parse_primary([tk_lbracket|R], OpTable, _, Term, 0, Env0, Env, Rest) :- !,
     parse_list_body(R, OpTable, Term, Env0, Env, Rest).
 
 % parse_atom_head: an atom token at primary position can be (1) a functor
 % application (atom immediately followed by `(`), (2) a prefix-op application,
-% or (3) a stand-alone atom.
-parse_atom_head(Name, [tk_lparen|R], OpTable, _, Term, Env0, Env, Rest) :- !,
+% or (3) a stand-alone atom. Functor / atom are precedence 0; prefix-op is
+% the op's own precedence so chained `\+ \+ X` differs correctly between
+% `op(900, fx, \+)` and `op(900, fy, \+)`.
+parse_atom_head(Name, [tk_lparen|R], OpTable, _, Term, 0, Env0, Env, Rest) :- !,
     parse_args(R, OpTable, Args, Env0, Env, Rest),
     Term =.. [Name|Args].
-parse_atom_head(Name, R, OpTable, MaxPrec, Term, Env0, Env, Rest) :-
+parse_atom_head(Name, R, OpTable, MaxPrec, Term, Prec, Env0, Env, Rest) :-
     R = [Next|_],
     starts_term(Next),
-    resolve_prefix(Name, OpTable, Prec),
+    resolve_prefix(Name, OpTable, Prec, Type),
     Prec =< MaxPrec,
     !,
-    OperandMax is Prec - 1,
-    parse_expr(R, OpTable, OperandMax, Operand, Env0, Env, Rest),
+    prefix_rhs_max(Type, Prec, OperandMax),
+    parse_expr(R, OpTable, OperandMax, Operand, _, Env0, Env, Rest),
     Term =.. [Name, Operand].
-parse_atom_head(Name, R, _, _, Name, Env, Env, R).
+parse_atom_head(Name, R, _, _, Name, 0, Env, Env, R).
+
+prefix_rhs_max(fy, Prec, Prec) :- !.
+prefix_rhs_max(_,  Prec, Max)  :- Max is Prec - 1.
 
 % parse_args: comma-separated arg list inside `(...)`, max_prec 999 so the
 % top-level comma operator (1000) doesn't get folded in.
 parse_args(Tokens, OpTable, [Arg|Rest], Env0, Env, RestOut) :-
-    parse_expr(Tokens, OpTable, 999, Arg, Env0, Env1, Tokens1),
+    parse_expr(Tokens, OpTable, 999, Arg, _ArgPrec, Env0, Env1, Tokens1),
     (   Tokens1 = [tk_comma|Tokens2]
     ->  parse_args(Tokens2, OpTable, Rest, Env1, Env, RestOut)
     ;   Tokens1 = [tk_rparen|RestOut]
@@ -348,11 +376,11 @@ parse_list_body(Tokens, OpTable, List, Env0, Env, Rest) :-
     list_build(Elems, Tail, List).
 
 parse_list_elems(Tokens, OpTable, [E|Rest], Tail, Env0, Env, RestOut) :-
-    parse_expr(Tokens, OpTable, 999, E, Env0, Env1, Tokens1),
+    parse_expr(Tokens, OpTable, 999, E, _EPrec, Env0, Env1, Tokens1),
     (   Tokens1 = [tk_comma|Tokens2]
     ->  parse_list_elems(Tokens2, OpTable, Rest, Tail, Env1, Env, RestOut)
     ;   Tokens1 = [tk_pipe|Tokens2]
-    ->  parse_expr(Tokens2, OpTable, 999, Tail, Env1, Env, Tokens3),
+    ->  parse_expr(Tokens2, OpTable, 999, Tail, _TPrec, Env1, Env, Tokens3),
         Tokens3 = [tk_rbracket|RestOut],
         Rest = []
     ;   Tokens1 = [tk_rbracket|RestOut]
@@ -379,7 +407,7 @@ resolve_postfix(Name, OpTable, Prec, Type) :-
     is_postfix_type(Type),
     !.
 
-resolve_prefix(Name, OpTable, Prec) :-
+resolve_prefix(Name, OpTable, Prec, Type) :-
     member(op(Name, Prec, Type), OpTable),
     is_prefix_type(Type),
     !.

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -840,12 +840,12 @@ WamRuntime$op_infix <- list(
 )
 
 WamRuntime$op_prefix <- list(
-  ":-"  = list(prec = 1200L),
-  "?-"  = list(prec = 1200L),
-  "\\+" = list(prec = 900L),
-  "-"   = list(prec = 200L),
-  "+"   = list(prec = 200L),
-  "\\"  = list(prec = 200L)
+  ":-"  = list(prec = 1200L, assoc = "fx"),
+  "?-"  = list(prec = 1200L, assoc = "fx"),
+  "\\+" = list(prec = 900L,  assoc = "fy"),
+  "-"   = list(prec = 200L,  assoc = "fy"),
+  "+"   = list(prec = 200L,  assoc = "fy"),
+  "\\"  = list(prec = 200L,  assoc = "fy")
 )
 
 # Postfix operator table. Empty by default -- canonical Prolog
@@ -1008,6 +1008,12 @@ WamRuntime$parse_term <- function(text, table, state) {
 WamRuntime$wam_parse_expr <- function(p, max_prec) {
   left <- WamRuntime$wam_parse_primary(p, max_prec)
   if (is.null(left)) return(NULL)
+  # Precedence of the parsed primary. Atoms / numbers / vars / lists /
+  # parenthesised exprs / functor-applied compounds are 0; a prefix-op
+  # application carries the op's precedence. wam_parse_primary stashes
+  # the value on p$last_prec; we copy it to a local so the recursive
+  # rhs parse below can't clobber it before we use it.
+  left_prec <- p$last_prec
   repeat {
     if (p$pos > length(p$tokens)) return(left)
     tok <- p$tokens[[p$pos]]
@@ -1016,34 +1022,48 @@ WamRuntime$wam_parse_expr <- function(p, max_prec) {
                else if (tok$type == "semicolon") ";"
                else NULL
     if (is.null(op_name)) return(left)
+    # Infix: xfx / xfy require lhs prec STRICTLY less than the op's;
+    # yfx accepts lhs at the op's prec (left-fold). All three drop
+    # the rhs ceiling per associativity.
     iop <- WamRuntime$op_infix[[op_name]]
     if (!is.null(iop) && iop$prec <= max_prec) {
-      p$pos <- p$pos + 1L
-      rhs_max <- if (iop$assoc == "xfy") iop$prec else iop$prec - 1L
-      rhs <- WamRuntime$wam_parse_expr(p, rhs_max)
-      if (is.null(rhs)) return(NULL)
-      left <- StructTerm(WamRuntime$intern(p$table, op_name),
-                         list(left, rhs))
-      next
+      lhs_ok <- if (identical(iop$assoc, "yfx")) left_prec <= iop$prec
+                else left_prec < iop$prec
+      if (lhs_ok) {
+        p$pos <- p$pos + 1L
+        rhs_max <- if (iop$assoc == "xfy") iop$prec else iop$prec - 1L
+        rhs <- WamRuntime$wam_parse_expr(p, rhs_max)
+        if (is.null(rhs)) return(NULL)
+        left <- StructTerm(WamRuntime$intern(p$table, op_name),
+                           list(left, rhs))
+        left_prec <- iop$prec
+        next
+      }
     }
-    # Postfix: prefer infix when both are defined and applicable
-    # (matches SWI). Fires only when no infix entry fits the
-    # current precedence ceiling. yf accepts left at op$prec; xf
-    # requires left at op$prec - 1, but the operand precedence is
-    # already bounded by the recursive call and the outer loop's
-    # max_prec; we defer to max_prec here.
+    # Postfix: yf accepts operand at op$prec (left-fold), xf demands
+    # strictly less. Prefer infix when both apply and infix is the
+    # better fit; postfix fires when no infix matched.
     pop <- WamRuntime$op_postfix[[op_name]]
     if (!is.null(pop) && pop$prec <= max_prec) {
-      p$pos <- p$pos + 1L
-      left <- StructTerm(WamRuntime$intern(p$table, op_name),
-                         list(left))
-      next
+      lhs_ok <- if (identical(pop$assoc, "yf")) left_prec <= pop$prec
+                else left_prec < pop$prec
+      if (lhs_ok) {
+        p$pos <- p$pos + 1L
+        left <- StructTerm(WamRuntime$intern(p$table, op_name),
+                           list(left))
+        left_prec <- pop$prec
+        next
+      }
     }
     return(left)
   }
 }
 
 WamRuntime$wam_parse_primary <- function(p, max_prec) {
+  # Default precedence for the primary term. Atomic terms, lists,
+  # parens, and functor applications are 0. A prefix-op application
+  # overrides this to its own precedence below.
+  p$last_prec <- 0L
   if (p$pos > length(p$tokens)) return(NULL)
   tok <- p$tokens[[p$pos]]
   if (tok$type == "number") {
@@ -1089,15 +1109,22 @@ WamRuntime$wam_parse_primary <- function(p, max_prec) {
       return(StructTerm(WamRuntime$intern(p$table, tok$value), args))
     }
     # Prefix operator: name in op_prefix, prec fits, and the next
-    # token can start a term. Otherwise stand-alone atom.
+    # token can start a term. Otherwise stand-alone atom. The
+    # operand-precedence ceiling depends on associativity: fx wants
+    # operand prec strictly less than op_prec, fy accepts at op_prec
+    # (left-folding, so `\+ \+ X` parses for `op(900, fy, \+)` but
+    # not for `op(900, fx, \+)`).
     op <- WamRuntime$op_prefix[[tok$value]]
     if (!is.null(op) && op$prec <= max_prec && p$pos <= length(p$tokens)) {
       next_tok <- p$tokens[[p$pos]]
       starts_term <- next_tok$type %in%
         c("number", "var", "atom", "lparen", "lbracket")
       if (starts_term) {
-        operand <- WamRuntime$wam_parse_expr(p, op$prec - 1L)
+        rhs_max <- if (identical(op$assoc, "fy")) op$prec
+                   else op$prec - 1L
+        operand <- WamRuntime$wam_parse_expr(p, rhs_max)
         if (is.null(operand)) return(NULL)
+        p$last_prec <- op$prec
         return(StructTerm(WamRuntime$intern(p$table, tok$value),
                           list(operand)))
       }

--- a/tests/test_prolog_term_parser.pl
+++ b/tests/test_prolog_term_parser.pl
@@ -124,6 +124,59 @@ test(postfix_with_infix) :-
     parse_term_from_atom('5! + 3', Ops, T),
     T == '!'(5) + 3.
 
+% xf is the strict variant: operand precedence must be < op prec.
+% So `5!` parses (5 has prec 0, 0 < 100), but `5!!` does not (the
+% inner `!(5)` has prec 100, and 100 < 100 is false).
+strict_postfix_op_table(Ops) :-
+    canonical_op_table(Base),
+    Ops = [op('!', 100, xf) | Base].
+
+test(postfix_xf_single) :-
+    strict_postfix_op_table(Ops),
+    parse_term_from_atom('5!', Ops, T),
+    T == '!'(5).
+
+test(postfix_xf_chain_fails, [fail]) :-
+    strict_postfix_op_table(Ops),
+    parse_term_from_atom('5!!', Ops, _).
+
+% Prefix fy permits chaining (operand at op prec OK); fx forbids it.
+fy_neg_op_table(Ops) :-
+    canonical_op_table(Base),
+    Ops = [op('neg', 900, fy) | Base].
+
+fx_neg_op_table(Ops) :-
+    canonical_op_table(Base),
+    Ops = [op('neg', 900, fx) | Base].
+
+test(prefix_fy_chain) :-
+    fy_neg_op_table(Ops),
+    parse_term_from_atom('neg neg foo', Ops, T),
+    T == neg(neg(foo)).
+
+test(prefix_fx_chain_fails, [fail]) :-
+    fx_neg_op_table(Ops),
+    parse_term_from_atom('neg neg foo', Ops, _).
+
+% Infix associativity. `1 - 2 - 3` should fold left under yfx (the
+% canonical binding for `-`); under xfx it fails because both sides
+% must be strictly less than op prec.
+test(infix_yfx_chain) :-
+    canonical_op_table(Ops),
+    parse_term_from_atom('1 - 2 - 3', Ops, T),
+    T == (1 - 2) - 3.
+
+test(infix_xfx_chain_fails, [fail]) :-
+    canonical_op_table(Base),
+    Ops = [op('@@', 700, xfx) | Base],
+    parse_term_from_atom('a @@ b @@ c', Ops, _).
+
+% xfy is right-associative: `a -> b -> c` parses as a -> (b -> c).
+test(infix_xfy_right_assoc) :-
+    canonical_op_table(Ops),
+    parse_term_from_atom('a -> b -> c', Ops, T),
+    T == (a -> (b -> c)).
+
 % --- failure modes ----------------------------------------------------------
 
 test(unterminated_quote_fails, [fail]) :-

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -3647,6 +3647,72 @@ e2e_nested_if_then_else_via_rscript :-
 % The nonvar guard makes the function safe to call with any term;
 % as a side benefit the parser's natural-form `parse_op_loop` /
 % `parse_list_elems` bodies (triple-nested ITE) compile cleanly.
+% End-to-end: the runtime parser (WamRuntime$wam_parse_expr) enforces
+% strict (xf / xfx / xfy / fx) vs non-strict (yf / yfx / fy) lhs-prec
+% rules. yf / fy permit chaining `5!!` / `neg neg foo`; xf / fx
+% reject the second application because the operand precedence is
+% required to be strictly less than the operator precedence.
+test(strict_xf_chain_fails_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_strict_xf_chain_fails_via_rscript
+    ;   true
+    )).
+
+e2e_strict_xf_chain_fails_via_rscript :-
+    retractall(user:strict_xf_single_ok/0),
+    retractall(user:strict_xf_chain_fails/0),
+    retractall(user:strict_fx_chain_fails/0),
+    retractall(user:nonstrict_yf_chain_ok/0),
+    retractall(user:nonstrict_fy_chain_ok/0),
+    % yf permits chaining (5!! parses to !(!(5))).
+    assertz((user:nonstrict_yf_chain_ok :-
+        op(100, yf, '!'),
+        read_term_from_atom('5!!', T),
+        T =.. [F, Inner],
+        F == '!',
+        Inner =.. [F, A],
+        A == 5)),
+    % xf single application still works.
+    assertz((user:strict_xf_single_ok :-
+        op(100, xf, '!'),
+        read_term_from_atom('5!', T),
+        T =.. [F, A],
+        F == '!', A == 5)),
+    % xf chained: parser refuses 5!! because the inner !(5) has prec
+    % 100 and the outer ! requires its operand at < 100.
+    assertz((user:strict_xf_chain_fails :-
+        op(100, xf, '!'),
+        \+ read_term_from_atom('5!!', _))),
+    % fy permits chaining; fx rejects.
+    assertz((user:nonstrict_fy_chain_ok :-
+        op(900, fy, neg),
+        read_term_from_atom('neg neg foo', T),
+        T =.. [F, Inner],
+        F == neg,
+        Inner =.. [F, A],
+        A == foo)),
+    assertz((user:strict_fx_chain_fails :-
+        op(900, fx, neg),
+        \+ read_term_from_atom('neg neg foo', _))),
+    unique_r_tmp_dir('tmp_r_strict_xf_chain_e2e', TmpDir),
+    write_wam_r_project(
+        [user:nonstrict_yf_chain_ok/0, user:strict_xf_single_ok/0,
+         user:strict_xf_chain_fails/0, user:nonstrict_fy_chain_ok/0,
+         user:strict_fx_chain_fails/0],
+        [],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [nonstrict_yf_chain_ok, strict_xf_single_ok,
+           strict_xf_chain_fails, nonstrict_fy_chain_ok,
+           strict_fx_chain_fails],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    delete_directory_and_contents(TmpDir).
+
 test(deeply_nested_ite_compiles) :-
     retractall(user:dni_chain/1),
     % Triple-nested if-then-else. The exact shape that previously


### PR DESCRIPTION
## Summary

Both parsers (the R runtime's `WamRuntime$wam_parse_expr` and the cross-target `prolog_term_parser`) now thread the precedence of the parsed left expression through the operator-precedence loop and enforce the ISO strict-vs-non-strict associativity rules:

| Type | Lhs / operand precedence required |
|---|---|
| `xfx` / `xfy` / `xf` | **strictly less** than op precedence |
| `yfx` / `yf` | accepted **at** op precedence (left-fold) |
| `fx` | operand strictly less than op prec |
| `fy` | operand accepted at op prec (right-chain) |

Previously the parsers checked only `op.prec <= max_prec` and used `op.prec - 1` as the rhs ceiling regardless of associativity, which made `5!!` accidentally parse with `op(100, xf, '!')` (it should fail) and made `\+ \+ X` accidentally fail with `op(900, fy, '\+')` (it should parse). Documented as a "real-world non-blocker" but still a correctness gap.

## Implementation

- **R runtime** (`templates/targets/r_wam/runtime.R.mustache`): the parser state `p` gains `last_prec`. `wam_parse_primary` stamps it (0 for atomic / list / parens / functor; `op_prec` for a prefix-op application). `wam_parse_expr` reads it as `left_prec`, gates the infix and postfix branches on it, and updates it after each successful application. Prefix-op rhs ceiling now picks `op.prec` for `fy` and `op.prec - 1` for `fx`.
- **Cross-target parser** (`src/unifyweaver/core/prolog_term_parser.pl`): `parse_expr` / `parse_primary` / `parse_atom_head` all gain a `TermPrec` output arg threaded through the recursion. Same gates as the R runtime. `resolve_prefix/3` → `resolve_prefix/4` (now returns Type so `prefix_rhs_max` can pick the right ceiling).
- The canonical `op_prefix` seeds in both parsers gain explicit `assoc` fields (`fx` for `:-` / `?-`, `fy` for `\+` / unary `-` / unary `+` / `\`), matching the standard Prolog seed.

## Test plan

- [x] 7 new SWI-level tests in `test_prolog_term_parser`: `postfix_xf_single`, `postfix_xf_chain_fails`, `prefix_fy_chain`, `prefix_fx_chain_fails`, `infix_yfx_chain`, `infix_xfx_chain_fails`, `infix_xfy_right_assoc`.
- [x] New e2e test `strict_xf_chain_fails_e2e_rscript` exercises the runtime parser through the `op/3` + `read_term_from_atom` builtins: asserts that `op(100, xf, '!')` rejects `5!!`, `op(900, fx, neg)` rejects `neg neg foo`, while `yf` / `fy` variants accept them.
- [x] Existing `op_3_runtime_e2e_rscript` and `op_3_postfix_e2e_rscript` still pass (xfy right-associativity and yf chaining were already exercised end-to-end; the new strictness gates the formerly-permissive flank without disturbing them).
- [x] Full WAM-R suite: **71/71** (was 70, +1 new).
- [x] Parser SWI suite: **32/32** (was 25, +7 new).
- [x] Compile-to-WAM-R parser suite: 3/3.

## Where the loop stands now

The cross-target Prolog parser story is fully ISO-correct end-to-end on the operator-precedence semantics. Remaining handoff items (renumbered in the doc): #3 inline `WamRuntime$parse_term` swap-in (medium-large; needs benchmarks), #4+ mode analysis, multi-line `read/2`, multi-solution `retract/1`, Phase-3 expansion, range/interval indexes.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_