### PR TITLE
feat(wam-r): mode-analysis phase 1 -- visibility-only mode_comments option

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -470,6 +470,46 @@ A lowered predicate is dispatched the same way as a compiled label:
 the wrapper calls the lowered function instead of stepping the
 instruction array. Failure semantics are identical.
 
+### Mode-analysis visibility (`mode_comments`)
+
+Phase 1 of WAM-R mode-analysis integration. The shared
+`core/binding_state_analysis.pl` analyser is already wired into the
+WAM compiler for `=../2` / `functor/3` / `arg/3` /
+`not_member_set` specialisations. The WAM-R lowered emitter
+now optionally surfaces the same analyser output as comments
+prepended to each generated function:
+
+```prolog
+:- assertz(user:mode(p(+, -))).
+
+:- write_wam_r_project(
+       [user:p/2, ...],
+       [emit_mode(functions), mode_comments(on)],
+       '/tmp/proj').
+```
+
+The generated R contains:
+
+```r
+# Mode analysis (phase 1, visibility-only):
+#   clause 1 head: [A-bound, B-unbound]   (mode_decl=[input, output])
+#
+# Lowered: p/2  (deterministic single-clause)
+lowered_p_2 <- function(program, state) { ... }
+```
+
+`mode_comments(on)` is **visibility-only** -- no runtime or codegen
+behaviour change. The block is intended as a debugging aid and as
+the foundation for phase 2, which will consume the same analyser
+records to pick specialised emission paths (e.g. skipping deref on
+known-bound register slots). See
+[`design/WAM_R_MODE_ANALYSIS_PLAN.md`](design/WAM_R_MODE_ANALYSIS_PLAN.md)
+for the phase roadmap.
+
+The mode declaration uses `user:mode/1` with `+` / `-` / `?`
+shorthand (input / output / any), the same convention
+`demand_analysis:read_mode_declaration/3` reads.
+
 ## Supported features
 
 ### Control
@@ -824,6 +864,7 @@ Coverage map (e2e tests, by feature group):
 | `strict_xf_chain_fails_e2e_rscript` | runtime parser enforces strict (xf / fx) vs non-strict (yf / fy) lhs-precedence rules: `5!!` parses with `op(100, yf, '!')` but fails with `op(100, xf, '!')`; `neg neg foo` parses with `op(900, fy, neg)` but fails with `op(900, fx, neg)` |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
+| `mode_analysis_phase1_comments` | Mode-analysis phase 1 visibility: `mode_comments(on)` option prepends `# Mode analysis:` block to each lowered function with per-clause head-binding states; foundation for phase 2 specialisations |
 
 ## Contributing
 

--- a/docs/design/WAM_R_MODE_ANALYSIS_PLAN.md
+++ b/docs/design/WAM_R_MODE_ANALYSIS_PLAN.md
@@ -1,0 +1,106 @@
+# WAM-R Mode Analysis: Phase Roadmap
+
+> **Companion docs:** [`WAM_HASKELL_MODE_ANALYSIS_PHILOSOPHY.md`](WAM_HASKELL_MODE_ANALYSIS_PHILOSOPHY.md)
+> (the *why*) and [`WAM_HASKELL_MODE_ANALYSIS_SPEC.md`](WAM_HASKELL_MODE_ANALYSIS_SPEC.md)
+> (the *what*) describe the shared analyser. This doc is the WAM-R-
+> specific *how*: which downstream specialisations the WAM-R target
+> consumes the analyser output for, in priority order.
+
+## Starting point (already in place)
+
+The shared analyser at `src/unifyweaver/core/binding_state_analysis.pl`
+runs per-clause inside the WAM compiler. It's already consulted at
+~15 call sites in `src/unifyweaver/targets/wam_target.pl` to choose
+between specialised and generic codegen for:
+
+- `=../2` compose-mode -> `PutStructureDyn` instruction
+- `functor/3` compose-mode -> same `PutStructureDyn` shape
+- `arg/3` -> dedicated `arg` WAM instruction
+- `\+ member(X, V)` for visited-set vars -> `not_member_set` (O(log N))
+
+WAM-R inherits all of these via the shared compiler. The gap this
+plan closes: the **WAM-R lowered emitter** (`wam_r_lowered_emitter.pl`)
+operates one level downstream (on WAM-text lines) and currently has
+no link to the analyser. The lowered emitter is the hot path for
+predicates that `wam_r_lowerable/3` accepts.
+
+## Phase 1 — visibility (LANDED)
+
+**PR**: see commit history on `claude/wam-r-mode-analysis-phase1`.
+
+- Add `mode_comments(on)` option to `write_wam_r_project/3`.
+- Wire `binding_state_analysis:analyse_clause_bindings/3` into
+  `lower_predicate_to_r/4` via `gather_pred_mode_records/2`.
+- When the option is on, prepend a `# Mode analysis:` block to each
+  emitted lowered function summarising the per-clause head-binding
+  states and any `:- mode/1` declaration.
+- No runtime / codegen behaviour change; visibility only.
+- Foundation for phase 2: the analyser records are now reachable
+  from the emitter without re-running the analyser at WAM-text-
+  parsing time.
+
+## Phase 2 candidates — measured next
+
+The fact-source-bench Rprof profile (see WAM_R_TARGET.md "Rprof
+profile of the WAM stepping engine") flags the dominant costs:
+
+| Function | self.s | %self | Mode-info lever? |
+|---------:|-------:|------:|------------------|
+| `WamRuntime$step` | 1.500 | 29.0% | **YES** -- inline more ops when modes prove the slot shape |
+| `WamRuntime$run` | 0.760 | 14.7% | indirectly (fewer step calls = fewer run iterations) |
+| `WamRuntime$run_predicate` | 0.690 | 13.3% | no -- per-call overhead, not mode-driven |
+| `WamRuntime$deref` | 0.380 | 7.3% | **YES** -- skip deref at known-bound slots |
+| `WamRuntime$put_reg` | 0.260 | 5.0% | no -- already trivial |
+
+Top phase-2 candidates, in priority order:
+
+1. **`get_constant` head match -- skip deref when slot is provably
+   bound to a constant.** Currently delegates to `step`. With
+   mode info, emit `if (state$regs2[[idx]]$id != C$id) return(FALSE)`
+   inline. Expected: ~3-7% wall-clock on fact-source-bench
+   (head-match heavy).
+2. **`get_value` head match -- skip deref-then-unify when both
+   sides are provably bound atomics.** Similar to #1 but for
+   var-to-var matching.
+3. **`is/2` arithmetic fast path -- skip per-call type-tag checks
+   when all RHS vars are provably bound to numerics.** Lives in
+   builtin handlers, not the lowered emitter. Independent project.
+4. **Lowering more shapes.** When mode info proves a multi-clause
+   predicate is deterministic at this call site, the emitter could
+   pick `deterministic` instead of `multi_clause_1`, skipping the
+   CP push. Requires call-site mode info, not just clause-level.
+
+Phase 2 should pick **one** candidate (likely #1), implement +
+bench, and only proceed to the next if the measured win justifies
+it. The bench command is documented in WAM_R_TARGET.md ("Rprof
+profile of the WAM stepping engine").
+
+## Phase 3+ — adaptive specialisation
+
+Once phase 2 demonstrates a measurable win, the next direction is
+call-site-driven specialisation: the analyser tracks not just
+"variables in this clause body" but "modes of every call site I
+see," and the emitter picks specialised emission per call site.
+This is a much bigger change (requires whole-program mode
+propagation) and is deferred until phase 2 establishes the
+pay-for-itself baseline.
+
+## Risks / open questions
+
+- **Analyser cost.** Running the analyser per clause at compile
+  time is cheap (the analyser is single-pass + no fixpoint), but
+  it's not free. The visibility phase doesn't show this cost
+  because it only runs when the user opts in. Phase 2 will need
+  to run the analyser unconditionally; if codegen time becomes
+  noticeable, we'd memoise per-clause.
+- **Mode declaration coverage.** Users today rarely declare
+  modes. Without declarations, the analyser starts from
+  "everything unknown" and proves very little. Phase 2's wins
+  may be small until users start adding `:- mode/1` declarations
+  or we add automatic mode inference from call sites.
+- **Divergence from Haskell.** The Haskell target's analyser
+  integration drives `PutStructureDyn` lowering. WAM-R doesn't
+  have an equivalent specialised instruction; its leverage is
+  in the lowered emitter, not in new WAM ops. The plans diverge
+  here intentionally -- both target the same analyser, but
+  consume its output differently.

--- a/src/unifyweaver/targets/wam_r_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_r_lowered_emitter.pl
@@ -34,10 +34,13 @@
 :- module(wam_r_lowered_emitter, [
     wam_r_lowerable/3,           % +Pred, +WamCode, -Reason
     lower_predicate_to_r/4,      % +Pred, +WamCode, +Options, -Entry
-    r_lowered_func_name/2        % +Functor/Arity, -RFuncName
+    r_lowered_func_name/2,       % +Functor/Arity, -RFuncName
+    gather_pred_mode_records/2   % +PredIndicator, -Records
 ]).
 
 :- use_module(library(lists)).
+:- use_module('../core/binding_state_analysis').
+:- use_module('../core/demand_analysis').
 
 % =====================================================================
 % Emission plan
@@ -185,43 +188,175 @@ r_safe_code(_, 0'_).
 
 %% lower_predicate_to_r(+Pred/Arity, +WamCode, +Options, -Entry)
 %  Entry = lowered(PredName, FuncName, RCode).
-lower_predicate_to_r(PI, WamCode, _Opts,
+%
+%  Options:
+%    mode_comments(on)  -- prepend a `# Mode analysis:` comment block
+%                          summarising the inferred binding env per
+%                          clause. Off by default. Visibility-only;
+%                          no codegen change. Phase 1 of WAM-R mode-
+%                          analysis integration (see
+%                          docs/design/WAM_R_MODE_ANALYSIS_PLAN.md).
+lower_predicate_to_r(PI, WamCode, Opts,
                      lowered(PredName, FuncName, Code)) :-
     ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     format(atom(PredName), '~w/~w', [Pred, Arity]),
     r_lowered_func_name(Pred/Arity, FuncName),
     build_emission_plan(WamCode, plan(Mode, AltLabel, ClauseLines)),
+    mode_comment_header(PI, Opts, ModeHeader),
     (   Mode == deterministic
-    ->  emit_deterministic_function(PredName, FuncName, ClauseLines, Code)
+    ->  emit_deterministic_function(PredName, FuncName, ClauseLines,
+                                    ModeHeader, Code)
     ;   Mode == multi_clause_1
-    ->  emit_multi_clause_function(PredName, FuncName, AltLabel, ClauseLines, Code)
+    ->  emit_multi_clause_function(PredName, FuncName, AltLabel,
+                                   ClauseLines, ModeHeader, Code)
     ).
 
-emit_deterministic_function(PredName, FuncName, ClauseLines, Code) :-
+%% mode_comment_header(+PI, +Opts, -Header) is det.
+%  Builds the R comment block for the predicate's mode analysis when
+%  Opts contains mode_comments(on). Otherwise Header is the empty
+%  string. The block is intended to be visible in the generated R
+%  file so developers can see what the analyser inferred without
+%  re-running it.
+mode_comment_header(PI, Opts, Header) :-
+    (   member(mode_comments(on), Opts),
+        catch(gather_pred_mode_records(PI, Records), _, fail),
+        Records \= []
+    ->  format_mode_records(Records, Lines),
+        atomic_list_concat(Lines, '', Header)
+    ;   Header = ""
+    ).
+
+%% gather_pred_mode_records(+PredIndicator, -Records) is det.
+%  Pulls the user-asserted clauses for the predicate, runs the
+%  binding-state analyser per clause, and returns one
+%  `mode_record(Idx, ModeDecl, HeadVars, GoalBindings)` per clause.
+%
+%    - Idx        : 1-based clause number.
+%    - ModeDecl   : list of mode atoms (input/output/any) from
+%                   `:- mode/1`, or `none` if undeclared.
+%    - HeadVars   : list of `Var-Name-State` triples for each head
+%                   variable, where Name is the numbervars-assigned
+%                   atom and State is the binding state immediately
+%                   after head unification (i.e. BeforeEnv of goal 1).
+%    - GoalBindings : the raw goal_binding(Idx, Before, After) list
+%                     from the analyser (renderable via
+%                     format_mode_records/2).
+%
+%  Module qualifiers in clause bodies are stripped (plunit wraps
+%  asserted bodies in plunit_<test>:user:Goal). Failure is silent --
+%  any error in the analyser causes the records to be empty so the
+%  caller can degrade gracefully.
+gather_pred_mode_records(PI, Records) :-
+    ( PI = _Mod:Pred/Arity -> true ; PI = Pred/Arity ),
+    functor(HeadTpl, Pred, Arity),
+    catch(findall(HeadCopy-BodyCopy,
+                  ( user:clause(HeadTpl, RawBody),
+                    wam_r_target:strip_module_qualifiers(RawBody,
+                                                         StrippedBody),
+                    copy_term(HeadTpl-StrippedBody,
+                              HeadCopy-BodyCopy),
+                    numbervars(HeadCopy-BodyCopy, 0, _) ),
+                  Clauses), _, Clauses = []),
+    (   demand_analysis:read_mode_declaration(Pred, Arity, ModeDecl)
+    ->  true
+    ;   ModeDecl = none
+    ),
+    gather_clause_records(Clauses, 1, ModeDecl, Records).
+
+gather_clause_records([], _, _, []).
+gather_clause_records([Head-Body | Rest], Idx, ModeDecl,
+                      [mode_record(Idx, ModeDecl, HeadVars, GBs) | Tail]) :-
+    catch(binding_state_analysis:analyse_clause_bindings(Head, Body, GBs0),
+          _, GBs0 = []),
+    GBs = GBs0,
+    head_var_states(Head, GBs, HeadVars),
+    Idx1 is Idx + 1,
+    gather_clause_records(Rest, Idx1, ModeDecl, Tail).
+
+%% head_var_states(+Head, +GoalBindings, -HeadVars) is det.
+%  Returns a list of `Name-State` pairs, one per direct head-arg
+%  variable. State is read from goal_binding(1, BeforeEnv, _) --
+%  the env right before the first body goal, which is what an
+%  optimizer choosing a head-match specialisation would consult.
+head_var_states(Head, GBs, HeadVars) :-
+    Head =.. [_ | Args],
+    (   member(goal_binding(1, BeforeEnv, _), GBs)
+    ->  true
+    ;   binding_state_analysis:empty_binding_env(BeforeEnv)
+    ),
+    head_var_states_(Args, BeforeEnv, HeadVars).
+
+head_var_states_([], _, []).
+head_var_states_([Arg | Rest], Env, [Name-State | Tail]) :-
+    (   var(Arg)
+    ->  format(atom(Name), '_var_~w', [Arg])
+    ;   Arg = '$VAR'(N)
+    ->  numbered_var_atom(N, Name)
+    ;   Name = '<nonvar>'
+    ),
+    (   var(Arg)
+    ->  State = unbound
+    ;   binding_state_analysis:get_binding_state(Env, Arg, State0)
+    ->  State = State0
+    ;   State = unknown
+    ),
+    head_var_states_(Rest, Env, Tail).
+
+%% numbered_var_atom(+N, -Atom) is det.
+%  Mirrors the SWI numbervars convention: 0..25 -> A..Z, then A1..Z1,
+%  A2..Z2, etc. Used so head-arg variable names in the emitted
+%  comments match what numbervars/3 displays elsewhere.
+numbered_var_atom(N, Atom) :-
+    Letter is N mod 26,
+    Suffix is N // 26,
+    Code is 0'A + Letter,
+    (   Suffix =:= 0
+    ->  char_code(Char, Code), atom_concat(Char, '', Atom)
+    ;   char_code(Char, Code), atom_concat(Char, Suffix, Atom)
+    ).
+
+%% format_mode_records(+Records, -Lines) is det.
+%  Renders the analyser output as a block of R comment lines.
+%  Empty record list yields the empty string (no comment block).
+format_mode_records([], [""]) :- !.
+format_mode_records(Records, [Header | Body]) :-
+    Header = "# Mode analysis (phase 1, visibility-only):\n",
+    maplist(format_one_clause, Records, Bodies),
+    flatten(Bodies, Body0),
+    append(Body0, ["#\n"], Body).
+
+format_one_clause(mode_record(Idx, ModeDecl, HeadVars, _GBs), Lines) :-
+    format(string(L1), "#   clause ~w head: ~w   (mode_decl=~w)\n",
+           [Idx, HeadVars, ModeDecl]),
+    Lines = [L1].
+
+emit_deterministic_function(PredName, FuncName, ClauseLines,
+                            ModeHeader, Code) :-
     with_output_to(string(Body), emit_lines(ClauseLines, "  ")),
     % The clause body always ends with `proceed`, which emits
     % `return(TRUE)`. We keep an explicit `invisible(TRUE)` after the
     % body as a defensive fallback in case future codegen produces a
     % proceed-less clause; the wrapper does isTRUE() on the result.
     format(string(Code),
-'# Lowered: ~w  (deterministic single-clause)
+'~w# Lowered: ~w  (deterministic single-clause)
 ~w <- function(program, state) {
 ~w  invisible(TRUE)
-}', [PredName, FuncName, Body]).
+}', [ModeHeader, PredName, FuncName, Body]).
 
 % Multi-clause: push a CP whose next_pc points at clause 2+, run
 % clause 1 inline. If clause 1 succeeds the lowered fn returns TRUE
 % (the CP stays in $cps for downstream backtracking). If clause 1
 % fails we backtrack via the runtime helper, advance past the
 % trust_me, and drop into the run loop so it can drive clause 2+.
-emit_multi_clause_function(PredName, FuncName, AltLabel, ClauseLines, Code) :-
+emit_multi_clause_function(PredName, FuncName, AltLabel, ClauseLines,
+                           ModeHeader, Code) :-
     with_output_to(string(Body), emit_lines(ClauseLines, "    ")),
     % clause1_ok is the value of the closure's last expression, which
     % is the `return(TRUE)` emitted by the proceed line at the end of
     % clause 1. invisible(FALSE) is a defensive fallback for the
     % proceed-less case (caller does isTRUE() on the result).
     format(string(Code),
-'# Lowered: ~w  (multi-clause; clause 1 inline, fall back to array)
+'~w# Lowered: ~w  (multi-clause; clause 1 inline, fall back to array)
 ~w <- function(program, state) {
   alt_pc <- program$labels[["~w"]]
   if (is.null(alt_pc)) return(FALSE)
@@ -240,7 +375,7 @@ emit_multi_clause_function(PredName, FuncName, AltLabel, ClauseLines, Code) :-
   state$pc   <- state$pc + 1L
   state$halt <- FALSE
   isTRUE(WamRuntime$run(program, state))
-}', [PredName, FuncName, AltLabel, Body]).
+}', [ModeHeader, PredName, FuncName, AltLabel, Body]).
 
 emit_lines([], _).
 emit_lines([Line|Rest], Ind) :-

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -904,7 +904,7 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
     ;   should_try_lower(Mode, P, Arity),
         WamCodeForLower \= "",
         catch(wam_r_lowerable(Pred, WamCodeForLower, _Reason), _, fail),
-        catch(lower_predicate_to_r(Pred, WamCodeForLower, [],
+        catch(lower_predicate_to_r(Pred, WamCodeForLower, Options,
                                    lowered(_PName, FuncName, LoweredR)),
               _, fail)
     ->  NewLoweredAcc = [LoweredR | LoweredAcc],

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -627,6 +627,61 @@ e2e_phase3_multi_clause :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% Mode-analysis phase 1 (visibility-only). With mode_comments(on) in
+% Options, the lowered emitter prepends a `# Mode analysis:` comment
+% block above each lowered function summarising the analyser's per-
+% clause head-binding states. Pure visibility -- no runtime / codegen
+% behaviour change. Foundation for phase 2 specialisations.
+%
+% This is a structural test (no Rscript needed); it asserts on the
+% generated R file contents directly.
+% ------------------------------------------------------------------
+test(mode_analysis_phase1_comments) :-
+    once((
+        % Cleanup previous assertions if any.
+        retractall(user:ma_caller/1),
+        retractall(user:ma_callee/1),
+        retractall(user:mode(ma_caller(_))),
+        % Single-clause deterministic predicate so the lowered emitter
+        % picks it up. The mode declaration seeds the analyser: arg 1
+        % is input (-> bound at clause entry).
+        assertz(user:mode(ma_caller(+))),
+        assertz(user:ma_callee(_)),
+        assertz((user:ma_caller(X) :- user:ma_callee(X))),
+        unique_r_tmp_dir('tmp_r_mode_comments', TmpDir),
+        write_wam_r_project(
+            [ user:ma_caller/1, user:ma_callee/1 ],
+            [emit_mode(functions), mode_comments(on)],
+            TmpDir),
+        directory_file_path(TmpDir, 'R/generated_program.R', Program),
+        read_file_to_string(Program, Code, []),
+        % The lowered function for ma_caller/1 should be preceded by
+        % the mode-analysis comment block, including the head-binding
+        % summary that mirrors the input-mode declaration.
+        assertion(sub_string(Code, _, _, _,
+            '# Mode analysis (phase 1, visibility-only):')),
+        assertion(sub_string(Code, _, _, _,
+            'mode_decl=[input]')),
+        % And the lowered function itself is still emitted.
+        assertion(sub_string(Code, _, _, _,
+            'lowered_ma_caller_1 <- function(program, state)')),
+        % Sanity: with the option OFF, the comment block is absent.
+        unique_r_tmp_dir('tmp_r_mode_comments_off', TmpDir2),
+        write_wam_r_project(
+            [ user:ma_caller/1, user:ma_callee/1 ],
+            [emit_mode(functions)],
+            TmpDir2),
+        directory_file_path(TmpDir2, 'R/generated_program.R', Program2),
+        read_file_to_string(Program2, Code2, []),
+        assertion(\+ sub_string(Code2, _, _, _,
+            '# Mode analysis (phase 1, visibility-only):')),
+        % Cleanup.
+        retractall(user:mode(ma_caller(_))),
+        delete_directory_and_contents(TmpDir),
+        delete_directory_and_contents(TmpDir2)
+    )).
+
+% ------------------------------------------------------------------
 % Phase-3 follow-up: extended builtins.
 % Type checks, term equality / identity, standard order of terms,
 % and the cut (!/0). Each predicate compiles to the corresponding


### PR DESCRIPTION
## Summary

Foundation PR for WAM-R mode-analysis integration. The shared `core/binding_state_analysis.pl` analyser is **already wired** into the WAM compiler for `=../2` / `functor/3` / `arg/3` / `not_member_set` specialisations; this PR closes the gap on the WAM-R-specific downstream emitter so phase 2+ can consume the analyser output to pick specialised lowered-emitter paths.

**Pure visibility -- no runtime or codegen behaviour change beyond the optional comment text.** Default option state is OFF.

### What landed

- `wam_r_lowered_emitter.pl` gains `gather_pred_mode_records/2`, which pulls the user-asserted clauses for a predicate, runs the binding-state analyser per clause, and returns `mode_record(Idx, ModeDecl, HeadVars, GoalBindings)` records. HeadVars is a list of `Name-State` pairs (Name from `numbervars/2`, State from the analyser's BeforeEnv of goal 1). Module qualifiers in clause bodies are stripped via `wam_r_target:strip_module_qualifiers/2`, mirroring the kernel-detection path.
- New `mode_comments(on)` option threads through `write_wam_r_project/3` -> `compile_all_predicates/...` -> `lower_predicate_to_r/4`. When set, each lowered function is prepended with a `# Mode analysis (phase 1, visibility-only):` comment block.
- `emit_deterministic_function` / `emit_multi_clause_function` accept the header as an additional arg and splice it in before the existing `# Lowered: ...` comment.

### Example output

```prolog
:- assertz(user:mode(p(+, -))).

:- write_wam_r_project(
       [user:p/2, ...],
       [emit_mode(functions), mode_comments(on)],
       '/tmp/proj').
```

generates:

```r
# Mode analysis (phase 1, visibility-only):
#   clause 1 head: [A-bound, B-unbound]   (mode_decl=[input, output])
#
# Lowered: p/2  (deterministic single-clause)
lowered_p_2 <- function(program, state) { ... }
```

### Why visibility first

The analyser is already producing useful output, but it's invisible to anyone working on the lowered emitter. Phase 1 surfaces it so phase 2 can pick **measured** specialisations (driven by the existing Rprof profile in `docs/WAM_R_TARGET.md`), not guessed ones.

### Phase 2 roadmap

`docs/design/WAM_R_MODE_ANALYSIS_PLAN.md` (new) outlines phase 2 candidates ranked against the existing Rprof profile:

| Function | self.s | %self | Mode-info lever? |
|---------:|-------:|------:|------------------|
| `WamRuntime$step` | 1.500 | 29.0% | **YES** -- inline more ops when modes prove the slot shape |
| `WamRuntime$deref` | 0.380 | 7.3% | **YES** -- skip deref at known-bound slots |

Top phase-2 candidate: skip deref on `get_constant` head match when the analyser proves the target slot is bound to a constant (currently delegates to `step`).

## Test plan

- [x] New structural test `mode_analysis_phase1_comments` (no Rscript needed). Declares `:- mode(ma_caller(+))`, compiles with `emit_mode(functions), mode_comments(on)`, asserts the comment block appears with `mode_decl=[input]`. Also asserts that with the option OFF the block is absent.
- [x] Full WAM-R suite: **77/77 pass** (76 prior + 1 new), ~663s wall-clock.

## Risks

- The `emit_deterministic_function` / `emit_multi_clause_function` predicates gain an arity (4 -> 5, 5 -> 6). These are module-private to `wam_r_lowered_emitter`; the Lua target has its own private copies with original arity. No cross-target collision.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_