### PR TITLE
feat(wam-clojure): add read-mode arg builtin

### DIFF
--- a/PR_WAM_CLOJURE_ARG_READ_BUILTIN.md
+++ b/PR_WAM_CLOJURE_ARG_READ_BUILTIN.md
@@ -1,0 +1,25 @@
+# PR Title
+
+feat(wam-clojure): add read-mode arg builtin
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM lowered-emitter recognition for `arg/3`.
+- Implements runtime `apply-arg-solution` for read-mode `arg(+Index, +Term, ?Arg)`.
+- Wires interpreted built-in dispatch for `"arg/3"`.
+- Adds lowered-emitter and runtime smoke coverage for compound, list, out-of-bounds, and non-compound cases.
+
+## Scope
+
+This PR implements read-mode argument extraction only. It expects `Index` to be a positive integer and `Term` to be a compound/list structure, then unifies the selected 1-based argument with `Arg`.
+
+It intentionally does not add broader term-construction or enumeration behavior.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -368,6 +368,10 @@ clojure_direct_builtin("functor/3", "3").
 clojure_direct_builtin("functor/3", 3).
 clojure_direct_builtin('functor/3', "3").
 clojure_direct_builtin('functor/3', 3).
+clojure_direct_builtin("arg/3", "3").
+clojure_direct_builtin("arg/3", 3).
+clojure_direct_builtin('arg/3', "3").
+clojure_direct_builtin('arg/3', 3).
 clojure_direct_builtin("ground/1", "1").
 clojure_direct_builtin("ground/1", 1).
 clojure_direct_builtin('ground/1', "1").
@@ -581,6 +585,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "functor/3" ; Op == 'functor/3'),
     !,
     format(atom(Expr), '(runtime/apply-functor-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "arg/3" ; Op == 'arg/3'),
+    !,
+    format(atom(Expr), '(runtime/apply-arg-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "ground/1" ; Op == 'ground/1'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -558,6 +558,24 @@
           (backtrack state)))
       (backtrack state))))
 
+(defn apply-arg-solution [state]
+  (let [index (deref-value (:bindings state)
+                           (or (reg-get-raw state "A1") ::unbound))
+        term (deref-value (:bindings state)
+                          (or (reg-get-raw state "A2") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A3") ::unbound))]
+    (if (and (integer? index)
+             (pos? index)
+             (structure-term? term)
+             (<= index (count (:args term))))
+      (let [arg-value (nth (:args term) (dec index))
+            [ok next-state] (unify-values state out arg-value)]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+      (backtrack state))))
+
 (declare apply-member-solution)
 (declare apply-append-solution)
 (declare apply-first-foreign-solution)
@@ -1284,6 +1302,9 @@
 
           "functor/3"
           (apply-functor-solution state)
+
+          "arg/3"
+          (apply-arg-solution state)
 
           "ground/1"
           (let [value (deref-value (:bindings state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -494,6 +494,15 @@ test(simple_builtin_functor_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_arg_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_arg/3:\nbuiltin_call arg/3, 3\nproceed\n",
+        wam_clojure_lowerable(test_arg/3, WamCode, deterministic),
+        lower_predicate_to_clojure(test_arg/3, WamCode, [], Code),
+        has(Code, "runtime/apply-arg-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_ground_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_ground/1:\nbuiltin_call ground/1, 1\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -69,6 +69,7 @@
 :- dynamic user:wam_copy_term_sharing_fail/0.
 :- dynamic user:wam_copy_term_independent_ok/0.
 :- dynamic user:wam_functor_guard/3.
+:- dynamic user:wam_arg_guard/3.
 :- dynamic user:wam_ground_guard/1.
 :- dynamic user:wam_ground_unbound/1.
 :- dynamic user:wam_ground_nested_unbound/1.
@@ -159,6 +160,7 @@ user:wam_copy_term_guard(A, B) :- copy_term(A, B).
 user:wam_copy_term_sharing_fail :- user:wam_unbound_arg(X), copy_term(f(X, X), f(a, b)).
 user:wam_copy_term_independent_ok :- copy_term(f(_, _), f(a, b)).
 user:wam_functor_guard(Term, Name, Arity) :- functor(Term, Name, Arity).
+user:wam_arg_guard(Index, Term, Arg) :- arg(Index, Term, Arg).
 user:wam_ground_guard(X) :- ground(X).
 user:wam_ground_unbound(_) :- user:wam_unbound_arg(Y), ground(Y).
 user:wam_ground_nested_unbound(_) :- user:wam_unbound_arg(Y), ground(f(Y)).
@@ -254,6 +256,7 @@ run_smoke :-
           user:wam_copy_term_sharing_fail/0,
           user:wam_copy_term_independent_ok/0,
           user:wam_functor_guard/3,
+          user:wam_arg_guard/3,
           user:wam_ground_guard/1,
           user:wam_ground_unbound/1,
           user:wam_ground_nested_unbound/1,
@@ -306,6 +309,7 @@ run_smoke :-
     assert_lowered_append_builtin_emitted(TmpDir),
     assert_lowered_copy_term_builtin_emitted(TmpDir),
     assert_lowered_functor_builtin_emitted(TmpDir),
+    assert_lowered_arg_builtin_emitted(TmpDir),
     assert_lowered_ground_builtin_emitted(TmpDir),
     assert_lowered_arithmetic_comparison_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
@@ -438,6 +442,11 @@ smoke_cases([
     case('wam_functor_guard/3', args('f(a)', a, 1), "false"),
     case('wam_functor_guard/3', args(a, a, 0), "true"),
     case('wam_functor_guard/3', args(42, 42, 0), "true"),
+    case('wam_arg_guard/3', args(1, 'f(a,b)', a), "true"),
+    case('wam_arg_guard/3', args(2, 'f(a,b)', b), "true"),
+    case('wam_arg_guard/3', args(1, '[a,b]', a), "true"),
+    case('wam_arg_guard/3', args(3, 'f(a,b)', a), "false"),
+    case('wam_arg_guard/3', args(1, a, a), "false"),
     case('wam_ground_guard/1', a, "true"),
     case('wam_ground_guard/1', 42, "true"),
     case('wam_ground_guard/1', 3.5, "true"),
@@ -636,6 +645,12 @@ assert_lowered_functor_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-functor-guard-3"),
     has(CoreCode, "runtime/apply-functor-solution").
 
+assert_lowered_arg_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-arg-guard-3"),
+    has(CoreCode, "runtime/apply-arg-solution").
+
 assert_lowered_ground_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
@@ -823,6 +838,7 @@ prolog_term_string_to_edn(-42, "-42") :- !.
 prolog_term_string_to_edn(0, "0") :- !.
 prolog_term_string_to_edn(1, "1") :- !.
 prolog_term_string_to_edn(2, "2") :- !.
+prolog_term_string_to_edn(3, "3") :- !.
 prolog_term_string_to_edn(2.5, "2.5") :- !.
 prolog_term_string_to_edn(3.5, "3.5") :- !.
 prolog_term_string_to_edn(11, "11") :- !.
@@ -836,6 +852,7 @@ prolog_term_string_to_edn(f, "\"f\"") :- !.
 prolog_term_string_to_edn("f", "\"f\"") :- !.
 prolog_term_string_to_edn("z", "\"z\"") :- !.
 prolog_term_string_to_edn('f(a)', "{:tag :struct :functor \"f/1\" :args [\"a\"]}") :- !.
+prolog_term_string_to_edn('f(a,b)', "{:tag :struct :functor \"f/2\" :args [\"a\" \"b\"]}") :- !.
 prolog_term_string_to_edn('f(b)', "{:tag :struct :functor \"f/1\" :args [\"b\"]}") :- !.
 prolog_term_string_to_edn('[a]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}") :- !.
 prolog_term_string_to_edn('[a,b]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.
@@ -845,6 +862,7 @@ prolog_term_string_to_edn('[a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\
 prolog_term_string_to_edn('[a,b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[a|b]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"b\"]}") :- !.
 prolog_term_string_to_edn("f(a)", "{:tag :struct :functor \"f/1\" :args [\"a\"]}") :- !.
+prolog_term_string_to_edn("f(a,b)", "{:tag :struct :functor \"f/2\" :args [\"a\" \"b\"]}") :- !.
 prolog_term_string_to_edn("f(b)", "{:tag :struct :functor \"f/1\" :args [\"b\"]}") :- !.
 prolog_term_string_to_edn("[a]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}") :- !.
 prolog_term_string_to_edn("[a,b]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.


### PR DESCRIPTION
## Summary

- Adds Clojure WAM lowered-emitter recognition for `arg/3`.
- Implements runtime `apply-arg-solution` for read-mode `arg(+Index, +Term, ?Arg)`.
- Wires interpreted built-in dispatch for `"arg/3"`.
- Adds lowered-emitter and runtime smoke coverage for compound, list, out-of-bounds, and non-compound cases.

## Scope

This PR implements read-mode argument extraction only. It expects `Index` to be a positive integer and `Term` to be a compound/list structure, then unifies the selected 1-based argument with `Arg`.

It intentionally does not add broader term-construction or enumeration behavior.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
