### PR TITLE
test(wam-c): cover scaled lowered helper rows

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -1,20 +1,20 @@
 # WAM C Target - Status And Next Steps
 
-Status date: 2026-05-15
+Status date: 2026-05-16
 
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `e727e49b` (`Merge pull request #2139 from s243a/feat/wam-c-lowered-helper-projection-bench`)
+- `main` at `ee3a7f9a` (`Merge pull request #2141 from s243a/feat/wam-c-lowered-helper-scale-workload`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
-- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets c-wam-lowered-helper --repetitions 1 --baseline-target c-wam-lowered-helper-interpreted`
+- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev,10x --target-sets c-wam-lowered-helper --repetitions 1 --baseline-target c-wam-lowered-helper-interpreted`
 - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
 
 Active branch:
 
-- `feat/wam-c-lowered-helper-scale-workload`
+- `test/wam-c-lowered-helper-scale-regression`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -59,7 +59,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper ignored-output projections | Done | Projected body-call helpers pass singleton callee-local variables as fresh unbound arguments and ignore their returned bindings |
 | Lowered helper projection row constraints | Done | Repeated caller-variable projections lower through materialized native fact rows while preserving availability checks |
 | Lowered helper projection benchmark | Done | Tiny lowered-helper benchmark covers direct, reordered, ignored-output, and row-constrained projection shapes |
-| Lowered helper scaled benchmark workload | In progress | Active branch parameterizes the lowered-helper generator by scale while preserving interpreted/lowered output matching |
+| Lowered helper scaled benchmark workload | Done | `dev` emits 16 normalized rows and `10x` emits 160 rows for the same projection-shape workload, with interpreted and lowered output hashes matching per scale |
+| Lowered helper scale regression coverage | In progress | Active branch adds explicit local regression coverage for `dev`/`10x` row counts and interpreted/lowered hash parity |
 
 ## Current C Target Baseline
 
@@ -140,37 +141,38 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lowered-helper-scale-workload`
+### 1. `test/wam-c-lowered-helper-scale-regression`
 
-Goal: scale the lowered-helper benchmark beyond the tiny dev smoke while keeping
-the output contract stable across interpreted and lowered modes.
-
-Scope:
-
-- Parameterize the lowered-helper generator by scale instead of hard-coding a
-  handful of facts.
-- Preserve projection-shape coverage and output matching across modes.
-- Keep the first pass small enough for routine matrix validation.
-
-Status: active; `dev` now emits 16 normalized rows and `10x` emits 160 rows for
-the same projection-shape workload, with interpreted and lowered output hashes
-matching per scale.
-
-### 2. `feat/wam-c-lowered-helper-scale-ci-smoke`
-
-Goal: add focused regression coverage for the scaled lowered-helper generator
-and matrix output row counts.
+Goal: pin the scaled lowered-helper workload with focused local regression
+coverage instead of adding a broad CI action for an unstable target family.
 
 Scope:
 
 - Assert that `dev` and `10x` lowered-helper matrix rows differ by scale but
   match between interpreted and lowered modes.
+- Verify the expected `dev` and `10x` row counts from the scaled projection
+  workload.
 - Keep the test narrow so it does not turn the general matrix unit test into a
   slow compile/run suite.
 
+Status: active.
+
+### 2. `feat/wam-c-lowered-helper-larger-scale-calibration`
+
+Goal: decide whether the lowered-helper workload needs a larger routine
+calibration point after the local `dev`/`10x` regression is pinned.
+
+Scope:
+
+- Run a small manual sweep above `10x` and compare lowered/interpreted output
+  parity plus runtime shape.
+- Promote only a cheap, stable scale into routine validation.
+- Defer GitHub Actions coverage until the target surface is stable enough that
+  CI failures are likely to be actionable.
+
 ## Suggested Immediate Next Step
 
-Continue validating `feat/wam-c-lowered-helper-scale-workload`.
+Continue validating `test/wam-c-lowered-helper-scale-regression`.
 
-The active branch gives the lowered-helper projection benchmark a real scale
-dimension while keeping the standard three-column benchmark output contract.
+The active branch should add a focused regression test for `dev`/`10x` scaled
+lowered-helper matrix parity and keep CI workflow changes out of scope for now.

--- a/tests/test_wam_c_lowered_helper_scale_regression.py
+++ b/tests/test_wam_c_lowered_helper_scale_regression.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MATRIX_SCRIPT = ROOT / "examples" / "benchmark" / "benchmark_effective_distance_matrix.py"
+
+
+class WamCLoweredHelperScaleRegressionTests(unittest.TestCase):
+    def test_dev_and_10x_scales_preserve_lowered_helper_output_parity(self) -> None:
+        if shutil.which("swipl") is None:
+            self.skipTest("swipl is not available")
+        if shutil.which("gcc") is None:
+            self.skipTest("gcc is not available")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(MATRIX_SCRIPT),
+                "--scales",
+                "dev,10x",
+                "--target-sets",
+                "c-wam-lowered-helper",
+                "--repetitions",
+                "1",
+                "--baseline-target",
+                "c-wam-lowered-helper-interpreted",
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=180,
+        )
+
+        if result.returncode != 0:
+            self.fail(
+                "lowered-helper scale matrix failed\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+
+        target_rows = self._parse_target_rows(result.stdout)
+        targets = {
+            "c-wam-lowered-helper",
+            "c-wam-lowered-helper-interpreted",
+        }
+
+        for scale, expected_rows in {"dev": 16, "10x": 160}.items():
+            rows_for_scale = {
+                row["target"]: row
+                for row in target_rows
+                if row["scale"] == scale and row["target"] in targets
+            }
+            self.assertEqual(set(rows_for_scale), targets)
+
+            for target, row in rows_for_scale.items():
+                with self.subTest(scale=scale, target=target):
+                    self.assertEqual(row["status"], "ok")
+                    self.assertEqual(row["rows"], str(expected_rows))
+
+            self.assertEqual(
+                rows_for_scale["c-wam-lowered-helper"]["stdout_sha256"],
+                rows_for_scale["c-wam-lowered-helper-interpreted"]["stdout_sha256"],
+            )
+
+        self.assertNotEqual(
+            {
+                row["stdout_sha256"]
+                for row in target_rows
+                if row["scale"] == "dev" and row["target"] in targets
+            },
+            {
+                row["stdout_sha256"]
+                for row in target_rows
+                if row["scale"] == "10x" and row["target"] in targets
+            },
+        )
+        self.assertIn("dev\tall_outputs\tmatch", result.stdout)
+        self.assertIn("10x\tall_outputs\tmatch", result.stdout)
+        self.assertIn("dev\thybrid-wam-lowered-helper_outputs\tmatch", result.stdout)
+        self.assertIn("10x\thybrid-wam-lowered-helper_outputs\tmatch", result.stdout)
+
+    def _parse_target_rows(self, stdout: str) -> list[dict[str, str]]:
+        lines = [line for line in stdout.splitlines() if line]
+        self.assertTrue(lines, "matrix output should not be empty")
+        header = lines[0].split("\t")
+        self.assertEqual(
+            header,
+            [
+                "scale",
+                "target",
+                "category",
+                "status",
+                "median_s",
+                "min_s",
+                "max_s",
+                "rows",
+                "stdout_sha256",
+                "message",
+            ],
+        )
+
+        rows: list[dict[str, str]] = []
+        for line in lines[1:]:
+            parts = line.split("\t")
+            if len(parts) > len(header):
+                continue
+            parts.extend([""] * (len(header) - len(parts)))
+            row = dict(zip(header, parts))
+            if row["target"].startswith("c-wam-lowered-helper"):
+                rows.append(row)
+        return rows
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Test scaled WAM-C lowered-helper matrix parity

## Summary

- Add a focused local regression test for the WAM-C lowered-helper matrix at `dev` and `10x` scales.
- Assert interpreted and lowered helper outputs stay hash-identical per scale.
- Pin expected scaled row counts: `dev` emits 16 rows and `10x` emits 160 rows.
- Refresh the WAM-C next-steps roadmap to mark the scaled workload complete and track this regression branch.

## Validation

- `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_wam_c_lowered_helper_scale_regression.py`
- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --check`