### PR TITLE
test(csharp-query): Bind scan source-mode calibration to runtime policy

### DIFF
--- a/tests/test_csharp_query_graph_source_mode_policy.py
+++ b/tests/test_csharp_query_graph_source_mode_policy.py
@@ -20,6 +20,10 @@ from generate_pipeline import (  # noqa: E402
 )
 from benchmark_csharp_query_source_mode_sweep import load_calibration_artifact  # noqa: E402
 
+SCAN_CALIBRATION_ARTIFACT = ROOT / "examples" / "benchmark" / "csharp_query_scan_source_mode_calibration.tsv"
+SCAN_WORKLOAD_PREFIX = "scan-materialization:"
+SMALL_PREBUILT_ARTIFACT_ROW_THRESHOLD = 7_500
+
 
 class CSharpQueryGraphSourceModePolicyTests(unittest.TestCase):
     def test_graph_benchmark_generators_use_source_mode_policy_helper(self) -> None:
@@ -107,6 +111,7 @@ class CSharpQueryGraphSourceModePolicyTests(unittest.TestCase):
         ).read_text()
 
         expected_cases = [
+            "private const long SmallPrebuiltArtifactRowThreshold = 7_500L",
             '"bound_scan" => RelationSourceMode.Artifact',
             (
                 '"selective_join" when totalRows <= SmallPrebuiltArtifactRowThreshold '
@@ -125,6 +130,21 @@ class CSharpQueryGraphSourceModePolicyTests(unittest.TestCase):
         for expected_case in expected_cases:
             with self.subTest(expected_case=expected_case):
                 self.assertIn(expected_case, runtime_source)
+
+    def test_runtime_scan_source_mode_policy_matches_scan_calibration_artifact(self) -> None:
+        rows = load_calibration_artifact(SCAN_CALIBRATION_ARTIFACT)
+
+        for row in rows:
+            with self.subTest(workload=row.workload, scale=row.scale):
+                self.assertTrue(row.workload.startswith(SCAN_WORKLOAD_PREFIX))
+                scan_mode = row.workload[len(SCAN_WORKLOAD_PREFIX):]
+                expected_mode = self._expected_scan_source_mode(scan_mode, row.scale)
+
+                self.assertEqual(row.current_auto_resolved_source_mode, expected_mode)
+                self.assertIn(
+                    f"auto:{expected_mode}",
+                    row.resolved_source_mode_summary,
+                )
 
     def test_runtime_source_mode_policy_matches_calibration_artifact(self) -> None:
         runtime_source = (
@@ -146,6 +166,32 @@ class CSharpQueryGraphSourceModePolicyTests(unittest.TestCase):
             "artifact": "Artifact",
             "artifact-prebuilt": "ArtifactPrebuilt",
         }[source_mode]
+
+    @staticmethod
+    def _expected_scan_source_mode(scan_mode: str, scale: str) -> str:
+        total_rows = (
+            CSharpQueryGraphSourceModePolicyTests._data_row_count(
+                ROOT / "data" / "benchmark" / scale / "article_category.tsv"
+            )
+            + CSharpQueryGraphSourceModePolicyTests._data_row_count(
+                ROOT / "data" / "benchmark" / scale / "category_parent.tsv"
+            )
+        )
+        if scan_mode == "bound_scan":
+            return "artifact"
+        if scan_mode in {"selective_join", "join"}:
+            if total_rows <= SMALL_PREBUILT_ARTIFACT_ROW_THRESHOLD:
+                return "artifact-prebuilt"
+            return "artifact"
+        if scan_mode == "nary_join":
+            return "artifact-prebuilt"
+        return "preload"
+
+    @staticmethod
+    def _data_row_count(path: Path) -> int:
+        with path.open(encoding="utf-8") as handle:
+            next(handle, None)
+            return sum(1 for _ in handle)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary

  - Adds a policy-contract test for `csharp_query_scan_source_mode_calibration.tsv`.
  - Verifies each `scan-materialization:<mode>` row’s `current_auto_resolved_source_mode` matches the documented
  `ResolveScanBenchmarkMode` policy.
  - Checks the scan artifact’s `auto:<mode>` resolved summary stays aligned with that expected runtime policy.
  - Pins the small prebuilt artifact row-count threshold used by scan policy tests.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_graph_source_mode_policy.py`
  - `python3 -m unittest tests/test_csharp_query_graph_source_mode_policy.py tests/
  test_csharp_query_scan_calibration_refresh_wrapper.py tests/test_csharp_query_source_mode_sweep.py`
  - `python3 -m py_compile tests/test_csharp_query_graph_source_mode_policy.py`
  - `git diff --check`