### PR TITLE
feat(wam-c): Lower WAM-C body-call projections with ignored callee outputs

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,7 +5,7 @@ Status date: 2026-05-15
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `9b19eace` (`Merge pull request #2113 from s243a/test/wam-c-generated-project-multi-predicate-setup`)
+- `main` at `1bd3d43e` (`Merge pull request #2116 from s243a/feat/wam-c-lowered-helper-nonreordered-projections`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
@@ -14,7 +14,7 @@ Base verified locally:
 
 Active branch:
 
-- `feat/wam-c-lowered-helper-nonreordered-projections`
+- `feat/wam-c-lowered-helper-ignored-output-contract`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -55,7 +55,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper body-call rejection metadata | Done | Planner reports explicit unavailable and non-lowerable callee reasons for exact user-predicate body-call shapes |
 | Lowered helper projected body calls | Done | Variable-only reordered body-call projections lower through native fact-helper dispatch with executable coverage |
 | Generated multi-predicate setup | Done | Generated setup appends predicate code at per-setup base PCs and covers multiple setup functions in one executable |
-| Lowered helper non-reordered projection metadata | In progress | Active branch reports explicit planner rejection reasons for omitted head variables, repeated head variables, and unbound callee variables |
+| Lowered helper non-reordered projection metadata | Done | Planner reports explicit rejection reasons for omitted head variables, repeated head variables, and unbound callee variables |
+| Lowered helper ignored-output projections | In progress | Active branch allows projected body-call helpers to pass callee-local variables as fresh unbound arguments and ignore their returned bindings |
 
 ## Current C Target Baseline
 
@@ -136,22 +137,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lowered-helper-nonreordered-projections`
-
-Goal: decide whether body-call helper lowering should support projection shapes
-that bind only a subset of callee variables.
-
-Scope:
-
-- Start with planner metadata for repeated or omitted head/callee variables.
-- Avoid runtime support until the binding contract for ignored callee outputs is
-  explicit.
-- Keep constant filters on the existing materialized `filtered_fact` path.
-
-Status: active; the planner now classifies unsupported variable-only projection
-shapes before they fall through to generic fact/filter rejection metadata.
-
-### 2. `feat/wam-c-lowered-helper-ignored-output-contract`
+### 1. `feat/wam-c-lowered-helper-ignored-output-contract`
 
 Goal: define the runtime contract for projected body calls whose callee produces
 variables that are not exposed by the caller.
@@ -163,10 +149,26 @@ Scope:
 - If supported, add executable coverage before enabling native helper lowering.
 - Keep constant filters on the existing materialized `filtered_fact` path.
 
+Status: active; ignored callee outputs are allowed when every caller-visible
+head variable is projected exactly once, with executable coverage for the
+lowered helper path.
+
+### 2. `feat/wam-c-lowered-helper-projection-row-constraints`
+
+Goal: decide whether repeated caller variables in projected body calls should
+lower through native row constraints instead of staying rejected.
+
+Scope:
+
+- Preserve the current rejection for omitted caller-visible head variables.
+- Consider lowering repeated caller variables only by materializing matching
+  fact rows, similar to repeated-variable filtered helpers.
+- Keep constant filters on the existing materialized `filtered_fact` path.
+
 ## Suggested Immediate Next Step
 
-Continue validating `feat/wam-c-lowered-helper-nonreordered-projections`.
+Continue validating `feat/wam-c-lowered-helper-ignored-output-contract`.
 
-The active branch keeps runtime lowering conservative and improves planner
-metadata first, so the next implementation step can be based on explicit
-projection-shape evidence instead of generic rejection comments.
+The active branch turns the previously classified unbound-callee projection
+case into supported lowering while keeping omitted caller-visible outputs and
+repeated caller variables explicit planner rejections.

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -453,12 +453,13 @@ lowered_body_call_helper(PredIndicator, AvailableKeys, CalleeKey, CalleeArity) :
     memberchk(CalleeKey, AvailableKeys).
 
 lowered_body_call_projected_helper(PredIndicator, AvailableKeys, CalleeKey, CalleeArity, CalleeArgs) :-
-    projected_body_call_context(PredIndicator, HeadArgs, CalleePred, CalleeArity, CalleeKey, CalleeArgs),
+    body_call_projection_context(PredIndicator, HeadArgs, CalleePred, CalleeArity, CalleeKey, CalleeArgs),
     format(atom(CalleeKey), '~w/~w', [CalleePred, CalleeArity]),
     memberchk(CalleeKey, AvailableKeys),
     CalleeIndicator = user:CalleePred/CalleeArity,
     lowered_fact_helper_rows(CalleeIndicator, _Rows),
-    head_args_project_once(HeadArgs, CalleeArgs).
+    head_args_project_once(HeadArgs, CalleeArgs),
+    callee_local_variables_singletons(HeadArgs, CalleeArgs).
 
 lowered_body_call_rejection_reason(PredIndicator, AvailableKeys, Reason) :-
     body_call_context(PredIndicator, CalleePred, CalleeArity, CalleeKey),
@@ -510,10 +511,6 @@ projected_body_call_arg_supported(HeadArgs, Arg) :-
     member(HeadArg, HeadArgs),
     Arg == HeadArg.
 
-body_call_projection_rejection_reason(HeadArgs, CalleeArgs, body_call_projection_unbound_callee_variable) :-
-    member(CalleeArg, CalleeArgs),
-    \+ projected_body_call_arg_supported(HeadArgs, CalleeArg),
-    !.
 body_call_projection_rejection_reason(HeadArgs, CalleeArgs, body_call_projection_omits_head_variable) :-
     member(HeadArg, HeadArgs),
     variable_occurrence_count(HeadArg, CalleeArgs, 0),
@@ -521,6 +518,12 @@ body_call_projection_rejection_reason(HeadArgs, CalleeArgs, body_call_projection
 body_call_projection_rejection_reason(HeadArgs, CalleeArgs, body_call_projection_repeats_head_variable) :-
     member(HeadArg, HeadArgs),
     variable_occurrence_count(HeadArg, CalleeArgs, Count),
+    Count > 1,
+    !.
+body_call_projection_rejection_reason(HeadArgs, CalleeArgs, body_call_projection_repeats_callee_local_variable) :-
+    member(CalleeArg, CalleeArgs),
+    \+ projected_body_call_arg_supported(HeadArgs, CalleeArg),
+    variable_occurrence_count(CalleeArg, CalleeArgs, Count),
     Count > 1,
     !.
 
@@ -532,6 +535,14 @@ head_args_project_once([], _CalleeArgs).
 head_args_project_once([HeadArg|Rest], CalleeArgs) :-
     variable_occurrence_count(HeadArg, CalleeArgs, 1),
     head_args_project_once(Rest, CalleeArgs).
+
+callee_local_variables_singletons(_HeadArgs, []).
+callee_local_variables_singletons(HeadArgs, [CalleeArg|Rest]) :-
+    (   projected_body_call_arg_supported(HeadArgs, CalleeArg)
+    ->  true
+    ;   variable_occurrence_count(CalleeArg, Rest, 0)
+    ),
+    callee_local_variables_singletons(HeadArgs, Rest).
 
 same_variable(Left, Right) :-
     Left == Right.
@@ -618,6 +629,8 @@ projected_body_call_arg_assignment(I, Arg, HeadArgs, Line) :-
     Arg == HeadArg,
     !,
     format(atom(Line), '    state->A[~w] = saved_args[~w];', [I, HeadIndex]).
+projected_body_call_arg_assignment(I, _Arg, _HeadArgs, Line) :-
+    format(atom(Line), '    state->A[~w] = val_unbound("_");', [I]).
 
 projected_body_call_result_copies(PredIndicator, Code) :-
     projected_body_call_clause_args(PredIndicator, HeadArgs, CalleeArgs),

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -357,7 +357,7 @@ test_lowered_helper_planner_metadata :-
                                     Plans),
         member(wam_c_lowered_helper_plan('wam_c_plan_fact/2', _, lowered, fact_only([[a,b]])), Plans),
         member(wam_c_lowered_helper_plan('wam_c_plan_alias/2', _, lowered, body_call('wam_c_plan_fact/2', 2)), Plans),
-        member(wam_c_lowered_helper_plan('wam_c_plan_rule/1', _, rejected, body_call_projection_unbound_callee_variable), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_plan_rule/1', _, lowered, body_call_projected('wam_c_plan_fact/2', 2, _)), Plans),
         member(wam_c_lowered_helper_plan('category_ancestor/4', _, interpreted, detected_kernel), Plans)
     ->  pass(Test)
     ;   fail_test(Test, 'planner did not classify lowered/rejected/interpreted predicates')
@@ -384,7 +384,7 @@ test_lowered_helper_plan_generation :-
         sub_string(LibS, _, _, _, '// WAM-C lowered helper plan'),
         sub_string(LibS, _, _, _, '// - lowered wam_c_plan_emit_fact/2: fact_only'),
         sub_string(LibS, _, _, _, '// - lowered wam_c_plan_emit_alias/2: body_call'),
-        sub_string(LibS, _, _, _, '// - rejected wam_c_plan_emit_rule/1: body_call_projection_unbound_callee_variable'),
+        sub_string(LibS, _, _, _, '// - lowered wam_c_plan_emit_rule/1: body_call_projected'),
         sub_string(LibS, _, _, _, 'INSTR_CALL_FOREIGN'),
         sub_string(LibS, _, _, _, 'static bool wam_c_lowered_wam_c_plan_emit_alias_2'),
         sub_string(LibS, _, _, _, 'setup_wam_c_plan_emit_rule_1')
@@ -400,22 +400,26 @@ test_lowered_body_call_helper_generation :-
     assertz(user:wam_c_body_fact(a, b)),
     assertz((user:wam_c_body_alias(X, Y) :- user:wam_c_body_fact(X, Y))),
     assertz((user:wam_c_body_projected(X, Y) :- user:wam_c_body_fact(Y, X))),
+    assertz((user:wam_c_body_ignored_output(X) :- user:wam_c_body_fact(X, _Ignored))),
     get_time(Now),
     Stamp is round(Now * 1000000),
     wam_c_temp_path('unifyweaver_wam_c_lowered_body_project', Stamp, ProjectDir),
     directory_file_path(ProjectDir, 'lib.c', LibPath),
     (   plan_wam_c_lowered_helpers([user:wam_c_body_fact/2,
                                      user:wam_c_body_alias/2,
-                                     user:wam_c_body_projected/2],
+                                     user:wam_c_body_projected/2,
+                                     user:wam_c_body_ignored_output/1],
                                     [lowered_helpers(true)],
                                     [],
                                     Plans),
         member(wam_c_lowered_helper_plan('wam_c_body_fact/2', _, lowered, fact_only([[a,b]])), Plans),
         member(wam_c_lowered_helper_plan('wam_c_body_alias/2', _, lowered, body_call('wam_c_body_fact/2', 2)), Plans),
         member(wam_c_lowered_helper_plan('wam_c_body_projected/2', _, lowered, body_call_projected('wam_c_body_fact/2', 2, _)), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_body_ignored_output/1', _, lowered, body_call_projected('wam_c_body_fact/2', 2, _)), Plans),
         write_wam_c_project([user:wam_c_body_fact/2,
                              user:wam_c_body_alias/2,
-                             user:wam_c_body_projected/2],
+                             user:wam_c_body_projected/2,
+                             user:wam_c_body_ignored_output/1],
                             [lowered_helpers(true)],
                             ProjectDir),
         read_file_to_string(LibPath, LibS, []),
@@ -423,6 +427,8 @@ test_lowered_body_call_helper_generation :-
         sub_string(LibS, _, _, _, '// - lowered wam_c_body_projected/2: body_call_projected'),
         sub_string(LibS, _, _, _, 'static bool wam_c_lowered_wam_c_body_alias_2'),
         sub_string(LibS, _, _, _, 'static bool wam_c_lowered_wam_c_body_projected_2'),
+        sub_string(LibS, _, _, _, 'static bool wam_c_lowered_wam_c_body_ignored_output_1'),
+        sub_string(LibS, _, _, _, 'state->A[1] = val_unbound("_");'),
         sub_string(LibS, _, _, _, 'return wam_c_lowered_wam_c_body_fact_2(state, "wam_c_body_fact/2", 2);'),
         sub_string(LibS, _, _, _, 'wam_c_lowered_wam_c_body_fact_2(state, "wam_c_body_fact/2", 2);'),
         sub_string(LibS, _, _, _, '.pred = "wam_c_body_alias/2"')
@@ -431,7 +437,8 @@ test_lowered_body_call_helper_generation :-
     ),
     retractall(user:wam_c_body_fact(_, _)),
     retractall(user:wam_c_body_alias(_, _)),
-    retractall(user:wam_c_body_projected(_, _)).
+    retractall(user:wam_c_body_projected(_, _)),
+    retractall(user:wam_c_body_ignored_output(_)).
 
 test_lowered_body_call_rejection_metadata :-
     Test = 'WAM-C: lowered helper planner explains unsupported body-call shapes',
@@ -476,48 +483,53 @@ test_lowered_body_call_projection_rejection_metadata :-
     Test = 'WAM-C: lowered helper planner explains unsupported projection shapes',
     assertz(user:wam_c_body_projection_fact1(a)),
     assertz(user:wam_c_body_projection_fact2(a, a)),
+    assertz(user:wam_c_body_projection_fact3(a, b, b)),
     assertz((user:wam_c_body_projection_omit(X, _Ignored) :-
                  user:wam_c_body_projection_fact1(X))),
     assertz((user:wam_c_body_projection_repeat(X) :-
                  user:wam_c_body_projection_fact2(X, X))),
-    assertz((user:wam_c_body_projection_unbound(X) :-
-                 user:wam_c_body_projection_fact2(X, _Unbound))),
+    assertz((user:wam_c_body_projection_repeated_local(X) :-
+                 user:wam_c_body_projection_fact3(X, Y, Y))),
     get_time(Now),
     Stamp is round(Now * 1000000),
     wam_c_temp_path('unifyweaver_wam_c_lowered_body_projection_reject_project', Stamp, ProjectDir),
     directory_file_path(ProjectDir, 'lib.c', LibPath),
     (   plan_wam_c_lowered_helpers([user:wam_c_body_projection_fact1/1,
                                      user:wam_c_body_projection_fact2/2,
+                                     user:wam_c_body_projection_fact3/3,
                                      user:wam_c_body_projection_omit/2,
                                      user:wam_c_body_projection_repeat/1,
-                                     user:wam_c_body_projection_unbound/1],
+                                     user:wam_c_body_projection_repeated_local/1],
                                     [lowered_helpers(true)],
                                     [],
                                     Plans),
         member(wam_c_lowered_helper_plan('wam_c_body_projection_fact1/1', _, lowered, fact_only([[a]])), Plans),
         member(wam_c_lowered_helper_plan('wam_c_body_projection_fact2/2', _, lowered, fact_only([[a,a]])), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_body_projection_fact3/3', _, lowered, fact_only([[a,b,b]])), Plans),
         member(wam_c_lowered_helper_plan('wam_c_body_projection_omit/2', _, rejected, body_call_projection_omits_head_variable), Plans),
         member(wam_c_lowered_helper_plan('wam_c_body_projection_repeat/1', _, rejected, body_call_projection_repeats_head_variable), Plans),
-        member(wam_c_lowered_helper_plan('wam_c_body_projection_unbound/1', _, rejected, body_call_projection_unbound_callee_variable), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_body_projection_repeated_local/1', _, rejected, body_call_projection_repeats_callee_local_variable), Plans),
         write_wam_c_project([user:wam_c_body_projection_fact1/1,
                              user:wam_c_body_projection_fact2/2,
+                             user:wam_c_body_projection_fact3/3,
                              user:wam_c_body_projection_omit/2,
                              user:wam_c_body_projection_repeat/1,
-                             user:wam_c_body_projection_unbound/1],
+                             user:wam_c_body_projection_repeated_local/1],
                             [lowered_helpers(true)],
                             ProjectDir),
         read_file_to_string(LibPath, LibS, []),
         sub_string(LibS, _, _, _, '// - rejected wam_c_body_projection_omit/2: body_call_projection_omits_head_variable'),
         sub_string(LibS, _, _, _, '// - rejected wam_c_body_projection_repeat/1: body_call_projection_repeats_head_variable'),
-        sub_string(LibS, _, _, _, '// - rejected wam_c_body_projection_unbound/1: body_call_projection_unbound_callee_variable')
+        sub_string(LibS, _, _, _, '// - rejected wam_c_body_projection_repeated_local/1: body_call_projection_repeats_callee_local_variable')
     ->  pass(Test)
     ;   fail_test(Test, 'planner did not report explicit projection rejection reasons')
     ),
     retractall(user:wam_c_body_projection_fact1(_)),
     retractall(user:wam_c_body_projection_fact2(_, _)),
+    retractall(user:wam_c_body_projection_fact3(_, _, _)),
     retractall(user:wam_c_body_projection_omit(_, _)),
     retractall(user:wam_c_body_projection_repeat(_)),
-    retractall(user:wam_c_body_projection_unbound(_)).
+    retractall(user:wam_c_body_projection_repeated_local(_)).
 
 test_lowered_filtered_fact_helper_generation :-
     Test = 'WAM-C: guarded fact predicates can lower to filtered native helper',
@@ -1436,6 +1448,7 @@ run_lowered_body_call_helper_executable_smoke :-
     assertz(user:wam_c_body_fact(a, c)),
     assertz((user:wam_c_body_alias(X, Y) :- user:wam_c_body_fact(X, Y))),
     assertz((user:wam_c_body_projected(X, Y) :- user:wam_c_body_fact(Y, X))),
+    assertz((user:wam_c_body_ignored_output(X) :- user:wam_c_body_fact(X, _Ignored))),
     get_time(Now),
     Stamp is round(Now * 1000000),
     wam_c_temp_path('unifyweaver_wam_c_lowered_body_smoke', Stamp, ProjectDir),
@@ -1445,7 +1458,8 @@ run_lowered_body_call_helper_executable_smoke :-
     directory_file_path(ProjectDir, 'wam_c_lowered_body_smoke', ExePath),
     (   write_wam_c_project([user:wam_c_body_fact/2,
                              user:wam_c_body_alias/2,
-                             user:wam_c_body_projected/2],
+                             user:wam_c_body_projected/2,
+                             user:wam_c_body_ignored_output/1],
                             [lowered_helpers(true)],
                             ProjectDir),
         wam_c_lowered_body_smoke_main(MainCode),
@@ -1454,10 +1468,12 @@ run_lowered_body_call_helper_executable_smoke :-
         run_c_smoke_plain(ExePath)
     ->  retractall(user:wam_c_body_fact(_, _)),
         retractall(user:wam_c_body_alias(_, _)),
-        retractall(user:wam_c_body_projected(_, _))
+        retractall(user:wam_c_body_projected(_, _)),
+        retractall(user:wam_c_body_ignored_output(_))
     ;   retractall(user:wam_c_body_fact(_, _)),
         retractall(user:wam_c_body_alias(_, _)),
         retractall(user:wam_c_body_projected(_, _)),
+        retractall(user:wam_c_body_ignored_output(_)),
         fail
     ).
 
@@ -2357,6 +2373,7 @@ wam_c_lowered_body_smoke_main(
 void setup_wam_c_body_fact_2(WamState* state);
 void setup_wam_c_body_alias_2(WamState* state);
 void setup_wam_c_body_projected_2(WamState* state);
+void setup_wam_c_body_ignored_output_1(WamState* state);
 void setup_lowered_wam_c_helpers(WamState* state);
 
 int main(void) {
@@ -2408,6 +2425,21 @@ int main(void) {
     if (projected_fail_rc != WAM_HALT) {
         wam_free_state(&state);
         return 60;
+    }
+
+    setup_wam_c_body_ignored_output_1(&state);
+    WamValue ignored_args[1] = { val_atom("a") };
+    int ignored_rc = wam_run_predicate(&state, "wam_c_body_ignored_output/1", ignored_args, 1);
+    if (ignored_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 70;
+    }
+
+    WamValue ignored_fail_args[1] = { val_atom("z") };
+    int ignored_fail_rc = wam_run_predicate(&state, "wam_c_body_ignored_output/1", ignored_fail_args, 1);
+    if (ignored_fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 80;
     }
 
     wam_free_state(&state);


### PR DESCRIPTION
## Summary

- allow lowered WAM-C projected body-call helpers to pass callee-local variables as fresh unbound arguments
- preserve caller-visible projection safety by still rejecting omitted head variables, repeated head variables, and repeated callee-local variables
- add planner, generated-code, and executable smoke coverage for ignored-output projections
- refresh the WAM-C next-steps roadmap with this branch as active and row-constrained projection handling as the next follow-up

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --check`