### PR TITLE
tool(csharp-query): Report actionable C# query source-mode calibration rows

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -192,6 +192,17 @@ When intentionally adding new workload/scale rows to a calibration artifact,
 also pass `--allow-new-calibration-rows`. Keep that flag off for normal
 refreshes so missing baseline rows still fail as calibration drift.
 
+To review source-mode policy tuning candidates without reading every
+calibration row, use:
+
+```bash
+python examples/benchmark/report_csharp_query_source_mode_actions.py --format markdown
+```
+
+The report includes rows where the current `auto` policy differs from the
+observed best mode, plus rows where `auto` is slower than the best mode by the
+configured `--slow-ratio`.
+
 ### WAM-Rust and WAM-Haskell Benchmark Variants
 
 The effective-distance harness also includes hybrid WAM benchmark targets:
@@ -604,6 +615,7 @@ Tables:
 | `benchmark_csharp_query_source_mode_sweep.py` | Run generated C# query source-mode sweeps across selected workloads and emit a compact TSV/Markdown comparison |
 | `refresh_csharp_query_source_mode_calibration.py` | Refresh the graph source-mode calibration TSV with guarded idle checks |
 | `refresh_csharp_query_scan_source_mode_calibration.py` | Refresh the scan-materialization source-mode calibration TSV with guarded idle checks |
+| `report_csharp_query_source_mode_actions.py` | Report graph and scan calibration rows where the current source-mode policy differs from observed best or `auto` is slow |
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
 | `benchmark_scan_materialization.py` | Exercise relation scan, pattern scan, binary/n-ary join, negation, and aggregate under the scan materialization planner; use `--format markdown` or `--format report-tsv` with `join,nary_join` to compare source registrations and artifact bucket strategy rows; use `--format calibration-tsv` or `--format calibration-markdown` to summarize auto-policy chosen-vs-best status, 10% timing tolerance, overlap confidence, slow matches, auto median, and timing spread; use `--format actionable-tsv` or `--format actionable-markdown` to show only separated timing regressions worth policy review |
 | `benchmark_closure_materialization.py` | Exercise generic seeded closure and streamed auxiliary accumulation under the closure materialization planner |

--- a/examples/benchmark/report_csharp_query_source_mode_actions.py
+++ b/examples/benchmark/report_csharp_query_source_mode_actions.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+Report actionable C# query source-mode calibration rows.
+
+The calibration TSVs keep every measured row. This report filters them down to
+rows where the runtime's current auto policy differs from the observed best
+source mode, or where auto is slower than the best mode by a configured ratio.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmark_common import scale_sort_key
+from benchmark_csharp_query_source_mode_sweep import (
+    CALIBRATION_ARTIFACT,
+    CalibrationArtifactRow,
+    load_calibration_artifact,
+    parse_ratio,
+)
+
+
+BENCHMARK_DIR = Path(__file__).resolve().parent
+SCAN_CALIBRATION_ARTIFACT = BENCHMARK_DIR / "csharp_query_scan_source_mode_calibration.tsv"
+
+
+@dataclass(frozen=True)
+class ActionableCalibrationRow:
+    artifact: str
+    workload: str
+    scale: str
+    reason: str
+    current_auto_resolved_source_mode: str
+    observed_best_source_mode: str
+    observed_auto_vs_best: str
+    median_summary: str
+    source_registration_summary: str
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--graph-artifact",
+        type=Path,
+        default=CALIBRATION_ARTIFACT,
+        help="Graph source-mode calibration TSV.",
+    )
+    parser.add_argument(
+        "--scan-artifact",
+        type=Path,
+        default=SCAN_CALIBRATION_ARTIFACT,
+        help="Scan-materialization source-mode calibration TSV.",
+    )
+    parser.add_argument(
+        "--slow-ratio",
+        type=float,
+        default=1.10,
+        help="Report rows whose observed auto-vs-best ratio is at or above this value.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("tsv", "markdown"),
+        default="tsv",
+        help="Output format.",
+    )
+    return parser.parse_args(argv)
+
+
+def actionable_rows_from_artifacts(
+    artifacts: list[tuple[str, Path]],
+    *,
+    slow_ratio: float = 1.10,
+) -> list[ActionableCalibrationRow]:
+    rows: list[ActionableCalibrationRow] = []
+    for artifact_name, path in artifacts:
+        rows.extend(
+            actionable_rows(
+                artifact_name,
+                load_calibration_artifact(path),
+                slow_ratio=slow_ratio,
+            )
+        )
+    return sorted(rows, key=_action_sort_key)
+
+
+def actionable_rows(
+    artifact_name: str,
+    calibration_rows: list[CalibrationArtifactRow],
+    *,
+    slow_ratio: float = 1.10,
+) -> list[ActionableCalibrationRow]:
+    actions: list[ActionableCalibrationRow] = []
+    for row in calibration_rows:
+        reasons = actionable_reasons(row, slow_ratio=slow_ratio)
+        if not reasons:
+            continue
+        actions.append(
+            ActionableCalibrationRow(
+                artifact=artifact_name,
+                workload=row.workload,
+                scale=row.scale,
+                reason=",".join(reasons),
+                current_auto_resolved_source_mode=row.current_auto_resolved_source_mode,
+                observed_best_source_mode=row.observed_best_source_mode,
+                observed_auto_vs_best=row.observed_auto_vs_best,
+                median_summary=row.median_summary,
+                source_registration_summary=row.source_registration_summary,
+            )
+        )
+    return actions
+
+
+def actionable_reasons(row: CalibrationArtifactRow, *, slow_ratio: float) -> list[str]:
+    reasons: list[str] = []
+    if row.current_auto_resolved_source_mode != row.observed_best_source_mode:
+        reasons.append("policy-diff")
+
+    ratio = parse_ratio(row.observed_auto_vs_best)
+    if ratio is not None and ratio >= slow_ratio:
+        reasons.append("slow-auto")
+    return reasons
+
+
+def render_tsv(rows: list[ActionableCalibrationRow]) -> str:
+    lines = [
+        (
+            "artifact\tworkload\tscale\treason\tcurrent_auto_resolved_source_mode\t"
+            "observed_best_source_mode\tobserved_auto_vs_best\tmedian_s_by_mode\t"
+            "source_registrations_by_mode"
+        )
+    ]
+    for row in rows:
+        lines.append(
+            (
+                f"{row.artifact}\t{row.workload}\t{row.scale}\t{row.reason}\t"
+                f"{row.current_auto_resolved_source_mode}\t{row.observed_best_source_mode}\t"
+                f"{row.observed_auto_vs_best}\t{row.median_summary}\t"
+                f"{row.source_registration_summary}"
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def render_markdown(rows: list[ActionableCalibrationRow]) -> str:
+    lines = [
+        "| Artifact | Workload | Scale | Reason | Auto | Best | Auto vs Best |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        lines.append(
+            (
+                f"| {row.artifact} | {row.workload} | {row.scale} | {row.reason} | "
+                f"{row.current_auto_resolved_source_mode} | {row.observed_best_source_mode} | "
+                f"{row.observed_auto_vs_best} |"
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _action_sort_key(row: ActionableCalibrationRow) -> tuple[str, str, tuple[int, str]]:
+    return (row.artifact, row.workload, scale_sort_key(row.scale))
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    rows = actionable_rows_from_artifacts(
+        [
+            ("graph", args.graph_artifact),
+            ("scan", args.scan_artifact),
+        ],
+        slow_ratio=args.slow_ratio,
+    )
+    if args.format == "markdown":
+        print(render_markdown(rows), end="")
+    else:
+        print(render_tsv(rows), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_csharp_query_source_mode_action_report.py
+++ b/tests/test_csharp_query_source_mode_action_report.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
+
+from benchmark_csharp_query_source_mode_sweep import (  # noqa: E402
+    CalibrationArtifactRow,
+    write_calibration_artifact,
+)
+from report_csharp_query_source_mode_actions import (  # noqa: E402
+    actionable_reasons,
+    actionable_rows,
+    actionable_rows_from_artifacts,
+    main,
+    render_markdown,
+    render_tsv,
+)
+
+
+class CSharpQuerySourceModeActionReportTests(unittest.TestCase):
+    def test_actionable_reasons_flags_policy_diff_and_slow_auto(self) -> None:
+        row = self._row(
+            current_auto_resolved_source_mode="preload",
+            observed_best_source_mode="artifact-prebuilt",
+            observed_auto_vs_best="1.25x",
+        )
+
+        self.assertEqual(
+            actionable_reasons(row, slow_ratio=1.10),
+            ["policy-diff", "slow-auto"],
+        )
+
+    def test_actionable_rows_ignores_matching_fast_rows(self) -> None:
+        rows = actionable_rows(
+            "graph",
+            [
+                self._row(
+                    current_auto_resolved_source_mode="preload",
+                    observed_best_source_mode="preload",
+                    observed_auto_vs_best="1.01x",
+                )
+            ],
+        )
+
+        self.assertEqual(rows, [])
+
+    def test_actionable_rows_from_artifacts_sorts_by_artifact_workload_scale(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            graph_path = Path(tmp_dir) / "graph.tsv"
+            scan_path = Path(tmp_dir) / "scan.tsv"
+            write_calibration_artifact(
+                graph_path,
+                [
+                    self._row(workload="weighted-shortest-path", scale="10k"),
+                    self._row(workload="weighted-shortest-path", scale="1k"),
+                ],
+            )
+            write_calibration_artifact(scan_path, [self._row(workload="scan-materialization:join")])
+
+            rows = actionable_rows_from_artifacts(
+                [("scan", scan_path), ("graph", graph_path)],
+                slow_ratio=1.10,
+            )
+
+        self.assertEqual(
+            [(row.artifact, row.workload, row.scale) for row in rows],
+            [
+                ("graph", "weighted-shortest-path", "1k"),
+                ("graph", "weighted-shortest-path", "10k"),
+                ("scan", "scan-materialization:join", "300"),
+            ],
+        )
+
+    def test_render_tsv_includes_reason_and_modes(self) -> None:
+        report = render_tsv(actionable_rows("graph", [self._row()]))
+
+        self.assertIn("artifact\tworkload\tscale\treason", report)
+        self.assertIn("graph\tcategory-influence\t300\tpolicy-diff", report)
+        self.assertIn("preload\tauto\t1.00x", report)
+
+    def test_render_markdown_includes_compact_table(self) -> None:
+        report = render_markdown(actionable_rows("graph", [self._row()]))
+
+        self.assertIn("| Artifact | Workload | Scale | Reason | Auto | Best | Auto vs Best |", report)
+        self.assertIn("| graph | category-influence | 300 | policy-diff | preload | auto | 1.00x |", report)
+
+    def test_main_accepts_temp_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            graph_path = Path(tmp_dir) / "graph.tsv"
+            scan_path = Path(tmp_dir) / "scan.tsv"
+            write_calibration_artifact(graph_path, [self._row()])
+            write_calibration_artifact(scan_path, [])
+
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                self.assertEqual(
+                    main(
+                        [
+                            "--graph-artifact",
+                            str(graph_path),
+                            "--scan-artifact",
+                            str(scan_path),
+                            "--format",
+                            "markdown",
+                        ]
+                    ),
+                    0,
+                )
+            self.assertIn("| graph | category-influence | 300 |", stdout.getvalue())
+
+    @staticmethod
+    def _row(
+        *,
+        workload: str = "category-influence",
+        scale: str = "300",
+        current_auto_resolved_source_mode: str = "preload",
+        observed_best_source_mode: str = "auto",
+        observed_auto_vs_best: str = "1.00x",
+    ) -> CalibrationArtifactRow:
+        return CalibrationArtifactRow(
+            workload=workload,
+            scale=scale,
+            observed_best_source_mode=observed_best_source_mode,
+            current_auto_resolved_source_mode=current_auto_resolved_source_mode,
+            observed_auto_vs_best=observed_auto_vs_best,
+            output_agreement="match",
+            median_summary="artifact-prebuilt:0.904,auto:0.467,preload:0.360",
+            resolved_source_mode_summary="artifact-prebuilt:artifact-prebuilt,auto:preload,preload:preload",
+            source_registration_summary="auto:preloaded:preload:arity2=3",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  - Adds `report_csharp_query_source_mode_actions.py` to summarize graph and scan calibration rows that need policy review.
  - Reports rows where the current `auto` policy differs from the observed best source mode.
  - Reports rows where `auto` is slower than best by the configurable `--slow-ratio`.
  - Documents the report command in the benchmark README.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_source_mode_action_report.py tests/test_csharp_query_source_mode_sweep.py`
  - `python3 -m py_compile examples/benchmark/report_csharp_query_source_mode_actions.py tests/
  test_csharp_query_source_mode_action_report.py examples/benchmark/benchmark_csharp_query_source_mode_sweep.py`
  - `python3 examples/benchmark/report_csharp_query_source_mode_actions.py --format markdown`
  - `git diff --check`