### PR TITLE
test(wam-r): silence mode analysis singleton warning

### DIFF
--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -681,12 +681,12 @@ test(mode_analysis_phase1_comments) :-
         % The lowered emitter picks all of them; we assert the visibility
         % comment reports the correct head-binding for each.
         assertz(user:mode(ma_pin(+))),
-        assertz((user:ma_pin(_X)   :- true)),
+        assertz((user:ma_pin(_)   :- true)),
         assertz(user:mode(ma_pout(-))),
-        assertz((user:ma_pout(_X)  :- true)),
+        assertz((user:ma_pout(_)  :- true)),
         assertz(user:mode(ma_pany(?))),
-        assertz((user:ma_pany(_X)  :- true)),
-        assertz((user:ma_pnone(_X) :- true)),
+        assertz((user:ma_pany(_)  :- true)),
+        assertz((user:ma_pnone(_) :- true)),
         unique_r_tmp_dir('tmp_r_mode_comments', TmpDir),
         write_wam_r_project(
             [ user:ma_pin/1, user:ma_pout/1,


### PR DESCRIPTION
## Summary

- Replace repeated singleton-marked `_X` placeholders with anonymous variables in the WAM-R mode-analysis phase 1 structural test.
- Keep the generated test predicates semantically identical while removing the load-time SWI-Prolog warning.

## Verification

- `swipl -g "run_tests([wam_r_generator:mode_analysis_phase1_comments,wam_r_generator:mode_analysis_phase3_is_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`

Both tests passed locally, and the previous singleton-marked variable warning no longer appears.
