### PR TITLE
docs(csharp-query): Document C# query scan calibration refresh workflow

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -173,14 +173,24 @@ selected explicitly with `--workloads scan-materialization` or
 The scan-materialization source-mode policy has its own artifact,
 `csharp_query_scan_source_mode_calibration.tsv`, so graph calibration refreshes
 do not accidentally rewrite scan rows. The default scan refresh is intentionally
-small and uses `dev` scale:
+small and uses `dev` scale as a fast smoke refresh:
 
 ```bash
 python examples/benchmark/refresh_csharp_query_scan_source_mode_calibration.py
 ```
 
-Pass `--scales 300,1k` or a larger scale list when a broader scan refresh is
-needed.
+The checked-in scan calibration artifact covers `dev`, `300`, `1k`, `5k`, and
+`10k` for each scan-materialization mode. Use an explicit scale list when
+refreshing broader coverage:
+
+```bash
+python examples/benchmark/refresh_csharp_query_scan_source_mode_calibration.py \
+  --scales dev,300,1k,5k,10k
+```
+
+When intentionally adding new workload/scale rows to a calibration artifact,
+also pass `--allow-new-calibration-rows`. Keep that flag off for normal
+refreshes so missing baseline rows still fail as calibration drift.
 
 ### WAM-Rust and WAM-Haskell Benchmark Variants
 


### PR DESCRIPTION
  ## Summary

  - Clarifies that the default scan calibration refresh is a fast `dev` smoke refresh.
  - Documents that the checked-in scan calibration artifact now covers `dev`, `300`, `1k`, `5k`, and `10k`.
  - Adds the broader scan refresh command for full checked-in coverage.
  - Explains that `--allow-new-calibration-rows` should be used only for intentional artifact expansion.

  ## Validation

  - `git diff --check`
  - `python3 examples/benchmark/refresh_csharp_query_source_mode_calibration.py --dry-run`
  - `python3 examples/benchmark/refresh_csharp_query_scan_source_mode_calibration.py --dry-run`