### PR TITLE
feat(wam-c): Prototype WAM C lowered fact helper

### DIFF
--- a/PR_DESCRIPTION_WAM_C_LOWERED_HELPER_PROTOTYPE.md
+++ b/PR_DESCRIPTION_WAM_C_LOWERED_HELPER_PROTOTYPE.md
@@ -1,0 +1,26 @@
+# feat: Prototype WAM C lowered fact helpers
+
+## Summary
+
+This PR adds the first opt-in lowered/native helper path for the WAM-C target. Constant fact-only predicates can now be emitted as native C foreign handlers, while the normal predicate entry point remains a generated `call_foreign` trampoline through the existing WAM-C foreign registry.
+
+## What Changed
+
+- Adds `lowered_helpers(true)` support to WAM-C project generation.
+- Detects simple fact-only predicates whose head arguments are atoms or integers.
+- Emits native C `WamForeignHandler` helpers for those fact rows.
+- Registers lowered helpers through `setup_lowered_wam_c_helpers`.
+- Keeps detected recursive kernels excluded from this generic lowered-helper path.
+- Adds generation and executable smoke coverage for a lowered fact-only predicate.
+- Updates `WAM_C_TARGET_NEXT_STEPS.md` to mark this branch active and recommend planner/selection metadata next.
+
+## Validation
+
+- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
+- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
+- `git diff --check`
+
+## Follow-Up
+
+Next recommended branch: `feat/wam-c-lowered-helper-planner`.

--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,13 +5,13 @@ Status date: 2026-05-12
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `8268a7cd` (`Merge pull request #2039 from s243a/perf/wam-c-pack-instruction`)
+- `main` at `ae7d6d0e` (`Merge pull request #2040 from s243a/test/wam-c-memory-lifecycle-asan`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
 
 Active branch:
 
-- `test/wam-c-memory-lifecycle-asan`
+- `feat/wam-c-lowered-helper-prototype`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -37,7 +37,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Effective-distance LMDB fact-storage wiring | Done | `facts_lmdb` generator mode, LMDB seeder/validator, `c-wam-accumulated-lmdb` matrix targets, `dev` parity smoke against Prolog |
 | Classic recursive program e2e | Done | Generated Prolog-to-WAM-C Fibonacci smoke, `set_*` instruction support, dereferenced constants/results, call-base choicepoint pruning |
 | Packed instruction layout | Done | `InstructionPayload` union keyed by `WamInstrTag`, typed generated initializers, typed runtime dispatch payload reads, switch-table cleanup guarded by switch tags |
-| ASAN memory lifecycle smoke | Done on active branch | ASAN-generated executable smoke covers switch table setup replacement, indexed clauses, FactSource loading, native foreign kernel dispatch, and repeated top-level calls |
+| ASAN memory lifecycle smoke | Done | ASAN-generated executable smoke covers switch table setup replacement, indexed clauses, FactSource loading, native foreign kernel dispatch, and repeated top-level calls |
+| Lowered fact-only helper prototype | In progress | `lowered_helpers(true)` emits native C foreign handlers for constant fact-only predicates plus a `call_foreign` trampoline |
 
 ## Current C Target Baseline
 
@@ -57,6 +58,9 @@ The C target is now a credible small WAM backend:
 - Supports basic `builtin_call` delegation for tested builtins:
   `atom/1`, `integer/1`, `is_list/1`, `=/2`, and `is/2`.
 - Supports deterministic `call_foreign` dispatch through a C handler registry.
+- Can opt into a prototype lowered-helper path for constant fact-only
+  predicates, emitted as native C foreign handlers behind `call_foreign`
+  trampolines.
 - Supports a deterministic native `category_ancestor/4` handler over an
   in-memory category-parent edge table.
 - Supports loading category-parent facts from TSV through a small
@@ -105,7 +109,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup and all-hop collection; add more kernel kinds only after runtime support exists. |
 | Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`; broaden as more native C kernels land. |
-| Lowered/native helper functions | Missing | Done | Done | Consider after foreign kernels; C can lower simple fact-only or deterministic predicates. |
+| Lowered/native helper functions | Partial/Active | Done | Done | Active branch prototypes constant fact-only native helpers via the existing foreign registry. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
 | Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB `kernels_on`/`kernels_off`; next gap is larger artifact layouts. |
@@ -115,23 +119,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `test/wam-c-memory-lifecycle-asan`
-
-Goal: make the C runtime cleanup story harder to regress as generated programs
-grow.
-
-Scope:
-
-- Add an AddressSanitizer-friendly generated executable smoke, ideally covering
-  switch tables, predicate setup replacement, atoms, facts, foreign handlers,
-  and classic recursive execution in one path.
-- Keep the default suite portable if ASAN is unavailable; run the sanitizer
-  smoke opportunistically or behind a clearly named test helper.
-- Use this to validate the packed-instruction cleanup path on larger programs.
-
-Status: ready on the active branch pending PR/merge.
-
-### 2. `feat/wam-c-lowered-helper-prototype`
+### 1. `feat/wam-c-lowered-helper-prototype`
 
 Goal: start closing the C gap with the Haskell and Rust hybrid WAM lowered
 helper paths.
@@ -144,12 +132,24 @@ Scope:
 - Prefer a fact-only or simple deterministic helper before attempting aggregate
   or multi-result helpers.
 
+Status: active; constant fact-only helper prototype is implemented and passing
+local executable smoke.
+
+### 2. `feat/wam-c-lowered-helper-planner`
+
+Goal: make C lowered-helper selection less ad hoc and closer to Haskell/Rust
+hybrid routing.
+
+Scope:
+
+- Add explicit selection/planning metadata for C lowered helpers.
+- Keep detected recursive kernels excluded from generic lowering.
+- Report which predicates were lowered, interpreted, or rejected.
+
 ## Suggested Immediate Next Step
 
-Open a PR for `test/wam-c-memory-lifecycle-asan`, then continue with
-`feat/wam-c-lowered-helper-prototype`.
+Continue validating `feat/wam-c-lowered-helper-prototype`.
 
-The branch already has an ASAN lifecycle smoke running locally and has exposed
-two runtime correctness fixes: pruning top-level choicepoints after
-`wam_run_predicate/4` returns, and guarding indexed `retry_me_else` execution
-when no sequential choicepoint exists.
+The active branch now prototypes native C lowered helpers for constant
+fact-only predicates using the existing foreign registry and generated
+`call_foreign` trampolines.

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -52,13 +52,17 @@ write_wam_c_project(Predicates, Options, ProjectDir) :-
 
     % Compile predicates and generate lib.c
     pairs_keys(DetectedKernels, DetectedKeys),
+    compile_lowered_helpers_for_project(Predicates, Options, LoweredKeys, LoweredCode, SetupLoweredCode),
     generate_setup_detected_kernels_c(DetectedKernels, SetupKernelCode),
-    compile_predicates_for_project(Predicates, [detected_kernel_keys(DetectedKeys)|Options],
+    compile_predicates_for_project(Predicates,
+                                   [detected_kernel_keys(DetectedKeys),
+                                    lowered_helper_keys(LoweredKeys)|Options],
                                    PredicatesCode),
-    format(atom(LibCode), '#include "wam_runtime.h"~n~n~w~n~n~w',
-           [SetupKernelCode, PredicatesCode]),
+    format(atom(LibCode), '#include "wam_runtime.h"~n~n~w~n~n~w~n~n~w',
+           [SetupKernelCode, LoweredCode, SetupLoweredCode]),
+    format(atom(LibCodeWithPredicates), '~w~n~n~w', [LibCode, PredicatesCode]),
     directory_file_path(ProjectDir, 'lib.c', LibPath),
-    write_file(LibPath, LibCode),
+    write_file(LibPath, LibCodeWithPredicates),
 
     format('WAM C project created at: ~w~n', [ProjectDir]).
 
@@ -76,7 +80,12 @@ compile_predicates_for_project([PredIndicator|Rest], Options, Code) :-
     predicate_indicator_parts(PredIndicator, Module, Pred, Arity),
     format(atom(Key), '~w/~w', [Pred, Arity]),
     option(detected_kernel_keys(DetectedKeys), Options, []),
+    option(lowered_helper_keys(LoweredKeys), Options, []),
     (   memberchk(Key, DetectedKeys)
+    ->  format(atom(WamCode), '~w/~w:\n    call_foreign ~w, ~w\n    proceed',
+               [Pred, Arity, Key, Arity]),
+        compile_wam_predicate_to_c(Module:Pred/Arity, WamCode, Options, PredCode)
+    ;   memberchk(Key, LoweredKeys)
     ->  format(atom(WamCode), '~w/~w:\n    call_foreign ~w, ~w\n    proceed',
                [Pred, Arity, Key, Arity]),
         compile_wam_predicate_to_c(Module:Pred/Arity, WamCode, Options, PredCode)
@@ -145,6 +154,103 @@ wam_c_kernel_max_depth(ConfigOps, MaxDepth) :-
     ->  MaxDepth = MaxDepth0
     ;   MaxDepth = 10
     ).
+
+% ============================================================================
+% Prototype native lowered helpers
+% ============================================================================
+
+compile_lowered_helpers_for_project(Predicates, Options, LoweredKeys, Code, SetupCode) :-
+    (   option(lowered_helpers(true), Options)
+    ->  findall(Key-CodePart-SetupLine,
+                (   member(PredIndicator, Predicates),
+                    lowered_fact_helper_for_predicate(PredIndicator, Key, CodePart, SetupLine)
+                ),
+                Entries),
+        findall(K, member(K-_-_, Entries), LoweredKeys),
+        findall(C, member(_-C-_, Entries), Codes),
+        findall(S, member(_-_-S, Entries), SetupLines),
+        atomic_list_concat(Codes, '\n\n', Code),
+        atomic_list_concat(SetupLines, '\n', SetupBody),
+        format(atom(SetupCode),
+               'void setup_lowered_wam_c_helpers(WamState* state) {\n~w\n}',
+               [SetupBody])
+    ;   LoweredKeys = [],
+        Code = '',
+        SetupCode = 'void setup_lowered_wam_c_helpers(WamState* state) {\n    (void)state;\n}'
+    ).
+
+lowered_fact_helper_for_predicate(PredIndicator, Key, Code, SetupLine) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
+    functor(Head, Pred, Arity),
+    findall(Args,
+            (   user:clause(Head, true),
+                Head =.. [_|Args],
+                maplist(wam_c_lowered_constant, Args)
+            ),
+            Rows),
+    Rows \= [],
+    \+ ( user:clause(Head, Body), Body \== true ),
+    format(atom(Key), '~w/~w', [Pred, Arity]),
+    wam_c_symbol_name(Pred, Arity, Symbol),
+    maplist(wam_c_lowered_fact_row(Arity), Rows, RowCodes),
+    atomic_list_concat(RowCodes, '\n', BodyCode),
+    format(atom(Code),
+'static bool ~w(WamState *state, const char *pred, int arity) {
+    (void)pred;
+    if (arity != ~w) return false;
+~w
+    return false;
+}',
+           [Symbol, Arity, BodyCode]),
+    format(atom(SetupLine),
+           '    wam_register_foreign_predicate(state, "~w", ~w, ~w);',
+           [Key, Arity, Symbol]).
+
+wam_c_lowered_constant(Arg) :- atom(Arg), !.
+wam_c_lowered_constant(Arg) :- integer(Arg).
+
+wam_c_symbol_name(Pred, Arity, Symbol) :-
+    atom_chars(Pred, Chars),
+    maplist(wam_c_symbol_char, Chars, SafeChars),
+    atom_chars(SafePred, SafeChars),
+    format(atom(Symbol), 'wam_c_lowered_~w_~w', [SafePred, Arity]).
+
+wam_c_symbol_char(Char, Char) :-
+    char_type(Char, alnum), !.
+wam_c_symbol_char('_', '_') :- !.
+wam_c_symbol_char(_, '_').
+
+wam_c_lowered_fact_row(Arity, Args, Code) :-
+    findall(MatchLine,
+            (   nth0(I, Args, Arg),
+                c_value_literal(Arg, ValLit),
+                format(atom(MatchLine),
+                       '    if (!val_is_unbound(*cells[~w]) && !val_equal(*cells[~w], ~w)) match = false;',
+                       [I, I, ValLit])
+            ),
+            MatchLines),
+    findall(BindLine,
+            (   nth0(I, Args, Arg),
+                c_value_literal(Arg, ValLit),
+                format(atom(BindLine),
+                       '        if (val_is_unbound(*cells[~w])) { trail_binding(state, cells[~w]); *cells[~w] = ~w; }',
+                       [I, I, I, ValLit])
+            ),
+            BindLines),
+    atomic_list_concat(MatchLines, '\n', MatchCode),
+    atomic_list_concat(BindLines, '\n', BindCode),
+    format(atom(Code),
+'    {
+        WamValue *cells[~w];
+        for (int i = 0; i < ~w; i++) cells[i] = wam_deref_ptr(state, &state->A[i]);
+        bool match = true;
+~w
+        if (match) {
+~w
+            return true;
+        }
+    }',
+           [Arity, Arity, MatchCode, BindCode]).
 
 % ============================================================================
 % PHASE 2: WAM instructions -> C Struct Literals

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -310,6 +310,26 @@ test_kernel_detector_project_generation :-
         fail_test(Test, 'generated project did not lower detected kernel')
     ).
 
+test_lowered_fact_helper_generation :-
+    Test = 'WAM-C: fact-only predicates can lower to native helper',
+    assertz(user:wam_c_lowered_pair(a, b)),
+    assertz(user:wam_c_lowered_pair(a, c)),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(ProjectDir), '/tmp/unifyweaver_wam_c_lowered_fact_project_~w', [Stamp]),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    (   write_wam_c_project([user:wam_c_lowered_pair/2], [lowered_helpers(true)], ProjectDir),
+        read_file_to_string(LibPath, LibS, []),
+        sub_string(LibS, _, _, _, 'static bool wam_c_lowered_wam_c_lowered_pair_2'),
+        sub_string(LibS, _, _, _, 'void setup_lowered_wam_c_helpers'),
+        sub_string(LibS, _, _, _, 'wam_register_foreign_predicate(state, "wam_c_lowered_pair/2", 2'),
+        sub_string(LibS, _, _, _, 'INSTR_CALL_FOREIGN'),
+        sub_string(LibS, _, _, _, '.pred = "wam_c_lowered_pair/2"')
+    ->  pass(Test)
+    ;   fail_test(Test, 'lowered fact helper was not emitted')
+    ),
+    retractall(user:wam_c_lowered_pair(_, _)).
+
 test_unsupported_instruction_fails_loudly :-
     Test = 'WAM-C: unsupported instructions fail loudly',
     BadWamCode = 'foo/1:\n    unknown_opcode A1\n    proceed',
@@ -500,6 +520,16 @@ test_real_prolog_classic_recursive_executable_smoke :-
     ->  (   run_real_prolog_classic_recursive_executable_smoke
         ->  pass(Test)
         ;   fail_test(Test, 'real Prolog classic recursive executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
+test_lowered_fact_helper_executable_smoke :-
+    Test = 'WAM-C: lowered fact helper executable smoke',
+    (   gcc_available
+    ->  (   run_lowered_fact_helper_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'lowered fact helper executable failed')
         )
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
@@ -881,6 +911,26 @@ run_real_prolog_classic_recursive_executable_smoke :-
         run_c_smoke_plain(ExePath)
     ->  retractall(user:wam_c_classic_fib(_, _))
     ;   retractall(user:wam_c_classic_fib(_, _)),
+        fail
+    ).
+
+run_lowered_fact_helper_executable_smoke :-
+    assertz(user:wam_c_lowered_pair(a, b)),
+    assertz(user:wam_c_lowered_pair(a, c)),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(ProjectDir), '/tmp/unifyweaver_wam_c_lowered_fact_smoke_~w', [Stamp]),
+    directory_file_path(ProjectDir, 'wam_runtime.c', RuntimePath),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    directory_file_path(ProjectDir, 'main.c', MainPath),
+    directory_file_path(ProjectDir, 'wam_c_lowered_fact_smoke', ExePath),
+    (   write_wam_c_project([user:wam_c_lowered_pair/2], [lowered_helpers(true)], ProjectDir),
+        wam_c_lowered_fact_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, LibPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  retractall(user:wam_c_lowered_pair(_, _))
+    ;   retractall(user:wam_c_lowered_pair(_, _)),
         fail
     ).
 
@@ -1591,6 +1641,45 @@ int main(void) {
 }
 ', [DataPath]).
 
+wam_c_lowered_fact_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_lowered_pair_2(WamState* state);
+void setup_lowered_wam_c_helpers(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_lowered_pair_2(&state);
+    setup_lowered_wam_c_helpers(&state);
+
+    WamValue ok_args[2] = { val_atom("a"), val_unbound("Out") };
+    int ok_rc = wam_run_predicate(&state, "wam_c_lowered_pair/2", ok_args, 2);
+    if (ok_rc != 0 || state.P != WAM_HALT ||
+        state.A[1].tag != VAL_ATOM || strcmp(state.A[1].data.atom, "b") != 0) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue ground_args[2] = { val_atom("a"), val_atom("c") };
+    int ground_rc = wam_run_predicate(&state, "wam_c_lowered_pair/2", ground_args, 2);
+    if (ground_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue fail_args[2] = { val_atom("z"), val_unbound("Out") };
+    int fail_rc = wam_run_predicate(&state, "wam_c_lowered_pair/2", fail_args, 2);
+    if (fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_real_builtin_smoke_main(
 '#include "wam_runtime.h"
 
@@ -1922,6 +2011,7 @@ run_tests_once :-
     test_streaming_foreign_results_generation,
     test_kernel_detector_setup_generation,
     test_kernel_detector_project_generation,
+    test_lowered_fact_helper_generation,
     test_unsupported_instruction_fails_loudly,
     test_no_zero_instruction_fallback,
     test_list_target_pc_emission,
@@ -1940,6 +2030,7 @@ run_tests_once :-
     test_real_prolog_is_list_executable_smoke,
     test_real_prolog_unify_executable_smoke,
     test_real_prolog_classic_recursive_executable_smoke,
+    test_lowered_fact_helper_executable_smoke,
     test_asan_memory_lifecycle_executable_smoke,
     format('~n=== WAM-C Target Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).


### PR DESCRIPTION
## Summary

This PR adds the first opt-in lowered/native helper path for the WAM-C target. Constant fact-only predicates can now be emitted as native C foreign handlers, while the normal predicate entry point remains a generated `call_foreign` trampoline through the existing WAM-C foreign registry.

## What Changed

- Adds `lowered_helpers(true)` support to WAM-C project generation.
- Detects simple fact-only predicates whose head arguments are atoms or integers.
- Emits native C `WamForeignHandler` helpers for those fact rows.
- Registers lowered helpers through `setup_lowered_wam_c_helpers`.
- Keeps detected recursive kernels excluded from this generic lowered-helper path.
- Adds generation and executable smoke coverage for a lowered fact-only predicate.
- Updates `WAM_C_TARGET_NEXT_STEPS.md` to mark this branch active and recommend planner/selection metadata next.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
- `git diff --check`

## Follow-Up

Next recommended branch: `feat/wam-c-lowered-helper-planner`.