### PR TITLE
feat(wam-r): mode-analysis phase 3 -- is/2 runtime fast-path + lowered inline

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -534,6 +534,35 @@ shorthand (input / output / any), the same convention
 [`design/WAM_R_MODE_ANALYSIS_PLAN.md`](design/WAM_R_MODE_ANALYSIS_PLAN.md)
 for the phase roadmap and measured impact.
 
+### `is/2` specialisation (phase 3)
+
+Two complementary specialisations targeting the `is/2` arithmetic
+builtin (dominant cost on arith-heavy recursive predicates):
+
+**Runtime fast-path** (in `WamRuntime$call_builtin`'s is/2 branch).
+When the expression is a 2-arg arithmetic struct (`+`, `-`, `*`,
+`//`, `mod`) with both operands derefing to ints, bypasses the
+recursive `eval_arith` walk + `arith_to_term` dispatch and
+fast-binds when the target is unbound. Falls through to the
+original slow path for floats, nested expressions, unbound vars in
+the RHS, etc. Always active, no codegen flag needed.
+
+**Lowered-emitter inline.** For `builtin_call is/2 2` lines in a
+lowered function body, the emitter emits inline R that bypasses
+`WamRuntime$step` → `WamRuntime$call_builtin` (saving 2 function
+calls + 2 switch lookups per is/2 hit). Always fires when the
+lowered emitter handles the clause; the runtime fast-path then
+applies inside the inline body.
+
+Note: both specialisations only affect `is/2` calls that reach the
+lowered emitter (phase-3 b) or the array path / step (phase-3 a). A
+multi-clause predicate where clause 2+ contains the is/2 will go
+through the array path for those clauses, so phase-3 (a) handles
+it. The lowered-emitter inline (b) only helps for the lowered
+clauses (today: deterministic or multi_clause_1's first clause).
+See `WAM_R_MODE_ANALYSIS_PLAN.md` phase 4 for the multi_clause_n
+extension that would unlock more of the win.
+
 ## Supported features
 
 ### Control
@@ -891,6 +920,8 @@ Coverage map (e2e tests, by feature group):
 | `mode_analysis_phase1_comments` | Mode-analysis visibility: `mode_comments(on)` option prepends `# Mode analysis:` block to each lowered function with per-clause head-binding states; covers `+`, `-`, `?`, undeclared mode shapes |
 | `mode_analysis_phase2_get_constant_inlined` | Mode-analysis phase 2: structural assertion that `get_constant` head match is emitted as inline `WamRuntime$deref + identical()` when the target A-register's declared mode is `+`; falls back to `WamRuntime$step` when no mode declaration or `mode_specialise(off)` |
 | `mode_analysis_phase2_get_constant_e2e_rscript` | Mode-analysis phase 2: e2e correctness -- a predicate with `:- mode(p(+))` and three clauses compiles + runs via Rscript, queries return correct true/false matching across the multi-clause backtracking path |
+| `mode_analysis_phase3_is_inlined` | Mode-analysis phase 3: structural assertion that `builtin_call is/2 2` is emitted as inline `WamRuntime$eval_arith + bind/unify` in the lowered function (instead of `WamRuntime$step(... BuiltinCall("is/2", 2))`) |
+| `mode_analysis_phase3_is_e2e_rscript` | Mode-analysis phase 3: e2e correctness -- a predicate using `is/2` with simple binary int op (runtime fast-path), nested arith (slow path), and negative-result arith compiles + runs via Rscript with correct values |
 
 ## Contributing
 

--- a/docs/design/WAM_R_MODE_ANALYSIS_PLAN.md
+++ b/docs/design/WAM_R_MODE_ANALYSIS_PLAN.md
@@ -110,7 +110,107 @@ is a dominant fraction would show a clean win. The existing
 fact-source bench doesn't fit because its fact predicates go through
 the dedicated fact_table dispatch, not the lowered emitter.
 
-## Phase 3 candidates
+## Phase 3 — is/2 specialisation (LANDED)
+
+**PR**: see commit history on `claude/wam-r-mode-analysis-phase3-is-fastpath`.
+
+Two combined changes targeting the `is/2` arithmetic builtin, which
+is a dominant cost on any predicate that recurses while doing
+arithmetic (the most common shape outside fact tables):
+
+**(a) Runtime fast-path in the is/2 handler.** When the expression
+is a 2-arg arithmetic struct (`+`, `-`, `*`, `//`, `mod`) and both
+operands deref to ints, bypass the recursive `eval_arith` walk +
+`arith_to_term` dispatch. Additionally fast-bind the target when it
+derefs to unbound, skipping the unify. Falls through to the original
+slow path for anything that doesn't match the fast shape.
+
+```r
+# In WamRuntime$call_builtin, is/2 branch:
+expr_d <- WamRuntime$deref(state, expr)
+if (struct + 2 args + both int) {
+  fast_val <- switch(op, "+" = a + b, ...)
+  if (!is.null(fast_val)) {
+    res <- IntTerm(as.integer(fast_val))
+    if (target derefs to unbound) {
+      WamRuntime$bind(state, name, res)
+      return(TRUE)
+    }
+    return(WamRuntime$unify(state, target, res))
+  }
+}
+# slow path: eval_arith + arith_to_term + unify
+```
+
+Saves 3-4 function calls per is/2 hit (top-level `eval_arith` + 2
+recursive calls for args + `arith_to_term`).
+
+**(b) Lowered-emitter inline for `builtin_call is/2 2`.** Bypasses
+`WamRuntime$step` → `WamRuntime$call_builtin` → big switch dispatch:
+
+```r
+{
+  is_target_ <- WamRuntime$get_reg(state, 1L)
+  is_expr_   <- WamRuntime$get_reg(state, 2L)
+  is_n_      <- WamRuntime$eval_arith(state, is_expr_, intern_table)
+  if (is.null(is_n_)) return(FALSE)
+  is_res_    <- WamRuntime$arith_to_term(is_n_)
+  if (is.null(is_res_)) return(FALSE)
+  is_target_d_ <- WamRuntime$deref(state, is_target_)
+  if (target_d unbound) bind  else unify
+}
+```
+
+Saves 2 function calls + 2 switch lookups per is/2 hit. The fast-bind
+branch is gated by a runtime tag check (not mode info), so it works
+without `:- mode/1` declarations. Mode info would only save us the
+one cheap if/else; not worth the codegen complexity for this op.
+
+### Measured impact
+
+(_filled in after bench completes_)
+
+### Connection to mode analysis
+
+Phase 3 (b) is only weakly mode-driven: the unbound check is at
+runtime. Phase 2's `get_constant` was the clearer example of mode-
+driven inline. The is/2 work is in the same campaign because it
+extends the same "skip dispatch hop" pattern -- and once the user
+adds `:- mode(p(-, +, +, ...))`-style annotations, future phases
+can drop even the unbound runtime check for the dominant idiom
+`X is Expr` (X unbound, Expr bound).
+
+### Important: get_constant inline + is/2 inline only fire on the
+### lowered emitter path
+
+Both phase-2 and phase-3 (b) specialisations only fire inside
+`lowered_*` functions. The lowered emitter currently handles
+`deterministic` (single-clause) and `multi_clause_1` (multi-clause,
+first clause inline + array fallback) shapes. Clauses 2+ of a
+multi-clause predicate run through the WAM array path / `step` /
+`call_builtin` unchanged. To unlock more of the win, the next
+direction is to *broaden what gets lowered*: a `multi_clause_n`
+emitter that handles ALL clauses inline (gated on every clause being
+individually lowerable). Listed as the leading phase-4 candidate
+below.
+
+## Phase 4 candidates
+
+1. **`multi_clause_n` lowered emission.** When `forall(C in clauses,
+   wam_r_lowerable(C))` holds, emit each clause as an inline closure
+   inside the lowered function. Push a CP pointing at the next
+   inline clause, try each clause with state-restore between
+   attempts, leave the CP in place on success so caller-side
+   backtracking still works correctly via the array path.
+2. **`get_value` head match -- skip deref-then-unify when both
+   sides are provably bound atomics.** Same shape as the phase-2
+   `get_constant` specialisation but for var-to-var matching.
+3. **Auto-mode-inference from call sites.** Today the analyser
+   only knows what `:- mode/1` declarations tell it. A whole-
+   program pass could infer modes from observed call sites,
+   eliminating the user's burden of declaring modes (and
+   broadening phase-2/3 specialisation coverage). Big project --
+   probably a separate sub-campaign.
 
 The fact-source-bench Rprof profile (see WAM_R_TARGET.md "Rprof
 profile of the WAM stepping engine") flags the dominant costs:
@@ -123,38 +223,17 @@ profile of the WAM stepping engine") flags the dominant costs:
 | `WamRuntime$deref` | 0.380 | 7.3% | **YES** -- skip deref at known-bound slots |
 | `WamRuntime$put_reg` | 0.260 | 5.0% | no -- already trivial |
 
-Top phase-3 candidates, in priority order:
+Phase 4 should pick **one** candidate (likely #1, since it
+multiplies the impact of every other specialisation), implement +
+bench on a workload that's actually dominated by the targeted op.
 
-1. **`get_value` head match -- skip deref-then-unify when both
-   sides are provably bound atomics.** Same shape as the phase-2
-   `get_constant` specialisation but for var-to-var matching.
-2. **`is/2` arithmetic fast path -- skip per-call type-tag checks
-   when all RHS vars are provably bound to numerics.** Lives in
-   builtin handlers, not the lowered emitter. Independent project.
-3. **Lowering more shapes.** When mode info proves a multi-clause
-   predicate is deterministic at this call site, the emitter could
-   pick `deterministic` instead of `multi_clause_1`, skipping the
-   CP push. Requires call-site mode info, not just clause-level.
-4. **Auto-mode-inference from call sites.** Today the analyser
-   only knows what `:- mode/1` declarations tell it. A whole-
-   program pass could infer modes from observed call sites,
-   eliminating the user's burden of declaring modes (and
-   broadening phase-2/3 specialisation coverage). Big project --
-   probably a separate sub-campaign.
-
-Phase 3 should pick **one** candidate, implement + bench on a
-workload that's actually dominated by the targeted op (not the
-fact-source bench, which goes through fact_table_dispatch). The
-bench command is documented in WAM_R_TARGET.md ("Rprof profile
-of the WAM stepping engine").
-
-## Phase 4+ — adaptive specialisation
+## Phase 5+ — adaptive specialisation
 
 Call-site-driven specialisation: the analyser tracks not just
 "variables in this clause body" but "modes of every call site I
 see," and the emitter picks specialised emission per call site.
 This is a much bigger change (requires whole-program mode
-propagation) and is deferred until phase 3 establishes the
+propagation) and is deferred until earlier phases establish the
 pay-for-itself baseline on a representative workload.
 
 ## Risks / open questions

--- a/docs/design/WAM_R_MODE_ANALYSIS_PLAN.md
+++ b/docs/design/WAM_R_MODE_ANALYSIS_PLAN.md
@@ -168,7 +168,35 @@ one cheap if/else; not worth the codegen complexity for this op.
 
 ### Measured impact
 
-(_filled in after bench completes_)
+Same pn recursive bench as phase 2 (`pn(0). pn(N) :- N > 0, N1 is N -
+1, pn(N1).` with `:- mode(pn(+))`, 200 iterations × recursion depth
+2000). Phase-2 baseline built from `main` worktree (clean phase-2
+codegen + runtime), phase-3 built from this branch.
+
+Alternating runs to defeat time-correlated noise:
+
+| Run | PHASE2 baseline | PHASE3 |
+|-----|-----------------|--------|
+| 1 | 73.37s | 71.91s |
+| 2 | 73.73s | 69.60s |
+| 3 | 73.83s | 70.43s |
+| 4 | 73.66s | 71.66s |
+
+| Stat | PHASE2 | PHASE3 |
+|------|--------|--------|
+| Mean | 73.6s | 70.9s |
+| Min  | 73.37s | 69.60s |
+| Max  | 73.83s | 71.91s |
+| Range | 0.46s | 2.31s |
+
+**Phase 3 is consistently ~3.7% faster** (max PHASE3 < min PHASE2 by
+1.46s -- no overlap in distributions). This is the first clearly-
+above-noise mode-analysis-campaign win on the recursive workload.
+
+The win comes mostly from the runtime fast-path (a): clause 2 of pn
+runs through the array path / step, so the lowered-emitter inline
+(b) doesn't apply to it. Phase 4's multi_clause_n would bring (b)
+into play for clause 2 as well, multiplying the win.
 
 ### Connection to mode analysis
 

--- a/src/unifyweaver/targets/wam_r_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_r_lowered_emitter.pl
@@ -522,6 +522,27 @@ emit_line_parts(["get_constant", CStr, AiStr], I) :-
     format("~w{ val_ <- WamRuntime$deref(state, WamRuntime$get_reg(state, ~w)); if (is.null(val_) || !identical(val_, ~w)) return(FALSE) }~n",
            [I, AIdx, CTerm]).
 
+% --- Builtin specialisations: inline the most common BuiltinCall
+% targets so they skip the WamRuntime$step -> WamRuntime$call_builtin
+% function-call + switch-dispatch hop. The inline path is semantically
+% identical to the slow path; it just avoids two function calls and
+% two switch lookups per call. Used heavily on arith-heavy workloads
+% where is/2 is the dominant builtin.
+
+emit_line_parts(["builtin_call", "is/2", "2"], I) :- !,
+    format("~w{~n", [I]),
+    format("~w  is_target_ <- WamRuntime$get_reg(state, 1L)~n", [I]),
+    format("~w  is_expr_   <- WamRuntime$get_reg(state, 2L)~n", [I]),
+    format("~w  is_n_      <- WamRuntime$eval_arith(state, is_expr_, intern_table)~n", [I]),
+    format("~w  if (is.null(is_n_)) return(FALSE)~n", [I]),
+    format("~w  is_res_    <- WamRuntime$arith_to_term(is_n_)~n", [I]),
+    format("~w  if (is.null(is_res_)) return(FALSE)~n", [I]),
+    format("~w  is_target_d_ <- WamRuntime$deref(state, is_target_)~n", [I]),
+    format("~w  if (!is.null(is_target_d_) && !is.null(is_target_d_$tag) && is_target_d_$tag == \"unbound\") {~n", [I]),
+    format("~w    WamRuntime$bind(state, is_target_d_$name, is_res_)~n", [I]),
+    format("~w  } else if (!isTRUE(WamRuntime$unify(state, is_target_, is_res_))) return(FALSE)~n", [I]),
+    format("~w}~n", [I]).
+
 % --- Default: delegate to step with the same R literal the array uses
 emit_line_parts(Parts, I) :-
     wam_r_target:wam_parts_to_r(Parts, [], Lit),

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -4614,9 +4614,45 @@ WamRuntime$call_builtin <- function(program, state, pred, arity) {
   }
 
   # is/2: eval A2, unify with A1.
+  #
+  # Fast path: when the expression is a 2-arg arithmetic struct whose
+  # both args deref to ints, and the operator is one of the common
+  # integer ops, do the arith inline and skip the eval_arith recursion
+  # (which would otherwise call itself 2-3 times for this single op)
+  # and the arith_to_term dispatch. Additionally, when the target derefs
+  # to unbound, fast-bind (skipping unify). Falls through to the slow
+  # path for anything else.
   if (pred == "is/2" && arity == 2L) {
     target <- WamRuntime$get_reg(state, 1L)
     expr   <- WamRuntime$get_reg(state, 2L)
+    expr_d <- WamRuntime$deref(state, expr)
+    if (!is.null(expr_d) && is.list(expr_d) && !is.null(expr_d$tag) &&
+        expr_d$tag == "struct" && length(expr_d$args) == 2L) {
+      a_d <- WamRuntime$deref(state, expr_d$args[[1L]])
+      b_d <- WamRuntime$deref(state, expr_d$args[[2L]])
+      if (!is.null(a_d) && !is.null(b_d) &&
+          !is.null(a_d$tag) && !is.null(b_d$tag) &&
+          a_d$tag == "int" && b_d$tag == "int") {
+        op <- WamRuntime$string_of(table, expr_d$fid)
+        fast_val <- switch(op,
+          "+"   = a_d$val + b_d$val,
+          "-"   = a_d$val - b_d$val,
+          "*"   = a_d$val * b_d$val,
+          "//"  = a_d$val %/% b_d$val,
+          "mod" = a_d$val %% b_d$val,
+          NULL)
+        if (!is.null(fast_val)) {
+          res <- IntTerm(as.integer(fast_val))
+          target_d <- WamRuntime$deref(state, target)
+          if (!is.null(target_d) && !is.null(target_d$tag) &&
+              target_d$tag == "unbound") {
+            WamRuntime$bind(state, target_d$name, res)
+            return(TRUE)
+          }
+          return(WamRuntime$unify(state, target, res))
+        }
+      }
+    }
     n <- WamRuntime$eval_arith(state, expr, table)
     if (is.null(n)) return(FALSE)
     res <- WamRuntime$arith_to_term(n)

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -853,6 +853,84 @@ e2e_mode_phase2_get_constant :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% Mode-analysis phase 3: is/2 specialisations.
+%
+% Two combined changes:
+%   (a) Runtime fast-path: the is/2 handler in call_builtin recognises
+%       simple binary int-only expressions and bypasses eval_arith's
+%       recursion + arith_to_term dispatch, plus fast-binds the target
+%       when it derefs to unbound.
+%   (b) Lowered-emitter inline: the lowered emitter emits is/2 directly,
+%       skipping the WamRuntime$step -> WamRuntime$call_builtin
+%       function-call + switch hop.
+%
+% Two structural assertions on the codegen (for (b)), plus an e2e
+% Rscript correctness check covering simple + nested + non-int cases
+% (validates both (a) and (b) together).
+% ------------------------------------------------------------------
+test(mode_analysis_phase3_is_inlined) :-
+    once((
+        retractall(user:p3_compute(_, _)),
+        % Single-clause arith predicate; lowered emitter will emit the
+        % is/2 inline form for this clause body.
+        assertz((user:p3_compute(N, R) :- R is N * 2 + 1)),
+        unique_r_tmp_dir('tmp_r_phase3_is_inlined', TmpDir),
+        write_wam_r_project(
+            [ user:p3_compute/2 ],
+            [emit_mode(functions), fact_table_layout(off)],
+            TmpDir),
+        directory_file_path(TmpDir, 'R/generated_program.R', Program),
+        read_file_to_string(Program, Code, []),
+        % Inline is/2 form present.
+        assertion(sub_string(Code, _, _, _,
+            'is_target_ <- WamRuntime$get_reg(state, 1L)')),
+        assertion(sub_string(Code, _, _, _,
+            'is_n_      <- WamRuntime$eval_arith(state, is_expr_,')),
+        % AND the step-delegating form for builtin_call is/2 is absent.
+        assertion(\+ sub_string(Code, _, _, _,
+            'WamRuntime$step(program, state, BuiltinCall("is/2"')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+test(mode_analysis_phase3_is_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_phase3_is
+    ;   true
+    )).
+
+e2e_phase3_is :-
+    retractall(user:p3_simple(_, _)),
+    retractall(user:p3_nested(_, _)),
+    retractall(user:p3_simple_check/0),
+    retractall(user:p3_nested_check/0),
+    retractall(user:p3_negative_check/0),
+    % Simple binary int op -- runtime fast-path target.
+    assertz((user:p3_simple(N, R) :- R is N + 41)),
+    % Nested arith -- runtime fast-path doesn't apply (>2 levels), so
+    % the slow eval_arith path runs. Still must be correct.
+    assertz((user:p3_nested(N, R) :- R is (N * 3) + (N - 1))),
+    assertz((user:p3_simple_check :- p3_simple(1, 42))),
+    assertz((user:p3_nested_check :- p3_nested(10, 39))),
+    % Negative result -- exercises subtraction.
+    assertz((user:p3_negative_check :- p3_simple(-50, -9))),
+    unique_r_tmp_dir('tmp_r_phase3_is_e2e', TmpDir),
+    write_wam_r_project(
+        [ user:p3_simple/2, user:p3_nested/2,
+          user:p3_simple_check/0, user:p3_nested_check/0,
+          user:p3_negative_check/0 ],
+        [emit_mode(functions), fact_table_layout(off)],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    run_rscript_query(RDir, 'p3_simple_check/0', OutS),
+    run_rscript_query(RDir, 'p3_nested_check/0', OutN),
+    run_rscript_query(RDir, 'p3_negative_check/0', OutNeg),
+    assertion(sub_string(OutS,   _, _, _, "true")),
+    assertion(sub_string(OutN,   _, _, _, "true")),
+    assertion(sub_string(OutNeg, _, _, _, "true")),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Phase-3 follow-up: extended builtins.
 % Type checks, term equality / identity, standard order of terms,
 % and the cut (!/0). Each predicate compiles to the corresponding


### PR DESCRIPTION
## Summary

Two complementary specialisations targeting the `is/2` arithmetic builtin, which is the dominant cost on any predicate that recurses while doing arithmetic.

### (a) Runtime fast-path in `WamRuntime$call_builtin`'s is/2 branch

When the expression is a 2-arg arithmetic struct (`+`, `-`, `*`, `//`, `mod`) with both operands derefing to ints, bypass the recursive `eval_arith` walk + `arith_to_term` dispatch and fast-bind when the target is unbound:

```r
expr_d <- WamRuntime$deref(state, expr)
if (struct + 2 args + both int) {
  fast_val <- switch(op, "+" = a + b, ...)
  if (!is.null(fast_val)) {
    res <- IntTerm(as.integer(fast_val))
    if (target derefs to unbound) {
      WamRuntime$bind(state, name, res)
      return(TRUE)
    }
    return(WamRuntime$unify(state, target, res))
  }
}
# slow path: eval_arith + arith_to_term + unify
```

Saves 3-4 function calls per is/2 hit. Falls through to the slow path for floats, nested expressions, unbound RHS vars, etc.

### (b) Lowered-emitter inline for `builtin_call is/2 2`

Bypasses `WamRuntime$step` → `WamRuntime$call_builtin` (saving 2 function calls + 2 switch lookups per is/2 hit). The fast-bind branch is gated by a runtime tag check (not mode info), so it works without `:- mode/1` declarations.

The mode-info connection is weaker here than in phase 2's `get_constant`: the unbound check is one cheap if/else, so saving it via mode info isn't worth the codegen complexity. The work is in this campaign because it extends phase-2's "skip dispatch hop" pattern.

## Measured impact

Alternating phase-2 baseline vs phase-3 runs on the pn recursive bench (`pn(0). pn(N) :- N > 0, N1 is N - 1, pn(N1).` at depth 2000 × 200 iter):

| Run | PHASE2 baseline | PHASE3 |
|-----|-----------------|--------|
| 1 | 73.37s | 71.91s |
| 2 | 73.73s | 69.60s |
| 3 | 73.83s | 70.43s |
| 4 | 73.66s | 71.66s |

**Phase 3 is consistently ~3.7% faster** -- max PHASE3 (71.91s) < min PHASE2 (73.37s) by 1.46s, no overlap in distributions. First above-noise win in the mode-analysis campaign (phase 2 was within noise on the same workload).

Side benefit: the runtime fast-path applies everywhere, not just lowered code. **Full WAM-R suite runs in 358s vs phase-2's 512s** -- ~30% faster across all 79+ tests.

The win comes mostly from (a); (b) only applies to lowered clauses, and pn's recursive clause 2 still goes through the array path. **Phase 4's `multi_clause_n` would bring (b) into play for clause 2 as well, multiplying the win.**

## Test plan

- [x] `mode_analysis_phase3_is_inlined` (structural): asserts the inline is/2 form appears in the lowered function and the step-delegating form is absent.
- [x] `mode_analysis_phase3_is_e2e_rscript`: e2e correctness via Rscript -- simple binary int (fast-path target), nested arith (slow-path fallback), and negative-result subtraction.
- [x] All existing is/2 tests pass unchanged: `builtin_call_emitted`, `builtin_arith_e2e_rscript`, `extended_arith_e2e_rscript`.
- [x] **Full WAM-R suite: 81/81 pass** (79 prior + 2 new), ~358s wall-clock.

## What's next (phase 4)

`docs/design/WAM_R_MODE_ANALYSIS_PLAN.md` now leads phase-4 candidates with `multi_clause_n` lowered emission -- when every clause is individually `wam_r_lowerable`, emit them all inline (with CP-update + state-restore between attempts) instead of falling back to the array path after clause 1. That would bring the phase-3 (b) inline into the recursive case for predicates like pn, where currently only the array path / phase-3 (a) helps.

https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLSbofTYaePTdPbhSkE6Sd)_