### PR TITLE
feat(wam-clojure): lower member builtin

### DIFF
--- a/PR_WAM_CLOJURE_MEMBER_BUILTIN_LOWERING.md
+++ b/PR_WAM_CLOJURE_MEMBER_BUILTIN_LOWERING.md
@@ -1,0 +1,29 @@
+# feat(wam-clojure): lower member builtin
+
+## Summary
+
+Adds direct lowered Clojure WAM support for `member/2`.
+
+## What Changed
+
+- Marks `member/2` as a direct Clojure lowered builtin.
+- Emits lowered `member/2` calls through `runtime/apply-member-solution` instead of routing through the generic WAM step loop.
+- Adds Clojure runtime member choice points so backtracking can resume at the next list tail.
+- Generalizes foreign choice activation into `activate-choice` so both foreign stream choices and member choices share the backtrack restore path.
+- Adds generator, lowered-emitter, and smoke coverage for emitted member support.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- Targeted generated Clojure runtime checks:
+  - `wam_member_guard/2` succeeds for first element.
+  - `wam_member_guard/2` succeeds for later element.
+  - `wam_member_guard/2` fails for missing element.
+  - `wam_member_backtrack_b/0` succeeds by backtracking from `a` to `b`.
+  - `wam_member_unbound_list/1` fails for an unbound list argument.
+
+## Notes
+
+The full `tests/test_wam_clojure_runtime_smoke.pl` run was attempted with a 240 second timeout in Termux. It generated the project successfully but timed out during the broad multi-invocation Java smoke phase, so targeted Java checks were used for this feature path.

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -352,6 +352,10 @@ clojure_direct_builtin("length/2", "2").
 clojure_direct_builtin("length/2", 2).
 clojure_direct_builtin('length/2', "2").
 clojure_direct_builtin('length/2', 2).
+clojure_direct_builtin("member/2", "2").
+clojure_direct_builtin("member/2", 2).
+clojure_direct_builtin('member/2', "2").
+clojure_direct_builtin('member/2', 2).
 clojure_direct_builtin("ground/1", "1").
 clojure_direct_builtin("ground/1", 1).
 clojure_direct_builtin('ground/1', "1").
@@ -541,6 +545,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr),
            '(let [list-value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) len (runtime/proper-list-length ~w list-value) out (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound))] (if (some? len) (let [[ok next-state] (runtime/unify-values ~w out len)] (if ok (runtime/advance next-state) (runtime/backtrack ~w))) (runtime/backtrack ~w)))',
            [S, S, S, S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "member/2" ; Op == 'member/2'),
+    !,
+    format(atom(Expr),
+           '(let [elem (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) list-value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound))] (runtime/apply-member-solution ~w (inc (:pc ~w)) elem list-value))',
+           [S, S, S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "ground/1" ; Op == 'ground/1'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -220,7 +220,7 @@
 (defn restore-choice-regs [state saved-regs]
   (assoc state :regs saved-regs))
 
-(declare activate-foreign-choice)
+(declare activate-choice)
 
 (defn choice-snapshot [state target-pc]
   {:kind :wam
@@ -245,6 +245,12 @@
    :cut-bar (:cut-bar state)
    :next-var-id (:next-var-id state)
    :foreign-results (vec results)})
+
+(defn member-choice-snapshot [state target-pc elem rest-list]
+  (assoc (choice-snapshot state target-pc)
+         :kind :member
+         :member-elem elem
+         :member-rest rest-list))
 
 (defn push-choice-point [state target-pc]
   (update state :choice-points conj (choice-snapshot state target-pc)))
@@ -291,7 +297,7 @@
   (if-let [cp (peek (:choice-points state))]
     (-> state
         (restore-choice-state cp)
-        (activate-foreign-choice cp))
+        (activate-choice cp))
     (fail-state state)))
 
 (defn y-slot? [reg]
@@ -491,6 +497,44 @@
              (= 2 (count (:args cur))))
         (recur (deref-value bindings (second (:args cur))) (conj seen cur) (inc n))
         :else nil))))
+
+(declare apply-member-solution)
+
+(defn push-member-choice-point [state base-state resume-pc elem rest-list]
+  (let [rest* (deref-value (:bindings base-state) rest-list)
+        empty-list (normalize-literal-atom (:intern-context base-state) "[]")]
+    (if (interned-equal? rest* empty-list)
+      state
+      (update state :choice-points conj
+              (member-choice-snapshot base-state resume-pc elem rest*)))))
+
+(defn apply-member-solution [base-state resume-pc elem list-value]
+  (let [bindings (:bindings base-state)
+        empty-list (normalize-literal-atom (:intern-context base-state) "[]")
+        list-functor (list-functor-term (:intern-context base-state))]
+    (loop [cur (deref-value bindings list-value)
+           seen #{}]
+      (cond
+        (interned-equal? cur empty-list)
+        (backtrack base-state)
+
+        (or (= cur ::unbound) (logic-var? cur) (contains? seen cur))
+        (backtrack base-state)
+
+        (and (structure-term? cur)
+             (interned-equal? (:functor cur) list-functor)
+             (= 2 (count (:args cur))))
+        (let [head (first (:args cur))
+              tail (second (:args cur))
+              [ok next-state] (unify-values base-state elem head)]
+          (if ok
+            (-> next-state
+                (push-member-choice-point base-state resume-pc elem tail)
+                (assoc :pc resume-pc))
+            (recur (deref-value bindings tail) (conj seen cur))))
+
+        :else
+        (backtrack base-state)))))
 
 (defn ground-term? [state value]
   (let [bindings (:bindings state)]
@@ -712,9 +756,16 @@
           (recur (next remaining))))
       (backtrack base-state))))
 
-(defn activate-foreign-choice [state cp]
-  (if-let [results (seq (:foreign-results cp))]
-    (apply-first-foreign-solution state (:pc cp) results)
+(defn activate-choice [state cp]
+  (case (:kind cp)
+    :foreign
+    (if-let [results (seq (:foreign-results cp))]
+      (apply-first-foreign-solution state (:pc cp) results)
+      (assoc state :status :running))
+
+    :member
+    (apply-member-solution state (:pc cp) (:member-elem cp) (:member-rest cp))
+
     (assoc state :status :running)))
 
 (defn execute-foreign [state instr]
@@ -1085,6 +1136,13 @@
                   (advance next-state)
                   (backtrack state)))
               (backtrack state)))
+
+          "member/2"
+          (let [elem (deref-value (:bindings state)
+                                  (or (reg-get-raw state "A1") ::unbound))
+                list-value (deref-value (:bindings state)
+                                        (or (reg-get-raw state "A2") ::unbound))]
+            (apply-member-solution state (inc (:pc state)) elem list-value))
 
           "ground/1"
           (let [value (deref-value (:bindings state)

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -126,6 +126,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, '"float/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"is_list/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"length/2"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"member/2"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"ground/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -450,6 +450,19 @@ test(simple_builtin_length_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/backtrack")
     )).
 
+test(simple_builtin_member_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_member/2:\nbuiltin_call member/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_member/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_member/2, WamCode, [], Code),
+        has(Code, "runtime/apply-member-solution"),
+        has(Code, "\"A1\""),
+        has(Code, "\"A2\""),
+        has(Code, "inc (:pc"),
+        has(Code, "runtime/deref-value"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_ground_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_ground/1:\nbuiltin_call ground/1, 1\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -58,6 +58,9 @@
 :- dynamic user:wam_length_guard/2.
 :- dynamic user:wam_length_bad_list/1.
 :- dynamic user:wam_length_unbound_list/1.
+:- dynamic user:wam_member_guard/2.
+:- dynamic user:wam_member_backtrack_b/0.
+:- dynamic user:wam_member_unbound_list/1.
 :- dynamic user:wam_ground_guard/1.
 :- dynamic user:wam_ground_unbound/1.
 :- dynamic user:wam_ground_nested_unbound/1.
@@ -137,6 +140,9 @@ user:wam_is_list_unbound(_) :- user:wam_unbound_arg(Y), is_list(Y).
 user:wam_length_guard(L, N) :- length(L, N).
 user:wam_length_bad_list(N) :- length([a|b], N).
 user:wam_length_unbound_list(N) :- user:wam_unbound_arg(Y), length(Y, N).
+user:wam_member_guard(X, L) :- member(X, L).
+user:wam_member_backtrack_b :- member(X, [a,b]), X = b.
+user:wam_member_unbound_list(X) :- user:wam_unbound_arg(Y), member(X, Y).
 user:wam_ground_guard(X) :- ground(X).
 user:wam_ground_unbound(_) :- user:wam_unbound_arg(Y), ground(Y).
 user:wam_ground_nested_unbound(_) :- user:wam_unbound_arg(Y), ground(f(Y)).
@@ -221,6 +227,9 @@ run_smoke :-
           user:wam_length_guard/2,
           user:wam_length_bad_list/1,
           user:wam_length_unbound_list/1,
+          user:wam_member_guard/2,
+          user:wam_member_backtrack_b/0,
+          user:wam_member_unbound_list/1,
           user:wam_ground_guard/1,
           user:wam_ground_unbound/1,
           user:wam_ground_nested_unbound/1,
@@ -269,6 +278,7 @@ run_smoke :-
     assert_lowered_float_builtin_emitted(TmpDir),
     assert_lowered_is_list_builtin_emitted(TmpDir),
     assert_lowered_length_builtin_emitted(TmpDir),
+    assert_lowered_member_builtin_emitted(TmpDir),
     assert_lowered_ground_builtin_emitted(TmpDir),
     assert_lowered_arithmetic_comparison_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
@@ -371,6 +381,11 @@ run_smoke :-
     verify_output(TmpDir, 'wam_length_guard/2', args('[]', 0), "true"),
     verify_output(TmpDir, 'wam_length_bad_list/1', 1, "false"),
     verify_output(TmpDir, 'wam_length_unbound_list/1', 0, "false"),
+    verify_output(TmpDir, 'wam_member_guard/2', args(a, '[a,b]'), "true"),
+    verify_output(TmpDir, 'wam_member_guard/2', args(b, '[a,b]'), "true"),
+    verify_output(TmpDir, 'wam_member_guard/2', args(c, '[a,b]'), "false"),
+    verify_output(TmpDir, 'wam_member_backtrack_b/0', no_args, "true"),
+    verify_output(TmpDir, 'wam_member_unbound_list/1', a, "false"),
     verify_output(TmpDir, 'wam_ground_guard/1', a, "true"),
     verify_output(TmpDir, 'wam_ground_guard/1', 42, "true"),
     verify_output(TmpDir, 'wam_ground_guard/1', 3.5, "true"),
@@ -539,6 +554,14 @@ assert_lowered_length_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-length-unbound-list-1"),
     has(CoreCode, "runtime/proper-list-length").
 
+assert_lowered_member_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-member-guard-2"),
+    has(CoreCode, "defn lowered-wam-member-backtrack-b-0"),
+    has(CoreCode, "defn lowered-wam-member-unbound-list-1"),
+    has(CoreCode, "runtime/apply-member-solution").
+
 assert_lowered_ground_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
@@ -621,6 +644,22 @@ run_clojure_predicate(ProjectDir, PredKey, args(Arg1, Arg2), Output) :-
     (   ErrStr == ""
     ->  true
     ;   throw(error(java_stderr(PredKey, args(Arg1, Arg2), ErrStr), _))
+    ).
+
+run_clojure_predicate(ProjectDir, PredKey, no_args, Output) :-
+    find_clojure_classpath(ClassPath),
+    process_create(path(java),
+                   ['-cp', ClassPath, 'clojure.main', '-m',
+                    'generated.wam_exec_test.core', PredKey],
+                   [cwd(ProjectDir), stdout(pipe(Out)), stderr(pipe(Err))]),
+    read_string(Out, _, OutStr0),
+    read_string(Err, _, ErrStr),
+    close(Out),
+    close(Err),
+    normalize_space(string(Output), OutStr0),
+    (   ErrStr == ""
+    ->  true
+    ;   throw(error(java_stderr(PredKey, no_args, ErrStr), _))
     ).
 
 run_clojure_predicate(ProjectDir, PredKey, Arg, Output) :-


### PR DESCRIPTION
## Summary

Adds direct lowered Clojure WAM support for `member/2`.

## What Changed

- Marks `member/2` as a direct Clojure lowered builtin.
- Emits lowered `member/2` calls through `runtime/apply-member-solution` instead of routing through the generic WAM step loop.
- Adds Clojure runtime member choice points so backtracking can resume at the next list tail.
- Generalizes foreign choice activation into `activate-choice` so both foreign stream choices and member choices share the backtrack restore path.
- Adds generator, lowered-emitter, and smoke coverage for emitted member support.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- Targeted generated Clojure runtime checks:
  - `wam_member_guard/2` succeeds for first element.
  - `wam_member_guard/2` succeeds for later element.
  - `wam_member_guard/2` fails for missing element.
  - `wam_member_backtrack_b/0` succeeds by backtracking from `a` to `b`.
  - `wam_member_unbound_list/1` fails for an unbound list argument.

## Notes

The full `tests/test_wam_clojure_runtime_smoke.pl` run was attempted with a 240 second timeout in Termux. It generated the project successfully but timed out during the broad multi-invocation Java smoke phase, so targeted Java checks were used for this feature path.
