### PR TITLE
Feature/lua wam univ builtin

### DIFF
--- a/PR_lua_wam_univ_builtin.md
+++ b/PR_lua_wam_univ_builtin.md
@@ -1,0 +1,17 @@
+# PR Title
+
+Add Lua WAM univ builtin
+
+# PR Description
+
+## Summary
+
+- add Lua WAM runtime support for `=../2` (`univ`) in decompose mode
+- add Lua WAM runtime support for `=../2` compose mode from proper WAM cons-list terms
+- add Lua generator end-to-end coverage for struct, atom, and list decomposition, struct/atom composition, and mismatch failure
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`

--- a/templates/targets/lua_wam/runtime.lua.mustache
+++ b/templates/targets/lua_wam/runtime.lua.mustache
@@ -430,6 +430,37 @@ local function builtin_arg(_program, state)
   return bind_or_compare(state, 3, arg)
 end
 
+local function builtin_univ(program, state)
+  local term = Runtime.deref(state, Runtime.get_reg(state, 1))
+  if type(term) == "table" and term.tag == "unbound" then
+    local items = list_items(program, state, Runtime.get_reg(state, 2))
+    if items == nil or #items == 0 then return false end
+    local built = nil
+    if #items == 1 then
+      built = items[1]
+    else
+      local name = Runtime.deref(state, items[1])
+      if type(name) ~= "table" or name.tag ~= "atom" then return false end
+      local args = {}
+      for i = 2, #items do args[#args + 1] = items[i] end
+      built = V.Struct(name.id, args)
+    end
+    return Runtime.unify(state, term, built)
+  end
+
+  local out = nil
+  if type(term) == "table" and term.tag == "struct" then
+    local items = { V.Atom(term.fid) }
+    for _, arg in ipairs(term.args or {}) do items[#items + 1] = arg end
+    out = Runtime.list_from_terms(items, program.intern_table)
+  elseif type(term) == "table" and (term.tag == "atom" or term.tag == "int" or term.tag == "float") then
+    out = Runtime.list_from_terms({ term }, program.intern_table)
+  else
+    return false
+  end
+  return bind_or_compare(state, 2, out)
+end
+
 local function numeric_value(v)
   if type(v) == "table" and (v.tag == "int" or v.tag == "float") then return v.val end
   return nil
@@ -789,6 +820,7 @@ function Runtime.builtin_call(program, state, instr)
   if p == "length" or p == "length/2" then return builtin_length(program, state) end
   if p == "functor" or p == "functor/3" then return builtin_functor(program, state) end
   if p == "arg" or p == "arg/3" then return builtin_arg(program, state) end
+  if p == "=.." or p == "=../2" then return builtin_univ(program, state) end
   if p == "is" or p == "is/2" then
     local n = number_value(Runtime.deref(state, Runtime.get_reg(state, 2)))
     if n == nil then return false end

--- a/tests/test_wam_lua_generator.pl
+++ b/tests/test_wam_lua_generator.pl
@@ -44,6 +44,12 @@
 :- dynamic user:wam_lua_arg_struct/0.
 :- dynamic user:wam_lua_arg_list/0.
 :- dynamic user:wam_lua_arg_no/0.
+:- dynamic user:wam_lua_univ_decompose_struct/0.
+:- dynamic user:wam_lua_univ_decompose_atom/0.
+:- dynamic user:wam_lua_univ_decompose_list/0.
+:- dynamic user:wam_lua_univ_compose_struct/0.
+:- dynamic user:wam_lua_univ_compose_atom/0.
+:- dynamic user:wam_lua_univ_no/0.
 
 user:wam_lua_fact(a).
 user:wam_lua_choice(a).
@@ -113,6 +119,20 @@ user:wam_lua_functor_construct :-
 user:wam_lua_arg_struct :- arg(2, f(a, b), b).
 user:wam_lua_arg_list :- arg(2, [a, b], [b]).
 user:wam_lua_arg_no :- arg(3, f(a, b), _).
+user:wam_lua_univ_decompose_struct :- f(a, b) =.. [f, a, b].
+user:wam_lua_univ_decompose_atom :- a =.. [a].
+user:wam_lua_univ_decompose_list :-
+    [a, b] =.. L,
+    arg(1, L, '[|]'),
+    arg(2, L, Tail),
+    arg(1, Tail, a).
+user:wam_lua_univ_compose_struct :-
+    T =.. [f, a, b],
+    T = f(a, b).
+user:wam_lua_univ_compose_atom :-
+    T =.. [a],
+    T = a.
+user:wam_lua_univ_no :- f(a) =.. [g, a].
 
 test(exports) :-
     assertion(current_predicate(wam_lua_target:write_wam_lua_project/3)),
@@ -444,6 +464,30 @@ test(lua_term_inspection_builtins_e2e, [condition(lua_available)]) :-
           run_lua_query(LuaDir, 'wam_lua_arg_struct/0', [], true),
           run_lua_query(LuaDir, 'wam_lua_arg_list/0', [], true),
           run_lua_query(LuaDir, 'wam_lua_arg_no/0', [], false)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(lua_univ_builtin_e2e, [condition(lua_available)]) :-
+    unique_lua_tmp_dir('tmp_lua_univ_builtin_e2e', TmpDir),
+    setup_call_cleanup(
+        write_wam_lua_project(
+            [ user:wam_lua_univ_decompose_struct/0,
+              user:wam_lua_univ_decompose_atom/0,
+              user:wam_lua_univ_decompose_list/0,
+              user:wam_lua_univ_compose_struct/0,
+              user:wam_lua_univ_compose_atom/0,
+              user:wam_lua_univ_no/0
+            ],
+            [],
+            TmpDir),
+        ( directory_file_path(TmpDir, 'lua', LuaDir),
+          run_lua_query(LuaDir, 'wam_lua_univ_decompose_struct/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_univ_decompose_atom/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_univ_decompose_list/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_univ_compose_struct/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_univ_compose_atom/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_univ_no/0', [], false)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
# Add Lua WAM univ builtin

## Summary

- add Lua WAM runtime support for `=../2` (`univ`) in decompose mode
- add Lua WAM runtime support for `=../2` compose mode from proper WAM cons-list terms
- add Lua generator end-to-end coverage for struct, atom, and list decomposition, struct/atom composition, and mismatch failure

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`
