### PR TITLE
Feature/lua wam copy term builtin

### DIFF
--- a/PR_lua_wam_copy_term_builtin.md
+++ b/PR_lua_wam_copy_term_builtin.md
@@ -1,0 +1,18 @@
+# PR Title
+
+Add Lua WAM copy_term builtin
+
+# PR Description
+
+## Summary
+
+- add Lua WAM runtime support for `copy_term/2`
+- copy terms with fresh variables while preserving sharing for repeated source variables
+- add a self-unify guard for identical unbound variables to avoid self-binding dereference loops
+- add Lua generator end-to-end coverage for ground copies, freshness, shared variables, and independent variables
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`

--- a/templates/targets/lua_wam/runtime.lua.mustache
+++ b/templates/targets/lua_wam/runtime.lua.mustache
@@ -184,6 +184,11 @@ end
 function Runtime.unify(state, a, b)
   a = Runtime.deref(state, a)
   b = Runtime.deref(state, b)
+  if type(a) == "table" and type(b) == "table"
+      and a.tag == "unbound" and b.tag == "unbound"
+      and a.name == b.name then
+    return true
+  end
   if type(a) == "table" and a.tag == "unbound" then return bind_var(state, a, b) end
   if type(b) == "table" and b.tag == "unbound" then return bind_var(state, b, a) end
   if type(a) ~= "table" or type(b) ~= "table" then return a == b end
@@ -459,6 +464,40 @@ local function builtin_univ(program, state)
     return false
   end
   return bind_or_compare(state, 2, out)
+end
+
+local function copy_term_fresh(state, term, var_map, seen)
+  term = Runtime.deref(state, term)
+  if type(term) ~= "table" then return term end
+  var_map = var_map or {}
+  seen = seen or {}
+  if term.tag == "unbound" then
+    local mapped = var_map[term.name]
+    if mapped ~= nil then return mapped end
+    local fresh = Runtime.new_var(state)
+    var_map[term.name] = fresh
+    return fresh
+  end
+  if seen[term] then return seen[term] end
+  if term.tag == "struct" then
+    local out = V.Struct(term.fid, {})
+    seen[term] = out
+    for i, arg in ipairs(term.args or {}) do
+      out.args[i] = copy_term_fresh(state, arg, var_map, seen)
+    end
+    return out
+  end
+  if term.tag == "atom" then return V.Atom(term.id) end
+  if term.tag == "int" then return V.Int(term.val) end
+  if term.tag == "float" then return V.Float(term.val) end
+  return term
+end
+
+local function builtin_copy_term(_program, state)
+  local term = Runtime.get_reg(state, 1)
+  if term == nil then return false end
+  local copied = copy_term_fresh(state, term, {}, {})
+  return bind_or_compare(state, 2, copied)
 end
 
 local function numeric_value(v)
@@ -821,6 +860,7 @@ function Runtime.builtin_call(program, state, instr)
   if p == "functor" or p == "functor/3" then return builtin_functor(program, state) end
   if p == "arg" or p == "arg/3" then return builtin_arg(program, state) end
   if p == "=.." or p == "=../2" then return builtin_univ(program, state) end
+  if p == "copy_term" or p == "copy_term/2" then return builtin_copy_term(program, state) end
   if p == "is" or p == "is/2" then
     local n = number_value(Runtime.deref(state, Runtime.get_reg(state, 2)))
     if n == nil then return false end

--- a/tests/test_wam_lua_generator.pl
+++ b/tests/test_wam_lua_generator.pl
@@ -50,6 +50,10 @@
 :- dynamic user:wam_lua_univ_compose_struct/0.
 :- dynamic user:wam_lua_univ_compose_atom/0.
 :- dynamic user:wam_lua_univ_no/0.
+:- dynamic user:wam_lua_copy_term_ground/0.
+:- dynamic user:wam_lua_copy_term_fresh/0.
+:- dynamic user:wam_lua_copy_term_sharing/0.
+:- dynamic user:wam_lua_copy_term_independent_vars/0.
 
 user:wam_lua_fact(a).
 user:wam_lua_choice(a).
@@ -133,6 +137,24 @@ user:wam_lua_univ_compose_atom :-
     T =.. [a],
     T = a.
 user:wam_lua_univ_no :- f(a) =.. [g, a].
+user:wam_lua_copy_term_ground :-
+    copy_term(f(a, b), C),
+    C = f(a, b).
+user:wam_lua_copy_term_fresh :-
+    copy_term(f(X), C),
+    C = f(a),
+    var(X).
+user:wam_lua_copy_term_sharing :-
+    copy_term(f(X, X), C),
+    C = f(A, B),
+    A = b,
+    B = b,
+    var(X).
+user:wam_lua_copy_term_independent_vars :-
+    copy_term(f(_, _), C),
+    C = f(A, B),
+    A = a,
+    B = b.
 
 test(exports) :-
     assertion(current_predicate(wam_lua_target:write_wam_lua_project/3)),
@@ -488,6 +510,26 @@ test(lua_univ_builtin_e2e, [condition(lua_available)]) :-
           run_lua_query(LuaDir, 'wam_lua_univ_compose_struct/0', [], true),
           run_lua_query(LuaDir, 'wam_lua_univ_compose_atom/0', [], true),
           run_lua_query(LuaDir, 'wam_lua_univ_no/0', [], false)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(lua_copy_term_builtin_e2e, [condition(lua_available)]) :-
+    unique_lua_tmp_dir('tmp_lua_copy_term_builtin_e2e', TmpDir),
+    setup_call_cleanup(
+        write_wam_lua_project(
+            [ user:wam_lua_copy_term_ground/0,
+              user:wam_lua_copy_term_fresh/0,
+              user:wam_lua_copy_term_sharing/0,
+              user:wam_lua_copy_term_independent_vars/0
+            ],
+            [],
+            TmpDir),
+        ( directory_file_path(TmpDir, 'lua', LuaDir),
+          run_lua_query(LuaDir, 'wam_lua_copy_term_ground/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_copy_term_fresh/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_copy_term_sharing/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_copy_term_independent_vars/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
# Add Lua WAM copy_term builtin

## Summary

- add Lua WAM runtime support for `copy_term/2`
- copy terms with fresh variables while preserving sharing for repeated source variables
- add a self-unify guard for identical unbound variables to avoid self-binding dereference loops
- add Lua generator end-to-end coverage for ground copies, freshness, shared variables, and independent variables

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`
