### PR TITLE
test(csharp-query): guard calibration CI wiring

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
           python3 examples/benchmark/refresh_csharp_query_source_mode_calibration.py --dry-run
           python3 -m unittest tests/test_csharp_query_scan_calibration_refresh_wrapper.py
           python3 examples/benchmark/refresh_csharp_query_scan_source_mode_calibration.py --dry-run
+          python3 -m unittest tests/test_csharp_query_calibration_ci_contract.py
 
       - name: Generate and run inference test runner
         run: |

--- a/tests/test_csharp_query_calibration_ci_contract.py
+++ b/tests/test_csharp_query_calibration_ci_contract.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "test.yml"
+
+
+class CSharpQueryCalibrationCiContractTests(unittest.TestCase):
+    def test_ci_runs_calibration_artifact_and_wrapper_contracts(self) -> None:
+        workflow = WORKFLOW.read_text()
+
+        required_commands = [
+            "python3 -m unittest tests/test_csharp_query_source_mode_policy.py",
+            "python3 -m unittest tests/test_csharp_query_calibration_refresh_wrapper.py",
+            "python3 examples/benchmark/refresh_csharp_query_source_mode_calibration.py --dry-run",
+            "python3 -m unittest tests/test_csharp_query_scan_calibration_refresh_wrapper.py",
+            "python3 examples/benchmark/refresh_csharp_query_scan_source_mode_calibration.py --dry-run",
+            "python3 -m unittest tests/test_csharp_query_calibration_ci_contract.py",
+        ]
+
+        for command in required_commands:
+            with self.subTest(command=command):
+                self.assertIn(command, workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Guard C# query calibration CI wiring

  ## Summary

  - Adds a CI contract test for the C# query calibration workflow wiring.
  - Ensures CI continues to run graph and scan calibration wrapper tests.
  - Ensures CI continues to run both calibration refresh wrappers in `--dry-run` mode.
  - Wires the new contract test into the existing GitHub Actions calibration step.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py`
  - `python3 -m unittest tests/test_csharp_query_calibration_refresh_wrapper.py`
  - `python3 examples/benchmark/refresh_csharp_query_source_mode_calibration.py --dry-run`
  - `python3 -m unittest tests/test_csharp_query_scan_calibration_refresh_wrapper.py`
  - `python3 examples/benchmark/refresh_csharp_query_scan_source_mode_calibration.py --dry-run`
  - `python3 -m unittest tests/test_csharp_query_calibration_ci_contract.py`
  - `python3 -m py_compile tests/test_csharp_query_calibration_ci_contract.py`
  - `git diff --check`