### PR TITLE
Refactor/wam python runtime source of truth

### DIFF
--- a/PR_wam_python_runtime_source_of_truth.md
+++ b/PR_wam_python_runtime_source_of_truth.md
@@ -1,0 +1,26 @@
+# PR Title
+
+Use packaged Python WAM runtime as source of truth
+
+# PR Description
+
+## Summary
+
+- makes `compile_wam_runtime_to_python/2` read the packaged `WamRuntime.py`
+- removes the divergent generated fallback runtime path from Python WAM project generation
+- documents that Python WAM now has one runtime source of truth
+
+## Details
+
+Generated Python WAM projects already copy `src/unifyweaver/targets/wam_python_runtime/WamRuntime.py` as `wam_runtime.py`. This PR makes `compile_wam_runtime_to_python/2` return that same static runtime source instead of assembling a second runtime from Prolog string fragments.
+
+This keeps runtime inspection tests, generated projects, compiled facts, and TSV-backed dynamic fact loading on the same runtime surface. The TSV benchmark path is unchanged: generated `main.py` still loads TSV files and registers facts into the packaged runtime with `register_indexed_atom_fact2_pairs`.
+
+## Verification
+
+```sh
+swipl -q -g run_tests -t halt tests/test_wam_python_target.pl
+swipl -q -g run_tests -t halt tests/test_wam_python_effective_distance_smoke.pl
+python3 -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+swipl -q -g "use_module(src/unifyweaver/targets/wam_python_target), halt"
+```

--- a/docs/design/WAM_PYTHON_PARITY_AUDIT.md
+++ b/docs/design/WAM_PYTHON_PARITY_AUDIT.md
@@ -25,35 +25,27 @@ matters for parity.
 | Control | `true/0`, `fail/0`, `!/0`, `\+/1`, `cut_ite` opcode | `true/0`, `fail/0`, `!/0`, `\+/1`, `CutIte` | Present |
 | IO | `write/1`, `display/1`, `nl/0` output behavior | `write/1`, `display/1`, `nl/0` output behavior | Present |
 
-## Generated Fallback Runtime
+## Runtime Source Of Truth
 
-`compile_wam_runtime_to_python/2` emits a fallback runtime only when the static
-runtime file cannot be copied. Its builtin dispatch is not equivalent to the
-packaged static runtime:
-
-- It includes `=/2`, `\=/2`, `float/1`, `compound/1`, `write/1`, `writeln/1`,
-  `nl/0`, `copy_term/2`, `functor/3`, and `=../2`.
-- It does not include the static runtime's `member/2`, `length/2`, `true/0`,
-  `fail/0`, `!/0`, or `\+/1` dispatch.
-- It does not include `arg/3`, `is_list/1`, `==/2`, or `display/1`.
-
-This split is a parity risk: tests that inspect the generated fallback runtime
-can pass while generated Python projects still run against the static runtime.
+`compile_wam_runtime_to_python/2` now reads the packaged static runtime source
+instead of assembling a second runtime from Prolog string fragments. Generated
+projects also copy the same `WamRuntime.py`, so tests and generated projects
+now share one Python WAM runtime surface.
 
 ## Remaining Follow-Up
 
 The packaged static runtime now carries the Lua/Rust/Haskell builtin baseline.
 The remaining parity work is narrower:
 
-1. Reconcile or retire the generated fallback runtime so it cannot drift from
-   `WamRuntime.py`.
-2. Decide whether `member/2` should enumerate all solutions via builtin choice
+1. Decide whether `member/2` should enumerate all solutions via builtin choice
    points, or remain first-solution-only like the current packaged runtime.
 
 Completed follow-up:
 
 - Generated-project E2E tests now exercise term builtins, copy/NAF/IO, and
   type/comparison builtins through the packaged static runtime.
+- `compile_wam_runtime_to_python/2` now returns the packaged static runtime,
+  removing the separate fallback runtime surface.
 
 ## Verification Commands
 

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -1311,19 +1311,15 @@ wam_lines_to_python([Line|Rest], PC, Instrs, Labels) :-
 % ============================================================================
 
 %% compile_wam_runtime_to_python(+Options, -PythonCode)
-%  Generates the complete runtime Python code (types + step + helpers).
-compile_wam_runtime_to_python(Options, PythonCode) :-
-	python_wam_type_header(TypeHeader),
-	compile_step_wam_to_python(Options, StepCode),
-	compile_wam_helpers_to_python(Options, HelpersCode),
-	compile_format_value_to_python(FormatCode),
-	atomic_list_concat([
-		TypeHeader, '\n\n',
-		FormatCode, '\n\n',
-		'# === WamState methods (mixed into class) ===\n',
-		StepCode, '\n\n',
-		HelpersCode
-	], PythonCode).
+%  Return the packaged static runtime source.
+%
+%  Historically this predicate generated a second WAM runtime from bindings,
+%  which drifted from the WamRuntime.py copied into real generated projects.
+%  Keep this API as a read-through compatibility layer so callers and tests see
+%  the same runtime that write_wam_python_project/3 packages.
+compile_wam_runtime_to_python(_Options, PythonCode) :-
+	static_runtime_source_path(SrcPath),
+	read_file_to_string(SrcPath, PythonCode, []).
 
 % ============================================================================
 % PHASE 7: Project Generation
@@ -1333,8 +1329,7 @@ compile_wam_runtime_to_python(Options, PythonCode) :-
 %  Generates a runnable Python WAM project in ProjectDir.
 %
 %  Generated files:
-%    - wam_runtime.py   — WAM runtime (copied from wam_python_runtime/ or
-%                         generated from bindings if the static file is absent)
+%    - wam_runtime.py   — WAM runtime copied from wam_python_runtime/
 %    - predicates.py    — compiled predicates (via compile_wam_predicate_to_python/4)
 %    - main.py          — entry point: parses argv, runs a named predicate,
 %                         prints register results
@@ -1383,16 +1378,16 @@ write_wam_python_project(Predicates, Options, ProjectDir) :-
 %  Uses module source location for reliable path resolution.
 copy_static_runtime(ProjectDir) :-
 	directory_file_path(ProjectDir, 'wam_runtime.py', DestPath),
-	% Resolve relative to this module's source file
-	(   source_file(wam_python_target:compile_step_wam_to_python(_,_), ThisFile),
-		file_directory_name(ThisFile, ThisDir),
-		directory_file_path(ThisDir, 'wam_python_runtime/WamRuntime.py', SrcPath),
-		exists_file(SrcPath)
-	->  copy_file(SrcPath, DestPath)
-	;   % Generate from bindings if static file not found
-		compile_wam_runtime_to_python([], RuntimeCode),
-		write_file(DestPath, RuntimeCode)
-	).
+	static_runtime_source_path(SrcPath),
+	copy_file(SrcPath, DestPath).
+
+%% static_runtime_source_path(-SrcPath)
+%  Resolve the packaged Python WAM runtime relative to this module.
+static_runtime_source_path(SrcPath) :-
+	source_file(wam_python_target:compile_step_wam_to_python(_,_), ThisFile),
+	file_directory_name(ThisFile, ThisDir),
+	directory_file_path(ThisDir, 'wam_python_runtime/WamRuntime.py', SrcPath),
+	exists_file(SrcPath).
 
 %% is_ffi_predicate(+Functor, +Arity, +Options)
 %  True if this predicate is handled by a registered foreign predicate,

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -280,7 +280,7 @@ test(wamstate_has_trail_len, [nondet]) :-
 test(wamstate_heap_is_dict, [nondet]) :-
 	% Heap is initialised as dict, not list
 	wam_python_target:compile_wam_runtime_to_python([], Code),
-	sub_string(Code, _, _, _, "self.heap = {}").
+	sub_string(Code, _, _, _, "self.heap: Dict[int, Term] = {}").
 
 test(heap_put_uses_heap_len, [nondet]) :-
 	% heap_put helper uses heap_len as the address counter
@@ -291,6 +291,14 @@ test(heap_trim_emitted, [nondet]) :-
 	% heap_trim helper is emitted (dict-based trimming)
 	wam_python_target:compile_wam_runtime_to_python([], Code),
 	sub_string(Code, _, _, _, "heap_trim").
+
+test(compile_runtime_reads_static_runtime_source) :-
+	wam_python_target:compile_wam_runtime_to_python([], Code),
+	source_file(wam_python_target:compile_step_wam_to_python(_,_), ThisFile),
+	file_directory_name(ThisFile, ThisDir),
+	directory_file_path(ThisDir, 'wam_python_runtime/WamRuntime.py', SrcPath),
+	read_file_to_string(SrcPath, StaticCode, []),
+	assertion(Code == StaticCode).
 
 :- end_tests(wam_python_phase_a).
 


### PR DESCRIPTION
# Use packaged Python WAM runtime as source of truth

## Summary

- makes `compile_wam_runtime_to_python/2` read the packaged `WamRuntime.py`
- removes the divergent generated fallback runtime path from Python WAM project generation
- documents that Python WAM now has one runtime source of truth

## Details

Generated Python WAM projects already copy `src/unifyweaver/targets/wam_python_runtime/WamRuntime.py` as `wam_runtime.py`. This PR makes `compile_wam_runtime_to_python/2` return that same static runtime source instead of assembling a second runtime from Prolog string fragments.

This keeps runtime inspection tests, generated projects, compiled facts, and TSV-backed dynamic fact loading on the same runtime surface. The TSV benchmark path is unchanged: generated `main.py` still loads TSV files and registers facts into the packaged runtime with `register_indexed_atom_fact2_pairs`.

## Verification

```sh
swipl -q -g run_tests -t halt tests/test_wam_python_target.pl
swipl -q -g run_tests -t halt tests/test_wam_python_effective_distance_smoke.pl
python3 -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
swipl -q -g "use_module(src/unifyweaver/targets/wam_python_target), halt"
```
