### PR TITLE
feat(wam-cpp): bagof/3 + setof/3 (meta-call + ^/2 + recursive term ordering)

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -1724,6 +1724,12 @@ struct WamState {
     // (collect template, force backtrack); goal-exhaustion triggers
     // backtrack()''s aggregate-finalise (build list, bind to result).
     bool    dispatch_findall_call(std::size_t after_pc);
+    // bagof/setof meta-call. Same shape as dispatch_findall_call
+    // but the AggregateFrame''s kind is "bagof" or "setof", so
+    // finalize_aggregate fails on empty acc (bagof) or
+    // sorts + dedup''s + fails on empty (setof).
+    bool    dispatch_aggregate_call(const std::string& kind,
+                                    std::size_t after_pc);
     bool    execute_catch();
     bool    execute_throw();
 
@@ -2983,12 +2989,19 @@ bool WamState::step(const Instruction& instr) {
         case Instruction::Op::Call: {
             if (instr.a == "catch/3") { cp = pc + 1; return execute_catch(); }
             if (instr.a == "throw/1") { cp = pc + 1; return execute_throw(); }
-            // findall/3 meta-call — handles the non-inlined case
-            // (nested findalls, where only the OUTER findall gets
-            // BeginAggregate-inlined; the inner is emitted as a
-            // plain Call to findall/3 which we dispatch here).
-            if (instr.a == "findall/3") {
-                return dispatch_findall_call(pc + 1);
+            // findall/3, bagof/3, setof/3 meta-call — handles the
+            // non-inlined cases (nested aggregates, where only the
+            // OUTER one gets BeginAggregate-inlined; the inner is
+            // emitted as a plain Call to findall/bagof/setof which
+            // we dispatch here).
+            if (instr.a == "findall/3") return dispatch_findall_call(pc + 1);
+            if (instr.a == "bagof/3")   return dispatch_aggregate_call("bagof", pc + 1);
+            if (instr.a == "setof/3")   return dispatch_aggregate_call("setof", pc + 1);
+            // ^/2 — existential quantification. Transparent for our
+            // find-style aggregation: invoke A2 (the goal) with the
+            // standard non-tail after-pc.
+            if (instr.a == "^/2") {
+                return invoke_goal_as_call(get_cell("A2"), pc + 1);
             }
             // call/N meta — needs its own arm so the after_pc is
             // correctly pc + 1 (non-tail) rather than going through
@@ -3011,9 +3024,16 @@ bool WamState::step(const Instruction& instr) {
         case Instruction::Op::Execute: {
             if (instr.a == "catch/3") return execute_catch();
             if (instr.a == "throw/1") return execute_throw();
-            if (instr.a == "findall/3") {
+            if (instr.a == "findall/3" || instr.a == "bagof/3"
+                || instr.a == "setof/3") {
                 std::size_t tail_after = cp;
-                return dispatch_findall_call(tail_after);
+                std::string kind =
+                    (instr.a == "findall/3") ? "collect" :
+                    (instr.a == "bagof/3")   ? "bagof"   : "setof";
+                return dispatch_aggregate_call(kind, tail_after);
+            }
+            if (instr.a == "^/2") {
+                return invoke_goal_as_call(get_cell("A2"), cp);
             }
             // call/N meta in tail position — after_pc is the
             // caller''s saved cp (or halt if cp == 0).
@@ -3279,6 +3299,39 @@ bool WamState::step(const Instruction& instr) {
 
 // Build the finalisation result for an aggregate based on its kind.
 // Falls back to the raw list when the kind isn''t recognised.
+// Standard-order-of-terms comparison for setof''s sort + dedup.
+// Sorts: Var < Number < Atom < Compound, with compounds compared by
+// (functor-string, arity, args lexicographically). The functor
+// string already encodes "Name/Arity" so comparing it covers both
+// name and arity at once when they differ. Args are deref''d so
+// indirect bindings come through correctly.
+static bool term_less(const Value& a, const Value& b) {
+    if (a.tag != b.tag)
+        return static_cast<int>(a.tag) < static_cast<int>(b.tag);
+    switch (a.tag) {
+        case Value::Tag::Atom:
+        case Value::Tag::Unbound:
+            return a.s < b.s;
+        case Value::Tag::Integer:
+            return a.i < b.i;
+        case Value::Tag::Float:
+            return a.f < b.f;
+        case Value::Tag::Compound: {
+            if (a.s != b.s) return a.s < b.s;
+            // Same functor/arity — compare args lexicographically.
+            for (std::size_t i = 0;
+                 i < a.args.size() && i < b.args.size(); ++i) {
+                if (!a.args[i] || !b.args[i]) continue;
+                if (term_less(*a.args[i], *b.args[i])) return true;
+                if (term_less(*b.args[i], *a.args[i])) return false;
+            }
+            return a.args.size() < b.args.size();
+        }
+        default:
+            return false;
+    }
+}
+
 static Value finalize_aggregate(const std::string& kind, const std::vector<Value>& acc) {
     auto as_d = [](const Value& v) { return v.tag == Value::Tag::Float ? v.f : (double)v.i; };
     auto is_num = [](const Value& v) {
@@ -3325,21 +3378,7 @@ static Value finalize_aggregate(const std::string& kind, const std::vector<Value
             if (!dup) uniq.push_back(v);
         }
         items = std::move(uniq);
-        std::sort(items.begin(), items.end(), [](const Value& a, const Value& b) {
-            if (a.tag != b.tag) return static_cast<int>(a.tag) < static_cast<int>(b.tag);
-            switch (a.tag) {
-                case Value::Tag::Atom:
-                case Value::Tag::Unbound:
-                case Value::Tag::Compound:
-                    return a.s < b.s;
-                case Value::Tag::Integer:
-                    return a.i < b.i;
-                case Value::Tag::Float:
-                    return a.f < b.f;
-                default:
-                    return false;
-            }
-        });
+        std::sort(items.begin(), items.end(), term_less);
     }
     Value tail = Value::Atom("[]");
     for (auto it = items.rbegin(); it != items.rend(); ++it) {
@@ -3452,9 +3491,20 @@ bool WamState::invoke_goal_as_call(CellPtr goal_cell, std::size_t after_pc) {
         }
         // Meta-builtins handled directly by step() arms — go through
         // the same code path so nested catch / re-throw works.
-        if (key == "throw/1")  { cp = after_pc; return execute_throw(); }
-        if (key == "catch/3")  { cp = after_pc; return execute_catch(); }
+        if (key == "throw/1")   { cp = after_pc; return execute_throw(); }
+        if (key == "catch/3")   { cp = after_pc; return execute_catch(); }
         if (key == "findall/3") { cp = after_pc; return dispatch_findall_call(after_pc); }
+        if (key == "bagof/3")   { cp = after_pc; return dispatch_aggregate_call("bagof", after_pc); }
+        if (key == "setof/3")   { cp = after_pc; return dispatch_aggregate_call("setof", after_pc); }
+        // ^/2 — existential quantification. For find-style
+        // aggregation (which is all this runtime currently
+        // supports for bagof/setof) ^/2 is transparent: invoke A2
+        // and ignore the binder. (Full bagof/setof grouping
+        // semantics would treat ^/2 specially during the bagof
+        // body; here we just dispatch the goal.)
+        if (key == "^/2") {
+            return invoke_goal_as_call(g.args[1], after_pc);
+        }
         // User predicate path.
         auto it = labels.find(key);
         if (it != labels.end()) {
@@ -3533,12 +3583,20 @@ bool WamState::dispatch_call_meta(const std::string& op,
 }
 
 bool WamState::dispatch_findall_call(std::size_t after_pc) {
-    // findall(Template, Goal, List). We arrive here via the
-    // Call/Execute special-case for non-inlined findall/3 (the
-    // inner findall in a nested call is NOT inlined by the WAM
-    // compiler — only the outermost findall/bagof/setof gets the
-    // BeginAggregate/EndAggregate inline expansion. Without this
-    // path, nested findalls silently produce empty results.)
+    return dispatch_aggregate_call("collect", after_pc);
+}
+
+bool WamState::dispatch_aggregate_call(const std::string& kind,
+                                       std::size_t after_pc) {
+    // findall/bagof/setof(Template, Goal, List). Reached via the
+    // Call/Execute special-case for non-inlined occurrences (the
+    // WAM compiler only inlines BeginAggregate/EndAggregate for the
+    // OUTERMOST findall/bagof/setof in a body; nested ones are
+    // emitted as plain calls). kind selects finalize_aggregate''s
+    // behaviour:
+    //   "collect" — findall semantics (list, empty on no solutions).
+    //   "bagof"   — list, FAILS on no solutions.
+    //   "setof"   — sorted + dedup''d list, FAILS on no solutions.
     //
     // Snapshot Template''s cell as value_cell and List''s cell as
     // result_cell — A1/A3 will get clobbered when we dispatch the
@@ -3546,7 +3604,7 @@ bool WamState::dispatch_findall_call(std::size_t after_pc) {
     // from the goal''s args). The synthetic FindallCollect op
     // reads the value through these stored CellPtrs.
     AggregateFrame frame;
-    frame.agg_kind          = "collect";
+    frame.agg_kind          = kind;
     frame.value_cell        = get_cell("A1");
     frame.result_cell       = get_cell("A3");
     frame.begin_pc          = pc;
@@ -3560,8 +3618,6 @@ bool WamState::dispatch_findall_call(std::size_t after_pc) {
     frame.saved_mode_stack  = mode_stack;
     frame.saved_env_stack   = env_stack;
     aggregate_frames.push_back(std::move(frame));
-    // Dispatch the goal. cp = findall_collect_pc so goal-success
-    // lands at the FindallCollect synthetic op.
     CellPtr goal = get_cell("A2");
     return invoke_goal_as_call(goal, findall_collect_pc);
 }
@@ -3850,7 +3906,15 @@ bool WamState::backtrack() {
             // dispatch_findall_call); the inlined BeginAggregate
             // path uses the result_reg name.
             Value result = finalize_aggregate(f.agg_kind, f.acc);
-            if (result.tag == Value::Tag::Uninit) return false;
+            if (result.tag == Value::Tag::Uninit) {
+                // bagof/setof with empty acc → the aggregate
+                // FAILS (per ISO). Continue backtracking so any
+                // enclosing if-then-else / catch-frame / outer
+                // choice point gets to react. Returning false here
+                // would short-circuit the WAM''s normal failure
+                // propagation.
+                continue;
+            }
             CellPtr rcell = f.result_cell
                 ? f.result_cell
                 : get_cell(f.result_reg);

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -424,6 +424,56 @@ user:wam_cpp_test_findall_meta_no_conjunction :-
     findall(X, member(X, [a, b, c]), L),
     L = [a, b, c].
 
+% bagof/3 + setof/3 — share dispatch_aggregate_call with findall.
+% bagof FAILS on empty acc; setof sorts + dedups via standard term
+% order. Nested forms use the meta-call path (same as nested findall
+% from PR #2099).
+:- dynamic user:wam_cpp_test_bagof_basic/0.
+:- dynamic user:wam_cpp_test_bagof_fails_empty/0.
+:- dynamic user:wam_cpp_test_setof_basic/0.
+:- dynamic user:wam_cpp_test_setof_dedups/0.
+:- dynamic user:wam_cpp_test_setof_sorts_ints/0.
+:- dynamic user:wam_cpp_test_bagof_nested/0.
+:- dynamic user:wam_cpp_test_setof_nested/0.
+
+user:wam_cpp_test_bagof_basic :-
+    bagof(X, member(X, [a, b, c]), L), L = [a, b, c].
+
+% bagof fails on empty acc (per ISO); the if-then-else wraps that
+% so the predicate succeeds via the else branch. Regression guard
+% for the backtrack-continue-on-Uninit fix in aggregate-finalise.
+user:wam_cpp_test_bagof_fails_empty :-
+    (bagof(_X, (member(_X, [a, b]), _X = z), _) -> true ; true).
+
+user:wam_cpp_test_setof_basic :-
+    setof(X, member(X, [c, a, b]), L), L = [a, b, c].
+
+user:wam_cpp_test_setof_dedups :-
+    setof(X, member(X, [c, a, b, a, c]), L), L = [a, b, c].
+
+user:wam_cpp_test_setof_sorts_ints :-
+    setof(X, member(X, [3, 1, 2, 1]), L), L = [1, 2, 3].
+
+% Nested bagof — inner is non-inlined. Existential quantifier
+% (N^Goal) exercises the ^/2 transparency path. Without the
+% ^/2 handler, the body would fall through to builtin() and fail.
+user:wam_cpp_test_bagof_nested :-
+    bagof(L,
+          N^(member(N, [2, 3]),
+             bagof(X, (member(X, [1, 2, 3, 4]), X =< N), L)),
+          Ls),
+    Ls = [[1, 2], [1, 2, 3]].
+
+% Nested setof — also exercises term_less recursion for the outer
+% sort. List terms with the same functor ([|]/2) require
+% args-level comparison to be ordered correctly.
+user:wam_cpp_test_setof_nested :-
+    setof(L,
+          N^(member(N, [3, 2]),
+             setof(X, (member(X, [3, 1, 2, 1]), X =< N), L)),
+          Ls),
+    Ls = [[1, 2], [1, 2, 3]].
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -2055,6 +2105,114 @@ test(cpp_e2e_findall_nested, [condition(cpp_compiler_available)]) :-
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath,
                     'wam_cpp_test_findall_nested/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% bagof/3 + setof/3 — share dispatch_aggregate_call with findall.
+% bagof fails on empty; setof sorts + dedups via standard term order
+% (term_less in finalize_aggregate, with recursive args comparison
+% so list compounds with the same functor get ordered correctly).
+% Nested forms exercise the meta-call path and the ^/2 transparency
+% handler.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_bagof_basic, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_bagof_basic', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_bagof_basic/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_bagof_basic/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_bagof_fails_empty,
+     [condition(cpp_compiler_available)]) :-
+    % bagof returns failure (per ISO) when the goal has no
+    % solutions. The if-then-else wraps that — predicate succeeds
+    % via the else branch. Regression guard for the
+    % backtrack-continue-on-Uninit fix.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_bagof_empty', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_bagof_fails_empty/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_bagof_fails_empty/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_setof_basic, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_setof_basic', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_setof_basic/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_setof_basic/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_setof_dedups, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_setof_dedups', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_setof_dedups/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_setof_dedups/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_setof_sorts_ints,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_setof_sorts', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_setof_sorts_ints/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_setof_sorts_ints/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_bagof_nested, [condition(cpp_compiler_available)]) :-
+    % Nested bagof with existential quantifier (N^Goal).
+    % Exercises:
+    %   - Outer inlined bagof.
+    %   - Inner non-inlined bagof via dispatch_aggregate_call("bagof").
+    %   - ^/2 transparency in both invoke_goal_as_call AND the
+    %     Call step arm (the WAM emits `call ^/2, 2` for the
+    %     existential quantifier).
+    %   - ConjFrame dispatch for the inner''s ,(member, X =< N) goal.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_bagof_nested', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_bagof_nested/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_bagof_nested/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_setof_nested, [condition(cpp_compiler_available)]) :-
+    % Nested setof. The outer setof''s sort sees list-shaped
+    % compounds [1,2] and [1,2,3] (both functor [|]/2/2). The
+    % term_less helper''s recursive args comparison is what makes
+    % the lexicographic ordering work: regression guard for the
+    % "compound sort by functor only" bug fixed in this PR.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_setof_nested', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_setof_nested/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_setof_nested/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Extends the meta-call aggregate dispatch from PR #2099 (nested findall) to **bagof/3 and setof/3**. Inner (non-inlined) `bagof`/`setof` calls now work, including the common `N^Goal` existential quantification pattern.

## Changes — five pieces

### 1. `dispatch_aggregate_call(kind, after_pc)` factored out
Same shape as `dispatch_findall_call` — push an `AggregateFrame` with `value_cell`/`result_cell`, dispatch A2 with `cp = findall_collect_pc`. The `kind` flows into the existing `finalize_aggregate` which already had per-kind semantics.

### 2. `bagof/3` and `setof/3` recognised as meta-builtins
Routed to `dispatch_aggregate_call("bagof", ...)` / `dispatch_aggregate_call("setof", ...)` from Call/Execute step arms AND `invoke_goal_as_call`.

### 3. `^/2` transparency
For find-style aggregation `^/2` is transparent — invoke A2 (the goal), ignore the binder. Both the Call/Execute special-case AND `invoke_goal_as_call` handle it. This was the missing piece for `N^Goal` patterns to compile and run; without it the body fell through to `builtin()` and silently failed.

### 4. Aggregate-finalise no longer short-circuits on empty bagof/setof
Previously, when `finalize_aggregate` returned `Uninit` (the "no solutions" signal for bagof/setof), `backtrack()` returned `false` immediately — which short-circuited the outer flow. Now it `continue`s the backtrack loop so any enclosing if-then-else / catch-frame / outer choice point gets to react.

### 5. Standard-order-of-terms comparator (`term_less`) for setof's sort
The previous comparator compared compound terms by functor string only — leaving lists with the same functor (`[|]/2`) in their accumulation order. Now does recursive args comparison so `[1,2]` correctly sorts before `[1,2,3]`. Surfaced by the nested-setof test.

## Tests — 7 new e2e tests

| Test | Coverage |
|---|---|
| `cpp_e2e_bagof_basic` | Outermost inlined bagof |
| `cpp_e2e_bagof_fails_empty` | bagof with no solutions fails; if-then-else takes else branch. **Regression guard for the backtrack-continue-on-Uninit fix** |
| `cpp_e2e_setof_basic` | Outermost inlined setof sorts atoms |
| `cpp_e2e_setof_dedups` | Duplicates removed |
| `cpp_e2e_setof_sorts_ints` | Integer sort |
| `cpp_e2e_bagof_nested` | **Full nested bagof reproduction with `^/2`**. Exercises meta-call path + `^/2` transparency + `ConjFrame` dispatch |
| `cpp_e2e_setof_nested` | **Nested setof**. Regression guard for `term_less` recursive args comparison |

**Total: 114/114 passing** (was 107; +7 new).

## Verification

```
$ swipl -g "[tests/test_wam_cpp_generator], run_tests(wam_cpp_generator)" -t halt
% All 114 tests passed
```

Sample runs:

```
$ ./cpp_t test_bagof_basic/0          → true   # bagof(X, member(X,[a,b,c]), L)
$ ./cpp_t test_bagof_fails_empty/0    → true   # bagof fails, else branch
$ ./cpp_t test_setof_dedups/0         → true   # [c,a,b,a,c] → [a,b,c]
$ ./cpp_t test_setof_nested/0         → true   # nested setof with list-sort
```

## Two latent bugs discovered

Both surfaced when the nested test first ran:

**a) bagof's failure-on-empty propagated incorrectly.** The aggregate-finalise path returned `false` straight up instead of continuing the backtrack loop, so an if-then-else wrapping the bagof couldn't take its else branch. Fixed.

**b) setof's sort didn't descend into compound args.** `std::sort` + a top-level-only comparator left list-shaped Values in accumulation order. Fixed by `term_less` (recursive standard-order-of-terms).

Both bugs are real regression risks — the new tests guard against them.

## Test plan

- [x] All 107 prior tests still pass (no regression)
- [x] 7 new e2e tests pass covering bagof, setof, nested forms, ^/2, and the two latent bugs above
- [x] `g++ -std=c++17` clean compile
- [ ] Follow-up: full bagof/setof grouping semantics (with `^/2` actually quantifying for grouping). Our current `^/2` is just transparent — sufficient for finding-style aggregation but not for the spec's grouping use case
- [ ] Follow-up: disjunction goal-terms `(G1 ; G2)` — same synthetic-frame pattern would work
- [ ] Follow-up: `aggregate_all/3` family if not already inlined

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_