### PR TITLE
test(wam-c): Capture ASAN smoke stderr separately

### DIFF
--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -1517,7 +1517,7 @@ cleanup_wam_c_detector_category_ancestor :-
 run_c_smoke(ExePath) :-
     format(atom(LogPath), '~w.asan.log', [ExePath]),
     format(atom(Cmd),
-           'ASAN_OPTIONS=detect_leaks=0:abort_on_error=1 timeout 10 ~w > ~w 2>&1',
+           'ASAN_OPTIONS=detect_leaks=0:abort_on_error=1 timeout 10 ~w > /dev/null 2> ~w',
            [ExePath, LogPath]),
     shell(Cmd, Status),
     (   Status =:= 0


### PR DESCRIPTION
## Summary

- update the WAM-C ASAN smoke wrapper to discard stdout and capture stderr in the diagnostic log
- avoid the combined `> log 2>&1` redirection path that can make the ASAN lifecycle smoke time out locally
- keep the generated WAM-C runtime behavior unchanged

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --check`

## Notes

- This is a test-harness-only fix for the ASAN lifecycle smoke.
- The branch is committed as `3e097de1 test(wam-c): capture ASAN smoke stderr separately`.