### PR TITLE
feat(wam-cpp): environment frames (Y-reg isolation + cp threading) + PutConstant fix

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -807,6 +807,15 @@ struct TrailEntry {
     Value prev;
 };
 
+// Environment frame for permanent variables (Y-regs) and continuation
+// preservation. Allocate pushes one; Deallocate pops. Y-reg lookup goes
+// through env_stack.back().y_regs rather than the flat regs map, so two
+// nested calls that both use Y1 don''t clobber each other.
+struct EnvFrame {
+    std::size_t saved_cp = 0;
+    std::unordered_map<std::string, CellPtr> y_regs;
+};
+
 // Read/write mode for the most recent Get-/Put-Structure / Get-/Put-List.
 // Only one is "active" at a time — nested compounds restart the mode
 // when their own Get-/Put-Structure fires.
@@ -826,6 +835,7 @@ struct ChoicePoint {
     std::size_t cut_barrier;
     std::unordered_map<std::string, CellPtr> saved_regs;
     std::vector<ModeFrame> saved_mode_stack;
+    std::vector<EnvFrame> saved_env_stack;
 };
 
 // Aggregate scope opened by BeginAggregate. Backtrack() finalises the
@@ -844,6 +854,7 @@ struct AggregateFrame {
     std::size_t saved_cut_barrier = 0;
     std::unordered_map<std::string, CellPtr> saved_regs;
     std::vector<ModeFrame> saved_mode_stack;
+    std::vector<EnvFrame> saved_env_stack;
     std::vector<Value> acc;
 };
 
@@ -857,6 +868,9 @@ struct WamState {
     // Mode stack: Get-/Put-Structure / Get-/Put-List PUSH; Unify*/Set*
     // operate on top(); each frame auto-pops once its arity is filled.
     std::vector<ModeFrame> mode_stack;
+    // Environment stack: Allocate pushes (saving cp + giving fresh Y-regs),
+    // Deallocate pops (restoring cp). Y-reg lookup is scoped to top().
+    std::vector<EnvFrame> env_stack;
     std::size_t pc = 0;
     std::size_t cp = 0;
     std::size_t cut_barrier = 0;
@@ -945,7 +959,21 @@ static CellPtr make_cell(Value v = Value{}) {
     return std::make_shared<Cell>(std::move(v));
 }
 
+// Y-regs are scoped to the top env frame; A/X-regs use the flat map.
+static bool is_y_reg(const std::string& name) {
+    return !name.empty() && name[0] == \'Y\';
+}
+
 CellPtr WamState::get_cell(const std::string& name) {
+    if (is_y_reg(name)) {
+        if (env_stack.empty()) env_stack.emplace_back();
+        auto& y = env_stack.back().y_regs;
+        auto it = y.find(name);
+        if (it != y.end()) return it->second;
+        CellPtr c = make_cell(Value::Unbound("_U_" + name));
+        y[name] = c;
+        return c;
+    }
     auto it = regs.find(name);
     if (it != regs.end()) return it->second;
     CellPtr c = make_cell(Value::Unbound("_U_" + name));
@@ -954,16 +982,36 @@ CellPtr WamState::get_cell(const std::string& name) {
 }
 
 void WamState::set_cell(const std::string& name, CellPtr c) {
+    if (is_y_reg(name)) {
+        if (env_stack.empty()) env_stack.emplace_back();
+        env_stack.back().y_regs[name] = std::move(c);
+        return;
+    }
     regs[name] = std::move(c);
 }
 
 Value WamState::get_reg(const std::string& name) const {
+    if (is_y_reg(name)) {
+        if (env_stack.empty()) return Value{};
+        auto& y = env_stack.back().y_regs;
+        auto it = y.find(name);
+        if (it == y.end()) return Value{};
+        return *it->second;
+    }
     auto it = regs.find(name);
     if (it == regs.end()) return Value{};
     return *it->second;
 }
 
 void WamState::put_reg(const std::string& name, Value v) {
+    if (is_y_reg(name)) {
+        if (env_stack.empty()) env_stack.emplace_back();
+        auto& y = env_stack.back().y_regs;
+        auto it = y.find(name);
+        if (it == y.end()) y[name] = make_cell(std::move(v));
+        else               *it->second = std::move(v);
+        return;
+    }
     auto it = regs.find(name);
     if (it == regs.end()) regs[name] = make_cell(std::move(v));
     else                  *it->second = std::move(v);
@@ -1560,7 +1608,10 @@ bool WamState::step(const Instruction& instr) {
 
         // ---- Body construction -------------------------------------
         case Instruction::Op::PutConstant: {
-            put_reg(instr.a, instr.val);
+            // Must allocate a fresh cell, not mutate the existing one:
+            // any X-reg aliasing this register (e.g. via prior
+            // get_variable) must NOT see the new value.
+            set_cell(instr.a, make_cell(instr.val));
             pc += 1; return true;
         }
         case Instruction::Op::PutVariable: {
@@ -1660,10 +1711,20 @@ bool WamState::step(const Instruction& instr) {
             pc += 1; return true;
         }
 
-        // ---- Environment frames (no Y-reg discipline yet) ----------
-        case Instruction::Op::Allocate:
-        case Instruction::Op::Deallocate:
+        // ---- Environment frames -----------------------------------
+        case Instruction::Op::Allocate: {
+            EnvFrame f;
+            f.saved_cp = cp;
+            env_stack.push_back(std::move(f));
             pc += 1; return true;
+        }
+        case Instruction::Op::Deallocate: {
+            if (!env_stack.empty()) {
+                cp = env_stack.back().saved_cp;
+                env_stack.pop_back();
+            }
+            pc += 1; return true;
+        }
 
         // ---- Control flow ------------------------------------------
         case Instruction::Op::Call: {
@@ -1700,6 +1761,7 @@ bool WamState::step(const Instruction& instr) {
             cp_.cut_barrier = cut_barrier;
             cp_.saved_regs = regs;
             cp_.saved_mode_stack = mode_stack;
+            cp_.saved_env_stack = env_stack;
             choice_points.push_back(std::move(cp_));
             pc += 1; return true;
         }
@@ -1738,6 +1800,7 @@ bool WamState::step(const Instruction& instr) {
             frame.saved_cut_barrier = cut_barrier;
             frame.saved_regs        = regs;
             frame.saved_mode_stack  = mode_stack;
+            frame.saved_env_stack   = env_stack;
             aggregate_frames.push_back(std::move(frame));
             pc += 1;
             return true;
@@ -1850,6 +1913,7 @@ bool WamState::backtrack() {
             }
             regs        = std::move(f.saved_regs);
             mode_stack  = std::move(f.saved_mode_stack);
+            env_stack   = std::move(f.saved_env_stack);
             cp          = f.saved_cp;
             cut_barrier = f.saved_cut_barrier;
             // Build and bind the result.
@@ -1878,6 +1942,7 @@ bool WamState::backtrack() {
         }
         regs        = cp_.saved_regs;
         mode_stack  = cp_.saved_mode_stack;
+        env_stack   = cp_.saved_env_stack;
         cp          = cp_.saved_cp;
         cut_barrier = cp_.cut_barrier;
         pc          = cp_.alt_pc;
@@ -1907,6 +1972,7 @@ bool WamState::query(const std::string& pred_key, const std::vector<Value>& args
     choice_points.clear();
     aggregate_frames.clear();
     mode_stack.clear();
+    env_stack.clear();
     pc = it->second;
     cp = 0;
     cut_barrier = 0;

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -56,8 +56,35 @@
 :- dynamic user:wam_cpp_test_min/0.
 :- dynamic user:wam_cpp_test_max/0.
 :- dynamic user:wam_cpp_test_set/0.
+:- dynamic user:wam_cpp_h1/1.
+:- dynamic user:wam_cpp_h2/1.
+:- dynamic user:wam_cpp_two_helpers/0.
+:- dynamic user:wam_cpp_two_helpers_swap/0.
+:- dynamic user:wam_cpp_length_acc/3.
+:- dynamic user:wam_cpp_list_length/2.
+:- dynamic user:wam_cpp_test_len_empty/0.
+:- dynamic user:wam_cpp_test_len_one/0.
+:- dynamic user:wam_cpp_test_len_three/0.
+:- dynamic user:wam_cpp_test_len_five/0.
 
 user:wam_cpp_test_write :- write(hello), nl.
+% Y-reg isolation: both helpers use Y1/Y2 internally. Caller relies on
+% preserved Y1 across the two calls.
+user:wam_cpp_h1(X) :- user:wam_cpp_num(_), X = a.
+user:wam_cpp_h2(Y) :- user:wam_cpp_num(_), Y = b.
+user:wam_cpp_two_helpers      :- user:wam_cpp_h1(A), user:wam_cpp_h2(B), A = a, B = b.
+user:wam_cpp_two_helpers_swap :- user:wam_cpp_h1(A), user:wam_cpp_h2(B), A = b, B = a.
+% Tail-recursive list length — exercises cp threading + Y-reg framing
+% across recursive calls.
+user:wam_cpp_length_acc([], Acc, Acc).
+user:wam_cpp_length_acc([_|T], Acc, N) :-
+    Acc1 is Acc + 1,
+    user:wam_cpp_length_acc(T, Acc1, N).
+user:wam_cpp_list_length(L, N) :- user:wam_cpp_length_acc(L, 0, N).
+user:wam_cpp_test_len_empty :- user:wam_cpp_list_length([], 0).
+user:wam_cpp_test_len_one   :- user:wam_cpp_list_length([a], 1).
+user:wam_cpp_test_len_three :- user:wam_cpp_list_length([a, b, c], 3).
+user:wam_cpp_test_len_five  :- user:wam_cpp_list_length([a, b, c, d, e], 5).
 user:wam_cpp_item(a). user:wam_cpp_item(b). user:wam_cpp_item(c).
 user:wam_cpp_num(1).  user:wam_cpp_num(2).  user:wam_cpp_num(3). user:wam_cpp_num(2).
 user:wam_cpp_test_findall         :- findall(X, user:wam_cpp_item(X), L), L = [a, b, c].
@@ -536,6 +563,55 @@ test(cpp_e2e_aggregate_all, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_min/0',   [], true),
           run_query(BinPath, 'wam_cpp_test_max/0',   [], true),
           run_query(BinPath, 'wam_cpp_test_set/0',   [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% Environment frames: Y-reg isolation across nested calls + cp threading
+% through tail-recursive arithmetic. Both are correctness bugs that
+% existed in #2036 and are fixed by this PR''s env-frame implementation
+% (Allocate pushes a frame saving cp; Deallocate pops + restores;
+% Y-reg lookup is scoped to the top frame).
+% ------------------------------------------------------------------
+
+test(cpp_e2e_yreg_isolation, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_yreg', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_num/1,
+                               user:wam_cpp_h1/1, user:wam_cpp_h2/1,
+                               user:wam_cpp_two_helpers/0,
+                               user:wam_cpp_two_helpers_swap/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          % Both helpers use Y1/Y2 internally. The caller calls h1 then h2
+          % and must NOT see h2''s Y1 stomp on h1''s result.
+          run_query(BinPath, 'wam_cpp_two_helpers/0',      [], true),
+          run_query(BinPath, 'wam_cpp_two_helpers_swap/0', [], false)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_recursive_arithmetic, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_recur', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_length_acc/3,
+                               user:wam_cpp_list_length/2,
+                               user:wam_cpp_test_len_empty/0,
+                               user:wam_cpp_test_len_one/0,
+                               user:wam_cpp_test_len_three/0,
+                               user:wam_cpp_test_len_five/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          % Tail-recursive length with accumulator. Exercises:
+          %   - cp threading through nested Call/Execute
+          %   - Y-reg isolation across recursive frames
+          %   - PutConstant allocating fresh cells (not mutating
+          %     X-reg-aliased cells)
+          run_query(BinPath, 'wam_cpp_test_len_empty/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_len_one/0',   [], true),
+          run_query(BinPath, 'wam_cpp_test_len_three/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_len_five/0',  [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Implements proper WAM environment frames, closing the **last named follow-up from #2032**. Diagnosing this turned up two real correctness bugs that were silently producing wrong-but-plausible results before — both fixed here.

## Background: why this turned out to be a correctness PR

I started this branch expecting "stack hygiene with no observable changes" (the framing from #2036). Building a Y-reg collision repro immediately surfaced a deeper issue: my `Call` instruction was overwriting `cp` without saving the caller's `cp`, and `Allocate`/`Deallocate` were no-ops. So in any predicate like `a :- b, c.` where `b` internally called another predicate, `b`'s callee would clobber `a`'s continuation. The program then silently halted after `b` returned because `cp == 0`, returning `true` "by accident" if `b` had succeeded.

That meant the e2e tests in #2032 / #2033 / #2035 / #2036 were running predicates with at most one level of cross-predicate calls — and even those only worked because they were tail calls (`Execute`, which doesn't touch `cp`).

A second bug surfaced while debugging `list_length`: `PutConstant N, Ai` was mutating Ai's existing cell instead of allocating a fresh one. Any X-reg that had been aliased to Ai via a prior `get_variable Xn, Ai` was silently rebound too. The wrapper

```
get_variable X2, A2     # X2 ← caller's N
put_constant 0, A2      # A2 = 0  ...but also X2 = 0!
put_value X2, A3        # A3 = X2 = 0 (was supposed to be N)
```

caused `list_length([a,b,c], 3)` to fail because `length_acc` was called with the target = 0 instead of 3.

## Changes

### Environment frames

- New `EnvFrame { saved_cp, y_regs }` and `env_stack` on `WamState`.
- `Allocate` pushes a frame, saving the caller's `cp`.
- `Deallocate` pops the frame and restores `cp` — fixing the silent-halt bug.
- `get_cell` / `set_cell` / `get_reg` / `put_reg` now route Y-reg accesses (names starting with `Y`) through `env_stack.back().y_regs` instead of the flat `regs` map. Two nested calls that both use `Y1` no longer share state.
- `ChoicePoint` and `AggregateFrame` snapshot `env_stack` alongside `regs` / `mode_stack`; backtrack and aggregate-finalisation restore it.

### PutConstant fix

`PutConstant` now calls `set_cell(name, make_cell(val))` — always a fresh cell — matching classic WAM semantics (`put_constant overwrites Ai with a heap-allocated constant`). X-regs aliasing Ai are unaffected.

## Tests

Existing 40 still pass. Two new e2e tests:

- **`cpp_e2e_yreg_isolation`** — two helpers that both use Y1/Y2 internally, verifying caller-side bindings survive across both calls. Includes a swap-expectation negative case.
- **`cpp_e2e_recursive_arithmetic`** — tail-recursive list_length with accumulator at depths 0 / 1 / 3 / 5. Exercises cp threading, Y-reg framing across recursion, and the PutConstant fresh-cell fix all at once.

**Total: 42/42 passing** with `swipl 9.0.4` + `g++ 13`.

## Verification

```
$ swipl -g "[tests/test_wam_cpp_generator]" -g "run_tests(wam_cpp_generator)" -t halt
% All 42 tests passed
```

Manual sanity:

```
$ ./cpp_test list_length/2 '[a,b,c]' 3        → true
$ ./cpp_test list_length/2 '[a,b,c,d,e]' 5    → true
$ ./cpp_test two_helpers/0                    → true   # Y-regs isolated across h1, h2
$ ./cpp_test test_findall_doubled/0           → true   # (re-verified — findall path unchanged)
```

## Closes the original #2032 follow-up list

This is the last item from the three named follow-ups in #2032:

- [x] heap-resident structures + lists (#2033)
- [x] arithmetic / comparison / I/O builtins (#2035)
- [x] findall/3 + aggregate_all/3 + critical backtrack/mode-stack fixes (#2036)
- [x] Y-reg / environment-frame discipline (**this PR**)

wam_cpp now has parity with `wam_rust_target` on every opcode the WAM compiler emits in practice. Remaining items are perf opportunities rather than correctness gaps:

- Indexing instructions (`switch_on_constant`, etc.) are silently dropped by the parser, falling through to `try_me_else` chains. Real perf win but no behavior change.
- Lowered emitter could inline more compound ops instead of delegating to `step()` (currently `Get-/PutStructure / Get-/PutList / Unify*` all go through the interpreter).
- More builtins (`bagof/3`, `setof/3`, `assert/1`, `catch/3`, `between/3`, `format/2`, etc.).

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_