### PR TITLE
feat(wam-clojure): add term identity builtins

### DIFF
--- a/PR_WAM_CLOJURE_TERM_IDENTITY_BUILTINS.md
+++ b/PR_WAM_CLOJURE_TERM_IDENTITY_BUILTINS.md
@@ -1,0 +1,26 @@
+# PR Title
+
+feat(wam-clojure): add term identity builtins
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM lowered-emitter support for `==/2` and `\==/2`.
+- Adds runtime `term-identical?`, which dereferences terms but never binds.
+- Wires interpreted runtime dispatch for `"==/2"` and `"\\==/2"`.
+- Adds lowered-emitter coverage for both builtins.
+- Adds runtime smoke coverage for atoms, structures, same variable identity, distinct variable non-identity, alias identity, and non-binding failure behavior.
+
+## Scope
+
+This PR implements strict term identity and non-identity only. It does not implement standard term ordering or comparison builtins such as `@</2`, `@=</2`, `@>/2`, or `@>=/2`.
+
+The key semantic distinction from `=/2` and `\=/2` is that `==/2` and `\==/2` inspect current term identity after dereferencing but do not unify or mutate bindings.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -272,6 +272,14 @@ clojure_direct_builtin("\\=/2", "2").
 clojure_direct_builtin("\\=/2", 2).
 clojure_direct_builtin('\\=/2', "2").
 clojure_direct_builtin('\\=/2', 2).
+clojure_direct_builtin("==/2", "2").
+clojure_direct_builtin("==/2", 2).
+clojure_direct_builtin('==/2', "2").
+clojure_direct_builtin('==/2', 2).
+clojure_direct_builtin("\\==/2", "2").
+clojure_direct_builtin("\\==/2", 2).
+clojure_direct_builtin('\\==/2', "2").
+clojure_direct_builtin('\\==/2', 2).
 clojure_direct_builtin("=:=/2", "2").
 clojure_direct_builtin("=:=/2", 2).
 clojure_direct_builtin('=:=/2', "2").
@@ -512,6 +520,20 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     !,
     format(atom(Expr),
            '(let [left (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound) right (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound)] (if (runtime/unifiable? ~w left right) (runtime/backtrack ~w) (runtime/advance ~w)))',
+           [S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "==/2" ; Op == '==/2'),
+    !,
+    format(atom(Expr),
+           '(let [left (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound) right (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound)] (if (runtime/term-identical? ~w left right) (runtime/advance ~w) (runtime/backtrack ~w)))',
+           [S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "\\==/2" ; Op == '\\==/2'),
+    !,
+    format(atom(Expr),
+           '(let [left (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound) right (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound)] (if (runtime/term-identical? ~w left right) (runtime/backtrack ~w) (runtime/advance ~w)))',
            [S, S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -371,6 +371,23 @@
 (defn unifiable? [state left right]
   (first (unify-values state left right)))
 
+(defn term-identical? [state left right]
+  (let [bindings (:bindings state)]
+    (letfn [(identical* [l r]
+              (let [l* (deref-value bindings l)
+                    r* (deref-value bindings r)]
+                (cond
+                  (logic-var? l*) (and (logic-var? r*) (= (:var l*) (:var r*)))
+                  (logic-var? r*) false
+                  (structure-term? l*)
+                  (and (structure-term? r*)
+                       (interned-equal? (:functor l*) (:functor r*))
+                       (= (count (:args l*)) (count (:args r*)))
+                       (every? true? (map identical* (:args l*) (:args r*))))
+                  (structure-term? r*) false
+                  :else (interned-equal? l* r*))))]
+      (identical* left right))))
+
 (defn parse-numeric-atom [text]
   (when (and (string? text)
              (re-matches #"[+-]?(?:\d+(?:\.\d*)?|\.\d+)" text))
@@ -1170,6 +1187,20 @@
           (let [left (or (reg-get-raw state "A1") ::unbound)
                 right (or (reg-get-raw state "A2") ::unbound)]
             (if (unifiable? state left right)
+              (backtrack state)
+              (advance state)))
+
+          "==/2"
+          (let [left (or (reg-get-raw state "A1") ::unbound)
+                right (or (reg-get-raw state "A2") ::unbound)]
+            (if (term-identical? state left right)
+              (advance state)
+              (backtrack state)))
+
+          "\\==/2"
+          (let [left (or (reg-get-raw state "A1") ::unbound)
+                right (or (reg-get-raw state "A2") ::unbound)]
+            (if (term-identical? state left right)
               (backtrack state)
               (advance state)))
 

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -146,6 +146,26 @@ test(simple_builtin_not_unify_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/backtrack")
     )).
 
+test(simple_builtin_identity_is_direct_lowered_in_prefix) :-
+    once((
+        lower_predicate_to_clojure(test_identity/2, [builtin_call('==/2', 2), proceed], [], Code),
+        has(Code, "runtime/reg-get-raw"),
+        has(Code, "\"A1\""),
+        has(Code, "\"A2\""),
+        has(Code, "runtime/term-identical?"),
+        has(Code, "runtime/backtrack")
+    )).
+
+test(simple_builtin_not_identity_is_direct_lowered_in_prefix) :-
+    once((
+        lower_predicate_to_clojure(test_not_identity/2, [builtin_call('\\==/2', 2), proceed], [], Code),
+        has(Code, "runtime/reg-get-raw"),
+        has(Code, "\"A1\""),
+        has(Code, "\"A2\""),
+        has(Code, "runtime/term-identical?"),
+        has(Code, "runtime/backtrack")
+    )).
+
 test(simple_builtin_arithmetic_equal_is_direct_lowered_in_prefix) :-
     once((
         lower_predicate_to_clojure(test_arith_eq/2, [builtin_call('=:=/2', 2), proceed], [], Code),

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -37,6 +37,12 @@
 :- dynamic user:wam_cut_helper/1.
 :- dynamic user:wam_hard_cut_outer_ok/1.
 :- dynamic user:wam_not_b/1.
+:- dynamic user:wam_identity_guard/2.
+:- dynamic user:wam_not_identity_guard/2.
+:- dynamic user:wam_identity_same_unbound/0.
+:- dynamic user:wam_identity_distinct_unbound/0.
+:- dynamic user:wam_identity_after_alias/0.
+:- dynamic user:wam_identity_does_not_bind/0.
 :- dynamic user:wam_fail_after_bind/1.
 :- dynamic user:wam_atom_guard/1.
 :- dynamic user:wam_integer_guard/1.
@@ -140,6 +146,12 @@ user:wam_soft_cut_outer_ok(X) :- (user:wam_soft_cut_helper(Y), X = Y ; X = b).
 user:wam_cut_helper(X) :- X = a, !, fail.
 user:wam_hard_cut_outer_ok(X) :- (user:wam_cut_helper(Y), X = Y ; X = b).
 user:wam_not_b(X) :- X \= b.
+user:wam_identity_guard(A, B) :- A == B.
+user:wam_not_identity_guard(A, B) :- A \== B.
+user:wam_identity_same_unbound :- user:wam_unbound_arg(X), X == X.
+user:wam_identity_distinct_unbound :- user:wam_unbound_arg(X), user:wam_unbound_arg(Y), X == Y.
+user:wam_identity_after_alias :- user:wam_unbound_arg(X), Y = X, X == Y.
+user:wam_identity_does_not_bind :- user:wam_unbound_arg(X), X == a.
 user:wam_fail_after_bind(X) :- X = a, fail.
 user:wam_atom_guard(X) :- atom(X).
 user:wam_integer_guard(X) :- integer(X).
@@ -248,6 +260,12 @@ run_smoke :-
           user:wam_cut_helper/1,
           user:wam_hard_cut_outer_ok/1,
           user:wam_not_b/1,
+          user:wam_identity_guard/2,
+          user:wam_not_identity_guard/2,
+          user:wam_identity_same_unbound/0,
+          user:wam_identity_distinct_unbound/0,
+          user:wam_identity_after_alias/0,
+          user:wam_identity_does_not_bind/0,
           user:wam_fail_after_bind/1,
           user:wam_atom_guard/1,
           user:wam_integer_guard/1,
@@ -329,6 +347,7 @@ run_smoke :-
     assert_lowered_call_emitted(TmpDir),
     assert_lowered_cut_builtin_emitted(TmpDir),
     assert_lowered_not_unify_builtin_emitted(TmpDir),
+    assert_lowered_identity_builtin_emitted(TmpDir),
     assert_lowered_fail_builtin_emitted(TmpDir),
     assert_lowered_atom_builtin_emitted(TmpDir),
     assert_lowered_integer_builtin_emitted(TmpDir),
@@ -408,6 +427,16 @@ smoke_cases([
     case('wam_hard_cut_outer_ok/1', b, "true"),
     case('wam_not_b/1', a, "true"),
     case('wam_not_b/1', b, "false"),
+    case('wam_identity_guard/2', args(a, a), "true"),
+    case('wam_identity_guard/2', args(a, b), "false"),
+    case('wam_identity_guard/2', args('f(a)', 'f(a)'), "true"),
+    case('wam_identity_guard/2', args('f(a)', 'f(b)'), "false"),
+    case('wam_not_identity_guard/2', args(a, a), "false"),
+    case('wam_not_identity_guard/2', args(a, b), "true"),
+    case('wam_identity_same_unbound/0', no_args, "true"),
+    case('wam_identity_distinct_unbound/0', no_args, "false"),
+    case('wam_identity_after_alias/0', no_args, "true"),
+    case('wam_identity_does_not_bind/0', no_args, "false"),
     case('wam_fail_after_bind/1', a, "false"),
     case('wam_fail_after_bind/1', b, "false"),
     case('wam_atom_guard/1', a, "true"),
@@ -580,6 +609,13 @@ assert_lowered_not_unify_builtin_emitted(ProjectDir) :-
     read_file_to_string(CorePath, CoreCode, []),
     has(CoreCode, "defn lowered-wam-not-b-1"),
     has(CoreCode, "runtime/unifiable?").
+
+assert_lowered_identity_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-identity-guard-2"),
+    has(CoreCode, "defn lowered-wam-not-identity-guard-2"),
+    has(CoreCode, "runtime/term-identical?").
 
 assert_lowered_fail_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM lowered-emitter support for `==/2` and `\==/2`.
- Adds runtime `term-identical?`, which dereferences terms but never binds.
- Wires interpreted runtime dispatch for `"==/2"` and `"\\==/2"`.
- Adds lowered-emitter coverage for both builtins.
- Adds runtime smoke coverage for atoms, structures, same variable identity, distinct variable non-identity, alias identity, and non-binding failure behavior.

## Scope

This PR implements strict term identity and non-identity only. It does not implement standard term ordering or comparison builtins such as `@</2`, `@=</2`, `@>/2`, or `@>=/2`.

The key semantic distinction from `=/2` and `\=/2` is that `==/2` and `\==/2` inspect current term identity after dereferencing but do not unify or mutate bindings.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
