### PR TITLE
feat(wam-c): Explain WAM-C comparison-filter rejections

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,7 +5,7 @@ Status date: 2026-05-14
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `d4a8939d` (`Merge pull request #2056 from s243a/feat/wam-c-lowered-helper-filter-rejections`)
+- `main` at `209694ab` (`Merge pull request #2059 from s243a/feat/wam-c-lowered-helper-filter-guard-comparisons`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
@@ -14,7 +14,7 @@ Base verified locally:
 
 Active branch:
 
-- `feat/wam-c-lowered-helper-filter-guard-comparisons`
+- `feat/wam-c-lowered-helper-comparison-filter-rejections`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -48,7 +48,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper body-call shape | Done | Deterministic alias-to-fact body calls lower through the existing foreign registry |
 | Lowered helper filtered-fact shape | Done | Constant-guarded fact projections lower to native fact rows and the tiny lowered-helper matrix exercises the filtered helper in lowered mode |
 | Lowered helper filter rejection metadata | Done | Planner reports explicit rejection reasons for non-constant filter arguments, unsupported comparison guards, multi-goal bodies, and unsupported filter callees |
-| Lowered helper comparison-filter shape | In progress | Active branch lowers a fact-only callee plus one integer comparison guard into native fact rows |
+| Lowered helper comparison-filter shape | Done | Fact-only callee plus one integer comparison guard lowers into native fact rows and the tiny lowered-helper matrix exercises it |
+| Lowered helper comparison-filter rejection metadata | In progress | Active branch reports explicit planner reasons for unsupported comparison-filter boundaries |
 
 ## Current C Target Baseline
 
@@ -119,7 +120,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup and all-hop collection; add more kernel kinds only after runtime support exists. |
 | Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`; broaden as more native C kernels land. |
-| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, rejection metadata, and active comparison-filter helper work. |
+| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, comparison-filter helpers, and active comparison-filter rejection metadata work. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
 | Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB `kernels_on`/`kernels_off`; next gap is larger artifact layouts. |
@@ -129,23 +130,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lowered-helper-filter-guard-comparisons`
-
-Goal: consider one positive comparison-filter lowering only after rejection
-metadata is stable.
-
-Scope:
-
-- Pick one deterministic comparison shape with a fact-only callee.
-- Keep the first implementation planner-only unless the codegen and runtime
-  behavior remain obvious.
-- Preserve the explicit rejection reasons added by the current branch.
-
-Status: active; a fact-only callee plus one integer comparison guard now lowers
-to projected native fact rows and the tiny lowered-helper matrix exercises the
-shape in lowered mode.
-
-### 2. `feat/wam-c-lowered-helper-comparison-filter-rejections`
+### 1. `feat/wam-c-lowered-helper-comparison-filter-rejections`
 
 Goal: make the remaining comparison-filter boundaries explicit.
 
@@ -157,11 +142,27 @@ Scope:
 - Keep the supported comparison-filter lowering unchanged.
 - Prefer planner tests and generated plan comments over new runtime paths.
 
+Status: active; planner metadata now distinguishes unbound comparison guard
+variables, unsupported comparison expressions, non-integer ordering rows, and
+comparison filters with no matching rows.
+
+### 2. `feat/wam-c-lowered-helper-repeated-variable-filters`
+
+Goal: tighten repeated-variable behavior in lowered filtered helpers.
+
+Scope:
+
+- Add planner tests for repeated head/callee variables in constant and
+  comparison-filtered helper shapes.
+- Keep existing supported lowering unchanged where repeated variables are
+  already handled correctly.
+- Add explicit rejection metadata if a repeated-variable shape is ambiguous.
+
 ## Suggested Immediate Next Step
 
-Continue validating `feat/wam-c-lowered-helper-filter-guard-comparisons`.
+Continue validating `feat/wam-c-lowered-helper-comparison-filter-rejections`.
 
-The active branch lowers one comparison-filter shape, for example
-`small(X) :- fact(X, N), N =< 2`, into native fact rows. The tiny
-lowered-helper matrix now exercises this comparison-filter helper in its
-lowered target.
+The active branch keeps supported comparison-filter lowering unchanged and
+improves planner diagnostics for unsupported comparison-filter boundaries. The
+next useful checks are the WAM-C target suite, the effective-distance benchmark
+suite, and `git diff --check`.

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -215,6 +215,10 @@ lowered_fact_helper_rejection_reason(PredIndicator, unsupported_fact_arguments) 
     !.
 lowered_fact_helper_rejection_reason(_, no_clauses).
 
+lowered_filter_rejection_reason(HeadArgs, Body0, Reason) :-
+    strip_module_qualification(Body0, Body),
+    lowered_comparison_filter_rejection_reason(HeadArgs, Body, Reason),
+    !.
 lowered_filter_rejection_reason(_HeadArgs, Body0, multi_goal_body) :-
     strip_module_qualification(Body0, Body),
     Body = (_, _),
@@ -240,6 +244,56 @@ lowered_filter_rejection_reason(HeadArgs, Body0, unsupported_filter_callee) :-
     \+ lowered_fact_helper_rows(CalleeIndicator, _Rows),
     !.
 
+lowered_comparison_filter_rejection_reason(HeadArgs, Body, Reason) :-
+    Body = (Call0, Guard0),
+    Call0 \= (_, _),
+    Guard0 \= (_, _),
+    strip_module_qualification(Call0, Call),
+    strip_module_qualification(Guard0, Guard),
+    Guard =.. [GuardPred, Left, Right],
+    wam_c_lowered_comparison_guard(GuardPred/2),
+    comparison_filter_call_context(HeadArgs, Call, CalleeArgs, CalleeRows),
+    comparison_filter_guard_rejection_reason(CalleeArgs, CalleeRows, GuardPred, Left, Right, Reason).
+
+comparison_filter_call_context(HeadArgs, Call, CalleeArgs, CalleeRows) :-
+    Call =.. [CalleePred|CalleeArgs],
+    length(CalleeArgs, CalleeArity),
+    \+ wam_c_lowered_comparison_guard(CalleePred/CalleeArity),
+    maplist(var, HeadArgs),
+    maplist(callee_filter_arg_supported, CalleeArgs),
+    CalleeIndicator = user:CalleePred/CalleeArity,
+    lowered_fact_helper_rows(CalleeIndicator, CalleeRows).
+
+comparison_filter_guard_rejection_reason(CalleeArgs, _CalleeRows, _GuardPred, Left, Right, comparison_guard_unbound_variable) :-
+    (   comparison_arg_unbound_variable(Left, CalleeArgs)
+    ;   comparison_arg_unbound_variable(Right, CalleeArgs)
+    ),
+    !.
+comparison_filter_guard_rejection_reason(CalleeArgs, _CalleeRows, _GuardPred, Left, Right, unsupported_comparison_expression) :-
+    (   \+ comparison_arg_basic(Left, CalleeArgs)
+    ;   \+ comparison_arg_basic(Right, CalleeArgs)
+    ),
+    !.
+comparison_filter_guard_rejection_reason(CalleeArgs, CalleeRows, GuardPred, Left, Right, non_integer_comparison_rows) :-
+    wam_c_lowered_ordering_guard(GuardPred),
+    comparison_arg_supported(Left, CalleeArgs),
+    comparison_arg_supported(Right, CalleeArgs),
+    member(CalleeRow, CalleeRows),
+    callee_row_matches_arg_constraints(CalleeArgs, CalleeRow),
+    comparison_arg_value(Left, CalleeArgs, CalleeRow, LeftValue),
+    comparison_arg_value(Right, CalleeArgs, CalleeRow, RightValue),
+    (   \+ integer(LeftValue)
+    ;   \+ integer(RightValue)
+    ),
+    !.
+comparison_filter_guard_rejection_reason(CalleeArgs, CalleeRows, GuardPred, Left, Right, no_matching_comparison_rows) :-
+    comparison_arg_supported(Left, CalleeArgs),
+    comparison_arg_supported(Right, CalleeArgs),
+    \+ ( member(CalleeRow, CalleeRows),
+         callee_row_matches_comparison_filter(CalleeArgs, GuardPred, Left, Right, CalleeRow)
+       ),
+    !.
+
 wam_c_lowered_comparison_guard((=)/2).
 wam_c_lowered_comparison_guard((==)/2).
 wam_c_lowered_comparison_guard((\==)/2).
@@ -250,6 +304,13 @@ wam_c_lowered_comparison_guard((=<)/2).
 wam_c_lowered_comparison_guard((=:=)/2).
 wam_c_lowered_comparison_guard((=\=)/2).
 wam_c_lowered_comparison_guard(is/2).
+
+wam_c_lowered_ordering_guard((>)).
+wam_c_lowered_ordering_guard((<)).
+wam_c_lowered_ordering_guard((>=)).
+wam_c_lowered_ordering_guard((=<)).
+wam_c_lowered_ordering_guard((=:=)).
+wam_c_lowered_ordering_guard((=\=)).
 
 compile_lowered_helpers_for_project(Plans, LoweredKeys, Code, SetupCode) :-
     findall(Key-CodePart-SetupLine,
@@ -454,6 +515,19 @@ comparison_arg_supported(Arg, _CalleeArgs) :-
 comparison_arg_supported(Arg, CalleeArgs) :-
     member(CalleeArg, CalleeArgs),
     Arg == CalleeArg.
+
+comparison_arg_basic(Arg, CalleeArgs) :-
+    comparison_arg_supported(Arg, CalleeArgs),
+    !.
+comparison_arg_basic(Arg, _CalleeArgs) :-
+    var(Arg),
+    !.
+
+comparison_arg_unbound_variable(Arg, CalleeArgs) :-
+    var(Arg),
+    \+ ( member(CalleeArg, CalleeArgs),
+         Arg == CalleeArg
+       ).
 
 callee_row_matches_comparison_filter(CalleeArgs, GuardPred, Left, Right, CalleeRow) :-
     callee_row_matches_arg_constraints(CalleeArgs, CalleeRow),

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -521,6 +521,65 @@ test_lowered_filter_rejection_metadata :-
     retractall(user:wam_c_filter_reject_builtin(_)),
     retractall(user:wam_c_filter_reject_multi_goal(_)).
 
+test_lowered_comparison_filter_rejection_metadata :-
+    Test = 'WAM-C: lowered helper planner explains unsupported comparison filters',
+    assertz(user:wam_c_cmp_reject_score(a, 1)),
+    assertz(user:wam_c_cmp_reject_score(b, 2)),
+    assertz(user:wam_c_cmp_reject_label(a, low)),
+    assertz((user:wam_c_cmp_reject_unbound(X) :-
+                 user:wam_c_cmp_reject_score(X, _N),
+                 _Missing =< 2)),
+    assertz((user:wam_c_cmp_reject_expr(X) :-
+                 user:wam_c_cmp_reject_score(X, N),
+                 N + 1 =< 3)),
+    assertz((user:wam_c_cmp_reject_non_integer(X) :-
+                 user:wam_c_cmp_reject_label(X, Label),
+                 Label > 1)),
+    assertz((user:wam_c_cmp_reject_no_match(X) :-
+                 user:wam_c_cmp_reject_score(X, N),
+                 N < 0)),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    format(atom(ProjectDir), '/tmp/unifyweaver_wam_c_lowered_comparison_reject_project_~w', [Stamp]),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    (   plan_wam_c_lowered_helpers([user:wam_c_cmp_reject_score/2,
+                                     user:wam_c_cmp_reject_label/2,
+                                     user:wam_c_cmp_reject_unbound/1,
+                                     user:wam_c_cmp_reject_expr/1,
+                                     user:wam_c_cmp_reject_non_integer/1,
+                                     user:wam_c_cmp_reject_no_match/1],
+                                    [lowered_helpers(true)],
+                                    [],
+                                    Plans),
+        member(wam_c_lowered_helper_plan('wam_c_cmp_reject_score/2', _, lowered, fact_only([[a,1],[b,2]])), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_cmp_reject_label/2', _, lowered, fact_only([[a,low]])), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_cmp_reject_unbound/1', _, rejected, comparison_guard_unbound_variable), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_cmp_reject_expr/1', _, rejected, unsupported_comparison_expression), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_cmp_reject_non_integer/1', _, rejected, non_integer_comparison_rows), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_cmp_reject_no_match/1', _, rejected, no_matching_comparison_rows), Plans),
+        write_wam_c_project([user:wam_c_cmp_reject_score/2,
+                             user:wam_c_cmp_reject_label/2,
+                             user:wam_c_cmp_reject_unbound/1,
+                             user:wam_c_cmp_reject_expr/1,
+                             user:wam_c_cmp_reject_non_integer/1,
+                             user:wam_c_cmp_reject_no_match/1],
+                            [lowered_helpers(true)],
+                            ProjectDir),
+        read_file_to_string(LibPath, LibS, []),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_cmp_reject_unbound/1: comparison_guard_unbound_variable'),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_cmp_reject_expr/1: unsupported_comparison_expression'),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_cmp_reject_non_integer/1: non_integer_comparison_rows'),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_cmp_reject_no_match/1: no_matching_comparison_rows')
+    ->  pass(Test)
+    ;   fail_test(Test, 'planner did not report explicit comparison-filter rejection reasons')
+    ),
+    retractall(user:wam_c_cmp_reject_score(_, _)),
+    retractall(user:wam_c_cmp_reject_label(_, _)),
+    retractall(user:wam_c_cmp_reject_unbound(_)),
+    retractall(user:wam_c_cmp_reject_expr(_)),
+    retractall(user:wam_c_cmp_reject_non_integer(_)),
+    retractall(user:wam_c_cmp_reject_no_match(_)).
+
 test_unsupported_instruction_fails_loudly :-
     Test = 'WAM-C: unsupported instructions fail loudly',
     BadWamCode = 'foo/1:\n    unknown_opcode A1\n    proceed',
@@ -2450,6 +2509,7 @@ run_tests_once :-
     test_lowered_filtered_fact_helper_generation,
     test_lowered_comparison_filter_helper_generation,
     test_lowered_filter_rejection_metadata,
+    test_lowered_comparison_filter_rejection_metadata,
     test_unsupported_instruction_fails_loudly,
     test_no_zero_instruction_fallback,
     test_list_target_pc_emission,


### PR DESCRIPTION
## Summary

This PR improves WAM-C lowered-helper planner diagnostics for unsupported comparison-filter shapes. Supported comparison-filter lowering remains unchanged, while unsupported boundaries now report explicit planner reasons instead of falling back to generic multi-goal rejection metadata.

## What Changed

- Adds comparison-filter rejection metadata for:
  - `comparison_guard_unbound_variable`
  - `unsupported_comparison_expression`
  - `non_integer_comparison_rows`
  - `no_matching_comparison_rows`
- Keeps the existing `comparison_filtered_fact` lowering path unchanged for supported fact-only callees plus integer comparison guards.
- Adds focused planner tests that assert the new rejection reasons in both in-memory plans and generated `lib.c` plan comments.
- Refreshes `WAM_C_TARGET_NEXT_STEPS.md` to mark comparison-filter lowering done and make comparison-filter rejection diagnostics the active branch.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets c-wam-lowered-helper --repetitions 1 --baseline-target c-wam-lowered-helper-interpreted`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
- `git diff --check`

## Follow-Up

Next recommended branch: `feat/wam-c-lowered-helper-repeated-variable-filters`.
