### PR TITLE
feat(wam-c): explain lowered filter rejections

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -1,17 +1,20 @@
 # WAM C Target - Status And Next Steps
 
-Status date: 2026-05-12
+Status date: 2026-05-14
 
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `5efae2f1` (`Merge pull request #2050 from s243a/feat/wam-c-lowered-helper-body-calls`)
+- `main` at `2ee720e8` (`Merge pull request #2052 from s243a/feat/wam-c-lowered-helper-filtered-facts`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
+- `python3 tests/test_benchmark_target_matrix.py`
+- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
+- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets c-wam-lowered-helper --repetitions 1 --baseline-target c-wam-lowered-helper-interpreted`
 - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
 
 Active branch:
 
-- `feat/wam-c-lowered-helper-filtered-facts`
+- `feat/wam-c-lowered-helper-filter-rejections`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -43,7 +46,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper planner metadata | Done | Explicit lowered/interpreted/rejected helper plans, detected-kernel exclusion, generated `lib.c` plan comments, and `report_lowered_helpers(true)` |
 | Lowered helper benchmark wiring | Done | `c-wam-lowered-helper` and `c-wam-lowered-helper-interpreted` matrix targets compare a tiny fact-helper benchmark |
 | Lowered helper body-call shape | Done | Deterministic alias-to-fact body calls lower through the existing foreign registry |
-| Lowered helper filtered-fact shape | In progress | Active branch lowers one constant-guarded fact projection shape and wires it into the tiny lowered-helper matrix |
+| Lowered helper filtered-fact shape | Done | Constant-guarded fact projections lower to native fact rows and the tiny lowered-helper matrix exercises the filtered helper in lowered mode |
+| Lowered helper filter rejection metadata | In progress | Active branch reports explicit planner reasons for unsupported filtered-helper bodies without adding new codegen paths |
 
 ## Current C Target Baseline
 
@@ -114,7 +118,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup and all-hop collection; add more kernel kinds only after runtime support exists. |
 | Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`; broaden as more native C kernels land. |
-| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, and active filtered-fact helper work. |
+| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, and active rejection metadata work. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
 | Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB `kernels_on`/`kernels_off`; next gap is larger artifact layouts. |
@@ -124,21 +128,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lowered-helper-filtered-facts`
-
-Goal: add one constrained guard/filter shape on top of lowered fact helpers.
-
-Scope:
-
-- Pick a simple deterministic guard shape with atom/integer equality.
-- Keep unsupported guard bodies rejected with explicit planner metadata.
-- Extend the tiny lowered-helper matrix only if the shape remains small and
-  stable.
-
-Status: active; constant-guarded fact projection lowers to native fact rows and
-the tiny lowered-helper matrix exercises the filtered helper in lowered mode.
-
-### 2. `feat/wam-c-lowered-helper-filter-rejections`
+### 1. `feat/wam-c-lowered-helper-filter-rejections`
 
 Goal: make unsupported lowered-helper guard/filter cases more explainable.
 
@@ -150,10 +140,26 @@ Scope:
   filtered-fact helpers.
 - Add focused planner tests rather than new runtime paths.
 
+Status: active; planner metadata now distinguishes non-constant filter
+arguments, unsupported comparison guards, and multi-goal bodies.
+
+### 2. `feat/wam-c-lowered-helper-filter-guard-comparisons`
+
+Goal: consider one positive comparison-filter lowering only after rejection
+metadata is stable.
+
+Scope:
+
+- Pick one deterministic comparison shape with a fact-only callee.
+- Keep the first implementation planner-only unless the codegen and runtime
+  behavior remain obvious.
+- Preserve the explicit rejection reasons added by the current branch.
+
 ## Suggested Immediate Next Step
 
-Continue validating `feat/wam-c-lowered-helper-filtered-facts`.
+Continue validating `feat/wam-c-lowered-helper-filter-rejections`.
 
-The active branch lowers one constant-guarded fact projection shape, for
-example `keep(X) :- fact(X, keep)`, into native fact rows. The tiny
-lowered-helper matrix now exercises the filtered helper in its lowered target.
+The active branch keeps code generation unchanged and improves planner
+diagnostics for unsupported filtered-helper bodies. The next useful checks are
+the WAM-C target suite, the effective-distance benchmark suite, and `git diff
+--check`.

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -189,6 +189,17 @@ plan_wam_c_lowered_helper_disabled(PredIndicator, Plan) :-
     format(atom(Key), '~w/~w', [Pred, Arity]),
     Plan = wam_c_lowered_helper_plan(Key, PredIndicator, interpreted, lowering_disabled).
 
+lowered_fact_helper_rejection_reason(PredIndicator, Reason) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
+    functor(Head, Pred, Arity),
+    findall(Args-Body,
+            (   user:clause(Head, Body),
+                Head =.. [_|Args]
+            ),
+            [HeadArgs-Body0]),
+    Body0 \== true,
+    lowered_filter_rejection_reason(HeadArgs, Body0, Reason),
+    !.
 lowered_fact_helper_rejection_reason(PredIndicator, non_fact_clause) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
     functor(Head, Pred, Arity),
@@ -201,6 +212,42 @@ lowered_fact_helper_rejection_reason(PredIndicator, unsupported_fact_arguments) 
     user:clause(Head, true),
     !.
 lowered_fact_helper_rejection_reason(_, no_clauses).
+
+lowered_filter_rejection_reason(_HeadArgs, Body0, multi_goal_body) :-
+    strip_module_qualification(Body0, Body),
+    Body = (_, _),
+    !.
+lowered_filter_rejection_reason(_HeadArgs, Body0, unsupported_comparison_guard) :-
+    strip_module_qualification(Body0, Body),
+    Body =.. [Pred|Args],
+    length(Args, Arity),
+    wam_c_lowered_comparison_guard(Pred/Arity),
+    !.
+lowered_filter_rejection_reason(HeadArgs, Body0, non_constant_filter_argument) :-
+    strip_module_qualification(Body0, Body),
+    Body =.. [_CalleePred|CalleeArgs],
+    member(Arg, CalleeArgs),
+    \+ lowered_filter_arg_supported(Arg, HeadArgs),
+    !.
+lowered_filter_rejection_reason(HeadArgs, Body0, unsupported_filter_callee) :-
+    strip_module_qualification(Body0, Body),
+    Body =.. [CalleePred|CalleeArgs],
+    length(CalleeArgs, CalleeArity),
+    maplist(lowered_filter_arg_supported_(HeadArgs), CalleeArgs),
+    CalleeIndicator = user:CalleePred/CalleeArity,
+    \+ lowered_fact_helper_rows(CalleeIndicator, _Rows),
+    !.
+
+wam_c_lowered_comparison_guard((=)/2).
+wam_c_lowered_comparison_guard((==)/2).
+wam_c_lowered_comparison_guard((\==)/2).
+wam_c_lowered_comparison_guard((>)/2).
+wam_c_lowered_comparison_guard((<)/2).
+wam_c_lowered_comparison_guard((>=)/2).
+wam_c_lowered_comparison_guard((=<)/2).
+wam_c_lowered_comparison_guard((=:=)/2).
+wam_c_lowered_comparison_guard((=\=)/2).
+wam_c_lowered_comparison_guard(is/2).
 
 compile_lowered_helpers_for_project(Plans, LoweredKeys, Code, SetupCode) :-
     findall(Key-CodePart-SetupLine,
@@ -254,6 +301,11 @@ wam_c_lowered_plan_reason_label(filtered_fact(_CalleeKey, _Rows), filtered_fact)
 wam_c_lowered_plan_reason_label(Reason, Reason).
 
 lowered_fact_helper_rows(PredIndicator, Rows) :-
+    catch(lowered_fact_helper_rows_(PredIndicator, Rows),
+          error(permission_error(access, private_procedure, _), _),
+          fail).
+
+lowered_fact_helper_rows_(PredIndicator, Rows) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
     functor(Head, Pred, Arity),
     findall(Args,
@@ -327,8 +379,10 @@ lowered_filtered_fact_helper(PredIndicator, CalleeKey, Rows) :-
     Clauses = [HeadArgs-Body0],
     Body0 \== true,
     strip_module_qualification(Body0, Body),
+    Body \= (_, _),
     Body =.. [CalleePred|CalleeArgs],
     length(CalleeArgs, CalleeArity),
+    \+ wam_c_lowered_comparison_guard(CalleePred/CalleeArity),
     (Pred/Arity) \== (CalleePred/CalleeArity),
     maplist(var, HeadArgs),
     callee_args_supported_for_filter(CalleeArgs, HeadArgs),
@@ -352,12 +406,18 @@ strip_module_qualification(Body, Body).
 
 callee_args_supported_for_filter([], _).
 callee_args_supported_for_filter([Arg|Rest], HeadArgs) :-
+    lowered_filter_arg_supported(Arg, HeadArgs),
+    callee_args_supported_for_filter(Rest, HeadArgs).
+
+lowered_filter_arg_supported(Arg, HeadArgs) :-
+    lowered_filter_arg_supported_(HeadArgs, Arg).
+
+lowered_filter_arg_supported_(HeadArgs, Arg) :-
     (   member(HeadArg, HeadArgs),
         Arg == HeadArg
     ->  true
     ;   wam_c_lowered_constant(Arg)
-    ),
-    callee_args_supported_for_filter(Rest, HeadArgs).
+    ).
 
 callee_row_matches_filter(CalleeArgs, HeadArgs, CalleeRow) :-
     same_length(CalleeArgs, CalleeRow),

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -341,7 +341,7 @@ test_lowered_helper_planner_metadata :-
                                     ['category_ancestor/4'],
                                     Plans),
         member(wam_c_lowered_helper_plan('wam_c_plan_fact/2', _, lowered, fact_only([[a,b]])), Plans),
-        member(wam_c_lowered_helper_plan('wam_c_plan_rule/1', _, rejected, non_fact_clause), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_plan_rule/1', _, rejected, non_constant_filter_argument), Plans),
         member(wam_c_lowered_helper_plan('category_ancestor/4', _, interpreted, detected_kernel), Plans)
     ->  pass(Test)
     ;   fail_test(Test, 'planner did not classify lowered/rejected/interpreted predicates')
@@ -364,7 +364,7 @@ test_lowered_helper_plan_generation :-
         read_file_to_string(LibPath, LibS, []),
         sub_string(LibS, _, _, _, '// WAM-C lowered helper plan'),
         sub_string(LibS, _, _, _, '// - lowered wam_c_plan_emit_fact/2: fact_only'),
-        sub_string(LibS, _, _, _, '// - rejected wam_c_plan_emit_rule/1: non_fact_clause'),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_plan_emit_rule/1: non_constant_filter_argument'),
         sub_string(LibS, _, _, _, 'INSTR_CALL_FOREIGN'),
         sub_string(LibS, _, _, _, 'setup_wam_c_plan_emit_rule_1')
     ->  pass(Test)
@@ -435,6 +435,55 @@ test_lowered_filtered_fact_helper_generation :-
     ),
     retractall(user:wam_c_filter_fact(_, _)),
     retractall(user:wam_c_filter_keep(_)).
+
+test_lowered_filter_rejection_metadata :-
+    Test = 'WAM-C: lowered helper planner explains unsupported filter shapes',
+    assertz(user:wam_c_filter_reject_fact(a, 1, keep)),
+    assertz(user:wam_c_filter_reject_fact(b, 2, drop)),
+    assertz((user:wam_c_filter_reject_non_constant(X) :-
+                 user:wam_c_filter_reject_fact(X, _IgnoredN, keep))),
+    assertz((user:wam_c_filter_reject_comparison(X) :- X > 1)),
+    assertz((user:wam_c_filter_reject_builtin(X) :- atom(X))),
+    assertz((user:wam_c_filter_reject_multi_goal(X) :-
+                 user:wam_c_filter_reject_fact(X, _N, keep),
+                 X = a)),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(ProjectDir), '/tmp/unifyweaver_wam_c_lowered_filter_reject_project_~w', [Stamp]),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    (   plan_wam_c_lowered_helpers([user:wam_c_filter_reject_fact/3,
+                                     user:wam_c_filter_reject_non_constant/1,
+                                     user:wam_c_filter_reject_comparison/1,
+                                     user:wam_c_filter_reject_builtin/1,
+                                     user:wam_c_filter_reject_multi_goal/1],
+                                    [lowered_helpers(true)],
+                                    [],
+                                    Plans),
+        member(wam_c_lowered_helper_plan('wam_c_filter_reject_fact/3', _, lowered, fact_only([[a,1,keep],[b,2,drop]])), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_filter_reject_non_constant/1', _, rejected, non_constant_filter_argument), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_filter_reject_comparison/1', _, rejected, unsupported_comparison_guard), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_filter_reject_builtin/1', _, rejected, unsupported_filter_callee), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_filter_reject_multi_goal/1', _, rejected, multi_goal_body), Plans),
+        write_wam_c_project([user:wam_c_filter_reject_fact/3,
+                             user:wam_c_filter_reject_non_constant/1,
+                             user:wam_c_filter_reject_comparison/1,
+                             user:wam_c_filter_reject_builtin/1,
+                             user:wam_c_filter_reject_multi_goal/1],
+                            [lowered_helpers(true)],
+                            ProjectDir),
+        read_file_to_string(LibPath, LibS, []),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_filter_reject_non_constant/1: non_constant_filter_argument'),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_filter_reject_comparison/1: unsupported_comparison_guard'),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_filter_reject_builtin/1: unsupported_filter_callee'),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_filter_reject_multi_goal/1: multi_goal_body')
+    ->  pass(Test)
+    ;   fail_test(Test, 'planner did not report explicit filter rejection reasons')
+    ),
+    retractall(user:wam_c_filter_reject_fact(_, _, _)),
+    retractall(user:wam_c_filter_reject_non_constant(_)),
+    retractall(user:wam_c_filter_reject_comparison(_)),
+    retractall(user:wam_c_filter_reject_builtin(_)),
+    retractall(user:wam_c_filter_reject_multi_goal(_)).
 
 test_unsupported_instruction_fails_loudly :-
     Test = 'WAM-C: unsupported instructions fail loudly',
@@ -2283,6 +2332,7 @@ run_tests_once :-
     test_lowered_helper_plan_generation,
     test_lowered_body_call_helper_generation,
     test_lowered_filtered_fact_helper_generation,
+    test_lowered_filter_rejection_metadata,
     test_unsupported_instruction_fails_loudly,
     test_no_zero_instruction_fallback,
     test_list_target_pc_emission,


### PR DESCRIPTION
## Summary

This PR improves WAM-C lowered-helper planner diagnostics for unsupported filtered-helper shapes. It keeps code generation unchanged for supported fact-only, body-call, and filtered-fact helpers, but replaces generic rule rejection with explicit metadata for unsupported filter bodies.

## What Changed

- Adds explicit planner rejection reasons for:
  - `non_constant_filter_argument`
  - `unsupported_comparison_guard`
  - `multi_goal_body`
  - `unsupported_filter_callee`
- Prevents unsupported built-in or comparison callees from leaking `clause/2` permission errors during fact-row probing.
- Adds focused planner tests that assert the new rejection reasons in both in-memory plans and generated `lib.c` plan comments.
- Refreshes `WAM_C_TARGET_NEXT_STEPS.md` to mark filtered-fact helpers done and make rejection diagnostics the active branch.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
- `git diff --check`

## Follow-Up

Next recommended branch: `feat/wam-c-lowered-helper-filter-guard-comparisons`.
