### PR TITLE
feat(wam-clojure): lower append builtin concat mode

### DIFF
--- a/PR_WAM_CLOJURE_APPEND_BUILTIN_LOWERING.md
+++ b/PR_WAM_CLOJURE_APPEND_BUILTIN_LOWERING.md
@@ -1,0 +1,31 @@
+# feat(wam-clojure): lower append builtin concat mode
+
+## Summary
+
+Adds direct lowered Clojure WAM support for deterministic `append/3` concat mode.
+
+## What Changed
+
+- Marks `append/3` as a direct Clojure lowered builtin.
+- Emits lowered `append/3` calls through Clojure runtime list helpers instead of the generic WAM step loop.
+- Adds `runtime/proper-list-items` to decompose proper list terms into item vectors.
+- Adds runtime dispatch for `append/3`.
+- Adds generator, lowered-emitter, and batched runtime smoke coverage.
+
+## Semantics
+
+This PR intentionally implements the conservative deterministic mode:
+
+- `append(+ListA, +ListB, ?Out)`
+- Proper-list inputs are concatenated and unified with `Out`.
+- Improper lists and unbound first/second list inputs fail.
+- Split/generative modes, such as `append(A, B, [a,b,c])`, remain out of scope for this PR.
+
+This matches the cautious mode already used by the R WAM runtime and leaves Scala-style split enumeration for a separate follow-up.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -356,6 +356,10 @@ clojure_direct_builtin("member/2", "2").
 clojure_direct_builtin("member/2", 2).
 clojure_direct_builtin('member/2', "2").
 clojure_direct_builtin('member/2', 2).
+clojure_direct_builtin("append/3", "3").
+clojure_direct_builtin("append/3", 3).
+clojure_direct_builtin('append/3', "3").
+clojure_direct_builtin('append/3', 3).
 clojure_direct_builtin("ground/1", "1").
 clojure_direct_builtin("ground/1", 1).
 clojure_direct_builtin('ground/1', "1").
@@ -552,6 +556,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr),
            '(let [elem (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) list-value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound))] (runtime/apply-member-solution ~w (inc (:pc ~w)) elem list-value))',
            [S, S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "append/3" ; Op == 'append/3'),
+    !,
+    format(atom(Expr),
+           '(let [left (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) right (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound)) out (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A3") ::lowered-unbound)) left-items (runtime/proper-list-items ~w left) right-items (runtime/proper-list-items ~w right)] (if (and (some? left-items) (some? right-items)) (let [joined (runtime/list->term (:intern-context ~w) (concat left-items right-items)) [ok next-state] (runtime/unify-values ~w out joined)] (if ok (runtime/advance next-state) (runtime/backtrack ~w))) (runtime/backtrack ~w)))',
+           [S, S, S, S, S, S, S, S, S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "ground/1" ; Op == 'ground/1'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -498,6 +498,25 @@
         (recur (deref-value bindings (second (:args cur))) (conj seen cur) (inc n))
         :else nil))))
 
+(defn proper-list-items [state value]
+  (let [bindings (:bindings state)
+        empty-list (normalize-literal-atom (:intern-context state) "[]")
+        list-functor (list-functor-term (:intern-context state))]
+    (loop [cur (deref-value bindings value)
+           seen #{}
+           items []]
+      (cond
+        (interned-equal? cur empty-list) items
+        (or (= cur ::unbound) (logic-var? cur)) nil
+        (contains? seen cur) nil
+        (and (structure-term? cur)
+             (interned-equal? (:functor cur) list-functor)
+             (= 2 (count (:args cur))))
+        (recur (deref-value bindings (second (:args cur)))
+               (conj seen cur)
+               (conj items (first (:args cur))))
+        :else nil))))
+
 (declare apply-member-solution)
 
 (defn push-member-choice-point [state base-state resume-pc elem rest-list]
@@ -1143,6 +1162,24 @@
                 list-value (deref-value (:bindings state)
                                         (or (reg-get-raw state "A2") ::unbound))]
             (apply-member-solution state (inc (:pc state)) elem list-value))
+
+          "append/3"
+          (let [left (deref-value (:bindings state)
+                                  (or (reg-get-raw state "A1") ::unbound))
+                right (deref-value (:bindings state)
+                                   (or (reg-get-raw state "A2") ::unbound))
+                out (deref-value (:bindings state)
+                                 (or (reg-get-raw state "A3") ::unbound))
+                left-items (proper-list-items state left)
+                right-items (proper-list-items state right)]
+            (if (and (some? left-items) (some? right-items))
+              (let [joined (list->term (:intern-context state)
+                                       (concat left-items right-items))
+                    [ok next-state] (unify-values state out joined)]
+                (if ok
+                  (advance next-state)
+                  (backtrack state)))
+              (backtrack state)))
 
           "ground/1"
           (let [value (deref-value (:bindings state)

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -130,6 +130,7 @@ test(project_emits_runtime_and_lowered_dispatch_scaffold) :-
         assertion(sub_string(RuntimeCode, _, _, _, '"is_list/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"length/2"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"member/2"')),
+        assertion(sub_string(RuntimeCode, _, _, _, '"append/3"')),
         assertion(sub_string(RuntimeCode, _, _, _, '"ground/1"')),
         assertion(sub_string(RuntimeCode, _, _, _, ':call-foreign')),
         assertion(sub_string(RuntimeCode, _, _, _, '(defn apply-foreign-result [state result]')),

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -463,6 +463,20 @@ test(simple_builtin_member_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_append_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_append/3:\nbuiltin_call append/3, 3\nproceed\n",
+        wam_clojure_lowerable(test_append/3, WamCode, deterministic),
+        lower_predicate_to_clojure(test_append/3, WamCode, [], Code),
+        has(Code, "runtime/proper-list-items"),
+        has(Code, "runtime/list->term"),
+        has(Code, "\"A1\""),
+        has(Code, "\"A2\""),
+        has(Code, "\"A3\""),
+        has(Code, "runtime/unify-values"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_ground_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_ground/1:\nbuiltin_call ground/1, 1\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -61,6 +61,9 @@
 :- dynamic user:wam_member_guard/2.
 :- dynamic user:wam_member_backtrack_b/0.
 :- dynamic user:wam_member_unbound_list/1.
+:- dynamic user:wam_append_guard/3.
+:- dynamic user:wam_append_bad_left/1.
+:- dynamic user:wam_append_unbound_left/1.
 :- dynamic user:wam_ground_guard/1.
 :- dynamic user:wam_ground_unbound/1.
 :- dynamic user:wam_ground_nested_unbound/1.
@@ -143,6 +146,9 @@ user:wam_length_unbound_list(N) :- user:wam_unbound_arg(Y), length(Y, N).
 user:wam_member_guard(X, L) :- member(X, L).
 user:wam_member_backtrack_b :- member(X, [a,b]), X = b.
 user:wam_member_unbound_list(X) :- user:wam_unbound_arg(Y), member(X, Y).
+user:wam_append_guard(A, B, C) :- append(A, B, C).
+user:wam_append_bad_left(C) :- append([a|b], [c], C).
+user:wam_append_unbound_left(C) :- user:wam_unbound_arg(A), append(A, [b], C).
 user:wam_ground_guard(X) :- ground(X).
 user:wam_ground_unbound(_) :- user:wam_unbound_arg(Y), ground(Y).
 user:wam_ground_nested_unbound(_) :- user:wam_unbound_arg(Y), ground(f(Y)).
@@ -230,6 +236,9 @@ run_smoke :-
           user:wam_member_guard/2,
           user:wam_member_backtrack_b/0,
           user:wam_member_unbound_list/1,
+          user:wam_append_guard/3,
+          user:wam_append_bad_left/1,
+          user:wam_append_unbound_left/1,
           user:wam_ground_guard/1,
           user:wam_ground_unbound/1,
           user:wam_ground_nested_unbound/1,
@@ -279,6 +288,7 @@ run_smoke :-
     assert_lowered_is_list_builtin_emitted(TmpDir),
     assert_lowered_length_builtin_emitted(TmpDir),
     assert_lowered_member_builtin_emitted(TmpDir),
+    assert_lowered_append_builtin_emitted(TmpDir),
     assert_lowered_ground_builtin_emitted(TmpDir),
     assert_lowered_arithmetic_comparison_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
@@ -390,6 +400,12 @@ smoke_cases([
     case('wam_member_guard/2', args(c, '[a,b]'), "false"),
     case('wam_member_backtrack_b/0', no_args, "true"),
     case('wam_member_unbound_list/1', a, "false"),
+    case('wam_append_guard/3', args('[a]', '[b,c]', '[a,b,c]'), "true"),
+    case('wam_append_guard/3', args('[]', '[a,b]', '[a,b]'), "true"),
+    case('wam_append_guard/3', args('[a,b]', '[]', '[a,b]'), "true"),
+    case('wam_append_guard/3', args('[a]', '[b]', '[a,c]'), "false"),
+    case('wam_append_bad_left/1', '[a,c]', "false"),
+    case('wam_append_unbound_left/1', '[a,b]', "false"),
     case('wam_ground_guard/1', a, "true"),
     case('wam_ground_guard/1', 42, "true"),
     case('wam_ground_guard/1', 3.5, "true"),
@@ -565,6 +581,15 @@ assert_lowered_member_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-member-unbound-list-1"),
     has(CoreCode, "runtime/apply-member-solution").
 
+assert_lowered_append_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-append-guard-3"),
+    has(CoreCode, "defn lowered-wam-append-bad-left-1"),
+    has(CoreCode, "defn lowered-wam-append-unbound-left-1"),
+    has(CoreCode, "runtime/proper-list-items"),
+    has(CoreCode, "runtime/list->term").
+
 assert_lowered_ground_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
@@ -672,6 +697,12 @@ arg_to_edn_vector(args(Arg1, Arg2), ArgsEdn) :-
     prolog_term_string_to_edn(Arg1, EdnArg1),
     prolog_term_string_to_edn(Arg2, EdnArg2),
     format(string(ArgsEdn), "[~w ~w]", [EdnArg1, EdnArg2]).
+arg_to_edn_vector(args(Arg1, Arg2, Arg3), ArgsEdn) :-
+    !,
+    prolog_term_string_to_edn(Arg1, EdnArg1),
+    prolog_term_string_to_edn(Arg2, EdnArg2),
+    prolog_term_string_to_edn(Arg3, EdnArg3),
+    format(string(ArgsEdn), "[~w ~w ~w]", [EdnArg1, EdnArg2, EdnArg3]).
 arg_to_edn_vector(Arg, ArgsEdn) :-
     prolog_term_string_to_edn(Arg, EdnArg),
     format(string(ArgsEdn), "[~w]", [EdnArg]).
@@ -758,13 +789,19 @@ prolog_term_string_to_edn("d", "\"d\"") :- !.
 prolog_term_string_to_edn("z", "\"z\"") :- !.
 prolog_term_string_to_edn('f(a)', "{:tag :struct :functor \"f/1\" :args [\"a\"]}") :- !.
 prolog_term_string_to_edn('f(b)', "{:tag :struct :functor \"f/1\" :args [\"b\"]}") :- !.
+prolog_term_string_to_edn('[a]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}") :- !.
 prolog_term_string_to_edn('[a,b]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.
+prolog_term_string_to_edn('[b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
+prolog_term_string_to_edn('[a,b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[a|b]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"b\"]}") :- !.
 prolog_term_string_to_edn("f(a)", "{:tag :struct :functor \"f/1\" :args [\"a\"]}") :- !.
 prolog_term_string_to_edn("f(b)", "{:tag :struct :functor \"f/1\" :args [\"b\"]}") :- !.
+prolog_term_string_to_edn("[a]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}") :- !.
 prolog_term_string_to_edn("[a,b]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.
+prolog_term_string_to_edn("[b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[a,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
+prolog_term_string_to_edn("[a,b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn(Atom, Atom).
 
 find_clojure_classpath(ClassPath) :-


### PR DESCRIPTION
## Summary

Adds direct lowered Clojure WAM support for deterministic `append/3` concat mode.

## What Changed

- Marks `append/3` as a direct Clojure lowered builtin.
- Emits lowered `append/3` calls through Clojure runtime list helpers instead of the generic WAM step loop.
- Adds `runtime/proper-list-items` to decompose proper list terms into item vectors.
- Adds runtime dispatch for `append/3`.
- Adds generator, lowered-emitter, and batched runtime smoke coverage.

## Semantics

This PR intentionally implements the conservative deterministic mode:

- `append(+ListA, +ListB, ?Out)`
- Proper-list inputs are concatenated and unified with `Out`.
- Improper lists and unbound first/second list inputs fail.
- Split/generative modes, such as `append(A, B, [a,b,c])`, remain out of scope for this PR.

This matches the cautious mode already used by the R WAM runtime and leaves Scala-style split enumeration for a separate follow-up.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
