### PR TITLE
fix(wam-haskell): footprint guard in cache_strategy resolver

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -3126,6 +3126,13 @@ resolve_auto_demand_bfs_mode(Options, Mode) :-
 %    cost_model says `scan` → demand_bfs_mode(in_memory)
 %      (pre-load IntMap = sequential scan pattern)
 %
+%  Footprint guard: when the cost model recommends `scan` but
+%  `W > R_free`, the in_memory implementation would materialise an
+%  IntMap larger than available RAM. The guard overrides the
+%  recommendation to `cursor` in that case. Phase L#11 (Phase 2c
+%  validation) surfaced this gap; the cost model decides access
+%  patterns but says nothing about working-set footprint.
+%
 %  Composes with `resolve_auto_demand_bfs_mode/2`: this resolver
 %  replaces any existing `demand_bfs_mode/1` term, so the downstream
 %  resolver sees a concrete value and is a no-op.
@@ -3160,14 +3167,32 @@ compute_cache_strategy_decision(Options, BfsMode) :-
     ),
     option(cost_model_constants(Constants), Options, []),
     recommend_access_pattern(KKeys, WBytes, RFree, Constants, Pattern),
+    %% Footprint guard: cost_model decides between sort/scan access
+    %% patterns, but our `in_memory` implementation materialises the
+    %% full edge IntMap (working-set bytes resident in RAM). When
+    %% R_free < W the IntMap allocation would blow the available
+    %% memory budget — even though the model considers in_memory the
+    %% cheaper access pattern, we can't actually run it. Override to
+    %% cursor in that case. Documented in Phase L appendix #11
+    %% (the cold-regime probe that surfaced this).
     (   Pattern = sort
-    ->  BfsMode = cursor
-    ;   BfsMode = in_memory
+    ->  BfsMode = cursor,
+        Override = none
+    ;   WBytes > RFree
+    ->  BfsMode = cursor,
+        Override = footprint_guard
+    ;   BfsMode = in_memory,
+        Override = none
     ),
     (   option(cache_strategy_verbose(true), Options)
-    ->  format(user_error,
-               '[WAM-Haskell] cache_strategy(auto): K=~w W=~w R_free=~w → ~w (~w)~n',
-               [KKeys, WBytes, RFree, Pattern, BfsMode])
+    ->  (   Override == footprint_guard
+        ->  format(user_error,
+                   '[WAM-Haskell] cache_strategy(auto): K=~w W=~w R_free=~w → ~w (cursor, footprint guard: W > R_free)~n',
+                   [KKeys, WBytes, RFree, Pattern])
+        ;   format(user_error,
+                   '[WAM-Haskell] cache_strategy(auto): K=~w W=~w R_free=~w → ~w (~w)~n',
+                   [KKeys, WBytes, RFree, Pattern, BfsMode])
+        )
     ;   true
     ).
 

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -1965,6 +1965,46 @@ test_cache_strategy_auto_overrides_explicit_demand_bfs_mode :-
     ;   fail_test(Test, 'cache_strategy auto did not override explicit demand_bfs_mode')
     ).
 
+test_cache_strategy_footprint_guard_overrides_in_memory :-
+    %% Cold-regime case: cost_model would recommend scan → in_memory
+    %% (high selection ratio), but R_free < W means the in_memory
+    %% IntMap can't actually fit. Guard must override to cursor.
+    %% Inputs: 9.9M facts × 50 bytes/edge = 495 MB; wsf=0.05 → K=495k;
+    %% R_free=125 MB; K_cross at f_hot=0.25 ≈ 4k → scan picked first,
+    %% then footprint guard kicks in because 495 MB > 125 MB.
+    Test = 'WAM-Haskell: cache_strategy(auto) footprint guard overrides in_memory when W > R_free',
+    (   wam_haskell_target:resolve_auto_cache_strategy(
+            [cache_strategy(auto),
+             fact_count(9900000),
+             working_set_fraction(0.05),
+             db_size_bytes(495000000),
+             mem_available_bytes(125000000)],
+            R),
+        memberchk(demand_bfs_mode(cursor), R),
+        \+ memberchk(demand_bfs_mode(in_memory), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'footprint guard did not override in_memory when R_free < W')
+    ).
+
+test_cache_strategy_footprint_guard_inactive_in_hot_regime :-
+    %% Hot regime: cost_model recommends scan → in_memory and the
+    %% working set fits. Guard must NOT fire — in_memory stays.
+    %% 297k facts × 50 = 15 MB DB; wsf=0.5 → K=148k; R_free=16 GB
+    %% (W << R_free). K well above K_cross → scan → in_memory; guard
+    %% inactive because 15 MB < 16 GB.
+    Test = 'WAM-Haskell: cache_strategy(auto) footprint guard does NOT fire when W <= R_free',
+    (   wam_haskell_target:resolve_auto_cache_strategy(
+            [cache_strategy(auto),
+             fact_count(297000),
+             working_set_fraction(0.5),
+             db_size_bytes(15000000),
+             mem_available_bytes(16000000000)],
+            R),
+        memberchk(demand_bfs_mode(in_memory), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'footprint guard incorrectly fired in hot regime')
+    ).
+
 test_b1_lmdb_dupsort_per_thread_cursor :-
     Test = 'B1: dupsort layout uses per-thread cursor cache',
     (   compile_wam_runtime_to_haskell(
@@ -2396,6 +2436,8 @@ run_tests :-
     test_cache_strategy_auto_tiny_selection_picks_cursor,
     test_cache_strategy_absent_leaves_options_unchanged,
     test_cache_strategy_auto_overrides_explicit_demand_bfs_mode,
+    test_cache_strategy_footprint_guard_overrides_in_memory,
+    test_cache_strategy_footprint_guard_inactive_in_hot_regime,
     format('~n========================================~n'),
     (   test_failed
     ->  format('Tests FAILED~n'), halt(1)


### PR DESCRIPTION
  ## Summary

  Closes the gap surfaced by Phase L#11 (PR #1999). The cost model
  decides between sort/scan access patterns based on K, W, R_free,
  and the hardware constants — it says nothing about working-set
  footprint. Our `in_memory` implementation, though, materialises the
  full edge IntMap (~W bytes resident in RAM). When `R_free < W` the
  IntMap can't actually fit; the model's `scan → in_memory`
  recommendation is correct about access pattern but wrong about
  feasibility.

  ## What changed

  `src/unifyweaver/targets/wam_haskell_target.pl` —
  `compute_cache_strategy_decision/2` now applies a footprint guard:
  when the cost-model recommendation is `scan` (→ `in_memory`) AND
  `W > R_free`, override to `cursor`. Cursor BFS reads only the edges
  the query visits via mmap'd LMDB pages, with no IntMap allocation,
  so it works regardless of working-set vs RAM ratio.

  ## Verbose trace

  Guard-driven overrides are explicit:

  [WAM-Haskell] cache_strategy(auto): K=495000 W=495000000
    R_free=125000000 → scan (cursor, footprint guard: W > R_free)

  Normal case:

  [WAM-Haskell] cache_strategy(auto): K=14850 W=14850000
    R_free=16000000000 → scan (in_memory)

  ## Tests

  Two new tests in `tests/test_wam_haskell_target.pl`:

  - `test_cache_strategy_footprint_guard_overrides_in_memory` —
    cold-regime case: K above K_cross AND W > R_free → cursor.
    Pins the guard's positive branch.
  - `test_cache_strategy_footprint_guard_inactive_in_hot_regime` —
    hot-regime case: K above K_cross AND W ≤ R_free → in_memory.
    Pins that the guard doesn't over-fire and break the normal path.

  ## Verification

  - `tests/test_wam_haskell_target.pl`: **155/155** (153 existing + 2 new)
  - `tests/core/test_cost_model.pl`: **21/21** unchanged

  ## What this unblocks

  `resident_auto` is now correct at all scales, not just the hot
  regime. Article-level Wikipedia data (~250 GB uncompressed, well
  above any consumer machine's free RAM) will route through cursor
  correctly when it lands. The cost-model resolver becomes safe to
  make a default for new bench modes — previously it could recommend
  an allocation that crashes.

  ## Files

  - `src/unifyweaver/targets/wam_haskell_target.pl` (+30, -5)
  - `tests/test_wam_haskell_target.pl` (+42)