### PR TITLE
feat(wam-clojure): add standard term ordering builtins

### DIFF
--- a/PR_WAM_CLOJURE_TERM_ORDER_BUILTINS.md
+++ b/PR_WAM_CLOJURE_TERM_ORDER_BUILTINS.md
@@ -1,0 +1,32 @@
+# PR Title
+
+feat(wam-clojure): add standard term ordering builtins
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM lowered-emitter support for `@</2`, `@=</2`, `@>/2`, and `@>=/2`.
+- Adds runtime `term-compare` plus predicate helpers for less-than, less-or-equal, greater-than, and greater-or-equal.
+- Wires interpreted runtime dispatch for all four standard term-ordering builtins.
+- Adds lowered-emitter tests for each builtin.
+- Adds runtime smoke coverage for atoms, numbers, compounds, variables, equality boundaries, and non-binding behavior.
+
+## Semantics
+
+The runtime comparison follows a conservative standard-order policy:
+
+- Variables and unbound placeholders sort before numbers.
+- Numbers sort before atoms.
+- Atoms sort before compound terms.
+- Atoms compare by deinterned atom name instead of intern ID.
+- Compound terms compare by arity, then functor name, then recursive argument comparison.
+
+These builtins inspect current terms after dereferencing but do not unify or mutate bindings.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -280,6 +280,22 @@ clojure_direct_builtin("\\==/2", "2").
 clojure_direct_builtin("\\==/2", 2).
 clojure_direct_builtin('\\==/2', "2").
 clojure_direct_builtin('\\==/2', 2).
+clojure_direct_builtin("@</2", "2").
+clojure_direct_builtin("@</2", 2).
+clojure_direct_builtin('@</2', "2").
+clojure_direct_builtin('@</2', 2).
+clojure_direct_builtin("@=</2", "2").
+clojure_direct_builtin("@=</2", 2).
+clojure_direct_builtin('@=</2', "2").
+clojure_direct_builtin('@=</2', 2).
+clojure_direct_builtin("@>/2", "2").
+clojure_direct_builtin("@>/2", 2).
+clojure_direct_builtin('@>/2', "2").
+clojure_direct_builtin('@>/2', 2).
+clojure_direct_builtin("@>=/2", "2").
+clojure_direct_builtin("@>=/2", 2).
+clojure_direct_builtin('@>=/2', "2").
+clojure_direct_builtin('@>=/2', 2).
 clojure_direct_builtin("=:=/2", "2").
 clojure_direct_builtin("=:=/2", 2).
 clojure_direct_builtin('=:=/2', "2").
@@ -435,6 +451,15 @@ clojure_arithmetic_order_builtin('=</2', 'arithmetic-less-or-equal?').
 clojure_arithmetic_order_builtin(">=/2", 'arithmetic-greater-or-equal?').
 clojure_arithmetic_order_builtin('>=/2', 'arithmetic-greater-or-equal?').
 
+clojure_term_order_builtin("@</2", 'term-less?').
+clojure_term_order_builtin('@</2', 'term-less?').
+clojure_term_order_builtin("@=</2", 'term-less-or-equal?').
+clojure_term_order_builtin('@=</2', 'term-less-or-equal?').
+clojure_term_order_builtin("@>/2", 'term-greater?').
+clojure_term_order_builtin('@>/2', 'term-greater?').
+clojure_term_order_builtin("@>=/2", 'term-greater-or-equal?').
+clojure_term_order_builtin('@>=/2', 'term-greater-or-equal?').
+
 emit_lowered_unary_guard(TestExpr, S, Expr) :-
     format(atom(Expr),
            '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if ~w (runtime/advance ~w) (runtime/backtrack ~w)))',
@@ -535,6 +560,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr),
            '(let [left (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound) right (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound)] (if (runtime/term-identical? ~w left right) (runtime/backtrack ~w) (runtime/advance ~w)))',
            [S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    clojure_term_order_builtin(Op, RuntimePred),
+    !,
+    format(atom(Expr),
+           '(let [left (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound) right (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound)] (if (runtime/~w ~w left right) (runtime/advance ~w) (runtime/backtrack ~w)))',
+           [S, S, RuntimePred, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "=:=/2" ; Op == '=:=/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -388,6 +388,78 @@
                   :else (interned-equal? l* r*))))]
       (identical* left right))))
 
+(defn term-compare [state left right]
+  (let [bindings (:bindings state)
+        ctx (:intern-context state)]
+    (letfn [(variable-like? [v]
+              (or (= v ::unbound) (keyword? v) (logic-var? v)))
+            (term-rank [v]
+              (cond
+                (variable-like? v) 0
+                (number? v) 1
+                (atom-term? v) 2
+                (structure-term? v) 3
+                :else 2))
+            (variable-key [v]
+              (cond
+                (logic-var? v) (format "v%020d" (long (:var v)))
+                (keyword? v) (name v)
+                :else ""))
+            (atom-key [v]
+              (cond
+                (atom-term? v) (deintern-atom ctx (:id v))
+                :else (str v)))
+            (sign [n]
+              (cond
+                (neg? n) -1
+                (pos? n) 1
+                :else 0))
+            (compare-args [xs ys]
+              (loop [left-args xs
+                     right-args ys]
+                (cond
+                  (and (empty? left-args) (empty? right-args)) 0
+                  (empty? left-args) -1
+                  (empty? right-args) 1
+                  :else
+                  (let [c (compare* (first left-args) (first right-args))]
+                    (if (zero? c)
+                      (recur (rest left-args) (rest right-args))
+                      c)))))
+            (compare* [l r]
+              (let [l* (deref-value bindings l)
+                    r* (deref-value bindings r)
+                    l-rank (term-rank l*)
+                    r-rank (term-rank r*)]
+                (cond
+                  (not= l-rank r-rank) (compare l-rank r-rank)
+                  (variable-like? l*) (sign (compare (variable-key l*) (variable-key r*)))
+                  (number? l*) (sign (compare l* r*))
+                  (atom-term? l*) (sign (compare (atom-key l*) (atom-key r*)))
+                  (structure-term? l*)
+                  (let [arity-c (compare (count (:args l*)) (count (:args r*)))]
+                    (if (zero? arity-c)
+                      (let [functor-c (compare (atom-key (:functor l*))
+                                               (atom-key (:functor r*)))]
+                        (if (zero? functor-c)
+                          (compare-args (:args l*) (:args r*))
+                          (sign functor-c)))
+                      (sign arity-c)))
+                  :else (sign (compare (str l*) (str r*))))))]
+      (compare* left right))))
+
+(defn term-less? [state left right]
+  (neg? (term-compare state left right)))
+
+(defn term-less-or-equal? [state left right]
+  (not (pos? (term-compare state left right))))
+
+(defn term-greater? [state left right]
+  (pos? (term-compare state left right)))
+
+(defn term-greater-or-equal? [state left right]
+  (not (neg? (term-compare state left right))))
+
 (defn parse-numeric-atom [text]
   (when (and (string? text)
              (re-matches #"[+-]?(?:\d+(?:\.\d*)?|\.\d+)" text))
@@ -1203,6 +1275,34 @@
             (if (term-identical? state left right)
               (backtrack state)
               (advance state)))
+
+          "@</2"
+          (let [left (or (reg-get-raw state "A1") ::unbound)
+                right (or (reg-get-raw state "A2") ::unbound)]
+            (if (term-less? state left right)
+              (advance state)
+              (backtrack state)))
+
+          "@=</2"
+          (let [left (or (reg-get-raw state "A1") ::unbound)
+                right (or (reg-get-raw state "A2") ::unbound)]
+            (if (term-less-or-equal? state left right)
+              (advance state)
+              (backtrack state)))
+
+          "@>/2"
+          (let [left (or (reg-get-raw state "A1") ::unbound)
+                right (or (reg-get-raw state "A2") ::unbound)]
+            (if (term-greater? state left right)
+              (advance state)
+              (backtrack state)))
+
+          "@>=/2"
+          (let [left (or (reg-get-raw state "A1") ::unbound)
+                right (or (reg-get-raw state "A2") ::unbound)]
+            (if (term-greater-or-equal? state left right)
+              (advance state)
+              (backtrack state)))
 
           "=:=/2"
           (let [left (deref-value (:bindings state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -166,6 +166,46 @@ test(simple_builtin_not_identity_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/backtrack")
     )).
 
+test(simple_builtin_term_less_is_direct_lowered_in_prefix) :-
+    once((
+        lower_predicate_to_clojure(test_term_less/2, [builtin_call('@</2', 2), proceed], [], Code),
+        has(Code, "runtime/reg-get-raw"),
+        has(Code, "\"A1\""),
+        has(Code, "\"A2\""),
+        has(Code, "runtime/term-less?"),
+        has(Code, "runtime/backtrack")
+    )).
+
+test(simple_builtin_term_less_or_equal_is_direct_lowered_in_prefix) :-
+    once((
+        lower_predicate_to_clojure(test_term_less_or_equal/2, [builtin_call('@=</2', 2), proceed], [], Code),
+        has(Code, "runtime/reg-get-raw"),
+        has(Code, "\"A1\""),
+        has(Code, "\"A2\""),
+        has(Code, "runtime/term-less-or-equal?"),
+        has(Code, "runtime/backtrack")
+    )).
+
+test(simple_builtin_term_greater_is_direct_lowered_in_prefix) :-
+    once((
+        lower_predicate_to_clojure(test_term_greater/2, [builtin_call('@>/2', 2), proceed], [], Code),
+        has(Code, "runtime/reg-get-raw"),
+        has(Code, "\"A1\""),
+        has(Code, "\"A2\""),
+        has(Code, "runtime/term-greater?"),
+        has(Code, "runtime/backtrack")
+    )).
+
+test(simple_builtin_term_greater_or_equal_is_direct_lowered_in_prefix) :-
+    once((
+        lower_predicate_to_clojure(test_term_greater_or_equal/2, [builtin_call('@>=/2', 2), proceed], [], Code),
+        has(Code, "runtime/reg-get-raw"),
+        has(Code, "\"A1\""),
+        has(Code, "\"A2\""),
+        has(Code, "runtime/term-greater-or-equal?"),
+        has(Code, "runtime/backtrack")
+    )).
+
 test(simple_builtin_arithmetic_equal_is_direct_lowered_in_prefix) :-
     once((
         lower_predicate_to_clojure(test_arith_eq/2, [builtin_call('=:=/2', 2), proceed], [], Code),

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -43,6 +43,13 @@
 :- dynamic user:wam_identity_distinct_unbound/0.
 :- dynamic user:wam_identity_after_alias/0.
 :- dynamic user:wam_identity_does_not_bind/0.
+:- dynamic user:wam_term_lt/2.
+:- dynamic user:wam_term_le/2.
+:- dynamic user:wam_term_gt/2.
+:- dynamic user:wam_term_ge/2.
+:- dynamic user:wam_term_var_lt_atom/0.
+:- dynamic user:wam_term_var_le_same/0.
+:- dynamic user:wam_term_order_does_not_bind/0.
 :- dynamic user:wam_fail_after_bind/1.
 :- dynamic user:wam_atom_guard/1.
 :- dynamic user:wam_integer_guard/1.
@@ -152,6 +159,13 @@ user:wam_identity_same_unbound :- user:wam_unbound_arg(X), X == X.
 user:wam_identity_distinct_unbound :- user:wam_unbound_arg(X), user:wam_unbound_arg(Y), X == Y.
 user:wam_identity_after_alias :- user:wam_unbound_arg(X), Y = X, X == Y.
 user:wam_identity_does_not_bind :- user:wam_unbound_arg(X), X == a.
+user:wam_term_lt(A, B) :- A @< B.
+user:wam_term_le(A, B) :- A @=< B.
+user:wam_term_gt(A, B) :- A @> B.
+user:wam_term_ge(A, B) :- A @>= B.
+user:wam_term_var_lt_atom :- user:wam_unbound_arg(X), X @< a.
+user:wam_term_var_le_same :- user:wam_unbound_arg(X), X @=< X.
+user:wam_term_order_does_not_bind :- user:wam_unbound_arg(X), X @< a, X == a.
 user:wam_fail_after_bind(X) :- X = a, fail.
 user:wam_atom_guard(X) :- atom(X).
 user:wam_integer_guard(X) :- integer(X).
@@ -266,6 +280,13 @@ run_smoke :-
           user:wam_identity_distinct_unbound/0,
           user:wam_identity_after_alias/0,
           user:wam_identity_does_not_bind/0,
+          user:wam_term_lt/2,
+          user:wam_term_le/2,
+          user:wam_term_gt/2,
+          user:wam_term_ge/2,
+          user:wam_term_var_lt_atom/0,
+          user:wam_term_var_le_same/0,
+          user:wam_term_order_does_not_bind/0,
           user:wam_fail_after_bind/1,
           user:wam_atom_guard/1,
           user:wam_integer_guard/1,
@@ -348,6 +369,7 @@ run_smoke :-
     assert_lowered_cut_builtin_emitted(TmpDir),
     assert_lowered_not_unify_builtin_emitted(TmpDir),
     assert_lowered_identity_builtin_emitted(TmpDir),
+    assert_lowered_term_order_builtin_emitted(TmpDir),
     assert_lowered_fail_builtin_emitted(TmpDir),
     assert_lowered_atom_builtin_emitted(TmpDir),
     assert_lowered_integer_builtin_emitted(TmpDir),
@@ -437,6 +459,21 @@ smoke_cases([
     case('wam_identity_distinct_unbound/0', no_args, "false"),
     case('wam_identity_after_alias/0', no_args, "true"),
     case('wam_identity_does_not_bind/0', no_args, "false"),
+    case('wam_term_lt/2', args(a, b), "true"),
+    case('wam_term_lt/2', args(b, a), "false"),
+    case('wam_term_lt/2', args(42, a), "true"),
+    case('wam_term_lt/2', args(a, 'f(a)'), "true"),
+    case('wam_term_lt/2', args('f(a)', 'f(a,b)'), "true"),
+    case('wam_term_lt/2', args('f(a)', 'f(b)'), "true"),
+    case('wam_term_le/2', args(a, a), "true"),
+    case('wam_term_le/2', args(b, a), "false"),
+    case('wam_term_gt/2', args(b, a), "true"),
+    case('wam_term_gt/2', args(a, b), "false"),
+    case('wam_term_ge/2', args(a, a), "true"),
+    case('wam_term_ge/2', args(a, b), "false"),
+    case('wam_term_var_lt_atom/0', no_args, "true"),
+    case('wam_term_var_le_same/0', no_args, "true"),
+    case('wam_term_order_does_not_bind/0', no_args, "false"),
     case('wam_fail_after_bind/1', a, "false"),
     case('wam_fail_after_bind/1', b, "false"),
     case('wam_atom_guard/1', a, "true"),
@@ -616,6 +653,18 @@ assert_lowered_identity_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-identity-guard-2"),
     has(CoreCode, "defn lowered-wam-not-identity-guard-2"),
     has(CoreCode, "runtime/term-identical?").
+
+assert_lowered_term_order_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-term-lt-2"),
+    has(CoreCode, "defn lowered-wam-term-le-2"),
+    has(CoreCode, "defn lowered-wam-term-gt-2"),
+    has(CoreCode, "defn lowered-wam-term-ge-2"),
+    has(CoreCode, "runtime/term-less?"),
+    has(CoreCode, "runtime/term-less-or-equal?"),
+    has(CoreCode, "runtime/term-greater?"),
+    has(CoreCode, "runtime/term-greater-or-equal?").
 
 assert_lowered_fail_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM lowered-emitter support for `@</2`, `@=</2`, `@>/2`, and `@>=/2`.
- Adds runtime `term-compare` plus predicate helpers for less-than, less-or-equal, greater-than, and greater-or-equal.
- Wires interpreted runtime dispatch for all four standard term-ordering builtins.
- Adds lowered-emitter tests for each builtin.
- Adds runtime smoke coverage for atoms, numbers, compounds, variables, equality boundaries, and non-binding behavior.

## Semantics

The runtime comparison follows a conservative standard-order policy:

- Variables and unbound placeholders sort before numbers.
- Numbers sort before atoms.
- Atoms sort before compound terms.
- Atoms compare by deinterned atom name instead of intern ID.
- Compound terms compare by arity, then functor name, then recursive argument comparison.

These builtins inspect current terms after dereferencing but do not unify or mutate bindings.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
