### PR TITLE
feat(wam-clojure): add msort builtin

### DIFF
--- a/PR_WAM_CLOJURE_MSORT_BUILTIN.md
+++ b/PR_WAM_CLOJURE_MSORT_BUILTIN.md
@@ -1,0 +1,26 @@
+# PR Title
+
+feat(wam-clojure): add msort/2 builtin
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM support for `msort/2`.
+- Reuses the existing standard term-order comparator used by `sort/2`, `compare/3`, and the term-order predicates.
+- Preserves duplicate terms while returning the output list in standard term order.
+- Fails cleanly for improper or unbound input lists.
+- Adds lowered-emitter and runtime smoke coverage.
+
+## Semantics
+
+`msort/2` accepts a proper list in the first argument and unifies the second argument with a list ordered by standard term order. Unlike `sort/2`, duplicate terms are retained.
+
+The implementation is deterministic and does not enumerate permutations. It inspects and sorts existing list items without binding variables in the input list.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -392,6 +392,10 @@ clojure_direct_builtin("sort/2", "2").
 clojure_direct_builtin("sort/2", 2).
 clojure_direct_builtin('sort/2', "2").
 clojure_direct_builtin('sort/2', 2).
+clojure_direct_builtin("msort/2", "2").
+clojure_direct_builtin("msort/2", 2).
+clojure_direct_builtin('msort/2', "2").
+clojure_direct_builtin('msort/2', 2).
 clojure_direct_builtin("copy_term/2", "2").
 clojure_direct_builtin("copy_term/2", 2).
 clojure_direct_builtin('copy_term/2', "2").
@@ -662,6 +666,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "sort/2" ; Op == 'sort/2'),
     !,
     format(atom(Expr), '(runtime/apply-sort-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "msort/2" ; Op == 'msort/2'),
+    !,
+    format(atom(Expr), '(runtime/apply-msort-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "copy_term/2" ; Op == 'copy_term/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -757,6 +757,9 @@
           []
           (sort #(term-compare state %1 %2) items)))
 
+(defn sorted-terms [state items]
+  (sort #(term-compare state %1 %2) items))
+
 (defn apply-sort-solution [state]
   (let [list-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A1") ::unbound))
@@ -765,6 +768,20 @@
     (if-let [items (proper-list-items state list-value)]
       (let [sorted-term (list->term (:intern-context state)
                                     (sorted-unique-terms state items))
+            [ok next-state] (unify-values state out sorted-term)]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+      (backtrack state))))
+
+(defn apply-msort-solution [state]
+  (let [list-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A2") ::unbound))]
+    (if-let [items (proper-list-items state list-value)]
+      (let [sorted-term (list->term (:intern-context state)
+                                    (sorted-terms state items))
             [ok next-state] (unify-values state out sorted-term)]
         (if ok
           (advance next-state)
@@ -1523,6 +1540,9 @@
 
           "sort/2"
           (apply-sort-solution state)
+
+          "msort/2"
+          (apply-msort-solution state)
 
           "copy_term/2"
           (apply-copy-term-solution state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -559,6 +559,15 @@ test(simple_builtin_sort_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_msort_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_msort/2:\nbuiltin_call msort/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_msort/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_msort/2, WamCode, [], Code),
+        has(Code, "runtime/apply-msort-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_copy_term_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_copy_term/2:\nbuiltin_call copy_term/2, 2\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -87,6 +87,9 @@
 :- dynamic user:wam_sort_guard/2.
 :- dynamic user:wam_sort_bad_list/1.
 :- dynamic user:wam_sort_unbound_list/1.
+:- dynamic user:wam_msort_guard/2.
+:- dynamic user:wam_msort_bad_list/1.
+:- dynamic user:wam_msort_unbound_list/1.
 :- dynamic user:wam_copy_term_guard/2.
 :- dynamic user:wam_copy_term_sharing_fail/0.
 :- dynamic user:wam_copy_term_independent_ok/0.
@@ -212,6 +215,9 @@ user:wam_append_split(A, B) :- append(A, B, [a,b,c]).
 user:wam_sort_guard(L, S) :- sort(L, S).
 user:wam_sort_bad_list(S) :- sort([a|b], S).
 user:wam_sort_unbound_list(S) :- user:wam_unbound_arg(L), sort(L, S).
+user:wam_msort_guard(L, S) :- msort(L, S).
+user:wam_msort_bad_list(S) :- msort([a|b], S).
+user:wam_msort_unbound_list(S) :- user:wam_unbound_arg(L), msort(L, S).
 user:wam_copy_term_guard(A, B) :- copy_term(A, B).
 user:wam_copy_term_sharing_fail :- user:wam_unbound_arg(X), copy_term(f(X, X), f(a, b)).
 user:wam_copy_term_independent_ok :- copy_term(f(_, _), f(a, b)).
@@ -342,6 +348,9 @@ run_smoke :-
           user:wam_sort_guard/2,
           user:wam_sort_bad_list/1,
           user:wam_sort_unbound_list/1,
+          user:wam_msort_guard/2,
+          user:wam_msort_bad_list/1,
+          user:wam_msort_unbound_list/1,
           user:wam_copy_term_guard/2,
           user:wam_copy_term_sharing_fail/0,
           user:wam_copy_term_independent_ok/0,
@@ -413,6 +422,7 @@ run_smoke :-
     assert_lowered_member_builtin_emitted(TmpDir),
     assert_lowered_append_builtin_emitted(TmpDir),
     assert_lowered_sort_builtin_emitted(TmpDir),
+    assert_lowered_msort_builtin_emitted(TmpDir),
     assert_lowered_copy_term_builtin_emitted(TmpDir),
     assert_lowered_functor_builtin_emitted(TmpDir),
     assert_lowered_arg_builtin_emitted(TmpDir),
@@ -576,6 +586,11 @@ smoke_cases([
     case('wam_sort_guard/2', args('[f(b),f(a),a]', '[a,f(a),f(b)]'), "true"),
     case('wam_sort_bad_list/1', '[a,b,c]', "false"),
     case('wam_sort_unbound_list/1', '[a,b,c]', "false"),
+    case('wam_msort_guard/2', args('[b,a,a,c]', '[a,a,b,c]'), "true"),
+    case('wam_msort_guard/2', args('[b,a,a,c]', '[a,b,c]'), "false"),
+    case('wam_msort_guard/2', args('[f(b),f(a),a]', '[a,f(a),f(b)]'), "true"),
+    case('wam_msort_bad_list/1', '[a,b,c]', "false"),
+    case('wam_msort_unbound_list/1', '[a,b,c]', "false"),
     case('wam_copy_term_guard/2', args(a, a), "true"),
     case('wam_copy_term_guard/2', args(a, b), "false"),
     case('wam_copy_term_guard/2', args('f(a)', 'f(a)'), "true"),
@@ -823,6 +838,14 @@ assert_lowered_sort_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-sort-unbound-list-1"),
     has(CoreCode, "runtime/apply-sort-solution").
 
+assert_lowered_msort_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-msort-guard-2"),
+    has(CoreCode, "defn lowered-wam-msort-bad-list-1"),
+    has(CoreCode, "defn lowered-wam-msort-unbound-list-1"),
+    has(CoreCode, "runtime/apply-msort-solution").
+
 assert_lowered_copy_term_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
@@ -1065,6 +1088,7 @@ prolog_term_string_to_edn('[b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"b\
 prolog_term_string_to_edn('[c]', "{:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}") :- !.
 prolog_term_string_to_edn('[a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[a,b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn('[a,a,b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn('[b,a,a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn('[f(b),f(a),a]', "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[a,f(a),f(b)]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} \"[]\"]}]}]}") :- !.
@@ -1080,6 +1104,7 @@ prolog_term_string_to_edn("[b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"b\
 prolog_term_string_to_edn("[c]", "{:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}") :- !.
 prolog_term_string_to_edn("[a,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[a,b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn("[a,a,b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn("[b,a,a,c]", "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn("[f(b),f(a),a]", "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[a,f(a),f(b)]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} \"[]\"]}]}]}") :- !.


### PR DESCRIPTION
## Summary

- Adds Clojure WAM support for `msort/2`.
- Reuses the existing standard term-order comparator used by `sort/2`, `compare/3`, and the term-order predicates.
- Preserves duplicate terms while returning the output list in standard term order.
- Fails cleanly for improper or unbound input lists.
- Adds lowered-emitter and runtime smoke coverage.

## Semantics

`msort/2` accepts a proper list in the first argument and unifies the second argument with a list ordered by standard term order. Unlike `sort/2`, duplicate terms are retained.

The implementation is deterministic and does not enumerate permutations. It inspects and sorts existing list items without binding variables in the input list.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
