### PR TITLE
feat(core+haskell): pluggable cost-function strategy slot (P1)

### DIFF
--- a/src/unifyweaver/core/cost_function.pl
+++ b/src/unifyweaver/core/cost_function.pl
@@ -1,0 +1,210 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% cost_function.pl — Target-agnostic registry + validator for the
+% pluggable cost-function strategy slot.
+%
+% Cost functions score nodes for relevance during warm-build's tree
+% construction (see SCAN_STRATEGY_SPECIFICATION.md). Three are
+% registered:
+%
+%   - hop_distance         — BFS distance from the nearest endpoint;
+%                            cheap, no per-graph tuning, real
+%                            implementation in P1.
+%   - flux                 — branching-factor-aware decay from
+%                            endpoints with separate parent/child
+%                            legs; panic stub in P1, real in P3+.
+%   - semantic_similarity  — dot-product against a query embedding;
+%                            panic stub in P1, requires embeddings to
+%                            be useful.
+%
+% Each cost function has a parameter schema and a defaults list. The
+% target adapter (e.g. wam_haskell_target.pl) consults this module to
+% validate the workload's tree_cost_function/2 declaration, fill
+% defaults, and then emits target-specific code (the Haskell CostFn
+% record for the WAM-Haskell target; future targets will emit their
+% own equivalents).
+%
+% This module is target-agnostic. It does NOT emit code — that's the
+% target adapter's job.
+
+:- module(cost_function, [
+    %% Registry
+    cost_function_name/1,                  % ?Name
+    cost_function_param_schema/2,          % +Name, -Schema
+
+    %% Validation
+    validate_cost_function/1,              % +Term — throws on invalid
+    is_cost_function_term/1,               % +Term — semidet
+
+    %% Defaults
+    cost_function_default_params/2,        % +Name, -DefaultParams
+    cost_function_with_defaults/2          % +Term0, -Term1
+]).
+
+:- use_module(library(error), [must_be/2]).
+:- use_module(library(lists)).
+
+%% =====================================================================
+%% Registry
+%% =====================================================================
+%
+% Each schema entry is `param_spec(Key, Type, Optionality)` where
+%   - Key is the param-term functor (atom)
+%   - Type is integer, positive_integer, float, or atom
+%   - Optionality is `required` or `default(Value)`
+%
+% Adding a new cost function: append a new cost_function_entry/2 clause
+% with its param specs. Adding a new param to an existing function:
+% extend its schema list.
+
+cost_function_entry(hop_distance, [
+    param_spec(max_hops, positive_integer, default(5))
+]).
+
+cost_function_entry(flux, [
+    param_spec(iterations,   positive_integer, default(1)),
+    param_spec(parent_decay, float,            default(0.5)),
+    param_spec(child_decay,  float,            default(0.3)),
+    param_spec(flux_merge,   atom,             default(sum))
+]).
+
+cost_function_entry(semantic_similarity, [
+    param_spec(dim,            positive_integer, default(128)),
+    param_spec(embedding_path, atom,             required)
+]).
+
+%% =====================================================================
+%! cost_function_name(?Name) is nondet.
+%% =====================================================================
+
+cost_function_name(Name) :-
+    cost_function_entry(Name, _).
+
+%% =====================================================================
+%! cost_function_param_schema(+Name, -Schema) is det.
+%% =====================================================================
+
+cost_function_param_schema(Name, Schema) :-
+    must_be(atom, Name),
+    (   cost_function_entry(Name, Schema)
+    ->  true
+    ;   throw(error(domain_error(cost_function_name, Name),
+                    context(cost_function_param_schema/2,
+                            'no such cost function registered')))
+    ).
+
+%% =====================================================================
+%! is_cost_function_term(+Term) is semidet.
+%
+%  Shape check only — does NOT validate parameter contents.
+%% =====================================================================
+
+is_cost_function_term(tree_cost_function(Name, Params)) :-
+    atom(Name),
+    is_list(Params),
+    cost_function_entry(Name, _).
+
+%% =====================================================================
+%! validate_cost_function(+Term) is det.
+%
+%  Throws if Term is not a valid `tree_cost_function(Name, Params)`:
+%
+%    - Term must have the shape tree_cost_function(Name, Params)
+%    - Name must be a registered cost function
+%    - Params must be a list
+%    - Each schema entry marked `required` must be present in Params
+%    - Each provided param must match its schema type
+%
+%  Unknown param keys (not in the schema) are silently accepted —
+%  future-compat for newer-param-on-older-codegen flow.
+%% =====================================================================
+
+validate_cost_function(Term) :-
+    (   nonvar(Term),
+        Term = tree_cost_function(Name, Params)
+    ->  true
+    ;   throw(error(domain_error(cost_function_term, Term),
+                    context(validate_cost_function/1,
+                            'expected tree_cost_function(Name, Params)')))
+    ),
+    must_be(atom, Name),
+    must_be(list, Params),
+    cost_function_param_schema(Name, Schema),
+    validate_required_params(Schema, Params, Name),
+    validate_param_types(Schema, Params, Name).
+
+validate_required_params([], _, _).
+validate_required_params([param_spec(Key, _Type, required) | Rest], Params, Name) :-
+    !,
+    (   provided_param_key(Key, Params)
+    ->  validate_required_params(Rest, Params, Name)
+    ;   throw(error(domain_error(required_param, Key),
+                    context(validate_cost_function/1,
+                            cost_function_missing_required(Name, Key))))
+    ).
+validate_required_params([_ | Rest], Params, Name) :-
+    validate_required_params(Rest, Params, Name).
+
+provided_param_key(Key, Params) :-
+    member(Term, Params),
+    nonvar(Term),
+    functor(Term, Key, 1).
+
+validate_param_types([], _, _).
+validate_param_types([param_spec(Key, Type, _) | Rest], Params, Name) :-
+    Probe =.. [Key, Value],
+    (   member(Probe, Params)
+    ->  validate_param_type(Type, Value, Key, Name)
+    ;   true
+    ),
+    validate_param_types(Rest, Params, Name).
+
+validate_param_type(integer,          V, _, _) :- integer(V), !.
+validate_param_type(positive_integer, V, _, _) :- integer(V), V > 0, !.
+validate_param_type(float,            V, _, _) :- number(V), !.
+validate_param_type(atom,             V, _, _) :- atom(V), !.
+validate_param_type(Type, Value, Key, Name) :-
+    throw(error(type_error(Type, Value),
+                context(validate_cost_function/1,
+                        cost_function_param(Name, Key)))).
+
+%% =====================================================================
+%! cost_function_default_params(+Name, -Defaults) is det.
+%
+%  Default-bearing params from Name's schema as an option list.
+%  Required-without-default entries are omitted.
+%% =====================================================================
+
+cost_function_default_params(Name, Defaults) :-
+    cost_function_param_schema(Name, Schema),
+    findall(Term,
+            (member(param_spec(Key, _Type, default(Value)), Schema),
+             Term =.. [Key, Value]),
+            Defaults).
+
+%% =====================================================================
+%! cost_function_with_defaults(+Term0, -Term1) is det.
+%
+%  Fill in missing optional parameters with their defaults. Caller-
+%  provided params are kept (no override). Validates Term0 first.
+%% =====================================================================
+
+cost_function_with_defaults(tree_cost_function(Name, ProvidedParams),
+                            tree_cost_function(Name, FullParams)) :-
+    validate_cost_function(tree_cost_function(Name, ProvidedParams)),
+    cost_function_default_params(Name, Defaults),
+    %% Caller-provided params win — they come first in the concat.
+    append(ProvidedParams, Defaults, Combined),
+    %% De-duplicate by functor name so the output doesn't carry both.
+    dedupe_by_functor(Combined, FullParams).
+
+dedupe_by_functor([], []).
+dedupe_by_functor([T | Rest], [T | Out]) :-
+    functor(T, K, A),
+    exclude(same_functor(K, A), Rest, Filtered),
+    dedupe_by_functor(Filtered, Out).
+
+same_functor(K, A, T) :-
+    functor(T, K, A).

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -63,6 +63,8 @@
              [recommend_access_pattern/5, read_mem_available_bytes/1]).
 :- use_module('../core/algorithm_manifest',
              [load_algorithm_manifest/2]).
+:- use_module('../core/cost_function',
+             [validate_cost_function/1, cost_function_with_defaults/2]).
 
 % Phase 3: the real lowerability check and emission helpers live in the
 % wam_haskell_lowered_emitter module. We reexport so existing callers can
@@ -3508,6 +3510,14 @@ compile_wam_runtime_to_haskell(Options0, DetectedKernels, Code) :-
     ;   LmdbImports = "",
         LmdbFunctions = ""
     ),
+    % P1 (scan-strategy): conditional cost-function code.
+    % Emitted when option(tree_cost_function(Name, Params), Options) is
+    % present. Renders cost_function.hs.mustache and a `theCostFn`
+    % binding that selects the concrete CostFn constructor at codegen
+    % time. P3+ warm-build code will reference `theCostFn`; in P1 it's
+    % a top-level binding that GHC may flag as unused — accepted as
+    % a warning since the build still succeeds.
+    generate_cost_function_code(Options, CostFunctionCode),
     format(string(Code),
 '{-# LANGUAGE BangPatterns #-}
 module WamRuntime where
@@ -3703,7 +3713,9 @@ resolveCallInstrs labels foreignPreds = map resolve
       in SwitchOnConstantPc (IM.fromList [(extractId v, pc) | (v, label) <- Map.toList table,
                                                                Just pc <- [Map.lookup label labels]])
     resolve i = i
-', [LmdbImports, StepCode, BacktrackCode, RunCode, LmdbFunctions]).
+
+~w
+', [LmdbImports, StepCode, BacktrackCode, RunCode, LmdbFunctions, CostFunctionCode]).
 
 %% generate_wam_types_hs(-Code)
 generate_wam_types_hs(Code) :-
@@ -4553,6 +4565,64 @@ generate_lmdb_functions(Options, Code) :-
                      lmdb_cache_two_level=CacheTwoLevel,
                      lmdb_l2_capacity_bytes=L2CapacityBytes],
                     Code).
+
+%% generate_cost_function_code(+Options, -Code) is det.
+%
+%  Phase 1 (scan-strategy). When option(tree_cost_function(Name, Params),
+%  Options) is present, emit:
+%    1. The cost_function.hs.mustache template (CostFn record + concrete
+%       constructors hopDistanceCostFn / fluxCostFn / semanticCostFn).
+%    2. A `theCostFn :: CostFn` binding that selects the appropriate
+%       constructor with the chosen parameters.
+%
+%  The chosen tree_cost_function term is validated and filled with
+%  defaults via cost_function:cost_function_with_defaults/2. Bad terms
+%  (unknown name, wrong types, missing required params) throw at
+%  codegen time — no silent acceptance.
+%
+%  When the option is absent, returns the empty string. Existing
+%  workloads see no Haskell-level change.
+generate_cost_function_code(Options, Code) :-
+    (   option(tree_cost_function(Name, ProvidedParams), Options)
+    ->  validate_cost_function(tree_cost_function(Name, ProvidedParams)),
+        cost_function_with_defaults(
+            tree_cost_function(Name, ProvidedParams),
+            tree_cost_function(Name, FullParams)),
+        read_kernel_template('cost_function.hs.mustache', Template),
+        cost_function_haskell_constructor(Name, FullParams, ConstructorExpr),
+        format(string(Code),
+'-- ==================================================================
+-- Cost-function strategy slot (scan-strategy P1).
+-- ==================================================================
+
+~w
+
+-- | Cost function selected at codegen time from
+-- tree_cost_function(~w, ...) in workload options. P3+ warm-build
+-- consumes this to rank candidate nodes during tree construction.
+theCostFn :: CostFn
+theCostFn = ~w
+',                  [Template, Name, ConstructorExpr])
+    ;   Code = ""
+    ).
+
+%% cost_function_haskell_constructor(+Name, +Params, -Expr)
+%
+%  Map a (validated, defaults-filled) tree_cost_function/2 term into
+%  the Haskell expression that constructs the corresponding CostFn.
+cost_function_haskell_constructor(hop_distance, Params, Expr) :- !,
+    option(max_hops(MaxHops), Params),
+    format(string(Expr), 'hopDistanceCostFn ~d', [MaxHops]).
+cost_function_haskell_constructor(flux, Params, Expr) :- !,
+    option(parent_decay(PD), Params),
+    option(child_decay(CD), Params),
+    %% Third arg is currently a placeholder for the flux_merge mode;
+    %% the panic stub ignores it. P3+ will define a sensible encoding.
+    format(string(Expr), 'fluxCostFn ~w ~w 0.0', [PD, CD]).
+cost_function_haskell_constructor(semantic_similarity, Params, Expr) :- !,
+    option(dim(Dim), Params),
+    option(embedding_path(Path), Params),
+    format(string(Expr), 'semanticCostFn ~d "~w"', [Dim, Path]).
 
 %% maybe_parallelize_instrs(+PredIndicator, +Options, +InstrExprs0, -InstrExprs)
 %  Rewrite TryMeElse → ParTryMeElse etc. when the predicate certifies

--- a/templates/targets/haskell_wam/cost_function.hs.mustache
+++ b/templates/targets/haskell_wam/cost_function.hs.mustache
@@ -1,0 +1,86 @@
+-- | Pluggable cost-function strategy slot for warm-build node ranking.
+-- See docs/design/SCAN_STRATEGY_SPECIFICATION.md for the design.
+--
+-- Three concrete cost functions are defined:
+--
+--   hopDistanceCostFn   — real implementation; ranks nodes by their
+--                         BFS distance from the nearest endpoint.
+--                         Cheap, no per-graph tuning, ships in P1.
+--   fluxCostFn          — panic stub (P3+); will become flux scoring
+--                         with separate parent/child decay.
+--   semanticCostFn      — panic stub (embeddings pending).
+--
+-- The CostFn record itself has two fields:
+--
+--   cfInitial — initial score for an endpoint node (seed/root).
+--   cfRelax   — one round of score propagation: given a node, its
+--               neighbours, and the current score map, return the
+--               updated map.
+--
+-- The score of a node IS its value in the ScoreMap. There is no
+-- separate "compute score from node" function — that would require
+-- different signatures for flux (needs the global score map) vs hop
+-- distance (doesn't). Keeping cfRelax as the sole score-producing
+-- operation keeps the abstraction uniform.
+
+type NodeId   = Int
+type Cost     = Double
+type ScoreMap = IM.IntMap Cost
+
+data CostFn = CostFn
+  { cfInitial :: !(NodeId -> Cost)
+  , cfRelax   :: !(NodeId -> [NodeId] -> ScoreMap -> ScoreMap)
+  }
+
+-- | Hop-distance cost function: real implementation.
+--
+-- An endpoint scores `fromIntegral maxHops` (the cap). Each
+-- propagation step decreases the score by 1 per hop. Nodes more
+-- than maxHops away never get added.
+--
+-- This is the safe default: cheap to compute, no per-graph tuning
+-- needed, gives a useful (if coarse) ranking for any graph.
+hopDistanceCostFn :: Int -> CostFn
+hopDistanceCostFn maxHops = CostFn
+  { cfInitial = \_n -> fromIntegral maxHops
+  , cfRelax   = \u neighbours sm ->
+      case IM.lookup u sm of
+        Nothing      -> sm
+        Just costU
+          | costU <= 1 -> sm
+          | otherwise  ->
+              let costV = costU - 1
+                  relax_one acc v =
+                    case IM.lookup v acc of
+                      Just existing | existing >= costV -> acc
+                      _ -> IM.insert v costV acc
+              in foldl relax_one sm neighbours
+  }
+
+-- | Flux cost function — PANIC STUB.
+--
+-- Will become: flux(n) = parent_flux(n) + child_flux(n)
+-- where each leg decays by (decay / branching_factor)^hops from the
+-- nearest endpoint. See SCAN_STRATEGY_SPECIFICATION.md.
+--
+-- Implementation pending Phase 2.5 / scan-strategy P3+.
+fluxCostFn :: Double -> Double -> Double -> CostFn
+fluxCostFn _parentDecay _childDecay _ignored = CostFn
+  { cfInitial = \_n ->
+      error "Flux cost function not yet implemented (pending Phase 2.5/P3+)"
+  , cfRelax   = \_u _ns _sm ->
+      error "Flux cost function not yet implemented (pending Phase 2.5/P3+)"
+  }
+
+-- | Semantic-similarity cost function — PANIC STUB.
+--
+-- Will become: score = cosine_similarity(embedding(n), query_embedding)
+-- where embeddings are loaded from `embedding_path`. Implementation
+-- pending availability of an embeddings table at our scale.
+semanticCostFn :: Int -> FilePath -> CostFn
+semanticCostFn _dim _path = CostFn
+  { cfInitial = \_n ->
+      error "Semantic similarity cost function not yet implemented (embeddings pending)"
+  , cfRelax   = \_u _ns _sm ->
+      error "Semantic similarity cost function not yet implemented (embeddings pending)"
+  }

--- a/tests/core/test_cost_function.pl
+++ b/tests/core/test_cost_function.pl
@@ -1,0 +1,377 @@
+:- encoding(utf8).
+%% Test suite for cost_function.pl
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_cost_function.pl
+
+:- use_module('../../src/unifyweaver/core/cost_function').
+:- use_module(library(lists)).
+
+%% ========================================================================
+%% Test runner
+%% ========================================================================
+
+run_tests :-
+    format("~n========================================~n"),
+    format("Cost Function Tests~n"),
+    format("========================================~n~n"),
+    findall(Test, test(Test), Tests),
+    length(Tests, Total),
+    run_all(Tests, 0, Passed),
+    format("~n========================================~n"),
+    (   Passed =:= Total
+    ->  format("All ~w tests passed~n", [Total])
+    ;   Failed is Total - Passed,
+        format("~w of ~w tests FAILED~n", [Failed, Total]),
+        format("Tests FAILED~n"),
+        halt(1)
+    ),
+    format("========================================~n").
+
+run_all([], Passed, Passed).
+run_all([Test|Rest], Acc, Passed) :-
+    (   catch(call(Test), Error,
+            (format("[FAIL] ~w: ~w~n", [Test, Error]), fail))
+    ->  Acc1 is Acc + 1,
+        run_all(Rest, Acc1, Passed)
+    ;   run_all(Rest, Acc, Passed)
+    ).
+
+pass(Name) :- format("[PASS] ~w~n", [Name]).
+fail_test(Name, Reason) :- format("[FAIL] ~w: ~w~n", [Name, Reason]), fail.
+
+%% ========================================================================
+%% Tests
+%% ========================================================================
+
+test(test_registry_has_three_entries).
+test(test_hop_distance_registered).
+test(test_flux_registered).
+test(test_semantic_similarity_registered).
+test(test_unregistered_name_throws).
+
+test(test_validate_hop_distance_with_max_hops).
+test(test_validate_hop_distance_without_params).
+test(test_validate_flux_with_params).
+test(test_validate_flux_without_params).
+test(test_validate_semantic_requires_embedding_path).
+test(test_validate_rejects_wrong_shape).
+test(test_validate_rejects_unregistered_name).
+test(test_validate_rejects_wrong_param_type).
+test(test_validate_accepts_unknown_param_keys).
+
+test(test_defaults_hop_distance).
+test(test_defaults_flux).
+test(test_defaults_semantic_omits_required).
+
+test(test_with_defaults_fills_missing).
+test(test_with_defaults_preserves_caller_values).
+test(test_with_defaults_validates_first).
+
+test(test_is_cost_function_term_accepts_valid).
+test(test_is_cost_function_term_rejects_invalid).
+
+%% ========================================================================
+%% Registry tests
+%% ========================================================================
+
+test_registry_has_three_entries :-
+    Test = 'registry has exactly three entries',
+    findall(N, cost_function:cost_function_name(N), Names),
+    length(Names, 3),
+    (   sort(Names, [flux, hop_distance, semantic_similarity])
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('got ~w', [Names]))
+    ).
+
+test_hop_distance_registered :-
+    Test = 'hop_distance is in the registry',
+    cost_function:cost_function_param_schema(hop_distance, Schema),
+    (   memberchk(param_spec(max_hops, positive_integer, default(5)), Schema)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('schema=~w', [Schema]))
+    ).
+
+test_flux_registered :-
+    Test = 'flux is in the registry',
+    cost_function:cost_function_param_schema(flux, Schema),
+    (   memberchk(param_spec(iterations,   positive_integer, default(1)), Schema),
+        memberchk(param_spec(parent_decay, float, default(0.5)), Schema),
+        memberchk(param_spec(child_decay,  float, default(0.3)), Schema),
+        memberchk(param_spec(flux_merge,   atom, default(sum)), Schema)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('schema=~w', [Schema]))
+    ).
+
+test_semantic_similarity_registered :-
+    Test = 'semantic_similarity has embedding_path as required',
+    cost_function:cost_function_param_schema(semantic_similarity, Schema),
+    (   memberchk(param_spec(embedding_path, atom, required), Schema),
+        memberchk(param_spec(dim, positive_integer, default(128)), Schema)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('schema=~w', [Schema]))
+    ).
+
+test_unregistered_name_throws :-
+    Test = 'cost_function_param_schema throws for unknown name',
+    catch(
+        ( cost_function:cost_function_param_schema(no_such_function, _),
+          Caught = no
+        ),
+        error(domain_error(cost_function_name, no_such_function), _),
+        Caught = yes
+    ),
+    (   Caught == yes
+    ->  pass(Test)
+    ;   fail_test(Test, 'unknown name did not throw')
+    ).
+
+%% ========================================================================
+%% Validation tests
+%% ========================================================================
+
+test_validate_hop_distance_with_max_hops :-
+    Test = 'validate_cost_function accepts hop_distance with max_hops',
+    catch(
+        ( cost_function:validate_cost_function(
+              tree_cost_function(hop_distance, [max_hops(10)])),
+          Result = ok
+        ),
+        _, Result = error
+    ),
+    (   Result == ok
+    ->  pass(Test)
+    ;   fail_test(Test, 'rejected valid hop_distance')
+    ).
+
+test_validate_hop_distance_without_params :-
+    Test = 'validate_cost_function accepts hop_distance with empty params',
+    catch(
+        ( cost_function:validate_cost_function(
+              tree_cost_function(hop_distance, [])),
+          Result = ok
+        ),
+        _, Result = error
+    ),
+    (   Result == ok
+    ->  pass(Test)
+    ;   fail_test(Test, 'rejected empty params for hop_distance')
+    ).
+
+test_validate_flux_with_params :-
+    Test = 'validate_cost_function accepts flux with all params',
+    catch(
+        ( cost_function:validate_cost_function(
+              tree_cost_function(flux, [
+                  iterations(2),
+                  parent_decay(0.6),
+                  child_decay(0.4),
+                  flux_merge(max)
+              ])),
+          Result = ok
+        ),
+        _, Result = error
+    ),
+    (   Result == ok
+    ->  pass(Test)
+    ;   fail_test(Test, 'rejected valid flux')
+    ).
+
+test_validate_flux_without_params :-
+    Test = 'validate_cost_function accepts flux with no params (all default)',
+    catch(
+        ( cost_function:validate_cost_function(
+              tree_cost_function(flux, [])),
+          Result = ok
+        ),
+        _, Result = error
+    ),
+    (   Result == ok
+    ->  pass(Test)
+    ;   fail_test(Test, 'rejected empty params for flux')
+    ).
+
+test_validate_semantic_requires_embedding_path :-
+    Test = 'validate_cost_function rejects semantic_similarity missing embedding_path',
+    catch(
+        ( cost_function:validate_cost_function(
+              tree_cost_function(semantic_similarity, [dim(64)])),
+          Caught = no
+        ),
+        error(domain_error(required_param, embedding_path), _),
+        Caught = yes
+    ),
+    (   Caught == yes
+    ->  pass(Test)
+    ;   fail_test(Test, 'missing embedding_path did not throw')
+    ).
+
+test_validate_rejects_wrong_shape :-
+    Test = 'validate_cost_function rejects non-tree_cost_function term',
+    catch(
+        ( cost_function:validate_cost_function(some_other_term),
+          Caught = no
+        ),
+        error(domain_error(cost_function_term, _), _),
+        Caught = yes
+    ),
+    (   Caught == yes
+    ->  pass(Test)
+    ;   fail_test(Test, 'wrong shape was accepted')
+    ).
+
+test_validate_rejects_unregistered_name :-
+    Test = 'validate_cost_function rejects unregistered name',
+    catch(
+        ( cost_function:validate_cost_function(
+              tree_cost_function(bogus_function, [])),
+          Caught = no
+        ),
+        error(domain_error(cost_function_name, bogus_function), _),
+        Caught = yes
+    ),
+    (   Caught == yes
+    ->  pass(Test)
+    ;   fail_test(Test, 'unregistered name was accepted')
+    ).
+
+test_validate_rejects_wrong_param_type :-
+    Test = 'validate_cost_function rejects wrong param type',
+    catch(
+        ( cost_function:validate_cost_function(
+              tree_cost_function(hop_distance, [max_hops(not_an_integer)])),
+          Caught = no
+        ),
+        error(type_error(positive_integer, not_an_integer), _),
+        Caught = yes
+    ),
+    (   Caught == yes
+    ->  pass(Test)
+    ;   fail_test(Test, 'wrong param type was accepted')
+    ).
+
+test_validate_accepts_unknown_param_keys :-
+    %% Unknown keys are silently accepted (future-compat).
+    Test = 'validate_cost_function accepts unknown param keys',
+    catch(
+        ( cost_function:validate_cost_function(
+              tree_cost_function(hop_distance, [
+                  max_hops(5),
+                  future_param(42)
+              ])),
+          Result = ok
+        ),
+        _, Result = error
+    ),
+    (   Result == ok
+    ->  pass(Test)
+    ;   fail_test(Test, 'unknown param key was rejected')
+    ).
+
+%% ========================================================================
+%% Defaults tests
+%% ========================================================================
+
+test_defaults_hop_distance :-
+    Test = 'cost_function_default_params returns hop_distance defaults',
+    cost_function:cost_function_default_params(hop_distance, Defaults),
+    (   memberchk(max_hops(5), Defaults)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('got ~w', [Defaults]))
+    ).
+
+test_defaults_flux :-
+    Test = 'cost_function_default_params returns flux defaults',
+    cost_function:cost_function_default_params(flux, Defaults),
+    (   memberchk(iterations(1), Defaults),
+        memberchk(parent_decay(0.5), Defaults),
+        memberchk(child_decay(0.3), Defaults),
+        memberchk(flux_merge(sum), Defaults)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('got ~w', [Defaults]))
+    ).
+
+test_defaults_semantic_omits_required :-
+    Test = 'cost_function_default_params omits required-no-default params',
+    cost_function:cost_function_default_params(semantic_similarity, Defaults),
+    (   memberchk(dim(128), Defaults),
+        \+ memberchk(embedding_path(_), Defaults)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('got ~w', [Defaults]))
+    ).
+
+%% ========================================================================
+%% with_defaults tests
+%% ========================================================================
+
+test_with_defaults_fills_missing :-
+    Test = 'cost_function_with_defaults fills missing params',
+    cost_function:cost_function_with_defaults(
+        tree_cost_function(flux, [iterations(3)]),
+        tree_cost_function(flux, FullParams)),
+    (   memberchk(iterations(3), FullParams),
+        memberchk(parent_decay(0.5), FullParams),
+        memberchk(child_decay(0.3), FullParams),
+        memberchk(flux_merge(sum), FullParams)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('got ~w', [FullParams]))
+    ).
+
+test_with_defaults_preserves_caller_values :-
+    %% Caller-provided value should NOT get overwritten by default.
+    Test = 'cost_function_with_defaults preserves caller values',
+    cost_function:cost_function_with_defaults(
+        tree_cost_function(flux, [parent_decay(0.9)]),
+        tree_cost_function(flux, FullParams)),
+    (   memberchk(parent_decay(0.9), FullParams),
+        \+ memberchk(parent_decay(0.5), FullParams)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom('caller value lost: ~w', [FullParams]))
+    ).
+
+test_with_defaults_validates_first :-
+    Test = 'cost_function_with_defaults validates before filling',
+    catch(
+        ( cost_function:cost_function_with_defaults(
+              tree_cost_function(hop_distance, [max_hops(bogus)]),
+              _),
+          Caught = no
+        ),
+        error(type_error(positive_integer, bogus), _),
+        Caught = yes
+    ),
+    (   Caught == yes
+    ->  pass(Test)
+    ;   fail_test(Test, 'invalid input not caught')
+    ).
+
+%% ========================================================================
+%% is_cost_function_term tests
+%% ========================================================================
+
+test_is_cost_function_term_accepts_valid :-
+    Test = 'is_cost_function_term accepts valid shape',
+    (   cost_function:is_cost_function_term(
+            tree_cost_function(hop_distance, [max_hops(5)]))
+    ->  pass(Test)
+    ;   fail_test(Test, 'rejected valid term')
+    ).
+
+test_is_cost_function_term_rejects_invalid :-
+    Test = 'is_cost_function_term rejects wrong shape',
+    (   \+ cost_function:is_cost_function_term(some_other_term),
+        \+ cost_function:is_cost_function_term(tree_cost_function(bogus_name, []))
+    ->  pass(Test)
+    ;   fail_test(Test, 'accepted invalid term')
+    ).
+
+%% ========================================================================
+%% Helper
+%% ========================================================================
+
+format_atom(Format, Args, Atom) :-
+    format(string(S), Format, Args),
+    atom_string(Atom, S).
+format_atom(Format, Args) :-
+    format_atom(Format, Args, A),
+    A == A.

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -2176,6 +2176,86 @@ test_lmdb_cache_mode_memory_budget_floor_override :-
     ;   fail_test(Test, 'custom cache_tier_floor_bytes did not raise the threshold')
     ).
 
+%% =================================================================
+%% Scan-strategy P1: tree_cost_function emission
+%% =================================================================
+
+test_cost_function_absent_emits_nothing :-
+    Test = 'WAM-Haskell: tree_cost_function absent → no CostFn code',
+    (   compile_wam_runtime_to_haskell([], [], Code),
+        atom_string(Code, S),
+        \+ sub_string(S, _, _, _, "CostFn"),
+        \+ sub_string(S, _, _, _, "theCostFn")
+    ->  pass(Test)
+    ;   fail_test(Test, 'CostFn code emitted without tree_cost_function option')
+    ).
+
+test_cost_function_hop_distance_emits_constructor :-
+    Test = 'WAM-Haskell: tree_cost_function(hop_distance, ...) → hopDistanceCostFn',
+    (   compile_wam_runtime_to_haskell(
+            [tree_cost_function(hop_distance, [max_hops(10)])], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "data CostFn"),
+        sub_string(S, _, _, _, "hopDistanceCostFn"),
+        sub_string(S, _, _, _, "theCostFn = hopDistanceCostFn 10")
+    ->  pass(Test)
+    ;   fail_test(Test, 'hop_distance constructor not emitted correctly')
+    ).
+
+test_cost_function_hop_distance_fills_default :-
+    Test = 'WAM-Haskell: tree_cost_function(hop_distance, []) → uses default max_hops=5',
+    (   compile_wam_runtime_to_haskell(
+            [tree_cost_function(hop_distance, [])], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "theCostFn = hopDistanceCostFn 5")
+    ->  pass(Test)
+    ;   fail_test(Test, 'default max_hops=5 not filled in')
+    ).
+
+test_cost_function_flux_emits_panic_stub_constructor :-
+    Test = 'WAM-Haskell: tree_cost_function(flux, ...) → fluxCostFn (panic stub)',
+    (   compile_wam_runtime_to_haskell(
+            [tree_cost_function(flux, [parent_decay(0.7), child_decay(0.4)])], [],
+            Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "fluxCostFn"),
+        %% Verify the panic message is present, indicating the stub is wired
+        sub_string(S, _, _, _, "Flux cost function not yet implemented"),
+        sub_string(S, _, _, _, "theCostFn = fluxCostFn 0.7 0.4")
+    ->  pass(Test)
+    ;   fail_test(Test, 'flux constructor / panic stub not emitted correctly')
+    ).
+
+test_cost_function_unknown_name_throws :-
+    Test = 'WAM-Haskell: tree_cost_function with unregistered name throws at codegen',
+    catch(
+        ( compile_wam_runtime_to_haskell(
+              [tree_cost_function(bogus_function, [])], [], _),
+          Caught = no
+        ),
+        error(domain_error(cost_function_name, bogus_function), _),
+        Caught = yes
+    ),
+    (   Caught == yes
+    ->  pass(Test)
+    ;   fail_test(Test, 'unknown cost function did not throw')
+    ).
+
+test_cost_function_bad_param_type_throws :-
+    Test = 'WAM-Haskell: tree_cost_function with bad param type throws',
+    catch(
+        ( compile_wam_runtime_to_haskell(
+              [tree_cost_function(hop_distance, [max_hops(not_an_int)])], [], _),
+          Caught = no
+        ),
+        error(type_error(positive_integer, not_an_int), _),
+        Caught = yes
+    ),
+    (   Caught == yes
+    ->  pass(Test)
+    ;   fail_test(Test, 'bad param type did not throw')
+    ).
+
 test_b1_lmdb_dupsort_per_thread_cursor :-
     Test = 'B1: dupsort layout uses per-thread cursor cache',
     (   compile_wam_runtime_to_haskell(
@@ -2621,6 +2701,12 @@ run_tests :-
     test_lmdb_cache_mode_memory_budget_guard_fires,
     test_lmdb_cache_mode_memory_budget_guard_inactive_when_rfree_above_floor,
     test_lmdb_cache_mode_memory_budget_floor_override,
+    test_cost_function_absent_emits_nothing,
+    test_cost_function_hop_distance_emits_constructor,
+    test_cost_function_hop_distance_fills_default,
+    test_cost_function_flux_emits_panic_stub_constructor,
+    test_cost_function_unknown_name_throws,
+    test_cost_function_bad_param_type_throws,
     format('~n========================================~n'),
     (   test_failed
     ->  format('Tests FAILED~n'), halt(1)


### PR DESCRIPTION
## Summary

Second implementation phase from `SCAN_STRATEGY_IMPLEMENTATION_PLAN.md`. Introduces a pluggable cost-function strategy slot. P3+ warm-build will be the first real consumer; P1 just builds the abstraction and emits a `theCostFn` binding selected at codegen time.

**`hop_distance` is real this PR**; `flux` and `semantic_similarity` ship as panic stubs (preserve current behaviour pending P3+ / embeddings).

## Target-agnostic vs target-specific split

| layer | location | concern |
| --- | --- | --- |
| generic | `src/unifyweaver/core/cost_function.pl` | registry, schemas, validator, defaults |
| Haskell template | `templates/targets/haskell_wam/cost_function.hs.mustache` | `CostFn` record + concrete constructors |
| Haskell wiring | `src/unifyweaver/targets/wam_haskell_target.pl` | emits template + `theCostFn` binding |

Three cost functions are registered in `core/cost_function.pl`:

| name | status | params |
| --- | --- | --- |
| `hop_distance` | real (P1) | `max_hops(N)` (default 5) |
| `flux` | panic stub | `iterations`, `parent_decay`, `child_decay`, `flux_merge` |
| `semantic_similarity` | panic stub | `dim`, `embedding_path` (required) |

## CostFn abstraction

```haskell
data CostFn = CostFn
  { cfInitial :: !(NodeId -> Cost)
  , cfRelax   :: !(NodeId -> [NodeId] -> ScoreMap -> ScoreMap)
  }
```

The score of a node IS its value in the `ScoreMap`. No separate `cfScore` field — that would overlap with `cfRelax + cfInitial` and couldn't express flux (which needs the global `ScoreMap`). Per PR #2023 review #2 feedback.

## hop_distance is real

```haskell
hopDistanceCostFn :: Int -> CostFn
hopDistanceCostFn maxHops = CostFn
  { cfInitial = \_n -> fromIntegral maxHops
  , cfRelax   = \u neighbours sm ->
      case IM.lookup u sm of
        Nothing      -> sm
        Just costU
          | costU <= 1 -> sm
          | otherwise  ->
              let costV = costU - 1
                  relax_one acc v =
                    case IM.lookup v acc of
                      Just existing | existing >= costV -> acc
                      _ -> IM.insert v costV acc
              in foldl relax_one sm neighbours
  }
```

Cheap, no per-graph tuning needed. Workload authors who opt in via `tree_cost_function(hop_distance, [max_hops(N)])` get a usable CostFn.

## Workload API

In a workload's optimization manifest:

```prolog
:- decl_algorithm_optimization(my_alg, [
       tree_cost_function(hop_distance, [max_hops(7)])
   ]).
```

Or directly as a caller option:

```prolog
write_wam_haskell_project(Predicates,
    [tree_cost_function(flux, [parent_decay(0.7), child_decay(0.4)])],
    "/tmp/out").
```

## Tests

| suite | result | notes |
| --- | --- | --- |
| `tests/core/test_cost_function.pl` | 22 / 22 | new; registry, schemas, validators, defaults, type checks |
| `tests/test_wam_haskell_target.pl` | all pass | + 6 new codegen-emission tests |
| `tests/core/test_algorithm_manifest.pl` | 14 / 14 | unchanged (no regression from P0) |
| `tests/core/test_cost_model.pl` | 21 / 21 | unchanged |

## Codegen tests cover

- Absent `tree_cost_function` option produces no CostFn code (no-op for existing workloads).
- `hop_distance` with explicit `max_hops(N)` produces `hopDistanceCostFn N` in `theCostFn`.
- `hop_distance` with empty params fills default `max_hops=5`.
- `flux` produces `fluxCostFn` constructor and the panic message survives.
- Unregistered name throws `domain_error` at codegen.
- Bad param type throws `type_error` at codegen.

## Smoke build (deferred)

Full project build with `tree_cost_function` requires plumbing through the matrix bench's `resident` mode (the `use_hashmap` rewrite happens in `write_wam_haskell_project/3`, not `compile_wam_runtime_to_haskell/3`, so a standalone re-render misses it). The codegen tests confirm the right Haskell is emitted; full-build validation is the natural P3 deliverable when there's a real consumer of `theCostFn`.

## Files

| path | lines | role |
| --- | --- | --- |
| `src/unifyweaver/core/cost_function.pl` | +210 | new — registry, validators, defaults |
| `templates/targets/haskell_wam/cost_function.hs.mustache` | +86 | new — Haskell `CostFn` record + 3 constructors |
| `src/unifyweaver/targets/wam_haskell_target.pl` | +72 | wiring, codegen emission |
| `tests/core/test_cost_function.pl` | +377 | new — 22 unit tests |
| `tests/test_wam_haskell_target.pl` | +86 | + 6 codegen-emission tests |

## Refs

- `docs/design/SCAN_STRATEGY_SPECIFICATION.md` (cost-function slot)
- `docs/design/SCAN_STRATEGY_IMPLEMENTATION_PLAN.md` (P1 deliverables)
- PR #2023 review #2 shaped the `CostFn` redesign (no `cfScore`)

## What's next

- **P2** (at-scale validation re-ingest): measurement-only; can now validate `hop_distance` against `resident_cursor` baseline once warm-build lands.
- **P3** (warm-build + snapshot core): first real consumer of `theCostFn`. Will validate the full integration via cabal build.