### PR TITLE
Add Go WAM =/2 builtin support

### DIFF
--- a/PR_go_wam_unify_builtin.md
+++ b/PR_go_wam_unify_builtin.md
@@ -1,0 +1,18 @@
+# Add Go WAM =/2 builtin support
+
+## Description
+
+Adds explicit Go WAM runtime handling for the `=/2` builtin by routing it through normal WAM unification. This closes the documented Go parity gap where `\=/2` existed but `=/2` did not have a direct builtin handler.
+
+The generated Go builtin E2E now forces an emitted `Op: "=/2"` and verifies both successful structural binding and use under negation with `\+ =(a, b)`.
+
+## Tests
+
+```sh
+swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
+swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"
+```

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -14,7 +14,7 @@ current cross-target builtin/runtime baseline.
 | Structural builtins | `member/2`, `length/2`, `append/3` | `member/2`, `length/2`; Rust `append/3` is explicitly unimplemented | Present for current baseline structural checks |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2` | Includes `=</2` | Present for current baseline comparisons |
-| Unification builtin | `\=/2` | `=/2`, `\=/2` | Partial: no explicit `=/2` builtin handler |
+| Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
 | Term inspection | `functor/3`, `arg/3` | `functor/3`, `arg/3` | Present |
 | Univ | `=../2` compose/decompose | `=../2` compose/decompose | Present |
 | Copying | `copy_term/2` with fresh variables and preserved sharing | `copy_term/2` with fresh variables and preserved sharing | Present |
@@ -33,6 +33,7 @@ current cross-target builtin/runtime baseline.
   `findall/3` can collect every unifiable element.
 - `=</2`, `is_list/1`, and `display/1` are now covered by the generated Go
   WAM builtin E2E test.
+- `=/2` and `\=/2` are now covered by the generated Go WAM builtin E2E test.
 - `functor/3`, `arg/3`, `=../2`, and `copy_term/2` are now covered by the
   generated Go WAM builtin E2E test.
 - `aggregate_all(set(X), Goal, Set)` is now covered by the generated Go WAM

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1003,6 +1003,7 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 
 	case "==/2": return valueEquals(vm.deref(arg1), vm.deref(arg2))
 	case "\\==/2": return !valueEquals(vm.deref(arg1), vm.deref(arg2))
+	case "=/2": return vm.Unify(arg1, arg2)
 	case "\\=/2":
 		clone := vm.Clone()
 		return !clone.Unify(arg1, arg2)

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -9,6 +9,7 @@
 :- dynamic user:test_term_builtins/0.
 :- dynamic user:test_member_collect/0.
 :- dynamic user:test_set_aggregate/0.
+:- dynamic user:test_unify_builtin/0.
 
 test(builtins_execution) :-
     get_time(T),
@@ -52,6 +53,11 @@ test(builtins_execution) :-
                 length(S, 2),
                 member(a, S),
                 member(b, S)
+            )),
+          assertz(user:test_unify_builtin :-
+            (   =(f(a, X), f(a, b)),
+                X == b,
+                \+ =(a, b)
             ))
         ),
         run_builtins_test(TmpDir),
@@ -59,11 +65,12 @@ test(builtins_execution) :-
           retractall(user:test_term_builtins),
           retractall(user:test_member_collect),
           retractall(user:test_set_aggregate),
+          retractall(user:test_unify_builtin),
           delete_directory_and_contents(TmpDir) )
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_set_aggregate/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_set_aggregate/0, test_unify_builtin/0],
     Options = [module_name(builtin_test)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -81,6 +88,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "arg/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "=../2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "copy_term/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "=/2"')),
     assertion(sub_string(LibCode, _, _, _, 'AggType: "set"')),
 
     % Add a main.go to run the test in a separate cmd directory
@@ -132,6 +140,14 @@ func main() {
 	} else {
 		fmt.Println("SET_FAILURE")
 	}
+
+	unifyVM := wam.NewWamState(wam.Test_unify_builtinCode, wam.Test_unify_builtinLabels)
+	unifyVM.PC = wam.Test_unify_builtinStartPC
+	if unifyVM.Run() {
+		fmt.Println("UNIFY_SUCCESS")
+	} else {
+		fmt.Println("UNIFY_FAILURE")
+	}
 }
 '),
 
@@ -153,7 +169,8 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "SUCCESS: X=3")),
         assertion(sub_string(FullOutput, _, _, _, "TERM_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "MEMBER_SUCCESS")),
-        assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS"))
+        assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS"))
     ;   format("Go not found, skipping execution test.~n")
     ).
 


### PR DESCRIPTION
Adds explicit Go WAM runtime handling for the `=/2` builtin by routing it through normal WAM unification. This closes the documented Go parity gap where `\=/2` existed but `=/2` did not have a direct builtin handler.

The generated Go builtin E2E now forces an emitted `Op: "=/2"` and verifies both successful structural binding and use under negation with `\+ =(a, b)`.

## Tests

```sh
swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"
```
