### PR TITLE
feat(wam-cpp): nb_setval/getval and b_setval/getval globals

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -1857,6 +1857,15 @@ struct WamState {
     };
     std::vector<DynamicIterator> dynamic_iters;
     std::size_t dynamic_next_clause_pc = 0;
+    // Mutable globals — nb_setval/2, nb_getval/2, b_setval/2, b_getval/2.
+    // Each key maps to a CellPtr holding the current value. nb_setval
+    // replaces the pointer (non-backtrackable: prior bindings to the
+    // old cell stay trail-tracked but no longer reachable through
+    // the global). b_setval mutates the existing cell via bind_cell,
+    // so a trail entry restores the previous value on backtrack.
+    // Both setvals deep-copy the input to give the stored term
+    // independent vars.
+    std::unordered_map<std::string, CellPtr> nb_globals;
     // Iteration state for retract/1''s nondeterministic behaviour.
     // Each successful retract removes the matched clause; on
     // backtrack, retract_try_next continues from where it left off
@@ -2959,6 +2968,63 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
                     return ok;
                 }), vec.end());
         }
+        pc += 1; return true;
+    }
+
+    // ---- nb_setval/2, nb_getval/2, b_setval/2, b_getval/2 -----------
+    // Mutable globals. Key must be a ground atom. nb_setval REPLACES
+    // the stored value (no undo on backtrack); b_setval MUTATES the
+    // existing cell via bind_cell so the trail records the prior
+    // content, and backtrack restores it. Both deep-copy the value
+    // so the stored term has fresh variables (independent of the
+    // caller''s bindings). getvals deep-copy on retrieval so the
+    // returned term''s vars are fresh too — repeated reads see the
+    // same shape but disjoint vars.
+    auto read_global_key = [&](std::string& out) -> bool {
+        Value k = deref(*get_cell("A1"));
+        if (k.tag != Value::Tag::Atom) return false;
+        out = k.s;
+        return true;
+    };
+    if (op == "nb_setval/2") {
+        std::string key;
+        if (!read_global_key(key)) return false;
+        Value v = deref(*get_cell("A2"));
+        if (v.is_unbound()) return false; // need a concrete value
+        CellPtr fresh = deep_copy_term(get_cell("A2"));
+        nb_globals[key] = std::move(fresh);
+        pc += 1; return true;
+    }
+    if (op == "b_setval/2") {
+        std::string key;
+        if (!read_global_key(key)) return false;
+        Value v = deref(*get_cell("A2"));
+        if (v.is_unbound()) return false;
+        CellPtr fresh = deep_copy_term(get_cell("A2"));
+        auto it = nb_globals.find(key);
+        if (it == nb_globals.end()) {
+            // First binding for this key — no prior cell to mutate,
+            // so just install fresh. Subsequent b_setvals will mutate
+            // this cell in place so the trail can restore them.
+            nb_globals[key] = std::move(fresh);
+        } else {
+            // Mutate the existing cell so the trail entry can undo
+            // it on backtrack.
+            bind_cell(it->second, *fresh);
+        }
+        pc += 1; return true;
+    }
+    if (op == "nb_getval/2" || op == "b_getval/2") {
+        std::string key;
+        if (!read_global_key(key)) return false;
+        auto it = nb_globals.find(key);
+        if (it == nb_globals.end()) return false;
+        // Deep-copy on retrieval so each get returns a fresh-var
+        // copy; repeated reads share structure but not bindings.
+        CellPtr fresh = deep_copy_term(it->second);
+        CellPtr tgt = get_cell("A2");
+        if (tgt->is_unbound()) { bind_cell(tgt, *fresh); pc += 1; return true; }
+        if (!unify_cells(tgt, fresh)) return false;
         pc += 1; return true;
     }
 

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1467,6 +1467,10 @@ is_builtin_pred(asserta, 1).      % dynamic db: prepend fact.
 % through subsequent matches. NOT in is_builtin_pred so the compiler
 % emits `call retract/1, 1` rather than `builtin_call`.
 is_builtin_pred(retractall, 1).   % dynamic db: remove all matches.
+is_builtin_pred(nb_setval, 2).    % mutable global: replace value.
+is_builtin_pred(nb_getval, 2).    % mutable global: read value.
+is_builtin_pred(b_setval, 2).     % backtrackable mutable global: bind.
+is_builtin_pred(b_getval, 2).     % backtrackable mutable global: read.
 % Note: sub_atom/5 is nondeterministic; like findall/bagof/setof it
 % goes through the Call/Execute dispatch path (not is_builtin_pred)
 % so dispatch_sub_atom can manage its own CP machinery.

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -1148,6 +1148,66 @@ user:wam_cpp_test_retract_destructive :-
     retract(wam_cpp_nd_t(1)),
     \+ wam_cpp_nd_t(1).
 
+% nb_setval/2, nb_getval/2, b_setval/2, b_getval/2 — mutable globals.
+% Stored in WamState''s nb_globals map. nb_setval REPLACES the
+% CellPtr (non-backtrackable); b_setval mutates the existing cell
+% via bind_cell so the trail can restore it on backtrack. Both
+% setvals deep-copy the value so the stored term has fresh vars;
+% getvals deep-copy on retrieval so repeated reads share structure
+% but not bindings.
+:- dynamic user:wam_cpp_test_nb_basic/0.
+:- dynamic user:wam_cpp_test_nb_replace/0.
+:- dynamic user:wam_cpp_test_nb_survives_backtrack/0.
+:- dynamic user:wam_cpp_test_b_undone_on_backtrack/0.
+:- dynamic user:wam_cpp_test_nb_unset_fails/0.
+:- dynamic user:wam_cpp_test_nb_compound/0.
+:- dynamic user:wam_cpp_test_nb_counter/0.
+
+user:wam_cpp_test_nb_basic :-
+    nb_setval(wam_cpp_nb_c1, 0),
+    nb_getval(wam_cpp_nb_c1, V),
+    V = 0.
+
+user:wam_cpp_test_nb_replace :-
+    nb_setval(wam_cpp_nb_c2, 1),
+    nb_setval(wam_cpp_nb_c2, 2),
+    nb_getval(wam_cpp_nb_c2, V),
+    V = 2.
+
+% nb_setval survives backtrack — the mutation inside the failing
+% disjunct branch persists past the ;true continuation.
+user:wam_cpp_test_nb_survives_backtrack :-
+    nb_setval(wam_cpp_nb_c3, 10),
+    (nb_setval(wam_cpp_nb_c3, 20), fail ; true),
+    nb_getval(wam_cpp_nb_c3, V),
+    V = 20.
+
+% b_setval is undone on backtrack — same shape as above, but the
+% inner b_setval gets rolled back when the disjunct fails.
+user:wam_cpp_test_b_undone_on_backtrack :-
+    nb_setval(wam_cpp_nb_c4, 10),
+    (b_setval(wam_cpp_nb_c4, 20), fail ; true),
+    nb_getval(wam_cpp_nb_c4, V),
+    V = 10.
+
+user:wam_cpp_test_nb_unset_fails :-
+    \+ nb_getval(wam_cpp_nb_never_set, _).
+
+user:wam_cpp_test_nb_compound :-
+    nb_setval(wam_cpp_nb_c5, point(3, 4)),
+    nb_getval(wam_cpp_nb_c5, V),
+    V = point(3, 4).
+
+% Counter pattern: increment-via-get-then-set. Confirms that
+% repeated reads see the latest stored value (deep-copy-on-read
+% doesn''t break the round-trip).
+user:wam_cpp_test_nb_counter :-
+    nb_setval(wam_cpp_nb_c6, 0),
+    nb_getval(wam_cpp_nb_c6, V1), V2 is V1 + 1, nb_setval(wam_cpp_nb_c6, V2),
+    nb_getval(wam_cpp_nb_c6, V3), V4 is V3 + 1, nb_setval(wam_cpp_nb_c6, V4),
+    nb_getval(wam_cpp_nb_c6, Final),
+    Final = 2.
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -4187,6 +4247,96 @@ test(cpp_e2e_retract_destructive,
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath,
                     'wam_cpp_test_retract_destructive/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% Mutable globals — nb_setval/getval (non-backtrackable) and
+% b_setval/getval (trail-tracked). Stored in WamState::nb_globals.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_nb_basic, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_nb_basic', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_nb_basic/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_nb_basic/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_nb_replace, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_nb_replace', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_nb_replace/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_nb_replace/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_nb_survives_backtrack,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_nb_bt', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_test_nb_survives_backtrack/0],
+            [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_nb_survives_backtrack/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_b_undone_on_backtrack,
+     [condition(cpp_compiler_available)]) :-
+    % Direct regression guard for b_setval''s trail integration.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_b_bt', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_test_b_undone_on_backtrack/0],
+            [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_b_undone_on_backtrack/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_nb_unset_fails, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_nb_unset', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_nb_unset_fails/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_nb_unset_fails/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_nb_compound, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_nb_compound', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_nb_compound/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_nb_compound/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_nb_counter, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_nb_counter', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_nb_counter/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_nb_counter/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Mutable globals — key-indexed storage with both non-backtrackable (`nb_*`) and trail-tracked (`b_*`) variants. Useful for counters, generation IDs, side-channel state without the dynamic-predicate dispatch overhead.

## Implementation

- `WamState` gains `nb_globals: std::unordered_map<std::string, CellPtr>`.
- **`nb_setval(Key, V)`** deep-copies V into a fresh cell and **replaces** the map entry. Prior bindings to the old cell stay trail-tracked but are no longer reachable through the global — non-backtrackable.
- **`b_setval(Key, V)`** deep-copies V; on first binding creates a fresh cell, otherwise `bind_cell`-mutates the existing cell so the trail records the prior content and backtrack restores it.
- **`nb_getval` / `b_getval`** (identical implementation) deep-copy on retrieval so each read returns a fresh-var copy — repeated reads share structure but not bindings.

All four go through `is_builtin_pred` so the compiler emits `builtin_call` directly.

## Test plan

- [x] 7 new e2e tests:
  - Basic round-trip
  - Replacement (overwrite)
  - nb persistence across backtrack (`(nb_setval(k, 20), fail ; true)` → still 20)
  - b rollback on backtrack (same shape with `b_setval` → restored to 10)
  - Unset key → `nb_getval` fails (not throws)
  - Compound-value round-trip (`point(3, 4)`)
  - Counter pattern (increment via get-then-set, repeated reads)
- [x] Full `test_wam_cpp_generator.pl` suite passes
- [x] `test_wam_target.pl` passes

## Known limitations / deferred

- No `nb_current/2` enumeration — could add in a follow-up.
- No type-checking on Key (must be atom); other types currently fail silently rather than throw `instantiation_error` / `type_error`. ISO sweep covers this.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_