### PR TITLE
Add Go WAM member/2 choicepoint enumeration

### DIFF
--- a/PR_go_wam_member_choicepoints.md
+++ b/PR_go_wam_member_choicepoints.md
@@ -1,0 +1,18 @@
+# Add Go WAM member/2 choicepoint enumeration
+
+## Description
+
+Adds builtin choicepoint support for Go WAM `member/2`, allowing it to enumerate later list members on backtracking instead of stopping at the first unifiable element. This lets aggregate collection paths such as `findall(X, member(X, [a,b]), L)` observe all solutions.
+
+The change also teaches the Go WAM list walker to treat compiler-emitted cons structures such as `[|]/2` as list tails, and makes negated builtin dispatch clean up bindings and choicepoints after probing the inner goal.
+
+## Tests
+
+```sh
+swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
+swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"
+```

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -8,10 +8,10 @@ current cross-target builtin/runtime baseline.
 
 | Area | Go support | Rust/Haskell baseline | Status |
 | --- | --- | --- | --- |
-| Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries | Choice point stack with normal, builtin, and fact-stream resume states | Partial |
+| Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries, `member/2` builtin retries | Choice point stack with normal, builtin, and fact-stream resume states | Partial |
 | Direct fact dispatch | Foreign/native kernel registration and indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Partial |
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `count`, `sum`, `min`, `max` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Partial: no `set` aggregate result |
-| Structural builtins | `member/2`, `length/2`, `append/3` | `member/2`, `length/2`; Rust `append/3` is explicitly unimplemented | Partial: `member/2` is first-solution only |
+| Structural builtins | `member/2`, `length/2`, `append/3` | `member/2`, `length/2`; Rust `append/3` is explicitly unimplemented | Present for current baseline structural checks |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2` | Includes `=</2` | Present for current baseline comparisons |
 | Unification builtin | `\=/2` | `=/2`, `\=/2` | Partial: no explicit `=/2` builtin handler |
@@ -27,11 +27,10 @@ current cross-target builtin/runtime baseline.
   The Go target now emits `internAtom("...")` instead of raw
   `&Atom{Name: "..."}` literals, so the assertions needed to follow the
   current intern-table design.
-- The Go WAM runtime has a substantial execution core, but its builtin set is
-  behind Rust/Haskell/Lua/Python for term inspection and copying.
-- `member/2` succeeds on the first unifiable element and does not push builtin
-  choice points for later list members. This mirrors the Python gap that was
-  recently closed.
+- The Go WAM runtime has a substantial execution core; the remaining obvious
+  builtin parity gap is `set` aggregate support.
+- `member/2` now pushes builtin choice points for later list members, so
+  `findall/3` can collect every unifiable element.
 - `=</2`, `is_list/1`, and `display/1` are now covered by the generated Go
   WAM builtin E2E test.
 - `functor/3`, `arg/3`, `=../2`, and `copy_term/2` are now covered by the
@@ -41,9 +40,7 @@ current cross-target builtin/runtime baseline.
 
 1. Continue broadening the generated Go WAM builtin E2E as each remaining gap
    is closed.
-2. Upgrade `member/2` to enumerate through builtin choice points so aggregate
-   collection can observe all list members.
-3. Add `set` aggregate support if Go is expected to match the current Lua/Python
+2. Add `set` aggregate support if Go is expected to match the current Lua/Python
    aggregate parity surface.
 
 ## Verification Commands

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -52,6 +52,7 @@ type ChoicePoint struct {
 	ForeignPredKey   string
 	ForeignResultRegs []int
 	ForeignResults   []Value
+	MemberTail       Value
 }
 
 type EnvFrame struct {
@@ -653,8 +654,40 @@ func (vm *WamState) listHeadTail(list *List) (Value, Value, bool) {
 		if isEmptyListValue(tail) {
 			return list.Elements[0], emptyListAtom, true
 		}
+		switch t := tail.(type) {
+		case *Compound:
+			if isConsFunctor(t.Functor) && len(t.Args) == 2 {
+				return list.Elements[0], tail, true
+			}
+		case *Structure:
+			if isConsFunctor(t.Functor) && len(t.Args) == 2 {
+				return list.Elements[0], tail, true
+			}
+		}
 	}
 	return list.Elements[0], &List{Elements: list.Elements[1:]}, true
+}
+
+func isConsFunctor(functor string) bool {
+	name := parseFunctorName(functor)
+	return name == "." || name == "[|]"
+}
+
+func (vm *WamState) valueListHeadTail(v Value) (Value, Value, bool) {
+	v = vm.deref(v)
+	switch t := v.(type) {
+	case *List:
+		return vm.listHeadTail(t)
+	case *Compound:
+		if isConsFunctor(t.Functor) && len(t.Args) == 2 {
+			return t.Args[0], t.Args[1], true
+		}
+	case *Structure:
+		if isConsFunctor(t.Functor) && len(t.Args) == 2 {
+			return t.Args[0], t.Args[1], true
+		}
+	}
+	return nil, nil, false
 }
 
 // listToSlice walks a Prolog cons list and collects its elements
@@ -677,13 +710,9 @@ func (vm *WamState) listToSlice(v Value) ([]Value, bool) {
 		if isEmptyListValue(v) {
 			return out, true
 		}
-		list, ok := v.(*List)
+		head, tail, ok := vm.valueListHeadTail(v)
 		if !ok {
 			return nil, false
-		}
-		head, tail, ok := vm.listHeadTail(list)
-		if !ok {
-			return out, true
 		}
 		out = append(out, head)
 		v = vm.deref(tail)
@@ -990,7 +1019,13 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			if len(args) > 1 { vm.Regs[1] = args[1] }
 			if len(args) > 2 { vm.Regs[2] = args[2] }
 			opName := fmt.Sprintf("%s/%d", f, len(args))
+			trailMark := vm.TrailLen
+			cpLen := len(vm.ChoicePoints)
 			res := vm.executeBuiltin(opName, len(args))
+			vm.unwindTrailTo(trailMark)
+			if cpLen <= len(vm.ChoicePoints) {
+				vm.ChoicePoints = vm.ChoicePoints[:cpLen]
+			}
 			for idx := 0; idx < 3; idx++ {
 				vm.Regs[idx] = oldRegs[idx]
 			}
@@ -1010,13 +1045,9 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			if isEmptyListValue(v) {
 				break
 			}
-			list, ok := v.(*List)
+			head, tail, ok := vm.valueListHeadTail(v)
 			if !ok {
 				return false
-			}
-			head, tail, ok := vm.listHeadTail(list)
-			if !ok {
-				break
 			}
 			_ = head
 			count++
@@ -1024,29 +1055,31 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 		}
 		return vm.Unify(arg2, &Integer{Val: count})
 	case "member/2":
-		// Walk-and-unify; no intermediate slice. The bench's
-		// `\+ member(M, Visited)` is the hot caller — depth-10
-		// Visited × thousands of recursion steps was previously
-		// allocating a 10-element slice per call just to discard
-		// it after the first match (or after a no-match scan).
 		v := vm.deref(arg2)
 		for {
 			if isEmptyListValue(v) {
 				return false
 			}
-			list, ok := v.(*List)
+			head, tail, ok := vm.valueListHeadTail(v)
 			if !ok {
 				return false
 			}
-			head, tail, ok := vm.listHeadTail(list)
-			if !ok {
-				return false
-			}
-			// Saving and restoring the trail mark lets a failed
-			// Unify on this element not leak bindings into the
-			// next iteration. (Standard WAM member/2 semantics.)
 			mark := vm.TrailLen
+			savedRegs := vm.snapshotAllRegs()
 			if vm.Unify(arg1, head) {
+				tail = vm.deref(tail)
+				if !isEmptyListValue(tail) {
+					vm.ChoicePoints = append(vm.ChoicePoints, ChoicePoint{
+						ResumePC: vm.PC + 1,
+						CP:       vm.CP,
+						E:        vm.E,
+						StackLen: len(vm.Stack),
+						SavedRegs: savedRegs,
+						HeapTop:   vm.HeapLen,
+						TrailMark: mark,
+						MemberTail: tail,
+					})
+				}
 				return true
 			}
 			vm.unwindTrailTo(mark)
@@ -1217,6 +1250,45 @@ func (vm *WamState) backtrack() bool {
         }
         vm.PC = nextPC
         return true
+    }
+    if cp.MemberTail != nil {
+        for cp.MemberTail != nil {
+            vm.unwindTrailTo(cp.TrailMark)
+            vm.restoreSavedRegs(cp.SavedRegs)
+            if cp.StackLen <= len(vm.Stack) {
+                vm.Stack = vm.Stack[:cp.StackLen]
+            }
+            vm.E = cp.E
+            if cp.HeapTop >= 0 && cp.HeapTop <= vm.HeapLen {
+                vm.heapTrimTo(cp.HeapTop)
+            }
+            vm.CP = cp.CP
+            vm.Halted = false
+            vm.CurrentStruct = nil
+            vm.CurrentList = nil
+            v := vm.deref(cp.MemberTail)
+            if isEmptyListValue(v) {
+                vm.ChoicePoints = vm.ChoicePoints[:topIdx]
+                return vm.backtrack()
+            }
+            item, tail, ok := vm.valueListHeadTail(v)
+            if !ok {
+                vm.ChoicePoints = vm.ChoicePoints[:topIdx]
+                return vm.backtrack()
+            }
+            cp.MemberTail = vm.deref(tail)
+            resumePC := cp.ResumePC
+            if isEmptyListValue(cp.MemberTail) {
+                vm.ChoicePoints = vm.ChoicePoints[:topIdx]
+            }
+            if !vm.Unify(vm.getReg(0), item) {
+                vm.unwindTrailTo(cp.TrailMark)
+                continue
+            }
+            vm.PC = resumePC
+            return true
+        }
+        return vm.backtrack()
     }
     if len(cp.ForeignResults) > 0 {
         for len(cp.ForeignResults) > 0 {

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -7,6 +7,7 @@
 
 :- dynamic user:test_builtins/1.
 :- dynamic user:test_term_builtins/0.
+:- dynamic user:test_member_collect/0.
 
 test(builtins_execution) :-
     get_time(T),
@@ -38,16 +39,23 @@ test(builtins_execution) :-
                 arg(1, C, Y),
                 arg(2, C, Z),
                 Y == Z
+            )),
+          assertz(user:test_member_collect :-
+            (   findall(X, member(X, [a,b]), L),
+                length(L, 2),
+                member(a, L),
+                member(b, L)
             ))
         ),
         run_builtins_test(TmpDir),
         ( retractall(user:test_builtins(_)),
           retractall(user:test_term_builtins),
+          retractall(user:test_member_collect),
           delete_directory_and_contents(TmpDir) )
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0],
     Options = [module_name(builtin_test)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -99,6 +107,14 @@ func main() {
 	} else {
 		fmt.Println("TERM_FAILURE")
 	}
+
+	memberVM := wam.NewWamState(wam.Test_member_collectCode, wam.Test_member_collectLabels)
+	memberVM.PC = wam.Test_member_collectStartPC
+	if memberVM.Run() {
+		fmt.Println("MEMBER_SUCCESS")
+	} else {
+		fmt.Println("MEMBER_FAILURE")
+	}
 }
 '),
 
@@ -118,7 +134,8 @@ func main() {
         assertion(Exit == exit(0)),
         assertion(sub_string(FullOutput, _, _, _, "ok")),
         assertion(sub_string(FullOutput, _, _, _, "SUCCESS: X=3")),
-        assertion(sub_string(FullOutput, _, _, _, "TERM_SUCCESS"))
+        assertion(sub_string(FullOutput, _, _, _, "TERM_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "MEMBER_SUCCESS"))
     ;   format("Go not found, skipping execution test.~n")
     ).
 


### PR DESCRIPTION
## Description

Adds builtin choicepoint support for Go WAM `member/2`, allowing it to enumerate later list members on backtracking instead of stopping at the first unifiable element. This lets aggregate collection paths such as `findall(X, member(X, [a,b]), L)` observe all solutions.

The change also teaches the Go WAM list walker to treat compiler-emitted cons structures such as `[|]/2` as list tails, and makes negated builtin dispatch clean up bindings and choicepoints after probing the inner goal.

## Tests

```sh
swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"
```
