### PR TITLE
docs: scan-strategy + algorithm-manifest design (4 docs)

### DIFF
--- a/docs/design/ALGORITHM_MANIFEST_SPECIFICATION.md
+++ b/docs/design/ALGORITHM_MANIFEST_SPECIFICATION.md
@@ -1,0 +1,355 @@
+# Algorithm Optimization Manifest — Specification
+
+## Terminology note
+
+In this document and the scan-strategy docs that reference it,
+**"algorithm" means the *logical specification* of the graph
+problem** — the declarative *what*, not the operational *how*.
+This is closer to the Datalog / SQL sense (a query is an
+algorithm; its execution plan is a separate artefact) than the
+algorithms-textbook sense (an algorithm is a step-by-step
+procedure).
+
+An algorithm in our sense may *hint* at how it's computed (e.g. a
+recursive kernel suggests BFS-style expansion) but it doesn't
+fully specify the operational behaviour. The **optimization
+specification** completes the definition by saying which cache
+mode, scan strategy, cost function, etc. to use. Together,
+algorithm + optimization manifest = executable artefact.
+
+This split matters because the two halves have different owners
+(workload author vs perf engineer), different lifecycles (stable
+vs measurement-driven), and different concerns (correctness vs
+throughput). Mechanically the split is small; conceptually it's
+the central point of this doc.
+
+## What this is
+
+A workload-author-level mechanism for separating two concerns:
+
+1. **The algorithm** (logical specification): *what* is being
+   computed (a kernel, its inputs, its output shape).
+2. **The optimization manifest** (operational specification):
+   *how* the codegen should compile the algorithm (cost-model
+   knobs, cache mode, scan strategy, demand-filter spec, etc.).
+
+The split exists because the two have different owners and lifecycles:
+
+- Algorithm: stable, owned by whoever wrote the workload, rarely
+  changes.
+- Optimizations: tuning artefacts, owned by whoever cares about
+  perf, change with measurements / hardware / data scale.
+
+Without the split, every bench harness and every call site
+re-declares the same option bundle. With it, an algorithm is
+declared once with its current best-known optimization profile;
+any caller that names the algorithm gets the optimizations for
+free.
+
+This document specifies the mechanism. It's deliberately small —
+the abstraction is a thin layer over the existing option-list
+plumbing the resolvers already consume.
+
+## Connection to existing patterns
+
+This generalises three patterns already present in the codebase:
+
+| existing | how the manifest subsumes it |
+|---|---|
+| `user:demand_filter_spec(Strategy, Opts)` | an entry in the manifest's option list |
+| `user:max_depth/1`, `user:dimension_n/1` | algorithm-level metadata in `algorithm/2` |
+| `statistics:declare_cache_hints/1` | `workload_locality/1` entry in the manifest |
+
+The manifest is **additive**, not replacing existing mechanisms.
+The codegen still reads `user:demand_filter_spec/2`, etc., for
+backwards compatibility. New workloads use the manifest; old
+workloads keep working unchanged.
+
+## API
+
+Two user-level predicates. Both declared in workload files via
+`:- ...` directives (the standard Prolog idiom for facts about
+the workload).
+
+### `algorithm(+Name, +AlgorithmOpts) is det.`
+
+Declares an algorithm. `Name` is an atom identifying the
+algorithm (e.g. `effective_distance`, `transitive_closure`,
+`shortest_path`). `AlgorithmOpts` is an option list describing
+the algorithm's structural metadata:
+
+- `kernel(P/N)` — the recursive kernel predicate.
+- `seeds(P/N)` — the seed predicate (input).
+- `roots(P/N)` — the root predicate (target).
+- `max_depth(D)` — bound on recursion depth.
+- Other algorithm-specific keys (e.g. `dimension_n/1` for
+  effective_distance).
+
+Example:
+
+```prolog
+:- algorithm(effective_distance, [
+       kernel(category_ancestor/4),
+       seeds(article/1),
+       roots(root_category/1),
+       max_depth(10),
+       dimension_n(5)
+   ]).
+```
+
+At most one `algorithm/2` declaration per file. Multiple
+declarations with the same name in different files are an error;
+the codegen rejects compilation rather than silently picking one.
+
+### `algorithm_optimization(+Name, +OptList) is det.`
+
+Declares optimizations for an algorithm. `Name` matches an
+`algorithm/2` declaration. `OptList` contains any options that
+downstream resolvers consume.
+
+Example:
+
+```prolog
+:- algorithm_optimization(effective_distance, [
+       cache_strategy(auto),
+       working_set_fraction(0.001),
+       expected_query_count(10),
+       lmdb_cache_mode(auto),
+       workload_locality(unknown),
+       scan_strategy(auto),
+       tree_cost_function(flux, [iterations(1), parent_decay(0.5), child_decay(0.3)]),
+       tree_retention(snapshot_only),
+       warm_budget_nodes_fraction(0.1),
+       demand_filter_spec(hop_limit, [max_hops(10)])
+   ]).
+```
+
+Multiple `algorithm_optimization/2` facts for the same algorithm
+are allowed — their option lists concatenate with `option/3`
+first-match semantics. This lets workload authors split
+optimizations by concern:
+
+```prolog
+:- algorithm_optimization(effective_distance, [
+       cache_strategy(auto), working_set_fraction(0.001), ...
+   ]).
+:- algorithm_optimization(effective_distance, [
+       scan_strategy(auto), tree_cost_function(flux, [...]), ...
+   ]).
+```
+
+If a key appears in multiple facts, the first occurrence wins
+(matches `option/3` semantics). To override, place the overriding
+fact earlier or pass the option directly to the codegen entry
+point.
+
+## Merge semantics
+
+When the codegen enters `write_wam_haskell_project/3` (or
+`compile_wam_runtime_to_haskell/3`), the option pipeline is:
+
+```
+1. Caller-provided options: Options0
+2. Manifest options:        ManifestOpts
+                              = concat of all algorithm_optimization(Name, _)
+                                facts for the declared algorithm
+3. Merged options:          Options' = merge(Options0, ManifestOpts)
+   - For each key in either:
+       if Options0 has key  → take from Options0
+       else                 → take from ManifestOpts
+4. Resolvers run on Options' in their existing order.
+```
+
+**Caller wins on conflict.** This is the override path: a bench
+that wants to experiment with `tree_retention(live)` passes that
+option directly, and it beats the manifest's `snapshot_only`.
+
+**Manifest is best-known-defaults, not policy.** The manifest is
+a recommendation derived from measurement and cost-model logic.
+Callers should feel free to override when they have a reason.
+
+## Composition with resolvers
+
+The manifest sits *before* the existing resolvers in the option
+pipeline. By the time `resolve_auto_cache_strategy/2`,
+`resolve_auto_lmdb_cache_mode/2`, etc., run, they see a merged
+option list with manifest defaults filled in.
+
+```
+Options0 (caller)
+  → merge with ManifestOpts
+  → resolve_auto_use_lmdb
+  → resolve_auto_cache_strategy
+  → resolve_auto_lmdb_cache_mode
+  → resolve_auto_scan_strategy   (new in P4 of the scan-strategy plan)
+  → codegen
+```
+
+The resolvers themselves don't change. The manifest just provides
+their inputs.
+
+## Where the manifest is read
+
+A small Prolog helper, conceptually:
+
+```prolog
+%% load_algorithm_manifest(+Options0, -OptionsWithManifest) is det.
+%
+%  Reads user:algorithm/2 and user:algorithm_optimization/2 (if
+%  declared) and merges the optimization options into the codegen's
+%  option list. Caller-provided options always win on conflict.
+load_algorithm_manifest(Options0, OptionsWithManifest) :-
+    (   user:algorithm(Name, _AlgOpts)
+    ->  findall(Opts, user:algorithm_optimization(Name, Opts), AllOpts),
+        flatten(AllOpts, ManifestOpts),
+        merge_options(Options0, ManifestOpts, OptionsWithManifest)
+    ;   OptionsWithManifest = Options0
+    ).
+```
+
+`merge_options/3` is implemented to give caller options precedence
+on duplicate keys (this is *not* the SWI-Prolog library
+`merge_options/3` — that one's argument order convention is
+different; we'd implement our own or pick a clear name).
+
+This helper runs once at the top of
+`write_wam_haskell_project/3` (and `compile_wam_runtime_to_haskell/3`
+for the codegen-test path), before any resolver.
+
+## Edge cases
+
+### No algorithm declared
+
+The codegen continues to work without a manifest — `Options0`
+flows straight through. Existing workloads that don't use
+manifests are unaffected.
+
+### Algorithm declared but no optimization manifest
+
+Same as caller-provided options only. The `algorithm/2` declaration
+itself is informational (the codegen reads its `kernel/1`,
+`seeds/1`, etc. — same way it currently reads `user:max_depth/1`),
+but no optimization options are merged.
+
+### Multiple algorithms declared in one workload
+
+Currently an error. A workload that genuinely computes two
+algorithms in one binary is rare; the design defers the
+multi-algorithm case to a future extension (probably named
+manifests selected at call time). For now: one algorithm per
+workload.
+
+### Optimization for an undeclared algorithm
+
+`algorithm_optimization(foo, _)` without a matching `algorithm(foo,
+_)` is a warning. The optimization options are ignored; the
+codegen logs that the manifest was orphaned.
+
+### Manifest option that no resolver understands
+
+Unknown keys are passed through. If a future resolver adds support,
+existing manifests pick it up without changes. If a resolver
+removes support for a key, the unknown entry is silently ignored
+(or warned, depending on strict-mode setting).
+
+### Conflicting `algorithm_optimization/2` facts
+
+Multiple facts concat with first-match semantics. If two facts
+both set `cache_strategy/1` to different values, the first one
+encountered wins. Workload authors who need explicit ordering
+should consolidate into a single fact.
+
+## Example: full workload file
+
+```prolog
+:- module(workload_effective_distance, []).
+
+%% Algorithm declaration
+:- algorithm(effective_distance, [
+       kernel(category_ancestor/4),
+       seeds(article/1),
+       roots(root_category/1),
+       max_depth(10),
+       dimension_n(5)
+   ]).
+
+%% Optimization manifest, split by concern
+:- algorithm_optimization(effective_distance, [
+       %% Cache cost-model
+       cache_strategy(auto),
+       working_set_fraction(0.001),
+       expected_query_count(10),
+       mem_available_bytes(8_000_000_000)  % overrides /proc/meminfo
+   ]).
+:- algorithm_optimization(effective_distance, [
+       %% Cache tier
+       lmdb_cache_mode(auto),
+       workload_locality(unknown),
+       cache_tier_floor_bytes(8_000_000)
+   ]).
+:- algorithm_optimization(effective_distance, [
+       %% Scan strategy
+       scan_strategy(auto),
+       tree_cost_function(flux, [
+           iterations(1),
+           parent_decay(0.5),
+           child_decay(0.3),
+           flux_merge(sum)
+       ]),
+       tree_retention(snapshot_only),
+       warm_budget_nodes_fraction(0.1)
+   ]).
+:- algorithm_optimization(effective_distance, [
+       %% Demand filter
+       demand_filter_spec(hop_limit, [max_hops(10)])
+   ]).
+
+%% Kernel definition (unchanged)
+category_ancestor(Cat, Root, Hops, Visited) :-
+    category_parent(Cat, Mid),
+    \+ member(Mid, Visited),
+    category_ancestor(Mid, Root, H, [Mid|Visited]),
+    Hops is H + 1.
+```
+
+A bench harness or end-user code that wants to run this workload
+now just names the algorithm:
+
+```prolog
+:- use_module(workload_effective_distance).
+:- write_wam_haskell_project(
+       [category_ancestor/4, ...],
+       [],  % no caller-level options — manifest provides everything
+       'output/effective_distance_bench'
+   ).
+```
+
+To experiment with a different optimization:
+
+```prolog
+:- write_wam_haskell_project(
+       [category_ancestor/4, ...],
+       [tree_retention(live)],  % overrides manifest's snapshot_only
+       'output/effective_distance_bench_live'
+   ).
+```
+
+## What this isn't
+
+- **Not a DSL for algorithms.** `algorithm/2` is a metadata
+  declaration, not a language for *defining* algorithms. The
+  kernel still lives in normal Prolog clauses.
+- **Not a runtime mechanism.** Manifests are read at codegen time
+  only. They don't affect runtime behaviour directly; their effect
+  is mediated through the options they feed to the resolvers.
+- **Not a replacement for explicit options.** Callers retain full
+  control via the caller-wins merge rule.
+
+## See also
+
+- `docs/design/CACHE_COST_MODEL_PHILOSOPHY.md` — the cost-model
+  resolvers that consume manifest entries.
+- `docs/design/SCAN_STRATEGY_SPECIFICATION.md` — the scan-strategy
+  options that go in a manifest.
+- `docs/design/SCAN_STRATEGY_IMPLEMENTATION_PLAN.md` — Phase 0
+  introduces the manifest abstraction; later phases assume it.

--- a/docs/design/ALGORITHM_MANIFEST_SPECIFICATION.md
+++ b/docs/design/ALGORITHM_MANIFEST_SPECIFICATION.md
@@ -1,5 +1,15 @@
 # Algorithm Optimization Manifest — Specification
 
+## Naming note
+
+The user-level directives are `decl_algorithm/2` and
+`decl_algorithm_optimization/2`. The `decl_` prefix signals that
+these are *declarative directives* (facts that describe metadata
+about the workload), not callable predicates. The prefix also
+avoids any collision with library predicates that might define a
+plain `algorithm/2` — defensive even if no current standard
+library uses that name.
+
 ## Terminology note
 
 In this document and the scan-strategy docs that reference it,
@@ -57,7 +67,7 @@ This generalises three patterns already present in the codebase:
 | existing | how the manifest subsumes it |
 |---|---|
 | `user:demand_filter_spec(Strategy, Opts)` | an entry in the manifest's option list |
-| `user:max_depth/1`, `user:dimension_n/1` | algorithm-level metadata in `algorithm/2` |
+| `user:max_depth/1`, `user:dimension_n/1` | algorithm-level metadata in `decl_algorithm/2` |
 | `statistics:declare_cache_hints/1` | `workload_locality/1` entry in the manifest |
 
 The manifest is **additive**, not replacing existing mechanisms.
@@ -71,7 +81,7 @@ Two user-level predicates. Both declared in workload files via
 `:- ...` directives (the standard Prolog idiom for facts about
 the workload).
 
-### `algorithm(+Name, +AlgorithmOpts) is det.`
+### `decl_algorithm(+Name, +AlgorithmOpts) is det.`
 
 Declares an algorithm. `Name` is an atom identifying the
 algorithm (e.g. `effective_distance`, `transitive_closure`,
@@ -88,7 +98,7 @@ the algorithm's structural metadata:
 Example:
 
 ```prolog
-:- algorithm(effective_distance, [
+:- decl_algorithm(effective_distance, [
        kernel(category_ancestor/4),
        seeds(article/1),
        roots(root_category/1),
@@ -97,20 +107,20 @@ Example:
    ]).
 ```
 
-At most one `algorithm/2` declaration per file. Multiple
+At most one `decl_algorithm/2` declaration per file. Multiple
 declarations with the same name in different files are an error;
 the codegen rejects compilation rather than silently picking one.
 
-### `algorithm_optimization(+Name, +OptList) is det.`
+### `decl_algorithm_optimization(+Name, +OptList) is det.`
 
 Declares optimizations for an algorithm. `Name` matches an
-`algorithm/2` declaration. `OptList` contains any options that
+`decl_algorithm/2` declaration. `OptList` contains any options that
 downstream resolvers consume.
 
 Example:
 
 ```prolog
-:- algorithm_optimization(effective_distance, [
+:- decl_algorithm_optimization(effective_distance, [
        cache_strategy(auto),
        working_set_fraction(0.001),
        expected_query_count(10),
@@ -119,21 +129,30 @@ Example:
        scan_strategy(auto),
        tree_cost_function(flux, [iterations(1), parent_decay(0.5), child_decay(0.3)]),
        tree_retention(snapshot_only),
+       %% warm_budget_nodes_fraction(F) is a manifest-friendly alias
+       %% that scan_strategy's resolver converts to an absolute
+       %% warm_budget_nodes(N) before codegen. See the option list in
+       %% SCAN_STRATEGY_SPECIFICATION.md for both forms.
        warm_budget_nodes_fraction(0.1),
        demand_filter_spec(hop_limit, [max_hops(10)])
    ]).
 ```
 
-Multiple `algorithm_optimization/2` facts for the same algorithm
-are allowed — their option lists concatenate with `option/3`
-first-match semantics. This lets workload authors split
+Multiple `decl_algorithm_optimization/2` facts for the same algorithm
+are allowed — their option lists are concatenated in declaration
+order using `append/2` (shallow concat — see the `load_algorithm_manifest/2`
+sketch below for the trap with `flatten/2`). The manifest itself
+does no de-duplication at concat time. When the merged list is
+later read via SWI-Prolog's `option/3` accessor, the first
+occurrence of any key wins — that's `option/3`'s documented
+behaviour for repeated keys. This lets workload authors split
 optimizations by concern:
 
 ```prolog
-:- algorithm_optimization(effective_distance, [
+:- decl_algorithm_optimization(effective_distance, [
        cache_strategy(auto), working_set_fraction(0.001), ...
    ]).
-:- algorithm_optimization(effective_distance, [
+:- decl_algorithm_optimization(effective_distance, [
        scan_strategy(auto), tree_cost_function(flux, [...]), ...
    ]).
 ```
@@ -151,7 +170,7 @@ When the codegen enters `write_wam_haskell_project/3` (or
 ```
 1. Caller-provided options: Options0
 2. Manifest options:        ManifestOpts
-                              = concat of all algorithm_optimization(Name, _)
+                              = concat of all decl_algorithm_optimization(Name, _)
                                 facts for the declared algorithm
 3. Merged options:          Options' = merge(Options0, ManifestOpts)
    - For each key in either:
@@ -195,26 +214,46 @@ A small Prolog helper, conceptually:
 ```prolog
 %% load_algorithm_manifest(+Options0, -OptionsWithManifest) is det.
 %
-%  Reads user:algorithm/2 and user:algorithm_optimization/2 (if
+%  Reads user:decl_algorithm/2 and user:decl_algorithm_optimization/2 (if
 %  declared) and merges the optimization options into the codegen's
 %  option list. Caller-provided options always win on conflict.
 load_algorithm_manifest(Options0, OptionsWithManifest) :-
-    (   user:algorithm(Name, _AlgOpts)
-    ->  findall(Opts, user:algorithm_optimization(Name, Opts), AllOpts),
-        flatten(AllOpts, ManifestOpts),
-        merge_options(Options0, ManifestOpts, OptionsWithManifest)
+    (   user:decl_algorithm(Name, _AlgOpts)
+    ->  findall(Opts, user:decl_algorithm_optimization(Name, Opts), AllOpts),
+        %% IMPORTANT: shallow concat, not deep flatten. flatten/2 would
+        %% destructure option terms whose values are themselves lists —
+        %% e.g. `tree_cost_function(flux, [iterations(1), parent_decay(0.5)])`
+        %% would have its inner parameter list pulled into the outer
+        %% option list and corrupt the structure.
+        append(AllOpts, ManifestOpts),
+        merge_caller_and_manifest_options(Options0, ManifestOpts,
+                                          OptionsWithManifest)
     ;   OptionsWithManifest = Options0
     ).
 ```
 
-`merge_options/3` is implemented to give caller options precedence
-on duplicate keys (this is *not* the SWI-Prolog library
-`merge_options/3` — that one's argument order convention is
-different; we'd implement our own or pick a clear name).
+The merge helper is `merge_caller_and_manifest_options/3` — same
+name used in `SCAN_STRATEGY_IMPLEMENTATION_PLAN.md` P0. We
+deliberately avoid the bare name `merge_options/3` because
+SWI-Prolog's `library(option)` exports a different
+`merge_options/3` with reversed argument-order conventions;
+sharing the name would invite confusion at use sites.
 
-This helper runs once at the top of
-`write_wam_haskell_project/3` (and `compile_wam_runtime_to_haskell/3`
-for the codegen-test path), before any resolver.
+This helper runs once at the head of the codegen pipeline. There
+are two public entry points:
+
+- `write_wam_haskell_project/3` — the end-to-end path used by
+  bench harnesses and users.
+- `compile_wam_runtime_to_haskell/3` — the inner path used by
+  codegen tests that don't want to write a project to disk.
+
+`write_wam_haskell_project/3` calls `compile_wam_runtime_to_haskell/3`
+internally, so if the manifest load lives only at the inner entry
+point, both paths benefit. The current implementation puts it
+explicitly at both for symmetry with the existing cost-model
+resolver wiring (`resolve_auto_use_lmdb/2` already lives at both
+sites); P0's deliverables include making `load_algorithm_manifest/2`
+idempotent so the duplicate call in the outer path is harmless.
 
 ## Edge cases
 
@@ -226,7 +265,7 @@ manifests are unaffected.
 
 ### Algorithm declared but no optimization manifest
 
-Same as caller-provided options only. The `algorithm/2` declaration
+Same as caller-provided options only. The `decl_algorithm/2` declaration
 itself is informational (the codegen reads its `kernel/1`,
 `seeds/1`, etc. — same way it currently reads `user:max_depth/1`),
 but no optimization options are merged.
@@ -252,7 +291,7 @@ existing manifests pick it up without changes. If a resolver
 removes support for a key, the unknown entry is silently ignored
 (or warned, depending on strict-mode setting).
 
-### Conflicting `algorithm_optimization/2` facts
+### Conflicting `decl_algorithm_optimization/2` facts
 
 Multiple facts concat with first-match semantics. If two facts
 both set `cache_strategy/1` to different values, the first one
@@ -265,7 +304,7 @@ should consolidate into a single fact.
 :- module(workload_effective_distance, []).
 
 %% Algorithm declaration
-:- algorithm(effective_distance, [
+:- decl_algorithm(effective_distance, [
        kernel(category_ancestor/4),
        seeds(article/1),
        roots(root_category/1),
@@ -274,20 +313,24 @@ should consolidate into a single fact.
    ]).
 
 %% Optimization manifest, split by concern
-:- algorithm_optimization(effective_distance, [
+:- decl_algorithm_optimization(effective_distance, [
        %% Cache cost-model
        cache_strategy(auto),
        working_set_fraction(0.001),
        expected_query_count(10),
-       mem_available_bytes(8_000_000_000)  % overrides /proc/meminfo
+       mem_available_bytes(8000000000)  % 8 GB; overrides /proc/meminfo
+                                        % (underscore-grouped literals
+                                        %  also work in SWI-Prolog 8.x+,
+                                        %  but the plain form is portable
+                                        %  to older Prologs)
    ]).
-:- algorithm_optimization(effective_distance, [
+:- decl_algorithm_optimization(effective_distance, [
        %% Cache tier
        lmdb_cache_mode(auto),
        workload_locality(unknown),
-       cache_tier_floor_bytes(8_000_000)
+       cache_tier_floor_bytes(8000000)  % 8 MB
    ]).
-:- algorithm_optimization(effective_distance, [
+:- decl_algorithm_optimization(effective_distance, [
        %% Scan strategy
        scan_strategy(auto),
        tree_cost_function(flux, [
@@ -299,12 +342,15 @@ should consolidate into a single fact.
        tree_retention(snapshot_only),
        warm_budget_nodes_fraction(0.1)
    ]).
-:- algorithm_optimization(effective_distance, [
+:- decl_algorithm_optimization(effective_distance, [
        %% Demand filter
        demand_filter_spec(hop_limit, [max_hops(10)])
    ]).
 
 %% Kernel definition (unchanged)
+%% Base case: a node reaches itself at hop 0.
+category_ancestor(Root, Root, 0, _).
+%% Recursive case: step to a parent, recurse, account for the hop.
 category_ancestor(Cat, Root, Hops, Visited) :-
     category_parent(Cat, Mid),
     \+ member(Mid, Visited),
@@ -336,7 +382,7 @@ To experiment with a different optimization:
 
 ## What this isn't
 
-- **Not a DSL for algorithms.** `algorithm/2` is a metadata
+- **Not a DSL for algorithms.** `decl_algorithm/2` is a metadata
   declaration, not a language for *defining* algorithms. The
   kernel still lives in normal Prolog clauses.
 - **Not a runtime mechanism.** Manifests are read at codegen time

--- a/docs/design/SCAN_STRATEGY_IMPLEMENTATION_PLAN.md
+++ b/docs/design/SCAN_STRATEGY_IMPLEMENTATION_PLAN.md
@@ -70,9 +70,14 @@ the place.
 
 - All 167+ existing WAM-Haskell tests pass (no behaviour change).
 - New manifest unit tests pass.
-- A demo workload using `algorithm/2` + `algorithm_optimization/2`
-  emits the same Haskell code as the equivalent caller-options
-  invocation.
+- A demo workload using `decl_algorithm/2` +
+  `decl_algorithm_optimization/2` emits the same Haskell code
+  as the equivalent caller-options invocation.
+- **Negative test**: a workload that declares
+  `decl_algorithm(foo, [kernel(does_not_exist/3)])` (or any
+  reference to an undeclared predicate) fails at codegen with a
+  clear error ("manifest references undeclared kernel
+  `does_not_exist/3`"), not silently producing incorrect code.
 
 ### Estimated effort
 
@@ -120,6 +125,10 @@ preparation.
   `tree_cost_function(hop_distance, [max_hops(5)])` emits
   code that produces a non-zero score for nodes within 5 hops.
 - The existing Flux-panic test still passes (regression check).
+- A new test exercises the *new* `CostFn`-dispatch path with
+  `tree_cost_function(flux, [...])` and asserts the panic still
+  fires — protects against accidentally swallowing the panic
+  during the refactor.
 
 ### Estimated effort
 
@@ -158,8 +167,11 @@ No code changes. Tooling and measurement only.
 
 ### Success criteria
 
-- `resident_auto` runs within 5% of `resident_cursor` baseline at
-  every scale (resolver agrees with empirical best).
+- Median of 3 trials of `resident_auto` is within 10% of median
+  of 3 trials of `resident_cursor` at every scale. (10% to match
+  P3's tolerance and to account for the 3–8% multi-trial variance
+  Phase L measurements have shown at -N4 for BFS workloads,
+  especially under cold-start enwiki conditions.)
 - Branching-factor distribution captured: median, P90, P99 for
   parent and child legs separately.
 
@@ -192,7 +204,12 @@ Haskell side (`templates/targets/haskell_wam/`):
 
 - `scan_strategy.hs.mustache` — new template with:
   - `WarmHeap`, `WarmIndex`, `Frontier`, `Visited` types
-  - `runWarmBuild :: CostFn -> WarmConfig -> IO (WarmHeap, WarmIndex)`
+  - `runWarmBuild :: CostFn -> WarmConfig -> IO WarmHeap`
+    (The `WarmIndex`, `Frontier`, and `Visited` are warm-phase
+    internals; they're created and discarded inside `runWarmBuild`.
+    Callers don't see them. `live`-mode consumers in P7+ that need
+    them get a separate `runWarmBuildLive` entry point that
+    returns the full warm state.)
   - `snapshotCache :: WarmHeap -> IntMap NodeId [EdgeTarget]`
   - `snapshotRanked :: WarmHeap -> [(NodeId, Cost)]`
   - Stage-1 cursor loop + stage-2 scan trigger
@@ -290,14 +307,22 @@ per-HEC L1 cache from being useful.
 
 - `partitionByRank :: Int -> RankedView -> [[NodeId]]` in
   `scan_strategy.hs.mustache`.
-- `main.hs.mustache` — when `tree_retention(retain)` is set,
+- `main.hs.mustache` — when `tree_retention(snapshot_only)` is set,
   replace the seed `parMap rdeepseq` with a per-capability
-  `mapConcurrently` driven by `partitionByRank`.
+  `mapConcurrently` driven by `partitionByRank`. (The spec's
+  retention enum is `discard | snapshot_only | live`; there is no
+  `retain` value.)
 - New option: `spark_routing(capability_local)` (default
   `unsharded`).
 - Resolver hook: `scan_strategy(auto)` + `expected_query_count > 1`
-  → automatically opts into retention + capability_local routing
-  if L1 is the chosen cache mode.
+  → automatically opts into `tree_retention(snapshot_only)` +
+  `spark_routing(capability_local)` when the **resolved**
+  `lmdb_cache_mode` (i.e. the value after
+  `resolve_auto_lmdb_cache_mode/2` runs) is `per_hec`. The
+  resolver chain ordering (`load_manifest → cache_strategy →
+  lmdb_cache_mode → scan_strategy`) ensures the scan-strategy
+  resolver sees the finalised cache mode, not the raw `auto`
+  marker. No chicken-and-egg.
 - Tests pinning the partition algorithm + routing emission.
 - Phase L appendix #16: empirical comparison of
   `parMap` baseline vs capability-routed L1 at simplewiki -N4.
@@ -393,17 +418,23 @@ fine in steady-state but warm needs reproducibility for tests.
 P3's warm phase peaks at:
 
 ```
-peak_warm_mem ≈ |WarmHeap| × (cost + node_id + edges)
+peak_warm_mem ≈ |WarmHeap| × (cost + node_id + edges_pointer)
+              + |WarmHeap| × avg_edges × bytes_per_edge   (the edge data itself)
               + |WarmIndex| × (node_id + cost)
               + |Frontier| × (node_id + cost)
               + |Visited| × node_id
 ```
 
-For warm_budget_nodes = 10% of fact_count = 30k at simplewiki,
-average 5 children/node, ~30 bytes per entry: ≈ 5 MB. Fits
-easily. enwiki at 10% = 990k nodes × ~30 bytes = ~30 MB. Still
-fine. Article-level scales would push this; defer until that
-data lands.
+The second term is the edge-data payload — easy to miss. At
+simplewiki with 30k warm nodes × 5 children/node × 16 bytes/edge
+≈ 2.4 MB additional. At enwiki at 990k nodes ×
+5 × 16 ≈ 80 MB additional. Sums:
+
+- simplewiki: ~5 MB structural + 2.4 MB edge data = ~7 MB total.
+- enwiki: ~30 MB structural + 80 MB edge data = ~110 MB total.
+
+Both still fit easily. Article-level scales would push this;
+defer until that data lands.
 
 ### Telemetry
 
@@ -422,7 +453,10 @@ option `scan_strategy_verbose(true)` for full traces.
 
 Out of scope, file and forget:
 
-- Online cache growth (cache misses don't memoise).
+- Online cache *capacity* growth (cache misses *do* memoise — see
+  the Spec's Phase R lookup pseudocode — but the bucket array is
+  sized at codegen time and never resizes at runtime; high-volume
+  miss memoisation just overwrites buckets via collision).
 - Mid-workload re-warming.
 - Cost-function autoselect via ML — the registry has 3 options
   for now; pick one explicitly.

--- a/docs/design/SCAN_STRATEGY_IMPLEMENTATION_PLAN.md
+++ b/docs/design/SCAN_STRATEGY_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,457 @@
+# Scan Strategy — Implementation Plan
+
+Phased rollout for the design specified in
+`SCAN_STRATEGY_SPECIFICATION.md`. Each phase produces a landable PR
+with tests; later phases depend on earlier ones either for code or
+for measurements. Cancel/replan after any phase if measurements
+contradict assumptions — the plan is a default, not a contract.
+
+## Sequencing summary
+
+| phase | size | depends on | gates |
+|---|---|---|---|
+| P0: Algorithm-manifest abstraction | small | — | pure infrastructure; doesn't ship any optimization |
+| P1: Pluggable cost-function slot | small | P0 (so the slot can be declared in a manifest) | none — pure refactor |
+| P2: At-scale validation re-ingest | small | (data only, no code) | needs P0+P1 in for the matrix bench to exercise the slot, but P2 itself doesn't change code |
+| P3: Warm-build + snapshot core | medium | P1 (cost-function abstraction); P2 results inform tuning | empirical signal that warming is worth it |
+| P4: `scan_strategy(auto)` resolver + matrix-bench mode | small-medium | P3 | P3 lands |
+| P5: Spark routing via retained ranking | medium | P3 (snapshot produces ranked view); validation of P3 | tree retention has a real consumer |
+| P6: Adaptive fixed-point iteration | small | P3, P4 | initial measurements show diminishing returns |
+| P7+: Live-mode tree updates | medium | P3, P5; research-y use cases | when an algorithm actually needs post-warm tree updates |
+
+P0–P4 are the core deliverable. P5–P7 are extensions; treat as
+optional based on P3/P4 data.
+
+---
+
+## Phase 0 — Algorithm-manifest abstraction
+
+### Goal
+
+Introduce the algorithm + optimization-manifest split specified in
+`ALGORITHM_MANIFEST_SPECIFICATION.md`. Without this, every new
+resolver requires every bench harness to re-declare the same
+options, and the scan-strategy options end up duplicated all over
+the place.
+
+### Deliverables
+
+- `src/unifyweaver/core/algorithm_manifest.pl` — new module:
+  - `load_algorithm_manifest/2` — merges
+    `user:algorithm/2` + `user:algorithm_optimization/2` into the
+    codegen's option list. Caller options win on conflict.
+  - `merge_caller_and_manifest_options/3` — explicit
+    caller-wins merge semantics (not the SWI library
+    `merge_options/3`, whose convention is different).
+  - Validation: warn on orphan optimization, error on duplicate
+    `algorithm/2` declarations.
+- `src/unifyweaver/targets/wam_haskell_target.pl` — call
+  `load_algorithm_manifest/2` at the top of
+  `write_wam_haskell_project/3` and
+  `compile_wam_runtime_to_haskell/3`, before any resolver.
+- `tests/core/test_algorithm_manifest.pl` — unit tests:
+  - manifest absent → Options0 unchanged
+  - manifest present → options merged
+  - caller key wins over manifest key
+  - multiple `algorithm_optimization/2` facts concat
+  - orphan optimization → warning, ignored
+  - duplicate `algorithm/2` → error
+
+### Scope notes
+
+- This phase ships no new optimization. It's pure infrastructure;
+  the existing resolvers continue to work as today, just reading
+  from a slightly-enriched option list.
+- Backwards-compat: workloads without `algorithm/2` declarations
+  are completely unaffected. `user:demand_filter_spec/2`,
+  `user:max_depth/1` etc. still work alongside manifests.
+
+### Success criteria
+
+- All 167+ existing WAM-Haskell tests pass (no behaviour change).
+- New manifest unit tests pass.
+- A demo workload using `algorithm/2` + `algorithm_optimization/2`
+  emits the same Haskell code as the equivalent caller-options
+  invocation.
+
+### Estimated effort
+
+~1 session.
+
+---
+
+## Phase 1 — Pluggable cost-function slot
+
+### Goal
+
+Refactor the existing `Flux` panic stub in
+`runDemandBFS` / `runDemandBFSCursor` into a pluggable strategy
+slot. The stub becomes one implementation of a generic
+`CostFn`-parameterised path. No new functionality lands; this is
+preparation.
+
+### Deliverables
+
+- `src/unifyweaver/core/cost_function.pl` — new module:
+  - `tree_cost_function(+Name, +Params)` term constructor
+  - `validate_cost_function/1` predicate
+  - Registry of supported names: `flux`, `hop_distance`,
+    `semantic_similarity`
+- `templates/targets/haskell_wam/cost_function.hs.mustache` — new
+  Haskell-side `CostFn` record + concrete implementations.
+- `src/unifyweaver/targets/wam_haskell_target.pl` — codegen for
+  the cost-function strategy slot; ensures the existing Flux path
+  routes through the new abstraction.
+- Tests for the registry, term validation, and codegen emission.
+
+### Scope notes
+
+- The Flux implementation matches today's stub *exactly* —
+  `error "Flux strategy not implemented (Phase 2.5)"`. Same panic
+  at runtime; just routed through the new abstraction. P3 lands
+  the real Flux scoring.
+- `hop_distance` gets a real but simple implementation here
+  (it's cheap; ships as a working alternative even before Flux).
+
+### Success criteria
+
+- All existing tests pass.
+- A new test verifies that
+  `tree_cost_function(hop_distance, [max_hops(5)])` emits
+  code that produces a non-zero score for nodes within 5 hops.
+- The existing Flux-panic test still passes (regression check).
+
+### Estimated effort
+
+~1 session. Small refactor.
+
+---
+
+## Phase 2 — At-scale validation re-ingest
+
+### Goal
+
+Re-create the simplewiki and enwiki Phase 1 LMDB fixtures that
+were swept in an earlier workspace reset. Validate the
+already-landed cost-model resolvers against measured wall-clock
+numbers, not just unit tests.
+
+### Deliverables
+
+No code changes. Tooling and measurement only.
+
+- Re-run streaming pipeline to produce
+  `data/benchmark/simplewiki_cats/lmdb_proj/lmdb` and
+  `data/benchmark/enwiki_cats/lmdb_proj/lmdb`.
+- Run `convert_lmdb_to_phase1_layout.py` to produce
+  `lmdb_proj_resident` variants.
+- Generate matrix-bench projects at 1k, simplewiki, enwiki
+  scales with `resident_auto` mode.
+- Sweep: 3 trials × {-N1, -N2, -N4} × 2 roots × resident_auto.
+- Append Phase L appendix #14 to `WAM_PERF_OPTIMIZATION_LOG.md`
+  with:
+  - Measured wall-clock vs `resident_cursor` baseline.
+  - Resolver decisions (verbose traces).
+  - Miss-rate stats if instrumentation exists.
+  - Branching-factor distribution of the category graph (input
+    to P3's flux decay tuning).
+
+### Success criteria
+
+- `resident_auto` runs within 5% of `resident_cursor` baseline at
+  every scale (resolver agrees with empirical best).
+- Branching-factor distribution captured: median, P90, P99 for
+  parent and child legs separately.
+
+### Estimated effort
+
+~1 session for ingest + sweep + write-up. Wall-clock dominated by
+the streaming pipeline.
+
+---
+
+## Phase 3 — Warm-build + snapshot core
+
+### Goal
+
+Implement the three-phase warm-build / snapshot / steady-state
+architecture from the spec. This is the core deliverable.
+
+### Deliverables
+
+Prolog side (`src/unifyweaver/`):
+
+- `core/cost_function.pl` extended with concrete `flux/3`
+  implementation (real, not stub).
+- `core/scan_strategy.pl` — new module:
+  - `warm_budget_resolve/3` — compute defaults from options
+  - `stage2_threshold_resolve/3` — derive scan-vs-seek crossover
+  - `warm_phase_options/2` — bundle for codegen
+
+Haskell side (`templates/targets/haskell_wam/`):
+
+- `scan_strategy.hs.mustache` — new template with:
+  - `WarmHeap`, `WarmIndex`, `Frontier`, `Visited` types
+  - `runWarmBuild :: CostFn -> WarmConfig -> IO (WarmHeap, WarmIndex)`
+  - `snapshotCache :: WarmHeap -> IntMap NodeId [EdgeTarget]`
+  - `snapshotRanked :: WarmHeap -> [(NodeId, Cost)]`
+  - Stage-1 cursor loop + stage-2 scan trigger
+- `main.hs.mustache` — wire scan-strategy path conditionally on
+  `scan_strategy(auto)`.
+
+Tests:
+
+- `tests/core/test_scan_strategy.pl` — option resolution, threshold
+  computation, default values.
+- `tests/test_wam_haskell_target.pl` — codegen emission, integration.
+
+### Scope notes
+
+- Flux implementation uses the parent/child decay split from the
+  spec, with tuning constants from P2's branching-distribution data.
+- Stage-2 fixed-point is bounded to ≤ 2 scans for the first cut
+  (the spec's recommendation).
+- Tree retention defaults to `discard`. Retention is implemented
+  but unused by any consumer until P5.
+
+### Success criteria
+
+- Unit tests pass for warm-budget computation, threshold derivation,
+  cost-function dispatch.
+- End-to-end smoke build of a `scan_strategy(auto)`-enabled project
+  on the 1k fixture.
+- Functional run on simplewiki produces correct results (tuple
+  count matches `resident_cursor` baseline within tolerance).
+- Measured wall-clock at simplewiki: within 10% of
+  `resident_cursor` at -N4 (no regression at fixture sizes where
+  warming should be approximately neutral).
+
+### Estimated effort
+
+~3 sessions. The biggest deliverable in the plan.
+
+---
+
+## Phase 4 — `scan_strategy(auto)` resolver + matrix-bench mode
+
+### Goal
+
+Add the codegen-time auto-resolver and a new matrix-bench mode so
+the bench can exercise scan strategies end-to-end.
+
+### Deliverables
+
+- `resolve_auto_scan_strategy/2` in `wam_haskell_target.pl`:
+  - Reads workload metadata + cost-model outputs.
+  - Picks default `tree_cost_function`, `warm_budget_nodes`,
+    `stage2_scan_threshold`, `iterations`.
+- `parse_lmdb_mode(resident_warm, ...)` in
+  `generate_wam_haskell_matrix_benchmark.pl`:
+  - Bundles `scan_strategy(auto)` with sensible defaults.
+- Tests pinning resolver behaviour at known input combinations
+  (mirror of `cache_strategy(auto)` test set).
+- Phase L appendix #15: empirical comparison of
+  `resident_cursor` vs `resident_warm` at 1k, simplewiki, enwiki.
+
+### Scope notes
+
+- The resolver is a thin wrapper; most decisions defer to spec
+  defaults. Picks cost-function based on availability of
+  embeddings (semantic if available, hop_distance otherwise) and
+  graph properties (flux if branching distribution exists from
+  P2; hop_distance fallback).
+
+### Success criteria
+
+- All resolver tests pass deterministically.
+- `resident_warm` at simplewiki shows measurable improvement over
+  `resident_cursor` at -N4, *or* — equally informative — measured
+  worsening that tells us the warm-build path isn't worth it at
+  this scale. Either outcome is publishable.
+- enwiki regression check: `resident_warm` doesn't break what
+  `resident_cursor` already runs successfully.
+
+### Estimated effort
+
+~1 session for the resolver + 1 for the measurement sweep.
+
+---
+
+## Phase 5 — Spark routing via retained tree (snapshot_only mode)
+
+### Goal
+
+Use the snapshot's ranked view (`tree_retention(snapshot_only)`)
+to partition parMap-driven sparks into capability-local chunks.
+Closes the MoE-spark-routing gap that has been blocking the
+per-HEC L1 cache from being useful.
+
+### Deliverables
+
+- `partitionByRank :: Int -> RankedView -> [[NodeId]]` in
+  `scan_strategy.hs.mustache`.
+- `main.hs.mustache` — when `tree_retention(retain)` is set,
+  replace the seed `parMap rdeepseq` with a per-capability
+  `mapConcurrently` driven by `partitionByRank`.
+- New option: `spark_routing(capability_local)` (default
+  `unsharded`).
+- Resolver hook: `scan_strategy(auto)` + `expected_query_count > 1`
+  → automatically opts into retention + capability_local routing
+  if L1 is the chosen cache mode.
+- Tests pinning the partition algorithm + routing emission.
+- Phase L appendix #16: empirical comparison of
+  `parMap` baseline vs capability-routed L1 at simplewiki -N4.
+
+### Success criteria
+
+- Capability-routed L1 captures non-overlapping coverage in
+  threadCapability traces.
+- Measured -N4 speedup matches or exceeds sharded L2 baseline
+  (the existing default) on simplewiki.
+
+### Estimated effort
+
+~2 sessions. Depends on P3 producing a working ranked view.
+
+---
+
+## Phase 6 — Adaptive fixed-point iteration
+
+### Goal
+
+Lift the `stage2_max_scans(2)` bound to a measurement-driven
+fixed-point. Implement only if P3/P4 measurements show diminishing
+returns from the first scan don't actually plateau at 2 — i.e. if
+a third or fourth scan would still meaningfully grow the tree.
+
+### Deliverables
+
+- `convergence_metric/2` predicate in `scan_strategy.pl`.
+- Loop in `runWarmBuild` that scans until convergence or limit.
+- New option `convergence_threshold(F)`.
+
+### Scope notes
+
+May be unnecessary. Filed as optional. Likely de-prioritised in
+favour of cache-warming follow-ups if P3/P4 data shows 2 scans
+captures >95% of the tree.
+
+### Estimated effort
+
+~1 session if pursued.
+
+---
+
+## Phase 7+ — Live-mode tree updates
+
+### Goal
+
+Support `tree_retention(live)` — keep `WarmHeap` + `WarmIndex`
+alive past snapshot and let downstream algorithms update them.
+Unlocks the class of algorithms that need post-warm re-ranking:
+query-history-driven re-rank, adaptive cost-function switching,
+hot-region expansion, workload prioritisation.
+
+### Deliverables (per-algorithm; not a single PR)
+
+Per actual `live`-mode algorithm we want to ship:
+
+- The algorithm-specific update logic (what triggers a re-rank,
+  what cost is computed, how the cache reflects re-ranks).
+- Thread-safety for `WarmHeap` access (`MVar`/`IORef` guards;
+  concurrent priority queue if measurement shows contention).
+- Optional `treeRebuild` (re-snapshot the cache from the
+  updated tree) — useful when the workload pattern shifts enough
+  that the original snapshot is stale.
+
+### Scope notes
+
+Each `live`-mode algorithm is a research-y effort. Don't ship
+the infrastructure for a hypothetical algorithm — only land
+guards / concurrency support when a specific algorithm needs
+them. The spec leaves the door open structurally; this phase
+walks through it.
+
+### Estimated effort
+
+Per-algorithm; multiple PRs. ~2–3 sessions per algorithm
+including measurement and tuning.
+
+---
+
+## Cross-cutting concerns
+
+### Determinism
+
+All scan-strategy code paths must be deterministic given the same
+inputs (same fixture, same options, same seed). Avoid
+non-deterministic `parMap` ordering inside the warm phase; it's
+fine in steady-state but warm needs reproducibility for tests.
+
+### Memory budgets
+
+P3's warm phase peaks at:
+
+```
+peak_warm_mem ≈ |WarmHeap| × (cost + node_id + edges)
+              + |WarmIndex| × (node_id + cost)
+              + |Frontier| × (node_id + cost)
+              + |Visited| × node_id
+```
+
+For warm_budget_nodes = 10% of fact_count = 30k at simplewiki,
+average 5 children/node, ~30 bytes per entry: ≈ 5 MB. Fits
+easily. enwiki at 10% = 990k nodes × ~30 bytes = ~30 MB. Still
+fine. Article-level scales would push this; defer until that
+data lands.
+
+### Telemetry
+
+P3+ must support optional verbose tracing:
+
+```
+[WAM-Haskell] scan_strategy: warm_nodes=29950 warm_ms=2341 stage2_scans=1
+[WAM-Haskell] scan_strategy: snapshot bytes=4.8MB ranked_retained=True
+[WAM-Haskell] scan_strategy: steady-state hits=12839 misses=144 (1.1% miss rate)
+```
+
+Reuses the `cache_strategy_verbose(true)` pattern. Add a new
+option `scan_strategy_verbose(true)` for full traces.
+
+### What we won't do
+
+Out of scope, file and forget:
+
+- Online cache growth (cache misses don't memoise).
+- Mid-workload re-warming.
+- Cost-function autoselect via ML — the registry has 3 options
+  for now; pick one explicitly.
+- Distributed warm phases (single-process only).
+- Persistence: warm/snapshot artefacts are per-process, not
+  written to disk.
+
+## Open questions to resolve via measurement
+
+P2 and P3 data will inform answers:
+
+1. **Default `warm_budget_nodes(N)` fraction.** Spec says 10%; is
+   that right at simplewiki? At enwiki?
+2. **Default `parent_decay` / `child_decay` for flux.** Spec says
+   0.5 / 0.3 as starting points; what does the branching
+   distribution actually argue for?
+3. **`iterations(1)` vs `iterations(3)`.** Where does the
+   accuracy/speed curve hit diminishing returns?
+4. **`stage2_max_scans(N)`.** Spec says 2. Validate via P3.
+5. **Whether semantic_similarity is worth supporting** at all,
+   or whether flux + hop_distance covers the workloads we care
+   about. P5 might inform via spark-routing accuracy.
+
+## See also
+
+- `SCAN_STRATEGY_PHILOSOPHY.md` — the why.
+- `SCAN_STRATEGY_SPECIFICATION.md` — the what.
+- `CACHE_COST_MODEL_PHILOSOPHY.md` — the cost model this layer
+  builds on.
+- `WAM_PERF_OPTIMIZATION_LOG.md` — appendices #11–#13 (cost-model
+  resolver work); appendices #14+ for the validation and warm-
+  build measurements.

--- a/docs/design/SCAN_STRATEGY_PHILOSOPHY.md
+++ b/docs/design/SCAN_STRATEGY_PHILOSOPHY.md
@@ -1,0 +1,259 @@
+# Scan Strategy — Philosophy
+
+## What this is
+
+A design for an **adaptive query strategy** that picks between
+cursor-driven seeks and full-DB scans dynamically, builds a
+cost-ranked tree of relevant nodes during a warm phase, then
+snapshots the tree to a flat cache for steady-state lookups.
+
+This is the next layer above the cost model that landed in Phase
+2c (`docs/design/CACHE_COST_MODEL_PHILOSOPHY.md`). The cost model
+makes a *one-shot* decision at codegen time: sort or scan, this
+cache tier or that. The scan-strategy work generalises that to a
+*staged, iterative* decision: start with cursor seeks while the
+frontier is small, switch to scan when the frontier grows past
+the seek-vs-scan crossover, optionally repeat as the tree grows.
+
+The deliverable, in one sentence: a runtime that **warms a tree
+of cost-ranked candidates, snapshots it into a fast lookup cache,
+and optionally retains the ranking for downstream consumers like
+parallelisation**.
+
+## Why now
+
+Two pressures motivate this work:
+
+1. **The cost model's static decisions don't generalise.** Phase L#11
+   showed the model picking `in_memory` at simplewiki scale with
+   the wrong `working_set_fraction` default; Phase L#13 added the
+   memory-budget guard because the cost model's "scan" abstraction
+   said nothing about working-set footprint. Both fixes were
+   band-aids on a structurally static decision. A staged strategy
+   would let the runtime observe its own frontier size and switch
+   modes accordingly.
+
+2. **Empirically, cursor wins everywhere we've measured for BFS
+   workloads.** Phase L#7–9: simplewiki 1.96× faster cursor over
+   in_memory; enwiki cursor-only because in_memory can't allocate;
+   1k_cats roughly parity but cursor still nominally faster. The
+   matrix-bench `resident_auto` mode now picks cursor at every
+   scale. **The interesting question is no longer cursor-vs-in_memory
+   but cursor-vs-(cursor-then-scan)** — at what frontier size does
+   absorbing the remaining workload in one scan beat continuing to
+   seek edge-by-edge?
+
+## The core insight
+
+Three phases, three data structures:
+
+| phase | structure | operations | optimised for |
+|---|---|---|---|
+| **warm-build** | sorted heap / priority queue, scored by a cost function | insert with score, evict lowest, peek top-K | O(log N) construction + ranking |
+| **snapshot** | (one-shot) walk the heap, materialise an IntMap | iterate, build | one-time conversion |
+| **steady-state** | IntMap (the cache) + optional flux-ranked view | O(1) `lookup`; iterate in order | hot-path throughput |
+
+The split between warm and steady-state matters because they have
+genuinely different access patterns:
+
+- Warm phase: we're *exploring*. We don't know which 1–10% of the
+  DB is worth keeping. We need ranked insertion and bounded-capacity
+  eviction. O(log N) is fine because each insertion does meaningful
+  work (a cursor seek, a flux update).
+- Steady-state: we're *serving*. The set of relevant nodes is
+  frozen. We need O(1) lookup by key. Any ranking we maintained
+  during warm is either retained for downstream consumers
+  (parallelisation) or discarded as dead weight.
+
+Treating these as one structure forces a tradeoff: O(1)
+hashtable lookup competes with O(log N) heap-ordered eviction.
+Separating them lets each phase use the right shape.
+
+## Architectural alternatives we considered
+
+### 1. Tree-as-cache (single structure)
+
+Keep one data structure across all phases — a hybrid hashtable +
+parallel heap, with the heap providing eviction order. Lookups go
+through the hashtable; eviction through the heap. The cache *is*
+the tree.
+
+**Why we didn't pick this**: After warm completes, we never need
+the eviction ordering again. The heap becomes dead weight until
+the next eviction event — and steady-state caches don't evict
+during normal operation. So we'd be paying memory + cache-coherence
+cost for a structure we don't use.
+
+The hybrid is still the right call *during* warm. Just not after.
+
+### 2. Tree + L2 spillover
+
+Keep the tree for ranking and a separate L2 hashtable for
+overflow. Tree miss + L2 hit = serve from L2; tree miss + L2 miss
+= cursor + populate L2.
+
+**Why we didn't pick this for the first cut**: Two parallel
+structures means two lookups per query in the miss case. If the
+tree's predictions are accurate (10% covers most queries), L2 is
+dead weight; if predictions are poor, we should fix the cost
+function rather than paper over with spillover.
+
+We can add L2 spillover later if miss-rate measurements warrant
+it. Better to start simpler.
+
+### 3. Single-pass scan-only
+
+Forget cursor entirely; one scan pass at startup, materialise a
+flat cache. No staging, no priority queue.
+
+**Why we didn't pick this**: Already loses at every scale we've
+measured. Phase M1.b: even at 100% selection of a 10k subset of
+simplewiki, sorted seeks beat scan 2.8×. Scan only wins when we'd
+touch a large fraction of the DB *and* the DB exceeds free RAM
+(cold-disk regime). Most workloads at category scale aren't there.
+
+### 4. Hardcoded flux (or any single cost function)
+
+Pick one ranking function and hardcode it. Simpler API.
+
+**Why we didn't pick this**: We genuinely don't know which cost
+function works best. Flux makes sense for graph-shaped workloads
+where branching-factor decay tracks relevance. Hop distance is
+cheap and works for symmetric reachability problems. Semantic
+similarity needs embeddings but may dominate when those exist.
+Hardcoding forecloses A/B comparison; pluggable lets the workload
+author choose and lets the implementation evolve.
+
+## Separating the algorithm from its optimizations
+
+A meta-concern that surfaced during the design discussion: the
+*algorithm* (the logical specification of what is being computed
+— e.g. effective_distance — closer to the Datalog/SQL sense of
+"a query" than the algorithms-textbook sense of "a step-by-step
+procedure") and the *optimizations* (how to compile it —
+cost-model knobs, cache mode, scan strategy, demand-filter spec)
+have different owners and lifecycles. Bundling them in a single
+bench-harness declaration forces every caller to know every
+optimization. Splitting them lets the algorithm be declared once
+with its best-known optimization profile, with callers free to
+override on a per-knob basis. The terminology note in
+`ALGORITHM_MANIFEST_SPECIFICATION.md` covers this explicitly.
+
+We capture this split in a separate small specification
+(`ALGORITHM_MANIFEST_SPECIFICATION.md`). The scan-strategy work
+assumes the manifest exists — `tree_cost_function/2`,
+`tree_retention/1`, `scan_strategy/1` are all options that live in
+a manifest in practice. None of the scan-strategy mechanics depend
+on the manifest abstraction internally; the manifest is a
+deployment-time convenience layer.
+
+## What we picked
+
+**Warm-build with a heap + cost-function strategy slot, snapshot
+to a hashtable cache (overwrite-on-collision), optional retention
+of the flux-ranked view for parallelisation consumers, optional
+live tree updates for adaptive algorithms.**
+
+Specifically:
+
+- **Cost function** is a strategy parameter (`flux`,
+  `hop_distance`, `semantic_similarity`, future others). Each has
+  its own parameter list (decay constants, max hops, embedding
+  dim, etc.).
+- **Iterations** count is unified across access patterns: 1 = one
+  round of score relaxation (1 hop deep for cursor mode; 1 full
+  pass for scan mode). N iterations approximate the converged
+  score; pick a point on the cost/accuracy curve.
+- **Flux specifically** treats parent and child legs separately
+  because the branching factors are asymmetric (Wikipedia
+  categories: few parents per node, many children). Total flux is
+  the merge of two single-direction scores.
+- **Warm budget** targets 1–10% of the DB by node count. Below 1%
+  the tree is too small to be useful; above 10% we've defeated the
+  point of being selective.
+- **Cache misses** during steady-state fall back to LMDB cursor.
+  No memoisation of misses (no spillover) for the first cut. If
+  measurement shows miss rate is high, we widen the cache or
+  re-warm — tuning, not architecture.
+- **Tree retention** has three modes (default `discard`):
+  - `discard` — GC the tree after snapshot. Minimum memory.
+  - `snapshot_only` — keep the flux-sorted view (a frozen list).
+    Used by spark routing and other consumers that need a static
+    ranked view.
+  - `live` — keep the full heap + parallel index. Supports
+    post-warm updates: query-history-driven re-ranking, adaptive
+    cost-function switching, hot-region expansion. No current
+    consumer implements `live`-mode algorithms, but the data
+    structures we pick during warm support it without
+    architectural changes, so the door stays open.
+
+## Why retention matters: spark routing
+
+The retained flux-ranked view is precisely what MoE-style spark
+routing needs to break the per-HEC L1 cache-duplication problem.
+Memory note: "MoE-style spark routing would unlock L1; until then
+sharded is the right default" because parMap has no region
+affinity. With flux-sorted seeds:
+
+1. Partition seeds into N capability-local chunks by flux score
+   (high-flux chunk to capability 0, next to capability 1, etc.).
+2. Each thread's L1 cache accumulates non-overlapping coverage
+   instead of duplicating hot edges.
+3. Sharded L2 becomes a backup for cross-region hits, not the
+   primary mechanism.
+
+Retention is the bridge between "we built a tree for cache
+warming" and "we have a tree that's useful for scheduling
+parallelism". Same artefact, two consumers.
+
+## When this matters
+
+Same regime checklist as the cost model itself:
+
+1. **Article-level data ingestion** — enwiki article texts
+   (~250 GB uncompressed) will need adaptive cursor→scan
+   transitions because pure cursor wouldn't visit the
+   working set fast enough.
+2. **Multi-fixture aggregation** — categories + page metadata +
+   revisions + links; total working set may exceed even hot-regime
+   RAM.
+3. **Repeated queries from a hot root subset** — Phase M3 said
+   warming doesn't pay off for random-BFS, but it *would* pay off
+   for repeated queries against a small region. Warming a tree
+   per region is how we capture that.
+4. **Workloads where parallelisation matters** — even without the
+   cold regime, the retained flux ranking unlocks
+   region-affinity-aware spark routing.
+
+At today's fixture scale (simplewiki at 297k, enwiki at 9.9M),
+this work is groundwork. Like the cost model itself.
+
+## What this isn't doing
+
+- **Not a runtime auto-tuner.** Warm parameters
+  (cost function, iterations, budget) are picked at codegen or
+  workload-author time, not at runtime via measurement.
+- **Not a re-warming mechanism.** Once steady-state starts, the
+  cache is frozen until the workload completes. If query patterns
+  shift mid-workload, that's a follow-up problem.
+- **Not a correctness device.** Misses still return correct
+  results via LMDB cursor fallback. The strategy affects
+  performance, not semantics.
+- **Not a replacement for the cost model.** The model still picks
+  cursor-vs-in_memory and cache tier; scan strategies add an
+  adaptive runtime layer on top.
+
+## See also
+
+- `docs/design/CACHE_COST_MODEL_PHILOSOPHY.md` — the cost model
+  this layer sits on top of.
+- `docs/design/ALGORITHM_MANIFEST_SPECIFICATION.md` — the
+  declarative split between algorithm and optimization manifest;
+  prerequisite for the per-algorithm optimization profile this
+  scan-strategy work assumes.
+- `docs/design/SCAN_STRATEGY_SPECIFICATION.md` — concrete
+  formulas, data structures, option list.
+- `docs/design/SCAN_STRATEGY_IMPLEMENTATION_PLAN.md` — phased
+  rollout with deliverables and dependencies.
+- `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` — Phase M / Phase L
+  measurements that motivate the regimes.

--- a/docs/design/SCAN_STRATEGY_PHILOSOPHY.md
+++ b/docs/design/SCAN_STRATEGY_PHILOSOPHY.md
@@ -12,8 +12,9 @@ This is the next layer above the cost model that landed in Phase
 makes a *one-shot* decision at codegen time: sort or scan, this
 cache tier or that. The scan-strategy work generalises that to a
 *staged, iterative* decision: start with cursor seeks while the
-frontier is small, switch to scan when the frontier grows past
-the seek-vs-scan crossover, optionally repeat as the tree grows.
+frontier is small, switch to a sequential scan pass that absorbs
+the frontier's edge data when the frontier grows past the
+seek-vs-scan crossover, optionally repeat as the tree grows.
 
 The deliverable, in one sentence: a runtime that **warms a tree
 of cost-ranked candidates, snapshots it into a fast lookup cache,
@@ -93,13 +94,17 @@ overflow. Tree miss + L2 hit = serve from L2; tree miss + L2 miss
 = cursor + populate L2.
 
 **Why we didn't pick this for the first cut**: Two parallel
-structures means two lookups per query in the miss case. If the
-tree's predictions are accurate (10% covers most queries), L2 is
-dead weight; if predictions are poor, we should fix the cost
-function rather than paper over with spillover.
+structures means two lookups per query in the miss case. The
+design we picked already gets the same benefit cheaply — the
+overwrite-on-collision cache memoises misses, so a node that
+the cost function didn't predict but the workload queries twice
+becomes a hit on the second access. That's effectively a
+single-level spillover, just inside the same hashtable rather
+than in a parallel structure.
 
-We can add L2 spillover later if miss-rate measurements warrant
-it. Better to start simpler.
+If miss-rate measurements show systematic mis-prediction (not
+just random outliers), we'd fix the cost function or warm budget
+rather than add a second structure.
 
 ### 3. Single-pass scan-only
 
@@ -171,10 +176,12 @@ Specifically:
 - **Warm budget** targets 1–10% of the DB by node count. Below 1%
   the tree is too small to be useful; above 10% we've defeated the
   point of being selective.
-- **Cache misses** during steady-state fall back to LMDB cursor.
-  No memoisation of misses (no spillover) for the first cut. If
-  measurement shows miss rate is high, we widen the cache or
-  re-warm — tuning, not architecture.
+- **Cache misses** during steady-state fall back to LMDB cursor
+  and **memoise into the cache** (overwrite-on-collision; same
+  mechanism as the existing L1/L2 hashtables). The snapshot
+  provides the *initial state* of a real cache, not a frozen
+  lookup table. There's no separate spillover structure — the
+  cache itself plays that role via miss memoisation.
 - **Tree retention** has three modes (default `discard`):
   - `discard` — GC the tree after snapshot. Minimum memory.
   - `snapshot_only` — keep the flux-sorted view (a frozen list).
@@ -220,7 +227,9 @@ Same regime checklist as the cost model itself:
 3. **Repeated queries from a hot root subset** — Phase M3 said
    warming doesn't pay off for random-BFS, but it *would* pay off
    for repeated queries against a small region. Warming a tree
-   per region is how we capture that.
+   per region would capture that; we don't address sub-region
+   partitioning in the current spec — it's scoped as future work
+   when a workload that needs it lands.
 4. **Workloads where parallelisation matters** — even without the
    cold regime, the retained flux ranking unlocks
    region-affinity-aware spark routing.

--- a/docs/design/SCAN_STRATEGY_SPECIFICATION.md
+++ b/docs/design/SCAN_STRATEGY_SPECIFICATION.md
@@ -1,0 +1,442 @@
+# Scan Strategy — Specification
+
+This document specifies the concrete shapes (data structures, option
+list, formulas, composition rules) of the design laid out in
+`SCAN_STRATEGY_PHILOSOPHY.md`. Read the philosophy doc first if the
+"why" isn't clear.
+
+## Phases and data structures
+
+### Phase W (warm-build)
+
+| name | type sketch | role |
+|---|---|---|
+| `WarmHeap`  | `Data.Heap.MinPrioHeap Cost (NodeId, Edges)` | bounded-capacity ordered structure; lowest-cost evicted first |
+| `WarmIndex` | `IntMap NodeId Cost`                          | "do we already have this node, and at what cost?" — O(log N) lookup back into the heap |
+| `Frontier`  | `IntMap NodeId Cost`                          | candidate nodes not yet visited; same shape, separate logical role |
+| `Visited`   | `IntSet NodeId`                                | nodes whose edges we've already loaded |
+
+Both `WarmHeap` and `WarmIndex` are needed because a heap alone doesn't
+support "does this node already exist?" lookups in O(log N). The
+parallel index is the usual trick.
+
+The frontier is *candidates whose score has been updated but whose
+edges haven't been loaded yet*. Cursor seeks happen against frontier
+nodes selected by score.
+
+### Phase S (snapshot)
+
+Single conversion pass over `WarmHeap`:
+
+```haskell
+snapshotCache :: WarmHeap -> IntMap NodeId [EdgeTarget]
+```
+
+Optionally, also produce a flux-ranked view for retention:
+
+```haskell
+snapshotRanked :: WarmHeap -> [(NodeId, Cost)]   -- descending by cost
+```
+
+After snapshot, `WarmHeap`, `WarmIndex`, `Frontier`, `Visited` can
+all be GC'd. Steady-state holds only the cache (and optionally the
+ranked view).
+
+### Phase R (steady-state, "running")
+
+| name | type sketch | role |
+|---|---|---|
+| `Cache`        | fixed-capacity hashtable, overwrite-on-collision | O(1) lookup; initialised from snapshot; memoises misses |
+| `RankedView`   | `[(NodeId, Cost)]` | retained iff `tree_retention(snapshot_only)` |
+| `WarmHeap` + `WarmIndex` | (carried over from warm) | retained iff `tree_retention(live)` |
+| `LmdbFallback` | existing cursor handle | cache miss path |
+
+The `Cache` is the same shape as the existing L1/L2 hashtables: a
+fixed-bucket array, where insert into a non-empty bucket overwrites
+the prior occupant. No LRU/LFU tracking, no metadata per entry,
+no eviction policy beyond "the latest insert wins the bucket". This
+keeps lookups branch-free and matches the existing code paths the
+implementation can reuse.
+
+Lookup logic:
+
+```
+edgesOf n =
+  case lookupBucket n cache of
+    Just (k', es) | k' == n  -> hit es
+    _                         -> do        -- miss
+      es <- cursor n
+      insertBucket n es cache              -- memoise; may overwrite
+      return es
+```
+
+The cache is **memoised on miss**. A repeated query for the same
+node hits even when the cost function didn't predict it. This is
+the standard caching contract; the warm snapshot just provides
+the *initial state* of the cache, not its frozen contents.
+
+If a snapshot entry collides with a miss-memoised insert, the new
+insert wins the bucket. That's tolerable: re-cursoring the lost
+snapshot entry on a later query is a single seek, symmetric to any
+other miss. We're not trying to permanently protect the snapshot
+from the workload's access pattern; the cache is a fixed-capacity
+data structure that gets filled by whatever queries actually run.
+
+## Cost functions
+
+### Strategy slot
+
+```prolog
+%% Workload-author API on the Prolog side.
+tree_cost_function(flux,                [iterations(1), parent_decay(0.5), child_decay(0.3)]).
+tree_cost_function(hop_distance,        [max_hops(5)]).
+tree_cost_function(semantic_similarity, [dim(128), embedding_path('foo.bin')]).
+```
+
+The Haskell-side generated code consumes a `CostFn` abstraction:
+
+```haskell
+data CostFn = CostFn
+  { cfScore   :: !(NodeId -> Edges -> Cost)   -- pure scorer
+  , cfRelax   :: !(NodeId -> [NodeId] -> Cost -> ScoreMap -> ScoreMap)
+                                              -- propagation step
+  , cfInitial :: !(NodeId -> Cost)            -- endpoint score
+  }
+```
+
+Each concrete cost function (flux, hop, semantic) implements this
+record. The tree-building algorithm consumes a `CostFn` and is
+generic over which one.
+
+### Flux
+
+For each candidate node `n`, flux is the sum of two single-direction
+contributions:
+
+```
+flux(n) = parent_flux(n) + child_flux(n)
+
+parent_flux(n) = Σ_{p ∈ parents(n)}  (parent_decay / |children(p)|) ^ hops_from_endpoint(p)
+child_flux(n)  = Σ_{c ∈ children(n)} (child_decay  / |parents(c)|)  ^ hops_from_endpoint(c)
+```
+
+Reading the formula:
+
+- We decay flux by hops from the nearest endpoint (the standard
+  PageRank-style decay).
+- Within each hop, we also divide by the branching factor — many
+  children means each one inherits less flux from the parent (the
+  "probability of taking this specific edge" intuition).
+- Parent and child legs use *separate* decay constants because
+  Wikipedia (and most category hierarchies) is asymmetric: typically
+  1–5 parents per category, 10–1000 children. The same decay
+  constant for both would either underweight ancestors or overweight
+  descendants.
+
+### Hop distance
+
+```
+score(n) = max_hops - min(hops_to_endpoint, max_hops)
+```
+
+Simpler, cheaper, no branching-factor dependence. Useful when the
+graph is roughly homogeneous in degree or when flux's branching
+factor data isn't trusted.
+
+### Semantic similarity
+
+```
+score(n) = dot_product(embedding(n), query_embedding) / (|embedding(n)| * |query_embedding|)
+```
+
+Requires an embeddings table indexed by `NodeId`. Out of scope for
+the first cuts; included in the strategy enum because the slot
+should be open to it.
+
+## Iterations
+
+Unified meaning across access patterns:
+
+| iterations | meaning |
+|---|---|
+| 1 | one round of score propagation. Cursor mode: expand frontier by 1 hop, update scores within that hop. Scan mode: one full pass over the edge list, propagating from scored nodes to neighbours. |
+| N | N rounds. Approaches converged scoring as N → ∞. |
+| auto | until score-change-per-iteration drops below a threshold (deferred — needs a convergence metric to be defined). |
+
+The cost vs accuracy knob. Default `iterations(1)` for the cheap
+path; workload-authors who need converged scoring opt up.
+
+## Stage-1 → Stage-2 crossover
+
+The runtime tracks frontier size. When the frontier — i.e. *number
+of unvisited candidate nodes whose scores indicate worthwhile
+materialisation* — exceeds a threshold, switch from cursor seeks
+to a scan pass.
+
+```
+K_cross_stage2 = W_remaining / (bandwidth_eff * latency_eff)
+```
+
+where `W_remaining` is the bytes of edge data not yet materialised
+into the heap, and `bandwidth_eff` / `latency_eff` come from the
+cost model's formula (`CACHE_COST_MODEL_PHILOSOPHY.md`).
+
+Concretely:
+
+- Maintain a running count `|Frontier|`.
+- After each cursor batch (or every N seeks), check `|Frontier| >
+  K_cross_stage2`.
+- If yes: drain the frontier via a single scan pass that touches
+  every candidate's edges in one go, marking them visited.
+- Repeat the check after the scan — if the new frontier (revealed
+  by relaxing scores from the just-scanned nodes) is again above
+  threshold, scan again. This is the optional fixed-point loop.
+
+For the first cut, the fixed-point is bounded to ≤ 2 scans to
+avoid pathological cases.
+
+## Warm budget
+
+Two limits, whichever fires first:
+
+| limit | option | default |
+|---|---|---|
+| node count | `warm_budget_nodes(N)` | 10% of fact_count |
+| time | `warm_budget_ms(N)` | 10000 ms |
+
+When either limit is reached, warm phase ends, snapshot runs.
+
+## Eviction policies
+
+Two distinct policies, for two distinct structures:
+
+### Tree eviction (warm phase)
+
+When the heap is at capacity:
+
+- Compute candidate score.
+- Peek at the heap's lowest-scored element.
+- If candidate score > lowest, evict lowest, insert candidate.
+- Else discard candidate without inserting.
+
+Standard min-heap-bounded operations. The cost function's score
+is the eviction key. No LRU/LFU; the score *is* the prediction
+of relevance.
+
+### Cache eviction (steady-state)
+
+Overwrite-on-collision. The cache is a fixed-bucket hashtable:
+
+- Lookup: hash `key`, probe bucket. If occupied with matching
+  key, hit. Else miss.
+- Insert (on miss memoisation): hash `key`, probe bucket. If
+  empty, place. If occupied with a different key, overwrite.
+
+This is the same mechanism as the existing L1/L2 caches in the
+codebase. No metadata per entry, no priority queue, no LRU chain.
+Hash distribution decides what stays.
+
+The cache is sized at codegen time (`cache_capacity_buckets/1`,
+default `2 × warm_budget_nodes` so the snapshot can populate
+without immediately overwriting itself, and miss memoisation
+has headroom before colliding with snapshot entries).
+
+## Cache miss handling
+
+Steady-state lookup:
+
+1. Hash key; probe bucket.
+2. **Hit** (bucket holds matching key): return edges.
+3. **Miss** (bucket empty or holds different key): cursor seek to
+   LMDB, then insert into the cache (overwriting whatever was in
+   the bucket).
+
+Misses are memoised. The cache learns the workload's actual
+access pattern over time, on top of the warm-start the snapshot
+provided.
+
+If a snapshot entry gets overwritten by a miss, no special
+handling: the next access to the displaced node is just another
+miss, paying one cursor seek and re-inserting it. The cache
+churn settles to whatever the workload's hot set actually is.
+
+A diagnostic counter (`cache_strategy_verbose(true)`) exposes
+hit/miss rates so callers can see whether the snapshot's
+prediction accuracy is matching reality.
+
+## Tree retention modes
+
+```prolog
+tree_retention(discard).        % default
+tree_retention(snapshot_only).  % retain frozen ranked view
+tree_retention(live).           % retain full heap + index; allow post-warm updates
+```
+
+### `discard` (default)
+
+After snapshot, `WarmHeap`, `WarmIndex`, `Frontier`, `Visited` are
+all GC'd. Steady-state holds only the cache. Minimum memory
+footprint; suitable when nothing downstream needs the ranked
+view.
+
+### `snapshot_only`
+
+The snapshot produces both `Cache` and a frozen `RankedView`:
+
+```haskell
+type RankedView = [(NodeId, Cost)]   -- descending by cost; immutable
+```
+
+The warm structures themselves still get GC'd; only the immutable
+ranked list lives on. This is the "spark routing" use case — the
+consumer reads the ranked view to partition work without needing
+to update it.
+
+`RankedView` consumers (current target: MoE-style spark routing):
+
+```haskell
+-- Partition seeds by flux quartile across N capabilities.
+partitionByRank :: Int -> RankedView -> [[NodeId]]
+```
+
+Implemented as a follow-up consumer in the implementation plan
+(P5); the snapshot just produces the view.
+
+### `live`
+
+`WarmHeap` and `WarmIndex` persist past snapshot. Algorithms can
+update the tree during steady-state via:
+
+```haskell
+treeInsert  :: NodeId -> Cost -> Edges -> WarmHeap -> WarmHeap
+treeUpdate  :: NodeId -> Cost -> WarmHeap -> WarmHeap        -- re-rank
+treeRebuild :: WarmHeap -> Cache -> (WarmHeap, Cache)         -- re-snapshot
+```
+
+Use cases (none implemented; the door is open):
+
+- **Query-history-driven re-ranking**: observe which nodes are
+  actually touched, bump their costs, re-rank.
+- **Adaptive cost-function switching**: start with cheap
+  `hop_distance`, after N queries swap to `flux` and re-rank
+  via `treeRebuild`.
+- **Hot-region expansion**: detect a sub-region with high miss
+  rate; warm additional nodes around it via `treeInsert`.
+
+**Thread safety in `live` mode**: the warm phase is
+single-threaded by design. If steady-state code wants to update
+the tree concurrently with cache lookups, the implementation
+guards the heap behind an `MVar` or `IORef`. For the first cuts
+(P3, P5) only `discard` and `snapshot_only` are exercised, so
+the thread-safety question doesn't bite. `live`-mode landing
+(deferred to P7+) brings the locking question with it.
+
+## Option list
+
+All options accepted by the warm-build path. Defaults in
+parentheses.
+
+| option | default | purpose |
+|---|---|---|
+| `tree_cost_function(F, Params)` | `flux` with default params | strategy slot |
+| `iterations(N)` | `1` | score-propagation rounds |
+| `warm_budget_nodes(N)` | `fact_count / 10` | node-count limit |
+| `warm_budget_ms(N)` | `10000` | wall-clock limit |
+| `stage2_scan_threshold(K)` | derived from cost model | crossover trigger |
+| `stage2_max_scans(N)` | `2` | fixed-point bound |
+| `tree_retention(R)` | `discard` | `discard` / `snapshot_only` / `live` |
+| `cache_capacity_buckets(N)` | `2 × warm_budget_nodes` | hashtable bucket count |
+
+### Flux-specific sub-options
+
+| option | default | purpose |
+|---|---|---|
+| `parent_decay(D)` | `0.5` | parent-leg geometric decay per hop |
+| `child_decay(D)` | `0.3` | child-leg geometric decay per hop |
+| `flux_merge(M)` | `sum` | how to combine parent + child flux: `sum`, `max`, `weighted(W1,W2)` |
+
+### Hop-distance sub-options
+
+| option | default | purpose |
+|---|---|---|
+| `max_hops(N)` | `5` | hop cutoff |
+
+### Semantic-similarity sub-options
+
+| option | default | purpose |
+|---|---|---|
+| `dim(D)` | `128` | embedding dimension |
+| `embedding_path(P)` | required | path to embeddings file |
+
+## Composition with existing resolvers
+
+Decision order at codegen time:
+
+1. **(new)** `load_algorithm_manifest/2` — merge
+   `user:algorithm_optimization/2` facts into the option list.
+   Caller-provided options win on conflict. See
+   `ALGORITHM_MANIFEST_SPECIFICATION.md`.
+2. `resolve_auto_use_lmdb/2` — picks LMDB vs IntMap fact source.
+3. `resolve_auto_cache_strategy/2` — picks cursor vs in_memory BFS.
+4. `resolve_auto_lmdb_cache_mode/2` — picks cache tier (none / L1 /
+   L2 / two_level).
+5. **(new)** `resolve_auto_scan_strategy/2` — picks scan strategy
+   options if `scan_strategy(auto)` is set.
+
+The new scan-strategy resolver:
+
+- Fires only when `scan_strategy(auto)` is in the (merged) options.
+- Reads `tree_cost_function/1`, `expected_query_count/1`,
+  `working_set_fraction/1`, `mem_available_bytes/1`, etc. — most of
+  which typically come from the algorithm manifest, with caller
+  overrides on top.
+- Outputs concrete `tree_cost_function/2`, `warm_budget_nodes/1`,
+  `stage2_scan_threshold/1`, `tree_retention/1`.
+
+When `scan_strategy(auto)` is absent, the workload runs without
+warm-build / snapshot — direct cursor + cache mode picked by the
+existing resolvers. This is the default; warm-build is strictly
+opt-in (either via a caller option or via an algorithm manifest
+that declares it).
+
+## Edge cases
+
+### Warm produces zero useful nodes
+
+If after warm the heap has no entries whose score exceeds some
+floor, snapshot produces an empty `Cache`. Steady-state runs
+entirely on cursor fallback. Verbose trace warns:
+
+```
+[WAM-Haskell] scan_strategy(auto): warm produced 0 nodes above threshold; running cursor-only
+```
+
+### Cost function disagrees with workload
+
+If the workload's actual access pattern doesn't match the cost
+function's predictions, miss rate will be high. Measurement —
+not architecture — catches this. Recommend exposing
+`cache_strategy_verbose(true)`-style stats (hit/miss counters)
+during steady-state for diagnostic runs.
+
+### Endpoint disappears mid-warm
+
+Not applicable — warm reads endpoints at start, doesn't track
+mid-workload changes. Re-warm-on-shift is out of scope.
+
+### Bounded heap evicts a node we later need
+
+By design. Steady-state misses go to cursor fallback. The
+eviction policy is "lowest-score first"; the score *is* the
+prediction of relevance; an evicted node is a node the cost
+function predicted wouldn't matter. If misses are high, the
+prediction was wrong.
+
+## See also
+
+- `SCAN_STRATEGY_PHILOSOPHY.md` — the why.
+- `SCAN_STRATEGY_IMPLEMENTATION_PLAN.md` — the how (phased
+  rollout).
+- `CACHE_COST_MODEL_PHILOSOPHY.md` — the cost model this layer
+  builds on; provides `bandwidth_eff` / `latency_eff` /
+  `K_cross` formulas.

--- a/docs/design/SCAN_STRATEGY_SPECIFICATION.md
+++ b/docs/design/SCAN_STRATEGY_SPECIFICATION.md
@@ -10,8 +10,8 @@ list, formulas, composition rules) of the design laid out in
 ### Phase W (warm-build)
 
 | name | type sketch | role |
-|---|---|---|
-| `WarmHeap`  | `Data.Heap.MinPrioHeap Cost (NodeId, Edges)` | bounded-capacity ordered structure; lowest-cost evicted first |
+| --- | --- | --- |
+| `WarmHeap`  | `Data.Heap.MinPrioHeap Cost (NodeId, Edges)` | bounded-capacity **min-heap** keyed by cost; on insertion when at capacity, the minimum (lowest-cost) entry is evicted to make room for a higher-scored candidate |
 | `WarmIndex` | `IntMap NodeId Cost`                          | "do we already have this node, and at what cost?" — O(log N) lookup back into the heap |
 | `Frontier`  | `IntMap NodeId Cost`                          | candidate nodes not yet visited; same shape, separate logical role |
 | `Visited`   | `IntSet NodeId`                                | nodes whose edges we've already loaded |
@@ -32,11 +32,21 @@ Single conversion pass over `WarmHeap`:
 snapshotCache :: WarmHeap -> IntMap NodeId [EdgeTarget]
 ```
 
+**Cost values are not retained in the `Cache`.** Steady-state
+lookup is by-node only; there's no use for cost metadata once the
+cache is built. If cost information is needed post-snapshot (e.g.
+for spark routing in P5), it is retained separately via
+`snapshotRanked` below, not embedded in `Cache` entries.
+
 Optionally, also produce a flux-ranked view for retention:
 
 ```haskell
 snapshotRanked :: WarmHeap -> [(NodeId, Cost)]   -- descending by cost
 ```
+
+`RankedView` is immutable post-snapshot; concurrent reads from
+multiple capabilities (the P5 spark-routing use case) are safe
+without synchronisation by Haskell's GC contract on pure data.
 
 After snapshot, `WarmHeap`, `WarmIndex`, `Frontier`, `Visited` can
 all be GC'd. Steady-state holds only the cache (and optionally the
@@ -97,16 +107,26 @@ The Haskell-side generated code consumes a `CostFn` abstraction:
 
 ```haskell
 data CostFn = CostFn
-  { cfScore   :: !(NodeId -> Edges -> Cost)   -- pure scorer
-  , cfRelax   :: !(NodeId -> [NodeId] -> Cost -> ScoreMap -> ScoreMap)
-                                              -- propagation step
-  , cfInitial :: !(NodeId -> Cost)            -- endpoint score
+  { cfInitial :: !(NodeId -> Cost)
+      -- initial score for an endpoint node (seed or root)
+  , cfRelax   :: !(NodeId -> [NodeId] -> ScoreMap -> ScoreMap)
+      -- one round of score propagation:
+      -- given a node, its neighbours, and the current score map,
+      -- update the score map with the relaxed neighbour scores
   }
 ```
 
-Each concrete cost function (flux, hop, semantic) implements this
-record. The tree-building algorithm consumes a `CostFn` and is
-generic over which one.
+The "score" of a node is just its value in the `ScoreMap` — we
+intentionally don't have a separate `cfScore` field. Flux scoring
+depends on the global score map (parent/child contributions
+require already-scored neighbours), so a pure
+`NodeId -> Edges -> Cost` signature can't express it. Keeping the
+state in `ScoreMap` and treating `cfRelax` as the sole
+score-producing operation avoids the overlap.
+
+Each concrete cost function (flux, hop, semantic) implements
+this record. The tree-building algorithm consumes a `CostFn`
+and is generic over which one.
 
 ### Flux
 
@@ -119,6 +139,15 @@ flux(n) = parent_flux(n) + child_flux(n)
 parent_flux(n) = Σ_{p ∈ parents(n)}  (parent_decay / |children(p)|) ^ hops_from_endpoint(p)
 child_flux(n)  = Σ_{c ∈ children(n)} (child_decay  / |parents(c)|)  ^ hops_from_endpoint(c)
 ```
+
+**`hops_from_endpoint` semantics**: the BFS distance from `n` (or its
+parent/child neighbour, as in the formulas above) to the *nearest
+endpoint*. Endpoints are nodes named by the algorithm's `seeds/1`
+predicate. When the workload also declares `roots/1`, both seeds and
+roots are treated as endpoints — `hops_from_endpoint(x) = min(BFS to
+seeds, BFS to roots)`. This makes flux symmetric for workloads with
+two-sided endpoint sets (e.g. effective-distance computing reachability
+between an article and a target category).
 
 Reading the formula:
 
@@ -158,13 +187,24 @@ should be open to it.
 Unified meaning across access patterns:
 
 | iterations | meaning |
-|---|---|
+| --- | --- |
 | 1 | one round of score propagation. Cursor mode: expand frontier by 1 hop, update scores within that hop. Scan mode: one full pass over the edge list, propagating from scored nodes to neighbours. |
-| N | N rounds. Approaches converged scoring as N → ∞. |
-| auto | until score-change-per-iteration drops below a threshold (deferred — needs a convergence metric to be defined). |
+| N (positive integer) | N rounds. Approaches converged scoring as N → ∞. |
 
 The cost vs accuracy knob. Default `iterations(1)` for the cheap
 path; workload-authors who need converged scoring opt up.
+
+#### Future iteration modes (not yet exposed)
+
+`iterations(auto)` — runs until score-change-per-iteration drops
+below a threshold — is a natural endpoint of the cost/accuracy
+curve but is **not in the public option space for P0–P5**. It
+needs a convergence metric definition (e.g. max-delta or
+sum-of-deltas across the score map) plus a per-cost-function
+sensible default threshold. Filed as a Phase 6+ extension; until
+then, callers passing `iterations(auto)` are coerced to
+`iterations(1)` with a stderr warning so a workload author who
+typed it doesn't get silent surprises.
 
 ## Stage-1 → Stage-2 crossover
 
@@ -177,9 +217,17 @@ to a scan pass.
 K_cross_stage2 = W_remaining / (bandwidth_eff * latency_eff)
 ```
 
-where `W_remaining` is the bytes of edge data not yet materialised
-into the heap, and `bandwidth_eff` / `latency_eff` come from the
-cost model's formula (`CACHE_COST_MODEL_PHILOSOPHY.md`).
+where `bandwidth_eff` / `latency_eff` come from the cost model's
+formula (`CACHE_COST_MODEL_PHILOSOPHY.md`).
+
+**Static threshold, runtime check.** `K_cross_stage2` is computed
+**at codegen time** using the same formula as the cost model
+(static estimates of `W_remaining` from `db_size_bytes`,
+hardware constants from `cost_model_constants/1`). The frontier
+size `|Frontier|` is measured **at runtime** during warm-build and
+compared against the precomputed threshold. Implementors should
+*not* recompute the threshold dynamically — the inputs would
+require a runtime probe and the comparison is meant to be cheap.
 
 Concretely:
 
@@ -237,9 +285,24 @@ codebase. No metadata per entry, no priority queue, no LRU chain.
 Hash distribution decides what stays.
 
 The cache is sized at codegen time (`cache_capacity_buckets/1`,
-default `2 × warm_budget_nodes` so the snapshot can populate
-without immediately overwriting itself, and miss memoisation
-has headroom before colliding with snapshot entries).
+default `4 × warm_budget_nodes`). At `B = 4N` the expected
+collision rate during snapshot population is roughly
+`N(1 - (1 - 1/B)^N) / N ≈ 1 - e^{-1/4} ≈ 22%`. That is, ~22% of
+snapshot inserts will hit an occupied bucket and overwrite —
+acceptable because:
+
+1. The displaced snapshot entry is one cursor seek to recover on
+   first access; the cache catches it via miss-memoisation
+   thereafter.
+2. Steady-state miss memoisation will overwrite some snapshot
+   entries anyway as the workload's actual hot set diverges
+   from the prediction.
+
+Workloads that want a tighter floor on snapshot retention can
+override (`8×` halves the collision rate again, at the cost of
+~2× the cache memory). The Phase L#5/#7 measurements informed
+the `4×` default; revisit at P3 when warm-build measurements
+land.
 
 ## Cache miss handling
 
@@ -345,7 +408,7 @@ parentheses.
 | `stage2_scan_threshold(K)` | derived from cost model | crossover trigger |
 | `stage2_max_scans(N)` | `2` | fixed-point bound |
 | `tree_retention(R)` | `discard` | `discard` / `snapshot_only` / `live` |
-| `cache_capacity_buckets(N)` | `2 × warm_budget_nodes` | hashtable bucket count |
+| `cache_capacity_buckets(N)` | `4 × warm_budget_nodes` | hashtable bucket count |
 
 ### Flux-specific sub-options
 
@@ -399,6 +462,37 @@ existing resolvers. This is the default; warm-build is strictly
 opt-in (either via a caller option or via an algorithm manifest
 that declares it).
 
+### `tree_cost_function` auto-selection
+
+When `scan_strategy(auto)` is set but `tree_cost_function/2` is
+not supplied (neither by the caller nor by the manifest), the
+resolver picks one by priority:
+
+1. **`semantic_similarity`** — only if `embedding_path(P)` is set
+   AND the file exists at codegen time. Requires real
+   embeddings; degenerate scoring without them.
+2. **`flux`** — only if branching-factor data is available
+   (typically from P2's at-scale measurements feeding
+   `parent_branching_factor/1` / `child_branching_factor/1`
+   options). Without this data, the default decay constants are
+   arbitrary; better to fall through.
+3. **`hop_distance`** — the safe fallback. Cheap, no
+   data-dependent parameters, gives a useful (if coarse) ranking
+   for any graph.
+
+Each priority gate has its own `(if-available)` check. The
+resolver emits a verbose trace explaining the pick:
+
+```
+[WAM-Haskell] scan_strategy(auto): tree_cost_function defaulted to hop_distance
+  (no embedding_path; no branching_factor data)
+```
+
+Callers who want a specific function just set
+`tree_cost_function(flux, [...])` (or whichever) in their
+options or manifest; the auto-selection only fires when the slot
+is unspecified.
+
 ## Edge cases
 
 ### Warm produces zero useful nodes
@@ -415,9 +509,13 @@ entirely on cursor fallback. Verbose trace warns:
 
 If the workload's actual access pattern doesn't match the cost
 function's predictions, miss rate will be high. Measurement —
-not architecture — catches this. Recommend exposing
-`cache_strategy_verbose(true)`-style stats (hit/miss counters)
-during steady-state for diagnostic runs.
+not architecture — catches this. Recommend exposing the
+`scan_strategy_verbose(true)` option (defined in the
+implementation plan's cross-cutting telemetry section) to get
+hit/miss counters during steady-state for diagnostic runs. Note:
+this is a separate option from `cache_strategy_verbose(true)`,
+which is the cache-cost-model resolver's existing trace flag —
+the two flags toggle different telemetry paths.
 
 ### Endpoint disappears mid-warm
 


### PR DESCRIPTION
## Summary

Four design docs capturing the design discussion that followed Phase 2c's cache-cost-model arc. Doc-only PR — no code changes.

The scan-strategy work is the next layer above the cost model (`CACHE_COST_MODEL_PHILOSOPHY`). The algorithm-manifest doc abstracts a meta-concern that surfaced during the discussion: the declarative split between *algorithm* (the logical problem specification) and *optimization manifest* (the operational completion).

| doc | lines | role |
| --- | --- | --- |
| `ALGORITHM_MANIFEST_SPECIFICATION.md` | 355 | new — `algorithm/2` + `algorithm_optimization/2` API |
| `SCAN_STRATEGY_PHILOSOPHY.md` | 259 | what / why / when; three retention modes |
| `SCAN_STRATEGY_SPECIFICATION.md` | 442 | data structures, formulas, options, composition |
| `SCAN_STRATEGY_IMPLEMENTATION_PLAN.md` | 457 | phased rollout P0–P7 |

Total: 1,513 lines of docs.

## Algorithm-manifest abstraction

Workload-author API (extends the existing `user:demand_filter_spec/2` pattern to cover all optimizations):

```prolog
:- algorithm(effective_distance, [
       kernel(category_ancestor/4),
       seeds(article/1),
       roots(root_category/1),
       max_depth(10),
       dimension_n(5)
   ]).

:- algorithm_optimization(effective_distance, [
       cache_strategy(auto),
       working_set_fraction(0.001),
       scan_strategy(auto),
       tree_cost_function(flux, [iterations(1), parent_decay(0.5), child_decay(0.3)]),
       tree_retention(snapshot_only),
       demand_filter_spec(hop_limit, [max_hops(10)])
   ]).
```

Codegen runs `load_algorithm_manifest/2` before any resolver. Caller-provided options win on conflict. Backwards-compatible.

**Terminology note** (the docs flag this explicitly): "algorithm" in these docs means the *logical* specification of a graph problem — closer to the Datalog/SQL sense of "a query" than to the algorithms-textbook sense of "a step-by-step procedure". The optimization manifest *completes* the definition by specifying how to compile it.

## Scan-strategy core insight

Three phases, three data structures:

| phase | structure | optimised for |
| --- | --- | --- |
| warm-build | sorted heap + parallel index | O(log N) ranked construction |
| snapshot | one-shot conversion | one-time |
| steady-state | fixed-bucket hashtable, overwrite-on-collision | O(1) lookup, miss-memoised |

Cache is a real cache: misses cursor to LMDB and memoise into the hashtable. Snapshot provides the *initial state*, not a frozen lookup table. Eviction policy is overwrite-on-collision — same mechanism as the existing L1/L2 caches in the codebase.

## Three tree retention modes

| mode | tree post-snapshot | use case |
| --- | --- | --- |
| `discard` | GC'd | default; minimum memory |
| `snapshot_only` | frozen ranked list retained | spark routing, static prioritisation |
| `live` | full heap + index kept | adaptive re-ranking, query-history-driven updates |

`live` mode has no current consumer; the data structures we pick during warm support it without architectural changes, so the door stays open for query-history-driven re-ranking, adaptive cost-function switching, etc.

## Cost-function strategy slot

Pluggable: `flux`, `hop_distance`, `semantic_similarity`. Each has its own parameter list. **Flux specifically** uses separate parent/child decay constants because category-graph branching is asymmetric (few parents per node, many children).

`iterations(N)` unified across access patterns: 1 = local one-hop (cursor mode) / one full pass (scan mode), N → ∞ = converged scoring.

## Stage-1 → Stage-2 crossover

Same crossover formula as the cost model:

```
K_cross = W_remaining / (bandwidth_eff * latency_eff)
```

When unvisited frontier exceeds the crossover, switch from cursor seeks to a single scan pass. Fixed-point loop bounded to ≤ 2 scans for the first cut.

## Implementation plan (P0–P7)

| phase | size | gates |
| --- | --- | --- |
| P0: Algorithm-manifest abstraction | small | prerequisite for everything below |
| P1: Pluggable cost-function slot | small | P0 |
| P2: At-scale validation re-ingest | small (tooling) | needs P0+P1 in for matrix bench |
| P3: Warm-build + snapshot core | medium | P1; P2 data informs tuning |
| P4: `scan_strategy(auto)` resolver + matrix-bench mode | small-medium | P3 |
| P5: Spark routing via retained ranking (`snapshot_only`) | medium | P3 |
| P6: Adaptive fixed-point iteration | small | P3, P4; data-driven |
| P7+: Live-mode tree updates | medium per-algorithm | research-y, deferred |

P0–P4 are the core deliverable. P5–P7 are extensions; treat as optional based on P3/P4 measurements.

## Composition with existing arcs

The scan-strategy options compose with the cost-model resolvers landed in Phase 2c:

```
load_algorithm_manifest         (new in P0)
  → resolve_auto_use_lmdb       (existing)
  → resolve_auto_cache_strategy (Phase 2c)
  → resolve_auto_lmdb_cache_mode (Phase 2c+)
  → resolve_auto_scan_strategy  (new in P4)
  → codegen
```

Each layer reads the merged option list and refines its own slice of the decision space.

## Open questions filed for measurement

- Default `warm_budget_nodes(N)` fraction at each scale.
- Default `parent_decay` / `child_decay` for flux (waiting on the branching-factor distribution from P2).
- `iterations(1)` vs `iterations(3)` accuracy/cost curve.
- `stage2_max_scans(N)` bound — does 2 capture the gains?
- Whether `semantic_similarity` is worth supporting at our scale.

## What this isn't

- Not a runtime auto-tuner — warm parameters are picked at codegen / workload-author time.
- Not a re-warming mechanism — steady-state cache learns via miss-memoisation but the tree doesn't re-build mid-workload (that's `live` mode, deferred).
- Not a correctness device — misses fall back to LMDB cursor and return correct results; the strategy affects performance only.

## See also

- `docs/design/CACHE_COST_MODEL_PHILOSOPHY.md` — the cost model this layer builds on.
- `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` — Phase M / Phase L measurements that motivate the regimes.
- Existing patterns this work generalises: `user:demand_filter_spec/2`, `user:max_depth/1`, `statistics:declare_cache_hints/1`.