### PR TITLE
Feat/wam go tsv fact source

### DIFF
--- a/PR_go_wam_tsv_fact_source.md
+++ b/PR_go_wam_tsv_fact_source.md
@@ -1,0 +1,19 @@
+# Add Go WAM TSV atom fact source
+
+## Description
+
+Adds a TSV-backed atom fact source path for the Go WAM target. The runtime can now load a headered two-column TSV file into the indexed atom fact table with `registerTsvAtomFact2`, and `call_indexed_atom_fact2` can query those dynamically loaded facts with normal stream-style backtracking.
+
+This narrows the Go external fact-source parity gap against the Rust/Haskell baseline. TSV-backed atom facts are now covered; LMDB remains a separate follow-up.
+
+## Tests
+
+```sh
+swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl
+swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
+swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"
+```

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -9,7 +9,7 @@ current cross-target builtin/runtime baseline.
 | Area | Go support | Rust/Haskell baseline | Status |
 | --- | --- | --- | --- |
 | Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries, `member/2` builtin retries | Choice point stack with normal, builtin, and fact-stream resume states | Partial |
-| Direct fact dispatch | `call_indexed_atom_fact2`, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Partial: no external TSV/LMDB FactSource adaptor |
+| Direct fact dispatch | `call_indexed_atom_fact2`, TSV-backed atom fact loading, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Partial: no LMDB FactSource adaptor |
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
 | Structural builtins | `member/2`, `length/2`, `append/3` | `member/2`, `length/2`; Rust `append/3` is explicitly unimplemented | Present for current baseline structural checks |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
@@ -42,13 +42,15 @@ current cross-target builtin/runtime baseline.
   E2E test for both failing and succeeding inner goals.
 - `call_indexed_atom_fact2` is now parsed and executed by the Go WAM runtime,
   including backtracking over multiple indexed atom facts.
+- Headered two-column TSV files can now be loaded into Go WAM indexed atom
+  fact tables and queried through `call_indexed_atom_fact2`.
 
 ## Recommended Follow-Up Order
 
 1. Continue broadening generated Go WAM E2E coverage for control and external
    fact-source behavior that remains marked partial.
-2. Compare Go external fact-source adapters against Rust/Haskell TSV/LMDB
-   FactSource paths if Go should close the remaining direct-fact parity gap.
+2. Compare Go LMDB adapters against Rust/Haskell LMDB FactSource paths if Go
+   should close the remaining direct-fact parity gap.
 
 ## Verification Commands
 

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -653,6 +653,10 @@ go_foreign_setup_line(register_foreign_result_layout(Pred/Arity, Layout), Line) 
     format(atom(Line), '    vm.registerForeignResultLayout("~w/~w", "~w")', [Pred, Arity, Layout]).
 go_foreign_setup_line(register_foreign_result_mode(Pred/Arity, Mode), Line) :-
     format(atom(Line), '    vm.registerForeignResultMode("~w/~w", "~w")', [Pred, Arity, Mode]).
+go_foreign_setup_line(register_tsv_atom_fact2(Pred/Arity, Path), Line) :-
+    escape_go_string(Path, EscapedPath),
+    format(atom(Line), '    if err := vm.registerTsvAtomFact2("~w/~w", "~w"); err != nil { panic(err) }',
+        [Pred, Arity, EscapedPath]).
 go_foreign_setup_line(register_foreign_string_config(Pred/Arity, Key, ValuePred/ValueArity), Line) :-
     format(atom(Line), '    vm.registerForeignStringConfig("~w/~w", "~w", "~w/~w")',
         [Pred, Arity, Key, ValuePred, ValueArity]).
@@ -2266,6 +2270,36 @@ func (vm *WamState) registerForeignUsizeConfig(predKey string, key string, value
 
 func (vm *WamState) registerIndexedAtomFact2Pairs(predKey string, pairs []AtomPair) {
     vm.Ctx.IndexedAtomFactPairs[predKey] = pairs
+}
+
+func (vm *WamState) registerTsvAtomFact2(predKey string, path string) error {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return err
+    }
+    lines := strings.Split(string(data), "\\n")
+    pairs := make([]AtomPair, 0, len(lines))
+    for idx, line := range lines {
+        line = strings.TrimSpace(line)
+        if line == "" {
+            continue
+        }
+        if idx == 0 {
+            continue
+        }
+        cols := strings.Split(line, "\\t")
+        if len(cols) < 2 {
+            continue
+        }
+        left := strings.TrimSpace(cols[0])
+        right := strings.TrimSpace(cols[1])
+        if left == "" || right == "" {
+            continue
+        }
+        pairs = append(pairs, AtomPair{Left: left, Right: right})
+    }
+    vm.registerIndexedAtomFact2Pairs(predKey, pairs)
+    return nil
 }
 
 func (vm *WamState) registerIndexedWeightedEdgeTriples(predKey string, triples []WeightedEdgeTriple) {

--- a/templates/targets/go_wam/runtime.go.mustache
+++ b/templates/targets/go_wam/runtime.go.mustache
@@ -2,14 +2,18 @@ package {{package_name}}
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
 )
 
 var (
 	_ = fmt.Sprintf
+	_ = os.ReadFile
 	_ = runtime.GOMAXPROCS
+	_ = strings.Split
 	_ sync.Locker = (*sync.Mutex)(nil)
 )
 

--- a/tests/test_wam_go_foreign_lowering.pl
+++ b/tests/test_wam_go_foreign_lowering.pl
@@ -125,6 +125,10 @@ test(call_indexed_atom_fact2_literal) :-
         [], Lit),
     assertion(Lit == '&CallIndexedAtomFact2{Pred: "edge/2"}').
 
+test(tsv_atom_fact2_setup_generation) :-
+    wam_go_target:go_foreign_setup_line(register_tsv_atom_fact2(edge/2, '/tmp/edge.tsv'), Line),
+    assertion(Line == '    if err := vm.registerTsvAtomFact2("edge/2", "/tmp/edge.tsv"); err != nil { panic(err) }').
+
 test(foreign_auto_detect_generation) :-
     compile_wam_predicate_to_go(plunit_wam_go_foreign_lowering:test_reaches/2, "call test_reaches/2, 2",
         [foreign_lowering(true)], ClosureCode),
@@ -255,9 +259,37 @@ test(foreign_execution_graph_kernels) :-
         write_file(TestPath,
 'package wam
 
-import "testing"
+import (
+    "os"
+    "path/filepath"
+    "testing"
+)
 
 func TestForeignGraphKernels(t *testing.T) {
+    tsvPath := filepath.Join(t.TempDir(), "edge.tsv")
+    if err := os.WriteFile(tsvPath, []byte("left\\tright\\nx\\ty\\nx\\tz\\n"), 0644); err != nil {
+        t.Fatalf("write tsv: %v", err)
+    }
+    tsvVM := NewWamState([]Instruction{&CallIndexedAtomFact2{Pred: "tsv_edge/2"}, &Proceed{}}, map[string]int{})
+    if err := tsvVM.registerTsvAtomFact2("tsv_edge/2", tsvPath); err != nil {
+        t.Fatalf("register tsv facts: %v", err)
+    }
+    tsvTarget := &Unbound{Name: "TSV_TARGET", Idx: 1}
+    tsvVM.Regs[0] = internAtom("x")
+    tsvVM.Regs[1] = tsvTarget
+    if !tsvVM.Run() {
+        t.Fatalf("tsv-backed call_indexed_atom_fact2 failed")
+    }
+    if got, ok := tsvVM.deref(tsvTarget).(*Atom); !ok || got.Name != "y" {
+        t.Fatalf("expected first tsv target y, got %#v", tsvVM.deref(tsvTarget))
+    }
+    if !tsvVM.backtrack() {
+        t.Fatalf("expected second tsv fact result")
+    }
+    if got, ok := tsvVM.deref(tsvTarget).(*Atom); !ok || got.Name != "z" {
+        t.Fatalf("expected second tsv target z, got %#v", tsvVM.deref(tsvTarget))
+    }
+
     factVM := NewWamState([]Instruction{&CallIndexedAtomFact2{Pred: "edge/2"}, &Proceed{}}, map[string]int{})
     factVM.registerIndexedAtomFact2Pairs("edge/2", []AtomPair{
         {Left: "a", Right: "b"},


### PR DESCRIPTION
# Add Go WAM TSV atom fact source

Adds a TSV-backed atom fact source path for the Go WAM target. The runtime can now load a headered two-column TSV file into the indexed atom fact table with `registerTsvAtomFact2`, and `call_indexed_atom_fact2` can query those dynamically loaded facts with normal stream-style backtracking.

This narrows the Go external fact-source parity gap against the Rust/Haskell baseline. TSV-backed atom facts are now covered; LMDB remains a separate follow-up.

## Tests

```sh
swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl
swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"
```
