### PR TITLE
test(wam-c): support multi-predicate setup smoke

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,7 +5,7 @@ Status date: 2026-05-14
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `dedaeefc` (`Merge pull request #2088 from s243a/feat/wam-cpp-iso-sweep`)
+- `main` at `137a693f` (`Merge pull request #2096 from s243a/feat/wam-c-lowered-helper-expanded-body-calls`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
@@ -14,7 +14,7 @@ Base verified locally:
 
 Active branch:
 
-- `feat/wam-c-lowered-helper-expanded-body-calls`
+- `test/wam-c-generated-project-multi-predicate-setup`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -53,7 +53,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper repeated-variable filters | Done | Constant and comparison filtered helpers preserve repeated callee-variable row constraints with planner and executable coverage |
 | Lowered helper empty-result rejections | Done | Planner reports `no_matching_filter_rows` for supported constant filtered helpers whose constraints produce no rows, alongside existing comparison no-match metadata |
 | Lowered helper body-call rejection metadata | Done | Planner reports explicit unavailable and non-lowerable callee reasons for exact user-predicate body-call shapes |
-| Lowered helper projected body calls | In progress | Active branch lowers variable-only reordered body-call projections through native fact-helper dispatch with executable coverage |
+| Lowered helper projected body calls | Done | Variable-only reordered body-call projections lower through native fact-helper dispatch with executable coverage |
+| Generated multi-predicate setup | In progress | Active branch appends generated predicate code at per-setup base PCs and covers multiple setup functions in one executable |
 
 ## Current C Target Baseline
 
@@ -124,7 +125,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup and all-hop collection; add more kernel kinds only after runtime support exists. |
 | Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`; broaden as more native C kernels land. |
-| Lowered/native helper functions | Partial/Active | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, comparison-filter helpers, rejection metadata, repeated-variable filter hardening, empty-result rejection metadata, and active projected body-call helper expansion. |
+| Lowered/native helper functions | Partial/Done | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, comparison-filter helpers, rejection metadata, repeated-variable filter hardening, empty-result rejection metadata, and projected body-call helper expansion. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
 | Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB `kernels_on`/`kernels_off`; next gap is larger artifact layouts. |
@@ -134,23 +135,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lowered-helper-expanded-body-calls`
-
-Goal: expand body-call helper lowering beyond direct alias-to-fact dispatch only
-after unsupported body-call shapes have explicit planner metadata.
-
-Scope:
-
-- Evaluate simple variable-only body-call projections that were previously
-  handled as materialized filtered fact helpers.
-- Keep explicit rejection metadata for unavailable and non-lowerable callees.
-- Add runtime coverage only for any newly supported body-call shape.
-
-Status: active; variable-only reordered body-call projections now lower through
-native callee helper dispatch. Constant filters remain on the existing
-filtered-fact path.
-
-### 2. `test/wam-c-generated-project-multi-predicate-setup`
+### 1. `test/wam-c-generated-project-multi-predicate-setup`
 
 Goal: make generated-project smoke coverage less sensitive to setup-function
 ordering.
@@ -162,10 +147,26 @@ Scope:
 - Preserve existing lowered-helper foreign registration behavior.
 - Prefer a focused runtime/setup smoke before changing generated setup layout.
 
+Status: active; generated setup now appends predicate code using `base_pc`
+relative labels and a focused executable smoke covers multiple setup functions
+in one process.
+
+### 2. `feat/wam-c-lowered-helper-nonreordered-projections`
+
+Goal: decide whether body-call helper lowering should support projection shapes
+that bind only a subset of callee variables.
+
+Scope:
+
+- Start with planner metadata for repeated or omitted head/callee variables.
+- Avoid runtime support until the binding contract for ignored callee outputs is
+  explicit.
+- Keep constant filters on the existing materialized `filtered_fact` path.
+
 ## Suggested Immediate Next Step
 
-Continue validating `feat/wam-c-lowered-helper-expanded-body-calls`.
+Continue validating `test/wam-c-generated-project-multi-predicate-setup`.
 
-The active branch adds native wrapper generation for variable-only reordered
-body-call projections, while leaving direct body-call dispatch, constant
-filtered helpers, and rejection metadata unchanged.
+The active branch makes generated predicate setup append code instead of
+replacing prior predicate trampolines, and covers the behavior with a focused
+multi-predicate executable smoke.

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -1035,13 +1035,13 @@ wam_line_to_c_instr(["builtin_call", Op, N], Instr) :-
 wam_line_to_c_instr(["call_foreign", P, N], Instr) :-
     clean_comma(P, CP), clean_comma(N, CN),
     format(atom(Instr), '{ .tag = INSTR_CALL_FOREIGN, .as.pred = { .pred = "~w", .arity = ~w } }', [CP, CN]).
-wam_line_to_c_instr(["try_me_else", L], LabelMap, Arity, Instr) :-
+wam_line_to_c_instr(["try_me_else", L], LabelMap, Arity, OffsetVar, Instr) :-
     clean_comma(L, CL),
-    ( member(CL-TargetPC, LabelMap) -> true ; TargetPC = -1 ),
+    ( member(CL-TargetPC0, LabelMap) -> c_pc_expr(OffsetVar, TargetPC0, TargetPC) ; TargetPC = -1 ),
     format(atom(Instr), '{ .tag = INSTR_TRY_ME_ELSE, .as.choice = { .target_pc = ~w, .arity = ~w } }', [TargetPC, Arity]).
-wam_line_to_c_instr(["retry_me_else", L], LabelMap, Arity, Instr) :-
+wam_line_to_c_instr(["retry_me_else", L], LabelMap, Arity, OffsetVar, Instr) :-
     clean_comma(L, CL),
-    ( member(CL-TargetPC, LabelMap) -> true ; TargetPC = -1 ),
+    ( member(CL-TargetPC0, LabelMap) -> c_pc_expr(OffsetVar, TargetPC0, TargetPC) ; TargetPC = -1 ),
     format(atom(Instr), '{ .tag = INSTR_RETRY_ME_ELSE, .as.choice = { .target_pc = ~w, .arity = ~w } }', [TargetPC, Arity]).
 wam_line_to_c_instr(["trust_me"], _, '{ .tag = INSTR_TRUST_ME }').
 wam_line_to_c_instr(["proceed"], _, '{ .tag = INSTR_PROCEED }').
@@ -1071,43 +1071,45 @@ wam_lines_to_c_pass1([Line|Rest], PC, LabelMap) :-
         )
     ).
 
-wam_lines_to_c_pass2([], PC, _, _, PC, []).
-wam_lines_to_c_pass2([Line|Rest], PC, LabelMap, Arity, CodeSize, Instrs) :-
+wam_lines_to_c_pass2([], PC, _, _, _, PC, []).
+wam_lines_to_c_pass2([Line|Rest], PC, LabelMap, Arity, OffsetVar, CodeSize, Instrs) :-
     split_string(Line, " \t,", " \t,", Parts),
     delete(Parts, "", CleanParts),
-    (   CleanParts == [] -> wam_lines_to_c_pass2(Rest, PC, LabelMap, Arity, CodeSize, Instrs)
+    (   CleanParts == [] -> wam_lines_to_c_pass2(Rest, PC, LabelMap, Arity, OffsetVar, CodeSize, Instrs)
     ;   CleanParts = [First|_],
         (   sub_string(First, _, 1, 0, ":")
         ->  sub_string(First, 0, _, 1, LabelName),
             (   sub_string(LabelName, 0, 2, _, "L_")
-            ->  wam_lines_to_c_pass2(Rest, PC, LabelMap, Arity, CodeSize, Instrs)
-            ;   format(atom(PredReg), '    wam_register_predicate_hash(state, "~w", ~w);', [LabelName, PC]),
+            ->  wam_lines_to_c_pass2(Rest, PC, LabelMap, Arity, OffsetVar, CodeSize, Instrs)
+            ;   c_pc_expr(OffsetVar, PC, PCExpr),
+                format(atom(PredReg), '    wam_register_predicate_hash(state, "~w", ~w);', [LabelName, PCExpr]),
                 Instrs = [PredReg|RestInstrs],
-                wam_lines_to_c_pass2(Rest, PC, LabelMap, Arity, CodeSize, RestInstrs)
+                wam_lines_to_c_pass2(Rest, PC, LabelMap, Arity, OffsetVar, CodeSize, RestInstrs)
             )
-        ;   wam_generate_c_instruction(PC, CleanParts, LabelMap, Arity, CodeLines),
+        ;   wam_generate_c_instruction(PC, CleanParts, LabelMap, Arity, OffsetVar, CodeLines),
             NPC is PC + 1,
             append(CodeLines, RestInstrs, Instrs),
-            wam_lines_to_c_pass2(Rest, NPC, LabelMap, Arity, CodeSize, RestInstrs)
+            wam_lines_to_c_pass2(Rest, NPC, LabelMap, Arity, OffsetVar, CodeSize, RestInstrs)
         )
     ).
 
-wam_generate_c_instruction(PC, Parts, LabelMap, Arity, CodeLines) :-
+wam_generate_c_instruction(PC, Parts, LabelMap, Arity, OffsetVar, CodeLines) :-
+    c_pc_expr(OffsetVar, PC, PCExpr),
     (   (   Parts = ["switch_on_constant" | Entries],
             SwitchReg = 0
         ;   Parts = ["switch_on_constant_a2" | Entries],
             SwitchReg = 1
         )
     ->  length(Entries, HashSize),
-        format(atom(L0), '    state->code[~w] = (Instruction){ .tag = INSTR_SWITCH_ON_CONSTANT, .as.switch_index = { .reg = ~w, .hash_size = ~w } };', [PC, SwitchReg, HashSize]),
-        format(atom(L1), '    state->code[~w].as.switch_index.hash_table = malloc(sizeof(HashEntry) * ~w);', [PC, HashSize]),
-        generate_hash_table_entries(PC, "as.switch_index.hash_table", Entries, 0, LabelMap, HashLines),
+        format(atom(L0), '    state->code[~w] = (Instruction){ .tag = INSTR_SWITCH_ON_CONSTANT, .as.switch_index = { .reg = ~w, .hash_size = ~w } };', [PCExpr, SwitchReg, HashSize]),
+        format(atom(L1), '    state->code[~w].as.switch_index.hash_table = malloc(sizeof(HashEntry) * ~w);', [PCExpr, HashSize]),
+        generate_hash_table_entries(PC, PCExpr, "as.switch_index.hash_table", Entries, 0, LabelMap, OffsetVar, HashLines),
         append([L0, L1], HashLines, CodeLines)
     ;   Parts = ["switch_on_structure" | Entries]
     ->  length(Entries, HashSize),
-        format(atom(L0), '    state->code[~w] = (Instruction){ .tag = INSTR_SWITCH_ON_STRUCTURE, .as.switch_index = { .hash_size = ~w } };', [PC, HashSize]),
-        format(atom(L1), '    state->code[~w].as.switch_index.hash_table = malloc(sizeof(HashEntry) * ~w);', [PC, HashSize]),
-        generate_hash_table_entries(PC, "as.switch_index.hash_table", Entries, 0, LabelMap, HashLines),
+        format(atom(L0), '    state->code[~w] = (Instruction){ .tag = INSTR_SWITCH_ON_STRUCTURE, .as.switch_index = { .hash_size = ~w } };', [PCExpr, HashSize]),
+        format(atom(L1), '    state->code[~w].as.switch_index.hash_table = malloc(sizeof(HashEntry) * ~w);', [PCExpr, HashSize]),
+        generate_hash_table_entries(PC, PCExpr, "as.switch_index.hash_table", Entries, 0, LabelMap, OffsetVar, HashLines),
         append([L0, L1], HashLines, CodeLines)
     ;   Parts = ["switch_on_term", CLenStr | Rest1]
     ->  number_string(CLen, CLenStr),
@@ -1119,36 +1121,38 @@ wam_generate_c_instruction(PC, Parts, LabelMap, Arity, CodeLines) :-
         (   ListLabelStr == "none"
         ->  ListPC = -1
         ;   ListLabelStr == "default"
-        ->  ListPC is PC + 1
-        ;   member(ListLabelStr-ListPC, LabelMap)
-        ->  true
+        ->  ListPC0 is PC + 1,
+            c_pc_expr(OffsetVar, ListPC0, ListPC)
+        ;   member(ListLabelStr-ListPC0, LabelMap)
+        ->  c_pc_expr(OffsetVar, ListPC0, ListPC)
         ;   ListPC = -1
         ),
-        format(atom(L0), '    state->code[~w] = (Instruction){ .tag = INSTR_SWITCH_ON_TERM, .as.switch_index = { .hash_size = ~w, .s_hash_size = ~w, .list_target_pc = ~w } };', [PC, CLen, SLen, ListPC]),
-        format(atom(L1), '    state->code[~w].as.switch_index.hash_table = malloc(sizeof(HashEntry) * ~w);', [PC, CLen]),
-        format(atom(L2), '    state->code[~w].as.switch_index.s_hash_table = malloc(sizeof(HashEntry) * ~w);', [PC, SLen]),
-        generate_hash_table_entries(PC, "as.switch_index.hash_table", CEntries, 0, LabelMap, CHashLines),
-        generate_hash_table_entries(PC, "as.switch_index.s_hash_table", SEntries, 0, LabelMap, SHashLines),
+        format(atom(L0), '    state->code[~w] = (Instruction){ .tag = INSTR_SWITCH_ON_TERM, .as.switch_index = { .hash_size = ~w, .s_hash_size = ~w, .list_target_pc = ~w } };', [PCExpr, CLen, SLen, ListPC]),
+        format(atom(L1), '    state->code[~w].as.switch_index.hash_table = malloc(sizeof(HashEntry) * ~w);', [PCExpr, CLen]),
+        format(atom(L2), '    state->code[~w].as.switch_index.s_hash_table = malloc(sizeof(HashEntry) * ~w);', [PCExpr, SLen]),
+        generate_hash_table_entries(PC, PCExpr, "as.switch_index.hash_table", CEntries, 0, LabelMap, OffsetVar, CHashLines),
+        generate_hash_table_entries(PC, PCExpr, "as.switch_index.s_hash_table", SEntries, 0, LabelMap, OffsetVar, SHashLines),
         append([L0, L1, L2 | CHashLines], SHashLines, CodeLines)
-    ;   (   wam_line_to_c_instr(Parts, LabelMap, Arity, CInstr)
+    ;   (   wam_line_to_c_instr(Parts, LabelMap, Arity, OffsetVar, CInstr)
         ->  true
         ;   wam_line_to_c_instr(Parts, CInstr_NoMap)
         ->  CInstr = CInstr_NoMap
         ;   wam_line_to_c_instr(Parts, LabelMap, CInstr_NoArity)
         ->  CInstr = CInstr_NoArity
         ),
-        format(atom(L0), '    state->code[~w] = (Instruction)~w;', [PC, CInstr]),
+        format(atom(L0), '    state->code[~w] = (Instruction)~w;', [PCExpr, CInstr]),
         CodeLines = [L0]
     ).
 
-generate_hash_table_entries(_, _, [], _, _, []).
-generate_hash_table_entries(PC, TableName, [Entry|Rest], Idx, LabelMap, [Line|RestLines]) :-
+generate_hash_table_entries(_, _, _, [], _, _, _, []).
+generate_hash_table_entries(PC, PCExpr, TableName, [Entry|Rest], Idx, LabelMap, OffsetVar, [Line|RestLines]) :-
     split_string(Entry, ":", "", Parts),
     (   Parts = [KeyStr, LabelStr]
     ->  (   LabelStr == "default"
-        ->  TargetPC is PC + 1
-        ;   member(LabelStr-TargetPC, LabelMap)
-        ->  true
+        ->  TargetPC0 is PC + 1,
+            c_pc_expr(OffsetVar, TargetPC0, TargetPC)
+        ;   member(LabelStr-TargetPC0, LabelMap)
+        ->  c_pc_expr(OffsetVar, TargetPC0, TargetPC)
         ;   TargetPC = -1
         ),
         (   number_string(KeyNum, KeyStr), integer(KeyNum)
@@ -1156,10 +1160,16 @@ generate_hash_table_entries(PC, TableName, [Entry|Rest], Idx, LabelMap, [Line|Re
         ;   atom_string(KeyAtom, KeyStr),
             c_value_literal(KeyAtom, ValLit)
         ),
-        format(atom(Line), '    state->code[~w].~w[~w] = (HashEntry){ ~w, ~w };', [PC, TableName, Idx, ValLit, TargetPC]),
+        format(atom(Line), '    state->code[~w].~w[~w] = (HashEntry){ ~w, ~w };', [PCExpr, TableName, Idx, ValLit, TargetPC]),
         NextIdx is Idx + 1,
-        generate_hash_table_entries(PC, TableName, Rest, NextIdx, LabelMap, RestLines)
+        generate_hash_table_entries(PC, PCExpr, TableName, Rest, NextIdx, LabelMap, OffsetVar, RestLines)
     ;   throw(error(wam_c_target_error(invalid_switch_entry(Entry)), _))
+    ).
+
+c_pc_expr(OffsetVar, PC, Expr) :-
+    (   PC < 0
+    ->  Expr = '-1'
+    ;   format(atom(Expr), '~w + ~w', [OffsetVar, PC])
     ).
 
 compile_wam_predicate_to_c(PredIndicator, WamCode, _Options, CCode) :-
@@ -1171,30 +1181,18 @@ compile_wam_predicate_to_c(PredIndicator, WamCode, _Options, CCode) :-
     % We parse it line-by-line into structural C literals.
     split_string(WamStr, "\n", "", Lines),
     wam_lines_to_c_pass1(Lines, 0, LabelMap),
-    wam_lines_to_c_pass2(Lines, 0, LabelMap, Arity, CodeSize, InstrParts),
+    wam_lines_to_c_pass2(Lines, 0, LabelMap, Arity, base_pc, CodeSize, InstrParts),
     atomic_list_concat(InstrParts, '\n', InstrLiterals),
     
     format(atom(CCode), 
 '/* WAM-compiled predicate: ~w/~w */
 void setup_~w_~w(WamState* state) {
-    if (state->code) {
-        for (int i = 0; i < state->code_size; i++) {
-            if ((state->code[i].tag == INSTR_SWITCH_ON_CONSTANT || state->code[i].tag == INSTR_SWITCH_ON_STRUCTURE || state->code[i].tag == INSTR_SWITCH_ON_TERM) && state->code[i].as.switch_index.hash_table) {
-                free(state->code[i].as.switch_index.hash_table);
-                state->code[i].as.switch_index.hash_table = NULL;
-            }
-            if (state->code[i].tag == INSTR_SWITCH_ON_TERM && state->code[i].as.switch_index.s_hash_table) {
-                free(state->code[i].as.switch_index.s_hash_table);
-                state->code[i].as.switch_index.s_hash_table = NULL;
-            }
-        }
-    }
-    if (!state->code || state->code_size < ~w) {
-        state->code_size = ~w;
-        state->code = realloc(state->code, sizeof(Instruction) * state->code_size);
-    }
+    int base_pc = state->code_size;
+    int new_code_size = base_pc + ~w;
+    state->code_size = new_code_size;
+    state->code = realloc(state->code, sizeof(Instruction) * state->code_size);
 ~w
-}', [PredStr, Arity, PredStr, Arity, CodeSize, CodeSize, InstrLiterals]).
+}', [PredStr, Arity, PredStr, Arity, CodeSize, InstrLiterals]).
 
 % ============================================================================
 % PHASE 3: step_wam/3 -> C switch statement

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -213,7 +213,7 @@ test_predicate_hash_registration :-
         atom_string(PredCode, PredS),
         compile_step_wam_to_c([], StepCode),
         atom_string(StepCode, StepS),
-        sub_string(PredS, _, _, _, 'wam_register_predicate_hash(state, "foo/1", 0)'),
+        sub_string(PredS, _, _, _, 'wam_register_predicate_hash(state, "foo/1", base_pc + 0)'),
         sub_string(StepS, _, _, _, 'resolve_predicate_hash(state, instr->as.pred.pred)')
     ->  pass(Test)
     ;   fail_test(Test, 'predicate hash registration/lookup missing')
@@ -740,7 +740,7 @@ test_list_target_pc_emission :-
     (   compile_predicate_to_wam(user:wam_c_list_case/1, [], WamCode),
         compile_wam_predicate_to_c(user:wam_c_list_case/1, WamCode, [], CCode),
         atom_string(CCode, S),
-        sub_string(S, _, _, _, '.list_target_pc = 1')
+        sub_string(S, _, _, _, '.list_target_pc = base_pc + 1')
     ->  pass(Test)
     ;   fail_test(Test, 'list_target_pc not emitted')
     ),
@@ -762,6 +762,16 @@ test_cross_predicate_executable_smoke :-
     ->  (   run_cross_predicate_executable_smoke
         ->  pass(Test)
         ;   fail_test(Test, 'cross-predicate executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
+test_multi_predicate_setup_executable_smoke :-
+    Test = 'WAM-C: multi-predicate setup executable smoke',
+    (   gcc_available
+    ->  (   run_multi_predicate_setup_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'multi-predicate setup executable failed')
         )
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
@@ -1023,6 +1033,27 @@ run_cross_predicate_executable_smoke :-
     format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
     write_text_file(PredPath, PredTranslationUnit),
     wam_c_cross_exec_smoke_main(MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
+run_multi_predicate_setup_executable_smoke :-
+    FirstWamCode = 'wam_c_multi_first/1:\n    get_constant a, A1\n    proceed',
+    SecondWamCode = 'wam_c_multi_second/1:\n    get_constant b, A1\n    proceed',
+    compile_wam_predicate_to_c(user:wam_c_multi_first/1, FirstWamCode, [], FirstPredCode),
+    compile_wam_predicate_to_c(user:wam_c_multi_second/1, SecondWamCode, [], SecondPredCode),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_multi_setup_smoke', Stamp, TmpBase),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(RuntimePath, RuntimeCode),
+    format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w~n~n~w', [FirstPredCode, SecondPredCode]),
+    write_text_file(PredPath, PredTranslationUnit),
+    wam_c_multi_setup_smoke_main(MainCode),
     write_text_file(MainPath, MainCode),
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
@@ -1662,6 +1693,44 @@ int main(void) {
     if (fail_rc != WAM_HALT) {
         wam_free_state(&state);
         return 20;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
+wam_c_multi_setup_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_multi_first_1(WamState* state);
+void setup_wam_c_multi_second_1(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_multi_first_1(&state);
+    setup_wam_c_multi_second_1(&state);
+
+    WamValue first_args[1] = { val_atom("a") };
+    int first_rc = wam_run_predicate(&state, "wam_c_multi_first/1", first_args, 1);
+    if (first_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue second_args[1] = { val_atom("b") };
+    int second_rc = wam_run_predicate(&state, "wam_c_multi_second/1", second_args, 1);
+    if (second_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue first_fail_args[1] = { val_atom("b") };
+    int first_fail_rc = wam_run_predicate(&state, "wam_c_multi_first/1", first_fail_args, 1);
+    if (first_fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 30;
     }
 
     wam_free_state(&state);
@@ -2779,6 +2848,7 @@ run_tests_once :-
     test_list_target_pc_emission,
     test_generated_runtime_executable_smoke,
     test_cross_predicate_executable_smoke,
+    test_multi_predicate_setup_executable_smoke,
     test_builtin_call_executable_smoke,
     test_call_foreign_executable_smoke,
     test_category_ancestor_kernel_executable_smoke,


### PR DESCRIPTION
## Summary

- make generated WAM-C predicate setup append code at a per-call `base_pc` instead of replacing prior predicate code
- emit predicate registrations, switch targets, and choice targets relative to `base_pc`
- add a focused executable smoke that calls two independently generated setup functions in one process
- refresh the WAM-C roadmap with this setup branch and the next lowered-helper projection follow-up

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --check`

## Notes

- This preserves lowered-helper foreign registration behavior.
- The new smoke verifies both predicates remain callable after multiple generated setup calls.
- The branch is committed as `18a5241c test(wam-c): support multi-predicate setup smoke`.