### PR TITLE
feat(wam-clojure): add append split mode

### DIFF
--- a/PR_WAM_CLOJURE_APPEND_SPLIT_MODE.md
+++ b/PR_WAM_CLOJURE_APPEND_SPLIT_MODE.md
@@ -1,0 +1,29 @@
+# feat(wam-clojure): add append split mode
+
+## Summary
+
+Extends Clojure WAM `append/3` support from deterministic concat mode to split mode.
+
+## What Changed
+
+- Refactors lowered `append/3` emission to call shared `runtime/apply-append-solution`.
+- Keeps concat mode for `append(+ListA, +ListB, ?Out)`.
+- Adds split mode for `append(A, B, GroundList)`.
+- Enumerates prefix/suffix splits using existing foreign-style choice-point machinery.
+- Adds runtime smoke coverage for every split of `[a,b,c]`.
+
+## Semantics
+
+Supported modes after this PR:
+
+- `append(+ListA, +ListB, ?Out)`
+- `append(?Prefix, ?Suffix, +GroundList)`
+
+The split-mode path enumerates all valid prefix/suffix pairs and supports backtracking to later splits.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -561,8 +561,8 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "append/3" ; Op == 'append/3'),
     !,
     format(atom(Expr),
-           '(let [left (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) right (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound)) out (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A3") ::lowered-unbound)) left-items (runtime/proper-list-items ~w left) right-items (runtime/proper-list-items ~w right)] (if (and (some? left-items) (some? right-items)) (let [joined (runtime/list->term (:intern-context ~w) (concat left-items right-items)) [ok next-state] (runtime/unify-values ~w out joined)] (if ok (runtime/advance next-state) (runtime/backtrack ~w))) (runtime/backtrack ~w)))',
-           [S, S, S, S, S, S, S, S, S, S, S, S]).
+           '(let [left (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) right (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound)) out (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A3") ::lowered-unbound))] (runtime/apply-append-solution ~w (inc (:pc ~w)) left right out))',
+           [S, S, S, S, S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "ground/1" ; Op == 'ground/1'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -518,6 +518,9 @@
         :else nil))))
 
 (declare apply-member-solution)
+(declare apply-append-solution)
+(declare apply-first-foreign-solution)
+(declare list->term)
 
 (defn push-member-choice-point [state base-state resume-pc elem rest-list]
   (let [rest* (deref-value (:bindings base-state) rest-list)
@@ -553,6 +556,29 @@
             (recur (deref-value bindings tail) (conj seen cur))))
 
         :else
+        (backtrack base-state)))))
+
+(defn append-split-results [state items]
+  (let [ctx (:intern-context state)]
+    (mapv (fn [idx]
+            (let [[left right] (split-at idx items)]
+              {:bindings {1 (list->term ctx left)
+                          2 (list->term ctx right)}}))
+          (range (inc (count items))))))
+
+(defn apply-append-solution [base-state resume-pc left right out]
+  (let [left-items (proper-list-items base-state left)
+        right-items (proper-list-items base-state right)]
+    (if (and (some? left-items) (some? right-items))
+      (let [joined (list->term (:intern-context base-state)
+                               (concat left-items right-items))
+            [ok next-state] (unify-values base-state out joined)]
+        (if ok
+          (assoc next-state :pc resume-pc)
+          (backtrack base-state)))
+      (if-let [out-items (proper-list-items base-state out)]
+        (apply-first-foreign-solution base-state resume-pc
+                                      (append-split-results base-state out-items))
         (backtrack base-state)))))
 
 (defn ground-term? [state value]
@@ -1169,17 +1195,8 @@
                 right (deref-value (:bindings state)
                                    (or (reg-get-raw state "A2") ::unbound))
                 out (deref-value (:bindings state)
-                                 (or (reg-get-raw state "A3") ::unbound))
-                left-items (proper-list-items state left)
-                right-items (proper-list-items state right)]
-            (if (and (some? left-items) (some? right-items))
-              (let [joined (list->term (:intern-context state)
-                                       (concat left-items right-items))
-                    [ok next-state] (unify-values state out joined)]
-                (if ok
-                  (advance next-state)
-                  (backtrack state)))
-              (backtrack state)))
+                                 (or (reg-get-raw state "A3") ::unbound))]
+            (apply-append-solution state (inc (:pc state)) left right out))
 
           "ground/1"
           (let [value (deref-value (:bindings state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -468,12 +468,11 @@ test(simple_builtin_append_is_direct_lowered_in_prefix) :-
         WamCode = "test_append/3:\nbuiltin_call append/3, 3\nproceed\n",
         wam_clojure_lowerable(test_append/3, WamCode, deterministic),
         lower_predicate_to_clojure(test_append/3, WamCode, [], Code),
-        has(Code, "runtime/proper-list-items"),
-        has(Code, "runtime/list->term"),
+        has(Code, "runtime/apply-append-solution"),
         has(Code, "\"A1\""),
         has(Code, "\"A2\""),
         has(Code, "\"A3\""),
-        has(Code, "runtime/unify-values"),
+        has(Code, "inc (:pc"),
         assertion(\+ has(Code, "runtime/step"))
     )).
 

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -64,6 +64,7 @@
 :- dynamic user:wam_append_guard/3.
 :- dynamic user:wam_append_bad_left/1.
 :- dynamic user:wam_append_unbound_left/1.
+:- dynamic user:wam_append_split/2.
 :- dynamic user:wam_ground_guard/1.
 :- dynamic user:wam_ground_unbound/1.
 :- dynamic user:wam_ground_nested_unbound/1.
@@ -149,6 +150,7 @@ user:wam_member_unbound_list(X) :- user:wam_unbound_arg(Y), member(X, Y).
 user:wam_append_guard(A, B, C) :- append(A, B, C).
 user:wam_append_bad_left(C) :- append([a|b], [c], C).
 user:wam_append_unbound_left(C) :- user:wam_unbound_arg(A), append(A, [b], C).
+user:wam_append_split(A, B) :- append(A, B, [a,b,c]).
 user:wam_ground_guard(X) :- ground(X).
 user:wam_ground_unbound(_) :- user:wam_unbound_arg(Y), ground(Y).
 user:wam_ground_nested_unbound(_) :- user:wam_unbound_arg(Y), ground(f(Y)).
@@ -239,6 +241,7 @@ run_smoke :-
           user:wam_append_guard/3,
           user:wam_append_bad_left/1,
           user:wam_append_unbound_left/1,
+          user:wam_append_split/2,
           user:wam_ground_guard/1,
           user:wam_ground_unbound/1,
           user:wam_ground_nested_unbound/1,
@@ -405,7 +408,12 @@ smoke_cases([
     case('wam_append_guard/3', args('[a,b]', '[]', '[a,b]'), "true"),
     case('wam_append_guard/3', args('[a]', '[b]', '[a,c]'), "false"),
     case('wam_append_bad_left/1', '[a,c]', "false"),
-    case('wam_append_unbound_left/1', '[a,b]', "false"),
+    case('wam_append_unbound_left/1', '[a,b]', "true"),
+    case('wam_append_split/2', args('[]', '[a,b,c]'), "true"),
+    case('wam_append_split/2', args('[a]', '[b,c]'), "true"),
+    case('wam_append_split/2', args('[a,b]', '[c]'), "true"),
+    case('wam_append_split/2', args('[a,b,c]', '[]'), "true"),
+    case('wam_append_split/2', args('[a]', '[c]'), "false"),
     case('wam_ground_guard/1', a, "true"),
     case('wam_ground_guard/1', 42, "true"),
     case('wam_ground_guard/1', 3.5, "true"),
@@ -587,8 +595,8 @@ assert_lowered_append_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-append-guard-3"),
     has(CoreCode, "defn lowered-wam-append-bad-left-1"),
     has(CoreCode, "defn lowered-wam-append-unbound-left-1"),
-    has(CoreCode, "runtime/proper-list-items"),
-    has(CoreCode, "runtime/list->term").
+    has(CoreCode, "defn lowered-wam-append-split-2"),
+    has(CoreCode, "runtime/apply-append-solution").
 
 assert_lowered_ground_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
@@ -792,6 +800,7 @@ prolog_term_string_to_edn('f(b)', "{:tag :struct :functor \"f/1\" :args [\"b\"]}
 prolog_term_string_to_edn('[a]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}") :- !.
 prolog_term_string_to_edn('[a,b]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
+prolog_term_string_to_edn('[c]', "{:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}") :- !.
 prolog_term_string_to_edn('[a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[a,b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[a|b]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"b\"]}") :- !.
@@ -800,6 +809,7 @@ prolog_term_string_to_edn("f(b)", "{:tag :struct :functor \"f/1\" :args [\"b\"]}
 prolog_term_string_to_edn("[a]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}") :- !.
 prolog_term_string_to_edn("[a,b]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
+prolog_term_string_to_edn("[c]", "{:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}") :- !.
 prolog_term_string_to_edn("[a,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[a,b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn(Atom, Atom).


### PR DESCRIPTION
## Summary

Extends Clojure WAM `append/3` support from deterministic concat mode to split mode.

## What Changed

- Refactors lowered `append/3` emission to call shared `runtime/apply-append-solution`.
- Keeps concat mode for `append(+ListA, +ListB, ?Out)`.
- Adds split mode for `append(A, B, GroundList)`.
- Enumerates prefix/suffix splits using existing foreign-style choice-point machinery.
- Adds runtime smoke coverage for every split of `[a,b,c]`.

## Semantics

Supported modes after this PR:

- `append(+ListA, +ListB, ?Out)`
- `append(?Prefix, ?Suffix, +GroundList)`

The split-mode path enumerates all valid prefix/suffix pairs and supports backtracking to later splits.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
