### PR TITLE
feat(wam-cpp): maplist/2 + maplist/3 + PutStructure aliasing fix

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -928,7 +928,64 @@ helper_predicate_items(Items) :-
         put_value("Y3", "A2"),
         put_value("Y4", "A3"),
         deallocate,
-        execute("between/3")
+        execute("between/3"),
+        % --- maplist/2 ---------------------------------------------------
+        % maplist(_, []).
+        % maplist(P, [X|Xs]) :- call(P, X), maplist(P, Xs).
+        % Higher-order: dispatches user predicate P over each list
+        % element via call/2 (added in PR #2094). Verifies the
+        % helper-injection mechanism scales to higher-order use.
+        label("maplist/2"),
+        try_me_else("L_cpp_maplist_2_2"),
+        get_variable("X1", "A1"),
+        get_constant("[]", "A2"),
+        proceed,
+        label("L_cpp_maplist_2_2"),
+        trust_me,
+        allocate,
+        get_variable("Y1", "A1"),
+        get_list("A2"),
+        unify_variable("X3"),
+        unify_variable("Y2"),
+        put_value("Y1", "A1"),
+        put_value("X3", "A2"),
+        call("call/2", "2"),
+        put_value("Y1", "A1"),
+        put_value("Y2", "A2"),
+        deallocate,
+        execute("maplist/2"),
+        % --- maplist/3 ---------------------------------------------------
+        % maplist(_, [], []).
+        % maplist(P, [X|Xs], [Y|Ys]) :- call(P, X, Y), maplist(P, Xs, Ys).
+        % Paired list mapping — the canonical "transform each X to Y
+        % via P" pattern. With both lists ground, succeeds iff P
+        % holds for every paired (X, Y); with the second list
+        % unbound, builds Ys by calling P(X, Y) per element.
+        label("maplist/3"),
+        try_me_else("L_cpp_maplist_3_2"),
+        get_variable("X1", "A1"),
+        get_constant("[]", "A2"),
+        get_constant("[]", "A3"),
+        proceed,
+        label("L_cpp_maplist_3_2"),
+        trust_me,
+        allocate,
+        get_variable("Y1", "A1"),
+        get_list("A2"),
+        unify_variable("X4"),
+        unify_variable("Y2"),
+        get_list("A3"),
+        unify_variable("X5"),
+        unify_variable("Y3"),
+        put_value("Y1", "A1"),
+        put_value("X4", "A2"),
+        put_value("X5", "A3"),
+        call("call/3", "3"),
+        put_value("Y1", "A1"),
+        put_value("Y2", "A2"),
+        put_value("Y3", "A3"),
+        deallocate,
+        execute("maplist/3")
     ].
 
 flatten_blocks([], []).
@@ -2731,17 +2788,50 @@ bool WamState::step(const Instruction& instr) {
             pc += 1; return true;
         }
         case Instruction::Op::PutStructure: {
+            // X-regs and Y-regs are local — when set_variable
+            // attached the cell to a parent structure''s args slot,
+            // the cell is shared between the X/Y reg AND the parent.
+            // Subsequent put_structure on that reg MUST bind in place
+            // so the parent''s args slot sees the new structure too.
+            //
+            // A-regs are different — they''re argument-passing slots
+            // that may be aliased with OTHER A-regs via PutValue
+            // (e.g. the maplist/3 + call/3 case where the callee''s
+            // A1 and A2 ended up sharing the same caller''s var).
+            // Always allocate fresh for A-regs so we don''t corrupt
+            // the aliased value.
             const std::string& functor = instr.a;
             std::size_t arity = 0;
             auto p = functor.find_last_of(\'/\');
             if (p != std::string::npos) arity = std::stoull(functor.substr(p + 1));
+            CellPtr existing = get_cell(instr.b);
+            bool is_a_reg = !instr.b.empty() && instr.b[0] == \'A\';
             CellPtr target;
-            begin_write(*this, instr.b, functor, arity, target);
+            if (existing->is_unbound() && !is_a_reg) {
+                bind_cell(existing, Value::Compound(functor, {}));
+                target = existing;
+            } else {
+                target = std::make_shared<Cell>(
+                    Value::Compound(functor, {}));
+                set_cell(instr.b, target);
+            }
+            push_write_mode(mode_stack, target, arity);
             pc += 1; return true;
         }
         case Instruction::Op::PutList: {
+            // See PutStructure — same A-reg-vs-X/Y-reg rule.
+            CellPtr existing = get_cell(instr.a);
+            bool is_a_reg = !instr.a.empty() && instr.a[0] == \'A\';
             CellPtr target;
-            begin_write(*this, instr.a, "[|]/2", 2, target);
+            if (existing->is_unbound() && !is_a_reg) {
+                bind_cell(existing, Value::Compound("[|]/2", {}));
+                target = existing;
+            } else {
+                target = std::make_shared<Cell>(
+                    Value::Compound("[|]/2", {}));
+                set_cell(instr.a, target);
+            }
+            push_write_mode(mode_stack, target, 2);
             pc += 1; return true;
         }
 

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -318,6 +318,39 @@ user:wam_cpp_test_call_compound_already :-
 user:wam_cpp_test_call_user_pred :-
     call(wam_cpp_call_helper, hello).
 
+% maplist/2 + maplist/3 (helper-injected, built on call/N):
+:- dynamic user:wam_cpp_double/2.
+:- dynamic user:wam_cpp_positive/1.
+:- dynamic user:wam_cpp_test_maplist2_all/0.
+:- dynamic user:wam_cpp_test_maplist2_empty/0.
+:- dynamic user:wam_cpp_test_maplist3_double/0.
+:- dynamic user:wam_cpp_test_maplist3_check/0.
+:- dynamic user:wam_cpp_test_findall_call/0.
+
+user:wam_cpp_double(X, Y) :- Y is X * 2.
+user:wam_cpp_positive(X) :- X > 0.
+
+% Every element satisfies positive/1.
+user:wam_cpp_test_maplist2_all :- maplist(wam_cpp_positive, [1, 2, 3]).
+% Empty-list base case.
+user:wam_cpp_test_maplist2_empty :- maplist(wam_cpp_positive, []).
+% Higher-order list transformation: build the doubles list from
+% [1,2,3]. Verifies maplist/3 + call/3 + user predicate compose.
+user:wam_cpp_test_maplist3_double :-
+    maplist(wam_cpp_double, [1, 2, 3], L),
+    L = [2, 4, 6].
+% Both lists ground — verifies P holds for each paired (X, Y).
+user:wam_cpp_test_maplist3_check :-
+    maplist(wam_cpp_double, [1, 2], [2, 4]).
+% findall composes with call/N: collect the double of 1 into a
+% single-element list. (Note: findall + member + call/N in
+% conjunction has a separate latent bug unrelated to this PR — it
+% hangs because of how findall''s aggregate frame interacts with
+% member''s choice points; the simpler form here works.)
+user:wam_cpp_test_findall_call :-
+    findall(Y, call(wam_cpp_double, 1, Y), L),
+    L = [2].
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -1698,6 +1731,101 @@ test(cpp_e2e_call_user_pred, [condition(cpp_compiler_available)]) :-
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath,
                     'wam_cpp_test_call_user_pred/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% maplist/2 + maplist/3 — higher-order list mapping. Helper-injected
+% (per WAM_ITEMS_API §6) on top of call/N. maplist/2 is "predicate
+% holds for every element"; maplist/3 is "P transforms each X to Y".
+% The maplist/3 + call/3 + user-predicate composition is the key
+% demonstration that higher-order programming works end-to-end on
+% the C++ target.
+%
+% Also tests `findall + call/N` composition — a common idiom for
+% "collect transformed values."
+% ------------------------------------------------------------------
+
+test(cpp_e2e_maplist2_all, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_ml2_all', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_maplist2_all/0,
+                               user:wam_cpp_positive/1],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_maplist2_all/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_maplist2_empty, [condition(cpp_compiler_available)]) :-
+    % maplist/2 base case — empty list succeeds trivially.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_ml2_empty', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_maplist2_empty/0,
+                               user:wam_cpp_positive/1],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_maplist2_empty/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_maplist3_double, [condition(cpp_compiler_available)]) :-
+    % The key test: maplist/3 + call/3 + a USER predicate.
+    % maplist(double, [1,2,3], L) walks the input list, calling
+    % double/2 via call/3 on each element. The bug that broke
+    % this before the PutStructure-fresh-cell fix: when
+    % invoke_goal_as_call set A1 from the goal''s args and the
+    % goal body did PutStructure into A2 (e.g. */2 for Y is X*2),
+    % the existing-cell-bind optimisation in begin_write wrote
+    % into a cell still aliased with A1. Fix: PutStructure and
+    % PutList now always allocate fresh.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_ml3_double', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_maplist3_double/0,
+                               user:wam_cpp_double/2],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_maplist3_double/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_maplist3_check, [condition(cpp_compiler_available)]) :-
+    % Both lists ground — maplist/3 in checking mode: verifies
+    % double(X, Y) holds for each paired (X, Y).
+    unique_cpp_tmp_dir('tmp_cpp_e2e_ml3_check', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_maplist3_check/0,
+                               user:wam_cpp_double/2],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_maplist3_check/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_findall_call_compose,
+     [condition(cpp_compiler_available)]) :-
+    % findall with call/N inside its goal. Verifies the aggregate
+    % frame + meta-call composition. (The richer
+    % "findall + member + call/N" form has a separate latent bug
+    % involving aggregate-frame + choice-point interaction with
+    % conjunctions — not addressed in this PR.)
+    unique_cpp_tmp_dir('tmp_cpp_e2e_findall_call', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_findall_call/0,
+                               user:wam_cpp_double/2],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_findall_call/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Ships higher-order list mapping (`maplist/2`, `maplist/3`) via helper-injection on top of `call/N` (PR #2094). **Also fixes a latent `put_structure` aliasing bug** that surfaced when `maplist/3 + call/3 + a user predicate` composed end-to-end.

## Latent bug — PutStructure/PutList aliasing through A-registers

The original `begin_write` helper had a "bind existing cell in place if unbound" optimisation shared between Get-form (head matching) and Put-form (body building).

For **X/Y regs** this is correct and load-bearing: `set_variable Xn` attaches `Xn` to a parent structure's args slot, and the subsequent `put_structure F, Xn` MUST bind that shared cell in place so the parent sees the new structure too. That's how lists thread compound nodes through var-cells.

But for **A-regs** the same optimisation is incorrect. A-regs can end up aliased with OTHER A-regs via `PutValue` — e.g. `maplist/3`'s clause body does:

```
put_value Y1, A1      # A1 = (caller-side var-cell aliased through Y1)
put_value X5, A3
call call/3, 3        # dispatches user double/2 via call/N
```

Then `double/2` (the user predicate) runs:

```
get_variable Xa, A1   # Xa = same caller-side var-cell as A1
put_value Xa, A1      # A1 now aliases A2's var-cell too
put_structure */2, A2 # ←— BUG: bind-in-place wrote */2 into the
                      #     shared var cell, so A1 also sees */2.
```

Result: `maplist(double, [1, 2, 3], L)` returned false even though `L = [2, 4, 6]` is what it should produce.

**Fix:** `PutStructure` / `PutList` check whether the target register is an A-reg (first char `A`); if so, always allocate a fresh cell. For X/Y regs keep the bind-in-place behaviour since list-construction relies on it.

The distinguishing rule is precise enough — A-regs are explicitly argument-passing slots that participate in caller/callee aliasing, while X/Y regs are local to the clause body and only share with parent structure args via `set_variable`.

## maplist additions

- **`maplist/2`** and **`maplist/3`** added to `helper_predicate_items`. Bodies use `call/2` (for maplist/2) and `call/3` (for maplist/3) to dispatch the user-supplied predicate per element. Same auto-injection mechanism as `member/2`, `length/2`, etc.

## Tests — 5 new e2e tests

| Test | Coverage |
|---|---|
| `cpp_e2e_maplist2_all` | Every element satisfies P (calls `positive/1` via `call/2`) |
| `cpp_e2e_maplist2_empty` | Empty-list base case |
| `cpp_e2e_maplist3_double` | **The key test**: `maplist(double, [1,2,3], L) → L = [2,4,6]`. Tests the full maplist/3 + call/3 + user-predicate-via-arithmetic path. **Regression guard for the PutStructure aliasing bug** |
| `cpp_e2e_maplist3_check` | Both lists ground — checking mode rather than building |
| `cpp_e2e_findall_call_compose` | `findall` composes with `call/N` for goal dispatch |

**Total: 99/99 passing** (was 94; +5 new).

## Verification

```
$ swipl -g "[tests/test_wam_cpp_generator], run_tests(wam_cpp_generator)" -t halt
% All 99 tests passed
```

The PutStructure fix has **zero behaviour change for the 94 prior tests** — the A-reg rule only allocates fresh in the path that was already broken (and silently corrupting state). Verified by full suite + the maplist/3 reproduction.

## Known limitation (deferred)

`findall + member + call/N` in a conjunction (e.g. `findall(Y, (member(X, [1,2,3]), call(double, X, Y)), L)`) **hangs**. Separate latent bug involving aggregate-frame + choice-point interaction with `,/2` — not addressed in this PR. The simpler `findall(Y, call(double, 1, Y), L)` form works fine and is covered by `cpp_e2e_findall_call_compose`.

## Test plan

- [x] All 94 prior tests still pass (no regression — the PutStructure A-reg rule only kicks in where state was already being corrupted)
- [x] 5 new e2e tests pass covering maplist/2, maplist/3, and findall + call/N composition
- [x] `g++ -std=c++17` clean compile
- [x] Smoke-tested maplist/3 with arithmetic (the original failure pattern) — now works
- [ ] Follow-up: investigate the `findall + member + ,/2 + call/N` hang
- [ ] Follow-up: `maplist/4` and `maplist/5` (trivial extensions following the same pattern)

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_