### PR TITLE
bench(wam-c): scale lowered helper workload

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,7 +5,7 @@ Status date: 2026-05-15
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `cc2d432d` (`Merge pull request #2129 from s243a/feat/wam-c-lowered-helper-projection-row-constraints`)
+- `main` at `e727e49b` (`Merge pull request #2139 from s243a/feat/wam-c-lowered-helper-projection-bench`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
@@ -14,7 +14,7 @@ Base verified locally:
 
 Active branch:
 
-- `feat/wam-c-lowered-helper-projection-bench`
+- `feat/wam-c-lowered-helper-scale-workload`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -58,7 +58,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper non-reordered projection metadata | Done | Planner reports explicit rejection reasons for omitted head variables, repeated head variables, and unbound callee variables |
 | Lowered helper ignored-output projections | Done | Projected body-call helpers pass singleton callee-local variables as fresh unbound arguments and ignore their returned bindings |
 | Lowered helper projection row constraints | Done | Repeated caller-variable projections lower through materialized native fact rows while preserving availability checks |
-| Lowered helper projection benchmark | In progress | Active branch extends the tiny lowered-helper benchmark to cover direct, reordered, ignored-output, and row-constrained projection shapes |
+| Lowered helper projection benchmark | Done | Tiny lowered-helper benchmark covers direct, reordered, ignored-output, and row-constrained projection shapes |
+| Lowered helper scaled benchmark workload | In progress | Active branch parameterizes the lowered-helper generator by scale while preserving interpreted/lowered output matching |
 
 ## Current C Target Baseline
 
@@ -139,24 +140,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lowered-helper-projection-bench`
-
-Goal: add a small benchmark workload for projected lowered helpers that covers
-reordered, ignored-output, and row-constrained projection shapes.
-
-Scope:
-
-- Extend the tiny lowered-helper matrix workload before adding broader C
-  target benchmark slices.
-- Compare interpreted, direct projected, ignored-output, and row-constrained
-  helper variants.
-- Keep constant filters on the existing materialized `filtered_fact` path.
-
-Status: active; the existing `c-wam-lowered-helper` target set now runs direct,
-reordered, ignored-output, and row-constrained projected-helper queries in both
-interpreted and lowered modes.
-
-### 2. `feat/wam-c-lowered-helper-scale-workload`
+### 1. `feat/wam-c-lowered-helper-scale-workload`
 
 Goal: scale the lowered-helper benchmark beyond the tiny dev smoke while keeping
 the output contract stable across interpreted and lowered modes.
@@ -168,10 +152,25 @@ Scope:
 - Preserve projection-shape coverage and output matching across modes.
 - Keep the first pass small enough for routine matrix validation.
 
+Status: active; `dev` now emits 16 normalized rows and `10x` emits 160 rows for
+the same projection-shape workload, with interpreted and lowered output hashes
+matching per scale.
+
+### 2. `feat/wam-c-lowered-helper-scale-ci-smoke`
+
+Goal: add focused regression coverage for the scaled lowered-helper generator
+and matrix output row counts.
+
+Scope:
+
+- Assert that `dev` and `10x` lowered-helper matrix rows differ by scale but
+  match between interpreted and lowered modes.
+- Keep the test narrow so it does not turn the general matrix unit test into a
+  slow compile/run suite.
+
 ## Suggested Immediate Next Step
 
-Continue validating `feat/wam-c-lowered-helper-projection-bench`.
+Continue validating `feat/wam-c-lowered-helper-scale-workload`.
 
-The active branch broadens the existing lowered-helper matrix target from a
-fact-oriented smoke into a projection-shape benchmark, while preserving the same
-interpreted-vs-lowered target set.
+The active branch gives the lowered-helper projection benchmark a real scale
+dimension while keeping the standard three-column benchmark output contract.

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -356,6 +356,7 @@ def build_wam_c_lowered_helper_benchmark(root: Path, scale: str, mode: str) -> l
             "--",
             str(project_dir),
             mode,
+            scale,
         ],
         cwd=ROOT,
     )

--- a/examples/benchmark/generate_wam_c_lowered_helper_benchmark.pl
+++ b/examples/benchmark/generate_wam_c_lowered_helper_benchmark.pl
@@ -1,6 +1,7 @@
 :- module(generate_wam_c_lowered_helper_benchmark,
           [ main/0,
-            generate/2
+            generate/2,
+            generate/3
           ]).
 :- initialization(main, main).
 
@@ -14,20 +15,23 @@
 %%
 %% Usage:
 %%   swipl -q -s examples/benchmark/generate_wam_c_lowered_helper_benchmark.pl -- \
-%%       <output-dir> [interpreted|lowered]
+%%       <output-dir> [interpreted|lowered] [scale]
 
 main :-
     current_prolog_flag(argv, Argv),
     (   Argv == []
     ->  true
+    ;   Argv = [OutputDir, ModeAtom, ScaleAtom]
+    ->  generate(OutputDir, ModeAtom, ScaleAtom),
+        halt(0)
     ;   Argv = [OutputDir, ModeAtom]
-    ->  generate(OutputDir, ModeAtom),
+    ->  generate(OutputDir, ModeAtom, dev),
         halt(0)
     ;   Argv = [OutputDir]
-    ->  generate(OutputDir, lowered),
+    ->  generate(OutputDir, lowered, dev),
         halt(0)
     ;   format(user_error,
-               'Usage: ... -- <output-dir> [interpreted|lowered]~n',
+               'Usage: ... -- <output-dir> [interpreted|lowered] [scale]~n',
                []),
         halt(1)
     ).
@@ -37,19 +41,23 @@ main :-
     halt(1).
 
 generate(OutputDir, Mode) :-
+    generate(OutputDir, Mode, dev).
+
+generate(OutputDir, Mode, Scale) :-
     parse_mode(Mode, ParsedMode),
-    setup_benchmark_facts,
+    parse_scale(Scale, RowCount),
+    setup_benchmark_facts(RowCount),
     make_directory_path(OutputDir),
     mode_options(ParsedMode, Options),
     mode_predicates(ParsedMode, Predicates),
     write_wam_c_project(Predicates, Options, OutputDir),
     directory_file_path(OutputDir, 'main.c', MainPath),
-    lowered_helper_benchmark_main(MainCode),
+    lowered_helper_benchmark_main(RowCount, MainCode),
     write_text_file(MainPath, MainCode),
     directory_file_path(OutputDir, 'README.md', ReadmePath),
     format(atom(Readme),
-           '# WAM-C lowered-helper benchmark~n~nMode: `~w`~n~nThe generated runner queries direct, reordered, ignored-output, and row-constrained projection shapes. Planner metadata is emitted as comments in `lib.c`.~n',
-           [ParsedMode]),
+           '# WAM-C lowered-helper benchmark~n~nMode: `~w`~n~nScale: `~w` (~w rows per projection variant)~n~nThe generated runner queries direct, reordered, ignored-output, and row-constrained projection shapes. Planner metadata is emitted as comments in `lib.c`.~n',
+           [ParsedMode, Scale, RowCount]),
     write_text_file(ReadmePath, Readme),
     cleanup_benchmark_facts.
 
@@ -59,6 +67,37 @@ parse_mode(interpreted, interpreted) :- !.
 parse_mode('interpreted', interpreted) :- !.
 parse_mode(Mode, _) :-
     throw(error(domain_error(wam_c_lowered_helper_benchmark_mode, Mode), _)).
+
+parse_scale(Scale, Count) :-
+    atom(Scale),
+    parse_scale_atom(Scale, Count),
+    !.
+parse_scale(Scale, Count) :-
+    string(Scale),
+    atom_string(ScaleAtom, Scale),
+    parse_scale_atom(ScaleAtom, Count),
+    !.
+parse_scale(Scale, _) :-
+    throw(error(domain_error(wam_c_lowered_helper_benchmark_scale, Scale), _)).
+
+parse_scale_atom(dev, 4) :- !.
+parse_scale_atom(Scale, Count) :-
+    atom_chars(Scale, Chars),
+    append(DigitChars, SuffixChars, Chars),
+    DigitChars \= [],
+    maplist(char_type_digit, DigitChars),
+    number_chars(Base, DigitChars),
+    scale_suffix_multiplier(SuffixChars, Multiplier),
+    Count is Base * Multiplier,
+    Count > 0.
+
+char_type_digit(Char) :-
+    char_type(Char, digit).
+
+scale_suffix_multiplier([], 1).
+scale_suffix_multiplier(['x'], 4).
+scale_suffix_multiplier(['k'], 1000).
+scale_suffix_multiplier(['K'], 1000).
 
 mode_options(lowered, [lowered_helpers(true), report_lowered_helpers(true)]).
 mode_options(interpreted, [report_lowered_helpers(true)]).
@@ -73,18 +112,9 @@ mode_predicates(_Mode, [user:wam_c_bench_pair/2,
                         user:wam_c_bench_pair_score/3,
                         user:wam_c_bench_pair_small/2]).
 
-setup_benchmark_facts :-
+setup_benchmark_facts(RowCount) :-
     cleanup_benchmark_facts,
-    assertz(user:wam_c_bench_pair(a, b)),
-    assertz(user:wam_c_bench_pair(a, c)),
-    assertz(user:wam_c_bench_pair(a, a)),
-    assertz(user:wam_c_bench_pair(b, d)),
-    assertz(user:wam_c_bench_pair_tag(a, b, keep)),
-    assertz(user:wam_c_bench_pair_tag(a, c, keep)),
-    assertz(user:wam_c_bench_pair_tag(b, d, keep)),
-    assertz(user:wam_c_bench_pair_score(a, b, 1)),
-    assertz(user:wam_c_bench_pair_score(a, c, 2)),
-    assertz(user:wam_c_bench_pair_score(b, d, 3)),
+    forall(between(1, RowCount, I), assert_benchmark_fact_row(I)),
     assertz(user:((wam_c_bench_pair_alias(X, Y) :- wam_c_bench_pair(X, Y)))),
     assertz(user:((wam_c_bench_pair_projected(Y, X) :- wam_c_bench_pair(X, Y)))),
     assertz(user:((wam_c_bench_pair_left(X) :- wam_c_bench_pair(X, _Ignored)))),
@@ -93,6 +123,20 @@ setup_benchmark_facts :-
     assertz(user:((wam_c_bench_pair_small(X, Y) :-
         wam_c_bench_pair_score(X, Y, Score),
         Score =< 3))).
+
+assert_benchmark_fact_row(I) :-
+    benchmark_atoms(I, Left, Right, Equal),
+    assertz(user:wam_c_bench_pair(Left, Right)),
+    assertz(user:wam_c_bench_pair(Equal, Equal)),
+    assertz(user:wam_c_bench_pair_tag(Left, Right, keep)),
+    assertz(user:wam_c_bench_pair_tag(Equal, Equal, keep)),
+    assertz(user:wam_c_bench_pair_score(Left, Right, I)),
+    assertz(user:wam_c_bench_pair_score(Equal, Equal, I)).
+
+benchmark_atoms(I, Left, Right, Equal) :-
+    format(atom(Left), 'l~w', [I]),
+    format(atom(Right), 'r~w', [I]),
+    format(atom(Equal), 'e~w', [I]).
 
 cleanup_benchmark_facts :-
     retractall(user:wam_c_bench_pair(_, _)),
@@ -105,7 +149,10 @@ cleanup_benchmark_facts :-
     retractall(user:wam_c_bench_pair_score(_, _, _)),
     retractall(user:wam_c_bench_pair_small(_, _)).
 
-lowered_helper_benchmark_main(Code) :-
+lowered_helper_benchmark_main(RowCount, Code) :-
+    benchmark_atom_array(RowCount, left, LeftArray),
+    benchmark_atom_array(RowCount, right, RightArray),
+    benchmark_atom_array(RowCount, equal, EqualArray),
     format(atom(Code),
 '#include "wam_runtime.h"
 #include <stdio.h>
@@ -125,7 +172,7 @@ static int emit_pair(WamState* state, const char* variant, const char* pred, con
     WamValue args[2] = { val_atom(left), val_atom(right) };
     int rc = wam_run_predicate(state, pred, args, 2);
     if (rc != 0 || state->P != WAM_HALT) return 1;
-    printf("%s\\t%s\\t%s\\t%.6f\\n", variant, left, right, score);
+    printf("%s:%s\\t%s\\t%.6f\\n", variant, left, right, score);
     return 0;
 }
 
@@ -133,12 +180,16 @@ static int emit_left(WamState* state, const char* variant, const char* pred, con
     WamValue args[1] = { val_atom(left) };
     int rc = wam_run_predicate(state, pred, args, 1);
     if (rc != 0 || state->P != WAM_HALT) return 1;
-    printf("%s\\t%s\\t_\\t%.6f\\n", variant, left, score);
+    printf("%s:%s\\t_\\t%.6f\\n", variant, left, score);
     return 0;
 }
 
 int main(void) {
     WamState state;
+    static const char* lefts[] = { ~w };
+    static const char* rights[] = { ~w };
+    static const char* equals[] = { ~w };
+    const int row_count = ~w;
     wam_state_init(&state);
     setup_wam_c_bench_pair_2(&state);
     setup_wam_c_bench_pair_alias_2(&state);
@@ -151,30 +202,47 @@ int main(void) {
     setup_wam_c_bench_pair_small_2(&state);
     setup_lowered_wam_c_helpers(&state);
 
-    printf("variant\\tleft\\tright\\tscore\\n");
+    printf("left\\tright\\tscore\\n");
 
-    if (emit_pair(&state, "direct", "wam_c_bench_pair_alias/2", "a", "b", 1.0) != 0) {
-        wam_free_state(&state);
-        return 10;
-    }
-    if (emit_pair(&state, "reordered", "wam_c_bench_pair_projected/2", "b", "a", 2.0) != 0) {
-        wam_free_state(&state);
-        return 20;
-    }
-    if (emit_left(&state, "ignored-output", "wam_c_bench_pair_left/1", "a", 3.0) != 0) {
-        wam_free_state(&state);
-        return 30;
-    }
-    if (emit_left(&state, "row-constrained", "wam_c_bench_pair_equal/1", "a", 4.0) != 0) {
-        wam_free_state(&state);
-        return 40;
+    for (int i = 0; i < row_count; i++) {
+        double base = (double)(i + 1);
+        if (emit_pair(&state, "direct", "wam_c_bench_pair_alias/2", lefts[i], rights[i], base) != 0) {
+            wam_free_state(&state);
+            return 10;
+        }
+        if (emit_pair(&state, "reordered", "wam_c_bench_pair_projected/2", rights[i], lefts[i], base + 0.25) != 0) {
+            wam_free_state(&state);
+            return 20;
+        }
+        if (emit_left(&state, "ignored-output", "wam_c_bench_pair_left/1", lefts[i], base + 0.50) != 0) {
+            wam_free_state(&state);
+            return 30;
+        }
+        if (emit_left(&state, "row-constrained", "wam_c_bench_pair_equal/1", equals[i], base + 0.75) != 0) {
+            wam_free_state(&state);
+            return 40;
+        }
     }
 
     wam_free_state(&state);
     return 0;
 }
 ',
-           []).
+           [LeftArray, RightArray, EqualArray, RowCount]).
+
+benchmark_atom_array(RowCount, Kind, Code) :-
+    findall(Literal,
+            (   between(1, RowCount, I),
+                benchmark_atoms(I, Left, Right, Equal),
+                benchmark_array_atom(Kind, Left, Right, Equal, Atom),
+                format(atom(Literal), '"~w"', [Atom])
+            ),
+            Literals),
+    atomic_list_concat(Literals, ', ', Code).
+
+benchmark_array_atom(left, Left, _Right, _Equal, Left).
+benchmark_array_atom(right, _Left, Right, _Equal, Right).
+benchmark_array_atom(equal, _Left, _Right, Equal, Equal).
 
 write_text_file(Path, Content) :-
     setup_call_cleanup(


### PR DESCRIPTION
# Scale the WAM-C lowered-helper benchmark workload

## Summary

- parameterize the WAM-C lowered-helper benchmark generator by matrix scale
- pass the active matrix scale into generated lowered-helper benchmark projects
- preserve interpreted/lowered output matching while making `dev` emit 16 normalized rows and `10x` emit 160
- keep the benchmark output in the standard three-column format used by the matrix normalizer
- refresh the WAM-C next-steps roadmap with this branch active and focused scaled-workload regression coverage as the next follow-up

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev,10x --target-sets c-wam-lowered-helper --repetitions 1 --baseline-target c-wam-lowered-helper-interpreted`
- module-call smoke for `generate(..., lowered)`
- `git diff --check`
