### PR TITLE
bench(csharp-query): add rust lmdb fixture sink

### DIFF
--- a/docs/targets/csharp-query-high-performance-sources.md
+++ b/docs/targets/csharp-query-high-performance-sources.md
@@ -282,13 +282,14 @@ need manual override:
   dump tokenizer. For the C# backend benchmark, the fixture-prep helper is
   `examples/benchmark/prepare_csharp_query_enwiki_category_fixture.py`; it
   writes capped TSV fixtures first and can optionally add a provider-compatible
-  LMDB relation artifact with `--sink-lmdb`. That sink still reuses the capped
-  Python helper row set and the existing C# `lmdb_ingest` consumer, preserving
-  the Wikipedia page IDs from the parser output. Direct Rust-parser-to-LMDB
-  ingestion remains the follow-up once a native sink is implemented. The C#
-  backend benchmark can use those scale-local artifacts via
-  `--use-scale-lmdb-artifact`, which implies `--preserve-numeric-ids`; otherwise
-  it accepts a persistent
+  LMDB relation artifact with `--sink-lmdb`. The default sink reuses the capped
+  Python helper row set and the existing C# `lmdb_ingest` consumer; the
+  `--lmdb-sink-target rust` path uses `mysql_stream_lmdb` to write LMDB directly
+  from the Rust parser while preserving Wikipedia page IDs. The C# backend
+  benchmark can use those scale-local artifacts via `--use-scale-lmdb-artifact`,
+  which implies `--preserve-numeric-ids` when a scale-local artifact exists. Use
+  `--lmdb-only` to measure a scale-local LMDB artifact without requiring a TSV
+  fixture sidecar. Otherwise the benchmark accepts a persistent
   `--artifact-root` and reuses existing backend artifacts by default; use
   `--refresh-artifacts` to rebuild, matching the Haskell benchmark's explicit
   LMDB refresh convention.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -212,20 +212,22 @@ python examples/benchmark/prepare_csharp_query_enwiki_category_fixture.py \
   --scale 500k_cats \
   --max-edges 500000 \
   --dump data/enwiki/enwiki-latest-categorylinks.sql.gz \
-  --sink-lmdb
+  --sink-lmdb \
+  --lmdb-sink-target rust
 ```
 
-The LMDB sink reuses the capped row set and the existing C# `lmdb_ingest`
-consumer, so it preserves the helper's row cap and writes a provider-compatible
-`category_parent.lmdb.manifest.json`. The sink preserves the Wikipedia page IDs
-from the parser output; the backend benchmark implies `--preserve-numeric-ids`
-when `--use-scale-lmdb-artifact` is set so all compared backends use the same
-stable ID space. Existing LMDB artifacts are reused by default; pass
-`--refresh-lmdb` to rebuild them. A future Rust-native sink can still bypass the
-Python orchestrator entirely once that path is implemented. Pass
-`--use-scale-lmdb-artifact` to the backend benchmark when you want the `lmdb`
-mode to use this scale-local artifact instead of generating one under
-`--artifact-root`.
+The default LMDB sink reuses the capped row set and the existing C#
+`lmdb_ingest` consumer. With `--lmdb-sink-target rust`, `mysql_stream_lmdb`
+writes LMDB directly through Rust while preserving the helper's row cap and the
+Wikipedia page IDs from the parser output. In Rust mode, `category_parent.tsv`
+is only a fixture sidecar for non-LMDB backend comparisons, not the LMDB
+transport. Existing LMDB artifacts are reused by default; pass `--refresh-lmdb`
+to rebuild them.
+
+Pass `--use-scale-lmdb-artifact` to the backend benchmark when you want the
+`lmdb` mode to use this scale-local artifact instead of generating one under
+`--artifact-root`. If you want to benchmark only the scale-local LMDB artifact,
+pass `--lmdb-only`; that mode does not require `category_parent.tsv`.
 
 Pass `--artifact-root <dir>` to keep backend artifacts across benchmark runs.
 Existing binary, delimited, LMDB, and mmap-array manifests are reused by

--- a/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
+++ b/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
@@ -188,10 +188,13 @@ def run_scale(
     refresh_artifacts: bool,
     use_scale_lmdb_artifact: bool,
     preserve_numeric_ids: bool,
+    lmdb_only: bool,
 ) -> list[BenchmarkRow]:
     scale_dir = BENCH_DIR / scale
-    if not (scale_dir / "category_parent.tsv").exists():
+    if not lmdb_only and not (scale_dir / "category_parent.tsv").exists():
         raise RuntimeError(f"scale has no category_parent.tsv: {scale_dir}")
+    if lmdb_only and not (scale_dir / "category_parent.lmdb.manifest.json").exists():
+        raise RuntimeError(f"scale has no category_parent.lmdb.manifest.json: {scale_dir}")
 
     build_lmdb_runtime()
     temp_path = Path(tempfile.mkdtemp(prefix=f"uw-csharp-effective-distance-artifacts-{scale}-"))
@@ -226,6 +229,8 @@ def run_scale(
                 "true" if use_scale_lmdb_artifact else "false",
                 "--preserve-numeric-ids",
                 "true" if preserve_numeric_ids else "false",
+                "--lmdb-only",
+                "true" if lmdb_only else "false",
             ],
             cwd=temp_path,
             timeout=240,
@@ -512,6 +517,11 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--lmdb-only",
+        action="store_true",
+        help="benchmark only a scale-local LMDB artifact; does not require category_parent.tsv",
+    )
+    parser.add_argument(
         "--preserve-numeric-ids",
         action="store_true",
         help=(
@@ -582,7 +592,14 @@ def main(argv: list[str] | None = None) -> int:
             if scale in AUTO_PREPARED_LARGE_SCALES:
                 prepare_large_fixture(scale, db_path)
 
-    missing = [scale for scale in scales if not (BENCH_DIR / scale / "category_parent.tsv").exists()]
+    missing = [
+        scale
+        for scale in scales
+        if not (
+            (BENCH_DIR / scale / "category_parent.tsv").exists()
+            or (args.lmdb_only and (BENCH_DIR / scale / "category_parent.lmdb.manifest.json").exists())
+        )
+    ]
     if missing:
         if args.skip_missing_scales:
             print(f"skipping missing benchmark scale(s): {', '.join(missing)}", file=sys.stderr)
@@ -625,6 +642,7 @@ def main(argv: list[str] | None = None) -> int:
                     args.refresh_artifacts,
                     args.use_scale_lmdb_artifact,
                     args.preserve_numeric_ids,
+                    args.lmdb_only,
                 )
             )
 
@@ -889,6 +907,30 @@ static string? ExistingScaleLmdbManifest(string scaleDir)
     return manifestPath;
 }
 
+static object[][] ReadLmdbRowsForPlanning(PredicateId predicate, string manifestPath)
+{
+    var provider = new LmdbRelationProvider();
+    provider.RegisterArtifact(predicate, manifestPath);
+    return provider.GetFacts(predicate).ToArray();
+}
+
+static IReadOnlyList<object> LookupKeysFromRows(object[][] rows, int lookupKeyCount)
+{
+    return rows.Select(row => row[0])
+        .Distinct()
+        .OrderBy(value => Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture), StringComparer.Ordinal)
+        .Take(Math.Min(lookupKeyCount, rows.Length))
+        .ToArray();
+}
+
+static int DistinctCategoryCount(object[][] rows)
+{
+    return rows.SelectMany(row => row.Take(2))
+        .Select(value => Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture) ?? "")
+        .Distinct(StringComparer.Ordinal)
+        .Count();
+}
+
 static string HashBuckets(IEnumerable<IndexedRelationBucket> buckets)
 {
     return HashRows(buckets.Select(bucket => new object[]
@@ -1017,9 +1059,39 @@ var root = Path.GetFullPath(ReadArg(args, "--artifact-root", Directory.GetCurren
 var refreshArtifacts = ReadBoolArg(args, "--refresh-artifacts", false);
 var useScaleLmdbArtifact = ReadBoolArg(args, "--use-scale-lmdb-artifact", false);
 var requestedPreserveNumericIds = ReadBoolArg(args, "--preserve-numeric-ids", false);
+var lmdbOnly = ReadBoolArg(args, "--lmdb-only", false);
 Directory.CreateDirectory(root);
 var predicate = new PredicateId("category_parent", 2);
-var scaleLmdbManifest = (!refreshArtifacts && useScaleLmdbArtifact) ? ExistingScaleLmdbManifest(scaleDir) : null;
+var scaleLmdbManifest = (!refreshArtifacts && (useScaleLmdbArtifact || lmdbOnly)) ? ExistingScaleLmdbManifest(scaleDir) : null;
+if (lmdbOnly && scaleLmdbManifest is null)
+{
+    throw new InvalidOperationException("--lmdb-only requires a scale-local category_parent.lmdb.manifest.json");
+}
+if (lmdbOnly)
+{
+    var lmdbOnlyManifest = scaleLmdbManifest!;
+    var lmdbOnlyMetadata = LmdbRelationArtifactReader.LoadManifest(lmdbOnlyManifest);
+    var lmdbOnlyDir = ResolveManifestEnvironmentPath(lmdbOnlyMetadata, lmdbOnlyManifest);
+    var planningRows = ReadLmdbRowsForPlanning(predicate, lmdbOnlyManifest);
+    var lookupKeysOnly = LookupKeysFromRows(planningRows, lookupKeyCount);
+    Console.WriteLine("scale\tmode\trows\tdistinct_categories\tlookup_keys\tartifact_bytes\topen_ms\tlookup_ms\tbucket_ms\tscan_ms\tretained_bytes\tscan_hash\tlookup_hash\tbucket_hash");
+    BenchmarkProvider(
+        scale,
+        "lmdb",
+        () =>
+        {
+            var provider = new LmdbRelationProvider();
+            provider.RegisterArtifact(predicate, lmdbOnlyManifest);
+            return provider;
+        },
+        predicate,
+        lookupKeysOnly,
+        lookupRepetitions,
+        DirectorySize(lmdbOnlyDir) + new FileInfo(lmdbOnlyManifest).Length,
+        planningRows.Length,
+        DistinctCategoryCount(planningRows));
+    return;
+}
 var preserveNumericIds = requestedPreserveNumericIds || scaleLmdbManifest is not null;
 var rows = ReadEdges(scaleDir, preserveNumericIds, out var distinctCategories);
 var lookupKeys = rows.Select(row => row.Child)

--- a/examples/benchmark/prepare_csharp_query_enwiki_category_fixture.py
+++ b/examples/benchmark/prepare_csharp_query_enwiki_category_fixture.py
@@ -39,6 +39,41 @@ def parser_command(dump_path: Path) -> list[str]:
     ]
 
 
+def rust_lmdb_sink_command(
+    *,
+    dump_path: Path,
+    fixture_dir: Path,
+    max_edges: int,
+    map_size: int,
+    refresh: bool,
+) -> list[str]:
+    command = [
+        "cargo",
+        "run",
+        "--release",
+        "--manifest-path",
+        str(MYSQL_STREAM_MANIFEST),
+        "--bin",
+        "mysql_stream_lmdb",
+        "--",
+        str(dump_path),
+        str(fixture_dir / "category_parent.lmdb"),
+        "--manifest",
+        str(fixture_dir / "category_parent.lmdb.manifest.json"),
+        "--max-edges",
+        str(max_edges),
+        "--map-size",
+        str(map_size),
+        "--fixture-tsv",
+        str(fixture_dir / "category_parent.tsv"),
+        "--stats",
+        str(fixture_dir / "category_parent.lmdb.stats.json"),
+    ]
+    if refresh:
+        command.append("--refresh")
+    return command
+
+
 def edge_rows_from_mysql_stream(lines: Iterable[str], max_edges: int) -> tuple[list[tuple[str, str]], int]:
     rows: list[tuple[str, str]] = []
     scanned = 0
@@ -60,15 +95,24 @@ def write_fixture(scale: str, edges: list[tuple[str, str]], scanned_rows: int, o
         handle.write("child\tparent\n")
         for child, parent in edges:
             handle.write(f"{child}\t{parent}\n")
+    write_metadata(output_dir, scale=scale, edge_count=len(edges), scanned_rows=scanned_rows)
+    return output_dir
+
+
+def write_metadata(output_dir: Path, *, scale: str, edge_count: int, scanned_rows: int) -> None:
     metadata = {
         "source": "English Wikipedia categorylinks dump via rust mysql_stream parser",
         "shape": "category_parent/2 backend fixture; child=cl_from page id, parent=cl_target_id",
         "scale": scale,
-        "n_hierarchy_edges": len(edges),
+        "n_hierarchy_edges": edge_count,
         "mysql_rows_scanned": scanned_rows,
     }
     (output_dir / "metadata.json").write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
-    return output_dir
+
+
+def read_rust_lmdb_stats(fixture_dir: Path) -> tuple[int, int]:
+    stats = json.loads((fixture_dir / "category_parent.lmdb.stats.json").read_text(encoding="utf-8"))
+    return int(stats["edges_written"]), int(stats["rows_scanned"])
 
 
 def file_sha256(path: Path) -> str:
@@ -210,6 +254,45 @@ def prepare_from_stream(
     return output_dir
 
 
+def prepare_with_rust_lmdb_sink(
+    *,
+    scale: str,
+    max_edges: int,
+    output_root: Path,
+    dump_path: Path,
+    refresh_lmdb: bool,
+    lmdb_map_size: int,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> Path:
+    output_dir = output_root / scale
+    output_dir.mkdir(parents=True, exist_ok=True)
+    command = rust_lmdb_sink_command(
+        dump_path=dump_path,
+        fixture_dir=output_dir,
+        max_edges=max_edges,
+        map_size=lmdb_map_size,
+        refresh=refresh_lmdb,
+    )
+    result = run(
+        command,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=3600,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Rust mysql_stream_lmdb sink failed with status "
+            f"{result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    edge_count, scanned_rows = read_rust_lmdb_stats(output_dir)
+    if edge_count <= 0:
+        raise RuntimeError("Rust mysql_stream_lmdb sink produced no subcat edges")
+    write_metadata(output_dir, scale=scale, edge_count=edge_count, scanned_rows=scanned_rows)
+    return output_dir
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
@@ -232,6 +315,12 @@ def main(argv: list[str] | None = None) -> int:
         help="also sink the capped fixture rows into a reusable C# LMDB relation artifact under the scale directory",
     )
     parser.add_argument(
+        "--lmdb-sink-target",
+        choices=("csharp", "rust"),
+        default="csharp",
+        help="implementation used by --sink-lmdb; rust writes TSV and LMDB in one parser pass when reading from --dump",
+    )
+    parser.add_argument(
         "--refresh-lmdb",
         action="store_true",
         help="rebuild the LMDB artifact even when category_parent.lmdb.manifest.json already exists",
@@ -244,6 +333,9 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    if args.from_stdin and args.sink_lmdb and args.lmdb_sink_target == "rust":
+        parser.error("--lmdb-sink-target rust requires --dump input, not --from-stdin")
+
     if args.from_stdin:
         output_dir = prepare_from_stream(
             scale=args.scale,
@@ -251,6 +343,17 @@ def main(argv: list[str] | None = None) -> int:
             output_root=args.output_root,
             stream=sys.stdin,
             sink_lmdb=args.sink_lmdb,
+            refresh_lmdb=args.refresh_lmdb,
+            lmdb_map_size=args.lmdb_map_size,
+        )
+    elif args.sink_lmdb and args.lmdb_sink_target == "rust":
+        if not args.dump.exists():
+            raise FileNotFoundError(args.dump)
+        output_dir = prepare_with_rust_lmdb_sink(
+            scale=args.scale,
+            max_edges=args.max_edges,
+            output_root=args.output_root,
+            dump_path=args.dump,
             refresh_lmdb=args.refresh_lmdb,
             lmdb_map_size=args.lmdb_map_size,
         )

--- a/src/unifyweaver/runtime/rust/mysql_stream/Cargo.toml
+++ b/src/unifyweaver/runtime/rust/mysql_stream/Cargo.toml
@@ -7,10 +7,15 @@ description = "Streaming parser for MySQL INSERT dumps — leaf primitive for Un
 
 [dependencies]
 flate2 = "1.0"
+lmdb = "0.8.0"
 
 [[bin]]
 name = "mysql_stream"
 path = "src/main.rs"
+
+[[bin]]
+name = "mysql_stream_lmdb"
+path = "src/lmdb_sink.rs"
 
 [lib]
 name = "mysql_stream"

--- a/src/unifyweaver/runtime/rust/mysql_stream/README.md
+++ b/src/unifyweaver/runtime/rust/mysql_stream/README.md
@@ -34,6 +34,29 @@ Writes every INSERT row as TAB-separated TSV to stdout.
   escape as two-byte sequences; non-ASCII bytes as `\xNN`
 - `NULL`: `\N`
 
+## Direct LMDB sink
+
+```
+mysql_stream_lmdb <path-to-dump.sql[.gz]> <lmdb-dir> \
+  --manifest <manifest.json> \
+  --max-edges 1000000 \
+  --refresh
+```
+
+`mysql_stream_lmdb` is a MediaWiki `categorylinks` sink for `subcat` rows. It
+preserves the Wikipedia page IDs (`cl_from` -> `cl_target_id`) and writes a
+C# query-runtime compatible `category_parent/2` LMDB artifact:
+
+- named database: `main`
+- duplicate-sorted values: enabled
+- key/value encoding: UTF-8 decimal page IDs
+- manifest format: `unifyweaver.lmdb_relation.v1`
+
+The sink writes LMDB directly through the Rust `lmdb` crate. It does not use TSV
+as its transport interface. `--fixture-tsv <path>` is optional and exists only
+for benchmark packages that still need a `category_parent.tsv` sidecar for
+non-LMDB backend comparisons.
+
 ## Validation
 
 End-to-end tested against `simplewiki-latest-categorylinks.sql.gz`

--- a/src/unifyweaver/runtime/rust/mysql_stream/src/lib.rs
+++ b/src/unifyweaver/runtime/rust/mysql_stream/src/lib.rs
@@ -9,8 +9,8 @@
 //
 // See docs/design/cross-target-glue/streaming-pipelines/ for the design.
 
-use std::io::{self, BufRead, BufReader, Read};
 use std::fs::File;
+use std::io::{self, BufRead, BufReader, Read};
 
 use flate2::read::GzDecoder;
 
@@ -103,9 +103,7 @@ impl<R: BufRead> MysqlInsertIter<R> {
                 if line.starts_with(b"INSERT INTO") {
                     self.in_insert = true;
                     if let Some(idx) = find_subsequence(&line, b" VALUES ") {
-                        self.buf.extend_from_slice(
-                            &line[idx + b" VALUES ".len()..]
-                        );
+                        self.buf.extend_from_slice(&line[idx + b" VALUES ".len()..]);
                     } else {
                         self.buf.extend_from_slice(&line);
                     }
@@ -144,14 +142,12 @@ impl<R: BufRead> MysqlInsertIter<R> {
         if self.buf[self.pos] != b'(' {
             return None;
         }
-        self.pos += 1;  // consume '('
+        self.pos += 1; // consume '('
 
         let mut row = Vec::with_capacity(8);
         loop {
             // Skip whitespace before a field.
-            while self.pos < self.buf.len()
-                && matches!(self.buf[self.pos], b' ' | b'\t')
-            {
+            while self.pos < self.buf.len() && matches!(self.buf[self.pos], b' ' | b'\t') {
                 self.pos += 1;
             }
 
@@ -164,9 +160,7 @@ impl<R: BufRead> MysqlInsertIter<R> {
             row.push(field);
 
             // Skip whitespace before separator.
-            while self.pos < self.buf.len()
-                && matches!(self.buf[self.pos], b' ' | b'\t')
-            {
+            while self.pos < self.buf.len() && matches!(self.buf[self.pos], b' ' | b'\t') {
                 self.pos += 1;
             }
 
@@ -232,7 +226,7 @@ impl<R: BufRead> MysqlInsertIter<R> {
     ///
     /// Returns `Field::Str(Vec<u8>)` — raw bytes, not UTF-8-validated.
     fn parse_string(&mut self) -> Option<Field> {
-        self.pos += 1;  // consume opening '
+        self.pos += 1; // consume opening '
         let mut out = Vec::with_capacity(32);
         loop {
             let c = *self.buf.get(self.pos)?;
@@ -281,7 +275,9 @@ fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 /// True if `line`, after trimming trailing whitespace/newline, ends
 /// with byte `c`.
 fn line_trimmed_ends_with(line: &[u8], c: u8) -> bool {
-    let end = line.iter().rposition(|&b| !matches!(b, b' ' | b'\t' | b'\n' | b'\r'));
+    let end = line
+        .iter()
+        .rposition(|&b| !matches!(b, b' ' | b'\t' | b'\n' | b'\r'));
     match end {
         Some(i) => line[i] == c,
         None => false,
@@ -311,9 +307,7 @@ impl<R: BufRead> Iterator for MysqlInsertIter<R> {
 
 /// Open a file (optionally gzipped based on extension) and return an
 /// iterator over INSERT rows. Path ending in `.gz` is auto-decompressed.
-pub fn iter_mysql_rows(
-    path: &str,
-) -> io::Result<MysqlInsertIter<BufReader<Box<dyn Read + Send>>>> {
+pub fn iter_mysql_rows(path: &str) -> io::Result<MysqlInsertIter<BufReader<Box<dyn Read + Send>>>> {
     let file = File::open(path)?;
     let reader: Box<dyn Read + Send> = if path.ends_with(".gz") {
         Box::new(GzDecoder::new(file))
@@ -350,10 +344,7 @@ mod tests {
     #[test]
     fn simple_string_row() {
         let input = "INSERT INTO `t` VALUES ('foo','bar');\n";
-        assert_eq!(
-            parse(input),
-            vec![vec![s(b"foo"), s(b"bar")]]
-        );
+        assert_eq!(parse(input), vec![vec![s(b"foo"), s(b"bar")]]);
     }
 
     #[test]
@@ -373,19 +364,13 @@ mod tests {
     #[test]
     fn escaped_quote_in_string() {
         let input = "INSERT INTO `t` VALUES ('it\\'s','a \\\"test\\\"');\n";
-        assert_eq!(
-            parse(input),
-            vec![vec![s(b"it's"), s(b"a \"test\"")]]
-        );
+        assert_eq!(parse(input), vec![vec![s(b"it's"), s(b"a \"test\"")]]);
     }
 
     #[test]
     fn backslash_and_null_byte() {
         let input = "INSERT INTO `t` VALUES ('a\\\\b','c\\0d');\n";
-        assert_eq!(
-            parse(input),
-            vec![vec![s(b"a\\b"), s(b"c\0d")]]
-        );
+        assert_eq!(parse(input), vec![vec![s(b"a\\b"), s(b"c\0d")]]);
     }
 
     #[test]

--- a/src/unifyweaver/runtime/rust/mysql_stream/src/lmdb_sink.rs
+++ b/src/unifyweaver/runtime/rust/mysql_stream/src/lmdb_sink.rs
@@ -1,0 +1,457 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2025 John William Creighton (s243a)
+//
+// mysql_stream_lmdb — direct LMDB sink for MediaWiki categorylinks dumps.
+//
+// This keeps the parser path in Rust and writes C# query-runtime compatible
+// LMDB relation artifacts without a Python or C# row-sink subprocess.
+
+use std::error::Error;
+use std::ffi::OsString;
+use std::fs;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use lmdb::{DatabaseFlags, Environment, Transaction, WriteFlags};
+use mysql_stream::{iter_mysql_rows, Field};
+
+type DynError = Box<dyn Error>;
+
+const DEFAULT_MAP_SIZE: usize = 1 << 30;
+const DEFAULT_BATCH_SIZE: usize = 50_000;
+const DB_NAME: &str = "main";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Config {
+    dump_path: PathBuf,
+    lmdb_path: PathBuf,
+    manifest_path: PathBuf,
+    max_edges: Option<usize>,
+    map_size: usize,
+    batch_size: usize,
+    fixture_tsv_path: Option<PathBuf>,
+    stats_path: Option<PathBuf>,
+    refresh: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SinkStats {
+    rows_scanned: usize,
+    edges_written: usize,
+}
+
+fn main() -> ExitCode {
+    match run(std::env::args_os().skip(1)) {
+        Ok(stats) => {
+            eprintln!(
+                "mysql_stream_lmdb: scanned={} written={}",
+                stats.rows_scanned, stats.edges_written
+            );
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("mysql_stream_lmdb: {err}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn run<I>(args: I) -> Result<SinkStats, DynError>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let config = parse_args(args)?;
+    sink_categorylinks_to_lmdb(&config)
+}
+
+fn parse_args<I>(args: I) -> Result<Config, DynError>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let mut positional = Vec::new();
+    let mut manifest_path = None;
+    let mut max_edges = None;
+    let mut map_size = DEFAULT_MAP_SIZE;
+    let mut batch_size = DEFAULT_BATCH_SIZE;
+    let mut fixture_tsv_path = None;
+    let mut stats_path = None;
+    let mut refresh = false;
+
+    let mut args = args.into_iter();
+    while let Some(arg) = args.next() {
+        match arg.to_string_lossy().as_ref() {
+            "--manifest" => {
+                manifest_path = Some(PathBuf::from(
+                    args.next().ok_or("--manifest requires a path")?,
+                ));
+            }
+            "--max-edges" => {
+                max_edges = Some(parse_positive_usize(
+                    &args.next().ok_or("--max-edges requires a value")?,
+                    "--max-edges",
+                )?);
+            }
+            "--map-size" => {
+                map_size = parse_positive_usize(
+                    &args.next().ok_or("--map-size requires a value")?,
+                    "--map-size",
+                )?;
+            }
+            "--batch-size" => {
+                batch_size = parse_positive_usize(
+                    &args.next().ok_or("--batch-size requires a value")?,
+                    "--batch-size",
+                )?;
+            }
+            "--fixture-tsv" => {
+                fixture_tsv_path = Some(PathBuf::from(
+                    args.next().ok_or("--fixture-tsv requires a path")?,
+                ));
+            }
+            "--stats" => {
+                stats_path = Some(PathBuf::from(args.next().ok_or("--stats requires a path")?));
+            }
+            "--refresh" => refresh = true,
+            "--help" | "-h" => return Err(usage().into()),
+            value if value.starts_with("--") => {
+                return Err(format!("unknown option: {value}\n{}", usage()).into());
+            }
+            _ => positional.push(PathBuf::from(arg)),
+        }
+    }
+
+    if positional.len() != 2 {
+        return Err(usage().into());
+    }
+
+    let dump_path = positional.remove(0);
+    let lmdb_path = positional.remove(0);
+    let manifest_path = manifest_path.unwrap_or_else(|| default_manifest_path(&lmdb_path));
+    Ok(Config {
+        dump_path,
+        lmdb_path,
+        manifest_path,
+        max_edges,
+        map_size,
+        batch_size,
+        fixture_tsv_path,
+        stats_path,
+        refresh,
+    })
+}
+
+fn parse_positive_usize(value: &OsString, flag: &str) -> Result<usize, DynError> {
+    let parsed = value.to_string_lossy().parse::<usize>()?;
+    if parsed == 0 {
+        return Err(format!("{flag} must be positive").into());
+    }
+    Ok(parsed)
+}
+
+fn usage() -> String {
+    "usage: mysql_stream_lmdb <dump.sql[.gz]> <lmdb-dir> [--manifest <path>] [--max-edges N] [--map-size BYTES] [--batch-size N] [--fixture-tsv <path>] [--stats <path>] [--refresh]".to_string()
+}
+
+fn default_manifest_path(lmdb_path: &Path) -> PathBuf {
+    let mut manifest = lmdb_path.as_os_str().to_os_string();
+    manifest.push(".manifest.json");
+    PathBuf::from(manifest)
+}
+
+fn sink_categorylinks_to_lmdb(config: &Config) -> Result<SinkStats, DynError> {
+    if config.lmdb_path.exists() && config.manifest_path.exists() && !config.refresh {
+        let stats = SinkStats {
+            rows_scanned: 0,
+            edges_written: manifest_row_count(&config.manifest_path).unwrap_or(0),
+        };
+        write_stats_if_requested(config, &stats)?;
+        return Ok(stats);
+    }
+
+    if config.lmdb_path.exists() {
+        if !config.refresh {
+            return Err(format!(
+                "LMDB directory exists without reusable manifest; pass --refresh to rebuild: {}",
+                config.lmdb_path.display()
+            )
+            .into());
+        }
+        fs::remove_dir_all(&config.lmdb_path)?;
+    }
+    if config.manifest_path.exists() {
+        if !config.refresh {
+            return Err(format!(
+                "manifest exists without reusable LMDB directory; pass --refresh to rebuild: {}",
+                config.manifest_path.display()
+            )
+            .into());
+        }
+        fs::remove_file(&config.manifest_path)?;
+    }
+
+    fs::create_dir_all(&config.lmdb_path)?;
+    if let Some(parent) = config.manifest_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let env = Environment::new()
+        .set_max_dbs(4)
+        .set_map_size(config.map_size)
+        .open(&config.lmdb_path)?;
+    let db = env.create_db(Some(DB_NAME), DatabaseFlags::DUP_SORT)?;
+    let mut txn = env.begin_rw_txn()?;
+    let mut fixture_tsv = open_fixture_tsv(config.fixture_tsv_path.as_deref())?;
+    let mut rows_scanned = 0usize;
+    let mut edges_written = 0usize;
+
+    let dump_path = config
+        .dump_path
+        .to_str()
+        .ok_or("dump path must be valid UTF-8")?;
+    for row in iter_mysql_rows(dump_path)? {
+        rows_scanned += 1;
+        let Some((child, parent)) = categorylinks_subcat_edge(&row) else {
+            continue;
+        };
+        txn.put(
+            db,
+            &child.as_bytes(),
+            &parent.as_bytes(),
+            WriteFlags::empty(),
+        )?;
+        if let Some(writer) = fixture_tsv.as_mut() {
+            writeln!(writer, "{child}\t{parent}")?;
+        }
+        edges_written += 1;
+
+        if edges_written % config.batch_size == 0 {
+            txn.commit()?;
+            txn = env.begin_rw_txn()?;
+        }
+        if config
+            .max_edges
+            .is_some_and(|max_edges| edges_written >= max_edges)
+        {
+            break;
+        }
+    }
+    txn.commit()?;
+    if let Some(mut writer) = fixture_tsv {
+        writer.flush()?;
+    }
+
+    write_csharp_query_manifest(config, edges_written)?;
+    let stats = SinkStats {
+        rows_scanned,
+        edges_written,
+    };
+    write_stats_if_requested(config, &stats)?;
+    Ok(stats)
+}
+
+fn open_fixture_tsv(path: Option<&Path>) -> Result<Option<BufWriter<fs::File>>, DynError> {
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut writer = BufWriter::new(fs::File::create(path)?);
+    writer.write_all(b"child\tparent\n")?;
+    Ok(Some(writer))
+}
+
+fn categorylinks_subcat_edge(row: &[Field]) -> Option<(String, String)> {
+    if !matches!(row.get(4).and_then(Field::as_str), Some("subcat")) {
+        return None;
+    }
+    let child = field_i64(row.get(0)?)?;
+    let parent = field_i64(row.get(6)?)?;
+    Some((child.to_string(), parent.to_string()))
+}
+
+fn field_i64(field: &Field) -> Option<i64> {
+    match field {
+        Field::Int(value) => Some(*value),
+        Field::Str(bytes) => std::str::from_utf8(bytes).ok()?.parse().ok(),
+        Field::Null => None,
+    }
+}
+
+fn write_csharp_query_manifest(config: &Config, row_count: usize) -> Result<(), DynError> {
+    let environment_path = manifest_environment_path(&config.lmdb_path, &config.manifest_path);
+    let source_length = fs::metadata(&config.dump_path).ok().map(|meta| meta.len());
+    let source_path = config.dump_path.display().to_string();
+    let source_length_json = source_length
+        .map(|length| length.to_string())
+        .unwrap_or_else(|| "null".to_string());
+    let manifest = format!(
+        concat!(
+            "{{\n",
+            "  \"Format\": \"unifyweaver.lmdb_relation.v1\",\n",
+            "  \"Version\": 1,\n",
+            "  \"Backend\": \"lmdb\",\n",
+            "  \"PredicateName\": \"category_parent\",\n",
+            "  \"Arity\": 2,\n",
+            "  \"EnvironmentPath\": \"{}\",\n",
+            "  \"DatabaseName\": \"{}\",\n",
+            "  \"DupSort\": true,\n",
+            "  \"KeyEncoding\": \"utf8\",\n",
+            "  \"ValueEncoding\": \"utf8\",\n",
+            "  \"RowCount\": {},\n",
+            "  \"SourcePath\": \"{}\",\n",
+            "  \"SourceLength\": {}\n",
+            "}}\n"
+        ),
+        json_escape(&environment_path),
+        DB_NAME,
+        row_count,
+        json_escape(&source_path),
+        source_length_json
+    );
+    fs::write(&config.manifest_path, manifest)?;
+    Ok(())
+}
+
+fn write_stats_if_requested(config: &Config, stats: &SinkStats) -> Result<(), DynError> {
+    let Some(path) = config.stats_path.as_deref() else {
+        return Ok(());
+    };
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(
+        path,
+        format!(
+            "{{\n  \"rows_scanned\": {},\n  \"edges_written\": {}\n}}\n",
+            stats.rows_scanned, stats.edges_written
+        ),
+    )?;
+    Ok(())
+}
+
+fn manifest_environment_path(lmdb_path: &Path, manifest_path: &Path) -> String {
+    let lmdb_parent = lmdb_path.parent().map(Path::to_path_buf);
+    let manifest_parent = manifest_path.parent().map(Path::to_path_buf);
+    if lmdb_parent == manifest_parent {
+        return lmdb_path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| lmdb_path.display().to_string());
+    }
+    lmdb_path.display().to_string()
+}
+
+fn json_escape(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            ch if ch.is_control() => {
+                use std::fmt::Write as _;
+                let _ = write!(out, "\\u{:04x}", ch as u32);
+            }
+            ch => out.push(ch),
+        }
+    }
+    out
+}
+
+fn manifest_row_count(path: &Path) -> Option<usize> {
+    let text = fs::read_to_string(path).ok()?;
+    let marker = "\"RowCount\"";
+    let start = text.find(marker)? + marker.len();
+    let after_colon = text[start..].find(':')? + start + 1;
+    let digits: String = text[after_colon..]
+        .chars()
+        .skip_while(|ch| ch.is_whitespace())
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect();
+    digits.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_categorylinks_subcat_edges_from_page_ids() {
+        let row = vec![
+            Field::Int(10),
+            Field::Int(0),
+            Field::Str(b"A".to_vec()),
+            Field::Null,
+            Field::Str(b"subcat".to_vec()),
+            Field::Null,
+            Field::Int(20),
+        ];
+        assert_eq!(
+            categorylinks_subcat_edge(&row),
+            Some(("10".to_string(), "20".to_string()))
+        );
+    }
+
+    #[test]
+    fn ignores_non_subcat_rows() {
+        let row = vec![
+            Field::Int(10),
+            Field::Int(0),
+            Field::Str(b"A".to_vec()),
+            Field::Null,
+            Field::Str(b"page".to_vec()),
+            Field::Null,
+            Field::Int(20),
+        ];
+        assert_eq!(categorylinks_subcat_edge(&row), None);
+    }
+
+    #[test]
+    fn default_manifest_path_appends_manifest_suffix() {
+        assert_eq!(
+            default_manifest_path(Path::new("/tmp/category_parent.lmdb")),
+            PathBuf::from("/tmp/category_parent.lmdb.manifest.json")
+        );
+    }
+
+    #[test]
+    fn manifest_environment_path_is_relative_for_sibling_manifest() {
+        assert_eq!(
+            manifest_environment_path(
+                Path::new("/tmp/fixture/category_parent.lmdb"),
+                Path::new("/tmp/fixture/category_parent.lmdb.manifest.json")
+            ),
+            "category_parent.lmdb"
+        );
+    }
+
+    #[test]
+    fn json_escape_handles_manifest_paths() {
+        assert_eq!(json_escape("a\\b\"c"), "a\\\\b\\\"c");
+    }
+
+    #[test]
+    fn parse_args_accepts_fixture_tsv_and_stats_paths() {
+        let config = parse_args([
+            OsString::from("dump.sql.gz"),
+            OsString::from("category_parent.lmdb"),
+            OsString::from("--fixture-tsv"),
+            OsString::from("category_parent.tsv"),
+            OsString::from("--stats"),
+            OsString::from("stats.json"),
+            OsString::from("--max-edges"),
+            OsString::from("10"),
+        ])
+        .expect("valid args");
+        assert_eq!(
+            config.fixture_tsv_path,
+            Some(PathBuf::from("category_parent.tsv"))
+        );
+        assert_eq!(config.stats_path, Some(PathBuf::from("stats.json")));
+        assert_eq!(config.max_edges, Some(10));
+    }
+}

--- a/src/unifyweaver/runtime/rust/mysql_stream/src/main.rs
+++ b/src/unifyweaver/runtime/rust/mysql_stream/src/main.rs
@@ -22,7 +22,7 @@ fn tsv_escape_bytes(bytes: &[u8], out: &mut Vec<u8>) {
             b'\t' => out.extend_from_slice(b"\\t"),
             b'\n' => out.extend_from_slice(b"\\n"),
             b'\r' => out.extend_from_slice(b"\\r"),
-            0x20..=0x7E => out.push(b),  // printable ASCII
+            0x20..=0x7E => out.push(b), // printable ASCII
             _ => {
                 // Non-ASCII or non-printable — emit \xNN.
                 // Note: this over-escapes valid multi-byte UTF-8. The
@@ -82,15 +82,21 @@ fn main() -> ExitCode {
         for (i, field) in row.iter().enumerate() {
             if i > 0 {
                 if let Err(e) = out.write_all(b"\t") {
-                    if let Some(code) = handle_err(&e) { return code; }
+                    if let Some(code) = handle_err(&e) {
+                        return code;
+                    }
                 }
             }
             if let Err(e) = write_field(&mut out, field) {
-                if let Some(code) = handle_err(&e) { return code; }
+                if let Some(code) = handle_err(&e) {
+                    return code;
+                }
             }
         }
         if let Err(e) = out.write_all(b"\n") {
-            if let Some(code) = handle_err(&e) { return code; }
+            if let Some(code) = handle_err(&e) {
+                return code;
+            }
         }
     }
 

--- a/tests/test_prepare_csharp_query_enwiki_category_fixture.py
+++ b/tests/test_prepare_csharp_query_enwiki_category_fixture.py
@@ -70,6 +70,53 @@ class PrepareCSharpQueryEnwikiCategoryFixtureTests(unittest.TestCase):
         self.assertEqual(env["UW_KEY_ENCODING"], "utf8")
         self.assertEqual(env["UW_VAL_ENCODING"], "utf8")
 
+    def test_rust_lmdb_sink_command_writes_fixture_and_artifact_in_one_pass(self) -> None:
+        command = MODULE.rust_lmdb_sink_command(
+            dump_path=Path("dump.sql.gz"),
+            fixture_dir=Path("/tmp/fixture"),
+            max_edges=500000,
+            map_size=1234,
+            refresh=True,
+        )
+        self.assertEqual(command[:6], ["cargo", "run", "--release", "--manifest-path", str(MODULE.MYSQL_STREAM_MANIFEST), "--bin"])
+        self.assertIn("mysql_stream_lmdb", command)
+        self.assertIn("--fixture-tsv", command)
+        self.assertIn("/tmp/fixture/category_parent.tsv", command)
+        self.assertIn("--stats", command)
+        self.assertIn("/tmp/fixture/category_parent.lmdb.stats.json", command)
+        self.assertIn("--refresh", command)
+
+    def test_prepare_with_rust_lmdb_sink_writes_metadata_from_stats(self) -> None:
+        calls = []
+
+        def fake_run(*args, **kwargs):
+            calls.append((args, kwargs))
+            (output_dir / "category_parent.tsv").write_text("child\tparent\n10\t20\n12\t22\n", encoding="utf-8")
+            (output_dir / "category_parent.lmdb").mkdir()
+            (output_dir / "category_parent.lmdb.manifest.json").write_text('{"RowCount": 2}\n', encoding="utf-8")
+            (output_dir / "category_parent.lmdb.stats.json").write_text(
+                '{"rows_scanned": 3, "edges_written": 2}\n',
+                encoding="utf-8",
+            )
+            return SimpleNamespace(returncode=0, stdout="", stderr="mysql_stream_lmdb: scanned=3 written=2")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "500k_cats"
+            result_dir = MODULE.prepare_with_rust_lmdb_sink(
+                scale="500k_cats",
+                max_edges=2,
+                output_root=Path(tmp),
+                dump_path=Path("dump.sql.gz"),
+                refresh_lmdb=True,
+                lmdb_map_size=4096,
+                run=fake_run,
+            )
+            self.assertEqual(result_dir, output_dir)
+            self.assertEqual(len(calls), 1)
+            metadata = json.loads((output_dir / "metadata.json").read_text(encoding="utf-8"))
+            self.assertEqual(metadata["n_hierarchy_edges"], 2)
+            self.assertEqual(metadata["mysql_rows_scanned"], 3)
+
     def test_write_lmdb_artifact_invokes_csharp_consumer_and_writes_manifest(self) -> None:
         calls = []
 


### PR DESCRIPTION
  ## Summary

  - Add `mysql_stream_lmdb`, a Rust-native LMDB sink for MediaWiki `categorylinks` `subcat` rows.
  - Preserve Wikipedia page IDs and write C# query-compatible `category_parent/2` LMDB manifests.
  - Add `--lmdb-sink-target rust` to the enwiki fixture helper.
  - Add `--lmdb-only` to the C# artifact-backend benchmark so LMDB artifacts can be measured without a TSV sidecar.
  - Document that TSV output is optional fixture support, not the Rust sink transport.

  ## Verification

  - `cargo test --manifest-path src/unifyweaver/runtime/rust/mysql_stream/Cargo.toml`
  - `python3 -m unittest tests/test_prepare_csharp_query_enwiki_category_fixture.py tests/
  test_csharp_query_effective_distance_artifact_backends.py tests/test_csharp_query_lmdb_provider_smoke.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py examples/
  benchmark/prepare_csharp_query_enwiki_category_fixture.py tests/test_prepare_csharp_query_enwiki_category_fixture.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - Pure Rust LMDB smoke with no TSV sidecar
  - Fixture helper Rust sink smoke
  - LMDB-only benchmark smoke from an LMDB-only temp scale
  - `git diff --check`