### PR TITLE
feat(wam-r): generate lists for length/2 (-, -)

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -634,8 +634,9 @@ WamRuntime$run(shared_program, state)
   The runtime now groups non-existential free variables and enumerates
   additional witness groups on backtracking, but unusual attributed-var
   or cyclic-term cases still need broader compatibility coverage.
-- **`length/2` (-, -)** generative mode is not supported (would
-  need a CP-driving generator).
+- **`length/2` (-, -)** is an unbounded generator. It enumerates
+  `([], 0)`, then one-element lists, two-element lists, and so on via
+  an iter-CP; callers should add guards when collecting solutions.
 - **`between/3` (+, +, -)** in compiled-goal context produces an
   iter-CP and works as a generator. In runtime-aggregator context
   the R-level fast path enumerates directly. Mixed contexts that

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -3548,6 +3548,70 @@ WamRuntime$between_iter <- function(state, target, current, hi, resume_pc) {
   FALSE
 }
 
+WamRuntime$fresh_var_list <- function(state, n, table) {
+  args <- vector("list", n)
+  if (n > 0L) {
+    for (i in seq_len(n)) {
+      args[[i]] <- Unbound(paste0("V", state$var_counter))
+      state$var_counter <- state$var_counter + 1L
+    }
+  }
+  WamRuntime$wam_list_build(args, table)
+}
+
+# Unbounded length/2 generator for the (-, -) mode. Produces
+# length([], 0), then length([_], 1), length([_, _], 2), ... on
+# backtracking. Callers should add their own guard when they need a
+# finite search.
+WamRuntime$length_iter <- function(state, list_target, n_target, current, resume_pc, table) {
+  snap_regs  <- as.list.environment(state$regs2)
+  snap_trail <- length(state$trail)
+  snap_cp    <- state$cp
+  snap_vc    <- state$var_counter
+  snap_mode  <- state$mode
+  snap_build <- state$build_stack
+  snap_read  <- state$read_stack
+
+  list_term <- WamRuntime$fresh_var_list(state, current, table)
+  ok <- WamRuntime$unify(state, n_target, IntTerm(current))
+  if (isTRUE(ok)) ok <- WamRuntime$unify(state, list_target, list_term)
+  if (isTRUE(ok)) {
+    next_val <- current + 1L
+    captured_list <- list_target
+    captured_n <- n_target
+    captured_resume <- resume_pc
+    captured_table <- table
+    cp <- list(
+      kind        = "iter",
+      regs        = snap_regs,
+      trail_len   = snap_trail,
+      cp          = snap_cp,
+      var_counter = snap_vc,
+      mode        = snap_mode,
+      build_stack = snap_build,
+      read_stack  = snap_read,
+      resume_pc   = resume_pc,
+      retry       = function(state) {
+        WamRuntime$length_iter(state, captured_list, captured_n, next_val,
+                               captured_resume, captured_table)
+      }
+    )
+    state$cps <- c(state$cps, list(cp))
+    return(TRUE)
+  }
+
+  e <- new.env(parent = emptyenv(), hash = TRUE)
+  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
+  state$regs2 <- e
+  WamRuntime$undo_trail_to(state, snap_trail)
+  state$cp          <- snap_cp
+  state$var_counter <- snap_vc
+  state$mode        <- snap_mode
+  state$build_stack <- snap_build
+  state$read_stack  <- snap_read
+  FALSE
+}
+
 # Term-comparison-based merge sort. Used by msort/2 (keep dups) and
 # sort/2 (dedup after sorting). The compare_terms call orders unbound
 # vars first, then numbers, atoms, structs.
@@ -4313,12 +4377,10 @@ WamRuntime$call_builtin <- function(program, state, pred, arity) {
     return(WamRuntime$member_iter(state, target, elems, 1L, state$pc + 1L))
   }
 
-  # length/2: deterministic modes only.
+  # length/2.
   #   (+, -): traverse the list, count cells, unify N with the count.
   #   (-, +): build a list of N fresh unbound vars, unify with L.
-  # The (-, -) enumerable mode is intentionally not supported -- it
-  # requires choice-point machinery this scaffold doesn't provide for
-  # generated solutions.
+  #   (-, -): generate lists of increasing length on backtracking.
   if (pred == "length/2" && arity == 2L) {
     raw_list <- WamRuntime$get_reg(state, 1L)
     raw_n    <- WamRuntime$get_reg(state, 2L)
@@ -4332,12 +4394,11 @@ WamRuntime$call_builtin <- function(program, state, pred, arity) {
     if (!is.null(n_v) && !is.null(n_v$tag) && n_v$tag == "int") {
       n <- n_v$val
       if (n < 0L) return(FALSE)
-      args <- vector("list", n)
-      for (i in seq_len(n)) {
-        args[[i]] <- Unbound(paste0("V", state$var_counter))
-        state$var_counter <- state$var_counter + 1L
-      }
-      return(WamRuntime$unify(state, raw_list, WamRuntime$wam_list_build(args, table)))
+      return(WamRuntime$unify(state, raw_list, WamRuntime$fresh_var_list(state, n, table)))
+    }
+    if (!is.null(list_v) && !is.null(list_v$tag) && list_v$tag == "unbound" &&
+        !is.null(n_v) && !is.null(n_v$tag) && n_v$tag == "unbound") {
+      return(WamRuntime$length_iter(state, raw_list, raw_n, 0L, state$pc + 1L, table))
     }
     return(FALSE)
   }

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -848,11 +848,20 @@ test(list_atom_builtins_e2e_rscript) :-
     )).
 
 e2e_list_atom_builtins_via_rscript :-
-    % length/2 (both deterministic modes).
+    % length/2 deterministic and generative modes.
     assertz((user:lb_len_count :- length([a, b, c], 3))),
     assertz((user:lb_len_zero  :- length([], 0))),
     assertz((user:lb_len_wrong :- length([a, b, c], 4))),
     assertz((user:lb_len_build :- length(L, 3), is_list(L))),
+    assertz((user:lb_len_gen_zero :- length(L, N), L == [], N == 0)),
+    assertz((user:lb_len_gen_two :-
+        length(L, N),
+        N == 2,
+        L = [_, _])),
+    assertz((user:lb_len_gen_three :-
+        length(L, N),
+        N == 3,
+        L = [_, _, _])),
     % append/3 deterministic mode.
     assertz((user:lb_app_ok    :- append([1, 2], [3, 4], [1, 2, 3, 4]))),
     assertz((user:lb_app_empty :- append([], [a, b], [a, b]))),
@@ -873,7 +882,8 @@ e2e_list_atom_builtins_via_rscript :-
     unique_r_tmp_dir('tmp_r_listatom_e2e', TmpDir),
     write_wam_r_project(
         [ user:lb_len_count/0, user:lb_len_zero/0, user:lb_len_wrong/0,
-          user:lb_len_build/0,
+          user:lb_len_build/0, user:lb_len_gen_zero/0,
+          user:lb_len_gen_two/0, user:lb_len_gen_three/0,
           user:lb_app_ok/0, user:lb_app_empty/0, user:lb_app_no/0,
           user:lb_rev_ok/0, user:lb_rev_no/0,
           user:lb_last_ok/0, user:lb_last_no/0,
@@ -884,6 +894,7 @@ e2e_list_atom_builtins_via_rscript :-
         TmpDir),
     directory_file_path(TmpDir, 'R', RDir),
     Yes = [lb_len_count, lb_len_zero, lb_len_build,
+           lb_len_gen_zero, lb_len_gen_two, lb_len_gen_three,
            lb_app_ok, lb_app_empty,
            lb_rev_ok, lb_last_ok,
            lb_alen_ok, lb_acodes_ok, lb_achars_ok, lb_aconcat_ok],


### PR DESCRIPTION
## Summary

- Adds WAM-R support for generative `length/2` when both arguments are unbound.
- Introduces a `length_iter` choice-point path that enumerates `([], 0)`, then one-element lists, two-element lists, and so on on backtracking.
- Reuses a shared fresh-list helper for the existing `length(L, N)` mode where `N` is bound.
- Adds Rscript e2e coverage for generated lengths 0, 2, and 3.
- Updates WAM-R docs to document that `length/2 (-, -)` is an unbounded generator and should be guarded when collecting.

## Verification

- `swipl -g "run_tests([wam_r_generator:list_atom_builtins_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
- `swipl -g "run_tests([wam_r_generator:list_atom_builtins_e2e_rscript,wam_r_generator:enumerable_builtins_e2e_rscript,wam_r_generator:findall_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
- `git diff --check`
