### PR TITLE
test(wam-r): use writable temp dir for parser compile tests

### DIFF
--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
@@ -9,9 +9,9 @@ R remains the reference target. Its inline parser already supports
 `read/2`, `read_term_from_atom/2,3`, reverse `term_to_atom/2`, runtime `op/3`,
 and CLI argument parsing.
 
-Keep the R inline parser and tests in place while the compiled parser is being
-hardened. The inline parser is useful as an oracle for target behavior, not as
-the long-term source of parser semantics.
+Keep the R inline parser and tests in place. The inline parser is both a
+runtime implementation and an oracle for target behavior; benchmark data shows
+it should remain R's hot path for now.
 
 ## Phase 2: Harden The Portable Parser
 
@@ -19,42 +19,40 @@ Keep `src/unifyweaver/core/prolog_term_parser.pl` in the
 cross-target-compilable subset. Add tests when target runtime consumers expose
 new parser-sensitive behavior.
 
-Maintain structural compile coverage for WAM-R:
+Maintain compile and runtime coverage for WAM-R:
 
 ```text
 tests/test_prolog_term_parser_wam_r_compile.pl
 ```
 
 This test should continue proving that every parser predicate emits a target
-label and wrapper, even before the runtime parser is swapped in.
+label and wrapper and that representative parser drivers run through generated
+WAM-R.
 
-## Phase 3: Fix Runtime Requirements Exposed By The Parser
+## Phase 3: Preserve Runtime Requirements Exposed By The Parser
 
-The current blocker for running the transpiled parser as the R runtime parser
-is WAM-R cut-barrier behavior. The parser uses cuts inside multi-clause helper
-predicates such as tokenizer and identifier readers. The runtime must discard
-choice points created after the active cut barrier, not merely the most recent
-choice point.
+WAM-R cut-barrier behavior is now part of the parser proof surface. The parser
+uses cuts inside multi-clause helper predicates such as tokenizer and
+identifier readers, so the runtime must continue discarding choice points
+created after the active cut barrier, not merely the most recent choice point.
 
-Treat this as a general WAM correctness fix. Other non-trivial library code
-will eventually depend on the same behavior.
+Treat regressions here as general WAM correctness regressions. Other
+non-trivial library code depends on the same behavior.
 
-## Phase 4: Swap R Behind A Guard
+## Phase 4: Keep R Inline, Use The Compiled Parser As A Guard
 
-After cut semantics are correct, wire R so `read/2`,
-`read_term_from_atom/2,3`, reverse `term_to_atom/2`, and CLI parsing can use
-the compiled parser.
-
-During the transition, keep a selectable fallback to the inline parser. Compare
-both paths with:
+Compare the inline parser and compiled parser with:
 
 ```text
 tests/benchmarks/wam_r_parser_bench.pl
 ```
 
-The swap is complete when the compiled parser matches the inline parser on
-runtime tests and has acceptable performance for normal stream and atom parsing
-workloads.
+Current benchmark data shows the compiled parser is much slower than the inline
+R parser, so R should not swap to it by default. A guarded experimental switch
+is still useful for equivalence checks and future runtime-performance work, but
+`read/2`, `read_term_from_atom/2,3`, reverse `term_to_atom/2`, and CLI parsing
+should keep using the inline R parser until the compiled path is both
+equivalent and performance-credible.
 
 ## Phase 5: Generalize The Target Hook
 
@@ -75,8 +73,9 @@ availability alone. Good candidates are targets adding:
 - reverse `term_to_atom/2`;
 - user-facing CLI term arguments.
 
-Python, R, Elixir, and Lua are reasonable candidates, but R should stay the
-semantic reference until the compiled parser fully replaces its inline parser.
+Python, Elixir, Lua, and future R experiments are reasonable candidates, but R
+should stay the semantic reference while keeping its inline parser as the
+production path.
 
 ## Risks
 

--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
@@ -89,20 +89,22 @@ should remain visible until stricter ISO distinctions are implemented.
 R is the reference target because it already has runtime consumers:
 `read/2`, `read_term_from_atom/2,3`, reverse `term_to_atom/2`, and CLI parsing.
 The R target currently has an inline parser in `runtime.R.mustache`, while
-`prolog_term_parser.pl` compiles structurally to WAM-R.
+`prolog_term_parser.pl` compiles to WAM-R and runs representative parser
+drivers end to end.
 
-The structural guard is:
+The compile and runtime guard is:
 
 ```text
 tests/test_prolog_term_parser_wam_r_compile.pl
 ```
 
-Full replacement of the inline R parser is blocked by WAM-R cut-barrier
-semantics. The parser source relies on cuts in multi-clause helper predicates;
-the WAM-R runtime currently drops only the most recent choice point in cases
-where a proper cut barrier is needed. Once that runtime issue is fixed, the
-compiled parser should be compared against the inline parser and then used as
-the canonical R runtime parser.
+Full replacement of the inline R parser is not the current R target direction.
+The compiled parser is semantically useful, but R benchmark data shows it is
+far slower than the inline parser for ordinary atom, compound, list, and
+operator-expression parsing. R should keep the inline parser as its hot path
+unless future runtime changes close that gap. The portable parser remains the
+canonical cross-target specification and the preferred starting point for
+targets that do not already have a native runtime parser.
 
 ## Test Requirements
 

--- a/src/unifyweaver/core/prolog_term_parser.pl
+++ b/src/unifyweaver/core/prolog_term_parser.pl
@@ -32,16 +32,13 @@
 %
 % Compile-target status: this source compiles cleanly to WAM-R
 % (every predicate produces a label + wrapper; see
-% tests/test_prolog_term_parser_wam_r_compile.pl), and SWI runs it
-% to spec. End-to-end equivalence with the inline R parser at
-% WamRuntime$parse_term is currently gated on the WAM-R cut
-% implementation: the runtime's `!/0` and `CutIte` drop only the
-% most-recent CP, which loses cut-barrier semantics whenever a
-% multi-clause callee leaves CPs alive before the cut runs (which
-% e.g. tokenize_one and take_ident hit). Fix is filed as follow-up
-% #3 in docs/handoff/wam_r_session_handoff.md. When that lands the
-% inline parser can be retired -- the structural compile test is
-% the regression guard.
+% tests/test_prolog_term_parser_wam_r_compile.pl), SWI runs it to
+% spec, and WAM-R runs representative full-parser drivers end to
+% end. R still keeps its inline parser as the hot runtime path
+% because benchmarks show the WAM-compiled parser is much slower;
+% this source remains the canonical cross-target parser spec and a
+% proof that non-trivial parser code can be hosted by generated WAM
+% runtimes.
 % =============================================================================
 
 :- module(prolog_term_parser, [

--- a/tests/test_prolog_term_parser_wam_r_compile.pl
+++ b/tests/test_prolog_term_parser_wam_r_compile.pl
@@ -5,17 +5,13 @@
 % src/unifyweaver/core/prolog_term_parser.pl through
 % write_wam_r_project/3 and verifies (a) the generated R is syntactically
 % valid, (b) every parser predicate has a generated label and wrapper
-% function, and (c) a cut-free subset runs end-to-end via Rscript.
+% function, and (c) parser drivers run end-to-end via Rscript.
 %
 % This is the cross-target proof point: the same canonical-Prolog parser
-% source can be transpiled to a WAM-R project. End-to-end execution of
-% the FULL parser is not yet covered; the WAM-R cut scaffold drops only
-% the most recent choice point (runtime.R.mustache: cut comment near
-% `pred == "!/0"`), which loses cut-barrier semantics when the cut sits
-% in a clause body that calls another multi-clause predicate. The parser
-% relies on those exact semantics via take_ident, ident_cont, and
-% friends. Filed as a separate follow-up; this PR ships the source +
-% structural compilation, not the runtime swap-in.
+% source can be transpiled to a WAM-R project and executed through the
+% generated runtime. R still has its inline runtime parser; these tests
+% prove the portable parser can be compiled and run as a generated WAM-R
+% library.
 % =============================================================================
 
 :- use_module(library(plunit)).
@@ -48,15 +44,31 @@ parser_predicates(Preds) :-
             Raw),
     sort(Raw, Preds).
 
-% Helper: tmp project dir under /tmp/prolog_term_parser_compile_e2e_<stamp>.
+% Helper: tmp project dir under a writable temp root. Termux commonly
+% cannot write to /tmp, so prefer TMPDIR or the Termux tmp path before
+% falling back to /tmp.
 fresh_tmp_dir(Dir) :-
+    parser_tmp_root(Root),
     get_time(T),
     StampF is T,
-    format(atom(Dir), '/tmp/prolog_term_parser_compile_e2e_~w', [StampF]),
+    format(atom(Base), 'prolog_term_parser_compile_e2e_~w', [StampF]),
+    directory_file_path(Root, Base, Dir),
     (   exists_directory(Dir)
     ->  delete_directory_and_contents(Dir)
     ;   true
     ).
+
+parser_tmp_root(Root) :-
+    getenv('TMPDIR', EnvRoot),
+    exists_directory(EnvRoot),
+    access_file(EnvRoot, write),
+    !,
+    Root = EnvRoot.
+parser_tmp_root('/data/data/com.termux/files/usr/tmp') :-
+    exists_directory('/data/data/com.termux/files/usr/tmp'),
+    access_file('/data/data/com.termux/files/usr/tmp', write),
+    !.
+parser_tmp_root('/tmp').
 
 rscript_available :-
     catch((


### PR DESCRIPTION
## Summary

Fixes the WAM-R compiled parser tests on Termux-style environments where `/tmp` is not writable, and updates runtime-parser documentation to match the current WAM-R parser status.

## Details

- Uses `TMPDIR` or Termux's writable tmp path before falling back to `/tmp` in `tests/test_prolog_term_parser_wam_r_compile.pl`.
- Updates the parser compile-test header now that representative full-parser WAM-R drivers run end to end.
- Updates runtime parser transpilation docs and `prolog_term_parser.pl` comments to reflect that WAM-R cut-barrier semantics are no longer the blocker.
- Clarifies that R keeps the inline parser as the production hot path because the compiled WAM parser is currently much slower, while the portable parser remains the canonical cross-target spec.

## Verification

- `swipl -q -g run_tests -t halt tests/test_prolog_term_parser.pl`
- `swipl -q -g run_tests -t halt tests/test_prolog_term_parser_wam_r_compile.pl`
- `git diff --check HEAD`

## Notes

The full `tests/test_wam_r_generator.pl` suite was started locally on Termux but was killed partway through after reaching test 40/84. The focused parser tests above pass and cover this branch's changes.
