### PR TITLE
feat(wam-c): Lower WAM-C repeated projection rows through native helpers

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,7 +5,7 @@ Status date: 2026-05-15
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `1bd3d43e` (`Merge pull request #2116 from s243a/feat/wam-c-lowered-helper-nonreordered-projections`)
+- `main` at `87bfe424` (`Merge pull request #2126 from s243a/feat/wam-c-lowered-helper-ignored-output-contract`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
@@ -14,7 +14,7 @@ Base verified locally:
 
 Active branch:
 
-- `feat/wam-c-lowered-helper-ignored-output-contract`
+- `feat/wam-c-lowered-helper-projection-row-constraints`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -56,7 +56,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper projected body calls | Done | Variable-only reordered body-call projections lower through native fact-helper dispatch with executable coverage |
 | Generated multi-predicate setup | Done | Generated setup appends predicate code at per-setup base PCs and covers multiple setup functions in one executable |
 | Lowered helper non-reordered projection metadata | Done | Planner reports explicit rejection reasons for omitted head variables, repeated head variables, and unbound callee variables |
-| Lowered helper ignored-output projections | In progress | Active branch allows projected body-call helpers to pass callee-local variables as fresh unbound arguments and ignore their returned bindings |
+| Lowered helper ignored-output projections | Done | Projected body-call helpers pass singleton callee-local variables as fresh unbound arguments and ignore their returned bindings |
+| Lowered helper projection row constraints | In progress | Active branch lowers repeated caller-variable projections through materialized native fact rows while preserving availability checks |
 
 ## Current C Target Baseline
 
@@ -137,23 +138,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lowered-helper-ignored-output-contract`
-
-Goal: define the runtime contract for projected body calls whose callee produces
-variables that are not exposed by the caller.
-
-Scope:
-
-- Decide whether ignored callee outputs should be allowed only when they are
-  unconstrained, or whether they require materialized row filtering.
-- If supported, add executable coverage before enabling native helper lowering.
-- Keep constant filters on the existing materialized `filtered_fact` path.
-
-Status: active; ignored callee outputs are allowed when every caller-visible
-head variable is projected exactly once, with executable coverage for the
-lowered helper path.
-
-### 2. `feat/wam-c-lowered-helper-projection-row-constraints`
+### 1. `feat/wam-c-lowered-helper-projection-row-constraints`
 
 Goal: decide whether repeated caller variables in projected body calls should
 lower through native row constraints instead of staying rejected.
@@ -165,10 +150,27 @@ Scope:
   fact rows, similar to repeated-variable filtered helpers.
 - Keep constant filters on the existing materialized `filtered_fact` path.
 
+Status: active; repeated caller-variable projections now lower through
+availability-checked materialized native fact rows, while omitted caller-visible
+outputs and repeated callee-local variables remain explicit planner rejections.
+
+### 2. `feat/wam-c-lowered-helper-projection-bench`
+
+Goal: add a small benchmark workload for projected lowered helpers that covers
+reordered, ignored-output, and row-constrained projection shapes.
+
+Scope:
+
+- Extend the tiny lowered-helper matrix workload before adding broader C
+  target benchmark slices.
+- Compare interpreted, direct projected, ignored-output, and row-constrained
+  helper variants.
+- Keep constant filters on the existing materialized `filtered_fact` path.
+
 ## Suggested Immediate Next Step
 
-Continue validating `feat/wam-c-lowered-helper-ignored-output-contract`.
+Continue validating `feat/wam-c-lowered-helper-projection-row-constraints`.
 
-The active branch turns the previously classified unbound-callee projection
-case into supported lowering while keeping omitted caller-visible outputs and
-repeated caller variables explicit planner rejections.
+The active branch turns repeated caller-variable projections into a
+materialized-row helper path without weakening callee availability or omitted
+caller-output rejection semantics.

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -185,6 +185,8 @@ plan_wam_c_lowered_helper(DetectedKeys, AvailableKeys, PredIndicator, Plan) :-
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, body_call(CalleeKey, CalleeArity))
     ;   lowered_body_call_projected_helper(PredIndicator, AvailableKeys, CalleeKey, CalleeArity, CalleeArgs)
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, body_call_projected(CalleeKey, CalleeArity, CalleeArgs))
+    ;   lowered_body_call_projection_row_constrained_helper(PredIndicator, AvailableKeys, CalleeKey, Rows)
+    ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, filtered_fact(CalleeKey, Rows))
     ;   lowered_body_call_rejection_reason(PredIndicator, AvailableKeys, Reason)
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, rejected, Reason)
     ;   lowered_comparison_filtered_fact_helper(PredIndicator, CalleeKey, Rows)
@@ -461,6 +463,24 @@ lowered_body_call_projected_helper(PredIndicator, AvailableKeys, CalleeKey, Call
     head_args_project_once(HeadArgs, CalleeArgs),
     callee_local_variables_singletons(HeadArgs, CalleeArgs).
 
+lowered_body_call_projection_row_constrained_helper(PredIndicator, AvailableKeys, CalleeKey, Rows) :-
+    body_call_projection_context(PredIndicator, HeadArgs, CalleePred, CalleeArity, CalleeKey, CalleeArgs),
+    format(atom(CalleeKey), '~w/~w', [CalleePred, CalleeArity]),
+    memberchk(CalleeKey, AvailableKeys),
+    CalleeIndicator = user:CalleePred/CalleeArity,
+    lowered_fact_helper_rows(CalleeIndicator, CalleeRows),
+    head_args_project_at_least_once(HeadArgs, CalleeArgs),
+    repeated_head_variable_projection(HeadArgs, CalleeArgs),
+    callee_local_variables_singletons(HeadArgs, CalleeArgs),
+    include(callee_row_matches_arg_constraints(CalleeArgs), CalleeRows, MatchingRows),
+    findall(Projected,
+            (   member(CalleeRow, MatchingRows),
+                project_callee_row_to_head(HeadArgs, CalleeArgs, CalleeRow, Projected)
+            ),
+            ProjectedRows0),
+    sort(ProjectedRows0, Rows),
+    Rows \= [].
+
 lowered_body_call_rejection_reason(PredIndicator, AvailableKeys, Reason) :-
     body_call_context(PredIndicator, CalleePred, CalleeArity, CalleeKey),
     callee_has_user_clause(CalleePred, CalleeArity),
@@ -535,6 +555,18 @@ head_args_project_once([], _CalleeArgs).
 head_args_project_once([HeadArg|Rest], CalleeArgs) :-
     variable_occurrence_count(HeadArg, CalleeArgs, 1),
     head_args_project_once(Rest, CalleeArgs).
+
+head_args_project_at_least_once([], _CalleeArgs).
+head_args_project_at_least_once([HeadArg|Rest], CalleeArgs) :-
+    variable_occurrence_count(HeadArg, CalleeArgs, Count),
+    Count >= 1,
+    head_args_project_at_least_once(Rest, CalleeArgs).
+
+repeated_head_variable_projection(HeadArgs, CalleeArgs) :-
+    member(HeadArg, HeadArgs),
+    variable_occurrence_count(HeadArg, CalleeArgs, Count),
+    Count > 1,
+    !.
 
 callee_local_variables_singletons(_HeadArgs, []).
 callee_local_variables_singletons(HeadArgs, [CalleeArg|Rest]) :-

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -507,7 +507,7 @@ test_lowered_body_call_projection_rejection_metadata :-
         member(wam_c_lowered_helper_plan('wam_c_body_projection_fact2/2', _, lowered, fact_only([[a,a]])), Plans),
         member(wam_c_lowered_helper_plan('wam_c_body_projection_fact3/3', _, lowered, fact_only([[a,b,b]])), Plans),
         member(wam_c_lowered_helper_plan('wam_c_body_projection_omit/2', _, rejected, body_call_projection_omits_head_variable), Plans),
-        member(wam_c_lowered_helper_plan('wam_c_body_projection_repeat/1', _, rejected, body_call_projection_repeats_head_variable), Plans),
+        member(wam_c_lowered_helper_plan('wam_c_body_projection_repeat/1', _, lowered, filtered_fact('wam_c_body_projection_fact2/2', [[a]])), Plans),
         member(wam_c_lowered_helper_plan('wam_c_body_projection_repeated_local/1', _, rejected, body_call_projection_repeats_callee_local_variable), Plans),
         write_wam_c_project([user:wam_c_body_projection_fact1/1,
                              user:wam_c_body_projection_fact2/2,
@@ -519,7 +519,7 @@ test_lowered_body_call_projection_rejection_metadata :-
                             ProjectDir),
         read_file_to_string(LibPath, LibS, []),
         sub_string(LibS, _, _, _, '// - rejected wam_c_body_projection_omit/2: body_call_projection_omits_head_variable'),
-        sub_string(LibS, _, _, _, '// - rejected wam_c_body_projection_repeat/1: body_call_projection_repeats_head_variable'),
+        sub_string(LibS, _, _, _, '// - lowered wam_c_body_projection_repeat/1: filtered_fact'),
         sub_string(LibS, _, _, _, '// - rejected wam_c_body_projection_repeated_local/1: body_call_projection_repeats_callee_local_variable')
     ->  pass(Test)
     ;   fail_test(Test, 'planner did not report explicit projection rejection reasons')
@@ -1446,9 +1446,11 @@ run_lowered_fact_helper_executable_smoke :-
 run_lowered_body_call_helper_executable_smoke :-
     assertz(user:wam_c_body_fact(a, b)),
     assertz(user:wam_c_body_fact(a, c)),
+    assertz(user:wam_c_body_fact(a, a)),
     assertz((user:wam_c_body_alias(X, Y) :- user:wam_c_body_fact(X, Y))),
     assertz((user:wam_c_body_projected(X, Y) :- user:wam_c_body_fact(Y, X))),
     assertz((user:wam_c_body_ignored_output(X) :- user:wam_c_body_fact(X, _Ignored))),
+    assertz((user:wam_c_body_repeated_projection(X) :- user:wam_c_body_fact(X, X))),
     get_time(Now),
     Stamp is round(Now * 1000000),
     wam_c_temp_path('unifyweaver_wam_c_lowered_body_smoke', Stamp, ProjectDir),
@@ -1459,7 +1461,8 @@ run_lowered_body_call_helper_executable_smoke :-
     (   write_wam_c_project([user:wam_c_body_fact/2,
                              user:wam_c_body_alias/2,
                              user:wam_c_body_projected/2,
-                             user:wam_c_body_ignored_output/1],
+                             user:wam_c_body_ignored_output/1,
+                             user:wam_c_body_repeated_projection/1],
                             [lowered_helpers(true)],
                             ProjectDir),
         wam_c_lowered_body_smoke_main(MainCode),
@@ -1469,11 +1472,13 @@ run_lowered_body_call_helper_executable_smoke :-
     ->  retractall(user:wam_c_body_fact(_, _)),
         retractall(user:wam_c_body_alias(_, _)),
         retractall(user:wam_c_body_projected(_, _)),
-        retractall(user:wam_c_body_ignored_output(_))
+        retractall(user:wam_c_body_ignored_output(_)),
+        retractall(user:wam_c_body_repeated_projection(_))
     ;   retractall(user:wam_c_body_fact(_, _)),
         retractall(user:wam_c_body_alias(_, _)),
         retractall(user:wam_c_body_projected(_, _)),
         retractall(user:wam_c_body_ignored_output(_)),
+        retractall(user:wam_c_body_repeated_projection(_)),
         fail
     ).
 
@@ -2374,6 +2379,7 @@ void setup_wam_c_body_fact_2(WamState* state);
 void setup_wam_c_body_alias_2(WamState* state);
 void setup_wam_c_body_projected_2(WamState* state);
 void setup_wam_c_body_ignored_output_1(WamState* state);
+void setup_wam_c_body_repeated_projection_1(WamState* state);
 void setup_lowered_wam_c_helpers(WamState* state);
 
 int main(void) {
@@ -2440,6 +2446,21 @@ int main(void) {
     if (ignored_fail_rc != WAM_HALT) {
         wam_free_state(&state);
         return 80;
+    }
+
+    setup_wam_c_body_repeated_projection_1(&state);
+    WamValue repeated_args[1] = { val_atom("a") };
+    int repeated_rc = wam_run_predicate(&state, "wam_c_body_repeated_projection/1", repeated_args, 1);
+    if (repeated_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 90;
+    }
+
+    WamValue repeated_fail_args[1] = { val_atom("b") };
+    int repeated_fail_rc = wam_run_predicate(&state, "wam_c_body_repeated_projection/1", repeated_fail_args, 1);
+    if (repeated_fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 100;
     }
 
     wam_free_state(&state);


### PR DESCRIPTION
## Summary

- lower repeated caller-variable body-call projections like `p(X) :- fact(X, X)` through materialized native fact rows
- preserve callee availability checks before choosing the row-constrained helper path
- keep omitted caller-visible variables and repeated callee-local variables as explicit planner rejections
- add planner and executable smoke coverage for row-constrained projected helpers
- refresh the WAM-C next-steps roadmap with this branch active and projection benchmarking as the next follow-up

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --check`
