### PR TITLE
feat(wam-r): enumerate append/3 split mode

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -410,7 +410,8 @@ and rationals are not supported.
 ### Lists
 
 `member/2` (multi-solution via iter-CP), `memberchk/2`, `length/2`
-((+, -) and (-, +) modes), `append/3` ((+, +, -) mode), `reverse/2`
+((+, -), (-, +), and (-, -) modes), `append/3` ((+, +, -) mode
+and finite split mode over a ground third list), `reverse/2`
 (deterministic if either side bound), `last/2`, `nth0/3`, `nth1/3`,
 `select/3` (first match), `delete/3` (==/2 semantics),
 `permutation/2` ((+, +) check + (+, -) identity), `numlist/3`,

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -3617,6 +3617,64 @@ WamRuntime$length_iter <- function(state, list_target, n_target, current, resume
   FALSE
 }
 
+WamRuntime$append_split_iter <- function(state, left_target, right_target, elems,
+                                         split_idx, resume_pc, table) {
+  if (split_idx > length(elems)) return(FALSE)
+  for (idx in seq.int(split_idx, length(elems))) {
+    snap_regs  <- state$regs2
+    snap_trail <- length(state$trail)
+    snap_cp    <- state$cp
+    snap_vc    <- state$var_counter
+    snap_mode  <- state$mode
+    snap_build <- state$build_stack
+    snap_read  <- state$read_stack
+
+    left_elems <- if (idx == 0L) list() else elems[seq_len(idx)]
+    right_elems <- if (idx == length(elems)) list() else elems[(idx + 1L):length(elems)]
+    ok <- WamRuntime$unify(state, left_target, WamRuntime$wam_list_build(left_elems, table))
+    if (isTRUE(ok)) {
+      ok <- WamRuntime$unify(state, right_target, WamRuntime$wam_list_build(right_elems, table))
+    }
+    if (isTRUE(ok)) {
+      if (idx < length(elems)) {
+        next_idx <- idx + 1L
+        captured_left <- left_target
+        captured_right <- right_target
+        captured_elems <- elems
+        captured_resume <- resume_pc
+        captured_table <- table
+        cp <- list(
+          kind        = "iter",
+          regs        = snap_regs,
+          trail_len   = snap_trail,
+          cp          = snap_cp,
+          var_counter = snap_vc,
+          mode        = snap_mode,
+          build_stack = snap_build,
+          read_stack  = snap_read,
+          resume_pc   = resume_pc,
+          retry       = function(state) {
+            WamRuntime$append_split_iter(state, captured_left, captured_right,
+                                         captured_elems, next_idx,
+                                         captured_resume, captured_table)
+          }
+        )
+        state$cps <- c(state$cps, list(cp))
+      }
+      return(TRUE)
+    }
+
+    state$regs2 <- snap_regs
+    WamRuntime$undo_trail_to(state, snap_trail)
+    state$cp          <- snap_cp
+    state$var_counter <- snap_vc
+    state$mode        <- snap_mode
+    state$build_stack <- snap_build
+    state$read_stack  <- snap_read
+  }
+  FALSE
+}
+
 # Term-comparison-based merge sort. Used by msort/2 (keep dups) and
 # sort/2 (dedup after sorting). The compare_terms call orders unbound
 # vars first, then numbers, atoms, structs.
@@ -4398,16 +4456,25 @@ WamRuntime$call_builtin <- function(program, state, pred, arity) {
     return(FALSE)
   }
 
-  # append/3: deterministic (+, +, -) mode.
+  # append/3.
   #   append([1,2], [3,4], C) -> C = [1,2,3,4]
-  # The other modes (split-on-third-arg etc.) are non-deterministic
-  # and are intentionally skipped.
+  #   append(Prefix, Suffix, [a,b]) enumerates all finite split points.
   if (pred == "append/3" && arity == 3L) {
-    a_elems <- WamRuntime$wam_list_decompose(state, WamRuntime$get_reg(state, 1L), table)
-    b_elems <- WamRuntime$wam_list_decompose(state, WamRuntime$get_reg(state, 2L), table)
-    if (is.null(a_elems) || is.null(b_elems)) return(FALSE)
-    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 3L),
-                            WamRuntime$wam_list_build(c(a_elems, b_elems), table)))
+    left <- WamRuntime$get_reg(state, 1L)
+    right <- WamRuntime$get_reg(state, 2L)
+    combined <- WamRuntime$get_reg(state, 3L)
+    a_elems <- WamRuntime$wam_list_decompose(state, left, table)
+    b_elems <- WamRuntime$wam_list_decompose(state, right, table)
+    c_elems <- WamRuntime$wam_list_decompose(state, combined, table)
+    if (!is.null(a_elems) && !is.null(b_elems)) {
+      return(WamRuntime$unify(state, combined,
+                              WamRuntime$wam_list_build(c(a_elems, b_elems), table)))
+    }
+    if (!is.null(c_elems)) {
+      return(WamRuntime$append_split_iter(state, left, right, c_elems, 0L,
+                                          state$pc + 1L, table))
+    }
+    return(FALSE)
   }
 
   # Term equality / identity / standard order. =/2 may bind; the others

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -862,10 +862,25 @@ e2e_list_atom_builtins_via_rscript :-
         length(L, N),
         N == 3,
         L = [_, _, _])),
-    % append/3 deterministic mode.
+    % append/3 deterministic and finite split modes.
     assertz((user:lb_app_ok    :- append([1, 2], [3, 4], [1, 2, 3, 4]))),
     assertz((user:lb_app_empty :- append([], [a, b], [a, b]))),
     assertz((user:lb_app_no    :- append([1, 2], [3, 4], [1, 2, 3, 5]))),
+    assertz((user:lb_app_split_all :-
+        findall(P-S, append(P, S, [a, b]), Splits),
+        Splits == [ []-[a, b], [a]-[b], [a, b]-[] ])),
+    assertz((user:lb_app_split_later :-
+        append(P, S, [a, b, c]),
+        P == [a, b],
+        S == [c])),
+    assertz((user:lb_app_split_empty :-
+        append(P, S, []),
+        P == [],
+        S == [])),
+    assertz((user:lb_app_split_no :-
+        append(P, S, [a, b]),
+        P == [b],
+        S == [a])),
     % reverse/2.
     assertz((user:lb_rev_ok :- reverse([a, b, c], [c, b, a]))),
     assertz((user:lb_rev_no :- reverse([a, b, c], [a, b, c]))),
@@ -885,6 +900,8 @@ e2e_list_atom_builtins_via_rscript :-
           user:lb_len_build/0, user:lb_len_gen_zero/0,
           user:lb_len_gen_two/0, user:lb_len_gen_three/0,
           user:lb_app_ok/0, user:lb_app_empty/0, user:lb_app_no/0,
+          user:lb_app_split_all/0, user:lb_app_split_later/0,
+          user:lb_app_split_empty/0, user:lb_app_split_no/0,
           user:lb_rev_ok/0, user:lb_rev_no/0,
           user:lb_last_ok/0, user:lb_last_no/0,
           user:lb_alen_ok/0, user:lb_alen_no/0,
@@ -895,10 +912,12 @@ e2e_list_atom_builtins_via_rscript :-
     directory_file_path(TmpDir, 'R', RDir),
     Yes = [lb_len_count, lb_len_zero, lb_len_build,
            lb_len_gen_zero, lb_len_gen_two, lb_len_gen_three,
-           lb_app_ok, lb_app_empty,
+           lb_app_ok, lb_app_empty, lb_app_split_all,
+           lb_app_split_later, lb_app_split_empty,
            lb_rev_ok, lb_last_ok,
            lb_alen_ok, lb_acodes_ok, lb_achars_ok, lb_aconcat_ok],
-    No  = [lb_len_wrong, lb_app_no, lb_rev_no, lb_last_no,
+    No  = [lb_len_wrong, lb_app_no, lb_app_split_no,
+           lb_rev_no, lb_last_no,
            lb_alen_no, lb_aconcat_no],
     forall(member(P, Yes), (
         format(string(Q), '~w/0', [P]),


### PR DESCRIPTION
## Summary

- Adds finite split-mode support for WAM-R `append/3` when the third argument is a ground list.
- Enumerates `append(Prefix, Suffix, List)` split points on backtracking.
- Keeps the existing deterministic `append(+,+,-)` mode.
- Adds Rscript e2e coverage for all splits, later split backtracking, empty-list split, and a negative split case.
- Updates WAM-R docs to include the new `append/3` mode.

## Details

The runtime now uses a new `append_split_iter` helper for queries like:

```prolog
append(Prefix, Suffix, [a, b])
```

It enumerates:

```prolog
Prefix = [],     Suffix = [a, b]
Prefix = [a],    Suffix = [b]
Prefix = [a, b], Suffix = []
```

using the existing iter choice-point shape.

## Verification

- `swipl -g "run_tests([wam_r_generator:list_atom_builtins_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
- `swipl -g "run_tests([wam_r_generator:list_atom_builtins_e2e_rscript,wam_r_generator:enumerable_builtins_e2e_rscript,wam_r_generator:findall_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
- `git diff --check`
