### PR TITLE
feat(wam-cpp): disjunction goal-terms (;/2) via paired CP + DisjFrame

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -391,22 +391,27 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     helper_predicate_items(HelperItems),
     flatten_blocks([HelperItems|PerPredItems], AllItems),
     walk_blocks(AllItems, Labels, FlatInstrs0),
-    % Append four trailing synthetic-return instructions:
+    % Append five trailing synthetic-return instructions:
     %   catch_return     — CatchReturn (catch/3 success path).
     %   negation_return  — NegationReturn (\+/1 + not/1 success path).
     %   findall_collect  — FindallCollect (findall/3 meta-call
     %                      per-solution collect + force-backtrack).
     %   conj_return      — ConjReturn (,/2 goal-term''s G1 succeeded;
-    %                      pop frame and dispatch G2).
+    %                      dispatch G2 with the original after_pc).
+    %   disj_alt         — DisjAlt (;/2 goal-term''s CP fired:
+    %                      G1 exhausted; pop CP + DisjFrame and
+    %                      dispatch G2).
     % Their PCs are emitted as state-register initialisers in the
     % setup function.
     append(FlatInstrs0,
-           [catch_return, negation_return, findall_collect, conj_return],
+           [catch_return, negation_return, findall_collect,
+            conj_return, disj_alt],
            FlatInstrs),
     length(FlatInstrs0, CatchReturnPC),
     NegationReturnPC is CatchReturnPC + 1,
     FindallCollectPC is CatchReturnPC + 2,
     ConjReturnPC is CatchReturnPC + 3,
+    DisjAltPC is CatchReturnPC + 4,
     findall(LabelLine, (
         member(NameStr-PC, Labels),
         format(atom(LabelLine),
@@ -428,6 +433,7 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     vm.negation_return_pc = ~w;
     vm.findall_collect_pc = ~w;
     vm.conj_return_pc = ~w;
+    vm.disj_alt_pc = ~w;
 ~w
 ~w
 }
@@ -435,7 +441,8 @@ static const int _wam_cpp_setup_register = []() {
     Program::register_setup(&wam_cpp_setup);
     return 0;
 }();
-', [Reserve, CatchReturnPC, NegationReturnPC, FindallCollectPC, ConjReturnPC,
+', [Reserve, CatchReturnPC, NegationReturnPC, FindallCollectPC,
+    ConjReturnPC, DisjAltPC,
     LabelBody, InstrBody]).
 
 % ============================================================================
@@ -1045,6 +1052,8 @@ instr_to_setup_line(findall_collect, _Labels, Line) :- !,
     Line = '    vm.instrs.push_back(Instruction::FindallCollect());'.
 instr_to_setup_line(conj_return, _Labels, Line) :- !,
     Line = '    vm.instrs.push_back(Instruction::ConjReturn());'.
+instr_to_setup_line(disj_alt, _Labels, Line) :- !,
+    Line = '    vm.instrs.push_back(Instruction::DisjAlt());'.
 instr_to_setup_line(Instr, _Labels, Line) :-
     wam_instruction_to_cpp_literal(Instr, Lit),
     format(atom(Line), '    vm.instrs.push_back(~w);', [Lit]).
@@ -1415,7 +1424,7 @@ struct Instruction {
         TryMeElse, RetryMeElse, TrustMe, Jump, CutIte,
         BeginAggregate, EndAggregate,
         SwitchOnConstant, SwitchOnStructure, SwitchOnTerm,
-        CatchReturn, NegationReturn, FindallCollect, ConjReturn
+        CatchReturn, NegationReturn, FindallCollect, ConjReturn, DisjAlt
     };
     // Sentinel pc values for switch-table entries that should not jump.
     static constexpr std::size_t SWITCH_DEFAULT = static_cast<std::size_t>(-1);
@@ -1514,6 +1523,8 @@ struct Instruction {
         { Instruction i; i.op = Op::FindallCollect; return i; }
     static Instruction ConjReturn()
         { Instruction i; i.op = Op::ConjReturn; return i; }
+    static Instruction DisjAlt()
+        { Instruction i; i.op = Op::DisjAlt; return i; }
 };
 
 struct TrailEntry {
@@ -1628,6 +1639,17 @@ struct ConjFrame {
     std::size_t base_cp_count = 0;
 };
 
+// Frame for a disjunction goal (;(G1, G2)) dispatched as a goal-term.
+// invoke_goal_as_call pushes a DisjFrame AND a regular ChoicePoint
+// whose alt_pc = disj_alt_pc, then dispatches G1. If G1 succeeds the
+// CP stays around for outer backtracking to retry G2 later; if G1
+// fails (or backtrack reaches the CP), DisjAlt pops both the CP and
+// the DisjFrame and dispatches G2 with the original after_pc.
+struct DisjFrame {
+    CellPtr     second_goal;
+    std::size_t after_pc = 0;
+};
+
 struct WamState {
     std::unordered_map<std::string, CellPtr> regs;
     std::unordered_map<std::string, std::size_t> labels;
@@ -1641,6 +1663,9 @@ struct WamState {
     // Conjunction-goal-term dispatch (,(G1, G2) passed as a meta-call
     // argument, e.g. inside catch(_, _, _) or findall/3).
     std::vector<ConjFrame> conj_frames;
+    // Disjunction-goal-term dispatch (;(G1, G2)). Paired with a
+    // regular ChoicePoint — see DisjFrame struct doc.
+    std::vector<DisjFrame> disj_frames;
     // pc of the auto-injected single CatchReturn instruction. catch/3
     // sets cp to this value before dispatching to the protected goal;
     // when the goal proceeds, control lands here and the catcher frame
@@ -1663,6 +1688,11 @@ struct WamState {
     // the top ConjFrame and dispatches its G2 with the original
     // after_pc.
     std::size_t conj_return_pc = 0;
+    // pc of the auto-injected single DisjAlt instruction. ;/2
+    // dispatched as a goal-term arrives here via a ChoicePoint''s
+    // alt_pc when G1 fails; pops the matching DisjFrame and CP,
+    // then dispatches G2 with the original after_pc.
+    std::size_t disj_alt_pc = 0;
     // Mode stack: Get-/Put-Structure / Get-/Put-List PUSH; Unify*/Set*
     // operate on top(); each frame auto-pops once its arity is filled.
     std::vector<ModeFrame> mode_stack;
@@ -3131,6 +3161,18 @@ bool WamState::step(const Instruction& instr) {
             const ConjFrame& f = conj_frames.back();
             return invoke_goal_as_call(f.second_goal, f.after_pc);
         }
+        case Instruction::Op::DisjAlt: {
+            // Reached when the disjunction''s CP fired (G1 has
+            // exhausted its solutions). Pop the CP (trust_me-style —
+            // it''s a one-shot, no more alternatives after G2) and
+            // the matching DisjFrame, then dispatch G2 with the
+            // original after_pc.
+            if (!choice_points.empty()) choice_points.pop_back();
+            if (disj_frames.empty()) return false;
+            DisjFrame f = std::move(disj_frames.back());
+            disj_frames.pop_back();
+            return invoke_goal_as_call(f.second_goal, f.after_pc);
+        }
         case Instruction::Op::Proceed: {
             if (cp == 0) { halt = true; return true; }
             pc = cp;
@@ -3475,6 +3517,29 @@ bool WamState::invoke_goal_as_call(CellPtr goal_cell, std::size_t after_pc) {
             f.base_cp_count = choice_points.size();
             conj_frames.push_back(std::move(f));
             return invoke_goal_as_call(g.args[0], conj_return_pc);
+        }
+        // Disjunction goal-term (G1 ; G2): push a CP whose alt_pc
+        // is disj_alt_pc and a paired DisjFrame carrying G2 + the
+        // original after_pc. Dispatch G1 normally. If G1 succeeds,
+        // control flows past the disjunction; the CP stays so
+        // outer backtracking can retry G2 later. If G1 fails (or
+        // backtrack drains to this CP), DisjAlt pops the CP + the
+        // DisjFrame and dispatches G2 with after_pc.
+        if (key == ";/2" && g.args.size() == 2) {
+            ChoicePoint cp_;
+            cp_.alt_pc            = disj_alt_pc;
+            cp_.saved_cp          = cp;
+            cp_.trail_mark        = trail.size();
+            cp_.cut_barrier       = cut_barrier;
+            cp_.saved_regs        = regs;
+            cp_.saved_mode_stack  = mode_stack;
+            cp_.saved_env_stack   = env_stack;
+            choice_points.push_back(std::move(cp_));
+            DisjFrame df;
+            df.second_goal = g.args[1];
+            df.after_pc    = after_pc;
+            disj_frames.push_back(std::move(df));
+            return invoke_goal_as_call(g.args[0], after_pc);
         }
         auto slash = key.rfind(''/'');
         if (slash == std::string::npos) return false;

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -474,6 +474,43 @@ user:wam_cpp_test_setof_nested :-
           Ls),
     Ls = [[1, 2], [1, 2, 3]].
 
+% Disjunction goal-terms (;/2) as meta-call args. The WAM compiler
+% inlines disjunction inside findall/bagof/setof body but builds it
+% as a ;/2 compound when passed to catch/3, \+/1, call/1, or a
+% non-inlined meta-aggregate (inner findall/bagof/setof).
+:- dynamic user:wam_cpp_test_catch_disj/0.
+:- dynamic user:wam_cpp_test_not_disj_both_fail/0.
+:- dynamic user:wam_cpp_test_call_disj_first/0.
+:- dynamic user:wam_cpp_test_call_disj_second/0.
+:- dynamic user:wam_cpp_test_call_disj_first_fails/0.
+
+% catch with disjunction inside — first alternative succeeds.
+user:wam_cpp_test_catch_disj :-
+    catch((true ; fail), _E, fail).
+
+% \+ (fail ; fail) — both alternatives fail → \+ succeeds.
+user:wam_cpp_test_not_disj_both_fail :-
+    \+ (fail ; fail).
+
+% call((G1 ; G2)) — G1 succeeds, X = 1.
+user:wam_cpp_test_call_disj_first :-
+    call((X = 1 ; X = 2)),
+    X = 1.
+
+% call((G1 ; G2)) — backtrack into G2 by requiring X = 2.
+% Exercises the DisjAlt path: after G1 binds X=1, the X=2 check
+% fails, backtrack pops the disjunction''s CP, DisjAlt dispatches
+% G2 which binds X=2.
+user:wam_cpp_test_call_disj_second :-
+    call((X = 1 ; X = 2)),
+    X = 2.
+
+% call((fail ; G2)) — G1 fails immediately, G2 dispatched via
+% DisjAlt. Tests the failure-on-first-arm path.
+user:wam_cpp_test_call_disj_first_fails :-
+    call((fail ; X = 7)),
+    X = 7.
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -2213,6 +2250,93 @@ test(cpp_e2e_setof_nested, [condition(cpp_compiler_available)]) :-
                               [emit_main(true)], TmpDir),
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath, 'wam_cpp_test_setof_nested/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% Disjunction goal-terms (;/2) — handled by invoke_goal_as_call by
+% pushing a CP whose alt_pc = disj_alt_pc and a paired DisjFrame
+% carrying G2 + after_pc. G1 dispatched normally; on G1 exhaustion
+% backtrack reaches the CP, DisjAlt pops both CP and DisjFrame, then
+% dispatches G2.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_catch_disjunction,
+     [condition(cpp_compiler_available)]) :-
+    % catch((true ; fail), _, _) — the catch goal is a disjunction
+    % term. G1=true succeeds; the catch succeeds with no throw and
+    % the recovery never runs.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_catch_disj', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_catch_disj/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_catch_disj/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_negation_disjunction_both_fail,
+     [condition(cpp_compiler_available)]) :-
+    % \+ (fail ; fail) — both alternatives fail → \+ succeeds.
+    % Exercises the DisjAlt path: G1=fail fails immediately,
+    % DisjAlt fires, G2=fail also fails, full disjunction fails,
+    % which is what \+ needs to succeed.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_neg_disj', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_not_disj_both_fail/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_not_disj_both_fail/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_call_disjunction_first,
+     [condition(cpp_compiler_available)]) :-
+    % call((X = 1 ; X = 2)) with subsequent X = 1 — first
+    % alternative''s binding sticks (no backtrack needed).
+    unique_cpp_tmp_dir('tmp_cpp_e2e_call_disj_first', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_call_disj_first/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_call_disj_first/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_call_disjunction_second,
+     [condition(cpp_compiler_available)]) :-
+    % call((X = 1 ; X = 2)) with subsequent X = 2 — forces backtrack
+    % into G2 via DisjAlt. The critical regression guard for the
+    % CP-paired-with-DisjFrame mechanism.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_call_disj_second', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_call_disj_second/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_call_disj_second/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_call_disjunction_first_fails,
+     [condition(cpp_compiler_available)]) :-
+    % call((fail ; X = 7)) — G1 fails immediately, DisjAlt
+    % dispatches G2 which binds X=7. Tests the
+    % immediate-failure-of-G1 path.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_call_disj_g1fail', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_call_disj_first_fails/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_call_disj_first_fails/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Closes the last major control-flow gap in `invoke_goal_as_call`. Disjunction `(G1 ; G2)` as a **goal-term** (passed to `catch/3`, `\+/1`, `call/1`, or a non-inlined meta-aggregate) now works.

## Design — paired ChoicePoint + DisjFrame

When `invoke_goal_as_call` sees a `;/2` compound it:

1. **Pushes a regular ChoicePoint** with `alt_pc = disj_alt_pc`. The CP snapshots VM state (regs, trail mark, mode/env stacks, cut barrier).
2. **Pushes a paired DisjFrame** on a new `disj_frames` vector carrying the second goal + original `after_pc`.
3. Dispatches G1 normally.

Three outcomes:

| Outcome | What happens |
|---|---|
| **G1 succeeds** | Control flows past the disjunction. CP + DisjFrame stay on the stack so outer backtracking can retry G2 later |
| **G1 fails** | `backtrack()` pops CPs to ours. State restored via standard CP machinery; pc set to `disj_alt_pc` |
| **DisjAlt op fires** | Pops the CP (trust_me-style — no more alternatives after G2), pops the paired DisjFrame, dispatches G2 with original `after_pc` |

Nested disjunctions in goal terms work naturally — each `;/2` adds one CP + one DisjFrame, all matched LIFO.

## Note on the design choice

The natural alternative is "make DisjFrame self-contained, use a synthetic ConjReturn-style op." That doesn't work for disjunction because **the post-G1-success path must leave a CP for outer backtracking**. Using the standard CP machinery for backtrack-on-fail gets us the right state save/restore semantics for free. The DisjFrame is just bookkeeping for what G2 to dispatch when the CP fires.

## Tests — 5 new e2e tests

| Test | Coverage |
|---|---|
| `cpp_e2e_catch_disjunction` | `catch((true ; fail), _, _)` |
| `cpp_e2e_negation_disjunction_both_fail` | `\+ (fail ; fail)` — G1 fails, DisjAlt fires, G2 fails, disjunction fails, `\+` succeeds |
| `cpp_e2e_call_disjunction_first` | `call((X = 1 ; X = 2))` with `X = 1` — G1's binding sticks |
| `cpp_e2e_call_disjunction_second` | Same with `X = 2` — **forces backtrack into G2 via DisjAlt**. Critical regression guard for the CP-paired-with-DisjFrame mechanism |
| `cpp_e2e_call_disjunction_first_fails` | `call((fail ; X = 7))` — G1 fails immediately, DisjAlt dispatches G2 |

**Total: 119/119 passing** (was 114; +5 new).

## Verification

```
$ swipl -g "[tests/test_wam_cpp_generator], run_tests(wam_cpp_generator)" -t halt
% All 119 tests passed
```

## Where this fits

After PRs #2099 (nested findall + ConjFrame) and #2100 (bagof/setof + `^/2` + standard term ordering), `invoke_goal_as_call` now handles the full Prolog control-flow term zoo:

| Goal-term | Handler |
|---|---|
| Atoms (`true`, `fail`, `false`, `Name`) | Direct dispatch |
| User predicates `Name(...)` | Label lookup |
| `catch/3` | `execute_catch` |
| `throw/1` | `execute_throw` |
| `\+/1`, `not/1` | `execute_negation` |
| `findall/3` | `dispatch_findall_call` |
| `bagof/3`, `setof/3` | `dispatch_aggregate_call` |
| `^/2` | Transparent (invoke A2) |
| `,/2` (conjunction) | `ConjFrame` + `ConjReturn` |
| `;/2` (disjunction) | `DisjFrame` + paired CP + `DisjAlt` |

## Test plan

- [x] All 114 prior tests still pass (no regression)
- [x] 5 new e2e tests pass covering catch / `\+` / call / first-succeeds / backtrack-into-second / first-fails paths
- [x] `g++ -std=c++17` clean compile
- [ ] Follow-up: if-then-else `(Cond -> Then ; Else)` as a goal-term — currently the WAM inlines this when seen in clause bodies, but the goal-term form would need an `IfThenFrame` similar to DisjFrame
- [ ] Follow-up: full bagof/setof grouping (currently `^/2` is just transparent)

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_