### PR TITLE
feat(wam-cpp): format/1 + format/2 + quote-aware WAM-text tokenizer

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -316,10 +316,50 @@ parse_pred_blocks(WamText, Items) :-
     split_string(S, "\n", "", Lines),
     parse_block_lines(Lines, Items).
 
+%% tokenize_wam_line(+Line, -Tokens)
+%  Splits a WAM-text line on whitespace and commas, but respects
+%  single-quoted atom literals so the content (which may contain
+%  spaces, commas, or ~-directives for format strings) becomes a
+%  single token. Surrounding single quotes are stripped from the
+%  resulting token. No escape sequences are recognised inside quotes —
+%  matches the printer''s own non-escaping behaviour.
+tokenize_wam_line(Line, Tokens) :-
+    string_chars(Line, Chars),
+    tokenize_wam_chars(Chars, Tokens).
+
+tokenize_wam_chars([], []).
+tokenize_wam_chars([C|Cs], Tokens) :-
+    (   wam_token_sep(C)
+    ->  tokenize_wam_chars(Cs, Tokens)
+    ;   C == '\''
+    ->  read_quoted_chars(Cs, QChars, Rest),
+        string_chars(Tok, QChars),
+        Tokens = [Tok|More],
+        tokenize_wam_chars(Rest, More)
+    ;   read_unquoted_chars([C|Cs], TChars, Rest),
+        string_chars(Tok, TChars),
+        Tokens = [Tok|More],
+        tokenize_wam_chars(Rest, More)
+    ).
+
+wam_token_sep(' ').
+wam_token_sep('\t').
+wam_token_sep(',').
+
+read_quoted_chars([], [], []).
+read_quoted_chars(['\''|Rest], [], Rest) :- !.
+read_quoted_chars([C|Cs], [C|More], Rest) :-
+    read_quoted_chars(Cs, More, Rest).
+
+read_unquoted_chars([], [], []).
+read_unquoted_chars([C|Cs], [], [C|Cs]) :-
+    wam_token_sep(C), !.
+read_unquoted_chars([C|Cs], [C|More], Rest) :-
+    read_unquoted_chars(Cs, More, Rest).
+
 parse_block_lines([], []).
 parse_block_lines([Line|Rest], Items) :-
-    split_string(Line, " \t,", " \t,", Parts),
-    delete(Parts, "", CleanParts),
+    tokenize_wam_line(Line, CleanParts),
     (   CleanParts == []
     ->  parse_block_lines(Rest, Items)
     ;   CleanParts = [First|_],
@@ -1847,6 +1887,105 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         std::fflush(stdout);
         pc += 1; return true;
     }
+    // ---- format/1, format/2 ----------------------------------------
+    // Walks the format string A1 (Atom), expanding ~-directives.
+    // Supported: ~w (write), ~p (print, same as ~w), ~a (atom),
+    // ~d (integer), ~s (codes/atom), ~n (newline), ~~ (literal ~).
+    // Unsupported directives are echoed verbatim. Args list (A2, for
+    // format/2) is walked left-to-right; running off the end of args
+    // for a directive that needs one fails.
+    if (op == "format/1" || op == "format/2") {
+        Value fv = deref(*get_cell("A1"));
+        std::string fmt;
+        if (fv.tag == Value::Tag::Atom) fmt = fv.s;
+        else if (fv.tag == Value::Tag::Integer) fmt = std::to_string(fv.i);
+        else return false;
+        // Build a vector of arg cells from A2 (for format/2). For
+        // format/1 the list is implicitly empty.
+        std::vector<CellPtr> args;
+        if (op == "format/2") {
+            CellPtr lc = get_cell("A2");
+            for (;;) {
+                Value lv = deref(*lc);
+                if (lv.tag == Value::Tag::Atom && lv.s == "[]") break;
+                if (lv.tag == Value::Tag::Compound && lv.s == "[|]/2"
+                    && lv.args.size() == 2) {
+                    args.push_back(lv.args[0]);
+                    lc = lv.args[1];
+                    continue;
+                }
+                // Malformed args list (partial / unbound tail).
+                return false;
+            }
+        }
+        std::size_t ai = 0;
+        for (std::size_t i = 0; i < fmt.size(); ++i) {
+            char c = fmt[i];
+            if (c != ''~'' || i + 1 >= fmt.size()) {
+                std::fputc(c, stdout);
+                continue;
+            }
+            char d = fmt[++i];
+            switch (d) {
+                case ''n'': std::fputc(''\\n'', stdout); break;
+                case ''t'': std::fputc(''\\t'', stdout); break;
+                case ''~'': std::fputc(''~'', stdout); break;
+                case ''w'':
+                case ''p'': {
+                    if (ai >= args.size()) return false;
+                    std::printf("%s", render(deref(*args[ai++])).c_str());
+                    break;
+                }
+                case ''a'': {
+                    if (ai >= args.size()) return false;
+                    Value v = deref(*args[ai++]);
+                    if (v.tag == Value::Tag::Atom) std::printf("%s", v.s.c_str());
+                    else std::printf("%s", render(v).c_str());
+                    break;
+                }
+                case ''d'': {
+                    if (ai >= args.size()) return false;
+                    Value v = deref(*args[ai++]);
+                    if (v.tag == Value::Tag::Integer) std::printf("%lld",
+                        static_cast<long long>(v.i));
+                    else std::printf("%s", render(v).c_str());
+                    break;
+                }
+                case ''s'': {
+                    // String form: accept an atom (print as-is) or a
+                    // list of integer character codes.
+                    if (ai >= args.size()) return false;
+                    Value v = deref(*args[ai++]);
+                    if (v.tag == Value::Tag::Atom) {
+                        std::printf("%s", v.s.c_str());
+                    } else if (v.tag == Value::Tag::Compound
+                               && v.s == "[|]/2") {
+                        CellPtr lc = args[ai - 1];
+                        for (;;) {
+                            Value lv = deref(*lc);
+                            if (lv.tag == Value::Tag::Atom && lv.s == "[]") break;
+                            if (lv.tag != Value::Tag::Compound || lv.s != "[|]/2"
+                                || lv.args.size() != 2) return false;
+                            Value hv = deref(*lv.args[0]);
+                            if (hv.tag != Value::Tag::Integer) return false;
+                            std::fputc(static_cast<int>(hv.i), stdout);
+                            lc = lv.args[1];
+                        }
+                    } else {
+                        std::printf("%s", render(v).c_str());
+                    }
+                    break;
+                }
+                default:
+                    // Unknown directive: echo literally.
+                    std::fputc(''~'', stdout);
+                    std::fputc(d, stdout);
+                    break;
+            }
+        }
+        std::fflush(stdout);
+        pc += 1; return true;
+    }
 
     return false;
 }
@@ -2124,17 +2263,29 @@ bool WamState::step(const Instruction& instr) {
             if (instr.a == "catch/3") { cp = pc + 1; return execute_catch(); }
             if (instr.a == "throw/1") { cp = pc + 1; return execute_throw(); }
             auto it = labels.find(instr.a);
-            if (it == labels.end()) return false;
-            cp = pc + 1;
-            pc = it->second;
-            return true;
+            if (it != labels.end()) {
+                cp = pc + 1;
+                pc = it->second;
+                return true;
+            }
+            // No user predicate matches: fall back to builtin dispatch.
+            // builtin() advances pc itself on success, mirroring the
+            // BuiltinCall path.
+            return builtin(instr.a, instr.n);
         }
         case Instruction::Op::Execute: {
             if (instr.a == "catch/3") return execute_catch();
             if (instr.a == "throw/1") return execute_throw();
             auto it = labels.find(instr.a);
-            if (it == labels.end()) return false;
-            pc = it->second;
+            if (it != labels.end()) {
+                pc = it->second;
+                return true;
+            }
+            // Fall back to a deterministic builtin, then proceed to cp
+            // since execute is a tail call (no in-body continuation).
+            if (!builtin(instr.a, instr.n)) return false;
+            if (cp == 0) { halt = true; return true; }
+            pc = cp; cp = 0;
             return true;
         }
         case Instruction::Op::CatchReturn: {

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -135,6 +135,23 @@ user:wam_cpp_test_nth0_first           :- nth0(0, [a,b,c], X), X = a.
 user:wam_cpp_test_nth0_middle          :- nth0(1, [a,b,c], X), X = b.
 user:wam_cpp_test_nth0_last            :- nth0(2, [a,b,c], X), X = c.
 
+% format/1 + format/2 fixtures. Each predicate prints something to
+% stdout; the e2e test asserts exact captured output (printed text +
+% the final true/false line).
+:- dynamic user:wam_cpp_test_fmt1_noargs/0.
+:- dynamic user:wam_cpp_test_fmt2_atoms/0.
+:- dynamic user:wam_cpp_test_fmt2_ints/0.
+:- dynamic user:wam_cpp_test_fmt2_compound/0.
+:- dynamic user:wam_cpp_test_fmt2_tilde/0.
+:- dynamic user:wam_cpp_test_fmt2_no_directives/0.
+
+user:wam_cpp_test_fmt1_noargs       :- format('plain text~n').
+user:wam_cpp_test_fmt2_atoms        :- format('a=~w b=~w~n', [hello, world]).
+user:wam_cpp_test_fmt2_ints         :- format('~d + ~d = ~d~n', [1, 2, 3]).
+user:wam_cpp_test_fmt2_compound     :- format('result: ~w~n', [foo(1, bar)]).
+user:wam_cpp_test_fmt2_tilde        :- format('100~~~n', []).
+user:wam_cpp_test_fmt2_no_directives :- format('hello world', []).
+
 % Indexing-instruction fixtures (switch_on_constant / switch_on_term):
 :- dynamic user:wam_cpp_color/1.
 :- dynamic user:wam_cpp_shape/2.
@@ -974,6 +991,74 @@ test(cpp_e2e_nth0, [condition(cpp_compiler_available)]) :-
         delete_directory_and_contents(TmpDir)
     ).
 
+% ------------------------------------------------------------------
+% format/1 + format/2: tilde-directive formatted printing to stdout.
+% Compiled as `execute format/N`, which now falls back to builtin()
+% in step()''s Execute/Call arms when no user label matches. Asserts
+% exact captured stdout to verify directive expansion is correct.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_format_noargs, [condition(cpp_compiler_available)]) :-
+    % format/1 takes only a format string. Exercises the 1-arity
+    % dispatch path (no args list to walk).
+    unique_cpp_tmp_dir('tmp_cpp_e2e_fmt1', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_fmt1_noargs/0,
+                               user:wam_cpp_test_fmt2_no_directives/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_stdout(BinPath, 'wam_cpp_test_fmt1_noargs/0', [],
+                           true, "plain text\n"),
+          run_query_stdout(BinPath, 'wam_cpp_test_fmt2_no_directives/0', [],
+                           true, "hello world")
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_format_atoms_and_ints, [condition(cpp_compiler_available)]) :-
+    % ~w (write) on atoms and ~d (integer) directives.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_fmt2_ai', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_fmt2_atoms/0,
+                               user:wam_cpp_test_fmt2_ints/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_stdout(BinPath, 'wam_cpp_test_fmt2_atoms/0', [],
+                           true, "a=hello b=world\n"),
+          run_query_stdout(BinPath, 'wam_cpp_test_fmt2_ints/0', [],
+                           true, "1 + 2 = 3\n")
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_format_compound, [condition(cpp_compiler_available)]) :-
+    % ~w on a compound term goes through render(), exercising the
+    % full Value printer.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_fmt2_cmpd', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_fmt2_compound/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_stdout(BinPath, 'wam_cpp_test_fmt2_compound/0', [],
+                           true, "result: foo(1, bar)\n")
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_format_tilde_escape, [condition(cpp_compiler_available)]) :-
+    % ~~ emits a literal tilde. The format string ''100~~~n'' contains
+    % "100" + "~~" (literal tilde) + "~n" (newline) = "100~\n".
+    unique_cpp_tmp_dir('tmp_cpp_e2e_fmt2_tilde', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_fmt2_tilde/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_stdout(BinPath, 'wam_cpp_test_fmt2_tilde/0', [],
+                           true, "100~\n")
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
 test(cpp_e2e_switch_on_constant, [condition(cpp_compiler_available)]) :-
     unique_cpp_tmp_dir('tmp_cpp_e2e_swc', TmpDir),
     setup_call_cleanup(
@@ -1051,6 +1136,22 @@ run_query(BinPath, PredKey, Args, Expected) :-
 
 expected_str(true,  "true").
 expected_str(false, "false").
+
+% run_query_stdout(+BinPath, +PredKey, +Args, +Status, +ExpPrintedOut)
+%  Captures full stdout (printed bytes from the predicate body, then
+%  the trailing "true\n"/"false\n" line emitted by main) and asserts
+%  exact equality with ExpPrintedOut ++ Status + "\n".
+run_query_stdout(BinPath, PredKey, Args, Status, ExpPrint) :-
+    maplist(atom_string, Args, ArgStrs),
+    process_create(BinPath, [PredKey|ArgStrs],
+                   [stdout(pipe(Out)), stderr(null), process(PID)]),
+    read_string(Out, _, Output),
+    close(Out),
+    process_wait(PID, _),
+    expected_str(Status, StatusStr),
+    string_concat(ExpPrint, StatusStr, ExpWithStatus),
+    string_concat(ExpWithStatus, "\n", Expected),
+    assertion(Output == Expected).
 
 :- end_tests(wam_cpp_generator).
 


### PR DESCRIPTION
## Summary

Adds `format/1` + `format/2` — the standard Prolog formatted-print builtins. `write/1`, `nl/0` and `writeln/1` were already supported, but `format` is the workhorse and unlocks the most common stdout pattern (`format("~w + ~w = ~w~n", [A, B, C])`).

Three pieces:

### 1. `format/1` + `format/2` builtins

Walk the A1 format-atom char by char. On `~<X>`, expand the directive:

| Directive | Behavior |
|---|---|
| `~w` / `~p` | Write the next arg via `render()` |
| `~a` | Print the next arg as a raw atom (no quotes) |
| `~d` | Print the next arg as a signed integer |
| `~s` | Print as string: atom directly, or list of int codes one char at a time |
| `~n` | Newline |
| `~t` | Tab |
| `~~` | Literal tilde |
| `<other>` | Echoed verbatim (`~X`) |

For `format/2` the A2 args list is walked once before the format loop into a `vector<CellPtr>`; running off the end of args during expansion fails the builtin (matches SWI semantics).

### 2. Execute / Call step arms gain a builtin-fallback path

The SWI WAM compiler emits `execute format/N` (no labels). The prior arms returned `false` on unknown labels; now they fall back to `builtin()` with proper proceed semantics:

- **Call**: `builtin()` advances pc itself, mirroring `BuiltinCall`.
- **Execute**: `builtin()` advances pc, then we override with `pc = cp; cp = 0` (or `halt` if `cp == 0`) since execute is a tail call.

`catch/3` and `throw/1` still get their dedicated handlers. This is a **generalisation** that lets any future builtin emitted via `execute`/`call` (rather than `builtin_call`) just work.

### 3. Quote-aware WAM-text tokenizer

The original tokenizer used `split_string` on `" \t,"`. That worked for everything we'd seen, but format strings exposed the bug:

```
put_constant 'plain text~n', A1
```

split into **four** tokens, the 3-arg pattern didn't match, and the instruction was **silently skipped** — so the format string never made it to the runtime.

`tokenize_wam_line/2` walks the line char-by-char with three states: skip-separator, accumulate-quoted (preserving spaces / commas inside `'...'`), accumulate-unquoted. The closing single quote is consumed and surrounding quotes are stripped, so `'plain text~n'` becomes the single token `"plain text~n"`.

No escape sequences inside quotes — matches the WAM printer's own non-escaping output.

## Tests

- **`run_query_stdout/5`** helper added: captures full process stdout and asserts exact equality with `ExpectedPrint + "true|false\n"`. Distinct from `run_query` which only matches the trailing line via `normalize_space`.

Four new e2e tests adding 6 assertions:

| Test | Coverage |
|---|---|
| `cpp_e2e_format_noargs` | `format/1` + `format/2` with no directives (verifies the no-args dispatch path) |
| `cpp_e2e_format_atoms_and_ints` | `~w` on atoms and `~d` on ints |
| `cpp_e2e_format_compound` | `~w` on a compound term goes through the `Value` renderer (`"foo(1, bar)"`) |
| `cpp_e2e_format_tilde_escape` | `~~` + `~n` round-trip (`"100~\n"`) |

**Total: 62/62 passing** with `swipl 9.0.4` + `g++ 13`.

## Verification

```
$ swipl -g "[tests/test_wam_cpp_generator]" -g "run_tests(wam_cpp_generator)" -t halt
% All 62 tests passed
```

Sample runs:

```
$ ./cpp_test test_fmt2_atoms/0
a=hello b=world
true

$ ./cpp_test test_fmt2_ints/0
1 + 2 = 3
true

$ ./cpp_test test_fmt2_compound/0
result: foo(1, bar)
true
```

## Known limitations

- Numeric prefix specs (`~3d`, `~Nr`) not implemented; spec-with-arg forms (`~e`, `~f`) not implemented either. Easy follow-up since the switch dispatch table is in one place.
- Format strings must be atoms (single-quoted in source). List-of-codes form not yet supported — would require accepting a code-list in A1 alongside the atom form.

## Test plan

- [x] All 58 prior tests still pass (no regression)
- [x] Quote-aware tokenizer doesn't break any existing predicate (verified by suite)
- [x] 4 new e2e tests pass covering 6 dispatch + assertion cases
- [x] `g++ -std=c++17` clean compile
- [x] Generalised Execute/Call fallback is a transparent no-op for predicates that have labels

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_