### PR TITLE
bench(csharp-query): reuse effective-distance backend artifacts

### DIFF
--- a/docs/targets/csharp-query-high-performance-sources.md
+++ b/docs/targets/csharp-query-high-performance-sources.md
@@ -283,7 +283,10 @@ need manual override:
   `examples/benchmark/prepare_csharp_query_enwiki_category_fixture.py`; it
   writes capped TSV fixtures first. Direct Rust-parser-to-LMDB ingestion is a
   valid future optimization, but is intentionally not part of this first C#
-  benchmark fixture path.
+  benchmark fixture path. The C# backend benchmark now accepts a persistent
+  `--artifact-root` and reuses existing backend artifacts by default; use
+  `--refresh-artifacts` to rebuild, matching the Haskell benchmark's explicit
+  LMDB refresh convention.
   Haskell's LMDB cache modes remain a higher-level query-locality policy; this
   C# query benchmark intentionally isolates backend scan, lookup, and bucket
   access before adding cache-policy comparisons.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -170,6 +170,7 @@ timing-sensitive runs:
 python examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py \
   --scales 50k_cats,100k_cats \
   --prepare-missing-large-scales \
+  --artifact-root output/csharp-query-effective-distance-artifacts \
   --lookup-keys 256 \
   --lookup-repetitions 3 \
   --repetitions 3 \
@@ -206,6 +207,12 @@ This writes a capped `category_parent.tsv` fixture from `subcat` rows using the
 same Rust parser. It intentionally stops at TSV fixture creation; a future
 optimization can write the parser output directly to LMDB and bypass the Python
 orchestrator.
+
+Pass `--artifact-root <dir>` to keep backend artifacts across benchmark runs.
+Existing binary, delimited, LMDB, and mmap-array manifests are reused by
+default, matching the Haskell benchmark convention of not regenerating LMDB
+when it already exists. Add `--refresh-artifacts` when the fixture input or
+artifact format has changed and the artifacts should be rebuilt.
 
 Use `--stability-runs <n>` to run the wrapper-level sweep repeatedly and
 summarize stable winners. Values above `1` report majority winners, winner

--- a/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
+++ b/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
@@ -184,6 +184,8 @@ def run_scale(
     lookup_repetitions: int,
     run_index: int,
     keep_temp: bool,
+    artifact_root: Path | None,
+    refresh_artifacts: bool,
 ) -> list[BenchmarkRow]:
     scale_dir = BENCH_DIR / scale
     if not (scale_dir / "category_parent.tsv").exists():
@@ -214,6 +216,10 @@ def run_scale(
                 str(lookup_keys),
                 "--lookup-repetitions",
                 str(lookup_repetitions),
+                "--artifact-root",
+                str((artifact_root / scale) if artifact_root is not None else temp_path),
+                "--refresh-artifacts",
+                "true" if refresh_artifacts else "false",
             ],
             cwd=temp_path,
             timeout=240,
@@ -481,6 +487,17 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--lookup-repetitions", type=int, default=5, help="lookup passes per mode")
     parser.add_argument("--repetitions", type=int, default=1, help="independent benchmark runs per scale")
     parser.add_argument(
+        "--artifact-root",
+        type=Path,
+        default=None,
+        help="persistent artifact directory; when set, per-scale artifacts are reused across runs",
+    )
+    parser.add_argument(
+        "--refresh-artifacts",
+        action="store_true",
+        help="rebuild artifacts under --artifact-root instead of reusing existing manifests",
+    )
+    parser.add_argument(
         "--prepare-missing-large-scales",
         action="store_true",
         help="generate supported SimpleWiki category-only fixtures when 50k_cats/100k_cats are requested",
@@ -575,7 +592,17 @@ def main(argv: list[str] | None = None) -> int:
     rows: list[BenchmarkRow] = []
     for scale in scales:
         for run_index in range(1, args.repetitions + 1):
-            rows.extend(run_scale(scale, args.lookup_keys, args.lookup_repetitions, run_index, args.keep_temp))
+            rows.extend(
+                run_scale(
+                    scale,
+                    args.lookup_keys,
+                    args.lookup_repetitions,
+                    run_index,
+                    args.keep_temp,
+                    args.artifact_root,
+                    args.refresh_artifacts,
+                )
+            )
 
     if args.format == "summary-tsv":
         print(render_summary_tsv(summarize(rows)))
@@ -612,6 +639,14 @@ static string ReadArg(string[] args, string name, string defaultValue)
 static int ReadIntArg(string[] args, string name, int defaultValue)
 {
     return int.TryParse(ReadArg(args, name, ""), out var parsed) ? parsed : defaultValue;
+}
+
+static bool ReadBoolArg(string[] args, string name, bool defaultValue)
+{
+    var raw = ReadArg(args, name, defaultValue ? "true" : "false");
+    return raw.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+        raw.Equals("1", StringComparison.OrdinalIgnoreCase) ||
+        raw.Equals("yes", StringComparison.OrdinalIgnoreCase);
 }
 
 static long DirectorySize(string path)
@@ -707,6 +742,10 @@ static string WriteLmdbArtifact(
     string sourcePath)
 {
     var envPath = Path.Combine(root, "lmdb-category-parent");
+    if (Directory.Exists(envPath))
+    {
+        Directory.Delete(envPath, recursive: true);
+    }
     Directory.CreateDirectory(envPath);
     var mapSize = Math.Max(256L * 1024L * 1024L, rows.Count * 256L);
     using (var env = new LightningEnvironment(envPath) { MaxDatabases = 4, MapSize = mapSize })
@@ -746,6 +785,16 @@ static string WriteLmdbArtifact(
     var manifestPath = Path.Combine(root, "category_parent.lmdb.manifest.json");
     File.WriteAllText(manifestPath, JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true }), Encoding.UTF8);
     return manifestPath;
+}
+
+static string ExistingOrBuild(string manifestPath, bool refreshArtifacts, Func<string> build)
+{
+    if (!refreshArtifacts && File.Exists(manifestPath))
+    {
+        return manifestPath;
+    }
+
+    return build();
 }
 
 static string HashBuckets(IEnumerable<IndexedRelationBucket> buckets)
@@ -872,7 +921,9 @@ var scale = ReadArg(args, "--scale", "dev");
 var scaleDir = ReadArg(args, "--scale-dir", "");
 var lookupKeyCount = Math.Max(1, ReadIntArg(args, "--lookup-keys", 64));
 var lookupRepetitions = Math.Max(1, ReadIntArg(args, "--lookup-repetitions", 5));
-var root = Directory.GetCurrentDirectory();
+var root = Path.GetFullPath(ReadArg(args, "--artifact-root", Directory.GetCurrentDirectory()));
+var refreshArtifacts = ReadBoolArg(args, "--refresh-artifacts", false);
+Directory.CreateDirectory(root);
 var predicate = new PredicateId("category_parent", 2);
 var rows = ReadAndInternEdges(scaleDir, out var distinctCategories);
 var lookupKeys = rows.Select(row => row.Child)
@@ -883,17 +934,36 @@ var lookupKeys = rows.Select(row => row.Child)
     .ToArray();
 
 var inputPath = Path.Combine(root, "category_parent_ids.tsv");
-WriteInput(inputPath, rows);
+if (refreshArtifacts || !File.Exists(inputPath))
+{
+    WriteInput(inputPath, rows);
+}
 var source = new DelimitedRelationSource(inputPath, '\t', 1, 2);
 
 var binaryDir = Path.Combine(root, "binary-artifact");
-var binaryManifest = BinaryRelationArtifactBuilder.BuildFromDelimited(predicate, source, binaryDir);
+var binaryManifestPath = Path.Combine(binaryDir, "category_parent_2.uwbr.json");
+var binaryManifest = ExistingOrBuild(
+    binaryManifestPath,
+    refreshArtifacts,
+    () => BinaryRelationArtifactBuilder.BuildFromDelimited(predicate, source, binaryDir));
 var delimitedDir = Path.Combine(root, "delimited-artifact");
-var delimitedManifest = DelimitedRelationArtifactBuilder.BuildFromDelimited(predicate, source, delimitedDir);
-var lmdbManifest = WriteLmdbArtifact(root, predicate, rows, inputPath);
+var delimitedManifestPath = Path.Combine(delimitedDir, "category_parent_2.uwdr.json");
+var delimitedManifest = ExistingOrBuild(
+    delimitedManifestPath,
+    refreshArtifacts,
+    () => DelimitedRelationArtifactBuilder.BuildFromDelimited(predicate, source, delimitedDir));
+var lmdbManifestPath = Path.Combine(root, "category_parent.lmdb.manifest.json");
+var lmdbManifest = ExistingOrBuild(
+    lmdbManifestPath,
+    refreshArtifacts,
+    () => WriteLmdbArtifact(root, predicate, rows, inputPath));
 var lmdbDir = Path.Combine(root, "lmdb-category-parent");
 var mmapDir = Path.Combine(root, "mmap-array-artifact");
-var mmapManifest = MmapArrayRelationArtifactBuilder.BuildFromDelimited(predicate, source, mmapDir);
+var mmapManifestPath = Path.Combine(mmapDir, "category_parent_2.uwa.json");
+var mmapManifest = ExistingOrBuild(
+    mmapManifestPath,
+    refreshArtifacts,
+    () => MmapArrayRelationArtifactBuilder.BuildFromDelimited(predicate, source, mmapDir));
 
 Console.WriteLine("scale\tmode\trows\tdistinct_categories\tlookup_keys\tartifact_bytes\topen_ms\tlookup_ms\tbucket_ms\tscan_ms\tretained_bytes\tscan_hash\tlookup_hash\tbucket_hash");
 BenchmarkProvider(

--- a/tests/test_csharp_query_effective_distance_artifact_backends.py
+++ b/tests/test_csharp_query_effective_distance_artifact_backends.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import tempfile
 import unittest
 import importlib.util
 import sys
@@ -144,6 +145,54 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
         self.assertIn("| Scale | Rows | Categories | Lookup keys | Best lookup |", result.stdout)
         self.assertIn("| dev |", result.stdout)
         self.assertIn("Smallest artifact", result.stdout)
+
+    def test_artifact_root_reuses_existing_manifests(self) -> None:
+        if shutil.which("dotnet") is None:
+            self.skipTest("dotnet is not available")
+        if not LIGHTNINGDB_PACKAGE.exists():
+            self.skipTest("LightningDB 0.21.0 package is not available in the local NuGet cache")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact_root = Path(tmp) / "artifacts"
+            command = [
+                "python3",
+                str(SCRIPT),
+                "--scales",
+                "dev",
+                "--lookup-keys",
+                "4",
+                "--lookup-repetitions",
+                "1",
+                "--repetitions",
+                "1",
+                "--artifact-root",
+                str(artifact_root),
+                "--format",
+                "summary-markdown",
+            ]
+            first = subprocess.run(
+                command + ["--refresh-artifacts"],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=180,
+            )
+            self.assertEqual(first.returncode, 0, msg=f"stdout:\n{first.stdout}\nstderr:\n{first.stderr}")
+            manifest = artifact_root / "dev" / "category_parent.lmdb.manifest.json"
+            self.assertTrue(manifest.exists())
+            first_mtime = manifest.stat().st_mtime_ns
+
+            second = subprocess.run(
+                command,
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=180,
+            )
+            self.assertEqual(second.returncode, 0, msg=f"stdout:\n{second.stdout}\nstderr:\n{second.stderr}")
+            self.assertEqual(manifest.stat().st_mtime_ns, first_mtime)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary

  - Add `--artifact-root` to persist C# effective-distance backend artifacts per scale.
  - Add `--refresh-artifacts` to explicitly rebuild persisted artifacts.
  - Reuse existing binary, delimited, LMDB, and mmap-array manifests by default when an artifact root is provided.
  - Align the C# benchmark workflow with the Haskell convention: do not regenerate LMDB/artifacts unless refresh is requested.
  - Add regression coverage that verifies the LMDB manifest is not rewritten on a second no-refresh run.

  ## Measurement

  Prepared and measured a local `1m_cats` fixture from the enwiki dump:

  - Rows: `1,000,000`
  - Categories: `439,766`
  - Best lookup: `mmap-array`
  - Best bucket: `mmap-array`
  - Best scan: `preload`
  - Smallest artifact: `mmap-array`

  LMDB beats binary/delimited on scan, but still does not beat mmap-array at this scale.

  ## Notes

  This branch keeps the fixture path TSV-based. The next useful optimization is direct Rust-parser-to-LMDB ingestion to remove
  the parser-output-to-TSV-to-artifact-build hop.

  ## Verification

  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py examples/
  benchmark/prepare_csharp_query_enwiki_category_fixture.py tests/test_csharp_query_effective_distance_artifact_backends.py
  tests/test_prepare_csharp_query_enwiki_category_fixture.py`
  - `python3 -m unittest tests/test_csharp_query_effective_distance_artifact_backends.py tests/
  test_prepare_csharp_query_enwiki_category_fixture.py`
  - `python3 examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py --scales 1m_cats --lookup-keys
  16 --lookup-repetitions 1 --repetitions 1 --artifact-root output/csharp-query-effective-distance-artifacts --refresh-
  artifacts --min-free-memory-mib 1024 --format summary-tsv`
  - `python3 examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py --scales 1m_cats --lookup-keys
  16 --lookup-repetitions 1 --repetitions 1 --artifact-root output/csharp-query-effective-distance-artifacts --min-free-
  memory-mib 1024 --format summary-tsv`
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime_lmdb/UnifyWeaver.QueryRuntime.Lmdb.csproj`
  - `env SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  test_csharp_query_target:test_csharp_query_target -t halt`
  - `git diff --check`