### PR TITLE
feat(wam-clojure): add sort/2 builtin

### DIFF
--- a/PR_WAM_CLOJURE_SORT_BUILTIN.md
+++ b/PR_WAM_CLOJURE_SORT_BUILTIN.md
@@ -1,0 +1,26 @@
+# PR Title
+
+feat(wam-clojure): add sort/2 builtin
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM support for `sort/2`.
+- Reuses the existing `term-compare` ordering used by `@</2`, `@=</2`, `@>/2`, `@>=/2`, and `compare/3`.
+- Converts proper input lists to runtime items, sorts them, removes duplicate terms, rebuilds a WAM list, and unifies the output.
+- Fails cleanly for improper or unbound input lists.
+- Adds lowered-emitter and runtime smoke coverage.
+
+## Semantics
+
+`sort/2` accepts a proper list in the first argument and unifies the second argument with a duplicate-free list ordered by standard term order.
+
+The implementation is deterministic and does not enumerate list permutations. It inspects and sorts existing terms without binding variables in the input list.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -388,6 +388,10 @@ clojure_direct_builtin("append/3", "3").
 clojure_direct_builtin("append/3", 3).
 clojure_direct_builtin('append/3', "3").
 clojure_direct_builtin('append/3', 3).
+clojure_direct_builtin("sort/2", "2").
+clojure_direct_builtin("sort/2", 2).
+clojure_direct_builtin('sort/2', "2").
+clojure_direct_builtin('sort/2', 2).
 clojure_direct_builtin("copy_term/2", "2").
 clojure_direct_builtin("copy_term/2", 2).
 clojure_direct_builtin('copy_term/2', "2").
@@ -653,6 +657,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr),
            '(let [left (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) right (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound)) out (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A3") ::lowered-unbound))] (runtime/apply-append-solution ~w (inc (:pc ~w)) left right out))',
            [S, S, S, S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "sort/2" ; Op == 'sort/2'),
+    !,
+    format(atom(Expr), '(runtime/apply-sort-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "copy_term/2" ; Op == 'copy_term/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -748,6 +748,29 @@
                                       (append-split-results base-state out-items))
         (backtrack base-state)))))
 
+(defn sorted-unique-terms [state items]
+  (reduce (fn [out item]
+            (if (and (seq out)
+                     (zero? (term-compare state (peek out) item)))
+              out
+              (conj out item)))
+          []
+          (sort #(term-compare state %1 %2) items)))
+
+(defn apply-sort-solution [state]
+  (let [list-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A2") ::unbound))]
+    (if-let [items (proper-list-items state list-value)]
+      (let [sorted-term (list->term (:intern-context state)
+                                    (sorted-unique-terms state items))
+            [ok next-state] (unify-values state out sorted-term)]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+      (backtrack state))))
+
 (defn ground-term? [state value]
   (let [bindings (:bindings state)]
     (letfn [(ground* [term seen]
@@ -1497,6 +1520,9 @@
                 out (deref-value (:bindings state)
                                  (or (reg-get-raw state "A3") ::unbound))]
             (apply-append-solution state (inc (:pc state)) left right out))
+
+          "sort/2"
+          (apply-sort-solution state)
 
           "copy_term/2"
           (apply-copy-term-solution state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -550,6 +550,15 @@ test(simple_builtin_append_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_sort_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_sort/2:\nbuiltin_call sort/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_sort/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_sort/2, WamCode, [], Code),
+        has(Code, "runtime/apply-sort-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_copy_term_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_copy_term/2:\nbuiltin_call copy_term/2, 2\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -84,6 +84,9 @@
 :- dynamic user:wam_append_bad_left/1.
 :- dynamic user:wam_append_unbound_left/1.
 :- dynamic user:wam_append_split/2.
+:- dynamic user:wam_sort_guard/2.
+:- dynamic user:wam_sort_bad_list/1.
+:- dynamic user:wam_sort_unbound_list/1.
 :- dynamic user:wam_copy_term_guard/2.
 :- dynamic user:wam_copy_term_sharing_fail/0.
 :- dynamic user:wam_copy_term_independent_ok/0.
@@ -206,6 +209,9 @@ user:wam_append_guard(A, B, C) :- append(A, B, C).
 user:wam_append_bad_left(C) :- append([a|b], [c], C).
 user:wam_append_unbound_left(C) :- user:wam_unbound_arg(A), append(A, [b], C).
 user:wam_append_split(A, B) :- append(A, B, [a,b,c]).
+user:wam_sort_guard(L, S) :- sort(L, S).
+user:wam_sort_bad_list(S) :- sort([a|b], S).
+user:wam_sort_unbound_list(S) :- user:wam_unbound_arg(L), sort(L, S).
 user:wam_copy_term_guard(A, B) :- copy_term(A, B).
 user:wam_copy_term_sharing_fail :- user:wam_unbound_arg(X), copy_term(f(X, X), f(a, b)).
 user:wam_copy_term_independent_ok :- copy_term(f(_, _), f(a, b)).
@@ -333,6 +339,9 @@ run_smoke :-
           user:wam_append_bad_left/1,
           user:wam_append_unbound_left/1,
           user:wam_append_split/2,
+          user:wam_sort_guard/2,
+          user:wam_sort_bad_list/1,
+          user:wam_sort_unbound_list/1,
           user:wam_copy_term_guard/2,
           user:wam_copy_term_sharing_fail/0,
           user:wam_copy_term_independent_ok/0,
@@ -403,6 +412,7 @@ run_smoke :-
     assert_lowered_length_builtin_emitted(TmpDir),
     assert_lowered_member_builtin_emitted(TmpDir),
     assert_lowered_append_builtin_emitted(TmpDir),
+    assert_lowered_sort_builtin_emitted(TmpDir),
     assert_lowered_copy_term_builtin_emitted(TmpDir),
     assert_lowered_functor_builtin_emitted(TmpDir),
     assert_lowered_arg_builtin_emitted(TmpDir),
@@ -561,6 +571,11 @@ smoke_cases([
     case('wam_append_split/2', args('[a,b]', '[c]'), "true"),
     case('wam_append_split/2', args('[a,b,c]', '[]'), "true"),
     case('wam_append_split/2', args('[a]', '[c]'), "false"),
+    case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b,c]'), "true"),
+    case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b]'), "false"),
+    case('wam_sort_guard/2', args('[f(b),f(a),a]', '[a,f(a),f(b)]'), "true"),
+    case('wam_sort_bad_list/1', '[a,b,c]', "false"),
+    case('wam_sort_unbound_list/1', '[a,b,c]', "false"),
     case('wam_copy_term_guard/2', args(a, a), "true"),
     case('wam_copy_term_guard/2', args(a, b), "false"),
     case('wam_copy_term_guard/2', args('f(a)', 'f(a)'), "true"),
@@ -799,6 +814,14 @@ assert_lowered_append_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-append-unbound-left-1"),
     has(CoreCode, "defn lowered-wam-append-split-2"),
     has(CoreCode, "runtime/apply-append-solution").
+
+assert_lowered_sort_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-sort-guard-2"),
+    has(CoreCode, "defn lowered-wam-sort-bad-list-1"),
+    has(CoreCode, "defn lowered-wam-sort-unbound-list-1"),
+    has(CoreCode, "runtime/apply-sort-solution").
 
 assert_lowered_copy_term_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
@@ -1042,6 +1065,9 @@ prolog_term_string_to_edn('[b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"b\
 prolog_term_string_to_edn('[c]', "{:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}") :- !.
 prolog_term_string_to_edn('[a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[a,b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn('[b,a,a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
+prolog_term_string_to_edn('[f(b),f(a),a]', "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn('[a,f(a),f(b)]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[a|b]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"b\"]}") :- !.
 prolog_term_string_to_edn("f(a)", "{:tag :struct :functor \"f/1\" :args [\"a\"]}") :- !.
 prolog_term_string_to_edn("f(a,b)", "{:tag :struct :functor \"f/2\" :args [\"a\" \"b\"]}") :- !.
@@ -1054,6 +1080,9 @@ prolog_term_string_to_edn("[b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"b\
 prolog_term_string_to_edn("[c]", "{:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}") :- !.
 prolog_term_string_to_edn("[a,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[a,b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn("[b,a,a,c]", "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
+prolog_term_string_to_edn("[f(b),f(a),a]", "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn("[a,f(a),f(b)]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn(Atom, Atom).
 
 find_clojure_classpath(ClassPath) :-


### PR DESCRIPTION
## Summary

- Adds Clojure WAM support for `sort/2`.
- Reuses the existing `term-compare` ordering used by `@</2`, `@=</2`, `@>/2`, `@>=/2`, and `compare/3`.
- Converts proper input lists to runtime items, sorts them, removes duplicate terms, rebuilds a WAM list, and unifies the output.
- Fails cleanly for improper or unbound input lists.
- Adds lowered-emitter and runtime smoke coverage.

## Semantics

`sort/2` accepts a proper list in the first argument and unifies the second argument with a duplicate-free list ordered by standard term order.

The implementation is deterministic and does not enumerate list permutations. It inspects and sorts existing terms without binding variables in the input list.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
