### PR TITLE
bench(csharp-query): Wrap C# query calibration refresh command

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -142,6 +142,12 @@ preserved. Use `--format none` instead of `--format calibration-tsv` for
 scripted refreshes that should only write the artifact and avoid printing the
 full table to stdout.
 
+The usual full guarded refresh is wrapped by:
+
+```bash
+python examples/benchmark/refresh_csharp_query_source_mode_calibration.py
+```
+
 ```bash
 python examples/benchmark/benchmark_csharp_query_source_mode_sweep.py \
   --require-idle \

--- a/examples/benchmark/refresh_csharp_query_source_mode_calibration.py
+++ b/examples/benchmark/refresh_csharp_query_source_mode_calibration.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Refresh the checked-in C# query graph source-mode calibration artifact.
+
+This is a thin wrapper around benchmark_csharp_query_source_mode_sweep.py that
+keeps the validated guarded, quiet artifact-writer invocation in one place.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCHMARK_DIR = ROOT / "examples" / "benchmark"
+SWEEP_SCRIPT = BENCHMARK_DIR / "benchmark_csharp_query_source_mode_sweep.py"
+CALIBRATION_ARTIFACT = BENCHMARK_DIR / "csharp_query_graph_source_mode_calibration.tsv"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workloads", default="all")
+    parser.add_argument("--scales", default="300,1k,5k,10k")
+    parser.add_argument("--source-modes", default="auto,preload,artifact-prebuilt")
+    parser.add_argument("--repetitions", type=int, default=1)
+    parser.add_argument("--stability-runs", type=int, default=3)
+    parser.add_argument(
+        "--calibration-artifact",
+        type=Path,
+        default=CALIBRATION_ARTIFACT,
+        help="Calibration TSV to compare and update.",
+    )
+    parser.add_argument(
+        "--no-require-idle",
+        action="store_true",
+        help="Do not pass --require-idle to the underlying sweep.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the underlying command without running it.",
+    )
+    return parser.parse_args(argv)
+
+
+def build_refresh_command(args: argparse.Namespace) -> list[str]:
+    command = [
+        sys.executable,
+        str(SWEEP_SCRIPT),
+        "--workloads",
+        args.workloads,
+        "--scales",
+        args.scales,
+        "--source-modes",
+        args.source_modes,
+        "--repetitions",
+        str(args.repetitions),
+        "--stability-runs",
+        str(args.stability_runs),
+        "--compare-calibration",
+        "--format",
+        "none",
+        "--calibration-artifact",
+        str(args.calibration_artifact),
+        "--write-calibration-artifact",
+    ]
+    if not args.no_require_idle:
+        command.insert(2, "--require-idle")
+    return command
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    command = build_refresh_command(args)
+    if args.dry_run:
+        print(shlex.join(command))
+        return 0
+    return subprocess.run(command, cwd=ROOT).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_csharp_query_calibration_refresh_wrapper.py
+++ b/tests/test_csharp_query_calibration_refresh_wrapper.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
+
+from refresh_csharp_query_source_mode_calibration import (  # noqa: E402
+    CALIBRATION_ARTIFACT,
+    SWEEP_SCRIPT,
+    build_refresh_command,
+    main,
+    parse_args,
+)
+
+
+class CSharpQueryCalibrationRefreshWrapperTests(unittest.TestCase):
+    def test_default_command_uses_guarded_quiet_artifact_writer(self) -> None:
+        command = build_refresh_command(parse_args([]))
+
+        self.assertEqual(command[0], sys.executable)
+        self.assertEqual(command[1], str(SWEEP_SCRIPT))
+        self.assertIn("--require-idle", command)
+        self.assertEqual(self._option_value(command, "--workloads"), "all")
+        self.assertEqual(self._option_value(command, "--scales"), "300,1k,5k,10k")
+        self.assertEqual(
+            self._option_value(command, "--source-modes"),
+            "auto,preload,artifact-prebuilt",
+        )
+        self.assertEqual(self._option_value(command, "--repetitions"), "1")
+        self.assertEqual(self._option_value(command, "--stability-runs"), "3")
+        self.assertIn("--compare-calibration", command)
+        self.assertEqual(self._option_value(command, "--format"), "none")
+        self.assertEqual(
+            self._option_value(command, "--calibration-artifact"),
+            str(CALIBRATION_ARTIFACT),
+        )
+        self.assertIn("--write-calibration-artifact", command)
+
+    def test_no_require_idle_removes_idle_guard(self) -> None:
+        command = build_refresh_command(parse_args(["--no-require-idle"]))
+
+        self.assertNotIn("--require-idle", command)
+
+    def test_dry_run_prints_command_without_running(self) -> None:
+        stdout = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout):
+            result = main(["--dry-run", "--no-require-idle"])
+
+        self.assertEqual(result, 0)
+        output = stdout.getvalue()
+        self.assertIn(str(SWEEP_SCRIPT), output)
+        self.assertIn("--format none", output)
+        self.assertIn("--write-calibration-artifact", output)
+
+    @staticmethod
+    def _option_value(command: list[str], option: str) -> str:
+        return command[command.index(option) + 1]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  - Adds `refresh_csharp_query_source_mode_calibration.py` as a one-command wrapper for the guarded quiet calibration
  refresh flow.
  - Defaults to the validated full refresh command: `--require-idle`, all graph workloads, 300/1k/5k/10k scales,
  stability runs, calibration comparison, quiet output, and artifact writing.
  - Adds `--dry-run` for command inspection and `--no-require-idle` for controlled local smoke runs.
  - Documents the wrapper in the benchmark README.
  - Adds unit coverage for default command construction, idle-guard opt-out, and dry-run output.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_calibration_refresh_wrapper.py tests/
  test_csharp_query_source_mode_sweep.py`
  - `python3 -m py_compile examples/benchmark/refresh_csharp_query_source_mode_calibration.py examples/benchmark/
  benchmark_csharp_query_source_mode_sweep.py tests/test_csharp_query_calibration_refresh_wrapper.py tests/
  test_csharp_query_source_mode_sweep.py`
  - `git diff --check`
  - `python3 examples/benchmark/refresh_csharp_query_source_mode_calibration.py --dry-run`
  - Small wrapper smoke against `/tmp/csharp_query_calibration_refresh_wrapper_smoke.tsv`; preserved 25 rows and did not
  modify the checked-in TSV.