### PR TITLE
ci(csharp-query): Check C# query calibration wrapper contract in CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,6 +12,7 @@
 - ✅ Recursive compiler
 - ✅ Advanced recursion (24 tests)
 - ✅ Constraint integration
+- ✅ C# query calibration wrapper contract (unit test + dry-run command shape)
 - ✅ Inference test runner generation
 - ✅ Generated bash script syntax validation
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,11 @@ jobs:
         run: |
           SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g "test_csharp_query_target:test_csharp_query_target" -t halt
 
+      - name: Run C# query calibration wrapper contract tests
+        run: |
+          python3 -m unittest tests/test_csharp_query_calibration_refresh_wrapper.py
+          python3 examples/benchmark/refresh_csharp_query_source_mode_calibration.py --dry-run
+
       - name: Generate and run inference test runner
         run: |
           swipl -g "use_module('src/unifyweaver/core/advanced/test_runner_inference'), generate_test_runner_inferred('output/advanced/inferred_test_runner.sh'), halt."


### PR DESCRIPTION
  ## Summary

  - Adds a lightweight `test.yml` step for the C# query calibration refresh wrapper.
  - Runs the wrapper unit test and `--dry-run` command shape check.
  - Avoids the expensive benchmark sweep in CI.
  - Updates the workflow README to document the new contract check.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_calibration_refresh_wrapper.py`
  - `python3 examples/benchmark/refresh_csharp_query_source_mode_calibration.py --dry-run`
  - `python3 -m py_compile examples/benchmark/refresh_csharp_query_source_mode_calibration.py tests/
  test_csharp_query_calibration_refresh_wrapper.py`
  - `git diff --check`
  - Parsed `.github/workflows/test.yml` with PyYAML