### PR TITLE
fix(wam-clojure): prevent build-frame self-aliasing

### DIFF
--- a/PR_WAM_CLOJURE_BUILD_FRAME_OVERWRITE.md
+++ b/PR_WAM_CLOJURE_BUILD_FRAME_OVERWRITE.md
@@ -1,0 +1,26 @@
+# fix(wam-clojure): prevent build-frame self-aliasing
+
+## Summary
+
+Fixes a Clojure WAM runtime edge case where `put_structure` / `put_list` could unify a freshly built term with the old value of the same argument register, creating self-referential terms in aliasing scenarios.
+
+## What Changed
+
+- Added an `a-slot?` helper for generated Clojure WAM registers.
+- Changed build-frame finalization so `A*` argument-register targets are overwritten with the newly built term.
+- Preserved the previous `assign-or-unify-reg` behavior for `X*` / `Y*` targets, which is still needed for nested build placeholders.
+- Strengthened the `copy_term/2` smoke regression to cover the previously problematic aliased source shape.
+
+## Validation
+
+```sh
+git diff --check
+swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
+swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
+timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
+```
+
+## Notes
+
+- A blunt overwrite of all build targets regressed nested list construction on backtracking.
+- This fix intentionally distinguishes temporary argument registers from local build placeholders.

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -712,6 +712,9 @@
   (let [frame (peek (:build-stack state))]
     (and frame (= (count (:args frame)) (:arity frame)))))
 
+(defn a-slot? [reg]
+  (and (string? reg) (.startsWith reg "A")))
+
 (defn assign-or-unify-reg [state reg term]
   (let [current (or (reg-get-raw state reg) ::unbound)]
     (cond
@@ -725,11 +728,13 @@
   (let [frame (peek (:build-stack state))
         built (structure-term (:functor frame) (:args frame))
         target-reg (:target-reg frame)
-        next-state (update state :build-stack pop)
-        [ok bound-state] (assign-or-unify-reg next-state target-reg built)]
-    (if ok
-      bound-state
-      (backtrack state))))
+        next-state (update state :build-stack pop)]
+    (if (a-slot? target-reg)
+      (reg-set-raw next-state target-reg built)
+      (let [[ok bound-state] (assign-or-unify-reg next-state target-reg built)]
+        (if ok
+          bound-state
+          (backtrack state))))))
 
 (defn finalize-complete-builds [state]
   (loop [s state]

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -155,7 +155,7 @@ user:wam_append_bad_left(C) :- append([a|b], [c], C).
 user:wam_append_unbound_left(C) :- user:wam_unbound_arg(A), append(A, [b], C).
 user:wam_append_split(A, B) :- append(A, B, [a,b,c]).
 user:wam_copy_term_guard(A, B) :- copy_term(A, B).
-user:wam_copy_term_sharing_fail :- copy_term(f(X, X), f(a, b)).
+user:wam_copy_term_sharing_fail :- user:wam_unbound_arg(X), copy_term(f(X, X), f(a, b)).
 user:wam_copy_term_independent_ok :- copy_term(f(_, _), f(a, b)).
 user:wam_ground_guard(X) :- ground(X).
 user:wam_ground_unbound(_) :- user:wam_unbound_arg(Y), ground(Y).


### PR DESCRIPTION
## Summary

Fixes a Clojure WAM runtime edge case where `put_structure` / `put_list` could unify a freshly built term with the old value of the same argument register, creating self-referential terms in aliasing scenarios.

## What Changed

- Added an `a-slot?` helper for generated Clojure WAM registers.
- Changed build-frame finalization so `A*` argument-register targets are overwritten with the newly built term.
- Preserved the previous `assign-or-unify-reg` behavior for `X*` / `Y*` targets, which is still needed for nested build placeholders.
- Strengthened the `copy_term/2` smoke regression to cover the previously problematic aliased source shape.

## Validation

```sh
git diff --check
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
```

## Notes

- A blunt overwrite of all build targets regressed nested list construction on backtracking.
- This fix intentionally distinguishes temporary argument registers from local build placeholders.
