### PR TITLE
feat(wam-clojure): add compare/3 builtin

### DIFF
--- a/PR_WAM_CLOJURE_COMPARE_BUILTIN.md
+++ b/PR_WAM_CLOJURE_COMPARE_BUILTIN.md
@@ -1,0 +1,32 @@
+# PR Title
+
+feat(wam-clojure): add compare/3 builtin
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM support for `compare/3`.
+- Reuses the existing `term-compare` implementation from the standard term-ordering builtins.
+- Adds runtime `apply-compare-solution`, which unifies the first argument with `<`, `=`, or `>`.
+- Wires interpreted runtime dispatch for `compare/3`.
+- Direct-lowers `call compare/3` in addition to `execute compare/3`.
+- Hardens direct-builtin arity matching so parsed arities may be variables, integers, strings, or atoms.
+- Adds lowered-emitter and runtime smoke coverage.
+
+## Semantics
+
+`compare/3` compares the second and third arguments using the same term ordering as `@</2`, `@=</2`, `@>/2`, and `@>=/2`, then unifies the first argument with one of:
+
+- `<`
+- `=`
+- `>`
+
+The compared terms are dereferenced for inspection but are not unified or mutated.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -296,6 +296,10 @@ clojure_direct_builtin("@>=/2", "2").
 clojure_direct_builtin("@>=/2", 2).
 clojure_direct_builtin('@>=/2', "2").
 clojure_direct_builtin('@>=/2', 2).
+clojure_direct_builtin("compare/3", "3").
+clojure_direct_builtin("compare/3", 3).
+clojure_direct_builtin('compare/3', "3").
+clojure_direct_builtin('compare/3', 3).
 clojure_direct_builtin("=:=/2", "2").
 clojure_direct_builtin("=:=/2", 2).
 clojure_direct_builtin('=:=/2', "2").
@@ -418,8 +422,15 @@ clojure_pred_key_direct_builtin(Pred, Op, Arity) :-
     (   string(Pred) -> PredString = Pred
     ;   atom(Pred) -> atom_string(Pred, PredString)
     ),
-    split_string(PredString, "/", "", [Name, ArityString]),
-    number_string(Arity, ArityString),
+    (   split_string(PredString, "/", "", [Name, ArityString])
+    ->  (   var(Arity) -> number_string(Arity, ArityString)
+        ;   integer(Arity) -> number_string(Arity, ArityString)
+        ;   string(Arity) -> Arity = ArityString
+        ;   atom(Arity) -> atom_string(Arity, ArityString)
+        )
+    ;   integer(Arity),
+        Name = PredString
+    ),
     format(string(Op), "~w/~w", [Name, Arity]),
     clojure_direct_builtin(Op, Arity).
 
@@ -469,6 +480,10 @@ emit_lowered_expr(proceed, S, Expr) :-
     format(atom(Expr), '(runtime/succeed-state ~w)', [S]).
 emit_lowered_expr(fail, S, Expr) :-
     format(atom(Expr), '(runtime/fail-state ~w)', [S]).
+emit_lowered_expr(call(Pred, CallArity), S, Expr) :-
+    clojure_pred_key_direct_builtin(Pred, Op, CallArity),
+    !,
+    emit_lowered_expr(builtin_call(Op, CallArity), S, Expr).
 emit_lowered_expr(call(Pred, _Arity), S, Expr) :-
     clj_lowered_string_literal(Pred, PredLit),
     format(atom(Expr),
@@ -567,6 +582,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr),
            '(let [left (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound) right (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound)] (if (runtime/~w ~w left right) (runtime/advance ~w) (runtime/backtrack ~w)))',
            [S, S, RuntimePred, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "compare/3" ; Op == 'compare/3'),
+    !,
+    format(atom(Expr), '(runtime/apply-compare-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "=:=/2" ; Op == '=:=/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -460,6 +460,25 @@
 (defn term-greater-or-equal? [state left right]
   (not (neg? (term-compare state left right))))
 
+(defn compare-result-term [state left right]
+  (let [order (term-compare state left right)
+        atom-name (cond
+                    (neg? order) "<"
+                    (pos? order) ">"
+                    :else "=")]
+    (normalize-literal-atom (:intern-context state) atom-name)))
+
+(defn apply-compare-solution [state]
+  (let [out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A1") ::unbound))
+        left (or (reg-get-raw state "A2") ::unbound)
+        right (or (reg-get-raw state "A3") ::unbound)
+        result (compare-result-term state left right)
+        [ok next-state] (unify-values state out result)]
+    (if ok
+      (advance next-state)
+      (backtrack state))))
+
 (defn parse-numeric-atom [text]
   (when (and (string? text)
              (re-matches #"[+-]?(?:\d+(?:\.\d*)?|\.\d+)" text))
@@ -1303,6 +1322,9 @@
             (if (term-greater-or-equal? state left right)
               (advance state)
               (backtrack state)))
+
+          "compare/3"
+          (apply-compare-solution state)
 
           "=:=/2"
           (let [left (deref-value (:bindings state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -206,6 +206,20 @@ test(simple_builtin_term_greater_or_equal_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/backtrack")
     )).
 
+test(simple_builtin_compare_is_direct_lowered_in_prefix) :-
+    once((
+        lower_predicate_to_clojure(test_compare/3, [builtin_call('compare/3', 3), proceed], [], Code),
+        has(Code, "runtime/apply-compare-solution"),
+        \+ has(Code, "runtime/step")
+    )).
+
+test(simple_compare_call_is_direct_lowered_in_prefix) :-
+    once((
+        lower_predicate_to_clojure(test_compare_call/0, [call('compare/3', 3), proceed], [], Code),
+        has(Code, "runtime/apply-compare-solution"),
+        \+ has(Code, "target-pc")
+    )).
+
 test(simple_builtin_arithmetic_equal_is_direct_lowered_in_prefix) :-
     once((
         lower_predicate_to_clojure(test_arith_eq/2, [builtin_call('=:=/2', 2), proceed], [], Code),

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -50,6 +50,12 @@
 :- dynamic user:wam_term_var_lt_atom/0.
 :- dynamic user:wam_term_var_le_same/0.
 :- dynamic user:wam_term_order_does_not_bind/0.
+:- dynamic user:wam_compare_lt/0.
+:- dynamic user:wam_compare_eq/0.
+:- dynamic user:wam_compare_gt/0.
+:- dynamic user:wam_compare_atom_number/0.
+:- dynamic user:wam_compare_output_guard/1.
+:- dynamic user:wam_compare_does_not_bind/0.
 :- dynamic user:wam_fail_after_bind/1.
 :- dynamic user:wam_atom_guard/1.
 :- dynamic user:wam_integer_guard/1.
@@ -166,6 +172,12 @@ user:wam_term_ge(A, B) :- A @>= B.
 user:wam_term_var_lt_atom :- user:wam_unbound_arg(X), X @< a.
 user:wam_term_var_le_same :- user:wam_unbound_arg(X), X @=< X.
 user:wam_term_order_does_not_bind :- user:wam_unbound_arg(X), X @< a, X == a.
+user:wam_compare_lt :- compare(Order, a, b), Order == '<'.
+user:wam_compare_eq :- compare(Order, f(a), f(a)), Order == '='.
+user:wam_compare_gt :- compare(Order, b, a), Order == '>'.
+user:wam_compare_atom_number :- compare(Order, 42, a), Order == '<'.
+user:wam_compare_output_guard(Order) :- compare(Order, a, b).
+user:wam_compare_does_not_bind :- user:wam_unbound_arg(X), compare('<', X, a), X == a.
 user:wam_fail_after_bind(X) :- X = a, fail.
 user:wam_atom_guard(X) :- atom(X).
 user:wam_integer_guard(X) :- integer(X).
@@ -287,6 +299,12 @@ run_smoke :-
           user:wam_term_var_lt_atom/0,
           user:wam_term_var_le_same/0,
           user:wam_term_order_does_not_bind/0,
+          user:wam_compare_lt/0,
+          user:wam_compare_eq/0,
+          user:wam_compare_gt/0,
+          user:wam_compare_atom_number/0,
+          user:wam_compare_output_guard/1,
+          user:wam_compare_does_not_bind/0,
           user:wam_fail_after_bind/1,
           user:wam_atom_guard/1,
           user:wam_integer_guard/1,
@@ -370,6 +388,7 @@ run_smoke :-
     assert_lowered_not_unify_builtin_emitted(TmpDir),
     assert_lowered_identity_builtin_emitted(TmpDir),
     assert_lowered_term_order_builtin_emitted(TmpDir),
+    assert_lowered_compare_builtin_emitted(TmpDir),
     assert_lowered_fail_builtin_emitted(TmpDir),
     assert_lowered_atom_builtin_emitted(TmpDir),
     assert_lowered_integer_builtin_emitted(TmpDir),
@@ -474,6 +493,13 @@ smoke_cases([
     case('wam_term_var_lt_atom/0', no_args, "true"),
     case('wam_term_var_le_same/0', no_args, "true"),
     case('wam_term_order_does_not_bind/0', no_args, "false"),
+    case('wam_compare_lt/0', no_args, "true"),
+    case('wam_compare_eq/0', no_args, "true"),
+    case('wam_compare_gt/0', no_args, "true"),
+    case('wam_compare_atom_number/0', no_args, "true"),
+    case('wam_compare_output_guard/1', '<', "true"),
+    case('wam_compare_output_guard/1', '=', "false"),
+    case('wam_compare_does_not_bind/0', no_args, "false"),
     case('wam_fail_after_bind/1', a, "false"),
     case('wam_fail_after_bind/1', b, "false"),
     case('wam_atom_guard/1', a, "true"),
@@ -665,6 +691,13 @@ assert_lowered_term_order_builtin_emitted(ProjectDir) :-
     has(CoreCode, "runtime/term-less-or-equal?"),
     has(CoreCode, "runtime/term-greater?"),
     has(CoreCode, "runtime/term-greater-or-equal?").
+
+assert_lowered_compare_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-compare-lt-0"),
+    has(CoreCode, "defn lowered-wam-compare-output-guard-1"),
+    has(CoreCode, "runtime/apply-compare-solution").
 
 assert_lowered_fail_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
@@ -977,6 +1010,9 @@ prolog_term_string_to_edn(b, "\"b\"") :- !.
 prolog_term_string_to_edn(c, "\"c\"") :- !.
 prolog_term_string_to_edn(d, "\"d\"") :- !.
 prolog_term_string_to_edn(z, "\"z\"") :- !.
+prolog_term_string_to_edn('<', "\"<\"") :- !.
+prolog_term_string_to_edn('=', "\"=\"") :- !.
+prolog_term_string_to_edn('>', "\">\"") :- !.
 prolog_term_string_to_edn('[]', "\"[]\"") :- !.
 prolog_term_string_to_edn(-42, "-42") :- !.
 prolog_term_string_to_edn(0, "0") :- !.


### PR DESCRIPTION
## Summary

- Adds Clojure WAM support for `compare/3`.
- Reuses the existing `term-compare` implementation from the standard term-ordering builtins.
- Adds runtime `apply-compare-solution`, which unifies the first argument with `<`, `=`, or `>`.
- Wires interpreted runtime dispatch for `compare/3`.
- Direct-lowers `call compare/3` in addition to `execute compare/3`.
- Hardens direct-builtin arity matching so parsed arities may be variables, integers, strings, or atoms.
- Adds lowered-emitter and runtime smoke coverage.

## Semantics

`compare/3` compares the second and third arguments using the same term ordering as `@</2`, `@=</2`, `@>/2`, and `@>=/2`, then unifies the first argument with one of:

- `<`
- `=`
- `>`

The compared terms are dereferenced for inspection but are not unified or mutated.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
