### PR TITLE
feat(wam-clojure): add univ decompose builtin

### DIFF
--- a/PR_WAM_CLOJURE_UNIV_DECOMPOSE_BUILTIN.md
+++ b/PR_WAM_CLOJURE_UNIV_DECOMPOSE_BUILTIN.md
@@ -1,0 +1,30 @@
+# PR Title
+
+feat(wam-clojure): add univ decompose builtin
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM lowered-emitter recognition for `=../2`.
+- Implements runtime `apply-univ-solution` for decompose/read mode.
+- Converts bound terms into proper Prolog lists:
+  - `f(a,b) =.. [f,a,b]`
+  - `a =.. [a]`
+  - `42 =.. [42]`
+  - `[a,b] =.. ['[|]', a, [b]]`
+- Wires interpreted built-in dispatch for `"=../2"`.
+- Adds lowered-emitter and runtime smoke coverage for struct, atom, number, list, and mismatch cases.
+
+## Scope
+
+This PR intentionally implements decompose/read mode only: the first argument must already be a bound atom, number, or compound/list term.
+
+Compose mode, such as `T =.. [f,a,b]`, is left for a follow-up PR.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -372,6 +372,10 @@ clojure_direct_builtin("arg/3", "3").
 clojure_direct_builtin("arg/3", 3).
 clojure_direct_builtin('arg/3', "3").
 clojure_direct_builtin('arg/3', 3).
+clojure_direct_builtin("=../2", "2").
+clojure_direct_builtin("=../2", 2).
+clojure_direct_builtin('=../2', "2").
+clojure_direct_builtin('=../2', 2).
 clojure_direct_builtin("ground/1", "1").
 clojure_direct_builtin("ground/1", 1).
 clojure_direct_builtin('ground/1', "1").
@@ -590,6 +594,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "arg/3" ; Op == 'arg/3'),
     !,
     format(atom(Expr), '(runtime/apply-arg-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "=../2" ; Op == '=../2'),
+    !,
+    format(atom(Expr), '(runtime/apply-univ-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "ground/1" ; Op == 'ground/1'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -702,6 +702,33 @@
           (normalize-literal-atom ctx "[]")
           (reverse items)))
 
+(defn univ-decompose-term [state term]
+  (let [term* (deref-value (:bindings state) term)
+        ctx (:intern-context state)]
+    (cond
+      (structure-term? term*)
+      (let [key (functor-key ctx (:functor term*))
+            name (normalize-literal-atom ctx (functor-name-from-key key))]
+        (list->term ctx (cons name (:args term*))))
+
+      (or (atom-term? term*) (number? term*))
+      (list->term ctx [term*])
+
+      :else
+      nil)))
+
+(defn apply-univ-solution [state]
+  (let [term (deref-value (:bindings state)
+                          (or (reg-get-raw state "A1") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A2") ::unbound))]
+    (if-let [list-term (univ-decompose-term state term)]
+      (let [[ok next-state] (unify-values state out list-term)]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+      (backtrack state))))
+
 (defn term->unify-items [term]
   (if (structure-term? term)
     (seq (:args term))
@@ -1305,6 +1332,9 @@
 
           "arg/3"
           (apply-arg-solution state)
+
+          "=../2"
+          (apply-univ-solution state)
 
           "ground/1"
           (let [value (deref-value (:bindings state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -503,6 +503,15 @@ test(simple_builtin_arg_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_univ_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_univ/2:\nbuiltin_call =../2, 2\nproceed\n",
+        wam_clojure_lowerable(test_univ/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_univ/2, WamCode, [], Code),
+        has(Code, "runtime/apply-univ-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_ground_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_ground/1:\nbuiltin_call ground/1, 1\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -70,6 +70,12 @@
 :- dynamic user:wam_copy_term_independent_ok/0.
 :- dynamic user:wam_functor_guard/3.
 :- dynamic user:wam_arg_guard/3.
+:- dynamic user:wam_univ_guard/2.
+:- dynamic user:wam_univ_decompose_struct/0.
+:- dynamic user:wam_univ_decompose_atom/0.
+:- dynamic user:wam_univ_decompose_number/0.
+:- dynamic user:wam_univ_decompose_list/0.
+:- dynamic user:wam_univ_decompose_mismatch/0.
 :- dynamic user:wam_ground_guard/1.
 :- dynamic user:wam_ground_unbound/1.
 :- dynamic user:wam_ground_nested_unbound/1.
@@ -161,6 +167,12 @@ user:wam_copy_term_sharing_fail :- user:wam_unbound_arg(X), copy_term(f(X, X), f
 user:wam_copy_term_independent_ok :- copy_term(f(_, _), f(a, b)).
 user:wam_functor_guard(Term, Name, Arity) :- functor(Term, Name, Arity).
 user:wam_arg_guard(Index, Term, Arg) :- arg(Index, Term, Arg).
+user:wam_univ_guard(Term, List) :- Term =.. List.
+user:wam_univ_decompose_struct :- f(a, b) =.. [f, a, b].
+user:wam_univ_decompose_atom :- a =.. [a].
+user:wam_univ_decompose_number :- 42 =.. [42].
+user:wam_univ_decompose_list :- [a, b] =.. ['[|]', a, [b]].
+user:wam_univ_decompose_mismatch :- f(a, b) =.. [g, a, b].
 user:wam_ground_guard(X) :- ground(X).
 user:wam_ground_unbound(_) :- user:wam_unbound_arg(Y), ground(Y).
 user:wam_ground_nested_unbound(_) :- user:wam_unbound_arg(Y), ground(f(Y)).
@@ -257,6 +269,12 @@ run_smoke :-
           user:wam_copy_term_independent_ok/0,
           user:wam_functor_guard/3,
           user:wam_arg_guard/3,
+          user:wam_univ_guard/2,
+          user:wam_univ_decompose_struct/0,
+          user:wam_univ_decompose_atom/0,
+          user:wam_univ_decompose_number/0,
+          user:wam_univ_decompose_list/0,
+          user:wam_univ_decompose_mismatch/0,
           user:wam_ground_guard/1,
           user:wam_ground_unbound/1,
           user:wam_ground_nested_unbound/1,
@@ -310,6 +328,7 @@ run_smoke :-
     assert_lowered_copy_term_builtin_emitted(TmpDir),
     assert_lowered_functor_builtin_emitted(TmpDir),
     assert_lowered_arg_builtin_emitted(TmpDir),
+    assert_lowered_univ_builtin_emitted(TmpDir),
     assert_lowered_ground_builtin_emitted(TmpDir),
     assert_lowered_arithmetic_comparison_builtin_emitted(TmpDir),
     assert_multiclause_wrappers_runtime_mediated(TmpDir),
@@ -447,6 +466,14 @@ smoke_cases([
     case('wam_arg_guard/3', args(1, '[a,b]', a), "true"),
     case('wam_arg_guard/3', args(3, 'f(a,b)', a), "false"),
     case('wam_arg_guard/3', args(1, a, a), "false"),
+    case('wam_univ_guard/2', args('f(a,b)', '[f,a,b]'), "true"),
+    case('wam_univ_guard/2', args(a, '[a]'), "true"),
+    case('wam_univ_guard/2', args(42, '[42]'), "true"),
+    case('wam_univ_decompose_struct/0', no_args, "true"),
+    case('wam_univ_decompose_atom/0', no_args, "true"),
+    case('wam_univ_decompose_number/0', no_args, "true"),
+    case('wam_univ_decompose_list/0', no_args, "true"),
+    case('wam_univ_decompose_mismatch/0', no_args, "false"),
     case('wam_ground_guard/1', a, "true"),
     case('wam_ground_guard/1', 42, "true"),
     case('wam_ground_guard/1', 3.5, "true"),
@@ -650,6 +677,13 @@ assert_lowered_arg_builtin_emitted(ProjectDir) :-
     read_file_to_string(CorePath, CoreCode, []),
     has(CoreCode, "defn lowered-wam-arg-guard-3"),
     has(CoreCode, "runtime/apply-arg-solution").
+
+assert_lowered_univ_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-univ-guard-2"),
+    has(CoreCode, "defn lowered-wam-univ-decompose-struct-0"),
+    has(CoreCode, "runtime/apply-univ-solution").
 
 assert_lowered_ground_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
@@ -855,6 +889,8 @@ prolog_term_string_to_edn('f(a)', "{:tag :struct :functor \"f/1\" :args [\"a\"]}
 prolog_term_string_to_edn('f(a,b)', "{:tag :struct :functor \"f/2\" :args [\"a\" \"b\"]}") :- !.
 prolog_term_string_to_edn('f(b)', "{:tag :struct :functor \"f/1\" :args [\"b\"]}") :- !.
 prolog_term_string_to_edn('[a]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}") :- !.
+prolog_term_string_to_edn('[42]', "{:tag :struct :functor \"[|]/2\" :args [42 \"[]\"]}") :- !.
+prolog_term_string_to_edn('[f,a,b]', "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[a,b]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[c]', "{:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}") :- !.
@@ -865,6 +901,8 @@ prolog_term_string_to_edn("f(a)", "{:tag :struct :functor \"f/1\" :args [\"a\"]}
 prolog_term_string_to_edn("f(a,b)", "{:tag :struct :functor \"f/2\" :args [\"a\" \"b\"]}") :- !.
 prolog_term_string_to_edn("f(b)", "{:tag :struct :functor \"f/1\" :args [\"b\"]}") :- !.
 prolog_term_string_to_edn("[a]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}") :- !.
+prolog_term_string_to_edn("[42]", "{:tag :struct :functor \"[|]/2\" :args [42 \"[]\"]}") :- !.
+prolog_term_string_to_edn("[f,a,b]", "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[a,b]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[c]", "{:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}") :- !.


### PR DESCRIPTION
## Summary

- Adds Clojure WAM lowered-emitter recognition for `=../2`.
- Implements runtime `apply-univ-solution` for decompose/read mode.
- Converts bound terms into proper Prolog lists:
  - `f(a,b) =.. [f,a,b]`
  - `a =.. [a]`
  - `42 =.. [42]`
  - `[a,b] =.. ['[|]', a, [b]]`
- Wires interpreted built-in dispatch for `"=../2"`.
- Adds lowered-emitter and runtime smoke coverage for struct, atom, number, list, and mismatch cases.

## Scope

This PR intentionally implements decompose/read mode only: the first argument must already be a bound atom, number, or compound/list term.

Compose mode, such as `T =.. [f,a,b]`, is left for a follow-up PR.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
