### PR TITLE
feat(wam): inlined bagof/setof witness grouping

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -281,6 +281,13 @@ wam_instruction_to_cpp_literal_det(begin_aggregate(K, V, R), _, Code) :-
     escape_cpp_string(KS, EK), escape_cpp_string(VS, EV), escape_cpp_string(RS, ER),
     format(atom(Code),
            'Instruction::BeginAggregate("~w", "~w", "~w")', [EK, EV, ER]).
+wam_instruction_to_cpp_literal_det(begin_aggregate(K, V, R, W), _, Code) :-
+    to_string(K, KS), to_string(V, VS), to_string(R, RS), to_string(W, WS),
+    escape_cpp_string(KS, EK), escape_cpp_string(VS, EV),
+    escape_cpp_string(RS, ER), escape_cpp_string(WS, EW),
+    format(atom(Code),
+           'Instruction::BeginAggregate("~w", "~w", "~w", "~w")',
+           [EK, EV, ER, EW]).
 wam_instruction_to_cpp_literal_det(end_aggregate(R), _, Code) :-
     to_string(R, RS),
     escape_cpp_string(RS, ER),
@@ -1441,6 +1448,10 @@ struct Instruction {
     Value val;
     std::string a;
     std::string b;
+    // Reused by BeginAggregate for free-witness register names —
+    // a semicolon-delimited list ("Y1;Y2") matching the 4th arg of
+    // the 4-token wam-text shape. Empty for non-grouping aggregates.
+    std::string c;
     std::int64_t n = 0;
     std::size_t target = 0;
     // Indexing dispatch tables. const_table holds Value→pc for atom/int
@@ -1508,6 +1519,11 @@ struct Instruction {
     static Instruction BeginAggregate(std::string kind, std::string vreg, std::string rreg)
         { Instruction i; i.op = Op::BeginAggregate; i.a = std::move(kind);
           i.b = std::move(vreg); i.val = Value::Atom(std::move(rreg)); return i; }
+    static Instruction BeginAggregate(std::string kind, std::string vreg, std::string rreg,
+                                      std::string wregs)
+        { Instruction i; i.op = Op::BeginAggregate; i.a = std::move(kind);
+          i.b = std::move(vreg); i.val = Value::Atom(std::move(rreg));
+          i.c = std::move(wregs); return i; }
     static Instruction EndAggregate(std::string vreg)
         { Instruction i; i.op = Op::EndAggregate; i.a = std::move(vreg); return i; }
     static Instruction SwitchOnConstant(std::vector<std::pair<Value, std::size_t>> table)
@@ -1613,6 +1629,13 @@ struct AggregateFrame {
     // not yet supported (deferred follow-up).
     std::vector<CellPtr> witness_cells;
     std::vector<std::vector<Value>> acc_witnesses;
+    // Inlined-path witness registers: stored as names because Y-regs
+    // for free witnesses get allocated by put_variable INSIDE the
+    // aggregate body, AFTER BeginAggregate fires. EndAggregate resolves
+    // them once into witness_cells on the first iteration, then reuses
+    // the cached cells for later iterations (the env frame keeps the
+    // same Y-reg shared_ptr across body retries).
+    std::vector<std::string> witness_regs;
 };
 
 // Catcher frame opened by catch/3. Sits on a side stack (not the
@@ -3391,6 +3414,23 @@ bool WamState::step(const Instruction& instr) {
             frame.saved_regs        = regs;
             frame.saved_mode_stack  = mode_stack;
             frame.saved_env_stack   = env_stack;
+            // For bagof/setof with witnesses: instr.c is a semicolon-
+            // delimited list of register names ("Y2" / "Y1;Y2"). Store
+            // the names here — actual cell resolution happens lazily at
+            // EndAggregate, since Y-regs for free witnesses get
+            // allocated by put_variable INSIDE the aggregate body.
+            if (!instr.c.empty()) {
+                std::string buf;
+                for (char ch : instr.c) {
+                    if (ch == '';'') {
+                        if (!buf.empty()) frame.witness_regs.push_back(buf);
+                        buf.clear();
+                    } else {
+                        buf.push_back(ch);
+                    }
+                }
+                if (!buf.empty()) frame.witness_regs.push_back(buf);
+            }
             aggregate_frames.push_back(std::move(frame));
             pc += 1;
             return true;
@@ -3402,6 +3442,28 @@ bool WamState::step(const Instruction& instr) {
             // trail-driven mutations don''t alter what we collected).
             CellPtr v = get_cell(instr.a);
             f.acc.push_back(deep_copy(*v));
+            // For bagof/setof on the inlined path: resolve witness regs
+            // lazily on the first iteration (they get allocated inside
+            // the aggregate body, after BeginAggregate fired). The env
+            // frame keeps the same Y-reg shared_ptrs across body retries,
+            // so a single resolution is reusable for all later snapshots.
+            if (f.witness_cells.empty() && !f.witness_regs.empty()) {
+                for (auto& rname : f.witness_regs) {
+                    CellPtr wc = get_cell(rname);
+                    if (wc) f.witness_cells.push_back(wc);
+                }
+            }
+            // Snapshot witness values parallel to acc so finalise can
+            // partition by witness equality. Mirrors the FindallCollect
+            // arm used by the meta-call path.
+            if (!f.witness_cells.empty()) {
+                std::vector<Value> witness_snap;
+                witness_snap.reserve(f.witness_cells.size());
+                for (auto& wc : f.witness_cells) {
+                    witness_snap.push_back(deep_copy(*wc));
+                }
+                f.acc_witnesses.push_back(std::move(witness_snap));
+            }
             f.return_pc     = pc + 1;
             f.return_pc_set = true;
             // Force backtrack to find the next solution of the body.

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -876,14 +876,107 @@ compile_aggregate_all(Template, InnerGoal, Result, V0, Vf, Code) :-
     ->  FullInnerCode = InnerCode
     ;   format(string(FullInnerCode), "~w~n~w", [InnerCode, ConstructionCode])
     ),
+    % For bagof/setof: compute free witnesses (vars in InnerGoal NOT
+    % in Template and NOT under ^/2) and emit their registers as a
+    % 4th `begin_aggregate` arg. Runtimes that recognise the 4-arg
+    % form use the witness regs for ISO grouping. The 3-arg form
+    % stays untouched for findall/count/sum/min/max/bag/set —
+    % grouping doesn''t apply there.
+    % Use Vf (post-inner-compile varmap) so witness vars allocated
+    % during inner-goal compilation have register slots available
+    % for lookup.
+    aggregate_witness_clause(AggType, ValueVar, InnerGoal, Vf,
+                             WitnessRegsClause),
     (   InitValueCode \= ""
     ->  format(string(Code),
-            "~w~n    begin_aggregate ~w, ~w, ~w~n~w~n    end_aggregate ~w",
-            [InitValueCode, AggType, ValueReg, ResultReg0, FullInnerCode, ValueReg])
+            "~w~n    begin_aggregate ~w, ~w, ~w~w~n~w~n    end_aggregate ~w",
+            [InitValueCode, AggType, ValueReg, ResultReg0,
+             WitnessRegsClause, FullInnerCode, ValueReg])
     ;   format(string(Code),
-            "    begin_aggregate ~w, ~w, ~w~n~w~n    end_aggregate ~w",
-            [AggType, ValueReg, ResultReg0, FullInnerCode, ValueReg])
+            "    begin_aggregate ~w, ~w, ~w~w~n~w~n    end_aggregate ~w",
+            [AggType, ValueReg, ResultReg0, WitnessRegsClause,
+             FullInnerCode, ValueReg])
     ).
+
+%% aggregate_witness_clause(+AggType, +ValueVar, +InnerGoal, +V, -Clause)
+%  Build the trailing ", 'W1;W2;...'" string for begin_aggregate
+%  when AggType is bagof or setof. Returns "" for other kinds (so
+%  the existing 3-arg shape stays).
+aggregate_witness_clause(AggType, ValueVar, InnerGoal, V, Clause) :-
+    (   ( AggType == bagof ; AggType == setof )
+    ->  find_free_witnesses(ValueVar, InnerGoal, Witnesses),
+        witness_var_regs(Witnesses, V, WitnessRegs),
+        atomic_list_concat(WitnessRegs, ';', WitnessStr),
+        format(string(Clause), ", '~w'", [WitnessStr])
+    ;   Clause = ""
+    ).
+
+%% find_free_witnesses(+Template, +InnerGoal, -Witnesses)
+%  Vars in InnerGoal not in Template and not under ^/2.
+find_free_witnesses(Template, InnerGoal, Witnesses) :-
+    term_variables(Template, TemplateVars),
+    free_witness_walk(InnerGoal, TemplateVars, [], WitnessesRev),
+    list_to_set_var(WitnessesRev, Witnesses).
+
+free_witness_walk(Var, Exclude, Acc, Out) :-
+    var(Var), !,
+    (   memberchk_var(Var, Exclude)
+    ->  Out = Acc
+    ;   Out = [Var|Acc]
+    ).
+free_witness_walk(Atomic, _, Acc, Acc) :- atomic(Atomic), !.
+free_witness_walk(LHS^RHS, Exclude, Acc, Out) :- !,
+    term_variables(LHS, LHSVars),
+    append(LHSVars, Exclude, Exclude2),
+    free_witness_walk(RHS, Exclude2, Acc, Out).
+% Nested aggregate-style binders introduce their own scope: vars in
+% the inner Template (and the inner Result) are local to the inner
+% aggregate and don''t escape as witnesses of the outer. Walk only
+% the inner Goal with those vars added to the exclude set.
+free_witness_walk(bagof(T, G, R), Exclude, Acc, Out) :- !,
+    nested_aggregate_walk(T, G, R, Exclude, Acc, Out).
+free_witness_walk(setof(T, G, R), Exclude, Acc, Out) :- !,
+    nested_aggregate_walk(T, G, R, Exclude, Acc, Out).
+free_witness_walk(findall(T, G, R), Exclude, Acc, Out) :- !,
+    nested_aggregate_walk(T, G, R, Exclude, Acc, Out).
+free_witness_walk(aggregate_all(T, G, R), Exclude, Acc, Out) :- !,
+    nested_aggregate_walk(T, G, R, Exclude, Acc, Out).
+free_witness_walk(Compound, Exclude, Acc, Out) :-
+    Compound =.. [_|Args],
+    free_witness_walk_list(Args, Exclude, Acc, Out).
+
+nested_aggregate_walk(T, G, R, Exclude, Acc, Out) :-
+    term_variables(T, TVars),
+    term_variables(R, RVars),
+    append(TVars, RVars, Local0),
+    append(Local0, Exclude, Exclude2),
+    free_witness_walk(G, Exclude2, Acc, Out).
+
+free_witness_walk_list([], _, Acc, Acc).
+free_witness_walk_list([G|Gs], Exclude, Acc, Out) :-
+    free_witness_walk(G, Exclude, Acc, Acc2),
+    free_witness_walk_list(Gs, Exclude, Acc2, Out).
+
+memberchk_var(V, [X|_]) :- V == X, !.
+memberchk_var(V, [_|Rest]) :- memberchk_var(V, Rest).
+
+list_to_set_var([], []).
+list_to_set_var([V|Rest], [V|Out]) :-
+    \+ memberchk_var(V, Rest), !,
+    list_to_set_var(Rest, Out).
+list_to_set_var([_|Rest], Out) :-
+    list_to_set_var(Rest, Out).
+
+%% witness_var_regs(+Vars, +Varmap, -Regs)
+%  Look up each witness var''s register name in Varmap. If a var
+%  doesn''t have a register yet (rare — would mean it''s an
+%  unallocated singleton), it''s skipped silently.
+witness_var_regs([], _, []).
+witness_var_regs([V|Vs], Varmap, [Reg|Rest]) :-
+    catch(get_var_reg(V, Varmap, Reg), _, fail), !,
+    witness_var_regs(Vs, Varmap, Rest).
+witness_var_regs([_|Vs], Varmap, Rest) :-
+    witness_var_regs(Vs, Varmap, Rest).
 
 %% compile_compound_template(+Template, +V0, -Vf, -InitCode, -ConstructionCode)
 %  For findall(Functor(Arg1, Arg2, ...), Goal, L) with compound Template:

--- a/src/unifyweaver/targets/wam_text_parser.pl
+++ b/src/unifyweaver/targets/wam_text_parser.pl
@@ -174,6 +174,8 @@ wam_recognise_instruction(["trust_me"],                trust_me).
 wam_recognise_instruction(["jump", L],                 jump(L)).
 wam_recognise_instruction(["cut_ite"],                 cut_ite).
 wam_recognise_instruction(["begin_aggregate", K, V, R], begin_aggregate(K, V, R)).
+wam_recognise_instruction(["begin_aggregate", K, V, R, W],
+                                                       begin_aggregate(K, V, R, W)).
 wam_recognise_instruction(["end_aggregate", R],        end_aggregate(R)).
 % Indexing instructions: variable-arity tail tokens captured as a list,
 % target-side decoders parse them per the dispatch-table convention.

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -594,7 +594,9 @@ user:wam_cpp_test_bif_cut_commits :-
 :- dynamic user:wam_cpp_test_bagof_meta_groups_by_witness/0.
 :- dynamic user:wam_cpp_test_bagof_meta_existential_no_grouping/0.
 :- dynamic user:wam_cpp_test_setof_meta_groups_sorted/0.
-:- dynamic user:wam_cpp_test_bagof_inlined_flattens/0.
+:- dynamic user:wam_cpp_test_bagof_inlined_groups_by_witness/0.
+:- dynamic user:wam_cpp_test_bagof_inlined_existential_flattens/0.
+:- dynamic user:wam_cpp_test_setof_inlined_groups_sorted/0.
 
 user:wam_cpp_parent_fixture(tom, bob).
 user:wam_cpp_parent_fixture(tom, alice).
@@ -621,12 +623,27 @@ user:wam_cpp_test_setof_meta_groups_sorted :-
     L = [alice, bob],
     P = tom.
 
-% Inlined outer bagof — no witness collection (witness_cells
-% empty), so behaves like findall (all 3 children, no grouping).
-% Regression guard that the existing inlined path is untouched.
-user:wam_cpp_test_bagof_inlined_flattens :-
-    bagof(C, wam_cpp_parent_fixture(_P, C), L),
+% Inlined outer bagof — the WAM compiler now emits free-witness
+% register info alongside BeginAggregate (4-arg form), so the inlined
+% path does ISO witness grouping just like the meta-call path. First
+% group is P=tom -> L=[bob, alice]; witness binds back to the caller.
+user:wam_cpp_test_bagof_inlined_groups_by_witness :-
+    bagof(C, wam_cpp_parent_fixture(P, C), L),
+    L = [bob, alice],
+    P = tom.
+
+% Inlined bagof with caret existential — P is suppressed, so no
+% witnesses are emitted (empty 4-arg). Falls back to single-group
+% flat collection, matching the previous behaviour.
+user:wam_cpp_test_bagof_inlined_existential_flattens :-
+    bagof(C, P^wam_cpp_parent_fixture(P, C), L),
     L = [bob, alice, carol].
+
+% Inlined setof grouping — first group sorted by term order.
+user:wam_cpp_test_setof_inlined_groups_sorted :-
+    setof(C, wam_cpp_parent_fixture(P, C), L),
+    L = [alice, bob],
+    P = tom.
 
 % Bagof/setof GROUP BACKTRACKING — second-group binding works via
 % the aggregate_next_group_pc CP machinery. Outer findall drives
@@ -2724,23 +2741,64 @@ test(cpp_e2e_setof_meta_groups_sorted,
         delete_directory_and_contents(TmpDir)
     ).
 
-test(cpp_e2e_bagof_inlined_flattens,
+test(cpp_e2e_bagof_inlined_groups_by_witness,
      [condition(cpp_compiler_available)]) :-
     % Inlined outer bagof — the WAM compiler emits direct
-    % BeginAggregate/EndAggregate, NOT a meta-call. Witness
-    % collection requires a goal-term to walk; for inlined there''s
-    % no term so witness_cells stays empty → no grouping (findall-
-    % like). Regression guard that the existing inlined path is
-    % untouched.
-    unique_cpp_tmp_dir('tmp_cpp_e2e_bagof_inlined', TmpDir),
+    % BeginAggregate/EndAggregate with the 4-arg form carrying free-
+    % witness register info. The runtime resolves them lazily at
+    % EndAggregate (witness Y-regs get allocated INSIDE the aggregate
+    % body) and snapshots witness values parallel to acc, so the
+    % finaliser groups by witness equality. First group: P=tom,
+    % L=[bob, alice]; witness binding flows back to the caller.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_bagof_inl_grp', TmpDir),
     setup_call_cleanup(
         write_wam_cpp_project(
             [user:wam_cpp_parent_fixture/2,
-             user:wam_cpp_test_bagof_inlined_flattens/0],
+             user:wam_cpp_test_bagof_inlined_groups_by_witness/0],
             [emit_main(true)], TmpDir),
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath,
-                    'wam_cpp_test_bagof_inlined_flattens/0',
+                    'wam_cpp_test_bagof_inlined_groups_by_witness/0',
+                    [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_bagof_inlined_existential_flattens,
+     [condition(cpp_compiler_available)]) :-
+    % ^/2 existential on the inlined path → no witnesses emitted
+    % (4th begin_aggregate arg is empty). The frame''s witness_regs
+    % stays empty, so EndAggregate does the simple non-grouping path
+    % and aggregate-finalise builds one flat group. Regression guard
+    % that the existential-quantified inlined path keeps working.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_bagof_inl_ex', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_parent_fixture/2,
+             user:wam_cpp_test_bagof_inlined_existential_flattens/0],
+            [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_bagof_inlined_existential_flattens/0',
+                    [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_setof_inlined_groups_sorted,
+     [condition(cpp_compiler_available)]) :-
+    % setof on the inlined path: same witness grouping as bagof,
+    % per-group template list sorted via term_less. First group:
+    % P=tom, L=[alice, bob].
+    unique_cpp_tmp_dir('tmp_cpp_e2e_setof_inl_grp', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_parent_fixture/2,
+             user:wam_cpp_test_setof_inlined_groups_sorted/0],
+            [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_setof_inlined_groups_sorted/0',
                     [], true)
         ),
         delete_directory_and_contents(TmpDir)

--- a/tests/test_wam_text_parser.pl
+++ b/tests/test_wam_text_parser.pl
@@ -128,6 +128,29 @@ test(recognise_switch_on_constant_captures_tail) :-
 test(recognise_unknown_instruction_fails, [fail]) :-
     wam_recognise_instruction(["unknown_op", "X"], _).
 
+test(recognise_begin_aggregate_3_arg, [nondet]) :-
+    % findall/aggregate_all forms — no witness slot.
+    wam_recognise_instruction(["begin_aggregate", "collect", "Y1", "Y2"], I),
+    assertion(I == begin_aggregate("collect", "Y1", "Y2")).
+
+test(recognise_begin_aggregate_4_arg, [nondet]) :-
+    % bagof/setof inlined form — 4th arg carries the free-witness
+    % register names as a semicolon-delimited string (here just "Y3").
+    wam_recognise_instruction(
+        ["begin_aggregate", "bagof", "Y1", "Y2", "Y3"], I),
+    assertion(I == begin_aggregate("bagof", "Y1", "Y2", "Y3")).
+
+test(recognise_begin_aggregate_4_arg_multiple_witnesses, [nondet]) :-
+    wam_recognise_instruction(
+        ["begin_aggregate", "setof", "Y1", "Y2", "Y3;Y4"], I),
+    assertion(I == begin_aggregate("setof", "Y1", "Y2", "Y3;Y4")).
+
+test(recognise_begin_aggregate_4_arg_empty_witnesses, [nondet]) :-
+    % Existentially-quantified bagof — witness arg is empty string.
+    wam_recognise_instruction(
+        ["begin_aggregate", "bagof", "Y1", "Y2", ""], I),
+    assertion(I == begin_aggregate("bagof", "Y1", "Y2", "")).
+
 % ------------------------------------------------------------------
 % wam_text_to_items/2 — end-to-end
 % ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the last bagof/setof gap from the meta-call PRs: the **inlined** (outermost) bagof/setof path now does ISO witness grouping, matching what the meta-call path already had.

The WAM compiler emits free-witness register info as a 4th arg of `begin_aggregate`. The C++ runtime resolves witness regs lazily at `EndAggregate` (Y-regs for witnesses get allocated *inside* the aggregate body, after `BeginAggregate` has fired), snapshots witness values parallel to `acc`, and the existing finalise path partitions by witness equality through the aggregate-group-iterator.

## Changes

- **`wam_target.pl`** — `compile_aggregate_all` calls `aggregate_witness_clause` to compute free witnesses (vars in `InnerGoal` not in `Template` and not under `^/2`) and append their registers as `, 'Y1;Y2;…'` to the `begin_aggregate` line. The walker treats nested `bagof/setof/findall/aggregate_all` as binders so their inner template + result vars don't leak out as outer witnesses.
- **`wam_text_parser.pl`** — recognises the 5-token form `begin_aggregate K, V, R, W` alongside the existing 4-token form. Other targets that don't enable `inline_bagof_setof(true)` keep emitting/consuming the 3-arg form unchanged.
- **`wam_cpp_target.pl`** — new 4-string `BeginAggregate` factory overload (stores witness regs in `instr.c`), `AggregateFrame.witness_regs` holds the names, `EndAggregate` lazily resolves them via `get_cell` on first iteration (the env frame keeps the same Y-reg `shared_ptr` across body retries) and snapshots witnesses into `acc_witnesses`. New emission clause `wam_instruction_to_cpp_literal_det/3` for `begin_aggregate/4`.
- **Tests** — replaces the `bagof_inlined_flattens` regression guard (which asserted the OLD non-grouping behaviour) with three new e2e tests: by-witness grouping, existential flattening, setof sorted grouping. Adds four `wam_recognise_instruction` tests for the 3-arg and 4-arg `begin_aggregate` recogniser variants.

## Test plan

- [x] `tests/test_wam_target.pl` — 8 tests pass
- [x] `tests/test_wam_text_parser.pl` — 32 tests pass (incl. 4 new)
- [x] `tests/test_wam_cpp_generator.pl` — 138 tests pass (incl. 3 new e2e + 1 repurposed)
- [x] Smoke probe: `bagof(C, parent(P, C), L)` inlined → emits `begin_aggregate bagof, Y1, Y3, 'Y2'`; runtime groups → first solution `P=tom, L=[bob, alice]`

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_