### PR TITLE
feat(wam-cpp): rules in assertz/retract (recursive predicates)

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -398,13 +398,14 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     helper_predicate_items(HelperItems),
     flatten_blocks([HelperItems|PerPredItems], AllItems),
     walk_blocks(AllItems, Labels, FlatInstrs0),
-    % Append ten trailing synthetic-return instructions for the
+    % Append eleven trailing synthetic-return instructions for the
     % meta-call control-flow surface — see WamState for each pc''s
     % role.
     append(FlatInstrs0,
            [catch_return, negation_return, findall_collect,
             conj_return, disj_alt, if_then_commit, if_then_else,
-            aggregate_next_group, dynamic_next_clause, sub_atom_next],
+            aggregate_next_group, dynamic_next_clause, sub_atom_next,
+            body_next],
            FlatInstrs),
     length(FlatInstrs0, CatchReturnPC),
     NegationReturnPC is CatchReturnPC + 1,
@@ -416,6 +417,7 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     AggregateNextGroupPC is CatchReturnPC + 7,
     DynamicNextClausePC is CatchReturnPC + 8,
     SubAtomNextPC is CatchReturnPC + 9,
+    BodyNextPC is CatchReturnPC + 10,
     findall(LabelLine, (
         member(NameStr-PC, Labels),
         format(atom(LabelLine),
@@ -443,6 +445,7 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     vm.aggregate_next_group_pc = ~w;
     vm.dynamic_next_clause_pc = ~w;
     vm.sub_atom_next_pc = ~w;
+    vm.body_next_pc = ~w;
 ~w
 ~w
 }
@@ -453,6 +456,7 @@ static const int _wam_cpp_setup_register = []() {
 ', [Reserve, CatchReturnPC, NegationReturnPC, FindallCollectPC,
     ConjReturnPC, DisjAltPC, IfThenCommitPC, IfThenElsePC,
     AggregateNextGroupPC, DynamicNextClausePC, SubAtomNextPC,
+    BodyNextPC,
     LabelBody, InstrBody]).
 
 % ============================================================================
@@ -1074,6 +1078,8 @@ instr_to_setup_line(dynamic_next_clause, _Labels, Line) :- !,
     Line = '    vm.instrs.push_back(Instruction::DynamicNextClause());'.
 instr_to_setup_line(sub_atom_next, _Labels, Line) :- !,
     Line = '    vm.instrs.push_back(Instruction::SubAtomNext());'.
+instr_to_setup_line(body_next, _Labels, Line) :- !,
+    Line = '    vm.instrs.push_back(Instruction::BodyNext());'.
 instr_to_setup_line(Instr, _Labels, Line) :-
     wam_instruction_to_cpp_literal(Instr, Lit),
     format(atom(Line), '    vm.instrs.push_back(~w);', [Lit]).
@@ -1447,7 +1453,7 @@ struct Instruction {
         SwitchOnConstant, SwitchOnStructure, SwitchOnTerm,
         CatchReturn, NegationReturn, FindallCollect, ConjReturn, DisjAlt,
         IfThenCommit, IfThenElse, AggregateNextGroup, DynamicNextClause,
-        SubAtomNext
+        SubAtomNext, BodyNext
     };
     // Sentinel pc values for switch-table entries that should not jump.
     static constexpr std::size_t SWITCH_DEFAULT = static_cast<std::size_t>(-1);
@@ -1567,6 +1573,8 @@ struct Instruction {
         { Instruction i; i.op = Op::DynamicNextClause; return i; }
     static Instruction SubAtomNext()
         { Instruction i; i.op = Op::SubAtomNext; return i; }
+    static Instruction BodyNext()
+        { Instruction i; i.op = Op::BodyNext; return i; }
 };
 
 struct TrailEntry {
@@ -1595,6 +1603,19 @@ struct ModeFrame {
     std::size_t expected_arity = 0; // Write: stop when args.size() reaches this
 };
 
+// Rule-body sequencing frame for the dynamic-database dispatcher.
+// Declared at namespace scope so ChoicePoint can snapshot a stack of
+// these for backtrack-into-body correctness — without that snapshot,
+// popping the frame forward (when the last goal succeeds) would
+// leave subsequent backtrack-into-goal-CPs unable to find their
+// frame, so the next-goal dispatch chain would unravel.
+struct BodyFrame {
+    std::vector<CellPtr> goals;
+    std::size_t next_idx = 0;
+    std::size_t after_pc = 0;
+    std::size_t base_cp_count = 0;
+};
+
 struct ChoicePoint {
     std::size_t alt_pc;
     std::size_t saved_cp;
@@ -1603,6 +1624,7 @@ struct ChoicePoint {
     std::unordered_map<std::string, CellPtr> saved_regs;
     std::vector<ModeFrame> saved_mode_stack;
     std::vector<EnvFrame> saved_env_stack;
+    std::vector<BodyFrame> saved_body_frames;
 };
 
 // Aggregate scope opened by BeginAggregate. Backtrack() finalises the
@@ -1829,6 +1851,14 @@ struct WamState {
     };
     std::vector<DynamicIterator> dynamic_iters;
     std::size_t dynamic_next_clause_pc = 0;
+    // Rule-body sequencing — see BodyFrame doc at namespace scope.
+    // Each rule body is flattened into a sequential goal list;
+    // body_next dispatches them one at a time with cp=body_next_pc.
+    // Frames are popped FORWARD when goals are exhausted; backtrack
+    // restores body_frames from the CP that fires (since CPs
+    // snapshot body_frames at push time).
+    std::vector<BodyFrame> body_frames;
+    std::size_t body_next_pc = 0;
     // Iteration state for sub_atom/5. Each entry holds the source
     // atom, the bound cells (Before/Length/After/Sub), the call''s
     // continuation, and the list of (before, length) pairs still
@@ -1943,6 +1973,9 @@ struct WamState {
     // after_pc; on no-match, undo trail and recurse (CP-style).
     // On exhausted iterator, pop and return false.
     bool    dynamic_try_next();
+    // body_next — dispatch the top BodyFrame''s next goal, or pop
+    // and proceed to outer after_pc when goals are exhausted.
+    bool    body_next();
     // sub_atom/5 — enumerate (Before, Length) tuples matching the
     // bound constraints. Pre-filters the candidate list at entry,
     // then iterates via the SubAtomIterator + sub_atom_next_pc CP
@@ -1988,6 +2021,15 @@ struct WamState {
     // same fresh cell). Used by throw/1 to snapshot the thrown term
     // before unwinding state.
     CellPtr deep_copy_term(CellPtr src);
+    // Same as above but with a pre-seeded var-name → cell rename map.
+    // Pre-seeded entries are NOT overwritten; deep_copy_term reuses
+    // them whenever it encounters an unbound var with that name. Used
+    // by dynamic_try_next to make head args share the caller''s cells
+    // (essential so unbound-unbound unification works correctly —
+    // our cell model doesn''t alias-via-ref).
+    CellPtr deep_copy_term_seeded(
+        CellPtr src,
+        std::unordered_map<std::string, CellPtr> seed);
 
     // ---- Builtin helpers ---------------------------------------------
     // Arithmetic: returns Integer or Float; sets ok=false on failure
@@ -2819,24 +2861,29 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
     }
 
     // ---- assertz/1, asserta/1, retract/1, retractall/1 -------------
-    // Dynamic database manipulation. This PR supports FACTS only —
-    // rules (Head :- Body) are accepted by the parser but not yet
-    // dispatched by the runtime, so storing them would silently
-    // discard the body. To keep behaviour predictable, the asserts
-    // reject ":- "/2 terms outright.
+    // Dynamic database manipulation. Both FACTS and RULES are
+    // supported — a rule is stored as a ":-/2"(Head, Body) compound,
+    // and dynamic_try_next decomposes it on dispatch (binding head
+    // args, then invoking body as a goal-term).
     //
     // Storage: dynamic_db["name/arity"] is a std::vector<CellPtr> of
-    // deep-copied fact terms. Dispatch is via dispatch_dynamic_call
-    // (see Call/Execute step arms).
+    // deep-copied clause terms. The key is derived from the head''s
+    // functor (or, for rules, from the head inside ":-/2").
     auto dyn_key_of = [&](const Value& v, std::string& out) -> bool {
+        // Rule form ":-/2"(Head, Body): index by Head''s functor.
+        if (v.tag == Value::Tag::Compound && v.s == ":-/2"
+            && v.args.size() == 2) {
+            Value head = deref(*v.args[0]);
+            if (head.tag == Value::Tag::Atom) { out = head.s + "/0"; return true; }
+            if (head.tag == Value::Tag::Compound) { out = head.s; return true; }
+            return false;
+        }
+        // Fact form: the term itself is the head.
         if (v.tag == Value::Tag::Atom) {
-            // ":- "/2 — rule form, deferred (facts only for this PR).
-            if (v.s == ":-/2") return false;
             out = v.s + "/0";
             return true;
         }
         if (v.tag == Value::Tag::Compound) {
-            if (v.s == ":-/2") return false;
             out = v.s; // already "name/arity"
             return true;
         }
@@ -3756,6 +3803,15 @@ bool WamState::step(const Instruction& instr) {
             if (!choice_points.empty()) choice_points.pop_back();
             return sub_atom_try_next();
         }
+        case Instruction::Op::BodyNext: {
+            // Reached after a dynamic-rule body goal succeeded
+            // (either forward via cp=body_next_pc, or via backtrack
+            // into a CP that landed at one of the body''s goals).
+            // body_next dispatches the next goal in the BodyFrame''s
+            // sequence, or pops the frame + proceeds to outer
+            // after_pc when exhausted.
+            return body_next();
+        }
         case Instruction::Op::Proceed: {
             if (cp == 0) { halt = true; return true; }
             pc = cp;
@@ -3778,6 +3834,7 @@ bool WamState::step(const Instruction& instr) {
             cp_.saved_regs = regs;
             cp_.saved_mode_stack = mode_stack;
             cp_.saved_env_stack = env_stack;
+            cp_.saved_body_frames = body_frames;
             choice_points.push_back(std::move(cp_));
             pc += 1; return true;
         }
@@ -4147,6 +4204,7 @@ bool WamState::dynamic_try_next() {
         cp_.saved_regs        = regs;
         cp_.saved_mode_stack  = mode_stack;
         cp_.saved_env_stack   = env_stack;
+        cp_.saved_body_frames = body_frames;
         choice_points.push_back(std::move(cp_));
     } else {
         // Last clause for this call — drop the iterator. It''s no
@@ -4154,30 +4212,114 @@ bool WamState::dynamic_try_next() {
         // ordinary backtrack at the OUTER scope.
         dynamic_iters.pop_back();
     }
-    // Fresh-rename the clause so vars in different call iterations
-    // (and the stored fact itself, which may share vars across
-    // multiple stored clauses if asserta/assertz ever supports them)
-    // don''t alias.
-    CellPtr fresh = deep_copy_term(db_it->second[idx]);
-    Value fv = deref(*fresh);
-    // Unify the call args with the clause''s args.
-    if (fv.tag == Value::Tag::Atom) {
-        // 0-arity fact. call_args must be empty; key match already
-        // covered the name + arity (so call_args.empty() is implied).
-        if (!call_args.empty()) return false;
-    } else if (fv.tag == Value::Tag::Compound) {
-        if (fv.args.size() != call_args.size()) return false;
+    // Build a rename seed for fresh-copy: when a top-level head var is
+    // unbound AND the matching call arg is also unbound, map the
+    // stored var''s name to the caller''s cell. This makes the head
+    // arg (and any body occurrences of the same var) SHARE the
+    // caller''s cell — essential because our cell model lacks a ref-
+    // chain for unbound-unbound unification, so a plain unify_cells
+    // would leave the two unbound cells unaliased.
+    CellPtr stored = db_it->second[idx];
+    Value stored_v = deref(*stored);
+    CellPtr stored_head = stored;
+    if (stored_v.tag == Value::Tag::Compound && stored_v.s == ":-/2"
+        && stored_v.args.size() == 2) {
+        stored_head = stored_v.args[0];
+    }
+    std::unordered_map<std::string, CellPtr> seed;
+    Value sh = deref(*stored_head);
+    if (sh.tag == Value::Tag::Compound
+        && sh.args.size() == call_args.size())
+    {
         for (std::size_t i = 0; i < call_args.size(); ++i) {
-            if (!unify_cells(call_args[i], fv.args[i])) return false;
+            Value harg = deref(*sh.args[i]);
+            Value carg = deref(*call_args[i]);
+            if (harg.is_unbound() && carg.is_unbound()) {
+                seed.emplace(harg.s, call_args[i]);
+            }
+        }
+    }
+    CellPtr fresh = deep_copy_term_seeded(stored, std::move(seed));
+    Value fv = deref(*fresh);
+    // Decompose: clauses are either bare heads (facts) or
+    // ":-/2"(Head, Body) compounds (rules). Body defaults to a "true"
+    // atom for facts so the common dispatch path is the same.
+    CellPtr head_cell;
+    CellPtr body_cell;
+    if (fv.tag == Value::Tag::Compound && fv.s == ":-/2"
+        && fv.args.size() == 2) {
+        head_cell = fv.args[0];
+        body_cell = fv.args[1];
+    } else {
+        head_cell = fresh;
+        body_cell = std::make_shared<Cell>(Value::Atom("true"));
+    }
+    Value hv = deref(*head_cell);
+    // Unify the call args with the head''s args.
+    if (hv.tag == Value::Tag::Atom) {
+        // 0-arity head — no args to bind. call_args must be empty;
+        // the key-match already covered name + arity.
+        if (!call_args.empty()) return false;
+    } else if (hv.tag == Value::Tag::Compound) {
+        if (hv.args.size() != call_args.size()) return false;
+        for (std::size_t i = 0; i < call_args.size(); ++i) {
+            if (!unify_cells(call_args[i], hv.args[i])) return false;
         }
     } else {
         return false;
     }
-    // Proceed to the call''s continuation.
-    if (saved_after_pc == 0) { halt = true; return true; }
-    pc = saved_after_pc;
-    cp = 0;
-    return true;
+    // Body == "true" → fact match completes; jump to continuation.
+    Value bv = deref(*body_cell);
+    if (bv.tag == Value::Tag::Atom && bv.s == "true") {
+        if (saved_after_pc == 0) { halt = true; return true; }
+        pc = saved_after_pc;
+        cp = 0;
+        return true;
+    }
+    // Otherwise build a BodyFrame from the flattened conjunction body
+    // and dispatch sequentially. The flattening avoids ConjFrame
+    // nesting on the shared conj_return_pc — see BodyFrame doc.
+    std::vector<CellPtr> goals;
+    std::function<void(CellPtr)> flatten = [&](CellPtr g) {
+        Value gv = deref(*g);
+        if (gv.tag == Value::Tag::Compound && gv.s == ",/2"
+            && gv.args.size() == 2)
+        {
+            flatten(gv.args[0]);
+            flatten(gv.args[1]);
+        } else {
+            goals.push_back(g);
+        }
+    };
+    flatten(body_cell);
+    BodyFrame bf;
+    bf.goals = std::move(goals);
+    bf.next_idx = 0;
+    bf.after_pc = saved_after_pc;
+    bf.base_cp_count = choice_points.size();
+    body_frames.push_back(std::move(bf));
+    return body_next();
+}
+
+// Dispatch the top BodyFrame''s next goal (with cp=body_next_pc so
+// subsequent BodyNext fires advance through the sequence), or pop
+// the frame and proceed to outer after_pc when exhausted. Forward
+// pop is safe because ChoicePoints snapshot body_frames at push
+// time; if a CP from inside this body fires later, it restores
+// body_frames including this frame, and dispatch resumes correctly.
+bool WamState::body_next() {
+    if (body_frames.empty()) return false;
+    BodyFrame& f = body_frames.back();
+    if (f.next_idx >= f.goals.size()) {
+        std::size_t after = f.after_pc;
+        body_frames.pop_back();
+        if (after == 0) { halt = true; return true; }
+        pc = after;
+        cp = 0;
+        return true;
+    }
+    CellPtr g = f.goals[f.next_idx++];
+    return invoke_goal_as_call(g, body_next_pc);
 }
 
 // sub_atom/5 dispatcher. Reads A1..A5, decides which dimensions are
@@ -4310,6 +4452,7 @@ bool WamState::sub_atom_try_next() {
         cp_.saved_regs        = regs;
         cp_.saved_mode_stack  = mode_stack;
         cp_.saved_env_stack   = env_stack;
+        cp_.saved_body_frames = body_frames;
         choice_points.push_back(std::move(cp_));
     }
     // Unify each output cell with its computed value.
@@ -4335,7 +4478,14 @@ bool WamState::sub_atom_try_next() {
 // in the copy. Used by throw/1 to snapshot the thrown term before
 // state-unwind tears down the goal''s bindings.
 CellPtr WamState::deep_copy_term(CellPtr src) {
-    std::unordered_map<std::string, CellPtr> rename;
+    return deep_copy_term_seeded(src, {});
+}
+
+CellPtr WamState::deep_copy_term_seeded(
+    CellPtr src,
+    std::unordered_map<std::string, CellPtr> seed)
+{
+    std::unordered_map<std::string, CellPtr> rename = std::move(seed);
     std::function<CellPtr(CellPtr)> rec = [&](CellPtr c) -> CellPtr {
         Value v = deref(*c);
         if (v.tag == Value::Tag::Unbound || v.tag == Value::Tag::Uninit) {
@@ -4380,10 +4530,16 @@ bool WamState::invoke_goal_as_call(CellPtr goal_cell, std::size_t after_pc) {
         }
         std::string key = g.s + "/0";
         auto it = labels.find(key);
-        if (it == labels.end()) return false;
-        cp = after_pc;
-        pc = it->second;
-        return true;
+        if (it != labels.end()) {
+            cp = after_pc;
+            pc = it->second;
+            return true;
+        }
+        // 0-arity dynamic predicate fallback.
+        if (dynamic_db.count(key)) {
+            return dispatch_dynamic_call(key, after_pc);
+        }
+        return false;
     }
     if (g.tag == Value::Tag::Compound) {
         // s is "<name>/<arity>".
@@ -4421,6 +4577,7 @@ bool WamState::invoke_goal_as_call(CellPtr goal_cell, std::size_t after_pc) {
             cp_.saved_regs        = regs;
             cp_.saved_mode_stack  = mode_stack;
             cp_.saved_env_stack   = env_stack;
+            cp_.saved_body_frames = body_frames;
             choice_points.push_back(std::move(cp_));
             return invoke_goal_as_call(g.args[0], if_then_commit_pc);
         }
@@ -4452,6 +4609,7 @@ bool WamState::invoke_goal_as_call(CellPtr goal_cell, std::size_t after_pc) {
                 cp_.saved_regs        = regs;
                 cp_.saved_mode_stack  = mode_stack;
                 cp_.saved_env_stack   = env_stack;
+                cp_.saved_body_frames = body_frames;
                 choice_points.push_back(std::move(cp_));
                 // Dispatch Cond with cp = if_then_commit_pc so
                 // success lands at the commit op.
@@ -4469,6 +4627,7 @@ bool WamState::invoke_goal_as_call(CellPtr goal_cell, std::size_t after_pc) {
             cp_.saved_regs        = regs;
             cp_.saved_mode_stack  = mode_stack;
             cp_.saved_env_stack   = env_stack;
+            cp_.saved_body_frames = body_frames;
             choice_points.push_back(std::move(cp_));
             DisjFrame df;
             df.second_goal = g.args[1];
@@ -4526,6 +4685,7 @@ bool WamState::invoke_goal_as_call(CellPtr goal_cell, std::size_t after_pc) {
             cp_.saved_regs        = regs;
             cp_.saved_mode_stack  = mode_stack;
             cp_.saved_env_stack   = env_stack;
+            cp_.saved_body_frames = body_frames;
             choice_points.push_back(std::move(cp_));
             return invoke_goal_as_call(g.args[0], if_then_commit_pc);
         }
@@ -4556,6 +4716,13 @@ bool WamState::invoke_goal_as_call(CellPtr goal_cell, std::size_t after_pc) {
             cp = after_pc;
             pc = it->second;
             return true;
+        }
+        // Dynamic predicate path: when a rule''s body invokes a
+        // dynamic predicate (or a goal-term arg to catch/findall/etc.
+        // names one), we route through dispatch_dynamic_call so the
+        // clause-iteration CP machinery handles backtracking.
+        if (dynamic_db.count(key)) {
+            return dispatch_dynamic_call(key, after_pc);
         }
         // Builtin path: run the builtin inline. On success, jump to
         // the catch continuation (overriding the pc advance builtin()
@@ -4754,6 +4921,7 @@ bool WamState::aggregate_bind_next_group() {
         cp_.saved_regs        = regs;
         cp_.saved_mode_stack  = mode_stack;
         cp_.saved_env_stack   = env_stack;
+        cp_.saved_body_frames = body_frames;
         choice_points.push_back(std::move(cp_));
     }
     // Bind witness cells to this group''s witness values.
@@ -4976,6 +5144,16 @@ bool WamState::backtrack() {
             conj_frames.pop_back();
             continue;
         }
+        // BodyFrame: a dynamic rule''s body sequence ran out of CPs
+        // for one of its goals. Drop the frame so failure propagates
+        // out of the rule and the outer dynamic_try_next (if any)
+        // can try the next clause.
+        if (!body_frames.empty()
+            && choice_points.size() <= body_frames.back().base_cp_count)
+        {
+            body_frames.pop_back();
+            continue;
+        }
         // Negation frame: if the \\+ / not protected goal exhausted
         // all its CPs (i.e. the goal FAILED), pop the frame, unwind
         // state, and SUCCEED at saved_cp. Symmetric inverse of the
@@ -5161,6 +5339,7 @@ bool WamState::backtrack() {
         regs        = cp_.saved_regs;
         mode_stack  = cp_.saved_mode_stack;
         env_stack   = cp_.saved_env_stack;
+        body_frames = std::move(cp_.saved_body_frames);
         cp          = cp_.saved_cp;
         cut_barrier = cp_.cut_barrier;
         pc          = cp_.alt_pc;

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -1026,6 +1026,76 @@ user:wam_cpp_test_sub_atom_enum_all :-
     findall(S, sub_atom(ab, _, _, _, S), L),
     L = ['', a, ab, '', b, ''].
 
+% Rules in assertz/retract — extends #2136 (facts only). A rule is
+% stored as a ":-/2"(Head, Body) compound; dynamic_try_next decomposes
+% it on dispatch, unifies the head args with call args, and runs the
+% body through a BodyFrame (flattened conjunction sequence). The
+% BodyFrame mechanism replaces ConjFrame for rule bodies — ConjFrame
+% nests on a shared conj_return_pc that fires the wrong frame for
+% recursive predicates. ChoicePoints snapshot body_frames at push
+% time so backtrack-into-a-goal''s-CP restores the surrounding
+% rule body context.
+:- dynamic user:wam_cpp_test_rule_simple/0.
+:- dynamic user:wam_cpp_test_rule_conj/0.
+:- dynamic user:wam_cpp_test_rule_mixed_facts_and_rule/0.
+:- dynamic user:wam_cpp_test_rule_body_fails/0.
+:- dynamic user:wam_cpp_test_rule_recursive/0.
+:- dynamic user:wam_cpp_test_rule_backtrack_in_body/0.
+:- dynamic user:wam_cpp_test_retract_rule/0.
+
+user:wam_cpp_test_rule_simple :-
+    assertz((wam_cpp_dyn_pos(X) :- X > 5)),
+    wam_cpp_dyn_pos(10).
+
+user:wam_cpp_test_rule_conj :-
+    assertz((wam_cpp_dyn_dbl(X, Y) :- X > 0, Y is X * 2)),
+    wam_cpp_dyn_dbl(3, Y),
+    Y = 6.
+
+% Mixed: 2 facts + 1 (non-recursive) rule, findall via the head.
+% Note rule body is `true` to avoid infinite recursion through the
+% predicate''s own clauses.
+user:wam_cpp_test_rule_mixed_facts_and_rule :-
+    assertz(wam_cpp_dyn_t(a, 1)),
+    assertz(wam_cpp_dyn_t(b, 2)),
+    assertz((wam_cpp_dyn_t(c, 99) :- true)),
+    findall(K-V, wam_cpp_dyn_t(K, V), L),
+    L = [a-1, b-2, c-99].
+
+% Rule body fails on the call argument — the whole call fails.
+user:wam_cpp_test_rule_body_fails :-
+    assertz((wam_cpp_dyn_only_pos(X) :- X > 0)),
+    \+ wam_cpp_dyn_only_pos(-3).
+
+% Classic list-length recursion. Exercises BodyFrame chaining with
+% nested recursive calls, and ChoicePoint''s saved_body_frames
+% (since the recursive call''s outer body_frame must be restored
+% when backtrack fires a CP from inside the recursion).
+user:wam_cpp_test_rule_recursive :-
+    assertz(wam_cpp_dyn_len([], 0)),
+    assertz((wam_cpp_dyn_len([_|T], N) :- wam_cpp_dyn_len(T, M),
+                                          N is M + 1)),
+    wam_cpp_dyn_len([a, b, c], N),
+    N = 3.
+
+% Backtrack inside a rule body. A single clause whose body is
+% nondeterministic (member/2 enumerates 3 solutions); findall over
+% the rule collects all 3 — the body''s CPs must propagate up so
+% findall''s force-backtrack re-enters them.
+user:wam_cpp_test_rule_backtrack_in_body :-
+    assertz((wam_cpp_dyn_pick(X) :- member(X, [1, 2, 3]))),
+    findall(X, wam_cpp_dyn_pick(X), L),
+    L = [1, 2, 3].
+
+% retract a rule by its full ":-/2"(Head, Body) form — only the
+% pattern-matching clause is removed; remaining clauses are intact.
+user:wam_cpp_test_retract_rule :-
+    assertz((wam_cpp_dyn_r(X) :- X > 5)),
+    assertz((wam_cpp_dyn_r(X) :- X < 0)),
+    retract((wam_cpp_dyn_r(X) :- X > 5)),
+    \+ wam_cpp_dyn_r(10),
+    wam_cpp_dyn_r(-1).
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -3883,6 +3953,111 @@ test(cpp_e2e_sub_atom_enum_all,
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath,
                     'wam_cpp_test_sub_atom_enum_all/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% Rules in assertz/retract — completes the dynamic-database story
+% from #2136. Rules are stored as ":-/2"(Head, Body) compounds and
+% dispatched by flattening Body into a sequential goal list (a
+% BodyFrame), with ChoicePoints snapshotting body_frames so that
+% backtrack into any goal''s CP restores the correct rule context.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_rule_simple, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_rule_simple', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_rule_simple/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_rule_simple/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_rule_conj, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_rule_conj', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_rule_conj/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_rule_conj/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_rule_mixed_facts_and_rule,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_rule_mixed', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_test_rule_mixed_facts_and_rule/0],
+            [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_rule_mixed_facts_and_rule/0',
+                    [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_rule_body_fails, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_rule_body_fails', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_rule_body_fails/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_rule_body_fails/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_rule_recursive, [condition(cpp_compiler_available)]) :-
+    % Recursion regression guard: 3-deep list-length needs both
+    % BodyFrame (so nested rule-body conjunctions don''t loop on
+    % shared conj_return_pc) and ChoicePoint::saved_body_frames
+    % (so backtrack from a deeper level''s body CP restores the
+    % outer rule''s body_frame context).
+    unique_cpp_tmp_dir('tmp_cpp_e2e_rule_recursive', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_rule_recursive/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_rule_recursive/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_rule_backtrack_in_body,
+     [condition(cpp_compiler_available)]) :-
+    % Body of an asserted rule is itself nondet (member/2).
+    % findall must re-enter the body''s member CP after the first
+    % solution; that''s the path that exercises body_frames
+    % restoration via the CP.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_rule_bt', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_test_rule_backtrack_in_body/0],
+            [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_rule_backtrack_in_body/0',
+                    [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_retract_rule, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_retract_rule', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_retract_rule/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_retract_rule/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Completes the dynamic-database story from #2136. Asserts now accept rules `(Head :- Body)`, stored as `":-/2"(Head, Body)` compounds and indexed by `Head`'s functor. Recursive predicates work (list-length, etc.), and rule bodies can be arbitrary conjunctions / nondet goals.

## Two new mechanisms

### 1. `BodyFrame` + `body_next_pc` + `body_next()`

Rule bodies are flattened into a sequential goal list (walking `,/2` right-recursively) and dispatched one at a time with `cp=body_next_pc`. This replaces `ConjFrame` for rule bodies because `ConjFrame` nests on a single shared `conj_return_pc`: when a rule body calls another rule with its own conjunction body, the inner's continuation lands at the shared `conj_return_pc` and fires the inner's frame **again** — infinite loop. `BodyFrame` avoids that by popping forward when goals are exhausted and proceeding to the outer rule's `body_next_pc`, which correctly dispatches the outer's next goal.

### 2. `ChoicePoint::saved_body_frames`

Every CP push snapshots the `body_frames` stack. On backtrack, `body_frames` is restored to its state at CP-push time. This makes the forward-pop in (1) safe: if a CP from inside a rule body fires later (e.g. findall force-backtrack re-enters a `member/2` alternative nested in a rule body), `body_frames` is restored including the surrounding rule's frame, so dispatch continues correctly.

## Other fixes

- **`invoke_goal_as_call` didn't check `dynamic_db`** — a rule body invoking another dynamic predicate (or catch/findall with a dynamic-predicate goal-term) would fall to the builtin path and silently fail. Added `dynamic_db` lookup between the labels and builtin paths for both compound and 0-arity goal forms.

- **`deep_copy_term_seeded`** — new variant taking a pre-seeded var-name → cell rename map. `dynamic_try_next` uses it to make head args **share** the caller's cells when both sides are unbound, working around the cell model's lack of ref-chain aliasing in `unify_cells` (which would otherwise leave two unbound cells unaliased, breaking any subsequent binding through one of them).

## Test plan

- [x] 7 new e2e tests:
  - Simple rule with arith body
  - Conjunction body
  - Mixed facts + rule
  - Body fails → call fails
  - Recursive list-length (depth-3)
  - `findall` over rule with nondet body — exercises the `saved_body_frames` restore path
  - `retract` by full `(Head :- Body)` pattern
- [x] Full `test_wam_cpp_generator.pl` suite passes
- [x] `test_wam_target.pl` passes

## Known limitations / deferred

- `retract/1` is still deterministic (first match). Nondet retract — backtracking to subsequent matches — needs a `RetractIterator` similar to `DynamicIterator`. Deferred to a follow-up.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_