### PR TITLE
feat(wam-cpp): bare (Cond -> Then) goal-terms (no Else clause)

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -1654,21 +1654,24 @@ struct DisjFrame {
     std::size_t after_pc = 0;
 };
 
-// Frame for an if-then-else goal (;(->( Cond, Then), Else)) dispatched
-// as a goal-term. invoke_goal_as_call pushes an IfThenFrame and a
+// Frame for an if-then-else goal (;(->( Cond, Then), Else)) or a
+// bare if-then (->(Cond, Then) with no enclosing ;) dispatched as a
+// goal-term. invoke_goal_as_call pushes an IfThenFrame and a
 // ChoicePoint with alt_pc = if_then_else_pc, then dispatches Cond
 // with cp = if_then_commit_pc.
 //
 //   - Cond succeeds  → IfThenCommit fires: cut CPs back to
-//                       cp_count_at_entry (so Cond can''t backtrack-
+//                       base_cp_count (so Cond can''t backtrack-
 //                       retry), pop the frame, dispatch Then with
 //                       the original after_pc.
 //   - Cond fails     → backtrack drains to our CP, lands on
 //                       if_then_else_pc: pop the frame, dispatch
-//                       Else with after_pc.
+//                       Else with after_pc. For bare if-then (no
+//                       Else clause), else_goal is null and the
+//                       op propagates failure.
 struct IfThenFrame {
     CellPtr     then_goal;
-    CellPtr     else_goal;
+    CellPtr     else_goal;            // null for bare (Cond -> Then)
     std::size_t after_pc = 0;
     std::size_t base_cp_count = 0;   // CP-stack depth BEFORE we
                                      // pushed the if-then-else CP
@@ -3222,11 +3225,14 @@ bool WamState::step(const Instruction& instr) {
             // Reached when Cond failed and backtrack landed at our
             // CP''s alt_pc. Pop the CP (trust_me-style — once-only,
             // same as DisjAlt) and the matching IfThenFrame, then
-            // dispatch Else with the original after_pc.
+            // dispatch Else with the original after_pc. For bare
+            // (Cond -> Then) goal-terms (no Else clause), else_goal
+            // is null — propagate failure instead.
             if (!choice_points.empty()) choice_points.pop_back();
             if (if_then_frames.empty()) return false;
             IfThenFrame f = std::move(if_then_frames.back());
             if_then_frames.pop_back();
+            if (!f.else_goal) return false;
             return invoke_goal_as_call(f.else_goal, f.after_pc);
         }
         case Instruction::Op::Proceed: {
@@ -3573,6 +3579,29 @@ bool WamState::invoke_goal_as_call(CellPtr goal_cell, std::size_t after_pc) {
             f.base_cp_count = choice_points.size();
             conj_frames.push_back(std::move(f));
             return invoke_goal_as_call(g.args[0], conj_return_pc);
+        }
+        // Bare if-then `(Cond -> Then)` as a goal-term (no ;
+        // wrapper, so there''s no Else branch). Same machinery as
+        // if-then-else but with else_goal = nullptr — Cond failure
+        // propagates as failure of the whole construct.
+        if (key == "->/2" && g.args.size() == 2) {
+            IfThenFrame itf;
+            itf.then_goal     = g.args[1];
+            // else_goal stays null — IfThenElse propagates failure
+            // when it sees a null else slot.
+            itf.after_pc      = after_pc;
+            itf.base_cp_count = choice_points.size();
+            if_then_frames.push_back(std::move(itf));
+            ChoicePoint cp_;
+            cp_.alt_pc            = if_then_else_pc;
+            cp_.saved_cp          = cp;
+            cp_.trail_mark        = trail.size();
+            cp_.cut_barrier       = cut_barrier;
+            cp_.saved_regs        = regs;
+            cp_.saved_mode_stack  = mode_stack;
+            cp_.saved_env_stack   = env_stack;
+            choice_points.push_back(std::move(cp_));
+            return invoke_goal_as_call(g.args[0], if_then_commit_pc);
         }
         // Disjunction goal-term — two flavours, both shaped ;/2.
         // First check for the if-then-else special case

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -547,6 +547,41 @@ user:wam_cpp_test_ite_cut_commits_cond :-
     call((member(X, [1, 2, 3]) -> Y = X ; Y = none)),
     Y = 1.
 
+% Bare if-then goal-terms `(Cond -> Then)` — no Else. The WAM
+% compiler builds them as `->/2` at the top level (not wrapped in
+% ;/2). On Cond failure the whole construct fails. On Cond success
+% Cond''s CPs are cut and Then runs.
+:- dynamic user:wam_cpp_test_bif_then_runs/0.
+:- dynamic user:wam_cpp_test_bif_cond_fail_propagates/0.
+:- dynamic user:wam_cpp_test_bif_inside_catch/0.
+:- dynamic user:wam_cpp_test_bif_not_when_cond_fails/0.
+:- dynamic user:wam_cpp_test_bif_cut_commits/0.
+
+% Cond succeeds → Then runs.
+user:wam_cpp_test_bif_then_runs :-
+    call((true -> X = 1)),
+    X = 1.
+
+% Cond fails → bare-if-then fails → outer if-then-else takes Else.
+user:wam_cpp_test_bif_cond_fail_propagates :-
+    (call((fail -> _Y = 1)) -> false ; true).
+
+% Inside catch — Cond=true succeeds, Then binds X=7, catch passes
+% through with no throw.
+user:wam_cpp_test_bif_inside_catch :-
+    catch((true -> X = 7), _, fail),
+    X = 7.
+
+% \+ (Cond fails → bif fails) → \+ succeeds.
+user:wam_cpp_test_bif_not_when_cond_fails :-
+    \+ call((fail -> _Y = 1)).
+
+% Cut: Cond uses member/2 with 3 solutions. After committing to
+% X=1, no backtrack to X=2/X=3.
+user:wam_cpp_test_bif_cut_commits :-
+    call((member(X, [1, 2, 3]) -> Y = X)),
+    Y = 1.
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -2446,6 +2481,86 @@ test(cpp_e2e_ite_cut_commits_cond,
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath,
                     'wam_cpp_test_ite_cut_commits_cond/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% Bare (Cond -> Then) goal-terms — no Else. The WAM compiler builds
+% these as ->/2 at the top level (not wrapped in ;/2). Reuses the
+% IfThenFrame machinery with else_goal = null; on Cond failure the
+% IfThenElse op propagates failure instead of dispatching Else.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_bif_then_runs, [condition(cpp_compiler_available)]) :-
+    % Cond=true → IfThenCommit → Then runs.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_bif_then', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_bif_then_runs/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_bif_then_runs/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_bif_cond_fail_propagates,
+     [condition(cpp_compiler_available)]) :-
+    % Cond=fail → IfThenElse fires; else_goal is null → propagate
+    % failure. Wrapped in if-then-else so the outer test succeeds
+    % via the else branch.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_bif_fail', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_bif_cond_fail_propagates/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_bif_cond_fail_propagates/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_bif_inside_catch,
+     [condition(cpp_compiler_available)]) :-
+    % Bare (Cond -> Then) inside catch — the catch protected goal
+    % is a ->/2 term, dispatched via invoke_goal_as_call.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_bif_catch', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_bif_inside_catch/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_bif_inside_catch/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_bif_not_when_cond_fails,
+     [condition(cpp_compiler_available)]) :-
+    % \+ (bif with Cond=fail). The bif fails → \+ succeeds.
+    % Tests that bare-if-then''s failure propagates correctly
+    % through the negation layer.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_bif_not', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_bif_not_when_cond_fails/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_bif_not_when_cond_fails/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_bif_cut_commits,
+     [condition(cpp_compiler_available)]) :-
+    % Cut semantics for bare-if-then. member/2 in Cond has 3
+    % solutions; we commit to X=1 and don''t retry. Verifies
+    % IfThenCommit''s CP-trimming applies to the bare form too.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_bif_cut', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_bif_cut_commits/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_bif_cut_commits/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Completes the if-then-else picture from PR #2105. The WAM compiler builds bare `(Cond -> Then)` (no surrounding `;`) as a `->/2` compound at the **top level**, NOT wrapped in `;/2`. The previous handler only triggered when `->/2` was the first arg of `;/2`, so bare-if-then in a goal-term position (catch, call, `\+`) fell through to the unknown-functor builtin fallback and silently failed.

## Design — reuses `IfThenFrame` with `else_goal = null`

When `invoke_goal_as_call` sees a `->/2` compound at the top:

1. Pushes an `IfThenFrame` with `then_goal = arg2`, `else_goal = null`, `after_pc`, `base_cp_count`.
2. Pushes a ChoicePoint with `alt_pc = if_then_else_pc`.
3. Dispatches Cond with `cp = if_then_commit_pc`.

| Outcome | What happens |
|---|---|
| **Cond succeeds** | `IfThenCommit` (unchanged): cut CPs back to `base_cp_count`, pop frame, dispatch Then |
| **Cond fails** | `IfThenElse` checks `else_goal` — null → propagate failure (return false). `backtrack()` then continues popping more CPs |

Single-file change to runtime: extend the existing `->/2` detection in `invoke_goal_as_call` to handle the bare form, and add the null-else branch to the `IfThenElse` step arm.

## Tests — 5 new e2e tests

| Test | Coverage |
|---|---|
| `cpp_e2e_bif_then_runs` | Cond=true → Then runs |
| `cpp_e2e_bif_cond_fail_propagates` | Cond=fail → bif fails; outer if-then-else takes else. **Regression guard for the null-else-goal propagation** |
| `cpp_e2e_bif_inside_catch` | bif inside catch |
| `cpp_e2e_bif_not_when_cond_fails` | `\+ (bif with Cond=fail) → \+ succeeds` (failure propagates through negation) |
| `cpp_e2e_bif_cut_commits` | `call((member(X,[1,2,3]) -> Y = X)), Y = 1`. Cut commits Cond's first solution |

**Total: 128/128 passing** (was 123; +5 new).

## Verification

```
$ swipl -g "[tests/test_wam_cpp_generator], run_tests(wam_cpp_generator)" -t halt
% All 128 tests passed
```

## Where this fits

After this PR, `invoke_goal_as_call` handles the **complete Prolog control-flow term zoo**:

| Form | Handler |
|---|---|
| Atoms (`true`/`fail`/`false`/name) | Direct dispatch |
| User predicates | Label lookup |
| `catch/3` | `execute_catch` |
| `throw/1` | `execute_throw` |
| `\+/1`, `not/1` | `execute_negation` |
| `findall/3` | `dispatch_findall_call` |
| `bagof/3`, `setof/3` | `dispatch_aggregate_call` |
| `^/2` | Transparent |
| `,/2` | `ConjFrame` + `ConjReturn` |
| `;/2` (plain) | `DisjFrame` + paired CP + `DisjAlt` |
| `;(->(C, T), E)` | `IfThenFrame` + paired CP + `IfThenCommit`/`IfThenElse` |
| **`->/2` (bare)** | Same `IfThenFrame` with `else_goal = null` |

## Test plan

- [x] All 123 prior tests still pass (no regression)
- [x] 5 new e2e tests pass covering Then-runs, Cond-fail-propagates, inside-catch, `\+`-when-fails, cut-commits paths
- [x] `g++ -std=c++17` clean compile
- [x] Reuses existing IfThenFrame infrastructure — minimal new code
- [ ] Follow-up: full bagof/setof grouping semantics (currently `^/2` is just transparent)
- [ ] Follow-up: Items-API Phase 2 (start migrating other targets to `wam_text_parser`)

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_