### PR TITLE
bench(csharp-query): Quiet C# query calibration artifact writes

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -138,7 +138,9 @@ fields come from the independent-run stability summary instead of one noisy
 single run. Add `--write-calibration-artifact` to write those rows directly to
 `--calibration-artifact` after validation succeeds. If the artifact already
 exists, only the selected workload/scale rows are replaced; unselected rows are
-preserved.
+preserved. Use `--format none` instead of `--format calibration-tsv` for
+scripted refreshes that should only write the artifact and avoid printing the
+full table to stdout.
 
 ```bash
 python examples/benchmark/benchmark_csharp_query_source_mode_sweep.py \
@@ -149,7 +151,7 @@ python examples/benchmark/benchmark_csharp_query_source_mode_sweep.py \
   --repetitions 1 \
   --stability-runs 3 \
   --compare-calibration \
-  --format calibration-tsv \
+  --format none \
   --write-calibration-artifact
 ```
 

--- a/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
+++ b/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
@@ -126,7 +126,12 @@ def parse_args() -> argparse.Namespace:
             "Values above 1 print a stability summary instead of the raw per-run table."
         ),
     )
-    parser.add_argument("--format", choices=["tsv", "markdown", "calibration-tsv"], default="tsv")
+    parser.add_argument(
+        "--format",
+        choices=["tsv", "markdown", "calibration-tsv", "none"],
+        default="tsv",
+        help="Output format. Use 'none' to suppress table output for artifact-writer runs.",
+    )
     parser.add_argument(
         "--trace",
         action="store_true",
@@ -165,7 +170,7 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help=(
             "Write the fresh calibration TSV to --calibration-artifact. "
-            "Use with --format calibration-tsv and usually --stability-runs > 1."
+            "Use with --format calibration-tsv or --format none and usually --stability-runs > 1."
         ),
     )
     parser.add_argument(
@@ -195,8 +200,10 @@ def parse_args() -> argparse.Namespace:
         help="Minimum MemAvailable MiB required by --require-idle.",
     )
     args = parser.parse_args()
-    if args.write_calibration_artifact and args.format != "calibration-tsv":
-        raise SystemExit("--write-calibration-artifact requires --format calibration-tsv")
+    if args.write_calibration_artifact and args.format not in {"calibration-tsv", "none"}:
+        raise SystemExit(
+            "--write-calibration-artifact requires --format calibration-tsv or --format none"
+        )
     return args
 
 
@@ -1040,6 +1047,8 @@ def main() -> int:
             print_calibration_tsv(calibration_rows)
         elif args.format == "markdown":
             print_stability_markdown(stability_summaries)
+        elif args.format == "none":
+            pass
         else:
             print_stability_tsv(stability_summaries)
     else:
@@ -1048,6 +1057,8 @@ def main() -> int:
             print_calibration_tsv(calibration_rows)
         elif args.format == "markdown":
             print_markdown(summaries)
+        elif args.format == "none":
+            pass
         else:
             print_tsv(summaries)
 

--- a/tests/test_csharp_query_source_mode_sweep.py
+++ b/tests/test_csharp_query_source_mode_sweep.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import contextlib
+import io
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -17,6 +20,7 @@ from benchmark_csharp_query_source_mode_sweep import (  # noqa: E402
     DEFAULT_WORKLOADS,
     SourceModeSummary,
     WORKLOAD_SCRIPTS,
+    main,
     calibration_failures,
     calibration_rows_from_stability,
     calibration_rows_from_summaries,
@@ -73,6 +77,22 @@ class CSharpQuerySourceModeSweepTests(unittest.TestCase):
                 parse_args()
         finally:
             sys.argv = original_argv
+
+    def test_write_calibration_artifact_allows_quiet_format(self) -> None:
+        original_argv = sys.argv
+        try:
+            sys.argv = [
+                "benchmark_csharp_query_source_mode_sweep.py",
+                "--format",
+                "none",
+                "--write-calibration-artifact",
+            ]
+            args = parse_args()
+        finally:
+            sys.argv = original_argv
+
+        self.assertEqual(args.format, "none")
+        self.assertTrue(args.write_calibration_artifact)
 
     def test_filter_workload_scales_skips_unsupported_generated_graph_scales(self) -> None:
         self.assertEqual(
@@ -476,6 +496,42 @@ class CSharpQuerySourceModeSweepTests(unittest.TestCase):
 
             self.assertEqual(written, [fresh, untouched])
             self.assertEqual(load_calibration_artifact(artifact_path), [fresh, untouched])
+
+    def test_main_quiet_writer_suppresses_table_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            artifact_path = Path(tmp_dir) / "calibration.tsv"
+            write_calibration_artifact(artifact_path, [self._baseline()])
+            original_argv = sys.argv
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            try:
+                sys.argv = [
+                    "benchmark_csharp_query_source_mode_sweep.py",
+                    "--workloads",
+                    "category-influence",
+                    "--scales",
+                    "300",
+                    "--source-modes",
+                    "auto,preload",
+                    "--format",
+                    "none",
+                    "--calibration-artifact",
+                    str(artifact_path),
+                    "--write-calibration-artifact",
+                ]
+                with mock.patch(
+                    "benchmark_csharp_query_source_mode_sweep.run_workload",
+                    return_value=[self._summary()],
+                ):
+                    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                        result = main()
+            finally:
+                sys.argv = original_argv
+
+            self.assertEqual(result, 0)
+            self.assertEqual(stdout.getvalue(), "")
+            self.assertIn("Wrote calibration artifact:", stderr.getvalue())
+            self.assertEqual(load_calibration_artifact(artifact_path), [self._baseline()])
 
     def test_parse_runner_output_summarizes_modes_and_registrations(self) -> None:
         output = "\n".join(


### PR DESCRIPTION
  ## Summary

  - Adds `none` as an output format for `benchmark_csharp_query_source_mode_sweep.py`.
  - Allows `--write-calibration-artifact` with `--format none`.
  - Suppresses calibration table output for quiet artifact-writer runs while still printing the write confirmation.
  - Updates the README refresh command to use quiet artifact writes.
  - Adds parser and mocked `main()` coverage for the quiet writer path.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_source_mode_sweep.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_source_mode_sweep.py tests/
  test_csharp_query_source_mode_sweep.py`
  - `git diff --check`
  - Temp artifact smoke with `--format none --write-calibration-artifact`; preserved all 25 rows and did not modify the
  checked-in TSV.