### PR TITLE
bench(csharp-query): include scan source-mode sweep

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -161,10 +161,14 @@ python examples/benchmark/benchmark_csharp_query_source_mode_sweep.py \
   --write-calibration-artifact
 ```
 
-Mixed-scale sweeps are filtered per workload. File-backed graph workloads can
-use `dev`, `300`, `1k`, `5k`, and `10k`; generated dependency-depth workloads
-use `300`, `1k`, `5k`, and `10k`. Unsupported workload/scale pairs are skipped
-with warnings instead of aborting the full sweep.
+Mixed-scale sweeps are filtered per workload. File-backed graph and
+scan-materialization workloads can use `dev`, `300`, `1k`, `5k`, and `10k`;
+generated dependency-depth workloads use `300`, `1k`, `5k`, and `10k`.
+Unsupported workload/scale pairs are skipped with warnings instead of aborting
+the full sweep. The checked-in `csharp_query_graph_source_mode_calibration.tsv`
+remains graph-only; scan rows are emitted as `scan-materialization:<mode>` when
+selected explicitly with `--workloads scan-materialization` or
+`--workloads all-with-scan`.
 
 ### WAM-Rust and WAM-Haskell Benchmark Variants
 

--- a/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
+++ b/examples/benchmark/benchmark_csharp_query_source_mode_sweep.py
@@ -35,6 +35,10 @@ WORKLOAD_SCRIPTS = {
     "shortest-path": BENCHMARK_DIR / "benchmark_shortest_path_cross_target.py",
     "weighted-shortest-path": BENCHMARK_DIR / "benchmark_weighted_shortest_path_cross_target.py",
 }
+SCAN_WORKLOAD = "scan-materialization"
+SCAN_WORKLOAD_SCRIPT = BENCHMARK_DIR / "benchmark_scan_materialization.py"
+SCAN_WORKLOAD_MODES = ("scan", "bound_scan", "selective_join", "join", "nary_join")
+ALL_WORKLOADS = tuple(WORKLOAD_SCRIPTS) + (SCAN_WORKLOAD,)
 
 FILE_BACKED_GRAPH_SCALES = ("dev", "300", "1k", "5k", "10k")
 GENERATED_GRAPH_SCALES = ("300", "1k", "5k", "10k")
@@ -45,6 +49,7 @@ WORKLOAD_SUPPORTED_SCALES = {
     "effective-distance": FILE_BACKED_GRAPH_SCALES,
     "shortest-path": FILE_BACKED_GRAPH_SCALES,
     "weighted-shortest-path": FILE_BACKED_GRAPH_SCALES,
+    SCAN_WORKLOAD: FILE_BACKED_GRAPH_SCALES,
 }
 
 DEFAULT_WORKLOADS = "all"
@@ -108,7 +113,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--workloads",
         default=DEFAULT_WORKLOADS,
-        help="Comma-separated workloads, or 'all' for every registered graph workload.",
+        help=(
+            "Comma-separated workloads, 'all' for graph workloads, or "
+            "'all-with-scan' to include scan-materialization."
+        ),
     )
     parser.add_argument("--scales", default="300")
     parser.add_argument(
@@ -210,14 +218,16 @@ def parse_args() -> argparse.Namespace:
 def parse_workloads(value: str) -> list[str]:
     if value.strip().lower() == "all":
         return list(WORKLOAD_SCRIPTS)
+    if value.strip().lower() == "all-with-scan":
+        return list(ALL_WORKLOADS)
     workloads = split_csv(value)
-    unknown = [workload for workload in workloads if workload not in WORKLOAD_SCRIPTS]
+    unknown = [workload for workload in workloads if workload not in ALL_WORKLOADS]
     if unknown:
         raise SystemExit(
             "unknown workload(s): "
             + ", ".join(unknown)
             + "; expected one of "
-            + ", ".join(WORKLOAD_SCRIPTS)
+            + ", ".join(ALL_WORKLOADS)
         )
     if not workloads:
         raise SystemExit("expected at least one workload")
@@ -229,7 +239,7 @@ def supported_scales_for_workload(workload: str) -> tuple[str, ...]:
         return WORKLOAD_SUPPORTED_SCALES[workload]
     except KeyError as exc:
         raise SystemExit(
-            f"unknown workload {workload!r}; expected one of {', '.join(WORKLOAD_SCRIPTS)}"
+            f"unknown workload {workload!r}; expected one of {', '.join(ALL_WORKLOADS)}"
         ) from exc
 
 
@@ -449,6 +459,45 @@ def parse_runner_output(
                 median_summary=median_summary,
                 resolved_source_mode_summary=resolved_summary,
                 source_registration_summary=registration_summary,
+            )
+        )
+    return summaries
+
+
+def parse_scan_runner_output(output: str) -> list[SourceModeSummary]:
+    summaries: list[SourceModeSummary] = []
+    header: list[str] = []
+    for line in output.splitlines():
+        parts = line.rstrip("\n").split("\t")
+        if not parts:
+            continue
+        if parts[0] == "scale":
+            header = parts
+            continue
+        if not header or len(parts) < len(header):
+            continue
+        row = dict(zip(header, parts))
+        scale = row.get("scale", "")
+        mode = row.get("mode", "")
+        chosen_source_mode = row.get("chosen_source_mode", "")
+        best_source_mode = row.get("best_source_mode", "")
+        auto_vs_best = row.get("auto_vs_best", "")
+        median_summary = row.get("median_s_by_source_mode", "")
+        source_registration_summary = row.get("source_registrations_by_source_mode", "")
+        output_agreement = row.get("output_agreement", "match")
+        resolved_source_mode_summary = (
+            f"auto:{chosen_source_mode}" if chosen_source_mode else ""
+        )
+        summaries.append(
+            SourceModeSummary(
+                workload=f"{SCAN_WORKLOAD}:{mode}",
+                scale=scale,
+                best_source_mode=best_source_mode,
+                auto_vs_best=auto_vs_best,
+                output_agreement=output_agreement,
+                median_summary=median_summary,
+                resolved_source_mode_summary=resolved_source_mode_summary,
+                source_registration_summary=source_registration_summary,
             )
         )
     return summaries
@@ -841,6 +890,14 @@ def run_workload(
     repetitions: int,
     trace: bool,
 ) -> list[SourceModeSummary]:
+    if workload == SCAN_WORKLOAD:
+        return run_scan_workload(
+            scales=scales,
+            source_modes=source_modes,
+            repetitions=repetitions,
+            trace=trace,
+        )
+
     env = dict(os.environ)
     if trace:
         env["UNIFYWEAVER_BENCH_TRACE"] = "1"
@@ -870,6 +927,42 @@ def run_workload(
         result.stdout,
         default_source_mode=default_source_mode,
     )
+
+
+def run_scan_workload(
+    *,
+    scales: str,
+    source_modes: str,
+    repetitions: int,
+    trace: bool,
+) -> list[SourceModeSummary]:
+    env = dict(os.environ)
+    if trace:
+        env["UNIFYWEAVER_BENCH_TRACE"] = "1"
+    else:
+        env.pop("UNIFYWEAVER_BENCH_TRACE", None)
+
+    result = run_command(
+        [
+            sys.executable,
+            str(SCAN_WORKLOAD_SCRIPT),
+            "--scales",
+            scales,
+            "--modes",
+            ",".join(SCAN_WORKLOAD_MODES),
+            "--source-modes",
+            source_modes,
+            "--strategies",
+            "auto",
+            "--repetitions",
+            str(repetitions),
+            "--format",
+            "calibration-tsv",
+        ],
+        cwd=ROOT,
+        env=env,
+    )
+    return parse_scan_runner_output(result.stdout)
 
 
 def print_tsv(summaries: list[SourceModeSummary]) -> None:

--- a/examples/benchmark/benchmark_scan_materialization.py
+++ b/examples/benchmark/benchmark_scan_materialization.py
@@ -351,6 +351,7 @@ class BenchResult:
     strategy: str
     times: list[float]
     stderr: str
+    stdout_hash: str
 
     @property
     def median(self) -> float:
@@ -365,6 +366,7 @@ class SourceModeSummary:
     chosen_source_mode: str
     policy_status: str
     overlap_status: str
+    output_agreement: str
     auto_median: str
     auto_vs_best: str
     median_summary: str
@@ -450,6 +452,15 @@ def format_time_spread(result: BenchResult) -> str:
     return f"{min(result.times):.3f}-{max(result.times):.3f}"
 
 
+def normalized_output_hash(stdout: str) -> str:
+    lines = [line for line in stdout.splitlines() if line]
+    if not lines:
+        return ""
+    header, *rows = lines
+    normalized = "\n".join([header, *sorted(rows)]) + "\n"
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
 def classify_policy_status(
     chosen_source_mode: str,
     best_source_mode: str,
@@ -522,6 +533,11 @@ def summarize_by_source_mode(
             best_source_mode = best.source_mode if best is not None else ""
             policy_status = classify_policy_status(chosen_source_mode, best_source_mode, auto, best)
             overlap_status = classify_overlap_status(auto, best)
+            output_hashes = {
+                result.stdout_hash
+                for result in source_results.values()
+            }
+            output_agreement = "match" if len(output_hashes) == 1 else "MISMATCH"
             auto_median = f"{auto.median:.3f}" if auto is not None else ""
             auto_vs_best = ""
             if auto is not None and best is not None:
@@ -556,6 +572,7 @@ def summarize_by_source_mode(
                     chosen_source_mode=chosen_source_mode,
                     policy_status=policy_status,
                     overlap_status=overlap_status,
+                    output_agreement=output_agreement,
                     auto_median=auto_median,
                     auto_vs_best=auto_vs_best,
                     median_summary=median_summary,
@@ -628,43 +645,43 @@ def print_detail_tsv(
 
 
 def print_report_tsv(summaries: list[SourceModeSummary]) -> None:
-    print("scale	mode	best_source_mode	chosen_source_mode	auto_vs_best	median_s_by_source_mode	rows_by_source_mode	source_registrations_by_source_mode	bucket_strategies_by_source_mode")
+    print("scale	mode	best_source_mode	chosen_source_mode	output_agreement	auto_vs_best	median_s_by_source_mode	rows_by_source_mode	source_registrations_by_source_mode	bucket_strategies_by_source_mode")
     for summary in summaries:
         print(
             f"{summary.scale}	{summary.mode}	{summary.best_source_mode}	{summary.chosen_source_mode}	"
-            f"{summary.auto_vs_best}	{summary.median_summary}	{summary.row_summary}	"
+            f"{summary.output_agreement}	{summary.auto_vs_best}	{summary.median_summary}	{summary.row_summary}	"
             f"{summary.source_registration_summary}	{summary.bucket_strategy_summary}"
         )
 
 
 def print_markdown(summaries: list[SourceModeSummary]) -> None:
-    print("| Scale | Mode | Best source mode | Chosen source mode | Auto vs best | Median seconds by source mode | Rows by source mode | Source registrations by source mode | Bucket strategies by source mode |")
-    print("| --- | --- | --- | --- | ---: | --- | --- | --- | --- |")
+    print("| Scale | Mode | Best source mode | Chosen source mode | Outputs | Auto vs best | Median seconds by source mode | Rows by source mode | Source registrations by source mode | Bucket strategies by source mode |")
+    print("| --- | --- | --- | --- | --- | ---: | --- | --- | --- | --- |")
     for summary in summaries:
         print(
             f"| {summary.scale} | {summary.mode} | {summary.best_source_mode} | "
-            f"{summary.chosen_source_mode} | {summary.auto_vs_best} | `{summary.median_summary}` | "
+            f"{summary.chosen_source_mode} | {summary.output_agreement} | {summary.auto_vs_best} | `{summary.median_summary}` | "
             f"`{summary.row_summary}` | `{summary.source_registration_summary}` | "
             f"`{summary.bucket_strategy_summary}` |"
         )
 
 
 def print_calibration_tsv(summaries: list[SourceModeSummary]) -> None:
-    print("scale	mode	policy_status	overlap_status	chosen_source_mode	best_source_mode	auto_median_s	auto_vs_best	median_s_by_source_mode	spread_s_by_source_mode	source_registrations_by_source_mode")
+    print("scale	mode	policy_status	overlap_status	output_agreement	chosen_source_mode	best_source_mode	auto_median_s	auto_vs_best	median_s_by_source_mode	spread_s_by_source_mode	source_registrations_by_source_mode")
     for summary in summaries:
         print(
-            f"{summary.scale}	{summary.mode}	{summary.policy_status}	{summary.overlap_status}	"
+            f"{summary.scale}	{summary.mode}	{summary.policy_status}	{summary.overlap_status}	{summary.output_agreement}	"
             f"{summary.chosen_source_mode}	{summary.best_source_mode}	{summary.auto_median}	{summary.auto_vs_best}	"
             f"{summary.median_summary}	{summary.spread_summary}	{summary.source_registration_summary}"
         )
 
 
 def print_calibration_markdown(summaries: list[SourceModeSummary]) -> None:
-    print("| Scale | Mode | Policy | Overlap | Chosen source mode | Best source mode | Auto median seconds | Auto vs best | Median seconds by source mode | Spread seconds by source mode | Source registrations by source mode |")
-    print("| --- | --- | --- | --- | --- | --- | ---: | ---: | --- | --- | --- |")
+    print("| Scale | Mode | Policy | Overlap | Outputs | Chosen source mode | Best source mode | Auto median seconds | Auto vs best | Median seconds by source mode | Spread seconds by source mode | Source registrations by source mode |")
+    print("| --- | --- | --- | --- | --- | --- | --- | ---: | ---: | --- | --- | --- |")
     for summary in summaries:
         print(
-            f"| {summary.scale} | {summary.mode} | {summary.policy_status} | {summary.overlap_status} | "
+            f"| {summary.scale} | {summary.mode} | {summary.policy_status} | {summary.overlap_status} | {summary.output_agreement} | "
             f"{summary.chosen_source_mode} | {summary.best_source_mode} | {summary.auto_median} | {summary.auto_vs_best} | "
             f"`{summary.median_summary}` | `{summary.spread_summary}` | "
             f"`{summary.source_registration_summary}` |"
@@ -702,17 +719,20 @@ def benchmark_mode(
 
     times: list[float] = []
     stderr = ""
+    stdout = ""
     if repetitions > 0:
         run(command + [mode, str(edge_path), str(article_path)], env=env)
     for _ in range(repetitions):
         result = run(command + [mode, str(edge_path), str(article_path)], env=env)
         stderr = result.stderr
+        stdout = result.stdout
         metrics = parse_metrics(stderr)
         elapsed_ms = metrics.get("elapsed_ms")
         elapsed = float(elapsed_ms) / 1000.0 if elapsed_ms is not None else 0.0
         times.append(elapsed)
     metrics = parse_metrics(stderr)
     resolved_source_mode = metrics.get("resolved_source_mode", source_mode)
+    stdout_hash = normalized_output_hash(stdout)
 
     return BenchResult(
         scale=scale,
@@ -722,6 +742,7 @@ def benchmark_mode(
         strategy=strategy,
         times=times,
         stderr=stderr,
+        stdout_hash=stdout_hash,
     )
 
 

--- a/tests/test_csharp_query_graph_source_mode_policy.py
+++ b/tests/test_csharp_query_graph_source_mode_policy.py
@@ -92,6 +92,15 @@ class CSharpQueryGraphSourceModePolicyTests(unittest.TestCase):
             source,
         )
 
+    def test_scan_materialization_output_hash_ignores_row_order(self) -> None:
+        left = "value\nb\na\n"
+        right = "value\na\nb\n"
+
+        self.assertEqual(
+            benchmark_scan_materialization.normalized_output_hash(left),
+            benchmark_scan_materialization.normalized_output_hash(right),
+        )
+
     def test_runtime_scan_source_mode_policy_matches_documented_cases(self) -> None:
         runtime_source = (
             ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"

--- a/tests/test_csharp_query_source_mode_sweep.py
+++ b/tests/test_csharp_query_source_mode_sweep.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -18,6 +19,9 @@ from benchmark_csharp_query_source_mode_sweep import (  # noqa: E402
     CalibrationArtifactRow,
     CompetingProcess,
     DEFAULT_WORKLOADS,
+    SCAN_WORKLOAD,
+    SCAN_WORKLOAD_MODES,
+    SCAN_WORKLOAD_SCRIPT,
     SourceModeSummary,
     WORKLOAD_SCRIPTS,
     main,
@@ -35,9 +39,11 @@ from benchmark_csharp_query_source_mode_sweep import (  # noqa: E402
     parse_mode_summary,
     parse_ratio,
     parse_runner_output,
+    parse_scan_runner_output,
     parse_workloads,
     render_calibration_tsv,
     resource_preflight_failures,
+    run_scan_workload,
     summarize_stability,
     supported_scales_for_workload,
     write_calibration_artifact,
@@ -61,6 +67,9 @@ class CSharpQuerySourceModeSweepTests(unittest.TestCase):
     def test_parse_workloads_all_expands_to_all_graph_workloads(self) -> None:
         self.assertEqual(parse_workloads("all"), list(WORKLOAD_SCRIPTS))
         self.assertEqual(parse_workloads(" ALL "), list(WORKLOAD_SCRIPTS))
+
+    def test_parse_workloads_all_with_scan_includes_scan_workload(self) -> None:
+        self.assertEqual(parse_workloads("all-with-scan"), list(WORKLOAD_SCRIPTS) + [SCAN_WORKLOAD])
 
     def test_parse_workloads_rejects_unknown_workloads(self) -> None:
         with self.assertRaisesRegex(SystemExit, "unknown workload"):
@@ -112,6 +121,16 @@ class CSharpQuerySourceModeSweepTests(unittest.TestCase):
         self.assertEqual(
             filter_workload_scales("shortest-path", "dev"),
             ("dev", []),
+        )
+
+    def test_filter_workload_scales_keeps_dev_for_scan_workload(self) -> None:
+        self.assertEqual(
+            supported_scales_for_workload(SCAN_WORKLOAD),
+            ("dev", "300", "1k", "5k", "10k"),
+        )
+        self.assertEqual(
+            filter_workload_scales(SCAN_WORKLOAD, "dev,300"),
+            ("dev,300", []),
         )
 
     def test_parse_mem_available_mib(self) -> None:
@@ -650,6 +669,77 @@ class CSharpQuerySourceModeSweepTests(unittest.TestCase):
         self.assertEqual(len(summaries), 1)
         self.assertEqual(summaries[0].output_agreement, "MISMATCH")
         self.assertEqual(summaries[0].auto_vs_best, "")
+
+    def test_parse_scan_runner_output_keys_rows_by_scan_mode(self) -> None:
+        output = "\n".join(
+            [
+                (
+                    "scale\tmode\tpolicy_status\toverlap_status\toutput_agreement\tchosen_source_mode\t"
+                    "best_source_mode\tauto_median_s\tauto_vs_best\t"
+                    "median_s_by_source_mode\tspread_s_by_source_mode\t"
+                    "source_registrations_by_source_mode"
+                ),
+                (
+                    "300\tjoin\tmatch\tsingle-sample\tmatch\tartifact-prebuilt\t"
+                    "artifact-prebuilt\t0.120\t1.00x\t"
+                    "artifact-prebuilt:0.120,auto:0.120,preload:0.200\t"
+                    "artifact-prebuilt:0.120-0.120,auto:0.120-0.120,preload:0.200-0.200\t"
+                    "artifact-prebuilt:binary_artifact_artifact-prebuilt_arity2=2,"
+                    "auto:binary_artifact_artifact-prebuilt_arity2=2,"
+                    "preload:preloaded_preload_arity2=2"
+                ),
+            ]
+        )
+
+        summaries = parse_scan_runner_output(output)
+
+        self.assertEqual(len(summaries), 1)
+        summary = summaries[0]
+        self.assertEqual(summary.workload, f"{SCAN_WORKLOAD}:join")
+        self.assertEqual(summary.scale, "300")
+        self.assertEqual(summary.best_source_mode, "artifact-prebuilt")
+        self.assertEqual(summary.auto_vs_best, "1.00x")
+        self.assertEqual(summary.output_agreement, "match")
+        self.assertEqual(summary.resolved_source_mode_summary, "auto:artifact-prebuilt")
+        self.assertIn("auto:binary_artifact_artifact-prebuilt_arity2=2", summary.source_registration_summary)
+
+    def test_run_scan_workload_uses_scan_calibration_runner(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=(
+                "scale\tmode\tpolicy_status\toverlap_status\toutput_agreement\tchosen_source_mode\t"
+                "best_source_mode\tauto_median_s\tauto_vs_best\t"
+                "median_s_by_source_mode\tspread_s_by_source_mode\t"
+                "source_registrations_by_source_mode\n"
+                "300\tjoin\tmatch\tsingle-sample\tmatch\tartifact-prebuilt\t"
+                "artifact-prebuilt\t0.120\t1.00x\t"
+                "artifact-prebuilt:0.120,auto:0.120\t"
+                "artifact-prebuilt:0.120-0.120,auto:0.120-0.120\t"
+                "artifact-prebuilt:binary_artifact_artifact-prebuilt_arity2=2,"
+                "auto:binary_artifact_artifact-prebuilt_arity2=2\n"
+            ),
+            stderr="",
+        )
+
+        with mock.patch(
+            "benchmark_csharp_query_source_mode_sweep.run_command",
+            return_value=completed,
+        ) as run_command:
+            summaries = run_scan_workload(
+                scales="300",
+                source_modes="auto,artifact-prebuilt",
+                repetitions=1,
+                trace=True,
+            )
+
+        command = run_command.call_args.args[0]
+        self.assertEqual(command[1], str(SCAN_WORKLOAD_SCRIPT))
+        self.assertIn("--modes", command)
+        self.assertIn(",".join(SCAN_WORKLOAD_MODES), command)
+        self.assertIn("--format", command)
+        self.assertIn("calibration-tsv", command)
+        self.assertEqual(summaries[0].workload, f"{SCAN_WORKLOAD}:join")
 
     def test_calibration_failures_detect_slow_auto(self) -> None:
         output = "\n".join(


### PR DESCRIPTION
 #   Include scan materialization in C# query source-mode sweeps

  ## Summary

  - Adds opt-in scan materialization coverage to the C# query source-mode sweep via `--workloads scan-materialization`
  and `--workloads all-with-scan`.
  - Keeps the default `--workloads all` graph-only so the existing graph calibration artifact workflow remains stable.
  - Emits real scan output-agreement status using normalized stdout hashes, avoiding false mismatches from row ordering.
  - Adds tests for scan workload parsing, scale filtering, command dispatch, and normalized output hashing.
  - Documents the scan sweep behavior and graph-only calibration artifact boundary.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_source_mode_sweep.py tests/
  test_csharp_query_graph_source_mode_policy.py tests/test_csharp_query_calibration_refresh_wrapper.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_source_mode_sweep.py examples/benchmark/
  benchmark_scan_materialization.py tests/test_csharp_query_source_mode_sweep.py tests/
  test_csharp_query_graph_source_mode_policy.py`
  - `python3 examples/benchmark/benchmark_csharp_query_source_mode_sweep.py --workloads scan-materialization --scales
  dev --source-modes auto,preload --repetitions 1 --format tsv`
  - `git diff --check`