### PR TITLE
feat(wam-clojure): add reverse/2 builtin

### DIFF
--- a/PR_WAM_CLOJURE_REVERSE_BUILTIN.md
+++ b/PR_WAM_CLOJURE_REVERSE_BUILTIN.md
@@ -1,0 +1,26 @@
+# PR Title
+
+feat(wam-clojure): add reverse/2 builtin
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM support for `reverse/2`.
+- Reuses the existing proper-list conversion and `list->term` runtime helpers.
+- Direct-lowers `reverse/2` to a runtime helper instead of stepping through the interpreted builtin path.
+- Fails cleanly for improper or unbound input lists.
+- Adds lowered-emitter and runtime smoke coverage.
+
+## Semantics
+
+`reverse/2` accepts a proper list in the first argument and unifies the second argument with the reversed list.
+
+This initial Clojure WAM implementation is deterministic and conservative: it supports the common `(+List, ?Reversed)` mode and fails for unbound first arguments rather than generating lists relationally.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -388,6 +388,10 @@ clojure_direct_builtin("append/3", "3").
 clojure_direct_builtin("append/3", 3).
 clojure_direct_builtin('append/3', "3").
 clojure_direct_builtin('append/3', 3).
+clojure_direct_builtin("reverse/2", "2").
+clojure_direct_builtin("reverse/2", 2).
+clojure_direct_builtin('reverse/2', "2").
+clojure_direct_builtin('reverse/2', 2).
 clojure_direct_builtin("sort/2", "2").
 clojure_direct_builtin("sort/2", 2).
 clojure_direct_builtin('sort/2', "2").
@@ -661,6 +665,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr),
            '(let [left (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) right (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound)) out (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A3") ::lowered-unbound))] (runtime/apply-append-solution ~w (inc (:pc ~w)) left right out))',
            [S, S, S, S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "reverse/2" ; Op == 'reverse/2'),
+    !,
+    format(atom(Expr), '(runtime/apply-reverse-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "sort/2" ; Op == 'sort/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -760,6 +760,20 @@
 (defn sorted-terms [state items]
   (sort #(term-compare state %1 %2) items))
 
+(defn apply-reverse-solution [state]
+  (let [list-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A2") ::unbound))]
+    (if-let [items (proper-list-items state list-value)]
+      (let [reversed-term (list->term (:intern-context state)
+                                      (reverse items))
+            [ok next-state] (unify-values state out reversed-term)]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+      (backtrack state))))
+
 (defn apply-sort-solution [state]
   (let [list-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A1") ::unbound))
@@ -1537,6 +1551,9 @@
                 out (deref-value (:bindings state)
                                  (or (reg-get-raw state "A3") ::unbound))]
             (apply-append-solution state (inc (:pc state)) left right out))
+
+          "reverse/2"
+          (apply-reverse-solution state)
 
           "sort/2"
           (apply-sort-solution state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -550,6 +550,15 @@ test(simple_builtin_append_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_reverse_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_reverse/2:\nbuiltin_call reverse/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_reverse/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_reverse/2, WamCode, [], Code),
+        has(Code, "runtime/apply-reverse-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_sort_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_sort/2:\nbuiltin_call sort/2, 2\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -84,6 +84,9 @@
 :- dynamic user:wam_append_bad_left/1.
 :- dynamic user:wam_append_unbound_left/1.
 :- dynamic user:wam_append_split/2.
+:- dynamic user:wam_reverse_guard/2.
+:- dynamic user:wam_reverse_bad_list/1.
+:- dynamic user:wam_reverse_unbound_list/1.
 :- dynamic user:wam_sort_guard/2.
 :- dynamic user:wam_sort_bad_list/1.
 :- dynamic user:wam_sort_unbound_list/1.
@@ -212,6 +215,9 @@ user:wam_append_guard(A, B, C) :- append(A, B, C).
 user:wam_append_bad_left(C) :- append([a|b], [c], C).
 user:wam_append_unbound_left(C) :- user:wam_unbound_arg(A), append(A, [b], C).
 user:wam_append_split(A, B) :- append(A, B, [a,b,c]).
+user:wam_reverse_guard(L, R) :- reverse(L, R).
+user:wam_reverse_bad_list(R) :- reverse([a|b], R).
+user:wam_reverse_unbound_list(R) :- user:wam_unbound_arg(L), reverse(L, R).
 user:wam_sort_guard(L, S) :- sort(L, S).
 user:wam_sort_bad_list(S) :- sort([a|b], S).
 user:wam_sort_unbound_list(S) :- user:wam_unbound_arg(L), sort(L, S).
@@ -345,6 +351,9 @@ run_smoke :-
           user:wam_append_bad_left/1,
           user:wam_append_unbound_left/1,
           user:wam_append_split/2,
+          user:wam_reverse_guard/2,
+          user:wam_reverse_bad_list/1,
+          user:wam_reverse_unbound_list/1,
           user:wam_sort_guard/2,
           user:wam_sort_bad_list/1,
           user:wam_sort_unbound_list/1,
@@ -421,6 +430,7 @@ run_smoke :-
     assert_lowered_length_builtin_emitted(TmpDir),
     assert_lowered_member_builtin_emitted(TmpDir),
     assert_lowered_append_builtin_emitted(TmpDir),
+    assert_lowered_reverse_builtin_emitted(TmpDir),
     assert_lowered_sort_builtin_emitted(TmpDir),
     assert_lowered_msort_builtin_emitted(TmpDir),
     assert_lowered_copy_term_builtin_emitted(TmpDir),
@@ -581,6 +591,11 @@ smoke_cases([
     case('wam_append_split/2', args('[a,b]', '[c]'), "true"),
     case('wam_append_split/2', args('[a,b,c]', '[]'), "true"),
     case('wam_append_split/2', args('[a]', '[c]'), "false"),
+    case('wam_reverse_guard/2', args('[a,b,c]', '[c,b,a]'), "true"),
+    case('wam_reverse_guard/2', args('[]', '[]'), "true"),
+    case('wam_reverse_guard/2', args('[a,b,c]', '[a,b,c]'), "false"),
+    case('wam_reverse_bad_list/1', '[b,a]', "false"),
+    case('wam_reverse_unbound_list/1', '[b,a]', "false"),
     case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b,c]'), "true"),
     case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b]'), "false"),
     case('wam_sort_guard/2', args('[f(b),f(a),a]', '[a,f(a),f(b)]'), "true"),
@@ -829,6 +844,14 @@ assert_lowered_append_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-append-unbound-left-1"),
     has(CoreCode, "defn lowered-wam-append-split-2"),
     has(CoreCode, "runtime/apply-append-solution").
+
+assert_lowered_reverse_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-reverse-guard-2"),
+    has(CoreCode, "defn lowered-wam-reverse-bad-list-1"),
+    has(CoreCode, "defn lowered-wam-reverse-unbound-list-1"),
+    has(CoreCode, "runtime/apply-reverse-solution").
 
 assert_lowered_sort_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
@@ -1089,6 +1112,8 @@ prolog_term_string_to_edn('[c]', "{:tag :struct :functor \"[|]/2\" :args [\"c\" 
 prolog_term_string_to_edn('[a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[a,b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[a,a,b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
+prolog_term_string_to_edn('[c,b,a]', "{:tag :struct :functor \"[|]/2\" :args [\"c\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn('[b,a]', "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[b,a,a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn('[f(b),f(a),a]', "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[a,f(a),f(b)]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} \"[]\"]}]}]}") :- !.
@@ -1105,6 +1130,8 @@ prolog_term_string_to_edn("[c]", "{:tag :struct :functor \"[|]/2\" :args [\"c\" 
 prolog_term_string_to_edn("[a,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[a,b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[a,a,b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
+prolog_term_string_to_edn("[c,b,a]", "{:tag :struct :functor \"[|]/2\" :args [\"c\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn("[b,a]", "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[b,a,a,c]", "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn("[f(b),f(a),a]", "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[a,f(a),f(b)]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} \"[]\"]}]}]}") :- !.


### PR DESCRIPTION
## Summary

- Adds Clojure WAM support for `reverse/2`.
- Reuses the existing proper-list conversion and `list->term` runtime helpers.
- Direct-lowers `reverse/2` to a runtime helper instead of stepping through the interpreted builtin path.
- Fails cleanly for improper or unbound input lists.
- Adds lowered-emitter and runtime smoke coverage.

## Semantics

`reverse/2` accepts a proper list in the first argument and unifies the second argument with the reversed list.

This initial Clojure WAM implementation is deterministic and conservative: it supports the common `(+List, ?Reversed)` mode and fails for unbound first arguments rather than generating lists relationally.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
