### PR TITLE
test(csharp-query): Rename C# query source-mode policy test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run C# query calibration wrapper contract tests
         run: |
-          python3 -m unittest tests/test_csharp_query_graph_source_mode_policy.py
+          python3 -m unittest tests/test_csharp_query_source_mode_policy.py
           python3 -m unittest tests/test_csharp_query_calibration_refresh_wrapper.py
           python3 examples/benchmark/refresh_csharp_query_source_mode_calibration.py --dry-run
           python3 -m unittest tests/test_csharp_query_scan_calibration_refresh_wrapper.py

--- a/tests/test_csharp_query_source_mode_policy.py
+++ b/tests/test_csharp_query_source_mode_policy.py
@@ -25,7 +25,7 @@ SCAN_WORKLOAD_PREFIX = "scan-materialization:"
 SMALL_PREBUILT_ARTIFACT_ROW_THRESHOLD = 7_500
 
 
-class CSharpQueryGraphSourceModePolicyTests(unittest.TestCase):
+class CSharpQuerySourceModePolicyTests(unittest.TestCase):
     def test_graph_benchmark_generators_use_source_mode_policy_helper(self) -> None:
         article_cats = [("Article", "Physics")]
         category_parents = [("Physics", "Science")]
@@ -170,10 +170,10 @@ class CSharpQueryGraphSourceModePolicyTests(unittest.TestCase):
     @staticmethod
     def _expected_scan_source_mode(scan_mode: str, scale: str) -> str:
         total_rows = (
-            CSharpQueryGraphSourceModePolicyTests._data_row_count(
+            CSharpQuerySourceModePolicyTests._data_row_count(
                 ROOT / "data" / "benchmark" / scale / "article_category.tsv"
             )
-            + CSharpQueryGraphSourceModePolicyTests._data_row_count(
+            + CSharpQuerySourceModePolicyTests._data_row_count(
                 ROOT / "data" / "benchmark" / scale / "category_parent.tsv"
             )
         )


### PR DESCRIPTION
  ## Summary

  - Renames `tests/test_csharp_query_graph_source_mode_policy.py` to `tests/test_csharp_query_source_mode_policy.py`.
  - Renames the test class to `CSharpQuerySourceModePolicyTests`.
  - Updates GitHub Actions to run the new filename.
  - Keeps test behavior unchanged while making the name accurate for both graph and scan source-mode policy coverage.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py`
  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py tests/
  test_csharp_query_calibration_refresh_wrapper.py tests/test_csharp_query_scan_calibration_refresh_wrapper.py tests/
  test_csharp_query_source_mode_sweep.py`
  - `python3 -m py_compile tests/test_csharp_query_source_mode_policy.py examples/benchmark/
  refresh_csharp_query_scan_source_mode_calibration.py examples/benchmark/
  refresh_csharp_query_source_mode_calibration.py examples/benchmark/benchmark_csharp_query_source_mode_sweep.py`
  - Graph and scan refresh wrapper dry-runs
  - `git diff --check`