### PR TITLE
feat(wam-r): enumerate select/3 matches

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -413,7 +413,7 @@ and rationals are not supported.
 ((+, -), (-, +), and (-, -) modes), `append/3` ((+, +, -) mode
 and finite split mode over a ground third list), `reverse/2`
 (deterministic if either side bound), `last/2`, `nth0/3`, `nth1/3`,
-`select/3` (first match), `delete/3` (==/2 semantics),
+`select/3` (multi-solution over list positions), `delete/3` (==/2 semantics),
 `permutation/2` ((+, +) check + (+, -) identity), `numlist/3`,
 `sort/2` (sort + dedup, standard order of terms), `msort/2` (sort,
 keep duplicates), `maplist/2..3`.

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -3689,6 +3689,63 @@ WamRuntime$append_split_iter <- function(state, left_target, right_target, elems
   FALSE
 }
 
+WamRuntime$select_iter <- function(state, target, elems, rest_target, start_idx,
+                                   resume_pc, table) {
+  if (start_idx > length(elems)) return(FALSE)
+  for (idx in seq.int(start_idx, length(elems))) {
+    snap_regs  <- state$regs2
+    snap_trail <- length(state$trail)
+    snap_cp    <- state$cp
+    snap_vc    <- state$var_counter
+    snap_mode  <- state$mode
+    snap_build <- state$build_stack
+    snap_read  <- state$read_stack
+
+    rest <- if (length(elems) == 1L) list() else elems[-idx]
+    ok <- WamRuntime$unify(state, target, elems[[idx]])
+    if (isTRUE(ok)) {
+      ok <- WamRuntime$unify(state, rest_target, WamRuntime$wam_list_build(rest, table))
+    }
+    if (isTRUE(ok)) {
+      if (idx < length(elems)) {
+        next_idx <- idx + 1L
+        captured_target <- target
+        captured_elems <- elems
+        captured_rest <- rest_target
+        captured_resume <- resume_pc
+        captured_table <- table
+        cp <- list(
+          kind        = "iter",
+          regs        = snap_regs,
+          trail_len   = snap_trail,
+          cp          = snap_cp,
+          var_counter = snap_vc,
+          mode        = snap_mode,
+          build_stack = snap_build,
+          read_stack  = snap_read,
+          resume_pc   = resume_pc,
+          retry       = function(state) {
+            WamRuntime$select_iter(state, captured_target, captured_elems,
+                                   captured_rest, next_idx,
+                                   captured_resume, captured_table)
+          }
+        )
+        state$cps <- c(state$cps, list(cp))
+      }
+      return(TRUE)
+    }
+
+    state$regs2 <- snap_regs
+    WamRuntime$undo_trail_to(state, snap_trail)
+    state$cp          <- snap_cp
+    state$var_counter <- snap_vc
+    state$mode        <- snap_mode
+    state$build_stack <- snap_build
+    state$read_stack  <- snap_read
+  }
+  FALSE
+}
+
 # Term-comparison-based merge sort. Used by msort/2 (keep dups) and
 # sort/2 (dedup after sorting). The compare_terms call orders unbound
 # vars first, then numbers, atoms, structs.
@@ -4728,23 +4785,14 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
   }
 
   # ----- select/3: select(?X, +L, ?Rest) -----
-  # Find the first list element that unifies with X; Rest is L minus
-  # that element. Backtracking enumeration over multiple matches is
-  # not supported (deterministic first-match only).
+  # Enumerate list elements that unify with X; Rest is L minus the
+  # selected occurrence.
   if (key == "select/3") {
     target <- WamRuntime$get_reg(state, 1L)
     elems  <- WamRuntime$wam_list_decompose(state, WamRuntime$get_reg(state, 2L), table)
     if (is.null(elems)) return(FALSE)
-    for (i in seq_along(elems)) {
-      trail0 <- length(state$trail)
-      if (WamRuntime$unify(state, target, elems[[i]])) {
-        rest <- if (length(elems) == 1L) list() else elems[-i]
-        return(WamRuntime$unify(state, WamRuntime$get_reg(state, 3L),
-                                WamRuntime$wam_list_build(rest, table)))
-      }
-      WamRuntime$undo_trail_to(state, trail0)
-    }
-    return(FALSE)
+    return(WamRuntime$select_iter(state, target, elems, WamRuntime$get_reg(state, 3L),
+                                  1L, state$pc + 1L, table))
   }
 
   # ----- delete/3: delete(+L, @Elem, -Rest) -----

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -1215,6 +1215,15 @@ e2e_higherorder_listutil_via_rscript :-
     assertz((user:hl_select_mid :- select(b, [a, b, c], [a, c]))),
     assertz((user:hl_select_no  :- select(z, [a, b, c], _))),
     assertz((user:hl_select_one :- select(only, [only], []))),
+    assertz((user:hl_select_dup_all :-
+        findall(Rest, select(a, [a, b, a], Rest), Rests),
+        Rests == [[b, a], [a, b]])),
+    assertz((user:hl_select_var_all :-
+        findall(X-Rest, select(X, [a, b, a], Rest), Pairs),
+        Pairs == [a-[b, a], b-[a, a], a-[a, b]])),
+    assertz((user:hl_select_bound_rest :-
+        select(X, [a, b, c], [a, c]),
+        X == b)),
     % delete/3 (==/2 semantics, no var binding).
     assertz((user:hl_del_all    :- delete([a, b, a, c, a], a, [b, c]))),
     assertz((user:hl_del_none   :- delete([a, b, c], z, [a, b, c]))),
@@ -1232,6 +1241,8 @@ e2e_higherorder_listutil_via_rscript :-
           user:hl_nth0_first/0, user:hl_nth0_last/0, user:hl_nth0_oob/0,
           user:hl_nth1_first/0, user:hl_nth1_oob/0,
           user:hl_select_mid/0, user:hl_select_no/0, user:hl_select_one/0,
+          user:hl_select_dup_all/0, user:hl_select_var_all/0,
+          user:hl_select_bound_rest/0,
           user:hl_del_all/0, user:hl_del_none/0,
           user:hl_succ_fwd/0, user:hl_succ_back/0, user:hl_succ_zero/0,
           user:hl_succ_neg/0 ],
@@ -1242,7 +1253,8 @@ e2e_higherorder_listutil_via_rscript :-
            hl_maplist3_succ, hl_maplist3_build,
            hl_cmp_lt, hl_cmp_eq, hl_cmp_gt,
            hl_nth0_first, hl_nth0_last, hl_nth1_first,
-           hl_select_mid, hl_select_one,
+           hl_select_mid, hl_select_one, hl_select_dup_all,
+           hl_select_var_all, hl_select_bound_rest,
            hl_del_all, hl_del_none,
            hl_succ_fwd, hl_succ_back, hl_succ_zero],
     No  = [hl_maplist_int_n, hl_maplist3_n,


### PR DESCRIPTION
## Summary

- Adds multi-solution WAM-R support for `select/3`.
- Replaces deterministic first-match behavior with an iterator that enumerates each removable list position on backtracking.
- Preserves bound `Rest` filtering.
- Adds Rscript e2e coverage for duplicate alternatives, variable selection, and bound-rest selection.
- Updates WAM-R docs to describe `select/3` as multi-solution over list positions.

## Details

`select/3` now follows the usual Prolog shape for finite list selection:

```prolog
findall(X-Rest, select(X, [a,b,a], Rest), Pairs)
```

returns:

```prolog
[a-[b,a], b-[a,a], a-[a,b]]
```

The implementation uses the existing iter choice-point pattern so later alternatives resume through normal backtracking.

## Verification

- `swipl -g "run_tests([wam_r_generator:higherorder_listutil_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
- `swipl -g "run_tests([wam_r_generator:higherorder_listutil_e2e_rscript,wam_r_generator:list_atom_builtins_e2e_rscript,wam_r_generator:findall_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
- `git diff --check`
