### PR TITLE
feat(wam-r): lower all supported multi-clause bodies

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -453,7 +453,7 @@ add a `fact_source_loader_call/4` clause for the Spec shape and a
 
 ### Emit modes
 
-The Phase-3 lowered emitter can replace the instruction-array body
+The Phase-4 lowered emitter can replace the instruction-array body
 of a predicate with hand-emitted R that calls runtime helpers
 directly. This skips the per-instruction `step` dispatch and is a
 useful hot-path optimisation.
@@ -554,14 +554,11 @@ calls + 2 switch lookups per is/2 hit). Always fires when the
 lowered emitter handles the clause; the runtime fast-path then
 applies inside the inline body.
 
-Note: both specialisations only affect `is/2` calls that reach the
-lowered emitter (phase-3 b) or the array path / step (phase-3 a). A
-multi-clause predicate where clause 2+ contains the is/2 will go
-through the array path for those clauses, so phase-3 (a) handles
-it. The lowered-emitter inline (b) only helps for the lowered
-clauses (today: deterministic or multi_clause_1's first clause).
-See `WAM_R_MODE_ANALYSIS_PLAN.md` phase 4 for the multi_clause_n
-extension that would unlock more of the win.
+Note: phase 4 broadens lowered emission from the older
+`multi_clause_1` shape to `multi_clause_n`: when every clause is in
+the lowered emitter's supported instruction subset, each clause is
+emitted inline. That means lowered-emitter inline `is/2` now applies
+to clause 2+ as well as deterministic predicates and first clauses.
 
 ## Supported features
 
@@ -915,13 +912,14 @@ Coverage map (e2e tests, by feature group):
 | `nested_if_then_else_e2e_rscript` | chained `( A -> B ; C -> D ; E )` compiles as nested cut_ite/try_me_else_ite pairs (each `->` in Else position is recognised recursively rather than emitted as a stub `Call("->", 2)`) |
 | `deeply_nested_ite_compiles` | clause_body_analysis no longer stack-overflows on triple-nested if-then-else bodies (the `nonvar` guard on `disjunction_alternatives/2` keeps it from infinitely-expanding an unbound goal that passes through the analyser) |
 | `strict_xf_chain_fails_e2e_rscript` | runtime parser enforces strict (xf / fx) vs non-strict (yf / fy) lhs-precedence rules: `5!!` parses with `op(100, yf, '!')` but fails with `op(100, xf, '!')`; `neg neg foo` parses with `op(900, fy, neg)` but fails with `op(900, fx, neg)` |
-| `phase3_multi_clause_e2e_rscript` | Phase-3 lowered emitter (multi-clause) |
+| `phase3_multi_clause_e2e_rscript` | Lowered emitter multi-clause truth checks |
 | `lowered_emitter_e2e_rscript` | Phase-3 lowered emitter (single-clause) |
 | `mode_analysis_phase1_comments` | Mode-analysis visibility: `mode_comments(on)` option prepends `# Mode analysis:` block to each lowered function with per-clause head-binding states; covers `+`, `-`, `?`, undeclared mode shapes |
 | `mode_analysis_phase2_get_constant_inlined` | Mode-analysis phase 2: structural assertion that `get_constant` head match is emitted as inline `WamRuntime$deref + identical()` when the target A-register's declared mode is `+`; falls back to `WamRuntime$step` when no mode declaration or `mode_specialise(off)` |
 | `mode_analysis_phase2_get_constant_e2e_rscript` | Mode-analysis phase 2: e2e correctness -- a predicate with `:- mode(p(+))` and three clauses compiles + runs via Rscript, queries return correct true/false matching across the multi-clause backtracking path |
 | `mode_analysis_phase3_is_inlined` | Mode-analysis phase 3: structural assertion that `builtin_call is/2 2` is emitted as inline `WamRuntime$eval_arith + bind/unify` in the lowered function (instead of `WamRuntime$step(... BuiltinCall("is/2", 2))`) |
 | `mode_analysis_phase3_is_e2e_rscript` | Mode-analysis phase 3: e2e correctness -- a predicate using `is/2` with simple binary int op (runtime fast-path), nested arith (slow path), and negative-result arith compiles + runs via Rscript with correct values |
+| `mode_analysis_phase4_multiclause_n_e2e_rscript` | Mode-analysis phase 4: all-supported-clause `multi_clause_n` lowering, including direct R-wrapper execution of clause 2's inline `is/2` path |
 
 ## Contributing
 

--- a/docs/design/WAM_R_MODE_ANALYSIS_PLAN.md
+++ b/docs/design/WAM_R_MODE_ANALYSIS_PLAN.md
@@ -194,9 +194,9 @@ Alternating runs to defeat time-correlated noise:
 above-noise mode-analysis-campaign win on the recursive workload.
 
 The win comes mostly from the runtime fast-path (a): clause 2 of pn
-runs through the array path / step, so the lowered-emitter inline
-(b) doesn't apply to it. Phase 4's multi_clause_n would bring (b)
-into play for clause 2 as well, multiplying the win.
+ran through the array path / step in phase 3, so the lowered-emitter
+inline (b) did not apply to it. Phase 4's multi_clause_n broadens the
+lowered path so clause 2+ can use the inline body as well.
 
 ### Connection to mode analysis
 
@@ -212,24 +212,17 @@ can drop even the unbound runtime check for the dominant idiom
 ### lowered emitter path
 
 Both phase-2 and phase-3 (b) specialisations only fire inside
-`lowered_*` functions. The lowered emitter currently handles
-`deterministic` (single-clause) and `multi_clause_1` (multi-clause,
-first clause inline + array fallback) shapes. Clauses 2+ of a
-multi-clause predicate run through the WAM array path / `step` /
-`call_builtin` unchanged. To unlock more of the win, the next
-direction is to *broaden what gets lowered*: a `multi_clause_n`
-emitter that handles ALL clauses inline (gated on every clause being
-individually lowerable). Listed as the leading phase-4 candidate
-below.
+`lowered_*` functions. Phase 4 broadens the lowered emitter from
+`deterministic` and `multi_clause_1` to `multi_clause_n`: if every
+clause is individually lowerable, the generated function emits each
+clause inline and uses an iter-style retry CP for later clauses.
 
-## Phase 4 candidates
+## Phase 4 status and remaining candidates
 
-1. **`multi_clause_n` lowered emission.** When `forall(C in clauses,
-   wam_r_lowerable(C))` holds, emit each clause as an inline closure
-   inside the lowered function. Push a CP pointing at the next
-   inline clause, try each clause with state-restore between
-   attempts, leave the CP in place on success so caller-side
-   backtracking still works correctly via the array path.
+1. **`multi_clause_n` lowered emission.** Delivered: when all clauses
+   are in the supported subset, the lowered function emits each clause
+   as an inline closure, restores state between failed attempts, and
+   leaves an iter-style retry CP for later clauses.
 2. **`get_value` head match -- skip deref-then-unify when both
    sides are provably bound atomics.** Same shape as the phase-2
    `get_constant` specialisation but for var-to-var matching.
@@ -251,9 +244,8 @@ profile of the WAM stepping engine") flags the dominant costs:
 | `WamRuntime$deref` | 0.380 | 7.3% | **YES** -- skip deref at known-bound slots |
 | `WamRuntime$put_reg` | 0.260 | 5.0% | no -- already trivial |
 
-Phase 4 should pick **one** candidate (likely #1, since it
-multiplies the impact of every other specialisation), implement +
-bench on a workload that's actually dominated by the targeted op.
+The next phase should pick one remaining candidate and bench on a
+workload that's actually dominated by the targeted op.
 
 ## Phase 5+ — adaptive specialisation
 

--- a/src/unifyweaver/targets/wam_r_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_r_lowered_emitter.pl
@@ -2,7 +2,7 @@
 % SPDX-License-Identifier: MIT OR Apache-2.0
 % Copyright (c) 2026 John William Creighton (@s243a)
 %
-% wam_r_lowered_emitter.pl -- WAM-lowered R emission (Phase 3)
+% wam_r_lowered_emitter.pl -- WAM-lowered R emission (Phase 4)
 %
 % Plan mirrors the Haskell hybrid path in
 %   docs/design/WAM_HASKELL_LOWERED_{PHILOSOPHY,SPECIFICATION,
@@ -10,15 +10,11 @@
 %
 % Phase 2 covered deterministic single-clause predicates and emitted
 % one R function per predicate, delegating every instruction to
-% WamRuntime$step. Phase 3 (this iteration) adds two refinements:
+% WamRuntime$step. Phase 3 added two refinements:
 %
 %   1. Expanded lowerability. Multi-clause predicates whose first
-%      clause is in the supported set are now lowerable with reason
-%      multi_clause_1. The lowered function inlines clause 1 and, if
-%      clause 1 fails, drops back into the array path so the standard
-%      backtracking machinery can run clause 2+. This is the same
-%      design the Haskell lowered emitter uses for its multi-clause
-%      path.
+%      clause is in the supported set became lowerable with reason
+%      multi_clause_1.
 %
 %   2. Native per-instruction emission for the simple register ops
 %      (allocate/deallocate, put_constant/put_variable/put_value,
@@ -27,6 +23,10 @@
 %      involves deref/unify/heap-build (get_constant, get_value,
 %      get_structure, *_list, unify_*, set_*, builtin_call,
 %      call_foreign) still delegates to step.
+%
+% Phase 4 broadens multi-clause lowering to multi_clause_n: when every
+% clause is supported, each clause is emitted inline and later clauses
+% are exposed through an iter-style retry CP.
 %
 % Output under emit_mode(interpreter) is unchanged; this file is only
 % consulted under emit_mode(functions) / emit_mode(mixed([...])).
@@ -49,21 +49,17 @@
 % A predicate's WAM text is summarised into a `plan(Mode, AltLabel,
 % ClauseLines)` record:
 %
-%   - Mode is `deterministic` or `multi_clause_1`.
-%   - AltLabel is the label to backtrack to under multi_clause_1; it's
-%     the literal label string from the try_me_else operand. For
-%     deterministic predicates this is the atom `none`.
-%   - ClauseLines is the list of WAM-text lines that make up the
-%     emitted body. For deterministic mode this is every non-switch
-%     instruction line; for multi_clause_1 it's the lines of clause 1
-%     only (the lines between try_me_else and the corresponding
-%     trust_me, ending at proceed).
+%   - Mode is `deterministic` or `multi_clause_n`.
+%   - AltLabel is retained for the older multi_clause_1 shape; phase 4
+%     multi_clause_n does not need it and uses `none`.
+%   - ClauseLines is either the deterministic clause's WAM-text lines
+%     or, for multi_clause_n, a list of per-clause WAM-text line lists.
 %
 % switch_on_constant / switch_on_structure prefixes are dropped: they
 % were optimisations the array path uses to short-circuit dispatch.
-% Skipping them in the lowered path is correctness-preserving (clause
-% 1 either matches or we fall back to the array, which still runs the
-% switch).
+% Skipping them in the lowered path is correctness-preserving: each
+% lowered clause tries its own head match and failures move to the next
+% lowered clause.
 
 build_emission_plan(WamCode, plan(Mode, AltLabel, ClauseLines)) :-
     atom_string(WamCode, S),
@@ -87,39 +83,87 @@ skippable_prefix_line(["switch_on_constant"|_]).
 skippable_prefix_line(["switch_on_structure"|_]).
 
 % First-real-instruction discriminates between deterministic and
-% multi_clause_1. A try_me_else here means clause 1 starts at the next
-% line and ends at the trust_me/proceed boundary.
-classify_clause_shape([FirstLine|Rest], plan(multi_clause_1, AltAtom, ClauseLines)) :-
-    wam_r_target:tokenize_wam_line(FirstLine, ["try_me_else", AltStr]), !,
-    atom_string(AltAtom, AltStr),
-    take_clause1_lines(Rest, ClauseLines).
+% multi_clause_n. A try_me_else here means a standard WAM try-chain
+% follows, which we split into per-clause line groups.
+classify_clause_shape([FirstLine|Rest], plan(multi_clause_n, none, Clauses)) :-
+    wam_r_target:tokenize_wam_line(FirstLine, ["try_me_else", _AltStr]), !,
+    take_multi_clause_lines(Rest, Clauses).
 classify_clause_shape(Lines, plan(deterministic, none, Lines)).
 
-% Clause 1 ends either at a `proceed` (success path; we keep the
-% proceed line so the emitter renders return(TRUE) at that point) or
-% at a `trust_me` (start of clause 2; we stop without including it).
-take_clause1_lines([], []).
-take_clause1_lines([Line|Rest], Out) :-
-    wam_r_target:tokenize_wam_line(Line, Parts),
-    (   Parts == ["proceed"]
-    ->  Out = [Line]
-    ;   Parts == ["trust_me"]
-    ->  Out = []
-    ;   Out = [Line|RestOut],
-        take_clause1_lines(Rest, RestOut)
+% Multi-clause WAM emitted by the shared compiler has the shape:
+%   try_me_else L2, clause1..., L2:, retry_me_else L3, clause2...,
+%   L3:, trust_me, clause3...
+% We drop labels and choice instructions, preserving each clause body
+% through its `proceed` so the lowered closure returns TRUE at success.
+take_multi_clause_lines(Lines0, Clauses) :-
+    skip_clause_prefix(Lines0, Lines),
+    take_one_clause(Lines, Clause, Rest),
+    (   Clause == []
+    ->  Clauses = []
+    ;   Clauses = [Clause | Tail],
+        take_multi_clause_lines(Rest, Tail)
     ).
+
+skip_clause_prefix([], []).
+skip_clause_prefix([Line|Rest], Out) :-
+    wam_r_target:tokenize_wam_line(Line, Parts),
+    (   Parts == []
+    ->  skip_clause_prefix(Rest, Out)
+    ;   Parts = [First|_],
+        sub_string(First, _, 1, 0, ":")
+    ->  skip_clause_prefix(Rest, Out)
+    ;   Parts = ["retry_me_else", _]
+    ->  skip_clause_prefix(Rest, Out)
+    ;   Parts == ["trust_me"]
+    ->  skip_clause_prefix(Rest, Out)
+    ;   Out = [Line|Rest]
+    ).
+
+take_one_clause(Lines, Clause, Tail) :-
+    take_one_clause_(Lines, [], RevClause, Tail),
+    reverse(RevClause, Clause).
+
+take_one_clause_([], Acc, Acc, []).
+take_one_clause_([Line|Rest], Acc, Acc, [Line|Rest]) :-
+    wam_r_target:tokenize_wam_line(Line, Parts),
+    Acc \= [],
+    clause_boundary_parts(Parts),
+    !.
+take_one_clause_([Line|Rest], Acc, Out, Tail) :-
+    wam_r_target:tokenize_wam_line(Line, Parts),
+    Acc1 = [Line|Acc],
+    (   terminal_clause_parts(Parts)
+    ->  Out = Acc1,
+        Tail = Rest
+    ;   take_one_clause_(Rest, Acc1, Out, Tail)
+    ).
+
+clause_boundary_parts([First|_]) :-
+    sub_string(First, _, 1, 0, ":"), !.
+clause_boundary_parts(["retry_me_else", _]).
+clause_boundary_parts(["trust_me"]).
+
+terminal_clause_parts(["proceed"]).
+terminal_clause_parts(["fail"]).
+terminal_clause_parts(["execute", _]).
+terminal_clause_parts(["execute", _, _]).
 
 % =====================================================================
 % Lowerability
 % =====================================================================
 
 %% wam_r_lowerable(+Pred, +WamCode, -Reason) is semidet.
-%  Reason is one of `deterministic` or `multi_clause_1`. Lowerability
+%  Reason is one of `deterministic` or `multi_clause_n`. Lowerability
 %  is decided against the emission-plan's clause lines.
 wam_r_lowerable(_PI, WamCode, Reason) :-
-    catch(build_emission_plan(WamCode, plan(Mode, _, ClauseLines)), _, fail),
-    forall(member(Line, ClauseLines), line_supported(Line)),
+    catch(build_emission_plan(WamCode, plan(Mode, _, ClauseData)), _, fail),
+    emission_plan_lines(Mode, ClauseData, Lines),
+    forall(member(Line, Lines), line_supported(Line)),
     Reason = Mode.
+
+emission_plan_lines(deterministic, Lines, Lines).
+emission_plan_lines(multi_clause_n, Clauses, Lines) :-
+    append(Clauses, Lines).
 
 line_supported(Line) :-
     wam_r_target:tokenize_wam_line(Line, Parts),
@@ -209,16 +253,16 @@ lower_predicate_to_r(PI, WamCode, Opts,
     ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     format(atom(PredName), '~w/~w', [Pred, Arity]),
     r_lowered_func_name(Pred/Arity, FuncName),
-    build_emission_plan(WamCode, plan(Mode, AltLabel, ClauseLines)),
+    build_emission_plan(WamCode, plan(Mode, _AltLabel, ClauseLines)),
     catch(gather_pred_mode_records(PI, Records), _, Records = []),
     set_lowered_mode_context(Records, Opts),
     mode_comment_header_from_records(Opts, Records, ModeHeader),
     (   Mode == deterministic
     ->  emit_deterministic_function(PredName, FuncName, ClauseLines,
                                     ModeHeader, Code)
-    ;   Mode == multi_clause_1
-    ->  emit_multi_clause_function(PredName, FuncName, AltLabel,
-                                   ClauseLines, ModeHeader, Code)
+    ;   Mode == multi_clause_n
+    ->  emit_multi_clause_function(PredName, FuncName, ClauseLines,
+                                   ModeHeader, Code)
     ),
     clear_lowered_mode_context.
 
@@ -406,39 +450,94 @@ emit_deterministic_function(PredName, FuncName, ClauseLines,
 ~w  invisible(TRUE)
 }', [ModeHeader, PredName, FuncName, Body]).
 
-% Multi-clause: push a CP whose next_pc points at clause 2+, run
-% clause 1 inline. If clause 1 succeeds the lowered fn returns TRUE
-% (the CP stays in $cps for downstream backtracking). If clause 1
-% fails we backtrack via the runtime helper, advance past the
-% trust_me, and drop into the run loop so it can drive clause 2+.
-emit_multi_clause_function(PredName, FuncName, AltLabel, ClauseLines,
+% Multi-clause: every supported clause is emitted as an inline closure.
+% On success, a lightweight iter CP is pushed for the next clause so
+% caller-side backtracking can resume at clause N+1. On failure, the
+% original entry snapshot is restored before the next inline clause is
+% tried.
+emit_multi_clause_function(PredName, FuncName, Clauses,
                            ModeHeader, Code) :-
-    with_output_to(string(Body), emit_lines(ClauseLines, "    ")),
-    % clause1_ok is the value of the closure's last expression, which
-    % is the `return(TRUE)` emitted by the proceed line at the end of
-    % clause 1. invisible(FALSE) is a defensive fallback for the
-    % proceed-less case (caller does isTRUE() on the result).
+    length(Clauses, NClauses),
+    with_output_to(string(ClauseCode), emit_clause_dispatch(Clauses, 1)),
     format(string(Code),
-'~w# Lowered: ~w  (multi-clause; clause 1 inline, fall back to array)
+'~w# Lowered: ~w  (multi-clause; all clauses inline)
 ~w <- function(program, state) {
-  alt_pc <- program$labels[["~w"]]
-  if (is.null(alt_pc)) return(FALSE)
-  state$cps <- c(state$cps, list(list(
-    next_pc     = as.integer(alt_pc),
-    regs        = state$regs2,
-    cp          = state$cp,
-    trail_len   = length(state$trail),
-    var_counter = state$var_counter
-  )))
-  clause1_ok <- (function() {
-~w    invisible(FALSE)
-  })()
-  if (isTRUE(clause1_ok)) return(TRUE)
-  if (!isTRUE(WamRuntime$backtrack(state))) return(FALSE)
-  state$pc   <- state$pc + 1L
-  state$halt <- FALSE
-  isTRUE(WamRuntime$run(program, state))
-}', [ModeHeader, PredName, FuncName, AltLabel, Body]).
+  snap_regs_      <- state$regs2
+  snap_cp_        <- state$cp
+  snap_trail_     <- length(state$trail)
+  snap_var_count_ <- state$var_counter
+  snap_mode_      <- state$mode
+  snap_build_     <- state$build_stack
+  snap_read_      <- state$read_stack
+  snap_stack_len_ <- length(state$stack)
+  snap_barrier_   <- state$pending_call_barrier
+  resume_pc_      <- state$pc + 1L
+  restore_clause_entry_ <- function() {
+    state$regs2 <- snap_regs_
+    WamRuntime$undo_trail_to(state, snap_trail_)
+    state$cp <- snap_cp_
+    state$var_counter <- snap_var_count_
+    state$mode <- snap_mode_
+    state$build_stack <- snap_build_
+    state$read_stack <- snap_read_
+    state$pending_call_barrier <- snap_barrier_
+    if (length(state$stack) > snap_stack_len_) {
+      if (snap_stack_len_ == 0L) state$stack <- list()
+      else state$stack <- state$stack[seq_len(snap_stack_len_)]
+    }
+    state$shadow_frame <- NULL
+  }
+  try_clause_ <- function(idx_) {
+~w    FALSE
+  }
+  push_next_clause_ <- function(next_idx_) {
+    state$cps <- c(state$cps, list(list(
+      kind        = "iter",
+      regs        = snap_regs_,
+      trail_len   = snap_trail_,
+      cp          = snap_cp_,
+      var_counter = snap_var_count_,
+      mode        = snap_mode_,
+      build_stack = snap_build_,
+      read_stack  = snap_read_,
+      call_barrier = snap_barrier_,
+      stack_len   = snap_stack_len_,
+      resume_pc   = resume_pc_,
+      retry       = function(state) {
+        for (idx_ in seq.int(next_idx_, ~wL)) {
+          ok_ <- isTRUE(try_clause_(idx_))
+          if (ok_) {
+            if (idx_ < ~wL) push_next_clause_(idx_ + 1L)
+            return(TRUE)
+          }
+          restore_clause_entry_()
+        }
+        FALSE
+      }
+    )))
+  }
+  for (idx_ in seq_len(~wL)) {
+    ok_ <- isTRUE(try_clause_(idx_))
+    if (ok_) {
+      if (idx_ < ~wL) push_next_clause_(idx_ + 1L)
+      return(TRUE)
+    }
+    restore_clause_entry_()
+  }
+  FALSE
+}', [ModeHeader, PredName, FuncName, ClauseCode,
+      NClauses, NClauses, NClauses, NClauses]).
+
+emit_clause_dispatch([], _).
+emit_clause_dispatch([Lines|Rest], Idx) :-
+    format("    if (identical(idx_, ~wL)) {~n", [Idx]),
+    format("      return((function() {~n"),
+    emit_lines(Lines, "        "),
+    format("        invisible(FALSE)~n"),
+    format("      })())~n"),
+    format("    }~n"),
+    Idx1 is Idx + 1,
+    emit_clause_dispatch(Rest, Idx1).
 
 emit_lines([], _).
 emit_lines([Line|Rest], Ind) :-

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -6078,6 +6078,13 @@ WamRuntime$backtrack <- function(state) {
     state$mode        <- cp$mode
     state$build_stack <- cp$build_stack
     if (!is.null(cp$read_stack)) state$read_stack <- cp$read_stack
+    if (!is.null(cp$call_barrier)) state$pending_call_barrier <- cp$call_barrier
+    if (!is.null(cp$stack_len) &&
+        length(state$stack) > cp$stack_len) {
+      if (cp$stack_len == 0L) state$stack <- list()
+      else state$stack <- state$stack[seq_len(cp$stack_len)]
+    }
+    state$shadow_frame <- NULL
     if (cp$retry(state)) {
       state$pc <- as.integer(cp$resume_pc)
       return(TRUE)

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -42,6 +42,8 @@ user:wam_r_caller(X) :- user:wam_r_fact(X).
 user:wam_r_pair(f(a, b)).
 user:wam_r_list([a, b, c]).
 
+:- dynamic user:mode/1.
+
 % ------------------------------------------------------------------
 % Test 1: module exports the documented entry points
 % ------------------------------------------------------------------
@@ -385,6 +387,17 @@ run_rscript_with_args(RDir, Query, ExtraArgs, Out) :-
     read_string(ErrStream, _, _),   close(ErrStream),
     process_wait(PID, _).
 
+run_rscript_expr(RDir, Expr, Out) :-
+    process_create(path('Rscript'), ['-e', Expr],
+                   [ cwd(RDir),
+                     stdout(pipe(OutStream)),
+                     stderr(pipe(ErrStream)),
+                     process(PID)
+                   ]),
+    read_string(OutStream, _, Out), close(OutStream),
+    read_string(ErrStream, _, _),   close(ErrStream),
+    process_wait(PID, _).
+
 rscript_available :-
     catch((
         process_create(path('Rscript'), ['--version'],
@@ -462,11 +475,11 @@ test(lowered_emitter_phase3) :-
     assertion(current_predicate(wam_r_lowered_emitter:wam_r_lowerable/3)),
     assertion(current_predicate(wam_r_lowered_emitter:lower_predicate_to_r/4)),
     assertion(current_predicate(wam_r_lowered_emitter:r_lowered_func_name/2)),
-    % Multi-clause predicates are now lowerable as multi_clause_1
-    % (clause 1 inline + fallback to the array path on failure).
+    % Multi-clause predicates are now lowerable as multi_clause_n
+    % (all supported clauses inline).
     compile_predicate_to_wam_string(user:wam_r_choice_fact/1, ChoiceWam),
     once(wam_r_lowered_emitter:wam_r_lowerable(user:wam_r_choice_fact/1,
-                                               ChoiceWam, multi_clause_1)),
+                                               ChoiceWam, multi_clause_n)),
     % Single-clause deterministic rule is lowered with reason
     % `deterministic`.
     compile_predicate_to_wam_string(user:wam_r_caller/1, CallerWam),
@@ -516,14 +529,14 @@ test(emit_mode_functions_lowers_caller) :-
     )).
 
 % ------------------------------------------------------------------
-% Test: multi-clause predicates lower to a multi_clause_1 wrapper
-%       (clause 1 inline; backtrack into the array path on failure).
+% Test: multi-clause predicates lower to a multi_clause_n wrapper
+%       (all supported clauses inline).
 % ------------------------------------------------------------------
 test(emit_mode_functions_lowers_multi_clause) :-
     once((
         unique_r_tmp_dir('tmp_r_mode_multi', TmpDir),
         % fact_table_layout(off) keeps wam_r_choice_fact/1 on the
-        % multi_clause_1 lowered path; without it the new fact-table
+        % multi_clause_n lowered path; without it the new fact-table
         % path would pre-empt this test's assertions.
         write_wam_r_project(
             [user:wam_r_choice_fact/1],
@@ -533,11 +546,12 @@ test(emit_mode_functions_lowers_multi_clause) :-
         read_file_to_string(Program, Code, []),
         % Lowered fn definition exists.
         assertion(sub_string(Code, _, _, _, 'lowered_wam_r_choice_fact_1 <- function(program, state)')),
-        % multi_clause_1 marker is in the comment header.
-        assertion(sub_string(Code, _, _, _, 'multi-clause; clause 1 inline, fall back to array')),
-        % Clause-1 closure structure is in place.
-        assertion(sub_string(Code, _, _, _, 'clause1_ok <- (function() {')),
-        assertion(sub_string(Code, _, _, _, 'WamRuntime$backtrack(state)')),
+        % multi_clause_n marker is in the comment header.
+        assertion(sub_string(Code, _, _, _, 'multi-clause; all clauses inline')),
+        % Clause dispatch and retry CP structure are in place.
+        assertion(sub_string(Code, _, _, _, 'try_clause_ <- function(idx_)')),
+        assertion(sub_string(Code, _, _, _, 'push_next_clause_ <- function(next_idx_)')),
+        assertion(sub_string(Code, _, _, _, 'for (idx_ in seq_len(3L))')),
         % Wrapper points at the lowered fn.
         assertion(sub_string(Code, _, _, _, 'isTRUE(lowered_wam_r_choice_fact_1(shared_program, state))')),
         delete_directory_and_contents(TmpDir)
@@ -636,7 +650,7 @@ e2e_phase3_multi_clause :-
     write_wam_r_project(
         [ user:p3_fact/1,
           user:p3_a/0, user:p3_b/0, user:p3_c/0, user:p3_z/0 ],
-        % fact_table_layout(off) forces the multi_clause_1 lowered
+        % fact_table_layout(off) forces the multi_clause_n lowered
         % path that this test was written to cover; the new fact-
         % table path is exercised separately by
         % fact_table_e2e_rscript.
@@ -644,8 +658,9 @@ e2e_phase3_multi_clause :-
         TmpDir),
     directory_file_path(TmpDir, 'R/generated_program.R', Program),
     read_file_to_string(Program, Code, []),
-    % p3_fact/1 should be lowered as multi_clause_1.
+    % p3_fact/1 should be lowered as multi_clause_n.
     assertion(sub_string(Code, _, _, _, 'lowered_p3_fact_1 <- function(program, state)')),
+    assertion(sub_string(Code, _, _, _, 'multi-clause; all clauses inline')),
     directory_file_path(TmpDir, 'R', RDir),
     run_rscript_query(RDir, 'p3_a/0', A),  % matches clause 1
     run_rscript_query(RDir, 'p3_b/0', B),  % must backtrack to clause 2
@@ -827,7 +842,7 @@ e2e_mode_phase2_get_constant :-
     retractall(user:ma_check_b/0),
     retractall(user:ma_check_z/0),
     % `+` mode -- caller will always pass a bound atom; specialisation
-    % fires. Use three clauses so multi_clause_1 lowering also kicks in,
+    % fires. Use three clauses so multi_clause_n lowering also kicks in,
     % exercising the inlined get_constant in the multi-clause path.
     assertz(user:mode(ma_pe(+))),
     assertz((user:ma_pe(a))),
@@ -928,6 +943,49 @@ e2e_phase3_is :-
     assertion(sub_string(OutS,   _, _, _, "true")),
     assertion(sub_string(OutN,   _, _, _, "true")),
     assertion(sub_string(OutNeg, _, _, _, "true")),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
+% Mode-analysis phase 4: multi_clause_n lowered emission.
+% All supported clauses are emitted into the lowered wrapper, so
+% specialisations such as inline is/2 apply to clause 2+ instead of
+% those clauses falling back through the WAM array path.
+% ------------------------------------------------------------------
+test(mode_analysis_phase4_multiclause_n_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_phase4_multiclause_n
+    ;   true
+    )).
+
+e2e_phase4_multiclause_n :-
+    retractall(user:p4_mc(_, _)),
+    retractall(user:p4_enum(_)),
+    retractall(user:p4_call(_)),
+    assertz((user:p4_mc(1, R) :- R is 40 + 2)),
+    assertz((user:p4_mc(2, R) :- R is 98 + 1)),
+    assertz(user:p4_enum(a)),
+    assertz(user:p4_enum(b)),
+    assertz((user:p4_call(a) :- p4_enum(a))),
+    assertz((user:p4_call(b) :- p4_enum(b))),
+    unique_r_tmp_dir('tmp_r_phase4_mcn_e2e', TmpDir),
+    write_wam_r_project(
+        [user:p4_mc/2, user:p4_enum/1, user:p4_call/1],
+        [emit_mode(functions), fact_table_layout(off)],
+        TmpDir),
+    directory_file_path(TmpDir, 'R/generated_program.R', Program),
+    read_file_to_string(Program, Code, []),
+    assertion(sub_string(Code, _, _, _, 'multi-clause; all clauses inline')),
+    assertion(sub_string(Code, _, _, _, 'if (identical(idx_, 2L))')),
+    assertion(sub_string(Code, _, _, _, 'is_target_ <- WamRuntime$get_reg(state, 1L)')),
+    assertion(sub_string(Code, _, _, _, 'lowered_p4_call_1 <- function(program, state)')),
+    directory_file_path(TmpDir, 'R', RDir),
+    Expr =
+        'source("generated_program.R"); cat(if (isTRUE(pred_p4_mc(IntTerm(2L), IntTerm(99L)))) "true\\n" else "false\\n"); cat(if (isTRUE(pred_p4_mc(IntTerm(2L), IntTerm(100L)))) "true\\n" else "false\\n"); cat(if (isTRUE(pred_p4_call(Atom(WamRuntime$intern(intern_table, "b"))))) "true\\n" else "false\\n"); st <- WamRuntime$new_state(); WamRuntime$promote_regs(st); WamRuntime$put_reg(st, 1L, Unbound("X")); ok1 <- lowered_p4_enum_1(shared_program, st); x1 <- WamRuntime$deref(st, Unbound("X")); ok2 <- WamRuntime$backtrack(st); x2 <- WamRuntime$deref(st, Unbound("X")); cat(paste(isTRUE(ok1), WamRuntime$string_of(intern_table, x1$id), isTRUE(ok2), WamRuntime$string_of(intern_table, x2$id), sep=":"), "\\n", sep="")',
+    run_rscript_expr(RDir, Expr, Out),
+    split_string(Out, "\n", "\r\n", Lines0),
+    exclude(=("") , Lines0, Lines),
+    assertion(Lines == ["true", "false", "true", "TRUE:a:TRUE:b"]),
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extend the WAM-R lowered emitter from `multi_clause_1` to `multi_clause_n` for predicates where every clause is in the supported lowered subset.
- Emit each supported clause as an inline R closure, so lowered-emitter specializations such as inline `is/2` apply to clause 2+ instead of falling back through the instruction array.
- Preserve backtracking by pushing an iter-style retry CP for later lowered clauses.
- Restore optional stack and cut-barrier snapshots from iter CPs so lowered multi-clause retries remain safe for rule bodies that allocate frames.
- Add phase-4 e2e coverage for clause-2 inline `is/2`, direct lowered-wrapper execution, and retry CP enumeration.
- Update WAM-R target docs and the mode-analysis plan to describe `multi_clause_n`.

## Verification

- `git diff --check`
- `swipl -g "run_tests([wam_r_generator:lowered_emitter_phase3,wam_r_generator:emit_mode_functions_lowers_multi_clause,wam_r_generator:phase3_multi_clause_e2e_rscript,wam_r_generator:mode_analysis_phase2_get_constant_inlined,wam_r_generator:mode_analysis_phase2_get_constant_e2e_rscript,wam_r_generator:mode_analysis_phase3_is_inlined,wam_r_generator:mode_analysis_phase3_is_e2e_rscript,wam_r_generator:mode_analysis_phase4_multiclause_n_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
- `swipl -g "run_tests([wam_r_generator:list_atom_builtins_e2e_rscript,wam_r_generator:findall_e2e_rscript,wam_r_generator:bagof_setof_existential_e2e_rscript,wam_r_generator:mode_analysis_phase4_multiclause_n_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`

All checks passed locally.
