### PR TITLE
feat(wam-c): Lower WAM-C comparison-filter helpers

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,7 +5,7 @@ Status date: 2026-05-14
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `2ee720e8` (`Merge pull request #2052 from s243a/feat/wam-c-lowered-helper-filtered-facts`)
+- `main` at `d4a8939d` (`Merge pull request #2056 from s243a/feat/wam-c-lowered-helper-filter-rejections`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
@@ -14,7 +14,7 @@ Base verified locally:
 
 Active branch:
 
-- `feat/wam-c-lowered-helper-filter-rejections`
+- `feat/wam-c-lowered-helper-filter-guard-comparisons`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -47,7 +47,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper benchmark wiring | Done | `c-wam-lowered-helper` and `c-wam-lowered-helper-interpreted` matrix targets compare a tiny fact-helper benchmark |
 | Lowered helper body-call shape | Done | Deterministic alias-to-fact body calls lower through the existing foreign registry |
 | Lowered helper filtered-fact shape | Done | Constant-guarded fact projections lower to native fact rows and the tiny lowered-helper matrix exercises the filtered helper in lowered mode |
-| Lowered helper filter rejection metadata | In progress | Active branch reports explicit planner reasons for unsupported filtered-helper bodies without adding new codegen paths |
+| Lowered helper filter rejection metadata | Done | Planner reports explicit rejection reasons for non-constant filter arguments, unsupported comparison guards, multi-goal bodies, and unsupported filter callees |
+| Lowered helper comparison-filter shape | In progress | Active branch lowers a fact-only callee plus one integer comparison guard into native fact rows |
 
 ## Current C Target Baseline
 
@@ -118,7 +119,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup and all-hop collection; add more kernel kinds only after runtime support exists. |
 | Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`; broaden as more native C kernels land. |
-| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, and active rejection metadata work. |
+| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, rejection metadata, and active comparison-filter helper work. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
 | Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB `kernels_on`/`kernels_off`; next gap is larger artifact layouts. |
@@ -128,22 +129,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lowered-helper-filter-rejections`
-
-Goal: make unsupported lowered-helper guard/filter cases more explainable.
-
-Scope:
-
-- Add explicit planner rejection reasons for non-constant guards, unsupported
-  comparison predicates, and multi-goal bodies.
-- Keep code generation unchanged for supported fact-only, body-call, and
-  filtered-fact helpers.
-- Add focused planner tests rather than new runtime paths.
-
-Status: active; planner metadata now distinguishes non-constant filter
-arguments, unsupported comparison guards, and multi-goal bodies.
-
-### 2. `feat/wam-c-lowered-helper-filter-guard-comparisons`
+### 1. `feat/wam-c-lowered-helper-filter-guard-comparisons`
 
 Goal: consider one positive comparison-filter lowering only after rejection
 metadata is stable.
@@ -155,11 +141,27 @@ Scope:
   behavior remain obvious.
 - Preserve the explicit rejection reasons added by the current branch.
 
+Status: active; a fact-only callee plus one integer comparison guard now lowers
+to projected native fact rows and the tiny lowered-helper matrix exercises the
+shape in lowered mode.
+
+### 2. `feat/wam-c-lowered-helper-comparison-filter-rejections`
+
+Goal: make the remaining comparison-filter boundaries explicit.
+
+Scope:
+
+- Add focused rejection metadata for unsupported comparison-filter shapes such
+  as unbound guard variables, unsupported arithmetic expressions, and
+  non-integer ordering comparisons.
+- Keep the supported comparison-filter lowering unchanged.
+- Prefer planner tests and generated plan comments over new runtime paths.
+
 ## Suggested Immediate Next Step
 
-Continue validating `feat/wam-c-lowered-helper-filter-rejections`.
+Continue validating `feat/wam-c-lowered-helper-filter-guard-comparisons`.
 
-The active branch keeps code generation unchanged and improves planner
-diagnostics for unsupported filtered-helper bodies. The next useful checks are
-the WAM-C target suite, the effective-distance benchmark suite, and `git diff
---check`.
+The active branch lowers one comparison-filter shape, for example
+`small(X) :- fact(X, N), N =< 2`, into native fact rows. The tiny
+lowered-helper matrix now exercises this comparison-filter helper in its
+lowered target.

--- a/examples/benchmark/generate_wam_c_lowered_helper_benchmark.pl
+++ b/examples/benchmark/generate_wam_c_lowered_helper_benchmark.pl
@@ -68,15 +68,17 @@ mode_options(interpreted, [report_lowered_helpers(true)]).
 mode_predicates(lowered, [user:wam_c_bench_pair/2,
                           user:wam_c_bench_pair_alias/2,
                           user:wam_c_bench_pair_tag/3,
-                          user:wam_c_bench_pair_keep/2]).
+                          user:wam_c_bench_pair_keep/2,
+                          user:wam_c_bench_pair_score/3,
+                          user:wam_c_bench_pair_small/2]).
 mode_predicates(interpreted, [user:wam_c_bench_pair/2]).
 
-mode_query_predicate(lowered, 'wam_c_bench_pair_keep/2').
+mode_query_predicate(lowered, 'wam_c_bench_pair_small/2').
 mode_query_predicate(interpreted, 'wam_c_bench_pair/2').
 
 mode_alias_setup(lowered,
-                 'void setup_wam_c_bench_pair_alias_2(WamState* state);\nvoid setup_wam_c_bench_pair_tag_3(WamState* state);\nvoid setup_wam_c_bench_pair_keep_2(WamState* state);\n',
-                 '    setup_wam_c_bench_pair_alias_2(&state);\n    setup_wam_c_bench_pair_tag_3(&state);\n    setup_wam_c_bench_pair_keep_2(&state);\n').
+                 'void setup_wam_c_bench_pair_alias_2(WamState* state);\nvoid setup_wam_c_bench_pair_tag_3(WamState* state);\nvoid setup_wam_c_bench_pair_keep_2(WamState* state);\nvoid setup_wam_c_bench_pair_score_3(WamState* state);\nvoid setup_wam_c_bench_pair_small_2(WamState* state);\n',
+                 '    setup_wam_c_bench_pair_alias_2(&state);\n    setup_wam_c_bench_pair_tag_3(&state);\n    setup_wam_c_bench_pair_keep_2(&state);\n    setup_wam_c_bench_pair_score_3(&state);\n    setup_wam_c_bench_pair_small_2(&state);\n').
 mode_alias_setup(interpreted, '', '').
 
 setup_benchmark_facts :-
@@ -87,14 +89,22 @@ setup_benchmark_facts :-
     assertz(user:wam_c_bench_pair_tag(a, b, keep)),
     assertz(user:wam_c_bench_pair_tag(a, c, keep)),
     assertz(user:wam_c_bench_pair_tag(b, d, keep)),
+    assertz(user:wam_c_bench_pair_score(a, b, 1)),
+    assertz(user:wam_c_bench_pair_score(a, c, 2)),
+    assertz(user:wam_c_bench_pair_score(b, d, 3)),
     assertz(user:((wam_c_bench_pair_alias(X, Y) :- wam_c_bench_pair(X, Y)))),
-    assertz(user:((wam_c_bench_pair_keep(X, Y) :- wam_c_bench_pair_tag(X, Y, keep)))).
+    assertz(user:((wam_c_bench_pair_keep(X, Y) :- wam_c_bench_pair_tag(X, Y, keep)))),
+    assertz(user:((wam_c_bench_pair_small(X, Y) :-
+        wam_c_bench_pair_score(X, Y, Score),
+        Score =< 3))).
 
 cleanup_benchmark_facts :-
     retractall(user:wam_c_bench_pair(_, _)),
     retractall(user:wam_c_bench_pair_alias(_, _)),
     retractall(user:wam_c_bench_pair_tag(_, _, _)),
-    retractall(user:wam_c_bench_pair_keep(_, _)).
+    retractall(user:wam_c_bench_pair_keep(_, _)),
+    retractall(user:wam_c_bench_pair_score(_, _, _)),
+    retractall(user:wam_c_bench_pair_small(_, _)).
 
 lowered_helper_benchmark_main(QueryPred, AliasDecl, AliasSetup, Code) :-
     format(atom(Code),

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -178,6 +178,8 @@ plan_wam_c_lowered_helper(DetectedKeys, PredIndicator, Plan) :-
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, fact_only(Rows))
     ;   lowered_body_call_helper(PredIndicator, CalleeKey, CalleeArity)
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, body_call(CalleeKey, CalleeArity))
+    ;   lowered_comparison_filtered_fact_helper(PredIndicator, CalleeKey, Rows)
+    ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, comparison_filtered_fact(CalleeKey, Rows))
     ;   lowered_filtered_fact_helper(PredIndicator, CalleeKey, Rows)
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, filtered_fact(CalleeKey, Rows))
     ;   lowered_fact_helper_rejection_reason(PredIndicator, Reason),
@@ -255,7 +257,9 @@ compile_lowered_helpers_for_project(Plans, LoweredKeys, Code, SetupCode) :-
                 lowered_fact_helper_for_predicate(PredIndicator, Rows, Key, CodePart, SetupLine)
             ;   member(wam_c_lowered_helper_plan(Key, PredIndicator, lowered, body_call(CalleeKey, CalleeArity)), Plans),
                 lowered_body_call_helper_for_predicate(PredIndicator, CalleeKey, CalleeArity, Key, CodePart, SetupLine)
-            ;   member(wam_c_lowered_helper_plan(Key, PredIndicator, lowered, filtered_fact(_CalleeKey, Rows)), Plans),
+            ;   member(wam_c_lowered_helper_plan(Key, PredIndicator, lowered, filtered_fact(_FilteredCalleeKey, Rows)), Plans),
+                lowered_fact_helper_for_predicate(PredIndicator, Rows, Key, CodePart, SetupLine)
+            ;   member(wam_c_lowered_helper_plan(Key, PredIndicator, lowered, comparison_filtered_fact(_ComparisonCalleeKey, Rows)), Plans),
                 lowered_fact_helper_for_predicate(PredIndicator, Rows, Key, CodePart, SetupLine)
             ),
             Entries),
@@ -298,6 +302,7 @@ wam_c_lowered_helper_plan_by_action(Plans, Action, Key, ReasonLabel) :-
 wam_c_lowered_plan_reason_label(fact_only(_Rows), fact_only) :- !.
 wam_c_lowered_plan_reason_label(body_call(_CalleeKey, _CalleeArity), body_call) :- !.
 wam_c_lowered_plan_reason_label(filtered_fact(_CalleeKey, _Rows), filtered_fact) :- !.
+wam_c_lowered_plan_reason_label(comparison_filtered_fact(_CalleeKey, _Rows), comparison_filtered_fact) :- !.
 wam_c_lowered_plan_reason_label(Reason, Reason).
 
 lowered_fact_helper_rows(PredIndicator, Rows) :-
@@ -397,6 +402,100 @@ lowered_filtered_fact_helper(PredIndicator, CalleeKey, Rows) :-
     sort(ProjectedRows0, Rows),
     Rows \= [],
     format(atom(CalleeKey), '~w/~w', [CalleePred, CalleeArity]).
+
+lowered_comparison_filtered_fact_helper(PredIndicator, CalleeKey, Rows) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
+    functor(Head, Pred, Arity),
+    findall(HeadArgs-Body,
+            (   user:clause(Head, Body),
+                Head =.. [_|HeadArgs]
+            ),
+            Clauses),
+    Clauses = [HeadArgs-Body0],
+    Body0 \== true,
+    strip_module_qualification(Body0, Body),
+    Body = (Call0, Guard0),
+    strip_module_qualification(Call0, Call),
+    strip_module_qualification(Guard0, Guard),
+    lowered_fact_call_for_filter(Pred/Arity, HeadArgs, Call, CalleeKey, CalleeArgs, CalleeRows),
+    Guard =.. [GuardPred, Left, Right],
+    wam_c_lowered_comparison_guard(GuardPred/2),
+    comparison_arg_supported(Left, CalleeArgs),
+    comparison_arg_supported(Right, CalleeArgs),
+    include(callee_row_matches_comparison_filter(CalleeArgs, GuardPred, Left, Right), CalleeRows, MatchingRows),
+    findall(Projected,
+            (   member(CalleeRow, MatchingRows),
+                project_callee_row_to_head(HeadArgs, CalleeArgs, CalleeRow, Projected)
+            ),
+            ProjectedRows0),
+    sort(ProjectedRows0, Rows),
+    Rows \= [].
+
+lowered_fact_call_for_filter(CurrentPred/CurrentArity, HeadArgs, Call, CalleeKey, CalleeArgs, CalleeRows) :-
+    Call =.. [CalleePred|CalleeArgs],
+    length(CalleeArgs, CalleeArity),
+    \+ wam_c_lowered_comparison_guard(CalleePred/CalleeArity),
+    (CurrentPred/CurrentArity) \== (CalleePred/CalleeArity),
+    maplist(var, HeadArgs),
+    maplist(callee_filter_arg_supported, CalleeArgs),
+    CalleeIndicator = user:CalleePred/CalleeArity,
+    lowered_fact_helper_rows(CalleeIndicator, CalleeRows),
+    format(atom(CalleeKey), '~w/~w', [CalleePred, CalleeArity]).
+
+callee_filter_arg_supported(Arg) :-
+    var(Arg),
+    !.
+callee_filter_arg_supported(Arg) :-
+    wam_c_lowered_constant(Arg).
+
+comparison_arg_supported(Arg, _CalleeArgs) :-
+    wam_c_lowered_constant(Arg),
+    !.
+comparison_arg_supported(Arg, CalleeArgs) :-
+    member(CalleeArg, CalleeArgs),
+    Arg == CalleeArg.
+
+callee_row_matches_comparison_filter(CalleeArgs, GuardPred, Left, Right, CalleeRow) :-
+    callee_row_matches_arg_constraints(CalleeArgs, CalleeRow),
+    comparison_arg_value(Left, CalleeArgs, CalleeRow, LeftValue),
+    comparison_arg_value(Right, CalleeArgs, CalleeRow, RightValue),
+    wam_c_eval_lowered_comparison_guard(GuardPred, LeftValue, RightValue).
+
+callee_row_matches_arg_constraints(CalleeArgs, CalleeRow) :-
+    same_length(CalleeArgs, CalleeRow),
+    \+ ( nth0(I, CalleeArgs, Arg),
+         nth0(I, CalleeRow, Value),
+         wam_c_lowered_constant(Arg),
+         Arg \== Value
+       ),
+    \+ ( nth0(I, CalleeArgs, Arg),
+         var(Arg),
+         nth0(J, CalleeArgs, OtherArg),
+         J > I,
+         Arg == OtherArg,
+         nth0(I, CalleeRow, Value),
+         nth0(J, CalleeRow, OtherValue),
+         Value \== OtherValue
+       ).
+
+comparison_arg_value(Arg, _CalleeArgs, _CalleeRow, Arg) :-
+    wam_c_lowered_constant(Arg),
+    !.
+comparison_arg_value(Arg, CalleeArgs, CalleeRow, Value) :-
+    nth0(Index, CalleeArgs, CalleeArg),
+    Arg == CalleeArg,
+    !,
+    nth0(Index, CalleeRow, Value).
+
+wam_c_eval_lowered_comparison_guard((=), Left, Right) :- Left == Right.
+wam_c_eval_lowered_comparison_guard((==), Left, Right) :- Left == Right.
+wam_c_eval_lowered_comparison_guard((\==), Left, Right) :- Left \== Right.
+wam_c_eval_lowered_comparison_guard((>), Left, Right) :- integer(Left), integer(Right), Left > Right.
+wam_c_eval_lowered_comparison_guard((<), Left, Right) :- integer(Left), integer(Right), Left < Right.
+wam_c_eval_lowered_comparison_guard((>=), Left, Right) :- integer(Left), integer(Right), Left >= Right.
+wam_c_eval_lowered_comparison_guard((=<), Left, Right) :- integer(Left), integer(Right), Left =< Right.
+wam_c_eval_lowered_comparison_guard((=:=), Left, Right) :- integer(Left), integer(Right), Left =:= Right.
+wam_c_eval_lowered_comparison_guard((=\=), Left, Right) :- integer(Left), integer(Right), Left =\= Right.
 
 strip_module_qualification(Module:Body, Stripped) :-
     atom(Module),

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -436,6 +436,41 @@ test_lowered_filtered_fact_helper_generation :-
     retractall(user:wam_c_filter_fact(_, _)),
     retractall(user:wam_c_filter_keep(_)).
 
+test_lowered_comparison_filter_helper_generation :-
+    Test = 'WAM-C: comparison-guarded fact predicates can lower to native helper',
+    assertz(user:wam_c_filter_score(a, 1)),
+    assertz(user:wam_c_filter_score(b, 2)),
+    assertz(user:wam_c_filter_score(c, 3)),
+    assertz((user:wam_c_filter_small(X) :-
+                 user:wam_c_filter_score(X, N),
+                 N =< 2)),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(ProjectDir), '/tmp/unifyweaver_wam_c_lowered_comparison_filter_project_~w', [Stamp]),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    (   plan_wam_c_lowered_helpers([user:wam_c_filter_score/2,
+                                     user:wam_c_filter_small/1],
+                                    [lowered_helpers(true)],
+                                    [],
+                                    Plans),
+        member(wam_c_lowered_helper_plan('wam_c_filter_score/2', _, lowered, fact_only([[a,1],[b,2],[c,3]])), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_filter_small/1', _, lowered, comparison_filtered_fact('wam_c_filter_score/2', [[a],[b]])), Plans),
+        write_wam_c_project([user:wam_c_filter_score/2,
+                             user:wam_c_filter_small/1],
+                            [lowered_helpers(true)],
+                            ProjectDir),
+        read_file_to_string(LibPath, LibS, []),
+        sub_string(LibS, _, _, _, '// - lowered wam_c_filter_small/1: comparison_filtered_fact'),
+        sub_string(LibS, _, _, _, 'static bool wam_c_lowered_wam_c_filter_small_1'),
+        sub_string(LibS, _, _, _, 'val_atom("a")'),
+        sub_string(LibS, _, _, _, 'val_atom("b")'),
+        sub_string(LibS, _, _, _, '.pred = "wam_c_filter_small/1"')
+    ->  pass(Test)
+    ;   fail_test(Test, 'lowered comparison-filter helper was not emitted')
+    ),
+    retractall(user:wam_c_filter_score(_, _)),
+    retractall(user:wam_c_filter_small(_)).
+
 test_lowered_filter_rejection_metadata :-
     Test = 'WAM-C: lowered helper planner explains unsupported filter shapes',
     assertz(user:wam_c_filter_reject_fact(a, 1, keep)),
@@ -446,7 +481,8 @@ test_lowered_filter_rejection_metadata :-
     assertz((user:wam_c_filter_reject_builtin(X) :- atom(X))),
     assertz((user:wam_c_filter_reject_multi_goal(X) :-
                  user:wam_c_filter_reject_fact(X, _N, keep),
-                 X = a)),
+                 X = a,
+                 atom(X))),
     get_time(Now),
     Stamp is round(Now * 1000000),
     format(atom(ProjectDir), '/tmp/unifyweaver_wam_c_lowered_filter_reject_project_~w', [Stamp]),
@@ -705,6 +741,16 @@ test_lowered_filtered_fact_helper_executable_smoke :-
     ->  (   run_lowered_filtered_fact_helper_executable_smoke
         ->  pass(Test)
         ;   fail_test(Test, 'lowered filtered fact helper executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
+test_lowered_comparison_filter_helper_executable_smoke :-
+    Test = 'WAM-C: lowered comparison-filter helper executable smoke',
+    (   gcc_available
+    ->  (   run_lowered_comparison_filter_helper_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'lowered comparison-filter helper executable failed')
         )
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
@@ -1165,6 +1211,35 @@ run_lowered_filtered_fact_helper_executable_smoke :-
         retractall(user:wam_c_filter_keep(_))
     ;   retractall(user:wam_c_filter_fact(_, _)),
         retractall(user:wam_c_filter_keep(_)),
+        fail
+    ).
+
+run_lowered_comparison_filter_helper_executable_smoke :-
+    assertz(user:wam_c_filter_score(a, 1)),
+    assertz(user:wam_c_filter_score(b, 2)),
+    assertz(user:wam_c_filter_score(c, 3)),
+    assertz((user:wam_c_filter_small(X) :-
+                 user:wam_c_filter_score(X, N),
+                 N =< 2)),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(ProjectDir), '/tmp/unifyweaver_wam_c_lowered_comparison_filter_smoke_~w', [Stamp]),
+    directory_file_path(ProjectDir, 'wam_runtime.c', RuntimePath),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    directory_file_path(ProjectDir, 'main.c', MainPath),
+    directory_file_path(ProjectDir, 'wam_c_lowered_comparison_filter_smoke', ExePath),
+    (   write_wam_c_project([user:wam_c_filter_score/2,
+                             user:wam_c_filter_small/1],
+                            [lowered_helpers(true)],
+                            ProjectDir),
+        wam_c_lowered_comparison_filter_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, LibPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  retractall(user:wam_c_filter_score(_, _)),
+        retractall(user:wam_c_filter_small(_))
+    ;   retractall(user:wam_c_filter_score(_, _)),
+        retractall(user:wam_c_filter_small(_)),
         fail
     ).
 
@@ -1996,6 +2071,47 @@ int main(void) {
 }
 ').
 
+wam_c_lowered_comparison_filter_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_filter_score_2(WamState* state);
+void setup_wam_c_filter_small_1(WamState* state);
+void setup_lowered_wam_c_helpers(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_filter_score_2(&state);
+    setup_wam_c_filter_small_1(&state);
+    setup_lowered_wam_c_helpers(&state);
+
+    WamValue ok_args[1] = { val_unbound("Out") };
+    int ok_rc = wam_run_predicate(&state, "wam_c_filter_small/1", ok_args, 1);
+    if (ok_rc != 0 || state.P != WAM_HALT ||
+        state.A[0].tag != VAL_ATOM || strcmp(state.A[0].data.atom, "a") != 0) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue ground_args[1] = { val_atom("b") };
+    int ground_rc = wam_run_predicate(&state, "wam_c_filter_small/1", ground_args, 1);
+    if (ground_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue fail_args[1] = { val_atom("c") };
+    int fail_rc = wam_run_predicate(&state, "wam_c_filter_small/1", fail_args, 1);
+    if (fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_real_builtin_smoke_main(
 '#include "wam_runtime.h"
 
@@ -2332,6 +2448,7 @@ run_tests_once :-
     test_lowered_helper_plan_generation,
     test_lowered_body_call_helper_generation,
     test_lowered_filtered_fact_helper_generation,
+    test_lowered_comparison_filter_helper_generation,
     test_lowered_filter_rejection_metadata,
     test_unsupported_instruction_fails_loudly,
     test_no_zero_instruction_fallback,
@@ -2354,6 +2471,7 @@ run_tests_once :-
     test_lowered_fact_helper_executable_smoke,
     test_lowered_body_call_helper_executable_smoke,
     test_lowered_filtered_fact_helper_executable_smoke,
+    test_lowered_comparison_filter_helper_executable_smoke,
     test_asan_memory_lifecycle_executable_smoke,
     format('~n=== WAM-C Target Tests Complete ===~n'),
     (   test_failed -> halt(1) ; true ).


### PR DESCRIPTION
## Summary

This PR extends WAM-C lowered-helper planning with one positive comparison-filter shape. A predicate with a fact-only callee plus a single integer comparison guard, such as `small(X) :- fact(X, N), N =< 2`, can now be projected into native fact-helper rows at generation time.

## What Changed

- Adds `comparison_filtered_fact` lowered-helper planning for one fact call followed by one supported comparison guard.
- Evaluates supported integer comparison guards against fact-only callee rows during project generation.
- Reuses the existing native fact-helper codegen path for projected comparison-filter rows.
- Preserves the explicit rejection metadata added for unsupported filtered-helper shapes.
- Adds generated-code and executable smoke coverage for comparison-filtered helpers.
- Updates the tiny lowered-helper benchmark so lowered mode exercises fact-only, body-call, filtered-fact, and comparison-filtered helper shapes.
- Refreshes `WAM_C_TARGET_NEXT_STEPS.md` to mark rejection metadata done and make comparison-filter helper work active.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets c-wam-lowered-helper --repetitions 1 --baseline-target c-wam-lowered-helper-interpreted`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
- `git diff --check`

## Follow-Up

Next recommended branch: `feat/wam-c-lowered-helper-comparison-filter-rejections`.
