### PR TITLE
perf(wam-r): single-lookup bindings + state pool (~9% incremental)

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -811,42 +811,53 @@ swipl -g main -t halt tests/benchmarks/wam_r_fact_source_bench.pl \
 
 Representative hotspots for the WAM backend, single-row `cp(c0, X)`
 query against a 100-row chain, 100000 iterations (R 4.4), with X / A
-registers stored as an integer-indexed R list:
+registers stored as an integer-indexed R list, the `state$bindings`
+env accessed via `e[[name]]` (single lookup) and trail rollback via
+`e[[name]] <- NULL` (env-delete), and a single-slot state pool that
+recycles state envs across `run_predicate` calls:
 
 ```
   function                                       self.s  %self  total.s   %tot
-  WamRuntime$step                                 1.370  24.0%    2.230  39.1%
-  WamRuntime$run                                  0.900  15.8%    3.150  55.3%
-  WamRuntime$deref                                0.520   9.1%    0.760  13.3%
-  WamRuntime$new_state                            0.500   8.8%    0.650  11.4%
-  WamRuntime$run_predicate                        0.440   7.7%    5.550  97.4%
-  WamRuntime$put_reg                              0.290   5.1%    0.300   5.3%
-  WamRuntime$get_reg                              0.200   3.5%    0.210   3.7%
-  list                                            0.170   3.0%    0.170   3.0%
-  new.env                                         0.080   1.4%    0.090   1.6%
+  WamRuntime$step                                 1.500  29.0%    2.180  42.2%
+  WamRuntime$run                                  0.760  14.7%    2.940  56.9%
+  WamRuntime$run_predicate                        0.690  13.3%    5.090  98.5%
+  WamRuntime$deref                                0.380   7.3%    0.610  11.8%
+  WamRuntime$put_reg                              0.260   5.0%    0.260   5.0%
+  WamRuntime$reset_state                          0.240   4.6%    0.360   7.0%
+  WamRuntime$get_reg                              0.160   3.1%    0.180   3.5%
 ```
 
-`step` dispatch and `deref` lead, with a long tail in `new_state`
-(per-call cost of fresh state allocation). The register layer is
-near the floor: `state$regs2` is now a plain R list and X / A
-access is `state$regs2[[idx]]` / `state$regs2[[idx]] <- v`, so each
-read/write is a direct integer subscript -- no `as.character`,
-`exists`, `assign`, `get`, or environment hash lookup. R's
-copy-on-write keeps CP snapshots correct with a bare list
-assignment (`cp$regs <- state$regs2`); subsequent puts clone,
-leaving the snapshot intact.
+`step` dispatch and `run` lead. `deref` was overhauled to a single
+env subscript -- `state$bindings[[v$name]]` returns the bound value or
+NULL in one operation, replacing the prior `exists()` + `get()` pair.
+The trail rollback sites (`undo_trail_to` and ~16 backtrack/CP-restore
+sites) likewise use `state$bindings[[name]] <- NULL` to delete
+bindings, replacing the prior `if (exists) rm()` pattern.
 
-A prior profile of the same workload before this refactor showed
-`get_reg` self.s = 0.820 and a combined ~0.89 self.s spent in
-`exists` + `as.character` + `assign`, with elapsed = 7.7s. After
-the refactor, elapsed dropped to ~5.7s (≈26% wall-clock
-improvement); `get_reg` self time fell ≈4× and `exists` /
-`as.character` / `assign` no longer appear in the X / A path.
-(`as.character` is still used on the Y-register path; Y reads
-remain in per-frame envs because Allocate / Deallocate snapshot
-semantics rely on each call frame owning its own Y storage.) The
-next directly actionable target is `new_state` (per-call env
-allocation amortised across `run_predicate` invocations).
+`new_state` no longer appears in the top hotspots: a single-slot pool
+(`WamRuntime$state_pool_idle`) parks the state env on
+`run_predicate` exit and the next call recycles it via `reset_state`.
+That swaps a fresh `new.env()` for the state record (the bindings env
+is still freshly allocated each call -- cheaper than rm-ing entries
+when bindings is non-empty, and correctness-trivial). Recursive
+`run_predicate` calls -- if they ever happen -- see a NULL pool,
+allocate fresh, and only re-park if the slot is still NULL on exit.
+
+A prior profile of the same workload before these refactors showed
+elapsed = 7.7s (env-keyed regs2). After the regs2 -> integer-indexed
+list refactor: 5.7s (~26%). After the bindings + state-pool refactor:
+~5.2s (~33% total, ~9% incremental). `deref` self.s 0.520 -> 0.380
+(~27%); the `exists` / `rm` calls dropped off the by-self table for
+the X / A path entirely; `new_state` dropped from 8.8% to 0%
+(replaced by `reset_state` at 4.6%).
+
+Remaining levers, in priority order:
+- `step` (29% self): the big `switch(op_name, ...)`. A per-instruction
+  closure-based dispatch could shave this.
+- `run_predicate` (10-13% self): on.exit + tryCatch + the pool dance
+  itself adds overhead. Trimming this would also help, though it's
+  inherent to the recycling pattern.
+- `run` (14.7% self): the main interpreter loop body.
 
 When adding a builtin:
 

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -353,6 +353,35 @@ WamRuntime$promote_regs <- function(state) {
   }
 }
 
+# Single-slot state pool. `run_predicate` parks its used state here on
+# exit and the next call retrieves it (if non-NULL) instead of running
+# `new_state` from scratch -- skipping the outer-env allocation. The
+# bindings env is replaced with a fresh one on reset (cheaper than
+# rm-ing entries when bindings is non-empty, and correctness-trivial).
+# Recursive `run_predicate` calls -- if they ever happen -- see a NULL
+# pool, allocate fresh, and only re-park if the slot is still NULL on
+# exit; this loses one state to GC per recursion but stays correct.
+WamRuntime$state_pool_idle <- NULL
+
+WamRuntime$reset_state <- function(s) {
+  s$pc          <- 1L
+  s$cp          <- 0L
+  s$regs        <- list()
+  s$regs2       <- list()
+  s$stack       <- list()
+  s$cps         <- list()
+  s$bindings    <- new.env(parent = emptyenv(), hash = TRUE)
+  s$trail       <- list()
+  s$var_counter <- 0L
+  s$halt        <- FALSE
+  s$mode        <- NULL
+  s$build_stack <- list()
+  s$read_stack  <- list()
+  s$pending_call_barrier <- 0L
+  s$shadow_frame <- NULL
+  invisible(NULL)
+}
+
 # ----------------------------------------------------------
 # Structure build helpers (write mode)
 # ----------------------------------------------------------
@@ -497,15 +526,15 @@ WamRuntime$count_following_unify <- function(program, pc) {
 # ----------------------------------------------------------
 WamRuntime$deref <- function(state, v) {
   while (is.list(v) && !is.null(v$tag) && v$tag == "unbound") {
-    name <- v$name
-    if (!exists(name, envir = state$bindings, inherits = FALSE)) break
-    v <- get(name, envir = state$bindings, inherits = FALSE)
+    bound <- state$bindings[[v$name]]
+    if (is.null(bound)) break
+    v <- bound
   }
   v
 }
 
 WamRuntime$bind <- function(state, name, val) {
-  assign(name, val, envir = state$bindings)
+  state$bindings[[name]] <- val
   state$trail <- c(state$trail, list(name))
   invisible(NULL)
 }
@@ -517,9 +546,7 @@ WamRuntime$undo_trail_to <- function(state, n) {
   while (length(state$trail) > n) {
     last <- length(state$trail)
     name <- state$trail[[last]]
-    if (exists(name, envir = state$bindings, inherits = FALSE)) {
-      rm(list = name, envir = state$bindings)
-    }
+    state$bindings[[name]] <- NULL
     state$trail <- state$trail[-last]
   }
   invisible(NULL)
@@ -2091,9 +2118,7 @@ WamRuntime$dynamic_iter <- function(program, state, clauses, start_idx, arity, r
     if (length(state$trail) > snap_trail) {
       to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
       for (name in to_undo) {
-        if (exists(name, envir = state$bindings, inherits = FALSE)) {
-          rm(list = name, envir = state$bindings)
-        }
+        state$bindings[[name]] <- NULL
       }
       state$trail <- state$trail[seq_len(snap_trail)]
     }
@@ -2322,9 +2347,7 @@ WamRuntime$transitive_closure2 <- function(program, state, key, edge_pred,
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
-      if (exists(name, envir = state$bindings, inherits = FALSE)) {
-        rm(list = name, envir = state$bindings)
-      }
+      state$bindings[[name]] <- NULL
     }
     state$trail <- state$trail[seq_len(snap_trail)]
   }
@@ -2411,9 +2434,7 @@ WamRuntime$transitive_distance3 <- function(program, state, key, edge_pred,
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
-      if (exists(name, envir = state$bindings, inherits = FALSE)) {
-        rm(list = name, envir = state$bindings)
-      }
+      state$bindings[[name]] <- NULL
     }
     state$trail <- state$trail[seq_len(snap_trail)]
   }
@@ -2533,9 +2554,7 @@ WamRuntime$weighted_shortest_path3 <- function(program, state, key, edge_pred,
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
-      if (exists(name, envir = state$bindings, inherits = FALSE)) {
-        rm(list = name, envir = state$bindings)
-      }
+      state$bindings[[name]] <- NULL
     }
     state$trail <- state$trail[seq_len(snap_trail)]
   }
@@ -2629,9 +2648,7 @@ WamRuntime$transitive_parent_distance4 <- function(program, state, key,
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
-      if (exists(name, envir = state$bindings, inherits = FALSE)) {
-        rm(list = name, envir = state$bindings)
-      }
+      state$bindings[[name]] <- NULL
     }
     state$trail <- state$trail[seq_len(snap_trail)]
   }
@@ -2736,9 +2753,7 @@ WamRuntime$transitive_step_parent_distance5 <- function(program, state, key,
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
-      if (exists(name, envir = state$bindings, inherits = FALSE)) {
-        rm(list = name, envir = state$bindings)
-      }
+      state$bindings[[name]] <- NULL
     }
     state$trail <- state$trail[seq_len(snap_trail)]
   }
@@ -2828,9 +2843,7 @@ WamRuntime$category_ancestor <- function(program, state, key, edge_pred,
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
-      if (exists(name, envir = state$bindings, inherits = FALSE)) {
-        rm(list = name, envir = state$bindings)
-      }
+      state$bindings[[name]] <- NULL
     }
     state$trail <- state$trail[seq_len(snap_trail)]
   }
@@ -2969,9 +2982,7 @@ WamRuntime$astar_shortest_path4 <- function(program, state, key, edge_pred,
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
-      if (exists(name, envir = state$bindings, inherits = FALSE)) {
-        rm(list = name, envir = state$bindings)
-      }
+      state$bindings[[name]] <- NULL
     }
     state$trail <- state$trail[seq_len(snap_trail)]
   }
@@ -3493,9 +3504,7 @@ WamRuntime$member_iter <- function(state, target, elems, start_idx, resume_pc) {
     if (length(state$trail) > snap_trail) {
       to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
       for (name in to_undo) {
-        if (exists(name, envir = state$bindings, inherits = FALSE)) {
-          rm(list = name, envir = state$bindings)
-        }
+        state$bindings[[name]] <- NULL
       }
       state$trail <- state$trail[seq_len(snap_trail)]
     }
@@ -3997,9 +4006,7 @@ WamRuntime$collect_solutions <- function(program, state, template_term, goal_ter
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
-      if (exists(name, envir = state$bindings, inherits = FALSE)) {
-        rm(list = name, envir = state$bindings)
-      }
+      state$bindings[[name]] <- NULL
     }
     state$trail <- state$trail[seq_len(snap_trail)]
   }
@@ -4073,9 +4080,7 @@ WamRuntime$collect_bag_groups <- function(program, state, template_term, goal_te
   if (length(state$trail) > snap_trail) {
     to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
     for (name in to_undo) {
-      if (exists(name, envir = state$bindings, inherits = FALSE)) {
-        rm(list = name, envir = state$bindings)
-      }
+      state$bindings[[name]] <- NULL
     }
     state$trail <- state$trail[seq_len(snap_trail)]
   }
@@ -4830,9 +4835,7 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     if (length(state$trail) > snap_trail) {
       to_undo <- state$trail[(snap_trail + 1L):length(state$trail)]
       for (name in to_undo) {
-        if (exists(name, envir = state$bindings, inherits = FALSE)) {
-          rm(list = name, envir = state$bindings)
-        }
+        state$bindings[[name]] <- NULL
       }
       state$trail <- state$trail[seq_len(snap_trail)]
     }
@@ -5548,9 +5551,7 @@ WamRuntime$backtrack <- function(state) {
     if (length(state$trail) > cp$trail_len) {
       to_undo <- state$trail[(cp$trail_len + 1L):length(state$trail)]
       for (name in to_undo) {
-        if (exists(name, envir = state$bindings, inherits = FALSE)) {
-          rm(list = name, envir = state$bindings)
-        }
+        state$bindings[[name]] <- NULL
       }
       state$trail <- state$trail[seq_len(cp$trail_len)]
     }
@@ -5576,9 +5577,7 @@ WamRuntime$backtrack <- function(state) {
     if (length(state$trail) > cp$trail_len) {
       to_undo <- state$trail[(cp$trail_len + 1L):length(state$trail)]
       for (name in to_undo) {
-        if (exists(name, envir = state$bindings, inherits = FALSE)) {
-          rm(list = name, envir = state$bindings)
-        }
+        state$bindings[[name]] <- NULL
       }
       state$trail <- state$trail[seq_len(cp$trail_len)]
     }
@@ -5604,9 +5603,7 @@ WamRuntime$backtrack <- function(state) {
     if (length(state$trail) > cp$trail_len) {
       to_undo <- state$trail[(cp$trail_len + 1L):length(state$trail)]
       for (name in to_undo) {
-        if (exists(name, envir = state$bindings, inherits = FALSE)) {
-          rm(list = name, envir = state$bindings)
-        }
+        state$bindings[[name]] <- NULL
       }
       state$trail <- state$trail[seq_len(cp$trail_len)]
     }
@@ -5634,9 +5631,7 @@ WamRuntime$backtrack <- function(state) {
   if (length(state$trail) > cp$trail_len) {
     to_undo <- state$trail[(cp$trail_len + 1L):length(state$trail)]
     for (name in to_undo) {
-      if (exists(name, envir = state$bindings, inherits = FALSE)) {
-        rm(list = name, envir = state$bindings)
-      }
+      state$bindings[[name]] <- NULL
     }
     state$trail <- state$trail[seq_len(cp$trail_len)]
   }
@@ -5686,9 +5681,20 @@ WamRuntime$run <- function(program, state, max_steps = 1e7) {
 }
 
 WamRuntime$run_predicate <- function(program, start_pc, args) {
-  state <- WamRuntime$new_state()
-  state$regs <- list()
-  WamRuntime$promote_regs(state)
+  state <- WamRuntime$state_pool_idle
+  if (is.null(state)) {
+    state <- WamRuntime$new_state()
+  } else {
+    WamRuntime$state_pool_idle <- NULL
+    WamRuntime$reset_state(state)
+  }
+  on.exit({
+    # Park back in the pool if the slot is still free; recursive calls
+    # that allocated their own state silently drop on exit.
+    if (is.null(WamRuntime$state_pool_idle)) {
+      WamRuntime$state_pool_idle <- state
+    }
+  })
   for (i in seq_along(args)) {
     WamRuntime$put_reg(state, i, args[[i]])
   }


### PR DESCRIPTION
## Summary

Two complementary refactors targeting the post-regs2-refactor hotspots (`deref` @ 9.1%, `new_state` @ 8.8%).

**deref / bindings access.** Replaces the prior `exists(name, envir = state$bindings)` + `get(name, ...)` pair with a single `state$bindings[[name]]` lookup. R's `[[` on an env returns NULL for a missing key in one operation. Trail rollback (`undo_trail_to` + ~16 backtrack / CP-restore sites) likewise becomes `state$bindings[[name]] <- NULL` instead of `if (exists) rm()`. `bind` uses `[[<-` directly.

**state pool.** New single-slot `WamRuntime$state_pool_idle` parks state envs on `run_predicate` exit (via `on.exit`). Subsequent calls recycle via `WamRuntime$reset_state`, replacing the outer `new.env()` with field re-init. The bindings env is still freshly allocated each reset (cheaper than rm-ing entries when bindings is non-empty, and correctness-trivial). Recursive `run_predicate` calls -- if they ever happen -- see a NULL pool, allocate fresh, and only re-park if the slot is still NULL on exit; this loses one state to GC per recursion but stays correct.

## Profile result

`tests/benchmarks/wam_r_fact_source_bench.pl --profile 100 --inner 100000` (R 4.4):

| metric | before this PR | after this PR |
|---|---|---|
| elapsed | 5.7s | ~5.2s (~9% incremental) |
| `deref` self.s | 0.520 (9.1%) | 0.380 (7.3%) |
| `new_state` self.s | 0.500 (8.8%) | not in top hotspots |
| `reset_state` self.s | n/a | 0.240 (4.6%) |
| `exists` / `rm` on X/A path | present | absent |

Cumulative since the env-keyed regs2 baseline (7.7s): ~33% wall-clock improvement.

Remaining levers in priority order: `step` switch dispatch (29%), `run_predicate` overhead (10-13%, partly inherent to pooling), `run` loop body (15%).

## Test plan

- [x] Full WAM-R suite (`swipl -g '[tests/test_wam_r_generator], run_tests' -t halt`) -- 71/71 passing
- [x] `--profile` mode re-run with new code; numbers captured in `WAM_R_TARGET.md`
- [x] Sanity check: two consecutive profile runs both produce stable ~5.2s elapsed

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_