### PR TITLE
perf(wam-r): integer-indexed regs2 list (~26% wall-clock improvement)

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -810,33 +810,43 @@ swipl -g main -t halt tests/benchmarks/wam_r_fact_source_bench.pl \
 ```
 
 Representative hotspots for the WAM backend, single-row `cp(c0, X)`
-query against a 100-row chain, 100000 iterations (R 4.4):
+query against a 100-row chain, 100000 iterations (R 4.4), with X / A
+registers stored as an integer-indexed R list:
 
 ```
   function                                       self.s  %self  total.s   %tot
-  WamRuntime$step                                 1.670  21.7%    3.850  49.9%
-  WamRuntime$run                                  0.910  11.8%    4.780  62.0%
-  WamRuntime$get_reg                              0.820  10.6%    1.510  19.6%
-  WamRuntime$deref                                0.430   5.6%    1.970  25.6%
-  exists                                          0.400   5.2%    0.400   5.2%
-  WamRuntime$put_reg                              0.390   5.1%    0.760   9.9%
-  WamRuntime$new_state                            0.390   5.1%    0.550   7.1%
-  WamRuntime$run_predicate                        0.340   4.4%    7.590  98.4%
-  as.character                                    0.260   3.4%    0.260   3.4%
-  assign                                          0.230   3.0%    0.230   3.0%
+  WamRuntime$step                                 1.370  24.0%    2.230  39.1%
+  WamRuntime$run                                  0.900  15.8%    3.150  55.3%
+  WamRuntime$deref                                0.520   9.1%    0.760  13.3%
+  WamRuntime$new_state                            0.500   8.8%    0.650  11.4%
+  WamRuntime$run_predicate                        0.440   7.7%    5.550  97.4%
+  WamRuntime$put_reg                              0.290   5.1%    0.300   5.3%
+  WamRuntime$get_reg                              0.200   3.5%    0.210   3.7%
+  list                                            0.170   3.0%    0.170   3.0%
+  new.env                                         0.080   1.4%    0.090   1.6%
 ```
 
-The pattern: per-instruction `step` dispatch (~22% self) plus the
-register-access machinery (`get_reg` + `put_reg` + the env-key
-plumbing they call -- `as.character`, `exists`, `assign`, `get`) is
-the bulk of the runtime, with a long tail in `deref` and
-`new_state`. Concretely, every `get_reg` / `put_reg` call does
-`as.character(idx)` -> `exists(key, envir)` (or `assign`) on
-`state$regs2`, which is an env keyed by stringified register
-indices. Replacing `state$regs2` with an integer-indexed list
-(or a preallocated vector for the dense small register-index
-range) is the most directly actionable single optimisation; that's
-the next planned PR (handoff item #2 follow-up).
+`step` dispatch and `deref` lead, with a long tail in `new_state`
+(per-call cost of fresh state allocation). The register layer is
+near the floor: `state$regs2` is now a plain R list and X / A
+access is `state$regs2[[idx]]` / `state$regs2[[idx]] <- v`, so each
+read/write is a direct integer subscript -- no `as.character`,
+`exists`, `assign`, `get`, or environment hash lookup. R's
+copy-on-write keeps CP snapshots correct with a bare list
+assignment (`cp$regs <- state$regs2`); subsequent puts clone,
+leaving the snapshot intact.
+
+A prior profile of the same workload before this refactor showed
+`get_reg` self.s = 0.820 and a combined ~0.89 self.s spent in
+`exists` + `as.character` + `assign`, with elapsed = 7.7s. After
+the refactor, elapsed dropped to ~5.7s (≈26% wall-clock
+improvement); `get_reg` self time fell ≈4× and `exists` /
+`as.character` / `assign` no longer appear in the X / A path.
+(`as.character` is still used on the Y-register path; Y reads
+remain in per-frame envs because Allocate / Deallocate snapshot
+semantics rely on each call frame owning its own Y storage.) The
+next directly actionable target is `new_state` (per-call env
+allocation amortised across `run_predicate` invocations).
 
 When adding a builtin:
 

--- a/docs/handoff/wam_r_session_handoff.md
+++ b/docs/handoff/wam_r_session_handoff.md
@@ -55,7 +55,7 @@ then read `docs/WAM_R_TARGET.md` for the user-facing reference.
 
 ### Architecture in one paragraph
 
-Tagged R lists for values (`list(tag = "atom" | "int" | "float" | "unbound" | "struct", ...)`); state lives in an R environment for pass-by-reference; A/X registers and Y registers are split (`regs2` for A/X, stack-frame `saved_ys` for Y, restored on `Deallocate`). Choice points are tagged `"iter"` / `"dynamic"` / `"aggregate"` plus the standard variant. Dispatch tier is: lowered-dispatch -> labels -> foreign-handlers -> dynamic-store -> library -> builtin. The `iterate_goal` helper has R-level fast paths for `member/2`, `between/3`, conjunctions, dynamic preds, and lowered-dispatch preds, falling back to a `call_goal + backtrack + run` loop.
+Tagged R lists for values (`list(tag = "atom" | "int" | "float" | "unbound" | "struct", ...)`); state lives in an R environment for pass-by-reference; A/X registers and Y registers are split (`regs2`, an integer-indexed list, for A/X; per-frame `ys` env on the call stack for Y, restored on `Deallocate`). Choice points are tagged `"iter"` / `"dynamic"` / `"aggregate"` plus the standard variant. Dispatch tier is: lowered-dispatch -> labels -> foreign-handlers -> dynamic-store -> library -> builtin. The `iterate_goal` helper has R-level fast paths for `member/2`, `between/3`, conjunctions, dynamic preds, and lowered-dispatch preds, falling back to a `call_goal + backtrack + run` loop.
 
 ## Following the campaign through the PR list
 
@@ -134,33 +134,30 @@ roughly priority order:
    `fact_source_loader_call/4` clause for the new Spec shape **plus** a
    parallel `WamRuntime$lmdb_fact_dispatch` to skip the in-memory tuple
    list, since materialising every key defeats the point.
-2. **Replace `state$regs2` env with an integer-indexed vector / list.**
-   The Rprof instrumentation that just landed (see
-   `tests/benchmarks/wam_r_fact_source_bench.pl --profile` and the
-   "Rprof profile" subsection in `WAM_R_TARGET.md`) shows the
-   register-access machinery -- `get_reg` + `put_reg` + the
-   `as.character(idx)` / `exists(key, envir)` / `assign(key, val,
-   envir)` calls they make against the env-keyed `state$regs2` -- is
-   ~15-18% of total runtime on the WAM backend, and the underlying R
-   builtins themselves (`exists`, `as.character`, `assign`) account
-   for ~12% of self-time on top of `get_reg` / `put_reg`'s 16%.
-   Register indices are dense small integers (A: 1..100, X: 101..200,
-   Y: 201..~256), so an integer-indexed list (or a preallocated
-   vector) eliminates the string conversion + env hash-lookup per
-   access. CP / TryMeElse / Allocate snapshots of `state$regs2` need
-   to switch to list-copy semantics. Per-frame Y storage (`frame$ys`)
-   stays as is or moves to the same data structure. Should be a
-   single, contained PR with a clear before/after measurement via
-   the same `--profile` mode.
+2. ~~**Replace `state$regs2` env with an integer-indexed vector / list.**~~
+   *Done.* `state$regs2` is now a plain R list, X / A access is
+   `state$regs2[[idx]]` / `state$regs2[[idx]] <- v`. R copy-on-write
+   keeps CP snapshots correct without a copy loop -- `cp$regs <-
+   state$regs2` shares the list, and the next `put_reg` clones.
+   Y registers stay in per-frame `frame$ys` envs (Allocate /
+   Deallocate semantics depend on each frame owning its own Y
+   storage); their `as.character(idx)` cost is unchanged but Y
+   reads are rare on the hot path. Profile result on the same
+   `--profile 100 --inner 100000` workload: elapsed 7.7s -> 5.7s
+   (~26% wall-clock improvement); `get_reg` self.s 0.820 -> 0.200
+   (4x); `exists` / `as.character` / `assign` no longer on the X /
+   A path. See "Rprof profile of the WAM stepping engine" in
+   `WAM_R_TARGET.md` for the after-snapshot.
 
-   Other bottlenecks the same profile flagged, in priority order:
-   - `WamRuntime$step` (22% self): the big `switch(op_name, ...)`. A
+   Bottlenecks the post-refactor profile flags, in priority order:
+   - `WamRuntime$step` (24% self): the big `switch(op_name, ...)`. A
      per-instruction closure-based dispatch could shave this; bigger
      refactor though.
-   - `WamRuntime$deref` (5.6% self / 25.6% total): same env-keyed
-     `state$bindings` lookup pattern as regs2; fixing one informs
-     the other.
-   - `WamRuntime$new_state` (5.1% self): re-allocates a full state
+   - `WamRuntime$deref` (9.1% self / 13.3% total): same env-keyed
+     `state$bindings` lookup pattern; bindings can't trivially move
+     to integer indices (variable names are strings) but a per-state
+     binding cache may help.
+   - `WamRuntime$new_state` (8.8% self): re-allocates a full state
      env on every `run_predicate` call. A pooled state would amortise
      over the bench's tight loop, less impactful in real workloads.
 3. **Mode analysis (start).** Big multi-PR effort. Phase 1 collects
@@ -213,13 +210,27 @@ prepending `pred_` to every wrapper. Keep it.
 
 ### The `Y`-register save/restore on `Allocate` / `Deallocate` is also load-bearing
 
-The flat `regs2` env stores A, X, and Y registers under the same
-namespace. Without the save/restore in `Allocate` / `Deallocate`,
-nested calls like `rt(F) :- do_write(F), do_read(F).` stomp each
-other's permanent vars. PR #1920 fixed this. The fix is conservative
-on `Deallocate` -- it restores caller's saved Ys but leaves callee-
-added Ys alone, because SWI's WAM emit reads Ys after `Deallocate`
-in some cases.
+X / A registers (`idx < 201`) live in the integer-indexed
+`state$regs2` list; Y registers (`idx >= 201`) live in a per-frame
+`frame$ys` env that Allocate pushes and Deallocate pops. Without
+the save/restore in `Allocate` / `Deallocate`, nested calls like
+`rt(F) :- do_write(F), do_read(F).` would stomp each other's
+permanent vars. PR #1920 fixed this. The fix is conservative on
+`Deallocate` -- it parks the popped frame's `ys` env on
+`state$shadow_frame` so SWI's WAM emit can still read Ys between
+Deallocate and Proceed/Execute.
+
+`state$regs2` is a plain R list (not an env). Reads use
+`state$regs2[[idx]]` with a guard `if (idx > length(state$regs2))
+return(NULL)`; writes use `state$regs2[[idx]] <- val` (or
+`state$regs2[idx] <- list(NULL)` for explicit NULL writes, since
+`[[<-` with NULL deletes). CP snapshots store `cp$regs <-
+state$regs2` directly; R's copy-on-write makes subsequent puts
+clone, leaving snapshots intact. Restore is a bare `state$regs2 <-
+cp$regs`. The legacy `state$regs` field exists only so external
+callers that pre-populate it (REPL inspection, tests) keep
+working; `WamRuntime$promote_regs` migrates any entries into
+`regs2` and is a no-op for the typical empty-`regs` case.
 
 ### Module qualifiers in clause bodies
 

--- a/src/unifyweaver/targets/wam_r_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_r_lowered_emitter.pl
@@ -227,7 +227,7 @@ emit_multi_clause_function(PredName, FuncName, AltLabel, ClauseLines, Code) :-
   if (is.null(alt_pc)) return(FALSE)
   state$cps <- c(state$cps, list(list(
     next_pc     = as.integer(alt_pc),
-    regs        = as.list.environment(state$regs2),
+    regs        = state$regs2,
     cp          = state$cp,
     trail_len   = length(state$trail),
     var_counter = state$var_counter

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -227,7 +227,8 @@ WamRuntime$new_state <- function() {
   s <- new.env(parent = emptyenv())
   s$pc          <- 1L                       # 1-based; matches R indexing
   s$cp          <- 0L                       # 0 = top-level
-  s$regs        <- list()                   # integer-keyed: regs[[as.character(idx)]]
+  s$regs        <- list()                   # legacy field; promote_regs migrates into regs2
+  s$regs2       <- list()                   # integer-indexed list of X/A register values
   s$stack       <- list()                   # env frames
   s$cps         <- list()                   # choice-point stack
   s$bindings    <- new.env(parent = emptyenv(), hash = TRUE)
@@ -268,14 +269,18 @@ WamRuntime$new_state <- function() {
   # frame's `ys` env, not in s$regs2. Deallocate pops the frame but
   # parks its ys env on s$shadow_frame so the SWI WAM emit's typical
   # post-Deallocate Y reads still resolve. Allocate clears it; the
-  # next body's Y writes don't leak in. Also initialise the regs2
-  # env so X / A access works before the first Allocate.
+  # next body's Y writes don't leak in.
   s$shadow_frame <- NULL
   s
 }
 
+# X / A register access is integer-indexed on `state$regs2`, a plain R
+# list. R lists are copy-on-write, so CP snapshots can store the list
+# by reference (`cp$regs <- state$regs2`) and any subsequent
+# `state$regs2[[idx]] <- v` clones, leaving the snapshot untouched.
+# Reading past the list end (or an unset slot) returns NULL, which
+# matches the previous env-based semantics without an `exists()` probe.
 WamRuntime$get_reg <- function(state, idx) {
-  key <- as.character(idx)
   # Y registers live in the topmost frame's `ys` env, not in regs2.
   # When state$shadow_frame is set (a Deallocate has just popped a
   # frame and we're in the post-Deallocate code section of THAT
@@ -287,6 +292,7 @@ WamRuntime$get_reg <- function(state, idx) {
   # we're inside a normal pre-Deallocate body Y reads bypass shadow
   # and hit the topmost frame's ys directly.
   if (idx >= 201L) {
+    key <- as.character(idx)
     sf <- state$shadow_frame
     if (!is.null(sf)) {
       ys <- sf$ys
@@ -303,38 +309,48 @@ WamRuntime$get_reg <- function(state, idx) {
     }
     return(NULL)
   }
-  if (exists(key, envir = state$regs2, inherits = FALSE)) {
-    get(key, envir = state$regs2, inherits = FALSE)
-  } else {
-    NULL
-  }
+  if (idx > length(state$regs2)) return(NULL)
+  state$regs2[[idx]]
 }
 
 WamRuntime$put_reg <- function(state, idx, val) {
-  key <- as.character(idx)
   # Y writes go to the topmost frame's ys env. Outside any Allocate'd
   # frame (top-level pre-Allocate, builtin handlers without their own
   # frame) Y writes fall back to regs2 so we keep something accessible.
   if (idx >= 201L) {
     sn <- length(state$stack)
     if (sn > 0L) {
-      assign(key, val, envir = state$stack[[sn]]$ys)
+      assign(as.character(idx), val, envir = state$stack[[sn]]$ys)
       return(invisible(NULL))
     }
   }
-  assign(key, val, envir = state$regs2)
+  # Use single-bracket assignment to avoid removing the slot when val
+  # is NULL (`x[[i]] <- NULL` deletes; `x[i] <- list(NULL)` keeps).
+  if (is.null(val)) {
+    state$regs2[idx] <- list(NULL)
+  } else {
+    state$regs2[[idx]] <- val
+  }
   invisible(NULL)
 }
 
-# Promote $regs from a plain list to an environment for O(1) update.
-# Called once at run_predicate entry; lazy migration keeps the data
-# model self-describing for inspection in the REPL.
+# Migrate any legacy `$regs` named-list entries into the integer-indexed
+# `$regs2` list. Called once at run_predicate entry. With the new
+# storage model `$regs` is unused at runtime; this exists so external
+# callers that pre-populate `$regs` (tests, REPL inspection) still work.
 WamRuntime$promote_regs <- function(state) {
-  e <- new.env(parent = emptyenv(), hash = TRUE)
+  if (length(state$regs) == 0L) return(invisible(NULL))
   for (k in names(state$regs)) {
-    assign(k, state$regs[[k]], envir = e)
+    idx <- suppressWarnings(as.integer(k))
+    if (!is.na(idx)) {
+      v <- state$regs[[k]]
+      if (is.null(v)) {
+        state$regs2[idx] <- list(NULL)
+      } else {
+        state$regs2[[idx]] <- v
+      }
+    }
   }
-  state$regs2 <- e
 }
 
 # ----------------------------------------------------------
@@ -961,7 +977,7 @@ WamRuntime$current_op_iter <- function(program, state, snapshot, idx,
         captured_resume   <- resume_pc
         cp <- list(
           kind        = "iter",
-          regs        = as.list.environment(state$regs2),
+          regs        = state$regs2,
           trail_len   = snap_trail,
           cp          = state$cp,
           var_counter = snap_vc,
@@ -1443,7 +1459,7 @@ WamRuntime$step <- function(program, state, instr) {
       #     depth before jumping to the next clause.
       cp <- list(
         next_pc       = program$labels[[instr$label]],
-        regs          = as.list.environment(state$regs2),
+        regs          = state$regs2,
         cp            = state$cp,
         trail_len     = length(state$trail),
         var_counter   = state$var_counter,
@@ -1462,7 +1478,7 @@ WamRuntime$step <- function(program, state, instr) {
       cp <- list(
         kind          = "ite",
         next_pc       = program$labels[[instr$label]],
-        regs          = as.list.environment(state$regs2),
+        regs          = state$regs2,
         cp            = state$cp,
         trail_len     = length(state$trail),
         var_counter   = state$var_counter,
@@ -1625,7 +1641,7 @@ WamRuntime$step <- function(program, state, instr) {
         template_reg = as.integer(instr$template),
         bag_reg      = as.integer(instr$bag),
         next_pc      = end_pc + 1L,
-        regs         = as.list.environment(state$regs2),
+        regs         = state$regs2,
         cp           = state$cp,
         trail_len    = length(state$trail),
         var_counter  = state$var_counter,
@@ -2032,7 +2048,7 @@ WamRuntime$dynamic_iter <- function(program, state, clauses, start_idx, arity, r
     if (length(clause$head_args) != arity) next
     # Snapshot for rollback / CP. Taken BEFORE any unification so the
     # snapshot is the pre-dispatch state.
-    snap_regs        <- as.list.environment(state$regs2)
+    snap_regs        <- state$regs2
     snap_trail       <- length(state$trail)
     snap_cp          <- state$cp
     snap_vc          <- state$var_counter
@@ -2071,9 +2087,7 @@ WamRuntime$dynamic_iter <- function(program, state, clauses, start_idx, arity, r
       return(TRUE)
     }
     # Rollback to snapshot before trying the next clause.
-    e <- new.env(parent = emptyenv(), hash = TRUE)
-    for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
-    state$regs2 <- e
+    state$regs2 <- snap_regs
     if (length(state$trail) > snap_trail) {
       to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
       for (name in to_undo) {
@@ -2144,7 +2158,7 @@ WamRuntime$retract_iter <- function(program, state, head_args, body, arity,
         captured_program   <- program
         cp <- list(
           kind        = "iter",
-          regs        = as.list.environment(state$regs2),
+          regs        = state$regs2,
           trail_len   = snap_trail,
           cp          = state$cp,
           var_counter = snap_vc,
@@ -2210,7 +2224,7 @@ WamRuntime$clause_iter <- function(program, state, head_args, body, arity,
         captured_program   <- program
         cp <- list(
           kind        = "iter",
-          regs        = as.list.environment(state$regs2),
+          regs        = state$regs2,
           trail_len   = snap_trail,
           cp          = state$cp,
           var_counter = snap_vc,
@@ -2265,7 +2279,7 @@ WamRuntime$transitive_closure2 <- function(program, state, key, edge_pred,
   # Snapshot state so the iterate_goal calls below don't leak
   # bindings or CPs into the caller.
   snap_cps   <- length(state$cps)
-  snap_regs  <- as.list.environment(state$regs2)
+  snap_regs  <- state$regs2
   snap_trail <- length(state$trail)
   snap_pc    <- state$pc
   snap_cp    <- state$cp
@@ -2304,9 +2318,7 @@ WamRuntime$transitive_closure2 <- function(program, state, key, edge_pred,
   if (length(state$cps) > snap_cps) {
     state$cps <- state$cps[seq_len(snap_cps)]
   }
-  e <- new.env(parent = emptyenv(), hash = TRUE)
-  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
-  state$regs2 <- e
+  state$regs2 <- snap_regs
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
@@ -2348,7 +2360,7 @@ WamRuntime$transitive_distance3 <- function(program, state, key, edge_pred,
     return(FALSE)
   }
   snap_cps   <- length(state$cps)
-  snap_regs  <- as.list.environment(state$regs2)
+  snap_regs  <- state$regs2
   snap_trail <- length(state$trail)
   snap_pc    <- state$pc
   snap_cp    <- state$cp
@@ -2395,9 +2407,7 @@ WamRuntime$transitive_distance3 <- function(program, state, key, edge_pred,
   if (length(state$cps) > snap_cps) {
     state$cps <- state$cps[seq_len(snap_cps)]
   }
-  e <- new.env(parent = emptyenv(), hash = TRUE)
-  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
-  state$regs2 <- e
+  state$regs2 <- snap_regs
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
@@ -2442,7 +2452,7 @@ WamRuntime$weighted_shortest_path3 <- function(program, state, key, edge_pred,
     return(FALSE)
   }
   snap_cps   <- length(state$cps)
-  snap_regs  <- as.list.environment(state$regs2)
+  snap_regs  <- state$regs2
   snap_trail <- length(state$trail)
   snap_pc    <- state$pc
   snap_cp    <- state$cp
@@ -2519,9 +2529,7 @@ WamRuntime$weighted_shortest_path3 <- function(program, state, key, edge_pred,
   if (length(state$cps) > snap_cps) {
     state$cps <- state$cps[seq_len(snap_cps)]
   }
-  e <- new.env(parent = emptyenv(), hash = TRUE)
-  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
-  state$regs2 <- e
+  state$regs2 <- snap_regs
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
@@ -2565,7 +2573,7 @@ WamRuntime$transitive_parent_distance4 <- function(program, state, key,
     return(FALSE)
   }
   snap_cps   <- length(state$cps)
-  snap_regs  <- as.list.environment(state$regs2)
+  snap_regs  <- state$regs2
   snap_trail <- length(state$trail)
   snap_pc    <- state$pc
   snap_cp    <- state$cp
@@ -2617,9 +2625,7 @@ WamRuntime$transitive_parent_distance4 <- function(program, state, key,
   if (length(state$cps) > snap_cps) {
     state$cps <- state$cps[seq_len(snap_cps)]
   }
-  e <- new.env(parent = emptyenv(), hash = TRUE)
-  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
-  state$regs2 <- e
+  state$regs2 <- snap_regs
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
@@ -2665,7 +2671,7 @@ WamRuntime$transitive_step_parent_distance5 <- function(program, state, key,
     return(FALSE)
   }
   snap_cps   <- length(state$cps)
-  snap_regs  <- as.list.environment(state$regs2)
+  snap_regs  <- state$regs2
   snap_trail <- length(state$trail)
   snap_pc    <- state$pc
   snap_cp    <- state$cp
@@ -2726,9 +2732,7 @@ WamRuntime$transitive_step_parent_distance5 <- function(program, state, key,
   if (length(state$cps) > snap_cps) {
     state$cps <- state$cps[seq_len(snap_cps)]
   }
-  e <- new.env(parent = emptyenv(), hash = TRUE)
-  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
-  state$regs2 <- e
+  state$regs2 <- snap_regs
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
@@ -2776,7 +2780,7 @@ WamRuntime$category_ancestor <- function(program, state, key, edge_pred,
     return(FALSE)
   }
   snap_cps   <- length(state$cps)
-  snap_regs  <- as.list.environment(state$regs2)
+  snap_regs  <- state$regs2
   snap_trail <- length(state$trail)
   snap_pc    <- state$pc
   snap_cp    <- state$cp
@@ -2820,9 +2824,7 @@ WamRuntime$category_ancestor <- function(program, state, key, edge_pred,
   if (length(state$cps) > snap_cps) {
     state$cps <- state$cps[seq_len(snap_cps)]
   }
-  e <- new.env(parent = emptyenv(), hash = TRUE)
-  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
-  state$regs2 <- e
+  state$regs2 <- snap_regs
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
@@ -2875,7 +2877,7 @@ WamRuntime$astar_shortest_path4 <- function(program, state, key, edge_pred,
     return(FALSE)
   }
   snap_cps   <- length(state$cps)
-  snap_regs  <- as.list.environment(state$regs2)
+  snap_regs  <- state$regs2
   snap_trail <- length(state$trail)
   snap_pc    <- state$pc
   snap_cp    <- state$cp
@@ -2963,9 +2965,7 @@ WamRuntime$astar_shortest_path4 <- function(program, state, key, edge_pred,
   if (length(state$cps) > snap_cps) {
     state$cps <- state$cps[seq_len(snap_cps)]
   }
-  e <- new.env(parent = emptyenv(), hash = TRUE)
-  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
-  state$regs2 <- e
+  state$regs2 <- snap_regs
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
@@ -3019,7 +3019,7 @@ WamRuntime$kernel_pair_iter <- function(program, state, key, results, target,
         captured_key     <- key
         cp <- list(
           kind        = "iter",
-          regs        = as.list.environment(state$regs2),
+          regs        = state$regs2,
           trail_len   = snap_trail,
           cp          = state$cp,
           var_counter = snap_vc,
@@ -3071,7 +3071,7 @@ WamRuntime$kernel_triple_iter <- function(program, state, key, results, target,
         captured_key     <- key
         cp <- list(
           kind        = "iter",
-          regs        = as.list.environment(state$regs2),
+          regs        = state$regs2,
           trail_len   = snap_trail,
           cp          = state$cp,
           var_counter = snap_vc,
@@ -3126,7 +3126,7 @@ WamRuntime$kernel_quad_iter <- function(program, state, key, results, target,
         captured_key     <- key
         cp <- list(
           kind        = "iter",
-          regs        = as.list.environment(state$regs2),
+          regs        = state$regs2,
           trail_len   = snap_trail,
           cp          = state$cp,
           var_counter = snap_vc,
@@ -3170,7 +3170,7 @@ WamRuntime$kernel_stream_iter <- function(program, state, key, results, target,
         captured_key     <- key
         cp <- list(
           kind        = "iter",
-          regs        = as.list.environment(state$regs2),
+          regs        = state$regs2,
           trail_len   = snap_trail,
           cp          = state$cp,
           var_counter = snap_vc,
@@ -3244,7 +3244,7 @@ WamRuntime$fact_table_iter_subset <- function(program, state, key, tuples,
         captured_key      <- key
         cp <- list(
           kind        = "iter",
-          regs        = as.list.environment(state$regs2),
+          regs        = state$regs2,
           trail_len   = snap_trail,
           cp          = state$cp,
           var_counter = snap_vc,
@@ -3457,7 +3457,7 @@ WamRuntime$build_fact_indexes <- function(facts, arity) {
 WamRuntime$member_iter <- function(state, target, elems, start_idx, resume_pc) {
   if (start_idx > length(elems)) return(FALSE)
   for (idx in seq.int(start_idx, length(elems))) {
-    snap_regs  <- as.list.environment(state$regs2)
+    snap_regs  <- state$regs2
     snap_trail <- length(state$trail)
     snap_cp    <- state$cp
     snap_vc    <- state$var_counter
@@ -3489,9 +3489,7 @@ WamRuntime$member_iter <- function(state, target, elems, start_idx, resume_pc) {
       return(TRUE)
     }
     # Rollback for the next iteration.
-    e <- new.env(parent = emptyenv(), hash = TRUE)
-    for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
-    state$regs2 <- e
+    state$regs2 <- snap_regs
     if (length(state$trail) > snap_trail) {
       to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
       for (name in to_undo) {
@@ -3514,7 +3512,7 @@ WamRuntime$member_iter <- function(state, target, elems, start_idx, resume_pc) {
 # generate mode. Same iter-CP machinery as member_iter.
 WamRuntime$between_iter <- function(state, target, current, hi, resume_pc) {
   if (current > hi) return(FALSE)
-  snap_regs  <- as.list.environment(state$regs2)
+  snap_regs  <- state$regs2
   snap_trail <- length(state$trail)
   snap_cp    <- state$cp
   snap_vc    <- state$var_counter
@@ -3974,7 +3972,7 @@ WamRuntime$iterate_goal <- function(program, state, goal_term, on_each) {
 # findall/3 alternatives). Restores state completely on return.
 WamRuntime$collect_solutions <- function(program, state, template_term, goal_term) {
   snap_cps_len   <- length(state$cps)
-  snap_regs      <- as.list.environment(state$regs2)
+  snap_regs      <- state$regs2
   snap_trail     <- length(state$trail)
   snap_pc        <- state$pc
   snap_cp        <- state$cp
@@ -3995,9 +3993,7 @@ WamRuntime$collect_solutions <- function(program, state, template_term, goal_ter
   if (length(state$cps) > snap_cps_len) {
     state$cps <- state$cps[seq_len(snap_cps_len)]
   }
-  e <- new.env(parent = emptyenv(), hash = TRUE)
-  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
-  state$regs2 <- e
+  state$regs2 <- snap_regs
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
@@ -4028,7 +4024,7 @@ WamRuntime$collect_bag_groups <- function(program, state, template_term, goal_te
   witness_names <- setdiff(goal_vars, unique(c(template_vars, existential_vars)))
 
   snap_cps_len   <- length(state$cps)
-  snap_regs      <- as.list.environment(state$regs2)
+  snap_regs      <- state$regs2
   snap_trail     <- length(state$trail)
   snap_pc        <- state$pc
   snap_cp        <- state$cp
@@ -4073,9 +4069,7 @@ WamRuntime$collect_bag_groups <- function(program, state, template_term, goal_te
   if (length(state$cps) > snap_cps_len) {
     state$cps <- state$cps[seq_len(snap_cps_len)]
   }
-  e <- new.env(parent = emptyenv(), hash = TRUE)
-  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
-  state$regs2 <- e
+  state$regs2 <- snap_regs
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
@@ -4122,7 +4116,7 @@ WamRuntime$bag_group_values <- function(state, group, table, sort_dedup = FALSE)
 WamRuntime$bag_group_iter <- function(state, groups, start_idx, bag_target, table, sort_dedup, resume_pc) {
   if (start_idx > length(groups)) return(FALSE)
   for (idx in seq.int(start_idx, length(groups))) {
-    snap_regs  <- as.list.environment(state$regs2)
+    snap_regs  <- state$regs2
     snap_trail <- length(state$trail)
     snap_cp    <- state$cp
     snap_vc    <- state$var_counter
@@ -4172,9 +4166,7 @@ WamRuntime$bag_group_iter <- function(state, groups, start_idx, bag_target, tabl
       return(TRUE)
     }
 
-    e <- new.env(parent = emptyenv(), hash = TRUE)
-    for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
-    state$regs2 <- e
+    state$regs2 <- snap_regs
     WamRuntime$undo_trail_to(state, snap_trail)
     state$cp          <- snap_cp
     state$var_counter <- snap_vc
@@ -4816,7 +4808,7 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     cond   <- WamRuntime$get_reg(state, 1L)
     action <- WamRuntime$get_reg(state, 2L)
     snap_cps_len <- length(state$cps)
-    snap_regs    <- as.list.environment(state$regs2)
+    snap_regs    <- state$regs2
     snap_trail   <- length(state$trail)
     snap_pc      <- state$pc
     snap_cp      <- state$cp
@@ -4834,9 +4826,7 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     if (length(state$cps) > snap_cps_len) {
       state$cps <- state$cps[seq_len(snap_cps_len)]
     }
-    e <- new.env(parent = emptyenv(), hash = TRUE)
-    for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
-    state$regs2 <- e
+    state$regs2 <- snap_regs
     if (length(state$trail) > snap_trail) {
       to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
       for (name in to_undo) {
@@ -5554,9 +5544,7 @@ WamRuntime$backtrack <- function(state) {
   # handles the backtrack.
   if (!is.null(cp$kind) && cp$kind == "dynamic") {
     state$cps <- state$cps[-n]
-    e <- new.env(parent = emptyenv(), hash = TRUE)
-    for (k in names(cp$regs)) assign(k, cp$regs[[k]], envir = e)
-    state$regs2 <- e
+    state$regs2 <- cp$regs
     if (length(state$trail) > cp$trail_len) {
       to_undo <- state$trail[(cp$trail_len + 1L):length(state$trail)]
       for (name in to_undo) {
@@ -5584,9 +5572,7 @@ WamRuntime$backtrack <- function(state) {
   # executes the post-call body with the new bindings.
   if (!is.null(cp$kind) && cp$kind == "iter") {
     state$cps <- state$cps[-n]
-    e <- new.env(parent = emptyenv(), hash = TRUE)
-    for (k in names(cp$regs)) assign(k, cp$regs[[k]], envir = e)
-    state$regs2 <- e
+    state$regs2 <- cp$regs
     if (length(state$trail) > cp$trail_len) {
       to_undo <- state$trail[(cp$trail_len + 1L):length(state$trail)]
       for (name in to_undo) {
@@ -5614,9 +5600,7 @@ WamRuntime$backtrack <- function(state) {
   # and resume at the instruction after end_aggregate.
   if (!is.null(cp$kind) && cp$kind == "aggregate") {
     state$cps <- state$cps[-n]
-    e <- new.env(parent = emptyenv(), hash = TRUE)
-    for (k in names(cp$regs)) assign(k, cp$regs[[k]], envir = e)
-    state$regs2 <- e
+    state$regs2 <- cp$regs
     if (length(state$trail) > cp$trail_len) {
       to_undo <- state$trail[(cp$trail_len + 1L):length(state$trail)]
       for (name in to_undo) {
@@ -5646,9 +5630,7 @@ WamRuntime$backtrack <- function(state) {
     return(TRUE)
   }
   # Standard backtrack: restore from CP and jump to its alt PC.
-  e <- new.env(parent = emptyenv(), hash = TRUE)
-  for (k in names(cp$regs)) assign(k, cp$regs[[k]], envir = e)
-  state$regs2 <- e
+  state$regs2 <- cp$regs
   if (length(state$trail) > cp$trail_len) {
     to_undo <- state$trail[(cp$trail_len + 1L):length(state$trail)]
     for (name in to_undo) {


### PR DESCRIPTION
## Summary

- Replaces `state$regs2` (env keyed by stringified register indices) with a plain integer-indexed R list. X / A reads become `state$regs2[[idx]]`; writes become `state$regs2[[idx]] <- val`.
- CP snapshots store the list by reference (`cp$regs <- state$regs2`); R copy-on-write makes subsequent puts clone, leaving snapshots intact. Restore is a bare `state$regs2 <- cp$regs` (replacing 17 sites that previously rebuilt an env via a name-loop).
- Y registers (`idx >= 201`) keep their per-frame `ys` env -- Allocate / Deallocate semantics depend on each frame owning its own Y storage; the Y path is rare on hot loops anyway.
- Closes handoff item #2.

## Profile result

`tests/benchmarks/wam_r_fact_source_bench.pl --profile 100 --inner 100000` (R 4.4):

| metric | before | after |
|---|---|---|
| elapsed | 7.7s | 5.7s (~26% faster) |
| `get_reg` self.s | 0.820 | 0.200 (4×) |
| `exists` / `as.character` / `assign` self.s | ~0.89 combined | not on X / A path |

Next post-refactor hotspots in priority order: `step` switch dispatch (24% self), `deref` (9.1%), `new_state` (8.8%).

## Test plan

- [x] Full WAM-R suite (`swipl -g '[tests/test_wam_r_generator], run_tests' -t halt`) -- 71/71 passing
- [x] `--profile` mode re-run with new code; numbers captured in `WAM_R_TARGET.md`
- [x] Handoff item #2 marked done; "Things to know" section updated to describe the new list-based regs2 + copy-on-write snapshot semantics

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_