### PR TITLE
feat(csharp-query): add mmap array artifact provider

### DIFF
--- a/docs/targets/csharp-query-high-performance-sources.md
+++ b/docs/targets/csharp-query-high-performance-sources.md
@@ -245,6 +245,8 @@ need manual override:
      manifest-declared ID strategy.
    - Acceptance: scan and lookup parity with delimited facts, plus benchmark
      comparison against LMDB.
+   - Status: implemented by `MmapArrayRelationArtifactProvider` and covered by
+     `tests/test_csharp_query_mmap_array_provider_smoke.py`.
 
 ## Non-Goals For The First Runtime PR
 

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -127,9 +127,10 @@ before running child benchmarks if `MemAvailable` is below
 rows from being captured accidentally.
 
 `benchmark_csharp_query_lmdb_source_mode_sweep.py` runs a focused arity-2
-provider comparison for preload, binary artifact, delimited artifact, and the
-optional LMDB provider. It reports open time, repeated arg0 lookup time, full
-scan time, retained managed memory, artifact bytes, and output hashes:
+provider comparison for preload, binary artifact, delimited artifact, the
+optional LMDB provider, and the dependency-free mmap-array provider. It reports
+open time, repeated arg0 lookup time, full scan time, retained managed memory,
+artifact bytes, and output hashes:
 
 ```bash
 python examples/benchmark/benchmark_csharp_query_lmdb_source_mode_sweep.py \
@@ -626,7 +627,7 @@ Tables:
 | `benchmark_dependency_depth_cross_target.py` | Compare synthetic dependency reach-count across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_longest_depth_cross_target.py` | Compare true DAG longest dependency-chain depth across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_csharp_query_source_mode_sweep.py` | Run generated C# query source-mode sweeps across selected workloads and emit a compact TSV/Markdown comparison |
-| `benchmark_csharp_query_lmdb_source_mode_sweep.py` | Compare preload, binary artifact, delimited artifact, and LMDB providers on one arity-2 C# query relation workload |
+| `benchmark_csharp_query_lmdb_source_mode_sweep.py` | Compare preload, binary artifact, delimited artifact, LMDB, and mmap-array providers on one arity-2 C# query relation workload |
 | `refresh_csharp_query_source_mode_calibration.py` | Refresh the graph source-mode calibration TSV with guarded idle checks |
 | `refresh_csharp_query_scan_source_mode_calibration.py` | Refresh the scan-materialization source-mode calibration TSV with guarded idle checks |
 | `report_csharp_query_source_mode_actions.py` | Report graph and scan calibration rows where the current source-mode policy differs from observed best or `auto` is slow |

--- a/examples/benchmark/benchmark_csharp_query_lmdb_source_mode_sweep.py
+++ b/examples/benchmark/benchmark_csharp_query_lmdb_source_mode_sweep.py
@@ -424,10 +424,10 @@ var lookupRepetitions = Math.Max(1, ReadIntArg(args, "--lookup-repetitions", 10)
 var root = Directory.GetCurrentDirectory();
 var predicate = new PredicateId("edge", 2);
 var rows = Enumerable.Range(0, rowCount)
-    .Select(index => (Key: $"k{index % keyCount:D6}", Value: $"v{index:D8}"))
+    .Select(index => (Key: (index % keyCount).ToString(System.Globalization.CultureInfo.InvariantCulture), Value: index.ToString(System.Globalization.CultureInfo.InvariantCulture)))
     .ToArray();
 var lookupKeys = Enumerable.Range(0, Math.Min(keyCount, rowCount))
-    .Select(index => (object)$"k{index:D6}")
+    .Select(index => (object)index.ToString(System.Globalization.CultureInfo.InvariantCulture))
     .ToArray();
 
 var inputPath = Path.Combine(root, "edge.tsv");
@@ -440,6 +440,8 @@ var delimitedDir = Path.Combine(root, "delimited-artifact");
 var delimitedManifest = DelimitedRelationArtifactBuilder.BuildFromDelimited(predicate, source, delimitedDir);
 var lmdbManifest = WriteLmdbArtifact(root, predicate, rows, inputPath);
 var lmdbDir = Path.Combine(root, "lmdb-edge");
+var mmapDir = Path.Combine(root, "mmap-array-artifact");
+var mmapManifest = MmapArrayRelationArtifactBuilder.BuildFromDelimited(predicate, source, mmapDir);
 
 Console.WriteLine("mode\trows\tlookup_keys\tartifact_bytes\topen_ms\tlookup_ms\tscan_ms\tretained_bytes\tscan_hash\tlookup_hash");
 BenchmarkProvider(
@@ -493,6 +495,19 @@ BenchmarkProvider(
     lookupKeys,
     lookupRepetitions,
     DirectorySize(lmdbDir) + new FileInfo(lmdbManifest).Length,
+    rowCount);
+BenchmarkProvider(
+    "mmap-array",
+    () =>
+    {
+        var provider = new MmapArrayRelationArtifactProvider();
+        provider.RegisterArtifact(predicate, mmapManifest);
+        return provider;
+    },
+    predicate,
+    lookupKeys,
+    lookupRepetitions,
+    DirectorySize(mmapDir),
     rowCount);
 """
 

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;
 using System.IO;
+using System.IO.MemoryMappedFiles;
 using System.Numerics;
 using System.Text;
 using System.Text.Json;
@@ -332,6 +333,99 @@ namespace UnifyWeaver.QueryRuntime
         }
     }
 
+    public sealed class MmapArrayRelationArtifactManifest
+    {
+        public const string CurrentFormat = "unifyweaver.mmap_array_relation.v1";
+
+        public string Format { get; set; } = CurrentFormat;
+
+        public int Version { get; set; } = 1;
+
+        public string PhysicalBackend { get; set; } = "mmap_array";
+
+        public string PredicateName { get; set; } = string.Empty;
+
+        public int Arity { get; set; } = 2;
+
+        public string DataPath { get; set; } = string.Empty;
+
+        public long RowCount { get; set; }
+
+        public string IdStrategy { get; set; } = "provided_id";
+
+        public int IdWidth { get; set; } = 32;
+
+        public string ValueEncoding { get; set; } = "int32_le";
+
+        public int SortColumn { get; set; } = 0;
+
+        public string? StringTable { get; set; }
+
+        public string? SourcePath { get; set; }
+
+        public long? SourceLength { get; set; }
+
+        public string? SourceSha256 { get; set; }
+
+        public void Validate(string manifestPath)
+        {
+            if (!string.Equals(Format, CurrentFormat, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException($"Unsupported mmap array relation artifact format '{Format}': {manifestPath}");
+            }
+
+            if (Version != 1)
+            {
+                throw new InvalidDataException($"Unsupported mmap array relation artifact manifest version {Version}: {manifestPath}");
+            }
+
+            if (!string.Equals(PhysicalBackend, "mmap_array", StringComparison.Ordinal))
+            {
+                throw new InvalidDataException($"Mmap array relation artifact has unsupported backend '{PhysicalBackend}': {manifestPath}");
+            }
+
+            if (string.IsNullOrWhiteSpace(PredicateName))
+            {
+                throw new InvalidDataException($"Mmap array relation artifact manifest has no predicate name: {manifestPath}");
+            }
+
+            if (Arity != 2)
+            {
+                throw new InvalidDataException($"Mmap array relation artifact smoke provider only supports arity-2 facts: {manifestPath}");
+            }
+
+            if (string.IsNullOrWhiteSpace(DataPath))
+            {
+                throw new InvalidDataException($"Mmap array relation artifact manifest has no data path: {manifestPath}");
+            }
+
+            if (RowCount < 0)
+            {
+                throw new InvalidDataException($"Mmap array relation artifact row count must be non-negative: {manifestPath}");
+            }
+
+            if (IdStrategy is not ("provided_id" or "position_id"))
+            {
+                throw new InvalidDataException($"Mmap array relation artifact has unsupported id strategy '{IdStrategy}': {manifestPath}");
+            }
+
+            if (IdWidth != 32 || !string.Equals(ValueEncoding, "int32_le", StringComparison.Ordinal))
+            {
+                throw new InvalidDataException($"Mmap array relation artifact smoke provider only supports int32_le values: {manifestPath}");
+            }
+
+            if (SortColumn != 0)
+            {
+                throw new InvalidDataException($"Mmap array relation artifact smoke provider only supports sort column 0: {manifestPath}");
+            }
+
+            if (!string.IsNullOrEmpty(StringTable))
+            {
+                throw new InvalidDataException($"Mmap array relation artifact smoke provider does not support sidecar string tables yet: {manifestPath}");
+            }
+        }
+    }
+
     public interface IReplayableRelationSource
     {
         IEnumerable<object[]> Stream();
@@ -419,6 +513,11 @@ namespace UnifyWeaver.QueryRuntime
                     var delimitedProvider = new DelimitedRelationArtifactProvider(fallback);
                     delimitedProvider.RegisterArtifact(predicate, manifestPath);
                     result = new RelationArtifactProviderOpenResult(delimitedProvider, "delimited_artifact");
+                    return true;
+                case MmapArrayRelationArtifactManifest.CurrentFormat:
+                    var mmapProvider = new MmapArrayRelationArtifactProvider(fallback);
+                    mmapProvider.RegisterArtifact(predicate, manifestPath);
+                    result = new RelationArtifactProviderOpenResult(mmapProvider, "mmap_array_artifact");
                     return true;
                 default:
                     result = default!;
@@ -2186,6 +2285,263 @@ namespace UnifyWeaver.QueryRuntime
         }
     }
 
+    public static class MmapArrayRelationArtifactBuilder
+    {
+        public static string BuildFromDelimited(
+            PredicateId predicate,
+            DelimitedRelationSource source,
+            string artifactDirectory,
+            string? artifactName = null,
+            string idStrategy = "provided_id")
+        {
+            if (artifactDirectory is null) throw new ArgumentNullException(nameof(artifactDirectory));
+            Directory.CreateDirectory(artifactDirectory);
+
+            if (predicate.Arity != 2 || source.ExpectedWidth != 2)
+            {
+                throw new InvalidDataException("Mmap array relation artifact builder only supports arity-2 int32 facts.");
+            }
+
+            artifactName ??= SanitizeArtifactName(predicate);
+            var dataPath = Path.Combine(artifactDirectory, artifactName + ".uwa");
+            var manifestPath = Path.Combine(artifactDirectory, artifactName + ".uwa.json");
+
+            var rows = DelimitedRelationReader.ReadRows(source)
+                .Select(row => (First: ParseInt32Cell(row[0]), Second: ParseInt32Cell(row[1])))
+                .OrderBy(row => row.First)
+                .ThenBy(row => row.Second)
+                .ToArray();
+
+            using (var stream = new FileStream(dataPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            using (var writer = new BinaryWriter(stream, Encoding.UTF8))
+            {
+                foreach (var row in rows)
+                {
+                    writer.Write(row.First);
+                    writer.Write(row.Second);
+                }
+            }
+
+            var sourceInfo = File.Exists(source.InputPath)
+                ? new FileInfo(source.InputPath)
+                : null;
+            var manifest = new MmapArrayRelationArtifactManifest
+            {
+                PredicateName = predicate.Name,
+                Arity = predicate.Arity,
+                DataPath = Path.GetFileName(dataPath),
+                RowCount = rows.LongLength,
+                IdStrategy = idStrategy,
+                IdWidth = 32,
+                ValueEncoding = "int32_le",
+                SortColumn = 0,
+                SourcePath = source.InputPath,
+                SourceLength = sourceInfo?.Length,
+                SourceSha256 = sourceInfo is null ? null : ComputeSha256(source.InputPath),
+            };
+
+            var json = JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(manifestPath, json, Encoding.UTF8);
+            return manifestPath;
+        }
+
+        private static int ParseInt32Cell(object value)
+        {
+            if (value is int intValue)
+            {
+                return intValue;
+            }
+
+            if (value is long longValue && longValue >= int.MinValue && longValue <= int.MaxValue)
+            {
+                return (int)longValue;
+            }
+
+            if (int.TryParse(Convert.ToString(value, CultureInfo.InvariantCulture), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                return parsed;
+            }
+
+            throw new InvalidDataException($"Mmap array relation artifact value '{value}' is not an int32 ID.");
+        }
+
+        private static string SanitizeArtifactName(PredicateId predicate)
+        {
+            var raw = $"{predicate.Name}_{predicate.Arity}";
+            var builder = new StringBuilder(raw.Length);
+            foreach (var ch in raw)
+            {
+                builder.Append(char.IsLetterOrDigit(ch) || ch == '_' || ch == '-' ? ch : '_');
+            }
+
+            return builder.ToString();
+        }
+
+        private static string ComputeSha256(string path)
+        {
+            using var stream = File.OpenRead(path);
+            var hash = SHA256.HashData(stream);
+            return Convert.ToHexString(hash).ToLowerInvariant();
+        }
+    }
+
+    public static class MmapArrayRelationArtifactReader
+    {
+        private const int RecordSize = sizeof(int) * 2;
+
+        public static MmapArrayRelationArtifactManifest LoadManifest(string manifestPath)
+        {
+            if (manifestPath is null) throw new ArgumentNullException(nameof(manifestPath));
+            var manifest = JsonSerializer.Deserialize<MmapArrayRelationArtifactManifest>(File.ReadAllText(manifestPath, Encoding.UTF8))
+                ?? throw new InvalidDataException($"Mmap array relation artifact manifest is empty: {manifestPath}");
+            manifest.Validate(manifestPath);
+            return manifest;
+        }
+
+        public static IEnumerable<object[]> ReadRows(string manifestPath)
+        {
+            var manifest = LoadManifest(manifestPath);
+            var dataPath = ResolveDataPath(manifest, manifestPath);
+            ValidateDataLength(manifest, dataPath);
+            if (manifest.RowCount == 0)
+            {
+                yield break;
+            }
+
+            using var mappedFile = MemoryMappedFile.CreateFromFile(dataPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var accessor = mappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+            for (var rowIndex = 0L; rowIndex < manifest.RowCount; rowIndex++)
+            {
+                yield return ReadRow(accessor, rowIndex);
+            }
+        }
+
+        public static IEnumerable<object[]> LookupRows(string manifestPath, IEnumerable<object> keys)
+        {
+            var manifest = LoadManifest(manifestPath);
+            var dataPath = ResolveDataPath(manifest, manifestPath);
+            ValidateDataLength(manifest, dataPath);
+            if (manifest.RowCount == 0)
+            {
+                yield break;
+            }
+
+            using var mappedFile = MemoryMappedFile.CreateFromFile(dataPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var accessor = mappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+
+            foreach (var key in keys)
+            {
+                var parsedKey = ParseLookupKey(key);
+                var first = LowerBound(accessor, manifest.RowCount, parsedKey);
+                for (var rowIndex = first; rowIndex < manifest.RowCount && ReadFirst(accessor, rowIndex) == parsedKey; rowIndex++)
+                {
+                    yield return ReadRow(accessor, rowIndex);
+                }
+            }
+        }
+
+        public static IEnumerable<IndexedRelationBucket> ReadBuckets(string manifestPath)
+        {
+            var manifest = LoadManifest(manifestPath);
+            var dataPath = ResolveDataPath(manifest, manifestPath);
+            ValidateDataLength(manifest, dataPath);
+            if (manifest.RowCount == 0)
+            {
+                yield break;
+            }
+
+            using var mappedFile = MemoryMappedFile.CreateFromFile(dataPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var accessor = mappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+
+            var rowIndex = 0L;
+            while (rowIndex < manifest.RowCount)
+            {
+                var key = ReadFirst(accessor, rowIndex);
+                var rows = new List<object[]>();
+                do
+                {
+                    rows.Add(ReadRow(accessor, rowIndex));
+                    rowIndex++;
+                }
+                while (rowIndex < manifest.RowCount && ReadFirst(accessor, rowIndex) == key);
+
+                yield return new IndexedRelationBucket(key, rows);
+            }
+        }
+
+        private static object[] ReadRow(MemoryMappedViewAccessor accessor, long rowIndex)
+        {
+            var offset = checked(rowIndex * RecordSize);
+            return new object[]
+            {
+                accessor.ReadInt32(offset),
+                accessor.ReadInt32(offset + sizeof(int))
+            };
+        }
+
+        private static int ReadFirst(MemoryMappedViewAccessor accessor, long rowIndex)
+        {
+            return accessor.ReadInt32(checked(rowIndex * RecordSize));
+        }
+
+        private static long LowerBound(MemoryMappedViewAccessor accessor, long rowCount, int key)
+        {
+            var low = 0L;
+            var high = rowCount;
+            while (low < high)
+            {
+                var mid = low + ((high - low) / 2);
+                if (ReadFirst(accessor, mid) < key)
+                {
+                    low = mid + 1;
+                }
+                else
+                {
+                    high = mid;
+                }
+            }
+
+            return low;
+        }
+
+        private static int ParseLookupKey(object key)
+        {
+            if (key is int intValue)
+            {
+                return intValue;
+            }
+
+            if (key is long longValue && longValue >= int.MinValue && longValue <= int.MaxValue)
+            {
+                return (int)longValue;
+            }
+
+            if (int.TryParse(Convert.ToString(key, CultureInfo.InvariantCulture), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                return parsed;
+            }
+
+            throw new InvalidDataException($"Mmap array relation artifact lookup key '{key}' is not an int32 ID.");
+        }
+
+        private static string ResolveDataPath(MmapArrayRelationArtifactManifest manifest, string manifestPath)
+        {
+            return Path.IsPathRooted(manifest.DataPath)
+                ? manifest.DataPath
+                : Path.Combine(Path.GetDirectoryName(Path.GetFullPath(manifestPath)) ?? ".", manifest.DataPath);
+        }
+
+        private static void ValidateDataLength(MmapArrayRelationArtifactManifest manifest, string dataPath)
+        {
+            var expectedLength = checked(manifest.RowCount * RecordSize);
+            var actualLength = new FileInfo(dataPath).Length;
+            if (actualLength != expectedLength)
+            {
+                throw new InvalidDataException($"Mmap array relation artifact data length is {actualLength}, expected {expectedLength}: {dataPath}");
+            }
+        }
+    }
+
     public static class BinaryRelationArtifactBuilder
     {
         public static string BuildFromDelimited(
@@ -3751,6 +4107,94 @@ namespace UnifyWeaver.QueryRuntime
             }
 
             reader.BaseStream.Position += length;
+        }
+    }
+
+    public sealed class MmapArrayRelationArtifactProvider : IIndexedRelationProvider, IIndexedRelationBucketProvider, IRelationCardinalityProvider
+    {
+        private readonly IRelationProvider? _fallback;
+        private readonly Dictionary<PredicateId, string> _manifestPaths = new();
+
+        public MmapArrayRelationArtifactProvider(IRelationProvider? fallback = null)
+        {
+            _fallback = fallback;
+        }
+
+        public void RegisterArtifact(PredicateId predicate, string manifestPath)
+        {
+            if (manifestPath is null) throw new ArgumentNullException(nameof(manifestPath));
+            var manifest = MmapArrayRelationArtifactReader.LoadManifest(manifestPath);
+            if (!string.Equals(manifest.PredicateName, predicate.Name, StringComparison.Ordinal) ||
+                manifest.Arity != predicate.Arity)
+            {
+                throw new InvalidDataException($"Mmap array relation artifact manifest describes {manifest.PredicateName}/{manifest.Arity}, not {predicate}.");
+            }
+
+            _manifestPaths[predicate] = manifestPath;
+        }
+
+        public IEnumerable<object[]> GetFacts(PredicateId predicate)
+        {
+            if (_manifestPaths.TryGetValue(predicate, out var manifestPath))
+            {
+                return MmapArrayRelationArtifactReader.ReadRows(manifestPath);
+            }
+
+            return _fallback?.GetFacts(predicate) ?? Array.Empty<object[]>();
+        }
+
+        public bool TryLookupFacts(PredicateId predicate, int columnIndex, IEnumerable<object> keys, out IEnumerable<object[]> facts)
+        {
+            if (columnIndex == 0 && _manifestPaths.TryGetValue(predicate, out var manifestPath))
+            {
+                facts = MmapArrayRelationArtifactReader.LookupRows(manifestPath, keys);
+                return true;
+            }
+
+            if (_fallback is IIndexedRelationProvider indexedFallback &&
+                indexedFallback.TryLookupFacts(predicate, columnIndex, keys, out facts))
+            {
+                return true;
+            }
+
+            facts = default!;
+            return false;
+        }
+
+        public bool TryReadIndexedBuckets(PredicateId predicate, int columnIndex, out IEnumerable<IndexedRelationBucket> buckets)
+        {
+            if (columnIndex == 0 && _manifestPaths.TryGetValue(predicate, out var manifestPath))
+            {
+                buckets = MmapArrayRelationArtifactReader.ReadBuckets(manifestPath);
+                return true;
+            }
+
+            if (_fallback is IIndexedRelationBucketProvider bucketFallback &&
+                bucketFallback.TryReadIndexedBuckets(predicate, columnIndex, out buckets))
+            {
+                return true;
+            }
+
+            buckets = default!;
+            return false;
+        }
+
+        public bool TryGetRelationCardinality(PredicateId predicate, out long rowCount)
+        {
+            if (_manifestPaths.TryGetValue(predicate, out var manifestPath))
+            {
+                rowCount = MmapArrayRelationArtifactReader.LoadManifest(manifestPath).RowCount;
+                return true;
+            }
+
+            if (_fallback is IRelationCardinalityProvider cardinalityFallback &&
+                cardinalityFallback.TryGetRelationCardinality(predicate, out rowCount))
+            {
+                return true;
+            }
+
+            rowCount = 0;
+            return false;
         }
     }
 

--- a/tests/test_csharp_query_lmdb_source_mode_benchmark.py
+++ b/tests/test_csharp_query_lmdb_source_mode_benchmark.py
@@ -41,13 +41,13 @@ class CSharpQueryLmdbSourceModeBenchmarkTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
 
         lines = result.stdout.strip().splitlines()
-        self.assertGreaterEqual(len(lines), 5)
+        self.assertGreaterEqual(len(lines), 6)
         headers = lines[0].split("\t")
         rows = [dict(zip(headers, line.split("\t"))) for line in lines[1:]]
 
         self.assertEqual(
             [row["mode"] for row in rows],
-            ["preload", "binary-artifact", "delimited-artifact", "lmdb"],
+            ["preload", "binary-artifact", "delimited-artifact", "lmdb", "mmap-array"],
         )
         self.assertEqual({row["scan_hash"] for row in rows}, {rows[0]["scan_hash"]})
         self.assertEqual({row["lookup_hash"] for row in rows}, {rows[0]["lookup_hash"]})

--- a/tests/test_csharp_query_mmap_array_provider_smoke.py
+++ b/tests/test_csharp_query_mmap_array_provider_smoke.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CORE_PROJECT = (
+    ROOT
+    / "src"
+    / "unifyweaver"
+    / "targets"
+    / "csharp_query_runtime"
+    / "UnifyWeaver.QueryRuntime.Core.csproj"
+)
+CORE_DLL = (
+    ROOT
+    / "src"
+    / "unifyweaver"
+    / "targets"
+    / "csharp_query_runtime"
+    / "bin"
+    / "Debug"
+    / "net9.0"
+    / "UnifyWeaver.QueryRuntime.Core.dll"
+)
+
+
+class CSharpQueryMmapArrayProviderSmokeTests(unittest.TestCase):
+    def test_mmap_array_provider_scans_lookups_and_buckets_match_expected_rows(self) -> None:
+        if shutil.which("dotnet") is None:
+            self.skipTest("dotnet is not available")
+
+        build_provider = subprocess.run(
+            ["dotnet", "build", str(CORE_PROJECT)],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=60,
+        )
+        self.assertEqual(
+            build_provider.returncode,
+            0,
+            msg=f"stdout:\n{build_provider.stdout}\nstderr:\n{build_provider.stderr}",
+        )
+
+        with tempfile.TemporaryDirectory(prefix="uw-csharp-mmap-array-smoke-") as tmp:
+            tmp_path = Path(tmp)
+            project_path = tmp_path / "MmapArrayProviderSmoke.csproj"
+            program_path = tmp_path / "Program.cs"
+            output_dir = tmp_path / "bin" / "Debug" / "net9.0"
+            project_path.write_text(
+                textwrap.dedent(
+                    f"""\
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <OutputType>Exe</OutputType>
+                        <TargetFramework>net9.0</TargetFramework>
+                        <Nullable>enable</Nullable>
+                        <ImplicitUsings>enable</ImplicitUsings>
+                        <NuGetAudit>false</NuGetAudit>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <Reference Include="UnifyWeaver.QueryRuntime.Core">
+                          <HintPath>{CORE_DLL}</HintPath>
+                        </Reference>
+                      </ItemGroup>
+                    </Project>
+                    """
+                ),
+                encoding="utf-8",
+            )
+            program_path.write_text(SMOKE_PROGRAM, encoding="utf-8")
+
+            build_result = subprocess.run(
+                ["dotnet", "build", str(project_path)],
+                cwd=tmp_path,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=60,
+            )
+            self.assertEqual(
+                build_result.returncode,
+                0,
+                msg=f"stdout:\n{build_result.stdout}\nstderr:\n{build_result.stderr}",
+            )
+
+            result = subprocess.run(
+                ["dotnet", str(output_dir / "MmapArrayProviderSmoke.dll")],
+                cwd=tmp_path,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=60,
+            )
+
+            self.assertEqual(
+                result.returncode,
+                0,
+                msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+            )
+            self.assertIn("MMAP_ARRAY_PROVIDER_SMOKE_OK", result.stdout)
+
+
+SMOKE_PROGRAM = r"""
+using UnifyWeaver.QueryRuntime;
+
+static void Assert(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException(message);
+    }
+}
+
+static string RowText(object[] row) => string.Join(">", row.Select(Convert.ToString));
+
+var root = Directory.GetCurrentDirectory();
+var sourcePath = Path.Combine(root, "edge.tsv");
+File.WriteAllLines(sourcePath, new[]
+{
+    "from\tto",
+    "2\t4",
+    "1\t3",
+    "1\t2",
+});
+
+var predicate = new PredicateId("edge", 2);
+var source = new DelimitedRelationSource(sourcePath, '\t', 1, 2);
+var manifestPath = MmapArrayRelationArtifactBuilder.BuildFromDelimited(predicate, source, Path.Combine(root, "edge-mmap"));
+
+var provider = new MmapArrayRelationArtifactProvider();
+provider.RegisterArtifact(predicate, manifestPath);
+
+var scanned = provider.GetFacts(predicate).Select(RowText).ToArray();
+Assert(scanned.SequenceEqual(new[] { "1>2", "1>3", "2>4" }), "scan rows did not match");
+
+Assert(provider.TryLookupFacts(predicate, 0, new object[] { "1" }, out var lookupRows), "arg0 lookup was not served");
+var lookedUp = lookupRows.Select(RowText).ToArray();
+Assert(lookedUp.SequenceEqual(new[] { "1>2", "1>3" }), "arg0 lookup rows did not match");
+
+Assert(provider.TryReadIndexedBuckets(predicate, 0, out var buckets), "arg0 bucket stream was not served");
+var bucketText = buckets.Select(bucket => $"{bucket.Key}:{string.Join(",", bucket.Rows.Select(RowText))}").ToArray();
+Assert(bucketText.SequenceEqual(new[] { "1:1>2,1>3", "2:2>4" }), "bucket rows did not match");
+
+Assert(provider.TryGetRelationCardinality(predicate, out var rowCount), "row count was not served");
+Assert(rowCount == 3, $"row count was {rowCount}, expected 3");
+
+var factory = new DefaultRelationArtifactProviderFactory();
+Assert(factory.TryOpen(predicate, manifestPath, fallback: null, out var opened), "factory did not open mmap array manifest");
+Assert(opened.StorageKind == "mmap_array_artifact", $"storage kind was {opened.StorageKind}");
+var factoryRows = opened.Provider.GetFacts(predicate).Select(RowText).ToArray();
+Assert(factoryRows.SequenceEqual(scanned), "factory provider scan rows did not match");
+
+Console.WriteLine("MMAP_ARRAY_PROVIDER_SMOKE_OK");
+"""
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  Adds a dependency-free fixed-width mmap-array artifact provider for the C# query runtime.

  The first implementation supports arity-2 `int32_le` relation artifacts sorted by column 0, with:

  - full scan support
  - arg0 binary-search lookup
  - column-0 bucket streaming
  - relation cardinality
  - default artifact factory dispatch
  - a builder for delimited int32 relation inputs

  The existing LMDB source-mode benchmark now also includes `mmap-array`, giving a direct comparison across preload, binary
  artifact, delimited artifact, LMDB, and mmap-array providers.

  ## Testing

  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py tests/test_csharp_query_lmdb_provider_smoke.py tests/
  test_csharp_query_mmap_array_provider_smoke.py tests/test_csharp_query_lmdb_source_mode_benchmark.py`
  - `python3 examples/benchmark/benchmark_csharp_query_lmdb_source_mode_sweep.py --rows 100 --keys 10 --lookup-repetitions 3
  --format markdown`
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime_lmdb/UnifyWeaver.QueryRuntime.Lmdb.csproj`
  - `env SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  test_csharp_query_target:test_csharp_query_target -t halt`
  - `git diff --check`