### PR TITLE
refactor(wam-cpp): Instruction::Execute carries arity (matches Call)

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -149,6 +149,23 @@ to_string(X, S) :- atom(X), !, atom_string(X, S).
 to_string(X, S) :- number(X), !, number_string(X, S).
 to_string(X, S) :- format(string(S), "~w", [X]).
 
+% execute_arity_from_key(+Key, -Arity)
+%   For a predicate key like "foo/3", returns the integer arity (3).
+%   For anything that doesn''t parse, returns 0. Used by the Execute
+%   instruction emitter so Instruction::Execute carries arity in
+%   instr.n — matches Call''s factory and lets meta-builtins
+%   (call/N) read arity uniformly from instr.n regardless of dispatch
+%   path.
+execute_arity_from_key(Key, Arity) :-
+    to_string(Key, KS),
+    (   split_string(KS, "/", "", Parts),
+        last(Parts, ArS),
+        number_string(N, ArS),
+        integer(N)
+    ->  Arity = N
+    ;   Arity = 0
+    ).
+
 % ============================================================================
 % Phase 2: WAM instructions -> C++ struct-initializer literals
 % ============================================================================
@@ -229,7 +246,13 @@ wam_instruction_to_cpp_literal_det(call(P, N), _, Code) :-
 wam_instruction_to_cpp_literal_det(execute(P), _, Code) :-
     to_string(P, PS),
     escape_cpp_string(PS, EP),
-    format(atom(Code), 'Instruction::Execute("~w")', [EP]).
+    % Derive arity from the "Name/Arity" predicate-key suffix so the
+    % runtime can read instr.n directly (matches Call''s factory).
+    % Anything that doesn''t parse falls back to arity 0 — Execute
+    % targeting a label-only predicate (e.g. the auto-injected
+    % helpers) doesn''t care about arity downstream.
+    execute_arity_from_key(PS, NArity),
+    format(atom(Code), 'Instruction::Execute("~w", ~w)', [EP, NArity]).
 wam_instruction_to_cpp_literal_det(proceed, _, 'Instruction::Proceed()').
 wam_instruction_to_cpp_literal_det(fail, _, 'Instruction::Fail()').
 wam_instruction_to_cpp_literal_det(allocate, _, 'Instruction::Allocate()').
@@ -1379,8 +1402,8 @@ struct Instruction {
         { Instruction i; i.op = Op::SetConstant; i.val = std::move(v); return i; }
     static Instruction Call(std::string p, std::int64_t n)
         { Instruction i; i.op = Op::Call; i.a = std::move(p); i.n = n; return i; }
-    static Instruction Execute(std::string p)
-        { Instruction i; i.op = Op::Execute; i.a = std::move(p); return i; }
+    static Instruction Execute(std::string p, std::int64_t n = 0)
+        { Instruction i; i.op = Op::Execute; i.a = std::move(p); i.n = n; return i; }
     static Instruction Proceed()    { Instruction i; i.op = Op::Proceed;    return i; }
     static Instruction Fail()       { Instruction i; i.op = Op::Fail;       return i; }
     static Instruction Allocate()   { Instruction i; i.op = Op::Allocate;   return i; }
@@ -3249,17 +3272,20 @@ bool WamState::invoke_goal_as_call(CellPtr goal_cell, std::size_t after_pc) {
 }
 
 bool WamState::dispatch_call_meta(const std::string& op,
-                                  std::int64_t /* n_unused */,
+                                  std::int64_t instr_n,
                                   std::size_t after_pc) {
-    // Parse arity from the op-name suffix. Execute instructions
-    // don''t carry an arity field (only Call does), so we always
-    // derive arity from the key — same result either way for
-    // Call but only this path works for Execute.
-    std::int64_t total_arity = 0;
-    auto slash = op.rfind(''/'');
-    if (slash == std::string::npos) return false;
-    try { total_arity = std::stoll(op.substr(slash + 1)); }
-    catch (...) { return false; }
+    // Prefer the arity the caller passed (instr.n from both Call AND
+    // Execute now that Execute carries arity via its factory). Fall
+    // back to parsing the op-name suffix for robustness in case any
+    // direct caller forgets to pass it.
+    std::int64_t total_arity = instr_n;
+    if (total_arity < 1) {
+        auto slash = op.rfind(''/'');
+        if (slash != std::string::npos) {
+            try { total_arity = std::stoll(op.substr(slash + 1)); }
+            catch (...) { return false; }
+        }
+    }
     if (total_arity < 1) return false;
     CellPtr goal_cell = get_cell("A1");
     if (total_arity == 1) {


### PR DESCRIPTION
## Summary

Architectural cleanup for the asymmetry flagged in PR #2094: `Instruction::Call(p, n)` carried arity in `instr.n` but `Instruction::Execute(p)` didn't, so any code reading `instr.n` for an Execute instruction silently got 0. `dispatch_call_meta` worked around this by parsing arity from the op-name suffix; now arity is uniformly available from `instr.n` regardless of dispatch path.

## Changes

- **`Instruction::Execute` factory** grows a second arg with default `0` for backwards compatibility:
  ```cpp
  static Instruction Execute(std::string p, std::int64_t n = 0)
  ```
  The default keeps any direct C++ caller working; new emissions pass arity explicitly.
- **`execute_arity_from_key/2`** helper added next to `to_string/2` — parses the `"Name/Arity"` key into the integer arity, returns 0 on unparseable input. Used only by the emitter; runtime stays string-shape agnostic.
- **Emitter** for `execute(P)` now produces `Instruction::Execute("<key>", <arity>)` where arity comes from `execute_arity_from_key/2`.
- **`dispatch_call_meta`** switches to `instr_n` as the primary arity source. The op-name-suffix parse stays as a fallback for direct C++ callers that might forget to pass arity — keeps the bug surface zero either way.

## Observable effect

```diff
- vm.instrs.push_back(Instruction::Execute("member/2"));
- vm.instrs.push_back(Instruction::Execute("append/3"));
+ vm.instrs.push_back(Instruction::Execute("member/2", 2));
+ vm.instrs.push_back(Instruction::Execute("append/3", 3));
```

## Verification

**All 94 prior tests still pass** — this is a zero-behavior-change refactor.

```
$ swipl -g "[tests/test_wam_cpp_generator]" -g "run_tests(wam_cpp_generator)" -t halt
% All 94 tests passed
```

## Test plan

- [x] All 94 prior tests still pass (no regression)
- [x] `Instruction::Execute(p)` (single-arg) still compiles thanks to the default arg
- [x] Generated `Instruction::Execute` calls now consistently carry arity
- [x] `dispatch_call_meta` works correctly from both Call and Execute paths
- [ ] Future: any new meta-builtins that need arity at dispatch can read `instr.n` uniformly without re-parsing the key

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_