### PR TITLE
feat(wam-c): Lower simple WAM C body-call helpers

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,13 +5,13 @@ Status date: 2026-05-12
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `55b898f9` (`Merge pull request #2046 from s243a/feat/wam-c-lowered-helper-planner`)
+- `main` at `6ead5232` (`Merge pull request #2047 from s243a/feat/wam-c-lowered-helper-benchmark-wiring`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
 
 Active branch:
 
-- `feat/wam-c-lowered-helper-benchmark-wiring`
+- `feat/wam-c-lowered-helper-body-calls`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -41,7 +41,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered fact-only helper prototype | Done | `lowered_helpers(true)` emits native C foreign handlers for constant fact-only predicates plus a `call_foreign` trampoline |
 | ASAN availability probe hardening | Done | `asan_available/0` requires a trivial sanitized executable to compile and run before enabling the optional ASAN lifecycle smoke |
 | Lowered helper planner metadata | Done | Explicit lowered/interpreted/rejected helper plans, detected-kernel exclusion, generated `lib.c` plan comments, and `report_lowered_helpers(true)` |
-| Lowered helper benchmark wiring | In progress | Active branch adds `c-wam-lowered-helper` and `c-wam-lowered-helper-interpreted` matrix targets over a tiny fact-helper benchmark |
+| Lowered helper benchmark wiring | Done | `c-wam-lowered-helper` and `c-wam-lowered-helper-interpreted` matrix targets compare a tiny fact-helper benchmark |
+| Lowered helper body-call shape | In progress | Active branch lowers one deterministic alias-to-fact body-call shape through the existing foreign registry |
 
 ## Current C Target Baseline
 
@@ -112,7 +113,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup and all-hop collection; add more kernel kinds only after runtime support exists. |
 | Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`; broaden as more native C kernels land. |
-| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers, planner metadata, and active interpreted-vs-lowered matrix wiring. |
+| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, and active body-call helper work. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
 | Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB `kernels_on`/`kernels_off`; next gap is larger artifact layouts. |
@@ -122,23 +123,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lowered-helper-benchmark-wiring`
-
-Goal: prove the lowered-helper path on a small benchmark surface before
-attempting broader helper classes.
-
-Scope:
-
-- Add a narrow generated benchmark or matrix target that exercises C lowered
-  fact helpers.
-- Keep the comparison against interpreted C and Prolog small enough for routine
-  local validation.
-- Record lowered/interpreted planning output with the benchmark artifacts.
-
-Status: active; a tiny fact-helper matrix target pair is implemented for
-interpreted-vs-lowered WAM-C comparison.
-
-### 2. `feat/wam-c-lowered-helper-body-calls`
+### 1. `feat/wam-c-lowered-helper-body-calls`
 
 Goal: broaden C lowered helpers past fact-only predicates into one small
 deterministic body-call shape.
@@ -150,10 +135,25 @@ Scope:
 - Add executable smoke coverage before expanding to aggregates or multi-result
   helpers.
 
+Status: active; deterministic alias-to-fact body calls are implemented via
+foreign-handler delegation and covered by generated/executable smoke tests.
+
+### 2. `feat/wam-c-lowered-helper-filtered-facts`
+
+Goal: add one constrained guard/filter shape on top of lowered fact helpers.
+
+Scope:
+
+- Pick a simple deterministic guard shape with atom/integer equality.
+- Keep unsupported guard bodies rejected with explicit planner metadata.
+- Extend the tiny lowered-helper matrix only if the shape remains small and
+  stable.
+
 ## Suggested Immediate Next Step
 
-Continue validating `feat/wam-c-lowered-helper-benchmark-wiring`.
+Continue validating `feat/wam-c-lowered-helper-body-calls`.
 
-The active branch wires a tiny fact-helper benchmark into the existing matrix
-surface as separate interpreted and lowered WAM-C targets. The next check is
-final validation, then the following branch can broaden lowered helper shapes.
+The active branch lowers one deterministic body-call shape by delegating from
+the caller helper to an already lowered callee helper through the existing
+foreign registry. The tiny lowered-helper matrix now exercises that lowered
+body-call path in its lowered target.

--- a/examples/benchmark/generate_wam_c_lowered_helper_benchmark.pl
+++ b/examples/benchmark/generate_wam_c_lowered_helper_benchmark.pl
@@ -41,9 +41,12 @@ generate(OutputDir, Mode) :-
     setup_benchmark_facts,
     make_directory_path(OutputDir),
     mode_options(ParsedMode, Options),
-    write_wam_c_project([user:wam_c_bench_pair/2], Options, OutputDir),
+    mode_predicates(ParsedMode, Predicates),
+    write_wam_c_project(Predicates, Options, OutputDir),
     directory_file_path(OutputDir, 'main.c', MainPath),
-    lowered_helper_benchmark_main(MainCode),
+    mode_query_predicate(ParsedMode, QueryPred),
+    mode_alias_setup(ParsedMode, AliasDecl, AliasSetup),
+    lowered_helper_benchmark_main(QueryPred, AliasDecl, AliasSetup, MainCode),
     write_text_file(MainPath, MainCode),
     directory_file_path(OutputDir, 'README.md', ReadmePath),
     format(atom(Readme),
@@ -62,25 +65,40 @@ parse_mode(Mode, _) :-
 mode_options(lowered, [lowered_helpers(true), report_lowered_helpers(true)]).
 mode_options(interpreted, [report_lowered_helpers(true)]).
 
+mode_predicates(lowered, [user:wam_c_bench_pair/2, user:wam_c_bench_pair_alias/2]).
+mode_predicates(interpreted, [user:wam_c_bench_pair/2]).
+
+mode_query_predicate(lowered, 'wam_c_bench_pair_alias/2').
+mode_query_predicate(interpreted, 'wam_c_bench_pair/2').
+
+mode_alias_setup(lowered,
+                 'void setup_wam_c_bench_pair_alias_2(WamState* state);\n',
+                 '    setup_wam_c_bench_pair_alias_2(&state);\n').
+mode_alias_setup(interpreted, '', '').
+
 setup_benchmark_facts :-
     cleanup_benchmark_facts,
     assertz(user:wam_c_bench_pair(a, b)),
     assertz(user:wam_c_bench_pair(a, c)),
-    assertz(user:wam_c_bench_pair(b, d)).
+    assertz(user:wam_c_bench_pair(b, d)),
+    assertz(user:((wam_c_bench_pair_alias(X, Y) :- wam_c_bench_pair(X, Y)))).
 
 cleanup_benchmark_facts :-
-    retractall(user:wam_c_bench_pair(_, _)).
+    retractall(user:wam_c_bench_pair(_, _)),
+    retractall(user:wam_c_bench_pair_alias(_, _)).
 
-lowered_helper_benchmark_main(
+lowered_helper_benchmark_main(QueryPred, AliasDecl, AliasSetup, Code) :-
+    format(atom(Code),
 '#include "wam_runtime.h"
 #include <stdio.h>
 
 void setup_wam_c_bench_pair_2(WamState* state);
+~w
 void setup_lowered_wam_c_helpers(WamState* state);
 
 static int emit_pair(WamState* state, const char* left, const char* right, double score) {
     WamValue args[2] = { val_atom(left), val_atom(right) };
-    int rc = wam_run_predicate(state, "wam_c_bench_pair/2", args, 2);
+    int rc = wam_run_predicate(state, "~w", args, 2);
     if (rc != 0 || state->P != WAM_HALT) return 1;
     printf("%s\\t%s\\t%.6f\\n", left, right, score);
     return 0;
@@ -90,6 +108,7 @@ int main(void) {
     WamState state;
     wam_state_init(&state);
     setup_wam_c_bench_pair_2(&state);
+~w
     setup_lowered_wam_c_helpers(&state);
 
     printf("left\\tright\\tscore\\n");
@@ -107,17 +126,11 @@ int main(void) {
         return 30;
     }
 
-    WamValue missing_args[2] = { val_atom("z"), val_atom("missing") };
-    int missing_rc = wam_run_predicate(&state, "wam_c_bench_pair/2", missing_args, 2);
-    if (missing_rc != WAM_HALT) {
-        wam_free_state(&state);
-        return 40;
-    }
-
     wam_free_state(&state);
     return 0;
 }
-').
+',
+           [AliasDecl, QueryPred, AliasSetup]).
 
 write_text_file(Path, Content) :-
     setup_call_cleanup(

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -176,6 +176,8 @@ plan_wam_c_lowered_helper(DetectedKeys, PredIndicator, Plan) :-
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, interpreted, detected_kernel)
     ;   lowered_fact_helper_rows(PredIndicator, Rows)
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, fact_only(Rows))
+    ;   lowered_body_call_helper(PredIndicator, CalleeKey, CalleeArity)
+    ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, body_call(CalleeKey, CalleeArity))
     ;   lowered_fact_helper_rejection_reason(PredIndicator, Reason),
         Plan = wam_c_lowered_helper_plan(Key, PredIndicator, rejected, Reason)
     ).
@@ -202,6 +204,8 @@ compile_lowered_helpers_for_project(Plans, LoweredKeys, Code, SetupCode) :-
     findall(Key-CodePart-SetupLine,
             (   member(wam_c_lowered_helper_plan(Key, PredIndicator, lowered, fact_only(Rows)), Plans),
                 lowered_fact_helper_for_predicate(PredIndicator, Rows, Key, CodePart, SetupLine)
+            ;   member(wam_c_lowered_helper_plan(Key, PredIndicator, lowered, body_call(CalleeKey, CalleeArity)), Plans),
+                lowered_body_call_helper_for_predicate(PredIndicator, CalleeKey, CalleeArity, Key, CodePart, SetupLine)
             ),
             Entries),
     findall(K, member(K-_-_, Entries), LoweredKeys),
@@ -241,6 +245,7 @@ wam_c_lowered_helper_plan_by_action(Plans, Action, Key, ReasonLabel) :-
     wam_c_lowered_plan_reason_label(Reason, ReasonLabel).
 
 wam_c_lowered_plan_reason_label(fact_only(_Rows), fact_only) :- !.
+wam_c_lowered_plan_reason_label(body_call(_CalleeKey, _CalleeArity), body_call) :- !.
 wam_c_lowered_plan_reason_label(Reason, Reason).
 
 lowered_fact_helper_rows(PredIndicator, Rows) :-
@@ -269,6 +274,39 @@ lowered_fact_helper_for_predicate(PredIndicator, Rows, Key, Code, SetupLine) :-
     return false;
 }',
            [Symbol, Arity, BodyCode]),
+    format(atom(SetupLine),
+           '    wam_register_foreign_predicate(state, "~w", ~w, ~w);',
+           [Key, Arity, Symbol]).
+
+lowered_body_call_helper(PredIndicator, CalleeKey, CalleeArity) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
+    functor(Head, Pred, Arity),
+    findall(Args-Body,
+            (   user:clause(Head, Body),
+                Head =.. [_|Args]
+            ),
+            Clauses),
+    Clauses = [Args-Body],
+    Body \== true,
+    Body =.. [CalleePred|CalleeArgs],
+    length(CalleeArgs, CalleeArity),
+    Args == CalleeArgs,
+    (Pred/Arity) \== (CalleePred/CalleeArity),
+    CalleeIndicator = user:CalleePred/CalleeArity,
+    lowered_fact_helper_rows(CalleeIndicator, _Rows),
+    format(atom(CalleeKey), '~w/~w', [CalleePred, CalleeArity]).
+
+lowered_body_call_helper_for_predicate(PredIndicator, CalleeKey, CalleeArity, Key, Code, SetupLine) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
+    format(atom(Key), '~w/~w', [Pred, Arity]),
+    wam_c_symbol_name(Pred, Arity, Symbol),
+    format(atom(Code),
+'static bool ~w(WamState *state, const char *pred, int arity) {
+    (void)pred;
+    if (arity != ~w) return false;
+    return wam_execute_foreign_predicate(state, "~w", ~w);
+}',
+           [Symbol, Arity, CalleeKey, CalleeArity]),
     format(atom(SetupLine),
            '    wam_register_foreign_predicate(state, "~w", ~w, ~w);',
            [Key, Arity, Symbol]).

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -373,6 +373,36 @@ test_lowered_helper_plan_generation :-
     retractall(user:wam_c_plan_emit_fact(_, _)),
     retractall(user:wam_c_plan_emit_rule(_)).
 
+test_lowered_body_call_helper_generation :-
+    Test = 'WAM-C: deterministic body-call predicates can lower to native helper',
+    assertz(user:wam_c_body_fact(a, b)),
+    assertz((user:wam_c_body_alias(X, Y) :- user:wam_c_body_fact(X, Y))),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(ProjectDir), '/tmp/unifyweaver_wam_c_lowered_body_project_~w', [Stamp]),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    (   plan_wam_c_lowered_helpers([user:wam_c_body_fact/2,
+                                     user:wam_c_body_alias/2],
+                                    [lowered_helpers(true)],
+                                    [],
+                                    Plans),
+        member(wam_c_lowered_helper_plan('wam_c_body_fact/2', _, lowered, fact_only([[a,b]])), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_body_alias/2', _, lowered, body_call('wam_c_body_fact/2', 2)), Plans),
+        write_wam_c_project([user:wam_c_body_fact/2,
+                             user:wam_c_body_alias/2],
+                            [lowered_helpers(true)],
+                            ProjectDir),
+        read_file_to_string(LibPath, LibS, []),
+        sub_string(LibS, _, _, _, '// - lowered wam_c_body_alias/2: body_call'),
+        sub_string(LibS, _, _, _, 'static bool wam_c_lowered_wam_c_body_alias_2'),
+        sub_string(LibS, _, _, _, 'return wam_execute_foreign_predicate(state, "wam_c_body_fact/2", 2);'),
+        sub_string(LibS, _, _, _, '.pred = "wam_c_body_alias/2"')
+    ->  pass(Test)
+    ;   fail_test(Test, 'lowered body-call helper was not emitted')
+    ),
+    retractall(user:wam_c_body_fact(_, _)),
+    retractall(user:wam_c_body_alias(_, _)).
+
 test_unsupported_instruction_fails_loudly :-
     Test = 'WAM-C: unsupported instructions fail loudly',
     BadWamCode = 'foo/1:\n    unknown_opcode A1\n    proceed',
@@ -573,6 +603,16 @@ test_lowered_fact_helper_executable_smoke :-
     ->  (   run_lowered_fact_helper_executable_smoke
         ->  pass(Test)
         ;   fail_test(Test, 'lowered fact helper executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
+test_lowered_body_call_helper_executable_smoke :-
+    Test = 'WAM-C: lowered body-call helper executable smoke',
+    (   gcc_available
+    ->  (   run_lowered_body_call_helper_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'lowered body-call helper executable failed')
         )
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
@@ -980,6 +1020,32 @@ run_lowered_fact_helper_executable_smoke :-
         run_c_smoke_plain(ExePath)
     ->  retractall(user:wam_c_lowered_pair(_, _))
     ;   retractall(user:wam_c_lowered_pair(_, _)),
+        fail
+    ).
+
+run_lowered_body_call_helper_executable_smoke :-
+    assertz(user:wam_c_body_fact(a, b)),
+    assertz(user:wam_c_body_fact(a, c)),
+    assertz((user:wam_c_body_alias(X, Y) :- user:wam_c_body_fact(X, Y))),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(ProjectDir), '/tmp/unifyweaver_wam_c_lowered_body_smoke_~w', [Stamp]),
+    directory_file_path(ProjectDir, 'wam_runtime.c', RuntimePath),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    directory_file_path(ProjectDir, 'main.c', MainPath),
+    directory_file_path(ProjectDir, 'wam_c_lowered_body_smoke', ExePath),
+    (   write_wam_c_project([user:wam_c_body_fact/2,
+                             user:wam_c_body_alias/2],
+                            [lowered_helpers(true)],
+                            ProjectDir),
+        wam_c_lowered_body_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, LibPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  retractall(user:wam_c_body_fact(_, _)),
+        retractall(user:wam_c_body_alias(_, _))
+    ;   retractall(user:wam_c_body_fact(_, _)),
+        retractall(user:wam_c_body_alias(_, _)),
         fail
     ).
 
@@ -1729,6 +1795,47 @@ int main(void) {
 }
 ').
 
+wam_c_lowered_body_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_body_fact_2(WamState* state);
+void setup_wam_c_body_alias_2(WamState* state);
+void setup_lowered_wam_c_helpers(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_body_fact_2(&state);
+    setup_wam_c_body_alias_2(&state);
+    setup_lowered_wam_c_helpers(&state);
+
+    WamValue ok_args[2] = { val_atom("a"), val_unbound("Out") };
+    int ok_rc = wam_run_predicate(&state, "wam_c_body_alias/2", ok_args, 2);
+    if (ok_rc != 0 || state.P != WAM_HALT ||
+        state.A[1].tag != VAL_ATOM || strcmp(state.A[1].data.atom, "b") != 0) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue ground_args[2] = { val_atom("a"), val_atom("c") };
+    int ground_rc = wam_run_predicate(&state, "wam_c_body_alias/2", ground_args, 2);
+    if (ground_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue fail_args[2] = { val_atom("z"), val_unbound("Out") };
+    int fail_rc = wam_run_predicate(&state, "wam_c_body_alias/2", fail_args, 2);
+    if (fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_real_builtin_smoke_main(
 '#include "wam_runtime.h"
 
@@ -2063,6 +2170,7 @@ run_tests_once :-
     test_lowered_fact_helper_generation,
     test_lowered_helper_planner_metadata,
     test_lowered_helper_plan_generation,
+    test_lowered_body_call_helper_generation,
     test_unsupported_instruction_fails_loudly,
     test_no_zero_instruction_fallback,
     test_list_target_pc_emission,
@@ -2082,6 +2190,7 @@ run_tests_once :-
     test_real_prolog_unify_executable_smoke,
     test_real_prolog_classic_recursive_executable_smoke,
     test_lowered_fact_helper_executable_smoke,
+    test_lowered_body_call_helper_executable_smoke,
     test_asan_memory_lifecycle_executable_smoke,
     format('~n=== WAM-C Target Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).


### PR DESCRIPTION
## Summary

This PR broadens the WAM-C lowered-helper prototype beyond fact-only predicates by adding one deterministic body-call shape. A simple alias predicate whose body delegates directly to an already lowerable fact predicate can now be planned and emitted as a native helper while staying inside the existing `call_foreign` registry path.

## What Changed

- Extends WAM-C lowered-helper planning to recognize deterministic alias-to-fact body calls.
- Emits body-call helpers that delegate through `wam_execute_foreign_predicate`.
- Reports the new `body_call` reason in generated `lib.c` planner metadata and optional console summaries.
- Adds generated-code and executable smoke coverage for the new body-call helper shape.
- Updates the tiny lowered-helper benchmark so the lowered target exercises the body-call alias path.
- Updates `WAM_C_TARGET_NEXT_STEPS.md` to mark benchmark wiring done and make body-call helper work active.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets c-wam-lowered-helper --repetitions 1 --baseline-target c-wam-lowered-helper-interpreted`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
- `git diff --check`

## Follow-Up

Next recommended branch: `feat/wam-c-lowered-helper-filtered-facts`.