### PR TITLE
feat(wam-c): WAM C lowered helper routing

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,13 +5,13 @@ Status date: 2026-05-12
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `e03da1d5` (`Merge pull request #2042 from s243a/feat/wam-c-lowered-helper-prototype`)
+- `main` at `b78879ed` (`Merge pull request #2043 from s243a/fix/wam-c-asan-availability-probe`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
 
 Active branch:
 
-- `fix/wam-c-asan-availability-probe`
+- `feat/wam-c-lowered-helper-planner`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -39,7 +39,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Packed instruction layout | Done | `InstructionPayload` union keyed by `WamInstrTag`, typed generated initializers, typed runtime dispatch payload reads, switch-table cleanup guarded by switch tags |
 | ASAN memory lifecycle smoke | Done | ASAN-generated executable smoke covers switch table setup replacement, indexed clauses, FactSource loading, native foreign kernel dispatch, and repeated top-level calls |
 | Lowered fact-only helper prototype | Done | `lowered_helpers(true)` emits native C foreign handlers for constant fact-only predicates plus a `call_foreign` trampoline |
-| ASAN availability probe hardening | In progress | Active branch requires a trivial ASAN executable to compile and run before enabling the optional ASAN lifecycle smoke |
+| ASAN availability probe hardening | Done | `asan_available/0` requires a trivial sanitized executable to compile and run before enabling the optional ASAN lifecycle smoke |
+| Lowered helper planner metadata | In progress | Active branch adds explicit lowered/interpreted/rejected helper plans, excludes detected kernels, emits plan comments in generated `lib.c`, and supports `report_lowered_helpers(true)` |
 
 ## Current C Target Baseline
 
@@ -110,7 +111,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup and all-hop collection; add more kernel kinds only after runtime support exists. |
 | Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`; broaden as more native C kernels land. |
-| Lowered/native helper functions | Partial/Active | Done | Done | Active branch prototypes constant fact-only native helpers via the existing foreign registry. |
+| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers plus active planner metadata for lowered/interpreted/rejected routing. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
 | Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB `kernels_on`/`kernels_off`; next gap is larger artifact layouts. |
@@ -131,8 +132,9 @@ Scope:
 - Keep detected recursive kernels excluded from generic lowering.
 - Report which predicates were lowered, interpreted, or rejected.
 
-Status: recommended next feature branch after
-`fix/wam-c-asan-availability-probe` lands.
+Status: active; planner metadata is implemented for constant fact-only helper
+routing, detected-kernel exclusion, generated project reporting, and optional
+console summaries.
 
 ### 2. `feat/wam-c-lowered-helper-benchmark-wiring`
 
@@ -149,11 +151,8 @@ Scope:
 
 ## Suggested Immediate Next Step
 
-Finish `fix/wam-c-asan-availability-probe`, then move to
-`feat/wam-c-lowered-helper-planner`.
+Continue validating `feat/wam-c-lowered-helper-planner`.
 
-The merged lowered-helper prototype is passing locally, but `main` verification
-exposed that the optional ASAN lifecycle smoke can fail when the local ASAN
-runtime is unhealthy. The active fix branch hardens `asan_available/0` by
-requiring a trivial sanitized executable to compile and run before the optional
-ASAN lifecycle smoke is enabled.
+The active branch now exposes explicit WAM-C lowered-helper planning metadata
+in generated projects and through `report_lowered_helpers(true)`. The next
+check is final validation for this branch before moving to benchmark wiring.

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -21,6 +21,7 @@
     wam_instruction_to_c_literal/3,   % +WamInstr, +LabelMap, -CCode
     detect_kernels/2,                 % +Predicates, -DetectedKernels
     generate_setup_detected_kernels_c/2, % +DetectedKernels, -CCode
+    plan_wam_c_lowered_helpers/4,     % +Predicates, +Options, +DetectedKeys, -Plans
     write_wam_c_project/3             % +Predicates, +Options, +ProjectDir
 ]).
 
@@ -52,14 +53,17 @@ write_wam_c_project(Predicates, Options, ProjectDir) :-
 
     % Compile predicates and generate lib.c
     pairs_keys(DetectedKernels, DetectedKeys),
-    compile_lowered_helpers_for_project(Predicates, Options, LoweredKeys, LoweredCode, SetupLoweredCode),
+    plan_wam_c_lowered_helpers(Predicates, Options, DetectedKeys, LoweredPlans),
+    maybe_report_wam_c_lowered_helper_plan(Options, LoweredPlans),
+    compile_lowered_helpers_for_project(LoweredPlans, LoweredKeys, LoweredCode, SetupLoweredCode),
+    render_wam_c_lowered_helper_plan(LoweredPlans, LoweredPlanCode),
     generate_setup_detected_kernels_c(DetectedKernels, SetupKernelCode),
     compile_predicates_for_project(Predicates,
                                    [detected_kernel_keys(DetectedKeys),
                                     lowered_helper_keys(LoweredKeys)|Options],
                                    PredicatesCode),
-    format(atom(LibCode), '#include "wam_runtime.h"~n~n~w~n~n~w~n~n~w',
-           [SetupKernelCode, LoweredCode, SetupLoweredCode]),
+    format(atom(LibCode), '#include "wam_runtime.h"~n~n~w~n~n~w~n~n~w~n~n~w',
+           [LoweredPlanCode, SetupKernelCode, LoweredCode, SetupLoweredCode]),
     format(atom(LibCodeWithPredicates), '~w~n~n~w', [LibCode, PredicatesCode]),
     directory_file_path(ProjectDir, 'lib.c', LibPath),
     write_file(LibPath, LibCodeWithPredicates),
@@ -159,27 +163,87 @@ wam_c_kernel_max_depth(ConfigOps, MaxDepth) :-
 % Prototype native lowered helpers
 % ============================================================================
 
-compile_lowered_helpers_for_project(Predicates, Options, LoweredKeys, Code, SetupCode) :-
+plan_wam_c_lowered_helpers(Predicates, Options, DetectedKeys, Plans) :-
     (   option(lowered_helpers(true), Options)
-    ->  findall(Key-CodePart-SetupLine,
-                (   member(PredIndicator, Predicates),
-                    lowered_fact_helper_for_predicate(PredIndicator, Key, CodePart, SetupLine)
-                ),
-                Entries),
-        findall(K, member(K-_-_, Entries), LoweredKeys),
-        findall(C, member(_-C-_, Entries), Codes),
-        findall(S, member(_-_-S, Entries), SetupLines),
-        atomic_list_concat(Codes, '\n\n', Code),
-        atomic_list_concat(SetupLines, '\n', SetupBody),
+    ->  maplist(plan_wam_c_lowered_helper(DetectedKeys), Predicates, Plans)
+    ;   maplist(plan_wam_c_lowered_helper_disabled, Predicates, Plans)
+    ).
+
+plan_wam_c_lowered_helper(DetectedKeys, PredIndicator, Plan) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
+    format(atom(Key), '~w/~w', [Pred, Arity]),
+    (   memberchk(Key, DetectedKeys)
+    ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, interpreted, detected_kernel)
+    ;   lowered_fact_helper_rows(PredIndicator, Rows)
+    ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, fact_only(Rows))
+    ;   lowered_fact_helper_rejection_reason(PredIndicator, Reason),
+        Plan = wam_c_lowered_helper_plan(Key, PredIndicator, rejected, Reason)
+    ).
+
+plan_wam_c_lowered_helper_disabled(PredIndicator, Plan) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
+    format(atom(Key), '~w/~w', [Pred, Arity]),
+    Plan = wam_c_lowered_helper_plan(Key, PredIndicator, interpreted, lowering_disabled).
+
+lowered_fact_helper_rejection_reason(PredIndicator, non_fact_clause) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
+    functor(Head, Pred, Arity),
+    user:clause(Head, Body),
+    Body \== true,
+    !.
+lowered_fact_helper_rejection_reason(PredIndicator, unsupported_fact_arguments) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
+    functor(Head, Pred, Arity),
+    user:clause(Head, true),
+    !.
+lowered_fact_helper_rejection_reason(_, no_clauses).
+
+compile_lowered_helpers_for_project(Plans, LoweredKeys, Code, SetupCode) :-
+    findall(Key-CodePart-SetupLine,
+            (   member(wam_c_lowered_helper_plan(Key, PredIndicator, lowered, fact_only(Rows)), Plans),
+                lowered_fact_helper_for_predicate(PredIndicator, Rows, Key, CodePart, SetupLine)
+            ),
+            Entries),
+    findall(K, member(K-_-_, Entries), LoweredKeys),
+    findall(C, member(_-C-_, Entries), Codes),
+    findall(S, member(_-_-S, Entries), SetupLines),
+    atomic_list_concat(Codes, '\n\n', Code),
+    (   SetupLines = []
+    ->  SetupCode = 'void setup_lowered_wam_c_helpers(WamState* state) {\n    (void)state;\n}'
+    ;   atomic_list_concat(SetupLines, '\n', SetupBody),
         format(atom(SetupCode),
                'void setup_lowered_wam_c_helpers(WamState* state) {\n~w\n}',
                [SetupBody])
-    ;   LoweredKeys = [],
-        Code = '',
-        SetupCode = 'void setup_lowered_wam_c_helpers(WamState* state) {\n    (void)state;\n}'
     ).
 
-lowered_fact_helper_for_predicate(PredIndicator, Key, Code, SetupLine) :-
+render_wam_c_lowered_helper_plan([], '// WAM-C lowered helper plan: none').
+render_wam_c_lowered_helper_plan(Plans, Code) :-
+    maplist(render_wam_c_lowered_helper_plan_line, Plans, Lines),
+    atomic_list_concat(['// WAM-C lowered helper plan'|Lines], '\n', Code).
+
+render_wam_c_lowered_helper_plan_line(wam_c_lowered_helper_plan(Key, _PredIndicator, Action, Reason), Line) :-
+    wam_c_lowered_plan_reason_label(Reason, ReasonLabel),
+    format(atom(Line), '// - ~w ~w: ~w', [Action, Key, ReasonLabel]).
+
+maybe_report_wam_c_lowered_helper_plan(Options, Plans) :-
+    (   option(report_lowered_helpers(true), Options)
+    ->  findall(Key-ReasonLabel, wam_c_lowered_helper_plan_by_action(Plans, lowered, Key, ReasonLabel), Lowered),
+        findall(Key-ReasonLabel, wam_c_lowered_helper_plan_by_action(Plans, interpreted, Key, ReasonLabel), Interpreted),
+        findall(Key-ReasonLabel, wam_c_lowered_helper_plan_by_action(Plans, rejected, Key, ReasonLabel), Rejected),
+        format(user_error,
+               '[WAM-C] lowered helper plan: lowered=~w interpreted=~w rejected=~w~n',
+               [Lowered, Interpreted, Rejected])
+    ;   true
+    ).
+
+wam_c_lowered_helper_plan_by_action(Plans, Action, Key, ReasonLabel) :-
+    member(wam_c_lowered_helper_plan(Key, _, Action, Reason), Plans),
+    wam_c_lowered_plan_reason_label(Reason, ReasonLabel).
+
+wam_c_lowered_plan_reason_label(fact_only(_Rows), fact_only) :- !.
+wam_c_lowered_plan_reason_label(Reason, Reason).
+
+lowered_fact_helper_rows(PredIndicator, Rows) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
     functor(Head, Pred, Arity),
     findall(Args,
@@ -189,7 +253,10 @@ lowered_fact_helper_for_predicate(PredIndicator, Key, Code, SetupLine) :-
             ),
             Rows),
     Rows \= [],
-    \+ ( user:clause(Head, Body), Body \== true ),
+    \+ ( user:clause(Head, Body), Body \== true ).
+
+lowered_fact_helper_for_predicate(PredIndicator, Rows, Key, Code, SetupLine) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
     format(atom(Key), '~w/~w', [Pred, Arity]),
     wam_c_symbol_name(Pred, Arity, Symbol),
     maplist(wam_c_lowered_fact_row(Arity), Rows, RowCodes),

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -330,6 +330,49 @@ test_lowered_fact_helper_generation :-
     ),
     retractall(user:wam_c_lowered_pair(_, _)).
 
+test_lowered_helper_planner_metadata :-
+    Test = 'WAM-C: lowered helper planner reports routing decisions',
+    assertz(user:wam_c_plan_fact(a, b)),
+    assertz((user:wam_c_plan_rule(X) :- user:wam_c_plan_fact(X, _))),
+    (   plan_wam_c_lowered_helpers([user:wam_c_plan_fact/2,
+                                     user:wam_c_plan_rule/1,
+                                     user:category_ancestor/4],
+                                    [lowered_helpers(true)],
+                                    ['category_ancestor/4'],
+                                    Plans),
+        member(wam_c_lowered_helper_plan('wam_c_plan_fact/2', _, lowered, fact_only([[a,b]])), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_plan_rule/1', _, rejected, non_fact_clause), Plans),
+        member(wam_c_lowered_helper_plan('category_ancestor/4', _, interpreted, detected_kernel), Plans)
+    ->  pass(Test)
+    ;   fail_test(Test, 'planner did not classify lowered/rejected/interpreted predicates')
+    ),
+    retractall(user:wam_c_plan_fact(_, _)),
+    retractall(user:wam_c_plan_rule(_)).
+
+test_lowered_helper_plan_generation :-
+    Test = 'WAM-C: generated project reports lowered helper plan',
+    assertz(user:wam_c_plan_emit_fact(a, b)),
+    assertz((user:wam_c_plan_emit_rule(X) :- user:wam_c_plan_emit_fact(X, _))),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(ProjectDir), '/tmp/unifyweaver_wam_c_lowered_plan_project_~w', [Stamp]),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    (   write_wam_c_project([user:wam_c_plan_emit_fact/2,
+                             user:wam_c_plan_emit_rule/1],
+                            [lowered_helpers(true), report_lowered_helpers(true)],
+                            ProjectDir),
+        read_file_to_string(LibPath, LibS, []),
+        sub_string(LibS, _, _, _, '// WAM-C lowered helper plan'),
+        sub_string(LibS, _, _, _, '// - lowered wam_c_plan_emit_fact/2: fact_only'),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_plan_emit_rule/1: non_fact_clause'),
+        sub_string(LibS, _, _, _, 'INSTR_CALL_FOREIGN'),
+        sub_string(LibS, _, _, _, 'setup_wam_c_plan_emit_rule_1')
+    ->  pass(Test)
+    ;   fail_test(Test, 'generated project did not include lowered helper plan metadata')
+    ),
+    retractall(user:wam_c_plan_emit_fact(_, _)),
+    retractall(user:wam_c_plan_emit_rule(_)).
+
 test_unsupported_instruction_fails_loudly :-
     Test = 'WAM-C: unsupported instructions fail loudly',
     BadWamCode = 'foo/1:\n    unknown_opcode A1\n    proceed',
@@ -2018,6 +2061,8 @@ run_tests_once :-
     test_kernel_detector_setup_generation,
     test_kernel_detector_project_generation,
     test_lowered_fact_helper_generation,
+    test_lowered_helper_planner_metadata,
+    test_lowered_helper_plan_generation,
     test_unsupported_instruction_fails_loudly,
     test_no_zero_instruction_fallback,
     test_list_target_pc_emission,


### PR DESCRIPTION
## Summary

This PR adds explicit planning metadata for the WAM-C lowered-helper path. Instead of directly emitting any fact-only helper that happens to match, WAM-C now builds a lowered-helper plan that records whether each predicate is lowered, interpreted, or rejected, while keeping detected recursive kernels out of generic lowering.

## What Changed

- Adds `plan_wam_c_lowered_helpers/4` for lowered/interpreted/rejected routing decisions.
- Keeps detected recursive kernels interpreted through their existing `call_foreign` trampoline path.
- Drives lowered helper emission from the planner output.
- Emits lowered-helper plan comments into generated `lib.c`.
- Adds `report_lowered_helpers(true)` for an optional console routing summary.
- Adds tests for planner metadata and generated project plan reporting.
- Updates `WAM_C_TARGET_NEXT_STEPS.md` to mark planner work active and point the next branch at benchmark wiring.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
- `git diff --check`

## Follow-Up

Next recommended branch: `feat/wam-c-lowered-helper-benchmark-wiring`.
