### PR TITLE
bench(wam-r): inline-vs-compiled parser benchmark; document no-swap

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -755,6 +755,45 @@ directly when invoked via `Rscript`; it warmups for 5% of the
 iterations (capped at 50) so the R-level data structures settle
 before timing, then prints `BENCH n=<N> elapsed=<sec> last=<true|false>`.
 
+### Parser benchmark (inline vs compiled-from-Prolog)
+
+`tests/benchmarks/wam_r_parser_bench.pl` measures the cost of the
+inline R parser (`WamRuntime$wam_parse_expr` / `parse_term`, called
+by `read/2` / `term_to_atom/2` / `read_term_from_atom/2,3` and the
+CLI arg parser) versus the cross-target Prolog parser at
+`src/unifyweaver/core/prolog_term_parser.pl` compiled to WAM-R.
+Both produce identical terms (verified by
+`tests/test_prolog_term_parser_wam_r_compile.pl`); this is purely
+a "should we swap?" benchmark.
+
+```bash
+swipl -g main -t halt tests/benchmarks/wam_r_parser_bench.pl
+swipl -g main -t halt tests/benchmarks/wam_r_parser_bench.pl -- --inner 2000
+```
+
+Representative numbers (200 iters each, single-threaded R 4.4):
+
+```
+     input  inline (s)  compiled (s)   per-iter (us)       ratio
+      atom    0.042000      4.081000         20405.0       97.2x
+   integer    0.043000      3.756000         18780.0       87.3x
+  compound    0.058000     15.028000         75140.0      259.1x
+     arith    0.067000     13.869000         69345.0      207.0x
+      list    0.072000     20.261000        101305.0      281.4x
+    nested    0.093000     25.770000        128850.0      277.1x
+```
+
+The compiled parser is **80-300x slower** than the inline one
+across the parser surface (atoms / integers / compounds / operator
+expressions / lists / nested compounds). The slowdown comes from
+running the Pratt parser through the WAM stepping engine instead
+of native R control flow plus inline tagged-list construction.
+Per the project directive *"only swap if equivalent or better"*,
+the runtime keeps the inline parser as the hot path. The
+cross-target parser source remains valuable as the canonical spec
+and as the parser-of-record for any future target that doesn't
+have a hand-written inline path.
+
 When adding a builtin:
 
 1. Implement it in `WamRuntime$call_builtin` (if the WAM compiler

--- a/docs/handoff/wam_r_session_handoff.md
+++ b/docs/handoff/wam_r_session_handoff.md
@@ -139,46 +139,37 @@ roughly priority order:
    identify a single hot path; subsequent PRs each fix one bottleneck.
    Tagged-list `$tag` access and env-based register lookups are likely
    suspects.
-3. **Inline `WamRuntime$parse_term` swap-in.** The cross-target Prolog
-   term parser at `src/unifyweaver/core/prolog_term_parser.pl` now
-   runs end-to-end through the WAM-R compiled path -- atoms, integers,
-   simple compounds, multi-arg compounds, lists, infix operators with
-   correct precedence, postfix, var sharing, nested. Coverage proven
-   by `tests/test_prolog_term_parser_wam_r_compile.pl:full_parser_e2e_via_rscript`.
-   Per-frame Y storage and the `dispatch_call` sub-call cleanup landed
-   alongside the cut-barrier work; nothing in the parser source needs
-   to change. The remaining work is wiring `WamRuntime$parse_term`
-   (and `term_to_atom/2`, `read_term_from_atom/2,3`, `read/2`, the
-   CLI arg parser) to dispatch into the compiled predicate instead of
-   the inline R parser. Important: existing op-related tests
-   (`op_3_runtime_e2e_rscript`, `op_3_decl_e2e_rscript`,
-   `op_3_postfix_e2e_rscript`, `term_to_atom*`) all exercise the
-   inline parser today; the swap needs to keep them green. Performance
-   Performance is unmeasured but the compiled parser will be slower
-   than the inline R version (WAM stepping engine vs. native R
-   control flow); the swap is a correctness / cross-target win, not
-   a speed win, so benchmark before pulling the trigger and consider
-   keeping the inline path for the CLI arg parser if startup latency
-   regresses too far.
-
-4. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
+3. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
    mode info per predicate (in/out per arg); Phase 2 wires it to
    specialised emission (skip unifications when the mode says the slot
    is unbound, etc.). Look at the Haskell target's
    `WAM_HASKELL_MODE_ANALYSIS_*.md` design docs for the precedent.
-5. **Multi-line `read/2`.** Read until a `.` terminator across lines.
+4. **Multi-line `read/2`.** Read until a `.` terminator across lines.
    Niche but completes the streams story.
-6. **Multi-solution `retract/1` ignoring snapshot.** I.e. re-read the
+5. **Multi-solution `retract/1` ignoring snapshot.** I.e. re-read the
    live clause list on each backtrack. Trickier semantics; document
    carefully if pursued.
-7. **Phase-3 lowered emitter expansion.** Currently handles only
+6. **Phase-3 lowered emitter expansion.** Currently handles only
    `deterministic` and `multi_clause_1` shapes. Could grow N-clause
    general lowering; would compete with the kernel / fact-table paths
    so the value is unclear.
-8. **Range / interval indexes** on fact tables. Per-arg hash indexes
+7. **Range / interval indexes** on fact tables. Per-arg hash indexes
    land queries with ground atom/int args; range queries (`X > 5`,
    `X between A B`) still go through the per-tuple scan. A sorted-
    per-arg index would route these. Niche but a natural extension.
+
+## Closed items (recent history)
+
+The cross-target Prolog term parser story landed across PRs #1948,
+#1954, #1960, #1964, #1965, #1968, #1977. The parser source at
+`src/unifyweaver/core/prolog_term_parser.pl` is the canonical spec
+(plain natural Prolog, ISO-correct on operator precedence,
+SWI-runnable + WAM-R compilable). The runtime keeps its inline R
+parser as the hot path because the compiled-from-Prolog parser is
+80-300x slower (see `tests/benchmarks/wam_r_parser_bench.pl` and
+the "Parser benchmark" section in WAM_R_TARGET.md). The compiled
+parser remains the parser-of-record for any future target that
+doesn't have a hand-written inline path.
 
 ## Things to know before you start a follow-up
 

--- a/tests/benchmarks/wam_r_parser_bench.pl
+++ b/tests/benchmarks/wam_r_parser_bench.pl
@@ -1,0 +1,229 @@
+:- encoding(utf8).
+%% Microbenchmark for the WAM R hybrid target's parser layer.
+%% Compares the inline R parser (WamRuntime$wam_parse_expr / parse_term)
+%% against the compiled-from-Prolog cross-target parser
+%% (prolog_term_parser:parse_term_from_atom). The two parsers produce
+%% the same terms (proven by tests/test_prolog_term_parser_wam_r_compile),
+%% so this benchmark is purely about the cost of swapping out the
+%% inline path for the compiled one as the runtime's parser.
+%%
+%% For each input the benchmark drives `Rscript --bench N` against:
+%%   inline    -- a driver that calls read_term_from_atom/2, which
+%%                dispatches into the inline parser.
+%%   compiled  -- a driver that calls
+%%                prolog_term_parser:parse_term_from_atom/3 with the
+%%                canonical op table built per-iteration. The op-table
+%%                construction is included in the timing because it
+%%                would also be required at every call site if the
+%%                runtime swapped to the compiled parser internally.
+%%
+%% Inputs cover the parser surface:
+%%   atom      `foo`
+%%   integer   `42`
+%%   compound  `foo(a, b)`
+%%   arith     `1 + 2 * 3`     (operator precedence)
+%%   list      `[a, b, c]`
+%%   nested    `foo(bar(1), [a, b])`
+%%
+%% Usage:
+%%   swipl -g main -t halt tests/benchmarks/wam_r_parser_bench.pl
+%%   swipl -g main -t halt tests/benchmarks/wam_r_parser_bench.pl -- --inner 2000
+%%
+%% Inner iterations default to 1000. Honours WAM_R_BENCH_KEEP=1 to
+%% retain the generated project.
+
+:- use_module('../../src/unifyweaver/core/prolog_term_parser').
+:- use_module('../../src/unifyweaver/targets/wam_r_target').
+:- use_module(library(filesex), [directory_file_path/3,
+                                  delete_directory_and_contents/1]).
+:- use_module(library(process)).
+:- use_module(library(readutil)).
+
+rscript_available :-
+    catch(
+        (   process_create(path('Rscript'), ['--version'],
+                [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0))
+        ),
+        _, fail).
+
+%% ========================================================================
+%% Driver predicates (asserted into user)
+%% ========================================================================
+
+setup_drivers :-
+    retractall(user:bench_inline_atom/0),
+    retractall(user:bench_inline_int/0),
+    retractall(user:bench_inline_compound/0),
+    retractall(user:bench_inline_arith/0),
+    retractall(user:bench_inline_list/0),
+    retractall(user:bench_inline_nested/0),
+    retractall(user:bench_compiled_atom/0),
+    retractall(user:bench_compiled_int/0),
+    retractall(user:bench_compiled_compound/0),
+    retractall(user:bench_compiled_arith/0),
+    retractall(user:bench_compiled_list/0),
+    retractall(user:bench_compiled_nested/0),
+    assertz((user:bench_inline_atom :-
+        read_term_from_atom('foo', _))),
+    assertz((user:bench_inline_int :-
+        read_term_from_atom('42', _))),
+    assertz((user:bench_inline_compound :-
+        read_term_from_atom('foo(a, b)', _))),
+    assertz((user:bench_inline_arith :-
+        read_term_from_atom('1 + 2 * 3', _))),
+    assertz((user:bench_inline_list :-
+        read_term_from_atom('[a, b, c]', _))),
+    assertz((user:bench_inline_nested :-
+        read_term_from_atom('foo(bar(1), [a, b])', _))),
+    assertz((user:bench_compiled_atom :-
+        canonical_op_table(O), parse_term_from_atom('foo', O, _))),
+    assertz((user:bench_compiled_int :-
+        canonical_op_table(O), parse_term_from_atom('42', O, _))),
+    assertz((user:bench_compiled_compound :-
+        canonical_op_table(O), parse_term_from_atom('foo(a, b)', O, _))),
+    assertz((user:bench_compiled_arith :-
+        canonical_op_table(O), parse_term_from_atom('1 + 2 * 3', O, _))),
+    assertz((user:bench_compiled_list :-
+        canonical_op_table(O), parse_term_from_atom('[a, b, c]', O, _))),
+    assertz((user:bench_compiled_nested :-
+        canonical_op_table(O),
+        parse_term_from_atom('foo(bar(1), [a, b])', O, _))).
+
+%% ========================================================================
+%% Project builder
+%% ========================================================================
+
+parser_module_predicates(Preds) :-
+    findall(prolog_term_parser:N/A,
+            (   current_predicate(prolog_term_parser:N/A),
+                functor(H, N, A),
+                once(clause(prolog_term_parser:H, _)),
+                \+ predicate_property(prolog_term_parser:H,
+                                       imported_from(_))
+            ),
+            Raw),
+    sort(Raw, Preds).
+
+driver_predicates([
+    user:bench_inline_atom/0,
+    user:bench_inline_int/0,
+    user:bench_inline_compound/0,
+    user:bench_inline_arith/0,
+    user:bench_inline_list/0,
+    user:bench_inline_nested/0,
+    user:bench_compiled_atom/0,
+    user:bench_compiled_int/0,
+    user:bench_compiled_compound/0,
+    user:bench_compiled_arith/0,
+    user:bench_compiled_list/0,
+    user:bench_compiled_nested/0
+]).
+
+build_project(ProjectDir) :-
+    catch(delete_directory_and_contents(ProjectDir), _, true),
+    setup_drivers,
+    parser_module_predicates(ParserPreds),
+    driver_predicates(Drivers),
+    append(Drivers, ParserPreds, Compile),
+    write_wam_r_project(Compile, [], ProjectDir).
+
+%% ========================================================================
+%% Rscript helpers (mirrors wam_r_fact_source_bench)
+%% ========================================================================
+
+run_rscript_bench(RDir, N, PredKey, BenchSec) :-
+    atom_string(N, NStr),
+    ProcArgs = ['generated_program.R', '--bench', NStr, PredKey],
+    process_create(path('Rscript'), ProcArgs,
+                   [cwd(RDir), stdout(pipe(O)), stderr(pipe(E)),
+                    process(Pid)]),
+    read_string(O, _, OutStr), read_string(E, _, ErrStr),
+    close(O), close(E),
+    process_wait(Pid, exit(EC)),
+    (   (EC =:= 0 ; EC =:= 1)
+    ->  parse_bench_line(OutStr, BenchSec)
+    ;   throw(error(rscript_bench_failed(EC, PredKey, ErrStr), _))
+    ).
+
+parse_bench_line(Str, Seconds) :-
+    split_string(Str, "\n", "", Lines),
+    member(Line, Lines),
+    sub_string(Line, _, _, _, "BENCH"),
+    sub_string(Line, B, _, _, "elapsed="),
+    Bp is B + 8,
+    sub_string(Line, Bp, _, 0, Tail),
+    split_string(Tail, " \n", "", [SecStr | _]),
+    number_string(Seconds, SecStr), !.
+
+%% ========================================================================
+%% Bench driver
+%% ========================================================================
+
+input_cases([
+    'atom'-bench_inline_atom-bench_compiled_atom,
+    'integer'-bench_inline_int-bench_compiled_int,
+    'compound'-bench_inline_compound-bench_compiled_compound,
+    'arith'-bench_inline_arith-bench_compiled_arith,
+    'list'-bench_inline_list-bench_compiled_list,
+    'nested'-bench_inline_nested-bench_compiled_nested
+]).
+
+run_bench(InnerN) :-
+    bench_proj_path(ProjectDir),
+    format("[INFO] inner=~w iterations per case~n", [InnerN]),
+    format("[INFO] building project...~n", []),
+    build_project(ProjectDir),
+    directory_file_path(ProjectDir, 'R', RDir),
+    format("[INFO] running benchmarks via Rscript --bench ~w...~n~n",
+           [InnerN]),
+    format("~`-t~64|~n", []),
+    format("~t~w~10| ~t~w~22| ~t~w~36| ~t~w~52| ~t~w~64|~n",
+           ['input', 'inline (s)', 'compiled (s)',
+            'per-iter (us)', 'ratio']),
+    format("~`-t~64|~n", []),
+    input_cases(Cases),
+    forall(member(Name-IPred-CPred, Cases),
+        ( inline_pred_key(IPred, IKey),
+          inline_pred_key(CPred, CKey),
+          run_rscript_bench(RDir, InnerN, IKey, ISec),
+          run_rscript_bench(RDir, InnerN, CKey, CSec),
+          Ratio is CSec / ISec,
+          PerIterUs is (CSec / InnerN) * 1_000_000,
+          format("~t~w~10| ~t~6f~22| ~t~6f~36| ~t~1f~52| ~t~1fx~64|~n",
+                 [Name, ISec, CSec, PerIterUs, Ratio])
+        )),
+    format("~`-t~64|~n~n", []),
+    cleanup_after(ProjectDir).
+
+inline_pred_key(Name, Key) :-
+    atom_string(Name, NameStr),
+    string_concat(NameStr, "/0", Key).
+
+bench_proj_path(P) :-
+    absolute_file_name('_tmp_wam_r_parser_bench', P).
+
+cleanup_after(ProjectDir) :-
+    (   getenv('WAM_R_BENCH_KEEP', "1")
+    ->  format("[INFO] keeping project at ~w (WAM_R_BENCH_KEEP=1)~n",
+               [ProjectDir])
+    ;   catch(delete_directory_and_contents(ProjectDir), _, true)
+    ).
+
+%% ========================================================================
+%% Entry point
+%% ========================================================================
+
+inner_iterations(I) :-
+    current_prolog_flag(argv, Argv),
+    append(_, ['--inner', IStr], Argv),
+    atom_number(IStr, I),
+    integer(I), I > 0, !.
+inner_iterations(1000).
+
+main :-
+    (   rscript_available
+    ->  inner_iterations(I),
+        run_bench(I)
+    ;   format(user_error, "[SKIP] Rscript not on PATH~n", [])
+    ).


### PR DESCRIPTION
## Summary

Closes the cross-target parser story per the project directive *"only swap if equivalent or better."* The cross-target Prolog parser at `src/unifyweaver/core/prolog_term_parser.pl` is correctness-equivalent to the inline R parser (proven by `tests/test_prolog_term_parser_wam_r_compile.pl`); this PR measures the performance cost of swapping it in and decides **not to**.

## New benchmark

`tests/benchmarks/wam_r_parser_bench.pl` builds a single project containing the parser predicates plus twelve driver predicates (one inline + one compiled per input shape). It drives `Rscript --bench N` against each driver to amortise Rscript startup over N iterations, then prints a side-by-side table with elapsed time, per-iter cost, and slowdown ratio.

Inputs cover the parser surface: bare atom, integer, simple compound, operator expression with precedence, list, and nested compound + list.

## Representative numbers

200 iterations, single-threaded R 4.4:

```
       input  inline (s)  compiled (s)   per-iter (us)       ratio
        atom    0.042         4.081          20405.0         97.2x
     integer    0.043         3.756          18780.0         87.3x
    compound    0.058        15.028          75140.0        259.1x
       arith    0.067        13.869          69345.0        207.0x
        list    0.072        20.261         101305.0        281.4x
      nested    0.093        25.770         128850.0        277.1x
```

The compiled parser is **80-300x slower** than the inline one. The slowdown comes from running the Pratt parser through the WAM stepping engine (instr-by-instr dispatch through `state$cps`, `state$stack`, `regs2` envs) instead of native R control flow plus inline tagged-list construction. There is no realistic per-call optimisation that closes that gap without changing the engine fundamentally.

## Decision

**Keep the inline R parser as the hot path.** The cross-target parser source is the canonical spec, and it remains the parser-of-record for any future WAM target that doesn't have a hand-written inline path — the spec / canonical-source value stands without the runtime swap.

## Docs

- `WAM_R_TARGET.md` "Benchmark" section gets a "Parser benchmark (inline vs compiled-from-Prolog)" subsection with the numbers and the no-swap rationale.
- WAM-R handoff: item #3 (Inline `parse_term` swap-in) closed and moved to a new "Closed items" section that summarises the cross-target parser story across PRs #1948, #1954, #1960, #1964, #1965, #1968, #1977. Remaining follow-ups renumbered.

## What's next

Remaining handoff items: mode analysis (multi-PR), multi-line `read/2`, multi-solution `retract/1` ignoring snapshot, Phase-3 lowered emitter expansion, range/interval indexes on fact tables, plus the deferred LMDB backend for `r_fact_sources` and the open-ended performance profiling pass on `wam_r_fact_source_bench.pl`.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_