### PR TITLE
bench(csharp-query): measure rust lmdb sink

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -229,6 +229,21 @@ Pass `--use-scale-lmdb-artifact` to the backend benchmark when you want the
 `--artifact-root`. If you want to benchmark only the scale-local LMDB artifact,
 pass `--lmdb-only`; that mode does not require `category_parent.tsv`.
 
+For ingestion-plus-access timing, use the Rust sink measurement wrapper:
+
+```bash
+python examples/benchmark/benchmark_csharp_query_rust_lmdb_sink.py \
+  --scale rust_lmdb_50k \
+  --max-edges 50000 \
+  --dump data/enwiki/enwiki-latest-categorylinks.sql.gz \
+  --output-root /tmp/uw-csharp-query-rust-lmdb \
+  --refresh-lmdb
+```
+
+The wrapper reports Rust sink preparation time plus the C# query `lmdb-only`
+access row. Starting with smaller caps is useful before moving to `500k_cats`
+or `1m_cats`.
+
 Pass `--artifact-root <dir>` to keep backend artifacts across benchmark runs.
 Existing binary, delimited, LMDB, and mmap-array manifests are reused by
 default, matching the Haskell benchmark convention of not regenerating LMDB

--- a/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
+++ b/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
@@ -180,6 +180,7 @@ def parse_rows(output: str, run_index: int) -> list[BenchmarkRow]:
 
 def run_scale(
     scale: str,
+    benchmark_root: Path,
     lookup_keys: int,
     lookup_repetitions: int,
     run_index: int,
@@ -190,7 +191,7 @@ def run_scale(
     preserve_numeric_ids: bool,
     lmdb_only: bool,
 ) -> list[BenchmarkRow]:
-    scale_dir = BENCH_DIR / scale
+    scale_dir = benchmark_root / scale
     if not lmdb_only and not (scale_dir / "category_parent.tsv").exists():
         raise RuntimeError(f"scale has no category_parent.tsv: {scale_dir}")
     if lmdb_only and not (scale_dir / "category_parent.lmdb.manifest.json").exists():
@@ -494,6 +495,12 @@ def main(argv: list[str] | None = None) -> int:
         description="Compare C# query artifact backends on the real effective-distance category_parent/2 relation."
     )
     parser.add_argument("--scales", default="300,1k,5k,10k", help="comma-separated scales from data/benchmark")
+    parser.add_argument(
+        "--benchmark-root",
+        type=Path,
+        default=BENCH_DIR,
+        help="directory containing benchmark scale subdirectories",
+    )
     parser.add_argument("--lookup-keys", type=int, default=64, help="number of category IDs to probe")
     parser.add_argument("--lookup-repetitions", type=int, default=5, help="lookup passes per mode")
     parser.add_argument("--repetitions", type=int, default=1, help="independent benchmark runs per scale")
@@ -596,8 +603,8 @@ def main(argv: list[str] | None = None) -> int:
         scale
         for scale in scales
         if not (
-            (BENCH_DIR / scale / "category_parent.tsv").exists()
-            or (args.lmdb_only and (BENCH_DIR / scale / "category_parent.lmdb.manifest.json").exists())
+            (args.benchmark_root / scale / "category_parent.tsv").exists()
+            or (args.lmdb_only and (args.benchmark_root / scale / "category_parent.lmdb.manifest.json").exists())
         )
     ]
     if missing:
@@ -634,6 +641,7 @@ def main(argv: list[str] | None = None) -> int:
             rows.extend(
                 run_scale(
                     scale,
+                    args.benchmark_root,
                     args.lookup_keys,
                     args.lookup_repetitions,
                     run_index,

--- a/examples/benchmark/benchmark_csharp_query_rust_lmdb_sink.py
+++ b/examples/benchmark/benchmark_csharp_query_rust_lmdb_sink.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+DEFAULT_DUMP = ROOT / "data" / "enwiki" / "enwiki-latest-categorylinks.sql.gz"
+PREPARE_SCRIPT = ROOT / "examples" / "benchmark" / "prepare_csharp_query_enwiki_category_fixture.py"
+BACKEND_BENCHMARK = ROOT / "examples" / "benchmark" / "benchmark_csharp_query_effective_distance_artifact_backends.py"
+
+HEADERS = [
+    "scale",
+    "max_edges",
+    "prepare_s",
+    "rows",
+    "distinct_categories",
+    "lookup_keys",
+    "artifact_bytes",
+    "open_ms",
+    "lookup_ms",
+    "bucket_ms",
+    "scan_ms",
+]
+
+
+@dataclass(frozen=True)
+class Measurement:
+    values: dict[str, str]
+
+
+def parse_positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("expected a positive integer")
+    return parsed
+
+
+def run_checked(command: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"command failed: {' '.join(command)}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def prepare_command(
+    *,
+    scale: str,
+    max_edges: int,
+    dump_path: Path,
+    output_root: Path,
+    map_size: int,
+    refresh_lmdb: bool,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(PREPARE_SCRIPT),
+        "--scale",
+        scale,
+        "--max-edges",
+        str(max_edges),
+        "--dump",
+        str(dump_path),
+        "--output-root",
+        str(output_root),
+        "--sink-lmdb",
+        "--lmdb-sink-target",
+        "rust",
+        "--lmdb-map-size",
+        str(map_size),
+    ]
+    if refresh_lmdb:
+        command.append("--refresh-lmdb")
+    return command
+
+
+def benchmark_command(
+    *,
+    scale: str,
+    output_root: Path,
+    lookup_keys: int,
+    lookup_repetitions: int,
+) -> list[str]:
+    return [
+        sys.executable,
+        str(BACKEND_BENCHMARK),
+        "--scales",
+        scale,
+        "--benchmark-root",
+        str(output_root),
+        "--lookup-keys",
+        str(lookup_keys),
+        "--lookup-repetitions",
+        str(lookup_repetitions),
+        "--repetitions",
+        "1",
+        "--use-scale-lmdb-artifact",
+        "--lmdb-only",
+        "--format",
+        "tsv",
+    ]
+
+
+def lmdb_row_from_tsv(output: str) -> dict[str, str]:
+    rows = list(csv.DictReader(output.splitlines(), delimiter="\t"))
+    if len(rows) != 1 or rows[0].get("mode") != "lmdb":
+        raise RuntimeError(f"expected one lmdb row, got: {output}")
+    return rows[0]
+
+
+def measure(
+    *,
+    scale: str,
+    max_edges: int,
+    dump_path: Path,
+    output_root: Path,
+    map_size: int,
+    refresh_lmdb: bool,
+    lookup_keys: int,
+    lookup_repetitions: int,
+) -> Measurement:
+    started = time.perf_counter()
+    run_checked(
+        prepare_command(
+            scale=scale,
+            max_edges=max_edges,
+            dump_path=dump_path,
+            output_root=output_root,
+            map_size=map_size,
+            refresh_lmdb=refresh_lmdb,
+        ),
+        timeout=3600,
+    )
+    prepare_s = time.perf_counter() - started
+
+    benchmark = run_checked(
+        benchmark_command(
+            scale=scale,
+            output_root=output_root,
+            lookup_keys=lookup_keys,
+            lookup_repetitions=lookup_repetitions,
+        ),
+        timeout=600,
+    )
+    row = lmdb_row_from_tsv(benchmark.stdout)
+    return Measurement(
+        {
+            "scale": scale,
+            "max_edges": str(max_edges),
+            "prepare_s": f"{prepare_s:.3f}",
+            "rows": row["rows"],
+            "distinct_categories": row["distinct_categories"],
+            "lookup_keys": row["lookup_keys"],
+            "artifact_bytes": row["artifact_bytes"],
+            "open_ms": row["open_ms"],
+            "lookup_ms": row["lookup_ms"],
+            "bucket_ms": row["bucket_ms"],
+            "scan_ms": row["scan_ms"],
+        }
+    )
+
+
+def render_tsv(rows: list[Measurement]) -> str:
+    lines = ["\t".join(HEADERS)]
+    lines.extend("\t".join(row.values[column] for column in HEADERS) for row in rows)
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Measure Rust mysql_stream_lmdb fixture ingestion plus C# query LMDB-only access."
+    )
+    parser.add_argument("--scale", required=True, help="fixture label to create under --output-root")
+    parser.add_argument("--max-edges", type=parse_positive_int, required=True, help="subcat edge cap")
+    parser.add_argument("--dump", type=Path, default=DEFAULT_DUMP, help="categorylinks SQL dump")
+    parser.add_argument("--output-root", type=Path, default=BENCH_DIR, help="benchmark scale output root")
+    parser.add_argument("--lmdb-map-size", type=parse_positive_int, default=1 << 30, help="LMDB map size in bytes")
+    parser.add_argument("--lookup-keys", type=parse_positive_int, default=64, help="lookup key count")
+    parser.add_argument("--lookup-repetitions", type=parse_positive_int, default=1, help="lookup repetitions")
+    parser.add_argument("--refresh-lmdb", action="store_true", help="rebuild LMDB artifact before measuring")
+    args = parser.parse_args(argv)
+
+    if not args.dump.exists():
+        raise FileNotFoundError(args.dump)
+
+    measurement = measure(
+        scale=args.scale,
+        max_edges=args.max_edges,
+        dump_path=args.dump,
+        output_root=args.output_root,
+        map_size=args.lmdb_map_size,
+        refresh_lmdb=args.refresh_lmdb,
+        lookup_keys=args.lookup_keys,
+        lookup_repetitions=args.lookup_repetitions,
+    )
+    print(render_tsv([measurement]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_csharp_query_rust_lmdb_sink_benchmark.py
+++ b/tests/test_csharp_query_rust_lmdb_sink_benchmark.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "examples" / "benchmark" / "benchmark_csharp_query_rust_lmdb_sink.py"
+
+SPEC = importlib.util.spec_from_file_location("benchmark_csharp_query_rust_lmdb_sink", SCRIPT)
+assert SPEC is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class CSharpQueryRustLmdbSinkBenchmarkTests(unittest.TestCase):
+    def test_prepare_command_uses_rust_lmdb_sink_target(self) -> None:
+        command = MODULE.prepare_command(
+            scale="rust_lmdb_10k",
+            max_edges=10_000,
+            dump_path=Path("dump.sql.gz"),
+            output_root=Path("/tmp/bench"),
+            map_size=1234,
+            refresh_lmdb=True,
+        )
+        self.assertIn("--sink-lmdb", command)
+        self.assertIn("--lmdb-sink-target", command)
+        self.assertIn("rust", command)
+        self.assertIn("--refresh-lmdb", command)
+        self.assertIn("--lmdb-map-size", command)
+        self.assertIn("1234", command)
+
+    def test_benchmark_command_uses_lmdb_only_without_tsv_requirement(self) -> None:
+        command = MODULE.benchmark_command(
+            scale="rust_lmdb_10k",
+            output_root=Path("/tmp/bench"),
+            lookup_keys=8,
+            lookup_repetitions=2,
+        )
+        self.assertIn("--benchmark-root", command)
+        self.assertIn("/tmp/bench", command)
+        self.assertIn("--use-scale-lmdb-artifact", command)
+        self.assertIn("--lmdb-only", command)
+        self.assertIn("--lookup-keys", command)
+        self.assertIn("8", command)
+
+    def test_lmdb_row_from_tsv_requires_one_lmdb_row(self) -> None:
+        row = MODULE.lmdb_row_from_tsv(
+            "scale\trun\tmode\trows\tdistinct_categories\tlookup_keys\tartifact_bytes\topen_ms\tlookup_ms\tbucket_ms\tscan_ms\tretained_bytes\tscan_hash\tlookup_hash\tbucket_hash\n"
+            "s\t1\tlmdb\t2\t4\t2\t100\t0.1\t0.2\t0.3\t0.4\t10\ta\tb\tc\n"
+        )
+        self.assertEqual(row["mode"], "lmdb")
+        self.assertEqual(row["rows"], "2")
+        with self.assertRaisesRegex(RuntimeError, "expected one lmdb row"):
+            MODULE.lmdb_row_from_tsv("scale\trun\tmode\ns\t1\tpreload\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  - Add a benchmark wrapper that prepares enwiki category fixtures through the Rust `mysql_stream_lmdb` sink and immediately
  measures C# query `lmdb-only` access.
  - Add `--benchmark-root` support to the C# query artifact backend benchmark so generated scale roots can live outside `data/
  benchmark`.
  - Document the Rust LMDB sink measurement workflow and recommended smaller-cap ramp-up.

  ## Verification

  - `python3 -m unittest tests/test_csharp_query_rust_lmdb_sink_benchmark.py tests/
  test_prepare_csharp_query_enwiki_category_fixture.py tests/test_csharp_query_effective_distance_artifact_backends.py tests/
  test_csharp_query_lmdb_provider_smoke.py`
  - `python3 -m py_compile ...`
  - `cargo test --manifest-path src/unifyweaver/runtime/rust/mysql_stream/Cargo.toml`
  - 10k, 50k, and 100k Rust sink measurement runs under `/tmp`
  - 50k full backend summary using the scale-local LMDB artifact
  - `git diff --check`