### PR TITLE
refactor(wam): shared wam_text_parser module + C++ target migration

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_cpp_lowered_emitter.pl
@@ -26,72 +26,25 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(wam_text_parser, [wam_text_to_items/2]).
 % Inlined escape helper to avoid a circular import with wam_cpp_target.
 % Keeps this module standalone-loadable.
 
 % =====================================================================
 % Parsing — accept either an instruction list or a WAM-text blob.
-% Mirrors parse_wam_text/2 from wam_rust_lowered_emitter.pl exactly.
+% Delegates to the shared wam_text_parser module so this module gets
+% the quote-aware tokenizer + ",/N" handling for free (previously
+% used a split_string-based parser that mis-tokenised any predicate
+% with a quoted atom argument or a conjunction-as-data, silently
+% returning empty instruction lists and disabling lowering for those
+% predicates).
 % =====================================================================
 
 parse_wam_text(WamText, Instrs) :-
-    atom_string(WamText, S),
-    split_string(S, "\n", "", Lines),
-    parse_lines(Lines, Instrs).
+    wam_text_to_items(WamText, Items),
+    exclude(is_label_item, Items, Instrs).
 
-parse_lines([], []).
-parse_lines([Line|Rest], Instrs) :-
-    split_string(Line, " \t,", " \t,", Parts),
-    delete(Parts, "", CleanParts),
-    (   CleanParts == []
-    ->  parse_lines(Rest, Instrs)
-    ;   CleanParts = [First|_],
-        (   sub_string(First, _, 1, 0, ":")
-        ->  parse_lines(Rest, Instrs)
-        ;   instr_from_parts(CleanParts, Instr)
-        ->  Instrs = [Instr|RestInstrs],
-            parse_lines(Rest, RestInstrs)
-        ;   parse_lines(Rest, Instrs)
-        )
-    ).
-
-instr_from_parts(["get_constant", C, Ai], get_constant(C, Ai)).
-instr_from_parts(["get_variable", Xn, Ai], get_variable(Xn, Ai)).
-instr_from_parts(["get_value", Xn, Ai], get_value(Xn, Ai)).
-instr_from_parts(["get_structure", F, Ai], get_structure(F, Ai)).
-instr_from_parts(["get_list", Ai], get_list(Ai)).
-instr_from_parts(["get_nil", Ai], get_nil(Ai)).
-instr_from_parts(["get_integer", N, Ai], get_integer(N, Ai)).
-instr_from_parts(["unify_variable", Xn], unify_variable(Xn)).
-instr_from_parts(["unify_value", Xn], unify_value(Xn)).
-instr_from_parts(["unify_constant", C], unify_constant(C)).
-instr_from_parts(["put_variable", Xn, Ai], put_variable(Xn, Ai)).
-instr_from_parts(["put_value", Xn, Ai], put_value(Xn, Ai)).
-instr_from_parts(["put_constant", C, Ai], put_constant(C, Ai)).
-instr_from_parts(["put_structure", F, Ai], put_structure(F, Ai)).
-instr_from_parts(["put_list", Ai], put_list(Ai)).
-instr_from_parts(["set_variable", Xn], set_variable(Xn)).
-instr_from_parts(["set_value", Xn], set_value(Xn)).
-instr_from_parts(["set_constant", C], set_constant(C)).
-instr_from_parts(["call", P, N], call(P, N)).
-instr_from_parts(["execute", P], execute(P)).
-instr_from_parts(["proceed"], proceed).
-instr_from_parts(["fail"], fail).
-instr_from_parts(["allocate"], allocate).
-instr_from_parts(["deallocate"], deallocate).
-instr_from_parts(["builtin_call", Op, Ar], builtin_call(Op, Ar)).
-instr_from_parts(["call_foreign", Pred, Ar], call_foreign(Pred, Ar)).
-instr_from_parts(["try_me_else", L], try_me_else(L)).
-instr_from_parts(["retry_me_else", L], retry_me_else(L)).
-instr_from_parts(["trust_me"], trust_me).
-instr_from_parts(["jump", L], jump(L)).
-instr_from_parts(["cut_ite"], cut_ite).
-instr_from_parts(["begin_aggregate", K, V, R], begin_aggregate(K, V, R)).
-instr_from_parts(["end_aggregate", R], end_aggregate(R)).
-instr_from_parts(["switch_on_constant" | Entries], switch_on_constant(Entries)).
-instr_from_parts(["switch_on_constant_a2" | Entries], switch_on_constant_a2(Entries)).
-instr_from_parts(["switch_on_structure" | Entries], switch_on_structure(Entries)).
-instr_from_parts(["switch_on_term" | Tokens], switch_on_term(Tokens)).
+is_label_item(label(_)).
 
 % =====================================================================
 % Lowerability

--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -51,6 +51,13 @@
     cpp_lowered_func_name/2,
     parse_wam_text/2
 ]).
+% Shared WAM-text tokenizer + recogniser (PR following #2086). Local
+% tokenizer + parser predicates were lifted into this module; the
+% wrapper parse_pred_blocks/2 below is kept as a thin alias since
+% existing call sites still use that name.
+:- use_module(wam_text_parser, [
+    wam_text_to_items/2
+]).
 
 :- multifile user:wam_cpp_emit_mode/1.
 
@@ -313,123 +320,11 @@ extern void wam_cpp_setup_~w(WamState&);
 % ============================================================================
 
 %% parse_pred_blocks(+WamText, -Items)
-%  Items is a list interleaving label(Name) and instruction terms in
-%  source order. Unrecognised instructions (e.g. switch_on_constant) are
-%  silently skipped — the try_me_else / trust_me path still works.
+%  Thin alias for wam_text_parser:wam_text_to_items/2. Kept under the
+%  pre-existing name since several call sites in this file still use
+%  it; new code should call wam_text_to_items/2 directly.
 parse_pred_blocks(WamText, Items) :-
-    atom_string(WamText, S),
-    split_string(S, "\n", "", Lines),
-    parse_block_lines(Lines, Items).
-
-%% tokenize_wam_line(+Line, -Tokens)
-%  Splits a WAM-text line on whitespace and commas, but respects
-%  single-quoted atom literals so the content (which may contain
-%  spaces, commas, or ~-directives for format strings) becomes a
-%  single token. Surrounding single quotes are stripped from the
-%  resulting token. No escape sequences are recognised inside quotes —
-%  matches the printer''s own non-escaping behaviour.
-tokenize_wam_line(Line, Tokens) :-
-    string_chars(Line, Chars),
-    tokenize_wam_chars(Chars, Tokens).
-
-tokenize_wam_chars([], []).
-tokenize_wam_chars([C|Cs], Tokens) :-
-    (   wam_token_sep(C)
-    ->  tokenize_wam_chars(Cs, Tokens)
-    ;   C == '\''
-    ->  read_quoted_chars(Cs, QChars, Rest),
-        string_chars(Tok, QChars),
-        Tokens = [Tok|More],
-        tokenize_wam_chars(Rest, More)
-    ;   C == ',' , \+ ( Cs = ['/'|_] )
-    ->  % Bare comma (not followed by ''/'' as in ",/2") is the WAM
-        % printer''s argument separator — discard.
-        tokenize_wam_chars(Cs, Tokens)
-    ;   read_unquoted_chars([C|Cs], TChars, Rest),
-        string_chars(Tok, TChars),
-        Tokens = [Tok|More],
-        tokenize_wam_chars(Rest, More)
-    ).
-
-% Whitespace separators. Bare commas are handled in tokenize_wam_chars
-% above (treated as separators only when NOT immediately followed by
-% ''/'', so the conjunction functor ",/N" survives as one token).
-wam_token_sep(' ').
-wam_token_sep('\t').
-
-read_quoted_chars([], [], []).
-read_quoted_chars(['\''|Rest], [], Rest) :- !.
-read_quoted_chars([C|Cs], [C|More], Rest) :-
-    read_quoted_chars(Cs, More, Rest).
-
-read_unquoted_chars([], [], []).
-read_unquoted_chars([C|Cs], [], [C|Cs]) :-
-    wam_token_sep(C), !.
-read_unquoted_chars([',' | Cs], [], [',' | Cs]) :-
-    \+ ( Cs = ['/'|_] ), !.
-read_unquoted_chars([C|Cs], [C|More], Rest) :-
-    read_unquoted_chars(Cs, More, Rest).
-
-parse_block_lines([], []).
-parse_block_lines([Line|Rest], Items) :-
-    tokenize_wam_line(Line, CleanParts),
-    (   CleanParts == []
-    ->  parse_block_lines(Rest, Items)
-    ;   CleanParts = [First|_],
-        (   sub_string(First, _, 1, 0, ":")
-        ->  string_length(First, FLen),
-            L1 is FLen - 1,
-            sub_string(First, 0, L1, _, NameStr),
-            Items = [label(NameStr)|MoreItems],
-            parse_block_lines(Rest, MoreItems)
-        ;   wam_cpp_lowered_emitter_instr(CleanParts, Instr)
-        ->  Items = [Instr|MoreItems],
-            parse_block_lines(Rest, MoreItems)
-        ;   parse_block_lines(Rest, Items)
-        )
-    ).
-
-% Inline copy of the lowered emitter's instr_from_parts to avoid making
-% it public. Kept in lockstep with wam_cpp_lowered_emitter.pl.
-wam_cpp_lowered_emitter_instr(["get_constant", C, Ai], get_constant(C, Ai)).
-wam_cpp_lowered_emitter_instr(["get_variable", Xn, Ai], get_variable(Xn, Ai)).
-wam_cpp_lowered_emitter_instr(["get_value", Xn, Ai], get_value(Xn, Ai)).
-wam_cpp_lowered_emitter_instr(["get_structure", F, Ai], get_structure(F, Ai)).
-wam_cpp_lowered_emitter_instr(["get_list", Ai], get_list(Ai)).
-wam_cpp_lowered_emitter_instr(["get_nil", Ai], get_nil(Ai)).
-wam_cpp_lowered_emitter_instr(["get_integer", N, Ai], get_integer(N, Ai)).
-wam_cpp_lowered_emitter_instr(["unify_variable", Xn], unify_variable(Xn)).
-wam_cpp_lowered_emitter_instr(["unify_value", Xn], unify_value(Xn)).
-wam_cpp_lowered_emitter_instr(["unify_constant", C], unify_constant(C)).
-wam_cpp_lowered_emitter_instr(["put_variable", Xn, Ai], put_variable(Xn, Ai)).
-wam_cpp_lowered_emitter_instr(["put_value", Xn, Ai], put_value(Xn, Ai)).
-wam_cpp_lowered_emitter_instr(["put_constant", C, Ai], put_constant(C, Ai)).
-wam_cpp_lowered_emitter_instr(["put_structure", F, Ai], put_structure(F, Ai)).
-wam_cpp_lowered_emitter_instr(["put_list", Ai], put_list(Ai)).
-wam_cpp_lowered_emitter_instr(["set_variable", Xn], set_variable(Xn)).
-wam_cpp_lowered_emitter_instr(["set_value", Xn], set_value(Xn)).
-wam_cpp_lowered_emitter_instr(["set_constant", C], set_constant(C)).
-wam_cpp_lowered_emitter_instr(["call", P, N], call(P, N)).
-wam_cpp_lowered_emitter_instr(["execute", P], execute(P)).
-wam_cpp_lowered_emitter_instr(["proceed"], proceed).
-wam_cpp_lowered_emitter_instr(["fail"], fail).
-wam_cpp_lowered_emitter_instr(["allocate"], allocate).
-wam_cpp_lowered_emitter_instr(["deallocate"], deallocate).
-wam_cpp_lowered_emitter_instr(["builtin_call", Op, Ar], builtin_call(Op, Ar)).
-wam_cpp_lowered_emitter_instr(["call_foreign", Pred, Ar], call_foreign(Pred, Ar)).
-wam_cpp_lowered_emitter_instr(["try_me_else", L], try_me_else(L)).
-wam_cpp_lowered_emitter_instr(["retry_me_else", L], retry_me_else(L)).
-wam_cpp_lowered_emitter_instr(["trust_me"], trust_me).
-wam_cpp_lowered_emitter_instr(["jump", L], jump(L)).
-wam_cpp_lowered_emitter_instr(["cut_ite"], cut_ite).
-wam_cpp_lowered_emitter_instr(["begin_aggregate", K, V, R], begin_aggregate(K, V, R)).
-wam_cpp_lowered_emitter_instr(["end_aggregate", R], end_aggregate(R)).
-% Indexing instructions: variable-arity, so we capture all tail tokens
-% and parse them in instr_to_setup_line.
-wam_cpp_lowered_emitter_instr(["switch_on_constant" | Entries], switch_on_constant(Entries)).
-wam_cpp_lowered_emitter_instr(["switch_on_constant_a2" | Entries], switch_on_constant_a2(Entries)).
-wam_cpp_lowered_emitter_instr(["switch_on_structure" | Entries], switch_on_structure(Entries)).
-wam_cpp_lowered_emitter_instr(["switch_on_term" | Tokens], switch_on_term(Tokens)).
+    wam_text_to_items(WamText, Items).
 
 %% walk_blocks(+AllItems, -Labels, -FlatInstrs)
 %  Single pass: every label() records its PC; every instruction goes into

--- a/src/unifyweaver/targets/wam_text_parser.pl
+++ b/src/unifyweaver/targets/wam_text_parser.pl
@@ -1,0 +1,180 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% wam_text_parser.pl - Shared WAM-text parser building blocks
+%
+% Per WAM_ITEMS_API_PHILOSOPHY.md and WAM_ITEMS_API_SPECIFICATION.md
+% (PR #2086): each WAM target used to ship its own tokenizer +
+% recogniser, with subtle bugs that drifted across targets (the
+% quote-aware tokenizer fix from PR #2076 lived only in the C++
+% target until this module landed; the ,/2 fix from PR #2084 same).
+% This module is the single source of truth.
+%
+% Public predicates:
+%   wam_tokenize_line/2        - quote-aware tokenizer (whitespace-
+%                                separated, with bare-comma logic that
+%                                preserves ",/N"-shaped functor names).
+%   wam_recognise_label/2      - one-token line ending in ':' → label
+%                                name string.
+%   wam_recognise_instruction/2 - token list → standard WAM
+%                                instruction term, or fail.
+%   wam_text_to_items/2        - high-level: WAM text → list of
+%                                label(Name) and instruction items in
+%                                source order. Unrecognised lines
+%                                silently skipped (the long-standing
+%                                tolerance behaviour of every target''s
+%                                parser).
+%
+% The instruction-term shapes are the catalogue from
+% WAM_ITEMS_API_SPECIFICATION.md §2 — every target consumes them
+% the same way.
+
+:- module(wam_text_parser, [
+    wam_tokenize_line/2,           % +Line, -Tokens
+    wam_recognise_label/2,         % +Tokens, -LabelName
+    wam_recognise_instruction/2,   % +Tokens, -Item
+    wam_text_to_items/2            % +WamText, -Items
+]).
+
+:- use_module(library(lists)).
+
+% =====================================================================
+% wam_text_to_items/2
+% =====================================================================
+
+%% wam_text_to_items(+WamText, -Items) is det.
+%
+%  Items is a list interleaving label(NameStr) and instruction terms
+%  in source order. Anything that fails to recognise as either is
+%  silently skipped — keeps the format forward-compatible with new
+%  instructions that haven''t been added to wam_recognise_instruction
+%  yet (and matches every target''s historical tolerance behaviour).
+wam_text_to_items(WamText, Items) :-
+    atom_string(WamText, S),
+    split_string(S, "\n", "", Lines),
+    parse_lines(Lines, Items).
+
+parse_lines([], []).
+parse_lines([Line|Rest], Items) :-
+    wam_tokenize_line(Line, Tokens),
+    (   Tokens == []
+    ->  parse_lines(Rest, Items)
+    ;   wam_recognise_label(Tokens, Name)
+    ->  Items = [label(Name)|More],
+        parse_lines(Rest, More)
+    ;   wam_recognise_instruction(Tokens, Instr)
+    ->  Items = [Instr|More],
+        parse_lines(Rest, More)
+    ;   parse_lines(Rest, Items)
+    ).
+
+% =====================================================================
+% Tokenizer
+% =====================================================================
+
+%% wam_tokenize_line(+Line, -Tokens) is det.
+%
+%  Splits a WAM-text line into tokens. Whitespace separates;
+%  single-quoted regions preserve their content verbatim (with the
+%  surrounding quotes stripped); bare commas are separators except
+%  when immediately followed by ''/'' (so the conjunction functor
+%  ",/N" survives as one token). No escape sequences inside quotes.
+wam_tokenize_line(Line, Tokens) :-
+    string_chars(Line, Chars),
+    tokenize_chars(Chars, Tokens).
+
+tokenize_chars([], []).
+tokenize_chars([C|Cs], Tokens) :-
+    (   ws(C)
+    ->  tokenize_chars(Cs, Tokens)
+    ;   C == '\''
+    ->  read_quoted(Cs, QChars, Rest),
+        string_chars(Tok, QChars),
+        Tokens = [Tok|More],
+        tokenize_chars(Rest, More)
+    ;   C == ',' , \+ ( Cs = ['/'|_] )
+    ->  % Bare comma (not part of ",/N") is the WAM printer''s
+        % argument separator — discard.
+        tokenize_chars(Cs, Tokens)
+    ;   read_unquoted([C|Cs], TChars, Rest),
+        string_chars(Tok, TChars),
+        Tokens = [Tok|More],
+        tokenize_chars(Rest, More)
+    ).
+
+ws(' ').
+ws('\t').
+
+read_quoted([], [], []).
+read_quoted(['\''|Rest], [], Rest) :- !.
+read_quoted([C|Cs], [C|More], Rest) :-
+    read_quoted(Cs, More, Rest).
+
+read_unquoted([], [], []).
+read_unquoted([C|Cs], [], [C|Cs]) :- ws(C), !.
+read_unquoted([',' | Cs], [], [',' | Cs]) :-
+    \+ ( Cs = ['/'|_] ), !.
+read_unquoted([C|Cs], [C|More], Rest) :-
+    read_unquoted(Cs, More, Rest).
+
+% =====================================================================
+% Label / instruction recognisers
+% =====================================================================
+
+%% wam_recognise_label(+Tokens, -LabelName) is semidet.
+%
+%  Recognises a label line. A label is a single token ending in '':''.
+%  Strips the colon, returns the LabelName as a string.
+wam_recognise_label([First|_], LabelName) :-
+    sub_string(First, _, 1, 0, ":"),
+    string_length(First, Len),
+    L1 is Len - 1,
+    sub_string(First, 0, L1, _, LabelName).
+
+%% wam_recognise_instruction(+Tokens, -Item) is semidet.
+%
+%  Recognises a standard WAM instruction line. Returns the
+%  corresponding item term per the catalogue in
+%  WAM_ITEMS_API_SPECIFICATION.md §2. Fails (no exception) on
+%  unrecognised tokens — caller can chain its own
+%  extension-recogniser.
+wam_recognise_instruction(["get_constant", C, Ai],     get_constant(C, Ai)).
+wam_recognise_instruction(["get_variable", Xn, Ai],    get_variable(Xn, Ai)).
+wam_recognise_instruction(["get_value", Xn, Ai],       get_value(Xn, Ai)).
+wam_recognise_instruction(["get_structure", F, Ai],    get_structure(F, Ai)).
+wam_recognise_instruction(["get_list", Ai],            get_list(Ai)).
+wam_recognise_instruction(["get_nil", Ai],             get_nil(Ai)).
+wam_recognise_instruction(["get_integer", N, Ai],      get_integer(N, Ai)).
+wam_recognise_instruction(["unify_variable", Xn],      unify_variable(Xn)).
+wam_recognise_instruction(["unify_value", Xn],         unify_value(Xn)).
+wam_recognise_instruction(["unify_constant", C],       unify_constant(C)).
+wam_recognise_instruction(["put_variable", Xn, Ai],    put_variable(Xn, Ai)).
+wam_recognise_instruction(["put_value", Xn, Ai],       put_value(Xn, Ai)).
+wam_recognise_instruction(["put_constant", C, Ai],     put_constant(C, Ai)).
+wam_recognise_instruction(["put_structure", F, Ai],    put_structure(F, Ai)).
+wam_recognise_instruction(["put_list", Ai],            put_list(Ai)).
+wam_recognise_instruction(["set_variable", Xn],        set_variable(Xn)).
+wam_recognise_instruction(["set_value", Xn],           set_value(Xn)).
+wam_recognise_instruction(["set_constant", C],         set_constant(C)).
+wam_recognise_instruction(["call", P, N],              call(P, N)).
+wam_recognise_instruction(["execute", P],              execute(P)).
+wam_recognise_instruction(["proceed"],                 proceed).
+wam_recognise_instruction(["fail"],                    fail).
+wam_recognise_instruction(["allocate"],                allocate).
+wam_recognise_instruction(["deallocate"],              deallocate).
+wam_recognise_instruction(["builtin_call", Op, Ar],    builtin_call(Op, Ar)).
+wam_recognise_instruction(["call_foreign", Pred, Ar],  call_foreign(Pred, Ar)).
+wam_recognise_instruction(["try_me_else", L],          try_me_else(L)).
+wam_recognise_instruction(["retry_me_else", L],        retry_me_else(L)).
+wam_recognise_instruction(["trust_me"],                trust_me).
+wam_recognise_instruction(["jump", L],                 jump(L)).
+wam_recognise_instruction(["cut_ite"],                 cut_ite).
+wam_recognise_instruction(["begin_aggregate", K, V, R], begin_aggregate(K, V, R)).
+wam_recognise_instruction(["end_aggregate", R],        end_aggregate(R)).
+% Indexing instructions: variable-arity tail tokens captured as a list,
+% target-side decoders parse them per the dispatch-table convention.
+wam_recognise_instruction(["switch_on_constant"     | Es], switch_on_constant(Es)).
+wam_recognise_instruction(["switch_on_constant_a2"  | Es], switch_on_constant_a2(Es)).
+wam_recognise_instruction(["switch_on_structure"    | Es], switch_on_structure(Es)).
+wam_recognise_instruction(["switch_on_term"         | Ts], switch_on_term(Ts)).

--- a/tests/test_wam_text_parser.pl
+++ b/tests/test_wam_text_parser.pl
@@ -1,0 +1,156 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Unit tests for src/unifyweaver/targets/wam_text_parser.pl.
+%
+% Pins the tokenizer + recogniser shapes that every WAM target now
+% relies on (per WAM_ITEMS_API_SPECIFICATION §2). Two regression
+% guards in particular: PR #2076''s quoted-atom handling and
+% PR #2084''s ",/N"-shaped operator handling — both used to live
+% only in the C++ target''s private parser and silently failed in
+% the lowered emitter''s copy.
+
+:- use_module('../src/unifyweaver/targets/wam_text_parser').
+:- use_module(library(plunit)).
+
+:- begin_tests(wam_text_parser).
+
+% ------------------------------------------------------------------
+% wam_tokenize_line/2
+% ------------------------------------------------------------------
+
+test(tokenize_simple_instruction) :-
+    wam_tokenize_line("    put_variable X1, A1", T),
+    assertion(T == ["put_variable", "X1", "A1"]).
+
+test(tokenize_label_keeps_colon) :-
+    wam_tokenize_line("L_my_member_2_2:", T),
+    assertion(T == ["L_my_member_2_2:"]).
+
+test(tokenize_quoted_atom_with_spaces) :-
+    % PR #2076 regression: format strings must survive tokenization
+    % as a single token.
+    wam_tokenize_line("    put_constant 'plain text~n', A1", T),
+    assertion(T == ["put_constant", "plain text~n", "A1"]).
+
+test(tokenize_quoted_atom_with_internal_commas) :-
+    wam_tokenize_line("    put_constant 'a, b, c', A1", T),
+    assertion(T == ["put_constant", "a, b, c", "A1"]).
+
+test(tokenize_conjunction_functor_preserved) :-
+    % PR #2084 regression: ",/2" must be one token; bare comma
+    % between arg positions should still split.
+    wam_tokenize_line("    put_structure ,/2, A1", T),
+    assertion(T == ["put_structure", ",/2", "A1"]).
+
+test(tokenize_negative_integer_constant) :-
+    wam_tokenize_line("    set_constant -1", T),
+    assertion(T == ["set_constant", "-1"]).
+
+test(tokenize_no_args) :-
+    wam_tokenize_line("    proceed", T),
+    assertion(T == ["proceed"]).
+
+test(tokenize_blank_line) :-
+    wam_tokenize_line("", T),
+    assertion(T == []).
+
+test(tokenize_whitespace_only) :-
+    wam_tokenize_line("      \t  ", T),
+    assertion(T == []).
+
+% ------------------------------------------------------------------
+% wam_recognise_label/2
+% ------------------------------------------------------------------
+
+test(recognise_label_basic) :-
+    wam_recognise_label(["my_pred/2:"], N),
+    assertion(N == "my_pred/2").
+
+test(recognise_label_with_underscores) :-
+    wam_recognise_label(["L_clause_3:"], N),
+    assertion(N == "L_clause_3").
+
+test(recognise_label_rejects_non_label, [fail]) :-
+    wam_recognise_label(["proceed"], _).
+
+test(recognise_label_rejects_instruction_args, [fail]) :-
+    wam_recognise_label(["put_variable", "X1", "A1"], _).
+
+% ------------------------------------------------------------------
+% wam_recognise_instruction/2
+% ------------------------------------------------------------------
+
+test(recognise_get_constant) :-
+    wam_recognise_instruction(["get_constant", "5", "A1"], I),
+    assertion(I == get_constant("5", "A1")).
+
+test(recognise_put_variable) :-
+    wam_recognise_instruction(["put_variable", "Y1", "A1"], I),
+    assertion(I == put_variable("Y1", "A1")).
+
+test(recognise_proceed) :-
+    wam_recognise_instruction(["proceed"], I),
+    assertion(I == proceed).
+
+test(recognise_call) :-
+    wam_recognise_instruction(["call", "foo/2", "2"], I),
+    assertion(I == call("foo/2", "2")).
+
+test(recognise_execute) :-
+    wam_recognise_instruction(["execute", "catch/3"], I),
+    assertion(I == execute("catch/3")).
+
+test(recognise_builtin_call) :-
+    wam_recognise_instruction(["builtin_call", "is/2", "2"], I),
+    assertion(I == builtin_call("is/2", "2")).
+
+test(recognise_try_me_else) :-
+    wam_recognise_instruction(["try_me_else", "L_clause_2"], I),
+    assertion(I == try_me_else("L_clause_2")).
+
+test(recognise_switch_on_constant_captures_tail) :-
+    % Variable-arity instruction — entries captured as one list,
+    % parsed by the per-target decoder.
+    wam_recognise_instruction(
+        ["switch_on_constant", "a:L1", "b:L2"], I),
+    assertion(I == switch_on_constant(["a:L1", "b:L2"])).
+
+test(recognise_unknown_instruction_fails, [fail]) :-
+    wam_recognise_instruction(["unknown_op", "X"], _).
+
+% ------------------------------------------------------------------
+% wam_text_to_items/2 — end-to-end
+% ------------------------------------------------------------------
+
+test(text_to_items_single_clause) :-
+    Text = "foo/0:\n    proceed\n",
+    wam_text_to_items(Text, Items),
+    assertion(Items == [label("foo/0"), proceed]).
+
+test(text_to_items_with_quoted_atom) :-
+    % End-to-end check that the format-string fix works through the
+    % full pipeline (regression guard for PR #2076).
+    Text = "tp/0:\n    put_constant 'hello world', A1\n    execute write/1\n",
+    wam_text_to_items(Text, Items),
+    assertion(Items == [label("tp/0"),
+                        put_constant("hello world", "A1"),
+                        execute("write/1")]).
+
+test(text_to_items_with_conjunction_functor) :-
+    % End-to-end regression guard for PR #2084.
+    Text = "tp/0:\n    put_structure ,/2, A1\n    proceed\n",
+    wam_text_to_items(Text, Items),
+    assertion(Items == [label("tp/0"),
+                        put_structure(",/2", "A1"),
+                        proceed]).
+
+test(text_to_items_skips_unrecognised) :-
+    % Forward-compat: unknown instruction lines silently dropped, the
+    % rest of the predicate parses fine.
+    Text = "tp/0:\n    proceed\n    unknown_future_op X1\n    fail\n",
+    wam_text_to_items(Text, Items),
+    assertion(Items == [label("tp/0"), proceed, fail]).
+
+:- end_tests(wam_text_parser).


### PR DESCRIPTION
## Summary

First implementation step from PR #2086's items-API design. Lifts the WAM-text tokenizer + recogniser out of `wam_cpp_target.pl` **and** `wam_cpp_lowered_emitter.pl` into a single shared module `src/unifyweaver/targets/wam_text_parser.pl` that future target migrations (Phase 2) will import from.

Per the user feedback on #2086 ("starting with the target at hand but creating generic modules where applicable"), this lands **one target's migration plus the generic parser module**. The remaining 13 WAM targets stay on their own parsers until their respective migration PRs.

## New module — `wam_text_parser.pl`

Exports four predicates per `WAM_ITEMS_API_SPECIFICATION` §1.3 / §3:

| Predicate | Role |
|---|---|
| `wam_tokenize_line/2` | Quote-aware whitespace tokenizer with the selective-comma rule that preserves `",/N"`-shaped functor names |
| `wam_recognise_label/2` | Single token ending in `:` → name string |
| `wam_recognise_instruction/2` | Token list → standard WAM instruction term per the SPEC §2 catalogue |
| `wam_text_to_items/2` | High-level: WAM text → label + instruction items in source order |

## Latent-bug fix

`wam_cpp_lowered_emitter.pl` had its **own COPY** of the parser using the OLD `split_string`-on-space-tab-comma tokenizer that predated #2076's quote-aware fix AND #2084's `,/N` fix. Any predicate whose WAM contained a quoted atom argument or a conjunction-as-data was being mis-tokenised, returning an empty instruction list, and therefore failing `wam_cpp_lowerable/3` — **silently disabling lowering** for those predicates and falling back to the interpreter array.

Migrating the lowered emitter to the shared parser fixes this transparently. The existing test suite catches no regression because no test happened to exercise an affected lowering candidate, but more predicates will now be eligible for lowering than were before. (No behavior change for already-lowered predicates.)

## C++ target changes

- Imports `wam_text_to_items` from `wam_text_parser`.
- `parse_pred_blocks/2` becomes a one-line alias (kept under the pre-existing name since several call sites use it).
- **Deleted:** `tokenize_wam_line` + `tokenize_wam_chars` + `read_quoted` + `read_unquoted` + `wam_token_sep` + `parse_block_lines` + `wam_cpp_lowered_emitter_instr` (the inline-copied recogniser table). **~120 LOC removed.**

## Lowered-emitter changes

- Imports `wam_text_to_items` from `wam_text_parser`.
- `parse_wam_text/2` becomes:
  ```prolog
  parse_wam_text(Text, Instrs) :-
      wam_text_to_items(Text, Items),
      exclude(is_label_item, Items, Instrs).
  ```
- **~50 LOC removed** (the broken parser + its `instr_from_parts` table).

## Tests

New `tests/test_wam_text_parser.pl` with **26 unit tests** covering each level of the parser pipeline:

- **9 tokenizer tests** including the PR #2076 (quoted atom with spaces) and PR #2084 (`,/2` functor) regression guards.
- **4 `wam_recognise_label` tests**.
- **9 `wam_recognise_instruction` tests** covering the main shape families + a fail case for unknown instructions.
- **4 end-to-end `wam_text_to_items` tests** including the two PR regression guards through the full pipeline.

## Verification

```
$ swipl -g "[tests/test_wam_text_parser]" -g "run_tests(wam_text_parser)" -t halt
% All 26 tests passed                          (< 10ms)

$ swipl -g "[tests/test_wam_cpp_generator]" -g "run_tests(wam_cpp_generator)" -t halt
% All 74 tests passed                          (no regression)
```

## Test plan

- [x] 26/26 new `wam_text_parser` unit tests pass
- [x] 74/74 existing C++ generator tests still pass (no regression)
- [x] No external Prolog dependency changes
- [x] Both targets that had a parser copy (cpp + lowered emitter) now share the same fixed implementation
- [ ] Phase 2 follow-ups: migrate the other 13 targets one PR each (smallest first per SPEC §6, starting with `wam_clojure_target.pl` at 7 format calls)
- [ ] Phase 1 proper (future): refactor `wam_target.pl` to emit items natively, deprecating the parsing path for in-process compile-then-emit flows. The shared parser stays for external WAM ingest.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_