### PR TITLE
feat(csharp-query): add artifact provider factory seam

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -384,6 +384,64 @@ namespace UnifyWeaver.QueryRuntime
         bool TryGetRelationCardinality(PredicateId predicate, out long rowCount);
     }
 
+    public sealed record RelationArtifactProviderOpenResult(
+        IRelationProvider Provider,
+        string StorageKind);
+
+    public interface IRelationArtifactProviderFactory
+    {
+        bool TryOpen(
+            PredicateId predicate,
+            string manifestPath,
+            IRelationProvider? fallback,
+            out RelationArtifactProviderOpenResult result);
+    }
+
+    public sealed class DefaultRelationArtifactProviderFactory : IRelationArtifactProviderFactory
+    {
+        public bool TryOpen(
+            PredicateId predicate,
+            string manifestPath,
+            IRelationProvider? fallback,
+            out RelationArtifactProviderOpenResult result)
+        {
+            if (manifestPath is null) throw new ArgumentNullException(nameof(manifestPath));
+
+            var format = RelationArtifactManifestFormatReader.ReadFormat(manifestPath);
+            switch (format)
+            {
+                case BinaryRelationArtifactManifest.CurrentFormat:
+                    var binaryProvider = new BinaryRelationArtifactProvider(fallback);
+                    binaryProvider.RegisterArtifact(predicate, manifestPath);
+                    result = new RelationArtifactProviderOpenResult(binaryProvider, "binary_artifact");
+                    return true;
+                case DelimitedRelationArtifactManifest.CurrentFormat:
+                    var delimitedProvider = new DelimitedRelationArtifactProvider(fallback);
+                    delimitedProvider.RegisterArtifact(predicate, manifestPath);
+                    result = new RelationArtifactProviderOpenResult(delimitedProvider, "delimited_artifact");
+                    return true;
+                default:
+                    result = default!;
+                    return false;
+            }
+        }
+    }
+
+    internal static class RelationArtifactManifestFormatReader
+    {
+        public static string ReadFormat(string manifestPath)
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(manifestPath, Encoding.UTF8));
+            if (!document.RootElement.TryGetProperty("Format", out var formatElement) &&
+                !document.RootElement.TryGetProperty("format", out formatElement))
+            {
+                throw new InvalidDataException($"Relation artifact manifest has no format: {manifestPath}");
+            }
+
+            return formatElement.GetString() ?? string.Empty;
+        }
+    }
+
     internal static class RelationArtifactBucketRows
     {
         public static IEnumerable<IndexedRelationBucket> ReadBucketsFromBucketRows(

--- a/tests/test_csharp_query_source_mode_policy.py
+++ b/tests/test_csharp_query_source_mode_policy.py
@@ -23,6 +23,7 @@ from benchmark_csharp_query_source_mode_sweep import load_calibration_artifact  
 SCAN_CALIBRATION_ARTIFACT = ROOT / "examples" / "benchmark" / "csharp_query_scan_source_mode_calibration.tsv"
 SCAN_WORKLOAD_PREFIX = "scan-materialization:"
 SMALL_PREBUILT_ARTIFACT_ROW_THRESHOLD = 7_500
+QUERY_RUNTIME_SOURCE = ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
 
 
 class CSharpQuerySourceModePolicyTests(unittest.TestCase):
@@ -106,9 +107,7 @@ class CSharpQuerySourceModePolicyTests(unittest.TestCase):
         )
 
     def test_runtime_scan_source_mode_policy_matches_documented_cases(self) -> None:
-        runtime_source = (
-            ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
-        ).read_text()
+        runtime_source = QUERY_RUNTIME_SOURCE.read_text()
 
         expected_cases = [
             "private const long SmallPrebuiltArtifactRowThreshold = 7_500L",
@@ -147,9 +146,7 @@ class CSharpQuerySourceModePolicyTests(unittest.TestCase):
                 )
 
     def test_runtime_source_mode_policy_matches_calibration_artifact(self) -> None:
-        runtime_source = (
-            ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
-        ).read_text()
+        runtime_source = QUERY_RUNTIME_SOURCE.read_text()
 
         for row in load_calibration_artifact():
             with self.subTest(workload=row.workload):
@@ -157,6 +154,29 @@ class CSharpQuerySourceModePolicyTests(unittest.TestCase):
                     f'"{row.workload}" => RelationSourceMode.{self._source_mode_member(row.current_auto_resolved_source_mode)}',
                     runtime_source,
                 )
+
+    def test_runtime_has_dependency_free_artifact_provider_factory(self) -> None:
+        runtime_source = QUERY_RUNTIME_SOURCE.read_text()
+
+        expected_contract = [
+            "public sealed record RelationArtifactProviderOpenResult",
+            "public interface IRelationArtifactProviderFactory",
+            "public sealed class DefaultRelationArtifactProviderFactory",
+            "BinaryRelationArtifactManifest.CurrentFormat:",
+            "DelimitedRelationArtifactManifest.CurrentFormat:",
+            "new BinaryRelationArtifactProvider(fallback)",
+            "new DelimitedRelationArtifactProvider(fallback)",
+            'new RelationArtifactProviderOpenResult(binaryProvider, "binary_artifact")',
+            'new RelationArtifactProviderOpenResult(delimitedProvider, "delimited_artifact")',
+            "RelationArtifactManifestFormatReader.ReadFormat(manifestPath)",
+        ]
+
+        for expected in expected_contract:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, runtime_source)
+
+        self.assertNotIn("LightningDB", runtime_source)
+        self.assertNotIn("LmdbRelationProvider", runtime_source)
 
     @staticmethod
     def _source_mode_member(source_mode: str) -> str:


### PR DESCRIPTION
  ## Summary

  Adds a dependency-free C# query artifact provider factory seam for opening existing binary and delimited relation artifacts
  by manifest format.

  This keeps `UnifyWeaver.QueryRuntime.Core` free of LMDB/LightningDB while creating a narrow extension point for future
  optional source backends such as LMDB or memory-mapped arrays.

  ## Changes

  - Added `IRelationArtifactProviderFactory` and `DefaultRelationArtifactProviderFactory`.
  - Added `RelationArtifactProviderOpenResult` carrying the opened provider and storage kind.
  - Added manifest-format dispatch for existing binary and delimited artifact providers.
  - Added regression coverage that locks down the factory contract and verifies no LMDB dependency is introduced into core.

  ## Verification

  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py`
  - `python3 -m py_compile tests/test_csharp_query_source_mode_policy.py`
  - `git diff --check`
  - `env SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  test_csharp_query_target:test_csharp_query_target -t halt`
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj --no-restore`