### PR TITLE
feat(wam-cpp): support bagof setof aggregates

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -106,14 +106,16 @@ escape_cpp_string(In, Out) :-
     split_string(S, "\\", "", Parts),
     cpp_atomics_to_string(Parts, "\\\\", Escaped1),
     split_string(Escaped1, "\"", "", Parts2),
-    cpp_atomics_to_string(Parts2, "\\\"", Out).
+    cpp_atomics_to_string(Parts2, "\\\"", Out),
+    !.
 
-cpp_atomics_to_string([], _, "").
-cpp_atomics_to_string([X], _, X).
+cpp_atomics_to_string([], _, "") :- !.
+cpp_atomics_to_string([X], _, X) :- !.
 cpp_atomics_to_string([X, Y|Rest], Sep, Result) :-
     cpp_atomics_to_string([Y|Rest], Sep, Tail),
     string_concat(X, Sep, XSep),
-    string_concat(XSep, Tail, Result).
+    string_concat(XSep, Tail, Result),
+    !.
 
 %% cpp_value_literal(+ConstantToken, -CppLiteral)
 %  Convert a WAM constant (atom, integer, float, []) into a C++ Value
@@ -145,101 +147,106 @@ to_string(X, S) :- format(string(S), "~w", [X]).
 % C++17 without the GCC extension).
 
 wam_instruction_to_cpp_literal(Instr, Code) :-
-    wam_instruction_to_cpp_literal(Instr, [], Code).
+    wam_instruction_to_cpp_literal(Instr, [], Code),
+    !.
 
-wam_instruction_to_cpp_literal(get_constant(C, Ai), _, Code) :-
+wam_instruction_to_cpp_literal(Instr, LabelMap, Code) :-
+    wam_instruction_to_cpp_literal_det(Instr, LabelMap, Code),
+    !.
+
+wam_instruction_to_cpp_literal_det(get_constant(C, Ai), _, Code) :-
     cpp_value_literal(C, V), to_string(Ai, R),
     format(atom(Code), 'Instruction::GetConstant(~w, "~w")', [V, R]).
-wam_instruction_to_cpp_literal(get_variable(Xn, Ai), _, Code) :-
+wam_instruction_to_cpp_literal_det(get_variable(Xn, Ai), _, Code) :-
     to_string(Xn, X), to_string(Ai, R),
     format(atom(Code), 'Instruction::GetVariable("~w", "~w")', [X, R]).
-wam_instruction_to_cpp_literal(get_value(Xn, Ai), _, Code) :-
+wam_instruction_to_cpp_literal_det(get_value(Xn, Ai), _, Code) :-
     to_string(Xn, X), to_string(Ai, R),
     format(atom(Code), 'Instruction::GetValue("~w", "~w")', [X, R]).
-wam_instruction_to_cpp_literal(get_structure(F, Ai), _, Code) :-
+wam_instruction_to_cpp_literal_det(get_structure(F, Ai), _, Code) :-
     to_string(F, FS), to_string(Ai, R),
     escape_cpp_string(FS, EF),
     format(atom(Code), 'Instruction::GetStructure("~w", "~w")', [EF, R]).
-wam_instruction_to_cpp_literal(get_list(Ai), _, Code) :-
+wam_instruction_to_cpp_literal_det(get_list(Ai), _, Code) :-
     to_string(Ai, R),
     format(atom(Code), 'Instruction::GetList("~w")', [R]).
-wam_instruction_to_cpp_literal(get_nil(Ai), _, Code) :-
+wam_instruction_to_cpp_literal_det(get_nil(Ai), _, Code) :-
     to_string(Ai, R),
     format(atom(Code), 'Instruction::GetNil("~w")', [R]).
-wam_instruction_to_cpp_literal(get_integer(N, Ai), _, Code) :-
+wam_instruction_to_cpp_literal_det(get_integer(N, Ai), _, Code) :-
     to_string(N, NS), to_string(Ai, R),
     format(atom(Code), 'Instruction::GetInteger(~w, "~w")', [NS, R]).
-wam_instruction_to_cpp_literal(put_constant(C, Ai), _, Code) :-
+wam_instruction_to_cpp_literal_det(put_constant(C, Ai), _, Code) :-
     cpp_value_literal(C, V), to_string(Ai, R),
     format(atom(Code), 'Instruction::PutConstant(~w, "~w")', [V, R]).
-wam_instruction_to_cpp_literal(put_variable(Xn, Ai), _, Code) :-
+wam_instruction_to_cpp_literal_det(put_variable(Xn, Ai), _, Code) :-
     to_string(Xn, X), to_string(Ai, R),
     format(atom(Code), 'Instruction::PutVariable("~w", "~w")', [X, R]).
-wam_instruction_to_cpp_literal(put_value(Xn, Ai), _, Code) :-
+wam_instruction_to_cpp_literal_det(put_value(Xn, Ai), _, Code) :-
     to_string(Xn, X), to_string(Ai, R),
     format(atom(Code), 'Instruction::PutValue("~w", "~w")', [X, R]).
-wam_instruction_to_cpp_literal(put_structure(F, Ai), _, Code) :-
+wam_instruction_to_cpp_literal_det(put_structure(F, Ai), _, Code) :-
     to_string(F, FS), to_string(Ai, R),
     escape_cpp_string(FS, EF),
     format(atom(Code), 'Instruction::PutStructure("~w", "~w")', [EF, R]).
-wam_instruction_to_cpp_literal(put_list(Ai), _, Code) :-
+wam_instruction_to_cpp_literal_det(put_list(Ai), _, Code) :-
     to_string(Ai, R),
     format(atom(Code), 'Instruction::PutList("~w")', [R]).
-wam_instruction_to_cpp_literal(unify_variable(Xn), _, Code) :-
+wam_instruction_to_cpp_literal_det(unify_variable(Xn), _, Code) :-
     to_string(Xn, X),
     format(atom(Code), 'Instruction::UnifyVariable("~w")', [X]).
-wam_instruction_to_cpp_literal(unify_value(Xn), _, Code) :-
+wam_instruction_to_cpp_literal_det(unify_value(Xn), _, Code) :-
     to_string(Xn, X),
     format(atom(Code), 'Instruction::UnifyValue("~w")', [X]).
-wam_instruction_to_cpp_literal(unify_constant(C), _, Code) :-
+wam_instruction_to_cpp_literal_det(unify_constant(C), _, Code) :-
     cpp_value_literal(C, V),
     format(atom(Code), 'Instruction::UnifyConstant(~w)', [V]).
-wam_instruction_to_cpp_literal(set_variable(Xn), _, Code) :-
+wam_instruction_to_cpp_literal_det(set_variable(Xn), _, Code) :-
     to_string(Xn, X),
     format(atom(Code), 'Instruction::SetVariable("~w")', [X]).
-wam_instruction_to_cpp_literal(set_value(Xn), _, Code) :-
+wam_instruction_to_cpp_literal_det(set_value(Xn), _, Code) :-
     to_string(Xn, X),
     format(atom(Code), 'Instruction::SetValue("~w")', [X]).
-wam_instruction_to_cpp_literal(set_constant(C), _, Code) :-
+wam_instruction_to_cpp_literal_det(set_constant(C), _, Code) :-
     cpp_value_literal(C, V),
     format(atom(Code), 'Instruction::SetConstant(~w)', [V]).
-wam_instruction_to_cpp_literal(call(P, N), _, Code) :-
+wam_instruction_to_cpp_literal_det(call(P, N), _, Code) :-
     to_string(P, PS), to_string(N, NS),
     escape_cpp_string(PS, EP),
     format(atom(Code), 'Instruction::Call("~w", ~w)', [EP, NS]).
-wam_instruction_to_cpp_literal(execute(P), _, Code) :-
+wam_instruction_to_cpp_literal_det(execute(P), _, Code) :-
     to_string(P, PS),
     escape_cpp_string(PS, EP),
     format(atom(Code), 'Instruction::Execute("~w")', [EP]).
-wam_instruction_to_cpp_literal(proceed, _, 'Instruction::Proceed()').
-wam_instruction_to_cpp_literal(fail, _, 'Instruction::Fail()').
-wam_instruction_to_cpp_literal(allocate, _, 'Instruction::Allocate()').
-wam_instruction_to_cpp_literal(deallocate, _, 'Instruction::Deallocate()').
-wam_instruction_to_cpp_literal(builtin_call(Op, Ar), _, Code) :-
+wam_instruction_to_cpp_literal_det(proceed, _, 'Instruction::Proceed()').
+wam_instruction_to_cpp_literal_det(fail, _, 'Instruction::Fail()').
+wam_instruction_to_cpp_literal_det(allocate, _, 'Instruction::Allocate()').
+wam_instruction_to_cpp_literal_det(deallocate, _, 'Instruction::Deallocate()').
+wam_instruction_to_cpp_literal_det(builtin_call(Op, Ar), _, Code) :-
     to_string(Op, OpS), to_string(Ar, ArS),
     escape_cpp_string(OpS, EOp),
     format(atom(Code), 'Instruction::BuiltinCall("~w", ~w)', [EOp, ArS]).
-wam_instruction_to_cpp_literal(call_foreign(P, Ar), _, Code) :-
+wam_instruction_to_cpp_literal_det(call_foreign(P, Ar), _, Code) :-
     to_string(P, PS), to_string(Ar, ArS),
     escape_cpp_string(PS, EP),
     format(atom(Code), 'Instruction::CallForeign("~w", ~w)', [EP, ArS]).
-wam_instruction_to_cpp_literal(try_me_else(L), LabelMap, Code) :-
+wam_instruction_to_cpp_literal_det(try_me_else(L), LabelMap, Code) :-
     label_index(L, LabelMap, Idx),
     format(atom(Code), 'Instruction::TryMeElse(~w)', [Idx]).
-wam_instruction_to_cpp_literal(retry_me_else(L), LabelMap, Code) :-
+wam_instruction_to_cpp_literal_det(retry_me_else(L), LabelMap, Code) :-
     label_index(L, LabelMap, Idx),
     format(atom(Code), 'Instruction::RetryMeElse(~w)', [Idx]).
-wam_instruction_to_cpp_literal(trust_me, _, 'Instruction::TrustMe()').
-wam_instruction_to_cpp_literal(jump(L), LabelMap, Code) :-
+wam_instruction_to_cpp_literal_det(trust_me, _, 'Instruction::TrustMe()').
+wam_instruction_to_cpp_literal_det(jump(L), LabelMap, Code) :-
     label_index(L, LabelMap, Idx),
     format(atom(Code), 'Instruction::Jump(~w)', [Idx]).
-wam_instruction_to_cpp_literal(cut_ite, _, 'Instruction::CutIte()').
-wam_instruction_to_cpp_literal(begin_aggregate(K, V, R), _, Code) :-
+wam_instruction_to_cpp_literal_det(cut_ite, _, 'Instruction::CutIte()').
+wam_instruction_to_cpp_literal_det(begin_aggregate(K, V, R), _, Code) :-
     to_string(K, KS), to_string(V, VS), to_string(R, RS),
     escape_cpp_string(KS, EK), escape_cpp_string(VS, EV), escape_cpp_string(RS, ER),
     format(atom(Code),
            'Instruction::BeginAggregate("~w", "~w", "~w")', [EK, EV, ER]).
-wam_instruction_to_cpp_literal(end_aggregate(R), _, Code) :-
+wam_instruction_to_cpp_literal_det(end_aggregate(R), _, Code) :-
     to_string(R, RS),
     escape_cpp_string(RS, ER),
     format(atom(Code), 'Instruction::EndAggregate("~w")', [ER]).
@@ -393,7 +400,7 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     findall(Items, (
         member(PI, Predicates),
         catch(
-            ( compile_predicate_to_wam(PI, [], WamText),
+            ( compile_predicate_to_wam(PI, [inline_bagof_setof(true)], WamText),
               parse_pred_blocks(WamText, Items)
             ),
             _, fail)
@@ -625,7 +632,7 @@ compile_predicates_for_project(Predicates, Options, PredicatesCode) :-
     findall(Code, (
         member(PI, Predicates),
         catch(
-            ( compile_predicate_to_wam(PI, [], WamCode),
+            ( compile_predicate_to_wam(PI, [inline_bagof_setof(true)], WamCode),
               compile_wam_predicate_to_cpp(PI, WamCode, Options1, Code)
             ),
             _Err,
@@ -930,6 +937,7 @@ compile_wam_runtime_to_cpp(_Options,
 
 #include "wam_runtime.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <sstream>
 #include <string>
@@ -1793,10 +1801,14 @@ static Value finalize_aggregate(const std::string& kind, const std::vector<Value
         }
         return *best;
     }
-    // "collect" (findall) and "set" / "bag" all build a list. set/bag
-    // dedup variants are handled below if we recognise the kind.
+    // "collect" (findall), bagof/setof, and aggregate_all bag/set all
+    // build a list. bagof/setof fail on empty; findall and
+    // aggregate_all(bag/set) keep the historical empty-list behaviour.
+    if ((kind == "bagof" || kind == "setof") && acc.empty()) {
+        return Value{};
+    }
     std::vector<Value> items = acc;
-    if (kind == "set") {
+    if (kind == "set" || kind == "setof") {
         std::vector<Value> uniq;
         for (auto& v : items) {
             bool dup = false;
@@ -1804,7 +1816,21 @@ static Value finalize_aggregate(const std::string& kind, const std::vector<Value
             if (!dup) uniq.push_back(v);
         }
         items = std::move(uniq);
-        // sort lexicographically by render() — cheap, good enough for atoms / ints.
+        std::sort(items.begin(), items.end(), [](const Value& a, const Value& b) {
+            if (a.tag != b.tag) return static_cast<int>(a.tag) < static_cast<int>(b.tag);
+            switch (a.tag) {
+                case Value::Tag::Atom:
+                case Value::Tag::Unbound:
+                case Value::Tag::Compound:
+                    return a.s < b.s;
+                case Value::Tag::Integer:
+                    return a.i < b.i;
+                case Value::Tag::Float:
+                    return a.f < b.f;
+                default:
+                    return false;
+            }
+        });
     }
     Value tail = Value::Atom("[]");
     for (auto it = items.rbegin(); it != items.rend(); ++it) {
@@ -1854,6 +1880,7 @@ bool WamState::backtrack() {
             cut_barrier = f.saved_cut_barrier;
             // Build and bind the result.
             Value result = finalize_aggregate(f.agg_kind, f.acc);
+            if (result.tag == Value::Tag::Uninit) return false;
             CellPtr rcell = get_cell(f.result_reg);
             if (rcell->is_unbound()) bind_cell(rcell, result);
             else if (!unify_cells(rcell, std::make_shared<Cell>(result))) return false;

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -91,6 +91,10 @@ compile_wam_module(Predicates, Options, Code) :-
 %% compile_clauses_to_wam(+Pred, +Arity, +Clauses, +Options, -Code)
 compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code) :-
     format(string(Label), "~w/~w:", [Pred, Arity]),
+    (   option(inline_bagof_setof(true), Options)
+    ->  b_setval(wam_inline_bagof_setof, true)
+    ;   b_setval(wam_inline_bagof_setof, false)
+    ),
     (   length(Clauses, 1)
     ->  Clauses = [Clause],
         compile_single_clause_wam(Clause, Options, ClausesCode0)
@@ -344,16 +348,22 @@ compile_single_clause_wam(Head-Body, Options, Code) :-
 
 %% goals_contain_call_or_aggregate(+Goals)
 %  True if any goal in the list is a Call to a user predicate or an
-%  aggregate_all/findall that internally produces Call instructions.
+%  aggregate_all/findall/bagof/setof that internally produces Call
+%  instructions.
 %  Used to force permanent variable allocation in single-goal clauses
 %  that would otherwise skip it (since length(Goals) == 1).
 goals_contain_call_or_aggregate(Goals) :-
     member(G, Goals),
     ( G = aggregate_all(_, _, _)
     ; G = findall(_, _, _)
+    ; wam_inline_bagof_setof_enabled, G = bagof(_, _, _)
+    ; wam_inline_bagof_setof_enabled, G = setof(_, _, _)
     ; callable(G), functor(G, F, _), \+ is_builtin_goal(F)
     ),
     !.
+
+wam_inline_bagof_setof_enabled :-
+    catch(b_getval(wam_inline_bagof_setof, true), _, fail).
 
 is_builtin_goal(is).
 is_builtin_goal(=).
@@ -375,8 +385,8 @@ is_builtin_goal(append).
 is_builtin_goal((\+)).
 
 %% expand_aggregate_goals_for_perm_vars(+Goals, -Expanded)
-%  For permanent-variable detection, expand aggregate_all/findall into
-%  their inner goals + a synthetic "result" goal. This ensures
+%  For permanent-variable detection, expand aggregate_all/findall/
+%  bagof/setof into their inner goals + a synthetic "result" goal. This ensures
 %  variables shared between the clause head and the aggregate body
 %  are detected as permanent (appear in >1 "goal").
 expand_aggregate_goals_for_perm_vars([], []).
@@ -388,6 +398,14 @@ expand_aggregate_goals_for_perm_vars([G|Rest], Expanded) :-
         % inner body register as permanent (cross-goal).
         append([G|InnerGoals], RestExpanded, Expanded)
     ;   G = findall(_Template, InnerGoal, _Result)
+    ->  flatten_conjunction(InnerGoal, InnerGoals),
+        append([G|InnerGoals], RestExpanded, Expanded)
+    ;   wam_inline_bagof_setof_enabled,
+        G = bagof(_Template, InnerGoal, _Result)
+    ->  flatten_conjunction(InnerGoal, InnerGoals),
+        append([G|InnerGoals], RestExpanded, Expanded)
+    ;   wam_inline_bagof_setof_enabled,
+        G = setof(_Template, InnerGoal, _Result)
     ->  flatten_conjunction(InnerGoal, InnerGoals),
         append([G|InnerGoals], RestExpanded, Expanded)
     ;   ( G = (_;_) ; G = (_->_) )
@@ -652,7 +670,8 @@ pre_bind_unbound_yi([Var|Rest], Bindings, YI, NewBindings) :-
 %% compile_goals(+Goals, +VarMap, +HasEnv, -Vf, -Code)
 compile_goals([], V, _, V, "").
 compile_goals([Goal|Rest], V0, HasEnv, Vf, Code) :-
-    % Check for aggregate_all/findall first — these are always compiled inline
+    % Check for aggregate_all/findall/bagof/setof first — these are
+    % always compiled inline.
     (   Goal = aggregate_all(Template, InnerGoal, Result)
     ->  compile_aggregate_all(Template, InnerGoal, Result, V0, V1, GoalCode),
         (   Rest == []
@@ -666,6 +685,30 @@ compile_goals([Goal|Rest], V0, HasEnv, Vf, Code) :-
         )
     ;   Goal = findall(Template, InnerGoal, Result)
     ->  compile_findall(Template, InnerGoal, Result, V0, V1, GoalCode),
+        (   Rest == []
+        ->  Vf = V1,
+            (   HasEnv == yes
+            ->  format(string(Code), "~w~n    deallocate~n    proceed", [GoalCode])
+            ;   format(string(Code), "~w~n    proceed", [GoalCode])
+            )
+        ;   compile_goals(Rest, V1, HasEnv, Vf, RestCode),
+            format(string(Code), "~w~n~w", [GoalCode, RestCode])
+        )
+    ;   wam_inline_bagof_setof_enabled,
+        Goal = bagof(Template, InnerGoal, Result)
+    ->  compile_bagof(Template, InnerGoal, Result, V0, V1, GoalCode),
+        (   Rest == []
+        ->  Vf = V1,
+            (   HasEnv == yes
+            ->  format(string(Code), "~w~n    deallocate~n    proceed", [GoalCode])
+            ;   format(string(Code), "~w~n    proceed", [GoalCode])
+            )
+        ;   compile_goals(Rest, V1, HasEnv, Vf, RestCode),
+            format(string(Code), "~w~n~w", [GoalCode, RestCode])
+        )
+    ;   wam_inline_bagof_setof_enabled,
+        Goal = setof(Template, InnerGoal, Result)
+    ->  compile_setof(Template, InnerGoal, Result, V0, V1, GoalCode),
         (   Rest == []
         ->  Vf = V1,
             (   HasEnv == yes
@@ -760,6 +803,8 @@ compile_aggregate_all(Template, InnerGoal, Result, V0, Vf, Code) :-
     ;   Template = min(ValueVar) -> AggType = min
     ;   Template = bag(ValueVar) -> AggType = bag
     ;   Template = set(ValueVar) -> AggType = set
+    ;   Template = bagof-BagVar -> AggType = bagof, ValueVar = BagVar
+    ;   Template = setof-SetVar -> AggType = setof, ValueVar = SetVar
     % findall/3 → compile_findall/5 wraps Template as `collect-Template`.
     % Unwrap to expose the real ValueVar so the var(ValueVar) branch
     % below allocates a Y-register and emits put_variable Y_n, A1.
@@ -896,6 +941,18 @@ compile_template_arg_set([Arg | Rest], V0, Vf, [Line | Lines]) :-
 %% compile_findall(+Template, +InnerGoal, +Result, +V0, -Vf, -Code)
 compile_findall(Template, InnerGoal, Result, V0, Vf, Code) :-
     compile_aggregate_all(collect-Template, InnerGoal, Result, V0, Vf, Code).
+
+%% compile_bagof(+Template, +InnerGoal, +Result, +V0, -Vf, -Code)
+%  Compile the no-witness-group subset of bagof/3. The runtime fails
+%  empty bags, unlike findall/3.
+compile_bagof(Template, InnerGoal, Result, V0, Vf, Code) :-
+    compile_aggregate_all(bagof-Template, InnerGoal, Result, V0, Vf, Code).
+
+%% compile_setof(+Template, +InnerGoal, +Result, +V0, -Vf, -Code)
+%  Compile the no-witness-group subset of setof/3. The runtime fails
+%  empty sets, then sorts/deduplicates collected values.
+compile_setof(Template, InnerGoal, Result, V0, Vf, Code) :-
+    compile_aggregate_all(setof-Template, InnerGoal, Result, V0, Vf, Code).
 
 %% next_ite_label(-ElseLabel, -ContLabel)
 %  Generate unique labels for if-then-else compilation.

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -51,6 +51,10 @@
 :- dynamic user:wam_cpp_test_findall/0.
 :- dynamic user:wam_cpp_test_findall_empty/0.
 :- dynamic user:wam_cpp_test_findall_doubled/0.
+:- dynamic user:wam_cpp_test_bagof/0.
+:- dynamic user:wam_cpp_test_bagof_empty/0.
+:- dynamic user:wam_cpp_test_setof/0.
+:- dynamic user:wam_cpp_test_setof_empty/0.
 :- dynamic user:wam_cpp_test_count/0.
 :- dynamic user:wam_cpp_test_sum/0.
 :- dynamic user:wam_cpp_test_min/0.
@@ -61,9 +65,13 @@ user:wam_cpp_test_write :- write(hello), nl.
 user:wam_cpp_item(a). user:wam_cpp_item(b). user:wam_cpp_item(c).
 user:wam_cpp_num(1).  user:wam_cpp_num(2).  user:wam_cpp_num(3). user:wam_cpp_num(2).
 user:wam_cpp_test_findall         :- findall(X, user:wam_cpp_item(X), L), L = [a, b, c].
-user:wam_cpp_test_findall_empty   :- findall(X, fail, L), L = [].
+user:wam_cpp_test_findall_empty   :- findall(_, fail, L), L = [].
 user:wam_cpp_test_findall_doubled :- findall(p(X, X), user:wam_cpp_item(X), L),
                                      L = [p(a, a), p(b, b), p(c, c)].
+user:wam_cpp_test_bagof           :- bagof(X, user:wam_cpp_item(X), L), L = [a, b, c].
+user:wam_cpp_test_bagof_empty     :- bagof(_, fail, _).
+user:wam_cpp_test_setof           :- setof(X, user:wam_cpp_num(X), L), L = [1, 2, 3].
+user:wam_cpp_test_setof_empty     :- setof(_, fail, _).
 user:wam_cpp_test_count :- aggregate_all(count, user:wam_cpp_item(_), N), N = 3.
 user:wam_cpp_test_sum   :- aggregate_all(sum(X),  user:wam_cpp_num(X), S), S = 8.
 user:wam_cpp_test_min   :- aggregate_all(min(X),  user:wam_cpp_num(X), M), M = 1.
@@ -518,6 +526,24 @@ test(cpp_e2e_findall, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_findall/0',         [], true),
           run_query(BinPath, 'wam_cpp_test_findall_empty/0',   [], true),
           run_query(BinPath, 'wam_cpp_test_findall_doubled/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_bagof_setof, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_bagof_setof', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_item/1, user:wam_cpp_num/1,
+                               user:wam_cpp_test_bagof/0,
+                               user:wam_cpp_test_bagof_empty/0,
+                               user:wam_cpp_test_setof/0,
+                               user:wam_cpp_test_setof_empty/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_bagof/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_bagof_empty/0', [], false),
+          run_query(BinPath, 'wam_cpp_test_setof/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_setof_empty/0', [], false)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

- Adds WAM-C++ support for the no-witness-group subset of `bagof/3` and `setof/3`.
- Reuses the existing aggregate frame path with C++-only opt-in lowering from the shared WAM compiler.
- Preserves existing WAM-R `bagof`/`setof` behavior by keeping the new lowering gated behind `inline_bagof_setof(true)`.
- Makes `bagof`/`setof` fail on empty results, while `findall/3` and `aggregate_all(bag/set)` keep empty-list behavior.
- Sorts and deduplicates `setof` results.
- Cleans WAM-C++ literal/string helper determinism so the C++ test suite no longer emits choicepoint warnings.

## Scope

This intentionally covers the simple no-free-witness subset. Full ISO-style witness grouping and backtracking across multiple witness groups remains a separate follow-up, matching the staged approach used by the R target.

## Verification

- `swipl -q -l tests/test_wam_cpp_generator.pl -g run_tests -t halt`
- `swipl -q -l tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:bagof_setof_once_forall_e2e_rscript,wam_r_generator:bagof_setof_existential_e2e_rscript])" -t halt`
- `git diff --check`
