### PR TITLE
fix(wam-r): live-store retract/1 + assertz value-copy

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -628,13 +628,14 @@ WamRuntime$run(shared_program, state)
   family is intentionally lenient (accepts ints/floats with their
   decimal name) to compensate. To round-trip an atom-of-digits
   reliably, build it via `atom_codes/2`.
-- **`retract/1` snapshot semantics**. `retract/1` is multi-solution
-  via an iter-CP, but the iteration walks a snapshot of the clause
-  list captured at the original call -- so clauses asserted *during*
-  the iteration are not retracted by the same `retract/1` call.
-  Removed clauses are matched against the live store by object
-  identity, so concurrent retracts/asserts of unrelated clauses
-  don't disturb the iteration order.
+- **`retract/1` immediate-update view**. `retract/1` is multi-solution
+  via an iter-CP, and the iteration reads the live clause list afresh
+  on every retry. Clauses asserted *during* the iteration are visible
+  to subsequent solutions; clauses already retracted (or retracted by
+  another call mid-iteration) are simply skipped. This deliberately
+  diverges from SWI's logical-update view (which would hide mid-
+  iteration asserts); see `streams_multiline_read_e2e_rscript`-adjacent
+  `multi_solution_retract_e2e_rscript` for the locked-in test case.
 - **Full ISO/SWI compatibility for every `bagof/3` / `setof/3` edge**.
   The runtime now groups non-existential free variables and enumerates
   additional witness groups on backtracking, but unusual attributed-var

--- a/docs/handoff/wam_r_session_handoff.md
+++ b/docs/handoff/wam_r_session_handoff.md
@@ -182,14 +182,47 @@ roughly priority order:
    inside a quoted atom / string / unclosed compound and reading
    continues. EOF on an empty buffer still binds `end_of_file`.
    Covered by `streams_multiline_read_e2e_rscript`.
-5. **Multi-solution `retract/1` ignoring snapshot.** I.e. re-read the
-   live clause list on each backtrack. Trickier semantics; document
-   carefully if pursued.
-6. **Phase-3 lowered emitter expansion.** Currently handles only
+5. ~~**Multi-solution `retract/1` ignoring snapshot.**~~ *Done.*
+   `retract_iter` now reads `program$dynamic[[ck]]` afresh on every
+   retry; the prior snapshot of the clause list is gone. Asserts
+   that happen between retract solutions become visible to
+   subsequent solutions (immediate-update view -- a deliberate
+   divergence from SWI's logical-update view, locked in by the
+   `msr_live_assert` sub-test). Implementing this also surfaced and
+   fixed a pre-existing bug in `assertz/1` / `asserta/1`: the
+   stored clause kept references to the caller's term nodes
+   directly, so a backtrack that undid the caller's bindings would
+   leave stored clauses with unbound args. Both predicates now
+   `copy_term` their head args + body before storing.
+
+   Surfaced but **not** fixed in this PR: the WAM compiler's
+   `compile_inner_call_goals` (used by `compile_disjunction`'s
+   left/right branches and a few other inner-conjunction sites)
+   does not recurse for nested if-then-else (`(C -> T ; E)`) inside
+   a conjunction body -- it falls through to a generic
+   `compile_goal_call` and ends up emitting `Call(";", 2)`, which
+   has no runtime implementation and just fails. So
+   `findall(X, (retract(...), (X > 0 -> Y is X+1 ; true)), L)`
+   silently produces `L = []`. Workaround: hoist the inner ITE out
+   of the conjunction (e.g., via a helper predicate) or replace
+   it with explicit disjunction. Filed as a separate item:
+6. **Nested if-then-else inside conjunction bodies.**
+   `src/unifyweaver/targets/wam_target.pl :: compile_inner_call_goals/4`
+   loops over each goal calling `compile_goal_call`, never recursing
+   into `compile_if_then_else` / `compile_disjunction` for nested
+   `(C -> T ; E)` / `(A ; B)` sub-goals. As a result, an inner ITE
+   in a disjunction-left branch or an aggregate body emits as
+   `Call(";", 2)` (with the term constructed as data via
+   PutStructure / SetConstant), which has no runtime handler and
+   just fails. Fix: have `compile_inner_call_goals` dispatch on
+   `(C -> T ; E)` / `(A ; B)` exactly like the outer
+   `compile_goals` does. Tests covering inner ITE inside a
+   `findall(...)` body would catch this; none exist today.
+7. **Phase-3 lowered emitter expansion.** Currently handles only
    `deterministic` and `multi_clause_1` shapes. Could grow N-clause
    general lowering; would compete with the kernel / fact-table paths
    so the value is unclear.
-7. **Range / interval indexes** on fact tables. Per-arg hash indexes
+8. **Range / interval indexes** on fact tables. Per-arg hash indexes
    land queries with ground atom/int args; range queries (`X > 5`,
    `X between A B`) still go through the per-tuple scan. A sorted-
    per-arg index would route these. Niche but a natural extension.

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -2130,22 +2130,49 @@ WamRuntime$dynamic_iter <- function(program, state, clauses, start_idx, arity, r
   FALSE
 }
 
-# Multi-solution retract/1. Walks `snapshot` (the clause list captured
-# at the original retract call) from `start_idx`, trying each clause
-# against the caller's pattern (head_args + optional body). On the
-# first match, the matching clause is deleted from the live store
-# (matched by object identity, since the live store may have been
-# mutated since the snapshot) and -- if more snapshot entries remain
-# -- an iter CP is pushed so backtracking re-enters the iteration at
-# `idx + 1` and re-binds the caller's pattern against that next
-# match. The captured snapshot is value-stable: asserts/retracts that
-# happen during the iteration don't perturb the order, and clauses
-# already retracted are simply skipped on subsequent identity checks.
+# Multi-solution retract/1, live-store iteration (immediate-update
+# view). Unlike `clause/2` -- which captures a snapshot of the
+# dynamic store at the original call and walks it -- retract/1 reads
+# `program$dynamic[[ck]]` afresh on every iteration. Concretely:
+#
+#   1. Reads the current live list each call (initial + every retry).
+#   2. Walks it from index 1 looking for the first clause whose
+#      head args (and optional body) unify with the caller's pattern.
+#   3. On match: deletes that clause from the live list (matching
+#      *by index* in the just-read list, not by identity) and pushes
+#      an iter-CP whose `retry` re-enters this same function. On
+#      backtrack, that retry re-reads the (now-mutated) live list
+#      and looks for the next match.
+#
+# Why live and not snapshot? Asserts that happen between retract
+# solutions become visible to subsequent solutions; the user
+# program's view of the dynamic store stays "current". This is a
+# deliberate divergence from SWI's logical-update view (which would
+# hide mid-iteration asserts). The `multi_solution_retract_live_*`
+# tests cover the assert-during-retract case to lock in this choice.
+#
+# Performance vs snapshot: snapshot was O(N) to copy the clause list
+# at the first call plus O(N) per match (identity scan to find the
+# matched clause in live for deletion). Live is O(1) extra per
+# iteration (no snapshot copy, direct index-based delete) but
+# re-scans non-matching clauses on each retry, so net is similar
+# (O(N*K) where K is the number of matches) with a smaller constant
+# in the snapshot-copy direction and a larger constant on the
+# scanning side.
+#
+# Pushing a CP unconditionally on each successful match (rather
+# than only when more candidates remain) is intentional: with live
+# iteration we can't cheaply tell whether more matches exist
+# without scanning, and a no-match retry just returns FALSE which
+# triggers another backtrack -- no semantic difference, only one
+# extra CP frame on the stack.
 WamRuntime$retract_iter <- function(program, state, head_args, body, arity,
-                                     ck, snapshot, start_idx, resume_pc) {
-  if (start_idx > length(snapshot)) return(FALSE)
-  for (idx in seq.int(start_idx, length(snapshot))) {
-    cl <- snapshot[[idx]]
+                                     ck, resume_pc) {
+  if (!exists(ck, envir = program$dynamic, inherits = FALSE)) return(FALSE)
+  live <- get(ck, envir = program$dynamic, inherits = FALSE)
+  if (length(live) == 0L) return(FALSE)
+  for (idx in seq_along(live)) {
+    cl <- live[[idx]]
     if (length(cl$head_args) != arity) next
     snap_trail <- length(state$trail)
     snap_vc    <- state$var_counter
@@ -2160,46 +2187,33 @@ WamRuntime$retract_iter <- function(program, state, head_args, body, arity,
       ok <- WamRuntime$unify(state, body, fresh$body)
     }
     if (ok) {
-      # Remove the matched clause from the live store. Identity match
-      # rather than index, because the store may have been mutated.
-      if (exists(ck, envir = program$dynamic, inherits = FALSE)) {
-        live <- get(ck, envir = program$dynamic, inherits = FALSE)
-        for (li in seq_along(live)) {
-          if (identical(live[[li]], cl)) {
-            new_live <- if (length(live) == 1L) list() else live[-li]
-            assign(ck, new_live, envir = program$dynamic)
-            break
-          }
+      # Remove the matched clause from the live store. We just read
+      # `live` so `idx` is valid in it; assign the modified list back.
+      new_live <- if (length(live) == 1L) list() else live[-idx]
+      assign(ck, new_live, envir = program$dynamic)
+      captured_head_args <- head_args
+      captured_body      <- body
+      captured_arity     <- arity
+      captured_ck        <- ck
+      captured_resume    <- resume_pc
+      captured_program   <- program
+      cp <- list(
+        kind        = "iter",
+        regs        = state$regs2,
+        trail_len   = snap_trail,
+        cp          = state$cp,
+        var_counter = snap_vc,
+        mode        = state$mode,
+        build_stack = state$build_stack,
+        resume_pc   = resume_pc,
+        retry       = function(state) {
+          WamRuntime$retract_iter(captured_program, state,
+                                   captured_head_args, captured_body,
+                                   captured_arity, captured_ck,
+                                   captured_resume)
         }
-      }
-      if (idx < length(snapshot)) {
-        captured_head_args <- head_args
-        captured_body      <- body
-        captured_arity     <- arity
-        captured_ck        <- ck
-        captured_snapshot  <- snapshot
-        captured_next_idx  <- idx + 1L
-        captured_resume    <- resume_pc
-        captured_program   <- program
-        cp <- list(
-          kind        = "iter",
-          regs        = state$regs2,
-          trail_len   = snap_trail,
-          cp          = state$cp,
-          var_counter = snap_vc,
-          mode        = state$mode,
-          build_stack = state$build_stack,
-          resume_pc   = resume_pc,
-          retry       = function(state) {
-            WamRuntime$retract_iter(captured_program, state,
-                                     captured_head_args, captured_body,
-                                     captured_arity, captured_ck,
-                                     captured_snapshot, captured_next_idx,
-                                     captured_resume)
-          }
-        )
-        state$cps <- c(state$cps, list(cp))
-      }
+      )
+      state$cps <- c(state$cps, list(cp))
       return(TRUE)
     }
     WamRuntime$undo_trail_to(state, snap_trail)
@@ -5529,8 +5543,17 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
 
   # ----- assertz/1, asserta/1: add a clause to the dynamic store -----
   # The arg is either a Head (fact) or a `:-`/2(Head, Body) struct.
-  # We split it via split_clause and store a fresh copy of the args
-  # so subsequent unification doesn't see leaked bindings.
+  # We split it via split_clause, then copy_term the args + body so
+  # the stored clause is independent of the caller's bindings. Any
+  # ground-at-assert-time vars stay frozen at their values; any
+  # still-unbound vars become fresh, unrelated to the caller's
+  # var nodes (so a backtrack that undoes the caller's bindings
+  # doesn't unbind the stored copy). Without this, an assertz
+  # inside a fail-driven loop -- e.g.
+  #   ( retract(m(X)), assertz(seen(X)), fail ; true )
+  # would store seen(X) where X is the live ref bound to the
+  # current retract solution; the trail-undo on backtrack would
+  # then leave the stored seen/1 clauses with unbound args.
   if (key == "assertz/1" || key == "asserta/1") {
     raw <- WamRuntime$get_reg(state, 1L)
     parts <- WamRuntime$split_clause(state, raw, table)
@@ -5539,7 +5562,12 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     cur <- if (exists(ck, envir = program$dynamic, inherits = FALSE))
              get(ck, envir = program$dynamic, inherits = FALSE)
            else list()
-    new_clause <- list(head_args = parts$head_args, body = parts$body)
+    mapping <- new.env(parent = emptyenv())
+    copied_head_args <- lapply(parts$head_args, function(a)
+      WamRuntime$copy_term_walk(state, a, mapping))
+    copied_body <- if (is.null(parts$body)) NULL
+                   else WamRuntime$copy_term_walk(state, parts$body, mapping)
+    new_clause <- list(head_args = copied_head_args, body = copied_body)
     if (key == "assertz/1") {
       assign(ck, c(cur, list(new_clause)), envir = program$dynamic)
     } else {
@@ -5550,20 +5578,18 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
 
   # ----- retract/1: remove a matching clause; multi-solution -----
   # Bindings made by the unification persist on success (standard
-  # Prolog semantics). On backtracking, retract_iter scans the rest
-  # of the snapshot taken at the original call and removes the next
-  # matching clause; when the snapshot is exhausted, backtracking
-  # continues outward as failure.
+  # Prolog semantics). retract_iter reads `program$dynamic[[ck]]`
+  # afresh on every retry, so asserts that happen between solutions
+  # become visible to subsequent solutions (immediate-update view --
+  # see retract_iter's leading comment for why).
   if (key == "retract/1") {
     raw <- WamRuntime$get_reg(state, 1L)
     parts <- WamRuntime$split_clause(state, raw, table)
     if (is.null(parts)) return(FALSE)
     ck <- paste0(parts$pred, "/", parts$arity)
-    if (!exists(ck, envir = program$dynamic, inherits = FALSE)) return(FALSE)
-    snapshot <- get(ck, envir = program$dynamic, inherits = FALSE)
     return(WamRuntime$retract_iter(program, state,
                                     parts$head_args, parts$body, parts$arity,
-                                    ck, snapshot, 1L, state$pc + 1L))
+                                    ck, state$pc + 1L))
   }
 
   # ----- abolish/1: drop all clauses for Name/Arity -----

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2099,14 +2099,42 @@ e2e_multi_solution_retract_via_rscript :-
         % rr(2) (with body `fail`) survives.
         findall(Y, retract((rr(Y) :- _)), Rest),
         Rest == [2])),
+    % Live (immediate-update) view: assertz that happens between
+    % retract solutions is visible to subsequent solutions. The
+    % fail-driven loop retracts m/1 and asserts m(X*10) on the way
+    % out. With live-store iteration the next backtrack sees the
+    % new clauses and retracts them in turn until the X*10 result
+    % >= 1000. SWI's logical-update view would stop after the
+    % original m(1) is retracted (snapshot doesn't see the asserts).
+    %
+    % Result accumulator uses dynamic retracted/1 so we don't have
+    % to use findall + nested if-then-else here -- the compiler's
+    % handling of nested ITE inside disjunction bodies has a
+    % separate gap (Call(";", 2) emitted instead of inline ITE),
+    % so this test stays in flat-conjunction territory.
+    assertz((user:msr_live_assert :-
+        assertz(m(1)),
+        (   retract(m(X)),
+            assertz(retracted(X)),
+            Y is X * 10,
+            Y < 1000,
+            assertz(m(Y)),
+            fail
+        ;   true
+        ),
+        findall(R, retract(retracted(R)), Rs),
+        msort(Rs, Sorted),
+        Sorted == [1, 10, 100],
+        \+ retract(m(_)))),
     unique_r_tmp_dir('tmp_r_msr_e2e', TmpDir),
     write_wam_r_project(
         [user:msr_all/0, user:msr_filtered/0, user:msr_pattern/0,
-         user:msr_rule/0],
+         user:msr_rule/0, user:msr_live_assert/0],
         [],
         TmpDir),
     directory_file_path(TmpDir, 'R', RDir),
-    Yes = [msr_all, msr_filtered, msr_pattern, msr_rule],
+    Yes = [msr_all, msr_filtered, msr_pattern, msr_rule,
+           msr_live_assert],
     forall(member(P, Yes), (
         format(string(Q), '~w/0', [P]),
         run_rscript_query(RDir, Q, Out),


### PR DESCRIPTION
## Summary

Two coupled fixes; the second was surfaced while testing the first. Closes handoff item #5 and fixes a pre-existing assertz copy bug.

### `retract/1` (multi-solution): live-store iteration

`retract_iter` no longer captures a snapshot of the dynamic store at the original call. Each retry re-reads `program$dynamic[[ck]]` and scans from index 1 for the next match. Asserts that happen between retract solutions become visible to subsequent solutions (immediate-update view -- a deliberate divergence from SWI's logical-update view, locked in by the new `msr_live_assert` sub-test).

An iter-CP is now pushed unconditionally on every successful match (we can't cheaply tell whether more matches exist without a full live-store scan); a no-match retry just returns FALSE which triggers another backtrack -- no semantic difference, only one extra CP frame on the stack.

### `assertz/1` + `asserta/1`: copy_term at assert time

The pre-existing implementation stored references to the caller's term nodes directly, so a backtrack that undid the caller's bindings would leave stored clauses with unbound args. With the live retract refactor, this manifested as asserts inside fail-driven loops storing the loop variable as an unbound ref, which on backtrack became a fresh `_V` var. `assertz` / `asserta` now `copy_term` the head args + body before storing (sharing one fresh-var mapping per call so vars common to head and body stay one fresh var), matching SWI semantics.

## Test plan

New e2e sub-test `msr_live_assert` exercises both fixes via a fail-driven loop that retracts `m(X)` and asserts `m(X*10)` on the way out; with live retract + correct assertz copy, the bag of retracted values is `[1, 10, 100]` as the `X*10` result climbs until the `Y<1000` filter rejects.

- [x] Full WAM-R suite (`swipl -g '[tests/test_wam_r_generator], run_tests' -t halt`) -- 72/72 passing
- [x] Existing 4 sub-tests of `multi_solution_retract_e2e_rscript` (msr_all, msr_filtered, msr_pattern, msr_rule) all still pass under the new live-store iteration

## Surfaced but not fixed in this PR

`src/unifyweaver/targets/wam_target.pl :: compile_inner_call_goals/4` does not recurse for nested `(C -> T ; E)` / `(A ; B)` sub-goals inside a conjunction body -- it falls through to `compile_goal_call` and emits `Call(";", 2)`, which has no runtime handler and just fails. So an ITE inside a `findall(...)` body silently produces an empty bag. Filed as new follow-up #6 in `docs/handoff/wam_r_session_handoff.md`. The new test is written in flat-conjunction style to dodge this.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_