### PR TITLE
feat(wam-clojure): add copy_term/2 builtin support

### DIFF
--- a/PR_WAM_CLOJURE_COPY_TERM_BUILTIN.md
+++ b/PR_WAM_CLOJURE_COPY_TERM_BUILTIN.md
@@ -1,0 +1,27 @@
+# feat(wam-clojure): add copy_term/2 builtin support
+
+## Summary
+
+Adds Clojure WAM runtime and lowered-emitter support for `copy_term/2`.
+
+## What Changed
+
+- Added a sharing-preserving `copy-term` walker to the generated Clojure WAM runtime.
+- Routed interpreted `copy_term/2` builtin calls through `apply-copy-term-solution`.
+- Registered `copy_term/2` as a direct lowered Clojure builtin.
+- Added lowered-emitter coverage proving `copy_term/2` bypasses generic `runtime/step`.
+- Extended the Clojure runtime smoke suite with ground copy, repeated-variable sharing, and independent-variable copy cases.
+
+## Validation
+
+```sh
+git diff --check
+swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
+swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
+timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
+```
+
+## Notes
+
+- This keeps the scope focused on `copy_term/2` parity for the Clojure hybrid WAM path.
+- Broader generated-build cyclic-term behavior is left unchanged; this PR only validates `copy_term/2` semantics independently of that older runtime edge case.

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -360,6 +360,10 @@ clojure_direct_builtin("append/3", "3").
 clojure_direct_builtin("append/3", 3).
 clojure_direct_builtin('append/3', "3").
 clojure_direct_builtin('append/3', 3).
+clojure_direct_builtin("copy_term/2", "2").
+clojure_direct_builtin("copy_term/2", 2).
+clojure_direct_builtin('copy_term/2', "2").
+clojure_direct_builtin('copy_term/2', 2).
 clojure_direct_builtin("ground/1", "1").
 clojure_direct_builtin("ground/1", 1).
 clojure_direct_builtin('ground/1', "1").
@@ -563,6 +567,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr),
            '(let [left (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) right (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound)) out (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A3") ::lowered-unbound))] (runtime/apply-append-solution ~w (inc (:pc ~w)) left right out))',
            [S, S, S, S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "copy_term/2" ; Op == 'copy_term/2'),
+    !,
+    format(atom(Expr), '(runtime/apply-copy-term-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "ground/1" ; Op == 'ground/1'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -659,6 +659,41 @@
   (let [id (:next-var-id state)]
     [(var-term id) (update state :next-var-id inc)]))
 
+(defn copy-term-walk [state term var-map]
+  (let [term* (deref-value (:bindings state) term)]
+    (cond
+      (logic-var? term*)
+      (if-let [fresh (get var-map (:var term*))]
+        [fresh state var-map]
+        (let [[fresh next-state] (fresh-var state)]
+          [fresh next-state (assoc var-map (:var term*) fresh)]))
+
+      (structure-term? term*)
+      (loop [s state
+             env var-map
+             args (:args term*)
+             out []]
+        (if-let [arg (first args)]
+          (let [[arg-copy s* env*] (copy-term-walk s arg env)]
+            (recur s* env* (next args) (conj out arg-copy)))
+          [(structure-term (:functor term*) out) s env]))
+
+      :else
+      [term* state var-map])))
+
+(defn copy-term [state term]
+  (let [[copied next-state _] (copy-term-walk state term {})]
+    [copied next-state]))
+
+(defn apply-copy-term-solution [state]
+  (let [source (or (reg-get-raw state "A1") ::unbound)
+        target (or (reg-get-raw state "A2") ::unbound)
+        [copied copy-state] (copy-term state source)
+        [ok next-state] (unify-values copy-state target copied)]
+    (if ok
+      (advance next-state)
+      (backtrack state))))
+
 (defn push-build-frame [state target-reg functor arity]
   (update state :build-stack conj {:target-reg target-reg
                                    :functor functor
@@ -1197,6 +1232,9 @@
                 out (deref-value (:bindings state)
                                  (or (reg-get-raw state "A3") ::unbound))]
             (apply-append-solution state (inc (:pc state)) left right out))
+
+          "copy_term/2"
+          (apply-copy-term-solution state)
 
           "ground/1"
           (let [value (deref-value (:bindings state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -476,6 +476,15 @@ test(simple_builtin_append_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_copy_term_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_copy_term/2:\nbuiltin_call copy_term/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_copy_term/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_copy_term/2, WamCode, [], Code),
+        has(Code, "runtime/apply-copy-term-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_ground_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_ground/1:\nbuiltin_call ground/1, 1\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -65,6 +65,9 @@
 :- dynamic user:wam_append_bad_left/1.
 :- dynamic user:wam_append_unbound_left/1.
 :- dynamic user:wam_append_split/2.
+:- dynamic user:wam_copy_term_guard/2.
+:- dynamic user:wam_copy_term_sharing_fail/0.
+:- dynamic user:wam_copy_term_independent_ok/0.
 :- dynamic user:wam_ground_guard/1.
 :- dynamic user:wam_ground_unbound/1.
 :- dynamic user:wam_ground_nested_unbound/1.
@@ -151,6 +154,9 @@ user:wam_append_guard(A, B, C) :- append(A, B, C).
 user:wam_append_bad_left(C) :- append([a|b], [c], C).
 user:wam_append_unbound_left(C) :- user:wam_unbound_arg(A), append(A, [b], C).
 user:wam_append_split(A, B) :- append(A, B, [a,b,c]).
+user:wam_copy_term_guard(A, B) :- copy_term(A, B).
+user:wam_copy_term_sharing_fail :- copy_term(f(X, X), f(a, b)).
+user:wam_copy_term_independent_ok :- copy_term(f(_, _), f(a, b)).
 user:wam_ground_guard(X) :- ground(X).
 user:wam_ground_unbound(_) :- user:wam_unbound_arg(Y), ground(Y).
 user:wam_ground_nested_unbound(_) :- user:wam_unbound_arg(Y), ground(f(Y)).
@@ -242,6 +248,9 @@ run_smoke :-
           user:wam_append_bad_left/1,
           user:wam_append_unbound_left/1,
           user:wam_append_split/2,
+          user:wam_copy_term_guard/2,
+          user:wam_copy_term_sharing_fail/0,
+          user:wam_copy_term_independent_ok/0,
           user:wam_ground_guard/1,
           user:wam_ground_unbound/1,
           user:wam_ground_nested_unbound/1,
@@ -292,6 +301,7 @@ run_smoke :-
     assert_lowered_length_builtin_emitted(TmpDir),
     assert_lowered_member_builtin_emitted(TmpDir),
     assert_lowered_append_builtin_emitted(TmpDir),
+    assert_lowered_copy_term_builtin_emitted(TmpDir),
     assert_lowered_ground_builtin_emitted(TmpDir),
     assert_lowered_arithmetic_comparison_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
@@ -414,6 +424,12 @@ smoke_cases([
     case('wam_append_split/2', args('[a,b]', '[c]'), "true"),
     case('wam_append_split/2', args('[a,b,c]', '[]'), "true"),
     case('wam_append_split/2', args('[a]', '[c]'), "false"),
+    case('wam_copy_term_guard/2', args(a, a), "true"),
+    case('wam_copy_term_guard/2', args(a, b), "false"),
+    case('wam_copy_term_guard/2', args('f(a)', 'f(a)'), "true"),
+    case('wam_copy_term_guard/2', args('f(a)', 'f(b)'), "false"),
+    case('wam_copy_term_sharing_fail/0', no_args, "false"),
+    case('wam_copy_term_independent_ok/0', no_args, "true"),
     case('wam_ground_guard/1', a, "true"),
     case('wam_ground_guard/1', 42, "true"),
     case('wam_ground_guard/1', 3.5, "true"),
@@ -597,6 +613,14 @@ assert_lowered_append_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-append-unbound-left-1"),
     has(CoreCode, "defn lowered-wam-append-split-2"),
     has(CoreCode, "runtime/apply-append-solution").
+
+assert_lowered_copy_term_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-copy-term-guard-2"),
+    has(CoreCode, "defn lowered-wam-copy-term-sharing-fail-0"),
+    has(CoreCode, "defn lowered-wam-copy-term-independent-ok-0"),
+    has(CoreCode, "runtime/apply-copy-term-solution").
 
 assert_lowered_ground_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

Adds Clojure WAM runtime and lowered-emitter support for `copy_term/2`.

## What Changed

- Added a sharing-preserving `copy-term` walker to the generated Clojure WAM runtime.
- Routed interpreted `copy_term/2` builtin calls through `apply-copy-term-solution`.
- Registered `copy_term/2` as a direct lowered Clojure builtin.
- Added lowered-emitter coverage proving `copy_term/2` bypasses generic `runtime/step`.
- Extended the Clojure runtime smoke suite with ground copy, repeated-variable sharing, and independent-variable copy cases.

## Validation

```sh
git diff --check
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
```

## Notes

- This keeps the scope focused on `copy_term/2` parity for the Clojure hybrid WAM path.
- Broader generated-build cyclic-term behavior is left unchanged; this PR only validates `copy_term/2` semantics independently of that older runtime edge case.
