### PR TITLE
feat(wam-cpp): assertz/asserta/retract/retractall for facts

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -398,13 +398,13 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     helper_predicate_items(HelperItems),
     flatten_blocks([HelperItems|PerPredItems], AllItems),
     walk_blocks(AllItems, Labels, FlatInstrs0),
-    % Append eight trailing synthetic-return instructions for the
+    % Append nine trailing synthetic-return instructions for the
     % meta-call control-flow surface — see WamState for each pc''s
     % role.
     append(FlatInstrs0,
            [catch_return, negation_return, findall_collect,
             conj_return, disj_alt, if_then_commit, if_then_else,
-            aggregate_next_group],
+            aggregate_next_group, dynamic_next_clause],
            FlatInstrs),
     length(FlatInstrs0, CatchReturnPC),
     NegationReturnPC is CatchReturnPC + 1,
@@ -414,6 +414,7 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     IfThenCommitPC is CatchReturnPC + 5,
     IfThenElsePC is CatchReturnPC + 6,
     AggregateNextGroupPC is CatchReturnPC + 7,
+    DynamicNextClausePC is CatchReturnPC + 8,
     findall(LabelLine, (
         member(NameStr-PC, Labels),
         format(atom(LabelLine),
@@ -439,6 +440,7 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     vm.if_then_commit_pc = ~w;
     vm.if_then_else_pc = ~w;
     vm.aggregate_next_group_pc = ~w;
+    vm.dynamic_next_clause_pc = ~w;
 ~w
 ~w
 }
@@ -448,7 +450,7 @@ static const int _wam_cpp_setup_register = []() {
 }();
 ', [Reserve, CatchReturnPC, NegationReturnPC, FindallCollectPC,
     ConjReturnPC, DisjAltPC, IfThenCommitPC, IfThenElsePC,
-    AggregateNextGroupPC,
+    AggregateNextGroupPC, DynamicNextClausePC,
     LabelBody, InstrBody]).
 
 % ============================================================================
@@ -1066,6 +1068,8 @@ instr_to_setup_line(if_then_else, _Labels, Line) :- !,
     Line = '    vm.instrs.push_back(Instruction::IfThenElse());'.
 instr_to_setup_line(aggregate_next_group, _Labels, Line) :- !,
     Line = '    vm.instrs.push_back(Instruction::AggregateNextGroup());'.
+instr_to_setup_line(dynamic_next_clause, _Labels, Line) :- !,
+    Line = '    vm.instrs.push_back(Instruction::DynamicNextClause());'.
 instr_to_setup_line(Instr, _Labels, Line) :-
     wam_instruction_to_cpp_literal(Instr, Lit),
     format(atom(Line), '    vm.instrs.push_back(~w);', [Lit]).
@@ -1438,7 +1442,7 @@ struct Instruction {
         BeginAggregate, EndAggregate,
         SwitchOnConstant, SwitchOnStructure, SwitchOnTerm,
         CatchReturn, NegationReturn, FindallCollect, ConjReturn, DisjAlt,
-        IfThenCommit, IfThenElse, AggregateNextGroup
+        IfThenCommit, IfThenElse, AggregateNextGroup, DynamicNextClause
     };
     // Sentinel pc values for switch-table entries that should not jump.
     static constexpr std::size_t SWITCH_DEFAULT = static_cast<std::size_t>(-1);
@@ -1554,6 +1558,8 @@ struct Instruction {
         { Instruction i; i.op = Op::IfThenElse; return i; }
     static Instruction AggregateNextGroup()
         { Instruction i; i.op = Op::AggregateNextGroup; return i; }
+    static Instruction DynamicNextClause()
+        { Instruction i; i.op = Op::DynamicNextClause; return i; }
 };
 
 struct TrailEntry {
@@ -1797,6 +1803,25 @@ struct WamState {
     // pops the next group from the top AggregateGroupIterator and
     // binds it.
     std::size_t aggregate_next_group_pc = 0;
+    // Per-predicate dynamic clause store. Maps "name/arity" → list
+    // of fact terms (Compound or 0-arity Atom cells). Populated by
+    // assertz/asserta builtins; mutated by retract/retractall.
+    // dispatch_dynamic_call iterates these, pushing a CP whose
+    // alt_pc = dynamic_next_clause_pc when more clauses remain.
+    // Rules (Head :- Body) are NOT supported in this PR — only facts.
+    std::unordered_map<std::string, std::vector<CellPtr>> dynamic_db;
+    // Iteration state for dispatch_dynamic_call. Mirrors the
+    // AggregateGroupIterator pattern: one entry per active dynamic
+    // call, popped when clauses are exhausted or the call commits
+    // past its last clause.
+    struct DynamicIterator {
+        std::string key;
+        std::size_t next_idx = 0;
+        std::vector<CellPtr> call_args;
+        std::size_t after_pc = 0;
+    };
+    std::vector<DynamicIterator> dynamic_iters;
+    std::size_t dynamic_next_clause_pc = 0;
     // Mode stack: Get-/Put-Structure / Get-/Put-List PUSH; Unify*/Set*
     // operate on top(); each frame auto-pops once its arity is filled.
     std::vector<ModeFrame> mode_stack;
@@ -1879,6 +1904,17 @@ struct WamState {
     // iterator.return_pc on success. Returns false if no iterator,
     // no remaining groups, or a binding mismatch.
     bool    aggregate_bind_next_group();
+    // Dispatch a Call/Execute to a dynamic predicate. Snapshots
+    // A-registers as call_args, pushes a DynamicIterator, then
+    // delegates to dynamic_try_next which unifies the first
+    // clause (and pushes a CP for the rest if any).
+    bool    dispatch_dynamic_call(const std::string& key,
+                                  std::size_t after_pc);
+    // Try the next clause in the top DynamicIterator. On match,
+    // unify the call_args with the clause''s args and proceed to
+    // after_pc; on no-match, undo trail and recurse (CP-style).
+    // On exhausted iterator, pop and return false.
+    bool    dynamic_try_next();
     bool    execute_catch();
     bool    execute_throw();
 
@@ -2747,6 +2783,105 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         return false;
     }
 
+    // ---- assertz/1, asserta/1, retract/1, retractall/1 -------------
+    // Dynamic database manipulation. This PR supports FACTS only —
+    // rules (Head :- Body) are accepted by the parser but not yet
+    // dispatched by the runtime, so storing them would silently
+    // discard the body. To keep behaviour predictable, the asserts
+    // reject ":- "/2 terms outright.
+    //
+    // Storage: dynamic_db["name/arity"] is a std::vector<CellPtr> of
+    // deep-copied fact terms. Dispatch is via dispatch_dynamic_call
+    // (see Call/Execute step arms).
+    auto dyn_key_of = [&](const Value& v, std::string& out) -> bool {
+        if (v.tag == Value::Tag::Atom) {
+            // ":- "/2 — rule form, deferred (facts only for this PR).
+            if (v.s == ":-/2") return false;
+            out = v.s + "/0";
+            return true;
+        }
+        if (v.tag == Value::Tag::Compound) {
+            if (v.s == ":-/2") return false;
+            out = v.s; // already "name/arity"
+            return true;
+        }
+        return false;
+    };
+    if (op == "assertz/1" || op == "asserta/1") {
+        Value t = deref(*get_cell("A1"));
+        if (t.is_unbound()) return false;
+        std::string key;
+        if (!dyn_key_of(t, key)) return false;
+        // Deep-copy so the stored term has FRESH unbound vars,
+        // independent of the caller''s vars (which will be unwound
+        // on backtrack).
+        CellPtr stored = deep_copy_term(get_cell("A1"));
+        auto& vec = dynamic_db[key];
+        if (op == "assertz/1") vec.push_back(stored);
+        else                   vec.insert(vec.begin(), stored);
+        pc += 1; return true;
+    }
+    if (op == "retract/1") {
+        // Deterministic single-match retract: find the FIRST stored
+        // clause that unifies with A1, remove it, leave the bindings
+        // from the unify in place (per ISO). Nondet retract — keep
+        // backtracking to subsequent matches — is deferred.
+        Value t = deref(*get_cell("A1"));
+        if (t.is_unbound()) return false;
+        std::string key;
+        if (!dyn_key_of(t, key)) return false;
+        auto db_it = dynamic_db.find(key);
+        if (db_it == dynamic_db.end() || db_it->second.empty()) return false;
+        CellPtr pattern = get_cell("A1");
+        for (auto cit = db_it->second.begin();
+             cit != db_it->second.end(); ++cit)
+        {
+            std::size_t mark = trail.size();
+            CellPtr fresh = deep_copy_term(*cit);
+            if (unify_cells(pattern, fresh)) {
+                db_it->second.erase(cit);
+                pc += 1; return true;
+            }
+            // No match: undo any trail entries the failed unify
+            // pushed before trying the next candidate.
+            while (trail.size() > mark) {
+                TrailEntry te = std::move(trail.back());
+                trail.pop_back();
+                *te.cell = std::move(te.prev);
+            }
+        }
+        return false;
+    }
+    if (op == "retractall/1") {
+        // Remove every clause whose head unifies with the pattern.
+        // Always succeeds (even when there are no matches, per ISO).
+        // Pattern bindings are undone after each match attempt so
+        // they don''t leak; only the database changes persist.
+        Value t = deref(*get_cell("A1"));
+        if (t.is_unbound()) return false;
+        std::string key;
+        if (!dyn_key_of(t, key)) return false;
+        auto db_it = dynamic_db.find(key);
+        if (db_it != dynamic_db.end()) {
+            CellPtr pattern = get_cell("A1");
+            auto& vec = db_it->second;
+            vec.erase(std::remove_if(vec.begin(), vec.end(),
+                [&](const CellPtr& clause) {
+                    std::size_t mark = trail.size();
+                    CellPtr fresh = deep_copy_term(clause);
+                    bool ok = unify_cells(pattern, fresh);
+                    // Undo bindings either way.
+                    while (trail.size() > mark) {
+                        TrailEntry te = std::move(trail.back());
+                        trail.pop_back();
+                        *te.cell = std::move(te.prev);
+                    }
+                    return ok;
+                }), vec.end());
+        }
+        pc += 1; return true;
+    }
+
     // ---- functor/3 -------------------------------------------------
     if (op == "functor/3") {
         CellPtr t = get_cell("A1");
@@ -3382,6 +3517,13 @@ bool WamState::step(const Instruction& instr) {
                 pc = it->second;
                 return true;
             }
+            // Dynamic predicate path: assertz/retract have put facts
+            // into dynamic_db. Iterate through them via the iterator
+            // pattern. Tried before the builtin fallback so a user
+            // can assertz over a builtin name (unusual, but allowed).
+            if (dynamic_db.count(instr.a)) {
+                return dispatch_dynamic_call(instr.a, pc + 1);
+            }
             // No user predicate matches: fall back to builtin dispatch.
             // builtin() advances pc itself on success, mirroring the
             // BuiltinCall path.
@@ -3414,6 +3556,11 @@ bool WamState::step(const Instruction& instr) {
             if (it != labels.end()) {
                 pc = it->second;
                 return true;
+            }
+            // Dynamic predicate path — tail-call form. after_pc is cp
+            // (the caller''s saved continuation) for TCO.
+            if (dynamic_db.count(instr.a)) {
+                return dispatch_dynamic_call(instr.a, cp);
             }
             // Fall back to a deterministic builtin, then proceed to cp
             // since execute is a tail call (no in-body continuation).
@@ -3554,6 +3701,14 @@ bool WamState::step(const Instruction& instr) {
             // CP if even MORE groups remain.
             if (!choice_points.empty()) choice_points.pop_back();
             return aggregate_bind_next_group();
+        }
+        case Instruction::Op::DynamicNextClause: {
+            // Reached when a dynamic-predicate call backtracks into
+            // its remaining clauses. Pop the CP and delegate to
+            // dynamic_try_next, which unifies the next clause and
+            // pushes another CP if more remain.
+            if (!choice_points.empty()) choice_points.pop_back();
+            return dynamic_try_next();
         }
         case Instruction::Op::Proceed: {
             if (cp == 0) { halt = true; return true; }
@@ -3883,6 +4038,100 @@ static std::size_t find_matching_end_aggregate(
         }
     }
     return instrs.size();
+}
+
+// Dispatch a Call/Execute to a dynamic predicate (one populated by
+// assertz/asserta and not present in labels). Snapshots the A-args
+// from regs, pushes a DynamicIterator, then delegates to
+// dynamic_try_next which unifies the first clause and pushes a CP
+// for the rest when more than one exists.
+bool WamState::dispatch_dynamic_call(const std::string& key,
+                                     std::size_t after_pc) {
+    auto db_it = dynamic_db.find(key);
+    if (db_it == dynamic_db.end() || db_it->second.empty()) return false;
+    auto sl = key.rfind(''/'');
+    if (sl == std::string::npos) return false;
+    std::size_t arity = 0;
+    try { arity = std::stoul(key.substr(sl + 1)); }
+    catch (...) { return false; }
+    // Snapshot A-registers BEFORE pushing the iterator so backtrack
+    // (which restores regs from the CP) gets the same call_args.
+    DynamicIterator dit;
+    dit.key = key;
+    dit.next_idx = 0;
+    dit.after_pc = after_pc;
+    dit.call_args.reserve(arity);
+    for (std::size_t i = 1; i <= arity; ++i) {
+        dit.call_args.push_back(get_cell("A" + std::to_string(i)));
+    }
+    dynamic_iters.push_back(std::move(dit));
+    return dynamic_try_next();
+}
+
+// Try the next clause in the top DynamicIterator. Unify the call
+// args with a fresh-renamed copy of the clause; if more clauses
+// remain, push a CP whose alt_pc = dynamic_next_clause_pc. Pop the
+// iterator and fail if exhausted.
+bool WamState::dynamic_try_next() {
+    if (dynamic_iters.empty()) return false;
+    DynamicIterator& it = dynamic_iters.back();
+    auto db_it = dynamic_db.find(it.key);
+    // The predicate may have been retract-all''d mid-iteration. Treat
+    // a missing or empty clause list as exhaustion.
+    if (db_it == dynamic_db.end() || it.next_idx >= db_it->second.size()) {
+        dynamic_iters.pop_back();
+        return false;
+    }
+    std::size_t idx = it.next_idx;
+    bool has_more = (idx + 1 < db_it->second.size());
+    std::string saved_key = it.key;
+    std::vector<CellPtr> call_args = it.call_args;
+    std::size_t saved_after_pc = it.after_pc;
+    // Advance the index BEFORE we push the CP — the CP snapshots
+    // dynamic_iters state, so the captured `next_idx` should already
+    // point at the SUBSEQUENT clause to try on backtrack.
+    it.next_idx = idx + 1;
+    // Push the CP (only if more clauses remain after this one).
+    if (has_more) {
+        ChoicePoint cp_;
+        cp_.alt_pc            = dynamic_next_clause_pc;
+        cp_.saved_cp          = cp;
+        cp_.trail_mark        = trail.size();
+        cp_.cut_barrier       = cut_barrier;
+        cp_.saved_regs        = regs;
+        cp_.saved_mode_stack  = mode_stack;
+        cp_.saved_env_stack   = env_stack;
+        choice_points.push_back(std::move(cp_));
+    } else {
+        // Last clause for this call — drop the iterator. It''s no
+        // longer needed; clause exhaustion will fall through to
+        // ordinary backtrack at the OUTER scope.
+        dynamic_iters.pop_back();
+    }
+    // Fresh-rename the clause so vars in different call iterations
+    // (and the stored fact itself, which may share vars across
+    // multiple stored clauses if asserta/assertz ever supports them)
+    // don''t alias.
+    CellPtr fresh = deep_copy_term(db_it->second[idx]);
+    Value fv = deref(*fresh);
+    // Unify the call args with the clause''s args.
+    if (fv.tag == Value::Tag::Atom) {
+        // 0-arity fact. call_args must be empty; key match already
+        // covered the name + arity (so call_args.empty() is implied).
+        if (!call_args.empty()) return false;
+    } else if (fv.tag == Value::Tag::Compound) {
+        if (fv.args.size() != call_args.size()) return false;
+        for (std::size_t i = 0; i < call_args.size(); ++i) {
+            if (!unify_cells(call_args[i], fv.args[i])) return false;
+        }
+    } else {
+        return false;
+    }
+    // Proceed to the call''s continuation.
+    if (saved_after_pc == 0) { halt = true; return true; }
+    pc = saved_after_pc;
+    cp = 0;
+    return true;
 }
 
 // Deep-copy a value tree. Unbound leaves are renamed via a name→cell

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1460,6 +1460,10 @@ is_builtin_pred(number_codes, 2). % number ↔ list of integer codes.
 is_builtin_pred(atom_concat, 3).  % (+, +, ?) — concatenation.
 is_builtin_pred(atom_length, 2).  % atom → length in chars.
 is_builtin_pred(char_code, 2).    % char-atom ↔ integer code.
+is_builtin_pred(assertz, 1).      % dynamic db: append fact.
+is_builtin_pred(asserta, 1).      % dynamic db: prepend fact.
+is_builtin_pred(retract, 1).      % dynamic db: remove first match.
+is_builtin_pred(retractall, 1).   % dynamic db: remove all matches.
 is_builtin_pred(=, 2).       % unification: bind / structurally unify two terms.
 is_builtin_pred(is_list, 1).
                              % Without this entry, X = Y in a body goal

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -888,6 +888,80 @@ user:wam_cpp_test_format_atom_then_codes :-
     atom_length(A, 7),
     atom_codes(A, [104, 101, 108, 108, 111, 52, 50]).
 
+% assertz/1, asserta/1, retract/1, retractall/1 — dynamic database
+% manipulation. Facts only in this PR (rules deferred). Call/Execute
+% dispatch through dynamic_db when no static label matches; each
+% iteration unifies a fresh-renamed copy of the stored fact and
+% pushes a CP (alt_pc=dynamic_next_clause_pc) when more remain.
+:- dynamic user:wam_cpp_test_assertz_query/0.
+:- dynamic user:wam_cpp_test_assertz_multi/0.
+:- dynamic user:wam_cpp_test_asserta_order/0.
+:- dynamic user:wam_cpp_test_retract/0.
+:- dynamic user:wam_cpp_test_retract_var/0.
+:- dynamic user:wam_cpp_test_retractall/0.
+:- dynamic user:wam_cpp_test_retractall_empty/0.
+:- dynamic user:wam_cpp_test_assertz_pair/0.
+:- dynamic user:wam_cpp_test_dyn_backtrack/0.
+
+user:wam_cpp_test_assertz_query :-
+    assertz(wam_cpp_dyn_fact1(a)),
+    wam_cpp_dyn_fact1(a).
+
+user:wam_cpp_test_assertz_multi :-
+    assertz(wam_cpp_dyn_item(1)),
+    assertz(wam_cpp_dyn_item(2)),
+    assertz(wam_cpp_dyn_item(3)),
+    findall(X, wam_cpp_dyn_item(X), L),
+    L = [1, 2, 3].
+
+user:wam_cpp_test_asserta_order :-
+    assertz(wam_cpp_dyn_thing(b)),
+    asserta(wam_cpp_dyn_thing(a)),
+    findall(X, wam_cpp_dyn_thing(X), L),
+    L = [a, b].
+
+user:wam_cpp_test_retract :-
+    assertz(wam_cpp_dyn_p(1)),
+    assertz(wam_cpp_dyn_p(2)),
+    assertz(wam_cpp_dyn_p(3)),
+    retract(wam_cpp_dyn_p(2)),
+    findall(X, wam_cpp_dyn_p(X), L),
+    L = [1, 3].
+
+user:wam_cpp_test_retract_var :-
+    assertz(wam_cpp_dyn_q(10)),
+    retract(wam_cpp_dyn_q(X)),
+    X = 10.
+
+user:wam_cpp_test_retractall :-
+    assertz(wam_cpp_dyn_r(1)),
+    assertz(wam_cpp_dyn_r(2)),
+    assertz(wam_cpp_dyn_r(3)),
+    retractall(wam_cpp_dyn_r(_)),
+    findall(X, wam_cpp_dyn_r(X), L),
+    L = [].
+
+% retractall always succeeds, even on never-asserted predicates.
+user:wam_cpp_test_retractall_empty :-
+    retractall(wam_cpp_dyn_absent(_)).
+
+user:wam_cpp_test_assertz_pair :-
+    assertz(wam_cpp_dyn_pair(a, 1)),
+    assertz(wam_cpp_dyn_pair(b, 2)),
+    findall(K-V, wam_cpp_dyn_pair(K, V), L),
+    L = [a-1, b-2].
+
+% Backtracking through dynamic clauses — the CP pushed by
+% dynamic_try_next when more clauses remain drives findall''s
+% next-solution loop. Filter via X > 1 to verify the iteration
+% actually reaches subsequent clauses.
+user:wam_cpp_test_dyn_backtrack :-
+    assertz(wam_cpp_dyn_num(1)),
+    assertz(wam_cpp_dyn_num(2)),
+    assertz(wam_cpp_dyn_num(3)),
+    findall(X, (wam_cpp_dyn_num(X), X > 1), L),
+    L = [2, 3].
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -3497,6 +3571,117 @@ test(cpp_e2e_format_atom_then_codes,
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath,
                     'wam_cpp_test_format_atom_then_codes/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% assertz/asserta/retract/retractall — dynamic database manipulation
+% for FACTS. Rules (Head :- Body) are rejected by the builtin and
+% deferred to a follow-up PR. Each test asserts into a uniquely-
+% named predicate so tests are independent across runs.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_assertz_query, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_assertz_query', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_assertz_query/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_assertz_query/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_assertz_multi, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_assertz_multi', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_assertz_multi/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_assertz_multi/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_asserta_order, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_asserta_order', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_asserta_order/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_asserta_order/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_retract, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_retract', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_retract/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_retract/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_retract_var, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_retract_var', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_retract_var/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_retract_var/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_retractall, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_retractall', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_retractall/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_retractall/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_retractall_empty, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_retractall_empty', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_retractall_empty/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_retractall_empty/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_assertz_pair, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_assertz_pair', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_assertz_pair/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_assertz_pair/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_dyn_backtrack, [condition(cpp_compiler_available)]) :-
+    % Backtracking through dynamic clauses: findall driver explores
+    % all 3 wam_cpp_dyn_num/1 facts via the CP pushed by
+    % dynamic_try_next. Filtering with X > 1 confirms iteration
+    % actually reaches the later clauses, not just the first.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_dyn_bt', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_dyn_backtrack/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_dyn_backtrack/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Adds runtime clause-list mutation: `assertz/1`, `asserta/1`, `retract/1`, `retractall/1`. FACTS only — rules (`Head :- Body`) are rejected by the asserts; rule support needs interpreter-style body dispatch and is deferred to a follow-up.

This unlocks the common patterns that the static-predicate model couldn't express: caches, accumulators, learned facts, mark-sets.

## Runtime model

- `WamState` gains a `dynamic_db` map (`name/arity` → `vector<CellPtr>`), a `DynamicIterator` side-stack mirroring `AggregateGroupIterator`, and a `dynamic_next_clause_pc` synthetic op.
- `Call` / `Execute`: when no static label matches **and** the predicate key has clauses in `dynamic_db`, dispatch through `dispatch_dynamic_call`. Static lookup still wins (you can't shadow a compiled predicate), and the builtin fallback runs only when neither path applies.
- `dispatch_dynamic_call` snapshots A-args, pushes a `DynamicIterator`, and calls `dynamic_try_next`.
- `dynamic_try_next` unifies a fresh-renamed copy of `dynamic_db[key][next_idx]` with the call args, advances the index, and pushes a CP (`alt_pc=dynamic_next_clause_pc`) when more clauses remain. On backtrack the synthetic op pops the CP and recurses to the next clause.
- `assertz`/`asserta` deep-copy A1 (stored vars are fresh) and append/prepend to `dynamic_db[key]`. `retract` finds the first unifying clause, leaves bindings in place per ISO. `retractall` removes every matching clause and undoes pattern bindings after each attempt; always succeeds (even when no matches).

## Test plan

- [x] 9 new e2e tests:
  - `assertz_query` — single fact, query
  - `assertz_multi` — three facts, findall
  - `asserta_order` — asserta prepends
  - `retract` — middle fact removed
  - `retract_var` — retract binds a variable
  - `retractall` — removes all, then findall returns `[]`
  - `retractall_empty` — succeeds on never-asserted predicate
  - `assertz_pair` — 2-arg dynamic facts with key-value findall
  - `dyn_backtrack` — `findall(X, (num(X), X > 1), L)` confirms `dynamic_try_next` reaches subsequent clauses, not just the first
- [x] Full `test_wam_cpp_generator.pl` suite passes
- [x] `test_wam_target.pl` passes

## Deferred follow-ups

- Rules (`assertz((head(X) :- body(X)))`) — requires interpreter-style body dispatch.
- Nondeterministic `retract/1` — currently first-match deterministic; ISO retract is supposed to backtrack to subsequent matches.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_