### PR TITLE
feat(wam-cpp): is_iso/2 + is_lax/2 — first ISO-aware arithmetic builtin

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -341,15 +341,21 @@ tokenize_wam_chars([C|Cs], Tokens) :-
         string_chars(Tok, QChars),
         Tokens = [Tok|More],
         tokenize_wam_chars(Rest, More)
+    ;   C == ',' , \+ ( Cs = ['/'|_] )
+    ->  % Bare comma (not followed by ''/'' as in ",/2") is the WAM
+        % printer''s argument separator — discard.
+        tokenize_wam_chars(Cs, Tokens)
     ;   read_unquoted_chars([C|Cs], TChars, Rest),
         string_chars(Tok, TChars),
         Tokens = [Tok|More],
         tokenize_wam_chars(Rest, More)
     ).
 
+% Whitespace separators. Bare commas are handled in tokenize_wam_chars
+% above (treated as separators only when NOT immediately followed by
+% ''/'', so the conjunction functor ",/N" survives as one token).
 wam_token_sep(' ').
 wam_token_sep('\t').
-wam_token_sep(',').
 
 read_quoted_chars([], [], []).
 read_quoted_chars(['\''|Rest], [], Rest) :- !.
@@ -359,6 +365,8 @@ read_quoted_chars([C|Cs], [C|More], Rest) :-
 read_unquoted_chars([], [], []).
 read_unquoted_chars([C|Cs], [], [C|Cs]) :-
     wam_token_sep(C), !.
+read_unquoted_chars([',' | Cs], [], [',' | Cs]) :-
+    \+ ( Cs = ['/'|_] ), !.
 read_unquoted_chars([C|Cs], [C|More], Rest) :-
     read_unquoted_chars(Cs, More, Rest).
 
@@ -525,6 +533,15 @@ static const int _wam_cpp_setup_register = []() {
 :- dynamic iso_errors_default_to_iso/2.
 :- dynamic iso_errors_default_to_lax/2.
 
+% is/2 — first ISO-aware builtin. ISO-mode predicates get their
+% default is/2 calls rewritten to is_iso/2 (which throws on bad
+% RHS); lax-mode predicates rewrite to is_lax/2 (a no-op rename
+% since is/2 and is_lax/2 share the runtime body). Explicit
+% is_iso/2 or is_lax/2 in user source survives the rewrite — see
+% iso_errors_rewrite_item/3.
+iso_errors_default_to_iso("is/2", "is_iso/2").
+iso_errors_default_to_lax("is/2", "is_lax/2").
+
 %% iso_errors_resolve_options(+Options, -Config)
 %  Merges the (optional) file config with inline options into one
 %  iso_config(Default, Overrides) struct. Inline options override
@@ -653,9 +670,34 @@ iso_errors_rewrite(Config, PI, Items0, Items) :-
     iso_errors_mode_for(Config, PI, Mode),
     maplist(iso_errors_rewrite_item(Mode), Items0, Items).
 
+% Two surfaces to rewrite for an ISO-relevant builtin:
+%
+% - builtin_call("is/2", _) — the direct call form (`X is Expr` in a
+%   regular conjunction).
+% - put_structure("is/2", _) — the data form when `X is Expr` appears
+%   inside a meta-goal that takes the goal as a term (notably
+%   catch(Goal, ...) — the WAM compiler builds `is(X, Expr)` into A1
+%   and passes it through). Without this rewrite,
+%   invoke_goal_as_call would dispatch the un-rewritten functor and
+%   miss the surrounding predicate''s ISO mode.
+%
+% Also `call("is/2", _)` and `execute("is/2")` for completeness, even
+% though the SWI WAM compiler emits these less commonly for is/2.
 iso_errors_rewrite_item(true, builtin_call(Key, N), builtin_call(IsoKey, N)) :-
     iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(true, put_structure(Key, Reg), put_structure(IsoKey, Reg)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(true, call(Key, N), call(IsoKey, N)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(true, execute(Key), execute(IsoKey)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
 iso_errors_rewrite_item(false, builtin_call(Key, N), builtin_call(LaxKey, N)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(false, put_structure(Key, Reg), put_structure(LaxKey, Reg)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(false, call(Key, N), call(LaxKey, N)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(false, execute(Key), execute(LaxKey)) :-
     iso_errors_default_to_lax(Key, LaxKey), !.
 iso_errors_rewrite_item(_, Item, Item).
 
@@ -719,12 +761,14 @@ iso_errors_other_mode(true,  false).
 iso_errors_other_mode(false, true).
 
 % Match keys like "foo_iso/N" or "foo_lax/N" — Suffix is e.g.
-% '_iso'. Splits on the / first, then checks the name component.
+% "_iso". Splits on the / first, then checks the name component.
+% Keys come through parse_pred_blocks as strings; convert defensively
+% so atom-shaped table entries also work.
 iso_errors_key_has_suffix(Key, Suffix) :-
-    atom(Key),
-    atomic_list_concat(Parts, '/', Key),
+    ( atom(Key) -> atom_string(Key, KS) ; KS = Key ),
+    split_string(KS, "/", "", Parts),
     Parts = [Name | _],
-    atom_concat(_, Suffix, Name).
+    string_concat(_, Suffix, Name).
 
 %% wam_cpp_iso_audit_report(+Audit)
 %  Human-readable pretty-print of an audit result.
@@ -1598,6 +1642,13 @@ struct WamState {
     Value   make_instantiation_error();
     Value   make_domain_error(const std::string& domain, Value culprit);
     Value   make_evaluation_error(const std::string& kind);
+
+    // ISO-arith helpers. term_contains_unbound walks an arith term
+    // tree to detect an instantiation_error condition; arith_culprit
+    // shapes a non-evaluable into the Name/Arity compound ISO mandates
+    // for the type_error culprit slot.
+    bool    term_contains_unbound(CellPtr c) const;
+    Value   arith_culprit(const Value& v) const;
     // Deep-copy a value tree, allocating fresh cells for any Unbound
     // leaves (multiple references to the same source name share the
     // same fresh cell). Used by throw/1 to snapshot the thrown term
@@ -1998,11 +2049,38 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         pc += 1; return true;
     }
 
-    // ---- is/2 -------------------------------------------------------
-    if (op == "is/2") {
+    // ---- is/2, is_lax/2 ---------------------------------------------
+    // Lax arithmetic evaluation. is_lax/2 shares the body so user
+    // code can write is_lax(X, Expr) directly to opt out of an
+    // enclosing ISO-mode predicate''s rewrite (the three-forms
+    // guarantee from WAM_CPP_ISO_ERRORS_PHILOSOPHY §3.3).
+    if (op == "is/2" || op == "is_lax/2") {
         bool ok = true;
         Value rhs = eval_arith(get_cell("A2"), ok);
         if (!ok) return false;
+        CellPtr lhs = get_cell("A1");
+        if (lhs->is_unbound()) { bind_cell(lhs, std::move(rhs)); pc += 1; return true; }
+        if (!(*lhs == rhs)) return false;
+        pc += 1; return true;
+    }
+    // ---- is_iso/2 ---------------------------------------------------
+    // ISO-strict arithmetic. Throws instantiation_error for unbound
+    // sub-terms; type_error(evaluable, Culprit) for non-evaluable
+    // atoms / unknown functors. The walk classifies BEFORE eval so
+    // the diagnostic is the actual culprit shape (matches SPEC §6).
+    if (op == "is_iso/2") {
+        CellPtr rhs_cell = get_cell("A2");
+        if (term_contains_unbound(rhs_cell)) {
+            return throw_iso_error(make_instantiation_error());
+        }
+        bool ok = true;
+        Value rhs = eval_arith(rhs_cell, ok);
+        if (!ok) {
+            // Build culprit as Name/Arity (or the raw value if shape
+            // is unrecognised — fallback for robustness).
+            Value culprit = arith_culprit(deref(*rhs_cell));
+            return throw_iso_error(make_type_error("evaluable", culprit));
+        }
         CellPtr lhs = get_cell("A1");
         if (lhs->is_unbound()) { bind_cell(lhs, std::move(rhs)); pc += 1; return true; }
         if (!(*lhs == rhs)) return false;
@@ -3104,6 +3182,50 @@ Value WamState::make_evaluation_error(const std::string& kind) {
         std::make_shared<Cell>(Value::Atom(kind))
     };
     return Value::Compound("evaluation_error/1", std::move(args));
+}
+
+bool WamState::term_contains_unbound(CellPtr c) const {
+    Value v = deref(*c);
+    if (v.tag == Value::Tag::Unbound || v.tag == Value::Tag::Uninit) return true;
+    if (v.tag == Value::Tag::Compound) {
+        for (auto& arg : v.args) {
+            if (term_contains_unbound(arg)) return true;
+        }
+    }
+    return false;
+}
+
+Value WamState::arith_culprit(const Value& v) const {
+    // ISO type_error(evaluable, Culprit) expects Culprit to be a
+    // Name/Arity compound (`foo/0` for an atom; `unknown/3` for an
+    // unknown compound). Fall back to the raw value if the shape is
+    // unrecognised — diagnostic is still useful, just not standards-
+    // perfect.
+    if (v.tag == Value::Tag::Atom) {
+        std::vector<CellPtr> args = {
+            std::make_shared<Cell>(Value::Atom(v.s)),
+            std::make_shared<Cell>(Value::Integer(0))
+        };
+        return Value::Compound("//2", std::move(args));
+    }
+    if (v.tag == Value::Tag::Compound) {
+        // Compound s is "name/arity". Split and rebuild as the
+        // ISO-shaped name/arity compound.
+        auto slash = v.s.rfind(''/'');
+        if (slash != std::string::npos) {
+            std::string name  = v.s.substr(0, slash);
+            std::string arity = v.s.substr(slash + 1);
+            try {
+                long long n = std::stoll(arity);
+                std::vector<CellPtr> args = {
+                    std::make_shared<Cell>(Value::Atom(name)),
+                    std::make_shared<Cell>(Value::Integer(n))
+                };
+                return Value::Compound("//2", std::move(args));
+            } catch (...) {}
+        }
+    }
+    return v;
 }
 
 bool WamState::backtrack() {

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -152,6 +152,52 @@ user:wam_cpp_test_fmt2_compound     :- format('result: ~w~n', [foo(1, bar)]).
 user:wam_cpp_test_fmt2_tilde        :- format('100~~~n', []).
 user:wam_cpp_test_fmt2_no_directives :- format('hello world', []).
 
+% ISO-error fixtures for is_iso/2 + is_lax/2. Some predicates expect
+% to be flipped to ISO mode by the test''s write_wam_cpp_project
+% options; others stay in lax mode to exercise the no-rewrite path.
+:- dynamic user:wam_cpp_test_iso_is_type_error/0.
+:- dynamic user:wam_cpp_test_iso_is_instantiation/0.
+:- dynamic user:wam_cpp_test_iso_is_unmatched/0.
+:- dynamic user:wam_cpp_test_lax_is_silent/0.
+:- dynamic user:wam_cpp_test_explicit_lax_in_iso/0.
+:- dynamic user:wam_cpp_test_iso_unbound_context/0.
+
+user:wam_cpp_test_iso_is_type_error :-
+    catch(X is foo, error(type_error(evaluable, _Culprit), _), X = X).
+
+user:wam_cpp_test_iso_is_instantiation :-
+    catch(Y is _Z + 1, error(instantiation_error, _), Y = Y).
+
+% Unmatched catcher: ISO mode throws type_error, the catcher pattern
+% doesn''t unify, so the throw propagates uncaught. Result: false.
+user:wam_cpp_test_iso_is_unmatched :-
+    catch(X is foo, error(some_other_kind, _), X = X).
+
+% Lax mode: X is foo just fails. The (-> ; true) wrapper turns the
+% failure into success so the predicate as a whole returns true —
+% verifies that lax mode emits NO throw (otherwise the catch would
+% need to recover).
+user:wam_cpp_test_lax_is_silent :-
+    (X is foo -> X = X ; true).
+
+% Three-forms guarantee: explicit is_lax/2 inside an ISO-mode
+% predicate must still fail silently. If the rewrite incorrectly
+% touched the explicit form, this would throw and the (-> ; true)
+% wrapper would still succeed — but stderr would have a "uncaught
+% exception" trace and the catch above would catch type_error,
+% breaking the (-> ; true) branch. Easier to test: just verify the
+% (-> ; true) takes the false branch (returns true overall).
+user:wam_cpp_test_explicit_lax_in_iso :-
+    (is_lax(X, foo) -> X = X ; true).
+
+% Verifies catch(_, error(Pattern, _), _) works even though Context
+% is left unbound by throw_iso_error. Forward-looking test from
+% SPECIFICATION §8.
+user:wam_cpp_test_iso_unbound_context :-
+    catch(X is foo,
+          error(type_error(evaluable, Culprit), _Context),
+          Culprit = foo/0).
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -1077,6 +1123,126 @@ test(cpp_e2e_format_tilde_escape, [condition(cpp_compiler_available)]) :-
         ( build_e2e_binary(TmpDir, BinPath),
           run_query_stdout(BinPath, 'wam_cpp_test_fmt2_tilde/0', [],
                            true, "100~\n")
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% ISO arithmetic — first ISO-aware builtin (is_iso/2 + is_lax/2).
+% Each test flips the relevant test predicate to ISO mode via the
+% inline `iso_errors(PI, true)` option; the explicit-lax test ALSO
+% flips its enclosing predicate to ISO mode and verifies the
+% explicit is_lax/2 call site survives the rewrite (three-forms
+% guarantee from WAM_CPP_ISO_ERRORS_PHILOSOPHY §3.3).
+% ------------------------------------------------------------------
+
+test(cpp_e2e_iso_is_throws_type_error, [condition(cpp_compiler_available)]) :-
+    % ISO mode + non-evaluable atom → catcher with
+    % error(type_error(evaluable, _), _) matches; recovery runs.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_iso_is_type', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_iso_is_type_error/0],
+                              [emit_main(true),
+                               iso_errors(wam_cpp_test_iso_is_type_error/0,
+                                          true)],
+                              TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_iso_is_type_error/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_iso_is_throws_instantiation, [condition(cpp_compiler_available)]) :-
+    % ISO mode + RHS contains unbound → catcher with
+    % error(instantiation_error, _) matches.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_iso_is_inst', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_iso_is_instantiation/0],
+                              [emit_main(true),
+                               iso_errors(wam_cpp_test_iso_is_instantiation/0,
+                                          true)],
+                              TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_iso_is_instantiation/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_iso_is_unmatched_propagates,
+     [condition(cpp_compiler_available)]) :-
+    % ISO mode throws type_error, but the catcher pattern is
+    % error(some_other_kind, _) which doesn''t unify. Throw walks
+    % past the catcher → uncaught → false on stdout, "uncaught
+    % exception" diagnostic on stderr (which run_query discards).
+    unique_cpp_tmp_dir('tmp_cpp_e2e_iso_is_unmatched', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_iso_is_unmatched/0],
+                              [emit_main(true),
+                               iso_errors(wam_cpp_test_iso_is_unmatched/0,
+                                          true)],
+                              TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_iso_is_unmatched/0', [], false)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_lax_is_silent_fail, [condition(cpp_compiler_available)]) :-
+    % Default-mode predicate: X is foo silently fails. The
+    % (-> ; true) wraps that into success → true.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_lax_is', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_lax_is_silent/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_lax_is_silent/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_explicit_lax_in_iso_predicate,
+     [condition(cpp_compiler_available)]) :-
+    % Three-forms guarantee: predicate is flipped to ISO mode, but
+    % uses is_lax(X, foo) directly. The rewrite must NOT touch the
+    % explicit lax key; behavior stays lax (silent fail wrapped
+    % into success by -> ; true). If the rewrite incorrectly
+    % converted is_lax/2 → is_iso/2, throw would propagate and the
+    % program would not return true cleanly.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_explicit_lax_in_iso', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_explicit_lax_in_iso/0],
+                              [emit_main(true),
+                               iso_errors(wam_cpp_test_explicit_lax_in_iso/0,
+                                          true)],
+                              TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_explicit_lax_in_iso/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_iso_unbound_context, [condition(cpp_compiler_available)]) :-
+    % Catcher pattern is error(type_error(evaluable, Culprit), _) —
+    % the Context slot is bound to a fresh unbound, but the catch
+    % still succeeds because unification with an unbound is
+    % unconditional. Recovery verifies Culprit binds to foo/0 (per
+    % SPEC §6 culprit-shape rule). Regression guard against the
+    % decision to leave Context unbound for v1.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_iso_unbound_ctx', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_iso_unbound_context/0],
+                              [emit_main(true),
+                               iso_errors(wam_cpp_test_iso_unbound_context/0,
+                                          true)],
+                              TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_iso_unbound_context/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Second PR in the ISO-errors phasing plan (SPEC §10 step 2). Adds the runtime branches and the swap-table entry that turn ISO-mode predicates' `X is Expr` calls into structured throws, while leaving lax-mode (default) behavior **byte-identical** to today.

## Runtime additions

- **`is/2`** and **`is_lax/2`** share a single C++ branch — both fail silently on bad eval. `is_lax/2` exists as a separate dispatch key so user code can write `is_lax(X, Expr)` to opt out of an enclosing ISO-mode predicate's rewrite (three-forms guarantee from PHILOSOPHY §3.3).
- **`is_iso/2`** is the strict flavor. Classifies the RHS **before** eval:
  - `term_contains_unbound` walks the deref'd tree; any `Unbound`/`Uninit` triggers `throw_iso_error(make_instantiation_error())`.
  - `eval_arith` failure (non-evaluable atom or unknown functor) triggers `throw_iso_error(make_type_error("evaluable", arith_culprit(...)))`.
  - `arith_culprit` shapes the culprit into `Name/Arity` (`foo/0` for an atom, `unknown/3` for a compound) — matches the SPEC §6 thrown-term shape.

## Generator additions

- `iso_errors_default_to_iso("is/2", "is_iso/2")` — first entry in the previously-empty default→ISO swap table.
- `iso_errors_default_to_lax("is/2", "is_lax/2")` — symmetric entry; no-op semantically since `is/2` and `is_lax/2` share a body, but makes the audit's `resolved` field accurate.
- `iso_errors_rewrite_item/3` grows three more head patterns (`put_structure`, `call`, `execute`) on top of the existing `builtin_call` form. This catches the case where `X is Expr` appears as a goal-term — e.g. `catch(X is foo, ...)` where the SWI WAM compiler emits `put_structure is/2, ...` to build the goal, then `execute catch/3`. Without the `put_structure` rewrite, `invoke_goal_as_call` would dispatch the un-rewritten functor and miss the surrounding predicate's ISO mode.

## Tokenizer fix

The previous tokenizer treated bare comma as a whitespace-style separator, which corrupted the conjunction functor name (`",/2"` became `"/2"`). The fix: tokenize on whitespace only, and treat comma as a separator **only** when not immediately followed by `/`. That keeps `,/N`-shaped operator names as one token while still discarding the `"X1," → "X1"` argument-separator commas. Same logic in `read_unquoted_chars` stops accumulation on a bare comma.

This was a latent bug — it would have hit anyone writing `catch((A, B), ...)` or any other use of conjunction-as-data, but the existing test suite happened to avoid it. Surfaced while verifying `is_iso/2`.

## Tests — 6 new e2e tests

| Test | Coverage |
|---|---|
| `cpp_e2e_iso_is_throws_type_error` | `X is foo` in ISO mode throws `type_error(evaluable, foo/0)`; catcher matches |
| `cpp_e2e_iso_is_throws_instantiation` | `Y is _ + 1` in ISO mode throws `instantiation_error`; catcher matches |
| `cpp_e2e_iso_is_unmatched_propagates` | ISO throw + non-matching catcher → uncaught, stderr diagnostic, exit false |
| `cpp_e2e_lax_is_silent_fail` | Default-mode predicate with `X is foo` still fails silently |
| `cpp_e2e_explicit_lax_in_iso_predicate` | ISO-mode predicate that uses `is_lax(X, foo)` directly — rewrite must NOT touch the explicit lax key (three-forms guarantee end-to-end) |
| `cpp_e2e_iso_unbound_context` | Catcher pattern `error(type_error(evaluable, Culprit), _Context)` — unbound Context still unifies; `Culprit` binds to `foo/0`. Forward-looking test from SPEC §8 |

**Total: 74/74 passing** with `swipl 9.0.4` + `g++ 13` (was 68; +6 new).

## Verification

```
$ swipl -g "[tests/test_wam_cpp_generator]" -g "run_tests(wam_cpp_generator)" -t halt
% All 74 tests passed
```

Sample run demonstrating the uncaught-throw stderr path:

```
$ ./cpp_test test_iso_unmatched/0
uncaught exception: error(type_error(evaluable, /(foo, 0)), _T3)   ← stderr
false                                                              ← stdout
```

## Known limitations

- `catch` with a **conjunction goal** — `catch((A, B), ...)` — needs `invoke_goal_as_call` to handle the `,/2` functor by sequencing two invocations. **Not in this PR**. The tokenizer fix shipped here because that's a latent bug regardless; the catch-conjunction support is its own feature.

## Test plan

- [x] All 68 prior tests still pass (no regression)
- [x] 6 new e2e tests pass covering ISO/lax/explicit/unbound-context paths
- [x] `g++ -std=c++17` clean compile
- [x] Smoke-tested with stderr capture to verify the throw-walk path
- [ ] Follow-up PR #3 (sweep): arith compares + `succ_iso/2` + IEEE-754 lax float divide

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_