### PR TITLE
ci(csharp-query): Check scan calibration wrapper in CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@
 - ✅ Recursive compiler
 - ✅ Advanced recursion (24 tests)
 - ✅ Constraint integration
-- ✅ C# query calibration wrapper contract (unit test + dry-run command shape)
+- ✅ C# query graph and scan calibration wrapper contracts (unit test + dry-run command shape)
 - ✅ Inference test runner generation
 - ✅ Generated bash script syntax validation
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,8 @@ jobs:
         run: |
           python3 -m unittest tests/test_csharp_query_calibration_refresh_wrapper.py
           python3 examples/benchmark/refresh_csharp_query_source_mode_calibration.py --dry-run
+          python3 -m unittest tests/test_csharp_query_scan_calibration_refresh_wrapper.py
+          python3 examples/benchmark/refresh_csharp_query_scan_source_mode_calibration.py --dry-run
 
       - name: Generate and run inference test runner
         run: |


### PR DESCRIPTION
  ## Summary

  - Adds the scan source-mode calibration wrapper unit test to the GitHub Actions test workflow.
  - Adds a CI dry-run check for `refresh_csharp_query_scan_source_mode_calibration.py`.
  - Updates the workflow README to document both graph and scan calibration wrapper contracts.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_calibration_refresh_wrapper.py`
  - `python3 examples/benchmark/refresh_csharp_query_source_mode_calibration.py --dry-run`
  - `python3 -m unittest tests/test_csharp_query_scan_calibration_refresh_wrapper.py`
  - `python3 examples/benchmark/refresh_csharp_query_scan_source_mode_calibration.py --dry-run`
  - `git diff --check`