### PR TITLE
docs(wam-cpp): ISO error terms — philosophy + specification

### DIFF
--- a/docs/design/WAM_CPP_ISO_ERRORS_PHILOSOPHY.md
+++ b/docs/design/WAM_CPP_ISO_ERRORS_PHILOSOPHY.md
@@ -1,0 +1,256 @@
+# WAM C++: ISO Error Terms — Philosophy
+
+How the C++ WAM target should report runtime errors to user Prolog
+code. Discusses the alternatives we considered, why we picked
+compile-time per-predicate dispatch over runtime flags, and how the
+config format choice falls out of "this is a Prolog codebase
+configuring Prolog predicates."
+
+Companion docs:
+- `WAM_CPP_ISO_ERRORS_SPECIFICATION.md` — the concrete shape we ship.
+
+## 1. What ISO errors are
+
+Standard Prolog (ISO/IEC 13211-1) specifies that certain builtins
+**throw** rather than fail when given malformed arguments:
+
+```prolog
+?- X is foo.        % type_error(evaluable, foo/0)
+?- X is _.          % instantiation_error
+?- succ(-1, _).     % type_error(not_less_than_zero, -1)
+?- atom_length(X, _). % instantiation_error
+```
+
+The thrown term has the structure `error(ErrorType, Context)` where
+`ErrorType` is one of a fixed set (`type_error/2`,
+`instantiation_error`, `domain_error/2`, `existence_error/2`,
+`permission_error/3`, `evaluation_error/1`, ...) and `Context` is
+implementation-defined.
+
+The catch/3 + throw/1 infrastructure landed earlier already makes the
+matching side work — user code can write
+`catch(Goal, error(type_error(_, _), _), Handler)` today. **What's
+missing is the builtins themselves throwing structured errors instead
+of just failing.**
+
+## 2. Why this is more configurable than it looks
+
+The naive framing — "add ISO errors everywhere" — assumes a single
+mode for the whole program. Two reasons that's wrong.
+
+**Compatibility with existing code.** Pre-existing Prolog code may
+rely on failure semantics for control flow:
+
+```prolog
+% Common pre-ISO idiom: try to compute, fall back if fails.
+safe_div(_, 0, fallback) :- !.
+safe_div(X, Y, R) :- R is X / Y.   % might throw under ISO
+```
+
+The first clause's cut handles the divide-by-zero case in pre-ISO
+mode but is bypassed if `is/2` throws. Code like this exists in real
+codebases; we don't want to break it.
+
+**Performance.** The user raised this concern in review. The short
+answer: for the builtins we ship today (`is/2`, arith compares,
+`succ/2`) ISO errors are essentially free on the happy path because
+the validating check already exists — only the *action* on the
+failed check changes:
+
+```cpp
+// Today
+if (!ok) return false;
+
+// ISO
+if (!ok) { throw_iso_error("type_error", ...); return false; }
+```
+
+The branch existed already; the body of the false-branch grows. Happy
+path: byte-identical.
+
+The longer answer: this **isn't true in general**. A future
+`atom_length/2` or `functor/3` implemented lazily (returns false on
+non-atom args without an explicit check) would need a new validating
+check to throw the ISO-mandated `type_error`. There the ISO version
+*does* have a hot-path cost the lax version avoids. So we want a
+mechanism that lets each predicate's call sites decide.
+
+## 3. Three knob layouts we considered
+
+### 3.1 Compile-time global flag (rejected)
+
+```prolog
+write_wam_cpp_project(Preds, [iso_errors(true)], Dir).
+```
+
+Generator emits `#define WAM_CPP_ISO_ERRORS 1`; runtime uses `#if` to
+choose throw vs fail. Zero per-op cost when off.
+
+Rejected because it can't express "ISO mode on for new code, lax for
+legacy module X." That's the realistic migration story.
+
+### 3.2 Runtime VM flag (rejected)
+
+```cpp
+struct WamState { bool iso_errors_enabled = false; ... };
+// every error site:
+if (vm.iso_errors_enabled) throw_iso_error(...);
+else return false;
+```
+
+Flexible, dynamic, but adds one branch per error site (even if
+predictable). The bigger issue: it's still a *global* knob — there's
+no way to scope it to a single predicate without a save/restore stack
+on every call, which gets expensive.
+
+### 3.3 Compile-time per-predicate via distinct builtin keys (chosen)
+
+The generator already knows which predicate each instruction belongs
+to. Instead of emitting `builtin_call is/2`, it emits either:
+
+```
+builtin_call is_iso/2, 2
+```
+
+or
+
+```
+builtin_call is/2, 2
+```
+
+per call site, driven by the surrounding predicate's mode. The
+runtime registers both flavors as separate builtins:
+
+```cpp
+if (op == "is/2") {
+    // lax: return false on bad eval
+}
+if (op == "is_iso/2") {
+    // strict: build error term and throw
+}
+```
+
+**Properties:**
+
+- **Zero cost on the happy path**, either flavor. The builtins are
+  separate functions; the dispatch is the same single `if` chain it
+  was before. ISO mode literally just sends you to a different
+  function.
+- **Per-predicate granularity**: each `is/2` call site picks its
+  flavor independently. Module A can be ISO-strict, module B lax,
+  they coexist in one binary with no global state.
+- **No runtime overhead**: the choice was made at compile time;
+  nothing to check.
+- **No coupling between predicates**: changing `pred_a/2`'s ISO mode
+  doesn't affect `pred_b/2` even when both call the same `is/2`.
+
+The cost is some generator complexity (the per-call-site rewrite) and
+some runtime code duplication (two flavors per ISO-relevant builtin).
+Both are contained and easy to reason about.
+
+## 4. Why a config file
+
+Two-level configuration — global default + per-predicate override —
+needs to live somewhere. Options:
+
+### Inline as compile options
+
+```prolog
+write_wam_cpp_project(Preds, [
+    iso_errors(true),
+    iso_errors(legacy_lookup/3, false),
+    iso_errors(unsafe_div/3, false)
+], Dir).
+```
+
+Works for small projects, gets unwieldy past a few overrides, and
+mixes "what predicates" with "how to compile them" in the call site.
+
+### A config file
+
+```prolog
+% iso_errors_config.pl
+:- iso_errors_default(true).
+:- iso_errors_override(legacy_lookup/3, false).
+:- iso_errors_override(unsafe_div/3, false).
+```
+
+```prolog
+write_wam_cpp_project(Preds, [
+    iso_errors_config('iso_errors.pl')
+], Dir).
+```
+
+Scales to dozens of overrides. Lives alongside the code, version-
+controlled, reviewable. The compile-options form stays available as a
+shorthand for one-off cases (and is the underlying mechanism — the
+config file expands into the same option terms).
+
+## 5. Config format: Prolog vs JSON vs YAML
+
+We picked Prolog. Three reasons.
+
+**Native syntax for predicate indicators.** `foo/2` is a first-class
+Prolog term. In JSON it becomes a string `"foo/2"` that needs
+parsing. In YAML, same. Prolog's compound-term syntax handles this
+natively.
+
+**Trivial to load.** A Prolog config is just `consult/1` — no parser
+to write or maintain. JSON would pull in a JSON library; YAML's
+worse.
+
+**Idiomatic for the codebase.** Everything else in UnifyWeaver is
+Prolog source. A Prolog config means contributors don't need to
+context-switch.
+
+**Counter-arguments considered:**
+
+- JSON is more familiar across teams. True, but the contributors to
+  this codebase already write Prolog daily.
+- JSON enables tooling integration. True for CI/CD, but the use
+  case here is dev-time config read by the Prolog generator — not
+  shipped to other systems.
+- A config could need richer structure (lists, conditional rules)
+  someday. Prolog handles all of those natively; JSON would force
+  ad-hoc schema design.
+
+## 6. Default value
+
+**Default off (lax).** Reasoning:
+
+- Existing tests rely on failure semantics in places. Flipping the
+  default to ISO would break them en masse. Easier to opt-in
+  per-predicate or per-project than to opt-out everywhere.
+- ISO-strict is the *long-term* desired state for new code, but new
+  code can explicitly request it via the config. Legacy code stays
+  working without modification.
+- The default can flip later without further design work — that's
+  just a one-line change in the config defaults once enough of the
+  ecosystem is ISO-clean.
+
+## 7. What's intentionally out of scope
+
+- **Runtime mode switching.** The mode is fixed at compile time. No
+  `set_prolog_flag(iso, true)` equivalent.
+- **Wildcard / module-level rules.** Overrides are per
+  predicate-indicator. If a module wants all its predicates ISO, it
+  lists them. We can add wildcards (`module:*` or `*/*`) later
+  without breaking the per-predicate form.
+- **Builtins not currently shipped.** `atom_length/2`, `functor/3`,
+  `arg/3`, etc. would need their own audit when added — see the
+  perf discussion in §2.
+
+## 8. Open questions
+
+These are flagged for review during the implementation PR, not now.
+
+- **Which `ErrorType` for divide-by-zero?** ISO says
+  `evaluation_error(zero_divisor)`. Our runtime currently fails
+  silently; the implementation should match ISO's choice here.
+- **Should the `Context` part of `error(_, Context)` carry the call
+  site?** ISO lets it be implementation-defined. A minimal version
+  is just `Context = _` (unbound). A more useful version stores
+  e.g. the predicate indicator that threw. Open.
+- **Migration tooling.** Should we ship a `--iso-audit` switch that
+  reports which existing predicates would change behavior under ISO?
+  Probably not in the first PR.

--- a/docs/design/WAM_CPP_ISO_ERRORS_PHILOSOPHY.md
+++ b/docs/design/WAM_CPP_ISO_ERRORS_PHILOSOPHY.md
@@ -106,47 +106,61 @@ on every call, which gets expensive.
 ### 3.3 Compile-time per-predicate via distinct builtin keys (chosen)
 
 The generator already knows which predicate each instruction belongs
-to. Instead of emitting `builtin_call is/2`, it emits either:
+to. We register **three** flavors of each ISO-relevant builtin:
+
+| Form | Key | Behavior | Who writes it |
+|---|---|---|---|
+| Default | `is/2` | Resolves to lax or ISO at generator time based on the surrounding predicate's mode | The user writes `X is Expr`; the WAM compiler emits `builtin_call is/2` |
+| Explicit ISO | `is_iso/2` | Always throws ISO errors | The user writes `is_iso(X, Expr)` directly |
+| Explicit lax | `is_lax/2` | Always fails silently | The user writes `is_lax(X, Expr)` directly |
+
+Per-predicate dispatch only rewrites the **default** form. Explicit
+`is_iso/2` and `is_lax/2` call sites are never rewritten — they say
+what they mean and survive a mode flip on the enclosing predicate.
+This is what the user feedback asked for: "declaring a predicate ISO
+should mean the default versions in its clauses use ISO, unless we
+specify them explicitly as lax."
+
+**Concrete example.** A predicate annotated ISO with a mix of forms:
+
+```prolog
+:- iso_errors_override(my_calc/2, true).
+
+my_calc(X, R) :-
+    R1 is X + 1,           % default → rewrites to is_iso/2
+    R2 is_lax R1 * 2,      % explicit lax — stays lax
+    R is_iso R2 - 0.       % explicit ISO — stays ISO (redundant but legal).
+```
+
+After the generator pass, the WAM call sites emit:
 
 ```
-builtin_call is_iso/2, 2
-```
-
-or
-
-```
-builtin_call is/2, 2
-```
-
-per call site, driven by the surrounding predicate's mode. The
-runtime registers both flavors as separate builtins:
-
-```cpp
-if (op == "is/2") {
-    // lax: return false on bad eval
-}
-if (op == "is_iso/2") {
-    // strict: build error term and throw
-}
+builtin_call is_iso/2, 2    % rewritten from is/2
+builtin_call is_lax/2, 2    % unchanged
+builtin_call is_iso/2, 2    % unchanged
 ```
 
 **Properties:**
 
-- **Zero cost on the happy path**, either flavor. The builtins are
-  separate functions; the dispatch is the same single `if` chain it
-  was before. ISO mode literally just sends you to a different
+- **Zero cost on the happy path**, all three flavors. They are
+  separate functions; dispatch is the same single `if` chain it was
+  before. Mode choice literally just sends you to a different
   function.
-- **Per-predicate granularity**: each `is/2` call site picks its
+- **Per-predicate granularity**: each default call site picks its
   flavor independently. Module A can be ISO-strict, module B lax,
   they coexist in one binary with no global state.
 - **No runtime overhead**: the choice was made at compile time;
   nothing to check.
+- **Explicit overrides survive**: a developer who wants
+  belt-and-suspenders behavior writes `is_iso/2` directly and the
+  generator doesn't second-guess them.
 - **No coupling between predicates**: changing `pred_a/2`'s ISO mode
-  doesn't affect `pred_b/2` even when both call the same `is/2`.
+  doesn't affect `pred_b/2` even when both call `is/2`.
 
 The cost is some generator complexity (the per-call-site rewrite) and
-some runtime code duplication (two flavors per ISO-relevant builtin).
-Both are contained and easy to reason about.
+some runtime code duplication (three flavors per ISO-relevant
+builtin, though lax and default can share a function body). Both are
+contained and easy to reason about.
 
 ## 4. Why a config file
 
@@ -239,18 +253,102 @@ context-switch.
 - **Builtins not currently shipped.** `atom_length/2`, `functor/3`,
   `arg/3`, etc. would need their own audit when added — see the
   perf discussion in §2.
+- **Auto-fixing legacy code.** The audit tool (§9) reports; it
+  doesn't rewrite. Migration is opt-in per predicate by editing the
+  config.
 
-## 8. Open questions
+## 8. Divide-by-zero: throw, NaN, or both?
 
-These are flagged for review during the implementation PR, not now.
+Worth its own section because the user flagged that "for numbers,
+divide-by-zero should give NaN, which has rules in various
+programming languages." This is a real tension between ISO Prolog
+and floating-point conventions.
 
-- **Which `ErrorType` for divide-by-zero?** ISO says
-  `evaluation_error(zero_divisor)`. Our runtime currently fails
-  silently; the implementation should match ISO's choice here.
+**ISO Prolog says:**
+
+- `1 // 0` (integer division) → throw
+  `evaluation_error(zero_divisor)`.
+- `1 / 0`  (general division) → throw
+  `evaluation_error(zero_divisor)`.
+- IEEE 754 says floats divide to ±∞ or NaN; ISO predates wide IEEE
+  adoption and chose throw uniformly.
+
+**Languages we might compare to:**
+
+- C / C++: integer `1/0` is undefined behavior; float `1.0/0.0` is
+  `inf` (no exception).
+- JavaScript / Lua: `1/0` is `Infinity`, `0/0` is `NaN`. No
+  exceptions.
+- Python: integer `1//0` throws `ZeroDivisionError`; float `1.0/0.0`
+  *also* throws (Python doesn't follow IEEE here).
+- Haskell: integer throws; `Float`/`Double` divide produces `Infinity`
+  or `NaN`.
+
+**Our position:** ISO-mode follows ISO (throws for both). Lax-mode
+follows IEEE 754: integer divide-by-zero fails silently (preserves
+current behavior); float divide produces `inf` or `nan` and succeeds.
+This makes the choice consistent with the three-form design — if you
+want NaN/inf semantics, write `is_lax/2` (or have your predicate in
+lax mode); if you want exception semantics, write `is_iso/2` (or have
+it in ISO mode).
+
+Concrete behavior table:
+
+| Expression | Lax / Default(lax) | ISO / Default(iso) |
+|---|---|---|
+| `X is 1 // 0` | `false` (fail) | throw `evaluation_error(zero_divisor)` |
+| `X is 1 / 0` | `false` (fail) | throw `evaluation_error(zero_divisor)` |
+| `X is 1.0 / 0.0` | `X = inf` | throw `evaluation_error(zero_divisor)` |
+| `X is 0.0 / 0.0` | `X = nan` | throw `evaluation_error(zero_divisor)` |
+| `X is -1.0 / 0.0` | `X = -inf` | throw `evaluation_error(zero_divisor)` |
+
+The lax behavior change (currently divide-by-zero fails uniformly;
+proposed lax behavior: only integer fails, float produces
+inf/nan) is a small breaking change worth flagging. It comes online
+with the implementation, not the docs.
+
+## 9. Audit tooling
+
+User feedback called this out as a good idea; moving it from
+"probably not" into the plan.
+
+Ship a `wam_cpp_iso_audit/2` predicate alongside the rewrite. Given
+a predicate list and a config, it walks each predicate's compiled
+WAM and reports:
+
+- Which `builtin_call` sites would resolve to ISO vs lax under the
+  current config.
+- Which sites would change behavior if the predicate's mode flipped.
+- Which sites use explicit `is_iso/2` or `is_lax/2` overrides (so
+  reviewers know mode-flips won't touch them).
+
+Output is a Prolog list of records, e.g.:
+
+```prolog
+[ audit(my_calc/2, [
+      site(pc=12, lax_key=is/2, iso_key=is_iso/2,
+           resolved=is_iso/2, source=default,
+           would_change_under_lax=true),
+      site(pc=18, lax_key=is_lax/2, iso_key=is_lax/2,
+           resolved=is_lax/2, source=explicit_lax,
+           would_change_under_lax=false)
+  ])
+]
+```
+
+A pretty-printer renders this as a human-readable table for command-
+line use. The audit is read-only; it doesn't modify the generator
+state. Useful as both a migration aid and a sanity check on the
+config file.
+
+## 10. Other open questions
+
+Flagged for review during the implementation PR, not now.
+
 - **Should the `Context` part of `error(_, Context)` carry the call
   site?** ISO lets it be implementation-defined. A minimal version
   is just `Context = _` (unbound). A more useful version stores
   e.g. the predicate indicator that threw. Open.
-- **Migration tooling.** Should we ship a `--iso-audit` switch that
-  reports which existing predicates would change behavior under ISO?
-  Probably not in the first PR.
+- **Module-qualified config rules.** Bare `Name/Arity` matches in
+  any module today; multi-module projects may want explicit module
+  scoping. Revisit when those land.

--- a/docs/design/WAM_CPP_ISO_ERRORS_SPECIFICATION.md
+++ b/docs/design/WAM_CPP_ISO_ERRORS_SPECIFICATION.md
@@ -98,34 +98,64 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
 ```
 
 `iso_errors_rewrite/4` walks the items for one predicate and rewrites
-`builtin_call(Key, N)` lines according to the predicate's mode:
+**only the default-form** `builtin_call(Key, N)` lines according to
+the predicate's mode. Explicit `_iso`/`_lax` keys are passed through
+unchanged.
 
 ```prolog
 iso_errors_rewrite(IsoConfig, PI, Items0, Items) :-
     iso_errors_mode_for(IsoConfig, PI, Mode),
     maplist(iso_errors_rewrite_item(Mode), Items0, Items).
 
-iso_errors_rewrite_item(true,  builtin_call(Key, N), builtin_call(IsoKey, N)) :-
-    iso_errors_swap_key(Key, IsoKey), !.
+% Only the default form gets rewritten. Explicit _iso / _lax keys
+% survive untouched — that''s the three-forms guarantee from the
+% philosophy doc §3.3.
+iso_errors_rewrite_item(true,  builtin_call(Key, N),
+                        builtin_call(IsoKey, N)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(false, builtin_call(Key, N),
+                        builtin_call(LaxKey, N)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
 iso_errors_rewrite_item(_, Item, Item).
 ```
 
-`iso_errors_swap_key/2` is a simple lookup table:
+### 3.1 The three-form key tables
 
-| Lax key | ISO key |
-|---|---|
-| `is/2` | `is_iso/2` |
-| `>/2` | `>_iso/2` |
-| `</2` | `<_iso/2` |
-| `>=/2` | `>=_iso/2` |
-| `=</2` | `=<_iso/2` |
-| `=:=/2` | `=:=_iso/2` |
-| `=\\=/2` | `=\\=_iso/2` |
-| `succ/2` | `succ_iso/2` |
+There are two lookup tables, both registered as deterministic facts.
+The default → iso table fires in ISO-mode predicates; the default →
+lax table is a no-op for now (default and lax share the same key)
+but is kept for symmetry and future use.
+
+| Default key | ISO key | Lax key |
+|---|---|---|
+| `is/2` | `is_iso/2` | `is_lax/2` |
+| `>/2` | `>_iso/2` | `>_lax/2` |
+| `</2` | `<_iso/2` | `<_lax/2` |
+| `>=/2` | `>=_iso/2` | `>=_lax/2` |
+| `=</2` | `=<_iso/2` | `=<_lax/2` |
+| `=:=/2` | `=:=_iso/2` | `=:=_lax/2` |
+| `=\\=/2` | `=\\=_iso/2` | `=\\=_lax/2` |
+| `succ/2` | `succ_iso/2` | `succ_lax/2` |
 
 (Operator-name keys with `/2` suffix follow the existing convention.
-Builtins not in the table are left unchanged — they're considered
+Builtins not in either table are left unchanged — they're considered
 ISO-equivalent or not yet audited.)
+
+### 3.2 Default vs lax — share implementation, separate keys
+
+For each entry in the tables, the runtime registers **three** branches.
+`is/2` and `is_lax/2` execute the same body; `is_iso/2` has its own.
+This keeps the explicit-lax form available to user code without
+introducing a runtime mode register.
+
+```cpp
+if (op == "is/2" || op == "is_lax/2") {
+    // Shared lax body. One implementation, two dispatch keys.
+}
+if (op == "is_iso/2") {
+    // ISO body. Throws on bad eval.
+}
+```
 
 ## 4. Runtime registrations
 
@@ -188,14 +218,15 @@ correctness issue.
 
 ## 6. Error-term shapes
 
-These are the structures `throw_iso_error` builds for the v1
+These are the structures `throw_iso_error` builds for the v1 ISO
 builtins. The list will grow as more builtins are audited.
 
 | Builtin | Trigger | Thrown term |
 |---|---|---|
 | `is_iso/2` | RHS contains unbound | `error(instantiation_error, _)` |
 | `is_iso/2` | RHS non-evaluable atom `foo` | `error(type_error(evaluable, foo/0), _)` |
-| `is_iso/2` | Divide by zero | `error(evaluation_error(zero_divisor), _)` |
+| `is_iso/2` | Integer divide by zero | `error(evaluation_error(zero_divisor), _)` |
+| `is_iso/2` | Float divide by zero | `error(evaluation_error(zero_divisor), _)` |
 | `>_iso/2` etc. | Either arg unbound | `error(instantiation_error, _)` |
 | `>_iso/2` etc. | Either arg non-evaluable | `error(type_error(evaluable, X/N), _)` |
 | `succ_iso/2` | Both args unbound | `error(instantiation_error, _)` |
@@ -205,35 +236,121 @@ builtins. The list will grow as more builtins are audited.
 (Atom-form predicate indicators are constructed as `Atom/Arity`
 compound terms, matching ISO's recommendation.)
 
+### 6.1 Lax behavior — IEEE 754 for floats
+
+Lax / default-lax keys follow IEEE 754 float semantics rather than
+the uniform-fail behavior the runtime ships today. See
+`WAM_CPP_ISO_ERRORS_PHILOSOPHY.md` §8 for the comparison-language
+rationale.
+
+| Expression | Lax behavior |
+|---|---|
+| `X is 1 // 0` | `false` (fail) — integer divide stays uniform-fail |
+| `X is 1 / 0` | `false` (fail) — `/` is integer when both args are integer |
+| `X is 1.0 / 0.0` | `X = inf` (Value::Float with `+inf`) |
+| `X is 0.0 / 0.0` | `X = nan` |
+| `X is -1.0 / 0.0` | `X = -inf` |
+
+This is a small breaking change to the existing lax behavior
+(today: float `1.0/0.0` also fails). The implementation PR documents
+the change in its release notes.
+
 ## 7. Migration path
 
 For each existing ISO-relevant builtin:
 
 1. Decide what the ISO error should be (see §6).
 2. Add an `if (op == "<key>_iso/N")` branch alongside the existing
-   lax `if (op == "<key>/N")`.
-3. Add the key to `iso_errors_swap_key/2`.
+   lax `if (op == "<key>/N")`. The lax branch also matches
+   `<key>_lax/N` so the explicit-lax form is callable from user
+   code.
+3. Add the keys to `iso_errors_default_to_iso/2` and
+   `iso_errors_default_to_lax/2`.
 4. Add e2e tests that:
    - Verify lax behavior is unchanged (existing tests, no edits).
    - Verify ISO behavior with `catch(Goal, error(Pattern, _), ...)`.
+   - Verify explicit `_lax` and `_iso` forms work from user source
+     (call site bypasses the rewrite).
 
-The same pattern applies when adding a new builtin: ship both
-flavors from the start, or document that the lax flavor is the only
-one and gets the lax key.
+The same pattern applies when adding a new builtin: ship all three
+forms from the start, or document that the lax flavor is the only
+one (in which case the default key and the lax key alias to the
+same body and no `_iso` form exists yet).
+
+## 7.1 Audit tooling
+
+`wam_cpp_iso_audit/2` is a read-only generator pass that mirrors
+the rewrite without actually emitting code. Useful for migration
+review and for verifying the config does what's intended.
+
+```prolog
+%% wam_cpp_iso_audit(+Predicates, +Options, -Audit)
+%
+%  For each predicate in Predicates, walk its compiled WAM and
+%  report each builtin_call site''s key resolution. Options accepts
+%  the same iso_errors_config / iso_errors / iso_errors(PI, Mode)
+%  options as write_wam_cpp_project/3.
+wam_cpp_iso_audit(Predicates, Options, Audit) :-
+    iso_errors_resolve_options(Options, IsoConfig),
+    findall(PredEntry, (
+        member(PI, Predicates),
+        iso_errors_audit_predicate(IsoConfig, PI, PredEntry)
+    ), Audit).
+```
+
+Output records carry enough information to drive both a human
+report and machine-readable downstream tools:
+
+```prolog
+audit(my_calc/2, Mode, [
+    site(pc=12,
+         original=is/2,             % what the WAM compiler emitted
+         resolved=is_iso/2,         % what the generator will write out
+         source=default,            % default | explicit_iso | explicit_lax
+         iso_key=is_iso/2,          % what flipping to ISO would give
+         lax_key=is_lax/2,          % what flipping to lax would give
+         would_change_on_flip=true),
+    site(pc=18,
+         original=is_lax/2,
+         resolved=is_lax/2,
+         source=explicit_lax,
+         iso_key=is_iso/2,
+         lax_key=is_lax/2,
+         would_change_on_flip=false)
+])
+```
+
+A simple pretty-printer (`wam_cpp_iso_audit_report/1`) renders the
+audit as a human-readable table:
+
+```
+my_calc/2 [iso]
+  pc=12  is/2       -> is_iso/2  (default)      would-change-on-flip
+  pc=18  is_lax/2   -> is_lax/2  (explicit-lax) survives-flip
+```
+
+The audit ships in the same plumbing PR as the rewrite, since the
+two share `iso_errors_resolve_options/2` and the key tables. Cost:
+one extra exported predicate + a few hundred lines of inspection
+code.
 
 ## 8. Test surface
 
-Two new test categories in `test_wam_cpp_generator.pl`:
+Three new test categories in `test_wam_cpp_generator.pl`:
 
 ```
-cpp_e2e_iso_*    — verifies ISO-mode predicates throw the right
-                   error terms (catch with specific patterns).
-cpp_e2e_lax_*    — verifies lax-mode predicates still fail silently
-                   (regression guard against the rewrite accidentally
-                   touching lax call sites).
+cpp_e2e_iso_*       — verifies ISO-mode predicates throw the right
+                      error terms (catch with specific patterns).
+cpp_e2e_lax_*       — verifies lax-mode predicates still fail
+                      silently (regression guard).
+cpp_e2e_explicit_*  — verifies user code using is_iso/2 or
+                      is_lax/2 directly bypasses the rewrite (the
+                      three-forms guarantee). e.g. an ISO-mode
+                      predicate with an explicit is_lax/2 call
+                      should fail silently on bad eval.
 ```
 
-Plus a unit test for the config loader:
+Plus two unit tests for the generator-side helpers:
 
 ```
 test_iso_errors_config_loader — parses a sample config, verifies
@@ -241,17 +358,29 @@ test_iso_errors_config_loader — parses a sample config, verifies
                                  right Mode for several predicates
                                  (with and without overrides,
                                  module-qualified and bare).
+
+test_iso_errors_audit         — given a sample config + a couple
+                                 predicates with mixed default /
+                                 explicit_iso / explicit_lax call
+                                 sites, verify wam_cpp_iso_audit/3
+                                 reports the right `resolved`,
+                                 `source`, and
+                                 `would_change_on_flip` fields.
 ```
 
 ## 9. Files touched (estimated)
 
 - `src/unifyweaver/targets/wam_cpp_target.pl`
-  - `iso_errors_*` config-loading + rewrite predicates (~80 lines).
-  - Runtime `builtin()` gains `_iso/N` cases (~20 lines per builtin).
+  - `iso_errors_*` config-loading + rewrite predicates (~100 lines).
+  - `wam_cpp_iso_audit/3` + pretty-printer (~120 lines).
+  - Runtime `builtin()` gains `_iso/N` and `_lax/N` cases
+    (~25 lines per builtin, mostly the ISO body since lax shares
+    with default).
   - Runtime gains `throw_iso_error` + `make_*_error` helpers (~60
     lines).
 - `tests/test_wam_cpp_generator.pl`
-  - 1 config-loader unit test + 1 test per ISO-enabled builtin.
+  - 2 unit tests (config loader, audit).
+  - 3 e2e tests per ISO-enabled builtin (iso / lax / explicit).
 - `docs/design/WAM_CPP_ISO_ERRORS_PHILOSOPHY.md` — this design.
 - `docs/design/WAM_CPP_ISO_ERRORS_SPECIFICATION.md` — this design.
 
@@ -260,12 +389,16 @@ test_iso_errors_config_loader — parses a sample config, verifies
 This is sized for **three small PRs** so each is reviewable:
 
 1. **Plumbing PR**: config loader, `iso_errors_rewrite/4` machinery,
-   key-swap table, `throw_iso_error` runtime helper. No behavior
-   change yet — `iso_errors_swap_key/2` returns empty so nothing
-   gets rewritten. Smoke-tested by a config-loader unit test.
-2. **First builtin PR**: add `is_iso/2` registration and one entry
-   to the swap table. Tests cover lax-still-works + ISO-throws.
-3. **Sweep PR**: add the remaining arith compares + `succ_iso/2`
-   and their swap-table entries. Tests for each.
+   default→iso and default→lax key tables (initially empty),
+   `throw_iso_error` runtime helper, audit predicate + pretty
+   printer. No behavior change yet — tables are empty so nothing
+   gets rewritten. Smoke-tested by config-loader + audit unit tests.
+2. **First builtin PR**: add `is_iso/2` and `is_lax/2` registrations
+   and the matching entries to both key tables. Tests cover
+   lax-still-works + ISO-throws + explicit-lax-bypass-of-rewrite.
+3. **Sweep PR**: add the remaining arith compares + `succ_iso/2` /
+   `succ_lax/2` and their table entries. Tests for each. Also
+   ships the lax IEEE-754 float-divide behavior change documented
+   in §6.1.
 
 Future builtins follow the §7 pattern incrementally.

--- a/docs/design/WAM_CPP_ISO_ERRORS_SPECIFICATION.md
+++ b/docs/design/WAM_CPP_ISO_ERRORS_SPECIFICATION.md
@@ -1,0 +1,271 @@
+# WAM C++: ISO Error Terms — Specification
+
+Concrete shape of the ISO-error dispatch we're implementing in
+`wam_cpp_target.pl`. For *why* each decision, see
+`WAM_CPP_ISO_ERRORS_PHILOSOPHY.md`.
+
+## 1. Config schema
+
+A config is a Prolog file that asserts two kinds of facts using a
+dedicated module:
+
+```prolog
+% iso_errors.pl
+
+:- module(iso_errors_config, [
+       iso_errors_default/1,
+       iso_errors_override/2
+   ]).
+
+% Global default for predicates not otherwise listed.
+iso_errors_default(true).
+
+% Per-predicate overrides. Either direction is allowed.
+iso_errors_override(legacy_lookup/3, false).
+iso_errors_override(unsafe_div/3,    false).
+iso_errors_override(experimental:my_pred/2, true).
+```
+
+**Fact shapes:**
+
+| Fact | Arity | Meaning |
+|---|---|---|
+| `iso_errors_default(Mode)` | 1 | Default for all predicates. `Mode` is `true` or `false`. Optional; omitted means `false`. |
+| `iso_errors_override(PI, Mode)` | 2 | Mode for one predicate. `PI` is a predicate indicator (`Name/Arity` or `Module:Name/Arity`). |
+
+**Module qualifier:** if `PI` is `Module:Name/Arity`, the override
+applies only to that module. Bare `Name/Arity` matches the predicate
+in whichever module the generator is compiling — the default is to
+match across all modules (this is the common case in single-module
+projects). We'll likely need to revisit this rule when multi-module
+projects appear.
+
+**Conflict resolution:** later `iso_errors_override/2` facts in the
+file override earlier ones for the same `PI`. The
+`iso_errors_default/1` fact is read once; multiple definitions are
+an error.
+
+## 2. Loading the config
+
+`write_wam_cpp_project/3` gains an option:
+
+```prolog
+write_wam_cpp_project(Preds, [
+    iso_errors_config('config/iso_errors.pl')
+], Dir).
+```
+
+The loader:
+
+1. `consult/1`s the file in a fresh sub-namespace (so its
+   `iso_errors_*` facts don't bleed into user code).
+2. Reads `iso_errors_default/1` (if present) into a generator-local
+   default. Absent → `false`.
+3. Builds a dict (or association list) of `PI → Mode` from
+   `iso_errors_override/2` facts.
+
+Inline overrides on the `write_wam_cpp_project/3` call line still
+work and merge with the config, with inline winning. So:
+
+```prolog
+% Config says default false.
+write_wam_cpp_project(Preds, [
+    iso_errors_config('config/iso_errors.pl'),
+    iso_errors(true),                          % override the default
+    iso_errors(legacy_lookup/3, false)         % override one predicate
+], Dir).
+```
+
+## 3. Per-predicate dispatch in the generator
+
+The generator already walks predicates one at a time inside
+`emit_setup_function/3`. We hook into the per-predicate phase:
+
+```prolog
+emit_setup_function(Predicates, Options, SetupCpp) :-
+    iso_errors_resolve_options(Options, IsoConfig),
+    foreign_pred_keys_from_options(Options, _ForeignKeys),
+    findall(Items, (
+        member(PI, Predicates),
+        catch(
+            ( compile_predicate_to_wam(PI, [inline_bagof_setof(true)], WamText),
+              parse_pred_blocks(WamText, Items0),
+              iso_errors_rewrite(IsoConfig, PI, Items0, Items)  % <-- new
+            ),
+            _, fail)
+    ), PerPredItems),
+    ...
+```
+
+`iso_errors_rewrite/4` walks the items for one predicate and rewrites
+`builtin_call(Key, N)` lines according to the predicate's mode:
+
+```prolog
+iso_errors_rewrite(IsoConfig, PI, Items0, Items) :-
+    iso_errors_mode_for(IsoConfig, PI, Mode),
+    maplist(iso_errors_rewrite_item(Mode), Items0, Items).
+
+iso_errors_rewrite_item(true,  builtin_call(Key, N), builtin_call(IsoKey, N)) :-
+    iso_errors_swap_key(Key, IsoKey), !.
+iso_errors_rewrite_item(_, Item, Item).
+```
+
+`iso_errors_swap_key/2` is a simple lookup table:
+
+| Lax key | ISO key |
+|---|---|
+| `is/2` | `is_iso/2` |
+| `>/2` | `>_iso/2` |
+| `</2` | `<_iso/2` |
+| `>=/2` | `>=_iso/2` |
+| `=</2` | `=<_iso/2` |
+| `=:=/2` | `=:=_iso/2` |
+| `=\\=/2` | `=\\=_iso/2` |
+| `succ/2` | `succ_iso/2` |
+
+(Operator-name keys with `/2` suffix follow the existing convention.
+Builtins not in the table are left unchanged — they're considered
+ISO-equivalent or not yet audited.)
+
+## 4. Runtime registrations
+
+Each ISO-flavored builtin lives next to its lax counterpart in
+`builtin()`. Example for `is/2`:
+
+```cpp
+if (op == "is/2") {
+    bool ok = true;
+    Value rhs = eval_arith(get_cell("A2"), ok);
+    if (!ok) return false;                    // lax: silent failure
+    if (!unify_cells(get_cell("A1"),
+                     std::make_shared<Cell>(rhs))) return false;
+    pc += 1; return true;
+}
+if (op == "is_iso/2") {
+    bool ok = true;
+    Value rhs = eval_arith(get_cell("A2"), ok);
+    if (!ok) {
+        // Build error(type_error(evaluable, <term>), _) and throw.
+        throw_iso_error(make_type_error("evaluable",
+                                        deref(*get_cell("A2"))));
+        return false;
+    }
+    if (!unify_cells(get_cell("A1"),
+                     std::make_shared<Cell>(rhs))) return false;
+    pc += 1; return true;
+}
+```
+
+The two share zero code apart from `eval_arith` — that's
+intentional: the lax version's hot path stays untouched.
+
+## 5. Error-term constructors
+
+A small set of helpers in the runtime:
+
+```cpp
+struct WamState {
+    ...
+    // Construct error(<ErrTerm>, _) and dispatch via execute_throw.
+    void throw_iso_error(Value err_term);
+
+    // Convenience builders.
+    Value make_type_error(const std::string& expected, Value culprit);
+    Value make_instantiation_error();
+    Value make_domain_error(const std::string& domain, Value culprit);
+    Value make_evaluation_error(const std::string& kind);
+};
+```
+
+`throw_iso_error` sets `A1` to the constructed `error/2` term, then
+calls `execute_throw()`. Existing catch/3 machinery handles unwind
+and recovery dispatch without changes.
+
+The `Context` slot of `error(ErrType, Context)` is left as a fresh
+unbound variable for the v1. Future revisions could carry the
+predicate indicator that threw — that's an enhancement, not a
+correctness issue.
+
+## 6. Error-term shapes
+
+These are the structures `throw_iso_error` builds for the v1
+builtins. The list will grow as more builtins are audited.
+
+| Builtin | Trigger | Thrown term |
+|---|---|---|
+| `is_iso/2` | RHS contains unbound | `error(instantiation_error, _)` |
+| `is_iso/2` | RHS non-evaluable atom `foo` | `error(type_error(evaluable, foo/0), _)` |
+| `is_iso/2` | Divide by zero | `error(evaluation_error(zero_divisor), _)` |
+| `>_iso/2` etc. | Either arg unbound | `error(instantiation_error, _)` |
+| `>_iso/2` etc. | Either arg non-evaluable | `error(type_error(evaluable, X/N), _)` |
+| `succ_iso/2` | Both args unbound | `error(instantiation_error, _)` |
+| `succ_iso/2` | X negative | `error(type_error(not_less_than_zero, X), _)` |
+| `succ_iso/2` | Y zero or negative | `error(domain_error(not_less_than_zero, Y), _)` |
+
+(Atom-form predicate indicators are constructed as `Atom/Arity`
+compound terms, matching ISO's recommendation.)
+
+## 7. Migration path
+
+For each existing ISO-relevant builtin:
+
+1. Decide what the ISO error should be (see §6).
+2. Add an `if (op == "<key>_iso/N")` branch alongside the existing
+   lax `if (op == "<key>/N")`.
+3. Add the key to `iso_errors_swap_key/2`.
+4. Add e2e tests that:
+   - Verify lax behavior is unchanged (existing tests, no edits).
+   - Verify ISO behavior with `catch(Goal, error(Pattern, _), ...)`.
+
+The same pattern applies when adding a new builtin: ship both
+flavors from the start, or document that the lax flavor is the only
+one and gets the lax key.
+
+## 8. Test surface
+
+Two new test categories in `test_wam_cpp_generator.pl`:
+
+```
+cpp_e2e_iso_*    — verifies ISO-mode predicates throw the right
+                   error terms (catch with specific patterns).
+cpp_e2e_lax_*    — verifies lax-mode predicates still fail silently
+                   (regression guard against the rewrite accidentally
+                   touching lax call sites).
+```
+
+Plus a unit test for the config loader:
+
+```
+test_iso_errors_config_loader — parses a sample config, verifies
+                                 iso_errors_mode_for/3 returns the
+                                 right Mode for several predicates
+                                 (with and without overrides,
+                                 module-qualified and bare).
+```
+
+## 9. Files touched (estimated)
+
+- `src/unifyweaver/targets/wam_cpp_target.pl`
+  - `iso_errors_*` config-loading + rewrite predicates (~80 lines).
+  - Runtime `builtin()` gains `_iso/N` cases (~20 lines per builtin).
+  - Runtime gains `throw_iso_error` + `make_*_error` helpers (~60
+    lines).
+- `tests/test_wam_cpp_generator.pl`
+  - 1 config-loader unit test + 1 test per ISO-enabled builtin.
+- `docs/design/WAM_CPP_ISO_ERRORS_PHILOSOPHY.md` — this design.
+- `docs/design/WAM_CPP_ISO_ERRORS_SPECIFICATION.md` — this design.
+
+## 10. Implementation phasing
+
+This is sized for **three small PRs** so each is reviewable:
+
+1. **Plumbing PR**: config loader, `iso_errors_rewrite/4` machinery,
+   key-swap table, `throw_iso_error` runtime helper. No behavior
+   change yet — `iso_errors_swap_key/2` returns empty so nothing
+   gets rewritten. Smoke-tested by a config-loader unit test.
+2. **First builtin PR**: add `is_iso/2` registration and one entry
+   to the swap table. Tests cover lax-still-works + ISO-throws.
+3. **Sweep PR**: add the remaining arith compares + `succ_iso/2`
+   and their swap-table entries. Tests for each.
+
+Future builtins follow the §7 pattern incrementally.


### PR DESCRIPTION
## Summary

Two design docs for the upcoming ISO-errors work — no code changes. Review the design before implementation lands. Updated once based on review feedback.

### Files

- **`WAM_CPP_ISO_ERRORS_PHILOSOPHY.md`** — rationale, alternatives, perf claim with explicit boundaries, three-form design (lax / iso / default), config-format choice (Prolog), default-off, divide-by-zero / NaN survey, audit tooling.
- **`WAM_CPP_ISO_ERRORS_SPECIFICATION.md`** — config schema, loader contract, three-form key tables, runtime registration pattern, error-term shapes per builtin per trigger, audit predicate spec, test surface, 3-PR phasing.

### Design highlights from review-1

**Three forms per ISO-relevant builtin** (PHILOSOPHY §3.3 / SPECIFICATION §3):

| Form | Key | Behavior | Who writes it |
|---|---|---|---|
| Default | `is/2` | Resolves to lax or ISO at generator time per surrounding-predicate mode | WAM compiler from `X is Expr` |
| Explicit ISO | `is_iso/2` | Always throws | User writes `is_iso(X, Expr)` directly |
| Explicit lax | `is_lax/2` | Always fails silently | User writes `is_lax(X, Expr)` directly |

The rewrite only touches default-form keys. Explicit `_iso` / `_lax` survives a mode-flip on the enclosing predicate — that's the three-forms guarantee.

**Float divide-by-zero gets IEEE 754 semantics in lax mode** (PHILOSOPHY §8 / SPECIFICATION §6.1):

| Expression | Lax | ISO |
|---|---|---|
| `1 // 0` | `false` | throw `evaluation_error(zero_divisor)` |
| `1.0 / 0.0` | `X = inf` | throw `evaluation_error(zero_divisor)` |
| `0.0 / 0.0` | `X = nan` | throw `evaluation_error(zero_divisor)` |

Small breaking change to today's uniform-fail-on-divide-by-zero behavior; flagged for the implementation PR's release notes.

**Audit tooling promoted into the plumbing PR** (PHILOSOPHY §9 / SPECIFICATION §7.1):

`wam_cpp_iso_audit/3` walks each predicate and reports per-call-site key resolution, including a `would_change_on_flip` field that makes it a useful migration tool. Ships in the same PR as the rewrite since they share the key tables.

### Phasing (SPECIFICATION §10)

1. **Plumbing PR** — config loader, rewrite machinery, key tables (initially empty), `throw_iso_error` helper, audit predicate + pretty-printer. No behavior change.
2. **First builtin PR** — `is_iso/2` + `is_lax/2` registrations + matching table entries. Tests: lax-still-works, ISO-throws, explicit-lax-bypasses-rewrite.
3. **Sweep PR** — remaining arith compares + `succ_iso/2` / `succ_lax/2`. Ships the lax IEEE-754 float-divide behavior change.

### Test plan

- [x] Docs follow `docs/design/` convention (PHILOSOPHY + SPECIFICATION companion files, see `WAM_DEMAND_FILTER_*`)
- [x] Three-form design integrated end-to-end (philosophy, spec rules, runtime registration, test surface)
- [x] Float divide-by-zero rationale documented with cross-language survey
- [x] Audit tool spec'd with example output
- [ ] No code yet — implementation lands in 3 follow-up PRs per §10

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_