### PR TITLE
bench(csharp-query): report rust lmdb sink scales

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -241,8 +241,21 @@ python examples/benchmark/benchmark_csharp_query_rust_lmdb_sink.py \
 ```
 
 The wrapper reports Rust sink preparation time plus the C# query `lmdb-only`
-access row. Starting with smaller caps is useful before moving to `500k_cats`
-or `1m_cats`.
+access row. It also accepts repeated or comma-separated
+`--scale-spec SCALE:MAX_EDGES` entries for progression reports:
+
+```bash
+python examples/benchmark/benchmark_csharp_query_rust_lmdb_sink.py \
+  --scale-spec rust_lmdb_100k:100000,rust_lmdb_500k:500000 \
+  --dump data/enwiki/enwiki-latest-categorylinks.sql.gz \
+  --output-root /tmp/uw-csharp-query-rust-lmdb \
+  --lmdb-map-size 1073741824 \
+  --lookup-keys 64 \
+  --format markdown
+```
+
+Starting with smaller caps is useful before moving to `500k_cats` or
+`1m_cats`.
 
 Pass `--artifact-root <dir>` to keep backend artifacts across benchmark runs.
 Existing binary, delimited, LMDB, and mmap-array manifests are reused by

--- a/examples/benchmark/benchmark_csharp_query_rust_lmdb_sink.py
+++ b/examples/benchmark/benchmark_csharp_query_rust_lmdb_sink.py
@@ -36,11 +36,54 @@ class Measurement:
     values: dict[str, str]
 
 
+@dataclass(frozen=True)
+class ScaleSpec:
+    scale: str
+    max_edges: int
+
+
 def parse_positive_int(value: str) -> int:
     parsed = int(value)
     if parsed <= 0:
         raise argparse.ArgumentTypeError("expected a positive integer")
     return parsed
+
+
+def split_csv(value: str) -> list[str]:
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def parse_scale_spec(value: str) -> ScaleSpec:
+    if ":" not in value:
+        raise argparse.ArgumentTypeError("expected SCALE:MAX_EDGES")
+    scale, max_edges = value.split(":", 1)
+    scale = scale.strip()
+    if not scale:
+        raise argparse.ArgumentTypeError("expected non-empty SCALE")
+    return ScaleSpec(scale=scale, max_edges=parse_positive_int(max_edges.strip()))
+
+
+def parse_scale_specs(values: list[str] | None) -> list[ScaleSpec]:
+    specs: list[ScaleSpec] = []
+    for value in values or []:
+        specs.extend(parse_scale_spec(part) for part in split_csv(value))
+    return specs
+
+
+def resolve_scale_specs(
+    *,
+    scale_specs: list[str] | None,
+    scale: str | None,
+    max_edges: int | None,
+) -> list[ScaleSpec]:
+    specs = parse_scale_specs(scale_specs)
+    if specs:
+        if scale is not None or max_edges is not None:
+            raise SystemExit("--scale-spec cannot be combined with --scale or --max-edges")
+        return specs
+    if scale is None or max_edges is None:
+        raise SystemExit("provide either --scale and --max-edges, or one or more --scale-spec SCALE:MAX_EDGES")
+    return [ScaleSpec(scale=scale, max_edges=max_edges)]
 
 
 def run_checked(command: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
@@ -182,34 +225,66 @@ def render_tsv(rows: list[Measurement]) -> str:
     return "\n".join(lines)
 
 
+def render_markdown(rows: list[Measurement]) -> str:
+    lines = [
+        "| " + " | ".join(HEADERS) + " |",
+        "| " + " | ".join("---" for _ in HEADERS) + " |",
+    ]
+    lines.extend("| " + " | ".join(row.values[column] for column in HEADERS) + " |" for row in rows)
+    return "\n".join(lines)
+
+
+def render(rows: list[Measurement], output_format: str) -> str:
+    if output_format == "markdown":
+        return render_markdown(rows)
+    return render_tsv(rows)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Measure Rust mysql_stream_lmdb fixture ingestion plus C# query LMDB-only access."
     )
-    parser.add_argument("--scale", required=True, help="fixture label to create under --output-root")
-    parser.add_argument("--max-edges", type=parse_positive_int, required=True, help="subcat edge cap")
+    parser.add_argument("--scale", help="fixture label to create under --output-root")
+    parser.add_argument("--max-edges", type=parse_positive_int, help="subcat edge cap")
+    parser.add_argument(
+        "--scale-spec",
+        action="append",
+        help=(
+            "Scale and cap pair in SCALE:MAX_EDGES form. May be repeated or comma-separated; "
+            "for example rust_lmdb_100k:100000,rust_lmdb_500k:500000."
+        ),
+    )
     parser.add_argument("--dump", type=Path, default=DEFAULT_DUMP, help="categorylinks SQL dump")
     parser.add_argument("--output-root", type=Path, default=BENCH_DIR, help="benchmark scale output root")
     parser.add_argument("--lmdb-map-size", type=parse_positive_int, default=1 << 30, help="LMDB map size in bytes")
     parser.add_argument("--lookup-keys", type=parse_positive_int, default=64, help="lookup key count")
     parser.add_argument("--lookup-repetitions", type=parse_positive_int, default=1, help="lookup repetitions")
+    parser.add_argument("--format", choices=["tsv", "markdown"], default="tsv", help="report output format")
     parser.add_argument("--refresh-lmdb", action="store_true", help="rebuild LMDB artifact before measuring")
     args = parser.parse_args(argv)
 
     if not args.dump.exists():
         raise FileNotFoundError(args.dump)
 
-    measurement = measure(
+    scale_specs = resolve_scale_specs(
+        scale_specs=args.scale_spec,
         scale=args.scale,
         max_edges=args.max_edges,
-        dump_path=args.dump,
-        output_root=args.output_root,
-        map_size=args.lmdb_map_size,
-        refresh_lmdb=args.refresh_lmdb,
-        lookup_keys=args.lookup_keys,
-        lookup_repetitions=args.lookup_repetitions,
     )
-    print(render_tsv([measurement]))
+    measurements = [
+        measure(
+            scale=scale_spec.scale,
+            max_edges=scale_spec.max_edges,
+            dump_path=args.dump,
+            output_root=args.output_root,
+            map_size=args.lmdb_map_size,
+            refresh_lmdb=args.refresh_lmdb,
+            lookup_keys=args.lookup_keys,
+            lookup_repetitions=args.lookup_repetitions,
+        )
+        for scale_spec in scale_specs
+    ]
+    print(render(measurements, args.format))
     return 0
 
 

--- a/tests/test_csharp_query_rust_lmdb_sink_benchmark.py
+++ b/tests/test_csharp_query_rust_lmdb_sink_benchmark.py
@@ -59,6 +59,32 @@ class CSharpQueryRustLmdbSinkBenchmarkTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "expected one lmdb row"):
             MODULE.lmdb_row_from_tsv("scale\trun\tmode\ns\t1\tpreload\n")
 
+    def test_scale_specs_accept_repeated_and_comma_separated_values(self) -> None:
+        specs = MODULE.parse_scale_specs(["rust_lmdb_100k:100000,rust_lmdb_500k:500000", "rust_lmdb_1m:1000000"])
+        self.assertEqual(
+            [(spec.scale, spec.max_edges) for spec in specs],
+            [
+                ("rust_lmdb_100k", 100_000),
+                ("rust_lmdb_500k", 500_000),
+                ("rust_lmdb_1m", 1_000_000),
+            ],
+        )
+
+    def test_resolve_scale_specs_preserves_single_scale_compatibility(self) -> None:
+        specs = MODULE.resolve_scale_specs(scale_specs=None, scale="rust_lmdb_10k", max_edges=10_000)
+        self.assertEqual([(spec.scale, spec.max_edges) for spec in specs], [("rust_lmdb_10k", 10_000)])
+        with self.assertRaises(SystemExit):
+            MODULE.resolve_scale_specs(scale_specs=["rust_lmdb_10k:10000"], scale="other", max_edges=None)
+
+    def test_render_markdown_includes_multiple_rows(self) -> None:
+        rows = [
+            MODULE.Measurement({column: column for column in MODULE.HEADERS}),
+            MODULE.Measurement({column: f"{column}2" for column in MODULE.HEADERS}),
+        ]
+        output = MODULE.render(rows, "markdown")
+        self.assertIn("| scale | max_edges | prepare_s |", output)
+        self.assertIn("| scale2 | max_edges2 | prepare_s2 |", output)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
  ## Summary

  - Add multi-scale `--scale-spec SCALE:MAX_EDGES` support to the Rust LMDB sink measurement wrapper.
  - Add markdown output for PR/report-friendly progression tables.
  - Document the 100k/500k Rust LMDB sink scale-report workflow.

  ## Verification

  - `python3 -m unittest tests/test_csharp_query_rust_lmdb_sink_benchmark.py`
  - `python3 -m unittest tests/test_csharp_query_rust_lmdb_sink_benchmark.py tests/
  test_prepare_csharp_query_enwiki_category_fixture.py tests/test_csharp_query_effective_distance_artifact_backends.py tests/
  test_csharp_query_lmdb_provider_smoke.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_rust_lmdb_sink.py tests/
  test_csharp_query_rust_lmdb_sink_benchmark.py`
  - `git diff --check`
  - Live `/tmp` report for `rust_lmdb_100k` and `rust_lmdb_500k`