### PR TITLE
feat(wam-clojure): add read-mode functor/3 builtin support

### DIFF
--- a/PR_WAM_CLOJURE_FUNCTOR_READ_BUILTIN.md
+++ b/PR_WAM_CLOJURE_FUNCTOR_READ_BUILTIN.md
@@ -1,0 +1,36 @@
+# feat(wam-clojure): add read-mode functor/3 builtin support
+
+## Summary
+
+Adds read-mode `functor/3` support to the Clojure WAM runtime and lowered-emitter path.
+
+## What Changed
+
+- Added Clojure runtime helpers to inspect a term and derive its functor name and arity.
+- Added interpreted runtime dispatch for `functor/3`.
+- Registered `functor/3` as a direct lowered Clojure builtin.
+- Added lowered-emitter coverage proving `functor/3` bypasses generic `runtime/step`.
+- Extended the Clojure runtime smoke suite for structure, atom, number, and mismatch cases.
+
+## Supported Scope
+
+This PR supports read mode:
+
+```prolog
+functor(+Term, ?Name, ?Arity)
+```
+
+Construct mode is intentionally left for a follow-up:
+
+```prolog
+functor(?Term, +Name, +Arity)
+```
+
+## Validation
+
+```sh
+git diff --check
+swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
+swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
+timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
+```

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -364,6 +364,10 @@ clojure_direct_builtin("copy_term/2", "2").
 clojure_direct_builtin("copy_term/2", 2).
 clojure_direct_builtin('copy_term/2', "2").
 clojure_direct_builtin('copy_term/2', 2).
+clojure_direct_builtin("functor/3", "3").
+clojure_direct_builtin("functor/3", 3).
+clojure_direct_builtin('functor/3', "3").
+clojure_direct_builtin('functor/3', 3).
 clojure_direct_builtin("ground/1", "1").
 clojure_direct_builtin("ground/1", 1).
 clojure_direct_builtin('ground/1', "1").
@@ -572,6 +576,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "copy_term/2" ; Op == 'copy_term/2'),
     !,
     format(atom(Expr), '(runtime/apply-copy-term-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "functor/3" ; Op == 'functor/3'),
+    !,
+    format(atom(Expr), '(runtime/apply-functor-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "ground/1" ; Op == 'ground/1'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -517,6 +517,47 @@
                (conj items (first (:args cur))))
         :else nil))))
 
+(defn functor-name-from-key [key]
+  (let [slash (.lastIndexOf ^String key "/")]
+    (if (pos? slash)
+      (subs key 0 slash)
+      key)))
+
+(defn functor-read-pair [state value]
+  (let [value* (deref-value (:bindings state) value)
+        ctx (:intern-context state)]
+    (cond
+      (atom-term? value*)
+      [value* 0]
+
+      (number? value*)
+      [value* 0]
+
+      (structure-term? value*)
+      (let [key (functor-key ctx (:functor value*))
+            name (normalize-literal-atom ctx (functor-name-from-key key))]
+        [name (count (:args value*))])
+
+      :else
+      nil)))
+
+(defn apply-functor-solution [state]
+  (let [term (deref-value (:bindings state)
+                          (or (reg-get-raw state "A1") ::unbound))]
+    (if-let [[name arity] (functor-read-pair state term)]
+      (let [name-out (deref-value (:bindings state)
+                                  (or (reg-get-raw state "A2") ::unbound))
+            arity-out (deref-value (:bindings state)
+                                   (or (reg-get-raw state "A3") ::unbound))
+            [ok-name name-state] (unify-values state name-out name)]
+        (if ok-name
+          (let [[ok-arity arity-state] (unify-values name-state arity-out arity)]
+            (if ok-arity
+              (advance arity-state)
+              (backtrack state)))
+          (backtrack state)))
+      (backtrack state))))
+
 (declare apply-member-solution)
 (declare apply-append-solution)
 (declare apply-first-foreign-solution)
@@ -1240,6 +1281,9 @@
 
           "copy_term/2"
           (apply-copy-term-solution state)
+
+          "functor/3"
+          (apply-functor-solution state)
 
           "ground/1"
           (let [value (deref-value (:bindings state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -485,6 +485,15 @@ test(simple_builtin_copy_term_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_functor_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_functor/3:\nbuiltin_call functor/3, 3\nproceed\n",
+        wam_clojure_lowerable(test_functor/3, WamCode, deterministic),
+        lower_predicate_to_clojure(test_functor/3, WamCode, [], Code),
+        has(Code, "runtime/apply-functor-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_ground_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_ground/1:\nbuiltin_call ground/1, 1\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -68,6 +68,7 @@
 :- dynamic user:wam_copy_term_guard/2.
 :- dynamic user:wam_copy_term_sharing_fail/0.
 :- dynamic user:wam_copy_term_independent_ok/0.
+:- dynamic user:wam_functor_guard/3.
 :- dynamic user:wam_ground_guard/1.
 :- dynamic user:wam_ground_unbound/1.
 :- dynamic user:wam_ground_nested_unbound/1.
@@ -157,6 +158,7 @@ user:wam_append_split(A, B) :- append(A, B, [a,b,c]).
 user:wam_copy_term_guard(A, B) :- copy_term(A, B).
 user:wam_copy_term_sharing_fail :- user:wam_unbound_arg(X), copy_term(f(X, X), f(a, b)).
 user:wam_copy_term_independent_ok :- copy_term(f(_, _), f(a, b)).
+user:wam_functor_guard(Term, Name, Arity) :- functor(Term, Name, Arity).
 user:wam_ground_guard(X) :- ground(X).
 user:wam_ground_unbound(_) :- user:wam_unbound_arg(Y), ground(Y).
 user:wam_ground_nested_unbound(_) :- user:wam_unbound_arg(Y), ground(f(Y)).
@@ -251,6 +253,7 @@ run_smoke :-
           user:wam_copy_term_guard/2,
           user:wam_copy_term_sharing_fail/0,
           user:wam_copy_term_independent_ok/0,
+          user:wam_functor_guard/3,
           user:wam_ground_guard/1,
           user:wam_ground_unbound/1,
           user:wam_ground_nested_unbound/1,
@@ -302,6 +305,7 @@ run_smoke :-
     assert_lowered_member_builtin_emitted(TmpDir),
     assert_lowered_append_builtin_emitted(TmpDir),
     assert_lowered_copy_term_builtin_emitted(TmpDir),
+    assert_lowered_functor_builtin_emitted(TmpDir),
     assert_lowered_ground_builtin_emitted(TmpDir),
     assert_lowered_arithmetic_comparison_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
@@ -430,6 +434,10 @@ smoke_cases([
     case('wam_copy_term_guard/2', args('f(a)', 'f(b)'), "false"),
     case('wam_copy_term_sharing_fail/0', no_args, "false"),
     case('wam_copy_term_independent_ok/0', no_args, "true"),
+    case('wam_functor_guard/3', args('f(a)', f, 1), "true"),
+    case('wam_functor_guard/3', args('f(a)', a, 1), "false"),
+    case('wam_functor_guard/3', args(a, a, 0), "true"),
+    case('wam_functor_guard/3', args(42, 42, 0), "true"),
     case('wam_ground_guard/1', a, "true"),
     case('wam_ground_guard/1', 42, "true"),
     case('wam_ground_guard/1', 3.5, "true"),
@@ -621,6 +629,12 @@ assert_lowered_copy_term_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-copy-term-sharing-fail-0"),
     has(CoreCode, "defn lowered-wam-copy-term-independent-ok-0"),
     has(CoreCode, "runtime/apply-copy-term-solution").
+
+assert_lowered_functor_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-functor-guard-3"),
+    has(CoreCode, "runtime/apply-functor-solution").
 
 assert_lowered_ground_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
@@ -818,6 +832,8 @@ prolog_term_string_to_edn("a", "\"a\"") :- !.
 prolog_term_string_to_edn("b", "\"b\"") :- !.
 prolog_term_string_to_edn("c", "\"c\"") :- !.
 prolog_term_string_to_edn("d", "\"d\"") :- !.
+prolog_term_string_to_edn(f, "\"f\"") :- !.
+prolog_term_string_to_edn("f", "\"f\"") :- !.
 prolog_term_string_to_edn("z", "\"z\"") :- !.
 prolog_term_string_to_edn('f(a)', "{:tag :struct :functor \"f/1\" :args [\"a\"]}") :- !.
 prolog_term_string_to_edn('f(b)', "{:tag :struct :functor \"f/1\" :args [\"b\"]}") :- !.


### PR DESCRIPTION
## Summary

Adds read-mode `functor/3` support to the Clojure WAM runtime and lowered-emitter path.

## What Changed

- Added Clojure runtime helpers to inspect a term and derive its functor name and arity.
- Added interpreted runtime dispatch for `functor/3`.
- Registered `functor/3` as a direct lowered Clojure builtin.
- Added lowered-emitter coverage proving `functor/3` bypasses generic `runtime/step`.
- Extended the Clojure runtime smoke suite for structure, atom, number, and mismatch cases.

## Supported Scope

This PR supports read mode:

```prolog
functor(+Term, ?Name, ?Arity)
```

Construct mode is intentionally left for a follow-up:

```prolog
functor(?Term, +Name, +Arity)
```

## Validation

```sh
git diff --check
swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl
swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl
timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl
```
