### PR TITLE
feat(wam-r): inline bound get_value head checks

### DIFF
--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -508,25 +508,31 @@ declaration directly, not the visibility output.
 
 **2. Specialised inline emission (default ON)** -- when the mode
 declaration says `+` for a head arg position, the lowered emitter
-inlines `get_constant` head matches as:
+inlines selected head matches.
+
+For `get_constant`, it emits:
 
 ```r
 { val_ <- WamRuntime$deref(state, WamRuntime$get_reg(state, AIdx))
   if (is.null(val_) || !identical(val_, CTerm)) return(FALSE) }
 ```
 
-instead of delegating to `WamRuntime$step`. Saves one `step()` call
-(list construction + function call + switch dispatch) per
-get_constant. Opt out via `mode_specialise(off)` if you need the
+For repeated head variables (`p(X, X)`) that compile to
+`get_variable X1, A1` followed by `get_value X1, A2`, mode `(+,+)`
+lets the emitter inline a bound-pair check. Atomic pairs use direct
+tag/value identity; non-atomic bound terms fall back to
+`WamRuntime$unify` to preserve structural semantics.
+
+Both paths avoid the `WamRuntime$step` dispatcher for the specialised
+instruction. Opt out via `mode_specialise(off)` if you need the
 unspecialised codegen (testing / regression bisection).
 
 **Soundness:** the specialisation skips the "rebind unbound to the
-constant" branch of `step`'s GetConstant handler, since mode `+`
-promises A_k is bound at clause entry. If a caller passes an
-unbound term where the mode says `+`, the inline form returns
-`FALSE` (treating unbound as a tag mismatch) where the step path
-would have bound it. Document; user is responsible for honest mode
-declarations.
+constant" / "bind unbound variable" branches of the step handlers,
+since mode `+` promises the relevant slots are bound at clause entry.
+If a caller passes an unbound term where the mode says `+`, the inline
+form returns `FALSE` where the step path would have bound it. Document;
+user is responsible for honest mode declarations.
 
 The mode declaration uses `user:mode/1` with `+` / `-` / `?`
 shorthand (input / output / any), the same convention
@@ -920,6 +926,8 @@ Coverage map (e2e tests, by feature group):
 | `mode_analysis_phase3_is_inlined` | Mode-analysis phase 3: structural assertion that `builtin_call is/2 2` is emitted as inline `WamRuntime$eval_arith + bind/unify` in the lowered function (instead of `WamRuntime$step(... BuiltinCall("is/2", 2))`) |
 | `mode_analysis_phase3_is_e2e_rscript` | Mode-analysis phase 3: e2e correctness -- a predicate using `is/2` with simple binary int op (runtime fast-path), nested arith (slow path), and negative-result arith compiles + runs via Rscript with correct values |
 | `mode_analysis_phase4_multiclause_n_e2e_rscript` | Mode-analysis phase 4: all-supported-clause `multi_clause_n` lowering, including direct R-wrapper execution of clause 2's inline `is/2` path |
+| `mode_analysis_get_value_inlined` | Mode-analysis follow-up: structural assertion that repeated bound head variables compile `get_value` to an inline atomic identity fast path with safe fallback |
+| `mode_analysis_get_value_e2e_rscript` | Mode-analysis follow-up: e2e correctness for inline `get_value` on matching and non-matching bound atom pairs |
 
 ## Contributing
 

--- a/docs/design/WAM_R_MODE_ANALYSIS_PLAN.md
+++ b/docs/design/WAM_R_MODE_ANALYSIS_PLAN.md
@@ -223,9 +223,10 @@ clause inline and uses an iter-style retry CP for later clauses.
    are in the supported subset, the lowered function emits each clause
    as an inline closure, restores state between failed attempts, and
    leaves an iter-style retry CP for later clauses.
-2. **`get_value` head match -- skip deref-then-unify when both
-   sides are provably bound atomics.** Same shape as the phase-2
-   `get_constant` specialisation but for var-to-var matching.
+2. **`get_value` head match.** Delivered: repeated head variables
+   such as `p(X, X)` with mode `(+,+)` now inline the lowered
+   `get_value` instruction. Atomic bound pairs use direct identity;
+   non-atomic bound terms fall back to `WamRuntime$unify`.
 3. **Auto-mode-inference from call sites.** Today the analyser
    only knows what `:- mode/1` declarations tell it. A whole-
    program pass could infer modes from observed call sites,

--- a/src/unifyweaver/targets/wam_r_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_r_lowered_emitter.pl
@@ -288,10 +288,12 @@ set_lowered_mode_context(Records, Opts) :-
     ->  ModeDecl = none
     ;   clause1_mode_decl(Records, ModeDecl)
     ),
-    b_setval(wam_r_lowered_mode_decl, ModeDecl).
+    b_setval(wam_r_lowered_mode_decl, ModeDecl),
+    b_setval(wam_r_lowered_x_states, []).
 
 clear_lowered_mode_context :-
-    b_setval(wam_r_lowered_mode_decl, none).
+    b_setval(wam_r_lowered_mode_decl, none),
+    b_setval(wam_r_lowered_x_states, []).
 
 %% clause1_mode_decl(+Records, -ModeDecl) is det.
 %  Pulls the ModeDecl component of clause 1's record. Returns `none`
@@ -320,6 +322,27 @@ head_state_for_areg(AiStr, State) :-
 
 mode_atom_to_state(input,  bound).
 mode_atom_to_state(output, unbound).
+
+%% x_reg_state(+XStr, -State) is semidet.
+%  Returns the simple binding state tracked for X registers during
+%  lowered emission. This is intentionally shallow: get_variable from
+%  a known-bound A register marks the destination X register as bound;
+%  get_variable from a known-unbound A register marks it unbound.
+x_reg_state(XStr, State) :-
+    catch(b_getval(wam_r_lowered_x_states, States), _, fail),
+    memberchk(XStr-State, States).
+
+%% set_x_reg_state(+XStr, +State) is det.
+set_x_reg_state(XStr, State) :-
+    catch(b_getval(wam_r_lowered_x_states, States0), _, States0 = []),
+    exclude(same_x_reg(XStr), States0, States),
+    b_setval(wam_r_lowered_x_states, [XStr-State | States]).
+
+same_x_reg(XStr, K-_) :-
+    K == XStr.
+
+reset_x_reg_states :-
+    b_setval(wam_r_lowered_x_states, []).
 
 %% mode_comment_header_from_records(+Opts, +Records, -Header) is det.
 %  Builds the R comment block for the predicate's mode analysis when
@@ -439,6 +462,7 @@ format_one_clause(mode_record(Idx, ModeDecl, HeadVars, _GBs), Lines) :-
 
 emit_deterministic_function(PredName, FuncName, ClauseLines,
                             ModeHeader, Code) :-
+    reset_x_reg_states,
     with_output_to(string(Body), emit_lines(ClauseLines, "  ")),
     % The clause body always ends with `proceed`, which emits
     % `return(TRUE)`. We keep an explicit `invisible(TRUE)` after the
@@ -532,6 +556,7 @@ emit_clause_dispatch([], _).
 emit_clause_dispatch([Lines|Rest], Idx) :-
     format("    if (identical(idx_, ~wL)) {~n", [Idx]),
     format("      return((function() {~n"),
+    reset_x_reg_states,
     emit_lines(Lines, "        "),
     format("        invisible(FALSE)~n"),
     format("      })())~n"),
@@ -597,6 +622,10 @@ emit_line_parts(["put_value", XStr, AiStr], I) :- !,
 emit_line_parts(["get_variable", XStr, AiStr], I) :- !,
     wam_r_target:reg_to_int(XStr, XIdx),
     wam_r_target:reg_to_int(AiStr, AIdx),
+    (   head_state_for_areg(AiStr, State)
+    ->  set_x_reg_state(XStr, State)
+    ;   true
+    ),
     format("~wWamRuntime$put_reg(state, ~w, WamRuntime$get_reg(state, ~w))~n",
            [I, XIdx, AIdx]).
 
@@ -620,6 +649,33 @@ emit_line_parts(["get_constant", CStr, AiStr], I) :-
     wam_r_target:constant_to_r_term(CStr, CTerm),
     format("~w{ val_ <- WamRuntime$deref(state, WamRuntime$get_reg(state, ~w)); if (is.null(val_) || !identical(val_, ~w)) return(FALSE) }~n",
            [I, AIdx, CTerm]).
+
+% Mode-driven specialisation for head get_value. In the common
+% repeated-head-var pattern (`p(X, X)`), WAM emits get_variable for
+% the first occurrence and get_value for the second. When mode decls
+% prove both positions are bound, the unbound-binding branch of unify
+% is dead. Atomic bound pairs can be checked by tag/value identity;
+% non-atomic bound terms fall back to unify to preserve structural
+% semantics.
+emit_line_parts(["get_value", XStr, AiStr], I) :-
+    x_reg_state(XStr, bound),
+    head_state_for_areg(AiStr, bound),
+    !,
+    wam_r_target:reg_to_int(XStr, XIdx),
+    wam_r_target:reg_to_int(AiStr, AIdx),
+    format("~w{~n", [I]),
+    format("~w  gv_x_ <- WamRuntime$get_reg(state, ~w)~n", [I, XIdx]),
+    format("~w  gv_a_ <- WamRuntime$get_reg(state, ~w)~n", [I, AIdx]),
+    format("~w  gv_x_d_ <- WamRuntime$deref(state, gv_x_)~n", [I]),
+    format("~w  gv_a_d_ <- WamRuntime$deref(state, gv_a_)~n", [I]),
+    format("~w  if (is.null(gv_x_d_) || is.null(gv_a_d_)) return(FALSE)~n", [I]),
+    format("~w  if (!is.null(gv_x_d_$tag) && gv_x_d_$tag == \"unbound\") return(FALSE)~n", [I]),
+    format("~w  if (!is.null(gv_a_d_$tag) && gv_a_d_$tag == \"unbound\") return(FALSE)~n", [I]),
+    format("~w  gv_atomic_ <- c(\"atom\", \"int\", \"float\")~n", [I]),
+    format("~w  if (!is.null(gv_x_d_$tag) && !is.null(gv_a_d_$tag) && gv_x_d_$tag %in% gv_atomic_ && gv_a_d_$tag %in% gv_atomic_) {~n", [I]),
+    format("~w    if (!identical(gv_x_d_, gv_a_d_)) return(FALSE)~n", [I]),
+    format("~w  } else if (!isTRUE(WamRuntime$unify(state, gv_x_, gv_a_))) return(FALSE)~n", [I]),
+    format("~w}~n", [I]).
 
 % --- Builtin specialisations: inline the most common BuiltinCall
 % targets so they skip the WamRuntime$step -> WamRuntime$call_builtin

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -989,6 +989,82 @@ e2e_phase4_multiclause_n :-
     delete_directory_and_contents(TmpDir).
 
 % ------------------------------------------------------------------
+% Mode-analysis follow-up: get_value head-match specialisation.
+% For repeated bound head variables (`p(X, X)` with mode(+,+)), the
+% lowered emitter can fast-check atomic pairs without delegating the
+% get_value instruction through WamRuntime$step.
+% ------------------------------------------------------------------
+test(mode_analysis_get_value_inlined) :-
+    once((
+        retractall(user:mode(ma_gv(_, _))),
+        retractall(user:ma_gv(_, _)),
+        assertz(user:mode(ma_gv(+, +))),
+        assertz((user:ma_gv(X, X) :- true)),
+        unique_r_tmp_dir('tmp_r_get_value_specialised', TmpDir),
+        write_wam_r_project(
+            [user:ma_gv/2],
+            [emit_mode(functions), fact_table_layout(off)],
+            TmpDir),
+        directory_file_path(TmpDir, 'R/generated_program.R', Program),
+        read_file_to_string(Program, Code, []),
+        assertion(sub_string(Code, _, _, _, 'gv_x_d_ <- WamRuntime$deref(state, gv_x_)')),
+        assertion(sub_string(Code, _, _, _, 'gv_atomic_ <- c("atom", "int", "float")')),
+        assertion(\+ sub_string(Code, _, _, _, 'WamRuntime$step(program, state, GetValue')),
+        retractall(user:mode(ma_gv(_, _))),
+        unique_r_tmp_dir('tmp_r_get_value_unspecialised', TmpDir2),
+        write_wam_r_project(
+            [user:ma_gv/2],
+            [emit_mode(functions), fact_table_layout(off)],
+            TmpDir2),
+        directory_file_path(TmpDir2, 'R/generated_program.R', Program2),
+        read_file_to_string(Program2, Code2, []),
+        assertion(sub_string(Code2, _, _, _, 'WamRuntime$step(program, state, GetValue')),
+        assertz(user:mode(ma_gv(+, +))),
+        unique_r_tmp_dir('tmp_r_get_value_optout', TmpDir3),
+        write_wam_r_project(
+            [user:ma_gv/2],
+            [emit_mode(functions), fact_table_layout(off),
+             mode_specialise(off)],
+            TmpDir3),
+        directory_file_path(TmpDir3, 'R/generated_program.R', Program3),
+        read_file_to_string(Program3, Code3, []),
+        assertion(sub_string(Code3, _, _, _, 'WamRuntime$step(program, state, GetValue')),
+        retractall(user:mode(ma_gv(_, _))),
+        delete_directory_and_contents(TmpDir),
+        delete_directory_and_contents(TmpDir2),
+        delete_directory_and_contents(TmpDir3)
+    )).
+
+test(mode_analysis_get_value_e2e_rscript) :-
+    once((
+        rscript_available
+    ->  e2e_mode_analysis_get_value
+    ;   true
+    )).
+
+e2e_mode_analysis_get_value :-
+    retractall(user:mode(ma_gv(_, _))),
+    retractall(user:ma_gv(_, _)),
+    retractall(user:ma_gv_same/0),
+    retractall(user:ma_gv_diff/0),
+    assertz(user:mode(ma_gv(+, +))),
+    assertz((user:ma_gv(X, X) :- true)),
+    assertz((user:ma_gv_same :- ma_gv(alice, alice))),
+    assertz((user:ma_gv_diff :- ma_gv(alice, bob))),
+    unique_r_tmp_dir('tmp_r_get_value_e2e', TmpDir),
+    write_wam_r_project(
+        [user:ma_gv/2, user:ma_gv_same/0, user:ma_gv_diff/0],
+        [emit_mode(functions), fact_table_layout(off)],
+        TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    run_rscript_query(RDir, 'ma_gv_same/0', SameOut),
+    run_rscript_query(RDir, 'ma_gv_diff/0', DiffOut),
+    assertion(sub_string(SameOut, _, _, _, "true")),
+    assertion(sub_string(DiffOut, _, _, _, "false")),
+    retractall(user:mode(ma_gv(_, _))),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % Phase-3 follow-up: extended builtins.
 % Type checks, term equality / identity, standard order of terms,
 % and the cut (!/0). Each predicate compiles to the corresponding


### PR DESCRIPTION
## Summary

- Add lowered-emitter tracking for simple X-register binding state.
- Inline `get_value` head checks for repeated bound head variables, such as `p(X, X)` under `mode(+,+)`.
- Use direct atomic identity for bound atom/int/float pairs, while falling back to `WamRuntime$unify` for non-atomic bound terms.
- Reset tracked X-register state at lowered clause boundaries.
- Add structural and Rscript e2e coverage for the specialized and fallback code paths.
- Update WAM-R target docs and the mode-analysis plan.

## Verification

- `git diff --check`
- `swipl -g "run_tests([wam_r_generator:mode_analysis_phase2_get_constant_inlined,wam_r_generator:mode_analysis_phase2_get_constant_e2e_rscript,wam_r_generator:mode_analysis_phase3_is_inlined,wam_r_generator:mode_analysis_phase3_is_e2e_rscript,wam_r_generator:mode_analysis_phase4_multiclause_n_e2e_rscript,wam_r_generator:mode_analysis_get_value_inlined,wam_r_generator:mode_analysis_get_value_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`
- `swipl -g "run_tests([wam_r_generator:list_atom_builtins_e2e_rscript,wam_r_generator:findall_e2e_rscript,wam_r_generator:mode_analysis_get_value_e2e_rscript])" -t halt tests/test_wam_r_generator.pl`

All checks passed locally.
