### PR TITLE
Feat/wam Add Go WAM builtin parity fixes

### DIFF
--- a/PR_wam_go_builtin_parity.md
+++ b/PR_wam_go_builtin_parity.md
@@ -1,0 +1,26 @@
+# PR Title
+
+Add Go WAM builtin parity fixes
+
+# PR Description
+
+## Summary
+
+- Fix Go WAM builtin dispatch for `=</2`.
+- Add Go WAM runtime support for `is_list/1`, `display/1`, `functor/3`, `arg/3`, `=../2`, and `copy_term/2`.
+- Add runtime helpers for term functor/arity extraction, univ conversion, structure construction, and sharing-preserving fresh `copy_term/2`.
+- Extend the generated Go WAM builtin E2E test to compile and execute the new builtin coverage.
+- Update the Go parity audit to mark the small builtin and term builtin parity slices complete.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_python_target.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -15,9 +15,9 @@ current cross-target builtin/runtime baseline.
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2` | Includes `=</2` | Present for current baseline comparisons |
 | Unification builtin | `\=/2` | `=/2`, `\=/2` | Partial: no explicit `=/2` builtin handler |
-| Term inspection | Not present in `executeBuiltin/2` | `functor/3`, `arg/3` | Gap |
-| Univ | Not present in `executeBuiltin/2` | `=../2` compose/decompose | Gap |
-| Copying | Not present in `executeBuiltin/2` | `copy_term/2` with fresh variables and preserved sharing | Gap |
+| Term inspection | `functor/3`, `arg/3` | `functor/3`, `arg/3` | Present |
+| Univ | `=../2` compose/decompose | `=../2` compose/decompose | Present |
+| Copying | `copy_term/2` with fresh variables and preserved sharing | `copy_term/2` with fresh variables and preserved sharing | Present |
 | Control | `true/0`, `fail/0`, `!/0`, `\+/1`, `CutIte` | Same baseline, with broader isolated-goal NAF in Haskell/Python | Partial: `\+/1` only dispatches builtin-shaped goals |
 | IO | `write/1`, `display/1`, `nl/0` | `write/1`, `display/1`, `nl/0` | Present |
 
@@ -34,15 +34,16 @@ current cross-target builtin/runtime baseline.
   recently closed.
 - `=</2`, `is_list/1`, and `display/1` are now covered by the generated Go
   WAM builtin E2E test.
+- `functor/3`, `arg/3`, `=../2`, and `copy_term/2` are now covered by the
+  generated Go WAM builtin E2E test.
 
 ## Recommended Follow-Up Order
 
-1. Add a focused generated-project E2E parity suite for Go WAM builtins, similar
-   to the Python and Lua generated-project tests.
-2. Add term builtin parity: `functor/3`, `arg/3`, `=../2`, and `copy_term/2`.
-3. Upgrade `member/2` to enumerate through builtin choice points so aggregate
+1. Continue broadening the generated Go WAM builtin E2E as each remaining gap
+   is closed.
+2. Upgrade `member/2` to enumerate through builtin choice points so aggregate
    collection can observe all list members.
-4. Add `set` aggregate support if Go is expected to match the current Lua/Python
+3. Add `set` aggregate support if Go is expected to match the current Lua/Python
    aggregate parity surface.
 
 ## Verification Commands

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -12,14 +12,14 @@ current cross-target builtin/runtime baseline.
 | Direct fact dispatch | Foreign/native kernel registration and indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Partial |
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `count`, `sum`, `min`, `max` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Partial: no `set` aggregate result |
 | Structural builtins | `member/2`, `length/2`, `append/3` | `member/2`, `length/2`; Rust `append/3` is explicitly unimplemented | Partial: `member/2` is first-solution only |
-| Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1` | Includes `is_list/1` in the current baseline | Partial: no `is_list/1` |
-| Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `>=/2` | Includes `=</2` | Partial: `=</2` handler is misspelled as `=< /2` |
+| Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
+| Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2` | Includes `=</2` | Present for current baseline comparisons |
 | Unification builtin | `\=/2` | `=/2`, `\=/2` | Partial: no explicit `=/2` builtin handler |
 | Term inspection | Not present in `executeBuiltin/2` | `functor/3`, `arg/3` | Gap |
 | Univ | Not present in `executeBuiltin/2` | `=../2` compose/decompose | Gap |
 | Copying | Not present in `executeBuiltin/2` | `copy_term/2` with fresh variables and preserved sharing | Gap |
 | Control | `true/0`, `fail/0`, `!/0`, `\+/1`, `CutIte` | Same baseline, with broader isolated-goal NAF in Haskell/Python | Partial: `\+/1` only dispatches builtin-shaped goals |
-| IO | `write/1`, `nl/0` | `write/1`, `display/1`, `nl/0` | Partial: no `display/1` |
+| IO | `write/1`, `display/1`, `nl/0` | `write/1`, `display/1`, `nl/0` | Present |
 
 ## Immediate Findings
 
@@ -32,19 +32,17 @@ current cross-target builtin/runtime baseline.
 - `member/2` succeeds on the first unifiable element and does not push builtin
   choice points for later list members. This mirrors the Python gap that was
   recently closed.
-- The `=</2` comparison appears unreachable because the handler key is
-  `=< /2` with a space.
+- `=</2`, `is_list/1`, and `display/1` are now covered by the generated Go
+  WAM builtin E2E test.
 
 ## Recommended Follow-Up Order
 
 1. Add a focused generated-project E2E parity suite for Go WAM builtins, similar
    to the Python and Lua generated-project tests.
-2. Fix the narrow builtin dispatch typo for `=</2` and add `is_list/1` plus
-   `display/1`; these are small, low-risk surface parity patches.
-3. Add term builtin parity: `functor/3`, `arg/3`, `=../2`, and `copy_term/2`.
-4. Upgrade `member/2` to enumerate through builtin choice points so aggregate
+2. Add term builtin parity: `functor/3`, `arg/3`, `=../2`, and `copy_term/2`.
+3. Upgrade `member/2` to enumerate through builtin choice points so aggregate
    collection can observe all list members.
-5. Add `set` aggregate support if Go is expected to match the current Lua/Python
+4. Add `set` aggregate support if Go is expected to match the current Lua/Python
    aggregate parity surface.
 
 ## Verification Commands

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -367,10 +367,12 @@ is_builtin_goal(=\=).
 is_builtin_goal(true).
 is_builtin_goal(fail).
 is_builtin_goal(write).
+is_builtin_goal(display).
 is_builtin_goal(nl).
 is_builtin_goal(format).
 is_builtin_goal(member).
 is_builtin_goal(length).
+is_builtin_goal(is_list).
 is_builtin_goal(append).
 is_builtin_goal((\+)).
 
@@ -1252,8 +1254,10 @@ is_builtin_pred(arg, 3).     % term inspection: Nth argument access
 is_builtin_pred((=..), 2).   % term inspection: univ (decompose/compose)
 is_builtin_pred(copy_term, 2). % term inspection: fresh-variable copy
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
+is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).
 is_builtin_pred(=, 2).       % unification: bind / structurally unify two terms.
+is_builtin_pred(is_list, 1).
                              % Without this entry, X = Y in a body goal
                              % would compile to `execute =/2`, which looks
                              % up "=/2" as a user predicate, misses, and

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -814,6 +814,9 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 	if arity >= 3 { arg3 = vm.getReg(2) } // A3
 
 	switch op {
+	case "display/1":
+		fmt.Print(vm.deref(arg1).String())
+		return true
 	case "write/1":
 		fmt.Print(vm.deref(arg1).String())
 		return true
@@ -857,7 +860,7 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 		v1, ok1 := vm.evalArithmetic(arg1)
 		v2, ok2 := vm.evalArithmetic(arg2)
 		return ok1 && ok2 && v1 > v2
-	case "=< /2":
+	case "=</2":
 		v1, ok1 := vm.evalArithmetic(arg1)
 		v2, ok2 := vm.evalArithmetic(arg2)
 		return ok1 && ok2 && v1 <= v2
@@ -874,6 +877,7 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 	case "number/1": return isNumber(vm.deref(arg1))
 	case "compound/1": return isCompound(vm.deref(arg1))
 	case "atomic/1": return isAtomic(vm.deref(arg1))
+	case "is_list/1": return isList(vm.deref(arg1))
 
 	case "==/2": return valueEquals(vm.deref(arg1), vm.deref(arg2))
 	case "\\==/2": return !valueEquals(vm.deref(arg1), vm.deref(arg2))

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -707,6 +707,99 @@ func decompose(v Value) (string, []Value) {
 	return "", nil
 }
 
+func makeStructureValue(name string, args []Value) Value {
+	return &Structure{
+		Functor: fmt.Sprintf("%s/%d", name, len(args)),
+		Arity:   len(args),
+		Args:    append([]Value(nil), args...),
+	}
+}
+
+func (vm *WamState) termFunctorArity(v Value) (Value, int64, bool) {
+	v = vm.deref(v)
+	switch t := v.(type) {
+	case *Atom:
+		return t, 0, true
+	case *Integer:
+		return t, 0, true
+	case *Float:
+		return t, 0, true
+	case *Compound:
+		return internAtom(parseFunctorName(t.Functor)), int64(len(t.Args)), true
+	case *Structure:
+		return internAtom(parseFunctorName(t.Functor)), int64(t.Arity), true
+	case *List:
+		if isEmptyListValue(t) {
+			return emptyListAtom, 0, true
+		}
+		return internAtom("."), 2, true
+	default:
+		return nil, 0, false
+	}
+}
+
+func (vm *WamState) termToUnivList(v Value) (Value, bool) {
+	v = vm.deref(v)
+	switch t := v.(type) {
+	case *Atom, *Integer, *Float:
+		return &List{Elements: []Value{t}}, true
+	case *Compound:
+		items := make([]Value, 0, len(t.Args)+1)
+		items = append(items, internAtom(parseFunctorName(t.Functor)))
+		items = append(items, t.Args...)
+		return &List{Elements: items}, true
+	case *Structure:
+		items := make([]Value, 0, len(t.Args)+1)
+		items = append(items, internAtom(parseFunctorName(t.Functor)))
+		items = append(items, t.Args...)
+		return &List{Elements: items}, true
+	case *List:
+		if isEmptyListValue(t) {
+			return &List{Elements: []Value{emptyListAtom}}, true
+		}
+		head, tail, ok := vm.listHeadTail(t)
+		if !ok {
+			return nil, false
+		}
+		return &List{Elements: []Value{internAtom("."), head, tail}}, true
+	default:
+		return nil, false
+	}
+}
+
+func (vm *WamState) copyTermValue(v Value, seen map[int]*Unbound) Value {
+	v = vm.deref(v)
+	switch t := v.(type) {
+	case *Unbound:
+		if existing, ok := seen[t.Idx]; ok {
+			return existing
+		}
+		fresh := &Unbound{Name: fmt.Sprintf("_C%d", len(seen)), Idx: vm.allocVarId()}
+		seen[t.Idx] = fresh
+		return fresh
+	case *Compound:
+		args := make([]Value, len(t.Args))
+		for i, arg := range t.Args {
+			args[i] = vm.copyTermValue(arg, seen)
+		}
+		return &Compound{Functor: t.Functor, Args: args}
+	case *Structure:
+		args := make([]Value, len(t.Args))
+		for i, arg := range t.Args {
+			args[i] = vm.copyTermValue(arg, seen)
+		}
+		return &Structure{Functor: t.Functor, Arity: t.Arity, Args: args}
+	case *List:
+		items := make([]Value, len(t.Elements))
+		for i, item := range t.Elements {
+			items[i] = vm.copyTermValue(item, seen)
+		}
+		return &List{Elements: items}
+	default:
+		return t
+	}
+}
+
 func (vm *WamState) Deref(v Value) Value {
 	return vm.deref(v)
 }
@@ -965,6 +1058,92 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 		if !ok1 || !ok2 { return false }
 		combined := &List{Elements: append(append([]Value{}, l1...), l2...)}
 		return vm.Unify(arg3, combined)
+	case "functor/3":
+		t := vm.deref(arg1)
+		if isUnbound(t) {
+			name := vm.deref(arg2)
+			arityVal := vm.deref(arg3)
+			arityInt, ok := arityVal.(*Integer)
+			if !ok || arityInt.Val < 0 {
+				return false
+			}
+			if arityInt.Val == 0 {
+				return vm.Unify(arg1, name)
+			}
+			nameAtom, ok := name.(*Atom)
+			if !ok {
+				return false
+			}
+			args := make([]Value, int(arityInt.Val))
+			for i := range args {
+				args[i] = &Unbound{Name: fmt.Sprintf("_F%d", i), Idx: vm.allocVarId()}
+			}
+			return vm.Unify(arg1, makeStructureValue(nameAtom.Name, args))
+		}
+		name, arityOut, ok := vm.termFunctorArity(t)
+		if !ok {
+			return false
+		}
+		return vm.Unify(arg2, name) && vm.Unify(arg3, &Integer{Val: arityOut})
+	case "arg/3":
+		idxVal := vm.deref(arg1)
+		idx, ok := idxVal.(*Integer)
+		if !ok || idx.Val < 1 {
+			return false
+		}
+		term := vm.deref(arg2)
+		var selected Value
+		switch t := term.(type) {
+		case *Compound:
+			if int(idx.Val) > len(t.Args) {
+				return false
+			}
+			selected = t.Args[int(idx.Val)-1]
+		case *Structure:
+			if int(idx.Val) > len(t.Args) {
+				return false
+			}
+			selected = t.Args[int(idx.Val)-1]
+		case *List:
+			head, tail, ok := vm.listHeadTail(t)
+			if !ok {
+				return false
+			}
+			if idx.Val == 1 {
+				selected = head
+			} else if idx.Val == 2 {
+				selected = tail
+			} else {
+				return false
+			}
+		default:
+			return false
+		}
+		return vm.Unify(arg3, selected)
+	case "=../2":
+		t := vm.deref(arg1)
+		if isUnbound(t) {
+			items, ok := vm.listToSlice(arg2)
+			if !ok || len(items) == 0 {
+				return false
+			}
+			if len(items) == 1 {
+				return vm.Unify(arg1, items[0])
+			}
+			nameAtom, ok := vm.deref(items[0]).(*Atom)
+			if !ok {
+				return false
+			}
+			return vm.Unify(arg1, makeStructureValue(nameAtom.Name, items[1:]))
+		}
+		list, ok := vm.termToUnivList(t)
+		if !ok {
+			return false
+		}
+		return vm.Unify(arg2, list)
+	case "copy_term/2":
+		copy := vm.copyTermValue(arg1, make(map[int]*Unbound))
+		return vm.Unify(arg2, copy)
 	}
 	return false
 }

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -9,7 +9,17 @@ test(builtins_execution) :-
     get_time(T),
     format(atom(TmpDir), 'tmp_wam_builtins_~w', [T]),
     setup_call_cleanup(
-        assertz(user:test_builtins(X) :- (X is 1 + 2, X < 5, X =:= 3, atom(foo), \+ atom(5))),
+        assertz(user:test_builtins(X) :-
+            (   X is 1 + 2,
+                X < 5,
+                X =:= 3,
+                X =< 3,
+                is_list([a,b]),
+                display(ok),
+                nl,
+                atom(foo),
+                \+ atom(5)
+            )),
         run_builtins_test(TmpDir),
         ( retractall(user:test_builtins(_)),
           delete_directory_and_contents(TmpDir) )
@@ -25,6 +35,11 @@ run_builtins_test(TmpDir) :-
     directory_file_path(TmpDir, 'value.go', ValuePath),
     read_file_to_string(ValuePath, ValueCode, []),
     assertion(sub_string(ValueCode, _, _, _, "type Structure struct")),
+    directory_file_path(TmpDir, 'lib.go', LibPath),
+    read_file_to_string(LibPath, LibCode, []),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "=</2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "is_list/1"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "display/1"')),
 
     % Add a main.go to run the test in a separate cmd directory
     directory_file_path(TmpDir, 'cmd', CmdDir),
@@ -68,6 +83,7 @@ func main() {
         process_wait(Pid, Exit),
         format('Full output from Go: ~s~n', [FullOutput]),
         assertion(Exit == exit(0)),
+        assertion(sub_string(FullOutput, _, _, _, "ok")),
         assertion(sub_string(FullOutput, _, _, _, "SUCCESS: X=3"))
     ;   format("Go not found, skipping execution test.~n")
     ).

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -5,11 +5,14 @@
 
 :- begin_tests(go_wam_builtins).
 
+:- dynamic user:test_builtins/1.
+:- dynamic user:test_term_builtins/0.
+
 test(builtins_execution) :-
     get_time(T),
     format(atom(TmpDir), 'tmp_wam_builtins_~w', [T]),
     setup_call_cleanup(
-        assertz(user:test_builtins(X) :-
+        ( assertz(user:test_builtins(X) :-
             (   X is 1 + 2,
                 X < 5,
                 X =:= 3,
@@ -20,13 +23,31 @@ test(builtins_execution) :-
                 atom(foo),
                 \+ atom(5)
             )),
+          assertz(user:test_term_builtins :-
+            (   functor(f(a, 7), F, A),
+                F == f,
+                A =:= 2,
+                arg(2, f(a, 7), V),
+                V =:= 7,
+                f(a, 7) =.. L,
+                length(L, 3),
+                member(f, L),
+                member(a, L),
+                member(7, L),
+                copy_term(f(X, X), C),
+                arg(1, C, Y),
+                arg(2, C, Z),
+                Y == Z
+            ))
+        ),
         run_builtins_test(TmpDir),
         ( retractall(user:test_builtins(_)),
+          retractall(user:test_term_builtins),
           delete_directory_and_contents(TmpDir) )
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1],
+    Predicates = [test_builtins/1, test_term_builtins/0],
     Options = [module_name(builtin_test)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -40,6 +61,10 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "=</2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "is_list/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "display/1"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "functor/3"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "arg/3"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "=../2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "copy_term/2"')),
 
     % Add a main.go to run the test in a separate cmd directory
     directory_file_path(TmpDir, 'cmd', CmdDir),
@@ -66,6 +91,14 @@ func main() {
 	} else {
 		fmt.Println("FAILURE")
 	}
+
+	termVM := wam.NewWamState(wam.Test_term_builtinsCode, wam.Test_term_builtinsLabels)
+	termVM.PC = wam.Test_term_builtinsStartPC
+	if termVM.Run() {
+		fmt.Println("TERM_SUCCESS")
+	} else {
+		fmt.Println("TERM_FAILURE")
+	}
 }
 '),
 
@@ -84,7 +117,8 @@ func main() {
         format('Full output from Go: ~s~n', [FullOutput]),
         assertion(Exit == exit(0)),
         assertion(sub_string(FullOutput, _, _, _, "ok")),
-        assertion(sub_string(FullOutput, _, _, _, "SUCCESS: X=3"))
+        assertion(sub_string(FullOutput, _, _, _, "SUCCESS: X=3")),
+        assertion(sub_string(FullOutput, _, _, _, "TERM_SUCCESS"))
     ;   format("Go not found, skipping execution test.~n")
     ).
 


### PR DESCRIPTION
## Summary

- Fix Go WAM builtin dispatch for `=</2`.
- Add Go WAM runtime support for `is_list/1`, `display/1`, `functor/3`, `arg/3`, `=../2`, and `copy_term/2`.
- Add runtime helpers for term functor/arity extraction, univ conversion, structure construction, and sharing-preserving fresh `copy_term/2`.
- Extend the generated Go WAM builtin E2E test to compile and execute the new builtin coverage.
- Update the Go parity audit to mark the small builtin and term builtin parity slices complete.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_python_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_lua_generator.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`
