### PR TITLE
feat(wam-haskell): lmdb_cache_mode auto-resolver + composition + docs

### DIFF
--- a/docs/design/CACHE_COST_MODEL_PHILOSOPHY.md
+++ b/docs/design/CACHE_COST_MODEL_PHILOSOPHY.md
@@ -174,10 +174,76 @@ share:
 - **User override is always available**. The model is a default
   picker, not a gatekeeper.
 
-Phase 2c will add a fourth resolver, `resolve_auto_cache_strategy/2`,
-that uses `cost_model.pl` as its decision engine. That resolver is
-not built yet — it needs the workload-metadata channel (`K_query`,
-`M`, `X_query`) plumbed through the codegen pipeline first.
+Phase 2c added `resolve_auto_cache_strategy/2` as the fourth
+resolver. It uses `cost_model.pl` to decide between cursor and
+in-memory demand BFS via the workload-metadata channel. A
+footprint guard (Phase L#11 follow-up) overrides `in_memory` →
+`cursor` when `R_free < W`.
+
+Phase 2c+ added a fifth resolver, `resolve_auto_lmdb_cache_mode/2`,
+covered in the next section.
+
+## The `lmdb_cache_mode` auto-resolver
+
+`resolve_auto_cache_strategy/2` picks the *access pattern*
+(cursor vs in-memory). `resolve_auto_lmdb_cache_mode/2` picks the
+*cache tier* on top of that. The two compose.
+
+### Inputs
+
+| input | source | purpose |
+|---|---|---|
+| `lmdb_cache_mode(auto)` | option | triggers resolution |
+| `workload_locality(L)` | option (opt-in signal) | tier choice — `L ∈ {intra_thread, cross_thread, mixed, unknown}` |
+| `expected_query_count(M)` | option | reused from cost_model channel; whether caching pays off |
+| `demand_bfs_mode/1` | already-resolved by cache_strategy | composition: `in_memory` → no cache |
+
+The opt-in signal is `workload_locality/1`. Without it, the new
+resolver is a no-op and the existing in-place auto resolution
+(`statistics:select_cache_mode/2` consulted in
+`generate_lmdb_functions/2`) handles `lmdb_cache_mode(auto)`. This
+preserves backwards compatibility for callers using the older
+`statistics:declare_cache_hints/1` channel.
+
+### Decision matrix
+
+| condition | pick | rationale |
+|---|---|---|
+| `demand_bfs_mode = in_memory` | `none` | the edge IntMap *is* the cache; another tier is redundant |
+| `M = 1` | `none` | nothing to amortise the cache fill against |
+| `M > 1` and `intra_thread` | `per_hec` (L1) | per-HEC L1 wins when sparks have region affinity |
+| `M > 1` and `cross_thread` | `sharded` (L2) | single shared cache, mild contention, captures inter-thread hits |
+| `M > 10` and `mixed` | `two_level` (L1+L2) | both intra- and inter-thread locality |
+| `M > 1` and (`mixed` with low M, or `unknown`) | `sharded` (L2) | safe default |
+
+### Why the `unknown → sharded` default
+
+Mirrors the conventional wisdom documented in the matrix bench:
+per-HEC L1 caches duplicate hot edges across threads when sparks
+have no region affinity (parMap-scheduled). Until MoE-style spark
+routing lands, L1 is dominated by sharded L2 in the unknown-
+locality case.
+
+### Composition with `cache_strategy(auto)`
+
+The two resolvers run in order: `cache_strategy(auto)` first
+(picks cursor or in_memory), then `lmdb_cache_mode(auto)` reads
+the result. The composition rule "in_memory → none cache tier"
+is the key piece of information they share — it's what lets one
+opt-in (`workload_locality(unknown)` + `cache_strategy(auto)`)
+produce a self-consistent end-to-end decision.
+
+### What this isn't doing (yet)
+
+- **No memory-budget guard on the cache itself.** Tier choice is
+  based on quantity and locality, not on whether the cache size
+  fits after the working set is accounted for. `lmdb_cache_l2_capacity_bytes`
+  lets users override the L2 size manually; an automatic floor
+  ("`R_free - W_working < N MB` → fall back to `none`") is a
+  follow-up.
+- **No automatic locality inference.** `workload_locality(...)`
+  comes from the workload author. Inferring it from purity
+  analysis or kernel metadata is research-y and deferred.
 
 ## What this isn't
 
@@ -196,9 +262,14 @@ not built yet — it needs the workload-metadata channel (`K_query`,
 ## See also
 
 - `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` — Phase M appendix #10
-  (measurements that motivate the formula).
+  (measurements that motivate the formula), Phase L#11 (the
+  matrix-bench validation that surfaced the footprint-guard gap),
+  and the resolvers' usage notes.
 - `examples/benchmark/cache_warming_microbench/` — the M1/M1.b/M2/M3
   microbench that produced those measurements.
 - `src/unifyweaver/core/cost_model.pl` — the formula implementation.
 - `tests/core/test_cost_model.pl` — unit tests for the predicates
   with the simplewiki/enwiki crossover values from this document.
+- `src/unifyweaver/targets/wam_haskell_target.pl` —
+  `resolve_auto_cache_strategy/2` and `resolve_auto_lmdb_cache_mode/2`
+  (the Phase 2c/2c+ resolvers).

--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -3714,4 +3714,88 @@ The cost model has now been exercised end-to-end on real
 fixtures; future warming and `lmdb_cache_mode` resolvers can
 build on the same channel.
 
+## Phase L appendix #12: `lmdb_cache_mode(auto)` resolver wiring (2026-05-10)
+
+### What landed
+
+`resolve_auto_lmdb_cache_mode/2` in `wam_haskell_target.pl`. Picks
+`none` / `per_hec` / `sharded` / `two_level` from
+`expected_query_count`, `workload_locality(...)`, and the already-
+resolved `demand_bfs_mode/1`. Opt-in signal is presence of
+`workload_locality/1`; without it, the existing in-place
+resolution (via `statistics:select_cache_mode/2`) continues to
+handle the auto path.
+
+Decision matrix mirrors the philosophy doc:
+
+| M    | locality        | pick      |
+|---|---|---|
+| ≤ 1  | *               | none      |
+| > 1  | intra_thread    | per_hec   |
+| > 1  | cross_thread    | sharded   |
+| > 10 | mixed           | two_level |
+| > 1  | mixed (low M)   | sharded   |
+| > 1  | unknown         | sharded   |
+| (any) | * + in_memory  | none (composition rule) |
+
+The `unknown → sharded` default is the same call the matrix bench
+has been making by hand since Phase L#5 — now explicit and
+overridable per-workload.
+
+### Matrix-bench `resident_auto` update
+
+The mode previously hardcoded `lmdb_cache_mode(sharded)` and
+`expected_query_count(1)`. Both are replaced with:
+
+```prolog
+expected_query_count(10),  % bench runs many parMap-driven queries
+lmdb_cache_mode(auto),
+workload_locality(unknown)
+```
+
+Smoke run at 1k confirms both resolvers fire:
+
+```
+[WAM-Haskell] cache_strategy(auto): K=6 W=296650 R_free=3653779456 → sort (cursor)
+[WAM-Haskell] lmdb_cache_mode(auto) → sharded (default_safe)
+```
+
+The picks match the previous hardcoded values exactly, so this is
+a behaviour-preserving refactor for the matrix bench. The
+benefit is that workload authors can now override locality via
+`workload_locality(intra_thread)` etc. without touching the bench
+generator.
+
+### Tests
+
+9 new tests in `tests/test_wam_haskell_target.pl`:
+
+- `intra_thread + M > 1 → per_hec`
+- `cross_thread + M > 1 → sharded`
+- `mixed + M > 10 → two_level`
+- `mixed + M ≤ 10 → sharded (low-M fallback)`
+- `unknown → sharded (safe default)`
+- `M = 1 → none (no amortisation)`
+- `composition: in_memory → none`
+- `no-op without workload_locality`
+- `explicit lmdb_cache_mode flows through unchanged`
+
+All 164 WAM-Haskell tests pass (155 existing + 9 new); 21
+cost_model tests unchanged.
+
+### Open follow-ups
+
+- **Memory budget guard on the cache layer itself.** The footprint
+  guard from Phase L#11 covers the working set (`R_free < W` →
+  cursor). The cache tier doesn't have an analogous guard yet:
+  when `R_free - W_working < L2_capacity_floor` the L2 cache
+  would thrash. Filed for a follow-up.
+- **Automatic locality inference.** `workload_locality(...)` is
+  authored by hand. Could be derived from kernel metadata
+  (purity certificate, parMap usage). Research-y.
+- **At-scale empirical validation.** The fixtures from Phase L#7–9
+  were swept in the workspace reset; re-validating the resolvers'
+  picks against measured wall-clock numbers needs them re-ingested.
+  Filed.
+
 

--- a/examples/benchmark/generate_wam_haskell_matrix_benchmark.pl
+++ b/examples/benchmark/generate_wam_haskell_matrix_benchmark.pl
@@ -175,7 +175,12 @@ parse_lmdb_mode(resident_auto, [
     int_atom_seeds(lmdb),
     cache_strategy(auto),
     cache_strategy_verbose(true),
-    expected_query_count(1),
+    %% expected_query_count: the matrix bench runs many parMap-driven
+    %% query expansions per binary invocation (seed × root × sweep).
+    %% Set to 10 as a reasonable lower bound so the lmdb_cache_mode
+    %% auto-resolver picks a tier rather than `none`. Workloads with
+    %% genuinely 1-shot queries can override to 1.
+    expected_query_count(10),
     %% BFS demand-set workloads (matrix bench's effective-distance
     %% kernel) touch a tiny fraction of total edges per query.
     %% Empirically (Phase L appendix #7): the simplewiki Physics root
@@ -186,7 +191,12 @@ parse_lmdb_mode(resident_auto, [
     %% right shape for many-keys-per-query lookups; for BFS-style
     %% reachability it's two orders of magnitude too high.
     working_set_fraction(0.001),
-    lmdb_cache_mode(sharded)
+    %% Let the lmdb_cache_mode auto-resolver pick the tier. `unknown`
+    %% locality (the safe default) routes to `sharded` (L2), which is
+    %% the existing hardcode we're replacing — but now the choice is
+    %% explicit and overridable per-workload via workload_locality/1.
+    lmdb_cache_mode(auto),
+    workload_locality(unknown)
 ]).
 
 parse_variant(seeded, [

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2579,7 +2579,13 @@ write_wam_haskell_project(Predicates, Options0, ProjectDir) :-
     % Phase 2c: resolve cache_strategy(auto) into a concrete
     % demand_bfs_mode/1 via cost_model:recommend_access_pattern/5.
     % No-op when cache_strategy(auto) is absent.
-    resolve_auto_cache_strategy(Options1, Options),
+    resolve_auto_cache_strategy(Options1, Options2),
+    % Phase 2c+: resolve lmdb_cache_mode(auto) into a concrete tier
+    % (none/per_hec/sharded/two_level) when workload_locality/1 is
+    % set. Composes with the cache_strategy decision above: in_memory
+    % → none. No-op when workload_locality is absent (the in-place
+    % auto resolver in generate_lmdb_functions/2 then takes over).
+    resolve_auto_lmdb_cache_mode(Options2, Options),
 
     % Initialize the compile-time atom intern table with well-known atoms
     init_atom_intern_table,
@@ -3196,6 +3202,88 @@ compute_cache_strategy_decision(Options, BfsMode) :-
     ;   true
     ).
 
+%% resolve_auto_lmdb_cache_mode(+Options0, -Options) is det.
+%
+%  Phase 2c+ opt-in resolver for `lmdb_cache_mode(auto)`. Decides
+%  between `none` / `per_hec` (L1) / `sharded` (L2) / `two_level`
+%  (L1+L2) from workload metadata.
+%
+%  Opt-in signal: presence of `workload_locality/1` in Options. Without
+%  it, this resolver is a no-op and the existing in-place resolution
+%  in `generate_lmdb_functions/2` (via
+%  `statistics:select_cache_mode/2`) continues to handle the auto
+%  path. With it, the new resolver runs and the in-place path becomes
+%  a no-op because `lmdb_cache_mode(auto)` has already been replaced
+%  with a concrete value.
+%
+%  Inputs:
+%
+%    - `lmdb_cache_mode(auto)`         — triggers resolution
+%    - `workload_locality(L)`          — opt-in signal; L ∈
+%                                        {intra_thread, cross_thread,
+%                                         mixed, unknown}
+%    - `expected_query_count(M)`       — defaults to 1
+%    - `demand_bfs_mode/1`             — read to compose with
+%                                        cache_strategy resolver
+%    - `cache_strategy_verbose(true)`  — stderr trace of decision
+%
+%  Composition with `resolve_auto_cache_strategy/2`:
+%
+%    If the cache_strategy resolver already picked `in_memory`, the
+%    edge IntMap *is* the cache and adding another tier is redundant.
+%    Pick `none` in that case regardless of locality / M.
+%
+%  Decision matrix for the cursor path:
+%
+%    M = 1                          → none      (no queries to amortise over)
+%    M > 1 & intra_thread          → per_hec   (L1)
+%    M > 1 & cross_thread          → sharded   (L2)
+%    M > 10 & mixed                → two_level (L1+L2)
+%    M > 1 & (mixed but M ≤ 10)    → sharded   (safe default)
+%    M > 1 & unknown               → sharded   (safe default;
+%                                                matches the existing
+%                                                resident_auto hardcode)
+%
+%  The `unknown → sharded` default mirrors the conventional wisdom
+%  documented in the matrix-bench: per-HEC L1 caches duplicate hot
+%  edges across threads when sparks have no region affinity, so until
+%  MoE-style spark routing lands, sharded is the right floor.
+%
+%  See docs/design/CACHE_COST_MODEL_PHILOSOPHY.md (decision-matrix
+%  section).
+resolve_auto_lmdb_cache_mode(Options0, Options) :-
+    (   option(lmdb_cache_mode(auto), Options0),
+        memberchk(workload_locality(_), Options0)
+    ->  compute_lmdb_cache_mode_decision(Options0, Mode),
+        select(lmdb_cache_mode(auto), Options0, Rest),
+        Options = [lmdb_cache_mode(Mode) | Rest]
+    ;   Options = Options0
+    ).
+
+compute_lmdb_cache_mode_decision(Options, Mode) :-
+    (   option(demand_bfs_mode(in_memory), Options)
+    ->  Mode = none,
+        Reason = in_memory_path
+    ;   option(expected_query_count(M), Options, 1),
+        option(workload_locality(Locality), Options, unknown),
+        (   M =< 1
+        ->  Mode = none, Reason = m_too_small
+        ;   Locality == intra_thread
+        ->  Mode = per_hec, Reason = intra_thread
+        ;   Locality == cross_thread
+        ->  Mode = sharded, Reason = cross_thread
+        ;   Locality == mixed, M > 10
+        ->  Mode = two_level, Reason = mixed
+        ;   Mode = sharded, Reason = default_safe
+        )
+    ),
+    (   option(cache_strategy_verbose(true), Options)
+    ->  format(user_error,
+               '[WAM-Haskell] lmdb_cache_mode(auto) → ~w (~w)~n',
+               [Mode, Reason])
+    ;   true
+    ).
+
 %% resolve_demand_filter_spec(+Options, -SpecHs)
 %  Pick the DemandFilterSpec literal to emit into Main.hs.
 %  Precedence:
@@ -3354,7 +3442,10 @@ compile_wam_runtime_to_haskell(Options0, DetectedKernels, Code) :-
     % Phase 2c: resolve cache_strategy(auto) into a concrete
     % demand_bfs_mode/1 BEFORE downstream code consults it. No-op
     % when the option is absent.
-    resolve_auto_cache_strategy(Options0, Options),
+    resolve_auto_cache_strategy(Options0, Options1),
+    % Phase 2c+: resolve lmdb_cache_mode(auto) → concrete tier.
+    % No-op when workload_locality/1 is absent.
+    resolve_auto_lmdb_cache_mode(Options1, Options),
     step_function_haskell(StepCode),
     backtrack_haskell(BacktrackCodeTemplate),
     run_loop_haskell(RunCode),

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -2005,6 +2005,129 @@ test_cache_strategy_footprint_guard_inactive_in_hot_regime :-
     ;   fail_test(Test, 'footprint guard incorrectly fired in hot regime')
     ).
 
+%% =================================================================
+%% lmdb_cache_mode(auto) resolver (Phase 2c+)
+%% =================================================================
+
+test_lmdb_cache_mode_auto_intra_thread_picks_per_hec :-
+    Test = 'WAM-Haskell: lmdb_cache_mode(auto) + intra_thread → per_hec',
+    (   wam_haskell_target:resolve_auto_lmdb_cache_mode(
+            [lmdb_cache_mode(auto),
+             workload_locality(intra_thread),
+             expected_query_count(10)],
+            R),
+        memberchk(lmdb_cache_mode(per_hec), R),
+        \+ memberchk(lmdb_cache_mode(auto), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'intra_thread did not resolve to per_hec')
+    ).
+
+test_lmdb_cache_mode_auto_cross_thread_picks_sharded :-
+    Test = 'WAM-Haskell: lmdb_cache_mode(auto) + cross_thread → sharded',
+    (   wam_haskell_target:resolve_auto_lmdb_cache_mode(
+            [lmdb_cache_mode(auto),
+             workload_locality(cross_thread),
+             expected_query_count(10)],
+            R),
+        memberchk(lmdb_cache_mode(sharded), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'cross_thread did not resolve to sharded')
+    ).
+
+test_lmdb_cache_mode_auto_mixed_high_m_picks_two_level :-
+    Test = 'WAM-Haskell: lmdb_cache_mode(auto) + mixed + M>10 → two_level',
+    (   wam_haskell_target:resolve_auto_lmdb_cache_mode(
+            [lmdb_cache_mode(auto),
+             workload_locality(mixed),
+             expected_query_count(100)],
+            R),
+        memberchk(lmdb_cache_mode(two_level), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'mixed + high M did not resolve to two_level')
+    ).
+
+test_lmdb_cache_mode_auto_mixed_low_m_picks_sharded :-
+    Test = 'WAM-Haskell: lmdb_cache_mode(auto) + mixed + M<=10 → sharded (safe default)',
+    (   wam_haskell_target:resolve_auto_lmdb_cache_mode(
+            [lmdb_cache_mode(auto),
+             workload_locality(mixed),
+             expected_query_count(5)],
+            R),
+        memberchk(lmdb_cache_mode(sharded), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'mixed + low M did not fall back to sharded')
+    ).
+
+test_lmdb_cache_mode_auto_unknown_picks_sharded :-
+    Test = 'WAM-Haskell: lmdb_cache_mode(auto) + unknown → sharded (safe default)',
+    (   wam_haskell_target:resolve_auto_lmdb_cache_mode(
+            [lmdb_cache_mode(auto),
+             workload_locality(unknown),
+             expected_query_count(10)],
+            R),
+        memberchk(lmdb_cache_mode(sharded), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'unknown did not resolve to sharded')
+    ).
+
+test_lmdb_cache_mode_auto_m_le_one_picks_none :-
+    Test = 'WAM-Haskell: lmdb_cache_mode(auto) + M=1 → none (nothing to amortise)',
+    (   wam_haskell_target:resolve_auto_lmdb_cache_mode(
+            [lmdb_cache_mode(auto),
+             workload_locality(cross_thread),
+             expected_query_count(1)],
+            R),
+        memberchk(lmdb_cache_mode(none), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'M=1 did not resolve to none')
+    ).
+
+test_lmdb_cache_mode_auto_composes_with_in_memory_bfs :-
+    %% Composition with cache_strategy: when demand_bfs_mode is already
+    %% in_memory (the IntMap *is* the cache), adding a tier is redundant.
+    %% Pick none regardless of locality/M.
+    Test = 'WAM-Haskell: lmdb_cache_mode(auto) → none when demand_bfs_mode is in_memory',
+    (   wam_haskell_target:resolve_auto_lmdb_cache_mode(
+            [lmdb_cache_mode(auto),
+             workload_locality(cross_thread),
+             expected_query_count(100),
+             demand_bfs_mode(in_memory)],
+            R),
+        memberchk(lmdb_cache_mode(none), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'in_memory composition did not produce none')
+    ).
+
+test_lmdb_cache_mode_auto_no_op_without_workload_locality :-
+    %% Opt-in signal: without workload_locality/1, the new resolver is
+    %% a no-op and the existing in-place auto resolution handles it.
+    Test = 'WAM-Haskell: lmdb_cache_mode(auto) is a no-op without workload_locality',
+    (   wam_haskell_target:resolve_auto_lmdb_cache_mode(
+            [lmdb_cache_mode(auto),
+             expected_query_count(10)],
+            R),
+        memberchk(lmdb_cache_mode(auto), R),
+        \+ memberchk(lmdb_cache_mode(per_hec), R),
+        \+ memberchk(lmdb_cache_mode(sharded), R),
+        \+ memberchk(lmdb_cache_mode(two_level), R),
+        \+ memberchk(lmdb_cache_mode(none), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'no-op condition mutated Options')
+    ).
+
+test_lmdb_cache_mode_explicit_unchanged :-
+    %% Explicit lmdb_cache_mode/1 (non-auto) flows through untouched.
+    Test = 'WAM-Haskell: explicit lmdb_cache_mode flows through unchanged',
+    (   wam_haskell_target:resolve_auto_lmdb_cache_mode(
+            [lmdb_cache_mode(sharded),
+             workload_locality(intra_thread),
+             expected_query_count(10)],
+            R),
+        memberchk(lmdb_cache_mode(sharded), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'explicit lmdb_cache_mode was mutated')
+    ).
+
 test_b1_lmdb_dupsort_per_thread_cursor :-
     Test = 'B1: dupsort layout uses per-thread cursor cache',
     (   compile_wam_runtime_to_haskell(
@@ -2438,6 +2561,15 @@ run_tests :-
     test_cache_strategy_auto_overrides_explicit_demand_bfs_mode,
     test_cache_strategy_footprint_guard_overrides_in_memory,
     test_cache_strategy_footprint_guard_inactive_in_hot_regime,
+    test_lmdb_cache_mode_auto_intra_thread_picks_per_hec,
+    test_lmdb_cache_mode_auto_cross_thread_picks_sharded,
+    test_lmdb_cache_mode_auto_mixed_high_m_picks_two_level,
+    test_lmdb_cache_mode_auto_mixed_low_m_picks_sharded,
+    test_lmdb_cache_mode_auto_unknown_picks_sharded,
+    test_lmdb_cache_mode_auto_m_le_one_picks_none,
+    test_lmdb_cache_mode_auto_composes_with_in_memory_bfs,
+    test_lmdb_cache_mode_auto_no_op_without_workload_locality,
+    test_lmdb_cache_mode_explicit_unchanged,
     format('~n========================================~n'),
     (   test_failed
     ->  format('Tests FAILED~n'), halt(1)


### PR DESCRIPTION
  ## Summary

  Second cost-model resolver in the Phase 2c arc.
  `resolve_auto_lmdb_cache_mode/2` picks the cache tier
  (`none` / `per_hec` / `sharded` / `two_level`) from
  `expected_query_count`, `workload_locality(...)`, and the already-
  resolved `demand_bfs_mode/1`. Composes with `cache_strategy(auto)`
  so a single opt-in produces a self-consistent end-to-end decision.

  ## Inputs

  | input | source | purpose |
  |---|---|---|
  | `lmdb_cache_mode(auto)` | option | triggers resolution |
  | `workload_locality(L)` | option (opt-in signal) | tier choice; `L ∈ {intra_thread, cross_thread, mixed, unknown}` |
  | `expected_query_count(M)` | option | reused from cost_model channel |
  | `demand_bfs_mode/1` | resolved by cache_strategy | composition rule |

  Opt-in signal: `workload_locality/1`. Without it the resolver is
  a no-op, and the existing in-place resolution via
  `statistics:select_cache_mode/2` (older `declare_cache_hints/1`
  channel) continues to handle the auto path. Backwards-compatible.

  ## Decision matrix

  | condition | pick |
  |---|---|
  | `demand_bfs_mode = in_memory` | `none` (IntMap is the cache) |
  | `M ≤ 1` | `none` (nothing to amortise) |
  | `M > 1` + `intra_thread` | `per_hec` (L1) |
  | `M > 1` + `cross_thread` | `sharded` (L2) |
  | `M > 10` + `mixed` | `two_level` (L1+L2) |
  | `M > 1` + `mixed` (low M) or `unknown` | `sharded` (safe default) |

  The `unknown → sharded` default is the same call the matrix bench
  has been making by hand since Phase L#5 — now explicit and
  overridable per-workload.

  ## Matrix-bench `resident_auto` update

  ```diff
  -   expected_query_count(1),
  +   expected_query_count(10),   % bench runs many parMap queries
      working_set_fraction(0.001),
  -   lmdb_cache_mode(sharded)
  +   lmdb_cache_mode(auto),
  +   workload_locality(unknown)

  Smoke run at 1k confirms both resolvers fire:

  [WAM-Haskell] cache_strategy(auto): K=6 W=296650 R_free=3653779456 → sort (cursor)
  [WAM-Haskell] lmdb_cache_mode(auto) → sharded (default_safe)

  Behaviour-preserving: same cursor + sharded picks as the
  hardcoded version. Benefit: workload authors override locality
  without touching the bench generator.

  Documentation

  - docs/design/CACHE_COST_MODEL_PHILOSOPHY.md — new "The
  lmdb_cache_mode auto-resolver" section explaining inputs,
  decision matrix, composition with cache_strategy, and what
  this doesn't cover yet.
  - docs/design/WAM_PERF_OPTIMIZATION_LOG.md — Phase L appendix
  #12 with resolver wiring summary, smoke-run output, open
  follow-ups.

  Tests

  9 new tests in tests/test_wam_haskell_target.pl:

  - intra_thread + M > 1 → per_hec
  - cross_thread + M > 1 → sharded
  - mixed + M > 10 → two_level
  - mixed + M ≤ 10 → sharded (low-M fallback)
  - unknown → sharded (safe default)
  - M = 1 → none (no amortisation)
  - composition: in_memory → none
  - no-op without workload_locality
  - explicit lmdb_cache_mode flows through unchanged

  164/164 WAM-Haskell tests pass (155 existing + 9 new).
  21/21 cost_model tests unchanged.
  Smoke build at 1k with resident_auto clean.

  Open follow-ups

  1. Memory budget guard on the cache layer itself. The Phase
  L#11 footprint guard covers the working set (R_free < W →
  cursor). The cache tier has no analogous guard: when
  R_free - W_working < L2_capacity_floor the L2 cache would
  thrash. Should fall back to none.
  2. Automatic locality inference. workload_locality(...) is
  authored by hand. Could derive from kernel metadata.
  3. At-scale empirical validation. Phase L#7–9 fixtures got
  swept in the workspace reset; re-validating the resolvers'
  picks against measured wall-clock numbers needs them
  re-ingested.

  Phase 2c is now structurally complete: opt in once with
  cache_strategy(auto) + workload_locality(...) and both
  cursor/in_memory and cache-tier decisions come from the model.