### PR TITLE
bench(wam-c): Wire WAM C lowered helper matrix targets

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,13 +5,13 @@ Status date: 2026-05-12
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `b78879ed` (`Merge pull request #2043 from s243a/fix/wam-c-asan-availability-probe`)
+- `main` at `55b898f9` (`Merge pull request #2046 from s243a/feat/wam-c-lowered-helper-planner`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
 
 Active branch:
 
-- `feat/wam-c-lowered-helper-planner`
+- `feat/wam-c-lowered-helper-benchmark-wiring`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -40,7 +40,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | ASAN memory lifecycle smoke | Done | ASAN-generated executable smoke covers switch table setup replacement, indexed clauses, FactSource loading, native foreign kernel dispatch, and repeated top-level calls |
 | Lowered fact-only helper prototype | Done | `lowered_helpers(true)` emits native C foreign handlers for constant fact-only predicates plus a `call_foreign` trampoline |
 | ASAN availability probe hardening | Done | `asan_available/0` requires a trivial sanitized executable to compile and run before enabling the optional ASAN lifecycle smoke |
-| Lowered helper planner metadata | In progress | Active branch adds explicit lowered/interpreted/rejected helper plans, excludes detected kernels, emits plan comments in generated `lib.c`, and supports `report_lowered_helpers(true)` |
+| Lowered helper planner metadata | Done | Explicit lowered/interpreted/rejected helper plans, detected-kernel exclusion, generated `lib.c` plan comments, and `report_lowered_helpers(true)` |
+| Lowered helper benchmark wiring | In progress | Active branch adds `c-wam-lowered-helper` and `c-wam-lowered-helper-interpreted` matrix targets over a tiny fact-helper benchmark |
 
 ## Current C Target Baseline
 
@@ -111,7 +112,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup and all-hop collection; add more kernel kinds only after runtime support exists. |
 | Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`; broaden as more native C kernels land. |
-| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers plus active planner metadata for lowered/interpreted/rejected routing. |
+| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers, planner metadata, and active interpreted-vs-lowered matrix wiring. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
 | Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB `kernels_on`/`kernels_off`; next gap is larger artifact layouts. |
@@ -121,22 +122,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lowered-helper-planner`
-
-Goal: make C lowered-helper selection less ad hoc and closer to Haskell/Rust
-hybrid routing.
-
-Scope:
-
-- Add explicit selection/planning metadata for C lowered helpers.
-- Keep detected recursive kernels excluded from generic lowering.
-- Report which predicates were lowered, interpreted, or rejected.
-
-Status: active; planner metadata is implemented for constant fact-only helper
-routing, detected-kernel exclusion, generated project reporting, and optional
-console summaries.
-
-### 2. `feat/wam-c-lowered-helper-benchmark-wiring`
+### 1. `feat/wam-c-lowered-helper-benchmark-wiring`
 
 Goal: prove the lowered-helper path on a small benchmark surface before
 attempting broader helper classes.
@@ -149,10 +135,25 @@ Scope:
   local validation.
 - Record lowered/interpreted planning output with the benchmark artifacts.
 
+Status: active; a tiny fact-helper matrix target pair is implemented for
+interpreted-vs-lowered WAM-C comparison.
+
+### 2. `feat/wam-c-lowered-helper-body-calls`
+
+Goal: broaden C lowered helpers past fact-only predicates into one small
+deterministic body-call shape.
+
+Scope:
+
+- Pick one simple deterministic helper body that Haskell/Rust already lower.
+- Keep fallback/interpreter routing explicit through the planner metadata.
+- Add executable smoke coverage before expanding to aggregates or multi-result
+  helpers.
+
 ## Suggested Immediate Next Step
 
-Continue validating `feat/wam-c-lowered-helper-planner`.
+Continue validating `feat/wam-c-lowered-helper-benchmark-wiring`.
 
-The active branch now exposes explicit WAM-C lowered-helper planning metadata
-in generated projects and through `report_lowered_helpers(true)`. The next
-check is final validation for this branch before moving to benchmark wiring.
+The active branch wires a tiny fact-helper benchmark into the existing matrix
+surface as separate interpreted and lowered WAM-C targets. The next check is
+final validation, then the following branch can broaden lowered helper shapes.

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -155,6 +155,8 @@ def available_targets(requested: list[str]) -> list[str]:
     c_wam_targets = {
         "c-wam-accumulated",
         "c-wam-accumulated-no-kernels",
+        "c-wam-lowered-helper",
+        "c-wam-lowered-helper-interpreted",
     }
     c_wam_lmdb_targets = {
         "c-wam-accumulated-lmdb",

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -70,6 +70,7 @@ WAM_RUST_MATRIX_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_rust
 WAM_HASKELL_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_haskell_matrix_benchmark.pl"
 WAM_GO_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_go_effective_distance_benchmark.pl"
 WAM_C_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_c_effective_distance_benchmark.pl"
+WAM_C_LOWERED_HELPER_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_c_lowered_helper_benchmark.pl"
 WAM_CLOJURE_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_clojure_optimized_benchmark.pl"
 WAM_SCALA_GENERATOR = ROOT / "examples" / "benchmark" / "generate_wam_scala_effective_distance_benchmark.pl"
 DEFAULT_FACTS = BENCH_DIR / "10k" / "facts.pl"
@@ -333,6 +334,46 @@ def build_wam_c_effective_distance(
             str(lib_path),
             str(main_path),
             *link_flags,
+            "-o",
+            str(binary_path),
+        ],
+        cwd=ROOT,
+    )
+    quoted_dir = shlex.quote(str(project_dir))
+    quoted_binary = shlex.quote(str(binary_path))
+    return ["sh", "-c", f"cd {quoted_dir} && {quoted_binary}"]
+
+
+def build_wam_c_lowered_helper_benchmark(root: Path, scale: str, mode: str) -> list[str]:
+    project_dir = root / f"wam_c_lowered_helper_{mode}" / scale
+    project_dir.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(WAM_C_LOWERED_HELPER_GENERATOR),
+            "--",
+            str(project_dir),
+            mode,
+        ],
+        cwd=ROOT,
+    )
+    runtime_path = project_dir / "wam_runtime.c"
+    lib_path = project_dir / "lib.c"
+    main_path = project_dir / "main.c"
+    binary_path = project_dir / "wam_c_lowered_helper_benchmark"
+    run_command(
+        [
+            "gcc",
+            "-std=c11",
+            "-Wall",
+            "-Wextra",
+            "-I",
+            str(ROOT / "src" / "unifyweaver" / "targets" / "wam_c_runtime"),
+            str(runtime_path),
+            str(lib_path),
+            str(main_path),
             "-o",
             str(binary_path),
         ],
@@ -1017,6 +1058,10 @@ def main() -> int:
                     command = build_wam_c_effective_distance(temp_root, scale, "kernels_on", "facts_lmdb")
                 elif target == "c-wam-accumulated-no-kernels-lmdb":
                     command = build_wam_c_effective_distance(temp_root, scale, "kernels_off", "facts_lmdb")
+                elif target == "c-wam-lowered-helper":
+                    command = build_wam_c_lowered_helper_benchmark(temp_root, scale, "lowered")
+                elif target == "c-wam-lowered-helper-interpreted":
+                    command = build_wam_c_lowered_helper_benchmark(temp_root, scale, "interpreted")
                 elif target == "scala-wam-seeded":
                     command = build_wam_scala_effective_distance(temp_root, scale, "seeded", "kernels_on")
                 elif target == "scala-wam-seeded-artifact":

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -102,6 +102,16 @@ TARGETS: dict[str, TargetInfo] = {
         "hybrid-wam",
         "Hybrid WAM C effective-distance runner with reference DFS, kernels disabled, and LMDB fact storage",
     ),
+    "c-wam-lowered-helper": TargetInfo(
+        "c-wam-lowered-helper",
+        "hybrid-wam-lowered-helper",
+        "Hybrid WAM C fact-helper smoke benchmark with lowered helpers enabled",
+    ),
+    "c-wam-lowered-helper-interpreted": TargetInfo(
+        "c-wam-lowered-helper-interpreted",
+        "hybrid-wam-lowered-helper",
+        "Hybrid WAM C fact-helper smoke benchmark through interpreted WAM facts",
+    ),
     "scala-wam-seeded": TargetInfo(
         "scala-wam-seeded",
         "hybrid-wam",
@@ -364,6 +374,10 @@ TARGET_SETS: dict[str, list[str]] = {
         "scala-wam-seeded-no-kernels",
         "scala-wam-accumulated",
         "scala-wam-accumulated-no-kernels",
+    ],
+    "c-wam-lowered-helper": [
+        "c-wam-lowered-helper-interpreted",
+        "c-wam-lowered-helper",
     ],
     "scala-wam-artifact": [
         "scala-wam-seeded",

--- a/examples/benchmark/generate_wam_c_lowered_helper_benchmark.pl
+++ b/examples/benchmark/generate_wam_c_lowered_helper_benchmark.pl
@@ -1,0 +1,127 @@
+:- module(generate_wam_c_lowered_helper_benchmark,
+          [ main/0,
+            generate/2
+          ]).
+:- initialization(main, main).
+
+:- use_module('../../src/unifyweaver/targets/wam_c_target').
+:- use_module(library(filesex), [directory_file_path/3, make_directory_path/1]).
+
+%% generate_wam_c_lowered_helper_benchmark.pl
+%%
+%% Generates a tiny WAM-C benchmark project that compares interpreted WAM-C
+%% facts against the prototype lowered fact-helper path.
+%%
+%% Usage:
+%%   swipl -q -s examples/benchmark/generate_wam_c_lowered_helper_benchmark.pl -- \
+%%       <output-dir> [interpreted|lowered]
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv == []
+    ->  true
+    ;   Argv = [OutputDir, ModeAtom]
+    ->  generate(OutputDir, ModeAtom),
+        halt(0)
+    ;   Argv = [OutputDir]
+    ->  generate(OutputDir, lowered),
+        halt(0)
+    ;   format(user_error,
+               'Usage: ... -- <output-dir> [interpreted|lowered]~n',
+               []),
+        halt(1)
+    ).
+
+main :-
+    format(user_error, 'Error: WAM-C lowered-helper benchmark generation failed~n', []),
+    halt(1).
+
+generate(OutputDir, Mode) :-
+    parse_mode(Mode, ParsedMode),
+    setup_benchmark_facts,
+    make_directory_path(OutputDir),
+    mode_options(ParsedMode, Options),
+    write_wam_c_project([user:wam_c_bench_pair/2], Options, OutputDir),
+    directory_file_path(OutputDir, 'main.c', MainPath),
+    lowered_helper_benchmark_main(MainCode),
+    write_text_file(MainPath, MainCode),
+    directory_file_path(OutputDir, 'README.md', ReadmePath),
+    format(atom(Readme),
+           '# WAM-C lowered-helper benchmark~n~nMode: `~w`~n~nPlanner metadata is emitted as comments in `lib.c`.~n',
+           [ParsedMode]),
+    write_text_file(ReadmePath, Readme),
+    cleanup_benchmark_facts.
+
+parse_mode(lowered, lowered) :- !.
+parse_mode('lowered', lowered) :- !.
+parse_mode(interpreted, interpreted) :- !.
+parse_mode('interpreted', interpreted) :- !.
+parse_mode(Mode, _) :-
+    throw(error(domain_error(wam_c_lowered_helper_benchmark_mode, Mode), _)).
+
+mode_options(lowered, [lowered_helpers(true), report_lowered_helpers(true)]).
+mode_options(interpreted, [report_lowered_helpers(true)]).
+
+setup_benchmark_facts :-
+    cleanup_benchmark_facts,
+    assertz(user:wam_c_bench_pair(a, b)),
+    assertz(user:wam_c_bench_pair(a, c)),
+    assertz(user:wam_c_bench_pair(b, d)).
+
+cleanup_benchmark_facts :-
+    retractall(user:wam_c_bench_pair(_, _)).
+
+lowered_helper_benchmark_main(
+'#include "wam_runtime.h"
+#include <stdio.h>
+
+void setup_wam_c_bench_pair_2(WamState* state);
+void setup_lowered_wam_c_helpers(WamState* state);
+
+static int emit_pair(WamState* state, const char* left, const char* right, double score) {
+    WamValue args[2] = { val_atom(left), val_atom(right) };
+    int rc = wam_run_predicate(state, "wam_c_bench_pair/2", args, 2);
+    if (rc != 0 || state->P != WAM_HALT) return 1;
+    printf("%s\\t%s\\t%.6f\\n", left, right, score);
+    return 0;
+}
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_bench_pair_2(&state);
+    setup_lowered_wam_c_helpers(&state);
+
+    printf("left\\tright\\tscore\\n");
+
+    if (emit_pair(&state, "a", "b", 1.0) != 0) {
+        wam_free_state(&state);
+        return 10;
+    }
+    if (emit_pair(&state, "a", "c", 2.0) != 0) {
+        wam_free_state(&state);
+        return 20;
+    }
+    if (emit_pair(&state, "b", "d", 3.0) != 0) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    WamValue missing_args[2] = { val_atom("z"), val_atom("missing") };
+    int missing_rc = wam_run_predicate(&state, "wam_c_bench_pair/2", missing_args, 2);
+    if (missing_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
+write_text_file(Path, Content) :-
+    setup_call_cleanup(
+        open(Path, write, Stream),
+        format(Stream, '~w', [Content]),
+        close(Stream)
+    ).

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -93,6 +93,27 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         self.assertIn("clojure-wam-accumulated-no-kernels", targets)
         self.assertIn("clojure-wam-seeded", targets)
         self.assertIn("clojure-wam-seeded-no-kernels", targets)
+        self.assertNotIn("c-wam-lowered-helper", targets)
+        self.assertNotIn("c-wam-lowered-helper-interpreted", targets)
+
+    def test_c_lowered_helper_targets_are_registered_separately(self) -> None:
+        targets = resolve_targets(
+            explicit_targets=None,
+            target_set_names=["c-wam-lowered-helper"],
+        )
+
+        self.assertEqual(
+            targets,
+            [
+                "c-wam-lowered-helper-interpreted",
+                "c-wam-lowered-helper",
+            ],
+        )
+        self.assertEqual(TARGETS["c-wam-lowered-helper"].category, "hybrid-wam-lowered-helper")
+        self.assertEqual(
+            TARGETS["c-wam-lowered-helper-interpreted"].category,
+            "hybrid-wam-lowered-helper",
+        )
 
     def test_scala_targets_are_registered(self) -> None:
         targets = resolve_targets(


### PR DESCRIPTION
## Summary

This PR adds a small benchmark surface for the WAM-C lowered-helper path. It wires interpreted and lowered WAM-C fact-helper variants into the existing benchmark matrix so the prototype lowered helper can be validated through the same target-selection, output-normalization, and local comparison workflow used by the broader effective-distance matrix.

## What Changed

- Adds `generate_wam_c_lowered_helper_benchmark.pl`, a tiny WAM-C fact-helper benchmark generator.
- Registers `c-wam-lowered-helper-interpreted` and `c-wam-lowered-helper` matrix targets.
- Adds a separate `c-wam-lowered-helper` target set so this smoke benchmark does not affect default effective-distance comparisons.
- Builds both variants through the existing WAM-C project writer and GCC path.
- Keeps planner metadata visible in generated artifacts.
- Extends target-matrix tests for the new target set.
- Updates `WAM_C_TARGET_NEXT_STEPS.md` to mark planner metadata done and make benchmark wiring the active branch.

## Validation

- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets c-wam-lowered-helper --repetitions 1 --baseline-target c-wam-lowered-helper-interpreted`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
- `git diff --check`

## Follow-Up

Next recommended branch: `feat/wam-c-lowered-helper-body-calls`.
