### PR TITLE
bench(csharp-query): summarize effective-distance backend scales

### DIFF
--- a/docs/targets/csharp-query-high-performance-sources.md
+++ b/docs/targets/csharp-query-high-performance-sources.md
@@ -265,6 +265,11 @@ need manual override:
 - Effective-distance `category_parent/2` is the first real-workload artifact
   backend measurement because it exercises the same arity-2 graph support
   relation used by the established Wikipedia/SimpleWiki benchmark family.
+  The benchmark now supports repeated 300/1k/5k/10k runs with summary output
+  for best lookup, bucket, scan, and artifact-size backend.
+  At these scales, mmap-array and preload are expected to beat LMDB; LMDB is
+  still the larger-data comparison point once memory pressure starts to matter
+  around future 50k+ runs.
   Haskell's LMDB cache modes remain a higher-level query-locality policy; this
   C# query benchmark intentionally isolates backend scan, lookup, and bucket
   access before adding cache-policy comparisons.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -147,11 +147,19 @@ formats, then reports open, lookup, bucket, and scan timings:
 
 ```bash
 python examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py \
-  --scales 300 \
+  --scales 300,1k,5k,10k \
   --lookup-keys 64 \
   --lookup-repetitions 3 \
-  --format markdown
+  --repetitions 3 \
+  --format summary-markdown
 ```
+
+Use `--format tsv` or `--format markdown` for raw per-run rows. Use
+`summary-tsv` or `summary-markdown` to collapse repeated runs to per-scale
+median timings and report the best lookup, bucket, scan, and artifact-size
+backend. At the checked-in 300-10k scales this is expected to favor preload
+or mmap-array; LMDB is primarily retained as the larger-data comparison point
+for future 50k+ style runs where memory pressure matters.
 
 Use `--stability-runs <n>` to run the wrapper-level sweep repeatedly and
 summarize stable winners. Values above `1` report majority winners, winner

--- a/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
+++ b/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
@@ -5,6 +5,7 @@ import argparse
 import csv
 import os
 import shutil
+import statistics
 import subprocess
 import sys
 import tempfile
@@ -51,6 +52,7 @@ LIGHTNINGDB_DLL = LIGHTNINGDB_PACKAGE / "lib" / "net9.0" / "LightningDB.dll"
 
 HEADERS = [
     "scale",
+    "run",
     "mode",
     "rows",
     "distinct_categories",
@@ -66,9 +68,31 @@ HEADERS = [
     "bucket_hash",
 ]
 
+RAW_HEADERS = [column for column in HEADERS if column != "run"]
+
+SUMMARY_HEADERS = [
+    "scale",
+    "rows",
+    "distinct_categories",
+    "lookup_keys",
+    "best_lookup_mode",
+    "best_bucket_mode",
+    "best_scan_mode",
+    "smallest_artifact_mode",
+    "lookup_ms_by_mode",
+    "bucket_ms_by_mode",
+    "scan_ms_by_mode",
+    "artifact_bytes_by_mode",
+]
+
 
 @dataclass(frozen=True)
 class BenchmarkRow:
+    values: dict[str, str]
+
+
+@dataclass(frozen=True)
+class SummaryRow:
     values: dict[str, str]
 
 
@@ -134,15 +158,25 @@ def write_benchmark_project(project_dir: Path) -> Path:
     return project_path
 
 
-def parse_rows(output: str) -> list[BenchmarkRow]:
+def parse_rows(output: str, run_index: int) -> list[BenchmarkRow]:
     reader = csv.DictReader(output.splitlines(), delimiter="\t")
-    rows = [BenchmarkRow(dict(row)) for row in reader]
-    if reader.fieldnames != HEADERS:
+    if reader.fieldnames != RAW_HEADERS:
         raise RuntimeError(f"unexpected benchmark headers: {reader.fieldnames}")
+    rows = []
+    for row in reader:
+        values = dict(row)
+        values["run"] = str(run_index)
+        rows.append(BenchmarkRow(values))
     return rows
 
 
-def run_scale(scale: str, lookup_keys: int, lookup_repetitions: int, keep_temp: bool) -> list[BenchmarkRow]:
+def run_scale(
+    scale: str,
+    lookup_keys: int,
+    lookup_repetitions: int,
+    run_index: int,
+    keep_temp: bool,
+) -> list[BenchmarkRow]:
     scale_dir = BENCH_DIR / scale
     if not (scale_dir / "category_parent.tsv").exists():
         raise RuntimeError(f"scale has no category_parent.tsv: {scale_dir}")
@@ -176,7 +210,7 @@ def run_scale(scale: str, lookup_keys: int, lookup_repetitions: int, keep_temp: 
             cwd=temp_path,
             timeout=240,
         )
-        return parse_rows(result.stdout)
+        return parse_rows(result.stdout, run_index)
     finally:
         if keep_temp:
             print(f"kept benchmark project: {temp_path}", file=sys.stderr)
@@ -192,16 +226,111 @@ def render_tsv(rows: list[BenchmarkRow]) -> str:
 
 def render_markdown(rows: list[BenchmarkRow]) -> str:
     lines = [
-        "| Scale | Mode | Rows | Categories | Lookup keys | Artifact bytes | Open ms | Lookup ms | Bucket ms | Scan ms | Retained bytes |",
-        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        "| Scale | Run | Mode | Rows | Categories | Lookup keys | Artifact bytes | Open ms | Lookup ms | Bucket ms | Scan ms | Retained bytes |",
+        "| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ]
     for row in rows:
         value = row.values
         lines.append(
-            "| {scale} | {mode} | {rows} | {distinct_categories} | {lookup_keys} | {artifact_bytes} | {open_ms} | {lookup_ms} | {bucket_ms} | {scan_ms} | {retained_bytes} |".format(
+            "| {scale} | {run} | {mode} | {rows} | {distinct_categories} | {lookup_keys} | {artifact_bytes} | {open_ms} | {lookup_ms} | {bucket_ms} | {scan_ms} | {retained_bytes} |".format(
                 **value
             )
         )
+    return "\n".join(lines)
+
+
+def numeric(row: BenchmarkRow, column: str) -> float:
+    return float(row.values[column])
+
+
+def scale_sort_key(scale: str) -> tuple[int, str]:
+    label = scale.strip().lower()
+    multiplier = 1
+    if label.endswith("k"):
+        multiplier = 1_000
+        label = label[:-1]
+    elif label.endswith("m"):
+        multiplier = 1_000_000
+        label = label[:-1]
+
+    try:
+        return (int(float(label) * multiplier), scale)
+    except ValueError:
+        return (sys.maxsize, scale)
+
+
+def summarize(rows: list[BenchmarkRow]) -> list[SummaryRow]:
+    grouped: dict[str, list[BenchmarkRow]] = {}
+    for row in rows:
+        grouped.setdefault(row.values["scale"], []).append(row)
+
+    summaries: list[SummaryRow] = []
+    for scale in sorted(grouped, key=scale_sort_key):
+        scale_rows = grouped[scale]
+        modes = sorted({row.values["mode"] for row in scale_rows})
+
+        def median_by_mode(column: str) -> dict[str, float]:
+            return {
+                mode: statistics.median(numeric(row, column) for row in scale_rows if row.values["mode"] == mode)
+                for mode in modes
+            }
+
+        lookup = median_by_mode("lookup_ms")
+        bucket = median_by_mode("bucket_ms")
+        scan = median_by_mode("scan_ms")
+        artifact = median_by_mode("artifact_bytes")
+        row0 = scale_rows[0].values
+        summaries.append(
+            SummaryRow(
+                {
+                    "scale": scale,
+                    "rows": row0["rows"],
+                    "distinct_categories": row0["distinct_categories"],
+                    "lookup_keys": row0["lookup_keys"],
+                    "best_lookup_mode": min(lookup, key=lookup.get),
+                    "best_bucket_mode": min(bucket, key=bucket.get),
+                    "best_scan_mode": min(scan, key=scan.get),
+                    "smallest_artifact_mode": min(
+                        (mode for mode in artifact if mode != "preload"),
+                        key=artifact.get,
+                    ),
+                    "lookup_ms_by_mode": format_mode_values(lookup),
+                    "bucket_ms_by_mode": format_mode_values(bucket),
+                    "scan_ms_by_mode": format_mode_values(scan),
+                    "artifact_bytes_by_mode": format_mode_values(artifact, digits=0),
+                }
+            )
+        )
+    return summaries
+
+
+def format_mode_values(values: dict[str, float], digits: int = 3) -> str:
+    def format_value(value: float) -> str:
+        return f"{value:.{digits}f}" if digits > 0 else str(int(value))
+
+    return "|".join(f"{mode}:{format_value(values[mode])}" for mode in sorted(values))
+
+
+def render_summary_tsv(rows: list[SummaryRow]) -> str:
+    lines = ["\t".join(SUMMARY_HEADERS)]
+    lines.extend("\t".join(row.values[column] for column in SUMMARY_HEADERS) for row in rows)
+    return "\n".join(lines)
+
+
+def render_summary_markdown(rows: list[SummaryRow]) -> str:
+    lines = [
+        "| Scale | Rows | Categories | Lookup keys | Best lookup | Best bucket | Best scan | Smallest artifact |",
+        "| --- | ---: | ---: | ---: | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        value = row.values
+        lines.append(
+            "| {scale} | {rows} | {distinct_categories} | {lookup_keys} | {best_lookup_mode} | {best_bucket_mode} | {best_scan_mode} | {smallest_artifact_mode} |".format(
+                **value
+            )
+        )
+    lines.append("")
+    lines.append("Median timing/detail fields are available in `summary-tsv`.")
     return "\n".join(lines)
 
 
@@ -209,10 +338,15 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Compare C# query artifact backends on the real effective-distance category_parent/2 relation."
     )
-    parser.add_argument("--scales", default="dev", help="comma-separated scales from data/benchmark")
+    parser.add_argument("--scales", default="300,1k,5k,10k", help="comma-separated scales from data/benchmark")
     parser.add_argument("--lookup-keys", type=int, default=64, help="number of category IDs to probe")
     parser.add_argument("--lookup-repetitions", type=int, default=5, help="lookup passes per mode")
-    parser.add_argument("--format", choices=("tsv", "markdown"), default="tsv")
+    parser.add_argument("--repetitions", type=int, default=1, help="independent benchmark runs per scale")
+    parser.add_argument(
+        "--format",
+        choices=("tsv", "markdown", "summary-tsv", "summary-markdown"),
+        default="tsv",
+    )
     parser.add_argument("--keep-temp", action="store_true", help="keep the generated C# benchmark project")
     args = parser.parse_args(argv)
 
@@ -220,6 +354,8 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--lookup-keys must be positive")
     if args.lookup_repetitions <= 0:
         parser.error("--lookup-repetitions must be positive")
+    if args.repetitions <= 0:
+        parser.error("--repetitions must be positive")
 
     scales = [scale.strip() for scale in args.scales.split(",") if scale.strip()]
     if not scales:
@@ -227,9 +363,14 @@ def main(argv: list[str] | None = None) -> int:
 
     rows: list[BenchmarkRow] = []
     for scale in scales:
-        rows.extend(run_scale(scale, args.lookup_keys, args.lookup_repetitions, args.keep_temp))
+        for run_index in range(1, args.repetitions + 1):
+            rows.extend(run_scale(scale, args.lookup_keys, args.lookup_repetitions, run_index, args.keep_temp))
 
-    if args.format == "markdown":
+    if args.format == "summary-tsv":
+        print(render_summary_tsv(summarize(rows)))
+    elif args.format == "summary-markdown":
+        print(render_summary_markdown(summarize(rows)))
+    elif args.format == "markdown":
         print(render_markdown(rows))
     else:
         print(render_tsv(rows))

--- a/tests/test_csharp_query_effective_distance_artifact_backends.py
+++ b/tests/test_csharp_query_effective_distance_artifact_backends.py
@@ -29,6 +29,8 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
                 "4",
                 "--lookup-repetitions",
                 "1",
+                "--repetitions",
+                "1",
                 "--format",
                 "tsv",
             ],
@@ -50,6 +52,7 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
             ["preload", "binary-artifact", "delimited-artifact", "lmdb", "mmap-array"],
         )
         self.assertEqual({row["scale"] for row in rows}, {"dev"})
+        self.assertEqual({row["run"] for row in rows}, {"1"})
         self.assertEqual({row["scan_hash"] for row in rows}, {rows[0]["scan_hash"]})
         self.assertEqual({row["lookup_hash"] for row in rows}, {rows[0]["lookup_hash"]})
         self.assertEqual({row["bucket_hash"] for row in rows}, {rows[0]["bucket_hash"]})
@@ -60,6 +63,38 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
             self.assertEqual(row["lookup_keys"], "4")
             for column in ("artifact_bytes", "open_ms", "lookup_ms", "bucket_ms", "scan_ms", "retained_bytes"):
                 float(row[column])
+
+    def test_summary_markdown_reports_best_modes(self) -> None:
+        if shutil.which("dotnet") is None:
+            self.skipTest("dotnet is not available")
+        if not LIGHTNINGDB_PACKAGE.exists():
+            self.skipTest("LightningDB 0.21.0 package is not available in the local NuGet cache")
+
+        result = subprocess.run(
+            [
+                "python3",
+                str(SCRIPT),
+                "--scales",
+                "dev",
+                "--lookup-keys",
+                "4",
+                "--lookup-repetitions",
+                "1",
+                "--repetitions",
+                "1",
+                "--format",
+                "summary-markdown",
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=180,
+        )
+        self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        self.assertIn("| Scale | Rows | Categories | Lookup keys | Best lookup |", result.stdout)
+        self.assertIn("| dev |", result.stdout)
+        self.assertIn("Smallest artifact", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary

  - Extend the C# effective-distance artifact backend benchmark to run repeated scale sweeps.
  - Add summary output modes that report median backend timings and identify the best lookup, bucket, scan, and smallest
  artifact backend per scale.
  - Default the benchmark to the checked-in `300,1k,5k,10k` scales instead of only `dev`.
  - Document that preload/mmap-array are expected to win at these sizes, while LMDB remains the larger-data comparison point
  once memory pressure matters.

  ## Verification

  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 -m unittest tests/test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py --scales dev --lookup-keys 4
  --lookup-repetitions 1 --repetitions 1 --format summary-markdown`
  - `python3 examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py --scales 300,1k --lookup-keys 8
  --lookup-repetitions 1 --repetitions 1 --format summary-markdown`
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime_lmdb/UnifyWeaver.QueryRuntime.Lmdb.csproj`
  - `env SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  test_csharp_query_target:test_csharp_query_target -t halt`
  - `git diff --check`