### PR TITLE
Add Go WAM set aggregate support

### DIFF
--- a/PR_go_wam_set_aggregate.md
+++ b/PR_go_wam_set_aggregate.md
@@ -1,0 +1,18 @@
+# Add Go WAM set aggregate support
+
+## Description
+
+Adds Go WAM aggregate finalization for `set` and `setof`, deduplicating collected values in first-seen order to match the current Haskell `nub` behavior. The same runtime helper now also treats `bag` and `bagof` as list-producing aggregate aliases.
+
+This closes the documented Go aggregate parity gap against the Rust/Haskell aggregate baseline and adds generated Go E2E coverage for `aggregate_all(set(X), member(X, [a,b,a]), S)`.
+
+## Tests
+
+```sh
+swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
+swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"
+```

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -10,7 +10,7 @@ current cross-target builtin/runtime baseline.
 | --- | --- | --- | --- |
 | Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries, `member/2` builtin retries | Choice point stack with normal, builtin, and fact-stream resume states | Partial |
 | Direct fact dispatch | Foreign/native kernel registration and indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Partial |
-| Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `count`, `sum`, `min`, `max` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Partial: no `set` aggregate result |
+| Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
 | Structural builtins | `member/2`, `length/2`, `append/3` | `member/2`, `length/2`; Rust `append/3` is explicitly unimplemented | Present for current baseline structural checks |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2` | Includes `=</2` | Present for current baseline comparisons |
@@ -27,21 +27,23 @@ current cross-target builtin/runtime baseline.
   The Go target now emits `internAtom("...")` instead of raw
   `&Atom{Name: "..."}` literals, so the assertions needed to follow the
   current intern-table design.
-- The Go WAM runtime has a substantial execution core; the remaining obvious
-  builtin parity gap is `set` aggregate support.
+- The Go WAM runtime has a substantial execution core; `set` aggregate results
+  are now deduplicated like Haskell's `nub` behavior.
 - `member/2` now pushes builtin choice points for later list members, so
   `findall/3` can collect every unifiable element.
 - `=</2`, `is_list/1`, and `display/1` are now covered by the generated Go
   WAM builtin E2E test.
 - `functor/3`, `arg/3`, `=../2`, and `copy_term/2` are now covered by the
   generated Go WAM builtin E2E test.
+- `aggregate_all(set(X), Goal, Set)` is now covered by the generated Go WAM
+  builtin E2E test.
 
 ## Recommended Follow-Up Order
 
-1. Continue broadening the generated Go WAM builtin E2E as each remaining gap
-   is closed.
-2. Add `set` aggregate support if Go is expected to match the current Lua/Python
-   aggregate parity surface.
+1. Continue broadening generated Go WAM E2E coverage for control and fact-source
+   behavior that remains marked partial.
+2. Compare Go direct fact dispatch against Rust/Haskell external fact stream
+   paths if Go should close the remaining direct-fact parity gap.
 
 ## Verification Commands
 

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -2103,6 +2103,10 @@ func aggregateResultValue(aggType string, values []Value, count int) (Value, boo
         return &Integer{Val: int64(count)}, true
     case "collect":
         return &List{Elements: append([]Value(nil), values...)}, true
+    case "bag", "bagof":
+        return &List{Elements: append([]Value(nil), values...)}, true
+    case "set", "setof":
+        return &List{Elements: uniqueAggregateValues(values)}, true
     case "sum":
         total := 0.0
         for _, value := range values {
@@ -2152,6 +2156,23 @@ func aggregateResultValue(aggType string, values []Value, count int) (Value, boo
     default:
         return nil, false
     }
+}
+
+func uniqueAggregateValues(values []Value) []Value {
+    out := make([]Value, 0, len(values))
+    for _, value := range values {
+        found := false
+        for _, existing := range out {
+            if valueEquals(existing, value) {
+                found = true
+                break
+            }
+        }
+        if !found {
+            out = append(out, value)
+        }
+    }
+    return out
 }
 
 func aggregateNumericValue(value Value) (float64, bool) {

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -8,6 +8,7 @@
 :- dynamic user:test_builtins/1.
 :- dynamic user:test_term_builtins/0.
 :- dynamic user:test_member_collect/0.
+:- dynamic user:test_set_aggregate/0.
 
 test(builtins_execution) :-
     get_time(T),
@@ -45,17 +46,24 @@ test(builtins_execution) :-
                 length(L, 2),
                 member(a, L),
                 member(b, L)
+            )),
+          assertz(user:test_set_aggregate :-
+            (   aggregate_all(set(X), member(X, [a,b,a]), S),
+                length(S, 2),
+                member(a, S),
+                member(b, S)
             ))
         ),
         run_builtins_test(TmpDir),
         ( retractall(user:test_builtins(_)),
           retractall(user:test_term_builtins),
           retractall(user:test_member_collect),
+          retractall(user:test_set_aggregate),
           delete_directory_and_contents(TmpDir) )
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_set_aggregate/0],
     Options = [module_name(builtin_test)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -73,6 +81,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "arg/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "=../2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "copy_term/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'AggType: "set"')),
 
     % Add a main.go to run the test in a separate cmd directory
     directory_file_path(TmpDir, 'cmd', CmdDir),
@@ -115,6 +124,14 @@ func main() {
 	} else {
 		fmt.Println("MEMBER_FAILURE")
 	}
+
+	setVM := wam.NewWamState(wam.Test_set_aggregateCode, wam.Test_set_aggregateLabels)
+	setVM.PC = wam.Test_set_aggregateStartPC
+	if setVM.Run() {
+		fmt.Println("SET_SUCCESS")
+	} else {
+		fmt.Println("SET_FAILURE")
+	}
 }
 '),
 
@@ -135,7 +152,8 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "ok")),
         assertion(sub_string(FullOutput, _, _, _, "SUCCESS: X=3")),
         assertion(sub_string(FullOutput, _, _, _, "TERM_SUCCESS")),
-        assertion(sub_string(FullOutput, _, _, _, "MEMBER_SUCCESS"))
+        assertion(sub_string(FullOutput, _, _, _, "MEMBER_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS"))
     ;   format("Go not found, skipping execution test.~n")
     ).
 


### PR DESCRIPTION
Adds Go WAM aggregate finalization for `set` and `setof`, deduplicating collected values in first-seen order to match the current Haskell `nub` behavior. The same runtime helper now also treats `bag` and `bagof` as list-producing aggregate aliases.

This closes the documented Go aggregate parity gap against the Rust/Haskell aggregate baseline and adds generated Go E2E coverage for `aggregate_all(set(X), member(X, [a,b,a]), S)`.

## Tests

```sh
swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"
```
