### PR TITLE
feat(wam-cpp): ISO-errors plumbing — config loader, rewrite hook, audit, runtime helpers

### DIFF
--- a/docs/design/WAM_CPP_ISO_ERRORS_PHILOSOPHY.md
+++ b/docs/design/WAM_CPP_ISO_ERRORS_PHILOSOPHY.md
@@ -312,7 +312,7 @@ with the implementation, not the docs.
 User feedback called this out as a good idea; moving it from
 "probably not" into the plan.
 
-Ship a `wam_cpp_iso_audit/2` predicate alongside the rewrite. Given
+Ship a `wam_cpp_iso_audit/3` predicate alongside the rewrite. Given
 a predicate list and a config, it walks each predicate's compiled
 WAM and reports:
 

--- a/docs/design/WAM_CPP_ISO_ERRORS_SPECIFICATION.md
+++ b/docs/design/WAM_CPP_ISO_ERRORS_SPECIFICATION.md
@@ -6,16 +6,14 @@ Concrete shape of the ISO-error dispatch we're implementing in
 
 ## 1. Config schema
 
-A config is a Prolog file that asserts two kinds of facts using a
-dedicated module:
+A config is a Prolog file containing plain facts — no module
+declaration, no clauses with bodies, no directives. The loader reads
+terms one at a time and extracts the recognised fact shapes; anything
+else is silently ignored (so the file stays forward-compatible with
+new fact kinds we may add later).
 
 ```prolog
 % iso_errors.pl
-
-:- module(iso_errors_config, [
-       iso_errors_default/1,
-       iso_errors_override/2
-   ]).
 
 % Global default for predicates not otherwise listed.
 iso_errors_default(true).
@@ -40,8 +38,26 @@ match across all modules (this is the common case in single-module
 projects). We'll likely need to revisit this rule when multi-module
 projects appear.
 
+**Footgun mitigation — multi-module bare-PI matching.** The loader
+emits a warning when a bare `iso_errors_override/2` matches more
+than one module in the input predicate list, e.g.:
+
+```
+Warning: iso_errors_override(safe_div/2, false) matches
+         3 predicates in different modules
+         (mod_a:safe_div/2, mod_b:safe_div/2, util:safe_div/2).
+         Qualify with `mod:safe_div/2` for module-scoped overrides.
+```
+
+Code keeps compiling — the override applies to all matches — but
+reviewers see the surprise immediately. Reviewing this in CI before
+merging migration commits catches the case where a `safe_div/2`
+override silently changes the behavior of an unrelated module.
+
 **Conflict resolution:** later `iso_errors_override/2` facts in the
-file override earlier ones for the same `PI`. The
+file override earlier ones for the same `PI`. Inline options on the
+`write_wam_cpp_project/3` call line override the loaded config for
+the same `PI` (inline-wins precedence — see §2). The
 `iso_errors_default/1` fact is read once; multiple definitions are
 an error.
 
@@ -108,7 +124,7 @@ iso_errors_rewrite(IsoConfig, PI, Items0, Items) :-
     maplist(iso_errors_rewrite_item(Mode), Items0, Items).
 
 % Only the default form gets rewritten. Explicit _iso / _lax keys
-% survive untouched — that''s the three-forms guarantee from the
+% survive untouched - the three-forms guarantee from the
 % philosophy doc §3.3.
 iso_errors_rewrite_item(true,  builtin_call(Key, N),
                         builtin_call(IsoKey, N)) :-
@@ -140,6 +156,17 @@ but is kept for symmetry and future use.
 (Operator-name keys with `/2` suffix follow the existing convention.
 Builtins not in either table are left unchanged — they're considered
 ISO-equivalent or not yet audited.)
+
+**Intentionally excluded** from the table:
+
+- `\=/2` (not-unifiable) and `\==/2` (structural inequality) are
+  **not** arithmetic; they fail when their args don't unify or are
+  structurally unequal. ISO doesn't define error-throwing semantics
+  for them. Leaving them out of the table is a conscious choice.
+- `=/2` (unify) and `==/2` (structural equality) — same reasoning.
+- I/O builtins (`write/1`, `nl/0`, `format/2`) — ISO defines stream
+  errors, but our runtime writes to a fixed stdout and can't fail.
+  Out of scope for v1.
 
 ### 3.2 Default vs lax — share implementation, separate keys
 
@@ -279,7 +306,7 @@ same body and no `_iso` form exists yet).
 
 ## 7.1 Audit tooling
 
-`wam_cpp_iso_audit/2` is a read-only generator pass that mirrors
+`wam_cpp_iso_audit/3` is a read-only generator pass that mirrors
 the rewrite without actually emitting code. Useful for migration
 review and for verifying the config does what's intended.
 
@@ -287,7 +314,7 @@ review and for verifying the config does what's intended.
 %% wam_cpp_iso_audit(+Predicates, +Options, -Audit)
 %
 %  For each predicate in Predicates, walk its compiled WAM and
-%  report each builtin_call site''s key resolution. Options accepts
+%  report each builtin_call site's key resolution. Options accepts
 %  the same iso_errors_config / iso_errors / iso_errors(PI, Mode)
 %  options as write_wam_cpp_project/3.
 wam_cpp_iso_audit(Predicates, Options, Audit) :-
@@ -350,23 +377,61 @@ cpp_e2e_explicit_*  — verifies user code using is_iso/2 or
                       should fail silently on bad eval.
 ```
 
-Plus two unit tests for the generator-side helpers:
+Plus four unit tests for the generator-side helpers:
 
 ```
-test_iso_errors_config_loader — parses a sample config, verifies
-                                 iso_errors_mode_for/3 returns the
-                                 right Mode for several predicates
-                                 (with and without overrides,
-                                 module-qualified and bare).
+test_iso_errors_config_loader        — parses a sample config,
+                                        verifies iso_errors_mode_for/3
+                                        returns the right Mode for
+                                        several predicates (with and
+                                        without overrides,
+                                        module-qualified and bare).
 
-test_iso_errors_audit         — given a sample config + a couple
-                                 predicates with mixed default /
-                                 explicit_iso / explicit_lax call
-                                 sites, verify wam_cpp_iso_audit/3
-                                 reports the right `resolved`,
-                                 `source`, and
-                                 `would_change_on_flip` fields.
+test_iso_errors_inline_wins          — file config sets pred X to
+                                        false; inline option sets
+                                        same X to true. Verifies
+                                        iso_errors_mode_for/3
+                                        returns true (inline wins).
+
+test_iso_errors_multi_module_warning — config has bare
+                                        `safe_div/2` override;
+                                        predicate list contains
+                                        safe_div/2 from two modules.
+                                        Verifies the loader emits
+                                        the multi-module warning
+                                        (captured via with_output_to
+                                        on user_error or a hookable
+                                        sink).
+
+test_iso_errors_audit                — given a sample config +
+                                        predicates with mixed
+                                        default / explicit_iso /
+                                        explicit_lax call sites,
+                                        verify wam_cpp_iso_audit/3
+                                        reports the right
+                                        `resolved`, `source`, and
+                                        `would_change_on_flip`
+                                        fields.
 ```
+
+Once the first ISO builtin lands (PR #2 in §10), one more
+correctness test gates the catch-with-unbound-context path:
+
+```
+cpp_e2e_iso_unbound_context — Goal that throws an ISO error;
+                              catcher binds `error(Pattern, _)`
+                              with an unbound Context slot.
+                              Verifies the catch succeeds and the
+                              recovery goal sees Pattern bound to
+                              the type/instantiation/domain term
+                              even though Context is the fresh
+                              variable the runtime made.
+```
+
+This is the regression guard against the §5 SPECIFICATION decision
+to leave Context unbound for v1 — making sure that decision doesn't
+break user code that uses the standard `error(Pattern, _)` catcher
+shape.
 
 ## 9. Files touched (estimated)
 

--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -33,7 +33,12 @@
     wam_instruction_to_cpp_literal/3,      % +Instr, +LabelMap, -CppCode
     cpp_safe_function_name/2,              % +Pred, -CppFuncName
     escape_cpp_string/2,                   % +InStr, -OutStr
-    cpp_value_literal/2                    % +Constant, -CppLiteral
+    cpp_value_literal/2,                   % +Constant, -CppLiteral
+    iso_errors_resolve_options/2,          % +Options, -Config
+    iso_errors_load_config/2,              % +File, -Config
+    iso_errors_mode_for/3,                 % +Config, +PI, -Mode
+    wam_cpp_iso_audit/3,                   % +Predicates, +Options, -Audit
+    wam_cpp_iso_audit_report/1             % +Audit
 ]).
 
 :- use_module(library(lists)).
@@ -443,11 +448,14 @@ lookup_label(NameStr, Labels, PC) :-
 %  wam_cpp_setup() function that populates WamState::instrs / labels.
 emit_setup_function(Predicates, Options, SetupCpp) :-
     foreign_pred_keys_from_options(Options, _ForeignKeys),
+    iso_errors_resolve_options(Options, IsoConfig),
+    iso_errors_warn_multi_module(IsoConfig, Predicates),
     findall(Items, (
         member(PI, Predicates),
         catch(
             ( compile_predicate_to_wam(PI, [inline_bagof_setof(true)], WamText),
-              parse_pred_blocks(WamText, Items)
+              parse_pred_blocks(WamText, Items0),
+              iso_errors_rewrite(IsoConfig, PI, Items0, Items)
             ),
             _, fail)
     ), PerPredItems),
@@ -488,6 +496,248 @@ static const int _wam_cpp_setup_register = []() {
     return 0;
 }();
 ', [Reserve, CatchReturnPC, LabelBody, InstrBody]).
+
+% ============================================================================
+% ISO error configuration
+% ============================================================================
+%
+% Per-predicate ISO-error dispatch. See:
+%   docs/design/WAM_CPP_ISO_ERRORS_PHILOSOPHY.md
+%   docs/design/WAM_CPP_ISO_ERRORS_SPECIFICATION.md
+%
+% The key tables iso_errors_default_to_iso/2 and iso_errors_default_to_lax/2
+% are intentionally empty in this plumbing PR. iso_errors_rewrite/4 is a
+% no-op when both tables are empty (every default key falls through
+% unchanged). The first ISO-aware builtin lands in the follow-up PR.
+
+%% iso_errors_default_to_iso(+DefaultKey, -IsoKey)
+%  Maps a default builtin key (e.g. "is/2") to its ISO flavour
+%  ("is_iso/2"). Empty in this PR. Declared `dynamic` so calls
+%  with no clauses simply fail (rather than throwing
+%  existence_error) and so follow-up PRs can populate it either as
+%  asserted facts or as ordinary static clauses below this line.
+%
+%% iso_errors_default_to_lax(+DefaultKey, -LaxKey)
+%  Maps a default key to its explicit-lax flavour. Same shape as
+%  the iso table — empty for now since default and lax will share
+%  an implementation in the runtime, so the rewrite stays a no-op
+%  even when populated.
+:- dynamic iso_errors_default_to_iso/2.
+:- dynamic iso_errors_default_to_lax/2.
+
+%% iso_errors_resolve_options(+Options, -Config)
+%  Merges the (optional) file config with inline options into one
+%  iso_config(Default, Overrides) struct. Inline options override
+%  file entries for the same PI.
+iso_errors_resolve_options(Options, iso_config(Default, Overrides)) :-
+    (   option(iso_errors_config(File), Options)
+    ->  iso_errors_load_config(File, iso_config(FileDefault, FileOv))
+    ;   FileDefault = false, FileOv = []
+    ),
+    iso_errors_inline_default(Options, FileDefault, Default),
+    iso_errors_inline_overrides(Options, InlineOv),
+    iso_errors_merge_overrides(FileOv, InlineOv, Overrides).
+
+iso_errors_inline_default(Options, FileDefault, Default) :-
+    (   member(iso_errors(M), Options),
+        (M == true ; M == false)
+    ->  Default = M
+    ;   Default = FileDefault
+    ).
+
+iso_errors_inline_overrides(Options, InlineOv) :-
+    findall(PI-Mode,
+            ( member(iso_errors(PI, Mode), Options),
+              (Mode == true ; Mode == false),
+              iso_errors_valid_pi(PI)
+            ),
+            InlineOv).
+
+% Accepts both bare Name/Arity and Module:Name/Arity.
+iso_errors_valid_pi(Name/Arity) :- atom(Name), integer(Arity), Arity >= 0, !.
+iso_errors_valid_pi(Module:Name/Arity) :-
+    atom(Module), atom(Name), integer(Arity), Arity >= 0.
+
+iso_errors_merge_overrides(FileOv, InlineOv, Merged) :-
+    exclude(iso_errors_shadowed(InlineOv), FileOv, Kept),
+    append(Kept, InlineOv, Merged).
+
+iso_errors_shadowed(InlineOv, PI-_) :-
+    member(InlinePI-_, InlineOv),
+    iso_errors_pi_matches(InlinePI, PI), !.
+
+% PI matching: bare Name/Arity matches Module:Name/Arity in any
+% module; Module:Name/Arity matches only its own module.
+iso_errors_pi_matches(PI, PI) :- !.
+iso_errors_pi_matches(Name/Arity, _:Name/Arity) :-
+    atom(Name), integer(Arity), !.
+iso_errors_pi_matches(_:Name/Arity, Name/Arity) :-
+    atom(Name), integer(Arity), !.
+
+%% iso_errors_load_config(+File, -Config)
+%  Reads a Prolog facts file and extracts iso_errors_default/1 +
+%  iso_errors_override/2 terms. Unrecognised terms are silently
+%  ignored. Returns iso_config(false, []) on I/O error.
+iso_errors_load_config(File, iso_config(Default, Overrides)) :-
+    catch(
+        setup_call_cleanup(
+            open(File, read, Stream),
+            iso_errors_read_terms(Stream, RawTerms),
+            close(Stream)),
+        _,
+        RawTerms = []),
+    iso_errors_extract_terms(RawTerms, false, [], Default, RevOv),
+    reverse(RevOv, Overrides).
+
+iso_errors_read_terms(Stream, Terms) :-
+    read_term(Stream, T, []),
+    ( T == end_of_file
+    -> Terms = []
+    ; Terms = [T|Rest],
+      iso_errors_read_terms(Stream, Rest)
+    ).
+
+iso_errors_extract_terms([], D, Ov, D, Ov).
+iso_errors_extract_terms([T|Rest], D0, Ov0, D, Ov) :-
+    (   T = iso_errors_default(NewD), (NewD == true ; NewD == false)
+    ->  iso_errors_extract_terms(Rest, NewD, Ov0, D, Ov)
+    ;   T = iso_errors_override(PI, Mode),
+        (Mode == true ; Mode == false),
+        iso_errors_valid_pi(PI)
+    ->  iso_errors_extract_terms(Rest, D0, [PI-Mode|Ov0], D, Ov)
+    ;   iso_errors_extract_terms(Rest, D0, Ov0, D, Ov)
+    ).
+
+%% iso_errors_mode_for(+Config, +PI, -Mode)
+%  Resolves a predicate''s ISO mode. Bare Name/Arity in overrides
+%  matches Module:Name/Arity in any module and vice versa. Falls
+%  back to the config''s default when no override matches.
+iso_errors_mode_for(iso_config(Default, Overrides), PI, Mode) :-
+    (   member(OvPI-OvMode, Overrides),
+        iso_errors_pi_matches(OvPI, PI)
+    ->  Mode = OvMode
+    ;   Mode = Default
+    ).
+
+%% iso_errors_warn_multi_module(+Config, +Predicates)
+%  Emits a user_error warning for each bare override that matches
+%  predicates from more than one module in the input list. Catches
+%  the safe_div/2-in-two-modules footgun (SPECIFICATION §1).
+iso_errors_warn_multi_module(iso_config(_, Overrides), Predicates) :-
+    forall(member(OvPI-_, Overrides),
+           iso_errors_check_override_scope(OvPI, Predicates)).
+
+iso_errors_check_override_scope(Name/Arity, Predicates) :-
+    atom(Name), integer(Arity), !,
+    findall(M, ( member(P, Predicates),
+                 iso_errors_pi_module(P, Name, Arity, M)
+               ), Modules),
+    list_to_set(Modules, Unique),
+    (   Unique = [_, _ | _]
+    ->  length(Unique, N),
+        format(user_error,
+               'Warning: iso_errors_override(~w/~w, _) matches ~w predicates~n         in different modules (~w).~n         Qualify with `mod:~w/~w` for module-scoped overrides.~n',
+               [Name, Arity, N, Unique, Name, Arity])
+    ;   true
+    ).
+iso_errors_check_override_scope(_, _).
+
+iso_errors_pi_module(Module:Name/Arity, Name, Arity, Module) :- !.
+iso_errors_pi_module(Name/Arity,         Name, Arity, user).
+
+%% iso_errors_rewrite(+Config, +PI, +Items0, -Items)
+%  Rewrites the default-form builtin_call keys for one predicate.
+%  Explicit *_iso / *_lax keys pass through unchanged. With empty
+%  key tables (this PR), the rewrite is a no-op.
+iso_errors_rewrite(Config, PI, Items0, Items) :-
+    iso_errors_mode_for(Config, PI, Mode),
+    maplist(iso_errors_rewrite_item(Mode), Items0, Items).
+
+iso_errors_rewrite_item(true, builtin_call(Key, N), builtin_call(IsoKey, N)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(false, builtin_call(Key, N), builtin_call(LaxKey, N)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(_, Item, Item).
+
+%% wam_cpp_iso_audit(+Predicates, +Options, -Audit)
+%  Read-only inspection of how each predicate''s builtin_call sites
+%  would resolve under the given options. Returns a list of
+%  audit(PI, Mode, Sites). Each Site is:
+%    site(PC, OrigKey, ResolvedKey, Source, WouldChangeOnFlip)
+%  Source is one of: default, explicit_iso, explicit_lax.
+wam_cpp_iso_audit(Predicates, Options, Audit) :-
+    iso_errors_resolve_options(Options, Config),
+    findall(audit(PI, Mode, Sites), (
+        member(PI, Predicates),
+        iso_errors_mode_for(Config, PI, Mode),
+        iso_errors_audit_predicate(PI, Mode, Sites)
+    ), Audit).
+
+iso_errors_audit_predicate(PI, Mode, Sites) :-
+    (   catch(
+            ( compile_predicate_to_wam(PI, [inline_bagof_setof(true)], WamText),
+              parse_pred_blocks(WamText, Items)
+            ),
+            _, fail)
+    ->  iso_errors_audit_walk(Items, 0, Mode, [], SitesRev),
+        reverse(SitesRev, Sites)
+    ;   Sites = []
+    ).
+
+iso_errors_audit_walk([], _, _, Acc, Acc).
+iso_errors_audit_walk([label(_)|Rest], PC, Mode, Acc, Out) :- !,
+    iso_errors_audit_walk(Rest, PC, Mode, Acc, Out).
+iso_errors_audit_walk([builtin_call(Key, _)|Rest], PC, Mode, Acc, Out) :- !,
+    iso_errors_audit_classify(Key, Mode, Source, Resolved, Flip),
+    Site = site(PC, Key, Resolved, Source, Flip),
+    PC1 is PC + 1,
+    iso_errors_audit_walk(Rest, PC1, Mode, [Site|Acc], Out).
+iso_errors_audit_walk([_|Rest], PC, Mode, Acc, Out) :-
+    PC1 is PC + 1,
+    iso_errors_audit_walk(Rest, PC1, Mode, Acc, Out).
+
+% Classify a builtin_call key. Explicit *_iso/N or *_lax/N suffix
+% always wins; otherwise it's a default site whose resolution
+% depends on Mode and the (currently empty) swap tables.
+iso_errors_audit_classify(Key, _Mode, explicit_iso, Key, false) :-
+    iso_errors_key_has_suffix(Key, '_iso'), !.
+iso_errors_audit_classify(Key, _Mode, explicit_lax, Key, false) :-
+    iso_errors_key_has_suffix(Key, '_lax'), !.
+iso_errors_audit_classify(Key, Mode, default, Resolved, Flip) :-
+    iso_errors_resolve_default(Key, Mode, Resolved),
+    iso_errors_other_mode(Mode, OtherMode),
+    iso_errors_resolve_default(Key, OtherMode, OtherResolved),
+    ( Resolved == OtherResolved -> Flip = false ; Flip = true ).
+
+iso_errors_resolve_default(Key, true, IsoKey) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_resolve_default(Key, false, LaxKey) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_resolve_default(Key, _, Key).
+
+iso_errors_other_mode(true,  false).
+iso_errors_other_mode(false, true).
+
+% Match keys like "foo_iso/N" or "foo_lax/N" — Suffix is e.g.
+% '_iso'. Splits on the / first, then checks the name component.
+iso_errors_key_has_suffix(Key, Suffix) :-
+    atom(Key),
+    atomic_list_concat(Parts, '/', Key),
+    Parts = [Name | _],
+    atom_concat(_, Suffix, Name).
+
+%% wam_cpp_iso_audit_report(+Audit)
+%  Human-readable pretty-print of an audit result.
+wam_cpp_iso_audit_report([]).
+wam_cpp_iso_audit_report([audit(PI, Mode, Sites)|Rest]) :-
+    format('~w [~w]~n', [PI, Mode]),
+    (   Sites == []
+    ->  format('  (no builtin_call sites)~n', [])
+    ;   forall(member(site(PC, Orig, Res, Src, Flip), Sites),
+               format('  pc=~w  ~w -> ~w  (~w)  flip-changes=~w~n',
+                      [PC, Orig, Res, Src, Flip]))
+    ),
+    wam_cpp_iso_audit_report(Rest).
 
 %% helper_predicate_items(-Items)
 %  Canonical WAM for builtin "library" predicates the user can call via
@@ -1331,6 +1581,23 @@ struct WamState {
     bool    invoke_goal_as_call(CellPtr goal_cell, std::size_t after_pc);
     bool    execute_catch();
     bool    execute_throw();
+
+    // ---- ISO error term helpers --------------------------------------
+    // Construct error(ErrTerm, _) with a fresh unbound Context slot,
+    // bind it into A1, and dispatch via execute_throw(). Callers
+    // typically build ErrTerm with one of the make_*_error helpers
+    // below. Returns whatever execute_throw() returns (always false
+    // unless a matching catcher exists).
+    bool    throw_iso_error(Value err_term);
+
+    // Concrete error-term constructors. Each returns a Value that
+    // sits inside the outer error/2 wrapper built by
+    // throw_iso_error. Shapes match WAM_CPP_ISO_ERRORS_SPECIFICATION
+    // §6 (the table of thrown terms per builtin per trigger).
+    Value   make_type_error(const std::string& expected, Value culprit);
+    Value   make_instantiation_error();
+    Value   make_domain_error(const std::string& domain, Value culprit);
+    Value   make_evaluation_error(const std::string& kind);
     // Deep-copy a value tree, allocating fresh cells for any Unbound
     // leaves (multiple references to the same source name share the
     // same fresh cell). Used by throw/1 to snapshot the thrown term
@@ -2790,6 +3057,53 @@ bool WamState::execute_throw() {
                  render(deref(*thrown)).c_str());
     halt = true;
     return false;
+}
+
+// ----------------------------------------------------------------------
+// ISO error term constructors + thrower. Used by the *_iso/N builtin
+// flavours added in follow-up PRs. The shapes match
+// WAM_CPP_ISO_ERRORS_SPECIFICATION §6.
+// ----------------------------------------------------------------------
+
+bool WamState::throw_iso_error(Value err_term) {
+    // Wrap in error(ErrTerm, Context) with Context = fresh unbound.
+    CellPtr err_cell = std::make_shared<Cell>(std::move(err_term));
+    CellPtr ctx_cell = std::make_shared<Cell>(
+        Value::Unbound("_E" + std::to_string(var_counter++)));
+    std::vector<CellPtr> args = { err_cell, ctx_cell };
+    Value wrapper = Value::Compound("error/2", std::move(args));
+    // Set A1 = the wrapped error term, then dispatch through the
+    // existing throw machinery so catch/3 frames see a normal throw.
+    regs["A1"] = std::make_shared<Cell>(std::move(wrapper));
+    return execute_throw();
+}
+
+Value WamState::make_type_error(const std::string& expected, Value culprit) {
+    std::vector<CellPtr> args = {
+        std::make_shared<Cell>(Value::Atom(expected)),
+        std::make_shared<Cell>(std::move(culprit))
+    };
+    return Value::Compound("type_error/2", std::move(args));
+}
+
+Value WamState::make_instantiation_error() {
+    // ISO uses the atom "instantiation_error" (no args).
+    return Value::Atom("instantiation_error");
+}
+
+Value WamState::make_domain_error(const std::string& domain, Value culprit) {
+    std::vector<CellPtr> args = {
+        std::make_shared<Cell>(Value::Atom(domain)),
+        std::make_shared<Cell>(std::move(culprit))
+    };
+    return Value::Compound("domain_error/2", std::move(args));
+}
+
+Value WamState::make_evaluation_error(const std::string& kind) {
+    std::vector<CellPtr> args = {
+        std::make_shared<Cell>(Value::Atom(kind))
+    };
+    return Value::Compound("evaluation_error/1", std::move(args));
 }
 
 bool WamState::backtrack() {

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -1219,6 +1219,112 @@ run_query_stdout(BinPath, PredKey, Args, Status, ExpPrint) :-
     string_concat(ExpWithStatus, "\n", Expected),
     assertion(Output == Expected).
 
+% ------------------------------------------------------------------
+% ISO error configuration — plumbing PR tests. The key swap tables
+% are intentionally empty in this PR so the rewrite is a no-op; the
+% tests here exercise the config loader, the mode resolver, the
+% inline-wins precedence, and the multi-module warning emission.
+% Behavior-changing tests (cpp_e2e_iso_* / cpp_e2e_lax_* /
+% cpp_e2e_explicit_*) land with the first ISO builtin.
+% ------------------------------------------------------------------
+
+test(iso_errors_config_loader_basic) :-
+    iso_errors_temp_config_file(Path, [
+        'iso_errors_default(true).',
+        'iso_errors_override(legacy_lookup/3, false).',
+        'iso_errors_override(unsafe_div/3, false).',
+        'iso_errors_override(experimental:my_pred/2, true).',
+        'some_future_fact(hello).'
+    ]),
+    setup_call_cleanup(
+        true,
+        ( wam_cpp_target:iso_errors_load_config(Path, Config),
+          assertion(Config == iso_config(true,
+              [legacy_lookup/3-false,
+               unsafe_div/3-false,
+               (experimental:my_pred/2)-true])),
+          % mode_for resolution, including bare-PI cross-module match.
+          wam_cpp_target:iso_errors_mode_for(Config,
+              user:legacy_lookup/3, M1),
+          assertion(M1 == false),
+          wam_cpp_target:iso_errors_mode_for(Config,
+              user:never_listed/2, M2),
+          assertion(M2 == true),                  % falls back to default
+          wam_cpp_target:iso_errors_mode_for(Config,
+              experimental:my_pred/2, M3),
+          assertion(M3 == true),
+          wam_cpp_target:iso_errors_mode_for(Config,
+              other_mod:my_pred/2, M4),
+          assertion(M4 == true)                   % only experimental: matches; default wins
+        ),
+        delete_file(Path)
+    ).
+
+test(iso_errors_inline_wins_over_file) :-
+    iso_errors_temp_config_file(Path, [
+        'iso_errors_default(false).',
+        'iso_errors_override(legacy_lookup/3, false).'
+    ]),
+    setup_call_cleanup(
+        true,
+        ( % File says false; inline says true. Inline wins.
+          wam_cpp_target:iso_errors_resolve_options(
+              [iso_errors_config(Path),
+               iso_errors(true),
+               iso_errors(legacy_lookup/3, true)],
+              Config),
+          wam_cpp_target:iso_errors_mode_for(Config,
+              user:legacy_lookup/3, M1),
+          assertion(M1 == true),
+          wam_cpp_target:iso_errors_mode_for(Config,
+              user:never_listed/2, M2),
+          assertion(M2 == true)                   % inline default wins too
+        ),
+        delete_file(Path)
+    ).
+
+test(iso_errors_multi_module_warning) :-
+    % Capture user_error output via with_output_to. Verify the
+    % warning fires when a bare override matches predicates from
+    % two different modules in the input list.
+    Config = iso_config(false, [safe_div/2-false]),
+    Predicates = [mod_a:safe_div/2, mod_b:safe_div/2, mod_c:other/3],
+    with_output_to(string(Captured),
+        % stderr is the actual target — redirect via user_error.
+        ( current_output(Curr),
+          set_stream(Curr, alias(user_error)),
+          wam_cpp_target:iso_errors_warn_multi_module(Config, Predicates),
+          set_stream(user_error, alias(user_error))
+        )),
+    assertion(sub_string(Captured, _, _, _,
+        "matches 2 predicates")),
+    assertion(sub_string(Captured, _, _, _, "mod_a")),
+    assertion(sub_string(Captured, _, _, _, "mod_b")).
+
+test(iso_errors_audit_structure) :-
+    % With empty key tables, every site is `default` with no flip.
+    % Verifies the audit machinery walks predicates + reports the
+    % expected record shape, even without behavior changes yet.
+    Options = [iso_errors(test_audit_pred/0, true)],
+    wam_cpp_target:wam_cpp_iso_audit(
+        [user:wam_cpp_test_audit_pred/0],
+        Options,
+        Audit),
+    % One predicate in input → one audit record.
+    assertion(Audit = [audit(user:wam_cpp_test_audit_pred/0, _Mode, _Sites)]).
+
+:- dynamic user:wam_cpp_test_audit_pred/0.
+user:wam_cpp_test_audit_pred :- X is 1 + 2, X = 3.
+
+% Helper: write a list of lines to a temp file, return its path.
+iso_errors_temp_config_file(Path, Lines) :-
+    get_time(T), N is round(T * 1000),
+    format(atom(Path), '/tmp/iso_cfg_~w.pl', [N]),
+    setup_call_cleanup(
+        open(Path, write, Out),
+        forall(member(L, Lines), format(Out, '~w~n', [L])),
+        close(Out)).
+
 :- end_tests(wam_cpp_generator).
 
 % --------------------------------------------------------------------


### PR DESCRIPTION
## Summary

First implementation PR after the design docs landed (#2079). Wires up everything needed to ship the actual ISO-aware builtins in follow-up PRs but **changes zero behavior today**: the two key swap tables are empty, so the per-predicate rewrite is a no-op and all existing programs compile to byte-identical WAM.

Per spec §10, this is the **"plumbing PR"** — first in the merged 3-PR phasing plan.

### Doc updates (Perplexity post-merge review of #2079)

- Audit predicate arity fixed to `/3` in both PHILOSOPHY §9 and SPECIFICATION §7.1 (was inconsistent between prose and code example).
- SPECIFICATION §1 drops the `:- module(...)` declaration from the config schema (simpler loader; just read terms and filter).
- SPECIFICATION §1 adds a **"Footgun mitigation"** subsection documenting the multi-module bare-PI warning the loader emits.
- SPECIFICATION §3.1 adds an **"Intentionally excluded"** list — `\=/2`, `\==/2`, `=/2`, `==/2`, and I/O builtins — so future contributors know these are conscious omissions.
- SPECIFICATION §8 grows from 2 to 4 unit tests (adds inline-wins precedence and multi-module-warning tests) plus a forward-looking e2e test for the unbound-Context catcher shape that the first ISO builtin PR will pick up.
- Two `''` markdown leaks in code-block comments cleaned up.

### Generator additions (~280 lines)

- **`iso_errors_default_to_iso/2`** + **`iso_errors_default_to_lax/2`** — declared `:- dynamic`, both empty. Calls just fail cleanly.
- **`iso_errors_resolve_options/2`** — merges file config + inline options into `iso_config(Default, Overrides)`. Inline wins.
- **`iso_errors_load_config/2`** — reads a flat Prolog facts file (no module decl, no directives), extracts `iso_errors_default/1` and `iso_errors_override/2`, silently ignores everything else.
- **`iso_errors_mode_for/3`** — resolves PI → Mode. Bare `Name/Arity` matches `Module:Name/Arity` in any module and vice versa.
- **`iso_errors_warn_multi_module/2`** — emits `user_error` warning for each bare override that matches predicates from more than one module (the `safe_div/2`-in-two-modules footgun from SPEC §1).
- **`iso_errors_rewrite/4`** — walks Items, rewrites default-form `builtin_call` keys via the swap tables. Explicit `*_iso/N` and `*_lax/N` pass through unchanged. **No-op while tables empty.**
- **`emit_setup_function/3`** — now calls `iso_errors_resolve_options` + `iso_errors_warn_multi_module` before the per-predicate walk, and threads `iso_errors_rewrite` into the parse pipeline.
- **`wam_cpp_iso_audit/3`** + **`wam_cpp_iso_audit_report/1`** — read-only inspection of how each predicate's `builtin_call` sites resolve. Explicit forms detected by `*_iso` / `*_lax` suffix; default sites carry the `would_change_on_flip` diagnostic.

### Runtime helpers (~50 lines)

- **`WamState::throw_iso_error(Value)`** — wraps error term in `error(ErrTerm, _)` (Context = fresh unbound), binds into A1, dispatches via existing `execute_throw()`.
- **`make_type_error`**, **`make_instantiation_error`**, **`make_domain_error`**, **`make_evaluation_error`** — return the inner error term ready for `throw_iso_error`.

No builtin uses these yet — they're here so the first ISO-builtin PR doesn't have to ship runtime + generator changes in the same commit.

### Tests (4 new unit tests, ~100 lines)

| Test | Coverage |
|---|---|
| `iso_errors_config_loader_basic` | 5-line config round-trip; `iso_errors_mode_for/3` against four PI shapes (bare match, fallback, module-qualified, same-name-different-module non-match) |
| `iso_errors_inline_wins_over_file` | File says `false`, inline says `true`; inline wins for both default and per-PI override (covers Perplexity-flagged precedence gap) |
| `iso_errors_multi_module_warning` | Config has bare `safe_div/2`; predicate list has `safe_div/2` in two modules. Captures `user_error`, verifies warning mentions "matches 2 predicates" and both module names |
| `iso_errors_audit_structure` | Runs the audit on a predicate that uses `is/2`; verifies the `audit(PI, Mode, Sites)` record shape |

**Total: 68/68 passing** with `swipl 9.0.4` + `g++ 13` (was 64; +4 new unit tests).

## Verification

```
$ swipl -g "[tests/test_wam_cpp_generator]" -g "run_tests(wam_cpp_generator)" -t halt
% All 68 tests passed
```

## Test plan

- [x] All 64 prior tests still pass (no behavior change since swap tables are empty)
- [x] 4 new unit tests pass
- [x] `g++ -std=c++17` clean compile of the new runtime helpers
- [x] Smoke-tested config loader and multi-module warning in isolation
- [ ] Follow-up PR #2: register `is_iso/2` + `is_lax/2`, add entries to the swap tables, add `cpp_e2e_iso_*` / `cpp_e2e_lax_*` / `cpp_e2e_explicit_*` tests
- [ ] Follow-up PR #3: sweep — arith compares + `succ_iso/2`, ship the lax IEEE-754 float-divide behavior change

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_