### PR TITLE
feat(wam-cpp): ISO sweep — arith compares, succ_iso, IEEE-754 lax floats

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -427,6 +427,11 @@ static const int _wam_cpp_setup_register = []() {
 %  even when populated.
 :- dynamic iso_errors_default_to_iso/2.
 :- dynamic iso_errors_default_to_lax/2.
+% Paired clauses (iso/lax for the same default key) interleave so
+% each builtin reads as a logical unit. Tell the consult-time
+% checker not to warn about that.
+:- discontiguous iso_errors_default_to_iso/2.
+:- discontiguous iso_errors_default_to_lax/2.
 
 % is/2 — first ISO-aware builtin. ISO-mode predicates get their
 % default is/2 calls rewritten to is_iso/2 (which throws on bad
@@ -434,8 +439,26 @@ static const int _wam_cpp_setup_register = []() {
 % since is/2 and is_lax/2 share the runtime body). Explicit
 % is_iso/2 or is_lax/2 in user source survives the rewrite — see
 % iso_errors_rewrite_item/3.
+% is/2 — landed in PR #2084.
 iso_errors_default_to_iso("is/2", "is_iso/2").
 iso_errors_default_to_lax("is/2", "is_lax/2").
+% Arithmetic comparisons. ISO body classifies args + throws via the
+% same machinery is_iso/2 uses; lax body shares with default.
+iso_errors_default_to_iso(">/2",   ">_iso/2").
+iso_errors_default_to_lax(">/2",   ">_lax/2").
+iso_errors_default_to_iso("</2",   "<_iso/2").
+iso_errors_default_to_lax("</2",   "<_lax/2").
+iso_errors_default_to_iso(">=/2",  ">=_iso/2").
+iso_errors_default_to_lax(">=/2",  ">=_lax/2").
+iso_errors_default_to_iso("=</2",  "=<_iso/2").
+iso_errors_default_to_lax("=</2",  "=<_lax/2").
+iso_errors_default_to_iso("=:=/2", "=:=_iso/2").
+iso_errors_default_to_lax("=:=/2", "=:=_lax/2").
+iso_errors_default_to_iso("=\\=/2","=\\=_iso/2").
+iso_errors_default_to_lax("=\\=/2","=\\=_lax/2").
+% succ/2 — bidirectional with proper ISO error throws.
+iso_errors_default_to_iso("succ/2", "succ_iso/2").
+iso_errors_default_to_lax("succ/2", "succ_lax/2").
 
 %% iso_errors_resolve_options(+Options, -Config)
 %  Merges the (optional) file config with inline options into one
@@ -1544,6 +1567,13 @@ struct WamState {
     // for the type_error culprit slot.
     bool    term_contains_unbound(CellPtr c) const;
     Value   arith_culprit(const Value& v) const;
+    // Walk an arith term tree looking for a "/" or "//" or "mod"
+    // node whose RHS dereferences to a zero integer or zero float.
+    // Used by ISO arith builtins to throw
+    // evaluation_error(zero_divisor) before eval_arith silently
+    // succeeds with IEEE 754 inf / NaN (lax behavior) — see
+    // SPECIFICATION §6.1.
+    bool    term_has_zero_divide(CellPtr c) const;
     // Deep-copy a value tree, allocating fresh cells for any Unbound
     // leaves (multiple references to the same source name share the
     // same fresh cell). Used by throw/1 to snapshot the thrown term
@@ -1590,7 +1620,9 @@ compile_wam_runtime_to_cpp(_Options,
 #include "wam_runtime.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdio>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -1769,8 +1801,25 @@ Value WamState::eval_arith(CellPtr c, bool& ok) const {
                 return Value::Integer(a.i * b.i);
             }
             if (v.s == "//2") {
-                // Prolog ''/'' is float division.
-                if (as_d(b) == 0.0) { ok = false; return Value{}; }
+                // Prolog ''/'' is float division. Lax / default mode
+                // follows IEEE 754 for float operands (inf / -inf /
+                // NaN on divide-by-zero) per
+                // WAM_CPP_ISO_ERRORS_SPECIFICATION §6.1; integer
+                // divide-by-zero remains uniform-fail. ISO mode
+                // detects divide-by-zero before calling eval_arith
+                // (via term_has_zero_divide) and throws
+                // evaluation_error(zero_divisor) regardless of
+                // operand type.
+                if (as_d(b) == 0.0) {
+                    if (either_float) {
+                        double num = as_d(a);
+                        if (num == 0.0) return Value::Float(std::nan(""));
+                        return Value::Float(num > 0
+                            ? std::numeric_limits<double>::infinity()
+                            : -std::numeric_limits<double>::infinity());
+                    }
+                    ok = false; return Value{};
+                }
                 if (either_float) return Value::Float(as_d(a) / as_d(b));
                 if (a.i % b.i == 0) return Value::Integer(a.i / b.i);
                 return Value::Float((double)a.i / (double)b.i);
@@ -1904,7 +1953,9 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
     // integer, derive Y; if Y is a positive integer, derive X. Fails
     // if X < 0 or Y <= 0 or both args unbound (ISO would throw
     // instantiation_error in the both-unbound case; v1 just fails).
-    if (op == "succ/2") {
+    // succ/2 and succ_lax/2 share the lax body. succ_lax exists as
+    // a distinct dispatch key for the three-forms guarantee.
+    if (op == "succ/2" || op == "succ_lax/2") {
         Value a = deref(*get_cell("A1"));
         Value b = deref(*get_cell("A2"));
         if (a.tag == Value::Tag::Integer) {
@@ -1928,6 +1979,55 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
             pc += 1; return true;
         }
         return false;
+    }
+    // ---- succ_iso/2 -------------------------------------------------
+    // ISO semantics:
+    //   - both args unbound → instantiation_error.
+    //   - either arg non-integer (and bound) → type_error(integer, X).
+    //   - X negative → type_error(not_less_than_zero, X).
+    //   - Y zero or negative → domain_error(not_less_than_zero, Y).
+    // (SPECIFICATION §6.)
+    if (op == "succ_iso/2") {
+        Value a = deref(*get_cell("A1"));
+        Value b = deref(*get_cell("A2"));
+        bool a_unbound = (a.tag == Value::Tag::Unbound
+                          || a.tag == Value::Tag::Uninit);
+        bool b_unbound = (b.tag == Value::Tag::Unbound
+                          || b.tag == Value::Tag::Uninit);
+        if (a_unbound && b_unbound) {
+            return throw_iso_error(make_instantiation_error());
+        }
+        if (!a_unbound && a.tag != Value::Tag::Integer) {
+            return throw_iso_error(make_type_error("integer", a));
+        }
+        if (!b_unbound && b.tag != Value::Tag::Integer) {
+            return throw_iso_error(make_type_error("integer", b));
+        }
+        if (a.tag == Value::Tag::Integer) {
+            if (a.i < 0) {
+                return throw_iso_error(
+                    make_type_error("not_less_than_zero", a));
+            }
+            long long next = a.i + 1;
+            if (b.tag == Value::Tag::Integer) {
+                if (b.i != next) return false;
+                pc += 1; return true;
+            }
+            if (!unify_cells(get_cell("A2"),
+                             std::make_shared<Cell>(Value::Integer(next))))
+                return false;
+            pc += 1; return true;
+        }
+        // a unbound, b is integer (covered by guards above).
+        if (b.i <= 0) {
+            return throw_iso_error(
+                make_domain_error("not_less_than_zero", b));
+        }
+        long long prev = b.i - 1;
+        if (!unify_cells(get_cell("A1"),
+                         std::make_shared<Cell>(Value::Integer(prev))))
+            return false;
+        pc += 1; return true;
     }
     // ---- \\=/2 (cannot unify) --------------------------------------
     if (op == "\\\\=/2") {
@@ -1960,19 +2060,22 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
     }
     // ---- is_iso/2 ---------------------------------------------------
     // ISO-strict arithmetic. Throws instantiation_error for unbound
-    // sub-terms; type_error(evaluable, Culprit) for non-evaluable
-    // atoms / unknown functors. The walk classifies BEFORE eval so
-    // the diagnostic is the actual culprit shape (matches SPEC §6).
+    // sub-terms, evaluation_error(zero_divisor) for /0 (regardless
+    // of operand type — see SPECIFICATION §6 + §6.1), and
+    // type_error(evaluable, Culprit) for non-evaluable atoms or
+    // unknown functors. Classification happens BEFORE eval so the
+    // diagnostic captures the actual culprit shape.
     if (op == "is_iso/2") {
         CellPtr rhs_cell = get_cell("A2");
         if (term_contains_unbound(rhs_cell)) {
             return throw_iso_error(make_instantiation_error());
         }
+        if (term_has_zero_divide(rhs_cell)) {
+            return throw_iso_error(make_evaluation_error("zero_divisor"));
+        }
         bool ok = true;
         Value rhs = eval_arith(rhs_cell, ok);
         if (!ok) {
-            // Build culprit as Name/Arity (or the raw value if shape
-            // is unrecognised — fallback for robustness).
             Value culprit = arith_culprit(deref(*rhs_cell));
             return throw_iso_error(make_type_error("evaluable", culprit));
         }
@@ -1982,15 +2085,59 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         pc += 1; return true;
     }
 
-    // ---- Arithmetic comparisons ------------------------------------
+    // ---- Arithmetic comparisons (lax / default) --------------------
+    // The _lax/2 keys share this body so user code can write e.g.
+    // `>_lax(X, Y)` to opt out of an enclosing ISO-mode predicate''s
+    // rewrite (three-forms guarantee from PHILOSOPHY §3.3). The
+    // dispatch op-name is also passed to arith_compare for the
+    // operator semantics, so we strip the "_lax" suffix first.
     if (op == ">/2" || op == "</2" || op == ">=/2" || op == "=</2"
-        || op == "=:=/2" || op == "=\\\\=/2") {
+        || op == "=:=/2" || op == "=\\\\=/2"
+        || op == ">_lax/2" || op == "<_lax/2" || op == ">=_lax/2"
+        || op == "=<_lax/2" || op == "=:=_lax/2" || op == "=\\\\=_lax/2") {
         bool ok = true;
         Value a = eval_arith(get_cell("A1"), ok);
         if (!ok) return false;
         Value b = eval_arith(get_cell("A2"), ok);
         if (!ok) return false;
-        if (!arith_compare(op, a, b)) return false;
+        std::string base_op = op;
+        // Strip "_lax" before "/" so arith_compare sees ">/2" etc.
+        auto pos = base_op.find("_lax/");
+        if (pos != std::string::npos) base_op.replace(pos, 4, "");
+        if (!arith_compare(base_op, a, b)) return false;
+        pc += 1; return true;
+    }
+    // ---- Arithmetic comparisons (ISO) ------------------------------
+    // ISO arith compares throw the same errors is_iso/2 throws:
+    // instantiation_error for unbound args, evaluation_error for
+    // zero_divisor in either operand subterm,
+    // type_error(evaluable, ...) for non-evaluable atoms / unknown
+    // functors. arith_compare gets the un-suffixed operator key.
+    if (op == ">_iso/2" || op == "<_iso/2" || op == ">=_iso/2"
+        || op == "=<_iso/2" || op == "=:=_iso/2" || op == "=\\\\=_iso/2") {
+        CellPtr a_cell = get_cell("A1");
+        CellPtr b_cell = get_cell("A2");
+        if (term_contains_unbound(a_cell) || term_contains_unbound(b_cell)) {
+            return throw_iso_error(make_instantiation_error());
+        }
+        if (term_has_zero_divide(a_cell) || term_has_zero_divide(b_cell)) {
+            return throw_iso_error(make_evaluation_error("zero_divisor"));
+        }
+        bool ok = true;
+        Value a = eval_arith(a_cell, ok);
+        if (!ok) {
+            Value culprit = arith_culprit(deref(*a_cell));
+            return throw_iso_error(make_type_error("evaluable", culprit));
+        }
+        Value b = eval_arith(b_cell, ok);
+        if (!ok) {
+            Value culprit = arith_culprit(deref(*b_cell));
+            return throw_iso_error(make_type_error("evaluable", culprit));
+        }
+        std::string base_op = op;
+        auto pos = base_op.find("_iso/");
+        if (pos != std::string::npos) base_op.replace(pos, 4, "");
+        if (!arith_compare(base_op, a, b)) return false;
         pc += 1; return true;
     }
 
@@ -3086,6 +3233,21 @@ bool WamState::term_contains_unbound(CellPtr c) const {
         for (auto& arg : v.args) {
             if (term_contains_unbound(arg)) return true;
         }
+    }
+    return false;
+}
+
+bool WamState::term_has_zero_divide(CellPtr c) const {
+    Value v = deref(*c);
+    if (v.tag != Value::Tag::Compound) return false;
+    if (v.args.size() == 2 && (v.s == "//2" || v.s == "///2"
+                            || v.s == "mod/2" || v.s == "rem/2")) {
+        Value rhs = deref(*v.args[1]);
+        if (rhs.tag == Value::Tag::Integer && rhs.i == 0) return true;
+        if (rhs.tag == Value::Tag::Float && rhs.f == 0.0) return true;
+    }
+    for (auto& arg : v.args) {
+        if (term_has_zero_divide(arg)) return true;
     }
     return false;
 }

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -198,6 +198,74 @@ user:wam_cpp_test_iso_unbound_context :-
           error(type_error(evaluable, Culprit), _Context),
           Culprit = foo/0).
 
+% ISO sweep fixtures — arith compares + succ/2 + IEEE-754 float
+% divide-by-zero. Each predicate tests one ISO/lax/explicit path.
+:- dynamic user:wam_cpp_test_iso_gt_throws_inst/0.
+:- dynamic user:wam_cpp_test_iso_lt_throws_type/0.
+:- dynamic user:wam_cpp_test_iso_eq_throws_zero_div/0.
+:- dynamic user:wam_cpp_test_lax_gt_silent_fail/0.
+:- dynamic user:wam_cpp_test_explicit_lax_gt_in_iso/0.
+:- dynamic user:wam_cpp_test_iso_succ_neg_throws/0.
+:- dynamic user:wam_cpp_test_iso_succ_unbound_throws/0.
+:- dynamic user:wam_cpp_test_iso_zero_div_throws/0.
+:- dynamic user:wam_cpp_test_lax_float_div_zero_inf/0.
+:- dynamic user:wam_cpp_test_lax_float_div_zero_nan/0.
+
+user:wam_cpp_test_iso_gt_throws_inst :-
+    % `_X > 5` with _X unbound → instantiation_error.
+    catch(_X > 5, error(instantiation_error, _), true).
+
+user:wam_cpp_test_iso_lt_throws_type :-
+    % `foo < 5` → type_error(evaluable, foo/0).
+    catch(foo < 5, error(type_error(evaluable, _), _), true).
+
+user:wam_cpp_test_iso_eq_throws_zero_div :-
+    % `1 / 0 =:= 0` → evaluation_error(zero_divisor) on int divide.
+    catch(1 / 0 =:= 0,
+          error(evaluation_error(zero_divisor), _),
+          true).
+
+user:wam_cpp_test_lax_gt_silent_fail :-
+    % Lax: `_X > 5` with _X unbound → just fails.
+    (_X > 5 -> true ; true).
+
+user:wam_cpp_test_explicit_lax_gt_in_iso :-
+    % Explicit `>_lax` inside an ISO-mode predicate must NOT throw —
+    % three-forms guarantee end-to-end on a non-is/2 builtin.
+    % Quoted because `>` is a Prolog operator and the unquoted form
+    % `>_lax(_X, 5)` is a syntax error.
+    ('>_lax'(_X, 5) -> true ; true).
+
+user:wam_cpp_test_iso_succ_neg_throws :-
+    % succ_iso(-1, _) → type_error(not_less_than_zero, -1).
+    catch(succ(-1, _Y),
+          error(type_error(not_less_than_zero, _), _),
+          true).
+
+user:wam_cpp_test_iso_succ_unbound_throws :-
+    % succ_iso(_X, _Y) → instantiation_error.
+    catch(succ(_X, _Y), error(instantiation_error, _), true).
+
+user:wam_cpp_test_iso_zero_div_throws :-
+    % Both int and float divide-by-zero throw under ISO.
+    catch(_R is 1.0 / 0.0,
+          error(evaluation_error(zero_divisor), _),
+          true).
+
+user:wam_cpp_test_lax_float_div_zero_inf :-
+    % Lax: `R is 1.0 / 0.0` succeeds with R = inf. Verifies the
+    % SPEC §6.1 IEEE-754 behavior change — previously this failed.
+    R is 1.0 / 0.0,
+    R > 1.0e308.
+
+user:wam_cpp_test_lax_float_div_zero_nan :-
+    % Lax: `R is 0.0 / 0.0` succeeds with NaN. IEEE 754 says
+    % NaN =\= NaN is true (NaN is not equal to anything, including
+    % itself), so this is the simplest self-checking NaN signature.
+    % Avoids \+/1 which the runtime doesn''t implement yet.
+    R is 0.0 / 0.0,
+    R =\= R.
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -1243,6 +1311,176 @@ test(cpp_e2e_iso_unbound_context, [condition(cpp_compiler_available)]) :-
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath,
                     'wam_cpp_test_iso_unbound_context/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% ISO sweep — arithmetic comparisons + succ + IEEE-754 lax floats
+% (PR #3 of the ISO series). Builds on the is_iso/2 + is_lax/2
+% infrastructure from #2084. Verifies:
+%   - >_iso/2, <_iso/2, =:=_iso/2 throw the right errors.
+%   - >_lax/2 inside an ISO-mode predicate survives the rewrite.
+%   - succ_iso/2 throws type_error / instantiation_error per §6.
+%   - Lax float divide-by-zero produces inf / NaN per §6.1.
+%   - ISO float and integer divide-by-zero both throw
+%     evaluation_error(zero_divisor).
+% ------------------------------------------------------------------
+
+test(cpp_e2e_iso_compare_throws_inst, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_iso_gt_inst', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_iso_gt_throws_inst/0],
+                              [emit_main(true),
+                               iso_errors(wam_cpp_test_iso_gt_throws_inst/0,
+                                          true)],
+                              TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_iso_gt_throws_inst/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_iso_compare_throws_type, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_iso_lt_type', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_iso_lt_throws_type/0],
+                              [emit_main(true),
+                               iso_errors(wam_cpp_test_iso_lt_throws_type/0,
+                                          true)],
+                              TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_iso_lt_throws_type/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_iso_compare_throws_zero_div,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_iso_eq_zerodiv', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_iso_eq_throws_zero_div/0],
+                              [emit_main(true),
+                               iso_errors(wam_cpp_test_iso_eq_throws_zero_div/0,
+                                          true)],
+                              TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_iso_eq_throws_zero_div/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_lax_compare_silent_fail, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_lax_gt', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_lax_gt_silent_fail/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_lax_gt_silent_fail/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_explicit_lax_compare_in_iso,
+     [condition(cpp_compiler_available)]) :-
+    % Three-forms guarantee for arith compares: explicit `>_lax/2`
+    % inside an ISO-mode predicate must survive the rewrite (silent
+    % fail), not be upgraded to `>_iso/2` (which would throw).
+    unique_cpp_tmp_dir('tmp_cpp_e2e_explicit_lax_gt', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_explicit_lax_gt_in_iso/0],
+                              [emit_main(true),
+                               iso_errors(wam_cpp_test_explicit_lax_gt_in_iso/0,
+                                          true)],
+                              TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_explicit_lax_gt_in_iso/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_iso_succ_negative_throws,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_iso_succ_neg', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_iso_succ_neg_throws/0],
+                              [emit_main(true),
+                               iso_errors(wam_cpp_test_iso_succ_neg_throws/0,
+                                          true)],
+                              TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_iso_succ_neg_throws/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_iso_succ_unbound_throws,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_iso_succ_unbound', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_iso_succ_unbound_throws/0],
+                              [emit_main(true),
+                               iso_errors(wam_cpp_test_iso_succ_unbound_throws/0,
+                                          true)],
+                              TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_iso_succ_unbound_throws/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_iso_float_div_zero_throws,
+     [condition(cpp_compiler_available)]) :-
+    % ISO mode catches float divide-by-zero too (lax would silently
+    % succeed with inf — see the next test for that side).
+    unique_cpp_tmp_dir('tmp_cpp_e2e_iso_zero_div', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_iso_zero_div_throws/0],
+                              [emit_main(true),
+                               iso_errors(wam_cpp_test_iso_zero_div_throws/0,
+                                          true)],
+                              TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_iso_zero_div_throws/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_lax_float_div_zero_inf,
+     [condition(cpp_compiler_available)]) :-
+    % SPEC §6.1 lax behavior change: float divide-by-zero now
+    % produces inf instead of failing. Verifies R > 1e308 to avoid
+    % depending on Value::Float''s text rendering of "inf".
+    unique_cpp_tmp_dir('tmp_cpp_e2e_lax_inf', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_lax_float_div_zero_inf/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_lax_float_div_zero_inf/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_lax_float_div_zero_nan,
+     [condition(cpp_compiler_available)]) :-
+    % SPEC §6.1: 0.0 / 0.0 produces NaN. Verified via NaN \=:= NaN
+    % which is the IEEE-754 self-comparison signature.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_lax_nan', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_lax_float_div_zero_nan/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_lax_float_div_zero_nan/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Third PR in the ISO-errors phasing plan (SPEC §10 step 3). Adds ISO + lax flavors for the six arithmetic comparison operators (`>/2`, `</2`, `>=/2`, `=</2`, `=:=/2`, `=\=/2`) and `succ/2`, plus the **lax IEEE-754 float divide-by-zero behavior change** called out in SPEC §6.1.

## Runtime additions

- **`eval_arith` float divide gains IEEE-754 semantics for lax mode.** `1.0/0.0 → +inf`, `-1.0/0.0 → -inf`, `0.0/0.0 → NaN`. Integer divide-by-zero still uniform-fails.
- **New helper `term_has_zero_divide/1`** walks an arith term tree looking for `/`, `//`, `mod`, or `rem` nodes whose RHS dereferences to a zero integer or zero float. Used by ISO arith builtins to throw `evaluation_error(zero_divisor)` **before** the IEEE-754-permissive `eval_arith` silently produces inf or NaN.
- **`is_iso/2` extended** to detect divide-by-zero before eval, in addition to the existing `instantiation_error` / `type_error` classification. Three failure modes now: `instantiation_error`, `evaluation_error(zero_divisor)`, `type_error(evaluable, _)`.
- **New combined branch** handles `>_iso/2`, `<_iso/2`, `>=_iso/2`, `=<_iso/2`, `=:=_iso/2`, `=\=_iso/2` with the same three-way classification.
- **Existing arith-compares branch extended** to include the `_lax` counterparts for all six operators — they share the lax body. The dispatched operator key has its `_lax` infix stripped so `arith_compare` sees the bare name.
- **`succ/2` and `succ_lax/2`** now share one branch; **new `succ_iso/2`** implements the SPEC §6 error table: both args unbound → `instantiation_error`; either arg non-integer → `type_error(integer, X)`; X negative → `type_error(not_less_than_zero, X)`; Y zero or negative → `domain_error(not_less_than_zero, Y)`.

## Generator additions

- Swap-table entries for `>/2`, `</2`, `>=/2`, `=</2`, `=:=/2`, `=\=/2`, `succ/2` — each gets a `default→iso` and a `default→lax` mapping.
- `:- discontiguous` declaration on the swap tables so the paired iso/lax clauses for the same builtin can interleave (each builtin reads as a logical unit).

## Tests — 10 new e2e tests

| Test | Coverage |
|---|---|
| `cpp_e2e_iso_compare_throws_inst` | `_X > 5` ISO → `instantiation_error` |
| `cpp_e2e_iso_compare_throws_type` | `foo < 5` ISO → `type_error(evaluable, foo/0)` |
| `cpp_e2e_iso_compare_throws_zero_div` | `1 / 0 =:= 0` ISO → `evaluation_error(zero_divisor)` |
| `cpp_e2e_lax_compare_silent_fail` | `_X > 5` lax → fails (regression guard) |
| `cpp_e2e_explicit_lax_compare_in_iso` | `'>_lax'(_X, 5)` inside ISO → no throw (three-forms guarantee on a non-`is/2` builtin) |
| `cpp_e2e_iso_succ_negative_throws` | `succ(-1, _)` ISO → `type_error(not_less_than_zero, -1)` |
| `cpp_e2e_iso_succ_unbound_throws` | `succ(_, _)` ISO → `instantiation_error` |
| `cpp_e2e_iso_float_div_zero_throws` | `_R is 1.0 / 0.0` ISO → `evaluation_error(zero_divisor)` |
| `cpp_e2e_lax_float_div_zero_inf` | `R is 1.0 / 0.0` lax → `R = inf` (verified via `R > 1e308`) |
| `cpp_e2e_lax_float_div_zero_nan` | `R is 0.0 / 0.0` lax → `R = NaN` (verified via `R =\= R`) |

**Total: 84/84 passing** (was 74; +10 new).

## Test-fixture quirks worth flagging

- **Quoting required** for explicit-lax compare in source: `'>_lax'(_X, 5)`, not `>_lax(_X, 5)`. The unquoted form is a syntax error since `>` is a Prolog operator and `_lax` would be a separate var token.
- **`\+/1` is not implemented** in the runtime, so NaN self-checks use `=\=/2` (which IEEE-754 says is `true` for NaN vs NaN — NaN is unequal to itself).

## Verification

```
$ swipl -g "[tests/test_wam_cpp_generator]" -g "run_tests(wam_cpp_generator)" -t halt
% All 84 tests passed
```

## ISO-errors series status

Per SPEC §10 the ISO-errors series is now **feature-complete**:

- PR #2079 — design docs (PHILOSOPHY + SPECIFICATION).
- PR #2081 — plumbing (config loader, rewrite hook, audit, `throw_iso_error` helper).
- PR #2084 — first builtin (`is_iso/2` + `is_lax/2`).
- **This PR** — sweep (arith compares + `succ_iso` + IEEE-754 lax floats).

Future builtins follow the §7 migration pattern incrementally.

## Test plan

- [x] All 74 prior tests still pass (no regression)
- [x] 10 new e2e tests pass covering ISO/lax/explicit/IEEE-754 paths
- [x] `g++ -std=c++17` clean compile (added `<cmath>` + `<limits>` includes)
- [x] Smoke-tested NaN/inf round-trip in isolation
- [x] Suite ran in ~207s — no perf regression on the existing tests

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_