### PR TITLE
Feature/lua wam term inspection builtins

### DIFF
--- a/PR_lua_wam_term_inspection_builtins.md
+++ b/PR_lua_wam_term_inspection_builtins.md
@@ -1,0 +1,17 @@
+# PR Title
+
+Add Lua WAM term inspection builtins
+
+# PR Description
+
+## Summary
+
+- add Lua WAM runtime support for `functor/3` in read and construct modes
+- add Lua WAM runtime support for `arg/3` over compound terms and WAM cons-list cells
+- add Lua generator end-to-end coverage for functor read mode, atom arity, construct mode, struct argument extraction, list argument extraction, and out-of-range failure
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`

--- a/templates/targets/lua_wam/runtime.lua.mustache
+++ b/templates/targets/lua_wam/runtime.lua.mustache
@@ -387,6 +387,49 @@ local function builtin_length(program, state)
   return bind_or_compare(state, 2, V.Int(#items))
 end
 
+local function builtin_functor(program, state)
+  local term = Runtime.deref(state, Runtime.get_reg(state, 1))
+  if type(term) == "table" and term.tag == "unbound" then
+    local name = Runtime.deref(state, Runtime.get_reg(state, 2))
+    local arity = Runtime.deref(state, Runtime.get_reg(state, 3))
+    if type(arity) ~= "table" or arity.tag ~= "int" or arity.val < 0 then return false end
+    if type(name) ~= "table" or name.tag == "unbound" then return false end
+    local built = nil
+    if arity.val == 0 then
+      built = name
+    else
+      if type(name) ~= "table" or name.tag ~= "atom" then return false end
+      local args = {}
+      for i = 1, arity.val do args[i] = Runtime.new_var(state) end
+      built = V.Struct(name.id, args)
+    end
+    return Runtime.unify(state, term, built)
+  end
+  local name = nil
+  local arity = nil
+  if type(term) == "table" and term.tag == "struct" then
+    name = V.Atom(term.fid)
+    arity = #(term.args or {})
+  elseif type(term) == "table" and (term.tag == "atom" or term.tag == "int" or term.tag == "float") then
+    name = term
+    arity = 0
+  else
+    return false
+  end
+  if bind_or_compare(state, 2, name) ~= true then return false end
+  return bind_or_compare(state, 3, V.Int(arity))
+end
+
+local function builtin_arg(_program, state)
+  local n = Runtime.deref(state, Runtime.get_reg(state, 1))
+  local term = Runtime.deref(state, Runtime.get_reg(state, 2))
+  if type(n) ~= "table" or n.tag ~= "int" or n.val < 1 then return false end
+  if type(term) ~= "table" or term.tag ~= "struct" then return false end
+  local arg = (term.args or {})[n.val]
+  if arg == nil then return false end
+  return bind_or_compare(state, 3, arg)
+end
+
 local function numeric_value(v)
   if type(v) == "table" and (v.tag == "int" or v.tag == "float") then return v.val end
   return nil
@@ -744,6 +787,8 @@ function Runtime.builtin_call(program, state, instr)
   if p == "==" or p == "==/2" then return exact_equal(state, Runtime.get_reg(state, 1), Runtime.get_reg(state, 2)) end
   if p == "member" or p == "member/2" then return builtin_member(program, state) end
   if p == "length" or p == "length/2" then return builtin_length(program, state) end
+  if p == "functor" or p == "functor/3" then return builtin_functor(program, state) end
+  if p == "arg" or p == "arg/3" then return builtin_arg(program, state) end
   if p == "is" or p == "is/2" then
     local n = number_value(Runtime.deref(state, Runtime.get_reg(state, 2)))
     if n == nil then return false end

--- a/tests/test_wam_lua_generator.pl
+++ b/tests/test_wam_lua_generator.pl
@@ -38,6 +38,12 @@
 :- dynamic user:wam_lua_type_var/0.
 :- dynamic user:wam_lua_type_no/0.
 :- dynamic user:wam_lua_compare_builtins/0.
+:- dynamic user:wam_lua_functor_read/0.
+:- dynamic user:wam_lua_functor_atom/0.
+:- dynamic user:wam_lua_functor_construct/0.
+:- dynamic user:wam_lua_arg_struct/0.
+:- dynamic user:wam_lua_arg_list/0.
+:- dynamic user:wam_lua_arg_no/0.
 
 user:wam_lua_fact(a).
 user:wam_lua_choice(a).
@@ -97,6 +103,16 @@ user:wam_lua_compare_builtins :-
     3 =:= 3,
     3 =\= 2,
     a == a.
+user:wam_lua_functor_read :- functor(f(a, b), f, 2).
+user:wam_lua_functor_atom :- functor(a, a, 0).
+user:wam_lua_functor_construct :-
+    functor(T, f, 2),
+    compound(T),
+    arg(1, T, A),
+    var(A).
+user:wam_lua_arg_struct :- arg(2, f(a, b), b).
+user:wam_lua_arg_list :- arg(2, [a, b], [b]).
+user:wam_lua_arg_no :- arg(3, f(a, b), _).
 
 test(exports) :-
     assertion(current_predicate(wam_lua_target:write_wam_lua_project/3)),
@@ -404,6 +420,30 @@ test(lua_type_and_compare_builtins_e2e, [condition(lua_available)]) :-
           run_lua_query(LuaDir, 'wam_lua_type_var/0', [], true),
           run_lua_query(LuaDir, 'wam_lua_type_no/0', [], false),
           run_lua_query(LuaDir, 'wam_lua_compare_builtins/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(lua_term_inspection_builtins_e2e, [condition(lua_available)]) :-
+    unique_lua_tmp_dir('tmp_lua_term_inspection_builtins_e2e', TmpDir),
+    setup_call_cleanup(
+        write_wam_lua_project(
+            [ user:wam_lua_functor_read/0,
+              user:wam_lua_functor_atom/0,
+              user:wam_lua_functor_construct/0,
+              user:wam_lua_arg_struct/0,
+              user:wam_lua_arg_list/0,
+              user:wam_lua_arg_no/0
+            ],
+            [],
+            TmpDir),
+        ( directory_file_path(TmpDir, 'lua', LuaDir),
+          run_lua_query(LuaDir, 'wam_lua_functor_read/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_functor_atom/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_functor_construct/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_arg_struct/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_arg_list/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_arg_no/0', [], false)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

- add Lua WAM runtime support for `functor/3` in read and construct modes
- add Lua WAM runtime support for `arg/3` over compound terms and WAM cons-list cells
- add Lua generator end-to-end coverage for functor read mode, atom arity, construct mode, struct argument extraction, list argument extraction, and out-of-range failure

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`
