### PR TITLE
bench(wam-c): cover projected lowered helpers

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,7 +5,7 @@ Status date: 2026-05-15
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `87bfe424` (`Merge pull request #2126 from s243a/feat/wam-c-lowered-helper-ignored-output-contract`)
+- `main` at `cc2d432d` (`Merge pull request #2129 from s243a/feat/wam-c-lowered-helper-projection-row-constraints`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
@@ -14,7 +14,7 @@ Base verified locally:
 
 Active branch:
 
-- `feat/wam-c-lowered-helper-projection-row-constraints`
+- `feat/wam-c-lowered-helper-projection-bench`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -57,7 +57,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Generated multi-predicate setup | Done | Generated setup appends predicate code at per-setup base PCs and covers multiple setup functions in one executable |
 | Lowered helper non-reordered projection metadata | Done | Planner reports explicit rejection reasons for omitted head variables, repeated head variables, and unbound callee variables |
 | Lowered helper ignored-output projections | Done | Projected body-call helpers pass singleton callee-local variables as fresh unbound arguments and ignore their returned bindings |
-| Lowered helper projection row constraints | In progress | Active branch lowers repeated caller-variable projections through materialized native fact rows while preserving availability checks |
+| Lowered helper projection row constraints | Done | Repeated caller-variable projections lower through materialized native fact rows while preserving availability checks |
+| Lowered helper projection benchmark | In progress | Active branch extends the tiny lowered-helper benchmark to cover direct, reordered, ignored-output, and row-constrained projection shapes |
 
 ## Current C Target Baseline
 
@@ -138,23 +139,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lowered-helper-projection-row-constraints`
-
-Goal: decide whether repeated caller variables in projected body calls should
-lower through native row constraints instead of staying rejected.
-
-Scope:
-
-- Preserve the current rejection for omitted caller-visible head variables.
-- Consider lowering repeated caller variables only by materializing matching
-  fact rows, similar to repeated-variable filtered helpers.
-- Keep constant filters on the existing materialized `filtered_fact` path.
-
-Status: active; repeated caller-variable projections now lower through
-availability-checked materialized native fact rows, while omitted caller-visible
-outputs and repeated callee-local variables remain explicit planner rejections.
-
-### 2. `feat/wam-c-lowered-helper-projection-bench`
+### 1. `feat/wam-c-lowered-helper-projection-bench`
 
 Goal: add a small benchmark workload for projected lowered helpers that covers
 reordered, ignored-output, and row-constrained projection shapes.
@@ -167,10 +152,26 @@ Scope:
   helper variants.
 - Keep constant filters on the existing materialized `filtered_fact` path.
 
+Status: active; the existing `c-wam-lowered-helper` target set now runs direct,
+reordered, ignored-output, and row-constrained projected-helper queries in both
+interpreted and lowered modes.
+
+### 2. `feat/wam-c-lowered-helper-scale-workload`
+
+Goal: scale the lowered-helper benchmark beyond the tiny dev smoke while keeping
+the output contract stable across interpreted and lowered modes.
+
+Scope:
+
+- Parameterize the lowered-helper generator by scale instead of hard-coding a
+  handful of facts.
+- Preserve projection-shape coverage and output matching across modes.
+- Keep the first pass small enough for routine matrix validation.
+
 ## Suggested Immediate Next Step
 
-Continue validating `feat/wam-c-lowered-helper-projection-row-constraints`.
+Continue validating `feat/wam-c-lowered-helper-projection-bench`.
 
-The active branch turns repeated caller-variable projections into a
-materialized-row helper path without weakening callee availability or omitted
-caller-output rejection semantics.
+The active branch broadens the existing lowered-helper matrix target from a
+fact-oriented smoke into a projection-shape benchmark, while preserving the same
+interpreted-vs-lowered target set.

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -105,12 +105,12 @@ TARGETS: dict[str, TargetInfo] = {
     "c-wam-lowered-helper": TargetInfo(
         "c-wam-lowered-helper",
         "hybrid-wam-lowered-helper",
-        "Hybrid WAM C fact-helper smoke benchmark with lowered helpers enabled",
+        "Hybrid WAM C projected-helper benchmark with lowered helpers enabled",
     ),
     "c-wam-lowered-helper-interpreted": TargetInfo(
         "c-wam-lowered-helper-interpreted",
         "hybrid-wam-lowered-helper",
-        "Hybrid WAM C fact-helper smoke benchmark through interpreted WAM facts",
+        "Hybrid WAM C projected-helper benchmark through interpreted WAM predicates",
     ),
     "scala-wam-seeded": TargetInfo(
         "scala-wam-seeded",

--- a/examples/benchmark/generate_wam_c_lowered_helper_benchmark.pl
+++ b/examples/benchmark/generate_wam_c_lowered_helper_benchmark.pl
@@ -10,7 +10,7 @@
 %% generate_wam_c_lowered_helper_benchmark.pl
 %%
 %% Generates a tiny WAM-C benchmark project that compares interpreted WAM-C
-%% facts against the prototype lowered fact-helper path.
+%% predicates against the prototype lowered helper paths.
 %%
 %% Usage:
 %%   swipl -q -s examples/benchmark/generate_wam_c_lowered_helper_benchmark.pl -- \
@@ -44,13 +44,11 @@ generate(OutputDir, Mode) :-
     mode_predicates(ParsedMode, Predicates),
     write_wam_c_project(Predicates, Options, OutputDir),
     directory_file_path(OutputDir, 'main.c', MainPath),
-    mode_query_predicate(ParsedMode, QueryPred),
-    mode_alias_setup(ParsedMode, AliasDecl, AliasSetup),
-    lowered_helper_benchmark_main(QueryPred, AliasDecl, AliasSetup, MainCode),
+    lowered_helper_benchmark_main(MainCode),
     write_text_file(MainPath, MainCode),
     directory_file_path(OutputDir, 'README.md', ReadmePath),
     format(atom(Readme),
-           '# WAM-C lowered-helper benchmark~n~nMode: `~w`~n~nPlanner metadata is emitted as comments in `lib.c`.~n',
+           '# WAM-C lowered-helper benchmark~n~nMode: `~w`~n~nThe generated runner queries direct, reordered, ignored-output, and row-constrained projection shapes. Planner metadata is emitted as comments in `lib.c`.~n',
            [ParsedMode]),
     write_text_file(ReadmePath, Readme),
     cleanup_benchmark_facts.
@@ -65,26 +63,21 @@ parse_mode(Mode, _) :-
 mode_options(lowered, [lowered_helpers(true), report_lowered_helpers(true)]).
 mode_options(interpreted, [report_lowered_helpers(true)]).
 
-mode_predicates(lowered, [user:wam_c_bench_pair/2,
-                          user:wam_c_bench_pair_alias/2,
-                          user:wam_c_bench_pair_tag/3,
-                          user:wam_c_bench_pair_keep/2,
-                          user:wam_c_bench_pair_score/3,
-                          user:wam_c_bench_pair_small/2]).
-mode_predicates(interpreted, [user:wam_c_bench_pair/2]).
-
-mode_query_predicate(lowered, 'wam_c_bench_pair_small/2').
-mode_query_predicate(interpreted, 'wam_c_bench_pair/2').
-
-mode_alias_setup(lowered,
-                 'void setup_wam_c_bench_pair_alias_2(WamState* state);\nvoid setup_wam_c_bench_pair_tag_3(WamState* state);\nvoid setup_wam_c_bench_pair_keep_2(WamState* state);\nvoid setup_wam_c_bench_pair_score_3(WamState* state);\nvoid setup_wam_c_bench_pair_small_2(WamState* state);\n',
-                 '    setup_wam_c_bench_pair_alias_2(&state);\n    setup_wam_c_bench_pair_tag_3(&state);\n    setup_wam_c_bench_pair_keep_2(&state);\n    setup_wam_c_bench_pair_score_3(&state);\n    setup_wam_c_bench_pair_small_2(&state);\n').
-mode_alias_setup(interpreted, '', '').
+mode_predicates(_Mode, [user:wam_c_bench_pair/2,
+                        user:wam_c_bench_pair_alias/2,
+                        user:wam_c_bench_pair_projected/2,
+                        user:wam_c_bench_pair_left/1,
+                        user:wam_c_bench_pair_equal/1,
+                        user:wam_c_bench_pair_tag/3,
+                        user:wam_c_bench_pair_keep/2,
+                        user:wam_c_bench_pair_score/3,
+                        user:wam_c_bench_pair_small/2]).
 
 setup_benchmark_facts :-
     cleanup_benchmark_facts,
     assertz(user:wam_c_bench_pair(a, b)),
     assertz(user:wam_c_bench_pair(a, c)),
+    assertz(user:wam_c_bench_pair(a, a)),
     assertz(user:wam_c_bench_pair(b, d)),
     assertz(user:wam_c_bench_pair_tag(a, b, keep)),
     assertz(user:wam_c_bench_pair_tag(a, c, keep)),
@@ -93,6 +86,9 @@ setup_benchmark_facts :-
     assertz(user:wam_c_bench_pair_score(a, c, 2)),
     assertz(user:wam_c_bench_pair_score(b, d, 3)),
     assertz(user:((wam_c_bench_pair_alias(X, Y) :- wam_c_bench_pair(X, Y)))),
+    assertz(user:((wam_c_bench_pair_projected(Y, X) :- wam_c_bench_pair(X, Y)))),
+    assertz(user:((wam_c_bench_pair_left(X) :- wam_c_bench_pair(X, _Ignored)))),
+    assertz(user:((wam_c_bench_pair_equal(X) :- wam_c_bench_pair(X, X)))),
     assertz(user:((wam_c_bench_pair_keep(X, Y) :- wam_c_bench_pair_tag(X, Y, keep)))),
     assertz(user:((wam_c_bench_pair_small(X, Y) :-
         wam_c_bench_pair_score(X, Y, Score),
@@ -101,25 +97,43 @@ setup_benchmark_facts :-
 cleanup_benchmark_facts :-
     retractall(user:wam_c_bench_pair(_, _)),
     retractall(user:wam_c_bench_pair_alias(_, _)),
+    retractall(user:wam_c_bench_pair_projected(_, _)),
+    retractall(user:wam_c_bench_pair_left(_)),
+    retractall(user:wam_c_bench_pair_equal(_)),
     retractall(user:wam_c_bench_pair_tag(_, _, _)),
     retractall(user:wam_c_bench_pair_keep(_, _)),
     retractall(user:wam_c_bench_pair_score(_, _, _)),
     retractall(user:wam_c_bench_pair_small(_, _)).
 
-lowered_helper_benchmark_main(QueryPred, AliasDecl, AliasSetup, Code) :-
+lowered_helper_benchmark_main(Code) :-
     format(atom(Code),
 '#include "wam_runtime.h"
 #include <stdio.h>
 
 void setup_wam_c_bench_pair_2(WamState* state);
-~w
+void setup_wam_c_bench_pair_alias_2(WamState* state);
+void setup_wam_c_bench_pair_projected_2(WamState* state);
+void setup_wam_c_bench_pair_left_1(WamState* state);
+void setup_wam_c_bench_pair_equal_1(WamState* state);
+void setup_wam_c_bench_pair_tag_3(WamState* state);
+void setup_wam_c_bench_pair_keep_2(WamState* state);
+void setup_wam_c_bench_pair_score_3(WamState* state);
+void setup_wam_c_bench_pair_small_2(WamState* state);
 void setup_lowered_wam_c_helpers(WamState* state);
 
-static int emit_pair(WamState* state, const char* left, const char* right, double score) {
+static int emit_pair(WamState* state, const char* variant, const char* pred, const char* left, const char* right, double score) {
     WamValue args[2] = { val_atom(left), val_atom(right) };
-    int rc = wam_run_predicate(state, "~w", args, 2);
+    int rc = wam_run_predicate(state, pred, args, 2);
     if (rc != 0 || state->P != WAM_HALT) return 1;
-    printf("%s\\t%s\\t%.6f\\n", left, right, score);
+    printf("%s\\t%s\\t%s\\t%.6f\\n", variant, left, right, score);
+    return 0;
+}
+
+static int emit_left(WamState* state, const char* variant, const char* pred, const char* left, double score) {
+    WamValue args[1] = { val_atom(left) };
+    int rc = wam_run_predicate(state, pred, args, 1);
+    if (rc != 0 || state->P != WAM_HALT) return 1;
+    printf("%s\\t%s\\t_\\t%.6f\\n", variant, left, score);
     return 0;
 }
 
@@ -127,29 +141,40 @@ int main(void) {
     WamState state;
     wam_state_init(&state);
     setup_wam_c_bench_pair_2(&state);
-~w
+    setup_wam_c_bench_pair_alias_2(&state);
+    setup_wam_c_bench_pair_projected_2(&state);
+    setup_wam_c_bench_pair_left_1(&state);
+    setup_wam_c_bench_pair_equal_1(&state);
+    setup_wam_c_bench_pair_tag_3(&state);
+    setup_wam_c_bench_pair_keep_2(&state);
+    setup_wam_c_bench_pair_score_3(&state);
+    setup_wam_c_bench_pair_small_2(&state);
     setup_lowered_wam_c_helpers(&state);
 
-    printf("left\\tright\\tscore\\n");
+    printf("variant\\tleft\\tright\\tscore\\n");
 
-    if (emit_pair(&state, "a", "b", 1.0) != 0) {
+    if (emit_pair(&state, "direct", "wam_c_bench_pair_alias/2", "a", "b", 1.0) != 0) {
         wam_free_state(&state);
         return 10;
     }
-    if (emit_pair(&state, "a", "c", 2.0) != 0) {
+    if (emit_pair(&state, "reordered", "wam_c_bench_pair_projected/2", "b", "a", 2.0) != 0) {
         wam_free_state(&state);
         return 20;
     }
-    if (emit_pair(&state, "b", "d", 3.0) != 0) {
+    if (emit_left(&state, "ignored-output", "wam_c_bench_pair_left/1", "a", 3.0) != 0) {
         wam_free_state(&state);
         return 30;
+    }
+    if (emit_left(&state, "row-constrained", "wam_c_bench_pair_equal/1", "a", 4.0) != 0) {
+        wam_free_state(&state);
+        return 40;
     }
 
     wam_free_state(&state);
     return 0;
 }
 ',
-           [AliasDecl, QueryPred, AliasSetup]).
+           []).
 
 write_text_file(Path, Content) :-
     setup_call_cleanup(


### PR DESCRIPTION
# Benchmark WAM-C projected lowered helpers

## Summary

- expand the WAM-C lowered-helper benchmark beyond the original fact-oriented smoke
- run direct, reordered, ignored-output, and row-constrained projection shapes in both interpreted and lowered modes
- update target descriptions to describe the projected-helper benchmark surface
- refresh the WAM-C next-steps roadmap with this branch active and scaled lowered-helper workloads as the next follow-up

## Verification

- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets c-wam-lowered-helper --repetitions 1 --baseline-target c-wam-lowered-helper-interpreted`
- direct generator compile/run for interpreted and lowered modes
- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --check`