### PR TITLE
ci(csharp-query): Check C# query calibration policy contracts in CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@
 - ✅ Recursive compiler
 - ✅ Advanced recursion (24 tests)
 - ✅ Constraint integration
-- ✅ C# query graph and scan calibration wrapper contracts (unit test + dry-run command shape)
+- ✅ C# query graph and scan calibration policy/wrapper contracts (unit test + dry-run command shape)
 - ✅ Inference test runner generation
 - ✅ Generated bash script syntax validation
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Run C# query calibration wrapper contract tests
         run: |
+          python3 -m unittest tests/test_csharp_query_graph_source_mode_policy.py
           python3 -m unittest tests/test_csharp_query_calibration_refresh_wrapper.py
           python3 examples/benchmark/refresh_csharp_query_source_mode_calibration.py --dry-run
           python3 -m unittest tests/test_csharp_query_scan_calibration_refresh_wrapper.py


### PR DESCRIPTION
  ## Summary

  - Adds `tests/test_csharp_query_graph_source_mode_policy.py` to the C# query calibration CI step.
  - Ensures graph and scan source-mode calibration policy contracts run in GitHub Actions.
  - Updates the workflow README to describe both calibration policy and wrapper contract coverage.

  ## Validation

  - Exact CI command block for policy, graph wrapper, and scan wrapper checks
  - `python3 -m unittest tests/test_csharp_query_graph_source_mode_policy.py tests/
  test_csharp_query_calibration_refresh_wrapper.py tests/test_csharp_query_scan_calibration_refresh_wrapper.py tests/
  test_csharp_query_source_mode_sweep.py`
  - `python3 -m py_compile tests/test_csharp_query_graph_source_mode_policy.py examples/benchmark/
  refresh_csharp_query_scan_source_mode_calibration.py examples/benchmark/
  refresh_csharp_query_source_mode_calibration.py examples/benchmark/benchmark_csharp_query_source_mode_sweep.py`
  - `git diff --check`