### PR TITLE
feat(wam): add runtime parser capability hook

### DIFF
--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
@@ -74,9 +74,13 @@ The initial implementation is intentionally small:
 - targets without runtime source-term parsing resolve to `none`;
 - `compiled(prolog_term_parser)` is available only for targets
   with compile and runtime proof tests.
+- the R project writer records the resolved mode in the generated
+  `shared_program$runtime_parser` metadata.
 
 Do not immediately wire every target's `write_wam_*_project/3` through the new
 hook. The hook is a stable contract; target writers can migrate one at a time.
+For R, builtin routing still uses the native inline parser hot path while the
+metadata provides a stable seam for later experiments.
 
 The hook should be independent of the WAM items API. A target can skip WAM text
 generation at build time and still need runtime source-term parsing.

--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
@@ -56,9 +56,27 @@ equivalent and performance-credible.
 
 ## Phase 5: Generalize The Target Hook
 
-Add a target capability hook for runtime parser inclusion. The hook should
-answer whether a generated runtime needs the parser library and how the target
-should expose parser entry points to builtins.
+The target capability hook for runtime parser inclusion lives in
+`src/unifyweaver/targets/wam_runtime_parser_capability.pl`:
+
+```prolog
+wam_target_runtime_parser(+Target, +Options, -Mode)
+```
+
+`Mode` is `none`, `native(Entry)`, or `compiled(prolog_term_parser)`.
+`Options` accepts
+`runtime_parser(auto|off|native|compiled)`.
+
+The initial implementation is intentionally small:
+
+- the shared predicate and tests cover option resolution;
+- R is registered as `native(parse_term)` by default;
+- targets without runtime source-term parsing resolve to `none`;
+- `compiled(prolog_term_parser)` is available only for targets
+  with compile and runtime proof tests.
+
+Do not immediately wire every target's `write_wam_*_project/3` through the new
+hook. The hook is a stable contract; target writers can migrate one at a time.
 
 The hook should be independent of the WAM items API. A target can skip WAM text
 generation at build time and still need runtime source-term parsing.

--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
@@ -40,7 +40,52 @@ The parser must not own mutable operator state. Runtime predicates such as
 `op/3` and `current_op/3` belong to the target runtime. Before a parse, the
 runtime passes the parser a snapshot derived from its current table.
 
-## Required Consumers
+## Target Capability Hook
+
+Each WAM target exposes its runtime parser posture through the shared
+generator-side hook in `src/unifyweaver/targets/wam_runtime_parser_capability.pl`:
+
+```prolog
+%% wam_target_runtime_parser(+Target, +Options, -Mode)
+%
+%  Mode is one of:
+%    none
+%      The generated runtime has no source-term parser.
+%    native(Entry)
+%      The target has a hand-written parser entry point named by Entry.
+%    compiled(SourceModule)
+%      The target should include the portable Prolog parser module and call
+%      the generated wrapper predicates.
+%
+%  Options may override the target default:
+%    runtime_parser(off)       -> none
+%    runtime_parser(native)    -> native(...) if the target supports one
+%    runtime_parser(compiled)  -> compiled(prolog_term_parser)
+%    runtime_parser(auto)      -> target default
+```
+
+The hook is a generator contract, not a runtime predicate. It lets project
+writers decide whether to include parser library predicates, whether parser
+builtins should dispatch to a native parser, and whether a target should reject
+parser-dependent builtins at generation time.
+
+The same module also defines `parser_dependent_builtin/1`, the catalogue of
+builtins that require runtime source-term parsing.
+
+Target defaults should be conservative:
+
+- targets with a fast existing runtime parser, such as R, default to
+  `native(...)`;
+- targets without a parser default to `none`;
+- targets may opt into `compiled(prolog_term_parser)` only after they can run
+  the portable parser's compile and runtime tests.
+
+The generated runtime should expose only one builtin-facing parser entry point
+per target. A target may keep both native and compiled parsers for testing, but
+`read/2`, `read_term_from_atom/2,3`, reverse `term_to_atom/2`, and CLI parsing
+should route through the selected mode consistently.
+
+## Required Consumers And Inclusion
 
 Targets that expose the corresponding predicates should route these operations
 through the runtime parser:
@@ -52,6 +97,18 @@ through the runtime parser:
 
 Targets may also use the same parser for CLI argument decoding, REPL input, or
 runtime data-file ingestion.
+
+When `wam_target_runtime_parser/3` returns `compiled(prolog_term_parser)`, the
+project writer must add `src/unifyweaver/core/prolog_term_parser.pl` predicates
+to the generated project before compiling parser-dependent drivers. Inclusion
+should be demand-driven by default: if no emitted builtin or target feature
+needs runtime source-term parsing, the parser library should not be included.
+
+When the selected mode is `none`, parser-dependent builtins must either be
+omitted from the target's advertised capability set or fail with a clear
+generation-time diagnostic. Silent runtime stubs are not acceptable for new
+targets because parser failure is otherwise hard to distinguish from ordinary
+predicate failure.
 
 ## Stream Read Semantics
 

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -65,6 +65,8 @@
 ]).
 :- use_module('../core/recursive_kernel_detection',
              [detect_recursive_kernel/4, kernel_config/2]).
+:- use_module(wam_runtime_parser_capability,
+             [wam_target_runtime_parser/3]).
 
 % ============================================================================
 % EMIT MODE
@@ -1743,6 +1745,8 @@ write_wam_r_project(Predicates, Options, ProjectDir) :-
     directory_file_path(ProjectDir, 'R', RDir),
     make_directory_path(RDir),
     option(module_name(ModName), Options, 'wam.r.generated'),
+    wam_target_runtime_parser(wam_r, Options, RuntimeParserMode),
+    r_runtime_parser_mode_literal(RuntimeParserMode, RuntimeParserModeCode),
     write_description(ProjectDir, ModName),
     compile_predicates_for_project(Predicates, Options,
         AllInstrs, TopLevelLabelEntries, AllLabelEntries,
@@ -1760,7 +1764,8 @@ write_wam_r_project(Predicates, Options, ProjectDir) :-
     write_program_source(RDir, InstrBody, LabelBody, DispatchBody,
                          WrapperCode, IdToStringStr, ForeignHandlersBody,
                          LoweredFunctionsCode, FactShapeComments,
-                         LoweredDispatchCode, OpDeclsBody).
+                         LoweredDispatchCode, OpDeclsBody,
+                         RuntimeParserModeCode).
 
 write_description(ProjectDir, ModName) :-
     find_template('templates/targets/r_wam/DESCRIPTION.mustache', Template),
@@ -1780,7 +1785,8 @@ write_runtime_source(RDir) :-
 write_program_source(RDir, InstrBody, LabelBody, DispatchBody,
                      WrapperCode, IdToStringStr, ForeignHandlersBody,
                      LoweredFunctionsCode, FactShapeComments,
-                     LoweredDispatchCode, OpDeclsBody) :-
+                     LoweredDispatchCode, OpDeclsBody,
+                     RuntimeParserModeCode) :-
     find_template('templates/targets/r_wam/program.R.mustache', Template),
     get_time(T), format_time(string(DateStr), "%Y-%m-%d", T),
     render_template(Template,
@@ -1794,10 +1800,25 @@ write_program_source(RDir, InstrBody, LabelBody, DispatchBody,
           'foreign_handlers'=ForeignHandlersBody,
           'lowered_functions'=LoweredFunctionsCode,
           'fact_shape_comments'=FactShapeComments,
-          'op_decls'=OpDeclsBody
+          'op_decls'=OpDeclsBody,
+          'runtime_parser_mode'=RuntimeParserModeCode
         ], Content),
     directory_file_path(RDir, 'generated_program.R', Path),
     write_file(Path, Content).
+
+r_runtime_parser_mode_literal(none,
+    'list(kind = "none", entry = NULL, source = NULL)') :- !.
+r_runtime_parser_mode_literal(native(Entry), Code) :-
+    !,
+    r_string_literal_atom(Entry, EntryLit),
+    format(string(Code),
+           'list(kind = "native", entry = ~w, source = NULL)',
+           [EntryLit]).
+r_runtime_parser_mode_literal(compiled(SourceModule), Code) :-
+    r_string_literal_atom(SourceModule, SourceLit),
+    format(string(Code),
+           'list(kind = "compiled", entry = NULL, source = ~w)',
+           [SourceLit]).
 
 % ============================================================================
 % HELPERS

--- a/src/unifyweaver/targets/wam_runtime_parser_capability.pl
+++ b/src/unifyweaver/targets/wam_runtime_parser_capability.pl
@@ -1,0 +1,79 @@
+:- module(wam_runtime_parser_capability, [
+    wam_target_runtime_parser/3,
+    parser_dependent_builtin/1,
+    target_supports_runtime_parser_mode/2
+]).
+
+:- use_module(library(error)).
+:- use_module(library(option)).
+
+%% wam_target_runtime_parser(+Target, +Options, -Mode)
+%
+% Resolve the runtime Prolog-term parser mode for a WAM target.
+% Mode is one of:
+%   - none
+%   - native(Entry)
+%   - compiled(prolog_term_parser)
+%
+% Options:
+%   - runtime_parser(auto)     target default
+%   - runtime_parser(off)      no source-term parser
+%   - runtime_parser(native)   require a native target parser
+%   - runtime_parser(compiled) require the portable compiled parser
+wam_target_runtime_parser(Target, Options, Mode) :-
+    must_be(atom, Target),
+    must_be(list, Options),
+    normalize_runtime_parser_target(Target, Canonical),
+    option(runtime_parser(Request), Options, auto),
+    resolve_runtime_parser_request(Request, Canonical, Mode).
+
+%% parser_dependent_builtin(?Name/Arity)
+%
+% Builtins/features that need source text parsed into runtime terms.
+parser_dependent_builtin(read/2).
+parser_dependent_builtin(read_term_from_atom/2).
+parser_dependent_builtin(read_term_from_atom/3).
+parser_dependent_builtin(term_to_atom/2).
+
+%% target_supports_runtime_parser_mode(+Target, ?Mode)
+%
+% Capability facts used by the resolver. Keep this conservative:
+% only advertise compiled parser support for targets with compile and
+% runtime proof tests.
+target_supports_runtime_parser_mode(Target, Mode) :-
+    must_be(atom, Target),
+    normalize_runtime_parser_target(Target, Canonical),
+    target_runtime_parser_mode_(Canonical, Mode).
+
+resolve_runtime_parser_request(auto, Target, Mode) :-
+    !,
+    (   target_runtime_parser_default(Target, Mode)
+    ->  true
+    ;   Mode = none
+    ).
+resolve_runtime_parser_request(off, _Target, none) :- !.
+resolve_runtime_parser_request(native, Target, Mode) :-
+    !,
+    (   target_supports_runtime_parser_mode(Target, Mode),
+        Mode = native(_)
+    ->  true
+    ;   domain_error(runtime_parser_mode(Target), native)
+    ).
+resolve_runtime_parser_request(compiled, Target, Mode) :-
+    !,
+    (   target_supports_runtime_parser_mode(Target,
+                                            compiled(prolog_term_parser))
+    ->  Mode = compiled(prolog_term_parser)
+    ;   domain_error(runtime_parser_mode(Target), compiled)
+    ).
+resolve_runtime_parser_request(Request, _Target, _Mode) :-
+    domain_error(runtime_parser_request, Request).
+
+target_runtime_parser_default(wam_r, native(parse_term)).
+
+target_runtime_parser_mode_(wam_r, native(parse_term)).
+target_runtime_parser_mode_(wam_r, compiled(prolog_term_parser)).
+
+normalize_runtime_parser_target(r, wam_r) :- !.
+normalize_runtime_parser_target(wam_r, wam_r) :- !.
+normalize_runtime_parser_target(Target, Target).

--- a/templates/targets/r_wam/program.R.mustache
+++ b/templates/targets/r_wam/program.R.mustache
@@ -72,6 +72,11 @@ shared_program <- list(
   dispatch         = dispatch,
   foreign_handlers = foreign_handlers,
   intern_table     = intern_table,
+  # Runtime source-term parser mode resolved by
+  # wam_runtime_parser_capability:wam_target_runtime_parser/3.
+  # The R hot path is native(parse_term); compiled parser metadata is
+  # kept for equivalence experiments and later routing work.
+  runtime_parser   = {{runtime_parser_mode}},
   # Dynamic predicate store for runtime assertz/asserta/retract.
   # Keyed by "pred/arity"; each value is a list of clause records
   # of shape list(head_args, body). An env (rather than a list) so

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -93,6 +93,34 @@ test(intern_and_instructions) :-
         delete_directory_and_contents(TmpDir)
     )).
 
+test(runtime_parser_mode_metadata) :-
+    once((
+        unique_r_tmp_dir('tmp_r_parser_mode', TmpDir),
+        write_wam_r_project(
+            [user:wam_r_fact/1],
+            [],
+            TmpDir),
+        directory_file_path(TmpDir, 'R/generated_program.R', Program),
+        read_file_to_string(Program, Code, []),
+        assertion(sub_string(Code, _, _, _,
+                             'runtime_parser   = list(kind = "native", entry = "parse_term", source = NULL)')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+test(runtime_parser_mode_option_off) :-
+    once((
+        unique_r_tmp_dir('tmp_r_parser_mode_off', TmpDir),
+        write_wam_r_project(
+            [user:wam_r_fact/1],
+            [runtime_parser(off)],
+            TmpDir),
+        directory_file_path(TmpDir, 'R/generated_program.R', Program),
+        read_file_to_string(Program, Code, []),
+        assertion(sub_string(Code, _, _, _,
+                             'runtime_parser   = list(kind = "none", entry = NULL, source = NULL)')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
 % ------------------------------------------------------------------
 % Test 4: label map carries the predicate entry
 % ------------------------------------------------------------------

--- a/tests/test_wam_runtime_parser_capability.pl
+++ b/tests/test_wam_runtime_parser_capability.pl
@@ -1,0 +1,45 @@
+:- use_module(library(plunit)).
+:- use_module('../src/unifyweaver/targets/wam_runtime_parser_capability').
+
+:- begin_tests(wam_runtime_parser_capability).
+
+test(r_defaults_to_native_parser) :-
+    wam_target_runtime_parser(wam_r, [], native(parse_term)).
+
+test(r_alias_defaults_to_native_parser) :-
+    wam_target_runtime_parser(r, [], native(parse_term)).
+
+test(off_disables_parser_even_for_r) :-
+    wam_target_runtime_parser(wam_r, [runtime_parser(off)], none).
+
+test(r_can_require_native_parser) :-
+    wam_target_runtime_parser(wam_r, [runtime_parser(native)],
+                              native(parse_term)).
+
+test(r_can_opt_into_compiled_parser) :-
+    wam_target_runtime_parser(wam_r, [runtime_parser(compiled)],
+                              compiled(prolog_term_parser)).
+
+test(unknown_target_defaults_to_none) :-
+    wam_target_runtime_parser(wam_lua, [], none).
+
+test(unknown_target_native_request_errors,
+     [error(domain_error(runtime_parser_mode(wam_lua), native))]) :-
+    wam_target_runtime_parser(wam_lua, [runtime_parser(native)], _).
+
+test(unknown_target_compiled_request_errors,
+     [error(domain_error(runtime_parser_mode(wam_lua), compiled))]) :-
+    wam_target_runtime_parser(wam_lua, [runtime_parser(compiled)], _).
+
+test(invalid_request_errors,
+     [error(domain_error(runtime_parser_request, bogus))]) :-
+    wam_target_runtime_parser(wam_r, [runtime_parser(bogus)], _).
+
+test(parser_dependent_builtin_catalogue) :-
+    findall(PI, parser_dependent_builtin(PI), PIs),
+    assertion(PIs == [read/2,
+                      read_term_from_atom/2,
+                      read_term_from_atom/3,
+                      term_to_atom/2]).
+
+:- end_tests(wam_runtime_parser_capability).


### PR DESCRIPTION
## Summary

Adds a shared WAM runtime-parser capability resolver and wires the R project writer to record its selected parser mode.

This follows the runtime parser transpilation design: targets should explicitly report whether they have no runtime parser, a native parser, or an opt-in compiled `prolog_term_parser` path.

## Details

- Adds `wam_runtime_parser_capability.pl` with:
  - `wam_target_runtime_parser/3`
  - `parser_dependent_builtin/1`
  - `target_supports_runtime_parser_mode/2`
- Supports `runtime_parser(auto|off|native|compiled)` option resolution.
- Registers WAM-R as `native(parse_term)` by default.
- Allows WAM-R to opt into `compiled(prolog_term_parser)` for experiments and proof tests.
- Defaults unknown targets to `none`, while explicit unsupported `native` / `compiled` requests raise domain errors.
- Records the resolved parser mode in generated R `shared_program$runtime_parser` metadata.
- Updates runtime parser transpilation docs to describe the hook and R integration.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_runtime_parser_capability.pl`
- `swipl -q -g run_tests -t halt tests/test_prolog_term_parser.pl`
- `swipl -q -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:runtime_parser_mode_metadata,wam_r_generator:runtime_parser_mode_option_off])" -t halt`
- `git diff --check HEAD`

## Notes

This does not switch R builtins away from the native inline parser. R still uses the inline parser as the hot path; the new metadata gives later target writers and experiments a stable capability contract.
