### PR TITLE
bench(csharp-query): sink enwiki fixtures to LMDB

### DIFF
--- a/docs/targets/csharp-query-high-performance-sources.md
+++ b/docs/targets/csharp-query-high-performance-sources.md
@@ -281,9 +281,14 @@ need manual override:
   `examples/streaming/enwiki_category_ingest.pl`, instead of adding another
   dump tokenizer. For the C# backend benchmark, the fixture-prep helper is
   `examples/benchmark/prepare_csharp_query_enwiki_category_fixture.py`; it
-  writes capped TSV fixtures first. Direct Rust-parser-to-LMDB ingestion is a
-  valid future optimization, but is intentionally not part of this first C#
-  benchmark fixture path. The C# backend benchmark now accepts a persistent
+  writes capped TSV fixtures first and can optionally add a provider-compatible
+  LMDB relation artifact with `--sink-lmdb`. That sink still reuses the capped
+  Python helper row set and the existing C# `lmdb_ingest` consumer, preserving
+  the Wikipedia page IDs from the parser output. Direct Rust-parser-to-LMDB
+  ingestion remains the follow-up once a native sink is implemented. The C#
+  backend benchmark can use those scale-local artifacts via
+  `--use-scale-lmdb-artifact`, which implies `--preserve-numeric-ids`; otherwise
+  it accepts a persistent
   `--artifact-root` and reuses existing backend artifacts by default; use
   `--refresh-artifacts` to rebuild, matching the Haskell benchmark's explicit
   LMDB refresh convention.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -204,9 +204,28 @@ python examples/benchmark/prepare_csharp_query_enwiki_category_fixture.py \
 ```
 
 This writes a capped `category_parent.tsv` fixture from `subcat` rows using the
-same Rust parser. It intentionally stops at TSV fixture creation; a future
-optimization can write the parser output directly to LMDB and bypass the Python
-orchestrator.
+same Rust parser. Add `--sink-lmdb` to also write a reusable C# query LMDB
+relation artifact beside the TSV fixture:
+
+```bash
+python examples/benchmark/prepare_csharp_query_enwiki_category_fixture.py \
+  --scale 500k_cats \
+  --max-edges 500000 \
+  --dump data/enwiki/enwiki-latest-categorylinks.sql.gz \
+  --sink-lmdb
+```
+
+The LMDB sink reuses the capped row set and the existing C# `lmdb_ingest`
+consumer, so it preserves the helper's row cap and writes a provider-compatible
+`category_parent.lmdb.manifest.json`. The sink preserves the Wikipedia page IDs
+from the parser output; the backend benchmark implies `--preserve-numeric-ids`
+when `--use-scale-lmdb-artifact` is set so all compared backends use the same
+stable ID space. Existing LMDB artifacts are reused by default; pass
+`--refresh-lmdb` to rebuild them. A future Rust-native sink can still bypass the
+Python orchestrator entirely once that path is implemented. Pass
+`--use-scale-lmdb-artifact` to the backend benchmark when you want the `lmdb`
+mode to use this scale-local artifact instead of generating one under
+`--artifact-root`.
 
 Pass `--artifact-root <dir>` to keep backend artifacts across benchmark runs.
 Existing binary, delimited, LMDB, and mmap-array manifests are reused by

--- a/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
+++ b/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
@@ -186,6 +186,8 @@ def run_scale(
     keep_temp: bool,
     artifact_root: Path | None,
     refresh_artifacts: bool,
+    use_scale_lmdb_artifact: bool,
+    preserve_numeric_ids: bool,
 ) -> list[BenchmarkRow]:
     scale_dir = BENCH_DIR / scale
     if not (scale_dir / "category_parent.tsv").exists():
@@ -220,6 +222,10 @@ def run_scale(
                 str((artifact_root / scale) if artifact_root is not None else temp_path),
                 "--refresh-artifacts",
                 "true" if refresh_artifacts else "false",
+                "--use-scale-lmdb-artifact",
+                "true" if use_scale_lmdb_artifact else "false",
+                "--preserve-numeric-ids",
+                "true" if preserve_numeric_ids else "false",
             ],
             cwd=temp_path,
             timeout=240,
@@ -498,6 +504,22 @@ def main(argv: list[str] | None = None) -> int:
         help="rebuild artifacts under --artifact-root instead of reusing existing manifests",
     )
     parser.add_argument(
+        "--use-scale-lmdb-artifact",
+        action="store_true",
+        help=(
+            "prefer data/benchmark/<scale>/category_parent.lmdb.manifest.json for the LMDB mode "
+            "when present; falls back to --artifact-root generation"
+        ),
+    )
+    parser.add_argument(
+        "--preserve-numeric-ids",
+        action="store_true",
+        help=(
+            "preserve numeric category_parent.tsv IDs instead of re-interning them densely; "
+            "implied by --use-scale-lmdb-artifact only when a scale-local LMDB manifest exists"
+        ),
+    )
+    parser.add_argument(
         "--prepare-missing-large-scales",
         action="store_true",
         help="generate supported SimpleWiki category-only fixtures when 50k_cats/100k_cats are requested",
@@ -601,6 +623,8 @@ def main(argv: list[str] | None = None) -> int:
                     args.keep_temp,
                     args.artifact_root,
                     args.refresh_artifacts,
+                    args.use_scale_lmdb_artifact,
+                    args.preserve_numeric_ids,
                 )
             )
 
@@ -694,6 +718,44 @@ static int Intern(Dictionary<string, int> ids, string value)
     id = ids.Count;
     ids[value] = id;
     return id;
+}
+
+static IReadOnlyList<(int Child, int Parent)> ReadEdges(string scaleDir, bool preserveNumericIds, out int distinctCategories)
+{
+    if (preserveNumericIds)
+    {
+        return ReadNumericEdges(scaleDir, out distinctCategories);
+    }
+
+    return ReadAndInternEdges(scaleDir, out distinctCategories);
+}
+
+static IReadOnlyList<(int Child, int Parent)> ReadNumericEdges(string scaleDir, out int distinctCategories)
+{
+    var ids = new HashSet<int>();
+    var rows = new List<(int Child, int Parent)>();
+    foreach (var line in File.ReadLines(Path.Combine(scaleDir, "category_parent.tsv")).Skip(1))
+    {
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            continue;
+        }
+
+        var tab = line.IndexOf('\t');
+        if (tab < 0)
+        {
+            throw new InvalidDataException($"category_parent.tsv row has no tab: {line}");
+        }
+
+        var child = int.Parse(line.Substring(0, tab), System.Globalization.CultureInfo.InvariantCulture);
+        var parent = int.Parse(line.Substring(tab + 1), System.Globalization.CultureInfo.InvariantCulture);
+        rows.Add((child, parent));
+        ids.Add(child);
+        ids.Add(parent);
+    }
+
+    distinctCategories = ids.Count;
+    return rows;
 }
 
 static IReadOnlyList<(int Child, int Parent)> ReadAndInternEdges(string scaleDir, out int distinctCategories)
@@ -795,6 +857,36 @@ static string ExistingOrBuild(string manifestPath, bool refreshArtifacts, Func<s
     }
 
     return build();
+}
+
+static string ResolveManifestEnvironmentPath(LmdbRelationArtifactManifest manifest, string manifestPath)
+{
+    return Path.IsPathRooted(manifest.EnvironmentPath)
+        ? manifest.EnvironmentPath
+        : Path.Combine(Path.GetDirectoryName(Path.GetFullPath(manifestPath)) ?? ".", manifest.EnvironmentPath);
+}
+
+static string? ExistingScaleLmdbManifest(string scaleDir)
+{
+    var manifestPath = Path.Combine(scaleDir, "category_parent.lmdb.manifest.json");
+    if (!File.Exists(manifestPath))
+    {
+        return null;
+    }
+
+    var manifest = LmdbRelationArtifactReader.LoadManifest(manifestPath);
+    if (manifest.PredicateName != "category_parent" || manifest.Arity != 2)
+    {
+        throw new InvalidDataException($"Scale-local LMDB manifest describes {manifest.PredicateName}/{manifest.Arity}, not category_parent/2: {manifestPath}");
+    }
+
+    var environmentPath = ResolveManifestEnvironmentPath(manifest, manifestPath);
+    if (!Directory.Exists(environmentPath))
+    {
+        throw new DirectoryNotFoundException($"Scale-local LMDB manifest environment does not exist: {environmentPath}");
+    }
+
+    return manifestPath;
 }
 
 static string HashBuckets(IEnumerable<IndexedRelationBucket> buckets)
@@ -923,9 +1015,13 @@ var lookupKeyCount = Math.Max(1, ReadIntArg(args, "--lookup-keys", 64));
 var lookupRepetitions = Math.Max(1, ReadIntArg(args, "--lookup-repetitions", 5));
 var root = Path.GetFullPath(ReadArg(args, "--artifact-root", Directory.GetCurrentDirectory()));
 var refreshArtifacts = ReadBoolArg(args, "--refresh-artifacts", false);
+var useScaleLmdbArtifact = ReadBoolArg(args, "--use-scale-lmdb-artifact", false);
+var requestedPreserveNumericIds = ReadBoolArg(args, "--preserve-numeric-ids", false);
 Directory.CreateDirectory(root);
 var predicate = new PredicateId("category_parent", 2);
-var rows = ReadAndInternEdges(scaleDir, out var distinctCategories);
+var scaleLmdbManifest = (!refreshArtifacts && useScaleLmdbArtifact) ? ExistingScaleLmdbManifest(scaleDir) : null;
+var preserveNumericIds = requestedPreserveNumericIds || scaleLmdbManifest is not null;
+var rows = ReadEdges(scaleDir, preserveNumericIds, out var distinctCategories);
 var lookupKeys = rows.Select(row => row.Child)
     .Distinct()
     .OrderBy(value => value)
@@ -953,11 +1049,12 @@ var delimitedManifest = ExistingOrBuild(
     refreshArtifacts,
     () => DelimitedRelationArtifactBuilder.BuildFromDelimited(predicate, source, delimitedDir));
 var lmdbManifestPath = Path.Combine(root, "category_parent.lmdb.manifest.json");
-var lmdbManifest = ExistingOrBuild(
+var lmdbManifest = scaleLmdbManifest ?? ExistingOrBuild(
     lmdbManifestPath,
     refreshArtifacts,
     () => WriteLmdbArtifact(root, predicate, rows, inputPath));
-var lmdbDir = Path.Combine(root, "lmdb-category-parent");
+var lmdbMetadata = LmdbRelationArtifactReader.LoadManifest(lmdbManifest);
+var lmdbDir = ResolveManifestEnvironmentPath(lmdbMetadata, lmdbManifest);
 var mmapDir = Path.Combine(root, "mmap-array-artifact");
 var mmapManifestPath = Path.Combine(mmapDir, "category_parent_2.uwa.json");
 var mmapManifest = ExistingOrBuild(

--- a/examples/benchmark/prepare_csharp_query_enwiki_category_fixture.py
+++ b/examples/benchmark/prepare_csharp_query_enwiki_category_fixture.py
@@ -2,17 +2,22 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Iterable, TextIO
+from typing import Callable, Iterable, TextIO
 
 
 ROOT = Path(__file__).resolve().parents[2]
 BENCH_DIR = ROOT / "data" / "benchmark"
 MYSQL_STREAM_MANIFEST = ROOT / "src" / "unifyweaver" / "runtime" / "rust" / "mysql_stream" / "Cargo.toml"
+CSHARP_LMDB_INGEST_PROJECT = ROOT / "src" / "unifyweaver" / "runtime" / "csharp" / "lmdb_ingest" / "lmdb_ingest.csproj"
 DEFAULT_DUMP = ROOT / "data" / "enwiki" / "enwiki-latest-categorylinks.sql.gz"
+DEFAULT_LMDB_DBNAME = "main"
 
 
 def parse_positive_int(value: str) -> int:
@@ -66,17 +71,143 @@ def write_fixture(scale: str, edges: list[tuple[str, str]], scanned_rows: int, o
     return output_dir
 
 
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def lmdb_manifest(
+    *,
+    predicate_name: str,
+    environment_path: str,
+    database_name: str,
+    row_count: int,
+    source_path: Path,
+) -> dict[str, object]:
+    return {
+        "Format": "unifyweaver.lmdb_relation.v1",
+        "Version": 1,
+        "Backend": "lmdb",
+        "PredicateName": predicate_name,
+        "Arity": 2,
+        "EnvironmentPath": environment_path,
+        "DatabaseName": database_name,
+        "DupSort": True,
+        "KeyEncoding": "utf8",
+        "ValueEncoding": "utf8",
+        "RowCount": row_count,
+        "SourcePath": str(source_path),
+        "SourceLength": source_path.stat().st_size,
+        "SourceSha256": file_sha256(source_path),
+    }
+
+
+def lmdb_consumer_env(
+    *,
+    lmdb_path: Path,
+    map_size: int,
+    database_name: str = DEFAULT_LMDB_DBNAME,
+) -> dict[str, str]:
+    return {
+        "UW_LMDB_PATH": str(lmdb_path),
+        "UW_LMDB_MAP_SIZE": str(map_size),
+        "UW_LMDB_DBNAME": database_name,
+        "UW_LMDB_DUPSORT": "1",
+        "UW_KEY_COL": "0",
+        "UW_VAL_COL": "1",
+        "UW_KEY_ENCODING": "utf8",
+        "UW_VAL_ENCODING": "utf8",
+        "UW_BATCH_SIZE": "50000",
+    }
+
+
+def lmdb_sink_input(edges: list[tuple[str, str]]) -> str:
+    return "".join(f"{child}\t{parent}\n" for child, parent in edges)
+
+
+def write_lmdb_artifact(
+    *,
+    fixture_dir: Path,
+    edges: list[tuple[str, str]],
+    refresh: bool,
+    map_size: int,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> Path:
+    if shutil.which("dotnet") is None:
+        raise RuntimeError("dotnet is not available; cannot sink C# LMDB artifact")
+    if not CSHARP_LMDB_INGEST_PROJECT.exists():
+        raise FileNotFoundError(CSHARP_LMDB_INGEST_PROJECT)
+
+    lmdb_dir = fixture_dir / "category_parent.lmdb"
+    manifest_path = fixture_dir / "category_parent.lmdb.manifest.json"
+    if manifest_path.exists() and lmdb_dir.exists() and not refresh:
+        print(f"[lmdb] reuse {manifest_path}", file=sys.stderr)
+        return manifest_path
+
+    if lmdb_dir.exists():
+        if not refresh:
+            raise RuntimeError(f"LMDB directory exists without manifest; pass --refresh-lmdb to rebuild: {lmdb_dir}")
+        shutil.rmtree(lmdb_dir)
+    if manifest_path.exists():
+        if not refresh:
+            raise RuntimeError(f"LMDB manifest exists without directory; pass --refresh-lmdb to rebuild: {manifest_path}")
+        manifest_path.unlink()
+
+    process_env = {**os.environ, **lmdb_consumer_env(lmdb_path=lmdb_dir, map_size=map_size)}
+    result = run(
+        ["dotnet", "run", "--project", str(CSHARP_LMDB_INGEST_PROJECT), "--configuration", "Release"],
+        cwd=ROOT,
+        text=True,
+        input=lmdb_sink_input(edges),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=process_env,
+        timeout=600,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "C# LMDB ingest failed with status "
+            f"{result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+    source_path = fixture_dir / "category_parent.tsv"
+    manifest = lmdb_manifest(
+        predicate_name="category_parent",
+        environment_path=lmdb_dir.name,
+        database_name=DEFAULT_LMDB_DBNAME,
+        row_count=len(edges),
+        source_path=source_path,
+    )
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(f"[lmdb] wrote {manifest_path}", file=sys.stderr)
+    return manifest_path
+
+
 def prepare_from_stream(
     *,
     scale: str,
     max_edges: int,
     output_root: Path,
     stream: TextIO,
+    sink_lmdb: bool = False,
+    refresh_lmdb: bool = False,
+    lmdb_map_size: int = 1 << 30,
 ) -> Path:
     edges, scanned_rows = edge_rows_from_mysql_stream(stream, max_edges)
     if not edges:
         raise RuntimeError("parser stream produced no subcat edges")
-    return write_fixture(scale, edges, scanned_rows, output_root)
+    output_dir = write_fixture(scale, edges, scanned_rows, output_root)
+    if sink_lmdb:
+        write_lmdb_artifact(
+            fixture_dir=output_dir,
+            edges=edges,
+            refresh=refresh_lmdb,
+            map_size=lmdb_map_size,
+        )
+    return output_dir
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -95,6 +226,22 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="read mysql_stream TSV from stdin instead of invoking cargo; useful for tests and pipelines",
     )
+    parser.add_argument(
+        "--sink-lmdb",
+        action="store_true",
+        help="also sink the capped fixture rows into a reusable C# LMDB relation artifact under the scale directory",
+    )
+    parser.add_argument(
+        "--refresh-lmdb",
+        action="store_true",
+        help="rebuild the LMDB artifact even when category_parent.lmdb.manifest.json already exists",
+    )
+    parser.add_argument(
+        "--lmdb-map-size",
+        type=parse_positive_int,
+        default=1 << 30,
+        help="LMDB map size in bytes for --sink-lmdb",
+    )
     args = parser.parse_args(argv)
 
     if args.from_stdin:
@@ -103,6 +250,9 @@ def main(argv: list[str] | None = None) -> int:
             max_edges=args.max_edges,
             output_root=args.output_root,
             stream=sys.stdin,
+            sink_lmdb=args.sink_lmdb,
+            refresh_lmdb=args.refresh_lmdb,
+            lmdb_map_size=args.lmdb_map_size,
         )
     else:
         if not args.dump.exists():
@@ -121,6 +271,9 @@ def main(argv: list[str] | None = None) -> int:
                     max_edges=args.max_edges,
                     output_root=args.output_root,
                     stream=proc.stdout,
+                    sink_lmdb=args.sink_lmdb,
+                    refresh_lmdb=args.refresh_lmdb,
+                    lmdb_map_size=args.lmdb_map_size,
                 )
             finally:
                 proc.stdout.close()

--- a/tests/test_prepare_csharp_query_enwiki_category_fixture.py
+++ b/tests/test_prepare_csharp_query_enwiki_category_fixture.py
@@ -6,6 +6,7 @@ import json
 import sys
 import tempfile
 import unittest
+from types import SimpleNamespace
 from io import StringIO
 from pathlib import Path
 
@@ -51,6 +52,93 @@ class PrepareCSharpQueryEnwikiCategoryFixtureTests(unittest.TestCase):
             self.assertEqual(metadata["scale"], "500k_cats")
             self.assertEqual(metadata["n_hierarchy_edges"], 2)
             self.assertEqual(metadata["mysql_rows_scanned"], 2)
+
+    def test_lmdb_sink_input_uses_capped_page_id_edge_rows_without_header(self) -> None:
+        self.assertEqual(
+            MODULE.lmdb_sink_input([("10", "20"), ("12", "20"), ("10", "22")]),
+            "10\t20\n12\t20\n10\t22\n",
+        )
+
+    def test_lmdb_consumer_env_uses_csharp_query_provider_compatible_defaults(self) -> None:
+        env = MODULE.lmdb_consumer_env(lmdb_path=Path("/tmp/category_parent.lmdb"), map_size=1234)
+        self.assertEqual(env["UW_LMDB_PATH"], "/tmp/category_parent.lmdb")
+        self.assertEqual(env["UW_LMDB_MAP_SIZE"], "1234")
+        self.assertEqual(env["UW_LMDB_DBNAME"], "main")
+        self.assertEqual(env["UW_LMDB_DUPSORT"], "1")
+        self.assertEqual(env["UW_KEY_COL"], "0")
+        self.assertEqual(env["UW_VAL_COL"], "1")
+        self.assertEqual(env["UW_KEY_ENCODING"], "utf8")
+        self.assertEqual(env["UW_VAL_ENCODING"], "utf8")
+
+    def test_write_lmdb_artifact_invokes_csharp_consumer_and_writes_manifest(self) -> None:
+        calls = []
+
+        def fake_run(*args, **kwargs):
+            calls.append((args, kwargs))
+            return SimpleNamespace(returncode=0, stdout="", stderr="ingest_to_lmdb (csharp): in=2 written=2 skipped=0")
+
+        original_which = MODULE.shutil.which
+        MODULE.shutil.which = lambda name: "/usr/bin/dotnet" if name == "dotnet" else original_which(name)
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                fixture_dir = Path(tmp)
+                (fixture_dir / "category_parent.tsv").write_text("child\tparent\n10\t20\n12\t22\n", encoding="utf-8")
+
+                manifest_path = MODULE.write_lmdb_artifact(
+                    fixture_dir=fixture_dir,
+                    edges=[("10", "20"), ("12", "22")],
+                    refresh=False,
+                    map_size=4096,
+                    run=fake_run,
+                )
+
+                self.assertEqual(manifest_path, fixture_dir / "category_parent.lmdb.manifest.json")
+                self.assertEqual(len(calls), 1)
+                command = calls[0][0][0]
+                kwargs = calls[0][1]
+                self.assertEqual(command[:2], ["dotnet", "run"])
+                self.assertEqual(kwargs["input"], "10\t20\n12\t22\n")
+                self.assertEqual(kwargs["env"]["UW_LMDB_PATH"], str(fixture_dir / "category_parent.lmdb"))
+                self.assertEqual(kwargs["env"]["UW_LMDB_MAP_SIZE"], "4096")
+
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                self.assertEqual(manifest["Format"], "unifyweaver.lmdb_relation.v1")
+                self.assertEqual(manifest["PredicateName"], "category_parent")
+                self.assertEqual(manifest["EnvironmentPath"], "category_parent.lmdb")
+                self.assertEqual(manifest["DatabaseName"], "main")
+                self.assertTrue(manifest["DupSort"])
+                self.assertEqual(manifest["KeyEncoding"], "utf8")
+                self.assertEqual(manifest["ValueEncoding"], "utf8")
+                self.assertEqual(manifest["RowCount"], 2)
+                self.assertEqual(manifest["SourceLength"], (fixture_dir / "category_parent.tsv").stat().st_size)
+        finally:
+            MODULE.shutil.which = original_which
+
+    def test_write_lmdb_artifact_reuses_existing_manifest_without_consumer(self) -> None:
+        def fail_run(*args, **kwargs):
+            raise AssertionError("consumer should not run when manifest and LMDB directory already exist")
+
+        original_which = MODULE.shutil.which
+        MODULE.shutil.which = lambda name: "/usr/bin/dotnet" if name == "dotnet" else original_which(name)
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                fixture_dir = Path(tmp)
+                (fixture_dir / "category_parent.lmdb").mkdir()
+                manifest_path = fixture_dir / "category_parent.lmdb.manifest.json"
+                manifest_path.write_text("{}\n", encoding="utf-8")
+
+                self.assertEqual(
+                    MODULE.write_lmdb_artifact(
+                        fixture_dir=fixture_dir,
+                        edges=[("10", "20")],
+                        refresh=False,
+                        map_size=4096,
+                        run=fail_run,
+                    ),
+                    manifest_path,
+                )
+        finally:
+            MODULE.shutil.which = original_which
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary

  - Add `--sink-lmdb`, `--refresh-lmdb`, and `--lmdb-map-size` to the C# enwiki category fixture prep helper.
  - Write reusable `category_parent.lmdb` artifacts plus `category_parent.lmdb.manifest.json` using the existing C#
  `lmdb_ingest` consumer.
  - Let the effective-distance artifact backend benchmark use prepared scale-local LMDB artifacts via `--use-scale-lmdb-
  artifact`.
  - Preserve Wikipedia page IDs for scale-local LMDB artifacts instead of forcing dense re-interning.
  - Document the staged path and leave true Rust-native direct-LMDB sinking as the next follow-up.

  ## Verification

  - `python3 -m unittest tests/test_prepare_csharp_query_enwiki_category_fixture.py tests/
  test_csharp_query_effective_distance_artifact_backends.py tests/test_csharp_query_lmdb_provider_smoke.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py examples/
  benchmark/prepare_csharp_query_enwiki_category_fixture.py tests/test_prepare_csharp_query_enwiki_category_fixture.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py --scales dev --lookup-keys 4
  --lookup-repetitions 1 --repetitions 1 --use-scale-lmdb-artifact --format tsv`
  - `git diff --check`