### PR TITLE
feat(wam-r): mode-analysis phase 2 -- get_constant inline + visibility fix

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -470,14 +470,17 @@ A lowered predicate is dispatched the same way as a compiled label:
 the wrapper calls the lowered function instead of stepping the
 instruction array. Failure semantics are identical.
 
-### Mode-analysis visibility (`mode_comments`)
+### Mode analysis (`mode_comments`, `mode_specialise`)
 
-Phase 1 of WAM-R mode-analysis integration. The shared
+WAM-R mode-analysis integration. The shared
 `core/binding_state_analysis.pl` analyser is already wired into the
-WAM compiler for `=../2` / `functor/3` / `arg/3` /
-`not_member_set` specialisations. The WAM-R lowered emitter
-now optionally surfaces the same analyser output as comments
-prepended to each generated function:
+WAM compiler for `=../2` / `functor/3` / `arg/3` / `not_member_set`
+specialisations. The WAM-R lowered emitter wires the same analyser
+output into two consumers:
+
+**1. Visibility (`mode_comments(on)`)** -- prepend a
+`# Mode analysis:` comment block above each lowered function so
+developers can inspect what the analyser inferred:
 
 ```prolog
 :- assertz(user:mode(p(+, -))).
@@ -488,27 +491,48 @@ prepended to each generated function:
        '/tmp/proj').
 ```
 
-The generated R contains:
-
 ```r
 # Mode analysis (phase 1, visibility-only):
-#   clause 1 head: [A-bound, B-unbound]   (mode_decl=[input, output])
+#   clause 1 head: [Arg1-bound, Arg2-unbound]   (mode_decl=[input, output])
 #
 # Lowered: p/2  (deterministic single-clause)
 lowered_p_2 <- function(program, state) { ... }
 ```
 
-`mode_comments(on)` is **visibility-only** -- no runtime or codegen
-behaviour change. The block is intended as a debugging aid and as
-the foundation for phase 2, which will consume the same analyser
-records to pick specialised emission paths (e.g. skipping deref on
-known-bound register slots). See
-[`design/WAM_R_MODE_ANALYSIS_PLAN.md`](design/WAM_R_MODE_ANALYSIS_PLAN.md)
-for the phase roadmap.
+Head-arg state legend: `bound` (mode +), `unbound` (mode -),
+`unknown` (mode ?, no declaration, or analyser can't prove either
+way). Non-variable head patterns (e.g. `p(alice)`) report `bound`
+because head unification by definition binds them, but this is
+visibility-only -- the specialisation below uses the mode
+declaration directly, not the visibility output.
+
+**2. Specialised inline emission (default ON)** -- when the mode
+declaration says `+` for a head arg position, the lowered emitter
+inlines `get_constant` head matches as:
+
+```r
+{ val_ <- WamRuntime$deref(state, WamRuntime$get_reg(state, AIdx))
+  if (is.null(val_) || !identical(val_, CTerm)) return(FALSE) }
+```
+
+instead of delegating to `WamRuntime$step`. Saves one `step()` call
+(list construction + function call + switch dispatch) per
+get_constant. Opt out via `mode_specialise(off)` if you need the
+unspecialised codegen (testing / regression bisection).
+
+**Soundness:** the specialisation skips the "rebind unbound to the
+constant" branch of `step`'s GetConstant handler, since mode `+`
+promises A_k is bound at clause entry. If a caller passes an
+unbound term where the mode says `+`, the inline form returns
+`FALSE` (treating unbound as a tag mismatch) where the step path
+would have bound it. Document; user is responsible for honest mode
+declarations.
 
 The mode declaration uses `user:mode/1` with `+` / `-` / `?`
 shorthand (input / output / any), the same convention
-`demand_analysis:read_mode_declaration/3` reads.
+`demand_analysis:read_mode_declaration/3` reads. See
+[`design/WAM_R_MODE_ANALYSIS_PLAN.md`](design/WAM_R_MODE_ANALYSIS_PLAN.md)
+for the phase roadmap and measured impact.
 
 ## Supported features
 
@@ -864,7 +888,9 @@ Coverage map (e2e tests, by feature group):
 | `strict_xf_chain_fails_e2e_rscript` | runtime parser enforces strict (xf / fx) vs non-strict (yf / fy) lhs-precedence rules: `5!!` parses with `op(100, yf, '!')` but fails with `op(100, xf, '!')`; `neg neg foo` parses with `op(900, fy, neg)` but fails with `op(900, fx, neg)` |
 | `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
-| `mode_analysis_phase1_comments` | Mode-analysis phase 1 visibility: `mode_comments(on)` option prepends `# Mode analysis:` block to each lowered function with per-clause head-binding states; foundation for phase 2 specialisations |
+| `mode_analysis_phase1_comments` | Mode-analysis visibility: `mode_comments(on)` option prepends `# Mode analysis:` block to each lowered function with per-clause head-binding states; covers `+`, `-`, `?`, undeclared mode shapes |
+| `mode_analysis_phase2_get_constant_inlined` | Mode-analysis phase 2: structural assertion that `get_constant` head match is emitted as inline `WamRuntime$deref + identical()` when the target A-register's declared mode is `+`; falls back to `WamRuntime$step` when no mode declaration or `mode_specialise(off)` |
+| `mode_analysis_phase2_get_constant_e2e_rscript` | Mode-analysis phase 2: e2e correctness -- a predicate with `:- mode(p(+))` and three clauses compiles + runs via Rscript, queries return correct true/false matching across the multi-clause backtracking path |
 
 ## Contributing
 

--- a/docs/design/WAM_R_MODE_ANALYSIS_PLAN.md
+++ b/docs/design/WAM_R_MODE_ANALYSIS_PLAN.md
@@ -39,7 +39,78 @@ predicates that `wam_r_lowerable/3` accepts.
   from the emitter without re-running the analyser at WAM-text-
   parsing time.
 
-## Phase 2 candidates — measured next
+## Phase 2 — get_constant inline specialisation (LANDED)
+
+**PR**: see commit history on `claude/wam-r-mode-analysis-phase2`.
+
+- Fix the visibility bug from phase 1 where `numbervars` ran before
+  the analyser query, causing `get_binding_state(_, '$VAR'(N), bound)`
+  to fire (treating numbervared vars as non-vars) and every head arg
+  to render as `bound` regardless of declared mode. Phase 2 runs the
+  analyser on plain Prolog vars and renders names positionally
+  (`Arg1`, `Arg2`, ...) instead. Test extended to cover all four
+  cases: `+`, `-`, `?`, undeclared.
+- New `mode_specialise(off)` option to disable the specialisation
+  (defaults to ON; off is for testing / regression bisection).
+- Add a specialised `emit_line_parts(["get_constant", ...], I)` clause
+  that fires when the declared mode of the target A-register is `+`
+  (input). The clause emits inline R:
+
+  ```r
+  { val_ <- WamRuntime$deref(state, WamRuntime$get_reg(state, AIdx))
+    if (is.null(val_) || !identical(val_, CTerm)) return(FALSE) }
+  ```
+
+  in place of `if (!isTRUE(WamRuntime$step(program, state,
+  GetConstant(C, AIdx)))) return(FALSE)`. Saves one `step()` call
+  (list construction + function call + switch dispatch) per
+  get_constant on the inlined clause-1 path.
+- The specialisation reads the mode declaration directly (via a
+  `b_setval`-stashed `wam_r_lowered_mode_decl`), not the analyser's
+  BeforeEnv -- BeforeEnv conflates head-pattern binding (a literal
+  `alice` in the head pattern looks `bound`) with caller-side
+  binding (whether A_k was bound when the caller invoked us). For
+  head-match instructions like get_constant we need the latter, and
+  only the mode declaration gives it to us.
+
+### Measured impact
+
+On a recursive predicate (`pn(0). pn(N) :- N > 0, N1 is N - 1,
+pn(N1).` with `:- mode(pn(+))`), 200 iterations × recursion depth
+2000:
+
+| Run | WITH (spec) | WITHOUT |
+|-----|-------------|---------|
+| 1 | 93.64s | 100.98s |
+| 2 | 95.03s | 94.69s |
+| 3 | 95.28s | 94.14s |
+| 4 | 97.14s | 96.75s |
+
+Mean: WITH 95.3s, WITHOUT 96.6s. The difference is **within run-to-
+run noise** (run 1's WITHOUT looks like an outlier).
+
+This is the expected result: most of the work is in clause 2 (the
+recursive case), which runs through the WAM array path / `step`
+unchanged. The inline get_constant only fires for clause 1 (the
+base case `pn(0)`), which is ~2000 calls per recursion chain --
+saving ~1-2μs each → ~2-4ms per chain → ~0.5-1% of the 95s total.
+
+**Conclusion:** the specialisation is *correct + sound + zero
+regression*, but the measurable wall-clock impact on existing
+benches is small. The infrastructure is the win. Phase 3+ extends
+the impact by:
+1. Adding more specialisations (so a larger fraction of step()
+   calls disappear).
+2. Lowering more shapes (so a larger fraction of clauses runs the
+   lowered path instead of the array path).
+
+Future bench design: a workload where the lowered emitter runs the
+*entire* call sequence (no array fallback) and where get_constant
+is a dominant fraction would show a clean win. The existing
+fact-source bench doesn't fit because its fact predicates go through
+the dedicated fact_table dispatch, not the lowered emitter.
+
+## Phase 3 candidates
 
 The fact-source-bench Rprof profile (see WAM_R_TARGET.md "Rprof
 profile of the WAM stepping engine") flags the dominant costs:
@@ -52,38 +123,39 @@ profile of the WAM stepping engine") flags the dominant costs:
 | `WamRuntime$deref` | 0.380 | 7.3% | **YES** -- skip deref at known-bound slots |
 | `WamRuntime$put_reg` | 0.260 | 5.0% | no -- already trivial |
 
-Top phase-2 candidates, in priority order:
+Top phase-3 candidates, in priority order:
 
-1. **`get_constant` head match -- skip deref when slot is provably
-   bound to a constant.** Currently delegates to `step`. With
-   mode info, emit `if (state$regs2[[idx]]$id != C$id) return(FALSE)`
-   inline. Expected: ~3-7% wall-clock on fact-source-bench
-   (head-match heavy).
-2. **`get_value` head match -- skip deref-then-unify when both
-   sides are provably bound atomics.** Similar to #1 but for
-   var-to-var matching.
-3. **`is/2` arithmetic fast path -- skip per-call type-tag checks
+1. **`get_value` head match -- skip deref-then-unify when both
+   sides are provably bound atomics.** Same shape as the phase-2
+   `get_constant` specialisation but for var-to-var matching.
+2. **`is/2` arithmetic fast path -- skip per-call type-tag checks
    when all RHS vars are provably bound to numerics.** Lives in
    builtin handlers, not the lowered emitter. Independent project.
-4. **Lowering more shapes.** When mode info proves a multi-clause
+3. **Lowering more shapes.** When mode info proves a multi-clause
    predicate is deterministic at this call site, the emitter could
    pick `deterministic` instead of `multi_clause_1`, skipping the
    CP push. Requires call-site mode info, not just clause-level.
+4. **Auto-mode-inference from call sites.** Today the analyser
+   only knows what `:- mode/1` declarations tell it. A whole-
+   program pass could infer modes from observed call sites,
+   eliminating the user's burden of declaring modes (and
+   broadening phase-2/3 specialisation coverage). Big project --
+   probably a separate sub-campaign.
 
-Phase 2 should pick **one** candidate (likely #1), implement +
-bench, and only proceed to the next if the measured win justifies
-it. The bench command is documented in WAM_R_TARGET.md ("Rprof
-profile of the WAM stepping engine").
+Phase 3 should pick **one** candidate, implement + bench on a
+workload that's actually dominated by the targeted op (not the
+fact-source bench, which goes through fact_table_dispatch). The
+bench command is documented in WAM_R_TARGET.md ("Rprof profile
+of the WAM stepping engine").
 
-## Phase 3+ — adaptive specialisation
+## Phase 4+ — adaptive specialisation
 
-Once phase 2 demonstrates a measurable win, the next direction is
-call-site-driven specialisation: the analyser tracks not just
+Call-site-driven specialisation: the analyser tracks not just
 "variables in this clause body" but "modes of every call site I
 see," and the emitter picks specialised emission per call site.
 This is a much bigger change (requires whole-program mode
-propagation) and is deferred until phase 2 establishes the
-pay-for-itself baseline.
+propagation) and is deferred until phase 3 establishes the
+pay-for-itself baseline on a representative workload.
 
 ## Risks / open questions
 

--- a/src/unifyweaver/targets/wam_r_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_r_lowered_emitter.pl
@@ -193,33 +193,96 @@ r_safe_code(_, 0'_).
 %    mode_comments(on)  -- prepend a `# Mode analysis:` comment block
 %                          summarising the inferred binding env per
 %                          clause. Off by default. Visibility-only;
-%                          no codegen change. Phase 1 of WAM-R mode-
-%                          analysis integration (see
-%                          docs/design/WAM_R_MODE_ANALYSIS_PLAN.md).
+%                          phase 1 of WAM-R mode-analysis integration.
+%    mode_specialise(off) -- disable the analyser-driven instruction
+%                          specialisations (currently: inline
+%                          get_constant when the target A-register is
+%                          provably bound). Phase 2 specialisations
+%                          are ON by default since they're always
+%                          sound when mode declarations are honest
+%                          and degrade to the step-delegating path
+%                          when mode info is insufficient.
+%
+%  See docs/design/WAM_R_MODE_ANALYSIS_PLAN.md for the roadmap.
 lower_predicate_to_r(PI, WamCode, Opts,
                      lowered(PredName, FuncName, Code)) :-
     ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     format(atom(PredName), '~w/~w', [Pred, Arity]),
     r_lowered_func_name(Pred/Arity, FuncName),
     build_emission_plan(WamCode, plan(Mode, AltLabel, ClauseLines)),
-    mode_comment_header(PI, Opts, ModeHeader),
+    catch(gather_pred_mode_records(PI, Records), _, Records = []),
+    set_lowered_mode_context(Records, Opts),
+    mode_comment_header_from_records(Opts, Records, ModeHeader),
     (   Mode == deterministic
     ->  emit_deterministic_function(PredName, FuncName, ClauseLines,
                                     ModeHeader, Code)
     ;   Mode == multi_clause_1
     ->  emit_multi_clause_function(PredName, FuncName, AltLabel,
                                    ClauseLines, ModeHeader, Code)
-    ).
+    ),
+    clear_lowered_mode_context.
 
-%% mode_comment_header(+PI, +Opts, -Header) is det.
+%% set_lowered_mode_context(+Records, +Opts) is det.
+%  Stashes clause 1's `:- mode/1` declaration on a non-backtrackable
+%  global so emit_line_parts can consult it without threading extra
+%  args through the entire emission chain. Mirrors the shared
+%  compiler's wam_clause_binding_records pattern.
+%
+%  Specialisations are gated by `mode_specialise(off)` in Opts --
+%  defaulting to ON. When OFF (or when no mode declaration exists),
+%  the stashed value is `none` so the specialised emit_line_parts
+%  clauses all fail and the default step-delegating path runs.
+%
+%  IMPORTANT: the specialisation uses the mode declaration directly,
+%  not the analyser's BeforeEnv. The BeforeEnv conflates head-pattern
+%  binding (a literal `alice` looks `bound`) with caller-side binding
+%  (whether A_k was bound when the caller invoked us). For head-match
+%  instructions like get_constant we need the latter, and only the
+%  mode declaration gives it to us.
+set_lowered_mode_context(Records, Opts) :-
+    (   member(mode_specialise(off), Opts)
+    ->  ModeDecl = none
+    ;   clause1_mode_decl(Records, ModeDecl)
+    ),
+    b_setval(wam_r_lowered_mode_decl, ModeDecl).
+
+clear_lowered_mode_context :-
+    b_setval(wam_r_lowered_mode_decl, none).
+
+%% clause1_mode_decl(+Records, -ModeDecl) is det.
+%  Pulls the ModeDecl component of clause 1's record. Returns `none`
+%  when there are no records or no declaration.
+clause1_mode_decl([mode_record(1, ModeDecl, _, _) | _], ModeDecl) :- !.
+clause1_mode_decl(_, none).
+
+%% head_state_for_areg(+AiStr, -State) is semidet.
+%  Returns the caller-side binding state for the A-register named by
+%  AiStr (e.g. "A1" -> first head arg position). Uses the stashed
+%  mode declaration:
+%    +  (input)  -> bound
+%    -  (output) -> unbound
+%    ?  (any)    -> fails (no provable state)
+%  Fails if AiStr isn't in the A-register range (1..100), if no mode
+%  declaration is stashed, or if the position is out of range in the
+%  mode list. Used by the get_constant specialised emit_line_parts
+%  clause.
+head_state_for_areg(AiStr, State) :-
+    wam_r_target:reg_to_int(AiStr, AIdx),
+    AIdx >= 1, AIdx =< 100,
+    catch(b_getval(wam_r_lowered_mode_decl, ModeDecl), _, fail),
+    is_list(ModeDecl),
+    nth1(AIdx, ModeDecl, Mode),
+    mode_atom_to_state(Mode, State).
+
+mode_atom_to_state(input,  bound).
+mode_atom_to_state(output, unbound).
+
+%% mode_comment_header_from_records(+Opts, +Records, -Header) is det.
 %  Builds the R comment block for the predicate's mode analysis when
 %  Opts contains mode_comments(on). Otherwise Header is the empty
-%  string. The block is intended to be visible in the generated R
-%  file so developers can see what the analyser inferred without
-%  re-running it.
-mode_comment_header(PI, Opts, Header) :-
+%  string.
+mode_comment_header_from_records(Opts, Records, Header) :-
     (   member(mode_comments(on), Opts),
-        catch(gather_pred_mode_records(PI, Records), _, fail),
         Records \= []
     ->  format_mode_records(Records, Lines),
         atomic_list_concat(Lines, '', Header)
@@ -234,13 +297,21 @@ mode_comment_header(PI, Opts, Header) :-
 %    - Idx        : 1-based clause number.
 %    - ModeDecl   : list of mode atoms (input/output/any) from
 %                   `:- mode/1`, or `none` if undeclared.
-%    - HeadVars   : list of `Var-Name-State` triples for each head
-%                   variable, where Name is the numbervars-assigned
-%                   atom and State is the binding state immediately
-%                   after head unification (i.e. BeforeEnv of goal 1).
+%    - HeadVars   : list of `Name-State` pairs, one per head arg
+%                   position. Name is `Arg<N>` for the Nth arg
+%                   position (1-based); State is the analyser's
+%                   binding-state for that arg right before the
+%                   first body goal (== entry to the clause body).
+%                   Non-variable head args render as `Arg<N>-bound`
+%                   (literal terms are always bound).
 %    - GoalBindings : the raw goal_binding(Idx, Before, After) list
 %                     from the analyser (renderable via
 %                     format_mode_records/2).
+%
+%  IMPORTANT: the analyser is called on plain Prolog variables (NOT
+%  numbervars-renamed), because `get_binding_state(_, NonVar, bound)`
+%  treats `'$VAR'(N)` as a nonvar and would always return `bound`.
+%  Head arg names in HeadVars are position-based for display only.
 %
 %  Module qualifiers in clause bodies are stripped (plunit wraps
 %  asserted bodies in plunit_<test>:user:Goal). Failure is silent --
@@ -254,8 +325,7 @@ gather_pred_mode_records(PI, Records) :-
                     wam_r_target:strip_module_qualifiers(RawBody,
                                                          StrippedBody),
                     copy_term(HeadTpl-StrippedBody,
-                              HeadCopy-BodyCopy),
-                    numbervars(HeadCopy-BodyCopy, 0, _) ),
+                              HeadCopy-BodyCopy) ),
                   Clauses), _, Clauses = []),
     (   demand_analysis:read_mode_declaration(Pred, Arity, ModeDecl)
     ->  true
@@ -269,51 +339,44 @@ gather_clause_records([Head-Body | Rest], Idx, ModeDecl,
     catch(binding_state_analysis:analyse_clause_bindings(Head, Body, GBs0),
           _, GBs0 = []),
     GBs = GBs0,
-    head_var_states(Head, GBs, HeadVars),
+    head_var_states(Head, ModeDecl, GBs, HeadVars),
     Idx1 is Idx + 1,
     gather_clause_records(Rest, Idx1, ModeDecl, Tail).
 
-%% head_var_states(+Head, +GoalBindings, -HeadVars) is det.
-%  Returns a list of `Name-State` pairs, one per direct head-arg
-%  variable. State is read from goal_binding(1, BeforeEnv, _) --
-%  the env right before the first body goal, which is what an
-%  optimizer choosing a head-match specialisation would consult.
-head_var_states(Head, GBs, HeadVars) :-
+%% head_var_states(+Head, +ModeDecl, +GoalBindings, -HeadVars) is det.
+%  Returns one `Arg<N>-State` pair per head arg position, where State
+%  is the analyser's binding state for that arg right before the first
+%  body goal (the env that an optimizer would consult when deciding
+%  whether to specialise a head-match instruction). Non-variable head
+%  args (compound, atomic, struct, ...) always render as `bound`
+%  because head unification by definition binds them. Variable head
+%  args render with the analyser's actual state -- `bound` (mode +),
+%  `unbound` (mode -), or `unknown` (no info).
+%
+%  When the body has no goals (e.g. `true` / a fact clause), the
+%  analyser returns an empty GoalBindings list; we fall back to the
+%  initial env from `initial_binding_env/3` so head modes still
+%  surface in the visibility comment.
+head_var_states(Head, ModeDecl, GBs, HeadVars) :-
     Head =.. [_ | Args],
     (   member(goal_binding(1, BeforeEnv, _), GBs)
-    ->  true
-    ;   binding_state_analysis:empty_binding_env(BeforeEnv)
+    ->  Env = BeforeEnv
+    ;   binding_state_analysis:initial_binding_env(Head, ModeDecl, Env)
     ),
-    head_var_states_(Args, BeforeEnv, HeadVars).
+    head_var_states_(Args, 1, Env, HeadVars).
 
-head_var_states_([], _, []).
-head_var_states_([Arg | Rest], Env, [Name-State | Tail]) :-
-    (   var(Arg)
-    ->  format(atom(Name), '_var_~w', [Arg])
-    ;   Arg = '$VAR'(N)
-    ->  numbered_var_atom(N, Name)
-    ;   Name = '<nonvar>'
-    ),
-    (   var(Arg)
-    ->  State = unbound
-    ;   binding_state_analysis:get_binding_state(Env, Arg, State0)
-    ->  State = State0
-    ;   State = unknown
-    ),
-    head_var_states_(Rest, Env, Tail).
+head_var_states_([], _, _, []).
+head_var_states_([Arg | Rest], Pos, Env, [Name-State | Tail]) :-
+    format(atom(Name), 'Arg~w', [Pos]),
+    head_arg_state(Arg, Env, State),
+    Pos1 is Pos + 1,
+    head_var_states_(Rest, Pos1, Env, Tail).
 
-%% numbered_var_atom(+N, -Atom) is det.
-%  Mirrors the SWI numbervars convention: 0..25 -> A..Z, then A1..Z1,
-%  A2..Z2, etc. Used so head-arg variable names in the emitted
-%  comments match what numbervars/3 displays elsewhere.
-numbered_var_atom(N, Atom) :-
-    Letter is N mod 26,
-    Suffix is N // 26,
-    Code is 0'A + Letter,
-    (   Suffix =:= 0
-    ->  char_code(Char, Code), atom_concat(Char, '', Atom)
-    ;   char_code(Char, Code), atom_concat(Char, Suffix, Atom)
-    ).
+head_arg_state(Arg, _Env, bound) :-
+    nonvar(Arg), !.
+head_arg_state(Arg, Env, State) :-
+    var(Arg),
+    binding_state_analysis:get_binding_state(Env, Arg, State).
 
 %% format_mode_records(+Records, -Lines) is det.
 %  Renders the analyser output as a block of R comment lines.
@@ -437,6 +500,27 @@ emit_line_parts(["get_variable", XStr, AiStr], I) :- !,
     wam_r_target:reg_to_int(AiStr, AIdx),
     format("~wWamRuntime$put_reg(state, ~w, WamRuntime$get_reg(state, ~w))~n",
            [I, XIdx, AIdx]).
+
+% --- Mode-driven specialisation: inline get_constant when the analyser
+% proves the target A-register is bound. The default path delegates to
+% WamRuntime$step which handles the unbound branch (binds A_i to the
+% constant). When mode info promises A_i is already bound, the unbound
+% branch is dead code -- we just need a deref + identical-equality
+% check. Saves one function call (~0.5us, the dominant cost) per
+% get_constant; significant on head-match-heavy workloads.
+%
+% Soundness: relies on the analyser's `bound` answer being correct,
+% which in turn relies on `:- mode/1` declarations being honest. If a
+% caller passes an unbound term where the mode says +, the inline
+% form returns FALSE (treating unbound as a tag mismatch) where the
+% step path would have bound it. Document; user is responsible.
+emit_line_parts(["get_constant", CStr, AiStr], I) :-
+    head_state_for_areg(AiStr, bound),
+    !,
+    wam_r_target:reg_to_int(AiStr, AIdx),
+    wam_r_target:constant_to_r_term(CStr, CTerm),
+    format("~w{ val_ <- WamRuntime$deref(state, WamRuntime$get_reg(state, ~w)); if (is.null(val_) || !identical(val_, ~w)) return(FALSE) }~n",
+           [I, AIdx, CTerm]).
 
 % --- Default: delegate to step with the same R literal the array uses
 emit_line_parts(Parts, I) :-

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -639,36 +639,51 @@ e2e_phase3_multi_clause :-
 test(mode_analysis_phase1_comments) :-
     once((
         % Cleanup previous assertions if any.
-        retractall(user:ma_caller/1),
-        retractall(user:ma_callee/1),
-        retractall(user:mode(ma_caller(_))),
-        % Single-clause deterministic predicate so the lowered emitter
-        % picks it up. The mode declaration seeds the analyser: arg 1
-        % is input (-> bound at clause entry).
-        assertz(user:mode(ma_caller(+))),
-        assertz(user:ma_callee(_)),
-        assertz((user:ma_caller(X) :- user:ma_callee(X))),
+        retractall(user:ma_pin(_)),
+        retractall(user:ma_pout(_)),
+        retractall(user:ma_pany(_)),
+        retractall(user:ma_pnone(_)),
+        retractall(user:mode(ma_pin(_))),
+        retractall(user:mode(ma_pout(_))),
+        retractall(user:mode(ma_pany(_))),
+        % Four single-clause deterministic predicates, one per mode shape.
+        % The lowered emitter picks all of them; we assert the visibility
+        % comment reports the correct head-binding for each.
+        assertz(user:mode(ma_pin(+))),
+        assertz((user:ma_pin(_X)   :- true)),
+        assertz(user:mode(ma_pout(-))),
+        assertz((user:ma_pout(_X)  :- true)),
+        assertz(user:mode(ma_pany(?))),
+        assertz((user:ma_pany(_X)  :- true)),
+        assertz((user:ma_pnone(_X) :- true)),
         unique_r_tmp_dir('tmp_r_mode_comments', TmpDir),
         write_wam_r_project(
-            [ user:ma_caller/1, user:ma_callee/1 ],
+            [ user:ma_pin/1, user:ma_pout/1,
+              user:ma_pany/1, user:ma_pnone/1 ],
             [emit_mode(functions), mode_comments(on)],
             TmpDir),
         directory_file_path(TmpDir, 'R/generated_program.R', Program),
         read_file_to_string(Program, Code, []),
-        % The lowered function for ma_caller/1 should be preceded by
-        % the mode-analysis comment block, including the head-binding
-        % summary that mirrors the input-mode declaration.
+        % The lowered function for each is preceded by the mode-analysis
+        % comment block; head-binding state matches the mode declaration.
         assertion(sub_string(Code, _, _, _,
             '# Mode analysis (phase 1, visibility-only):')),
         assertion(sub_string(Code, _, _, _,
-            'mode_decl=[input]')),
-        % And the lowered function itself is still emitted.
+            '[Arg1-bound]   (mode_decl=[input])')),
         assertion(sub_string(Code, _, _, _,
-            'lowered_ma_caller_1 <- function(program, state)')),
+            '[Arg1-unbound]   (mode_decl=[output])')),
+        assertion(sub_string(Code, _, _, _,
+            '[Arg1-unknown]   (mode_decl=[any])')),
+        assertion(sub_string(Code, _, _, _,
+            '[Arg1-unknown]   (mode_decl=none)')),
+        % And the lowered functions themselves are still emitted.
+        assertion(sub_string(Code, _, _, _,
+            'lowered_ma_pin_1 <- function(program, state)')),
         % Sanity: with the option OFF, the comment block is absent.
         unique_r_tmp_dir('tmp_r_mode_comments_off', TmpDir2),
         write_wam_r_project(
-            [ user:ma_caller/1, user:ma_callee/1 ],
+            [ user:ma_pin/1, user:ma_pout/1,
+              user:ma_pany/1, user:ma_pnone/1 ],
             [emit_mode(functions)],
             TmpDir2),
         directory_file_path(TmpDir2, 'R/generated_program.R', Program2),
@@ -676,10 +691,135 @@ test(mode_analysis_phase1_comments) :-
         assertion(\+ sub_string(Code2, _, _, _,
             '# Mode analysis (phase 1, visibility-only):')),
         % Cleanup.
-        retractall(user:mode(ma_caller(_))),
+        retractall(user:mode(ma_pin(_))),
+        retractall(user:mode(ma_pout(_))),
+        retractall(user:mode(ma_pany(_))),
         delete_directory_and_contents(TmpDir),
         delete_directory_and_contents(TmpDir2)
     )).
+
+% ------------------------------------------------------------------
+% Mode-analysis phase 2: get_constant head match specialisation.
+% When the analyser proves the target A-register is bound at the head
+% match (via `:- mode(p(+, ...))`), the lowered emitter emits an
+% inline `WamRuntime$deref + identical()` check instead of delegating
+% to WamRuntime$step. Saves one function call (~0.5us, the dominant
+% cost) per get_constant on the hot path.
+%
+% This test asserts the inlined form appears for the +mode case and
+% the step-delegating form appears for the no-mode case. Structural
+% (no Rscript required); the e2e correctness path is exercised by the
+% existing fact_table tests, which the full suite verifies still
+% pass.
+% ------------------------------------------------------------------
+test(mode_analysis_phase2_get_constant_inlined) :-
+    once((
+        retractall(user:ma_pc(_)),
+        retractall(user:mode(ma_pc(_))),
+        % Predicate matches against an atom constant in the head -- the
+        % shared compiler emits `get_constant alice, A1` here. With
+        % :- mode(ma_pc(+)) the analyser proves Arg1 is bound, so the
+        % lowered emitter should inline the get_constant.
+        assertz(user:mode(ma_pc(+))),
+        assertz((user:ma_pc(alice) :- true)),
+        unique_r_tmp_dir('tmp_r_get_const_specialised', TmpDir),
+        write_wam_r_project(
+            [ user:ma_pc/1 ],
+            [emit_mode(functions), fact_table_layout(off)],
+            TmpDir),
+        directory_file_path(TmpDir, 'R/generated_program.R', Program),
+        read_file_to_string(Program, Code, []),
+        % Specialised inline form present.
+        assertion(sub_string(Code, _, _, _,
+            'val_ <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1))')),
+        assertion(sub_string(Code, _, _, _,
+            'if (is.null(val_) || !identical(val_, Atom(')),
+        % AND the step-delegating form for THIS get_constant must be
+        % absent (the assertion verifies the specialised clause won.)
+        assertion(\+ sub_string(Code, _, _, _,
+            'WamRuntime$step(program, state, GetConstant(Atom(')),
+        % --- Negative path: same predicate compiled WITHOUT mode decl
+        % (and WITHOUT the global mode option). The analyser can't prove
+        % Arg1 is bound, so the specialisation must NOT fire -- the
+        % default step-delegating form should appear.
+        retractall(user:mode(ma_pc(_))),
+        unique_r_tmp_dir('tmp_r_get_const_unspecialised', TmpDir2),
+        write_wam_r_project(
+            [ user:ma_pc/1 ],
+            [emit_mode(functions), fact_table_layout(off)],
+            TmpDir2),
+        directory_file_path(TmpDir2, 'R/generated_program.R', Program2),
+        read_file_to_string(Program2, Code2, []),
+        assertion(sub_string(Code2, _, _, _,
+            'WamRuntime$step(program, state, GetConstant(Atom(')),
+        assertion(\+ sub_string(Code2, _, _, _,
+            'val_ <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1))')),
+        % --- mode_specialise(off) opt-out: even with the mode decl, the
+        % user can disable the specialisation if needed for debugging /
+        % bisection. Verify the opt-out works.
+        assertz(user:mode(ma_pc(+))),
+        unique_r_tmp_dir('tmp_r_get_const_optout', TmpDir3),
+        write_wam_r_project(
+            [ user:ma_pc/1 ],
+            [emit_mode(functions), fact_table_layout(off),
+             mode_specialise(off)],
+            TmpDir3),
+        directory_file_path(TmpDir3, 'R/generated_program.R', Program3),
+        read_file_to_string(Program3, Code3, []),
+        assertion(sub_string(Code3, _, _, _,
+            'WamRuntime$step(program, state, GetConstant(Atom(')),
+        % Cleanup.
+        retractall(user:mode(ma_pc(_))),
+        delete_directory_and_contents(TmpDir),
+        delete_directory_and_contents(TmpDir2),
+        delete_directory_and_contents(TmpDir3)
+    )).
+
+% ------------------------------------------------------------------
+% Mode-analysis phase 2: e2e correctness of the get_constant
+% specialisation. A predicate with declared input mode is compiled
+% with the specialisation enabled; the runtime must produce the same
+% true/false results as the unspecialised path. Auto-skips when
+% Rscript is not on PATH.
+% ------------------------------------------------------------------
+test(mode_analysis_phase2_get_constant_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_mode_phase2_get_constant
+    ;   true
+    )).
+
+e2e_mode_phase2_get_constant :-
+    retractall(user:ma_pe(_)),
+    retractall(user:mode(ma_pe(_))),
+    retractall(user:ma_check_a/0),
+    retractall(user:ma_check_b/0),
+    retractall(user:ma_check_z/0),
+    % `+` mode -- caller will always pass a bound atom; specialisation
+    % fires. Use three clauses so multi_clause_1 lowering also kicks in,
+    % exercising the inlined get_constant in the multi-clause path.
+    assertz(user:mode(ma_pe(+))),
+    assertz((user:ma_pe(a))),
+    assertz((user:ma_pe(b))),
+    assertz((user:ma_pe(c))),
+    assertz((user:ma_check_a :- ma_pe(a))),
+    assertz((user:ma_check_b :- ma_pe(b))),
+    assertz((user:ma_check_z :- ma_pe(z))),
+    unique_r_tmp_dir('tmp_r_mode_phase2_e2e', TmpDir),
+    write_wam_r_project(
+        [ user:ma_pe/1, user:ma_check_a/0,
+          user:ma_check_b/0, user:ma_check_z/0 ],
+        [emit_mode(functions), fact_table_layout(off)],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    run_rscript_query(RDir, 'ma_check_a/0', OutA),
+    run_rscript_query(RDir, 'ma_check_b/0', OutB),
+    run_rscript_query(RDir, 'ma_check_z/0', OutZ),
+    assertion(sub_string(OutA, _, _, _, "true")),
+    assertion(sub_string(OutB, _, _, _, "true")),
+    assertion(sub_string(OutZ, _, _, _, "false")),
+    retractall(user:mode(ma_pe(_))),
+    delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
 % Phase-3 follow-up: extended builtins.


### PR DESCRIPTION
## Summary

Two changes in one PR:

### 1. Visibility bug fix from phase 1

`gather_pred_mode_records` ran `numbervars/2` on the clause copy **before** querying the analyser's binding env. The analyser's `get_binding_state(_, NonVar, bound)` clause fired immediately for `'$VAR'(N)` (since it's `nonvar/1`), so every head arg rendered as `bound` regardless of declared mode.

Fix: analyser runs on plain Prolog vars; head-arg names are rendered positionally as `Arg1`, `Arg2`, ... rather than via numbervars. Also adds a fallback to `initial_binding_env/3` when the body is `true`/empty.

The test now correctly distinguishes the four mode shapes:

```r
#   clause 1 head: [Arg1-bound]   (mode_decl=[input])
#   clause 1 head: [Arg1-unbound]   (mode_decl=[output])
#   clause 1 head: [Arg1-unknown]   (mode_decl=[any])
#   clause 1 head: [Arg1-unknown]   (mode_decl=none)
```

### 2. `get_constant` inline specialisation

New `mode_specialise(off)` option (defaults ON). When the declared mode of the target A-register is `+`, the lowered emitter replaces

```r
if (!isTRUE(WamRuntime$step(program, state, GetConstant(C, AIdx)))) return(FALSE)
```

with

```r
{ val_ <- WamRuntime$deref(state, WamRuntime$get_reg(state, AIdx))
  if (is.null(val_) || !identical(val_, CTerm)) return(FALSE) }
```

skipping the `WamRuntime$step` function call (list construction + function call + switch dispatch).

The specialisation reads the **mode declaration directly** via a `b_setval`-stashed `wam_r_lowered_mode_decl`, **not** the analyser's BeforeEnv -- BeforeEnv conflates head-pattern binding (a literal `alice` in the head pattern looks `bound`) with caller-side binding (whether A_k was bound when the caller invoked us). For head-match instructions we need the latter, and only the mode declaration gives it to us.

**Soundness:** the inline form omits the "rebind unbound to the constant" branch of `step`'s GetConstant handler, since mode `+` promises A_k is bound at clause entry. If a caller passes an unbound term where the mode says `+`, the inline form returns FALSE where the step path would have bound it. User is responsible for honest mode declarations.

## Measured impact

Honest result: the specialisation is **correct + sound + zero regression**, but the measurable wall-clock impact on the existing recursive-predicate bench (200 iter × depth 2000) is **within run-to-run noise**:

| Run | WITH (spec) | WITHOUT |
|-----|-------------|---------|
| 1 | 93.64s | 100.98s |
| 2 | 95.03s | 94.69s |
| 3 | 95.28s | 94.14s |
| 4 | 97.14s | 96.75s |

Mean: WITH 95.3s, WITHOUT 96.6s. Most of the bench's work runs through the WAM array path / `step` unchanged, since clause 2 (the recursive case) falls back to the array. The inline `get_constant` only fires for clause 1 (the base case), saving ~1-2μs × 2000 calls per chain ≈ 0.5-1% of total -- below the noise floor.

**The infrastructure is the win.** Phase 3+ will broaden specialisation coverage (`get_value`, `is/2`, lowering more shapes) to push more of the per-instruction cost out of the `step` hot path. See `docs/design/WAM_R_MODE_ANALYSIS_PLAN.md` for the updated roadmap.

## Test plan

- [x] `mode_analysis_phase1_comments` -- extended to cover all four mode shapes (`+`, `-`, `?`, undeclared) and assert correct head-binding states for each.
- [x] **NEW** `mode_analysis_phase2_get_constant_inlined` (structural): asserts the inline form appears with mode `+`, the step-delegating form appears without mode and with `mode_specialise(off)`.
- [x] **NEW** `mode_analysis_phase2_get_constant_e2e_rscript`: end-to-end correctness via Rscript, three-clause backtracking with `+` mode, true/true/false matching.
- [x] Full WAM-R suite: **79/79 pass** (77 prior + 2 new), ~512s wall-clock.

## Risks

- `b_setval(wam_r_lowered_mode_decl, ...)` is non-backtrackable. The set/clear pair around the emit functions keeps it scoped to one `lower_predicate_to_r/4` invocation; recursive lowering (which doesn't currently happen) would need additional care.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_