### PR TITLE
Feat/wam python member choice

### DIFF
--- a/PR_wam_python_member_choice_points.md
+++ b/PR_wam_python_member_choice_points.md
@@ -1,0 +1,19 @@
+# PR Title
+
+Add Python WAM member choice points
+
+# PR Description
+
+## Summary
+
+- Make Python WAM `member/2` enumerate list members via builtin choice points instead of returning only the first solution.
+- Pass builtin resume PCs through normal runtime execution and aggregate body execution so backtracking consumers can resume `member/2`.
+- Add generated-project E2E coverage proving `member/2` enumeration through aggregate collection.
+- Update the Python WAM parity audit to mark the remaining structural builtin gap closed.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_wam_python_target.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_python_effective_distance_smoke.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_python_target), halt"`
+- `git diff --check`

--- a/docs/design/WAM_PYTHON_PARITY_AUDIT.md
+++ b/docs/design/WAM_PYTHON_PARITY_AUDIT.md
@@ -14,8 +14,8 @@ matters for parity.
 | Area | Python support | Lua/Rust/Haskell baseline | Status |
 | --- | --- | --- | --- |
 | Direct fact dispatch | `call_indexed_atom_fact2`, category ancestor helpers | Indexed fact paths | Present |
-| Aggregates | `begin_aggregate`, `end_aggregate` runtime paths | `findall/3`, `aggregate_all/3` families | Present, but not covered by a parity guard |
-| Structural builtins | `member/2`, `length/2` | `member/2`, `length/2` | Partial: `member/2` returns only the first solution |
+| Aggregates | `begin_aggregate`, `end_aggregate` runtime paths | `findall/3`, `aggregate_all/3` families | Present, covered by generated-project E2E |
+| Structural builtins | `member/2`, `length/2` | `member/2`, `length/2` | Present: `member/2` enumerates via builtin choice points |
 | Type builtins | `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `var/1`, `nonvar/1`, `is_list/1` | Same baseline set | Present |
 | Comparison builtins | `==/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2` | Same baseline set | Present |
 | Unification builtins | `=/2`, `\=/2` | `=/2`, `\=/2` in comparable runtimes | Present |
@@ -35,15 +35,14 @@ now share one Python WAM runtime surface.
 ## Remaining Follow-Up
 
 The packaged static runtime now carries the Lua/Rust/Haskell builtin baseline.
-The remaining parity work is narrower:
-
-1. Decide whether `member/2` should enumerate all solutions via builtin choice
-   points, or remain first-solution-only like the current packaged runtime.
+No Python WAM builtin parity gaps are currently tracked here.
 
 Completed follow-up:
 
 - Generated-project E2E tests now exercise term builtins, copy/NAF/IO, and
   type/comparison builtins through the packaged static runtime.
+- Generated-project E2E tests now verify `member/2` enumeration through
+  aggregate collection.
 - `compile_wam_runtime_to_python/2` now returns the packaged static runtime,
   removing the separate fallback runtime surface.
 

--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -635,6 +635,40 @@ def _term_to_list(term: 'Term', state: WamState) -> Optional[List['Term']]:
     return None
 
 
+def _unify_would_succeed(left: 'Term', right: 'Term', state: WamState) -> bool:
+    """Check unification against an isolated state before mutating the live one."""
+    sub = copy.deepcopy(state)
+    return unify(copy.deepcopy(left), copy.deepcopy(right), sub)
+
+
+def _execute_member_from_index(elem: 'Term', items: List['Term'], start_idx: int,
+                               resume_ip: int, state: WamState) -> bool:
+    for idx in range(start_idx, len(items)):
+        candidate = items[idx]
+        if not _unify_would_succeed(elem, candidate, state):
+            continue
+
+        if resume_ip >= 0 and idx + 1 < len(items):
+            def make_cont(next_idx, rip):
+                def cont(s):
+                    if s.b >= 0 and isinstance(s.stack[s.b], ChoicePoint):
+                        cp_index = s.b
+                        parent_b = s.stack[cp_index].saved_b
+                        del s.stack[cp_index:]
+                        s.b = parent_b
+                    resumed_items = _term_to_list(get_reg(s, 2), s)
+                    if resumed_items is None:
+                        return -1
+                    if _execute_member_from_index(get_reg(s, 1), resumed_items, next_idx, rip, s):
+                        return rip
+                    return -1
+                return cont
+            push_choice_point(state, 2, make_cont(idx + 1, resume_ip))
+
+        return unify(elem, candidate, state)
+    return False
+
+
 def _list_from_terms(items: List['Term']) -> 'Term':
     """Build a proper Prolog list from Python terms."""
     result: Term = make_atom('[]')
@@ -701,7 +735,7 @@ def _goal_succeeds_once(goal: 'Term', state: WamState) -> bool:
     return False
 
 
-def _execute_builtin(builtin: str, arity: int, state: 'WamState') -> bool:
+def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int = -1) -> bool:
     """Execute a WAM builtin_call instruction."""
     if builtin == '!/0' or builtin == '!':  # cut
         state.cut_b = state.b
@@ -811,18 +845,12 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState') -> bool:
     if builtin in ('fail/0', 'fail', 'false/0', 'false'):
         return False
     if builtin in ('member/2', 'member'):
-        # member(Elem, List): succeeds if Elem is in List (only first solution)
-        elem = deref(get_reg(state, 1), state)
-        lst = deref(get_reg(state, 2), state)
-        def member_find(e, l):
-            if isinstance(l, Atom) and l.name == '[]': return False
-            if isinstance(l, Compound) and _strip_arity(l.functor) == '.':
-                head = deref(l.args[0], state) if l.args[0] is not None else None
-                tail = deref(l.args[1], state) if l.args[1] is not None else None
-                if head is not None and unify(e, head, state): return True
-                return member_find(e, tail)
+        # member(Elem, List): bind the first solution and leave choice points
+        # for later list elements so aggregate/backtracking consumers enumerate.
+        items = _term_to_list(get_reg(state, 2), state)
+        if items is None:
             return False
-        return member_find(elem, lst)
+        return _execute_member_from_index(get_reg(state, 1), items, 0, resume_ip, state)
     if builtin in ('functor/3', 'functor') and arity == 3:
         term = deref(get_reg(state, 1), state)
         name = deref(get_reg(state, 2), state)
@@ -1646,7 +1674,7 @@ def run_wam(code: list, labels: dict, entry: str, state: WamState) -> bool:
 
         elif op == 'builtin_call':
             _, builtin, arity = instr
-            ok = _execute_builtin(builtin, arity, state)
+            ok = _execute_builtin(builtin, arity, state, resume_ip=ip)
             if not ok:
                 if not fail(): return False
                 continue
@@ -2116,7 +2144,7 @@ def _run_aggregate_body(code: list, labels: dict, body_start: int, end_pc: int,
                 continue
         elif op == 'builtin_call':
             _, builtin, arity = instr
-            ok = _execute_builtin(builtin, arity, sub)
+            ok = _execute_builtin(builtin, arity, sub, resume_ip=sub_ip)
             if not ok:
                 if not sub_fail(): break
                 sub_arg_snap = list(sub.regs)

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -818,14 +818,25 @@ test(generated_project_runs_type_and_comparison_builtins) :-
 		),
 		cleanup_tmp_dir(ProjectDir)).
 
+test(generated_project_enumerates_member_builtin) :-
+	setup_call_cleanup(
+		unique_tmp_dir('tmp_wam_python_builtin_e2e', ProjectDir),
+		(   write_builtin_project(ProjectDir),
+			run_generated_query(ProjectDir, 'member_collect_demo/0', Output),
+			once(sub_string(Output, _, _, _, "A3 = .(a, .(b, []))"))
+		),
+		cleanup_tmp_dir(ProjectDir)).
+
 write_builtin_project(ProjectDir) :-
 	term_builtin_wam(TermWam),
 	copy_naf_io_wam(CopyNafIoWam),
 	type_compare_wam(TypeCompareWam),
+	member_collect_wam(MemberCollectWam),
 	wam_python_target:write_wam_python_project(
 		[term_demo/0-TermWam,
 		 copy_naf_io_demo/0-CopyNafIoWam,
-		 type_compare_demo/0-TypeCompareWam],
+		 type_compare_demo/0-TypeCompareWam,
+		 member_collect_demo/0-MemberCollectWam],
 		[],
 		ProjectDir).
 
@@ -890,6 +901,21 @@ type_compare_wam(
   put_integer 3, 2
   builtin_call =\\=/2 2
   put_constant ok, 1
+  proceed').
+
+member_collect_wam(
+'member_collect_demo/0:
+  put_variable 8, 3
+  begin_aggregate collect 1 3
+  put_variable 6, 1
+  put_list 4
+  set_constant b
+  set_nil
+  put_list 2
+  set_constant a
+  set_value 4
+  builtin_call member/2 2
+  end_aggregate 1
   proceed').
 
 run_generated_query(ProjectDir, Query, Output) :-


### PR DESCRIPTION
# Add Python WAM member choice points

## Summary

- Make Python WAM `member/2` enumerate list members via builtin choice points instead of returning only the first solution.
- Pass builtin resume PCs through normal runtime execution and aggregate body execution so backtracking consumers can resume `member/2`.
- Add generated-project E2E coverage proving `member/2` enumeration through aggregate collection.
- Update the Python WAM parity audit to mark the remaining structural builtin gap closed.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_python_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_python_effective_distance_smoke.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_python_target), halt"`
- `git diff --check`
