### PR TITLE
feat(wam-c): Report unsupported WAM-C lowered-helper projection shapes

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -1,11 +1,11 @@
 # WAM C Target - Status And Next Steps
 
-Status date: 2026-05-14
+Status date: 2026-05-15
 
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `137a693f` (`Merge pull request #2096 from s243a/feat/wam-c-lowered-helper-expanded-body-calls`)
+- `main` at `9b19eace` (`Merge pull request #2113 from s243a/test/wam-c-generated-project-multi-predicate-setup`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
@@ -14,7 +14,7 @@ Base verified locally:
 
 Active branch:
 
-- `test/wam-c-generated-project-multi-predicate-setup`
+- `feat/wam-c-lowered-helper-nonreordered-projections`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -54,7 +54,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper empty-result rejections | Done | Planner reports `no_matching_filter_rows` for supported constant filtered helpers whose constraints produce no rows, alongside existing comparison no-match metadata |
 | Lowered helper body-call rejection metadata | Done | Planner reports explicit unavailable and non-lowerable callee reasons for exact user-predicate body-call shapes |
 | Lowered helper projected body calls | Done | Variable-only reordered body-call projections lower through native fact-helper dispatch with executable coverage |
-| Generated multi-predicate setup | In progress | Active branch appends generated predicate code at per-setup base PCs and covers multiple setup functions in one executable |
+| Generated multi-predicate setup | Done | Generated setup appends predicate code at per-setup base PCs and covers multiple setup functions in one executable |
+| Lowered helper non-reordered projection metadata | In progress | Active branch reports explicit planner rejection reasons for omitted head variables, repeated head variables, and unbound callee variables |
 
 ## Current C Target Baseline
 
@@ -135,23 +136,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `test/wam-c-generated-project-multi-predicate-setup`
-
-Goal: make generated-project smoke coverage less sensitive to setup-function
-ordering.
-
-Scope:
-
-- Cover multiple generated WAM predicate trampolines in one executable without
-  relying on the last `setup_*` call.
-- Preserve existing lowered-helper foreign registration behavior.
-- Prefer a focused runtime/setup smoke before changing generated setup layout.
-
-Status: active; generated setup now appends predicate code using `base_pc`
-relative labels and a focused executable smoke covers multiple setup functions
-in one process.
-
-### 2. `feat/wam-c-lowered-helper-nonreordered-projections`
+### 1. `feat/wam-c-lowered-helper-nonreordered-projections`
 
 Goal: decide whether body-call helper lowering should support projection shapes
 that bind only a subset of callee variables.
@@ -163,10 +148,25 @@ Scope:
   explicit.
 - Keep constant filters on the existing materialized `filtered_fact` path.
 
+Status: active; the planner now classifies unsupported variable-only projection
+shapes before they fall through to generic fact/filter rejection metadata.
+
+### 2. `feat/wam-c-lowered-helper-ignored-output-contract`
+
+Goal: define the runtime contract for projected body calls whose callee produces
+variables that are not exposed by the caller.
+
+Scope:
+
+- Decide whether ignored callee outputs should be allowed only when they are
+  unconstrained, or whether they require materialized row filtering.
+- If supported, add executable coverage before enabling native helper lowering.
+- Keep constant filters on the existing materialized `filtered_fact` path.
+
 ## Suggested Immediate Next Step
 
-Continue validating `test/wam-c-generated-project-multi-predicate-setup`.
+Continue validating `feat/wam-c-lowered-helper-nonreordered-projections`.
 
-The active branch makes generated predicate setup append code instead of
-replacing prior predicate trampolines, and covers the behavior with a focused
-multi-predicate executable smoke.
+The active branch keeps runtime lowering conservative and improves planner
+metadata first, so the next implementation step can be based on explicit
+projection-shape evidence instead of generic rejection comments.

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -470,12 +470,24 @@ lowered_body_call_rejection_reason(PredIndicator, AvailableKeys, Reason) :-
     ->  Reason = body_call_callee_not_lowerable
     ),
     !.
+lowered_body_call_rejection_reason(PredIndicator, AvailableKeys, Reason) :-
+    body_call_projection_context(PredIndicator, HeadArgs, CalleePred, CalleeArity, CalleeKey, CalleeArgs),
+    callee_has_user_clause(CalleePred, CalleeArity),
+    memberchk(CalleeKey, AvailableKeys),
+    CalleeIndicator = user:CalleePred/CalleeArity,
+    lowered_fact_helper_rows(CalleeIndicator, _Rows),
+    body_call_projection_rejection_reason(HeadArgs, CalleeArgs, Reason),
+    !.
 
 body_call_context(PredIndicator, CalleePred, CalleeArity, CalleeKey) :-
     projected_body_call_context(PredIndicator, HeadArgs, CalleePred, CalleeArity, CalleeKey, CalleeArgs),
     HeadArgs == CalleeArgs.
 
 projected_body_call_context(PredIndicator, HeadArgs, CalleePred, CalleeArity, CalleeKey, CalleeArgs) :-
+    body_call_projection_context(PredIndicator, HeadArgs, CalleePred, CalleeArity, CalleeKey, CalleeArgs),
+    maplist(projected_body_call_arg_supported(HeadArgs), CalleeArgs).
+
+body_call_projection_context(PredIndicator, HeadArgs, CalleePred, CalleeArity, CalleeKey, CalleeArgs) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
     functor(Head, Pred, Arity),
     findall(Args-Body,
@@ -491,17 +503,34 @@ projected_body_call_context(PredIndicator, HeadArgs, CalleePred, CalleeArity, Ca
     (Pred/Arity) \== (CalleePred/CalleeArity),
     HeadArgs = Args,
     maplist(var, HeadArgs),
-    maplist(projected_body_call_arg_supported(HeadArgs), CalleeArgs),
+    maplist(var, CalleeArgs),
     format(atom(CalleeKey), '~w/~w', [CalleePred, CalleeArity]).
 
 projected_body_call_arg_supported(HeadArgs, Arg) :-
     member(HeadArg, HeadArgs),
     Arg == HeadArg.
 
+body_call_projection_rejection_reason(HeadArgs, CalleeArgs, body_call_projection_unbound_callee_variable) :-
+    member(CalleeArg, CalleeArgs),
+    \+ projected_body_call_arg_supported(HeadArgs, CalleeArg),
+    !.
+body_call_projection_rejection_reason(HeadArgs, CalleeArgs, body_call_projection_omits_head_variable) :-
+    member(HeadArg, HeadArgs),
+    variable_occurrence_count(HeadArg, CalleeArgs, 0),
+    !.
+body_call_projection_rejection_reason(HeadArgs, CalleeArgs, body_call_projection_repeats_head_variable) :-
+    member(HeadArg, HeadArgs),
+    variable_occurrence_count(HeadArg, CalleeArgs, Count),
+    Count > 1,
+    !.
+
+variable_occurrence_count(Needle, Args, Count) :-
+    include(same_variable(Needle), Args, Matches),
+    length(Matches, Count).
+
 head_args_project_once([], _CalleeArgs).
 head_args_project_once([HeadArg|Rest], CalleeArgs) :-
-    include(same_variable(HeadArg), CalleeArgs, Matches),
-    Matches = [_],
+    variable_occurrence_count(HeadArg, CalleeArgs, 1),
     head_args_project_once(Rest, CalleeArgs).
 
 same_variable(Left, Right) :-

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -357,7 +357,7 @@ test_lowered_helper_planner_metadata :-
                                     Plans),
         member(wam_c_lowered_helper_plan('wam_c_plan_fact/2', _, lowered, fact_only([[a,b]])), Plans),
         member(wam_c_lowered_helper_plan('wam_c_plan_alias/2', _, lowered, body_call('wam_c_plan_fact/2', 2)), Plans),
-        member(wam_c_lowered_helper_plan('wam_c_plan_rule/1', _, rejected, non_constant_filter_argument), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_plan_rule/1', _, rejected, body_call_projection_unbound_callee_variable), Plans),
         member(wam_c_lowered_helper_plan('category_ancestor/4', _, interpreted, detected_kernel), Plans)
     ->  pass(Test)
     ;   fail_test(Test, 'planner did not classify lowered/rejected/interpreted predicates')
@@ -384,7 +384,7 @@ test_lowered_helper_plan_generation :-
         sub_string(LibS, _, _, _, '// WAM-C lowered helper plan'),
         sub_string(LibS, _, _, _, '// - lowered wam_c_plan_emit_fact/2: fact_only'),
         sub_string(LibS, _, _, _, '// - lowered wam_c_plan_emit_alias/2: body_call'),
-        sub_string(LibS, _, _, _, '// - rejected wam_c_plan_emit_rule/1: non_constant_filter_argument'),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_plan_emit_rule/1: body_call_projection_unbound_callee_variable'),
         sub_string(LibS, _, _, _, 'INSTR_CALL_FOREIGN'),
         sub_string(LibS, _, _, _, 'static bool wam_c_lowered_wam_c_plan_emit_alias_2'),
         sub_string(LibS, _, _, _, 'setup_wam_c_plan_emit_rule_1')
@@ -471,6 +471,53 @@ test_lowered_body_call_rejection_metadata :-
     retractall(user:wam_c_body_reject_missing(_, _)),
     retractall(user:wam_c_body_reject_rule_callee(_, _)),
     retractall(user:wam_c_body_reject_rule_alias(_, _)).
+
+test_lowered_body_call_projection_rejection_metadata :-
+    Test = 'WAM-C: lowered helper planner explains unsupported projection shapes',
+    assertz(user:wam_c_body_projection_fact1(a)),
+    assertz(user:wam_c_body_projection_fact2(a, a)),
+    assertz((user:wam_c_body_projection_omit(X, _Ignored) :-
+                 user:wam_c_body_projection_fact1(X))),
+    assertz((user:wam_c_body_projection_repeat(X) :-
+                 user:wam_c_body_projection_fact2(X, X))),
+    assertz((user:wam_c_body_projection_unbound(X) :-
+                 user:wam_c_body_projection_fact2(X, _Unbound))),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_lowered_body_projection_reject_project', Stamp, ProjectDir),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    (   plan_wam_c_lowered_helpers([user:wam_c_body_projection_fact1/1,
+                                     user:wam_c_body_projection_fact2/2,
+                                     user:wam_c_body_projection_omit/2,
+                                     user:wam_c_body_projection_repeat/1,
+                                     user:wam_c_body_projection_unbound/1],
+                                    [lowered_helpers(true)],
+                                    [],
+                                    Plans),
+        member(wam_c_lowered_helper_plan('wam_c_body_projection_fact1/1', _, lowered, fact_only([[a]])), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_body_projection_fact2/2', _, lowered, fact_only([[a,a]])), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_body_projection_omit/2', _, rejected, body_call_projection_omits_head_variable), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_body_projection_repeat/1', _, rejected, body_call_projection_repeats_head_variable), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_body_projection_unbound/1', _, rejected, body_call_projection_unbound_callee_variable), Plans),
+        write_wam_c_project([user:wam_c_body_projection_fact1/1,
+                             user:wam_c_body_projection_fact2/2,
+                             user:wam_c_body_projection_omit/2,
+                             user:wam_c_body_projection_repeat/1,
+                             user:wam_c_body_projection_unbound/1],
+                            [lowered_helpers(true)],
+                            ProjectDir),
+        read_file_to_string(LibPath, LibS, []),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_body_projection_omit/2: body_call_projection_omits_head_variable'),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_body_projection_repeat/1: body_call_projection_repeats_head_variable'),
+        sub_string(LibS, _, _, _, '// - rejected wam_c_body_projection_unbound/1: body_call_projection_unbound_callee_variable')
+    ->  pass(Test)
+    ;   fail_test(Test, 'planner did not report explicit projection rejection reasons')
+    ),
+    retractall(user:wam_c_body_projection_fact1(_)),
+    retractall(user:wam_c_body_projection_fact2(_, _)),
+    retractall(user:wam_c_body_projection_omit(_, _)),
+    retractall(user:wam_c_body_projection_repeat(_)),
+    retractall(user:wam_c_body_projection_unbound(_)).
 
 test_lowered_filtered_fact_helper_generation :-
     Test = 'WAM-C: guarded fact predicates can lower to filtered native helper',
@@ -2838,6 +2885,7 @@ run_tests_once :-
     test_lowered_helper_plan_generation,
     test_lowered_body_call_helper_generation,
     test_lowered_body_call_rejection_metadata,
+    test_lowered_body_call_projection_rejection_metadata,
     test_lowered_filtered_fact_helper_generation,
     test_lowered_comparison_filter_helper_generation,
     test_lowered_repeated_variable_filter_generation,


### PR DESCRIPTION
## Summary

- add explicit lowered-helper planner rejection reasons for variable-only body-call projections that cannot be safely lowered yet
- classify unbound callee variables, omitted head variables, and repeated head variables before they fall through to generic filter/fact rejection metadata
- refresh the WAM-C next-steps roadmap to mark generated multi-predicate setup complete and make ignored-output projection semantics the next follow-up

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --check`