### PR TITLE
feat(wam-cpp): if-then-else goal-terms (;(->(Cond, Then), Else))

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -391,27 +391,20 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     helper_predicate_items(HelperItems),
     flatten_blocks([HelperItems|PerPredItems], AllItems),
     walk_blocks(AllItems, Labels, FlatInstrs0),
-    % Append five trailing synthetic-return instructions:
-    %   catch_return     — CatchReturn (catch/3 success path).
-    %   negation_return  — NegationReturn (\+/1 + not/1 success path).
-    %   findall_collect  — FindallCollect (findall/3 meta-call
-    %                      per-solution collect + force-backtrack).
-    %   conj_return      — ConjReturn (,/2 goal-term''s G1 succeeded;
-    %                      dispatch G2 with the original after_pc).
-    %   disj_alt         — DisjAlt (;/2 goal-term''s CP fired:
-    %                      G1 exhausted; pop CP + DisjFrame and
-    %                      dispatch G2).
-    % Their PCs are emitted as state-register initialisers in the
-    % setup function.
+    % Append seven trailing synthetic-return instructions for the
+    % meta-call control-flow surface — see WamState for each pc''s
+    % role.
     append(FlatInstrs0,
            [catch_return, negation_return, findall_collect,
-            conj_return, disj_alt],
+            conj_return, disj_alt, if_then_commit, if_then_else],
            FlatInstrs),
     length(FlatInstrs0, CatchReturnPC),
     NegationReturnPC is CatchReturnPC + 1,
     FindallCollectPC is CatchReturnPC + 2,
     ConjReturnPC is CatchReturnPC + 3,
     DisjAltPC is CatchReturnPC + 4,
+    IfThenCommitPC is CatchReturnPC + 5,
+    IfThenElsePC is CatchReturnPC + 6,
     findall(LabelLine, (
         member(NameStr-PC, Labels),
         format(atom(LabelLine),
@@ -434,6 +427,8 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     vm.findall_collect_pc = ~w;
     vm.conj_return_pc = ~w;
     vm.disj_alt_pc = ~w;
+    vm.if_then_commit_pc = ~w;
+    vm.if_then_else_pc = ~w;
 ~w
 ~w
 }
@@ -442,7 +437,7 @@ static const int _wam_cpp_setup_register = []() {
     return 0;
 }();
 ', [Reserve, CatchReturnPC, NegationReturnPC, FindallCollectPC,
-    ConjReturnPC, DisjAltPC,
+    ConjReturnPC, DisjAltPC, IfThenCommitPC, IfThenElsePC,
     LabelBody, InstrBody]).
 
 % ============================================================================
@@ -1054,6 +1049,10 @@ instr_to_setup_line(conj_return, _Labels, Line) :- !,
     Line = '    vm.instrs.push_back(Instruction::ConjReturn());'.
 instr_to_setup_line(disj_alt, _Labels, Line) :- !,
     Line = '    vm.instrs.push_back(Instruction::DisjAlt());'.
+instr_to_setup_line(if_then_commit, _Labels, Line) :- !,
+    Line = '    vm.instrs.push_back(Instruction::IfThenCommit());'.
+instr_to_setup_line(if_then_else, _Labels, Line) :- !,
+    Line = '    vm.instrs.push_back(Instruction::IfThenElse());'.
 instr_to_setup_line(Instr, _Labels, Line) :-
     wam_instruction_to_cpp_literal(Instr, Lit),
     format(atom(Line), '    vm.instrs.push_back(~w);', [Lit]).
@@ -1424,7 +1423,8 @@ struct Instruction {
         TryMeElse, RetryMeElse, TrustMe, Jump, CutIte,
         BeginAggregate, EndAggregate,
         SwitchOnConstant, SwitchOnStructure, SwitchOnTerm,
-        CatchReturn, NegationReturn, FindallCollect, ConjReturn, DisjAlt
+        CatchReturn, NegationReturn, FindallCollect, ConjReturn, DisjAlt,
+        IfThenCommit, IfThenElse
     };
     // Sentinel pc values for switch-table entries that should not jump.
     static constexpr std::size_t SWITCH_DEFAULT = static_cast<std::size_t>(-1);
@@ -1525,6 +1525,10 @@ struct Instruction {
         { Instruction i; i.op = Op::ConjReturn; return i; }
     static Instruction DisjAlt()
         { Instruction i; i.op = Op::DisjAlt; return i; }
+    static Instruction IfThenCommit()
+        { Instruction i; i.op = Op::IfThenCommit; return i; }
+    static Instruction IfThenElse()
+        { Instruction i; i.op = Op::IfThenElse; return i; }
 };
 
 struct TrailEntry {
@@ -1650,6 +1654,26 @@ struct DisjFrame {
     std::size_t after_pc = 0;
 };
 
+// Frame for an if-then-else goal (;(->( Cond, Then), Else)) dispatched
+// as a goal-term. invoke_goal_as_call pushes an IfThenFrame and a
+// ChoicePoint with alt_pc = if_then_else_pc, then dispatches Cond
+// with cp = if_then_commit_pc.
+//
+//   - Cond succeeds  → IfThenCommit fires: cut CPs back to
+//                       cp_count_at_entry (so Cond can''t backtrack-
+//                       retry), pop the frame, dispatch Then with
+//                       the original after_pc.
+//   - Cond fails     → backtrack drains to our CP, lands on
+//                       if_then_else_pc: pop the frame, dispatch
+//                       Else with after_pc.
+struct IfThenFrame {
+    CellPtr     then_goal;
+    CellPtr     else_goal;
+    std::size_t after_pc = 0;
+    std::size_t base_cp_count = 0;   // CP-stack depth BEFORE we
+                                     // pushed the if-then-else CP
+};
+
 struct WamState {
     std::unordered_map<std::string, CellPtr> regs;
     std::unordered_map<std::string, std::size_t> labels;
@@ -1666,6 +1690,9 @@ struct WamState {
     // Disjunction-goal-term dispatch (;(G1, G2)). Paired with a
     // regular ChoicePoint — see DisjFrame struct doc.
     std::vector<DisjFrame> disj_frames;
+    // If-then-else-goal-term dispatch (;(->(Cond, Then), Else)).
+    // Paired with a regular ChoicePoint — see IfThenFrame doc.
+    std::vector<IfThenFrame> if_then_frames;
     // pc of the auto-injected single CatchReturn instruction. catch/3
     // sets cp to this value before dispatching to the protected goal;
     // when the goal proceeds, control lands here and the catcher frame
@@ -1693,6 +1720,12 @@ struct WamState {
     // alt_pc when G1 fails; pops the matching DisjFrame and CP,
     // then dispatches G2 with the original after_pc.
     std::size_t disj_alt_pc = 0;
+    // pcs for the two if-then-else synthetic ops. Cond reaches
+    // if_then_commit_pc on success (cut + dispatch Then); the
+    // paired CP''s alt_pc is if_then_else_pc, reached on Cond
+    // failure (dispatch Else).
+    std::size_t if_then_commit_pc = 0;
+    std::size_t if_then_else_pc = 0;
     // Mode stack: Get-/Put-Structure / Get-/Put-List PUSH; Unify*/Set*
     // operate on top(); each frame auto-pops once its arity is filled.
     std::vector<ModeFrame> mode_stack;
@@ -3173,6 +3206,29 @@ bool WamState::step(const Instruction& instr) {
             disj_frames.pop_back();
             return invoke_goal_as_call(f.second_goal, f.after_pc);
         }
+        case Instruction::Op::IfThenCommit: {
+            // Reached when Cond succeeded. Cut: drop all CPs the
+            // dispatch pushed (including our own paired CP). Pop
+            // the IfThenFrame. Dispatch Then with the original
+            // after_pc.
+            if (if_then_frames.empty()) return false;
+            IfThenFrame f = std::move(if_then_frames.back());
+            if_then_frames.pop_back();
+            while (choice_points.size() > f.base_cp_count)
+                choice_points.pop_back();
+            return invoke_goal_as_call(f.then_goal, f.after_pc);
+        }
+        case Instruction::Op::IfThenElse: {
+            // Reached when Cond failed and backtrack landed at our
+            // CP''s alt_pc. Pop the CP (trust_me-style — once-only,
+            // same as DisjAlt) and the matching IfThenFrame, then
+            // dispatch Else with the original after_pc.
+            if (!choice_points.empty()) choice_points.pop_back();
+            if (if_then_frames.empty()) return false;
+            IfThenFrame f = std::move(if_then_frames.back());
+            if_then_frames.pop_back();
+            return invoke_goal_as_call(f.else_goal, f.after_pc);
+        }
         case Instruction::Op::Proceed: {
             if (cp == 0) { halt = true; return true; }
             pc = cp;
@@ -3518,14 +3574,43 @@ bool WamState::invoke_goal_as_call(CellPtr goal_cell, std::size_t after_pc) {
             conj_frames.push_back(std::move(f));
             return invoke_goal_as_call(g.args[0], conj_return_pc);
         }
-        // Disjunction goal-term (G1 ; G2): push a CP whose alt_pc
-        // is disj_alt_pc and a paired DisjFrame carrying G2 + the
-        // original after_pc. Dispatch G1 normally. If G1 succeeds,
-        // control flows past the disjunction; the CP stays so
-        // outer backtracking can retry G2 later. If G1 fails (or
-        // backtrack drains to this CP), DisjAlt pops the CP + the
-        // DisjFrame and dispatches G2 with after_pc.
+        // Disjunction goal-term — two flavours, both shaped ;/2.
+        // First check for the if-then-else special case
+        // `;(->( Cond, Then), Else)`: built by the WAM compiler
+        // when the user writes `(Cond -> Then ; Else)` as data
+        // (passed to catch/3, call/1, etc.). Cut semantics differ
+        // from plain disjunction, so we route to a separate frame.
         if (key == ";/2" && g.args.size() == 2) {
+            // Peek the first arg — is it ->/2 ?
+            Value first = deref(*g.args[0]);
+            if (first.tag == Value::Tag::Compound
+                && first.s == "->/2"
+                && first.args.size() == 2)
+            {
+                IfThenFrame itf;
+                itf.then_goal     = first.args[1];
+                itf.else_goal     = g.args[1];
+                itf.after_pc      = after_pc;
+                itf.base_cp_count = choice_points.size();
+                if_then_frames.push_back(std::move(itf));
+                // CP whose alt_pc dispatches Else on Cond failure.
+                ChoicePoint cp_;
+                cp_.alt_pc            = if_then_else_pc;
+                cp_.saved_cp          = cp;
+                cp_.trail_mark        = trail.size();
+                cp_.cut_barrier       = cut_barrier;
+                cp_.saved_regs        = regs;
+                cp_.saved_mode_stack  = mode_stack;
+                cp_.saved_env_stack   = env_stack;
+                choice_points.push_back(std::move(cp_));
+                // Dispatch Cond with cp = if_then_commit_pc so
+                // success lands at the commit op.
+                return invoke_goal_as_call(first.args[0],
+                                            if_then_commit_pc);
+            }
+            // Plain disjunction: push a CP whose alt_pc is
+            // disj_alt_pc and a paired DisjFrame carrying G2 + the
+            // original after_pc. Dispatch G1 normally.
             ChoicePoint cp_;
             cp_.alt_pc            = disj_alt_pc;
             cp_.saved_cp          = cp;

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -511,6 +511,42 @@ user:wam_cpp_test_call_disj_first_fails :-
     call((fail ; X = 7)),
     X = 7.
 
+% If-then-else goal-terms `;(->(Cond, Then), Else)` — built by the
+% WAM compiler when the user writes `(Cond -> Then ; Else)` as data
+% (passed to catch/3, call/1, or inside a non-inlined meta-call).
+% Distinct from plain disjunction because of cut semantics: when
+% Cond succeeds, all of Cond''s choice points are committed away.
+:- dynamic user:wam_cpp_test_ite_then_branch/0.
+:- dynamic user:wam_cpp_test_ite_else_branch/0.
+:- dynamic user:wam_cpp_test_ite_inside_findall/0.
+:- dynamic user:wam_cpp_test_ite_cut_commits_cond/0.
+
+% Cond=true → Then branch fires.
+user:wam_cpp_test_ite_then_branch :-
+    call((true -> X = 1 ; X = 2)),
+    X = 1.
+
+% Cond=fail → Else branch fires (via IfThenElse path).
+user:wam_cpp_test_ite_else_branch :-
+    call((fail -> X = 1 ; X = 2)),
+    X = 2.
+
+% findall + if-then-else as call''d goal-term — each iteration of
+% the outer member picks Then or Else based on the condition.
+user:wam_cpp_test_ite_inside_findall :-
+    findall(Y, (member(X, [1, 2, 3, 4]),
+                call((X > 2 -> Y = big ; Y = small))),
+            L),
+    L = [small, small, big, big].
+
+% Cut semantics: Cond uses member/2 which has multiple solutions.
+% After Cond commits with X=1, we don''t backtrack to try X=2.
+% Y must be 1 — if cut weren''t happening, this would also succeed
+% with Y=2 via re-dispatch of Cond.
+user:wam_cpp_test_ite_cut_commits_cond :-
+    call((member(X, [1, 2, 3]) -> Y = X ; Y = none)),
+    Y = 1.
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -2337,6 +2373,79 @@ test(cpp_e2e_call_disjunction_first_fails,
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath,
                     'wam_cpp_test_call_disj_first_fails/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% If-then-else goal-terms `(Cond -> Then ; Else)` passed to a
+% meta-call. The WAM compiler builds them as `;(->(Cond, Then), Else)`.
+% invoke_goal_as_call peeks at the first arg of ;/2 — if it''s ->/2,
+% routes to an IfThenFrame + paired CP with cut-on-Cond-success
+% semantics. Otherwise falls through to plain disjunction.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_ite_then_branch,
+     [condition(cpp_compiler_available)]) :-
+    % Cond=true → IfThenCommit fires → Then branch dispatched.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_ite_then', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_ite_then_branch/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_ite_then_branch/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_ite_else_branch,
+     [condition(cpp_compiler_available)]) :-
+    % Cond=fail → backtrack to our CP → IfThenElse fires → Else
+    % branch dispatched. Regression guard for the trust_me-style
+    % pop in IfThenElse (without it the alt_pc fires repeatedly
+    % into an empty if_then_frames, causing infinite recurse).
+    unique_cpp_tmp_dir('tmp_cpp_e2e_ite_else', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_ite_else_branch/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_ite_else_branch/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_ite_inside_findall,
+     [condition(cpp_compiler_available)]) :-
+    % findall + if-then-else as a call''d goal. Each iteration of
+    % member dispatches the if-then-else; for X∈{1,2} the Else
+    % branch fires (Y=small), for X∈{3,4} the Then branch fires
+    % (Y=big). Exercises if-then-else inside an aggregate context
+    % with backtracking.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_ite_findall', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_ite_inside_findall/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_ite_inside_findall/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_ite_cut_commits_cond,
+     [condition(cpp_compiler_available)]) :-
+    % Cut semantics: `call((member(X, [1, 2, 3]) -> Y = X ; ...))`
+    % must commit to X=1 (Cond''s first solution) and NOT
+    % backtrack-retry for X=2 / X=3 later. IfThenCommit drops the
+    % CPs from Cond''s dispatch back to base_cp_count, achieving
+    % the cut. Critical regression guard.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_ite_cut', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_ite_cut_commits_cond/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_ite_cut_commits_cond/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Extends the disjunction handler from PR #2102 to recognise the **if-then-else pattern**. When `invoke_goal_as_call` sees a `;/2` compound it peeks at the first arg — if it's `->/2`, routes to an `IfThenFrame` with cut-on-Cond-success semantics; otherwise falls through to the plain `DisjFrame` path.

## Design — IfThenFrame + paired CP + two synthetic ops

When `invoke_goal_as_call` detects `;(->(Cond, Then), Else)`:

1. Pushes an **`IfThenFrame`** with `Then`, `Else`, `after_pc`, and the CP-stack depth before the frame.
2. Pushes a regular **ChoicePoint** with `alt_pc = if_then_else_pc`.
3. Dispatches `Cond` with `cp = if_then_commit_pc`.

Three outcomes:

| Outcome | Op | Action |
|---|---|---|
| **Cond succeeds** | `IfThenCommit` | Pop CPs back to `base_cp_count` (cuts Cond's CPs + our paired CP), pop frame, dispatch `Then` |
| **Cond fails** | `IfThenElse` (via backtrack to `alt_pc`) | Pop CP (trust_me-style), pop frame, dispatch `Else` |
| Cond fails + no Else | n/a | The WAM compiler builds `;(->(C, T), E)` only when Else exists; bare `(Cond -> Then)` would need a different shape |

The cut semantics are the load-bearing difference vs plain disjunction.

## Tests — 4 new e2e tests

| Test | Coverage |
|---|---|
| `cpp_e2e_ite_then_branch` | `true → Then`. Smoke |
| `cpp_e2e_ite_else_branch` | `fail → Else` (via `IfThenElse`). **Regression guard for the trust_me-style CP pop** — without it the alt_pc fires repeatedly into an empty frame vector |
| `cpp_e2e_ite_inside_findall` | `findall(Y, (member(X, [...]), call((X > 2 -> Y = big ; Y = small))), L)`. If-then-else inside an aggregate with outer backtracking |
| `cpp_e2e_ite_cut_commits_cond` | `call((member(X, [1,2,3]) -> Y = X ; ...)), Y = 1`. **Critical regression guard for the cut**. If `IfThenCommit` didn't trim Cond's CPs, the predicate would also succeed with Y=2/Y=3 on retry |

**Total: 123/123 passing** (was 119; +4 new).

## One latent bug surfaced during development

The first draft of `IfThenElse` didn't pop the CP — just popped the `IfThenFrame` and dispatched Else. That caused infinite recurse: backtrack landed on `alt_pc` again later (CP still present), fired `IfThenElse` with empty `if_then_frames`, returned false, backtracked, landed on the same CP again. Fixed by adding the trust_me-style CP pop (same pattern as `DisjAlt`).

The `ite_else_branch` test would have caught it on the first run; the `ite_inside_findall` test hung until the fix landed.

## Where this fits

`invoke_goal_as_call` now handles the full Prolog control-flow zoo for goal-terms passed to meta-calls:

| Form | Handler |
|---|---|
| Atoms (`true`/`fail`/`false`/name) | Direct dispatch |
| User predicates `Name(...)` | Label lookup |
| `catch/3` | `execute_catch` |
| `throw/1` | `execute_throw` |
| `\+/1`, `not/1` | `execute_negation` |
| `findall/3` | `dispatch_findall_call` |
| `bagof/3`, `setof/3` | `dispatch_aggregate_call` |
| `^/2` | Transparent |
| `,/2` | `ConjFrame` + `ConjReturn` |
| `;/2` (plain) | `DisjFrame` + paired CP + `DisjAlt` |
| **`;(->(C, T), E)` (if-then-else)** | `IfThenFrame` + paired CP + `IfThenCommit`/`IfThenElse` |

## Verification

```
$ swipl -g "[tests/test_wam_cpp_generator], run_tests(wam_cpp_generator)" -t halt
% All 123 tests passed
```

## Test plan

- [x] All 119 prior tests still pass (no regression)
- [x] 4 new e2e tests pass covering Then-branch, Else-branch, ITE-in-findall, and cut-commits-cond
- [x] `g++ -std=c++17` clean compile
- [x] `IfThenElse` pops CP trust_me-style (same as `DisjAlt`) — verified via the hang-fix
- [ ] Follow-up: `(Cond -> Then)` without Else as a goal-term — different shape (just `->/2` at the top), would need its own handler
- [ ] Follow-up: full bagof/setof grouping (currently `^/2` is just transparent)
- [ ] Follow-up: Items-API Phase 2 (start migrating other targets to `wam_text_parser`)

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_