### PR TITLE
feat(wam-c): Lower filtered WAM-C fact helpers

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,13 +5,13 @@ Status date: 2026-05-12
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `6ead5232` (`Merge pull request #2047 from s243a/feat/wam-c-lowered-helper-benchmark-wiring`)
+- `main` at `5efae2f1` (`Merge pull request #2050 from s243a/feat/wam-c-lowered-helper-body-calls`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
 
 Active branch:
 
-- `feat/wam-c-lowered-helper-body-calls`
+- `feat/wam-c-lowered-helper-filtered-facts`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -42,7 +42,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | ASAN availability probe hardening | Done | `asan_available/0` requires a trivial sanitized executable to compile and run before enabling the optional ASAN lifecycle smoke |
 | Lowered helper planner metadata | Done | Explicit lowered/interpreted/rejected helper plans, detected-kernel exclusion, generated `lib.c` plan comments, and `report_lowered_helpers(true)` |
 | Lowered helper benchmark wiring | Done | `c-wam-lowered-helper` and `c-wam-lowered-helper-interpreted` matrix targets compare a tiny fact-helper benchmark |
-| Lowered helper body-call shape | In progress | Active branch lowers one deterministic alias-to-fact body-call shape through the existing foreign registry |
+| Lowered helper body-call shape | Done | Deterministic alias-to-fact body calls lower through the existing foreign registry |
+| Lowered helper filtered-fact shape | In progress | Active branch lowers one constant-guarded fact projection shape and wires it into the tiny lowered-helper matrix |
 
 ## Current C Target Baseline
 
@@ -113,7 +114,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup and all-hop collection; add more kernel kinds only after runtime support exists. |
 | Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`; broaden as more native C kernels land. |
-| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, and active body-call helper work. |
+| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, and active filtered-fact helper work. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
 | Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB `kernels_on`/`kernels_off`; next gap is larger artifact layouts. |
@@ -123,22 +124,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lowered-helper-body-calls`
-
-Goal: broaden C lowered helpers past fact-only predicates into one small
-deterministic body-call shape.
-
-Scope:
-
-- Pick one simple deterministic helper body that Haskell/Rust already lower.
-- Keep fallback/interpreter routing explicit through the planner metadata.
-- Add executable smoke coverage before expanding to aggregates or multi-result
-  helpers.
-
-Status: active; deterministic alias-to-fact body calls are implemented via
-foreign-handler delegation and covered by generated/executable smoke tests.
-
-### 2. `feat/wam-c-lowered-helper-filtered-facts`
+### 1. `feat/wam-c-lowered-helper-filtered-facts`
 
 Goal: add one constrained guard/filter shape on top of lowered fact helpers.
 
@@ -149,11 +135,25 @@ Scope:
 - Extend the tiny lowered-helper matrix only if the shape remains small and
   stable.
 
+Status: active; constant-guarded fact projection lowers to native fact rows and
+the tiny lowered-helper matrix exercises the filtered helper in lowered mode.
+
+### 2. `feat/wam-c-lowered-helper-filter-rejections`
+
+Goal: make unsupported lowered-helper guard/filter cases more explainable.
+
+Scope:
+
+- Add explicit planner rejection reasons for non-constant guards, unsupported
+  comparison predicates, and multi-goal bodies.
+- Keep code generation unchanged for supported fact-only, body-call, and
+  filtered-fact helpers.
+- Add focused planner tests rather than new runtime paths.
+
 ## Suggested Immediate Next Step
 
-Continue validating `feat/wam-c-lowered-helper-body-calls`.
+Continue validating `feat/wam-c-lowered-helper-filtered-facts`.
 
-The active branch lowers one deterministic body-call shape by delegating from
-the caller helper to an already lowered callee helper through the existing
-foreign registry. The tiny lowered-helper matrix now exercises that lowered
-body-call path in its lowered target.
+The active branch lowers one constant-guarded fact projection shape, for
+example `keep(X) :- fact(X, keep)`, into native fact rows. The tiny
+lowered-helper matrix now exercises the filtered helper in its lowered target.

--- a/examples/benchmark/generate_wam_c_lowered_helper_benchmark.pl
+++ b/examples/benchmark/generate_wam_c_lowered_helper_benchmark.pl
@@ -65,15 +65,18 @@ parse_mode(Mode, _) :-
 mode_options(lowered, [lowered_helpers(true), report_lowered_helpers(true)]).
 mode_options(interpreted, [report_lowered_helpers(true)]).
 
-mode_predicates(lowered, [user:wam_c_bench_pair/2, user:wam_c_bench_pair_alias/2]).
+mode_predicates(lowered, [user:wam_c_bench_pair/2,
+                          user:wam_c_bench_pair_alias/2,
+                          user:wam_c_bench_pair_tag/3,
+                          user:wam_c_bench_pair_keep/2]).
 mode_predicates(interpreted, [user:wam_c_bench_pair/2]).
 
-mode_query_predicate(lowered, 'wam_c_bench_pair_alias/2').
+mode_query_predicate(lowered, 'wam_c_bench_pair_keep/2').
 mode_query_predicate(interpreted, 'wam_c_bench_pair/2').
 
 mode_alias_setup(lowered,
-                 'void setup_wam_c_bench_pair_alias_2(WamState* state);\n',
-                 '    setup_wam_c_bench_pair_alias_2(&state);\n').
+                 'void setup_wam_c_bench_pair_alias_2(WamState* state);\nvoid setup_wam_c_bench_pair_tag_3(WamState* state);\nvoid setup_wam_c_bench_pair_keep_2(WamState* state);\n',
+                 '    setup_wam_c_bench_pair_alias_2(&state);\n    setup_wam_c_bench_pair_tag_3(&state);\n    setup_wam_c_bench_pair_keep_2(&state);\n').
 mode_alias_setup(interpreted, '', '').
 
 setup_benchmark_facts :-
@@ -81,11 +84,17 @@ setup_benchmark_facts :-
     assertz(user:wam_c_bench_pair(a, b)),
     assertz(user:wam_c_bench_pair(a, c)),
     assertz(user:wam_c_bench_pair(b, d)),
-    assertz(user:((wam_c_bench_pair_alias(X, Y) :- wam_c_bench_pair(X, Y)))).
+    assertz(user:wam_c_bench_pair_tag(a, b, keep)),
+    assertz(user:wam_c_bench_pair_tag(a, c, keep)),
+    assertz(user:wam_c_bench_pair_tag(b, d, keep)),
+    assertz(user:((wam_c_bench_pair_alias(X, Y) :- wam_c_bench_pair(X, Y)))),
+    assertz(user:((wam_c_bench_pair_keep(X, Y) :- wam_c_bench_pair_tag(X, Y, keep)))).
 
 cleanup_benchmark_facts :-
     retractall(user:wam_c_bench_pair(_, _)),
-    retractall(user:wam_c_bench_pair_alias(_, _)).
+    retractall(user:wam_c_bench_pair_alias(_, _)),
+    retractall(user:wam_c_bench_pair_tag(_, _, _)),
+    retractall(user:wam_c_bench_pair_keep(_, _)).
 
 lowered_helper_benchmark_main(QueryPred, AliasDecl, AliasSetup, Code) :-
     format(atom(Code),

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -178,6 +178,8 @@ plan_wam_c_lowered_helper(DetectedKeys, PredIndicator, Plan) :-
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, fact_only(Rows))
     ;   lowered_body_call_helper(PredIndicator, CalleeKey, CalleeArity)
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, body_call(CalleeKey, CalleeArity))
+    ;   lowered_filtered_fact_helper(PredIndicator, CalleeKey, Rows)
+    ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, filtered_fact(CalleeKey, Rows))
     ;   lowered_fact_helper_rejection_reason(PredIndicator, Reason),
         Plan = wam_c_lowered_helper_plan(Key, PredIndicator, rejected, Reason)
     ).
@@ -206,6 +208,8 @@ compile_lowered_helpers_for_project(Plans, LoweredKeys, Code, SetupCode) :-
                 lowered_fact_helper_for_predicate(PredIndicator, Rows, Key, CodePart, SetupLine)
             ;   member(wam_c_lowered_helper_plan(Key, PredIndicator, lowered, body_call(CalleeKey, CalleeArity)), Plans),
                 lowered_body_call_helper_for_predicate(PredIndicator, CalleeKey, CalleeArity, Key, CodePart, SetupLine)
+            ;   member(wam_c_lowered_helper_plan(Key, PredIndicator, lowered, filtered_fact(_CalleeKey, Rows)), Plans),
+                lowered_fact_helper_for_predicate(PredIndicator, Rows, Key, CodePart, SetupLine)
             ),
             Entries),
     findall(K, member(K-_-_, Entries), LoweredKeys),
@@ -246,6 +250,7 @@ wam_c_lowered_helper_plan_by_action(Plans, Action, Key, ReasonLabel) :-
 
 wam_c_lowered_plan_reason_label(fact_only(_Rows), fact_only) :- !.
 wam_c_lowered_plan_reason_label(body_call(_CalleeKey, _CalleeArity), body_call) :- !.
+wam_c_lowered_plan_reason_label(filtered_fact(_CalleeKey, _Rows), filtered_fact) :- !.
 wam_c_lowered_plan_reason_label(Reason, Reason).
 
 lowered_fact_helper_rows(PredIndicator, Rows) :-
@@ -310,6 +315,71 @@ lowered_body_call_helper_for_predicate(PredIndicator, CalleeKey, CalleeArity, Ke
     format(atom(SetupLine),
            '    wam_register_foreign_predicate(state, "~w", ~w, ~w);',
            [Key, Arity, Symbol]).
+
+lowered_filtered_fact_helper(PredIndicator, CalleeKey, Rows) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
+    functor(Head, Pred, Arity),
+    findall(HeadArgs-Body,
+            (   user:clause(Head, Body),
+                Head =.. [_|HeadArgs]
+            ),
+            Clauses),
+    Clauses = [HeadArgs-Body0],
+    Body0 \== true,
+    strip_module_qualification(Body0, Body),
+    Body =.. [CalleePred|CalleeArgs],
+    length(CalleeArgs, CalleeArity),
+    (Pred/Arity) \== (CalleePred/CalleeArity),
+    maplist(var, HeadArgs),
+    callee_args_supported_for_filter(CalleeArgs, HeadArgs),
+    CalleeIndicator = user:CalleePred/CalleeArity,
+    lowered_fact_helper_rows(CalleeIndicator, CalleeRows),
+    include(callee_row_matches_filter(CalleeArgs, HeadArgs), CalleeRows, MatchingRows),
+    findall(Projected,
+            (   member(CalleeRow, MatchingRows),
+                project_callee_row_to_head(HeadArgs, CalleeArgs, CalleeRow, Projected)
+            ),
+            ProjectedRows0),
+    sort(ProjectedRows0, Rows),
+    Rows \= [],
+    format(atom(CalleeKey), '~w/~w', [CalleePred, CalleeArity]).
+
+strip_module_qualification(Module:Body, Stripped) :-
+    atom(Module),
+    !,
+    strip_module_qualification(Body, Stripped).
+strip_module_qualification(Body, Body).
+
+callee_args_supported_for_filter([], _).
+callee_args_supported_for_filter([Arg|Rest], HeadArgs) :-
+    (   member(HeadArg, HeadArgs),
+        Arg == HeadArg
+    ->  true
+    ;   wam_c_lowered_constant(Arg)
+    ),
+    callee_args_supported_for_filter(Rest, HeadArgs).
+
+callee_row_matches_filter(CalleeArgs, HeadArgs, CalleeRow) :-
+    same_length(CalleeArgs, CalleeRow),
+    callee_row_matches_filter_(CalleeArgs, HeadArgs, CalleeRow).
+
+callee_row_matches_filter_([], _, []).
+callee_row_matches_filter_([Arg|ArgRest], HeadArgs, [Value|ValueRest]) :-
+    (   wam_c_lowered_constant(Arg)
+    ->  Arg == Value
+    ;   member(HeadArg, HeadArgs),
+        Arg == HeadArg
+    ->  true
+    ),
+    callee_row_matches_filter_(ArgRest, HeadArgs, ValueRest).
+
+project_callee_row_to_head([], _, _, []).
+project_callee_row_to_head([HeadArg|Rest], CalleeArgs, CalleeRow, [Value|Values]) :-
+    nth0(Index, CalleeArgs, CalleeArg),
+    CalleeArg == HeadArg,
+    !,
+    nth0(Index, CalleeRow, Value),
+    project_callee_row_to_head(Rest, CalleeArgs, CalleeRow, Values).
 
 wam_c_lowered_constant(Arg) :- atom(Arg), !.
 wam_c_lowered_constant(Arg) :- integer(Arg).

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -403,6 +403,39 @@ test_lowered_body_call_helper_generation :-
     retractall(user:wam_c_body_fact(_, _)),
     retractall(user:wam_c_body_alias(_, _)).
 
+test_lowered_filtered_fact_helper_generation :-
+    Test = 'WAM-C: guarded fact predicates can lower to filtered native helper',
+    assertz(user:wam_c_filter_fact(a, keep)),
+    assertz(user:wam_c_filter_fact(b, drop)),
+    assertz(user:wam_c_filter_fact(c, keep)),
+    assertz((user:wam_c_filter_keep(X) :- user:wam_c_filter_fact(X, keep))),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(ProjectDir), '/tmp/unifyweaver_wam_c_lowered_filter_project_~w', [Stamp]),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    (   plan_wam_c_lowered_helpers([user:wam_c_filter_fact/2,
+                                     user:wam_c_filter_keep/1],
+                                    [lowered_helpers(true)],
+                                    [],
+                                    Plans),
+        member(wam_c_lowered_helper_plan('wam_c_filter_fact/2', _, lowered, fact_only([[a,keep],[b,drop],[c,keep]])), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_filter_keep/1', _, lowered, filtered_fact('wam_c_filter_fact/2', [[a],[c]])), Plans),
+        write_wam_c_project([user:wam_c_filter_fact/2,
+                             user:wam_c_filter_keep/1],
+                            [lowered_helpers(true)],
+                            ProjectDir),
+        read_file_to_string(LibPath, LibS, []),
+        sub_string(LibS, _, _, _, '// - lowered wam_c_filter_keep/1: filtered_fact'),
+        sub_string(LibS, _, _, _, 'static bool wam_c_lowered_wam_c_filter_keep_1'),
+        sub_string(LibS, _, _, _, 'val_atom("a")'),
+        sub_string(LibS, _, _, _, 'val_atom("c")'),
+        sub_string(LibS, _, _, _, '.pred = "wam_c_filter_keep/1"')
+    ->  pass(Test)
+    ;   fail_test(Test, 'lowered filtered fact helper was not emitted')
+    ),
+    retractall(user:wam_c_filter_fact(_, _)),
+    retractall(user:wam_c_filter_keep(_)).
+
 test_unsupported_instruction_fails_loudly :-
     Test = 'WAM-C: unsupported instructions fail loudly',
     BadWamCode = 'foo/1:\n    unknown_opcode A1\n    proceed',
@@ -613,6 +646,16 @@ test_lowered_body_call_helper_executable_smoke :-
     ->  (   run_lowered_body_call_helper_executable_smoke
         ->  pass(Test)
         ;   fail_test(Test, 'lowered body-call helper executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
+test_lowered_filtered_fact_helper_executable_smoke :-
+    Test = 'WAM-C: lowered filtered fact helper executable smoke',
+    (   gcc_available
+    ->  (   run_lowered_filtered_fact_helper_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'lowered filtered fact helper executable failed')
         )
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
@@ -1046,6 +1089,33 @@ run_lowered_body_call_helper_executable_smoke :-
         retractall(user:wam_c_body_alias(_, _))
     ;   retractall(user:wam_c_body_fact(_, _)),
         retractall(user:wam_c_body_alias(_, _)),
+        fail
+    ).
+
+run_lowered_filtered_fact_helper_executable_smoke :-
+    assertz(user:wam_c_filter_fact(a, keep)),
+    assertz(user:wam_c_filter_fact(b, drop)),
+    assertz(user:wam_c_filter_fact(c, keep)),
+    assertz((user:wam_c_filter_keep(X) :- user:wam_c_filter_fact(X, keep))),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(ProjectDir), '/tmp/unifyweaver_wam_c_lowered_filter_smoke_~w', [Stamp]),
+    directory_file_path(ProjectDir, 'wam_runtime.c', RuntimePath),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    directory_file_path(ProjectDir, 'main.c', MainPath),
+    directory_file_path(ProjectDir, 'wam_c_lowered_filter_smoke', ExePath),
+    (   write_wam_c_project([user:wam_c_filter_fact/2,
+                             user:wam_c_filter_keep/1],
+                            [lowered_helpers(true)],
+                            ProjectDir),
+        wam_c_lowered_filter_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, LibPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  retractall(user:wam_c_filter_fact(_, _)),
+        retractall(user:wam_c_filter_keep(_))
+    ;   retractall(user:wam_c_filter_fact(_, _)),
+        retractall(user:wam_c_filter_keep(_)),
         fail
     ).
 
@@ -1836,6 +1906,47 @@ int main(void) {
 }
 ').
 
+wam_c_lowered_filter_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_filter_fact_2(WamState* state);
+void setup_wam_c_filter_keep_1(WamState* state);
+void setup_lowered_wam_c_helpers(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_filter_fact_2(&state);
+    setup_wam_c_filter_keep_1(&state);
+    setup_lowered_wam_c_helpers(&state);
+
+    WamValue ok_args[1] = { val_unbound("Out") };
+    int ok_rc = wam_run_predicate(&state, "wam_c_filter_keep/1", ok_args, 1);
+    if (ok_rc != 0 || state.P != WAM_HALT ||
+        state.A[0].tag != VAL_ATOM || strcmp(state.A[0].data.atom, "a") != 0) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue ground_args[1] = { val_atom("c") };
+    int ground_rc = wam_run_predicate(&state, "wam_c_filter_keep/1", ground_args, 1);
+    if (ground_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue fail_args[1] = { val_atom("b") };
+    int fail_rc = wam_run_predicate(&state, "wam_c_filter_keep/1", fail_args, 1);
+    if (fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_real_builtin_smoke_main(
 '#include "wam_runtime.h"
 
@@ -2171,6 +2282,7 @@ run_tests_once :-
     test_lowered_helper_planner_metadata,
     test_lowered_helper_plan_generation,
     test_lowered_body_call_helper_generation,
+    test_lowered_filtered_fact_helper_generation,
     test_unsupported_instruction_fails_loudly,
     test_no_zero_instruction_fallback,
     test_list_target_pc_emission,
@@ -2191,6 +2303,7 @@ run_tests_once :-
     test_real_prolog_classic_recursive_executable_smoke,
     test_lowered_fact_helper_executable_smoke,
     test_lowered_body_call_helper_executable_smoke,
+    test_lowered_filtered_fact_helper_executable_smoke,
     test_asan_memory_lifecycle_executable_smoke,
     format('~n=== WAM-C Target Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).


### PR DESCRIPTION
## Summary

This PR extends the WAM-C lowered-helper planner beyond fact-only and direct body-call helpers by supporting simple constant-filtered fact projections. Predicates shaped like `keep(X) :- fact(X, keep)` can now be planned as native lowered helpers when the callee is fact-only lowerable, with projected matching rows emitted through the existing foreign-helper registration path.

## What Changed

- Recognizes one-call filtered fact predicates whose callee arguments are head variables plus atom or integer constants.
- Projects matching callee fact rows into caller rows and emits them with the existing fact-helper codegen path.
- Reports the new `filtered_fact` planner reason in generated plan comments and lowered-helper summaries.
- Adds generated-code and executable smoke coverage for filtered fact helpers.
- Updates the lowered-helper benchmark so the lowered mode exercises fact-only, body-call, and filtered-fact helper shapes.
- Refreshes `WAM_C_TARGET_NEXT_STEPS.md` to mark this branch active and name the next rejection-diagnostics branch.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets c-wam-lowered-helper --repetitions 1 --baseline-target c-wam-lowered-helper-interpreted`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
- `git diff --check`

## Follow-Up

Next recommended branch: `feat/wam-c-lowered-helper-filter-rejections`.
