### PR TITLE
feat(wam-cpp): succ/2 + between/3 arithmetic builtins

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -655,7 +655,38 @@ helper_predicate_items(Items) :-
         put_value("Y3", "A2"),
         put_value("Y4", "A3"),
         deallocate,
-        execute("nth0/3")
+        execute("nth0/3"),
+        % --- between/3 ---------------------------------------------------
+        % between(L, H, L) :- L =< H.
+        % between(L, H, X) :- L < H, L1 is L + 1, between(L1, H, X).
+        label("between/3"),
+        try_me_else("L_cpp_between_3_2"),
+        get_variable("X1", "A1"),
+        get_variable("X2", "A2"),
+        get_value("X1", "A3"),
+        put_value("X1", "A1"),
+        put_value("X2", "A2"),
+        builtin_call("=</2", "2"),
+        proceed,
+        label("L_cpp_between_3_2"),
+        trust_me,
+        allocate,
+        get_variable("Y1", "A1"),
+        get_variable("Y3", "A2"),
+        get_variable("Y4", "A3"),
+        put_value("Y1", "A1"),
+        put_value("Y3", "A2"),
+        builtin_call("</2", "2"),
+        put_variable("Y2", "A1"),
+        put_structure("+/2", "A2"),
+        set_value("Y1"),
+        set_constant("1"),
+        builtin_call("is/2", "2"),
+        put_value("Y2", "A1"),
+        put_value("Y3", "A2"),
+        put_value("Y4", "A3"),
+        deallocate,
+        execute("between/3")
     ].
 
 flatten_blocks([], []).
@@ -1653,6 +1684,37 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         CellPtr copy = rec(get_cell("A1"));
         if (!unify_cells(get_cell("A2"), copy)) return false;
         pc += 1; return true;
+    }
+
+    // ---- succ/2 ----------------------------------------------------
+    // succ(X, Y): Y is X + 1. Bidirectional — if X is a non-negative
+    // integer, derive Y; if Y is a positive integer, derive X. Fails
+    // if X < 0 or Y <= 0 or both args unbound (ISO would throw
+    // instantiation_error in the both-unbound case; v1 just fails).
+    if (op == "succ/2") {
+        Value a = deref(*get_cell("A1"));
+        Value b = deref(*get_cell("A2"));
+        if (a.tag == Value::Tag::Integer) {
+            if (a.i < 0) return false;
+            long long next = a.i + 1;
+            if (b.tag == Value::Tag::Integer) {
+                if (b.i != next) return false;
+                pc += 1; return true;
+            }
+            if (!unify_cells(get_cell("A2"),
+                             std::make_shared<Cell>(Value::Integer(next))))
+                return false;
+            pc += 1; return true;
+        }
+        if (b.tag == Value::Tag::Integer) {
+            if (b.i <= 0) return false;
+            long long prev = b.i - 1;
+            if (!unify_cells(get_cell("A1"),
+                             std::make_shared<Cell>(Value::Integer(prev))))
+                return false;
+            pc += 1; return true;
+        }
+        return false;
     }
     // ---- \\=/2 (cannot unify) --------------------------------------
     if (op == "\\\\=/2") {

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -152,6 +152,28 @@ user:wam_cpp_test_fmt2_compound     :- format('result: ~w~n', [foo(1, bar)]).
 user:wam_cpp_test_fmt2_tilde        :- format('100~~~n', []).
 user:wam_cpp_test_fmt2_no_directives :- format('hello world', []).
 
+% succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
+% between is helper-injected and exercises the nondet path via findall.
+:- dynamic user:wam_cpp_test_succ_fwd/0.
+:- dynamic user:wam_cpp_test_succ_bwd/0.
+:- dynamic user:wam_cpp_test_succ_zero/0.
+:- dynamic user:wam_cpp_test_succ_neg_fail/0.
+:- dynamic user:wam_cpp_test_succ_y_zero_fail/0.
+:- dynamic user:wam_cpp_test_between_first/0.
+:- dynamic user:wam_cpp_test_between_enum/0.
+:- dynamic user:wam_cpp_test_between_singleton/0.
+:- dynamic user:wam_cpp_test_between_empty/0.
+
+user:wam_cpp_test_succ_fwd          :- succ(3, X), X = 4.
+user:wam_cpp_test_succ_bwd          :- succ(X, 4), X = 3.
+user:wam_cpp_test_succ_zero         :- succ(0, X), X = 1.
+user:wam_cpp_test_succ_neg_fail     :- succ(-1, _).
+user:wam_cpp_test_succ_y_zero_fail  :- succ(_, 0).
+user:wam_cpp_test_between_first     :- between(1, 5, X), X = 1.
+user:wam_cpp_test_between_enum      :- findall(X, between(1, 3, X), L), L = [1, 2, 3].
+user:wam_cpp_test_between_singleton :- findall(X, between(5, 5, X), L), L = [5].
+user:wam_cpp_test_between_empty     :- findall(X, between(5, 3, X), L), L = [].
+
 % Indexing-instruction fixtures (switch_on_constant / switch_on_term):
 :- dynamic user:wam_cpp_color/1.
 :- dynamic user:wam_cpp_shape/2.
@@ -1055,6 +1077,50 @@ test(cpp_e2e_format_tilde_escape, [condition(cpp_compiler_available)]) :-
         ( build_e2e_binary(TmpDir, BinPath),
           run_query_stdout(BinPath, 'wam_cpp_test_fmt2_tilde/0', [],
                            true, "100~\n")
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% Arithmetic builtins: succ/2 (direct bidirectional) and between/3
+% (helper-injected, nondet via the standard two-clause definition).
+% ------------------------------------------------------------------
+
+test(cpp_e2e_succ, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_succ', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_succ_fwd/0,
+                               user:wam_cpp_test_succ_bwd/0,
+                               user:wam_cpp_test_succ_zero/0,
+                               user:wam_cpp_test_succ_neg_fail/0,
+                               user:wam_cpp_test_succ_y_zero_fail/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_succ_fwd/0',         [], true),
+          run_query(BinPath, 'wam_cpp_test_succ_bwd/0',         [], true),
+          run_query(BinPath, 'wam_cpp_test_succ_zero/0',        [], true),
+          % succ(-1, _) and succ(_, 0) both fail per ISO domain.
+          run_query(BinPath, 'wam_cpp_test_succ_neg_fail/0',    [], false),
+          run_query(BinPath, 'wam_cpp_test_succ_y_zero_fail/0', [], false)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_between, [condition(cpp_compiler_available)]) :-
+    % between/3 is helper-injected. The enum case exercises the full
+    % nondet path: findall drives backtracking through both clauses.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_between', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_between_first/0,
+                               user:wam_cpp_test_between_enum/0,
+                               user:wam_cpp_test_between_singleton/0,
+                               user:wam_cpp_test_between_empty/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_between_first/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_between_enum/0',      [], true),
+          run_query(BinPath, 'wam_cpp_test_between_singleton/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_between_empty/0',     [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Adds two more standard library predicates from the parity list. Different mechanisms for each:

### `succ/2` — direct bidirectional builtin

`Y is X + 1` with either argument bindable:
- Bound-X path requires `X >= 0`.
- Bound-Y path requires `Y > 0`.
- Both-unbound fails (ISO would throw `instantiation_error`; v1 just fails — would land naturally with the ISO-errors PR).

### `between/3` — helper-injected, nondet via two-clause definition

```prolog
between(L, H, L) :- L =< H.
between(L, H, X) :- L < H, L1 is L + 1, between(L1, H, X).
```

The recursive form uses Y-register locals and three `builtin_call`s (`=</2`, `</2`, `is/2`) — verifies the helper-injection mechanism continues to interoperate with arithmetic builtins (same pattern as `nth0/3` from the prior batch).

## Tests

Two new e2e blocks adding 9 assertions on top of the previous 62:

### `cpp_e2e_succ`

| Case | Expected |
|---|---|
| `succ(3, X)` | `X = 4` |
| `succ(X, 4)` | `X = 3` |
| `succ(0, X)` | `X = 1` (zero edge) |
| `succ(-1, _)` | `false` (negative-X domain check) |
| `succ(_, 0)` | `false` (Y must be positive) |

### `cpp_e2e_between`

| Case | Expected |
|---|---|
| `between(1, 5, X), X = 1` | `true` (first solution) |
| `findall(X, between(1, 3, X), L), L = [1,2,3]` | `true` (nondet enum) |
| `between(5, 5, X)` enum → `[5]` | `true` (singleton range) |
| `between(5, 3, X)` enum → `[]` | `true` (empty range — first clause's `=<` check fails, no recursion) |

**Total: 64/64 passing** with `swipl 9.0.4` + `g++ 13`.

## Verification

```
$ swipl -g "[tests/test_wam_cpp_generator]" -g "run_tests(wam_cpp_generator)" -t halt
% All 64 tests passed
```

Sample queries:

```
$ ./cpp_test test_succ_fwd/0          → true   # succ(3, X), X=4
$ ./cpp_test test_succ_bwd/0          → true   # succ(X, 4), X=3
$ ./cpp_test test_between_enum/0      → true   # findall→[1,2,3] via between
$ ./cpp_test test_between_empty/0     → true   # between(5,3,X) enum → []
```

## Test plan

- [x] All 62 prior tests still pass (no regression)
- [x] 2 new e2e tests pass covering 9 dispatch cases
- [x] `g++ -std=c++17` clean compile
- [x] `between/3` exercises nondet enumeration via `findall` (the choice-point path)
- [ ] Follow-up: ISO error terms remain — `succ` with both-unbound and out-of-domain inputs should ideally throw rather than fail.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_