### PR TITLE
Feat/wam go fact source registry

### DIFF
--- a/PR_go_wam_fact_source_registry.md
+++ b/PR_go_wam_fact_source_registry.md
@@ -1,0 +1,31 @@
+# PR Title
+
+Add Go WAM atom fact-source registry
+
+# PR Description
+
+## Summary
+
+- Adds a Go WAM `AtomFact2Source` interface with `Scan` and `LookupArg1`.
+- Registers inline indexed atom facts and TSV-backed atom facts through the same source registry.
+- Keeps `IndexedAtomFactPairs` populated so existing native graph/kernel paths continue to work unchanged.
+- Routes `call_indexed_atom_fact2` through registered fact sources before falling back to stored pairs.
+- Updates the Go WAM parity audit to mark the Haskell-shaped fact-source abstraction as present while leaving concrete LMDB support as the remaining direct-fact parity gap.
+- Fixes Go generator test isolation so combined Prolog test runs do not inherit stale atom-intern state from earlier suites.
+
+## Verification
+
+```sh
+swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
+swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl tests/test_wam_go_generator.pl tests/test_go_wam_builtins.pl
+git diff --check
+```
+
+## Follow-Up
+
+- Add a concrete LMDB-backed `AtomFact2Source` implementation if Go should close the remaining direct-fact parity gap against Haskell.

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -9,7 +9,7 @@ current cross-target builtin/runtime baseline.
 | Area | Go support | Rust/Haskell baseline | Status |
 | --- | --- | --- | --- |
 | Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries, `member/2` builtin retries | Choice point stack with normal, builtin, and fact-stream resume states | Partial |
-| Direct fact dispatch | `call_indexed_atom_fact2`, TSV-backed atom fact loading, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Partial: no LMDB FactSource adaptor |
+| Direct fact dispatch | `call_indexed_atom_fact2`, `AtomFact2Source` registry, TSV-backed atom fact loading, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Partial: no LMDB FactSource adaptor |
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
 | Structural builtins | `member/2`, `length/2`, `append/3` | `member/2`, `length/2`; Rust `append/3` is explicitly unimplemented | Present for current baseline structural checks |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
@@ -44,13 +44,16 @@ current cross-target builtin/runtime baseline.
   including backtracking over multiple indexed atom facts.
 - Headered two-column TSV files can now be loaded into Go WAM indexed atom
   fact tables and queried through `call_indexed_atom_fact2`.
+- Inline and TSV atom fact pairs now register through a Go `AtomFact2Source`
+  interface with `Scan` and `LookupArg1`, matching the Haskell FactSource shape
+  while preserving the existing indexed pair table used by native kernels.
 
 ## Recommended Follow-Up Order
 
-1. Continue broadening generated Go WAM E2E coverage for control and external
-   fact-source behavior that remains marked partial.
-2. Compare Go LMDB adapters against Rust/Haskell LMDB FactSource paths if Go
-   should close the remaining direct-fact parity gap.
+1. Add a concrete LMDB-backed `AtomFact2Source` implementation if Go should
+   close the remaining direct-fact parity gap.
+2. Continue broadening generated Go WAM E2E coverage for control behavior that
+   remains marked partial.
 
 ## Verification Commands
 

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -2270,6 +2270,15 @@ func (vm *WamState) registerForeignUsizeConfig(predKey string, key string, value
 
 func (vm *WamState) registerIndexedAtomFact2Pairs(predKey string, pairs []AtomPair) {
     vm.Ctx.IndexedAtomFactPairs[predKey] = pairs
+    vm.registerAtomFact2Source(predKey, newStaticAtomFact2Source(pairs))
+}
+
+func (vm *WamState) registerAtomFact2Source(predKey string, source AtomFact2Source) {
+    if source == nil {
+        return
+    }
+    vm.Ctx.AtomFact2Sources[predKey] = source
+    vm.Ctx.IndexedAtomFactPairs[predKey] = source.Scan()
 }
 
 func (vm *WamState) registerTsvAtomFact2(predKey string, path string) error {
@@ -2298,7 +2307,7 @@ func (vm *WamState) registerTsvAtomFact2(predKey string, path string) error {
         }
         pairs = append(pairs, AtomPair{Left: left, Right: right})
     }
-    vm.registerIndexedAtomFact2Pairs(predKey, pairs)
+    vm.registerAtomFact2Source(predKey, newStaticAtomFact2Source(pairs))
     return nil
 }
 
@@ -2336,6 +2345,34 @@ func parseForeignTupleLayout(layout string) int {
         return arity
     }
     return 0
+}
+
+type staticAtomFact2Source struct {
+    pairs []AtomPair
+    byLeft map[string][]AtomPair
+}
+
+func newStaticAtomFact2Source(pairs []AtomPair) *staticAtomFact2Source {
+    copied := append([]AtomPair(nil), pairs...)
+    byLeft := make(map[string][]AtomPair)
+    for _, pair := range copied {
+        byLeft[pair.Left] = append(byLeft[pair.Left], pair)
+    }
+    return &staticAtomFact2Source{pairs: copied, byLeft: byLeft}
+}
+
+func (source *staticAtomFact2Source) Scan() []AtomPair {
+    if source == nil {
+        return nil
+    }
+    return append([]AtomPair(nil), source.pairs...)
+}
+
+func (source *staticAtomFact2Source) LookupArg1(left string) []AtomPair {
+    if source == nil {
+        return nil
+    }
+    return append([]AtomPair(nil), source.byLeft[left]...)
 }
 
 func (vm *WamState) applyForeignResult(predKey string, resultRegs []int, result Value) bool {
@@ -2443,6 +2480,9 @@ func (vm *WamState) executeIndexedAtomFact2(predKey string) bool {
         return false
     }
     pairs := vm.Ctx.IndexedAtomFactPairs[predKey]
+    if source, ok := vm.Ctx.AtomFact2Sources[predKey]; ok {
+        pairs = source.LookupArg1(key)
+    }
     results := make([]Value, 0)
     for _, pair := range pairs {
         if pair.Left == key {

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -20,6 +20,11 @@ type AtomPair struct {
 	Right string
 }
 
+type AtomFact2Source interface {
+	Scan() []AtomPair
+	LookupArg1(left string) []AtomPair
+}
+
 type WeightedEdgeTriple struct {
 	Left   string
 	Right  string
@@ -111,6 +116,7 @@ type WamContext struct {
 	ForeignResultModes        map[string]string
 	ForeignStringConfigs      map[string]map[string]string
 	ForeignUsizeConfigs       map[string]map[string]int
+	AtomFact2Sources          map[string]AtomFact2Source
 	IndexedAtomFactPairs      map[string][]AtomPair
 	IndexedWeightedEdgeTriples map[string][]WeightedEdgeTriple
 	AtomIntern                map[string]int
@@ -214,6 +220,7 @@ func NewWamContext(code []Instruction, labels map[string]int) *WamContext {
 		ForeignResultModes:   make(map[string]string),
 		ForeignStringConfigs: make(map[string]map[string]string),
 		ForeignUsizeConfigs:  make(map[string]map[string]int),
+		AtomFact2Sources:     make(map[string]AtomFact2Source),
 		IndexedAtomFactPairs: make(map[string][]AtomPair),
 		IndexedWeightedEdgeTriples: make(map[string][]WeightedEdgeTriple),
 		AtomIntern:           make(map[string]int),

--- a/tests/test_wam_go_foreign_lowering.pl
+++ b/tests/test_wam_go_foreign_lowering.pl
@@ -129,6 +129,17 @@ test(tsv_atom_fact2_setup_generation) :-
     wam_go_target:go_foreign_setup_line(register_tsv_atom_fact2(edge/2, '/tmp/edge.tsv'), Line),
     assertion(Line == '    if err := vm.registerTsvAtomFact2("edge/2", "/tmp/edge.tsv"); err != nil { panic(err) }').
 
+test(atom_fact2_source_registry_runtime_shape) :-
+    wam_go_target:compile_wam_runtime_to_go([], RuntimeCode),
+    atom_string(RuntimeCode, Runtime),
+    assertion(sub_string(Runtime, _, _, _, 'type staticAtomFact2Source struct')),
+    assertion(sub_string(Runtime, _, _, _, 'func newStaticAtomFact2Source(pairs []AtomPair) *staticAtomFact2Source')),
+    assertion(sub_string(Runtime, _, _, _, 'func (vm *WamState) registerAtomFact2Source(predKey string, source AtomFact2Source)')),
+    assertion(sub_string(Runtime, _, _, _, 'pairs = source.LookupArg1(key)')),
+    read_file_to_string('templates/targets/go_wam/state.go.mustache', State, []),
+    assertion(sub_string(State, _, _, _, 'type AtomFact2Source interface')),
+    assertion(sub_string(State, _, _, _, 'AtomFact2Sources          map[string]AtomFact2Source')).
+
 test(foreign_auto_detect_generation) :-
     compile_wam_predicate_to_go(plunit_wam_go_foreign_lowering:test_reaches/2, "call test_reaches/2, 2",
         [foreign_lowering(true)], ClosureCode),
@@ -274,6 +285,9 @@ func TestForeignGraphKernels(t *testing.T) {
     if err := tsvVM.registerTsvAtomFact2("tsv_edge/2", tsvPath); err != nil {
         t.Fatalf("register tsv facts: %v", err)
     }
+    if _, ok := tsvVM.Ctx.AtomFact2Sources["tsv_edge/2"]; !ok {
+        t.Fatalf("expected TSV source to register through AtomFact2Sources")
+    }
     tsvTarget := &Unbound{Name: "TSV_TARGET", Idx: 1}
     tsvVM.Regs[0] = internAtom("x")
     tsvVM.Regs[1] = tsvTarget
@@ -296,6 +310,9 @@ func TestForeignGraphKernels(t *testing.T) {
         {Left: "a", Right: "c"},
         {Left: "b", Right: "d"},
     })
+    if _, ok := factVM.Ctx.AtomFact2Sources["edge/2"]; !ok {
+        t.Fatalf("expected indexed facts to register through AtomFact2Sources")
+    }
     factTarget := &Unbound{Name: "FACT_TARGET", Idx: 1}
     factVM.Regs[0] = internAtom("a")
     factVM.Regs[1] = factTarget

--- a/tests/test_wam_go_generator.pl
+++ b/tests/test_wam_go_generator.pl
@@ -20,7 +20,12 @@ test_caller(X, X).
 wam_only_inner(X, Y) :- Y is X + 1, atom(foo), \+ atom(5).
 wam_only_caller(X, Z) :- wam_only_inner(X, Y), wam_only_inner(Y, Z).
 
+reset_go_atom_literal_fallback :-
+    wam_go_target:retractall(go_atom_intern_id(_, _)),
+    wam_go_target:retractall(go_atom_intern_next(_)).
+
 test(wam_get_constant) :-
+    reset_go_atom_literal_fallback,
     wam_instruction_to_go_literal(get_constant(atom(john), 'A1'), Literal),
     assertion(Literal == '&GetConstant{C: internAtom("john"), Ai: 0}').
 
@@ -34,6 +39,7 @@ test(wam_put_structure) :-
 
 test(wam_switch_on_constant) :-
     once((
+        reset_go_atom_literal_fallback,
         Table = [john-default, jane-'L1'],
         wam_instruction_to_go_literal(switch_on_constant(Table), Literal),
         assertion(sub_string(Literal, _, _, _, '&SwitchOnConstant{Cases: []ConstCase{')),
@@ -47,6 +53,7 @@ test(parse_wam_line_label) :-
     assertion(sub_string(GoCode, _, _, _, '"L_parent_2_2": 0')).
 
 test(parse_wam_line_instruction) :-
+    reset_go_atom_literal_fallback,
     WamCode = "    get_constant john, A1",
     compile_wam_predicate_to_go(test/1, WamCode, [], GoCode),
     assertion(sub_string(GoCode, _, _, _, '&GetConstant{C: internAtom("john"), Ai: 0}')).


### PR DESCRIPTION
# Add Go WAM atom fact-source registry

## Summary

- Adds a Go WAM `AtomFact2Source` interface with `Scan` and `LookupArg1`.
- Registers inline indexed atom facts and TSV-backed atom facts through the same source registry.
- Keeps `IndexedAtomFactPairs` populated so existing native graph/kernel paths continue to work unchanged.
- Routes `call_indexed_atom_fact2` through registered fact sources before falling back to stored pairs.
- Updates the Go WAM parity audit to mark the Haskell-shaped fact-source abstraction as present while leaving concrete LMDB support as the remaining direct-fact parity gap.
- Fixes Go generator test isolation so combined Prolog test runs do not inherit stale atom-intern state from earlier suites.

## Verification

```sh
swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl
swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl tests/test_wam_go_generator.pl tests/test_go_wam_builtins.pl
git diff --check
```

## Follow-Up

- Add a concrete LMDB-backed `AtomFact2Source` implementation if Go should close the remaining direct-fact parity gap against Haskell.
