### PR TITLE
bench(csharp-query): Write C# query calibration artifacts directly

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -135,7 +135,23 @@ Use `--format calibration-tsv` when refreshing
 `csharp_query_graph_source_mode_calibration.tsv`. Combined with
 `--stability-runs <n>`, it emits artifact-compatible rows whose median timing
 fields come from the independent-run stability summary instead of one noisy
-single run.
+single run. Add `--write-calibration-artifact` to write those rows directly to
+`--calibration-artifact` after validation succeeds. If the artifact already
+exists, only the selected workload/scale rows are replaced; unselected rows are
+preserved.
+
+```bash
+python examples/benchmark/benchmark_csharp_query_source_mode_sweep.py \
+  --require-idle \
+  --workloads all \
+  --scales 300,1k,5k,10k \
+  --source-modes auto,preload,artifact-prebuilt \
+  --repetitions 1 \
+  --stability-runs 3 \
+  --compare-calibration \
+  --format calibration-tsv \
+  --write-calibration-artifact
+```
 
 Mixed-scale sweeps are filtered per workload. File-backed graph workloads can
 use `dev`, `300`, `1k`, `5k`, and `10k`; generated dependency-depth workloads

--- a/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
+++ b/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
@@ -16,6 +16,7 @@ import os
 import statistics
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
@@ -157,7 +158,15 @@ def parse_args() -> argparse.Namespace:
         "--calibration-artifact",
         type=Path,
         default=CALIBRATION_ARTIFACT,
-        help="TSV calibration artifact used by --compare-calibration.",
+        help="TSV calibration artifact used by --compare-calibration and --write-calibration-artifact.",
+    )
+    parser.add_argument(
+        "--write-calibration-artifact",
+        action="store_true",
+        help=(
+            "Write the fresh calibration TSV to --calibration-artifact. "
+            "Use with --format calibration-tsv and usually --stability-runs > 1."
+        ),
     )
     parser.add_argument(
         "--timing-drift-ratio",
@@ -185,7 +194,10 @@ def parse_args() -> argparse.Namespace:
         default=1024,
         help="Minimum MemAvailable MiB required by --require-idle.",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.write_calibration_artifact and args.format != "calibration-tsv":
+        raise SystemExit("--write-calibration-artifact requires --format calibration-tsv")
+    return args
 
 
 def parse_workloads(value: str) -> list[str]:
@@ -903,14 +915,68 @@ def print_stability_markdown(summaries: list[SourceModeStabilitySummary]) -> Non
 
 
 def print_calibration_tsv(rows: list[CalibrationArtifactRow]) -> None:
-    print("workload\tscale\tobserved_best_source_mode\tcurrent_auto_resolved_source_mode\tobserved_auto_vs_best\toutput_agreement\tmedian_s_by_mode\tresolved_source_modes_by_mode\tsource_registrations_by_mode")
+    print(render_calibration_tsv(rows), end="")
+
+
+def render_calibration_tsv(rows: list[CalibrationArtifactRow]) -> str:
+    lines = [
+        (
+            "workload\tscale\tobserved_best_source_mode\t"
+            "current_auto_resolved_source_mode\tobserved_auto_vs_best\t"
+            "output_agreement\tmedian_s_by_mode\tresolved_source_modes_by_mode\t"
+            "source_registrations_by_mode"
+        )
+    ]
     for row in rows:
-        print(
+        lines.append(
             f"{row.workload}\t{row.scale}\t{row.observed_best_source_mode}\t"
             f"{row.current_auto_resolved_source_mode}\t{row.observed_auto_vs_best}\t"
             f"{row.output_agreement}\t{row.median_summary}\t"
             f"{row.resolved_source_mode_summary}\t{row.source_registration_summary}"
         )
+    return "\n".join(lines) + "\n"
+
+
+def merge_calibration_rows(
+    baseline_rows: list[CalibrationArtifactRow],
+    fresh_rows: list[CalibrationArtifactRow],
+) -> list[CalibrationArtifactRow]:
+    merged_by_key = {
+        (row.workload, row.scale): row
+        for row in baseline_rows
+    }
+    for row in fresh_rows:
+        merged_by_key[(row.workload, row.scale)] = row
+    return [
+        merged_by_key[key]
+        for key in sorted(merged_by_key, key=_calibration_key_sort_key)
+    ]
+
+
+def write_calibration_artifact(path: Path, rows: list[CalibrationArtifactRow]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        newline="",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as handle:
+        tmp_path = Path(handle.name)
+        handle.write(render_calibration_tsv(rows))
+    tmp_path.replace(path)
+
+
+def write_merged_calibration_artifact(
+    path: Path,
+    fresh_rows: list[CalibrationArtifactRow],
+) -> list[CalibrationArtifactRow]:
+    baseline_rows = load_calibration_artifact(path) if path.exists() else []
+    merged_rows = merge_calibration_rows(baseline_rows, fresh_rows)
+    write_calibration_artifact(path, merged_rows)
+    return merged_rows
 
 
 def main() -> int:
@@ -1014,6 +1080,9 @@ def main() -> int:
         for failure in failures:
             print(f"ERROR: {failure}", file=sys.stderr)
         return 1
+    if args.write_calibration_artifact:
+        write_merged_calibration_artifact(args.calibration_artifact, calibration_rows)
+        print(f"Wrote calibration artifact: {args.calibration_artifact}", file=sys.stderr)
     return 0
 
 

--- a/tests/test_csharp_query_source_mode_sweep.py
+++ b/tests/test_csharp_query_source_mode_sweep.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -23,6 +24,7 @@ from benchmark_csharp_query_source_mode_sweep import (  # noqa: E402
     compare_calibration_rows,
     filter_workload_scales,
     load_calibration_artifact,
+    merge_calibration_rows,
     parse_args,
     parse_competing_processes,
     parse_mem_available_mib,
@@ -30,9 +32,12 @@ from benchmark_csharp_query_source_mode_sweep import (  # noqa: E402
     parse_ratio,
     parse_runner_output,
     parse_workloads,
+    render_calibration_tsv,
     resource_preflight_failures,
     summarize_stability,
     supported_scales_for_workload,
+    write_calibration_artifact,
+    write_merged_calibration_artifact,
 )
 from benchmark_common import csharp_query_source_mode_choices  # noqa: E402
 
@@ -56,6 +61,18 @@ class CSharpQuerySourceModeSweepTests(unittest.TestCase):
     def test_parse_workloads_rejects_unknown_workloads(self) -> None:
         with self.assertRaisesRegex(SystemExit, "unknown workload"):
             parse_workloads("category-influence,not-a-workload")
+
+    def test_write_calibration_artifact_requires_calibration_tsv_format(self) -> None:
+        original_argv = sys.argv
+        try:
+            sys.argv = [
+                "benchmark_csharp_query_source_mode_sweep.py",
+                "--write-calibration-artifact",
+            ]
+            with self.assertRaisesRegex(SystemExit, "requires --format calibration-tsv"):
+                parse_args()
+        finally:
+            sys.argv = original_argv
 
     def test_filter_workload_scales_skips_unsupported_generated_graph_scales(self) -> None:
         self.assertEqual(
@@ -398,6 +415,67 @@ class CSharpQuerySourceModeSweepTests(unittest.TestCase):
             "artifact-prebuilt:artifact-prebuilt,auto:preload",
         )
         self.assertEqual(row.source_registration_summary, "auto:preloaded_preload_arity2=2")
+
+    def test_render_calibration_tsv_matches_artifact_shape(self) -> None:
+        rendered = render_calibration_tsv([self._baseline()])
+
+        self.assertEqual(
+            rendered,
+            "\n".join(
+                [
+                    (
+                        "workload\tscale\tobserved_best_source_mode\t"
+                        "current_auto_resolved_source_mode\tobserved_auto_vs_best\t"
+                        "output_agreement\tmedian_s_by_mode\tresolved_source_modes_by_mode\t"
+                        "source_registrations_by_mode"
+                    ),
+                    (
+                        "category-influence\t300\tpreload\tpreload\t1.30x\tmatch\t"
+                        "artifact-prebuilt:0.904,auto:0.467,preload:0.360\t"
+                        "artifact-prebuilt:artifact-prebuilt,auto:preload,preload:preload\t"
+                        "auto:preloaded_preload_arity2=2"
+                    ),
+                    "",
+                ]
+            ),
+        )
+
+    def test_write_calibration_artifact_round_trips_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            artifact_path = Path(tmp_dir) / "calibration.tsv"
+
+            write_calibration_artifact(artifact_path, [self._baseline()])
+
+            self.assertEqual(load_calibration_artifact(artifact_path), [self._baseline()])
+
+    def test_merge_calibration_rows_replaces_selected_keys_only(self) -> None:
+        baseline = self._baseline()
+        untouched = self._baseline(workload="dependency-depth", scale="1k")
+        fresh = self._baseline(
+            observed_best_source_mode="auto",
+            observed_auto_vs_best="1.00x",
+        )
+
+        self.assertEqual(
+            merge_calibration_rows([untouched, baseline], [fresh]),
+            [fresh, untouched],
+        )
+
+    def test_write_merged_calibration_artifact_preserves_unselected_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            artifact_path = Path(tmp_dir) / "calibration.tsv"
+            untouched = self._baseline(workload="dependency-depth", scale="1k")
+            write_calibration_artifact(artifact_path, [self._baseline(), untouched])
+
+            fresh = self._baseline(
+                observed_best_source_mode="auto",
+                observed_auto_vs_best="1.00x",
+            )
+
+            written = write_merged_calibration_artifact(artifact_path, [fresh])
+
+            self.assertEqual(written, [fresh, untouched])
+            self.assertEqual(load_calibration_artifact(artifact_path), [fresh, untouched])
 
     def test_parse_runner_output_summarizes_modes_and_registrations(self) -> None:
         output = "\n".join(


### PR DESCRIPTION
  ## Summary

  - Adds `--write-calibration-artifact` to `benchmark_csharp_query_source_mode_sweep.py`.
  - Reuses a single calibration TSV renderer for stdout and file writes.
  - Writes calibration artifacts atomically.
  - Merges fresh rows into an existing artifact so partial workload refreshes preserve unselected rows.
  - Documents the guarded direct-refresh workflow in the benchmark README.
  - Adds unit coverage for format validation, TSV rendering, artifact round trips, and merge preservation.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_source_mode_sweep.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_source_mode_sweep.py tests/
  test_csharp_query_source_mode_sweep.py`
  - `git diff --check`
  - Small writer smoke against `/tmp/csharp_query_calibration_writer_smoke.tsv`, preserving the full 25-line artifact.