### PR TITLE
fix(wam): self-init put_variable for findall template var

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -732,6 +732,7 @@ Coverage map (e2e tests, by feature group):
 | `streams_multiline_read_e2e_rscript` | `read/2` across multi-line clauses: buffer accumulates lines until trimmed buffer ends with `.` and parser accepts |
 | `fact_table_e2e_rscript` | fact-table lowering: hash-indexed dispatch, multi-solution backtracking, atoms + integers |
 | `fact_in_range_e2e_rscript` | `fact_in_range/5` range query on fact tables (sorted-arg index + binary search + iter-CP), inclusive bounds, atom-only column = fail, out-of-range ArgPos = fail |
+| `findall_template_in_struct_arg_e2e_rscript` | findall template var initialised via `put_variable Y, Y` self-init so a later `put_structure` on A1 (when the inner goal's first arg is a compound) doesn't auto-bind a shared ref into the template |
 | `fact_table_multi_arg_index_e2e_rscript` | per-arg fact-table indexes: dispatch picks smallest matching bucket among bound atom/int args (arg2-only, arg3-only, multi-arg-bound queries) |
 | `kernel_tc2_e2e_rscript` | recursive-kernel detection: `transitive_closure2` BFS over a fact-table edge predicate |
 | `kernel_td3_e2e_rscript` | recursive-kernel detection: `transitive_distance3` BFS-with-depth over a fact-table edge predicate |

--- a/docs/handoff/wam_r_session_handoff.md
+++ b/docs/handoff/wam_r_session_handoff.md
@@ -235,26 +235,20 @@ roughly priority order:
    `p(X, Y), X >= Lo, X =< Hi` automatically). Covered by
    `fact_in_range_e2e_rscript`.
 
-8. **Compiler bug: `PutVariable(Yn, Ai)` + later `PutStructure(_,
-   Ai, _)` leaks the template var.** Surfaced while writing the
-   `fact_in_range/5` test. When the WAM compiler emits
-   `PutVariable(201, 1)` to initialize a permanent var (e.g. the
-   template of a `findall`) into both Y1 and A1, then later builds
-   a call whose first arg is a compound (e.g. `price/2`) via
-   `PutStructure(_, 1, _)`, the build's auto-bind logic in
-   `append_build_arg` sees A1's value is the shared unbound and
-   binds it to the new struct. Y1 (which shared that unbound)
-   transitively dereferences to the struct, so the user's template
-   var is silently bound to the call's first arg. Repro:
-   `findall(X, fact_in_range(p/2, 2, 5, 10, [X, _]), L)` -- X is
-   the template but X never appears as a direct arg of the call,
-   so `PutVariable` sharing was inappropriate. Fix is in the
-   compiler: don't share Y/A registers when the next call's first
-   arg is a constructed compound, or rebuild the shared unbound
-   before the PutStructure. Workaround for users: drive the
-   accumulator with assertz + fail-driven loops instead of
-   findall when the template appears inside a struct arg of the
-   inner goal.
+8. ~~**Compiler bug: `PutVariable(Yn, Ai)` + later `PutStructure(_,
+   Ai, _)` leaks the template var.**~~ *Done.* The fix is in
+   `compile_aggregate_all` (which handles `findall` /
+   `aggregate_all` template-var initialization): the
+   `put_variable Y_n, A1` emission for the var-template branch is
+   now `put_variable Y_n, Y_n` (self-init, no A-register sharing).
+   The compound-template branch already used the self-init pattern,
+   so it was unaffected. The inner goal's compilation emits
+   `put_value Y_n, A_k` when the template var IS a direct call arg
+   (e.g. `findall(X, member(X, [1,2,3]), L)`), so cases that don't
+   have the struct-first-arg conflict are unchanged. Covered by
+   `findall_template_in_struct_arg_e2e_rscript` with three sub-
+   tests: template inside list arg, template inside compound arg,
+   and the sanity case where the template IS a direct call arg.
 
 9. **Phase-3 lowered emitter expansion.** Currently handles only
    `deterministic` and `multi_clause_1` shapes. Could grow N-clause

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -781,8 +781,21 @@ compile_aggregate_all(Template, InnerGoal, Result, V0, Vf, Code) :-
     (   var(ValueVar)
     ->  % ValueVar is a Prolog variable — allocate a Y-register for it
         allocate_var(ValueVar, V1, V2, ValueReg),
-        % Emit put_variable to actually create the Y-register in the env frame
-        format(string(InitValueCode), "    put_variable ~w, A1", [ValueReg]),
+        % Emit put_variable to actually create the Y-register in the env
+        % frame. Use the SELF-INIT form (put_variable Y_n, Y_n) rather
+        % than (put_variable Y_n, A1): the latter would share a fresh
+        % unbound between Y_n and A1, and if the inner goal's first
+        % arg is a constructed compound (e.g.
+        % `findall(X, fact_in_range(p/2, ..., [X,_]), L)` where A1
+        % holds `p/2`), put_structure_'s auto-bind in append_build_arg
+        % would bind the shared unbound to the new struct -- silently
+        % capturing the inner goal's first arg into the template var.
+        % Self-init avoids the A1 share entirely; the inner goal's
+        % compilation emits `put_value Y_n, A_k` when the template
+        % var IS a direct call arg, so cases that don't have the
+        % struct-first-arg conflict are unaffected.
+        format(string(InitValueCode), "    put_variable ~w, ~w",
+               [ValueReg, ValueReg]),
         ConstructionCode = ""
     ;   compound(ValueVar)
     ->  % Compound Template — `findall(p(X, Y), Goal, L)` and similar.

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -2335,6 +2335,69 @@ e2e_fact_in_range_via_rscript :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% End-to-end Rscript run for findall whose template var appears
+% inside a struct arg of the inner goal. Prior to the put_variable
+% self-init fix in compile_aggregate_all, the compiler emitted
+% `put_variable Y_template, A1` -- sharing a fresh unbound between
+% the Y register and A1. When the inner goal's first arg was then
+% built as a compound (e.g. `p/2`), append_build_arg's auto-bind
+% logic bound the shared unbound to the new struct, silently
+% capturing the inner goal's first arg into the template var.
+% Now put_variable self-inits (put_variable Y, Y) so A1 is left
+% untouched until the call's arg construction.
+%
+% Three sub-tests:
+%   - template inside list arg: findall(X, p(.../2, ..., [X, _]), L)
+%   - template inside a compound arg: findall(Y, q(f(Y)), L)
+%   - sanity: template as a direct call arg still works (member/2)
+% Auto-skips when Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(findall_template_in_struct_arg_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_findall_template_in_struct_arg_via_rscript
+    ;   true
+    )).
+
+e2e_findall_template_in_struct_arg_via_rscript :-
+    % t_list: template inside a list arg of fact_in_range.
+    assertz(user:tprice(apple,  5)),
+    assertz(user:tprice(banana, 8)),
+    assertz(user:tprice(cherry, 12)),
+    assertz((user:t_list :-
+        findall(Item,
+                fact_in_range(tprice/2, 2, 5, 10, [Item, _P]),
+                L),
+        L == [apple, banana])),
+    % t_compound: template inside a compound (non-list) arg.
+    % Defines q/1 dynamically so the inner goal compiles as a Call
+    % whose first arg is built via put_structure.
+    assertz((user:tq(f(red)))),
+    assertz((user:tq(f(green)))),
+    assertz((user:tq(f(blue)))),
+    assertz((user:t_compound :-
+        findall(Y, tq(f(Y)), Ys),
+        Ys == [red, green, blue])),
+    % t_member: template as a direct call arg (sanity, was always OK).
+    assertz((user:t_member :-
+        findall(X, member(X, [1, 2, 3]), Xs),
+        Xs == [1, 2, 3])),
+    unique_r_tmp_dir('tmp_r_findall_struct_e2e', TmpDir),
+    write_wam_r_project(
+        [user:tprice/2, user:tq/1, user:t_list/0, user:t_compound/0,
+         user:t_member/0],
+        [intern_atoms([apple, banana, cherry, red, green, blue, f])],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    Yes = [t_list, t_compound, t_member],
+    forall(member(P, Yes), (
+        format(string(Q), '~w/0', [P]),
+        run_rscript_query(RDir, Q, Out),
+        assertion(sub_string(Out, _, _, _, "true"))
+    )),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % End-to-end Rscript run for `^/2` existential scope and first
 % free-variable grouping in bagof/setof. Asserts 2-arg dynamic
 % predicates, then drives bagof(X, Y^p(X,Y), L) and


### PR DESCRIPTION
## Summary

Closes handoff item #8 (filed in the previous PR).

`compile_aggregate_all`'s var-template branch (which handles `findall(Var, Goal, Result)` / `aggregate_all(Var, Goal, Result)`) was emitting `put_variable Y_n, A1` to initialize the template's permanent var. This shared a fresh unbound between Y_n and A1.

When the inner goal's first arg was then built as a compound (e.g. `findall(X, fact_in_range(p/2, ..., [X, _]), L)` where A1 holds `p/2`), `put_structure`'s auto-bind in `append_build_arg` saw A1's value was the shared unbound and bound it to the new struct -- silently capturing the inner goal's first arg into the template var. So `findall` would return `[p/2, p/2, ...]` or similar garbage rather than the intended template solutions.

**Fix**: emit `put_variable Y_n, Y_n` (self-init, no A-register share) matching the pattern already used by the compound-template branch (`compile_template_arg_init`). The inner goal's compilation emits `put_value Y_n, A_k` when the template var IS a direct call arg (e.g. `findall(X, member(X, [1,2,3]), L)`), so existing non-conflicting cases are unchanged.

## Test plan

New e2e test `findall_template_in_struct_arg_e2e_rscript` with three sub-tests:
- `t_list`: template inside a list arg (`fact_in_range(p/2, ..., [X, _])`).
- `t_compound`: template inside a compound (non-list) arg (`tq(f(Y))`).
- `t_member`: sanity for the always-worked case where the template is a direct call arg (`member(X, [1,2,3])`).

- [x] New test passes in isolation
- [x] Full WAM-R suite (`swipl -g '[tests/test_wam_r_generator], run_tests' -t halt`) -- 75/75 passing (was 74)
- [x] Re-verified the original `fact_in_range_e2e_rscript` and other findall-using tests still pass

## Scope

This is a fix in shared WAM-front-end code (`src/unifyweaver/targets/wam_target.pl`), so it benefits all WAM targets (R / Scala / Haskell / etc.). The new test runs through the R backend specifically.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_