### PR TITLE
feat(wam-elixir): call/N meta-call (PR #1 of 5)

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -232,9 +232,11 @@ wam_elixir_case(call,
         %{state | pc: target_pc, cp: state.pc + 1}
       # Meta-call call/N — caught BEFORE label lookup so the
       # "call/N" string is dispatched as the meta-call, not
-      # treated as a missing user predicate.
-      {:call, "call/" <> _, n} ->
-        dispatch_call_meta(state, n, state.pc + 1)
+      # treated as a missing user predicate. The `n` field IS
+      # the total arity (= 1 base goal + extras), matching the
+      # WAM compiler''s emission convention.
+      {:call, "call/" <> _, total_arity} ->
+        dispatch_call_meta(state, total_arity, state.pc + 1)
       # Fallback: unresolved string label (cross-module/orphan).
       {:call, p, _n} when is_binary(p) ->
         case Map.get(state.labels, p) do
@@ -248,9 +250,14 @@ wam_elixir_case(execute,
         %{state | pc: target_pc}
       # Tail-position meta-call call/N. Total arity comes from
       # the op-name suffix (Execute carries no arity field).
+      # Integer.parse/1 instead of String.to_integer/1 so a
+      # malformed opcode (corrupted instr stream) fails cleanly
+      # rather than raising ArgumentError.
       {:execute, "call/" <> arity_str} ->
-        total_arity = String.to_integer(arity_str)
-        dispatch_call_meta(state, total_arity, state.cp)
+        case Integer.parse(arity_str) do
+          {total_arity, ""} -> dispatch_call_meta(state, total_arity, state.cp)
+          _ -> :fail
+        end
       # Fallback: unresolved string label.
       {:execute, p} when is_binary(p) ->
         case Map.get(state.labels, p) do
@@ -1197,9 +1204,17 @@ compile_utility_helpers_to_elixir(Code) :-
   # Then load the combined args into A1..A_total, set cp to after_pc,
   # and route through WamDispatcher.call (which knows about user
   # predicates and falls through to execute_builtin for builtins).
-  @doc "Dispatch a call/N meta-call. After the called goal returns, control resumes at after_pc."
-  def dispatch_call_meta(state, total_arity, after_pc) do
+  #
+  # `defp`: only invoked from within WamRuntime (execute_builtin
+  # arm + the :call/:execute step arms via the same module). Not
+  # part of the runtime''s external API.
+  defp dispatch_call_meta(state, total_arity, after_pc) do
     goal = deref_var(state, get_reg(state, 1))
+    # Elixir descending-range trap: `for i <- 2..1` would raise
+    # in Elixir 1.16+ (without an explicit step) and would yield
+    # [2, 1] in older Elixir. The `total_arity > 1` guard
+    # short-circuits the 0-extras case so the comprehension only
+    # runs on a real ascending range.
     extras =
       if total_arity > 1 do
         for i <- 2..total_arity, do: deref_var(state, get_reg(state, i))
@@ -1212,12 +1227,31 @@ compile_utility_helpers_to_elixir(Code) :-
         call_state = %{prepared_state | cp: after_pc}
         try do
           case WamDispatcher.call(pred_arity, call_state) do
+            # Why override pc to after_pc here? WamDispatcher.call
+            # returns the dispatched goal''s post-state, whose
+            # pc is whatever the called goal''s last instruction
+            # left it at (typically state.pc + 1 for builtins, or
+            # the user-pred''s last-instr pc for lowered predicates).
+            # Neither matches the meta-call''s logical resumption
+            # point, which is after_pc (= state.pc + 1 for non-tail
+            # call, state.cp for tail execute). Forcing pc to
+            # after_pc makes the meta-call behave like a single
+            # logical instruction regardless of what the dispatched
+            # goal did internally. PRs #2-5 (catch/throw + ISO)
+            # depend on this invariant.
             {:ok, post_state} -> %{post_state | pc: after_pc}
             :fail -> :fail
           end
         catch
+          # :fail and {:fail, _} — internal control-flow throws used
+          # for backtrack propagation. Cargoed from the \\+/1 block
+          # (see negation_as_failure handling); same semantics.
           :fail -> :fail
           {:fail, _} -> :fail
+          # {:return, _} — same provenance as the catch arms in the
+          # negation block. Some lowered code paths use throw({:return,
+          # state}) to short-circuit out of a body. Re-pin pc the
+          # same way the success path does.
           {:return, post_state} -> %{post_state | pc: after_pc}
         end
       :fail -> :fail
@@ -1251,9 +1285,21 @@ compile_utility_helpers_to_elixir(Code) :-
       _ -> :fail
     end
   end
+  # Catch-all: unbound goal, malformed term, or otherwise unrecognised
+  # shape. Returns :fail (lax semantics), matching the rest of the
+  # current Elixir runtime. PR #3 (ISO errors plumbing) will replace
+  # this with `instantiation_error` for the unbound-goal case
+  # specifically; the malformed-shape cases stay :fail.
   defp build_call_target(_state, _goal, _extras), do: :fail
 
-  # Write a list of arg values into consecutive A-regs starting at start_reg.
+  # Write a list of arg values into consecutive A-regs starting at
+  # start_reg. Note: callers pass start_reg=1, which means the FIRST
+  # extra (or first base-arg, for compound goals) overwrites A1 — the
+  # register that originally held the base goal-term. That is correct:
+  # after dispatch_call_meta builds the combined name/total_arity,
+  # the dispatched predicate''s arg 1 is the FIRST argument of the
+  # combined call, not the base-goal term. The base-goal value is no
+  # longer needed once pred_arity is built.
   defp load_args_into_regs(state, start_reg, args) do
     args
     |> Enum.with_index(start_reg)

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -230,6 +230,11 @@ wam_elixir_case(call,
 '      # Fast path: label pre-resolved at codegen to integer PC.
       {:call, target_pc, _n} when is_integer(target_pc) ->
         %{state | pc: target_pc, cp: state.pc + 1}
+      # Meta-call call/N — caught BEFORE label lookup so the
+      # "call/N" string is dispatched as the meta-call, not
+      # treated as a missing user predicate.
+      {:call, "call/" <> _, n} ->
+        dispatch_call_meta(state, n, state.pc + 1)
       # Fallback: unresolved string label (cross-module/orphan).
       {:call, p, _n} when is_binary(p) ->
         case Map.get(state.labels, p) do
@@ -241,6 +246,11 @@ wam_elixir_case(execute,
 '      # Fast path: label pre-resolved at codegen to integer PC.
       {:execute, target_pc} when is_integer(target_pc) ->
         %{state | pc: target_pc}
+      # Tail-position meta-call call/N. Total arity comes from
+      # the op-name suffix (Execute carries no arity field).
+      {:execute, "call/" <> arity_str} ->
+        total_arity = String.to_integer(arity_str)
+        dispatch_call_meta(state, total_arity, state.cp)
       # Fallback: unresolved string label.
       {:execute, p} when is_binary(p) ->
         case Map.get(state.labels, p) do
@@ -826,6 +836,11 @@ compile_utility_helpers_to_elixir(Code) :-
         # failure. (Pre-hardening, fail/0 worked accidentally because
         # the default arm returned :fail — same semantic, wrong reason.)
         :fail
+      {"true/0", 0} ->
+        # ISO `true` — succeeds unconditionally. Same default-arm
+        # hardening reasoning as fail/0 above.
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        %{state | pc: new_pc}
       {"</2", 2} ->
         v1 = eval_arith(state, get_reg(state, 1))
         v2 = eval_arith(state, get_reg(state, 2))
@@ -1144,6 +1159,14 @@ compile_utility_helpers_to_elixir(Code) :-
             preserved_aggs ++ state.cut_point
           end
         %{state | choice_points: new_cps, pc: new_pc}
+      {"call/" <> _, n} ->
+        # call/N meta-call. Lowered-mode dispatch arrives here via
+        # WamDispatcher.call("call/N", state) -> execute_builtin/3
+        # falling through. Interpreter mode also reaches the same
+        # helper from the :call / :execute step arms (see
+        # wam_elixir_case(call, ...) and wam_elixir_case(execute, ...)).
+        # See WAM_ELIXIR_GAPS_SPECIFICATION.md PR #1.
+        dispatch_call_meta(state, n, state.cp)
       _ ->
         # Hardening: surface unimplemented builtins instead of silently
         # returning :fail. The pre-hardening default arm masked
@@ -1155,6 +1178,86 @@ compile_utility_helpers_to_elixir(Code) :-
         # be added rather than relying on the silent-:fail accident.
         throw({:unknown_builtin, op, arity})
     end
+  end
+
+  # ---- call/N meta-call dispatch -----------------------------------
+  #
+  # Mirrors the C++ dispatch_call_meta in wam_cpp_target.pl. The
+  # WAM compiler emits call(Goal[, X1..Xk]) usage as
+  #   {:execute, "call/N"}        -- when call/N is the body tail
+  #   {:call,    "call/N", N}     -- otherwise (non-tail)
+  # with the base goal in A1 and any extras in A2..AN. The :call
+  # and :execute step arms catch the "call/" prefix BEFORE doing
+  # label lookup and route here.
+  #
+  # Build the combined goal:
+  #   - A1 atom        (`true`, `fail`, `append`)  -> use as-is, arity = total - 1
+  #   - A1 compound    ({:ref, addr} -> {:str, "name/baseN"}) ->
+  #       gather base args from heap, append extras, total = baseN + (total - 1)
+  # Then load the combined args into A1..A_total, set cp to after_pc,
+  # and route through WamDispatcher.call (which knows about user
+  # predicates and falls through to execute_builtin for builtins).
+  @doc "Dispatch a call/N meta-call. After the called goal returns, control resumes at after_pc."
+  def dispatch_call_meta(state, total_arity, after_pc) do
+    goal = deref_var(state, get_reg(state, 1))
+    extras =
+      if total_arity > 1 do
+        for i <- 2..total_arity, do: deref_var(state, get_reg(state, i))
+      else
+        []
+      end
+
+    case build_call_target(state, goal, extras) do
+      {:ok, pred_arity, prepared_state} ->
+        call_state = %{prepared_state | cp: after_pc}
+        try do
+          case WamDispatcher.call(pred_arity, call_state) do
+            {:ok, post_state} -> %{post_state | pc: after_pc}
+            :fail -> :fail
+          end
+        catch
+          :fail -> :fail
+          {:fail, _} -> :fail
+          {:return, post_state} -> %{post_state | pc: after_pc}
+        end
+      :fail -> :fail
+    end
+  end
+
+  # Build the combined predicate-key + load A-regs from the goal+extras.
+  # Atomic goal: arity is just the count of extras.
+  # Compound {:ref, addr} -> {:str, "name/baseN"}: read base args
+  # from heap, concat extras, total = baseN + length(extras).
+  defp build_call_target(state, goal, extras) when is_binary(goal) do
+    arity = length(extras)
+    pred_arity = "#{goal}/#{arity}"
+    new_state = load_args_into_regs(state, 1, extras)
+    {:ok, pred_arity, new_state}
+  end
+  defp build_call_target(state, goal, extras) when is_atom(goal) and not is_nil(goal) do
+    build_call_target(state, Atom.to_string(goal), extras)
+  end
+  defp build_call_target(state, {:ref, addr}, extras) do
+    case Map.get(state.heap, addr) do
+      {:str, base_pred_arity} ->
+        base_arity = parse_functor_arity(base_pred_arity)
+        name = parse_functor_name(base_pred_arity)
+        base_args = heap_slice(state, addr + 1, base_arity)
+        combined = base_args ++ extras
+        total = base_arity + length(extras)
+        pred_arity = "#{name}/#{total}"
+        new_state = load_args_into_regs(state, 1, combined)
+        {:ok, pred_arity, new_state}
+      _ -> :fail
+    end
+  end
+  defp build_call_target(_state, _goal, _extras), do: :fail
+
+  # Write a list of arg values into consecutive A-regs starting at start_reg.
+  defp load_args_into_regs(state, start_reg, args) do
+    args
+    |> Enum.with_index(start_reg)
+    |> Enum.reduce(state, fn {arg, i}, s -> %{s | regs: Map.put(s.regs, i, arg)} end)
   end
 
   # Extract the functor-name part from a "name/arity" string.

--- a/tests/test_wam_elixir_classic_programs.pl
+++ b/tests/test_wam_elixir_classic_programs.pl
@@ -66,6 +66,22 @@ user:sum_of_squares(A, B, S) :- user:square(A, A2),
                                 user:square(B, B2),
                                 S is A2 + B2.
 
+% --- call/N meta-call acceptance cases (PR #1) ---
+% Spec: docs/design/WAM_ELIXIR_GAPS_SPECIFICATION.md §3 PR #1.
+% Each predicate exercises one shape of meta-call dispatch:
+%   - elx_call_true/0       atom goal, 0 extras  (succeeds)
+%   - elx_call_fail/0       atom goal, 0 extras  (fails)
+%   - elx_call_compound/1   compound goal, 0 extras (heap-built goal)
+%   - elx_call_extras/1     atom goal, 3 extras   (partial-application)
+:- dynamic user:elx_call_true/0.
+:- dynamic user:elx_call_fail/0.
+:- dynamic user:elx_call_compound/1.
+:- dynamic user:elx_call_extras/1.
+user:elx_call_true :- call(true).
+user:elx_call_fail :- call(fail).
+user:elx_call_compound(R) :- G = (X is 1 + 1), call(G), R = X.
+user:elx_call_extras(R) :- call(append, [a, b], [c, d], R).
+
 % ============================================================
 % elixir_available — same gating pattern as the Scala suite
 % ============================================================
@@ -145,6 +161,43 @@ test(pythagoras) :-
             % square direct: 7^2 = 49 -> true
             verify_elixir_args(TmpDir, 'square/2', ['7', '49'], "true")
         )).
+
+% --- call/N meta-call tests (PR #1 acceptance) ---
+
+test(call_atom_true) :-
+    with_elixir_project(
+        [user:elx_call_true/0],
+        _Opts,
+        TmpDir,
+        verify_elixir_args(TmpDir, 'elx_call_true/0', [], "true")
+    ).
+
+test(call_atom_fail) :-
+    with_elixir_project(
+        [user:elx_call_fail/0],
+        _Opts,
+        TmpDir,
+        verify_elixir_args(TmpDir, 'elx_call_fail/0', [], "false")
+    ).
+
+test(call_compound_goal) :-
+    % G = (X is 1+1), call(G), R = X.  R = 2 -> true.
+    with_elixir_project(
+        [user:elx_call_compound/1],
+        _Opts,
+        TmpDir,
+        verify_elixir_args(TmpDir, 'elx_call_compound/1', ['2'], "true")
+    ).
+
+test(call_with_extras) :-
+    % call(append, [a,b], [c,d], R) -> R = [a,b,c,d].
+    with_elixir_project(
+        [user:elx_call_extras/1],
+        _Opts,
+        TmpDir,
+        verify_elixir_args(TmpDir, 'elx_call_extras/1',
+                           ['[a,b,c,d]'], "true")
+    ).
 
 :- end_tests(wam_elixir_classic_programs).
 

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -156,6 +156,54 @@ test_builtin_call_delegates :-
     ;   fail_test(Test, 'builtin_call does not delegate to execute_builtin')
     ).
 
+%% call/N meta-call generator gates (PR #1)
+
+test_call_n_dispatch_meta_helper :-
+    Test = 'WAM-Elixir: dispatch_call_meta helper present in runtime',
+    (   compile_wam_helpers_to_elixir([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _,
+                   'def dispatch_call_meta(state, total_arity, after_pc)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'dispatch_call_meta missing from runtime helpers')
+    ).
+
+test_call_n_step_arms :-
+    Test = 'WAM-Elixir: :call and :execute step arms catch "call/N" \
+                       before label lookup',
+    (   wam_elixir_case(call, CallCode),
+        sub_string(CallCode, _, _, _, '"call/" <> _'),
+        sub_string(CallCode, _, _, _,
+                   'dispatch_call_meta(state, n, state.pc + 1)'),
+        wam_elixir_case(execute, ExecCode),
+        sub_string(ExecCode, _, _, _, '"call/" <> arity_str'),
+        sub_string(ExecCode, _, _, _,
+                   'dispatch_call_meta(state, total_arity, state.cp)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'call/N dispatch missing from step arms')
+    ).
+
+test_true_zero_builtin :-
+    Test = 'WAM-Elixir: true/0 builtin arm exists',
+    (   compile_wam_helpers_to_elixir([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, '{"true/0", 0}')
+    ->  pass(Test)
+    ;   fail_test(Test, 'true/0 builtin missing')
+    ).
+
+test_build_call_target_helpers :-
+    Test = 'WAM-Elixir: build_call_target + load_args_into_regs helpers \
+                       present',
+    (   compile_wam_helpers_to_elixir([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'defp build_call_target('),
+        sub_string(S, _, _, _, 'defp load_args_into_regs(')
+    ->  pass(Test)
+    ;   fail_test(Test,
+                  'build_call_target / load_args_into_regs missing')
+    ).
+
 %% Code style tests
 
 test_elixir_idioms :-
@@ -2758,6 +2806,10 @@ run_tests :-
     test_choice_point_instructions,
     test_choice_point_bytecode,
     test_builtin_call_delegates,
+    test_call_n_dispatch_meta_helper,
+    test_call_n_step_arms,
+    test_true_zero_builtin,
+    test_build_call_target_helpers,
     test_elixir_idioms,
     test_immutable_state_updates,
     test_functional_run_loop,

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -163,7 +163,7 @@ test_call_n_dispatch_meta_helper :-
     (   compile_wam_helpers_to_elixir([], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _,
-                   'def dispatch_call_meta(state, total_arity, after_pc)')
+                   'defp dispatch_call_meta(state, total_arity, after_pc)')
     ->  pass(Test)
     ;   fail_test(Test, 'dispatch_call_meta missing from runtime helpers')
     ).
@@ -174,13 +174,27 @@ test_call_n_step_arms :-
     (   wam_elixir_case(call, CallCode),
         sub_string(CallCode, _, _, _, '"call/" <> _'),
         sub_string(CallCode, _, _, _,
-                   'dispatch_call_meta(state, n, state.pc + 1)'),
+                   'dispatch_call_meta(state, total_arity, state.pc + 1)'),
         wam_elixir_case(execute, ExecCode),
         sub_string(ExecCode, _, _, _, '"call/" <> arity_str'),
+        sub_string(ExecCode, _, _, _, 'Integer.parse(arity_str)'),
         sub_string(ExecCode, _, _, _,
                    'dispatch_call_meta(state, total_arity, state.cp)')
     ->  pass(Test)
     ;   fail_test(Test, 'call/N dispatch missing from step arms')
+    ).
+
+test_build_call_target_compound_clause :-
+    Test = 'WAM-Elixir: build_call_target has {:ref, addr} compound clause',
+    (   compile_wam_helpers_to_elixir([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _,
+                   'defp build_call_target(state, {:ref, addr}, extras)'),
+        % Heap deref + functor parse should be inline in the clause body.
+        sub_string(S, _, _, _, 'Map.get(state.heap, addr)'),
+        sub_string(S, _, _, _, 'parse_functor_arity(base_pred_arity)')
+    ->  pass(Test)
+    ;   fail_test(Test, '{:ref, addr} compound dispatch clause missing')
     ).
 
 test_true_zero_builtin :-
@@ -2810,6 +2824,7 @@ run_tests :-
     test_call_n_step_arms,
     test_true_zero_builtin,
     test_build_call_target_helpers,
+    test_build_call_target_compound_clause,
     test_elixir_idioms,
     test_immutable_state_updates,
     test_functional_run_loop,


### PR DESCRIPTION
  ## Summary

  PR #1 from [`WAM_ELIXIR_GAPS_SPECIFICATION.md`](docs/design/WAM_ELIXIR_GAPS_SPECIFICATION.md) §3.
  Closes the `call/N` gap so user code can write higher-order patterns
  and so `catch/3` (PR #2) has the goal-term dispatch it needs.

  ### Audit findings (the gap before this commit)

  - `WamDispatcher.call/2` dispatches by predicate-string with builtin
    fallback, but had no understanding of `"call/N"` as a meta-call.
  - `:call` / `:execute` step arms only do label lookup, so
    `{:call, "call/N", N}` fell through to `:fail`.
  - `execute_builtin` had no `"call/N"` arm — lowered code emitting
    `WamDispatcher.call("call/N", state)` hit the `unknown_builtin`
    throw.
  - No `true/0` builtin, so `call(true)` would have crashed even if
    routing worked.

  ### Changes

  | Component | Purpose |
  |---|---|
  | `dispatch_call_meta/3` runtime helper | Reads A1 as base goal, gathers A2..A_TotalArity as extras, builds combined
  `"name/total_arity"` key, loads regs, routes through `WamDispatcher.call`. Mirrors C++ `dispatch_call_meta` in
  `wam_cpp_target.pl`. |
  | `execute_builtin "call/N"` arm | Catches lowered-mode dispatch from `WamDispatcher.call("call/N", state)` |
  | `:call` / `:execute` step arms | Catch `"call/N"` before label lookup (interpreter-mode coverage) |
  | `true/0` builtin arm | Required for `call(true)` |
  | `build_call_target/3`, `load_args_into_regs/3` | Internal helpers — handle bare-string atom, BEAM-atom, and `{:ref,
  addr} → {:str, "name/baseN"}` compound goal shapes |

  Reference: C++ commit `b5fc6041` *feat(wam-cpp): call/N meta-call*.

  ### Bench fixtures

  Deferred to PR #2 (catch/3 + throw/1) per spec §6.1's "may also
  pre-land" wording — no bench infrastructure changes were
  incidental to this PR.

  ## Test plan

  ### Unit tests (`tests/test_wam_elixir_target.pl`)

  - [x] `WAM-Elixir: dispatch_call_meta helper present in runtime`
  - [x] `WAM-Elixir: :call and :execute step arms catch "call/N" before label lookup`
  - [x] `WAM-Elixir: true/0 builtin arm exists`
  - [x] `WAM-Elixir: build_call_target + load_args_into_regs helpers present`

  ### E2E acceptance tests (`tests/test_wam_elixir_classic_programs.pl`)

  Full Prolog → WAM → Elixir → elixir-subprocess execution.

  - [x] `call_atom_true` — `?- call(true).` succeeds → `"true"`
  - [x] `call_atom_fail` — `?- call(fail).` fails → `"false"`
  - [x] `call_compound_goal` — `?- G = (X is 1+1), call(G), R = X.` with R=2 → `"true"`
  - [x] `call_with_extras` — `?- call(append, [a,b], [c,d], R).` with R=[a,b,c,d] → `"true"`

  ### Regression

  - [x] All existing `tests/test_wam_elixir_target.pl` tests pass.
  - [x] All existing `tests/test_wam_elixir_classic_programs.pl` tests pass (fibonacci, ackermann, pythagoras).

  ## Reviewer notes

  - The `:call` / `:execute` step arm changes serve interpreter mode;
    the `execute_builtin "call/N"` arm serves lowered mode. Both
    share `dispatch_call_meta/3`. Belt-and-suspenders so future
    callers from either mode get the same dispatch behaviour.
  - No changes to existing `\+/1` / `findall/3` paths, which use
    `WamDispatcher.call` directly (not via `"call/N"`). The new arm
    is additive.
  - `true/0` was added because the `_ -> throw({:unknown_builtin, ...})`
    hardening would otherwise crash on `call(true)` even after
    routing worked. Same justification used for the existing `fail/0`
    arm (see line 821 comment).

  🤖 Generated with [Claude Code](https://claude.com/claude-code)