### PR TITLE
feat(csharp-query): Add optional LMDB relation provider smoke

### DIFF
--- a/docs/targets/csharp-query-high-performance-sources.md
+++ b/docs/targets/csharp-query-high-performance-sources.md
@@ -255,7 +255,8 @@ need manual override:
 
 ## Open Questions
 
-- Should the first C# LMDB reader consume the Rust prototype manifest or define
-  a C#-owned manifest that later converges with the shared proposal?
+- The first C# LMDB reader uses a C#-owned manifest
+  (`unifyweaver.lmdb_relation.v1`) that matches the existing C#/Python ingest
+  key/value contract and can later converge with the shared artifact proposal.
 - Which workloads should drive the first LMDB measurement: graph parent lookup,
   scan-materialization joins, or effective-distance support relations?

--- a/src/unifyweaver/targets/csharp_query_runtime_lmdb/LmdbRelationProvider.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime_lmdb/LmdbRelationProvider.cs
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Optional LMDB-backed relation provider for C# query runtime artifacts.
+
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using LightningDB;
+
+namespace UnifyWeaver.QueryRuntime;
+
+public sealed class LmdbRelationArtifactManifest
+{
+    public const string CurrentFormat = "unifyweaver.lmdb_relation.v1";
+
+    public string Format { get; set; } = CurrentFormat;
+
+    public int Version { get; set; } = 1;
+
+    public string Backend { get; set; } = "lmdb";
+
+    public string PredicateName { get; set; } = string.Empty;
+
+    public int Arity { get; set; } = 2;
+
+    public string EnvironmentPath { get; set; } = string.Empty;
+
+    public string? DatabaseName { get; set; }
+
+    public bool DupSort { get; set; }
+
+    public string KeyEncoding { get; set; } = "utf8";
+
+    public string ValueEncoding { get; set; } = "utf8";
+
+    public long RowCount { get; set; }
+
+    public string? SourcePath { get; set; }
+
+    public long? SourceLength { get; set; }
+
+    public string? SourceSha256 { get; set; }
+
+    public void Validate(string manifestPath)
+    {
+        if (!string.Equals(Format, CurrentFormat, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException($"Unsupported LMDB relation artifact format '{Format}': {manifestPath}");
+        }
+
+        if (Version != 1)
+        {
+            throw new InvalidDataException($"Unsupported LMDB relation artifact manifest version {Version}: {manifestPath}");
+        }
+
+        if (!string.Equals(Backend, "lmdb", StringComparison.Ordinal))
+        {
+            throw new InvalidDataException($"LMDB relation artifact has unsupported backend '{Backend}': {manifestPath}");
+        }
+
+        if (string.IsNullOrWhiteSpace(PredicateName))
+        {
+            throw new InvalidDataException($"LMDB relation artifact manifest has no predicate name: {manifestPath}");
+        }
+
+        if (Arity != 2)
+        {
+            throw new InvalidDataException($"LMDB relation artifact smoke provider only supports arity-2 facts: {manifestPath}");
+        }
+
+        if (string.IsNullOrWhiteSpace(EnvironmentPath))
+        {
+            throw new InvalidDataException($"LMDB relation artifact manifest has no environment path: {manifestPath}");
+        }
+
+        if (RowCount < 0)
+        {
+            throw new InvalidDataException($"LMDB relation artifact row count must be non-negative: {manifestPath}");
+        }
+
+        ValidateEncoding(KeyEncoding, manifestPath);
+        ValidateEncoding(ValueEncoding, manifestPath);
+    }
+
+    private static void ValidateEncoding(string encoding, string manifestPath)
+    {
+        if (!string.Equals(encoding, "utf8", StringComparison.Ordinal) &&
+            !string.Equals(encoding, "int32_le", StringComparison.Ordinal))
+        {
+            throw new InvalidDataException($"LMDB relation artifact has unsupported value encoding '{encoding}': {manifestPath}");
+        }
+    }
+}
+
+public static class LmdbRelationArtifactReader
+{
+    public static LmdbRelationArtifactManifest LoadManifest(string manifestPath)
+    {
+        if (manifestPath is null) throw new ArgumentNullException(nameof(manifestPath));
+        var manifest = JsonSerializer.Deserialize<LmdbRelationArtifactManifest>(File.ReadAllText(manifestPath, Encoding.UTF8))
+            ?? throw new InvalidDataException($"LMDB relation artifact manifest is empty: {manifestPath}");
+        manifest.Validate(manifestPath);
+        return manifest;
+    }
+
+    public static string ResolveEnvironmentPath(LmdbRelationArtifactManifest manifest, string manifestPath)
+    {
+        var environmentPath = manifest.EnvironmentPath;
+        return Path.IsPathRooted(environmentPath)
+            ? environmentPath
+            : Path.Combine(Path.GetDirectoryName(Path.GetFullPath(manifestPath)) ?? ".", environmentPath);
+    }
+}
+
+public sealed class LmdbRelationProvider : IIndexedRelationProvider, IRelationCardinalityProvider
+{
+    private readonly IRelationProvider? _fallback;
+    private readonly Dictionary<PredicateId, string> _manifestPaths = new();
+
+    public LmdbRelationProvider(IRelationProvider? fallback = null)
+    {
+        _fallback = fallback;
+    }
+
+    public void RegisterArtifact(PredicateId predicate, string manifestPath)
+    {
+        if (manifestPath is null) throw new ArgumentNullException(nameof(manifestPath));
+        var manifest = LmdbRelationArtifactReader.LoadManifest(manifestPath);
+        if (!string.Equals(manifest.PredicateName, predicate.Name, StringComparison.Ordinal) ||
+            manifest.Arity != predicate.Arity)
+        {
+            throw new InvalidDataException($"LMDB relation artifact manifest describes {manifest.PredicateName}/{manifest.Arity}, not {predicate}.");
+        }
+
+        _manifestPaths[predicate] = manifestPath;
+    }
+
+    public IEnumerable<object[]> GetFacts(PredicateId predicate)
+    {
+        if (!_manifestPaths.TryGetValue(predicate, out var manifestPath))
+        {
+            return _fallback?.GetFacts(predicate) ?? Array.Empty<object[]>();
+        }
+
+        return ReadRows(manifestPath);
+    }
+
+    public bool TryLookupFacts(PredicateId predicate, int columnIndex, IEnumerable<object> keys, out IEnumerable<object[]> facts)
+    {
+        if (columnIndex == 0 && _manifestPaths.TryGetValue(predicate, out var manifestPath))
+        {
+            facts = LookupRows(manifestPath, keys);
+            return true;
+        }
+
+        if (_fallback is IIndexedRelationProvider indexedFallback &&
+            indexedFallback.TryLookupFacts(predicate, columnIndex, keys, out facts))
+        {
+            return true;
+        }
+
+        facts = default!;
+        return false;
+    }
+
+    public bool TryGetRelationCardinality(PredicateId predicate, out long rowCount)
+    {
+        if (_manifestPaths.TryGetValue(predicate, out var manifestPath))
+        {
+            rowCount = LmdbRelationArtifactReader.LoadManifest(manifestPath).RowCount;
+            return true;
+        }
+
+        if (_fallback is IRelationCardinalityProvider cardinalityFallback &&
+            cardinalityFallback.TryGetRelationCardinality(predicate, out rowCount))
+        {
+            return true;
+        }
+
+        rowCount = 0;
+        return false;
+    }
+
+    private static IEnumerable<object[]> ReadRows(string manifestPath)
+    {
+        var manifest = LmdbRelationArtifactReader.LoadManifest(manifestPath);
+        using var env = OpenEnvironment(manifest, manifestPath);
+        using var tx = env.BeginTransaction(TransactionBeginFlags.ReadOnly);
+        using var db = OpenDatabase(tx, manifest);
+        using var cursor = tx.CreateCursor(db);
+
+        for (var current = cursor.First();
+             current.resultCode == MDBResultCode.Success;
+             current = cursor.Next())
+        {
+            yield return DecodeRow(manifest, current.key.AsSpan(), current.value.AsSpan());
+        }
+    }
+
+    private static IEnumerable<object[]> LookupRows(string manifestPath, IEnumerable<object> keys)
+    {
+        var manifest = LmdbRelationArtifactReader.LoadManifest(manifestPath);
+        using var env = OpenEnvironment(manifest, manifestPath);
+        using var tx = env.BeginTransaction(TransactionBeginFlags.ReadOnly);
+        using var db = OpenDatabase(tx, manifest);
+        using var cursor = tx.CreateCursor(db);
+
+        foreach (var key in keys)
+        {
+            var keyBytes = EncodeValue(key, manifest.KeyEncoding);
+            if (manifest.DupSort)
+            {
+                var result = cursor.Set(keyBytes);
+                if (result != MDBResultCode.Success)
+                {
+                    continue;
+                }
+
+                do
+                {
+                    var current = cursor.GetCurrent();
+                    yield return DecodeRow(manifest, current.key.AsSpan(), current.value.AsSpan());
+                }
+                while (cursor.NextDuplicate().resultCode == MDBResultCode.Success);
+            }
+            else
+            {
+                var (resultCode, currentKey, currentValue) = tx.Get(db, keyBytes);
+                if (resultCode == MDBResultCode.Success)
+                {
+                    yield return DecodeRow(manifest, currentKey.AsSpan(), currentValue.AsSpan());
+                }
+            }
+        }
+    }
+
+    private static LightningEnvironment OpenEnvironment(LmdbRelationArtifactManifest manifest, string manifestPath)
+    {
+        var env = new LightningEnvironment(LmdbRelationArtifactReader.ResolveEnvironmentPath(manifest, manifestPath))
+        {
+            MaxDatabases = string.IsNullOrWhiteSpace(manifest.DatabaseName) ? 0 : 4,
+        };
+        env.Open(EnvironmentOpenFlags.ReadOnly);
+        return env;
+    }
+
+    private static LightningDatabase OpenDatabase(LightningTransaction tx, LmdbRelationArtifactManifest manifest)
+    {
+        return string.IsNullOrWhiteSpace(manifest.DatabaseName)
+            ? tx.OpenDatabase()
+            : tx.OpenDatabase(manifest.DatabaseName);
+    }
+
+    private static object[] DecodeRow(LmdbRelationArtifactManifest manifest, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+    {
+        return new[]
+        {
+            DecodeValue(key, manifest.KeyEncoding),
+            DecodeValue(value, manifest.ValueEncoding),
+        };
+    }
+
+    private static object DecodeValue(ReadOnlySpan<byte> bytes, string encoding)
+    {
+        return encoding switch
+        {
+            "int32_le" when bytes.Length == 4 => BinaryPrimitives.ReadInt32LittleEndian(bytes),
+            "utf8" => Encoding.UTF8.GetString(bytes),
+            _ => Convert.ToHexString(bytes),
+        };
+    }
+
+    private static byte[] EncodeValue(object value, string encoding)
+    {
+        return encoding switch
+        {
+            "int32_le" => EncodeInt32(value),
+            "utf8" => Encoding.UTF8.GetBytes(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty),
+            _ => throw new InvalidDataException($"Unsupported LMDB relation artifact encoding '{encoding}'."),
+        };
+    }
+
+    private static byte[] EncodeInt32(object value)
+    {
+        var buffer = new byte[4];
+        BinaryPrimitives.WriteInt32LittleEndian(buffer, Convert.ToInt32(value, CultureInfo.InvariantCulture));
+        return buffer;
+    }
+}
+
+public sealed class LmdbRelationArtifactProviderFactory : IRelationArtifactProviderFactory
+{
+    public bool TryOpen(
+        PredicateId predicate,
+        string manifestPath,
+        IRelationProvider? fallback,
+        out RelationArtifactProviderOpenResult result)
+    {
+        if (manifestPath is null) throw new ArgumentNullException(nameof(manifestPath));
+        var manifest = LmdbRelationArtifactReader.LoadManifest(manifestPath);
+        if (!string.Equals(manifest.Format, LmdbRelationArtifactManifest.CurrentFormat, StringComparison.Ordinal))
+        {
+            result = default!;
+            return false;
+        }
+
+        var provider = new LmdbRelationProvider(fallback);
+        provider.RegisterArtifact(predicate, manifestPath);
+        result = new RelationArtifactProviderOpenResult(provider, "lmdb_artifact");
+        return true;
+    }
+}

--- a/src/unifyweaver/targets/csharp_query_runtime_lmdb/UnifyWeaver.QueryRuntime.Lmdb.csproj
+++ b/src/unifyweaver/targets/csharp_query_runtime_lmdb/UnifyWeaver.QueryRuntime.Lmdb.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="LmdbRelationProvider.cs" />
+    <ProjectReference Include="../csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj" />
+    <PackageReference Include="LightningDB" Version="0.21.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/test_csharp_query_lmdb_provider_smoke.py
+++ b/tests/test_csharp_query_lmdb_provider_smoke.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+import os
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LMDB_PROJECT = (
+    ROOT
+    / "src"
+    / "unifyweaver"
+    / "targets"
+    / "csharp_query_runtime_lmdb"
+    / "UnifyWeaver.QueryRuntime.Lmdb.csproj"
+)
+CORE_DLL = (
+    ROOT
+    / "src"
+    / "unifyweaver"
+    / "targets"
+    / "csharp_query_runtime"
+    / "bin"
+    / "Debug"
+    / "net9.0"
+    / "UnifyWeaver.QueryRuntime.Core.dll"
+)
+LMDB_DLL = (
+    ROOT
+    / "src"
+    / "unifyweaver"
+    / "targets"
+    / "csharp_query_runtime_lmdb"
+    / "bin"
+    / "Debug"
+    / "net9.0"
+    / "UnifyWeaver.QueryRuntime.Lmdb.dll"
+)
+LIGHTNINGDB_PACKAGE = Path.home() / ".nuget" / "packages" / "lightningdb" / "0.21.0"
+LIGHTNINGDB_DLL = LIGHTNINGDB_PACKAGE / "lib" / "net9.0" / "LightningDB.dll"
+
+
+class CSharpQueryLmdbProviderSmokeTests(unittest.TestCase):
+    def test_lmdb_provider_scans_and_arg0_lookups_match_expected_rows(self) -> None:
+        if shutil.which("dotnet") is None:
+            self.skipTest("dotnet is not available")
+        if not LIGHTNINGDB_PACKAGE.exists():
+            self.skipTest("LightningDB 0.21.0 package is not available in the local NuGet cache")
+
+        build_provider = subprocess.run(
+            ["dotnet", "build", str(LMDB_PROJECT)],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=60,
+        )
+        self.assertEqual(
+            build_provider.returncode,
+            0,
+            msg=f"stdout:\n{build_provider.stdout}\nstderr:\n{build_provider.stderr}",
+        )
+
+        with tempfile.TemporaryDirectory(prefix="uw-csharp-lmdb-smoke-") as tmp:
+            tmp_path = Path(tmp)
+            project_path = tmp_path / "LmdbProviderSmoke.csproj"
+            program_path = tmp_path / "Program.cs"
+            output_dir = tmp_path / "bin" / "Debug" / "net9.0"
+            project_path.write_text(
+                textwrap.dedent(
+                    f"""\
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <OutputType>Exe</OutputType>
+                        <TargetFramework>net9.0</TargetFramework>
+                        <Nullable>enable</Nullable>
+                        <ImplicitUsings>enable</ImplicitUsings>
+                        <NuGetAudit>false</NuGetAudit>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <Reference Include="UnifyWeaver.QueryRuntime.Core">
+                          <HintPath>{CORE_DLL}</HintPath>
+                        </Reference>
+                        <Reference Include="UnifyWeaver.QueryRuntime.Lmdb">
+                          <HintPath>{LMDB_DLL}</HintPath>
+                        </Reference>
+                        <Reference Include="LightningDB">
+                          <HintPath>{LIGHTNINGDB_DLL}</HintPath>
+                        </Reference>
+                      </ItemGroup>
+                    </Project>
+                    """
+                ),
+                encoding="utf-8",
+            )
+            program_path.write_text(SMOKE_PROGRAM, encoding="utf-8")
+
+            build_result = subprocess.run(
+                ["dotnet", "build", str(project_path)],
+                cwd=tmp_path,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=60,
+            )
+            self.assertEqual(
+                build_result.returncode,
+                0,
+                msg=f"stdout:\n{build_result.stdout}\nstderr:\n{build_result.stderr}",
+            )
+
+            env = os.environ.copy()
+            env["LD_LIBRARY_PATH"] = (
+                str(output_dir)
+                if not env.get("LD_LIBRARY_PATH")
+                else f"{output_dir}:{env['LD_LIBRARY_PATH']}"
+            )
+            result = subprocess.run(
+                ["dotnet", str(output_dir / "LmdbProviderSmoke.dll")],
+                cwd=tmp_path,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=60,
+            )
+
+            self.assertEqual(
+                result.returncode,
+                0,
+                msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+            )
+            self.assertIn("LMDB_PROVIDER_SMOKE_OK", result.stdout)
+
+
+SMOKE_PROGRAM = r"""
+using System.Text;
+using System.Text.Json;
+using LightningDB;
+using UnifyWeaver.QueryRuntime;
+
+static void Assert(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException(message);
+    }
+}
+
+static string RowText(object[] row) => string.Join(">", row.Select(Convert.ToString));
+
+var root = Directory.GetCurrentDirectory();
+var envPath = Path.Combine(root, "edges.lmdb");
+Directory.CreateDirectory(envPath);
+
+using (var env = new LightningEnvironment(envPath) { MaxDatabases = 4 })
+{
+    env.Open();
+    using var tx = env.BeginTransaction();
+    using var db = tx.OpenDatabase("main", new DatabaseConfiguration
+    {
+        Flags = DatabaseOpenFlags.Create | DatabaseOpenFlags.DuplicatesSort,
+    });
+
+    tx.Put(db, Encoding.UTF8.GetBytes("alice"), Encoding.UTF8.GetBytes("bob"));
+    tx.Put(db, Encoding.UTF8.GetBytes("alice"), Encoding.UTF8.GetBytes("carol"));
+    tx.Put(db, Encoding.UTF8.GetBytes("bob"), Encoding.UTF8.GetBytes("dave"));
+    tx.Commit();
+}
+
+var manifestPath = Path.Combine(root, "edge.lmdb.manifest.json");
+var manifest = new LmdbRelationArtifactManifest
+{
+    PredicateName = "edge",
+    Arity = 2,
+    EnvironmentPath = "edges.lmdb",
+    DatabaseName = "main",
+    DupSort = true,
+    KeyEncoding = "utf8",
+    ValueEncoding = "utf8",
+    RowCount = 3,
+};
+File.WriteAllText(manifestPath, JsonSerializer.Serialize(manifest));
+
+var predicate = new PredicateId("edge", 2);
+var provider = new LmdbRelationProvider();
+provider.RegisterArtifact(predicate, manifestPath);
+
+var scanned = provider.GetFacts(predicate).Select(RowText).OrderBy(value => value).ToArray();
+Assert(scanned.SequenceEqual(new[] { "alice>bob", "alice>carol", "bob>dave" }), "scan rows did not match");
+
+Assert(provider.TryLookupFacts(predicate, 0, new object[] { "alice" }, out var lookupRows), "arg0 lookup was not served");
+var lookedUp = lookupRows.Select(RowText).OrderBy(value => value).ToArray();
+Assert(lookedUp.SequenceEqual(new[] { "alice>bob", "alice>carol" }), "arg0 lookup rows did not match");
+
+Assert(provider.TryGetRelationCardinality(predicate, out var rowCount), "row count was not served");
+Assert(rowCount == 3, $"row count was {rowCount}, expected 3");
+
+var factory = new LmdbRelationArtifactProviderFactory();
+Assert(factory.TryOpen(predicate, manifestPath, fallback: null, out var opened), "factory did not open LMDB manifest");
+Assert(opened.StorageKind == "lmdb_artifact", $"storage kind was {opened.StorageKind}");
+var factoryRows = opened.Provider.GetFacts(predicate).Select(RowText).OrderBy(value => value).ToArray();
+Assert(factoryRows.SequenceEqual(scanned), "factory provider scan rows did not match");
+
+Console.WriteLine("LMDB_PROVIDER_SMOKE_OK");
+"""
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  Adds an optional C# query runtime LMDB integration project while keeping `UnifyWeaver.QueryRuntime.Core` dependency-free.

  This introduces a narrow `LmdbRelationProvider` smoke path for arity-2 relation artifacts using a C#-owned
  `unifyweaver.lmdb_relation.v1` manifest.

  ## Changes

  - Added `UnifyWeaver.QueryRuntime.Lmdb` as an optional project with the LightningDB dependency.
  - Added `LmdbRelationProvider` with arity-2 full scan, arg0 lookup, and row-count metadata.
  - Added `LmdbRelationArtifactProviderFactory` for opening LMDB manifests through the provider-factory seam.
  - Added an executable smoke test that writes a tiny dupsort LMDB and verifies scan, lookup, factory open, and cardinality
  behavior.
  - Updated the high-performance source backend doc to record the C#-owned LMDB manifest decision.

  ## Verification

  - `dotnet build src/unifyweaver/targets/csharp_query_runtime_lmdb/UnifyWeaver.QueryRuntime.Lmdb.csproj`
  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py tests/test_csharp_query_lmdb_provider_smoke.py`
  - `env SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  test_csharp_query_target:test_csharp_query_target -t halt`
  - `git diff --check`