### PR TITLE
feat(wam-clojure): add last/2 builtin

### DIFF
--- a/PR_WAM_CLOJURE_LAST_BUILTIN.md
+++ b/PR_WAM_CLOJURE_LAST_BUILTIN.md
@@ -1,0 +1,26 @@
+# PR Title
+
+feat(wam-clojure): add last/2 builtin
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM support for `last/2`.
+- Reuses the existing proper-list conversion and unification helpers.
+- Direct-lowers `last/2` to a runtime helper instead of stepping through the interpreted builtin path.
+- Fails cleanly for empty, improper, or unbound input lists.
+- Adds lowered-emitter and runtime smoke coverage.
+
+## Semantics
+
+`last/2` accepts a non-empty proper list in the first argument and unifies the second argument with the final item.
+
+This initial Clojure WAM implementation is deterministic and conservative: it supports the common `(+List, ?Last)` mode and fails for unbound first arguments rather than generating lists relationally.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -392,6 +392,10 @@ clojure_direct_builtin("reverse/2", "2").
 clojure_direct_builtin("reverse/2", 2).
 clojure_direct_builtin('reverse/2', "2").
 clojure_direct_builtin('reverse/2', 2).
+clojure_direct_builtin("last/2", "2").
+clojure_direct_builtin("last/2", 2).
+clojure_direct_builtin('last/2', "2").
+clojure_direct_builtin('last/2', 2).
 clojure_direct_builtin("sort/2", "2").
 clojure_direct_builtin("sort/2", 2).
 clojure_direct_builtin('sort/2', "2").
@@ -670,6 +674,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "reverse/2" ; Op == 'reverse/2'),
     !,
     format(atom(Expr), '(runtime/apply-reverse-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "last/2" ; Op == 'last/2'),
+    !,
+    format(atom(Expr), '(runtime/apply-last-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "sort/2" ; Op == 'sort/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -774,6 +774,20 @@
           (backtrack state)))
       (backtrack state))))
 
+(defn apply-last-solution [state]
+  (let [list-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A2") ::unbound))]
+    (if-let [items (proper-list-items state list-value)]
+      (if-let [last-item (peek (vec items))]
+        (let [[ok next-state] (unify-values state out last-item)]
+          (if ok
+            (advance next-state)
+            (backtrack state)))
+        (backtrack state))
+      (backtrack state))))
+
 (defn apply-sort-solution [state]
   (let [list-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A1") ::unbound))
@@ -1554,6 +1568,9 @@
 
           "reverse/2"
           (apply-reverse-solution state)
+
+          "last/2"
+          (apply-last-solution state)
 
           "sort/2"
           (apply-sort-solution state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -559,6 +559,15 @@ test(simple_builtin_reverse_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_last_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_last/2:\nbuiltin_call last/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_last/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_last/2, WamCode, [], Code),
+        has(Code, "runtime/apply-last-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_sort_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_sort/2:\nbuiltin_call sort/2, 2\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -87,6 +87,10 @@
 :- dynamic user:wam_reverse_guard/2.
 :- dynamic user:wam_reverse_bad_list/1.
 :- dynamic user:wam_reverse_unbound_list/1.
+:- dynamic user:wam_last_guard/2.
+:- dynamic user:wam_last_empty/1.
+:- dynamic user:wam_last_bad_list/1.
+:- dynamic user:wam_last_unbound_list/1.
 :- dynamic user:wam_sort_guard/2.
 :- dynamic user:wam_sort_bad_list/1.
 :- dynamic user:wam_sort_unbound_list/1.
@@ -218,6 +222,10 @@ user:wam_append_split(A, B) :- append(A, B, [a,b,c]).
 user:wam_reverse_guard(L, R) :- reverse(L, R).
 user:wam_reverse_bad_list(R) :- reverse([a|b], R).
 user:wam_reverse_unbound_list(R) :- user:wam_unbound_arg(L), reverse(L, R).
+user:wam_last_guard(L, X) :- last(L, X).
+user:wam_last_empty(X) :- last([], X).
+user:wam_last_bad_list(X) :- last([a|b], X).
+user:wam_last_unbound_list(X) :- user:wam_unbound_arg(L), last(L, X).
 user:wam_sort_guard(L, S) :- sort(L, S).
 user:wam_sort_bad_list(S) :- sort([a|b], S).
 user:wam_sort_unbound_list(S) :- user:wam_unbound_arg(L), sort(L, S).
@@ -354,6 +362,10 @@ run_smoke :-
           user:wam_reverse_guard/2,
           user:wam_reverse_bad_list/1,
           user:wam_reverse_unbound_list/1,
+          user:wam_last_guard/2,
+          user:wam_last_empty/1,
+          user:wam_last_bad_list/1,
+          user:wam_last_unbound_list/1,
           user:wam_sort_guard/2,
           user:wam_sort_bad_list/1,
           user:wam_sort_unbound_list/1,
@@ -431,6 +443,7 @@ run_smoke :-
     assert_lowered_member_builtin_emitted(TmpDir),
     assert_lowered_append_builtin_emitted(TmpDir),
     assert_lowered_reverse_builtin_emitted(TmpDir),
+    assert_lowered_last_builtin_emitted(TmpDir),
     assert_lowered_sort_builtin_emitted(TmpDir),
     assert_lowered_msort_builtin_emitted(TmpDir),
     assert_lowered_copy_term_builtin_emitted(TmpDir),
@@ -596,6 +609,12 @@ smoke_cases([
     case('wam_reverse_guard/2', args('[a,b,c]', '[a,b,c]'), "false"),
     case('wam_reverse_bad_list/1', '[b,a]', "false"),
     case('wam_reverse_unbound_list/1', '[b,a]', "false"),
+    case('wam_last_guard/2', args('[a,b,c]', c), "true"),
+    case('wam_last_guard/2', args('[a]', a), "true"),
+    case('wam_last_guard/2', args('[a,b,c]', b), "false"),
+    case('wam_last_empty/1', a, "false"),
+    case('wam_last_bad_list/1', a, "false"),
+    case('wam_last_unbound_list/1', a, "false"),
     case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b,c]'), "true"),
     case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b]'), "false"),
     case('wam_sort_guard/2', args('[f(b),f(a),a]', '[a,f(a),f(b)]'), "true"),
@@ -852,6 +871,15 @@ assert_lowered_reverse_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-reverse-bad-list-1"),
     has(CoreCode, "defn lowered-wam-reverse-unbound-list-1"),
     has(CoreCode, "runtime/apply-reverse-solution").
+
+assert_lowered_last_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-last-guard-2"),
+    has(CoreCode, "defn lowered-wam-last-empty-1"),
+    has(CoreCode, "defn lowered-wam-last-bad-list-1"),
+    has(CoreCode, "defn lowered-wam-last-unbound-list-1"),
+    has(CoreCode, "runtime/apply-last-solution").
 
 assert_lowered_sort_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM support for `last/2`.
- Reuses the existing proper-list conversion and unification helpers.
- Direct-lowers `last/2` to a runtime helper instead of stepping through the interpreted builtin path.
- Fails cleanly for empty, improper, or unbound input lists.
- Adds lowered-emitter and runtime smoke coverage.

## Semantics

`last/2` accepts a non-empty proper list in the first argument and unifies the second argument with the final item.

This initial Clojure WAM implementation is deterministic and conservative: it supports the common `(+List, ?Last)` mode and fails for unbound first arguments rather than generating lists relationally.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
