### PR TITLE
feat(wam-cpp): call/N meta-call

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -1576,6 +1576,15 @@ struct WamState {
     // after_pc becomes the new cp (where the goal proceeds to).
     // Returns false if the goal''s functor has no registered label.
     bool    invoke_goal_as_call(CellPtr goal_cell, std::size_t after_pc);
+    // call/N meta-call dispatch. Total arity comes from the op
+    // suffix (call/3 → 3). For total_arity == 1 the goal in A1 is
+    // invoked as-is; otherwise A2..AN are appended to the goal''s
+    // existing args and the combined goal is dispatched. after_pc
+    // is supplied by the caller — pc+1 for non-tail (Call), cp for
+    // tail (Execute). Returns invoke_goal_as_call''s result.
+    bool    dispatch_call_meta(const std::string& op,
+                               std::int64_t total_arity,
+                               std::size_t after_pc);
     bool    execute_catch();
     bool    execute_throw();
 
@@ -2802,6 +2811,13 @@ bool WamState::step(const Instruction& instr) {
         case Instruction::Op::Call: {
             if (instr.a == "catch/3") { cp = pc + 1; return execute_catch(); }
             if (instr.a == "throw/1") { cp = pc + 1; return execute_throw(); }
+            // call/N meta — needs its own arm so the after_pc is
+            // correctly pc + 1 (non-tail) rather than going through
+            // the Execute fallback''s post-builtin pc=cp override.
+            if (instr.a.size() > 5
+                && instr.a.compare(0, 5, "call/") == 0) {
+                return dispatch_call_meta(instr.a, instr.n, pc + 1);
+            }
             auto it = labels.find(instr.a);
             if (it != labels.end()) {
                 cp = pc + 1;
@@ -2816,6 +2832,15 @@ bool WamState::step(const Instruction& instr) {
         case Instruction::Op::Execute: {
             if (instr.a == "catch/3") return execute_catch();
             if (instr.a == "throw/1") return execute_throw();
+            // call/N meta in tail position — after_pc is the
+            // caller''s saved cp (or halt if cp == 0).
+            if (instr.a.size() > 5
+                && instr.a.compare(0, 5, "call/") == 0) {
+                std::size_t tail_after = cp;
+                bool ok = dispatch_call_meta(instr.a, instr.n, tail_after);
+                if (!ok) return false;
+                return true;
+            }
             auto it = labels.find(instr.a);
             if (it != labels.end()) {
                 pc = it->second;
@@ -3221,6 +3246,60 @@ bool WamState::invoke_goal_as_call(CellPtr goal_cell, std::size_t after_pc) {
         return true;
     }
     return false;
+}
+
+bool WamState::dispatch_call_meta(const std::string& op,
+                                  std::int64_t /* n_unused */,
+                                  std::size_t after_pc) {
+    // Parse arity from the op-name suffix. Execute instructions
+    // don''t carry an arity field (only Call does), so we always
+    // derive arity from the key — same result either way for
+    // Call but only this path works for Execute.
+    std::int64_t total_arity = 0;
+    auto slash = op.rfind(''/'');
+    if (slash == std::string::npos) return false;
+    try { total_arity = std::stoll(op.substr(slash + 1)); }
+    catch (...) { return false; }
+    if (total_arity < 1) return false;
+    CellPtr goal_cell = get_cell("A1");
+    if (total_arity == 1) {
+        // No extras — dispatch A1 as-is.
+        return invoke_goal_as_call(goal_cell, after_pc);
+    }
+    // Snapshot extras BEFORE we mutate A-registers further. Extras
+    // come from A2..AN as cell pointers (so any aliasing into the
+    // future combined goal stays sharing-correct).
+    std::vector<CellPtr> extras;
+    extras.reserve(total_arity - 1);
+    for (std::int64_t i = 2; i <= total_arity; ++i) {
+        extras.push_back(get_cell("A" + std::to_string(i)));
+    }
+    // Resolve the goal''s base name and existing args.
+    Value goal = deref(*goal_cell);
+    std::string base_name;
+    std::size_t base_arity = 0;
+    std::vector<CellPtr> all_args;
+    if (goal.tag == Value::Tag::Atom) {
+        base_name = goal.s;
+    } else if (goal.tag == Value::Tag::Compound) {
+        auto slash = goal.s.rfind(''/'');
+        if (slash == std::string::npos) return false;
+        base_name = goal.s.substr(0, slash);
+        try { base_arity = std::stoul(goal.s.substr(slash + 1)); }
+        catch (...) { return false; }
+        if (base_arity != goal.args.size()) return false;
+        all_args = goal.args;
+    } else {
+        // Unbound goal — ISO call/N throws instantiation_error;
+        // v1 lax just fails.
+        return false;
+    }
+    for (auto& e : extras) all_args.push_back(e);
+    std::size_t new_arity = base_arity + extras.size();
+    std::string new_functor = base_name + "/" + std::to_string(new_arity);
+    CellPtr combined = std::make_shared<Cell>(
+        Value::Compound(new_functor, std::move(all_args)));
+    return invoke_goal_as_call(combined, after_pc);
 }
 
 // catch(Goal, Catcher, Recovery): push a CatcherFrame snapshotting

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -285,6 +285,39 @@ user:wam_cpp_test_not_alias_fails    :- not(true).
 % because NaN =:= NaN is false but \=== NaN at the structural level.
 user:wam_cpp_test_not_nan_check   :- R is 0.0 / 0.0, \+ (R =:= R).
 
+% call/N (meta-call):
+:- dynamic user:wam_cpp_call_helper/1.
+:- dynamic user:wam_cpp_test_call_atom/0.
+:- dynamic user:wam_cpp_test_call_with_args/0.
+:- dynamic user:wam_cpp_test_call_partial/0.
+:- dynamic user:wam_cpp_test_call_compound_already/0.
+:- dynamic user:wam_cpp_test_call_user_pred/0.
+
+% Helper user predicate to dispatch indirectly.
+user:wam_cpp_call_helper(hello).
+
+% call(true) — 0-extra-args, atom goal. Tail-call path.
+user:wam_cpp_test_call_atom :- call(true).
+
+% call(=, X, 5) — 2 extras appended to atom functor. Mid-body Call
+% path. Verifies the X gets bound to 5 by the dispatched =/2.
+user:wam_cpp_test_call_with_args :- call(=, X, 5), X = 5.
+
+% call(=(X), 7) — 1 extra appended to a 1-arg compound. The combined
+% goal is =(X, 7), arity 2. Exercises the existing-args-plus-extras
+% path of dispatch_call_meta.
+user:wam_cpp_test_call_partial :- G = =(X), call(G, 7), X = 7.
+
+% call(G) where G is already a full goal — no extras, compound goal.
+user:wam_cpp_test_call_compound_already :-
+    G = wam_cpp_call_helper(hello),
+    call(G).
+
+% call(F, X) dispatching to a USER predicate (not a builtin). Tests
+% the user-label dispatch path inside invoke_goal_as_call.
+user:wam_cpp_test_call_user_pred :-
+    call(wam_cpp_call_helper, hello).
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -1584,6 +1617,87 @@ test(cpp_e2e_not_nan_check, [condition(cpp_compiler_available)]) :-
                               [emit_main(true)], TmpDir),
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath, 'wam_cpp_test_not_nan_check/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% call/N — meta-call. `call(Goal)` dispatches Goal as a goal;
+% `call(Goal, X1, ..., XK)` appends X1..XK to Goal''s existing args
+% and dispatches the resulting goal. The WAM compiler emits this as
+% `execute call/N` (tail) or `call call/N, N` (non-tail), with Goal
+% in A1 and the extras in A2..AN. dispatch_call_meta builds the
+% combined goal term and routes through invoke_goal_as_call (the
+% same path catch/3 and \+/1 use).
+% ------------------------------------------------------------------
+
+test(cpp_e2e_call_atom, [condition(cpp_compiler_available)]) :-
+    % call(true) — tail-call dispatch path through the Execute arm
+    % (where instr.n is 0 since Execute instructions don''t carry
+    % arity; dispatch_call_meta parses arity from the op-name
+    % suffix). Regression guard for that specific Execute/Call
+    % asymmetry.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_call_atom', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_call_atom/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_call_atom/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_call_with_args, [condition(cpp_compiler_available)]) :-
+    % call(=, X, 5) builds =(X, 5) and dispatches.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_call_args', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_call_with_args/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_call_with_args/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_call_partial, [condition(cpp_compiler_available)]) :-
+    % G = =(X), call(G, 7) — extras append to existing compound args.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_call_partial', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_call_partial/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_call_partial/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_call_compound_already,
+     [condition(cpp_compiler_available)]) :-
+    % G = full_goal, call(G) — no extras, already-complete compound.
+    % Tests the call/1 path with a compound argument.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_call_compound', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_call_compound_already/0,
+                               user:wam_cpp_call_helper/1],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_call_compound_already/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_call_user_pred, [condition(cpp_compiler_available)]) :-
+    % call(F, X) dispatching to a USER predicate (not a builtin).
+    % Tests the user-label dispatch path inside invoke_goal_as_call.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_call_user', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_call_user_pred/0,
+                               user:wam_cpp_call_helper/1],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_call_user_pred/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Adds the `call/N` family of meta-calls — `call(Goal)`, `call(Goal, X1)`, ... `call(Goal, X1, ..., XK)`. User code can now write higher-order patterns (maplist-like dispatch, indirect predicate invocation, partial application of compound goal-terms).

The WAM compiler emits `call/N` usage as:
- `execute call/N` — when `call/N` is the tail goal of a body.
- `call call/N, N` — otherwise (non-tail).

with the goal in `A1` and any extras in `A2..AN`.

## Runtime additions

- **`WamState::dispatch_call_meta/3`** builds the combined goal term:
  - Parses the total arity from the op-name suffix (Execute instructions don't carry arity in `instr.n` — only Call does, so parsing from the key works for both paths).
  - Reads `A1` as the base goal (atom for 0-arity or `"name/arity"` compound).
  - Gathers `A2..AN` extras, appends to the base goal's args.
  - Routes through `invoke_goal_as_call` to dispatch the combined goal.
- **Call step arm** gets a `call/N` branch before the labels lookup, with `after_pc = pc + 1` (non-tail semantics).
- **Execute step arm** gets a parallel `call/N` branch using `cp` as `after_pc` (tail semantics).

`catch/3` and `throw/1` special cases remain ahead of the `call/N` check so a goal-term of `catch(...)` or `throw(...)` routed through `call/1` still gets the meta-builtin handling.

The dispatch is layered on top of the existing `invoke_goal_as_call` machinery — same path `\+/1` and `catch/3` use — so atom control goals (`true`, `fail`, `false`) and user-predicate label dispatch all work for `call/N` without duplicate logic.

## Tests — 5 new e2e tests

| Test | Coverage |
|---|---|
| `cpp_e2e_call_atom` | `call(true)` via tail Execute arm. Regression guard for the Execute-instr-has-no-arity case discovered during this PR's development (the original `dispatch_call_meta` used `instr.n` which is 0 for Execute; fix parses arity from the op name) |
| `cpp_e2e_call_with_args` | `call(=, X, 5)` builds `=(X, 5)` and dispatches; `X` binds to 5 |
| `cpp_e2e_call_partial` | `call(=(X), 7)` appends one extra to a 1-arg compound goal, yielding `=(X, 7)` |
| `cpp_e2e_call_compound_already` | `call(G)` where `G` is already a complete compound goal. Tests the 0-extras path with a non-atom base |
| `cpp_e2e_call_user_pred` | `call(F, X)` dispatching to a **user** predicate (not a builtin) — verifies the user-label dispatch inside `invoke_goal_as_call` works for meta-calls too |

**Total: 94/94 passing** (was 89; +5 new).

## Verification

```
$ swipl -g "[tests/test_wam_cpp_generator]" -g "run_tests(wam_cpp_generator)" -t halt
% All 94 tests passed
```

## Latent bug surfaced during development

`Instruction::Execute(P)` doesn't carry an arity field — only `Instruction::Call(p, n)` does. The original draft of `dispatch_call_meta` trusted `instr.n` for arity, which silently produced 0 for tail-call dispatch (`execute call/N`) and made `call(true)` always fail. Fix: parse arity from the op-name suffix (`call/3` → 3) in `dispatch_call_meta` regardless of caller. Now Execute and Call paths derive arity the same way.

## Known limitations (deferred)

- Unbound goal — `call(_X)` should throw `instantiation_error` under ISO; v1 just fails. Lands when the ISO-error rewrite adds an iso flavour for `call/N`.

## Test plan

- [x] All 89 prior tests still pass (no regression)
- [x] 5 new e2e tests pass covering atom / args-appended / partial / already-compound / user-pred paths
- [x] `g++ -std=c++17` clean compile
- [x] Smoke-tested both `execute call/N` and `call call/N, N` paths
- [ ] Follow-up: `findall`-pattern using `call/N` for user-supplied goals — exercises the higher-order use case end-to-end

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_