### PR TITLE
Audit Go WAM parity against Rust and Haskell

### DIFF
--- a/PR_wam_go_rust_haskell_parity_audit.md
+++ b/PR_wam_go_rust_haskell_parity_audit.md
@@ -1,0 +1,21 @@
+# PR Title
+
+Audit Go WAM parity against Rust and Haskell
+
+# PR Description
+
+## Summary
+
+- Add a Go WAM parity audit comparing the Go hybrid WAM target against the Rust and Haskell runtime/builtin baseline.
+- Document concrete Go parity gaps for follow-up work, including `member/2` enumeration, term builtins, `copy_term/2`, `is_list/1`, `display/1`, `=/2`, `set` aggregation, and the likely `=</2` dispatch typo.
+- Update stale Go generator assertions to match the current atom interning output (`internAtom("...")`) instead of old raw `&Atom{Name: ...}` literals.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -1,0 +1,61 @@
+# WAM Go Parity Audit
+
+This note compares the Go hybrid WAM target against the Rust and Haskell WAM
+targets, using the Lua and Python parity audits as secondary references for the
+current cross-target builtin/runtime baseline.
+
+## Verified Runtime Surface
+
+| Area | Go support | Rust/Haskell baseline | Status |
+| --- | --- | --- | --- |
+| Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries | Choice point stack with normal, builtin, and fact-stream resume states | Partial |
+| Direct fact dispatch | Foreign/native kernel registration and indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Partial |
+| Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `count`, `sum`, `min`, `max` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Partial: no `set` aggregate result |
+| Structural builtins | `member/2`, `length/2`, `append/3` | `member/2`, `length/2`; Rust `append/3` is explicitly unimplemented | Partial: `member/2` is first-solution only |
+| Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1` | Includes `is_list/1` in the current baseline | Partial: no `is_list/1` |
+| Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `>=/2` | Includes `=</2` | Partial: `=</2` handler is misspelled as `=< /2` |
+| Unification builtin | `\=/2` | `=/2`, `\=/2` | Partial: no explicit `=/2` builtin handler |
+| Term inspection | Not present in `executeBuiltin/2` | `functor/3`, `arg/3` | Gap |
+| Univ | Not present in `executeBuiltin/2` | `=../2` compose/decompose | Gap |
+| Copying | Not present in `executeBuiltin/2` | `copy_term/2` with fresh variables and preserved sharing | Gap |
+| Control | `true/0`, `fail/0`, `!/0`, `\+/1`, `CutIte` | Same baseline, with broader isolated-goal NAF in Haskell/Python | Partial: `\+/1` only dispatches builtin-shaped goals |
+| IO | `write/1`, `nl/0` | `write/1`, `display/1`, `nl/0` | Partial: no `display/1` |
+
+## Immediate Findings
+
+- `tests/test_wam_go_generator.pl` had stale expectations for atom literals.
+  The Go target now emits `internAtom("...")` instead of raw
+  `&Atom{Name: "..."}` literals, so the assertions needed to follow the
+  current intern-table design.
+- The Go WAM runtime has a substantial execution core, but its builtin set is
+  behind Rust/Haskell/Lua/Python for term inspection and copying.
+- `member/2` succeeds on the first unifiable element and does not push builtin
+  choice points for later list members. This mirrors the Python gap that was
+  recently closed.
+- The `=</2` comparison appears unreachable because the handler key is
+  `=< /2` with a space.
+
+## Recommended Follow-Up Order
+
+1. Add a focused generated-project E2E parity suite for Go WAM builtins, similar
+   to the Python and Lua generated-project tests.
+2. Fix the narrow builtin dispatch typo for `=</2` and add `is_list/1` plus
+   `display/1`; these are small, low-risk surface parity patches.
+3. Add term builtin parity: `functor/3`, `arg/3`, `=../2`, and `copy_term/2`.
+4. Upgrade `member/2` to enumerate through builtin choice points so aggregate
+   collection can observe all list members.
+5. Add `set` aggregate support if Go is expected to match the current Lua/Python
+   aggregate parity surface.
+
+## Verification Commands
+
+Use these checks after touching Go WAM parity:
+
+```sh
+swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
+swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
+swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"
+```

--- a/tests/test_wam_go_generator.pl
+++ b/tests/test_wam_go_generator.pl
@@ -22,7 +22,7 @@ wam_only_caller(X, Z) :- wam_only_inner(X, Y), wam_only_inner(Y, Z).
 
 test(wam_get_constant) :-
     wam_instruction_to_go_literal(get_constant(atom(john), 'A1'), Literal),
-    assertion(Literal == '&GetConstant{C: &Atom{Name: "john"}, Ai: 0}').
+    assertion(Literal == '&GetConstant{C: internAtom("john"), Ai: 0}').
 
 test(wam_get_variable) :-
     wam_instruction_to_go_literal(get_variable('X1', 'A1'), Literal),
@@ -37,8 +37,8 @@ test(wam_switch_on_constant) :-
         Table = [john-default, jane-'L1'],
         wam_instruction_to_go_literal(switch_on_constant(Table), Literal),
         assertion(sub_string(Literal, _, _, _, '&SwitchOnConstant{Cases: []ConstCase{')),
-        assertion(sub_string(Literal, _, _, _, '{Val: &Atom{Name: "john"}, Label: "default"}')),
-        assertion(sub_string(Literal, _, _, _, '{Val: &Atom{Name: "jane"}, Label: "L1"}'))
+        assertion(sub_string(Literal, _, _, _, '{Val: internAtom("john"), Label: "default"}')),
+        assertion(sub_string(Literal, _, _, _, '{Val: internAtom("jane"), Label: "L1"}'))
     )).
 
 test(parse_wam_line_label) :-
@@ -49,7 +49,7 @@ test(parse_wam_line_label) :-
 test(parse_wam_line_instruction) :-
     WamCode = "    get_constant john, A1",
     compile_wam_predicate_to_go(test/1, WamCode, [], GoCode),
-    assertion(sub_string(GoCode, _, _, _, '&GetConstant{C: &Atom{Name: "john"}, Ai: 0}')).
+    assertion(sub_string(GoCode, _, _, _, '&GetConstant{C: internAtom("john"), Ai: 0}')).
 
 test(parse_wam_line_switch) :-
     once((
@@ -89,7 +89,7 @@ test(robust_switch_parsing) :-
     once((
         % Test malformed input robustness
         wam_line_to_go_literal(["switch_on_constant", "john"], Literal),
-        assertion(sub_string(Literal, _, _, _, '&Atom{Name: "malformed"}'))
+        assertion(sub_string(Literal, _, _, _, 'internAtom("malformed")'))
     )).
 
 :- end_tests(wam_go_generator).


### PR DESCRIPTION
## Summary

- Add a Go WAM parity audit comparing the Go hybrid WAM target against the Rust and Haskell runtime/builtin baseline.
- Document concrete Go parity gaps for follow-up work, including `member/2` enumeration, term builtins, `copy_term/2`, `is_list/1`, `display/1`, `=/2`, `set` aggregation, and the likely `=</2` dispatch typo.
- Update stale Go generator assertions to match the current atom interning output (`internAtom("...")`) instead of old raw `&Atom{Name: ...}` literals.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`
