### PR TITLE
test(wam-c): add ASAN lifecycle smoke

### DIFF
--- a/PR_DESCRIPTION_WAM_C_MEMORY_LIFECYCLE_ASAN.md
+++ b/PR_DESCRIPTION_WAM_C_MEMORY_LIFECYCLE_ASAN.md
@@ -1,0 +1,24 @@
+# test: Add WAM C ASAN lifecycle smoke
+
+## Summary
+
+This PR adds an AddressSanitizer-backed WAM-C executable smoke for runtime lifecycle coverage. The smoke recompiles generated WAM-C with `-fsanitize=address` and exercises repeated setup, switch-table replacement, indexed dispatch, FactSource loading, native foreign kernel dispatch, and repeated top-level predicate calls.
+
+## What Changed
+
+- Adds an optional ASAN lifecycle smoke to `tests/test_wam_c_target.pl`.
+- Redirects sanitizer executable output to a per-smoke log path on failure.
+- Prunes top-level choicepoints after `wam_run_predicate` returns so later top-level calls do not restore stale heap or register snapshots.
+- Guards `retry_me_else` when indexed dispatch jumps directly into a later clause without a sequential choicepoint.
+- Updates `WAM_C_TARGET_NEXT_STEPS.md` to mark this branch ready and recommend the lowered helper prototype next.
+
+## Validation
+
+- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
+- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
+- `git diff --check`
+
+## Follow-Up
+
+Next recommended branch: `feat/wam-c-lowered-helper-prototype`.

--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -1,17 +1,17 @@
 # WAM C Target - Status And Next Steps
 
-Status date: 2026-05-06
+Status date: 2026-05-12
 
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `a91d8521` (`Merge pull request #1870 from s243a/feat/wam-c-classic-program-e2e`)
+- `main` at `8268a7cd` (`Merge pull request #2039 from s243a/perf/wam-c-pack-instruction`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
 
 Active branch:
 
-- `perf/wam-c-pack-instruction`
+- `test/wam-c-memory-lifecycle-asan`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -36,7 +36,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Effective-distance matrix wiring | Done | `c-wam-accumulated`, `c-wam-accumulated-no-kernels`, C kernel-pair delta, `dev` parity smoke against Prolog |
 | Effective-distance LMDB fact-storage wiring | Done | `facts_lmdb` generator mode, LMDB seeder/validator, `c-wam-accumulated-lmdb` matrix targets, `dev` parity smoke against Prolog |
 | Classic recursive program e2e | Done | Generated Prolog-to-WAM-C Fibonacci smoke, `set_*` instruction support, dereferenced constants/results, call-base choicepoint pruning |
-| Packed instruction layout | Done on active branch | `InstructionPayload` union keyed by `WamInstrTag`, typed generated initializers, typed runtime dispatch payload reads, switch-table cleanup guarded by switch tags |
+| Packed instruction layout | Done | `InstructionPayload` union keyed by `WamInstrTag`, typed generated initializers, typed runtime dispatch payload reads, switch-table cleanup guarded by switch tags |
+| ASAN memory lifecycle smoke | Done on active branch | ASAN-generated executable smoke covers switch table setup replacement, indexed clauses, FactSource loading, native foreign kernel dispatch, and repeated top-level calls |
 
 ## Current C Target Baseline
 
@@ -51,8 +52,8 @@ The C target is now a credible small WAM backend:
   choice-point instructions.
 - Supports `switch_on_constant`, `switch_on_structure`, `switch_on_term`,
   second-argument constant dispatch, and direct list dispatch.
-- Uses a tagged `InstructionPayload` union on the active branch instead of a
-  single wide instruction struct.
+- Uses a tagged `InstructionPayload` union instead of a single wide instruction
+  struct.
 - Supports basic `builtin_call` delegation for tested builtins:
   `atom/1`, `integer/1`, `is_list/1`, `=/2`, and `is/2`.
 - Supports deterministic `call_foreign` dispatch through a C handler registry.
@@ -109,25 +110,12 @@ missing important target features; `Missing` = no comparable C path yet.
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
 | Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB `kernels_on`/`kernels_off`; next gap is larger artifact layouts. |
 | Classic-program e2e suite | Partial/Done | Partial/Done | Partial/Done | C now covers generated Fibonacci-style recursion with arithmetic; add Ackermann-style depth only if routine runtime stays acceptable. |
-| Memory lifecycle | Partial | Runtime-managed | Runtime-managed | C has init/free; needs ASAN/Valgrind CI-style coverage for larger programs. |
-| Instruction layout efficiency | Done on active branch | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
+| Memory lifecycle | Partial/Done | Runtime-managed | Runtime-managed | Active branch adds an ASAN lifecycle smoke and fixes stale top-level choicepoints plus indexed `retry_me_else` without an active choicepoint. |
+| Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
 
-### 1. `perf/wam-c-pack-instruction`
-
-Goal: reduce `Instruction` memory footprint.
-
-Scope:
-
-- Replace the current wide struct with a tagged union keyed by `WamInstrTag`.
-- Keep setup emission readable.
-- Add compile-time or smoke coverage to ensure every instruction arm reads the
-  correct union member.
-
-Status: ready on the active branch pending PR/merge.
-
-### 2. `test/wam-c-memory-lifecycle-asan`
+### 1. `test/wam-c-memory-lifecycle-asan`
 
 Goal: make the C runtime cleanup story harder to regress as generated programs
 grow.
@@ -141,10 +129,27 @@ Scope:
   smoke opportunistically or behind a clearly named test helper.
 - Use this to validate the packed-instruction cleanup path on larger programs.
 
+Status: ready on the active branch pending PR/merge.
+
+### 2. `feat/wam-c-lowered-helper-prototype`
+
+Goal: start closing the C gap with the Haskell and Rust hybrid WAM lowered
+helper paths.
+
+Scope:
+
+- Prototype one small deterministic lowered/native helper path for C.
+- Keep the runtime interface narrow and compatible with existing
+  `call_foreign` registration.
+- Prefer a fact-only or simple deterministic helper before attempting aggregate
+  or multi-result helpers.
+
 ## Suggested Immediate Next Step
 
-Open a PR for `perf/wam-c-pack-instruction`, then continue with
-`test/wam-c-memory-lifecycle-asan`.
+Open a PR for `test/wam-c-memory-lifecycle-asan`, then continue with
+`feat/wam-c-lowered-helper-prototype`.
 
-The packed-instruction branch is validated locally with WAM-C target tests,
-focused effective-distance tests, and the dev effective-distance matrix.
+The branch already has an ASAN lifecycle smoke running locally and has exposed
+two runtime correctness fixes: pruning top-level choicepoints after
+`wam_run_predicate/4` returns, and guarding indexed `retry_me_else` execution
+when no sequential choicepoint exists.

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -634,8 +634,10 @@ compile_step_wam_to_c(_Options, CCode) :-
             }
             case INSTR_RETRY_ME_ELSE: {
                 int target = instr->as.choice.target_pc;
-                ChoicePoint *cp = &state->B_array[state->B - 1];
-                cp->next_pc = target;
+                if (state->B > 0) {
+                    ChoicePoint *cp = &state->B_array[state->B - 1];
+                    cp->next_pc = target;
+                }
                 state->P++;
                 return true;
             }
@@ -955,10 +957,15 @@ int wam_run_predicate(WamState *state, const char *pred,
                       WamValue *args, int arity) {
     int entry = resolve_predicate_hash(state, pred);
     if (entry < 0) return WAM_ERR_OOB;
+    int base_b = state->B;
+    int base_call_base_top = state->call_base_top;
     for (int i = 0; i < arity; i++) state->A[i] = args[i];
     state->CP = WAM_HALT;
     state->P = entry;
-    return wam_run(state);
+    int rc = wam_run(state);
+    wam_prune_choice_points(state, base_b);
+    state->call_base_top = base_call_base_top;
+    return rc;
 }
 
 static bool wam_eval_arith(WamState *state, WamValue value, int *out) {

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -504,11 +504,35 @@ test_real_prolog_classic_recursive_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_asan_memory_lifecycle_executable_smoke :-
+    Test = 'WAM-C: ASAN memory lifecycle executable smoke',
+    (   asan_available
+    ->  (   run_asan_memory_lifecycle_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'ASAN memory lifecycle executable failed')
+        )
+    ;   format('[PASS] ~w (ASAN unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 gcc_available :-
     catch(process_create(path(gcc), ['--version'],
                          [stdout(null), stderr(null), process(Pid)]),
           _, fail),
     process_wait(Pid, exit(0)).
+
+asan_available :-
+    gcc_available,
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(TmpBase), '/tmp/unifyweaver_wam_c_asan_probe_~w', [Stamp]),
+    format(atom(SourcePath), '~w.c', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(SourcePath, 'int main(void) { return 0; }\n'),
+    format(atom(CompileCmd),
+           'gcc -std=c11 -fsanitize=address ~w -o ~w',
+           [SourcePath, ExePath]),
+    catch(shell(CompileCmd, CompileStatus), _, fail),
+    CompileStatus =:= 0.
 
 lmdb_available :-
     catch(process_create(path('pkg-config'), ['--exists', 'lmdb'],
@@ -860,6 +884,37 @@ run_real_prolog_classic_recursive_executable_smoke :-
         fail
     ).
 
+run_asan_memory_lifecycle_executable_smoke :-
+    assertz((user:wam_c_asan_term(a, atom) :- true)),
+    assertz((user:wam_c_asan_term(foo(_), struct) :- true)),
+    assertz((user:wam_c_asan_term([_|_], list) :- true)),
+    (   compile_predicate_to_wam(user:wam_c_asan_term/2, [], TermWamCode),
+        sub_string(TermWamCode, _, _, _, 'switch_on_term'),
+        compile_wam_predicate_to_c(user:wam_c_asan_term/2, TermWamCode, [], TermPredCode),
+        CategoryWamCode = 'category_ancestor/4:\n    call_foreign category_ancestor/4, 4\n    proceed',
+        compile_wam_predicate_to_c(user:category_ancestor/4, CategoryWamCode, [], CategoryPredCode),
+        compile_wam_runtime_to_c([], RuntimeCode),
+        get_time(Now),
+        Stamp is round(Now * 1000000),
+        format(atom(TmpBase), '/tmp/unifyweaver_wam_c_asan_lifecycle_smoke_~w', [Stamp]),
+        format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+        format(atom(PredPath), '~w_pred.c', [TmpBase]),
+        format(atom(MainPath), '~w_main.c', [TmpBase]),
+        format(atom(DataPath), '~w_edges.tsv', [TmpBase]),
+        format(atom(ExePath), '~w_bin', [TmpBase]),
+        write_text_file(RuntimePath, RuntimeCode),
+        format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w~n~n~w', [TermPredCode, CategoryPredCode]),
+        write_text_file(PredPath, PredTranslationUnit),
+        write_text_file(DataPath, 'leaf\tmid\nmid\troot\nleaf\tother\n'),
+        wam_c_asan_lifecycle_smoke_main(DataPath, MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke(RuntimePath, PredPath, MainPath, ExePath),
+        run_c_smoke(ExePath)
+    ->  retractall(user:wam_c_asan_term(_, _))
+    ;   retractall(user:wam_c_asan_term(_, _)),
+        fail
+    ).
+
 write_text_file(Path, Content) :-
     setup_call_cleanup(
         open(Path, write, Stream),
@@ -924,13 +979,14 @@ cleanup_wam_c_detector_category_ancestor :-
     retractall(user:category_ancestor(_, _, _, _)).
 
 run_c_smoke(ExePath) :-
+    format(atom(LogPath), '~w.asan.log', [ExePath]),
     format(atom(Cmd),
-           'ASAN_OPTIONS=detect_leaks=0:abort_on_error=1 timeout 10 ~w',
-           [ExePath]),
+           'ASAN_OPTIONS=detect_leaks=0:abort_on_error=1 timeout 10 ~w > ~w 2>&1',
+           [ExePath, LogPath]),
     shell(Cmd, Status),
     (   Status =:= 0
     ->  true
-    ;   format(user_error, 'generated executable failed with status ~w~n', [Status]),
+    ;   format(user_error, 'generated executable failed with status ~w (log: ~w)~n', [Status, LogPath]),
         fail
     ).
 
@@ -1429,6 +1485,112 @@ int main(void) {
 }
 ').
 
+wam_c_asan_lifecycle_smoke_main(DataPath, MainCode) :-
+    format(atom(MainCode),
+'#include "wam_runtime.h"
+
+void setup_wam_c_asan_term_2(WamState* state);
+void setup_category_ancestor_4(WamState* state);
+
+static WamValue make_list_pair(WamState *state, const char *head, const char *tail) {
+    WamValue list;
+    list.tag = VAL_LIST;
+    list.data.ref_addr = state->H;
+    state->H_array[state->H++] = val_atom(head);
+    state->H_array[state->H++] = val_atom(tail);
+    return list;
+}
+
+static WamValue make_unary_struct(WamState *state, const char *functor, const char *arg) {
+    WamValue term;
+    term.tag = VAL_STR;
+    term.data.ref_addr = state->H;
+    state->H_array[state->H++] = val_atom(functor);
+    state->H_array[state->H++] = val_atom(arg);
+    return term;
+}
+
+static bool expect_label(WamState *state, WamValue input, const char *label) {
+    WamValue args[2] = { input, val_unbound("Kind") };
+    int rc = wam_run_predicate(state, "wam_c_asan_term/2", args, 2);
+    return rc == 0 &&
+           state->P == WAM_HALT &&
+           state->A[1].tag == VAL_ATOM &&
+           strcmp(state->A[1].data.atom, label) == 0;
+}
+
+static WamValue make_visited_singleton(WamState *state, const char *atom) {
+    return make_list_pair(state, atom, "[]");
+}
+
+int main(void) {
+    WamState state;
+    WamFactSource source;
+    CategoryEdge matches[4];
+    wam_state_init(&state);
+    wam_fact_source_init(&source);
+
+    setup_wam_c_asan_term_2(&state);
+    setup_wam_c_asan_term_2(&state);
+
+    if (!expect_label(&state, val_atom("a"), "atom")) {
+        wam_fact_source_close(&source);
+        wam_free_state(&state);
+        return 10;
+    }
+    if (!expect_label(&state, make_list_pair(&state, "head", "tail"), "list")) {
+        wam_fact_source_close(&source);
+        wam_free_state(&state);
+        return 20;
+    }
+    if (!expect_label(&state, make_unary_struct(&state, "foo/1", "arg"), "struct")) {
+        wam_fact_source_close(&source);
+        wam_free_state(&state);
+        return 30;
+    }
+
+    setup_category_ancestor_4(&state);
+    if (!wam_fact_source_load_tsv(&state, &source, "~w")) {
+        wam_fact_source_close(&source);
+        wam_free_state(&state);
+        return 40;
+    }
+    int match_count = wam_fact_source_lookup_arg1(&source, "leaf", matches, 4);
+    if (match_count != 2) {
+        wam_fact_source_close(&source);
+        wam_free_state(&state);
+        return 50;
+    }
+    wam_register_category_parent_fact_source(&state, &source);
+    wam_register_category_ancestor_kernel(&state, "category_ancestor/4", 10);
+
+    WamValue args[4] = {
+        val_atom("leaf"),
+        val_atom("root"),
+        val_unbound("Hops"),
+        make_visited_singleton(&state, "leaf")
+    };
+    int rc = wam_run_predicate(&state, "category_ancestor/4", args, 4);
+    if (rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 2) {
+        wam_fact_source_close(&source);
+        wam_free_state(&state);
+        return 60;
+    }
+
+    setup_wam_c_asan_term_2(&state);
+    if (!expect_label(&state, val_atom("a"), "atom")) {
+        wam_fact_source_close(&source);
+        wam_free_state(&state);
+        return 70;
+    }
+
+    wam_fact_source_close(&source);
+    wam_free_state(&state);
+    return 0;
+}
+', [DataPath]).
+
 wam_c_real_builtin_smoke_main(
 '#include "wam_runtime.h"
 
@@ -1778,6 +1940,7 @@ run_tests_once :-
     test_real_prolog_is_list_executable_smoke,
     test_real_prolog_unify_executable_smoke,
     test_real_prolog_classic_recursive_executable_smoke,
+    test_asan_memory_lifecycle_executable_smoke,
     format('~n=== WAM-C Target Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).
 


### PR DESCRIPTION
## Summary

This PR adds an AddressSanitizer-backed WAM-C executable smoke for runtime lifecycle coverage. The smoke recompiles generated WAM-C with `-fsanitize=address` and exercises repeated setup, switch-table replacement, indexed dispatch, FactSource loading, native foreign kernel dispatch, and repeated top-level predicate calls.

## What Changed

- Adds an optional ASAN lifecycle smoke to `tests/test_wam_c_target.pl`.
- Redirects sanitizer executable output to a per-smoke log path on failure.
- Prunes top-level choicepoints after `wam_run_predicate` returns so later top-level calls do not restore stale heap or register snapshots.
- Guards `retry_me_else` when indexed dispatch jumps directly into a later clause without a sequential choicepoint.
- Updates `WAM_C_TARGET_NEXT_STEPS.md` to mark this branch ready and recommend the lowered helper prototype next.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
- `git diff --check`

## Follow-Up

Next recommended branch: `feat/wam-c-lowered-helper-prototype`.
