### PR TITLE
feat(wam-c): report body-call lowering rejections

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,7 +5,7 @@ Status date: 2026-05-14
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `69d5b9e9` (`Merge pull request #2070 from s243a/test/wam-c-asan-smoke-stderr-log`)
+- `main` at `6e5e8cca` (`Merge pull request #2083 from s243a/feat/wam-c-lowered-helper-empty-result-rejections`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
@@ -14,7 +14,7 @@ Base verified locally:
 
 Active branch:
 
-- `feat/wam-c-lowered-helper-empty-result-rejections`
+- `feat/wam-c-lowered-helper-body-call-rejections`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -51,7 +51,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper comparison-filter shape | Done | Fact-only callee plus one integer comparison guard lowers into native fact rows and the tiny lowered-helper matrix exercises it |
 | Lowered helper comparison-filter rejection metadata | Done | Planner reports explicit rejection reasons for unbound comparison guard variables, unsupported expressions, non-integer ordering rows, and no matching rows |
 | Lowered helper repeated-variable filters | Done | Constant and comparison filtered helpers preserve repeated callee-variable row constraints with planner and executable coverage |
-| Lowered helper empty-result rejections | In progress | Active branch reports `no_matching_filter_rows` for supported constant filtered helpers whose constraints produce no rows, alongside existing comparison no-match metadata |
+| Lowered helper empty-result rejections | Done | Planner reports `no_matching_filter_rows` for supported constant filtered helpers whose constraints produce no rows, alongside existing comparison no-match metadata |
+| Lowered helper body-call rejection metadata | In progress | Active branch reports explicit unavailable and non-lowerable callee reasons for exact user-predicate body-call shapes |
 
 ## Current C Target Baseline
 
@@ -132,24 +133,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lowered-helper-empty-result-rejections`
-
-Goal: make empty lowered-helper result sets explicit across supported filter
-families.
-
-Scope:
-
-- Add focused planner metadata for filters whose supported shape produces no
-  rows.
-- Keep successful fact-only, body-call, filtered-fact, comparison-filtered,
-  and repeated-variable paths unchanged.
-- Prefer planner tests and generated plan comments over new runtime paths.
-
-Status: active; constant filtered helpers now report
-`no_matching_filter_rows` when supported constraints produce no projected rows,
-matching the existing explicit comparison no-match metadata.
-
-### 2. `feat/wam-c-lowered-helper-body-call-rejections`
+### 1. `feat/wam-c-lowered-helper-body-call-rejections`
 
 Goal: make unsupported body-call lowering failures explicit before expanding
 the body-call helper surface.
@@ -161,10 +145,26 @@ Scope:
 - Keep the existing direct native fact-helper dispatch unchanged.
 - Prefer planner tests and generated plan comments over runtime changes.
 
+Status: active; exact user-predicate body-call shapes now report
+`body_call_callee_not_available` or `body_call_callee_not_lowerable` when they
+cannot use direct native helper dispatch.
+
+### 2. `feat/wam-c-lowered-helper-expanded-body-calls`
+
+Goal: expand body-call helper lowering beyond direct alias-to-fact dispatch only
+after unsupported body-call shapes have explicit planner metadata.
+
+Scope:
+
+- Evaluate simple body-call projections that are currently handled as filtered
+  fact helpers.
+- Keep explicit rejection metadata for unavailable and non-lowerable callees.
+- Add runtime coverage only for any newly supported body-call shape.
+
 ## Suggested Immediate Next Step
 
-Continue validating `feat/wam-c-lowered-helper-empty-result-rejections`.
+Continue validating `feat/wam-c-lowered-helper-body-call-rejections`.
 
 The active branch adds explicit planner and generated-comment metadata for
-supported constant filtered helpers whose constraints produce no rows, while
-leaving successful lowered helper paths unchanged.
+exact user-predicate body-call shapes whose callee is unavailable or not
+lowerable, while leaving successful direct body-call helper dispatch unchanged.

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -183,6 +183,8 @@ plan_wam_c_lowered_helper(DetectedKeys, AvailableKeys, PredIndicator, Plan) :-
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, fact_only(Rows))
     ;   lowered_body_call_helper(PredIndicator, AvailableKeys, CalleeKey, CalleeArity)
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, body_call(CalleeKey, CalleeArity))
+    ;   lowered_body_call_rejection_reason(PredIndicator, AvailableKeys, Reason)
+    ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, rejected, Reason)
     ;   lowered_comparison_filtered_fact_helper(PredIndicator, CalleeKey, Rows)
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, comparison_filtered_fact(CalleeKey, Rows))
     ;   lowered_filtered_fact_helper(PredIndicator, CalleeKey, Rows)
@@ -441,6 +443,41 @@ lowered_body_call_helper(PredIndicator, AvailableKeys, CalleeKey, CalleeArity) :
     lowered_fact_helper_rows(CalleeIndicator, _Rows),
     format(atom(CalleeKey), '~w/~w', [CalleePred, CalleeArity]),
     memberchk(CalleeKey, AvailableKeys).
+
+lowered_body_call_rejection_reason(PredIndicator, AvailableKeys, Reason) :-
+    body_call_context(PredIndicator, CalleePred, CalleeArity, CalleeKey),
+    callee_has_user_clause(CalleePred, CalleeArity),
+    (   \+ memberchk(CalleeKey, AvailableKeys)
+    ->  Reason = body_call_callee_not_available
+    ;   CalleeIndicator = user:CalleePred/CalleeArity,
+        \+ lowered_fact_helper_rows(CalleeIndicator, _Rows)
+    ->  Reason = body_call_callee_not_lowerable
+    ),
+    !.
+
+body_call_context(PredIndicator, CalleePred, CalleeArity, CalleeKey) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
+    functor(Head, Pred, Arity),
+    findall(Args-Body,
+            (   user:clause(Head, Body),
+                Head =.. [_|Args]
+            ),
+            [Args-Body0]),
+    Body0 \== true,
+    strip_module_qualification(Body0, Body),
+    Body \= (_, _),
+    Body =.. [CalleePred|CalleeArgs],
+    length(CalleeArgs, CalleeArity),
+    Args == CalleeArgs,
+    (Pred/Arity) \== (CalleePred/CalleeArity),
+    format(atom(CalleeKey), '~w/~w', [CalleePred, CalleeArity]).
+
+callee_has_user_clause(Pred, Arity) :-
+    functor(Head, Pred, Arity),
+    catch(user:clause(Head, _Body),
+          error(permission_error(access, private_procedure, _), _),
+          fail),
+    !.
 
 lowered_body_call_helper_for_predicate(PredIndicator, CalleeKey, CalleeArity, Key, Code, SetupLine) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -425,6 +425,45 @@ test_lowered_body_call_helper_generation :-
     retractall(user:wam_c_body_fact(_, _)),
     retractall(user:wam_c_body_alias(_, _)).
 
+test_lowered_body_call_rejection_metadata :-
+    Test = 'WAM-C: lowered helper planner explains unsupported body-call shapes',
+    assertz(user:wam_c_body_reject_fact(a, b)),
+    assertz((user:wam_c_body_reject_missing(X, Y) :-
+                 user:wam_c_body_reject_fact(X, Y))),
+    assertz((user:wam_c_body_reject_rule_callee(X, Y) :-
+                 user:wam_c_body_reject_fact(X, Y))),
+    assertz((user:wam_c_body_reject_rule_alias(X, Y) :-
+                 user:wam_c_body_reject_rule_callee(X, Y))),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_lowered_body_reject_project', Stamp, ProjectDir),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    (   plan_wam_c_lowered_helpers([user:wam_c_body_reject_missing/2,
+                                     user:wam_c_body_reject_rule_callee/2,
+                                     user:wam_c_body_reject_rule_alias/2],
+                                    [lowered_helpers(true)],
+                                    [],
+                                    Plans),
+        member(wam_c_lowered_helper_plan('wam_c_body_reject_missing/2', _, rejected, body_call_callee_not_available), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_body_reject_rule_callee/2', _, rejected, body_call_callee_not_available), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_body_reject_rule_alias/2', _, rejected, body_call_callee_not_lowerable), Plans),
+        write_wam_c_project([user:wam_c_body_reject_missing/2,
+                             user:wam_c_body_reject_rule_callee/2,
+                             user:wam_c_body_reject_rule_alias/2],
+                            [lowered_helpers(true)],
+                            ProjectDir),
+        read_file_to_string(LibPath, LibS, []),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_body_reject_missing/2: body_call_callee_not_available'),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_body_reject_rule_callee/2: body_call_callee_not_available'),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_body_reject_rule_alias/2: body_call_callee_not_lowerable')
+    ->  pass(Test)
+    ;   fail_test(Test, 'planner did not report explicit body-call rejection reasons')
+    ),
+    retractall(user:wam_c_body_reject_fact(_, _)),
+    retractall(user:wam_c_body_reject_missing(_, _)),
+    retractall(user:wam_c_body_reject_rule_callee(_, _)),
+    retractall(user:wam_c_body_reject_rule_alias(_, _)).
+
 test_lowered_filtered_fact_helper_generation :-
     Test = 'WAM-C: guarded fact predicates can lower to filtered native helper',
     assertz(user:wam_c_filter_fact(a, keep)),
@@ -2683,6 +2722,7 @@ run_tests_once :-
     test_lowered_helper_planner_metadata,
     test_lowered_helper_plan_generation,
     test_lowered_body_call_helper_generation,
+    test_lowered_body_call_rejection_metadata,
     test_lowered_filtered_fact_helper_generation,
     test_lowered_comparison_filter_helper_generation,
     test_lowered_repeated_variable_filter_generation,


### PR DESCRIPTION
## Summary

- add explicit lowered-helper planner metadata for exact user-predicate body-call shapes that cannot lower through direct native helper dispatch
- distinguish unavailable callees from available but non-lowerable callees with `body_call_callee_not_available` and `body_call_callee_not_lowerable`
- cover the new rejection reasons in planner assertions and generated `lib.c` plan comments
- refresh the WAM-C roadmap to mark empty-result rejection metadata done and this branch active

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --check`

## Notes

- Successful direct body-call helper lowering is unchanged.
- Builtin and filtered-fact rejection paths keep their existing classifications.
- The branch is committed as `bb27dada feat(wam-c): report body-call lowering rejections`.