### PR TITLE
docs: design runtime parser transpilation

### DIFF
--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,93 @@
+# Runtime Parser Transpilation Implementation Plan
+
+This plan moves runtime Prolog term parsing from target-local parsers toward a
+single portable Prolog parser compiled into targets.
+
+## Phase 1: Document The Existing R Contract
+
+R remains the reference target. Its inline parser already supports
+`read/2`, `read_term_from_atom/2,3`, reverse `term_to_atom/2`, runtime `op/3`,
+and CLI argument parsing.
+
+Keep the R inline parser and tests in place while the compiled parser is being
+hardened. The inline parser is useful as an oracle for target behavior, not as
+the long-term source of parser semantics.
+
+## Phase 2: Harden The Portable Parser
+
+Keep `src/unifyweaver/core/prolog_term_parser.pl` in the
+cross-target-compilable subset. Add tests when target runtime consumers expose
+new parser-sensitive behavior.
+
+Maintain structural compile coverage for WAM-R:
+
+```text
+tests/test_prolog_term_parser_wam_r_compile.pl
+```
+
+This test should continue proving that every parser predicate emits a target
+label and wrapper, even before the runtime parser is swapped in.
+
+## Phase 3: Fix Runtime Requirements Exposed By The Parser
+
+The current blocker for running the transpiled parser as the R runtime parser
+is WAM-R cut-barrier behavior. The parser uses cuts inside multi-clause helper
+predicates such as tokenizer and identifier readers. The runtime must discard
+choice points created after the active cut barrier, not merely the most recent
+choice point.
+
+Treat this as a general WAM correctness fix. Other non-trivial library code
+will eventually depend on the same behavior.
+
+## Phase 4: Swap R Behind A Guard
+
+After cut semantics are correct, wire R so `read/2`,
+`read_term_from_atom/2,3`, reverse `term_to_atom/2`, and CLI parsing can use
+the compiled parser.
+
+During the transition, keep a selectable fallback to the inline parser. Compare
+both paths with:
+
+```text
+tests/benchmarks/wam_r_parser_bench.pl
+```
+
+The swap is complete when the compiled parser matches the inline parser on
+runtime tests and has acceptable performance for normal stream and atom parsing
+workloads.
+
+## Phase 5: Generalize The Target Hook
+
+Add a target capability hook for runtime parser inclusion. The hook should
+answer whether a generated runtime needs the parser library and how the target
+should expose parser entry points to builtins.
+
+The hook should be independent of the WAM items API. A target can skip WAM text
+generation at build time and still need runtime source-term parsing.
+
+## Phase 6: Port The Next Target
+
+Choose the next target based on a real runtime consumer, not on parser
+availability alone. Good candidates are targets adding:
+
+- `read/2`;
+- `read_term_from_atom/2,3`;
+- reverse `term_to_atom/2`;
+- user-facing CLI term arguments.
+
+Python, R, Elixir, and Lua are reasonable candidates, but R should stay the
+semantic reference until the compiled parser fully replaces its inline parser.
+
+## Risks
+
+Parser performance may matter for stream-heavy programs. Benchmarks should run
+on stable machines before drawing hard conclusions; Termux phone runs are good
+smoke tests but not authoritative performance data.
+
+Compiled parser code size may be noticeable in small generated programs.
+Targets should include it only when runtime parsing predicates are reachable or
+when the user requests a runtime parser explicitly.
+
+Operator table shape differs by target runtime. The parser contract should stay
+data-oriented so each target can adapt its native table into the canonical
+`op(Name, Prec, Type)` list without exposing target internals.

--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_PHILOSOPHY.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_PHILOSOPHY.md
@@ -1,0 +1,77 @@
+# Runtime Parser Transpilation Philosophy
+
+UnifyWeaver has two parser problems that should stay separate:
+
+- build-time WAM item parsing, where the generator currently may emit WAM
+  text and parse it back into structured instruction items;
+- runtime Prolog term parsing, where a generated target program must turn
+  source text back into Prolog terms while it is running.
+
+PR #2086 addresses the first problem. Runtime parser transpilation addresses
+the second one.
+
+The R target already demonstrates why the runtime parser matters. Its
+`read/2`, `read_term_from_atom/2,3`, reverse `term_to_atom/2`, and CLI argument
+parsing all need an operator-aware Prolog term parser in the generated runtime.
+`read/2` is the clearest example: a stream reader cannot just read one line or
+split on a period. It must keep accumulating text until the buffer ends with a
+dotted term and the parser accepts the term before the trailing dot. That is a
+runtime behavior, not a generator-time convenience.
+
+## Direction
+
+The canonical runtime parser should live in portable Prolog and be compiled
+into target runtimes when a target needs source-term input. The current source
+for that role is:
+
+```text
+src/unifyweaver/core/prolog_term_parser.pl
+```
+
+Keeping the parser in portable Prolog gives us one parser specification, one
+test surface, and one place to harden operator semantics. Targets may keep a
+temporary native parser while the transpiled parser matures, but target-local
+parsers should be treated as bridges rather than as independent semantic
+sources.
+
+## Why Transpile The Parser
+
+Runtime parsing needs target-local term values, variables, lists, compounds,
+and operator tables. Reimplementing that logic per target creates drift:
+variable sharing, anonymous variables, prefix and infix precedence, runtime
+`op/3`, and stream-read completion rules all become subtly target-specific.
+
+A transpiled parser keeps these semantics under the same compiler and runtime
+contract as ordinary user code. It also tests an important ability: generated
+targets should be able to host non-trivial Prolog library code, not just user
+predicates selected by a benchmark.
+
+## Design Constraints
+
+The parser should remain pure with respect to operator state. Targets own their
+runtime operator table, including mutations from `op/3`; the parser receives a
+snapshot of that table as data.
+
+The parser must preserve source variable identity within one parse. Repeated
+variable names share one logic variable; `_` remains anonymous.
+
+The parser should fail cleanly on invalid input. Higher-level predicates decide
+whether failure becomes predicate failure, EOF handling, or a target-specific
+error.
+
+The parser should stay in the cross-target-compilable subset. If the parser
+requires stronger WAM behavior, such as correct cut-barrier semantics, that is
+a runtime correctness requirement rather than a reason to fork the parser.
+
+## Non-Goals
+
+This work is not the shared WAM items API. It does not replace the Prolog-side
+WAM text parser used by target generators.
+
+This work is not a full source-program parser. The first goal is term parsing
+for runtime predicates such as `read/2` and `read_term_from_atom/2,3`, not full
+module loading, comments, source layout preservation, or complete
+`read_term/3` option handling.
+
+This work does not require every target to adopt the transpiled parser at once.
+R is the reference consumer because it already needed the runtime behavior.

--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
@@ -1,0 +1,118 @@
+# Runtime Parser Transpilation Specification
+
+This document defines the target-runtime contract for parsing Prolog terms from
+text. It is separate from the build-time WAM items parser used by target
+generators.
+
+## Canonical Source
+
+The portable parser source is:
+
+```text
+src/unifyweaver/core/prolog_term_parser.pl
+```
+
+Its public predicates are:
+
+```prolog
+parse_term_from_codes(+Codes, +OpTable, -Term).
+parse_term_from_atom(+Atom, +OpTable, -Term).
+canonical_op_table(-OpTable).
+```
+
+`OpTable` is a list of `op(Name, Prec, Type)` terms, where `Type` is one of
+`xfx`, `xfy`, `yfx`, `fx`, `fy`, `xf`, or `yf`.
+
+## Runtime Contract
+
+A target that enables runtime term parsing must provide a parser entry point
+that accepts text or character codes, an operator table snapshot, and returns a
+target-native Prolog term. Invalid input fails unless the calling predicate
+explicitly maps it to an error.
+
+The returned term must use the target runtime's ordinary term representation:
+atoms, integers, floats, compounds, lists, and logic variables must be values
+the rest of the WAM runtime can unify with. Variable names repeated in one parse
+must share one logic variable. `_` must produce a fresh anonymous variable for
+each occurrence.
+
+The parser must not own mutable operator state. Runtime predicates such as
+`op/3` and `current_op/3` belong to the target runtime. Before a parse, the
+runtime passes the parser a snapshot derived from its current table.
+
+## Required Consumers
+
+Targets that expose the corresponding predicates should route these operations
+through the runtime parser:
+
+- `read_term_from_atom/2`
+- `read_term_from_atom/3`
+- `term_to_atom/2` in reverse mode
+- `read/2`
+
+Targets may also use the same parser for CLI argument decoding, REPL input, or
+runtime data-file ingestion.
+
+## Stream Read Semantics
+
+`read/2` must read from a target stream until it can parse one complete dotted
+term. The R target is the current reference behavior:
+
+- accumulate source text across lines;
+- only attempt completion when the trimmed buffer ends with `.`;
+- parse the buffer without the trailing `.`;
+- if parsing fails, continue reading because the dot may be inside a quoted
+  atom, string, or incomplete compound;
+- EOF on an empty buffer binds `end_of_file`;
+- EOF on a non-empty buffer makes one final parse attempt.
+
+The parser itself does not own stream state. It only answers whether the current
+source buffer is a valid term.
+
+## Operator Semantics
+
+The initial table should come from `canonical_op_table/1` or an equivalent
+target seed table. Runtime `op/3` declarations mutate the target's table, and
+later parses must observe the new table.
+
+Compile-time target options may seed additional operators before user input is
+parsed. In WAM-R this role is served by `r_op_decls(...)`, which emits runtime
+operator table initialization before CLI parsing.
+
+The current parser intentionally matches the R Pratt-style parser. It supports
+standard prefix, infix, and postfix operators, but treats `fx`/`fy` and
+`xf`/`yf` the same at chained prefix/postfix sites. This compatibility note
+should remain visible until stricter ISO distinctions are implemented.
+
+## Target Status
+
+R is the reference target because it already has runtime consumers:
+`read/2`, `read_term_from_atom/2,3`, reverse `term_to_atom/2`, and CLI parsing.
+The R target currently has an inline parser in `runtime.R.mustache`, while
+`prolog_term_parser.pl` compiles structurally to WAM-R.
+
+The structural guard is:
+
+```text
+tests/test_prolog_term_parser_wam_r_compile.pl
+```
+
+Full replacement of the inline R parser is blocked by WAM-R cut-barrier
+semantics. The parser source relies on cuts in multi-clause helper predicates;
+the WAM-R runtime currently drops only the most recent choice point in cases
+where a proper cut barrier is needed. Once that runtime issue is fixed, the
+compiled parser should be compared against the inline parser and then used as
+the canonical R runtime parser.
+
+## Test Requirements
+
+Runtime parser changes should be covered at three levels:
+
+- SWI tests for `prolog_term_parser.pl` itself;
+- target compile tests proving the parser source lowers into the target;
+- target runtime tests through real predicates such as `read/2` and
+  `read_term_from_atom/2,3`.
+
+For R, existing runtime coverage lives in `tests/test_wam_r_generator.pl`, and
+parser performance/equivalence work is tracked by
+`tests/benchmarks/wam_r_parser_bench.pl`.


### PR DESCRIPTION
## Summary

Adds design documentation for runtime Prolog term parser transpilation, using the R target as the reference consumer.

The docs distinguish this work from the shared WAM items API: WAM items parsing is build-time compiler plumbing, while runtime parser transpilation is for generated programs that need to parse Prolog terms while running.

## Details

- Defines the philosophy for keeping a canonical runtime term parser in portable Prolog.
- Specifies the runtime parser contract for `read/2`, `read_term_from_atom/2,3`, reverse `term_to_atom/2`, CLI parsing, operator tables, variables, lists, and stream completion.
- Lays out an implementation plan that keeps R as the reference target, preserves the inline R parser as an oracle for now, and identifies WAM-R cut-barrier semantics as the blocker before swapping to the compiled parser.

## Verification

- `git diff --check HEAD`

## Notes

This is documentation-only. It does not change target runtime behavior.
