### PR TITLE
fix(wam-r): reject parser builtins when parser disabled

### DIFF
--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
@@ -81,6 +81,10 @@ Do not immediately wire every target's `write_wam_*_project/3` through the new
 hook. The hook is a stable contract; target writers can migrate one at a time.
 For R, builtin routing still uses the native inline parser hot path while the
 metadata provides a stable seam for later experiments.
+When R resolves to `runtime_parser(off)`, the project writer rejects requested
+predicates whose statically visible bodies call parser-dependent builtins, so
+the disabled mode does not silently generate a runtime that still accepts
+source-term parsing calls.
 
 The hook should be independent of the WAM items API. A target can skip WAM text
 generation at build time and still need runtime source-term parsing.

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -66,7 +66,8 @@
 :- use_module('../core/recursive_kernel_detection',
              [detect_recursive_kernel/4, kernel_config/2]).
 :- use_module(wam_runtime_parser_capability,
-             [wam_target_runtime_parser/3]).
+             [parser_dependent_builtin/1,
+              wam_target_runtime_parser/3]).
 
 % ============================================================================
 % EMIT MODE
@@ -1741,12 +1742,13 @@ r_escape_chars([C    | T], [C | RestEsc]) :-
 %    R/wam_runtime.R            WAM runtime
 %    R/generated_program.R      compiled program (instr array, labels, wrappers)
 write_wam_r_project(Predicates, Options, ProjectDir) :-
+    option(module_name(ModName), Options, 'wam.r.generated'),
+    wam_target_runtime_parser(wam_r, Options, RuntimeParserMode),
+    validate_r_runtime_parser_mode(Predicates, RuntimeParserMode),
+    r_runtime_parser_mode_literal(RuntimeParserMode, RuntimeParserModeCode),
     make_directory_path(ProjectDir),
     directory_file_path(ProjectDir, 'R', RDir),
     make_directory_path(RDir),
-    option(module_name(ModName), Options, 'wam.r.generated'),
-    wam_target_runtime_parser(wam_r, Options, RuntimeParserMode),
-    r_runtime_parser_mode_literal(RuntimeParserMode, RuntimeParserModeCode),
     write_description(ProjectDir, ModName),
     compile_predicates_for_project(Predicates, Options,
         AllInstrs, TopLevelLabelEntries, AllLabelEntries,
@@ -1819,6 +1821,61 @@ r_runtime_parser_mode_literal(compiled(SourceModule), Code) :-
     format(string(Code),
            'list(kind = "compiled", entry = NULL, source = ~w)',
            [SourceLit]).
+
+validate_r_runtime_parser_mode(Predicates, none) :-
+    !,
+    (   r_predicates_parser_dependency(Predicates, Pred, Builtin)
+    ->  throw(error(permission_error(use, runtime_parser, Builtin),
+                    context(write_wam_r_project/3,
+                            parser_disabled_for_predicate(Pred))))
+    ;   true
+    ).
+validate_r_runtime_parser_mode(_Predicates, _Mode).
+
+r_predicates_parser_dependency(Predicates, Pred, Builtin) :-
+    member(Pred, Predicates),
+    r_predicate_clause(Pred, _Head, Body),
+    r_goal_uses_parser_builtin(Body, Builtin),
+    !.
+
+r_predicate_clause(Module:Name/Arity, Head, Body) :-
+    !,
+    functor(Head, Name, Arity),
+    clause(Module:Head, Body).
+r_predicate_clause(Name/Arity, Head, Body) :-
+    functor(Head, Name, Arity),
+    clause(user:Head, Body).
+
+r_goal_uses_parser_builtin(Goal, Builtin) :-
+    nonvar(Goal),
+    (   r_goal_builtin_pi(Goal, Builtin),
+        parser_dependent_builtin(Builtin)
+    ->  true
+    ;   r_goal_child(Goal, Child),
+        r_goal_uses_parser_builtin(Child, Builtin)
+    ).
+
+r_goal_builtin_pi(Module:Goal, Builtin) :-
+    atom(Module),
+    nonvar(Goal),
+    !,
+    r_goal_builtin_pi(Goal, Builtin).
+r_goal_builtin_pi(Goal, Name/Arity) :-
+    callable(Goal),
+    functor(Goal, Name, Arity).
+
+r_goal_child((A, _), A).
+r_goal_child((_, B), B).
+r_goal_child((A ; _), A).
+r_goal_child((_ ; B), B).
+r_goal_child((A -> _), A).
+r_goal_child((_ -> B), B).
+r_goal_child((*->(A, _)), A).
+r_goal_child((*->(_, B)), B).
+r_goal_child(\+(A), A).
+r_goal_child(not(A), A).
+r_goal_child(once(A), A).
+r_goal_child(call(A), A).
 
 % ============================================================================
 % HELPERS

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -33,6 +33,7 @@
 :- dynamic user:wam_r_caller/1.
 :- dynamic user:wam_r_pair/1.
 :- dynamic user:wam_r_list/1.
+:- dynamic user:wam_r_parser_dep/0.
 
 user:wam_r_fact(a).
 user:wam_r_choice_fact(a).
@@ -120,6 +121,21 @@ test(runtime_parser_mode_option_off) :-
                              'runtime_parser   = list(kind = "none", entry = NULL, source = NULL)')),
         delete_directory_and_contents(TmpDir)
     )).
+
+test(runtime_parser_off_rejects_parser_dependent_builtin,
+     [error(permission_error(use, runtime_parser, read_term_from_atom/2))]) :-
+    retractall(user:wam_r_parser_dep),
+    assertz((user:wam_r_parser_dep :-
+        read_term_from_atom('f(a)', _))),
+    unique_r_tmp_dir('tmp_r_parser_mode_reject', TmpDir),
+    call_cleanup(
+        write_wam_r_project(
+            [user:wam_r_parser_dep/0],
+            [runtime_parser(off)],
+            TmpDir),
+        (   retractall(user:wam_r_parser_dep),
+            (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true)
+        )).
 
 % ------------------------------------------------------------------
 % Test 4: label map carries the predicate entry


### PR DESCRIPTION
## Summary

Enforces the runtime parser capability contract for WAM-R when `runtime_parser(off)` is selected.

Previously WAM-R recorded `runtime_parser = none` metadata, but generated programs could still include predicates that call parser-dependent builtins. This change rejects those programs at generation time instead of silently producing ambiguous runtime behavior.

## Details

- Validates `runtime_parser(off)` in `write_wam_r_project/3` before creating project files.
- Scans requested predicate bodies for parser-dependent builtins from `parser_dependent_builtin/1`.
- Raises `permission_error(use, runtime_parser, Builtin)` when a disabled parser mode conflicts with a statically visible parser-dependent call.
- Handles direct calls and common wrappers/control forms:
  - conjunction
  - disjunction
  - if-then / soft-cut
  - `\+/1`
  - `not/1`
  - `once/1`
  - `call/1`
- Adds a focused WAM-R generator test for `read_term_from_atom/2` under `runtime_parser(off)`.
- Updates the runtime parser transpilation plan to document the WAM-R enforcement behavior.

## Verification

- `swipl -q -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:runtime_parser_mode_metadata,wam_r_generator:runtime_parser_mode_option_off,wam_r_generator:runtime_parser_off_rejects_parser_dependent_builtin])" -t halt`
- `swipl -q -g run_tests -t halt tests/test_wam_runtime_parser_capability.pl`
- `git diff --check HEAD`

## Notes

This is a generation-time validation change only. It does not alter R runtime parser execution or switch R away from its native inline parser hot path.
