### PR TITLE
feat(wam-cpp): format/3 with atom/string/codes destinations

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -2730,24 +2730,39 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         std::fflush(stdout);
         pc += 1; return true;
     }
-    // ---- format/1, format/2 ----------------------------------------
-    // Walks the format string A1 (Atom), expanding ~-directives.
+    // ---- format/1, format/2, format/3 -------------------------------
+    // Walks the format string, expanding ~-directives.
     // Supported: ~w (write), ~p (print, same as ~w), ~a (atom),
     // ~d (integer), ~s (codes/atom), ~n (newline), ~~ (literal ~).
-    // Unsupported directives are echoed verbatim. Args list (A2, for
-    // format/2) is walked left-to-right; running off the end of args
-    // for a directive that needs one fails.
-    if (op == "format/1" || op == "format/2") {
-        Value fv = deref(*get_cell("A1"));
+    // Unsupported directives are echoed verbatim. Args list is walked
+    // left-to-right; running off the end of args for a directive that
+    // needs one fails.
+    //
+    // Shape variants:
+    //   format/1   — just a format string, no args (implicit []).
+    //   format/2   — Format, Args.
+    //   format/3   — Dest, Format, Args. Dest selects output:
+    //     atom user_output / user_error → stdout / stderr (printed).
+    //     atom(V) / string(V)           → V is unified with the rendered
+    //                                     string as an Atom value.
+    //     codes(V)                      → V is unified with a list of
+    //                                     character codes.
+    if (op == "format/1" || op == "format/2" || op == "format/3") {
+        bool is_f3 = (op == "format/3");
+        // Resolve format-string + args-list positions.
+        CellPtr fmt_cell  = get_cell(is_f3 ? "A2" : "A1");
+        CellPtr args_cell = (op == "format/2")
+            ? get_cell("A2")
+            : (is_f3 ? get_cell("A3") : CellPtr{});
+        Value fv = deref(*fmt_cell);
         std::string fmt;
         if (fv.tag == Value::Tag::Atom) fmt = fv.s;
         else if (fv.tag == Value::Tag::Integer) fmt = std::to_string(fv.i);
         else return false;
-        // Build a vector of arg cells from A2 (for format/2). For
-        // format/1 the list is implicitly empty.
+        // Build a vector of arg cells from the args list (if any).
         std::vector<CellPtr> args;
-        if (op == "format/2") {
-            CellPtr lc = get_cell("A2");
+        if (args_cell) {
+            CellPtr lc = args_cell;
             for (;;) {
                 Value lv = deref(*lc);
                 if (lv.tag == Value::Tag::Atom && lv.s == "[]") break;
@@ -2761,46 +2776,49 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
                 return false;
             }
         }
+        // Render into a buffer first (used by format/3 string-destinations
+        // and by stdout/stderr printing alike — single rendering path).
+        std::string buf;
         std::size_t ai = 0;
         for (std::size_t i = 0; i < fmt.size(); ++i) {
             char c = fmt[i];
             if (c != ''~'' || i + 1 >= fmt.size()) {
-                std::fputc(c, stdout);
+                buf.push_back(c);
                 continue;
             }
             char d = fmt[++i];
             switch (d) {
-                case ''n'': std::fputc(''\\n'', stdout); break;
-                case ''t'': std::fputc(''\\t'', stdout); break;
-                case ''~'': std::fputc(''~'', stdout); break;
+                case ''n'': buf.push_back(''\\n''); break;
+                case ''t'': buf.push_back(''\\t''); break;
+                case ''~'': buf.push_back(''~''); break;
                 case ''w'':
                 case ''p'': {
                     if (ai >= args.size()) return false;
-                    std::printf("%s", render(deref(*args[ai++])).c_str());
+                    buf += render(deref(*args[ai++]));
                     break;
                 }
                 case ''a'': {
                     if (ai >= args.size()) return false;
                     Value v = deref(*args[ai++]);
-                    if (v.tag == Value::Tag::Atom) std::printf("%s", v.s.c_str());
-                    else std::printf("%s", render(v).c_str());
+                    if (v.tag == Value::Tag::Atom) buf += v.s;
+                    else buf += render(v);
                     break;
                 }
                 case ''d'': {
                     if (ai >= args.size()) return false;
                     Value v = deref(*args[ai++]);
-                    if (v.tag == Value::Tag::Integer) std::printf("%lld",
-                        static_cast<long long>(v.i));
-                    else std::printf("%s", render(v).c_str());
+                    if (v.tag == Value::Tag::Integer)
+                        buf += std::to_string(v.i);
+                    else buf += render(v);
                     break;
                 }
                 case ''s'': {
-                    // String form: accept an atom (print as-is) or a
-                    // list of integer character codes.
+                    // String form: accept an atom (use as-is) or a list
+                    // of integer character codes.
                     if (ai >= args.size()) return false;
                     Value v = deref(*args[ai++]);
                     if (v.tag == Value::Tag::Atom) {
-                        std::printf("%s", v.s.c_str());
+                        buf += v.s;
                     } else if (v.tag == Value::Tag::Compound
                                && v.s == "[|]/2") {
                         CellPtr lc = args[ai - 1];
@@ -2811,23 +2829,72 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
                                 || lv.args.size() != 2) return false;
                             Value hv = deref(*lv.args[0]);
                             if (hv.tag != Value::Tag::Integer) return false;
-                            std::fputc(static_cast<int>(hv.i), stdout);
+                            buf.push_back(static_cast<char>(hv.i));
                             lc = lv.args[1];
                         }
                     } else {
-                        std::printf("%s", render(v).c_str());
+                        buf += render(v);
                     }
                     break;
                 }
                 default:
                     // Unknown directive: echo literally.
-                    std::fputc(''~'', stdout);
-                    std::fputc(d, stdout);
+                    buf.push_back(''~'');
+                    buf.push_back(d);
                     break;
             }
         }
-        std::fflush(stdout);
-        pc += 1; return true;
+        // Dispatch on destination (format/3) or just print (format/1, /2).
+        if (!is_f3) {
+            std::fwrite(buf.data(), 1, buf.size(), stdout);
+            std::fflush(stdout);
+            pc += 1; return true;
+        }
+        // format/3: A1 selects destination.
+        Value dv = deref(*get_cell("A1"));
+        if (dv.tag == Value::Tag::Atom) {
+            if (dv.s == "user_output") {
+                std::fwrite(buf.data(), 1, buf.size(), stdout);
+                std::fflush(stdout);
+                pc += 1; return true;
+            }
+            if (dv.s == "user_error") {
+                std::fwrite(buf.data(), 1, buf.size(), stderr);
+                std::fflush(stderr);
+                pc += 1; return true;
+            }
+        }
+        if (dv.tag == Value::Tag::Compound && dv.args.size() == 1) {
+            // atom(V) / string(V) → V unifies with the buffer as Atom.
+            if (dv.s == "atom/1" || dv.s == "string/1") {
+                Value out = Value::Atom(buf);
+                CellPtr tgt = dv.args[0];
+                if (tgt->is_unbound()) { bind_cell(tgt, out); pc += 1; return true; }
+                if (!unify_cells(tgt, std::make_shared<Cell>(out))) return false;
+                pc += 1; return true;
+            }
+            // codes(V) → V unifies with a [|]/2 list of integer codes,
+            // built bottom-up: end with [], then prepend each code.
+            if (dv.s == "codes/1") {
+                CellPtr list = std::make_shared<Cell>(Value::Atom("[]"));
+                for (auto it = buf.rbegin(); it != buf.rend(); ++it) {
+                    CellPtr head = std::make_shared<Cell>(
+                        Value::Integer(static_cast<std::int64_t>(
+                            static_cast<unsigned char>(*it))));
+                    std::vector<CellPtr> cons_args;
+                    cons_args.push_back(head);
+                    cons_args.push_back(list);
+                    list = std::make_shared<Cell>(
+                        Value::Compound("[|]/2", std::move(cons_args)));
+                }
+                CellPtr tgt = dv.args[0];
+                if (tgt->is_unbound()) { bind_cell(tgt, *list); pc += 1; return true; }
+                if (!unify_cells(tgt, list)) return false;
+                pc += 1; return true;
+            }
+        }
+        // Unrecognised destination — fail.
+        return false;
     }
 
     return false;

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1451,6 +1451,9 @@ is_builtin_pred(copy_term, 2). % term inspection: fresh-variable copy
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).
+is_builtin_pred(format, 1).  % I/O — formatted output, ~-directives.
+is_builtin_pred(format, 2).
+is_builtin_pred(format, 3).
 is_builtin_pred(=, 2).       % unification: bind / structurally unify two terms.
 is_builtin_pred(is_list, 1).
                              % Without this entry, X = Y in a body goal

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -763,6 +763,51 @@ user:wam_cpp_test_ite_in_findall_no_cut_outer :-
     findall(X, (member(X, [1, 2, 3]), (X > 0 -> true ; fail)), L),
     L = [1, 2, 3].
 
+% format/1, /2, /3 — formatted output with ~-directives. /1 takes
+% just a format string; /2 takes Format + Args; /3 takes Dest +
+% Format + Args, where Dest selects user_output / user_error /
+% atom(V) / string(V) / codes(V).
+:- dynamic user:wam_cpp_test_format1/0.
+:- dynamic user:wam_cpp_test_format2_w/0.
+:- dynamic user:wam_cpp_test_format2_multi/0.
+:- dynamic user:wam_cpp_test_format2_d/0.
+:- dynamic user:wam_cpp_test_format2_a/0.
+:- dynamic user:wam_cpp_test_format3_atom/0.
+:- dynamic user:wam_cpp_test_format3_string/0.
+:- dynamic user:wam_cpp_test_format3_codes/0.
+:- dynamic user:wam_cpp_test_format3_chained/0.
+
+user:wam_cpp_test_format1 :-
+    format("plain text~n").
+
+user:wam_cpp_test_format2_w :-
+    format("X = ~w~n", [42]).
+
+user:wam_cpp_test_format2_multi :-
+    format("~w + ~w = ~w~n", [1, 2, 3]).
+
+user:wam_cpp_test_format2_d :-
+    format("~d~n", [42]).
+
+user:wam_cpp_test_format2_a :-
+    format("~a~n", [hello]).
+
+user:wam_cpp_test_format3_atom :-
+    format(atom(A), "X = ~w", [42]),
+    A = 'X = 42'.
+
+user:wam_cpp_test_format3_string :-
+    format(string(S), "S = ~a", [hello]),
+    S = 'S = hello'.
+
+user:wam_cpp_test_format3_codes :-
+    format(codes(C), "ab", []),
+    C = [97, 98].
+
+user:wam_cpp_test_format3_chained :-
+    format(atom(A), "n=~d", [42]),
+    A = 'n=42'.
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -3090,6 +3135,118 @@ test(cpp_e2e_ite_in_findall_no_cut_outer,
           run_query(BinPath,
                     'wam_cpp_test_ite_in_findall_no_cut_outer/0',
                     [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% format/1, /2, /3 — formatted output. /1 and /2 print to stdout;
+% /3 dispatches on a destination argument that selects user_output /
+% user_error / atom(V) / string(V) / codes(V). The string-building
+% variants (atom/string/codes) unify their argument with the
+% rendered output, enabling in-process string construction.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_format1, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_format1', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_format1/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_stdout(BinPath, 'wam_cpp_test_format1/0', [],
+                           true, "plain text\n")
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_format2_w, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_format2_w', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_format2_w/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_stdout(BinPath, 'wam_cpp_test_format2_w/0', [],
+                           true, "X = 42\n")
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_format2_multi, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_format2_multi', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_format2_multi/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_stdout(BinPath, 'wam_cpp_test_format2_multi/0', [],
+                           true, "1 + 2 = 3\n")
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_format2_d, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_format2_d', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_format2_d/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_stdout(BinPath, 'wam_cpp_test_format2_d/0', [],
+                           true, "42\n")
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_format2_a, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_format2_a', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_format2_a/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_stdout(BinPath, 'wam_cpp_test_format2_a/0', [],
+                           true, "hello\n")
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_format3_atom, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_format3_atom', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_format3_atom/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_format3_atom/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_format3_string, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_format3_string', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_format3_string/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_format3_string/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_format3_codes, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_format3_codes', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_format3_codes/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_format3_codes/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_format3_chained, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_format3_chained', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_format3_chained/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_format3_chained/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Adds `format/3` with a destination argument that selects where the rendered output goes — most usefully, `atom(V)` / `string(V)` / `codes(V)` for in-process string building without touching I/O. `format/1` and `format/2` already worked at runtime via the existing `~`-directive interpreter; this refactors that code to render into a buffer first so the same rendering path serves both stdout printing and string-destination unification.

## Changes

- **`wam_cpp_target.pl` runtime** — the format builtin now handles `format/1`, `format/2`, and `format/3` through a single rendering loop that fills a `std::string buf`. After rendering:
  - `/1` and `/2`: print buf to stdout.
  - `/3`: dispatch on A1:
    - `user_output` / `user_error` atoms → write to stdout / stderr.
    - `atom(V)` / `string(V)` compounds → unify V with `Atom(buf)`.
    - `codes(V)` compound → build a `[|]/2` list of integer codes and unify with V.
- **`wam_target.pl`** — `is_builtin_pred` entries for `format/1`, `format/2`, `format/3` so the compiler emits `builtin_call` directly. Functionally equivalent to the previous fallback dispatch; cleaner emission.
- **Tests** — 9 new e2e tests: `format/1`, four `format/2` variants (`~w`, `~d`, `~a`, multi-arg), four `format/3` variants (`atom`, `string`, `codes`, chained atom-build-then-print). Stdout-printing tests use `run_query_stdout` to assert on the full byte stream; string-building tests unify the result and assert with `run_query`.

## Test plan

- [x] 9 new e2e tests pass
- [x] Full `test_wam_cpp_generator.pl` suite passes (existing + new)
- [x] `test_wam_target.pl` passes

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_