### PR TITLE
fix(wam-c): preserve repeated variables in lowered filters

### DIFF
--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -18,7 +18,7 @@ current cross-target builtin/runtime baseline.
 | Term inspection | `functor/3`, `arg/3` | `functor/3`, `arg/3` | Present |
 | Univ | `=../2` compose/decompose | `=../2` compose/decompose | Present |
 | Copying | `copy_term/2` with fresh variables and preserved sharing | `copy_term/2` with fresh variables and preserved sharing | Present |
-| Control | `true/0`, `fail/0`, `!/0`, `\+/1`, `CutIte` | Same baseline, with broader isolated-goal NAF in Haskell/Python | Partial: `\+/1` only dispatches builtin-shaped goals |
+| Control | `true/0`, `fail/0`, `!/0`, `\+/1`, `CutIte` | Same baseline, with broader isolated-goal NAF in Haskell/Python | Partial: `\+/1` handles builtin-shaped and sequential user goals; no parallel race path |
 | IO | `write/1`, `display/1`, `nl/0` | `write/1`, `display/1`, `nl/0` | Present |
 
 ## Immediate Findings
@@ -38,6 +38,8 @@ current cross-target builtin/runtime baseline.
   generated Go WAM builtin E2E test.
 - `aggregate_all(set(X), Goal, Set)` is now covered by the generated Go WAM
   builtin E2E test.
+- `\+/1` over user predicates is now covered by the generated Go WAM builtin
+  E2E test for both failing and succeeding inner goals.
 
 ## Recommended Follow-Up Order
 

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -1866,6 +1866,30 @@ func (vm *WamState) enterIndexedClause(targetPC int) bool {
     return vm.enterIndexedAlternatives([]int{vm.indexedClauseBodyStart(targetPC)})
 }
 
+func (vm *WamState) runIsolatedGoal(targetPC int, args []Value) bool {
+    sub := vm.Clone()
+    for idx := range sub.Regs {
+        sub.Regs[idx] = nil
+    }
+    for idx, arg := range args {
+        if idx >= len(sub.Regs) {
+            break
+        }
+        sub.Regs[idx] = arg
+    }
+    sub.PC = targetPC
+    sub.CP = 0
+    sub.E = -1
+    sub.Stack = nil
+    sub.Trail = nil
+    sub.TrailLen = 0
+    sub.ChoicePoints = nil
+    sub.Halted = false
+    sub.CurrentStruct = nil
+    sub.CurrentList = nil
+    return sub.Run()
+}
+
 // CollectResults gathers values from A registers (indices 0..N-1).
 func (vm *WamState) CollectResults() []Value {
 	results := make([]Value, 0)

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1030,7 +1030,13 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			for idx := 0; idx < 3; idx++ {
 				vm.Regs[idx] = oldRegs[idx]
 			}
-			return !res
+			if res {
+				return false
+			}
+			if pc, ok := vm.Ctx.Labels[opName]; ok {
+				return !vm.runIsolatedGoal(pc, args)
+			}
+			return true
 		}
 		return false
 

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -10,6 +10,9 @@
 :- dynamic user:test_member_collect/0.
 :- dynamic user:test_set_aggregate/0.
 :- dynamic user:test_unify_builtin/0.
+:- dynamic user:test_neg_fact/1.
+:- dynamic user:test_neg_goal/0.
+:- dynamic user:test_neg_goal_fail/0.
 
 test(builtins_execution) :-
     get_time(T),
@@ -58,6 +61,14 @@ test(builtins_execution) :-
             (   =(f(a, X), f(a, b)),
                 X == b,
                 \+ =(a, b)
+            )),
+          assertz(user:test_neg_fact(a)),
+          assertz(user:test_neg_fact(b)),
+          assertz(user:test_neg_goal :-
+            (   \+ test_neg_fact(c)
+            )),
+          assertz(user:test_neg_goal_fail :-
+            (   \+ test_neg_fact(a)
             ))
         ),
         run_builtins_test(TmpDir),
@@ -66,12 +77,15 @@ test(builtins_execution) :-
           retractall(user:test_member_collect),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
+          retractall(user:test_neg_fact(_)),
+          retractall(user:test_neg_goal),
+          retractall(user:test_neg_goal_fail),
           delete_directory_and_contents(TmpDir) )
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_set_aggregate/0, test_unify_builtin/0],
-    Options = [module_name(builtin_test)],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
 
@@ -89,6 +103,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "=../2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "copy_term/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "=/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "\\\\+/1"')),
     assertion(sub_string(LibCode, _, _, _, 'AggType: "set"')),
 
     % Add a main.go to run the test in a separate cmd directory
@@ -148,6 +163,22 @@ func main() {
 	} else {
 		fmt.Println("UNIFY_FAILURE")
 	}
+
+	negVM := wam.NewWamState(wam.Test_neg_goalCode, wam.Test_neg_goalLabels)
+	negVM.PC = wam.Test_neg_goalStartPC
+	if negVM.Run() {
+		fmt.Println("NEG_SUCCESS")
+	} else {
+		fmt.Println("NEG_FAILURE")
+	}
+
+	negFailVM := wam.NewWamState(wam.Test_neg_goal_failCode, wam.Test_neg_goal_failLabels)
+	negFailVM.PC = wam.Test_neg_goal_failStartPC
+	if negFailVM.Run() {
+		fmt.Println("NEG_FAIL_UNEXPECTED_SUCCESS")
+	} else {
+		fmt.Println("NEG_FAIL_EXPECTED")
+	}
 }
 '),
 
@@ -170,7 +201,9 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "TERM_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "MEMBER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
-        assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS"))
+        assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "NEG_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "NEG_FAIL_EXPECTED"))
     ;   format("Go not found, skipping execution test.~n")
     ).
 


### PR DESCRIPTION
## Summary

- Preserve repeated callee-variable equality constraints in WAM-C lowered filtered helpers.
- Reuse the existing row-constraint check for plain filtered helpers so shapes like `keep(X) :- edge(X, X, keep)` reject non-equal rows.
- Add planner/generation coverage for repeated-variable filtered helpers and comparison-filtered helpers.
- Add executable smoke coverage for repeated-variable lowered helpers.
- Update `WAM_C_TARGET_NEXT_STEPS.md` to record the repeated-variable filter work.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --check`

Note: validation was run locally on Termux. Benchmark timing on this device should be treated as non-authoritative.
