### PR TITLE
fix(wam-haskell): cache-tier memory-budget guard (Phase L#13)

### DIFF
--- a/docs/design/CACHE_COST_MODEL_PHILOSOPHY.md
+++ b/docs/design/CACHE_COST_MODEL_PHILOSOPHY.md
@@ -233,14 +233,24 @@ is the key piece of information they share — it's what lets one
 opt-in (`workload_locality(unknown)` + `cache_strategy(auto)`)
 produce a self-consistent end-to-end decision.
 
+### Memory budget guard (Phase L#13)
+
+Symmetric to the working-set footprint guard from Phase L#11. The
+cache layer needs *some* RAM to be useful; under memory pressure
+the resolver picks `none` rather than risk OOM. Concretely: when
+`R_free < cache_tier_floor_bytes` the resolver short-circuits to
+`none` regardless of locality/M.
+
+- Default floor: 4 MB. Enough headroom for a modest L2 with the
+  default capacity, biases toward enabling caching when RAM is
+  plentiful, protects against thrashing when it isn't.
+- Override per-call via `cache_tier_floor_bytes(N)`.
+- Reads `mem_available_bytes(R)` (option) or
+  `/proc/meminfo:MemAvailable` (fallback), with a 1 GB fallback on
+  non-Linux — same chain as the cache_strategy resolver.
+
 ### What this isn't doing (yet)
 
-- **No memory-budget guard on the cache itself.** Tier choice is
-  based on quantity and locality, not on whether the cache size
-  fits after the working set is accounted for. `lmdb_cache_l2_capacity_bytes`
-  lets users override the L2 size manually; an automatic floor
-  ("`R_free - W_working < N MB` → fall back to `none`") is a
-  follow-up.
 - **No automatic locality inference.** `workload_locality(...)`
   comes from the workload author. Inferring it from purity
   analysis or kernel metadata is research-y and deferred.

--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -3798,4 +3798,65 @@ cost_model tests unchanged.
   picks against measured wall-clock numbers needs them re-ingested.
   Filed.
 
+## Phase L appendix #13: cache-tier memory-budget guard (2026-05-10)
+
+### What landed
+
+Symmetric to the working-set footprint guard from Phase L#11 (PR
+#2001), but for the cache layer. The Phase L#11 guard catches
+"the BFS state won't fit in RAM" (forces cursor mode). The new
+guard catches "even a small cache won't fit" (forces `none` for
+the cache tier).
+
+`compute_lmdb_cache_mode_decision/2` short-circuits to `Mode = none`
+when `R_free < cache_tier_floor_bytes`:
+
+```prolog
+;   cache_tier_memory_budget_short(Options, FloorBytes, RFree)
+->  Mode = none,
+    Reason = memory_budget(RFree, FloorBytes)
+```
+
+Default floor: 4 MB. Configurable via `cache_tier_floor_bytes(N)`.
+Reads `mem_available_bytes/1` (option) or
+`/proc/meminfo:MemAvailable` (fallback), same chain as the
+cache_strategy resolver.
+
+### Tests
+
+Three new tests in `tests/test_wam_haskell_target.pl`:
+
+- `memory_budget_guard_fires` — 1 MB free + cross_thread + M=100
+  → `none` (guard overrides what would have been `sharded`).
+- `memory_budget_guard_inactive_when_rfree_above_floor` — 64 MB
+  free → `sharded` (normal matrix runs).
+- `memory_budget_floor_override` — custom floor of 100 MB vs
+  64 MB free → `none` (override raises the threshold).
+
+All 167 WAM-Haskell tests pass (164 existing + 3 new); 21
+cost_model tests unchanged.
+
+### What this closes
+
+The cost-model arc now has symmetric resource-safety guards:
+
+- **Working-set footprint** (Phase L#11, PR #2001):
+  `cache_strategy(auto)` overrides `in_memory` → `cursor` when
+  `R_free < W`. Prevents allocating a working-set IntMap bigger
+  than RAM.
+- **Cache-tier memory budget** (Phase L#13, this PR):
+  `lmdb_cache_mode(auto)` overrides any tier → `none` when
+  `R_free < cache_tier_floor_bytes`. Prevents thrashing the
+  cache when there's no headroom left.
+
+The two together mean every cost-model decision is honest about
+the runtime's actual memory budget, not just the access-pattern
+math.
+
+### Open follow-ups
+
+The remaining items from Phase L#12 stand — automatic locality
+inference and at-scale empirical validation. No new follow-ups
+land here.
+
 

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -3233,7 +3233,13 @@ compute_cache_strategy_decision(Options, BfsMode) :-
 %    edge IntMap *is* the cache and adding another tier is redundant.
 %    Pick `none` in that case regardless of locality / M.
 %
-%  Decision matrix for the cursor path:
+%  Memory budget guard (Phase L#13): when R_free is below
+%  `cache_tier_floor_bytes(N)` (default 4 MB), pick `none` regardless
+%  of locality/M. Symmetric to the working-set footprint guard in
+%  `compute_cache_strategy_decision/2` but for the cache layer rather
+%  than the BFS state.
+%
+%  Decision matrix for the cursor path (when memory budget allows):
 %
 %    M = 1                          → none      (no queries to amortise over)
 %    M > 1 & intra_thread          → per_hec   (L1)
@@ -3264,6 +3270,9 @@ compute_lmdb_cache_mode_decision(Options, Mode) :-
     (   option(demand_bfs_mode(in_memory), Options)
     ->  Mode = none,
         Reason = in_memory_path
+    ;   cache_tier_memory_budget_short(Options, FloorBytes, RFree)
+    ->  Mode = none,
+        Reason = memory_budget(RFree, FloorBytes)
     ;   option(expected_query_count(M), Options, 1),
         option(workload_locality(Locality), Options, unknown),
         (   M =< 1
@@ -3283,6 +3292,31 @@ compute_lmdb_cache_mode_decision(Options, Mode) :-
                [Mode, Reason])
     ;   true
     ).
+
+%% cache_tier_memory_budget_short(+Options, -FloorBytes, -RFree) is semidet.
+%
+%  True when free RAM is below the minimum needed to host even a
+%  modest cache. Reads:
+%    - cache_tier_floor_bytes(N): minimum RAM the cache layer needs
+%      to be useful. Default 4 MB — enough headroom for a small L2
+%      with the default capacity, leaves the budget guard biased
+%      toward enabling caching when free RAM is plentiful but
+%      protects against OOM under memory pressure.
+%    - mem_available_bytes(R): /proc/meminfo:MemAvailable override
+%      (same fallback chain as the cache_strategy resolver).
+%  Symmetric to the working-set footprint guard in
+%  compute_cache_strategy_decision/2 (Phase L#11) but for the cache
+%  layer rather than the BFS state.
+cache_tier_memory_budget_short(Options, FloorBytes, RFree) :-
+    option(cache_tier_floor_bytes(FloorBytes), Options, 4_000_000),
+    integer(FloorBytes),
+    FloorBytes > 0,
+    (   option(mem_available_bytes(R), Options),
+        integer(R), R > 0
+    ->  RFree = R
+    ;   catch(read_mem_available_bytes(RFree), _, RFree = 1_000_000_000)
+    ),
+    RFree < FloorBytes.
 
 %% resolve_demand_filter_spec(+Options, -SpecHs)
 %  Pick the DemandFilterSpec literal to emit into Main.hs.

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -2128,6 +2128,54 @@ test_lmdb_cache_mode_explicit_unchanged :-
     ;   fail_test(Test, 'explicit lmdb_cache_mode was mutated')
     ).
 
+test_lmdb_cache_mode_memory_budget_guard_fires :-
+    %% R_free below the cache-tier floor: even with a locality that
+    %% would otherwise pick a tier, the guard overrides to `none`.
+    %% 1 MB free vs 4 MB default floor → none.
+    Test = 'WAM-Haskell: lmdb_cache_mode(auto) memory-budget guard overrides tier → none',
+    (   wam_haskell_target:resolve_auto_lmdb_cache_mode(
+            [lmdb_cache_mode(auto),
+             workload_locality(cross_thread),
+             expected_query_count(100),
+             mem_available_bytes(1_000_000)],
+            R),
+        memberchk(lmdb_cache_mode(none), R),
+        \+ memberchk(lmdb_cache_mode(sharded), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'memory budget guard did not override tier under pressure')
+    ).
+
+test_lmdb_cache_mode_memory_budget_guard_inactive_when_rfree_above_floor :-
+    %% R_free comfortably above floor: guard inactive, normal matrix runs.
+    %% 64 MB free vs 4 MB default floor → cross_thread → sharded.
+    Test = 'WAM-Haskell: lmdb_cache_mode(auto) memory-budget guard inactive when R_free >= floor',
+    (   wam_haskell_target:resolve_auto_lmdb_cache_mode(
+            [lmdb_cache_mode(auto),
+             workload_locality(cross_thread),
+             expected_query_count(100),
+             mem_available_bytes(64_000_000)],
+            R),
+        memberchk(lmdb_cache_mode(sharded), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'memory budget guard incorrectly fired with ample R_free')
+    ).
+
+test_lmdb_cache_mode_memory_budget_floor_override :-
+    %% Custom floor via cache_tier_floor_bytes/1. Set floor to 100 MB:
+    %% 64 MB free is now below floor → guard fires → none.
+    Test = 'WAM-Haskell: lmdb_cache_mode(auto) cache_tier_floor_bytes overrides default',
+    (   wam_haskell_target:resolve_auto_lmdb_cache_mode(
+            [lmdb_cache_mode(auto),
+             workload_locality(cross_thread),
+             expected_query_count(100),
+             mem_available_bytes(64_000_000),
+             cache_tier_floor_bytes(100_000_000)],
+            R),
+        memberchk(lmdb_cache_mode(none), R)
+    ->  pass(Test)
+    ;   fail_test(Test, 'custom cache_tier_floor_bytes did not raise the threshold')
+    ).
+
 test_b1_lmdb_dupsort_per_thread_cursor :-
     Test = 'B1: dupsort layout uses per-thread cursor cache',
     (   compile_wam_runtime_to_haskell(
@@ -2570,6 +2618,9 @@ run_tests :-
     test_lmdb_cache_mode_auto_composes_with_in_memory_bfs,
     test_lmdb_cache_mode_auto_no_op_without_workload_locality,
     test_lmdb_cache_mode_explicit_unchanged,
+    test_lmdb_cache_mode_memory_budget_guard_fires,
+    test_lmdb_cache_mode_memory_budget_guard_inactive_when_rfree_above_floor,
+    test_lmdb_cache_mode_memory_budget_floor_override,
     format('~n========================================~n'),
     (   test_failed
     ->  format('Tests FAILED~n'), halt(1)


### PR DESCRIPTION
  ## Summary

  Symmetric to PR #2001 (working-set footprint guard) but for the
  cache layer rather than the BFS state. Closes the resource-safety
  story for the cost-model arc.

  | guard | trigger | override |
  |---|---|---|
  | **L#11** (PR #2001) | `R_free < W` | `cache_strategy: in_memory → cursor` |
  | **L#13** (this PR) | `R_free < cache_tier_floor_bytes` | `lmdb_cache_mode: any tier → none` |

  Together: every cost-model decision is now honest about the
  runtime's actual memory budget, not just the access-pattern math.

  ## What changed

  `compute_lmdb_cache_mode_decision/2` short-circuits to
  `Mode = none` when `R_free < cache_tier_floor_bytes`:

  ```prolog
  ;   cache_tier_memory_budget_short(Options, Floor, RFree)
  ->  Mode = none,
      Reason = memory_budget(RFree, Floor)
  ```
  New option cache_tier_floor_bytes(N) (default 4 MB):
  - Enough headroom for a modest L2 with the default capacity.
  - Biased toward enabling caching when RAM is plentiful.
  - Protects against thrashing under pressure.
  - Override per-call when you know the workload's true minimum.

  R_free reads from mem_available_bytes(R) option or
  /proc/meminfo:MemAvailable (1 GB fallback off-Linux) — same
  chain as the cache_strategy resolver.

  Tests

  Three new tests:

  - memory_budget_guard_fires — 1 MB free + cross_thread + M=100
  → none (guard overrides what would have been sharded).
  - memory_budget_guard_inactive_when_rfree_above_floor — 64 MB
  free → sharded (normal matrix runs).
  - memory_budget_floor_override — custom floor of 100 MB vs 64 MB
  free → none (override raises the threshold).

  167/167 WAM-Haskell tests pass (164 existing + 3 new).
  21/21 cost_model tests unchanged.

  Docs

  - docs/design/CACHE_COST_MODEL_PHILOSOPHY.md — new "Memory
  budget guard" subsection. Removed the corresponding "what this
  isn't doing yet" bullet.
  - docs/design/WAM_PERF_OPTIMIZATION_LOG.md — Phase L appendix
  #13 with the symmetric-guards summary and what this closes.

  Files

  - src/unifyweaver/targets/wam_haskell_target.pl (+34, -2)
  - tests/test_wam_haskell_target.pl (+51)
  - docs/design/CACHE_COST_MODEL_PHILOSOPHY.md (+15, -7)
  - docs/design/WAM_PERF_OPTIMIZATION_LOG.md (+61)

  What's left in the arc

  From Phase L#12's open follow-ups, only one item remains:

  - Automatic locality inference — workload_locality(...) is
  authored by hand. Could derive from kernel metadata. Research-y.

  And from Phase L#11's:

  - At-scale empirical validation — fixtures were swept in the
  workspace reset; needs re-ingest before any new measurement
  PRs land.