### PR TITLE
Feature/lua wam control builtins

### DIFF
--- a/PR_lua_wam_control_builtins.md
+++ b/PR_lua_wam_control_builtins.md
@@ -1,0 +1,17 @@
+# PR Title
+
+Add Lua WAM control builtins
+
+# PR Description
+
+## Summary
+
+- add Lua WAM runtime support for `true/0`, `fail/0`, `!/0`, `\+/1`, and `CutIte`
+- evaluate negated goals in an isolated substate so bindings inside `\+/1` do not leak
+- add Lua generator end-to-end coverage for cut over alternatives, if-then-else soft cut, negation success/failure, and negated `member/2`
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`

--- a/templates/targets/lua_wam/runtime.lua.mustache
+++ b/templates/targets/lua_wam/runtime.lua.mustache
@@ -500,6 +500,14 @@ local function builtin_copy_term(_program, state)
   return bind_or_compare(state, 2, copied)
 end
 
+local goal_succeeds
+
+local function builtin_naf(program, state)
+  local goal = Runtime.deref(state, Runtime.get_reg(state, 1))
+  if goal_succeeds(program, state, goal) == true then return false end
+  return true
+end
+
 local function numeric_value(v)
   if type(v) == "table" and (v.tag == "int" or v.tag == "float") then return v.val end
   return nil
@@ -853,6 +861,10 @@ function Runtime.builtin_call(program, state, instr)
   local p = instr.pred
   local type_ok = type_builtin(program, state, p)
   if type_ok ~= nil then return type_ok end
+  if p == "true" or p == "true/0" then return true end
+  if p == "fail" or p == "fail/0" then return false end
+  if p == "!" or p == "!/0" then state.cps = {}; return true end
+  if p == "\\+" or p == "\\+/1" then return builtin_naf(program, state) end
   if p == "=" or p == "=/2" then return Runtime.unify(state, Runtime.get_reg(state, 1), Runtime.get_reg(state, 2)) end
   if p == "==" or p == "==/2" then return exact_equal(state, Runtime.get_reg(state, 1), Runtime.get_reg(state, 2)) end
   if p == "member" or p == "member/2" then return builtin_member(program, state) end
@@ -897,6 +909,49 @@ function Runtime.builtin_call(program, state, instr)
     return a ~= nil and b ~= nil and a <= b
   end
   return false
+end
+
+goal_succeeds = function(program, parent_state, goal)
+  goal = Runtime.deref(parent_state, goal)
+  if type(goal) ~= "table" then return false end
+  if goal.tag == "atom" then
+    local name = Runtime.string_of(program.intern_table, goal.id)
+    if name == "true" then return true end
+    if name == "fail" then return false end
+    local target = program.labels[name .. "/0"]
+    if target == nil then return false end
+    local substate = Runtime.new_state()
+    substate.pc = target
+    substate.bindings = Runtime.copy_table(parent_state.bindings)
+    substate.var_counter = parent_state.var_counter
+    return Runtime.run(program, substate) == true
+  end
+  if goal.tag ~= "struct" then return false end
+  local pred = Runtime.string_of(program.intern_table, goal.fid)
+  local arity = #(goal.args or {})
+  local substate = Runtime.new_state()
+  substate.bindings = Runtime.copy_table(parent_state.bindings)
+  substate.var_counter = parent_state.var_counter
+  for i, arg in ipairs(goal.args or {}) do Runtime.put_reg(substate, i, arg) end
+  local temp_program = {
+    instructions = { I.BuiltinCall(pred, arity), I.Proceed() },
+    labels = {},
+    intern_table = program.intern_table,
+    indexed_atom_fact2 = program.indexed_atom_fact2,
+    inline_facts = program.inline_facts,
+    fact_sources = program.fact_sources,
+    foreign_handlers = program.foreign_handlers
+  }
+  substate.pc = 1
+  if Runtime.run(temp_program, substate) == true then return true end
+  local target = program.labels[pred]
+  if target == nil then return false end
+  substate = Runtime.new_state()
+  substate.bindings = Runtime.copy_table(parent_state.bindings)
+  substate.var_counter = parent_state.var_counter
+  for i, arg in ipairs(goal.args or {}) do Runtime.put_reg(substate, i, arg) end
+  substate.pc = target
+  return Runtime.run(program, substate) == true
 end
 
 function Runtime.call_foreign(program, state, instr)
@@ -992,6 +1047,11 @@ function Runtime.step(program, state, instr)
   if op == "TrustMe" then
     local cp = state.cps[#state.cps]
     if cp ~= nil and cp.kind ~= "aggregate" then table.remove(state.cps) end
+    state.pc = state.pc + 1
+    return true
+  end
+  if op == "CutIte" then
+    if #state.cps > 0 then table.remove(state.cps) end
     state.pc = state.pc + 1
     return true
   end

--- a/tests/test_wam_lua_generator.pl
+++ b/tests/test_wam_lua_generator.pl
@@ -54,6 +54,13 @@
 :- dynamic user:wam_lua_copy_term_fresh/0.
 :- dynamic user:wam_lua_copy_term_sharing/0.
 :- dynamic user:wam_lua_copy_term_independent_vars/0.
+:- dynamic user:wam_lua_cut_choice/1.
+:- dynamic user:wam_lua_if_then_else_then/0.
+:- dynamic user:wam_lua_if_then_else_else/0.
+:- dynamic user:wam_lua_naf_true/0.
+:- dynamic user:wam_lua_naf_false/0.
+:- dynamic user:wam_lua_naf_member/0.
+:- dynamic user:wam_lua_naf_member_no/0.
 
 user:wam_lua_fact(a).
 user:wam_lua_choice(a).
@@ -155,6 +162,18 @@ user:wam_lua_copy_term_independent_vars :-
     C = f(A, B),
     A = a,
     B = b.
+user:wam_lua_cut_choice(X) :-
+    (X = a ; X = b),
+    !,
+    X = a.
+user:wam_lua_if_then_else_then :-
+    (true -> true ; fail).
+user:wam_lua_if_then_else_else :-
+    (fail -> fail ; true).
+user:wam_lua_naf_true :- \+ fail.
+user:wam_lua_naf_false :- \+ true.
+user:wam_lua_naf_member :- \+ member(d, [a, b, c]).
+user:wam_lua_naf_member_no :- \+ member(a, [a, b, c]).
 
 test(exports) :-
     assertion(current_predicate(wam_lua_target:write_wam_lua_project/3)),
@@ -530,6 +549,33 @@ test(lua_copy_term_builtin_e2e, [condition(lua_available)]) :-
           run_lua_query(LuaDir, 'wam_lua_copy_term_fresh/0', [], true),
           run_lua_query(LuaDir, 'wam_lua_copy_term_sharing/0', [], true),
           run_lua_query(LuaDir, 'wam_lua_copy_term_independent_vars/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(lua_control_builtins_e2e, [condition(lua_available)]) :-
+    unique_lua_tmp_dir('tmp_lua_control_builtins_e2e', TmpDir),
+    setup_call_cleanup(
+        write_wam_lua_project(
+            [ user:wam_lua_cut_choice/1,
+              user:wam_lua_if_then_else_then/0,
+              user:wam_lua_if_then_else_else/0,
+              user:wam_lua_naf_true/0,
+              user:wam_lua_naf_false/0,
+              user:wam_lua_naf_member/0,
+              user:wam_lua_naf_member_no/0
+            ],
+            [],
+            TmpDir),
+        ( directory_file_path(TmpDir, 'lua', LuaDir),
+          run_lua_query(LuaDir, 'wam_lua_cut_choice/1', [a], true),
+          run_lua_query(LuaDir, 'wam_lua_cut_choice/1', [b], false),
+          run_lua_query(LuaDir, 'wam_lua_if_then_else_then/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_if_then_else_else/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_naf_true/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_naf_false/0', [], false),
+          run_lua_query(LuaDir, 'wam_lua_naf_member/0', [], true),
+          run_lua_query(LuaDir, 'wam_lua_naf_member_no/0', [], false)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
# Add Lua WAM control builtins

## Summary

- add Lua WAM runtime support for `true/0`, `fail/0`, `!/0`, `\+/1`, and `CutIte`
- evaluate negated goals in an isolated substate so bindings inside `\+/1` do not leak
- add Lua generator end-to-end coverage for cut over alternatives, if-then-else soft cut, negation success/failure, and negated `member/2`

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`
