### PR TITLE
feat(wam-cpp): bagof/setof witness grouping for meta-call dispatch

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -1364,6 +1364,7 @@ compile_wam_runtime_header_to_cpp(_Options,
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -1593,6 +1594,17 @@ struct AggregateFrame {
     std::vector<ModeFrame> saved_mode_stack;
     std::vector<EnvFrame> saved_env_stack;
     std::vector<Value> acc;
+    // Witness vars for bagof/setof grouping. Populated by
+    // dispatch_aggregate_call from a walk of the goal-term (vars
+    // present in Goal but NOT in Template and NOT under ^/2). When
+    // empty, the aggregate behaves as findall (single flat group).
+    // When non-empty, acc_witnesses[i] is the witness snapshot
+    // parallel to acc[i]; finalise groups acc by witness equality
+    // and binds the result for the first group, with the witness
+    // vars also bound. Backtracking through additional groups is
+    // not yet supported (deferred follow-up).
+    std::vector<CellPtr> witness_cells;
+    std::vector<std::vector<Value>> acc_witnesses;
 };
 
 // Catcher frame opened by catch/3. Sits on a side stack (not the
@@ -1796,6 +1808,15 @@ struct WamState {
     // sorts + dedup''s + fails on empty (setof).
     bool    dispatch_aggregate_call(const std::string& kind,
                                     std::size_t after_pc);
+    // Walk a goal term collecting unbound-variable cells, ignoring
+    // any cells reachable through the LHS of a ^/2 binder (those
+    // are existentially quantified). Used by dispatch_aggregate_call
+    // to determine grouping witnesses for bagof/setof — see the
+    // AggregateFrame::witness_cells doc.
+    void    collect_goal_witnesses(CellPtr goal,
+                                   const std::set<Cell*>& exclude,
+                                   std::vector<CellPtr>& out,
+                                   std::set<Cell*>& seen) const;
     bool    execute_catch();
     bool    execute_throw();
 
@@ -3183,6 +3204,17 @@ bool WamState::step(const Instruction& instr) {
                 : get_cell(f.value_reg);
             if (!value_cell) return false;
             f.acc.push_back(deep_copy(*value_cell));
+            // For bagof/setof: also snapshot the current witness
+            // values (parallel to acc) so finalise can group by
+            // witness binding.
+            if (!f.witness_cells.empty()) {
+                std::vector<Value> witness_snap;
+                witness_snap.reserve(f.witness_cells.size());
+                for (auto& wc : f.witness_cells) {
+                    witness_snap.push_back(deep_copy(*wc));
+                }
+                f.acc_witnesses.push_back(std::move(witness_snap));
+            }
             return false;
         }
         case Instruction::Op::ConjReturn: {
@@ -3774,14 +3806,13 @@ bool WamState::dispatch_aggregate_call(const std::string& kind,
     // emitted as plain calls). kind selects finalize_aggregate''s
     // behaviour:
     //   "collect" — findall semantics (list, empty on no solutions).
-    //   "bagof"   — list, FAILS on no solutions.
-    //   "setof"   — sorted + dedup''d list, FAILS on no solutions.
+    //   "bagof"   — list, FAILS on no solutions, GROUPS by witness.
+    //   "setof"   — like bagof but sort+dedup within each group.
     //
-    // Snapshot Template''s cell as value_cell and List''s cell as
-    // result_cell — A1/A3 will get clobbered when we dispatch the
-    // goal in A2 via invoke_goal_as_call (it sets A-registers
-    // from the goal''s args). The synthetic FindallCollect op
-    // reads the value through these stored CellPtrs.
+    // For bagof/setof: walk Goal to find free witnesses (unbound
+    // vars that aren''t in Template and aren''t under ^/2). Witness
+    // values are snapshotted alongside each acc[i] for group
+    // partitioning at finalise time.
     AggregateFrame frame;
     frame.agg_kind          = kind;
     frame.value_cell        = get_cell("A1");
@@ -3796,9 +3827,64 @@ bool WamState::dispatch_aggregate_call(const std::string& kind,
     frame.saved_regs        = regs;
     frame.saved_mode_stack  = mode_stack;
     frame.saved_env_stack   = env_stack;
+    if (kind == "bagof" || kind == "setof") {
+        // Build the "vars in Template" exclude set, then walk Goal
+        // to find witness cells (skipping anything in the exclude
+        // set or reachable only via the LHS of ^/2). The result
+        // order is deterministic (DFS over the goal tree).
+        std::set<Cell*> exclude;
+        std::set<Cell*> seen_in_template;
+        std::vector<CellPtr> tmpl_vars_unused;
+        collect_goal_witnesses(get_cell("A1"), exclude,
+                               tmpl_vars_unused, seen_in_template);
+        for (auto& c : tmpl_vars_unused) exclude.insert(c.get());
+        std::set<Cell*> seen;
+        collect_goal_witnesses(get_cell("A2"), exclude,
+                               frame.witness_cells, seen);
+    }
     aggregate_frames.push_back(std::move(frame));
     CellPtr goal = get_cell("A2");
     return invoke_goal_as_call(goal, findall_collect_pc);
+}
+
+void WamState::collect_goal_witnesses(CellPtr goal,
+                                      const std::set<Cell*>& exclude,
+                                      std::vector<CellPtr>& out,
+                                      std::set<Cell*>& seen) const {
+    if (!goal) return;
+    // Use the DEREF''d underlying cell for identity (so var-chains
+    // collapse to one address).
+    Value v = deref(*goal);
+    Cell* key = goal.get();
+    // Re-deref via the trail: if goal is bound, follow the chain.
+    // For our purposes the cell-identity of goal''s direct pointer
+    // suffices, since unbound vars always point to themselves in
+    // this runtime''s cell model.
+    if (v.tag == Value::Tag::Unbound || v.tag == Value::Tag::Uninit) {
+        if (seen.count(key)) return;
+        seen.insert(key);
+        if (exclude.count(key)) return;
+        out.push_back(goal);
+        return;
+    }
+    if (v.tag == Value::Tag::Compound) {
+        // ^/2 binder: skip the LHS (existentially quantified vars),
+        // recurse into the RHS only.
+        if (v.s == "^/2" && v.args.size() == 2) {
+            // Collect LHS vars into a local exclude set merged with
+            // the caller''s, then walk only the RHS.
+            std::set<Cell*> exclude2 = exclude;
+            std::set<Cell*> lhs_seen;
+            std::vector<CellPtr> lhs_vars;
+            collect_goal_witnesses(v.args[0], exclude, lhs_vars, lhs_seen);
+            for (auto& c : lhs_vars) exclude2.insert(c.get());
+            collect_goal_witnesses(v.args[1], exclude2, out, seen);
+            return;
+        }
+        for (auto& arg : v.args) {
+            collect_goal_witnesses(arg, exclude, out, seen);
+        }
+    }
 }
 
 // catch(Goal, Catcher, Recovery): push a CatcherFrame snapshotting
@@ -4080,11 +4166,45 @@ bool WamState::backtrack() {
             env_stack   = std::move(f.saved_env_stack);
             cp          = f.saved_cp;
             cut_barrier = f.saved_cut_barrier;
+            // For bagof/setof with free witnesses, narrow acc to the
+            // first group (matching first acc_witnesses[0]) and bind
+            // the witness cells to that group''s witness values.
+            // Other groups are silently dropped — full backtracking
+            // through groups is a planned follow-up. acc.empty()
+            // remains a failure signal handled by finalize_aggregate.
+            std::vector<Value> grouped_acc = f.acc;
+            if (!f.witness_cells.empty() && !f.acc_witnesses.empty()
+                && f.acc.size() == f.acc_witnesses.size())
+            {
+                const std::vector<Value>& first_w = f.acc_witnesses[0];
+                grouped_acc.clear();
+                for (std::size_t i = 0; i < f.acc.size(); ++i) {
+                    bool same = (f.acc_witnesses[i].size() == first_w.size());
+                    for (std::size_t k = 0; same && k < first_w.size(); ++k) {
+                        if (!(f.acc_witnesses[i][k] == first_w[k])) same = false;
+                    }
+                    if (same) grouped_acc.push_back(f.acc[i]);
+                }
+                // Bind witness cells to first_w''s values (so the
+                // caller sees the bindings the group corresponds to).
+                for (std::size_t k = 0; k < f.witness_cells.size()
+                         && k < first_w.size(); ++k) {
+                    CellPtr wc = f.witness_cells[k];
+                    if (!wc) continue;
+                    if (wc->is_unbound()) bind_cell(wc, first_w[k]);
+                    else if (!(*wc == first_w[k])) {
+                        // Witness already bound to something else —
+                        // signal failure.
+                        grouped_acc.clear();
+                        break;
+                    }
+                }
+            }
             // Build and bind the result. The meta-call findall/3
             // path stores the result cell directly (set by
             // dispatch_findall_call); the inlined BeginAggregate
             // path uses the result_reg name.
-            Value result = finalize_aggregate(f.agg_kind, f.acc);
+            Value result = finalize_aggregate(f.agg_kind, grouped_acc);
             if (result.tag == Value::Tag::Uninit) {
                 // bagof/setof with empty acc → the aggregate
                 // FAILS (per ISO). Continue backtracking so any

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -582,6 +582,52 @@ user:wam_cpp_test_bif_cut_commits :-
     call((member(X, [1, 2, 3]) -> Y = X)),
     Y = 1.
 
+% bagof/setof witness grouping. The WAM compiler inlines the
+% OUTERMOST bagof/setof — there the goal is direct WAM, no term to
+% walk for witnesses, so it behaves findall-like. For meta-call
+% (non-inlined) dispatch, dispatch_aggregate_call walks the goal
+% term to find free witnesses (vars in goal NOT in template and
+% NOT under ^/2) and groups results by witness binding. First-
+% group binding only for v1; backtracking through additional
+% groups is a planned follow-up.
+:- dynamic user:wam_cpp_parent_fixture/2.
+:- dynamic user:wam_cpp_test_bagof_meta_groups_by_witness/0.
+:- dynamic user:wam_cpp_test_bagof_meta_existential_no_grouping/0.
+:- dynamic user:wam_cpp_test_setof_meta_groups_sorted/0.
+:- dynamic user:wam_cpp_test_bagof_inlined_flattens/0.
+
+user:wam_cpp_parent_fixture(tom, bob).
+user:wam_cpp_parent_fixture(tom, alice).
+user:wam_cpp_parent_fixture(jane, carol).
+
+% bagof via catch wrapper → meta-call dispatch → witness grouping.
+% P is a free witness; first group is P=tom → L=[bob,alice].
+% Verifies BOTH the result list AND the witness binding.
+user:wam_cpp_test_bagof_meta_groups_by_witness :-
+    catch(bagof(C, wam_cpp_parent_fixture(P, C), L), _, fail),
+    L = [bob, alice],
+    P = tom.
+
+% Same goal but with ^/2 existential: P is suppressed → no
+% witnesses → single flat group with all 3 children.
+user:wam_cpp_test_bagof_meta_existential_no_grouping :-
+    catch(bagof(C, P^wam_cpp_parent_fixture(P, C), L), _, fail),
+    L = [bob, alice, carol].
+
+% setof grouping — same witness logic as bagof but the group''s
+% template list is sorted + dedup''d.
+user:wam_cpp_test_setof_meta_groups_sorted :-
+    catch(setof(C, wam_cpp_parent_fixture(P, C), L), _, fail),
+    L = [alice, bob],
+    P = tom.
+
+% Inlined outer bagof — no witness collection (witness_cells
+% empty), so behaves like findall (all 3 children, no grouping).
+% Regression guard that the existing inlined path is untouched.
+user:wam_cpp_test_bagof_inlined_flattens :-
+    bagof(C, wam_cpp_parent_fixture(_P, C), L),
+    L = [bob, alice, carol].
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -2561,6 +2607,93 @@ test(cpp_e2e_bif_cut_commits,
                               [emit_main(true)], TmpDir),
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath, 'wam_cpp_test_bif_cut_commits/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% bagof/setof witness grouping. Meta-call dispatch walks the goal
+% term to find free witnesses (unbound vars in Goal that aren''t in
+% Template and aren''t under ^/2). Results are grouped by witness
+% binding; first group''s template list is bound to the result and
+% the witness cells are bound to that group''s witness values.
+% Backtracking through additional groups is a planned follow-up.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_bagof_meta_groups_by_witness,
+     [condition(cpp_compiler_available)]) :-
+    % The key test: bagof(C, parent(P, C), L) via meta-call
+    % dispatch. P is a free witness. First group is P=tom →
+    % L=[bob, alice]. Verifies BOTH the list shape AND that P
+    % gets bound to tom (witness binding back to caller).
+    unique_cpp_tmp_dir('tmp_cpp_e2e_bagof_grp', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_parent_fixture/2,
+             user:wam_cpp_test_bagof_meta_groups_by_witness/0],
+            [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_bagof_meta_groups_by_witness/0',
+                    [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_bagof_meta_existential_no_grouping,
+     [condition(cpp_compiler_available)]) :-
+    % ^/2 existentially quantifies P → no witnesses → all 3
+    % children flatten into one group.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_bagof_excl', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_parent_fixture/2,
+             user:wam_cpp_test_bagof_meta_existential_no_grouping/0],
+            [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_bagof_meta_existential_no_grouping/0',
+                    [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_setof_meta_groups_sorted,
+     [condition(cpp_compiler_available)]) :-
+    % setof: same witness grouping as bagof, but the per-group
+    % template list is sorted (and dedup''d via term_less).
+    unique_cpp_tmp_dir('tmp_cpp_e2e_setof_grp', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_parent_fixture/2,
+             user:wam_cpp_test_setof_meta_groups_sorted/0],
+            [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_setof_meta_groups_sorted/0',
+                    [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_bagof_inlined_flattens,
+     [condition(cpp_compiler_available)]) :-
+    % Inlined outer bagof — the WAM compiler emits direct
+    % BeginAggregate/EndAggregate, NOT a meta-call. Witness
+    % collection requires a goal-term to walk; for inlined there''s
+    % no term so witness_cells stays empty → no grouping (findall-
+    % like). Regression guard that the existing inlined path is
+    % untouched.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_bagof_inlined', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_parent_fixture/2,
+             user:wam_cpp_test_bagof_inlined_flattens/0],
+            [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_bagof_inlined_flattens/0',
+                    [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Adds proper ISO **witness grouping semantics** for `bagof/3` and `setof/3` when dispatched via the meta-call path (non-inlined occurrences such as nested aggregates or `catch(bagof(...), ...)`). Free witnesses in the goal — unbound vars NOT in the Template and NOT under `^/2` — now partition results into groups; the first group's template list is bound to the result and the witness cells are bound to that group's witness values.

**Backtracking through additional groups is a planned follow-up.** v1 binds the first group only, which is sufficient for the common single-group case and unblocks `findall(_, bagof(...), _)` style queries.

## Mechanism — three pieces

### 1. `AggregateFrame` grows witness tracking

- `witness_cells` (`vector<CellPtr>`): the free witness vars from the goal.
- `acc_witnesses` (`vector<vector<Value>>`): per-iteration witness snapshots, parallel to `acc`.

Populated by `dispatch_aggregate_call` for bagof/setof only; left empty for findall and for inlined aggregates (which don't have a goal-term to walk).

### 2. `collect_goal_witnesses/4` — recursive goal-tree walk

- Unbound cells go into `out` (deduplicated by cell pointer).
- Cells in `exclude` are skipped (used to remove Template's vars).
- **`^/2` binders**: LHS vars are added to a local exclude set; only the RHS is walked.

`dispatch_aggregate_call` calls this twice — once on Template (its result becomes the exclude set), then on Goal to find the actual witnesses.

### 3. Finalise narrows to first group

`FindallCollect` snapshots witness values via `deep_copy` parallel to the template. The aggregate-finalise path then narrows `acc` to entries matching `acc_witnesses[0]` (first-group filter) and binds `witness_cells` to that group's values. Mismatches with already-bound witnesses abort to empty acc (triggering the standard bagof/setof empty-fails path).

## Tests — 4 new e2e tests + 1 fixture (`parent/2`)

| Test | Coverage |
|---|---|
| `cpp_e2e_bagof_meta_groups_by_witness` | **The key test**: `catch(bagof(C, parent(P, C), L), _, fail)`. First group `P=tom → L=[bob, alice]`. Verifies both list AND witness binding back to caller |
| `cpp_e2e_bagof_meta_existential_no_grouping` | `bagof(C, P^parent(P, C), L)`. `^/2` quantifies P → no witnesses → flat group with all 3 children |
| `cpp_e2e_setof_meta_groups_sorted` | `setof` same grouping as bagof but per-group list is sorted+dedup'd via `term_less` |
| `cpp_e2e_bagof_inlined_flattens` | Inlined outer bagof has no goal term to walk → `witness_cells` empty → findall-like flattening. Regression guard for the inlined path |

**Total: 132/132 passing** (was 128; +4 new).

## Verification

```
$ swipl -g "[tests/test_wam_cpp_generator], run_tests(wam_cpp_generator)" -t halt
% All 132 tests passed
```

Sample:

```prolog
?- catch(bagof(C, parent(P, C), L), _, fail).
L = [bob, alice], P = tom.        % first group bound

?- catch(bagof(C, P^parent(P, C), L), _, fail).
L = [bob, alice, carol].          % P existentially → flat
```

## Known limitations / planned follow-ups

- **Inlined outer bagof/setof** has no goal term to walk, so witness grouping doesn't fire there. Workaround: wrap in `catch` or `call` to force meta-call dispatch. Proper fix would require the WAM compiler to emit witness info alongside `BeginAggregate`.
- **Only the first group** is bound. Backtracking through additional witness groups (e.g. `P=jane → [carol]` after `P=tom → [bob, alice]`) needs a synthetic next-group op + CP machinery at finalise time. The infrastructure (witness_cells / acc_witnesses) is already in place; just needs CP push + advance logic.

## Test plan

- [x] All 128 prior tests still pass (no regression)
- [x] 4 new e2e tests pass covering witness grouping, `^/2` suppression, setof sort, inlined regression guard
- [x] `g++ -std=c++17` clean compile
- [x] Witness binding flows back to caller (verified by `P = tom` assertion)
- [ ] Follow-up: backtracking through groups (next-group CP machinery)
- [ ] Follow-up: WAM-compiler emission of witness info for inlined aggregates
- [ ] Follow-up: Items-API Phase 2 (start migrating other targets to `wam_text_parser`)

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_