### PR TITLE
feat(core): algorithm-manifest abstraction (Phase 0)

### DIFF
--- a/src/unifyweaver/core/algorithm_manifest.pl
+++ b/src/unifyweaver/core/algorithm_manifest.pl
@@ -1,0 +1,227 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% algorithm_manifest.pl — Workload-author manifest abstraction.
+%
+% Separates the *algorithm* (the logical/declarative specification of
+% what is being computed) from the *optimization manifest* (the
+% operational specification of how to compile it: cost-model knobs,
+% cache mode, scan strategy, demand-filter spec, etc.).
+%
+% Algorithm here means the Datalog/SQL sense of "a query" — the
+% declarative *what*, not the algorithms-textbook sense of "a
+% step-by-step procedure". The optimization manifest *completes* the
+% definition by saying how the algorithm should be compiled.
+%
+% This module is target-agnostic. The manifest entries flow into the
+% existing option-list plumbing that resolvers in
+% src/unifyweaver/core/cost_model.pl and target-specific code
+% (e.g. wam_haskell_target.pl) already consume.
+%
+% See docs/design/ALGORITHM_MANIFEST_SPECIFICATION.md for the full
+% spec.
+
+:- module(algorithm_manifest, [
+    %% User-facing directives (workload files call these via `:-`)
+    decl_algorithm/2,                       % +Name, +AlgorithmOpts
+    decl_algorithm_optimization/2,          % +Name, +OptList
+
+    %% Codegen-side API (target adapters call these)
+    load_algorithm_manifest/2,              % +Options0, -Options
+    merge_caller_and_manifest_options/3,    % +Caller, +Manifest, -Merged
+
+    %% Accessors
+    manifest_algorithm/2,                   % -Name, -AlgorithmOpts
+    manifest_optimization_options/2,        % +Name, -ConcatenatedOpts
+
+    %% Test isolation
+    reset_manifest/0
+]).
+
+:- use_module(library(error), [must_be/2, domain_error/2]).
+:- use_module(library(lists)).
+:- use_module(library(option), [option/3]).
+
+%% =====================================================================
+%% Internal registry
+%% =====================================================================
+%
+% These are private dynamic predicates that hold the asserted state.
+% Workloads don't touch them directly — they call decl_algorithm/2
+% and decl_algorithm_optimization/2 as directives, which assert into
+% the registry.
+
+:- dynamic registered_algorithm/2.
+:- dynamic registered_optimization/2.
+
+%% =====================================================================
+%! decl_algorithm(+Name, +AlgorithmOpts) is det.
+%
+%  Declare an algorithm.
+%
+%  Workload usage:
+%
+%      :- use_module(library(algorithm_manifest)).
+%      :- decl_algorithm(effective_distance, [
+%             kernel(category_ancestor/4),
+%             seeds(article/1),
+%             roots(root_category/1),
+%             max_depth(10),
+%             dimension_n(5)
+%         ]).
+%
+%  At most one decl_algorithm/2 per Name across all loaded files. A
+%  second declaration with the same Name throws an error rather than
+%  silently picking one (defensive: keeps the manifest unambiguous).
+%
+%  Validation of AlgorithmOpts beyond list-shape is deferred to the
+%  target adapter, which knows what option keys make sense for its
+%  codegen. The manifest module itself doesn't validate semantically.
+%% =====================================================================
+
+decl_algorithm(Name, Opts) :-
+    must_be(atom, Name),
+    must_be(list, Opts),
+    (   registered_algorithm(Name, _)
+    ->  throw(error(
+            domain_error(unique_algorithm_decl, Name),
+            context(decl_algorithm/2,
+                    'algorithm already declared (only one decl_algorithm/2 per Name is allowed)')))
+    ;   assertz(registered_algorithm(Name, Opts))
+    ).
+
+%% =====================================================================
+%! decl_algorithm_optimization(+Name, +OptList) is det.
+%
+%  Declare an optimization manifest entry for an algorithm.
+%
+%  Multiple decl_algorithm_optimization/2 facts per Name are allowed
+%  and recommended — workload authors can split optimizations by
+%  concern (cost-model knobs, cache tier, scan strategy, demand filter,
+%  etc.) into separate declarations for readability.
+%
+%  Their option lists are concatenated in declaration order using
+%  append/2 (shallow concat; NOT flatten/2, which would destructure
+%  nested option terms whose values are themselves lists).
+%
+%  When the merged list is later read via SWI-Prolog's option/3
+%  accessor, the first occurrence of any key wins. That's option/3's
+%  documented behaviour for repeated keys; the manifest itself does
+%  no de-duplication at concat time.
+%% =====================================================================
+
+decl_algorithm_optimization(Name, Opts) :-
+    must_be(atom, Name),
+    must_be(list, Opts),
+    assertz(registered_optimization(Name, Opts)).
+
+%% =====================================================================
+%! load_algorithm_manifest(+Options0, -Options) is det.
+%
+%  Merge the declared algorithm + optimization manifest into Options0.
+%  Caller-provided options win on key conflict (i.e. they appear
+%  earlier in the resulting list, so option/3's first-match read
+%  semantics prefer them).
+%
+%  Idempotent: a sentinel `algorithm_manifest_loaded(true)` marks an
+%  already-merged option list; calling load_algorithm_manifest/2 a
+%  second time on the same list is a no-op. This lets target
+%  adapters call it from multiple entry points (e.g.
+%  write_wam_haskell_project/3 and compile_wam_runtime_to_haskell/3,
+%  the latter of which is also a nested call from the former)
+%  without double-merging.
+%
+%  When no decl_algorithm/2 is in scope but decl_algorithm_optimization/2
+%  facts exist, those facts are orphan and ignored with a stderr
+%  warning. (We can't merge optimizations without an algorithm to
+%  attach them to.)
+%
+%  When no manifest data is present at all, returns Options0 unchanged
+%  (with the sentinel added).
+%% =====================================================================
+
+load_algorithm_manifest(Options0, Options) :-
+    must_be(list, Options0),
+    (   memberchk(algorithm_manifest_loaded(true), Options0)
+    ->  Options = Options0
+    ;   compute_merged_options(Options0, MergedNoSentinel),
+        Options = [algorithm_manifest_loaded(true) | MergedNoSentinel]
+    ).
+
+compute_merged_options(Options0, Merged) :-
+    (   registered_algorithm(Name, _AlgOpts)
+    ->  manifest_optimization_options(Name, ManifestOpts),
+        merge_caller_and_manifest_options(Options0, ManifestOpts, Merged)
+    ;   warn_orphan_optimizations,
+        Merged = Options0
+    ).
+
+%% =====================================================================
+%! merge_caller_and_manifest_options(+Caller, +Manifest, -Merged) is det.
+%
+%  Concatenate caller options with manifest options.
+%
+%  Implementation: `append(Caller, Manifest, Merged)`. Caller appears
+%  first, so when downstream code reads via option/3 (which returns
+%  the first matching key), caller values win on conflict.
+%
+%  This is intentionally not the SWI-Prolog library predicate
+%  `merge_options/3` — that one has different conventions around
+%  argument order and `option/3`'s default-handling semantics. We
+%  pick a clear name to avoid confusion at call sites.
+%% =====================================================================
+
+merge_caller_and_manifest_options(Caller, Manifest, Merged) :-
+    must_be(list, Caller),
+    must_be(list, Manifest),
+    append(Caller, Manifest, Merged).
+
+%% =====================================================================
+%! manifest_algorithm(-Name, -AlgorithmOpts) is semidet.
+%
+%  Read the currently declared algorithm. Fails if none is declared.
+%  Useful for target adapters that want to consult algorithm-level
+%  metadata (e.g. `kernel(P/N)` to know which predicate is the
+%  recursive kernel).
+%% =====================================================================
+
+manifest_algorithm(Name, Opts) :-
+    registered_algorithm(Name, Opts).
+
+%% =====================================================================
+%! manifest_optimization_options(+Name, -ConcatenatedOpts) is det.
+%
+%  Read all optimization options declared for Name, concatenated in
+%  declaration order. Returns the empty list if no optimizations are
+%  declared (this is not an error — an algorithm with no manifest
+%  optimizations runs with caller-only options).
+%% =====================================================================
+
+manifest_optimization_options(Name, ConcatenatedOpts) :-
+    must_be(atom, Name),
+    findall(OptList, registered_optimization(Name, OptList), AllOptLists),
+    append(AllOptLists, ConcatenatedOpts).
+
+%% =====================================================================
+%! reset_manifest is det.
+%
+%  Clear all registered manifest state. Used by tests for isolation
+%  between runs. Production code should not call this.
+%% =====================================================================
+
+reset_manifest :-
+    retractall(registered_algorithm(_, _)),
+    retractall(registered_optimization(_, _)).
+
+%% =====================================================================
+%% Internals
+%% =====================================================================
+
+warn_orphan_optimizations :-
+    findall(Name, registered_optimization(Name, _), Names),
+    sort(Names, Unique),
+    forall(member(Name, Unique),
+           format(user_error,
+                  '[algorithm_manifest] warning: decl_algorithm_optimization(~w, _) declared but no matching decl_algorithm(~w, _); optimization ignored~n',
+                  [Name, Name])).

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -61,6 +61,8 @@
              [select_cache_mode/2]).
 :- use_module('../core/cost_model',
              [recommend_access_pattern/5, read_mem_available_bytes/1]).
+:- use_module('../core/algorithm_manifest',
+             [load_algorithm_manifest/2]).
 
 % Phase 3: the real lowerability check and emission helpers live in the
 % wam_haskell_lowered_emitter module. We reexport so existing callers can
@@ -2571,11 +2573,17 @@ callForeign !ctx pred !sc = executeForeign ctx pred sc'.
 %  - Predicates.hs: compiled predicates
 %  - Main.hs: benchmark driver
 write_wam_haskell_project(Predicates, Options0, ProjectDir) :-
+    % Phase 0: merge any declared algorithm manifest into the option
+    % list BEFORE the resolvers run, so they see manifest-supplied
+    % values as defaults that caller options can still override.
+    % No-op (and idempotent — guarded by an internal sentinel) when no
+    % decl_algorithm/2 is in scope.
+    load_algorithm_manifest(Options0, OptionsM),
     % Resolve `use_lmdb(auto)` (if present) to a concrete true/false
     % BEFORE any downstream `option(use_lmdb(true), ...)` checks fire.
     % Auto consults ghc-pkg for the lmdb package + fact_count threshold;
     % see resolve_auto_use_lmdb/2.
-    resolve_auto_use_lmdb(Options0, Options1),
+    resolve_auto_use_lmdb(OptionsM, Options1),
     % Phase 2c: resolve cache_strategy(auto) into a concrete
     % demand_bfs_mode/1 via cost_model:recommend_access_pattern/5.
     % No-op when cache_strategy(auto) is absent.
@@ -3473,10 +3481,13 @@ build_predicate_loads(Predicates, Code) :-
 
 %% compile_wam_runtime_to_haskell(+Options, +DetectedKernels, -Code)
 compile_wam_runtime_to_haskell(Options0, DetectedKernels, Code) :-
+    % Phase 0: merge any declared algorithm manifest. Idempotent when
+    % the outer write_wam_haskell_project/3 already merged.
+    load_algorithm_manifest(Options0, OptionsM),
     % Phase 2c: resolve cache_strategy(auto) into a concrete
     % demand_bfs_mode/1 BEFORE downstream code consults it. No-op
     % when the option is absent.
-    resolve_auto_cache_strategy(Options0, Options1),
+    resolve_auto_cache_strategy(OptionsM, Options1),
     % Phase 2c+: resolve lmdb_cache_mode(auto) → concrete tier.
     % No-op when workload_locality/1 is absent.
     resolve_auto_lmdb_cache_mode(Options1, Options),

--- a/tests/core/test_algorithm_manifest.pl
+++ b/tests/core/test_algorithm_manifest.pl
@@ -1,0 +1,269 @@
+:- encoding(utf8).
+%% Test suite for algorithm_manifest.pl
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_algorithm_manifest.pl
+
+:- use_module('../../src/unifyweaver/core/algorithm_manifest').
+:- use_module(library(lists)).
+
+%% ========================================================================
+%% Test runner
+%% ========================================================================
+
+run_tests :-
+    format("~n========================================~n"),
+    format("Algorithm Manifest Tests~n"),
+    format("========================================~n~n"),
+    findall(Test, test(Test), Tests),
+    length(Tests, Total),
+    run_all(Tests, 0, Passed),
+    format("~n========================================~n"),
+    (   Passed =:= Total
+    ->  format("All ~w tests passed~n", [Total])
+    ;   Failed is Total - Passed,
+        format("~w of ~w tests FAILED~n", [Failed, Total]),
+        format("Tests FAILED~n"),
+        halt(1)
+    ),
+    format("========================================~n").
+
+run_all([], Passed, Passed).
+run_all([Test|Rest], Acc, Passed) :-
+    %% Each test isolates its own manifest state.
+    algorithm_manifest:reset_manifest,
+    (   catch(call(Test), Error,
+            (format("[FAIL] ~w: ~w~n", [Test, Error]), fail))
+    ->  Acc1 is Acc + 1,
+        run_all(Rest, Acc1, Passed)
+    ;   run_all(Rest, Acc, Passed)
+    ).
+
+pass(Name) :- format("[PASS] ~w~n", [Name]).
+fail_test(Name, Reason) :- format("[FAIL] ~w: ~w~n", [Name, Reason]), fail.
+
+%% ========================================================================
+%% Test declarations
+%% ========================================================================
+
+test(test_manifest_absent_options_unchanged).
+test(test_manifest_absent_adds_sentinel).
+test(test_manifest_present_merges_options).
+test(test_caller_wins_on_conflict).
+test(test_multiple_optimization_facts_concat).
+test(test_optimization_options_preserves_nested_structure).
+test(test_orphan_optimization_emits_warning_and_no_merge).
+test(test_duplicate_decl_algorithm_throws).
+test(test_decl_algorithm_validates_name_is_atom).
+test(test_decl_algorithm_validates_opts_is_list).
+test(test_load_manifest_is_idempotent).
+test(test_manifest_algorithm_accessor).
+test(test_manifest_optimization_options_accessor).
+test(test_reset_manifest_clears_state).
+
+%% ========================================================================
+%% Tests: manifest absent
+%% ========================================================================
+
+test_manifest_absent_options_unchanged :-
+    Test = 'manifest absent: caller options pass through (sans sentinel)',
+    Options0 = [foo(1), bar(2)],
+    algorithm_manifest:load_algorithm_manifest(Options0, Result),
+    %% Strip the sentinel for comparison
+    select(algorithm_manifest_loaded(true), Result, StrippedResult),
+    (   StrippedResult == Options0
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('expected ~w, got ~w', [Options0, StrippedResult]))
+    ).
+
+test_manifest_absent_adds_sentinel :-
+    Test = 'manifest absent: sentinel still added',
+    algorithm_manifest:load_algorithm_manifest([foo(1)], Result),
+    (   memberchk(algorithm_manifest_loaded(true), Result)
+    ->  pass(Test)
+    ;   fail_test(Test, 'sentinel missing from result')
+    ).
+
+%% ========================================================================
+%% Tests: manifest present
+%% ========================================================================
+
+test_manifest_present_merges_options :-
+    Test = 'manifest present: optimization options merge in',
+    algorithm_manifest:decl_algorithm(test_alg, [kernel(foo/2)]),
+    algorithm_manifest:decl_algorithm_optimization(test_alg, [
+        cache_strategy(auto),
+        working_set_fraction(0.001)
+    ]),
+    Options0 = [foo(1)],
+    algorithm_manifest:load_algorithm_manifest(Options0, Result),
+    (   memberchk(cache_strategy(auto), Result),
+        memberchk(working_set_fraction(0.001), Result),
+        memberchk(foo(1), Result)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('merged options missing keys: ~w', [Result]))
+    ).
+
+test_caller_wins_on_conflict :-
+    Test = 'caller wins: caller option value precedes manifest value',
+    algorithm_manifest:decl_algorithm(test_alg, [kernel(foo/2)]),
+    algorithm_manifest:decl_algorithm_optimization(test_alg, [
+        cache_strategy(auto)
+    ]),
+    %% Caller specifies cache_strategy(manual); should win over manifest's auto.
+    Options0 = [cache_strategy(manual)],
+    algorithm_manifest:load_algorithm_manifest(Options0, Result),
+    %% option/3 returns first match
+    option(cache_strategy(Picked), Result),
+    (   Picked == manual
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('manifest beat caller: got ~w', [Picked]))
+    ).
+
+test_multiple_optimization_facts_concat :-
+    Test = 'multiple decl_algorithm_optimization/2 facts concatenate',
+    algorithm_manifest:decl_algorithm(test_alg, [kernel(foo/2)]),
+    algorithm_manifest:decl_algorithm_optimization(test_alg, [a(1), b(2)]),
+    algorithm_manifest:decl_algorithm_optimization(test_alg, [c(3), d(4)]),
+    algorithm_manifest:manifest_optimization_options(test_alg, Concat),
+    (   Concat == [a(1), b(2), c(3), d(4)]
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('expected [a(1),b(2),c(3),d(4)], got ~w', [Concat]))
+    ).
+
+test_optimization_options_preserves_nested_structure :-
+    %% Regression test for the flatten/2 trap. An option whose value
+    %% is itself a list (like tree_cost_function/2's parameters) must
+    %% survive the concat step intact.
+    Test = 'nested option terms survive manifest concat (no flatten)',
+    algorithm_manifest:decl_algorithm(test_alg, [kernel(foo/2)]),
+    algorithm_manifest:decl_algorithm_optimization(test_alg, [
+        tree_cost_function(flux, [iterations(1), parent_decay(0.5)])
+    ]),
+    algorithm_manifest:manifest_optimization_options(test_alg, Concat),
+    (   memberchk(tree_cost_function(flux, [iterations(1), parent_decay(0.5)]),
+                  Concat)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('nested params got flattened: ~w', [Concat]))
+    ).
+
+%% ========================================================================
+%% Tests: orphans and errors
+%% ========================================================================
+
+test_orphan_optimization_emits_warning_and_no_merge :-
+    %% Optimization declared but no matching algorithm. Should emit a
+    %% warning (we can't easily assert on stderr; just verify it
+    %% doesn't merge into the result).
+    Test = 'orphan optimization: no algorithm → ignored',
+    algorithm_manifest:decl_algorithm_optimization(orphaned_alg, [
+        cache_strategy(auto)
+    ]),
+    Options0 = [foo(1)],
+    algorithm_manifest:load_algorithm_manifest(Options0, Result),
+    (   \+ memberchk(cache_strategy(auto), Result),
+        memberchk(foo(1), Result)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('orphan optimization leaked in: ~w', [Result]))
+    ).
+
+test_duplicate_decl_algorithm_throws :-
+    Test = 'duplicate decl_algorithm/2 throws error',
+    algorithm_manifest:decl_algorithm(dup_alg, [kernel(a/1)]),
+    catch(
+        ( algorithm_manifest:decl_algorithm(dup_alg, [kernel(b/2)]),
+          Caught = no
+        ),
+        error(domain_error(unique_algorithm_decl, dup_alg), _),
+        Caught = yes
+    ),
+    (   Caught == yes
+    ->  pass(Test)
+    ;   fail_test(Test, 'duplicate decl_algorithm did not throw')
+    ).
+
+test_decl_algorithm_validates_name_is_atom :-
+    Test = 'decl_algorithm/2 rejects non-atom Name',
+    catch(
+        ( algorithm_manifest:decl_algorithm("not_an_atom", [foo(1)]),
+          Caught = no
+        ),
+        error(type_error(atom, _), _),
+        Caught = yes
+    ),
+    (   Caught == yes
+    ->  pass(Test)
+    ;   fail_test(Test, 'string Name was accepted')
+    ).
+
+test_decl_algorithm_validates_opts_is_list :-
+    Test = 'decl_algorithm/2 rejects non-list AlgorithmOpts',
+    catch(
+        ( algorithm_manifest:decl_algorithm(test_alg, not_a_list),
+          Caught = no
+        ),
+        error(type_error(list, _), _),
+        Caught = yes
+    ),
+    (   Caught == yes
+    ->  pass(Test)
+    ;   fail_test(Test, 'non-list Opts was accepted')
+    ).
+
+%% ========================================================================
+%% Tests: idempotency and accessors
+%% ========================================================================
+
+test_load_manifest_is_idempotent :-
+    Test = 'load_algorithm_manifest is idempotent (sentinel-driven)',
+    algorithm_manifest:decl_algorithm(test_alg, [kernel(foo/2)]),
+    algorithm_manifest:decl_algorithm_optimization(test_alg, [cache_strategy(auto)]),
+    Options0 = [caller_opt(x)],
+    algorithm_manifest:load_algorithm_manifest(Options0, Once),
+    algorithm_manifest:load_algorithm_manifest(Once, Twice),
+    (   Once == Twice
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('second call mutated: ~w vs ~w', [Once, Twice]))
+    ).
+
+test_manifest_algorithm_accessor :-
+    Test = 'manifest_algorithm/2 returns declared algorithm',
+    algorithm_manifest:decl_algorithm(my_alg, [kernel(foo/4), max_depth(7)]),
+    algorithm_manifest:manifest_algorithm(Name, Opts),
+    (   Name == my_alg,
+        memberchk(kernel(foo/4), Opts),
+        memberchk(max_depth(7), Opts)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('got name=~w opts=~w', [Name, Opts]))
+    ).
+
+test_manifest_optimization_options_accessor :-
+    Test = 'manifest_optimization_options/2 returns empty list for algorithm with no optimizations',
+    algorithm_manifest:decl_algorithm(bare_alg, [kernel(foo/2)]),
+    algorithm_manifest:manifest_optimization_options(bare_alg, Opts),
+    (   Opts == []
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('expected [], got ~w', [Opts]))
+    ).
+
+test_reset_manifest_clears_state :-
+    Test = 'reset_manifest/0 clears registered state',
+    algorithm_manifest:decl_algorithm(clear_alg, [kernel(foo/2)]),
+    algorithm_manifest:decl_algorithm_optimization(clear_alg, [foo(1)]),
+    algorithm_manifest:reset_manifest,
+    (   \+ algorithm_manifest:manifest_algorithm(_, _),
+        algorithm_manifest:manifest_optimization_options(clear_alg, [])
+    ->  pass(Test)
+    ;   fail_test(Test, 'state survived reset')
+    ).
+
+%% ========================================================================
+%% Helper
+%% ========================================================================
+
+format_atom(Format, Args, Atom) :-
+    format(string(S), Format, Args),
+    atom_string(Atom, S).
+format_atom(Format, Args) :-
+    format_atom(Format, Args, A),
+    A == A.


### PR DESCRIPTION
  ## Summary

  First implementation phase from `SCAN_STRATEGY_IMPLEMENTATION_PLAN.md`.
  Pure infrastructure — no new optimization ships. This is the
  abstraction the rest of the scan-strategy / cost-function /
  cost-model work will read from.

  ## Target-agnostic vs target-specific split

  Following the convention established by `core/cost_model.pl`:

  | layer | location | concern |
  | --- | --- | --- |
  | generic | `src/unifyweaver/core/algorithm_manifest.pl` | manifest API, merge semantics, validation — target-agnostic
   |
  | Haskell wiring | `src/unifyweaver/targets/wam_haskell_target.pl` | calls `load_algorithm_manifest/2` at the head of
  the codegen entry points |

  Any future target (Rust, Elixir, R, C#) calls the same generic
  helper — only the wiring is per-target.

  ## Workload API

  ```prolog
  :- use_module(library(algorithm_manifest)).
  :- decl_algorithm(effective_distance, [
         kernel(category_ancestor/4),
         seeds(article/1),
         roots(root_category/1),
         max_depth(10),
         dimension_n(5)
     ]).
  :- decl_algorithm_optimization(effective_distance, [
         cache_strategy(auto),
         working_set_fraction(0.001)
     ]).
  ```
  Merge semantics

  Caller-provided options precede manifest options in the merged
  list. Downstream code reads via option/3, which has first-match
  semantics on repeated keys — so caller values win on conflict.

  Multiple decl_algorithm_optimization/2 facts per algorithm are
  allowed (split by concern). Their option lists concatenate via
  append/2 (shallow concat — not flatten/2, which would
  destructure nested option terms like
  tree_cost_function(flux, [iterations(1), parent_decay(0.5)])).

  Idempotency

  load_algorithm_manifest/2 marks merged options with a sentinel
  algorithm_manifest_loaded(true). Calling it twice on the same
  list is a no-op. This makes the helper safe to call from both
  write_wam_haskell_project/3 and the nested
  compile_wam_runtime_to_haskell/3 without double-merging.

  Validation

  - decl_algorithm/2 enforces at-most-one-per-Name across files
  - Type checks on Name (atom) and Opts (list)
  - Orphan optimizations (no matching algorithm) warn + ignore
  - Kernel-existence check deferred to target adapter (future P0
  follow-up — the adapter has the predicate list)

  Tests

  14 unit tests in tests/core/test_algorithm_manifest.pl.
  14/14 pass. Includes:

  - Manifest absent → no-op (with sentinel)
  - Manifest present → merge happens
  - Caller-wins on key conflict
  - Multiple optimization facts concatenate in order
  - Nested option terms survive (regression for the flatten/2 trap from PR #2023's review)
  - Orphan optimization warns + isn't merged
  - Duplicate decl_algorithm throws domain_error
  - Type checks on Name and Opts
  - Idempotency via sentinel

  Regression check

  - tests/core/test_algorithm_manifest.pl — 14/14 pass (new)
  - tests/test_wam_haskell_target.pl — 167/167 pass (no regression)
  - tests/core/test_cost_model.pl — 21/21 pass (no regression)

  The manifest helper is a no-op for workloads that don't declare
  an algorithm — existing caller-options paths are byte-for-byte
  unchanged.

  Files

  - src/unifyweaver/core/algorithm_manifest.pl (227 lines, new)
  - tests/core/test_algorithm_manifest.pl (269 lines, new)
  - src/unifyweaver/targets/wam_haskell_target.pl (+13, -2)

  What's next

  P1 (pluggable cost-function slot) can land in parallel — it
  depends on P0 but doesn't conflict. P2 (at-scale validation
  re-ingest) is measurement-only and can happen any time.

  Refs

  - docs/design/ALGORITHM_MANIFEST_SPECIFICATION.md (spec)
  - docs/design/SCAN_STRATEGY_IMPLEMENTATION_PLAN.md (P0 deliverables)
  - PR #2023 review feedback (the flatten/2 trap was a reviewer catch)