### PR TITLE
fix(wam-r): snapshot length generator registers as lists

### DIFF
--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -3562,7 +3562,7 @@ WamRuntime$fresh_var_list <- function(state, n, table) {
 # backtracking. Callers should add their own guard when they need a
 # finite search.
 WamRuntime$length_iter <- function(state, list_target, n_target, current, resume_pc, table) {
-  snap_regs  <- as.list.environment(state$regs2)
+  snap_regs  <- state$regs2
   snap_trail <- length(state$trail)
   snap_cp    <- state$cp
   snap_vc    <- state$var_counter
@@ -3598,9 +3598,7 @@ WamRuntime$length_iter <- function(state, list_target, n_target, current, resume
     return(TRUE)
   }
 
-  e <- new.env(parent = emptyenv(), hash = TRUE)
-  for (k in names(snap_regs)) assign(k, snap_regs[[k]], envir = e)
-  state$regs2 <- e
+  state$regs2 <- snap_regs
   WamRuntime$undo_trail_to(state, snap_trail)
   state$cp          <- snap_cp
   state$var_counter <- snap_vc


### PR DESCRIPTION
## Summary

- Fixes the merged `length/2 (-, -)` generator on current `main`.
- Updates `WamRuntime$length_iter` to snapshot and restore `state$regs2` as the current list-backed register store instead of using the old environment snapshot path.

## Details

After the `length/2` generator branch merged, `list_atom_builtins_e2e_rscript` failed on current `main` because `length_iter` still called `as.list.environment(state$regs2)`. The newer WAM-R runtime uses list-backed `regs2`, so generated `length(L, N)` queries crashed before printing `true` or `false`.

This patch aligns `length_iter` with the existing iterator helpers by storing `snap_regs <- state$regs2` and restoring that list snapshot directly.

## Verification

- Isolated generated checks for:
  - `length(L, N), L == [], N == 0`
  - `length(L, N), N == 2, L = [_, _]`
  - `length(L, N), N == 3, L = [_, _, _]`
- `swipl -g "run_tests([wam_r_generator:list_atom_builtins_e2e_rscript,wam_r_generator:enumerable_builtins_e2e_rscript,wam_r_generator:findall_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
- `git diff --check`
