### PR TITLE
feat(wam-c): Lower projected body-call helpers

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,7 +5,7 @@ Status date: 2026-05-14
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `6e5e8cca` (`Merge pull request #2083 from s243a/feat/wam-c-lowered-helper-empty-result-rejections`)
+- `main` at `dedaeefc` (`Merge pull request #2088 from s243a/feat/wam-cpp-iso-sweep`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
@@ -14,7 +14,7 @@ Base verified locally:
 
 Active branch:
 
-- `feat/wam-c-lowered-helper-body-call-rejections`
+- `feat/wam-c-lowered-helper-expanded-body-calls`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -52,7 +52,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper comparison-filter rejection metadata | Done | Planner reports explicit rejection reasons for unbound comparison guard variables, unsupported expressions, non-integer ordering rows, and no matching rows |
 | Lowered helper repeated-variable filters | Done | Constant and comparison filtered helpers preserve repeated callee-variable row constraints with planner and executable coverage |
 | Lowered helper empty-result rejections | Done | Planner reports `no_matching_filter_rows` for supported constant filtered helpers whose constraints produce no rows, alongside existing comparison no-match metadata |
-| Lowered helper body-call rejection metadata | In progress | Active branch reports explicit unavailable and non-lowerable callee reasons for exact user-predicate body-call shapes |
+| Lowered helper body-call rejection metadata | Done | Planner reports explicit unavailable and non-lowerable callee reasons for exact user-predicate body-call shapes |
+| Lowered helper projected body calls | In progress | Active branch lowers variable-only reordered body-call projections through native fact-helper dispatch with executable coverage |
 
 ## Current C Target Baseline
 
@@ -123,7 +124,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup and all-hop collection; add more kernel kinds only after runtime support exists. |
 | Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`; broaden as more native C kernels land. |
-| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, comparison-filter helpers, rejection metadata, repeated-variable filter hardening, and active empty-result rejection metadata. |
+| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, comparison-filter helpers, rejection metadata, repeated-variable filter hardening, empty-result rejection metadata, and active projected body-call helper expansion. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
 | Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB `kernels_on`/`kernels_off`; next gap is larger artifact layouts. |
@@ -133,38 +134,38 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lowered-helper-body-call-rejections`
-
-Goal: make unsupported body-call lowering failures explicit before expanding
-the body-call helper surface.
-
-Scope:
-
-- Add planner metadata for alias/body-call shapes whose callee is not available
-  for native lowering.
-- Keep the existing direct native fact-helper dispatch unchanged.
-- Prefer planner tests and generated plan comments over runtime changes.
-
-Status: active; exact user-predicate body-call shapes now report
-`body_call_callee_not_available` or `body_call_callee_not_lowerable` when they
-cannot use direct native helper dispatch.
-
-### 2. `feat/wam-c-lowered-helper-expanded-body-calls`
+### 1. `feat/wam-c-lowered-helper-expanded-body-calls`
 
 Goal: expand body-call helper lowering beyond direct alias-to-fact dispatch only
 after unsupported body-call shapes have explicit planner metadata.
 
 Scope:
 
-- Evaluate simple body-call projections that are currently handled as filtered
-  fact helpers.
+- Evaluate simple variable-only body-call projections that were previously
+  handled as materialized filtered fact helpers.
 - Keep explicit rejection metadata for unavailable and non-lowerable callees.
 - Add runtime coverage only for any newly supported body-call shape.
 
+Status: active; variable-only reordered body-call projections now lower through
+native callee helper dispatch. Constant filters remain on the existing
+filtered-fact path.
+
+### 2. `test/wam-c-generated-project-multi-predicate-setup`
+
+Goal: make generated-project smoke coverage less sensitive to setup-function
+ordering.
+
+Scope:
+
+- Cover multiple generated WAM predicate trampolines in one executable without
+  relying on the last `setup_*` call.
+- Preserve existing lowered-helper foreign registration behavior.
+- Prefer a focused runtime/setup smoke before changing generated setup layout.
+
 ## Suggested Immediate Next Step
 
-Continue validating `feat/wam-c-lowered-helper-body-call-rejections`.
+Continue validating `feat/wam-c-lowered-helper-expanded-body-calls`.
 
-The active branch adds explicit planner and generated-comment metadata for
-exact user-predicate body-call shapes whose callee is unavailable or not
-lowerable, while leaving successful direct body-call helper dispatch unchanged.
+The active branch adds native wrapper generation for variable-only reordered
+body-call projections, while leaving direct body-call dispatch, constant
+filtered helpers, and rejection metadata unchanged.

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -183,6 +183,8 @@ plan_wam_c_lowered_helper(DetectedKeys, AvailableKeys, PredIndicator, Plan) :-
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, fact_only(Rows))
     ;   lowered_body_call_helper(PredIndicator, AvailableKeys, CalleeKey, CalleeArity)
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, body_call(CalleeKey, CalleeArity))
+    ;   lowered_body_call_projected_helper(PredIndicator, AvailableKeys, CalleeKey, CalleeArity, CalleeArgs)
+    ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, body_call_projected(CalleeKey, CalleeArity, CalleeArgs))
     ;   lowered_body_call_rejection_reason(PredIndicator, AvailableKeys, Reason)
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, rejected, Reason)
     ;   lowered_comparison_filtered_fact_helper(PredIndicator, CalleeKey, Rows)
@@ -347,7 +349,12 @@ compile_lowered_helpers_for_project(Plans, LoweredKeys, Code, SetupCode) :-
                 lowered_body_call_helper_for_predicate(PredIndicator, CalleeKey, CalleeArity, Key, CodePart, SetupLine)
             ),
             BodyCallEntries),
-    append(FactEntries, BodyCallEntries, Entries),
+    findall(Key-CodePart-SetupLine,
+            (   member(wam_c_lowered_helper_plan(Key, PredIndicator, lowered, body_call_projected(CalleeKey, CalleeArity, CalleeArgs)), Plans),
+                lowered_body_call_projected_helper_for_predicate(PredIndicator, CalleeKey, CalleeArity, CalleeArgs, Key, CodePart, SetupLine)
+            ),
+            ProjectedBodyCallEntries),
+    append([FactEntries, BodyCallEntries, ProjectedBodyCallEntries], Entries),
     findall(K, member(K-_-_, Entries), LoweredKeys),
     findall(C, member(_-C-_, Entries), Codes),
     findall(S, member(_-_-S, Entries), SetupLines),
@@ -386,6 +393,7 @@ wam_c_lowered_helper_plan_by_action(Plans, Action, Key, ReasonLabel) :-
 
 wam_c_lowered_plan_reason_label(fact_only(_Rows), fact_only) :- !.
 wam_c_lowered_plan_reason_label(body_call(_CalleeKey, _CalleeArity), body_call) :- !.
+wam_c_lowered_plan_reason_label(body_call_projected(_CalleeKey, _CalleeArity, _CalleeArgs), body_call_projected) :- !.
 wam_c_lowered_plan_reason_label(filtered_fact(_CalleeKey, _Rows), filtered_fact) :- !.
 wam_c_lowered_plan_reason_label(comparison_filtered_fact(_CalleeKey, _Rows), comparison_filtered_fact) :- !.
 wam_c_lowered_plan_reason_label(Reason, Reason).
@@ -444,6 +452,14 @@ lowered_body_call_helper(PredIndicator, AvailableKeys, CalleeKey, CalleeArity) :
     format(atom(CalleeKey), '~w/~w', [CalleePred, CalleeArity]),
     memberchk(CalleeKey, AvailableKeys).
 
+lowered_body_call_projected_helper(PredIndicator, AvailableKeys, CalleeKey, CalleeArity, CalleeArgs) :-
+    projected_body_call_context(PredIndicator, HeadArgs, CalleePred, CalleeArity, CalleeKey, CalleeArgs),
+    format(atom(CalleeKey), '~w/~w', [CalleePred, CalleeArity]),
+    memberchk(CalleeKey, AvailableKeys),
+    CalleeIndicator = user:CalleePred/CalleeArity,
+    lowered_fact_helper_rows(CalleeIndicator, _Rows),
+    head_args_project_once(HeadArgs, CalleeArgs).
+
 lowered_body_call_rejection_reason(PredIndicator, AvailableKeys, Reason) :-
     body_call_context(PredIndicator, CalleePred, CalleeArity, CalleeKey),
     callee_has_user_clause(CalleePred, CalleeArity),
@@ -456,6 +472,10 @@ lowered_body_call_rejection_reason(PredIndicator, AvailableKeys, Reason) :-
     !.
 
 body_call_context(PredIndicator, CalleePred, CalleeArity, CalleeKey) :-
+    projected_body_call_context(PredIndicator, HeadArgs, CalleePred, CalleeArity, CalleeKey, CalleeArgs),
+    HeadArgs == CalleeArgs.
+
+projected_body_call_context(PredIndicator, HeadArgs, CalleePred, CalleeArity, CalleeKey, CalleeArgs) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
     functor(Head, Pred, Arity),
     findall(Args-Body,
@@ -468,9 +488,24 @@ body_call_context(PredIndicator, CalleePred, CalleeArity, CalleeKey) :-
     Body \= (_, _),
     Body =.. [CalleePred|CalleeArgs],
     length(CalleeArgs, CalleeArity),
-    Args == CalleeArgs,
     (Pred/Arity) \== (CalleePred/CalleeArity),
+    HeadArgs = Args,
+    maplist(var, HeadArgs),
+    maplist(projected_body_call_arg_supported(HeadArgs), CalleeArgs),
     format(atom(CalleeKey), '~w/~w', [CalleePred, CalleeArity]).
+
+projected_body_call_arg_supported(HeadArgs, Arg) :-
+    member(HeadArg, HeadArgs),
+    Arg == HeadArg.
+
+head_args_project_once([], _CalleeArgs).
+head_args_project_once([HeadArg|Rest], CalleeArgs) :-
+    include(same_variable(HeadArg), CalleeArgs, Matches),
+    Matches = [_],
+    head_args_project_once(Rest, CalleeArgs).
+
+same_variable(Left, Right) :-
+    Left == Right.
 
 callee_has_user_clause(Pred, Arity) :-
     functor(Head, Pred, Arity),
@@ -494,6 +529,77 @@ lowered_body_call_helper_for_predicate(PredIndicator, CalleeKey, CalleeArity, Ke
     format(atom(SetupLine),
            '    wam_register_foreign_predicate(state, "~w", ~w, ~w);',
            [Key, Arity, Symbol]).
+
+lowered_body_call_projected_helper_for_predicate(PredIndicator, CalleeKey, CalleeArity, _CalleeArgs, Key, Code, SetupLine) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
+    format(atom(Key), '~w/~w', [Pred, Arity]),
+    wam_c_symbol_name(Pred, Arity, Symbol),
+    wam_c_symbol_for_key(CalleeKey, CalleeSymbol),
+    projected_body_call_arg_assignments(PredIndicator, ArgAssignments),
+    projected_body_call_result_copies(PredIndicator, ResultCopies),
+    MaxArity is max(Arity, CalleeArity),
+    format(atom(Code),
+'static bool ~w(WamState *state, const char *pred, int arity) {
+    (void)pred;
+    if (arity != ~w) return false;
+    WamValue saved_args[~w];
+    for (int i = 0; i < ~w; i++) saved_args[i] = state->A[i];
+~w
+    bool ok = ~w(state, "~w", ~w);
+    if (ok) {
+        WamValue result_args[~w];
+        for (int i = 0; i < ~w; i++) result_args[i] = state->A[i];
+~w
+    } else {
+        for (int i = 0; i < ~w; i++) state->A[i] = saved_args[i];
+    }
+    for (int i = ~w; i < ~w; i++) state->A[i] = saved_args[i];
+    return ok;
+}',
+           [Symbol, Arity, MaxArity, MaxArity, ArgAssignments, CalleeSymbol, CalleeKey, CalleeArity, CalleeArity, CalleeArity, ResultCopies, Arity, Arity, MaxArity]),
+    format(atom(SetupLine),
+           '    wam_register_foreign_predicate(state, "~w", ~w, ~w);',
+           [Key, Arity, Symbol]).
+
+projected_body_call_arg_assignments(PredIndicator, Code) :-
+    projected_body_call_clause_args(PredIndicator, HeadArgs, CalleeArgs),
+    findall(Line,
+            (   nth0(I, CalleeArgs, Arg),
+                projected_body_call_arg_assignment(I, Arg, HeadArgs, Line)
+            ),
+            Lines),
+    atomic_list_concat(Lines, '\n', Code).
+
+projected_body_call_clause_args(PredIndicator, HeadArgs, CalleeArgs) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
+    functor(Head, Pred, Arity),
+    user:clause(Head, Body),
+    Body \== true,
+    Head =.. [_|HeadArgs],
+    strip_module_qualification(Body, StrippedBody),
+    StrippedBody =.. [_CalleePred|CalleeArgs].
+
+projected_body_call_arg_assignment(I, Arg, _HeadArgs, Line) :-
+    wam_c_lowered_constant(Arg),
+    !,
+    c_value_literal(Arg, ValLit),
+    format(atom(Line), '    state->A[~w] = ~w;', [I, ValLit]).
+projected_body_call_arg_assignment(I, Arg, HeadArgs, Line) :-
+    nth0(HeadIndex, HeadArgs, HeadArg),
+    Arg == HeadArg,
+    !,
+    format(atom(Line), '    state->A[~w] = saved_args[~w];', [I, HeadIndex]).
+
+projected_body_call_result_copies(PredIndicator, Code) :-
+    projected_body_call_clause_args(PredIndicator, HeadArgs, CalleeArgs),
+    findall(Line,
+            (   nth0(HeadIndex, HeadArgs, HeadArg),
+                nth0(CalleeIndex, CalleeArgs, CalleeArg),
+                HeadArg == CalleeArg,
+                format(atom(Line), '        state->A[~w] = result_args[~w];', [HeadIndex, CalleeIndex])
+            ),
+            Lines),
+    atomic_list_concat(Lines, '\n', Code).
 
 wam_c_symbol_for_key(Key, Symbol) :-
     atomic_list_concat([PredAtom, ArityAtom], '/', Key),

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -399,31 +399,39 @@ test_lowered_body_call_helper_generation :-
     Test = 'WAM-C: deterministic body-call predicates can lower to native helper',
     assertz(user:wam_c_body_fact(a, b)),
     assertz((user:wam_c_body_alias(X, Y) :- user:wam_c_body_fact(X, Y))),
+    assertz((user:wam_c_body_projected(X, Y) :- user:wam_c_body_fact(Y, X))),
     get_time(Now),
     Stamp is round(Now * 1000000),
     wam_c_temp_path('unifyweaver_wam_c_lowered_body_project', Stamp, ProjectDir),
     directory_file_path(ProjectDir, 'lib.c', LibPath),
     (   plan_wam_c_lowered_helpers([user:wam_c_body_fact/2,
-                                     user:wam_c_body_alias/2],
+                                     user:wam_c_body_alias/2,
+                                     user:wam_c_body_projected/2],
                                     [lowered_helpers(true)],
                                     [],
                                     Plans),
         member(wam_c_lowered_helper_plan('wam_c_body_fact/2', _, lowered, fact_only([[a,b]])), Plans),
         member(wam_c_lowered_helper_plan('wam_c_body_alias/2', _, lowered, body_call('wam_c_body_fact/2', 2)), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_body_projected/2', _, lowered, body_call_projected('wam_c_body_fact/2', 2, _)), Plans),
         write_wam_c_project([user:wam_c_body_fact/2,
-                             user:wam_c_body_alias/2],
+                             user:wam_c_body_alias/2,
+                             user:wam_c_body_projected/2],
                             [lowered_helpers(true)],
                             ProjectDir),
         read_file_to_string(LibPath, LibS, []),
         sub_string(LibS, _, _, _, '// - lowered wam_c_body_alias/2: body_call'),
+        sub_string(LibS, _, _, _, '// - lowered wam_c_body_projected/2: body_call_projected'),
         sub_string(LibS, _, _, _, 'static bool wam_c_lowered_wam_c_body_alias_2'),
+        sub_string(LibS, _, _, _, 'static bool wam_c_lowered_wam_c_body_projected_2'),
         sub_string(LibS, _, _, _, 'return wam_c_lowered_wam_c_body_fact_2(state, "wam_c_body_fact/2", 2);'),
+        sub_string(LibS, _, _, _, 'wam_c_lowered_wam_c_body_fact_2(state, "wam_c_body_fact/2", 2);'),
         sub_string(LibS, _, _, _, '.pred = "wam_c_body_alias/2"')
     ->  pass(Test)
     ;   fail_test(Test, 'lowered body-call helper was not emitted')
     ),
     retractall(user:wam_c_body_fact(_, _)),
-    retractall(user:wam_c_body_alias(_, _)).
+    retractall(user:wam_c_body_alias(_, _)),
+    retractall(user:wam_c_body_projected(_, _)).
 
 test_lowered_body_call_rejection_metadata :-
     Test = 'WAM-C: lowered helper planner explains unsupported body-call shapes',
@@ -1349,6 +1357,7 @@ run_lowered_body_call_helper_executable_smoke :-
     assertz(user:wam_c_body_fact(a, b)),
     assertz(user:wam_c_body_fact(a, c)),
     assertz((user:wam_c_body_alias(X, Y) :- user:wam_c_body_fact(X, Y))),
+    assertz((user:wam_c_body_projected(X, Y) :- user:wam_c_body_fact(Y, X))),
     get_time(Now),
     Stamp is round(Now * 1000000),
     wam_c_temp_path('unifyweaver_wam_c_lowered_body_smoke', Stamp, ProjectDir),
@@ -1357,7 +1366,8 @@ run_lowered_body_call_helper_executable_smoke :-
     directory_file_path(ProjectDir, 'main.c', MainPath),
     directory_file_path(ProjectDir, 'wam_c_lowered_body_smoke', ExePath),
     (   write_wam_c_project([user:wam_c_body_fact/2,
-                             user:wam_c_body_alias/2],
+                             user:wam_c_body_alias/2,
+                             user:wam_c_body_projected/2],
                             [lowered_helpers(true)],
                             ProjectDir),
         wam_c_lowered_body_smoke_main(MainCode),
@@ -1365,9 +1375,11 @@ run_lowered_body_call_helper_executable_smoke :-
         compile_c_smoke_plain(RuntimePath, LibPath, MainPath, ExePath),
         run_c_smoke_plain(ExePath)
     ->  retractall(user:wam_c_body_fact(_, _)),
-        retractall(user:wam_c_body_alias(_, _))
+        retractall(user:wam_c_body_alias(_, _)),
+        retractall(user:wam_c_body_projected(_, _))
     ;   retractall(user:wam_c_body_fact(_, _)),
         retractall(user:wam_c_body_alias(_, _)),
+        retractall(user:wam_c_body_projected(_, _)),
         fail
     ).
 
@@ -1562,15 +1574,26 @@ cleanup_wam_c_detector_category_ancestor :-
 
 run_c_smoke(ExePath) :-
     format(atom(LogPath), '~w.asan.log', [ExePath]),
-    format(atom(Cmd),
-           'ASAN_OPTIONS=detect_leaks=0:abort_on_error=1 timeout 10 ~w > /dev/null 2> ~w',
-           [ExePath, LogPath]),
-    shell(Cmd, Status),
+    run_c_smoke_once(ExePath, LogPath, Status),
     (   Status =:= 0
     ->  true
+    ;   Status =:= 124
+    ->  format(atom(RetryLogPath), '~w.asan.retry.log', [ExePath]),
+        run_c_smoke_once(ExePath, RetryLogPath, RetryStatus),
+        (   RetryStatus =:= 0
+        ->  true
+        ;   format(user_error, 'generated executable failed with status ~w (log: ~w)~n', [RetryStatus, RetryLogPath]),
+            fail
+        )
     ;   format(user_error, 'generated executable failed with status ~w (log: ~w)~n', [Status, LogPath]),
         fail
     ).
+
+run_c_smoke_once(ExePath, LogPath, Status) :-
+    format(atom(Cmd),
+           'ASAN_OPTIONS=detect_leaks=0:abort_on_error=1 timeout 10 ~w > /dev/null 2> ~w',
+           [ExePath, LogPath]),
+    shell(Cmd, Status).
 
 run_c_smoke_plain(ExePath) :-
     format(atom(Cmd), 'timeout 10 ~w', [ExePath]),
@@ -2217,15 +2240,15 @@ wam_c_lowered_body_smoke_main(
 
 void setup_wam_c_body_fact_2(WamState* state);
 void setup_wam_c_body_alias_2(WamState* state);
+void setup_wam_c_body_projected_2(WamState* state);
 void setup_lowered_wam_c_helpers(WamState* state);
 
 int main(void) {
     WamState state;
     wam_state_init(&state);
-    setup_wam_c_body_fact_2(&state);
-    setup_wam_c_body_alias_2(&state);
     setup_lowered_wam_c_helpers(&state);
 
+    setup_wam_c_body_alias_2(&state);
     WamValue ok_args[2] = { val_atom("a"), val_unbound("Out") };
     int ok_rc = wam_run_predicate(&state, "wam_c_body_alias/2", ok_args, 2);
     if (ok_rc != 0 || state.P != WAM_HALT ||
@@ -2246,6 +2269,29 @@ int main(void) {
     if (fail_rc != WAM_HALT) {
         wam_free_state(&state);
         return 30;
+    }
+
+    setup_wam_c_body_projected_2(&state);
+    WamValue projected_args[2] = { val_atom("b"), val_unbound("Projected") };
+    int projected_rc = wam_run_predicate(&state, "wam_c_body_projected/2", projected_args, 2);
+    if (projected_rc != 0 || state.P != WAM_HALT ||
+        state.A[1].tag != VAL_ATOM || strcmp(state.A[1].data.atom, "a") != 0) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    WamValue projected_ground_args[2] = { val_atom("b"), val_atom("a") };
+    int projected_ground_rc = wam_run_predicate(&state, "wam_c_body_projected/2", projected_ground_args, 2);
+    if (projected_ground_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 50;
+    }
+
+    WamValue projected_fail_args[2] = { val_atom("b"), val_atom("c") };
+    int projected_fail_rc = wam_run_predicate(&state, "wam_c_body_projected/2", projected_fail_args, 2);
+    if (projected_fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 60;
     }
 
     wam_free_state(&state);


### PR DESCRIPTION
## Summary

- add `body_call_projected` lowered-helper planning for variable-only reordered body-call projections
- generate native wrapper helpers that map caller arguments into the callee helper and project successful callee results back to the caller
- keep constant filters on the existing `filtered_fact` path and preserve existing rejection metadata
- add planner, generated-comment, and executable smoke coverage for projected body-call helpers
- retry transient ASAN smoke timeout status `124` once before failing the WAM-C target suite
- refresh the WAM-C roadmap with the active projected body-call branch and the generated multi-predicate setup follow-up

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --check`

## Notes

- Supported shape is intentionally narrow: variable-only reordered projections where every head variable appears exactly once in the callee call.
- Constant guards continue to use the materialized `filtered_fact` helper path.
- The branch is committed as `73095214 feat(wam-c): lower projected body-call helpers`.