### PR TITLE
Feature/lua wam io builtins

### DIFF
--- a/PR_lua_wam_io_builtins.md
+++ b/PR_lua_wam_io_builtins.md
@@ -1,0 +1,18 @@
+# PR Title
+
+Add Lua WAM IO builtins
+
+# PR Description
+
+## Summary
+
+- add Lua WAM runtime support for `write/1`, `display/1`, and `nl/0`
+- add term formatting for atoms, numbers, variables, lists, and compound terms
+- add Lua generator end-to-end coverage for generated `write/1` plus `nl/0`
+- add direct Lua runtime coverage for `display/1`
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`

--- a/templates/targets/lua_wam/runtime.lua.mustache
+++ b/templates/targets/lua_wam/runtime.lua.mustache
@@ -392,6 +392,31 @@ local function builtin_length(program, state)
   return bind_or_compare(state, 2, V.Int(#items))
 end
 
+local function term_to_string(program, state, term)
+  term = Runtime.deref(state, term)
+  if type(term) ~= "table" then return tostring(term) end
+  if term.tag == "atom" then return Runtime.string_of(program.intern_table, term.id) end
+  if term.tag == "int" or term.tag == "float" then return tostring(term.val) end
+  if term.tag == "unbound" then return "_" .. tostring(term.name) end
+  if term.tag == "struct" then
+    local items = list_items(program, state, term)
+    if items ~= nil then
+      local parts = {}
+      for _, item in ipairs(items) do parts[#parts + 1] = term_to_string(program, state, item) end
+      return "[" .. table.concat(parts, ", ") .. "]"
+    end
+    local parts = {}
+    for _, arg in ipairs(term.args or {}) do parts[#parts + 1] = term_to_string(program, state, arg) end
+    return Runtime.string_of(program.intern_table, term.fid) .. "(" .. table.concat(parts, ", ") .. ")"
+  end
+  return tostring(term)
+end
+
+local function builtin_write(program, state)
+  io.write(term_to_string(program, state, Runtime.get_reg(state, 1)))
+  return true
+end
+
 local function builtin_functor(program, state)
   local term = Runtime.deref(state, Runtime.get_reg(state, 1))
   if type(term) == "table" and term.tag == "unbound" then
@@ -865,6 +890,8 @@ function Runtime.builtin_call(program, state, instr)
   if p == "fail" or p == "fail/0" then return false end
   if p == "!" or p == "!/0" then state.cps = {}; return true end
   if p == "\\+" or p == "\\+/1" then return builtin_naf(program, state) end
+  if p == "write" or p == "write/1" or p == "display" or p == "display/1" then return builtin_write(program, state) end
+  if p == "nl" or p == "nl/0" then io.write("\n"); return true end
   if p == "=" or p == "=/2" then return Runtime.unify(state, Runtime.get_reg(state, 1), Runtime.get_reg(state, 2)) end
   if p == "==" or p == "==/2" then return exact_equal(state, Runtime.get_reg(state, 1), Runtime.get_reg(state, 2)) end
   if p == "member" or p == "member/2" then return builtin_member(program, state) end

--- a/tests/test_wam_lua_generator.pl
+++ b/tests/test_wam_lua_generator.pl
@@ -61,6 +61,7 @@
 :- dynamic user:wam_lua_naf_false/0.
 :- dynamic user:wam_lua_naf_member/0.
 :- dynamic user:wam_lua_naf_member_no/0.
+:- dynamic user:wam_lua_write_line/0.
 
 user:wam_lua_fact(a).
 user:wam_lua_choice(a).
@@ -174,6 +175,9 @@ user:wam_lua_naf_true :- \+ fail.
 user:wam_lua_naf_false :- \+ true.
 user:wam_lua_naf_member :- \+ member(d, [a, b, c]).
 user:wam_lua_naf_member_no :- \+ member(a, [a, b, c]).
+user:wam_lua_write_line :-
+    write(hello),
+    nl.
 
 test(exports) :-
     assertion(current_predicate(wam_lua_target:write_wam_lua_project/3)),
@@ -576,6 +580,36 @@ test(lua_control_builtins_e2e, [condition(lua_available)]) :-
           run_lua_query(LuaDir, 'wam_lua_naf_false/0', [], false),
           run_lua_query(LuaDir, 'wam_lua_naf_member/0', [], true),
           run_lua_query(LuaDir, 'wam_lua_naf_member_no/0', [], false)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(lua_io_builtins_e2e, [condition(lua_available)]) :-
+    unique_lua_tmp_dir('tmp_lua_io_builtins_e2e', TmpDir),
+    setup_call_cleanup(
+        write_wam_lua_project([user:wam_lua_write_line/0], [], TmpDir),
+        ( directory_file_path(TmpDir, 'lua', LuaDir),
+          run_lua_script(
+              LuaDir,
+              'local m=require("generated_program"); assert(m.wam_lua_write_line())',
+              WriteOutput),
+          assertion(WriteOutput == "hello\n"),
+          atomic_list_concat([
+              'local rt=require("wam_runtime"); ',
+              'local R=rt.Runtime; local V=rt.V; local I=rt.I; ',
+              'local p={instructions={}, labels={}, ',
+              'intern_table=R.new_intern_table({"true","fail","[]",".","","[|]","f","a"})}; ',
+              'local fid=R.intern(p.intern_table,"f"); ',
+              'local aid=R.intern(p.intern_table,"a"); ',
+              'p.instructions={I.PutStructure(fid,1,1),I.SetConstant(V.Atom(aid)),',
+              'I.BuiltinCall("display/1",1),I.BuiltinCall("nl/0",0),I.Proceed()}; ',
+              'R.run_predicate(p,1,{})'
+          ], DisplayScript),
+          run_lua_script(
+              LuaDir,
+              DisplayScript,
+              DisplayOutput),
+          assertion(DisplayOutput == "f(a)\n")
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
# Add Lua WAM IO builtins

# PR Description

## Summary

- add Lua WAM runtime support for `write/1`, `display/1`, and `nl/0`
- add term formatting for atoms, numbers, variables, lists, and compound terms
- add Lua generator end-to-end coverage for generated `write/1` plus `nl/0`
- add direct Lua runtime coverage for `display/1`

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_lua_target), halt"`
