### PR TITLE
feat(wam-clojure): add univ compose builtin

### DIFF
--- a/PR_WAM_CLOJURE_UNIV_COMPOSE_BUILTIN.md
+++ b/PR_WAM_CLOJURE_UNIV_COMPOSE_BUILTIN.md
@@ -1,0 +1,29 @@
+# PR Title
+
+feat(wam-clojure): add univ compose builtin
+
+# PR Description
+
+## Summary
+
+- Extends Clojure WAM `=../2` support with compose mode.
+- Builds terms from proper univ lists when the first argument is unbound.
+- Synthesizes and interns `Name/Arity` functor keys for compound construction.
+- Keeps existing decompose mode for bound first arguments.
+- Adds runtime smoke coverage for struct, atom, number, list, empty-list failure, and invalid functor-head failure cases.
+
+## Scope
+
+This PR completes the narrow `=../2` bidirectional path for Clojure WAM:
+
+- Decompose mode remains `BoundTerm =.. List`.
+- Compose mode adds `UnboundTerm =.. ProperList`.
+
+The compose path requires a non-empty proper list. Multi-element lists require an atom head as the functor name; one-element lists compose to the atomic head value.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -717,17 +717,38 @@
       :else
       nil)))
 
+(defn univ-compose-term [state list-value]
+  (when-let [items (proper-list-items state list-value)]
+    (when (seq items)
+      (if (= 1 (count items))
+        [state (deref-value (:bindings state) (first items))]
+        (let [head (deref-value (:bindings state) (first items))
+              args (vec (rest items))]
+          (when (atom-term? head)
+            (let [name (deintern-atom (:intern-context state) (:id head))
+                  functor-key (str name "/" (count args))
+                  [ctx* functor-id] (intern-atom (:intern-context state) functor-key)
+                  state* (assoc state :intern-context ctx*)]
+              [state* (structure-term (atom-term functor-id) args)])))))))
+
 (defn apply-univ-solution [state]
-  (let [term (deref-value (:bindings state)
-                          (or (reg-get-raw state "A1") ::unbound))
+  (let [raw-term (or (reg-get-raw state "A1") ::unbound)
+        term (deref-value (:bindings state) raw-term)
         out (deref-value (:bindings state)
                          (or (reg-get-raw state "A2") ::unbound))]
-    (if-let [list-term (univ-decompose-term state term)]
-      (let [[ok next-state] (unify-values state out list-term)]
-        (if ok
-          (advance next-state)
-          (backtrack state)))
-      (backtrack state))))
+    (if (logic-var? term)
+      (if-let [[compose-state built] (univ-compose-term state out)]
+        (let [[ok next-state] (unify-values compose-state raw-term built)]
+          (if ok
+            (advance next-state)
+            (backtrack state)))
+        (backtrack state))
+      (if-let [list-term (univ-decompose-term state term)]
+        (let [[ok next-state] (unify-values state out list-term)]
+          (if ok
+            (advance next-state)
+            (backtrack state)))
+        (backtrack state)))))
 
 (defn term->unify-items [term]
   (if (structure-term? term)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -76,6 +76,12 @@
 :- dynamic user:wam_univ_decompose_number/0.
 :- dynamic user:wam_univ_decompose_list/0.
 :- dynamic user:wam_univ_decompose_mismatch/0.
+:- dynamic user:wam_univ_compose_struct/0.
+:- dynamic user:wam_univ_compose_atom/0.
+:- dynamic user:wam_univ_compose_number/0.
+:- dynamic user:wam_univ_compose_list/0.
+:- dynamic user:wam_univ_compose_empty/0.
+:- dynamic user:wam_univ_compose_bad_functor/0.
 :- dynamic user:wam_ground_guard/1.
 :- dynamic user:wam_ground_unbound/1.
 :- dynamic user:wam_ground_nested_unbound/1.
@@ -173,6 +179,12 @@ user:wam_univ_decompose_atom :- a =.. [a].
 user:wam_univ_decompose_number :- 42 =.. [42].
 user:wam_univ_decompose_list :- [a, b] =.. ['[|]', a, [b]].
 user:wam_univ_decompose_mismatch :- f(a, b) =.. [g, a, b].
+user:wam_univ_compose_struct :- T =.. [f, a, b], T = f(a, b).
+user:wam_univ_compose_atom :- T =.. [a], T = a.
+user:wam_univ_compose_number :- T =.. [42], T = 42.
+user:wam_univ_compose_list :- T =.. ['[|]', a, [b]], T = [a, b].
+user:wam_univ_compose_empty :- _T =.. [].
+user:wam_univ_compose_bad_functor :- user:wam_unbound_arg(F), _T =.. [F, a].
 user:wam_ground_guard(X) :- ground(X).
 user:wam_ground_unbound(_) :- user:wam_unbound_arg(Y), ground(Y).
 user:wam_ground_nested_unbound(_) :- user:wam_unbound_arg(Y), ground(f(Y)).
@@ -275,6 +287,12 @@ run_smoke :-
           user:wam_univ_decompose_number/0,
           user:wam_univ_decompose_list/0,
           user:wam_univ_decompose_mismatch/0,
+          user:wam_univ_compose_struct/0,
+          user:wam_univ_compose_atom/0,
+          user:wam_univ_compose_number/0,
+          user:wam_univ_compose_list/0,
+          user:wam_univ_compose_empty/0,
+          user:wam_univ_compose_bad_functor/0,
           user:wam_ground_guard/1,
           user:wam_ground_unbound/1,
           user:wam_ground_nested_unbound/1,
@@ -474,6 +492,12 @@ smoke_cases([
     case('wam_univ_decompose_number/0', no_args, "true"),
     case('wam_univ_decompose_list/0', no_args, "true"),
     case('wam_univ_decompose_mismatch/0', no_args, "false"),
+    case('wam_univ_compose_struct/0', no_args, "true"),
+    case('wam_univ_compose_atom/0', no_args, "true"),
+    case('wam_univ_compose_number/0', no_args, "true"),
+    case('wam_univ_compose_list/0', no_args, "true"),
+    case('wam_univ_compose_empty/0', no_args, "false"),
+    case('wam_univ_compose_bad_functor/0', no_args, "false"),
     case('wam_ground_guard/1', a, "true"),
     case('wam_ground_guard/1', 42, "true"),
     case('wam_ground_guard/1', 3.5, "true"),
@@ -683,6 +707,7 @@ assert_lowered_univ_builtin_emitted(ProjectDir) :-
     read_file_to_string(CorePath, CoreCode, []),
     has(CoreCode, "defn lowered-wam-univ-guard-2"),
     has(CoreCode, "defn lowered-wam-univ-decompose-struct-0"),
+    has(CoreCode, "defn lowered-wam-univ-compose-struct-0"),
     has(CoreCode, "runtime/apply-univ-solution").
 
 assert_lowered_ground_builtin_emitted(ProjectDir) :-


### PR DESCRIPTION
## Summary

- Extends Clojure WAM `=../2` support with compose mode.
- Builds terms from proper univ lists when the first argument is unbound.
- Synthesizes and interns `Name/Arity` functor keys for compound construction.
- Keeps existing decompose mode for bound first arguments.
- Adds runtime smoke coverage for struct, atom, number, list, empty-list failure, and invalid functor-head failure cases.

## Scope

This PR completes the narrow `=../2` bidirectional path for Clojure WAM:

- Decompose mode remains `BoundTerm =.. List`.
- Compose mode adds `UnboundTerm =.. ProperList`.

The compose path requires a non-empty proper list. Multi-element lists require an atom head as the functor name; one-element lists compose to the atomic head value.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
