### PR TITLE
Feat/wam go fact dispatch parity

### DIFF
--- a/PR_go_wam_indexed_fact_dispatch.md
+++ b/PR_go_wam_indexed_fact_dispatch.md
@@ -1,0 +1,21 @@
+# Add Go WAM indexed atom fact dispatch
+
+## Description
+
+Adds `call_indexed_atom_fact2` support to the Go WAM target. The Go instruction set now includes `CallIndexedAtomFact2`, the WAM text parser emits it, and the runtime executes indexed atom fact lookups with stream-style backtracking over multiple matches.
+
+This narrows the Go direct fact dispatch parity gap against the Rust/Haskell baseline by covering the inline indexed fact instruction path. External TSV/LMDB FactSource adapters remain a separate follow-up.
+
+The generated Go runtime now also writes a minimal `internAtom` helper even when a project has no compile-time atom literals, because fact dispatch and foreign graph helpers can construct atoms dynamically.
+
+## Tests
+
+```sh
+swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl
+swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
+swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"
+```

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -9,7 +9,7 @@ current cross-target builtin/runtime baseline.
 | Area | Go support | Rust/Haskell baseline | Status |
 | --- | --- | --- | --- |
 | Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries, `member/2` builtin retries | Choice point stack with normal, builtin, and fact-stream resume states | Partial |
-| Direct fact dispatch | Foreign/native kernel registration and indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Partial |
+| Direct fact dispatch | `call_indexed_atom_fact2`, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Partial: no external TSV/LMDB FactSource adaptor |
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
 | Structural builtins | `member/2`, `length/2`, `append/3` | `member/2`, `length/2`; Rust `append/3` is explicitly unimplemented | Present for current baseline structural checks |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
@@ -40,13 +40,15 @@ current cross-target builtin/runtime baseline.
   builtin E2E test.
 - `\+/1` over user predicates is now covered by the generated Go WAM builtin
   E2E test for both failing and succeeding inner goals.
+- `call_indexed_atom_fact2` is now parsed and executed by the Go WAM runtime,
+  including backtracking over multiple indexed atom facts.
 
 ## Recommended Follow-Up Order
 
-1. Continue broadening generated Go WAM E2E coverage for control and fact-source
-   behavior that remains marked partial.
-2. Compare Go direct fact dispatch against Rust/Haskell external fact stream
-   paths if Go should close the remaining direct-fact parity gap.
+1. Continue broadening generated Go WAM E2E coverage for control and external
+   fact-source behavior that remains marked partial.
+2. Compare Go external fact-source adapters against Rust/Haskell TSV/LMDB
+   FactSource paths if Go should close the remaining direct-fact parity gap.
 
 ## Verification Commands
 

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -116,10 +116,9 @@ write_wam_go_project(Predicates, Options, ProjectDir) :-
     compile_lowered_predicates(Predicates, Options, LoweredCode),
     emit_atom_table_go(AtomTableCode),
 
-    % Always write atoms.go when there are interned atoms, regardless of
-    % whether lowered.go gets generated. lib.go references these vars
-    % via the intern table, so the declarations have to exist as
-    % package-level vars even when there's no lowered code.
+    % Always write atoms.go. When there are interned atoms, lib.go references
+    % their package-level vars. When there are none, runtime helpers still need
+    % the internAtom function for dynamically sourced facts.
     (   AtomTableCode \== ""
     ->  format(atom(AtomsContent),
 'package ~w
@@ -134,7 +133,24 @@ write_wam_go_project(Predicates, Options, ProjectDir) :-
 ', [PackageName, AtomTableCode]),
         directory_file_path(ProjectDir, 'atoms.go', AtomsPath),
         write_file(AtomsPath, AtomsContent)
-    ;   true
+    ;   format(atom(AtomsContent),
+'package ~w
+
+// Runtime-only atom intern table. This project has no compile-time atom
+// literals, but fact-source helpers may still construct atoms dynamically.
+var atomInternMap = make(map[string]*Atom)
+
+func internAtom(name string) *Atom {
+    if a, ok := atomInternMap[name]; ok {
+        return a
+    }
+    a := &Atom{Name: name}
+    atomInternMap[name] = a
+    return a
+}
+', [PackageName]),
+        directory_file_path(ProjectDir, 'atoms.go', AtomsPath),
+        write_file(AtomsPath, AtomsContent)
     ),
 
     (   LoweredCode \== ""
@@ -456,6 +472,9 @@ wam_instruction_to_go_literal(allocate, '&Allocate{}').
 wam_instruction_to_go_literal(deallocate, '&Deallocate{}').
 wam_instruction_to_go_literal(call(P, N), GoLiteral) :-
     format(atom(GoLiteral), '&Call{Pred: "~w", Arity: ~w}', [P, N]).
+wam_instruction_to_go_literal(call_indexed_atom_fact2(Pred), GoLiteral) :-
+    escape_go_string(Pred, EscapedPred),
+    format(atom(GoLiteral), '&CallIndexedAtomFact2{Pred: "~w"}', [EscapedPred]).
 wam_instruction_to_go_literal(execute(P), GoLiteral) :-
     format(atom(GoLiteral), '&Execute{Pred: "~w"}', [P]).
 wam_instruction_to_go_literal(proceed, '&Proceed{}').
@@ -976,6 +995,9 @@ wam_line_to_go_literal(["call", P, N], PredIndicator, Options, GoLit) :-
     ->  format(atom(GoLit), '&CallForeign{Pred: "~w", Arity: ~w}', [ForeignPred, ForeignArity])
     ;   format(atom(GoLit), '&Call{Pred: "~w", Arity: ~w}', [CP, CN])
     ).
+wam_line_to_go_literal(["call_indexed_atom_fact2", Pred], _PredIndicator, _Options, GoLit) :-
+    clean_comma(Pred, CPred),
+    wam_instruction_to_go_literal(call_indexed_atom_fact2(CPred), GoLit).
 wam_line_to_go_literal(["execute", P], PredIndicator, Options, GoLit) :-
     clean_comma(P, CP),
     (   go_foreign_rewrite_execute(Options, PredIndicator, CP, ForeignPred, ForeignArity)
@@ -1608,6 +1630,8 @@ wam_go_case('Call', '        vm.CP = vm.PC + 1
         return false').
 
 wam_go_case('CallForeign', '        return vm.executeForeignPredicate(i.Pred, i.Arity)').
+
+wam_go_case('CallIndexedAtomFact2', '        return vm.executeIndexedAtomFact2(i.Pred)').
 
 wam_go_case('CallPc', '        vm.CP = vm.PC + 1
         vm.PC = i.TargetPC
@@ -2308,57 +2332,7 @@ func (vm *WamState) finishForeignResults(predKey string, resultRegs []int, resul
     mode := vm.foreignResultMode(predKey)
     switch mode {
     case "stream":
-        var baseRegs [320]Value
-        baseRegs = vm.Regs
-        // Capture stack length and the env-pointer instead of cloning
-        // the stack — backtrack truncates to baseStackLen and restores
-        // baseE the same way the regular CP path does.
-        baseStackLen := len(vm.Stack)
-        baseE := vm.E
-        trailMark := vm.TrailLen
-        heapTop := vm.HeapLen
-        for idx, result := range results {
-            vm.unwindTrailTo(trailMark)
-            vm.Regs = baseRegs
-            if baseStackLen <= len(vm.Stack) {
-                vm.Stack = vm.Stack[:baseStackLen]
-            }
-            vm.E = baseE
-            if heapTop >= 0 && heapTop <= vm.HeapLen {
-                vm.heapTrimTo(heapTop)
-            }
-            vm.Halted = false
-            vm.CurrentStruct = nil
-            vm.CurrentList = nil
-            if !vm.applyForeignResult(predKey, resultRegs, result) {
-                continue
-            }
-            if idx+1 < len(results) {
-                remaining := append([]Value(nil), results[idx+1:]...)
-                // Match the regular CP snapshot layout that
-                // restoreSavedRegs() expects: 8 A-regs + 100 Y-regs,
-                // skipping the clause-local X-reg range.
-                savedRegs := make([]Value, 108)
-                copy(savedRegs[:8], baseRegs[:8])
-                copy(savedRegs[8:], baseRegs[200:300])
-                vm.ChoicePoints = append(vm.ChoicePoints, ChoicePoint{
-                    NextPC: resumePC,
-                    ResumePC: resumePC,
-                    CP: vm.CP,
-                    E: baseE,
-                    StackLen: baseStackLen,
-                    SavedRegs: savedRegs,
-                    HeapTop: heapTop,
-                    TrailMark: trailMark,
-                    ForeignPredKey: predKey,
-                    ForeignResultRegs: append([]int(nil), resultRegs...),
-                    ForeignResults: remaining,
-                })
-            }
-            vm.PC = resumePC
-            return true
-        }
-        return false
+        return vm.finishStreamResults(predKey, resultRegs, results)
     default:
         if !vm.applyForeignResult(predKey, resultRegs, results[0]) {
             return false
@@ -2366,6 +2340,82 @@ func (vm *WamState) finishForeignResults(predKey string, resultRegs []int, resul
         vm.PC = resumePC
         return true
     }
+}
+
+func (vm *WamState) finishStreamResults(predKey string, resultRegs []int, results []Value) bool {
+    if len(results) == 0 {
+        return false
+    }
+    resumePC := vm.PC + 1
+    var baseRegs [320]Value
+    baseRegs = vm.Regs
+    // Capture stack length and the env-pointer instead of cloning
+    // the stack — backtrack truncates to baseStackLen and restores
+    // baseE the same way the regular CP path does.
+    baseStackLen := len(vm.Stack)
+    baseE := vm.E
+    trailMark := vm.TrailLen
+    heapTop := vm.HeapLen
+    for idx, result := range results {
+        vm.unwindTrailTo(trailMark)
+        vm.Regs = baseRegs
+        if baseStackLen <= len(vm.Stack) {
+            vm.Stack = vm.Stack[:baseStackLen]
+        }
+        vm.E = baseE
+        if heapTop >= 0 && heapTop <= vm.HeapLen {
+            vm.heapTrimTo(heapTop)
+        }
+        vm.Halted = false
+        vm.CurrentStruct = nil
+        vm.CurrentList = nil
+        if !vm.applyForeignResult(predKey, resultRegs, result) {
+            continue
+        }
+        if idx+1 < len(results) {
+            remaining := append([]Value(nil), results[idx+1:]...)
+            ycount := vm.MaxYReg - 200
+            if ycount < 0 {
+                ycount = 0
+            }
+            savedRegs := make([]Value, 8+ycount)
+            copy(savedRegs[:8], baseRegs[:8])
+            if ycount > 0 {
+                copy(savedRegs[8:], baseRegs[200:200+ycount])
+            }
+            vm.ChoicePoints = append(vm.ChoicePoints, ChoicePoint{
+                NextPC: resumePC,
+                ResumePC: resumePC,
+                CP: vm.CP,
+                E: baseE,
+                StackLen: baseStackLen,
+                SavedRegs: savedRegs,
+                HeapTop: heapTop,
+                TrailMark: trailMark,
+                ForeignPredKey: predKey,
+                ForeignResultRegs: append([]int(nil), resultRegs...),
+                ForeignResults: remaining,
+            })
+        }
+        vm.PC = resumePC
+        return true
+    }
+    return false
+}
+
+func (vm *WamState) executeIndexedAtomFact2(predKey string) bool {
+    key, ok := valueAsAtomString(vm, vm.getReg(0))
+    if !ok {
+        return false
+    }
+    pairs := vm.Ctx.IndexedAtomFactPairs[predKey]
+    results := make([]Value, 0)
+    for _, pair := range pairs {
+        if pair.Left == key {
+            results = append(results, internAtom(pair.Right))
+        }
+    }
+    return vm.finishStreamResults(predKey, []int{1}, results)
 }
 
 func valueAsAtomString(vm *WamState, v Value) (string, bool) {

--- a/templates/targets/go_wam/instructions.go.mustache
+++ b/templates/targets/go_wam/instructions.go.mustache
@@ -75,6 +75,9 @@ func (i *Call) instrTag() {}
 type CallForeign struct { Pred string; Arity int }
 func (i *CallForeign) instrTag() {}
 
+type CallIndexedAtomFact2 struct { Pred string }
+func (i *CallIndexedAtomFact2) instrTag() {}
+
 type CallPc struct { TargetPC int; Arity int }
 func (i *CallPc) instrTag() {}
 

--- a/tests/test_wam_go_foreign_lowering.pl
+++ b/tests/test_wam_go_foreign_lowering.pl
@@ -120,6 +120,11 @@ test(foreign_call_rewrite_generation) :-
         assertion(Lit2 == '&CallForeign{Pred: "test_tri_sum", Arity: 2}')
     )).
 
+test(call_indexed_atom_fact2_literal) :-
+    wam_go_target:wam_line_to_go_literal(["call_indexed_atom_fact2", "edge/2"], test_reaches/2,
+        [], Lit),
+    assertion(Lit == '&CallIndexedAtomFact2{Pred: "edge/2"}').
+
 test(foreign_auto_detect_generation) :-
     compile_wam_predicate_to_go(plunit_wam_go_foreign_lowering:test_reaches/2, "call test_reaches/2, 2",
         [foreign_lowering(true)], ClosureCode),
@@ -253,6 +258,50 @@ test(foreign_execution_graph_kernels) :-
 import "testing"
 
 func TestForeignGraphKernels(t *testing.T) {
+    factVM := NewWamState([]Instruction{&CallIndexedAtomFact2{Pred: "edge/2"}, &Proceed{}}, map[string]int{})
+    factVM.registerIndexedAtomFact2Pairs("edge/2", []AtomPair{
+        {Left: "a", Right: "b"},
+        {Left: "a", Right: "c"},
+        {Left: "b", Right: "d"},
+    })
+    factTarget := &Unbound{Name: "FACT_TARGET", Idx: 1}
+    factVM.Regs[0] = internAtom("a")
+    factVM.Regs[1] = factTarget
+    if !factVM.Run() {
+        t.Fatalf("call_indexed_atom_fact2 failed")
+    }
+    if got, ok := factVM.deref(factTarget).(*Atom); !ok || got.Name != "b" {
+        t.Fatalf("expected first indexed fact target b, got %#v", factVM.deref(factTarget))
+    }
+    if !factVM.backtrack() {
+        t.Fatalf("expected second indexed fact result")
+    }
+    if got, ok := factVM.deref(factTarget).(*Atom); !ok || got.Name != "c" {
+        t.Fatalf("expected second indexed fact target c, got %#v", factVM.deref(factTarget))
+    }
+    if factVM.backtrack() {
+        t.Fatalf("expected indexed fact stream to be exhausted")
+    }
+
+    factExact := NewWamState([]Instruction{&CallIndexedAtomFact2{Pred: "edge/2"}, &Proceed{}}, map[string]int{})
+    factExact.registerIndexedAtomFact2Pairs("edge/2", []AtomPair{
+        {Left: "a", Right: "b"},
+        {Left: "a", Right: "c"},
+    })
+    factExact.Regs[0] = internAtom("a")
+    factExact.Regs[1] = internAtom("c")
+    if !factExact.Run() {
+        t.Fatalf("expected exact indexed fact match a-c")
+    }
+
+    factFail := NewWamState([]Instruction{&CallIndexedAtomFact2{Pred: "edge/2"}, &Proceed{}}, map[string]int{})
+    factFail.registerIndexedAtomFact2Pairs("edge/2", []AtomPair{{Left: "a", Right: "b"}})
+    factFail.Regs[0] = internAtom("missing")
+    factFail.Regs[1] = &Unbound{Name: "NO_FACT", Idx: 1}
+    if factFail.Run() {
+        t.Fatalf("expected indexed fact lookup for missing key to fail")
+    }
+
     vm := NewWamState(nil, nil)
     vm.registerForeignNativeKind("test_reaches_dist/3", "transitive_distance3")
     vm.registerForeignResultLayout("test_reaches_dist/3", "tuple:2")


### PR DESCRIPTION
# Add Go WAM indexed atom fact dispatch

Adds `call_indexed_atom_fact2` support to the Go WAM target. The Go instruction set now includes `CallIndexedAtomFact2`, the WAM text parser emits it, and the runtime executes indexed atom fact lookups with stream-style backtracking over multiple matches.

This narrows the Go direct fact dispatch parity gap against the Rust/Haskell baseline by covering the inline indexed fact instruction path. External TSV/LMDB FactSource adapters remain a separate follow-up.

The generated Go runtime now also writes a minimal `internAtom` helper even when a project has no compile-time atom literals, because fact dispatch and foreign graph helpers can construct atoms dynamically.

## Tests

```sh
swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl
swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"
```
